### PR TITLE
Fix line-length tool not coercing to string correctly

### DIFF
--- a/tools/line_length.py
+++ b/tools/line_length.py
@@ -27,15 +27,13 @@ FileLines = typing.NamedTuple(
 
 def get_git_added_lines() -> LineGenerator:
     proc = subprocess.run(
-        ["git", "diff", "--cached", "--unified=0"],
-        capture_output=True,
-        text=True,
+        ["git", "diff", "--cached", "--unified=0"], capture_output=True
     )
     proc.check_returncode()
     current_file = None
     current_lineno = None
     lines_left = 0
-    for line in proc.stdout.splitlines():
+    for line in str(proc.stdout).splitlines():
         match_file = re.match(r"^\+\+\+ b/(.*)$", line)
         if match_file:
             current_file = match_file.group(1)

--- a/tools/line_length.py
+++ b/tools/line_length.py
@@ -33,7 +33,7 @@ def get_git_added_lines() -> LineGenerator:
     current_file = None
     current_lineno = None
     lines_left = 0
-    for line in str(proc.stdout).splitlines():
+    for line in proc.stdout.decode(errors="replace").splitlines():
         match_file = re.match(r"^\+\+\+ b/(.*)$", line)
         if match_file:
             current_file = match_file.group(1)


### PR DESCRIPTION
Fixes issues with errors like 
`UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa9 in position 7492120: invalid start byte`
