### PR TITLE
Get rid of char group strings

### DIFF
--- a/src/control/controlobject.h
+++ b/src/control/controlobject.h
@@ -47,10 +47,6 @@ class ControlObject : public QObject {
         ConfigKey key(group, item);
         return getControl(key, warn);
     }
-    static inline ControlObject* getControl(const char* group, const char* item, bool warn = true) {
-        ConfigKey key(group, item);
-        return getControl(key, warn);
-    }
 
     QString name() const {
         return m_pControl ?  m_pControl->name() : QString();

--- a/src/controllers/bulk/bulkcontroller.cpp
+++ b/src/controllers/bulk/bulkcontroller.cpp
@@ -181,8 +181,7 @@ int BulkController::open() {
         m_pReader = new BulkReader(m_phandle, in_epaddr);
         m_pReader->setObjectName(QString("BulkReader %1").arg(getName()));
 
-        connect(m_pReader, SIGNAL(incomingData(QByteArray, mixxx::Duration)),
-                this, SLOT(receive(QByteArray, mixxx::Duration)));
+        connect(m_pReader, &BulkReader::incomingData, this, &BulkController::receive);
 
         // Controller input needs to be prioritized since it can affect the
         // audio directly, like when scratching
@@ -205,8 +204,7 @@ int BulkController::close() {
         qWarning() << "BulkReader not present for" << getName()
                    << "yet the device is open!";
     } else {
-        disconnect(m_pReader, SIGNAL(incomingData(QByteArray, mixxx::Duration)),
-                   this, SLOT(receive(QByteArray, mixxx::Duration)));
+        disconnect(m_pReader, &BulkReader::incomingData, this, &BulkController::receive);
         m_pReader->stop();
         controllerDebug("  Waiting on reader to finish");
         m_pReader->wait();

--- a/src/effects/effectparameterslotbase.h
+++ b/src/effects/effectparameterslotbase.h
@@ -32,7 +32,7 @@ class EffectParameterSlotBase : public QObject {
 
   protected:
     const unsigned int m_iParameterSlotNumber;
-    QString m_group;
+    const QString m_group;
     EffectPointer m_pEffect;
     EffectParameter* m_pEffectParameter;
 

--- a/src/engine/cachingreader/cachingreaderworker.h
+++ b/src/engine/cachingreader/cachingreaderworker.h
@@ -119,7 +119,7 @@ class CachingReaderWorker : public EngineWorker {
     void trackLoadFailed(TrackPointer pTrack, QString reason);
 
   private:
-    QString m_group;
+    const QString m_group;
     QString m_tag;
 
     // Thread-safe FIFOs for communication between the engine callback and

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -95,7 +95,7 @@ class HotcueControl : public QObject {
   private:
     ConfigKey keyForControl(int hotcue, const char* name);
 
-    QString m_group;
+    const QString m_group;
     int m_iHotcueNumber;
     CuePointer m_pCue;
 

--- a/src/engine/controls/enginecontrol.h
+++ b/src/engine/controls/enginecontrol.h
@@ -91,7 +91,7 @@ class EngineControl : public QObject {
     EngineMaster* getEngineMaster();
     EngineBuffer* getEngineBuffer();
 
-    QString m_group;
+    const QString m_group;
     UserSettingsPointer m_pConfig;
 
   private:

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -249,7 +249,7 @@ class EngineBuffer : public EngineObject {
     void processTrackLocked(CSAMPLE* pOutput, const int iBufferSize, int sample_rate);
 
     // Holds the name of the control group
-    QString m_group;
+    const QString m_group;
     UserSettingsPointer m_pConfig;
 
     friend class CueControlTest;

--- a/src/engine/enginedelay.cpp
+++ b/src/engine/enginedelay.cpp
@@ -28,7 +28,7 @@ const int kiMaxDelay = (kdMaxDelayPot + 8) / 1000 *
     mixxx::audio::SampleRate::kValueMax * mixxx::kEngineChannelCount;
 } // anonymous namespace
 
-EngineDelay::EngineDelay(const char* group, ConfigKey delayControl, bool bPersist)
+EngineDelay::EngineDelay(const QString& group, ConfigKey delayControl, bool bPersist)
         : m_iDelayPos(0),
           m_iDelay(0) {
     m_pDelayBuffer = SampleUtil::alloc(kiMaxDelay);

--- a/src/engine/enginedelay.h
+++ b/src/engine/enginedelay.h
@@ -26,7 +26,7 @@ class ControlProxy;
 class EngineDelay : public EngineObject {
     Q_OBJECT
   public:
-    EngineDelay(const char* group, ConfigKey delayControl, bool bPersist = true);
+    EngineDelay(const QString& group, ConfigKey delayControl, bool bPersist = true);
     virtual ~EngineDelay();
 
     void process(CSAMPLE* pInOut, const int iBufferSize);

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -29,8 +29,9 @@
 #include "util/timer.h"
 #include "util/trace.h"
 
-EngineMaster::EngineMaster(UserSettingsPointer pConfig,
-        const char* group,
+EngineMaster::EngineMaster(
+        UserSettingsPointer pConfig,
+        const QString& group,
         EffectsManager* pEffectsManager,
         ChannelHandleFactoryPointer pChannelHandleFactory,
         bool bEnableSidechain)

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -56,7 +56,7 @@ class EngineMaster : public QObject, public AudioSource {
     Q_OBJECT
   public:
     EngineMaster(UserSettingsPointer pConfig,
-            const char* pGroup,
+            const QString& group,
             EffectsManager* pEffectsManager,
             ChannelHandleFactoryPointer pChannelHandleFactory,
             bool bEnableSidechain);

--- a/src/engine/enginesidechaincompressor.cpp
+++ b/src/engine/enginesidechaincompressor.cpp
@@ -2,7 +2,7 @@
 
 #include "engine/enginesidechaincompressor.h"
 
-EngineSideChainCompressor::EngineSideChainCompressor(const char* group)
+EngineSideChainCompressor::EngineSideChainCompressor(const QString& group)
         : m_compressRatio(1.0),
           m_bAboveThreshold(false),
           m_threshold(1.0),

--- a/src/engine/enginesidechaincompressor.h
+++ b/src/engine/enginesidechaincompressor.h
@@ -5,7 +5,7 @@
 
 class EngineSideChainCompressor {
   public:
-    EngineSideChainCompressor(const char* group);
+    EngineSideChainCompressor(const QString& group);
     virtual ~EngineSideChainCompressor() { };
 
     void setParameters(CSAMPLE threshold, CSAMPLE strength,

--- a/src/engine/enginetalkoverducking.cpp
+++ b/src/engine/enginetalkoverducking.cpp
@@ -4,10 +4,10 @@
 #define DUCK_THRESHOLD 0.1
 
 EngineTalkoverDucking::EngineTalkoverDucking(
-        UserSettingsPointer pConfig, const char* group)
-    : EngineSideChainCompressor(group),
-      m_pConfig(pConfig),
-      m_group(group) {
+        UserSettingsPointer pConfig, const QString& group)
+        : EngineSideChainCompressor(group),
+          m_pConfig(pConfig),
+          m_group(group) {
     m_pMasterSampleRate = new ControlProxy(m_group, "samplerate", this);
     m_pMasterSampleRate->connectValueChanged(this, &EngineTalkoverDucking::slotSampleRateChanged,
                                              Qt::DirectConnection);

--- a/src/engine/enginetalkoverducking.h
+++ b/src/engine/enginetalkoverducking.h
@@ -15,7 +15,7 @@ class EngineTalkoverDucking : public QObject, public EngineSideChainCompressor {
         MANUAL,
     };
 
-    EngineTalkoverDucking(UserSettingsPointer pConfig, const char* group);
+    EngineTalkoverDucking(UserSettingsPointer pConfig, const QString& group);
     virtual ~EngineTalkoverDucking();
 
     TalkoverDuckSetting getMode() const {
@@ -31,7 +31,7 @@ class EngineTalkoverDucking : public QObject, public EngineSideChainCompressor {
 
   private:
     UserSettingsPointer m_pConfig;
-    const char* m_group;
+    const QString m_group;
 
     ControlProxy* m_pMasterSampleRate;
     ControlPotmeter* m_pDuckStrength;

--- a/src/engine/sync/basesyncablelistener.cpp
+++ b/src/engine/sync/basesyncablelistener.cpp
@@ -4,7 +4,11 @@
 
 #include "engine/sync/internalclock.h"
 
+namespace {
+
 const QString kInternalClockGroup = QStringLiteral("[InternalClock]");
+
+} // anonymous namespace
 
 BaseSyncableListener::BaseSyncableListener(UserSettingsPointer pConfig)
         : m_pConfig(pConfig),

--- a/src/engine/sync/basesyncablelistener.cpp
+++ b/src/engine/sync/basesyncablelistener.cpp
@@ -4,7 +4,7 @@
 
 #include "engine/sync/internalclock.h"
 
-static const char* kInternalClockGroup = "[InternalClock]";
+const QString kInternalClockGroup = QStringLiteral("[InternalClock]");
 
 BaseSyncableListener::BaseSyncableListener(UserSettingsPointer pConfig)
         : m_pConfig(pConfig),

--- a/src/engine/sync/internalclock.cpp
+++ b/src/engine/sync/internalclock.cpp
@@ -13,8 +13,8 @@ namespace {
 const mixxx::Logger kLogger("InternalClock");
 } // namespace
 
-InternalClock::InternalClock(const char* pGroup, SyncableListener* pEngineSync)
-        : m_group(pGroup),
+InternalClock::InternalClock(const QString& group, SyncableListener* pEngineSync)
+        : m_group(group),
           m_pEngineSync(pEngineSync),
           m_mode(SYNC_NONE),
           m_iOldSampleRate(44100),
@@ -28,8 +28,8 @@ InternalClock::InternalClock(const char* pGroup, SyncableListener* pEngineSync)
     // and bpm_down controls.
     // bpm_up / bpm_down steps by 1
     // bpm_up_small / bpm_down_small steps by 0.1
-    m_pClockBpm.reset(new ControlLinPotmeter(ConfigKey(m_group, "bpm"),
-                                          1, 200, 1, 0.1, true));
+    m_pClockBpm.reset(
+            new ControlLinPotmeter(ConfigKey(m_group, "bpm"), 1, 200, 1, 0.1, true));
     connect(m_pClockBpm.data(), &ControlObject::valueChanged,
             this, &InternalClock::slotBpmChanged,
             Qt::DirectConnection);
@@ -41,11 +41,10 @@ InternalClock::InternalClock(const char* pGroup, SyncableListener* pEngineSync)
             Qt::DirectConnection);
 
     m_pSyncMasterEnabled.reset(
-        new ControlPushButton(ConfigKey(pGroup, "sync_master")));
+            new ControlPushButton(ConfigKey(m_group, "sync_master")));
     m_pSyncMasterEnabled->setButtonMode(ControlPushButton::TOGGLE);
     m_pSyncMasterEnabled->connectValueChangeRequest(
-        this, &InternalClock::slotSyncMasterEnabledChangeRequest,
-        Qt::DirectConnection);
+            this, &InternalClock::slotSyncMasterEnabledChangeRequest, Qt::DirectConnection);
 }
 
 InternalClock::~InternalClock() {

--- a/src/engine/sync/internalclock.h
+++ b/src/engine/sync/internalclock.h
@@ -65,7 +65,7 @@ class InternalClock : public QObject, public Clock, public Syncable {
   private:
     void updateBeatLength(int sampleRate, double bpm);
 
-    QString m_group;
+    const QString m_group;
     SyncableListener* m_pEngineSync;
     QScopedPointer<ControlLinPotmeter> m_pClockBpm;
     QScopedPointer<ControlObject> m_pClockBeatDistance;

--- a/src/engine/sync/internalclock.h
+++ b/src/engine/sync/internalclock.h
@@ -22,7 +22,7 @@ class EngineSync;
 class InternalClock : public QObject, public Clock, public Syncable {
     Q_OBJECT
   public:
-    InternalClock(const char* pGroup, SyncableListener* pEngineSync);
+    InternalClock(const QString& group, SyncableListener* pEngineSync);
     ~InternalClock() override;
 
     const QString& getGroup() const override {

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -30,7 +30,7 @@ class LoadToGroupController : public QObject {
     void slotLoadToGroupAndPlay(double v);
 
   private:
-    QString m_group;
+    const QString m_group;
     std::unique_ptr<ControlObject> m_pLoadControl;
     std::unique_ptr<ControlObject> m_pLoadAndPlayControl;
 };

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -89,8 +89,9 @@
 
 using mixxx::skin::SkinManifest;
 
-QList<const char*> LegacySkinParser::s_channelStrs;
-QMutex LegacySkinParser::s_safeStringMutex;
+/// This QSet allows to make use of the implicit sharing
+/// of QString instead of every widget keeping its own copy.
+QSet<QString> LegacySkinParser::s_sharedGroupStrings;
 
 static bool sDebug = false;
 
@@ -248,14 +249,9 @@ QList<QString> LegacySkinParser::getSchemeList(const QString& qSkinPath) {
 }
 
 // static
-void LegacySkinParser::freeChannelStrings() {
-    QMutexLocker lock(&s_safeStringMutex);
-    for (int i = 0; i < s_channelStrs.length(); ++i) {
-        if (s_channelStrs[i]) {
-            delete [] s_channelStrs[i];
-        }
-        s_channelStrs[i] = NULL;
-    }
+void LegacySkinParser::clearSharedGroupStrings() {
+    // This frees up the memory allocated by the QString objects
+    s_sharedGroupStrings.clear();
 }
 
 SkinManifest LegacySkinParser::getSkinManifest(const QDomElement& skinDocument) {
@@ -919,25 +915,22 @@ void LegacySkinParser::setupLabelWidget(const QDomElement& element, WLabel* pLab
 }
 
 QWidget* LegacySkinParser::parseOverview(const QDomElement& node) {
-    QString channelStr = lookupNodeGroup(node);
+    QString group = lookupNodeGroup(node);
+    BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
+    if (!pPlayer) {
+        return nullptr;
+    }
 
-    const char* pSafeChannelStr = safeChannelString(channelStr);
-
-    BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(channelStr);
-
-    if (pPlayer == NULL)
-        return NULL;
-
-    WOverview* overviewWidget = NULL;
+    WOverview* overviewWidget = nullptr;
 
     // "RGB" = "2", "HSV" = "1" or "Filtered" = "0" (LMH) waveform overview type
     int type = m_pConfig->getValue(ConfigKey("[Waveform]","WaveformOverviewType"), 2);
     if (type == 0) {
-        overviewWidget = new WOverviewLMH(pSafeChannelStr, m_pPlayerManager, m_pConfig, m_pParent);
+        overviewWidget = new WOverviewLMH(group, m_pPlayerManager, m_pConfig, m_pParent);
     } else if (type == 1) {
-        overviewWidget = new WOverviewHSV(pSafeChannelStr, m_pPlayerManager, m_pConfig, m_pParent);
+        overviewWidget = new WOverviewHSV(group, m_pPlayerManager, m_pConfig, m_pParent);
     } else {
-        overviewWidget = new WOverviewRGB(pSafeChannelStr, m_pPlayerManager, m_pConfig, m_pParent);
+        overviewWidget = new WOverviewRGB(group, m_pPlayerManager, m_pConfig, m_pParent);
     }
 
     connect(overviewWidget, SIGNAL(trackDropped(QString, QString)),
@@ -965,15 +958,13 @@ QWidget* LegacySkinParser::parseOverview(const QDomElement& node) {
 }
 
 QWidget* LegacySkinParser::parseVisual(const QDomElement& node) {
-    QString channelStr = lookupNodeGroup(node);
-    BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(channelStr);
+    QString group = lookupNodeGroup(node);
+    BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
+    if (!pPlayer) {
+        return nullptr;
+    }
 
-    const char* pSafeChannelStr = safeChannelString(channelStr);
-
-    if (pPlayer == NULL)
-        return NULL;
-
-    WWaveformViewer* viewer = new WWaveformViewer(pSafeChannelStr, m_pConfig, m_pParent);
+    WWaveformViewer* viewer = new WWaveformViewer(group, m_pConfig, m_pParent);
     viewer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     WaveformWidgetFactory* factory = WaveformWidgetFactory::instance();
     factory->setWaveformWidget(viewer, node, *m_pContext);
@@ -1004,18 +995,16 @@ QWidget* LegacySkinParser::parseVisual(const QDomElement& node) {
 }
 
 QWidget* LegacySkinParser::parseText(const QDomElement& node) {
-    QString channelStr = lookupNodeGroup(node);
-    const char* pSafeChannelStr = safeChannelString(channelStr);
-
-    BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(channelStr);
-
-    if (!pPlayer)
-        return NULL;
+    QString group = lookupNodeGroup(node);
+    BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
+    if (!pPlayer) {
+        return nullptr;
+    }
 
     WTrackText* p = new WTrackText(m_pParent,
             m_pConfig,
             m_pLibrary->trackCollections(),
-            pSafeChannelStr);
+            group);
     setupLabelWidget(node, p);
 
     connect(pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
@@ -1036,18 +1025,17 @@ QWidget* LegacySkinParser::parseText(const QDomElement& node) {
 }
 
 QWidget* LegacySkinParser::parseTrackProperty(const QDomElement& node) {
-    QString channelStr = lookupNodeGroup(node);
-    const char* pSafeChannelStr = safeChannelString(channelStr);
+    QString group = lookupNodeGroup(node);
+    BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
+    if (!pPlayer) {
+        return nullptr;
+    }
 
-    BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(channelStr);
-
-    if (!pPlayer)
-        return NULL;
-
-    WTrackProperty* p = new WTrackProperty(m_pParent,
+    WTrackProperty* p = new WTrackProperty(
+            m_pParent,
             m_pConfig,
             m_pLibrary->trackCollections(),
-            pSafeChannelStr);
+            group);
     setupLabelWidget(node, p);
 
     connect(pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
@@ -1068,15 +1056,13 @@ QWidget* LegacySkinParser::parseTrackProperty(const QDomElement& node) {
 }
 
 QWidget* LegacySkinParser::parseStarRating(const QDomElement& node) {
-    QString channelStr = lookupNodeGroup(node);
-    const char* pSafeChannelStr = safeChannelString(channelStr);
+    QString group = lookupNodeGroup(node);
+    BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
+    if (!pPlayer) {
+        return nullptr;
+    }
 
-    BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(channelStr);
-
-    if (!pPlayer)
-        return NULL;
-
-    WStarRating* p = new WStarRating(pSafeChannelStr, m_pParent);
+    WStarRating* p = new WStarRating(group, m_pParent);
     commonWidgetSetup(node, p, false);
     p->setup(node, *m_pContext);
 
@@ -1096,10 +1082,7 @@ QWidget* LegacySkinParser::parseStarRating(const QDomElement& node) {
 
 
 QWidget* LegacySkinParser::parseNumberRate(const QDomElement& node) {
-    QString channelStr = lookupNodeGroup(node);
-
-    const char* pSafeChannelStr = safeChannelString(channelStr);
-
+    QString group = lookupNodeGroup(node);
     QColor c(255,255,255);
     QString cStr;
     if (m_pContext->hasNodeSelectString(node, "BgColor", &cStr)) {
@@ -1110,7 +1093,7 @@ QWidget* LegacySkinParser::parseNumberRate(const QDomElement& node) {
     //palette.setBrush(QPalette::Background, WSkinColor::getCorrectColor(c));
     palette.setBrush(QPalette::Button, Qt::NoBrush);
 
-    WNumberRate* p = new WNumberRate(pSafeChannelStr, m_pParent);
+    WNumberRate* p = new WNumberRate(group, m_pParent);
     setupLabelWidget(node, p);
 
     // TODO(rryan): Let's look at removing this palette change in 1.12.0. I
@@ -1121,19 +1104,15 @@ QWidget* LegacySkinParser::parseNumberRate(const QDomElement& node) {
 }
 
 QWidget* LegacySkinParser::parseNumberPos(const QDomElement& node) {
-    QString channelStr = lookupNodeGroup(node);
-
-    const char* pSafeChannelStr = safeChannelString(channelStr);
-
-    WNumberPos* p = new WNumberPos(pSafeChannelStr, m_pParent);
+    QString group = lookupNodeGroup(node);
+    WNumberPos* p = new WNumberPos(group, m_pParent);
     setupLabelWidget(node, p);
     return p;
 }
 
 QWidget* LegacySkinParser::parseEngineKey(const QDomElement& node) {
-    QString channelStr = lookupNodeGroup(node);
-    const char* pSafeChannelStr = safeChannelString(channelStr);
-    WKey* pEngineKey = new WKey(pSafeChannelStr, m_pParent);
+    QString group = lookupNodeGroup(node);
+    WKey* pEngineKey = new WKey(group, m_pParent);
     setupLabelWidget(node, pEngineKey);
     return pEngineKey;
 }
@@ -1181,7 +1160,6 @@ QWidget* LegacySkinParser::parseRecordingDuration(const QDomElement& node) {
 }
 
 QWidget* LegacySkinParser::parseSpinny(const QDomElement& node) {
-    QString channelStr = lookupNodeGroup(node);
     if (CmdlineArgs::Instance().getSafeMode()) {
         WLabel* dummy = new WLabel(m_pParent);
         //: Shown when Mixxx is running in safe mode.
@@ -1199,9 +1177,9 @@ QWidget* LegacySkinParser::parseSpinny(const QDomElement& node) {
         return dummy;
     }
 
-    BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(channelStr);
-    WSpinny* spinny = new WSpinny(m_pParent, channelStr, m_pConfig,
-                                  m_pVCManager, pPlayer);
+    QString group = lookupNodeGroup(node);
+    BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
+    WSpinny* spinny = new WSpinny(m_pParent, group, m_pConfig, m_pVCManager, pPlayer);
     commonWidgetSetup(node, spinny);
 
     connect(waveformWidgetFactory, SIGNAL(renderSpinnies(VSyncThread*)), spinny, SLOT(render(VSyncThread*)));
@@ -1563,24 +1541,14 @@ QString LegacySkinParser::lookupNodeGroup(const QDomElement& node) {
         }
     }
 
-    return group;
+    QString sharedGroup = getSharedGroupString(group);
+    return sharedGroup;
 }
 
 // static
-const char* LegacySkinParser::safeChannelString(const QString& channelStr) {
-    QMutexLocker lock(&s_safeStringMutex);
-    foreach (const char *s, s_channelStrs) {
-        if (channelStr == s) { // calls QString::operator==(const char*)
-            return s;
-        }
-    }
-    QByteArray qba(channelStr.toLatin1());
-    char *safe = new char[qba.size() + 1]; // +1 for \0
-    int i = 0;
-    // Copy string
-    while ((safe[i] = qba[i])) ++i;
-    s_channelStrs.append(safe);
-    return safe;
+QString LegacySkinParser::getSharedGroupString(const QString& channelStr) {
+    QSet<QString>::iterator i = s_sharedGroupStrings.insert(channelStr);
+    return *i;
 }
 
 QWidget* LegacySkinParser::parseEffectChainName(const QDomElement& node) {

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -505,7 +505,7 @@ QList<QWidget*> LegacySkinParser::parseNode(const QDomElement& node) {
     } else if (nodeName == "EffectPushButton") {
         result = wrapWidget(parseEffectPushButton(node));
     } else if (nodeName == "HotcueButton") {
-        result = wrapWidget(parseStandardWidget<WHotcueButton>(node));
+        result = wrapWidget(parseHotcueButton(node));
     } else if (nodeName == "ComboBox") {
         result = wrapWidget(parseStandardWidget<WComboBox>(node));
     } else if (nodeName == "Overview") {
@@ -1218,15 +1218,15 @@ QWidget* LegacySkinParser::parseSearchBox(const QDomElement& node) {
 }
 
 QWidget* LegacySkinParser::parseCoverArt(const QDomElement& node) {
-    QString channel = lookupNodeGroup(node);
-    BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(channel);
+    QString group = lookupNodeGroup(node);
+    BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
 
-    WCoverArt* pCoverArt = new WCoverArt(m_pParent, m_pConfig, channel, pPlayer);
+    WCoverArt* pCoverArt = new WCoverArt(m_pParent, m_pConfig, group, pPlayer);
     commonWidgetSetup(node, pCoverArt);
     pCoverArt->setup(node, *m_pContext);
 
     // If no group was provided, hook the widget up to the Library.
-    if (channel.isEmpty()) {
+    if (group.isEmpty()) {
         // Connect cover art signals to the library
         connect(m_pLibrary, SIGNAL(switchToView(const QString&)),
                 pCoverArt, SLOT(slotReset()));
@@ -1549,6 +1549,18 @@ QString LegacySkinParser::lookupNodeGroup(const QDomElement& node) {
 QString LegacySkinParser::getSharedGroupString(const QString& channelStr) {
     QSet<QString>::iterator i = s_sharedGroupStrings.insert(channelStr);
     return *i;
+}
+
+QWidget* LegacySkinParser::parseHotcueButton(const QDomElement& element) {
+    QString group = lookupNodeGroup(element);
+    WHotcueButton* pWidget = new WHotcueButton(group, m_pParent);
+    commonWidgetSetup(element, pWidget);
+    pWidget->setup(element, *m_pContext);
+    pWidget->installEventFilter(m_pKeyboard);
+    pWidget->installEventFilter(
+            m_pControllerManager->getControllerLearningEventFilter());
+    pWidget->Init();
+    return pWidget;
 }
 
 QWidget* LegacySkinParser::parseEffectChainName(const QDomElement& node) {

--- a/src/skin/legacyskinparser.h
+++ b/src/skin/legacyskinparser.h
@@ -88,6 +88,7 @@ class LegacySkinParser : public QObject, public SkinParser {
     QWidget* parseEffectButtonParameterName(const QDomElement& node);
     QWidget* parseEffectPushButton(const QDomElement& node);
     QWidget* parseEffectSelector(const QDomElement& node);
+    QWidget* parseHotcueButton(const QDomElement& node);
 
     // Legacy pre-1.12.0 skin support.
     QWidget* parseBackground(const QDomElement& node, QWidget* pOuterWidget, QWidget* pInnerWidget);

--- a/src/skin/legacyskinparser.h
+++ b/src/skin/legacyskinparser.h
@@ -48,7 +48,7 @@ class LegacySkinParser : public QObject, public SkinParser {
     static QList<QString> getSchemeList(const QString& qSkinPath);
     // Parse a skin manifest from the provided skin document root.
     static mixxx::skin::SkinManifest getSkinManifest(const QDomElement& skinDocument);
-    static void freeChannelStrings();
+    static void clearSharedGroupStrings();
 
     static Qt::MouseButton parseButtonState(const QDomNode& node,
                                             const SkinContext& context);
@@ -129,7 +129,7 @@ class LegacySkinParser : public QObject, public SkinParser {
     QString getLibraryStyle(const QDomNode& node);
 
     QString lookupNodeGroup(const QDomElement& node);
-    static const char* safeChannelString(const QString& channelStr);
+    static QString getSharedGroupString(const QString& channelStr);
     ControlObject* controlFromConfigNode(const QDomElement& element,
                                          const QString& nodeName,
                                          bool* created);
@@ -150,8 +150,7 @@ class LegacySkinParser : public QObject, public SkinParser {
     QString m_style;
     Tooltips m_tooltips;
     QHash<QString, QDomElement> m_templateCache;
-    static QList<const char*> s_channelStrs;
-    static QMutex s_safeStringMutex;
+    static QSet<QString> s_sharedGroupStrings;
 };
 
 

--- a/src/skin/skinloader.cpp
+++ b/src/skin/skinloader.cpp
@@ -25,7 +25,7 @@ SkinLoader::SkinLoader(UserSettingsPointer pConfig) :
 }
 
 SkinLoader::~SkinLoader() {
-    LegacySkinParser::freeChannelStrings();
+    LegacySkinParser::clearSharedGroupStrings();
 }
 
 QList<QDir> SkinLoader::getSkinSearchPaths() const {

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -23,12 +23,12 @@
 
 class EngineSyncTest : public MockedEngineBackendTest {
   public:
-    std::string getMasterGroup() {
+    QString getMasterGroup() {
         Syncable* pMasterSyncable = m_pEngineSync->getMasterSyncable();
         if (pMasterSyncable) {
-            return pMasterSyncable->getGroup().toStdString();
+            return pMasterSyncable->getGroup();
         }
-        return "";
+        return QString();
     }
     bool isExplicitMaster(QString group) {
         return isMaster(group, true);
@@ -109,7 +109,7 @@ class EngineSyncTest : public MockedEngineBackendTest {
                 return false;
             }
         }
-        if (getMasterGroup() != group.toStdString()) {
+        if (getMasterGroup() != group) {
             return false;
         }
 

--- a/src/test/signalpathtest.cpp
+++ b/src/test/signalpathtest.cpp
@@ -1,13 +1,13 @@
 #include "test/signalpathtest.h"
 
-const char* BaseSignalPathTest::m_sMasterGroup = "[Master]";
-const char* BaseSignalPathTest::m_sInternalClockGroup = "[InternalClock]";
+const QString BaseSignalPathTest::m_sMasterGroup = QStringLiteral("[Master]");
+const QString BaseSignalPathTest::m_sInternalClockGroup = QStringLiteral("[InternalClock]");
 // these names need to match PlayerManager::groupForDeck and friends
-const char* BaseSignalPathTest::m_sGroup1 = "[Channel1]";
-const char* BaseSignalPathTest::m_sGroup2 = "[Channel2]";
-const char* BaseSignalPathTest::m_sGroup3 = "[Channel3]";
-const char* BaseSignalPathTest::m_sPreviewGroup = "[PreviewDeck1]";
-const char* BaseSignalPathTest::m_sSamplerGroup = "[Sampler1]";
+const QString BaseSignalPathTest::m_sGroup1 = QStringLiteral("[Channel1]");
+const QString BaseSignalPathTest::m_sGroup2 = QStringLiteral("[Channel2]");
+const QString BaseSignalPathTest::m_sGroup3 = QStringLiteral("[Channel3]");
+const QString BaseSignalPathTest::m_sPreviewGroup = QStringLiteral("[PreviewDeck1]");
+const QString BaseSignalPathTest::m_sSamplerGroup = QStringLiteral("[Sampler1]");
 const double BaseSignalPathTest::kDefaultRateRange = 0.08;
 const double BaseSignalPathTest::kDefaultRateDir = 1.0;
 const double BaseSignalPathTest::kRateRangeDivisor = kDefaultRateDir * kDefaultRateRange;

--- a/src/test/signalpathtest.h
+++ b/src/test/signalpathtest.h
@@ -36,7 +36,7 @@ using ::testing::_;
 class TestEngineMaster : public EngineMaster {
   public:
     TestEngineMaster(UserSettingsPointer _config,
-            const char* group,
+            const QString& group,
             EffectsManager* pEffectsManager,
             ChannelHandleFactoryPointer pChannelHandleFactory,
             bool bEnableSidechain)

--- a/src/test/signalpathtest.h
+++ b/src/test/signalpathtest.h
@@ -210,13 +210,13 @@ class BaseSignalPathTest : public MixxxTest {
     EngineDeck *m_pChannel1, *m_pChannel2, *m_pChannel3;
     PreviewDeck* m_pPreview1;
 
-    static const char* m_sGroup1;
-    static const char* m_sGroup2;
-    static const char* m_sGroup3;
-    static const char* m_sMasterGroup;
-    static const char* m_sInternalClockGroup;
-    static const char* m_sPreviewGroup;
-    static const char* m_sSamplerGroup;
+    static const QString m_sGroup1;
+    static const QString m_sGroup2;
+    static const QString m_sGroup3;
+    static const QString m_sMasterGroup;
+    static const QString m_sInternalClockGroup;
+    static const QString m_sPreviewGroup;
+    static const QString m_sSamplerGroup;
     static const double kDefaultRateRange;
     static const double kDefaultRateDir;
     static const double kRateRangeDivisor;

--- a/src/vinylcontrol/vinylcontrol.h
+++ b/src/vinylcontrol/vinylcontrol.h
@@ -23,7 +23,7 @@ class VinylControl : public QObject {
     virtual float getAngle() = 0;
 
     UserSettingsPointer m_pConfig;
-    QString m_group;
+    const QString m_group;
 
     // The VC input gain preference.
     ControlProxy* m_pVinylControlInputGain;

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -14,34 +14,33 @@ const double WaveformWidgetRenderer::s_waveformMaxZoom = 10.0;
 const double WaveformWidgetRenderer::s_waveformDefaultZoom = 3.0;
 const double WaveformWidgetRenderer::s_defaultPlayMarkerPosition = 0.5;
 
-WaveformWidgetRenderer::WaveformWidgetRenderer(const char* group)
-    : m_group(group),
-      m_orientation(Qt::Horizontal),
-      m_height(-1),
-      m_width(-1),
-      m_devicePixelRatio(1.0f),
+WaveformWidgetRenderer::WaveformWidgetRenderer(const QString& group)
+        : m_group(group),
+          m_orientation(Qt::Horizontal),
+          m_height(-1),
+          m_width(-1),
+          m_devicePixelRatio(1.0f),
 
-      m_firstDisplayedPosition(0.0),
-      m_lastDisplayedPosition(0.0),
-      m_trackPixelCount(0.0),
+          m_firstDisplayedPosition(0.0),
+          m_lastDisplayedPosition(0.0),
+          m_trackPixelCount(0.0),
 
-      m_zoomFactor(1.0),
-      m_visualSamplePerPixel(1.0),
-      m_audioSamplePerPixel(1.0),
-      m_alphaBeatGrid(90),
-      // Really create some to manage those;
-      m_visualPlayPosition(NULL),
-      m_playPos(-1),
-      m_playPosVSample(0),
-      m_pRateRatioCO(NULL),
-      m_rateRatio(1.0),
-      m_pGainControlObject(NULL),
-      m_gain(1.0),
-      m_pTrackSamplesControlObject(NULL),
-      m_trackSamples(0.0),
-      m_scaleFactor(1.0),
-      m_playMarkerPosition(s_defaultPlayMarkerPosition) {
-
+          m_zoomFactor(1.0),
+          m_visualSamplePerPixel(1.0),
+          m_audioSamplePerPixel(1.0),
+          m_alphaBeatGrid(90),
+          // Really create some to manage those;
+          m_visualPlayPosition(NULL),
+          m_playPos(-1),
+          m_playPosVSample(0),
+          m_pRateRatioCO(NULL),
+          m_rateRatio(1.0),
+          m_pGainControlObject(NULL),
+          m_gain(1.0),
+          m_pTrackSamplesControlObject(NULL),
+          m_trackSamples(0.0),
+          m_scaleFactor(1.0),
+          m_playMarkerPosition(s_defaultPlayMarkerPosition) {
     //qDebug() << "WaveformWidgetRenderer";
 
 #ifdef WAVEFORMWIDGETRENDERER_DEBUG

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -28,7 +28,7 @@ class WaveformWidgetRenderer {
     static const double s_defaultPlayMarkerPosition;
 
   public:
-    explicit WaveformWidgetRenderer(const char* group);
+    explicit WaveformWidgetRenderer(const QString& group);
     virtual ~WaveformWidgetRenderer();
 
     bool init();
@@ -38,8 +38,12 @@ class WaveformWidgetRenderer {
     void onPreRender(VSyncThread* vsyncThread);
     void draw(QPainter* painter, QPaintEvent* event);
 
-    inline const char* getGroup() const { return m_group;}
-    const TrackPointer getTrackInfo() const { return m_pTrack;}
+    const QString& getGroup() const {
+        return m_group;
+    }
+    const TrackPointer getTrackInfo() const {
+        return m_pTrack;
+    }
     /// Get cue mark at a point on the waveform widget.
     WaveformMarkPointer getCueMarkAtPoint(QPoint point) const;
 
@@ -112,7 +116,7 @@ class WaveformWidgetRenderer {
     }
 
   protected:
-    const char* m_group;
+    const QString m_group;
     TrackPointer m_pTrack;
     QList<WaveformRendererAbstract*> m_rendererStack;
     Qt::Orientation m_orientation;

--- a/src/waveform/visualsmanager.h
+++ b/src/waveform/visualsmanager.h
@@ -26,7 +26,7 @@ class DeckVisuals {
     void process(double remainingTimeTriggerSeconds);
 
   private:
-    QString m_group;
+    const QString m_group;
     int m_SlowTickCnt;
     bool m_trackLoaded;
 

--- a/src/waveform/widgets/emptywaveformwidget.cpp
+++ b/src/waveform/widgets/emptywaveformwidget.cpp
@@ -5,7 +5,7 @@
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveform/renderers/waveformrenderbackground.h"
 
-EmptyWaveformWidget::EmptyWaveformWidget(const char* group, QWidget* parent)
+EmptyWaveformWidget::EmptyWaveformWidget(const QString& group, QWidget* parent)
         : QWidget(parent),
           WaveformWidgetAbstract(group) {
     //Empty means just a background ;)

--- a/src/waveform/widgets/emptywaveformwidget.h
+++ b/src/waveform/widgets/emptywaveformwidget.h
@@ -27,7 +27,7 @@ class EmptyWaveformWidget : public QWidget, public WaveformWidgetAbstract {
     virtual mixxx::Duration render();
 
   private:
-    EmptyWaveformWidget(const char* group, QWidget* parent);
+    EmptyWaveformWidget(const QString& group, QWidget* parent);
     friend class WaveformWidgetFactory;
 };
 

--- a/src/waveform/widgets/glrgbwaveformwidget.cpp
+++ b/src/waveform/widgets/glrgbwaveformwidget.cpp
@@ -12,10 +12,9 @@
 
 #include "util/performancetimer.h"
 
-GLRGBWaveformWidget::GLRGBWaveformWidget(const char* group, QWidget* parent)
+GLRGBWaveformWidget::GLRGBWaveformWidget(const QString& group, QWidget* parent)
         : QGLWidget(parent, SharedGLContext::getWidget()),
           WaveformWidgetAbstract(group) {
-
     qDebug() << "Created QGLWidget. Context"
              << "Valid:" << context()->isValid()
              << "Sharing:" << context()->isSharing();

--- a/src/waveform/widgets/glrgbwaveformwidget.h
+++ b/src/waveform/widgets/glrgbwaveformwidget.h
@@ -8,7 +8,7 @@
 class GLRGBWaveformWidget : public QGLWidget, public WaveformWidgetAbstract {
     Q_OBJECT
   public:
-    GLRGBWaveformWidget(const char* group, QWidget* parent);
+    GLRGBWaveformWidget(const QString& group, QWidget* parent);
     virtual ~GLRGBWaveformWidget();
 
     virtual WaveformWidgetType::Type getType() const { return WaveformWidgetType::GLRGBWaveform; }

--- a/src/waveform/widgets/glsimplewaveformwidget.cpp
+++ b/src/waveform/widgets/glsimplewaveformwidget.cpp
@@ -15,7 +15,7 @@
 
 #include "util/performancetimer.h"
 
-GLSimpleWaveformWidget::GLSimpleWaveformWidget(const char* group, QWidget* parent)
+GLSimpleWaveformWidget::GLSimpleWaveformWidget(const QString& group, QWidget* parent)
         : QGLWidget(parent, SharedGLContext::getWidget()),
           WaveformWidgetAbstract(group) {
     qDebug() << "Created QGLWidget. Context"

--- a/src/waveform/widgets/glsimplewaveformwidget.h
+++ b/src/waveform/widgets/glsimplewaveformwidget.h
@@ -8,7 +8,7 @@
 class GLSimpleWaveformWidget : public QGLWidget, public WaveformWidgetAbstract {
     Q_OBJECT
   public:
-    GLSimpleWaveformWidget(const char* group, QWidget* parent);
+    GLSimpleWaveformWidget(const QString& group, QWidget* parent);
     virtual ~GLSimpleWaveformWidget();
 
     virtual WaveformWidgetType::Type getType() const { return WaveformWidgetType::GLSimpleWaveform; }

--- a/src/waveform/widgets/glslwaveformwidget.cpp
+++ b/src/waveform/widgets/glslwaveformwidget.cpp
@@ -15,17 +15,22 @@
 
 #include "util/performancetimer.h"
 
-GLSLFilteredWaveformWidget::GLSLFilteredWaveformWidget(const char* group,
-                                                       QWidget* parent)
+GLSLFilteredWaveformWidget::GLSLFilteredWaveformWidget(
+        const QString& group,
+        QWidget* parent)
         : GLSLWaveformWidget(group, parent, false) {
 }
 
-GLSLRGBWaveformWidget::GLSLRGBWaveformWidget(const char* group, QWidget* parent)
+GLSLRGBWaveformWidget::GLSLRGBWaveformWidget(
+        const QString& group,
+        QWidget* parent)
         : GLSLWaveformWidget(group, parent, true) {
 }
 
-GLSLWaveformWidget::GLSLWaveformWidget(const char* group, QWidget* parent,
-                                       bool rgbRenderer)
+GLSLWaveformWidget::GLSLWaveformWidget(
+        const QString& group,
+        QWidget* parent,
+        bool rgbRenderer)
         : QGLWidget(parent, SharedGLContext::getWidget()),
           WaveformWidgetAbstract(group) {
     qDebug() << "Created QGLWidget. Context"

--- a/src/waveform/widgets/glslwaveformwidget.h
+++ b/src/waveform/widgets/glslwaveformwidget.h
@@ -10,8 +10,10 @@ class GLSLWaveformRendererSignal;
 class GLSLWaveformWidget : public QGLWidget, public WaveformWidgetAbstract {
     Q_OBJECT
   public:
-    GLSLWaveformWidget(const char* group, QWidget* parent,
-                       bool rgbRenderer);
+    GLSLWaveformWidget(
+            const QString& group,
+            QWidget* parent,
+            bool rgbRenderer);
     ~GLSLWaveformWidget() override;
 
     void resize(int width, int height) override;
@@ -31,7 +33,7 @@ class GLSLWaveformWidget : public QGLWidget, public WaveformWidgetAbstract {
 class GLSLFilteredWaveformWidget : public GLSLWaveformWidget {
     Q_OBJECT
   public:
-    GLSLFilteredWaveformWidget(const char* group, QWidget* parent);
+    GLSLFilteredWaveformWidget(const QString& group, QWidget* parent);
     ~GLSLFilteredWaveformWidget() override = default;
 
     WaveformWidgetType::Type getType() const override { return WaveformWidgetType::GLSLFilteredWaveform; }
@@ -46,7 +48,7 @@ class GLSLFilteredWaveformWidget : public GLSLWaveformWidget {
 class GLSLRGBWaveformWidget : public GLSLWaveformWidget {
     Q_OBJECT
   public:
-    GLSLRGBWaveformWidget(const char* group, QWidget* parent);
+    GLSLRGBWaveformWidget(const QString& group, QWidget* parent);
     ~GLSLRGBWaveformWidget() override = default;
 
     WaveformWidgetType::Type getType() const override { return WaveformWidgetType::GLSLRGBWaveform; }

--- a/src/waveform/widgets/glvsynctestwidget.cpp
+++ b/src/waveform/widgets/glvsynctestwidget.cpp
@@ -15,9 +15,9 @@
 
 #include "util/performancetimer.h"
 
-GLVSyncTestWidget::GLVSyncTestWidget(const char* group, QWidget* parent)
-    : QGLWidget(parent, SharedGLContext::getWidget()),
-      WaveformWidgetAbstract(group) {
+GLVSyncTestWidget::GLVSyncTestWidget(const QString& group, QWidget* parent)
+        : QGLWidget(parent, SharedGLContext::getWidget()),
+          WaveformWidgetAbstract(group) {
     qDebug() << "Created QGLWidget. Context"
              << "Valid:" << context()->isValid()
              << "Sharing:" << context()->isSharing();

--- a/src/waveform/widgets/glvsynctestwidget.h
+++ b/src/waveform/widgets/glvsynctestwidget.h
@@ -8,7 +8,7 @@
 class GLVSyncTestWidget : public QGLWidget, public WaveformWidgetAbstract {
     Q_OBJECT
   public:
-    GLVSyncTestWidget(const char* group, QWidget* parent);
+    GLVSyncTestWidget(const QString& group, QWidget* parent);
     virtual ~GLVSyncTestWidget();
 
     virtual WaveformWidgetType::Type getType() const { return WaveformWidgetType::GLVSyncTest; }

--- a/src/waveform/widgets/glwaveformwidget.cpp
+++ b/src/waveform/widgets/glwaveformwidget.cpp
@@ -15,7 +15,7 @@
 #include "waveform/sharedglcontext.h"
 #include "util/performancetimer.h"
 
-GLWaveformWidget::GLWaveformWidget(const char* group, QWidget* parent)
+GLWaveformWidget::GLWaveformWidget(const QString& group, QWidget* parent)
         : QGLWidget(parent, SharedGLContext::getWidget()),
           WaveformWidgetAbstract(group) {
     qDebug() << "Created QGLWidget. Context"

--- a/src/waveform/widgets/glwaveformwidget.h
+++ b/src/waveform/widgets/glwaveformwidget.h
@@ -8,7 +8,7 @@
 class GLWaveformWidget : public QGLWidget, public WaveformWidgetAbstract {
     Q_OBJECT
   public:
-    GLWaveformWidget(const char* group, QWidget* parent);
+    GLWaveformWidget(const QString& group, QWidget* parent);
     virtual ~GLWaveformWidget();
 
     virtual WaveformWidgetType::Type getType() const { return WaveformWidgetType::GLFilteredWaveform; }

--- a/src/waveform/widgets/hsvwaveformwidget.cpp
+++ b/src/waveform/widgets/hsvwaveformwidget.cpp
@@ -11,9 +11,9 @@
 #include "waveform/renderers/waveformrendererendoftrack.h"
 #include "waveform/renderers/waveformrenderbeat.h"
 
-HSVWaveformWidget::HSVWaveformWidget(const char* group, QWidget* parent)
-    : QWidget(parent),
-      WaveformWidgetAbstract(group) {
+HSVWaveformWidget::HSVWaveformWidget(const QString& group, QWidget* parent)
+        : QWidget(parent),
+          WaveformWidgetAbstract(group) {
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
     addRenderer<WaveformRendererPreroll>();

--- a/src/waveform/widgets/hsvwaveformwidget.h
+++ b/src/waveform/widgets/hsvwaveformwidget.h
@@ -23,7 +23,7 @@ class HSVWaveformWidget : public QWidget, public WaveformWidgetAbstract {
     virtual void paintEvent(QPaintEvent* event);
 
   private:
-    HSVWaveformWidget(const char* group, QWidget* parent);
+    HSVWaveformWidget(const QString& group, QWidget* parent);
     friend class WaveformWidgetFactory;
 };
 

--- a/src/waveform/widgets/qthsvwaveformwidget.cpp
+++ b/src/waveform/widgets/qthsvwaveformwidget.cpp
@@ -13,9 +13,9 @@
 #include "waveform/renderers/waveformrendererendoftrack.h"
 #include "waveform/renderers/waveformrenderbeat.h"
 
-QtHSVWaveformWidget::QtHSVWaveformWidget(const char* group, QWidget* parent)
-    : QGLWidget(parent),
-      WaveformWidgetAbstract(group) {
+QtHSVWaveformWidget::QtHSVWaveformWidget(const QString& group, QWidget* parent)
+        : QGLWidget(parent),
+          WaveformWidgetAbstract(group) {
     if (QGLContext::currentContext() != context()) {
         makeCurrent();
     }

--- a/src/waveform/widgets/qthsvwaveformwidget.h
+++ b/src/waveform/widgets/qthsvwaveformwidget.h
@@ -24,7 +24,7 @@ class QtHSVWaveformWidget : public QGLWidget, public WaveformWidgetAbstract {
     virtual mixxx::Duration render();
 
   private:
-    QtHSVWaveformWidget(const char* group, QWidget* parent);
+    QtHSVWaveformWidget(const QString& group, QWidget* parent);
     friend class WaveformWidgetFactory;
 };
 

--- a/src/waveform/widgets/qtrgbwaveformwidget.cpp
+++ b/src/waveform/widgets/qtrgbwaveformwidget.cpp
@@ -14,7 +14,7 @@
 #include "waveform/renderers/waveformrenderbeat.h"
 #include "waveform/sharedglcontext.h"
 
-QtRGBWaveformWidget::QtRGBWaveformWidget(const char* group, QWidget* parent)
+QtRGBWaveformWidget::QtRGBWaveformWidget(const QString& group, QWidget* parent)
         : QGLWidget(parent, SharedGLContext::getWidget()),
           WaveformWidgetAbstract(group) {
     qDebug() << "Created QGLWidget. Context"

--- a/src/waveform/widgets/qtrgbwaveformwidget.h
+++ b/src/waveform/widgets/qtrgbwaveformwidget.h
@@ -24,7 +24,7 @@ class QtRGBWaveformWidget : public QGLWidget, public WaveformWidgetAbstract {
     virtual mixxx::Duration render();
 
   private:
-    QtRGBWaveformWidget(const char* group, QWidget* parent);
+    QtRGBWaveformWidget(const QString& group, QWidget* parent);
     friend class WaveformWidgetFactory;
 };
 

--- a/src/waveform/widgets/qtsimplewaveformwidget.cpp
+++ b/src/waveform/widgets/qtsimplewaveformwidget.cpp
@@ -15,7 +15,9 @@
 
 #include "util/performancetimer.h"
 
-QtSimpleWaveformWidget::QtSimpleWaveformWidget(const char* group, QWidget* parent)
+QtSimpleWaveformWidget::QtSimpleWaveformWidget(
+        const QString& group,
+        QWidget* parent)
         : QGLWidget(parent, SharedGLContext::getWidget()),
           WaveformWidgetAbstract(group) {
     qDebug() << "Created QGLWidget. Context"

--- a/src/waveform/widgets/qtsimplewaveformwidget.h
+++ b/src/waveform/widgets/qtsimplewaveformwidget.h
@@ -8,7 +8,7 @@
 class QtSimpleWaveformWidget : public QGLWidget, public WaveformWidgetAbstract {
     Q_OBJECT
   public:
-    QtSimpleWaveformWidget(const char* group, QWidget* parent);
+    QtSimpleWaveformWidget(const QString& group, QWidget* parent);
     virtual ~QtSimpleWaveformWidget();
 
 

--- a/src/waveform/widgets/qtvsynctestwidget.cpp
+++ b/src/waveform/widgets/qtvsynctestwidget.cpp
@@ -16,9 +16,9 @@
 
 #include "util/performancetimer.h"
 
-QtVSyncTestWidget::QtVSyncTestWidget(const char* group, QWidget* parent)
-    : QGLWidget(parent, SharedGLContext::getWidget()),
-      WaveformWidgetAbstract(group) {
+QtVSyncTestWidget::QtVSyncTestWidget(const QString& group, QWidget* parent)
+        : QGLWidget(parent, SharedGLContext::getWidget()),
+          WaveformWidgetAbstract(group) {
     qDebug() << "Created QGLWidget. Context"
              << "Valid:" << context()->isValid()
              << "Sharing:" << context()->isSharing();

--- a/src/waveform/widgets/qtvsynctestwidget.h
+++ b/src/waveform/widgets/qtvsynctestwidget.h
@@ -8,7 +8,7 @@
 class QtVSyncTestWidget : public QGLWidget, public WaveformWidgetAbstract {
     Q_OBJECT
   public:
-    QtVSyncTestWidget(const char* group, QWidget* parent);
+    QtVSyncTestWidget(const QString& group, QWidget* parent);
     virtual ~QtVSyncTestWidget();
 
     virtual WaveformWidgetType::Type getType() const { return WaveformWidgetType::QtVSyncTest; }

--- a/src/waveform/widgets/qtwaveformwidget.cpp
+++ b/src/waveform/widgets/qtwaveformwidget.cpp
@@ -16,7 +16,7 @@
 
 #include "util/performancetimer.h"
 
-QtWaveformWidget::QtWaveformWidget(const char* group, QWidget* parent)
+QtWaveformWidget::QtWaveformWidget(const QString& group, QWidget* parent)
         : QGLWidget(parent, SharedGLContext::getWidget()),
           WaveformWidgetAbstract(group) {
     qDebug() << "Created QGLWidget. Context"

--- a/src/waveform/widgets/qtwaveformwidget.h
+++ b/src/waveform/widgets/qtwaveformwidget.h
@@ -8,7 +8,7 @@
 class QtWaveformWidget : public QGLWidget, public WaveformWidgetAbstract {
     Q_OBJECT
   public:
-    QtWaveformWidget(const char* group, QWidget* parent);
+    QtWaveformWidget(const QString& group, QWidget* parent);
     virtual ~QtWaveformWidget();
 
     virtual WaveformWidgetType::Type getType() const { return WaveformWidgetType::QtWaveform; }

--- a/src/waveform/widgets/rgbwaveformwidget.cpp
+++ b/src/waveform/widgets/rgbwaveformwidget.cpp
@@ -11,7 +11,7 @@
 #include "waveform/renderers/waveformrendererendoftrack.h"
 #include "waveform/renderers/waveformrenderbeat.h"
 
-RGBWaveformWidget::RGBWaveformWidget(const char* group, QWidget* parent)
+RGBWaveformWidget::RGBWaveformWidget(const QString& group, QWidget* parent)
         : QWidget(parent),
           WaveformWidgetAbstract(group) {
     addRenderer<WaveformRenderBackground>();

--- a/src/waveform/widgets/rgbwaveformwidget.h
+++ b/src/waveform/widgets/rgbwaveformwidget.h
@@ -23,7 +23,7 @@ class RGBWaveformWidget : public QWidget, public WaveformWidgetAbstract {
     virtual void paintEvent(QPaintEvent* event);
 
   private:
-    RGBWaveformWidget(const char* group, QWidget* parent);
+    RGBWaveformWidget(const QString& group, QWidget* parent);
     friend class WaveformWidgetFactory;
 };
 

--- a/src/waveform/widgets/softwarewaveformwidget.cpp
+++ b/src/waveform/widgets/softwarewaveformwidget.cpp
@@ -11,9 +11,9 @@
 #include "waveform/renderers/waveformrendererendoftrack.h"
 #include "waveform/renderers/waveformrenderbeat.h"
 
-SoftwareWaveformWidget::SoftwareWaveformWidget(const char* group, QWidget* parent)
-    : QWidget(parent),
-      WaveformWidgetAbstract(group) {
+SoftwareWaveformWidget::SoftwareWaveformWidget(const QString& group, QWidget* parent)
+        : QWidget(parent),
+          WaveformWidgetAbstract(group) {
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
     addRenderer<WaveformRendererPreroll>();

--- a/src/waveform/widgets/softwarewaveformwidget.h
+++ b/src/waveform/widgets/softwarewaveformwidget.h
@@ -23,7 +23,7 @@ class SoftwareWaveformWidget : public QWidget, public WaveformWidgetAbstract {
     virtual void paintEvent(QPaintEvent* event);
 
   private:
-    SoftwareWaveformWidget(const char* group, QWidget* parent);
+    SoftwareWaveformWidget(const QString& groupp, QWidget* parent);
     friend class WaveformWidgetFactory;
 };
 

--- a/src/waveform/widgets/waveformwidgetabstract.cpp
+++ b/src/waveform/widgets/waveformwidgetabstract.cpp
@@ -5,9 +5,9 @@
 #include <QtDebug>
 #include <QWidget>
 
-WaveformWidgetAbstract::WaveformWidgetAbstract(const char* group)
-    : WaveformWidgetRenderer(group),
-      m_initSuccess(false) {
+WaveformWidgetAbstract::WaveformWidgetAbstract(const QString& group)
+        : WaveformWidgetRenderer(group),
+          m_initSuccess(false) {
     m_widget = NULL;
 }
 

--- a/src/waveform/widgets/waveformwidgetabstract.h
+++ b/src/waveform/widgets/waveformwidgetabstract.h
@@ -18,7 +18,7 @@ class VSyncThread;
 
 class WaveformWidgetAbstract : public WaveformWidgetRenderer {
   public:
-    WaveformWidgetAbstract(const char* group);
+    WaveformWidgetAbstract(const QString& group);
     virtual ~WaveformWidgetAbstract();
 
     //Type is use by the factory to safely up-cast waveform widgets

--- a/src/widget/wcoverart.h
+++ b/src/widget/wcoverart.h
@@ -62,7 +62,7 @@ class WCoverArt : public QWidget, public WBaseWidget, public TrackDropTarget {
   private:
     QPixmap scaledCoverArt(const QPixmap& normal);
 
-    QString m_group;
+    const QString m_group;
     UserSettingsPointer m_pConfig;
     bool m_bEnable;
     WCoverArtMenu* m_pMenu;

--- a/src/widget/whotcuebutton.cpp
+++ b/src/widget/whotcuebutton.cpp
@@ -6,8 +6,9 @@
 
 #include "mixer/playerinfo.h"
 
-WHotcueButton::WHotcueButton(QWidget* pParent)
+WHotcueButton::WHotcueButton(const QString& group, QWidget* pParent)
         : WPushButton(pParent),
+          m_group(group),
           m_hotcue(Cue::kNoHotCue),
           m_hoverCueColor(false),
           m_pCoColor(nullptr),
@@ -20,7 +21,6 @@ void WHotcueButton::setup(const QDomNode& node, const SkinContext& context) {
     // Setup parent class.
     WPushButton::setup(node, context);
 
-    m_group = context.selectString(node, QStringLiteral("Group"));
     bool ok;
     int hotcue = context.selectInt(node, QStringLiteral("Hotcue"), &ok);
     if (ok && hotcue > 0) {

--- a/src/widget/whotcuebutton.h
+++ b/src/widget/whotcuebutton.h
@@ -12,7 +12,7 @@
 class WHotcueButton : public WPushButton {
     Q_OBJECT
   public:
-    WHotcueButton(QWidget* pParent);
+    WHotcueButton(const QString& group, QWidget* pParent);
 
     void setup(const QDomNode& node, const SkinContext& context) override;
 
@@ -30,7 +30,7 @@ class WHotcueButton : public WPushButton {
     ConfigKey createConfigKey(const QString& name);
     void updateStyleSheet();
 
-    QString m_group;
+    const QString m_group;
     int m_hotcue;
     bool m_hoverCueColor;
     parented_ptr<ControlProxy> m_pCoColor;

--- a/src/widget/wkey.cpp
+++ b/src/widget/wkey.cpp
@@ -2,7 +2,7 @@
 #include "track/keys.h"
 #include "track/keyutils.h"
 
-WKey::WKey(const char* group, QWidget* pParent)
+WKey::WKey(const QString& group, QWidget* pParent)
         : WLabel(pParent),
           m_dOldValue(0),
           m_keyNotation("[Library]", "key_notation", this),

--- a/src/widget/wkey.h
+++ b/src/widget/wkey.h
@@ -9,7 +9,7 @@
 class WKey : public WLabel  {
     Q_OBJECT
   public:
-    explicit WKey(const char* group, QWidget* pParent=nullptr);
+    explicit WKey(const QString& group, QWidget* pParent = nullptr);
 
     void onConnectedControlChanged(double dParameter, double dValue) override;
     void setup(const QDomNode& node, const SkinContext& context) override;

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -6,7 +6,7 @@
 #include "util/math.h"
 #include "util/duration.h"
 
-WNumberPos::WNumberPos(const char* group, QWidget* parent)
+WNumberPos::WNumberPos(const QString& group, QWidget* parent)
         : WNumber(parent),
           m_displayFormat(TrackTime::DisplayFormat::TRADITIONAL),
           m_dOldTimeElapsed(0.0) {

--- a/src/widget/wnumberpos.h
+++ b/src/widget/wnumberpos.h
@@ -14,7 +14,7 @@ class WNumberPos : public WNumber {
     Q_OBJECT
 
   public:
-    explicit WNumberPos(const char *group, QWidget *parent=nullptr);
+    explicit WNumberPos(const QString& group, QWidget* parent = nullptr);
 
   protected:
     void mousePressEvent(QMouseEvent* pEvent) override;

--- a/src/widget/wnumberrate.cpp
+++ b/src/widget/wnumberrate.cpp
@@ -16,7 +16,7 @@
 #include "control/controlproxy.h"
 #include "util/math.h"
 
-WNumberRate::WNumberRate(const char * group, QWidget * parent)
+WNumberRate::WNumberRate(const QString& group, QWidget* parent)
         : WNumber(parent) {
     m_pRateRatio = new ControlProxy(group, "rate_ratio", this);
     m_pRateRatio->connectValueChanged(this, &WNumberRate::setValue);

--- a/src/widget/wnumberrate.h
+++ b/src/widget/wnumberrate.h
@@ -19,7 +19,7 @@ class ControlProxy;
 class WNumberRate final : public WNumber {
     Q_OBJECT
   public:
-    explicit WNumberRate(const char *group, QWidget *parent=nullptr);
+    explicit WNumberRate(const QString& group, QWidget* parent = nullptr);
 
     void setup(const QDomNode& node, const SkinContext& context) override;
 

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -41,7 +41,7 @@
 #include "wskincolor.h"
 
 WOverview::WOverview(
-        const char* group,
+        const QString& group,
         PlayerManager* pPlayerManager,
         UserSettingsPointer pConfig,
         QWidget* parent)

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -51,7 +51,7 @@ class WOverview : public WWidget, public TrackDropTarget {
 
   protected:
     WOverview(
-            const char* group,
+            const QString& group,
             PlayerManager* pPlayerManager,
             UserSettingsPointer pConfig,
             QWidget* parent = nullptr);

--- a/src/widget/woverviewhsv.cpp
+++ b/src/widget/woverviewhsv.cpp
@@ -8,11 +8,11 @@
 #include "waveform/waveform.h"
 
 WOverviewHSV::WOverviewHSV(
-        const char* group,
+        const QString& group,
         PlayerManager* pPlayerManager,
         UserSettingsPointer pConfig,
         QWidget* parent)
-        : WOverview(group, pPlayerManager, pConfig, parent)  {
+        : WOverview(group, pPlayerManager, pConfig, parent) {
 }
 
 bool WOverviewHSV::drawNextPixmapPart() {

--- a/src/widget/woverviewhsv.h
+++ b/src/widget/woverviewhsv.h
@@ -6,7 +6,7 @@
 class WOverviewHSV : public WOverview {
   public:
     WOverviewHSV(
-            const char* group,
+            const QString& group,
             PlayerManager* pPlayerManager,
             UserSettingsPointer pConfig,
             QWidget* parent = nullptr);

--- a/src/widget/woverviewlmh.cpp
+++ b/src/widget/woverviewlmh.cpp
@@ -9,13 +9,12 @@
 #include "waveform/waveform.h"
 
 WOverviewLMH::WOverviewLMH(
-        const char* group,
+        const QString& group,
         PlayerManager* pPlayerManager,
         UserSettingsPointer pConfig,
         QWidget* parent)
-        : WOverview(group, pPlayerManager, pConfig, parent)  {
+        : WOverview(group, pPlayerManager, pConfig, parent) {
 }
-
 
 bool WOverviewLMH::drawNextPixmapPart() {
     ScopedTimer t("WOverviewLMH::drawNextPixmapPart");

--- a/src/widget/woverviewlmh.h
+++ b/src/widget/woverviewlmh.h
@@ -6,7 +6,7 @@
 class WOverviewLMH : public WOverview {
   public:
     WOverviewLMH(
-            const char* group,
+            const QString& group,
             PlayerManager* pPlayerManager,
             UserSettingsPointer pConfig,
             QWidget* parent = nullptr);

--- a/src/widget/woverviewrgb.cpp
+++ b/src/widget/woverviewrgb.cpp
@@ -7,11 +7,11 @@
 #include "waveform/waveform.h"
 
 WOverviewRGB::WOverviewRGB(
-        const char* group,
+        const QString& group,
         PlayerManager* pPlayerManager,
         UserSettingsPointer pConfig,
         QWidget* parent)
-        : WOverview(group, pPlayerManager, pConfig, parent)  {
+        : WOverview(group, pPlayerManager, pConfig, parent) {
 }
 
 bool WOverviewRGB::drawNextPixmapPart() {

--- a/src/widget/woverviewrgb.h
+++ b/src/widget/woverviewrgb.h
@@ -6,7 +6,7 @@
 class WOverviewRGB : public WOverview {
   public:
     WOverviewRGB(
-            const char* group,
+            const QString& group,
             PlayerManager* pPlayerManager,
             UserSettingsPointer pConfig,
             QWidget* parent = nullptr);

--- a/src/widget/wspinny.h
+++ b/src/widget/wspinny.h
@@ -82,7 +82,7 @@ class WSpinny : public QGLWidget, public WBaseWidget, public VinylSignalQualityL
     QPixmap scaledCoverArt(const QPixmap& normal);
 
   private:
-    QString m_group;
+    const QString m_group;
     UserSettingsPointer m_pConfig;
     std::shared_ptr<QImage> m_pBgImage;
     std::shared_ptr<QImage> m_pMaskImage;

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -7,14 +7,14 @@
 
 WStarRating::WStarRating(QString group, QWidget* pParent)
         : WWidget(pParent),
-          m_starRating(0,5),
-          m_pGroup(group),
+          m_starRating(0, 5),
+          m_group(group),
           m_focused(false) {
-  // Controls to change the star rating with controllers
-  m_pStarsUp = std::make_unique<ControlPushButton>(ConfigKey(group, "stars_up"));
-  m_pStarsDown = std::make_unique<ControlPushButton>(ConfigKey(group, "stars_down"));
-  connect(m_pStarsUp.get(), SIGNAL(valueChanged(double)),this, SLOT(slotStarsUp(double)));
-  connect(m_pStarsDown.get(), SIGNAL(valueChanged(double)),this, SLOT(slotStarsDown(double)));
+    // Controls to change the star rating with controllers
+    m_pStarsUp = std::make_unique<ControlPushButton>(ConfigKey(group, "stars_up"));
+    m_pStarsDown = std::make_unique<ControlPushButton>(ConfigKey(group, "stars_down"));
+    connect(m_pStarsUp.get(), SIGNAL(valueChanged(double)), this, SLOT(slotStarsUp(double)));
+    connect(m_pStarsDown.get(), SIGNAL(valueChanged(double)), this, SLOT(slotStarsDown(double)));
 }
 
 void WStarRating::setup(const QDomNode& node, const SkinContext& context) {

--- a/src/widget/wstarrating.h
+++ b/src/widget/wstarrating.h
@@ -40,7 +40,7 @@ class WStarRating : public WWidget {
     void fillDebugTooltip(QStringList* debug) override;
 
     StarRating m_starRating;
-    QString m_pGroup;
+    const QString m_group;
     TrackPointer m_pCurrentTrack;
     bool m_focused;
     mutable QRect m_contentRect;

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -18,12 +18,13 @@ const WTrackMenu::Features trackMenuFeatures =
         WTrackMenu::Feature::Properties;
 }
 
-WTrackProperty::WTrackProperty(QWidget* pParent,
+WTrackProperty::WTrackProperty(
+        QWidget* pParent,
         UserSettingsPointer pConfig,
         TrackCollectionManager* pTrackCollectionManager,
-        const char* group)
+        const QString& group)
         : WLabel(pParent),
-          m_pGroup(group),
+          m_group(group),
           m_pConfig(pConfig),
           m_pTrackMenu(make_parented<WTrackMenu>(
                   this, pConfig, pTrackCollectionManager, trackMenuFeatures)) {
@@ -79,16 +80,16 @@ void WTrackProperty::updateLabel() {
 
 void WTrackProperty::mouseMoveEvent(QMouseEvent *event) {
     if ((event->buttons() & Qt::LeftButton) && m_pCurrentTrack) {
-        DragAndDropHelper::dragTrack(m_pCurrentTrack, this, m_pGroup);
+        DragAndDropHelper::dragTrack(m_pCurrentTrack, this, m_group);
     }
 }
 
 void WTrackProperty::dragEnterEvent(QDragEnterEvent *event) {
-    DragAndDropHelper::handleTrackDragEnterEvent(event, m_pGroup, m_pConfig);
+    DragAndDropHelper::handleTrackDragEnterEvent(event, m_group, m_pConfig);
 }
 
 void WTrackProperty::dropEvent(QDropEvent *event) {
-    DragAndDropHelper::handleTrackDropEvent(event, *this, m_pGroup, m_pConfig);
+    DragAndDropHelper::handleTrackDropEvent(event, *this, m_group, m_pConfig);
 }
 
 void WTrackProperty::contextMenuEvent(QContextMenuEvent *event) {

--- a/src/widget/wtrackproperty.h
+++ b/src/widget/wtrackproperty.h
@@ -21,7 +21,7 @@ class WTrackProperty : public WLabel, public TrackDropTarget {
             QWidget* pParent,
             UserSettingsPointer pConfig,
             TrackCollectionManager* pTrackCollectionManager,
-            const char* group);
+            const QString& group);
     ~WTrackProperty() override;
 
     void setup(const QDomNode& node, const SkinContext& context) override;
@@ -45,7 +45,7 @@ signals:
 
     void updateLabel();
 
-    const char* m_pGroup;
+    const QString m_group;
     const UserSettingsPointer m_pConfig;
     TrackPointer m_pCurrentTrack;
     QString m_property;

--- a/src/widget/wtracktext.cpp
+++ b/src/widget/wtracktext.cpp
@@ -22,9 +22,9 @@ const WTrackMenu::Features trackMenuFeatures =
 WTrackText::WTrackText(QWidget* pParent,
         UserSettingsPointer pConfig,
         TrackCollectionManager* pTrackCollectionManager,
-        const char* group)
+        const QString& group)
         : WLabel(pParent),
-          m_pGroup(group),
+          m_group(group),
           m_pConfig(pConfig),
           m_pTrackMenu(make_parented<WTrackMenu>(
                   this, pConfig, pTrackCollectionManager, trackMenuFeatures)) {
@@ -71,16 +71,16 @@ void WTrackText::updateLabel() {
 
 void WTrackText::mouseMoveEvent(QMouseEvent *event) {
     if ((event->buttons() & Qt::LeftButton) && m_pCurrentTrack) {
-        DragAndDropHelper::dragTrack(m_pCurrentTrack, this, m_pGroup);
+        DragAndDropHelper::dragTrack(m_pCurrentTrack, this, m_group);
     }
 }
 
 void WTrackText::dragEnterEvent(QDragEnterEvent *event) {
-    DragAndDropHelper::handleTrackDragEnterEvent(event, m_pGroup, m_pConfig);
+    DragAndDropHelper::handleTrackDragEnterEvent(event, m_group, m_pConfig);
 }
 
 void WTrackText::dropEvent(QDropEvent *event) {
-    DragAndDropHelper::handleTrackDropEvent(event, *this, m_pGroup, m_pConfig);
+    DragAndDropHelper::handleTrackDropEvent(event, *this, m_group, m_pConfig);
 }
 
 void WTrackText::contextMenuEvent(QContextMenuEvent* event) {

--- a/src/widget/wtracktext.h
+++ b/src/widget/wtracktext.h
@@ -42,7 +42,7 @@ class WTrackText : public WLabel, public TrackDropTarget {
 
     void updateLabel();
 
-    QString m_group;
+    const QString m_group;
     UserSettingsPointer m_pConfig;
     TrackPointer m_pCurrentTrack;
     const parented_ptr<WTrackMenu> m_pTrackMenu;

--- a/src/widget/wtracktext.h
+++ b/src/widget/wtracktext.h
@@ -20,7 +20,7 @@ class WTrackText : public WLabel, public TrackDropTarget {
             QWidget* pParent,
             UserSettingsPointer pConfig,
             TrackCollectionManager* pTrackCollectionManager,
-            const char* group);
+            const QString& group);
     ~WTrackText() override;
 
   signals:
@@ -42,7 +42,7 @@ class WTrackText : public WLabel, public TrackDropTarget {
 
     void updateLabel();
 
-    const char* m_pGroup;
+    QString m_group;
     UserSettingsPointer m_pConfig;
     TrackPointer m_pCurrentTrack;
     const parented_ptr<WTrackMenu> m_pTrackMenu;

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -17,9 +17,12 @@
 #include "waveform/waveformwidgetfactory.h"
 #include "waveform/widgets/waveformwidgetabstract.h"
 
-WWaveformViewer::WWaveformViewer(const char* group, UserSettingsPointer pConfig, QWidget* parent)
+WWaveformViewer::WWaveformViewer(
+        const QString& group,
+        UserSettingsPointer pConfig,
+        QWidget* parent)
         : WWidget(parent),
-          m_pGroup(group),
+          m_group(group),
           m_pConfig(pConfig),
           m_zoomZoneWidth(20),
           m_bScratching(false),
@@ -185,11 +188,11 @@ void WWaveformViewer::wheelEvent(QWheelEvent *event) {
 }
 
 void WWaveformViewer::dragEnterEvent(QDragEnterEvent* event) {
-    DragAndDropHelper::handleTrackDragEnterEvent(event, m_pGroup, m_pConfig);
+    DragAndDropHelper::handleTrackDragEnterEvent(event, m_group, m_pConfig);
 }
 
 void WWaveformViewer::dropEvent(QDropEvent* event) {
-    DragAndDropHelper::handleTrackDropEvent(event, *this, m_pGroup, m_pConfig);
+    DragAndDropHelper::handleTrackDropEvent(event, *this, m_group, m_pConfig);
 }
 
 void WWaveformViewer::leaveEvent(QEvent*) {

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -71,7 +71,7 @@ class WWaveformViewer : public WWidget, public TrackDropTarget {
     void setPlayMarkerPosition(double position);
 
   private:
-    QString m_group;
+    const QString m_group;
     UserSettingsPointer m_pConfig;
     int m_zoomZoneWidth;
     ControlProxy* m_pZoom;

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -23,10 +23,15 @@ class ControlPotmeter;
 class WWaveformViewer : public WWidget, public TrackDropTarget {
     Q_OBJECT
   public:
-    WWaveformViewer(const char *group, UserSettingsPointer pConfig, QWidget *parent=nullptr);
+    WWaveformViewer(
+            const QString& group,
+            UserSettingsPointer pConfig,
+            QWidget* parent = nullptr);
     ~WWaveformViewer() override;
 
-    const char* getGroup() const { return m_pGroup;}
+    const QString& getGroup() const {
+        return m_group;
+    }
     void setup(const QDomNode& node, const SkinContext& context);
 
     void dragEnterEvent(QDragEnterEvent *event) override;
@@ -41,15 +46,15 @@ class WWaveformViewer : public WWidget, public TrackDropTarget {
     void trackDropped(QString filename, QString group) override;
     void cloneDeck(QString source_group, QString target_group) override;
 
-public slots:
+  public slots:
     void slotTrackLoaded(TrackPointer track);
     void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
 
-protected:
+  protected:
     void resizeEvent(QResizeEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
 
-private slots:
+  private slots:
     void onZoomChange(double zoom);
     void slotWidgetDead() {
         m_waveformWidget = nullptr;
@@ -65,8 +70,8 @@ private slots:
     void setDisplayBeatGridAlpha(int alpha);
     void setPlayMarkerPosition(double position);
 
-private:
-    const char* m_pGroup;
+  private:
+    QString m_group;
     UserSettingsPointer m_pConfig;
     int m_zoomZoneWidth;
     ControlProxy* m_pZoom;


### PR DESCRIPTION
For accessing control objects we need QStrings and converting them on the fly
takes some unnecessary time.

I have stumbled over various time and now I finally find the mood to fix it. 

This is targeted to master, but branched from 2.3. 
So we can decide.   
