### PR TITLE
TrackFile/TrackRef are now qHash-able

### DIFF
--- a/src/track/trackfile.h
+++ b/src/track/trackfile.h
@@ -123,3 +123,7 @@ inline QDebug operator<<(QDebug debug, const TrackFile& trackFile) {
     return debug << trackFile.location();
 #endif
 }
+
+inline uint qHash(const TrackFile& key, uint seed) {
+    return qHash(key.location(), seed);
+}

--- a/src/track/trackref.h
+++ b/src/track/trackref.h
@@ -115,3 +115,7 @@ Q_DECLARE_METATYPE(TrackRef)
 std::ostream& operator<<(std::ostream& os, const TrackRef& trackRef);
 
 QDebug operator<<(QDebug debug, const TrackRef& trackRef);
+
+inline uint qHash(const TrackRef& key, uint seed) {
+    return qHash(key.getLocation(), seed) ^ qHash(key.getId(), seed);
+}


### PR DESCRIPTION
This PR adds a `qHash()` overload for `TrackFile` and `TrackRef`, allowing them to be used in `QSet` etc.

This is a pre-requisite for PR #2753.