### PR TITLE
Fix load/save of most recent loop

### DIFF
--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -218,7 +218,7 @@ void BaseTrackPlayerImpl::loadTrack(TrackPointer pTrack) {
         QListIterator<CuePointer> it(trackCues);
         while (it.hasNext()) {
             CuePointer pCue(it.next());
-            if (pCue->getType() == mixxx::CueType::Loop) {
+            if (pCue->getType() == mixxx::CueType::Loop && pCue->getHotCue() == Cue::kNoHotCue) {
                 double loopStart = pCue->getPosition();
                 double loopEnd = loopStart + pCue->getLength();
                 if (loopStart != kNoTrigger && loopEnd != kNoTrigger && loopStart <= loopEnd) {
@@ -256,7 +256,7 @@ TrackPointer BaseTrackPlayerImpl::unloadTrack() {
         QListIterator<CuePointer> it(cuePoints);
         while (it.hasNext()) {
             CuePointer pCue(it.next());
-            if (pCue->getType() == mixxx::CueType::Loop) {
+            if (pCue->getType() == mixxx::CueType::Loop && pCue->getHotCue() == Cue::kNoHotCue) {
                 pLoopCue = pCue;
                 break;
             }

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -258,6 +258,7 @@ TrackPointer BaseTrackPlayerImpl::unloadTrack() {
             CuePointer pCue(it.next());
             if (pCue->getType() == mixxx::CueType::Loop) {
                 pLoopCue = pCue;
+                break;
             }
         }
         if (!pLoopCue) {

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -216,16 +216,29 @@ void BaseTrackPlayerImpl::loadTrack(TrackPointer pTrack) {
     if (!m_pChannelToCloneFrom) {
         const QList<CuePointer> trackCues(m_pLoadedTrack->getCuePoints());
         QListIterator<CuePointer> it(trackCues);
+        CuePointer pLoopCue;
+        // Restore loop from the first loop cue with minimum hotcue number.
+        // For the volatile "most recent loop" the hotcue number will be -1.
+        // If no such loop exists, restore a saved loop cue.
         while (it.hasNext()) {
             CuePointer pCue(it.next());
-            if (pCue->getType() == mixxx::CueType::Loop && pCue->getHotCue() == Cue::kNoHotCue) {
-                double loopStart = pCue->getPosition();
-                double loopEnd = loopStart + pCue->getLength();
-                if (loopStart != kNoTrigger && loopEnd != kNoTrigger && loopStart <= loopEnd) {
-                    m_pLoopInPoint->set(loopStart);
-                    m_pLoopOutPoint->set(loopEnd);
-                    break;
-                }
+            if (pCue->getType() != mixxx::CueType::Loop) {
+                continue;
+            }
+
+            if (pLoopCue && pLoopCue->getHotCue() <= pCue->getHotCue()) {
+                continue;
+            }
+
+            pLoopCue = pCue;
+        }
+
+        if (pLoopCue) {
+            double loopStart = pLoopCue->getPosition();
+            double loopEnd = loopStart + pLoopCue->getLength();
+            if (loopStart != kNoTrigger && loopEnd != kNoTrigger && loopStart <= loopEnd) {
+                m_pLoopInPoint->set(loopStart);
+                m_pLoopOutPoint->set(loopEnd);
             }
         }
     } else {


### PR DESCRIPTION
I don't know if this actually causes problems right now, but it would if there are multiple loops per track (first loop is loaded, last loop is saved). Should we backport this fix for 2.2?