### PR TITLE
ColorPaletteEditor: use theme's list-add and list-remove icons

### DIFF
--- a/src/preferences/colorpaletteeditor.cpp
+++ b/src/preferences/colorpaletteeditor.cpp
@@ -31,7 +31,12 @@ ColorPaletteEditor::ColorPaletteEditor(QWidget* parent, bool showHotcueNumbers)
             QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred));
     pColorButtonLayout->addWidget(pExpander);
 
-    m_pRemoveColorButton = new QPushButton(QIcon::fromTheme("list-remove"), "", this);
+    QIcon removeIcon = QIcon::fromTheme("list-remove", QIcon());
+    if (!removeIcon.isNull()) {
+        m_pRemoveColorButton = new QPushButton(removeIcon, "", this);
+    } else {
+        m_pRemoveButton = new QPushButton("-", this);
+    }
     m_pRemoveColorButton->setFixedWidth(32);
     m_pRemoveColorButton->setToolTip(tr("Remove Color"));
     m_pRemoveColorButton->setDisabled(true);
@@ -41,7 +46,12 @@ ColorPaletteEditor::ColorPaletteEditor(QWidget* parent, bool showHotcueNumbers)
             this,
             &ColorPaletteEditor::slotRemoveColor);
 
-    m_pAddColorButton = new QPushButton(QIcon::fromTheme("list-add"), "", this);
+    QIcon addIcon = QIcon::fromTheme("list-add", QIcon());
+    if (!addIcon.isNull()) {
+        m_pAddColorButton = new QPushButton(addIcon, "", this);
+    } else {
+        m_pAddColorButton = new QPushButton("+", this);
+    }
     m_pAddColorButton->setFixedWidth(32);
     m_pAddColorButton->setToolTip(tr("Add Color"));
     pColorButtonLayout->addWidget(m_pAddColorButton);

--- a/src/preferences/colorpaletteeditor.cpp
+++ b/src/preferences/colorpaletteeditor.cpp
@@ -31,7 +31,7 @@ ColorPaletteEditor::ColorPaletteEditor(QWidget* parent, bool showHotcueNumbers)
             QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred));
     pColorButtonLayout->addWidget(pExpander);
 
-    m_pRemoveColorButton = new QPushButton("-", this);
+    m_pRemoveColorButton = new QPushButton(QIcon::fromTheme("list-remove"), "", this);
     m_pRemoveColorButton->setFixedWidth(32);
     m_pRemoveColorButton->setToolTip(tr("Remove Color"));
     m_pRemoveColorButton->setDisabled(true);
@@ -41,7 +41,7 @@ ColorPaletteEditor::ColorPaletteEditor(QWidget* parent, bool showHotcueNumbers)
             this,
             &ColorPaletteEditor::slotRemoveColor);
 
-    m_pAddColorButton = new QPushButton("+", this);
+    m_pAddColorButton = new QPushButton(QIcon::fromTheme("list-add"), "", this);
     m_pAddColorButton->setFixedWidth(32);
     m_pAddColorButton->setToolTip(tr("Add Color"));
     pColorButtonLayout->addWidget(m_pAddColorButton);

--- a/src/preferences/colorpaletteeditor.cpp
+++ b/src/preferences/colorpaletteeditor.cpp
@@ -31,11 +31,9 @@ ColorPaletteEditor::ColorPaletteEditor(QWidget* parent, bool showHotcueNumbers)
             QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred));
     pColorButtonLayout->addWidget(pExpander);
 
-    QIcon removeIcon = QIcon::fromTheme("list-remove", QIcon());
-    if (!removeIcon.isNull()) {
-        m_pRemoveColorButton = new QPushButton(removeIcon, "", this);
-    } else {
-        m_pRemoveButton = new QPushButton("-", this);
+    m_pRemoveColorButton = new QPushButton(QIcon::fromTheme("list-remove"), "", this);
+    if (m_pRemoveColorButton->icon().isNull()) {
+        m_pRemoveColorButton->setText("-");
     }
     m_pRemoveColorButton->setFixedWidth(32);
     m_pRemoveColorButton->setToolTip(tr("Remove Color"));
@@ -46,11 +44,9 @@ ColorPaletteEditor::ColorPaletteEditor(QWidget* parent, bool showHotcueNumbers)
             this,
             &ColorPaletteEditor::slotRemoveColor);
 
-    QIcon addIcon = QIcon::fromTheme("list-add", QIcon());
-    if (!addIcon.isNull()) {
-        m_pAddColorButton = new QPushButton(addIcon, "", this);
-    } else {
-        m_pAddColorButton = new QPushButton("+", this);
+    m_pAddColorButton = new QPushButton(QIcon::fromTheme("list-add"), "", this);
+    if (m_pAddColorButton->icon().isNull()) {
+        m_pAddColorButton->setText("+");
     }
     m_pAddColorButton->setFixedWidth(32);
     m_pAddColorButton->setToolTip(tr("Add Color"));


### PR DESCRIPTION
Continuing from discussion on #2589
before:
![image](https://user-images.githubusercontent.com/9455094/78501342-f1f14080-7720-11ea-85e0-fa0fac85c901.png)

after:
![image](https://user-images.githubusercontent.com/9455094/78466623-e540fe00-76c8-11ea-8961-91aaf76abd07.png)