### PR TITLE
make mic ducking use strength the same way in Auto & Man mode

### DIFF
--- a/src/engine/enginesidechaincompressor.cpp
+++ b/src/engine/enginesidechaincompressor.cpp
@@ -3,10 +3,10 @@
 #include "engine/enginesidechaincompressor.h"
 
 EngineSideChainCompressor::EngineSideChainCompressor(const char* group)
-        : m_compressRatio(0.0),
+        : m_compressRatio(1.0),
           m_bAboveThreshold(false),
           m_threshold(1.0),
-          m_strength(0.0),
+          m_strength(1.0),
           m_attackTime(0),
           m_decayTime(0),
           m_attackPerFrame(0.0),
@@ -54,28 +54,27 @@ void EngineSideChainCompressor::processKey(const CSAMPLE* pIn, const int iBuffer
 
 double EngineSideChainCompressor::calculateCompressedGain(int frames) {
     if (m_bAboveThreshold) {
-        if (m_compressRatio < m_strength) {
-            m_compressRatio += m_attackPerFrame * frames;
-            if (m_compressRatio > m_strength) {
+        if (m_compressRatio > m_strength) {
+            m_compressRatio -= m_attackPerFrame * frames;
+            if (m_compressRatio < m_strength) {
                 // If we overshot, clamp.
                 m_compressRatio = m_strength;
             }
-        } else if (m_compressRatio > m_strength) {
+        } else if (m_compressRatio < m_strength) {
             // If the strength param was changed, we might be compressing too much.
-            m_compressRatio -= m_decayPerFrame * frames;
+            m_compressRatio += m_decayPerFrame * frames;
         }
     } else {
-        if (m_compressRatio > 0) {
-            m_compressRatio -= m_decayPerFrame * frames;
-            if (m_compressRatio < 0) {
-                // If we overshot, clamp.
-                m_compressRatio = 0;
-            }
-        } else if (m_compressRatio < 0) {
-            // Complain loudly.
+        VERIFY_OR_DEBUG_ASSERT(m_compressRatio >= 0) {
             qWarning() << "Programming error, below-zero compression detected.";
-            m_compressRatio += m_attackPerFrame * frames;
+        }
+        if (m_compressRatio < 1) {
+            m_compressRatio += m_decayPerFrame * frames;
+            if (m_compressRatio > 1) {
+                // If we overshot, clamp.
+                m_compressRatio = 1;
+            }
         }
     }
-    return (1. - m_compressRatio);
+    return m_compressRatio;
 }


### PR DESCRIPTION
Previously, engine/enginetalkoverducking returned opposite gain values for 'strength' in Auto and Manual mode.

This commit removes the inversion from Auto mode, thus the Strength knob is like  a Music volume knob with both modes now, nicely illustrated with reversed knob arc:
![image](https://user-images.githubusercontent.com/5934199/80772798-27d6e880-8b58-11ea-8e1c-ca90c7e915fe.png)
* fully left: music muted completely
* fully right: music volume unchanged