### PR TITLE
engine/enginedeck: Fix broken vinyl passthrough

### DIFF
--- a/src/engine/enginedeck.cpp
+++ b/src/engine/enginedeck.cpp
@@ -50,7 +50,7 @@ EngineDeck::EngineDeck(const ChannelHandleAndGroup& handle_group,
             Qt::DirectConnection);
 
     // Set up passthrough toggle button
-    connect(m_pPassing, SIGNAL(valueChanged(double)),
+    connect(m_pPassing, SIGNAL(valueChangedFromEngine(double)),
             this, SLOT(slotPassingToggle(double)),
             Qt::DirectConnection);
 


### PR DESCRIPTION
In commit 0f5d4b358f023b7431009e13e6b9370794c759ab we connected a
valueChangeRequest that sets the value on the same object that we expect
to send the valueChanged signal. If a value is set for a control object,
that object doesn't emit the valueChanged signal though - it emits the
valueChangedFromEngine signal instead.