### PR TITLE
change Tremolo effect mixing

### DIFF
--- a/src/effects/builtin/tremoloeffect.cpp
+++ b/src/effects/builtin/tremoloeffect.cpp
@@ -216,9 +216,8 @@ void TremoloEffect::processChannel(const ChannelHandle& handle,
         //  This function gives the gain to apply for position in [0 1]
         //  Plot the function to get a grasp :
         //  From a sine to a square wave depending on the smooth parameter
-        double gainTarget = 1.0 - (depth / 2.0)
-                + (atan(sin(2.0 * M_PI * position) / smooth) / (2 * atan(1 / smooth)))
-                    * depth;
+        double gainTarget = depth *
+                (atan(sin(2.0 * M_PI * position) / smooth) / (2 * atan(1 / smooth)));
 
         if (gainTarget > gain + kMaxGainIncrement) {
             gain += kMaxGainIncrement;

--- a/src/effects/builtin/tremoloeffect.cpp
+++ b/src/effects/builtin/tremoloeffect.cpp
@@ -13,6 +13,9 @@ QString TremoloEffect::getId() {
 // static
 EffectManifestPointer TremoloEffect::getManifest() {
     EffectManifestPointer pManifest(new EffectManifest());
+
+    pManifest->setAddDryToWet(true);
+
     pManifest->setId(getId());
     pManifest->setName(QObject::tr("Tremolo"));
     pManifest->setShortName(QObject::tr("Tremolo"));


### PR DESCRIPTION
Trying to come up with default chain presets for #2618, I noticed the way this effect was mixed was strange. There was no way to have the effect enabled without increasing the gain of the track. Also, this needs the addDryToWet flag set to work right in Dry+Wet mode chains.