### PR TITLE
Add help button to preferences

### DIFF
--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -5,19 +5,21 @@
 * @brief Configuration dialog for a DJ controller
 */
 
-#include <QtDebug>
-#include <QFileInfo>
+#include "controllers/dlgprefcontroller.h"
+
+#include <QDesktopServices>
 #include <QFileDialog>
+#include <QFileInfo>
+#include <QStandardPaths>
 #include <QTableWidget>
 #include <QTableWidgetItem>
-#include <QDesktopServices>
-#include <QStandardPaths>
+#include <QtDebug>
 
-#include "controllers/dlgprefcontroller.h"
-#include "controllers/controllerlearningeventfilter.h"
 #include "controllers/controller.h"
+#include "controllers/controllerlearningeventfilter.h"
 #include "controllers/controllermanager.h"
 #include "controllers/defs_controllers.h"
+#include "defs_urls.h"
 #include "preferences/usersettings.h"
 #include "util/version.h"
 
@@ -414,6 +416,10 @@ void DlgPrefController::slotApply() {
 
     // Mark the dialog as not dirty
     setDirty(false);
+}
+
+QUrl DlgPrefController::helpUrl() const {
+    return QUrl(MIXXX_MANUAL_CONTROLLERS_URL);
 }
 
 void DlgPrefController::slotPresetSelected(int chosenIndex) {

--- a/src/controllers/dlgprefcontroller.h
+++ b/src/controllers/dlgprefcontroller.h
@@ -39,6 +39,8 @@ class DlgPrefController : public DlgPreferencePage {
     /// Called when the user clicks the global "Reset to Defaults" button.
     void slotResetToDefaults();
 
+    QUrl helpUrl() const override;
+
   signals:
     void applyPreset(Controller* pController, ControllerPresetPointer pPreset, bool bEnabled);
     void mappingStarted();

--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -1,11 +1,12 @@
-#include <QDesktopServices>
-
 #include "controllers/dlgprefcontrollers.h"
 
-#include "preferences/dialog/dlgpreferences.h"
+#include <QDesktopServices>
+
 #include "controllers/controllermanager.h"
-#include "controllers/dlgprefcontroller.h"
 #include "controllers/defs_controllers.h"
+#include "controllers/dlgprefcontroller.h"
+#include "defs_urls.h"
+#include "preferences/dialog/dlgpreferences.h"
 
 DlgPrefControllers::DlgPrefControllers(DlgPreferences* pPreferences,
                                        UserSettingsPointer pConfig,
@@ -58,6 +59,10 @@ void DlgPrefControllers::slotResetToDefaults() {
     for (DlgPrefController* pControllerWindows : qAsConst(m_controllerWindows)) {
         pControllerWindows->slotResetToDefaults();
     }
+}
+
+QUrl DlgPrefControllers::helpUrl() const {
+    return QUrl(MIXXX_MANUAL_CONTROLLERS_URL);
 }
 
 bool DlgPrefControllers::handleTreeItemClick(QTreeWidgetItem* clickedItem) {

--- a/src/controllers/dlgprefcontrollers.h
+++ b/src/controllers/dlgprefcontrollers.h
@@ -24,6 +24,7 @@ class DlgPrefControllers : public DlgPreferencePage, public Ui::DlgPrefControlle
     virtual ~DlgPrefControllers();
 
     bool handleTreeItemClick(QTreeWidgetItem* clickedItem);
+    QUrl helpUrl() const override;
 
   public slots:
     /// Called when the preference dialog (not this page) is shown to the user.

--- a/src/defs_urls.h
+++ b/src/defs_urls.h
@@ -23,6 +23,23 @@
 #define MIXXX_FEEDBACK_URL      "https://goo.gl/forms/IHf3JK7Q9DXmExXc2"
 #define MIXXX_MANUAL_URL        "https://mixxx.org/manual/2.3"
 #define MIXXX_SHORTCUTS_URL     "https://mixxx.org/manual/2.3/en/chapters/controlling_mixxx.html#using-a-keyboard"
+#define MIXXX_MANUAL_CONTROLLERS_URL \
+    MIXXX_MANUAL_URL                 \
+    "/chapters/controlling_mixxx.html#using-midi-hid-controllers"
+#define MIXXX_MANUAL_SOUND_URL \
+    MIXXX_MANUAL_URL "/chapters/preferences.html#sound-hardware"
+#define MIXXX_MANUAL_LIBRARY_URL \
+    MIXXX_MANUAL_URL "/chapters/preferences.html#library"
+#define MIXXX_MANUAL_BEATS_URL \
+    MIXXX_MANUAL_URL "/chapters/preferences.html#beat-detection"
+#define MIXXX_MANUAL_KEY_URL \
+    MIXXX_MANUAL_URL "/chapters/preferences.html#key-detection"
+#define MIXXX_MANUAL_EQ_URL \
+    MIXXX_MANUAL_URL "/chapters/preferences.html#equalizers"
+#define MIXXX_MANUAL_BROADCAST_URL \
+    MIXXX_MANUAL_URL "/chapters/livebroadcasting.html#configuring-mixxx"
+#define MIXXX_MANUAL_VINYL_URL \
+    MIXXX_MANUAL_URL "/chapters/vinyl_control.html#configuring-vinyl-control"
 #define MIXXX_MANUAL_FILENAME   "Mixxx-Manual.pdf"
 
 #endif

--- a/src/defs_urls.h
+++ b/src/defs_urls.h
@@ -22,7 +22,8 @@
 #define MIXXX_TRANSLATION_URL   "https://www.transifex.com/projects/p/mixxxdj/"
 #define MIXXX_FEEDBACK_URL      "https://goo.gl/forms/IHf3JK7Q9DXmExXc2"
 #define MIXXX_MANUAL_URL        "https://mixxx.org/manual/2.3"
-#define MIXXX_SHORTCUTS_URL     "https://mixxx.org/manual/2.3/en/chapters/controlling_mixxx.html#using-a-keyboard"
+#define MIXXX_MANUAL_SHORTCUTS_URL \
+    MIXXX_MANUAL_URL "/chapters/controlling_mixxx.html#using-a-keyboard"
 #define MIXXX_MANUAL_CONTROLLERS_URL \
     MIXXX_MANUAL_URL                 \
     "/chapters/controlling_mixxx.html#using-midi-hid-controllers"

--- a/src/preferences/dialog/dlgprefbeats.cpp
+++ b/src/preferences/dialog/dlgprefbeats.cpp
@@ -2,6 +2,7 @@
 
 #include "analyzer/analyzerbeats.h"
 #include "control/controlobject.h"
+#include "defs_urls.h"
 
 DlgPrefBeats::DlgPrefBeats(QWidget *parent, UserSettingsPointer pConfig)
         : DlgPreferencePage(parent),
@@ -45,6 +46,10 @@ DlgPrefBeats::DlgPrefBeats(QWidget *parent, UserSettingsPointer pConfig)
 }
 
 DlgPrefBeats::~DlgPrefBeats() {
+}
+
+QUrl DlgPrefBeats::helpUrl() const {
+    return QUrl(MIXXX_MANUAL_BEATS_URL);
 }
 
 void DlgPrefBeats::loadSettings() {

--- a/src/preferences/dialog/dlgprefbeats.h
+++ b/src/preferences/dialog/dlgprefbeats.h
@@ -21,6 +21,8 @@ class DlgPrefBeats : public DlgPreferencePage, public Ui::DlgBeatsDlg {
     DlgPrefBeats(QWidget *parent, UserSettingsPointer _config);
     virtual ~DlgPrefBeats();
 
+    QUrl helpUrl() const override;
+
   public slots:
     // Apply changes to widget
     void slotApply();

--- a/src/preferences/dialog/dlgprefbroadcast.cpp
+++ b/src/preferences/dialog/dlgprefbroadcast.cpp
@@ -168,6 +168,10 @@ void DlgPrefBroadcast::slotUpdate() {
     btnDisconnectAll->setEnabled(enabled);
 }
 
+QUrl DlgPrefBroadcast::helpUrl() const {
+    return QUrl(MIXXX_MANUAL_BROADCAST_URL);
+}
+
 void DlgPrefBroadcast::applyModel() {
     if (m_pProfileListSelection) {
         setValuesToProfile(m_pProfileListSelection);

--- a/src/preferences/dialog/dlgprefbroadcast.h
+++ b/src/preferences/dialog/dlgprefbroadcast.h
@@ -21,6 +21,8 @@ class DlgPrefBroadcast : public DlgPreferencePage, public Ui::DlgPrefBroadcastDl
                      BroadcastSettingsPointer pBroadcastSettings);
     virtual ~DlgPrefBroadcast();
 
+    QUrl helpUrl() const override;
+
   public slots:
     /** Apply changes to widget */
     void slotApply();

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -15,20 +15,22 @@
 *                                                                         *
 ***************************************************************************/
 
-#include <QWidget>
-#include <QString>
-#include <QHBoxLayout>
-
 #include "preferences/dialog/dlgprefeq.h"
-#include "effects/builtin/biquadfullkilleqeffect.h"
-#include "effects/builtin/filtereffect.h"
-#include "effects/effectslot.h"
-#include "engine/filters/enginefilterbessel4.h"
+
+#include <QHBoxLayout>
+#include <QString>
+#include <QWidget>
+
 #include "control/controlobject.h"
 #include "control/controlproxy.h"
-#include "util/math.h"
-#include "mixer/playermanager.h"
+#include "defs_urls.h"
+#include "effects/builtin/biquadfullkilleqeffect.h"
+#include "effects/builtin/filtereffect.h"
 #include "effects/effectrack.h"
+#include "effects/effectslot.h"
+#include "engine/filters/enginefilterbessel4.h"
+#include "mixer/playermanager.h"
+#include "util/math.h"
 
 const QString kConfigKey = "[Mixer Profile]";
 const QString kEnableEqs = "EnableEQs";
@@ -299,6 +301,10 @@ void DlgPrefEQ::slotSingleEqChecked(int checked) {
     }
 
     applySelections();
+}
+
+QUrl DlgPrefEQ::helpUrl() const {
+    return QUrl(MIXXX_MANUAL_EQ_URL);
 }
 
 void DlgPrefEQ::loadSettings() {

--- a/src/preferences/dialog/dlgprefeq.h
+++ b/src/preferences/dialog/dlgprefeq.h
@@ -38,6 +38,8 @@ class DlgPrefEQ : public DlgPreferencePage, public Ui::DlgPrefEQDlg  {
               UserSettingsPointer _config);
     virtual ~DlgPrefEQ();
 
+    QUrl helpUrl() const override;
+
     QString getEQEffectGroupForDeck(int deck) const;
     QString getQuickEffectGroupForDeck(int deck) const;
 

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -481,11 +481,10 @@ void DlgPreferences::slotButtonPressed(QAbstractButton* pButton) {
             reject();
             break;
         case QDialogButtonBox::HelpRole:
-            if (pCurrentPage != nullptr) {
+            if (pCurrentPage) {
                 QUrl helpUrl = pCurrentPage->helpUrl();
-                if (helpUrl.isValid()) {
-                    QDesktopServices::openUrl(helpUrl);
-                }
+                DEBUG_ASSERT(helpUrl.isValid());
+                QDesktopServices::openUrl(helpUrl);
             }
             break;
         default:

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -462,13 +462,13 @@ void DlgPreferences::slotButtonPressed(QAbstractButton* pButton) {
     switch (role) {
         case QDialogButtonBox::ResetRole:
             // Only reset to defaults on the current page.
-            if (pCurrentPage != NULL) {
+            if (pCurrentPage) {
                 pCurrentPage->slotResetToDefaults();
             }
             break;
         case QDialogButtonBox::ApplyRole:
             // Only apply settings on the current page.
-            if (pCurrentPage != NULL) {
+            if (pCurrentPage) {
                 pCurrentPage->slotApply();
             }
             break;

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -480,6 +480,14 @@ void DlgPreferences::slotButtonPressed(QAbstractButton* pButton) {
             emit cancelPreferences();
             reject();
             break;
+        case QDialogButtonBox::HelpRole:
+            if (pCurrentPage != nullptr) {
+                QUrl helpUrl = pCurrentPage->helpUrl();
+                if (helpUrl.isValid()) {
+                    QDesktopServices::openUrl(helpUrl);
+                }
+            }
+            break;
         default:
             break;
     }
@@ -537,6 +545,17 @@ void DlgPreferences::expandTreeItem(QTreeWidgetItem* pItem) {
 
 void DlgPreferences::switchToPage(DlgPreferencePage* pWidget) {
     pagesWidget->setCurrentWidget(pWidget->parentWidget()->parentWidget());
+
+    QPushButton* pButton = buttonBox->button(QDialogButtonBox::Help);
+    VERIFY_OR_DEBUG_ASSERT(pButton) {
+        return;
+    }
+
+    if (pWidget->helpUrl().isValid()) {
+        pButton->show();
+    } else {
+        pButton->hide();
+    }
 }
 
 void DlgPreferences::moveEvent(QMoveEvent* e) {

--- a/src/preferences/dialog/dlgpreferencesdlg.ui
+++ b/src/preferences/dialog/dlgpreferencesdlg.ui
@@ -87,7 +87,7 @@
           <enum>Qt::Horizontal</enum>
          </property>
          <property name="standardButtons">
-          <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::RestoreDefaults</set>
+          <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok|QDialogButtonBox::RestoreDefaults</set>
          </property>
          <property name="centerButtons">
           <bool>false</bool>

--- a/src/preferences/dialog/dlgprefkey.cpp
+++ b/src/preferences/dialog/dlgprefkey.cpp
@@ -95,6 +95,10 @@ DlgPrefKey::DlgPrefKey(QWidget* parent, UserSettingsPointer pConfig)
 DlgPrefKey::~DlgPrefKey() {
 }
 
+QUrl DlgPrefKey::helpUrl() const {
+    return QUrl(MIXXX_MANUAL_KEY_URL);
+}
+
 void DlgPrefKey::loadSettings() {
     m_selectedAnalyzerId = m_keySettings.getKeyPluginId();
     qDebug() << "Key plugin ID:" << m_selectedAnalyzerId;

--- a/src/preferences/dialog/dlgprefkey.h
+++ b/src/preferences/dialog/dlgprefkey.h
@@ -2,22 +2,25 @@
 #define DLGPREFKEY_H
 
 #include <QList>
-#include <QWidget>
 #include <QMap>
+#include <QWidget>
 
 #include "analyzer/plugins/analyzerplugin.h"
 #include "control/controlproxy.h"
+#include "defs_urls.h"
 #include "preferences/dialog/ui_dlgprefkeydlg.h"
+#include "preferences/dlgpreferencepage.h"
 #include "preferences/keydetectionsettings.h"
 #include "preferences/usersettings.h"
 #include "track/keyutils.h"
-#include "preferences/dlgpreferencepage.h"
 
 class DlgPrefKey : public DlgPreferencePage, Ui::DlgPrefKeyDlg {
     Q_OBJECT
   public:
     DlgPrefKey(QWidget *parent, UserSettingsPointer _config);
     virtual ~DlgPrefKey();
+
+    QUrl helpUrl() const override;
 
   public slots:
     // Apply changes to widget

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -115,6 +115,10 @@ void DlgPrefLibrary::slotHide() {
     }
 }
 
+QUrl DlgPrefLibrary::helpUrl() const {
+    return QUrl(MIXXX_MANUAL_LIBRARY_URL);
+}
+
 void DlgPrefLibrary::initializeDirList() {
     // save which index was selected
     const QString selected = dirList->currentIndex().data().toString();

--- a/src/preferences/dialog/dlgpreflibrary.h
+++ b/src/preferences/dialog/dlgpreflibrary.h
@@ -1,15 +1,16 @@
 #ifndef DLGPREFLIBRARY_H
 #define DLGPREFLIBRARY_H
 
+#include <QFont>
 #include <QStandardItemModel>
 #include <QWidget>
-#include <QFont>
 
-#include "preferences/dialog/ui_dlgpreflibrarydlg.h"
-#include "preferences/usersettings.h"
+#include "defs_urls.h"
 #include "library/library.h"
 #include "library/library_preferences.h"
+#include "preferences/dialog/ui_dlgpreflibrarydlg.h"
 #include "preferences/dlgpreferencepage.h"
+#include "preferences/usersettings.h"
 
 /**
   *@author Tue & Ken Haste Andersen
@@ -29,6 +30,8 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
             UserSettingsPointer pConfig,
             Library* pLibrary);
     ~DlgPrefLibrary() override {}
+
+    QUrl helpUrl() const override;
 
   public slots:
     // Common preference page slots.

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -246,6 +246,10 @@ void DlgPrefSound::slotApply() {
     m_bSkipConfigClear = false;
 }
 
+QUrl DlgPrefSound::helpUrl() const {
+    return QUrl(MIXXX_MANUAL_SOUND_URL);
+}
+
 /**
  * Initializes (and creates) all the path items. Each path item widget allows
  * the user to input a sound device name and channel number given a description

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -16,12 +16,13 @@
 #ifndef DLGPREFSOUND_H
 #define DLGPREFSOUND_H
 
+#include "defs_urls.h"
 #include "preferences/dialog/ui_dlgprefsounddlg.h"
-#include "preferences/usersettings.h"
-#include "soundio/soundmanagerconfig.h"
-#include "soundio/sounddeviceerror.h"
 #include "preferences/dlgpreferencepage.h"
+#include "preferences/usersettings.h"
 #include "soundio/sounddevice.h"
+#include "soundio/sounddeviceerror.h"
+#include "soundio/soundmanagerconfig.h"
 
 class SoundManager;
 class PlayerManager;
@@ -46,6 +47,8 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
                  PlayerManager* pPlayerManager,
                  UserSettingsPointer pSettings);
     virtual ~DlgPrefSound();
+
+    QUrl helpUrl() const override;
 
   signals:
     void loadPaths(const SoundManagerConfig &config);

--- a/src/preferences/dialog/dlgprefvinyl.cpp
+++ b/src/preferences/dialog/dlgprefvinyl.cpp
@@ -393,6 +393,10 @@ void DlgPrefVinyl::slotUpdateVinylGain() {
             QString("%1 dB").arg(value));
 }
 
+QUrl DlgPrefVinyl::helpUrl() const {
+    return QUrl(MIXXX_MANUAL_VINYL_URL);
+}
+
 void DlgPrefVinyl::setDeckWidgetsVisible(int deck, bool visible) {
     switch(deck) {
     case 0:

--- a/src/preferences/dialog/dlgprefvinyl.h
+++ b/src/preferences/dialog/dlgprefvinyl.h
@@ -34,6 +34,8 @@ class DlgPrefVinyl : public DlgPreferencePage, Ui::DlgPrefVinylDlg  {
     DlgPrefVinyl(QWidget* pParent, VinylControlManager* m_pVCMan, UserSettingsPointer _config);
     virtual ~DlgPrefVinyl();
 
+    QUrl helpUrl() const override;
+
   public slots:
     void slotUpdate();
     void slotApply();

--- a/src/preferences/dlgpreferencepage.cpp
+++ b/src/preferences/dlgpreferencepage.cpp
@@ -2,12 +2,6 @@
 
 #include "defs_urls.h"
 
-namespace {
-
-const QString manualUrl(MIXXX_MANUAL_URL);
-
-}
-
 DlgPreferencePage::DlgPreferencePage(QWidget* pParent)
         : QWidget(pParent) {
 }

--- a/src/preferences/dlgpreferencepage.cpp
+++ b/src/preferences/dlgpreferencepage.cpp
@@ -1,8 +1,20 @@
 #include "preferences/dlgpreferencepage.h"
 
+#include "defs_urls.h"
+
+namespace {
+
+const QString manualUrl(MIXXX_MANUAL_URL);
+
+}
+
 DlgPreferencePage::DlgPreferencePage(QWidget* pParent)
         : QWidget(pParent) {
 }
 
 DlgPreferencePage::~DlgPreferencePage() {
+}
+
+QUrl DlgPreferencePage::helpUrl() const {
+    return QUrl();
 }

--- a/src/preferences/dlgpreferencepage.h
+++ b/src/preferences/dlgpreferencepage.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QString>
+#include <QUrl>
 #include <QWidget>
 
 /// Interface that all preference pages have to implement.
@@ -8,6 +10,11 @@ class DlgPreferencePage : public QWidget {
   public:
     DlgPreferencePage(QWidget* pParent);
     virtual ~DlgPreferencePage();
+
+    /// Returns the help URL for the current page.
+    /// Subclasses can provide a path to the appropriate manual page by
+    /// overriding this. The default implementation returns an invalid QUrl.
+    virtual QUrl helpUrl() const;
 
   public slots:
     /// Called when the preference dialog is shown to the user (not necessarily

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -543,8 +543,9 @@ void WMainMenuBar::initialize() {
     auto pHelpShortcuts = new QAction(shortcutsTitle, this);
     pHelpShortcuts->setStatusTip(shortcutsText);
     pHelpShortcuts->setWhatsThis(buildWhatsThis(shortcutsTitle, shortcutsText));
-    connect(pHelpShortcuts, &QAction::triggered,
-            this, [this] { slotVisitUrl(MIXXX_SHORTCUTS_URL); });
+    connect(pHelpShortcuts, &QAction::triggered, this, [this] {
+        slotVisitUrl(MIXXX_MANUAL_SHORTCUTS_URL);
+    });
     pHelpMenu->addAction(pHelpShortcuts);
 
     QString feedbackTitle = tr("Send Us &Feedback") + externalLinkSuffix;


### PR DESCRIPTION
Our manual covers most parts of Mixxx in great detail, but unfortunately many users are not aware of it. This commit makes it possible to add a help button that opens the manual for the current preference page.