### PR TITLE
[WiP] Remove <experimental/optional> hack from util/optional.h

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ jobs:
 
     - name: OSX/clang/SCons build
       os: osx
-      osx_image: xcode11
+      osx_image: xcode9.3
       compiler: clang
       cache:
         directories:
@@ -127,7 +127,7 @@ jobs:
 
     - name: OSX/clang/CMake build
       os: osx
-      osx_image: xcode11
+      osx_image: xcode9.3
       compiler: clang
       cache:
         ccache: true

--- a/src/util/optional.h
+++ b/src/util/optional.h
@@ -1,27 +1,6 @@
 #pragma once
 
-#if __has_include(<optional>) || \
-    (defined(__cpp_lib_optional) && __cpp_lib_optional >= 201606L)
-
 #include <optional>
-
-#else
-
-#include <experimental/optional>
-
-namespace std {
-
-using std::experimental::make_optional;
-using std::experimental::nullopt;
-using std::experimental::optional;
-
-// Workarounds for missing member functions:
-// option::has_value() -> explicit operator bool()
-// option::value() -> operator*()
-
-} // namespace std
-
-#endif
 
 #include <QtDebug>
 


### PR DESCRIPTION
Try to fix the macOS build on the build server caused by #2601.