### PR TITLE
fix color scheme parsing & picking

### DIFF
--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -130,12 +130,12 @@ DlgPrefInterface::DlgPrefInterface(QWidget * parent, MixxxMainWindow * mixxx,
     // Screensaver mode
     //
     comboBoxScreensaver->clear();
-    comboBoxScreensaver->addItem(tr("Allow screensaver to run"), 
-        static_cast<int>(mixxx::ScreenSaverPreference::PREVENT_OFF));
-    comboBoxScreensaver->addItem(tr("Prevent screensaver from running"), 
-        static_cast<int>(mixxx::ScreenSaverPreference::PREVENT_ON));
-    comboBoxScreensaver->addItem(tr("Prevent screensaver while playing"), 
-        static_cast<int>(mixxx::ScreenSaverPreference::PREVENT_ON_PLAY));
+    comboBoxScreensaver->addItem(tr("Allow screensaver to run"),
+            static_cast<int>(mixxx::ScreenSaverPreference::PREVENT_OFF));
+    comboBoxScreensaver->addItem(tr("Prevent screensaver from running"),
+            static_cast<int>(mixxx::ScreenSaverPreference::PREVENT_ON));
+    comboBoxScreensaver->addItem(tr("Prevent screensaver while playing"),
+            static_cast<int>(mixxx::ScreenSaverPreference::PREVENT_ON_PLAY));
 
     int inhibitsettings = static_cast<int>(mixxx->getInhibitScreensaver());
     comboBoxScreensaver->setCurrentIndex(comboBoxScreensaver->findData(inhibitsettings));

--- a/src/skin/colorschemeparser.cpp
+++ b/src/skin/colorschemeparser.cpp
@@ -39,6 +39,12 @@ void ColorSchemeParser::setupLegacyColorSchemes(QDomElement docElem,
             }
         }
 
+        if (!bSelectedColorSchemeFound) {
+            // If we didn't find a matching color scheme, pick the first one
+            schemeNode = schemesNode.firstChild();
+            bSelectedColorSchemeFound = !schemeNode.isNull();
+        }
+
         if (bSelectedColorSchemeFound) {
             QSharedPointer<ImgSource> imsrc =
                     QSharedPointer<ImgSource>(parseFilters(schemeNode.namedItem("Filters")));
@@ -50,12 +56,12 @@ void ColorSchemeParser::setupLegacyColorSchemes(QDomElement docElem,
             // iterates over all <SetVariable> nodes in the selected color scheme node
             pContext->updateVariables(schemeNode);
 
-
             if (pStyle) {
                 *pStyle = LegacySkinParser::getStyleFromNode(schemeNode);
             }
         }
     }
+
     if (!bSelectedColorSchemeFound) {
         QSharedPointer<ImgSource> imsrc =
                 QSharedPointer<ImgSource>(new ImgLoader());

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -230,19 +230,21 @@ QDomElement LegacySkinParser::openSkin(const QString& skinPath) {
 QList<QString> LegacySkinParser::getSchemeList(const QString& qSkinPath) {
 
     QDomElement docElem = openSkin(qSkinPath);
-    QList<QString> schlist;
+    QList<QString> schemeList;
 
-    QDomNode colsch = docElem.namedItem("Schemes");
-    if (!colsch.isNull() && colsch.isElement()) {
-        QDomNode sch = colsch.firstChild();
+    QDomNode colScheme = docElem.namedItem("Schemes");
+    if (!colScheme.isNull() && colScheme.isElement()) {
+        QDomNode scheme = colScheme.firstChild();
 
-        while (!sch.isNull()) {
-            QString thisname = XmlParse::selectNodeQString(sch, "Name");
-            schlist.append(thisname);
-            sch = sch.nextSibling();
+        while (!scheme.isNull()) {
+            if (scheme.isElement()) {
+                QString schemeName = XmlParse::selectNodeQString(scheme, "Name");
+                schemeList.append(schemeName);
+            }
+            scheme = scheme.nextSibling();
         }
     }
-    return schlist;
+    return schemeList;
 }
 
 // static


### PR DESCRIPTION
* ignore comments in `<Schemes>` node
Previously those were added as nameless items to the combobox
* pick first scheme if the previously selected scheme is not found in skin.xml
This might happen when the skin was reset or a color scheme removed.