### PR TITLE
Lp1876202: Fix WSearchLineEdit state machine

### DIFF
--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -236,11 +236,11 @@ void Library::bindSearchboxWidget(WSearchLineEdit* pSearchboxWidget) {
     connect(this,
             &Library::disableSearch,
             pSearchboxWidget,
-            &WSearchLineEdit::disableSearch);
+            &WSearchLineEdit::slotDisableSearch);
     connect(this,
             &Library::restoreSearch,
             pSearchboxWidget,
-            &WSearchLineEdit::restoreSearch);
+            &WSearchLineEdit::slotRestoreSearch);
     connect(this,
             &Library::setTrackTableFont,
             pSearchboxWidget,

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -335,7 +335,7 @@ void LibraryControl::bindSearchboxWidget(WSearchLineEdit* pSearchbox) {
     connect(this,
             &LibraryControl::clearSearchIfClearButtonHasFocus,
             m_pSearchbox,
-            &WSearchLineEdit::clearSearchIfClearButtonHasFocus);
+            &WSearchLineEdit::slotClearSearchIfClearButtonHasFocus);
     connect(m_pSearchbox,
             &WSearchLineEdit::destroyed,
             this,

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -333,9 +333,9 @@ void LibraryControl::bindSearchboxWidget(WSearchLineEdit* pSearchbox) {
     }
     m_pSearchbox = pSearchbox;
     connect(this,
-            &LibraryControl::clearSearch,
+            &LibraryControl::clearSearchIfClearButtonHasFocus,
             m_pSearchbox,
-            &WSearchLineEdit::clearSearch);
+            &WSearchLineEdit::clearSearchIfClearButtonHasFocus);
     connect(m_pSearchbox,
             &WSearchLineEdit::destroyed,
             this,
@@ -621,9 +621,8 @@ void LibraryControl::slotGoToItem(double v) {
     }
 
     // Clear the search if the searchbox has focus
-    if (m_pSearchbox->clearBtnHasFocus()) {
-        return emit clearSearch();
-    }
+    emit clearSearchIfClearButtonHasFocus();
+
     // TODO(xxx) instead of remote control the widgets individual, we should
     // translate this into Alt+Return and handle it at each library widget
     // individual https://bugs.launchpad.net/mixxx/+bug/1758618

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -46,7 +46,7 @@ class LibraryControl : public QObject {
     void bindSearchboxWidget(WSearchLineEdit* pSearchbox);
 
   signals:
-    void clearSearch();
+    void clearSearchIfClearButtonHasFocus();
 
   public slots:
     // Deprecated navigation slots

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1230,7 +1230,7 @@ QWidget* LegacySkinParser::parseSearchBox(const QDomElement& node) {
 
     WSearchLineEdit* pLineEditSearch = new WSearchLineEdit(m_pParent);
     commonWidgetSetup(node, pLineEditSearch, false);
-    pLineEditSearch->setupSkin(node, *m_pContext);
+    pLineEditSearch->setup(node, *m_pContext);
 
     m_pLibrary->bindSearchboxWidget(pLineEditSearch);
 

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1230,7 +1230,7 @@ QWidget* LegacySkinParser::parseSearchBox(const QDomElement& node) {
 
     WSearchLineEdit* pLineEditSearch = new WSearchLineEdit(m_pParent);
     commonWidgetSetup(node, pLineEditSearch, false);
-    pLineEditSearch->setup(node, *m_pContext);
+    pLineEditSearch->setupSkin(node, *m_pContext);
 
     m_pLibrary->bindSearchboxWidget(pLineEditSearch);
 

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -186,6 +186,13 @@ void WSearchLineEdit::setup(const QDomNode& node, const SkinContext& context) {
     DEBUG_ASSERT(backgroundColor != foregroundColor);
     pal.setBrush(backgroundRole(), backgroundColor);
     pal.setBrush(foregroundRole(), foregroundColor);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+    // Use only 25% instead of 50% transparency for the placeholder text color
+    auto placeholderColor = foregroundColor;
+    placeholderColor.setAlpha(
+            placeholderColor.alpha() - placeholderColor.alpha() / 4);
+    pal.setBrush(QPalette::PlaceholderText, placeholderColor);
+#endif
     setPalette(pal);
 
     m_clearButton->setToolTip(tr("Clear input") + "\n" +

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -69,7 +69,9 @@ WSearchLineEdit::WSearchLineEdit(QWidget* pParent)
     DEBUG_ASSERT(!kEmptySearch.isNull());
 
     setAcceptDrops(false);
-    setPlaceholderText(tr("Search...", "noun"));
+
+    //: This should be a noun.
+    setPlaceholderText(tr("Search..."));
 
     m_clearButton->setCursor(Qt::ArrowCursor);
     m_clearButton->setObjectName(kClearButtonName);

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -17,7 +17,6 @@ namespace {
 
 const mixxx::Logger kLogger("WSearchLineEdit");
 
-const QColor kDefaultForegroundColor = QColor(0, 0, 0);
 const QColor kDefaultBackgroundColor = QColor(255, 255, 255);
 
 const QString kEmptySearch = QStringLiteral("");
@@ -78,7 +77,6 @@ WSearchLineEdit::WSearchLineEdit(QWidget* pParent)
     : QLineEdit(pParent),
       WBaseWidget(this),
       m_clearButton(new QToolButton(this)),
-      m_foregroundColor(kDefaultForegroundColor),
       m_state(State::Inactive) {
     DEBUG_ASSERT(kEmptySearch.isEmpty());
     DEBUG_ASSERT(!kEmptySearch.isNull());
@@ -158,36 +156,36 @@ void WSearchLineEdit::setup(const QDomNode& node, const SkinContext& context) {
             << backgroundColor;
 
     const auto defaultForegroundColor =
-            QColor(
+            QColor::fromRgb(
                     255 - backgroundColor.red(),
                     255 - backgroundColor.green(),
                     255 - backgroundColor.blue());
-    m_foregroundColor = defaultForegroundColor;
+    auto foregroundColor = defaultForegroundColor;
     QString fgColorName;
     if (context.hasNodeSelectString(node, "FgColor", &fgColorName)) {
         auto namedColor = QColor(fgColorName);
         if (namedColor.isValid()) {
-            m_foregroundColor = namedColor;
+            foregroundColor = namedColor;
         } else {
             kLogger.warning()
                     << "Failed to parse foreground color"
                     << fgColorName;
         }
     }
-    m_foregroundColor = WSkinColor::getCorrectColor(m_foregroundColor);
-    VERIFY_OR_DEBUG_ASSERT(m_foregroundColor != backgroundColor) {
+    foregroundColor = WSkinColor::getCorrectColor(foregroundColor);
+    VERIFY_OR_DEBUG_ASSERT(foregroundColor != backgroundColor) {
         kLogger.warning()
                 << "Invisible foreground color - using default color as fallback";
-        m_foregroundColor = defaultForegroundColor;
+        foregroundColor = defaultForegroundColor;
     }
     kLogger.debug()
             << "Foreground color:"
-            << m_foregroundColor;
+            << foregroundColor;
 
     QPalette pal = palette();
-    DEBUG_ASSERT(backgroundColor != m_foregroundColor);
+    DEBUG_ASSERT(backgroundColor != foregroundColor);
     pal.setBrush(backgroundRole(), backgroundColor);
-    pal.setBrush(foregroundRole(), m_foregroundColor);
+    pal.setBrush(foregroundRole(), foregroundColor);
     setPalette(pal);
 
     m_clearButton->setToolTip(tr("Clear input") + "\n" +

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -70,7 +70,7 @@ WSearchLineEdit::WSearchLineEdit(QWidget* pParent)
 
     setAcceptDrops(false);
 
-    //: This should be a noun.
+    //: Shown in the library search bar when it is empty.
     setPlaceholderText(tr("Search..."));
 
     m_clearButton->setCursor(Qt::ArrowCursor);

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -17,7 +17,7 @@ namespace {
 
 const mixxx::Logger kLogger("WSearchLineEdit");
 
-const QColor kDefaultBackgroundColor = QColor(255, 255, 255);
+const QColor kDefaultBackgroundColor = QColor(0, 0, 0);
 
 const QString kEmptySearch = QStringLiteral("");
 

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -134,9 +134,7 @@ WSearchLineEdit::WSearchLineEdit(QWidget* pParent)
     showPlaceholder();
 }
 
-void WSearchLineEdit::setupSkin(
-        const QDomNode& node,
-        const SkinContext& context) {
+void WSearchLineEdit::setup(const QDomNode& node, const SkinContext& context) {
     auto backgroundColor = kDefaultBackgroundColor;
     QString bgColorName;
     if (context.hasNodeSelectString(node, "BgColor", &bgColorName)) {

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -18,9 +18,18 @@ const mixxx::Logger kLogger("WSearchLineEdit");
 const QColor kDefaultForegroundColor = QColor(0, 0, 0);
 const QColor kDefaultBackgroundColor = QColor(255, 255, 255);
 
-const QString kEmptySearch = "";
+const QString kEmptySearch = QStringLiteral("");
 
-const QString kDisabledText = "- - -";
+const QString kDisabledText = QStringLiteral("- - -");
+
+const QString kClearButtonName = QStringLiteral("SearchClearButton");
+
+inline QString clearButtonStyleSheet(int pxPaddingRight) {
+    DEBUG_ASSERT(pxPaddingRight >= 0);
+    return QString(
+            QStringLiteral("QLineEdit { padding-right: %1px; }"))
+            .arg(pxPaddingRight);
+}
 
 int verifyDebouncingTimeoutMillis(int debouncingTimeoutMillis) {
     VERIFY_OR_DEBUG_ASSERT(debouncingTimeoutMillis >= WSearchLineEdit::kMinDebouncingTimeoutMillis) {
@@ -63,7 +72,7 @@ WSearchLineEdit::WSearchLineEdit(QWidget* pParent)
     setAcceptDrops(false);
 
     m_clearButton->setCursor(Qt::ArrowCursor);
-    m_clearButton->setObjectName("SearchClearButton");
+    m_clearButton->setObjectName(kClearButtonName);
     // Assume the qss border is at least 1px wide
     m_frameWidth = 1;
     m_clearButton->hide();
@@ -107,9 +116,9 @@ WSearchLineEdit::WSearchLineEdit(QWidget* pParent)
             });
 
     QSize clearButtonSize = m_clearButton->sizeHint();
+
     // Ensures the text does not obscure the clear image.
-    setStyleSheet(QString("QLineEdit { padding-right: %1px; } ")
-                          .arg(clearButtonSize.width() + m_frameWidth + 1));
+    setStyleSheet(clearButtonStyleSheet(clearButtonSize.width() + m_frameWidth + 1));
 
     showPlaceholder();
 }
@@ -297,12 +306,11 @@ void WSearchLineEdit::updateClearButton(const QString& text) {
     if (!text.isEmpty() && (m_state == State::Active)) {
         m_clearButton->setVisible(true);
         // make sure the text won't be drawn behind the Clear button icon
-        setStyleSheet(QString("QLineEdit { padding-right: %1px; } ")
-                              .arg(m_innerHeight + m_frameWidth));
+        setStyleSheet(clearButtonStyleSheet(m_innerHeight + m_frameWidth));
     } else {
         m_clearButton->setVisible(false);
         // no right padding
-        setStyleSheet(QString("QLineEdit { padding-right: 0px; } "));
+        setStyleSheet(clearButtonStyleSheet(0));
     }
 }
 

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -116,14 +116,12 @@ WSearchLineEdit::WSearchLineEdit(QWidget* pParent)
             this,
             &WSearchLineEdit::updateText);
 
-    // When you hit enter, it will trigger the search.
+    // When you hit enter, it will trigger or clear the search.
     connect(this,
             &QLineEdit::returnPressed,
             this,
             [this] {
-                if (clearBtnHasFocus()) {
-                    clearSearch();
-                } else {
+                if (!clearSearchIfClearButtonHasFocus()) {
                     triggerSearch();
                 }
             });
@@ -326,7 +324,6 @@ void WSearchLineEdit::disableSearch() {
     setEnabled(false);
 }
 
-// slot
 void WSearchLineEdit::enableSearch(const QString& text) {
 #if ENABLE_TRACE_LOG
     kLogger.trace()
@@ -458,11 +455,6 @@ bool WSearchLineEdit::event(QEvent* pEvent) {
 }
 
 // slot
-bool WSearchLineEdit::clearBtnHasFocus() const {
-    return m_clearButton->hasFocus();
-}
-
-// slot
 void WSearchLineEdit::clearSearch() {
 #if ENABLE_TRACE_LOG
     kLogger.trace()
@@ -477,6 +469,15 @@ void WSearchLineEdit::clearSearch() {
     setText(kEmptySearch);
     // Refocus the edit field
     setFocus(Qt::OtherFocusReason);
+}
+
+// slot
+bool WSearchLineEdit::clearSearchIfClearButtonHasFocus() {
+    if (!m_clearButton->hasFocus()) {
+        return false;
+    }
+    clearSearch();
+    return true;
 }
 
 // slot

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -98,7 +98,13 @@ WSearchLineEdit::WSearchLineEdit(QWidget* pParent)
     connect(this,
             &QLineEdit::returnPressed,
             this,
-            &WSearchLineEdit::triggerSearch);
+            [this] {
+                if (clearBtnHasFocus()) {
+                    clearSearch();
+                } else {
+                    triggerSearch();
+                }
+            });
 
     QSize clearButtonSize = m_clearButton->sizeHint();
     // Ensures the text does not obscure the clear image.

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -377,10 +377,6 @@ void WSearchLineEdit::showPlaceholder() {
     DEBUG_ASSERT(shouldShowPlaceholder(getSearchText()));
 
     updateClearButton(kEmptySearch);
-
-    QPalette pal = palette();
-    pal.setColor(foregroundRole(), Qt::lightGray);
-    setPalette(pal);
 }
 
 void WSearchLineEdit::showSearchText(const QString& text) {
@@ -398,10 +394,6 @@ void WSearchLineEdit::showSearchText(const QString& text) {
     }
     m_state = State::Active;
     updateClearButton(text);
-
-    QPalette pal = palette();
-    pal.setColor(foregroundRole(), m_foregroundColor);
-    setPalette(pal);
 
     // This gets rid of the blue mac highlight.
     setAttribute(Qt::WA_MacShowFocusRect, false);

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -335,6 +335,8 @@ void WSearchLineEdit::clearSearch() {
     // before returning the whole (and probably huge) library.
     // No need to manually trigger a search at this point!
     // See also: https://bugs.launchpad.net/mixxx/+bug/1635087
+    // Refocus the edit field
+    setFocus(Qt::OtherFocusReason);
 }
 
 // slot

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -224,7 +224,7 @@ void WSearchLineEdit::resizeEvent(QResizeEvent* e) {
         m_clearButton->setIconSize(newSize);
         // Note(ronso0): For some reason this ensures the search text
         // is being displayed after skin change/reload.
-        refreshEditBox();
+        refreshState();
     }
     int top = rect().top() + m_frameWidth;
     if (layoutDirection() == Qt::LeftToRight) {
@@ -400,10 +400,10 @@ void WSearchLineEdit::showSearchText(const QString& text) {
     setAttribute(Qt::WA_MacShowFocusRect, false);
 }
 
-void WSearchLineEdit::refreshEditBox() {
+void WSearchLineEdit::refreshState() {
 #if ENABLE_TRACE_LOG
     kLogger.trace()
-            << "refreshEditBox";
+            << "refreshState";
 #endif // ENABLE_TRACE_LOG
     if (isEnabled()) {
         enableSearch(getSearchText());

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -134,7 +134,9 @@ WSearchLineEdit::WSearchLineEdit(QWidget* pParent)
     showPlaceholder();
 }
 
-void WSearchLineEdit::setup(const QDomNode& node, const SkinContext& context) {
+void WSearchLineEdit::setupSkin(
+        const QDomNode& node,
+        const SkinContext& context) {
     auto backgroundColor = kDefaultBackgroundColor;
     QString bgColorName;
     if (context.hasNodeSelectString(node, "BgColor", &bgColorName)) {

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -92,7 +92,7 @@ WSearchLineEdit::WSearchLineEdit(QWidget* pParent)
     connect(m_clearButton,
             &QAbstractButton::clicked,
             this,
-            &WSearchLineEdit::clearSearch);
+            &WSearchLineEdit::slotClearSearch);
 
     // This prevents the searchbox from being focused by Tab key (real or emulated)
     // so it is skipped when using the library controls 'MoveFocus[...]'
@@ -102,7 +102,7 @@ WSearchLineEdit::WSearchLineEdit(QWidget* pParent)
     connect(setFocusShortcut,
             &QShortcut::activated,
             this,
-            &WSearchLineEdit::setShortcutFocus);
+            &WSearchLineEdit::slotSetShortcutFocus);
 
     // Set up a timer to search after a few hundred milliseconds timeout.  This
     // stops us from thrashing the database if you type really fast.
@@ -110,19 +110,19 @@ WSearchLineEdit::WSearchLineEdit(QWidget* pParent)
     connect(&m_debouncingTimer,
             &QTimer::timeout,
             this,
-            &WSearchLineEdit::triggerSearch);
+            &WSearchLineEdit::slotTriggerSearch);
     connect(this,
             &QLineEdit::textChanged,
             this,
-            &WSearchLineEdit::updateText);
+            &WSearchLineEdit::slotTextChanged);
 
     // When you hit enter, it will trigger or clear the search.
     connect(this,
             &QLineEdit::returnPressed,
             this,
             [this] {
-                if (!clearSearchIfClearButtonHasFocus()) {
-                    triggerSearch();
+                if (!slotClearSearchIfClearButtonHasFocus()) {
+                    slotTriggerSearch();
                 }
             });
 
@@ -291,7 +291,7 @@ void WSearchLineEdit::focusOutEvent(QFocusEvent* event) {
         // Trigger a pending search before leaving the edit box.
         // Otherwise the entered text might be ignored and get lost
         // due to the debouncing timeout!
-        triggerSearch();
+        slotTriggerSearch();
     }
     switchState(State::Inactive);
     if (getSearchText().isEmpty()) {
@@ -310,11 +310,10 @@ void WSearchLineEdit::setTextBlockSignals(const QString& text) {
     blockSignals(false);
 }
 
-// slot
-void WSearchLineEdit::disableSearch() {
+void WSearchLineEdit::slotDisableSearch() {
 #if ENABLE_TRACE_LOG
     kLogger.trace()
-            << "disableSearch";
+            << "slotDisableSearch";
 #endif // ENABLE_TRACE_LOG
     if (!isEnabled()) {
         return;
@@ -338,25 +337,23 @@ void WSearchLineEdit::enableSearch(const QString& text) {
     updateEditBox(text);
 }
 
-// slot
-void WSearchLineEdit::restoreSearch(const QString& text) {
+void WSearchLineEdit::slotRestoreSearch(const QString& text) {
 #if ENABLE_TRACE_LOG
     kLogger.trace()
-            << "restoreSearch"
+            << "slotRestoreSearch"
             << text;
 #endif // ENABLE_TRACE_LOG
     if (text.isNull()) {
-        disableSearch();
+        slotDisableSearch();
     } else {
         enableSearch(text);
     }
 }
 
-// slot
-void WSearchLineEdit::triggerSearch() {
+void WSearchLineEdit::slotTriggerSearch() {
 #if ENABLE_TRACE_LOG
     kLogger.trace()
-            << "triggerSearch"
+            << "slotTriggerSearch"
             << getSearchText();
 #endif // ENABLE_TRACE_LOG
     DEBUG_ASSERT(isEnabled());
@@ -409,7 +406,7 @@ void WSearchLineEdit::refreshEditBox() {
     if (isEnabled()) {
         enableSearch(getSearchText());
     } else {
-        disableSearch();
+        slotDisableSearch();
     }
 }
 
@@ -454,11 +451,10 @@ bool WSearchLineEdit::event(QEvent* pEvent) {
     return QLineEdit::event(pEvent);
 }
 
-// slot
-void WSearchLineEdit::clearSearch() {
+void WSearchLineEdit::slotClearSearch() {
 #if ENABLE_TRACE_LOG
     kLogger.trace()
-            << "clearSearch";
+            << "slotClearSearch";
 #endif // ENABLE_TRACE_LOG
     DEBUG_ASSERT(isEnabled());
     // Clearing the edit field will engage the debouncing timer
@@ -471,20 +467,18 @@ void WSearchLineEdit::clearSearch() {
     setFocus(Qt::OtherFocusReason);
 }
 
-// slot
-bool WSearchLineEdit::clearSearchIfClearButtonHasFocus() {
+bool WSearchLineEdit::slotClearSearchIfClearButtonHasFocus() {
     if (!m_clearButton->hasFocus()) {
         return false;
     }
-    clearSearch();
+    slotClearSearch();
     return true;
 }
 
-// slot
-void WSearchLineEdit::updateText(const QString& text) {
+void WSearchLineEdit::slotTextChanged(const QString& text) {
 #if ENABLE_TRACE_LOG
     kLogger.trace()
-            << "updateText"
+            << "slotTextChanged"
             << text;
 #endif // ENABLE_TRACE_LOG
     m_debouncingTimer.stop();
@@ -504,8 +498,7 @@ void WSearchLineEdit::updateText(const QString& text) {
     }
 }
 
-// slot
-void WSearchLineEdit::setShortcutFocus() {
+void WSearchLineEdit::slotSetShortcutFocus() {
     setFocus(Qt::ShortcutFocusReason);
 }
 

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -187,8 +187,7 @@ void WSearchLineEdit::setup(const QDomNode& node, const SkinContext& context) {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
     // Use only 25% instead of 50% transparency for the placeholder text color
     auto placeholderColor = foregroundColor;
-    placeholderColor.setAlpha(
-            placeholderColor.alpha() - placeholderColor.alpha() / 4);
+    placeholderColor.setAlpha(placeholderColor.alpha() * 3 / 4); // 75% opaque
     kLogger.debug()
             << "Placeholder color:"
             << placeholderColor;

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -64,7 +64,7 @@ void WSearchLineEdit::setDebouncingTimeoutMillis(int debouncingTimeoutMillis) {
 WSearchLineEdit::WSearchLineEdit(QWidget* pParent)
     : QLineEdit(pParent),
       WBaseWidget(this),
-      m_clearButton(new QToolButton(this)) {
+      m_clearButton(make_parented<QToolButton>(this)) {
     DEBUG_ASSERT(kEmptySearch.isEmpty());
     DEBUG_ASSERT(!kEmptySearch.isNull());
 

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -185,7 +185,6 @@ void WSearchLineEdit::setup(const QDomNode& node, const SkinContext& context) {
     pal.setBrush(backgroundRole(), backgroundColor);
     pal.setBrush(foregroundRole(), foregroundColor);
 #if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
-    // Use only 25% instead of 50% transparency for the placeholder text color
     auto placeholderColor = foregroundColor;
     placeholderColor.setAlpha(placeholderColor.alpha() * 3 / 4); // 75% opaque
     kLogger.debug()

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -11,6 +11,8 @@
 #include "util/assert.h"
 #include "util/logger.h"
 
+#define ENABLE_TRACE_LOG false
+
 namespace {
 
 const mixxx::Logger kLogger("WSearchLineEdit");
@@ -223,22 +225,39 @@ QString WSearchLineEdit::getSearchText() const {
 }
 
 void WSearchLineEdit::focusInEvent(QFocusEvent* event) {
+#if ENABLE_TRACE_LOG
+    kLogger.trace()
+            << "focusInEvent";
+#endif // ENABLE_TRACE_LOG
     QLineEdit::focusInEvent(event);
     showSearchText(getSearchText());
 }
 
 void WSearchLineEdit::focusOutEvent(QFocusEvent* event) {
+#if ENABLE_TRACE_LOG
+    kLogger.trace()
+            << "focusOutEvent";
+#endif // ENABLE_TRACE_LOG
     QLineEdit::focusOutEvent(event);
     updateEditBox(getSearchText());
 }
 
 // slot
 void WSearchLineEdit::disableSearch() {
+#if ENABLE_TRACE_LOG
+    kLogger.trace()
+            << "disableSearch";
+#endif // ENABLE_TRACE_LOG
     restoreSearch(QString());
 }
 
 // slot
 void WSearchLineEdit::restoreSearch(const QString& text) {
+#if ENABLE_TRACE_LOG
+    kLogger.trace()
+            << "restoreSearch"
+            << text;
+#endif // ENABLE_TRACE_LOG
     if (text.isNull()) {
         // disable
         setEnabled(false);
@@ -252,6 +271,11 @@ void WSearchLineEdit::restoreSearch(const QString& text) {
 
 // slot
 void WSearchLineEdit::triggerSearch() {
+#if ENABLE_TRACE_LOG
+    kLogger.trace()
+            << "triggerSearch"
+            << getSearchText();
+#endif // ENABLE_TRACE_LOG
     m_debouncingTimer.stop();
     emit search(getSearchText());
 }
@@ -261,6 +285,11 @@ void WSearchLineEdit::showPlaceholder() {
 
     // Deactivate text change listener
     m_state = State::Inactive;
+#if ENABLE_TRACE_LOG
+    kLogger.trace()
+            << "showPlaceholder"
+            << getSearchText();
+#endif // ENABLE_TRACE_LOG
 
     setText(tr("Search...", "noun"));
 
@@ -270,6 +299,11 @@ void WSearchLineEdit::showPlaceholder() {
 }
 
 void WSearchLineEdit::showSearchText(const QString& text) {
+#if ENABLE_TRACE_LOG
+    kLogger.trace()
+            << "showSearchText"
+            << text;
+#endif // ENABLE_TRACE_LOG
     DEBUG_ASSERT(isEnabled());
 
     // Reactivate text change listener
@@ -295,6 +329,11 @@ void WSearchLineEdit::showSearchText(const QString& text) {
 }
 
 void WSearchLineEdit::updateEditBox(const QString& text) {
+#if ENABLE_TRACE_LOG
+    kLogger.trace()
+            << "updateEditBox"
+            << text;
+#endif // ENABLE_TRACE_LOG
     if (text.isEmpty()) {
         showPlaceholder();
     } else {
@@ -303,6 +342,11 @@ void WSearchLineEdit::updateEditBox(const QString& text) {
 }
 
 void WSearchLineEdit::updateClearButton(const QString& text) {
+#if ENABLE_TRACE_LOG
+    kLogger.trace()
+            << "updateClearButton"
+            << text;
+#endif // ENABLE_TRACE_LOG
     if (!text.isEmpty() && (m_state == State::Active)) {
         m_clearButton->setVisible(true);
         // make sure the text won't be drawn behind the Clear button icon
@@ -328,6 +372,10 @@ bool WSearchLineEdit::clearBtnHasFocus() const {
 
 // slot
 void WSearchLineEdit::clearSearch() {
+#if ENABLE_TRACE_LOG
+    kLogger.trace()
+            << "clearSearch";
+#endif // ENABLE_TRACE_LOG
     DEBUG_ASSERT(m_state == State::Active);
     setText(kEmptySearch);
     // Clearing the edit field will engage the debouncing timer
@@ -341,6 +389,11 @@ void WSearchLineEdit::clearSearch() {
 
 // slot
 void WSearchLineEdit::updateText(const QString& text) {
+#if ENABLE_TRACE_LOG
+    kLogger.trace()
+            << "updateText"
+            << text;
+#endif // ENABLE_TRACE_LOG
     if (isEnabled() && (m_state == State::Active)) {
         updateClearButton(text);
         DEBUG_ASSERT(m_debouncingTimer.isSingleShot());

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -191,6 +191,9 @@ void WSearchLineEdit::setupSkin(
     auto placeholderColor = foregroundColor;
     placeholderColor.setAlpha(
             placeholderColor.alpha() - placeholderColor.alpha() / 4);
+    kLogger.debug()
+            << "Placeholder color:"
+            << placeholderColor;
     pal.setBrush(QPalette::PlaceholderText, placeholderColor);
 #endif
     setPalette(pal);

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -13,11 +13,6 @@ class SkinContext;
 class WSearchLineEdit : public QLineEdit, public WBaseWidget {
     Q_OBJECT
   public:
-    enum class State {
-        Active,
-        Inactive,
-    };
-
     // Delay for triggering a search while typing
     static constexpr int kMinDebouncingTimeoutMillis = 100;
     static constexpr int kDefaultDebouncingTimeoutMillis = 300;
@@ -26,10 +21,6 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
     // Use 'active' property to apply an alternative style to the
     // placeholder text
     Q_PROPERTY(bool active READ isActive);
-
-    bool isActive() const {
-        return m_state == State::Active ? true : false;
-    }
 
     // TODO(XXX): Replace with a public slot
     static void setDebouncingTimeoutMillis(int debouncingTimeoutMillis);
@@ -71,7 +62,6 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
     // configuration value changes.
     static int s_debouncingTimeoutMillis;
 
-    void switchState(State state);
     void updateEditBox(const QString& text);
     void refreshEditBox();
 
@@ -95,5 +85,15 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
 
     QTimer m_debouncingTimer;
 
+    enum class State {
+        Active,
+        Inactive,
+    };
     State m_state;
+
+    void switchState(State state);
+
+    bool isActive() const {
+        return m_state == State::Active ? true : false;
+    }
 };

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -64,14 +64,8 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
 
     void refreshState();
 
-    void updateEditBox(const QString& text);
-
-    void showPlaceholder();
-    bool shouldShowPlaceholder(const QString& text) const;
-
     void enableSearch(const QString& text);
-    void showSearchText(const QString& text);
-
+    void updateEditBox(const QString& text);
     void updateClearButton(const QString& text);
 
     QString getSearchText() const;

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -17,7 +17,6 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
     enum class State {
         Active,
         Inactive,
-        InactivePlaceholder, // placeholder is displayed instead of an empty search text
     };
 
     // Delay for triggering a search while typing

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -39,6 +39,8 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
 
     void setup(const QDomNode& node, const SkinContext& context);
 
+    bool clearBtnHasFocus() const;
+
   protected:
     void resizeEvent(QResizeEvent*) override;
     void focusInEvent(QFocusEvent*) override;
@@ -50,10 +52,8 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
 
   public slots:
     void restoreSearch(const QString& text);
-    void enableSearch(const QString& text);
     void disableSearch();
     void slotSetFont(const QFont& font);
-    bool clearBtnHasFocus() const;
     void clearSearch();
 
   private slots:
@@ -76,6 +76,8 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
 
     void showPlaceholder();
     bool shouldShowPlaceholder(const QString& text) const;
+
+    void enableSearch(const QString& text);
     void showSearchText(const QString& text);
 
     void updateClearButton(const QString& text);

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -28,7 +28,9 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
     explicit WSearchLineEdit(QWidget* pParent);
     ~WSearchLineEdit() override = default;
 
-    void setup(const QDomNode& node, const SkinContext& context);
+    void setupSkin(
+            const QDomNode& node,
+            const SkinContext& context);
 
   protected:
     void resizeEvent(QResizeEvent*) override;

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -6,6 +6,7 @@
 #include <QTimer>
 #include <QToolButton>
 
+#include "util/parented_ptr.h"
 #include "widget/wbasewidget.h"
 
 class SkinContext;
@@ -69,7 +70,7 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
     // Update the displayed text without (re-)starting the timer
     void setTextBlockSignals(const QString& text);
 
-    QToolButton* const m_clearButton;
+    parented_ptr<QToolButton> const m_clearButton;
 
     int m_frameWidth;
     int m_innerHeight;

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -39,8 +39,6 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
 
     void setup(const QDomNode& node, const SkinContext& context);
 
-    bool clearBtnHasFocus() const;
-
   protected:
     void resizeEvent(QResizeEvent*) override;
     void focusInEvent(QFocusEvent*) override;
@@ -54,7 +52,9 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
     void restoreSearch(const QString& text);
     void disableSearch();
     void slotSetFont(const QFont& font);
+
     void clearSearch();
+    bool clearSearchIfClearButtonHasFocus();
 
   private slots:
     void setShortcutFocus();

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -62,8 +62,9 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
     // configuration value changes.
     static int s_debouncingTimeoutMillis;
 
+    void refreshState();
+
     void updateEditBox(const QString& text);
-    void refreshEditBox();
 
     void showPlaceholder();
     bool shouldShowPlaceholder(const QString& text) const;

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -49,18 +49,19 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
     void search(const QString& text);
 
   public slots:
-    void restoreSearch(const QString& text);
-    void disableSearch();
     void slotSetFont(const QFont& font);
 
-    void clearSearch();
-    bool clearSearchIfClearButtonHasFocus();
+    void slotRestoreSearch(const QString& text);
+    void slotDisableSearch();
+
+    void slotClearSearch();
+    bool slotClearSearchIfClearButtonHasFocus();
 
   private slots:
-    void setShortcutFocus();
-    void updateText(const QString& text);
+    void slotSetShortcutFocus();
+    void slotTextChanged(const QString& text);
 
-    void triggerSearch();
+    void slotTriggerSearch();
 
   private:
     // TODO(XXX): This setting shouldn't be static and the widget

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -15,8 +15,9 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
     Q_OBJECT
   public:
     enum class State {
-        Inactive,
         Active,
+        Inactive,
+        InactivePlaceholder, // placeholder is displayed instead of an empty search text
     };
 
     // Delay for triggering a search while typing
@@ -51,6 +52,7 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
 
   public slots:
     void restoreSearch(const QString& text);
+    void enableSearch(const QString& text);
     void disableSearch();
     void slotSetFont(const QFont& font);
     bool clearBtnHasFocus() const;
@@ -70,13 +72,20 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
     // configuration value changes.
     static int s_debouncingTimeoutMillis;
 
-    void showPlaceholder();
-    void showSearchText(const QString& text);
+    void switchState(State state);
     void updateEditBox(const QString& text);
+    void refreshEditBox();
+
+    void showPlaceholder();
+    bool shouldShowPlaceholder(const QString& text) const;
+    void showSearchText(const QString& text);
 
     void updateClearButton(const QString& text);
 
     QString getSearchText() const;
+
+    // Update the displayed text without (re-)starting the timer
+    void setTextBlockSignals(const QString& text);
 
     QToolButton* const m_clearButton;
 

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -18,10 +18,6 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
     static constexpr int kDefaultDebouncingTimeoutMillis = 300;
     static constexpr int kMaxDebouncingTimeoutMillis = 9999;
 
-    // Use 'active' property to apply an alternative style to the
-    // placeholder text
-    Q_PROPERTY(bool active READ isActive);
-
     // TODO(XXX): Replace with a public slot
     static void setDebouncingTimeoutMillis(int debouncingTimeoutMillis);
 
@@ -79,16 +75,4 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
     int m_innerHeight;
 
     QTimer m_debouncingTimer;
-
-    enum class State {
-        Active,
-        Inactive,
-    };
-    State m_state;
-
-    void switchState(State state);
-
-    bool isActive() const {
-        return m_state == State::Active ? true : false;
-    }
 };

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <QColor>
 #include <QDomNode>
 #include <QEvent>
 #include <QLineEdit>
@@ -90,8 +89,6 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
 
     int m_frameWidth;
     int m_innerHeight;
-
-    QColor m_foregroundColor;
 
     QTimer m_debouncingTimer;
 

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -28,9 +28,7 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
     explicit WSearchLineEdit(QWidget* pParent);
     ~WSearchLineEdit() override = default;
 
-    void setupSkin(
-            const QDomNode& node,
-            const SkinContext& context);
+    void setup(const QDomNode& node, const SkinContext& context);
 
   protected:
     void resizeEvent(QResizeEvent*) override;


### PR DESCRIPTION
***This escalated quickly and became a complete refactoring!***

- ~~A 3rd state was missing to cover all use cases~~ Now using built-in Qt features!!
- I found some more inconsistencies, i.e. handling of the Return key when the Clear button is focused
- `#define ENABLE_TRACE_LOG false` already anticipates the removal of `mixxx::Logger`

@ronso0 Unrelated issue: An empty search box never gets the focus again when using Tab!? I can only switch the focus between the sidebar and the table view. If the edit box is not empty then the Clear button gets the focus.

