### PR TITLE
Windows CMake installer improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1065,16 +1065,16 @@ install(
 )
 if(WIN32)
 install(
+  # I haven't seen a way to determine where the translations dir is, so I am making
+  # some assumptions here, and assuming that Qt5_DIR points to Qt-5.14.2/lib/cmake/Qt5
+  # which is what my configuration tells me.
   DIRECTORY
-    # I haven't seen a way to determine where the translations dir is, so I am making
-    # some assumptions here, and assuming that Qt5_DIR points to Qt-5.14.2/lib/cmake/Qt5
-    # which is what my configuration tells me.
     "${Qt5_DIR}/../../../translations"
   DESTINATION
     "${MIXXX_INSTALL_DATADIR}"
+  # QT 5 translations have been separated into several files, and most of the qt_xx.qm files
+  # contain just shortcuts to load the qtbase, qtmultimedia etc files.
   FILES_MATCHING REGEX
-    # QT 5 translations have been separated into several files, and most of the qt_xx.qm files
-    # contain just shortcuts to load the qtbase, qtmultimedia etc files.
     "qt_.+\.qm|qtbase_.*\.qm|qtmultimedia_.*\.qm|qtscript_.*\.qm|qtxmlpatterns_.*\.qm"
 )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1073,7 +1073,7 @@ install(
   DESTINATION
     "${MIXXX_INSTALL_DATADIR}"
   FILES_MATCHING REGEX
-    # QT 5 translations have been separated into several files, and most of the qt_xx.qm files 
+    # QT 5 translations have been separated into several files, and most of the qt_xx.qm files
     # contain just shortcuts to load the qtbase, qtmultimedia etc files.
     "qt_.+\.qm|qtbase_.*\.qm|qtmultimedia_.*\.qm|qtscript_.*\.qm|qtxmlpatterns_.*\.qm"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1021,8 +1021,8 @@ target_link_libraries(mixxx PUBLIC mixxx-lib)
 #
 set(MIXXX_INSTALL_BINDIR ".")
 set(MIXXX_INSTALL_DATADIR ".")
-set(MIXXX_INSTALL_DOCDIR ".")
-set(MIXXX_INSTALL_LICENSEDIR ".")
+set(MIXXX_INSTALL_DOCDIR "./doc")
+set(MIXXX_INSTALL_LICENSEDIR "./doc")
 if (UNIX)
   include(GNUInstallDirs)
   set(MIXXX_INSTALL_BINDIR "${CMAKE_INSTALL_BINDIR}")
@@ -1063,6 +1063,22 @@ install(
   FILES_MATCHING PATTERN
     "*.qm"
 )
+if(WIN32)
+install(
+  DIRECTORY
+    # I haven't seen a way to determine where the translations dir is, so I am making
+    # some assumptions here, and assuming that Qt5_DIR points to Qt-5.14.2/lib/cmake/Qt5
+    # which is what my configuration tells me.
+    "${Qt5_DIR}/../../../translations"
+  DESTINATION
+    "${MIXXX_INSTALL_DATADIR}"
+  FILES_MATCHING REGEX
+    # QT 5 translations have been separated into several files, and most of the qt_xx.qm files 
+    # contain just shortcuts to load the qtbase, qtmultimedia etc files.
+    "qt_.+\.qm|qtbase_.*\.qm|qtmultimedia_.*\.qm|qtscript_.*\.qm|qtxmlpatterns_.*\.qm"
+)
+endif()
+
 # Font files
 install(
   DIRECTORY

--- a/SConscript
+++ b/SConscript
@@ -267,7 +267,14 @@ skin_files = Glob('#res/skins/*')
 controllermappings_files = Glob('#res/controllers/*')
 
 # Translation files
-translation_files = Glob('#res/translations/*.qm') + Glob(os.path.join(build.env['QTDIR'], 'translations/qt_*.qm'))
+# QT 5 translations have been separated into several files, and most of the qt_xx.qm files contain just shortcuts to load the qtbase, qtmultimedia etc files.
+translation_files = Glob('#res/translations/*.qm') 
++ Glob(os.path.join(build.env['QTDIR'], 'translations/qt_*.qm'))
++ Glob(os.path.join(build.env['QTDIR'], 'translations/qtbase_*.qm'))
++ Glob(os.path.join(build.env['QTDIR'], 'translations/qtmultimedia_*.qm'))
++ Glob(os.path.join(build.env['QTDIR'], 'translations/qtscript_*.qm'))
++ Glob(os.path.join(build.env['QTDIR'], 'translations/qtxmlpatterns_*.qm'))
+
 
 # Font files
 font_files = Glob('#res/fonts/*')

--- a/SConscript
+++ b/SConscript
@@ -268,12 +268,7 @@ controllermappings_files = Glob('#res/controllers/*')
 
 # Translation files
 # QT 5 translations have been separated into several files, and most of the qt_xx.qm files contain just shortcuts to load the qtbase, qtmultimedia etc files.
-translation_files = Glob('#res/translations/*.qm') 
-+ Glob(os.path.join(build.env['QTDIR'], 'translations/qt_*.qm'))
-+ Glob(os.path.join(build.env['QTDIR'], 'translations/qtbase_*.qm'))
-+ Glob(os.path.join(build.env['QTDIR'], 'translations/qtmultimedia_*.qm'))
-+ Glob(os.path.join(build.env['QTDIR'], 'translations/qtscript_*.qm'))
-+ Glob(os.path.join(build.env['QTDIR'], 'translations/qtxmlpatterns_*.qm'))
+translation_files = Glob('#res/translations/*.qm') + Glob(os.path.join(build.env['QTDIR'], 'translations/qt_*.qm')) + Glob(os.path.join(build.env['QTDIR'], 'translations/qtbase_*.qm')) + Glob(os.path.join(build.env['QTDIR'], 'translations/qtmultimedia_*.qm')) + Glob(os.path.join(build.env['QTDIR'], 'translations/qtscript_*.qm')) + Glob(os.path.join(build.env['QTDIR'], 'translations/qtxmlpatterns_*.qm'))
 
 
 # Font files

--- a/res/mixxx.qrc
+++ b/res/mixxx.qrc
@@ -1,4 +1,5 @@
-<RCC>
+<!DOCTYPE RCC>
+<RCC version="1.0">
     <qresource prefix="/">
         <file>../LICENSE</file>
         <file>images/library/ic_library_drag_and_drop.svg</file>
@@ -22,7 +23,6 @@
         <file>images/library/ic_library_prepare.svg</file>
         <file>images/library/ic_library_preview_pause.svg</file>
         <file>images/library/ic_library_preview_play.svg</file>
-        <file>images/library/ic_library_promotracks.svg</file>
         <file>images/library/ic_library_recordings.svg</file>
         <file>images/library/ic_library_rhythmbox.svg</file>
         <file>images/library/ic_library_traktor.svg</file>
@@ -50,11 +50,9 @@
         <file>images/preferences/ic_preferences_keydetect.svg</file>
         <file>images/preferences/ic_preferences_library.svg</file>
         <file>images/preferences/ic_preferences_lv2.svg</file>
-        <file>images/preferences/ic_preferences_midicontrollers.svg</file>
         <file>images/preferences/ic_preferences_modplug.svg</file>
         <file>images/preferences/ic_preferences_recording.svg</file>
         <file>images/preferences/ic_preferences_replaygain.svg</file>
-        <file>images/preferences/ic_preferences_sampler.svg</file>
         <file>images/preferences/ic_preferences_soundhardware.svg</file>
         <file>images/preferences/ic_preferences_vinyl.svg</file>
         <file>images/preferences/ic_preferences_warning.svg</file>
@@ -64,82 +62,5 @@
         <file>shaders/passthrough.vert</file>
         <file>shaders/rgbsignal.frag</file>
         <file>skins/default.qss</file>
-        <file>translations/mixxx_ar.qm</file>
-        <file>translations/mixxx_ast.qm</file>
-        <file>translations/mixxx_bg.qm</file>
-        <file>translations/mixxx_br.qm</file>
-        <file>translations/mixxx_bs.qm</file>
-        <file>translations/mixxx_ca-ES.qm</file>
-        <file>translations/mixxx_ca.qm</file>
-        <file>translations/mixxx_ceb.qm</file>
-        <file>translations/mixxx_cs.qm</file>
-        <file>translations/mixxx_da.qm</file>
-        <file>translations/mixxx_de.qm</file>
-        <file>translations/mixxx_el.qm</file>
-        <file>translations/mixxx_el-GR.qm</file>
-        <file>translations/mixxx_en.qm</file>
-        <file>translations/mixxx_en_GB.qm</file>
-        <file>translations/mixxx_eo.qm</file>
-        <file>translations/mixxx_es-ES.qm</file>
-        <file>translations/mixxx_es-MX.qm</file>
-        <file>translations/mixxx_es.qm</file>
-        <file>translations/mixxx_et.qm</file>
-        <file>translations/mixxx_eu.qm</file>
-        <file>translations/mixxx_fa.qm</file>
-        <file>translations/mixxx_fi.qm</file>
-        <file>translations/mixxx_fr.qm</file>
-        <file>translations/mixxx_fr-FR.qm</file>
-        <file>translations/mixxx_ga.qm</file>
-        <file>translations/mixxx_gl.qm</file>
-        <file>translations/mixxx_he.qm</file>
-        <file>translations/mixxx_he-IL.qm</file>
-        <file>translations/mixxx_hr.qm</file>
-        <file>translations/mixxx_hu.qm</file>
-        <file>translations/mixxx_hy.qm</file>
-        <file>translations/mixxx_ia.qm</file>
-        <file>translations/mixxx_id.qm</file>
-        <file>translations/mixxx_is.qm</file>
-        <file>translations/mixxx_it.qm</file>
-        <file>translations/mixxx_ja.qm</file>
-        <file>translations/mixxx_ko.qm</file>
-        <file>translations/mixxx_ky.qm</file>
-        <file>translations/mixxx_lb.qm</file>
-        <file>translations/mixxx_lt.qm</file>
-        <file>translations/mixxx_lv.qm</file>
-        <file>translations/mixxx_mi-NZ.qm</file>
-        <file>translations/mixxx_mk.qm</file>
-        <file>translations/mixxx_ml.qm</file>
-        <file>translations/mixxx_mn.qm</file>
-        <file>translations/mixxx_mr.qm</file>
-        <file>translations/mixxx_ms.qm</file>
-        <file>translations/mixxx_my.qm</file>
-        <file>translations/mixxx_nb.qm</file>
-        <file>translations/mixxx_nl.qm</file>
-        <file>translations/mixxx_nl-BE.qm</file>
-        <file>translations/mixxx_nl-NL.qm</file>
-        <file>translations/mixxx_nn.qm</file>
-        <file>translations/mixxx_oc.qm</file>
-        <file>translations/mixxx_pl.qm</file>
-        <file>translations/mixxx_pt-PT.qm</file>
-        <file>translations/mixxx_pt.qm</file>
-        <file>translations/mixxx_pt_BR.qm</file>
-        <file>translations/mixxx_ro.qm</file>
-        <file>translations/mixxx_ru.qm</file>
-        <file>translations/mixxx_si.qm</file>
-        <file>translations/mixxx_sk.qm</file>
-        <file>translations/mixxx_sl.qm</file>
-        <file>translations/mixxx_sn.qm</file>
-        <file>translations/mixxx_sq-AL.qm</file>
-        <file>translations/mixxx_sr.qm</file>
-        <file>translations/mixxx_sv.qm</file>
-        <file>translations/mixxx_te.qm</file>
-        <file>translations/mixxx_tr.qm</file>
-        <file>translations/mixxx_uk.qm</file>
-        <file>translations/mixxx_uz.qm</file>
-        <file>translations/mixxx_vi.qm</file>
-        <file>translations/mixxx_zh_CN.qm</file>
-        <file>translations/mixxx_zh-HK.qm</file>
-        <file>translations/mixxx_zh_TW.qm</file>
-        <file>translations/mixxx_zh_TW.Big5.qm</file>
     </qresource>
 </RCC>

--- a/src/waveform/renderers/glslwaveformrenderersignal.cpp
+++ b/src/waveform/renderers/glslwaveformrenderersignal.cpp
@@ -45,7 +45,7 @@ bool GLSLWaveformRendererSignal::loadShaders() {
     m_frameShaderProgram->removeAllShaders();
 
     if (!m_frameShaderProgram->addShaderFromSourceFile(
-            QGLShader::Vertex, ":shaders/passthrough.vert")) {
+            QGLShader::Vertex, ":/shaders/passthrough.vert")) {
         qDebug() << "GLWaveformRendererSignalShader::loadShaders - "
                  << m_frameShaderProgram->log();
         return false;


### PR DESCRIPTION
Corrections to the doc installation path (CMake)
Inclusion of the current QT 5 translation files (CMake and Scons)
Corrected one resource path in glslwaveformrenderersignal.cpp
Cleaned mixxx.qrc

- [x] Path fixes (CMake)
- [x] Inclusion of new qt translations (CMake, Scons)
- [ ] Installer translations (CMake)
- [ ] runtime installation (CMake)

It seems that for installer translations,  the loop and regeneration implemented in the Scons script is needed. In other words, to generate a multi-language installer, first one needs to create N localized installers, extract the "difference" and generate a new installer adding those templates.
