### PR TITLE
TrackDAO: Reformat code / Avoid mutex locks on Track object

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -457,7 +457,7 @@ void bindTrackLibraryValues(QSqlQuery* pTrackLibraryQuery, const Track& track) {
     pTrackLibraryQuery->bindValue(":timesplayed", playCounter.getTimesPlayed());
     pTrackLibraryQuery->bindValue(":played", playCounter.isPlayed() ? 1 : 0);
 
-    const CoverInfoRelative coverInfo(track.getCoverInfo());
+    const CoverInfoRelative& coverInfo = track.getCoverInfo();
     pTrackLibraryQuery->bindValue(":coverart_source", coverInfo.source);
     pTrackLibraryQuery->bindValue(":coverart_type", coverInfo.type);
     pTrackLibraryQuery->bindValue(":coverart_location", coverInfo.coverLocation);
@@ -485,7 +485,7 @@ void bindTrackLibraryValues(QSqlQuery* pTrackLibraryQuery, const Track& track) {
     QString keysSubVersion;
     QString keyText;
     mixxx::track::io::key::ChromaticKey globalKey = mixxx::track::io::key::INVALID;
-    const Keys keys(track.getKeys());
+    const Keys& keys = track.getKeys();
     if (keys.isValid()) {
         keysBlob = keys.toByteArray();
         keysVersion = keys.getVersion();

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -521,9 +521,7 @@ bool insertTrackLibrary(QSqlQuery* pTrackLibraryInsert, const Track& track, DbId
     // We no longer store the wavesummary in the library table.
     pTrackLibraryInsert->bindValue(":wavesummaryhex", QVariant(QVariant::ByteArray));
 
-    if (pTrackLibraryInsert->exec()) {
-        return true;
-    } else {
+    VERIFY_OR_DEBUG_ASSERT(pTrackLibraryInsert->exec()) {
         // We failed to insert the track. Maybe it is already in the library
         // but marked deleted? Skip this track.
         LOG_FAILED_QUERY(*pTrackLibraryInsert)
@@ -531,6 +529,7 @@ bool insertTrackLibrary(QSqlQuery* pTrackLibraryInsert, const Track& track, DbId
                 << track.getLocation();
         return false;
     }
+    return true;
 }
 
 } // anonymous namespace

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -42,9 +42,8 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
             UserSettingsPointer pConfig);
     ~TrackDAO() override;
 
-    void initialize(const QSqlDatabase& database) override {
-        m_database = database;
-    }
+    void initialize(
+            const QSqlDatabase& database) override;
     void finish();
 
     QList<TrackId> resolveTrackIds(


### PR DESCRIPTION
This technical PR will reduce the number of merge conflicts that I already experience frequently.

- Reformat code in anonymous namespace, i.e. fix the indentation
- Bind database column upon insert/update from `TrackRecord` instead of `Track` to avoid repeated locking of mutexes. The additional copy shouldn't matter since all dynamically allocated C++ objects are implicitly shared (Qt)

Both changes affect a single part of the code.