### PR TITLE
Reloop TM2/4: remove linebreaks from mapping description

### DIFF
--- a/res/controllers/Reloop Terminal Mix 2-4.midi.xml
+++ b/res/controllers/Reloop Terminal Mix 2-4.midi.xml
@@ -3,9 +3,7 @@
   <info>
     <name>Reloop Terminal Mix 2/4</name>
     <author>Sean M. Pappalardo (1.11), ronso0 (2.1 update)</author>
-    <description>
-A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
-    </description>
+    <description>A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.</description>
     <wiki>http://mixxx.org/wiki/doku.php/reloop_terminal_mix</wiki>
   </info>
   <controller id="TerminalMix">


### PR DESCRIPTION
... to align the description text with the label in the left column.