### PR TITLE
Fix crash in ControllerEngine::gracefulShutdown()

### DIFF
--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -189,14 +189,17 @@ void ControllerEngine::gracefulShutdown() {
     m_scriptWrappedFunctionCache.clear();
 
     // Free all the ControlObjectScripts
-    for (auto it = m_controlCache.begin(); it != m_controlCache.end(); /*see loop body*/) {
-        qDebug()
-                << "Deleting ControlObjectScript"
-                << it.key().group
-                << it.key().item;
-        delete it.value();
-        // Advance iterator
-        it = m_controlCache.erase(it);
+    {
+        auto it = m_controlCache.begin();
+        while (it != m_controlCache.end()) {
+            qDebug()
+                    << "Deleting ControlObjectScript"
+                    << it.key().group
+                    << it.key().item;
+            delete it.value();
+            // Advance iterator
+            it = m_controlCache.erase(it);
+        }
     }
 
     delete m_pBaClass;

--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -167,7 +167,7 @@ void ControllerEngine::gracefulShutdown() {
     // Stop all timers
     stopAllTimers();
 
-    // Call each script's shutdown function if it exists
+    qDebug() << "Invoking shutdown() hook in scripts";
     callFunctionOnObjects(m_scriptFunctionPrefixes, "shutdown");
 
     // Prevents leaving decks in an unstable state
@@ -185,18 +185,18 @@ void ControllerEngine::gracefulShutdown() {
         }
     }
 
-    // Clear the cache of function wrappers
+    qDebug() << "Clearing function wrapper cache";
     m_scriptWrappedFunctionCache.clear();
 
     // Free all the ControlObjectScripts
-    QList<ConfigKey> keys = m_controlCache.keys();
-    QList<ConfigKey>::iterator it = keys.begin();
-    QList<ConfigKey>::iterator end = keys.end();
-    while (it != end) {
-        ConfigKey key = *it;
-        ControlObjectScript* coScript = m_controlCache.take(key);
-        delete coScript;
-        ++it;
+    for (auto it = m_controlCache.begin(); it != m_controlCache.end(); /*see loop body*/) {
+        qDebug()
+                << "Deleting ControlObjectScript"
+                << it.key().group
+                << it.key().item;
+        delete it.value();
+        // Advance iterator
+        it = m_controlCache.erase(it);
     }
 
     delete m_pBaClass;


### PR DESCRIPTION
This fixes crash caused by invalid iterator usage when shutting down Mixxx while a controller is connected.

But afterwards Mixxx still crashes when exiting the *Controller* thread:
```
Debug [Controller]: Deleting USB Bulk devices...
Debug [Controller]: Deleting HID devices...
[Thread 0x7ffec3fff700 (LWP 22012) exited]
malloc_consolidate(): invalid chunk size

Thread 34 "Controller" received signal SIGABRT, Aborted.
[Switching to Thread 0x7ffee2ffd700 (LWP 22006)]
__GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
50	  return ret;
(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007ffff3623895 in __GI_abort () at abort.c:79
#2  0x00007ffff367e8c7 in __libc_message (action=action@entry=do_abort, fmt=fmt@entry=0x7ffff378fe1d "%s\n") at ../sysdeps/posix/libc_fatal.c:155
#3  0x00007ffff3685dec in malloc_printerr (str=str@entry=0x7ffff37920a0 "malloc_consolidate(): invalid chunk size") at malloc.c:5347
#4  0x00007ffff3686cb8 in malloc_consolidate (av=av@entry=0x7ffff37c19e0 <main_arena>) at malloc.c:4477
#5  0x00007ffff3687460 in _int_free (av=0x7ffff37c19e0 <main_arena>, p=0x17057f0, have_lock=<optimized out>) at malloc.c:4400
#6  0x00007ffff63fb5bb in magazine_cache_push_magazine () at /lib64/libglib-2.0.so.0
#7  0x00007ffff63fb6cf in private_thread_memory_cleanup () at /lib64/libglib-2.0.so.0
#8  0x00007ffff37d1251 in __nptl_deallocate_tsd () at pthread_create.c:301
#9  __nptl_deallocate_tsd () at pthread_create.c:250
#10 0x00007ffff37d1445 in start_thread (arg=<optimized out>) at pthread_create.c:488
#11 0x00007ffff36ff9d3 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```