### PR TITLE
Enable secure credential storing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2180,7 +2180,7 @@ endif()
 
 # QtKeychain
 find_package(Qt5Keychain QUIET)
-option(QTKEYCHAIN "Secure credentials storage support for Live Broadcasting profiles" OFF)
+option(QTKEYCHAIN "Secure credentials storage support for Live Broadcasting profiles" ON)
 if(QTKEYCHAIN)
   if(NOT Qt5Keychain_FOUND)
     message(FATAL_ERROR "Secure credential storage support requires the Qt5::Keychain component.")

--- a/build/features.py
+++ b/build/features.py
@@ -1213,7 +1213,7 @@ class QtKeychain(Feature):
         return "Secure credentials storage support for Live Broadcasting profiles"
 
     def enabled(self, build):
-        build.flags['qtkeychain'] = util.get_flags(build.env, 'qtkeychain', 0)
+        build.flags['qtkeychain'] = util.get_flags(build.env, 'qtkeychain', 1)
         if int(build.flags['qtkeychain']):
             return True
         return False


### PR DESCRIPTION
I think this should be enabled in 2.3.

Let's see if it builds. 

https://bugs.launchpad.net/mixxx/+bug/1642765