### PR TITLE
Reset parented pointer when the menu is unset. 

### DIFF
--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -685,7 +685,8 @@ void MixxxMainWindow::finalize() {
         qWarning() << "Central widget was not deleted by our sendPostedEvents trick.";
     }
 
-    // TODO(rryan): WMainMenuBar holds references to controls so we need to delete it
+    // TODO() Verify if this comment still applies:
+    // WMainMenuBar holds references to controls so we need to delete it
     // before MixxxMainWindow is destroyed. QMainWindow calls deleteLater() in
     // setMenuBar() but we need to delete it now so we can ask for
     // DeferredDelete events to be processed for it. Once Mixxx shutdown lives
@@ -695,6 +696,8 @@ void MixxxMainWindow::finalize() {
 
     QPointer<WMainMenuBar> pMenuBar = m_pMenuBar.toWeakRef();
     DEBUG_ASSERT(menuBar() == m_pMenuBar.get());
+    // We need to reset the parented pointer here that it does not become a
+    // dangling pinter after the object has been deleted.
     m_pMenuBar = nullptr;
     setMenuBar(nullptr);
     if (!pMenuBar.isNull()) {

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -159,7 +159,6 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
 #endif
           m_pKeyboard(nullptr),
           m_pLibrary(nullptr),
-          m_pMenuBar(nullptr),
           m_pDeveloperToolsDlg(nullptr),
           m_pPrefDlg(nullptr),
           m_pKbdConfig(nullptr),
@@ -693,7 +692,10 @@ void MixxxMainWindow::finalize() {
     // outside of MixxxMainWindow the parent relationship will directly destroy
     // the WMainMenuBar and this will no longer be a problem.
     qDebug() << t.elapsed(false).debugMillisWithUnit() << "deleting menubar";
-    QPointer<QWidget> pMenuBar(menuBar());
+
+    QPointer<WMainMenuBar> pMenuBar = m_pMenuBar.toWeakRef();
+    DEBUG_ASSERT(menuBar() == m_pMenuBar.get());
+    m_pMenuBar = nullptr;
     setMenuBar(nullptr);
     if (!pMenuBar.isNull()) {
         QCoreApplication::sendPostedEvents(pMenuBar, QEvent::DeferredDelete);


### PR DESCRIPTION
This fixes a crash during shut down.

A regression since: 
https://github.com/mixxxdj/mixxx/pull/2792/commits/54f744f8e534bcb567dc78610367859354e7ba46