### PR TITLE
Fix race-condition in multi-threaded analysis

### DIFF
--- a/src/analyzer/analyzerthread.cpp
+++ b/src/analyzer/analyzerthread.cpp
@@ -203,7 +203,7 @@ bool AnalyzerThread::submitNextTrack(TrackPointer nextTrack) {
     return false;
 }
 
-WorkerThread::FetchWorkResult AnalyzerThread::tryFetchWorkItems() {
+WorkerThread::TryFetchWorkItemsResult AnalyzerThread::tryFetchWorkItems() {
     DEBUG_ASSERT(!m_currentTrack);
     TrackPointer* pFront = m_nextTrack.front();
     if (pFront) {
@@ -212,10 +212,10 @@ WorkerThread::FetchWorkResult AnalyzerThread::tryFetchWorkItems() {
         kLogger.debug()
                 << "Dequeued next track"
                 << m_currentTrack->getId();
-        return FetchWorkResult::Ready;
+        return TryFetchWorkItemsResult::Ready;
     } else {
         emitProgress(AnalyzerThreadState::Idle);
-        return FetchWorkResult::Idle;
+        return TryFetchWorkItemsResult::Idle;
     }
 }
 

--- a/src/analyzer/analyzerthread.cpp
+++ b/src/analyzer/analyzerthread.cpp
@@ -125,7 +125,7 @@ void AnalyzerThread::doRun() {
     mixxx::AudioSource::OpenParams openParams;
     openParams.setChannelCount(mixxx::kAnalysisChannels);
 
-    while (waitUntilWorkItemsFetched()) {
+    while (awaitWorkItemsFetched()) {
         DEBUG_ASSERT(m_currentTrack);
         kLogger.debug() << "Analyzing" << m_currentTrack->getFileInfo();
 

--- a/src/analyzer/analyzerthread.h
+++ b/src/analyzer/analyzerthread.h
@@ -88,7 +88,7 @@ class AnalyzerThread : public WorkerThread {
   protected:
     void doRun() override;
 
-    FetchWorkResult tryFetchWorkItems() override;
+    TryFetchWorkItemsResult tryFetchWorkItems() override;
 
   private:
     /////////////////////////////////////////////////////////////////////////

--- a/src/util/workerthread.cpp
+++ b/src/util/workerthread.cpp
@@ -95,6 +95,10 @@ void WorkerThread::resume() {
 void WorkerThread::wake() {
     logTrace(m_logger, "Waking up");
     std::unique_lock<std::mutex> locked(m_sleepMutex);
+    // We need to always aquire the mutex before notifying the
+    // worker thread! Otherwise the worker thread might invoke
+    // m_sleepWaitCond.wait(locked) just after the notification
+    // has been signaled and remain waiting forever!
     m_sleepWaitCond.notify_one();
 }
 

--- a/src/util/workerthread.cpp
+++ b/src/util/workerthread.cpp
@@ -77,12 +77,9 @@ void WorkerThread::suspend() {
 }
 
 void WorkerThread::resume() {
+    logTrace(m_logger, "Resuming");
     // Reset m_suspend to false to allow the thread to make progress.
-    bool suspended = true; // expected value
-    // Reset value: true -> false
-    if (m_suspend.compare_exchange_strong(suspended, false)) {
-        logTrace(m_logger, "Resuming");
-    }
+    m_suspend.store(false);
     // Wake up the thread so that it is able to check m_suspend and
     // continue processing. To avoid race conditions this needs to
     // be performed unconditionally even if m_suspend was false and has

--- a/src/util/workerthread.cpp
+++ b/src/util/workerthread.cpp
@@ -123,14 +123,9 @@ void WorkerThread::sleepWhileSuspended() {
         return;
     }
     std::unique_lock<std::mutex> locked(m_sleepMutex);
-    sleepWhileSuspended(&locked);
-}
-
-void WorkerThread::sleepWhileSuspended(std::unique_lock<std::mutex>* locked) {
-    DEBUG_ASSERT(locked);
     while (m_suspend.load()) {
         logTrace(m_logger, "Sleeping while suspended");
-        m_sleepWaitCond.wait(*locked) ;
+        m_sleepWaitCond.wait(locked) ;
         logTrace(m_logger, "Continuing after sleeping while suspended");
     }
 }

--- a/src/util/workerthread.cpp
+++ b/src/util/workerthread.cpp
@@ -143,12 +143,12 @@ bool WorkerThread::waitUntilWorkItemsFetched() {
     // Keep the mutex locked while idle or suspended
     std::unique_lock<std::mutex> locked(m_sleepMutex);
     while (!isStopping()) {
-        FetchWorkResult fetchWorkResult = tryFetchWorkItems();
+        TryFetchWorkItemsResult fetchWorkResult = tryFetchWorkItems();
         switch (fetchWorkResult) {
-        case FetchWorkResult::Ready:
+        case TryFetchWorkItemsResult::Ready:
             logTrace(m_logger, "Work items fetched and ready");
             return true;
-        case FetchWorkResult::Idle:
+        case TryFetchWorkItemsResult::Idle:
             logTrace(m_logger, "Sleeping while idle");
             m_sleepWaitCond.wait(locked) ;
             logTrace(m_logger, "Continuing after slept while idle");

--- a/src/util/workerthread.cpp
+++ b/src/util/workerthread.cpp
@@ -135,7 +135,7 @@ void WorkerThread::sleepWhileSuspended(std::unique_lock<std::mutex>* locked) {
     }
 }
 
-bool WorkerThread::waitUntilWorkItemsFetched() {
+bool WorkerThread::awaitWorkItemsFetched() {
     if (isStopping()) {
         // Early exit without locking the mutex
         return false;

--- a/src/util/workerthread.cpp
+++ b/src/util/workerthread.cpp
@@ -69,6 +69,7 @@ void WorkerThread::run() {
 }
 
 void WorkerThread::suspend() {
+    DEBUG_ASSERT(QThread::currentThread() != this);
     logTrace(m_logger, "Suspending");
     m_suspend.store(true);
     // The thread will suspend processing and fall asleep the
@@ -77,6 +78,7 @@ void WorkerThread::suspend() {
 }
 
 void WorkerThread::resume() {
+    DEBUG_ASSERT(QThread::currentThread() != this);
     logTrace(m_logger, "Resuming");
     // Reset m_suspend to false to allow the thread to make progress.
     m_suspend.store(false);
@@ -90,6 +92,7 @@ void WorkerThread::resume() {
 }
 
 void WorkerThread::wake() {
+    DEBUG_ASSERT(QThread::currentThread() != this);
     logTrace(m_logger, "Waking up");
     std::unique_lock<std::mutex> locked(m_sleepMutex);
     // We need to always aquire the mutex before notifying the
@@ -100,6 +103,7 @@ void WorkerThread::wake() {
 }
 
 void WorkerThread::stop() {
+    DEBUG_ASSERT(QThread::currentThread() != this);
     logTrace(m_logger, "Stopping");
     m_stop.store(true);
     // Wake up the thread to make sure that the stop flag is
@@ -148,16 +152,6 @@ bool WorkerThread::waitUntilWorkItemsFetched() {
             logTrace(m_logger, "Sleeping while idle");
             m_sleepWaitCond.wait(locked) ;
             logTrace(m_logger, "Continuing after slept while idle");
-            break;
-        case FetchWorkResult::Suspend:
-            logTrace(m_logger, "Suspending while idle");
-            suspend();
-            sleepWhileSuspended(&locked);
-            logTrace(m_logger, "Continuing after suspended while idle");
-            break;
-        case FetchWorkResult::Stop:
-            logTrace(m_logger, "Stopping after trying to fetch work items");
-            stop();
             break;
         }
     }

--- a/src/util/workerthread.h
+++ b/src/util/workerthread.h
@@ -45,18 +45,30 @@ class WorkerThread : public QThread {
     }
 
     /// Commands the thread to suspend itself asap.
+    ///
+    /// Must not be invoked from the worker thread itself to
+    /// avoid race conditions!
     void suspend();
 
     /// Resumes a suspended thread by waking it up.
+    ///
+    /// Must not be invoked from the worker thread itself to
+    /// avoid race conditions!
     void resume();
 
     /// Wakes up a sleeping thread. If the thread has been suspended
     /// it will fall asleep again. A suspended thread needs to be
     /// resumed.
+    ///
+    /// Must not be invoked from the worker thread itself to
+    /// avoid race conditions!
     void wake();
 
     /// Commands the thread to stop asap. This action is irreversible,
     /// i.e. the thread cannot be restarted once it has been stopped.
+    ///
+    /// Must not be invoked from the worker thread itself to
+    /// avoid race conditions!
     void stop();
 
     /// Non-blocking atomic read of the stop flag which indicates that
@@ -81,8 +93,6 @@ class WorkerThread : public QThread {
     enum class FetchWorkResult {
         Ready,
         Idle,
-        Suspend,
-        Stop,
     };
 
     /// Non-blocking function that determines whether the worker thread

--- a/src/util/workerthread.h
+++ b/src/util/workerthread.h
@@ -120,6 +120,10 @@ class WorkerThread : public QThread {
     bool awaitWorkItemsFetched();
 
     /// Blocks the worker thread while the suspend flag is set.
+    ///
+    /// Worker threads should invoke this function before starting
+    /// computational intensive work that is expected to take some time.
+    ///
     /// This function must not be called from tryFetchWorkItems()
     /// to avoid a deadlock on the non-recursive mutex!
     void sleepWhileSuspended();

--- a/src/util/workerthread.h
+++ b/src/util/workerthread.h
@@ -121,8 +121,12 @@ class WorkerThread : public QThread {
 
     /// Blocks the worker thread while the suspend flag is set.
     ///
-    /// Worker threads should invoke this function before starting
-    /// computational intensive work that is expected to take some time.
+    /// Worker threads should invoke this yield-like method periodically.
+    /// Especially before starting any computational intensive work that
+    /// is expected to take some time.
+    ///
+    /// After returning from this function worker threads should also
+    /// check isStopping() and exit if they have been asked to stop.
     ///
     /// This function must not be called from tryFetchWorkItems()
     /// to avoid a deadlock on the non-recursive mutex!

--- a/src/util/workerthread.h
+++ b/src/util/workerthread.h
@@ -9,33 +9,33 @@
 #include "util/logger.h"
 
 
-// A worker thread without an event loop.
-//
-// This object lives in the creating thread of the host, i.e. does not
-// run its own event loop. It does not use slots for communication
-// with its host which would otherwise still be executed in the host's
-// thread.
-//
-// Signals emitted from the internal worker thread by derived classes
-// will queued connections. Communication in the opposite direction is
-// accomplished by using lock-free types to avoid locking the host
-// thread through priority inversion. Lock-free types might also used
-// for any shared state that is read from the host thread after being
-// notified about changes.
-//
-// Derived classes or their owners are responsible to start the thread
-// with the desired priority.
+/// A worker thread without an event loop.
+///
+/// This object lives in the creating thread of the host, i.e. does not
+/// run its own event loop. It does not use slots for communication
+/// with its host which would otherwise still be executed in the host's
+/// thread.
+///
+/// Signals emitted from the internal worker thread by derived classes
+/// will queued connections. Communication in the opposite direction is
+/// accomplished by using lock-free types to avoid locking the host
+/// thread through priority inversion. Lock-free types might also used
+/// for any shared state that is read from the host thread after being
+/// notified about changes.
+///
+/// Derived classes or their owners are responsible to start the thread
+/// with the desired priority.
 class WorkerThread : public QThread {
     Q_OBJECT
 
   public:
     explicit WorkerThread(
             const QString& name = QString());
-    // The destructor must be triggered by calling deleteLater() to
-    // ensure that the thread has already finished and is not running
-    // while destroyed! Connect finished() to deleteAfter() and then
-    // call stop() on the running worker thread explicitly to trigger
-    // the destruction. Use deleteAfterFinished() for this purpose.
+    /// The destructor must be triggered by calling deleteLater() to
+    /// ensure that the thread has already finished and is not running
+    /// while destroyed! Connect finished() to deleteAfter() and then
+    /// call stop() on the running worker thread explicitly to trigger
+    /// the destruction. Use deleteAfterFinished() for this purpose.
     ~WorkerThread() override;
 
     void deleteAfterFinished();
@@ -44,24 +44,24 @@ class WorkerThread : public QThread {
         return m_name;
     }
 
-    // Commands the thread to suspend itself asap.
+    /// Commands the thread to suspend itself asap.
     void suspend();
 
-    // Resumes a suspended thread by waking it up.
+    /// Resumes a suspended thread by waking it up.
     void resume();
 
-    // Wakes up a sleeping thread. If the thread has been suspended
-    // it will fall asleep again. A suspended thread needs to be
-    // resumed.
+    /// Wakes up a sleeping thread. If the thread has been suspended
+    /// it will fall asleep again. A suspended thread needs to be
+    /// resumed.
     void wake();
 
-    // Commands the thread to stop asap. This action is irreversible,
-    // i.e. the thread cannot be restarted once it has been stopped.
+    /// Commands the thread to stop asap. This action is irreversible,
+    /// i.e. the thread cannot be restarted once it has been stopped.
     void stop();
 
-    // Non-blocking atomic read of the stop flag which indicates that
-    // the thread is stopping, i.e. it will soon exit or already has
-    // exited the run loop.
+    /// Non-blocking atomic read of the stop flag which indicates that
+    /// the thread is stopping, i.e. it will soon exit or already has
+    /// exited the run loop.
     bool isStopping() const {
         return m_stop.load();
     }
@@ -69,13 +69,13 @@ class WorkerThread : public QThread {
   protected:
     void run() final;
 
-    // The internal run loop. Not to be confused with the Qt event
-    // loop since the worker thread doesn't have one!
-    // An implementation may exit this loop after all work is done,
-    // which in turn exits and terminates the thread. The loop should
-    // also be left asap when isStopping() returns true. This condition
-    // should be checked repeatedly during execution of the loop and
-    // especially before starting any expensive subtasks.
+    /// The internal run loop. Not to be confused with the Qt event
+    /// loop since the worker thread doesn't have one!
+    /// An implementation may exit this loop after all work is done,
+    /// which in turn exits and terminates the thread. The loop should
+    /// also be left asap when isStopping() returns true. This condition
+    /// should be checked repeatedly during execution of the loop and
+    /// especially before starting any expensive subtasks.
     virtual void doRun() = 0;
 
     enum class FetchWorkResult {
@@ -85,35 +85,33 @@ class WorkerThread : public QThread {
         Stop,
     };
 
-    // Non-blocking function that determines whether the worker thread
-    // is idle (i.e. no new tasks have been scheduled) and should be
-    // either suspended until resumed or put to sleep until woken up.
-    //
-    // Implementing classes are able to control what to do if no more
-    // work is currently available. Returning FetchWorkResult::Idle
-    // preserves the current suspend state and just puts the thread
-    // to sleep until wake() is called. Returning FetchWorkResult::Suspend
-    // will suspend the thread until resume() is called. Returning
-    // FetchWorkResult::Stop will stop the worker thread.
-    //
-    // Implementing classes are responsible for storing the fetched
-    // work items internally for later processing during
-    // doRun().
-    //
-    // The stop flag does not have to be checked when entering this function,
-    // because it has already been checked just before the invocation. Though
-    // the fetch operation may check again before starting any expensive
-    // internal subtask.
+    /// Non-blocking function that determines whether the worker thread
+    /// is idle (i.e. no new tasks have been scheduled) and should be
+    /// either suspended until resumed or put to sleep until woken up.
+    ///
+    /// Implementing classes are able to control what to do if no more
+    /// work is currently available. Returning FetchWorkResult::Idle
+    /// preserves the current suspend state and lets the thread sleep
+    /// until wake() is called.
+    ///
+    /// Implementing classes are responsible for storing the fetched
+    /// work items internally for later processing during
+    /// doRun().
+    ///
+    /// The stop flag does not have to be checked when entering this function,
+    /// because it has already been checked just before the invocation. Though
+    /// the fetch operation may check again before starting any expensive
+    /// internal subtask.
     virtual FetchWorkResult tryFetchWorkItems() = 0;
 
-    // Blocks while idle and not stopped. Returns true when new work items
-    // for processing have been fetched and false if the thread has been
-    // stopped while waiting.
+    /// Blocks while idle and not stopped. Returns true when new work items
+    /// for processing have been fetched and false if the thread has been
+    /// stopped while waiting.
     bool waitUntilWorkItemsFetched();
 
-    // Blocks the worker thread while the suspend flag is set.
-    // This function must not be called from tryFetchWorkItems()
-    // to avoid a deadlock on the non-recursive mutex!
+    /// Blocks the worker thread while the suspend flag is set.
+    /// This function must not be called from tryFetchWorkItems()
+    /// to avoid a deadlock on the non-recursive mutex!
     void sleepWhileSuspended();
 
   private:

--- a/src/util/workerthread.h
+++ b/src/util/workerthread.h
@@ -90,7 +90,7 @@ class WorkerThread : public QThread {
     /// especially before starting any expensive subtasks.
     virtual void doRun() = 0;
 
-    enum class FetchWorkResult {
+    enum class TryFetchWorkItemsResult {
         Ready,
         Idle,
     };
@@ -100,7 +100,7 @@ class WorkerThread : public QThread {
     /// either suspended until resumed or put to sleep until woken up.
     ///
     /// Implementing classes are able to control what to do if no more
-    /// work is currently available. Returning FetchWorkResult::Idle
+    /// work is currently available. Returning TryFetchWorkItemsResult::Idle
     /// preserves the current suspend state and lets the thread sleep
     /// until wake() is called.
     ///
@@ -112,7 +112,7 @@ class WorkerThread : public QThread {
     /// because it has already been checked just before the invocation. Though
     /// the fetch operation may check again before starting any expensive
     /// internal subtask.
-    virtual FetchWorkResult tryFetchWorkItems() = 0;
+    virtual TryFetchWorkItemsResult tryFetchWorkItems() = 0;
 
     /// Blocks while idle and not stopped. Returns true when new work items
     /// for processing have been fetched and false if the thread has been

--- a/src/util/workerthread.h
+++ b/src/util/workerthread.h
@@ -117,7 +117,7 @@ class WorkerThread : public QThread {
     /// Blocks while idle and not stopped. Returns true when new work items
     /// for processing have been fetched and false if the thread has been
     /// stopped while waiting.
-    bool waitUntilWorkItemsFetched();
+    bool awaitWorkItemsFetched();
 
     /// Blocks the worker thread while the suspend flag is set.
     /// This function must not be called from tryFetchWorkItems()

--- a/src/util/workerthread.h
+++ b/src/util/workerthread.h
@@ -125,8 +125,6 @@ class WorkerThread : public QThread {
     void sleepWhileSuspended();
 
   private:
-    void sleepWhileSuspended(std::unique_lock<std::mutex>* locked);
-
     const QString m_name;
 
     const mixxx::Logger m_logger;

--- a/src/util/workerthreadscheduler.cpp
+++ b/src/util/workerthreadscheduler.cpp
@@ -29,17 +29,17 @@ bool WorkerThreadScheduler::resumeWorkers() {
     }
 }
 
-WorkerThread::FetchWorkResult WorkerThreadScheduler::tryFetchWorkItems() {
+WorkerThread::TryFetchWorkItemsResult WorkerThreadScheduler::tryFetchWorkItems() {
     DEBUG_ASSERT(!m_fetchedWorker);
     WorkerThread* worker;
     if (m_scheduledWorkers.read(&worker, 1) == 1) {
         DEBUG_ASSERT(worker);
         m_fetchedWorker = worker;
-        return FetchWorkResult::Ready;
+        return TryFetchWorkItemsResult::Ready;
     } else {
         // Fall asleep after all scheduled workers have have
         // been resumed.
-        return FetchWorkResult::Idle;
+        return TryFetchWorkItemsResult::Idle;
     }
 }
 

--- a/src/util/workerthreadscheduler.cpp
+++ b/src/util/workerthreadscheduler.cpp
@@ -44,7 +44,7 @@ WorkerThread::TryFetchWorkItemsResult WorkerThreadScheduler::tryFetchWorkItems()
 }
 
 void WorkerThreadScheduler::doRun() {
-    while (waitUntilWorkItemsFetched()) {
+    while (awaitWorkItemsFetched()) {
         m_fetchedWorker->resume();
         m_fetchedWorker = nullptr;
     }

--- a/src/util/workerthreadscheduler.cpp
+++ b/src/util/workerthreadscheduler.cpp
@@ -37,9 +37,9 @@ WorkerThread::FetchWorkResult WorkerThreadScheduler::tryFetchWorkItems() {
         m_fetchedWorker = worker;
         return FetchWorkResult::Ready;
     } else {
-        // Suspend the thread after all scheduled workers have
-        // have been resumed.
-        return FetchWorkResult::Suspend;
+        // Fall asleep after all scheduled workers have have
+        // been resumed.
+        return FetchWorkResult::Idle;
     }
 }
 

--- a/src/util/workerthreadscheduler.h
+++ b/src/util/workerthreadscheduler.h
@@ -23,7 +23,7 @@ class WorkerThreadScheduler : public WorkerThread {
   protected:
     void doRun() override;
 
-    FetchWorkResult tryFetchWorkItems() override;
+    TryFetchWorkItemsResult tryFetchWorkItems() override;
 
   private:
     FIFO<WorkerThread*> m_scheduledWorkers;

--- a/src/util/workerthreadscheduler.h
+++ b/src/util/workerthreadscheduler.h
@@ -6,9 +6,9 @@
 
 class WorkerThread;
 
-// Non-blocking scheduler for worker threads which itself runs
-// as a worker thread. The maximum number of worker threads is
-// limited.
+/// Non-blocking scheduler for worker threads which itself runs
+/// as a worker thread. The maximum number of worker threads is
+/// limited.
 class WorkerThreadScheduler : public WorkerThread {
   public:
     explicit WorkerThreadScheduler(


### PR DESCRIPTION
https://mixxx.zulipchat.com/#narrow/stream/109695-_support/topic/Bulk.20Analysing.20seeming.20to.20freeze

This fixes a race condition in the multi-threaded analysis where some worker threads might get stuck forever by not resuming after they received a next track for analysis.

The public method was lacking a mutex lock!

I found this by adding more detailed log messages. Those changes could later be merged to master.