### PR TITLE
Fix qHash definitions

### DIFF
--- a/src/effects/defs.h
+++ b/src/effects/defs.h
@@ -22,8 +22,10 @@ enum class SignalProcessingStage {
     Postfader
 };
 
-inline uint qHash(SignalProcessingStage stage) {
-    return static_cast<uint>(stage);
+inline uint qHash(
+        SignalProcessingStage stage,
+        uint seed = 0) {
+    return qHash(static_cast<uint>(stage), seed);
 };
 
 enum class EffectChainMixMode {

--- a/src/engine/channelhandle.h
+++ b/src/engine/channelhandle.h
@@ -66,8 +66,10 @@ inline QDebug operator<<(QDebug stream, const ChannelHandle& h) {
     return stream;
 }
 
-inline uint qHash(const ChannelHandle& handle) {
-    return qHash(handle.handle());
+inline uint qHash(
+        const ChannelHandle& handle,
+        uint seed = 0) {
+    return qHash(handle.handle(), seed);
 }
 
 // Convenience class that mimics QPair<ChannelHandle, QString> except with
@@ -104,8 +106,10 @@ inline QDebug operator<<(QDebug stream, const ChannelHandleAndGroup& g) {
     return stream;
 }
 
-inline uint qHash(const ChannelHandleAndGroup& handle_group) {
-    return qHash(handle_group.handle());
+inline uint qHash(
+        const ChannelHandleAndGroup& handle_group,
+        uint seed = 0) {
+    return qHash(handle_group.handle(), seed);
 }
 
 // A helper class used by EngineMaster to assign ChannelHandles to channel group

--- a/src/preferences/configobject.h
+++ b/src/preferences/configobject.h
@@ -64,8 +64,11 @@ inline QDebug operator<<(QDebug stream, const ConfigKey& configKey) {
 }
 
 // QHash hash function for ConfigKey objects.
-inline uint qHash(const ConfigKey& key) {
-    return qHash(key.group) ^ qHash(key.item);
+inline uint qHash(
+        const ConfigKey& key,
+        uint seed = 0) {
+    return qHash(key.group, seed) ^
+            qHash(key.item, seed);
 }
 
 // The value corresponding to a key. The basic value is a string, but can be
@@ -97,8 +100,10 @@ inline bool operator!=(const ConfigValue& lhs, const ConfigValue& rhs) {
     return !(lhs == rhs);
 }
 
-inline uint qHash(const ConfigValue& key) {
-    return qHash(key.value.toUpper());
+inline uint qHash(
+        const ConfigValue& key,
+        uint seed = 0) {
+    return qHash(key.value.toUpper(), seed);
 }
 
 class ConfigValueKbd : public ConfigValue {

--- a/src/soundio/soundmanagerutil.cpp
+++ b/src/soundio/soundmanagerutil.cpp
@@ -453,17 +453,3 @@ QString SoundDeviceId::debugName() const {
         return name + QStringLiteral(", ") + alsaHwDevice + QStringLiteral(", ") + QString::number(portAudioIndex);
     }
 }
-
-/**
- * Defined for QHash, so AudioOutput can be used as a QHash key.
- */
-unsigned int qHash(const AudioOutput &output) {
-    return output.getHash();
-}
-
-/**
- * Defined for QHash, so AudioInput can be used as a QHash key.
- */
-unsigned int qHash(const AudioInput &input) {
-    return input.getHash();
-}

--- a/src/soundio/soundmanagerutil.cpp
+++ b/src/soundio/soundmanagerutil.cpp
@@ -70,14 +70,6 @@ bool ChannelGroup::clashesWith(const ChannelGroup &other) const {
 }
 
 /**
- * Generates a hash of this ChannelGroup, so it can act as a key in a QHash.
- * @return a hash for this ChannelGroup
- */
-unsigned int ChannelGroup::getHash() const {
-    return 0 | (m_channels << 8) | m_channelBase;
-}
-
-/**
  * Constructs an AudioPath object (must be called by a child class's
  * constructor, AudioPath is abstract).
  * @param channelBase the first channel on a sound device used by this AudioPath.
@@ -117,14 +109,6 @@ unsigned char AudioPath::getIndex() const {
 bool AudioPath::operator==(const AudioPath &other) const {
     return m_type == other.m_type
         && m_index == other.m_index;
-}
-
-/**
- * Generates a hash of this AudioPath, so it can act as a key in a QHash.
- * @return a hash for this AudioPath
- */
-unsigned int AudioPath::getHash() const {
-    return 0 | (m_type << 8) | m_index;
 }
 
 /**
@@ -468,13 +452,6 @@ QString SoundDeviceId::debugName() const {
     } else {
         return name + QStringLiteral(", ") + alsaHwDevice + QStringLiteral(", ") + QString::number(portAudioIndex);
     }
-}
-
-/**
- * Defined for QHash, so ChannelGroup can be used as a QHash key.
- */
-unsigned int qHash(const ChannelGroup &group) {
-    return group.getHash();
 }
 
 /**

--- a/src/soundio/soundmanagerutil.cpp
+++ b/src/soundio/soundmanagerutil.cpp
@@ -42,16 +42,6 @@ unsigned char ChannelGroup::getChannelCount() const {
 }
 
 /**
- * Defines equality between two ChannelGroups.
- * @return true if the two ChannelGroups share a common base channel
- *          and channel count, otherwise false.
- */
-bool ChannelGroup::operator==(const ChannelGroup &other) const {
-    return m_channelBase == other.m_channelBase
-        && m_channels == other.m_channels;
-}
-
-/**
  * Checks if another ChannelGroup shares channels with this one.
  * @param other the other ChannelGroup to check for a clash with.
  * @return true if the other and this ChannelGroup share any channels,

--- a/src/soundio/soundmanagerutil.h
+++ b/src/soundio/soundmanagerutil.h
@@ -98,6 +98,7 @@ public:
             const AudioPath& path,
             uint seed = 0) {
         return qHash(static_cast<uint>(path.m_type), seed) ^
+                qHash(path.m_channelGroup, seed) ^
                 qHash(path.m_index, seed);
     }
 

--- a/src/soundio/soundmanagerutil.h
+++ b/src/soundio/soundmanagerutil.h
@@ -253,6 +253,4 @@ inline QDebug operator<<(QDebug dbg, const SoundDeviceId& soundDeviceId) {
     return dbg << QString("SoundDeviceId(" + soundDeviceId.debugName() + ")");
 }
 
-unsigned int qHash(const AudioOutput &output);
-unsigned int qHash(const AudioInput &input);
 #endif

--- a/src/soundio/soundmanagerutil.h
+++ b/src/soundio/soundmanagerutil.h
@@ -256,6 +256,7 @@ inline bool operator!=(
 
 // There is not really a use case for this, but it is required for QMetaType::registerComparators.
 inline bool operator<(const SoundDeviceId& lhs, const SoundDeviceId& rhs) {
+    DEBUG_ASSERT(!"should never be invoked");
     return lhs.portAudioIndex < rhs.portAudioIndex;
 }
 

--- a/src/soundio/soundmanagerutil.h
+++ b/src/soundio/soundmanagerutil.h
@@ -86,6 +86,8 @@ public:
         INVALID, // if this isn't last bad things will happen -bkgood
     };
     AudioPath(unsigned char channelBase, unsigned char channels);
+    virtual ~AudioPath() = default;
+
     AudioPathType getType() const;
     ChannelGroup getChannelGroup() const;
     unsigned char getIndex() const;
@@ -132,7 +134,7 @@ class AudioOutput : public AudioPath {
     AudioOutput(AudioPathType type, unsigned char channelBase,
                 unsigned char channels,
                 unsigned char index = 0);
-    virtual ~AudioOutput();
+    ~AudioOutput() override;
     QDomElement toXML(QDomElement *element) const;
     static AudioOutput fromXML(const QDomElement &xml);
     static QList<AudioPathType> getSupportedTypes();
@@ -149,6 +151,7 @@ class AudioOutputBuffer : public AudioOutput {
              m_pBuffer(pBuffer) {
 
     };
+    ~AudioOutputBuffer() override = default;
     inline const CSAMPLE* getBuffer() const { return m_pBuffer; }
   private:
     const CSAMPLE* m_pBuffer;
@@ -164,7 +167,7 @@ class AudioInput : public AudioPath {
   public:
     AudioInput(AudioPathType type = INVALID, unsigned char channelBase = 0,
                unsigned char channels = 0, unsigned char index = 0);
-    virtual ~AudioInput();
+    ~AudioInput() override;
     QDomElement toXML(QDomElement *element) const;
     static AudioInput fromXML(const QDomElement &xml);
     static QList<AudioPathType> getSupportedTypes();
@@ -181,6 +184,7 @@ class AudioInputBuffer : public AudioInput {
               m_pBuffer(pBuffer) {
 
     }
+    ~AudioInputBuffer() override = default;
     inline CSAMPLE* getBuffer() const { return m_pBuffer; }
   private:
     CSAMPLE* m_pBuffer;
@@ -189,6 +193,8 @@ class AudioInputBuffer : public AudioInput {
 
 class AudioSource {
 public:
+    virtual ~AudioSource() = default;
+
     virtual const CSAMPLE* buffer(AudioOutput output) const = 0;
 
     // This is called by SoundManager whenever an output is connected for this
@@ -204,6 +210,8 @@ public:
 
 class AudioDestination {
 public:
+    virtual ~AudioDestination() = default;
+
     // This is called by SoundManager whenever there are new samples from the
     // configured input to be processed. This is run in the clock reference
     // callback thread
@@ -223,7 +231,7 @@ public:
 
 typedef AudioPath::AudioPathType AudioPathType;
 
-class SoundDeviceId {
+class SoundDeviceId final {
   public:
     QString name;
     // The "hw:X,Y" device name. Remains an empty string if not using ALSA

--- a/src/soundio/soundmanagerutil.h
+++ b/src/soundio/soundmanagerutil.h
@@ -34,7 +34,6 @@ class ChannelGroup {
     ChannelGroup(unsigned char channelBase, unsigned char channels);
     unsigned char getChannelBase() const;
     unsigned char getChannelCount() const;
-    bool operator==(const ChannelGroup& other) const;
     bool clashesWith(const ChannelGroup& other) const;
 
     friend uint qHash(
@@ -44,10 +43,23 @@ class ChannelGroup {
                 qHash(group.m_channels, seed);
     }
 
+    friend bool operator==(
+            const ChannelGroup& lhs,
+            const ChannelGroup& rhs) {
+        return lhs.m_channelBase == rhs.m_channelBase &&
+                lhs.m_channels == rhs.m_channels;
+    }
+
   private:
     unsigned char m_channelBase; // base (first) channel used on device
     unsigned char m_channels; // number of channels used (s/b 2 in most cases)
 };
+
+inline bool operator!=(
+        const ChannelGroup& lhs,
+        const ChannelGroup& rhs) {
+    return !(lhs == rhs);
+}
 
 /**
  * @class AudioPath
@@ -228,10 +240,18 @@ class SoundDeviceId {
 // This must be registered with QMetaType::registerComparators for
 // QVariant::operator== to use it, which is required for QComboBox::findData to
 // work in DlgPrefSoundItem.
-inline bool operator==(const SoundDeviceId& lhs, const SoundDeviceId& rhs) {
+inline bool operator==(
+        const SoundDeviceId& lhs,
+        const SoundDeviceId& rhs) {
     return lhs.name == rhs.name
             && lhs.alsaHwDevice == rhs.alsaHwDevice
             && lhs.portAudioIndex == rhs.portAudioIndex;
+}
+
+inline bool operator!=(
+        const SoundDeviceId& lhs,
+        const SoundDeviceId& rhs) {
+    return !(lhs == rhs);
 }
 
 // There is not really a use case for this, but it is required for QMetaType::registerComparators.

--- a/src/soundio/soundmanagerutil.h
+++ b/src/soundio/soundmanagerutil.h
@@ -1,20 +1,4 @@
-/**
- * @file soundmanagerutil.h
- * @author Bill Good <bkgood at gmail dot com>
- * @date 20100611
- */
-
-/***************************************************************************
- *                                                                         *
- *   This program is free software; you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation; either version 2 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- ***************************************************************************/
-
-#ifndef SOUNDMANAGERUTIL_U
-#define SOUNDMANAGERUTIL_U
+#pragma once
 
 #include <QString>
 #include <QMutex>
@@ -24,11 +8,7 @@
 #include "util/types.h"
 #include "util/fifo.h"
 
-/**
- * @class ChannelGroup
- * @brief Describes a group of channels, typically a pair for stereo sound in
- *        Mixxx.
- */
+/// Describes a group of channels, typically a pair for stereo sound in Mixxx.
 class ChannelGroup {
   public:
     ChannelGroup(unsigned char channelBase, unsigned char channels);
@@ -61,18 +41,17 @@ inline bool operator!=(
     return !(lhs == rhs);
 }
 
-/**
- * @class AudioPath
- * @brief Describes a path for audio to take.
- * @note This needs a new name, the current one sucks. If you find one,
- *       feel free to rename as necessary.
- */
+/// Describes a path for audio to take.
+///
+/// TODO: Choose a better name for this class
 class AudioPath {
 public:
-    // XXX if you add a new type here, be sure to add it to the various
-    // methods including getStringFromType, isIndexed, getTypeFromInt,
-    // channelsNeededForType (if necessary), the subclasses' getSupportedTypes
-    // (if necessary), etc. -- bkgood
+    /// Predefined types.
+    ///
+    /// If you add a new type here, be sure to add it to the various
+    /// methods including getStringFromType, isIndexed, getTypeFromInt,
+    /// channelsNeededForType (if necessary), the subclasses' getSupportedTypes
+    /// (if necessary), etc.
     enum AudioPathType {
         MASTER,
         HEADPHONES,
@@ -100,8 +79,8 @@ public:
     static bool isIndexed(AudioPathType type);
     static AudioPathType getTypeFromInt(int typeInt);
 
-    // Returns the minimum number of channels needed on a sound device for an
-    // AudioPathType.
+    /// Returns the minimum number of channels needed on a sound device for an
+    /// AudioPathType.
     static unsigned char minChannelsForType(AudioPathType type);
 
     // Returns the maximum number of channels needed on a sound device for an
@@ -123,12 +102,8 @@ protected:
     unsigned char m_index;
 };
 
-/**
- * @class AudioOutput
- * @extends AudioPath
- * @brief A source of audio in Mixxx that is to be output to a group of
- *        channels on an audio interface.
- */
+/// A source of audio in Mixxx that is to be output to a group of
+/// channels on an audio interface.
 class AudioOutput : public AudioPath {
   public:
     AudioOutput(AudioPathType type, unsigned char channelBase,
@@ -157,12 +132,8 @@ class AudioOutputBuffer : public AudioOutput {
     const CSAMPLE* m_pBuffer;
 };
 
-/**
- * @class AudioInput
- * @extends AudioPath
- * @brief A source of audio at a group of channels on an audio interface
- *        that is be processed in Mixxx.
- */
+/// A source of audio at a group of channels on an audio interface
+/// that is be processed in Mixxx.
 class AudioInput : public AudioPath {
   public:
     AudioInput(AudioPathType type = INVALID, unsigned char channelBase = 0,
@@ -197,14 +168,14 @@ public:
 
     virtual const CSAMPLE* buffer(AudioOutput output) const = 0;
 
-    // This is called by SoundManager whenever an output is connected for this
-    // source. When this is called it is guaranteed that no callback is
-    // active.
+    /// This is called by SoundManager whenever an output is connected for this
+    /// source. When this is called it is guaranteed that no callback is
+    /// active.
     virtual void onOutputConnected(AudioOutput output) { Q_UNUSED(output); };
 
-    // This is called by SoundManager whenever an output is disconnected for
-    // this source. When this is called it is guaranteed that no callback is
-    // active.
+    /// This is called by SoundManager whenever an output is disconnected for
+    /// this source. When this is called it is guaranteed that no callback is
+    /// active.
     virtual void onOutputDisconnected(AudioOutput output) { Q_UNUSED(output); };
 };
 
@@ -212,20 +183,20 @@ class AudioDestination {
 public:
     virtual ~AudioDestination() = default;
 
-    // This is called by SoundManager whenever there are new samples from the
-    // configured input to be processed. This is run in the clock reference
-    // callback thread
+    /// This is called by SoundManager whenever there are new samples from the
+    /// configured input to be processed. This is run in the clock reference
+    /// callback thread
     virtual void receiveBuffer(AudioInput input, const CSAMPLE* pBuffer,
                                unsigned int iNumFrames) = 0;
 
-    // This is called by SoundManager whenever an input is configured for this
-    // destination. When this is called it is guaranteed that no callback is
-    // active.
+    /// This is called by SoundManager whenever an input is configured for this
+    /// destination. When this is called it is guaranteed that no callback is
+    /// active.
     virtual void onInputConfigured(AudioInput input) { Q_UNUSED(input); };
 
-    // This is called by SoundManager whenever an input is unconfigured for this
-    // destination. When this is called it is guaranteed that no callback is
-    // active.
+    /// This is called by SoundManager whenever an input is unconfigured for this
+    /// destination. When this is called it is guaranteed that no callback is
+    /// active.
     virtual void onInputUnconfigured(AudioInput input) { Q_UNUSED(input); };
 };
 
@@ -234,8 +205,8 @@ typedef AudioPath::AudioPathType AudioPathType;
 class SoundDeviceId final {
   public:
     QString name;
-    // The "hw:X,Y" device name. Remains an empty string if not using ALSA
-    // or using a non-hw ALSA device such as "default" or "pulse".
+    /// The "hw:X,Y" device name. Remains an empty string if not using ALSA
+    /// or using a non-hw ALSA device such as "default" or "pulse".
     QString alsaHwDevice;
     int portAudioIndex;
 
@@ -245,9 +216,9 @@ class SoundDeviceId final {
        : portAudioIndex(-1) {}
 };
 
-// This must be registered with QMetaType::registerComparators for
-// QVariant::operator== to use it, which is required for QComboBox::findData to
-// work in DlgPrefSoundItem.
+/// This must be registered with QMetaType::registerComparators for
+/// QVariant::operator== to use it, which is required for QComboBox::findData to
+/// work in DlgPrefSoundItem.
 inline bool operator==(
         const SoundDeviceId& lhs,
         const SoundDeviceId& rhs) {
@@ -262,7 +233,7 @@ inline bool operator!=(
     return !(lhs == rhs);
 }
 
-// There is not really a use case for this, but it is required for QMetaType::registerComparators.
+/// There is not really a use case for this, but it is required for QMetaType::registerComparators.
 inline bool operator<(const SoundDeviceId& lhs, const SoundDeviceId& rhs) {
     DEBUG_ASSERT(!"should never be invoked");
     return lhs.portAudioIndex < rhs.portAudioIndex;
@@ -281,5 +252,3 @@ inline uint qHash(
 inline QDebug operator<<(QDebug dbg, const SoundDeviceId& soundDeviceId) {
     return dbg << QString("SoundDeviceId(" + soundDeviceId.debugName() + ")");
 }
-
-#endif

--- a/src/track/trackfile.h
+++ b/src/track/trackfile.h
@@ -124,6 +124,8 @@ inline QDebug operator<<(QDebug debug, const TrackFile& trackFile) {
 #endif
 }
 
-inline uint qHash(const TrackFile& key, uint seed) {
+inline uint qHash(
+        const TrackFile& key,
+        uint seed = 0) {
     return qHash(key.location(), seed);
 }

--- a/src/track/trackref.h
+++ b/src/track/trackref.h
@@ -116,6 +116,10 @@ std::ostream& operator<<(std::ostream& os, const TrackRef& trackRef);
 
 QDebug operator<<(QDebug debug, const TrackRef& trackRef);
 
-inline uint qHash(const TrackRef& key, uint seed) {
-    return qHash(key.getLocation(), seed) ^ qHash(key.getId(), seed);
+inline uint qHash(
+        const TrackRef& key,
+        uint seed = 0) {
+    return qHash(
+            key.getLocation(), seed) ^
+            qHash(key.getId(), seed);
 }

--- a/src/util/db/dbid.h
+++ b/src/util/db/dbid.h
@@ -102,8 +102,10 @@ public:
         return debug << dbId.m_value;
     }
 
-    friend uint qHash(const DbId& dbId) {
-        return qHash(dbId.m_value);
+    friend uint qHash(
+            const DbId& dbId,
+            uint seed = 0) {
+        return qHash(dbId.m_value, seed);
     }
 
 private:


### PR DESCRIPTION
- The optional seed = 0 parameter in overloaded qHash() functions was missing
- qHash() for AudioPath ignored m_channelGroup
- Functions for AudioInput/-Output were undefined and unused

~~Now Mixxx crashes on exit when a MIDI controller is connected~~ The crash is caused by #2767.