### PR TITLE
Fix warning about implicit enumerated type conversion

### DIFF
--- a/src/library/proxytrackmodel.cpp
+++ b/src/library/proxytrackmodel.cpp
@@ -106,7 +106,11 @@ QAbstractItemDelegate* ProxyTrackModel::delegateForColumn(const int i, QObject* 
 }
 
 TrackModel::CapabilitiesFlags ProxyTrackModel::getCapabilities() const {
-    return m_pTrackModel ? m_pTrackModel->getCapabilities() : TrackModel::TRACKMODELCAPS_NONE;
+    if (m_pTrackModel) {
+        return m_pTrackModel->getCapabilities();
+    } else {
+        return static_cast<CapabilitiesFlags>(TRACKMODELCAPS_NONE);
+    }
 }
 
 bool ProxyTrackModel::filterAcceptsRow(int sourceRow,


### PR DESCRIPTION
No static_cast required when replacing the conditional expressions with a more readable
explicit if/else statement.

library/proxytrackmodel.cpp:110:26: warning:
enumerated and non-enumerated type in conditional expression [-Wextra]