### PR TITLE
Master sync: disable explicit mode

### DIFF
--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -113,11 +113,11 @@ void EngineSync::requestSyncMode(Syncable* pSyncable, SyncMode mode) {
     } else if (mode == SYNC_FOLLOWER ||
             mode == SYNC_MASTER_SOFT ||
             pSyncable == m_pInternalClock) {
-        // Note: SYNC_MASTER_SOFT and SYNC_FOLLOWER cannot be set explicit,
+        // Note: SYNC_MASTER_SOFT and SYNC_FOLLOWER cannot be set explicitly,
         // they are calculated by pickMaster.
         // Internal clock cannot be disabled, it is always listening
         if (m_pMasterSyncable == pSyncable) {
-            // Was this  pSyncable was master before. Hand off.
+            // This Syncable was master before. Hand off.
             m_pMasterSyncable = nullptr;
             pSyncable->setSyncMode(SYNC_FOLLOWER);
         }

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -393,30 +393,20 @@ void SyncControl::slotSyncModeChangeRequest(double state) {
 }
 
 void SyncControl::slotSyncMasterEnabledChangeRequest(double state) {
-    SyncMode mode = getSyncMode();
     if (state > 0.0) {
-        if (mode == SYNC_MASTER_EXPLICIT) {
+        if (isMaster(getSyncMode())) {
             // Already master.
-            return;
-        }
-        if (mode == SYNC_MASTER_SOFT) {
-            // user request: make master explicit
-            m_pSyncMode->setAndConfirm(SYNC_MASTER_EXPLICIT);
             return;
         }
         if (m_pPassthroughEnabled->get()) {
             qDebug() << "Disallowing enabling of sync mode when passthrough active";
             return;
         }
-        m_pChannel->getEngineBuffer()->requestSyncMode(SYNC_MASTER_EXPLICIT);
-    } else {
-        // Turning off master goes back to follower mode.
-        if (mode == SYNC_FOLLOWER) {
-            // Already not master.
-            return;
-        }
-        m_pChannel->getEngineBuffer()->requestSyncMode(SYNC_FOLLOWER);
     }
+    // TODO(owilliams): Because SYNC_MASTER_EXPLICIT has issues, for now we
+    // actually just enable follower mode even when they ask for master. This
+    // is equivalent to the behavior in 2.2
+    m_pChannel->getEngineBuffer()->requestSyncMode(SYNC_FOLLOWER);
 }
 
 void SyncControl::slotSyncEnabledChangeRequest(double enabled) {


### PR DESCRIPTION
This restores the sync_master CO behavior to what it did in 2.2 so that users won't stumble onto explicit master mode. Since that mode still has a lot of bugs we don't want to expose it just yet.

Some minor test updates based on the change