### PR TITLE
lp1879160: Log warning about cover load failure only once

### DIFF
--- a/src/library/coverart.cpp
+++ b/src/library/coverart.cpp
@@ -83,19 +83,27 @@ QDebug operator<<(QDebug dbg, const CoverInfoRelative& infoRelative) {
             .arg(coverInfoRelativeToString(infoRelative));
 }
 
-QImage CoverInfo::loadImage(
+CoverInfo::LoadedImage CoverInfo::loadImage(
         const SecurityTokenPointer& pTrackLocationToken) const {
+    LoadedImage loadedImage;
     if (type == CoverInfo::METADATA) {
         VERIFY_OR_DEBUG_ASSERT(!trackLocation.isEmpty()) {
-            kLogger.warning()
-                    << "loadImage"
-                    << type
-                    << "cover with empty trackLocation";
-            return QImage();
+            loadedImage.result = LoadedImage::Result::ErrorMetadataWithEmptyTrackLocation;
+            return loadedImage;
         }
-        return CoverArtUtils::extractEmbeddedCover(
+        loadedImage.filePath = trackLocation;
+        loadedImage.image = CoverArtUtils::extractEmbeddedCover(
                 TrackFile(trackLocation),
                 pTrackLocationToken);
+        if (loadedImage.image.isNull()) {
+            // TODO: extractEmbeddedCover() should indicate if no image
+            // is available or if loading the embedded image failed.
+            // Until then we assume optimistically that no image is
+            // available instead of presuming that an error occurred.
+            loadedImage.result = LoadedImage::Result::NoImage;
+        } else {
+            loadedImage.result = LoadedImage::Result::Ok;
+        }
     } else if (type == CoverInfo::FILE) {
         auto coverFile = QFileInfo(coverLocation);
         if (coverFile.isRelative()) {
@@ -104,13 +112,9 @@ QImage CoverInfo::loadImage(
                 // must have a valid location, i.e. a file path. Most
                 // likely a programming error, but might also be caused
                 // by yet unknown circumstances.
-                kLogger.warning()
-                        << "loadImage"
-                        << type
-                        << "cover with empty track location"
-                        << "and relative file path:"
-                        << coverFile.filePath();
-                return QImage();
+                loadedImage.result = LoadedImage::Result::
+                        ErrorRelativeFilePathWithEmptyTrackLocation;
+                return loadedImage;
             }
             // Compose track directory with relative path
             const auto trackFile = TrackFile(trackLocation);
@@ -120,28 +124,28 @@ QImage CoverInfo::loadImage(
                     coverLocation);
         }
         DEBUG_ASSERT(coverFile.isAbsolute());
+        loadedImage.filePath = coverFile.filePath();
         if (!coverFile.exists()) {
-            // Disabled because this code can cause high CPU and thus possibly
-            // xruns as it might print the warning repeatedly.
-            // ToDo: Print warning about missing cover image only once.
-            //            kLogger.warning()
-            //                    << "loadImage"
-            //                    << type
-            //                    << "cover does not exist:"
-            //                    << coverFile.filePath();
-            return QImage();
+            loadedImage.result = LoadedImage::Result::ErrorFilePathDoesNotExist;
+            return loadedImage;
         }
         SecurityTokenPointer pToken =
                 Sandbox::openSecurityToken(
                         coverFile,
                         true);
-        return QImage(coverFile.filePath());
+        if (loadedImage.image.load(loadedImage.filePath)) {
+            DEBUG_ASSERT(!loadedImage.image.isNull());
+            loadedImage.result = LoadedImage::Result::Ok;
+        } else {
+            DEBUG_ASSERT(loadedImage.image.isNull());
+            loadedImage.result = LoadedImage::Result::ErrorLoadingFailed;
+        }
     } else if (type == CoverInfo::NONE) {
-        return QImage();
+        loadedImage.result = LoadedImage::Result::NoImage;
     } else {
         DEBUG_ASSERT(!"unhandled CoverInfo::Type");
-        return QImage();
     }
+    return loadedImage;
 }
 
 bool CoverInfo::refreshImageHash(
@@ -154,8 +158,8 @@ bool CoverInfo::refreshImageHash(
         return false;
     }
     QImage image = loadedImage;
-    if (loadedImage.isNull()) {
-        image = loadImage(pTrackLocationToken);
+    if (image.isNull()) {
+        image = loadImage(pTrackLocationToken).image;
     }
     if (image.isNull() && type != CoverInfo::NONE) {
         kLogger.warning()
@@ -185,9 +189,47 @@ QDebug operator<<(QDebug dbg, const CoverInfo& info) {
             .arg(coverInfoToString(info));
 }
 
+QDebug operator<<(QDebug dbg, const CoverInfo::LoadedImage::Result& result) {
+    switch (result) {
+    case CoverInfo::LoadedImage::Result::Ok:
+        return dbg << "Ok";
+    case CoverInfo::LoadedImage::Result::NoImage:
+        return dbg << "NoImage";
+    case CoverInfo::LoadedImage::Result::ErrorMetadataWithEmptyTrackLocation:
+        return dbg << "ErrorMetadataWithEmptyTrackLocation";
+    case CoverInfo::LoadedImage::Result::ErrorRelativeFilePathWithEmptyTrackLocation:
+        return dbg << "ErrorRelativeFilePathWithEmptyTrackLocation";
+    case CoverInfo::LoadedImage::Result::ErrorFilePathDoesNotExist:
+        return dbg << "ErrorFilePathDoesNotExist";
+    case CoverInfo::LoadedImage::Result::ErrorLoadingFailed:
+        return dbg << "ErrorLoadingFailed";
+    case CoverInfo::LoadedImage::Result::ErrorUnknown:
+        return dbg << "ErrorUnknown";
+    }
+    DEBUG_ASSERT(!"unreachable");
+    return dbg;
+}
+
+QDebug operator<<(QDebug dbg, const CoverInfo::LoadedImage& loadedImage) {
+    dbg = dbg.maybeSpace() << "CoverInfo::LoadedImage";
+    return dbg.nospace()
+            << '{'
+            << loadedImage.filePath
+            << ','
+            << loadedImage.image.size()
+            << ','
+            << loadedImage.result
+            << '}';
+}
+
 QDebug operator<<(QDebug dbg, const CoverArt& art) {
-    return dbg.maybeSpace() << QString("CoverArt(%1,%2,%3)")
-            .arg(coverInfoToString(art),
-                 toDebugString(art.image.size()),
-                 QString::number(art.resizedToWidth));
+    dbg = dbg.maybeSpace() << "CoverArt";
+    return dbg.nospace()
+            << '{'
+            << static_cast<const CoverInfo&>(art)
+            << ','
+            << art.loadedImage
+            << ','
+            << art.resizedToWidth
+            << '}';
 }

--- a/src/library/coverart.cpp
+++ b/src/library/coverart.cpp
@@ -1,5 +1,7 @@
 #include "library/coverart.h"
 
+#include <QDebugStateSaver>
+
 #include "library/coverartutils.h"
 #include "util/debug.h"
 #include "util/logger.h"
@@ -211,6 +213,7 @@ QDebug operator<<(QDebug dbg, const CoverInfo::LoadedImage::Result& result) {
 }
 
 QDebug operator<<(QDebug dbg, const CoverInfo::LoadedImage& loadedImage) {
+    const QDebugStateSaver saver(dbg);
     dbg = dbg.maybeSpace() << "CoverInfo::LoadedImage";
     return dbg.nospace()
             << '{'
@@ -223,6 +226,7 @@ QDebug operator<<(QDebug dbg, const CoverInfo::LoadedImage& loadedImage) {
 }
 
 QDebug operator<<(QDebug dbg, const CoverArt& art) {
+    const QDebugStateSaver saver(dbg);
     dbg = dbg.maybeSpace() << "CoverArt";
     return dbg.nospace()
             << '{'

--- a/src/library/coverart.cpp
+++ b/src/library/coverart.cpp
@@ -85,7 +85,7 @@ QDebug operator<<(QDebug dbg, const CoverInfoRelative& infoRelative) {
 
 CoverInfo::LoadedImage CoverInfo::loadImage(
         const SecurityTokenPointer& pTrackLocationToken) const {
-    LoadedImage loadedImage;
+    LoadedImage loadedImage(LoadedImage::Result::ErrorUnknown);
     if (type == CoverInfo::METADATA) {
         VERIFY_OR_DEBUG_ASSERT(!trackLocation.isEmpty()) {
             loadedImage.result = LoadedImage::Result::ErrorMetadataWithEmptyTrackLocation;

--- a/src/library/coverart.h
+++ b/src/library/coverart.h
@@ -93,12 +93,9 @@ class CoverInfo : public CoverInfoRelative {
             ErrorRelativeFilePathWithEmptyTrackLocation,
             ErrorFilePathDoesNotExist,
             ErrorLoadingFailed, // if the image file is not readable or the format is not supported
-            ErrorUnknown,
+            ErrorUnknown,       // should never happen
         };
 
-        LoadedImage()
-                : result(Result::ErrorUnknown) {
-        }
         LoadedImage(const LoadedImage&) = default;
         LoadedImage(LoadedImage&&) = default;
         LoadedImage& operator=(const LoadedImage&) = default;
@@ -113,6 +110,13 @@ class CoverInfo : public CoverInfoRelative {
 
         /// The result of the operation.
         Result result;
+
+      private:
+        friend class CoverArt;
+        friend class CoverInfo;
+        LoadedImage(Result result)
+                : result(result) {
+        }
     };
     LoadedImage loadImage(
             const SecurityTokenPointer& pTrackLocationToken = SecurityTokenPointer()) const;
@@ -138,7 +142,8 @@ QDebug operator<<(QDebug dbg, const CoverInfo::LoadedImage& loadedImage);
 class CoverArt : public CoverInfo {
   public:
     CoverArt()
-        : resizedToWidth(0) {
+            : loadedImage(LoadedImage::Result::NoImage), // not loaded = no image
+              resizedToWidth(0) {
     }
     CoverArt(
             const CoverInfo&& base,

--- a/src/library/coverart.h
+++ b/src/library/coverart.h
@@ -85,7 +85,36 @@ class CoverInfo : public CoverInfoRelative {
     CoverInfo(CoverInfo&&) = default;
     CoverInfo& operator=(CoverInfo&&) = default;
 
-    QImage loadImage(
+    struct LoadedImage final {
+        enum class Result {
+            Ok,
+            NoImage,
+            ErrorMetadataWithEmptyTrackLocation,
+            ErrorRelativeFilePathWithEmptyTrackLocation,
+            ErrorFilePathDoesNotExist,
+            ErrorLoadingFailed, // if the image file is not readable or the format is not supported
+            ErrorUnknown,
+        };
+
+        LoadedImage()
+                : result(Result::ErrorUnknown) {
+        }
+        LoadedImage(const LoadedImage&) = default;
+        LoadedImage(LoadedImage&&) = default;
+        LoadedImage& operator=(const LoadedImage&) = default;
+        LoadedImage& operator=(LoadedImage&&) = default;
+
+        /// The loaded image if available.
+        QImage image;
+
+        /// Either the track location if the image was embedded in
+        /// the metadata or the (absolute) path of the image file.
+        QString filePath;
+
+        /// The result of the operation.
+        Result result;
+    };
+    LoadedImage loadImage(
             const SecurityTokenPointer& pTrackLocationToken = SecurityTokenPointer()) const;
 
     // Verify the image hash and update it if necessary.
@@ -103,16 +132,21 @@ bool operator==(const CoverInfo& a, const CoverInfo& b);
 bool operator!=(const CoverInfo& a, const CoverInfo& b);
 QDebug operator<<(QDebug dbg, const CoverInfo& info);
 
+QDebug operator<<(QDebug dbg, const CoverInfo::LoadedImage::Result& result);
+QDebug operator<<(QDebug dbg, const CoverInfo::LoadedImage& loadedImage);
+
 class CoverArt : public CoverInfo {
   public:
     CoverArt()
         : resizedToWidth(0) {
     }
-
-    CoverArt(const CoverInfo& base, const QImage& img, int rtw)
-        : CoverInfo(base),
-          image(img),
-          resizedToWidth(rtw) {
+    CoverArt(
+            const CoverInfo&& base,
+            CoverInfo::LoadedImage&& loadedImage,
+            int resizedToWidth)
+            : CoverInfo(std::move(base)),
+              loadedImage(std::move(loadedImage)),
+              resizedToWidth(resizedToWidth) {
     }
 
     // all-default memory management
@@ -123,7 +157,7 @@ class CoverArt : public CoverInfo {
 
     // it is not a QPixmap, because it is not safe to use pixmaps
     // outside the GUI thread
-    QImage image;
+    CoverInfo::LoadedImage loadedImage;
     int resizedToWidth;
 };
 

--- a/src/library/coverartcache.cpp
+++ b/src/library/coverartcache.cpp
@@ -252,7 +252,9 @@ void CoverArtCache::coverLoaded() {
                 !m_filePathLoadImageFailed.contains(res.coverArt.loadedImage.filePath)) {
             kLogger.warning()
                     << "Failed to load cover art image"
-                    << res.coverArt.loadedImage;
+                    << res.coverArt.loadedImage
+                    << "for track"
+                    << res.coverArt.trackLocation;
         }
         if (!res.coverArt.loadedImage.filePath.isEmpty()) {
             m_filePathLoadImageFailed.insert(res.coverArt.loadedImage.filePath);

--- a/src/library/coverartcache.h
+++ b/src/library/coverartcache.h
@@ -65,7 +65,7 @@ class CoverArtCache : public QObject, public Singleton<CoverArtCache> {
         quint16 requestedHash;
         bool signalWhenDone;
 
-        CoverArt cover;
+        CoverArt coverArt;
         bool coverInfoUpdated;
     };
     // Load cover from path indicated in coverInfo. WARNING: This is run in a
@@ -107,7 +107,8 @@ class CoverArtCache : public QObject, public Singleton<CoverArtCache> {
             int desiredWidth,
             Loading loading);
 
-    QSet<QPair<const QObject*, quint16> > m_runningRequests;
+    QSet<QPair<const QObject*, quint16>> m_runningRequests;
+    QSet<QString> m_filePathLoadImageFailed;
 };
 
 inline

--- a/src/library/coverartcache.h
+++ b/src/library/coverartcache.h
@@ -108,7 +108,6 @@ class CoverArtCache : public QObject, public Singleton<CoverArtCache> {
             Loading loading);
 
     QSet<QPair<const QObject*, quint16>> m_runningRequests;
-    QSet<QString> m_filePathLoadImageFailed;
 };
 
 inline

--- a/src/test/coverartcache_test.cpp
+++ b/src/test/coverartcache_test.cpp
@@ -33,20 +33,20 @@ class CoverArtCacheTest : public LibraryTest, public CoverArtCache {
     }
 
     void loadCoverFromFile(QString trackLocation, QString coverLocation, QString absoluteCoverLocation) {
-        QImage img = QImage(absoluteCoverLocation);
+        const QImage img = QImage(absoluteCoverLocation);
+        ASSERT_FALSE(img.isNull());
 
         CoverInfo info;
         info.type = CoverInfo::FILE;
         info.source = CoverInfo::GUESSED;
         info.coverLocation = coverLocation;
         info.trackLocation = trackLocation;
-        info.hash = 39287; // actual cover image hash!
 
         CoverArtCache::FutureResult res;
         res = CoverArtCache::loadCover(nullptr, TrackPointer(), info, 0, false);
-        EXPECT_TRUE(res.coverInfoUpdated);
+        EXPECT_TRUE(res.coverInfoUpdated); // hash updated
         EXPECT_EQ(img, res.coverArt.loadedImage.image);
-        EXPECT_EQ(info.hash, res.coverArt.hash);
+        EXPECT_EQ(CoverImageUtils::calculateHash(img), res.coverArt.hash);
         EXPECT_QSTRING_EQ(info.coverLocation, res.coverArt.coverLocation);
     }
 };

--- a/src/test/coverartcache_test.cpp
+++ b/src/test/coverartcache_test.cpp
@@ -20,8 +20,8 @@ class CoverArtCacheTest : public LibraryTest, public CoverArtCache {
 
         CoverArtCache::FutureResult res;
         res = CoverArtCache::loadCover(nullptr, TrackPointer(), info, 0, false);
-        EXPECT_QSTRING_EQ(QString(), res.cover.coverLocation);
-        EXPECT_TRUE(CoverImageUtils::isValidHash(res.cover.hash));
+        EXPECT_QSTRING_EQ(QString(), res.coverArt.coverLocation);
+        EXPECT_TRUE(CoverImageUtils::isValidHash(res.coverArt.hash));
         EXPECT_TRUE(res.coverInfoUpdated);
 
         SecurityTokenPointer securityToken =
@@ -29,7 +29,7 @@ class CoverArtCacheTest : public LibraryTest, public CoverArtCache {
         QImage img = SoundSourceProxy::importTemporaryCoverImage(
                 trackLocation, securityToken);
         EXPECT_FALSE(img.isNull());
-        EXPECT_EQ(img, res.cover.image);
+        EXPECT_EQ(img, res.coverArt.loadedImage.image);
     }
 
     void loadCoverFromFile(QString trackLocation, QString coverLocation, QString absoluteCoverLocation) {
@@ -44,10 +44,10 @@ class CoverArtCacheTest : public LibraryTest, public CoverArtCache {
 
         CoverArtCache::FutureResult res;
         res = CoverArtCache::loadCover(nullptr, TrackPointer(), info, 0, false);
-        EXPECT_QSTRING_EQ(info.coverLocation, res.cover.coverLocation);
-        EXPECT_EQ(info.hash, res.cover.hash);
-        EXPECT_FALSE(img.isNull());
-        EXPECT_EQ(img, res.cover.image);
+        EXPECT_TRUE(res.coverInfoUpdated);
+        EXPECT_EQ(img, res.coverArt.loadedImage.image);
+        EXPECT_EQ(info.hash, res.coverArt.hash);
+        EXPECT_QSTRING_EQ(info.coverLocation, res.coverArt.coverLocation);
     }
 };
 

--- a/src/test/coverartutils_test.cpp
+++ b/src/test/coverartutils_test.cpp
@@ -142,7 +142,7 @@ TEST_F(CoverArtUtilTest, searchImage) {
     // stuff below.
 
     result.trackLocation = kTrackLocationTest;
-    const QImage img = result.loadImage();
+    const QImage img = result.loadImage().image;
     EXPECT_EQ(img.isNull(), false);
 
     QString trackBaseName = "cover-test";


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/mixxx/+bug/1879160 without suppressing warnings. The actual issues are already fixed, but currently we don't notice when loading a cover image fails.

Solution: Forward the results of loading cover images to CoverArtCache instead of logging failures directly. In CoverArtCache we are able to detect failed attempts and log the warning for each file path only once per session.

@Holzhaus This PR causes merge conflicts with #2524 which needs to be rebased afterwards. I have already resolved most of them by cherry-picking the initial commit from this PR.