### PR TITLE
Reloop Beatmix 2/4: Reduce sensitivity of jog pitch bend

### DIFF
--- a/res/controllers/Reloop-Beatmix-2-4-scripts.js
+++ b/res/controllers/Reloop-Beatmix-2-4-scripts.js
@@ -407,7 +407,7 @@ ReloopBeatmix24.WheelTurn = function(channel, control, value, status, group) {
     if (engine.isScratching(deck)) {
         engine.scratchTick(deck, newValue); // Scratch!
     } else {
-        engine.setValue(group, 'jog', newValue); // Pitch bend
+        engine.setValue(group, 'jog', newValue / 5); // Pitch bend
     }
 };
 


### PR DESCRIPTION
The default jog sensitivity is too high, this should be closer to the default Serato behaviour (so it has a better response and is easier to beatmatch with).