### PR TITLE
Fix various typos

### DIFF
--- a/res/controllers/Denon-MC3000-scripts.js
+++ b/res/controllers/Denon-MC3000-scripts.js
@@ -3,7 +3,7 @@
  *
  * Written by Bertrand Espern 2012
  *
- * 2012/05/11 V0.995 : first "good" version approuved and tested by me
+ * 2012/05/11 V0.995 : first "good" version approved and tested by me
  *
  * Special Thanks to the Programmers of Mixxx and all the contributors
  *

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -78,7 +78,7 @@ MC7000.jogParams = {
 /////////////////////////////////*/
 
 
-/* OTHER VARIABLES - DONT'T TOUCH EXCEPT YOU KNOW WHAT YOU DO */
+/* OTHER VARIABLES - DON'T TOUCH UNLESS YOU KNOW WHAT YOU'RE DOING */
 
 // Resolution of the jog wheel, set so the spinny
 // Jog LED to match exactly the movement of the Jog Wheel
@@ -642,7 +642,7 @@ MC7000.needleSearchStripPosition = function(channel, control, value, status,
     if (MC7000.needleSearchTouched[deckNumber]) {
         var fullValue = (MC7000.needleDropMSB << 7) +
                     value; // move MSB 7 binary gigits to the left and add LSB
-        var position = (fullValue / 0x3FFF); // devide by all possible positions to
+        var position = (fullValue / 0x3FFF); // divide by all possible positions to
         // get relative between 0 - 1
         engine.setParameter(group, "playposition", position);
     }

--- a/res/controllers/Denon-MC7000.midi.xml
+++ b/res/controllers/Denon-MC7000.midi.xml
@@ -2125,7 +2125,7 @@
                 </options>
             </control>
 <!-- EFFECTS -->
-    <!-- ASSIGN EFECT RACK TO DECK -->
+    <!-- ASSIGN EFFECT RACK TO DECK -->
             <control>
                 <group>[EffectRack1_EffectUnit1]</group>
                 <key>group_[Channel1]_enable</key>
@@ -3768,7 +3768,7 @@
             </output>
 <!-- PAD LEDs -->
 
-<!-- ASSIGN EFECT RACK TO DECK -->
+<!-- ASSIGN EFFECT RACK TO DECK -->
             <output>
                 <group>[EffectRack1_EffectUnit1]</group>
                 <key>group_[Channel1]_enable</key>

--- a/res/controllers/Hercules_DJControl_Inpulse_300.midi.xml
+++ b/res/controllers/Hercules_DJControl_Inpulse_300.midi.xml
@@ -1859,7 +1859,7 @@
 				<on>0x07</on>
 				<off>0x05</off>
 			</output>
-			<!-- LED Assitant button-->
+			<!-- LED Assistant button-->
 			<output>
 				<group>[AutoDJ]</group>
 				<key>enabled</key>

--- a/res/controllers/Novation-Launchpad-Mini-scripts.js
+++ b/res/controllers/Novation-Launchpad-Mini-scripts.js
@@ -405,7 +405,7 @@ NLM.init = function()
 
         //Init hw
         midi.sendShortMsg(0xb0, 0x0, 0x0);
-        //midi.sendShortMsg(0xb0, 0x0, 0x28); //Enable buffer cycling <-- Figure out whats wrong with this
+        //midi.sendShortMsg(0xb0, 0x0, 0x28); //Enable buffer cycling <-- Figure out what's wrong with this
 
         // select buffer 0
         midi.sendShortMsg(0xb0, 0x68, 3);

--- a/res/controllers/Pioneer-DDJ-SB2.midi.xml
+++ b/res/controllers/Pioneer-DDJ-SB2.midi.xml
@@ -2419,7 +2419,7 @@
             <control>
                 <group>[EffectRack1_EffectUnit1]</group>
                 <key>prev_chain</key>
-                <description>Preview Effekt 1, Button: SHIFT &amp; PAD1 (in CUE LOOP-Mode, Deck 1 active)</description>
+                <description>Preview Effect 1, Button: SHIFT &amp; PAD1 (in CUE LOOP-Mode, Deck 1 active)</description>
                 <status>0x97</status>
                 <midino>0x68</midino>
                 <options>
@@ -2429,7 +2429,7 @@
             <control>
                 <group>[EffectRack1_EffectUnit2]</group>
                 <key>prev_chain</key>
-                <description>Preview Effekt 1, Button: SHIFT &amp; PAD1 (in CUE LOOP-Mode, Deck 2 active)</description>
+                <description>Preview Effect 1, Button: SHIFT &amp; PAD1 (in CUE LOOP-Mode, Deck 2 active)</description>
                 <status>0x98</status>
                 <midino>0x68</midino>
                 <options>
@@ -2439,7 +2439,7 @@
             <control>
                 <group>[EffectRack1_EffectUnit2]</group>
                 <key>prev_chain</key>
-                <description>Preview Effekt 1, Button: SHIFT &amp; PAD1 (in CUE LOOP-Mode, Deck 3 active)</description>
+                <description>Preview Effect 1, Button: SHIFT &amp; PAD1 (in CUE LOOP-Mode, Deck 3 active)</description>
                 <status>0x99</status>
                 <midino>0x68</midino>
                 <options>
@@ -2449,7 +2449,7 @@
             <control>
                 <group>[EffectRack1_EffectUnit2]</group>
                 <key>prev_chain</key>
-                <description>Preview Effekt 1, Button: SHIFT &amp; PAD1 (in CUE LOOP-Mode, Deck 4 active)</description>
+                <description>Preview Effect 1, Button: SHIFT &amp; PAD1 (in CUE LOOP-Mode, Deck 4 active)</description>
                 <status>0x9A</status>
                 <midino>0x68</midino>
                 <options>
@@ -3059,7 +3059,7 @@
             <control>
                 <group>[EffectRack1_EffectUnit1]</group>
                 <key>next_chain</key>
-                <description>Next Effekt 1, Button: SHIFT &amp; PAD2 (in CUE LOOP-Mode, Deck 1 active)</description>
+                <description>Next Effect 1, Button: SHIFT &amp; PAD2 (in CUE LOOP-Mode, Deck 1 active)</description>
                 <status>0x97</status>
                 <midino>0x69</midino>
                 <options>
@@ -3069,7 +3069,7 @@
             <control>
                 <group>[EffectRack1_EffectUnit2]</group>
                 <key>next_chain</key>
-                <description>Next Effekt 1, Button: SHIFT &amp; PAD2 (in CUE LOOP-Mode, Deck 2 active)</description>
+                <description>Next Effect 1, Button: SHIFT &amp; PAD2 (in CUE LOOP-Mode, Deck 2 active)</description>
                 <status>0x98</status>
                 <midino>0x69</midino>
                 <options>
@@ -3079,7 +3079,7 @@
             <control>
                 <group>[EffectRack1_EffectUnit2]</group>
                 <key>next_chain</key>
-                <description>Next Effekt 1, Button: SHIFT &amp; PAD2 (in CUE LOOP-Mode, Deck 3 active)</description>
+                <description>Next Effect 1, Button: SHIFT &amp; PAD2 (in CUE LOOP-Mode, Deck 3 active)</description>
                 <status>0x99</status>
                 <midino>0x69</midino>
                 <options>
@@ -3089,7 +3089,7 @@
             <control>
                 <group>[EffectRack1_EffectUnit2]</group>
                 <key>next_chain</key>
-                <description>Next Effekt 1, Button: SHIFT &amp; PAD2 (in CUE LOOP-Mode, Deck 4 active)</description>
+                <description>Next Effect 1, Button: SHIFT &amp; PAD2 (in CUE LOOP-Mode, Deck 4 active)</description>
                 <status>0x9A</status>
                 <midino>0x69</midino>
                 <options>

--- a/res/controllers/common-controller-scripts.js
+++ b/res/controllers/common-controller-scripts.js
@@ -481,7 +481,7 @@ bpm.tapButton = function(deck) {
         bpm.tap = [];
         return;
     }
-    // reject occurences of accidental double or missed taps
+    // reject occurrences of accidental double or missed taps
     // a tap is considered missed when the delta of this press is 80% longer than the previous one
     // and a tap is considered double when the delta is shorter than 40% of the previous one.
     // these numbers are just guesses that produced good results in practice

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -105,7 +105,7 @@
             style_scheme  icons & backgrounds for library, splitters, spinnies,
                           covers, vinyl control, toolbar
             bg_tile       allows to experiment with the background tile of recessed
-                          areas without having to creat a new style_scheme folder
+                          areas without having to create a new style_scheme folder
             Note:   button borders and icons are set in style_[SCHEME].qss, too
                     so do a mass-find-and-replace there, as well. -->
       <SetVariable name="btn_scheme">classic</SetVariable>
@@ -352,7 +352,7 @@
       <Layout>vertical</Layout>
       <SizePolicy>me,me</SizePolicy>
       <Children>
-        <!-- regular/maximized libary + skin settings menu -->
+        <!-- regular/maximized library + skin settings menu -->
         <WidgetGroup>
           <Layout>horizontal</Layout>
           <SizePolicy>me,me</SizePolicy>
@@ -426,7 +426,7 @@
             <Template src="skin:skin_settings.xml"/>
 
           </Children>
-        </WidgetGroup><!-- regular/maximized libary + skin settings menu -->
+        </WidgetGroup><!-- regular/maximized library + skin settings menu -->
 
         <Template src="skin:toolbar.xml"/>
         <Template src="skin:screen_h-size_detection.xml"/>

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -2192,7 +2192,7 @@ WCueMenuPopup QPushButton:focus {
     padding-right: 3px;
     border-right: 1px solid #000;
     /* gradient colors should match those of QHeaderView gradient,
-      with a litte transparency added to not cut off the header label */
+      with a little transparency added to not cut off the header label */
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
       stop:0 rgba(34,34,34,190),
       stop:1 rgba(17,17,17,190));

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -613,9 +613,9 @@ WEffectSelector QAbstractScrollArea QScrollBar:vertical,
 }
 #LibraryContainer QHeaderView {
   /* Note(ronso0)
-  This previously interferred with skin scaling:
+  This previously interfered with skin scaling:
   font-size: 13px/13px;
-  This doesnt't scale when usinf QT_SCALE_FACTOR manually:
+  This doesn't scale when using QT_SCALE_FACTOR manually:
   font-size: 10pt;	*/
   font-size: 13px/13px;
   font-weight: bold;

--- a/res/skins/Tango (64 Samplers)/skin.xml
+++ b/res/skins/Tango (64 Samplers)/skin.xml
@@ -362,10 +362,10 @@
       </Children>
     </SingletonDefinition>
 
-<!--  ################################################################
-       SkinContainer  ###############################################
-      skin incl. invisble size detector for deck Stars #############
-     ############################################################## -->
+<!--  ##############################################################
+      SkinContainer  ###############################################
+      skin incl. invisible size detector for deck Stars ############
+      ############################################################## -->
     <WidgetGroup>
       <ObjectName>SkinContainer</ObjectName>
       <Layout>vertical</Layout>
@@ -568,6 +568,6 @@
       </Children>
     </WidgetGroup>
     <!-- SkinContainer -->
-    <!-- /skin incl. invisble size detector for deck Stars -->
+    <!-- /skin incl. invisible size detector for deck Stars -->
   </Children>
 </skin>

--- a/res/skins/Tango (64 Samplers)/skin_settings.xml
+++ b/res/skins/Tango (64 Samplers)/skin_settings.xml
@@ -95,7 +95,7 @@ Description:
                   <!-- index 0 due to bug -->
                   <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
 
-                  <WidgetGroup><!-- translucent cover when Hot Cues are invisble -->
+                  <WidgetGroup><!-- translucent cover when Hot Cues are invisible -->
                     <ObjectName>SubmenuCover</ObjectName>
                     <Layout>vertical</Layout>
                     <Size>182f,13me</Size>
@@ -704,7 +704,7 @@ Description:
               <!-- index 0 due to bug -->
               <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
 
-              <!-- translucent cover when Effects are invisble -->
+              <!-- translucent cover when Effects are invisible -->
               <WidgetGroup>
                 <ObjectName>SubmenuCover</ObjectName>
                 <Layout>vertical</Layout>

--- a/res/skins/Tango/size_detector_deck_controls_toggle.xml
+++ b/res/skins/Tango/size_detector_deck_controls_toggle.xml
@@ -2,7 +2,7 @@
 Description:
   Size-aware container that hides the toggle for deck controls if it is not
   necessary (when all deck controls are permanently visible).
-  Overall width of all controls is XYpx, the SizeAwareStack fills remainig space.
+  Overall width of all controls is XYpx, the SizeAwareStack fills remaining space.
   If it can grow broader than 1px the toggle should be visible.
 
 -->

--- a/res/skins/Tango/skin.xml
+++ b/res/skins/Tango/skin.xml
@@ -356,10 +356,10 @@
       </Children>
     </SingletonDefinition>
 
-<!--  ################################################################
-       SkinContainer  ###############################################
-      skin incl. invisble size detector for deck Stars #############
-     ############################################################## -->
+<!--  ##############################################################
+      SkinContainer ################################################
+      skin incl. invisible size detector for deck Stars ############
+      ############################################################## -->
     <WidgetGroup>
       <ObjectName>SkinContainer</ObjectName>
       <Layout>vertical</Layout>
@@ -560,6 +560,6 @@
       </Children>
     </WidgetGroup>
     <!-- SkinContainer -->
-    <!-- /skin incl. invisble size detector for deck Stars -->
+    <!-- /skin incl. invisible size detector for deck Stars -->
   </Children>
 </skin>

--- a/res/skins/Tango/skin_settings.xml
+++ b/res/skins/Tango/skin_settings.xml
@@ -95,7 +95,7 @@ Description:
                   <!-- index 0 due to bug -->
                   <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
 
-                  <!-- translucent cover when Hot Cues are invisble -->
+                  <!-- translucent cover when Hot Cues are invisible -->
                   <WidgetGroup>
                     <ObjectName>SubmenuCover</ObjectName>
                     <Layout>vertical</Layout>
@@ -705,7 +705,7 @@ Description:
               <!-- index 0 due to bug -->
               <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
 
-              <!-- translucent cover when Effects are invisble -->
+              <!-- translucent cover when Effects are invisible -->
               <WidgetGroup>
                 <ObjectName>SubmenuCover</ObjectName>
                 <Layout>vertical</Layout>

--- a/scripts/qsscheck.py
+++ b/scripts/qsscheck.py
@@ -392,7 +392,7 @@ def main(argv=None):
     parser.add_argument(
         "-p",
         "--extra-skins-path",
-        help="Additonal skin path, to check (.e.g. ~/.mixxx/skins)",
+        help="Additional skin path, to check (.e.g. ~/.mixxx/skins)",
     )
     parser.add_argument("-s", "--skin", help="Only check skin with this name")
     parser.add_argument(

--- a/src/controllers/colormapper.cpp
+++ b/src/controllers/colormapper.cpp
@@ -15,7 +15,7 @@ double colorDistance(QRgb a, QRgb b) {
     // of colors into account. More accurate algorithms like the CIELAB2000
     // Delta-E rely on sophisticated color space conversions and need a lot
     // of costly computations. In contrast, this is a low-cost
-    // approximation and should be sufficently accurate.
+    // approximation and should be sufficiently accurate.
     // More details: https://www.compuphase.com/cmetric.htm
     long mean_red = (static_cast<long>(qRed(a)) + static_cast<long>(qRed(b))) / 2;
     long delta_red = static_cast<long>(qRed(a)) - static_cast<long>(qRed(b));

--- a/src/controllers/dlgprefcontroller.h
+++ b/src/controllers/dlgprefcontroller.h
@@ -80,7 +80,7 @@ class DlgPrefController : public DlgPreferencePage {
 
     /// Set dirty state (i.e. changes have been made).
     ///
-    /// When this preferences page is marked as "dirty", changes have occured
+    /// When this preferences page is marked as "dirty", changes have occurred
     /// that can be applied or discarded.
     ///
     /// @param bDirty The new dialog's dirty state.
@@ -90,7 +90,7 @@ class DlgPrefController : public DlgPreferencePage {
 
     /// Set dirty state (i.e. changes have been made).
     ///
-    /// When this preferences page is marked as "dirty", changes have occured
+    /// When this preferences page is marked as "dirty", changes have occurred
     /// that can be applied or discarded.
     ///
     /// @param bDirty The new dialog's dirty state.

--- a/src/encoder/encoderwave.cpp
+++ b/src/encoder/encoderwave.cpp
@@ -14,7 +14,7 @@
 #include "recording/defs_recording.h"
 
 
-// The virtual file contex must return the length of the virtual file in bytes.
+// The virtual file context must return the length of the virtual file in bytes.
 static sf_count_t  sf_f_get_filelen (void *user_data)
 {
     EncoderCallback* pCallback = static_cast<EncoderCallback*>(user_data);

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1361,7 +1361,7 @@ double EngineBuffer::getExactPlayPos() {
         return getVisualPlayPos() * getTrackSamples();
     } else {
         // Track was just loaded and the first buffer was not processed yet.
-        // asume it is at 0:00
+        // assume it is at 0:00
         return 0.0;
     }
 }

--- a/src/engine/sync/internalclock.cpp
+++ b/src/engine/sync/internalclock.cpp
@@ -75,7 +75,7 @@ void InternalClock::slotSyncMasterEnabledChangeRequest(double state) {
             return;
         }
         if (mode == SYNC_MASTER_SOFT) {
-            // user request: make master explicite
+            // user request: make master explicit
             m_mode = SYNC_MASTER_EXPLICIT;
             return;
         }

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -239,7 +239,7 @@ void SyncControl::setMasterParams(
         double beatDistance, double baseBpm, double bpm) {
     double masterBpmAdjustFactor = determineBpmMultiplier(fileBpm(), baseBpm);
     if (isMaster(getSyncMode())) {
-        // In Master mode we adjust the incomming Bpm for the inital sync.
+        // In Master mode we adjust the incoming Bpm for the initial sync.
         bpm *= masterBpmAdjustFactor;
         m_masterBpmAdjustFactor = kBpmUnity;
     } else {
@@ -337,7 +337,7 @@ void SyncControl::trackBeatsUpdated(BeatsPointer pBeats) {
     }
 
     VERIFY_OR_DEBUG_ASSERT(m_pLocalBpm) {
-        // object not initalized
+        // object not initialized
         return;
     }
 
@@ -400,7 +400,7 @@ void SyncControl::slotSyncMasterEnabledChangeRequest(double state) {
             return;
         }
         if (mode == SYNC_MASTER_SOFT) {
-            // user request: make master explicite
+            // user request: make master explicit
             m_pSyncMode->setAndConfirm(SYNC_MASTER_EXPLICIT);
             return;
         }
@@ -452,7 +452,7 @@ void SyncControl::setLocalBpm(double local_bpm) {
         m_pEngineSync->requestBpmUpdate(this, bpm);
     } else {
         DEBUG_ASSERT(isMaster(syncMode));
-        // We might have adopted an adjust factor when becomming master.
+        // We might have adopted an adjust factor when becoming master.
         // Keep it when reporting our bpm.
         m_pEngineSync->notifyBpmChanged(this, bpm / m_masterBpmAdjustFactor);
     }

--- a/src/library/basecoverartdelegate.h
+++ b/src/library/basecoverartdelegate.h
@@ -36,7 +36,7 @@ class BaseCoverArtDelegate : public TableItemDelegate {
     // (background) color is painted.
     //
     // It is useful to handle cases when the user scroll down
-    // very fast or when they hold an arrow key. In thise case
+    // very fast or when they hold an arrow key. In this case
     // it is NOT desirable to start multiple expensive file
     // system operations in worker threads for loading and
     // scaling cover images that are not even displayed after

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1296,7 +1296,7 @@ TrackPointer TrackDAO::getTrackById(TrackId trackId) const {
 
     // Listen to signals from Track objects and forward them to
     // receivers. TrackDAO works as a relay for selected track signals
-    // that allows receivers to use permament connections with
+    // that allows receivers to use permanent connections with
     // TrackDAO instead of connecting to individual Track objects.
     connect(pTrack.get(),
             &Track::dirty,

--- a/src/library/externaltrackcollection.h
+++ b/src/library/externaltrackcollection.h
@@ -58,7 +58,7 @@ Q_OBJECT
         Disconnected,
     };
 
-    // Check if the connection to the extenal track collection
+    // Check if the connection to the external track collection
     // has been established, i.e. if the synchronization is active.
     virtual ConnectionState connectionState() const = 0;
 

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -164,7 +164,7 @@ Library::Library(
     // TODO(XXX) Rekordbox feature added persistently as the only way to enable it to
     // dynamically appear/disappear when correctly prepared removable devices
     // are mounted/unmounted would be to have some form of timed thread to check
-    // periodically. Not ideal perfomance wise.
+    // periodically. Not ideal performance wise.
     if (m_pConfig->getValue(ConfigKey(kConfigGroup, "ShowRekordboxLibrary"), true)) {
         addFeature(new RekordboxFeature(this, m_pConfig));
     }

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -891,7 +891,7 @@ void readAnalyze(TrackPointer track, double sampleRate, int timingOffset, bool i
                         memoryCues << memoryCue;
                     } break;
                     case rekordbox_anlz_t::CUE_ENTRY_TYPE_LOOP: {
-                        // As Mixxx can only have 1 saved loop, use the first occurance of a memory loop relative to the start of the track
+                        // As Mixxx can only have 1 saved loop, use the first occurrence of a memory loop relative to the start of the track
                         if (position < cueLoopStartPosition) {
                             cueLoopStartPosition = position;
                             int endTime = static_cast<int>((*cueEntry)->loop_time()) - timingOffset;
@@ -936,7 +936,7 @@ void readAnalyze(TrackPointer track, double sampleRate, int timingOffset, bool i
                         memoryCues << memoryCue;
                     } break;
                     case rekordbox_anlz_t::CUE_ENTRY_TYPE_LOOP: {
-                        // As Mixxx can only have 1 saved loop, use the first occurance of a memory loop relative to the start of the track
+                        // As Mixxx can only have 1 saved loop, use the first occurrence of a memory loop relative to the start of the track
                         if (position < cueLoopStartPosition) {
                             cueLoopStartPosition = position;
                             int endTime = static_cast<int>((*cueExtendedEntry)->loop_time()) - timingOffset;
@@ -1051,7 +1051,7 @@ TrackPointer RekordboxPlaylistModel::getTrack(const QModelIndex& index) const {
     // exported from Rekordbox. This is caused by different MP3
     // decoders treating MP3s encoded in a variety of different cases
     // differently. The mp3guessenc library is used to determine which
-    // case the MP3 is clasified in. See the following PR for more
+    // case the MP3 is classified in. See the following PR for more
     // detailed information:
     // https://github.com/mixxxdj/mixxx/pull/2119
 

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -427,7 +427,7 @@ void LibraryScanner::cancelAndQuit() {
     changeScannerState(CANCELING);
     cancel();
     // Quit the event loop gracefully and stay in CANCELING state until all
-    // pendig signals are processed
+    // pending signals are processed
     quit();
     wait();
     changeScannerState(IDLE);

--- a/src/library/serato/seratofeature.cpp
+++ b/src/library/serato/seratofeature.cpp
@@ -34,7 +34,7 @@
 namespace {
 
 // Serato Database Field IDs
-// The "magic" value is the short 4 byte ascii code intepreted as quint32, so
+// The "magic" value is the short 4 byte ascii code interpreted as quint32, so
 // that we can use the value in a switch statement instead of going through
 // a strcmp if/else ladder.
 enum class FieldId : quint32 {

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -65,7 +65,7 @@ TrackCollectionManager::TrackCollectionManager(
     // TODO: Extract and decouple LibraryScanner from TrackCollectionManager
     if (deleteTrackForTestingFn) {
         // Exclude the library scanner from tests
-        kLogger.info() << "Libary scanner is disabled in test mode";
+        kLogger.info() << "Library scanner is disabled in test mode";
     } else {
         m_pScanner = std::make_unique<LibraryScanner>(pDbConnectionPool, pConfig);
 
@@ -179,7 +179,7 @@ bool TrackCollectionManager::saveTrack(const TrackPointer& pTrack) {
 }
 
 // Export metadata and save the track in both the internal database
-// and external libaries.
+// and external libraries.
 void TrackCollectionManager::saveEvictedTrack(Track* pTrack) noexcept {
     saveTrack(pTrack, TrackMetadataExportMode::Immediate);
 }

--- a/src/network/webtask.cpp
+++ b/src/network/webtask.cpp
@@ -193,7 +193,7 @@ void WebTask::slotStart(int timeoutMillis) {
         return;
     }
     // Still idle after the request has been started
-    // successfully, i.e. nothing happend yet in this
+    // successfully, i.e. nothing happened yet in this
     // thread.
     DEBUG_ASSERT(m_status == Status::Idle);
     m_status = Status::Pending;

--- a/src/network/webtask.h
+++ b/src/network/webtask.h
@@ -187,7 +187,7 @@ class WebTask : public QObject {
 
     // Handle status change requests by aborting a running request
     // and return the request URL. If no request is running or if
-    // the request has already been finished tha QUrl() must be
+    // the request has already been finished the QUrl() must be
     // returned.
     virtual QUrl doAbort() = 0;
     virtual QUrl doTimeOut() = 0;

--- a/src/skin/launchimage.h
+++ b/src/skin/launchimage.h
@@ -9,7 +9,7 @@ class QProgressBar;
 // until the skin is ready to use.
 // It shows a centered Image and a progress bar below.
 // By default a symbolic Mixxx icon and logo is shown.
-// It can be modified in the skin.xml file at <skin> sction,
+// It can be modified in the skin.xml file at <skin> section,
 // to match the skin like that:
 //    <LaunchImageStyle>
 //        LaunchImage { background-color: #202020; }

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -613,7 +613,7 @@ QWidget* LegacySkinParser::parseSplitter(const QDomElement& node) {
     m_pParent = pSplitter;
 
     if (!childrenNode.isNull()) {
-        // Descend chilren
+        // Descend children
         QDomNodeList children = childrenNode.childNodes();
 
         for (int i = 0; i < children.count(); ++i) {
@@ -724,7 +724,7 @@ QWidget* LegacySkinParser::parseWidgetStack(const QDomElement& node) {
 
     QDomNode childrenNode = m_pContext->selectNode(node, "Children");
     if (!childrenNode.isNull()) {
-        // Descend chilren
+        // Descend children
         QDomNodeList children = childrenNode.childNodes();
 
         for (int i = 0; i < children.count(); ++i) {
@@ -798,7 +798,7 @@ QWidget* LegacySkinParser::parseSizeAwareStack(const QDomElement& node) {
 
     QDomNode childrenNode = m_pContext->selectNode(node, "Children");
     if (!childrenNode.isNull()) {
-        // Descend chilren
+        // Descend children
         QDomNodeList children = childrenNode.childNodes();
 
         for (int i = 0; i < children.count(); ++i) {
@@ -1277,7 +1277,7 @@ void LegacySkinParser::parseSingletonDefinition(const QDomElement& node) {
                 << "SingletonDefinition requires a Children tag with one child";
     }
 
-    // Descend chilren, taking the first valid element.
+    // Descend children, taking the first valid element.
     QDomNode child_node;
     QDomNodeList children = childrenNode.childNodes();
     for (int i = 0; i < children.count(); ++i) {

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -32,7 +32,7 @@ class SkinContext {
             const SkinContext* parent);
     virtual ~SkinContext();
 
-    // Not copyable
+    // Not copiable
     SkinContext(const SkinContext&) = delete;
     SkinContext& operator=(const SkinContext&) = delete;
 

--- a/src/sources/soundsourcewv.h
+++ b/src/sources/soundsourcewv.h
@@ -36,7 +36,7 @@ class SoundSourceWV : public SoundSource {
     // A WavpackContext* type
     // we cannot use the type directly, because it has 
     // changing definitions with different wavpack.h versions. 
-    // wavpack.h can't be included here, bacause it has concurrent definitions 
+    // wavpack.h can't be included here, because it has concurrent definitions 
     // with other decoder's header.     
     void* m_wpc;
  

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -1529,7 +1529,7 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
     ProcessBuffer();
 
     // We expect that the second deck (master) has adjusted the "beat_distance" of the
-    // internal clock and the fist deck is advanced sightly but slower to slowly get
+    // internal clock and the fist deck is advanced slightly but slower to slowly get
     // rid of the additional buffer ahead
     // TODO: It does sounds odd to start the track 1 at a random position and adjust the
     // phase later. Seeking into phase is the best option even with quantize off.
@@ -1803,7 +1803,7 @@ TEST_F(EngineSyncTest, QuantizeImpliesSyncPhase) {
     EXPECT_DOUBLE_EQ(130, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
     EXPECT_DOUBLE_EQ(100, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
 
-    // we aligne here to the past beat, because beat_distance < 1.0/8
+    // we align here to the past beat, because beat_distance < 1.0/8
     EXPECT_DOUBLE_EQ(
             ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")) / 130 * 100,
             ControlObject::get(ConfigKey(m_sGroup2, "beat_distance")));

--- a/src/track/serato/tags.cpp
+++ b/src/track/serato/tags.cpp
@@ -108,7 +108,7 @@ double SeratoTags::findTimingOffsetMillis(const QString& filePath) {
     // correctly align timing information (e.g. cue points) exported from
     // Serato. This is caused by different MP3 decoders treating MP3s encoded
     // in a variety of different cases differently. The mp3guessenc library is
-    // used to determine which case the MP3 is clasified in. See the following
+    // used to determine which case the MP3 is classified in. See the following
     // PR for more detailed information:
     // https://github.com/mixxxdj/mixxx/pull/2119
 

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -943,7 +943,7 @@ void Track::importPendingCueInfosMarkDirtyAndUnlock(
         return;
     }
     // The sample rate can only be trusted after the audio
-    // stream has been openend.
+    // stream has been opened.
     DEBUG_ASSERT(m_streamInfo);
     const auto sampleRate =
             m_streamInfo->getSignalInfo().getSampleRate();

--- a/src/util/assert.h
+++ b/src/util/assert.h
@@ -57,6 +57,6 @@ inline void mixxx_release_assert(const char* assertion, const char* file, int li
 #define DEBUG_ASSERT(cond)
 #endif
 
-/// Same as DEBUG_ASSERT, but if MIXXX_DEBUG_ASSERTIONS_FATAL is disabled run the specified fallback funtion.
+/// Same as DEBUG_ASSERT, but if MIXXX_DEBUG_ASSERTIONS_FATAL is disabled run the specified fallback function.
 /// In most cases you should probably use this rather than DEBUG_ASSERT. Only use DEBUG_ASSERT if there is no appropriate fallback.
 #define VERIFY_OR_DEBUG_ASSERT(cond) if ((!(cond)) && mixxx_maybe_debug_assert_return_true(#cond, __FILE__, __LINE__, ASSERT_FUNCTION))

--- a/src/waveform/renderers/waveformmarkrange.h
+++ b/src/waveform/renderers/waveformmarkrange.h
@@ -19,7 +19,7 @@ class WaveformMarkRange {
             const QDomNode& node,
             const SkinContext& context,
             const WaveformSignalColors& signalColors);
-    // This class is only moveable, but not copyable!
+    // This class is only moveable, but not copiable!
     WaveformMarkRange(WaveformMarkRange&&) = default;
     WaveformMarkRange(const WaveformMarkRange&) = delete;
 

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -835,7 +835,7 @@ void WOverview::drawMarks(QPainter* pPainter, const float offset, const float ga
                 }
             }
             // Sometimes QFontMetrics::elidedText turns the QString into just an
-            // elipsis character, so always show at least the hotcue number if
+            // ellipsis character, so always show at least the hotcue number if
             // the label does not fit.
             if ((text.isEmpty() || text == "…") && pMark->getHotCue() != Cue::kNoHotCue) {
                 text = QString::number(pMark->getHotCue() + 1);


### PR DESCRIPTION
Found via codespell v1.17.0.dev0  
```
codespell -q 3 -S *.ts,*.po,*.rtf,./.git,./src/library,./lib,./build/wix -L ba,chang,ect,everytime,german,hace,iff,jus,ith,lokal,nd,ons,pevent,pparent,preverse,seeked,sheat,sinc,splitted,substract,thru,tim,uint
```