### PR TITLE
show Passthrough cover on track overview

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -819,6 +819,13 @@ WOverview {
   text-transform: none;
 }
 
+/* Passthrough label on overview waveform */
+WOverview #PassthroughLabel {
+  font-size: 16px;
+  font-weight: bold;
+  color: #73b3f7;
+}
+
 /* Start spacing for Deck overview row (small waveform, option grid) */
 #OptionGrid, #ButtonGrid {
   background-color: #333333;

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -262,6 +262,13 @@ WCoverArtMenu,
   #FxButtonLabel {
     qproperty-alignment: 'AlignLeft | AlignVCenter';
     }
+
+/* Passthrough label on overview waveform */
+WOverview #PassthroughLabel {
+  font-weight: bold;
+  color: #d09300;
+}
+
 /************** font colors **************************************************/
 /************** font settings *************************************************/
 

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -18,6 +18,13 @@ WOverview {
   font-family: "Ubuntu";
 }
 
+/* Passthrough label on overview waveform */
+WOverview #PassthroughLabel {
+  font-size: 12px;
+  font-weight: bold;
+  color: #55F764;
+}
+
 WBeatSpinBox,
 /* For some mysterious reason #DlgAutoDJ QSpinBox
 wouldn't style the respective spinbox in Shade (anymore),

--- a/res/skins/Shade/style_dark.qss
+++ b/res/skins/Shade/style_dark.qss
@@ -91,6 +91,11 @@ WCoverArtMenu::item {
   background-color: #3F3041;
 }
 
+/* Passthrough label on overview waveform */
+WOverview #PassthroughLabel {
+  color: #00aaff;
+}
+
 
 
 #LibraryContainer QTableView:focus,

--- a/res/skins/Shade/style_summer_sunset.qss
+++ b/res/skins/Shade/style_summer_sunset.qss
@@ -88,6 +88,11 @@ WCoverArtMenu::item {
   background-color: #706633;
 }
 
+/* Passthrough label on overview waveform */
+WOverview #PassthroughLabel {
+  color: #FF9900;
+}
+
 #DlgMissing > QPushButton:enabled,
 #DlgHidden > QPushButton:enabled,
 #DlgAutoDJ > QPushButton:enabled,

--- a/res/skins/Tango/deck_row_overview_left.xml
+++ b/res/skins/Tango/deck_row_overview_left.xml
@@ -33,46 +33,12 @@ Variables:
 
           <Template src="skin:vinyl_controls_left.xml"/>
 
-          <WidgetGroup><!-- Vinyl Controls toggles -->
-            <Size>15f,50f</Size>
-            <Layout>vertical</Layout>
-            <Children>
-              <WidgetGroup><!-- Vinyl Controls toggle with passthrough -->
-                <Size>15f,50f</Size>
-                <Layout>horizontal</Layout>
-                <Children>
-                  <Template src="skin:button_2state.xml">
-                    <SetVariable name="ObjectName">VinylTogglerLeftPassthrough</SetVariable>
-                    <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
-                    <SetVariable name="Size">15f,50f</SetVariable>
-                    <SetVariable name="ConfigKey">[Tango],vinylControlsDeck<Variable name="chanNum"/></SetVariable>
-                  </Template>
-                </Children>
-                <Connection>
-                  <ConfigKey><Variable name="group"/>,passthrough</ConfigKey>
-                  <BindProperty>visible</BindProperty>
-                </Connection>
-              </WidgetGroup>
-
-              <WidgetGroup><!-- Vinyl Controls toggle without passthrough -->
-                <Size>15f,50f</Size>
-                <Layout>horizontal</Layout>
-                <Children>
-                  <Template src="skin:button_2state.xml">
-                    <SetVariable name="ObjectName">VinylTogglerLeft</SetVariable>
-                    <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
-                    <SetVariable name="Size">15f,50f</SetVariable>
-                    <SetVariable name="ConfigKey">[Tango],vinylControlsDeck<Variable name="chanNum"/></SetVariable>
-                  </Template>
-                </Children>
-                <Connection>
-                  <ConfigKey><Variable name="group"/>,passthrough</ConfigKey>
-                  <Transform><Not/></Transform>
-                  <BindProperty>visible</BindProperty>
-                </Connection>
-              </WidgetGroup>
-            </Children>
-          </WidgetGroup><!-- /Vinyl Controls toggles -->
+          <Template src="skin:button_2state.xml">
+            <SetVariable name="ObjectName">VinylTogglerLeft</SetVariable>
+            <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
+            <SetVariable name="Size">15f,50f</SetVariable>
+            <SetVariable name="ConfigKey">[Tango],vinylControlsDeck<Variable name="chanNum"/></SetVariable>
+          </Template>
 
           <!-- Small Cover/Spinny when explicitly set 'small' -->
           <WidgetGroup>

--- a/res/skins/Tango/deck_row_overview_right.xml
+++ b/res/skins/Tango/deck_row_overview_right.xml
@@ -71,46 +71,12 @@ Variables:
             </Connection>
           </WidgetGroup><!-- / Small Cover/Spinny 2 -->
 
-          <WidgetGroup><!-- Vinyl Controls toggles -->
-            <Size>15f,50f</Size>
-            <Layout>vertical</Layout>
-            <Children>
-              <WidgetGroup><!-- Vinyl Controls toggle with passthrough -->
-                <Size>15f,50f</Size>
-                <Layout>horizontal</Layout>
-                <Children>
-                  <Template src="skin:button_2state.xml">
-                    <SetVariable name="ObjectName">VinylTogglerRightPassthrough</SetVariable>
-                    <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
-                    <SetVariable name="Size">15f,50f</SetVariable>
-                    <SetVariable name="ConfigKey">[Tango],vinylControlsDeck<Variable name="chanNum"/></SetVariable>
-                  </Template>
-                </Children>
-                <Connection>
-                  <ConfigKey><Variable name="group"/>,passthrough</ConfigKey>
-                  <BindProperty>visible</BindProperty>
-                </Connection>
-              </WidgetGroup>
-
-              <WidgetGroup><!-- Vinyl Controls toggle without passthrough -->
-                <Size>15f,50f</Size>
-                <Layout>horizontal</Layout>
-                <Children>
-                  <Template src="skin:button_2state.xml">
-                    <SetVariable name="ObjectName">VinylTogglerRight</SetVariable>
-                    <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
-                    <SetVariable name="Size">15f,50f</SetVariable>
-                    <SetVariable name="ConfigKey">[Tango],vinylControlsDeck<Variable name="chanNum"/></SetVariable>
-                  </Template>
-                </Children>
-                <Connection>
-                  <ConfigKey><Variable name="group"/>,passthrough</ConfigKey>
-                  <Transform><Not/></Transform>
-                  <BindProperty>visible</BindProperty>
-                </Connection>
-              </WidgetGroup>
-            </Children>
-          </WidgetGroup><!-- /Vinyl Controls toggles -->
+          <Template src="skin:button_2state.xml">
+            <SetVariable name="ObjectName">VinylTogglerLeft</SetVariable>
+            <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
+            <SetVariable name="Size">15f,50f</SetVariable>
+            <SetVariable name="ConfigKey">[Tango],vinylControlsDeck<Variable name="chanNum"/></SetVariable>
+          </Template>
 
           <WidgetGroup><ObjectName>Spacer0f</ObjectName><Size>1f,1min</Size></WidgetGroup>
 

--- a/res/skins/Tango/deck_row_transport_left.xml
+++ b/res/skins/Tango/deck_row_transport_left.xml
@@ -207,18 +207,6 @@ Variables:
             <Children>
               <!-- index 0 due to bug -->
               <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
-
-              <!-- Block Play button if passthrough is active,
-                  show speaker icon instead -->
-              <WidgetGroup>
-                <ObjectName>PassthroughPlayCover</ObjectName>
-                <Layout>vertical</Layout>
-                <SizePolicy>me,me</SizePolicy>
-                <Connection>
-                  <ConfigKey><Variable name="group"/>,passthrough</ConfigKey>
-                  <BindProperty>visible</BindProperty>
-                </Connection>
-              </WidgetGroup>
               <!-- Play -->
               <Template src="skin:button_2state_right_display.xml">
                 <SetVariable name="ObjectName">PlayCue</SetVariable>
@@ -276,26 +264,6 @@ Variables:
                 <Children>
                   <!-- index 0 due to bug -->
                   <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
-                  <!-- Block Play button if passthrough is active,
-                      show speaker icon instead -->
-                  <WidgetGroup>
-                    <ObjectName>PassthroughPlayCover</ObjectName>
-                    <Layout>vertical</Layout>
-                    <SizePolicy>me,me</SizePolicy>
-                    <Connection>
-                      <ConfigKey><Variable name="group"/>,passthrough</ConfigKey>
-                      <BindProperty>visible</BindProperty>
-                    </Connection>
-                  </WidgetGroup>
-                  <WidgetGroup>
-                    <ObjectName>Spacer33</ObjectName>
-                    <Layout>vertical</Layout>
-                    <SizePolicy>me,me</SizePolicy>
-                    <Connection>
-                      <ConfigKey><Variable name="group"/>,passthrough</ConfigKey>
-                      <BindProperty>visible</BindProperty>
-                    </Connection>
-                  </WidgetGroup>
                   <!-- Play -->
                   <Template src="skin:button_2state_right_display.xml">
                     <SetVariable name="ObjectName">PlayCue</SetVariable>

--- a/res/skins/Tango/deck_row_transport_right.xml
+++ b/res/skins/Tango/deck_row_transport_right.xml
@@ -24,26 +24,6 @@ Variables:
         <Children>
           <!-- index 0 due to bug -->
           <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
-          <!-- Block Play button if passthrough is active,
-              show speaker icon instead -->
-          <WidgetGroup>
-            <ObjectName>PassthroughPlayCover</ObjectName>
-            <Layout>vertical</Layout>
-            <SizePolicy>me,me</SizePolicy>
-            <Connection>
-              <ConfigKey><Variable name="group"/>,passthrough</ConfigKey>
-              <BindProperty>visible</BindProperty>
-            </Connection>
-          </WidgetGroup>
-          <WidgetGroup>
-            <ObjectName>Spacer33</ObjectName>
-            <Layout>vertical</Layout>
-            <SizePolicy>me,me</SizePolicy>
-            <Connection>
-              <ConfigKey><Variable name="group"/>,passthrough</ConfigKey>
-              <BindProperty>visible</BindProperty>
-            </Connection>
-          </WidgetGroup>
           <!-- Play -->
           <Template src="skin:button_2state_right_display.xml">
             <SetVariable name="ObjectName">PlayCue</SetVariable>
@@ -89,17 +69,6 @@ Variables:
             <Children>
               <!-- index 0 due to bug -->
               <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
-              <!-- Block Play button if passthrough is active,
-                  show speaker icon instead -->
-              <WidgetGroup>
-                <ObjectName>PassthroughPlayCover</ObjectName>
-                <Layout>vertical</Layout>
-                <SizePolicy>me,me</SizePolicy>
-                <Connection>
-                  <ConfigKey><Variable name="group"/>,passthrough</ConfigKey>
-                  <BindProperty>visible</BindProperty>
-                </Connection>
-              </WidgetGroup>
               <!-- Play -->
               <Template src="skin:button_2state_right_display.xml">
                 <SetVariable name="ObjectName">PlayCue</SetVariable>

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -2073,6 +2073,12 @@ WTrackProperty#SamplerTitle_mini {
  ######  Misc  ##################################################
 ##############################################################*/
 
+/* Passthrough label on overview waveform */
+WOverview #PassthroughLabel {
+  font-weight: bold;
+  color: #ff8f00;
+}
+
 QToolTip,
 #LibraryContainer QMenu,
 WBeatSpinBox QMenu,

--- a/res/skins/default.qss
+++ b/res/skins/default.qss
@@ -53,6 +53,15 @@ WColorPicker QPushButton[checked="true"] {
   qproperty-icon: url(:/images/ic_checkmark.svg);
 }
 
+/* Passthrough label on overview waveform */
+WOverview #PassthroughLabel {
+  margin-left: 4px;
+  font-family: "Open Sans";
+  font-weight: bold;
+  font-size: 18px;
+  color: #ff8800;
+}
+
 /* Clear button */
 #SearchClearButton {
   background: none;

--- a/src/waveform/renderers/waveformsignalcolors.cpp
+++ b/src/waveform/renderers/waveformsignalcolors.cpp
@@ -62,6 +62,14 @@ bool WaveformSignalColors::setup(const QDomNode &node, const SkinContext& contex
         m_playedOverlayColor = Qt::transparent;
     }
 
+    // This color is used to draw an overlay over the entire overview-waveforms
+    // if vinyl passthrough is enabled
+    m_passthroughOverlayColor = context.selectColor(node, "PassthroughOverlayColor");
+    m_passthroughOverlayColor = WSkinColor::getCorrectColor(m_passthroughOverlayColor).toRgb();
+    if (!m_passthroughOverlayColor.isValid()) {
+        m_passthroughOverlayColor = WSkinColor::getCorrectColor(QColor(187, 0, 0, 0)).toRgb();
+    }
+
     m_bgColor = context.selectColor(node, "BgColor");
     if (!m_bgColor.isValid()) {
         m_bgColor = Qt::transparent;

--- a/src/waveform/renderers/waveformsignalcolors.h
+++ b/src/waveform/renderers/waveformsignalcolors.h
@@ -23,6 +23,7 @@ class WaveformSignalColors {
     inline const QColor& getAxesColor() const { return m_axesColor; }
     inline const QColor& getPlayPosColor() const { return m_playPosColor; }
     inline const QColor& getPlayedOverlayColor() const { return m_playedOverlayColor; }
+    inline const QColor& getPassthroughOverlayColor() const { return m_passthroughOverlayColor; }
     inline const QColor& getBgColor() const { return m_bgColor; }
 
   protected:
@@ -42,6 +43,7 @@ class WaveformSignalColors {
     QColor m_axesColor;
     QColor m_playPosColor;
     QColor m_playedOverlayColor;
+    QColor m_passthroughOverlayColor;
     QColor m_bgColor;
 };
 

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -17,7 +17,6 @@
 #include <QMouseEvent>
 #include <QPaintEvent>
 #include <QPainter>
-#include <QPixmap>
 #include <QUrl>
 #include <QtDebug>
 
@@ -94,6 +93,18 @@ WOverview::WOverview(
             this, &WOverview::onTrackAnalyzerProgress);
 
     connect(m_pCueMenuPopup.get(), &WCueMenuPopup::aboutToHide, this, &WOverview::slotCueMenuPopupAboutToHide);
+
+    m_pPassthroughLabel = new QLabel(this);
+    m_pPassthroughLabel->setObjectName("PassthroughLabel");
+    m_pPassthroughLabel->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    // Shown on the overview waveform when vinyl passthrough is enabled
+    m_pPassthroughLabel->setText(tr("Passthrough"));
+    m_pPassthroughLabel->hide();
+    QVBoxLayout *pPassthroughLayout = new QVBoxLayout(this);
+    pPassthroughLayout->setContentsMargins(0,0,0,0);
+    pPassthroughLayout->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    pPassthroughLayout->addWidget(m_pPassthroughLabel);
+    setLayout(pPassthroughLayout);
 }
 
 void WOverview::setup(const QDomNode& node, const SkinContext& context) {
@@ -134,6 +145,8 @@ void WOverview::setup(const QDomNode& node, const SkinContext& context) {
         m_endOfTrackColor.setNamedColor(endOfTrackColorName);
         m_endOfTrackColor = WSkinColor::getCorrectColor(m_endOfTrackColor);
     }
+
+    m_passthroughOverlayColor = m_signalColors.getPlayedOverlayColor();
 
     // setup hotcues and cue and loop(s)
     m_marks.setup(m_group, node, context, m_signalColors);
@@ -242,11 +255,6 @@ void WOverview::onConnectedControlChanged(double dParameter, double dValue) {
 
 void WOverview::slotWaveformSummaryUpdated() {
     //qDebug() << "WOverview::slotWaveformSummaryUpdated()";
-
-    // Do not draw the waveform when passthrough is enabled
-    if (m_bPassthroughEnabled) {
-        return;
-    }
 
     TrackPointer pTrack(m_pCurrentTrack);
     if (!pTrack) {
@@ -563,11 +571,6 @@ void WOverview::paintEvent(QPaintEvent* pEvent) {
         painter.drawPixmap(rect(), m_backgroundPixmap);
     }
 
-    if (m_bPassthroughEnabled) {
-        paintText(tr("Passthrough"), &painter);
-        return;
-    }
-
     if (m_pCurrentTrack) {
         // Refer to util/ScopePainter.h to understand the semantics of
         // ScopePainter.
@@ -589,7 +592,15 @@ void WOverview::paintEvent(QPaintEvent* pEvent) {
             drawMarkLabels(&painter, offset, gain);
         }
     }
+
+    if (m_bPassthroughEnabled) {
+        drawPassthroughOverlay(&painter);
+        m_pPassthroughLabel->show();
+    } else {
+        m_pPassthroughLabel->hide();
+    }
 }
+
 void WOverview::drawEndOfTrackBackground(QPainter* pPainter) {
     if (m_endOfTrack) {
         PainterScope painterScope(pPainter);
@@ -1074,6 +1085,13 @@ void WOverview::drawMarkLabels(QPainter* pPainter, const float offset, const flo
                 markRange.m_durationLabel.draw(pPainter);
             }
         }
+    }
+}
+
+void WOverview::drawPassthroughOverlay(QPainter* pPainter) {
+    if (!m_waveformSourceImage.isNull() && m_passthroughOverlayColor.alpha() > 0) {
+        // Overlay the entire overview-waveform with a skin defined color
+        pPainter->fillRect(rect(), m_passthroughOverlayColor);
     }
 }
 

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -117,6 +117,7 @@ class WOverview : public WWidget, public TrackDropTarget {
     void drawPickupPosition(QPainter* pPainter);
     void drawTimeRuler(QPainter* pPainter);
     void drawMarkLabels(QPainter* pPainter, const float offset, const float gain);
+    void drawPassthroughOverlay(QPainter* pPainter);
     void paintText(const QString& text, QPainter* pPainter);
     double samplePositionToSeconds(double sample);
     inline int valueToPosition(double value) const {
@@ -170,6 +171,8 @@ class WOverview : public WWidget, public TrackDropTarget {
     QColor m_labelTextColor;
     QColor m_labelBackgroundColor;
     QColor m_endOfTrackColor;
+    QColor m_passthroughOverlayColor;
+    QLabel* m_pPassthroughLabel;
 
     // All WaveformMarks
     WaveformMarkSet m_marks;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5934199/78095467-5afe4e80-73d7-11ea-939d-8418222374bc.png)

Inspired by #2575 

Show passthrough cover over entire overview, picks color from `<PassthroughOverlayColor>` node.
Stack _Passthrough_ label on top, accepts custom styles via qss: `WOverview #PassthroughLabel`.
All mouse events are still passed to the overview.

I added the `PassthroughOverlayColor` picker to /waveform/renderers/waveformsignalcolors.cpp, I guess it can also be used for the scrolling waveform then?

- [x] add styles to all skins
- [x] add default color to C++?
