### PR TITLE
WTrackMenu: Cleanup & performance regression fixes (part 2)

### DIFF
--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1028,6 +1028,8 @@ void WTrackMenu::loadSelectionToGroup(QString group, bool play) {
     if (trackPointers.empty()) {
         return;
     }
+    // Only the first track was requested
+    DEBUG_ASSERT(trackPointers.size() == 1);
     // If the track load override is disabled, check to see if a track is
     // playing before trying to load it
     if (!(m_pConfig->getValueString(

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1150,48 +1150,48 @@ bool WTrackMenu::featureIsEnabled(Feature flag) const {
         return false;
     }
 
-    if (m_pTrackModel) {
-        if (flag == Feature::AutoDJ) {
-            return m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_ADDTOAUTODJ);
-        } else if (flag == Feature::LoadTo) {
-            return m_pTrackModel->hasCapabilities(
-                           TrackModel::TRACKMODELCAPS_LOADTODECK) ||
-                    m_pTrackModel->hasCapabilities(
-                            TrackModel::TRACKMODELCAPS_LOADTOSAMPLER) ||
-                    m_pTrackModel->hasCapabilities(
-                            TrackModel::TRACKMODELCAPS_LOADTOPREVIEWDECK);
-        } else if (flag == Feature::Playlist) {
-            return m_pTrackModel->hasCapabilities(
-                    TrackModel::TRACKMODELCAPS_ADDTOPLAYLIST);
-        } else if (flag == Feature::Crate) {
-            return m_pTrackModel->hasCapabilities(
-                    TrackModel::TRACKMODELCAPS_ADDTOCRATE);
-        } else if (flag == Feature::Remove) {
-            return m_pTrackModel->hasCapabilities(
-                           TrackModel::TRACKMODELCAPS_REMOVE) ||
-                    m_pTrackModel->hasCapabilities(
-                            TrackModel::TRACKMODELCAPS_REMOVE_PLAYLIST) ||
-                    m_pTrackModel->hasCapabilities(
-                            TrackModel::TRACKMODELCAPS_REMOVE_CRATE);
-        } else if (flag == Feature::Metadata) {
-            return m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_EDITMETADATA);
-        } else if (flag == Feature::Reset) {
-            return m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_EDITMETADATA) &&
-                    m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_RESETPLAYED);
-        } else if (flag == Feature::BPM) {
-            return m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_EDITMETADATA);
-        } else if (flag == Feature::Color) {
-            return m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_EDITMETADATA);
-        } else if (flag == Feature::HideUnhidePurge) {
-            return m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_HIDE) ||
-                    m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_UNHIDE) ||
-                    m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_PURGE);
-        } else if (flag == Feature::Properties) {
-            return m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_EDITMETADATA);
-        } else {
-            return true;
-        }
+    if (!m_pTrackModel) {
+        return !m_eTrackModelFeatures.testFlag(flag);
     }
 
-    return !m_eTrackModelFeatures.testFlag(flag);
+    if (flag == Feature::AutoDJ) {
+        return m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_ADDTOAUTODJ);
+    } else if (flag == Feature::LoadTo) {
+        return m_pTrackModel->hasCapabilities(
+                        TrackModel::TRACKMODELCAPS_LOADTODECK) ||
+                m_pTrackModel->hasCapabilities(
+                        TrackModel::TRACKMODELCAPS_LOADTOSAMPLER) ||
+                m_pTrackModel->hasCapabilities(
+                        TrackModel::TRACKMODELCAPS_LOADTOPREVIEWDECK);
+    } else if (flag == Feature::Playlist) {
+        return m_pTrackModel->hasCapabilities(
+                TrackModel::TRACKMODELCAPS_ADDTOPLAYLIST);
+    } else if (flag == Feature::Crate) {
+        return m_pTrackModel->hasCapabilities(
+                TrackModel::TRACKMODELCAPS_ADDTOCRATE);
+    } else if (flag == Feature::Remove) {
+        return m_pTrackModel->hasCapabilities(
+                        TrackModel::TRACKMODELCAPS_REMOVE) ||
+                m_pTrackModel->hasCapabilities(
+                        TrackModel::TRACKMODELCAPS_REMOVE_PLAYLIST) ||
+                m_pTrackModel->hasCapabilities(
+                        TrackModel::TRACKMODELCAPS_REMOVE_CRATE);
+    } else if (flag == Feature::Metadata) {
+        return m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_EDITMETADATA);
+    } else if (flag == Feature::Reset) {
+        return m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_EDITMETADATA) &&
+                m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_RESETPLAYED);
+    } else if (flag == Feature::BPM) {
+        return m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_EDITMETADATA);
+    } else if (flag == Feature::Color) {
+        return m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_EDITMETADATA);
+    } else if (flag == Feature::HideUnhidePurge) {
+        return m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_HIDE) ||
+                m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_UNHIDE) ||
+                m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_PURGE);
+    } else if (flag == Feature::Properties) {
+        return m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_EDITMETADATA);
+    } else {
+        return true;
+    }
 }

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -416,6 +416,10 @@ void WTrackMenu::setupActions() {
 }
 
 void WTrackMenu::updateMenus() {
+    if (isEmpty()) {
+        return;
+    }
+
     const auto trackIds = getTrackIds();
     // TODO: Loading all tracks just by opening the context menu
     // menu is a real UX performance killer!!
@@ -600,9 +604,7 @@ void WTrackMenu::loadTrackModelIndices(
     clearTrackSelection();
 
     m_trackIndexList = trackIndexList;
-    if (!m_trackIndexList.empty()) {
-        updateMenus();
-    }
+    updateMenus();
 }
 
 TrackIdList WTrackMenu::getTrackIds() const {

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -512,21 +512,34 @@ void WTrackMenu::updateMenus() {
     }
 
     if (featureIsEnabled(Feature::BPM)) {
-        bool anyLocked = false; //true if any of the selected items are locked
-        for (const auto& pTrack : trackPointers) {
-            if (pTrack->isBpmLocked()) {
-                anyLocked = true;
-                break;
+        bool anyBpmLocked = false;
+        if (m_pTrackModel) {
+            const int bpmLockedCol =
+                    m_pTrackModel->fieldIndex(LIBRARYTABLE_BPM_LOCK);
+            for (const auto trackIndex : m_trackIndexList) {
+                QModelIndex bpmLockedIndex =
+                        trackIndex.sibling(trackIndex.row(), bpmLockedCol);
+                if (bpmLockedIndex.data().toBool()) {
+                    anyBpmLocked = true;
+                    break;
+                }
+            }
+        } else {
+            for (const auto& pTrack : m_trackPointerList) {
+                if (pTrack->isBpmLocked()) {
+                    anyBpmLocked = true;
+                    break;
+                }
             }
         }
-        m_pBpmUnlockAction->setEnabled(anyLocked);
-        m_pBpmLockAction->setEnabled(!anyLocked);
-        m_pBpmDoubleAction->setEnabled(!anyLocked);
-        m_pBpmHalveAction->setEnabled(!anyLocked);
-        m_pBpmTwoThirdsAction->setEnabled(!anyLocked);
-        m_pBpmThreeFourthsAction->setEnabled(!anyLocked);
-        m_pBpmFourThirdsAction->setEnabled(!anyLocked);
-        m_pBpmThreeHalvesAction->setEnabled(!anyLocked);
+        m_pBpmUnlockAction->setEnabled(anyBpmLocked);
+        m_pBpmLockAction->setEnabled(!anyBpmLocked);
+        m_pBpmDoubleAction->setEnabled(!anyBpmLocked);
+        m_pBpmHalveAction->setEnabled(!anyBpmLocked);
+        m_pBpmTwoThirdsAction->setEnabled(!anyBpmLocked);
+        m_pBpmThreeFourthsAction->setEnabled(!anyBpmLocked);
+        m_pBpmFourThirdsAction->setEnabled(!anyBpmLocked);
+        m_pBpmThreeHalvesAction->setEnabled(!anyBpmLocked);
     }
 
     if (featureIsEnabled(Feature::Color)) {

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -67,8 +67,16 @@ WTrackMenu::~WTrackMenu() {
     // forward declared in the header file.
 }
 
+bool WTrackMenu::isEmpty() const {
+    if (m_pTrackModel) {
+        return m_trackIndexList.isEmpty();
+    } else {
+        return m_trackPointerList.isEmpty();
+    }
+}
+
 void WTrackMenu::popup(const QPoint& pos, QAction* at) {
-    if (getTrackPointers().empty()) {
+    if (isEmpty()) {
         return;
     }
     QMenu::popup(pos, at);

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1190,9 +1190,12 @@ bool WTrackMenu::featureIsEnabled(Feature flag) const {
         return m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_HIDE) ||
                 m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_UNHIDE) ||
                 m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_PURGE);
+    case Feature::FileBrowser:
+        return true;
     case Feature::Properties:
         return m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_EDITMETADATA);
     default:
+        DEBUG_ASSERT(!"unreachable");
         return true;
     }
 }

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -268,6 +268,12 @@ void WTrackMenu::createActions() {
         connect(m_pBpmThreeFourthsAction, &QAction::triggered, this, [this] { slotScaleBpm(Beats::THREEFOURTHS); });
         connect(m_pBpmFourThirdsAction, &QAction::triggered, this, [this] { slotScaleBpm(Beats::FOURTHIRDS); });
         connect(m_pBpmThreeHalvesAction, &QAction::triggered, this, [this] { slotScaleBpm(Beats::THREEHALVES); });
+
+        m_pBpmResetAction = new QAction(tr("Reset BPM"), m_pBPMMenu);
+        connect(m_pBpmResetAction,
+                &QAction::triggered,
+                this,
+                &WTrackMenu::slotClearBeats);
     }
 
     if (featureIsEnabled(Feature::Color)) {
@@ -342,6 +348,8 @@ void WTrackMenu::setupActions() {
         m_pBPMMenu->addSeparator();
         m_pBPMMenu->addAction(m_pBpmLockAction);
         m_pBPMMenu->addAction(m_pBpmUnlockAction);
+        m_pBPMMenu->addSeparator();
+        m_pBPMMenu->addAction(m_pBpmResetAction);
         m_pBPMMenu->addSeparator();
 
         addMenu(m_pBPMMenu);
@@ -613,6 +621,7 @@ void WTrackMenu::updateMenus() {
             m_pBpmThreeFourthsAction->setEnabled(!anyBpmLocked);
             m_pBpmFourThirdsAction->setEnabled(!anyBpmLocked);
             m_pBpmThreeHalvesAction->setEnabled(!anyBpmLocked);
+            m_pBpmResetAction->setEnabled(!anyBpmLocked);
         }
     }
 

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1051,30 +1051,24 @@ void WTrackMenu::slotClearAllMetadata() {
 }
 
 void WTrackMenu::slotShowTrackInfo() {
+    if (isEmpty()) {
+        return;
+    }
     if (m_pTrackModel) {
-        if (m_trackIndexList.isEmpty()) {
-            return;
-        }
         m_pTrackInfo->loadTrack(m_trackIndexList.at(0));
     } else {
-        if (m_trackPointerList.isEmpty()) {
-            return;
-        }
         m_pTrackInfo->loadTrack(m_trackPointerList.at(0));
     }
     m_pTrackInfo->show();
 }
 
 void WTrackMenu::slotShowDlgTagFetcher() {
+    if (isEmpty()) {
+        return;
+    }
     if (m_pTrackModel) {
-        if (m_trackIndexList.isEmpty()) {
-            return;
-        }
         m_pTagFetcher->loadTrack(m_trackIndexList.at(0));
     } else {
-        if (m_trackPointerList.isEmpty()) {
-            return;
-        }
         m_pTagFetcher->loadTrack(m_trackPointerList.at(0));
     }
     m_pTagFetcher->show();

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -635,13 +635,19 @@ TrackIdList WTrackMenu::getTrackIds() const {
     return trackIds;
 }
 
-TrackPointerList WTrackMenu::getTrackPointers() const {
+TrackPointerList WTrackMenu::getTrackPointers(
+        int maxSize) const {
     if (!m_pTrackModel) {
         return m_trackPointerList;
     }
     TrackPointerList trackPointers;
     trackPointers.reserve(m_trackIndexList.size());
     for (const auto& index : m_trackIndexList) {
+        DEBUG_ASSERT(maxSize < 0 ||
+                maxSize <= trackPointers.size());
+        if (maxSize >= 0 && maxSize <= trackPointers.size()) {
+            return trackPointers;
+        }
         const auto pTrack = m_pTrackModel->getTrack(index);
         if (!pTrack) {
             // Skip unavailable tracks
@@ -946,7 +952,7 @@ void WTrackMenu::slotColorPicked(mixxx::RgbColor::optional_t color) {
 }
 
 void WTrackMenu::loadSelectionToGroup(QString group, bool play) {
-    const TrackPointerList trackPointers = getTrackPointers();
+    const auto trackPointers = getTrackPointers(1);
     if (trackPointers.empty()) {
         return;
     }

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1154,44 +1154,45 @@ bool WTrackMenu::featureIsEnabled(Feature flag) const {
         return !m_eTrackModelFeatures.testFlag(flag);
     }
 
-    if (flag == Feature::AutoDJ) {
+    switch (flag) {
+    case Feature::AutoDJ:
         return m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_ADDTOAUTODJ);
-    } else if (flag == Feature::LoadTo) {
+    case Feature::LoadTo:
         return m_pTrackModel->hasCapabilities(
-                        TrackModel::TRACKMODELCAPS_LOADTODECK) ||
+                       TrackModel::TRACKMODELCAPS_LOADTODECK) ||
                 m_pTrackModel->hasCapabilities(
                         TrackModel::TRACKMODELCAPS_LOADTOSAMPLER) ||
                 m_pTrackModel->hasCapabilities(
                         TrackModel::TRACKMODELCAPS_LOADTOPREVIEWDECK);
-    } else if (flag == Feature::Playlist) {
+    case Feature::Playlist:
         return m_pTrackModel->hasCapabilities(
                 TrackModel::TRACKMODELCAPS_ADDTOPLAYLIST);
-    } else if (flag == Feature::Crate) {
+    case Feature::Crate:
         return m_pTrackModel->hasCapabilities(
                 TrackModel::TRACKMODELCAPS_ADDTOCRATE);
-    } else if (flag == Feature::Remove) {
+    case Feature::Remove:
         return m_pTrackModel->hasCapabilities(
-                        TrackModel::TRACKMODELCAPS_REMOVE) ||
+                       TrackModel::TRACKMODELCAPS_REMOVE) ||
                 m_pTrackModel->hasCapabilities(
                         TrackModel::TRACKMODELCAPS_REMOVE_PLAYLIST) ||
                 m_pTrackModel->hasCapabilities(
                         TrackModel::TRACKMODELCAPS_REMOVE_CRATE);
-    } else if (flag == Feature::Metadata) {
+    case Feature::Metadata:
         return m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_EDITMETADATA);
-    } else if (flag == Feature::Reset) {
+    case Feature::Reset:
         return m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_EDITMETADATA) &&
                 m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_RESETPLAYED);
-    } else if (flag == Feature::BPM) {
+    case Feature::BPM:
         return m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_EDITMETADATA);
-    } else if (flag == Feature::Color) {
+    case Feature::Color:
         return m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_EDITMETADATA);
-    } else if (flag == Feature::HideUnhidePurge) {
+    case Feature::HideUnhidePurge:
         return m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_HIDE) ||
                 m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_UNHIDE) ||
                 m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_PURGE);
-    } else if (flag == Feature::Properties) {
+    case Feature::Properties:
         return m_pTrackModel->hasCapabilities(TrackModel::TRACKMODELCAPS_EDITMETADATA);
-    } else {
+    default:
         return true;
     }
 }

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -602,18 +602,12 @@ void WTrackMenu::loadTracks(QModelIndexList indexList) {
         return;
     }
 
-    QModelIndexList indices;
-    indices.reserve(indexList.size());
+    m_trackIndexList.reserve(indexList.size());
     for (const auto& index : indexList) {
-        TrackPointer pTrack = m_pTrackModel->getTrack(index);
-        // Checking if passed indexList is valid
-        if (pTrack) {
-            indices.push_back(index);
-        }
+        m_trackIndexList.push_back(index);
     }
-    m_pTrackIndexList = indices;
 
-    if (!m_pTrackIndexList.empty()) {
+    if (!m_trackIndexList.empty()) {
         updateMenus();
     }
 }
@@ -668,7 +662,7 @@ QModelIndexList WTrackMenu::getTrackIndices() const {
     // Indices are associated with a TrackModel. Can only be obtained
     // if a TrackModel is available.
     DEBUG_ASSERT(m_pTrackModel);
-    return m_pTrackIndexList;
+    return m_trackIndexList;
 }
 
 void WTrackMenu::slotOpenInFileBrowser() {
@@ -1187,7 +1181,7 @@ void WTrackMenu::slotPurge() {
 
 void WTrackMenu::clearTrackSelection() {
     m_pTrackPointerList.clear();
-    m_pTrackIndexList.clear();
+    m_trackIndexList.clear();
 }
 
 bool WTrackMenu::featureIsEnabled(Feature flag) const {

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -541,18 +541,8 @@ void WTrackMenu::updateMenus() {
         m_pMetadataMenu->addMenu(m_pCoverMenu);
     }
 
-    if (featureIsEnabled(Feature::Reset)) {
-        bool allowClear = true;
-        for (const auto& pTrack : trackPointers) {
-            if (pTrack->isBpmLocked()) {
-                allowClear = false;
-                break;
-            }
-        }
-        m_pClearBeatsAction->setEnabled(allowClear);
-    }
-
-    if (featureIsEnabled(Feature::BPM)) {
+    if (featureIsEnabled(Feature::Reset) ||
+        featureIsEnabled(Feature::BPM)) {
         bool anyBpmLocked = false;
         if (m_pTrackModel) {
             const int bpmLockedCol =
@@ -573,14 +563,19 @@ void WTrackMenu::updateMenus() {
                 }
             }
         }
-        m_pBpmUnlockAction->setEnabled(anyBpmLocked);
-        m_pBpmLockAction->setEnabled(!anyBpmLocked);
-        m_pBpmDoubleAction->setEnabled(!anyBpmLocked);
-        m_pBpmHalveAction->setEnabled(!anyBpmLocked);
-        m_pBpmTwoThirdsAction->setEnabled(!anyBpmLocked);
-        m_pBpmThreeFourthsAction->setEnabled(!anyBpmLocked);
-        m_pBpmFourThirdsAction->setEnabled(!anyBpmLocked);
-        m_pBpmThreeHalvesAction->setEnabled(!anyBpmLocked);
+        if (featureIsEnabled(Feature::Reset)) {
+            m_pClearBeatsAction->setEnabled(!anyBpmLocked);
+        }
+        if (featureIsEnabled(Feature::BPM)) {
+            m_pBpmUnlockAction->setEnabled(anyBpmLocked);
+            m_pBpmLockAction->setEnabled(!anyBpmLocked);
+            m_pBpmDoubleAction->setEnabled(!anyBpmLocked);
+            m_pBpmHalveAction->setEnabled(!anyBpmLocked);
+            m_pBpmTwoThirdsAction->setEnabled(!anyBpmLocked);
+            m_pBpmThreeFourthsAction->setEnabled(!anyBpmLocked);
+            m_pBpmFourThirdsAction->setEnabled(!anyBpmLocked);
+            m_pBpmThreeHalvesAction->setEnabled(!anyBpmLocked);
+        }
     }
 
     if (featureIsEnabled(Feature::Color)) {

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -445,17 +445,13 @@ std::optional<mixxx::RgbColor> WTrackMenu::getCommonTrackColor() const {
         const int column =
                 m_pTrackModel->fieldIndex(LIBRARYTABLE_COLOR);
         commonColor = mixxx::RgbColor::fromQVariant(
-                m_trackIndexList.first().sibling(
-                                                m_trackIndexList.first().row(), column)
-                        .data());
+                m_trackIndexList.first().sibling(m_trackIndexList.first().row(), column).data());
         if (!commonColor) {
             return std::nullopt;
         }
         for (const auto trackIndex : m_trackIndexList) {
             const auto otherColor = mixxx::RgbColor::fromQVariant(
-                    trackIndex.sibling(
-                                        trackIndex.row(), column)
-                            .data());
+                    trackIndex.sibling(trackIndex.row(), column).data());
             if (commonColor != otherColor) {
                 // Multiple, different colors
                 return std::nullopt;
@@ -603,7 +599,7 @@ void WTrackMenu::updateMenus() {
     }
 
     if (featureIsEnabled(Feature::Reset) ||
-        featureIsEnabled(Feature::BPM)) {
+            featureIsEnabled(Feature::BPM)) {
         const bool anyBpmLocked = isAnyTrackBpmLocked();
         if (featureIsEnabled(Feature::Reset)) {
             m_pClearBeatsAction->setEnabled(!anyBpmLocked);

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1058,29 +1058,31 @@ void WTrackMenu::slotClearAllMetadata() {
 }
 
 void WTrackMenu::slotShowTrackInfo() {
-    const auto trackPointers = getTrackPointers();
-    if (trackPointers.empty()) {
-        return;
-    }
     if (m_pTrackModel) {
-        const auto indices = getTrackIndices();
-        m_pTrackInfo->loadTrack(indices.at(0));
+        if (m_trackIndexList.isEmpty()) {
+            return;
+        }
+        m_pTrackInfo->loadTrack(m_trackIndexList.at(0));
     } else {
-        m_pTrackInfo->loadTrack(trackPointers.at(0));
+        if (m_trackPointerList.isEmpty()) {
+            return;
+        }
+        m_pTrackInfo->loadTrack(m_trackPointerList.at(0));
     }
     m_pTrackInfo->show();
 }
 
 void WTrackMenu::slotShowDlgTagFetcher() {
-    const auto trackPointers = getTrackPointers();
-    if (trackPointers.empty()) {
-        return;
-    }
     if (m_pTrackModel) {
-        const auto indices = getTrackIndices();
-        m_pTagFetcher->loadTrack(indices.at(0));
+        if (m_trackIndexList.isEmpty()) {
+            return;
+        }
+        m_pTagFetcher->loadTrack(m_trackIndexList.at(0));
     } else {
-        m_pTagFetcher->loadTrack(trackPointers.at(0));
+        if (m_trackPointerList.isEmpty()) {
+            return;
+        }
+        m_pTagFetcher->loadTrack(m_trackPointerList.at(0));
     }
     m_pTagFetcher->show();
 }

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -492,12 +492,53 @@ void WTrackMenu::updateMenus() {
     if (featureIsEnabled(Feature::Metadata)) {
         m_pImportMetadataFromMusicBrainzAct->setEnabled(singleTrackSelected);
 
-        // We load a single track to get the necessary context for the cover (we use
-        // last to be consistent with selectionChanged above).
-        TrackPointer pTrack = trackPointers.last();
-
-        m_pCoverMenu->setCoverArt(
-                pTrack->getCoverInfoWithLocation());
+        // We use the last selected track for the cover art context to be
+        // consistent with selectionChanged above.
+        if (m_pTrackModel) {
+            const QModelIndex lastIndex = m_trackIndexList.last();
+            CoverInfo coverInfo;
+            coverInfo.source = static_cast<CoverInfo::Source>(
+                    lastIndex
+                            .sibling(
+                                    lastIndex.row(),
+                                    m_pTrackModel->fieldIndex(LIBRARYTABLE_COVERART_SOURCE))
+                            .data()
+                            .toInt());
+            coverInfo.type = static_cast<CoverInfo::Type>(
+                    lastIndex
+                            .sibling(
+                                    lastIndex.row(),
+                                    m_pTrackModel->fieldIndex(LIBRARYTABLE_COVERART_TYPE))
+                            .data()
+                            .toInt());
+            coverInfo.hash =
+                    lastIndex
+                            .sibling(
+                                    lastIndex.row(),
+                                    m_pTrackModel->fieldIndex(LIBRARYTABLE_COVERART_HASH))
+                            .data()
+                            .toUInt();
+            coverInfo.coverLocation =
+                    lastIndex
+                            .sibling(
+                                    lastIndex.row(),
+                                    m_pTrackModel->fieldIndex(LIBRARYTABLE_COVERART_LOCATION))
+                            .data()
+                            .toString();
+            coverInfo.trackLocation =
+                    lastIndex
+                            .sibling(
+                                    lastIndex.row(),
+                                    m_pTrackModel->fieldIndex(LIBRARYTABLE_LOCATION))
+                            .data()
+                            .toString();
+            m_pCoverMenu->setCoverArt(coverInfo);
+        } else {
+            TrackPointer pTrack = m_trackPointerList.last();
+            m_pCoverMenu->setCoverArt(
+                    pTrack->getCoverInfoWithLocation());
+        }
+        m_pMetadataMenu->addMenu(m_pCoverMenu);
     }
 
     if (featureIsEnabled(Feature::Reset)) {

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -622,7 +622,7 @@ TrackIdList WTrackMenu::getTrackIds() const {
         for (const auto& pTrack : m_trackPointerList) {
             const auto trackId = pTrack->getId();
             DEBUG_ASSERT(trackId.isValid());
-            trackIds.push_back(pTrack->getId());
+            trackIds.push_back(trackId);
         }
     }
     return trackIds;

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -131,7 +131,7 @@ class WTrackMenu : public QMenu {
     // TODO: This function desperately needs to be replaced
     // by an iterator pattern that loads (and drops) tracks
     // lazily one-by-one during the traversal!!
-    TrackPointerList getTrackPointers() const;
+    TrackPointerList getTrackPointers(int maxSize = -1) const;
 
     bool isEmpty() const;
 

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -133,6 +133,8 @@ class WTrackMenu : public QMenu {
     // lazily one-by-one during the traversal!!
     TrackPointerList getTrackPointers() const;
 
+    bool isEmpty() const;
+
     void createMenus();
     void createActions();
     void setupActions();

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -142,12 +142,11 @@ class WTrackMenu : public QMenu {
     void loadSelectionToGroup(QString group, bool play = false);
     void clearTrackSelection();
 
+    TrackModel* m_pTrackModel{};
+    QModelIndexList m_trackIndexList;
+
     // Source of track list when TrackModel is not set.
     TrackPointerList m_pTrackPointerList;
-    // Source of track list when TrackModel is set.
-    QModelIndexList m_pTrackIndexList;
-
-    TrackModel* m_pTrackModel{};
 
     const ControlProxy* m_pNumSamplers{};
     const ControlProxy* m_pNumDecks{};

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -220,6 +220,7 @@ class WTrackMenu : public QMenu {
     QAction* m_pBpmThreeFourthsAction{};
     QAction* m_pBpmFourThirdsAction{};
     QAction* m_pBpmThreeHalvesAction{};
+    QAction* m_pBpmResetAction{};
 
     // Track color
     WColorPickerAction* m_pColorPickerAction{};

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -52,10 +52,15 @@ class WTrackMenu : public QMenu {
             TrackModel* trackModel = nullptr);
     ~WTrackMenu() override;
 
-    void loadTrack(TrackId trackId);
-    void loadTrack(QModelIndex index);
-    void loadTracks(TrackIdList trackList);
-    void loadTracks(QModelIndexList indexList);
+    void loadTrackModelIndex(
+            const QModelIndex& trackIndex) {
+        loadTrackModelIndices(QModelIndexList{trackIndex});
+    }
+    void loadTrackModelIndices(
+            const QModelIndexList& trackIndexList);
+
+    void loadTrack(
+            const TrackPointer& pTrack);
 
     // WARNING: This function hides non-virtual QMenu::popup().
     // This has been done on purpose to ensure menu doesn't popup without loaded track(s).
@@ -117,13 +122,16 @@ class WTrackMenu : public QMenu {
     void slotPurge();
 
   private:
-    // These getters make sure the required lists are
-    // derived from a single source in state, which is the
-    // m_pTrackIndexList if m_pTrackModel is set and
-    // m_pTrackPointerList if m_pTrackModel is not set.
-    TrackIdList getTrackIds() const;
-    TrackPointerList getTrackPointers() const;
+    // This getter verifies that m_pTrackModel is set when
+    // invoked.
     QModelIndexList getTrackIndices() const;
+
+    TrackIdList getTrackIds() const;
+
+    // TODO: This function desperately needs to be replaced
+    // by an iterator pattern that loads (and drops) tracks
+    // lazily one-by-one during the traversal!!
+    TrackPointerList getTrackPointers() const;
 
     void createMenus();
     void createActions();
@@ -146,7 +154,7 @@ class WTrackMenu : public QMenu {
     QModelIndexList m_trackIndexList;
 
     // Source of track list when TrackModel is not set.
-    TrackPointerList m_pTrackPointerList;
+    TrackPointerList m_trackPointerList;
 
     const ControlProxy* m_pNumSamplers{};
     const ControlProxy* m_pNumDecks{};
@@ -229,14 +237,14 @@ class WTrackMenu : public QMenu {
     struct UpdateExternalTrackCollection {
         QPointer<ExternalTrackCollection> externalTrackCollection;
         QAction* action{};
+        };
+        QList<UpdateExternalTrackCollection> m_updateInExternalTrackCollections;
+
+        bool m_bPlaylistMenuLoaded;
+        bool m_bCrateMenuLoaded;
+
+        Features m_eActiveFeatures;
+        const Features m_eTrackModelFeatures;
     };
-    QList<UpdateExternalTrackCollection> m_updateInExternalTrackCollections;
-
-    bool m_bPlaylistMenuLoaded;
-    bool m_bCrateMenuLoaded;
-
-    Features m_eActiveFeatures;
-    const Features m_eTrackModelFeatures;
-};
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(WTrackMenu::Features)

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -133,7 +133,10 @@ class WTrackMenu : public QMenu {
     // lazily one-by-one during the traversal!!
     TrackPointerList getTrackPointers(int maxSize = -1) const;
 
-    bool isEmpty() const;
+    bool isEmpty() const {
+        return getTrackCount() == 0;
+    }
+    int getTrackCount() const;
 
     void createMenus();
     void createActions();

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -155,6 +155,10 @@ class WTrackMenu : public QMenu {
     void loadSelectionToGroup(QString group, bool play = false);
     void clearTrackSelection();
 
+    bool isAnyTrackBpmLocked() const;
+    std::optional<mixxx::RgbColor> getCommonTrackColor() const;
+    CoverInfo getCoverInfoOfLastTrack() const;
+
     TrackModel* m_pTrackModel{};
     QModelIndexList m_trackIndexList;
 

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -93,7 +93,7 @@ void WTrackProperty::dropEvent(QDropEvent *event) {
 
 void WTrackProperty::contextMenuEvent(QContextMenuEvent *event) {
     if (m_pCurrentTrack) {
-        m_pTrackMenu->loadTrack(m_pCurrentTrack->getId());
+        m_pTrackMenu->loadTrack(m_pCurrentTrack);
         // Create the right-click menu
         m_pTrackMenu->popup(event->globalPos());
     }

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -377,7 +377,7 @@ void WTrackTableView::contextMenuEvent(QContextMenuEvent* event) {
     }
     // Update track indices in context menu
     QModelIndexList indices = selectionModel()->selectedRows();
-    m_pTrackMenu->loadTracks(indices);
+    m_pTrackMenu->loadTrackModelIndices(indices);
 
     //Create the right-click menu
     m_pTrackMenu->popup(event->globalPos());

--- a/src/widget/wtracktext.cpp
+++ b/src/widget/wtracktext.cpp
@@ -85,7 +85,7 @@ void WTrackText::dropEvent(QDropEvent *event) {
 
 void WTrackText::contextMenuEvent(QContextMenuEvent* event) {
     if (m_pCurrentTrack) {
-        m_pTrackMenu->loadTrack(m_pCurrentTrack->getId());
+        m_pTrackMenu->loadTrack(m_pCurrentTrack);
         // Create the right-click menu
         m_pTrackMenu->popup(event->globalPos());
     }


### PR DESCRIPTION
@Be-ing @hacksdump 

As promised another round of optimizations for #2612. This one fixes some more regressions and also an indexing bug in a loop in updateMenu() that only considered the first element.

We need to optimize updateMenu() that still is very inefficient and able to freeze the UI longer than acceptable. This was already an open issue before extracting the WTrackMenu class.

The major regression and pain point caused by getTrackPointers() is still unresolved, I added comments. A *proof-of-concept* for handling those long running actions is ready for testing. Next time ;)