### PR TITLE
Move Beats et al. to mixxx namespace

### DIFF
--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -139,7 +139,7 @@ bool AnalyzerBeats::shouldAnalyze(TrackPointer tio) const {
 
     // If the track already has a Beats object then we need to decide whether to
     // analyze this track or not.
-    BeatsPointer pBeats = tio->getBeats();
+    mixxx::BeatsPointer pBeats = tio->getBeats();
     if (pBeats) {
         QString version = pBeats->getVersion();
         QString subVersion = pBeats->getSubVersion();
@@ -205,7 +205,7 @@ void AnalyzerBeats::storeResults(TrackPointer tio) {
         return;
     }
 
-    BeatsPointer pBeats;
+    mixxx::BeatsPointer pBeats;
     if (m_pPlugin->supportsBeatTracking()) {
         QVector<double> beats = m_pPlugin->getBeats();
         QHash<QString, QString> extraVersionInfo = getExtraVersionInfo(
@@ -228,7 +228,7 @@ void AnalyzerBeats::storeResults(TrackPointer tio) {
         pBeats = BeatFactory::makeBeatGrid(*tio, bpm, 0.0f);
     }
 
-    BeatsPointer pCurrentBeats = tio->getBeats();
+    mixxx::BeatsPointer pCurrentBeats = tio->getBeats();
 
     // If the track has no beats object then set our newly generated one
     // regardless of beat lock.

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -158,8 +158,8 @@ double BpmControl::getBpm() const {
 }
 
 void BpmControl::slotAdjustBeatsFaster(double v) {
-    BeatsPointer pBeats = m_pBeats;
-    if (v > 0 && pBeats && (pBeats->getCapabilities() & Beats::BEATSCAP_SETBPM)) {
+    mixxx::BeatsPointer pBeats = m_pBeats;
+    if (v > 0 && pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM)) {
         double bpm = pBeats->getBpm();
         double adjustedBpm = bpm + kBpmAdjustStep;
         pBeats->setBpm(adjustedBpm);
@@ -167,8 +167,8 @@ void BpmControl::slotAdjustBeatsFaster(double v) {
 }
 
 void BpmControl::slotAdjustBeatsSlower(double v) {
-    BeatsPointer pBeats = m_pBeats;
-    if (v > 0 && pBeats && (pBeats->getCapabilities() & Beats::BEATSCAP_SETBPM)) {
+    mixxx::BeatsPointer pBeats = m_pBeats;
+    if (v > 0 && pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM)) {
         double bpm = pBeats->getBpm();
         double adjustedBpm = math_max(kBpmAdjustMin, bpm - kBpmAdjustStep);
         pBeats->setBpm(adjustedBpm);
@@ -176,18 +176,18 @@ void BpmControl::slotAdjustBeatsSlower(double v) {
 }
 
 void BpmControl::slotTranslateBeatsEarlier(double v) {
-    BeatsPointer pBeats = m_pBeats;
+    mixxx::BeatsPointer pBeats = m_pBeats;
     if (v > 0 && pBeats &&
-            (pBeats->getCapabilities() & Beats::BEATSCAP_TRANSLATE)) {
+            (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
         const int translate_dist = getSampleOfTrack().rate * -.01;
         pBeats->translate(translate_dist);
     }
 }
 
 void BpmControl::slotTranslateBeatsLater(double v) {
-    BeatsPointer pBeats = m_pBeats;
+    mixxx::BeatsPointer pBeats = m_pBeats;
     if (v > 0 && pBeats &&
-            (pBeats->getCapabilities() & Beats::BEATSCAP_TRANSLATE)) {
+            (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
         // TODO(rryan): Track::getSampleRate is possibly inaccurate!
         const int translate_dist = getSampleOfTrack().rate * .01;
         pBeats->translate(translate_dist);
@@ -208,7 +208,7 @@ void BpmControl::slotTapFilter(double averageLength, int numSamples) {
         return;
     }
 
-    BeatsPointer pBeats = m_pBeats;
+    mixxx::BeatsPointer pBeats = m_pBeats;
     if (!pBeats) {
         return;
     }
@@ -507,12 +507,12 @@ double BpmControl::getBeatDistance(double dThisPosition) const {
 }
 
 // static
-bool BpmControl::getBeatContext(const BeatsPointer& pBeats,
-                                const double dPosition,
-                                double* dpPrevBeat,
-                                double* dpNextBeat,
-                                double* dpBeatLength,
-                                double* dpBeatPercentage) {
+bool BpmControl::getBeatContext(const mixxx::BeatsPointer& pBeats,
+        const double dPosition,
+        double* dpPrevBeat,
+        double* dpNextBeat,
+        double* dpBeatLength,
+        double* dpBeatPercentage) {
     if (!pBeats) {
         return false;
     }
@@ -566,7 +566,7 @@ bool BpmControl::getBeatContextNoLookup(
 double BpmControl::getNearestPositionInPhase(
         double dThisPosition, bool respectLoops, bool playing) {
     // Without a beatgrid, we don't know the phase offset.
-    BeatsPointer pBeats = m_pBeats;
+    mixxx::BeatsPointer pBeats = m_pBeats;
     if (!pBeats) {
         return dThisPosition;
     }
@@ -624,7 +624,8 @@ double BpmControl::getNearestPositionInPhase(
         }
 
         TrackPointer otherTrack = pOtherEngineBuffer->getLoadedTrack();
-        BeatsPointer otherBeats = otherTrack ? otherTrack->getBeats() : BeatsPointer();
+        mixxx::BeatsPointer otherBeats =
+                otherTrack ? otherTrack->getBeats() : mixxx::BeatsPointer();
 
         // If either track does not have beats, then we can't adjust the phase.
         if (!otherBeats) {
@@ -781,7 +782,7 @@ double BpmControl::getBeatMatchPosition(
     }
 
     TrackPointer otherTrack = pOtherEngineBuffer->getLoadedTrack();
-    BeatsPointer otherBeats = otherTrack ? otherTrack->getBeats() : BeatsPointer();
+    mixxx::BeatsPointer otherBeats = otherTrack ? otherTrack->getBeats() : mixxx::BeatsPointer();
 
     // If either track does not have beats, then we can't adjust the phase.
     if (!otherBeats) {
@@ -909,14 +910,14 @@ void BpmControl::notifySeek(double dNewPlaypos) {
 
 // called from an engine worker thread
 void BpmControl::trackLoaded(TrackPointer pNewTrack) {
-    BeatsPointer pBeats;
+    mixxx::BeatsPointer pBeats;
     if (pNewTrack) {
         pBeats = pNewTrack->getBeats();
     }
     trackBeatsUpdated(pBeats);
 }
 
-void BpmControl::trackBeatsUpdated(BeatsPointer pBeats) {
+void BpmControl::trackBeatsUpdated(mixxx::BeatsPointer pBeats) {
     if (kLogger.traceEnabled()) {
         kLogger.trace() << getGroup() << "BpmControl::trackBeatsUpdated"
                         << (pBeats ? pBeats->getBpm() : 0.0);
@@ -927,8 +928,8 @@ void BpmControl::trackBeatsUpdated(BeatsPointer pBeats) {
 }
 
 void BpmControl::slotBeatsTranslate(double v) {
-    BeatsPointer pBeats = m_pBeats;
-    if (v > 0 && pBeats && (pBeats->getCapabilities() & Beats::BEATSCAP_TRANSLATE)) {
+    mixxx::BeatsPointer pBeats = m_pBeats;
+    if (v > 0 && pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
         double currentSample = getSampleOfTrack().current;
         double closestBeat = pBeats->findClosestBeat(currentSample);
         int delta = currentSample - closestBeat;
@@ -940,8 +941,8 @@ void BpmControl::slotBeatsTranslate(double v) {
 }
 
 void BpmControl::slotBeatsTranslateMatchAlignment(double v) {
-    BeatsPointer pBeats = m_pBeats;
-    if (v > 0 && pBeats && (pBeats->getCapabilities() & Beats::BEATSCAP_TRANSLATE)) {
+    mixxx::BeatsPointer pBeats = m_pBeats;
+    if (v > 0 && pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
         // Must reset the user offset *before* calling getPhaseOffset(),
         // otherwise it will always return 0 if master sync is active.
         m_dUserOffset.setValue(0.0);
@@ -954,7 +955,7 @@ void BpmControl::slotBeatsTranslateMatchAlignment(double v) {
 double BpmControl::updateLocalBpm() {
     double prev_local_bpm = m_pLocalBpm->get();
     double local_bpm = 0;
-    BeatsPointer pBeats = m_pBeats;
+    mixxx::BeatsPointer pBeats = m_pBeats;
     if (pBeats) {
         local_bpm = pBeats->getBpmAroundPosition(
                 getSampleOfTrack().current, kLocalBpmSpan);

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -53,12 +53,12 @@ class BpmControl : public EngineControl {
     // next beat, the current beat length, and the beat ratio (how far dPosition
     // lies within the current beat). Returns false if a previous or next beat
     // does not exist. NULL arguments are safe and ignored.
-    static bool getBeatContext(const BeatsPointer& pBeats,
-                               const double dPosition,
-                               double* dpPrevBeat,
-                               double* dpNextBeat,
-                               double* dpBeatLength,
-                               double* dpBeatPercentage);
+    static bool getBeatContext(const mixxx::BeatsPointer& pBeats,
+            const double dPosition,
+            double* dpPrevBeat,
+            double* dpNextBeat,
+            double* dpBeatLength,
+            double* dpBeatPercentage);
 
     // Alternative version that works if the next and previous beat positions
     // are already known.
@@ -77,7 +77,7 @@ class BpmControl : public EngineControl {
     double getRateRatio() const;
     void notifySeek(double dNewPlaypos) override;
     void trackLoaded(TrackPointer pNewTrack) override;
-    void trackBeatsUpdated(BeatsPointer pBeats) override;
+    void trackBeatsUpdated(mixxx::BeatsPointer pBeats) override;
 
   private slots:
     void slotAdjustBeatsFaster(double);
@@ -160,7 +160,7 @@ class BpmControl : public EngineControl {
     bool m_dUserTweakingSync;
 
     // m_pBeats is written from an engine worker thread
-    BeatsPointer m_pBeats;
+    mixxx::BeatsPointer m_pBeats;
 
     FRIEND_TEST(EngineSyncTest, UserTweakBeatDistance);
 };

--- a/src/engine/controls/clockcontrol.cpp
+++ b/src/engine/controls/clockcontrol.cpp
@@ -19,14 +19,14 @@ ClockControl::~ClockControl() {
 
 // called from an engine worker thread
 void ClockControl::trackLoaded(TrackPointer pNewTrack) {
-    BeatsPointer pBeats;
+    mixxx::BeatsPointer pBeats;
     if (pNewTrack) {
         pBeats = pNewTrack->getBeats();
     }
     trackBeatsUpdated(pBeats);
 }
 
-void ClockControl::trackBeatsUpdated(BeatsPointer pBeats) {
+void ClockControl::trackBeatsUpdated(mixxx::BeatsPointer pBeats) {
     // Clear on-beat control
     m_pCOBeatActive->set(0.0);
     m_pBeats = pBeats;
@@ -45,7 +45,7 @@ void ClockControl::process(const double dRate,
     // by the rate.
     const double blinkIntervalSamples = 2.0 * samplerate * (1.0 * dRate) * blinkSeconds;
 
-    BeatsPointer pBeats = m_pBeats;
+    mixxx::BeatsPointer pBeats = m_pBeats;
     if (pBeats) {
         double closestBeat = pBeats->findClosestBeat(currentSample);
         double distanceToClosestBeat = fabs(currentSample - closestBeat);

--- a/src/engine/controls/clockcontrol.h
+++ b/src/engine/controls/clockcontrol.h
@@ -22,14 +22,14 @@ class ClockControl: public EngineControl {
             const int iBufferSize) override;
 
     void trackLoaded(TrackPointer pNewTrack) override;
-    void trackBeatsUpdated(BeatsPointer pBeats) override;
+    void trackBeatsUpdated(mixxx::BeatsPointer pBeats) override;
 
   private:
     ControlObject* m_pCOBeatActive;
     ControlProxy* m_pCOSampleRate;
 
     // m_pBeats is written from an engine worker thread
-    BeatsPointer m_pBeats;
+    mixxx::BeatsPointer m_pBeats;
 };
 
 #endif /* CLOCKCONTROL_H */

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -579,7 +579,7 @@ void CueControl::trackCuesUpdated() {
     loadCuesFromTrack();
 }
 
-void CueControl::trackBeatsUpdated(BeatsPointer pBeats) {
+void CueControl::trackBeatsUpdated(mixxx::BeatsPointer pBeats) {
     Q_UNUSED(pBeats);
     loadCuesFromTrack();
 }
@@ -1682,7 +1682,7 @@ double CueControl::quantizeCuePoint(double cuePos) {
         return cuePos;
     }
 
-    BeatsPointer pBeats = m_pLoadedTrack->getBeats();
+    mixxx::BeatsPointer pBeats = m_pLoadedTrack->getBeats();
     if (!pBeats) {
         return cuePos;
     }

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -132,7 +132,7 @@ class CueControl : public EngineControl {
     bool getPlayFlashingAtPause();
     SeekOnLoadMode getSeekOnLoadPreference();
     void trackLoaded(TrackPointer pNewTrack) override;
-    void trackBeatsUpdated(BeatsPointer pBeats) override;
+    void trackBeatsUpdated(mixxx::BeatsPointer pBeats) override;
 
   private slots:
     void quantizeChanged(double v);

--- a/src/engine/controls/enginecontrol.cpp
+++ b/src/engine/controls/enginecontrol.cpp
@@ -31,7 +31,7 @@ void EngineControl::trackLoaded(TrackPointer pNewTrack) {
     Q_UNUSED(pNewTrack);
 }
 
-void EngineControl::trackBeatsUpdated(BeatsPointer pBeats) {
+void EngineControl::trackBeatsUpdated(mixxx::BeatsPointer pBeats) {
     Q_UNUSED(pBeats);
 }
 

--- a/src/engine/controls/enginecontrol.h
+++ b/src/engine/controls/enginecontrol.h
@@ -67,7 +67,7 @@ class EngineControl : public QObject {
     // Called whenever a seek occurs to allow the EngineControl to respond.
     virtual void notifySeek(double dNewPlaypos);
     virtual void trackLoaded(TrackPointer pNewTrack);
-    virtual void trackBeatsUpdated(BeatsPointer pBeats);
+    virtual void trackBeatsUpdated(mixxx::BeatsPointer pBeats);
 
   protected:
     struct SampleOfTrack {

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -514,7 +514,7 @@ double LoopingControl::getSyncPositionInsideLoop(double dRequestedPlaypos, doubl
 
 void LoopingControl::setLoopInToCurrentPosition() {
     // set loop-in position
-    BeatsPointer pBeats = m_pBeats;
+    mixxx::BeatsPointer pBeats = m_pBeats;
     LoopSamples loopSamples = m_loopSamples.getValue();
     double quantizedBeat = -1;
     double pos = m_currentSample.getValue();
@@ -616,7 +616,7 @@ void LoopingControl::slotLoopInGoto(double pressed) {
 }
 
 void LoopingControl::setLoopOutToCurrentPosition() {
-    BeatsPointer pBeats = m_pBeats;
+    mixxx::BeatsPointer pBeats = m_pBeats;
     LoopSamples loopSamples = m_loopSamples.getValue();
     double quantizedBeat = -1;
     int pos = m_currentSample.getValue();
@@ -873,14 +873,14 @@ bool LoopingControl::isLoopingEnabled() {
 
 void LoopingControl::trackLoaded(TrackPointer pNewTrack) {
     m_pTrack = pNewTrack;
-    BeatsPointer pBeats;
+    mixxx::BeatsPointer pBeats;
     if (pNewTrack) {
         pBeats = pNewTrack->getBeats();
     }
     trackBeatsUpdated(pBeats);
 }
 
-void LoopingControl::trackBeatsUpdated(BeatsPointer pBeats) {
+void LoopingControl::trackBeatsUpdated(mixxx::BeatsPointer pBeats) {
     clearActiveBeatLoop();
     m_pBeats = pBeats;
     if (m_pBeats) {
@@ -958,7 +958,7 @@ void LoopingControl::clearActiveBeatLoop() {
 }
 
 bool LoopingControl::currentLoopMatchesBeatloopSize() {
-    BeatsPointer pBeats = m_pBeats;
+    mixxx::BeatsPointer pBeats = m_pBeats;
     if (!pBeats) {
         return false;
     }
@@ -974,7 +974,7 @@ bool LoopingControl::currentLoopMatchesBeatloopSize() {
 }
 
 double LoopingControl::findBeatloopSizeForLoop(double start, double end) const {
-    BeatsPointer pBeats = m_pBeats;
+    mixxx::BeatsPointer pBeats = m_pBeats;
     if (!pBeats) {
         return -1;
     }
@@ -1032,7 +1032,7 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable
     }
 
     int samples = m_pTrackSamples->get();
-    BeatsPointer pBeats = m_pBeats;
+    mixxx::BeatsPointer pBeats = m_pBeats;
     if (samples == 0 || !pBeats) {
         clearActiveBeatLoop();
         m_pCOBeatLoopSize->setAndConfirm(beats);
@@ -1198,7 +1198,7 @@ void LoopingControl::slotBeatLoopRollActivate(double pressed) {
 }
 
 void LoopingControl::slotBeatJump(double beats) {
-    BeatsPointer pBeats = m_pBeats;
+    mixxx::BeatsPointer pBeats = m_pBeats;
     if (!pBeats) {
         return;
     }
@@ -1229,7 +1229,7 @@ void LoopingControl::slotBeatJumpBackward(double pressed) {
 }
 
 void LoopingControl::slotLoopMove(double beats) {
-    BeatsPointer pBeats = m_pBeats;
+    mixxx::BeatsPointer pBeats = m_pBeats;
     if (!pBeats || beats == 0) {
         return;
     }

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -55,7 +55,7 @@ class LoopingControl : public EngineControl {
     bool isLoopingEnabled();
 
     void trackLoaded(TrackPointer pNewTrack) override;
-    void trackBeatsUpdated(BeatsPointer pBeats) override;
+    void trackBeatsUpdated(mixxx::BeatsPointer pBeats) override;
 
   public slots:
     void slotLoopIn(double pressed);
@@ -171,7 +171,7 @@ class LoopingControl : public EngineControl {
 
     // objects below are written from an engine worker thread
     TrackPointer m_pTrack;
-    BeatsPointer m_pBeats;
+    mixxx::BeatsPointer m_pBeats;
 };
 
 // Class for handling loop moves of a set size. This allows easy access from

--- a/src/engine/controls/quantizecontrol.cpp
+++ b/src/engine/controls/quantizecontrol.cpp
@@ -47,7 +47,7 @@ void QuantizeControl::trackLoaded(TrackPointer pNewTrack) {
     }
 }
 
-void QuantizeControl::trackBeatsUpdated(BeatsPointer pBeats) {
+void QuantizeControl::trackBeatsUpdated(mixxx::BeatsPointer pBeats) {
     m_pBeats = pBeats;
     double current = getSampleOfTrack().current;
     lookupBeatPositions(current);
@@ -79,7 +79,7 @@ void QuantizeControl::playPosChanged(double dNewPlaypos) {
 }
 
 void QuantizeControl::lookupBeatPositions(double dCurrentSample) {
-    BeatsPointer pBeats = m_pBeats;
+    mixxx::BeatsPointer pBeats = m_pBeats;
     if (pBeats) {
         double prevBeat, nextBeat;
         pBeats->findPrevNextBeats(dCurrentSample, &prevBeat, &nextBeat);

--- a/src/engine/controls/quantizecontrol.h
+++ b/src/engine/controls/quantizecontrol.h
@@ -22,7 +22,7 @@ class QuantizeControl : public EngineControl {
             const double dTotalSamples, const double dTrackSampleRate) override;
     void notifySeek(double dNewPlaypos) override;
     void trackLoaded(TrackPointer pNewTrack) override;
-    void trackBeatsUpdated(BeatsPointer pBeats) override;
+    void trackBeatsUpdated(mixxx::BeatsPointer pBeats) override;
 
   private:
     // Update positions of previous and next beats from beatgrid.
@@ -38,7 +38,7 @@ class QuantizeControl : public EngineControl {
     ControlObject* m_pCOClosestBeat;
 
     // m_pBeats is written from an engine worker thread
-    BeatsPointer m_pBeats;
+    mixxx::BeatsPointer m_pBeats;
 };
 
 #endif // QUANTIZECONTROL_H

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -322,14 +322,14 @@ void SyncControl::reportTrackPosition(double fractionalPlaypos) {
 
 // called from an engine worker thread
 void SyncControl::trackLoaded(TrackPointer pNewTrack) {
-    BeatsPointer pBeats;
+    mixxx::BeatsPointer pBeats;
     if (pNewTrack) {
         pBeats = pNewTrack->getBeats();
     }
     trackBeatsUpdated(pBeats);
 }
 
-void SyncControl::trackBeatsUpdated(BeatsPointer pBeats) {
+void SyncControl::trackBeatsUpdated(mixxx::BeatsPointer pBeats) {
     // This slot is fired by a new file is loaded or if the user
     // has adjusted the beatgrid.
     if (kLogger.traceEnabled()) {
@@ -491,7 +491,7 @@ void SyncControl::notifySeek(double dNewPlaypos) {
 }
 
 double SyncControl::fileBpm() const {
-    BeatsPointer pBeats = m_pBeats;
+    mixxx::BeatsPointer pBeats = m_pBeats;
     if (pBeats) {
         return pBeats->getBpm();
     }

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -61,7 +61,7 @@ class SyncControl : public EngineControl, public Syncable {
     void reportPlayerSpeed(double speed, bool scratching);
     void notifySeek(double dNewPlaypos) override;
     void trackLoaded(TrackPointer pNewTrack) override;
-    void trackBeatsUpdated(BeatsPointer pBeats) override;
+    void trackBeatsUpdated(mixxx::BeatsPointer pBeats) override;
 
   private slots:
     // Fired by changes in play.
@@ -133,7 +133,7 @@ class SyncControl : public EngineControl, public Syncable {
     ControlProxy* m_pQuantize;
 
     // m_pBeats is written from an engine worker thread
-    BeatsPointer m_pBeats;
+    mixxx::BeatsPointer m_pBeats;
 };
 
 

--- a/src/library/banshee/bansheeplaylistmodel.cpp
+++ b/src/library/banshee/bansheeplaylistmodel.cpp
@@ -294,7 +294,7 @@ TrackPointer BansheePlaylistModel::getTrack(const QModelIndex& index) const {
         pTrack->setComposer(getFieldString(index, CLM_COMPOSER));
         // If the track has a BPM, then give it a static beatgrid.
         if (bpm > 0) {
-            BeatsPointer pBeats = BeatFactory::makeBeatGrid(*pTrack, bpm, 0.0);
+            mixxx::BeatsPointer pBeats = BeatFactory::makeBeatGrid(*pTrack, bpm, 0.0);
             pTrack->setBeats(pBeats);
         }
 

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -461,7 +461,7 @@ namespace {
         QString beatsSubVersion;
         // Fall back on cached BPM
         double dBpm = track.getBpm();
-        const BeatsPointer pBeats(track.getBeats());
+        const mixxx::BeatsPointer pBeats(track.getBeats());
         if (!pBeats.isNull()) {
             beatsBlob = pBeats->toByteArray();
             beatsVersion = pBeats->getVersion();
@@ -1059,7 +1059,7 @@ bool setTrackBeats(const QSqlRecord& record, const int column,
     QString beatsSubVersion = record.value(column + 2).toString();
     QByteArray beatsBlob = record.value(column + 3).toByteArray();
     bool bpmLocked = record.value(column + 4).toBool();
-    BeatsPointer pBeats = BeatFactory::loadBeatsFromByteArray(
+    mixxx::BeatsPointer pBeats = BeatFactory::loadBeatsFromByteArray(
             *pTrack, beatsVersion, beatsSubVersion, beatsBlob);
     if (pBeats) {
         pTrack->setBeats(pBeats);

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -272,7 +272,7 @@ void DlgTrackInfo::populateFields(const Track& track) {
 }
 
 void DlgTrackInfo::reloadTrackBeats(const Track& track) {
-    BeatsPointer pBeats = track.getBeats();
+    mixxx::BeatsPointer pBeats = track.getBeats();
     if (pBeats) {
         spinBpm->setValue(pBeats->getBpm());
         m_pBeatsClone = pBeats->clone();
@@ -280,7 +280,7 @@ void DlgTrackInfo::reloadTrackBeats(const Track& track) {
         m_pBeatsClone.clear();
         spinBpm->setValue(0.0);
     }
-    m_trackHasBeatMap = pBeats && !(pBeats->getCapabilities() & Beats::BEATSCAP_SETBPM);
+    m_trackHasBeatMap = pBeats && !(pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM);
     bpmConst->setChecked(!m_trackHasBeatMap);
     bpmConst->setEnabled(m_trackHasBeatMap); // We cannot make turn a BeatGrid to a BeatMap
     spinBpm->setEnabled(!m_trackHasBeatMap); // We cannot change bpm continuously or tab them
@@ -461,42 +461,42 @@ void DlgTrackInfo::clear() {
 }
 
 void DlgTrackInfo::slotBpmDouble() {
-    m_pBeatsClone->scale(Beats::DOUBLE);
+    m_pBeatsClone->scale(mixxx::Beats::DOUBLE);
     // read back the actual value
     double newValue = m_pBeatsClone->getBpm();
     spinBpm->setValue(newValue);
 }
 
 void DlgTrackInfo::slotBpmHalve() {
-    m_pBeatsClone->scale(Beats::HALVE);
+    m_pBeatsClone->scale(mixxx::Beats::HALVE);
     // read back the actual value
     double newValue = m_pBeatsClone->getBpm();
     spinBpm->setValue(newValue);
 }
 
 void DlgTrackInfo::slotBpmTwoThirds() {
-    m_pBeatsClone->scale(Beats::TWOTHIRDS);
+    m_pBeatsClone->scale(mixxx::Beats::TWOTHIRDS);
     // read back the actual value
     double newValue = m_pBeatsClone->getBpm();
     spinBpm->setValue(newValue);
 }
 
 void DlgTrackInfo::slotBpmThreeFourth() {
-    m_pBeatsClone->scale(Beats::THREEFOURTHS);
+    m_pBeatsClone->scale(mixxx::Beats::THREEFOURTHS);
     // read back the actual value
     double newValue = m_pBeatsClone->getBpm();
     spinBpm->setValue(newValue);
 }
 
 void DlgTrackInfo::slotBpmFourThirds() {
-    m_pBeatsClone->scale(Beats::FOURTHIRDS);
+    m_pBeatsClone->scale(mixxx::Beats::FOURTHIRDS);
     // read back the actual value
     double newValue = m_pBeatsClone->getBpm();
     spinBpm->setValue(newValue);
 }
 
 void DlgTrackInfo::slotBpmThreeHalves() {
-    m_pBeatsClone->scale(Beats::THREEHALVES);
+    m_pBeatsClone->scale(mixxx::Beats::THREEHALVES);
     // read back the actual value
     double newValue = m_pBeatsClone->getBpm();
     spinBpm->setValue(newValue);
@@ -566,7 +566,7 @@ void DlgTrackInfo::slotSpinBpmValueChanged(double value) {
         return;
     }
 
-    if (m_pBeatsClone->getCapabilities() & Beats::BEATSCAP_SETBPM) {
+    if (m_pBeatsClone->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM) {
         m_pBeatsClone->setBpm(value);
     }
 

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -90,7 +90,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void clear();
     void init();
     TrackPointer m_pLoadedTrack;
-    BeatsPointer m_pBeatsClone;
+    mixxx::BeatsPointer m_pBeatsClone;
     Keys m_keysClone;
     bool m_trackHasBeatMap;
 

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -861,7 +861,7 @@ void readAnalyze(TrackPointer track, double sampleRate, int timingOffset, bool i
 
             QHash<QString, QString> extraVersionInfo;
 
-            BeatsPointer pBeats = BeatFactory::makePreferredBeats(
+            mixxx::BeatsPointer pBeats = BeatFactory::makePreferredBeats(
                     *track, beats, extraVersionInfo, false, false, sampleRate, 0, 0, 0);
 
             track->setBeats(pBeats);

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -4,6 +4,8 @@
 #include "track/beatgrid.h"
 #include "util/memory.h"
 
+using namespace mixxx;
+
 namespace {
 
 const double kMaxBeatError = 1e-9;

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -4,6 +4,8 @@
 #include "track/beatmap.h"
 #include "util/memory.h"
 
+using namespace mixxx;
+
 namespace {
 
 class BeatMapTest : public testing::Test {

--- a/src/test/beatstranslatetest.cpp
+++ b/src/test/beatstranslatetest.cpp
@@ -9,14 +9,14 @@ TEST_F(BeatsTranslateTest, SimpleTranslateMatch) {
     // Set up BeatGrids for decks 1 and 2.
     const double bpm = 60.0;
     const double firstBeat = 0.0;
-    auto grid1 = new BeatGrid(*m_pTrack1, m_pTrack1->getSampleRate());
+    auto grid1 = new mixxx::BeatGrid(*m_pTrack1, m_pTrack1->getSampleRate());
     grid1->setGrid(bpm, firstBeat);
-    m_pTrack1->setBeats(BeatsPointer(grid1));
+    m_pTrack1->setBeats(mixxx::BeatsPointer(grid1));
     ASSERT_DOUBLE_EQ(firstBeat, grid1->findClosestBeat(0));
 
-    auto grid2 = new BeatGrid(*m_pTrack2, m_pTrack2->getSampleRate());
+    auto grid2 = new mixxx::BeatGrid(*m_pTrack2, m_pTrack2->getSampleRate());
     grid2->setGrid(bpm, firstBeat);
-    m_pTrack2->setBeats(BeatsPointer(grid2));
+    m_pTrack2->setBeats(mixxx::BeatsPointer(grid2));
     ASSERT_DOUBLE_EQ(firstBeat, grid2->findClosestBeat(0));
 
     // Seek deck 1 forward a bit.

--- a/src/test/bpmcontrol_test.cpp
+++ b/src/test/bpmcontrol_test.cpp
@@ -38,7 +38,7 @@ TEST_F(BpmControlTest, BeatContext_BeatGrid) {
     const int kFrameSize = 2;
     const double expectedBeatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
-    BeatsPointer pBeats = BeatFactory::makeBeatGrid(*pTrack, bpm, 0);
+    mixxx::BeatsPointer pBeats = BeatFactory::makeBeatGrid(*pTrack, bpm, 0);
 
     // On a beat.
     double prevBeat, nextBeat, beatLength, beatPercentage;

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -145,9 +145,9 @@ TEST_F(EngineSyncTest, SetMasterSuccess) {
 TEST_F(EngineSyncTest, ExplicitMasterPersists) {
     // If we set an explicit master, enabling sync or pressing play on other decks
     // doesn't cause the master to move around.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 120, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 120, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 124, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 124, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     auto pButtonMasterSync1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
@@ -175,11 +175,11 @@ TEST_F(EngineSyncTest, ExplicitMasterPersists) {
 
 TEST_F(EngineSyncTest, SetMasterWhilePlaying) {
     // Make sure we don't get two master lights if we change masters while playing.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 120, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 120, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 124, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 124, 0.0);
     m_pTrack2->setBeats(pBeats2);
-    BeatsPointer pBeats3 = BeatFactory::makeBeatGrid(*m_pTrack3, 128, 0.0);
+    mixxx::BeatsPointer pBeats3 = BeatFactory::makeBeatGrid(*m_pTrack3, 128, 0.0);
     m_pTrack3->setBeats(pBeats3);
 
     auto pButtonMasterSync1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
@@ -206,7 +206,7 @@ TEST_F(EngineSyncTest, SetMasterWhilePlaying) {
 
 TEST_F(EngineSyncTest, SetEnabledBecomesMaster) {
     // If we set the first channel with a valid tempo to follower, it should be master.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 80, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 80, 0.0);
     m_pTrack1->setBeats(pBeats1);
     auto pButtonMasterSync1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     pButtonMasterSync1->slotSet(SYNC_FOLLOWER);
@@ -229,10 +229,10 @@ TEST_F(EngineSyncTest, DisableInternalMasterWhilePlaying) {
     assertIsExplicitMaster(m_sInternalClockGroup);
 
     // Make sure both decks are playing.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 80, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 80, 0.0);
     m_pTrack1->setBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 80, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 80, 0.0);
     m_pTrack2->setBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup2, "play"))->set(1.0);
     ProcessBuffer();
@@ -248,12 +248,12 @@ TEST_F(EngineSyncTest, DisableInternalMasterWhilePlaying) {
 
 TEST_F(EngineSyncTest, DisableSyncOnMaster) {
     // Channel 1 follower, channel 2 master.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
     auto pButtonSyncMode1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     pButtonSyncMode1->slotSet(SYNC_FOLLOWER);
 
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 130, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 130, 0.0);
     m_pTrack2->setBeats(pBeats2);
     auto pButtonSyncMaster2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_master");
     pButtonSyncMaster2->slotSet(1.0);
@@ -278,7 +278,7 @@ TEST_F(EngineSyncTest, InternalMasterSetFollowerSliderMoves) {
     pMasterSyncSlider->set(100.0);
 
     // Set the file bpm of channel 1 to 80 bpm.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 80, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 80, 0.0);
     m_pTrack1->setBeats(pBeats1);
 
     auto pButtonMasterSync1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
@@ -294,7 +294,7 @@ TEST_F(EngineSyncTest, AnySyncDeckSliderStays) {
     // If there exists a sync deck, even if it's not playing, don't change the
     // master BPM if a new deck enables sync.
 
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 80, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 80, 0.0);
     m_pTrack1->setBeats(pBeats1);
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     pButtonSyncEnabled1->set(1.0);
@@ -303,7 +303,7 @@ TEST_F(EngineSyncTest, AnySyncDeckSliderStays) {
     EXPECT_FLOAT_EQ(80.0,
                     ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))->get());
 
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 100, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 100, 0.0);
     m_pTrack2->setBeats(pBeats2);
     auto pButtonSyncEnabled2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     pButtonSyncEnabled2->set(1.0);
@@ -321,11 +321,11 @@ TEST_F(EngineSyncTest, InternalClockFollowsFirstPlayingDeck) {
     auto pButtonSyncEnabled2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
 
     // Set up decks so they can be playing, and start deck 1.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 100, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 100, 0.0);
     m_pTrack1->setBeats(pBeats1);
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 130, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 130, 0.0);
     m_pTrack2->setBeats(pBeats2);
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup2, "play"), 0.0);
@@ -386,10 +386,10 @@ TEST_F(EngineSyncTest, SetExplicitMasterByLights) {
     auto pButtonSyncMaster2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_master");
 
     // Set the file bpm of channel 1 to 160bpm.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
     m_pTrack1->setBeats(pBeats1);
     // Set the file bpm of channel 2 to 150bpm.
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack1, 150, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack1, 150, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     // Set channel 1 to be explicit master.
@@ -458,7 +458,7 @@ TEST_F(EngineSyncTest, RateChangeTest) {
     ProcessBuffer();
 
     // Set the file bpm of channel 1 to 160bpm.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
     m_pTrack1->setBeats(pBeats1);
     EXPECT_FLOAT_EQ(160.0, ControlObject::get(ConfigKey(m_sGroup1, "file_bpm")));
     ProcessBuffer();
@@ -474,7 +474,7 @@ TEST_F(EngineSyncTest, RateChangeTest) {
     EXPECT_FLOAT_EQ(192.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
     m_pTrack2->setBeats(pBeats2);
     EXPECT_FLOAT_EQ(120.0, ControlObject::get(ConfigKey(m_sGroup2, "file_bpm")));
 
@@ -493,12 +493,12 @@ TEST_F(EngineSyncTest, RateChangeTestWeirdOrder) {
     ProcessBuffer();
 
     // Set the file bpm of channel 1 to 160bpm.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
     m_pTrack1->setBeats(pBeats1);
     EXPECT_FLOAT_EQ(160.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     // Set the rate slider of channel 1 to 1.2.
@@ -515,12 +515,12 @@ TEST_F(EngineSyncTest, RateChangeTestWeirdOrder) {
 
 TEST_F(EngineSyncTest, RateChangeTestOrder3) {
     // Set the file bpm of channel 1 to 160bpm.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
     m_pTrack1->setBeats(pBeats1);
     EXPECT_FLOAT_EQ(160.0, ControlObject::get(ConfigKey(m_sGroup1, "file_bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
     m_pTrack2->setBeats(pBeats2);
     EXPECT_FLOAT_EQ(120.0, ControlObject::get(ConfigKey(m_sGroup2, "file_bpm")));
 
@@ -552,11 +552,11 @@ TEST_F(EngineSyncTest, FollowerRateChange) {
     ProcessBuffer();
 
     // Set the file bpm of channel 1 to 160bpm.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
     m_pTrack1->setBeats(pBeats1);
 
     // Set the file bpm of channel 2 to 120bpm.
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     // Set the rate slider of channel 1 to 1.2.
@@ -595,12 +595,12 @@ TEST_F(EngineSyncTest, InternalRateChangeTest) {
     assertIsFollower(m_sGroup2);
 
     // Set the file bpm of channel 1 to 160bpm.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
     m_pTrack1->setBeats(pBeats1);
     EXPECT_FLOAT_EQ(160.0, ControlObject::getControl(ConfigKey(m_sGroup1, "file_bpm"))->get());
 
     // Set the file bpm of channel 2 to 120bpm.
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
     m_pTrack2->setBeats(pBeats2);
     EXPECT_FLOAT_EQ(120.0, ControlObject::getControl(ConfigKey(m_sGroup2, "file_bpm"))->get());
 
@@ -639,9 +639,9 @@ TEST_F(EngineSyncTest, InternalRateChangeTest) {
 
 TEST_F(EngineSyncTest, MasterStopSliderCheck) {
     // If the master is playing, and stop is pushed, the sliders should stay the same.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 120, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 120, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 128, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 128, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     auto pButtonMasterSync1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
@@ -681,7 +681,7 @@ TEST_F(EngineSyncTest, EnableOneDeckInitsMaster) {
     ProcessBuffer();
 
     // Set up the deck to play.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))->set(getRateSliderValue(1.0));
     ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->set(0.2);
@@ -705,7 +705,7 @@ TEST_F(EngineSyncTest, EnableOneDeckInitsMaster) {
                                                         "beat_distance")));
 
     // Enable second deck, bpm and beat distance should still match original setting.
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 140, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 140, 0.0);
     m_pTrack2->setBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))->set(getRateSliderValue(1.0));
     ControlObject::getControl(ConfigKey(m_sGroup2, "beat_distance"))->set(0.2);
@@ -729,7 +729,7 @@ TEST_F(EngineSyncTest, EnableOneDeckInitsMaster) {
 TEST_F(EngineSyncTest, EnableOneDeckInitializesMaster) {
     // Enabling sync on a deck causes it to be master, and sets bpm and clock.
     // Set the deck to play.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))->set(getRateSliderValue(1.0));
     ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->set(0.2);
@@ -918,7 +918,7 @@ TEST_F(EngineSyncTest, EnableOneDeckSliderUpdates) {
     // If we enable a deck to be master, the internal slider should immediately update.
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
 
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))->set(getRateSliderValue(1.0));
 
@@ -941,11 +941,11 @@ TEST_F(EngineSyncTest, SyncToNonSyncDeck) {
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     auto pButtonSyncEnabled2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
 
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
     ProcessBuffer();
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 100, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 100, 0.0);
     m_pTrack2->setBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))->set(getRateSliderValue(1.0));
 
@@ -1017,11 +1017,11 @@ TEST_F(EngineSyncTest, MomentarySyncDependsOnPlayingStates) {
     auto pButtonSyncEnabled2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
 
     // Set up decks so they can be playing, and start deck 1.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 100, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 100, 0.0);
     m_pTrack1->setBeats(pBeats1);
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 130, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 130, 0.0);
     m_pTrack2->setBeats(pBeats2);
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup2, "play"), 1.0);
@@ -1089,7 +1089,7 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
     auto pButtonSyncEnabled2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     auto pButtonEject1 = std::make_unique<ControlProxy>(m_sGroup1, "eject");
 
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 120, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 120, 0.0);
     m_pTrack1->setBeats(pBeats1);
     pButtonSyncEnabled1->set(1.0);
     ProcessBuffer();
@@ -1114,7 +1114,7 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
     m_pMixerDeck1->loadFakeTrack(false, 128.0);
     EXPECT_FLOAT_EQ(128.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 135, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 135, 0.0);
     m_pTrack2->setBeats(pBeats2);
     pButtonSyncEnabled2->set(1.0);
     ProcessBuffer();
@@ -1124,7 +1124,7 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
     assertIsFollower(m_sGroup2);
 
     pButtonEject1->set(1.0);
-    m_pTrack1->setBeats(BeatsPointer());
+    m_pTrack1->setBeats(mixxx::BeatsPointer());
     ProcessBuffer();
 
     assertIsFollower(m_sInternalClockGroup);
@@ -1134,13 +1134,13 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
 
 TEST_F(EngineSyncTest, FileBpmChangesDontAffectMaster) {
     // If filebpm changes, don't treat it like a rate change.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 100, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 100, 0.0);
     m_pTrack1->setBeats(pBeats1);
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     pButtonSyncEnabled1->set(1.0);
     ProcessBuffer();
 
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
     m_pTrack2->setBeats(pBeats2);
     auto pButtonSyncEnabled2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     pButtonSyncEnabled2->set(1.0);
@@ -1158,7 +1158,7 @@ TEST_F(EngineSyncTest, ExplicitMasterPostProcessed) {
     // channel gets post-processed.
     auto pButtonMasterSync1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     pButtonMasterSync1->slotSet(SYNC_MASTER_EXPLICIT);
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
     m_pTrack1->setBeats(pBeats1);
     ProcessBuffer();
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
@@ -1170,14 +1170,14 @@ TEST_F(EngineSyncTest, ExplicitMasterPostProcessed) {
 TEST_F(EngineSyncTest, ZeroBPMRateAdjustIgnored) {
     // If a track isn't loaded (0 bpm), but the deck has sync enabled,
     // don't pay attention to rate changes.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 0, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 0, 0.0);
     m_pTrack1->setBeats(pBeats1);
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     pButtonSyncEnabled1->set(1.0);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))->set(getRateSliderValue(1.0));
     ProcessBuffer();
 
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
     m_pTrack2->setBeats(pBeats2);
     auto pButtonSyncEnabled2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     pButtonSyncEnabled2->set(1.0);
@@ -1210,9 +1210,9 @@ TEST_F(EngineSyncTest, ZeroBPMRateAdjustIgnored) {
 TEST_F(EngineSyncTest, ZeroLatencyRateChange) {
     // Confirm that a rate change in an explicit master is instantly communicated
     // to followers.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 128, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 128, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 128, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 128, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
@@ -1242,9 +1242,9 @@ TEST_F(EngineSyncTest, ZeroLatencyRateChange) {
 }
 
 TEST_F(EngineSyncTest, HalfDoubleBpmTest) {
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 70, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 70, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 140, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 140, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
@@ -1317,9 +1317,9 @@ TEST_F(EngineSyncTest, HalfDoubleBpmTest) {
 TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
     // If a deck plays that had its multiplier set, we need to reset the
     // internal clock.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 80, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 80, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 175, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 175, 0.0);
     m_pTrack2->setBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))->set(getRateSliderValue(1.0));
 
@@ -1402,9 +1402,9 @@ TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
 
 TEST_F(EngineSyncTest, HalfDoubleInternalClockTest) {
     // If we set the file_bpm CO's directly, the correct signals aren't fired.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 70, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 70, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 140, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 140, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
@@ -1441,13 +1441,13 @@ TEST_F(EngineSyncTest, HalfDoubleConsistency) {
     double startOffsetFrames = 0;
     const int numBeats = 100;
     QVector<double> beats1 = createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pBeats1 = new BeatMap(*m_pTrack1, 0, beats1);
-    m_pTrack1->setBeats(BeatsPointer(pBeats1));
+    auto pBeats1 = new mixxx::BeatMap(*m_pTrack1, 0, beats1);
+    m_pTrack1->setBeats(mixxx::BeatsPointer(pBeats1));
 
     beatLengthFrames = 60.0 * 44100 / 145.0;
     QVector<double> beats2 = createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pBeats2 = new BeatMap(*m_pTrack2, 0, beats2);
-    m_pTrack2->setBeats(BeatsPointer(pBeats2));
+    auto pBeats2 = new mixxx::BeatMap(*m_pTrack2, 0, beats2);
+    m_pTrack2->setBeats(mixxx::BeatsPointer(pBeats2));
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
     ControlObject::getControl(ConfigKey(m_sGroup2, "sync_enabled"))->set(1);
@@ -1468,7 +1468,7 @@ TEST_F(EngineSyncTest, HalfDoubleConsistency) {
 
 TEST_F(EngineSyncTest, SetFileBpmUpdatesLocalBpm) {
     ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->set(0.2);
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
     ASSERT_EQ(130.0, m_pEngineSync->getSyncableForGroup(m_sGroup1)->getBaseBpm());
 }
@@ -1478,13 +1478,13 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
     // deck if there are no sync decks and the non-sync deck is playing.
 
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
 
     auto pButtonSyncEnabled2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     ControlObject::set(ConfigKey(m_sGroup2, "rate_ratio"), 1.0);
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 100, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 100, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     // Set the sync deck playing with nothing else active.
@@ -1559,7 +1559,7 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
     auto pButtonSyncEnabled3 = std::make_unique<ControlProxy>(m_sGroup3, "sync_enabled");
     ControlObject::set(ConfigKey(m_sGroup3, "beat_distance"), 0.6);
     ControlObject::set(ConfigKey(m_sGroup2, "rate_ratio"), 1.0);
-    BeatsPointer pBeats3 = BeatFactory::makeBeatGrid(*m_pTrack3, 140, 0.0);
+    mixxx::BeatsPointer pBeats3 = BeatFactory::makeBeatGrid(*m_pTrack3, 140, 0.0);
     m_pTrack3->setBeats(pBeats3);
     // This will sync to the first deck here and not the second (lp1784185)
     pButtonSyncEnabled3->set(1.0);
@@ -1594,9 +1594,9 @@ TEST_F(EngineSyncTest, UserTweakBeatDistance) {
     // If a deck has a user tweak, and another deck stops such that the first
     // is used to reseed the master beat distance, make sure the user offset
     // is reset.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 128, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 128, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 128, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 128, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
@@ -1638,9 +1638,9 @@ TEST_F(EngineSyncTest, UserTweakBeatDistance) {
 }
 
 TEST_F(EngineSyncTest, UserTweakPreservedInSeek) {
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 128, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 128, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 130, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 130, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
@@ -1684,13 +1684,13 @@ TEST_F(EngineSyncTest, UserTweakPreservedInSeek) {
 }
 
 TEST_F(EngineSyncTest, MasterBpmNeverZero) {
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 128, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 128, 0.0);
     m_pTrack1->setBeats(pBeats1);
 
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     pButtonSyncEnabled1->set(1.0);
 
-    m_pTrack1->setBeats(BeatsPointer());
+    m_pTrack1->setBeats(mixxx::BeatsPointer());
     EXPECT_EQ(128.0,
               ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))->get());
 }
@@ -1699,7 +1699,7 @@ TEST_F(EngineSyncTest, ZeroBpmNaturalRate) {
     // If a track has a zero bpm and a bad beatgrid, make sure the rate
     // doesn't end up something crazy when sync is enabled..
     // Maybe the beatgrid ended up at zero also.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 0.0, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 0.0, 0.0);
     m_pTrack1->setBeats(pBeats1);
 
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
@@ -1718,11 +1718,11 @@ TEST_F(EngineSyncTest, QuantizeImpliesSyncPhase) {
     auto pButtonBeatsync1 = std::make_unique<ControlProxy>(m_sGroup1, "beatsync");
     auto pButtonBeatsyncPhase1 = std::make_unique<ControlProxy>(m_sGroup1, "beatsync_phase");
 
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
 
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 100, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 100, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
@@ -1812,7 +1812,7 @@ TEST_F(EngineSyncTest, QuantizeImpliesSyncPhase) {
 TEST_F(EngineSyncTest, SeekStayInPhase) {
     ControlObject::set(ConfigKey(m_sGroup1, "quantize"), 1.0);
 
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
@@ -1831,9 +1831,9 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
 
 TEST_F(EngineSyncTest, SyncWithoutBeatgrid) {
     // this tests bug lp1783020, notresetting rate when other deck has no beatgrid
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 128, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 128, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    m_pTrack2->setBeats(BeatsPointer());
+    m_pTrack2->setBeats(mixxx::BeatsPointer());
 
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), 0.5);
 
@@ -1850,11 +1850,11 @@ TEST_F(EngineSyncTest, SyncWithoutBeatgrid) {
 }
 
 TEST_F(EngineSyncTest, QuantizeHotCueActivate) {
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
 
     auto pHotCue2Activate = std::make_unique<ControlProxy>(m_sGroup2, "hotcue_1_activate");
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 100, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 100, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
@@ -1909,7 +1909,7 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
     auto pButtonSyncEnabled2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
 
     // set beatgrid
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
     pButtonSyncEnabled1->set(1.0);
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
@@ -1941,7 +1941,7 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
     assertIsFollower(m_sGroup2);
 
     // Load a new beatgrid during playing, this happens when the analyser is finished
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 140, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 140, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     ProcessBuffer();
@@ -1963,7 +1963,7 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
     assertIsFollower(m_sGroup2);
 
     // Load a new beatgrid again, this happens when the user adjusts the beatgrid
-    BeatsPointer pBeats2n = BeatFactory::makeBeatGrid(*m_pTrack2, 75, 0.0);
+    mixxx::BeatsPointer pBeats2n = BeatFactory::makeBeatGrid(*m_pTrack2, 75, 0.0);
     m_pTrack2->setBeats(pBeats2n);
 
     ProcessBuffer();

--- a/src/track/beatfactory.cpp
+++ b/src/track/beatfactory.cpp
@@ -6,35 +6,36 @@
 #include "track/beatfactory.h"
 #include "track/beatutils.h"
 
-BeatsPointer BeatFactory::loadBeatsFromByteArray(const Track& track,
-                                                 QString beatsVersion,
-                                                 QString beatsSubVersion,
-                                                 const QByteArray& beatsSerialized) {
+mixxx::BeatsPointer BeatFactory::loadBeatsFromByteArray(const Track& track,
+        QString beatsVersion,
+        QString beatsSubVersion,
+        const QByteArray& beatsSerialized) {
     if (beatsVersion == BEAT_GRID_1_VERSION ||
         beatsVersion == BEAT_GRID_2_VERSION) {
-        BeatGrid* pGrid = new BeatGrid(track, 0, beatsSerialized);
+        mixxx::BeatGrid* pGrid = new mixxx::BeatGrid(track, 0, beatsSerialized);
         pGrid->setSubVersion(beatsSubVersion);
         qDebug() << "Successfully deserialized BeatGrid";
-        return BeatsPointer(pGrid, &BeatFactory::deleteBeats);
+        return mixxx::BeatsPointer(pGrid, &BeatFactory::deleteBeats);
     } else if (beatsVersion == BEAT_MAP_VERSION) {
-        BeatMap* pMap = new BeatMap(track, 0, beatsSerialized);
+        mixxx::BeatMap* pMap = new mixxx::BeatMap(track, 0, beatsSerialized);
         pMap->setSubVersion(beatsSubVersion);
         qDebug() << "Successfully deserialized BeatMap";
-        return BeatsPointer(pMap, &BeatFactory::deleteBeats);
+        return mixxx::BeatsPointer(pMap, &BeatFactory::deleteBeats);
     }
     qDebug() << "BeatFactory::loadBeatsFromByteArray could not parse serialized beats.";
-    return BeatsPointer();
+    return mixxx::BeatsPointer();
 }
 
-BeatsPointer BeatFactory::makeBeatGrid(const Track& track, double dBpm,
-                                       double dFirstBeatSample) {
-    BeatGrid* pGrid = new BeatGrid(track, 0);
+mixxx::BeatsPointer BeatFactory::makeBeatGrid(
+        const Track& track, double dBpm, double dFirstBeatSample) {
+    mixxx::BeatGrid* pGrid = new mixxx::BeatGrid(track, 0);
     pGrid->setGrid(dBpm, dFirstBeatSample);
-    return BeatsPointer(pGrid, &BeatFactory::deleteBeats);
+    return mixxx::BeatsPointer(pGrid, &BeatFactory::deleteBeats);
 }
 
 // static
-QString BeatFactory::getPreferredVersion(const bool bEnableFixedTempoCorrection) {
+QString BeatFactory::getPreferredVersion(
+        const bool bEnableFixedTempoCorrection) {
     if (bEnableFixedTempoCorrection) {
         return BEAT_GRID_2_VERSION;
     }
@@ -42,55 +43,64 @@ QString BeatFactory::getPreferredVersion(const bool bEnableFixedTempoCorrection)
 }
 
 QString BeatFactory::getPreferredSubVersion(
-    const bool bEnableFixedTempoCorrection,
-    const bool bEnableOffsetCorrection,
-    const int iMinBpm, const int iMaxBpm,
-    const QHash<QString, QString> extraVersionInfo) {
+        const bool bEnableFixedTempoCorrection,
+        const bool bEnableOffsetCorrection,
+        const int iMinBpm,
+        const int iMaxBpm,
+        const QHash<QString, QString> extraVersionInfo) {
     const char* kSubVersionKeyValueSeparator = "=";
     const char* kSubVersionFragmentSeparator = "|";
     QStringList fragments;
 
     // min/max BPM limits only apply to fixed-tempo assumption
     if (bEnableFixedTempoCorrection) {
-        fragments << QString("min_bpm%1%2").arg(kSubVersionKeyValueSeparator,
-                                                QString::number(iMinBpm));
-        fragments << QString("max_bpm%1%2").arg(kSubVersionKeyValueSeparator,
-                                                QString::number(iMaxBpm));
+        fragments << QString("min_bpm%1%2")
+                             .arg(kSubVersionKeyValueSeparator,
+                                     QString::number(iMinBpm));
+        fragments << QString("max_bpm%1%2")
+                             .arg(kSubVersionKeyValueSeparator,
+                                     QString::number(iMaxBpm));
     }
 
     QHashIterator<QString, QString> it(extraVersionInfo);
     while (it.hasNext()) {
         it.next();
         if (it.key().contains(kSubVersionKeyValueSeparator) ||
-            it.key().contains(kSubVersionFragmentSeparator) ||
-            it.value().contains(kSubVersionKeyValueSeparator) ||
-            it.value().contains(kSubVersionFragmentSeparator)) {
-            qDebug() << "ERROR: Your analyzer key/value contains invalid characters:"
+                it.key().contains(kSubVersionFragmentSeparator) ||
+                it.value().contains(kSubVersionKeyValueSeparator) ||
+                it.value().contains(kSubVersionFragmentSeparator)) {
+            qDebug() << "ERROR: Your analyzer key/value contains invalid "
+                        "characters:"
                      << it.key() << ":" << it.value() << "Skipping.";
             continue;
         }
         fragments << QString("%1%2%3").arg(
-            it.key(), kSubVersionKeyValueSeparator, it.value());
+                it.key(), kSubVersionKeyValueSeparator, it.value());
     }
     if (bEnableFixedTempoCorrection && bEnableOffsetCorrection) {
         fragments << QString("offset_correction%1%2")
-                .arg(kSubVersionKeyValueSeparator, QString::number(1));
+                             .arg(kSubVersionKeyValueSeparator,
+                                     QString::number(1));
     }
 
-    fragments << QString("rounding%1%2").
-            arg(kSubVersionKeyValueSeparator, QString::number(0.05));
+    fragments << QString("rounding%1%2")
+                         .arg(kSubVersionKeyValueSeparator,
+                                 QString::number(0.05));
 
     std::sort(fragments.begin(), fragments.end());
-    return (fragments.size() > 0) ? fragments.join(kSubVersionFragmentSeparator) : "";
+    return (fragments.size() > 0) ? fragments.join(kSubVersionFragmentSeparator)
+                                  : "";
 }
 
-
-BeatsPointer BeatFactory::makePreferredBeats(
-    const Track& track, QVector<double> beats,
-    const QHash<QString, QString> extraVersionInfo,
-    const bool bEnableFixedTempoCorrection, const bool bEnableOffsetCorrection,
-    const int iSampleRate, const int iTotalSamples,
-    const int iMinBpm, const int iMaxBpm) {
+mixxx::BeatsPointer BeatFactory::makePreferredBeats(const Track& track,
+        QVector<double> beats,
+        const QHash<QString, QString> extraVersionInfo,
+        const bool bEnableFixedTempoCorrection,
+        const bool bEnableOffsetCorrection,
+        const int iSampleRate,
+        const int iTotalSamples,
+        const int iMinBpm,
+        const int iMaxBpm) {
     const QString version = getPreferredVersion(bEnableFixedTempoCorrection);
     const QString subVersion = getPreferredSubVersion(bEnableFixedTempoCorrection,
                                                       bEnableOffsetCorrection,
@@ -103,22 +113,22 @@ BeatsPointer BeatFactory::makePreferredBeats(
         double firstBeat = BeatUtils::calculateFixedTempoFirstBeat(
             bEnableOffsetCorrection,
             beats, iSampleRate, iTotalSamples, globalBpm);
-        BeatGrid* pGrid = new BeatGrid(track, iSampleRate);
+        mixxx::BeatGrid* pGrid = new mixxx::BeatGrid(track, iSampleRate);
         // firstBeat is in frames here and setGrid() takes samples.
         pGrid->setGrid(globalBpm, firstBeat * 2);
         pGrid->setSubVersion(subVersion);
-        return BeatsPointer(pGrid, &BeatFactory::deleteBeats);
+        return mixxx::BeatsPointer(pGrid, &BeatFactory::deleteBeats);
     } else if (version == BEAT_MAP_VERSION) {
-        BeatMap* pBeatMap = new BeatMap(track, iSampleRate, beats);
+        mixxx::BeatMap* pBeatMap = new mixxx::BeatMap(track, iSampleRate, beats);
         pBeatMap->setSubVersion(subVersion);
-        return BeatsPointer(pBeatMap, &BeatFactory::deleteBeats);
+        return mixxx::BeatsPointer(pBeatMap, &BeatFactory::deleteBeats);
     } else {
         qDebug() << "ERROR: Could not determine what type of beatgrid to create.";
-        return BeatsPointer();
+        return mixxx::BeatsPointer();
     }
 }
 
-void BeatFactory::deleteBeats(Beats* pBeats) {
+void BeatFactory::deleteBeats(mixxx::Beats* pBeats) {
     // BeatGrid/BeatMap objects have no parent and live in the same thread as
     // their associated TIO. QObject::deleteLater does not have the desired
     // effect when the QObject's thread does not have an event loop (i.e. when

--- a/src/track/beatfactory.h
+++ b/src/track/beatfactory.h
@@ -8,12 +8,13 @@
 
 class BeatFactory {
   public:
-    static BeatsPointer loadBeatsFromByteArray(const Track& track,
-                                               QString beatsVersion,
-                                               QString beatsSubVersion,
-                                               const QByteArray& beatsSerialized);
-    static BeatsPointer makeBeatGrid(const Track& track,
-                                     double dBpm, double dFirstBeatSample);
+    static mixxx::BeatsPointer loadBeatsFromByteArray(const Track& track,
+            QString beatsVersion,
+            QString beatsSubVersion,
+            const QByteArray& beatsSerialized);
+    static mixxx::BeatsPointer makeBeatGrid(const Track& track,
+            double dBpm,
+            double dFirstBeatSample);
 
     static QString getPreferredVersion(const bool bEnableFixedTempoCorrection);
 
@@ -23,16 +24,18 @@ class BeatFactory {
         const int iMinBpm, const int iMaxBpm,
         const QHash<QString, QString> extraVersionInfo);
 
-    static BeatsPointer makePreferredBeats(
-        const Track& track, QVector<double> beats,
-        const QHash<QString, QString> extraVersionInfo,
-        const bool bEnableFixedTempoCorrection,
-        const bool bEnableOffsetCorrection,
-        const int iSampleRate, const int iTotalSamples,
-        const int iMinBpm, const int iMaxBpm);
+    static mixxx::BeatsPointer makePreferredBeats(const Track& track,
+            QVector<double> beats,
+            const QHash<QString, QString> extraVersionInfo,
+            const bool bEnableFixedTempoCorrection,
+            const bool bEnableOffsetCorrection,
+            const int iSampleRate,
+            const int iTotalSamples,
+            const int iMinBpm,
+            const int iMaxBpm);
 
   private:
-    static void deleteBeats(Beats* pBeats);
+    static void deleteBeats(mixxx::Beats* pBeats);
 };
 
 #endif /* BEATFACTORY_H */

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -11,6 +11,8 @@ struct BeatGridData {
     double firstBeat;
 };
 
+namespace mixxx {
+
 class BeatGridIterator : public BeatIterator {
   public:
     BeatGridIterator(double dBeatLength, double dFirstBeat, double dEndSample)
@@ -362,3 +364,5 @@ void BeatGrid::setBpm(double dBpm) {
     locker.unlock();
     emit updated();
 }
+
+} // namespace mixxx

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -10,6 +10,8 @@
 #define BEAT_GRID_1_VERSION "BeatGrid-1.0"
 #define BEAT_GRID_2_VERSION "BeatGrid-2.0"
 
+namespace mixxx {
+
 // BeatGrid is an implementation of the Beats interface that implements an
 // infinite grid of beats, aligned to a song simply by a starting offset of the
 // first beat and the song's average beats-per-minute.
@@ -94,5 +96,6 @@ class BeatGrid final : public Beats {
     double m_dBeatLength;
 };
 
+} // namespace mixxx
 
 #endif /* BEATGRID_H */

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -30,6 +30,8 @@ bool BeatLessThan(const Beat& beat1, const Beat& beat2) {
     return beat1.frame_position() < beat2.frame_position();
 }
 
+namespace mixxx {
+
 class BeatMapIterator : public BeatIterator {
   public:
     BeatMapIterator(BeatList::const_iterator start, BeatList::const_iterator end)
@@ -722,3 +724,5 @@ double BeatMap::calculateBpm(const Beat& startBeat, const Beat& stopBeat) const 
 
     return BeatUtils::calculateBpm(beatvect, m_iSampleRate, 0, 9999);
 }
+
+} // namespace mixxx

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -18,6 +18,8 @@
 
 typedef QList<mixxx::track::io::Beat> BeatList;
 
+namespace mixxx {
+
 class BeatMap final : public Beats {
   public:
     // Construct a BeatMap. iSampleRate may be provided if a more accurate
@@ -109,4 +111,5 @@ class BeatMap final : public Beats {
     BeatList m_beats;
 };
 
+} // namespace mixxx
 #endif /* BEATMAP_H_ */

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -1,7 +1,7 @@
 
 #include "track/beats.h"
 
-
+namespace mixxx {
 
 int Beats::numBeatsInRange(double dStartSample, double dEndSample) {
     double dLastCountedBeat = 0.0;
@@ -53,3 +53,4 @@ double Beats::findNBeatsFromSample(double fromSample, double beats) const {
     return nthBeat;
 };
 
+} // namespace mixxx

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -14,6 +14,8 @@ namespace {
     double kMaxBpm = 500;
 }
 
+namespace mixxx {
+
 class Beats;
 typedef QSharedPointer<Beats> BeatsPointer;
 
@@ -171,4 +173,5 @@ class Beats : public QObject {
     void updated();
 };
 
+} // namespace mixxx
 #endif /* BEATS_H */

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -42,10 +42,9 @@ bool compareAndSet(T* pField, const T& value) {
     }
 }
 
-inline
-mixxx::Bpm getActualBpm(
+inline mixxx::Bpm getActualBpm(
         mixxx::Bpm bpm,
-        BeatsPointer pBeats = BeatsPointer()) {
+        mixxx::BeatsPointer pBeats = mixxx::BeatsPointer()) {
     // Only use the imported BPM if the beat grid is not valid!
     // Reason: The BPM value in the metadata might be normalized
     // or rounded, e.g. ID3v2 only supports integer values.
@@ -264,7 +263,7 @@ double Track::setBpm(double bpmValue) {
     if (!mixxx::Bpm::isValidValue(bpmValue)) {
         // If the user sets the BPM to an invalid value, we assume
         // they want to clear the beatgrid.
-        setBeats(BeatsPointer());
+        setBeats(mixxx::BeatsPointer());
         return bpmValue;
     }
 
@@ -273,7 +272,7 @@ double Track::setBpm(double bpmValue) {
     if (!m_pBeats) {
         // No beat grid available -> create and initialize
         double cue = getCuePoint().getPosition();
-        BeatsPointer pBeats(BeatFactory::makeBeatGrid(*this, bpmValue, cue));
+        mixxx::BeatsPointer pBeats(BeatFactory::makeBeatGrid(*this, bpmValue, cue));
         setBeatsAndUnlock(&lock, pBeats);
         return bpmValue;
     }
@@ -297,12 +296,12 @@ QString Track::getBpmText() const {
     return QString("%1").arg(getBpm(), 3,'f',1);
 }
 
-void Track::setBeats(BeatsPointer pBeats) {
+void Track::setBeats(mixxx::BeatsPointer pBeats) {
     QMutexLocker lock(&m_qMutex);
     setBeatsAndUnlock(&lock, pBeats);
 }
 
-void Track::setBeatsAndUnlock(QMutexLocker* pLock, BeatsPointer pBeats) {
+void Track::setBeatsAndUnlock(QMutexLocker* pLock, mixxx::BeatsPointer pBeats) {
     // This whole method is not so great. The fact that Beats is an ABC is
     // limiting with respect to QObject and signals/slots.
 
@@ -312,7 +311,7 @@ void Track::setBeatsAndUnlock(QMutexLocker* pLock, BeatsPointer pBeats) {
     }
 
     if (m_pBeats) {
-        disconnect(m_pBeats.data(), &Beats::updated, this, &Track::slotBeatsUpdated);
+        disconnect(m_pBeats.data(), &mixxx::Beats::updated, this, &Track::slotBeatsUpdated);
     }
 
     m_pBeats = std::move(pBeats);
@@ -320,7 +319,7 @@ void Track::setBeatsAndUnlock(QMutexLocker* pLock, BeatsPointer pBeats) {
     auto bpmValue = mixxx::Bpm::kValueUndefined;
     if (m_pBeats) {
         bpmValue = m_pBeats->getBpm();
-        connect(m_pBeats.data(), &Beats::updated, this, &Track::slotBeatsUpdated);
+        connect(m_pBeats.data(), &mixxx::Beats::updated, this, &Track::slotBeatsUpdated);
     }
     m_record.refMetadata().refTrackInfo().setBpm(mixxx::Bpm(bpmValue));
 
@@ -329,7 +328,7 @@ void Track::setBeatsAndUnlock(QMutexLocker* pLock, BeatsPointer pBeats) {
     emit beatsUpdated();
 }
 
-BeatsPointer Track::getBeats() const {
+mixxx::BeatsPointer Track::getBeats() const {
     QMutexLocker lock(&m_qMutex);
     return m_pBeats;
 }

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -275,10 +275,10 @@ class Track : public QObject {
     bool isDirty();
 
     // Get the track's Beats list
-    BeatsPointer getBeats() const;
+    mixxx::BeatsPointer getBeats() const;
 
     // Set the track's Beats
-    void setBeats(BeatsPointer beats);
+    void setBeats(mixxx::BeatsPointer beats);
 
     void resetKeys();
     void setKeys(const Keys& keys);
@@ -375,7 +375,7 @@ class Track : public QObject {
     void markDirtyAndUnlock(QMutexLocker* pLock, bool bDirty = true);
     void setDirtyAndUnlock(QMutexLocker* pLock, bool bDirty);
 
-    void setBeatsAndUnlock(QMutexLocker* pLock, BeatsPointer pBeats);
+    void setBeatsAndUnlock(QMutexLocker* pLock, mixxx::BeatsPointer pBeats);
 
     void afterKeysUpdated(QMutexLocker* pLock);
 
@@ -428,7 +428,7 @@ class Track : public QObject {
     QList<CuePointer> m_cuePoints;
 
     // Storage for the track's beats
-    BeatsPointer m_pBeats;
+    mixxx::BeatsPointer m_pBeats;
 
     //Visual waveform data
     ConstWaveformPointer m_waveform;

--- a/src/waveform/renderers/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/waveformrenderbeat.cpp
@@ -31,7 +31,7 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
     if (!trackInfo)
         return;
 
-    BeatsPointer trackBeats = trackInfo->getBeats();
+    mixxx::BeatsPointer trackBeats = trackInfo->getBeats();
     if (!trackBeats)
         return;
 
@@ -54,7 +54,7 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
     //          << "firstDisplayedPosition" << firstDisplayedPosition
     //          << "lastDisplayedPosition" << lastDisplayedPosition;
 
-    std::unique_ptr<BeatIterator> it(trackBeats->findBeats(
+    std::unique_ptr<mixxx::BeatIterator> it(trackBeats->findBeats(
             firstDisplayedPosition * trackSamples,
             lastDisplayedPosition * trackSamples));
 

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -262,12 +262,24 @@ void WTrackMenu::createActions() {
         m_pBpmFourThirdsAction = new QAction(tr("4/3 BPM"), m_pBPMMenu);
         m_pBpmThreeHalvesAction = new QAction(tr("3/2 BPM"), m_pBPMMenu);
 
-        connect(m_pBpmDoubleAction, &QAction::triggered, this, [this] { slotScaleBpm(Beats::DOUBLE); });
-        connect(m_pBpmHalveAction, &QAction::triggered, this, [this] { slotScaleBpm(Beats::HALVE); });
-        connect(m_pBpmTwoThirdsAction, &QAction::triggered, this, [this] { slotScaleBpm(Beats::TWOTHIRDS); });
-        connect(m_pBpmThreeFourthsAction, &QAction::triggered, this, [this] { slotScaleBpm(Beats::THREEFOURTHS); });
-        connect(m_pBpmFourThirdsAction, &QAction::triggered, this, [this] { slotScaleBpm(Beats::FOURTHIRDS); });
-        connect(m_pBpmThreeHalvesAction, &QAction::triggered, this, [this] { slotScaleBpm(Beats::THREEHALVES); });
+        connect(m_pBpmDoubleAction, &QAction::triggered, this, [this] {
+            slotScaleBpm(mixxx::Beats::DOUBLE);
+        });
+        connect(m_pBpmHalveAction, &QAction::triggered, this, [this] {
+            slotScaleBpm(mixxx::Beats::HALVE);
+        });
+        connect(m_pBpmTwoThirdsAction, &QAction::triggered, this, [this] {
+            slotScaleBpm(mixxx::Beats::TWOTHIRDS);
+        });
+        connect(m_pBpmThreeFourthsAction, &QAction::triggered, this, [this] {
+            slotScaleBpm(mixxx::Beats::THREEFOURTHS);
+        });
+        connect(m_pBpmFourThirdsAction, &QAction::triggered, this, [this] {
+            slotScaleBpm(mixxx::Beats::FOURTHIRDS);
+        });
+        connect(m_pBpmThreeHalvesAction, &QAction::triggered, this, [this] {
+            slotScaleBpm(mixxx::Beats::THREEHALVES);
+        });
 
         m_pBpmResetAction = new QAction(tr("Reset BPM"), m_pBPMMenu);
         connect(m_pBpmResetAction,
@@ -1009,11 +1021,11 @@ void WTrackMenu::slotScaleBpm(int scale) {
         if (pTrack->isBpmLocked()) {
             continue;
         }
-        BeatsPointer pBeats = pTrack->getBeats();
+        mixxx::BeatsPointer pBeats = pTrack->getBeats();
         if (!pBeats) {
             continue;
         }
-        pBeats->scale(static_cast<Beats::BPMScale>(scale));
+        pBeats->scale(static_cast<mixxx::Beats::BPMScale>(scale));
     }
 }
 
@@ -1073,7 +1085,7 @@ void WTrackMenu::slotClearBeats() {
         if (pTrack->isBpmLocked()) {
             continue;
         }
-        pTrack->setBeats(BeatsPointer());
+        pTrack->setBeats(mixxx::BeatsPointer());
     }
 }
 


### PR DESCRIPTION
This is just a technical PR. I have moved the Beats class, and associated ones, to the mixxx namespace.