### PR TITLE
Serato Markers Integration for Track Color/BPM lock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -977,6 +977,7 @@ add_executable(mixxx-test
   src/test/searchqueryparsertest.cpp
   src/test/seratomarkerstest.cpp
   src/test/seratomarkers2test.cpp
+  src/test/seratotagstest.cpp
   src/test/signalpathtest.cpp
   src/test/skincontext_test.cpp
   src/test/softtakeover_test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -519,6 +519,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/track/replaygain.cpp
   src/track/serato/markers.cpp
   src/track/serato/markers2.cpp
+  src/track/serato/tags.cpp
   src/track/track.cpp
   src/track/trackfile.cpp
   src/track/trackinfo.cpp

--- a/build/depends.py
+++ b/build/depends.py
@@ -1211,6 +1211,7 @@ class MixxxCore(Feature):
                    "src/track/replaygain.cpp",
                    "src/track/serato/markers.cpp",
                    "src/track/serato/markers2.cpp",
+                   "src/track/serato/tags.cpp",
                    "src/track/track.cpp",
                    "src/track/globaltrackcache.cpp",
                    "src/track/trackfile.cpp",

--- a/src/test/seratomarkers2test.cpp
+++ b/src/test/seratomarkers2test.cpp
@@ -277,4 +277,12 @@ TEST_F(SeratoMarkers2Test, ParseMarkers2Data) {
     }
 }
 
+TEST_F(SeratoMarkers2Test, ParseEmptyData) {
+    QByteArray inputValue;
+    mixxx::SeratoMarkers2 seratoMarkers2;
+    mixxx::SeratoMarkers2::parse(&seratoMarkers2, inputValue);
+    QByteArray outputValue = seratoMarkers2.dump();
+    EXPECT_EQ(inputValue, outputValue);
+}
+
 }  // namespace

--- a/src/test/seratomarkerstest.cpp
+++ b/src/test/seratomarkerstest.cpp
@@ -155,4 +155,12 @@ TEST_F(SeratoMarkersTest, ParseMarkersData) {
     }
 }
 
+TEST_F(SeratoMarkersTest, ParseEmptyData) {
+    QByteArray inputValue;
+    mixxx::SeratoMarkers seratoMarkers;
+    mixxx::SeratoMarkers::parse(&seratoMarkers, inputValue);
+    QByteArray outputValue = seratoMarkers.dump();
+    EXPECT_EQ(inputValue, outputValue);
+}
+
 } // namespace

--- a/src/test/seratotagstest.cpp
+++ b/src/test/seratotagstest.cpp
@@ -1,0 +1,43 @@
+#include <gtest/gtest.h>
+
+#include "track/serato/tags.h"
+
+namespace {
+
+class SeratoTagsTest : public testing::Test {
+  protected:
+    void trackColorRoundtrip(mixxx::RgbColor storedColor, mixxx::RgbColor::optional_t parsedColor) {
+        mixxx::RgbColor::optional_t actualParsedColor = mixxx::SeratoTags::colorFromStoredTrackColor(storedColor);
+        EXPECT_EQ(parsedColor, actualParsedColor);
+
+        mixxx::RgbColor actualStoredColor = mixxx::SeratoTags::colorToStoredTrackColor(actualParsedColor);
+        EXPECT_EQ(actualStoredColor, storedColor);
+    }
+};
+
+TEST_F(SeratoTagsTest, ParseTrackColor) {
+    trackColorRoundtrip(mixxx::RgbColor(0xFF99FF), mixxx::RgbColor::optional(0x993399));
+    trackColorRoundtrip(mixxx::RgbColor(0xFF99DD), mixxx::RgbColor::optional(0x993377));
+    trackColorRoundtrip(mixxx::RgbColor(0xFF99BB), mixxx::RgbColor::optional(0x993355));
+    trackColorRoundtrip(mixxx::RgbColor(0xFF9999), mixxx::RgbColor::optional(0x993333));
+    trackColorRoundtrip(mixxx::RgbColor(0xFFBB99), mixxx::RgbColor::optional(0x995533));
+    trackColorRoundtrip(mixxx::RgbColor(0xFFDD99), mixxx::RgbColor::optional(0x997733));
+    trackColorRoundtrip(mixxx::RgbColor(0xFFFF99), mixxx::RgbColor::optional(0x999933));
+    trackColorRoundtrip(mixxx::RgbColor(0xDDFF99), mixxx::RgbColor::optional(0x779933));
+    trackColorRoundtrip(mixxx::RgbColor(0xBBFF99), mixxx::RgbColor::optional(0x559933));
+    trackColorRoundtrip(mixxx::RgbColor(0x99FF99), mixxx::RgbColor::optional(0x339933));
+    trackColorRoundtrip(mixxx::RgbColor(0x99FFBB), mixxx::RgbColor::optional(0x339955));
+    trackColorRoundtrip(mixxx::RgbColor(0x99FFDD), mixxx::RgbColor::optional(0x339977));
+    trackColorRoundtrip(mixxx::RgbColor(0x99FFFF), mixxx::RgbColor::optional(0x339999));
+    trackColorRoundtrip(mixxx::RgbColor(0x99DDFF), mixxx::RgbColor::optional(0x337799));
+    trackColorRoundtrip(mixxx::RgbColor(0x99BBFF), mixxx::RgbColor::optional(0x335599));
+    trackColorRoundtrip(mixxx::RgbColor(0x9999FF), mixxx::RgbColor::optional(0x333399));
+    trackColorRoundtrip(mixxx::RgbColor(0xBB99FF), mixxx::RgbColor::optional(0x553399));
+    trackColorRoundtrip(mixxx::RgbColor(0xDD99FF), mixxx::RgbColor::optional(0x773399));
+    trackColorRoundtrip(mixxx::RgbColor(0x000000), mixxx::RgbColor::optional(0x333333));
+    trackColorRoundtrip(mixxx::RgbColor(0xBBBBBB), mixxx::RgbColor::optional(0x555555));
+    trackColorRoundtrip(mixxx::RgbColor(0x999999), mixxx::RgbColor::optional(0x090909));
+    trackColorRoundtrip(mixxx::RgbColor(0xFFFFFF), std::nullopt);
+}
+
+} // namespace

--- a/src/test/seratotagstest.cpp
+++ b/src/test/seratotagstest.cpp
@@ -6,11 +6,11 @@ namespace {
 
 class SeratoTagsTest : public testing::Test {
   protected:
-    void trackColorRoundtrip(mixxx::RgbColor storedColor, mixxx::RgbColor::optional_t parsedColor) {
-        mixxx::RgbColor::optional_t actualParsedColor = mixxx::SeratoTags::colorFromStoredTrackColor(storedColor);
-        EXPECT_EQ(parsedColor, actualParsedColor);
+    void trackColorRoundtrip(mixxx::RgbColor storedColor, mixxx::RgbColor::optional_t displayedColor) {
+        mixxx::RgbColor::optional_t actualDisplayedColor = mixxx::SeratoTags::storedToDisplayedTrackColor(storedColor);
+        EXPECT_EQ(displayedColor, actualDisplayedColor);
 
-        mixxx::RgbColor actualStoredColor = mixxx::SeratoTags::colorToStoredTrackColor(actualParsedColor);
+        mixxx::RgbColor actualStoredColor = mixxx::SeratoTags::displayedToStoredTrackColor(actualDisplayedColor);
         EXPECT_EQ(actualStoredColor, storedColor);
     }
 };

--- a/src/track/serato/markers.cpp
+++ b/src/track/serato/markers.cpp
@@ -2,7 +2,7 @@
 
 #include <QtEndian>
 
-#include "util/color/rgbcolor.h"
+#include "track/serato/tags.h"
 
 namespace {
 
@@ -10,7 +10,6 @@ const int kNumEntries = 14;
 const int kLoopEntryStartIndex = 5;
 const int kEntrySize = 22;
 const quint16 kVersion = 0x0205;
-constexpr mixxx::RgbColor kDefaultTrackColor = mixxx::RgbColor(0xFF9999);
 
 // These functions conversion between the 4-byte "Serato Markers_" color format
 // and RgbColor (3-Byte RGB, transparency disabled).
@@ -262,7 +261,7 @@ QByteArray SeratoMarkers::dump() const {
         SeratoMarkersEntryPointer pEntry = m_entries.at(i);
         stream.writeRawData(pEntry->dump(), kEntrySize);
     }
-    stream << seratoColorFromRgb(m_trackColor.value_or(kDefaultTrackColor));
+    stream << seratoColorFromRgb(m_trackColor.value_or(SeratoTags::kDefaultTrackColor));
     return data;
 }
 

--- a/src/track/serato/markers.cpp
+++ b/src/track/serato/markers.cpp
@@ -251,6 +251,11 @@ bool SeratoMarkers::parse(SeratoMarkers* seratoMarkers, const QByteArray& data) 
 
 QByteArray SeratoMarkers::dump() const {
     QByteArray data;
+    if (isEmpty()) {
+        // Return empty QByteArray
+        return data;
+    }
+
     data.resize(sizeof(quint16) + 2 * sizeof(quint32) + kEntrySize * m_entries.size());
 
     QDataStream stream(&data, QIODevice::WriteOnly);

--- a/src/track/serato/markers.h
+++ b/src/track/serato/markers.h
@@ -11,7 +11,6 @@
 
 namespace mixxx {
 
-// Forward declaration
 class SeratoMarkersEntry;
 typedef std::shared_ptr<SeratoMarkersEntry> SeratoMarkersEntryPointer;
 

--- a/src/track/serato/markers2.cpp
+++ b/src/track/serato/markers2.cpp
@@ -372,6 +372,13 @@ bool SeratoMarkers2::parse(SeratoMarkers2* seratoMarkers2, const QByteArray& out
 
 QByteArray SeratoMarkers2::dump() const {
     QByteArray data;
+
+    // To reduce disk fragmentation, Serato pre-allocates at least 470 bytes
+    // for the "Markers2" tag. Unused bytes are filled with null-bytes.
+    // Hence, it's possible to have a valid tag that does not contain actual
+    // marker information. The allocated size is set after successfully parsing
+    // the tag, so if the tag is valid but does not contain entries we
+    // shouldn't delete the tag content.
     if (isEmpty() && getAllocatedSize() == 0) {
         // Return empty QByteArray
         return data;

--- a/src/track/serato/markers2.cpp
+++ b/src/track/serato/markers2.cpp
@@ -426,4 +426,34 @@ QByteArray SeratoMarkers2::dump() const {
     return outerData.leftJustified(size, '\0');
 }
 
+RgbColor::optional_t SeratoMarkers2::getTrackColor() const {
+    qDebug() << "Reading track color from 'Serato Markers2' tag data...";
+
+    for (auto& pEntry : m_entries) {
+        DEBUG_ASSERT(pEntry);
+        if (pEntry->typeId() != SeratoMarkers2Entry::TypeId::Color) {
+            continue;
+        }
+        const SeratoMarkers2ColorEntry* pColorEntry = static_cast<SeratoMarkers2ColorEntry*>(pEntry.get());
+        return RgbColor::optional(pColorEntry->getColor());
+    }
+
+    return std::nullopt;
+}
+
+bool SeratoMarkers2::isBpmLocked() const {
+    qDebug() << "Reading bpmlock state from 'Serato Markers2' tag data...";
+
+    for (auto& pEntry : m_entries) {
+        DEBUG_ASSERT(pEntry);
+        if (pEntry->typeId() != SeratoMarkers2Entry::TypeId::Bpmlock) {
+            continue;
+        }
+        const SeratoMarkers2BpmlockEntry* pBpmlockEntry = static_cast<SeratoMarkers2BpmlockEntry*>(pEntry.get());
+        return pBpmlockEntry->isLocked();
+    }
+
+    return false;
+}
+
 } //namespace mixxx

--- a/src/track/serato/markers2.cpp
+++ b/src/track/serato/markers2.cpp
@@ -372,6 +372,11 @@ bool SeratoMarkers2::parse(SeratoMarkers2* seratoMarkers2, const QByteArray& out
 
 QByteArray SeratoMarkers2::dump() const {
     QByteArray data;
+    if (isEmpty() && getAllocatedSize() == 0) {
+        // Return empty QByteArray
+        return data;
+    }
+
     QDataStream stream(&data, QIODevice::WriteOnly);
     stream.setVersion(QDataStream::Qt_5_0);
     stream.setByteOrder(QDataStream::BigEndian);

--- a/src/track/serato/markers2.h
+++ b/src/track/serato/markers2.h
@@ -363,7 +363,9 @@ inline QDebug operator<<(QDebug dbg, const SeratoMarkers2LoopEntry& arg) {
 //
 class SeratoMarkers2 final {
   public:
-    SeratoMarkers2() = default;
+    SeratoMarkers2()
+            : m_allocatedSize(0) {
+    }
     explicit SeratoMarkers2(
             QList<std::shared_ptr<SeratoMarkers2Entry>> entries)
             : m_allocatedSize(0),

--- a/src/track/serato/markers2.h
+++ b/src/track/serato/markers2.h
@@ -9,11 +9,6 @@
 #include "util/color/rgbcolor.h"
 #include "util/types.h"
 
-namespace {
-constexpr mixxx::RgbColor kDefaultTrackColor = mixxx::RgbColor(0xFF9999);
-constexpr mixxx::RgbColor kDefaultCueColor = mixxx::RgbColor(0xCC0000);
-} // namespace
-
 namespace mixxx {
 
 // Enum values need to appear in the same order as the corresponding entries
@@ -61,6 +56,7 @@ class SeratoMarkers2UnknownEntry : public SeratoMarkers2Entry {
             : m_type(std::move(type)),
               m_data(std::move(data)) {
     }
+    SeratoMarkers2UnknownEntry() = delete;
     ~SeratoMarkers2UnknownEntry() override = default;
 
     QString type() const override {
@@ -89,10 +85,7 @@ class SeratoMarkers2BpmlockEntry : public SeratoMarkers2Entry {
     SeratoMarkers2BpmlockEntry(bool locked)
             : m_locked(locked) {
     }
-
-    SeratoMarkers2BpmlockEntry()
-            : m_locked(false) {
-    }
+    SeratoMarkers2BpmlockEntry() = delete;
 
     static SeratoMarkers2EntryPointer parse(const QByteArray& data);
 
@@ -139,10 +132,7 @@ class SeratoMarkers2ColorEntry : public SeratoMarkers2Entry {
     SeratoMarkers2ColorEntry(RgbColor color)
             : m_color(color) {
     }
-
-    SeratoMarkers2ColorEntry()
-            : m_color(kDefaultTrackColor) {
-    }
+    SeratoMarkers2ColorEntry() = delete;
 
     static SeratoMarkers2EntryPointer parse(const QByteArray& data);
 
@@ -192,13 +182,7 @@ class SeratoMarkers2CueEntry : public SeratoMarkers2Entry {
               m_color(color),
               m_label(label) {
     }
-
-    SeratoMarkers2CueEntry()
-            : m_index(0),
-              m_position(0),
-              m_color(kDefaultCueColor),
-              m_label(QString("")) {
-    }
+    SeratoMarkers2CueEntry() = delete;
 
     static SeratoMarkers2EntryPointer parse(const QByteArray& data);
 
@@ -282,14 +266,7 @@ class SeratoMarkers2LoopEntry : public SeratoMarkers2Entry {
               m_locked(locked),
               m_label(label) {
     }
-
-    SeratoMarkers2LoopEntry()
-            : m_index(0),
-              m_startposition(0),
-              m_endposition(0),
-              m_locked(false),
-              m_label(QString("")) {
-    }
+    SeratoMarkers2LoopEntry() = delete;
 
     static SeratoMarkers2EntryPointer parse(const QByteArray& data);
 
@@ -418,6 +395,9 @@ class SeratoMarkers2 final {
     void setEntries(QList<std::shared_ptr<SeratoMarkers2Entry>> entries) {
         m_entries = std::move(entries);
     }
+
+    RgbColor::optional_t getTrackColor() const;
+    bool isBpmLocked() const;
 
   private:
     int m_allocatedSize;

--- a/src/track/serato/tags.cpp
+++ b/src/track/serato/tags.cpp
@@ -2,12 +2,74 @@
 
 namespace mixxx {
 
+RgbColor::optional_t SeratoTags::colorFromStoredTrackColor(RgbColor color) {
+    // Serato stores Track colors differently from how they are displayed in
+    // the library column. Instead of the color from the library view, the
+    // value from the color picker is stored instead (which is different).
+    // To make sure that the track looks the same in both Mixxx' and Serato's
+    // libraries, we need to convert between the two values.
+    //
+    // See this for details:
+    // https://github.com/Holzhaus/serato-tags/blob/master/docs/colors.md#track-colors
+
+    quint32 value = static_cast<quint32>(color);
+
+    if (color == 0xFFFFFF) {
+        return RgbColor::nullopt();
+    }
+
+    if (color == 0x999999) {
+        return RgbColor::optional(0x090909);
+    }
+
+    if (color == 0x000000) {
+        return RgbColor::optional(0x333333);
+    }
+
+    value = (value < 0x666666) ? value + 0x99999A : value - 0x666666;
+    return RgbColor::optional(value);
+}
+
+RgbColor SeratoTags::colorToStoredTrackColor(RgbColor::optional_t color) {
+    if (!color) {
+        return RgbColor(0xFFFFFF);
+    }
+
+    quint32 value = static_cast<quint32>(*color);
+
+    if (value == 0x090909) {
+        return RgbColor(0x999999);
+    }
+
+    if (value == 0x333333) {
+        return RgbColor(0x000000);
+    }
+
+    // Special case: 0x999999 and 0x99999a are not representable as Serato
+    // track color We'll just modify them a little, so that the look the
+    // same in Serato.
+    if (value == 0x999999) {
+        return RgbColor(0x999998);
+    }
+
+    if (value == 0x99999a) {
+        return RgbColor(0x99999b);
+    }
+
+    value = (value < 0x99999A) ? value + 0x666666 : value - 0x99999A;
+    return RgbColor(value);
+}
+
 RgbColor::optional_t SeratoTags::getTrackColor() const {
     RgbColor::optional_t color = m_seratoMarkers.getTrackColor();
 
     if (!color) {
         // Markers_ is empty, but we may have a color in Markers2
         color = m_seratoMarkers2.getTrackColor();
+    }
+
+    if (color) {
+        color = SeratoTags::colorFromStoredTrackColor(*color);
     }
 
     return color;

--- a/src/track/serato/tags.cpp
+++ b/src/track/serato/tags.cpp
@@ -12,8 +12,6 @@ RgbColor::optional_t SeratoTags::storedToDisplayedTrackColor(RgbColor color) {
     // See this for details:
     // https://github.com/Holzhaus/serato-tags/blob/master/docs/colors.md#track-colors
 
-    quint32 value = static_cast<quint32>(color);
-
     if (color == 0xFFFFFF) {
         return RgbColor::nullopt();
     }
@@ -26,8 +24,9 @@ RgbColor::optional_t SeratoTags::storedToDisplayedTrackColor(RgbColor color) {
         return RgbColor::optional(0x333333);
     }
 
-    value = (value < 0x666666) ? value + 0x99999A : value - 0x666666;
-    return RgbColor::optional(value);
+    RgbColor::code_t colorCode = color;
+    colorCode = (colorCode < 0x666666) ? colorCode + 0x99999A : colorCode - 0x666666;
+    return RgbColor::optional(colorCode);
 }
 
 RgbColor SeratoTags::displayedToStoredTrackColor(RgbColor::optional_t color) {
@@ -35,29 +34,29 @@ RgbColor SeratoTags::displayedToStoredTrackColor(RgbColor::optional_t color) {
         return RgbColor(0xFFFFFF);
     }
 
-    quint32 value = static_cast<quint32>(*color);
+    RgbColor::code_t colorCode = *color;
 
-    if (value == 0x090909) {
+    if (colorCode == 0x090909) {
         return RgbColor(0x999999);
     }
 
-    if (value == 0x333333) {
+    if (colorCode == 0x333333) {
         return RgbColor(0x000000);
     }
 
     // Special case: 0x999999 and 0x99999a are not representable as Serato
     // track color We'll just modify them a little, so that the look the
     // same in Serato.
-    if (value == 0x999999) {
+    if (colorCode == 0x999999) {
         return RgbColor(0x999998);
     }
 
-    if (value == 0x99999a) {
+    if (colorCode == 0x99999a) {
         return RgbColor(0x99999b);
     }
 
-    value = (value < 0x99999A) ? value + 0x666666 : value - 0x99999A;
-    return RgbColor(value);
+    colorCode = (colorCode < 0x99999A) ? colorCode + 0x666666 : colorCode - 0x99999A;
+    return RgbColor(colorCode);
 }
 
 RgbColor::optional_t SeratoTags::getTrackColor() const {

--- a/src/track/serato/tags.cpp
+++ b/src/track/serato/tags.cpp
@@ -2,7 +2,7 @@
 
 namespace mixxx {
 
-RgbColor::optional_t SeratoTags::colorFromStoredTrackColor(RgbColor color) {
+RgbColor::optional_t SeratoTags::storedToDisplayedTrackColor(RgbColor color) {
     // Serato stores Track colors differently from how they are displayed in
     // the library column. Instead of the color from the library view, the
     // value from the color picker is stored instead (which is different).
@@ -30,7 +30,7 @@ RgbColor::optional_t SeratoTags::colorFromStoredTrackColor(RgbColor color) {
     return RgbColor::optional(value);
 }
 
-RgbColor SeratoTags::colorToStoredTrackColor(RgbColor::optional_t color) {
+RgbColor SeratoTags::displayedToStoredTrackColor(RgbColor::optional_t color) {
     if (!color) {
         return RgbColor(0xFFFFFF);
     }
@@ -69,7 +69,7 @@ RgbColor::optional_t SeratoTags::getTrackColor() const {
     }
 
     if (color) {
-        color = SeratoTags::colorFromStoredTrackColor(*color);
+        color = SeratoTags::storedToDisplayedTrackColor(*color);
     }
 
     return color;

--- a/src/track/serato/tags.cpp
+++ b/src/track/serato/tags.cpp
@@ -1,0 +1,20 @@
+#include "track/serato/tags.h"
+
+namespace mixxx {
+
+RgbColor::optional_t SeratoTags::getTrackColor() const {
+    RgbColor::optional_t color = m_seratoMarkers.getTrackColor();
+
+    if (!color) {
+        // Markers_ is empty, but we may have a color in Markers2
+        color = m_seratoMarkers2.getTrackColor();
+    }
+
+    return color;
+}
+
+bool SeratoTags::isBpmLocked() const {
+    return m_seratoMarkers2.isBpmLocked();
+}
+
+} // namespace mixxx

--- a/src/track/serato/tags.h
+++ b/src/track/serato/tags.h
@@ -15,6 +15,9 @@ class SeratoTags final {
 
     SeratoTags() = default;
 
+    static RgbColor colorToStoredTrackColor(RgbColor::optional_t color);
+    static RgbColor::optional_t colorFromStoredTrackColor(RgbColor color);
+
     bool isEmpty() const {
         return m_seratoMarkers.isEmpty() && m_seratoMarkers2.isEmpty();
     }

--- a/src/track/serato/tags.h
+++ b/src/track/serato/tags.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "track/serato/markers.h"
+#include "track/serato/markers2.h"
+
+namespace mixxx {
+
+// DTO for storing information from the SeratoMarkers_/2 tags used by the
+// Serato DJ Pro software.
+//
+class SeratoTags final {
+  public:
+    static constexpr RgbColor kDefaultTrackColor = RgbColor(0xFF9999);
+    static constexpr RgbColor kDefaultCueColor = RgbColor(0xCC0000);
+
+    SeratoTags() = default;
+
+    bool isEmpty() const {
+        return m_seratoMarkers.isEmpty() && m_seratoMarkers2.isEmpty();
+    }
+
+    bool parseMarkers(const QByteArray& data) {
+        return SeratoMarkers::parse(&m_seratoMarkers, data);
+    }
+
+    bool parseMarkers2(const QByteArray& data) {
+        return SeratoMarkers2::parse(&m_seratoMarkers2, data);
+    }
+
+    QByteArray dumpMarkers() const {
+        return m_seratoMarkers.dump();
+    }
+
+    QByteArray dumpMarkers2() const {
+        return m_seratoMarkers2.dump();
+    }
+
+    RgbColor::optional_t getTrackColor() const;
+    bool isBpmLocked() const;
+
+  private:
+    SeratoMarkers m_seratoMarkers;
+    SeratoMarkers2 m_seratoMarkers2;
+};
+
+inline bool operator==(const SeratoTags& lhs, const SeratoTags& rhs) {
+    // FIXME: Find a more efficient way to do this
+    return (lhs.dumpMarkers() == rhs.dumpMarkers() && lhs.dumpMarkers2() == rhs.dumpMarkers2());
+}
+
+inline bool operator!=(const SeratoTags& lhs, const SeratoTags& rhs) {
+    return !(lhs == rhs);
+}
+
+inline QDebug operator<<(QDebug dbg, const SeratoTags& arg) {
+    Q_UNUSED(arg);
+
+    // TODO
+    return dbg << "SeratoTags";
+}
+
+} // namespace mixxx
+
+Q_DECLARE_TYPEINFO(mixxx::SeratoTags, Q_MOVABLE_TYPE);
+Q_DECLARE_METATYPE(mixxx::SeratoTags)

--- a/src/track/serato/tags.h
+++ b/src/track/serato/tags.h
@@ -15,8 +15,8 @@ class SeratoTags final {
 
     SeratoTags() = default;
 
-    static RgbColor colorToStoredTrackColor(RgbColor::optional_t color);
-    static RgbColor::optional_t colorFromStoredTrackColor(RgbColor color);
+    static RgbColor::optional_t storedToDisplayedTrackColor(RgbColor color);
+    static RgbColor displayedToStoredTrackColor(RgbColor::optional_t color);
 
     bool isEmpty() const {
         return m_seratoMarkers.isEmpty() && m_seratoMarkers2.isEmpty();

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -128,6 +128,15 @@ void Track::importMetadata(
     const auto newBpm = importedMetadata.getTrackInfo().getBpm();
     const auto newKey = importedMetadata.getTrackInfo().getKey();
     const auto newReplayGain = importedMetadata.getTrackInfo().getReplayGain();
+    const auto newSeratoMarkers = importedMetadata.getTrackInfo().getSeratoMarkers();
+#ifdef __EXTRA_METADATA__
+    {
+        // enter locking scope
+        QMutexLocker lock(&m_qMutex);
+        newSeratoMarkers.syncToTrackObject(this);
+        // implicitly unlocked when leaving scope
+    }
+#endif // __EXTRA_METADATA__
 
     {
         // enter locking scope

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -128,12 +128,18 @@ void Track::importMetadata(
     const auto newBpm = importedMetadata.getTrackInfo().getBpm();
     const auto newKey = importedMetadata.getTrackInfo().getKey();
     const auto newReplayGain = importedMetadata.getTrackInfo().getReplayGain();
-    const auto newSeratoMarkers = importedMetadata.getTrackInfo().getSeratoMarkers();
 #ifdef __EXTRA_METADATA__
+    const auto newSeratoMarkers = importedMetadata.getTrackInfo().getSeratoMarkers();
+    const auto newSeratoMarkers2 = importedMetadata.getTrackInfo().getSeratoMarkers2();
     {
         // enter locking scope
         QMutexLocker lock(&m_qMutex);
-        newSeratoMarkers.syncToTrackObject(this);
+        // Import "Serato Markers2" first, then overwrite values with those
+        // from "Serato Markers_". This is what Serato does too (i.e. if
+        // "Serato Markers_" and "Serato Markers2" contradict each other,
+        // Serato will use the values from "Serato Markers_").
+        newSeratoMarkers2.syncToTrackObject(this);
+        newSeratoMarkers.syncToTrackObject(this, true);
         // implicitly unlocked when leaving scope
     }
 #endif // __EXTRA_METADATA__

--- a/src/track/trackinfo.cpp
+++ b/src/track/trackinfo.cpp
@@ -75,8 +75,7 @@ bool TrackInfo::compareEq(
 #endif // __EXTRA_METADATA__
             (getReplayGain() == trackInfo.getReplayGain()) &&
 #if defined(__EXTRA_METADATA__)
-            (getSeratoMarkers() == trackInfo.getSeratoMarkers()) &&
-            (getSeratoMarkers2() == trackInfo.getSeratoMarkers2()) &&
+            (getSeratoTags() == trackInfo.getSeratoTags()) &&
             (getSubtitle() == trackInfo.getSubtitle()) &&
 #endif // __EXTRA_METADATA__
             (getTitle() == trackInfo.getTitle()) &&
@@ -120,7 +119,7 @@ QDebug operator<<(QDebug dbg, const TrackInfo& arg) {
 #endif // __EXTRA_METADATA__
     arg.dbgReplayGain(dbg);
 #if defined(__EXTRA_METADATA__)
-    arg.dbgSeratoMarkers2(dbg);
+    arg.dbgSeratoTags(dbg);
     arg.dbgSubtitle(dbg);
 #endif // __EXTRA_METADATA__
     arg.dbgTitle(dbg);

--- a/src/track/trackinfo.h
+++ b/src/track/trackinfo.h
@@ -6,8 +6,7 @@
 #include "sources/audiosource.h"
 #include "track/bpm.h"
 #include "track/replaygain.h"
-#include "track/serato/markers.h"
-#include "track/serato/markers2.h"
+#include "track/serato/tags.h"
 #include "util/duration.h"
 #include "util/macros.h"
 
@@ -45,8 +44,7 @@ class TrackInfo final {
 #endif // __EXTRA_METADATA__
     PROPERTY_SET_BYVAL_GET_BYREF(ReplayGain, replayGain,           ReplayGain)
 #if defined(__EXTRA_METADATA__)
-    PROPERTY_SET_BYVAL_GET_BYREF(SeratoMarkers, seratoMarkers, SeratoMarkers)
-    PROPERTY_SET_BYVAL_GET_BYREF(SeratoMarkers2, seratoMarkers2,   SeratoMarkers2)
+    PROPERTY_SET_BYVAL_GET_BYREF(SeratoTags, seratoTags,           SeratoTags)
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    subtitle,             Subtitle)
 #endif // __EXTRA_METADATA__
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    title,                Title)

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -419,10 +419,10 @@ bool parseSeratoMarkers(
         const QByteArray& data) {
     DEBUG_ASSERT(pTrackMetadata);
 
-    SeratoMarkers seratoMarkers(pTrackMetadata->getTrackInfo().getSeratoMarkers());
-    bool isValid = SeratoMarkers::parse(&seratoMarkers, data);
+    SeratoTags seratoTags(pTrackMetadata->getTrackInfo().getSeratoTags());
+    bool isValid = seratoTags.parseMarkers(data);
     if (isValid) {
-        pTrackMetadata->refTrackInfo().setSeratoMarkers(seratoMarkers);
+        pTrackMetadata->refTrackInfo().setSeratoTags(seratoTags);
     }
     return isValid;
 }
@@ -432,10 +432,10 @@ bool parseSeratoMarkers2(
         const QByteArray& data) {
     DEBUG_ASSERT(pTrackMetadata);
 
-    SeratoMarkers2 seratoMarkers2(pTrackMetadata->getTrackInfo().getSeratoMarkers2());
-    bool isValid = SeratoMarkers2::parse(&seratoMarkers2, data);
+    SeratoTags seratoTags(pTrackMetadata->getTrackInfo().getSeratoTags());
+    bool isValid = seratoTags.parseMarkers2(data);
     if (isValid) {
-        pTrackMetadata->refTrackInfo().setSeratoMarkers2(seratoMarkers2);
+        pTrackMetadata->refTrackInfo().setSeratoTags(seratoTags);
     }
     return isValid;
 }
@@ -2516,11 +2516,11 @@ bool exportTrackMetadataIntoID3v2Tag(TagLib::ID3v2::Tag* pTag,
     writeID3v2GeneralEncapsulatedObjectFrame(
             pTag,
             "Serato Markers_",
-            trackMetadata.getTrackInfo().getSeratoMarkers().dump());
+            trackMetadata.getTrackInfo().getSeratoTags().dumpMarkers());
     writeID3v2GeneralEncapsulatedObjectFrame(
             pTag,
             "Serato Markers2",
-            trackMetadata.getTrackInfo().getSeratoMarkers2().dump());
+            trackMetadata.getTrackInfo().getSeratoTags().dumpMarkers2());
 #endif // __EXTRA_METADATA__
 
     return true;

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -120,8 +120,7 @@ void TrackRecord::mergeImportedMetadata(
     copyIfNotNull(mergedTrackInfo.refMusicBrainzReleaseId(), importedTrackInfo.getMusicBrainzReleaseId());
     copyIfNotNull(mergedTrackInfo.refMusicBrainzWorkId(), importedTrackInfo.getMusicBrainzWorkId());
     copyIfNotNull(mergedTrackInfo.refRemixer(), importedTrackInfo.getRemixer());
-    copyIfNotEmpty(mergedTrackInfo.refSeratoMarkers(), importedTrackInfo.getSeratoMarkers());
-    copyIfNotEmpty(mergedTrackInfo.refSeratoMarkers2(), importedTrackInfo.getSeratoMarkers2());
+    copyIfNotEmpty(mergedTrackInfo.refSeratoTags(), importedTrackInfo.getSeratoTags());
     copyIfNotNull(mergedTrackInfo.refSubtitle(), importedTrackInfo.getSubtitle());
     copyIfNotNull(mergedTrackInfo.refWork(), importedTrackInfo.getWork());
     AlbumInfo& mergedAlbumInfo = refMetadata().refAlbumInfo();

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -120,6 +120,7 @@ void TrackRecord::mergeImportedMetadata(
     copyIfNotNull(mergedTrackInfo.refMusicBrainzReleaseId(), importedTrackInfo.getMusicBrainzReleaseId());
     copyIfNotNull(mergedTrackInfo.refMusicBrainzWorkId(), importedTrackInfo.getMusicBrainzWorkId());
     copyIfNotNull(mergedTrackInfo.refRemixer(), importedTrackInfo.getRemixer());
+    copyIfNotEmpty(mergedTrackInfo.refSeratoMarkers(), importedTrackInfo.getSeratoMarkers());
     copyIfNotEmpty(mergedTrackInfo.refSeratoMarkers2(), importedTrackInfo.getSeratoMarkers2());
     copyIfNotNull(mergedTrackInfo.refSubtitle(), importedTrackInfo.getSubtitle());
     copyIfNotNull(mergedTrackInfo.refWork(), importedTrackInfo.getWork());


### PR DESCRIPTION
This adds support for reading the `Serato Markers_` and `Serato Markers2` tag that are written by Serato and contains Cues, Loops, Track Color, etc. 

This PR supersedes #2473 and depends on #2495. As @daschuer suggested I removed export support for now.

**IMPORTANT:** You need to apply this patch to enable the actual integration:
```diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 59564fa2c0..614b65a808 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -698,6 +698,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
 set_target_properties(mixxx-lib PROPERTIES AUTOMOC ON AUTOUIC ON)
 target_include_directories(mixxx-lib PUBLIC src "${CMAKE_CURRENT_BINARY_DIR}/src")
 target_compile_definitions(mixxx-lib PRIVATE SETTINGS_FILE="mixxx.cfg")
+target_compile_definitions(mixxx-lib PUBLIC __EXTRA_METADATA__)
 if(UNIX AND NOT APPLE)
   target_compile_definitions(mixxx-lib PRIVATE SETTINGS_PATH=".mixxx/")
 endif()
```