### PR TITLE
SoundManager: Prevent reconfiguring if num_decks unchanged

### DIFF
--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -682,6 +682,10 @@ void SoundManager::setJACKName() const {
 }
 
 void SoundManager::setConfiguredDeckCount(int count) {
+    if (getConfiguredDeckCount() == count) {
+        // Unchanged
+        return;
+    }
     m_config.setDeckCount(count);
     checkConfig();
     m_config.writeToDisk();


### PR DESCRIPTION
Setting the control "num_decks" in the controller shutdown hook crashes Mixxx 2.3, even if the number of decks is unchanged. Use case: Restore the original number of decks when disconnecting the controller (see: DenonMC6000MK2.shutdown).

This patch fixes the crash in the most common case that the number of decks does not need to be changed.