### PR TITLE
Add OpenSSL to libshout CMakeLists.txt

### DIFF
--- a/lib/libshout/CMakeLists.txt
+++ b/lib/libshout/CMakeLists.txt
@@ -10,7 +10,6 @@ include_directories(
   src
   include
   src/common
-  "${OPENSSL_INCLUDE_DIR}"
 )
 
 add_library(shout_mixxx STATIC
@@ -38,6 +37,6 @@ add_library(shout_mixxx STATIC
   src/tls.c
 )
 
-target_link_libraries(shout_mixxx ogg vorbis theora speex ssl crypto)
+target_link_libraries(shout_mixxx ogg vorbis theora speex OpenSSL::SSL OpenSSL::Crypto)
 
 

--- a/lib/libshout/CMakeLists.txt
+++ b/lib/libshout/CMakeLists.txt
@@ -3,11 +3,14 @@ project(shout_mixxx C)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_CONFIG_H -Wall -ffast-math -pthread -g -O2")
  
+find_package(OpenSSL)
+
 include_directories(
   .
   src
   include
   src/common
+  "${OPENSSL_INCLUDE_DIR}"
 )
 
 add_library(shout_mixxx STATIC


### PR DESCRIPTION
libshout requires OpenSSL to build using cmake.