### PR TITLE
Shade :: fix track color picker

### DIFF
--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -344,7 +344,8 @@ WCueMenuPopup QLabel {
   selection-background-color: #ccc;
   padding: 2px;
 }
-#CueColorPicker QPushButton {
+#CueColorPicker QPushButton,
+WLibrary WColorPicker QPushButton {
   width: 38px;
   height: 20px;
   border: 1px solid #060613;

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -220,7 +220,7 @@ WCoverArtMenu {
   /* unchecked menu checkbox */
   #LibraryContainer QMenu QCheckBox::indicator:enabled:!checked,
   #LibraryContainer QMenu::indicator:!checked {
-    border-color: #1a2025;/* 
+    border-color: #1a2025;/*
     background-color: #7e868b;
     remove OS focus indicator */
     outline: none;

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -401,7 +401,7 @@ WCueMenuPopup QLabel {
     color: #cfcfcf;
     }
     /* remove OS focus indicator from BPM cell */
-    WLibrary QCheckBox {
+    WLibrary QCheckBox:focus {
       outline: none;
     }
 
@@ -710,7 +710,11 @@ WLibrary QRadioButton::indicator:unchecked {
   image: url(skin:/btn/btn_lib_radio_button_off.svg) center center;
 }
 
-WLibrary QPushButton {
+#DlgMissing > QPushButton,
+#DlgHidden > QPushButton,
+#DlgAutoDJ > QPushButton,
+#DlgRecording > QPushButton,
+#DlgAnalysis > QPushButton {
   text-align: center;
   font-size: 9pt;
   font-weight: normal;
@@ -737,18 +741,39 @@ WLibrary QPushButton {
       width: 40px;
     }
 
-  WLibrary QPushButton:!enabled {
+  #DlgMissing > QPushButton:!enabled,
+  #DlgHidden > QPushButton:!enabled,
+  #DlgAutoDJ > QPushButton:!enabled,
+  #DlgRecording > QPushButton:!enabled,
+  #DlgAnalysis > QPushButton:!enabled {
     background-color: #72777A;
     border: 1px solid #72777A;
     }
-  WLibrary QPushButton:unchecked {
+  #DlgMissing > QPushButton:unchecked,
+  #DlgHidden > QPushButton:unchecked,
+  #DlgAutoDJ > QPushButton:unchecked,
+  #DlgRecording > QPushButton:unchecked,
+  #DlgAnalysis > QPushButton:unchecked {
     color: #888;
     background-color: #444;
     }
-  WLibrary QPushButton:checked {
+  #DlgMissing > QPushButton:checked,
+  #DlgHidden > QPushButton:checked,
+  #DlgAutoDJ > QPushButton:checked,
+  #DlgRecording > QPushButton:checked,
+  #DlgAnalysis > QPushButton:checked {
     color: #000;
     background-color: #F90562;
+    border: 1px solid #F90562;
     }
+  #DlgAnalysis > QPushButton:focus,
+  #DlgMissing > QPushButton:focus,
+  #DlgHidden > QPushButton:focus,
+  #DlgAutoDJ > QPushButton:focus,
+  #DlgRecording > QPushButton:focus,
+  #DlgAnalysis > QPushButton:focus {
+    outline: none;
+  }
   /* Space in between 'Recording'	button and recording label */
   QPushButton#pushButtonRecording {
     margin: 1px 6px 3px 1px;

--- a/res/skins/Shade/style_dark.qss
+++ b/res/skins/Shade/style_dark.qss
@@ -170,18 +170,30 @@ WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal,
   #LibraryContainer QHeaderView::down-arrow {
     image: url(skin:/btn/btn_lib_sort_down_green.png)
   }
-
-WLibrary QPushButton:enabled {
+#DlgMissing > QPushButton:enabled,
+#DlgHidden > QPushButton:enabled,
+#DlgAutoDJ > QPushButton:enabled,
+#DlgRecording > QPushButton:enabled,
+#DlgAnalysis > QPushButton:enabled {
   background-color: #5C5B5D;
   border: 1px solid #5C5B5D;
   }
-  WLibrary QPushButton:!enabled {
+  #DlgMissing > QPushButton:!enabled,
+  #DlgHidden > QPushButton:!enabled,
+  #DlgAutoDJ > QPushButton:!enabled,
+  #DlgRecording > QPushButton:!enabled,
+  #DlgAnalysis > QPushButton:!enabled {
     background-color: #3D3E3F;
     border: 1px solid #3D3E3F;
   }
-  WLibrary QPushButton:checked {
+  #DlgMissing > QPushButton:checked,
+  #DlgHidden > QPushButton:checked,
+  #DlgAutoDJ > QPushButton:checked,
+  #DlgRecording > QPushButton:checked,
+  #DlgAnalysis > QPushButton:checked {
     color: #000;
     background-color: #B79E00;
+    border: 1px solid #B79E00;
   }
 
 WLibrary QRadioButton::indicator:checked {

--- a/res/skins/Shade/style_summer_sunset.qss
+++ b/res/skins/Shade/style_summer_sunset.qss
@@ -88,11 +88,19 @@ WCoverArtMenu::item {
   background-color: #706633;
 }
 
-WLibrary QPushButton:enabled {
+#DlgMissing > QPushButton:enabled,
+#DlgHidden > QPushButton:enabled,
+#DlgAutoDJ > QPushButton:enabled,
+#DlgRecording > QPushButton:enabled,
+#DlgAnalysis > QPushButton:enabled {
   background-color: #998A3C;
-	border: 1px solid #998A3C;
+  border: 1px solid #998A3C;
   }
-  WLibrary QPushButton:!enabled {
+  #DlgMissing > QPushButton:!enabled,
+  #DlgHidden > QPushButton:!enabled,
+  #DlgAutoDJ > QPushButton:!enabled,
+  #DlgRecording > QPushButton:!enabled,
+  #DlgAnalysis > QPushButton:!enabled {
     background-color: #706633;
     border: 1px solid #706633;
     }
@@ -100,9 +108,14 @@ WLibrary QPushButton:enabled {
     color: #888;
     background-color: #444;
     }
-  WLibrary QPushButton:checked {
+  #DlgMissing > QPushButton:checked,
+  #DlgHidden > QPushButton:checked,
+  #DlgAutoDJ > QPushButton:checked,
+  #DlgRecording > QPushButton:checked,
+  #DlgAnalysis > QPushButton:checked {
     color: #000;
     background-color: #52F904;
+    border: 1px solid #52F904;
     }
 
 WLibrary QRadioButton::indicator:checked {


### PR DESCRIPTION
**1** Changes how library feature buttons are styled in Shade schemes so that the style from /res/skins/default.qss is applied to the default track color button like in the other skins (black bg).
**2** Styles track color buttons like the cue color buttons

![image](https://user-images.githubusercontent.com/5934199/76633913-c4f8a600-6545-11ea-8758-c2c34c629289.png)
