### PR TITLE
appveyor.yml: Skip commits if no relevant files were changed

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,12 +31,16 @@ matrix:
 skip_commits:
   files:
     - doc/
+    - res/controllers/
+    - res/skins/
     - LICENCE
     - README
     - README.md
     - CHANGELOG
     - COPYING
     - CODE_OF_CONDUCT.md
+    - .travis.yml
+    - **/*.svg
 
 for:
 


### PR DESCRIPTION
Since Appveyor builds do not run in parallel, they are queued, so it can take a long time until they finish. To speed this up, we could stop rebuilding Mixxx on Appveyor when it's a pure controller or skin change. 