### PR TITLE
LibraryScanner: Improve hashing of directory contents

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -526,6 +526,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/util/audiosignal.cpp
   src/util/autohidpi.cpp
   src/util/battery/battery.cpp
+  src/util/cache.cpp
   src/util/cmdlineargs.cpp
   src/util/color/color.cpp
   src/util/color/predefinedcolor.cpp
@@ -913,6 +914,7 @@ add_executable(mixxx-test
   src/test/bpmcontrol_test.cpp
   src/test/broadcastprofile_test.cpp
   src/test/broadcastsettings_test.cpp
+  src/test/cache_test.cpp
   src/test/channelhandle_test.cpp
   src/test/configobject_test.cpp
   src/test/controller_preset_validation_test.cpp

--- a/build/depends.py
+++ b/build/depends.py
@@ -1269,6 +1269,7 @@ class MixxxCore(Feature):
                    "src/util/xml.cpp",
                    "src/util/tapfilter.cpp",
                    "src/util/movinginterquartilemean.cpp",
+                   "src/util/cache.cpp",
                    "src/util/console.cpp",
                    "src/util/color/color.cpp",
                    "src/util/db/dbconnection.cpp",

--- a/src/library/dao/libraryhashdao.cpp
+++ b/src/library/dao/libraryhashdao.cpp
@@ -8,10 +8,21 @@
 #include "libraryhashdao.h"
 #include "library/queryutil.h"
 
-QHash<QString, int> LibraryHashDAO::getDirectoryHashes() {
+namespace {
+
+// Store hash values as a signed 64-bit integer. Otherwise values greater
+// than 2^63-1 would be converted into a floating point numbers while
+// losing precision!!
+inline mixxx::cache_key_signed_t dbHash(mixxx::cache_key_t hash) {
+    return static_cast<mixxx::cache_key_signed_t>(hash);
+}
+
+} // anonymous namespace
+
+QHash<QString, mixxx::cache_key_t> LibraryHashDAO::getDirectoryHashes() {
     QSqlQuery query(m_database);
     query.prepare("SELECT hash, directory_path FROM LibraryHashes");
-    QHash<QString, int> hashes;
+    QHash<QString, mixxx::cache_key_t> hashes;
     if (!query.exec()) {
         LOG_FAILED_QUERY(query);
     }
@@ -20,15 +31,15 @@ QHash<QString, int> LibraryHashDAO::getDirectoryHashes() {
     int directoryPathColumn = query.record().indexOf("directory_path");
     while (query.next()) {
         hashes[query.value(directoryPathColumn).toString()] =
-                query.value(hashColumn).toInt();
+                query.value(hashColumn).toULongLong();
     }
 
     return hashes;
 }
 
-int LibraryHashDAO::getDirectoryHash(const QString& dirPath) {
+mixxx::cache_key_t LibraryHashDAO::getDirectoryHash(const QString& dirPath) {
     //qDebug() << "LibraryHashDAO::getDirectoryHash" << QThread::currentThread() << m_database.connectionName();
-    int hash = -1;
+    mixxx::cache_key_t hash = mixxx::invalidCacheKey();
 
     QSqlQuery query(m_database);
     query.prepare("SELECT hash FROM LibraryHashes "
@@ -40,7 +51,7 @@ int LibraryHashDAO::getDirectoryHash(const QString& dirPath) {
     }
     //Grab a hash for this directory from the database, from the last time it was scanned.
     if (query.next()) {
-        hash = query.value(query.record().indexOf("hash")).toInt();
+        hash = query.value(query.record().indexOf("hash")).toULongLong();
         //qDebug() << "prev hash exists" << hash << dirPath;
     } else {
         //qDebug() << "prev hash does not exist" << dirPath;
@@ -49,13 +60,13 @@ int LibraryHashDAO::getDirectoryHash(const QString& dirPath) {
     return hash;
 }
 
-void LibraryHashDAO::saveDirectoryHash(const QString& dirPath, const int hash) {
+void LibraryHashDAO::saveDirectoryHash(const QString& dirPath, mixxx::cache_key_t hash) {
     //qDebug() << "LibraryHashDAO::saveDirectoryHash" << QThread::currentThread() << m_database.connectionName();
     QSqlQuery query(m_database);
     query.prepare("INSERT INTO LibraryHashes (directory_path, hash, directory_deleted) "
                     "VALUES (:directory_path, :hash, :directory_deleted)");
     query.bindValue(":directory_path", dirPath);
-    query.bindValue(":hash", hash);
+    query.bindValue(":hash", dbHash(hash));
     query.bindValue(":directory_deleted", 0);
 
     if (!query.exec()) {
@@ -65,8 +76,8 @@ void LibraryHashDAO::saveDirectoryHash(const QString& dirPath, const int hash) {
 }
 
 void LibraryHashDAO::updateDirectoryHash(const QString& dirPath,
-                                         const int newHash,
-                                         const int dir_deleted) {
+                                         mixxx::cache_key_t newHash,
+                                         int dir_deleted) {
     //qDebug() << "LibraryHashDAO::updateDirectoryHash" << QThread::currentThread() << m_database.connectionName();
     QSqlQuery query(m_database);
     // By definition if we have calculated a new hash for a directory then it
@@ -75,7 +86,7 @@ void LibraryHashDAO::updateDirectoryHash(const QString& dirPath,
             "SET hash=:hash, directory_deleted=:directory_deleted, "
             "needs_verification=0 "
             "WHERE directory_path=:directory_path");
-    query.bindValue(":hash", newHash);
+    query.bindValue(":hash", dbHash(newHash));
     query.bindValue(":directory_deleted", dir_deleted);
     query.bindValue(":directory_path", dirPath);
 

--- a/src/library/dao/libraryhashdao.cpp
+++ b/src/library/dao/libraryhashdao.cpp
@@ -13,8 +13,8 @@ namespace {
 // Store hash values as a signed 64-bit integer. Otherwise values greater
 // than 2^63-1 would be converted into a floating point numbers while
 // losing precision!!
-inline mixxx::cache_key_signed_t dbHash(mixxx::cache_key_t hash) {
-    return static_cast<mixxx::cache_key_signed_t>(hash);
+inline constexpr mixxx::cache_key_signed_t dbHash(mixxx::cache_key_t hash) {
+    return mixxx::signedCacheKey(hash);
 }
 
 } // anonymous namespace

--- a/src/library/dao/libraryhashdao.h
+++ b/src/library/dao/libraryhashdao.h
@@ -7,6 +7,7 @@
 #include <QSqlDatabase>
 
 #include "library/dao/dao.h"
+#include "util/cache.h"
 
 class LibraryHashDAO : public DAO {
   public:
@@ -16,11 +17,11 @@ class LibraryHashDAO : public DAO {
         m_database = database;
     };
 
-    QHash<QString, int> getDirectoryHashes();
-    int getDirectoryHash(const QString& dirPath);
-    void saveDirectoryHash(const QString& dirPath, const int hash);
-    void updateDirectoryHash(const QString& dirPath, const int newHash,
-                             const int dir_deleted);
+    QHash<QString, mixxx::cache_key_t> getDirectoryHashes();
+    mixxx::cache_key_t getDirectoryHash(const QString& dirPath);
+    void saveDirectoryHash(const QString& dirPath, mixxx::cache_key_t hash);
+    void updateDirectoryHash(const QString& dirPath, mixxx::cache_key_t newHash,
+                             int dir_deleted);
     void markAsExisting(const QString& dirPath);
     void invalidateAllDirectories();
     void markUnverifiedDirectoriesAsDeleted();

--- a/src/library/scanner/importfilestask.cpp
+++ b/src/library/scanner/importfilestask.cpp
@@ -8,7 +8,7 @@ ImportFilesTask::ImportFilesTask(LibraryScanner* pScanner,
                                  const ScannerGlobalPointer scannerGlobal,
                                  const QString& dirPath,
                                  const bool prevHashExists,
-                                 const int newHash,
+                                 const mixxx::cache_key_t newHash,
                                  const QLinkedList<QFileInfo>& filesToImport,
                                  const QLinkedList<QFileInfo>& possibleCovers,
                                  SecurityTokenPointer pToken)

--- a/src/library/scanner/importfilestask.h
+++ b/src/library/scanner/importfilestask.h
@@ -6,7 +6,6 @@
 
 #include "util/sandbox.h"
 #include "library/scanner/scannertask.h"
-#include "library/scanner/scannerglobal.h"
 
 // Import the provided files. Successful if the scan completed without being
 // cancelled. False if the scan was cancelled part-way through.
@@ -17,7 +16,7 @@ class ImportFilesTask : public ScannerTask {
                     const ScannerGlobalPointer scannerGlobal,
                     const QString& dirPath,
                     const bool prevHashExists,
-                    const int newHash,
+                    const mixxx::cache_key_t newHash,
                     const QLinkedList<QFileInfo>& filesToImport,
                     const QLinkedList<QFileInfo>& possibleCovers,
                     SecurityTokenPointer pToken);
@@ -28,7 +27,7 @@ class ImportFilesTask : public ScannerTask {
   private:
     const QString m_dirPath;
     const bool m_prevHashExists;
-    const int m_newHash;
+    const mixxx::cache_key_t m_newHash;
     const QLinkedList<QFileInfo> m_filesToImport;
     const QLinkedList<QFileInfo> m_possibleCovers;
     SecurityTokenPointer m_pToken;

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -69,7 +69,7 @@ class LibraryScanner : public QThread {
 
     // ScannerTask signal handlers.
     void slotDirectoryHashedAndScanned(const QString& directoryPath,
-                                   bool newDirectory, int hash);
+                                   bool newDirectory, mixxx::cache_key_t hash);
     void slotDirectoryUnchanged(const QString& directoryPath);
     void slotTrackExists(const QString& trackPath);
     void slotAddNewTrack(const QString& trackPath);

--- a/src/library/scanner/recursivescandirectorytask.cpp
+++ b/src/library/scanner/recursivescandirectorytask.cpp
@@ -1,3 +1,4 @@
+#include <QCryptographicHash>
 #include <QDirIterator>
 
 #include "library/scanner/recursivescandirectorytask.h"
@@ -38,7 +39,8 @@ void RecursiveScanDirectoryTask::run() {
     QLinkedList<QFileInfo> filesToImport;
     QLinkedList<QFileInfo> possibleCovers;
     QLinkedList<QDir> dirsToScan;
-    QStringList newHashStr;
+
+    QCryptographicHash hasher(QCryptographicHash::Sha256);
 
     // TODO(rryan) benchmark QRegExp copy versus QMutex/QRegExp in ScannerGlobal
     // versus slicing the extension off and checking for set/list containment.
@@ -54,7 +56,7 @@ void RecursiveScanDirectoryTask::run() {
         if (currentFileInfo.isFile()) {
             const QString& fileName = currentFileInfo.fileName();
             if (supportedExtensionsRegex.indexIn(fileName) != -1) {
-                newHashStr.append(currentFile);
+                hasher.addData(currentFile.toUtf8());
                 filesToImport.append(currentFileInfo);
             } else if (supportedCoverExtensionsRegex.indexIn(fileName) != -1) {
                 possibleCovers.append(currentFileInfo);
@@ -73,13 +75,13 @@ void RecursiveScanDirectoryTask::run() {
 
     // Note: A hash of "0" is a real hash if the directory contains no files!
     // Calculate a hash of the directory's file list.
-    int newHash = qHash(newHashStr.join(""));
+    const mixxx::cache_key_t newHash = mixxx::calculateCacheKey(hasher.result());
 
     QString dirPath = m_dir.path();
 
     // Try to retrieve a hash from the last time that directory was scanned.
-    int prevHash = m_scannerGlobal->directoryHashInDatabase(dirPath);
-    bool prevHashExists = prevHash != -1;
+    const mixxx::cache_key_t prevHash = m_scannerGlobal->directoryHashInDatabase(dirPath);
+    const bool prevHashExists = mixxx::isValidCacheKey(prevHash);
 
     if (prevHashExists || m_scanUnhashed) {
         // Compare the hashes, and if they don't match, rescan the files in that

--- a/src/library/scanner/recursivescandirectorytask.cpp
+++ b/src/library/scanner/recursivescandirectorytask.cpp
@@ -75,7 +75,7 @@ void RecursiveScanDirectoryTask::run() {
 
     // Note: A hash of "0" is a real hash if the directory contains no files!
     // Calculate a hash of the directory's file list.
-    const mixxx::cache_key_t newHash = mixxx::calculateCacheKey(hasher.result());
+    const mixxx::cache_key_t newHash = mixxx::cacheKeyFromMessageDigest(hasher.result());
 
     QString dirPath = m_dir.path();
 

--- a/src/library/scanner/scannerglobal.h
+++ b/src/library/scanner/scannerglobal.h
@@ -9,6 +9,7 @@
 #include <QMutexLocker>
 #include <QSharedPointer>
 
+#include "util/cache.h"
 #include "util/task.h"
 #include "util/performancetimer.h"
 
@@ -37,7 +38,7 @@ class DirInfo {
 class ScannerGlobal {
   public:
     ScannerGlobal(const QSet<QString>& trackLocations,
-                  const QHash<QString, int>& directoryHashes,
+                  const QHash<QString, mixxx::cache_key_t>& directoryHashes,
                   const QRegExp& supportedExtensionsMatcher,
                   const QRegExp& supportedCoverExtensionsMatcher,
                   const QStringList& directoriesBlacklist)
@@ -62,7 +63,7 @@ class ScannerGlobal {
     }
 
     // Returns the directory hash if it exists or -1 if it doesn't.
-    inline int directoryHashInDatabase(const QString& directoryPath) const {
+    inline mixxx::cache_key_t directoryHashInDatabase(const QString& directoryPath) const {
         return m_directoryHashes.value(directoryPath, -1);
     }
 
@@ -177,7 +178,7 @@ class ScannerGlobal {
     TaskWatcher m_watcher;
 
     QSet<QString> m_trackLocations;
-    QHash<QString, int> m_directoryHashes;
+    QHash<QString, mixxx::cache_key_t> m_directoryHashes;
 
     mutable QMutex m_supportedExtensionsMatcherMutex;
     QRegExp m_supportedExtensionsMatcher;

--- a/src/library/scanner/scannertask.h
+++ b/src/library/scanner/scannertask.h
@@ -22,7 +22,7 @@ class ScannerTask : public QObject, public QRunnable {
     void taskDone(bool success);
     void queueTask(ScannerTask* pTask);
     void directoryHashedAndScanned(const QString& directoryPath,
-                                   bool newDirectory, int hash);
+                                   bool newDirectory, mixxx::cache_key_t hash);
     void directoryUnchanged(const QString& directoryPath);
     void trackExists(const QString& filePath);
     void addNewTrack(const QString& filePath);

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -9,6 +9,7 @@
 #include "soundio/soundmanagerutil.h"
 #include "track/track.h"
 #include "track/trackref.h"
+#include "util/cache.h"
 #include "util/color/rgbcolor.h"
 #include "util/math.h"
 
@@ -66,6 +67,7 @@ void MixxxApplication::registerMetaTypes() {
     qRegisterMetaType<QList<CrateId>>();
     qRegisterMetaType<TrackPointer>();
     qRegisterMetaType<mixxx::ReplayGain>("mixxx::ReplayGain");
+    qRegisterMetaType<mixxx::cache_key_t>("mixxx::cache_key_t");
     qRegisterMetaType<mixxx::Bpm>("mixxx::Bpm");
     qRegisterMetaType<mixxx::Duration>("mixxx::Duration");
     qRegisterMetaType<std::optional<mixxx::RgbColor>>("std::optional<mixxx::RgbColor>");

--- a/src/test/cache_test.cpp
+++ b/src/test/cache_test.cpp
@@ -1,0 +1,41 @@
+#include "util/cache.h"
+
+#include <gtest/gtest.h>
+
+#include <QtDebug>
+
+namespace {
+
+class CacheTest : public testing::Test {
+};
+
+TEST_F(CacheTest, InvalidCacheKey) {
+    EXPECT_FALSE(mixxx::isValidCacheKey(
+            mixxx::invalidCacheKey()));
+}
+
+TEST_F(CacheTest, InvalidCacheKeyEmptyByteArray) {
+    EXPECT_FALSE(mixxx::isValidCacheKey(
+            mixxx::calculateCacheKey(QByteArray())));
+    EXPECT_FALSE(mixxx::isValidCacheKey(
+            mixxx::calculateCacheKey("")));
+    EXPECT_FALSE(mixxx::isValidCacheKey(
+            mixxx::calculateCacheKey("\0")));
+}
+
+TEST_F(CacheTest, ValidCacheKey) {
+    EXPECT_TRUE(mixxx::isValidCacheKey(
+            mixxx::calculateCacheKey(QByteArrayLiteral("test"))));
+}
+
+TEST_F(CacheTest, ValidCacheKeySingleZeroAscii) {
+    EXPECT_TRUE(mixxx::isValidCacheKey(
+            mixxx::calculateCacheKey(QByteArray("0"))));
+}
+
+TEST_F(CacheTest, ValidCacheKeySingleZeroByte) {
+    EXPECT_TRUE(mixxx::isValidCacheKey(
+            mixxx::calculateCacheKey(QByteArray("\0", 1))));
+}
+
+} // anonymous namespace

--- a/src/test/cache_test.cpp
+++ b/src/test/cache_test.cpp
@@ -16,26 +16,26 @@ TEST_F(CacheTest, InvalidCacheKey) {
 
 TEST_F(CacheTest, InvalidCacheKeyEmptyByteArray) {
     EXPECT_FALSE(mixxx::isValidCacheKey(
-            mixxx::calculateCacheKey(QByteArray())));
+            mixxx::cacheKeyFromMessageDigest(QByteArray())));
     EXPECT_FALSE(mixxx::isValidCacheKey(
-            mixxx::calculateCacheKey("")));
+            mixxx::cacheKeyFromMessageDigest("")));
     EXPECT_FALSE(mixxx::isValidCacheKey(
-            mixxx::calculateCacheKey("\0")));
+            mixxx::cacheKeyFromMessageDigest("\0")));
 }
 
 TEST_F(CacheTest, ValidCacheKey) {
     EXPECT_TRUE(mixxx::isValidCacheKey(
-            mixxx::calculateCacheKey(QByteArrayLiteral("test"))));
+            mixxx::cacheKeyFromMessageDigest(QByteArrayLiteral("test"))));
 }
 
 TEST_F(CacheTest, ValidCacheKeySingleZeroAscii) {
     EXPECT_TRUE(mixxx::isValidCacheKey(
-            mixxx::calculateCacheKey(QByteArray("0"))));
+            mixxx::cacheKeyFromMessageDigest(QByteArray("0"))));
 }
 
 TEST_F(CacheTest, ValidCacheKeySingleZeroByte) {
     EXPECT_TRUE(mixxx::isValidCacheKey(
-            mixxx::calculateCacheKey(QByteArray("\0", 1))));
+            mixxx::cacheKeyFromMessageDigest(QByteArray("\0", 1))));
 }
 
 } // anonymous namespace

--- a/src/util/cache.cpp
+++ b/src/util/cache.cpp
@@ -1,0 +1,31 @@
+#include "util/cache.h"
+
+#include "util/assert.h"
+
+namespace mixxx {
+
+cache_key_t calculateCacheKey(const QByteArray& bytes) {
+    cache_key_t key = invalidCacheKey();
+    DEBUG_ASSERT(!isValidCacheKey(key));
+    if (bytes.isEmpty()) {
+        return key;
+    }
+    size_t leftShiftBytes = 0;
+    for (const auto nextByte : bytes) {
+        // Only 8 bits are relevant and we don't want the sign
+        // extension of a (signed) char during conversion.
+        const cache_key_t nextBits =
+                static_cast<unsigned char>(nextByte);
+        DEBUG_ASSERT(nextBits == (nextBits & static_cast<cache_key_t>(0xff)));
+        key ^= nextBits << (leftShiftBytes * 8);
+        leftShiftBytes = (leftShiftBytes + 1) % sizeof(cache_key_t);
+    }
+    if (!isValidCacheKey(key)) {
+        // Unlikely but possible
+        key = ~key;
+    }
+    DEBUG_ASSERT(isValidCacheKey(key));
+    return key;
+}
+
+} // namespace mixxx

--- a/src/util/cache.cpp
+++ b/src/util/cache.cpp
@@ -10,6 +10,12 @@ cache_key_t calculateCacheKey(const QByteArray& bytes) {
     if (bytes.isEmpty()) {
         return key;
     }
+    // We should not make any assumptions about the significance of
+    // the given bytes, even if they are supposed to be the result of
+    // applying a hash function. Instead of truncating the information
+    // by using only the first sizeof(cache_key_t) bytes we slice the
+    // array into groups of sizeof(cache_key_t) bytes and combine them
+    // with XOR.
     size_t leftShiftBytes = 0;
     for (const auto nextByte : bytes) {
         // Only 8 bits are relevant and we don't want the sign

--- a/src/util/cache.h
+++ b/src/util/cache.h
@@ -21,7 +21,9 @@ inline constexpr bool isValidCacheKey(cache_key_t key) {
 }
 
 inline constexpr cache_key_t signedCacheKey(cache_key_t cacheKey) {
-    static_assert(sizeof(cache_key_t) == sizeof(cache_key_signed_t));
+    static_assert(
+            sizeof(cache_key_t) == sizeof(cache_key_signed_t),
+            "size mismatch of signed/unsigned cache key types");
     return static_cast<cache_key_signed_t>(cacheKey);
 }
 

--- a/src/util/cache.h
+++ b/src/util/cache.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <QByteArray>
+#include <QMetaType>
+
+namespace mixxx {
+
+typedef quint64 cache_key_t;
+
+// A signed integer is needed for storing cache keys as
+// integer numbers with full precision in the database.
+typedef qint64 cache_key_signed_t;
+
+inline constexpr cache_key_t invalidCacheKey() {
+    return 0;
+}
+
+inline constexpr bool isValidCacheKey(cache_key_t key) {
+    return key != invalidCacheKey();
+}
+
+// Transforms a byte array containing a hash result into an
+// unsigned integer number that should be almost unique.
+cache_key_t calculateCacheKey(const QByteArray& bytes);
+
+} // namespace mixxx
+
+Q_DECLARE_METATYPE(mixxx::cache_key_t);

--- a/src/util/cache.h
+++ b/src/util/cache.h
@@ -2,6 +2,7 @@
 
 #include <QByteArray>
 #include <QMetaType>
+#include <type_traits> // static_assert
 
 namespace mixxx {
 
@@ -19,9 +20,16 @@ inline constexpr bool isValidCacheKey(cache_key_t key) {
     return key != invalidCacheKey();
 }
 
-// Transforms a byte array containing a hash result into an
-// unsigned integer number that should be almost unique.
-cache_key_t calculateCacheKey(const QByteArray& bytes);
+inline constexpr cache_key_t signedCacheKey(cache_key_t cacheKey) {
+    static_assert(sizeof(cache_key_t) == sizeof(cache_key_signed_t));
+    return static_cast<cache_key_signed_t>(cacheKey);
+}
+
+// Truncate a message digest to obtain a cache key.
+//
+// The message digest should either be empty or contain at least as many
+// bytes as the size (in bytes) of the cache key.
+cache_key_t cacheKeyFromMessageDigest(const QByteArray& messageDigest);
 
 } // namespace mixxx
 


### PR DESCRIPTION
- Use a cryptographic SHA256 hash that can be calculated incrementally instead of concatenating all file path strings (requiring many intermediate dynamic memory allocations) and finally hashing the resulting string with `qHash()`
- Use 64-bit integers (by ~~mangling all~~truncating SHA256 bytes) instead of 32-bit integers from `qHash()`
- The hash code 0 is reserved and considered invalid. Tests verify the correct behavior.
- We don't need a database migration. The stored hash values will be replaced with the next library rescan.

**Remark** The new `cache_key_t` typedef (a primitive type) and utility functions could be reused for caching artwork images. The aoide branch already contains the code for hashing images. Unfortunately this migration will require to discard and recalculate the hash of all artwork images. But we need to do it at some point if we want to get rid of the crippled 16-bit integer hashes that cause many hash collisions and wrong artwork display.