### PR TITLE
fix skin change bug on linux

### DIFF
--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -1462,7 +1462,13 @@ void MixxxMainWindow::rebootMixxxView() {
     }
 
     setCentralWidget(m_pWidgetParent);
+#ifdef __LINUX__
+    // don't adjustSize() on Linux as this wouldn't use the entire available area
+    // to paint the new skin with X11
+    // https://bugs.launchpad.net/mixxx/+bug/1773587
+#else
     adjustSize();
+#endif
 
     if (wasFullScreen) {
         slotViewFullScreen(true);


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1773587
QT5: changing skins the old skin remains in background

fixes the skin change/reload issue entirely for me on Ubuntu with X11.
Change restricted to Linux as it is working fine on Win & Mac.
https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/window.20minimizes.20on.20skin.20change