### PR TITLE
fix creation of debian packages for our 2.2.4 release. 

### DIFF
--- a/build/debian/rules
+++ b/build/debian/rules
@@ -6,15 +6,18 @@ DEB_BUILD_OPTIONS= noopt
 
 # Build flags are passed in from the SConscript.
 MIXXX_SCONS_FLAGS = ""
+MIXXX_BUILD_FOLDER = "linux_build"
 
 # If ARCH is set to a different architecture when running pbuilder, pbuilder
 # will be set to create an environment to build packages for the architecture
 # specified in ARCH.
 ifneq (,$(findstring i386,$(ARCH)))
-       MIXXX_SCONS_FLAGS += machine=x86
+    MIXXX_SCONS_FLAGS += machine=x86
+    MIXXX_BUILD_FOLDER = "lin32_build"
 endif
 ifneq (,$(findstring amd64,$(ARCH)))
-       MIXXX_SCONS_FLAGS += machine=x86_64
+    MIXXX_SCONS_FLAGS += machine=x86_64
+    MIXXX_BUILD_FOLDER = "lin64_build"
 endif
 
 # parallel builds for scons
@@ -35,9 +38,9 @@ override_dh_auto_build:
 
 override_dh_auto_clean:
 	scons $(MIXXX_SCONS_FLAGS) -c || true
-	rm -rf .sconf_temp/ cache/ linux_build/
+	rm -rf .sconf_temp/ cache/ $(MIXXX_BUILD_FOLDER)/ 
 	dh_clean .sconsign.dblite cachecustom.py \
-		config.log src/build.h build/*.pyc mixxx.1
+		config.log src/build.h build/*.pyc mixxx.1 lib/*/lib/*.a
 	dh_auto_clean
 
 override_dh_auto_install:

--- a/build/features.py
+++ b/build/features.py
@@ -859,6 +859,7 @@ class LiveBroadcasting(Feature):
             # Clone our main environment so we don't change any settings in the
             # Mixxx environment
             libshout_env = build.env.Clone()
+            libshout_env['LIB_OUTPUT'] = '#lib/libshout/lib'
 
             if build.toolchain_is_gnu:
                 libshout_env.Append(CCFLAGS='-pthread')
@@ -870,10 +871,14 @@ class LiveBroadcasting(Feature):
             env = libshout_env
             SCons.Export('env')
             SCons.Export('build')
-            env.SConscript(env.File('SConscript', libshout_dir))
+            env.SConscript(
+                env.File('SConscript', libshout_dir),
+                variant_dir="lib/libshout2",
+                duplicate=0,
+                exports=['build'])
 
             build.env.Append(CPPPATH="#lib/libshout/include")
-            build.env.Append(LIBPATH=libshout_dir)
+            build.env.Append(LIBPATH='#lib/libshout/lib')
             build.env.Append(LIBS=['shout_mixxx', 'ogg', 'vorbis', 'theora', 'speex', 'ssl', 'crypto'])
 
         depends.Qt.uic(build)('preferences/dialog/dlgprefbroadcastdlg.ui')

--- a/lib/libshout/SConscript
+++ b/lib/libshout/SConscript
@@ -32,4 +32,8 @@ env.Append(CPPDEFINES='HAVE_CONFIG_H')
 env.Append(CPPPATH='src/common')
 env.Append(CPPPATH='include')
 
-env.StaticLibrary(target='libshout_mixxx', source=libshout_sources)
+libshout_mixxx = env.StaticLibrary(target='libshout_mixxx', source=libshout_sources)
+
+# Install the libraries if needed.
+if 'LIB_OUTPUT' in env.Dictionary():
+    env.Install('$LIB_OUTPUT', source=[libshout_mixxx])


### PR DESCRIPTION
This should fix the following fail:
```
dpkg-source: error: cannot represent change to lib/libshout/libshout_mixxx.a: binary file contents changed
dpkg-source: error: cannot represent change to lib/libshout/src/codec_opus.o: binary file contents changed
dpkg-source: error: cannot represent change to lib/libshout/src/codec_speex.o: binary file contents changed
dpkg-source: error: cannot represent change to lib/libshout/src/codec_theora.o: binary file contents changed
dpkg-source: error: cannot represent change to lib/libshout/src/codec_vorbis.o: binary file contents changed
dpkg-source: error: cannot represent change to lib/libshout/src/common/avl/avl.o: binary file contents changed
dpkg-source: error: cannot represent change to lib/libshout/src/common/httpp/encoding.o: binary file contents changed
dpkg-source: error: cannot represent change to lib/libshout/src/common/httpp/httpp.o: binary file contents changed
dpkg-source: error: cannot represent change to lib/libshout/src/common/net/resolver.o: binary file contents changed
dpkg-source: error: cannot represent change to lib/libshout/src/common/net/sock.o: binary file contents changed
dpkg-source: error: cannot represent change to lib/libshout/src/common/thread/thread.o: binary file contents changed
dpkg-source: error: cannot represent change to lib/libshout/src/common/timing/timing.o: binary file contents changed
dpkg-source: error: cannot represent change to lib/libshout/src/format_mp3.o: binary file contents changed
dpkg-source: error: cannot represent change to lib/libshout/src/format_ogg.o: binary file contents changed
dpkg-source: error: cannot represent change to lib/libshout/src/format_webm.o: binary file contents changed
dpkg-source: error: cannot represent change to lib/libshout/src/proto_http.o: binary file contents changed
dpkg-source: error: cannot represent change to lib/libshout/src/proto_icy.o: binary file contents changed
dpkg-source: error: cannot represent change to lib/libshout/src/proto_roaraudio.o: binary file contents changed
dpkg-source: error: cannot represent change to lib/libshout/src/proto_xaudiocast.o: binary file contents changed
dpkg-source: error: cannot represent change to lib/libshout/src/queue.o: binary file contents changed
dpkg-source: error: cannot represent change to lib/libshout/src/shout.o: binary file contents changed
dpkg-source: error: cannot represent change to lib/libshout/src/tls.o: binary file contents changed
dpkg-source: error: cannot represent change to lib/libshout/src/util.o: binary file contents changed
dpkg-source: warning: executable mode 0775 of 'plugins/build/debian/DEBIAN/control' will not be represented in diff
dpkg-source: warning: the diff modifies the following upstream files: 
 build/debian/changelog
 build/debian/compat
 build/debian/control
 build/debian/copyright
 build/debian/dirs
 build/debian/menu
 build/debian/mixxx.desktop
 build/debian/mixxx.docs
 build/debian/mixxx.install
 build/debian/mixxx.links
 build/debian/mixxx.sgml
 build/debian/rules
 build/debian/watch
 lin64_build/build.h
 plugins/build/debian/DEBIAN/control
dpkg-source: info: use the '3.0 (quilt)' format to have separate and documented changes to upstream files, see dpkg-source(1)
dpkg-source: error: unrepresentable changes to source
* Build failed.

scons: *** [lin64_build/blah] Exception : Ubuntu package build failed.
Traceback (most recent call last):
  File "/usr/lib/scons/SCons/Action.py", line 1197, in execute
    result = self.execfunction(target=target, source=rsources, env=env)
  File "/home/mixxx/jenkins/workspace/v2.2/mixxx-2.2-release/architecture/amd64/platform/ubuntu/src/SConscript", line 1236, in BuildUbuntuPackage
    raise Exception('Ubuntu package build failed.')
Exception: Ubuntu package build failed.
scons: building terminated because of errors.
```
https://builds.renegadetech.mixxx.org/job/v2.2/job/mixxx-2.2-release/architecture=amd64,platform=ubuntu/249/console