### PR TITLE
Remove auto hotcue colors option

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -618,13 +618,8 @@ void CueControl::hotcueSet(HotcueControl* pControl, double v) {
     pCue->setLabel();
     pCue->setType(mixxx::CueType::HotCue);
 
-    ConfigKey autoHotcueColorsKey("[Controls]", "auto_hotcue_colors");
-    if (getConfig()->getValue(autoHotcueColorsKey, false)) {
-        auto hotcueColorPalette = m_colorPaletteSettings.getHotcueColorPalette();
-        pCue->setColor(hotcueColorPalette.colorForHotcueIndex(hotcue));
-    } else {
-        pCue->setColor(mixxx::PredefinedColorPalettes::kDefaultCueColor);
-    }
+    auto hotcueColorPalette = m_colorPaletteSettings.getHotcueColorPalette();
+    pCue->setColor(hotcueColorPalette.colorForHotcueIndex(hotcue));
 
     // TODO(XXX) deal with spurious signals
     attachCue(pCue, pControl);

--- a/src/preferences/dialog/dlgprefcolors.cpp
+++ b/src/preferences/dialog/dlgprefcolors.cpp
@@ -93,8 +93,4 @@ void DlgPrefColors::slotApply() {
                 m_colorPaletteSettings.getColorPalette(trackColorPaletteName,
                         m_colorPaletteSettings.getTrackColorPalette()));
     }
-
-    m_pConfig->setValue(
-            ConfigKey("[Controls]", "auto_hotcue_colors"),
-            checkBoxAssignHotcueColors->isChecked());
 }

--- a/src/preferences/dialog/dlgprefcolorsdlg.ui
+++ b/src/preferences/dialog/dlgprefcolorsdlg.ui
@@ -26,6 +26,16 @@
       <string>Colors</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
+      <item row="1" column="1">
+       <widget class="QComboBox" name="comboBoxTrackColors"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelTrackColors">
+        <property name="text">
+         <string>Track:</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="labelHotcueColors">
         <property name="text">
@@ -35,36 +45,6 @@
       </item>
       <item row="0" column="1">
        <widget class="QComboBox" name="comboBoxHotcueColors"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="labelTrackColors">
-        <property name="text">
-         <string>Track:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="comboBoxTrackColors"/>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="labelAutoHotcueColors">
-        <property name="text">
-         <string>Auto hotcue colors</string>
-        </property>
-        <property name="buddy">
-         <cstring>checkBoxAssignHotcueColors</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QCheckBox" name="checkBoxAssignHotcueColors">
-        <property name="toolTip">
-         <string>Automatically assigns a predefined color to a newly created hotcue point, based on its index.</string>
-        </property>
-        <property name="text">
-         <string>Assign predefined colors to newly created hotcue points</string>
-        </property>
-       </widget>
       </item>
      </layout>
     </widget>

--- a/src/preferences/dialog/dlgprefdeck.h
+++ b/src/preferences/dialog/dlgprefdeck.h
@@ -125,7 +125,6 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
     bool m_bSetIntroStartAtMainCue;
     bool m_bDisallowTrackLoadToPlayingDeck;
     bool m_bCloneDeckOnLoadDoubleTap;
-    bool m_bAssignHotcueColors;
 
     int m_iRateRangePercent;
     bool m_bRateInverted;

--- a/src/util/color/predefinedcolorpalettes.cpp
+++ b/src/util/color/predefinedcolorpalettes.cpp
@@ -102,8 +102,7 @@ constexpr mixxx::RgbColor kVirtualDJTrackColorBlue(0x0000FF);
 constexpr mixxx::RgbColor kVirtualDJTrackColorFuchsia(0xFF00FF);
 constexpr mixxx::RgbColor kVirtualDJTrackColorWhite(0xFFFFFF);
 
-// Replaces "no color" values and is used for new cues if auto_hotcue_colors is
-// disabled
+// Replaces "no color" values
 constexpr mixxx::RgbColor kSchemaMigrationReplacementColor(0xFF8000);
 
 } // anonymous namespace

--- a/src/util/color/predefinedcolorpalettes.cpp
+++ b/src/util/color/predefinedcolorpalettes.cpp
@@ -123,6 +123,22 @@ const ColorPalette PredefinedColorPalettes::kMixxxHotcueColorPalette =
                         kColorMixxxWhite,
                 });
 
+const ColorPalette PredefinedColorPalettes::kMixxxHotcueColorPaletteWithDefaultColor =
+        ColorPalette(
+                QStringLiteral("Mixxx Hotcue Colors (with default color)"),
+                QList<mixxx::RgbColor>{
+                        kColorMixxxRed,
+                        kColorMixxxYellow,
+                        kColorMixxxGreen,
+                        kColorMixxxCeleste,
+                        kColorMixxxBlue,
+                        kColorMixxxPurple,
+                        kColorMixxxPink,
+                        kColorMixxxWhite,
+                        kSchemaMigrationReplacementColor,
+                },
+                QList<unsigned int>{8});
+
 const ColorPalette PredefinedColorPalettes::kSeratoDJIntroHotcueColorPalette =
         ColorPalette(
                 QStringLiteral("Serato DJ Intro Hotcue Colors"),
@@ -248,6 +264,7 @@ const ColorPalette PredefinedColorPalettes::kDefaultTrackColorPalette =
 const QList<ColorPalette> PredefinedColorPalettes::kPalettes{
         // Hotcue Color Palettes
         mixxx::PredefinedColorPalettes::kMixxxHotcueColorPalette,
+        mixxx::PredefinedColorPalettes::kMixxxHotcueColorPaletteWithDefaultColor,
         mixxx::PredefinedColorPalettes::kSeratoDJProHotcueColorPalette,
         mixxx::PredefinedColorPalettes::kSeratoDJIntroHotcueColorPalette,
 

--- a/src/util/color/predefinedcolorpalettes.h
+++ b/src/util/color/predefinedcolorpalettes.h
@@ -6,6 +6,7 @@ namespace mixxx {
 class PredefinedColorPalettes {
   public:
     static const ColorPalette kMixxxHotcueColorPalette;
+    static const ColorPalette kMixxxHotcueColorPaletteWithDefaultColor;
     static const ColorPalette kSeratoDJIntroHotcueColorPalette;
     static const ColorPalette kSeratoDJProHotcueColorPalette;
 


### PR DESCRIPTION
This option is now obsolete since the same can be archieved using the palette editor.

I also added a second Mixxx Hotcue Palette that includes the orange default color and always assigns that to all new hotcues.