### PR TITLE
 Check for overwrite when defaulting to m3u in playlist/crate export

### DIFF
--- a/src/library/baseplaylistfeature.cpp
+++ b/src/library/baseplaylistfeature.cpp
@@ -535,21 +535,10 @@ void BasePlaylistFeature::slotExportPlaylist() {
             QModelIndex index = pPlaylistTableModel->index(i, 0);
             playlist_items << pPlaylistTableModel->getTrackLocation(index);
         }
-
-        if (file_location.endsWith(".pls", Qt::CaseInsensitive)) {
-            ParserPls::writePLSFile(file_location, playlist_items, useRelativePath);
-        } else if (file_location.endsWith(".m3u8", Qt::CaseInsensitive)) {
-            ParserM3u::writeM3U8File(file_location, playlist_items, useRelativePath);
-        } else {
-            //default export to M3U if file extension is missing
-            if(!file_location.endsWith(".m3u", Qt::CaseInsensitive))
-            {
-                qDebug() << "Crate export: No valid file extension specified. Appending .m3u "
-                         << "and exporting to M3U.";
-                file_location.append(".m3u");
-            }
-            ParserM3u::writeM3UFile(file_location, playlist_items, useRelativePath);
-        }
+        exportPlaylistItemsIntoFile(
+                file_location,
+                playlist_items,
+                useRelativePath);
     }
 }
 

--- a/src/library/baseplaylistfeature.cpp
+++ b/src/library/baseplaylistfeature.cpp
@@ -486,15 +486,7 @@ void BasePlaylistFeature::slotExportPlaylist() {
     if (file_location.isNull() || file_location.isEmpty()) {
         return;
     }
-    // Manually add extension due to bug in QFileDialog
-    // via https://bugreports.qt-project.org/browse/QTBUG-27186
-    // Can be removed after switch to Qt5
     QFileInfo fileName(file_location);
-    if (fileName.suffix().isNull() || fileName.suffix().isEmpty()) {
-        QString ext = filefilter.section(".",1,1);
-        ext.chop(1);
-        file_location.append(".").append(ext);
-    }
     // Update the import/export playlist directory
     m_pConfig->set(ConfigKey("[Library]","LastImportExportPlaylistDirectory"),
                 ConfigValue(fileName.dir().absolutePath()));

--- a/src/library/crate/cratefeature.cpp
+++ b/src/library/crate/cratefeature.cpp
@@ -703,21 +703,10 @@ void CrateFeature::slotExportPlaylist() {
             QModelIndex index = m_crateTableModel.index(i, 0);
             playlist_items << m_crateTableModel.getTrackLocation(index);
         }
-
-        if (file_location.endsWith(".pls", Qt::CaseInsensitive)) {
-            ParserPls::writePLSFile(file_location, playlist_items, useRelativePath);
-        } else if (file_location.endsWith(".m3u8", Qt::CaseInsensitive)) {
-            ParserM3u::writeM3U8File(file_location, playlist_items, useRelativePath);
-        } else {
-            //default export to M3U if file extension is missing
-            if(!file_location.endsWith(".m3u", Qt::CaseInsensitive))
-            {
-                qDebug() << "Crate export: No valid file extension specified. Appending .m3u "
-                         << "and exporting to M3U.";
-                file_location.append(".m3u");
-            }
-            ParserM3u::writeM3UFile(file_location, playlist_items, useRelativePath);
-        }
+        exportPlaylistItemsIntoFile(
+                file_location,
+                playlist_items,
+                useRelativePath);
     }
 }
 

--- a/src/library/libraryfeature.cpp
+++ b/src/library/libraryfeature.cpp
@@ -79,8 +79,9 @@ bool LibraryFeature::exportPlaylistItemsIntoFile(
                 auto overwrite = QMessageBox::question(
                         NULL,
                         tr("Overwrite File?"),
-                        tr("Since you have specified no extension, m3u is used, but the file \"%1"
-                           "\" already exists. Do you wish to overwrite it?").arg(playlistFilePath)
+                        tr("A playlist file with the name \"%1\" already exists.\n"
+                           "The default \"m3u\" extension was added because none was specified.\n\n"
+                           "Do you really want to overwrite it?").arg(playlistFilePath)
                 );
                 if (overwrite != QMessageBox::StandardButton::Yes) {
                     return false;

--- a/src/library/libraryfeature.cpp
+++ b/src/library/libraryfeature.cpp
@@ -3,9 +3,20 @@
 
 #include "library/libraryfeature.h"
 
+#include "library/library.h"
+#include "library/parserm3u.h"
+#include "library/parserpls.h"
+#include "util/logger.h"
+
 // KEEP THIS cpp file to tell scons that moc should be called on the class!!!
 // The reason for this is that LibraryFeature uses slots/signals and for this
 // to work the code has to be precompiles by moc
+
+namespace {
+
+const mixxx::Logger kLogger("LibraryFeature");
+
+} // anonymous namespace
 
 LibraryFeature::LibraryFeature(
         QObject *parent)
@@ -35,4 +46,39 @@ QStringList LibraryFeature::getPlaylistFiles(QFileDialog::FileMode mode) const {
     // If the user refuses return
     if (! dialog.exec()) return QStringList();
     return dialog.selectedFiles();
+}
+
+bool LibraryFeature::exportPlaylistItemsIntoFile(
+        QString playlistFilePath,
+        const QList<QString>& playlistItemLocations,
+        bool useRelativePath)    {
+    if (playlistFilePath.endsWith(
+            QStringLiteral(".pls"),
+            Qt::CaseInsensitive)) {
+        return ParserPls::writePLSFile(
+                playlistFilePath,
+                playlistItemLocations,
+                useRelativePath);
+    } else if (playlistFilePath.endsWith(
+            QStringLiteral(".m3u8"),
+            Qt::CaseInsensitive)) {
+        return ParserM3u::writeM3U8File(
+                playlistFilePath,
+                playlistItemLocations,
+                useRelativePath);
+    } else {
+        //default export to M3U if file extension is missing
+        if (!playlistFilePath.endsWith(
+                QStringLiteral(".m3u"),
+                Qt::CaseInsensitive)) {
+            kLogger.debug()
+                    << "No valid file extension for playlist export specified."
+                    << "Appending .m3u and exporting to M3U.";
+            playlistFilePath.append(QStringLiteral(".m3u"));
+        }
+        return ParserM3u::writeM3UFile(
+                playlistFilePath,
+                playlistItemLocations,
+                useRelativePath);
+    }
 }

--- a/src/library/libraryfeature.cpp
+++ b/src/library/libraryfeature.cpp
@@ -75,6 +75,17 @@ bool LibraryFeature::exportPlaylistItemsIntoFile(
                     << "No valid file extension for playlist export specified."
                     << "Appending .m3u and exporting to M3U.";
             playlistFilePath.append(QStringLiteral(".m3u"));
+            if (QFileInfo(playlistFilePath).exists()) {
+                auto overwrite = QMessageBox::question(
+                        NULL,
+                        tr("Overwrite File?"),
+                        tr("Since you have specified no extension, m3u is used, but the file \"%1"
+                           "\" already exists. Do you wish to overwrite it?").arg(playlistFilePath)
+                );
+                if (overwrite != QMessageBox::StandardButton::Yes) {
+                    return false;
+                }
+            }
         }
         return ParserM3u::writeM3UFile(
                 playlistFilePath,

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -6,6 +6,7 @@
 
 #include <QtDebug>
 #include <QIcon>
+#include <QList>
 #include <QModelIndex>
 #include <QObject>
 #include <QString>
@@ -123,7 +124,15 @@ class LibraryFeature : public QObject {
     void enableCoverArtDisplay(bool);
     void trackSelected(TrackPointer pTrack);
 
-  private: 
+  protected:
+    // TODO: Move common crate/playlist functions into
+    // a separate base class
+    static bool exportPlaylistItemsIntoFile(
+            QString playlistFilePath,
+            const QList<QString>& playlistItemLocations,
+            bool useRelativePath);
+
+  private:
     QStringList getPlaylistFiles(QFileDialog::FileMode mode) const;
 };
 

--- a/src/library/parserm3u.cpp
+++ b/src/library/parserm3u.cpp
@@ -118,15 +118,15 @@ QString ParserM3u::getFilepath(QTextStream* stream, QString basepath) {
     return QString();
 }
 
-bool ParserM3u::writeM3UFile(const QString &file_str, QList<QString> &items, bool useRelativePath) {
+bool ParserM3u::writeM3UFile(const QString &file_str, const QList<QString> &items, bool useRelativePath) {
     return writeM3UFile(file_str, items, useRelativePath, false);
 }
 
-bool ParserM3u::writeM3U8File(const QString &file_str, QList<QString> &items, bool useRelativePath) {
+bool ParserM3u::writeM3U8File(const QString &file_str, const QList<QString> &items, bool useRelativePath) {
     return writeM3UFile(file_str, items, useRelativePath, true);
 }
 
-bool ParserM3u::writeM3UFile(const QString &file_str, QList<QString> &items, bool useRelativePath, bool useUtf8)
+bool ParserM3u::writeM3UFile(const QString &file_str, const QList<QString> &items, bool useRelativePath, bool useUtf8)
 {
     // Important note:
     // On Windows \n will produce a <CR><CL> (=\r\n)

--- a/src/library/parserm3u.h
+++ b/src/library/parserm3u.h
@@ -28,9 +28,9 @@ public:
     /**Overwriting function parse in class Parser**/
     QList<QString> parse(QString);
     //Playlist Export
-    static bool writeM3UFile(const QString &file_str, QList<QString> &items, bool useRelativePath, bool useUtf8);
-    static bool writeM3UFile(const QString &file, QList<QString> &items, bool useRelativePath);
-    static bool writeM3U8File(const QString &file_str, QList<QString> &items, bool useRelativePath);
+    static bool writeM3UFile(const QString &file_str, const QList<QString> &items, bool useRelativePath, bool useUtf8);
+    static bool writeM3UFile(const QString &file, const QList<QString> &items, bool useRelativePath);
+    static bool writeM3U8File(const QString &file_str, const QList<QString> &items, bool useRelativePath);
 
 private:
     /**Reads a line from the file and returns filepath if a valid file**/

--- a/src/library/parserpls.cpp
+++ b/src/library/parserpls.cpp
@@ -135,7 +135,7 @@ QString ParserPls::getFilepath(QTextStream *stream, QString basepath) {
     return 0;
 }
 
-bool ParserPls::writePLSFile(const QString &file_str, QList<QString> &items, bool useRelativePath)
+bool ParserPls::writePLSFile(const QString &file_str, const QList<QString> &items, bool useRelativePath)
 {
     QFile file(file_str);
     if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {

--- a/src/library/parserpls.h
+++ b/src/library/parserpls.h
@@ -26,7 +26,7 @@ class ParserPls : public Parser {
     /**Can be called to parse a pls file**/
     QList<QString> parse(QString);
     //Playlist Export
-    static bool writePLSFile(const QString &file, QList<QString> &items, bool useRelativePath);
+    static bool writePLSFile(const QString &file, const QList<QString> &items, bool useRelativePath);
 
   private:
     /**Returns the Number of entries in the pls file**/


### PR DESCRIPTION
When the export file already existed and "Automatically select filename extension" was disabled, Mixxx would default to m3u and overwrite without prompt. This PR implements an additional check before exporting.