### PR TITLE
Customize TrackTableBackgroundColorOpacity from skins

### DIFF
--- a/res/skins/Deere/library.xml
+++ b/res/skins/Deere/library.xml
@@ -71,6 +71,7 @@
 
               <Library>
                 <ShowButtonText>false</ShowButtonText>
+                <TrackTableBackgroundColorOpacity>0.125</TrackTableBackgroundColorOpacity>
               </Library>
 
             </Children>

--- a/res/skins/LateNight/library.xml
+++ b/res/skins/LateNight/library.xml
@@ -74,6 +74,7 @@
                 <BgColor>#585858</BgColor>
                 <FgColor>#eece33</FgColor>
                 <ShowButtonText>false</ShowButtonText>
+                <TrackTableBackgroundColorOpacity>0.125</TrackTableBackgroundColorOpacity>
               </Library>
 
             </Children>

--- a/res/skins/Shade/skin.xml
+++ b/res/skins/Shade/skin.xml
@@ -251,7 +251,7 @@
         Above the maximized library there are minimal decks which contain overview waveforms.
         For the end-of-track warning in those overviews to work instances of scrolling waveforms
         are required. We load in the maximzed library view, as well, but they are invisible as
-        they are 0px tall. 
+        they are 0px tall.
     ############################################################################################
     ############################################################################################
     -->
@@ -296,6 +296,7 @@
       <Children>
         <Library>
           <ShowButtonText>false</ShowButtonText>
+          <TrackTableBackgroundColorOpacity>0.125</TrackTableBackgroundColorOpacity>
         </Library>
       </Children>
     </SingletonDefinition>

--- a/res/skins/Tango/library.xml
+++ b/res/skins/Tango/library.xml
@@ -115,6 +115,7 @@ Description:
                     <BgColor>#585858</BgColor>
                     <FgColor>#eece33</FgColor>
                     <ShowButtonText>false</ShowButtonText>
+                    <TrackTableBackgroundColorOpacity>0.125</TrackTableBackgroundColorOpacity>
                   </Library>
                 </Children>
               </WidgetGroup><!-- /Library Table -->

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -122,8 +122,7 @@ void AutoDJFeature::bindLibraryWidget(
             m_pConfig,
             m_pLibrary,
             m_pAutoDJProcessor,
-            keyboard,
-            libraryWidget->getShowButtonText());
+            keyboard);
     libraryWidget->registerView(kViewName, m_pAutoDJView);
     connect(m_pAutoDJView,
             &DlgAutoDJ::loadTrack,

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -7,6 +7,7 @@
 #include "util/assert.h"
 #include "util/compatibility.h"
 #include "util/duration.h"
+#include "widget/wlibrary.h"
 #include "widget/wtracktableview.h"
 
 namespace {
@@ -15,19 +16,20 @@ const char* kRepeatPlaylistPreference = "Requeue";
 } // anonymous namespace
 
 DlgAutoDJ::DlgAutoDJ(
-        QWidget* parent,
+        WLibrary* parent,
         UserSettingsPointer pConfig,
         Library* pLibrary,
         AutoDJProcessor* pProcessor,
-        KeyboardEventFilter* pKeyboard,
-        bool showButtonText)
+        KeyboardEventFilter* pKeyboard)
         : QWidget(parent),
           Ui::DlgAutoDJ(),
           m_pConfig(pConfig),
           m_pAutoDJProcessor(pProcessor),
           m_pTrackTableView(new WTrackTableView(this, m_pConfig,
-                                                pLibrary->trackCollections(), /*no sorting*/ false)),
-          m_bShowButtonText(showButtonText),
+                                                pLibrary->trackCollections(),
+                                                parent->getTrackTableBackgroundColorOpacity(),
+                                                /*no sorting*/ false)),
+          m_bShowButtonText(parent->getShowButtonText()),
           m_pAutoDJTableModel(nullptr) {
     setupUi(this);
 

--- a/src/library/autodj/dlgautodj.h
+++ b/src/library/autodj/dlgautodj.h
@@ -14,17 +14,17 @@
 #include "controllers/keyboard/keyboardeventfilter.h"
 
 class PlaylistTableModel;
+class WLibrary;
 class WTrackTableView;
 
 class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
     Q_OBJECT
   public:
-    DlgAutoDJ(QWidget* parent,
+    DlgAutoDJ(WLibrary* parent,
             UserSettingsPointer pConfig,
             Library* pLibrary,
             AutoDJProcessor* pProcessor,
-            KeyboardEventFilter* pKeyboard,
-            bool showButtonText);
+            KeyboardEventFilter* pKeyboard);
     ~DlgAutoDJ() override;
 
     void onShow() override;

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -10,6 +10,7 @@
 
 class BaseCoverArtDelegate;
 class TrackCollectionManager;
+class WLibraryTableView;
 
 class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     Q_OBJECT
@@ -19,7 +20,7 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     explicit BaseTrackTableModel(
             const char* settingsNamespace,
             TrackCollectionManager* const pTrackCollectionManager,
-            QObject* parent = nullptr);
+            QObject* parent);
     ~BaseTrackTableModel() override = default;
 
     ///////////////////////////////////////////////////////
@@ -199,6 +200,8 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
             const QModelIndexList& indexes) const;
 
     const QString m_previewDeckGroup;
+
+    double m_backgroundColorOpacity;
 
     ColumnCache m_columnCache;
 

--- a/src/library/dlganalysis.cpp
+++ b/src/library/dlganalysis.cpp
@@ -8,9 +8,10 @@
 #include "library/trackcollectionmanager.h"
 #include "library/dlganalysis.h"
 #include "library/library.h"
+#include "widget/wlibrary.h"
 #include "util/assert.h"
 
-DlgAnalysis::DlgAnalysis(QWidget* parent,
+DlgAnalysis::DlgAnalysis(WLibrary* parent,
                        UserSettingsPointer pConfig,
                        Library* pLibrary)
         : QWidget(parent),
@@ -20,7 +21,11 @@ DlgAnalysis::DlgAnalysis(QWidget* parent,
     m_songsButtonGroup.addButton(radioButtonRecentlyAdded);
     m_songsButtonGroup.addButton(radioButtonAllSongs);
 
-    m_pAnalysisLibraryTableView = new WAnalysisLibraryTableView(this, pConfig, pLibrary->trackCollections());
+    m_pAnalysisLibraryTableView = new WAnalysisLibraryTableView(
+            this,
+            pConfig,
+            pLibrary->trackCollections(),
+            parent->getTrackTableBackgroundColorOpacity());
     connect(m_pAnalysisLibraryTableView,
             &WAnalysisLibraryTableView::loadTrack,
             this,

--- a/src/library/dlganalysis.h
+++ b/src/library/dlganalysis.h
@@ -13,11 +13,12 @@
 class AnalysisLibraryTableModel;
 class WAnalysisLibraryTableView;
 class Library;
+class WLibrary;
 
 class DlgAnalysis : public QWidget, public Ui::DlgAnalysis, public virtual LibraryView {
     Q_OBJECT
   public:
-    DlgAnalysis(QWidget *parent,
+    DlgAnalysis(WLibrary *parent,
                UserSettingsPointer pConfig,
                Library* pLibrary);
     ~DlgAnalysis() override = default;

--- a/src/library/dlghidden.cpp
+++ b/src/library/dlghidden.cpp
@@ -2,16 +2,24 @@
 
 #include "library/hiddentablemodel.h"
 #include "library/trackcollectionmanager.h"
+#include "widget/wlibrary.h"
 #include "widget/wtracktableview.h"
 #include "util/assert.h"
 
-DlgHidden::DlgHidden(QWidget* parent, UserSettingsPointer pConfig,
-                     Library* pLibrary,
-                     KeyboardEventFilter* pKeyboard)
-         : QWidget(parent),
-           Ui::DlgHidden(),
-           m_pTrackTableView(
-               new WTrackTableView(this, pConfig, pLibrary->trackCollections(), false)) {
+DlgHidden::DlgHidden(
+        WLibrary* parent,
+        UserSettingsPointer pConfig,
+        Library* pLibrary,
+        KeyboardEventFilter* pKeyboard)
+        : QWidget(parent),
+          Ui::DlgHidden(),
+          m_pTrackTableView(
+                  new WTrackTableView(
+                          this,
+                          pConfig,
+                          pLibrary->trackCollections(),
+                          parent->getTrackTableBackgroundColorOpacity(),
+                          false)) {
     setupUi(this);
     m_pTrackTableView->installEventFilter(pKeyboard);
 

--- a/src/library/dlghidden.h
+++ b/src/library/dlghidden.h
@@ -8,6 +8,7 @@
 #include "library/libraryview.h"
 #include "controllers/keyboard/keyboardeventfilter.h"
 
+class WLibrary;
 class WTrackTableView;
 class HiddenTableModel;
 class QItemSelection;
@@ -16,7 +17,7 @@ class DlgHidden : public QWidget, public Ui::DlgHidden, public LibraryView {
     Q_OBJECT
 
   public:
-    DlgHidden(QWidget* parent, UserSettingsPointer pConfig,
+    DlgHidden(WLibrary* parent, UserSettingsPointer pConfig,
               Library* pLibrary,
               KeyboardEventFilter* pKeyboard);
     ~DlgHidden() override;

--- a/src/library/dlgmissing.cpp
+++ b/src/library/dlgmissing.cpp
@@ -2,16 +2,24 @@
 
 #include "library/missingtablemodel.h"
 #include "library/trackcollectionmanager.h"
+#include "widget/wlibrary.h"
 #include "widget/wtracktableview.h"
 #include "util/assert.h"
 
-DlgMissing::DlgMissing(QWidget* parent, UserSettingsPointer pConfig,
-                       Library* pLibrary,
-                       KeyboardEventFilter* pKeyboard)
-         : QWidget(parent),
-           Ui::DlgMissing(),
-           m_pTrackTableView(
-               new WTrackTableView(this, pConfig, pLibrary->trackCollections(), false)) {
+DlgMissing::DlgMissing(
+        WLibrary* parent,
+        UserSettingsPointer pConfig,
+        Library* pLibrary,
+        KeyboardEventFilter* pKeyboard)
+        : QWidget(parent),
+          Ui::DlgMissing(),
+          m_pTrackTableView(
+                  new WTrackTableView(
+                          this,
+                          pConfig,
+                          pLibrary->trackCollections(),
+                          parent->getTrackTableBackgroundColorOpacity(),
+                          false)) {
     setupUi(this);
     m_pTrackTableView->installEventFilter(pKeyboard);
 

--- a/src/library/dlgmissing.h
+++ b/src/library/dlgmissing.h
@@ -8,6 +8,7 @@
 #include "library/libraryview.h"
 #include "controllers/keyboard/keyboardeventfilter.h"
 
+class WLibrary;
 class WTrackTableView;
 class MissingTableModel;
 
@@ -15,7 +16,7 @@ class DlgMissing : public QWidget, public Ui::DlgMissing, public LibraryView {
     Q_OBJECT
 
   public:
-    DlgMissing(QWidget* parent, UserSettingsPointer pConfig,
+    DlgMissing(WLibrary* parent, UserSettingsPointer pConfig,
                Library* pLibrary,
                KeyboardEventFilter* pKeyboard);
     ~DlgMissing() override;

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -295,6 +295,7 @@ void Library::bindLibraryWidget(WLibrary* pLibraryWidget,
                     pLibraryWidget,
                     m_pConfig,
                     m_pTrackCollectionManager,
+                    pLibraryWidget->getTrackTableBackgroundColorOpacity(),
                     true);
     pTrackTableView->installEventFilter(pKeyboard);
     connect(this,

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -5,15 +5,25 @@
 #include "library/trackcollectionmanager.h"
 #include "widget/wwidget.h"
 #include "widget/wskincolor.h"
+#include "widget/wlibrary.h"
 #include "widget/wtracktableview.h"
 #include "util/assert.h"
 
-DlgRecording::DlgRecording(QWidget* parent, UserSettingsPointer pConfig,
-                           Library* pLibrary,
-                           RecordingManager* pRecordingManager, KeyboardEventFilter* pKeyboard)
+DlgRecording::DlgRecording(
+        WLibrary* parent,
+        UserSettingsPointer pConfig,
+        Library* pLibrary,
+        RecordingManager* pRecordingManager,
+        KeyboardEventFilter* pKeyboard)
         : QWidget(parent),
           m_pConfig(pConfig),
-          m_pTrackTableView(new WTrackTableView(this, pConfig, pLibrary->trackCollections(), true)),
+          m_pTrackTableView(
+                  new WTrackTableView(
+                          this,
+                          pConfig,
+                          pLibrary->trackCollections(),
+                          parent->getTrackTableBackgroundColorOpacity(),
+                          true)),
           m_browseModel(this, pLibrary->trackCollections(), pRecordingManager),
           m_proxyModel(&m_browseModel),
           m_bytesRecordedStr("--"),

--- a/src/library/recording/dlgrecording.h
+++ b/src/library/recording/dlgrecording.h
@@ -14,12 +14,13 @@
 
 class PlaylistTableModel;
 class QSqlTableModel;
+class WLibrary;
 class WTrackTableView;
 
 class DlgRecording : public QWidget, public Ui::DlgRecording, public virtual LibraryView {
     Q_OBJECT
   public:
-    DlgRecording(QWidget *parent, UserSettingsPointer pConfig,
+    DlgRecording(WLibrary *parent, UserSettingsPointer pConfig,
                  Library* pLibrary,
                  RecordingManager* pRecManager, KeyboardEventFilter* pKeyboard);
     ~DlgRecording() override;

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -101,16 +101,16 @@ class SkinContext {
         return nodeToString(child);
     }
 
-    inline float selectFloat(const QDomNode& node, const QString& nodeName) const {
+    inline float selectFloat(const QDomNode& node, const QString& nodeName, float defaultValue = 0.0) const {
         bool ok = false;
         float conv = nodeToString(selectElement(node, nodeName)).toFloat(&ok);
-        return ok ? conv : 0.0f;
+        return ok ? conv : defaultValue;
     }
 
-    inline double selectDouble(const QDomNode& node, const QString& nodeName) const {
+    inline double selectDouble(const QDomNode& node, const QString& nodeName, double defaultValue = 0.0) const {
         bool ok = false;
         double conv = nodeToString(selectElement(node, nodeName)).toDouble(&ok);
-        return ok ? conv : 0.0;
+        return ok ? conv : defaultValue;
     }
 
     inline int selectInt(const QDomNode& node, const QString& nodeName,

--- a/src/widget/wanalysislibrarytableview.cpp
+++ b/src/widget/wanalysislibrarytableview.cpp
@@ -1,10 +1,16 @@
 #include "library/trackcollection.h"
 #include "widget/wanalysislibrarytableview.h"
 
-WAnalysisLibraryTableView::WAnalysisLibraryTableView(QWidget* parent,
-                                                   UserSettingsPointer pConfig,
-                                                   TrackCollectionManager* pTrackCollectionManager)
-        : WTrackTableView(parent, pConfig, pTrackCollectionManager, true) {
+WAnalysisLibraryTableView::WAnalysisLibraryTableView(
+        QWidget* parent,
+        UserSettingsPointer pConfig,
+        TrackCollectionManager* pTrackCollectionManager,
+        double trackTableBackgroundColorOpacity)
+        : WTrackTableView(parent,
+                  pConfig,
+                  pTrackCollectionManager,
+                  trackTableBackgroundColorOpacity,
+                  true) {
     setDragDropMode(QAbstractItemView::DragOnly);
     setDragEnabled(true); //Always enable drag for now (until we have a model that doesn't support this.)
 }

--- a/src/widget/wanalysislibrarytableview.h
+++ b/src/widget/wanalysislibrarytableview.h
@@ -6,13 +6,15 @@
 #include "preferences/usersettings.h"
 #include "widget/wtracktableview.h"
 
-class WAnalysisLibraryTableView : public WTrackTableView
-{
-    public:
-        WAnalysisLibraryTableView(QWidget* parent, UserSettingsPointer pConfig,
-                                 TrackCollectionManager* pTrackCollectionManager);
+class WAnalysisLibraryTableView : public WTrackTableView {
+  public:
+    WAnalysisLibraryTableView(
+            QWidget* parent,
+            UserSettingsPointer pConfig,
+            TrackCollectionManager* pTrackCollectionManager,
+            double trackTableBackgroundColorOpacity);
 
-        void onSearch(const QString& text) override;
+    void onSearch(const QString& text) override;
 };
 
 #endif

--- a/src/widget/wlibrary.cpp
+++ b/src/widget/wlibrary.cpp
@@ -7,17 +7,30 @@
 #include "widget/wlibrary.h"
 #include "library/libraryview.h"
 #include "controllers/keyboard/keyboardeventfilter.h"
-#include "wtracktableview.h"
+#include "widget/wtracktableview.h"
+#include "util/math.h"
 
 WLibrary::WLibrary(QWidget* parent)
         : QStackedWidget(parent),
           WBaseWidget(this),
           m_mutex(QMutex::Recursive),
+          m_trackTableBackgroundColorOpacity(kDefaultTrackTableBackgroundColorOpacity),
           m_bShowButtonText(true) {
 }
 
 void WLibrary::setup(const QDomNode& node, const SkinContext& context) {
-    m_bShowButtonText = context.selectBool(node, "ShowButtonText", true);
+    m_bShowButtonText =
+            context.selectBool(
+                    node,
+                    "ShowButtonText",
+                    true);
+    m_trackTableBackgroundColorOpacity = math_clamp(
+            context.selectDouble(
+                    node,
+                    "TrackTableBackgroundColorOpacity",
+                    kDefaultTrackTableBackgroundColorOpacity),
+            kMinTrackTableBackgroundColorOpacity,
+            kMaxTrackTableBackgroundColorOpacity);
 }
 
 bool WLibrary::registerView(QString name, QWidget* view) {

--- a/src/widget/wlibrary.h
+++ b/src/widget/wlibrary.h
@@ -1,8 +1,4 @@
-// wlibrary.h
-// Created 8/28/2009 by RJ Ryan (rryan@mit.edu)
-
-#ifndef WLIBRARY_H
-#define WLIBRARY_H
+#pragma once
 
 #include <QMap>
 #include <QMutex>
@@ -33,6 +29,15 @@ class WLibrary : public QStackedWidget, public WBaseWidget {
 
     LibraryView* getActiveView() const;
 
+    // Alpha value for row color background
+    static constexpr double kDefaultTrackTableBackgroundColorOpacity = 0.125; // 12.5% opacity
+    static constexpr double kMinTrackTableBackgroundColorOpacity = 0.0; // 0% opacity
+    static constexpr double kMaxTrackTableBackgroundColorOpacity = 1.0; // 100% opacity
+
+    double getTrackTableBackgroundColorOpacity() const {
+        return m_trackTableBackgroundColorOpacity;
+    }
+
     bool getShowButtonText() const {
         return m_bShowButtonText;
     }
@@ -51,8 +56,6 @@ class WLibrary : public QStackedWidget, public WBaseWidget {
   private:
     QMutex m_mutex;
     QMap<QString, QWidget*> m_viewMap;
+    double m_trackTableBackgroundColorOpacity;
     bool m_bShowButtonText;
 };
-
-#endif /* WLIBRARY_H */
-

--- a/src/widget/wlibrarytableview.h
+++ b/src/widget/wlibrarytableview.h
@@ -59,10 +59,11 @@ class WLibraryTableView : public QTableView, public virtual LibraryView {
     void loadVScrollBarPosState();
     void saveVScrollBarPosState();
 
+    const UserSettingsPointer m_pConfig;
+    const ConfigKey m_vScrollBarPosKey;
+
     QMap<TrackModel*, int> m_vScrollBarPosValues;
 
-    UserSettingsPointer m_pConfig;
-    ConfigKey m_vScrollBarPosKey;
     // The position of the vertical scrollbar slider, eg. before a search is
     // executed
     int m_noSearchVScrollBarPos;

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -41,15 +41,17 @@
 #include "widget/wtracktableviewheader.h"
 #include "widget/wwidget.h"
 
-WTrackTableView::WTrackTableView(QWidget * parent,
+WTrackTableView::WTrackTableView(QWidget* parent,
                                  UserSettingsPointer pConfig,
                                  TrackCollectionManager* pTrackCollectionManager,
+                                 double backgroundColorOpacity,
                                  bool sorting)
         : WLibraryTableView(parent, pConfig,
                             ConfigKey(LIBRARY_CONFIGVALUE,
                                       WTRACKTABLEVIEW_VSCROLLBARPOS_KEY)),
           m_pConfig(pConfig),
           m_pTrackCollectionManager(pTrackCollectionManager),
+          m_backgroundColorOpacity(backgroundColorOpacity),
           m_sorting(sorting),
           m_iCoverSourceColumn(-1),
           m_iCoverTypeColumn(-1),

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -32,6 +32,7 @@ class WTrackTableView : public WLibraryTableView {
             QWidget* parent,
             UserSettingsPointer pConfig,
             TrackCollectionManager* pTrackCollectionManager,
+            double backgroundColorOpacity,
             bool sorting);
     ~WTrackTableView() override;
     void contextMenuEvent(QContextMenuEvent * event) override;
@@ -45,6 +46,10 @@ class WTrackTableView : public WLibraryTableView {
     void setSelectedTracks(const QList<TrackId>& tracks);
     void saveCurrentVScrollBarPos();
     void restoreCurrentVScrollBarPos();
+
+    double getBackgroundColorOpacity() const {
+        return m_backgroundColorOpacity;
+    }
 
   public slots:
     void loadTrackModel(QAbstractItemModel* model);
@@ -132,6 +137,8 @@ class WTrackTableView : public WLibraryTableView {
     const UserSettingsPointer m_pConfig;
 
     TrackCollectionManager* const m_pTrackCollectionManager;
+
+    const double m_backgroundColorOpacity;
 
     QScopedPointer<DlgTrackInfo> m_pTrackInfo;
     QScopedPointer<DlgTagFetcher> m_pTagFetcher;


### PR DESCRIPTION
~~***Based on PR #2538***~~ Ready for review now after prerequisite PR has been merged.

As suggested by @ronso0 here: https://github.com/mixxxdj/mixxx/pull/2539#issuecomment-596435468

~~I'm not sure about the name `TrackColorBackgroundOpacity`. As an alternative this parameter could also be applied to the background color of the cover image that will be introduced in #2524. I don't use track colors and this would better fit my use case.~~ More generic name is now `TrackTableBackgroundColorOpacity`.

Naming rationale:
- it is applied to the *track table*
- it controls the alpha channel (= *opacity*) of the *background color*
- the *background color* might be chosen from either the *track color* or the *cover art background/preview color*.

Due to many dependencies the implementation required more changes than expected. If we ever need more customizable parameters then we should rethink the design. But for now this works and should be approachable.