### PR TITLE
Fix pre-commit-hook exclusion of .ts files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@
 # Using the `$SKIP` var is preferable to using `git commit --no-verify`
 # because it won't prevent catching other, unrelated issues.
 
-exclude: ^(lib/|src/test/.*data/).*$
+exclude: ^(lib/|src/test/.*data/).*|res/translations/.*\.ts$
 default_language_version:
   python: python3
 repos:
@@ -54,13 +54,11 @@ repos:
   - id: check-xml
   - id: check-yaml
   - id: end-of-file-fixer
-    exclude: ^.*(\.ts)$
     stages:
     - commit
     - manual
   - id: mixed-line-ending
   - id: trailing-whitespace
-    exclude: ^.*(\.ts)$
     stages:
     - commit
     - manual

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,7 @@ repos:
     - manual
   - id: mixed-line-ending
   - id: trailing-whitespace
+    exclude: ^.*(\.ts)$
     stages:
     - commit
     - manual

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,13 +47,14 @@ repos:
   rev: v2.3.0
   hooks:
   - id: check-byte-order-marker
-    exclude: ^.*(\.cbproj|\.groupproj|\.props|\.sln|\.vcxproj|\.vcxproj.filters|\.ts)$
+    exclude: ^.*(\.cbproj|\.groupproj|\.props|\.sln|\.vcxproj|\.vcxproj.filters)$
   - id: check-case-conflict
   - id: check-json
   - id: check-merge-conflict
   - id: check-xml
   - id: check-yaml
   - id: end-of-file-fixer
+    exclude: ^.*(\.ts)$
     stages:
     - commit
     - manual


### PR DESCRIPTION
Instead of from check-byte-order-marker we must exclude the files from end-of-file-fixer :see_no_evil: 