### PR TITLE
Draw hotcue mark with lowest index on top

### DIFF
--- a/src/waveform/renderers/waveformmarkset.cpp
+++ b/src/waveform/renderers/waveformmarkset.cpp
@@ -55,7 +55,7 @@ void WaveformMarkSet::setup(const QString& group, const QDomNode& node,
             if (m_hotCueMarks.value(i).isNull()) {
                 //qDebug() << "WaveformRenderMark::setup - Automatic mark" << hotCueControlItem;
                 WaveformMarkPointer pMark(new WaveformMark(group, defaultChild, context, signalColors, i));
-                m_marks.push_back(pMark);
+                m_marks.push_front(pMark);
                 m_hotCueMarks.insert(pMark->getHotCue(), pMark);
             }
         }


### PR DESCRIPTION
Currently, hotcue marks on the same position are drawn over each other
and only the hotcue mark with the highest index is shown. Since not all
hotcue indices might be mapped on the controller (or accessible via the
skin) it makes sense to draw mark with the lowest index on top to
increase the chance that a user can jump to it via GUI or performance
pads.

Zulip Discussion:
https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/hotcue.20markers.20drawn.20over.20each.20other