### PR TITLE
Reorder track context menu entries

### DIFF
--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -315,6 +315,26 @@ void WTrackMenu::setupActions() {
 
     addSeparator();
 
+    if (featureIsEnabled(Feature::BPM)) {
+        m_pBPMMenu->addAction(m_pBpmDoubleAction);
+        m_pBPMMenu->addAction(m_pBpmHalveAction);
+        m_pBPMMenu->addAction(m_pBpmTwoThirdsAction);
+        m_pBPMMenu->addAction(m_pBpmThreeFourthsAction);
+        m_pBPMMenu->addAction(m_pBpmFourThirdsAction);
+        m_pBPMMenu->addAction(m_pBpmThreeHalvesAction);
+        m_pBPMMenu->addSeparator();
+        m_pBPMMenu->addAction(m_pBpmLockAction);
+        m_pBPMMenu->addAction(m_pBpmUnlockAction);
+        m_pBPMMenu->addSeparator();
+
+        addMenu(m_pBPMMenu);
+    }
+
+    if (featureIsEnabled(Feature::Color)) {
+        m_pColorMenu->addAction(m_pColorPickerAction);
+        addMenu(m_pColorMenu);
+    }
+
     if (featureIsEnabled(Feature::Metadata)) {
         m_pMetadataMenu->addAction(m_pImportMetadataFromFileAct);
         m_pMetadataMenu->addAction(m_pImportMetadataFromMusicBrainzAct);
@@ -353,26 +373,6 @@ void WTrackMenu::setupActions() {
         m_pClearMetadataMenu->addSeparator();
         m_pClearMetadataMenu->addAction(m_pClearAllMetadataAction);
         addMenu(m_pClearMetadataMenu);
-    }
-
-    if (featureIsEnabled(Feature::BPM)) {
-        m_pBPMMenu->addAction(m_pBpmDoubleAction);
-        m_pBPMMenu->addAction(m_pBpmHalveAction);
-        m_pBPMMenu->addAction(m_pBpmTwoThirdsAction);
-        m_pBPMMenu->addAction(m_pBpmThreeFourthsAction);
-        m_pBPMMenu->addAction(m_pBpmFourThirdsAction);
-        m_pBPMMenu->addAction(m_pBpmThreeHalvesAction);
-        m_pBPMMenu->addSeparator();
-        m_pBPMMenu->addAction(m_pBpmLockAction);
-        m_pBPMMenu->addAction(m_pBpmUnlockAction);
-        m_pBPMMenu->addSeparator();
-
-        addMenu(m_pBPMMenu);
-    }
-
-    if (featureIsEnabled(Feature::Color)) {
-        m_pColorMenu->addAction(m_pColorPickerAction);
-        addMenu(m_pColorMenu);
     }
 
     addSeparator();


### PR DESCRIPTION
Improve accessibility by reordering the entries. The generic *Metadata* and *Reset* entries are needed much less often then the other actions and should appear at the end of this section.

**Before:**
- Metadata
- Reset
- Adjust BPM
- Select Color

**After:**
- Adjust BPM
- Select Color
- Metadata
- Reset

**Before (screenshot):**
![before](https://user-images.githubusercontent.com/1474154/79604940-4ddba200-80ef-11ea-9889-9b8891c8686d.png)

**After (screenshot):**
![after](https://user-images.githubusercontent.com/1474154/79604961-592ecd80-80ef-11ea-8d6f-08b28cd67d42.png)

This becomes even more obvious when adding the new *Custom Tags* feature, which could now be added between *Select Color* and *Metadata*.