### PR TITLE
MusicBrainz: Handle 301 status response

### DIFF
--- a/src/musicbrainz/musicbrainzclient.cpp
+++ b/src/musicbrainz/musicbrainzclient.cpp
@@ -126,10 +126,11 @@ void MusicBrainzClient::replyFinished() {
     const QByteArray body(reply->readAll());
     QXmlStreamReader reader(body);
 
-    // MusicBrainz returns 404 when the MBID is not in their database. We treat
-    // a status of 404 the same as a 200 but it will produce an empty list of
-    // results.
-    if (status != 200 && status != 404) {
+    // HTTP status of successful results:
+    // 200: Found
+    // 301: Found, but UUID moved permanently in database
+    // 404: Not found in database, i.e. empty result
+    if (status != 200 && status != 301 && status != 404) {
         qDebug()
                 << "MusicBrainzClient GET reply"
                 << "status:" << status


### PR DESCRIPTION
Forgot about this one. Sorry, no plans to backport these fixes to 2.2.

Example for manual testing (included in commit message):
https://musicbrainz.org/ws/2/recording/1d0d3b69-e492-4dda-9dbe-5b2b797dc2bd
