### PR TITLE
Roland DJ-505: Add rudimentary support for the jog wheel LED indicators

### DIFF
--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -297,21 +297,21 @@ DJ505.sortLibrary = function(channel, control, value, _status, _group) {
 
     var sortColumn;
     switch (control) {
-        case 0x12:  // SONG
-            sortColumn = 1;
-            break;
-        case 0x13:  // BPM
-            sortColumn = 14;
-            break;
-        case 0x14:  // ARTIST
-            sortColumn = 0;
-            break;
-        case 0x1E:  // KEY
-            sortColumn = 19;
-            break;
-        default:
-            // unknown sort column
-            return;
+    case 0x12:  // SONG
+        sortColumn = 1;
+        break;
+    case 0x13:  // BPM
+        sortColumn = 14;
+        break;
+    case 0x14:  // ARTIST
+        sortColumn = 0;
+        break;
+    case 0x1E:  // KEY
+        sortColumn = 19;
+        break;
+    default:
+        // unknown sort column
+        return;
     }
     engine.setValue("[Library]", "sort_column_toggle", sortColumn);
 };
@@ -1113,24 +1113,24 @@ DJ505.PadSection.prototype.paramButtonPressed = function(channel, control, value
     }
     var button;
     switch (control) {
-        case 0x2A: // PARAMETER 2 -
-            if (this.currentMode.param2MinusButton) {
-                button = this.currentMode.param2MinusButton;
-                break;
-            }
-            /* falls through */
-        case 0x28: // PARAMETER -
-            button = this.currentMode.paramMinusButton;
+    case 0x2A: // PARAMETER 2 -
+        if (this.currentMode.param2MinusButton) {
+            button = this.currentMode.param2MinusButton;
             break;
-        case 0x2B: // PARAMETER 2 +
-            if (this.currentMode.param2PlusButton) {
-                button = this.currentMode.param2PlusButton;
-                break;
-            }
-            /* falls through */
-        case 0x29: // PARAMETER +
-            button = this.currentMode.paramPlusButton;
+        }
+        /* falls through */
+    case 0x28: // PARAMETER -
+        button = this.currentMode.paramMinusButton;
+        break;
+    case 0x2B: // PARAMETER 2 +
+        if (this.currentMode.param2PlusButton) {
+            button = this.currentMode.param2PlusButton;
             break;
+        }
+        /* falls through */
+    case 0x29: // PARAMETER +
+        button = this.currentMode.paramPlusButton;
+        break;
     }
     if (button) {
         button.input(channel, control, value, status, group);


### PR DESCRIPTION
Missing support was discovered by Daniél on Zulip:
https://mixxx.zulipchat.com/#narrow/stream/109695-_support/topic/for.20mevsme/near/187302854
