### PR TITLE
hack around macOS segfault on startup

### DIFF
--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -199,8 +199,11 @@ void Logging::initialize(const QDir& settingsDir,
     // Fedora: https://bugzilla.redhat.com/show_bug.cgi?id=1227295
     // Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=886437
     // Ubuntu: https://bugs.launchpad.net/ubuntu/+source/qtbase-opensource-src/+bug/1731646
+    // Somehow this causes a segfault on macOS though?? https://bugs.launchpad.net/mixxx/+bug/1871238
+#ifdef __LINUX__
     QLoggingCategory::setFilterRules("*.debug=true\n"
                                      "qt.*.debug=false");
+#endif
 }
 
 // static


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1871238

I don't know why this is leading to a segfault, but if I understand correctly this code is only needed on Linux anyway.