### PR TITLE
DlgTrackInfo: Show "Summary" instead of "BPM" upon opening

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -44,9 +44,9 @@ void DlgTrackInfo::init() {
 
     connect(btnNext, &QPushButton::clicked, this, &DlgTrackInfo::slotNext);
     connect(btnPrev, &QPushButton::clicked, this, &DlgTrackInfo::slotPrev);
-    connect(btnApply, &QPushButton::clicked, this, &DlgTrackInfo::apply);
-    connect(btnOK, &QPushButton::clicked, this, &DlgTrackInfo::OK);
-    connect(btnCancel, &QPushButton::clicked, this, &DlgTrackInfo::cancel);
+    connect(btnApply, &QPushButton::clicked, this, &DlgTrackInfo::slotApply);
+    connect(btnOK, &QPushButton::clicked, this, &DlgTrackInfo::slotOk);
+    connect(btnCancel, &QPushButton::clicked, this, &DlgTrackInfo::slotCancel);
 
     connect(bpmDouble,
             &QPushButton::clicked,
@@ -115,7 +115,7 @@ void DlgTrackInfo::init() {
             &DlgTrackInfo::slotOpenInFileBrowser);
 
     CoverArtCache* pCache = CoverArtCache::instance();
-    if (pCache != nullptr) {
+    if (pCache) {
         connect(pCache,
                 &CoverArtCache::coverFound,
                 this,
@@ -131,16 +131,16 @@ void DlgTrackInfo::init() {
             &DlgTrackInfo::slotReloadCoverArt);
 }
 
-void DlgTrackInfo::OK() {
+void DlgTrackInfo::slotOk() {
     unloadTrack(true);
     accept();
 }
 
-void DlgTrackInfo::apply() {
+void DlgTrackInfo::slotApply() {
     saveTrack();
 }
 
-void DlgTrackInfo::cancel() {
+void DlgTrackInfo::slotCancel() {
     unloadTrack(false);
     reject();
 }

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -34,9 +34,10 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
   private slots:
     void slotNext();
     void slotPrev();
-    void OK();
-    void apply();
-    void cancel();
+    void slotOk();
+    void slotApply();
+    void slotCancel();
+
     void trackUpdated();
 
     void slotBpmDouble();

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -41,7 +41,7 @@
       </size>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tabSummary">
       <attribute name="title">


### PR DESCRIPTION
When opening the DlgTrackInfo dialog first the _BPM_ tab is shown instead of the _Summary_. This behavior is inconvenient and confusing.

Most BPM controls are directly accessible from the track context menu. If you open the properties dialog you usually want to see and edit the metadata of the track instead of accessing the BPM controls.

The actual change affects a single line in the .ui file.