### PR TITLE
WColorPicker: always show custom color button

### DIFF
--- a/src/widget/wcolorpicker.cpp
+++ b/src/widget/wcolorpicker.cpp
@@ -102,10 +102,8 @@ void WColorPicker::addColorButtons() {
     int column = 0;
 
     int numColors = m_palette.size();
+    numColors++; // for custom color button
     if (m_options.testFlag(Option::AllowNoColor)) {
-        numColors++;
-    }
-    if (m_options.testFlag(Option::AllowCustomColor)) {
         numColors++;
     }
 
@@ -124,10 +122,8 @@ void WColorPicker::addColorButtons() {
         }
     }
 
-    if (m_options.testFlag(Option::AllowCustomColor)) {
-        addCustomColorButton(pLayout, row, column);
-        column++;
-    }
+    addCustomColorButton(pLayout, row, column);
+    column++;
 }
 
 void WColorPicker::addColorButton(mixxx::RgbColor color, QGridLayout* pLayout, int row, int column) {

--- a/src/widget/wcolorpicker.h
+++ b/src/widget/wcolorpicker.h
@@ -15,7 +15,6 @@ class WColorPicker : public QWidget {
     enum class Option {
         NoOptions = 0,
         AllowNoColor = 1,
-        AllowCustomColor = 1 << 1,
     };
     Q_DECLARE_FLAGS(Options, Option);
 


### PR DESCRIPTION
There's no need to hide the custom color button. It is useful anywhere a color can be picked. Following discussion from #2557.

This reveals a bug with the styling. Sometimes the custom color button shows a black background. Steps to reproduce:
1. set a color of a hotcue from the palette (not the custom color button)
2. change the color of that hotcue using the custom color button to select a color outside the palette
3. open the cue menu again. The custom color button only shows the gradient while the mouse is held down

Any hints what might be going wrong here would be appreciated. The styling is done in `res/skins/default.qss`

I propose to target this for 2.3. There is no need to block the beta release for this.
![image](https://user-images.githubusercontent.com/9455094/77490816-04f33f00-6e0a-11ea-9bbd-e4326786a639.png)
