### PR TITLE
AnalyzerBeats: fix analyzer not using max/min BPM values

### DIFF
--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -55,13 +55,8 @@ bool AnalyzerBeats::initialize(TrackPointer tio, int sampleRate, int totalSample
         return false;
     }
 
-    if (m_bpmSettings.getAllowBpmAboveRange()) {
-        m_iMinBpm = 0;
-        m_iMaxBpm = 9999;
-    } else {
-        m_iMinBpm = m_bpmSettings.getBpmRangeStart();
-        m_iMaxBpm = m_bpmSettings.getBpmRangeEnd();
-    }
+    m_iMinBpm = m_bpmSettings.getBpmRangeStart();
+    m_iMaxBpm = m_bpmSettings.getBpmRangeEnd();
 
     m_bPreferencesFixedTempo = m_bpmSettings.getFixedTempoAssumption();
     m_bPreferencesOffsetCorrection = m_bpmSettings.getFixedTempoOffsetCorrection();
@@ -131,15 +126,8 @@ bool AnalyzerBeats::initialize(TrackPointer tio, int sampleRate, int totalSample
 }
 
 bool AnalyzerBeats::shouldAnalyze(TrackPointer tio) const {
-    int iMinBpm;
-    int iMaxBpm;
-    if (m_bpmSettings.getAllowBpmAboveRange()) {
-        iMinBpm = 0;
-        iMaxBpm = 9999;
-    } else {
-        iMinBpm = m_bpmSettings.getBpmRangeStart();
-        iMaxBpm = m_bpmSettings.getBpmRangeEnd();
-    }
+    int iMinBpm = m_bpmSettings.getBpmRangeStart();
+    int iMaxBpm = m_bpmSettings.getBpmRangeEnd();
 
     bool bpmLock = tio->isBpmLocked();
     if (bpmLock) {

--- a/src/preferences/beatdetectionsettings.h
+++ b/src/preferences/beatdetectionsettings.h
@@ -21,7 +21,6 @@
 
 #define BPM_RANGE_START "BPMRangeStart"
 #define BPM_RANGE_END "BPMRangeEnd"
-#define BPM_ABOVE_RANGE_ENABLED "BPMAboveRangeEnabled"
 
 class BeatDetectionSettings {
   public:
@@ -29,9 +28,6 @@ class BeatDetectionSettings {
 
     DEFINE_PREFERENCE_HELPERS(BpmDetectionEnabled, bool,
                               BPM_CONFIG_KEY, BPM_DETECTION_ENABLED, true);
-
-    DEFINE_PREFERENCE_HELPERS(AllowBpmAboveRange, bool,
-                              BPM_CONFIG_KEY, BPM_ABOVE_RANGE_ENABLED, true);
 
     DEFINE_PREFERENCE_HELPERS(BpmRangeStart, int, BPM_CONFIG_KEY, BPM_RANGE_START, 70);
 


### PR DESCRIPTION
I think this was a regression when removing VAMP plugins in
PR #926. The AllowBpmAboveRange setting is not exposed in the
preferences window and I never recall it being shown to the user,
nor anyone asking for it, so remove it.