### PR TITLE
Optional and opaque RGB colors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -954,6 +954,7 @@ add_executable(mixxx-test
   src/test/readaheadmanager_test.cpp
   src/test/replaygaintest.cpp
   src/test/rescalertest.cpp
+  src/test/rgbcolor_test.cpp
   src/test/samplebuffertest.cpp
   src/test/sampleutiltest.cpp
   src/test/schemamanager_test.cpp

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -9,6 +9,7 @@
 #include "soundio/soundmanagerutil.h"
 #include "track/track.h"
 #include "track/trackref.h"
+#include "util/color/rgbcolor.h"
 #include "util/math.h"
 
 // When linking Qt statically on Windows we have to Q_IMPORT_PLUGIN all the
@@ -67,6 +68,7 @@ void MixxxApplication::registerMetaTypes() {
     qRegisterMetaType<mixxx::ReplayGain>("mixxx::ReplayGain");
     qRegisterMetaType<mixxx::Bpm>("mixxx::Bpm");
     qRegisterMetaType<mixxx::Duration>("mixxx::Duration");
+    qRegisterMetaType<mixxx::RgbColor>("mixxx::RgbColor");
     qRegisterMetaType<SoundDeviceId>("SoundDeviceId");
     QMetaType::registerComparators<SoundDeviceId>();
 }

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -68,7 +68,7 @@ void MixxxApplication::registerMetaTypes() {
     qRegisterMetaType<mixxx::ReplayGain>("mixxx::ReplayGain");
     qRegisterMetaType<mixxx::Bpm>("mixxx::Bpm");
     qRegisterMetaType<mixxx::Duration>("mixxx::Duration");
-    qRegisterMetaType<mixxx::RgbColor>("mixxx::RgbColor");
+    qRegisterMetaType<mixxx::OptionalRgbColor>("mixxx::OptionalRgbColor");
     qRegisterMetaType<SoundDeviceId>("SoundDeviceId");
     QMetaType::registerComparators<SoundDeviceId>();
 }

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -68,6 +68,7 @@ void MixxxApplication::registerMetaTypes() {
     qRegisterMetaType<mixxx::ReplayGain>("mixxx::ReplayGain");
     qRegisterMetaType<mixxx::Bpm>("mixxx::Bpm");
     qRegisterMetaType<mixxx::Duration>("mixxx::Duration");
+    qRegisterMetaType<std::optional<mixxx::RgbColor>>("std::optional<mixxx::RgbColor>");
     qRegisterMetaType<mixxx::OptionalRgbColor>("mixxx::OptionalRgbColor");
     qRegisterMetaType<SoundDeviceId>("SoundDeviceId");
     QMetaType::registerComparators<SoundDeviceId>();

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -69,7 +69,6 @@ void MixxxApplication::registerMetaTypes() {
     qRegisterMetaType<mixxx::Bpm>("mixxx::Bpm");
     qRegisterMetaType<mixxx::Duration>("mixxx::Duration");
     qRegisterMetaType<std::optional<mixxx::RgbColor>>("std::optional<mixxx::RgbColor>");
-    qRegisterMetaType<mixxx::OptionalRgbColor>("mixxx::OptionalRgbColor");
     qRegisterMetaType<SoundDeviceId>("SoundDeviceId");
     QMetaType::registerComparators<SoundDeviceId>();
 }

--- a/src/test/rgbcolor_test.cpp
+++ b/src/test/rgbcolor_test.cpp
@@ -1,0 +1,65 @@
+#include "util/color/rgbcolor.h"
+
+#include <gtest/gtest.h>
+
+#include "test/mixxxtest.h"
+
+namespace mixxx {
+
+TEST(RgbColorTest, DefaultIsInvalid) {
+    EXPECT_FALSE(RgbColor().isValid());
+}
+
+TEST(RgbColorTest, RgbColorCodeCtor) {
+    EXPECT_TRUE(RgbColor(0x000000).isValid());
+    EXPECT_EQ(0x000000, RgbColor(0x000000).code());
+    EXPECT_TRUE(RgbColor(0xFF0000).isValid());
+    EXPECT_EQ(0xFF0000, RgbColor(0xFF0000).code());
+    EXPECT_TRUE(RgbColor(0x00FF00).isValid());
+    EXPECT_EQ(0x00FF00, RgbColor(0x00FF00).code());
+    EXPECT_TRUE(RgbColor(0x0000FF).isValid());
+    EXPECT_EQ(0x0000FF, RgbColor(0x0000FF).code());
+    EXPECT_TRUE(RgbColor(0xFFFFFF).isValid());
+    EXPECT_EQ(0xFFFFFF, RgbColor(0xFFFFFF).code());
+}
+
+TEST(RgbColorTest, QColorCtor) {
+    EXPECT_TRUE(RgbColor(QColor::fromRgb(0x000000)).isValid());
+    EXPECT_EQ(0x000000, RgbColor(QColor::fromRgb(0x000000)).code());
+    EXPECT_TRUE(RgbColor(QColor::fromRgb(0xFF0000)).isValid());
+    EXPECT_EQ(0xFF0000, RgbColor(QColor::fromRgb(0xFF0000)).code());
+    EXPECT_TRUE(RgbColor(QColor::fromRgb(0x00FF00)).isValid());
+    EXPECT_EQ(0x00FF00, RgbColor(QColor::fromRgb(0x00FF00)).code());
+    EXPECT_TRUE(RgbColor(QColor::fromRgb(0x0000FF)).isValid());
+    EXPECT_EQ(0x0000FF, RgbColor(QColor::fromRgb(0x0000FF)).code());
+    EXPECT_TRUE(RgbColor(QColor::fromRgb(0xFFFFFF)).isValid());
+    EXPECT_EQ(0xFFFFFF, RgbColor(QColor::fromRgb(0xFFFFFF)).code());
+}
+
+TEST(RgbColorTest, FromRgbColorCodeWithAlpha) {
+    EXPECT_TRUE(RgbColor::fromCode(0xF0000000).isValid());
+    EXPECT_EQ(0x000000, RgbColor::fromCode(0xF0000000).code());
+    EXPECT_TRUE(RgbColor::fromCode(0xF0FF0000).isValid());
+    EXPECT_EQ(0xFF0000, RgbColor::fromCode(0xF0FF0000).code());
+    EXPECT_TRUE(RgbColor::fromCode(0xF000FF00).isValid());
+    EXPECT_EQ(0x00FF00, RgbColor::fromCode(0xF000FF00).code());
+    EXPECT_TRUE(RgbColor::fromCode(0xF00000FF).isValid());
+    EXPECT_EQ(0x0000FF, RgbColor::fromCode(0xF00000FF).code());
+    EXPECT_TRUE(RgbColor::fromCode(0xF0FFFFFF).isValid());
+    EXPECT_EQ(0xFFFFFF, RgbColor::fromCode(0xF0FFFFFF).code());
+}
+
+TEST(RgbColorTest, FromQColorWithAlpha) {
+    EXPECT_TRUE(RgbColor::fromCode(0xF0000000).isValid());
+    EXPECT_EQ(0x000000, RgbColor::fromCode(0xF0000000).code());
+    EXPECT_TRUE(RgbColor::fromCode(0xF0FF0000).isValid());
+    EXPECT_EQ(0xFF0000, RgbColor::fromCode(0xF0FF0000).code());
+    EXPECT_TRUE(RgbColor::fromCode(0xF000FF00).isValid());
+    EXPECT_EQ(0x00FF00, RgbColor::fromCode(0xF000FF00).code());
+    EXPECT_TRUE(RgbColor::fromCode(0xF00000FF).isValid());
+    EXPECT_EQ(0x0000FF, RgbColor::fromCode(0xF00000FF).code());
+    EXPECT_TRUE(RgbColor::fromCode(0xF0FFFFFF).isValid());
+    EXPECT_EQ(0xFFFFFF, RgbColor::fromCode(0xF0FFFFFF).code());
+}
+
+} // namespace mixxx

--- a/src/test/rgbcolor_test.cpp
+++ b/src/test/rgbcolor_test.cpp
@@ -38,29 +38,29 @@ TEST(RgbColorTest, QColorCtor) {
 }
 
 TEST(RgbColorTest, FromRgbColorCodeWithAlpha) {
-    EXPECT_TRUE(RgbColor::fromCode(0xF0000000).isValid());
-    EXPECT_EQ(0x000000, RgbColor::fromCode(0xF0000000).optionalCode());
-    EXPECT_TRUE(RgbColor::fromCode(0xF0FF0000).isValid());
-    EXPECT_EQ(0xFF0000, RgbColor::fromCode(0xF0FF0000).optionalCode());
-    EXPECT_TRUE(RgbColor::fromCode(0xF000FF00).isValid());
-    EXPECT_EQ(0x00FF00, RgbColor::fromCode(0xF000FF00).optionalCode());
-    EXPECT_TRUE(RgbColor::fromCode(0xF00000FF).isValid());
-    EXPECT_EQ(0x0000FF, RgbColor::fromCode(0xF00000FF).optionalCode());
-    EXPECT_TRUE(RgbColor::fromCode(0xF0FFFFFF).isValid());
-    EXPECT_EQ(0xFFFFFF, RgbColor::fromCode(0xF0FFFFFF).optionalCode());
+    EXPECT_TRUE(RgbColor(0xF0000000).isValid());
+    EXPECT_EQ(0x000000, RgbColor(0xF0000000).optionalCode());
+    EXPECT_TRUE(RgbColor(0xF0FF0000).isValid());
+    EXPECT_EQ(0xFF0000, RgbColor(0xF0FF0000).optionalCode());
+    EXPECT_TRUE(RgbColor(0xF000FF00).isValid());
+    EXPECT_EQ(0x00FF00, RgbColor(0xF000FF00).optionalCode());
+    EXPECT_TRUE(RgbColor(0xF00000FF).isValid());
+    EXPECT_EQ(0x0000FF, RgbColor(0xF00000FF).optionalCode());
+    EXPECT_TRUE(RgbColor(0xF0FFFFFF).isValid());
+    EXPECT_EQ(0xFFFFFF, RgbColor(0xF0FFFFFF).optionalCode());
 }
 
 TEST(RgbColorTest, FromQColorWithAlpha) {
-    EXPECT_TRUE(RgbColor::fromCode(0xF0000000).isValid());
-    EXPECT_EQ(0x000000, RgbColor::fromCode(0xF0000000).optionalCode());
-    EXPECT_TRUE(RgbColor::fromCode(0xF0FF0000).isValid());
-    EXPECT_EQ(0xFF0000, RgbColor::fromCode(0xF0FF0000).optionalCode());
-    EXPECT_TRUE(RgbColor::fromCode(0xF000FF00).isValid());
-    EXPECT_EQ(0x00FF00, RgbColor::fromCode(0xF000FF00).optionalCode());
-    EXPECT_TRUE(RgbColor::fromCode(0xF00000FF).isValid());
-    EXPECT_EQ(0x0000FF, RgbColor::fromCode(0xF00000FF).optionalCode());
-    EXPECT_TRUE(RgbColor::fromCode(0xF0FFFFFF).isValid());
-    EXPECT_EQ(0xFFFFFF, RgbColor::fromCode(0xF0FFFFFF).optionalCode());
+    EXPECT_TRUE(RgbColor(0xF0000000).isValid());
+    EXPECT_EQ(0x000000, RgbColor(0xF0000000).optionalCode());
+    EXPECT_TRUE(RgbColor(0xF0FF0000).isValid());
+    EXPECT_EQ(0xFF0000, RgbColor(0xF0FF0000).optionalCode());
+    EXPECT_TRUE(RgbColor(0xF000FF00).isValid());
+    EXPECT_EQ(0x00FF00, RgbColor(0xF000FF00).optionalCode());
+    EXPECT_TRUE(RgbColor(0xF00000FF).isValid());
+    EXPECT_EQ(0x0000FF, RgbColor(0xF00000FF).optionalCode());
+    EXPECT_TRUE(RgbColor(0xF0FFFFFF).isValid());
+    EXPECT_EQ(0xFFFFFF, RgbColor(0xF0FFFFFF).optionalCode());
 }
 
 } // namespace mixxx

--- a/src/test/rgbcolor_test.cpp
+++ b/src/test/rgbcolor_test.cpp
@@ -6,61 +6,63 @@
 
 namespace mixxx {
 
-TEST(RgbColorTest, DefaultIsInvalid) {
+TEST(RgbColorTest, DefaultIsUndefined) {
     EXPECT_FALSE(RgbColor());
-    EXPECT_FALSE(RgbColor().optionalCode());
+    EXPECT_FALSE(static_cast<bool>(RgbColor().optional()));
 }
 
-TEST(RgbColorTest, RgbColorCodeCtor) {
-    EXPECT_TRUE(RgbColor(0x000000).isValid());
-    EXPECT_EQ(0x000000, *RgbColor(0x000000).optionalCode());
-    EXPECT_TRUE(RgbColor(0xFF0000).isValid());
-    EXPECT_EQ(0xFF0000, *RgbColor(0xFF0000).optionalCode());
-    EXPECT_TRUE(RgbColor(0x00FF00).isValid());
-    EXPECT_EQ(0x00FF00, *RgbColor(0x00FF00).optionalCode());
-    EXPECT_TRUE(RgbColor(0x0000FF).isValid());
-    EXPECT_EQ(0x0000FF, *RgbColor(0x0000FF).optionalCode());
-    EXPECT_TRUE(RgbColor(0xFFFFFF).isValid());
-    EXPECT_EQ(0xFFFFFF, *RgbColor(0xFFFFFF).optionalCode());
+TEST(RgbColorTest, FromRgbColorCode) {
+    EXPECT_TRUE(RgbColor(0x000000));
+    EXPECT_EQ(0x000000, *RgbColor(0x000000).optional());
+    EXPECT_TRUE(RgbColor(0xFF0000));
+    EXPECT_EQ(0xFF0000, *RgbColor(0xFF0000).optional());
+    EXPECT_TRUE(RgbColor(0x00FF00));
+    EXPECT_EQ(0x00FF00, *RgbColor(0x00FF00).optional());
+    EXPECT_TRUE(RgbColor(0x0000FF));
+    EXPECT_EQ(0x0000FF, *RgbColor(0x0000FF).optional());
+    EXPECT_TRUE(RgbColor(0xFFFFFF));
+    EXPECT_EQ(0xFFFFFF, *RgbColor(0xFFFFFF).optional());
 }
 
-TEST(RgbColorTest, QColorCtor) {
+TEST(RgbColorTest, FromOptionalRgbColorCode) {
+    EXPECT_EQ(RgbColor(), RgbColor(std::nullopt));
+    EXPECT_EQ(RgbColor(0x123456), RgbColor(std::make_optional(0x123456)));
+}
+
+TEST(RgbColorTest, FromQColor) {
+    EXPECT_FALSE(RgbColor(QColor()));
+    EXPECT_EQ(RgbColor(), RgbColor(QColor()));
     EXPECT_TRUE(RgbColor(QColor::fromRgb(0x000000)));
-    EXPECT_EQ(0x000000, *RgbColor(QColor::fromRgb(0x000000)).optionalCode());
+    EXPECT_EQ(RgbColor(0x000000), RgbColor(QColor::fromRgb(0x000000)));
     EXPECT_TRUE(RgbColor(QColor::fromRgb(0xFF0000)));
-    EXPECT_EQ(0xFF0000, *RgbColor(QColor::fromRgb(0xFF0000)).optionalCode());
+    EXPECT_EQ(RgbColor(0xFF0000), RgbColor(QColor::fromRgb(0xFF0000)));
     EXPECT_TRUE(RgbColor(QColor::fromRgb(0x00FF00)));
-    EXPECT_EQ(0x00FF00, *RgbColor(QColor::fromRgb(0x00FF00)).optionalCode());
+    EXPECT_EQ(RgbColor(0x00FF00), RgbColor(QColor::fromRgb(0x00FF00)));
     EXPECT_TRUE(RgbColor(QColor::fromRgb(0x0000FF)));
-    EXPECT_EQ(0x0000FF, *RgbColor(QColor::fromRgb(0x0000FF)).optionalCode());
+    EXPECT_EQ(RgbColor(0x0000FF), RgbColor(QColor::fromRgb(0x0000FF)));
     EXPECT_TRUE(RgbColor(QColor::fromRgb(0xFFFFFF)));
-    EXPECT_EQ(0xFFFFFF, *RgbColor(QColor::fromRgb(0xFFFFFF)).optionalCode());
-}
-
-TEST(RgbColorTest, FromRgbColorCodeWithAlpha) {
-    EXPECT_TRUE(RgbColor(0xF0000000));
-    EXPECT_EQ(0x000000, *RgbColor(0xF0000000).optionalCode());
-    EXPECT_TRUE(RgbColor(0xF0FF0000));
-    EXPECT_EQ(0xFF0000, *RgbColor(0xF0FF0000).optionalCode());
-    EXPECT_TRUE(RgbColor(0xF000FF00));
-    EXPECT_EQ(0x00FF00, *RgbColor(0xF000FF00).optionalCode());
-    EXPECT_TRUE(RgbColor(0xF00000FF));
-    EXPECT_EQ(0x0000FF, *RgbColor(0xF00000FF).optionalCode());
-    EXPECT_TRUE(RgbColor(0xF0FFFFFF));
-    EXPECT_EQ(0xFFFFFF, *RgbColor(0xF0FFFFFF).optionalCode());
+    EXPECT_EQ(RgbColor(0xFFFFFF), RgbColor(QColor::fromRgb(0xFFFFFF)));
 }
 
 TEST(RgbColorTest, FromQColorWithAlpha) {
-    EXPECT_TRUE(RgbColor(0xF0000000));
-    EXPECT_EQ(0x000000, *RgbColor(0xF0000000).optionalCode());
-    EXPECT_TRUE(RgbColor(0xF0FF0000));
-    EXPECT_EQ(0xFF0000, *RgbColor(0xF0FF0000).optionalCode());
-    EXPECT_TRUE(RgbColor(0xF000FF00));
-    EXPECT_EQ(0x00FF00, *RgbColor(0xF000FF00).optionalCode());
-    EXPECT_TRUE(RgbColor(0xF00000FF));
-    EXPECT_EQ(0x0000FF, *RgbColor(0xF00000FF).optionalCode());
-    EXPECT_TRUE(RgbColor(0xF0FFFFFF));
-    EXPECT_EQ(0xFFFFFF, *RgbColor(0xF0FFFFFF).optionalCode());
+    EXPECT_TRUE(RgbColor(QColor::fromRgba(0xAA000000)));
+    EXPECT_EQ(RgbColor(0x000000), RgbColor(QColor::fromRgba(0xAA000000)));
+    EXPECT_TRUE(RgbColor(QColor::fromRgba(0xAAFF0000)));
+    EXPECT_EQ(RgbColor(0xFF0000), RgbColor(QColor::fromRgba(0xAAFF0000)));
+    EXPECT_TRUE(RgbColor(QColor::fromRgba(0xAA00FF00)));
+    EXPECT_EQ(RgbColor(0x00FF00), RgbColor(QColor::fromRgba(0xAA00FF00)));
+    EXPECT_TRUE(RgbColor(QColor::fromRgba(0xAA0000FF)));
+    EXPECT_EQ(RgbColor(0x0000FF), RgbColor(QColor::fromRgba(0xAA0000FF)));
+    EXPECT_TRUE(RgbColor(QColor::fromRgba(0xAAFFFFFF)));
+    EXPECT_EQ(RgbColor(0xFFFFFF), RgbColor(QColor::fromRgba(0xAAFFFFFF)));
+}
+
+TEST(RgbColorTest, ToQColor) {
+    EXPECT_EQ(QColor(), RgbColor().toQColor());
+    EXPECT_EQ(QColor::fromRgba(0xAABBCCDD),
+            RgbColor().toQColor(QColor::fromRgba(0xAABBCCDD)));
+    EXPECT_EQ(QColor::fromRgb(0x123456),
+            RgbColor(QColor::fromRgba(0xAA123456)).toQColor(QColor::fromRgba(0xAABBCCDD)));
 }
 
 } // namespace mixxx

--- a/src/test/rgbcolor_test.cpp
+++ b/src/test/rgbcolor_test.cpp
@@ -8,58 +8,59 @@ namespace mixxx {
 
 TEST(RgbColorTest, DefaultIsInvalid) {
     EXPECT_FALSE(RgbColor().isValid());
+    EXPECT_FALSE(RgbColor().optionalCode().has_value());
 }
 
 TEST(RgbColorTest, RgbColorCodeCtor) {
     EXPECT_TRUE(RgbColor(0x000000).isValid());
-    EXPECT_EQ(0x000000, RgbColor(0x000000).code());
+    EXPECT_EQ(0x000000, RgbColor(0x000000).optionalCode());
     EXPECT_TRUE(RgbColor(0xFF0000).isValid());
-    EXPECT_EQ(0xFF0000, RgbColor(0xFF0000).code());
+    EXPECT_EQ(0xFF0000, RgbColor(0xFF0000).optionalCode());
     EXPECT_TRUE(RgbColor(0x00FF00).isValid());
-    EXPECT_EQ(0x00FF00, RgbColor(0x00FF00).code());
+    EXPECT_EQ(0x00FF00, RgbColor(0x00FF00).optionalCode());
     EXPECT_TRUE(RgbColor(0x0000FF).isValid());
-    EXPECT_EQ(0x0000FF, RgbColor(0x0000FF).code());
+    EXPECT_EQ(0x0000FF, RgbColor(0x0000FF).optionalCode());
     EXPECT_TRUE(RgbColor(0xFFFFFF).isValid());
-    EXPECT_EQ(0xFFFFFF, RgbColor(0xFFFFFF).code());
+    EXPECT_EQ(0xFFFFFF, RgbColor(0xFFFFFF).optionalCode());
 }
 
 TEST(RgbColorTest, QColorCtor) {
     EXPECT_TRUE(RgbColor(QColor::fromRgb(0x000000)).isValid());
-    EXPECT_EQ(0x000000, RgbColor(QColor::fromRgb(0x000000)).code());
+    EXPECT_EQ(0x000000, RgbColor(QColor::fromRgb(0x000000)).optionalCode());
     EXPECT_TRUE(RgbColor(QColor::fromRgb(0xFF0000)).isValid());
-    EXPECT_EQ(0xFF0000, RgbColor(QColor::fromRgb(0xFF0000)).code());
+    EXPECT_EQ(0xFF0000, RgbColor(QColor::fromRgb(0xFF0000)).optionalCode());
     EXPECT_TRUE(RgbColor(QColor::fromRgb(0x00FF00)).isValid());
-    EXPECT_EQ(0x00FF00, RgbColor(QColor::fromRgb(0x00FF00)).code());
+    EXPECT_EQ(0x00FF00, RgbColor(QColor::fromRgb(0x00FF00)).optionalCode());
     EXPECT_TRUE(RgbColor(QColor::fromRgb(0x0000FF)).isValid());
-    EXPECT_EQ(0x0000FF, RgbColor(QColor::fromRgb(0x0000FF)).code());
+    EXPECT_EQ(0x0000FF, RgbColor(QColor::fromRgb(0x0000FF)).optionalCode());
     EXPECT_TRUE(RgbColor(QColor::fromRgb(0xFFFFFF)).isValid());
-    EXPECT_EQ(0xFFFFFF, RgbColor(QColor::fromRgb(0xFFFFFF)).code());
+    EXPECT_EQ(0xFFFFFF, RgbColor(QColor::fromRgb(0xFFFFFF)).optionalCode());
 }
 
 TEST(RgbColorTest, FromRgbColorCodeWithAlpha) {
     EXPECT_TRUE(RgbColor::fromCode(0xF0000000).isValid());
-    EXPECT_EQ(0x000000, RgbColor::fromCode(0xF0000000).code());
+    EXPECT_EQ(0x000000, RgbColor::fromCode(0xF0000000).optionalCode());
     EXPECT_TRUE(RgbColor::fromCode(0xF0FF0000).isValid());
-    EXPECT_EQ(0xFF0000, RgbColor::fromCode(0xF0FF0000).code());
+    EXPECT_EQ(0xFF0000, RgbColor::fromCode(0xF0FF0000).optionalCode());
     EXPECT_TRUE(RgbColor::fromCode(0xF000FF00).isValid());
-    EXPECT_EQ(0x00FF00, RgbColor::fromCode(0xF000FF00).code());
+    EXPECT_EQ(0x00FF00, RgbColor::fromCode(0xF000FF00).optionalCode());
     EXPECT_TRUE(RgbColor::fromCode(0xF00000FF).isValid());
-    EXPECT_EQ(0x0000FF, RgbColor::fromCode(0xF00000FF).code());
+    EXPECT_EQ(0x0000FF, RgbColor::fromCode(0xF00000FF).optionalCode());
     EXPECT_TRUE(RgbColor::fromCode(0xF0FFFFFF).isValid());
-    EXPECT_EQ(0xFFFFFF, RgbColor::fromCode(0xF0FFFFFF).code());
+    EXPECT_EQ(0xFFFFFF, RgbColor::fromCode(0xF0FFFFFF).optionalCode());
 }
 
 TEST(RgbColorTest, FromQColorWithAlpha) {
     EXPECT_TRUE(RgbColor::fromCode(0xF0000000).isValid());
-    EXPECT_EQ(0x000000, RgbColor::fromCode(0xF0000000).code());
+    EXPECT_EQ(0x000000, RgbColor::fromCode(0xF0000000).optionalCode());
     EXPECT_TRUE(RgbColor::fromCode(0xF0FF0000).isValid());
-    EXPECT_EQ(0xFF0000, RgbColor::fromCode(0xF0FF0000).code());
+    EXPECT_EQ(0xFF0000, RgbColor::fromCode(0xF0FF0000).optionalCode());
     EXPECT_TRUE(RgbColor::fromCode(0xF000FF00).isValid());
-    EXPECT_EQ(0x00FF00, RgbColor::fromCode(0xF000FF00).code());
+    EXPECT_EQ(0x00FF00, RgbColor::fromCode(0xF000FF00).optionalCode());
     EXPECT_TRUE(RgbColor::fromCode(0xF00000FF).isValid());
-    EXPECT_EQ(0x0000FF, RgbColor::fromCode(0xF00000FF).code());
+    EXPECT_EQ(0x0000FF, RgbColor::fromCode(0xF00000FF).optionalCode());
     EXPECT_TRUE(RgbColor::fromCode(0xF0FFFFFF).isValid());
-    EXPECT_EQ(0xFFFFFF, RgbColor::fromCode(0xF0FFFFFF).code());
+    EXPECT_EQ(0xFFFFFF, RgbColor::fromCode(0xF0FFFFFF).optionalCode());
 }
 
 } // namespace mixxx

--- a/src/test/rgbcolor_test.cpp
+++ b/src/test/rgbcolor_test.cpp
@@ -26,7 +26,7 @@ TEST(RgbColorTest, FromRgbColorCode) {
 
 TEST(RgbColorTest, FromOptionalRgbColorCode) {
     EXPECT_EQ(RgbColor(), RgbColor(std::nullopt));
-    EXPECT_EQ(RgbColor(0x123456), RgbColor(std::make_optional(0x123456)));
+    EXPECT_EQ(RgbColor(0x123456), RgbColor(std::make_optional(RgbColorCode(0x123456))));
 }
 
 TEST(RgbColorTest, FromQColor) {

--- a/src/test/rgbcolor_test.cpp
+++ b/src/test/rgbcolor_test.cpp
@@ -7,7 +7,7 @@
 namespace mixxx {
 
 TEST(RgbColorTest, DefaultIsInvalid) {
-    EXPECT_FALSE(RgbColor().isValid());
+    EXPECT_FALSE(RgbColor());
     EXPECT_FALSE(RgbColor().optionalCode());
 }
 
@@ -25,41 +25,41 @@ TEST(RgbColorTest, RgbColorCodeCtor) {
 }
 
 TEST(RgbColorTest, QColorCtor) {
-    EXPECT_TRUE(RgbColor(QColor::fromRgb(0x000000)).isValid());
+    EXPECT_TRUE(RgbColor(QColor::fromRgb(0x000000)));
     EXPECT_EQ(0x000000, *RgbColor(QColor::fromRgb(0x000000)).optionalCode());
-    EXPECT_TRUE(RgbColor(QColor::fromRgb(0xFF0000)).isValid());
+    EXPECT_TRUE(RgbColor(QColor::fromRgb(0xFF0000)));
     EXPECT_EQ(0xFF0000, *RgbColor(QColor::fromRgb(0xFF0000)).optionalCode());
-    EXPECT_TRUE(RgbColor(QColor::fromRgb(0x00FF00)).isValid());
+    EXPECT_TRUE(RgbColor(QColor::fromRgb(0x00FF00)));
     EXPECT_EQ(0x00FF00, *RgbColor(QColor::fromRgb(0x00FF00)).optionalCode());
-    EXPECT_TRUE(RgbColor(QColor::fromRgb(0x0000FF)).isValid());
+    EXPECT_TRUE(RgbColor(QColor::fromRgb(0x0000FF)));
     EXPECT_EQ(0x0000FF, *RgbColor(QColor::fromRgb(0x0000FF)).optionalCode());
-    EXPECT_TRUE(RgbColor(QColor::fromRgb(0xFFFFFF)).isValid());
+    EXPECT_TRUE(RgbColor(QColor::fromRgb(0xFFFFFF)));
     EXPECT_EQ(0xFFFFFF, *RgbColor(QColor::fromRgb(0xFFFFFF)).optionalCode());
 }
 
 TEST(RgbColorTest, FromRgbColorCodeWithAlpha) {
-    EXPECT_TRUE(RgbColor(0xF0000000).isValid());
+    EXPECT_TRUE(RgbColor(0xF0000000));
     EXPECT_EQ(0x000000, *RgbColor(0xF0000000).optionalCode());
-    EXPECT_TRUE(RgbColor(0xF0FF0000).isValid());
+    EXPECT_TRUE(RgbColor(0xF0FF0000));
     EXPECT_EQ(0xFF0000, *RgbColor(0xF0FF0000).optionalCode());
-    EXPECT_TRUE(RgbColor(0xF000FF00).isValid());
+    EXPECT_TRUE(RgbColor(0xF000FF00));
     EXPECT_EQ(0x00FF00, *RgbColor(0xF000FF00).optionalCode());
-    EXPECT_TRUE(RgbColor(0xF00000FF).isValid());
+    EXPECT_TRUE(RgbColor(0xF00000FF));
     EXPECT_EQ(0x0000FF, *RgbColor(0xF00000FF).optionalCode());
-    EXPECT_TRUE(RgbColor(0xF0FFFFFF).isValid());
+    EXPECT_TRUE(RgbColor(0xF0FFFFFF));
     EXPECT_EQ(0xFFFFFF, *RgbColor(0xF0FFFFFF).optionalCode());
 }
 
 TEST(RgbColorTest, FromQColorWithAlpha) {
-    EXPECT_TRUE(RgbColor(0xF0000000).isValid());
+    EXPECT_TRUE(RgbColor(0xF0000000));
     EXPECT_EQ(0x000000, *RgbColor(0xF0000000).optionalCode());
-    EXPECT_TRUE(RgbColor(0xF0FF0000).isValid());
+    EXPECT_TRUE(RgbColor(0xF0FF0000));
     EXPECT_EQ(0xFF0000, *RgbColor(0xF0FF0000).optionalCode());
-    EXPECT_TRUE(RgbColor(0xF000FF00).isValid());
+    EXPECT_TRUE(RgbColor(0xF000FF00));
     EXPECT_EQ(0x00FF00, *RgbColor(0xF000FF00).optionalCode());
-    EXPECT_TRUE(RgbColor(0xF00000FF).isValid());
+    EXPECT_TRUE(RgbColor(0xF00000FF));
     EXPECT_EQ(0x0000FF, *RgbColor(0xF00000FF).optionalCode());
-    EXPECT_TRUE(RgbColor(0xF0FFFFFF).isValid());
+    EXPECT_TRUE(RgbColor(0xF0FFFFFF));
     EXPECT_EQ(0xFFFFFF, *RgbColor(0xF0FFFFFF).optionalCode());
 }
 

--- a/src/test/rgbcolor_test.cpp
+++ b/src/test/rgbcolor_test.cpp
@@ -8,59 +8,59 @@ namespace mixxx {
 
 TEST(RgbColorTest, DefaultIsInvalid) {
     EXPECT_FALSE(RgbColor().isValid());
-    EXPECT_FALSE(RgbColor().optionalCode().has_value());
+    EXPECT_FALSE(RgbColor().optionalCode());
 }
 
 TEST(RgbColorTest, RgbColorCodeCtor) {
     EXPECT_TRUE(RgbColor(0x000000).isValid());
-    EXPECT_EQ(0x000000, RgbColor(0x000000).optionalCode());
+    EXPECT_EQ(0x000000, *RgbColor(0x000000).optionalCode());
     EXPECT_TRUE(RgbColor(0xFF0000).isValid());
-    EXPECT_EQ(0xFF0000, RgbColor(0xFF0000).optionalCode());
+    EXPECT_EQ(0xFF0000, *RgbColor(0xFF0000).optionalCode());
     EXPECT_TRUE(RgbColor(0x00FF00).isValid());
-    EXPECT_EQ(0x00FF00, RgbColor(0x00FF00).optionalCode());
+    EXPECT_EQ(0x00FF00, *RgbColor(0x00FF00).optionalCode());
     EXPECT_TRUE(RgbColor(0x0000FF).isValid());
-    EXPECT_EQ(0x0000FF, RgbColor(0x0000FF).optionalCode());
+    EXPECT_EQ(0x0000FF, *RgbColor(0x0000FF).optionalCode());
     EXPECT_TRUE(RgbColor(0xFFFFFF).isValid());
-    EXPECT_EQ(0xFFFFFF, RgbColor(0xFFFFFF).optionalCode());
+    EXPECT_EQ(0xFFFFFF, *RgbColor(0xFFFFFF).optionalCode());
 }
 
 TEST(RgbColorTest, QColorCtor) {
     EXPECT_TRUE(RgbColor(QColor::fromRgb(0x000000)).isValid());
-    EXPECT_EQ(0x000000, RgbColor(QColor::fromRgb(0x000000)).optionalCode());
+    EXPECT_EQ(0x000000, *RgbColor(QColor::fromRgb(0x000000)).optionalCode());
     EXPECT_TRUE(RgbColor(QColor::fromRgb(0xFF0000)).isValid());
-    EXPECT_EQ(0xFF0000, RgbColor(QColor::fromRgb(0xFF0000)).optionalCode());
+    EXPECT_EQ(0xFF0000, *RgbColor(QColor::fromRgb(0xFF0000)).optionalCode());
     EXPECT_TRUE(RgbColor(QColor::fromRgb(0x00FF00)).isValid());
-    EXPECT_EQ(0x00FF00, RgbColor(QColor::fromRgb(0x00FF00)).optionalCode());
+    EXPECT_EQ(0x00FF00, *RgbColor(QColor::fromRgb(0x00FF00)).optionalCode());
     EXPECT_TRUE(RgbColor(QColor::fromRgb(0x0000FF)).isValid());
-    EXPECT_EQ(0x0000FF, RgbColor(QColor::fromRgb(0x0000FF)).optionalCode());
+    EXPECT_EQ(0x0000FF, *RgbColor(QColor::fromRgb(0x0000FF)).optionalCode());
     EXPECT_TRUE(RgbColor(QColor::fromRgb(0xFFFFFF)).isValid());
-    EXPECT_EQ(0xFFFFFF, RgbColor(QColor::fromRgb(0xFFFFFF)).optionalCode());
+    EXPECT_EQ(0xFFFFFF, *RgbColor(QColor::fromRgb(0xFFFFFF)).optionalCode());
 }
 
 TEST(RgbColorTest, FromRgbColorCodeWithAlpha) {
     EXPECT_TRUE(RgbColor(0xF0000000).isValid());
-    EXPECT_EQ(0x000000, RgbColor(0xF0000000).optionalCode());
+    EXPECT_EQ(0x000000, *RgbColor(0xF0000000).optionalCode());
     EXPECT_TRUE(RgbColor(0xF0FF0000).isValid());
-    EXPECT_EQ(0xFF0000, RgbColor(0xF0FF0000).optionalCode());
+    EXPECT_EQ(0xFF0000, *RgbColor(0xF0FF0000).optionalCode());
     EXPECT_TRUE(RgbColor(0xF000FF00).isValid());
-    EXPECT_EQ(0x00FF00, RgbColor(0xF000FF00).optionalCode());
+    EXPECT_EQ(0x00FF00, *RgbColor(0xF000FF00).optionalCode());
     EXPECT_TRUE(RgbColor(0xF00000FF).isValid());
-    EXPECT_EQ(0x0000FF, RgbColor(0xF00000FF).optionalCode());
+    EXPECT_EQ(0x0000FF, *RgbColor(0xF00000FF).optionalCode());
     EXPECT_TRUE(RgbColor(0xF0FFFFFF).isValid());
-    EXPECT_EQ(0xFFFFFF, RgbColor(0xF0FFFFFF).optionalCode());
+    EXPECT_EQ(0xFFFFFF, *RgbColor(0xF0FFFFFF).optionalCode());
 }
 
 TEST(RgbColorTest, FromQColorWithAlpha) {
     EXPECT_TRUE(RgbColor(0xF0000000).isValid());
-    EXPECT_EQ(0x000000, RgbColor(0xF0000000).optionalCode());
+    EXPECT_EQ(0x000000, *RgbColor(0xF0000000).optionalCode());
     EXPECT_TRUE(RgbColor(0xF0FF0000).isValid());
-    EXPECT_EQ(0xFF0000, RgbColor(0xF0FF0000).optionalCode());
+    EXPECT_EQ(0xFF0000, *RgbColor(0xF0FF0000).optionalCode());
     EXPECT_TRUE(RgbColor(0xF000FF00).isValid());
-    EXPECT_EQ(0x00FF00, RgbColor(0xF000FF00).optionalCode());
+    EXPECT_EQ(0x00FF00, *RgbColor(0xF000FF00).optionalCode());
     EXPECT_TRUE(RgbColor(0xF00000FF).isValid());
-    EXPECT_EQ(0x0000FF, RgbColor(0xF00000FF).optionalCode());
+    EXPECT_EQ(0x0000FF, *RgbColor(0xF00000FF).optionalCode());
     EXPECT_TRUE(RgbColor(0xF0FFFFFF).isValid());
-    EXPECT_EQ(0xFFFFFF, RgbColor(0xF0FFFFFF).optionalCode());
+    EXPECT_EQ(0xFFFFFF, *RgbColor(0xF0FFFFFF).optionalCode());
 }
 
 } // namespace mixxx

--- a/src/test/rgbcolor_test.cpp
+++ b/src/test/rgbcolor_test.cpp
@@ -6,63 +6,63 @@
 
 namespace mixxx {
 
-TEST(RgbColorTest, DefaultIsUndefined) {
-    EXPECT_FALSE(RgbColor());
-    EXPECT_FALSE(static_cast<bool>(RgbColor().optional()));
+TEST(OptionalRgbColorTest, DefaultIsUndefined) {
+    EXPECT_FALSE(OptionalRgbColor().optional());
+    EXPECT_FALSE(static_cast<bool>(OptionalRgbColor().optional()));
 }
 
-TEST(RgbColorTest, FromRgbColorCode) {
-    EXPECT_TRUE(RgbColor(0x000000));
-    EXPECT_EQ(0x000000, *RgbColor(0x000000).optional());
-    EXPECT_TRUE(RgbColor(0xFF0000));
-    EXPECT_EQ(0xFF0000, *RgbColor(0xFF0000).optional());
-    EXPECT_TRUE(RgbColor(0x00FF00));
-    EXPECT_EQ(0x00FF00, *RgbColor(0x00FF00).optional());
-    EXPECT_TRUE(RgbColor(0x0000FF));
-    EXPECT_EQ(0x0000FF, *RgbColor(0x0000FF).optional());
-    EXPECT_TRUE(RgbColor(0xFFFFFF));
-    EXPECT_EQ(0xFFFFFF, *RgbColor(0xFFFFFF).optional());
+TEST(OptionalRgbColorTest, FromRgbColorCode) {
+    EXPECT_TRUE(OptionalRgbColor(0x000000).optional());
+    EXPECT_EQ(RgbColor(0x000000), *OptionalRgbColor(0x000000).optional());
+    EXPECT_TRUE(OptionalRgbColor(0xFF0000).optional());
+    EXPECT_EQ(RgbColor(0xFF0000), *OptionalRgbColor(0xFF0000).optional());
+    EXPECT_TRUE(OptionalRgbColor(0x00FF00).optional());
+    EXPECT_EQ(RgbColor(0x00FF00), *OptionalRgbColor(0x00FF00).optional());
+    EXPECT_TRUE(OptionalRgbColor(0x0000FF).optional());
+    EXPECT_EQ(RgbColor(0x0000FF), *OptionalRgbColor(0x0000FF).optional());
+    EXPECT_TRUE(OptionalRgbColor(0xFFFFFF).optional());
+    EXPECT_EQ(RgbColor(0xFFFFFF), *OptionalRgbColor(0xFFFFFF).optional());
 }
 
-TEST(RgbColorTest, FromOptionalRgbColorCode) {
-    EXPECT_EQ(RgbColor(), RgbColor(std::nullopt));
-    EXPECT_EQ(RgbColor(0x123456), RgbColor(std::make_optional(RgbColorCode(0x123456))));
+TEST(OptionalRgbColorTest, FromOptionalRgbColorCode) {
+    EXPECT_EQ(OptionalRgbColor(), OptionalRgbColor(std::nullopt));
+    EXPECT_EQ(OptionalRgbColor(0x123456), OptionalRgbColor(std::make_optional(RgbColor(0x123456))));
 }
 
-TEST(RgbColorTest, FromQColor) {
-    EXPECT_FALSE(RgbColor(QColor()));
-    EXPECT_EQ(RgbColor(), RgbColor(QColor()));
-    EXPECT_TRUE(RgbColor(QColor::fromRgb(0x000000)));
-    EXPECT_EQ(RgbColor(0x000000), RgbColor(QColor::fromRgb(0x000000)));
-    EXPECT_TRUE(RgbColor(QColor::fromRgb(0xFF0000)));
-    EXPECT_EQ(RgbColor(0xFF0000), RgbColor(QColor::fromRgb(0xFF0000)));
-    EXPECT_TRUE(RgbColor(QColor::fromRgb(0x00FF00)));
-    EXPECT_EQ(RgbColor(0x00FF00), RgbColor(QColor::fromRgb(0x00FF00)));
-    EXPECT_TRUE(RgbColor(QColor::fromRgb(0x0000FF)));
-    EXPECT_EQ(RgbColor(0x0000FF), RgbColor(QColor::fromRgb(0x0000FF)));
-    EXPECT_TRUE(RgbColor(QColor::fromRgb(0xFFFFFF)));
-    EXPECT_EQ(RgbColor(0xFFFFFF), RgbColor(QColor::fromRgb(0xFFFFFF)));
+TEST(OptionalRgbColorTest, FromQColor) {
+    EXPECT_FALSE(OptionalRgbColor(QColor()).optional());
+    EXPECT_EQ(OptionalRgbColor(), OptionalRgbColor(QColor()));
+    EXPECT_TRUE(OptionalRgbColor(QColor::fromRgb(0x000000)).optional());
+    EXPECT_EQ(OptionalRgbColor(0x000000), OptionalRgbColor(QColor::fromRgb(0x000000)));
+    EXPECT_TRUE(OptionalRgbColor(QColor::fromRgb(0xFF0000)).optional());
+    EXPECT_EQ(OptionalRgbColor(0xFF0000), OptionalRgbColor(QColor::fromRgb(0xFF0000)));
+    EXPECT_TRUE(OptionalRgbColor(QColor::fromRgb(0x00FF00)).optional());
+    EXPECT_EQ(OptionalRgbColor(0x00FF00), OptionalRgbColor(QColor::fromRgb(0x00FF00)));
+    EXPECT_TRUE(OptionalRgbColor(QColor::fromRgb(0x0000FF)).optional());
+    EXPECT_EQ(OptionalRgbColor(0x0000FF), OptionalRgbColor(QColor::fromRgb(0x0000FF)));
+    EXPECT_TRUE(OptionalRgbColor(QColor::fromRgb(0xFFFFFF)).optional());
+    EXPECT_EQ(OptionalRgbColor(0xFFFFFF), OptionalRgbColor(QColor::fromRgb(0xFFFFFF)));
 }
 
-TEST(RgbColorTest, FromQColorWithAlpha) {
-    EXPECT_TRUE(RgbColor(QColor::fromRgba(0xAA000000)));
-    EXPECT_EQ(RgbColor(0x000000), RgbColor(QColor::fromRgba(0xAA000000)));
-    EXPECT_TRUE(RgbColor(QColor::fromRgba(0xAAFF0000)));
-    EXPECT_EQ(RgbColor(0xFF0000), RgbColor(QColor::fromRgba(0xAAFF0000)));
-    EXPECT_TRUE(RgbColor(QColor::fromRgba(0xAA00FF00)));
-    EXPECT_EQ(RgbColor(0x00FF00), RgbColor(QColor::fromRgba(0xAA00FF00)));
-    EXPECT_TRUE(RgbColor(QColor::fromRgba(0xAA0000FF)));
-    EXPECT_EQ(RgbColor(0x0000FF), RgbColor(QColor::fromRgba(0xAA0000FF)));
-    EXPECT_TRUE(RgbColor(QColor::fromRgba(0xAAFFFFFF)));
-    EXPECT_EQ(RgbColor(0xFFFFFF), RgbColor(QColor::fromRgba(0xAAFFFFFF)));
+TEST(OptionalRgbColorTest, FromQColorWithAlpha) {
+    EXPECT_TRUE(OptionalRgbColor(QColor::fromRgba(0xAA000000)).optional());
+    EXPECT_EQ(OptionalRgbColor(0x000000), OptionalRgbColor(QColor::fromRgba(0xAA000000)));
+    EXPECT_TRUE(OptionalRgbColor(QColor::fromRgba(0xAAFF0000)).optional());
+    EXPECT_EQ(OptionalRgbColor(0xFF0000), OptionalRgbColor(QColor::fromRgba(0xAAFF0000)));
+    EXPECT_TRUE(OptionalRgbColor(QColor::fromRgba(0xAA00FF00)).optional());
+    EXPECT_EQ(OptionalRgbColor(0x00FF00), OptionalRgbColor(QColor::fromRgba(0xAA00FF00)));
+    EXPECT_TRUE(OptionalRgbColor(QColor::fromRgba(0xAA0000FF)).optional());
+    EXPECT_EQ(OptionalRgbColor(0x0000FF), OptionalRgbColor(QColor::fromRgba(0xAA0000FF)));
+    EXPECT_TRUE(OptionalRgbColor(QColor::fromRgba(0xAAFFFFFF)).optional());
+    EXPECT_EQ(OptionalRgbColor(0xFFFFFF), OptionalRgbColor(QColor::fromRgba(0xAAFFFFFF)));
 }
 
-TEST(RgbColorTest, ToQColor) {
-    EXPECT_EQ(QColor(), RgbColor().toQColor());
+TEST(OptionalRgbColorTest, ToQColor) {
+    EXPECT_EQ(QColor(), OptionalRgbColor().toQColor());
     EXPECT_EQ(QColor::fromRgba(0xAABBCCDD),
-            RgbColor().toQColor(QColor::fromRgba(0xAABBCCDD)));
+            OptionalRgbColor().toQColor(QColor::fromRgba(0xAABBCCDD)));
     EXPECT_EQ(QColor::fromRgb(0x123456),
-            RgbColor(QColor::fromRgba(0xAA123456)).toQColor(QColor::fromRgba(0xAABBCCDD)));
+            OptionalRgbColor(QColor::fromRgba(0xAA123456)).toQColor(QColor::fromRgba(0xAABBCCDD)));
 }
 
 } // namespace mixxx

--- a/src/test/rgbcolor_test.cpp
+++ b/src/test/rgbcolor_test.cpp
@@ -6,63 +6,45 @@
 
 namespace mixxx {
 
-TEST(OptionalRgbColorTest, DefaultIsUndefined) {
-    EXPECT_FALSE(OptionalRgbColor().optional());
-    EXPECT_FALSE(static_cast<bool>(OptionalRgbColor().optional()));
+TEST(RgbColorTest, OptionalRgbColorFromInvalidQColor) {
+    EXPECT_FALSE(RgbColor::optional(QColor()));
+    EXPECT_EQ(RgbColor::nullopt(), RgbColor::optional(QColor()));
 }
 
-TEST(OptionalRgbColorTest, FromRgbColorCode) {
-    EXPECT_TRUE(OptionalRgbColor(0x000000).optional());
-    EXPECT_EQ(RgbColor(0x000000), *OptionalRgbColor(0x000000).optional());
-    EXPECT_TRUE(OptionalRgbColor(0xFF0000).optional());
-    EXPECT_EQ(RgbColor(0xFF0000), *OptionalRgbColor(0xFF0000).optional());
-    EXPECT_TRUE(OptionalRgbColor(0x00FF00).optional());
-    EXPECT_EQ(RgbColor(0x00FF00), *OptionalRgbColor(0x00FF00).optional());
-    EXPECT_TRUE(OptionalRgbColor(0x0000FF).optional());
-    EXPECT_EQ(RgbColor(0x0000FF), *OptionalRgbColor(0x0000FF).optional());
-    EXPECT_TRUE(OptionalRgbColor(0xFFFFFF).optional());
-    EXPECT_EQ(RgbColor(0xFFFFFF), *OptionalRgbColor(0xFFFFFF).optional());
+TEST(RgbColorTest, OptionalRgbColorFromQColorWithoutAlpha) {
+    EXPECT_TRUE(RgbColor::optional(QColor::fromRgb(0x000000)));
+    EXPECT_EQ(0x000000, *RgbColor::optional(QColor::fromRgb(0x000000)));
+    EXPECT_TRUE(RgbColor::optional(QColor::fromRgb(0xFF0000)));
+    EXPECT_EQ(RgbColor::optional(0xFF0000), RgbColor::optional(QColor::fromRgb(0xFF0000)));
+    EXPECT_TRUE(RgbColor::optional(QColor::fromRgb(0x00FF00)));
+    EXPECT_EQ(RgbColor::optional(0x00FF00), RgbColor::optional(QColor::fromRgb(0x00FF00)));
+    EXPECT_TRUE(RgbColor::optional(QColor::fromRgb(0x0000FF)));
+    EXPECT_EQ(RgbColor::optional(0x0000FF), RgbColor::optional(QColor::fromRgb(0x0000FF)));
+    EXPECT_TRUE(RgbColor::optional(QColor::fromRgb(0xFFFFFF)));
+    EXPECT_EQ(RgbColor::optional(0xFFFFFF), RgbColor::optional(QColor::fromRgb(0xFFFFFF)));
 }
 
-TEST(OptionalRgbColorTest, FromOptionalRgbColorCode) {
-    EXPECT_EQ(OptionalRgbColor(), OptionalRgbColor(std::nullopt));
-    EXPECT_EQ(OptionalRgbColor(0x123456), OptionalRgbColor(std::make_optional(RgbColor(0x123456))));
+TEST(RgbColorTest, OptionalRgbColorFromQColorWithAlpha) {
+    EXPECT_TRUE(RgbColor::optional(QColor::fromRgba(0xAA000000)));
+    EXPECT_EQ(RgbColor::optional(0x000000), RgbColor::optional(QColor::fromRgba(0xAA000000)));
+    EXPECT_TRUE(RgbColor::optional(QColor::fromRgba(0xAAFF0000)));
+    EXPECT_EQ(RgbColor::optional(0xFF0000), RgbColor::optional(QColor::fromRgba(0xAAFF0000)));
+    EXPECT_TRUE(RgbColor::optional(QColor::fromRgba(0xAA00FF00)));
+    EXPECT_EQ(RgbColor::optional(0x00FF00), RgbColor::optional(QColor::fromRgba(0xAA00FF00)));
+    EXPECT_TRUE(RgbColor::optional(QColor::fromRgba(0xAA0000FF)));
+    EXPECT_EQ(RgbColor::optional(0x0000FF), RgbColor::optional(QColor::fromRgba(0xAA0000FF)));
+    EXPECT_TRUE(RgbColor::optional(QColor::fromRgba(0xAAFFFFFF)));
+    EXPECT_EQ(RgbColor::optional(0xFFFFFF), RgbColor::optional(QColor::fromRgba(0xAAFFFFFF)));
 }
 
-TEST(OptionalRgbColorTest, FromQColor) {
-    EXPECT_FALSE(OptionalRgbColor(QColor()).optional());
-    EXPECT_EQ(OptionalRgbColor(), OptionalRgbColor(QColor()));
-    EXPECT_TRUE(OptionalRgbColor(QColor::fromRgb(0x000000)).optional());
-    EXPECT_EQ(OptionalRgbColor(0x000000), OptionalRgbColor(QColor::fromRgb(0x000000)));
-    EXPECT_TRUE(OptionalRgbColor(QColor::fromRgb(0xFF0000)).optional());
-    EXPECT_EQ(OptionalRgbColor(0xFF0000), OptionalRgbColor(QColor::fromRgb(0xFF0000)));
-    EXPECT_TRUE(OptionalRgbColor(QColor::fromRgb(0x00FF00)).optional());
-    EXPECT_EQ(OptionalRgbColor(0x00FF00), OptionalRgbColor(QColor::fromRgb(0x00FF00)));
-    EXPECT_TRUE(OptionalRgbColor(QColor::fromRgb(0x0000FF)).optional());
-    EXPECT_EQ(OptionalRgbColor(0x0000FF), OptionalRgbColor(QColor::fromRgb(0x0000FF)));
-    EXPECT_TRUE(OptionalRgbColor(QColor::fromRgb(0xFFFFFF)).optional());
-    EXPECT_EQ(OptionalRgbColor(0xFFFFFF), OptionalRgbColor(QColor::fromRgb(0xFFFFFF)));
-}
-
-TEST(OptionalRgbColorTest, FromQColorWithAlpha) {
-    EXPECT_TRUE(OptionalRgbColor(QColor::fromRgba(0xAA000000)).optional());
-    EXPECT_EQ(OptionalRgbColor(0x000000), OptionalRgbColor(QColor::fromRgba(0xAA000000)));
-    EXPECT_TRUE(OptionalRgbColor(QColor::fromRgba(0xAAFF0000)).optional());
-    EXPECT_EQ(OptionalRgbColor(0xFF0000), OptionalRgbColor(QColor::fromRgba(0xAAFF0000)));
-    EXPECT_TRUE(OptionalRgbColor(QColor::fromRgba(0xAA00FF00)).optional());
-    EXPECT_EQ(OptionalRgbColor(0x00FF00), OptionalRgbColor(QColor::fromRgba(0xAA00FF00)));
-    EXPECT_TRUE(OptionalRgbColor(QColor::fromRgba(0xAA0000FF)).optional());
-    EXPECT_EQ(OptionalRgbColor(0x0000FF), OptionalRgbColor(QColor::fromRgba(0xAA0000FF)));
-    EXPECT_TRUE(OptionalRgbColor(QColor::fromRgba(0xAAFFFFFF)).optional());
-    EXPECT_EQ(OptionalRgbColor(0xFFFFFF), OptionalRgbColor(QColor::fromRgba(0xAAFFFFFF)));
-}
-
-TEST(OptionalRgbColorTest, ToQColor) {
-    EXPECT_EQ(QColor(), OptionalRgbColor().toQColor());
+TEST(RgbColorTest, OptionalRgbColorToQColor) {
+    EXPECT_EQ(QColor(), toQColor(RgbColor::nullopt()));
     EXPECT_EQ(QColor::fromRgba(0xAABBCCDD),
-            OptionalRgbColor().toQColor(QColor::fromRgba(0xAABBCCDD)));
+            toQColor(RgbColor::nullopt(), QColor::fromRgba(0xAABBCCDD)));
     EXPECT_EQ(QColor::fromRgb(0x123456),
-            OptionalRgbColor(QColor::fromRgba(0xAA123456)).toQColor(QColor::fromRgba(0xAABBCCDD)));
+            toQColor(RgbColor::optional(QColor::fromRgba(0xAA123456))));
+    EXPECT_EQ(QColor::fromRgb(0x123456),
+            toQColor(RgbColor::optional(QColor::fromRgba(0xAA123456)), QColor::fromRgba(0xAABBCCDD)));
 }
 
 } // namespace mixxx

--- a/src/test/rgbcolor_test.cpp
+++ b/src/test/rgbcolor_test.cpp
@@ -37,6 +37,10 @@ TEST(RgbColorTest, OptionalRgbColorFromQColorWithAlpha) {
     EXPECT_EQ(RgbColor::optional(0xFFFFFF), RgbColor::optional(QColor::fromRgba(0xAAFFFFFF)));
 }
 
+TEST(RgbColorTest,RgbColorToQColor) {
+    EXPECT_EQ(QColor::fromRgb(0x123456), toQColor(RgbColor(0x123456)));
+}
+
 TEST(RgbColorTest, OptionalRgbColorToQColor) {
     EXPECT_EQ(QColor(), toQColor(RgbColor::nullopt()));
     EXPECT_EQ(QColor::fromRgba(0xAABBCCDD),
@@ -45,6 +49,17 @@ TEST(RgbColorTest, OptionalRgbColorToQColor) {
             toQColor(RgbColor::optional(QColor::fromRgba(0xAA123456))));
     EXPECT_EQ(QColor::fromRgb(0x123456),
             toQColor(RgbColor::optional(QColor::fromRgba(0xAA123456)), QColor::fromRgba(0xAABBCCDD)));
+}
+
+TEST(RgbColorTest, RgbColorToQVariant) {
+    EXPECT_EQ(QVariant(), toQVariant(RgbColor::nullopt()));
+    EXPECT_EQ(QVariant(0x123456), toQVariant(RgbColor(0x123456)));
+}
+
+TEST(RgbColorTest, OptionalRgbColorToQVariant) {
+    EXPECT_EQ(QVariant(), toQVariant(RgbColor::nullopt()));
+    EXPECT_EQ(QVariant(0x123456),
+            toQVariant(RgbColor::optional(QColor::fromRgba(0xAA123456))));
 }
 
 } // namespace mixxx

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -16,6 +16,7 @@ typedef quint32 RgbColorCode;
 
 // Type-safe wrapper around RgbColorCode without implicit
 // range checks and no implicit validation.
+// Apart from the assignment operator this type is immutable.
 class RgbColor {
   public:
     // The default constructor is not available, because there is
@@ -46,7 +47,7 @@ class RgbColor {
 
   protected:
     // Bitmask of valid codes = 0x00RRGGBB
-    static const RgbColorCode kRgbCodeMask = 0x00FFFFFF;
+    static constexpr RgbColorCode kRgbCodeMask = 0x00FFFFFF;
 
     static RgbColorCode validateCode(RgbColorCode code) {
         return code & kRgbCodeMask;
@@ -140,7 +141,7 @@ class OptionalRgbColor final : public RgbColor {
     }
 
   private:
-    static const RgbColorCode kUndefinedInternalCode = 0xFFFFFFFF;
+    static constexpr RgbColorCode kUndefinedInternalCode = 0xFFFFFFFF;
 
     static RgbColorCode codeToInternalCode(RgbColorCode code) {
         // The unused bits of an RgbColorCode should never be set.

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -40,7 +40,7 @@ class RgbColor {
     }
 
     // Check if the color is defined.
-    constexpr operator bool() const noexcept {
+    operator bool() const noexcept {
         return m_internalCode != kUndefinedInternalCode;
     }
 

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -17,6 +17,7 @@ typedef quint32 RgbColorCode;
 // to opaque for valid RGB colors and that invalid colors
 // are always represented by the same, well defined QColor,
 // namely QColor().
+// Apart from assignment this type is immutable.
 class RgbColor {
   public:
     RgbColor() {

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QColor>
+#include <QVariant>
 #include <QtDebug>
 #include <QtGlobal>
 
@@ -70,6 +71,19 @@ class RgbColor {
             return nullopt();
         }
     }
+    static optional_t optional(const QVariant& varCode) {
+        if (varCode.isNull()) {
+            return nullopt();
+        } else {
+            DEBUG_ASSERT(varCode.canConvert(QMetaType::UInt));
+            bool ok = false;
+            const auto code = varCode.toUInt(&ok);
+            VERIFY_OR_DEBUG_ASSERT(ok) {
+                return nullopt();
+            }
+            return optional(static_cast<code_t>(code));
+        }
+    }
 
   protected:
     // Bitmask of valid codes = 0x00RRGGBB
@@ -105,6 +119,23 @@ QColor toQColor(RgbColor::optional_t optional, QColor defaultColor = QColor()) {
         return toQColor(*optional);
     } else {
         return defaultColor;
+    }
+}
+
+// Explicit conversion of both non-optional and optional
+// RgbColor values to QVariant as overloaded free functions.
+
+inline
+QVariant toQVariant(RgbColor color) {
+    return QVariant(static_cast<RgbColor::code_t>(color));
+}
+
+inline
+QVariant toQVariant(RgbColor::optional_t optional) {
+    if (optional) {
+        return toQVariant(*optional);
+    } else {
+        return QVariant();
     }
 }
 

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -23,7 +23,10 @@ class RgbColor {
     RgbColor() {
         DEBUG_ASSERT(!isValid());
     }
-    // Implicit conversion constructors without normalization!
+    // Implicit conversion constructors without normalization.
+    // Only use these conversion constructors if the argument
+    // matches an RgbColor! Otherwise a debug assertion will
+    // be triggered.
     /*non-explicit*/ RgbColor(RgbColorCode code)
             : m_color(toQColor(code)) {
         DEBUG_ASSERT(m_color == normalizeQColor(m_color));
@@ -33,11 +36,15 @@ class RgbColor {
         DEBUG_ASSERT(m_color == normalizeQColor(m_color));
     }
 
+    // Check that the provided color code is valid.
     static bool isValidCode(RgbColorCode code) {
         return code == (code & kRgbCodeMask);
     }
 
-    // Explicit conversions with normalization
+    // Explicit conversions with normalization.
+    // Use these static functions instead of the conversion
+    // constructors to ensure that the resulting RgbColor is
+    // well defined.
     static RgbColor fromCode(RgbColorCode code) {
         return RgbColor(normalizeCode(code));
     }
@@ -45,19 +52,28 @@ class RgbColor {
         return RgbColor(normalizeQColor(color));
     }
 
+    // Implicit conversion into the corresponding QColor.
     operator QColor() const {
         return m_color;
     }
 
+    // Checks if the color is valid or represents "no color",
+    // i.e. is missing or undefined. If the corresponding color
+    // code is stored in a database then the colum value is NULL.
     bool isValid() const {
         return m_color.isValid();
     }
 
+    // Returns the corresponding RGB color code of a valid color.
+    // Validity is a prerequisite and only checked by a debug
+    // assertion.
     RgbColorCode code() const {
         DEBUG_ASSERT(isValid());
         return toCode(m_color);
     }
 
+    // Returns the corresponding RGB color code of a valid color
+    // or the provided color code if the color is not valid.
     RgbColorCode codeOr(RgbColorCode codeIfNotValid) const {
         if (isValid()) {
             return code();

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -8,8 +8,8 @@
 
 namespace mixxx {
 
-// Type-safe wrapper around code_t without implicit
-// range checks and no implicit validation.
+// Type-safe wrapper for 24-bit RGB color codes without an alpha
+// channel. Code values are implicitly validated upon construction.
 //
 // Apart from the assignment operator this type is immutable.
 class RgbColor {

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -108,13 +108,11 @@ inline bool operator!=(RgbColor lhs, RgbColor rhs) {
 // Explicit conversion of both non-optional and optional
 // RgbColor values to QColor as overloaded free functions.
 
-inline
-QColor toQColor(RgbColor color) {
+inline QColor toQColor(RgbColor color) {
     return QColor::fromRgb(color);
 }
 
-inline
-QColor toQColor(RgbColor::optional_t optional, QColor defaultColor = QColor()) {
+inline QColor toQColor(RgbColor::optional_t optional, QColor defaultColor = QColor()) {
     if (optional) {
         return toQColor(*optional);
     } else {
@@ -125,13 +123,11 @@ QColor toQColor(RgbColor::optional_t optional, QColor defaultColor = QColor()) {
 // Explicit conversion of both non-optional and optional
 // RgbColor values to QVariant as overloaded free functions.
 
-inline
-QVariant toQVariant(RgbColor color) {
+inline QVariant toQVariant(RgbColor color) {
     return QVariant(static_cast<RgbColor::code_t>(color));
 }
 
-inline
-QVariant toQVariant(RgbColor::optional_t optional) {
+inline QVariant toQVariant(RgbColor::optional_t optional) {
     if (optional) {
         return toQVariant(*optional);
     } else {
@@ -141,13 +137,11 @@ QVariant toQVariant(RgbColor::optional_t optional) {
 
 // Debug output stream operators
 
-inline
-QDebug operator<<(QDebug dbg, RgbColor color) {
+inline QDebug operator<<(QDebug dbg, RgbColor color) {
     return dbg << toQColor(color);
 }
 
-inline
-QDebug operator<<(QDebug dbg, RgbColor::optional_t optional) {
+inline QDebug operator<<(QDebug dbg, RgbColor::optional_t optional) {
     return dbg << toQColor(optional);
 }
 

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -110,5 +110,5 @@ inline bool operator!=(const RgbColor& lhs, const RgbColor& rhs) {
 
 } // namespace mixxx
 
-Q_DECLARE_TYPEINFO(mixxx::RgbColor, Q_MOVABLE_TYPE);
+Q_DECLARE_TYPEINFO(mixxx::RgbColor, Q_PRIMITIVE_TYPE);
 Q_DECLARE_METATYPE(mixxx::RgbColor)

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -42,7 +42,7 @@ class RgbColor {
 
     // Implicit conversion to a color code.
     operator RgbColorCode() const {
-        return validateCode(m_code);
+        return m_code;
     }
 
     friend bool operator==(RgbColor lhs, RgbColor rhs) {

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -24,7 +24,7 @@ class RgbColor {
     static constexpr code_t validateCode(code_t code) {
         return code & kRgbCodeMask;
     }
-    static constexpr bool isValidCode(code_t code) {
+    static bool isValidCode(code_t code) {
         return code == validateCode(code);
     }
 
@@ -34,12 +34,10 @@ class RgbColor {
     // Explicit conversion from code_t with implicit validation.
     explicit constexpr RgbColor(code_t code)
             : m_code(validateCode(code)) {
-        DEBUG_ASSERT(isValidCode(m_code));
     }
     // Explicit conversion from QColor.
     RgbColor(QColor anyColor, code_t codeIfInvalid)
             : m_code(anyColorToCode(anyColor, codeIfInvalid)) {
-        DEBUG_ASSERT(isValidCode(m_code));
     }
 
     // Implicit conversion to a color code.

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -15,8 +15,16 @@ namespace mixxx {
 typedef quint32 RgbColorCode;
 
 // A thin wrapper around 24-bit opaque RGB values that includes
-// an undefined state. The undefined state could be used to
-// represent missing or transparent values.
+// a single undefined state. The undefined state could be used
+// to represent missing or transparent values.
+// This class might be used as a "hub" for the conversion between
+// RgbColorCode, std::optional<RgbColorCode>, and QColor. For
+// this particulare use case it's only purpose is to store an
+// intermediate representation before the internal value that
+// has been converted from the source type is finally converted
+// into the desired target type.
+// std::optional<RgbColorCode> is equivalent, RgbColorCode is
+// less versatile, and QColor is more versatile.
 // Apart from the assignment operator this type is immutable.
 class RgbColor {
   public:

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -8,18 +8,15 @@
 
 namespace mixxx {
 
-// A pure 24-bit 0xxRRGGBB color code without an alpha channel.
+// A pure 24-bit 0xxRRGGBB color code with 8-bit per channel
+// without an an alpha channel.
 // We are using a separate typedef, because QRgb implicitly
 // includes an alpha channel whereas this type does not!
 typedef quint32 RgbColorCode;
 
-// A thin wrapper around QColor to represent optional,
-// opaque RGB colors with 8-bit per channel without an
-// alpha channel. It ensures that the alpha channel is set
-// to opaque for valid RGB colors and that invalid colors
-// are always represented by the same, well defined QColor,
-// namely QColor().
-// Apart from assignment this type is immutable.
+// A thin wrapper around 24-bit opaque RGB values that includes
+// an optional state.
+// Apart from the assignment operator this type is immutable.
 class RgbColor {
   public:
     RgbColor()

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -3,9 +3,8 @@
 #include <QColor>
 #include <QtGlobal>
 
-#include <optional>
-
 #include "util/assert.h"
+#include "util/optional.h"
 
 namespace mixxx {
 
@@ -33,7 +32,7 @@ class RgbColor {
     }
     /*non-explicit*/ RgbColor(std::optional<RgbColorCode> optionalCode)
             : m_internalCode(optionalCodeToInternalCode(optionalCode)) {
-        DEBUG_ASSERT(isValid() == optionalCode.has_value());
+        DEBUG_ASSERT(isValid() == static_cast<bool>(optionalCode));
     }
     /*non-explicit*/ RgbColor(QColor anyColor)
             : m_internalCode(anyColorToInternalCode(anyColor)) {
@@ -70,8 +69,8 @@ class RgbColor {
         return code & kRgbCodeMask;
     }
     static RgbColorCode optionalCodeToInternalCode(std::optional<RgbColorCode> optionalCode) {
-        if (optionalCode.has_value()) {
-            return codeToInternalCode(optionalCode.value());
+        if (optionalCode) {
+            return codeToInternalCode(*optionalCode);
         } else {
             return kInvalidInternalCode;
         }

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <QColor>
+
+#include "util/assert.h"
+
+namespace mixxx {
+
+// A pure 24-bit 0xxRRGGBB color code without an alpha channel
+typedef quint32 RgbColorCode;
+
+// A thin wrapper around QColor to represent optional,
+// opaque RGB colors with 8-bit per channel without an
+// alpha channel. It ensures that the alpha channel is set
+// to opaque for valid RGB colors and that invalid colors
+// are always represented by the same, well defined QColor,
+// namely QColor().
+class RgbColor {
+  public:
+    RgbColor() {
+        DEBUG_ASSERT(!isValid());
+    }
+    // Implicit conversion constructors without normalization!
+    /*non-explicit*/ RgbColor(RgbColorCode code)
+            : m_color(toQColor(code)) {
+        DEBUG_ASSERT(m_color == normalizeQColor(m_color));
+    }
+    /*non-explicit*/ RgbColor(QColor color)
+            : m_color(color) {
+        DEBUG_ASSERT(m_color == normalizeQColor(m_color));
+    }
+
+    static bool isValidCode(RgbColorCode code) {
+        return code == (code & kRgbCodeMask);
+    }
+
+    // Explicit conversions with normalization
+    static RgbColor fromCode(RgbColorCode code) {
+        return RgbColor(normalizeCode(code));
+    }
+    static RgbColor fromQColor(QColor color) {
+        return RgbColor(normalizeQColor(color));
+    }
+
+    operator QColor() const {
+        return m_color;
+    }
+
+    bool isValid() const {
+        return m_color.isValid();
+    }
+
+    RgbColorCode code() const {
+        DEBUG_ASSERT(isValid());
+        return toCode(m_color);
+    }
+
+    RgbColorCode codeOr(RgbColorCode codeIfNotValid) const {
+        if (isValid()) {
+            return code();
+        } else {
+            return codeIfNotValid;
+        }
+    }
+
+  private:
+    static const RgbColorCode kRgbCodeMask = 0x00FFFFFF;
+    static const RgbColorCode kAlphaCodeMask = 0xFF000000;
+
+    static QColor toQColor(RgbColorCode code) {
+        DEBUG_ASSERT(isValidCode(code));
+        return QColor(code | kAlphaCodeMask);
+    }
+    static RgbColorCode normalizeCode(RgbColorCode code) {
+        return code & kRgbCodeMask;
+    }
+    static QColor normalizeQColor(QColor color) {
+        if (color.isValid()) {
+            return toQColor(toCode(color));
+        } else {
+            return QColor();
+        }
+    }
+    static RgbColorCode toCode(QColor color) {
+        DEBUG_ASSERT(color.isValid());
+        return normalizeCode(color.rgb());
+    }
+
+    QColor m_color;
+};
+
+} // namespace mixxx

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -21,31 +21,29 @@ class RgbColor {
   public:
     RgbColor()
             : m_internalCode(kInvalidInternalCode) {
-        DEBUG_ASSERT(!isValid());
+        DEBUG_ASSERT(!*this);
     }
     /*non-explicit*/ RgbColor(RgbColorCode code)
             : m_internalCode(codeToInternalCode(code)) {
-        DEBUG_ASSERT(isValid());
+        DEBUG_ASSERT(*this);
     }
     /*non-explicit*/ RgbColor(std::optional<RgbColorCode> optionalCode)
             : m_internalCode(optionalCodeToInternalCode(optionalCode)) {
-        DEBUG_ASSERT(isValid() == static_cast<bool>(optionalCode));
+        DEBUG_ASSERT(*this == static_cast<bool>(optionalCode));
     }
     /*non-explicit*/ RgbColor(QColor anyColor)
             : m_internalCode(anyColorToInternalCode(anyColor)) {
-        DEBUG_ASSERT(isValid() == anyColor.isValid());
-    }
-
-    // Implicit conversion into the corresponding QColor.
-    operator QColor() const {
-        return internalCodeToColor(m_internalCode);
+        DEBUG_ASSERT(*this == anyColor.isValid());
     }
 
     // Checks if the color is valid or represents "no color",
-    // i.e. is missing or undefined. If the corresponding color
-    // code is stored in a database then the colum value is NULL.
-    bool isValid() const {
-        return m_internalCode == (m_internalCode & kRgbCodeMask);
+    // i.e. is missing or undefined.
+    constexpr operator bool() const noexcept {
+        return m_internalCode == kInvalidInternalCode;
+    }
+
+    friend bool operator==(const RgbColor& lhs, const RgbColor& rhs) {
+        return lhs.m_internalCode == rhs.m_internalCode;
     }
 
     // Returns the corresponding, optional RGB color code.
@@ -53,8 +51,9 @@ class RgbColor {
         return internalCodeToOptionalCode(m_internalCode);
     }
 
-    friend bool operator==(const RgbColor& lhs, const RgbColor& rhs) {
-        return lhs.m_internalCode == rhs.m_internalCode;
+    // Implicit conversion into the corresponding QColor.
+    operator QColor() const {
+        return internalCodeToColor(m_internalCode);
     }
 
   private:
@@ -83,16 +82,20 @@ class RgbColor {
 
     std::optional<RgbColorCode> internalCodeToOptionalCode(RgbColorCode internalCode) const {
         if (internalCode == (internalCode & kRgbCodeMask)) {
+            DEBUG_ASSERT(*this);
             return std::make_optional(m_internalCode);
         } else {
+            DEBUG_ASSERT(!*this);
             return std::nullopt;
         }
     }
 
     QColor internalCodeToColor(RgbColorCode internalCode) const {
         if (internalCode == (internalCode & kRgbCodeMask)) {
+            DEBUG_ASSERT(*this);
             return QRgb(m_internalCode | kAlphaCodeMask);
         } else {
+            DEBUG_ASSERT(!*this);
             return QColor();
         }
     }

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QColor>
+#include <QtDebug>
 #include <QtGlobal>
 
 #include "util/assert.h"
@@ -101,12 +102,24 @@ QColor toQColor(RgbColor color) {
 }
 
 inline
-QColor toQColor(std::optional<RgbColor> optional, QColor defaultColor = QColor()) {
+QColor toQColor(RgbColor::optional_t optional, QColor defaultColor = QColor()) {
     if (optional) {
         return toQColor(*optional);
     } else {
         return defaultColor;
     }
+}
+
+// Debug output stream operators
+
+inline
+QDebug operator<<(QDebug dbg, RgbColor color) {
+    return dbg << toQColor(color);
+}
+
+inline
+QDebug operator<<(QDebug dbg, RgbColor::optional_t optional) {
+    return dbg << toQColor(optional);
 }
 
 } // namespace mixxx

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -16,6 +16,7 @@ typedef quint32 RgbColorCode;
 
 // Type-safe wrapper around RgbColorCode without implicit
 // range checks and no implicit validation.
+//
 // Apart from the assignment operator this type is immutable.
 class RgbColor {
   public:
@@ -75,14 +76,19 @@ inline bool operator!=(RgbColor lhs, RgbColor rhs) {
 // A thin wrapper around 24-bit opaque RGB values that includes
 // a single undefined state. The undefined state could be used
 // to represent missing or transparent values.
+//
 // This class might be used as a "hub" for the conversion between
 // RgbColorCode, std::optional<RgbColorCode>, and QColor. For
-// this particulare use case it's only purpose is to store an
+// this particular use case its only purpose is to store an
 // intermediate representation before the internal value that
 // has been converted from the source type is finally converted
 // into the desired target type.
-// std::optional<RgbColorCode> is equivalent, RgbColorCode is
-// less versatile, and QColor is more versatile.
+//
+// Type comparison
+// - RgbColorCode is less versatile
+// - std::optional<RgbColorCode> is equivalent
+// - QColor is more versatile
+//
 // Apart from the assignment operator this type is immutable.
 class OptionalRgbColor final : public RgbColor {
   public:

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QColor>
+#include <QtGlobal>
 
 #include <optional>
 
@@ -42,7 +43,7 @@ class RgbColor {
         DEBUG_ASSERT(m_color == normalizeAnyColor(m_color));
     }
     // Explicit conversion from any QColor with implicit
-    // normalization that results in a well define RgbColor.
+    // normalization that results in a well defined RgbColor.
     // Use this static function instead of the conversion
     // constructor to ensure that the resulting RgbColor is
     // well defined when converting from some QColor.
@@ -114,3 +115,6 @@ inline bool operator!=(const RgbColor& lhs, const RgbColor& rhs) {
 }
 
 } // namespace mixxx
+
+Q_DECLARE_TYPEINFO(mixxx::RgbColor, Q_MOVABLE_TYPE);
+Q_DECLARE_METATYPE(mixxx::RgbColor)

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -31,6 +31,8 @@ class RgbColor {
     // no common default value that fits all possible use cases!
     RgbColor() = delete;
     // Explicit conversion from a valid code_t.
+    // No implicit validation to allow declaring this constructor
+    // as constexpr.
     explicit constexpr RgbColor(code_t code)
             : m_code(code) {
         DEBUG_ASSERT(isValidCode(m_code));

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -38,6 +38,7 @@ class RgbColor {
     // Explicit conversion from QColor.
     RgbColor(QColor anyColor, RgbColorCode codeIfInvalid)
             : m_code(anyColorToCode(anyColor, codeIfInvalid)) {
+        DEBUG_ASSERT(isValidCode(m_code));
     }
 
     // Implicit conversion to a color code.

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -6,7 +6,9 @@
 
 namespace mixxx {
 
-// A pure 24-bit 0xxRRGGBB color code without an alpha channel
+// A pure 24-bit 0xxRRGGBB color code without an alpha channel.
+// We are using a separate typedef, because QRgb implicitly
+// includes an alpha channel whereas this type does not!
 typedef quint32 RgbColorCode;
 
 // A thin wrapper around QColor to represent optional,

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -42,7 +42,7 @@ class RgbColor {
     }
 
     // Implicit conversion to a color code.
-    operator code_t() const {
+    constexpr operator code_t() const {
         return m_code;
     }
 

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -20,21 +20,19 @@ class RgbColor {
     // includes an alpha channel whereas this type does not!
     typedef quint32 code_t;
 
-    static code_t validateCode(code_t code) {
+    static constexpr code_t validateCode(code_t code) {
         return code & kRgbCodeMask;
     }
-    static bool isValidCode(code_t code) {
+    static constexpr bool isValidCode(code_t code) {
         return code == validateCode(code);
     }
 
     // The default constructor is not available, because there is
     // no common default value that fits all possible use cases!
     RgbColor() = delete;
-    // Explicit conversion from a valid code_t.
-    // No implicit validation to allow declaring this constructor
-    // as constexpr.
+    // Explicit conversion from code_t with implicit validation.
     explicit constexpr RgbColor(code_t code)
-            : m_code(code) {
+            : m_code(validateCode(code)) {
         DEBUG_ASSERT(isValidCode(m_code));
     }
     // Explicit conversion from QColor.

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -8,41 +8,41 @@
 
 namespace mixxx {
 
-// A pure 24-bit 0xxRRGGBB color code with 8-bit per channel
-// without an an alpha channel.
-// We are using a separate typedef, because QRgb implicitly
-// includes an alpha channel whereas this type does not!
-typedef quint32 RgbColorCode;
-
-// Type-safe wrapper around RgbColorCode without implicit
+// Type-safe wrapper around code_t without implicit
 // range checks and no implicit validation.
 //
 // Apart from the assignment operator this type is immutable.
 class RgbColor {
   public:
-    static RgbColorCode validateCode(RgbColorCode code) {
+    // A pure 24-bit 0xxRRGGBB color code with 8-bit per channel
+    // without an an alpha channel.
+    // We are using a separate typedef, because QRgb implicitly
+    // includes an alpha channel whereas this type does not!
+    typedef quint32 code_t;
+
+    static code_t validateCode(code_t code) {
         return code & kRgbCodeMask;
     }
-    static bool isValidCode(RgbColorCode code) {
+    static bool isValidCode(code_t code) {
         return code == validateCode(code);
     }
 
     // The default constructor is not available, because there is
     // no common default value that fits all possible use cases!
     RgbColor() = delete;
-    // Explicit conversion from a valid RgbColorCode.
-    explicit constexpr RgbColor(RgbColorCode code)
+    // Explicit conversion from a valid code_t.
+    explicit constexpr RgbColor(code_t code)
             : m_code(code) {
         DEBUG_ASSERT(isValidCode(m_code));
     }
     // Explicit conversion from QColor.
-    RgbColor(QColor anyColor, RgbColorCode codeIfInvalid)
+    RgbColor(QColor anyColor, code_t codeIfInvalid)
             : m_code(anyColorToCode(anyColor, codeIfInvalid)) {
         DEBUG_ASSERT(isValidCode(m_code));
     }
 
     // Implicit conversion to a color code.
-    operator RgbColorCode() const {
+    operator code_t() const {
         return m_code;
     }
 
@@ -51,17 +51,18 @@ class RgbColor {
     }
 
     typedef std::optional<RgbColor> optional_t;
+
     static constexpr optional_t nullopt() {
         return std::nullopt;
     }
 
     // Overloaded conversion functions for conveniently creating
     // std::optional<RgbColor>.
+    static constexpr optional_t optional(code_t code) {
+        return optional(RgbColor(code));
+    }
     static constexpr optional_t optional(RgbColor color) {
         return std::make_optional(color);
-    }
-    static constexpr optional_t optional(RgbColorCode colorCode) {
-        return optional(RgbColor(colorCode));
     }
     static optional_t optional(QColor color) {
         if (color.isValid()) {
@@ -73,9 +74,9 @@ class RgbColor {
 
   protected:
     // Bitmask of valid codes = 0x00RRGGBB
-    static constexpr RgbColorCode kRgbCodeMask = 0x00FFFFFF;
+    static constexpr code_t kRgbCodeMask = 0x00FFFFFF;
 
-    static RgbColorCode anyColorToCode(QColor anyColor, RgbColorCode codeIfInvalid) {
+    static code_t anyColorToCode(QColor anyColor, code_t codeIfInvalid) {
         if (anyColor.isValid()) {
             // Strip alpha channel bits!
             return validateCode(anyColor.rgb());
@@ -84,7 +85,7 @@ class RgbColor {
         }
     }
 
-    RgbColorCode m_code;
+    code_t m_code;
 };
 
 inline bool operator!=(RgbColor lhs, RgbColor rhs) {

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -170,5 +170,8 @@ class OptionalRgbColor final : public RgbColor {
 
 } // namespace mixxx
 
+Q_DECLARE_TYPEINFO(std::optional<mixxx::RgbColor>, Q_PRIMITIVE_TYPE);
+Q_DECLARE_METATYPE(std::optional<mixxx::RgbColor>)
+
 Q_DECLARE_TYPEINFO(mixxx::OptionalRgbColor, Q_PRIMITIVE_TYPE);
 Q_DECLARE_METATYPE(mixxx::OptionalRgbColor)

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -63,6 +63,10 @@ class RgbColor {
         }
     }
 
+    friend bool operator==(const RgbColor& lhs, const RgbColor& rhs) {
+        return lhs.m_color == rhs.m_color;
+    }
+
   private:
     static const RgbColorCode kRgbCodeMask = 0x00FFFFFF;
     static const RgbColorCode kAlphaCodeMask = 0xFF000000;
@@ -88,5 +92,9 @@ class RgbColor {
 
     QColor m_color;
 };
+
+inline bool operator!=(const RgbColor& lhs, const RgbColor& rhs) {
+    return !(lhs == rhs);
+}
 
 } // namespace mixxx

--- a/src/util/optional.h
+++ b/src/util/optional.h
@@ -11,9 +11,9 @@
 
 namespace std {
 
-using std::experimental::optional;
 using std::experimental::make_optional;
 using std::experimental::nullopt;
+using std::experimental::optional;
 
 // Workarounds for missing member functions:
 // option::has_value() -> explicit operator bool()

--- a/src/util/optional.h
+++ b/src/util/optional.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#if __has_include(<optional>) || \
+    (defined(__cpp_lib_optional) && __cpp_lib_optional >= 201606L)
+
+#include <optional>
+
+#else
+
+#include <experimental/optional>
+
+namespace std {
+
+using std::experimental::optional;
+using std::experimental::make_optional;
+using std::experimental::nullopt;
+
+// Workarounds for missing member functions:
+// option::has_value() -> explicit operator bool()
+// option::value() -> operator*()
+
+} // namespace std
+
+#endif


### PR DESCRIPTION
QColor is too generic for representing opaque RGB colors with 8-bit per channel and a corresponding 24-bit color code. This new class handles all validation, normalization and conversion by wrapping QColor. It is more restrictive than QColor, but preserves the optional (= *invalid*) state.

This class could be used for all kinds of color metadata, both track colors (#2470) and cue colors. We might even think about making cue colors optional, because `QColor` is implicitly optional and we would need to handle it anyway! I should have noticed this before :see_no_evil: But my idea of such a wrapper class was rejected when I mentioned that we need such an abstraction and so I didn't dig deeper into the topic.

The unit tests revealed that the handling is trickier than expected and that directly dealing with `QColor` would be error prone.