### PR TITLE
Speed up beat detection for 48 kHz 96 kHz Tracks  

### DIFF
--- a/src/analyzer/plugins/analyzerqueenmarybeats.cpp
+++ b/src/analyzer/plugins/analyzerqueenmarybeats.cpp
@@ -10,12 +10,14 @@
 namespace mixxx {
 namespace {
 
-// This sets the resolution of the resulting BeatMap.
-// ~12 ms (86 Hz) is a fair compromise between accuracy and analysis speed.
-// These are the preferred window/step sizes from the BeatTrack VAMP
-// With a 44.1 kHz Track we go in 512 Sample Steps
-// TODO: The waveform sample rate of 441 (defined in AnalyzerWaveform::initialize)
-// is at an odd factor of 441 * 0.01161 = 5.12 producing visual jitter.
+// This determines the resolution of the resulting BeatMap.
+// ~12 ms (86 Hz) is a fair compromise between accuracy and analysis speed,
+// also matching the preferred window/step sizes from BeatTrack VAMP.
+// For a 44.1 kHz track, we go in 512 sample steps
+// TODO: kStepSecs and the waveform sample rate of 441
+// (defined in AnalyzerWaveform::initialize) do not align well and thus
+// generate interference. Currently we are at this odd factor: 441 * 0.01161 = 5.12.
+// This should be adjusted to be an integer.
 constexpr float kStepSecs = 0.01161;
 // results in 43 Hz @ 44.1 kHz / 47 Hz @ 48 kHz / 47 Hz @ 96 kHz
 constexpr int kMaximumBinSizeHz = 50; // Hz

--- a/src/analyzer/plugins/analyzerqueenmarybeats.cpp
+++ b/src/analyzer/plugins/analyzerqueenmarybeats.cpp
@@ -14,7 +14,8 @@ namespace {
 // ~12 ms (86 Hz) is a fair compromise between accuracy and analysis speed.
 // These are the preferred window/step sizes from the BeatTrack VAMP
 // With a 44.1 kHz Track we go in 512 Sample Steps
-// TODO: The waveform sample rate of 441 is at an odd factor of 5.12 producing visual jitter.
+// TODO: The waveform sample rate of 441 (defined in AnalyzerWaveform::initialize)
+// is at an odd factor of 441 * 0.01161 = 5.12 producing visual jitter.
 constexpr float kStepSecs = 0.01161;
 // results in 43 Hz @ 44.1 kHz / 47 Hz @ 48 kHz / 47 Hz @ 96 kHz
 constexpr int kMaximimBinSizeHz = 50; // Hz

--- a/src/analyzer/plugins/analyzerqueenmarybeats.cpp
+++ b/src/analyzer/plugins/analyzerqueenmarybeats.cpp
@@ -18,7 +18,7 @@ namespace {
 // is at an odd factor of 441 * 0.01161 = 5.12 producing visual jitter.
 constexpr float kStepSecs = 0.01161;
 // results in 43 Hz @ 44.1 kHz / 47 Hz @ 48 kHz / 47 Hz @ 96 kHz
-constexpr int kMaximimBinSizeHz = 50; // Hz
+constexpr int kMaximumBinSizeHz = 50; // Hz
 
 DFConfig makeDetectionFunctionConfig(int stepSize, int windowSize) {
     // These are the defaults for the VAMP beat tracker plugin we used in Mixxx
@@ -49,7 +49,7 @@ bool AnalyzerQueenMaryBeats::initialize(int samplerate) {
     m_detectionResults.clear();
     m_iSampleRate = samplerate;
     m_stepSize = m_iSampleRate * kStepSecs;
-    m_windowSize = MathUtilities::nextPowerOfTwo(m_iSampleRate / kMaximimBinSizeHz);
+    m_windowSize = MathUtilities::nextPowerOfTwo(m_iSampleRate / kMaximumBinSizeHz);
     m_pDetectionFunction = std::make_unique<DetectionFunction>(
             makeDetectionFunctionConfig(m_stepSize, m_windowSize));
     qDebug() << "input sample rate is " << m_iSampleRate << ", step size is " << m_stepSize;


### PR DESCRIPTION
Make use of MathUtilities::nextPowerOfTwo() to calculate a valid window size
This fixes the slow beat analysis for 48 and 96 kHz tracks, https://bugs.launchpad.net/mixxx/+bug/1879588