### PR TITLE
Add missing column binding for 'beats_version'

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1410,6 +1410,7 @@ bool TrackDAO::updateTrack(Track* pTrack) const {
             "samplerate=:samplerate,"
             "bitrate=:bitrate,"
             "duration=:duration,"
+            "beats_version=:beats_version,"
             "beats_sub_version=:beats_sub_version,"
             "beats=:beats,"
             "bpm_lock=:bpm_lock,"


### PR DESCRIPTION
This line got lost somehow. After resetting the BPM and beat grid the beat analyzer does **NOT** re-analyze the tracks with the default settings, because the version matches!