### PR TITLE
Remove false DEBUG_ASSERT fixing lp1881610

### DIFF
--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -737,8 +737,6 @@ TrackPointerList WTrackMenu::getTrackPointers(
     TrackPointerList trackPointers;
     trackPointers.reserve(m_trackIndexList.size());
     for (const auto& index : m_trackIndexList) {
-        DEBUG_ASSERT(maxSize < 0 ||
-                maxSize <= trackPointers.size());
         if (maxSize >= 0 && maxSize <= trackPointers.size()) {
             return trackPointers;
         }


### PR DESCRIPTION
The similar condition is checked one line below. The DEBUG_ASSERT has faied when calling this function with 1. It is obvious that the size is 0 during the first iteration. 