### PR TITLE
Logging Pt. 1: Prepare for QLoggingCategory

### DIFF
--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -27,6 +27,27 @@ CmdlineArgs::CmdlineArgs()
 #endif
 }
 
+namespace {
+    bool parseLogLevel(
+        QLatin1String logLevel,
+        mixxx::LogLevel *pLogLevel) {
+        if (logLevel == QLatin1String("trace")) {
+            *pLogLevel = mixxx::LogLevel::Trace;
+        } else if (logLevel == QLatin1String("debug")) {
+            *pLogLevel = mixxx::LogLevel::Debug;
+        } else if (logLevel == QLatin1String("info")) {
+            *pLogLevel = mixxx::LogLevel::Info;
+        } else if (logLevel == QLatin1String("warning")) {
+            *pLogLevel = mixxx::LogLevel::Warning;
+        } else if (logLevel == QLatin1String("critical")) {
+            *pLogLevel = mixxx::LogLevel::Critical;
+        } else {
+            return false;
+        }
+        return true;
+    }
+}
+
 bool CmdlineArgs::Parse(int &argc, char **argv) {
     bool logLevelSet = false;
     for (int i = 0; i < argc; ++i) {
@@ -61,34 +82,14 @@ bool CmdlineArgs::Parse(int &argc, char **argv) {
         } else if (argv[i] == QString("--logLevel") && i+1 < argc) {
             logLevelSet = true;
             auto level = QLatin1String(argv[i+1]);
-            if (level == "trace") {
-                m_logLevel = mixxx::LogLevel::Trace;
-            } else if (level == "debug") {
-                m_logLevel = mixxx::LogLevel::Debug;
-            } else if (level == "info") {
-                m_logLevel = mixxx::LogLevel::Info;
-            } else if (level == "warning") {
-                m_logLevel = mixxx::LogLevel::Warning;
-            } else if (level == "critical") {
-                m_logLevel = mixxx::LogLevel::Critical;
-            } else {
+            if (!parseLogLevel(level, &m_logLevel)) {
                 fputs("\nlogLevel argument wasn't 'trace', 'debug', 'info', 'warning', or 'critical'! Mixxx will only output\n\
 warnings and errors to the console unless this is set properly.\n", stdout);
             }
             i++;
         } else if (argv[i] == QString("--logFlushLevel") && i+1 < argc) {
             auto level = QLatin1String(argv[i+1]);
-            if (level == "trace") {
-                m_logFlushLevel = mixxx::LogLevel::Trace;
-            } else if (level == "debug") {
-                m_logFlushLevel = mixxx::LogLevel::Debug;
-            } else if (level == "info") {
-                m_logFlushLevel = mixxx::LogLevel::Info;
-            } else if (level == "warning") {
-                m_logFlushLevel = mixxx::LogLevel::Warning;
-            } else if (level == "critical") {
-                m_logFlushLevel = mixxx::LogLevel::Critical;
-            } else {
+            if (!parseLogLevel(level, &m_logFlushLevel)) {
                 fputs("\nlogFushLevel argument wasn't 'trace', 'debug', 'info', 'warning', or 'critical'! Mixxx will only flush messages to mixxx.log\n\
 when a critical error occurs unless this is set properly.\n", stdout);
             }

--- a/src/util/logger.h
+++ b/src/util/logger.h
@@ -28,7 +28,7 @@ public:
     }
 
     bool traceEnabled() const {
-        return Logging::traceEnabled();
+        return Logging::enabled(LogLevel::Trace);
     }
 
     // Trace the elapsed time of some timed action in microseconds.
@@ -51,7 +51,7 @@ public:
     }
 
     bool debugEnabled() const {
-        return Logging::debugEnabled();
+        return Logging::enabled(LogLevel::Debug);
     }
 
     QDebug info() const {
@@ -59,7 +59,7 @@ public:
     }
 
     bool infoEnabled() const {
-        return Logging::infoEnabled();
+        return Logging::enabled(LogLevel::Info);
     }
 
     QDebug warning() const {

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -107,6 +107,10 @@ void handleMessage(
         if (Logging::shouldFlush(LogLevel::Debug)) {
             writeFlags |= WriteFlag::Flush;
         }
+        // TODO: Remove the following line.
+        // Do not write debug log messages into log file if log level
+        // Debug is not enabled starting with release 2.4.0! Until then
+        // write debug messages unconditionally into the log file
         writeFlags |= WriteFlag::File;
         break;
     case QtInfoMsg:
@@ -269,6 +273,8 @@ void Logging::initialize(const QDir& settingsDir,
     // Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=886437
     // Ubuntu: https://bugs.launchpad.net/ubuntu/+source/qtbase-opensource-src/+bug/1731646
     // Somehow this causes a segfault on macOS though?? https://bugs.launchpad.net/mixxx/+bug/1871238
+    // TODO: Remove this code after switching the minmium log level
+    // in the log file from Debug to Info.
 #ifdef __LINUX__
     QLoggingCategory::setFilterRules(
             "*.debug=true\n"

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -54,10 +54,12 @@ inline void writeToLog(
                 message.constData(), sizeof(char), message.size(), stderr);
         DEBUG_ASSERT(written == message.size());
         if (flags & WriteFlag::Flush) {
-            // Just in case, might not be necessary but this happens only
-            // infrequently when errors occur.
-            const int flushed = fflush(stderr);
-            DEBUG_ASSERT(flushed == 0);
+            // Flushing stderr might not be necessary, because message
+            // should end with a newline character. Flushing occcurs
+            // only infrequently (log level >= Critical), so better safe
+            // than sorry.
+            const int ret = fflush(stderr);
+            DEBUG_ASSERT(ret == 0);
         }
     }
     if (flags & WriteFlag::File) {

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -4,7 +4,6 @@
 #include <stdio.h>
 
 #include <QByteArray>
-#include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QIODevice>
@@ -12,9 +11,8 @@
 #include <QMutex>
 #include <QMutexLocker>
 #include <QString>
+#include <QTextStream>
 #include <QThread>
-#include <QtDebug>
-#include <QtGlobal>
 
 #include "controllers/controllerdebug.h"
 #include "util/assert.h"
@@ -151,8 +149,12 @@ void handleMessage(
     int levelName_len = strlen(levelName);
     int baSize = levelName_len + 2 + 3 + 1; // including separators (see below)
 
-    const QByteArray threadName =
+    QByteArray threadName =
             QThread::currentThread()->objectName().toLocal8Bit();
+    if (threadName.isEmpty()) {
+        QTextStream textStream(&threadName);
+        textStream << QThread::currentThread();
+    }
     baSize += threadName.size();
 
     QByteArray input8Bit;

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -1,20 +1,20 @@
 #include "util/logging.h"
 
-#include <stdio.h>
 #include <signal.h>
+#include <stdio.h>
 
 #include <QByteArray>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QIODevice>
+#include <QLoggingCategory>
 #include <QMutex>
 #include <QMutexLocker>
 #include <QString>
 #include <QThread>
 #include <QtDebug>
 #include <QtGlobal>
-#include <QLoggingCategory>
 
 #include "controllers/controllerdebug.h"
 #include "util/assert.h"
@@ -36,8 +36,10 @@ QFile g_logfile;
 bool g_debugAssertBreak = false;
 
 // Handles actually writing to stderr and the log.
-inline void writeToLog(const QByteArray& message, bool shouldPrint,
-                       bool shouldFlush) {
+inline void writeToLog(
+        const QByteArray& message,
+        bool shouldPrint,
+        bool shouldFlush) {
     if (shouldPrint) {
         fwrite(message.constData(), sizeof(char), message.size(), stderr);
     }
@@ -55,8 +57,10 @@ inline void writeToLog(const QByteArray& message, bool shouldPrint,
 
 // Debug message handler which outputs to stderr and a logfile, prepending the
 // thread name and log level.
-void MessageHandler(QtMsgType type,
-                    const QMessageLogContext&, const QString& input) {
+void MessageHandler(
+        QtMsgType type,
+        const QMessageLogContext&,
+        const QString& input) {
     // For "]: " and '\n'.
     size_t baSize = 4;
     const char* tag = nullptr;
@@ -65,47 +69,48 @@ void MessageHandler(QtMsgType type,
     bool isDebugAssert = false;
     bool isControllerDebug = false;
     switch (type) {
-        case QtDebugMsg:
-            tag = "Debug [";
-            baSize += strlen(tag);
-            isControllerDebug = input.startsWith(QLatin1String(
+    case QtDebugMsg:
+        tag = "Debug [";
+        baSize += strlen(tag);
+        isControllerDebug = input.startsWith(QLatin1String(
                 ControllerDebug::kLogMessagePrefix));
-            shouldPrint = Logging::enabled(LogLevel::Debug) ||
-                    isControllerDebug;
-            shouldFlush = Logging::flushing(LogLevel::Debug);
-            break;
-        case QtInfoMsg:
-            tag = "Info [";
-            baSize += strlen(tag);
-            shouldPrint = Logging::enabled(LogLevel::Info);
-            shouldFlush = Logging::flushing(LogLevel::Info);
-            break;
-        case QtWarningMsg:
-            tag = "Warning [";
-            baSize += strlen(tag);
-            shouldPrint = Logging::enabled(LogLevel::Warning);
-            shouldFlush = Logging::flushing(LogLevel::Warning);
-            break;
-        case QtCriticalMsg:
-            tag = "Critical [";
-            baSize += strlen(tag);
-            shouldFlush = true;
-            isDebugAssert = input.startsWith(QLatin1String(kDebugAssertPrefix));
-            break;
-        case QtFatalMsg:
-            tag = "Fatal [";
-            baSize += strlen(tag);
-            shouldFlush = true;
-            break;
-        default:
-            tag = "Unknown [";
-            baSize += strlen(tag);
+        shouldPrint = Logging::enabled(LogLevel::Debug) ||
+                isControllerDebug;
+        shouldFlush = Logging::flushing(LogLevel::Debug);
+        break;
+    case QtInfoMsg:
+        tag = "Info [";
+        baSize += strlen(tag);
+        shouldPrint = Logging::enabled(LogLevel::Info);
+        shouldFlush = Logging::flushing(LogLevel::Info);
+        break;
+    case QtWarningMsg:
+        tag = "Warning [";
+        baSize += strlen(tag);
+        shouldPrint = Logging::enabled(LogLevel::Warning);
+        shouldFlush = Logging::flushing(LogLevel::Warning);
+        break;
+    case QtCriticalMsg:
+        tag = "Critical [";
+        baSize += strlen(tag);
+        shouldFlush = true;
+        isDebugAssert = input.startsWith(QLatin1String(kDebugAssertPrefix));
+        break;
+    case QtFatalMsg:
+        tag = "Fatal [";
+        baSize += strlen(tag);
+        shouldFlush = true;
+        break;
+    default:
+        tag = "Unknown [";
+        baSize += strlen(tag);
     }
 
     // qthread.cpp contains a Q_ASSERT that currentThread does not return
     // nullptr.
     QByteArray threadName = QThread::currentThread()
-            ->objectName().toLocal8Bit();
+                                    ->objectName()
+                                    .toLocal8Bit();
     baSize += threadName.length();
 
     QByteArray input8Bit;
@@ -145,13 +150,14 @@ void MessageHandler(QtMsgType type,
     writeToLog(ba, shouldPrint, shouldFlush);
 }
 
-}  // namespace
+} // namespace
 
 // static
-void Logging::initialize(const QDir& settingsDir,
-                         LogLevel logLevel,
-                         LogLevel logFlushLevel,
-                         bool debugAssertBreak) {
+void Logging::initialize(
+        const QDir& settingsDir,
+        LogLevel logLevel,
+        LogLevel logFlushLevel,
+        bool debugAssertBreak) {
     VERIFY_OR_DEBUG_ASSERT(!g_logfile.isOpen()) {
         // Somebody already called Logging::initialize.
         return;
@@ -178,8 +184,7 @@ void Logging::initialize(const QDir& settingsDir,
                 QFile::remove(olderlogname);
             }
             if (!QFile::rename(logFileName, olderlogname)) {
-                fprintf(stderr, "Error rolling over logfile %s",
-                        logFileName.toLocal8Bit().constData());
+                fprintf(stderr, "Error rolling over logfile %s", logFileName.toLocal8Bit().constData());
             }
         }
     }
@@ -201,14 +206,10 @@ void Logging::initialize(const QDir& settingsDir,
     // Ubuntu: https://bugs.launchpad.net/ubuntu/+source/qtbase-opensource-src/+bug/1731646
     // Somehow this causes a segfault on macOS though?? https://bugs.launchpad.net/mixxx/+bug/1871238
 #ifdef __LINUX__
-    QLoggingCategory::setFilterRules("*.debug=true\n"
-                                     "qt.*.debug=false");
+    QLoggingCategory::setFilterRules(
+            "*.debug=true\n"
+            "qt.*.debug=false");
 #endif
-}
-
-// static
-void Logging::setLogLevel(LogLevel logLevel) {
-    g_logLevel = logLevel;
 }
 
 // static
@@ -232,4 +233,4 @@ void Logging::flushLogFile() {
     }
 }
 
-}  // namespace mixxx
+} // namespace mixxx

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -281,8 +281,6 @@ void Logging::initialize(const QDir& settingsDir,
     // Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=886437
     // Ubuntu: https://bugs.launchpad.net/ubuntu/+source/qtbase-opensource-src/+bug/1731646
     // Somehow this causes a segfault on macOS though?? https://bugs.launchpad.net/mixxx/+bug/1871238
-    // TODO: Remove this code after switching the minmium log level
-    // in the log file from Debug to Info.
 #ifdef __LINUX__
     QLoggingCategory::setFilterRules(
             "*.debug=true\n"

--- a/src/util/logging.h
+++ b/src/util/logging.h
@@ -53,19 +53,6 @@ class Logging {
         return s_logLevel >= logLevel;
     }
 
-    // TODO: Mark as deprecated
-    /*[[deprecated]]*/ static bool traceEnabled() {
-        return enabled(LogLevel::Trace);
-    }
-
-    static bool debugEnabled() {
-        return enabled(LogLevel::Debug);
-    }
-
-    static bool infoEnabled() {
-        return enabled(LogLevel::Info);
-    }
-
   private:
     // Almost constant, i.e. initialized once at startup and
     // then could safely be read from multiple threads.

--- a/src/util/logging.h
+++ b/src/util/logging.h
@@ -9,19 +9,19 @@ enum class LogLevel {
     Warning = 1,
     Info = 2,
     Debug = 3,
-    Trace = 4, // for profiling etc.
+    Trace = 4, // DEPRECATED (not available in Qt, used for profiling etc.)
 };
 
+/// Default log level for (console) logs.
 constexpr LogLevel kLogLevelDefault = LogLevel::Warning;
+
+/// Default log level for flushing the buffered log stream.
+/// This is required to ensure that all buffered messages have
+/// been written before Mixxx crashes.
 constexpr LogLevel kLogFlushLevelDefault = LogLevel::Critical;
 
-// Almost constant, i.e. initialized once at startup
-// TODO(XXX): Remove this ugly "extern" hack after getting rid of
-// the broken plugin architecture. Both globals should (again)
-// become static members of the class Logging.
-extern LogLevel g_logLevel;
-extern LogLevel g_logFlushLevel;
-
+/// Utility class for accessing the logging settings that are
+/// configured at startup.
 class Logging {
   public:
     // These are not thread safe. Only call them on Mixxx startup and shutdown.
@@ -34,30 +34,44 @@ class Logging {
     // Sets only the loglevel without the on-disk settings. Used by mixxx-test.
     static void setLogLevel(
             LogLevel logLevel) {
-        g_logLevel = logLevel;
+        s_logLevel = logLevel;
     }
 
     static void shutdown();
 
     static void flushLogFile();
 
-    static bool enabled(LogLevel logLevel) {
-        return g_logLevel >= logLevel;
+    static bool shouldFlush(
+            LogLevel logFlushLevel) {
+        // Log levels are ordered by severity, i.e. more
+        // severe log levels have a lower ordinal
+        return s_logFlushLevel >= logFlushLevel;
     }
-    static bool flushing(LogLevel logFlushLevel) {
-        return g_logFlushLevel >= logFlushLevel;
+
+    static bool enabled(
+            LogLevel logLevel) {
+        return s_logLevel >= logLevel;
     }
-    static bool traceEnabled() {
+
+    // TODO: Mark as deprecated
+    /*[[deprecated]]*/ static bool traceEnabled() {
         return enabled(LogLevel::Trace);
     }
+
     static bool debugEnabled() {
         return enabled(LogLevel::Debug);
     }
+
     static bool infoEnabled() {
         return enabled(LogLevel::Info);
     }
 
   private:
+    // Almost constant, i.e. initialized once at startup and
+    // then could safely be read from multiple threads.
+    static LogLevel s_logLevel;
+    static LogLevel s_logFlushLevel;
+
     Logging() = delete;
 };
 

--- a/src/util/logging.h
+++ b/src/util/logging.h
@@ -1,8 +1,6 @@
-#ifndef MIXXX_UTIL_LOGGING_H
-#define MIXXX_UTIL_LOGGING_H
+#pragma once
 
 #include <QDir>
-
 
 namespace mixxx {
 
@@ -27,13 +25,17 @@ extern LogLevel g_logFlushLevel;
 class Logging {
   public:
     // These are not thread safe. Only call them on Mixxx startup and shutdown.
-    static void initialize(const QDir& settingsDir,
-                           LogLevel logLevel,
-                           LogLevel logFlushLevel,
-                           bool debugAssertBreak);
+    static void initialize(
+            const QDir& settingsDir,
+            LogLevel logLevel,
+            LogLevel logFlushLevel,
+            bool debugAssertBreak);
 
-    // Sets only the loglevel without the on-disk settings.  Used by mixxx-test.
-    static void setLogLevel(LogLevel logLevel);
+    // Sets only the loglevel without the on-disk settings. Used by mixxx-test.
+    static void setLogLevel(
+            LogLevel logLevel) {
+        g_logLevel = logLevel;
+    }
 
     static void shutdown();
 
@@ -59,6 +61,4 @@ class Logging {
     Logging() = delete;
 };
 
-}  // namespace mixxx
-
-#endif /* MIXXX_UTIL_LOGGING_H */
+} // namespace mixxx


### PR DESCRIPTION
*Need to fix one of the commits*

https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/Logging

Please refer to the commits messages for what has changed.
- The 1st commit is only a reformatting
- The 2nd commit includes
  - New debug assertion to ensure that everything is working as intended. 
  - Replaced the boolean parameters of writeToLog() with a mask of flags.
- TODOs indicate the required changes for switching the file log level from Debug to Info. This will also resolve the macOS crash, because then we don't need to install a custom filter rule (postponed until 2.4.0, no changes for 2.3.0)