### PR TITLE
.travis.yml: Build packages on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ jobs:
         - cd cmake_build
         - cmake -L $CMAKEFLAGS $CMAKEFLAGS_EXTRA ..
         - cmake --build .
-        - sudo env "PATH=$PATH" cmake --build . --target install
+        - cpack -G DEB
       script:
         # Run tests and benchmarks
         - ctest
@@ -169,7 +169,7 @@ jobs:
         - cd cmake_build
         - cmake -L $CMAKEFLAGS $CMAKEFLAGS_EXTRA -DCMAKE_PREFIX_PATH=${MIXXX_ENVPATH} -DQt5_DIR=${QT_DIR} ..
         - cmake --build .
-        - sudo cmake --build . --target install
+        - cpack -G DragNDrop
       script:
         # Run tests and benchmarks
         - ctest


### PR DESCRIPTION
I have no idea if the DMG or DEB packages actually work, but we should make sure that packaging does not throw an error.

If we are able to reach @rryan we could deploy them somewhere so that Ubuntu and macOS users can test development snapshots without having to compile them themselves.