### PR TITLE
Fix build with EXTRA_METADATA enabled / Update dirty flag

### DIFF
--- a/src/test/trackmetadata_test.cpp
+++ b/src/test/trackmetadata_test.cpp
@@ -127,7 +127,7 @@ TEST_F(TrackMetadataTest, mergeImportedMetadata) {
     pNewTrackInfo->setTrackNumber("2");
     pNewTrackInfo->setTrackTotal("20");
 #if defined(__EXTRA_METADATA__)
-    newTrackInfo.setWork("work");
+    pNewTrackInfo->setWork("work");
 #endif // __EXTRA_METADATA__
     pNewTrackInfo->setYear("2002-02-02");
     mixxx::AlbumInfo* pNewAlbumInfo = newTrackMetadata.ptrAlbumInfo();
@@ -139,7 +139,7 @@ TEST_F(TrackMetadataTest, mergeImportedMetadata) {
     pNewAlbumInfo->setMusicBrainzReleaseGroupId(QUuid("66666666-6666-6666-6666-666666666666"));
     pNewAlbumInfo->setMusicBrainzReleaseId(QUuid("77777777-7777-7777-7777-777777777777"));
     pNewAlbumInfo->setRecordLabel("copyright");
-    pNewAlbumInfo->> setReplayGain(mixxx::ReplayGain(0.3, 3));
+    pNewAlbumInfo->setReplayGain(mixxx::ReplayGain(0.3, 3));
 #endif // __EXTRA_METADATA__
     pNewAlbumInfo->setTitle("new album title");
 
@@ -193,7 +193,7 @@ TEST_F(TrackMetadataTest, mergeImportedMetadata) {
     EXPECT_EQ(
             pOldTrackInfo->getTrackTotal(), pMergedTrackInfo->getTrackTotal());
 #if defined(__EXTRA_METADATA__)
-    EXPECT_EQ(pNewTrackInfo.getWork(), pMergedTrackInfo->getWork());
+    EXPECT_EQ(pNewTrackInfo->getWork(), pMergedTrackInfo->getWork());
 #endif // __EXTRA_METADATA__
     EXPECT_EQ(pOldTrackInfo->getYear(), pMergedTrackInfo->getYear());
     mixxx::AlbumInfo* pMergedAlbumInfo =

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -189,7 +189,9 @@ void Track::importMetadata(
 void Track::mergeImportedMetadata(
         const mixxx::TrackMetadata& importedMetadata) {
     QMutexLocker lock(&m_qMutex);
-    m_record.mergeImportedMetadata(importedMetadata);
+    if (m_record.mergeImportedMetadata(importedMetadata)) {
+        markDirtyAndUnlock(&lock);
+    }
 }
 
 void Track::readTrackMetadata(
@@ -198,7 +200,7 @@ void Track::readTrackMetadata(
     DEBUG_ASSERT(pTrackMetadata);
     QMutexLocker lock(&m_qMutex);
     *pTrackMetadata = m_record.getMetadata();
-    if (pMetadataSynchronized != nullptr) {
+    if (pMetadataSynchronized) {
         *pMetadataSynchronized = m_record.getMetadataSynchronized();
     }
 }
@@ -209,7 +211,7 @@ void Track::readTrackRecord(
     DEBUG_ASSERT(pTrackRecord);
     QMutexLocker lock(&m_qMutex);
     *pTrackRecord = m_record;
-    if (pDirty != nullptr) {
+    if (pDirty) {
         *pDirty = m_bDirty;
     }
 }

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -582,7 +582,7 @@ QString Track::getComment() const {
 
 void Track::setComment(const QString& s) {
     QMutexLocker lock(&m_qMutex);
-    if (compareAndSet(&m_record.refMetadata().refTrackInfo().refComment(), s)) {
+    if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrComment(), s)) {
         markDirtyAndUnlock(&lock);
     }
 }

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -119,33 +119,60 @@ bool TrackRecord::mergeImportedMetadata(
         }
     }
 #if defined(__EXTRA_METADATA__)
-    modified |= copyIfNotNull(pMergedTrackInfo->ptrConductor(), importedTrackInfo.getConductor());
-    modified |= copyIfNotNull(pMergedTrackInfo->ptrDiscNumber(), importedTrackInfo.getDiscNumber());
-    modified |= copyIfNotNull(pMergedTrackInfo->ptrDiscTotal(), importedTrackInfo.getDiscTotal());
-    modified |= copyIfNotNull(pMergedTrackInfo->ptrEncoder(), importedTrackInfo.getEncoder());
-    modified |= copyIfNotNull(pMergedTrackInfo->ptrEncoderSettings(), importedTrackInfo.getEncoderSettings());
-    modified |= copyIfNotNull(pMergedTrackInfo->ptrISRC(), importedTrackInfo.getISRC());
-    modified |= copyIfNotNull(pMergedTrackInfo->ptrLanguage(), importedTrackInfo.getLanguage());
-    modified |= copyIfNotNull(pMergedTrackInfo->ptrLyricist(), importedTrackInfo.getLyricist());
-    modified |= copyIfNotNull(pMergedTrackInfo->ptrMood(), importedTrackInfo.getMood());
-    modified |= copyIfNotNull(pMergedTrackInfo->ptrMovement(), importedTrackInfo.getMovement());
-    modified |= copyIfNotNull(pMergedTrackInfo->ptrMusicBrainzArtistId(), importedTrackInfo.getMusicBrainzArtistId());
-    modified |= copyIfNotNull(pMergedTrackInfo->ptrMusicBrainzRecordingId(), importedTrackInfo.getMusicBrainzRecordingId());
-    modified |= copyIfNotNull(pMergedTrackInfo->ptrMusicBrainzReleaseId(), importedTrackInfo.getMusicBrainzReleaseId());
-    modified |= copyIfNotNull(pMergedTrackInfo->ptrMusicBrainzWorkId(), importedTrackInfo.getMusicBrainzWorkId());
-    modified |= copyIfNotNull(pMergedTrackInfo->ptrRemixer(), importedTrackInfo.getRemixer());
-    modified |= copyIfNotEmpty(pMergedTrackInfo->ptrSeratoTags(), importedTrackInfo.getSeratoTags());
-    modified |= copyIfNotNull(pMergedTrackInfo->ptrSubtitle(), importedTrackInfo.getSubtitle());
-    modified |= copyIfNotNull(pMergedTrackInfo->ptrWork(), importedTrackInfo.getWork());
-    AlbumInfo* pMergedAlbumInfo = refMetadata().ptrAlbumInfo();
-    const AlbumInfo& importedAlbumInfo = importedFromFile.getAlbumInfo();
-    modified |= mergeReplayGainMetadataProperty(pMergedAlbumInfo->ptrReplayGain(), importedAlbumInfo.getReplayGain());
-    modified |= copyIfNotNull(pMergedAlbumInfo->ptrCopyright(), importedAlbumInfo.getCopyright());
-    modified |= copyIfNotNull(pMergedAlbumInfo->ptrLicense(), importedAlbumInfo.getLicense());
-    modified |= copyIfNotNull(pMergedAlbumInfo->ptrMusicBrainzArtistId(), importedAlbumInfo.getMusicBrainzArtistId());
-    modified |= copyIfNotNull(pMergedAlbumInfo->ptrMusicBrainzReleaseGroupId(), importedAlbumInfo.getMusicBrainzReleaseGroupId());
-    modified |= copyIfNotNull(pMergedAlbumInfo->ptrMusicBrainzReleaseId(), importedAlbumInfo.getMusicBrainzReleaseId());
-    modified |= copyIfNotNull(pMergedAlbumInfo->ptrRecordLabel(), importedAlbumInfo.getRecordLabel());
+    modified |= copyIfNotNull(
+            pMergedTrackInfo->ptrConductor(),
+            importedTrackInfo.getConductor());
+    modified |= copyIfNotNull(
+            pMergedTrackInfo->ptrDiscNumber(),
+            importedTrackInfo.getDiscNumber());
+    modified |= copyIfNotNull(
+            pMergedTrackInfo->ptrDiscTotal(),
+            importedTrackInfo.getDiscTotal());
+    modified |= copyIfNotNull(
+            pMergedTrackInfo->ptrEncoder(),
+            importedTrackInfo.getEncoder());
+    modified |= copyIfNotNull(
+            pMergedTrackInfo->ptrEncoderSettings(),
+            importedTrackInfo.getEncoderSettings());
+    modified |= copyIfNotNull(
+            pMergedTrackInfo->ptrISRC(),
+            importedTrackInfo.getISRC());
+    modified |= copyIfNotNull(
+            pMergedTrackInfo->ptrLanguage(),
+            importedTrackInfo.getLanguage());
+    modified |= copyIfNotNull(
+            pMergedTrackInfo->ptrLyricist(),
+            importedTrackInfo.getLyricist());
+    modified |= copyIfNotNull(
+            pMergedTrackInfo->ptrMood(),
+            importedTrackInfo.getMood());
+    modified |= copyIfNotNull(
+            pMergedTrackInfo->ptrMovement(),
+            importedTrackInfo.getMovement());
+    modified |= copyIfNotNull(
+            pMergedTrackInfo->ptrMusicBrainzArtistId(),
+            importedTrackInfo.getMusicBrainzArtistId());
+    modified |= copyIfNotNull(
+            pMergedTrackInfo->ptrMusicBrainzRecordingId(),
+            importedTrackInfo.getMusicBrainzRecordingId());
+    modified |= copyIfNotNull(
+            pMergedTrackInfo->ptrMusicBrainzReleaseId(),
+            importedTrackInfo.getMusicBrainzReleaseId());
+    modified |= copyIfNotNull(
+            pMergedTrackInfo->ptrMusicBrainzWorkId(),
+            importedTrackInfo.getMusicBrainzWorkId());
+    modified |= copyIfNotNull(
+            pMergedTrackInfo->ptrRemixer(),
+            importedTrackInfo.getRemixer());
+    modified |= copyIfNotEmpty(
+            pMergedTrackInfo->ptrSeratoTags(),
+            importedTrackInfo.getSeratoTags());
+    modified |= copyIfNotNull(
+            pMergedTrackInfo->ptrSubtitle(),
+            importedTrackInfo.getSubtitle());
+    modified |= copyIfNotNull(
+            pMergedTrackInfo->ptrWork(),
+            importedTrackInfo.getWork());
 #endif // __EXTRA_METADATA__
     return modified;
 }

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -2,7 +2,6 @@
 
 #include "track/keyfactory.h"
 
-
 namespace mixxx {
 
 /*static*/ const QString TrackRecord::kTrackTotalPlaceholder = QStringLiteral("//");
@@ -173,6 +172,29 @@ bool TrackRecord::mergeImportedMetadata(
     modified |= copyIfNotNull(
             pMergedTrackInfo->ptrWork(),
             importedTrackInfo.getWork());
+    AlbumInfo* pMergedAlbumInfo = refMetadata().ptrAlbumInfo();
+    const AlbumInfo& importedAlbumInfo = importedFromFile.getAlbumInfo();
+    modified |= mergeReplayGainMetadataProperty(
+            pMergedAlbumInfo->ptrReplayGain(),
+            importedAlbumInfo.getReplayGain());
+    modified |= copyIfNotNull(
+            pMergedAlbumInfo->ptrCopyright(),
+            importedAlbumInfo.getCopyright());
+    modified |= copyIfNotNull(
+            pMergedAlbumInfo->ptrLicense(),
+            importedAlbumInfo.getLicense());
+    modified |= copyIfNotNull(
+            pMergedAlbumInfo->ptrMusicBrainzArtistId(),
+            importedAlbumInfo.getMusicBrainzArtistId());
+    modified |= copyIfNotNull(
+            pMergedAlbumInfo->ptrMusicBrainzReleaseGroupId(),
+            importedAlbumInfo.getMusicBrainzReleaseGroupId());
+    modified |= copyIfNotNull(
+            pMergedAlbumInfo->ptrMusicBrainzReleaseId(),
+            importedAlbumInfo.getMusicBrainzReleaseId());
+    modified |= copyIfNotNull(
+            pMergedAlbumInfo->ptrRecordLabel(),
+            importedAlbumInfo.getRecordLabel());
 #endif // __EXTRA_METADATA__
     return modified;
 }

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -53,15 +53,15 @@ namespace {
 
 #if defined(__EXTRA_METADATA__)
 void mergeReplayGainMetadataProperty(
-        ReplayGain& mergedReplayGain,
+        ReplayGain* pMergedReplayGain,
         const ReplayGain& importedReplayGain) {
     // Preserve the values calculated by Mixxx and only merge missing
     // values from the imported replay gain.
-    if (!mergedReplayGain.hasRatio()) {
-        mergedReplayGain.setRatio(importedReplayGain.getRatio());
+    if (!pMergedReplayGain->hasRatio()) {
+        pMergedReplayGain->setRatio(importedReplayGain.getRatio());
     }
-    if (!mergedReplayGain.hasPeak()) {
-        mergedReplayGain.setPeak(importedReplayGain.getPeak());
+    if (!pMergedReplayGain->hasPeak()) {
+        pMergedReplayGain->setPeak(importedReplayGain.getPeak());
     }
 }
 #endif // __EXTRA_METADATA__
@@ -70,10 +70,10 @@ void mergeReplayGainMetadataProperty(
 // like QString or QUuid.
 template<typename T>
 void copyIfNotNull(
-        T& mergedProperty,
+        T* pMergedProperty,
         const T& importedProperty) {
-    if (mergedProperty.isNull()) {
-        mergedProperty = importedProperty;
+    if (pMergedProperty->isNull()) {
+        *pMergedProperty = importedProperty;
     }
 }
 
@@ -81,10 +81,10 @@ void copyIfNotNull(
 // empty = missing.
 template<typename T>
 void copyIfNotEmpty(
-        T& mergedProperty,
+        T* pMergedProperty,
         const T& importedProperty) {
-    if (mergedProperty.isEmpty()) {
-        mergedProperty = importedProperty;
+    if (pMergedProperty->isEmpty()) {
+        *pMergedProperty = importedProperty;
     }
 }
 
@@ -105,33 +105,33 @@ void TrackRecord::mergeImportedMetadata(
         }
     }
 #if defined(__EXTRA_METADATA__)
-    copyIfNotNull(mergedTrackInfo.refConductor(), importedTrackInfo.getConductor());
-    copyIfNotNull(mergedTrackInfo.refDiscNumber(), importedTrackInfo.getDiscNumber());
-    copyIfNotNull(mergedTrackInfo.refDiscTotal(), importedTrackInfo.getDiscTotal());
-    copyIfNotNull(mergedTrackInfo.refEncoder(), importedTrackInfo.getEncoder());
-    copyIfNotNull(mergedTrackInfo.refEncoderSettings(), importedTrackInfo.getEncoderSettings());
-    copyIfNotNull(mergedTrackInfo.refISRC(), importedTrackInfo.getISRC());
-    copyIfNotNull(mergedTrackInfo.refLanguage(), importedTrackInfo.getLanguage());
-    copyIfNotNull(mergedTrackInfo.refLyricist(), importedTrackInfo.getLyricist());
-    copyIfNotNull(mergedTrackInfo.refMood(), importedTrackInfo.getMood());
-    copyIfNotNull(mergedTrackInfo.refMovement(), importedTrackInfo.getMovement());
-    copyIfNotNull(mergedTrackInfo.refMusicBrainzArtistId(), importedTrackInfo.getMusicBrainzArtistId());
-    copyIfNotNull(mergedTrackInfo.refMusicBrainzRecordingId(), importedTrackInfo.getMusicBrainzRecordingId());
-    copyIfNotNull(mergedTrackInfo.refMusicBrainzReleaseId(), importedTrackInfo.getMusicBrainzReleaseId());
-    copyIfNotNull(mergedTrackInfo.refMusicBrainzWorkId(), importedTrackInfo.getMusicBrainzWorkId());
-    copyIfNotNull(mergedTrackInfo.refRemixer(), importedTrackInfo.getRemixer());
-    copyIfNotEmpty(mergedTrackInfo.refSeratoTags(), importedTrackInfo.getSeratoTags());
-    copyIfNotNull(mergedTrackInfo.refSubtitle(), importedTrackInfo.getSubtitle());
-    copyIfNotNull(mergedTrackInfo.refWork(), importedTrackInfo.getWork());
-    AlbumInfo& mergedAlbumInfo = refMetadata().refAlbumInfo();
+    copyIfNotNull(pMergedTrackInfo->ptrConductor(), importedTrackInfo.getConductor());
+    copyIfNotNull(pMergedTrackInfo->ptrDiscNumber(), importedTrackInfo.getDiscNumber());
+    copyIfNotNull(pMergedTrackInfo->ptrDiscTotal(), importedTrackInfo.getDiscTotal());
+    copyIfNotNull(pMergedTrackInfo->ptrEncoder(), importedTrackInfo.getEncoder());
+    copyIfNotNull(pMergedTrackInfo->ptrEncoderSettings(), importedTrackInfo.getEncoderSettings());
+    copyIfNotNull(pMergedTrackInfo->ptrISRC(), importedTrackInfo.getISRC());
+    copyIfNotNull(pMergedTrackInfo->ptrLanguage(), importedTrackInfo.getLanguage());
+    copyIfNotNull(pMergedTrackInfo->ptrLyricist(), importedTrackInfo.getLyricist());
+    copyIfNotNull(pMergedTrackInfo->ptrMood(), importedTrackInfo.getMood());
+    copyIfNotNull(pMergedTrackInfo->ptrMovement(), importedTrackInfo.getMovement());
+    copyIfNotNull(pMergedTrackInfo->ptrMusicBrainzArtistId(), importedTrackInfo.getMusicBrainzArtistId());
+    copyIfNotNull(pMergedTrackInfo->ptrMusicBrainzRecordingId(), importedTrackInfo.getMusicBrainzRecordingId());
+    copyIfNotNull(pMergedTrackInfo->ptrMusicBrainzReleaseId(), importedTrackInfo.getMusicBrainzReleaseId());
+    copyIfNotNull(pMergedTrackInfo->ptrMusicBrainzWorkId(), importedTrackInfo.getMusicBrainzWorkId());
+    copyIfNotNull(pMergedTrackInfo->ptrRemixer(), importedTrackInfo.getRemixer());
+    copyIfNotEmpty(pMergedTrackInfo->ptrSeratoTags(), importedTrackInfo.getSeratoTags());
+    copyIfNotNull(pMergedTrackInfo->ptrSubtitle(), importedTrackInfo.getSubtitle());
+    copyIfNotNull(pMergedTrackInfo->ptrWork(), importedTrackInfo.getWork());
+    AlbumInfo* pMergedAlbumInfo = refMetadata().ptrAlbumInfo();
     const AlbumInfo& importedAlbumInfo = importedFromFile.getAlbumInfo();
-    mergeReplayGainMetadataProperty(mergedAlbumInfo.refReplayGain(), importedAlbumInfo.getReplayGain());
-    copyIfNotNull(mergedAlbumInfo.refCopyright(), importedAlbumInfo.getCopyright());
-    copyIfNotNull(mergedAlbumInfo.refLicense(), importedAlbumInfo.getLicense());
-    copyIfNotNull(mergedAlbumInfo.refMusicBrainzArtistId(), importedAlbumInfo.getMusicBrainzArtistId());
-    copyIfNotNull(mergedAlbumInfo.refMusicBrainzReleaseGroupId(), importedAlbumInfo.getMusicBrainzReleaseGroupId());
-    copyIfNotNull(mergedAlbumInfo.refMusicBrainzReleaseId(), importedAlbumInfo.getMusicBrainzReleaseId());
-    copyIfNotNull(mergedAlbumInfo.refRecordLabel(), importedAlbumInfo.getRecordLabel());
+    mergeReplayGainMetadataProperty(pMergedAlbumInfo->ptrReplayGain(), importedAlbumInfo.getReplayGain());
+    copyIfNotNull(pMergedAlbumInfo->ptrCopyright(), importedAlbumInfo.getCopyright());
+    copyIfNotNull(pMergedAlbumInfo->ptrLicense(), importedAlbumInfo.getLicense());
+    copyIfNotNull(pMergedAlbumInfo->ptrMusicBrainzArtistId(), importedAlbumInfo.getMusicBrainzArtistId());
+    copyIfNotNull(pMergedAlbumInfo->ptrMusicBrainzReleaseGroupId(), importedAlbumInfo.getMusicBrainzReleaseGroupId());
+    copyIfNotNull(pMergedAlbumInfo->ptrMusicBrainzReleaseId(), importedAlbumInfo.getMusicBrainzReleaseId());
+    copyIfNotNull(pMergedAlbumInfo->ptrRecordLabel(), importedAlbumInfo.getRecordLabel());
 #endif // __EXTRA_METADATA__
 }
 

--- a/src/track/trackrecord.h
+++ b/src/track/trackrecord.h
@@ -99,7 +99,9 @@ public:
     // Merge the current metadata from the file with the subset of metadata
     // that is stored in the library. This is required to NOT delete any tags
     // from the file that are not (yet) stored in the library database!
-    void mergeImportedMetadata(
+    //
+    // Returns true if any property has been modified or false otherwise.
+    bool mergeImportedMetadata(
             const TrackMetadata& importedMetadata);
 
 private:

--- a/src/track/trackrecord.h
+++ b/src/track/trackrecord.h
@@ -96,9 +96,12 @@ public:
             const QString& keyText,
             track::io::key::Source keySource);
 
-    // Merge the current metadata from the file with the subset of metadata
-    // that is stored in the library. This is required to NOT delete any tags
-    // from the file that are not (yet) stored in the library database!
+    // Merge the current metadata with new and additional properties
+    // imported from the file. Since these properties are not (yet)
+    // stored in the library or have been added later all existing
+    // data must be preserved and never be overwritten! This allows
+    // a gradual migration by selectively reimporting the required
+    // data when needed.
     //
     // Returns true if any property has been modified or false otherwise.
     bool mergeImportedMetadata(


### PR DESCRIPTION
@daschuer The EXTRA_METADATA feature is broken, caused by #2645.

**Update**: I might have found a minor bug. The dirty flag was not updated when merging re-imported metadata. I also decided to update the documentation, because I got confused by what I had written originally :see_no_evil: 