### PR TITLE
let controllers clear the searchbox

### DIFF
--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -246,6 +246,7 @@ void Library::bindSearchboxWidget(WSearchLineEdit* pSearchboxWidget) {
             pSearchboxWidget,
             &WSearchLineEdit::slotSetFont);
     emit setTrackTableFont(m_trackTableFont);
+    m_pLibraryControl->bindSearchboxWidget(pSearchboxWidget);
 }
 
 void Library::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -11,6 +11,7 @@
 #include "mixer/playermanager.h"
 #include "widget/wlibrary.h"
 #include "widget/wlibrarysidebar.h"
+#include "widget/wsearchlineedit.h"
 #include "widget/wtracktableview.h"
 #include "library/library.h"
 #include "library/libraryview.h"
@@ -55,6 +56,7 @@ LibraryControl::LibraryControl(Library* pLibrary)
           m_pLibrary(pLibrary),
           m_pLibraryWidget(nullptr),
           m_pSidebarWidget(nullptr),
+          m_pSearchbox(nullptr),
           m_numDecks("[Master]", "num_decks", this),
           m_numSamplers("[Master]", "num_samplers", this),
           m_numPreviewDecks("[Master]", "num_preview_decks", this) {
@@ -325,12 +327,33 @@ void LibraryControl::bindLibraryWidget(WLibrary* pLibraryWidget, KeyboardEventFi
             &LibraryControl::libraryWidgetDeleted);
 }
 
+void LibraryControl::bindSearchboxWidget(WSearchLineEdit* pSearchbox) {
+    if (m_pSearchbox) {
+        disconnect(m_pSearchbox, 0, this, 0);
+    }
+    m_pSearchbox = pSearchbox;
+    connect(this,
+            &LibraryControl::clearSearch,
+            m_pSearchbox,
+            &WSearchLineEdit::clearSearch);
+    connect(m_pSearchbox,
+            &WSearchLineEdit::destroyed,
+            this,
+            &LibraryControl::libraryWidgetDeleted);
+}
+
+
+
 void LibraryControl::libraryWidgetDeleted() {
     m_pLibraryWidget = nullptr;
 }
 
 void LibraryControl::sidebarWidgetDeleted() {
     m_pSidebarWidget = nullptr;
+}
+
+void LibraryControl::searchboxWidgetDeleted() {
+    m_pSearchbox = nullptr;
 }
 
 void LibraryControl::slotLoadSelectedTrackToGroup(QString group, bool play) {
@@ -568,23 +591,38 @@ void LibraryControl::slotToggleSelectedSidebarItem(double v) {
 }
 
 void LibraryControl::slotGoToItem(double v) {
-    if (!m_pLibraryWidget) {
+    if (v <= 0) {
         return;
     }
-    // Load current track if a LibraryView object has focus
-    const auto activeView = m_pLibraryWidget->getActiveView();
-    if (activeView && activeView->hasFocus()) {
-        return slotLoadSelectedIntoFirstStopped(v);
+    VERIFY_OR_DEBUG_ASSERT(m_pSidebarWidget) {
+        return;
+    }
+    VERIFY_OR_DEBUG_ASSERT(m_pLibraryWidget) {
+        return;
+    }
+    VERIFY_OR_DEBUG_ASSERT(m_pSearchbox) {
+        return;
     }
 
     // Focus the library if this is a leaf node in the tree
-    if (m_pSidebarWidget && m_pSidebarWidget->hasFocus()) {
-        if (v > 0 && m_pSidebarWidget->isLeafNodeSelected()) {
-            setLibraryFocus();
+    if (m_pSidebarWidget->hasFocus()) {
+        // ToDo can't expand Tracks and AutoDJ, always returns false for those root items
+        if (m_pSidebarWidget->isLeafNodeSelected()) {
+            return setLibraryFocus();
         } else {
             // Otherwise toggle the sidebar item expanded state
             slotToggleSelectedSidebarItem(v);
         }
+    }
+
+    // Load current track if a LibraryView object has focus
+    if (m_pLibraryWidget->hasFocus()) {
+        return slotLoadSelectedIntoFirstStopped(v);
+    }
+
+    // Clear the search if the searchbox has focus
+    if (m_pSearchbox->clearBtnHasFocus()) {
+        return emit clearSearch();
     }
     // TODO(xxx) instead of remote control the widgets individual, we should
     // translate this into Alt+Return and handle it at each library widget

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -13,6 +13,7 @@ class Library;
 class LibraryControl;
 class WLibrary;
 class WLibrarySidebar;
+class WSearchLineEdit;
 class KeyboardEventFilter;
 
 class LoadToGroupController : public QObject {
@@ -42,6 +43,10 @@ class LibraryControl : public QObject {
 
     void bindLibraryWidget(WLibrary* pLibrary, KeyboardEventFilter* pKeyboard);
     void bindSidebarWidget(WLibrarySidebar* pLibrarySidebar);
+    void bindSearchboxWidget(WSearchLineEdit* pSearchbox);
+
+  signals:
+    void clearSearch();
 
   public slots:
     // Deprecated navigation slots
@@ -50,6 +55,7 @@ class LibraryControl : public QObject {
   private slots:
     void libraryWidgetDeleted();
     void sidebarWidgetDeleted();
+    void searchboxWidgetDeleted();
 
     void slotMoveUp(double);
     void slotMoveDown(double);
@@ -154,6 +160,7 @@ class LibraryControl : public QObject {
     // Library widgets
     WLibrary* m_pLibraryWidget;
     WLibrarySidebar* m_pSidebarWidget;
+    WSearchLineEdit* m_pSearchbox;
 
     // Other variables
     ControlProxy m_numDecks;

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -72,6 +72,9 @@ WSearchLineEdit::WSearchLineEdit(QWidget* pParent)
             this,
             &WSearchLineEdit::clearSearch);
 
+    // This prevents the searchbox from being focused by Tab key (real or emulated)
+    // so it is skipped when using the library controls 'MoveFocus[...]'
+    // The Clear button can still be focused by Tab.
     setFocusPolicy(Qt::ClickFocus);
     QShortcut* setFocusShortcut = new QShortcut(QKeySequence(tr("Ctrl+F", "Search|Focus")), this);
     connect(setFocusShortcut,
@@ -302,6 +305,11 @@ bool WSearchLineEdit::event(QEvent* pEvent) {
         updateTooltip();
     }
     return QLineEdit::event(pEvent);
+}
+
+// slot
+bool WSearchLineEdit::clearBtnHasFocus() const {
+    return m_clearButton->hasFocus();
 }
 
 // slot

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -45,12 +45,13 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
     void restoreSearch(const QString& text);
     void disableSearch();
     void slotSetFont(const QFont& font);
+    bool clearBtnHasFocus() const;
+    void clearSearch();
 
   private slots:
     void setShortcutFocus();
     void updateText(const QString& text);
 
-    void clearSearch();
     void triggerSearch();
 
   private:


### PR DESCRIPTION
When the searchbox' Clear button has focus [Library,GoToItem] would clear the search and move the focus to the treeview, exactly like when triggering it with the keyboard (Space bar).

The only change that makes this looking complex is that we now check `if (v > 0) {` for all GoToItem actions, not only for those addressing the sidebar widget.