### PR TITLE
Use URI path for in-memory database

### DIFF
--- a/src/database/mixxxdb.cpp
+++ b/src/database/mixxxdb.cpp
@@ -17,6 +17,8 @@ namespace {
 
 const mixxx::Logger kLogger("MixxxDb");
 
+const QString kDefaultFileName = QStringLiteral("mixxxdb.sqlite");
+
 // The connection parameters for the main Mixxx DB
 mixxx::DbConnection::Params dbConnectionParams(
         const UserSettingsPointer& pConfig,
@@ -24,7 +26,16 @@ mixxx::DbConnection::Params dbConnectionParams(
     mixxx::DbConnection::Params params;
     params.type = "QSQLITE";
     params.hostName = "localhost";
-    params.filePath = inMemoryConnection ? QString(":memory:") : QDir(pConfig->getSettingsPath()).filePath("mixxxdb.sqlite");
+    params.filePath = QDir(pConfig->getSettingsPath()).filePath(kDefaultFileName);
+    // Allow multiple connections to the same in-memory database by
+    // using a named connection. This is needed to make the database
+    // connection pool work correctly even during tests.
+    //
+    // See also:
+    // https://www.sqlite.org/inmemorydb.html
+    if (inMemoryConnection) {
+        params.filePath += "?mode=memory";
+    }
     params.userName = "mixxx";
     params.password = "mixxx";
     return params;

--- a/src/database/mixxxdb.cpp
+++ b/src/database/mixxxdb.cpp
@@ -46,7 +46,7 @@ mixxx::DbConnection::Params dbConnectionParams(
     // See also:
     // https://www.sqlite.org/inmemorydb.html
     if (inMemoryConnection) {
-        params.filePath += QStringLiteral("?mode=memory");
+        params.filePath += QStringLiteral("?mode=memory&cache=shared");
     }
     params.userName = kUserName;
     params.password = kPassword;

--- a/src/database/mixxxdb.cpp
+++ b/src/database/mixxxdb.cpp
@@ -21,6 +21,8 @@ const QString kType = QStringLiteral("QSQLITE");
 
 const QString kConnectOptions = QStringLiteral("QSQLITE_OPEN_URI");
 
+const QString kUriPrefix = QStringLiteral("file://");
+
 const QString kDefaultFileName = QStringLiteral("mixxxdb.sqlite");
 
 const QString kUserName = QStringLiteral("mixxx");
@@ -34,11 +36,16 @@ mixxx::DbConnection::Params dbConnectionParams(
     mixxx::DbConnection::Params params;
     params.type = kType;
     params.connectOptions = kConnectOptions;
-    QString filePath = QDir(pConfig->getSettingsPath()).filePath(kDefaultFileName);
-    if (!filePath.startsWith(QStringLiteral("/"))) {
-        filePath = QStringLiteral("/") + filePath;
+    params.filePath = kUriPrefix;
+    const QString absFilePath =
+            QDir(pConfig->getSettingsPath()).absoluteFilePath(kDefaultFileName);
+    // On Windows absFilePath starts with a drive letter instead of
+    // the leading '/' as required.
+    // https://www.sqlite.org/c3ref/open.html#urifilenameexamples
+    if (!absFilePath.startsWith(QChar('/'))) {
+        params.filePath += QChar('/');
     }
-    params.filePath = QString(QStringLiteral("file://%1")).arg(filePath);
+    params.filePath = kUriPrefix + absFilePath;
     // Allow multiple connections to the same in-memory database by
     // using a named connection. This is needed to make the database
     // connection pool work correctly even during tests.

--- a/src/database/mixxxdb.cpp
+++ b/src/database/mixxxdb.cpp
@@ -45,7 +45,7 @@ mixxx::DbConnection::Params dbConnectionParams(
     if (!absFilePath.startsWith(QChar('/'))) {
         params.filePath += QChar('/');
     }
-    params.filePath = kUriPrefix + absFilePath;
+    params.filePath += absFilePath;
     // Allow multiple connections to the same in-memory database by
     // using a named connection. This is needed to make the database
     // connection pool work correctly even during tests.

--- a/src/database/mixxxdb.cpp
+++ b/src/database/mixxxdb.cpp
@@ -17,16 +17,28 @@ namespace {
 
 const mixxx::Logger kLogger("MixxxDb");
 
+const QString kType = QStringLiteral("QSQLITE");
+
+const QString kConnectOptions = QStringLiteral("QSQLITE_OPEN_URI");
+
 const QString kDefaultFileName = QStringLiteral("mixxxdb.sqlite");
+
+const QString kUserName = QStringLiteral("mixxx");
+
+const QString kPassword = QStringLiteral("mixxx");
 
 // The connection parameters for the main Mixxx DB
 mixxx::DbConnection::Params dbConnectionParams(
         const UserSettingsPointer& pConfig,
         bool inMemoryConnection) {
     mixxx::DbConnection::Params params;
-    params.type = "QSQLITE";
-    params.hostName = "localhost";
-    params.filePath = QDir(pConfig->getSettingsPath()).filePath(kDefaultFileName);
+    params.type = kType;
+    params.connectOptions = kConnectOptions;
+    QString filePath = QDir(pConfig->getSettingsPath()).filePath(kDefaultFileName);
+    if (!filePath.startsWith(QStringLiteral("/"))) {
+        filePath = QStringLiteral("/") + filePath;
+    }
+    params.filePath = QString(QStringLiteral("file://%1")).arg(filePath);
     // Allow multiple connections to the same in-memory database by
     // using a named connection. This is needed to make the database
     // connection pool work correctly even during tests.
@@ -34,10 +46,10 @@ mixxx::DbConnection::Params dbConnectionParams(
     // See also:
     // https://www.sqlite.org/inmemorydb.html
     if (inMemoryConnection) {
-        params.filePath += "?mode=memory";
+        params.filePath += QStringLiteral("?mode=memory");
     }
-    params.userName = "mixxx";
-    params.password = "mixxx";
+    params.userName = kUserName;
+    params.password = kPassword;
     return params;
 }
 

--- a/src/util/db/dbconnection.cpp
+++ b/src/util/db/dbconnection.cpp
@@ -31,6 +31,7 @@ QSqlDatabase createDatabase(
 
     QSqlDatabase database =
             QSqlDatabase::addDatabase(params.type, connectionName);
+    database.setConnectOptions(params.connectOptions);
     database.setHostName(params.hostName);
     database.setDatabaseName(params.filePath);
     database.setUserName(params.userName);

--- a/src/util/db/dbconnection.h
+++ b/src/util/db/dbconnection.h
@@ -26,6 +26,7 @@ class DbConnection final {
 
     struct Params {
         QString type;
+        QString connectOptions;
         QString hostName;
         QString filePath;
         QString userName;


### PR DESCRIPTION
- Use a named in-memory DB for testing
- Use URI file paths for databases
- ~~Disable LibraryScanner during library tests~~ #2515
- ~~Remove dependencies on TrackCollection from LibraryScanner~~  #2515
- ~~Use Qt::DirectConnection for signal-to-signal connections~~ #2515

Our connection pool does not work correctly with anonymous in-memory database connections that are used for testing. Only the database schema of the connection on the main thread will be initialized. Connections on other threads start with a fresh database and all queries are doomed to fail!

The tests succeed, but the log is spammed:

```
LibraryScanner - Cleaning up database...
FwdSqlQuery - Failed to prepare "DELETE FROM LibraryHashes WHERE hash <> :unequalHash AND directory_path NOT IN (SELECT directory FROM track_locations)" : QSqlError("1", "Unable to execute statement", "no such table: LibraryHashes")
DEBUG ASSERT: "query.isPrepared()" in function int {anonymous}::execCleanupQuery(FwdSqlQuery&) at src/library/scanner/libraryscanner.cpp:31
LibraryScanner - Failed to delete orphaned directory hashes
LibraryScanner - Finished database cleanup: 0 ms
src/library/dao/playlistdao.cpp 28 FAILED QUERY [ "SELECT COUNT(*) from PlaylistTracks" ] QSqlError("", "Unable to fetch row", "No query")
src/library/dao/playlistdao.cpp 34 FAILED QUERY [ "SELECT track_id, playlist_id from PlaylistTracks" ] QSqlError("", "Unable to fetch row", "No query")
LibraryScanner - Event loop starting
```

Fixed by using a named in-memory connection with the actual file name and an additional `mode` parameter.

~~Nevertheless I have disabled the `LibraryScanner` inside `TrackCollectionManager` during tests to avoid issues caused by concurrent database cleanup tasks that are executed by the `LibraryScanner` on startup unconditionally.~~

~~TODO (see code): The `LibraryScanner` doesn't belong in there and should be extracted and decoupled from `TrackCollectionManager` in the long term.~~ #2515