### PR TITLE
disable repeated logging of missing coverart image

### DIFF
--- a/src/library/coverart.cpp
+++ b/src/library/coverart.cpp
@@ -121,11 +121,14 @@ QImage CoverInfo::loadImage(
         }
         DEBUG_ASSERT(coverFile.isAbsolute());
         if (!coverFile.exists()) {
-            kLogger.warning()
-                    << "loadImage"
-                    << type
-                    << "cover does not exist:"
-                    << coverFile.filePath();
+            // Disabled because this code can cause high CPU and thus possibly
+            // xruns as it might print the warning repeatedly.
+            // ToDo: Print warning about missing cover image only once.
+            //            kLogger.warning()
+            //                    << "loadImage"
+            //                    << type
+            //                    << "cover does not exist:"
+            //                    << coverFile.filePath();
             return QImage();
         }
         SecurityTokenPointer pToken =


### PR DESCRIPTION
fixes high CPU and xruns when a coverart image is missing in file system and the log warning is printed repeatedly.
https://bugs.launchpad.net/mixxx/+bug/1879160

Is the coverart requested repeatedly with every GUI tick?

The missing cover art is now only noticed by ..well, the missing the cover art in the tracks table and elsewhere.
I guess until anyone comes up with a better fix no one will seriously be harmed as users can re-assign the coverart manually if they miss it.

@uklotzde Any other places where this might happen come to mind?