### PR TITLE
widget/wcolorpicker: Resize WColorPicker(Action) after palette change

### DIFF
--- a/src/widget/wcolorpicker.cpp
+++ b/src/widget/wcolorpicker.cpp
@@ -46,6 +46,9 @@ WColorPicker::WColorPicker(Options options, const ColorPalette& palette, QWidget
     pLayout->setMargin(0);
     pLayout->setContentsMargins(0, 0, 0, 0);
 
+    pLayout->setSizeConstraint(QLayout::SetFixedSize);
+    setSizePolicy(QSizePolicy());
+
     // Unfortunately, not all styles supported by Qt support setting a
     // background color for QPushButtons (see
     // https://bugreports.qt.io/browse/QTBUG-11089). For example, when using
@@ -130,6 +133,8 @@ void WColorPicker::addColorButtons() {
         addCustomColorButton(pLayout, row, column);
         column++;
     }
+
+    adjustSize();
 }
 
 void WColorPicker::addColorButton(mixxx::RgbColor color, QGridLayout* pLayout, int row, int column) {

--- a/src/widget/wcolorpickeraction.cpp
+++ b/src/widget/wcolorpickeraction.cpp
@@ -7,9 +7,11 @@ WColorPickerAction::WColorPickerAction(WColorPicker::Options options, const Colo
 
     QHBoxLayout* pLayout = new QHBoxLayout();
     pLayout->addWidget(m_pColorPicker);
+    pLayout->setSizeConstraint(QLayout::SetFixedSize);
 
     QWidget* pWidget = new QWidget();
     pWidget->setLayout(pLayout);
+    pWidget->setSizePolicy(QSizePolicy());
     setDefaultWidget(pWidget);
 }
 
@@ -23,4 +25,9 @@ void WColorPickerAction::setSelectedColor(mixxx::RgbColor::optional_t color) {
 
 void WColorPickerAction::setColorPalette(const ColorPalette& palette) {
     m_pColorPicker->setColorPalette(palette);
+    QWidget* pWidget = defaultWidget();
+    VERIFY_OR_DEBUG_ASSERT(pWidget) {
+        return;
+    }
+    pWidget->adjustSize();
 }

--- a/src/widget/wcolorpickeraction.h
+++ b/src/widget/wcolorpickeraction.h
@@ -17,6 +17,15 @@ class WColorPickerAction : public QWidgetAction {
 
     void resetSelectedColor();
     void setSelectedColor(mixxx::RgbColor::optional_t color);
+
+    /// Set a new color palette for the underlying color picker.
+    ///
+    /// After calling this, your need to tell Qt that the menu size needs to be
+    /// recalculated, e.g.:
+    ///
+    ///     m_pColorPickerAction->setColorPalette(palette);
+    ///     QResizeEvent resizeEvent(QSize(), m_pMenu->size());
+    ///     qApp->sendEvent(m_pMenu, &resizeEvent);
     void setColorPalette(const ColorPalette& palette);
 
   signals:


### PR DESCRIPTION
After spending countless hours on this, I think I finally fixed the resize issue with color pickers after setting another palette.