### PR TITLE
Fix beatsync while sync is enabled

### DIFF
--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -249,6 +249,10 @@ void BpmControl::slotTapFilter(double averageLength, int numSamples) {
 
 void BpmControl::slotControlBeatSyncPhase(double v) {
     if (!v) return;
+
+    if (isSynchronized()) {
+        m_dUserOffset.setValue(0.0);
+    }
     getEngineBuffer()->requestSyncPhase();
 }
 
@@ -268,7 +272,7 @@ void BpmControl::slotControlBeatSync(double v) {
     // this is used from controller scripts, where the latching behaviour of
     // the sync_enable CO cannot be used
     if (m_pPlayButton->toBool() && m_pQuantize->toBool()) {
-        getEngineBuffer()->requestSyncPhase();
+        slotControlBeatSyncPhase(v);
     }
 }
 


### PR DESCRIPTION
When both decks are playing and sync is enabled for both of them,
you can still tweak the phase by nudging the jog wheels of your
controller. To get the phases synced again, users might want to use
beatsync, but this is broken at the moment:

Behaviour without this change:
- After the user triggers beatsync, both tracks tempos/phases are synced
  instantly, but then the phase slowly goes out of sync again until it
  reaches the position before beatsync was triggered

Behaviour with this change:
- After the user triggers beatsync, both tracks tempos/phases are synced
  instantly