### PR TITLE
use TrackRef instead of TrackId

### DIFF
--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -1172,3 +1172,15 @@ void BaseSqlTableModel::hideTracks(const QModelIndexList& indices) {
     // there.
     select(); //Repopulate the data model.
 }
+
+QList<TrackRef> BaseSqlTableModel::getTrackRefs(
+        const QModelIndexList& indices) const {
+    QList<TrackRef> trackRefs;
+    trackRefs.reserve(indices.size());
+    foreach (QModelIndex index, indices) {
+        trackRefs.append(TrackRef::fromFileInfo(
+                TrackFile(getTrackLocation(index)),
+                getTrackId(index)));
+    }
+    return trackRefs;
+}

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -101,6 +101,8 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
     TrackCollectionManager* const m_pTrackCollectionManager;
 
   protected:
+    QList<TrackRef> getTrackRefs(const QModelIndexList& indices) const;
+
     QSqlDatabase m_database;
 
     QString m_previewDeckGroup;

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -228,7 +228,7 @@ QList<TrackId> TrackDAO::resolveTrackIds(
     return trackIds;
 }
 
-QSet<QString> TrackDAO::getTrackLocations() {
+QSet<QString> TrackDAO::getAllTrackLocations() {
     QSet<QString> locations;
     QSqlQuery query(m_database);
     query.prepare("SELECT track_locations.location FROM track_locations "

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -53,8 +53,6 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
 
     TrackId getTrackIdByRef(
             const TrackRef& trackRef) const;
-    QList<TrackId> getAllTrackIds(
-            const QDir& rootDir);
     QList<TrackRef> getAllTrackRefs(
             const QDir& rootDir);
 
@@ -64,7 +62,6 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     // Returns a set of all track locations in the library.
     QSet<QString> getTrackLocations();
     QString getTrackLocation(TrackId trackId);
-    QStringList getTrackLocations(const QList<TrackId>& trackIds);
 
     // Only used by friend class LibraryScanner, but public for testing!
     bool detectMovedTracks(

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -55,6 +55,8 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
             const TrackRef& trackRef) const;
     QList<TrackId> getAllTrackIds(
             const QDir& rootDir);
+    QList<TrackRef> getAllTrackRefs(
+            const QDir& rootDir);
 
     TrackPointer getTrackByRef(
             const TrackRef& trackRef) const;

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -60,7 +60,7 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
             const TrackRef& trackRef) const;
 
     // Returns a set of all track locations in the library.
-    QSet<QString> getTrackLocations();
+    QSet<QString> getAllTrackLocations();
     QString getTrackLocation(TrackId trackId);
 
     // Only used by friend class LibraryScanner, but public for testing!

--- a/src/library/hiddentablemodel.cpp
+++ b/src/library/hiddentablemodel.cpp
@@ -47,13 +47,7 @@ void HiddenTableModel::setTableModel(int id) {
 }
 
 void HiddenTableModel::purgeTracks(const QModelIndexList& indices) {
-    QList<TrackId> trackIds;
-
-    foreach (QModelIndex index, indices) {
-        trackIds.append(getTrackId(index));
-    }
-
-    m_pTrackCollectionManager->purgeTracks(trackIds);
+    m_pTrackCollectionManager->purgeTracks(getTrackRefs(indices));
 
     // TODO(rryan) : do not select, instead route event to BTC and notify from
     // there.

--- a/src/library/missingtablemodel.cpp
+++ b/src/library/missingtablemodel.cpp
@@ -57,13 +57,7 @@ MissingTableModel::~MissingTableModel() {
 
 
 void MissingTableModel::purgeTracks(const QModelIndexList& indices) {
-    QList<TrackId> trackIds;
-
-    foreach (QModelIndex index, indices) {
-        trackIds.append(getTrackId(index));
-    }
-
-    m_pTrackCollectionManager->purgeTracks(trackIds);
+    m_pTrackCollectionManager->purgeTracks(getTrackRefs(indices));
 
     // TODO(rryan) : do not select, instead route event to BTC and notify from
     // there.

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -192,7 +192,7 @@ void LibraryScanner::slotStartScan() {
     }
     changeScannerState(SCANNING);
 
-    QSet<QString> trackLocations = m_trackDao.getTrackLocations();
+    QSet<QString> trackLocations = m_trackDao.getAllTrackLocations();
     QHash<QString, mixxx::cache_key_t> directoryHashes = m_libraryHashDao.getDirectoryHashes();
     QRegExp extensionFilter(SoundSourceProxy::getSupportedFileNamesRegex());
     QRegExp coverExtensionFilter =

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -309,7 +309,13 @@ bool TrackCollection::purgeTracks(
 
 bool TrackCollection::purgeAllTracks(
         const QDir& rootDir) {
-    QList<TrackId> trackIds = m_trackDao.getAllTrackIds(rootDir);
+    QList<TrackRef> trackRefs = m_trackDao.getAllTrackRefs(rootDir);
+    QList<TrackId> trackIds;
+    trackIds.reserve(trackRefs.size());
+    for (const auto trackRef : trackRefs) {
+        DEBUG_ASSERT(trackRef.hasId());
+        trackIds.append(trackRef.getId());
+    }
     return purgeTracks(trackIds);
 }
 

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -271,47 +271,42 @@ void TrackCollectionManager::hideAllTracks(const QDir& rootDir) {
     m_pInternalCollection->hideAllTracks(rootDir);
 }
 
-void TrackCollectionManager::purgeTracks(const QList<TrackId>& trackIds) {
-    if (trackIds.isEmpty()) {
+void TrackCollectionManager::purgeTracks(const QList<TrackRef>& trackRefs) {
+    if (trackRefs.isEmpty()) {
         return;
     }
-    // Collect the corresponding track locations BEFORE purging the
-    // tracks from the internal collection!
-    QList<QString> trackLocations;
-    if (!m_externalCollections.isEmpty()) {
-        trackLocations =
-                m_pInternalCollection->getTrackDAO().getTrackLocations(trackIds);
-    }
-    DEBUG_ASSERT(trackLocations.size() <= trackIds.size());
     kLogger.debug()
-            << "Purging"
-            << trackIds.size()
+            << "trackRefs"
+            << trackRefs.size()
             << "tracks from internal collection";
-    if (!m_pInternalCollection->purgeTracks(trackIds)) {
-        kLogger.warning()
-                << "Failed to purge tracks from internal collection";
-        return;
+    {
+        QList<TrackId> trackIds;
+        trackIds.reserve(trackRefs.size());
+        for (const auto trackRef : trackRefs) {
+            DEBUG_ASSERT(trackRef.hasId());
+            trackIds.append(trackRef.getId());
+        }
+        if (!m_pInternalCollection->purgeTracks(trackIds)) {
+            kLogger.warning()
+                    << "Failed to purge tracks from internal collection";
+            return;
+        }
     }
     if (m_externalCollections.isEmpty()) {
         return;
     }
-    VERIFY_OR_DEBUG_ASSERT(trackLocations.size() == trackIds.size()) {
-        kLogger.warning()
-                << "Purging only"
-                << trackLocations.size()
-                << "of"
-                << trackIds.size()
-                << "tracks from"
-                << m_externalCollections.size()
-                << "external collection(s)";
-    } else {
-        kLogger.debug()
-                << "Purging"
-                << trackLocations.size()
-                << "tracks from"
-                << m_externalCollections.size()
-                << "external collection(s)";
+    QList<QString> trackLocations;
+    trackLocations.reserve(trackLocations.size());
+    for (const auto trackRef : trackRefs) {
+        DEBUG_ASSERT(trackRef.hasLocation());
+        trackLocations.append(trackRef.getLocation());
     }
+    kLogger.debug()
+            << "Purging"
+            << trackLocations.size()
+            << "tracks from"
+            << m_externalCollections.size()
+            << "external collection(s)";
     for (const auto& externalTrackCollection : m_externalCollections) {
         externalTrackCollection->purgeTracks(trackLocations);
     }

--- a/src/library/trackcollectionmanager.h
+++ b/src/library/trackcollectionmanager.h
@@ -46,7 +46,7 @@ class TrackCollectionManager: public QObject,
     bool unhideTracks(const QList<TrackId>& trackIds);
     void hideAllTracks(const QDir& rootDir);
 
-    void purgeTracks(const QList<TrackId>& trackIds);
+    void purgeTracks(const QList<TrackRef>& trackRefs);
     void purgeAllTracks(const QDir& rootDir);
 
     bool addDirectory(const QString& dir);

--- a/src/test/trackdao_test.cpp
+++ b/src/test/trackdao_test.cpp
@@ -52,6 +52,6 @@ TEST_F(TrackDAOTest, detectMovedTracks) {
     EXPECT_THAT(updatedTrackIds, UnorderedElementsAre(oldId));
     EXPECT_THAT(removedTrackIds, UnorderedElementsAre(newId));
 
-    QSet<QString> trackLocations = trackDAO.getTrackLocations();
+    QSet<QString> trackLocations = trackDAO.getAllTrackLocations();
     EXPECT_THAT(trackLocations, UnorderedElementsAre(newFile.location(), otherFile.location()));
 }


### PR DESCRIPTION
Replace `QList<TrackId>` with `QList<TrackRef>` as return type when purging tracks.

The temporary copy in `TrackCollection` is compensated by avoiding an unnecessary database access in `TrackCollectionManager`.

See also: https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/Export.20to.20Engine.20Prime/near/188593776