### PR TITLE
controllers/midi/midicontroller: Ignore MIDI clock messages (0xF8)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@
 * Add controller mapping for Stanton DJC.4 #2607
 * Fix broadcasting via broadcast/recording input lp:1876222 #2743
 * Only apply ducking gain in manual ducking mode when talkover is enabed lp:1394968 lp:1737113 lp:1662536 #2759
+* Ignore MIDI Clock Messages (0xF8) because they are not usable in Mixxx and inhibited the screensaver #2786
 
 ==== 2.2.3 2019-11-24 ====
 

--- a/src/controllers/midi/midicontroller.cpp
+++ b/src/controllers/midi/midicontroller.cpp
@@ -203,6 +203,16 @@ void MidiController::receive(unsigned char status, unsigned char control,
     unsigned char channel = MidiUtils::channelFromStatus(status);
     unsigned char opCode = MidiUtils::opCodeFromStatus(status);
 
+    // Ignore MIDI beat clock messages (0xF8) until we have proper MIDI sync in
+    // Mixxx. These messages are not suitable to use in JS anyway, as they are
+    // sent at 24 ppqn (i.e. one message every 20.83 ms for a 120 BPM track)
+    // and require real-time code. Currently, they are only spam on the
+    // console, inhibit the screen saver unintentionally, could potentially
+    // slow down Mixxx or interfere with the learning wizard.
+    if (status == 0xF8) {
+        return;
+    }
+
     controllerDebug(MidiUtils::formatMidiMessage(getName(), status, control, value,
                                                  channel, opCode, timestamp));
     MidiKey mappingKey(status, control);


### PR DESCRIPTION
Very small bugfix for MIDI beat clock capable controllers that inhibited the screensaver unintentionally. Nice side effect that this also makes `--controllerDebug` actually usable for me.