### PR TITLE
engine/enginedeck: Don't stop playback if no passthru input is configured

### DIFF
--- a/src/engine/enginedeck.cpp
+++ b/src/engine/enginedeck.cpp
@@ -173,6 +173,6 @@ void EngineDeck::slotPassthroughChangeRequest(double v) {
     if (v <= 0 || m_pInputConfigured->get() > 0) {
         m_pPassing->setAndConfirm(v);
     } else {
-        emit(noPassthroughInputConfigured());
+        emit noPassthroughInputConfigured();
     }
 }

--- a/src/engine/enginedeck.cpp
+++ b/src/engine/enginedeck.cpp
@@ -44,6 +44,11 @@ EngineDeck::EngineDeck(const ChannelHandleAndGroup& handle_group,
     m_bPassthroughIsActive = false;
     m_bPassthroughWasActive = false;
 
+    // Ensure that input is configured before enabling passthrough
+    m_pPassing->connectValueChangeRequest(
+            this, SLOT(slotPassthroughChangeRequest(double)),
+            Qt::DirectConnection);
+
     // Set up passthrough toggle button
     connect(m_pPassing, SIGNAL(valueChanged(double)),
             this, SLOT(slotPassingToggle(double)),
@@ -162,4 +167,10 @@ bool EngineDeck::isPassthroughActive() const {
 
 void EngineDeck::slotPassingToggle(double v) {
     m_bPassthroughIsActive = v > 0;
+}
+
+void EngineDeck::slotPassthroughChangeRequest(double v) {
+    if (v <= 0 || m_pInputConfigured->get() > 0) {
+        m_pPassing->setAndConfirm(v);
+    }
 }

--- a/src/engine/enginedeck.cpp
+++ b/src/engine/enginedeck.cpp
@@ -172,5 +172,7 @@ void EngineDeck::slotPassingToggle(double v) {
 void EngineDeck::slotPassthroughChangeRequest(double v) {
     if (v <= 0 || m_pInputConfigured->get() > 0) {
         m_pPassing->setAndConfirm(v);
+    } else {
+        emit(noPassthroughInputConfigured());
     }
 }

--- a/src/engine/enginedeck.h
+++ b/src/engine/enginedeck.h
@@ -75,6 +75,7 @@ class EngineDeck : public EngineChannel, public AudioDestination {
 
   public slots:
     void slotPassingToggle(double v);
+    void slotPassthroughChangeRequest(double v);
 
   private:
     UserSettingsPointer m_pConfig;

--- a/src/engine/enginedeck.h
+++ b/src/engine/enginedeck.h
@@ -73,6 +73,9 @@ class EngineDeck : public EngineChannel, public AudioDestination {
     // Return whether or not passthrough is active
     bool isPassthroughActive() const;
 
+  signals:
+    void noPassthroughInputConfigured();
+
   public slots:
     void slotPassingToggle(double v);
     void slotPassthroughChangeRequest(double v);

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -45,8 +45,6 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(QObject* pParent,
             [this]{ emit(noPassthroughInputConfigured()); });
 
     m_pInputConfigured = std::make_unique<ControlProxy>(group, "input_configured", this);
-    m_pPassthroughEnabled = std::make_unique<ControlProxy>(group, "passthrough", this);
-    m_pPassthroughEnabled->connectValueChanged(SLOT(slotPassthroughEnabled(double)));
 #ifdef __VINYLCONTROL__
     m_pVinylControlEnabled = std::make_unique<ControlProxy>(group, "vinylcontrol_enabled", this);
     m_pVinylControlEnabled->connectValueChanged(SLOT(slotVinylControlEnabled(double)));
@@ -408,18 +406,6 @@ void BaseTrackPlayerImpl::setupEqControls() {
     m_pHighFilterKill = std::make_unique<ControlProxy>(group, "filterHighKill", this);
     m_pRateSlider = std::make_unique<ControlProxy>(group, "rate", this);
     m_pPitchAdjust = std::make_unique<ControlProxy>(group, "pitch_adjust", this);
-}
-
-void BaseTrackPlayerImpl::slotPassthroughEnabled(double v) {
-    bool configured = m_pInputConfigured->toBool();
-    bool passthrough = v > 0.0;
-
-    // Warn the user if they try to enable passthrough on a player with no
-    // configured input.
-    if (!configured && passthrough) {
-        m_pPassthroughEnabled->set(0.0);
-        emit(noPassthroughInputConfigured());
-    }
 }
 
 void BaseTrackPlayerImpl::slotVinylControlEnabled(double v) {

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -41,6 +41,8 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(QObject* pParent,
             pMixingEngine->registerChannelGroup(group);
     m_pChannel = new EngineDeck(channelGroup, pConfig, pMixingEngine,
                                 pEffectsManager, defaultOrientation);
+    connect(m_pChannel, &EngineDeck::noPassthroughInputConfigured,
+            [this]{ emit(noPassthroughInputConfigured()); });
 
     m_pInputConfigured = std::make_unique<ControlProxy>(group, "input_configured", this);
     m_pPassthroughEnabled = std::make_unique<ControlProxy>(group, "passthrough", this);

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -41,8 +41,6 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(QObject* pParent,
             pMixingEngine->registerChannelGroup(group);
     m_pChannel = new EngineDeck(channelGroup, pConfig, pMixingEngine,
                                 pEffectsManager, defaultOrientation);
-    connect(m_pChannel, &EngineDeck::noPassthroughInputConfigured,
-            [this]{ emit(noPassthroughInputConfigured()); });
 
     m_pInputConfigured = std::make_unique<ControlProxy>(group, "input_configured", this);
 #ifdef __VINYLCONTROL__

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -78,7 +78,6 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     void slotPlayToggled(double);
 
   private slots:
-    void slotPassthroughEnabled(double v);
     void slotVinylControlEnabled(double v);
     void slotWaveformZoomValueChangeRequest(double pressed);
     void slotWaveformZoomUp(double pressed);
@@ -129,7 +128,6 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     std::unique_ptr<ControlProxy> m_pRateSlider;
     std::unique_ptr<ControlProxy> m_pPitchAdjust;
     std::unique_ptr<ControlProxy> m_pInputConfigured;
-    std::unique_ptr<ControlProxy> m_pPassthroughEnabled;
     std::unique_ptr<ControlProxy> m_pVinylControlEnabled;
     std::unique_ptr<ControlProxy> m_pVinylControlStatus;
 };

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -42,7 +42,6 @@ class BaseTrackPlayer : public BasePlayer {
     void newTrackLoaded(TrackPointer pLoadedTrack);
     void loadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
     void playerEmpty();
-    void noPassthroughInputConfigured();
     void noVinylControlInputConfigured();
 };
 

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -365,8 +365,8 @@ void PlayerManager::addDeckInner() {
 
     Deck* pDeck = new Deck(this, m_pConfig, m_pEngine, m_pEffectsManager,
                            orientation, group);
-    connect(pDeck, SIGNAL(noPassthroughInputConfigured()),
-            this, SIGNAL(noDeckPassthroughInputConfigured()));
+    connect(pDeck->getEngineDeck(), &EngineDeck::noPassthroughInputConfigured,
+            this, &PlayerManager::noDeckPassthroughInputConfigured);
     connect(pDeck, SIGNAL(noVinylControlInputConfigured()),
             this, SIGNAL(noVinylControlInputConfigured()));
 


### PR DESCRIPTION
This is related to PR #2466 and this discussion on Zulip:
https://mixxx.zulipchat.com/#narrow/stream/109122-general/topic/PASS.20button