### PR TITLE
Disable -Winvalid-constexpr 

### DIFF
--- a/src/util/optional.h
+++ b/src/util/optional.h
@@ -7,6 +7,8 @@
 
 #else
 
+#pragma clang diagnostic ignored "-Winvalid-constexpr"
+
 #include <experimental/optional>
 
 namespace std {

--- a/src/util/optional.h
+++ b/src/util/optional.h
@@ -7,7 +7,9 @@
 
 #else
 
+#ifdef __clang__
 #pragma clang diagnostic ignored "-Winvalid-constexpr"
+#endif
 
 #include <experimental/optional>
 


### PR DESCRIPTION
... in case of <experimental/optional> is usd which has no constexpr constructor.

Hopefully this fixes the Jenkins MacOs builds until the compiler is updated.  