### PR TITLE
CMake: Fix pixmaps install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -890,7 +890,7 @@ install(
 # Icon file for menu entry
 install(
   FILES ${CMAKE_CURRENT_SOURCE_DIR}/res/images/mixxx_icon.svg
-  DESTINATION ${CMAKE_INSTALL_DATADIR}/pixmaps/rules.d
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/pixmaps
 )
 
 # .appdata.xml file for KDE/GNOME AppStream initiative


### PR DESCRIPTION
Obvious fix, probably a copy&paste error.

Unfortunately I cannot make use of cmake install for the RPM build due to subtle differences. We could try to align the builds after the first RPM builds for Fedora are ready. Almost finished.