### PR TITLE
fix library navigation & focus issues

### DIFF
--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -356,5 +356,5 @@ void DlgAutoDJ::updateSelectionInfo() {
 }
 
 bool DlgAutoDJ::hasFocus() const {
-    return QWidget::hasFocus();
+    return m_pTrackTableView->hasFocus();
 }

--- a/src/library/dlganalysis.cpp
+++ b/src/library/dlganalysis.cpp
@@ -97,7 +97,7 @@ void DlgAnalysis::onShow() {
 }
 
 bool DlgAnalysis::hasFocus() const {
-    return QWidget::hasFocus();
+    return m_pAnalysisLibraryTableView->hasFocus();
 }
 
 void DlgAnalysis::onSearch(const QString& text) {

--- a/src/library/dlghidden.cpp
+++ b/src/library/dlghidden.cpp
@@ -112,5 +112,5 @@ void DlgHidden::selectionChanged(const QItemSelection &selected,
 }
 
 bool DlgHidden::hasFocus() const {
-    return QWidget::hasFocus();
+    return m_pTrackTableView->hasFocus();
 }

--- a/src/library/dlgmissing.cpp
+++ b/src/library/dlgmissing.cpp
@@ -81,5 +81,5 @@ void DlgMissing::selectionChanged(const QItemSelection &selected,
 }
 
 bool DlgMissing::hasFocus() const {
-    return QWidget::hasFocus();
+    return m_pTrackTableView->hasFocus();
 }

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -473,7 +473,7 @@ void LibraryControl::slotMoveFocus(double v) {
 }
 
 void LibraryControl::emitKeyEvent(QKeyEvent&& event) {
-    // Ensure a valid library widget has the keyboard focus.
+    // Ensure there's a valid library widget that can receive keyboard focus.
     // QApplication::focusWidget() is not sufficient here because it
     // would return any focused widget like WOverview, WWaveform, QSpinBox
     VERIFY_OR_DEBUG_ASSERT(m_pSidebarWidget) {
@@ -482,14 +482,25 @@ void LibraryControl::emitKeyEvent(QKeyEvent&& event) {
     VERIFY_OR_DEBUG_ASSERT(m_pLibraryWidget) {
         return;
     }
-    if (!m_pLibraryWidget->hasFocus() && !m_pSidebarWidget->hasFocus()) {
-        setLibraryFocus();
-    }
-    auto focusWidget = QApplication::focusWidget();
-    VERIFY_OR_DEBUG_ASSERT(focusWidget) {
+    if (!QApplication::focusWindow()) {
+        qDebug() << "Mixxx window is not focused, don't send key events";
         return;
     }
+
+    bool keyIsTab = event.key() == static_cast<int>(Qt::Key_Tab);
+
+    // If the main window has focus, any widget can receive Tab.
+    // Other keys should be sent to library widgets only to not
+    // accidentally alter spinboxes etc.
+    if (!keyIsTab && !m_pSidebarWidget->hasFocus()
+            && !m_pLibraryWidget->getActiveView()->hasFocus()) {
+        setLibraryFocus();
+    }
+    if (keyIsTab && !QApplication::focusWidget()){
+        setLibraryFocus();
+    }
     // Send the event pointer to the currently focused widget
+    auto focusWidget = QApplication::focusWidget();
     for (auto i = 0; i < event.count(); ++i) {
         QApplication::sendEvent(focusWidget, &event);
     }
@@ -563,8 +574,8 @@ void LibraryControl::slotGoToItem(double v) {
             slotToggleSelectedSidebarItem(v);
         }
     }
-    // TODO(xxx) instead of remote control the widgets individual, we should 
-    // translate this into Alt+Return and handle it at each library widget 
+    // TODO(xxx) instead of remote control the widgets individual, we should
+    // translate this into Alt+Return and handle it at each library widget
     // individual https://bugs.launchpad.net/mixxx/+bug/1758618
     //emitKeyEvent(QKeyEvent{QEvent::KeyPress, Qt::Key_Return, Qt::AltModifier});
 }

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -90,7 +90,7 @@ void DlgRecording::onShow() {
 }
 
 bool DlgRecording::hasFocus() const {
-    return QWidget::hasFocus();
+    return m_pTrackTableView->hasFocus();
 }
 
 void DlgRecording::refreshBrowseModel() {


### PR DESCRIPTION
These fixes are supposed to make the controller navigation (Up, Down, MoveFocus) behave exactly like using Up, Down and Tab on a keyboard.

See: [hints for testing this](https://github.com/mixxxdj/mixxx/pull/2599#issuecomment-608424968)

**fix `WLibrary->getActiveView()->hasFocus()`**
in DlgRecording, DlgAutoDJ, DlgAnalysis, DlgHidden and DlgMissing to prevent unnecessary calls to `setLibraryFocus()` before issuing any `[Library],Move...` command

**rework LibraryControl::emitKeyEvent()**
Any widget can receive `Tab`, but don't send key events if Mixxx isn't focused.

This also prevents lib focus getting stuck at Clear button:
In master, the focus can be moved to the Clear button with [Library],MoveFocus[Backward, Forward] (when there is an active search), but then, MoveFocusForward would do nothing because behind the scenes library control tests if the sidebar or tracks table have focus; if false it would try to re-focus the tracks table: focus the sidebar > emulate Tab > then send the MoveFocus Tab = we end up at the Clear button again. 
With MoveFocus, -1 it would previously jump between sidebar and Clear button.