### PR TITLE
Drop support for Ubuntu 16.04 Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
     - name: pre-commit
       if: type != pull_request
       os: linux
-      dist: xenial
+      dist: bionic
       language: python
       python: 3.7
       # There are too many files in the repo that have formatting issues. We'll
@@ -39,7 +39,7 @@ jobs:
     - name: pre-commit-pr
       if: type == pull_request
       os: linux
-      dist: xenial
+      dist: bionic
       language: python
       python: 3.7
       cache:
@@ -53,9 +53,9 @@ jobs:
 
     - name: Ubuntu/gcc/SCons build
       os: linux
-      dist: xenial
+      dist: bionic
       compiler: gcc
-      # Ubuntu Xenial build prerequisites
+      # Ubuntu Bionic build prerequisites
       before_install:
         - sudo apt-get install -y scons
       install:
@@ -68,10 +68,10 @@ jobs:
 
     - name: Ubuntu/gcc/CMake build
       os: linux
-      dist: xenial
+      dist: bionic
       compiler: gcc
       cache: ccache
-      # Ubuntu Xenial build prerequisites
+      # Ubuntu Bionic build prerequisites
       env: CMAKEFLAGS_EXTRA="-DLOCALECOMPARE=ON"
       before_install:
         - export CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -316,9 +316,7 @@ void TrackDAO::databaseTracksRelocated(QList<RelocatedTrack> relocatedTracks) {
         }
     }
     DEBUG_ASSERT(removedTrackIds.size() <= changedTrackIds.size());
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     DEBUG_ASSERT(!removedTrackIds.intersects(changedTrackIds));
-#endif
     if (!removedTrackIds.isEmpty()) {
         emit tracksRemoved(removedTrackIds);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,10 +69,8 @@ int main(int argc, char * argv[]) {
     QCoreApplication::setOrganizationDomain("mixxx.org");
 
     // This needs to be set before initializing the QApplication.
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-#endif
 
     // Setting the organization name results in a QDesktopStorage::DataLocation
     // of "$HOME/Library/Application Support/Mixxx/Mixxx" on OS X. Leave the

--- a/src/network/jsonwebtask.cpp
+++ b/src/network/jsonwebtask.cpp
@@ -1,8 +1,5 @@
 #include "network/jsonwebtask.h"
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 8, 0)
-#include <QBuffer>
-#endif
 #include <QMetaMethod>
 #include <QMimeDatabase>
 #include <QNetworkRequest>
@@ -72,9 +69,7 @@ QNetworkRequest newRequest(
         const QUrl& url) {
     QNetworkRequest request(url);
     request.setHeader(QNetworkRequest::ContentTypeHeader, JSON_CONTENT_TYPE);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
-#endif
     return request;
 }
 
@@ -171,19 +166,10 @@ QNetworkReply* JsonWebTask::sendNetworkRequest(
                     << url
                     << body;
         }
-#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
         return networkAccessManager->sendCustomRequest(
                 newRequest(url),
                 "PATCH",
                 body);
-#else
-        auto* buffer = new QBuffer(this);
-        buffer->setData(body);
-        return networkAccessManager->sendCustomRequest(
-                newRequest(url),
-                "PATCH",
-                buffer);
-#endif
     }
     case HttpRequestMethod::Delete: {
         DEBUG_ASSERT(content.isEmpty());

--- a/src/util/compatibility.h
+++ b/src/util/compatibility.h
@@ -2,102 +2,24 @@
 
 #include <QCoreApplication>
 #include <QGuiApplication>
-#include <QList>
 #include <QScreen>
 #include <QUuid>
-#include <QWindow>
 #include <QWidget>
 
 #include "util/assert.h"
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 7, 0)
-
-// this adds const to non-const objects (like std::as_const)
-template <typename T>
-struct QAddConst { typedef const T Type; };
-template <typename T>
-constexpr typename QAddConst<T>::Type &qAsConst(T &t) { return t; }
-// prevent rvalue arguments:
-template <typename T>
-void qAsConst(const T &&) = delete;
-
-template <typename... Args>
-struct QNonConstOverload
-{
-    template <typename R, typename T>
-    Q_DECL_CONSTEXPR auto operator()(R (T::*ptr)(Args...)) const Q_DECL_NOTHROW -> decltype(ptr)
-    { return ptr; }
-
-    template <typename R, typename T>
-    static Q_DECL_CONSTEXPR auto of(R (T::*ptr)(Args...)) Q_DECL_NOTHROW -> decltype(ptr)
-    { return ptr; }
-};
-
-template <typename... Args>
-struct QConstOverload
-{
-    template <typename R, typename T>
-    Q_DECL_CONSTEXPR auto operator()(R (T::*ptr)(Args...) const) const Q_DECL_NOTHROW -> decltype(ptr)
-    { return ptr; }
-
-    template <typename R, typename T>
-    static Q_DECL_CONSTEXPR auto of(R (T::*ptr)(Args...) const) Q_DECL_NOTHROW -> decltype(ptr)
-    { return ptr; }
-};
-
-template <typename... Args>
-struct QOverload : QConstOverload<Args...>, QNonConstOverload<Args...>
-{
-    using QConstOverload<Args...>::of;
-    using QConstOverload<Args...>::operator();
-    using QNonConstOverload<Args...>::of;
-    using QNonConstOverload<Args...>::operator();
-
-    template <typename R>
-    Q_DECL_CONSTEXPR auto operator()(R (*ptr)(Args...)) const Q_DECL_NOTHROW -> decltype(ptr)
-    { return ptr; }
-
-    template <typename R>
-    static Q_DECL_CONSTEXPR auto of(R (*ptr)(Args...)) Q_DECL_NOTHROW -> decltype(ptr)
-    { return ptr; }
-};
-
-#endif
-
-
 inline qreal getDevicePixelRatioF(const QWidget* widget) {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     return widget->devicePixelRatioF();
-#endif
-
-    // Crawl up to the window and return qreal value
-    QWindow* window = widget->window()->windowHandle();
-    if (window) {
-        return window->devicePixelRatio();
-    }
-
-    // return integer value as last resort
-    return widget->devicePixelRatio();
 }
 
 inline QScreen* getPrimaryScreen() {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     QGuiApplication* app = static_cast<QGuiApplication*>(QCoreApplication::instance());
     VERIFY_OR_DEBUG_ASSERT(app) {
         qWarning() << "Unable to get applications QCoreApplication instance, cannot determine primary screen!";
-    } else {
-        return app->primaryScreen();
+        // All attempts to find primary screen failed, return nullptr
+        return nullptr;
     }
-#endif
-    const QList<QScreen*> screens = QGuiApplication::screens();
-    VERIFY_OR_DEBUG_ASSERT(!screens.isEmpty()) {
-        qWarning() << "No screens found, cannot determine primary screen!";
-    } else {
-        return screens.first();
-    }
-
-    // All attempts to find primary screen failed, return nullptr
-    return nullptr;
+    return app->primaryScreen();
 }
 
 inline
@@ -206,14 +128,3 @@ inline void atomicStoreRelaxed(QAtomicPointer<T>& atomicPtr, T* newValue) {
     atomicPtr.store(newValue);
 #endif
 }
-
-#if QT_VERSION < QT_VERSION_CHECK(5, 6, 0)
-template<typename T>
-inline uint qHash(const QList<T>& key, uint seed = 0) {
-    uint hash = 0;
-    for (const auto& elem : key) {
-        hash ^= qHash(elem, seed);
-    }
-    return hash;
-}
-#endif

--- a/src/util/optional.h
+++ b/src/util/optional.h
@@ -1,24 +1,14 @@
 #pragma once
 
-#if __has_include(<optional>) || \
-    (defined(__cpp_lib_optional) && __cpp_lib_optional >= 201606L)
-
 #include <optional>
 
-#else
+#include <QtDebug>
 
-#include <experimental/optional>
-
-namespace std {
-
-using std::experimental::make_optional;
-using std::experimental::nullopt;
-using std::experimental::optional;
-
-// Workarounds for missing member functions:
-// option::has_value() -> explicit operator bool()
-// option::value() -> operator*()
-
-} // namespace std
-
-#endif
+template<typename T>
+QDebug operator<<(QDebug dbg, std::optional<T> arg) {
+    if (arg) {
+        return dbg << *arg;
+    } else {
+        return dbg << "nullopt";
+    }
+}


### PR DESCRIPTION
***Replacement for PR #2581***

- Require GCC 7 with decent C++17 support
- Require Qt 5.9 LTS and remove all obsolete workarounds
- Remove std::optional hacks for GCC 4/5/6
- Add qDebug() support for std::optional
