### PR TITLE
WTrackTableView: bring back load track overrides

### DIFF
--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -736,6 +736,37 @@ void WTrackTableView::keyPressEvent(QKeyEvent* event) {
     }
 }
 
+void WTrackTableView::loadSelectedTrack() {
+    auto indices = selectionModel()->selectedRows();
+    if (indices.size() > 0) {
+        slotMouseDoubleClicked(indices.at(0));
+    }
+}
+
+void WTrackTableView::loadSelectedTrackToGroup(QString group, bool play) {
+    auto indices = selectionModel()->selectedRows();
+    if (indices.size() > 0) {
+        // If the track load override is disabled, check to see if a track is
+        // playing before trying to load it
+        if (!(m_pConfig->getValueString(
+                               ConfigKey("[Controls]", "AllowTrackLoadToPlayingDeck"))
+                            .toInt())) {
+            // TODO(XXX): Check for other than just the first preview deck.
+            if (group != "[PreviewDeck1]" &&
+                    ControlObject::get(ConfigKey(group, "play")) > 0.0) {
+                return;
+            }
+        }
+        auto index = indices.at(0);
+        auto trackModel = getTrackModel();
+        TrackPointer pTrack;
+        if (trackModel &&
+                (pTrack = trackModel->getTrack(index))) {
+            emit loadTrackToPlayer(pTrack, group, play);
+        }
+    }
+}
+
 QList<TrackId> WTrackTableView::getSelectedTrackIds() const {
     QList<TrackId> trackIds;
 

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -38,6 +38,8 @@ class WTrackTableView : public WLibraryTableView {
     void onShow() override;
     bool hasFocus() const override;
     void keyPressEvent(QKeyEvent* event) override;
+    void loadSelectedTrack() override;
+    void loadSelectedTrackToGroup(QString group, bool play = false) override;
     void assignNextTrackColor() override;
     void assignPreviousTrackColor() override;
     QList<TrackId> getSelectedTrackIds() const;

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -39,7 +39,7 @@ class WTrackTableView : public WLibraryTableView {
     bool hasFocus() const override;
     void keyPressEvent(QKeyEvent* event) override;
     void loadSelectedTrack() override;
-    void loadSelectedTrackToGroup(QString group, bool play = false) override;
+    void loadSelectedTrackToGroup(QString group, bool play) override;
     void assignNextTrackColor() override;
     void assignPreviousTrackColor() override;
     QList<TrackId> getSelectedTrackIds() const;


### PR DESCRIPTION
Fixes [1873938](https://bugs.launchpad.net/mixxx/+bug/1873938) by adding back `loadSelectedTrack` and `loadSelectedTrackToGroup` function overrides which were factored out to `WTrackMenu` with #2612 