### PR TITLE
lp1861431: Fix debug assertion for invalid crate names

### DIFF
--- a/src/library/crate/cratefeature.cpp
+++ b/src/library/crate/cratefeature.cpp
@@ -371,34 +371,40 @@ void CrateFeature::slotRenameCrate() {
     if (readLastRightClickedCrate(&crate)) {
         const QString oldName = crate.getName();
         crate.resetName();
-        while (!crate.hasName()) {
+        for (;;) {
             bool ok = false;
-            crate.parseName(
+            auto newName =
                     QInputDialog::getText(
                             nullptr,
                             tr("Rename Crate"),
                             tr("Enter new name for crate:"),
                             QLineEdit::Normal,
                             oldName,
-                            &ok));
-            if (!ok || (crate.getName() == oldName)) {
+                            &ok);
+            if (!ok) {
                 return;
             }
-            if (!crate.hasName()) {
+            newName = parseEntityName(newName);
+            if (newName == oldName) {
+                return;
+            }
+            if (!isValidEntityName(newName)) {
                 QMessageBox::warning(
                         nullptr,
                         tr("Renaming Crate Failed"),
                         tr("A crate cannot have a blank name."));
                 continue;
             }
-            if (m_pTrackCollection->crates().readCrateByName(crate.getName())) {
+            if (m_pTrackCollection->crates().readCrateByName(newName)) {
                 QMessageBox::warning(
                         nullptr,
                         tr("Renaming Crate Failed"),
                         tr("A crate by that name already exists."));
-                crate.resetName();
                 continue;
             }
+            crate.setName(std::move(newName));
+            DEBUG_ASSERT(crate.hasName());
+            break;
         }
 
         if (!m_pTrackCollection->updateCrate(crate)) {
@@ -594,15 +600,16 @@ void CrateFeature::slotCreateImportCrate() {
         // Get a valid name
         QString baseName = fileName.baseName();
         for (int i = 0;; ++i) {
-            QString name = baseName;
+            auto name = baseName;
             if (i > 0) {
                 name += QString(" %1").arg(i);
             }
-
-            if (crate.parseName(name)) {
-                DEBUG_ASSERT(crate.hasName());
-                if (!m_pTrackCollection->crates().readCrateByName(crate.getName())) {
+            name = parseEntityName(name);
+            if (isValidEntityName(name)) {
+                if (!m_pTrackCollection->crates().readCrateByName(name)) {
                     // unused crate name found
+                    crate.setName(std::move(name));
+                    DEBUG_ASSERT(crate.hasName());
                     break; // terminate loop
                 }
             }

--- a/src/library/crate/cratefeature.cpp
+++ b/src/library/crate/cratefeature.cpp
@@ -380,15 +380,11 @@ void CrateFeature::slotRenameCrate() {
                             tr("Enter new name for crate:"),
                             QLineEdit::Normal,
                             oldName,
-                            &ok);
-            if (!ok) {
+                            &ok).trimmed();
+            if (!ok || newName.isEmpty()) {
                 return;
             }
-            newName = parseEntityName(newName);
-            if (newName == oldName) {
-                return;
-            }
-            if (!isValidEntityName(newName)) {
+            if (newName.isEmpty()) {
                 QMessageBox::warning(
                         nullptr,
                         tr("Renaming Crate Failed"),
@@ -604,8 +600,8 @@ void CrateFeature::slotCreateImportCrate() {
             if (i > 0) {
                 name += QString(" %1").arg(i);
             }
-            name = parseEntityName(name);
-            if (isValidEntityName(name)) {
+            name = name.trimmed();
+            if (!name.isEmpty()) {
                 if (!m_pTrackCollection->crates().readCrateByName(name)) {
                     // unused crate name found
                     crate.setName(std::move(name));

--- a/src/library/crate/cratefeaturehelper.cpp
+++ b/src/library/crate/cratefeaturehelper.cpp
@@ -35,35 +35,37 @@ CrateId CrateFeatureHelper::createEmptyCrate() {
     const QString proposedCrateName =
             proposeNameForNewCrate(tr("New Crate"));
     Crate newCrate;
-    while (!newCrate.hasName()) {
+    for (;;) {
         bool ok = false;
-        newCrate.parseName(
+        auto newName =
                 QInputDialog::getText(
                         nullptr,
                         tr("Create New Crate"),
                         tr("Enter name for new crate:"),
                         QLineEdit::Normal,
                         proposedCrateName,
-                        &ok));
+                        &ok);
         if (!ok) {
             return CrateId();
         }
-        if (!newCrate.hasName()) {
+        newName = parseEntityName(newName);
+        if (!isValidEntityName(newName)) {
             QMessageBox::warning(
                     nullptr,
                     tr("Creating Crate Failed"),
                     tr("A crate cannot have a blank name."));
             continue;
         }
-
-        if (m_pTrackCollection->crates().readCrateByName(newCrate.getName())) {
+        if (m_pTrackCollection->crates().readCrateByName(newName)) {
             QMessageBox::warning(
                     nullptr,
                     tr("Creating Crate Failed"),
                     tr("A crate by that name already exists."));
-            newCrate.resetName();
             continue;
         }
+        newCrate.setName(std::move(newName));
+        DEBUG_ASSERT(newCrate.hasName());
+        break;
     }
 
     CrateId newCrateId;
@@ -89,34 +91,37 @@ CrateId CrateFeatureHelper::duplicateCrate(const Crate& oldCrate) {
                     QString("%1 %2").arg(
                             oldCrate.getName(), tr("copy" , "[noun]")));
     Crate newCrate;
-    while (!newCrate.hasName()) {
+    for (;;) {
         bool ok = false;
-        newCrate.parseName(
+        auto newName =
                 QInputDialog::getText(
                         nullptr,
                          tr("Duplicate Crate"),
                          tr("Enter name for new crate:"),
                          QLineEdit::Normal,
                          proposedCrateName,
-                         &ok));
+                         &ok);
         if (!ok) {
             return CrateId();
         }
-        if (!newCrate.hasName()) {
+        newName = parseEntityName(newName);
+        if (!isValidEntityName(newName)) {
             QMessageBox::warning(
                     nullptr,
                     tr("Duplicating Crate Failed"),
                     tr("A crate cannot have a blank name."));
             continue;
         }
-        if (m_pTrackCollection->crates().readCrateByName(newCrate.getName())) {
+        if (m_pTrackCollection->crates().readCrateByName(newName)) {
             QMessageBox::warning(
                     nullptr,
                     tr("Duplicating Crate Failed"),
                     tr("A crate by that name already exists."));
-            newCrate.resetName();
             continue;
         }
+        newCrate.setName(std::move(newName));
+        DEBUG_ASSERT(newCrate.hasName());
+        break;
     }
 
     CrateId newCrateId;

--- a/src/library/crate/cratefeaturehelper.cpp
+++ b/src/library/crate/cratefeaturehelper.cpp
@@ -44,12 +44,11 @@ CrateId CrateFeatureHelper::createEmptyCrate() {
                         tr("Enter name for new crate:"),
                         QLineEdit::Normal,
                         proposedCrateName,
-                        &ok);
+                        &ok).trimmed();
         if (!ok) {
             return CrateId();
         }
-        newName = parseEntityName(newName);
-        if (!isValidEntityName(newName)) {
+        if (newName.isEmpty()) {
             QMessageBox::warning(
                     nullptr,
                     tr("Creating Crate Failed"),
@@ -100,12 +99,11 @@ CrateId CrateFeatureHelper::duplicateCrate(const Crate& oldCrate) {
                          tr("Enter name for new crate:"),
                          QLineEdit::Normal,
                          proposedCrateName,
-                         &ok);
+                         &ok).trimmed();
         if (!ok) {
             return CrateId();
         }
-        newName = parseEntityName(newName);
-        if (!isValidEntityName(newName)) {
+        if (newName.isEmpty()) {
             QMessageBox::warning(
                     nullptr,
                     tr("Duplicating Crate Failed"),

--- a/src/util/db/dbnamedentity.h
+++ b/src/util/db/dbnamedentity.h
@@ -2,15 +2,6 @@
 
 #include "util/db/dbentity.h"
 
-
-inline QString parseEntityName(const QString& name) {
-    return name.trimmed();
-}
-inline bool isValidEntityName(const QString& name) {
-    DEBUG_ASSERT(name == parseEntityName(name));
-    return !name.isEmpty();
-}
-
 // Base class for database entities with a non-empty name.
 template<typename T> // where T is derived from DbId
 class DbNamedEntity: public DbEntity<T> {
@@ -18,12 +9,16 @@ class DbNamedEntity: public DbEntity<T> {
     ~DbNamedEntity() override = default;
 
     bool hasName() const {
-        return isValidEntityName(m_name);
+        return !m_name.isEmpty();
     }
     const QString& getName() const {
         return m_name;
     }
     void setName(QString name) {
+        // Due to missing trimming names with only whitespaces
+        // may occur in the database and can't we assert on
+        // this here!
+        DEBUG_ASSERT(!name.isEmpty());
         m_name = std::move(name);
     }
     void resetName() {

--- a/src/util/db/dbnamedentity.h
+++ b/src/util/db/dbnamedentity.h
@@ -1,9 +1,15 @@
-#ifndef MIXXX_DBNAMEDENTITY_H
-#define MIXXX_DBNAMEDENTITY_H
-
+#pragma once
 
 #include "util/db/dbentity.h"
 
+
+inline QString parseEntityName(const QString& name) {
+    return name.trimmed();
+}
+inline bool isValidEntityName(const QString& name) {
+    DEBUG_ASSERT(name == parseEntityName(name));
+    return !name.isEmpty();
+}
 
 // Base class for database entities with a non-empty name.
 template<typename T> // where T is derived from DbId
@@ -11,33 +17,18 @@ class DbNamedEntity: public DbEntity<T> {
   public:
     ~DbNamedEntity() override = default;
 
-    static QString normalizeName(const QString& name) {
-        return name.trimmed();
-    }
     bool hasName() const {
-        DEBUG_ASSERT(normalizeName(m_name) == m_name); // already normalized
-        return !m_name.isEmpty();
+        return isValidEntityName(m_name);
     }
     const QString& getName() const {
         return m_name;
     }
-    void setName(const QString& name) {
-        DEBUG_ASSERT(normalizeName(name) == name); // already normalized
-        m_name = name;
+    void setName(QString name) {
+        m_name = std::move(name);
     }
     void resetName() {
         m_name.clear();
         DEBUG_ASSERT(!hasName());
-    }
-    bool parseName(const QString& name) {
-        QString normalizedName(normalizeName(name));
-        if (name.isEmpty()) {
-            return false;
-        } else {
-            setName(name);
-            DEBUG_ASSERT(hasName());
-            return true;
-        }
     }
 
   protected:
@@ -54,6 +45,3 @@ template<typename T>
 QDebug operator<<(QDebug debug, const DbNamedEntity<T>& entity) {
     return debug << QString("%1 '%2'").arg(entity.getId().toString(), entity.getName());
 }
-
-
-#endif // MIXXX_DBNAMEDENTITY_H


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1861431

- Fixed debug assertion for existing, invalid crate names in the database, i.e. with leading/trailing whitespaces
- Simplified the code for editing crate name (...won't fix the duplication)

Test: Manually add leading/trailing whitespaces to crate names in the database.