### PR TITLE
WaveformRenderMark: fix hotcues getting shifted to the right

### DIFF
--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -150,219 +150,148 @@ void WaveformRenderMark::generateMarkImage(WaveformMarkPointer pMark) {
 
     QPainter painter;
 
-    // If no text is provided, leave m_markImage as a null image
-    if (!pMark->m_text.isNull()) {
-        // Determine mark text.
-        QString label = pMark->m_text;
-        if (pMark->getHotCue() >= 0) {
-            if (!label.isEmpty()) {
-                label.prepend(": ");
-            }
-            label.prepend(QString::number(pMark->getHotCue() + 1));
-            if (label.size() > kMaxCueLabelLength) {
-                label = label.left(kMaxCueLabelLength - 3) + "...";
-            }
+    // Determine mark text.
+    QString label = pMark->m_text;
+    if (pMark->getHotCue() >= 0) {
+        if (!label.isEmpty()) {
+            label.prepend(": ");
         }
-
-        //QFont font("Bitstream Vera Sans");
-        //QFont font("Helvetica");
-        QFont font; // Uses the application default
-        font.setPointSizeF(10 * scaleFactor());
-        font.setStretch(100);
-        font.setWeight(75);
-
-        QFontMetrics metrics(font);
-
-        //fixed margin ...
-        QRect wordRect = metrics.tightBoundingRect(label);
-        const int marginX = 1;
-        const int marginY = 1;
-        wordRect.moveTop(marginX + 1);
-        wordRect.moveLeft(marginY + 1);
-        wordRect.setHeight(wordRect.height() + (wordRect.height()%2));
-        wordRect.setWidth(wordRect.width() + (wordRect.width())%2);
-        //even wordrect to have an even Image >> draw the line in the middle !
-
-        int labelRectWidth = wordRect.width() + 2 * marginX + 4;
-        int labelRectHeight = wordRect.height() + 2 * marginY + 4 ;
-
-        QRectF labelRect(0, 0,
-                (float)labelRectWidth, (float)labelRectHeight);
-
-        int width;
-        int height;
-
-        if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
-            width = 2 * labelRectWidth + 1;
-            height = m_waveformRenderer->getHeight();
-        } else {
-            width = m_waveformRenderer->getWidth();
-            height = 2 * labelRectHeight + 1;
+        label.prepend(QString::number(pMark->getHotCue() + 1));
+        if (label.size() > kMaxCueLabelLength) {
+            label = label.left(kMaxCueLabelLength - 3) + "...";
         }
+    }
 
-        pMark->m_image = QImage(width * m_waveformRenderer->getDevicePixelRatio(),
-                                height * m_waveformRenderer->getDevicePixelRatio(),
-                                QImage::Format_ARGB32_Premultiplied);
-        pMark->m_image.setDevicePixelRatio(m_waveformRenderer->getDevicePixelRatio());
+    //QFont font("Bitstream Vera Sans");
+    //QFont font("Helvetica");
+    QFont font; // Uses the application default
+    font.setPointSizeF(10 * scaleFactor());
+    font.setStretch(100);
+    font.setWeight(75);
 
-        Qt::Alignment markAlignH = pMark->m_align & Qt::AlignHorizontal_Mask;
-        Qt::Alignment markAlignV = pMark->m_align & Qt::AlignVertical_Mask;
+    QFontMetrics metrics(font);
 
+    //fixed margin ...
+    QRect wordRect = metrics.tightBoundingRect(label);
+    const int marginX = 1;
+    const int marginY = 1;
+    wordRect.moveTop(marginX + 1);
+    wordRect.moveLeft(marginY + 1);
+    wordRect.setHeight(wordRect.height() + (wordRect.height() % 2));
+    wordRect.setWidth(wordRect.width() + (wordRect.width()) % 2);
+    //even wordrect to have an even Image >> draw the line in the middle !
+
+    int labelRectWidth = wordRect.width() + 2 * marginX + 4;
+    int labelRectHeight = wordRect.height() + 2 * marginY + 4;
+
+    QRectF labelRect(0, 0, (float)labelRectWidth, (float)labelRectHeight);
+
+    int width;
+    int height;
+
+    if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
+        width = 2 * labelRectWidth + 1;
+        height = m_waveformRenderer->getHeight();
+    } else {
+        width = m_waveformRenderer->getWidth();
+        height = 2 * labelRectHeight + 1;
+    }
+
+    pMark->m_image = QImage(width * m_waveformRenderer->getDevicePixelRatio(),
+            height * m_waveformRenderer->getDevicePixelRatio(),
+            QImage::Format_ARGB32_Premultiplied);
+    pMark->m_image.setDevicePixelRatio(m_waveformRenderer->getDevicePixelRatio());
+
+    Qt::Alignment markAlignH = pMark->m_align & Qt::AlignHorizontal_Mask;
+    Qt::Alignment markAlignV = pMark->m_align & Qt::AlignVertical_Mask;
+
+    if (markAlignH == Qt::AlignHCenter) {
+        labelRect.moveLeft((width - labelRectWidth) / 2);
+    } else if (markAlignH == Qt::AlignRight) {
+        labelRect.moveRight(width - 1);
+    }
+
+    if (markAlignV == Qt::AlignVCenter) {
+        labelRect.moveTop((height - labelRectHeight) / 2);
+    } else if (markAlignV == Qt::AlignBottom) {
+        labelRect.moveBottom(height - 1);
+    }
+
+    // Fill with transparent pixels
+    pMark->m_image.fill(QColor(0, 0, 0, 0).rgba());
+
+    painter.begin(&pMark->m_image);
+    painter.setRenderHint(QPainter::TextAntialiasing);
+
+    painter.setWorldMatrixEnabled(false);
+
+    // Draw marker lines
+    if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
+        int middle = width / 2;
         if (markAlignH == Qt::AlignHCenter) {
-            labelRect.moveLeft((width - labelRectWidth) / 2);
-        } else if (markAlignH == Qt::AlignRight) {
-            labelRect.moveRight(width - 1);
-        }
+            if (labelRect.top() > 0) {
+                painter.setPen(pMark->fillColor());
+                painter.drawLine(middle, 0, middle, labelRect.top());
 
+                painter.setPen(pMark->borderColor());
+                painter.drawLine(middle - 1, 0, middle - 1, labelRect.top());
+                painter.drawLine(middle + 1, 0, middle + 1, labelRect.top());
+            }
+
+            if (labelRect.bottom() < height) {
+                painter.setPen(pMark->fillColor());
+                painter.drawLine(middle, labelRect.bottom(), middle, height);
+
+                painter.setPen(pMark->borderColor());
+                painter.drawLine(middle - 1, labelRect.bottom(), middle - 1, height);
+                painter.drawLine(middle + 1, labelRect.bottom(), middle + 1, height);
+            }
+        } else { // AlignLeft || AlignRight
+            painter.setPen(pMark->fillColor());
+            painter.drawLine(middle, 0, middle, height);
+
+            painter.setPen(pMark->borderColor());
+            painter.drawLine(middle - 1, 0, middle - 1, height);
+            painter.drawLine(middle + 1, 0, middle + 1, height);
+        }
+    } else { // Vertical
+        int middle = height / 2;
         if (markAlignV == Qt::AlignVCenter) {
-            labelRect.moveTop((height - labelRectHeight) / 2);
-        } else if (markAlignV == Qt::AlignBottom) {
-            labelRect.moveBottom(height - 1);
-        }
-
-        // Fill with transparent pixels
-        pMark->m_image.fill(QColor(0,0,0,0).rgba());
-
-        painter.begin(&pMark->m_image);
-        painter.setRenderHint(QPainter::TextAntialiasing);
-
-        painter.setWorldMatrixEnabled(false);
-
-        // Draw marker lines
-        if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
-            int middle = width / 2;
-            if (markAlignH == Qt::AlignHCenter) {
-                if (labelRect.top() > 0) {
-                    painter.setPen(pMark->fillColor());
-                    painter.drawLine(middle, 0, middle, labelRect.top());
-
-                    painter.setPen(pMark->borderColor());
-                    painter.drawLine(middle - 1, 0, middle - 1, labelRect.top());
-                    painter.drawLine(middle + 1, 0, middle + 1, labelRect.top());
-                }
-
-                if (labelRect.bottom() < height) {
-                    painter.setPen(pMark->fillColor());
-                    painter.drawLine(middle, labelRect.bottom(), middle, height);
-
-                    painter.setPen(pMark->borderColor());
-                    painter.drawLine(middle - 1, labelRect.bottom(), middle - 1, height);
-                    painter.drawLine(middle + 1, labelRect.bottom(), middle + 1, height);
-                }
-            } else {  // AlignLeft || AlignRight
+            if (labelRect.left() > 0) {
                 painter.setPen(pMark->fillColor());
-                painter.drawLine(middle, 0, middle, height);
+                painter.drawLine(0, middle, labelRect.left(), middle);
 
                 painter.setPen(pMark->borderColor());
-                painter.drawLine(middle - 1, 0, middle - 1, height);
-                painter.drawLine(middle + 1, 0, middle + 1, height);
+                painter.drawLine(0, middle - 1, labelRect.left(), middle - 1);
+                painter.drawLine(0, middle + 1, labelRect.left(), middle + 1);
             }
-        } else {  // Vertical
-            int middle = height / 2;
-            if (markAlignV == Qt::AlignVCenter) {
-                if (labelRect.left() > 0) {
-                    painter.setPen(pMark->fillColor());
-                    painter.drawLine(0, middle, labelRect.left(), middle);
 
-                    painter.setPen(pMark->borderColor());
-                    painter.drawLine(0, middle - 1, labelRect.left(), middle - 1);
-                    painter.drawLine(0, middle + 1, labelRect.left(), middle + 1);
-                }
-
-                if (labelRect.right() < width) {
-                    painter.setPen(pMark->fillColor());
-                    painter.drawLine(labelRect.right(), middle, width, middle);
-
-                    painter.setPen(pMark->borderColor());
-                    painter.drawLine(labelRect.right(), middle - 1, width, middle - 1);
-                    painter.drawLine(labelRect.right(), middle + 1, width, middle + 1);
-                }
-            } else {  // AlignTop || AlignBottom
+            if (labelRect.right() < width) {
                 painter.setPen(pMark->fillColor());
-                painter.drawLine(0, middle, width, middle);
+                painter.drawLine(labelRect.right(), middle, width, middle);
 
                 painter.setPen(pMark->borderColor());
-                painter.drawLine(0, middle - 1, width, middle - 1);
-                painter.drawLine(0, middle + 1, width, middle + 1);
+                painter.drawLine(labelRect.right(), middle - 1, width, middle - 1);
+                painter.drawLine(labelRect.right(), middle + 1, width, middle + 1);
             }
+        } else { // AlignTop || AlignBottom
+            painter.setPen(pMark->fillColor());
+            painter.drawLine(0, middle, width, middle);
+
+            painter.setPen(pMark->borderColor());
+            painter.drawLine(0, middle - 1, width, middle - 1);
+            painter.drawLine(0, middle + 1, width, middle + 1);
         }
-
-        // Draw the label rect
-        painter.setPen(pMark->borderColor());
-        painter.setBrush(QBrush(pMark->fillColor()));
-        painter.drawRoundedRect(labelRect, 2.0, 2.0);
-
-        // Draw text
-        painter.setBrush(QBrush(QColor(0,0,0,0)));
-        painter.setFont(font);
-        painter.setPen(pMark->labelColor());
-        painter.drawText(labelRect, Qt::AlignCenter, label);
     }
-    else //no text draw triangle
-    {
-        float triangleSize = 9.0;
-        float markLength = triangleSize + 1.0;
-        float markBreadth = m_waveformRenderer->getBreadth();
 
-        int width, height;
+    // Draw the label rect
+    painter.setPen(pMark->borderColor());
+    painter.setBrush(QBrush(pMark->fillColor()));
+    painter.drawRoundedRect(labelRect, 2.0, 2.0);
 
-        if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
-            width = markLength;
-            height = markBreadth;
-        } else {
-            width = markBreadth;
-            height = markLength;
-        }
-
-        pMark->m_image = QImage(width, height, QImage::Format_ARGB32_Premultiplied);
-        pMark->m_image.fill(QColor(0,0,0,0).rgba());
-
-        painter.begin(&pMark->m_image);
-        painter.setRenderHint(QPainter::TextAntialiasing);
-
-        painter.setWorldMatrixEnabled(false);
-
-        // Rotate if drawing vertical waveforms
-        if (m_waveformRenderer->getOrientation() == Qt::Vertical) {
-            painter.setTransform(QTransform(0, 1, 1, 0, 0, 0));
-        }
-
-        QColor triangleColor = pMark->fillColor();
-        painter.setPen(QColor(0,0,0,0));
-        painter.setBrush(QBrush(triangleColor));
-
-        //vRince: again don't ask about the +-0.1 0.5 ...
-        // just to make it nice in Qt ...
-
-        QPolygonF triangle;
-        triangle.append(QPointF(0.5,0));
-        triangle.append(QPointF(triangleSize+0.5,0));
-        triangle.append(QPointF(triangleSize*0.5 + 0.1, triangleSize*0.5));
-
-        painter.drawPolygon(triangle);
-
-        triangle.clear();
-        triangle.append(QPointF(0.0,markBreadth));
-        triangle.append(QPointF(triangleSize+0.5,markBreadth));
-        triangle.append(QPointF(triangleSize*0.5 + 0.1, markBreadth - triangleSize*0.5 - 2.1));
-
-        painter.drawPolygon(triangle);
-
-        //TODO vRince duplicated code make a method
-        //draw line
-        QColor lineColor = pMark->fillColor();
-        painter.setPen(lineColor);
-
-        float middle = markLength / 2.0;
-
-        float lineTop = triangleSize * 0.5 + 1;
-        float lineBottom = markBreadth - triangleSize * 0.5 - 1;
-
-        painter.drawLine(middle, lineTop, middle, lineBottom);
-
-        //other lines to increase contrast
-        painter.setPen(QColor(0,0,0,100));
-        painter.drawLine(middle - 1, lineTop, middle - 1, lineBottom);
-        painter.drawLine(middle + 1, lineTop, middle + 1, lineBottom);
-    }
+    // Draw text
+    painter.setBrush(QBrush(QColor(0, 0, 0, 0)));
+    painter.setFont(font);
+    painter.setPen(pMark->labelColor());
+    painter.drawText(labelRect, Qt::AlignCenter, label);
 }


### PR DESCRIPTION
Commit f024e7587f9b30a0890cb7e497d55bc3ef137f28 (from #2529) changed hotcue
creation so hotcues are labelled with a null default constructed
QString instead of an empty string by default. This triggered
a legacy code path in WaveformRenderMark::generateMarkImage which
is no longer needed. This commit deletes the legacy code path
and renders all cue images using the same drawing code regardless
of whether their label string is empty.

fixes https://bugs.launchpad.net/mixxx/+bug/1870942

Screenshot of the bug:
![Screenshot from 2020-04-10 18-48-46](https://user-images.githubusercontent.com/9455094/79030444-a4306a00-7b5e-11ea-92f3-d1f34e596b67.png)

With this fix:
![Screenshot from 2020-04-10 19-19-42](https://user-images.githubusercontent.com/9455094/79030755-456bf000-7b60-11ea-9b7e-e0c7a1e9c2d5.png)

