### PR TITLE
fix LibraryControl::bindSearchboxWidget

### DIFF
--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -339,7 +339,7 @@ void LibraryControl::bindSearchboxWidget(WSearchLineEdit* pSearchbox) {
     connect(m_pSearchbox,
             &WSearchLineEdit::destroyed,
             this,
-            &LibraryControl::libraryWidgetDeleted);
+            &LibraryControl::searchboxWidgetDeleted);
 }
 
 


### PR DESCRIPTION
fixes a copy/paste typo that slipped through in #2597 

I experienced a randomly recurring crasher when switching skins wit master, and I suspect this is the cause.