### PR TITLE
Fix import of Serato cue points during library scan

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -51,7 +51,7 @@ void markTrackLocationsAsDeleted(QSqlDatabase database, const QString& directory
                   "SET fs_deleted=1 "
                   "WHERE directory=:directory");
     query.bindValue(":directory", directory);
-    if (!query.exec()) {
+    VERIFY_OR_DEBUG_ASSERT(query.exec()) {
         LOG_FAILED_QUERY(query)
                 << "Couldn't mark tracks in" << directory << "as deleted.";
     }
@@ -121,7 +121,7 @@ TrackId TrackDAO::getTrackIdByLocation(const QString& location) const {
             "INNER JOIN track_locations ON library.location = track_locations.id "
             "WHERE track_locations.location=:location");
     query.bindValue(":location", location);
-    if (!query.exec()) {
+    VERIFY_OR_DEBUG_ASSERT(query.exec()) {
         LOG_FAILED_QUERY(query);
         return TrackId();
     }
@@ -145,7 +145,7 @@ QList<TrackId> TrackDAO::resolveTrackIds(
     query.prepare(
             "CREATE TEMP TABLE playlist_import "
             "(location varchar (512))");
-    if (!query.exec()) {
+    VERIFY_OR_DEBUG_ASSERT(query.exec()) {
         LOG_FAILED_QUERY(query);
         return trackIds;
     }
@@ -160,7 +160,7 @@ QList<TrackId> TrackDAO::resolveTrackIds(
     query.prepare(
             "INSERT INTO playlist_import (location) "
             "VALUES " + pathList.join(','));
-    if (!query.exec()) {
+    VERIFY_OR_DEBUG_ASSERT(query.exec()) {
         LOG_FAILED_QUERY(query);
     }
 
@@ -173,7 +173,7 @@ QList<TrackId> TrackDAO::resolveTrackIds(
         query.prepare("SELECT location FROM playlist_import "
                 "WHERE NOT EXISTS (SELECT location FROM track_locations "
                 "WHERE playlist_import.location = track_locations.location)");
-        if (!query.exec()) {
+        VERIFY_OR_DEBUG_ASSERT(query.exec()) {
             LOG_FAILED_QUERY(query);
         }
         const int locationColumn = query.record().indexOf("location");
@@ -220,7 +220,7 @@ QList<TrackId> TrackDAO::resolveTrackIds(
 
     // Drop the temporary playlist-import table.
     query.prepare("DROP TABLE IF EXISTS playlist_import");
-    if (!query.exec()) {
+    VERIFY_OR_DEBUG_ASSERT(query.exec()) {
         LOG_FAILED_QUERY(query);
     }
 
@@ -232,7 +232,7 @@ QSet<QString> TrackDAO::getAllTrackLocations() const {
     QSqlQuery query(m_database);
     query.prepare("SELECT track_locations.location FROM track_locations "
                   "INNER JOIN library on library.location = track_locations.id");
-    if (!query.exec()) {
+    VERIFY_OR_DEBUG_ASSERT(query.exec()) {
         LOG_FAILED_QUERY(query);
     }
 
@@ -254,7 +254,7 @@ QString TrackDAO::getTrackLocation(TrackId trackId) const {
                   "INNER JOIN library ON library.location = track_locations.id "
                   "WHERE library.id=:id");
     query.bindValue(":id", trackId.toVariant());
-    if (!query.exec()) {
+    VERIFY_OR_DEBUG_ASSERT(query.exec()) {
         LOG_FAILED_QUERY(query);
         return "";
     }
@@ -785,7 +785,7 @@ QList<TrackRef> TrackDAO::getAllTrackRefs(const QDir& rootDir) const {
                           "WHERE track_locations.location LIKE %1 ESCAPE '%2'")
                   .arg(SqlStringFormatter::format(m_database, likeClause), kSqlLikeMatchAll));
 
-    if (!query.exec()) {
+    VERIFY_OR_DEBUG_ASSERT(query.exec()) {
         LOG_FAILED_QUERY(query) << "could not get tracks within directory:" << dirPath;
     }
 
@@ -1213,7 +1213,7 @@ TrackPointer TrackDAO::getTrackById(TrackId trackId) const {
             "INNER JOIN track_locations ON library.location = track_locations.id "
             "WHERE library.id = %2").arg(columnsStr, trackId.toString()));
 
-    if (!query.exec()) {
+    VERIFY_OR_DEBUG_ASSERT(query.exec()) {
         LOG_FAILED_QUERY(query)
                 << QString("getTrack(%1)").arg(trackId.toString());
         return TrackPointer();
@@ -1425,7 +1425,7 @@ bool TrackDAO::updateTrack(Track* pTrack) const {
     query.bindValue(":track_id", trackId.toVariant());
     bindTrackLibraryValues(&query, *pTrack);
 
-    if (!query.exec()) {
+    VERIFY_OR_DEBUG_ASSERT(query.exec()) {
         LOG_FAILED_QUERY(query);
         return false;
     }
@@ -1461,7 +1461,7 @@ void TrackDAO::invalidateTrackLocationsInLibrary() const {
 
     QSqlQuery query(m_database);
     query.prepare("UPDATE track_locations SET needs_verification = 1");
-    if (!query.exec()) {
+    VERIFY_OR_DEBUG_ASSERT(query.exec()) {
         LOG_FAILED_QUERY(query)
                 << "Couldn't mark tracks in library as needing verification.";
     }
@@ -1475,7 +1475,7 @@ void TrackDAO::markTrackLocationsAsVerified(const QStringList& locations) const 
                           "SET needs_verification=0, fs_deleted=0 "
                           "WHERE location IN (%1)").arg(
                                   SqlStringFormatter::formatList(m_database, locations)));
-    if (!query.exec()) {
+    VERIFY_OR_DEBUG_ASSERT(query.exec()) {
         LOG_FAILED_QUERY(query)
                 << "Couldn't mark track locations as verified.";
     }
@@ -1490,7 +1490,7 @@ void TrackDAO::markTracksInDirectoriesAsVerified(const QStringList& directories)
                 "SET needs_verification=0 "
                 "WHERE directory IN (%1)").arg(
                         SqlStringFormatter::formatList(m_database, directories)));
-    if (!query.exec()) {
+    VERIFY_OR_DEBUG_ASSERT(query.exec()) {
         LOG_FAILED_QUERY(query)
                 << "Couldn't mark tracks in" << directories.size() << "directories as verified.";
     }
@@ -1503,7 +1503,7 @@ void TrackDAO::markUnverifiedTracksAsDeleted() {
                   "track_locations.id=library.location WHERE "
                   "track_locations.needs_verification=1");
     QSet<TrackId> trackIds;
-    if (!query.exec()) {
+    VERIFY_OR_DEBUG_ASSERT(query.exec()) {
         LOG_FAILED_QUERY(query) << "Couldn't find unverified tracks";
     }
     while (query.next()) {
@@ -1513,7 +1513,7 @@ void TrackDAO::markUnverifiedTracksAsDeleted() {
     query.prepare("UPDATE track_locations "
                   "SET fs_deleted=1, needs_verification=0 "
                   "WHERE needs_verification=1");
-    if (!query.exec()) {
+    VERIFY_OR_DEBUG_ASSERT(query.exec()) {
         LOG_FAILED_QUERY(query)
                 << "Couldn't mark unverified tracks as deleted.";
     }
@@ -1728,7 +1728,7 @@ void TrackDAO::hideAllTracks(const QDir& rootDir) const {
                           "WHERE track_locations.location LIKE %1 ESCAPE '%2'")
                   .arg(SqlStringFormatter::format(m_database, likeClause), kSqlLikeMatchAll));
 
-    if (!query.exec()) {
+    VERIFY_OR_DEBUG_ASSERT(query.exec()) {
         LOG_FAILED_QUERY(query) << "could not get tracks within directory:" << rootDir;
     }
 
@@ -1740,7 +1740,7 @@ void TrackDAO::hideAllTracks(const QDir& rootDir) const {
 
     query.prepare(QString("UPDATE library SET mixxx_deleted=1 "
                           "WHERE id in (%1)").arg(trackIds.join(",")));
-    if (!query.exec()) {
+    VERIFY_OR_DEBUG_ASSERT(query.exec()) {
         LOG_FAILED_QUERY(query);
     }
 }
@@ -1761,7 +1761,7 @@ bool TrackDAO::verifyRemainingTracks(
     query.prepare("SELECT location "
                   "FROM track_locations "
                   "WHERE needs_verification = 1");
-    if (!query.exec()) {
+    VERIFY_OR_DEBUG_ASSERT(query.exec()) {
         LOG_FAILED_QUERY(query);
         return false;
     }
@@ -1837,7 +1837,7 @@ void TrackDAO::detectCoverArtForTracksWithoutCover(volatile const bool* pCancel,
 
     QVector<TrackWithoutCover> tracksWithoutCover;
 
-    if (!query.exec()) {
+    VERIFY_OR_DEBUG_ASSERT(query.exec()) {
         LOG_FAILED_QUERY(query)
                 << "failed looking for tracks with unknown cover art";
         return;

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -537,6 +537,7 @@ void LibraryScanner::slotAddNewTrack(const QString& trackPath) {
     // For statistics tracking and to detect moved tracks
     TrackPointer pTrack(m_trackDao.addTracksAddFile(trackPath, false));
     if (pTrack) {
+        DEBUG_ASSERT(!pTrack->isDirty());
         // The track's actual location might differ from the
         // given trackPath
         const QString trackLocation(pTrack->getLocation());

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -299,7 +299,7 @@ void SoundSourceProxy::initSoundSource() {
 }
 
 void SoundSourceProxy::updateTrackFromSource(
-        ImportTrackMetadataMode importTrackMetadataMode) const {
+        ImportTrackMetadataMode importTrackMetadataMode) {
     DEBUG_ASSERT(m_pTrack);
 
     if (getUrl().isEmpty()) {
@@ -434,6 +434,14 @@ void SoundSourceProxy::updateTrackFromSource(
             }
         }
         m_pTrack->importMetadata(trackMetadata, metadataImported.second);
+        if (m_pTrack->getCueImportStatus() == Track::CueImportStatus::Pending) {
+            // Try to open the audio source once to determine the actual
+            // stream properties for finishing the pending import.
+            const auto pAudioSource = openAudioSource();
+            Q_UNUSED(pAudioSource); // only used in debug assertion
+            DEBUG_ASSERT(!pAudioSource ||
+                    m_pTrack->getCueImportStatus() == Track::CueImportStatus::Complete);
+        }
     }
 
     if (pCoverImg) {

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -437,6 +437,8 @@ void SoundSourceProxy::updateTrackFromSource(
         if (m_pTrack->getCueImportStatus() == Track::CueImportStatus::Pending) {
             // Try to open the audio source once to determine the actual
             // stream properties for finishing the pending import.
+            kLogger.debug()
+                    << "Opening audio source to finish import of cue points";
             const auto pAudioSource = openAudioSource();
             Q_UNUSED(pAudioSource); // only used in debug assertion
             DEBUG_ASSERT(!pAudioSource ||

--- a/src/sources/soundsourceproxy.h
+++ b/src/sources/soundsourceproxy.h
@@ -88,11 +88,12 @@ class SoundSourceProxy {
     // properly. The application log will contain warning messages for a detailed
     // analysis in case unexpected behavior has been reported.
     void updateTrackFromSource(
-            ImportTrackMetadataMode importTrackMetadataMode = ImportTrackMetadataMode::Default) const;
+            ImportTrackMetadataMode importTrackMetadataMode = ImportTrackMetadataMode::Default);
 
     // Parse only the metadata from the file without modifying
     // the referenced track.
-    mixxx::MetadataSource::ImportResult importTrackMetadata(mixxx::TrackMetadata* pTrackMetadata) const;
+    mixxx::MetadataSource::ImportResult importTrackMetadata(
+            mixxx::TrackMetadata* pTrackMetadata) const;
 
     // Opening the audio source through the proxy will update the
     // audio properties of the corresponding track object. Returns

--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -123,13 +123,13 @@ int Cue::getId() const {
 
 void Cue::setId(int cueId) {
     QMutexLocker lock(&m_mutex);
-    if (m_iId == cueId) {
-        return;
-    }
     m_iId = cueId;
-    m_bDirty = true;
-    lock.unlock();
-    emit updated();
+    // Neither mark as dirty nor do emit the updated() signal.
+    // This function is only called after adding the Cue object
+    // to the database. The id is not visible for anyone else.
+    // Unintended side effects with the LibraryScanner occur
+    // when adding new tracks that have their cue points stored
+    // in Serato marker tags!!
 }
 
 TrackId Cue::getTrackId() const {
@@ -143,9 +143,13 @@ void Cue::setTrackId(TrackId trackId) {
         return;
     }
     m_trackId = trackId;
+    // Mark as dirty, but DO NOT emit the updated() signal.
+    // The receiver is the corresponding Track object that
+    // would in turn be marked as dirty. This could cause
+    // unintended side effects with the LibraryScanner when
+    // adding new tracks that have their cue points stored
+    // in Serato marker tags!!
     m_bDirty = true;
-    lock.unlock();
-    emit updated();
 }
 
 mixxx::CueType Cue::getType() const {

--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -123,6 +123,9 @@ int Cue::getId() const {
 
 void Cue::setId(int cueId) {
     QMutexLocker lock(&m_mutex);
+    if (m_iId == cueId) {
+        return;
+    }
     m_iId = cueId;
     m_bDirty = true;
     lock.unlock();
@@ -136,6 +139,9 @@ TrackId Cue::getTrackId() const {
 
 void Cue::setTrackId(TrackId trackId) {
     QMutexLocker lock(&m_mutex);
+    if (m_trackId == trackId) {
+        return;
+    }
     m_trackId = trackId;
     m_bDirty = true;
     lock.unlock();
@@ -149,6 +155,9 @@ mixxx::CueType Cue::getType() const {
 
 void Cue::setType(mixxx::CueType type) {
     QMutexLocker lock(&m_mutex);
+    if (m_type == type) {
+        return;
+    }
     m_type = type;
     m_bDirty = true;
     lock.unlock();
@@ -162,6 +171,9 @@ double Cue::getPosition() const {
 
 void Cue::setStartPosition(double samplePosition) {
     QMutexLocker lock(&m_mutex);
+    if (m_sampleStartPosition == samplePosition) {
+        return;
+    }
     m_sampleStartPosition = samplePosition;
     m_bDirty = true;
     lock.unlock();
@@ -170,6 +182,9 @@ void Cue::setStartPosition(double samplePosition) {
 
 void Cue::setEndPosition(double samplePosition) {
     QMutexLocker lock(&m_mutex);
+    if (m_sampleEndPosition == samplePosition) {
+        return;
+    }
     m_sampleEndPosition = samplePosition;
     m_bDirty = true;
     lock.unlock();
@@ -195,6 +210,9 @@ int Cue::getHotCue() const {
 void Cue::setHotCue(int hotCue) {
     QMutexLocker lock(&m_mutex);
     // TODO(XXX) enforce uniqueness?
+    if (m_iHotCue == hotCue) {
+        return;
+    }
     m_iHotCue = hotCue;
     m_bDirty = true;
     lock.unlock();
@@ -208,6 +226,9 @@ QString Cue::getLabel() const {
 
 void Cue::setLabel(const QString label) {
     QMutexLocker lock(&m_mutex);
+    if (m_label == label) {
+        return;
+    }
     m_label = label;
     m_bDirty = true;
     lock.unlock();
@@ -221,6 +242,9 @@ mixxx::RgbColor Cue::getColor() const {
 
 void Cue::setColor(mixxx::RgbColor color) {
     QMutexLocker lock(&m_mutex);
+    if (m_color == color) {
+        return;
+    }
     m_color = color;
     m_bDirty = true;
     lock.unlock();

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -713,18 +713,20 @@ void Track::setCuePoint(CuePosition cue) {
     CuePointer pLoadCue = findCueByType(mixxx::CueType::MainCue);
     double position = cue.getPosition();
     if (position != -1.0) {
-        if (!pLoadCue) {
+        if (pLoadCue) {
+            pLoadCue->setStartPosition(position);
+        } else {
             pLoadCue = CuePointer(new Cue());
             pLoadCue->moveToThread(thread());
             pLoadCue->setTrackId(m_record.getId());
             pLoadCue->setType(mixxx::CueType::MainCue);
+            pLoadCue->setStartPosition(position);
             connect(pLoadCue.get(),
                     &Cue::updated,
                     this,
                     &Track::slotCueUpdated);
             m_cuePoints.push_back(pLoadCue);
         }
-        pLoadCue->setStartPosition(position);
     } else if (pLoadCue) {
         disconnect(pLoadCue.get(), 0, this, 0);
         m_cuePoints.removeOne(pLoadCue);
@@ -753,7 +755,10 @@ CuePointer Track::createAndAddCue() {
     CuePointer pCue(new Cue());
     pCue->moveToThread(thread());
     pCue->setTrackId(m_record.getId());
-    connect(pCue.get(), &Cue::updated, this, &Track::slotCueUpdated);
+    connect(pCue.get(),
+            &Cue::updated,
+            this,
+            &Track::slotCueUpdated);
     m_cuePoints.push_back(pCue);
     markDirtyAndUnlock(&lock);
     emit cuesUpdated();

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -717,6 +717,9 @@ void Track::setCuePoint(CuePosition cue) {
             pLoadCue->setStartPosition(position);
         } else {
             pLoadCue = CuePointer(new Cue());
+            // While this method could be called from any thread,
+            // associated Cue objects should always live on the
+            // same thread as their host, namely this->thread().
             pLoadCue->moveToThread(thread());
             pLoadCue->setTrackId(m_record.getId());
             pLoadCue->setType(mixxx::CueType::MainCue);
@@ -753,6 +756,9 @@ void Track::slotCueUpdated() {
 CuePointer Track::createAndAddCue() {
     QMutexLocker lock(&m_qMutex);
     CuePointer pCue(new Cue());
+    // While this method could be called from any thread,
+    // associated Cue objects should always live on the
+    // same thread as their host, namely this->thread().
     pCue->moveToThread(thread());
     pCue->setTrackId(m_record.getId());
     connect(pCue.get(),
@@ -833,7 +839,9 @@ QList<CuePointer> Track::getCuePoints() const {
 }
 
 void Track::setCuePoints(const QList<CuePointer>& cuePoints) {
-    //qDebug() << "setCuePoints" << cuePoints.length();
+    // While this method could be called from any thread,
+    // associated Cue objects should always live on the
+    // same thread as their host, namely this->thread().
     for (const auto& pCue : cuePoints) {
         pCue->moveToThread(thread());
     }
@@ -942,6 +950,9 @@ void Track::importPendingCueInfosMarkDirtyAndUnlock(
     cuePoints.reserve(m_importCueInfosPending.size());
     for (const auto& cueInfo : m_importCueInfosPending) {
         CuePointer pCue(new Cue(cueInfo, sampleRate));
+        // While this method could be called from any thread,
+        // associated Cue objects should always live on the
+        // same thread as their host, namely this->thread().
         pCue->moveToThread(thread());
         pCue->setTrackId(trackId);
         cuePoints.append(pCue);

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -257,7 +257,19 @@ class Track : public QObject {
     QList<CuePointer> getCuePoints() const;
 
     void setCuePoints(const QList<CuePointer>& cuePoints);
-    void importCueInfos(const QList<mixxx::CueInfo>& cueInfos);
+
+    enum class CueImportStatus {
+        Pending,
+        Complete,
+    };
+    /// Imports the given list of cue infos as cue points,
+    /// thereby replacing all existing cue points!
+    ///
+    /// If the list is empty it tries to complete any pending
+    /// import and returns the corresponding status.
+    CueImportStatus importCueInfos(
+            const QList<mixxx::CueInfo>& cueInfos = {});
+    CueImportStatus getCueImportStatus() const;
 
     bool isDirty();
 
@@ -369,9 +381,8 @@ class Track : public QObject {
     void setCuePointsMarkDirtyAndUnlock(
             QMutexLocker* pLock,
             const QList<CuePointer>& cuePoints);
-    void importCueInfosMarkDirtyAndUnlock(
-            QMutexLocker* pLock,
-            const QList<mixxx::CueInfo>& cueInfos);
+    void importPendingCueInfosMarkDirtyAndUnlock(
+            QMutexLocker* pLock);
 
     enum class DurationRounding {
         SECONDS, // rounded to full seconds


### PR DESCRIPTION
Bug reported and discussed on [Zulip](https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/Serato.20cue.20import/near/194995158).

If the import of cue infos is pending after importing metadata then we have to open the audio stream once for determining the actual sample rate.