### PR TITLE
Conversion functions for RgbColor

### DIFF
--- a/src/control/convert.h
+++ b/src/control/convert.h
@@ -7,23 +7,21 @@ namespace mixxx {
 
 namespace control {
 
-typedef double value_t;
+constexpr double kInvalidRgbColor = -1.0;
 
-constexpr value_t kInvalidRgbColor = -1.0;
-
-inline value_t valueFromRgbColor(RgbColor color) {
+inline double doubleFromRgbColor(RgbColor color) {
     return static_cast<RgbColor::code_t>(color);
 }
 
-inline value_t valueFromRgbColor(RgbColor::optional_t color) {
+inline double doubleFromRgbColor(RgbColor::optional_t color) {
     if (color) {
-        return valueFromRgbColor(*color);
+        return doubleFromRgbColor(*color);
     } else {
         return kInvalidRgbColor;
     }
 }
 
-inline RgbColor::optional_t valueToRgbColor(value_t value) {
+inline RgbColor::optional_t doubleToRgbColor(double value) {
     if (value >= 0) {
         const auto code = static_cast<RgbColor::code_t>(value);
         // If value is out of range then unused bits will be

--- a/src/control/convert.h
+++ b/src/control/convert.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "util/color/rgbcolor.h"
+#include "util/assert.h"
+
+namespace mixxx {
+
+namespace control {
+
+typedef double value_t;
+
+constexpr value_t kInvalidRgbColor = -1.0;
+
+inline value_t valueFromRgbColor(RgbColor color) {
+    return static_cast<RgbColor::code_t>(color);
+}
+
+inline value_t valueFromRgbColor(RgbColor::optional_t color) {
+    if (color) {
+        return valueFromRgbColor(*color);
+    } else {
+        return kInvalidRgbColor;
+    }
+}
+
+inline RgbColor::optional_t valueToRgbColor(value_t value) {
+    if (value >= 0) {
+        const auto code = static_cast<RgbColor::code_t>(value);
+        // If value is out of range then unused bits will be
+        // discarded when converting into an RgbColor. Nevertheless
+        // check with a debug assertion that the given value
+        // is in range as expected. Out of range values indicate
+        // programming errors in other components.
+        DEBUG_ASSERT(RgbColor::isValidCode(code));
+        return RgbColor::optional(code);
+    } else {
+        // < 0 or NaN (if non-signalling)
+        DEBUG_ASSERT(value == kInvalidRgbColor);
+        return RgbColor::nullopt();
+    }
+}
+
+} // namespace control
+
+} // namespace mixxx

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -724,12 +724,7 @@ QVariant BaseSqlTableModel::data(const QModelIndex& index, int role) const {
     switch (role) {
         case Qt::ToolTipRole:
             if (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COLOR)) {
-                const auto color = mixxx::RgbColor::optional(value);
-                if (color) {
-                    value = mixxx::toQColor(color).name();
-                } else {
-                    value = QString();
-                }
+                value = toQString(mixxx::RgbColor::optional(value));
             }
             [[fallthrough]];
         case Qt::DisplayRole:

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -24,6 +24,7 @@
 #include "util/duration.h"
 #include "util/assert.h"
 #include "util/performancetimer.h"
+#include "util/platform.h"
 #include "widget/wlibrarytableview.h"
 
 namespace {
@@ -726,7 +727,7 @@ QVariant BaseSqlTableModel::data(const QModelIndex& index, int role) const {
             if (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COLOR)) {
                 value = toQString(mixxx::RgbColor::optional(value));
             }
-            [[fallthrough]];
+            M_FALLTHROUGH_INTENDED;
         case Qt::DisplayRole:
             if (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_DURATION)) {
                 int duration = value.toInt();

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -725,7 +725,7 @@ QVariant BaseSqlTableModel::data(const QModelIndex& index, int role) const {
     switch (role) {
         case Qt::ToolTipRole:
             if (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COLOR)) {
-                value = toQString(mixxx::RgbColor::optional(value));
+                value = mixxx::RgbColor::toQString(mixxx::RgbColor::fromQVariant(value));
             }
             M_FALLTHROUGH_INTENDED;
         case Qt::DisplayRole:

--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -416,7 +416,7 @@ void BaseTrackCache::getTrackValueForColumn(TrackPointer pTrack,
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM_LOCK) == column) {
         trackValue.setValue(pTrack->isBpmLocked());
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COLOR) == column) {
-        trackValue.setValue(toQVariant(pTrack->getColor()));
+        trackValue.setValue(mixxx::RgbColor::toQVariant(pTrack->getColor()));
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COVERART_LOCATION) == column) {
         trackValue.setValue(pTrack->getCoverInfo().coverLocation);
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COVERART_HASH) == column ||

--- a/src/library/colordelegate.cpp
+++ b/src/library/colordelegate.cpp
@@ -13,7 +13,7 @@ ColorDelegate::ColorDelegate(QTableView* pTableView)
 }
 
 void ColorDelegate::paintItem(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const {
-    const auto color = mixxx::RgbColor::optional(index.data());
+    const auto color = mixxx::RgbColor::fromQVariant(index.data());
 
     if (!color) {
         // Filter out track color that is hidden
@@ -23,7 +23,7 @@ void ColorDelegate::paintItem(QPainter* painter, const QStyleOptionViewItem& opt
         return;
     }
 
-    painter->fillRect(option.rect, toQColor(color));
+    painter->fillRect(option.rect, mixxx::RgbColor::toQColor(color));
 
     // Paint transparent highlight if row is selected
     if (option.state & QStyle::State_Selected) {

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -463,7 +463,7 @@ namespace {
         pTrackLibraryQuery->bindValue(":tracknumber", track.getTrackNumber());
         pTrackLibraryQuery->bindValue(":tracktotal", track.getTrackTotal());
         pTrackLibraryQuery->bindValue(":filetype", track.getType());
-        pTrackLibraryQuery->bindValue(":color", toQVariant(track.getColor()));
+        pTrackLibraryQuery->bindValue(":color", mixxx::RgbColor::toQVariant(track.getColor()));
         pTrackLibraryQuery->bindValue(":comment", track.getComment());
         pTrackLibraryQuery->bindValue(":url", track.getURL());
         pTrackLibraryQuery->bindValue(":duration", track.getDuration());
@@ -985,7 +985,7 @@ bool setTrackTotal(const QSqlRecord& record, const int column,
 
 bool setTrackColor(const QSqlRecord& record, const int column,
                    TrackPointer pTrack) {
-    pTrack->setColor(mixxx::RgbColor::optional(record.value(column)));
+    pTrack->setColor(mixxx::RgbColor::fromQVariant(record.value(column)));
     return false;
 }
 

--- a/src/test/rgbcolor_test.cpp
+++ b/src/test/rgbcolor_test.cpp
@@ -7,73 +7,78 @@
 namespace mixxx {
 
 TEST(RgbColorTest, fromInvalidQColor) {
-    EXPECT_FALSE(RgbColor::optional(QColor()));
-    EXPECT_EQ(RgbColor::nullopt(), RgbColor::optional(QColor()));
+    EXPECT_FALSE(RgbColor::fromQColor(QColor()));
+    EXPECT_EQ(RgbColor::nullopt(), RgbColor::fromQColor(QColor()));
 }
 
 TEST(RgbColorTest, fromQColorWithoutAlpha) {
-    EXPECT_TRUE(RgbColor::optional(QColor::fromRgb(0x000000)));
-    EXPECT_EQ(0x000000, *RgbColor::optional(QColor::fromRgb(0x000000)));
-    EXPECT_TRUE(RgbColor::optional(QColor::fromRgb(0xFF0000)));
-    EXPECT_EQ(RgbColor::optional(0xFF0000), RgbColor::optional(QColor::fromRgb(0xFF0000)));
-    EXPECT_TRUE(RgbColor::optional(QColor::fromRgb(0x00FF00)));
-    EXPECT_EQ(RgbColor::optional(0x00FF00), RgbColor::optional(QColor::fromRgb(0x00FF00)));
-    EXPECT_TRUE(RgbColor::optional(QColor::fromRgb(0x0000FF)));
-    EXPECT_EQ(RgbColor::optional(0x0000FF), RgbColor::optional(QColor::fromRgb(0x0000FF)));
-    EXPECT_TRUE(RgbColor::optional(QColor::fromRgb(0xFFFFFF)));
-    EXPECT_EQ(RgbColor::optional(0xFFFFFF), RgbColor::optional(QColor::fromRgb(0xFFFFFF)));
+    EXPECT_TRUE(RgbColor::fromQColor(QColor::fromRgb(0x000000)));
+    EXPECT_EQ(RgbColor::optional(0x000000), RgbColor::fromQColor(QColor::fromRgb(0x000000)));
+    EXPECT_TRUE(RgbColor::fromQColor(QColor::fromRgb(0xFF0000)));
+    EXPECT_EQ(RgbColor::optional(0xFF0000), RgbColor::fromQColor(QColor::fromRgb(0xFF0000)));
+    EXPECT_TRUE(RgbColor::fromQColor(QColor::fromRgb(0x00FF00)));
+    EXPECT_EQ(RgbColor::optional(0x00FF00), RgbColor::fromQColor(QColor::fromRgb(0x00FF00)));
+    EXPECT_TRUE(RgbColor::fromQColor(QColor::fromRgb(0x0000FF)));
+    EXPECT_EQ(RgbColor::optional(0x0000FF), RgbColor::fromQColor(QColor::fromRgb(0x0000FF)));
+    EXPECT_TRUE(RgbColor::fromQColor(QColor::fromRgb(0xFFFFFF)));
+    EXPECT_EQ(RgbColor::optional(0xFFFFFF), RgbColor::fromQColor(QColor::fromRgb(0xFFFFFF)));
 }
 
 TEST(RgbColorTest, fromQColorWithAlpha) {
-    EXPECT_TRUE(RgbColor::optional(QColor::fromRgba(0xAA000000)));
-    EXPECT_EQ(RgbColor::optional(0x000000), RgbColor::optional(QColor::fromRgba(0xAA000000)));
-    EXPECT_TRUE(RgbColor::optional(QColor::fromRgba(0xAAFF0000)));
-    EXPECT_EQ(RgbColor::optional(0xFF0000), RgbColor::optional(QColor::fromRgba(0xAAFF0000)));
-    EXPECT_TRUE(RgbColor::optional(QColor::fromRgba(0xAA00FF00)));
-    EXPECT_EQ(RgbColor::optional(0x00FF00), RgbColor::optional(QColor::fromRgba(0xAA00FF00)));
-    EXPECT_TRUE(RgbColor::optional(QColor::fromRgba(0xAA0000FF)));
-    EXPECT_EQ(RgbColor::optional(0x0000FF), RgbColor::optional(QColor::fromRgba(0xAA0000FF)));
-    EXPECT_TRUE(RgbColor::optional(QColor::fromRgba(0xAAFFFFFF)));
-    EXPECT_EQ(RgbColor::optional(0xFFFFFF), RgbColor::optional(QColor::fromRgba(0xAAFFFFFF)));
+    EXPECT_TRUE(RgbColor::fromQColor(QColor::fromRgba(0xAA000000)));
+    EXPECT_EQ(RgbColor::optional(0x000000), RgbColor::fromQColor(QColor::fromRgba(0xAA000000)));
+    EXPECT_TRUE(RgbColor::fromQColor(QColor::fromRgba(0xAAFF0000)));
+    EXPECT_EQ(RgbColor::optional(0xFF0000), RgbColor::fromQColor(QColor::fromRgba(0xAAFF0000)));
+    EXPECT_TRUE(RgbColor::fromQColor(QColor::fromRgba(0xAA00FF00)));
+    EXPECT_EQ(RgbColor::optional(0x00FF00), RgbColor::fromQColor(QColor::fromRgba(0xAA00FF00)));
+    EXPECT_TRUE(RgbColor::fromQColor(QColor::fromRgba(0xAA0000FF)));
+    EXPECT_EQ(RgbColor::optional(0x0000FF), RgbColor::fromQColor(QColor::fromRgba(0xAA0000FF)));
+    EXPECT_TRUE(RgbColor::fromQColor(QColor::fromRgba(0xAAFFFFFF)));
+    EXPECT_EQ(RgbColor::optional(0xFFFFFF), RgbColor::fromQColor(QColor::fromRgba(0xAAFFFFFF)));
 }
 
 TEST(RgbColorTest, toQColor) {
-    EXPECT_EQ(QColor::fromRgb(0x123456), toQColor(RgbColor(0x123456)));
+    EXPECT_EQ(QColor::fromRgb(0x123456),
+            RgbColor::toQColor(RgbColor(0x123456)));
 }
 
 TEST(RgbColorTest, toQColorOptional) {
-    EXPECT_EQ(QColor(), toQColor(RgbColor::nullopt()));
+    EXPECT_EQ(QColor(),
+            RgbColor::toQColor(RgbColor::nullopt()));
     EXPECT_EQ(QColor::fromRgba(0xAABBCCDD),
-            toQColor(RgbColor::nullopt(), QColor::fromRgba(0xAABBCCDD)));
+            RgbColor::toQColor(RgbColor::nullopt(), QColor::fromRgba(0xAABBCCDD)));
     EXPECT_EQ(QColor::fromRgb(0x123456),
-            toQColor(RgbColor::optional(QColor::fromRgba(0xAA123456))));
+            RgbColor::toQColor(RgbColor::fromQColor(QColor::fromRgba(0xAA123456))));
     EXPECT_EQ(QColor::fromRgb(0x123456),
-            toQColor(RgbColor::optional(QColor::fromRgba(0xAA123456)), QColor::fromRgba(0xAABBCCDD)));
+            RgbColor::toQColor(RgbColor::fromQColor(QColor::fromRgba(0xAA123456)), QColor::fromRgba(0xAABBCCDD)));
 }
 
 TEST(RgbColorTest, toQVariant) {
-    EXPECT_EQ(QVariant(0x123456), toQVariant(RgbColor(0x123456)));
+    EXPECT_EQ(QVariant(0x123456),
+            RgbColor::toQVariant(RgbColor(0x123456)));
 }
 
 TEST(RgbColorTest, toQVariantOptional) {
-    EXPECT_EQ(QVariant(), toQVariant(RgbColor::nullopt()));
+    EXPECT_EQ(QVariant(),
+            RgbColor::toQVariant(RgbColor::nullopt()));
     EXPECT_EQ(QVariant(0x123456),
-            toQVariant(RgbColor::optional(QColor::fromRgba(0xAA123456))));
+            RgbColor::toQVariant(RgbColor::fromQColor(QColor::fromRgba(0xAA123456))));
 }
 
 TEST(RgbColorTest, toQString) {
-    EXPECT_EQ(QString("#123456"), toQString(RgbColor(0x123456)));
+    EXPECT_EQ(QString("#123456"),
+            RgbColor::toQString(RgbColor(0x123456)));
 }
 
 TEST(RgbColorTest, toQStringOptional) {
     EXPECT_EQ(QString(),
-            toQString(RgbColor::nullopt()));
+            RgbColor::toQString(RgbColor::nullopt()));
     EXPECT_EQ(QString("None"),
-            toQString(RgbColor::nullopt(), QStringLiteral("None")));
+            RgbColor::toQString(RgbColor::nullopt(), QStringLiteral("None")));
     EXPECT_EQ(QString("#123456"),
-            toQString(RgbColor::optional(QColor::fromRgba(0xAA123456))));
+            RgbColor::toQString(RgbColor::fromQColor(QColor::fromRgba(0xAA123456))));
     EXPECT_EQ(QString("#123456"),
-            toQString(RgbColor::optional(QColor::fromRgba(0xAA123456)), QStringLiteral("None")));
+            RgbColor::toQString(RgbColor::fromQColor(QColor::fromRgba(0xAA123456)), QStringLiteral("None")));
 }
 
 } // namespace mixxx

--- a/src/test/rgbcolor_test.cpp
+++ b/src/test/rgbcolor_test.cpp
@@ -84,24 +84,24 @@ TEST(RgbColorTest, toQStringOptional) {
 
 TEST(RgbColorTest, fromControlValue) {
     EXPECT_EQ(RgbColor::nullopt(),
-            control::valueToRgbColor(control::kInvalidRgbColor));
+            control::doubleToRgbColor(control::kInvalidRgbColor));
     EXPECT_EQ(RgbColor::optional(0),
-            control::valueToRgbColor(0));
+            control::doubleToRgbColor(0));
     EXPECT_EQ(RgbColor::optional(0xFEDCBA),
-            control::valueToRgbColor(0xFEDCBA));
+            control::doubleToRgbColor(0xFEDCBA));
 }
 
 TEST(RgbColorTest, toControlValue) {
     EXPECT_EQ(control::kInvalidRgbColor,
-            control::valueFromRgbColor(RgbColor::nullopt()));
+            control::doubleFromRgbColor(RgbColor::nullopt()));
     EXPECT_EQ(0.0,
-            control::valueFromRgbColor(RgbColor(0)));
+            control::doubleFromRgbColor(RgbColor(0)));
     EXPECT_EQ(0.0,
-            control::valueFromRgbColor(RgbColor::optional(0)));
+            control::doubleFromRgbColor(RgbColor::optional(0)));
     EXPECT_EQ(16702650.0,
-            control::valueFromRgbColor(RgbColor::optional(0xFEDCBA)));
+            control::doubleFromRgbColor(RgbColor::optional(0xFEDCBA)));
     EXPECT_EQ(16702650.0,
-            control::valueFromRgbColor(RgbColor::optional(0xFEDCBA)));
+            control::doubleFromRgbColor(RgbColor::optional(0xFEDCBA)));
 }
 
 } // namespace mixxx

--- a/src/test/rgbcolor_test.cpp
+++ b/src/test/rgbcolor_test.cpp
@@ -66,9 +66,14 @@ TEST(RgbColorTest, toQString) {
 }
 
 TEST(RgbColorTest, toQStringOptional) {
-    EXPECT_EQ(QString(), toQString(RgbColor::nullopt()));
+    EXPECT_EQ(QString(),
+            toQString(RgbColor::nullopt()));
+    EXPECT_EQ(QString("None"),
+            toQString(RgbColor::nullopt(), QStringLiteral("None")));
     EXPECT_EQ(QString("#123456"),
             toQString(RgbColor::optional(QColor::fromRgba(0xAA123456))));
+    EXPECT_EQ(QString("#123456"),
+            toQString(RgbColor::optional(QColor::fromRgba(0xAA123456)), QStringLiteral("None")));
 }
 
 } // namespace mixxx

--- a/src/test/rgbcolor_test.cpp
+++ b/src/test/rgbcolor_test.cpp
@@ -37,7 +37,7 @@ TEST(RgbColorTest, OptionalRgbColorFromQColorWithAlpha) {
     EXPECT_EQ(RgbColor::optional(0xFFFFFF), RgbColor::optional(QColor::fromRgba(0xAAFFFFFF)));
 }
 
-TEST(RgbColorTest,RgbColorToQColor) {
+TEST(RgbColorTest, RgbColorToQColor) {
     EXPECT_EQ(QColor::fromRgb(0x123456), toQColor(RgbColor(0x123456)));
 }
 
@@ -52,7 +52,6 @@ TEST(RgbColorTest, OptionalRgbColorToQColor) {
 }
 
 TEST(RgbColorTest, RgbColorToQVariant) {
-    EXPECT_EQ(QVariant(), toQVariant(RgbColor::nullopt()));
     EXPECT_EQ(QVariant(0x123456), toQVariant(RgbColor(0x123456)));
 }
 
@@ -60,6 +59,16 @@ TEST(RgbColorTest, OptionalRgbColorToQVariant) {
     EXPECT_EQ(QVariant(), toQVariant(RgbColor::nullopt()));
     EXPECT_EQ(QVariant(0x123456),
             toQVariant(RgbColor::optional(QColor::fromRgba(0xAA123456))));
+}
+
+TEST(RgbColorTest, toQString) {
+    EXPECT_EQ(QString("#123456"), toQString(RgbColor(0x123456)));
+}
+
+TEST(RgbColorTest, toNullableQString) {
+    EXPECT_EQ(QString(), toQString(RgbColor::nullopt()));
+    EXPECT_EQ(QString("#123456"),
+            toQString(RgbColor::optional(QColor::fromRgba(0xAA123456))));
 }
 
 } // namespace mixxx

--- a/src/test/rgbcolor_test.cpp
+++ b/src/test/rgbcolor_test.cpp
@@ -6,12 +6,12 @@
 
 namespace mixxx {
 
-TEST(RgbColorTest, OptionalRgbColorFromInvalidQColor) {
+TEST(RgbColorTest, fromInvalidQColor) {
     EXPECT_FALSE(RgbColor::optional(QColor()));
     EXPECT_EQ(RgbColor::nullopt(), RgbColor::optional(QColor()));
 }
 
-TEST(RgbColorTest, OptionalRgbColorFromQColorWithoutAlpha) {
+TEST(RgbColorTest, fromQColorWithoutAlpha) {
     EXPECT_TRUE(RgbColor::optional(QColor::fromRgb(0x000000)));
     EXPECT_EQ(0x000000, *RgbColor::optional(QColor::fromRgb(0x000000)));
     EXPECT_TRUE(RgbColor::optional(QColor::fromRgb(0xFF0000)));
@@ -24,7 +24,7 @@ TEST(RgbColorTest, OptionalRgbColorFromQColorWithoutAlpha) {
     EXPECT_EQ(RgbColor::optional(0xFFFFFF), RgbColor::optional(QColor::fromRgb(0xFFFFFF)));
 }
 
-TEST(RgbColorTest, OptionalRgbColorFromQColorWithAlpha) {
+TEST(RgbColorTest, fromQColorWithAlpha) {
     EXPECT_TRUE(RgbColor::optional(QColor::fromRgba(0xAA000000)));
     EXPECT_EQ(RgbColor::optional(0x000000), RgbColor::optional(QColor::fromRgba(0xAA000000)));
     EXPECT_TRUE(RgbColor::optional(QColor::fromRgba(0xAAFF0000)));
@@ -37,11 +37,11 @@ TEST(RgbColorTest, OptionalRgbColorFromQColorWithAlpha) {
     EXPECT_EQ(RgbColor::optional(0xFFFFFF), RgbColor::optional(QColor::fromRgba(0xAAFFFFFF)));
 }
 
-TEST(RgbColorTest, RgbColorToQColor) {
+TEST(RgbColorTest, toQColor) {
     EXPECT_EQ(QColor::fromRgb(0x123456), toQColor(RgbColor(0x123456)));
 }
 
-TEST(RgbColorTest, OptionalRgbColorToQColor) {
+TEST(RgbColorTest, toQColorOptional) {
     EXPECT_EQ(QColor(), toQColor(RgbColor::nullopt()));
     EXPECT_EQ(QColor::fromRgba(0xAABBCCDD),
             toQColor(RgbColor::nullopt(), QColor::fromRgba(0xAABBCCDD)));
@@ -51,11 +51,11 @@ TEST(RgbColorTest, OptionalRgbColorToQColor) {
             toQColor(RgbColor::optional(QColor::fromRgba(0xAA123456)), QColor::fromRgba(0xAABBCCDD)));
 }
 
-TEST(RgbColorTest, RgbColorToQVariant) {
+TEST(RgbColorTest, toQVariant) {
     EXPECT_EQ(QVariant(0x123456), toQVariant(RgbColor(0x123456)));
 }
 
-TEST(RgbColorTest, OptionalRgbColorToQVariant) {
+TEST(RgbColorTest, toQVariantOptional) {
     EXPECT_EQ(QVariant(), toQVariant(RgbColor::nullopt()));
     EXPECT_EQ(QVariant(0x123456),
             toQVariant(RgbColor::optional(QColor::fromRgba(0xAA123456))));
@@ -65,7 +65,7 @@ TEST(RgbColorTest, toQString) {
     EXPECT_EQ(QString("#123456"), toQString(RgbColor(0x123456)));
 }
 
-TEST(RgbColorTest, toNullableQString) {
+TEST(RgbColorTest, toQStringOptional) {
     EXPECT_EQ(QString(), toQString(RgbColor::nullopt()));
     EXPECT_EQ(QString("#123456"),
             toQString(RgbColor::optional(QColor::fromRgba(0xAA123456))));

--- a/src/test/rgbcolor_test.cpp
+++ b/src/test/rgbcolor_test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "test/mixxxtest.h"
+#include "control/convert.h"
 
 namespace mixxx {
 
@@ -79,6 +80,28 @@ TEST(RgbColorTest, toQStringOptional) {
             RgbColor::toQString(RgbColor::fromQColor(QColor::fromRgba(0xAA123456))));
     EXPECT_EQ(QString("#123456"),
             RgbColor::toQString(RgbColor::fromQColor(QColor::fromRgba(0xAA123456)), QStringLiteral("None")));
+}
+
+TEST(RgbColorTest, fromControlValue) {
+    EXPECT_EQ(RgbColor::nullopt(),
+            control::valueToRgbColor(control::kInvalidRgbColor));
+    EXPECT_EQ(RgbColor::optional(0),
+            control::valueToRgbColor(0));
+    EXPECT_EQ(RgbColor::optional(0xFEDCBA),
+            control::valueToRgbColor(0xFEDCBA));
+}
+
+TEST(RgbColorTest, toControlValue) {
+    EXPECT_EQ(control::kInvalidRgbColor,
+            control::valueFromRgbColor(RgbColor::nullopt()));
+    EXPECT_EQ(0.0,
+            control::valueFromRgbColor(RgbColor(0)));
+    EXPECT_EQ(0.0,
+            control::valueFromRgbColor(RgbColor::optional(0)));
+    EXPECT_EQ(16702650.0,
+            control::valueFromRgbColor(RgbColor::optional(0xFEDCBA)));
+    EXPECT_EQ(16702650.0,
+            control::valueFromRgbColor(RgbColor::optional(0xFEDCBA)));
 }
 
 } // namespace mixxx

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -20,7 +20,7 @@ class RgbColor {
     // without an an alpha channel.
     // We are using a separate typedef, because QRgb implicitly
     // includes an alpha channel whereas this type does not!
-    typedef quint32 code_t;
+    typedef QRgb code_t;
 
     static constexpr code_t validateCode(code_t code) {
         return code & kRgbCodeMask;

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -36,10 +36,6 @@ class RgbColor {
     explicit constexpr RgbColor(code_t code)
             : m_code(validateCode(code)) {
     }
-    // Explicit conversion from QColor.
-    RgbColor(QColor anyColor, code_t codeIfInvalid)
-            : m_code(anyColorToCode(anyColor, codeIfInvalid)) {
-    }
 
     // Implicit conversion to a color code.
     constexpr operator code_t() const {
@@ -64,43 +60,162 @@ class RgbColor {
     static constexpr optional_t optional(RgbColor color) {
         return std::make_optional(color);
     }
-    static optional_t optional(
-            QColor color,
-            optional_t defaultColor = nullopt()) {
-        if (color.isValid()) {
-            return optional(validateCode(color.rgb()));
+
+    ///////////////////////////////////////////////////////////////////
+    // Conversion functions from/to Qt types
+    ///////////////////////////////////////////////////////////////////
+
+    // Explicit conversion of both non-optional and optional
+    // RgbColor values to/from QColor as overloaded free functions.
+
+    static QColor toQColor(RgbColor color) {
+        return QColor::fromRgb(color);
+    }
+
+    static QColor toQColor(
+            RgbColor::optional_t optional,
+            const QColor& defaultColor = QColor()) {
+        if (optional) {
+            return toQColor(*optional);
         } else {
             return defaultColor;
         }
     }
-    static optional_t optional(
+
+    static RgbColor::optional_t fromQColor(
+            const QColor& color,
+            RgbColor::optional_t defaultColor = RgbColor::nullopt()) {
+        if (color.isValid()) {
+            return RgbColor::optional(
+                    RgbColor::validateCode(color.rgb()));
+        } else {
+            return defaultColor;
+        }
+    }
+
+    // Explicit conversion of both non-optional and optional
+    // RgbColor values to/from QString in the format #RRGGBB,
+    // e.g. for tool tips or settings.
+
+    static QString toQString(
+            mixxx::RgbColor color) {
+        return toQColor(color).name(QColor::HexRgb);
+    }
+
+    static QString toQString(
+            mixxx::RgbColor::optional_t color,
+            const QString& defaultString = QString()) {
+        if (color) {
+            return toQString(*color);
+        } else {
+            return defaultString;
+        }
+    }
+
+    static RgbColor::optional_t fromQString(
+            const QString& hexCode,
+            RgbColor::optional_t defaultColor = RgbColor::nullopt()) {
+        const auto color = QColor(hexCode);
+        if (color.isValid()) {
+            return fromQColor(color);
+        } else {
+            return defaultColor;
+        }
+    }
+
+    // Explicit conversion of both non-optional and optional
+    // RgbColor values to QVariant as overloaded free functions.
+    //
+    // The default versions encode the internal color code as
+    // an unsigned integer. The `Color` and `String` variants
+    // use the corresponding mapping to QColor and QString
+    // respectively.
+
+    static QVariant toQVariant(
+            RgbColor color) {
+        return QVariant(static_cast<code_t>(color));
+    }
+
+    static QVariant toQVariantColor(
+            RgbColor color) {
+        return QVariant(toQColor(color));
+    }
+
+    static QVariant toQVariantString(
+            RgbColor color) {
+        return QVariant(toQString(color));
+    }
+
+    static QVariant toQVariant(
+            optional_t optional,
+            const QVariant& defaultVariant = QVariant()) {
+        if (optional) {
+            return toQVariant(*optional);
+        } else {
+            return defaultVariant;
+        }
+    }
+
+    static QVariant toQVariantColor(
+            optional_t optional,
+            const QVariant& defaultVariant = QVariant()) {
+        if (optional) {
+            return toQVariantColor(*optional);
+        } else {
+            return defaultVariant;
+        }
+    }
+
+    static QVariant toQVariantString(
+            optional_t optional,
+            const QVariant& defaultVariant = QVariant()) {
+        if (optional) {
+            return toQVariantString(*optional);
+        } else {
+            return defaultVariant;
+        }
+    }
+
+    static optional_t fromQVariant(
             const QVariant& varCode,
             optional_t defaultColor = nullopt()) {
         if (varCode.isNull()) {
             return defaultColor;
-        } else {
-            DEBUG_ASSERT(varCode.canConvert(QMetaType::UInt));
-            bool ok = false;
-            const auto code = varCode.toUInt(&ok);
-            VERIFY_OR_DEBUG_ASSERT(ok) {
-                return defaultColor;
-            }
-            return optional(static_cast<code_t>(code));
         }
+        DEBUG_ASSERT(varCode.canConvert(QMetaType::UInt));
+        bool ok = false;
+        const auto code = varCode.toUInt(&ok);
+        VERIFY_OR_DEBUG_ASSERT(ok) {
+            return defaultColor;
+        }
+        return optional(static_cast<code_t>(code));
+    }
+
+    static optional_t fromQVariantColor(
+            const QVariant& varColor,
+            optional_t defaultColor = nullopt()) {
+        if (varColor.isNull()) {
+            return defaultColor;
+        }
+        DEBUG_ASSERT(varColor.canConvert(QMetaType::QColor));
+        const auto value = varColor.value<QColor>();
+        return fromQColor(value);
+    }
+
+    static optional_t fromQVariantString(
+            const QVariant& varString,
+            optional_t defaultColor = nullopt()) {
+        if (varString.isNull()) {
+            return defaultColor;
+        }
+        DEBUG_ASSERT(varString.canConvert(QMetaType::QString));
+        const auto value = varString.value<QString>();
+        return fromQString(value);
     }
 
   protected:
     // Bitmask of valid codes = 0x00RRGGBB
     static constexpr code_t kRgbCodeMask = 0x00FFFFFF;
-
-    static code_t anyColorToCode(QColor anyColor, code_t codeIfInvalid) {
-        if (anyColor.isValid()) {
-            // Strip alpha channel bits!
-            return validateCode(anyColor.rgb());
-        } else {
-            return codeIfInvalid;
-        }
-    }
 
     code_t m_code;
 };
@@ -109,69 +224,14 @@ inline bool operator!=(RgbColor lhs, RgbColor rhs) {
     return !(lhs == rhs);
 }
 
-// Explicit conversion of both non-optional and optional
-// RgbColor values to QColor as overloaded free functions.
-
-inline QColor toQColor(RgbColor color) {
-    return QColor::fromRgb(color);
-}
-
-inline QColor toQColor(
-        RgbColor::optional_t optional,
-        QColor defaultColor = QColor()) {
-    if (optional) {
-        return toQColor(*optional);
-    } else {
-        return defaultColor;
-    }
-}
-
-// Explicit conversion of both non-optional and optional
-// RgbColor values to QVariant as overloaded free functions.
-
-inline QVariant toQVariant(
-        RgbColor color) {
-    return QVariant(static_cast<RgbColor::code_t>(color));
-}
-
-inline QVariant toQVariant(
-        RgbColor::optional_t optional,
-        const QVariant& defaultVariant = QVariant()) {
-    if (optional) {
-        return toQVariant(*optional);
-    } else {
-        return defaultVariant;
-    }
-}
-
-// Explicit conversion of both non-optional and optional
-// RgbColor values to QString with the format #RRGGBB,
-// e.g. for tool.
-
-inline QString toQString(
-        mixxx::RgbColor color) {
-    return mixxx::toQColor(color).name();
-}
-
-// String representation #RRGGBB, e.g. for tool.
-inline QString toQString(
-        mixxx::RgbColor::optional_t color,
-        const QString& defaultString = QString()) {
-    if (color) {
-        return toQString(*color);
-    } else {
-        return defaultString;
-    }
-}
-
 // Debug output stream operators
 
 inline QDebug operator<<(QDebug dbg, RgbColor color) {
-    return dbg << toQColor(color);
+    return dbg << RgbColor::toQString(color).toLatin1().constData();
 }
 
-inline QDebug operator<<(QDebug dbg, RgbColor::optional_t optional) {
-    return dbg << toQColor(optional);
+inline QDebug operator<<(QDebug dbg, RgbColor::optional_t optionalColor) {
+    return dbg << RgbColor::toQString(optionalColor).toLatin1().constData();
 }
 
 } // namespace mixxx

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -182,13 +182,11 @@ class RgbColor {
         if (varCode.isNull()) {
             return defaultColor;
         }
-        DEBUG_ASSERT(varCode.canConvert(QMetaType::UInt));
-        bool ok = false;
-        const auto code = varCode.toUInt(&ok);
-        VERIFY_OR_DEBUG_ASSERT(ok) {
+        VERIFY_OR_DEBUG_ASSERT(varCode.canConvert(QMetaType::UInt)) {
             return defaultColor;
         }
-        return optional(static_cast<code_t>(code));
+        const auto value = varCode.value<code_t>();
+        return RgbColor::optional(value);
     }
 
     static optional_t fromQVariantColor(
@@ -197,7 +195,9 @@ class RgbColor {
         if (varColor.isNull()) {
             return defaultColor;
         }
-        DEBUG_ASSERT(varColor.canConvert(QMetaType::QColor));
+        VERIFY_OR_DEBUG_ASSERT(varColor.canConvert(QMetaType::QColor)) {
+            return defaultColor;
+        }
         const auto value = varColor.value<QColor>();
         return fromQColor(value);
     }
@@ -208,7 +208,9 @@ class RgbColor {
         if (varString.isNull()) {
             return defaultColor;
         }
-        DEBUG_ASSERT(varString.canConvert(QMetaType::QString));
+        VERIFY_OR_DEBUG_ASSERT(varString.canConvert(QMetaType::QString)) {
+            return defaultColor;
+        }
         const auto value = varString.value<QString>();
         return fromQString(value);
     }

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -135,6 +135,23 @@ inline QVariant toQVariant(RgbColor::optional_t optional) {
     }
 }
 
+// Explicit conversion of both non-optional and optional
+// RgbColor values to QString with the format #RRGGBB,
+// e.g. for tool.
+
+inline QString toQString(mixxx::RgbColor color) {
+    return mixxx::toQColor(color).name();
+}
+
+// String representation #RRGGBB, e.g. for tool.
+inline QString toQString(mixxx::RgbColor::optional_t color) {
+    if (color) {
+        return toQString(*color);
+    } else {
+        return QString();
+    }
+}
+
 // Debug output stream operators
 
 inline QDebug operator<<(QDebug dbg, RgbColor color) {

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -112,7 +112,9 @@ inline QColor toQColor(RgbColor color) {
     return QColor::fromRgb(color);
 }
 
-inline QColor toQColor(RgbColor::optional_t optional, QColor defaultColor = QColor()) {
+inline QColor toQColor(
+        RgbColor::optional_t optional,
+        QColor defaultColor = QColor()) {
     if (optional) {
         return toQColor(*optional);
     } else {
@@ -139,16 +141,19 @@ inline QVariant toQVariant(RgbColor::optional_t optional) {
 // RgbColor values to QString with the format #RRGGBB,
 // e.g. for tool.
 
-inline QString toQString(mixxx::RgbColor color) {
+inline QString toQString(
+        mixxx::RgbColor color) {
     return mixxx::toQColor(color).name();
 }
 
 // String representation #RRGGBB, e.g. for tool.
-inline QString toQString(mixxx::RgbColor::optional_t color) {
+inline QString toQString(
+        mixxx::RgbColor::optional_t color,
+        const QString& defaultString = QString()) {
     if (color) {
         return toQString(*color);
     } else {
-        return QString();
+        return defaultString;
     }
 }
 

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -64,22 +64,26 @@ class RgbColor {
     static constexpr optional_t optional(RgbColor color) {
         return std::make_optional(color);
     }
-    static optional_t optional(QColor color) {
+    static optional_t optional(
+            QColor color,
+            optional_t defaultColor = nullopt()) {
         if (color.isValid()) {
             return optional(validateCode(color.rgb()));
         } else {
-            return nullopt();
+            return defaultColor;
         }
     }
-    static optional_t optional(const QVariant& varCode) {
+    static optional_t optional(
+            const QVariant& varCode,
+            optional_t defaultColor = nullopt()) {
         if (varCode.isNull()) {
-            return nullopt();
+            return defaultColor;
         } else {
             DEBUG_ASSERT(varCode.canConvert(QMetaType::UInt));
             bool ok = false;
             const auto code = varCode.toUInt(&ok);
             VERIFY_OR_DEBUG_ASSERT(ok) {
-                return nullopt();
+                return defaultColor;
             }
             return optional(static_cast<code_t>(code));
         }
@@ -125,15 +129,18 @@ inline QColor toQColor(
 // Explicit conversion of both non-optional and optional
 // RgbColor values to QVariant as overloaded free functions.
 
-inline QVariant toQVariant(RgbColor color) {
+inline QVariant toQVariant(
+        RgbColor color) {
     return QVariant(static_cast<RgbColor::code_t>(color));
 }
 
-inline QVariant toQVariant(RgbColor::optional_t optional) {
+inline QVariant toQVariant(
+        RgbColor::optional_t optional,
+        const QVariant& defaultVariant = QVariant()) {
     if (optional) {
         return toQVariant(*optional);
     } else {
-        return QVariant();
+        return defaultVariant;
     }
 }
 

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1093,7 +1093,7 @@ void WTrackTableView::contextMenuEvent(QContextMenuEvent* event) {
             // Get color of first selected track
             int column = trackModel->fieldIndex(LIBRARYTABLE_COLOR);
             QModelIndex index = indices.at(0).sibling(indices.at(0).row(), column);
-            mixxx::RgbColor::optional_t trackColor = mixxx::RgbColor::optional(index.data());
+            auto trackColor = mixxx::RgbColor::fromQVariant(index.data());
 
             // Check if all other selected tracks have the same color
             bool multipleTrackColors = false;
@@ -1101,9 +1101,8 @@ void WTrackTableView::contextMenuEvent(QContextMenuEvent* event) {
                 int row = indices.at(i).row();
                 QModelIndex index = indices.at(i).sibling(row, column);
 
-                mixxx::RgbColor::optional_t otherTrackColor = mixxx::RgbColor::optional(index.data());
-                if (trackColor != otherTrackColor) {
-                    trackColor = std::nullopt;
+                if (trackColor != mixxx::RgbColor::fromQVariant(index.data())) {
+                    trackColor = mixxx::RgbColor::nullopt();
                     multipleTrackColors = true;
                     break;
                 }
@@ -1996,7 +1995,7 @@ void WTrackTableView::slotColorPicked(PredefinedColorPointer pColor) {
     // TODO: This should be done in a thread for large selections
     for (const auto& index : selectedTrackIndices) {
         TrackPointer track = trackModel->getTrack(index);
-        track->setColor(mixxx::RgbColor::optional(pColor->m_defaultRgba));
+        track->setColor(mixxx::RgbColor::fromQColor(pColor->m_defaultRgba));
     }
 
     m_pMenu->hide();


### PR DESCRIPTION
Add reusable functions for formatting colors as strings.

The tests verify that an optional/invalid color produces an empty null string which is not the case for `QColor().name()`.

Update:
- Conversion functions from/to various Qt types: QRgb = RgbColor::code_t, QQColor, QString, QVariant (QRgb, QColor, QString)
- Conversion functions for control values (double)