### PR TITLE
Track->TrackDAO: Simplify changed/clean/dirty signals

### DIFF
--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -77,30 +77,7 @@ void BaseTrackCache::connectTrackDAO(TrackDAO* pTrackDAO) {
 }
 
 void BaseTrackCache::disconnectTrackDAO(TrackDAO* pTrackDAO) {
-    disconnect(pTrackDAO,
-            &TrackDAO::trackDirty,
-            this,
-            &BaseTrackCache::slotTrackDirty);
-    disconnect(pTrackDAO,
-            &TrackDAO::trackClean,
-            this,
-            &BaseTrackCache::slotTrackClean);
-    disconnect(pTrackDAO,
-            &TrackDAO::trackChanged,
-            this,
-            &BaseTrackCache::slotTrackChanged);
-    disconnect(pTrackDAO,
-            &TrackDAO::tracksAdded,
-            this,
-            &BaseTrackCache::slotTracksAdded);
-    disconnect(pTrackDAO,
-            &TrackDAO::tracksRemoved,
-            this,
-            &BaseTrackCache::slotTracksRemoved);
-    disconnect(pTrackDAO,
-            &TrackDAO::dbTrackAdded,
-            this,
-            &BaseTrackCache::slotDbTrackAdded);
+    disconnect(pTrackDAO);
 }
 
 BaseTrackCache::~BaseTrackCache() {

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1311,24 +1311,25 @@ TrackPointer TrackDAO::getTrackById(TrackId trackId) const {
         SoundSourceProxy(pTrack).updateTrackFromSource();
     }
 
-    // Listen to dirty and changed signals from Track objects.
-    // These signal/signal connections are required to forward signals
-    // from Track objects to BaseTrackCache and AutoDJ.
-    // Since only the TrackId is sent it doesn't matter if the signal
-    // gets sent from another thread and the Track object itself has
-    // already deleted in memory when receiving this signal.
+    // Listen to signals from Track objects and forward them to
+    // receivers. TrackDAO works as a relay for selected track signals
+    // that allows receivers to use permament connections with
+    // TrackDAO instead of connecting to individual Track objects.
     connect(pTrack.get(),
             &Track::dirty,
             this,
-            &TrackDAO::trackDirty);
+            &TrackDAO::trackDirty,
+            /*signal-to-signal*/ Qt::DirectConnection);
     connect(pTrack.get(),
             &Track::clean,
             this,
-            &TrackDAO::trackClean);
+            &TrackDAO::trackClean,
+            /*signal-to-signal*/ Qt::DirectConnection);
     connect(pTrack.get(),
             &Track::changed,
             this,
-            &TrackDAO::trackChanged);
+            &TrackDAO::trackChanged,
+            /*signal-to-signal*/ Qt::DirectConnection);
 
     // BaseTrackCache cares about track trackDirty/trackClean notifications
     // from TrackDAO that are triggered by the track itself. But the preceding

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1316,8 +1316,7 @@ TrackPointer TrackDAO::getTrackById(TrackId trackId) const {
     // from Track objects to BaseTrackCache and AutoDJ.
     // Since only the TrackId is sent it doesn't matter if the signal
     // gets sent from another thread and the Track object itself has
-    // already deleted in memory when receiving this signal. Using
-    // a Qt::DirectConnection for this purpose would be unsafe!!
+    // already deleted in memory when receiving this signal.
     connect(pTrack.get(),
             &Track::dirty,
             this,

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -89,11 +89,6 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     void databaseTracksChanged(QSet<TrackId> changedTracks);
     void databaseTracksRelocated(QList<RelocatedTrack> relocatedTracks);
 
-  private slots:
-    void slotTrackDirty(TrackId trackId);
-    void slotTrackChanged(TrackId trackId);
-    void slotTrackClean(TrackId trackId);
-
   private:
     friend class LibraryScanner;
     friend class TrackCollection;

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -90,9 +90,9 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     void databaseTracksRelocated(QList<RelocatedTrack> relocatedTracks);
 
   private slots:
-    void slotTrackDirty(Track* pTrack);
-    void slotTrackChanged(Track* pTrack);
-    void slotTrackClean(Track* pTrack);
+    void slotTrackDirty(TrackId trackId);
+    void slotTrackChanged(TrackId trackId);
+    void slotTrackClean(TrackId trackId);
 
   private:
     friend class LibraryScanner;

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -44,23 +44,28 @@ void DlgTagFetcher::loadTrack(const TrackPointer& track) {
         return;
     }
     results->clear();
-    disconnect(track.get(), &Track::changed,
-            this, &DlgTagFetcher::updateTrackMetadata);
+    disconnect(track.get(),
+            &Track::changed,
+            this,
+            &DlgTagFetcher::slotTrackChanged);
 
     m_track = track;
     m_data = Data();
     m_networkResult = NetworkResult::Ok;
     m_tagFetcher.startFetch(m_track);
 
-    connect(track.get(), &Track::changed,
-            this, &DlgTagFetcher::updateTrackMetadata);
+    connect(track.get(),
+            &Track::changed,
+            this,
+            &DlgTagFetcher::slotTrackChanged);
 
     updateStack();
 }
 
-void DlgTagFetcher::updateTrackMetadata(Track* pTIO) {
-    Q_UNUSED(pTIO);
-    updateStack();
+void DlgTagFetcher::slotTrackChanged(TrackId trackId) {
+    if (m_track && m_track->getId() == trackId) {
+        updateStack();
+    }
 }
 
 void DlgTagFetcher::apply() {

--- a/src/library/dlgtagfetcher.h
+++ b/src/library/dlgtagfetcher.h
@@ -19,7 +19,6 @@ class DlgTagFetcher : public QDialog,  public Ui::DlgTagFetcher {
 
   public slots:
     void loadTrack(const TrackPointer& track);
-    void updateTrackMetadata(Track* pTIO);
 
   signals:
     void next();
@@ -30,6 +29,7 @@ class DlgTagFetcher : public QDialog,  public Ui::DlgTagFetcher {
     void resultSelected();
     void fetchTagProgress(QString);
     void slotNetworkResult(int httpStatus, QString app, QString message, int code);
+    void slotTrackChanged(TrackId trackId);
     void apply();
     void quit();
 

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -555,11 +555,13 @@ void DlgTrackInfo::unloadTrack(bool save) {
 }
 
 void DlgTrackInfo::clear() {
-    disconnect(m_pLoadedTrack.get(),
-            &Track::changed,
-            this,
-            &DlgTrackInfo::slotTrackChanged);
-    m_pLoadedTrack.reset();
+    if (m_pLoadedTrack) {
+        disconnect(m_pLoadedTrack.get(),
+                &Track::changed,
+                this,
+                &DlgTrackInfo::slotTrackChanged);
+        m_pLoadedTrack.reset();
+    }
 
     txtTrackName->setText("");
     txtArtist->setText("");

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -271,7 +271,7 @@ void DlgTrackInfo::loadTrack(TrackPointer pTrack) {
     connect(pTrack.get(),
             &Track::changed,
             this,
-            &DlgTrackInfo::updateTrackMetadata);
+            &DlgTrackInfo::slotTrackChanged);
 }
 
 void DlgTrackInfo::slotCoverFound(const QObject* pRequestor,
@@ -448,7 +448,7 @@ void DlgTrackInfo::saveTrack() {
     disconnect(m_pLoadedTrack.get(),
             &Track::changed,
             this,
-            &DlgTrackInfo::updateTrackMetadata);
+            &DlgTrackInfo::slotTrackChanged);
 
     m_pLoadedTrack->setTitle(txtTrackName->text());
     m_pLoadedTrack->setArtist(txtArtist->text());
@@ -540,7 +540,7 @@ void DlgTrackInfo::saveTrack() {
     connect(m_pLoadedTrack.get(),
             &Track::changed,
             this,
-            &DlgTrackInfo::updateTrackMetadata);
+            &DlgTrackInfo::slotTrackChanged);
 }
 
 void DlgTrackInfo::unloadTrack(bool save) {
@@ -558,7 +558,7 @@ void DlgTrackInfo::clear() {
     disconnect(m_pLoadedTrack.get(),
             &Track::changed,
             this,
-            &DlgTrackInfo::updateTrackMetadata);
+            &DlgTrackInfo::slotTrackChanged);
     m_pLoadedTrack.reset();
 
     txtTrackName->setText("");
@@ -742,8 +742,8 @@ void DlgTrackInfo::slotImportMetadataFromFile() {
     }
 }
 
-void DlgTrackInfo::updateTrackMetadata() {
-    if (m_pLoadedTrack) {
+void DlgTrackInfo::slotTrackChanged(TrackId trackId) {
+    if (m_pLoadedTrack && m_pLoadedTrack->getId() == trackId) {
         populateFields(*m_pLoadedTrack);
     }
 }

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -58,7 +58,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void slotImportMetadataFromFile();
     void slotImportMetadataFromMusicBrainz();
 
-    void updateTrackMetadata();
+    void slotTrackChanged(TrackId trackId);
     void slotOpenInFileBrowser();
 
     void slotCoverFound(const QObject* pRequestor,

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -795,19 +795,23 @@ void Track::setDirtyAndUnlock(QMutexLocker* pLock, bool bDirty) {
     const bool dirtyChanged = m_bDirty != bDirty;
     m_bDirty = bDirty;
 
+    const auto trackId = m_record.getId();
+
     // Unlock before emitting any signals!
     pLock->unlock();
 
-    if (dirtyChanged) {
-        if (bDirty) {
-            emit dirty(this);
-        } else {
-            emit clean(this);
+    if (trackId.isValid()) {
+        if (dirtyChanged) {
+            if (bDirty) {
+                emit dirty(trackId);
+            } else {
+                emit clean(trackId);
+            }
         }
-    }
-    if (bDirty) {
-        // Emit a changed signal regardless if this attempted to set us dirty.
-        emit changed(this);
+        if (bDirty) {
+            // Emit a changed signal regardless if this attempted to set us dirty.
+            emit changed(trackId);
+        }
     }
 }
 

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -314,9 +314,10 @@ class Track : public QObject {
     void keysUpdated();
     void ReplayGainUpdated(mixxx::ReplayGain replayGain);
     void cuesUpdated();
-    void changed(Track* pTrack);
-    void dirty(Track* pTrack);
-    void clean(Track* pTrack);
+
+    void changed(TrackId trackId);
+    void dirty(TrackId trackId);
+    void clean(TrackId trackId);
 
   private slots:
     void slotCueUpdated();

--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -39,14 +39,14 @@ void WCoverArtLabel::setCoverArt(const CoverInfo& coverInfo,
                                  QPixmap px) {
     qDebug() << "WCoverArtLabel::setCoverArt" << coverInfo << px.size();
 
-    m_loadedCover = px.scaled(s_labelDisplaySize * getDevicePixelRatioF(this),
-            Qt::KeepAspectRatio, Qt::SmoothTransformation);
-    m_loadedCover.setDevicePixelRatio(getDevicePixelRatioF(this));
     m_pCoverMenu->setCoverArt(coverInfo);
-
-    if (m_loadedCover.isNull()) {
+    if (px.isNull()) {
+        m_loadedCover = px;
         setPixmap(m_defaultCover);
     } else {
+        m_loadedCover = px.scaled(s_labelDisplaySize * getDevicePixelRatioF(this),
+                Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        m_loadedCover.setDevicePixelRatio(getDevicePixelRatioF(this));
         setPixmap(m_loadedCover);
     }
 

--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -77,4 +77,3 @@ void WCoverArtLabel::mousePressEvent(QMouseEvent* event) {
         }
     }
 }
-

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -47,8 +47,10 @@ void WStarRating::slotTrackLoaded(TrackPointer pTrack) {
             m_pCurrentTrack.reset();
         }
         if (pTrack) {
-            connect(pTrack.get(), SIGNAL(changed(Track*)),
-                    this, SLOT(updateRating(Track*)));
+            connect(pTrack.get(),
+                    &Track::changed,
+                    this,
+                    &WStarRating::slotTrackChanged);
             m_pCurrentTrack = pTrack;
         }
         updateRating();
@@ -64,7 +66,8 @@ void WStarRating::updateRating() {
     update();
 }
 
-void WStarRating::updateRating(Track* /*unused*/) {
+void WStarRating::slotTrackChanged(TrackId trackId) {
+    Q_UNUSED(trackId);
     updateRating();
 }
 

--- a/src/widget/wstarrating.h
+++ b/src/widget/wstarrating.h
@@ -28,7 +28,7 @@ class WStarRating : public WWidget {
     void slotTrackLoaded(TrackPointer pTrack = TrackPointer());
 
   private slots:
-    void updateRating(Track*);
+    void slotTrackChanged(TrackId);
     void slotStarsUp(double v);
     void slotStarsDown(double v);
 
@@ -45,11 +45,11 @@ class WStarRating : public WWidget {
     bool m_focused;
     mutable QRect m_contentRect;
 
-    private:
-        void updateRating();
-        int starAtPosition(int x);
-        std::unique_ptr<ControlPushButton> m_pStarsUp;
-        std::unique_ptr<ControlPushButton> m_pStarsDown;
+  private:
+    void updateRating();
+    int starAtPosition(int x);
+    std::unique_ptr<ControlPushButton> m_pStarsUp;
+    std::unique_ptr<ControlPushButton> m_pStarsDown;
 };
 
 #endif /* WSTARRATING_H */

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -24,9 +24,11 @@ void WTrackProperty::setup(const QDomNode& node, const SkinContext& context) {
 void WTrackProperty::slotTrackLoaded(TrackPointer track) {
     if (track) {
         m_pCurrentTrack = track;
-        connect(track.get(), SIGNAL(changed(Track*)),
-                this, SLOT(updateLabel(Track*)));
-        updateLabel(track.get());
+        connect(track.get(),
+                &Track::changed,
+                this,
+                &WTrackProperty::slotTrackChanged);
+        updateLabel();
     }
 }
 
@@ -37,16 +39,23 @@ void WTrackProperty::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldT
         disconnect(m_pCurrentTrack.get(), nullptr, this, nullptr);
     }
     m_pCurrentTrack.reset();
-    setText("");
+    updateLabel();
 }
 
-void WTrackProperty::updateLabel(Track* /*unused*/) {
+void WTrackProperty::slotTrackChanged(TrackId trackId) {
+    Q_UNUSED(trackId);
+    updateLabel();
+}
+
+void WTrackProperty::updateLabel() {
     if (m_pCurrentTrack) {
         QVariant property = m_pCurrentTrack->property(m_property.toUtf8().constData());
         if (property.isValid() && property.canConvert(QMetaType::QString)) {
             setText(property.toString());
+            return;
         }
     }
+    setText("");
 }
 
 void WTrackProperty::mouseMoveEvent(QMouseEvent *event) {

--- a/src/widget/wtrackproperty.h
+++ b/src/widget/wtrackproperty.h
@@ -27,12 +27,14 @@ class WTrackProperty : public WLabel, public TrackDropTarget {
     void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
 
   private slots:
-    void updateLabel(Track*);
+    void slotTrackChanged(TrackId);
 
   private:
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dropEvent(QDropEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
+
+    void updateLabel();
 
     const char* m_pGroup;
     UserSettingsPointer m_pConfig;

--- a/src/widget/wtracktext.cpp
+++ b/src/widget/wtracktext.cpp
@@ -16,9 +16,11 @@ WTrackText::WTrackText(const char *group, UserSettingsPointer pConfig, QWidget* 
 void WTrackText::slotTrackLoaded(TrackPointer track) {
     if (track) {
         m_pCurrentTrack = track;
-        connect(track.get(), SIGNAL(changed(Track*)),
-                this, SLOT(updateLabel(Track*)));
-        updateLabel(track.get());
+        connect(track.get(),
+                &Track::changed,
+                this,
+                &WTrackText::slotTrackChanged);
+        updateLabel();
     }
 }
 
@@ -29,12 +31,19 @@ void WTrackText::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack
         disconnect(m_pCurrentTrack.get(), nullptr, this, nullptr);
     }
     m_pCurrentTrack.reset();
-    setText("");
+    updateLabel();
 }
 
-void WTrackText::updateLabel(Track* /*unused*/) {
+void WTrackText::slotTrackChanged(TrackId trackId) {
+    Q_UNUSED(trackId);
+    updateLabel();
+}
+
+void WTrackText::updateLabel() {
     if (m_pCurrentTrack) {
         setText(m_pCurrentTrack->getInfo());
+    } else {
+        setText("");
     }
 }
 

--- a/src/widget/wtracktext.h
+++ b/src/widget/wtracktext.h
@@ -24,12 +24,14 @@ class WTrackText : public WLabel, public TrackDropTarget {
     void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
 
   private slots:
-    void updateLabel(Track*);
+    void slotTrackChanged(TrackId);
 
   private:
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dropEvent(QDropEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
+
+    void updateLabel();
 
     const char* m_pGroup;
     UserSettingsPointer m_pConfig;


### PR DESCRIPTION
...and fixed some nasty warnings caused by `DlgTrackInfo`.

Passing a raw `Track*` pointer with the signal although we only need the `TrackId` was unnecessary and unsafe. 