### PR TITLE
mixxx.exe copyright fix

### DIFF
--- a/src/mixxx.rc
+++ b/src/mixxx.rc
@@ -8,8 +8,9 @@ IDI_ICON1               ICON    DISCARDABLE     "res/images/ic_mixxx.ico"
 #define VER_PRODUCTNAME_STR         "Mixxx\0"
 #define VER_FILEDESCRIPTION_STR     "Mixxx digital DJ software"
 #define VER_COMPANYNAME_STR         "The Mixxx Development Team"
-#define VER_LEGALCOPYRIGHT_STR      "Copyright ©2001-" CUR_YEAR " The Mixxx Development Team and/or its subsidiary(-ies).\0"
-#define VER_ORIGINALFILENAME_STR         "Mixxx.exe"
+// \xA9 for (c) symbol. The Microsoft Resource Compiler compiler asumes Latin-1 strings
+#define VER_LEGALCOPYRIGHT_STR      "\xA9 2001-" CUR_YEAR " Mixxx Development Team\0"
+#define VER_ORIGINALFILENAME_STR    "Mixxx.exe"
 
 #if defined(AMD64) || defined(INTEL64) || defined(EM64T) || defined(x86_64)
     #define BITS                    " x64"


### PR DESCRIPTION
I have noticed a mismatch between our copyright, and what is shown in the "Details" view when right click on mixxx.exe.

Taken Microsoft Products as template I have removed the preceding Copyright, because this is already displayed before the statement in the table column. 
