### PR TITLE
Use trackcolor for whole row

### DIFF
--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -737,6 +737,8 @@ QVariant BaseSqlTableModel::data(const QModelIndex& index, int role) const {
         if (color.isValid()) {
             color.setAlpha(kTrackColorRowBackgroundOpacity);
             value = QBrush(color);
+        } else {
+            value = QVariant();
         }
         break;
     }

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -40,6 +40,9 @@ const int kMaxSortColumns = 3;
 // Constant for getModelSetting(name)
 const QString COLUMNS_SORTING = QStringLiteral("ColumnsSorting");
 
+// Alpha value for row color background (range 0 - 255)
+constexpr int kTrackColorRowBackgroundOpacity = 0x20; // 12.5% opacity
+
 } // anonymous namespace
 
 BaseSqlTableModel::BaseSqlTableModel(QObject* pParent,
@@ -732,7 +735,7 @@ QVariant BaseSqlTableModel::data(const QModelIndex& index, int role) const {
         QColor color = mixxx::RgbColor::toQColor(
                 mixxx::RgbColor::fromQVariant(getBaseValue(colorIndex, role)));
         if (color.isValid()) {
-            color.setAlpha(32); // Make this 12.5% opaque
+            color.setAlpha(kTrackColorRowBackgroundOpacity);
             value = QBrush(color);
         }
         break;

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -706,10 +706,12 @@ int BaseSqlTableModel::fieldIndex(const QString& fieldName) const {
 
 QVariant BaseSqlTableModel::data(const QModelIndex& index, int role) const {
     //qDebug() << this << "data()";
-    if (!index.isValid() || (role != Qt::DisplayRole &&
-                             role != Qt::EditRole &&
-                             role != Qt::CheckStateRole &&
-                             role != Qt::ToolTipRole)) {
+    if (!index.isValid() || (
+                role != Qt::BackgroundRole &&
+                role != Qt::DisplayRole &&
+                role != Qt::EditRole &&
+                role != Qt::CheckStateRole &&
+                role != Qt::ToolTipRole)) {
         return QVariant();
     }
 
@@ -723,6 +725,18 @@ QVariant BaseSqlTableModel::data(const QModelIndex& index, int role) const {
     // Format the value based on whether we are in a tooltip, display, or edit
     // role
     switch (role) {
+    case Qt::BackgroundRole: {
+        QModelIndex colorIndex = index.sibling(
+                index.row(),
+                fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COLOR));
+        QColor color = mixxx::RgbColor::toQColor(
+                mixxx::RgbColor::fromQVariant(getBaseValue(colorIndex, role)));
+        if (color.isValid()) {
+            color.setAlpha(32); // Make this 12.5% opaque
+            value = QBrush(color);
+        }
+        break;
+    }
         case Qt::ToolTipRole:
             if (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COLOR)) {
                 value = mixxx::RgbColor::toQString(mixxx::RgbColor::fromQVariant(value));
@@ -1050,7 +1064,8 @@ void BaseSqlTableModel::setTrackValueForColumn(TrackPointer pTrack, int column,
 
 QVariant BaseSqlTableModel::getBaseValue(
     const QModelIndex& index, int role) const {
-    if (role != Qt::DisplayRole &&
+    if (role != Qt::BackgroundRole &&
+        role != Qt::DisplayRole &&
         role != Qt::ToolTipRole &&
         role != Qt::EditRole) {
         return QVariant();

--- a/src/library/coverartdelegate.cpp
+++ b/src/library/coverartdelegate.cpp
@@ -87,6 +87,8 @@ void CoverArtDelegate::slotCoverFound(const QObject* pRequestor,
 void CoverArtDelegate::paintItem(QPainter *painter,
                              const QStyleOptionViewItem &option,
                              const QModelIndex &index) const {
+    paintItemBackground(painter, option, index);
+
     CoverArtCache* pCache = CoverArtCache::instance();
     if (pCache == NULL || m_iIdColumn == -1 || m_iCoverSourceColumn == -1 ||
             m_iCoverTypeColumn == -1 || m_iCoverLocationColumn == -1 ||

--- a/src/library/locationdelegate.cpp
+++ b/src/library/locationdelegate.cpp
@@ -11,6 +11,8 @@ void LocationDelegate::paintItem(
         QPainter* painter,
         const QStyleOptionViewItem& option,
         const QModelIndex& index) const {
+    paintItemBackground(painter, option, index);
+
     QString elidedText = option.fontMetrics.elidedText(
             index.data().toString(),
             Qt::ElideLeft,

--- a/src/library/previewbuttondelegate.cpp
+++ b/src/library/previewbuttondelegate.cpp
@@ -85,6 +85,8 @@ void PreviewButtonDelegate::setModelData(QWidget* editor,
 void PreviewButtonDelegate::paintItem(QPainter* painter,
                                       const QStyleOptionViewItem& option,
                                       const QModelIndex& index) const {
+    paintItemBackground(painter, option, index);
+
     // Let the editor paint in this case
     if (index == m_currentEditedCellIndex) {
         return;

--- a/src/library/stardelegate.cpp
+++ b/src/library/stardelegate.cpp
@@ -15,13 +15,14 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "library/stardelegate.h"
 
+#include <QPainter>
 #include <QtDebug>
 
-#include "library/tableitemdelegate.h"
-#include "library/stardelegate.h"
 #include "library/stareditor.h"
 #include "library/starrating.h"
+#include "library/tableitemdelegate.h"
 
 StarDelegate::StarDelegate(QTableView* pTableView)
         : TableItemDelegate(pTableView),
@@ -38,6 +39,8 @@ void StarDelegate::paintItem(
     if (index == m_currentEditedCellIndex) {
         return;
     }
+
+    paintItemBackground(painter, option, index);
 
     StarRating starRating = index.data().value<StarRating>();
     starRating.paint(painter, option.rect);

--- a/src/library/stardelegate.cpp
+++ b/src/library/stardelegate.cpp
@@ -30,17 +30,10 @@ StarDelegate::StarDelegate(QTableView* pTableView)
     connect(pTableView, &QTableView::entered, this, &StarDelegate::cellEntered);
 }
 
-void StarDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option,
-                         const QModelIndex& index) const {
-    // let the editor do the painting if this cell is currently being edited
-    if (index == m_currentEditedCellIndex) {
-        return;
-    }
-    TableItemDelegate::paint(painter, option, index);
-}
-
-void StarDelegate::paintItem(QPainter* painter, const QStyleOptionViewItem& option,
-                         const QModelIndex& index) const {
+void StarDelegate::paintItem(
+        QPainter* painter,
+        const QStyleOptionViewItem& option,
+        const QModelIndex& index) const {
     // let the editor do the painting if this cell is currently being edited
     if (index == m_currentEditedCellIndex) {
         return;

--- a/src/library/stardelegate.h
+++ b/src/library/stardelegate.h
@@ -28,9 +28,6 @@ class StarDelegate : public TableItemDelegate {
 
     // reimplemented from QItemDelegate and is called whenever the view needs to
     // repaint an item
-    void paint(QPainter* painter, const QStyleOptionViewItem& option,
-               const QModelIndex& index) const;
-
     void paintItem(QPainter* painter, const QStyleOptionViewItem& option,
                const QModelIndex& index) const;
 

--- a/src/library/tableitemdelegate.cpp
+++ b/src/library/tableitemdelegate.cpp
@@ -54,3 +54,18 @@ void TableItemDelegate::paint(
 int TableItemDelegate::columnWidth(const QModelIndex &index) const {
     return m_pTableView->columnWidth(index.column());
 }
+
+void paintItemBackground(
+        QPainter* painter,
+        const QStyleOptionViewItem& option,
+        const QModelIndex& index) {
+    // If the row is not selected, paint the desired background color before
+    // painting the delegate item
+    if (!option.showDecorationSelected || !(option.state & QStyle::State_Selected)) {
+        QVariant bgValue = index.data(Qt::BackgroundRole);
+        if (bgValue.isValid()) {
+            DEBUG_ASSERT(bgValue.canConvert<QBrush>());
+            painter->fillRect(option.rect, qvariant_cast<QBrush>(bgValue));
+        }
+    }
+}

--- a/src/library/tableitemdelegate.cpp
+++ b/src/library/tableitemdelegate.cpp
@@ -55,7 +55,7 @@ int TableItemDelegate::columnWidth(const QModelIndex &index) const {
     return m_pTableView->columnWidth(index.column());
 }
 
-void paintItemBackground(
+void TableItemDelegate::paintItemBackground(
         QPainter* painter,
         const QStyleOptionViewItem& option,
         const QModelIndex& index) {

--- a/src/library/tableitemdelegate.h
+++ b/src/library/tableitemdelegate.h
@@ -21,13 +21,13 @@ class TableItemDelegate : public QStyledItemDelegate {
             const QModelIndex &index) const = 0;
 
   protected:
+    static void paintItemBackground(
+            QPainter* painter,
+            const QStyleOptionViewItem& option,
+            const QModelIndex& index);
+
     int columnWidth(const QModelIndex &index) const;
 
   private:
     QTableView* m_pTableView;
 };
-
-void paintItemBackground(
-        QPainter* painter,
-        const QStyleOptionViewItem& option,
-        const QModelIndex& index);

--- a/src/library/tableitemdelegate.h
+++ b/src/library/tableitemdelegate.h
@@ -26,3 +26,8 @@ class TableItemDelegate : public QStyledItemDelegate {
   private:
     QTableView* m_pTableView;
 };
+
+void paintItemBackground(
+        QPainter* painter,
+        const QStyleOptionViewItem& option,
+        const QModelIndex& index);


### PR DESCRIPTION
The track color column is easy to overlook (especially if it's next to the cover art). Hence, I thought it might be cool paint the whole row in a dark shade of track color (similar to what Traktor does: https://www.youtube.com/watch?v=PV4VI-FtaLg)

This even allows using track colors on small screens where the color column takes too much space:

![2020-03-08-130255_1157x1102_scrot](https://user-images.githubusercontent.com/1834516/76162350-334ff980-613d-11ea-8899-de5ec69e4be1.png)
