### PR TITLE
added udev rule for AlphaTheta devices

### DIFF
--- a/res/linux/mixxx-usb-uaccess.rules
+++ b/res/linux/mixxx-usb-uaccess.rules
@@ -34,6 +34,8 @@ SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="17cc", TAG+="uac
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="057e", TAG+="uaccess"
 # Pioneer Corp.
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="08e4", TAG+="uaccess"
+# AlphaTheta Corp.
+SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="2b73", TAG+="uaccess"
 # Rane
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="13e5", TAG+="uaccess"
 # Reloop


### PR DESCRIPTION
Newer Pioneer Devices (such as the CDJ-2000NXS2) have a vendor ID of `2b73`.
I'm not sure whether this is sufficient or if there are other files that have to be tweaked for other OSes as well.