### PR TITLE
Utility functions for formatting UUIDs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -921,6 +921,7 @@ add_executable(mixxx-test
   src/test/broadcastsettings_test.cpp
   src/test/cache_test.cpp
   src/test/channelhandle_test.cpp
+  src/test/compatibility_test.cpp
   src/test/configobject_test.cpp
   src/test/controller_preset_validation_test.cpp
   src/test/controllerengine_test.cpp

--- a/src/test/compatibility_test.cpp
+++ b/src/test/compatibility_test.cpp
@@ -1,0 +1,16 @@
+#include "util/compatibility.h"
+
+#include <gtest/gtest.h>
+
+class CompatibilityTest : public testing::Test {
+};
+
+TEST_F(CompatibilityTest, uuidToStringWithoutBracesNullTest) {
+    EXPECT_EQ(QString("00000000-0000-0000-0000-000000000000"),
+            uuidToStringWithoutBraces(QUuid()));
+}
+
+TEST_F(CompatibilityTest, uuidToStringWithoutBracesValidTest) {
+    EXPECT_EQ(QString("93a20486-90fd-4ea5-a869-ef669cacb0b2"),
+            uuidToStringWithoutBraces(QUuid("93a20486-90fd-4ea5-a869-ef669cacb0b2")));
+}

--- a/src/test/compatibility_test.cpp
+++ b/src/test/compatibility_test.cpp
@@ -10,7 +10,17 @@ TEST_F(CompatibilityTest, uuidToStringWithoutBracesNullTest) {
             uuidToStringWithoutBraces(QUuid()));
 }
 
+TEST_F(CompatibilityTest, uuidToNullableStringWithoutBracesNullTest) {
+    EXPECT_EQ(QString(),
+            uuidToNullableStringWithoutBraces(QUuid()));
+}
+
 TEST_F(CompatibilityTest, uuidToStringWithoutBracesValidTest) {
     EXPECT_EQ(QString("93a20486-90fd-4ea5-a869-ef669cacb0b2"),
             uuidToStringWithoutBraces(QUuid("93a20486-90fd-4ea5-a869-ef669cacb0b2")));
+}
+
+TEST_F(CompatibilityTest, uuidToNullableStringWithoutBracesValidTest) {
+    EXPECT_EQ(QString("93a20486-90fd-4ea5-a869-ef669cacb0b2"),
+            uuidToNullableStringWithoutBraces(QUuid("93a20486-90fd-4ea5-a869-ef669cacb0b2")));
 }

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -266,21 +266,8 @@ inline TagLib::ByteVector toTByteVector(const QByteArray& bytearray) {
 }
 
 inline
-QString uuidToQStringWithoutBracesNullable(const QUuid& uuid) {
-    if (uuid.isNull()) {
-        return QString();
-    } else {
-        return uuidToStringWithoutBraces(uuid);
-    }
-}
-
-inline
-TagLib::String uuidToTStringWithoutBracesNullable(const QUuid& uuid) {
-    if (uuid.isNull()) {
-        return TagLib::String::null;
-    } else {
-        return toTString(uuidToStringWithoutBraces(uuid));
-    }
+TagLib::String uuidToTString(const QUuid& uuid) {
+    return toTString(uuidToNullableStringWithoutBraces(uuid));
 }
 
 #endif // __EXTRA_METADATA__
@@ -2434,7 +2421,7 @@ bool exportTrackMetadataIntoID3v2Tag(TagLib::ID3v2::Tag* pTag,
     writeID3v2UserTextIdentificationFrame(
             pTag,
             "MusicBrainz Artist Id",
-            uuidToQStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzArtistId()),
+            uuidToNullableStringWithoutBraces(trackMetadata.getTrackInfo().getMusicBrainzArtistId()),
             false);
     {
         QByteArray identifier = trackMetadata.getTrackInfo().getMusicBrainzRecordingId().toByteArray();
@@ -2453,27 +2440,27 @@ bool exportTrackMetadataIntoID3v2Tag(TagLib::ID3v2::Tag* pTag,
     writeID3v2UserTextIdentificationFrame(
             pTag,
             "MusicBrainz Release Track Id",
-            uuidToQStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()),
+            uuidToNullableStringWithoutBraces(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()),
             false);
     writeID3v2UserTextIdentificationFrame(
             pTag,
             "MusicBrainz Work Id",
-            uuidToQStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzWorkId()),
+            uuidToNullableStringWithoutBraces(trackMetadata.getTrackInfo().getMusicBrainzWorkId()),
             false);
     writeID3v2UserTextIdentificationFrame(
             pTag,
             "MusicBrainz Album Artist Id",
-            uuidToQStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()),
+            uuidToNullableStringWithoutBraces(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()),
             false);
     writeID3v2UserTextIdentificationFrame(
             pTag,
             "MusicBrainz Album Id",
-            uuidToQStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()),
+            uuidToNullableStringWithoutBraces(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()),
             false);
     writeID3v2UserTextIdentificationFrame(
             pTag,
             "MusicBrainz Release Group Id",
-            uuidToQStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()),
+            uuidToNullableStringWithoutBraces(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()),
             false);
 
     writeID3v2TextIdentificationFrame(
@@ -2588,19 +2575,19 @@ bool exportTrackMetadataIntoAPETag(TagLib::APE::Tag* pTag, const TrackMetadata& 
             toTString(formatAlbumPeak(trackMetadata)));
 
     writeAPEItem(pTag, "MUSICBRAINZ_ARTISTID",
-            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzArtistId()));
+            uuidToTString(trackMetadata.getTrackInfo().getMusicBrainzArtistId()));
     writeAPEItem(pTag, "MUSICBRAINZ_TRACKID",
-            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzRecordingId()));
+            uuidToTString(trackMetadata.getTrackInfo().getMusicBrainzRecordingId()));
     writeAPEItem(pTag, "MUSICBRAINZ_RELEASETRACKID",
-            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()));
+            uuidToTString(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()));
     writeAPEItem(pTag, "MUSICBRAINZ_WORKID",
-            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzWorkId()));
+            uuidToTString(trackMetadata.getTrackInfo().getMusicBrainzWorkId()));
     writeAPEItem(pTag, "MUSICBRAINZ_ALBUMARTISTID",
-            uuidToTStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()));
+            uuidToTString(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()));
     writeAPEItem(pTag, "MUSICBRAINZ_ALBUMID",
-            uuidToTStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()));
+            uuidToTString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()));
     writeAPEItem(pTag, "MUSICBRAINZ_RELEASEGROUPID",
-            uuidToTStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()));
+            uuidToTString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()));
 
     writeAPEItem(pTag, "Conductor",
             toTString(trackMetadata.getTrackInfo().getConductor()));
@@ -2723,19 +2710,19 @@ bool exportTrackMetadataIntoXiphComment(TagLib::Ogg::XiphComment* pTag,
             toTString(formatAlbumPeak(trackMetadata)));
 
     writeXiphCommentField(pTag, "MUSICBRAINZ_ARTISTID",
-            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzArtistId()));
+            uuidToTString(trackMetadata.getTrackInfo().getMusicBrainzArtistId()));
     writeXiphCommentField(pTag, "MUSICBRAINZ_TRACKID",
-            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzRecordingId()));
+            uuidToTString(trackMetadata.getTrackInfo().getMusicBrainzRecordingId()));
     writeXiphCommentField(pTag, "MUSICBRAINZ_RELEASETRACKID",
-            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()));
+            uuidToTString(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()));
     writeXiphCommentField(pTag, "MUSICBRAINZ_WORKID",
-            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzWorkId()));
+            uuidToTString(trackMetadata.getTrackInfo().getMusicBrainzWorkId()));
     writeXiphCommentField(pTag, "MUSICBRAINZ_ALBUMARTISTID",
-            uuidToTStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()));
+            uuidToTString(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()));
     writeXiphCommentField(pTag, "MUSICBRAINZ_ALBUMID",
-            uuidToTStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()));
+            uuidToTString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()));
     writeXiphCommentField(pTag, "MUSICBRAINZ_RELEASEGROUPID",
-            uuidToTStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()));
+            uuidToTString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()));
 
     writeXiphCommentField(pTag, "CONDUCTOR",
             toTString(trackMetadata.getTrackInfo().getConductor()));
@@ -2856,19 +2843,19 @@ bool exportTrackMetadataIntoMP4Tag(TagLib::MP4::Tag* pTag, const TrackMetadata& 
             toTString(formatAlbumPeak(trackMetadata)));
 
     writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Artist Id",
-            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzArtistId()));
+            uuidToTString(trackMetadata.getTrackInfo().getMusicBrainzArtistId()));
     writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Track Id",
-            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzRecordingId()));
+            uuidToTString(trackMetadata.getTrackInfo().getMusicBrainzRecordingId()));
     writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Release Track Id",
-            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()));
+            uuidToTString(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()));
     writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Work Id",
-            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzWorkId()));
+            uuidToTString(trackMetadata.getTrackInfo().getMusicBrainzWorkId()));
     writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Album Artist Id",
-            uuidToTStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()));
+            uuidToTString(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()));
     writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Album Id",
-            uuidToTStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()));
+            uuidToTString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()));
     writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Release Group Id",
-            uuidToTStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()));
+            uuidToTString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()));
 
     writeMP4Atom(pTag, "----:com.apple.iTunes:CONDUCTOR",
             toTString(trackMetadata.getTrackInfo().getConductor()));

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -199,10 +199,10 @@ inline QString toQString(const TagLib::String& tString) {
 }
 
 inline TagLib::String toTString(const QString& str) {
-    const QByteArray qba(str.toUtf8());
     if (str.isNull()) {
         return TagLib::String::null;
     } else {
+        const QByteArray qba(str.toUtf8());
         return TagLib::String(qba.constData(), TagLib::String::UTF8);
     }
 }

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -3,6 +3,7 @@
 #include "track/tracknumbers.h"
 
 #include "util/assert.h"
+#include "util/compatibility.h"
 #include "util/duration.h"
 #include "util/logger.h"
 #include "util/memory.h"
@@ -264,24 +265,8 @@ inline TagLib::ByteVector toTagLibByteVector(const QByteArray& bytearray) {
     }
 }
 
-inline QString formatUuid(const QUuid& uuid) {
-    if (uuid.isNull()) {
-        return QString();
-    } else {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
-        return uuid.toString(QUuid::WithoutBraces);
-#else
-        QString uuidWithBraces = uuid.toString();
-        DEBUG_ASSERT(uuidWithBraces.size() == 38);
-        DEBUG_ASSERT(uuidWithBraces.startsWith('{'));
-        DEBUG_ASSERT(uuidWithBraces.endsWith('}'));
-        return uuidWithBraces.mid(1, 36);
-#endif
-    }
-}
-
 inline TagLib::String toTagLibString(const QUuid& uuid) {
-    return toTagLibString(formatUuid(uuid));
+    return toTagLibString(uuidToStringWithoutBraces(uuid));
 }
 #endif // __EXTRA_METADATA__
 
@@ -2434,7 +2419,7 @@ bool exportTrackMetadataIntoID3v2Tag(TagLib::ID3v2::Tag* pTag,
     writeID3v2UserTextIdentificationFrame(
             pTag,
             "MusicBrainz Artist Id",
-            formatUuid(trackMetadata.getTrackInfo().getMusicBrainzArtistId()),
+            uuidToStringWithoutBraces(trackMetadata.getTrackInfo().getMusicBrainzArtistId()),
             false);
     {
         QByteArray identifier = trackMetadata.getTrackInfo().getMusicBrainzRecordingId().toByteArray();
@@ -2453,27 +2438,27 @@ bool exportTrackMetadataIntoID3v2Tag(TagLib::ID3v2::Tag* pTag,
     writeID3v2UserTextIdentificationFrame(
             pTag,
             "MusicBrainz Release Track Id",
-            formatUuid(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()),
+            uuidToStringWithoutBraces(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()),
             false);
     writeID3v2UserTextIdentificationFrame(
             pTag,
             "MusicBrainz Work Id",
-            formatUuid(trackMetadata.getTrackInfo().getMusicBrainzWorkId()),
+            uuidToStringWithoutBraces(trackMetadata.getTrackInfo().getMusicBrainzWorkId()),
             false);
     writeID3v2UserTextIdentificationFrame(
             pTag,
             "MusicBrainz Album Artist Id",
-            formatUuid(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()),
+            uuidToStringWithoutBraces(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()),
             false);
     writeID3v2UserTextIdentificationFrame(
             pTag,
             "MusicBrainz Album Id",
-            formatUuid(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()),
+            uuidToStringWithoutBraces(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()),
             false);
     writeID3v2UserTextIdentificationFrame(
             pTag,
             "MusicBrainz Release Group Id",
-            formatUuid(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()),
+            uuidToStringWithoutBraces(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()),
             false);
 
     writeID3v2TextIdentificationFrame(

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -198,6 +198,15 @@ inline QString toQString(const TagLib::String& tString) {
     }
 }
 
+inline TagLib::String toTString(const QString& str) {
+    const QByteArray qba(str.toUtf8());
+    if (str.isNull()) {
+        return TagLib::String::null;
+    } else {
+        return TagLib::String(qba.constData(), TagLib::String::UTF8);
+    }
+}
+
 // Returns the first element of TagLib string list that is not empty.
 QString toQStringFirstNotEmpty(const TagLib::StringList& strList) {
     for (const auto& str: strList) {
@@ -238,15 +247,6 @@ inline QString toQStringFirstNotEmpty(const TagLib::MP4::Item& mp4Item) {
     return toQStringFirstNotEmpty(mp4Item.toStringList());
 }
 
-inline TagLib::String toTagLibString(const QString& str) {
-    const QByteArray qba(str.toUtf8());
-    if (str.isNull()) {
-        return TagLib::String::null;
-    } else {
-        return TagLib::String(qba.constData(), TagLib::String::UTF8);
-    }
-}
-
 #if defined(__EXTRA_METADATA__)
 inline QByteArray toQByteArray(const TagLib::ByteVector& tByteVector) {
     if (tByteVector.isNull()) {
@@ -257,7 +257,7 @@ inline QByteArray toQByteArray(const TagLib::ByteVector& tByteVector) {
     }
 }
 
-inline TagLib::ByteVector toTagLibByteVector(const QByteArray& bytearray) {
+inline TagLib::ByteVector toTByteVector(const QByteArray& bytearray) {
     if (bytearray.isNull()) {
         return TagLib::ByteVector::null;
     } else {
@@ -279,7 +279,7 @@ TagLib::String uuidToTStringWithoutBracesNullable(const QUuid& uuid) {
     if (uuid.isNull()) {
         return TagLib::String::null;
     } else {
-        return toTagLibString(uuidToStringWithoutBraces(uuid));
+        return toTString(uuidToStringWithoutBraces(uuid));
     }
 }
 
@@ -755,7 +755,7 @@ void writeID3v2TextIdentificationFrame(
                 getID3v2StringType(*pTag, isNumericOrURL);
         auto pFrame =
                 std::make_unique<TagLib::ID3v2::TextIdentificationFrame>(id, stringType);
-        pFrame->setText(toTagLibString(text));
+        pFrame->setText(toTString(text));
         pTag->addFrame(pFrame.get());
         // Now that the plain pointer in pFrame is owned and managed by
         // pTag we need to release the ownership to avoid double deletion!
@@ -776,8 +776,8 @@ void writeID3v2UserTextIdentificationFrame(
             // Purge empty frames
             pTag->removeFrame(pFrame);
         } else {
-            pFrame->setDescription(toTagLibString(description));
-            pFrame->setText(toTagLibString(text));
+            pFrame->setDescription(toTString(description));
+            pFrame->setText(toTString(text));
         }
     } else {
         // Add a new (non-empty) frame
@@ -786,8 +786,8 @@ void writeID3v2UserTextIdentificationFrame(
                     getID3v2StringType(*pTag, isNumericOrURL);
             auto pFrame =
                     std::make_unique<TagLib::ID3v2::UserTextIdentificationFrame>(stringType);
-            pFrame->setDescription(toTagLibString(description));
-            pFrame->setText(toTagLibString(text));
+            pFrame->setDescription(toTString(description));
+            pFrame->setText(toTString(text));
             pTag->addFrame(pFrame.get());
             // Now that the plain pointer in pFrame is owned and managed by
             // pTag we need to release the ownership to avoid double deletion!
@@ -850,8 +850,8 @@ void writeID3v2CommentsFrame(
             // Purge empty frames
             pTag->removeFrame(pFrame);
         } else {
-            pFrame->setDescription(toTagLibString(description));
-            pFrame->setText(toTagLibString(text));
+            pFrame->setDescription(toTString(description));
+            pFrame->setText(toTString(text));
         }
     } else {
         // Add a new (non-empty) frame
@@ -860,8 +860,8 @@ void writeID3v2CommentsFrame(
                     getID3v2StringType(*pTag, isNumericOrURL);
             auto pFrame =
                     std::make_unique<TagLib::ID3v2::CommentsFrame>(stringType);
-            pFrame->setDescription(toTagLibString(description));
-            pFrame->setText(toTagLibString(text));
+            pFrame->setDescription(toTString(description));
+            pFrame->setText(toTString(text));
             pTag->addFrame(pFrame.get());
             // Now that the plain pointer in pFrame is owned and managed by
             // pTag we need to release the ownership to avoid double deletion!
@@ -899,7 +899,7 @@ void writeID3v2UniqueFileIdentifierFrame(
             // Purge empty frames
             pTag->removeFrame(pFrame);
         } else {
-            pFrame->setOwner(toTagLibString(owner));
+            pFrame->setOwner(toTString(owner));
             pFrame->setIdentifier(TagLib::ByteVector(identifier.constData(), identifier.size()));
         }
     } else {
@@ -907,7 +907,7 @@ void writeID3v2UniqueFileIdentifierFrame(
         if (!identifier.isEmpty()) {
             auto pFrame =
                     std::make_unique<TagLib::ID3v2::UniqueFileIdentifierFrame>(
-                            toTagLibString(owner),
+                            toTString(owner),
                             TagLib::ByteVector(identifier.constData(), identifier.size()));
             pTag->addFrame(pFrame.get());
             // Now that the plain pointer in pFrame is owned and managed by
@@ -929,16 +929,16 @@ void writeID3v2GeneralEncapsulatedObjectFrame(
             // Purge empty frames
             pTag->removeFrame(pFrame);
         } else {
-            pFrame->setDescription(toTagLibString(description));
-            pFrame->setObject(toTagLibByteVector(data));
+            pFrame->setDescription(toTString(description));
+            pFrame->setObject(toTByteVector(data));
         }
     } else {
         // Add a new (non-empty) frame
         if (!data.isEmpty()) {
             auto pFrame =
                     std::make_unique<TagLib::ID3v2::GeneralEncapsulatedObjectFrame>();
-            pFrame->setDescription(toTagLibString(description));
-            pFrame->setObject(toTagLibByteVector(data));
+            pFrame->setDescription(toTString(description));
+            pFrame->setObject(toTByteVector(data));
             pTag->addFrame(pFrame.get());
             // Now that the plain pointer in pFrame is owned and managed by
             // pTag we need to release the ownership to avoid double deletion!
@@ -2256,17 +2256,17 @@ void exportTrackMetadataIntoTag(
         int writeMask) {
     DEBUG_ASSERT(pTag); // already validated before
 
-    pTag->setArtist(toTagLibString(trackMetadata.getTrackInfo().getArtist()));
-    pTag->setTitle(toTagLibString(trackMetadata.getTrackInfo().getTitle()));
-    pTag->setAlbum(toTagLibString(trackMetadata.getAlbumInfo().getTitle()));
-    pTag->setGenre(toTagLibString(trackMetadata.getTrackInfo().getGenre()));
+    pTag->setArtist(toTString(trackMetadata.getTrackInfo().getArtist()));
+    pTag->setTitle(toTString(trackMetadata.getTrackInfo().getTitle()));
+    pTag->setAlbum(toTString(trackMetadata.getAlbumInfo().getTitle()));
+    pTag->setGenre(toTString(trackMetadata.getTrackInfo().getGenre()));
 
     // Using setComment() from TagLib::Tag might have undesirable
     // effects if the tag type supports multiple comment fields for
     // different purposes, e.g. ID3v2. In this case setting the
     // comment here should be omitted.
     if (0 == (writeMask & WRITE_TAG_OMIT_COMMENT)) {
-        pTag->setComment(toTagLibString(trackMetadata.getTrackInfo().getComment()));
+        pTag->setComment(toTString(trackMetadata.getTrackInfo().getComment()));
     }
 
     // Specialized write functions for tags derived from Taglib::Tag might
@@ -2551,41 +2551,41 @@ bool exportTrackMetadataIntoAPETag(TagLib::APE::Tag* pTag, const TrackMetadata& 
     // part of the tag with the custom string from the track metadata
     // (pass-through without any further validation)
     writeAPEItem(pTag, "Track",
-            toTagLibString(TrackNumbers::joinStrings(
+            toTString(TrackNumbers::joinStrings(
                     trackMetadata.getTrackInfo().getTrackNumber(),
                     trackMetadata.getTrackInfo().getTrackTotal())));
 
     writeAPEItem(pTag, "Year",
-            toTagLibString(trackMetadata.getTrackInfo().getYear()));
+            toTString(trackMetadata.getTrackInfo().getYear()));
 
     writeAPEItem(pTag, "Album Artist",
-            toTagLibString(trackMetadata.getAlbumInfo().getArtist()));
+            toTString(trackMetadata.getAlbumInfo().getArtist()));
     writeAPEItem(pTag, "Composer",
-            toTagLibString(trackMetadata.getTrackInfo().getComposer()));
+            toTString(trackMetadata.getTrackInfo().getComposer()));
     writeAPEItem(pTag, "Grouping",
-            toTagLibString(trackMetadata.getTrackInfo().getGrouping()));
+            toTString(trackMetadata.getTrackInfo().getGrouping()));
 
     writeAPEItem(pTag, "BPM",
-            toTagLibString(formatBpm(trackMetadata)));
+            toTString(formatBpm(trackMetadata)));
 
     writeAPEItem(pTag, "INITIALKEY",
-            toTagLibString(trackMetadata.getTrackInfo().getKey()));
+            toTString(trackMetadata.getTrackInfo().getKey()));
 
     writeAPEItem(pTag, "REPLAYGAIN_TRACK_GAIN",
-            toTagLibString(formatTrackGain(trackMetadata)));
+            toTString(formatTrackGain(trackMetadata)));
     writeAPEItem(pTag, "REPLAYGAIN_TRACK_PEAK",
-            toTagLibString(formatTrackPeak(trackMetadata)));
+            toTString(formatTrackPeak(trackMetadata)));
 
 #if defined(__EXTRA_METADATA__)
     auto discNumbers = TrackNumbers::joinStrings(
             trackMetadata.getTrackInfo().getDiscNumber(),
             trackMetadata.getTrackInfo().getDiscTotal());
-    writeAPEItem(pTag, "Disc", toTagLibString(discNumbers));
+    writeAPEItem(pTag, "Disc", toTString(discNumbers));
 
     writeAPEItem(pTag, "REPLAYGAIN_ALBUM_GAIN",
-            toTagLibString(formatAlbumGain(trackMetadata)));
+            toTString(formatAlbumGain(trackMetadata)));
     writeAPEItem(pTag, "REPLAYGAIN_ALBUM_PEAK",
-            toTagLibString(formatAlbumPeak(trackMetadata)));
+            toTString(formatAlbumPeak(trackMetadata)));
 
     writeAPEItem(pTag, "MUSICBRAINZ_ARTISTID",
             uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzArtistId()));
@@ -2603,29 +2603,29 @@ bool exportTrackMetadataIntoAPETag(TagLib::APE::Tag* pTag, const TrackMetadata& 
             uuidToTStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()));
 
     writeAPEItem(pTag, "Conductor",
-            toTagLibString(trackMetadata.getTrackInfo().getConductor()));
+            toTString(trackMetadata.getTrackInfo().getConductor()));
     writeAPEItem(pTag, "ISRC",
-            toTagLibString(trackMetadata.getTrackInfo().getISRC()));
+            toTString(trackMetadata.getTrackInfo().getISRC()));
     writeAPEItem(pTag, "Language",
-            toTagLibString(trackMetadata.getTrackInfo().getLanguage()));
+            toTString(trackMetadata.getTrackInfo().getLanguage()));
     writeAPEItem(pTag, "Lyricist",
-            toTagLibString(trackMetadata.getTrackInfo().getLyricist()));
+            toTString(trackMetadata.getTrackInfo().getLyricist()));
     writeAPEItem(pTag, "Mood",
-            toTagLibString(trackMetadata.getTrackInfo().getMood()));
+            toTString(trackMetadata.getTrackInfo().getMood()));
     writeAPEItem(pTag, "Copyright",
-            toTagLibString(trackMetadata.getAlbumInfo().getCopyright()));
+            toTString(trackMetadata.getAlbumInfo().getCopyright()));
     writeAPEItem(pTag, "LICENSE",
-            toTagLibString(trackMetadata.getAlbumInfo().getLicense()));
+            toTString(trackMetadata.getAlbumInfo().getLicense()));
     writeAPEItem(pTag, "Label",
-            toTagLibString(trackMetadata.getAlbumInfo().getRecordLabel()));
+            toTString(trackMetadata.getAlbumInfo().getRecordLabel()));
     writeAPEItem(pTag, "MixArtist",
-            toTagLibString(trackMetadata.getTrackInfo().getRemixer()));
+            toTString(trackMetadata.getTrackInfo().getRemixer()));
     writeAPEItem(pTag, "Subtitle",
-            toTagLibString(trackMetadata.getTrackInfo().getSubtitle()));
+            toTString(trackMetadata.getTrackInfo().getSubtitle()));
     writeAPEItem(pTag, "EncodedBy",
-            toTagLibString(trackMetadata.getTrackInfo().getEncoder()));
+            toTString(trackMetadata.getTrackInfo().getEncoder()));
     writeAPEItem(pTag, "EncoderSettings",
-            toTagLibString(trackMetadata.getTrackInfo().getEncoderSettings()));
+            toTString(trackMetadata.getTrackInfo().getEncoderSettings()));
 #endif // __EXTRA_METADATA__
 
     return true;
@@ -2650,40 +2650,40 @@ bool exportTrackMetadataIntoXiphComment(TagLib::Ogg::XiphComment* pTag,
     if (hasXiphCommentField(*pTag, "COMMENT") || !hasXiphCommentField(*pTag, "DESCRIPTION")) {
         // MusicBrainz-style
         writeXiphCommentField(pTag, "COMMENT",
-                toTagLibString(trackMetadata.getTrackInfo().getComment()));
+                toTString(trackMetadata.getTrackInfo().getComment()));
     } else {
         // Preserve and update the "DESCRIPTION" field only if it already exists
         DEBUG_ASSERT(hasXiphCommentField(*pTag, "DESCRIPTION"));
         writeXiphCommentField(pTag, "DESCRIPTION",
-                toTagLibString(trackMetadata.getTrackInfo().getComment()));
+                toTString(trackMetadata.getTrackInfo().getComment()));
     }
 
     // Write unambiguous fields
     writeXiphCommentField(pTag, "DATE",
-            toTagLibString(trackMetadata.getTrackInfo().getYear()));
+            toTString(trackMetadata.getTrackInfo().getYear()));
     writeXiphCommentField(pTag, "COMPOSER",
-            toTagLibString(trackMetadata.getTrackInfo().getComposer()));
+            toTString(trackMetadata.getTrackInfo().getComposer()));
     writeXiphCommentField(pTag, "GROUPING",
-            toTagLibString(trackMetadata.getTrackInfo().getGrouping()));
+            toTString(trackMetadata.getTrackInfo().getGrouping()));
     writeXiphCommentField(pTag, "TRACKNUMBER",
-            toTagLibString(trackMetadata.getTrackInfo().getTrackNumber()));
+            toTString(trackMetadata.getTrackInfo().getTrackNumber()));
 
     // According to https://wiki.xiph.org/Field_names "TRACKTOTAL" is
     // the proposed field name, but some applications use "TOTALTRACKS".
     const TagLib::String trackTotal(
-            toTagLibString(trackMetadata.getTrackInfo().getTrackTotal()));
+            toTString(trackMetadata.getTrackInfo().getTrackTotal()));
     writeXiphCommentField(pTag, "TRACKTOTAL", trackTotal); // recommended field
     updateXiphCommentField(pTag, "TOTALTRACKS", trackTotal); // alternative field
 
     const TagLib::String albumArtist(
-            toTagLibString(trackMetadata.getAlbumInfo().getArtist()));
+            toTString(trackMetadata.getAlbumInfo().getArtist()));
     writeXiphCommentField(pTag, "ALBUMARTIST", albumArtist); // recommended field
     updateXiphCommentField(pTag, "ALBUM_ARTIST", albumArtist); // alternative field
     updateXiphCommentField(pTag, "ALBUM ARTIST", albumArtist); // alternative field
     updateXiphCommentField(pTag, "ENSEMBLE", albumArtist); // alternative field
 
     const TagLib::String bpm(
-            toTagLibString(formatBpm(trackMetadata)));
+            toTString(formatBpm(trackMetadata)));
     // MusicBrainz recommends "BPM": https://picard.musicbrainz.org/docs/mappings
     // Mixxx (<= 2.0) favored "TEMPO": https://www.mixxx.org/wiki/doku.php/library_metadata_rewrite_using_taglib
     if (hasXiphCommentField(*pTag, "BPM") || !hasXiphCommentField(*pTag, "TEMPO")) {
@@ -2697,30 +2697,30 @@ bool exportTrackMetadataIntoXiphComment(TagLib::Ogg::XiphComment* pTag,
 
     // Write both INITIALKEY and KEY
     const TagLib::String key(
-            toTagLibString(trackMetadata.getTrackInfo().getKey()));
+            toTString(trackMetadata.getTrackInfo().getKey()));
     writeXiphCommentField(pTag, "INITIALKEY", key); // recommended field
     updateXiphCommentField(pTag, "KEY", key); // alternative field
 
     writeXiphCommentField(pTag, "REPLAYGAIN_TRACK_GAIN",
-            toTagLibString(formatTrackGain(trackMetadata)));
+            toTString(formatTrackGain(trackMetadata)));
     // NOTE(uklotzde, 2018-04-22): The analyzers currently doesn't
     // calculate a peak value, so leave it untouched in the file if
     // the value is invalid/absent. Otherwise the comment field would
     // be deleted.
     writeXiphCommentField(pTag, "REPLAYGAIN_TRACK_PEAK",
-            toTagLibString(formatTrackPeak(trackMetadata)));
+            toTString(formatTrackPeak(trackMetadata)));
 
 #if defined(__EXTRA_METADATA__)
     // According to https://wiki.xiph.org/Field_names "DISCTOTAL" is
     // the proposed field name, but some applications use "TOTALDISCS".
-    const TagLib::String discTotal(toTagLibString(trackMetadata.getTrackInfo().getDiscTotal()));
+    const TagLib::String discTotal(toTString(trackMetadata.getTrackInfo().getDiscTotal()));
     writeXiphCommentField(pTag, "DISCTOTAL", discTotal);   // recommended field
     updateXiphCommentField(pTag, "TOTALDISCS", discTotal); // alternative field
 
     writeXiphCommentField(pTag, "REPLAYGAIN_ALBUM_GAIN",
-            toTagLibString(formatAlbumGain(trackMetadata)));
+            toTString(formatAlbumGain(trackMetadata)));
     writeXiphCommentField(pTag, "REPLAYGAIN_ALBUM_PEAK",
-            toTagLibString(formatAlbumPeak(trackMetadata)));
+            toTString(formatAlbumPeak(trackMetadata)));
 
     writeXiphCommentField(pTag, "MUSICBRAINZ_ARTISTID",
             uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzArtistId()));
@@ -2738,31 +2738,31 @@ bool exportTrackMetadataIntoXiphComment(TagLib::Ogg::XiphComment* pTag,
             uuidToTStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()));
 
     writeXiphCommentField(pTag, "CONDUCTOR",
-            toTagLibString(trackMetadata.getTrackInfo().getConductor()));
+            toTString(trackMetadata.getTrackInfo().getConductor()));
     writeXiphCommentField(pTag, "ISRC",
-            toTagLibString(trackMetadata.getTrackInfo().getISRC()));
+            toTString(trackMetadata.getTrackInfo().getISRC()));
     writeXiphCommentField(pTag, "LANGUAGE",
-            toTagLibString(trackMetadata.getTrackInfo().getLanguage()));
+            toTString(trackMetadata.getTrackInfo().getLanguage()));
     writeXiphCommentField(pTag, "LYRICIST",
-            toTagLibString(trackMetadata.getTrackInfo().getLyricist()));
+            toTString(trackMetadata.getTrackInfo().getLyricist()));
     writeXiphCommentField(pTag, "MOOD",
-            toTagLibString(trackMetadata.getTrackInfo().getMood()));
+            toTString(trackMetadata.getTrackInfo().getMood()));
     writeXiphCommentField(pTag, "COPYRIGHT",
-            toTagLibString(trackMetadata.getAlbumInfo().getCopyright()));
+            toTString(trackMetadata.getAlbumInfo().getCopyright()));
     writeXiphCommentField(pTag, "LICENSE",
-            toTagLibString(trackMetadata.getAlbumInfo().getLicense()));
+            toTString(trackMetadata.getAlbumInfo().getLicense()));
     writeXiphCommentField(pTag, "LABEL",
-            toTagLibString(trackMetadata.getAlbumInfo().getRecordLabel()));
+            toTString(trackMetadata.getAlbumInfo().getRecordLabel()));
     writeXiphCommentField(pTag, "REMIXER",
-            toTagLibString(trackMetadata.getTrackInfo().getRemixer()));
+            toTString(trackMetadata.getTrackInfo().getRemixer()));
     writeXiphCommentField(pTag, "SUBTITLE",
-            toTagLibString(trackMetadata.getTrackInfo().getSubtitle()));
+            toTString(trackMetadata.getTrackInfo().getSubtitle()));
     writeXiphCommentField(pTag, "ENCODEDBY",
-            toTagLibString(trackMetadata.getTrackInfo().getEncoder()));
+            toTString(trackMetadata.getTrackInfo().getEncoder()));
     writeXiphCommentField(pTag, "ENCODERSETTINGS",
-            toTagLibString(trackMetadata.getTrackInfo().getEncoderSettings()));
+            toTString(trackMetadata.getTrackInfo().getEncoderSettings()));
     writeXiphCommentField(
-            pTag, "DISCNUMBER", toTagLibString(trackMetadata.getTrackInfo().getDiscNumber()));
+            pTag, "DISCNUMBER", toTString(trackMetadata.getTrackInfo().getDiscNumber()));
 #endif // __EXTRA_METADATA__
 
     return true;
@@ -2799,11 +2799,11 @@ bool exportTrackMetadataIntoMP4Tag(TagLib::MP4::Tag* pTag, const TrackMetadata& 
                     trackMetadata.getTrackInfo().getTrackTotal());
     }
 
-    writeMP4Atom(pTag, "\251day", toTagLibString(trackMetadata.getTrackInfo().getYear()));
+    writeMP4Atom(pTag, "\251day", toTString(trackMetadata.getTrackInfo().getYear()));
 
-    writeMP4Atom(pTag, "aART", toTagLibString(trackMetadata.getAlbumInfo().getArtist()));
-    writeMP4Atom(pTag, "\251wrt", toTagLibString(trackMetadata.getTrackInfo().getComposer()));
-    writeMP4Atom(pTag, "\251grp", toTagLibString(trackMetadata.getTrackInfo().getGrouping()));
+    writeMP4Atom(pTag, "aART", toTString(trackMetadata.getAlbumInfo().getArtist()));
+    writeMP4Atom(pTag, "\251wrt", toTString(trackMetadata.getTrackInfo().getComposer()));
+    writeMP4Atom(pTag, "\251grp", toTString(trackMetadata.getTrackInfo().getGrouping()));
 
     // Write both BPM fields (just in case)
     if (trackMetadata.getTrackInfo().getBpm().hasValue()) {
@@ -2815,17 +2815,17 @@ bool exportTrackMetadataIntoMP4Tag(TagLib::MP4::Tag* pTag, const TrackMetadata& 
         pTag->itemListMap().erase("tmpo");
     }
     writeMP4Atom(pTag, "----:com.apple.iTunes:BPM",
-            toTagLibString(formatBpm(trackMetadata)));
+            toTString(formatBpm(trackMetadata)));
 
     const TagLib::String key =
-            toTagLibString(trackMetadata.getTrackInfo().getKey());
+            toTString(trackMetadata.getTrackInfo().getKey());
     writeMP4Atom(pTag, "----:com.apple.iTunes:initialkey", key); // preferred
     updateMP4Atom(pTag, "----:com.apple.iTunes:KEY", key); // alternative
 
     writeMP4Atom(pTag, "----:com.apple.iTunes:replaygain_track_gain",
-            toTagLibString(formatTrackGain(trackMetadata)));
+            toTString(formatTrackGain(trackMetadata)));
     writeMP4Atom(pTag, "----:com.apple.iTunes:replaygain_track_peak",
-            toTagLibString(formatTrackPeak(trackMetadata)));
+            toTString(formatTrackPeak(trackMetadata)));
 
 #if defined(__EXTRA_METADATA__)
     // Write disc number/total pair
@@ -2851,9 +2851,9 @@ bool exportTrackMetadataIntoMP4Tag(TagLib::MP4::Tag* pTag, const TrackMetadata& 
     }
 
     writeMP4Atom(pTag, "----:com.apple.iTunes:replaygain_album_gain",
-            toTagLibString(formatAlbumGain(trackMetadata)));
+            toTString(formatAlbumGain(trackMetadata)));
     writeMP4Atom(pTag, "----:com.apple.iTunes:replaygain_album_peak",
-            toTagLibString(formatAlbumPeak(trackMetadata)));
+            toTString(formatAlbumPeak(trackMetadata)));
 
     writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Artist Id",
             uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzArtistId()));
@@ -2871,31 +2871,31 @@ bool exportTrackMetadataIntoMP4Tag(TagLib::MP4::Tag* pTag, const TrackMetadata& 
             uuidToTStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()));
 
     writeMP4Atom(pTag, "----:com.apple.iTunes:CONDUCTOR",
-            toTagLibString(trackMetadata.getTrackInfo().getConductor()));
+            toTString(trackMetadata.getTrackInfo().getConductor()));
     writeMP4Atom(pTag, "----:com.apple.iTunes:ISRC",
-            toTagLibString(trackMetadata.getTrackInfo().getISRC()));
+            toTString(trackMetadata.getTrackInfo().getISRC()));
     writeMP4Atom(pTag, "----:com.apple.iTunes:LANGUAGE",
-            toTagLibString(trackMetadata.getTrackInfo().getLanguage()));
+            toTString(trackMetadata.getTrackInfo().getLanguage()));
     writeMP4Atom(pTag, "----:com.apple.iTunes:LYRICIST",
-            toTagLibString(trackMetadata.getTrackInfo().getLyricist()));
+            toTString(trackMetadata.getTrackInfo().getLyricist()));
     writeMP4Atom(pTag, "----:com.apple.iTunes:MOOD",
-            toTagLibString(trackMetadata.getTrackInfo().getMood()));
+            toTString(trackMetadata.getTrackInfo().getMood()));
     writeMP4Atom(pTag, "cprt",
-            toTagLibString(trackMetadata.getAlbumInfo().getCopyright()));
+            toTString(trackMetadata.getAlbumInfo().getCopyright()));
     writeMP4Atom(pTag, "----:com.apple.iTunes:LICENSE",
-            toTagLibString(trackMetadata.getAlbumInfo().getLicense()));
+            toTString(trackMetadata.getAlbumInfo().getLicense()));
     writeMP4Atom(pTag, "----:com.apple.iTunes:LABEL",
-            toTagLibString(trackMetadata.getAlbumInfo().getRecordLabel()));
+            toTString(trackMetadata.getAlbumInfo().getRecordLabel()));
     writeMP4Atom(pTag, "----:com.apple.iTunes:REMIXER",
-            toTagLibString(trackMetadata.getTrackInfo().getRemixer()));
+            toTString(trackMetadata.getTrackInfo().getRemixer()));
     writeMP4Atom(pTag, "----:com.apple.iTunes:SUBTITLE",
-            toTagLibString(trackMetadata.getTrackInfo().getSubtitle()));
+            toTString(trackMetadata.getTrackInfo().getSubtitle()));
     writeMP4Atom(pTag, "\251too",
-            toTagLibString(trackMetadata.getTrackInfo().getEncoder()));
+            toTString(trackMetadata.getTrackInfo().getEncoder()));
     writeMP4Atom(pTag, "\251wrk",
-            toTagLibString(trackMetadata.getTrackInfo().getWork()));
+            toTString(trackMetadata.getTrackInfo().getWork()));
     writeMP4Atom(pTag, "\251mvn",
-            toTagLibString(trackMetadata.getTrackInfo().getMovement()));
+            toTString(trackMetadata.getTrackInfo().getMovement()));
 #endif // __EXTRA_METADATA__
 
     return true;

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -265,9 +265,24 @@ inline TagLib::ByteVector toTagLibByteVector(const QByteArray& bytearray) {
     }
 }
 
-inline TagLib::String toTagLibString(const QUuid& uuid) {
-    return toTagLibString(uuidToStringWithoutBraces(uuid));
+inline
+QString uuidToQStringWithoutBracesNullable(const QUuid& uuid) {
+    if (uuid.isNull()) {
+        return QString();
+    } else {
+        return uuidToStringWithoutBraces(uuid);
+    }
 }
+
+inline
+TagLib::String uuidToTStringWithoutBracesNullable(const QUuid& uuid) {
+    if (uuid.isNull()) {
+        return TagLib::String::null;
+    } else {
+        return toTagLibString(uuidToStringWithoutBraces(uuid));
+    }
+}
+
 #endif // __EXTRA_METADATA__
 
 inline QString formatBpm(const TrackMetadata& trackMetadata) {
@@ -2419,7 +2434,7 @@ bool exportTrackMetadataIntoID3v2Tag(TagLib::ID3v2::Tag* pTag,
     writeID3v2UserTextIdentificationFrame(
             pTag,
             "MusicBrainz Artist Id",
-            uuidToStringWithoutBraces(trackMetadata.getTrackInfo().getMusicBrainzArtistId()),
+            uuidToQStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzArtistId()),
             false);
     {
         QByteArray identifier = trackMetadata.getTrackInfo().getMusicBrainzRecordingId().toByteArray();
@@ -2438,27 +2453,27 @@ bool exportTrackMetadataIntoID3v2Tag(TagLib::ID3v2::Tag* pTag,
     writeID3v2UserTextIdentificationFrame(
             pTag,
             "MusicBrainz Release Track Id",
-            uuidToStringWithoutBraces(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()),
+            uuidToQStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()),
             false);
     writeID3v2UserTextIdentificationFrame(
             pTag,
             "MusicBrainz Work Id",
-            uuidToStringWithoutBraces(trackMetadata.getTrackInfo().getMusicBrainzWorkId()),
+            uuidToQStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzWorkId()),
             false);
     writeID3v2UserTextIdentificationFrame(
             pTag,
             "MusicBrainz Album Artist Id",
-            uuidToStringWithoutBraces(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()),
+            uuidToQStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()),
             false);
     writeID3v2UserTextIdentificationFrame(
             pTag,
             "MusicBrainz Album Id",
-            uuidToStringWithoutBraces(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()),
+            uuidToQStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()),
             false);
     writeID3v2UserTextIdentificationFrame(
             pTag,
             "MusicBrainz Release Group Id",
-            uuidToStringWithoutBraces(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()),
+            uuidToQStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()),
             false);
 
     writeID3v2TextIdentificationFrame(
@@ -2573,19 +2588,19 @@ bool exportTrackMetadataIntoAPETag(TagLib::APE::Tag* pTag, const TrackMetadata& 
             toTagLibString(formatAlbumPeak(trackMetadata)));
 
     writeAPEItem(pTag, "MUSICBRAINZ_ARTISTID",
-            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzArtistId()));
+            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzArtistId()));
     writeAPEItem(pTag, "MUSICBRAINZ_TRACKID",
-            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzRecordingId()));
+            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzRecordingId()));
     writeAPEItem(pTag, "MUSICBRAINZ_RELEASETRACKID",
-            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()));
+            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()));
     writeAPEItem(pTag, "MUSICBRAINZ_WORKID",
-            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzWorkId()));
+            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzWorkId()));
     writeAPEItem(pTag, "MUSICBRAINZ_ALBUMARTISTID",
-            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()));
+            uuidToTStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()));
     writeAPEItem(pTag, "MUSICBRAINZ_ALBUMID",
-            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()));
+            uuidToTStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()));
     writeAPEItem(pTag, "MUSICBRAINZ_RELEASEGROUPID",
-            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()));
+            uuidToTStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()));
 
     writeAPEItem(pTag, "Conductor",
             toTagLibString(trackMetadata.getTrackInfo().getConductor()));
@@ -2708,19 +2723,19 @@ bool exportTrackMetadataIntoXiphComment(TagLib::Ogg::XiphComment* pTag,
             toTagLibString(formatAlbumPeak(trackMetadata)));
 
     writeXiphCommentField(pTag, "MUSICBRAINZ_ARTISTID",
-            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzArtistId()));
+            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzArtistId()));
     writeXiphCommentField(pTag, "MUSICBRAINZ_TRACKID",
-            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzRecordingId()));
+            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzRecordingId()));
     writeXiphCommentField(pTag, "MUSICBRAINZ_RELEASETRACKID",
-            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()));
+            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()));
     writeXiphCommentField(pTag, "MUSICBRAINZ_WORKID",
-            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzWorkId()));
+            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzWorkId()));
     writeXiphCommentField(pTag, "MUSICBRAINZ_ALBUMARTISTID",
-            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()));
+            uuidToTStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()));
     writeXiphCommentField(pTag, "MUSICBRAINZ_ALBUMID",
-            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()));
+            uuidToTStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()));
     writeXiphCommentField(pTag, "MUSICBRAINZ_RELEASEGROUPID",
-            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()));
+            uuidToTStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()));
 
     writeXiphCommentField(pTag, "CONDUCTOR",
             toTagLibString(trackMetadata.getTrackInfo().getConductor()));
@@ -2841,19 +2856,19 @@ bool exportTrackMetadataIntoMP4Tag(TagLib::MP4::Tag* pTag, const TrackMetadata& 
             toTagLibString(formatAlbumPeak(trackMetadata)));
 
     writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Artist Id",
-            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzArtistId()));
+            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzArtistId()));
     writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Track Id",
-            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzRecordingId()));
+            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzRecordingId()));
     writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Release Track Id",
-            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()));
+            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()));
     writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Work Id",
-            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzWorkId()));
+            uuidToTStringWithoutBracesNullable(trackMetadata.getTrackInfo().getMusicBrainzWorkId()));
     writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Album Artist Id",
-            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()));
+            uuidToTStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()));
     writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Album Id",
-            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()));
+            uuidToTStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()));
     writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Release Group Id",
-            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()));
+            uuidToTStringWithoutBracesNullable(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()));
 
     writeMP4Atom(pTag, "----:com.apple.iTunes:CONDUCTOR",
             toTagLibString(trackMetadata.getTrackInfo().getConductor()));

--- a/src/util/compatibility.h
+++ b/src/util/compatibility.h
@@ -114,6 +114,15 @@ QString uuidToStringWithoutBraces(const QUuid& uuid) {
 #endif
 }
 
+inline
+QString uuidToNullableStringWithoutBraces(const QUuid& uuid) {
+    if (uuid.isNull()) {
+        return QString();
+    } else {
+        return uuidToStringWithoutBraces(uuid);
+    }
+}
+
 template <typename T>
 inline T atomicLoadAcquire(const QAtomicInteger<T>& atomicInt) {
     // TODO: QBasicAtomicInteger<T>::load() is deprecated and should be

--- a/src/util/compatibility.h
+++ b/src/util/compatibility.h
@@ -1,10 +1,10 @@
-#ifndef COMPATABILITY_H
-#define COMPATABILITY_H
+#pragma once
 
 #include <QCoreApplication>
 #include <QGuiApplication>
 #include <QList>
 #include <QScreen>
+#include <QUuid>
 #include <QWindow>
 #include <QWidget>
 
@@ -100,6 +100,20 @@ inline QScreen* getPrimaryScreen() {
     return nullptr;
 }
 
+inline
+QString uuidToStringWithoutBraces(const QUuid& uuid) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    return uuid.toString(QUuid::WithoutBraces);
+#else
+    QString withBraces = uuid.toString();
+    DEBUG_ASSERT(withBraces.size() == 38);
+    DEBUG_ASSERT(withBraces.startsWith('{'));
+    DEBUG_ASSERT(withBraces.endsWith('}'));
+    // We need to strip off the heading/trailing curly braces after formatting
+    return withBraces.mid(1, 36);
+#endif
+}
+
 template <typename T>
 inline T atomicLoadAcquire(const QAtomicInteger<T>& atomicInt) {
     // TODO: QBasicAtomicInteger<T>::load() is deprecated and should be
@@ -183,5 +197,3 @@ inline void atomicStoreRelaxed(QAtomicPointer<T>& atomicPtr, T* newValue) {
     atomicPtr.store(newValue);
 #endif
 }
-
-#endif /* COMPATABILITY_H */


### PR DESCRIPTION
Formatting UUIDs without braces will soon is needed for various features (aoide, MusicBrainz). I have added a utility function that takes into account Qt backward compatibility.

Thereby I noticed that null UUIDs were exported into file tags. This was unintended. Fixed.

The last commit adjusts the naming of central TagLib string conversion function and causes most of the changes.