### PR TITLE
Avoid spamming the log when loading cover art of missing files

### DIFF
--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -199,6 +199,11 @@ TrackPointer SoundSourceProxy::importTemporaryTrack(
 QImage SoundSourceProxy::importTemporaryCoverImage(
         TrackFile trackFile,
         SecurityTokenPointer pSecurityToken) {
+    if (!trackFile.checkFileExists()) {
+        // Silently ignore missing files to avoid spaming the log:
+        // https://bugs.launchpad.net/mixxx/+bug/1875237
+        return QImage();
+    }
     TrackPointer pTrack = Track::newTemporary(
             std::move(trackFile),
             std::move(pSecurityToken));


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1875237

The solution was simple than expected.