### PR TITLE
Use python 3.7 style for checking scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,8 @@
 # because it won't prevent catching other, unrelated issues.
 
 exclude: ^lib/.*$
+default_language_version:
+  python: python3.7
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v2.3.0


### PR DESCRIPTION
I'm getting this error on head with pre-commit:
```
scripts/serato_heartbeat.py:89:47: E999 SyntaxError: invalid syntax
```

This is because the serato_heartbeat file uses a new python3.6 syntax:
```
            print("{:02x} {:02x}  {}".format(*midi, desc))
```

This is fixed by telling black to allow this syntax