### PR TITLE
Fix runtime dependencies of LibraryScanner

### DIFF
--- a/src/library/basetrackcache.h
+++ b/src/library/basetrackcache.h
@@ -17,7 +17,6 @@
 #include "util/string.h"
 
 class SearchQueryParser;
-class TrackDAO;
 class TrackCollection;
 
 class SortColumn {

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -6,7 +6,6 @@
 #include "library/scanner/scannertask.h"
 #include "library/queryutil.h"
 #include "library/coverartutils.h"
-#include "library/trackcollection.h"
 #include "util/logger.h"
 #include "util/trace.h"
 #include "util/file.h"
@@ -41,10 +40,10 @@ int execCleanupQuery(FwdSqlQuery& query) {
 
 LibraryScanner::LibraryScanner(
         mixxx::DbConnectionPoolPtr pDbConnectionPool,
-        TrackCollection* pTrackCollection,
-        const UserSettingsPointer& pConfig)
-        : m_pDbConnectionPool(std::move(pDbConnectionPool)),
-          m_pTrackCollection(pTrackCollection),
+        const UserSettingsPointer& pConfig,
+        QObject* parent)
+        : QThread(parent),
+          m_pDbConnectionPool(std::move(pDbConnectionPool)),
           m_analysisDao(pConfig),
           m_trackDao(m_cueDao, m_playlistDao,
                   m_analysisDao, m_libraryHashDao,
@@ -53,7 +52,6 @@ LibraryScanner::LibraryScanner(
           m_state(IDLE) {
     // Move LibraryScanner to its own thread so that our signals/slots will
     // queue to our event loop.
-    kLogger.debug() << "Starting thread";
     moveToThread(this);
     m_pool.moveToThread(this);
 
@@ -65,24 +63,6 @@ LibraryScanner::LibraryScanner(
     // Listen to signals from our public methods (invoked by other threads) and
     // connect them to our slots to run the command on the scanner thread.
     connect(this, &LibraryScanner::startScan, this, &LibraryScanner::slotStartScan);
-
-    // Force the GUI thread's Track cache to be cleared when a library
-    // scan is finished, because we might have modified the database directly
-    // when we detected moved files, and the TIOs corresponding to the moved
-    // files would then have the wrong track location.
-    TrackDAO* trackDao = &(m_pTrackCollection->getTrackDAO());
-    connect(this,
-            &LibraryScanner::trackAdded,
-            trackDao,
-            &TrackDAO::databaseTrackAdded);
-    connect(this,
-            &LibraryScanner::tracksChanged,
-            trackDao,
-            &TrackDAO::databaseTracksChanged);
-    connect(this,
-            &LibraryScanner::tracksRelocated,
-            trackDao,
-            &TrackDAO::databaseTracksRelocated);
 
     m_pProgressDlg.reset(new LibraryScannerDlg());
     connect(this,
@@ -113,8 +93,6 @@ LibraryScanner::LibraryScanner(
             &TrackDAO::progressCoverArt,
             m_pProgressDlg.data(),
             &LibraryScannerDlg::slotUpdateCover);
-
-    start();
 }
 
 LibraryScanner::~LibraryScanner() {

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -40,10 +40,8 @@ int execCleanupQuery(FwdSqlQuery& query) {
 
 LibraryScanner::LibraryScanner(
         mixxx::DbConnectionPoolPtr pDbConnectionPool,
-        const UserSettingsPointer& pConfig,
-        QObject* parent)
-        : QThread(parent),
-          m_pDbConnectionPool(std::move(pDbConnectionPool)),
+        const UserSettingsPointer& pConfig)
+        : m_pDbConnectionPool(std::move(pDbConnectionPool)),
           m_analysisDao(pConfig),
           m_trackDao(m_cueDao, m_playlistDao,
                   m_analysisDao, m_libraryHashDao,

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -29,8 +29,7 @@ class LibraryScanner : public QThread {
   public:
     LibraryScanner(
             mixxx::DbConnectionPoolPtr pDbConnectionPool,
-            const UserSettingsPointer& pConfig,
-            QObject* parent = nullptr);
+            const UserSettingsPointer& pConfig);
     ~LibraryScanner() override;
 
   public slots:

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -22,7 +22,6 @@
 
 class ScannerTask;
 class LibraryScannerDlg;
-class TrackCollection;
 
 class LibraryScanner : public QThread {
     FRIEND_TEST(LibraryScannerTest, ScannerRoundtrip);
@@ -30,8 +29,8 @@ class LibraryScanner : public QThread {
   public:
     LibraryScanner(
             mixxx::DbConnectionPoolPtr pDbConnectionPool,
-            TrackCollection* pTrackCollection,
-            const UserSettingsPointer& pConfig);
+            const UserSettingsPointer& pConfig,
+            QObject* parent = nullptr);
     ~LibraryScanner() override;
 
   public slots:
@@ -99,10 +98,6 @@ class LibraryScanner : public QThread {
     void cleanUpScan();
 
     mixxx::DbConnectionPoolPtr m_pDbConnectionPool;
-
-    // The library trackcollection. Do not touch this from the library scanner
-    // thread.
-    TrackCollection* m_pTrackCollection;
 
     // The pool of threads used for worker tasks.
     QThreadPool m_pool;

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -36,12 +36,14 @@ TrackCollection::~TrackCollection() {
 void TrackCollection::repairDatabase(QSqlDatabase database) {
     DEBUG_ASSERT(QApplication::instance()->thread() == QThread::currentThread());
 
+    kLogger.info() << "Repairing database";
     m_crates.repairDatabase(database);
 }
 
 void TrackCollection::connectDatabase(QSqlDatabase database) {
     DEBUG_ASSERT(QApplication::instance()->thread() == QThread::currentThread());
 
+    kLogger.info() << "Connecting database";
     m_database = database;
     m_trackDao.initialize(database);
     m_playlistDao.initialize(database);
@@ -55,6 +57,7 @@ void TrackCollection::connectDatabase(QSqlDatabase database) {
 void TrackCollection::disconnectDatabase() {
     DEBUG_ASSERT(QApplication::instance()->thread() == QThread::currentThread());
 
+    kLogger.info() << "Disconnecting database";
     m_database = QSqlDatabase();
     m_trackDao.finish();
     m_crates.disconnectDatabase();
@@ -67,6 +70,7 @@ void TrackCollection::connectTrackSource(QSharedPointer<BaseTrackCache> pTrackSo
         kLogger.warning() << "Track source has already been connected";
         return;
     }
+    kLogger.info() << "Connecting track source";
     m_pTrackSource = pTrackSource;
     connect(&m_trackDao,
             &TrackDAO::trackDirty,

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -1,9 +1,8 @@
-#include "database/mixxxdb.h"
-
 #include "library/trackcollectionmanager.h"
 
-#include "library/trackcollection.h"
 #include "library/externaltrackcollection.h"
+#include "library/scanner/libraryscanner.h"
+#include "library/trackcollection.h"
 
 #include "sources/soundsourceproxy.h"
 #include "util/db/dbconnectionpooled.h"

--- a/src/library/trackcollectionmanager.h
+++ b/src/library/trackcollectionmanager.h
@@ -4,6 +4,8 @@
 #include <QList>
 #include <QSet>
 
+#include <memory>
+
 #include "library/relocatedtrack.h"
 #include "preferences/usersettings.h"
 #include "track/globaltrackcache.h"
@@ -99,5 +101,5 @@ class TrackCollectionManager: public QObject,
     QList<ExternalTrackCollection*> m_externalCollections;
 
     // TODO: Extract and decouple LibraryScanner from TrackCollectionManager
-    parented_ptr<LibraryScanner> m_pScanner;
+    std::unique_ptr<LibraryScanner> m_pScanner;
 };

--- a/src/library/trackcollectionmanager.h
+++ b/src/library/trackcollectionmanager.h
@@ -31,7 +31,7 @@ class TrackCollectionManager: public QObject,
             QObject* parent,
             UserSettingsPointer pConfig,
             mixxx::DbConnectionPoolPtr pDbConnectionPool,
-            deleteTrackFn_t deleteTrackFn = nullptr);
+            deleteTrackFn_t deleteTrackForTestingFn = nullptr);
     ~TrackCollectionManager() override;
 
     TrackCollection* internalCollection() {
@@ -98,5 +98,6 @@ class TrackCollectionManager: public QObject,
 
     QList<ExternalTrackCollection*> m_externalCollections;
 
-    LibraryScanner m_scanner;
+    // TODO: Extract and decouple LibraryScanner from TrackCollectionManager
+    parented_ptr<LibraryScanner> m_pScanner;
 };

--- a/src/library/trackcollectionmanager.h
+++ b/src/library/trackcollectionmanager.h
@@ -2,15 +2,15 @@
 
 #include <QDir>
 #include <QList>
-#include <QObject>
 #include <QSet>
 
-#include "library/scanner/libraryscanner.h"
+#include "library/relocatedtrack.h"
 #include "preferences/usersettings.h"
 #include "track/globaltrackcache.h"
 #include "util/db/dbconnectionpool.h"
 #include "util/parented_ptr.h"
 
+class LibraryScanner;
 class TrackCollection;
 class ExternalTrackCollection;
 

--- a/src/test/libraryscannertest.cpp
+++ b/src/test/libraryscannertest.cpp
@@ -8,7 +8,7 @@
 class LibraryScannerTest : public LibraryTest {
   protected:
     LibraryScannerTest()
-        : m_libraryScanner(dbConnectionPool(), internalCollection(), config()) {
+        : m_libraryScanner(dbConnectionPool(), config()) {
     }
     LibraryScanner m_libraryScanner;
 };


### PR DESCRIPTION
Extracted from #2511 (without URI changes) that should fix the test failures in #2508.

- Disable LibraryScanner during library tests
- Remove dependencies on TrackCollection from LibraryScanner
- Use Qt::DirectConnection for signal-to-signal connections

TODO (see code): The `LibraryScanner` should be extracted and decoupled from `TrackCollectionManager` in the long term.