### PR TITLE
Enable SoundSourceFFmpeg as a fallback for broken FAAD v2.9.1

### DIFF
--- a/src/library/relocatedtrack.h
+++ b/src/library/relocatedtrack.h
@@ -19,11 +19,12 @@ class RelocatedTrack final {
         DEBUG_ASSERT(m_missingTrackRef.isValid());
         DEBUG_ASSERT(m_missingTrackRef.hasId());
         DEBUG_ASSERT(m_missingTrackRef.hasLocation());
-        DEBUG_ASSERT(m_addedTrackRef.isValid());
-        // NOTE(uklotzde, 2019-12-16):
-        // m_addedTrackRef might not have a valid TrackId
-        // if the relocated track has not been added as a
-        // new track to the internal collection before.
+        // NOTE: m_addedTrackRef might not be valid!
+        // It might not have a valid TrackId if the relocated track has
+        // not been added as a new track to the internal collection before.
+        // It may also not have a valid canonical location, e.g. when
+        // relinking directories and the track is missing at both the old
+        // and the new location.
         DEBUG_ASSERT(m_addedTrackRef.hasLocation());
         DEBUG_ASSERT(updatedTrackRef().isValid());
         DEBUG_ASSERT(updatedTrackRef().hasId());

--- a/src/sources/audiosource.cpp
+++ b/src/sources/audiosource.cpp
@@ -8,7 +8,11 @@ namespace {
 
 const Logger kLogger("AudioSource");
 
-const SINT kVerifyReadableFrameCount = 1;
+// Maximum number of sample frames to verify that decoding the audio
+// stream works.
+// NOTE(2020-05-01): A single frame is sufficient to reliably detect
+// the broken FAAD2 v2.9.1 library.
+const SINT kVerifyReadableMaxFrameCount = 1;
 
 } // anonymous namespace
 
@@ -191,7 +195,7 @@ bool AudioSource::verifyReadable() {
     // Counterexample: The broken FAAD version 2.9.1 is able to open a file
     // but then fails to decode any sample frames.
     const SINT numSampleFrames =
-            math_min(kVerifyReadableFrameCount, frameIndexRange().length());
+            math_min(kVerifyReadableMaxFrameCount, frameIndexRange().length());
     SampleBuffer sampleBuffer(
             m_signalInfo.frames2samples(numSampleFrames));
     WritableSampleFrames writableSampleFrames(

--- a/src/sources/audiosource.cpp
+++ b/src/sources/audiosource.cpp
@@ -181,7 +181,7 @@ bool AudioSource::verifyReadable() {
     }
     if (frameIndexRange().empty()) {
         kLogger.warning()
-                << "No audio data available";
+                << "No audio data available, i.e. stream is empty";
         // Don't return false, even if reading from an empty source
         // is pointless. It is still a valid audio stream.
         return true;

--- a/src/sources/audiosource.cpp
+++ b/src/sources/audiosource.cpp
@@ -8,6 +8,8 @@ namespace {
 
 const Logger kLogger("AudioSource");
 
+const SINT kVerifyReadableFrameCount = 1;
+
 } // anonymous namespace
 
 AudioSource::AudioSource(QUrl url)
@@ -132,7 +134,9 @@ bool AudioSource::initBitrateOnce(audio::Bitrate bitrate) {
     return true;
 }
 
-bool AudioSource::verifyReadable() const {
+bool AudioSource::verifyReadable() {
+    // No early return desired! All tests should be performed, even
+    // if some fail.
     bool result = true;
     DEBUG_ASSERT(m_signalInfo.getSampleLayout());
     if (!m_signalInfo.getChannelCount().isValid()) {
@@ -170,13 +174,45 @@ bool AudioSource::verifyReadable() const {
             // to decode audio data!
         }
     }
+    if (!result) {
+        // Invalid or inconsistent properties detected. We can abort
+        // at this point and do not need to perform any read tests.
+        return false;
+    }
     if (frameIndexRange().empty()) {
         kLogger.warning()
                 << "No audio data available";
-        // Don't set the result to false, even if reading from an
-        // empty source is pointless!
+        // Don't return false, even if reading from an empty source
+        // is pointless. It is still a valid audio stream.
+        return true;
     }
-    return result;
+    // Try to read the some test frames to ensure that decoding actually
+    // works!
+    //
+    // Counterexample: The broken FAAD version 2.9.1 is able to open
+    // a file but then fails to decode any sample frames.
+    const SINT numSampleFrames =
+            math_min(kVerifyReadableFrameCount, frameIndexRange().length());
+    SampleBuffer sampleBuffer(
+            m_signalInfo.frames2samples(numSampleFrames));
+    WritableSampleFrames writableSampleFrames(
+            frameIndexRange().splitAndShrinkFront(numSampleFrames),
+            SampleBuffer::WritableSlice(sampleBuffer));
+    auto readableSampleFrames = readSampleFrames(writableSampleFrames);
+    DEBUG_ASSERT(
+            readableSampleFrames.frameIndexRange() <=
+            writableSampleFrames.frameIndexRange());
+    if (readableSampleFrames.frameIndexRange() <
+            writableSampleFrames.frameIndexRange()) {
+        kLogger.warning()
+                << "Read test failed:"
+                << "expected ="
+                << writableSampleFrames.frameIndexRange()
+                << ", actual ="
+                << readableSampleFrames.frameIndexRange();
+        return false;
+    }
+    return true;
 }
 
 WritableSampleFrames AudioSource::clampWritableSampleFrames(

--- a/src/sources/audiosource.cpp
+++ b/src/sources/audiosource.cpp
@@ -186,11 +186,10 @@ bool AudioSource::verifyReadable() {
         // is pointless. It is still a valid audio stream.
         return true;
     }
-    // Try to read the some test frames to ensure that decoding actually
-    // works!
+    // Try to read some test frames to ensure that decoding actually works!
     //
-    // Counterexample: The broken FAAD version 2.9.1 is able to open
-    // a file but then fails to decode any sample frames.
+    // Counterexample: The broken FAAD version 2.9.1 is able to open a file
+    // but then fails to decode any sample frames.
     const SINT numSampleFrames =
             math_min(kVerifyReadableFrameCount, frameIndexRange().length());
     SampleBuffer sampleBuffer(

--- a/src/sources/audiosource.h
+++ b/src/sources/audiosource.h
@@ -151,32 +151,50 @@ class AudioSource : public UrlResource, public virtual /*implements*/ IAudioSour
     // left and right channel respectively.
     static constexpr audio::SampleLayout kSampleLayout = mixxx::kEngineSampleLayout;
 
+    /// Defines how thoroughly the stream properties should be verified
+    /// when opening an audio stream.
     enum class OpenMode {
-        // In Strict mode the opening operation should be aborted
-        // as soon as any inconsistencies are detected.
+        /// In Strict mode the opening operation should be aborted
+        /// as soon as any inconsistencies of the stream properties
+        /// are detected when setting up the decoding.
         Strict,
-        // Opening in Permissive mode is used only after opening
-        // in Strict mode has been aborted by all available
-        // SoundSource implementations.
+
+        /// Opening in Permissive mode is used only after opening
+        /// in Strict mode has been aborted by all available
+        /// SoundSource implementations.
+        ///
+        /// Example: Assume safe default values if mandatory stream
+        /// properties could not be determined when setting up the
+        /// decoding.
         Permissive,
     };
 
+    /// Result of opening an audio stream.
     enum class OpenResult {
+        /// The file has been opened successfully and should be readable.
         Succeeded,
-        // If a SoundSource is not able to open a file because of
-        // internal errors of if the format of the content is not
-        // supported it should return Aborted. This gives SoundSources
-        // with a lower priority the chance to open the same file.
-        // Example: A SoundSourceProvider has been registered for
-        // files with a certain extension, but the corresponding
-        // SoundSource does only support a subset of all possible
-        // data formats that might be stored in files with this
-        // extension.
+
+        /// If a SoundSource is not able to open a file because of
+        /// internal errors of if the format of the content is not
+        /// supported it should return Aborted.
+        ///
+        /// Returing this error result gives other decoders with a
+        /// lower priority the chance to open the same file.
+        /// Example: A SoundSourceProvider has been registered for
+        /// files with a certain extension, but the corresponding
+        /// SoundSource does only support a subset of all possible
+        /// data formats that might be stored in files with this
+        /// extension.
+
         Aborted,
-        // If a SoundSource return Failed while opening a file
-        // the entire operation will fail immediately. No other
-        // sources with lower priority will be given the chance
-        // to open the same file.
+        /// If a SoundSource return Failed while opening a file the
+        /// file itself is supposed to be corrupt.
+        ///
+        /// If this happens during OpenMode::Strict then other decoders
+        /// with a lower priority are still given a chance to try
+        /// opening the file. In OpenMode::Permissive the first
+        /// SoundSource that returns Failed will declare this file
+        /// corrupt.
         Failed,
     };
 

--- a/src/sources/audiosource.h
+++ b/src/sources/audiosource.h
@@ -286,10 +286,11 @@ class AudioSource : public UrlResource, public virtual /*implements*/ IAudioSour
         return getSignalInfo().frames2secs(frameLength());
     }
 
-    // Verifies various properties to ensure that the audio data is
-    // actually readable. Warning messages are logged for properties
-    // with invalid values for diagnostic purposes.
-    bool verifyReadable() const;
+    /// Verifies various properties to ensure that the audio data is
+    /// actually readable. Warning messages are logged for properties
+    /// with invalid values for diagnostic purposes. Also performs a
+    /// basic read test.
+    bool verifyReadable();
 
     ReadableSampleFrames readSampleFrames(
             WritableSampleFrames sampleFrames);

--- a/src/sources/soundsourcem4a.h
+++ b/src/sources/soundsourcem4a.h
@@ -18,6 +18,14 @@
 
 namespace mixxx {
 
+/// Decode M4A (AAC in MP4) files using FAAD2.
+///
+/// NOTE(2020-05-01): Decoding in version v2.9.1 of the library
+/// is broken and any attempt to open files will fail.
+///
+/// https://github.com/mixxxdj/mixxx/pull/2738
+/// https://github.com/knik0/faad2/commit/a8dc3f8ce67f4069cfa4d5cf0fcc2c6e8ef2c2aa
+/// https://github.com/knik0/faad2/commit/920ec985a74c6f88fe507181df07a0cd7e51d519
 class SoundSourceM4A : public SoundSource {
   public:
     explicit SoundSourceM4A(const QUrl& url);

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -481,7 +481,9 @@ QImage SoundSourceProxy::importCoverImage() const {
 mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const mixxx::AudioSource::OpenParams& params) {
     DEBUG_ASSERT(m_pTrack);
     auto openMode = mixxx::SoundSource::OpenMode::Strict;
+    int attemptCount = 0;
     while (m_pSoundSource && !m_pAudioSource) {
+        ++attemptCount;
         const mixxx::SoundSource::OpenResult openResult =
                 m_pSoundSource->open(openMode, params);
         if (openResult == mixxx::SoundSource::OpenResult::Succeeded) {
@@ -543,8 +545,11 @@ mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const mixxx::AudioSo
     // All available providers have returned OpenResult::Aborted when
     // getting here. m_pSoundSource might already be invalid/null!
     kLogger.warning()
-            << "Unable to decode file"
-            << getUrl().toString();
+            << "Giving up to open file"
+            << getUrl().toString()
+            << "after"
+            << attemptCount
+            << "unsuccessful attempts";
     DEBUG_ASSERT(!m_pAudioSource);
     return m_pAudioSource;
 }

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -498,11 +498,6 @@ mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const mixxx::AudioSo
             if (m_pSoundSource->verifyReadable()) {
                 m_pAudioSource = mixxx::AudioSourceTrackProxy::create(m_pTrack, m_pSoundSource);
                 DEBUG_ASSERT(m_pAudioSource);
-                if (m_pAudioSource->frameIndexRange().empty()) {
-                    kLogger.warning()
-                            << "File is empty"
-                            << getUrl().toString();
-                }
                 // Overwrite metadata with actual audio properties
                 if (m_pTrack) {
                     m_pTrack->updateAudioPropertiesFromStream(


### PR DESCRIPTION
SoundSourceM4A fails to decode any audio data after successfully opening the file. Mixxx loads .m4a files but then displays an empty waveform and the audio stream becomes empty after trying to decode it.

This PR adds a basic read test to verify that the audio stream is actually readable. Otherwise sound sources with a lower priority get the chance to open the file. This wasn't possible before.

Tested with Fedora 32. RPMFusion distributes the broken FAAD v2.9.1 library like Arch does.

A backport to 2.2.x would be nice, but requires too much work. If anyone feels responsible to do this feel free to take this commit as a starting point. I will not invest any time to do this, neither for the implementation **nor for a review**!

Links:
https://www.mixxx.org/forums/viewtopic.php?f=3&t=13102
https://www.mixxx.org/forums/viewtopic.php?f=3&t=13157