### PR TITLE
fix bpm analysis regression after deprecating vamp

### DIFF
--- a/src/analyzer/plugins/analyzerqueenmarybeats.cpp
+++ b/src/analyzer/plugins/analyzerqueenmarybeats.cpp
@@ -10,7 +10,7 @@
 namespace mixxx {
 namespace {
 
-constexpr float kStepSecs = 0.01161; // 512 samples at 44100
+constexpr float kStepSecs = 0.01161; // stepsize should be equivalent to ~11.61 ms irrespectively of samplerate
 
 DFConfig makeDetectionFunctionConfig(int stepSize, int windowSize) {
     // These are the defaults for the VAMP beat tracker plugin we used in Mixxx
@@ -38,6 +38,7 @@ AnalyzerQueenMaryBeats::~AnalyzerQueenMaryBeats() {
 bool AnalyzerQueenMaryBeats::initialize(int samplerate) {
     m_detectionResults.clear();
     m_iSampleRate = samplerate;
+    // These are the preferred window/step sizes from the BeatTrack VAMP
     m_stepSize = int(m_iSampleRate * kStepSecs + 0.0001);
     m_windowSize = m_stepSize * 2;
     m_pDetectionFunction = std::make_unique<DetectionFunction>(

--- a/src/analyzer/plugins/analyzerqueenmarybeats.cpp
+++ b/src/analyzer/plugins/analyzerqueenmarybeats.cpp
@@ -10,14 +10,14 @@
 namespace mixxx {
 namespace {
 // These are the preferred window/step sizes from the BeatTrack VAMP plugin.
-constexpr size_t kWindowSize = 1024;
-constexpr size_t kStepSize = 512;
+constexpr size_t kWindowSize = 512;
+constexpr size_t kStepSize = 256;
 
 DFConfig makeDetectionFunctionConfig() {
     // These are the defaults for the VAMP beat tracker plugin we used in Mixxx
     // 2.0.
     DFConfig config;
-    config.DFType = DF_SPECDIFF;
+    config.DFType = DF_COMPLEXSD;
     config.stepSize = kStepSize;
     config.frameLength = kWindowSize;
     config.dbRise = 3;
@@ -70,13 +70,14 @@ bool AnalyzerQueenMaryBeats::finalize() {
     }
 
     std::vector<double> df;
-    std::vector<double> beatPeriod(nonZeroCount);
+    std::vector<double> beatPeriod;
     std::vector<double> tempi;
 
     df.reserve(nonZeroCount);
-
-    for (int i = 0; i < nonZeroCount; ++i) {
+    // no idea why skip first 2 results, but that's how vamp does and works best this way
+    for (int i = 2; i < nonZeroCount; ++i) {
         df.push_back(m_detectionResults.at(i));
+        beatPeriod.push_back(0.0);
     }
 
     TempoTrackV2 tt(m_iSampleRate, kStepSize);

--- a/src/analyzer/plugins/analyzerqueenmarybeats.cpp
+++ b/src/analyzer/plugins/analyzerqueenmarybeats.cpp
@@ -9,17 +9,16 @@
 
 namespace mixxx {
 namespace {
-// These are the preferred window/step sizes from the BeatTrack VAMP plugin.
-constexpr size_t kWindowSize = 512;
-constexpr size_t kStepSize = 256;
 
-DFConfig makeDetectionFunctionConfig() {
+constexpr float kStepSecs = 0.01161; // 512 samples at 44100
+
+DFConfig makeDetectionFunctionConfig(int stepSize, int windowSize) {
     // These are the defaults for the VAMP beat tracker plugin we used in Mixxx
     // 2.0.
     DFConfig config;
     config.DFType = DF_COMPLEXSD;
-    config.stepSize = kStepSize;
-    config.frameLength = kWindowSize;
+    config.stepSize = stepSize;
+    config.frameLength = windowSize;
     config.dbRise = 3;
     config.adaptiveWhitening = 0;
     config.whiteningRelaxCoeff = -1;
@@ -39,11 +38,14 @@ AnalyzerQueenMaryBeats::~AnalyzerQueenMaryBeats() {
 bool AnalyzerQueenMaryBeats::initialize(int samplerate) {
     m_detectionResults.clear();
     m_iSampleRate = samplerate;
+    m_stepSize = int(m_iSampleRate * kStepSecs + 0.0001);
+    m_windowSize = m_stepSize * 2;
     m_pDetectionFunction = std::make_unique<DetectionFunction>(
-            makeDetectionFunctionConfig());
+            makeDetectionFunctionConfig(m_stepSize, m_windowSize));
+    qDebug() << "input sample rate is " << m_iSampleRate << ", step size is " << m_stepSize;
 
     m_helper.initialize(
-            kWindowSize, kStepSize, [this](double* pWindow, size_t) {
+            m_windowSize, m_stepSize, [this](double* pWindow, size_t) {
                 // TODO(rryan) reserve?
                 m_detectionResults.push_back(
                         m_pDetectionFunction->processTimeDomain(pWindow));
@@ -72,46 +74,26 @@ bool AnalyzerQueenMaryBeats::finalize() {
     std::vector<double> df;
     std::vector<double> beatPeriod;
     std::vector<double> tempi;
+    const auto required_size = std::max(0, nonZeroCount - 2);
+    df.reserve(required_size);
+    beatPeriod.reserve(required_size);
 
-    df.reserve(nonZeroCount);
-    // no idea why skip first 2 results, but that's how vamp does and works best this way
+    // skip first 2 results as it might have detect noise as onset
+    // that's how vamp does and seems works best this way
     for (int i = 2; i < nonZeroCount; ++i) {
         df.push_back(m_detectionResults.at(i));
         beatPeriod.push_back(0.0);
     }
 
-    TempoTrackV2 tt(m_iSampleRate, kStepSize);
+    TempoTrackV2 tt(m_iSampleRate, m_stepSize);
     tt.calculateBeatPeriod(df, beatPeriod, tempi);
 
     std::vector<double> beats;
     tt.calculateBeats(df, beatPeriod, beats);
 
-    // In some tracks a beat at 0:00 is detected when a noise floor starts.
-    // Here we check the level and the position for plausibility and remove
-    // the beat if this is the case.
-    size_t firstBeat = 0;
-    if (beats.size() >= 3) {
-        if (beats.at(0) <= 0) {
-            firstBeat = 1;
-        } else if (m_detectionResults.at(beats.at(0)) <
-                (m_detectionResults.at(beats.at(1)) +
-                m_detectionResults.at(beats.at(2))) / 4) {
-            // the beat is not half es high than the average of the two
-            // following beats. Skip it.
-            firstBeat = 1;
-        } else {
-            int diff = (beats.at(1) - beats.at(0)) - (beats.at(2) - beats.at(1));
-            // we don't allow a significant tempo change after the first beat
-            if (diff > 2 || diff < -2) {
-                // first beat is off grid. Skip it.
-                firstBeat = 1;
-            }
-        }
-    }
-
     m_resultBeats.reserve(beats.size());
-    for (size_t i = firstBeat; i < beats.size(); ++i) {
-        double result = (beats.at(i) * kStepSize) - kStepSize / 2;
+    for (size_t i = 0; i < beats.size(); ++i) {
+        double result = (beats.at(i) * m_stepSize) - m_stepSize / 2;
         m_resultBeats.push_back(result);
     }
 

--- a/src/analyzer/plugins/analyzerqueenmarybeats.cpp
+++ b/src/analyzer/plugins/analyzerqueenmarybeats.cpp
@@ -9,8 +9,9 @@
 
 namespace mixxx {
 namespace {
-
-constexpr float kStepSecs = 0.01161; // stepsize should be equivalent to ~11.61 ms irrespectively of samplerate
+// stepsize should be equivalent to ~10ms and this constant (11.61ms) make the number 
+// of samples an exact power of 2 for 22.1k, 44.1k, and very close to, for 96k and 192k
+constexpr float kStepSecs = 0.01161; 
 
 DFConfig makeDetectionFunctionConfig(int stepSize, int windowSize) {
     // These are the defaults for the VAMP beat tracker plugin we used in Mixxx

--- a/src/analyzer/plugins/analyzerqueenmarybeats.h
+++ b/src/analyzer/plugins/analyzerqueenmarybeats.h
@@ -51,8 +51,7 @@ class AnalyzerQueenMaryBeats : public AnalyzerBeatsPlugin {
     int m_iSampleRate;
     int m_windowSize;
     int m_stepSize;
-    std::vector<double>
-            m_detectionResults;
+    std::vector<double> m_detectionResults;
     QVector<double> m_resultBeats;
 };
 

--- a/src/analyzer/plugins/analyzerqueenmarybeats.h
+++ b/src/analyzer/plugins/analyzerqueenmarybeats.h
@@ -49,7 +49,10 @@ class AnalyzerQueenMaryBeats : public AnalyzerBeatsPlugin {
     std::unique_ptr<DetectionFunction> m_pDetectionFunction;
     DownmixAndOverlapHelper m_helper;
     int m_iSampleRate;
-    std::vector<double> m_detectionResults;
+    int m_windowSize;
+    int m_stepSize;
+    std::vector<double>
+            m_detectionResults;
     QVector<double> m_resultBeats;
 };
 


### PR DESCRIPTION
Discussed at [Zulip](https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/BPM.20analysis.20improvements)

**Brief**: When testing [PR#2668](https://github.com/mixxxdj/mixxx/pull/2668) on the GTZAN dataset I accidentally found out that were major regression in the bpm analysis in master compared to 2.2, as shown [here](https://zulip-uploads.s3.amazonaws.com/2380/t2N0YDLQCZ8ee1NIXYqRcMv9/Screen-Shot-2020-04-17-at-3.38.52-PM.png?Signature=fVSHeUj8gJG10AbBZMk11TZJX8I%3D&Expires=1587309470&AWSAccessKeyId=AKIAIEVMBCAT2WD3M5KQ)

This PR fixes that.
Turns out it was caused by some different parameter values being used as default compared to vamp plugin defaults. Just changed them and voila. 
Maybe we should expose these as user configs?
Also, there is a weird undocumented offset that was removed when copying the vamp code that I restore.