### PR TITLE
.clang-format: Set column limit to 80

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,7 +6,7 @@ UseTab:       Never
 # NOTE(2019-02-23, uklotzde) The column limit has been set to 0
 # to avoid eagerly reformatting of the existing code base. This
 # may later be changed to 80-100 characters per line if desired.
-ColumnLimit:  0
+ColumnLimit:  80
 ---
 # Customize only those options that differ from the base style!
 # Dumping the options of the base style for comparison:


### PR DESCRIPTION
Right now, running clang-format or git clang-format will unwrap lines
and make them longer than 80 chars, even if the developer inserted
linebreaks manually.