### PR TITLE
widgethelper: hack around crash when right clicking cues

### DIFF
--- a/src/util/widgethelper.cpp
+++ b/src/util/widgethelper.cpp
@@ -13,15 +13,11 @@ QPoint mapPopupToScreen(
         const QWidget& widget,
         const QPoint& popupUpperLeft,
         const QSize& popupSize) {
-    const QWindow* window = widget.windowHandle();
-    VERIFY_OR_DEBUG_ASSERT(window) {
+    const auto* pWindow = getWindow(widget);
+    if (!pWindow) {
         return popupUpperLeft;
     }
-    const QScreen* screen = window->screen();
-    VERIFY_OR_DEBUG_ASSERT(screen) {
-        return popupUpperLeft;
-    }
-    const QSize screenSize = screen->size();
+    const auto screenSize = pWindow->screen()->size();
     // math_clamp() cannot be used, because if the dimensions of
     // the popup menu are greater than the screen size a debug
     // assertion would be triggered!
@@ -34,6 +30,17 @@ QPoint mapPopupToScreen(
                     popupUpperLeft.y(),
                     screenSize.height() - popupSize.height()));
     return QPoint(adjustedX, adjustedY);
+}
+
+QWindow* getWindow(
+        const QWidget& widget) {
+    if (auto* window = widget.windowHandle()) {
+        return window;
+    }
+    if (auto* nativeParent = widget.nativeParentWidget()) {
+        return nativeParent->windowHandle();
+    }
+    return nullptr;
 }
 
 } // namespace widgethelper

--- a/src/util/widgethelper.cpp
+++ b/src/util/widgethelper.cpp
@@ -13,7 +13,15 @@ QPoint mapPopupToScreen(
         const QWidget& widget,
         const QPoint& popupUpperLeft,
         const QSize& popupSize) {
-    const auto screenSize = widget.windowHandle()->screen()->size();
+    const QWindow* window = widget.windowHandle();
+    VERIFY_OR_DEBUG_ASSERT(window) {
+        return popupUpperLeft;
+    }
+    const QScreen* screen = window->screen();
+    VERIFY_OR_DEBUG_ASSERT(screen) {
+        return popupUpperLeft;
+    }
+    const QSize screenSize = screen->size();
     // math_clamp() cannot be used, because if the dimensions of
     // the popup menu are greater than the screen size a debug
     // assertion would be triggered!

--- a/src/util/widgethelper.h
+++ b/src/util/widgethelper.h
@@ -16,6 +16,14 @@ QPoint mapPopupToScreen(
         const QPoint& popupUpperLeft,
         const QSize& popupSize);
 
+/// Obtains the corresponding window for the given widget.
+///
+/// Might return nullptr if no window could be determined.
+///
+/// Adopted from windowForWidget() in qtbase/src/widgets/kernel/qapplication_p.h
+QWindow* getWindow(
+        const QWidget& widget);
+
 } // namespace widgethelper
 
 } // namespace mixxx


### PR DESCRIPTION
I do not know why QWidget::windowHandle sometimes returns nullptr,
but this should at least prevent Mixxx from crashing when that
happens.
https://bugs.launchpad.net/mixxx/+bug/1880446