### PR TITLE
CMake: Add support for script directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1139,10 +1139,18 @@ if(UNIX)
     COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/res" "${CMAKE_CURRENT_BINARY_DIR}/res"
     COMMENT "Symlinking resources to build directory..."
   )
+  add_custom_target(mixxx-script
+    COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/script" "${CMAKE_CURRENT_BINARY_DIR}/script"
+    COMMENT "Symlinking to build directory..."
+  )
 else()
   add_custom_target(mixxx-res
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/res" "${CMAKE_CURRENT_BINARY_DIR}/"
     COMMENT "Copying resources to build directory..."
+  )
+  add_custom_target(mixxx-script
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/script" "${CMAKE_CURRENT_BINARY_DIR}/"
+    COMMENT "Copying QScriptEngine extensions to build directory..."
   )
 endif()
 add_dependencies(mixxx-lib mixxx-res)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1161,7 +1161,7 @@ else()
     COMMENT "Copying QScriptEngine extensions to build directory..."
   )
 endif()
-add_dependencies(mixxx-lib mixxx-res)
+add_dependencies(mixxx-lib mixxx-res mixxx-script)
 
 # Windows-only resource file
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -885,6 +885,14 @@ install(
     ${CMAKE_INSTALL_DATADIR}/mixxx
 )
 
+# QScriptEngine extensions
+install(
+  DIRECTORY
+    ${CMAKE_CURRENT_SOURCE_DIR}/script
+  DESTINATION
+    ${CMAKE_INSTALL_DATADIR}/mixxx
+)
+
 # Licenses
 install(
   FILES


### PR DESCRIPTION
Fixes the import error that occurs when running mixxx from the build directory and `SkinContext` tries to import the `console` and `svg` extensions.