### PR TITLE
waveformrendermark: make background translucent

### DIFF
--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -124,6 +124,8 @@ void WaveformRenderMark::slotCuesUpdated() {
 
         QString newLabel = pCue->getLabel();
         QColor newColor = mixxx::RgbColor::toQColor(pCue->getColor());
+        // Make background translucent
+        newColor.setAlpha(100);
         if (pMark->m_text.isNull() || newLabel != pMark->m_text ||
                 !pMark->fillColor().isValid() || newColor != pMark->fillColor()) {
             pMark->m_text = newLabel;


### PR DESCRIPTION
Looks decent when there are waves under the label.
![Screenshot from 2020-05-09 04-05-50](https://user-images.githubusercontent.com/30816844/81454688-a102bb00-91aa-11ea-8ba1-ead02156ff0e.png)
But the text is quite unreadable when there are no opposite coloured waves underneath the translucent label.
![Screenshot from 2020-05-09 04-05-35](https://user-images.githubusercontent.com/30816844/81454734-c263a700-91aa-11ea-9a2b-b70fc1672b0c.png)
A solution might be to make the label translucent only when there are waves under it.
