### PR TITLE
pre-commit: Install clang-format dependency automatically

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,16 +71,19 @@ repos:
     stages:
     - commit
     - manual
-- repo: git://github.com/doublify/pre-commit-clang-format
-  rev: master
+- repo: local
   hooks:
   - id: clang-format
+    name: clang-format
     entry: git clang-format
-    args: []
     require_serial: true
     stages:
     - commit
     - manual
+    language: python
+    files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|mm|proto|vert)$
+    additional_dependencies:
+    - clang-format
 -   repo: https://github.com/psf/black
     rev: stable
     hooks:


### PR DESCRIPTION
Should fix: https://github.com/mixxxdj/mixxx/pull/2464#issuecomment-604561887