### PR TITLE
CMake: Link libSoundTouch dynamically if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1795,24 +1795,32 @@ if(WIN32)
 endif()
 
 # SoundTouch
-add_library(SoundTouch STATIC EXCLUDE_FROM_ALL
-  lib/soundtouch/AAFilter.cpp
-  lib/soundtouch/BPMDetect.cpp
-  lib/soundtouch/FIFOSampleBuffer.cpp
-  lib/soundtouch/FIRFilter.cpp
-  lib/soundtouch/InterpolateCubic.cpp
-  lib/soundtouch/InterpolateLinear.cpp
-  lib/soundtouch/InterpolateShannon.cpp
-  lib/soundtouch/PeakFinder.cpp
-  lib/soundtouch/RateTransposer.cpp
-  lib/soundtouch/SoundTouch.cpp
-  lib/soundtouch/TDStretch.cpp
-  lib/soundtouch/cpu_detect_x86.cpp
-  lib/soundtouch/mmx_optimized.cpp
-  lib/soundtouch/sse_optimized.cpp
-)
-target_include_directories(SoundTouch SYSTEM PUBLIC lib/soundtouch)
-target_link_libraries(mixxx-lib PUBLIC SoundTouch)
+find_package(SoundTouch)
+cmake_dependent_option(SoundTouch_STATIC "Link libSoundTouch statically" OFF "SoundTouch_FOUND" ON)
+if(SoundTouch_STATIC)
+  message(STATUS "Preparing internal libSoundTouch")
+  add_library(SoundTouch STATIC EXCLUDE_FROM_ALL
+    lib/soundtouch/AAFilter.cpp
+    lib/soundtouch/BPMDetect.cpp
+    lib/soundtouch/FIFOSampleBuffer.cpp
+    lib/soundtouch/FIRFilter.cpp
+    lib/soundtouch/InterpolateCubic.cpp
+    lib/soundtouch/InterpolateLinear.cpp
+    lib/soundtouch/InterpolateShannon.cpp
+    lib/soundtouch/PeakFinder.cpp
+    lib/soundtouch/RateTransposer.cpp
+    lib/soundtouch/SoundTouch.cpp
+    lib/soundtouch/TDStretch.cpp
+    lib/soundtouch/cpu_detect_x86.cpp
+    lib/soundtouch/mmx_optimized.cpp
+    lib/soundtouch/sse_optimized.cpp
+  )
+  target_include_directories(SoundTouch SYSTEM PUBLIC lib)
+  target_link_libraries(mixxx-lib PUBLIC SoundTouch)
+else()
+  message(STATUS "Linking libSoundTouch dynamically")
+  target_link_libraries(mixxx-lib PUBLIC SoundTouch::SoundTouch)
+endif()
 
 # TagLib
 find_package(Taglib REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1417,7 +1417,7 @@ if(WIN32)
   if(STATIC_DEPS)
     target_compile_definitions(mixxx-lib PUBLIC CHROMAPRINT_NODLL)
   endif()
-   # Rubberband is always built statically and needs fftw.
+   # Chromaprint is always built statically and needs fftw.
   find_package(FFTW REQUIRED)
   target_link_libraries(mixxx-lib PUBLIC FFTW::FFTW)
 endif()

--- a/build/depends.py
+++ b/build/depends.py
@@ -557,7 +557,7 @@ class SoundTouch(Dependence):
 
         if build.platform_is_linux or build.platform_is_bsd:
             # Try using system lib
-            if conf.CheckForPKG('soundtouch', '2.0.0'):
+            if conf.CheckForPKG('soundtouch', '2.1.1'):
                 # System Lib found
                 if not conf.CheckLib(['SoundTouch']):
                     raise Exception(
@@ -566,7 +566,9 @@ class SoundTouch(Dependence):
                 self.INTERNAL_LINK = False
 
         if self.INTERNAL_LINK:
-            env.Append(CPPPATH=['#' + self.SOUNDTOUCH_INTERNAL_PATH])
+            # The system includes all start with <soundtouch/...>, i.e.
+            # we must omit the "soundtouch" path component here!
+            env.Append(CPPPATH=['#/lib'])
 
             # Prevents circular import.
             from .features import Optimize

--- a/cmake/modules/FindSoundTouch.cmake
+++ b/cmake/modules/FindSoundTouch.cmake
@@ -1,0 +1,86 @@
+# This file is part of Mixxx, Digital DJ'ing software.
+# Copyright (C) 2001-2020 Mixxx Development Team
+# Distributed under the GNU General Public Licence (GPL) version 2 or any later
+# later version. See the LICENSE file for details.
+
+#[=======================================================================[.rst:
+FindSoundTouch
+--------------
+
+Finds the SoundTouch library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``SoundTouch::SoundTouch``
+  The SoundTouch library
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``SoundTouch_FOUND``
+  True if the system has the SoundTouch library.
+``SoundTouch_INCLUDE_DIRS``
+  Include directories needed to use SoundTouch.
+``SoundTouch_LIBRARIES``
+  Libraries needed to link to SoundTouch.
+``SoundTouch_DEFINITIONS``
+  Compile definitions needed to use SoundTouch.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``SoundTouch_INCLUDE_DIR``
+  The directory containing ``soundtouch/SoundTouch.h``.
+``SoundTouch_LIBRARY``
+  The path to the SoundTouch library.
+
+#]=======================================================================]
+
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+  pkg_check_modules(PC_SoundTouch QUIET SoundTouch>=2.1.1)
+endif()
+
+find_path(SoundTouch_INCLUDE_DIR
+  NAMES soundtouch/SoundTouch.h
+  PATHS ${PC_SoundTouch_INCLUDE_DIRS}
+  DOC "SoundTouch include directory")
+mark_as_advanced(SoundTouch_INCLUDE_DIR)
+
+find_library(SoundTouch_LIBRARY
+  NAMES SoundTouch
+  PATHS ${PC_SoundTouch_LIBRARY_DIRS}
+  DOC "SoundTouch library"
+)
+mark_as_advanced(SoundTouch_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  SoundTouch
+  DEFAULT_MSG
+  SoundTouch_LIBRARY
+  SoundTouch_INCLUDE_DIR
+)
+
+if(SoundTouch_FOUND)
+  set(SoundTouch_LIBRARIES "${SoundTouch_LIBRARY}")
+  set(SoundTouch_INCLUDE_DIRS "${SoundTouch_INCLUDE_DIR}")
+  set(SoundTouch_DEFINITIONS ${PC_SoundTouch_CFLAGS_OTHER})
+
+  if(NOT TARGET SoundTouch::SoundTouch)
+    add_library(SoundTouch::SoundTouch UNKNOWN IMPORTED)
+    set_target_properties(SoundTouch::SoundTouch
+      PROPERTIES
+        IMPORTED_LOCATION "${SoundTouch_LIBRARY}"
+        INTERFACE_COMPILE_OPTIONS "${PC_SoundTouch_CFLAGS_OTHER}"
+        INTERFACE_INCLUDE_DIRECTORIES "${SoundTouch_INCLUDE_DIR}"
+    )
+  endif()
+endif()

--- a/src/analyzer/plugins/analyzersoundtouchbeats.cpp
+++ b/src/analyzer/plugins/analyzersoundtouchbeats.cpp
@@ -1,6 +1,6 @@
 #include "analyzer/plugins/analyzersoundtouchbeats.h"
 
-#include <BPMDetect.h>
+#include <soundtouch/BPMDetect.h>
 
 #include "analyzer/constants.h"
 #include "util/sample.h"

--- a/src/engine/bufferscalers/enginebufferscalest.cpp
+++ b/src/engine/bufferscalers/enginebufferscalest.cpp
@@ -1,9 +1,7 @@
 #include "engine/bufferscalers/enginebufferscalest.h"
 
 // Fixes redefinition warnings from SoundTouch.
-#undef TRUE
-#undef FALSE
-#include <SoundTouch.h>
+#include <soundtouch/SoundTouch.h>
 
 #include "control/controlobject.h"
 #include "engine/engineobject.h"

--- a/src/util/version.cpp
+++ b/src/util/version.cpp
@@ -1,15 +1,12 @@
 #include "util/version.h"
 
+#include <soundtouch/SoundTouch.h>
+
 #include <QCoreApplication>
 #include <QStandardPaths>
 #include <QStringList>
 #include <QtDebug>
 #include <QtGlobal>
-
-// Fixes redefinition warnings from SoundTouch.
-#undef TRUE
-#undef FALSE
-#include <SoundTouch.h>
 
 // shout.h checks for WIN32 to see if we are on Windows.
 #ifdef WIN64


### PR DESCRIPTION
- Require libSoundTouch v2.1.1 (= current/bundled version)
- Fix system includes in C++ files (affects both SCons + CMake)