### PR TITLE
ColorMapperJSProxy: remove hack for using strings as keys

### DIFF
--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -1017,22 +1017,22 @@ DJ505.PadColor = {
 };
 
 DJ505.PadColorMap = new ColorMapper({
-    "#CC0000": DJ505.PadColor.RED,
-    "#CC4400": DJ505.PadColor.CORAL,
-    "#CC8800": DJ505.PadColor.ORANGE,
-    "#CCCC00": DJ505.PadColor.YELLOW,
-    "#88CC00": DJ505.PadColor.GREEN,
-    "#00CC00": DJ505.PadColor.APPLEGREEN,
-    "#00CC88": DJ505.PadColor.AQUAMARINE,
-    "#00CCCC": DJ505.PadColor.TURQUOISE,
-    "#0088CC": DJ505.PadColor.CELESTE,
-    "#0000CC": DJ505.PadColor.BLUE,
-    "#4400CC": DJ505.PadColor.AZURE,
-    "#8800CC": DJ505.PadColor.PURPLE,
-    "#CC00CC": DJ505.PadColor.MAGENTA,
-    "#CC0044": DJ505.PadColor.RED,
-    "#FFCCCC": DJ505.PadColor.APRICOT,
-    "#FFFFFF": DJ505.PadColor.WHITE,
+    0xCC0000: DJ505.PadColor.RED,
+    0xCC4400: DJ505.PadColor.CORAL,
+    0xCC8800: DJ505.PadColor.ORANGE,
+    0xCCCC00: DJ505.PadColor.YELLOW,
+    0x88CC00: DJ505.PadColor.GREEN,
+    0x00CC00: DJ505.PadColor.APPLEGREEN,
+    0x00CC88: DJ505.PadColor.AQUAMARINE,
+    0x00CCCC: DJ505.PadColor.TURQUOISE,
+    0x0088CC: DJ505.PadColor.CELESTE,
+    0x0000CC: DJ505.PadColor.BLUE,
+    0x4400CC: DJ505.PadColor.AZURE,
+    0x8800CC: DJ505.PadColor.PURPLE,
+    0xCC00CC: DJ505.PadColor.MAGENTA,
+    0xCC0044: DJ505.PadColor.RED,
+    0xFFCCCC: DJ505.PadColor.APRICOT,
+    0xFFFFFF: DJ505.PadColor.WHITE,
 });
 
 DJ505.PadSection = function(deck, offset) {

--- a/src/controllers/colormapperjsproxy.cpp
+++ b/src/controllers/colormapperjsproxy.cpp
@@ -38,8 +38,9 @@ QScriptValue ColorMapperJSProxyConstructor(QScriptContext* pScriptContext, QScri
     QScriptValueIterator it(argument);
     while (it.hasNext()) {
         it.next();
-        QColor color(it.name());
-        if (color.isValid()) {
+        bool isInt = false;
+        QColor color(it.name().toInt(&isInt));
+        if (isInt && color.isValid()) {
             availableColors.insert(color.rgb(), it.value().toVariant());
         } else {
             pScriptContext->throwError(

--- a/src/test/colormapperjsproxy_test.cpp
+++ b/src/test/colormapperjsproxy_test.cpp
@@ -25,9 +25,9 @@ TEST_F(ColorMapperJSProxyTest, Instantiation) {
     pEngine->evaluate(
             R"JavaScript(
             var mapper = new ColorMapper({
-                '#FF0000': 1,
-                '#00FF00': 2,
-                '#0000FF': 3,
+                0xFF0000: 1,
+                0x00FF00: 2,
+                0x0000FF: 3,
             });
             )JavaScript");
     EXPECT_FALSE(pEngine->hasUncaughtException());
@@ -64,14 +64,14 @@ TEST_F(ColorMapperJSProxyTest, GetNearestColor) {
     pEngine->evaluate(
             R"JavaScript(
             var mapper = new ColorMapper({
-                '#C50A08': 1,
-                '#32BE44': 2,
-                '#42D4F4': 3,
-                '#F8D200': 4,
-                '#0044FF': 5,
-                '#AF00CC': 6,
-                '#FCA6D7': 7,
-                '#F2F2FF': 8,
+                0xC50A08: 1,
+                0x32BE44: 2,
+                0x42D4F4: 3,
+                0xF8D200: 4,
+                0x0044FF: 5,
+                0xAF00CC: 6,
+                0xFCA6D7: 7,
+                0xF2F2FF: 8,
             });
             /* white */
             var color1 = mapper.getNearestColor(0xFFFFFF);
@@ -102,14 +102,14 @@ TEST_F(ColorMapperJSProxyTest, GetNearestValue) {
     pEngine->evaluate(
             R"JavaScript(
             var mapper = new ColorMapper({
-                '#C50A08': 1,
-                '#32BE44': 2,
-                '#42D4F4': 3,
-                '#F8D200': 4,
-                '#0044FF': 5,
-                '#AF00CC': 6,
-                '#FCA6D7': 7,
-                '#F2F2FF': 8,
+                0xC50A08: 1,
+                0x32BE44: 2,
+                0x42D4F4: 3,
+                0xF8D200: 4,
+                0x0044FF: 5,
+                0xAF00CC: 6,
+                0xFCA6D7: 7,
+                0xF2F2FF: 8,
             });
             /* red */
             if (mapper.getValueForNearestColor(0xFF0000) != 1) {


### PR DESCRIPTION
Keys must be JS numbers. If we don't release this hack in 2.3, we won't have to maintain it for 2.4: https://github.com/mixxxdj/mixxx/pull/2682#discussion_r410805698