### PR TITLE
restore/add F11 to toggle fullscreen

### DIFF
--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -265,7 +265,11 @@ void WMainMenuBar::initialize() {
     QString fullScreenTitle = tr("&Full Screen");
     QString fullScreenText = tr("Display Mixxx using the full screen");
     auto pViewFullScreen = new QAction(fullScreenTitle, this);
-    pViewFullScreen->setShortcut(QKeySequence(QKeySequence::FullScreen));
+    QList<QKeySequence> shortcuts;
+    shortcuts << QKeySequence::FullScreen;
+    shortcuts << QKeySequence("F11");
+
+    pViewFullScreen->setShortcuts(shortcuts);
     pViewFullScreen->setShortcutContext(Qt::ApplicationShortcut);
     pViewFullScreen->setCheckable(true);
     pViewFullScreen->setChecked(false);


### PR DESCRIPTION
... in addition to the system default set by Qt according to the OS / desktop environment used. https://github.com/mixxxdj/mixxx/pull/2735#issuecomment-623171144

1) to restore previous Linux shortcut
2) to have it as additional shortcut on OS where QKeySequence::FullScreen is not set (for example Ubuntu Studio 20.04 as of 2020-05-04)