### PR TITLE
set elasped and remaining time as default for showing times in decks

### DIFF
--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -79,15 +79,9 @@ DlgPrefDeck::DlgPrefDeck(QWidget * parent, MixxxMainWindow * mixxx,
     connect(m_pControlTrackTimeDisplay, SIGNAL(valueChanged(double)),
             this, SLOT(slotSetTrackTimeDisplay(double)));
 
-    // If not present in the config, set the default value
-    if (!m_pConfig->exists(ConfigKey("[Controls]","PositionDisplay"))) {
-        m_pConfig->set(ConfigKey("[Controls]","PositionDisplay"),
-          QString::number(static_cast<int>(TrackTime::DisplayMode::REMAINING)));
-    }
-
     double positionDisplayType = m_pConfig->getValue(
             ConfigKey("[Controls]", "PositionDisplay"),
-            static_cast<double>(TrackTime::DisplayMode::ELAPSED));
+            static_cast<double>(TrackTime::DisplayMode::ELAPSED_AND_REMAINING));
     if (positionDisplayType ==
             static_cast<double>(TrackTime::DisplayMode::REMAINING)) {
         radioButtonRemaining->setChecked(true);


### PR DESCRIPTION
As suggested by @pestrela https://mixxx.org/forums/viewtopic.php?f=1&t=13355

This is a really useful feature. Let's not hide it from users.

Note that this gets cut off when Mixxx is first opened with the minimum window size. But few people are using screens that small and there is no problem as soon as they maximize the window. Maybe we should also maximize the window on the first run? The few users who actually do use the minimum size can show only the elapsed or remaining time or hide the mixer.

![image](https://user-images.githubusercontent.com/9455094/82135084-41b53400-97c4-11ea-8aa0-c1c8194e320c.png)
