### PR TITLE
Add CueInfo DTO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -511,6 +511,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/track/beatutils.cpp
   src/track/bpm.cpp
   src/track/cue.cpp
+  src/track/cueinfo.cpp
   src/track/globaltrackcache.cpp
   src/track/keyfactory.cpp
   src/track/keys.cpp

--- a/build/depends.py
+++ b/build/depends.py
@@ -1204,6 +1204,7 @@ class MixxxCore(Feature):
                    "src/track/beats.cpp",
                    "src/track/bpm.cpp",
                    "src/track/cue.cpp",
+                   "src/track/cueinfo.cpp",
                    "src/track/keyfactory.cpp",
                    "src/track/keys.cpp",
                    "src/track/keyutils.cpp",

--- a/src/analyzer/analyzersilence.cpp
+++ b/src/analyzer/analyzersilence.cpp
@@ -10,9 +10,9 @@ constexpr float kSilenceThreshold = 0.001;
 //constexpr float kSilenceThreshold = db2ratio(-60.0f);
 
 bool shouldAnalyze(TrackPointer pTrack) {
-    CuePointer pIntroCue = pTrack->findCueByType(Cue::Type::Intro);
-    CuePointer pOutroCue = pTrack->findCueByType(Cue::Type::Outro);
-    CuePointer pAudibleSound = pTrack->findCueByType(Cue::Type::AudibleSound);
+    CuePointer pIntroCue = pTrack->findCueByType(mixxx::CueType::Intro);
+    CuePointer pOutroCue = pTrack->findCueByType(mixxx::CueType::Outro);
+    CuePointer pAudibleSound = pTrack->findCueByType(mixxx::CueType::AudibleSound);
 
     if (!pIntroCue || !pOutroCue || !pAudibleSound || pAudibleSound->getLength() <= 0) {
         return true;
@@ -92,10 +92,10 @@ void AnalyzerSilence::storeResults(TrackPointer pTrack) {
     double firstSound = mixxx::kAnalysisChannels * m_iSignalStart;
     double lastSound = mixxx::kAnalysisChannels * m_iSignalEnd;
 
-    CuePointer pAudibleSound = pTrack->findCueByType(Cue::Type::AudibleSound);
+    CuePointer pAudibleSound = pTrack->findCueByType(mixxx::CueType::AudibleSound);
     if (pAudibleSound == nullptr) {
         pAudibleSound = pTrack->createAndAddCue();
-        pAudibleSound->setType(Cue::Type::AudibleSound);
+        pAudibleSound->setType(mixxx::CueType::AudibleSound);
     }
     // The user has no way to directly edit the AudibleSound cue. If the user
     // has deleted the Intro or Outro Cue, this analysis will be rerun when
@@ -106,7 +106,7 @@ void AnalyzerSilence::storeResults(TrackPointer pTrack) {
     pAudibleSound->setStartPosition(firstSound);
     pAudibleSound->setEndPosition(lastSound);
 
-    CuePointer pIntroCue = pTrack->findCueByType(Cue::Type::Intro);
+    CuePointer pIntroCue = pTrack->findCueByType(mixxx::CueType::Intro);
 
     double mainCue = pTrack->getCuePoint().getPosition();
     double introStart = firstSound;
@@ -126,15 +126,15 @@ void AnalyzerSilence::storeResults(TrackPointer pTrack) {
 
     if (pIntroCue == nullptr) {
         pIntroCue = pTrack->createAndAddCue();
-        pIntroCue->setType(Cue::Type::Intro);
+        pIntroCue->setType(mixxx::CueType::Intro);
         pIntroCue->setStartPosition(introStart);
         pIntroCue->setEndPosition(Cue::kNoPosition);
     }
 
-    CuePointer pOutroCue = pTrack->findCueByType(Cue::Type::Outro);
+    CuePointer pOutroCue = pTrack->findCueByType(mixxx::CueType::Outro);
     if (pOutroCue == nullptr) {
         pOutroCue = pTrack->createAndAddCue();
-        pOutroCue->setType(Cue::Type::Outro);
+        pOutroCue->setType(mixxx::CueType::Outro);
         pOutroCue->setStartPosition(Cue::kNoPosition);
         pOutroCue->setEndPosition(lastSound);
     }

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -353,7 +353,7 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
 
     CuePointer pMainCue;
     for (const CuePointer& pCue : m_pLoadedTrack->getCuePoints()) {
-        if (pCue->getType() == Cue::Type::MainCue) {
+        if (pCue->getType() == mixxx::CueType::MainCue) {
             DEBUG_ASSERT(!pMainCue);
             pMainCue = pCue;
         }
@@ -366,7 +366,7 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
 
     // Because of legacy, we store the (load) cue point twice and need to
     // sync both values.
-    // The Cue::Type::MainCue from getCuePoints() has the priority
+    // The mixxx::CueType::MainCue from getCuePoints() has the priority
     CuePosition mainCuePoint;
     if (pMainCue) {
         mainCuePoint.setPosition(pMainCue->getPosition());
@@ -380,7 +380,7 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
         CuePointer pCue(pNewTrack->createAndAddCue());
         pCue->setStartPosition(mainCuePoint.getPosition());
         pCue->setHotCue(Cue::kNoHotCue);
-        pCue->setType(Cue::Type::MainCue);
+        pCue->setType(mixxx::CueType::MainCue);
     }
     m_pCuePoint->set(mainCuePoint.getPosition());
 
@@ -390,7 +390,7 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
     // Seek track according to SeekOnLoadMode.
     SeekOnLoadMode seekOnLoadMode = getSeekOnLoadPreference();
 
-    CuePointer pAudibleSound = pNewTrack->findCueByType(Cue::Type::AudibleSound);
+    CuePointer pAudibleSound = pNewTrack->findCueByType(mixxx::CueType::AudibleSound);
     double firstSound = Cue::kNoPosition;
     if (pAudibleSound) {
         firstSound = pAudibleSound->getPosition();
@@ -447,16 +447,16 @@ void CueControl::loadCuesFromTrack() {
         return;
 
     for (const CuePointer& pCue: m_pLoadedTrack->getCuePoints()) {
-        if (pCue->getType() == Cue::Type::MainCue) {
+        if (pCue->getType() == mixxx::CueType::MainCue) {
             DEBUG_ASSERT(!pLoadCue); // There should be only one MainCue cue
             pLoadCue = pCue;
-        } else if (pCue->getType() == Cue::Type::Intro) {
+        } else if (pCue->getType() == mixxx::CueType::Intro) {
             DEBUG_ASSERT(!pIntroCue); // There should be only one Intro cue
             pIntroCue = pCue;
-        } else if (pCue->getType() == Cue::Type::Outro) {
+        } else if (pCue->getType() == mixxx::CueType::Outro) {
             DEBUG_ASSERT(!pOutroCue); // There should be only one Outro cue
             pOutroCue = pCue;
-        } else if (pCue->getType() == Cue::Type::HotCue && pCue->getHotCue() != Cue::kNoHotCue) {
+        } else if (pCue->getType() == mixxx::CueType::HotCue && pCue->getHotCue() != Cue::kNoHotCue) {
             int hotcue = pCue->getHotCue();
             HotcueControl* pControl = m_hotcueControls.value(hotcue, NULL);
 
@@ -593,7 +593,7 @@ void CueControl::hotcueSet(HotcueControl* pControl, double v) {
     pCue->setStartPosition(cuePosition);
     pCue->setHotCue(hotcue);
     pCue->setLabel("");
-    pCue->setType(Cue::Type::HotCue);
+    pCue->setType(mixxx::CueType::HotCue);
     // TODO(XXX) deal with spurious signals
     attachCue(pCue, pControl);
 
@@ -1158,10 +1158,10 @@ void CueControl::introStartSet(double v) {
     lock.unlock();
 
     if (pLoadedTrack) {
-        CuePointer pCue = pLoadedTrack->findCueByType(Cue::Type::Intro);
+        CuePointer pCue = pLoadedTrack->findCueByType(mixxx::CueType::Intro);
         if (!pCue) {
             pCue = pLoadedTrack->createAndAddCue();
-            pCue->setType(Cue::Type::Intro);
+            pCue->setType(mixxx::CueType::Intro);
         }
         pCue->setStartPosition(position);
         pCue->setEndPosition(introEnd);
@@ -1179,7 +1179,7 @@ void CueControl::introStartClear(double v) {
     lock.unlock();
 
     if (pLoadedTrack) {
-        CuePointer pCue = pLoadedTrack->findCueByType(Cue::Type::Intro);
+        CuePointer pCue = pLoadedTrack->findCueByType(mixxx::CueType::Intro);
         if (introEnd != Cue::kNoPosition) {
             pCue->setStartPosition(Cue::kNoPosition);
             pCue->setEndPosition(introEnd);
@@ -1234,10 +1234,10 @@ void CueControl::introEndSet(double v) {
     lock.unlock();
 
     if (pLoadedTrack) {
-        CuePointer pCue = pLoadedTrack->findCueByType(Cue::Type::Intro);
+        CuePointer pCue = pLoadedTrack->findCueByType(mixxx::CueType::Intro);
         if (!pCue) {
             pCue = pLoadedTrack->createAndAddCue();
-            pCue->setType(Cue::Type::Intro);
+            pCue->setType(mixxx::CueType::Intro);
         }
         pCue->setStartPosition(introStart);
         pCue->setEndPosition(position);
@@ -1255,7 +1255,7 @@ void CueControl::introEndClear(double v) {
     lock.unlock();
 
     if (pLoadedTrack) {
-        CuePointer pCue = pLoadedTrack->findCueByType(Cue::Type::Intro);
+        CuePointer pCue = pLoadedTrack->findCueByType(mixxx::CueType::Intro);
         if (introStart != Cue::kNoPosition) {
             pCue->setStartPosition(introStart);
             pCue->setEndPosition(Cue::kNoPosition);
@@ -1310,10 +1310,10 @@ void CueControl::outroStartSet(double v) {
     lock.unlock();
 
     if (pLoadedTrack) {
-        CuePointer pCue = pLoadedTrack->findCueByType(Cue::Type::Outro);
+        CuePointer pCue = pLoadedTrack->findCueByType(mixxx::CueType::Outro);
         if (!pCue) {
             pCue = pLoadedTrack->createAndAddCue();
-            pCue->setType(Cue::Type::Outro);
+            pCue->setType(mixxx::CueType::Outro);
         }
         pCue->setStartPosition(position);
         pCue->setEndPosition(outroEnd);
@@ -1331,7 +1331,7 @@ void CueControl::outroStartClear(double v) {
     lock.unlock();
 
     if (pLoadedTrack) {
-        CuePointer pCue = pLoadedTrack->findCueByType(Cue::Type::Outro);
+        CuePointer pCue = pLoadedTrack->findCueByType(mixxx::CueType::Outro);
         if (outroEnd != Cue::kNoPosition) {
             pCue->setStartPosition(Cue::kNoPosition);
             pCue->setEndPosition(outroEnd);
@@ -1386,10 +1386,10 @@ void CueControl::outroEndSet(double v) {
     lock.unlock();
 
     if (pLoadedTrack) {
-        CuePointer pCue = pLoadedTrack->findCueByType(Cue::Type::Outro);
+        CuePointer pCue = pLoadedTrack->findCueByType(mixxx::CueType::Outro);
         if (!pCue) {
             pCue = pLoadedTrack->createAndAddCue();
-            pCue->setType(Cue::Type::Outro);
+            pCue->setType(mixxx::CueType::Outro);
         }
         pCue->setStartPosition(outroStart);
         pCue->setEndPosition(position);
@@ -1407,7 +1407,7 @@ void CueControl::outroEndClear(double v) {
     lock.unlock();
 
     if (pLoadedTrack) {
-        CuePointer pCue = pLoadedTrack->findCueByType(Cue::Type::Outro);
+        CuePointer pCue = pLoadedTrack->findCueByType(mixxx::CueType::Outro);
         if (outroStart != Cue::kNoPosition) {
             pCue->setStartPosition(outroStart);
             pCue->setEndPosition(Cue::kNoPosition);

--- a/src/engine/controls/vinylcontrolcontrol.cpp
+++ b/src/engine/controls/vinylcontrolcontrol.cpp
@@ -123,7 +123,7 @@ void VinylControlControl::slotControlVinylSeek(double fractionalPos) {
         QListIterator<CuePointer> it(cuePoints);
         while (it.hasNext()) {
             CuePointer pCue(it.next());
-            if (pCue->getType() != Cue::Type::HotCue || pCue->getHotCue() == -1) {
+            if (pCue->getType() != mixxx::CueType::HotCue || pCue->getHotCue() == -1) {
                 continue;
             }
 

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1068,7 +1068,7 @@ double AutoDJProcessor::getFirstSoundSecond(DeckAttributes* pDeck) {
         return 0.0;
     }
 
-    CuePointer pFromTrackAudibleSound = pTrack->findCueByType(Cue::Type::AudibleSound);
+    CuePointer pFromTrackAudibleSound = pTrack->findCueByType(mixxx::CueType::AudibleSound);
     if (pFromTrackAudibleSound) {
         double firstSound = pFromTrackAudibleSound->getPosition();
         if (firstSound > 0.0) {
@@ -1084,7 +1084,7 @@ double AutoDJProcessor::getLastSoundSecond(DeckAttributes* pDeck) {
         return 0.0;
     }
 
-    CuePointer pFromTrackAudibleSound = pTrack->findCueByType(Cue::Type::AudibleSound);
+    CuePointer pFromTrackAudibleSound = pTrack->findCueByType(mixxx::CueType::AudibleSound);
     if (pFromTrackAudibleSound && pFromTrackAudibleSound->getLength() > 0) {
         double lastSound = pFromTrackAudibleSound->getEndPosition();
         if (lastSound > 0) {

--- a/src/library/dao/cuedao.cpp
+++ b/src/library/dao/cuedao.cpp
@@ -55,7 +55,7 @@ CuePointer CueDAO::cueFromRow(const QSqlQuery& query) const {
     QString label = record.value(record.indexOf("label")).toString();
     int iColorId = record.value(record.indexOf("color")).toInt();
     PredefinedColorPointer color = Color::kPredefinedColorsSet.predefinedColorFromId(iColorId);
-    CuePointer pCue(new Cue(id, trackId, (Cue::Type)type, position, length, hotcue, label, color));
+    CuePointer pCue(new Cue(id, trackId, (mixxx::CueType)type, position, length, hotcue, label, color));
     m_cues[id] = pCue;
     return pCue;
 }

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -323,9 +323,8 @@ void DlgTrackInfo::populateCues(TrackPointer pTrack) {
     QListIterator<CuePointer> it(cuePoints);
     while (it.hasNext()) {
         CuePointer pCue = it.next();
-        Cue::Type type = pCue->getType();
-        if (type == Cue::Type::HotCue || type == Cue::Type::MainCue || type == Cue::Type::Intro
-                || type == Cue::Type::Outro) {
+        mixxx::CueType type = pCue->getType();
+        if (type == mixxx::CueType::HotCue || type == mixxx::CueType::MainCue || type == mixxx::CueType::Intro || type == mixxx::CueType::Outro) {
             listPoints.push_back(pCue);
         }
     }
@@ -376,32 +375,32 @@ void DlgTrackInfo::populateCues(TrackPointer pTrack) {
         // Decode cue type to display text
         QString cueType;
         switch (pCue->getType()) {
-            case Cue::Type::Invalid:
-                cueType = "?";
-                break;
-            case Cue::Type::HotCue:
-                cueType = "Hotcue";
-                break;
-            case Cue::Type::MainCue:
-                cueType = "Main Cue";
-                break;
-            case Cue::Type::Beat:
-                cueType = "Beat";
-                break;
-            case Cue::Type::Loop:
-                cueType = "Loop";
-                break;
-            case Cue::Type::Jump:
-                cueType = "Jump";
-                break;
-            case Cue::Type::Intro:
-                cueType = "Intro";
-                break;
-            case Cue::Type::Outro:
-                cueType = "Outro";
-                break;
-            default:
-                break;
+        case mixxx::CueType::Invalid:
+            cueType = "?";
+            break;
+        case mixxx::CueType::HotCue:
+            cueType = "Hotcue";
+            break;
+        case mixxx::CueType::MainCue:
+            cueType = "Main Cue";
+            break;
+        case mixxx::CueType::Beat:
+            cueType = "Beat";
+            break;
+        case mixxx::CueType::Loop:
+            cueType = "Loop";
+            break;
+        case mixxx::CueType::Jump:
+            cueType = "Jump";
+            break;
+        case mixxx::CueType::Intro:
+            cueType = "Intro";
+            break;
+        case mixxx::CueType::Outro:
+            cueType = "Outro";
+            break;
+        default:
+            break;
         }
 
         QTableWidgetItem* typeItem = new QTableWidgetItem(cueType);
@@ -504,7 +503,7 @@ void DlgTrackInfo::saveTrack() {
             pCue->setHotCue(-1);
         }
 
-        if (pCue->getType() == Cue::Type::HotCue) {
+        if (pCue->getType() == mixxx::CueType::HotCue) {
             auto colorComboBox = qobject_cast<QComboBox*>(colorWidget);
             if (colorComboBox) {
                 PredefinedColorPointer color = Color::kPredefinedColorsSet.allColors.at(colorComboBox->currentIndex());

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -672,7 +672,7 @@ void setHotCue(TrackPointer track, double position, int id, QString label, int /
         pCue = CuePointer(track->createAndAddCue());
     }
 
-    pCue->setType(Cue::Type::HotCue);
+    pCue->setType(mixxx::CueType::HotCue);
     pCue->setStartPosition(position);
     pCue->setHotCue(id);
 
@@ -867,7 +867,7 @@ void readAnalyze(TrackPointer track, double sampleRate, int timingOffset, bool i
 
     if (cueLoadPosition < kLongestPosition) {
         track->setCuePoint(CuePosition(cueLoadPosition));
-        CuePointer pLoadCue = track->findCueByType(Cue::Type::MainCue);
+        CuePointer pLoadCue = track->findCueByType(mixxx::CueType::MainCue);
         if (!cueLoadComment.isNull()) {
             pLoadCue->setLabel(cueLoadComment);
         }
@@ -876,7 +876,7 @@ void readAnalyze(TrackPointer track, double sampleRate, int timingOffset, bool i
         CuePointer pCue(track->createAndAddCue());
         pCue->setStartPosition(cueLoopStartPosition);
         pCue->setEndPosition(cueLoopEndPosition);
-        pCue->setType(Cue::Type::Loop);
+        pCue->setType(mixxx::CueType::Loop);
     }
 }
 

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -181,7 +181,7 @@ void BaseTrackPlayerImpl::loadTrack(TrackPointer pTrack) {
         QListIterator<CuePointer> it(trackCues);
         while (it.hasNext()) {
             CuePointer pCue(it.next());
-            if (pCue->getType() == Cue::Type::Loop) {
+            if (pCue->getType() == mixxx::CueType::Loop) {
                 double loopStart = pCue->getPosition();
                 double loopEnd = loopStart + pCue->getLength();
                 if (loopStart != kNoTrigger && loopEnd != kNoTrigger && loopStart <= loopEnd) {
@@ -220,13 +220,13 @@ TrackPointer BaseTrackPlayerImpl::unloadTrack() {
         QListIterator<CuePointer> it(cuePoints);
         while (it.hasNext()) {
             CuePointer pCue(it.next());
-            if (pCue->getType() == Cue::Type::Loop) {
+            if (pCue->getType() == mixxx::CueType::Loop) {
                 pLoopCue = pCue;
             }
         }
         if (!pLoopCue) {
             pLoopCue = m_pLoadedTrack->createAndAddCue();
-            pLoopCue->setType(Cue::Type::Loop);
+            pLoopCue->setType(mixxx::CueType::Loop);
         }
         pLoopCue->setStartPosition(loopStart);
         pLoopCue->setEndPosition(loopEnd);

--- a/src/test/analyzersilence_test.cpp
+++ b/src/test/analyzersilence_test.cpp
@@ -54,11 +54,11 @@ TEST_F(AnalyzerSilenceTest, SilenceTrack) {
     CuePosition cue = pTrack->getCuePoint();
     EXPECT_DOUBLE_EQ(0.0, cue.getPosition());
 
-    CuePointer pIntroCue = pTrack->findCueByType(Cue::Type::Intro);
+    CuePointer pIntroCue = pTrack->findCueByType(mixxx::CueType::Intro);
     EXPECT_DOUBLE_EQ(0.0, pIntroCue->getPosition());
     EXPECT_DOUBLE_EQ(0.0, pIntroCue->getLength());
 
-    CuePointer pOutroCue = pTrack->findCueByType(Cue::Type::Outro);
+    CuePointer pOutroCue = pTrack->findCueByType(mixxx::CueType::Outro);
     EXPECT_DOUBLE_EQ(Cue::kNoPosition, pOutroCue->getPosition());
     EXPECT_DOUBLE_EQ(nTrackSampleDataLength, pOutroCue->getLength());
 }
@@ -75,11 +75,11 @@ TEST_F(AnalyzerSilenceTest, EndToEndToneTrack) {
     CuePosition cue = pTrack->getCuePoint();
     EXPECT_DOUBLE_EQ(0.0, cue.getPosition());
 
-    CuePointer pIntroCue = pTrack->findCueByType(Cue::Type::Intro);
+    CuePointer pIntroCue = pTrack->findCueByType(mixxx::CueType::Intro);
     EXPECT_DOUBLE_EQ(0.0, pIntroCue->getPosition());
     EXPECT_DOUBLE_EQ(0.0, pIntroCue->getLength());
 
-    CuePointer pOutroCue = pTrack->findCueByType(Cue::Type::Outro);
+    CuePointer pOutroCue = pTrack->findCueByType(mixxx::CueType::Outro);
     EXPECT_DOUBLE_EQ(Cue::kNoPosition, pOutroCue->getPosition());
     EXPECT_DOUBLE_EQ(nTrackSampleDataLength, pOutroCue->getLength());
 }
@@ -106,11 +106,11 @@ TEST_F(AnalyzerSilenceTest, ToneTrackWithSilence) {
     CuePosition cue = pTrack->getCuePoint();
     EXPECT_DOUBLE_EQ(nTrackSampleDataLength / 4, cue.getPosition());
 
-    CuePointer pIntroCue = pTrack->findCueByType(Cue::Type::Intro);
+    CuePointer pIntroCue = pTrack->findCueByType(mixxx::CueType::Intro);
     EXPECT_DOUBLE_EQ(nTrackSampleDataLength / 4, pIntroCue->getPosition());
     EXPECT_DOUBLE_EQ(0.0, pIntroCue->getLength());
 
-    CuePointer pOutroCue = pTrack->findCueByType(Cue::Type::Outro);
+    CuePointer pOutroCue = pTrack->findCueByType(mixxx::CueType::Outro);
     EXPECT_DOUBLE_EQ(Cue::kNoPosition, pOutroCue->getPosition());
     EXPECT_DOUBLE_EQ(3 * nTrackSampleDataLength / 4, pOutroCue->getLength());
 }
@@ -149,11 +149,11 @@ TEST_F(AnalyzerSilenceTest, ToneTrackWithSilenceInTheMiddle) {
     CuePosition cue = pTrack->getCuePoint();
     EXPECT_DOUBLE_EQ(oneFifthOfTrackLength, cue.getPosition());
 
-    CuePointer pIntroCue = pTrack->findCueByType(Cue::Type::Intro);
+    CuePointer pIntroCue = pTrack->findCueByType(mixxx::CueType::Intro);
     EXPECT_DOUBLE_EQ(oneFifthOfTrackLength, pIntroCue->getPosition());
     EXPECT_DOUBLE_EQ(0.0, pIntroCue->getLength());
 
-    CuePointer pOutroCue = pTrack->findCueByType(Cue::Type::Outro);
+    CuePointer pOutroCue = pTrack->findCueByType(mixxx::CueType::Outro);
     EXPECT_DOUBLE_EQ(Cue::kNoPosition, pOutroCue->getPosition());
     EXPECT_DOUBLE_EQ(4 * oneFifthOfTrackLength, pOutroCue->getLength());
 }
@@ -167,12 +167,12 @@ TEST_F(AnalyzerSilenceTest, RespectUserEdits) {
     pTrack->setCuePoint(CuePosition(kManualCuePosition));
 
     CuePointer pIntroCue = pTrack->createAndAddCue();
-    pIntroCue->setType(Cue::Type::Intro);
+    pIntroCue->setType(mixxx::CueType::Intro);
     pIntroCue->setStartPosition(kManualIntroPosition);
     pIntroCue->setEndPosition(Cue::kNoPosition);
 
     CuePointer pOutroCue = pTrack->createAndAddCue();
-    pOutroCue->setType(Cue::Type::Outro);
+    pOutroCue->setType(mixxx::CueType::Outro);
     pOutroCue->setStartPosition(Cue::kNoPosition);
     pOutroCue->setEndPosition(kManualOutroPosition);
 

--- a/src/test/cuecontrol_test.cpp
+++ b/src/test/cuecontrol_test.cpp
@@ -77,11 +77,11 @@ TEST_F(CueControlTest, LoadUnloadTrack) {
     TrackPointer pTrack = createTestTrack();
     pTrack->setCuePoint(CuePosition(100.0));
     auto pIntro = pTrack->createAndAddCue();
-    pIntro->setType(Cue::Type::Intro);
+    pIntro->setType(mixxx::CueType::Intro);
     pIntro->setStartPosition(150.0);
     pIntro->setEndPosition(200.0);
     auto pOutro = pTrack->createAndAddCue();
-    pOutro->setType(Cue::Type::Outro);
+    pOutro->setType(mixxx::CueType::Outro);
     pOutro->setStartPosition(250.0);
     pOutro->setEndPosition(300.0);
 
@@ -114,11 +114,11 @@ TEST_F(CueControlTest, LoadTrackWithDetectedCues) {
     TrackPointer pTrack = createTestTrack();
     pTrack->setCuePoint(CuePosition(100.0));
     auto pIntro = pTrack->createAndAddCue();
-    pIntro->setType(Cue::Type::Intro);
+    pIntro->setType(mixxx::CueType::Intro);
     pIntro->setStartPosition(100.0);
     pIntro->setEndPosition(Cue::kNoPosition);
     auto pOutro = pTrack->createAndAddCue();
-    pOutro->setType(Cue::Type::Outro);
+    pOutro->setType(mixxx::CueType::Outro);
     pOutro->setStartPosition(Cue::kNoPosition);
     pOutro->setEndPosition(200.0);
 
@@ -138,11 +138,11 @@ TEST_F(CueControlTest, LoadTrackWithDetectedCues) {
 TEST_F(CueControlTest, LoadTrackWithIntroEndAndOutroStart) {
     TrackPointer pTrack = createTestTrack();
     auto pIntro = pTrack->createAndAddCue();
-    pIntro->setType(Cue::Type::Intro);
+    pIntro->setType(mixxx::CueType::Intro);
     pIntro->setStartPosition(Cue::kNoPosition);
     pIntro->setEndPosition(150.0);
     auto pOutro = pTrack->createAndAddCue();
-    pOutro->setType(Cue::Type::Outro);
+    pOutro->setType(mixxx::CueType::Outro);
     pOutro->setStartPosition(250.0);
     pOutro->setEndPosition(Cue::kNoPosition);
 
@@ -174,12 +174,12 @@ TEST_F(CueControlTest, LoadAutodetectedCues_QuantizeEnabled) {
     pTrack->setCuePoint(CuePosition(1.9 * beatLength));
 
     auto pIntro = pTrack->createAndAddCue();
-    pIntro->setType(Cue::Type::Intro);
+    pIntro->setType(mixxx::CueType::Intro);
     pIntro->setStartPosition(2.1 * beatLength);
     pIntro->setEndPosition(3.7 * beatLength);
 
     auto pOutro = pTrack->createAndAddCue();
-    pOutro->setType(Cue::Type::Outro);
+    pOutro->setType(mixxx::CueType::Outro);
     pOutro->setStartPosition(11.1 * beatLength);
     pOutro->setEndPosition(15.5 * beatLength);
 
@@ -202,12 +202,12 @@ TEST_F(CueControlTest, LoadAutodetectedCues_QuantizeEnabledNoBeats) {
     pTrack->setCuePoint(CuePosition(100.0));
 
     auto pIntro = pTrack->createAndAddCue();
-    pIntro->setType(Cue::Type::Intro);
+    pIntro->setType(mixxx::CueType::Intro);
     pIntro->setStartPosition(250.0);
     pIntro->setEndPosition(400.0);
 
     auto pOutro = pTrack->createAndAddCue();
-    pOutro->setType(Cue::Type::Outro);
+    pOutro->setType(mixxx::CueType::Outro);
     pOutro->setStartPosition(550.0);
     pOutro->setEndPosition(800.0);
 
@@ -230,12 +230,12 @@ TEST_F(CueControlTest, LoadAutodetectedCues_QuantizeDisabled) {
     pTrack->setCuePoint(CuePosition(240.0));
 
     auto pIntro = pTrack->createAndAddCue();
-    pIntro->setType(Cue::Type::Intro);
+    pIntro->setType(mixxx::CueType::Intro);
     pIntro->setStartPosition(210.0);
     pIntro->setEndPosition(330.0);
 
     auto pOutro = pTrack->createAndAddCue();
-    pOutro->setType(Cue::Type::Outro);
+    pOutro->setType(mixxx::CueType::Outro);
     pOutro->setStartPosition(770.0);
     pOutro->setEndPosition(990.0);
 
@@ -252,7 +252,7 @@ TEST_F(CueControlTest, SeekOnLoadDefault) {
     // Default is to load at the intro start
     TrackPointer pTrack = createTestTrack();
     auto pIntro = pTrack->createAndAddCue();
-    pIntro->setType(Cue::Type::Intro);
+    pIntro->setType(mixxx::CueType::Intro);
     pIntro->setStartPosition(250.0);
     pIntro->setEndPosition(400.0);
 
@@ -312,7 +312,7 @@ TEST_F(CueControlTest, IntroCue_SetStartEnd_ClearStartEnd) {
     EXPECT_DOUBLE_EQ(Cue::kNoPosition, m_pIntroEndPosition->get());
     EXPECT_FALSE(m_pIntroEndEnabled->toBool());
 
-    CuePointer pCue = pTrack->findCueByType(Cue::Type::Intro);
+    CuePointer pCue = pTrack->findCueByType(mixxx::CueType::Intro);
     EXPECT_NE(nullptr, pCue);
     if (pCue != nullptr) {
         EXPECT_DOUBLE_EQ(100.0, pCue->getPosition());
@@ -328,7 +328,7 @@ TEST_F(CueControlTest, IntroCue_SetStartEnd_ClearStartEnd) {
     EXPECT_DOUBLE_EQ(500.0, m_pIntroEndPosition->get());
     EXPECT_TRUE(m_pIntroEndEnabled->toBool());
 
-    pCue = pTrack->findCueByType(Cue::Type::Intro);
+    pCue = pTrack->findCueByType(mixxx::CueType::Intro);
     EXPECT_NE(nullptr, pCue);
     if (pCue != nullptr) {
         EXPECT_DOUBLE_EQ(100.0, pCue->getPosition());
@@ -343,7 +343,7 @@ TEST_F(CueControlTest, IntroCue_SetStartEnd_ClearStartEnd) {
     EXPECT_DOUBLE_EQ(500.0, m_pIntroEndPosition->get());
     EXPECT_TRUE(m_pIntroEndEnabled->toBool());
 
-    pCue = pTrack->findCueByType(Cue::Type::Intro);
+    pCue = pTrack->findCueByType(mixxx::CueType::Intro);
     EXPECT_NE(nullptr, pCue);
     if (pCue != nullptr) {
         EXPECT_DOUBLE_EQ(Cue::kNoPosition, pCue->getPosition());
@@ -358,7 +358,7 @@ TEST_F(CueControlTest, IntroCue_SetStartEnd_ClearStartEnd) {
     EXPECT_DOUBLE_EQ(Cue::kNoPosition, m_pIntroEndPosition->get());
     EXPECT_FALSE(m_pIntroEndEnabled->toBool());
 
-    EXPECT_EQ(nullptr, pTrack->findCueByType(Cue::Type::Intro));
+    EXPECT_EQ(nullptr, pTrack->findCueByType(mixxx::CueType::Intro));
 }
 
 TEST_F(CueControlTest, OutroCue_SetStartEnd_ClearStartEnd) {
@@ -373,7 +373,7 @@ TEST_F(CueControlTest, OutroCue_SetStartEnd_ClearStartEnd) {
     EXPECT_DOUBLE_EQ(Cue::kNoPosition, m_pOutroEndPosition->get());
     EXPECT_FALSE(m_pOutroEndEnabled->toBool());
 
-    CuePointer pCue = pTrack->findCueByType(Cue::Type::Outro);
+    CuePointer pCue = pTrack->findCueByType(mixxx::CueType::Outro);
     EXPECT_NE(nullptr, pCue);
     if (pCue != nullptr) {
         EXPECT_DOUBLE_EQ(750.0, pCue->getPosition());
@@ -389,7 +389,7 @@ TEST_F(CueControlTest, OutroCue_SetStartEnd_ClearStartEnd) {
     EXPECT_DOUBLE_EQ(1000.0, m_pOutroEndPosition->get());
     EXPECT_TRUE(m_pOutroEndEnabled->toBool());
 
-    pCue = pTrack->findCueByType(Cue::Type::Outro);
+    pCue = pTrack->findCueByType(mixxx::CueType::Outro);
     EXPECT_NE(nullptr, pCue);
     if (pCue != nullptr) {
         EXPECT_DOUBLE_EQ(750.0, pCue->getPosition());
@@ -404,7 +404,7 @@ TEST_F(CueControlTest, OutroCue_SetStartEnd_ClearStartEnd) {
     EXPECT_DOUBLE_EQ(1000.0, m_pOutroEndPosition->get());
     EXPECT_TRUE(m_pOutroEndEnabled->toBool());
 
-    pCue = pTrack->findCueByType(Cue::Type::Outro);
+    pCue = pTrack->findCueByType(mixxx::CueType::Outro);
     EXPECT_NE(nullptr, pCue);
     if (pCue != nullptr) {
         EXPECT_DOUBLE_EQ(Cue::kNoPosition, pCue->getPosition());
@@ -419,5 +419,5 @@ TEST_F(CueControlTest, OutroCue_SetStartEnd_ClearStartEnd) {
     EXPECT_DOUBLE_EQ(Cue::kNoPosition, m_pOutroEndPosition->get());
     EXPECT_FALSE(m_pOutroEndEnabled->toBool());
 
-    EXPECT_EQ(nullptr, pTrack->findCueByType(Cue::Type::Outro));
+    EXPECT_EQ(nullptr, pTrack->findCueByType(mixxx::CueType::Outro));
 }

--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -1,10 +1,12 @@
 // cue.cpp
 // Created 10/26/2009 by RJ Ryan (rryan@mit.edu)
 
+#include "track/cue.h"
+
 #include <QMutexLocker>
 #include <QtDebug>
 
-#include "track/cue.h"
+#include "engine/engine.h"
 #include "util/assert.h"
 #include "util/color/color.h"
 
@@ -23,7 +25,7 @@ Cue::Cue(TrackId trackId)
         : m_bDirty(false),
           m_iId(-1),
           m_trackId(trackId),
-          m_type(Cue::Type::Invalid),
+          m_type(mixxx::CueType::Invalid),
           m_sampleStartPosition(Cue::kNoPosition),
           m_sampleEndPosition(Cue::kNoPosition),
           m_iHotCue(-1),
@@ -32,8 +34,7 @@ Cue::Cue(TrackId trackId)
     DEBUG_ASSERT(!m_label.isNull());
 }
 
-Cue::Cue(int id, TrackId trackId, Cue::Type type, double position, double length,
-         int hotCue, QString label, PredefinedColorPointer color)
+Cue::Cue(int id, TrackId trackId, mixxx::CueType type, double position, double length, int hotCue, QString label, PredefinedColorPointer color)
         : m_bDirty(false),
           m_iId(id),
           m_trackId(trackId),
@@ -79,12 +80,12 @@ void Cue::setTrackId(TrackId trackId) {
     emit updated();
 }
 
-Cue::Type Cue::getType() const {
+mixxx::CueType Cue::getType() const {
     QMutexLocker lock(&m_mutex);
     return m_type;
 }
 
-void Cue::setType(Cue::Type type) {
+void Cue::setType(mixxx::CueType type) {
     QMutexLocker lock(&m_mutex);
     m_type = type;
     m_bDirty = true;

--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -64,7 +64,7 @@ Cue::Cue(TrackId trackId, mixxx::AudioSignal::SampleRate sampleRate, const mixxx
           m_sampleEndPosition(Cue::kNoPosition),
           m_iHotCue(Cue::kNoHotCue),
           m_label(cueInfo.getLabel()),
-          m_color(Color::kPredefinedColorsSet.noColor) {
+          m_color(Color::kPredefinedColorsSet.predefinedColorFromRgbColor(cueInfo.getColor())) {
     DEBUG_ASSERT(!m_label.isNull());
     DEBUG_ASSERT(sampleRate.valid());
 
@@ -82,16 +82,6 @@ Cue::Cue(TrackId trackId, mixxx::AudioSignal::SampleRate sampleRate, const mixxx
 
     if (cueInfo.getHotCueNumber()) {
         m_iHotCue = *cueInfo.getHotCueNumber();
-    }
-
-    mixxx::RgbColor::optional_t color = cueInfo.getColor();
-    if (color) {
-        for (PredefinedColorPointer pColor : Color::kPredefinedColorsSet.allColors) {
-            if (mixxx::RgbColor(pColor->m_defaultRgba.rgb()) == *color) {
-                m_color = pColor;
-                break;
-            }
-        }
     }
 }
 

--- a/src/track/cue.h
+++ b/src/track/cue.h
@@ -1,10 +1,11 @@
 #ifndef MIXXX_CUE_H
 #define MIXXX_CUE_H
 
-#include <QObject>
-#include <QMutex>
 #include <QColor>
+#include <QMutex>
+#include <QObject>
 
+#include "track/cueinfo.h"
 #include "track/trackid.h"
 #include "util/color/predefinedcolor.h"
 #include "util/memory.h"
@@ -17,21 +18,8 @@ class Cue : public QObject {
     Q_OBJECT
 
   public:
-    enum class Type {
-        Invalid = 0,
-        HotCue  = 1,
-        MainCue = 2,
-        Beat    = 3, // unused (what is this for?)
-        Loop    = 4,
-        Jump    = 5,
-        Intro   = 6,
-        Outro   = 7,
-        AudibleSound = 8, // range that covers beginning and end of audible sound;
-                          // not shown to user
-    };
-
     static constexpr double kNoPosition = -1.0;
-    static const int kNoHotCue = -1;
+    static constexpr int kNoHotCue = -1;
 
     ~Cue() override = default;
 
@@ -39,8 +27,8 @@ class Cue : public QObject {
     int getId() const;
     TrackId getTrackId() const;
 
-    Cue::Type getType() const;
-    void setType(Cue::Type type);
+    mixxx::CueType getType() const;
+    void setType(mixxx::CueType type);
 
     double getPosition() const;
     void setStartPosition(double samplePosition);
@@ -64,8 +52,7 @@ class Cue : public QObject {
 
   private:
     explicit Cue(TrackId trackId);
-    Cue(int id, TrackId trackId, Cue::Type type, double position, double length,
-        int hotCue, QString label, PredefinedColorPointer color);
+    Cue(int id, TrackId trackId, mixxx::CueType type, double position, double length, int hotCue, QString label, PredefinedColorPointer color);
     void setDirty(bool dirty);
     void setId(int id);
     void setTrackId(TrackId trackId);
@@ -75,7 +62,7 @@ class Cue : public QObject {
     bool m_bDirty;
     int m_iId;
     TrackId m_trackId;
-    Cue::Type m_type;
+    mixxx::CueType m_type;
     double m_sampleStartPosition;
     double m_sampleEndPosition;
     int m_iHotCue;

--- a/src/track/cue.h
+++ b/src/track/cue.h
@@ -7,6 +7,7 @@
 
 #include "track/cueinfo.h"
 #include "track/trackid.h"
+#include "util/audiosignal.h"
 #include "util/color/predefinedcolor.h"
 #include "util/memory.h"
 
@@ -52,6 +53,7 @@ class Cue : public QObject {
 
   private:
     explicit Cue(TrackId trackId);
+    explicit Cue(TrackId trackId, mixxx::AudioSignal::SampleRate sampleRate, const mixxx::CueInfo& cueInfo);
     Cue(int id, TrackId trackId, mixxx::CueType type, double position, double length, int hotCue, QString label, PredefinedColorPointer color);
     void setDirty(bool dirty);
     void setId(int id);

--- a/src/track/cueinfo.cpp
+++ b/src/track/cueinfo.cpp
@@ -1,0 +1,86 @@
+#include "track/cueinfo.h"
+
+#include "util/assert.h"
+
+namespace {
+const QString kDefaultLabel = QStringLiteral(""); // empty string, not null
+} // anonymous namespace
+
+namespace mixxx {
+
+CueInfo::CueInfo()
+        : m_type(CueType::Invalid),
+          m_startPositionMillis(std::nullopt),
+          m_endPositionMillis(std::nullopt),
+          m_hotCueNumber(std::nullopt),
+          m_label(kDefaultLabel),
+          m_color(std::nullopt) {
+    DEBUG_ASSERT(!m_label.isNull());
+}
+
+CueInfo::CueInfo(
+        CueType type,
+        std::optional<double> startPositionMillis,
+        std::optional<double> endPositionMillis,
+        std::optional<int> hotCueNumber,
+        QString label,
+        mixxx::RgbColor::optional_t color)
+        : m_type(type),
+          m_startPositionMillis(startPositionMillis),
+          m_endPositionMillis(endPositionMillis),
+          m_hotCueNumber(hotCueNumber),
+          m_label(label),
+          m_color(color) {
+    DEBUG_ASSERT(!m_label.isNull());
+}
+
+CueType CueInfo::getType() const {
+    return m_type;
+}
+
+void CueInfo::setType(CueType type) {
+    m_type = type;
+}
+
+void CueInfo::setStartPositionMillis(std::optional<double> positionMillis) {
+    m_startPositionMillis = positionMillis;
+}
+
+std::optional<double> CueInfo::getStartPositionMillis() const {
+    return m_startPositionMillis;
+}
+
+void CueInfo::setEndPositionMillis(std::optional<double> positionMillis) {
+    m_endPositionMillis = positionMillis;
+}
+
+std::optional<double> CueInfo::getEndPositionMillis() const {
+    return m_endPositionMillis;
+}
+
+std::optional<int> CueInfo::getHotCueNumber() const {
+    return m_hotCueNumber;
+}
+
+void CueInfo::setHotCueNumber(std::optional<int> hotCueNumber) {
+    m_hotCueNumber = hotCueNumber;
+}
+
+QString CueInfo::getLabel() const {
+    return m_label;
+}
+
+void CueInfo::setLabel(QString label) {
+    DEBUG_ASSERT(!label.isNull());
+    m_label = label;
+}
+
+RgbColor::optional_t CueInfo::getColor() const {
+    return m_color;
+}
+
+void CueInfo::setColor(RgbColor::optional_t color) {
+    m_color = color;
+}
+
+} // namespace mixxx

--- a/src/track/cueinfo.h
+++ b/src/track/cueinfo.h
@@ -1,0 +1,61 @@
+#pragma once
+// cueinfo.h
+// Created 2020-02-28 by Jan Holthuis
+
+#include "util/color/rgbcolor.h"
+#include "util/optional.h"
+
+namespace mixxx {
+
+enum class CueType {
+    Invalid = 0,
+    HotCue = 1,
+    MainCue = 2,
+    Beat = 3, // unused (what is this for?)
+    Loop = 4,
+    Jump = 5,
+    Intro = 6,
+    Outro = 7,
+    AudibleSound = 8, // range that covers beginning and end of audible
+                      // sound; not shown to user
+};
+
+// DTO for Cue information without dependencies on the actual Track object
+class CueInfo {
+  public:
+    CueInfo();
+    CueInfo(CueType type,
+            std::optional<double> startPositionMillis,
+            std::optional<double> endPositionMillis,
+            std::optional<int> hotCueNumber,
+            QString label,
+            RgbColor::optional_t color);
+
+    CueType getType() const;
+    void setType(CueType type);
+
+    void setStartPositionMillis(std::optional<double> positionMillis);
+    std::optional<double> getStartPositionMillis() const;
+
+    void setEndPositionMillis(std::optional<double> positionMillis);
+    std::optional<double> getEndPositionMillis() const;
+
+    std::optional<int> getHotCueNumber() const;
+    void setHotCueNumber(std::optional<int> hotCueNumber);
+
+    QString getLabel() const;
+    void setLabel(QString label);
+
+    mixxx::RgbColor::optional_t getColor() const;
+    void setColor(mixxx::RgbColor::optional_t color);
+
+  private:
+    CueType m_type;
+    std::optional<double> m_startPositionMillis;
+    std::optional<double> m_endPositionMillis;
+    std::optional<int> m_hotCueNumber;
+    QString m_label;
+    RgbColor::optional_t m_color;
+};
+
+} // namespace mixxx

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -788,6 +788,23 @@ void Track::setCuePoints(const QList<CuePointer>& cuePoints) {
     emit cuesUpdated();
 }
 
+void Track::importCuePoints(const QList<mixxx::CueInfo>& cueInfos) {
+    TrackId trackId;
+    mixxx::AudioSignal::SampleRate sampleRate;
+    {
+        QMutexLocker lock(&m_qMutex);
+        trackId = m_record.getId();
+        sampleRate = m_record.getMetadata().getSampleRate();
+    } // implicitly unlocked when leaving scope
+
+    QList<CuePointer> cuePoints;
+    for (const mixxx::CueInfo& cueInfo : cueInfos) {
+        CuePointer pCue(new Cue(trackId, sampleRate, cueInfo));
+        cuePoints.append(pCue);
+    }
+    setCuePoints(cuePoints);
+}
+
 void Track::markDirty() {
     QMutexLocker lock(&m_qMutex);
     setDirtyAndUnlock(&lock, true);

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -716,7 +716,9 @@ CuePointer Track::createAndAddCue() {
 CuePointer Track::findCueByType(mixxx::CueType type) const {
     // This method cannot be used for hotcues because there can be
     // multiple hotcues and this function returns only a single CuePointer.
-    DEBUG_ASSERT(type != mixxx::CueType::HotCue);
+    VERIFY_OR_DEBUG_ASSERT(type != mixxx::CueType::HotCue) {
+        return CuePointer();
+    }
     QMutexLocker lock(&m_qMutex);
     for (const CuePointer& pCue: m_cuePoints) {
         if (pCue->getType() == type) {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1,15 +1,15 @@
+#include "track/track.h"
+
 #include <QDirIterator>
 #include <QMutexLocker>
-
 #include <atomic>
 
-#include "track/track.h"
-#include "track/trackref.h"
+#include "engine/engine.h"
 #include "track/beatfactory.h"
-
+#include "track/trackref.h"
 #include "util/assert.h"
+#include "util/color/color.h"
 #include "util/logger.h"
-
 
 namespace {
 
@@ -671,12 +671,12 @@ void Track::setCuePoint(CuePosition cue) {
     }
 
     // Store the cue point in a load cue
-    CuePointer pLoadCue = findCueByType(Cue::Type::MainCue);
+    CuePointer pLoadCue = findCueByType(mixxx::CueType::MainCue);
     double position = cue.getPosition();
     if (position != -1.0) {
         if (!pLoadCue) {
             pLoadCue = CuePointer(new Cue(m_record.getId()));
-            pLoadCue->setType(Cue::Type::MainCue);
+            pLoadCue->setType(mixxx::CueType::MainCue);
             connect(pLoadCue.get(),
                     &Cue::updated,
                     this,
@@ -713,10 +713,10 @@ CuePointer Track::createAndAddCue() {
     return pCue;
 }
 
-CuePointer Track::findCueByType(Cue::Type type) const {
+CuePointer Track::findCueByType(mixxx::CueType type) const {
     // This method cannot be used for hotcues because there can be
     // multiple hotcues and this function returns only a single CuePointer.
-    DEBUG_ASSERT(type != Cue::Type::HotCue);
+    DEBUG_ASSERT(type != mixxx::CueType::HotCue);
     QMutexLocker lock(&m_qMutex);
     for (const CuePointer& pCue: m_cuePoints) {
         if (pCue->getType() == type) {
@@ -734,14 +734,14 @@ void Track::removeCue(const CuePointer& pCue) {
     QMutexLocker lock(&m_qMutex);
     disconnect(pCue.get(), 0, this, 0);
     m_cuePoints.removeOne(pCue);
-    if (pCue->getType() == Cue::Type::MainCue) {
+    if (pCue->getType() == mixxx::CueType::MainCue) {
         m_record.setCuePoint(CuePosition());
     }
     markDirtyAndUnlock(&lock);
     emit cuesUpdated();
 }
 
-void Track::removeCuesOfType(Cue::Type type) {
+void Track::removeCuesOfType(mixxx::CueType type) {
     QMutexLocker lock(&m_qMutex);
     bool dirty = false;
     QMutableListIterator<CuePointer> it(m_cuePoints);
@@ -780,7 +780,7 @@ void Track::setCuePoints(const QList<CuePointer>& cuePoints) {
     for (const auto& pCue: m_cuePoints) {
         connect(pCue.get(), &Cue::updated, this, &Track::slotCueUpdated);
         // update main cue point
-        if (pCue->getType() == Cue::Type::MainCue) {
+        if (pCue->getType() == mixxx::CueType::MainCue) {
             m_record.setCuePoint(CuePosition(pCue->getPosition()));
         }
     }

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -251,9 +251,9 @@ class Track : public QObject {
 
     // Calls for managing the track's cue points
     CuePointer createAndAddCue();
-    CuePointer findCueByType(Cue::Type type) const; // NOTE: Cannot be used for hotcues.
+    CuePointer findCueByType(mixxx::CueType type) const; // NOTE: Cannot be used for hotcues.
     void removeCue(const CuePointer& pCue);
-    void removeCuesOfType(Cue::Type);
+    void removeCuesOfType(mixxx::CueType);
     QList<CuePointer> getCuePoints() const;
     void setCuePoints(const QList<CuePointer>& cuePoints);
 

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -256,6 +256,7 @@ class Track : public QObject {
     void removeCuesOfType(mixxx::CueType);
     QList<CuePointer> getCuePoints() const;
     void setCuePoints(const QList<CuePointer>& cuePoints);
+    void importCuePoints(const QList<mixxx::CueInfo>& cueInfos);
 
     bool isDirty();
 

--- a/src/util/color/predefinedcolorsset.h
+++ b/src/util/color/predefinedcolorsset.h
@@ -110,6 +110,23 @@ class PredefinedColorsSet final {
         return noColor;
     };
 
+    PredefinedColorPointer predefinedColorFromRgbColor(mixxx::RgbColor color) const {
+        for (PredefinedColorPointer pColor : allColors) {
+            if (mixxx::RgbColor(pColor->m_defaultRgba.rgb()) == color) {
+                return pColor;
+                break;
+            }
+        }
+        return noColor;
+    };
+
+    PredefinedColorPointer predefinedColorFromRgbColor(mixxx::RgbColor::optional_t color) const {
+        if (!color) {
+            return noColor;
+        }
+        return predefinedColorFromRgbColor(*color);
+    };
+
     // The default color representation, i.e. maps each predefined color to its default Rgba.
     PredefinedColorsRepresentation defaultRepresentation() const {
         return m_defaultRepresentation;

--- a/src/util/color/predefinedcolorsset.h
+++ b/src/util/color/predefinedcolorsset.h
@@ -124,10 +124,10 @@ class PredefinedColorsSet final {
     };
 
     PredefinedColorPointer predefinedColorFromRgbColor(mixxx::RgbColor::optional_t color) const {
-        if (!color) {
-            return noColor;
+        if (color) {
+            return predefinedColorFromRgbColor(*color);
         }
-        return predefinedColorFromRgbColor(*color);
+        return noColor;
     };
 
     // The default color representation, i.e. maps each predefined color to its default Rgba.

--- a/src/util/color/predefinedcolorsset.h
+++ b/src/util/color/predefinedcolorsset.h
@@ -97,6 +97,7 @@ class PredefinedColorsSet final {
                 return color;
             }
         }
+        qWarning() << "No color matches name" << name;
         return noColor;
     };
 
@@ -108,6 +109,7 @@ class PredefinedColorsSet final {
                 return color;
             }
         }
+        qWarning() << "No color matches id" << iId;
         return noColor;
     };
 
@@ -118,6 +120,7 @@ class PredefinedColorsSet final {
                 break;
             }
         }
+        qWarning() << "No color matches RgbColor" << color;
         return noColor;
     };
 

--- a/src/util/color/predefinedcolorsset.h
+++ b/src/util/color/predefinedcolorsset.h
@@ -117,7 +117,6 @@ class PredefinedColorsSet final {
         for (PredefinedColorPointer pColor : allColors) {
             if (mixxx::RgbColor(pColor->m_defaultRgba.rgb()) == color) {
                 return pColor;
-                break;
             }
         }
         qWarning() << "No color matches RgbColor" << color;

--- a/src/util/color/predefinedcolorsset.h
+++ b/src/util/color/predefinedcolorsset.h
@@ -5,6 +5,7 @@
 
 #include "predefinedcolorsrepresentation.h"
 #include "util/color/predefinedcolor.h"
+#include "util/color/rgbcolor.h"
 
 // This class defines a set of predefined colors and provides some handy functions to work with them.
 // A single global instance is create in the Color namespace.

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -356,7 +356,7 @@ void WOverview::updateCues(const QList<CuePointer> &loadedCues) {
             }
 
             int hotcueNumber = currentCue->getHotCue();
-            if (currentCue->getType() == Cue::Type::HotCue && hotcueNumber != Cue::kNoHotCue) {
+            if (currentCue->getType() == mixxx::CueType::HotCue && hotcueNumber != Cue::kNoHotCue) {
                 // Prepend the hotcue number to hotcues' labels
                 QString newLabel = currentCue->getLabel();
                 if (newLabel.isEmpty()) {
@@ -1096,7 +1096,7 @@ double WOverview::samplePositionToSeconds(double sample) {
 }
 
 void WOverview::resizeEvent(QResizeEvent* pEvent) {
-    Q_UNUSED(pEvent);   
+    Q_UNUSED(pEvent);
     // Play-position potmeters range from 0 to 1 but they allow out-of-range
     // sets. This is to give VC access to the pre-roll area.
     const double kMaxPlayposRange = 1.0;

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1112,15 +1112,9 @@ void WTrackTableView::contextMenuEvent(QContextMenuEvent* event) {
             // different colors, do not preselect a color (by using nullptr
             // instead).
             PredefinedColorPointer predefinedTrackColor = nullptr;
-
             if (trackColor) {
                 // All tracks have the same color
-                for (PredefinedColorPointer color : Color::kPredefinedColorsSet.allColors) {
-                    if (mixxx::RgbColor(color->m_defaultRgba.rgb()) == *trackColor) {
-                        predefinedTrackColor = color;
-                        break;
-                    }
-                }
+                predefinedTrackColor = Color::kPredefinedColorsSet.predefinedColorFromRgbColor(trackColor);
             } else if (!multipleTrackColors) {
                 // All tracks have no color
                 predefinedTrackColor = Color::kPredefinedColorsSet.noColor;

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -2028,7 +2028,7 @@ void WTrackTableView::slotClearMainCue() {
     for (const QModelIndex& index : indices) {
         TrackPointer pTrack = trackModel->getTrack(index);
         if (pTrack) {
-            pTrack->removeCuesOfType(Cue::Type::MainCue);
+            pTrack->removeCuesOfType(mixxx::CueType::MainCue);
         }
     }
 }
@@ -2044,7 +2044,7 @@ void WTrackTableView::slotClearHotCues() {
     for (const QModelIndex& index : indices) {
         TrackPointer pTrack = trackModel->getTrack(index);
         if (pTrack) {
-            pTrack->removeCuesOfType(Cue::Type::HotCue);
+            pTrack->removeCuesOfType(mixxx::CueType::HotCue);
         }
     }
 }
@@ -2060,7 +2060,7 @@ void WTrackTableView::slotClearIntroCue() {
     for (const QModelIndex& index : indices) {
         TrackPointer pTrack = trackModel->getTrack(index);
         if (pTrack) {
-            pTrack->removeCuesOfType(Cue::Type::Intro);
+            pTrack->removeCuesOfType(mixxx::CueType::Intro);
         }
     }
 }
@@ -2076,7 +2076,7 @@ void WTrackTableView::slotClearOutroCue() {
     for (const QModelIndex& index : indices) {
         TrackPointer pTrack = trackModel->getTrack(index);
         if (pTrack) {
-            pTrack->removeCuesOfType(Cue::Type::Outro);
+            pTrack->removeCuesOfType(mixxx::CueType::Outro);
         }
     }
 }
@@ -2092,7 +2092,7 @@ void WTrackTableView::slotClearLoop() {
     for (const QModelIndex& index : indices) {
         TrackPointer pTrack = trackModel->getTrack(index);
         if (pTrack) {
-            pTrack->removeCuesOfType(Cue::Type::Loop);
+            pTrack->removeCuesOfType(mixxx::CueType::Loop);
         }
     }
 }


### PR DESCRIPTION
This adds a `CueInfo` class that does not have any dependencies on `Track` or `Cue`. To archieve this, we use *positions in milliseconds* instead of *sample positions*, so that we don't need to know the tracks' sample rate.

The `Track` object gets a new method to import cues from a list of `CueInfo` objects.

This would be useful for Serato Markers Integration (PR #2499).

Also see related Zulip discussion for details:
https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/2.2E3.20planning/near/189265725