### PR TITLE
[WiP] Add savepoints after (re-)importing track metadata

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1287,6 +1287,20 @@ TrackPointer TrackDAO::getTrackById(TrackId trackId) const {
         // before, so just check and try for every track that has been
         // freshly loaded from the database.
         SoundSourceProxy(pTrack).updateTrackFromSource();
+        if (pTrack->isDirty()) {
+            if (kLogger.debugEnabled()) {
+                mixxx::TrackMetadata trackMetadata;
+                pTrack->readTrackMetadata(&trackMetadata);
+                kLogger.debug()
+                        << "Updated track metadata from file tags:"
+                        << pTrack->getFileInfo().fileLastModified()
+                        << trackMetadata;
+            }
+            // Save the track update metadata to the database
+            // immediately. Otherwise it won't become visible for
+            // queries until the track object is dropped.
+            saveTrack(pTrack.get());
+        }
     }
 
     // Validate and refresh cover image hash values if needed.

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -759,6 +759,12 @@ void WTrackMenu::slotImportTrackMetadataFromFileTags() {
         // reloaded separately.
         SoundSourceProxy(pTrack).updateTrackFromSource(
                 SoundSourceProxy::ImportTrackMetadataMode::Again);
+        if (pTrack->isDirty()) {
+            // Update the database to reflect the recent changes. This is
+            // crucial for additional metadata like custom tags that are
+            // directly fetched from the database for certain use cases!
+            m_pTrackCollectionManager->saveTrack(pTrack);
+        }
     }
 }
 


### PR DESCRIPTION
Save updated track metadata in the database explicitly after it has been (re-)imported from the file. This prevents that database entries become stale and queries don't see updated metadata until the corresponding track references have been dropped and saved implicitly.

Currently this happens rarely and mostly goes unnoticed. But it becomes more apparent when adding the custom tags feature in #2656. The menu is populated directly from the database. After reimporting metadata from currently selected/loaded/cached tracks those changes would not be reflected in the menu when opening this menu afterwards.

Better fix the issue before users are affected. It helps to keep both database and cached tracks synchronized and consistent.

Remark: We don't save tracks explicitly after editing single fields in the track table or after applying changes from the properties dialog. I don't recommend saving tracks immediately after editing a single field. But we may decide to save them explicitly after applying changes from the properties dialog. If we decide to do so this should be done in a separate PR.