### PR TITLE
fix cropped Mic/Aux labels in LateNight

### DIFF
--- a/res/skins/LateNight/aux_unit.xml
+++ b/res/skins/LateNight/aux_unit.xml
@@ -148,7 +148,7 @@
 
               <Label>
                 <ObjectName>MicAuxSubTitle</ObjectName>
-                <Size>,17f</Size>
+                <Size>,21f</Size>
                 <Text>Aux <Variable name="auxnum"/></Text>
                 <Alignment>center</Alignment>
               </Label>

--- a/res/skins/LateNight/aux_unit_unconfigured.xml
+++ b/res/skins/LateNight/aux_unit_unconfigured.xml
@@ -24,7 +24,7 @@
 
               <Label>
                 <ObjectName>MicAuxSubTitle</ObjectName>
-                <Size>,17f</Size>
+                <Size>,21f</Size>
                 <Text>Aux <Variable name="auxnum"/></Text>
                 <Alignment>center</Alignment>
               </Label>

--- a/res/skins/LateNight/mic_unit.xml
+++ b/res/skins/LateNight/mic_unit.xml
@@ -148,7 +148,7 @@
 
               <Label>
                 <ObjectName>MicAuxSubTitle</ObjectName>
-                <Size>,17f</Size>
+                <Size>,21f</Size>
                 <Text>mic <Variable name="mic1hack"/><Variable name="micnum"/></Text>
                 <Alignment>center</Alignment>
               </Label>

--- a/res/skins/LateNight/mic_unit_unconfigured.xml
+++ b/res/skins/LateNight/mic_unit_unconfigured.xml
@@ -24,7 +24,7 @@
 
               <Label>
                 <ObjectName>MicAuxSubTitle</ObjectName>
-                <Size>,17f</Size>
+                <Size>,21f</Size>
                 <Text>mic <Variable name="mic1hack"/><Variable name="micnum"/></Text>
                 <Alignment>center</Alignment>
               </Label>

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -1652,10 +1652,12 @@ WBeatSpinBox,
         padding: 0px 0px 3px 1px;
       }
       #MicAuxPlayButtonBox {
-        margin: 0px 0px 2px 1px;
+        qproperty-alignment: 'AlignCenter | AlignBottom';
+        padding: 0px 0px 2px 1px;
       }
       #MicAuxAddBox {
-        margin: 6px 0px 8px 1px;
+        qproperty-alignment: 'AlignCenter | AlignBottom';
+        padding: 0px 0px 8px 1px;
       }
 
   #MicAuxSubControlsFrame {


### PR DESCRIPTION
noticed with Windows 10