### PR TITLE
Color Picker Improvements

### DIFF
--- a/res/skins/default.qss
+++ b/res/skins/default.qss
@@ -34,6 +34,17 @@ WColorPicker QPushButton[noColor="true"] {
   background-color: black;
 }
 
+WColorPicker QPushButton[customColor="true"] {
+  /* Diagonal Rainbow Gradient */
+  background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 1,
+                                    stop: 0 #FF0000,
+                                    stop: 0.2 #FFFF00,
+                                    stop: 0.4 #00FF00,
+                                    stop: 0.6 #00FFFF,
+                                    stop: 0.8 #0000FF,
+                                    stop: 1 #FF00FF)
+}
+
 WColorPicker QPushButton[checked="false"] {
   qproperty-icon: none;
 }

--- a/src/widget/wcolorpicker.cpp
+++ b/src/widget/wcolorpicker.cpp
@@ -57,6 +57,11 @@ WColorPicker::WColorPicker(Options options, const ColorPalette& palette, QWidget
     m_pStyle = QStyleFactory::create(QString("fusion"));
     setLayout(pLayout);
     addColorButtons();
+
+    connect(this,
+            &WColorPicker::colorPicked,
+            this,
+            &WColorPicker::slotColorPicked);
 }
 
 void WColorPicker::removeColorButtons() {
@@ -124,10 +129,6 @@ void WColorPicker::addColorButton(mixxx::RgbColor::optional_t color, QGridLayout
 
     pLayout->addWidget(pColorButton, row, column);
 
-    connect(this,
-            &WColorPicker::colorPicked,
-            this,
-            &WColorPicker::slotColorPicked);
     connect(pColorButton,
             &QPushButton::clicked,
             this,

--- a/src/widget/wcolorpicker.cpp
+++ b/src/widget/wcolorpicker.cpp
@@ -38,7 +38,8 @@ inline int idealColumnCount(int numItems) {
 WColorPicker::WColorPicker(Options options, const ColorPalette& palette, QWidget* parent)
         : QWidget(parent),
           m_options(options),
-          m_palette(palette) {
+          m_palette(palette),
+          m_pNoColorButton(nullptr) {
     QGridLayout* pLayout = new QGridLayout();
     pLayout->setMargin(0);
     pLayout->setContentsMargins(0, 0, 0, 0);
@@ -76,6 +77,11 @@ void WColorPicker::removeColorButtons() {
         pLayout->removeWidget(pColorButton);
         delete pColorButton;
     }
+
+    if (m_pNoColorButton) {
+        pLayout->removeWidget(m_pNoColorButton);
+        delete m_pNoColorButton;
+    }
 }
 
 void WColorPicker::addColorButtons() {
@@ -95,7 +101,7 @@ void WColorPicker::addColorButtons() {
 
     int numColumns = idealColumnCount(numColors);
     if (m_options.testFlag(Option::AllowNoColor)) {
-        addColorButton(std::nullopt, pLayout, row, column);
+        addNoColorButton(pLayout, row, column);
         column++;
     }
 
@@ -109,89 +115,81 @@ void WColorPicker::addColorButtons() {
     }
 }
 
-void WColorPicker::addColorButton(mixxx::RgbColor::optional_t color, QGridLayout* pLayout, int row, int column) {
-    parented_ptr<QPushButton> pColorButton = make_parented<QPushButton>("", this);
+void WColorPicker::addColorButton(mixxx::RgbColor color, QGridLayout* pLayout, int row, int column) {
+    parented_ptr<QPushButton> pButton = make_parented<QPushButton>("", this);
     if (m_pStyle) {
-        pColorButton->setStyle(m_pStyle);
+        pButton->setStyle(m_pStyle);
     }
 
-    if (color) {
-        // Set the background color of the button. This can't be overridden in skin stylesheets.
-        pColorButton->setStyleSheet(
-                QString("QPushButton { background-color: %1; }").arg(mixxx::RgbColor::toQString(color)));
-    } else {
-        pColorButton->setProperty("noColor", true);
-    }
-    pColorButton->setToolTip(mixxx::RgbColor::toQString(color, tr("No Color")));
+    // Set the background color of the button. This can't be overridden in skin stylesheets.
+    pButton->setStyleSheet(
+            QString("QPushButton { background-color: %1; }").arg(mixxx::RgbColor::toQString(color)));
+    pButton->setToolTip(mixxx::RgbColor::toQString(color));
+    pButton->setCheckable(true);
+    m_colorButtons.append(pButton);
 
-    pColorButton->setCheckable(true);
-    m_colorButtons.append(pColorButton);
-
-    pLayout->addWidget(pColorButton, row, column);
-
-    connect(pColorButton,
+    connect(pButton,
             &QPushButton::clicked,
             this,
             [this, color]() {
-                emit colorPicked(color);
+                emit colorPicked(mixxx::RgbColor::optional(color));
             });
+    pLayout->addWidget(pButton, row, column);
 }
 
-void WColorPicker::resetSelectedColor() {
+void WColorPicker::addNoColorButton(QGridLayout* pLayout, int row, int column) {
+    QPushButton* pButton = m_pNoColorButton;
+    if (!pButton) {
+        pButton = make_parented<QPushButton>("", this);
+        if (m_pStyle) {
+            pButton->setStyle(m_pStyle);
+        }
+
+        pButton->setProperty("noColor", true);
+        pButton->setToolTip(tr("No color"));
+        pButton->setCheckable(true);
+        connect(pButton,
+                &QPushButton::clicked,
+                this,
+                [this]() {
+                    emit colorPicked(std::nullopt);
+                });
+        m_pNoColorButton = pButton;
+    }
+    pLayout->addWidget(pButton, row, column);
+}
+
+void WColorPicker::setColorButtonChecked(mixxx::RgbColor::optional_t color, bool checked) {
     // Unset currently selected color
-    int i = 0;
-    if (m_selectedColor) {
-        i = m_palette.indexOf(*m_selectedColor);
-        if (i == -1) {
-            return;
+    QPushButton* pButton = nullptr;
+    if (color) {
+        int i = m_palette.indexOf(*color);
+        if (i != -1) {
+            pButton = m_colorButtons.at(i);
         }
-        if (m_options.testFlag(Option::AllowNoColor)) {
-            i++;
-        }
-    } else if (!m_options.testFlag(Option::AllowNoColor)) {
+    } else if (m_options.testFlag(Option::AllowNoColor)) {
+        pButton = m_pNoColorButton;
+    }
+
+    if (!pButton) {
         return;
     }
 
-    DEBUG_ASSERT(i < m_colorButtons.size());
-
-    QPushButton* pButton = m_colorButtons.at(i);
-    VERIFY_OR_DEBUG_ASSERT(pButton != nullptr) {
-        return;
-    }
-    pButton->setChecked(false);
+    pButton->setChecked(checked);
     // This is needed to re-apply skin styles (e.g. to show/hide a checkmark icon)
     pButton->style()->unpolish(pButton);
     pButton->style()->polish(pButton);
+}
+
+void WColorPicker::resetSelectedColor() {
+    setColorButtonChecked(m_selectedColor, false);
 }
 
 void WColorPicker::setSelectedColor(mixxx::RgbColor::optional_t color) {
     resetSelectedColor();
 
     m_selectedColor = color;
-
-    int i = 0;
-    if (color) {
-        i = m_palette.indexOf(*color);
-        if (i == -1) {
-            return;
-        }
-        if (m_options.testFlag(Option::AllowNoColor)) {
-            i++;
-        }
-    } else if (!m_options.testFlag(Option::AllowNoColor)) {
-        return;
-    }
-
-    DEBUG_ASSERT(i < m_colorButtons.size());
-
-    QPushButton* pButton = m_colorButtons.at(i);
-    VERIFY_OR_DEBUG_ASSERT(pButton != nullptr) {
-        return;
-    }
-    pButton->setChecked(true);
-    // This is needed to re-apply skin styles (e.g. to show/hide a checkmark icon)
-    pButton->style()->unpolish(pButton);
-    pButton->style()->polish(pButton);
+    setColorButtonChecked(m_selectedColor, true);
 }
 
 void WColorPicker::setColorPalette(const ColorPalette& palette) {

--- a/src/widget/wcolorpicker.cpp
+++ b/src/widget/wcolorpicker.cpp
@@ -35,9 +35,9 @@ inline int idealColumnCount(int numItems) {
     return numColumns;
 }
 
-WColorPicker::WColorPicker(ColorOption colorOption, const ColorPalette& palette, QWidget* parent)
+WColorPicker::WColorPicker(Options options, const ColorPalette& palette, QWidget* parent)
         : QWidget(parent),
-          m_colorOption(colorOption),
+          m_options(options),
           m_palette(palette) {
     QGridLayout* pLayout = new QGridLayout();
     pLayout->setMargin(0);
@@ -84,12 +84,12 @@ void WColorPicker::addColorButtons() {
     int column = 0;
 
     int numColors = m_palette.size();
-    if (m_colorOption == ColorOption::AllowNoColor) {
+    if (m_options.testFlag(Option::AllowNoColor)) {
         numColors++;
     }
 
     int numColumns = idealColumnCount(numColors);
-    if (m_colorOption == ColorOption::AllowNoColor) {
+    if (m_options.testFlag(Option::AllowNoColor)) {
         addColorButton(std::nullopt, pLayout, row, column);
         column++;
     }
@@ -144,10 +144,10 @@ void WColorPicker::resetSelectedColor() {
         if (i == -1) {
             return;
         }
-        if (m_colorOption == ColorOption::AllowNoColor) {
+        if (m_options.testFlag(Option::AllowNoColor)) {
             i++;
         }
-    } else if (m_colorOption != ColorOption::AllowNoColor) {
+    } else if (!m_options.testFlag(Option::AllowNoColor)) {
         return;
     }
 
@@ -174,10 +174,10 @@ void WColorPicker::setSelectedColor(mixxx::RgbColor::optional_t color) {
         if (i == -1) {
             return;
         }
-        if (m_colorOption == ColorOption::AllowNoColor) {
+        if (m_options.testFlag(Option::AllowNoColor)) {
             i++;
         }
-    } else if (m_colorOption != ColorOption::AllowNoColor) {
+    } else if (!m_options.testFlag(Option::AllowNoColor)) {
         return;
     }
 

--- a/src/widget/wcolorpicker.h
+++ b/src/widget/wcolorpicker.h
@@ -15,6 +15,7 @@ class WColorPicker : public QWidget {
     enum class Option {
         NoOptions = 0,
         AllowNoColor = 1,
+        AllowCustomColor = 1 << 1,
     };
     Q_DECLARE_FLAGS(Options, Option);
 
@@ -36,10 +37,12 @@ class WColorPicker : public QWidget {
     void removeColorButtons();
     void addColorButton(mixxx::RgbColor color, QGridLayout* pLayout, int row, int column);
     void addNoColorButton(QGridLayout* pLayout, int row, int column);
+    void addCustomColorButton(QGridLayout* pLayout, int row, int column);
     Options m_options;
     mixxx::RgbColor::optional_t m_selectedColor;
     ColorPalette m_palette;
     QPushButton* m_pNoColorButton;
+    QPushButton* m_pCustomColorButton;
     QList<QPushButton*> m_colorButtons;
     QStyle* m_pStyle;
 };

--- a/src/widget/wcolorpicker.h
+++ b/src/widget/wcolorpicker.h
@@ -12,12 +12,13 @@
 class WColorPicker : public QWidget {
     Q_OBJECT
   public:
-    enum class ColorOption {
-        DenyNoColor,
-        AllowNoColor,
+    enum class Option {
+        NoOptions = 0,
+        AllowNoColor = 1,
     };
+    Q_DECLARE_FLAGS(Options, Option);
 
-    explicit WColorPicker(ColorOption colorOption, const ColorPalette& palette, QWidget* parent = nullptr);
+    explicit WColorPicker(Options options, const ColorPalette& palette, QWidget* parent = nullptr);
 
     void resetSelectedColor();
     void setSelectedColor(mixxx::RgbColor::optional_t color);
@@ -33,9 +34,11 @@ class WColorPicker : public QWidget {
     void addColorButtons();
     void removeColorButtons();
     void addColorButton(mixxx::RgbColor::optional_t color, QGridLayout* pLayout, int row, int column);
-    ColorOption m_colorOption;
+    Options m_options;
     mixxx::RgbColor::optional_t m_selectedColor;
     ColorPalette m_palette;
     QList<QPushButton*> m_colorButtons;
     QStyle* m_pStyle;
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(WColorPicker::Options);

--- a/src/widget/wcolorpicker.h
+++ b/src/widget/wcolorpicker.h
@@ -31,12 +31,15 @@ class WColorPicker : public QWidget {
     void slotColorPicked(mixxx::RgbColor::optional_t color);
 
   private:
+    void setColorButtonChecked(mixxx::RgbColor::optional_t color, bool checked);
     void addColorButtons();
     void removeColorButtons();
-    void addColorButton(mixxx::RgbColor::optional_t color, QGridLayout* pLayout, int row, int column);
+    void addColorButton(mixxx::RgbColor color, QGridLayout* pLayout, int row, int column);
+    void addNoColorButton(QGridLayout* pLayout, int row, int column);
     Options m_options;
     mixxx::RgbColor::optional_t m_selectedColor;
     ColorPalette m_palette;
+    QPushButton* m_pNoColorButton;
     QList<QPushButton*> m_colorButtons;
     QStyle* m_pStyle;
 };

--- a/src/widget/wcolorpickeraction.cpp
+++ b/src/widget/wcolorpickeraction.cpp
@@ -1,8 +1,8 @@
 #include "widget/wcolorpickeraction.h"
 
-WColorPickerAction::WColorPickerAction(WColorPicker::ColorOption colorOption, const ColorPalette& palette, QWidget* parent)
+WColorPickerAction::WColorPickerAction(WColorPicker::Options options, const ColorPalette& palette, QWidget* parent)
         : QWidgetAction(parent),
-          m_pColorPicker(make_parented<WColorPicker>(colorOption, palette)) {
+          m_pColorPicker(make_parented<WColorPicker>(options, palette)) {
     connect(m_pColorPicker.get(), &WColorPicker::colorPicked, this, &WColorPickerAction::colorPicked);
 
     QHBoxLayout* pLayout = new QHBoxLayout();

--- a/src/widget/wcolorpickeraction.h
+++ b/src/widget/wcolorpickeraction.h
@@ -11,7 +11,7 @@ class WColorPickerAction : public QWidgetAction {
     Q_OBJECT
   public:
     explicit WColorPickerAction(
-            WColorPicker::ColorOption colorOption,
+            WColorPicker::Options options,
             const ColorPalette& palette,
             QWidget* parent = nullptr);
 

--- a/src/widget/wcuemenupopup.cpp
+++ b/src/widget/wcuemenupopup.cpp
@@ -32,7 +32,7 @@ WCueMenuPopup::WCueMenuPopup(UserSettingsPointer pConfig, QWidget* parent)
     connect(m_pEditLabel, &QLineEdit::textEdited, this, &WCueMenuPopup::slotEditLabel);
     connect(m_pEditLabel, &QLineEdit::returnPressed, this, &WCueMenuPopup::hide);
 
-    m_pColorPicker = new WColorPicker(WColorPicker::ColorOption::DenyNoColor, m_colorPaletteSettings.getHotcueColorPalette(), this);
+    m_pColorPicker = new WColorPicker(WColorPicker::Option::NoOptions, m_colorPaletteSettings.getHotcueColorPalette(), this);
     m_pColorPicker->setObjectName("CueColorPicker");
     connect(m_pColorPicker, &WColorPicker::colorPicked, this, &WCueMenuPopup::slotChangeCueColor);
 

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -575,7 +575,7 @@ void WTrackTableView::createActions() {
             this, [this] { slotScaleBpm(Beats::THREEHALVES); });
 
     ColorPaletteSettings colorPaletteSettings(m_pConfig);
-    m_pColorPickerAction = new WColorPickerAction(WColorPicker::ColorOption::AllowNoColor, colorPaletteSettings.getTrackColorPalette(), this);
+    m_pColorPickerAction = new WColorPickerAction(WColorPicker::Option::AllowNoColor, colorPaletteSettings.getTrackColorPalette(), this);
     m_pColorPickerAction->setObjectName("TrackColorPickerAction");
     connect(m_pColorPickerAction,
             &WColorPickerAction::colorPicked,


### PR DESCRIPTION
- Switch to `QFlags` for color picker options
- Minor code cleanup
- Add support for picking custom, non-palette colors (useful for #2547)