### PR TITLE
Added a clang_format.py to check the whole PR on CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,7 @@ repos:
   hooks:
   - id: clang-format
     name: clang-format
-    entry: git clang-format
+    entry: ./tools/clang_format.py
     require_serial: true
     stages:
     - commit

--- a/tools/clang_format.py
+++ b/tools/clang_format.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import argparse
+import logging
+import os
+import subprocess
+import typing
+
+
+def main(argv: typing.Optional[typing.List[str]] = None) -> int:
+    logging.basicConfig()
+    logger = logging.getLogger(__name__)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("files", nargs="*", help="only check these files")
+    args = parser.parse_args(argv)
+
+    cmd = ["git-clang-format"]
+
+    source_commit = os.environ.get("PRE_COMMIT_SOURCE")
+    if source_commit:
+        cmd += [source_commit]
+
+    # Filter filenames
+    rootdir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
+    if args.files:
+        files = [
+            os.path.abspath(os.path.join(rootdir, filename))
+            for filename in args.files
+        ]
+
+        cmd += ["--"]
+        cmd += files
+
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    try:
+        proc.check_returncode()
+    except subprocess.CalledProcessError:
+        logger.error(
+            "Error while executing command %s: %s", cmd, proc.stderr,
+        )
+        return 1
+    if proc.stderr:
+        print(proc.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/tools/line_length.py
+++ b/tools/line_length.py
@@ -26,11 +26,12 @@ FileLines = typing.NamedTuple(
 
 
 def get_git_added_lines() -> LineGenerator:
-    proc = subprocess.run(
-        ["git", "diff", "--cached", "--unified=0"],
-        capture_output=True,
-        text=True,
-    )
+    cmd = ["git", "diff", "--cached", "--unified=0"]
+    source_commit = os.environ.get("PRE_COMMIT_SOURCE")
+    if source_commit:
+        cmd += [source_commit]
+    source_commit = os.environ.get("PRE_COMMIT_SOURCE")
+    proc = subprocess.run(cmd, capture_output=True, text=True,)
     proc.check_returncode()
     current_file = None
     current_lineno = None
@@ -92,14 +93,9 @@ def main(argv: typing.Optional[typing.List[str]] = None) -> int:
     logging.basicConfig()
     logger = logging.getLogger(__name__)
 
-    import sys
-
-    print(sys.argv)
-
     parser = argparse.ArgumentParser()
     parser.add_argument("files", nargs="*", help="only check these files")
     args = parser.parse_args(argv)
-    print(args)
 
     all_lines = get_git_added_lines()
 


### PR DESCRIPTION
This fixes the issue that the pre-commit hook test on Travis successes even if there are pending clang-format issues. 
This was due to not check the files and the PRE_COMMIT_SOURCE environment variable. 
This PR fixes this.   