### PR TITLE
Work around lp:1872172 by hiding/showing waveform widgets when WWaveformViewer is shown.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -149,20 +149,19 @@ for:
   environment:
     ENVIRONMENTS_URL: https://downloads.mixxx.org/builds/buildserver/2.3.x-windows/
     ENVIRONMENTS_PATH: C:\mixxx-buildserver
-    ENVIRONMENT_NAME: 2.3-j00013-PLATFORM-CONFIGURATION-static-36f44bd2-minimal
-    QT_VERSION: 5.12.0
     MSVC_PATH: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community"
     PATH: 'C:\Python37-x64;C:\Python37-x64\Scripts;%PATH%'
 
 
   install:
-    - set ENVIRONMENT_NAME=%%ENVIRONMENT_NAME:PLATFORM=%platform%%%
-    - set ENVIRONMENT_NAME=%%ENVIRONMENT_NAME:CONFIGURATION=%configuration%%%
+    - set /P ENVIRONMENT_NAME=<build/windows/golden_environment
+    - call set ENVIRONMENT_NAME=%%ENVIRONMENT_NAME:PLATFORM=%platform%%%
+    - call set ENVIRONMENT_NAME=%%ENVIRONMENT_NAME:CONFIGURATION=%configuration%%%
     - set WINLIB_PATH=%ENVIRONMENTS_PATH%\%ENVIRONMENT_NAME%
     - IF EXIST %WINLIB_PATH% (
         echo Using cached environment %WINLIB_PATH%...
       ) else (
-        mkdir %ENVIRONMENTS_PATH% &&
+        mkdir %ENVIRONMENTS_PATH% &
         echo Downloading environment %ENVIRONMENT_NAME%... &&
         curl -fsS -L -o%ENVIRONMENTS_PATH%\%ENVIRONMENT_NAME%.zip %ENVIRONMENTS_URL%/%ENVIRONMENT_NAME%.zip &&
         echo Unpacking environment %ENVIRONMENT_NAME% to %ENVIRONMENTS_PATH%... &&
@@ -172,6 +171,10 @@ for:
     - python -m pip install git+https://github.com/frerich/clcache.git
 
   before_build:
+    - FOR /D %%G IN (%WINLIB_PATH%\Qt-*) DO SET QT_PATH=%%G
+    - IF "%QT_PATH%" EQU "" (
+        echo QT not found on %WINLIB_PATH%
+      )
     - set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
     - set QT_PATH=%WINLIB_PATH%\Qt-%QT_VERSION%
     - set CMAKE_BUILD_PARALLEL_LEVEL=%NUMBER_OF_CORES%

--- a/build/appveyor/build_mixxx.bat
+++ b/build/appveyor/build_mixxx.bat
@@ -94,9 +94,11 @@ set WINLIB_DIR=%3
 SET BIN_DIR=%WINLIB_DIR%\bin
 SET LIB_DIR=%WINLIB_DIR%\lib
 SET INCLUDE_DIR=%WINLIB_DIR%\include
-REM TODO(rryan): Remove hard-coding of Qt version.
-set QT_VERSION=5.12.0
-SET QTDIR=%WINLIB_DIR%\Qt-%QT_VERSION%
+FOR /D %%G IN (%WINLIB_DIR%\Qt-*) DO SET QTDIR=%%G
+IF "!QTDIR!" EQU "" (
+echo QT not found on %WINLIB_DIR%
+exit /b 1
+)
 
 if NOT EXIST "%BIN_DIR%\scons.py" (
 echo.

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -419,17 +419,12 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
         // Disable waiting for vertical Sync
         // This can be enabled when using a single Threads for each QGLContext
         // Setting 1 causes QGLContext::swapBuffer to sleep until the next VSync
-#if defined(__APPLE__)
-        // On OS X, syncing to vsync has good performance FPS-wise and
-        // eliminates tearing.
-        glFormat.setSwapInterval(1);
-#else
+
         // Otherwise, turn VSync off because it could cause horrible FPS on
         // Linux.
         // TODO(XXX): Make this configurable.
         // TODO(XXX): What should we do on Windows?
         glFormat.setSwapInterval(0);
-#endif
         glFormat.setRgba(true);
         QGLFormat::setDefaultFormat(glFormat);
 

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -50,8 +50,18 @@ void WWaveformViewer::setup(const QDomNode& node, const SkinContext& context) {
 }
 
 void WWaveformViewer::resizeEvent(QResizeEvent* /*event*/) {
+    qDebug() << this << "resizeEvent";
+    qDebug() << this << "isVisible()" << isVisible() << size();
+    qDebug() << this << "isVisible()" << parentWidget() << parentWidget()->size();
     if (m_waveformWidget) {
+        auto widget = m_waveformWidget->getWidget();
+        qDebug() << this << "widget isVisible()" << widget->isVisible() << widget->size();
         m_waveformWidget->resize(width(), height());
+        qDebug() << this << "widget isVisible()" << widget->isVisible() << widget->size();
+        auto window = widget->windowHandle();
+        if (window != nullptr) {
+            qDebug() << window << "vis" << window->isVisible() << window->size() << window->surfaceType() << "exposed" << window->isExposed();
+        }
     }
 }
 
@@ -206,6 +216,8 @@ void WWaveformViewer::setPlayMarkerPosition(double position) {
 }
 
 void WWaveformViewer::setWaveformWidget(WaveformWidgetAbstract* waveformWidget) {
+    qDebug() << this << "setWaveformWidget";
+    qDebug() << this << "isVisible()" << isVisible() << size();
     if (m_waveformWidget) {
         QWidget* pWidget = m_waveformWidget->getWidget();
         disconnect(pWidget, SIGNAL(destroyed()),
@@ -213,6 +225,7 @@ void WWaveformViewer::setWaveformWidget(WaveformWidgetAbstract* waveformWidget) 
     }
     m_waveformWidget = waveformWidget;
     if (m_waveformWidget) {
+        qDebug() << this << "widget isVisible()" << waveformWidget->getWidget()->isVisible();
         QWidget* pWidget = m_waveformWidget->getWidget();
         connect(pWidget, SIGNAL(destroyed()),
                 this, SLOT(slotWidgetDead()));
@@ -221,8 +234,14 @@ void WWaveformViewer::setWaveformWidget(WaveformWidgetAbstract* waveformWidget) 
 }
 
 void WWaveformViewer::showEvent(QShowEvent *event) {
+    qDebug() << this << "showEvent";
+    qDebug() << this << "isVisible()" << isVisible() << size();
+    qDebug() << this << "isVisible()" << parentWidget() << parentWidget()->size();
     if (m_waveformWidget) {
         auto widget = m_waveformWidget->getWidget();
+        qDebug() << this << "widget isVisible()" << widget->isVisible() << widget->size();
+        //widget->show();
+
         // Work around lp:1872172. On Qt 5.14, waveforms do not show on startup
         // on macOS and Windows.
         if (widget) {

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -217,4 +217,17 @@ void WWaveformViewer::setWaveformWidget(WaveformWidgetAbstract* waveformWidget) 
         connect(pWidget, SIGNAL(destroyed()),
                 this, SLOT(slotWidgetDead()));
     }
+
+}
+
+void WWaveformViewer::showEvent(QShowEvent *event) {
+    if (m_waveformWidget) {
+        auto widget = m_waveformWidget->getWidget();
+        // Work around lp:1872172. On Qt 5.14, waveforms do not show on startup
+        // on macOS and Windows.
+        if (widget) {
+            widget->hide();
+            widget->show();
+        }
+    }
 }

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -7,6 +7,7 @@
 #include <QEvent>
 #include <QList>
 #include <QMutex>
+#include <QShowEvent>
 
 #include "track/track.h"
 #include "widget/trackdroptarget.h"
@@ -28,6 +29,7 @@ class WWaveformViewer : public WWidget, public TrackDropTarget {
 
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dropEvent(QDropEvent *event) override;
+    void showEvent(QShowEvent *event) override;
 
     void mousePressEvent(QMouseEvent * /*unused*/) override;
     void mouseMoveEvent(QMouseEvent * /*unused*/) override;


### PR DESCRIPTION
On Qt 5.14, waveforms do not show on startup on macOS and Windows. This
workaround (hide/show the QGLWidget when its parent is shown) works on macOS.