### PR TITLE
Test: fix mic Auto ducking

### DIFF
--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -484,7 +484,9 @@ void EngineMaster::process(const int iBufferSize) {
     // channel volume faders, crossfader, and talkover ducking.
     // Talkover is mixed in later according to the configured MicMonitorMode
     CSAMPLE talkOvergain = 1;
-    if (!m_activeTalkoverChannels.isEmpty()) {
+    if ((m_pTalkoverDucking->getMode() == EngineTalkoverDucking::AUTO &&
+            !m_activeTalkoverChannels.isEmpty()) ||
+            m_pTalkoverDucking->getMode() == EngineTalkoverDucking::MANUAL) {
         talkOvergain = m_pTalkoverDucking->getGain();
     }
     m_masterGain.setGains(crossfaderLeftGain, 1.0, crossfaderRightGain,

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -483,8 +483,12 @@ void EngineMaster::process(const int iBufferSize) {
     // m_masterGain takes care of applying the attenuation from
     // channel volume faders, crossfader, and talkover ducking.
     // Talkover is mixed in later according to the configured MicMonitorMode
+    CSAMPLE talkOvergain = 1;
+    if (!m_activeTalkoverChannels.isEmpty()) {
+        talkOvergain = m_pTalkoverDucking->getGain();
+    }
     m_masterGain.setGains(crossfaderLeftGain, 1.0, crossfaderRightGain,
-                            m_pTalkoverDucking->getGain(m_iBufferSize / 2));
+                            talkOvergain);
 
     for (int o = EngineChannel::LEFT; o <= EngineChannel::RIGHT; o++) {
         ChannelMixer::applyEffectsInPlaceAndMixChannels(

--- a/src/engine/enginetalkoverducking.cpp
+++ b/src/engine/enginetalkoverducking.cpp
@@ -64,16 +64,11 @@ void EngineTalkoverDucking::slotDuckModeChanged(double mode) {
    m_pConfig->set(ConfigKey(m_group, "duckMode"), ConfigValue(mode));
 }
 
-CSAMPLE EngineTalkoverDucking::getGain(int numFrames) {
+CSAMPLE EngineTalkoverDucking::getGain() {
     // Apply microphone ducking.
-    switch (getMode()) {
-      case EngineTalkoverDucking::OFF:
+    if (getMode() == EngineTalkoverDucking::OFF) {
         return 1.0;
-      case EngineTalkoverDucking::AUTO:
-        return calculateCompressedGain(numFrames);
-      case EngineTalkoverDucking::MANUAL:
+    } else {
         return m_pDuckStrength->get();
     }
-    qWarning() << "Invalid ducking mode, returning 1.0";
-    return 1.0;
 }

--- a/src/engine/enginetalkoverducking.h
+++ b/src/engine/enginetalkoverducking.h
@@ -22,7 +22,7 @@ class EngineTalkoverDucking : public QObject, public EngineSideChainCompressor {
         return static_cast<TalkoverDuckSetting>(int(m_pTalkoverDucking->get()));
     }
 
-    CSAMPLE getGain(int numFrames);
+    CSAMPLE getGain();
 
   public slots:
     void slotSampleRateChanged(double);


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1737113
"Manual duck not works"
maybe also https://bugs.launchpad.net/mixxx/+bug/1662536
"Manual Ducking inconsistent behavior"

I'm sure this fix is not the most efficient solution as I'm not very much into the engine code.
First I'd like to check if I got the concept right, after that please comment how the code can be improved.

The Ducking Mode toolip says
**Off**: Do not reduce music volume
**Auto**: Automatically reduce music volume when microphones are in use. Adjust the amount the music volume is reduced with the Strength knob.
**Manual**: Reduce music volume by a fixed amount set by the Strength knob

So Auto mode should reduce the music volume if any Mic Talkover button is pressed?

First I looked at _EngineTalkoverDucking::getGain_ because this is what is called from _EngineMaster::process_ to adjust the master gain. With AUTO mode, this does some compression calculation that seems to depend on the Mic level but hardly returns values below 0.9, even if I crank up the Mic pregain to make the Mic input clip. So, hardly any effect on master gain.