### PR TITLE
Allen & Heath Xone K2 QuickEffect and sync changes

### DIFF
--- a/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
+++ b/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
@@ -266,14 +266,14 @@ XoneK2.Deck = function (column, deckNumber, midiChannel) {
         unshift: function () {
             this.input = function (channel, control, value, status) {
                 direction = (value === 1) ? 1 : -1;
-                var gain = engine.getValue(this.group, "pregain");
-                engine.setValue(this.group, "pregain", gain + 0.025 * direction);
+                engine.setValue(this.group, "jog", direction * 3);
             };
         },
         shift: function () {
             this.input = function (channel, control, value, status) {
                 direction = (value === 1) ? 1 : -1;
-                engine.setValue(this.group, "jog", direction);
+                var gain = engine.getValue(this.group, "pregain");
+                engine.setValue(this.group, "pregain", gain + 0.025 * direction);
             };
         },
         supershift: function () {

--- a/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
+++ b/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
@@ -288,15 +288,18 @@ XoneK2.Deck = function (column, deckNumber, midiChannel) {
     this.encoderPress = new components.Button({
         outKey: 'sync_enabled',
         unshift: function () {
+            this.group = theDeck.deckString;
             this.inKey = 'sync_enabled';
             this.type = components.Button.prototype.types.toggle;
         },
         shift: function () {
-            this.inKey = 'rate_set_zero';
-            this.type = components.Button.prototype.types.push;
+            this.group = '[QuickEffectRack1_' + theDeck.deckString + ']';
+            this.inKey = 'enabled';
+            this.type = components.Button.prototype.types.toggle;
         },
         supershift: function () {
-            this.inKey = 'reset_key';
+            this.group = theDeck.deckString;
+            this.inKey = 'rate_set_zero';
             this.type = components.Button.prototype.types.push;
         },
     });

--- a/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
+++ b/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
@@ -288,12 +288,12 @@ XoneK2.Deck = function (column, deckNumber, midiChannel) {
     this.encoderPress = new components.Button({
         outKey: 'sync_enabled',
         unshift: function () {
-            this.inKey = 'pregain_set_one';
-            this.type = components.Button.prototype.types.push;
-        },
-        shift: function () {
             this.inKey = 'sync_enabled';
             this.type = components.Button.prototype.types.toggle;
+        },
+        shift: function () {
+            this.inKey = 'rate_set_zero';
+            this.type = components.Button.prototype.types.push;
         },
         supershift: function () {
             this.inKey = 'reset_key';

--- a/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
+++ b/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
@@ -279,8 +279,7 @@ XoneK2.Deck = function (column, deckNumber, midiChannel) {
         supershift: function () {
             this.input = function (channel, control, value, status) {
                 direction = (value === 1) ? 1 : -1;
-                var pitch = engine.getValue(this.group, "pitch");
-                engine.setValue(this.group, "pitch", pitch + (.05 * direction));
+                engine.setValue('[QuickEffectRack1_' + theDeck.deckString + ']', 'chain_selector', direction);
             };
         },
     });

--- a/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
+++ b/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
@@ -302,12 +302,40 @@ XoneK2.Deck = function (column, deckNumber, midiChannel) {
     });
 
     this.knobs = new components.ComponentContainer();
-    for (var k = 1; k <= 3; k++) {
+    for (var k = 1; k <= 2; k++) {
         this.knobs[k] = new components.Pot({
             group: '[EqualizerRack1_' + this.deckString + '_Effect1]',
             inKey: 'parameter' + (4-k),
         });
     }
+    // Low EQ knob. With shift, switches to QuickEffect superknob. Stays as
+    // QuickEffect superknob until shift is pressed again to allow using the
+    // QuickEffect superknob without having to keep shift held down. This
+    // allows using the QuickEffect superknob for a transition while using
+    // the other hand for another control.
+    this.knobs[3] = new components.Pot({
+        hasBeenTurnedSinceShiftToggle: false,
+        input: function (channel, control, value, status) {
+            components.Pot.prototype.input.call(this, channel, control, value, status);
+            this.hasBeenTurnedSinceShiftToggle = true;
+        },
+        unshift: function() {
+            if (!this.hasBeenTurnedSinceShiftToggle) {
+                this.disconnect();
+                this.group = '[EqualizerRack1_' + theDeck.deckString + '_Effect1]';
+                this.inKey = 'parameter1';
+                this.connect();
+            }
+            this.hasBeenTurnedSinceShiftToggle = false;
+        },
+        shift: function() {
+            this.disconnect();
+            this.group = '[QuickEffectRack1_' + theDeck.deckString + ']';
+            this.inKey = 'super1';
+            this.connect();
+            this.hasBeenTurnedSinceShiftToggle = false;
+        }
+    });
 
     this.fader = new components.Pot({inKey: 'volume'});
 


### PR DESCRIPTION
Working on #2618, I wanted a way to use the QuickEffect superknob from my Xone K2. I took a [suggestion from the forum](https://mixxx.org/forums/viewtopic.php?p=42801#p42801) to use shift + low EQ knob. The simple implementation of this was cumbersome to use because the shift button had to be held down the whole time the QuickEffect superknob was in use. I made it so if the knob is turned for the QuickEffect superknob while shift is pressed, it does not go back to the low EQ knob when shift is released; it goes back to the low EQ knob the next time shift is pressed. This allows for using the QuickEffect superknob with one hand and using the other hand for another control.

I have implemented shift + top encoder press to toggle the QuickEffect enable button. Supershift + top encoder turn scrolls through the effect chain presets for the QuickEffect (this is not useful without #2618).

I rearranged other mappings for the top encoder to make sync easier to use. Now pressing the top encoder without shift toggles sync. Turning the top encoder without shift does jogging, and I increased the sensitivity of this. Gain is still accessible with shift + top encoder turn, but I got rid of the reset gain button because it's redundant with the gain knob. I also made supershift + top encoder press reset the tempo.

@poelzi could you test this with #2618?