### PR TITLE
Fix line-length hook working on all changed files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -113,8 +113,8 @@ repos:
     - manual
 - repo: local
   hooks:
-  - id: line_length
-    name: line_length
+  - id: line-length
+    name: line-length
     description: Check for lines longer 100 and brakes them before 80.
     entry: ./scripts/line_length.py
     stages:


### PR DESCRIPTION
Currently, the line length hook runs `clang-format` on *all* files with long lines. For JS files this will produce an error. Pre-commit passes filenames to check to the script anyway, so this makes the script actually use that information.