### PR TITLE
fixed abrupt transition when fade button clicked

### DIFF
--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -278,9 +278,12 @@ void AutoDJProcessor::fadeNow() {
         double introStart = getIntroStartSecond(pToDeck);
         double timeUntilOutroEnd = outroEnd - fromDeckCurrentSecond;
 
+        // IntroStart ends up being equal to introEnd when pToDeck is
+        // paused and its introEnd marker is not set. getIntroEndSecond returns
+        // introStart thus the two end up having equal values
         if (toDeckCurrentSecond >= introStart &&
                 toDeckCurrentSecond <= introEnd &&
-                introEnd >= 0 && introStart != introEnd) {
+                introStart != introEnd) {
             double timeUntilIntroEnd = introEnd - toDeckCurrentSecond;
             // The fade must end by the outro end at the latest.
             fadeTime = math_min(timeUntilIntroEnd, timeUntilOutroEnd);

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -280,7 +280,7 @@ void AutoDJProcessor::fadeNow() {
 
         if (toDeckCurrentSecond >= introStart &&
                 toDeckCurrentSecond <= introEnd &&
-                introEnd >= 0) {
+                introEnd >= 0 && introStart != introEnd) {
             double timeUntilIntroEnd = introEnd - toDeckCurrentSecond;
             // The fade must end by the outro end at the latest.
             fadeTime = math_min(timeUntilIntroEnd, timeUntilOutroEnd);


### PR DESCRIPTION
`getIntroEndSecond` currently returns `introStart` when `introEnd`  is not set, thus:
`introStart == introEnd`