### PR TITLE
Library -> WSearchLineEdit: Fix wrong signal/slot direction

### DIFF
--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -367,11 +367,11 @@ void Library::addFeature(LibraryFeature* feature) {
     connect(feature,
             &LibraryFeature::restoreSearch,
             this,
-            &Library::slotRestoreSearch);
+            &Library::restoreSearch); // forward signal
     connect(feature,
             &LibraryFeature::disableSearch,
             this,
-            &Library::slotDisableSearch);
+            &Library::disableSearch); // forward signal
     connect(feature,
             &LibraryFeature::enableCoverArtDisplay,
             this,
@@ -425,14 +425,6 @@ void Library::slotLoadLocationToPlayer(QString location, QString group) {
 
 void Library::slotLoadTrackToPlayer(TrackPointer pTrack, QString group, bool play) {
     emit loadTrackToPlayer(pTrack, group, play);
-}
-
-void Library::slotRestoreSearch(const QString& text) {
-    emit restoreSearch(text);
-}
-
-void Library::slotDisableSearch() {
-    emit disableSearch();
 }
 
 void Library::slotRefreshLibraryModels() {

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -228,14 +228,14 @@ void Library::bindSearchboxWidget(WSearchLineEdit* pSearchboxWidget) {
             &WSearchLineEdit::search,
             this,
             &Library::search);
-    connect(pSearchboxWidget,
-            &WSearchLineEdit::disableSearch,
-            this,
-            &Library::disableSearch);
-    connect(pSearchboxWidget,
-            &WSearchLineEdit::restoreSearch,
-            this,
-            &Library::restoreSearch);
+    connect(this,
+            &Library::disableSearch,
+            pSearchboxWidget,
+            &WSearchLineEdit::disableSearch);
+    connect(this,
+            &Library::restoreSearch,
+            pSearchboxWidget,
+            &WSearchLineEdit::restoreSearch);
     connect(this,
             &Library::setTrackTableFont,
             pSearchboxWidget,

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -95,8 +95,6 @@ class Library: public QObject {
     void slotLoadTrack(TrackPointer pTrack);
     void slotLoadTrackToPlayer(TrackPointer pTrack, QString group, bool play);
     void slotLoadLocationToPlayer(QString location, QString group);
-    void slotRestoreSearch(const QString& text);
-    void slotDisableSearch();
     void slotRefreshLibraryModels();
     void slotCreatePlaylist();
     void slotCreateCrate();

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1315,8 +1315,10 @@ QWidget* LegacySkinParser::parseLibrary(const QDomElement& node) {
     pLibraryWidget->setup(node, *m_pContext);
 
     // Connect Library search signals to the WLibrary
-    connect(m_pLibrary, SIGNAL(search(const QString&)),
-            pLibraryWidget, SLOT(search(const QString&)));
+    connect(m_pLibrary,
+            &Library::search,
+            pLibraryWidget,
+            &WLibrary::search);
 
     m_pLibrary->bindLibraryWidget(pLibraryWidget, m_pKeyboard);
 

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -67,26 +67,35 @@ WSearchLineEdit::WSearchLineEdit(QWidget* pParent)
     // Assume the qss border is at least 1px wide
     m_frameWidth = 1;
     m_clearButton->hide();
-    connect(m_clearButton, &QAbstractButton::clicked,
-            this, &WSearchLineEdit::clearSearch);
+    connect(m_clearButton,
+            &QAbstractButton::clicked,
+            this,
+            &WSearchLineEdit::clearSearch);
 
     setFocusPolicy(Qt::ClickFocus);
     QShortcut* setFocusShortcut = new QShortcut(QKeySequence(tr("Ctrl+F", "Search|Focus")), this);
-    connect(setFocusShortcut, &QShortcut::activated,
-            this, &WSearchLineEdit::setShortcutFocus);
+    connect(setFocusShortcut,
+            &QShortcut::activated,
+            this,
+            &WSearchLineEdit::setShortcutFocus);
 
     // Set up a timer to search after a few hundred milliseconds timeout.  This
     // stops us from thrashing the database if you type really fast.
     m_debouncingTimer.setSingleShot(true);
-    connect(&m_debouncingTimer, &QTimer::timeout,
-            this, &WSearchLineEdit::triggerSearch);
+    connect(&m_debouncingTimer,
+            &QTimer::timeout,
+            this,
+            &WSearchLineEdit::triggerSearch);
     connect(this,
-            SIGNAL(textChanged(const QString&)),
-            this, SLOT(updateText(const QString&)));
+            &QLineEdit::textChanged,
+            this,
+            &WSearchLineEdit::updateText);
 
     // When you hit enter, it will trigger the search.
-    connect(this, &WSearchLineEdit::returnPressed,
-            this, &WSearchLineEdit::triggerSearch);
+    connect(this,
+            &QLineEdit::returnPressed,
+            this,
+            &WSearchLineEdit::triggerSearch);
 
     QSize clearButtonSize = m_clearButton->sizeHint();
     // Ensures the text does not obscure the clear image.


### PR DESCRIPTION
2 connections between `Library` and `WSearchLineEdit` were established in the wrong direction:

```
Warning [Main]: QObject::connect: signal not found in WSearchLineEdit
Warning [Main]: QObject::connect: signal not found in WSearchLineEdit
```

Unfortunately the new connection syntax doesn't catch those errors at compile time and the log output is not very helpful.

Additional changes:
- Switch to new connection syntax
- Split connect() arguments on multiple lines to improve readability
- Remove redundant slots from signal-to-signal connections