### PR TITLE
Fix manual ducking

### DIFF
--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -464,11 +464,21 @@ void EngineMaster::process(const int iBufferSize) {
             m_pTalkover,
             m_iBufferSize, m_iSampleRate, busFeatures);
 
-
-    // Clear talkover compressor for the next round of gain calculation.
-    m_pTalkoverDucking->clearKeys();
-    if (m_pTalkoverDucking->getMode() != EngineTalkoverDucking::OFF) {
+    switch (m_pTalkoverDucking->getMode()) {
+    case EngineTalkoverDucking::OFF:
+        m_pTalkoverDucking->setAboveThreshold(false);
+        break;
+    case EngineTalkoverDucking::AUTO:
         m_pTalkoverDucking->processKey(m_pTalkover, m_iBufferSize);
+        break;
+    case EngineTalkoverDucking::MANUAL:
+        qDebug() << "m_activeTalkoverChannels.size()" << m_activeTalkoverChannels.size();
+        m_pTalkoverDucking->setAboveThreshold(m_activeTalkoverChannels.size());
+        break;
+    default:
+        DEBUG_ASSERT("!Unknown Ducking mode");
+        m_pTalkoverDucking->setAboveThreshold(false);
+        break;
     }
 
     // Calculate the crossfader gains for left and right side of the crossfader

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -472,7 +472,6 @@ void EngineMaster::process(const int iBufferSize) {
         m_pTalkoverDucking->processKey(m_pTalkover, m_iBufferSize);
         break;
     case EngineTalkoverDucking::MANUAL:
-        qDebug() << "m_activeTalkoverChannels.size()" << m_activeTalkoverChannels.size();
         m_pTalkoverDucking->setAboveThreshold(m_activeTalkoverChannels.size());
         break;
     default:

--- a/src/engine/enginesidechaincompressor.cpp
+++ b/src/engine/enginesidechaincompressor.cpp
@@ -3,10 +3,10 @@
 #include "engine/enginesidechaincompressor.h"
 
 EngineSideChainCompressor::EngineSideChainCompressor(const char* group)
-        : m_compressRatio(0.0),
+        : m_compressRatio(1.0),
           m_bAboveThreshold(false),
           m_threshold(1.0),
-          m_strength(0.0),
+          m_strength(1.0),
           m_attackTime(0),
           m_decayTime(0),
           m_attackPerFrame(0.0),
@@ -55,28 +55,27 @@ void EngineSideChainCompressor::processKey(const CSAMPLE* pIn, const int iBuffer
 
 double EngineSideChainCompressor::calculateCompressedGain(int frames) {
     if (m_bAboveThreshold) {
-        if (m_compressRatio < m_strength) {
-            m_compressRatio += m_attackPerFrame * frames;
-            if (m_compressRatio > m_strength) {
+        if (m_compressRatio > m_strength) {
+            m_compressRatio -= m_attackPerFrame * frames;
+            if (m_compressRatio < m_strength) {
                 // If we overshot, clamp.
                 m_compressRatio = m_strength;
             }
-        } else if (m_compressRatio > m_strength) {
+        } else if (m_compressRatio < m_strength) {
             // If the strength param was changed, we might be compressing too much.
-            m_compressRatio -= m_decayPerFrame * frames;
+            m_compressRatio += m_decayPerFrame * frames;
         }
     } else {
-        if (m_compressRatio > 0) {
-            m_compressRatio -= m_decayPerFrame * frames;
-            if (m_compressRatio < 0) {
-                // If we overshot, clamp.
-                m_compressRatio = 0;
-            }
-        } else if (m_compressRatio < 0) {
-            // Complain loudly.
+        VERIFY_OR_DEBUG_ASSERT(m_compressRatio >= 0) {
             qWarning() << "Programming error, below-zero compression detected.";
-            m_compressRatio += m_attackPerFrame * frames;
+        }
+        if (m_compressRatio < 1) {
+            m_compressRatio += m_decayPerFrame * frames;
+            if (m_compressRatio > 1) {
+                // If we overshot, clamp.
+                m_compressRatio = 1;
+            }
         }
     }
-    return (1. - m_compressRatio);
+    return m_compressRatio;
 }

--- a/src/engine/enginesidechaincompressor.cpp
+++ b/src/engine/enginesidechaincompressor.cpp
@@ -38,11 +38,12 @@ void EngineSideChainCompressor::calculateRates() {
              << "decay per frame: " << m_decayPerFrame;
 }
 
-void EngineSideChainCompressor::clearKeys() {
-    m_bAboveThreshold = false;
+void EngineSideChainCompressor::setAboveThreshold(bool value) {
+    m_bAboveThreshold = value;
 }
 
 void EngineSideChainCompressor::processKey(const CSAMPLE* pIn, const int iBufferSize) {
+    m_bAboveThreshold = false;
     for (int i = 0; i + 1 < iBufferSize; i += 2) {
         CSAMPLE val = (pIn[i] + pIn[i + 1]) / 2;
         if (val > m_threshold) {

--- a/src/engine/enginesidechaincompressor.h
+++ b/src/engine/enginesidechaincompressor.h
@@ -40,10 +40,8 @@ class EngineSideChainCompressor {
         calculateRates();
     }
 
-
-    // Before calling processKey on multiple channels, first call clearKeys to
-    // clear state from the last round of compressor gain calculation.
-    void clearKeys();
+    /// Forces the above threshold flag to the given value without calculations
+    void setAboveThreshold(bool value);
 
     // Every loop, before calling process, first call processKey to feed
     // the compressor the input key signal.  It is safe to call this function

--- a/src/engine/enginetalkoverducking.cpp
+++ b/src/engine/enginetalkoverducking.cpp
@@ -67,13 +67,13 @@ void EngineTalkoverDucking::slotDuckModeChanged(double mode) {
 CSAMPLE EngineTalkoverDucking::getGain(int numFrames) {
     // Apply microphone ducking.
     switch (getMode()) {
-      case EngineTalkoverDucking::OFF:
+    case EngineTalkoverDucking::OFF:
         return 1.0;
-      case EngineTalkoverDucking::AUTO:
+    case EngineTalkoverDucking::AUTO:
+    case EngineTalkoverDucking::MANUAL:
         return calculateCompressedGain(numFrames);
-      case EngineTalkoverDucking::MANUAL:
-        return m_pDuckStrength->get();
+    default:
+        DEBUG_ASSERT("!Unknown Ducking mode");
+        return 1.0;
     }
-    qWarning() << "Invalid ducking mode, returning 1.0";
-    return 1.0;
 }


### PR DESCRIPTION
Now the ducking gain is only applied when talkover is enabled. 

Before the manual mode has always applied the Ducking gain. This does not make much sense, because the user can also lower the deck gain to have the same effect. 

This Fixes a a regression since the introduction of the postfader effects in 2.1 
 