### PR TITLE
Fix potential race conditions and crashes during shutdown

### DIFF
--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -19,6 +19,9 @@ const QString kConfigGroup = QStringLiteral("[TrackCollection]");
 
 const ConfigKey kConfigKeyRepairDatabaseOnNextRestart(kConfigGroup, "RepairDatabaseOnNextRestart");
 
+// Prevent infinite delays during shutdown. Long enough to finish
+// the pending tasks and short enough to prevent users from killing
+// the process.
 constexpr int kThreadPoolTimeoutMillisOnShutdown = 30000; // 30 sec
 
 inline


### PR DESCRIPTION
Lessons learned from PR #2508: Concurrent guessing of cover infos may not have finished before shutting down. Those pending tasks may cause crashes when trying to access resources that have already disappeared.