### PR TITLE
BeatDetectionSettings: change minimum BPM to 60

### DIFF
--- a/src/preferences/beatdetectionsettings.h
+++ b/src/preferences/beatdetectionsettings.h
@@ -29,7 +29,7 @@ class BeatDetectionSettings {
     DEFINE_PREFERENCE_HELPERS(BpmDetectionEnabled, bool,
                               BPM_CONFIG_KEY, BPM_DETECTION_ENABLED, true);
 
-    DEFINE_PREFERENCE_HELPERS(BpmRangeStart, int, BPM_CONFIG_KEY, BPM_RANGE_START, 70);
+    DEFINE_PREFERENCE_HELPERS(BpmRangeStart, int, BPM_CONFIG_KEY, BPM_RANGE_START, 60);
 
     DEFINE_PREFERENCE_HELPERS(BpmRangeEnd, int, BPM_CONFIG_KEY, BPM_RANGE_END, 140);
 


### PR DESCRIPTION
I have a few tracks that are really between 60-69.9 BPM, but I have none that are actually below 60.

This requires #2692 to work.