### PR TITLE
WTrackMenu cleanups & optimizations

### DIFF
--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -610,18 +610,11 @@ void WTrackMenu::loadTracks(QModelIndexList indexList) {
 }
 
 void WTrackMenu::loadTrack(TrackId trackId) {
-    // Create a QList of single track to maintain common functions
-    // for single and multi track selection.
-    TrackIdList singleItemTrackIdList;
-    singleItemTrackIdList.push_back(trackId);
-    // Use setTrackIds to set a list of single element.
-    loadTracks(singleItemTrackIdList);
+    loadTracks(TrackIdList{trackId});
 }
 
 void WTrackMenu::loadTrack(QModelIndex index) {
-    QModelIndexList singleItemTrackIndexList;
-    singleItemTrackIndexList.push_back(index);
-    loadTracks(singleItemTrackIndexList);
+    loadTracks(QModelIndexList{index});
 }
 
 TrackIdList WTrackMenu::getTrackIds() const {

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -623,11 +623,16 @@ TrackIdList WTrackMenu::getTrackIds() const {
         const QModelIndexList indices = getTrackIndices();
         trackIds.reserve(indices.size());
         for (const auto& index : indices) {
-            trackIds.push_back(m_pTrackModel->getTrackId(index));
+            const auto trackId = m_pTrackModel->getTrackId(index);
+            if (trackId.isValid()) {
+                trackIds.push_back(trackId);
+            }
         }
     } else {
-        const TrackPointerList trackPointers = getTrackPointers();
-        for (const auto& pTrack : trackPointers) {
+        trackIds.reserve(m_pTrackPointerList.size());
+        for (const auto& pTrack : m_pTrackPointerList) {
+            const auto trackId = pTrack->getId();
+            DEBUG_ASSERT(trackId.isValid());
             trackIds.push_back(pTrack->getId());
         }
     }
@@ -635,16 +640,19 @@ TrackIdList WTrackMenu::getTrackIds() const {
 }
 
 TrackPointerList WTrackMenu::getTrackPointers() const {
-    if (m_pTrackModel) {
-        const QModelIndexList indices = getTrackIndices();
-        TrackPointerList trackPointers;
-        trackPointers.reserve(indices.size());
-        for (const auto& index : indices) {
-            trackPointers.push_back(m_pTrackModel->getTrack(index));
-        }
-        return trackPointers;
+    if (!m_pTrackModel) {
+        return m_pTrackPointerList;
     }
-    return m_pTrackPointerList;
+    const QModelIndexList indices = getTrackIndices();
+    TrackPointerList trackPointers;
+    trackPointers.reserve(indices.size());
+    for (const auto& index : indices) {
+        const auto pTrack = m_pTrackModel->getTrack(index);
+        if (pTrack) {
+            trackPointers.push_back(pTrack);
+        }
+    }
+    return trackPointers;
 }
 
 QModelIndexList WTrackMenu::getTrackIndices() const {

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -10,6 +10,8 @@
 #include "library/crate/cratefeaturehelper.h"
 #include "library/dao/trackdao.h"
 #include "library/dao/trackschema.h"
+#include "library/dlgtagfetcher.h"
+#include "library/dlgtrackinfo.h"
 #include "library/dlgtrackmetadataexport.h"
 #include "library/externaltrackcollection.h"
 #include "library/library.h"

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -60,6 +60,13 @@ WTrackMenu::WTrackMenu(QWidget* parent,
     setupActions();
 }
 
+WTrackMenu::~WTrackMenu() {
+    // ~QPointer() needs the definition of the wrapped type
+    // upon deletion! Otherwise the behavior is undefined.
+    // The wrapped types of some QPointer members are only
+    // forward declared in the header file.
+}
+
 void WTrackMenu::popup(const QPoint& pos, QAction* at) {
     if (getTrackPointers().empty()) {
         return;

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -11,8 +11,6 @@ class ControlProxy;
 class DlgTagFetcher;
 class DlgTrackInfo;
 class ExternalTrackCollection;
-class QAction;
-class QWidget;
 class TrackCollectionManager;
 class WColorPickerAction;
 class WCoverArtMenu;

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -50,8 +50,7 @@ class WTrackMenu : public QMenu {
             TrackCollectionManager* pTrackCollectionManager,
             Features flags = Feature::All,
             TrackModel* trackModel = nullptr);
-
-    ~WTrackMenu() override = default;
+    ~WTrackMenu() override;
 
     void loadTrack(TrackId trackId);
     void loadTrack(QModelIndex index);

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -1,17 +1,19 @@
 #pragma once
 
 #include <QMenu>
+#include <QModelIndex>
+#include <QPointer>
 
 #include "library/dao/playlistdao.h"
-#include "library/dlgtagfetcher.h"
-#include "library/dlgtrackinfo.h"
-#include "library/trackmodel.h"
+#include "preferences/usersettings.h"
+#include "track/track.h"
 
 class ControlProxy;
 class DlgTagFetcher;
 class DlgTrackInfo;
 class ExternalTrackCollection;
 class TrackCollectionManager;
+class TrackModel;
 class WColorPickerAction;
 class WCoverArtMenu;
 

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -30,6 +30,10 @@ WTrackProperty::WTrackProperty(QWidget* pParent,
     setAcceptDrops(true);
 }
 
+WTrackProperty::~WTrackProperty() {
+    // Required to allow forward declaration of WTrackMenu in header
+}
+
 void WTrackProperty::setup(const QDomNode& node, const SkinContext& context) {
     WLabel::setup(node, context);
 

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -2,6 +2,7 @@
 #include <QUrl>
 
 #include "control/controlobject.h"
+#include "widget/wtrackmenu.h"
 #include "widget/wtrackproperty.h"
 #include "util/dnd.h"
 

--- a/src/widget/wtrackproperty.h
+++ b/src/widget/wtrackproperty.h
@@ -1,5 +1,4 @@
-#ifndef WTRACKPROPERTY_H
-#define WTRACKPROPERTY_H
+#pragma once
 
 #include <QDragEnterEvent>
 #include <QDropEvent>
@@ -11,7 +10,8 @@
 #include "util/parented_ptr.h"
 #include "widget/trackdroptarget.h"
 #include "widget/wlabel.h"
-#include "widget/wtrackmenu.h"
+
+class WTrackMenu;
 
 class WTrackProperty : public WLabel, public TrackDropTarget {
     Q_OBJECT
@@ -52,6 +52,3 @@ signals:
 
     const parented_ptr<WTrackMenu> m_pTrackMenu;
 };
-
-
-#endif /* WTRACKPROPERTY_H */

--- a/src/widget/wtrackproperty.h
+++ b/src/widget/wtrackproperty.h
@@ -11,6 +11,7 @@
 #include "widget/trackdroptarget.h"
 #include "widget/wlabel.h"
 
+class TrackCollectionManager;
 class WTrackMenu;
 
 class WTrackProperty : public WLabel, public TrackDropTarget {
@@ -21,8 +22,7 @@ class WTrackProperty : public WLabel, public TrackDropTarget {
             UserSettingsPointer pConfig,
             TrackCollectionManager* pTrackCollectionManager,
             const char* group);
-
-    ~WTrackProperty() override = default;
+    ~WTrackProperty() override;
 
     void setup(const QDomNode& node, const SkinContext& context) override;
 

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -20,6 +20,7 @@
 #include "util/assert.h"
 #include "util/dnd.h"
 #include "util/time.h"
+#include "widget/wtrackmenu.h"
 #include "widget/wtracktableviewheader.h"
 
 WTrackTableView::WTrackTableView(QWidget* parent,

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -12,13 +12,13 @@
 #include "util/duration.h"
 #include "util/parented_ptr.h"
 #include "widget/wlibrarytableview.h"
-#include "widget/wtrackmenu.h"
 
 class ControlProxy;
 class DlgTagFetcher;
 class DlgTrackInfo;
 class TrackCollectionManager;
 class ExternalTrackCollection;
+class WTrackMenu;
 
 const QString WTRACKTABLEVIEW_VSCROLLBARPOS_KEY = "VScrollBarPos"; /** ConfigValue key for QTable vertical scrollbar position */
 const QString LIBRARY_CONFIGVALUE = "[Library]"; /** ConfigValue "value" (wtf) for library stuff */

--- a/src/widget/wtracktext.cpp
+++ b/src/widget/wtracktext.cpp
@@ -3,6 +3,7 @@
 #include <QUrl>
 
 #include "control/controlobject.h"
+#include "widget/wtrackmenu.h"
 #include "widget/wtracktext.h"
 #include "util/dnd.h"
 

--- a/src/widget/wtracktext.cpp
+++ b/src/widget/wtracktext.cpp
@@ -31,6 +31,10 @@ WTrackText::WTrackText(QWidget* pParent,
     setAcceptDrops(true);
 }
 
+WTrackText::~WTrackText() {
+    // Required to allow forward declaration of WTrackMenu in header
+}
+
 void WTrackText::slotTrackLoaded(TrackPointer track) {
     if (track) {
         m_pCurrentTrack = track;

--- a/src/widget/wtracktext.h
+++ b/src/widget/wtracktext.h
@@ -1,5 +1,4 @@
-#ifndef WTRACKTEXT_H
-#define WTRACKTEXT_H
+#pragma once
 
 #include <QDragEnterEvent>
 #include <QDropEvent>
@@ -10,7 +9,8 @@
 #include "util/parented_ptr.h"
 #include "widget/trackdroptarget.h"
 #include "widget/wlabel.h"
-#include "widget/wtrackmenu.h"
+
+class WTrackMenu;
 
 class WTrackText : public WLabel, public TrackDropTarget {
     Q_OBJECT
@@ -45,6 +45,3 @@ class WTrackText : public WLabel, public TrackDropTarget {
     TrackPointer m_pCurrentTrack;
     const parented_ptr<WTrackMenu> m_pTrackMenu;
 };
-
-
-#endif /* WTRACKTEXT_H */

--- a/src/widget/wtracktext.h
+++ b/src/widget/wtracktext.h
@@ -10,6 +10,7 @@
 #include "widget/trackdroptarget.h"
 #include "widget/wlabel.h"
 
+class TrackCollectionManager;
 class WTrackMenu;
 
 class WTrackText : public WLabel, public TrackDropTarget {
@@ -20,6 +21,7 @@ class WTrackText : public WLabel, public TrackDropTarget {
             UserSettingsPointer pConfig,
             TrackCollectionManager* pTrackCollectionManager,
             const char* group);
+    ~WTrackText() override;
 
   signals:
     void trackDropped(QString fileName, QString group) override;


### PR DESCRIPTION
Next round of cleanups:
- Single-element lists can be constructed directly using initializer lists. We don't need to comment this code, the purpose is obvious.
- Reserve capacity of lists upfront (was missing before one loop)
- Check that TrackId/TrackPointer returned from TrackModel are valid and otherwise skip them