### PR TITLE
Hotfix: Connect/disconnect BaseTrackCache in TrackCollection

### DIFF
--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -49,37 +49,6 @@ BaseTrackCache::BaseTrackCache(TrackCollection* pTrackCollection,
     }
 }
 
-void BaseTrackCache::connectTrackDAO(TrackDAO* pTrackDAO) {
-    connect(pTrackDAO,
-            &TrackDAO::trackDirty,
-            this,
-            &BaseTrackCache::slotTrackDirty);
-    connect(pTrackDAO,
-            &TrackDAO::trackClean,
-            this,
-            &BaseTrackCache::slotTrackClean);
-    connect(pTrackDAO,
-            &TrackDAO::trackChanged,
-            this,
-            &BaseTrackCache::slotTrackChanged);
-    connect(pTrackDAO,
-            &TrackDAO::tracksAdded,
-            this,
-            &BaseTrackCache::slotTracksAdded);
-    connect(pTrackDAO,
-            &TrackDAO::tracksRemoved,
-            this,
-            &BaseTrackCache::slotTracksRemoved);
-    connect(pTrackDAO,
-            &TrackDAO::dbTrackAdded,
-            this,
-            &BaseTrackCache::slotDbTrackAdded);
-}
-
-void BaseTrackCache::disconnectTrackDAO(TrackDAO* pTrackDAO) {
-    disconnect(pTrackDAO);
-}
-
 BaseTrackCache::~BaseTrackCache() {
     // Required to allow forward declarations of (managed pointer) members
     // in header file

--- a/src/library/basetrackcache.h
+++ b/src/library/basetrackcache.h
@@ -84,10 +84,6 @@ class BaseTrackCache : public QObject {
     void slotDbTrackAdded(TrackPointer pTrack);
 
   private:
-    friend class TrackCollection;
-    void connectTrackDAO(TrackDAO* pTrackDAO);
-    void disconnectTrackDAO(TrackDAO* pTrackDAO);
-
     const TrackPointer& getRecentTrack(TrackId trackId) const;
     void replaceRecentTrack(TrackPointer pTrack) const;
     void replaceRecentTrack(TrackId trackId, TrackPointer pTrack) const;

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -68,7 +68,30 @@ void TrackCollection::connectTrackSource(QSharedPointer<BaseTrackCache> pTrackSo
         return;
     }
     m_pTrackSource = pTrackSource;
-    m_pTrackSource->connectTrackDAO(&m_trackDao);
+    connect(&m_trackDao,
+            &TrackDAO::trackDirty,
+            m_pTrackSource.get(),
+            &BaseTrackCache::slotTrackDirty);
+    connect(&m_trackDao,
+            &TrackDAO::trackClean,
+            m_pTrackSource.get(),
+            &BaseTrackCache::slotTrackClean);
+    connect(&m_trackDao,
+            &TrackDAO::trackChanged,
+            m_pTrackSource.get(),
+            &BaseTrackCache::slotTrackChanged);
+    connect(&m_trackDao,
+            &TrackDAO::tracksAdded,
+            m_pTrackSource.get(),
+            &BaseTrackCache::slotTracksAdded);
+    connect(&m_trackDao,
+            &TrackDAO::tracksRemoved,
+            m_pTrackSource.get(),
+            &BaseTrackCache::slotTracksRemoved);
+    connect(&m_trackDao,
+            &TrackDAO::dbTrackAdded,
+            m_pTrackSource.get(),
+            &BaseTrackCache::slotDbTrackAdded);
 }
 
 QWeakPointer<BaseTrackCache> TrackCollection::disconnectTrackSource() {
@@ -76,7 +99,8 @@ QWeakPointer<BaseTrackCache> TrackCollection::disconnectTrackSource() {
 
     auto pWeakPtr = m_pTrackSource.toWeakRef();
     if (m_pTrackSource) {
-        m_pTrackSource->disconnectTrackDAO(&m_trackDao);
+        kLogger.info() << "Disconnecting track source";
+        m_trackDao.disconnect(m_pTrackSource.get());
         m_pTrackSource.reset();
     }
     return pWeakPtr;

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -70,27 +70,27 @@ void TrackCollection::connectTrackSource(QSharedPointer<BaseTrackCache> pTrackSo
     m_pTrackSource = pTrackSource;
     connect(&m_trackDao,
             &TrackDAO::trackDirty,
-            m_pTrackSource.get(),
+            m_pTrackSource.data(),
             &BaseTrackCache::slotTrackDirty);
     connect(&m_trackDao,
             &TrackDAO::trackClean,
-            m_pTrackSource.get(),
+            m_pTrackSource.data(),
             &BaseTrackCache::slotTrackClean);
     connect(&m_trackDao,
             &TrackDAO::trackChanged,
-            m_pTrackSource.get(),
+            m_pTrackSource.data(),
             &BaseTrackCache::slotTrackChanged);
     connect(&m_trackDao,
             &TrackDAO::tracksAdded,
-            m_pTrackSource.get(),
+            m_pTrackSource.data(),
             &BaseTrackCache::slotTracksAdded);
     connect(&m_trackDao,
             &TrackDAO::tracksRemoved,
-            m_pTrackSource.get(),
+            m_pTrackSource.data(),
             &BaseTrackCache::slotTracksRemoved);
     connect(&m_trackDao,
             &TrackDAO::dbTrackAdded,
-            m_pTrackSource.get(),
+            m_pTrackSource.data(),
             &BaseTrackCache::slotDbTrackAdded);
 }
 
@@ -100,7 +100,7 @@ QWeakPointer<BaseTrackCache> TrackCollection::disconnectTrackSource() {
     auto pWeakPtr = m_pTrackSource.toWeakRef();
     if (m_pTrackSource) {
         kLogger.info() << "Disconnecting track source";
-        m_trackDao.disconnect(m_pTrackSource.get());
+        m_trackDao.disconnect(m_pTrackSource.data());
         m_pTrackSource.reset();
     }
     return pWeakPtr;


### PR DESCRIPTION
**Crash on exit**

disconnect() was called on the wrong object and with the wrong argument. I have moved all operations into `TrackCollection` where they belong to avoid further confusion.