### PR TITLE
Fix Preferences Buttons

### DIFF
--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -368,7 +368,7 @@ void DlgPrefController::slotUpdate() {
 }
 
 void DlgPrefController::slotCancel() {
-    slotShowPreset(m_pController->getPreset());
+    slotUpdate();
 }
 
 void DlgPrefController::applyPresetChanges() {

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -370,6 +370,7 @@ void DlgPrefController::slotUpdate() {
 void DlgPrefController::slotResetToDefaults() {
     m_ui.chkEnabledDevice->setChecked(false);
     enumeratePresets(QString());
+    slotPresetSelected(m_ui.comboBoxPreset->currentIndex());
 }
 
 void DlgPrefController::applyPresetChanges() {

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -367,10 +367,6 @@ void DlgPrefController::slotUpdate() {
     m_ui.outputMappingsTab->setEnabled(isMappable);
 }
 
-void DlgPrefController::slotCancel() {
-    slotUpdate();
-}
-
 void DlgPrefController::slotResetToDefaults() {
     m_ui.chkEnabledDevice->setChecked(false);
     enumeratePresets(QString());

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -371,6 +371,11 @@ void DlgPrefController::slotCancel() {
     slotUpdate();
 }
 
+void DlgPrefController::slotResetToDefaults() {
+    m_ui.chkEnabledDevice->setChecked(false);
+    enumeratePresets(QString());
+}
+
 void DlgPrefController::applyPresetChanges() {
     if (m_pInputTableModel) {
         m_pInputTableModel->apply();

--- a/src/controllers/dlgprefcontroller.h
+++ b/src/controllers/dlgprefcontroller.h
@@ -36,8 +36,6 @@ class DlgPrefController : public DlgPreferencePage {
     void slotUpdate();
     /// Called when the user clicks the global "Apply" button.
     void slotApply();
-    /// Called when the user clicks the global "Cancel" button.
-    void slotCancel();
     /// Called when the user clicks the global "Reset to Defaults" button.
     void slotResetToDefaults();
 

--- a/src/controllers/dlgprefcontroller.h
+++ b/src/controllers/dlgprefcontroller.h
@@ -38,6 +38,8 @@ class DlgPrefController : public DlgPreferencePage {
     void slotApply();
     /// Called when the user clicks the global "Cancel" button.
     void slotCancel();
+    /// Called when the user clicks the global "Reset to Defaults" button.
+    void slotResetToDefaults();
 
   signals:
     void applyPreset(Controller* pController, ControllerPresetPointer pPreset, bool bEnabled);

--- a/src/controllers/dlgprefcontroller.h
+++ b/src/controllers/dlgprefcontroller.h
@@ -32,12 +32,12 @@ class DlgPrefController : public DlgPreferencePage {
     virtual ~DlgPrefController();
 
   public slots:
-    // Called when we should apply / save our changes.
-    void slotApply();
-    // Called when we should cancel the changes made.
-    void slotCancel();
-    // Called when preference dialog (not this dialog) is displayed.
+    /// Called when the preference dialog (not this page) is shown to the user.
     void slotUpdate();
+    /// Called when the user clicks the global "Apply" button.
+    void slotApply();
+    /// Called when the user clicks the global "Cancel" button.
+    void slotCancel();
 
   signals:
     void applyPreset(Controller* pController, ControllerPresetPointer pPreset, bool bEnabled);

--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -37,29 +37,25 @@ void DlgPrefControllers::slotOpenLocalFile(const QString& file) {
 }
 
 void DlgPrefControllers::slotUpdate() {
-    // Update our sub-windows.
-    foreach (DlgPrefController* pControllerWindows, m_controllerWindows) {
+    for (DlgPrefController* pControllerWindows : qAsConst(m_controllerWindows)) {
         pControllerWindows->slotUpdate();
     }
 }
 
 void DlgPrefControllers::slotCancel() {
-    // Update our sub-windows.
-    foreach (DlgPrefController* pControllerWindows, m_controllerWindows) {
+    for (DlgPrefController* pControllerWindows : qAsConst(m_controllerWindows)) {
         pControllerWindows->slotCancel();
     }
 }
 
 void DlgPrefControllers::slotApply() {
-    // Update our sub-windows.
-    foreach (DlgPrefController* pControllerWindows, m_controllerWindows) {
+    for (DlgPrefController* pControllerWindows : qAsConst(m_controllerWindows)) {
         pControllerWindows->slotApply();
     }
 }
 
 void DlgPrefControllers::slotResetToDefaults() {
-    // Update our sub-windows.
-    foreach (DlgPrefController* pControllerWindows, m_controllerWindows) {
+    for (DlgPrefController* pControllerWindows : qAsConst(m_controllerWindows)) {
         pControllerWindows->slotResetToDefaults();
     }
 }

--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -57,6 +57,13 @@ void DlgPrefControllers::slotApply() {
     }
 }
 
+void DlgPrefControllers::slotResetToDefaults() {
+    // Update our sub-windows.
+    foreach (DlgPrefController* pControllerWindows, m_controllerWindows) {
+        pControllerWindows->slotResetToDefaults();
+    }
+}
+
 bool DlgPrefControllers::handleTreeItemClick(QTreeWidgetItem* clickedItem) {
     int controllerIndex = m_controllerTreeItems.indexOf(clickedItem);
     if (controllerIndex >= 0) {

--- a/src/controllers/dlgprefcontrollers.h
+++ b/src/controllers/dlgprefcontrollers.h
@@ -26,9 +26,14 @@ class DlgPrefControllers : public DlgPreferencePage, public Ui::DlgPrefControlle
     bool handleTreeItemClick(QTreeWidgetItem* clickedItem);
 
   public slots:
+    /// Called when the preference dialog (not this page) is shown to the user.
     void slotUpdate();
+    /// Called when the user clicks the global "Apply" button.
     void slotApply();
+    /// Called when the user clicks the global "Cancel" button.
     void slotCancel();
+    /// Called when the user clicks the global "Reset to Defaults" button.
+    void slotResetToDefaults();
 
   private slots:
     void rescanControllers();

--- a/src/preferences/dialog/dlgprefcolors.cpp
+++ b/src/preferences/dialog/dlgprefcolors.cpp
@@ -27,8 +27,6 @@ DlgPrefColors::DlgPrefColors(
     comboBoxHotcueColors->setIconSize(kPalettePreviewSize);
     comboBoxTrackColors->setIconSize(kPalettePreviewSize);
 
-    loadSettings();
-
     connect(comboBoxHotcueColors,
             QOverload<const QString&>::of(&QComboBox::currentIndexChanged),
             this,
@@ -43,13 +41,15 @@ DlgPrefColors::DlgPrefColors(
             &QPushButton::clicked,
             this,
             &DlgPrefColors::slotEditTrackPaletteClicked);
+
+    slotUpdate();
 }
 
 DlgPrefColors::~DlgPrefColors() {
 }
 
 // Loads the config keys and sets the widgets in the dialog to match
-void DlgPrefColors::loadSettings() {
+void DlgPrefColors::slotUpdate() {
     comboBoxHotcueColors->clear();
     comboBoxTrackColors->clear();
     for (const auto& palette : qAsConst(mixxx::PredefinedColorPalettes::kPalettes)) {
@@ -264,7 +264,7 @@ void DlgPrefColors::trackPaletteUpdated(const QString& trackColors) {
     QString hotcueColors = comboBoxHotcueColors->currentText();
     int defaultColor = comboBoxHotcueDefaultColor->currentIndex();
 
-    loadSettings();
+    slotUpdate();
     restoreComboBoxes(hotcueColors, trackColors, defaultColor);
 }
 
@@ -272,7 +272,7 @@ void DlgPrefColors::hotcuePaletteUpdated(const QString& hotcueColors) {
     QString trackColors = comboBoxTrackColors->currentText();
     int defaultColor = comboBoxHotcueDefaultColor->currentIndex();
 
-    loadSettings();
+    slotUpdate();
     restoreComboBoxes(hotcueColors, trackColors, defaultColor);
 }
 
@@ -281,7 +281,7 @@ void DlgPrefColors::palettesUpdated() {
     QString trackColors = comboBoxTrackColors->currentText();
     int defaultColor = comboBoxHotcueDefaultColor->currentIndex();
 
-    loadSettings();
+    slotUpdate();
     restoreComboBoxes(hotcueColors, trackColors, defaultColor);
 }
 

--- a/src/preferences/dialog/dlgprefcolors.h
+++ b/src/preferences/dialog/dlgprefcolors.h
@@ -17,8 +17,11 @@ class DlgPrefColors : public DlgPreferencePage, public Ui::DlgPrefColorsDlg {
     virtual ~DlgPrefColors();
 
   public slots:
-    // Apply changes to widget
+    /// Called when the preference dialog (not this page) is shown to the user.
+    void slotUpdate();
+    /// Called when the user clicks the global "Apply" button.
     void slotApply();
+    /// Called when the user clicks the global "Reset to Defaults" button.
     void slotResetToDefaults();
 
   signals:
@@ -26,7 +29,6 @@ class DlgPrefColors : public DlgPreferencePage, public Ui::DlgPrefColorsDlg {
 
   private slots:
     void slotHotcuePaletteChanged(const QString& palette);
-    void loadSettings();
     void trackPaletteUpdated(const QString& palette);
     void hotcuePaletteUpdated(const QString& palette);
     void palettesUpdated();

--- a/src/preferences/dialog/dlgpreflv2.cpp
+++ b/src/preferences/dialog/dlgpreflv2.cpp
@@ -112,11 +112,13 @@ void DlgPrefLV2::slotDisplayParameters() {
 }
 
 void DlgPrefLV2::slotUpdate() {
-    // TODO: Implement this
+    // This preferences page will be removed in PR #2618 anyway, so we'll just
+    // leave this empty for now.
 }
 
 void DlgPrefLV2::slotResetToDefaults() {
-    // TODO: Implement this
+    // This preferences page will be removed in PR #2618 anyway, so we'll just
+    // leave this empty for now.
 }
 
 void DlgPrefLV2::slotApply() {

--- a/src/preferences/dialog/dlgpreflv2.cpp
+++ b/src/preferences/dialog/dlgpreflv2.cpp
@@ -111,6 +111,14 @@ void DlgPrefLV2::slotDisplayParameters() {
     lv2_vertical_layout_params->addStretch();
 }
 
+void DlgPrefLV2::slotUpdate() {
+    // TODO: Implement this
+}
+
+void DlgPrefLV2::slotResetToDefaults() {
+    // TODO: Implement this
+}
+
 void DlgPrefLV2::slotApply() {
     EffectManifestPointer pCurrentEffectManifest =
             m_pLV2Backend->getManifest(m_currentEffectId);

--- a/src/preferences/dialog/dlgpreflv2.h
+++ b/src/preferences/dialog/dlgpreflv2.h
@@ -19,7 +19,12 @@ class DlgPrefLV2 : public DlgPreferencePage, public Ui::DlgPrefLV2Dlg  {
     virtual ~DlgPrefLV2();
 
   public slots:
+    /// Called when the preference dialog (not this page) is shown to the user.
+    void slotUpdate();
+    /// Called when the user clicks the global "Apply" button.
     void slotApply();
+    /// Called when the user clicks the global "Reset to Defaults" button.
+    void slotResetToDefaults();
 
   private slots:
     void slotDisplayParameters();

--- a/src/preferences/dlgpreferencepage.h
+++ b/src/preferences/dlgpreferencepage.h
@@ -1,9 +1,8 @@
-#ifndef DLGPREFERENCEPAGE_H
-#define DLGPREFERENCEPAGE_H
+#pragma once
 
 #include <QWidget>
 
-// API that all preference pages should implement.
+/// Interface that all preference pages have to implement.
 class DlgPreferencePage : public QWidget {
     Q_OBJECT
   public:
@@ -11,31 +10,30 @@ class DlgPreferencePage : public QWidget {
     virtual ~DlgPreferencePage();
 
   public slots:
-    // Called when the preference dialog is shown to the user (not necessarily
-    // when this PreferencePage is shown to the user). At this point, the
-    // PreferencePage should update all of its setting to the latest values.
-    virtual void slotUpdate() {}
+    /// Called when the preference dialog is shown to the user (not necessarily
+    /// when this PreferencePage is shown to the user). At this point, the
+    /// PreferencePage should update all of its setting to the latest values.
+    virtual void slotUpdate() = 0;
 
-    // Called when the user clicks the global "Apply" button. The preference
-    // dialog should make all of the current setting of the UI widgets active.
-    virtual void slotApply() {}
+    /// Called when the user clicks the global "Apply" button. The preference
+    /// dialog should make all of the current setting of the UI widgets active.
+    virtual void slotApply() = 0;
 
-    // Called when the user clicks the global "Cancel" button. The preference
-    // dialog should revert all of the changes the user made since the last
-    // slotUpdate.
-    virtual void slotCancel() {}
+    /// Called when the user clicks the global "Cancel" button. The preference
+    /// dialog should revert all of the changes the user made since the last
+    /// slotUpdate. The default implementation just class slotUpdate.
+    virtual void slotCancel() {
+        slotUpdate();
+    }
 
-    // Called when the user clicks the global "Reset to Defaults" button. The
-    // preference dialog should revert settings to their default values.
-    virtual void slotResetToDefaults() {}
+    /// Called when the user clicks the global "Reset to Defaults" button. The
+    /// preference dialog should revert settings to their default values.
+    virtual void slotResetToDefaults() = 0;
 
-    // Called when the preferences dialog is shown to the user (not necessarily
-    // when this PreferencePage is shown to the user).
+    /// Called when the preferences dialog is shown to the user (not necessarily
+    /// when this PreferencePage is shown to the user).
     virtual void slotShow() {}
 
-    // Called when the preferences dialog is hidden from the user.
+    /// Called when the preferences dialog is hidden from the user.
     virtual void slotHide() {}
 };
-
-
-#endif /* DLGPREFERENCEPAGE_H */


### PR DESCRIPTION
A bunch of pages don't implement `slotCancel` and `slotResetToDefaults`.

I implemented `slotResetToDefaults` for the colors and the controller pages and added a default `slotCancel` implementation that falls back to `slotUpdate`.

To prevent situations like this in the future, I deleted the default implementation for `slotUpdate`/`slotApply`/`slotResetToDefault` so that pages have to implement them.

For the LV2 page I added empty functions with a `TODO` comment for now, since I don't have any LV2 plugins and can't test it. 