### PR TITLE
restore: no play when passthrough is enabled

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -619,7 +619,7 @@ bool EngineBuffer::updateIndicatorsAndModifyPlay(bool newPlay) {
     if ((!m_pCurrentTrack && atomicLoadRelaxed(m_iTrackLoading) == 0) ||
             (m_pCurrentTrack && atomicLoadRelaxed(m_iTrackLoading) == 0 &&
              m_filepos_play >= m_pTrackSamples->get() &&
-             !atomicLoadRelaxed(m_iSeekQueued))) {
+             !atomicLoadRelaxed(m_iSeekQueued)) || m_pPassthroughEnabled->toBool()) {
         // play not possible
         playPossible = false;
     }


### PR DESCRIPTION
Any `play` request is rejected if passthrough is enabled on deck (cue/hotcue activate, play_from_start etc.)

quick fix for https://bugs.launchpad.net/mixxx/+bug/1869985, _probably_ a regression from #2474 