### PR TITLE
CMake: Fix PortAudio package warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1319,8 +1319,8 @@ target_link_libraries(mixxx-lib PUBLIC ${OggVorbis_LIBRARIES})
 
 # PortAudio
 find_package(PortAudio REQUIRED)
-target_include_directories(mixxx-lib SYSTEM PUBLIC ${PORTAUDIO_INCLUDE_DIRS})
-target_link_libraries(mixxx-lib PUBLIC ${PORTAUDIO_LIBRARIES})
+target_include_directories(mixxx-lib SYSTEM PUBLIC ${PortAudio_INCLUDE_DIRS})
+target_link_libraries(mixxx-lib PUBLIC ${PortAudio_LIBRARIES})
 
 # PortAudio Ring Buffer
 add_library(PortAudioRingBuffer STATIC EXCLUDE_FROM_ALL

--- a/cmake/modules/FindPortAudio.cmake
+++ b/cmake/modules/FindPortAudio.cmake
@@ -1,26 +1,26 @@
 # - Try to find Portaudio
 # Once done this will define
 #
-#  PORTAUDIO_FOUND - system has Portaudio
-#  PORTAUDIO_INCLUDE_DIRS - the Portaudio include directory
-#  PORTAUDIO_LIBRARIES - Link these to use Portaudio
+#  PortAudio_FOUND - system has Portaudio
+#  PortAudio_INCLUDE_DIRS - the Portaudio include directory
+#  PortAudio_LIBRARIES - Link these to use Portaudio
 
 find_package(PkgConfig QUIET)
 if(PkgConfig_FOUND)
-  pkg_check_modules(PC_PORTAUDIO portaudio-2.0)
+  pkg_check_modules(PC_PortAudio portaudio-2.0)
 endif()
 
-find_path(PORTAUDIO_INCLUDE_DIRS
+find_path(PortAudio_INCLUDE_DIRS
   NAMES
     portaudio.h
   PATHS
       /usr/local/include
       /usr/include
   HINTS
-    ${PC_PORTAUDIO_INCLUDEDIR}
+    ${PC_PortAudio_INCLUDEDIR}
 )
 
-find_library(PORTAUDIO_LIBRARIES
+find_library(PortAudio_LIBRARIES
   NAMES
     portaudio
   PATHS
@@ -28,27 +28,27 @@ find_library(PORTAUDIO_LIBRARIES
       /usr/lib
       /usr/lib64
   HINTS
-    ${PC_PORTAUDIO_LIBDIR}
+    ${PC_PortAudio_LIBDIR}
 )
 
-mark_as_advanced(PORTAUDIO_INCLUDE_DIRS PORTAUDIO_LIBRARIES)
+mark_as_advanced(PortAudio_INCLUDE_DIRS PortAudio_LIBRARIES)
 
-# Found PORTAUDIO, but it may be version 18 which is not acceptable.
-if(EXISTS ${PORTAUDIO_INCLUDE_DIRS}/portaudio.h)
+# Found PortAudio, but it may be version 18 which is not acceptable.
+if(EXISTS ${PortAudio_INCLUDE_DIRS}/portaudio.h)
   include(CheckCXXSourceCompiles)
   set(CMAKE_REQUIRED_INCLUDES_SAVED ${CMAKE_REQUIRED_INCLUDES})
-  set(CMAKE_REQUIRED_INCLUDES ${PORTAUDIO_INCLUDE_DIRS})
+  set(CMAKE_REQUIRED_INCLUDES ${PortAudio_INCLUDE_DIRS})
   CHECK_CXX_SOURCE_COMPILES(
     "#include <portaudio.h>\nPaDeviceIndex pa_find_device_by_name(const char *name); int main () {return 0;}"
-    PORTAUDIO2_FOUND)
+    PortAudio2_FOUND)
   set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES_SAVED})
   unset(CMAKE_REQUIRED_INCLUDES_SAVED)
-  if(PORTAUDIO2_FOUND)
+  if(PortAudio2_FOUND)
     INCLUDE(FindPackageHandleStandardArgs)
-    FIND_PACKAGE_HANDLE_STANDARD_ARGS(PORTAUDIO DEFAULT_MSG PORTAUDIO_INCLUDE_DIRS PORTAUDIO_LIBRARIES)
-  else(PORTAUDIO2_FOUND)
+    FIND_PACKAGE_HANDLE_STANDARD_ARGS(PortAudio DEFAULT_MSG PortAudio_INCLUDE_DIRS PortAudio_LIBRARIES)
+  else(PortAudio2_FOUND)
     message(STATUS
       "  portaudio.h not compatible (requires API 2.0)")
-    set(PORTAUDIO_FOUND FALSE)
-  endif(PORTAUDIO2_FOUND)
+    set(PortAudio_FOUND FALSE)
+  endif(PortAudio2_FOUND)
 endif()


### PR DESCRIPTION
This fixes a CMake 3.17.0 complaint about the variable naming in our
CMake module for PortAudio detection:

    CMake Warning (dev) at /usr/share/cmake-3.17/Modules/FindPackageHandleStandardArgs.cmake:272 (message):
      The package name passed to `find_package_handle_standard_args` (PORTAUDIO)
      does not match the name of the calling package (PortAudio).  This can lead
      to problems in calling code that expects `find_package` result variables
      (e.g., `_FOUND`) to follow a certain pattern.
    Call Stack (most recent call first):
      cmake/modules/FindPortAudio.cmake:48 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
      CMakeLists.txt:1321 (find_package)
    This warning is for project developers.  Use -Wno-dev to suppress it.