### PR TITLE
TreeItem: Initialize LibraryFeature consistently

### DIFF
--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -69,7 +69,7 @@ AutoDJFeature::AutoDJFeature(Library* pLibrary,
     m_playlistDao.setAutoDJProcessor(m_pAutoDJProcessor);
 
     // Create the "Crates" tree-item under the root item.
-    auto pRootItem = std::make_unique<TreeItem>(this);
+    std::unique_ptr<TreeItem> pRootItem = TreeItem::newRoot(this);
     m_pCratesTreeItem = pRootItem->appendChild(tr("Crates"));
     m_pCratesTreeItem->setIcon(QIcon(":/images/library/ic_library_crates.svg"));
 
@@ -215,7 +215,7 @@ void AutoDJFeature::slotCrateChanged(CrateId crateId) {
         // No child item for crate found
         // -> Create and append a new child item for this crate
         QList<TreeItem*> rows;
-        rows.append(new TreeItem(this, crate.getName(), crate.getId().toVariant()));
+        rows.append(new TreeItem(crate.getName(), crate.getId().toVariant()));
         QModelIndex parentIndex = m_childModel.index(0, 0);
         m_childModel.insertTreeItemRows(rows, m_crateList.length(), parentIndex);
         DEBUG_ASSERT(rows.isEmpty()); // ownership passed to m_childModel

--- a/src/library/banshee/bansheefeature.cpp
+++ b/src/library/banshee/bansheefeature.cpp
@@ -91,7 +91,7 @@ void BansheeFeature::activate() {
 
         m_isActivated =  true;
 
-        auto pRootItem = std::make_unique<TreeItem>(this);
+        std::unique_ptr<TreeItem> pRootItem = TreeItem::newRoot(this);
         QList<BansheeDbConnection::Playlist> playlists = m_connection.getPlaylists();
         for (const BansheeDbConnection::Playlist& playlist: playlists) {
             qDebug() << playlist.name;

--- a/src/library/baseplaylistfeature.cpp
+++ b/src/library/baseplaylistfeature.cpp
@@ -677,7 +677,7 @@ QModelIndex BasePlaylistFeature::constructChildModel(int selected_id) {
         }
 
         // Create the TreeItem whose parent is the invisible root item
-        TreeItem* item = new TreeItem(this, playlistLabel, playlistId);
+        TreeItem* item = new TreeItem(playlistLabel, playlistId);
         item->setBold(m_playlistsSelectedTrackIsIn.contains(playlistId));
 
         decorateChild(item, playlistId);

--- a/src/library/crate/cratefeature.cpp
+++ b/src/library/crate/cratefeature.cpp
@@ -52,7 +52,7 @@ CrateFeature::CrateFeature(Library* pLibrary,
     initActions();
 
     // construct child model
-    m_childModel.setRootItem(std::make_unique<TreeItem>(this));
+    m_childModel.setRootItem(TreeItem::newRoot(this));
     rebuildChildModel();
 
     connectLibrary(pLibrary);
@@ -192,7 +192,7 @@ QString CrateFeature::formatRootViewHtml() const {
 
 std::unique_ptr<TreeItem> CrateFeature::newTreeItemForCrateSummary(
         const CrateSummary& crateSummary) {
-    auto pTreeItem = std::make_unique<TreeItem>(this);
+    auto pTreeItem = TreeItem::newRoot(this);
     updateTreeItemForCrateSummary(pTreeItem.get(), crateSummary);
     return pTreeItem;
 }

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -643,7 +643,7 @@ void ITunesFeature::parseTrack(QXmlStreamReader& xml, QSqlQuery& query) {
 
 TreeItem* ITunesFeature::parsePlaylists(QXmlStreamReader& xml) {
     qDebug() << "Parse iTunes playlists";
-    TreeItem* rootItem = new TreeItem(this);
+    std::unique_ptr<TreeItem> pRootItem = TreeItem::newRoot(this);
     QSqlQuery query_insert_to_playlists(m_database);
     query_insert_to_playlists.prepare("INSERT INTO itunes_playlists (id, name) "
                                       "VALUES (:id, :name)");
@@ -660,7 +660,7 @@ TreeItem* ITunesFeature::parsePlaylists(QXmlStreamReader& xml) {
             parsePlaylist(xml,
                           query_insert_to_playlists,
                           query_insert_to_playlist_tracks,
-                          rootItem);
+                          pRootItem.get());
             continue;
         }
         if (xml.isEndElement()) {
@@ -668,7 +668,7 @@ TreeItem* ITunesFeature::parsePlaylists(QXmlStreamReader& xml) {
                 break;
         }
     }
-    return rootItem;
+    return pRootItem.release();
 }
 
 bool ITunesFeature::readNextStartElement(QXmlStreamReader& xml) {

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -95,7 +95,7 @@ MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
     // These rely on the 'default' track source being present.
     m_pLibraryTableModel = new LibraryTableModel(this, pLibrary->trackCollections(), "mixxx.db.model.library");
 
-    auto pRootItem = std::make_unique<TreeItem>(this);
+    std::unique_ptr<TreeItem> pRootItem = TreeItem::newRoot(this);
     pRootItem->appendChild(kMissingTitle);
     pRootItem->appendChild(kHiddenTitle);
 

--- a/src/library/playlistfeature.cpp
+++ b/src/library/playlistfeature.cpp
@@ -49,7 +49,7 @@ PlaylistFeature::PlaylistFeature(
             "mixxx.db.model.playlist"));
 
     //construct child model
-    auto pRootItem = std::make_unique<TreeItem>(this);
+    std::unique_ptr<TreeItem> pRootItem = TreeItem::newRoot(this);
     m_childModel.setRootItem(std::move(pRootItem));
     constructChildModel(-1);
 }

--- a/src/library/rhythmbox/rhythmboxfeature.cpp
+++ b/src/library/rhythmbox/rhythmboxfeature.cpp
@@ -216,7 +216,7 @@ TreeItem* RhythmboxFeature::importPlaylists() {
             "INSERT INTO rhythmbox_playlist_tracks (playlist_id, track_id, position) "
             "VALUES (:playlist_id, :track_id, :position)");
     //The tree structure holding the playlists
-    TreeItem* rootItem = new TreeItem(this);
+    std::unique_ptr<TreeItem> rootItem = TreeItem::newRoot(this);
 
     QXmlStreamReader xml(&db);
     while (!xml.atEnd() && !m_cancelImport) {
@@ -253,13 +253,11 @@ TreeItem* RhythmboxFeature::importPlaylists() {
         // do error handling
         qDebug() << "Cannot process Rhythmbox music collection";
         qDebug() << "XML ERROR: " << xml.errorString();
-        delete rootItem;
-        return NULL;
+        return nullptr;
     }
     db.close();
 
-    return rootItem;
-
+    return rootItem.release();
 }
 
 void RhythmboxFeature::importTrack(QXmlStreamReader &xml, QSqlQuery &query) {

--- a/src/library/setlogfeature.cpp
+++ b/src/library/setlogfeature.cpp
@@ -34,8 +34,7 @@ SetlogFeature::SetlogFeature(
             /*show-all-tracks*/ true));
 
     //construct child model
-    auto pRootItem = std::make_unique<TreeItem>(this);
-    m_childModel.setRootItem(std::move(pRootItem));
+    m_childModel.setRootItem(TreeItem::newRoot(this));
     constructChildModel(-1);
 
     m_pJoinWithPreviousAction = new QAction(tr("Join with previous"), this);

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -390,8 +390,8 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
 
     QString delimiter = "-->";
 
-    TreeItem *rootItem = new TreeItem(this);
-    TreeItem * parent = rootItem;
+    std::unique_ptr<TreeItem> rootItem = TreeItem::newRoot(this);
+    TreeItem* parent = rootItem.get();
 
     QSqlQuery query_insert_to_playlists(m_database);
     query_insert_to_playlists.prepare("INSERT INTO traktor_playlists (name) "
@@ -452,7 +452,7 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
             }
         }
     }
-    return rootItem;
+    return rootItem.release();
 }
 
 void TraktorFeature::parsePlaylistEntries(

--- a/src/library/treeitem.cpp
+++ b/src/library/treeitem.cpp
@@ -101,15 +101,11 @@ void TreeItem::removeChild(int row) {
     delete m_children.takeAt(row);
 }
 
-void TreeItem::insertChildren(QList<TreeItem*>& children, int row, int count) {
-    DEBUG_ASSERT(feature() != nullptr);
-    DEBUG_ASSERT(count >= 0);
-    DEBUG_ASSERT(count <= children.size());
+void TreeItem::insertChildren(QList<TreeItem*>& children, int row) {
     Q_UNUSED(row); // only used in DEBUG_ASSERT
     DEBUG_ASSERT(row >= 0);
     DEBUG_ASSERT(row <= m_children.size());
-    for (int counter = 0; counter < count; ++counter) {
-        DEBUG_ASSERT(!children.empty());
+    while (!children.isEmpty()) {
         TreeItem* pChild = children.front();
         appendChild(pChild);
         children.pop_front();

--- a/src/library/treeitem.h
+++ b/src/library/treeitem.h
@@ -1,5 +1,4 @@
-#ifndef MIXXX_TREEITEM_H
-#define MIXXX_TREEITEM_H
+#pragma once
 
 #include <QList>
 #include <QString>
@@ -11,14 +10,31 @@
 
 
 class TreeItem final {
-  public:
-    static const int kInvalidRow = -1;
+    struct PrivateRootTag {};
 
-    TreeItem();
+  public:
+    static constexpr int kInvalidRow = -1;
+
+    static std::unique_ptr<TreeItem> newRoot(
+            LibraryFeature* pFeature) {
+        DEBUG_ASSERT(pFeature);
+        return std::make_unique<TreeItem>(pFeature, PrivateRootTag{});
+    }
+
     explicit TreeItem(
+            QString label = QString(),
+            QVariant data = QVariant())
+            : TreeItem(nullptr, std::move(label), std::move(data)) {
+    }
+    // This constructor should actually be private. But that wouldn't
+    // work for std::make_unique(). The private, nested tag essentially
+    // makes this constructor unavailable for everyone else.
+    TreeItem(
             LibraryFeature* pFeature,
-            const QString& label = QString(),
-            const QVariant& data = QVariant());
+            PrivateRootTag)
+            : TreeItem(pFeature) {
+    }
+
     ~TreeItem();
 
 
@@ -27,6 +43,9 @@ class TreeItem final {
     /////////////////////////////////////////////////////////////////////////
 
     LibraryFeature* feature() const {
+        DEBUG_ASSERT(
+                !m_pParent ||
+                m_pParent->m_pFeature == m_pFeature);
         return m_pFeature;
     }
 
@@ -68,11 +87,15 @@ class TreeItem final {
     TreeItem* appendChild(
             std::unique_ptr<TreeItem> pChild);
     TreeItem* appendChild(
-            const QString& label,
-            const QVariant& data = QVariant());
+            QString label,
+            QVariant data = QVariant());
     void removeChild(int row);
 
     // multiple child items
+    void insertChildren(QList<TreeItem*> children, int row) {
+        insertChildren(children, row, children.size());
+        DEBUG_ASSERT(children.isEmpty()); // took ownership
+    }
     void insertChildren(QList<TreeItem*>& children, int row, int count); // take ownership
     void removeChildren(int row, int count);
 
@@ -110,11 +133,21 @@ class TreeItem final {
     }
 
   private:
-    void appendChild(TreeItem* pChild);
+    explicit TreeItem(
+            LibraryFeature* pFeature,
+            QString label = QString(),
+            QVariant data = QVariant());
 
+    void appendChild(TreeItem* pChild);
+    void initFeatureRecursively(LibraryFeature* pFeature);
+
+    // The library feature is inherited from the parent.
+    // For all child items this is just a shortcut to the
+    // library feature of the root item!
     LibraryFeature* m_pFeature;
 
     TreeItem* m_pParent;
+
     QList<TreeItem*> m_children; // owned child items
 
     QString m_label;
@@ -122,5 +155,3 @@ class TreeItem final {
     QIcon m_icon;
     bool m_bold;
 };
-
-#endif // MIXXX_TREEITEM_H

--- a/src/library/treeitem.h
+++ b/src/library/treeitem.h
@@ -92,7 +92,8 @@ class TreeItem final {
     void removeChild(int row);
 
     // multiple child items
-    void insertChildren(QList<TreeItem*>& children, int row); // take ownership
+    // take ownership of children items
+    void insertChildren(int row, QList<TreeItem*>& children);
     void removeChildren(int row, int count);
 
 
@@ -134,7 +135,7 @@ class TreeItem final {
             QString label = QString(),
             QVariant data = QVariant());
 
-    void appendChild(TreeItem* pChild);
+    void insertChild(int row, TreeItem* pChild);
     void initFeatureRecursively(LibraryFeature* pFeature);
 
     // The library feature is inherited from the parent.

--- a/src/library/treeitem.h
+++ b/src/library/treeitem.h
@@ -92,11 +92,7 @@ class TreeItem final {
     void removeChild(int row);
 
     // multiple child items
-    void insertChildren(QList<TreeItem*> children, int row) {
-        insertChildren(children, row, children.size());
-        DEBUG_ASSERT(children.isEmpty()); // took ownership
-    }
-    void insertChildren(QList<TreeItem*>& children, int row, int count); // take ownership
+    void insertChildren(QList<TreeItem*>& children, int row); // take ownership
     void removeChildren(int row, int count);
 
 

--- a/src/library/treeitemmodel.cpp
+++ b/src/library/treeitemmodel.cpp
@@ -177,7 +177,8 @@ void TreeItemModel::insertTreeItemRows(
     DEBUG_ASSERT(pParentItem != nullptr);
 
     beginInsertRows(parent, position, position + rows.size() - 1);
-    pParentItem->insertChildren(rows, position);
+    pParentItem->insertChildren(position, rows);
+    DEBUG_ASSERT(rows.isEmpty());
     endInsertRows();
 }
 

--- a/src/library/treeitemmodel.cpp
+++ b/src/library/treeitemmodel.cpp
@@ -177,7 +177,7 @@ void TreeItemModel::insertTreeItemRows(
     DEBUG_ASSERT(pParentItem != nullptr);
 
     beginInsertRows(parent, position, position + rows.size() - 1);
-    pParentItem->insertChildren(rows, position, rows.size());
+    pParentItem->insertChildren(rows, position);
     endInsertRows();
 }
 


### PR DESCRIPTION
This refactoring avoids that `LibraryFeature*` needs to be passed to worker threads while importing/loading external libraries. Even if the contents of the object itself are not accessed from within the worker thread, we should prevent such unsafe runtime dependencies in the first place!

`LibraryFeature*` is now only passed to the root node and derived for all child nodes.