### PR TITLE
fix woverview playpos not being updated when clicking marker

### DIFF
--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -506,6 +506,7 @@ void WOverview::mousePressEvent(QMouseEvent* e) {
         if (m_pHoveredMark != nullptr) {
             dValue = m_pHoveredMark->getSamplePosition() / m_trackSamplesControl->get();
             m_iPickupPos = valueToPosition(dValue);
+            m_iPlayPos = m_iPickupPos;
             setControlParameterUp(dValue);
             m_bLeftClickDragging = false;
         } else {


### PR DESCRIPTION
When a marker was clicked previously when the track was paused,
the ruler jumped to the marker but the playposition of the
overview waveform (which influences the gray area) was not
getting updated. The actual playposition was updated however.
This left the playposition of the overview and the real one
out-of-sync.

You can see this happening in this screenshot:
![Screenshot from 2020-05-03 00-29-28](https://user-images.githubusercontent.com/12380386/80894782-9b0a6700-8cde-11ea-9954-bc2303cc4b41.png)