### PR TITLE
Optimize signal/slot connections

### DIFF
--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -105,13 +105,6 @@ void BaseTrackCache::slotTrackDirty(TrackId trackId) {
     m_dirtyTracks.insert(trackId);
 }
 
-void BaseTrackCache::slotTrackChanged(TrackId trackId) {
-    if (sDebug) {
-        qDebug() << this << "slotTrackChanged" << trackId;
-    }
-    emit tracksChanged(QSet<TrackId>{trackId});
-}
-
 void BaseTrackCache::slotTrackClean(TrackId trackId) {
     if (sDebug) {
         qDebug() << this << "slotTrackClean" << trackId;

--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -76,13 +76,9 @@ QString BaseTrackCache::columnSortForFieldIndex(int index) const {
 
 void BaseTrackCache::slotTracksAddedOrChanged(QSet<TrackId> trackIds) {
     if (sDebug) {
-        qDebug() << this << "slotTracksAdded" << trackIds.size();
+        qDebug() << this << "slotTracksAddedOrChanged" << trackIds.size();
     }
-    QSet<TrackId> updateTrackIds;
-    for (const auto& trackId: qAsConst(trackIds)) {
-        updateTrackIds.insert(trackId);
-    }
-    updateTracksInIndex(updateTrackIds);
+    updateTracksInIndex(trackIds);
 }
 
 void BaseTrackCache::slotDbTrackAdded(TrackPointer pTrack) {
@@ -121,6 +117,7 @@ void BaseTrackCache::slotTrackClean(TrackId trackId) {
         qDebug() << this << "slotTrackClean" << trackId;
     }
     m_dirtyTracks.remove(trackId);
+    // The track might have been reloaded from the database
     updateTrackInIndex(trackId);
 }
 

--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -81,11 +81,11 @@ void BaseTrackCache::slotTracksAddedOrChanged(QSet<TrackId> trackIds) {
     updateTracksInIndex(trackIds);
 }
 
-void BaseTrackCache::slotDbTrackAdded(TrackPointer pTrack) {
+void BaseTrackCache::slotScanTrackAdded(TrackPointer pTrack) {
     if (sDebug) {
-        qDebug() << this << "slotDbTrackAdded";
+        qDebug() << this << "slotScanTrackAdded";
     }
-    updateIndexWithTrackpointer(pTrack);
+    updateTrackInIndex(pTrack);
 }
 
 void BaseTrackCache::slotTracksRemoved(QSet<TrackId> trackIds) {
@@ -207,13 +207,13 @@ void BaseTrackCache::resetRecentTrack() const {
     m_recentTrackPtr.reset();
 }
 
-bool BaseTrackCache::updateIndexWithTrackpointer(TrackPointer pTrack) {
-    if (sDebug) {
-        qDebug() << "updateIndexWithTrackpointer:" << pTrack->getFileInfo();
-    }
-
-    if (!pTrack) {
+bool BaseTrackCache::updateTrackInIndex(
+        const TrackPointer& pTrack) {
+    VERIFY_OR_DEBUG_ASSERT(pTrack) {
         return false;
+    }
+    if (sDebug) {
+        qDebug() << "updateTrackInIndex:" << pTrack->getFileInfo();
     }
 
     int numColumns = columnCount();

--- a/src/library/basetrackcache.h
+++ b/src/library/basetrackcache.h
@@ -79,7 +79,6 @@ class BaseTrackCache : public QObject {
     void slotTracksRemoved(QSet<TrackId> trackId);
     void slotTrackDirty(TrackId trackId);
     void slotTrackClean(TrackId trackId);
-    void slotTrackChanged(TrackId trackId);
     void slotDbTrackAdded(TrackPointer pTrack);
 
   private:

--- a/src/library/basetrackcache.h
+++ b/src/library/basetrackcache.h
@@ -75,11 +75,12 @@ class BaseTrackCache : public QObject {
     void tracksChanged(QSet<TrackId> trackIds);
 
   public slots:
+    void slotScanTrackAdded(TrackPointer pTrack);
+
     void slotTracksAddedOrChanged(QSet<TrackId> trackId);
     void slotTracksRemoved(QSet<TrackId> trackId);
     void slotTrackDirty(TrackId trackId);
     void slotTrackClean(TrackId trackId);
-    void slotDbTrackAdded(TrackPointer pTrack);
 
   private:
     const TrackPointer& getRecentTrack(TrackId trackId) const;
@@ -88,8 +89,8 @@ class BaseTrackCache : public QObject {
     void resetRecentTrack() const;
 
     bool updateIndexWithQuery(const QString& query);
-    bool updateIndexWithTrackpointer(TrackPointer pTrack);
     void updateTrackInIndex(TrackId trackId);
+    bool updateTrackInIndex(const TrackPointer& pTrack);
     void updateTracksInIndex(const QSet<TrackId>& trackIds);
     void getTrackValueForColumn(TrackPointer pTrack, int column,
                                 QVariant& trackValue) const;

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -289,11 +289,6 @@ void TrackDAO::saveTrack(Track* pTrack) const {
     }
 }
 
-void TrackDAO::databaseTrackAdded(TrackPointer pTrack) {
-    DEBUG_ASSERT(pTrack);
-    emit dbTrackAdded(pTrack);
-}
-
 void TrackDAO::slotDatabaseTracksChanged(QSet<TrackId> changedTrackIds) {
     if (!changedTrackIds.isEmpty()) {
         emit tracksChanged(changedTrackIds);

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1310,8 +1310,10 @@ TrackPointer TrackDAO::getTrackById(TrackId trackId) const {
     connect(pTrack.get(),
             &Track::changed,
             this,
-            &TrackDAO::trackChanged,
-            /*signal-to-signal*/ Qt::DirectConnection);
+            [this](TrackId trackId) {
+                // Adapt and forward signal
+                emit tracksChanged(QSet<TrackId>{trackId});
+            });
 
     // BaseTrackCache cares about track trackDirty/trackClean notifications
     // from TrackDAO that are triggered by the track itself. But the preceding

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -294,14 +294,13 @@ void TrackDAO::databaseTrackAdded(TrackPointer pTrack) {
     emit dbTrackAdded(pTrack);
 }
 
-void TrackDAO::databaseTracksChanged(QSet<TrackId> changedTracks) {
-    // results in a call of BaseTrackCache::updateTracksInIndex(trackIds);
-    if (!changedTracks.isEmpty()) {
-        emit tracksChanged(changedTracks);
+void TrackDAO::slotDatabaseTracksChanged(QSet<TrackId> changedTrackIds) {
+    if (!changedTrackIds.isEmpty()) {
+        emit tracksChanged(changedTrackIds);
     }
 }
 
-void TrackDAO::databaseTracksRelocated(QList<RelocatedTrack> relocatedTracks) {
+void TrackDAO::slotDatabaseTracksRelocated(QList<RelocatedTrack> relocatedTracks) {
     QSet<TrackId> removedTrackIds;
     QSet<TrackId> changedTrackIds;
     for (const auto& relocatedTrack : qAsConst(relocatedTracks)) {
@@ -322,7 +321,9 @@ void TrackDAO::databaseTracksRelocated(QList<RelocatedTrack> relocatedTracks) {
     if (!removedTrackIds.isEmpty()) {
         emit tracksRemoved(removedTrackIds);
     }
-    databaseTracksChanged(changedTrackIds);
+    if (!changedTrackIds.isEmpty()) {
+        emit tracksChanged(changedTrackIds);
+    }
 }
 
 void TrackDAO::addTracksPrepare() {

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -73,12 +73,16 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     void saveTrack(Track* pTrack) const;
 
   signals:
+    // Forwarded from Track object
     void trackDirty(TrackId trackId) const;
     void trackClean(TrackId trackId) const;
+
+    // Multiple tracks
+    void tracksAdded(QSet<TrackId> trackIds) const;
+    void tracksChanged(QSet<TrackId> trackIds) const;
+    void tracksRemoved(QSet<TrackId> trackIds) const;
+
     void trackChanged(TrackId trackId);
-    void tracksChanged(QSet<TrackId> trackIds);
-    void tracksAdded(QSet<TrackId> trackIds);
-    void tracksRemoved(QSet<TrackId> trackIds);
     void dbTrackAdded(TrackPointer pTrack);
     void progressVerifyTracksOutside(QString path);
     void progressCoverArt(QString file);
@@ -86,8 +90,12 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
 
   public slots:
     void databaseTrackAdded(TrackPointer pTrack);
-    void databaseTracksChanged(QSet<TrackId> changedTracks);
-    void databaseTracksRelocated(QList<RelocatedTrack> relocatedTracks);
+    // Slots to inform the TrackDAO about changes that
+    // have been applied directly to the database.
+    void slotDatabaseTracksChanged(
+            QSet<TrackId> changedTrackIds);
+    void slotDatabaseTracksRelocated(
+            QList<RelocatedTrack> relocatedTracks);
 
   private:
     friend class LibraryScanner;

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -82,13 +82,11 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     void tracksChanged(QSet<TrackId> trackIds) const;
     void tracksRemoved(QSet<TrackId> trackIds) const;
 
-    void dbTrackAdded(TrackPointer pTrack);
     void progressVerifyTracksOutside(QString path);
     void progressCoverArt(QString file);
     void forceModelUpdate();
 
   public slots:
-    void databaseTrackAdded(TrackPointer pTrack);
     // Slots to inform the TrackDAO about changes that
     // have been applied directly to the database.
     void slotDatabaseTracksChanged(

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -82,7 +82,6 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     void tracksChanged(QSet<TrackId> trackIds) const;
     void tracksRemoved(QSet<TrackId> trackIds) const;
 
-    void trackChanged(TrackId trackId);
     void dbTrackAdded(TrackPointer pTrack);
     void progressVerifyTracksOutside(QString path);
     void progressCoverArt(QString file);

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -103,6 +103,10 @@ void TrackCollection::connectTrackSource(QSharedPointer<BaseTrackCache> pTrackSo
     }
     kLogger.info() << "Connecting track source";
     m_pTrackSource = pTrackSource;
+    connect(this,
+            &TrackCollection::scanTrackAdded,
+            m_pTrackSource.data(),
+            &BaseTrackCache::slotScanTrackAdded);
     connect(&m_trackDao,
             &TrackDAO::trackDirty,
             m_pTrackSource.data(),
@@ -123,10 +127,6 @@ void TrackCollection::connectTrackSource(QSharedPointer<BaseTrackCache> pTrackSo
             &TrackDAO::tracksRemoved,
             m_pTrackSource.data(),
             &BaseTrackCache::slotTracksRemoved);
-    connect(&m_trackDao,
-            &TrackDAO::dbTrackAdded,
-            m_pTrackSource.data(),
-            &BaseTrackCache::slotDbTrackAdded);
 }
 
 QWeakPointer<BaseTrackCache> TrackCollection::disconnectTrackSource() {
@@ -192,7 +192,8 @@ void TrackCollection::relocateDirectory(QString oldDir, QString newDir) {
         return;
     }
 
-    m_trackDao.databaseTracksRelocated(std::move(relocatedTracks));
+    // Inform the TrackDAO about the changes
+    m_trackDao.slotDatabaseTracksRelocated(std::move(relocatedTracks));
 
     GlobalTrackCacheLocker().relocateCachedTracks(&m_trackDao);
 }

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -35,13 +35,6 @@ TrackCollection::TrackCollection(
             &TrackCollection::trackDirty,
             /*signal-to-signal*/ Qt::DirectConnection);
     connect(&m_trackDao,
-            &TrackDAO::trackChanged,
-            this,
-            [this](TrackId trackId) {
-                emit tracksChanged(QSet<TrackId>{trackId});
-            },
-            /*signal-to-signal*/ Qt::DirectConnection);
-    connect(&m_trackDao,
             &TrackDAO::tracksAdded,
             this,
             &TrackCollection::tracksAdded,
@@ -118,10 +111,6 @@ void TrackCollection::connectTrackSource(QSharedPointer<BaseTrackCache> pTrackSo
             &TrackDAO::trackClean,
             m_pTrackSource.data(),
             &BaseTrackCache::slotTrackClean);
-    connect(&m_trackDao,
-            &TrackDAO::trackChanged,
-            m_pTrackSource.data(),
-            &BaseTrackCache::slotTrackChanged);
     connect(&m_trackDao,
             &TrackDAO::tracksAdded,
             m_pTrackSource.data(),

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -99,6 +99,9 @@ class TrackCollection : public QObject,
             bool unremove);
 
   signals:
+    // Forwarded signals from LibraryScanner
+    void scanTrackAdded(TrackPointer pTrack);
+
     // Forwarded signals from TrackDAO
     void trackClean(TrackId trackId);
     void trackDirty(TrackId trackId);

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -97,8 +97,8 @@ TrackCollectionManager::TrackCollectionManager(
 
         // Force the GUI thread's Track cache to be cleared when a library
         // scan is finished, because we might have modified the database directly
-        // when we detected moved files, and the TIOs corresponding to the moved
-        // files would then have the wrong track location.
+        // when we detected moved files, and the track objects and table entries
+        // corresponding to the moved files would then have the wrong track location.
         TrackDAO* pTrackDAO = &(m_pInternalCollection->getTrackDAO());
         connect(m_pScanner.get(),
                 &LibraryScanner::trackAdded,
@@ -107,11 +107,11 @@ TrackCollectionManager::TrackCollectionManager(
         connect(m_pScanner.get(),
                 &LibraryScanner::tracksChanged,
                 pTrackDAO,
-                &TrackDAO::databaseTracksChanged);
+                &TrackDAO::slotDatabaseTracksChanged);
         connect(m_pScanner.get(),
                 &LibraryScanner::tracksRelocated,
                 pTrackDAO,
-                &TrackDAO::databaseTracksRelocated);
+                &TrackDAO::slotDatabaseTracksRelocated);
 
         kLogger.info() << "Starting library scanner thread";
         m_pScanner->start();

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -101,10 +101,6 @@ TrackCollectionManager::TrackCollectionManager(
         // corresponding to the moved files would then have the wrong track location.
         TrackDAO* pTrackDAO = &(m_pInternalCollection->getTrackDAO());
         connect(m_pScanner.get(),
-                &LibraryScanner::trackAdded,
-                pTrackDAO,
-                &TrackDAO::databaseTrackAdded);
-        connect(m_pScanner.get(),
                 &LibraryScanner::tracksChanged,
                 pTrackDAO,
                 &TrackDAO::slotDatabaseTracksChanged);

--- a/src/preferences/dialog/dlgprefcolors.cpp
+++ b/src/preferences/dialog/dlgprefcolors.cpp
@@ -40,7 +40,7 @@ DlgPrefColors::DlgPrefColors(
     connect(m_pReplaceCueColorDlg,
             &DlgReplaceCueColor::databaseTracksChanged,
             &(pLibrary->trackCollections()->internalCollection()->getTrackDAO()),
-            &TrackDAO::databaseTracksChanged);
+            &TrackDAO::slotDatabaseTracksChanged);
 
     connect(comboBoxHotcueColors,
             QOverload<const QString&>::of(&QComboBox::currentIndexChanged),


### PR DESCRIPTION
I found and fixed some cumbersome signal/slot connections while working on #2705.

One of the signals doesn't need to be routed through TrackDAO. Instead TrackCollection serves better as the dispatcher.

We also don't need  separate signals for a single and TrackId and multiple TrackIds. In the end both signals are connected to a slot that accepts multiple TrackIds.