### PR TITLE
Unofficial Pre c++17 Ubuntu Xenial

### DIFF
--- a/src/audio/signalinfo.h
+++ b/src/audio/signalinfo.h
@@ -19,7 +19,7 @@ class SignalInfo final {
   public:
     constexpr SignalInfo() = default;
     constexpr explicit SignalInfo(
-            OptionalSampleLayout sampleLayout)
+            SampleLayout sampleLayout)
             : m_sampleLayout(sampleLayout) {
     }
     SignalInfo(

--- a/src/audio/signalinfo.h
+++ b/src/audio/signalinfo.h
@@ -12,9 +12,9 @@ namespace audio {
 // Properties that characterize an uncompressed PCM audio signal.
 class SignalInfo final {
     // Properties
-    PROPERTY_SET_BYVAL_GET_BYREF(ChannelCount, channelCount, ChannelCount)
-    PROPERTY_SET_BYVAL_GET_BYREF(SampleRate, sampleRate, SampleRate)
-    PROPERTY_SET_BYVAL_GET_BYREF(OptionalSampleLayout, sampleLayout, SampleLayout)
+    PROPERTY_SET_BYVAL_GET_BYREF_CONSTEXPR(ChannelCount, channelCount, ChannelCount)
+    PROPERTY_SET_BYVAL_GET_BYREF_CONSTEXPR(SampleRate, sampleRate, SampleRate)
+    PROPERTY_SET_BYVAL_GET_BYREF_CONSTEXPR(OptionalSampleLayout, sampleLayout, SampleLayout)
 
   public:
     constexpr SignalInfo() = default;

--- a/src/audio/streaminfo.h
+++ b/src/audio/streaminfo.h
@@ -13,9 +13,9 @@ namespace audio {
 // that is known upfront!
 class StreamInfo final {
     // Properties
-    PROPERTY_SET_BYVAL_GET_BYREF(SignalInfo, signalInfo, SignalInfo)
-    PROPERTY_SET_BYVAL_GET_BYREF(Bitrate, bitrate, Bitrate)
-    PROPERTY_SET_BYVAL_GET_BYREF(Duration, duration, Duration)
+    PROPERTY_SET_BYVAL_GET_BYREF_CONSTEXPR(SignalInfo, signalInfo, SignalInfo)
+    PROPERTY_SET_BYVAL_GET_BYREF_CONSTEXPR(Bitrate, bitrate, Bitrate)
+    PROPERTY_SET_BYVAL_GET_BYREF_CONSTEXPR(Duration, duration, Duration)
 
   public:
     constexpr StreamInfo() = default;

--- a/src/audio/streaminfo.h
+++ b/src/audio/streaminfo.h
@@ -19,11 +19,7 @@ class StreamInfo final {
 
   public:
     constexpr StreamInfo() = default;
-    constexpr explicit StreamInfo(
-            const SignalInfo& signalInfo)
-            : m_signalInfo(signalInfo) {
-    }
-    constexpr StreamInfo(
+    StreamInfo(
             const SignalInfo& signalInfo,
             Bitrate bitrate,
             Duration duration)

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -316,7 +316,9 @@ void TrackDAO::slotDatabaseTracksRelocated(QList<RelocatedTrack> relocatedTracks
         }
     }
     DEBUG_ASSERT(removedTrackIds.size() <= changedTrackIds.size());
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     DEBUG_ASSERT(!removedTrackIds.intersects(changedTrackIds));
+#endif
     if (!removedTrackIds.isEmpty()) {
         emit tracksRemoved(removedTrackIds);
     }

--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -262,5 +262,5 @@ std::unique_ptr<QueryNode> SearchQueryParser::parseQuery(const QString& query,
         parseTokens(tokens, searchColumns, pQuery.get());
     }
 
-    return pQuery;
+    return std::unique_ptr<QueryNode>(pQuery.release());
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,8 +69,10 @@ int main(int argc, char * argv[]) {
     QCoreApplication::setOrganizationDomain("mixxx.org");
 
     // This needs to be set before initializing the QApplication.
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
 
     // Setting the organization name results in a QDesktopStorage::DataLocation
     // of "$HOME/Library/Application Support/Mixxx/Mixxx" on OS X. Leave the

--- a/src/network/jsonwebtask.cpp
+++ b/src/network/jsonwebtask.cpp
@@ -1,11 +1,18 @@
 #include "network/jsonwebtask.h"
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 8, 0)
+#include <QBuffer>
+#endif
 #include <QMetaMethod>
 #include <QMimeDatabase>
 #include <QNetworkRequest>
 #include <QTimerEvent>
 #include <mutex> // std::once_flag
 
+#include "util/assert.h"
+#if QT_VERSION < QT_VERSION_CHECK(5, 7, 0)
+#include "util/compatibility.h"
+#endif
 #include "util/counter.h"
 #include "util/logger.h"
 #include "util/thread_affinity.h"
@@ -93,7 +100,9 @@ QNetworkRequest newRequest(
         const QUrl& url) {
     QNetworkRequest request(url);
     request.setHeader(QNetworkRequest::ContentTypeHeader, JSON_CONTENT_TYPE);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
+#endif
     return request;
 }
 
@@ -198,10 +207,19 @@ QNetworkReply* JsonWebTask::sendNetworkRequest(
                     << url
                     << body;
         }
+#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
         return networkAccessManager->sendCustomRequest(
                 newRequest(url),
                 "PATCH",
                 body);
+#else
+        auto* buffer = new QBuffer(this);
+        buffer->setData(body);
+        return networkAccessManager->sendCustomRequest(
+                newRequest(url),
+                "PATCH",
+                buffer);
+#endif
     }
     case HttpRequestMethod::Delete: {
         DEBUG_ASSERT(content.isEmpty());
@@ -258,6 +276,8 @@ bool JsonWebTask::doStart(
     connect(m_pendingNetworkReply,
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
             &QNetworkReply::errorOccurred,
+#elif QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+            qOverload<QNetworkReply::NetworkError>(&QNetworkReply::error),
 #else
             QOverload<QNetworkReply::NetworkError>::of(&QNetworkReply::error),
 #endif

--- a/src/preferences/colorpaletteeditormodel.cpp
+++ b/src/preferences/colorpaletteeditormodel.cpp
@@ -10,6 +10,9 @@ QIcon toQIcon(const QColor& color) {
 
 } // namespace
 
+//static
+const int ColorPaletteEditorModel::kNoHotcueIndex = -1;
+
 ColorPaletteEditorModel::ColorPaletteEditorModel(QObject* parent)
         : QStandardItemModel(parent),
           m_bEmpty(true),

--- a/src/preferences/colorpaletteeditormodel.h
+++ b/src/preferences/colorpaletteeditormodel.h
@@ -9,7 +9,7 @@
 class ColorPaletteEditorModel : public QStandardItemModel {
     Q_OBJECT
   public:
-    static constexpr int kNoHotcueIndex = -1;
+    static const int kNoHotcueIndex;
 
     ColorPaletteEditorModel(QObject* parent = nullptr);
 

--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -41,6 +41,10 @@ inline double positionMillisToSamples(
 }
 
 //static
+const double Cue::kNoPosition = -1.0;
+const int Cue::kNoHotCue = -1;
+
+//static
 void CuePointer::deleteLater(Cue* pCue) {
     if (pCue) {
         pCue->deleteLater();

--- a/src/track/cue.h
+++ b/src/track/cue.h
@@ -18,8 +18,8 @@ class Cue : public QObject {
     Q_OBJECT
 
   public:
-    static constexpr double kNoPosition = -1.0;
-    static constexpr int kNoHotCue = -1;
+    static const double kNoPosition;
+    static const int kNoHotCue;
 
     Cue();
     Cue(

--- a/src/track/serato/markers.cpp
+++ b/src/track/serato/markers.cpp
@@ -517,7 +517,7 @@ QByteArray SeratoMarkers::dumpMP4() const {
         stream.writeRawData(pEntry->dumpMP4(), kEntrySizeMP4);
     }
 
-    RgbColor trackColor = m_trackColor.value_or(SeratoTags::kDefaultTrackColor);
+    RgbColor trackColor = m_trackColor.value_or(RgbColor(SeratoTags::kDefaultTrackColor));
     stream << static_cast<quint8>(0x00)
            << static_cast<quint8>(qRed(trackColor))
            << static_cast<quint8>(qGreen(trackColor))

--- a/src/track/serato/tags.cpp
+++ b/src/track/serato/tags.cpp
@@ -79,6 +79,10 @@ namespace mixxx {
 ///
 /// See this for details:
 /// https://github.com/Holzhaus/serato-tags/blob/master/docs/colors.md#track-colors
+
+const RgbColor SeratoTags::kDefaultTrackColor = RgbColor(0xFF9999);
+const RgbColor SeratoTags::kDefaultCueColor = RgbColor(0xCC0000);
+
 RgbColor::optional_t SeratoTags::storedToDisplayedTrackColor(RgbColor color) {
     if (color == 0xFFFFFF) {
         return RgbColor::nullopt();

--- a/src/track/serato/tags.h
+++ b/src/track/serato/tags.h
@@ -11,8 +11,8 @@ namespace mixxx {
 /// Serato DJ Pro software.
 class SeratoTags final {
   public:
-    static constexpr RgbColor kDefaultTrackColor = RgbColor(0xFF9999);
-    static constexpr RgbColor kDefaultCueColor = RgbColor(0xCC0000);
+    static const RgbColor kDefaultTrackColor;
+    static const RgbColor kDefaultCueColor;
 
     SeratoTags() = default;
 

--- a/src/track/taglib/trackmetadata_xiph.h
+++ b/src/track/taglib/trackmetadata_xiph.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <taglib/flacpicture.h>
 #include <taglib/xiphcomment.h>
 
 #include "track/taglib/trackmetadata_common.h"

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -48,16 +48,16 @@ class RgbColor {
 
     typedef std::optional<RgbColor> optional_t;
 
-    static constexpr optional_t nullopt() {
+    static optional_t nullopt() {
         return std::nullopt;
     }
 
     // Overloaded conversion functions for conveniently creating
     // std::optional<RgbColor>.
-    static constexpr optional_t optional(code_t code) {
+    static optional_t optional(code_t code) {
         return optional(RgbColor(code));
     }
-    static constexpr optional_t optional(RgbColor color) {
+    static optional_t optional(RgbColor color) {
         return std::make_optional(color);
     }
 

--- a/src/util/compatibility.h
+++ b/src/util/compatibility.h
@@ -2,24 +2,102 @@
 
 #include <QCoreApplication>
 #include <QGuiApplication>
+#include <QList>
 #include <QScreen>
 #include <QUuid>
+#include <QWindow>
 #include <QWidget>
 
 #include "util/assert.h"
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 7, 0)
+
+// this adds const to non-const objects (like std::as_const)
+template <typename T>
+struct QAddConst { typedef const T Type; };
+template <typename T>
+constexpr typename QAddConst<T>::Type &qAsConst(T &t) { return t; }
+// prevent rvalue arguments:
+template <typename T>
+void qAsConst(const T &&) = delete;
+
+template <typename... Args>
+struct QNonConstOverload
+{
+    template <typename R, typename T>
+    Q_DECL_CONSTEXPR auto operator()(R (T::*ptr)(Args...)) const Q_DECL_NOTHROW -> decltype(ptr)
+    { return ptr; }
+
+    template <typename R, typename T>
+    static Q_DECL_CONSTEXPR auto of(R (T::*ptr)(Args...)) Q_DECL_NOTHROW -> decltype(ptr)
+    { return ptr; }
+};
+
+template <typename... Args>
+struct QConstOverload
+{
+    template <typename R, typename T>
+    Q_DECL_CONSTEXPR auto operator()(R (T::*ptr)(Args...) const) const Q_DECL_NOTHROW -> decltype(ptr)
+    { return ptr; }
+
+    template <typename R, typename T>
+    static Q_DECL_CONSTEXPR auto of(R (T::*ptr)(Args...) const) Q_DECL_NOTHROW -> decltype(ptr)
+    { return ptr; }
+};
+
+template <typename... Args>
+struct QOverload : QConstOverload<Args...>, QNonConstOverload<Args...>
+{
+    using QConstOverload<Args...>::of;
+    using QConstOverload<Args...>::operator();
+    using QNonConstOverload<Args...>::of;
+    using QNonConstOverload<Args...>::operator();
+
+    template <typename R>
+    Q_DECL_CONSTEXPR auto operator()(R (*ptr)(Args...)) const Q_DECL_NOTHROW -> decltype(ptr)
+    { return ptr; }
+
+    template <typename R>
+    static Q_DECL_CONSTEXPR auto of(R (*ptr)(Args...)) Q_DECL_NOTHROW -> decltype(ptr)
+    { return ptr; }
+};
+
+#endif
+
+
 inline qreal getDevicePixelRatioF(const QWidget* widget) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     return widget->devicePixelRatioF();
+#endif
+
+    // Crawl up to the window and return qreal value
+    QWindow* window = widget->window()->windowHandle();
+    if (window) {
+        return window->devicePixelRatio();
+    }
+
+    // return integer value as last resort
+    return widget->devicePixelRatio();
 }
 
 inline QScreen* getPrimaryScreen() {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     QGuiApplication* app = static_cast<QGuiApplication*>(QCoreApplication::instance());
     VERIFY_OR_DEBUG_ASSERT(app) {
         qWarning() << "Unable to get applications QCoreApplication instance, cannot determine primary screen!";
-        // All attempts to find primary screen failed, return nullptr
-        return nullptr;
+    } else {
+        return app->primaryScreen();
     }
-    return app->primaryScreen();
+#endif
+    const QList<QScreen*> screens = QGuiApplication::screens();
+    VERIFY_OR_DEBUG_ASSERT(!screens.isEmpty()) {
+        qWarning() << "No screens found, cannot determine primary screen!";
+    } else {
+        return screens.first();
+    }
+
+    // All attempts to find primary screen failed, return nullptr
+    return nullptr;
 }
 
 inline
@@ -128,3 +206,14 @@ inline void atomicStoreRelaxed(QAtomicPointer<T>& atomicPtr, T* newValue) {
     atomicPtr.store(newValue);
 #endif
 }
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 6, 0)
+template<typename T>
+inline uint qHash(const QList<T>& key, uint seed = 0) {
+    uint hash = 0;
+    for (const auto& elem : key) {
+        hash ^= qHash(elem, seed);
+    }
+    return hash;
+}
+#endif

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -29,7 +29,7 @@ QFile s_logfile;
 // Whether to break on debug assertions.
 bool s_debugAssertBreak = false;
 
-const QLoggingCategory kDefaultLoggingCategory = QLoggingCategory(nullptr);
+const QLoggingCategory kDefaultLoggingCategory(nullptr);
 
 enum class WriteFlag {
     None = 0,

--- a/src/util/macros.h
+++ b/src/util/macros.h
@@ -20,12 +20,98 @@
 // immutable access by a pointer.
 //
 // TODO: Adjust the name of this macro, e.g. DECL_MIXXX_PROPERTY
-#define PROPERTY_SET_BYVAL_GET_BYREF(TYPE, NAME, CAP_NAME) \
-public: template <typename T> typename std::enable_if<(std::is_fundamental<TYPE>::value || std::is_same<TYPE, bool>::value) && std::is_same<TYPE, T>::value>::type set##CAP_NAME(T _val) { m_##NAME = _val; } \
-public: template <typename T> typename std::enable_if<!(std::is_fundamental<TYPE>::value || std::is_same<TYPE, bool>::value) && std::is_assignable<TYPE, T>::value>::type set##CAP_NAME(T&& _val) { m_##NAME = std::forward<T>(_val); } \
-public: constexpr std::conditional<std::is_fundamental<TYPE>::value, TYPE, const TYPE&>::type get##CAP_NAME() const { return m_##NAME; } \
-public: constexpr TYPE& ref##CAP_NAME() { return m_##NAME; } \
-public: constexpr TYPE* ptr##CAP_NAME() { return &m_##NAME; } \
-public: constexpr const TYPE* ptr##CAP_NAME() const { return &m_##NAME; } \
-public: QDebug dbg##CAP_NAME(QDebug dbg) const { return dbg << #NAME ":" << m_##NAME; } \
-private: TYPE m_##NAME;
+#define PROPERTY_SET_BYVAL_GET_BYREF_CONSTEXPR(TYPE, NAME, CAP_NAME)    \
+  public:                                                               \
+    template<typename T>                                                \
+    typename std::enable_if<(std::is_fundamental<TYPE>::value ||        \
+                                    std::is_same<TYPE, bool>::value) && \
+            std::is_same<TYPE, T>::value>::type set##CAP_NAME(T _val) { \
+        m_##NAME = _val;                                                \
+    }                                                                   \
+                                                                        \
+  public:                                                               \
+    template<typename T>                                                \
+    typename std::enable_if<!(std::is_fundamental<TYPE>::value ||       \
+                                    std::is_same<TYPE, bool>::value) && \
+            std::is_assignable<TYPE, T>::value>::type                   \
+            set##CAP_NAME(T&& _val) {                                   \
+        m_##NAME = std::forward<T>(_val);                               \
+    }                                                                   \
+                                                                        \
+  public:                                                               \
+    constexpr std::conditional<std::is_fundamental<TYPE>::value,        \
+            TYPE,                                                       \
+            const TYPE&>::type get##CAP_NAME() const {                  \
+        return m_##NAME;                                                \
+    }                                                                   \
+                                                                        \
+  public:                                                               \
+    constexpr TYPE& ref##CAP_NAME() {                                   \
+        return m_##NAME;                                                \
+    }                                                                   \
+                                                                        \
+  public:                                                               \
+    constexpr TYPE* ptr##CAP_NAME() {                                   \
+        return &m_##NAME;                                               \
+    }                                                                   \
+                                                                        \
+  public:                                                               \
+    constexpr const TYPE* ptr##CAP_NAME() const {                       \
+        return &m_##NAME;                                               \
+    }                                                                   \
+                                                                        \
+  public:                                                               \
+    QDebug dbg##CAP_NAME(QDebug dbg) const {                            \
+        return dbg << #NAME ":" << m_##NAME;                            \
+    }                                                                   \
+                                                                        \
+  private:                                                              \
+    TYPE m_##NAME;
+
+#define PROPERTY_SET_BYVAL_GET_BYREF(TYPE, NAME, CAP_NAME)              \
+  public:                                                               \
+    template<typename T>                                                \
+    typename std::enable_if<(std::is_fundamental<TYPE>::value ||        \
+                                    std::is_same<TYPE, bool>::value) && \
+            std::is_same<TYPE, T>::value>::type set##CAP_NAME(T _val) { \
+        m_##NAME = _val;                                                \
+    }                                                                   \
+                                                                        \
+  public:                                                               \
+    template<typename T>                                                \
+    typename std::enable_if<!(std::is_fundamental<TYPE>::value ||       \
+                                    std::is_same<TYPE, bool>::value) && \
+            std::is_assignable<TYPE, T>::value>::type                   \
+            set##CAP_NAME(T&& _val) {                                   \
+        m_##NAME = std::forward<T>(_val);                               \
+    }                                                                   \
+                                                                        \
+  public:                                                               \
+    inline std::conditional<std::is_fundamental<TYPE>::value,           \
+            TYPE,                                                       \
+            const TYPE&>::type get##CAP_NAME() const {                  \
+        return m_##NAME;                                                \
+    }                                                                   \
+                                                                        \
+  public:                                                               \
+    inline TYPE& ref##CAP_NAME() {                                      \
+        return m_##NAME;                                                \
+    }                                                                   \
+                                                                        \
+  public:                                                               \
+    inline TYPE* ptr##CAP_NAME() {                                      \
+        return &m_##NAME;                                               \
+    }                                                                   \
+                                                                        \
+  public:                                                               \
+    inline const TYPE* ptr##CAP_NAME() const {                          \
+        return &m_##NAME;                                               \
+    }                                                                   \
+                                                                        \
+  public:                                                               \
+    QDebug dbg##CAP_NAME(QDebug dbg) const {                            \
+        return dbg << #NAME ":" << m_##NAME;                            \
+    }                                                                   \
+                                                                        \
+  private:                                                              \
+    TYPE m_##NAME;

--- a/src/util/optional.h
+++ b/src/util/optional.h
@@ -7,10 +7,6 @@
 
 #else
 
-#ifdef __clang__
-#pragma clang diagnostic ignored "-Winvalid-constexpr"
-#endif
-
 #include <experimental/optional>
 
 namespace std {

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -303,5 +303,5 @@ WaveformMarkPointer WaveformWidgetRenderer::getCueMarkAtPoint(QPoint point) cons
             return pMark;
         }
     }
-    return nullptr;
+    return WaveformMarkPointer();
 }

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -153,7 +153,7 @@ void WWaveformViewer::mouseMoveEvent(QMouseEvent* event) {
         } else {
             if (m_pHoveredMark) {
                 unhighlightMark(m_pHoveredMark);
-                m_pHoveredMark = nullptr;
+                m_pHoveredMark.clear();
             }
         }
     }
@@ -195,7 +195,7 @@ void WWaveformViewer::dropEvent(QDropEvent* event) {
 void WWaveformViewer::leaveEvent(QEvent*) {
     if (m_pHoveredMark) {
         unhighlightMark(m_pHoveredMark);
-        m_pHoveredMark = nullptr;
+        m_pHoveredMark.clear();
     }
 }
 


### PR DESCRIPTION
With this PR, compiling with c++14 compilers should be still possible.

This removes also the alternative solution for clang dieabling -Winvalid-constexpr, Which helps to make correct use of the constexpr keyword. 

We may either merge this branch, or just keep it around for users which are sucked on an outdated compiler for some reasons.
 