### PR TITLE
Fix repeated key and beat analysis with default settings

### DIFF
--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -22,6 +22,12 @@ QList<mixxx::AnalyzerPluginInfo> AnalyzerBeats::availablePlugins() {
     return plugins;
 }
 
+// static
+mixxx::AnalyzerPluginInfo AnalyzerBeats::defaultPlugin() {
+    DEBUG_ASSERT(availablePlugins().size() > 0);
+    return availablePlugins().at(0);
+}
+
 AnalyzerBeats::AnalyzerBeats(UserSettingsPointer pConfig, bool enforceBpmDetection)
         : m_bpmSettings(pConfig),
           m_enforceBpmDetection(enforceBpmDetection),
@@ -63,10 +69,10 @@ bool AnalyzerBeats::initialize(TrackPointer tio, int sampleRate, int totalSample
     m_bPreferencesReanalyzeOldBpm = m_bpmSettings.getReanalyzeWhenSettingsChange();
     m_bPreferencesFastAnalysis = m_bpmSettings.getFastAnalysis();
 
-    if (AnalyzerBeats::availablePlugins().size() > 0) {
-        m_pluginId = AnalyzerBeats::availablePlugins().at(0).id; // first is default
+    if (availablePlugins().size() > 0) {
+        m_pluginId = defaultPlugin().id;
         QString pluginId = m_bpmSettings.getBeatPluginId();
-        for (const auto& info : AnalyzerBeats::availablePlugins()) {
+        for (const auto& info : availablePlugins()) {
             if (info.id == pluginId) {
                 m_pluginId = pluginId; // configured Plug-In available
                 break;
@@ -136,6 +142,9 @@ bool AnalyzerBeats::shouldAnalyze(TrackPointer tio) const {
     }
 
     QString pluginID = m_bpmSettings.getBeatPluginId();
+    if (pluginID.isEmpty()) {
+        pluginID = defaultPlugin().id;
+    }
 
     // If the track already has a Beats object then we need to decide whether to
     // analyze this track or not.

--- a/src/analyzer/analyzerbeats.h
+++ b/src/analyzer/analyzerbeats.h
@@ -25,6 +25,7 @@ class AnalyzerBeats : public Analyzer {
     ~AnalyzerBeats() override = default;
 
     static QList<mixxx::AnalyzerPluginInfo> availablePlugins();
+    static mixxx::AnalyzerPluginInfo defaultPlugin();
 
     bool initialize(TrackPointer tio, int sampleRate, int totalSamples) override;
     bool processSamples(const CSAMPLE *pIn, const int iLen) override;

--- a/src/analyzer/analyzerkey.cpp
+++ b/src/analyzer/analyzerkey.cpp
@@ -22,6 +22,12 @@ QList<mixxx::AnalyzerPluginInfo> AnalyzerKey::availablePlugins() {
     return analyzers;
 }
 
+// static
+mixxx::AnalyzerPluginInfo AnalyzerKey::defaultPlugin() {
+    DEBUG_ASSERT(availablePlugins().size() > 0);
+    return availablePlugins().at(0);
+}
+
 AnalyzerKey::AnalyzerKey(KeyDetectionSettings keySettings)
         : m_keySettings(keySettings),
           m_iSampleRate(0),
@@ -47,10 +53,10 @@ bool AnalyzerKey::initialize(TrackPointer tio, int sampleRate, int totalSamples)
     m_bPreferencesFastAnalysisEnabled = m_keySettings.getFastAnalysis();
     m_bPreferencesReanalyzeEnabled = m_keySettings.getReanalyzeWhenSettingsChange();
 
-    if (AnalyzerKey::availablePlugins().size() > 0) {
-        m_pluginId = AnalyzerKey::availablePlugins().at(0).id; // first is default
+    if (availablePlugins().size() > 0) {
+        m_pluginId = defaultPlugin().id;
         QString pluginId = m_keySettings.getKeyPluginId();
-        for (const auto& info : AnalyzerKey::availablePlugins()) {
+        for (const auto& info : availablePlugins()) {
             if (info.id == pluginId) {
                 m_pluginId = pluginId; // configured Plug-In available
                 break;
@@ -109,6 +115,9 @@ bool AnalyzerKey::initialize(TrackPointer tio, int sampleRate, int totalSamples)
 bool AnalyzerKey::shouldAnalyze(TrackPointer tio) const {
     bool bPreferencesFastAnalysisEnabled = m_keySettings.getFastAnalysis();
     QString pluginID = m_keySettings.getKeyPluginId();
+    if (pluginID.isEmpty()) {
+        pluginID = defaultPlugin().id;
+    }
 
     const Keys keys(tio->getKeys());
     if (keys.isValid()) {

--- a/src/analyzer/analyzerkey.h
+++ b/src/analyzer/analyzerkey.h
@@ -18,6 +18,7 @@ class AnalyzerKey : public Analyzer {
     ~AnalyzerKey() override = default;
 
     static QList<mixxx::AnalyzerPluginInfo> availablePlugins();
+    static mixxx::AnalyzerPluginInfo defaultPlugin();
 
     bool initialize(TrackPointer tio, int sampleRate, int totalSamples) override;
     bool processSamples(const CSAMPLE *pIn, const int iLen) override;


### PR DESCRIPTION
Found while analyzing #2773.

Ideally the settings should **never** return an empty value, but I won't fix this.