### PR TITLE
Deere: suppress blue hotcue button border

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -1544,6 +1544,10 @@ WPushButton[value="2"]:hover {
     border: 1px solid #0080BE;
 }
 
+#HotcueButton {
+  border: none;
+}
+
 #HotcueButton[light="true"] {
     color: #1f1e1e;
 }


### PR DESCRIPTION
Paint Hotcuebuttons without border.
(changes from #2549 were removed by #2560 )