### PR TITLE
SoundManager: Restore qHash() behavior

### DIFF
--- a/src/soundio/soundmanagerutil.cpp
+++ b/src/soundio/soundmanagerutil.cpp
@@ -93,15 +93,6 @@ unsigned char AudioPath::getIndex() const {
 }
 
 /**
- * Defines equality for AudioPath objects.
- * @return true of this and other share a common type and index.
- */
-bool AudioPath::operator==(const AudioPath &other) const {
-    return m_type == other.m_type
-        && m_index == other.m_index;
-}
-
-/**
  * Checks if this AudioPath's channels clash with another's
  * (see ChannelGroup::clashesWith).
  */

--- a/src/soundio/soundmanagerutil.cpp
+++ b/src/soundio/soundmanagerutil.cpp
@@ -66,8 +66,8 @@ bool ChannelGroup::clashesWith(const ChannelGroup &other) const {
  * @param channels the number of channels used.
  */
 AudioPath::AudioPath(unsigned char channelBase, unsigned char channels)
-    : m_type(INVALID),
-      m_channelGroup(channelBase, channels),
+    : m_channelGroup(channelBase, channels),
+      m_type(INVALID),
       m_index(0) {
 }
 

--- a/src/soundio/soundmanagerutil.h
+++ b/src/soundio/soundmanagerutil.h
@@ -16,11 +16,14 @@ class ChannelGroup {
     unsigned char getChannelCount() const;
     bool clashesWith(const ChannelGroup& other) const;
 
+    uint hashValue() const {
+        return (m_channels << 8) |
+                m_channelBase;
+    }
     friend uint qHash(
             const ChannelGroup& group,
             uint seed = 0) {
-        return qHash(group.m_channelBase, seed) |
-                qHash(group.m_channels, seed);
+        return qHash(group.hashValue(), seed);
     }
 
     friend bool operator==(
@@ -87,18 +90,23 @@ public:
     // AudioPathType.
     static unsigned char maxChannelsForType(AudioPathType type);
 
+    uint hashValue() const {
+        // Exclude m_channelGroup from hash value!
+        // See also: operator==()
+        // TODO: Why??
+        return (m_type << 8) |
+                m_index;
+    }
     friend uint qHash(
             const AudioPath& path,
             uint seed = 0) {
-        return qHash(static_cast<uint>(path.m_type), seed) ^
-                qHash(path.m_channelGroup, seed) ^
-                qHash(path.m_index, seed);
+        return qHash(path.hashValue(), seed);
     }
 
 protected:
     virtual void setType(AudioPathType type) = 0;
-    AudioPathType m_type;
     ChannelGroup m_channelGroup;
+    AudioPathType m_type;
     unsigned char m_index;
 };
 

--- a/src/soundio/soundmanagerutil.h
+++ b/src/soundio/soundmanagerutil.h
@@ -73,7 +73,6 @@ public:
     AudioPathType getType() const;
     ChannelGroup getChannelGroup() const;
     unsigned char getIndex() const;
-    bool operator==(const AudioPath &other) const;
     bool channelsClash(const AudioPath &other) const;
     QString getString() const;
     static QString getStringFromType(AudioPathType type);
@@ -103,12 +102,28 @@ public:
         return qHash(path.hashValue(), seed);
     }
 
+    friend bool operator==(
+            const AudioPath& lhs,
+            const AudioPath& rhs) {
+        // Exclude m_channelGroup from comparison!
+        // See also: hashValue()/qHash()
+        // TODO: Why??
+        return lhs.m_type == rhs.m_type &&
+                lhs.m_index == rhs.m_index;
+    }
+
 protected:
     virtual void setType(AudioPathType type) = 0;
     ChannelGroup m_channelGroup;
     AudioPathType m_type;
     unsigned char m_index;
 };
+
+inline bool operator!=(
+        const AudioPath& lhs,
+        const AudioPath& rhs) {
+    return !(lhs == rhs);
+}
 
 /// A source of audio in Mixxx that is to be output to a group of
 /// channels on an audio interface.


### PR DESCRIPTION
Follow-up of #2762 

The AudioPath hashing (and operator==/!=) **MUST NOT** (for whatever reason) include the m_channelGroup member. Otherwise switching devices will crash Mixxx caused by memory corruption in QHashData.

I still see crashes when exiting Mixxx with the controller connected.