### PR TITLE
Fix display of KEY column for table models without KEY_ID column

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -538,17 +538,19 @@ QVariant BaseTrackTableModel::roleValue(
             // currently stored in the DB) then lookup the key and render it
             // using the user's selected notation.
             int keyIdColumn = fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_KEY_ID);
-            if (keyIdColumn != -1) {
-                mixxx::track::io::key::ChromaticKey key =
-                        KeyUtils::keyFromNumericValue(
-                                index.sibling(index.row(), keyIdColumn).data().toInt());
-                if (key != mixxx::track::io::key::INVALID) {
-                    // Render this key with the user-provided notation.
-                    return KeyUtils::keyToString(key);
-                }
+            if (keyIdColumn == -1) {
+                // Otherwise, just use the column value
+                return std::move(rawValue);
             }
-            // clear invalid values
-            return QVariant();
+            mixxx::track::io::key::ChromaticKey key =
+                    KeyUtils::keyFromNumericValue(
+                            index.sibling(index.row(), keyIdColumn).data().toInt());
+            if (key == mixxx::track::io::key::INVALID) {
+                // clear invalid values
+                return QVariant();
+            }
+            // Render this key with the user-provided notation.
+            return KeyUtils::keyToString(key);
         } else if (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_REPLAYGAIN)) {
             bool ok;
             const auto gainValue = rawValue.toDouble(&ok);


### PR DESCRIPTION
`BaseTrackTableModel` swallows the `rawValue` of the column COLUMN_LIBRARYTABLE_KEY if the numeric column COLUMN_LIBRARYTABLE_KEY_ID is not present. In this case it displays empty cells.

This bug might only affect the aoide TableModel, which directly provides a value for COLUMN_LIBRARYTABLE_KEY, but no value for COLUMN_LIBRARYTABLE_KEY_ID.