### PR TITLE
engine/sync/synccontrol: Fix re-syncing on play while holding cue

### DIFF
--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -134,6 +134,8 @@ class SyncControl : public EngineControl, public Syncable {
 
     // m_pBeats is written from an engine worker thread
     mixxx::BeatsPointer m_pBeats;
+
+    bool m_bPlaying;
 };
 
 


### PR DESCRIPTION
Partial fix for lp1879654. This makes holding CUE + user tweak + press play usable by avoiding a re-sync and hence fixes the issue described here: https://bugs.launchpad.net/mixxx/+bug/1879654/comments/2