### PR TITLE
Roland DJ-505: Fix Cue Loop and Pitch Play mode

### DIFF
--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -1297,7 +1297,7 @@ DJ505.CueLoopMode = function(deck, offset) {
         this.midi = [0x94 + offset, 0x14 + n];
         this.number = n + 1;
         this.outKey = "hotcue_" + this.number + "_enabled";
-        this.colorIdKey = "hotcue_" + this.number + "_color_id";
+        this.colorKey = "hotcue_" + this.number + "_color";
 
         components.Button.call(this);
     };
@@ -1353,44 +1353,9 @@ DJ505.CueLoopMode = function(deck, offset) {
             this.inKey = "hotcue_" + this.number + "_clear";
             this.input = components.Button.prototype.input;
         },
-        output: function(value) {
-            var outval = this.outValueScale(value);
-            // WARNING: outputColor only handles hotcueColors
-            // and there is no hotcueColor for turning the LED
-            // off. So the `send()` function is responsible for turning the
-            // actual LED off.
-            if (this.colorIdKey !== undefined && outval !== this.off) {
-                this.outputColor(engine.getValue(this.group, this.colorIdKey));
-            } else {
-                this.send(outval);
-            }
-        },
-        outputColor: function(id) {
-            var color = this.colors[id];
-            if (color instanceof Array) {
-                if (color.length !== 3) {
-                    print("ERROR: invalid color array for id: " + id);
-                    return;
-                }
-                if (this.sendRGB === undefined) {
-                    print("ERROR: no function defined for sending RGB colors");
-                    return;
-                }
-                this.sendRGB(color);
-            } else if (typeof color === "number") {
-                this.send(color);
-            }
-        },
-        connect: function() {
-            components.Button.prototype.connect.call(this); // call parent connect
-            if (undefined !== this.group && this.colorIdKey !== undefined) {
-                this.connections[1] = engine.makeConnection(this.group, this.colorIdKey, function(id) {
-                    if (engine.getValue(this.group, this.outKey)) {
-                        this.outputColor(id);
-                    }
-                });
-            }
-        },
+        output: components.HotcueButton.prototype.output,
+        outputColor: components.HotcueButton.prototype.outputColor,
+        connect: components.HotcueButton.prototype.connect,
     });
 
     this.pads = new components.ComponentContainer();

--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -1620,7 +1620,7 @@ DJ505.PitchPlayMode = function(deck, offset) {
         off: DJ505.PadColor.OFF,
         outputColor: function(colorCode) {
             // For colored hotcues (shifted only)
-            var midiColor = this.colorMapper.getNearestValue(colorCode);
+            var midiColor = this.colorMapper.getValueForNearestColor(colorCode);
             this.send((this.mode.cuepoint === this.number) ? midiColor : (midiColor + DJ505.PadColor.DIM_MODIFIER));
         },
         unshift: function() {


### PR DESCRIPTION
Looks like I forgot to update some functions for #2520 in the Roland DJ-505 mapping, so Cue Loop and Pitch Play modes were broken.