### PR TITLE
Cue context menu for scrolling waveform

### DIFF
--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -104,3 +104,19 @@ void WaveformMark::setBaseColor(QColor baseColor) {
     m_borderColor = Color::chooseContrastColor(baseColor);
     m_labelColor = Color::chooseColorByBrightness(baseColor, QColor(255,255,255,255), QColor(0,0,0,255));
 };
+
+bool WaveformMark::contains(QPoint point, Qt::Orientation orientation) {
+    // Without some padding, the user would only have a single pixel width that
+    // would count as hovering over the WaveformMark.
+    float lineHoverPadding = 5.0;
+    int position;
+    if (orientation == Qt::Horizontal) {
+        position = point.x();
+    } else {
+        position = point.y();
+    }
+    bool lineHovered = m_linePosition >= position - lineHoverPadding &&
+            m_linePosition <= position + lineHoverPadding;
+
+    return (m_label.area().contains(point) || lineHovered);
+}

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -105,7 +105,7 @@ void WaveformMark::setBaseColor(QColor baseColor) {
     m_labelColor = Color::chooseColorByBrightness(baseColor, QColor(255,255,255,255), QColor(0,0,0,255));
 };
 
-bool WaveformMark::contains(QPoint point, Qt::Orientation orientation) {
+bool WaveformMark::contains(QPoint point, Qt::Orientation orientation) const {
     // Without some padding, the user would only have a single pixel width that
     // would count as hovering over the WaveformMark.
     float lineHoverPadding = 5.0;
@@ -118,5 +118,5 @@ bool WaveformMark::contains(QPoint point, Qt::Orientation orientation) {
     bool lineHovered = m_linePosition >= position - lineHoverPadding &&
             m_linePosition <= position + lineHoverPadding;
 
-    return (m_label.area().contains(point) || lineHovered);
+    return m_label.area().contains(point) || lineHovered;
 }

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -99,6 +99,7 @@ WaveformMark::WaveformMark(const QString& group,
 }
 
 void WaveformMark::setBaseColor(QColor baseColor) {
+    m_image = QImage();
     m_fillColor = baseColor;
     m_borderColor = Color::chooseContrastColor(baseColor);
     m_labelColor = Color::chooseColorByBrightness(baseColor, QColor(255,255,255,255), QColor(0,0,0,255));

--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -66,6 +66,9 @@ class WaveformMark {
         return m_labelColor;
     }
 
+    // Check if a point (in image co-ordinates) lies on drawn image.
+    bool contains(QPoint point, Qt::Orientation orientation);
+
     QColor m_textColor;
     QString m_text;
     Qt::Alignment m_align;

--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -67,7 +67,7 @@ class WaveformMark {
     }
 
     // Check if a point (in image co-ordinates) lies on drawn image.
-    bool contains(QPoint point, Qt::Orientation orientation);
+    bool contains(QPoint point, Qt::Orientation orientation) const;
 
     QColor m_textColor;
     QString m_text;

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -226,10 +226,7 @@ void WaveformRenderMark::generateMarkImage(WaveformMarkPointer pMark) {
         labelRect.moveBottom(height - 1);
     }
 
-    pMark->m_label.setAreaRect(QRectF(labelRect.left(),
-            labelRect.top(),
-            labelRectWidth,
-            labelRectHeight));
+    pMark->m_label.setAreaRect(labelRect);
 
     // Fill with transparent pixels
     pMark->m_image.fill(QColor(0, 0, 0, 0).rgba());

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -60,7 +60,7 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
         if (samplePosition != -1.0) {
             double currentMarkPoint =
                     m_waveformRenderer->transformSamplePositionInRendererWorld(samplePosition);
-            const auto& labelBoundingRect = m_markBoundaries[pMark];
+            const auto& labelBoundingRect = pMark->m_label.area();
             if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
                 // NOTE: vRince I guess image width is odd to display the center on the exact line !
                 // external image should respect that ...
@@ -235,8 +235,10 @@ void WaveformRenderMark::generateMarkImage(WaveformMarkPointer pMark) {
         labelRect.moveBottom(height - 1);
     }
 
-    m_markBoundaries[pMark].setRect(
-            labelRect.left(), labelRect.top(), labelRectWidth, labelRectHeight);
+    pMark->m_label.setAreaRect(QRectF(labelRect.left(),
+            labelRect.top(),
+            labelRectWidth,
+            labelRectHeight));
 
     // Fill with transparent pixels
     pMark->m_image.fill(QColor(0, 0, 0, 0).rgba());

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -31,7 +31,7 @@ void WaveformRenderMark::setup(const QDomNode& node, const SkinContext& context)
 
 void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
     PainterScope PainterScope(painter);
-    // Maps mark image offset to mark object.
+    // Maps mark objects to their positions in the widget.
     QMap<WaveformMarkPointer, int> marksOnScreen;
     /*
     //DEBUG
@@ -67,7 +67,7 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
                 const int markHalfWidth = pMark->m_image.width() / 2.0
                         / m_waveformRenderer->getDevicePixelRatio();
 
-                // Check if the current point need to be displayed
+                // Check if the current point needs to be displayed.
                 if (currentMarkPoint > -markHalfWidth && currentMarkPoint < m_waveformRenderer->getWidth() + markHalfWidth) {
                     int drawOffset = currentMarkPoint - markHalfWidth;
                     painter->drawImage(QPoint(drawOffset, 0), pMark->m_image);
@@ -85,7 +85,7 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
             }
         }
     }
-    m_waveformRenderer->setMarkLabelBoundaries(marksOnScreen);
+    m_waveformRenderer->setMarkPositions(marksOnScreen);
 }
 
 void WaveformRenderMark::onResize() {

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -31,7 +31,8 @@ void WaveformRenderMark::setup(const QDomNode& node, const SkinContext& context)
 
 void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
     PainterScope PainterScope(painter);
-    QMap<WaveformMarkPointer, QRect> marksOnScreen;
+    // Maps mark image offset to mark object.
+    QMap<WaveformMarkPointer, int> marksOnScreen;
     /*
     //DEBUG
     for (int i = 0; i < m_markPoints.size(); i++) {
@@ -60,7 +61,6 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
         if (samplePosition != -1.0) {
             double currentMarkPoint =
                     m_waveformRenderer->transformSamplePositionInRendererWorld(samplePosition);
-            const auto& labelBoundingRect = pMark->m_label.area();
             if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
                 // NOTE: vRince I guess image width is odd to display the center on the exact line !
                 // external image should respect that ...
@@ -70,12 +70,8 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
                 // Check if the current point need to be displayed
                 if (currentMarkPoint > -markHalfWidth && currentMarkPoint < m_waveformRenderer->getWidth() + markHalfWidth) {
                     int drawOffset = currentMarkPoint - markHalfWidth;
-                    int labelBoundaryStartOffset = drawOffset + labelBoundingRect.left();
                     painter->drawImage(QPoint(drawOffset, 0), pMark->m_image);
-                    marksOnScreen[pMark] = QRect(labelBoundaryStartOffset,
-                            labelBoundingRect.top(),
-                            labelBoundingRect.width(),
-                            labelBoundingRect.height());
+                    marksOnScreen[pMark] = drawOffset;
                 }
             } else {
                 const int markHalfHeight = pMark->m_image.height() / 2.0;
@@ -83,13 +79,8 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
                         currentMarkPoint < m_waveformRenderer->getHeight() +
                                         markHalfHeight) {
                     int drawOffset = currentMarkPoint - markHalfHeight;
-                    int labelBoundaryStartOffset =
-                            drawOffset + labelBoundingRect.top();
                     painter->drawImage(QPoint(0, drawOffset), pMark->m_image);
-                    marksOnScreen[pMark] = QRect(labelBoundingRect.left(),
-                            labelBoundaryStartOffset,
-                            labelBoundingRect.width(),
-                            labelBoundingRect.height());
+                    marksOnScreen[pMark] = drawOffset;
                 }
             }
         }
@@ -251,6 +242,7 @@ void WaveformRenderMark::generateMarkImage(WaveformMarkPointer pMark) {
     // Draw marker lines
     if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
         int middle = width / 2;
+        pMark->m_linePosition = middle;
         if (markAlignH == Qt::AlignHCenter) {
             if (labelRect.top() > 0) {
                 painter.setPen(pMark->fillColor());
@@ -279,6 +271,7 @@ void WaveformRenderMark::generateMarkImage(WaveformMarkPointer pMark) {
         }
     } else { // Vertical
         int middle = height / 2;
+        pMark->m_linePosition = middle;
         if (markAlignV == Qt::AlignVCenter) {
             if (labelRect.left() > 0) {
                 painter.setPen(pMark->fillColor());

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -69,7 +69,10 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
 
                 // Check if the current point need to be displayed
                 if (currentMarkPoint > -markHalfWidth && currentMarkPoint < m_waveformRenderer->getWidth() + markHalfWidth) {
-                    painter->drawImage(QPoint(currentMarkPoint - markHalfWidth, 0), pMark->m_image);
+                    int drawOffset = currentMarkPoint - markHalfWidth;
+                    const auto topLeft = QPoint(drawOffset, 0);
+                    painter->drawImage(topLeft, pMark->m_image);
+                    m_markBoundaries[pMark].setTopLeft(topLeft);
                 }
             } else {
                 const int markHalfHeight = pMark->m_image.height() / 2.0;
@@ -80,6 +83,7 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
             }
         }
     }
+    m_waveformRenderer->setMarkLabelBoundaries(m_markBoundaries);
 }
 
 void WaveformRenderMark::onResize() {
@@ -185,6 +189,8 @@ void WaveformRenderMark::generateMarkImage(WaveformMarkPointer pMark) {
     int labelRectHeight = wordRect.height() + 2 * marginY + 4;
 
     QRectF labelRect(0, 0, (float)labelRectWidth, (float)labelRectHeight);
+    m_markBoundaries[pMark].setWidth(labelRectWidth);
+    m_markBoundaries[pMark].setHeight(labelRectHeight);
 
     int width;
     int height;

--- a/src/waveform/renderers/waveformrendermark.h
+++ b/src/waveform/renderers/waveformrendermark.h
@@ -36,7 +36,6 @@ class WaveformRenderMark : public QObject, public WaveformRendererAbstract {
     void generateMarkImage(WaveformMarkPointer pMark);
 
     WaveformMarkSet m_marks;
-    QMap<WaveformMarkPointer, QRect> m_markBoundaries;
     DISALLOW_COPY_AND_ASSIGN(WaveformRenderMark);
 };
 

--- a/src/waveform/renderers/waveformrendermark.h
+++ b/src/waveform/renderers/waveformrendermark.h
@@ -36,6 +36,7 @@ class WaveformRenderMark : public QObject, public WaveformRendererAbstract {
     void generateMarkImage(WaveformMarkPointer pMark);
 
     WaveformMarkSet m_marks;
+    QMap<WaveformMarkPointer, QRect> m_markBoundaries;
     DISALLOW_COPY_AND_ASSIGN(WaveformRenderMark);
 };
 

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -289,7 +289,7 @@ void WaveformWidgetRenderer::setTrack(TrackPointer track) {
     }
 }
 
-std::optional<CuePointer> WaveformWidgetRenderer::getCueAtPoint(QPoint point) {
+CuePointer WaveformWidgetRenderer::getCueAtPoint(QPoint point) {
     WaveformMarkPointer pSelectedMark;
     const int lineHoverpadding = 5;
     for (const auto& pMark : m_markLabelOffsets.keys()) {
@@ -333,19 +333,14 @@ std::optional<CuePointer> WaveformWidgetRenderer::getCueAtPoint(QPoint point) {
         }
     }
     if (!pSelectedMark) {
-        return std::nullopt;
+        return static_cast<CuePointer>(nullptr);
     }
-    CuePointer pSelectedCue;
+
     QList<CuePointer> cueList = getTrackInfo()->getCuePoints();
     for (const auto& pCue : cueList) {
         if (pCue->getHotCue() == pSelectedMark->getHotCue()) {
-            pSelectedCue = pCue;
-            break;
+            return pCue;
         }
     }
-    if (pSelectedCue != nullptr) {
-        return pSelectedCue;
-    }
-
-    return std::nullopt;
+    return static_cast<CuePointer>(nullptr);
 }

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -289,13 +289,14 @@ void WaveformWidgetRenderer::setTrack(TrackPointer track) {
     }
 }
 
-WaveformMarkPointer WaveformWidgetRenderer::getCueMarkAtPoint(QPoint point) {
+WaveformMarkPointer WaveformWidgetRenderer::getCueMarkAtPoint(QPoint point) const {
     for (const auto& pMark : m_markPositions.keys()) {
         int markImagePositionInWidgetSpace = m_markPositions[pMark];
         QPoint pointInImageSpace;
         if (getOrientation() == Qt::Horizontal) {
             pointInImageSpace = QPoint(point.x() - markImagePositionInWidgetSpace, point.y());
-        } else { /* Vertical */
+        } else {
+            DEBUG_ASSERT(getOrientation() == Qt::Vertical);
             pointInImageSpace = QPoint(point.x(), point.y() - markImagePositionInWidgetSpace);
         }
         if (pMark->contains(pointInImageSpace, getOrientation())) {

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -292,7 +292,8 @@ void WaveformWidgetRenderer::setTrack(TrackPointer track) {
 std::optional<CuePointer> WaveformWidgetRenderer::getCueAtPoint(QPoint point) {
     WaveformMarkPointer pSelectedMark;
     for (auto pMark : m_markBoundaries.keys()) {
-        if (m_markBoundaries[pMark].contains(point)) {
+        const auto labelRectangle = m_markBoundaries[pMark];
+        if (labelRectangle.contains(point)) {
             pSelectedMark = pMark;
             break;
         }

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -290,44 +290,15 @@ void WaveformWidgetRenderer::setTrack(TrackPointer track) {
 }
 
 WaveformMarkPointer WaveformWidgetRenderer::getCueMarkAtPoint(QPoint point) {
-    WaveformMarkPointer pSelectedMark;
-    const int lineHoverpadding = 5;
     for (const auto& pMark : m_markLabelOffsets.keys()) {
-        QRectF labelBoundingRectInMarkImageSpace = pMark->m_label.area();
-        int markImageOffsetInWaveformWidgetSpace = m_markLabelOffsets[pMark];
-        int markLineOffset = markImageOffsetInWaveformWidgetSpace + pMark->m_linePosition;
-        QRect labelRectangleInWaveformWidgetSpace;
-        QRect markLineVicinity;
+        int markImagePositionInWidgetSpace = m_markLabelOffsets[pMark];
+        QPoint pointInImageSpace;
         if (getOrientation() == Qt::Horizontal) {
-            int labelBoundaryStartOffset =
-                    markImageOffsetInWaveformWidgetSpace +
-                    labelBoundingRectInMarkImageSpace.left();
-            labelRectangleInWaveformWidgetSpace =
-                    QRect(labelBoundaryStartOffset,
-                            labelBoundingRectInMarkImageSpace.top(),
-                            labelBoundingRectInMarkImageSpace.width(),
-                            labelBoundingRectInMarkImageSpace.height());
-            markLineVicinity = QRect(markLineOffset - lineHoverpadding,
-                    0,
-                    lineHoverpadding * 2,
-                    getHeight());
+            pointInImageSpace = QPoint(point.x() - markImagePositionInWidgetSpace, point.y());
         } else { /* Vertical */
-            int labelBoundaryStartOffset =
-                    markImageOffsetInWaveformWidgetSpace +
-                    labelBoundingRectInMarkImageSpace.top();
-            labelRectangleInWaveformWidgetSpace =
-                    QRect(labelBoundingRectInMarkImageSpace.left(),
-                            labelBoundaryStartOffset,
-                            labelBoundingRectInMarkImageSpace.width(),
-                            labelBoundingRectInMarkImageSpace.height());
-            markLineVicinity = QRect(0,
-                    markLineOffset - lineHoverpadding,
-                    getWidth(),
-                    lineHoverpadding * 2);
+            pointInImageSpace = QPoint(point.x(), point.y() - markImagePositionInWidgetSpace);
         }
-
-        if (labelRectangleInWaveformWidgetSpace.contains(point) ||
-                markLineVicinity.contains(point)) {
+        if (pMark->contains(pointInImageSpace, getOrientation())) {
             return pMark;
         }
     }

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -288,3 +288,30 @@ void WaveformWidgetRenderer::setTrack(TrackPointer track) {
         m_rendererStack[i]->onSetTrack();
     }
 }
+
+std::optional<CuePointer> WaveformWidgetRenderer::getCueAtPoint(QPoint point) {
+    WaveformMarkPointer pSelectedMark;
+    for (auto pMark : m_markBoundaries.keys()) {
+        if (m_markBoundaries[pMark].contains(point)) {
+            pSelectedMark = pMark;
+            break;
+        }
+    }
+    if (!pSelectedMark) {
+        return std::nullopt;
+    }
+
+    CuePointer pSelectedCue;
+    QList<CuePointer> cueList = getTrackInfo()->getCuePoints();
+    for (const auto& pCue : cueList) {
+        if (pCue->getHotCue() == pSelectedMark->getHotCue()) {
+            pSelectedCue = pCue;
+            break;
+        }
+    }
+    if (pSelectedCue != nullptr) {
+        return pSelectedCue;
+    }
+
+    return std::nullopt;
+}

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -289,7 +289,7 @@ void WaveformWidgetRenderer::setTrack(TrackPointer track) {
     }
 }
 
-CuePointer WaveformWidgetRenderer::getCueAtPoint(QPoint point) {
+WaveformMarkPointer WaveformWidgetRenderer::getCueMarkAtPoint(QPoint point) {
     WaveformMarkPointer pSelectedMark;
     const int lineHoverpadding = 5;
     for (const auto& pMark : m_markLabelOffsets.keys()) {
@@ -328,19 +328,8 @@ CuePointer WaveformWidgetRenderer::getCueAtPoint(QPoint point) {
 
         if (labelRectangleInWaveformWidgetSpace.contains(point) ||
                 markLineVicinity.contains(point)) {
-            pSelectedMark = pMark;
-            break;
+            return pMark;
         }
     }
-    if (!pSelectedMark) {
-        return static_cast<CuePointer>(nullptr);
-    }
-
-    QList<CuePointer> cueList = getTrackInfo()->getCuePoints();
-    for (const auto& pCue : cueList) {
-        if (pCue->getHotCue() == pSelectedMark->getHotCue()) {
-            return pCue;
-        }
-    }
-    return static_cast<CuePointer>(nullptr);
+    return static_cast<WaveformMarkPointer>(nullptr);
 }

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -290,8 +290,8 @@ void WaveformWidgetRenderer::setTrack(TrackPointer track) {
 }
 
 WaveformMarkPointer WaveformWidgetRenderer::getCueMarkAtPoint(QPoint point) {
-    for (const auto& pMark : m_markLabelOffsets.keys()) {
-        int markImagePositionInWidgetSpace = m_markLabelOffsets[pMark];
+    for (const auto& pMark : m_markPositions.keys()) {
+        int markImagePositionInWidgetSpace = m_markPositions[pMark];
         QPoint pointInImageSpace;
         if (getOrientation() == Qt::Horizontal) {
             pointInImageSpace = QPoint(point.x() - markImagePositionInWidgetSpace, point.y());
@@ -302,5 +302,5 @@ WaveformMarkPointer WaveformWidgetRenderer::getCueMarkAtPoint(QPoint point) {
             return pMark;
         }
     }
-    return static_cast<WaveformMarkPointer>(nullptr);
+    return nullptr;
 }

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -96,8 +96,7 @@ class WaveformWidgetRenderer {
     }
 
     void setTrack(TrackPointer track);
-    inline void setMarkLabelBoundaries(
-            QMap<WaveformMarkPointer, int> markLabelOffsets) {
+    void setMarkLabelBoundaries(QMap<WaveformMarkPointer, int> markLabelOffsets) {
         m_markLabelOffsets = markLabelOffsets;
     }
 

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -40,7 +40,7 @@ class WaveformWidgetRenderer {
 
     inline const char* getGroup() const { return m_group;}
     const TrackPointer getTrackInfo() const { return m_pTrack;}
-    // Get cue at a point on the waveform widget.
+    /// Get cue mark at a point on the waveform widget.
     WaveformMarkPointer getCueMarkAtPoint(QPoint point);
 
     double getFirstDisplayedPosition() const { return m_firstDisplayedPosition;}
@@ -96,8 +96,8 @@ class WaveformWidgetRenderer {
     }
 
     void setTrack(TrackPointer track);
-    void setMarkLabelBoundaries(QMap<WaveformMarkPointer, int> markLabelOffsets) {
-        m_markLabelOffsets = markLabelOffsets;
+    void setMarkPositions(QMap<WaveformMarkPointer, int> markPositions) {
+        m_markPositions = markPositions;
     }
 
     double getPlayMarkerPosition() {
@@ -157,7 +157,7 @@ class WaveformWidgetRenderer {
 private:
     DISALLOW_COPY_AND_ASSIGN(WaveformWidgetRenderer);
     friend class WaveformWidgetFactory;
-    QMap<WaveformMarkPointer, int> m_markLabelOffsets;
+    QMap<WaveformMarkPointer, int> m_markPositions;
 };
 
 #endif // WAVEFORMWIDGETRENDERER_H

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -97,8 +97,8 @@ class WaveformWidgetRenderer {
 
     void setTrack(TrackPointer track);
     inline void setMarkLabelBoundaries(
-            const QMap<WaveformMarkPointer, QRect>& markLabelBoundaries) {
-        m_markBoundaries = markLabelBoundaries;
+            QMap<WaveformMarkPointer, int> markLabelOffsets) {
+        m_markLabelOffsets = markLabelOffsets;
     }
 
     double getPlayMarkerPosition() {
@@ -158,7 +158,7 @@ class WaveformWidgetRenderer {
 private:
     DISALLOW_COPY_AND_ASSIGN(WaveformWidgetRenderer);
     friend class WaveformWidgetFactory;
-    QMap<WaveformMarkPointer, QRect> m_markBoundaries;
+    QMap<WaveformMarkPointer, int> m_markLabelOffsets;
 };
 
 #endif // WAVEFORMWIDGETRENDERER_H

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -8,9 +8,10 @@
 
 #include "track/track.h"
 #include "util/class.h"
+#include "util/performancetimer.h"
+#include "waveform/renderers/waveformmark.h"
 #include "waveform/renderers/waveformrendererabstract.h"
 #include "waveform/renderers/waveformsignalcolors.h"
-#include "util/performancetimer.h"
 
 //#define WAVEFORMWIDGETRENDERER_DEBUG
 
@@ -39,6 +40,8 @@ class WaveformWidgetRenderer {
 
     inline const char* getGroup() const { return m_group;}
     const TrackPointer getTrackInfo() const { return m_pTrack;}
+    // Get cue at a point on the waveform widget.
+    std::optional<CuePointer> getCueAtPoint(QPoint point);
 
     double getFirstDisplayedPosition() const { return m_firstDisplayedPosition;}
     double getLastDisplayedPosition() const { return m_lastDisplayedPosition;}
@@ -93,6 +96,10 @@ class WaveformWidgetRenderer {
     }
 
     void setTrack(TrackPointer track);
+    inline void setMarkLabelBoundaries(
+            const QMap<WaveformMarkPointer, QRect>& markLabelBoundaries) {
+        m_markBoundaries = markLabelBoundaries;
+    }
 
     double getPlayMarkerPosition() {
         return m_playMarkerPosition;
@@ -151,6 +158,7 @@ class WaveformWidgetRenderer {
 private:
     DISALLOW_COPY_AND_ASSIGN(WaveformWidgetRenderer);
     friend class WaveformWidgetFactory;
+    QMap<WaveformMarkPointer, QRect> m_markBoundaries;
 };
 
 #endif // WAVEFORMWIDGETRENDERER_H

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -41,7 +41,7 @@ class WaveformWidgetRenderer {
     inline const char* getGroup() const { return m_group;}
     const TrackPointer getTrackInfo() const { return m_pTrack;}
     // Get cue at a point on the waveform widget.
-    CuePointer getCueAtPoint(QPoint point);
+    WaveformMarkPointer getCueMarkAtPoint(QPoint point);
 
     double getFirstDisplayedPosition() const { return m_firstDisplayedPosition;}
     double getLastDisplayedPosition() const { return m_lastDisplayedPosition;}

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -41,7 +41,7 @@ class WaveformWidgetRenderer {
     inline const char* getGroup() const { return m_group;}
     const TrackPointer getTrackInfo() const { return m_pTrack;}
     /// Get cue mark at a point on the waveform widget.
-    WaveformMarkPointer getCueMarkAtPoint(QPoint point);
+    WaveformMarkPointer getCueMarkAtPoint(QPoint point) const;
 
     double getFirstDisplayedPosition() const { return m_firstDisplayedPosition;}
     double getLastDisplayedPosition() const { return m_lastDisplayedPosition;}

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -41,7 +41,7 @@ class WaveformWidgetRenderer {
     inline const char* getGroup() const { return m_group;}
     const TrackPointer getTrackInfo() const { return m_pTrack;}
     // Get cue at a point on the waveform widget.
-    std::optional<CuePointer> getCueAtPoint(QPoint point);
+    CuePointer getCueAtPoint(QPoint point);
 
     double getFirstDisplayedPosition() const { return m_firstDisplayedPosition;}
     double getLastDisplayedPosition() const { return m_lastDisplayedPosition;}

--- a/src/waveform/waveformmarklabel.h
+++ b/src/waveform/waveformmarklabel.h
@@ -27,6 +27,10 @@ class WaveformMarkLabel {
         return m_areaRect;
     };
 
+    inline void setAreaRect(const QRectF& areaRect) {
+        m_areaRect = areaRect;
+    }
+
     bool intersects(const QRectF& other) const {
         return m_areaRect.intersects(other);
     }

--- a/src/waveform/waveformmarklabel.h
+++ b/src/waveform/waveformmarklabel.h
@@ -27,7 +27,7 @@ class WaveformMarkLabel {
         return m_areaRect;
     };
 
-    inline void setAreaRect(const QRectF& areaRect) {
+    void setAreaRect(const QRectF& areaRect) {
         m_areaRect = areaRect;
     }
 

--- a/src/waveform/waveformmarklabel.h
+++ b/src/waveform/waveformmarklabel.h
@@ -27,7 +27,7 @@ class WaveformMarkLabel {
         return m_areaRect;
     };
 
-    void setAreaRect(const QRectF& areaRect) {
+    void setAreaRect(QRectF areaRect) {
         m_areaRect = areaRect;
     }
 

--- a/src/widget/wcuemenupopup.cpp
+++ b/src/widget/wcuemenupopup.cpp
@@ -132,3 +132,8 @@ void WCueMenuPopup::slotDeleteCue() {
     m_pTrack->removeCue(m_pCue);
     hide();
 }
+
+void WCueMenuPopup::closeEvent(QCloseEvent* event) {
+    emit aboutToHide();
+    QWidget::closeEvent(event);
+}

--- a/src/widget/wcuemenupopup.h
+++ b/src/widget/wcuemenupopup.h
@@ -37,11 +37,6 @@ class WCueMenuPopup : public QWidget {
         show();
     }
 
-    void hide() {
-        emit aboutToHide();
-        QWidget::hide();
-    }
-
     void show() {
         setColorPalette(m_colorPaletteSettings.getHotcueColorPalette());
         m_pEditLabel->setFocus();
@@ -59,6 +54,8 @@ class WCueMenuPopup : public QWidget {
     void slotChangeCueColor(mixxx::RgbColor::optional_t color);
 
   private:
+    void closeEvent(QCloseEvent* event) override;
+
     ColorPaletteSettings m_colorPaletteSettings;
     CuePointer m_pCue;
     TrackPointer m_pTrack;

--- a/src/widget/wcuemenupopup.h
+++ b/src/widget/wcuemenupopup.h
@@ -54,8 +54,6 @@ class WCueMenuPopup : public QWidget {
     void slotChangeCueColor(mixxx::RgbColor::optional_t color);
 
   private:
-    void closeEvent(QCloseEvent* event) override;
-
     ColorPaletteSettings m_colorPaletteSettings;
     CuePointer m_pCue;
     TrackPointer m_pTrack;
@@ -65,4 +63,7 @@ class WCueMenuPopup : public QWidget {
     QLineEdit* m_pEditLabel;
     WColorPicker* m_pColorPicker;
     QPushButton* m_pDeleteCue;
+
+  protected:
+    void closeEvent(QCloseEvent* event) override;
 };

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -442,9 +442,7 @@ void WOverview::mouseMoveEvent(QMouseEvent* e) {
     }
 
     m_pHoveredMark.clear();
-    // Without some padding, the user would only have a single pixel width that
-    // would count as hovering over the WaveformMark.
-    float lineHoverPadding = 5.0;
+
     // Non-hotcue marks (intro/outro cues, main cue, loop in/out) are sorted
     // before hotcues in m_marksToRender so if there is a hotcue in the same
     // location, the hotcue gets rendered on top. When right clicking, the
@@ -453,16 +451,7 @@ void WOverview::mouseMoveEvent(QMouseEvent* e) {
     // reverse and the loop breaks as soon as m_pHoveredMark is set.
     for (int i = m_marksToRender.size() - 1; i >= 0; --i) {
         WaveformMarkPointer pMark = m_marksToRender.at(i);
-        int hoveredPosition;
-        if (m_orientation == Qt::Horizontal) {
-            hoveredPosition = e->x();
-        } else {
-            hoveredPosition = e->y();
-        }
-        bool lineHovered =
-                pMark->m_linePosition >= hoveredPosition - lineHoverPadding && pMark->m_linePosition <= hoveredPosition + lineHoverPadding;
-
-        if (pMark->m_label.area().contains(e->pos()) || lineHovered) {
+        if (pMark->contains(e->pos(), m_orientation)) {
             m_pHoveredMark = pMark;
             break;
         }

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -61,7 +61,6 @@ WOverview::WOverview(
           m_iPickupPos(0),
           m_iPlayPos(0),
           m_pHoveredMark(nullptr),
-          m_bHotcueMenuShowing(false),
           m_bTimeRulerActive(false),
           m_orientation(Qt::Horizontal),
           m_iLabelFontSize(10),
@@ -539,21 +538,19 @@ void WOverview::mousePressEvent(QMouseEvent* e) {
             if (pHoveredCue != nullptr) {
                 m_pCueMenuPopup->setTrackAndCue(m_pCurrentTrack, pHoveredCue);
                 m_pCueMenuPopup->popup(e->globalPos());
-                m_bHotcueMenuShowing = true;
             }
         }
     }
 }
 
 void WOverview::slotCueMenuPopupAboutToHide() {
-    m_bHotcueMenuShowing = false;
     m_pHoveredMark.clear();
     update();
 }
 
 void WOverview::leaveEvent(QEvent* pEvent) {
     Q_UNUSED(pEvent);
-    if (!m_bHotcueMenuShowing) {
+    if (!m_pCueMenuPopup->isVisible()) {
         m_pHoveredMark.clear();
     }
     m_bLeftClickDragging = false;

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -307,8 +307,10 @@ void WOverview::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack)
     //qDebug() << this << "WOverview::slotLoadingTrack" << pNewTrack.get() << pOldTrack.get();
     DEBUG_ASSERT(m_pCurrentTrack == pOldTrack);
     if (m_pCurrentTrack != nullptr) {
-        disconnect(m_pCurrentTrack.get(), SIGNAL(waveformSummaryUpdated()),
-                   this, SLOT(slotWaveformSummaryUpdated()));
+        disconnect(m_pCurrentTrack.get(),
+                &Track::waveformSummaryUpdated,
+                this,
+                &WOverview::slotWaveformSummaryUpdated);
     }
 
     m_waveformSourceImage = QImage();
@@ -323,11 +325,12 @@ void WOverview::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack)
         m_pCurrentTrack = pNewTrack;
         m_pWaveform = pNewTrack->getWaveformSummary();
 
-        connect(pNewTrack.get(), SIGNAL(waveformSummaryUpdated()),
-                this, SLOT(slotWaveformSummaryUpdated()));
+        connect(pNewTrack.get(),
+                &Track::waveformSummaryUpdated,
+                this,
+                &WOverview::slotWaveformSummaryUpdated);
         slotWaveformSummaryUpdated();
-        connect(pNewTrack.get(), SIGNAL(cuesUpdated()),
-                this, SLOT(receiveCuesUpdated()));
+        connect(pNewTrack.get(), &Track::cuesUpdated, this, &WOverview::receiveCuesUpdated);
     } else {
         m_pCurrentTrack.reset();
         m_pWaveform.clear();

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -156,7 +156,6 @@ class WOverview : public WWidget, public TrackDropTarget {
     int m_iPlayPos;
 
     WaveformMarkPointer m_pHoveredMark;
-    bool m_bHotcueMenuShowing;
     bool m_bTimeRulerActive;
     QPointF m_timeRulerPos;
     WaveformMarkLabel m_timeRulerPositionLabel;

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -109,7 +109,6 @@ void WWaveformViewer::mousePressEvent(QMouseEvent* event) {
 }
 
 void WWaveformViewer::mouseMoveEvent(QMouseEvent* event) {
-    qWarning() << event;
     if (!m_waveformWidget) {
         return;
     }

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -23,7 +23,6 @@ WWaveformViewer::WWaveformViewer(const char* group, UserSettingsPointer pConfig,
           m_zoomZoneWidth(20),
           m_bScratching(false),
           m_bBending(false),
-          m_bHotcueMenuShowing(false),
           m_pCueMenuPopup(make_parented<WCueMenuPopup>(pConfig, this)),
           m_waveformWidget(nullptr) {
     setMouseTracking(true);
@@ -39,10 +38,6 @@ WWaveformViewer::WWaveformViewer(const char* group, UserSettingsPointer pConfig,
     m_pWheel = new ControlProxy(
             group, "wheel", this);
 
-    connect(m_pCueMenuPopup.get(),
-            &WCueMenuPopup::aboutToHide,
-            this,
-            &WWaveformViewer::slotCueMenuPopupAboutToHide);
     setAttribute(Qt::WA_OpaquePaintEvent);
 }
 
@@ -89,7 +84,6 @@ void WWaveformViewer::mousePressEvent(QMouseEvent* event) {
         if (cueAtClickPos) {
             m_pCueMenuPopup->setTrackAndCue(currentTrack, cueAtClickPos);
             m_pCueMenuPopup->popup(event->globalPos());
-            m_bHotcueMenuShowing = true;
         } else {
             // If we are scratching then disable and reset because the two shouldn't
             // be used at once.
@@ -102,8 +96,8 @@ void WWaveformViewer::mousePressEvent(QMouseEvent* event) {
         }
     }
 
-    // Set the cursor to a hand while the mouse is down.
-    if (!m_bHotcueMenuShowing) {
+    // Set the cursor to a hand while the mouse is down (when cue menu is not open).
+    if (!m_pCueMenuPopup->isVisible()) {
         setCursor(Qt::ClosedHandCursor);
     }
 }
@@ -235,8 +229,4 @@ void WWaveformViewer::setWaveformWidget(WaveformWidgetAbstract* waveformWidget) 
                 this, SLOT(slotWidgetDead()));
         m_waveformWidget->getWidget()->setMouseTracking(true);
     }
-}
-
-void WWaveformViewer::slotCueMenuPopupAboutToHide() {
-    m_bHotcueMenuShowing = false;
 }

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -26,6 +26,7 @@ WWaveformViewer::WWaveformViewer(const char* group, UserSettingsPointer pConfig,
           m_bHotcueMenuShowing(false),
           m_pCueMenuPopup(make_parented<WCueMenuPopup>(pConfig, this)),
           m_waveformWidget(nullptr) {
+    setMouseTracking(true);
     setAcceptDrops(true);
 
     m_pZoom = new ControlProxy(group, "waveform_zoom", this);
@@ -107,6 +108,7 @@ void WWaveformViewer::mousePressEvent(QMouseEvent* event) {
 }
 
 void WWaveformViewer::mouseMoveEvent(QMouseEvent* event) {
+    qWarning() << event;
     if (!m_waveformWidget) {
         return;
     }
@@ -231,6 +233,7 @@ void WWaveformViewer::setWaveformWidget(WaveformWidgetAbstract* waveformWidget) 
         QWidget* pWidget = m_waveformWidget->getWidget();
         connect(pWidget, SIGNAL(destroyed()),
                 this, SLOT(slotWidgetDead()));
+        m_waveformWidget->getWidget()->setMouseTracking(true);
     }
 }
 

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -90,15 +90,16 @@ void WWaveformViewer::mousePressEvent(QMouseEvent* event) {
             m_pCueMenuPopup->setTrackAndCue(currentTrack, *cueAtClickPos);
             m_pCueMenuPopup->popup(event->globalPos());
             m_bHotcueMenuShowing = true;
+        } else {
+            // If we are scratching then disable and reset because the two shouldn't
+            // be used at once.
+            if (m_bScratching) {
+                m_pScratchPositionEnable->slotSet(0.0);
+                m_bScratching = false;
+            }
+            m_pWheel->setParameter(0.5);
+            m_bBending = true;
         }
-        // If we are scratching then disable and reset because the two shouldn't
-        // be used at once.
-        if (m_bScratching) {
-            m_pScratchPositionEnable->slotSet(0.0);
-            m_bScratching = false;
-        }
-        m_pWheel->setParameter(0.5);
-        m_bBending = true;
     }
 
     // Set the cursor to a hand while the mouse is down.

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -1,4 +1,3 @@
-
 #include <QtDebug>
 #include <QDomNode>
 #include <QEvent>

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -255,7 +255,7 @@ void WWaveformViewer::setWaveformWidget(WaveformWidgetAbstract* waveformWidget) 
     }
 }
 
-CuePointer WWaveformViewer::getCuePointerFromCueMark(WaveformMarkPointer pMark) {
+CuePointer WWaveformViewer::getCuePointerFromCueMark(WaveformMarkPointer pMark) const {
     if (pMark && pMark->getHotCue() != Cue::kNoHotCue) {
         QList<CuePointer> cueList = m_waveformWidget->getTrackInfo()->getCuePoints();
         for (const auto& pCue : cueList) {
@@ -277,6 +277,6 @@ void WWaveformViewer::unhighlightMark(WaveformMarkPointer pMark) {
     pMark->setBaseColor(originalColor);
 }
 
-bool WWaveformViewer::isPlaying() {
+bool WWaveformViewer::isPlaying() const {
     return m_pPlayEnabled->get();
 }

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -16,13 +16,14 @@
 #include "util/dnd.h"
 #include "util/math.h"
 
-WWaveformViewer::WWaveformViewer(const char *group, UserSettingsPointer pConfig, QWidget * parent)
+WWaveformViewer::WWaveformViewer(const char* group, UserSettingsPointer pConfig, QWidget* parent)
         : WWidget(parent),
           m_pGroup(group),
           m_pConfig(pConfig),
           m_zoomZoneWidth(20),
           m_bScratching(false),
           m_bBending(false),
+          m_pCueMenuPopup(make_parented<WCueMenuPopup>(pConfig, this)),
           m_waveformWidget(nullptr) {
     setAcceptDrops(true);
 
@@ -77,6 +78,12 @@ void WWaveformViewer::mousePressEvent(QMouseEvent* event) {
         m_pScratchPosition->set(targetPosition);
         m_pScratchPositionEnable->slotSet(1.0);
     } else if (event->button() == Qt::RightButton) {
+        const auto currentTrack = m_waveformWidget->getTrackInfo();
+        auto cueAtClickPos = m_waveformWidget->getCueAtPoint(event->pos());
+        if (cueAtClickPos) {
+            m_pCueMenuPopup->setTrackAndCue(currentTrack, *cueAtClickPos);
+            m_pCueMenuPopup->popup(event->globalPos());
+        }
         // If we are scratching then disable and reset because the two shouldn't
         // be used at once.
         if (m_bScratching) {

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -87,7 +87,7 @@ void WWaveformViewer::mousePressEvent(QMouseEvent* event) {
         const auto currentTrack = m_waveformWidget->getTrackInfo();
         auto cueAtClickPos = m_waveformWidget->getCueAtPoint(m_mouseAnchor);
         if (cueAtClickPos) {
-            m_pCueMenuPopup->setTrackAndCue(currentTrack, *cueAtClickPos);
+            m_pCueMenuPopup->setTrackAndCue(currentTrack, cueAtClickPos);
             m_pCueMenuPopup->popup(event->globalPos());
             m_bHotcueMenuShowing = true;
         } else {

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -265,7 +265,7 @@ CuePointer WWaveformViewer::getCuePointerFromCueMark(WaveformMarkPointer pMark) 
             }
         }
     }
-    return static_cast<CuePointer>(nullptr);
+    return CuePointer();
 }
 
 void WWaveformViewer::highlightMark(WaveformMarkPointer pMark) {

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -136,7 +136,7 @@ void WWaveformViewer::mouseMoveEvent(QMouseEvent* event) {
     } else if (!isPlaying()) {
         WaveformMarkPointer pMark;
         pMark = m_waveformWidget->getCueMarkAtPoint(event->pos());
-        if (pMark) {
+        if (pMark && getCuePointerFromCueMark(pMark)) {
             if (!m_pHoveredMark) {
                 m_pHoveredMark = pMark;
                 highlightMark(pMark);
@@ -257,7 +257,7 @@ void WWaveformViewer::setWaveformWidget(WaveformWidgetAbstract* waveformWidget) 
 }
 
 CuePointer WWaveformViewer::getCuePointerFromCueMark(WaveformMarkPointer pMark) {
-    if (pMark) {
+    if (pMark && pMark->getHotCue() != Cue::kNoHotCue) {
         QList<CuePointer> cueList = m_waveformWidget->getTrackInfo()->getCuePoints();
         for (const auto& pCue : cueList) {
             if (pCue->getHotCue() == pMark->getHotCue()) {

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -246,14 +246,12 @@ void WWaveformViewer::setPlayMarkerPosition(double position) {
 void WWaveformViewer::setWaveformWidget(WaveformWidgetAbstract* waveformWidget) {
     if (m_waveformWidget) {
         QWidget* pWidget = m_waveformWidget->getWidget();
-        disconnect(pWidget, SIGNAL(destroyed()),
-                   this, SLOT(slotWidgetDead()));
+        disconnect(pWidget, &QWidget::destroyed, this, &WWaveformViewer::slotWidgetDead);
     }
     m_waveformWidget = waveformWidget;
     if (m_waveformWidget) {
         QWidget* pWidget = m_waveformWidget->getWidget();
-        connect(pWidget, SIGNAL(destroyed()),
-                this, SLOT(slotWidgetDead()));
+        connect(pWidget, &QWidget::destroyed, this, &WWaveformViewer::slotWidgetDead);
         m_waveformWidget->getWidget()->setMouseTracking(true);
     }
 }

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -8,10 +8,12 @@
 #include <QList>
 #include <QMutex>
 
-#include "track/track.h"
-#include "widget/trackdroptarget.h"
-#include "widget/wwidget.h"
 #include "skin/skincontext.h"
+#include "track/track.h"
+#include "util/parented_ptr.h"
+#include "widget/trackdroptarget.h"
+#include "widget/wcuemenupopup.h"
+#include "widget/wwidget.h"
 
 class ControlProxy;
 class WaveformWidgetAbstract;
@@ -72,6 +74,7 @@ private:
     bool m_bScratching;
     bool m_bBending;
     QPoint m_mouseAnchor;
+    parented_ptr<WCueMenuPopup> m_pCueMenuPopup;
 
     WaveformWidgetAbstract* m_waveformWidget;
 

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -52,7 +52,6 @@ private slots:
     void slotWidgetDead() {
         m_waveformWidget = nullptr;
     }
-    void slotCueMenuPopupAboutToHide();
 
   private:
     void setWaveformWidget(WaveformWidgetAbstract* waveformWidget);
@@ -74,7 +73,6 @@ private:
     ControlProxy* m_pWheel;
     bool m_bScratching;
     bool m_bBending;
-    bool m_bHotcueMenuShowing;
     QPoint m_mouseAnchor;
     parented_ptr<WCueMenuPopup> m_pCueMenuPopup;
 

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -11,6 +11,7 @@
 #include "skin/skincontext.h"
 #include "track/track.h"
 #include "util/parented_ptr.h"
+#include "waveform/renderers/waveformmark.h"
 #include "widget/trackdroptarget.h"
 #include "widget/wcuemenupopup.h"
 #include "widget/wwidget.h"

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -52,8 +52,9 @@ private slots:
     void slotWidgetDead() {
         m_waveformWidget = nullptr;
     }
+    void slotCueMenuPopupAboutToHide();
 
-private:
+  private:
     void setWaveformWidget(WaveformWidgetAbstract* waveformWidget);
     WaveformWidgetAbstract* getWaveformWidget() {
         return m_waveformWidget;
@@ -73,6 +74,7 @@ private:
     ControlProxy* m_pWheel;
     bool m_bScratching;
     bool m_bBending;
+    bool m_bHotcueMenuShowing;
     QPoint m_mouseAnchor;
     parented_ptr<WCueMenuPopup> m_pCueMenuPopup;
 

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -34,8 +34,9 @@ class WWaveformViewer : public WWidget, public TrackDropTarget {
     void mousePressEvent(QMouseEvent * /*unused*/) override;
     void mouseMoveEvent(QMouseEvent * /*unused*/) override;
     void mouseReleaseEvent(QMouseEvent * /*unused*/) override;
+    void leaveEvent(QEvent* /*unused*/) override;
 
-signals:
+  signals:
     void trackDropped(QString filename, QString group) override;
     void cloneDeck(QString source_group, QString target_group) override;
 
@@ -75,10 +76,15 @@ private:
     bool m_bBending;
     QPoint m_mouseAnchor;
     parented_ptr<WCueMenuPopup> m_pCueMenuPopup;
+    WaveformMarkPointer m_pHoveredMark;
 
     WaveformWidgetAbstract* m_waveformWidget;
 
     friend class WaveformWidgetFactory;
+
+    CuePointer getCuePointerFromCueMark(WaveformMarkPointer pMark);
+    void highlightMark(WaveformMarkPointer pMark);
+    void unhighlightMark(WaveformMarkPointer pMark);
 };
 
 #endif

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -72,6 +72,7 @@ private:
     ControlProxy* m_pScratchPositionEnable;
     ControlProxy* m_pScratchPosition;
     ControlProxy* m_pWheel;
+    ControlProxy* m_pPlayEnabled;
     bool m_bScratching;
     bool m_bBending;
     QPoint m_mouseAnchor;
@@ -85,6 +86,7 @@ private:
     CuePointer getCuePointerFromCueMark(WaveformMarkPointer pMark);
     void highlightMark(WaveformMarkPointer pMark);
     void unhighlightMark(WaveformMarkPointer pMark);
+    bool isPlaying();
 };
 
 #endif

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -84,10 +84,10 @@ private:
 
     friend class WaveformWidgetFactory;
 
-    CuePointer getCuePointerFromCueMark(WaveformMarkPointer pMark);
+    CuePointer getCuePointerFromCueMark(WaveformMarkPointer pMark) const;
     void highlightMark(WaveformMarkPointer pMark);
     void unhighlightMark(WaveformMarkPointer pMark);
-    bool isPlaying();
+    bool isPlaying() const;
 };
 
 #endif


### PR DESCRIPTION
Adds context menu to hot cues on the scrolling waveform just like WOverview. Right-click on the label to invoke the context menu.

TODOs:
- [x]  Disallow opening context menu when a track is playing.

- [x]  Open context menu when right-clicking in the vicinity of marker line.

- [x]  Highlight cue mark on hover.