### PR TITLE
Store remaining Rekordbox memory cues as hotcues

### DIFF
--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -812,10 +812,7 @@ void setHotCue(TrackPointer track, double position, int id, QString label, int /
     pCue->setType(mixxx::CueType::HotCue);
     pCue->setStartPosition(position);
     pCue->setHotCue(id);
-
-    if (!label.isNull()) {
-        pCue->setLabel(label);
-    }
+    pCue->setLabel(label);
 
     /*
     TODO(ehendrikd):
@@ -1025,9 +1022,7 @@ void readAnalyze(TrackPointer track, double sampleRate, int timingOffset, bool i
         memory_cue_t firstCue = memoryCues[0];
         track->setCuePoint(CuePosition(firstCue.position));
         CuePointer pLoadCue = track->findCueByType(mixxx::CueType::MainCue);
-        if (!firstCue.comment.isNull()) {
-            pLoadCue->setLabel(firstCue.comment);
-        }
+        pLoadCue->setLabel(firstCue.comment);
 
         // Add remaining memory cues as hot cues (after actual found hotcues) as Mixxx can only have 1 cue
         for (int memoryCueIndex = 1; memoryCueIndex < memoryCues.size(); memoryCueIndex++) {

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -1013,11 +1013,11 @@ void readAnalyze(TrackPointer track, double sampleRate, int timingOffset, bool i
         }
     }
 
-    std::sort(memoryCues.begin(), memoryCues.end(), [](const memory_cue_t& a, const memory_cue_t& b) -> bool {
-        return a.position < b.position;
-    });
-
     if (memoryCues.size() > 0) {
+        std::sort(memoryCues.begin(), memoryCues.end(), [](const memory_cue_t& a, const memory_cue_t& b) -> bool {
+            return a.position < b.position;
+        });
+
         // Set first chronological memory cue as Mixxx MainCue
         memory_cue_t firstCue = memoryCues[0];
         track->setCuePoint(CuePosition(firstCue.position));


### PR DESCRIPTION
Rekordbox has multiple memory cues and multiple hot cues. As Mixxx only has one main cue, only the first Rekordbox memory cue found was used, all others were discarded. This PR adds the remaining memory cues found (after the first) as Mixxx hotcues. They are also added _after_ any found Rekordbox hotcues, to preserve consistency.

This is as discussed here: https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/Rekordbox.20removable.20device.20library.20feature.20PR/near/186346855