### PR TITLE
Fixes to allow Scons build to work with python 3 on windows.

### DIFF
--- a/build/qt5.py
+++ b/build/qt5.py
@@ -208,7 +208,8 @@ class _Automoc:
             
             # Now, check whether the corresponding CPP file
             # includes the moc'ed output directly...
-            inc_moc_cpp = r'^\s*#\s*include\s+"%s"' % str(moc_cpp[0])
+            inc_path_removed = os.path.split(str(moc_cpp[0]))[1]
+            inc_moc_cpp = r'^\s*#\s*include\s+"%s"' % inc_path_removed
             if cpp and re.search(inc_moc_cpp, cpp_contents, re.M):
                 if moc_options['debug']:
                     print("scons: qt5: CXX file '%s' directly includes the moc'ed output '%s', no compiling required" % (str(cpp), str(moc_cpp)))

--- a/build/util.py
+++ b/build/util.py
@@ -71,7 +71,7 @@ def export_source(source, dest):
 
 
 def get_git_revision():
-    return len(os.popen("git log --pretty=oneline --first-parent").read().splitlines())
+    return os.popen("git rev-list HEAD --first-parent --count").read().strip()
 
 
 def get_git_modified():


### PR DESCRIPTION
We are moving away from scons to cmake, but while we're not on 2.4, we might maintain this compatibility.
