### PR TITLE
Revert "Use python 3.7 style for checking scripts"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,8 +40,6 @@
 # because it won't prevent catching other, unrelated issues.
 
 exclude: ^lib/.*$
-default_language_version:
-  python: python3.7
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v2.3.0


### PR DESCRIPTION
This reverts commit 5bb8dff21938109defcb7f89d9dd237f45cfd3f9.

Breaks if the user doesn't have that exact version of python