### PR TITLE
Pin Xcode version to 9.4.1 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,8 @@ jobs:
 
     - name: OSX/clang/SCons build
       os: osx
-      osx_image: xcode11
+      # The XCode version should match that on the build server!
+      osx_image: xcode9.4
       compiler: clang
       cache:
         directories:
@@ -127,7 +128,8 @@ jobs:
 
     - name: OSX/clang/CMake build
       os: osx
-      osx_image: xcode11
+      # The XCode version should match that on the build server!
+      osx_image: xcode9.4
       compiler: clang
       cache:
         ccache: true


### PR DESCRIPTION
As reported here: https://bugs.launchpad.net/mixxx/+bug/1871238

Builds are expected to succeed: https://travis-ci.org/github/uklotzde/mixxx/builds/673896799