### PR TITLE
Windows CMake debug compilation fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1208,8 +1208,11 @@ option(STATIC_DEPS "Link dependencies statically" OFF)
 # Chromaprint
 find_package(Chromaprint REQUIRED)
 target_link_libraries(mixxx-lib PUBLIC Chromaprint::Chromaprint)
-if(WIN32 AND STATIC_DEPS)
-  target_compile_definitions(mixxx-lib PUBLIC CHROMAPRINT_NODLL)
+if(WIN32)
+  if(STATIC_DEPS)
+    target_compile_definitions(mixxx-lib PUBLIC CHROMAPRINT_NODLL)
+  endif()
+   # Rubberband is always built statically and needs fftw.
   find_package(FFTW REQUIRED)
   target_link_libraries(mixxx-lib PUBLIC FFTW::FFTW)
 endif()
@@ -1469,6 +1472,12 @@ elseif(WIN32)
     target_link_libraries(mixxx-lib PUBLIC "${QTLIBPNG_LIBRARY}")
     find_library(QTPCRE2_LIBRARY qtpcre2)
     target_link_libraries(mixxx-lib PUBLIC "${QTPCRE2_LIBRARY}")
+  else()
+    #libshout is always built statically
+    target_link_libraries(mixxx-lib PUBLIC
+      ws2_32      # libshout
+      gdi32       # libshout
+    )
   endif()
 endif()
 
@@ -1562,7 +1571,8 @@ if(SndFile_SUPPORTS_SET_COMPRESSION_LEVEL)
   target_compile_definitions(mixxx-lib PUBLIC SFC_SUPPORTS_SET_COMPRESSION_LEVEL)
 endif()
 
-if(WIN32 AND STATIC_DEPS)
+#libsndfile is always build statically, so we don't check for STATIC_DEPS
+if(WIN32)
   find_package(G72X REQUIRED)
   target_link_libraries(mixxx-lib PUBLIC G72X::G72X)
 endif()
@@ -1859,7 +1869,8 @@ if(OPUS)
   target_compile_definitions(mixxx-lib PUBLIC __OPUS__)
   target_include_directories(mixxx-lib SYSTEM PUBLIC ${Opus_INCLUDE_DIRS})
   target_link_libraries(mixxx-lib PUBLIC ${Opus_LIBRARIES})
-  if(WIN32 AND STATIC_DEPS)
+  # Opus is always built statically so we don't check STATIC_DEPS
+  if(WIN32)
     find_package(Celt)
     if(NOT Celt_FOUND)
       message(FATAL_ERROR "Opus support with static dependencies requires the celt library.")
@@ -2093,6 +2104,8 @@ if(NOT OPTIMIZE STREQUAL "off")
       # Jenkins logs) Should we turn on PGO ?
       # http://msdn.microsoft.com/en-us/library/xbf3tbeh.aspx
       target_link_options(mixxx-lib PUBLIC "/LTCG:OFF")
+    elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")    
+      target_compile_options(mixxx-lib PUBLIC "/GL-")
     else()
       target_compile_options(mixxx-lib PUBLIC "/GL")
       target_link_options(mixxx-lib PUBLIC "/LTCG:NOSTATUS")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2104,7 +2104,7 @@ if(NOT OPTIMIZE STREQUAL "off")
       # Jenkins logs) Should we turn on PGO ?
       # http://msdn.microsoft.com/en-us/library/xbf3tbeh.aspx
       target_link_options(mixxx-lib PUBLIC "/LTCG:OFF")
-    elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")    
+    elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
       target_compile_options(mixxx-lib PUBLIC "/GL-")
     else()
       target_compile_options(mixxx-lib PUBLIC "/GL")

--- a/build/appveyor/build_mixxx.bat
+++ b/build/appveyor/build_mixxx.bat
@@ -86,7 +86,7 @@ if "%4" == "skipinstaller" (
     if "%5" == "skipinstaller" (
        set PARAM_INSTALLER=
     ) else (
-       set PARAM_INSTALLER=makerelease 
+       set PARAM_INSTALLER=makerelease
     )
 )
 set WINLIB_DIR=%3

--- a/build/appveyor/build_mixxx.bat
+++ b/build/appveyor/build_mixxx.bat
@@ -183,6 +183,6 @@ FOR /F %%G IN ('dir "%BUILDTOOLS_PATH%\Tools\MSVC\%PARAM_VCVARSVER%*" /b /ad-h /
   set "LOCAL_64_CL=%BUILDTOOLS_PATH%\Tools\MSVC\%%G\bin\Hostx64\x64\cl.exe"
   if EXIST "!LOCAL_64_CL!" (
     EXIT /B 0
-  ) 
+  )
 )
 EXIT /B 1

--- a/build/appveyor/build_mixxx.bat
+++ b/build/appveyor/build_mixxx.bat
@@ -94,9 +94,13 @@ set WINLIB_DIR=%3
 SET BIN_DIR=%WINLIB_DIR%\bin
 SET LIB_DIR=%WINLIB_DIR%\lib
 SET INCLUDE_DIR=%WINLIB_DIR%\include
-REM TODO(rryan): Remove hard-coding of Qt version.
-set QT_VERSION=5.12.0
-SET QTDIR=%WINLIB_DIR%\Qt-%QT_VERSION%
+FOR /D %%G IN (%WINLIB_DIR%\Qt-*) DO SET QTDIR=%%G
+IF "!QTDIR!" EQU "" (
+echo QT not found on %WINLIB_DIR%
+exit /b 1
+)
+
+
 
 if NOT EXIST "%BIN_DIR%\scons.py" (
 echo.

--- a/cmake/modules/FindOpus.cmake
+++ b/cmake/modules/FindOpus.cmake
@@ -59,7 +59,7 @@ find_library(Opus_LIBRARY
 mark_as_advanced(Opus_LIBRARY)
 
 find_path(OpusFile_INCLUDE_DIR
-  NAMES opus/opusfile.h
+  NAMES opusfile.h
   PATH_SUFFIXES opus
   PATHS ${PC_OpusFile_INCLUDE_DIRS}
   DOC "Opusfile include directory")

--- a/cmake/modules/FindOpus.cmake
+++ b/cmake/modules/FindOpus.cmake
@@ -59,8 +59,7 @@ find_library(Opus_LIBRARY
 mark_as_advanced(Opus_LIBRARY)
 
 find_path(OpusFile_INCLUDE_DIR
-  NAMES opusfile.h
-  PATH_SUFFIXES opus
+  NAMES opus/opusfile.h
   PATHS ${PC_OpusFile_INCLUDE_DIRS}
   DOC "Opusfile include directory")
 mark_as_advanced(OpusFile_INCLUDE_DIR)

--- a/cmake/modules/FindOpus.cmake
+++ b/cmake/modules/FindOpus.cmake
@@ -60,6 +60,7 @@ mark_as_advanced(Opus_LIBRARY)
 
 find_path(OpusFile_INCLUDE_DIR
   NAMES opus/opusfile.h
+  PATH_SUFFIXES opus
   PATHS ${PC_OpusFile_INCLUDE_DIRS}
   DOC "Opusfile include directory")
 mark_as_advanced(OpusFile_INCLUDE_DIR)

--- a/src/util/db/dbconnection.cpp
+++ b/src/util/db/dbconnection.cpp
@@ -249,6 +249,8 @@ bool initDatabase(QSqlDatabase database, StringCollator* pCollator) {
     }
     // v.data() returns a pointer to the handle
     sqlite3* handle = *static_cast<sqlite3**>(v.data());
+    // Ensure initialization. database.open() might not do it
+    sqlite3_initialize();
     VERIFY_OR_DEBUG_ASSERT(handle != nullptr) {
         kLogger.warning()
                 << "SQLite3 handle is invalid";

--- a/src/util/db/dbconnection.cpp
+++ b/src/util/db/dbconnection.cpp
@@ -250,7 +250,9 @@ bool initDatabase(QSqlDatabase database, StringCollator* pCollator) {
     // v.data() returns a pointer to the handle
     sqlite3* handle = *static_cast<sqlite3**>(v.data());
     // Ensure initialization. database.open() might not do it
-    sqlite3_initialize();
+    int rc = sqlite3_initialize();
+    if( rc ) qDebug() << "sqlite3_initialize failed with the code: " << rc;
+
     VERIFY_OR_DEBUG_ASSERT(handle != nullptr) {
         kLogger.warning()
                 << "SQLite3 handle is invalid";

--- a/src/util/db/dbconnection.cpp
+++ b/src/util/db/dbconnection.cpp
@@ -247,12 +247,17 @@ bool initDatabase(QSqlDatabase database, StringCollator* pCollator) {
                << v.typeName();
         return false; // abort
     }
+    // Ensure initialization. sqlite recommends doing this before using it
+    // and might become required in future versions
+    int rc = sqlite3_initialize();
+    VERIFY_OR_DEBUG_ASSERT(rc == SQLITE_OK) {
+        kLogger.warning()
+            << "sqlite3_initialize failed with the code: "
+            << rc;
+    }
+
     // v.data() returns a pointer to the handle
     sqlite3* handle = *static_cast<sqlite3**>(v.data());
-    // Ensure initialization. database.open() might not do it
-    int rc = sqlite3_initialize();
-    if( rc ) qDebug() << "sqlite3_initialize failed with the code: " << rc;
-
     VERIFY_OR_DEBUG_ASSERT(handle != nullptr) {
         kLogger.warning()
                 << "SQLite3 handle is invalid";


### PR DESCRIPTION
This fixes some bugs building in debug:
 - do not use link time code generation since that slows down the build.
 - fixes if built with dynamically linked libraries. Note: Currently it needs manual copying of such dlls into the compiled directory (including the qt plugins).
 - Fixed detection of opus. I don't know why it didn't work as it was. Version included in CMake tools for visual studio is 3.16.19112601-MSVC_2
 - Fixed a database driver initialization error. This should only happen if SQLITE_OMIT_AUTOINIT was set. I didn't saw where this could happen, so I simply call sqlite3_initialize() explicitly in dbconnection. It is a no-op operation if it is already initialized.