### PR TITLE
Restore search when switching views

### DIFF
--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -280,9 +280,6 @@ void WSearchLineEdit::enableSearch(const QString& text) {
             << "enableSearch"
             << text;
 #endif // ENABLE_TRACE_LOG
-    if (isEnabled()) {
-        return;
-    }
     // Set enabled BEFORE updating the edit box!
     setEnabled(true);
     updateEditBox(text);


### PR DESCRIPTION
A minor bug from the WSearchLineEdit fixes. The search text was not replaced and search results not updated when switching views.

How to test:

Step 1:
- Select *Tracks*
- Enter a search query
- Select a crate

Expected behavior: Edit box is cleared
Actual behavior: Edit box still contains the text, but the results of an empty search are shown

Step 2:
- Enter a new 2nd search term for the crate
- Switch back to *Tracks*

Expected behavior: 1st search for Tracks is restored and shown in edit box
Actual behavior: Search results of 1st search are restored, but edit box still shows the text from the 2nd search