### PR TITLE
BPM rescan mode override

### DIFF
--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -28,9 +28,12 @@ mixxx::AnalyzerPluginInfo AnalyzerBeats::defaultPlugin() {
     return availablePlugins().at(0);
 }
 
-AnalyzerBeats::AnalyzerBeats(UserSettingsPointer pConfig, bool enforceBpmDetection)
+AnalyzerBeats::AnalyzerBeats(UserSettingsPointer pConfig,
+        bool enforceBpmDetection,
+        AnalyzerBeatsOverride modeOverride)
         : m_bpmSettings(pConfig),
           m_enforceBpmDetection(enforceBpmDetection),
+          m_modeOverride(modeOverride),
           m_bPreferencesReanalyzeOldBpm(false),
           m_bPreferencesFixedTempo(true),
           m_bPreferencesOffsetCorrection(false),
@@ -68,6 +71,18 @@ bool AnalyzerBeats::initialize(TrackPointer tio, int sampleRate, int totalSample
     m_bPreferencesOffsetCorrection = m_bpmSettings.getFixedTempoOffsetCorrection();
     m_bPreferencesReanalyzeOldBpm = m_bpmSettings.getReanalyzeWhenSettingsChange();
     m_bPreferencesFastAnalysis = m_bpmSettings.getFastAnalysis();
+    switch (m_modeOverride) {
+    case FixedBpm:
+        m_bPreferencesFixedTempo = true;
+        break;
+    case UnfixedBpm:
+        m_bPreferencesFixedTempo = false;
+        m_bPreferencesOffsetCorrection = false;
+        m_bPreferencesFastAnalysis = false;
+        break;
+    default:
+        break;
+    }
 
     if (availablePlugins().size() > 0) {
         m_pluginId = defaultPlugin().id;

--- a/src/analyzer/analyzerbeats.h
+++ b/src/analyzer/analyzerbeats.h
@@ -17,11 +17,18 @@
 #include "preferences/usersettings.h"
 #include "util/memory.h"
 
+enum AnalyzerBeatsOverride {
+    UsePreference,
+    FixedBpm,
+    UnfixedBpm,
+};
+
 class AnalyzerBeats : public Analyzer {
   public:
     explicit AnalyzerBeats(
             UserSettingsPointer pConfig,
-            bool enforceBpmDetection = false);
+            bool enforceBpmDetection = false,
+            AnalyzerBeatsOverride = UsePreference);
     ~AnalyzerBeats() override = default;
 
     static QList<mixxx::AnalyzerPluginInfo> availablePlugins();
@@ -40,6 +47,7 @@ class AnalyzerBeats : public Analyzer {
     BeatDetectionSettings m_bpmSettings;
     std::unique_ptr<mixxx::AnalyzerBeatsPlugin> m_pPlugin;
     const bool m_enforceBpmDetection;
+    AnalyzerBeatsOverride m_modeOverride;
     QString m_pluginId;
     bool m_bPreferencesReanalyzeOldBpm;
     bool m_bPreferencesFixedTempo;

--- a/src/analyzer/analyzerthread.cpp
+++ b/src/analyzer/analyzerthread.cpp
@@ -114,7 +114,14 @@ void AnalyzerThread::doRun() {
     // BPM detection might be disabled in the config, but can be overridden
     // and enabled by explicitly setting the mode flag.
     const bool enforceBpmDetection = (m_modeFlags & AnalyzerModeFlags::WithBeats) != 0;
-    m_analyzers.push_back(AnalyzerWithState(std::make_unique<AnalyzerBeats>(m_pConfig, enforceBpmDetection)));
+    AnalyzerBeatsOverride beatsOverride = AnalyzerBeatsOverride::UsePreference;
+    if (m_modeFlags & AnalyzerModeFlags::ForceFixedBpm) {
+        beatsOverride = AnalyzerBeatsOverride::FixedBpm;
+    } else if (m_modeFlags & AnalyzerModeFlags::ForceUnfixedBpm) {
+        beatsOverride = AnalyzerBeatsOverride::UnfixedBpm;
+    }
+    m_analyzers.push_back(AnalyzerWithState(std::make_unique<AnalyzerBeats>(
+            m_pConfig, enforceBpmDetection, beatsOverride)));
     m_analyzers.push_back(AnalyzerWithState(std::make_unique<AnalyzerKey>(m_pConfig)));
     m_analyzers.push_back(AnalyzerWithState(std::make_unique<AnalyzerSilence>(m_pConfig)));
     DEBUG_ASSERT(!m_analyzers.empty());

--- a/src/analyzer/analyzerthread.h
+++ b/src/analyzer/analyzerthread.h
@@ -20,6 +20,8 @@ enum AnalyzerModeFlags {
     WithBeats = 0x01,
     WithWaveform = 0x02,
     All = WithBeats | WithWaveform,
+    ForceFixedBpm = 0x04,
+    ForceUnfixedBpm = 0x08,
 };
 
 enum class AnalyzerThreadState {

--- a/src/library/analysisfeature.cpp
+++ b/src/library/analysisfeature.cpp
@@ -136,7 +136,8 @@ void AnalysisFeature::activate() {
 
 void AnalysisFeature::analyzeTracks(QList<TrackId> trackIds) {
     if (!m_pTrackAnalysisScheduler) {
-        const int numAnalyzerThreads = numberOfAnalyzerThreads();
+        const int numAnalyzerThreads =
+                math_min(trackIds.size(), numberOfAnalyzerThreads());
         kLogger.info()
                 << "Starting analysis using"
                 << numAnalyzerThreads

--- a/src/library/analysisfeature.h
+++ b/src/library/analysisfeature.h
@@ -5,17 +5,18 @@
 #ifndef ANALYSISFEATURE_H
 #define ANALYSISFEATURE_H
 
-#include <QStringListModel>
-#include <QUrl>
-#include <QObject>
-#include <QVariant>
 #include <QIcon>
 #include <QList>
+#include <QObject>
+#include <QStringListModel>
+#include <QUrl>
+#include <QVariant>
 
-#include "library/libraryfeature.h"
-#include "library/dlganalysis.h"
-#include "library/treeitemmodel.h"
+#include "analyzer/analyzerbeats.h"
 #include "analyzer/trackanalysisscheduler.h"
+#include "library/dlganalysis.h"
+#include "library/libraryfeature.h"
+#include "library/treeitemmodel.h"
 #include "preferences/usersettings.h"
 
 class TrackCollection;
@@ -42,6 +43,8 @@ class AnalysisFeature : public LibraryFeature {
 
     TreeItemModel* getChildModel() override;
     void refreshLibraryModels();
+    void analyzeTracksWithBeatsMode(QList<TrackId> trackIds,
+            AnalyzerBeatsOverride beatsOverride);
 
   signals:
     void analysisActive(bool bActive);

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -526,12 +526,12 @@ void Library::slotRequestRelocateDir(QString oldDir, QString newDir) {
     }
 }
 
-void Library::slotAnalyzeTracks(TrackPointerList tracks) {
+void Library::slotAnalyzeTracks(TrackPointerList tracks, AnalyzerBeatsOverride beatsOverride) {
     QList<TrackId> ids;
     for (auto pTrack : tracks) {
         ids.append(pTrack->getId());
     }
-    m_pAnalysisFeature->analyzeTracks(ids);
+    m_pAnalysisFeature->analyzeTracksWithBeatsMode(ids, beatsOverride);
 }
 
 QStringList Library::getDirs() {

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -311,6 +311,10 @@ void Library::bindLibraryWidget(WLibrary* pLibraryWidget,
             &WTrackTableView::loadTrackToPlayer,
             this,
             &Library::slotLoadTrackToPlayer);
+    connect(pTrackTableView,
+            &WTrackTableView::analyzeTracks,
+            this,
+            &Library::slotAnalyzeTracks);
     pLibraryWidget->registerView(m_sTrackViewName, pTrackTableView);
 
     connect(this,
@@ -520,6 +524,14 @@ void Library::slotRequestRelocateDir(QString oldDir, QString newDir) {
     if (oldDir == conDir) {
         m_pConfig->set(PREF_LEGACY_LIBRARY_DIR, newDir);
     }
+}
+
+void Library::slotAnalyzeTracks(TrackPointerList tracks) {
+    QList<TrackId> ids;
+    for (auto pTrack : tracks) {
+        ids.append(pTrack->getId());
+    }
+    m_pAnalysisFeature->analyzeTracks(ids);
 }
 
 QStringList Library::getDirs() {

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -1,11 +1,12 @@
 #pragma once
 
-#include <QList>
-#include <QObject>
 #include <QAbstractItemModel>
 #include <QFont>
+#include <QList>
+#include <QObject>
 #include <QPointer>
 
+#include "analyzer/analyzerbeats.h"
 #include "analyzer/analyzerprogress.h"
 #include "preferences/usersettings.h"
 #include "track/track.h"
@@ -102,7 +103,7 @@ class Library: public QObject {
     void slotRequestRemoveDir(QString directory, Library::RemovalType removalType);
     void slotRequestRelocateDir(QString previousDirectory, QString newDirectory);
     void onSkinLoadFinished();
-    void slotAnalyzeTracks(TrackPointerList);
+    void slotAnalyzeTracks(TrackPointerList, AnalyzerBeatsOverride);
 
   signals:
     void showTrackModel(QAbstractItemModel* model);

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -102,6 +102,7 @@ class Library: public QObject {
     void slotRequestRemoveDir(QString directory, Library::RemovalType removalType);
     void slotRequestRelocateDir(QString previousDirectory, QString newDirectory);
     void onSkinLoadFinished();
+    void slotAnalyzeTracks(TrackPointerList);
 
   signals:
     void showTrackModel(QAbstractItemModel* model);

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1059,7 +1059,7 @@ void WTrackMenu::slotRescanBpmConstant() {
         }
         pTrack->setBeats(mixxx::BeatsPointer());
     }
-    emit analyzeTracks(getTrackPointers());
+    emit analyzeTracks(getTrackPointers(), AnalyzerBeatsOverride::FixedBpm);
 }
 
 void WTrackMenu::slotRescanBpmNonConstant() {
@@ -1070,7 +1070,7 @@ void WTrackMenu::slotRescanBpmNonConstant() {
         }
         pTrack->setBeats(mixxx::BeatsPointer());
     }
-    emit analyzeTracks(getTrackPointers());
+    emit analyzeTracks(getTrackPointers(), AnalyzerBeatsOverride::UnfixedBpm);
 }
 
 void WTrackMenu::slotColorPicked(mixxx::RgbColor::optional_t color) {

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -286,6 +286,19 @@ void WTrackMenu::createActions() {
                 &QAction::triggered,
                 this,
                 &WTrackMenu::slotClearBeats);
+
+        m_pBpmRescanConstantTempo = new QAction(tr("Rescan BPM, Constant tempo"), m_pBPMMenu);
+        connect(m_pBpmRescanConstantTempo,
+                &QAction::triggered,
+                this,
+                &WTrackMenu::slotRescanBpmConstant);
+
+        m_pBpmRescanNonConstantTempo =
+                new QAction(tr("Rescan BPM, Non-constant tempo"), m_pBPMMenu);
+        connect(m_pBpmRescanNonConstantTempo,
+                &QAction::triggered,
+                this,
+                &WTrackMenu::slotRescanBpmNonConstant);
     }
 
     if (featureIsEnabled(Feature::Color)) {
@@ -361,6 +374,8 @@ void WTrackMenu::setupActions() {
         m_pBPMMenu->addAction(m_pBpmLockAction);
         m_pBPMMenu->addAction(m_pBpmUnlockAction);
         m_pBPMMenu->addSeparator();
+        m_pBPMMenu->addAction(m_pBpmRescanConstantTempo);
+        m_pBPMMenu->addAction(m_pBpmRescanNonConstantTempo);
         m_pBPMMenu->addAction(m_pBpmResetAction);
         m_pBPMMenu->addSeparator();
 
@@ -1034,6 +1049,28 @@ void WTrackMenu::lockBpm(bool lock) {
     for (const auto& pTrack : getTrackPointers()) {
         pTrack->setBpmLocked(lock);
     }
+}
+
+void WTrackMenu::slotRescanBpmConstant() {
+    // TODO: This should be done in a thread for large selections
+    for (const auto& pTrack : getTrackPointers()) {
+        if (pTrack->isBpmLocked()) {
+            continue;
+        }
+        pTrack->setBeats(mixxx::BeatsPointer());
+    }
+    emit analyzeTracks(getTrackPointers());
+}
+
+void WTrackMenu::slotRescanBpmNonConstant() {
+    // TODO: This should be done in a thread for large selections
+    for (const auto& pTrack : getTrackPointers()) {
+        if (pTrack->isBpmLocked()) {
+            continue;
+        }
+        pTrack->setBeats(mixxx::BeatsPointer());
+    }
+    emit analyzeTracks(getTrackPointers());
 }
 
 void WTrackMenu::slotColorPicked(mixxx::RgbColor::optional_t color) {

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -4,6 +4,7 @@
 #include <QModelIndex>
 #include <QPointer>
 
+#include "analyzer/analyzerbeats.h"
 #include "library/dao/playlistdao.h"
 #include "preferences/usersettings.h"
 #include "track/track.h"
@@ -68,7 +69,7 @@ class WTrackMenu : public QMenu {
 
   signals:
     void loadTrackToPlayer(TrackPointer pTrack, QString group, bool play = false);
-    void analyzeTracks(TrackPointerList);
+    void analyzeTracks(TrackPointerList, AnalyzerBeatsOverride);
 
   private slots:
     // File

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -68,6 +68,7 @@ class WTrackMenu : public QMenu {
 
   signals:
     void loadTrackToPlayer(TrackPointer pTrack, QString group, bool play = false);
+    void analyzeTracks(TrackPointerList);
 
   private slots:
     // File
@@ -93,6 +94,8 @@ class WTrackMenu : public QMenu {
     void slotLockBpm();
     void slotUnlockBpm();
     void slotScaleBpm(int);
+    void slotRescanBpmConstant();
+    void slotRescanBpmNonConstant();
 
     // Info and metadata
     void slotShowTrackInfo();
@@ -221,6 +224,8 @@ class WTrackMenu : public QMenu {
     QAction* m_pBpmFourThirdsAction{};
     QAction* m_pBpmThreeHalvesAction{};
     QAction* m_pBpmResetAction{};
+    QAction* m_pBpmRescanConstantTempo{};
+    QAction* m_pBpmRescanNonConstantTempo{};
 
     // Track color
     WColorPickerAction* m_pColorPickerAction{};

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -329,6 +329,10 @@ void WTrackTableView::initTrackMenu() {
             &WTrackMenu::loadTrackToPlayer,
             this,
             &WTrackTableView::loadTrackToPlayer);
+    connect(m_pTrackMenu.get(),
+            &WTrackMenu::analyzeTracks,
+            this,
+            &WTrackTableView::analyzeTracks);
 }
 
 // slot

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -4,6 +4,7 @@
 #include <QAbstractItemModel>
 #include <QSortFilterProxyModel>
 
+#include "analyzer/analyzerbeats.h"
 #include "control/controlproxy.h"
 #include "library/dao/playlistdao.h"
 #include "library/trackmodel.h" // Can't forward declare enums
@@ -52,7 +53,7 @@ class WTrackTableView : public WLibraryTableView {
     }
 
   signals:
-    void analyzeTracks(TrackPointerList);
+    void analyzeTracks(TrackPointerList, AnalyzerBeatsOverride);
 
   public slots:
     void loadTrackModel(QAbstractItemModel* model);

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -51,6 +51,9 @@ class WTrackTableView : public WLibraryTableView {
         return m_backgroundColorOpacity;
     }
 
+  signals:
+    void analyzeTracks(TrackPointerList);
+
   public slots:
     void loadTrackModel(QAbstractItemModel* model);
     void slotMouseDoubleClicked(const QModelIndex &);


### PR DESCRIPTION
Create a new track right-click option to rescan a track's bpm and force either constant or nonconstant mode.  

Current workflow:
* track scans, bpm is off because the track is non-constant.
* open preferences, navigate to bpm, turn off "Assume constant tempo"
* right click track, reset bpm / beatgrid
* load track in deck
* open preferences, navigate to bpm, turn "assume constant tempo" back on

New workflow:
* track scans, bpm is off because the track is non-constant.
* right click track, select "Rescan BPM, Non-constant tempo"

This change does not do anything tricky with the actual preferences, it just overrides the bpm mode for the individual analysis.

current issue: no progress bar for the rescan.