### PR TITLE
widget/wtrackmenu: Fix track color picker resize after palette change

### DIFF
--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -628,6 +628,11 @@ void WTrackMenu::updateMenus() {
     if (featureIsEnabled(Feature::Color)) {
         m_pColorPickerAction->setColorPalette(
                 ColorPaletteSettings(m_pConfig).getTrackColorPalette());
+
+        // Resize Menu to fit changed palette
+        QResizeEvent resizeEvent(QSize(), m_pColorMenu->size());
+        qApp->sendEvent(m_pColorMenu, &resizeEvent);
+
         const auto commonColor = getCommonTrackColor();
         if (commonColor) {
             m_pColorPickerAction->setSelectedColor(commonColor);


### PR DESCRIPTION
This just applies the fix that was added in commit 0230c87 and is
documented here:
https://github.com/mixxxdj/mixxx/blob/0230c87d481ae887555404772d9bb6c41c5aab92/src/widget/wcolorpickeraction.h#L21-L29

Zulip Discussion: https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/Color.20menu.20improvements/near/195287895