### PR TITLE
CMake typo fix in optimize code 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2262,14 +2262,7 @@ if(NOT OPTIMIZE STREQUAL "off")
       # Note: requires gcc >= 4.2.0
       # macros like __SSE2_MATH__ __SSE_MATH__ __SSE2__ __SSE__
       # are set automatically
-      if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(i[3456]86|x86|x64|x86_64|AMD64)$"
-         AND NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
-        # For 32 bit builds using gcc < 5.0, the mfpmath=sse is
-        # not set by default (not supported on arm builds)
-        # If -msse is not implicitly set, it falls back to mfpmath=387
-        # and a compiler warning is issued (tested with gcc 4.8.4)
-        target_compile_options(mixxx-lib PUBLIC "-mfpmath=sse")
-      elseif(CMAKE_SYSTEM_PROCESSOR EQUAL "arm")
+      if(CMAKE_SYSTEM_PROCESSOR EQUAL "arm")
         target_compile_options(mixxx-lib PUBLIC
           "-mfloat-abi=hard"
           "-mfpu=neon"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2259,7 +2259,6 @@ if(NOT OPTIMIZE STREQUAL "off")
     elseif(OPTIMIZE STREQUAL "native")
       message("Enabling native optimizations for ${CMAKE_SYSTEM_PROCESSOR}")
       target_compile_options(mixxx-lib PUBLIC "-march=native")
-      # http://en.chys.info/2010/04/what-exactly-marchnative-means/
       # Note: requires gcc >= 4.2.0
       # macros like __SSE2_MATH__ __SSE_MATH__ __SSE2__ __SSE__
       # are set automatically

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2229,12 +2229,12 @@ if(NOT OPTIMIZE STREQUAL "off")
       if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(i[3456]86|x86|x64|x86_64|AMD64)$")
         message(STATUS "Enabling SS2 CPU optimizations (>= Pentium 4)")
         target_compile_options(mixxx-lib PUBLIC "-mtune=generic")
-        # -mtune=generic pick the most common, but compatible options.
+        # -mtune=generic picks the most common, but compatible options.
         # on arm platforms equivalent to -march=arch
-        if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
           # the sse flags are not set by default on 32 bit builds
           # but are not supported on arm builds
-          target_compile_options(mixxx-lib PUBLIC "-msse" "-mfpmath=sse")
+          target_compile_options(mixxx-lib PUBLIC "-msse2" "-mfpmath=sse")
         endif()
         # TODO(rryan): macOS can use SSE3, and possibly SSE 4.1 once
         # we require macOS 10.12.

--- a/build/features.py
+++ b/build/features.py
@@ -1061,13 +1061,7 @@ class Optimize(Feature):
                 # Note: requires gcc >= 4.2.0
                 # macros like __SSE2_MATH__ __SSE_MATH__ __SSE2__ __SSE__
                 # are set automatically
-                if build.architecture_is_x86 and not build.machine_is_64bit:
-                    # For 32 bit builds using gcc < 5.0, the mfpmath=sse is
-                    # not set by default (not supported on arm builds)
-                    # If -msse is not implicitly set, it falls back to mfpmath=387
-                    # and a compiler warning is issued (tested with gcc 4.8.4)
-                    build.env.Append(CCFLAGS='-mfpmath=sse')
-                elif build.architecture_is_arm:
+                if build.architecture_is_arm:
                     self.status = self.build_status(optimize_level)
                     build.env.Append(CCFLAGS='-mfloat-abi=hard')
                     build.env.Append(CCFLAGS='-mfpu=neon')

--- a/build/features.py
+++ b/build/features.py
@@ -1058,7 +1058,6 @@ class Optimize(Feature):
                 self.status = self.build_status(
                     optimize_level, "tuned for this CPU (%s)" % build.machine)
                 build.env.Append(CCFLAGS='-march=native')
-                # http://en.chys.info/2010/04/what-exactly-marchnative-means/
                 # Note: requires gcc >= 4.2.0
                 # macros like __SSE2_MATH__ __SSE_MATH__ __SSE2__ __SSE__
                 # are set automatically


### PR DESCRIPTION
This aims to fix bug https://bugs.launchpad.net/mixxx/+bug/1879681
That CMake builds performs slower than Scons builds.

Even though the build flags are now more similar, I cannot confirm that the performance differences 
have been fixed. 
The beat analyzes with cmake is still slower.    

Maybe this is an odd caching issue. Maybe someone else can compare as well. 

At least the obvious typo in CMakeList is fixed now. 