### PR TITLE
Fix infinite recursion for legacy ID3v2 tags

### DIFF
--- a/src/track/taglib/trackmetadata_id3v2.cpp
+++ b/src/track/taglib/trackmetadata_id3v2.cpp
@@ -645,7 +645,7 @@ void importTrackMetadataFromTag(
     DEBUG_ASSERT(pHeader);
     if (!checkHeaderVersionSupported(*pHeader)) {
         kLogger.warning() << "Legacy ID3v2 version - importing only basic tags";
-        importTrackMetadataFromTag(pTrackMetadata, tag);
+        taglib::importTrackMetadataFromTag(pTrackMetadata, tag);
         return; // done
     }
 
@@ -1015,7 +1015,7 @@ bool exportTrackMetadataIntoTag(TagLib::ID3v2::Tag* pTag,
     DEBUG_ASSERT(pHeader);
     if (!checkHeaderVersionSupported(*pHeader)) {
         kLogger.warning() << "Legacy ID3v2 version - exporting only basic tags";
-        exportTrackMetadataIntoTag(pTag, trackMetadata, WriteTagFlag::OmitNone);
+        taglib::exportTrackMetadataIntoTag(pTag, trackMetadata, WriteTagFlag::OmitNone);
         return true; // done
     }
 


### PR DESCRIPTION
We missed the branches for legacy ID3v2 tags that cause an infinite recursion.

https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/master.20crash.20SIGSEGV