### PR TITLE
Exclude .ts files from Transifex from pre-commit-hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
   rev: v2.3.0
   hooks:
   - id: check-byte-order-marker
-    exclude: ^.*(\.cbproj|\.groupproj|\.props|\.sln|\.vcxproj|\.vcxproj.filters)$
+    exclude: ^.*(\.cbproj|\.groupproj|\.props|\.sln|\.vcxproj|\.vcxproj.filters|\.ts)$
   - id: check-case-conflict
   - id: check-json
   - id: check-merge-conflict


### PR DESCRIPTION
The .ts files are pulled from Transifex and not edited locally. The pre-commit-hook fails after those files have been updated recently.