### PR TITLE
disallow focusing library feature buttons with Tab

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -228,7 +228,8 @@
 }
 
 #LibraryContainer QTableView:focus,
-#LibraryContainer QTreeView:focus {
+#LibraryContainer QTreeView:focus,
+#LibraryContainer QTextBrowser:focus {
   border: 1px solid #FF6600;
 }
 

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -2040,7 +2040,8 @@ WLibrary,
 }
 
 #LibraryContainer QTableView:focus,
-#LibraryContainer QTreeView:focus {
+#LibraryContainer QTreeView:focus,
+#LibraryContainer QTextBrowser:focus {
   border: 1px solid #ff6600;
 }
 

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -493,8 +493,9 @@ WSearchLineEdit {
   Defined by SearchBox	*/
   margin: 0px;
   }
+  #LibraryContainer QTableView:focus,
   #LibraryContainer QTreeView:focus,
-  #LibraryContainer QTableView:focus { /*
+  #LibraryContainer QTextBrowser:focus { /*
     New Library navigation COs only work if TreeView or TableView have focus.
     Clicking on buttons, sliders and visuals elsewhere removes focus from Library.
     In conjunction with [Library],MoveFocusBackward/..Forward, this helps a lot. */

--- a/res/skins/Shade/style_dark.qss
+++ b/res/skins/Shade/style_dark.qss
@@ -94,7 +94,8 @@ WCoverArtMenu::item {
 
 
 #LibraryContainer QTableView:focus,
-#LibraryContainer QTreeView:focus {
+#LibraryContainer QTreeView:focus,
+#LibraryContainer QTextBrowser:focus {
   border: 1px solid #78C70B;
 }
 

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -2415,8 +2415,9 @@ WCoverArtMenu::item:!enabled,
   Shift WSearchLineEdit instead */
   margin: 0px;
   }
+  #LibraryContainer QTableView:focus,
   #LibraryContainer QTreeView:focus,
-  #LibraryContainer QTableView:focus { /*
+  #LibraryContainer QTextBrowser:focus { /*
     New Library navigation COs only work if TreeView or TableView have focus.
     Clicking on buttons, sliders and visuals elsewhere removes focus from Library.
     In conjunction with [Library],MoveFocusBackward/..Forward, some highlight

--- a/src/library/autodj/dlgautodj.ui
+++ b/src/library/autodj/dlgautodj.ui
@@ -48,6 +48,9 @@
      </property>
      <item>
       <widget class="QPushButton" name="pushButtonAutoDJ">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -77,6 +80,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="pushButtonFadeNow">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -87,6 +93,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="pushButtonSkipNext">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -99,10 +108,17 @@
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="fadeModeCombobox"/>
+      <widget class="QComboBox" name="fadeModeCombobox">
+       <property name="focusPolicy">
+        <enum>Qt::ClickFocus</enum>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QSpinBox" name="spinBoxTransition">
+       <property name="focusPolicy">
+        <enum>Qt::ClickFocus</enum>
+       </property>
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -145,6 +161,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="pushButtonShuffle">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -158,6 +177,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="pushButtonAddRandom">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -168,6 +190,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="pushButtonRepeatPlaylist">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
          <horstretch>0</horstretch>

--- a/src/library/dlganalysis.ui
+++ b/src/library/dlganalysis.ui
@@ -48,6 +48,9 @@
      </property>
      <item>
       <widget class="QRadioButton" name="radioButtonRecentlyAdded">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
        <property name="toolTip">
         <string>Shows tracks added to the library within the last 7 days.</string>
        </property>
@@ -58,6 +61,9 @@
      </item>
      <item>
       <widget class="QRadioButton" name="radioButtonAllSongs">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
        <property name="toolTip">
         <string>Shows all tracks in the library.</string>
        </property>
@@ -68,6 +74,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="pushButtonSelectAll">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
        <property name="toolTip">
         <string>Selects all tracks in the table below.</string>
        </property>
@@ -78,6 +87,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="pushButtonAnalyze">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
        <property name="toolTip">
         <string>Runs beatgrid, key, and ReplayGain detection on the selected tracks. Does not generate waveforms for the selected tracks to save disk space.</string>
        </property>

--- a/src/library/dlghidden.ui
+++ b/src/library/dlghidden.ui
@@ -48,6 +48,9 @@
      </property>
      <item>
       <widget class="QPushButton" name="btnSelect">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
        <property name="toolTip">
         <string>Selects all tracks in the table below.</string>
        </property>
@@ -58,6 +61,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="btnPurge">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
        <property name="toolTip">
         <string>Purge selected tracks from the library.</string>
        </property>
@@ -71,6 +77,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="btnUnhide">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
        <property name="toolTip">
         <string>Unhide selected tracks from the library.</string>
        </property>

--- a/src/library/dlgmissing.ui
+++ b/src/library/dlgmissing.ui
@@ -48,6 +48,9 @@
      </property>
      <item>
       <widget class="QPushButton" name="btnSelect">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
        <property name="toolTip">
         <string>Selects all tracks in the table below.</string>
        </property>
@@ -58,6 +61,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="btnPurge">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
        <property name="toolTip">
         <string>Purge selected tracks from the library.</string>
        </property>

--- a/src/library/recording/dlgrecording.ui
+++ b/src/library/recording/dlgrecording.ui
@@ -48,6 +48,9 @@
      </property>
      <item>
       <widget class="QPushButton" name="pushButtonRecording">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
        <property name="text">
         <string>Start Recording</string>
        </property>


### PR DESCRIPTION
Library feature buttons in Recording, AutoDJ, Analysis, Hidden or Missing accept click focus only, not from `Tab` key or `[Library]MoveFocus...` (emulated Tab).
Now it's easier to navigate the library with Tab as you don't have to tab through a row of feature buttons anymore to jump from the tree to the tracks tables and back.
There's no point in having those buttons focused as there's no way to trigger them, neither from keyboard or controllers. For AutoDJ and Recording there are keyboard shortcuts.

I added a focus border to WTextBrowser (library feature root view) so that it's always clear which part of the library is focused (links like Create New Playlist can still be selected).