### PR TITLE
Hotfix/Follow-up: Export serato markers

### DIFF
--- a/src/track/taglib/trackmetadata_id3v2.cpp
+++ b/src/track/taglib/trackmetadata_id3v2.cpp
@@ -506,6 +506,7 @@ void writeUniqueFileIdentifierFrame(
 }
 #endif // __EXTRA_METADATA__
 
+#if defined(__EXPORT_SERATO_MARKERS__)
 void writeGeneralEncapsulatedObjectFrame(
         TagLib::ID3v2::Tag* pTag,
         const QString& description,

--- a/src/track/taglib/trackmetadata_id3v2.cpp
+++ b/src/track/taglib/trackmetadata_id3v2.cpp
@@ -536,6 +536,7 @@ void writeGeneralEncapsulatedObjectFrame(
         }
     }
 }
+#endif // __EXPORT_SERATO_MARKERS__
 
 template<typename T>
 const T* downcastFrame(TagLib::ID3v2::Frame* frame) {
@@ -1283,9 +1284,9 @@ bool exportTrackMetadataIntoTag(TagLib::ID3v2::Tag* pTag,
             pTag,
             kFrameDescriptionSeratoMarkersV2,
             trackMetadata.getTrackInfo().getSeratoTags().dumpMarkers2());
+#endif // __EXPORT_SERATO_MARKERS__
 
     return true;
-#endif // __EXPORT_SERATO_MARKERS__
 }
 
 } // namespace id3v2


### PR DESCRIPTION
A return statement got captured :see_no_evil: 