### PR TITLE
pre-commit: Do not run `git clang-format` in parallel

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,6 +75,7 @@ repos:
   - id: clang-format
     entry: git clang-format
     args: []
+    require_serial: true
     stages:
     - commit
     - manual


### PR DESCRIPTION
Running `git clang-format` in parallel (when multiple files have been
changed) can cause issues because `.git/index.lock` already exists.