### PR TITLE
Get CueInfo from Cue object

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -930,6 +930,7 @@ add_executable(mixxx-test
   src/test/coverartcache_test.cpp
   src/test/coverartutils_test.cpp
   src/test/cratestorage_test.cpp
+  src/test/cue_test.cpp
   src/test/cuecontrol_test.cpp
   src/test/dbconnectionpool_test.cpp
   src/test/dbidtest.cpp

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -592,7 +592,7 @@ void CueControl::hotcueSet(HotcueControl* pControl, double v) {
     double cuePosition = getQuantizedCurrentPosition();
     pCue->setStartPosition(cuePosition);
     pCue->setHotCue(hotcue);
-    pCue->setLabel("");
+    pCue->setLabel();
     pCue->setType(mixxx::CueType::HotCue);
     // TODO(XXX) deal with spurious signals
     attachCue(pCue, pControl);

--- a/src/test/cue_test.cpp
+++ b/src/test/cue_test.cpp
@@ -1,0 +1,49 @@
+#include "track/cue.h"
+
+#include <gtest/gtest.h>
+
+#include "test/mixxxtest.h"
+#include "util/color/color.h"
+
+namespace mixxx {
+
+TEST(CueTest, DefaultCueToCueInfoTest) {
+    const Cue cueObject;
+    const auto cueInfo = cueObject.getCueInfo(
+            AudioSignal::SampleRate(44100));
+    EXPECT_EQ(CueInfo(), cueInfo);
+}
+
+TEST(CueTest, DefaultCueInfoToCueRoundtrip) {
+    const CueInfo cueInfo1;
+    const Cue cueObject(
+            cueInfo1,
+            AudioSignal::SampleRate(44100));
+    const auto cueInfo2 = cueObject.getCueInfo(
+            AudioSignal::SampleRate(44100));
+    EXPECT_EQ(cueInfo1, cueInfo2);
+}
+
+TEST(CueTest, ConvertCueInfoToCueRoundtrip) {
+    // Due to rounding errors this test may fail if the
+    // cue position/sample conversions don't always result
+    // in integer numbers.
+    const auto predefinedColor =
+            Color::kPredefinedColorsSet.predefinedColorFromRgbColor(
+                    RgbColor::optional(0xabcdef))->m_defaultRgba;
+    const auto cueInfo1 = CueInfo(
+            CueType::HotCue,
+            std::make_optional(1.0 * 44100 * 2),
+            std::make_optional(2.0 * 44100 * 2),
+            std::make_optional(3),
+            QStringLiteral("label"),
+            RgbColor::fromQColor(predefinedColor));
+    const Cue cueObject(
+            cueInfo1,
+            AudioSignal::SampleRate(44100));
+    const auto cueInfo2 = cueObject.getCueInfo(
+            AudioSignal::SampleRate(44100));
+    EXPECT_EQ(cueInfo1, cueInfo2);
+}
+
+} // namespace mixxx

--- a/src/test/cue_test.cpp
+++ b/src/test/cue_test.cpp
@@ -3,6 +3,8 @@
 #include <gtest/gtest.h>
 
 #include "test/mixxxtest.h"
+
+#include "engine/engine.h"
 #include "util/color/color.h"
 
 namespace mixxx {
@@ -33,8 +35,8 @@ TEST(CueTest, ConvertCueInfoToCueRoundtrip) {
                     RgbColor::optional(0xabcdef))->m_defaultRgba;
     const auto cueInfo1 = CueInfo(
             CueType::HotCue,
-            std::make_optional(1.0 * 44100 * 2),
-            std::make_optional(2.0 * 44100 * 2),
+            std::make_optional(1.0 * 44100 * mixxx::kEngineChannelCount),
+            std::make_optional(2.0 * 44100 * mixxx::kEngineChannelCount),
             std::make_optional(3),
             QStringLiteral("label"),
             RgbColor::fromQColor(predefinedColor));

--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -21,7 +21,8 @@ void CuePointer::deleteLater(Cue* pCue) {
     }
 }
 
-Cue::Cue(TrackId trackId)
+Cue::Cue(
+        TrackId trackId)
         : m_bDirty(false),
           m_iId(-1),
           m_trackId(trackId),
@@ -34,7 +35,15 @@ Cue::Cue(TrackId trackId)
     DEBUG_ASSERT(!m_label.isNull());
 }
 
-Cue::Cue(int id, TrackId trackId, mixxx::CueType type, double position, double length, int hotCue, QString label, PredefinedColorPointer color)
+Cue::Cue(
+        int id,
+        TrackId trackId,
+        mixxx::CueType type,
+        double position,
+        double length,
+        int hotCue,
+        QString label,
+        PredefinedColorPointer color)
         : m_bDirty(false),
           m_iId(id),
           m_trackId(trackId),
@@ -55,7 +64,10 @@ Cue::Cue(int id, TrackId trackId, mixxx::CueType type, double position, double l
     }
 }
 
-Cue::Cue(TrackId trackId, mixxx::AudioSignal::SampleRate sampleRate, const mixxx::CueInfo& cueInfo)
+Cue::Cue(
+        TrackId trackId,
+        mixxx::AudioSignal::SampleRate sampleRate,
+        const mixxx::CueInfo& cueInfo)
         : m_bDirty(false),
           m_iId(-1),
           m_trackId(trackId),

--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -43,7 +43,6 @@ Cue::Cue(
           m_sampleEndPosition(Cue::kNoPosition),
           m_iHotCue(Cue::kNoHotCue),
           m_color(Color::kPredefinedColorsSet.noColor) {
-    DEBUG_ASSERT(!m_label.isNull());
 }
 
 Cue::Cue(
@@ -63,7 +62,6 @@ Cue::Cue(
           m_iHotCue(hotCue),
           m_label(label),
           m_color(color) {
-    DEBUG_ASSERT(!m_label.isNull());
     if (length) {
         if (position != Cue::kNoPosition) {
             m_sampleEndPosition = position + length;
@@ -88,7 +86,6 @@ Cue::Cue(
           m_iHotCue(Cue::kNoHotCue),
           m_label(cueInfo.getLabel()),
           m_color(Color::kPredefinedColorsSet.predefinedColorFromRgbColor(cueInfo.getColor())) {
-    DEBUG_ASSERT(!m_label.isNull());
     DEBUG_ASSERT(sampleRate.valid());
 
     const double sampleRateKhz = sampleRate / 1000.0;

--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -207,8 +207,6 @@ QString Cue::getLabel() const {
 }
 
 void Cue::setLabel(const QString label) {
-    //qDebug() << "setLabel()" << m_label << "-" << label;
-    DEBUG_ASSERT(!label.isNull());
     QMutexLocker lock(&m_mutex);
     m_label = label;
     m_bDirty = true;

--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -111,22 +111,16 @@ Cue::Cue(
     }
 }
 
-void Cue::readInfo(
-        mixxx::AudioSignal::SampleRate sampleRate,
-        mixxx::CueInfo* pCueInfo,
-        bool* pDirty) const {
-    DEBUG_ASSERT(pCueInfo);
+mixxx::CueInfo Cue::getCueInfo(
+        mixxx::AudioSignal::SampleRate sampleRate) const {
     QMutexLocker lock(&m_mutex);
-    *pCueInfo = mixxx::CueInfo(
+    return mixxx::CueInfo(
             m_type,
             samplePositionToMillis(m_sampleStartPosition, sampleRate),
             samplePositionToMillis(m_sampleEndPosition, sampleRate),
             m_iHotCue == kNoHotCue ? std::nullopt : std::make_optional(m_iHotCue),
             m_label,
             m_color ? mixxx::RgbColor::fromQColor(m_color->m_defaultRgba) : std::nullopt);
-    if (pDirty) {
-        *pDirty = m_bDirty;
-    }
 }
 
 int Cue::getId() const {

--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -43,7 +43,7 @@ Cue::Cue(
           m_type(mixxx::CueType::Invalid),
           m_sampleStartPosition(Cue::kNoPosition),
           m_sampleEndPosition(Cue::kNoPosition),
-          m_iHotCue(-1),
+          m_iHotCue(Cue::kNoHotCue),
           m_label(kDefaultLabel),
           m_color(Color::kPredefinedColorsSet.noColor) {
     DEBUG_ASSERT(!m_label.isNull());

--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -12,8 +12,6 @@
 
 namespace {
 
-const QString kDefaultLabel = ""; // empty string, not null
-
 inline std::optional<double> samplePositionToMillis(
         double samplePosition,
         mixxx::AudioSignal::SampleRate sampleRate) {
@@ -44,7 +42,6 @@ Cue::Cue(
           m_sampleStartPosition(Cue::kNoPosition),
           m_sampleEndPosition(Cue::kNoPosition),
           m_iHotCue(Cue::kNoHotCue),
-          m_label(kDefaultLabel),
           m_color(Color::kPredefinedColorsSet.noColor) {
     DEBUG_ASSERT(!m_label.isNull());
 }

--- a/src/track/cue.h
+++ b/src/track/cue.h
@@ -44,7 +44,7 @@ class Cue : public QObject {
     void setHotCue(int hotCue);
 
     QString getLabel() const;
-    void setLabel(QString label);
+    void setLabel(QString label = QString());
 
     PredefinedColorPointer getColor() const;
     void setColor(PredefinedColorPointer color);

--- a/src/track/cue.h
+++ b/src/track/cue.h
@@ -1,5 +1,4 @@
-#ifndef MIXXX_CUE_H
-#define MIXXX_CUE_H
+#pragma once
 
 #include <QColor>
 #include <QMutex>
@@ -22,6 +21,10 @@ class Cue : public QObject {
     static constexpr double kNoPosition = -1.0;
     static constexpr int kNoHotCue = -1;
 
+    Cue();
+    Cue(
+            const mixxx::CueInfo& cueInfo,
+            mixxx::AudioSignal::SampleRate sampleRate);
     ~Cue() override = default;
 
     bool isDirty() const;
@@ -55,12 +58,6 @@ class Cue : public QObject {
     void updated();
 
   private:
-    explicit Cue(
-            TrackId trackId);
-    Cue(
-            TrackId trackId,
-            mixxx::AudioSignal::SampleRate sampleRate,
-            const mixxx::CueInfo& cueInfo);
     Cue(
             int id,
             TrackId trackId,
@@ -92,11 +89,11 @@ class Cue : public QObject {
     friend class CueDAO;
 };
 
-class CuePointer: public std::shared_ptr<Cue> {
+class CuePointer : public std::shared_ptr<Cue> {
   public:
     CuePointer() = default;
     explicit CuePointer(Cue* pCue)
-          : std::shared_ptr<Cue>(pCue, deleteLater) {
+            : std::shared_ptr<Cue>(pCue, deleteLater) {
     }
 
   private:
@@ -106,9 +103,11 @@ class CuePointer: public std::shared_ptr<Cue> {
 class CuePosition {
   public:
     CuePosition()
-        : m_position(0.0) {}
+            : m_position(0.0) {
+    }
     CuePosition(double position)
-        : m_position(position) {}
+            : m_position(position) {
+    }
 
     double getPosition() const {
         return m_position;
@@ -132,14 +131,10 @@ class CuePosition {
 
 bool operator==(const CuePosition& lhs, const CuePosition& rhs);
 
-inline
-bool operator!=(const CuePosition& lhs, const CuePosition& rhs) {
+inline bool operator!=(const CuePosition& lhs, const CuePosition& rhs) {
     return !(lhs == rhs);
 }
 
-inline
-QDebug operator<<(QDebug dbg, const CuePosition& arg) {
+inline QDebug operator<<(QDebug dbg, const CuePosition& arg) {
     return dbg << "position =" << arg.getPosition();
 }
-
-#endif // MIXXX_CUE_H

--- a/src/track/cue.h
+++ b/src/track/cue.h
@@ -52,10 +52,24 @@ class Cue : public QObject {
     void updated();
 
   private:
-    explicit Cue(TrackId trackId);
-    explicit Cue(TrackId trackId, mixxx::AudioSignal::SampleRate sampleRate, const mixxx::CueInfo& cueInfo);
-    Cue(int id, TrackId trackId, mixxx::CueType type, double position, double length, int hotCue, QString label, PredefinedColorPointer color);
+    explicit Cue(
+            TrackId trackId);
+    Cue(
+            TrackId trackId,
+            mixxx::AudioSignal::SampleRate sampleRate,
+            const mixxx::CueInfo& cueInfo);
+    Cue(
+            int id,
+            TrackId trackId,
+            mixxx::CueType type,
+            double position,
+            double length,
+            int hotCue,
+            QString label,
+            PredefinedColorPointer color);
+
     void setDirty(bool dirty);
+
     void setId(int id);
     void setTrackId(TrackId trackId);
 

--- a/src/track/cue.h
+++ b/src/track/cue.h
@@ -48,10 +48,8 @@ class Cue : public QObject {
 
     double getEndPosition() const;
 
-    void readInfo(
-            mixxx::AudioSignal::SampleRate sampleRate,
-            mixxx::CueInfo* pCueInfo,
-            bool* pDirty = nullptr) const;
+    mixxx::CueInfo getCueInfo(
+            mixxx::AudioSignal::SampleRate sampleRate) const;
 
   signals:
     void updated();

--- a/src/track/cue.h
+++ b/src/track/cue.h
@@ -48,6 +48,11 @@ class Cue : public QObject {
 
     double getEndPosition() const;
 
+    void readInfo(
+            mixxx::AudioSignal::SampleRate sampleRate,
+            mixxx::CueInfo* pCueInfo,
+            bool* pDirty = nullptr) const;
+
   signals:
     void updated();
 

--- a/src/track/cue.h
+++ b/src/track/cue.h
@@ -35,16 +35,20 @@ class Cue : public QObject {
     void setType(mixxx::CueType type);
 
     double getPosition() const;
-    void setStartPosition(double samplePosition);
-    void setEndPosition(double samplePosition);
+    void setStartPosition(
+            double samplePosition = kNoPosition);
+    void setEndPosition(
+            double samplePosition = kNoPosition);
 
     double getLength() const;
 
     int getHotCue() const;
-    void setHotCue(int hotCue);
+    void setHotCue(
+            int hotCue = kNoHotCue);
 
     QString getLabel() const;
-    void setLabel(QString label = QString());
+    void setLabel(
+            QString label = QString());
 
     PredefinedColorPointer getColor() const;
     void setColor(PredefinedColorPointer color);

--- a/src/track/cueinfo.cpp
+++ b/src/track/cueinfo.cpp
@@ -2,10 +2,6 @@
 
 #include "util/assert.h"
 
-namespace {
-const QString kDefaultLabel = QStringLiteral(""); // empty string, not null
-} // anonymous namespace
-
 namespace mixxx {
 
 CueInfo::CueInfo()
@@ -13,9 +9,7 @@ CueInfo::CueInfo()
           m_startPositionMillis(std::nullopt),
           m_endPositionMillis(std::nullopt),
           m_hotCueNumber(std::nullopt),
-          m_label(kDefaultLabel),
           m_color(std::nullopt) {
-    DEBUG_ASSERT(!m_label.isNull());
 }
 
 CueInfo::CueInfo(
@@ -31,7 +25,6 @@ CueInfo::CueInfo(
           m_hotCueNumber(hotCueNumber),
           m_label(label),
           m_color(color) {
-    DEBUG_ASSERT(!m_label.isNull());
 }
 
 CueType CueInfo::getType() const {

--- a/src/track/cueinfo.cpp
+++ b/src/track/cueinfo.cpp
@@ -76,4 +76,15 @@ void CueInfo::setColor(RgbColor::optional_t color) {
     m_color = color;
 }
 
+bool operator==(
+        const CueInfo& lhs,
+        const CueInfo& rhs) {
+    return lhs.getType() == rhs.getType() &&
+            lhs.getStartPositionMillis() == rhs.getStartPositionMillis() &&
+            lhs.getEndPositionMillis() == rhs.getEndPositionMillis() &&
+            lhs.getHotCueNumber() == rhs.getHotCueNumber() &&
+            lhs.getLabel() == rhs.getLabel() &&
+            lhs.getColor() == rhs.getColor();
+}
+
 } // namespace mixxx

--- a/src/track/cueinfo.cpp
+++ b/src/track/cueinfo.cpp
@@ -64,7 +64,6 @@ QString CueInfo::getLabel() const {
 }
 
 void CueInfo::setLabel(QString label) {
-    DEBUG_ASSERT(!label.isNull());
     m_label = label;
 }
 

--- a/src/track/cueinfo.h
+++ b/src/track/cueinfo.h
@@ -58,4 +58,14 @@ class CueInfo {
     RgbColor::optional_t m_color;
 };
 
+bool operator==(
+        const CueInfo& lhs,
+        const CueInfo& rhs);
+
+inline bool operator!=(
+        const CueInfo& lhs,
+        const CueInfo& rhs) {
+    return !(lhs == rhs);
+}
+
 } // namespace mixxx

--- a/src/track/cueinfo.h
+++ b/src/track/cueinfo.h
@@ -34,20 +34,25 @@ class CueInfo {
     CueType getType() const;
     void setType(CueType type);
 
-    void setStartPositionMillis(std::optional<double> positionMillis);
     std::optional<double> getStartPositionMillis() const;
+    void setStartPositionMillis(
+            std::optional<double> positionMillis = std::nullopt);
 
-    void setEndPositionMillis(std::optional<double> positionMillis);
     std::optional<double> getEndPositionMillis() const;
+    void setEndPositionMillis(
+            std::optional<double> positionMillis = std::nullopt);
 
     std::optional<int> getHotCueNumber() const;
-    void setHotCueNumber(std::optional<int> hotCueNumber);
+    void setHotCueNumber(
+            std::optional<int> hotCueNumber = std::nullopt);
 
     QString getLabel() const;
-    void setLabel(QString label);
+    void setLabel(
+            QString label = QString());
 
     mixxx::RgbColor::optional_t getColor() const;
-    void setColor(mixxx::RgbColor::optional_t color);
+    void setColor(
+            mixxx::RgbColor::optional_t color = std::nullopt);
 
   private:
     CueType m_type;

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -675,7 +675,8 @@ void Track::setCuePoint(CuePosition cue) {
     double position = cue.getPosition();
     if (position != -1.0) {
         if (!pLoadCue) {
-            pLoadCue = CuePointer(new Cue(m_record.getId()));
+            pLoadCue = CuePointer(new Cue());
+            pLoadCue->setTrackId(m_record.getId());
             pLoadCue->setType(mixxx::CueType::MainCue);
             connect(pLoadCue.get(),
                     &Cue::updated,
@@ -705,7 +706,8 @@ void Track::slotCueUpdated() {
 
 CuePointer Track::createAndAddCue() {
     QMutexLocker lock(&m_qMutex);
-    CuePointer pCue(new Cue(m_record.getId()));
+    CuePointer pCue(new Cue());
+    pCue->setTrackId(m_record.getId());
     connect(pCue.get(), &Cue::updated, this, &Track::slotCueUpdated);
     m_cuePoints.push_back(pCue);
     markDirtyAndUnlock(&lock);
@@ -801,7 +803,8 @@ void Track::importCuePoints(const QList<mixxx::CueInfo>& cueInfos) {
 
     QList<CuePointer> cuePoints;
     for (const mixxx::CueInfo& cueInfo : cueInfos) {
-        CuePointer pCue(new Cue(trackId, sampleRate, cueInfo));
+        CuePointer pCue(new Cue(cueInfo, sampleRate));
+        pCue->setTrackId(trackId);
         cuePoints.append(pCue);
     }
     setCuePoints(cuePoints);


### PR DESCRIPTION
`CueInfo` holds all the information needed for exporting/importing cue data. It is also much cleaner and less error prone to use than the heavy-weight `Cue` objects.

Tests for all cue conversions are still missing, but I don't have time to write some.