### PR TITLE
Switch to pip3 for Ubuntu Appveyor CI build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,12 +86,12 @@ for:
       libwavpack-dev
       portaudio19-dev
       protobuf-compiler
-      python-pip
+      python3-pip
       qt5-default
       qt5keychain-dev
       qtscript5-dev
       xsltproc
-    - sudo pip install cmake
+    - sudo pip3 install cmake
 
   before_build:
      # Limit cache size to 100 MB


### PR DESCRIPTION
pip on Python 2.7 is deprecated.