### PR TITLE
Fix LP1855321 - Prevent jumping to main cue

### DIFF
--- a/src/analyzer/analyzerthread.cpp
+++ b/src/analyzer/analyzerthread.cpp
@@ -348,6 +348,7 @@ void AnalyzerThread::emitDoneProgress(AnalyzerProgress doneProgress) {
     // thread that might trigger database actions! The TrackAnalysisScheduler
     // must store a TrackPointer until receiving the Done signal.
     TrackId trackId = m_currentTrack->getId();
+    m_currentTrack->analysisFinished();
     m_currentTrack.reset();
     emitProgress(AnalyzerThreadState::Done, trackId, doneProgress);
 }

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -433,13 +433,19 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
             seekExact(0.0);
         }
         break;
-    case SeekOnLoadMode::MainCue:
-        if (mainCuePoint.getPosition() != Cue::kNoPosition) {
-            seekExact(mainCuePoint.getPosition());
+    case SeekOnLoadMode::MainCue: {
+        // Take main cue position from CO instead of cue point list because
+        // value in CO will be quantized if quantization is enabled
+        // while value in cue point list will never be quantized.
+        // This prevents jumps when track analysis finishes while quantization is enabled.
+        double cuePoint = m_pCuePoint->get();
+        if (cuePoint != Cue::kNoPosition) {
+            seekExact(cuePoint);
         } else {
             seekExact(0.0);
         }
         break;
+    }
     case SeekOnLoadMode::IntroStart: {
         double introStart = m_pIntroStartPosition->get();
         if (introStart != Cue::kNoPosition) {

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -412,12 +412,6 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
     // Seek track according to SeekOnLoadMode.
     SeekOnLoadMode seekOnLoadMode = getSeekOnLoadPreference();
 
-    CuePointer pAudibleSound = pNewTrack->findCueByType(mixxx::CueType::AudibleSound);
-    double firstSound = Cue::kNoPosition;
-    if (pAudibleSound) {
-        firstSound = pAudibleSound->getPosition();
-    }
-
     switch (seekOnLoadMode) {
     case SeekOnLoadMode::Beginning:
         // This allows users to load tracks and have the needle-drop be maintained.
@@ -426,13 +420,15 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
             seekExact(0.0);
         }
         break;
-    case SeekOnLoadMode::FirstSound:
-        if (firstSound != Cue::kNoPosition) {
-            seekExact(firstSound);
+    case SeekOnLoadMode::FirstSound: {
+        CuePointer pAudibleSound = pNewTrack->findCueByType(mixxx::CueType::AudibleSound);
+        if (pAudibleSound && pAudibleSound->getPosition() != Cue::kNoPosition) {
+            seekExact(pAudibleSound->getPosition());
         } else {
             seekExact(0.0);
         }
         break;
+    }
     case SeekOnLoadMode::MainCue: {
         // Take main cue position from CO instead of cue point list because
         // value in CO will be quantized if quantization is enabled

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -549,14 +549,6 @@ void CueControl::loadCuesFromTrack() {
     }
 }
 
-void CueControl::reloadCuesFromTrack() {
-    if (!m_pLoadedTrack)
-        return;
-
-    // Update COs with cues from track.
-    loadCuesFromTrack();
-}
-
 void CueControl::trackAnalyzed() {
     if (!m_pLoadedTrack) {
         return;
@@ -586,11 +578,11 @@ void CueControl::trackAnalyzed() {
 }
 
 void CueControl::trackCuesUpdated() {
-    reloadCuesFromTrack();
+    loadCuesFromTrack();
 }
 
 void CueControl::trackBeatsUpdated() {
-    reloadCuesFromTrack();
+    loadCuesFromTrack();
 }
 
 void CueControl::quantizeChanged(double v) {
@@ -600,7 +592,7 @@ void CueControl::quantizeChanged(double v) {
     bool wasTrackAtCue = getTrackAt() == TrackAt::Cue;
     bool wasTrackAtIntro = isTrackAtIntroCue();
 
-    reloadCuesFromTrack();
+    loadCuesFromTrack();
 
     // if we are playing (no matter what reason for) do not seek
     if (m_pPlay->toBool()) {
@@ -1700,10 +1692,6 @@ double CueControl::quantizeCuePoint(double cuePos) {
     }
 
     return cuePos;
-}
-
-bool CueControl::isTrackAtZeroPos() {
-    return (fabs(getSampleOfTrack().current) < 1.0f);
 }
 
 bool CueControl::isTrackAtIntroCue() {

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -363,9 +363,7 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
     }
     m_pLoadedTrack = pNewTrack;
 
-    connect(m_pLoadedTrack.get(), &Track::analyzed,
-            this, &CueControl::trackAnalyzed,
-            Qt::DirectConnection);
+    connect(m_pLoadedTrack.get(), &Track::analyzed, this, &CueControl::trackAnalyzed, Qt::DirectConnection);
 
     connect(m_pLoadedTrack.get(), &Track::cuesUpdated,
             this, &CueControl::trackCuesUpdated,
@@ -564,6 +562,11 @@ void CueControl::trackAnalyzed() {
         return;
     }
 
+    // if we are playing (no matter what reason for) do not seek
+    if (m_pPlay->toBool()) {
+        return;
+    }
+
     // Retrieve current position of cues from COs.
     double cue = m_pCuePoint->get();
     double intro = m_pIntroStartPosition->get();
@@ -599,6 +602,11 @@ void CueControl::quantizeChanged(double v) {
 
     reloadCuesFromTrack();
 
+    // if we are playing (no matter what reason for) do not seek
+    if (m_pPlay->toBool()) {
+        return;
+    }
+
     // Retrieve new cue pos and follow
     double cue = m_pCuePoint->get();
     if (wasTrackAtCue && cue != Cue::kNoPosition) {
@@ -606,7 +614,7 @@ void CueControl::quantizeChanged(double v) {
     }
     // Retrieve new intro start pos and follow
     double intro = m_pIntroStartPosition->get();
-    if(wasTrackAtIntro && intro != Cue::kNoPosition) {
+    if (wasTrackAtIntro && intro != Cue::kNoPosition) {
         seekExact(intro);
     }
 }

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -138,6 +138,7 @@ class CueControl : public EngineControl {
     void quantizeChanged(double v);
 
     void cueUpdated();
+    void trackAnalyzed();
     void trackCuesUpdated();
     void trackBeatsUpdated();
     void hotcueSet(HotcueControl* pControl, double v);

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -126,7 +126,6 @@ class CueControl : public EngineControl {
     void hintReader(HintVector* pHintList) override;
     bool updateIndicatorsAndModifyPlay(bool newPlay, bool playPossible);
     void updateIndicators();
-    bool isTrackAtZeroPos();
     bool isTrackAtIntroCue();
     void resetIndicators();
     bool isPlayingByPlayButton();
@@ -191,7 +190,6 @@ class CueControl : public EngineControl {
     void attachCue(CuePointer pCue, HotcueControl* pControl);
     void detachCue(HotcueControl* pControl);
     void loadCuesFromTrack();
-    void reloadCuesFromTrack();
     double quantizeCuePoint(double position);
     double getQuantizedCurrentPosition();
     TrackAt getTrackAt() const;

--- a/src/test/cuecontrol_test.cpp
+++ b/src/test/cuecontrol_test.cpp
@@ -313,8 +313,8 @@ TEST_F(CueControlTest, FollowCueOnQuantize) {
     const int sampleRate = pTrack->getSampleRate();
     const double bpm = pTrack->getBpm();
     const double beatLength = (60.0 * sampleRate / bpm) * frameSize;
-    double cuePos = 1.8*beatLength;
-    double quantizedCuePos = 2.0*beatLength;
+    double cuePos = 1.8 * beatLength;
+    double quantizedCuePos = 2.0 * beatLength;
     pTrack->setCuePoint(cuePos);
 
     loadTrack(pTrack);
@@ -340,8 +340,6 @@ TEST_F(CueControlTest, FollowCueOnQuantize) {
     ProcessBuffer();
     EXPECT_DOUBLE_EQ(quantizedCuePos, m_pCuePoint->get());
     EXPECT_DOUBLE_EQ(0.0, getCurrentSample());
-
-
 }
 
 TEST_F(CueControlTest, IntroCue_SetStartEnd_ClearStartEnd) {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -702,6 +702,10 @@ void Track::setCuePoint(CuePosition cue) {
     emit cuesUpdated();
 }
 
+void Track::analysisFinished() {
+    emit analyzed();
+}
+
 CuePosition Track::getCuePoint() const {
     QMutexLocker lock(&m_qMutex);
     return m_record.getCuePoint();

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -248,6 +248,8 @@ class Track : public QObject {
     CuePosition getCuePoint() const;
     // Set the track's main cue point
     void setCuePoint(CuePosition cue);
+    // Call when analysis is done.
+    void analysisFinished();
 
     // Calls for managing the track's cue points
     CuePointer createAndAddCue();
@@ -325,6 +327,7 @@ class Track : public QObject {
     void keysUpdated();
     void ReplayGainUpdated(mixxx::ReplayGain replayGain);
     void cuesUpdated();
+    void analyzed();
 
     void changed(TrackId trackId);
     void dirty(TrackId trackId);


### PR DESCRIPTION
This PR fixes https://bugs.launchpad.net/mixxx/+bug/1855321.

The code I removed (or its functionality) should only be executed when a track is loaded and not when its hot cues or other cue points are updated. Even if we are at playposition 0:00 and change a cue point this is not equivalent to a track load.

Checked if jumping to main cue, intro start, and track start still work as before -> yes they do.