### PR TITLE
Knob arcs: add options for reversed paint direction & round caps

### DIFF
--- a/src/widget/wknobcomposed.h
+++ b/src/widget/wknobcomposed.h
@@ -61,6 +61,8 @@ class WKnobComposed : public WWidget {
     QColor m_arcColor;
     QColor m_arcBgColor;
     bool m_arcUnipolar;
+    bool m_arcReversed;
+    Qt::PenCapStyle m_arcPenCap;
     WidgetRenderTimer m_renderTimer;
 
     friend class KnobEventHandler<WKnobComposed>;


### PR DESCRIPTION
Final additions to #2275 / #2686 

* `<ArcRoundCaps>` allows to use a round pen cap for drawing the arc. For regularly sized knobs this will slightly increase visibility of the arc if the knob is just a bit away from the center. For large knobs it's a style tool.
* `<ArcReversed>` paints the arc from maxAngle to current position. I will use this for the microphone Ducking knob to communicate the ducking effect. Later on, we can use this for effect knobs like BitCrusher parameters.

Ducking: round cap
Mic Pregain: flat cap
See how the knob and the arc position diverge.
![image](https://user-images.githubusercontent.com/5934199/80772798-27d6e880-8b58-11ea-8e1c-ca90c7e915fe.png)
