### PR TITLE
fr_FR kbd cfg : Fix Chan2 - hotcue_4 & loop_out

### DIFF
--- a/res/keyboard/fr_FR.kbd.cfg
+++ b/res/keyboard/fr_FR.kbd.cfg
@@ -108,18 +108,18 @@ filterLowKill n
 hotcue_1_activate ,
 hotcue_2_activate ;
 hotcue_3_activate :
-hotcue_4_activate =
+hotcue_4_activate !
 hotcue_1_clear Shift+?
 hotcue_2_clear Shift+.
 hotcue_3_clear Shift+/
-hotcue_4_clear Shift++
+hotcue_4_clear Shift+§
 
 LoadSelectedTrack Shift+Right
 eject Alt+Shift+Right
 
 loop_in è
 loop_in_goto Shift+7
-loop_out !
+loop_out _
 loop_out_goto Shift+8
 reloop_toggle ç
 reloop_andstop Shift+9


### PR DESCRIPTION
with this fix, the default french keyboard config is consistent with default us layout representation (has shown in Mixx documentation)