### PR TITLE
AnalyzerKeyFinder: only record final key

### DIFF
--- a/src/analyzer/plugins/analyzerkeyfinder.cpp
+++ b/src/analyzer/plugins/analyzerkeyfinder.cpp
@@ -101,11 +101,6 @@ bool AnalyzerKeyFinder::processSamples(const CSAMPLE* pIn, const int iLen) {
         }
     }
     m_keyFinder.progressiveChromagram(m_audioData, m_workspace);
-    ChromaticKey key = chromaticKeyFromKeyFinderKeyT(
-            m_keyFinder.keyOfChromagram(m_workspace));
-    if (key != m_previousKey) {
-        m_resultKeys.push_back(qMakePair(key, m_currentFrame));
-    }
     return true;
 }
 

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -407,6 +407,11 @@ ChromaticKey KeyUtils::scaleKeySteps(ChromaticKey key, int key_changes) {
 // static
 mixxx::track::io::key::ChromaticKey KeyUtils::calculateGlobalKey(
     const KeyChangeList& key_changes, const int iTotalSamples, int iSampleRate) {
+    if (key_changes.size() == 1) {
+        qDebug() << keyDebugName(key_changes[0].first);
+        return key_changes[0].first;
+    }
+
     const int iTotalFrames = iTotalSamples / 2;
     QMap<mixxx::track::io::key::ChromaticKey, double> key_histogram;
 


### PR DESCRIPTION
This is how the KeyFinder GUI application (is_KeyFinder) uses the library. Apparently this is approximately as accurate as the current implementation https://github.com/mixxxdj/mixxx/pull/2689#issuecomment-620601604