### PR TITLE
make use of override in more places

### DIFF
--- a/src/broadcast/broadcastmanager.h
+++ b/src/broadcast/broadcastmanager.h
@@ -24,7 +24,7 @@ class BroadcastManager : public QObject {
 
     BroadcastManager(SettingsManager* pSettingsManager,
                      SoundManager* pSoundManager);
-    virtual ~BroadcastManager();
+    ~BroadcastManager() override;
 
     // Returns true if the broadcast connection is enabled. Note this only
     // indicates whether the connection is enabled, not whether it is connected.

--- a/src/encoder/encoder.h
+++ b/src/encoder/encoder.h
@@ -29,7 +29,7 @@ class Encoder {
         };
 
     Encoder() {}
-    virtual ~Encoder() {}
+    virtual ~Encoder() = default;
 
     virtual int initEncoder(int samplerate, QString errorMessage) = 0;
     // encodes the provided buffer of audio.
@@ -56,7 +56,7 @@ class EncoderFactory {
     Encoder::Format getFormatFor(QString format) const;
     EncoderPointer createRecordingEncoder(
             Encoder::Format format,
-            UserSettingsPointer pConfig, 
+            UserSettingsPointer pConfig,
             EncoderCallback* pCallback) const;
     EncoderPointer createEncoder(
             EncoderSettingsPointer pSettings,

--- a/src/encoder/encoderflacsettings.cpp
+++ b/src/encoder/encoderflacsettings.cpp
@@ -14,7 +14,6 @@ const int EncoderFlacSettings::DEFAULT_QUALITY_VALUE = 5;
 const QString EncoderFlacSettings::BITS_GROUP = "FLAC_BITS";
 const QString EncoderFlacSettings::GROUP_COMPRESSION = "FLAC_COMPRESSION";
 
- 
 EncoderFlacSettings::EncoderFlacSettings(UserSettingsPointer pConfig)
 {
     m_pConfig = pConfig;
@@ -23,7 +22,7 @@ EncoderFlacSettings::EncoderFlacSettings(UserSettingsPointer pConfig)
     names.append(QObject::tr("16 bits"));
     names.append(QObject::tr("24 bits"));
     m_radioList.append(OptionsGroup(QObject::tr("Bit depth"), BITS_GROUP, names));
-    
+
     m_qualList.append(0);
     m_qualList.append(1);
     m_qualList.append(2);
@@ -33,10 +32,6 @@ EncoderFlacSettings::EncoderFlacSettings(UserSettingsPointer pConfig)
     m_qualList.append(6);
     m_qualList.append(7);
     m_qualList.append(8);
-}
-EncoderFlacSettings::~EncoderFlacSettings()
-{
-    
 }
 
 bool EncoderFlacSettings::usesCompressionSlider() const
@@ -64,11 +59,11 @@ void EncoderFlacSettings::setCompression(int compression) {
 }
 int EncoderFlacSettings::getCompression() const
 {
-    int value = m_pConfig->getValue(ConfigKey(RECORDING_PREF_KEY, GROUP_COMPRESSION), 
-        DEFAULT_QUALITY_VALUE);
+    int value = m_pConfig->getValue(ConfigKey(RECORDING_PREF_KEY, GROUP_COMPRESSION),
+            DEFAULT_QUALITY_VALUE);
     if (!m_qualList.contains(value)) {
-        qWarning() << "Value saved for compression on preferences is out of range " 
-            << value << ". Returning default compression";
+        qWarning() << "Value saved for compression on preferences is out of range "
+                   << value << ". Returning default compression";
         value=DEFAULT_QUALITY_VALUE;
     }
     return value;
@@ -81,10 +76,9 @@ QList<EncoderSettings::OptionsGroup> EncoderFlacSettings::getOptionGroups() cons
     return m_radioList;
 }
 
-// Selects the option by its index. If it is a single-element option, 
+// Selects the option by its index. If it is a single-element option,
 // index 0 means disabled and 1 enabled.
-void EncoderFlacSettings::setGroupOption(QString groupCode, int optionIndex) 
-{
+void EncoderFlacSettings::setGroupOption(QString groupCode, int optionIndex) {
     bool found=false;
     for (const auto& group : m_radioList) {
         if (groupCode == group.groupCode) {
@@ -93,8 +87,8 @@ void EncoderFlacSettings::setGroupOption(QString groupCode, int optionIndex)
                 m_pConfig->set(ConfigKey(RECORDING_PREF_KEY, groupCode),
                     ConfigValue(optionIndex));
             } else {
-                qWarning() << "Received an index out of range for: " 
-                    << groupCode << ", index: " << optionIndex;
+                qWarning() << "Received an index out of range for: "
+                           << groupCode << ", index: " << optionIndex;
             }
         }
     }
@@ -102,18 +96,18 @@ void EncoderFlacSettings::setGroupOption(QString groupCode, int optionIndex)
         qWarning() << "Received an unknown groupCode on setGroupOption: " << groupCode;
     }
 }
-// Return the selected option of the group. If it is a single-element option, 
+// Return the selected option of the group. If it is a single-element option,
 // 0 means disabled and 1 enabled.
-int EncoderFlacSettings::getSelectedOption(QString groupCode) const 
-{
+int EncoderFlacSettings::getSelectedOption(QString groupCode) const {
     bool found=false;
     int value = m_pConfig->getValue(ConfigKey(RECORDING_PREF_KEY, groupCode), 0);
     for (const auto&  group : m_radioList) {
         if (groupCode == group.groupCode) {
             found=true;
             if (value >= group.controlNames.size() && value > 1) {
-                qWarning() << "Value saved for " << groupCode << 
-                    " on preferences is out of range " << value << ". Returning 0";
+                qWarning() << "Value saved for " << groupCode
+                           << " on preferences is out of range " << value
+                           << ". Returning 0";
                 value=0;
             }
         }

--- a/src/encoder/encoderflacsettings.h
+++ b/src/encoder/encoderflacsettings.h
@@ -15,7 +15,7 @@
 class EncoderFlacSettings : public EncoderRecordingSettings {
   public:
     EncoderFlacSettings(UserSettingsPointer pConfig);
-    virtual ~EncoderFlacSettings();
+    ~EncoderFlacSettings() override = default;
 
     // Indicates that it uses the compression slider section of the preferences
     bool usesCompressionSlider() const override;
@@ -27,10 +27,10 @@ class EncoderFlacSettings : public EncoderRecordingSettings {
     virtual int getCompression() const override;
     // Returns the list of radio options to show to the user
     QList<OptionsGroup> getOptionGroups() const override;
-    // Selects the option by its index. If it is a single-element option, 
+    // Selects the option by its index. If it is a single-element option,
     // index 0 means disabled and 1 enabled.
     void setGroupOption(QString groupCode, int optionIndex) override;
-    // Return the selected option of the group. If it is a single-element option, 
+    // Return the selected option of the group. If it is a single-element option,
     // 0 means disabled and 1 enabled.
     int getSelectedOption(QString groupCode) const override;
 
@@ -49,4 +49,3 @@ class EncoderFlacSettings : public EncoderRecordingSettings {
 };
 
 #endif // ENCODERFLACSETTINGS_H
-

--- a/src/encoder/encodermp3.h
+++ b/src/encoder/encodermp3.h
@@ -13,7 +13,7 @@ class EncoderMp3 final : public Encoder {
     static const int MONO_VBR_OFFSET;
 
     EncoderMp3(EncoderCallback* callback=nullptr);
-    virtual ~EncoderMp3();
+    ~EncoderMp3() override;
 
     int initEncoder(int samplerate, QString errorMessage) override;
     void encodeBuffer(const CSAMPLE *samples, const int size) override;

--- a/src/encoder/encodermp3settings.cpp
+++ b/src/encoder/encodermp3settings.cpp
@@ -40,18 +40,13 @@ EncoderMp3Settings::EncoderMp3Settings(UserSettingsPointer pConfig) :
     m_qualVBRList.append(200);// V2
     m_qualVBRList.append(240);// V1
     m_qualVBRList.append(260);// V0
-    
+
     QList<QString> vbrmodes;
     vbrmodes.append("CBR");
     vbrmodes.append("ABR");
     vbrmodes.append("VBR");
     m_radioList.append(OptionsGroup(QObject::tr("Bitrate Mode"), ENCODING_MODE_GROUP, vbrmodes));
 }
-EncoderMp3Settings::~EncoderMp3Settings()
-{
-    
-}
-
 
 QList<int> EncoderMp3Settings::getQualityValues() const
 {
@@ -68,8 +63,8 @@ void EncoderMp3Settings::setQualityByIndex(int qualityIndex)
     if (qualityIndex >= 0 && qualityIndex < m_qualList.size()) {
         m_pConfig->set(ConfigKey(RECORDING_PREF_KEY, "MP3_Quality"), ConfigValue(qualityIndex));
     } else {
-        qWarning() << "Invalid qualityIndex given to EncoderMp3Settings: " 
-            << qualityIndex << ". Ignoring it";
+        qWarning() << "Invalid qualityIndex given to EncoderMp3Settings: "
+                   << qualityIndex << ". Ignoring it";
     }
 }
 
@@ -85,9 +80,9 @@ int EncoderMp3Settings::getQualityIndex() const
         return qualityIndex;
     }
     else {
-        qWarning() << "Invalid qualityIndex in EncoderMp3Settings" 
-            << qualityIndex << "(Max is:" << m_qualList.size() << "). Ignoring it"
-            << "and returning default, which is:" << DEFAULT_BITRATE_INDEX;
+        qWarning() << "Invalid qualityIndex in EncoderMp3Settings"
+                   << qualityIndex << "(Max is:" << m_qualList.size() << "). Ignoring it"
+                   << "and returning default, which is:" << DEFAULT_BITRATE_INDEX;
     }
     return DEFAULT_BITRATE_INDEX;
 }
@@ -95,9 +90,9 @@ int EncoderMp3Settings::getQualityIndex() const
 // Returns the list of radio options to show to the user
 QList<EncoderSettings::OptionsGroup> EncoderMp3Settings::getOptionGroups() const
 {
-    return m_radioList;    
+    return m_radioList;
 }
-// Selects the option by its index. If it is a single-element option, 
+// Selects the option by its index. If it is a single-element option,
 // index 0 means disabled and 1 enabled.
 void EncoderMp3Settings::setGroupOption(QString groupCode, int optionIndex)
 {
@@ -109,8 +104,8 @@ void EncoderMp3Settings::setGroupOption(QString groupCode, int optionIndex)
                 m_pConfig->set(ConfigKey(RECORDING_PREF_KEY, ENCODING_MODE_GROUP),
                     ConfigValue(optionIndex));
             } else {
-                qWarning() << "Received an index out of range for: " 
-                    << groupCode << ", index: " << optionIndex;
+                qWarning() << "Received an index out of range for: "
+                           << groupCode << ", index: " << optionIndex;
             }
         }
     }
@@ -118,7 +113,7 @@ void EncoderMp3Settings::setGroupOption(QString groupCode, int optionIndex)
         qWarning() << "Received an unknown groupCode on setGroupOption: " << groupCode;
     }
 }
-// Return the selected option of the group. If it is a single-element option, 
+// Return the selected option of the group. If it is a single-element option,
 // 0 means disabled and 1 enabled.
 int EncoderMp3Settings::getSelectedOption(QString groupCode) const
 {
@@ -129,8 +124,9 @@ int EncoderMp3Settings::getSelectedOption(QString groupCode) const
         if (groupCode == group.groupCode) {
             found=true;
             if (value >= group.controlNames.size() && value > 1) {
-                qWarning() << "Value saved for " << groupCode << 
-                    " on preferences is out of range " << value << ". Returning 0";
+                qWarning() << "Value saved for " << groupCode
+                           << " on preferences is out of range " << value
+                           << ". Returning 0";
                 value=0;
             }
         }

--- a/src/encoder/encodermp3settings.h
+++ b/src/encoder/encodermp3settings.h
@@ -15,7 +15,7 @@
 class EncoderMp3Settings : public EncoderRecordingSettings {
   public:
     EncoderMp3Settings(UserSettingsPointer m_pConfig);
-    virtual ~EncoderMp3Settings();
+    ~EncoderMp3Settings() override = default;
 
     // Indicates that it uses the quality slider section of the preferences
     bool usesQualitySlider() const override {
@@ -31,10 +31,10 @@ class EncoderMp3Settings : public EncoderRecordingSettings {
     int getQualityIndex() const override;
     // Returns the list of radio options to show to the user
     QList<OptionsGroup> getOptionGroups() const override;
-    // Selects the option by its index. If it is a single-element option, 
+    // Selects the option by its index. If it is a single-element option,
     // index 0 means disabled and 1 enabled.
     void setGroupOption(QString groupCode, int optionIndex) override;
-    // Return the selected option of the group. If it is a single-element option, 
+    // Return the selected option of the group. If it is a single-element option,
     // 0 means disabled and 1 enabled.
     int getSelectedOption(QString groupCode) const override;
 

--- a/src/encoder/encoderopussettings.h
+++ b/src/encoder/encoderopussettings.h
@@ -16,7 +16,6 @@
 class EncoderOpusSettings: public EncoderRecordingSettings {
   public:
     explicit EncoderOpusSettings(UserSettingsPointer pConfig);
-    ~EncoderOpusSettings() override = default;
 
     // Indicates that it uses the quality slider section of the preferences
     bool usesQualitySlider() const override {

--- a/src/encoder/encoderrecordingsettings.h
+++ b/src/encoder/encoderrecordingsettings.h
@@ -5,8 +5,6 @@
 
 class EncoderRecordingSettings : public EncoderSettings {
   public:
-    ~EncoderRecordingSettings() override = default;
-
     // Indicates that it uses the quality slider section of the preferences
     virtual bool usesQualitySlider() const {
         return false;
@@ -28,7 +26,7 @@ class EncoderRecordingSettings : public EncoderSettings {
         DEBUG_ASSERT(!"unimplemented");
     }
 
-    // Selects the option by its index. If it is a single-element option, 
+    // Selects the option by its index. If it is a single-element option,
     // index 0 means disabled and 1 enabled.
     virtual void setGroupOption(QString groupCode, int optionIndex) {
         Q_UNUSED(groupCode);
@@ -38,4 +36,3 @@ class EncoderRecordingSettings : public EncoderSettings {
 };
 
 typedef std::shared_ptr<EncoderRecordingSettings> EncoderRecordingSettingsPointer;
-

--- a/src/encoder/encodersndfileflac.cpp
+++ b/src/encoder/encodersndfileflac.cpp
@@ -15,9 +15,6 @@ EncoderSndfileFlac::EncoderSndfileFlac(EncoderCallback* pCallback)
     :EncoderWave(pCallback) {
 }
 
-EncoderSndfileFlac::~EncoderSndfileFlac() {
-}
-
 void EncoderSndfileFlac::setEncoderSettings(const EncoderSettings& settings)
 {
     m_sfInfo.format = SF_FORMAT_FLAC;
@@ -32,11 +29,11 @@ void EncoderSndfileFlac::setEncoderSettings(const EncoderSettings& settings)
             break;
         default:
             m_sfInfo.format |= SF_FORMAT_PCM_16;
-            qWarning() << " Unexpected radio index on setEncoderSettings: " 
-                    << radio << ". reverting to Flac 16bits";
+            qWarning() << " Unexpected radio index on setEncoderSettings: "
+                       << radio << ". reverting to Flac 16bits";
             break;
     }
-    
+
     m_compression = static_cast<double>(settings.getCompression()) / 8.0;
 }
 

--- a/src/encoder/encodersndfileflac.h
+++ b/src/encoder/encodersndfileflac.h
@@ -27,11 +27,11 @@ class EncoderCallback;
 
 class EncoderSndfileFlac : public EncoderWave {
   public:
-    EncoderSndfileFlac(EncoderCallback* pCallback=nullptr);
-    virtual ~EncoderSndfileFlac();
+    EncoderSndfileFlac(EncoderCallback* pCallback = nullptr);
+    ~EncoderSndfileFlac() override = default;
 
     void setEncoderSettings(const EncoderSettings& settings) override;
-    
+
   protected:
     void initStream() override;
   private:

--- a/src/encoder/encodervorbis.h
+++ b/src/encoder/encodervorbis.h
@@ -22,9 +22,9 @@ class EncoderCallback;
 class EncoderVorbis : public Encoder {
   public:
     static const int MONO_BITRATE_THRESHOLD;
-  
-    EncoderVorbis(EncoderCallback* pCallback=nullptr);
-    virtual ~EncoderVorbis();
+
+    EncoderVorbis(EncoderCallback* pCallback = nullptr);
+    ~EncoderVorbis() override;
 
     int initEncoder(int samplerate, QString errorMessage) override;
     void encodeBuffer(const CSAMPLE *samples, const int size) override;

--- a/src/encoder/encodervorbissettings.cpp
+++ b/src/encoder/encodervorbissettings.cpp
@@ -27,11 +27,6 @@ EncoderVorbisSettings::EncoderVorbisSettings(UserSettingsPointer pConfig) :
     m_qualList.append(256);
     m_qualList.append(320);
 }
-EncoderVorbisSettings::~EncoderVorbisSettings()
-{
-    
-}
-
 
 QList<int> EncoderVorbisSettings::getQualityValues() const
 {
@@ -43,8 +38,8 @@ void EncoderVorbisSettings::setQualityByIndex(int qualityIndex)
     if (qualityIndex >= 0 && qualityIndex < m_qualList.size()) {
         m_pConfig->setValue<int>(ConfigKey(RECORDING_PREF_KEY, "OGG_Quality"), qualityIndex);
     } else {
-        qWarning() << "Invalid qualityIndex given to EncoderVorbisSettings: " 
-            << qualityIndex << ". Ignoring it";
+        qWarning() << "Invalid qualityIndex given to EncoderVorbisSettings: "
+                   << qualityIndex << ". Ignoring it";
     }
 }
 
@@ -69,9 +64,9 @@ int EncoderVorbisSettings::getQualityIndex() const
         return qualityIndex;
     }
     else {
-        qWarning() << "Invalid qualityIndex in EncoderVorbisSettings " 
-            << qualityIndex << "(Max is:" << m_qualList.size() << ") . Ignoring it and"
-            << "returning default which is" << DEFAULT_BITRATE_INDEX;
+        qWarning() << "Invalid qualityIndex in EncoderVorbisSettings "
+                   << qualityIndex << "(Max is:" << m_qualList.size() << ") . Ignoring it and"
+                   << "returning default which is" << DEFAULT_BITRATE_INDEX;
         return DEFAULT_BITRATE_INDEX;
     }
 }

--- a/src/encoder/encodervorbissettings.h
+++ b/src/encoder/encodervorbissettings.h
@@ -15,7 +15,7 @@
 class EncoderVorbisSettings : public EncoderRecordingSettings {
     public:
     EncoderVorbisSettings(UserSettingsPointer pConfig);
-    virtual ~EncoderVorbisSettings();
+    ~EncoderVorbisSettings() override = default;
 
     // Indicates that it uses the quality slider section of the preferences
     bool usesQualitySlider() const override {

--- a/src/encoder/encoderwave.h
+++ b/src/encoder/encoderwave.h
@@ -26,8 +26,8 @@ class EncoderCallback;
 
 class EncoderWave : public Encoder {
   public:
-    EncoderWave(EncoderCallback* pCallback=nullptr);
-    virtual ~EncoderWave();
+    EncoderWave(EncoderCallback* pCallback = nullptr);
+    ~EncoderWave() override;
 
     int initEncoder(int samplerate, QString errorMessage) override;
     void encodeBuffer(const CSAMPLE *samples, const int size) override;

--- a/src/encoder/encoderwavesettings.cpp
+++ b/src/encoder/encoderwavesettings.cpp
@@ -7,7 +7,7 @@
 
  #include "encoder/encoderwavesettings.h"
  #include "recording/defs_recording.h"
- 
+
 const QString EncoderWaveSettings::BITS_GROUP = "BITS";
 
 EncoderWaveSettings::EncoderWaveSettings(UserSettingsPointer pConfig,
@@ -26,22 +26,15 @@ EncoderWaveSettings::EncoderWaveSettings(UserSettingsPointer pConfig,
     m_radioList.append(OptionsGroup(QObject::tr("Bit depth"), BITS_GROUP, names));
 }
 
-EncoderWaveSettings::~EncoderWaveSettings()
-{
-    
-}
-
-
 // Returns the list of radio options to show to the user
 QList<EncoderSettings::OptionsGroup> EncoderWaveSettings::getOptionGroups() const
 {
     return m_radioList;
 }
 
-// Selects the option by its index. If it is a single-element option, 
+// Selects the option by its index. If it is a single-element option,
 // index 0 means disabled and 1 enabled.
-void EncoderWaveSettings::setGroupOption(QString groupCode, int optionIndex) 
-{
+void EncoderWaveSettings::setGroupOption(QString groupCode, int optionIndex) {
     bool found=false;
     for (const auto& group : m_radioList) {
         if (groupCode == group.groupCode) {
@@ -51,8 +44,8 @@ void EncoderWaveSettings::setGroupOption(QString groupCode, int optionIndex)
                         ConfigKey(RECORDING_PREF_KEY, m_format + "_" + groupCode),
                         ConfigValue(optionIndex));
             } else {
-                qWarning() << "Received an index out of range for: " 
-                    << groupCode << ", index: " << optionIndex;
+                qWarning() << "Received an index out of range for: "
+                           << groupCode << ", index: " << optionIndex;
             }
         }
     }
@@ -60,10 +53,9 @@ void EncoderWaveSettings::setGroupOption(QString groupCode, int optionIndex)
         qWarning() << "Received an unknown groupCode on setGroupOption: " << groupCode;
     }
 }
-// Return the selected option of the group. If it is a single-element option, 
+// Return the selected option of the group. If it is a single-element option,
 // 0 means disabled and 1 enabled.
-int EncoderWaveSettings::getSelectedOption(QString groupCode) const 
-{
+int EncoderWaveSettings::getSelectedOption(QString groupCode) const {
     bool found=false;
     int value = m_pConfig->getValue(
             ConfigKey(RECORDING_PREF_KEY, m_format + "_" + groupCode), 0);
@@ -71,8 +63,9 @@ int EncoderWaveSettings::getSelectedOption(QString groupCode) const
         if (groupCode == group.groupCode) {
             found=true;
             if (value >= group.controlNames.size() && value > 1) {
-                qWarning() << "Value saved for " << groupCode << 
-                    " on preferences is out of range " << value << ". Returning 0";
+                qWarning() << "Value saved for " << groupCode
+                           << " on preferences is out of range " << value
+                           << ". Returning 0";
                 value=0;
             }
         }

--- a/src/encoder/encoderwavesettings.h
+++ b/src/encoder/encoderwavesettings.h
@@ -15,14 +15,14 @@
 class EncoderWaveSettings : public EncoderRecordingSettings {
   public:
     EncoderWaveSettings(UserSettingsPointer pConfig, QString format);
-    virtual ~EncoderWaveSettings();
+    ~EncoderWaveSettings() override = default;
 
     // Returns the list of radio options to show to the user
     QList<OptionsGroup> getOptionGroups() const override;
-    // Selects the option by its index. If it is a single-element option, 
+    // Selects the option by its index. If it is a single-element option,
     // index 0 means disabled and 1 enabled.
     void setGroupOption(QString groupCode, int optionIndex) override;
-    // Return the selected option of the group. If it is a single-element option, 
+    // Return the selected option of the group. If it is a single-element option,
     // 0 means disabled and 1 enabled.
     int getSelectedOption(QString groupCode) const override;
 
@@ -30,7 +30,7 @@ class EncoderWaveSettings : public EncoderRecordingSettings {
     QString getFormat() const override{
         return m_format;
     }
-    
+
     static const QString BITS_GROUP;
   private:
     QList<OptionsGroup> m_radioList;

--- a/src/engine/sidechain/enginerecord.h
+++ b/src/engine/sidechain/enginerecord.h
@@ -24,7 +24,7 @@ class EngineRecord : public QObject, public EncoderCallback, public SideChainWor
     Q_OBJECT
   public:
     EngineRecord(UserSettingsPointer pConfig);
-    virtual ~EngineRecord();
+    ~EngineRecord() override;
 
     void process(const CSAMPLE* pBuffer, const int iBufferSize) override;
     void shutdown() override {}

--- a/src/recording/recordingmanager.h
+++ b/src/recording/recordingmanager.h
@@ -30,8 +30,7 @@ class RecordingManager : public QObject
     Q_OBJECT
   public:
     RecordingManager(UserSettingsPointer pConfig, EngineMaster* pEngine);
-    virtual ~RecordingManager();
-
+    ~RecordingManager() override;
 
     // This will try to start recording. If successful, slotIsRecording will be
     // called and a signal isRecording will be emitted.


### PR DESCRIPTION
clang format has with -wall the -Winconsistent-missing-override warning enabled.
This is a by-catch from my cmake optimize work. 
 