### PR TITLE
CMake: Install license files and docs in separate directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -885,10 +885,18 @@ install(
     ${CMAKE_INSTALL_DATADIR}/mixxx
 )
 
-# Documentation
+# Licenses
 install(
   FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE
+    ${CMAKE_CURRENT_SOURCE_DIR}/COPYING
+  DESTINATION
+    ${CMAKE_INSTALL_DATADIR}/licenses/mixxx
+)
+
+# Documentation
+install(
+  FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/README
     ${CMAKE_CURRENT_SOURCE_DIR}/Mixxx-Manual.pdf
   DESTINATION


### PR DESCRIPTION
To be discussed:

- /usr/share/doc/mixxx
- /usr/share/licenses/mixxx

This layout reflects the file structure used by RedHat and Arch.