### PR TITLE
Fix Ogg broadcasting

### DIFF
--- a/src/broadcast/defs_broadcast.h
+++ b/src/broadcast/defs_broadcast.h
@@ -23,11 +23,8 @@
 #define BROADCAST_BITRATE_48KBPS 48
 #define BROADCAST_BITRATE_32KBPS 32
 
-// WARNING! def_recordings and defs_broadcast format codes have to be the same
-// so that the broadcasting settings can be sent to create an encoder.
-#define BROADCAST_FORMAT_MP3 "MP3"
-#define BROADCAST_FORMAT_OV "OGG"
-#define BROADCAST_FORMAT_OPUS "Opus"
+// This code is intended just for fixing old settings. Use formats from defs_recording.h instead.
+#define BROADCAST_FORMAT_OV_LEGACY "OggVorbis"
 
 // EngineNetworkStream can't use locking mechanisms to protect its
 // internal worker list against concurrency issues, as it is used by

--- a/src/broadcast/defs_broadcast.h
+++ b/src/broadcast/defs_broadcast.h
@@ -23,8 +23,10 @@
 #define BROADCAST_BITRATE_48KBPS 48
 #define BROADCAST_BITRATE_32KBPS 32
 
+// WARNING! def_recordings and defs_broadcast format codes have to be the same
+// so that the broadcasting settings can be sent to create an encoder.
 #define BROADCAST_FORMAT_MP3 "MP3"
-#define BROADCAST_FORMAT_OV "OggVorbis"
+#define BROADCAST_FORMAT_OV "OGG"
 #define BROADCAST_FORMAT_OPUS "Opus"
 
 // EngineNetworkStream can't use locking mechanisms to protect its

--- a/src/engine/sidechain/shoutconnection.cpp
+++ b/src/engine/sidechain/shoutconnection.cpp
@@ -362,9 +362,9 @@ void ShoutConnection::updateFromPreferences() {
         return;
     }
 
-    m_format_is_mp3 = !qstrcmp(baFormat.constData(), BROADCAST_FORMAT_MP3);
-    m_format_is_ov = !qstrcmp(baFormat.constData(), BROADCAST_FORMAT_OV);
-    m_format_is_opus = !qstrcmp(baFormat.constData(), BROADCAST_FORMAT_OPUS);
+    m_format_is_mp3 = !qstrcmp(baFormat.constData(), ENCODING_MP3);
+    m_format_is_ov = !qstrcmp(baFormat.constData(), ENCODING_OGG);
+    m_format_is_opus = !qstrcmp(baFormat.constData(), ENCODING_OPUS);
     if (m_format_is_mp3) {
         format = SHOUT_FORMAT_MP3;
     } else if (m_format_is_ov || m_format_is_opus) {

--- a/src/preferences/broadcastprofile.cpp
+++ b/src/preferences/broadcastprofile.cpp
@@ -15,6 +15,7 @@ using namespace QKeychain;
 #endif // __QTKEYCHAIN__
 
 #include "broadcast/defs_broadcast.h"
+#include "recording/defs_recording.h"
 #include "defs_urls.h"
 #include "util/compatibility.h"
 #include "util/xml.h"
@@ -22,8 +23,6 @@ using namespace QKeychain;
 #include "util/logger.h"
 
 #include "broadcastprofile.h"
-
-#define BROADCAST_FORMAT_OV_LEGACYNAME "OggVorbis"
 
 namespace {
 const char* kDoctype = "broadcastprofile";
@@ -324,9 +323,9 @@ bool BroadcastProfile::loadValues(const QString& filename) {
     m_streamICQ = XmlParse::selectNodeQString(doc, kStreamICQ);
 
     m_format = XmlParse::selectNodeQString(doc, kFormat);
-    if (m_format == BROADCAST_FORMAT_OV_LEGACYNAME) {
+    if (m_format == BROADCAST_FORMAT_OV_LEGACY) {
         // Upgrade to have the same codec name than the recording define.
-        m_format = BROADCAST_FORMAT_OV;
+        m_format = ENCODING_OGG;
     }
     m_bitrate = XmlParse::selectNodeInt(doc, kBitrate);
     m_channels = XmlParse::selectNodeInt(doc, kChannels);

--- a/src/preferences/broadcastprofile.cpp
+++ b/src/preferences/broadcastprofile.cpp
@@ -23,6 +23,8 @@ using namespace QKeychain;
 
 #include "broadcastprofile.h"
 
+#define BROADCAST_FORMAT_OV_LEGACYNAME "OggVorbis"
+
 namespace {
 const char* kDoctype = "broadcastprofile";
 const char* kDocumentRoot = "BroadcastProfile";
@@ -322,6 +324,10 @@ bool BroadcastProfile::loadValues(const QString& filename) {
     m_streamICQ = XmlParse::selectNodeQString(doc, kStreamICQ);
 
     m_format = XmlParse::selectNodeQString(doc, kFormat);
+    if (m_format == BROADCAST_FORMAT_OV_LEGACYNAME) {
+        // Upgrade to have the same codec name than the recording define.
+        m_format = BROADCAST_FORMAT_OV;
+    }
     m_bitrate = XmlParse::selectNodeInt(doc, kBitrate);
     m_channels = XmlParse::selectNodeInt(doc, kChannels);
 

--- a/src/preferences/broadcastsettings_legacy.cpp
+++ b/src/preferences/broadcastsettings_legacy.cpp
@@ -1,5 +1,7 @@
 #include "preferences/broadcastsettings.h"
+#include "broadcast/defs_broadcast.h"
 
+#define BROADCAST_FORMAT_OV_LEGACYNAME "OggVorbis"
 namespace {
 const char* kConfigKey = "[Shoutcast]";
 const char* kBitrate = "bitrate";
@@ -124,9 +126,14 @@ void BroadcastSettings::loadLegacySettings(BroadcastProfilePtr profile) {
                              ConfigKey(kConfigKey, kChannels),
                              profile->getChannels()));
 
-    profile->setFormat(m_pConfig->getValue(
-                           ConfigKey(kConfigKey, kFormat),
-                           profile->getFormat()));
+    QString m_format = m_pConfig->getValue(
+            ConfigKey(kConfigKey, kFormat),
+            profile->getFormat());
+    if (m_format == BROADCAST_FORMAT_OV_LEGACYNAME) {
+        // Upgrade to have the same codec name than the recording define.
+        m_format = BROADCAST_FORMAT_OV;
+    }
+    profile->setFormat(m_format);
 
     profile->setNoDelayFirstReconnect(
                 m_pConfig->getValue(

--- a/src/preferences/broadcastsettings_legacy.cpp
+++ b/src/preferences/broadcastsettings_legacy.cpp
@@ -1,7 +1,7 @@
 #include "preferences/broadcastsettings.h"
 #include "broadcast/defs_broadcast.h"
+#include "recording/defs_recording.h"
 
-#define BROADCAST_FORMAT_OV_LEGACYNAME "OggVorbis"
 namespace {
 const char* kConfigKey = "[Shoutcast]";
 const char* kBitrate = "bitrate";
@@ -129,9 +129,9 @@ void BroadcastSettings::loadLegacySettings(BroadcastProfilePtr profile) {
     QString m_format = m_pConfig->getValue(
             ConfigKey(kConfigKey, kFormat),
             profile->getFormat());
-    if (m_format == BROADCAST_FORMAT_OV_LEGACYNAME) {
+    if (m_format == BROADCAST_FORMAT_OV_LEGACY) {
         // Upgrade to have the same codec name than the recording define.
-        m_format = BROADCAST_FORMAT_OV;
+        m_format = ENCODING_OGG;
     }
     profile->setFormat(m_format);
 

--- a/src/preferences/dialog/dlgprefbroadcast.cpp
+++ b/src/preferences/dialog/dlgprefbroadcast.cpp
@@ -17,6 +17,7 @@
 #endif
 
 #include "broadcast/defs_broadcast.h"
+#include "recording/defs_recording.h"
 #include "control/controlproxy.h"
 #include "defs_urls.h"
 #include "preferences/dialog/dlgprefbroadcast.h"
@@ -117,10 +118,10 @@ DlgPrefBroadcast::DlgPrefBroadcast(QWidget *parent,
      }
 
      // Encoding format combobox
-     comboBoxEncodingFormat->addItem(tr("MP3"), BROADCAST_FORMAT_MP3);
-     comboBoxEncodingFormat->addItem(tr("Ogg Vorbis"), BROADCAST_FORMAT_OV);
+     comboBoxEncodingFormat->addItem(tr("MP3"), ENCODING_MP3);
+     comboBoxEncodingFormat->addItem(tr("Ogg Vorbis"), ENCODING_OGG);
 #ifdef __OPUS__
-     comboBoxEncodingFormat->addItem(tr("Opus"), BROADCAST_FORMAT_OPUS);
+     comboBoxEncodingFormat->addItem(tr("Opus"), ENCODING_OPUS);
 #endif
 
      // Encoding channels combobox

--- a/src/recording/defs_recording.h
+++ b/src/recording/defs_recording.h
@@ -2,6 +2,7 @@
 #define __RECORDING_DEFS_H__
 
 #define RECORDING_PREF_KEY "[Recording]"
+// WARNING! def_recordings and defs_broadcast format codes have to be the same
 #define ENCODING_WAVE "WAV"
 #define ENCODING_FLAC "FLAC"
 #define ENCODING_AIFF "AIFF"

--- a/src/recording/defs_recording.h
+++ b/src/recording/defs_recording.h
@@ -2,7 +2,6 @@
 #define __RECORDING_DEFS_H__
 
 #define RECORDING_PREF_KEY "[Recording]"
-// WARNING! def_recordings and defs_broadcast format codes have to be the same
 #define ENCODING_WAVE "WAV"
 #define ENCODING_FLAC "FLAC"
 #define ENCODING_AIFF "AIFF"


### PR DESCRIPTION
Ogg vorbis does not work for Icecast. This bug has come from PR #2415 because on Broadcasting, the Ogg vorbis plugin has the code "OggVorbis", while the recording code is "OGG".
