### PR TITLE
test/cuecontrol_test: Fix compile error due to missing method

### DIFF
--- a/src/test/cuecontrol_test.cpp
+++ b/src/test/cuecontrol_test.cpp
@@ -309,7 +309,11 @@ TEST_F(CueControlTest, FollowCueOnQuantize) {
     config()->set(ConfigKey("[Controls]", "CueRecall"),
             ConfigValue(static_cast<int>(SeekOnLoadMode::MainCue)));
     TrackPointer pTrack = createTestTrack();
-    pTrack->setSampleRate(44100);
+    pTrack->setAudioProperties(
+            mixxx::kEngineChannelCount,
+            mixxx::audio::SampleRate(44100),
+            mixxx::audio::Bitrate(),
+            mixxx::Duration::fromSeconds(10));
     pTrack->setBpm(120.0);
 
     const int frameSize = 2;


### PR DESCRIPTION
The test was added in #2593 but the Track::setSampleRate method was removed in
didn't help detecting this in this case.