### PR TITLE
Sync Lock: prevent setting explicit leader to stopped decks

### DIFF
--- a/res/skins/LateNight/deck_rate_controls.xml
+++ b/res/skins/LateNight/deck_rate_controls.xml
@@ -190,7 +190,7 @@
                 <SetVariable name="Size">52f,26f</SetVariable>
                 <SetVariable name="btn_format">wide</SetVariable>
                 <SetVariable name="ConfigKey"><Variable name="group"/>,sync_enabled</SetVariable>
-                <SetVariable name="ConfigKeyRight"><Variable name="group"/>,beatsync_tempo</SetVariable>
+                <SetVariable name="ConfigKeyRight"><Variable name="group"/>,sync_master</SetVariable>
               </Template>
             </Children>
           </WidgetGroup>

--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -40,7 +40,10 @@ EngineSync::~EngineSync() {
 
 Syncable* EngineSync::pickMaster(Syncable* enabling_syncable) {
     // If there is an explicit master, and it is playing, keep it.
-    if (m_pMasterSyncable && m_pMasterSyncable->getSyncMode() == SYNC_MASTER_EXPLICIT) {
+    if (m_pMasterSyncable &&
+            m_pMasterSyncable->getSyncMode() == SYNC_MASTER_EXPLICIT &&
+            (m_pMasterSyncable->isPlaying() ||
+                    m_pMasterSyncable == m_pInternalClock)) {
         return m_pMasterSyncable;
     }
 


### PR DESCRIPTION
adjusted tests to match the new behavior