### PR TITLE
fix GUI states of Library feature buttons

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -583,15 +583,6 @@ WLibrary QRadioButton::indicator:unchecked {
 #DlgAnalysis > QPushButton:focus,
 #fadeModeCombobox:focus,
 #DlgAutoDJ QSpinBox:focus {
-  border: 1px solid #bbb;
-  outline: none;
-}
-#DlgMissing > QPushButton:checked:focus,
-#DlgHidden > QPushButton:checked:focus,
-#DlgAutoDJ > QPushButton:checked:focus,
-#DlgRecording > QPushButton:checked:focus,
-#DlgAnalysis > QPushButton:checked:focus {
-  border: 1px solid #d2d2d2;
   outline: none;
 }
 
@@ -655,6 +646,25 @@ QPushButton#pushButtonRepeatPlaylist {
   image: url(skin:/icon/ic_autodj_repeat_playlist.svg) no-repeat center center;
 }
 /* AutoDJ button icons */
+
+/* Recording info */
+#labelRecPrefix,
+#labelRecFilename,
+#labelRecStatistics {
+  text-transform: none;
+  padding: 3px 0px 0px 0px;
+  margin: 0px;
+}
+#labelRecPrefix {
+  margin-left: 3px;
+}
+#labelRecFilename {
+  font-weight: bold;
+}
+#labelRecPrefix,
+#labelRecStatistics {
+  font-weight: normal;
+}
 
 /* Scroll bars */
 #LibraryContainer QScrollBar:horizontal,
@@ -811,6 +821,7 @@ WLibrary QLabel,
 WLibrary QPushButton {
   font-family: "Open Sans";
   font-size: 12px;
+  font-weight: bold;
   text-transform: uppercase;
 }
 

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -506,18 +506,6 @@ QHeaderView::down-arrow {
   #DlgAutoDJ > QPushButton:focus,
   #DlgRecording > QPushButton:focus,
   #DlgAnalysis > QPushButton:focus {
-    border-width: 2px 2px 2px 2px;
-    border-image: url(skin:buttons_classic/btn_embedded_library.svg) 2 2 2 2;
-    outline: none;
-  }
-  #DlgAnalysis > QPushButton:checked:focus,
-  #DlgMissing > QPushButton:checked:focus,
-  #DlgHidden > QPushButton:checked:focus,
-  #DlgAutoDJ > QPushButton:checked:focus,
-  #DlgRecording > QPushButton:checked:focus,
-  #DlgAnalysis > QPushButton:checked:focus {
-    border-width: 2px 2px 2px 2px;
-    border-image: url(skin:buttons_classic/btn_embedded_library_active.svg) 2 2 2 2;
     outline: none;
   }
   #DlgMissing > QPushButton:pressed,
@@ -525,7 +513,7 @@ QHeaderView::down-arrow {
   #DlgAutoDJ > QPushButton:pressed,
   #DlgRecording > QPushButton:pressed,
   #DlgAnalysis > QPushButton:pressed {
-    border-image: url(skin:buttons_classic/btn_embedded_library_pressed.svg) 2 2 2 2;
+    border-image: url(skin:buttons_classic/btn_embedded_library_active.svg) 2 2 2 2;
     color: #d2d2d2;
   }
   #DlgMissing > QPushButton:!enabled,
@@ -2340,7 +2328,8 @@ WLibrary QRadioButton {
 }
 
 /* Additional space for QLabels */
-WLibrary QLabel {
+#DlgAnalysis QLabel,
+#DlgAutoDJ QLabel {
   margin: 2px 5px 5px 1px;
 }
 
@@ -2361,7 +2350,7 @@ WLibrary QRadioButton::indicator:unchecked {
 #DlgAutoDJ > QPushButton,
 #DlgRecording > QPushButton,
 #DlgAnalysis > QPushButton {
-  margin: 0px 4px 3px 2px;
+  margin: 0px 6px 3px 0px;
   padding: 0px;
   height: 20px;
   }
@@ -2371,12 +2360,10 @@ WLibrary QRadioButton::indicator:unchecked {
 #DlgAnalysis > QPushButton {
   padding: 0px 5px;
   }
-  /* Focus highlight is set via border-image at the top */
-  /* Space in between 'Enable AutoDJ' and transition time spinbox */
   QPushButton#pushButtonAutoDJ {
-    margin-left: 0px;
     min-width: 40px;
   }
+  /* Space in between 'Enable AutoDJ' and transition time spinbox */
   #DlgAutoDJ > #horizontalSpacer {
     width: 100px;
   }
@@ -2389,7 +2376,20 @@ WLibrary QRadioButton::indicator:unchecked {
     margin-left: 12px;
   }
 
-
+#labelRecPrefix,
+#labelRecFilename,
+#labelRecStatistics {
+  text-transform: none;
+  font-size: 13px;
+  padding: 0px 0px 3px 0px;
+  }
+  #labelRecFilename {
+    font-weight: bold;
+  }
+  #labelRecPrefix,
+  #labelRecStatistics {
+    font-weight: normal;
+  }
 
 #LibraryContainer QTreeView {
   show-decoration-selected: 0;

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -810,6 +810,14 @@ QPushButton#pushButtonRepeatPlaylist {
 }
 /* AutoDJ button icons */
 
+#labelRecFilename {
+  font-weight: bold;
+}
+#labelRecPrefix,
+#labelRecStatistics {
+  font-weight: normal;
+}
+
 #HotcueButton {
     background-color: #aab2b7;
 }

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -2766,11 +2766,19 @@ QPushButton#pushButtonRepeatPlaylist:!checked {
   /* Push labels away from buttons at the right */
   /* AutoDJ selection info */
   QLabel#labelSelectionInfo,
-  /* Recording info */
-  #DlgRecording QLabel,
   /* Analysis progress info */
   QLabel#labelProgress {
     margin: 0px 4px 5px 2px;
+  }
+
+  /* Recording info */
+  #labelRecFilename {
+    font-weight: bold;
+    margin: 0px 1px;
+  }
+  #labelRecPrefix,
+  #labelRecStatistics {
+    font-weight: normal;
   }
 
   /* Entire BPM cell */

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -80,7 +80,10 @@ DlgAutoDJ::DlgAutoDJ(
     // Do not set this because it disables auto-scrolling
     //m_pTrackTableView->setDragDropMode(QAbstractItemView::InternalMove);
 
-    connect(pushButtonAutoDJ, &QPushButton::toggled, this, &DlgAutoDJ::toggleAutoDJButton);
+    connect(pushButtonAutoDJ,
+            &QPushButton::clicked,
+            this,
+            &DlgAutoDJ::toggleAutoDJButton);
 
     setupActionButton(pushButtonFadeNow, &DlgAutoDJ::fadeNowButton, tr("Fade"));
     setupActionButton(pushButtonSkipNext, &DlgAutoDJ::skipNextButton, tr("Skip"));
@@ -171,7 +174,7 @@ DlgAutoDJ::DlgAutoDJ(
             &DlgAutoDJ::slotTransitionModeChanged);
 
     connect(pushButtonRepeatPlaylist,
-            &QPushButton::toggled,
+            &QPushButton::clicked,
             this,
             &DlgAutoDJ::slotRepeatPlaylistChanged);
     if (m_bShowButtonText) {
@@ -190,6 +193,7 @@ DlgAutoDJ::DlgAutoDJ(
             &AutoDJProcessor::transitionTimeChanged,
             this,
             &DlgAutoDJ::transitionTimeChanged);
+
     connect(m_pAutoDJProcessor,
             &AutoDJProcessor::autoDJStateChanged,
             this,

--- a/src/library/dlganalysis.cpp
+++ b/src/library/dlganalysis.cpp
@@ -63,6 +63,7 @@ DlgAnalysis::DlgAnalysis(QWidget* parent,
             &QPushButton::clicked,
             this,
             &DlgAnalysis::analyze);
+    pushButtonAnalyze->setEnabled(false);
 
     connect(pushButtonSelectAll,
             &QPushButton::clicked,
@@ -165,10 +166,11 @@ void DlgAnalysis::slotAnalysisActive(bool bActive) {
     //qDebug() << this << "slotAnalysisActive" << bActive;
     m_bAnalysisActive = bActive;
     if (bActive) {
-        pushButtonAnalyze->setEnabled(true);
+        pushButtonAnalyze->setChecked(true);
         pushButtonAnalyze->setText(tr("Stop Analysis"));
         labelProgress->setEnabled(true);
     } else {
+        pushButtonAnalyze->setChecked(false);
         pushButtonAnalyze->setText(tr("Analyze"));
         labelProgress->setText("");
         labelProgress->setEnabled(false);

--- a/src/library/dlganalysis.cpp
+++ b/src/library/dlganalysis.cpp
@@ -54,10 +54,8 @@ DlgAnalysis::DlgAnalysis(QWidget* parent,
             &QRadioButton::clicked,
             this,
             &DlgAnalysis::showAllSongs);
-
-    // TODO(rryan): This triggers a library search before the UI has even
-    // started up. Accounts for 0.2% of skin creation time. Get rid of this!
-    radioButtonRecentlyAdded->click();
+    // Don't click those radio buttons now reduce skin loading time.
+    // 'RecentlyAdded' is clicked in onShow()
 
     connect(pushButtonAnalyze,
             &QPushButton::clicked,
@@ -92,6 +90,10 @@ DlgAnalysis::DlgAnalysis(QWidget* parent,
 }
 
 void DlgAnalysis::onShow() {
+    if (!radioButtonRecentlyAdded->isChecked() &&
+            !radioButtonAllSongs->isChecked()) {
+        radioButtonRecentlyAdded->click();
+    }
     // Refresh table
     // There might be new tracks dropped to other views
     m_pAnalysisLibraryTableModel->select();

--- a/src/library/dlganalysis.ui
+++ b/src/library/dlganalysis.ui
@@ -84,6 +84,9 @@
        <property name="text">
         <string>Analyze</string>
        </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
      <item>

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -144,7 +144,7 @@ void DlgRecording::slotRecButtonClicked(bool toggle) {
 void DlgRecording::slotRecordingStateChanged(bool isRecording) {
     if (isRecording) {
         pushButtonRecording->setChecked(true);
-        pushButtonRecording->setText((tr("Stop Recording")));
+        pushButtonRecording->setText(tr("Stop Recording"));
         labelRecPrefix->show();
         labelRecFilename->show();
         labelRecStatistics->show();

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -175,7 +175,7 @@ void DlgRecording::slotDurationRecorded(QString durationRecorded) {
 // update label besides start/stop button
 void DlgRecording::refreshLabels() {
     QString recFile = m_pRecordingManager->getRecordingFile();
-    QString recData = tr("(%1 MiB written in %2)")
+    QString recData = (QStringLiteral("(") + tr("%1 MiB written in %2") + QStringLiteral(")"))
             .arg(m_bytesRecordedStr)
             .arg(m_durationRecordedStr);
     labelRecFilename->setText(recFile);

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -48,6 +48,7 @@ DlgRecording::DlgRecording(QWidget* parent, UserSettingsPointer pConfig,
             &RecordingManager::isRecording,
             this,
             &DlgRecording::slotRecordingStateChanged);
+
     connect(m_pRecordingManager,
             &RecordingManager::bytesRecorded,
             this,
@@ -80,6 +81,9 @@ DlgRecording::DlgRecording(QWidget* parent, UserSettingsPointer pConfig,
 
     label->setText("");
     label->setEnabled(false);
+
+    // Sync GUI with recording state, also refreshes labels
+    slotRecordingStateChanged(m_pRecordingManager->isRecordingActive());
 }
 
 DlgRecording::~DlgRecording() {

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -132,7 +132,7 @@ void DlgRecording::moveSelection(int delta) {
 
 void DlgRecording::slotRecButtonClicked(bool toggle) {
     Q_UNUSED(toggle);
-    m_pRecordingManager->slotToggleRecording(true);
+    m_pRecordingManager->slotToggleRecording(1);
 }
 
 void DlgRecording::slotRecordingStateChanged(bool isRecording) {

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -79,8 +79,10 @@ DlgRecording::DlgRecording(QWidget* parent, UserSettingsPointer pConfig,
             this,
             &DlgRecording::slotRecButtonClicked);
 
-    label->setText("");
-    label->setEnabled(false);
+    labelRecPrefix->hide();
+    labelRecFilename->hide();
+    labelRecStatistics->hide();
+    labelRecPrefix->setText(tr("Recording to file:"));
 
     // Sync GUI with recording state, also refreshes labels
     slotRecordingStateChanged(m_pRecordingManager->isRecordingActive());
@@ -143,12 +145,15 @@ void DlgRecording::slotRecordingStateChanged(bool isRecording) {
     if (isRecording) {
         pushButtonRecording->setChecked(true);
         pushButtonRecording->setText((tr("Stop Recording")));
-        label->setEnabled(true);
+        labelRecPrefix->show();
+        labelRecFilename->show();
+        labelRecStatistics->show();
     } else {
         pushButtonRecording->setChecked(false);
         pushButtonRecording->setText((tr("Start Recording")));
-        label->setText("");
-        label->setEnabled(false);
+        labelRecPrefix->hide();
+        labelRecFilename->hide();
+        labelRecStatistics->hide();
     }
     //This will update the recorded track table view
     m_browseModel.setPath(m_recordingDir);
@@ -158,20 +163,21 @@ void DlgRecording::slotRecordingStateChanged(bool isRecording) {
 void DlgRecording::slotBytesRecorded(int bytes) {
     double megabytes = bytes / 1048576.0;
     m_bytesRecordedStr = QString::number(megabytes,'f',2);
-    refreshLabel();
+    refreshLabels();
 }
 
 // gets recorded duration and update label
 void DlgRecording::slotDurationRecorded(QString durationRecorded) {
     m_durationRecordedStr = durationRecorded;
-    refreshLabel();
+    refreshLabels();
 }
 
 // update label besides start/stop button
-void DlgRecording::refreshLabel() {
-    QString text = tr("Recording to file: %1 (%2 MiB written in %3)")
-              .arg(m_pRecordingManager->getRecordingFile())
-              .arg(m_bytesRecordedStr)
-              .arg(m_durationRecordedStr);
-    label->setText(text);
+void DlgRecording::refreshLabels() {
+    QString recFile = m_pRecordingManager->getRecordingFile();
+    QString recData = tr("(%1 MiB written in %2)")
+            .arg(m_bytesRecordedStr)
+            .arg(m_durationRecordedStr);
+    labelRecFilename->setText(recFile);
+    labelRecStatistics->setText(recData);
 }

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -77,6 +77,7 @@ DlgRecording::DlgRecording(QWidget* parent, UserSettingsPointer pConfig,
             &QPushButton::clicked,
             this,
             &DlgRecording::toggleRecording);
+
     label->setText("");
     label->setEnabled(false);
 }
@@ -131,23 +132,16 @@ void DlgRecording::moveSelection(int delta) {
 
 void DlgRecording::toggleRecording(bool toggle) {
     Q_UNUSED(toggle);
-    if (!m_pRecordingManager->isRecordingActive()) //If recording is enabled
-    {
-        //pushButtonRecording->setText(tr("Stop Recording"));
-        m_pRecordingManager->startRecording();
-    }
-    else if(m_pRecordingManager->isRecordingActive()) //If we disable recording
-    {
-        //pushButtonRecording->setText(tr("Start Recording"));
-        m_pRecordingManager->stopRecording();
-    }
+    m_pRecordingManager->slotToggleRecording(true);
 }
 
 void DlgRecording::slotRecordingEnabled(bool isRecording) {
     if (isRecording) {
+        pushButtonRecording->setChecked(true);
         pushButtonRecording->setText((tr("Stop Recording")));
         label->setEnabled(true);
     } else {
+        pushButtonRecording->setChecked(false);
         pushButtonRecording->setText((tr("Start Recording")));
         label->setText("");
         label->setEnabled(false);
@@ -176,4 +170,4 @@ void DlgRecording::refreshLabel() {
               .arg(m_bytesRecordedStr)
               .arg(m_durationRecordedStr);
     label->setText(text);
- }
+}

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -74,7 +74,7 @@ DlgRecording::DlgRecording(QWidget* parent, UserSettingsPointer pConfig,
     m_pTrackTableView->loadTrackModel(&m_proxyModel);
 
     connect(pushButtonRecording,
-            &QPushButton::toggled,
+            &QPushButton::clicked,
             this,
             &DlgRecording::toggleRecording);
     label->setText("");

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -150,7 +150,7 @@ void DlgRecording::slotRecordingStateChanged(bool isRecording) {
         labelRecStatistics->show();
     } else {
         pushButtonRecording->setChecked(false);
-        pushButtonRecording->setText((tr("Start Recording")));
+        pushButtonRecording->setText(tr("Start Recording"));
         labelRecPrefix->hide();
         labelRecFilename->hide();
         labelRecStatistics->hide();

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -47,7 +47,7 @@ DlgRecording::DlgRecording(QWidget* parent, UserSettingsPointer pConfig,
     connect(m_pRecordingManager,
             &RecordingManager::isRecording,
             this,
-            &DlgRecording::slotRecordingEnabled);
+            &DlgRecording::slotRecordingStateChanged);
     connect(m_pRecordingManager,
             &RecordingManager::bytesRecorded,
             this,
@@ -76,7 +76,7 @@ DlgRecording::DlgRecording(QWidget* parent, UserSettingsPointer pConfig,
     connect(pushButtonRecording,
             &QPushButton::clicked,
             this,
-            &DlgRecording::toggleRecording);
+            &DlgRecording::slotRecButtonClicked);
 
     label->setText("");
     label->setEnabled(false);
@@ -130,12 +130,12 @@ void DlgRecording::moveSelection(int delta) {
     m_pTrackTableView->moveSelection(delta);
 }
 
-void DlgRecording::toggleRecording(bool toggle) {
+void DlgRecording::slotRecButtonClicked(bool toggle) {
     Q_UNUSED(toggle);
     m_pRecordingManager->slotToggleRecording(true);
 }
 
-void DlgRecording::slotRecordingEnabled(bool isRecording) {
+void DlgRecording::slotRecordingStateChanged(bool isRecording) {
     if (isRecording) {
         pushButtonRecording->setChecked(true);
         pushButtonRecording->setText((tr("Stop Recording")));

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -175,7 +175,7 @@ void DlgRecording::slotDurationRecorded(QString durationRecorded) {
 // update label besides start/stop button
 void DlgRecording::refreshLabels() {
     QString recFile = m_pRecordingManager->getRecordingFile();
-    QString recData = (QStringLiteral("(") + tr("%1 MiB written in %2") + QStringLiteral(")"))
+    QString recData = QString(QStringLiteral("(") + tr("%1 MiB written in %2") + QStringLiteral(")"))
             .arg(m_bytesRecordedStr)
             .arg(m_durationRecordedStr);
     labelRecFilename->setText(recFile);

--- a/src/library/recording/dlgrecording.h
+++ b/src/library/recording/dlgrecording.h
@@ -54,7 +54,7 @@ class DlgRecording : public QWidget, public Ui::DlgRecording, public virtual Lib
     ProxyTrackModel m_proxyModel;
     QString m_recordingDir;
 
-    void refreshLabel();
+    void refreshLabels();
     void slotRecButtonClicked(bool checked);
     QString m_bytesRecordedStr;
     QString m_durationRecordedStr;

--- a/src/library/recording/dlgrecording.h
+++ b/src/library/recording/dlgrecording.h
@@ -36,7 +36,7 @@ class DlgRecording : public QWidget, public Ui::DlgRecording, public virtual Lib
     inline const QString currentSearch() { return m_proxyModel.currentSearch(); }
 
   public slots:
-    void slotRecordingEnabled(bool);
+    void slotRecordingStateChanged(bool);
     void slotBytesRecorded(int);
     void refreshBrowseModel();
     void slotRestoreSearch();
@@ -55,7 +55,7 @@ class DlgRecording : public QWidget, public Ui::DlgRecording, public virtual Lib
     QString m_recordingDir;
 
     void refreshLabel();
-    void toggleRecording(bool checked);
+    void slotRecButtonClicked(bool checked);
     QString m_bytesRecordedStr;
     QString m_durationRecordedStr;
 

--- a/src/library/recording/dlgrecording.h
+++ b/src/library/recording/dlgrecording.h
@@ -36,7 +36,6 @@ class DlgRecording : public QWidget, public Ui::DlgRecording, public virtual Lib
     inline const QString currentSearch() { return m_proxyModel.currentSearch(); }
 
   public slots:
-    void toggleRecording(bool toggle);
     void slotRecordingEnabled(bool);
     void slotBytesRecorded(int);
     void refreshBrowseModel();
@@ -56,6 +55,7 @@ class DlgRecording : public QWidget, public Ui::DlgRecording, public virtual Lib
     QString m_recordingDir;
 
     void refreshLabel();
+    void toggleRecording(bool checked);
     QString m_bytesRecordedStr;
     QString m_durationRecordedStr;
 

--- a/src/library/recording/dlgrecording.ui
+++ b/src/library/recording/dlgrecording.ui
@@ -57,11 +57,13 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Status:</string>
-       </property>
-      </widget>
+      <widget class="QLabel" name="labelRecPrefix"/>
+     </item>
+     <item>
+      <widget class="QLabel" name="labelRecFilename"/>
+     </item>
+     <item>
+      <widget class="QLabel" name="labelRecStatistics"/>
      </item>
      <item>
       <spacer name="horizontalSpacer">

--- a/src/recording/recordingmanager.cpp
+++ b/src/recording/recordingmanager.cpp
@@ -81,8 +81,8 @@ void RecordingManager::slotSetRecording(bool recording) {
     }
 }
 
-void RecordingManager::slotToggleRecording(double v) {
-    if (v > 0) {
+void RecordingManager::slotToggleRecording(bool toggle) {
+    if (toggle) {
         if (isRecordingActive()) {
             stopRecording();
         } else {

--- a/src/recording/recordingmanager.cpp
+++ b/src/recording/recordingmanager.cpp
@@ -89,7 +89,8 @@ void RecordingManager::slotSetRecording(bool recording) {
     }
 }
 
-void RecordingManager::slotToggleRecording(bool toggle) {
+void RecordingManager::slotToggleRecording(double value) {
+    bool toggle = static_cast<bool>(value);
     if (toggle) {
         if (isRecordingActive()) {
             stopRecording();

--- a/src/recording/recordingmanager.cpp
+++ b/src/recording/recordingmanager.cpp
@@ -36,8 +36,10 @@ RecordingManager::RecordingManager(UserSettingsPointer pConfig, EngineMaster* pE
           m_secondsRecorded(0),
           m_secondsRecordedSplit(0) {
     m_pToggleRecording = new ControlPushButton(ConfigKey(RECORDING_PREF_KEY, "toggle_recording"));
-    connect(m_pToggleRecording, SIGNAL(valueChanged(double)),
-            this, SLOT(slotToggleRecording(double)));
+    connect(m_pToggleRecording,
+            &ControlPushButton::valueChanged,
+            this,
+            &RecordingManager::slotToggleRecording);
     m_recReadyCO = new ControlObject(ConfigKey(RECORDING_PREF_KEY, "status"));
     m_recReady = new ControlProxy(m_recReadyCO->getKey(), this);
 
@@ -49,12 +51,18 @@ RecordingManager::RecordingManager(UserSettingsPointer pConfig, EngineMaster* pE
     EngineSideChain* pSidechain = pEngine->getSideChain();
     if (pSidechain) {
         EngineRecord* pEngineRecord = new EngineRecord(m_pConfig);
-        connect(pEngineRecord, SIGNAL(isRecording(bool, bool)),
-                this, SLOT(slotIsRecording(bool, bool)));
-        connect(pEngineRecord, SIGNAL(bytesRecorded(int)),
-                this, SLOT(slotBytesRecorded(int)));
-        connect(pEngineRecord, SIGNAL(durationRecorded(quint64)),
-                this, SLOT(slotDurationRecorded(quint64)));
+        connect(pEngineRecord,
+                &EngineRecord::isRecording,
+                this,
+                &RecordingManager::slotIsRecording);
+        connect(pEngineRecord,
+                &EngineRecord::bytesRecorded,
+                this,
+                &RecordingManager::slotBytesRecorded);
+        connect(pEngineRecord,
+                &EngineRecord::durationRecorded,
+                this,
+                &RecordingManager::slotDurationRecorded);
         pSidechain->addSideChainWorker(pEngineRecord);
     }
 }

--- a/src/recording/recordingmanager.h
+++ b/src/recording/recordingmanager.h
@@ -56,9 +56,7 @@ class RecordingManager : public QObject
     void slotBytesRecorded(int);
     void slotDurationRecorded(quint64);
     void slotSetRecording(bool recording);
-
-  private slots:
-    void slotToggleRecording(double v);
+    void slotToggleRecording(bool toggle);
 
   private:
     QString formatDateTimeForFilename(QDateTime dateTime) const;

--- a/src/recording/recordingmanager.h
+++ b/src/recording/recordingmanager.h
@@ -56,7 +56,7 @@ class RecordingManager : public QObject
     void slotBytesRecorded(int);
     void slotDurationRecorded(quint64);
     void slotSetRecording(bool recording);
-    void slotToggleRecording(bool toggle);
+    void slotToggleRecording(double value);
 
   private:
     QString formatDateTimeForFilename(QDateTime dateTime) const;


### PR DESCRIPTION
fixes https://bugs.launchpad.net/mixxx/+bug/1854160

**Analyze**
`Analyze` button is now disabled by default until tracks are selected.
It can now be checked which also applies the 'active' style from qss when analysis is running.
(before, the enabled state was not synchronised until you changed the view from `New` to `All`)
The table model is now loaded when you switch to Analysis for the first time, not on skin load.

**Recording**
The Recording toggle and the info labels are now always synced to actual recording state and styled correctly, nomatter if the recording was toggled via Ctrl+R, menubar toggle, toolbar toggle or Rec toggle itself, even after changing the skin.
I've split up the GUI labels to emphasize the file name.
![image](https://user-images.githubusercontent.com/5934199/78666622-e431eb80-78d7-11ea-8660-dbace0276d4b.png)


In **DlgAutoDJ** I switched to `clicked()` signal to prevent any issues like with Recording, and applied the new signal/slot syntax.