### PR TITLE
Disable export of Serato markers as file tags

### DIFF
--- a/src/track/taglib/trackmetadata_id3v2.cpp
+++ b/src/track/taglib/trackmetadata_id3v2.cpp
@@ -1270,6 +1270,9 @@ bool exportTrackMetadataIntoTag(TagLib::ID3v2::Tag* pTag,
             trackMetadata.getTrackInfo().getEncoderSettings());
 #endif // __EXTRA_METADATA__
 
+    // Export of Serato markers is disabled, because Mixxx
+    // does not modify them.
+#if defined(__EXPORT_SERATO_MARKERS__)
     // Serato tags
     writeGeneralEncapsulatedObjectFrame(
             pTag,
@@ -1281,6 +1284,7 @@ bool exportTrackMetadataIntoTag(TagLib::ID3v2::Tag* pTag,
             trackMetadata.getTrackInfo().getSeratoTags().dumpMarkers2());
 
     return true;
+#endif // __EXPORT_SERATO_MARKERS__
 }
 
 } // namespace id3v2


### PR DESCRIPTION
We currently have no good reason to re-export the Serato markers. Instead we are risking to mess with the user's file tags. Serato might also decide to store additional information that we are not parsing yet.

Let's keep this feature disabled until we actually need it.