### PR TITLE
preferences/dialog/dlgprefdeck: Tick "Down increases Speed" by default

### DIFF
--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -206,9 +206,9 @@ DlgPrefDeck::DlgPrefDeck(QWidget * parent, MixxxMainWindow * mixxx,
             this,
             SLOT(slotCloneDeckOnLoadDoubleTapCheckbox(bool)));
 
-    m_bRateInverted = m_pConfig->getValue(ConfigKey("[Controls]", "RateDir"), false);
-    setRateDirectionForAllDecks(m_bRateInverted);
-    checkBoxInvertSpeedSlider->setChecked(m_bRateInverted);
+    m_bRateDownIncreasesSpeed = m_pConfig->getValue(ConfigKey("[Controls]", "RateDir"), true);
+    setRateDirectionForAllDecks(m_bRateDownIncreasesSpeed);
+    checkBoxInvertSpeedSlider->setChecked(m_bRateDownIncreasesSpeed);
     connect(checkBoxInvertSpeedSlider, SIGNAL(toggled(bool)),
             this, SLOT(slotRateInversionCheckbox(bool)));
 
@@ -490,7 +490,7 @@ void DlgPrefDeck::setRateRangeForAllDecks(int rangePercent) {
 }
 
 void DlgPrefDeck::slotRateInversionCheckbox(bool inverted) {
-    m_bRateInverted = inverted;
+    m_bRateDownIncreasesSpeed = inverted;
 }
 
 void DlgPrefDeck::setRateDirectionForAllDecks(bool inverted) {
@@ -633,9 +633,9 @@ void DlgPrefDeck::slotApply() {
     m_pConfig->setValue(ConfigKey("[Controls]", "RateRangePercent"),
                         m_iRateRangePercent);
 
-    setRateDirectionForAllDecks(m_bRateInverted);
+    setRateDirectionForAllDecks(m_bRateDownIncreasesSpeed);
     m_pConfig->setValue(ConfigKey("[Controls]", "RateDir"),
-                        static_cast<int>(m_bRateInverted));
+            static_cast<int>(m_bRateDownIncreasesSpeed));
 
     int configSPAutoReset = BaseTrackPlayer::RESET_NONE;
 

--- a/src/preferences/dialog/dlgprefdeck.h
+++ b/src/preferences/dialog/dlgprefdeck.h
@@ -128,7 +128,7 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
     bool m_bAssignHotcueColors;
 
     int m_iRateRangePercent;
-    bool m_bRateInverted;
+    bool m_bRateDownIncreasesSpeed;
 
     bool m_speedAutoReset;
     bool m_pitchAutoReset;


### PR DESCRIPTION
With this change, Mixxx is now consistent with almost every other DJ
application or hardware out there.

This also renames the internal variable, be "inverted" depends on your
perspective - is "Down increases speed" inverted because "low fader" =
"low speed"? Or is "Up increases speed" inverted because it's the
opposite of what the rest of the DJ world does?
The new name should be less ambiguous.

Zulip Discussion:
https://mixxx.zulipchat.com/#narrow/stream/109122-general/topic/Tempo.20Slider.20default.20behavior