### PR TITLE
Backport of #2776: Ensure that tracks with an invalid bpm are re-analyzed

### DIFF
--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -153,6 +153,11 @@ bool AnalyzerBeats::shouldAnalyze(TrackPointer tio) const {
         return true;
     }
     if (!mixxx::Bpm::isValidValue(pBeats->getBpm())) {
+        // Tracks with an invalid bpm <= 0 should be re-analyzed,
+        // independent of the preference settings. We expect that
+        // all tracks have a bpm > 0 when analyzed. Users that want
+        // to keep their zero bpm tracks could lock them to prevent
+        // this re-analysis (see the check above).
         qDebug() << "Re-analyzing track with invalid BPM despite preference settings.";
         return true;
     }

--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -149,41 +149,45 @@ bool AnalyzerBeats::shouldAnalyze(TrackPointer tio) const {
     // If the track already has a Beats object then we need to decide whether to
     // analyze this track or not.
     mixxx::BeatsPointer pBeats = tio->getBeats();
-    if (pBeats) {
-        QString version = pBeats->getVersion();
-        QString subVersion = pBeats->getSubVersion();
-
-        QHash<QString, QString> extraVersionInfo = getExtraVersionInfo(
-                pluginID,
-                m_bPreferencesFastAnalysis);
-        QString newVersion = BeatFactory::getPreferredVersion(
-                m_bPreferencesOffsetCorrection);
-        QString newSubVersion = BeatFactory::getPreferredSubVersion(
-                m_bPreferencesFixedTempo,
-                m_bPreferencesOffsetCorrection,
-                iMinBpm,
-                iMaxBpm,
-                extraVersionInfo);
-
-        if (version == newVersion && subVersion == newSubVersion) {
-            // If the version and settings have not changed then if the world is
-            // sane, re-analyzing will do nothing.
-            return false;
-        }
-        if (!m_bPreferencesReanalyzeOldBpm) {
-            return false;
-        }
-        if (pBeats->getBpm() == 0.0) {
-            qDebug() << "BPM is 0 for track so re-analyzing despite preference settings.";
-        } else if (pBeats->findNextBeat(0) <= 0.0) {
-            qDebug() << "First beat is 0 for grid so analyzing track to find first beat.";
-        } else {
-            qDebug() << "Beat calculation skips analyzing because the track has"
-                     << "a BPM computed by a previous Mixxx version and user"
-                     << "preferences indicate we should not change it.";
-            return false;
-        }
+    if (!pBeats) {
+        return true;
     }
+    if (!mixxx::Bpm::isValidValue(pBeats->getBpm())) {
+        qDebug() << "Re-analyzing track with invalid BPM despite preference settings.";
+        return true;
+    }
+    if (pBeats->findNextBeat(0) <= 0.0) {
+        qDebug() << "First beat is 0 for grid so analyzing track to find first beat.";
+        return true;
+    }
+
+    // Version check
+    QString version = pBeats->getVersion();
+    QString subVersion = pBeats->getSubVersion();
+    QHash<QString, QString> extraVersionInfo = getExtraVersionInfo(
+            pluginID,
+            m_bPreferencesFastAnalysis);
+    QString newVersion = BeatFactory::getPreferredVersion(
+            m_bPreferencesOffsetCorrection);
+    QString newSubVersion = BeatFactory::getPreferredSubVersion(
+            m_bPreferencesFixedTempo,
+            m_bPreferencesOffsetCorrection,
+            iMinBpm,
+            iMaxBpm,
+            extraVersionInfo);
+    if (version == newVersion && subVersion == newSubVersion) {
+        // If the version and settings have not changed then if the world is
+        // sane, re-analyzing will do nothing.
+        return false;
+    }
+    // Beat grid exists but version and settings differ
+    if (!m_bPreferencesReanalyzeOldBpm) {
+        qDebug() << "Beat calculation skips analyzing because the track has"
+                << "a BPM computed by a previous Mixxx version and user"
+                << "preferences indicate we should not change it.";
+        return false;
+    }
+
     return true;
 }
 


### PR DESCRIPTION
Unfortunately #2776 was targeted at *master* instead of *2.3* as intended. Commits are identical.