### PR TITLE
failed widget highlight: also print affectted widget's ObjectName

### DIFF
--- a/src/widget/controlwidgetconnection.cpp
+++ b/src/widget/controlwidgetconnection.cpp
@@ -124,7 +124,8 @@ void ControlWidgetPropertyConnection::slotControlValueChanged(double v) {
 
     if (!pWidget->setProperty(m_propertyName.constData(),parameter)) {
         qDebug() << "Setting property" << m_propertyName
-                << "to widget failed. Value:" << parameter;
+                 << "to widget" << pWidget->objectName()
+                 << "failed. Value:" << parameter;
     }
 
     // According to http://stackoverflow.com/a/3822243 this is the least


### PR DESCRIPTION
... to know from the log which widget is affected.

Side note:
the warning is also logged when the `highlight` connection actually works fine in the skin.