### PR TITLE
Rekordbox save all loops and correct AAC timing offset for CoreAudio

### DIFF
--- a/src/library/rekordbox/rekordbox_anlz.cpp
+++ b/src/library/rekordbox/rekordbox_anlz.cpp
@@ -165,7 +165,7 @@ rekordbox_anlz_t::song_structure_tag_t::song_structure_tag_t(kaitai::kstream* p_
 void rekordbox_anlz_t::song_structure_tag_t::_read() {
     m_len_entry_bytes = m__io->read_u4be();
     m_len_entries = m__io->read_u2be();
-    m_style = static_cast<rekordbox_anlz_t::phrase_style_t>(m__io->read_u2be());
+    m_style = m__io->read_u2be();
     m__unnamed3 = m__io->read_bytes(6);
     m_end_beat = m__io->read_u2be();
     m__unnamed5 = m__io->read_bytes(4);
@@ -199,7 +199,8 @@ void rekordbox_anlz_t::cue_extended_entry_t::_read() {
     m__unnamed5 = m__io->read_bytes(3);
     m_time = m__io->read_u4be();
     m_loop_time = m__io->read_u4be();
-    m__unnamed8 = m__io->read_bytes(12);
+    m_color_id = m__io->read_u1();
+    m__unnamed9 = m__io->read_bytes(11);
     n_len_comment = true;
     if (len_entry() > 43) {
         n_len_comment = false;
@@ -230,10 +231,10 @@ void rekordbox_anlz_t::cue_extended_entry_t::_read() {
         n_color_blue = false;
         m_color_blue = m__io->read_u1();
     }
-    n__unnamed15 = true;
+    n__unnamed16 = true;
     if ((len_entry() - len_comment()) > 48) {
-        n__unnamed15 = false;
-        m__unnamed15 = m__io->read_bytes(((len_entry() - 48) - len_comment()));
+        n__unnamed16 = false;
+        m__unnamed16 = m__io->read_bytes(((len_entry() - 48) - len_comment()));
     }
 }
 
@@ -250,7 +251,7 @@ rekordbox_anlz_t::cue_extended_entry_t::~cue_extended_entry_t() {
     }
     if (!n_color_blue) {
     }
-    if (!n__unnamed15) {
+    if (!n__unnamed16) {
     }
 }
 
@@ -284,11 +285,11 @@ void rekordbox_anlz_t::song_structure_entry_t::_read() {
     m_phrase_number = m__io->read_u2be();
     m_beat_number = m__io->read_u2be();
     switch (_parent()->style()) {
-    case PHRASE_STYLE_UP_DOWN: {
+    case 1: {
         m_phrase_id = new phrase_up_down_t(m__io, this, m__root);
         break;
     }
-    case PHRASE_STYLE_VERSE_BRIDGE: {
+    case 2: {
         m_phrase_id = new phrase_verse_bridge_t(m__io, this, m__root);
         break;
     }

--- a/src/library/rekordbox/rekordbox_anlz.h
+++ b/src/library/rekordbox/rekordbox_anlz.h
@@ -395,7 +395,7 @@ public:
     private:
         uint32_t m_len_entry_bytes;
         uint16_t m_len_entries;
-        phrase_style_t m_style;
+        uint16_t m_style;
         std::string m__unnamed3;
         uint16_t m_end_beat;
         std::string m__unnamed5;
@@ -424,7 +424,7 @@ public:
          * bridge-verse style except verses 1-3 are labeled VERSE1 and verses
          * 4-6 are labeled VERSE2 in rekordbox.
          */
-        phrase_style_t style() const { return m_style; }
+        uint16_t style() const { return m_style; }
         std::string _unnamed3() const { return m__unnamed3; }
 
         /**
@@ -465,7 +465,8 @@ public:
         std::string m__unnamed5;
         uint32_t m_time;
         uint32_t m_loop_time;
-        std::string m__unnamed8;
+        uint8_t m_color_id;
+        std::string m__unnamed9;
         uint32_t m_len_comment;
         bool n_len_comment;
 
@@ -508,11 +509,11 @@ public:
         bool _is_null_color_blue() { color_blue(); return n_color_blue; };
 
     private:
-        std::string m__unnamed15;
-        bool n__unnamed15;
+        std::string m__unnamed16;
+        bool n__unnamed16;
 
     public:
-        bool _is_null__unnamed15() { _unnamed15(); return n__unnamed15; };
+        bool _is_null__unnamed16() { _unnamed16(); return n__unnamed16; };
 
     private:
         rekordbox_anlz_t* m__root;
@@ -546,7 +547,13 @@ public:
          * back to the cue time if this is a loop.
          */
         uint32_t loop_time() const { return m_loop_time; }
-        std::string _unnamed8() const { return m__unnamed8; }
+
+        /**
+         * References a row in the colors table if the memory cue or loop
+         * has been assigned a color
+         */
+        uint8_t color_id() const { return m_color_id; }
+        std::string _unnamed9() const { return m__unnamed9; }
         uint32_t len_comment() const { return m_len_comment; }
 
         /**
@@ -573,7 +580,7 @@ public:
          * The blue component of the color to be displayed.
          */
         uint8_t color_blue() const { return m_color_blue; }
-        std::string _unnamed15() const { return m__unnamed15; }
+        std::string _unnamed16() const { return m__unnamed16; }
         rekordbox_anlz_t* _root() const { return m__root; }
         rekordbox_anlz_t::cue_extended_tag_t* _parent() const { return m__parent; }
     };

--- a/src/library/rekordbox/rekordbox_anlz.ksy
+++ b/src/library/rekordbox/rekordbox_anlz.ksy
@@ -244,7 +244,12 @@ types:
         doc: |
           The position, in milliseconds, at which the player loops
           back to the cue time if this is a loop.
-      - size: 12  # Loops seem to have some non-zero values in the last four bytes of this.
+      - id: color_id
+        type: u1
+        doc: |
+          Color ID of memory cues and loops, same color IDs as track colors
+      - size: 11  # Loops seem to have some non-zero values in the last four bytes of this.
+#      - size: 12  # Loops seem to have some non-zero values in the last four bytes of this.
       - id: len_comment
         type: u4
         if: len_entry > 43

--- a/src/library/rekordbox/rekordbox_anlz.ksy
+++ b/src/library/rekordbox/rekordbox_anlz.ksy
@@ -249,7 +249,6 @@ types:
         doc: |
           Color ID of memory cues and loops, same color IDs as track colors
       - size: 11  # Loops seem to have some non-zero values in the last four bytes of this.
-#      - size: 12  # Loops seem to have some non-zero values in the last four bytes of this.
       - id: len_comment
         type: u4
         if: len_entry > 43

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -1114,9 +1114,15 @@ TrackPointer RekordboxPlaylistModel::getTrack(const QModelIndex& index) const {
     double sampleRate = static_cast<double>(track->getSampleRate());
 
     QString anlzPath = index.sibling(index.row(), fieldIndex("analyze_path")).data().toString();
-    readAnalyze(track, sampleRate, timingOffset, true, anlzPath);
     QString anlzPathExt = anlzPath.left(anlzPath.length() - 3) + "EXT";
-    readAnalyze(track, sampleRate, timingOffset, false, anlzPathExt);
+
+    if (QFile(anlzPathExt).exists()) {
+        // Beatgrids appear to be only correct in legacy ANLZ file
+        readAnalyze(track, sampleRate, timingOffset, true, anlzPath);
+        readAnalyze(track, sampleRate, timingOffset, false, anlzPathExt);
+    } else {
+        readAnalyze(track, sampleRate, timingOffset, false, anlzPath);
+    }
 
     // Assume that the key of the file the has been analyzed in Recordbox is correct
     // and prevent the AnalyzerKey from re-analyzing.

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -991,7 +991,7 @@ void readAnalyze(TrackPointer track, double sampleRate, int timingOffset, bool i
             } else {
                 // Mixxx v2.4 will feature multiple loops, so these saved here will be usable
                 // For 2.3, Mixxx treats them as hotcues and the first one will be loaded as the single loop Mixxx supports
-		lastHotCueIndex++;
+                lastHotCueIndex++;
                 setHotCue(track, memoryCueOrLoop.startPosition, memoryCueOrLoop.endPosition, lastHotCueIndex, memoryCueOrLoop.comment, memoryCueOrLoop.color);
             }
         }

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -67,6 +67,7 @@ constexpr mixxx::RgbColor kTrackColorGreen(0x1EE000);
 constexpr mixxx::RgbColor kTrackColorAqua(0x16C0F8);
 constexpr mixxx::RgbColor kTrackColorBlue(0x0150F8);
 constexpr mixxx::RgbColor kTrackColorPurple(0x9808F8);
+constexpr mixxx::RgbColor kTrackNoColor(0x0);
 
 struct memory_cue_t {
     double position;
@@ -321,6 +322,28 @@ int createDevicePlaylist(QSqlDatabase& database, QString devicePath) {
     return playlistID;
 }
 
+mixxx::RgbColor colorFromID(int colorID) {
+    switch (static_cast<TrackColor>(colorID)) {
+    case TrackColor::Pink:
+        return kTrackColorPink;
+    case TrackColor::Red:
+        return kTrackColorRed;
+    case TrackColor::Orange:
+        return kTrackColorOrange;
+    case TrackColor::Yellow:
+        return kTrackColorYellow;
+    case TrackColor::Green:
+        return kTrackColorGreen;
+    case TrackColor::Aqua:
+        return kTrackColorAqua;
+    case TrackColor::Blue:
+        return kTrackColorBlue;
+    case TrackColor::Purple:
+        return kTrackColorPurple;
+    }
+    return kTrackNoColor;
+}
+
 void insertTrack(
         QSqlDatabase& database,
         rekordbox_pdb_t::track_row_t* track,
@@ -348,36 +371,6 @@ void insertTrack(
     QString comment = getText(track->comment());
     QString tracknumber = QString::number(track->track_number());
     QString anlzPath = devicePath + getText(track->analyze_path());
-    mixxx::RgbColor::optional_t color = mixxx::RgbColor::nullopt();
-
-    switch (static_cast<TrackColor>(track->color_id())) {
-    case TrackColor::Pink:
-        color = kTrackColorPink;
-        break;
-    case TrackColor::Red:
-        color = kTrackColorRed;
-        break;
-    case TrackColor::Orange:
-        color = kTrackColorOrange;
-        break;
-    case TrackColor::Yellow:
-        color = kTrackColorYellow;
-        break;
-    case TrackColor::Green:
-        color = kTrackColorGreen;
-        break;
-    case TrackColor::Aqua:
-        color = kTrackColorAqua;
-        break;
-    case TrackColor::Blue:
-        color = kTrackColorBlue;
-        break;
-    case TrackColor::Purple:
-        color = kTrackColorPurple;
-        break;
-    default:
-        break;
-    }
 
     query.bindValue(":rb_id", rbID);
     query.bindValue(":artist", artist);
@@ -395,7 +388,7 @@ void insertTrack(
     query.bindValue(":bitrate", bitrate);
     query.bindValue(":analyze_path", anlzPath);
     query.bindValue(":device", device);
-    query.bindValue(":color", mixxx::RgbColor::toQVariant(color));
+    query.bindValue(":color", mixxx::RgbColor::toQVariant(colorFromID(static_cast<int>(track->color_id()))));
 
     if (!query.exec()) {
         LOG_FAILED_QUERY(query);

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -1119,6 +1119,12 @@ TrackPointer RekordboxPlaylistModel::getTrack(const QModelIndex& index) const {
         }
     }
 
+#ifdef __COREAUDIO__
+    if (location.toLower().endsWith(".m4a")) {
+        timingOffset = 48;
+    }
+#endif
+
     double sampleRate = static_cast<double>(track->getSampleRate());
 
     QString anlzPath = index.sibling(index.row(), fieldIndex("analyze_path")).data().toString();

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -806,9 +806,9 @@ void setHotCue(TrackPointer track, double startPosition, double endPosition, int
 
     pCue->setStartPosition(startPosition);
     if (endPosition == Cue::kNoPosition) {
-    	pCue->setType(mixxx::CueType::HotCue);
+        pCue->setType(mixxx::CueType::HotCue);
     } else {
-    	pCue->setType(mixxx::CueType::Loop);
+        pCue->setType(mixxx::CueType::Loop);
         pCue->setEndPosition(endPosition);
     }
     pCue->setHotCue(id);


### PR DESCRIPTION
Save all Rekordbox loops as hotcues, as requested here: https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/Rekordbox.20loop.20numbers/near/196713410

In implementing this found memory cue and loop colors were incorrect, which is now fixed.

Also added correct timing offset for AAC files when using CoreAudio sound source (no offset required for FAAD2 or FFmpeg).