### PR TITLE
[WIP] Add support for importing/exporting the SeratoMarkers2 tag

### DIFF
--- a/src/track/seratomarkers2.cpp
+++ b/src/track/seratomarkers2.cpp
@@ -4,8 +4,7 @@
 
 namespace mixxx {
 
-SeratoMarkers2EntryPointer SeratoMarkers2BpmlockEntry::parse(const QByteArray &data)
-{
+SeratoMarkers2EntryPointer SeratoMarkers2BpmlockEntry::parse(const QByteArray& data) {
     if (data.length() != 1) {
         qWarning() << "Parsing SeratoMarkers2BpmlockEntry failed:"
                    << "Length" << data.length() << "!= 1";
@@ -34,11 +33,10 @@ quint32 SeratoMarkers2BpmlockEntry::length() const {
     return 1;
 }
 
-SeratoMarkers2EntryPointer SeratoMarkers2ColorEntry::parse(const QByteArray &data)
-{
+SeratoMarkers2EntryPointer SeratoMarkers2ColorEntry::parse(const QByteArray& data) {
     if (data.length() != 4) {
         qWarning() << "Parsing SeratoMarkers2ColorEntry failed:"
-                 << "Length" << data.length() << "!= 4";
+                   << "Length" << data.length() << "!= 4";
         return nullptr;
     }
 
@@ -51,8 +49,8 @@ SeratoMarkers2EntryPointer SeratoMarkers2ColorEntry::parse(const QByteArray &dat
     }
 
     QColor color(static_cast<quint8>(data.at(1)),
-                 static_cast<quint8>(data.at(2)),
-                 static_cast<quint8>(data.at(3)));
+            static_cast<quint8>(data.at(2)),
+            static_cast<quint8>(data.at(3)));
 
     SeratoMarkers2ColorEntry* pEntry = new SeratoMarkers2ColorEntry(color);
     qDebug() << "SeratoMarkers2ColorEntry" << *pEntry;
@@ -78,8 +76,7 @@ quint32 SeratoMarkers2ColorEntry::length() const {
     return 4;
 }
 
-SeratoMarkers2EntryPointer SeratoMarkers2CueEntry::parse(const QByteArray &data)
-{
+SeratoMarkers2EntryPointer SeratoMarkers2CueEntry::parse(const QByteArray& data) {
     if (data.length() < 13) {
         qWarning() << "Parsing SeratoMarkers2CueEntry failed:"
                    << "Length" << data.length() << "< 13";
@@ -111,8 +108,8 @@ SeratoMarkers2EntryPointer SeratoMarkers2CueEntry::parse(const QByteArray &data)
     }
 
     QColor color(static_cast<quint8>(data.at(7)),
-                 static_cast<quint8>(data.at(8)),
-                 static_cast<quint8>(data.at(9)));
+            static_cast<quint8>(data.at(8)),
+            static_cast<quint8>(data.at(9)));
 
     // Unknown field(s), make sure it's 0 in case it's a
     // null-terminated string
@@ -169,8 +166,7 @@ quint32 SeratoMarkers2CueEntry::length() const {
     return 13 + m_label.toUtf8().length();
 }
 
-SeratoMarkers2EntryPointer SeratoMarkers2LoopEntry::parse(const QByteArray &data)
-{
+SeratoMarkers2EntryPointer SeratoMarkers2LoopEntry::parse(const QByteArray& data) {
     if (data.length() < 21) {
         qWarning() << "Parsing SeratoMarkers2LoopEntry failed:"
                    << "Length" << data.length() << "< 21";
@@ -197,13 +193,13 @@ SeratoMarkers2EntryPointer SeratoMarkers2LoopEntry::parse(const QByteArray &data
 #endif
     // Unknown field, make sure it contains the expected "default" value
     if (data.at(10) != '\xff' ||
-        data.at(11) != '\xff' ||
-        data.at(12) != '\xff' ||
-        data.at(13) != '\xff' ||
-        data.at(14) != '\x00' ||
-        data.at(15) != '\x27' ||
-        data.at(16) != '\xaa' ||
-        data.at(17) != '\xe1') {
+            data.at(11) != '\xff' ||
+            data.at(12) != '\xff' ||
+            data.at(13) != '\xff' ||
+            data.at(14) != '\x00' ||
+            data.at(15) != '\x27' ||
+            data.at(16) != '\xaa' ||
+            data.at(17) != '\xe1') {
         qWarning() << "Parsing SeratoMarkers2LoopEntry failed:"
                    << "Invalid magic value " << data.mid(10, 16);
         return nullptr;
@@ -285,7 +281,7 @@ bool SeratoMarkers2::parse(SeratoMarkers2* seratoMarkers2, const QByteArray& out
 
     int offset = 2;
     int entryTypeEndPos;
-    while((entryTypeEndPos = data.indexOf('\x00', offset)) >= 0) {
+    while ((entryTypeEndPos = data.indexOf('\x00', offset)) >= 0) {
         // Entry Name
         QString entryType(data.mid(offset, entryTypeEndPos - offset));
         offset = entryTypeEndPos + 1;
@@ -314,20 +310,20 @@ bool SeratoMarkers2::parse(SeratoMarkers2* seratoMarkers2, const QByteArray& out
 
         // Entry Content
         SeratoMarkers2EntryPointer pEntry;
-        if(entryType.compare("BPMLOCK") == 0) {
+        if (entryType.compare("BPMLOCK") == 0) {
             pEntry = SeratoMarkers2BpmlockEntry::parse(entryData);
-        } else if(entryType.compare("COLOR") == 0) {
+        } else if (entryType.compare("COLOR") == 0) {
             pEntry = SeratoMarkers2ColorEntry::parse(entryData);
-        } else if(entryType.compare("CUE") == 0) {
+        } else if (entryType.compare("CUE") == 0) {
             pEntry = SeratoMarkers2CueEntry::parse(entryData);
-        } else if(entryType.compare("LOOP") == 0) {
+        } else if (entryType.compare("LOOP") == 0) {
             pEntry = SeratoMarkers2LoopEntry::parse(entryData);
         } else {
             pEntry = SeratoMarkers2EntryPointer(new SeratoMarkers2UnknownEntry(entryType, entryData));
             qDebug() << "SeratoMarkers2UnknownEntry" << *pEntry;
         }
 
-        if(!pEntry) {
+        if (!pEntry) {
             qWarning() << "Parsing SeratoMarkers2 failed:"
                        << "Unable to parse entry of type " << entryType;
             return false;
@@ -359,7 +355,7 @@ QByteArray SeratoMarkers2::data() const {
     // Hence, we can split the data into blocks of 72 bytes * 3/4 = 54 bytes
     // and base64-encode them one at a time:
     int offset = 0;
-    while(offset < data.size()) {
+    while (offset < data.size()) {
         if (offset > 0) {
             outerData.append('\n');
         }

--- a/src/track/seratomarkers2.h
+++ b/src/track/seratomarkers2.h
@@ -8,6 +8,9 @@
 
 #include "util/types.h"
 
+// forward declaration(s)
+class Track;
+
 namespace mixxx {
 
 // Enum values need to appear in the same order as the corresponding entries
@@ -395,6 +398,9 @@ class SeratoMarkers2 final {
     void setEntries(QList<std::shared_ptr<SeratoMarkers2Entry>> entries) {
         m_entries = std::move(entries);
     }
+
+    void syncFromTrackObject(const Track* track);
+    void syncToTrackObject(Track* track) const;
 
   private:
     int m_allocatedSize;

--- a/src/track/seratomarkers2.h
+++ b/src/track/seratomarkers2.h
@@ -1,18 +1,17 @@
 #pragma once
 
-#include <memory>
-
-#include <QColor>
 #include <QByteArray>
+#include <QColor>
 #include <QDataStream>
 #include <QList>
+#include <memory>
 
 #include "util/types.h"
 
 namespace mixxx {
 
 class SeratoMarkers2Entry {
-public:
+  public:
     virtual ~SeratoMarkers2Entry() = default;
 
     virtual QString type() const = 0;
@@ -26,28 +25,25 @@ public:
 
 typedef std::shared_ptr<SeratoMarkers2Entry> SeratoMarkers2EntryPointer;
 
-inline
-bool operator==(const SeratoMarkers2Entry& lhs, const SeratoMarkers2Entry& rhs) {
+inline bool operator==(const SeratoMarkers2Entry& lhs, const SeratoMarkers2Entry& rhs) {
     return (lhs.type() == rhs.type()) && (lhs.data() == rhs.data());
 }
 
-inline
-bool operator!=(const SeratoMarkers2Entry& lhs, const SeratoMarkers2Entry& rhs) {
+inline bool operator!=(const SeratoMarkers2Entry& lhs, const SeratoMarkers2Entry& rhs) {
     return !(lhs == rhs);
 }
 
-inline
-QDebug operator<<(QDebug dbg, const SeratoMarkers2Entry& arg) {
+inline QDebug operator<<(QDebug dbg, const SeratoMarkers2Entry& arg) {
     return dbg << "type =" << arg.type()
                << "data =" << arg.data()
-               << "(" << "length =" << arg.length() << ")";
+               << "("
+               << "length =" << arg.length() << ")";
 }
 
 class SeratoMarkers2UnknownEntry : public SeratoMarkers2Entry {
-public:
+  public:
     SeratoMarkers2UnknownEntry(QString type, QByteArray data)
-        : m_type(std::move(type))
-        , m_data(std::move(data)) {
+            : m_type(std::move(type)), m_data(std::move(data)) {
     }
     ~SeratoMarkers2UnknownEntry() override = default;
 
@@ -59,22 +55,22 @@ public:
         return m_data;
     }
 
-private:
+  private:
     QString m_type;
     QByteArray m_data;
 };
 
 class SeratoMarkers2BpmlockEntry : public SeratoMarkers2Entry {
-public:
+  public:
     SeratoMarkers2BpmlockEntry(bool locked)
-        : m_locked(locked) {
+            : m_locked(locked) {
     }
 
     SeratoMarkers2BpmlockEntry()
-        : m_locked(false) {
+            : m_locked(false) {
     }
 
-    static SeratoMarkers2EntryPointer parse(const QByteArray &data);
+    static SeratoMarkers2EntryPointer parse(const QByteArray& data);
 
     QString type() const override {
         return "BPMLOCK";
@@ -82,7 +78,7 @@ public:
 
     QByteArray data() const override;
 
-    bool isLocked() const  {
+    bool isLocked() const {
         return m_locked;
     }
 
@@ -92,38 +88,35 @@ public:
 
     quint32 length() const override;
 
-private:
+  private:
     bool m_locked;
 };
 
-inline
-bool operator==(const SeratoMarkers2BpmlockEntry& lhs,
-                const SeratoMarkers2BpmlockEntry& rhs) {
+inline bool operator==(const SeratoMarkers2BpmlockEntry& lhs,
+        const SeratoMarkers2BpmlockEntry& rhs) {
     return (lhs.isLocked() == rhs.isLocked());
 }
 
-inline
-bool operator!=(const SeratoMarkers2BpmlockEntry& lhs,
-                const SeratoMarkers2BpmlockEntry& rhs) {
+inline bool operator!=(const SeratoMarkers2BpmlockEntry& lhs,
+        const SeratoMarkers2BpmlockEntry& rhs) {
     return !(lhs == rhs);
 }
 
-inline
-QDebug operator<<(QDebug dbg, const SeratoMarkers2BpmlockEntry& arg) {
+inline QDebug operator<<(QDebug dbg, const SeratoMarkers2BpmlockEntry& arg) {
     return dbg << "locked =" << arg.isLocked();
 }
 
 class SeratoMarkers2ColorEntry : public SeratoMarkers2Entry {
-public:
+  public:
     SeratoMarkers2ColorEntry(QColor color)
-        : m_color(color) {
+            : m_color(color) {
     }
 
     SeratoMarkers2ColorEntry()
-        : m_color(QColor()) {
+            : m_color(QColor()) {
     }
 
-    static SeratoMarkers2EntryPointer parse(const QByteArray &data);
+    static SeratoMarkers2EntryPointer parse(const QByteArray& data);
 
     QString type() const override {
         return "COLOR";
@@ -141,45 +134,35 @@ public:
 
     quint32 length() const override;
 
-private:
+  private:
     QColor m_color;
 };
 
-inline
-bool operator==(const SeratoMarkers2ColorEntry& lhs,
-                const SeratoMarkers2ColorEntry& rhs) {
+inline bool operator==(const SeratoMarkers2ColorEntry& lhs,
+        const SeratoMarkers2ColorEntry& rhs) {
     return (lhs.getColor() == rhs.getColor());
 }
 
-inline
-bool operator!=(const SeratoMarkers2ColorEntry& lhs,
-                const SeratoMarkers2ColorEntry& rhs) {
+inline bool operator!=(const SeratoMarkers2ColorEntry& lhs,
+        const SeratoMarkers2ColorEntry& rhs) {
     return !(lhs == rhs);
 }
 
-inline
-QDebug operator<<(QDebug dbg, const SeratoMarkers2ColorEntry& arg) {
+inline QDebug operator<<(QDebug dbg, const SeratoMarkers2ColorEntry& arg) {
     return dbg << "color =" << arg.getColor();
 }
 
 class SeratoMarkers2CueEntry : public SeratoMarkers2Entry {
-public:
-    SeratoMarkers2CueEntry(quint8 index, quint32 position, QColor color,
-            QString label)
-        : m_index(index)
-        , m_position(position)
-        , m_color(color)
-        , m_label(label) {
+  public:
+    SeratoMarkers2CueEntry(quint8 index, quint32 position, QColor color, QString label)
+            : m_index(index), m_position(position), m_color(color), m_label(label) {
     }
 
     SeratoMarkers2CueEntry()
-        : m_index(0)
-        , m_position(0)
-        , m_color(QColor())
-        , m_label(QString("")) {
+            : m_index(0), m_position(0), m_color(QColor()), m_label(QString("")) {
     }
 
-    static SeratoMarkers2EntryPointer parse(const QByteArray &data);
+    static SeratoMarkers2EntryPointer parse(const QByteArray& data);
 
     QString type() const override {
         return "CUE";
@@ -187,7 +170,7 @@ public:
 
     QByteArray data() const override;
 
-    quint8 getIndex() const  {
+    quint8 getIndex() const {
         return m_index;
     }
 
@@ -211,7 +194,7 @@ public:
         m_color = color;
     }
 
-    QString getLabel() const  {
+    QString getLabel() const {
         return m_label;
     }
 
@@ -221,30 +204,27 @@ public:
 
     quint32 length() const override;
 
-private:
+  private:
     quint8 m_index;
     quint32 m_position;
     QColor m_color;
     QString m_label;
 };
 
-inline
-bool operator==(const SeratoMarkers2CueEntry& lhs,
-                const SeratoMarkers2CueEntry& rhs) {
+inline bool operator==(const SeratoMarkers2CueEntry& lhs,
+        const SeratoMarkers2CueEntry& rhs) {
     return (lhs.getIndex() == rhs.getIndex()) &&
-           (lhs.getPosition() == rhs.getPosition()) &&
-           (lhs.getColor() == rhs.getColor()) &&
-           (lhs.getLabel() == rhs.getLabel());
+            (lhs.getPosition() == rhs.getPosition()) &&
+            (lhs.getColor() == rhs.getColor()) &&
+            (lhs.getLabel() == rhs.getLabel());
 }
 
-inline
-bool operator!=(const SeratoMarkers2CueEntry& lhs,
-                const SeratoMarkers2CueEntry& rhs) {
+inline bool operator!=(const SeratoMarkers2CueEntry& lhs,
+        const SeratoMarkers2CueEntry& rhs) {
     return !(lhs == rhs);
 }
 
-inline
-QDebug operator<<(QDebug dbg, const SeratoMarkers2CueEntry& arg) {
+inline QDebug operator<<(QDebug dbg, const SeratoMarkers2CueEntry& arg) {
     return dbg << "index =" << arg.getIndex() << "/"
                << "position =" << arg.getPosition() << "/"
                << "color =" << arg.getColor() << "/"
@@ -252,26 +232,16 @@ QDebug operator<<(QDebug dbg, const SeratoMarkers2CueEntry& arg) {
 }
 
 class SeratoMarkers2LoopEntry : public SeratoMarkers2Entry {
-public:
-    SeratoMarkers2LoopEntry(quint8 index, quint32 startposition,
-            quint32 endposition, bool locked,
-            QString label)
-        : m_index(index)
-        , m_startposition(startposition)
-        , m_endposition(endposition)
-        , m_locked(locked)
-        , m_label(label) {
+  public:
+    SeratoMarkers2LoopEntry(quint8 index, quint32 startposition, quint32 endposition, bool locked, QString label)
+            : m_index(index), m_startposition(startposition), m_endposition(endposition), m_locked(locked), m_label(label) {
     }
 
     SeratoMarkers2LoopEntry()
-        : m_index(0)
-        , m_startposition(0)
-        , m_endposition(0)
-        , m_locked(false)
-        , m_label(QString("")) {
+            : m_index(0), m_startposition(0), m_endposition(0), m_locked(false), m_label(QString("")) {
     }
 
-    static SeratoMarkers2EntryPointer parse(const QByteArray &data);
+    static SeratoMarkers2EntryPointer parse(const QByteArray& data);
 
     QString type() const override {
         return "LOOP";
@@ -279,7 +249,7 @@ public:
 
     QByteArray data() const override;
 
-    quint8 getIndex() const  {
+    quint8 getIndex() const {
         return m_index;
     }
 
@@ -311,7 +281,7 @@ public:
         m_locked = locked;
     }
 
-    QString getLabel() const  {
+    QString getLabel() const {
         return m_label;
     }
 
@@ -321,7 +291,7 @@ public:
 
     quint32 length() const override;
 
-private:
+  private:
     quint8 m_index;
     quint32 m_startposition;
     quint32 m_endposition;
@@ -329,24 +299,21 @@ private:
     QString m_label;
 };
 
-inline
-bool operator==(const SeratoMarkers2LoopEntry& lhs,
-                const SeratoMarkers2LoopEntry& rhs) {
+inline bool operator==(const SeratoMarkers2LoopEntry& lhs,
+        const SeratoMarkers2LoopEntry& rhs) {
     return (lhs.getIndex() == rhs.getIndex()) &&
-           (lhs.getStartPosition() == rhs.getStartPosition()) &&
-           (lhs.getEndPosition() == rhs.getEndPosition()) &&
-           (lhs.isLocked() == rhs.isLocked()) &&
-           (lhs.getLabel() == rhs.getLabel());
+            (lhs.getStartPosition() == rhs.getStartPosition()) &&
+            (lhs.getEndPosition() == rhs.getEndPosition()) &&
+            (lhs.isLocked() == rhs.isLocked()) &&
+            (lhs.getLabel() == rhs.getLabel());
 }
 
-inline
-bool operator!=(const SeratoMarkers2LoopEntry& lhs,
-                const SeratoMarkers2LoopEntry& rhs) {
+inline bool operator!=(const SeratoMarkers2LoopEntry& lhs,
+        const SeratoMarkers2LoopEntry& rhs) {
     return !(lhs == rhs);
 }
 
-inline
-QDebug operator<<(QDebug dbg, const SeratoMarkers2LoopEntry& arg) {
+inline QDebug operator<<(QDebug dbg, const SeratoMarkers2LoopEntry& arg) {
     return dbg << "index =" << arg.getIndex() << "/"
                << "startposition =" << arg.getStartPosition() << "/"
                << "endposition =" << arg.getEndPosition() << "/"
@@ -364,12 +331,11 @@ QDebug operator<<(QDebug dbg, const SeratoMarkers2LoopEntry& arg) {
 // https://github.com/Holzhaus/serato-tags/blob/master/docs/serato_markers2.md
 //
 class SeratoMarkers2 final {
-public:
+  public:
     SeratoMarkers2() = default;
     explicit SeratoMarkers2(
             QList<std::shared_ptr<SeratoMarkers2Entry>> entries)
-        : m_allocatedSize(0)
-        , m_entries(std::move(entries)) {
+            : m_allocatedSize(0), m_entries(std::move(entries)) {
     }
 
     // Parsing and formatting of gain values according to the
@@ -394,31 +360,29 @@ public:
     const QList<std::shared_ptr<SeratoMarkers2Entry>>& getEntries() const {
         return m_entries;
     }
+
     void setEntries(QList<std::shared_ptr<SeratoMarkers2Entry>> entries) {
         m_entries = std::move(entries);
     }
 
-private:
+  private:
     int m_allocatedSize;
     QList<std::shared_ptr<SeratoMarkers2Entry>> m_entries;
 };
 
-inline
-bool operator==(const SeratoMarkers2& lhs, const SeratoMarkers2& rhs) {
+inline bool operator==(const SeratoMarkers2& lhs, const SeratoMarkers2& rhs) {
     return (lhs.getEntries() == rhs.getEntries());
 }
 
-inline
-bool operator!=(const SeratoMarkers2& lhs, const SeratoMarkers2& rhs) {
+inline bool operator!=(const SeratoMarkers2& lhs, const SeratoMarkers2& rhs) {
     return !(lhs == rhs);
 }
 
-inline
-QDebug operator<<(QDebug dbg, const SeratoMarkers2& arg) {
+inline QDebug operator<<(QDebug dbg, const SeratoMarkers2& arg) {
     return dbg << "entries =" << arg.getEntries().length();
 }
 
-}
+} // namespace mixxx
 
 Q_DECLARE_TYPEINFO(mixxx::SeratoMarkers2, Q_MOVABLE_TYPE);
 Q_DECLARE_METATYPE(mixxx::SeratoMarkers2)

--- a/src/track/seratomarkers2.h
+++ b/src/track/seratomarkers2.h
@@ -10,11 +10,22 @@
 
 namespace mixxx {
 
+// Enum values need to appear in the same order as the corresponding entries
+// are written to the tag by Serato.
+enum class SeratoMarkers2EntryTypeId {
+    Unknown,
+    Color,
+    Cue,
+    Loop,
+    Bpmlock,
+};
+
 class SeratoMarkers2Entry {
   public:
     virtual ~SeratoMarkers2Entry() = default;
 
     virtual QString type() const = 0;
+    virtual SeratoMarkers2EntryTypeId typeId() const = 0;
 
     virtual QByteArray data() const = 0;
 
@@ -51,6 +62,10 @@ class SeratoMarkers2UnknownEntry : public SeratoMarkers2Entry {
         return m_type;
     }
 
+    SeratoMarkers2EntryTypeId typeId() const override {
+        return SeratoMarkers2EntryTypeId::Unknown;
+    }
+
     QByteArray data() const override {
         return m_data;
     }
@@ -74,6 +89,10 @@ class SeratoMarkers2BpmlockEntry : public SeratoMarkers2Entry {
 
     QString type() const override {
         return "BPMLOCK";
+    }
+
+    SeratoMarkers2EntryTypeId typeId() const override {
+        return SeratoMarkers2EntryTypeId::Bpmlock;
     }
 
     QByteArray data() const override;
@@ -122,6 +141,10 @@ class SeratoMarkers2ColorEntry : public SeratoMarkers2Entry {
         return "COLOR";
     }
 
+    SeratoMarkers2EntryTypeId typeId() const override {
+        return SeratoMarkers2EntryTypeId::Color;
+    }
+
     QByteArray data() const override;
 
     QColor getColor() const {
@@ -166,6 +189,10 @@ class SeratoMarkers2CueEntry : public SeratoMarkers2Entry {
 
     QString type() const override {
         return "CUE";
+    }
+
+    SeratoMarkers2EntryTypeId typeId() const override {
+        return SeratoMarkers2EntryTypeId::Cue;
     }
 
     QByteArray data() const override;
@@ -245,6 +272,10 @@ class SeratoMarkers2LoopEntry : public SeratoMarkers2Entry {
 
     QString type() const override {
         return "LOOP";
+    }
+
+    SeratoMarkers2EntryTypeId typeId() const override {
+        return SeratoMarkers2EntryTypeId::Loop;
     }
 
     QByteArray data() const override;

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -6,6 +6,8 @@
 #include "track/track.h"
 #include "track/trackref.h"
 #include "track/beatfactory.h"
+#include "track/seratomarkers2.h"
+#include "engine/engine.h"
 
 #include "util/assert.h"
 #include "util/logger.h"
@@ -128,6 +130,7 @@ void Track::importMetadata(
     const auto newBpm = importedMetadata.getTrackInfo().getBpm();
     const auto newKey = importedMetadata.getTrackInfo().getKey();
     const auto newReplayGain = importedMetadata.getTrackInfo().getReplayGain();
+    const auto newSeratoMarkers2 = importedMetadata.getTrackInfo().getSeratoMarkers2();
 
     {
         // enter locking scope
@@ -164,6 +167,13 @@ void Track::importMetadata(
     if (!newKey.isEmpty()
             && KeyUtils::guessKeyFromText(newKey) != mixxx::track::io::key::INVALID) {
         setKeyText(newKey, mixxx::track::io::key::FILE_METADATA);
+    }
+
+    {
+        // enter locking scope
+        QMutexLocker lock(&m_qMutex);
+        newSeratoMarkers2.syncToTrackObject(this);
+        // implicitly unlocked when leaving scope
     }
 }
 


### PR DESCRIPTION
This aims to implement reading/writing the `SeratoMarkers2` tag that Serato DJ Pro uses to store Track Color, Hotcues, Saved Loops, Flips and BPM-Lock state. Support for parsing/dumping the tag was added in #2323.

*NOTE:* This is a very early state, but I guess it's better to release code early to get some feedback. Also I don't know when I'll find enough time to finish this, so at least the current progress doesn't get lost. (@bungrudi Let me know if you want to take over here!)

**TO DO:**
- [ ] Find best location to call `syncFromTrackObject`
- [ ] Check precision of conversion between position in samples (mixxx) and position in milliseconds (Serato)
- [ ] ...
- [ ] Extensive Testing