### PR TITLE
Roland DJ-505: Add new "Edit" pad mode

### DIFF
--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -1419,7 +1419,12 @@ DJ505.EditMode = function(deck, offset) {
 
     this.pads = new components.ComponentContainer();
     for (var i = 0; i <= 3; i++) {
-        var baseKey = ((i < 2) ? "intro" : "outro") + "_" + ((i % 2) ? "end" : "start");
+        var baseKey = [
+            "intro_start",
+            "intro_end",
+            "outro_start",
+            "outro_end",
+        ][i];
         var color = (i % 2) ? DJ505.PadColor.AZURE : DJ505.PadColor.BLUE;
 
         this.pads[i] = new components.Button({

--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -1425,7 +1425,7 @@ DJ505.EditMode = function(deck, offset) {
             "outro_start",
             "outro_end",
         ][i];
-        var color = (i % 2) ? DJ505.PadColor.AZURE : DJ505.PadColor.BLUE;
+        var color = (i > 1) ? DJ505.PadColor.AZURE : DJ505.PadColor.BLUE;
 
         this.pads[i] = new components.Button({
             midi: [0x94 + offset, 0x14 + i],

--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -1109,6 +1109,7 @@ DJ505.PadSection = function(deck, offset) {
         // call won't influence all modes at once
         "hotcue": new DJ505.HotcueMode(deck, offset),
         "cueloop": new DJ505.CueLoopMode(deck, offset),
+        "edit": new DJ505.EditMode(deck, offset),
         "roll": new DJ505.RollMode(deck, offset),
         "sampler": new DJ505.SamplerMode(deck, offset),
         "velocitysampler": new DJ505.VelocitySamplerMode(deck, offset),
@@ -1137,7 +1138,11 @@ DJ505.PadSection.prototype.controlToPadMode = function(control) {
     //    mode = this.modes.flip;
     //    break;
     case DJ505.PadMode.CUELOOP:
-        mode = this.modes.cueloop;
+        if (this.currentMode === this.modes.cueloop) {
+            mode = this.modes.edit;
+        } else {
+            mode = this.modes.cueloop;
+        }
         break;
     case DJ505.PadMode.TR:
     case DJ505.PadMode.PATTERN:
@@ -1406,6 +1411,53 @@ DJ505.CueLoopMode = function(deck, offset) {
     });
 };
 DJ505.CueLoopMode.prototype = Object.create(components.ComponentContainer.prototype);
+
+DJ505.EditMode = function(deck, offset) {
+    components.ComponentContainer.call(this);
+    this.ledControl = DJ505.PadMode.HOTCUE;
+    this.color = DJ505.PadColor.ORANGE;
+
+    this.pads = new components.ComponentContainer();
+    for (var i = 0; i <= 3; i++) {
+        var baseKey = ((i < 2) ? "intro" : "outro") + "_" + ((i % 2) ? "end" : "start");
+        var color = (i % 2) ? DJ505.PadColor.AZURE : DJ505.PadColor.BLUE;
+
+        this.pads[i] = new components.Button({
+            midi: [0x94 + offset, 0x14 + i],
+            sendShifted: true,
+            shiftControl: true,
+            shiftOffset: 8,
+            baseKey: baseKey,
+            outKey: baseKey + "_enabled",
+            group: deck.currentDeck,
+            on: color,
+            off: color + DJ505.PadColor.DIM_MODIFIER,
+            outConnect: false,
+            unshift: function() {
+                this.inKey = this.baseKey + "_activate";
+            },
+            shift: function() {
+                this.inKey = this.baseKey + "_clear";
+            },
+        });
+    }
+
+    // Disable other pads (reserved for editing downbeats or sections)
+    for (i = 4; i <= 7; i++) {
+        this.pads[i] = new components.Component({
+            midi: [0x94 + offset, 0x14 + i],
+            sendShifted: true,
+            shiftControl: true,
+            shiftOffset: 8,
+            input: function(_channel, _control, _value, _status, _group) {},
+            connect: function() {},
+            trigger: function() {
+                this.send(0);
+            },
+        });
+    }
+};
+DJ505.EditMode.prototype = Object.create(components.ComponentContainer.prototype);
 
 DJ505.RollMode = function(deck, offset) {
     components.ComponentContainer.call(this);

--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -1175,8 +1175,10 @@ DJ505.PadSection.prototype.controlToPadMode = function(control) {
     return mode;
 };
 
-DJ505.PadSection.prototype.padModeButtonPressed = function(channel, control, _value, _status, _group) {
-    this.setPadMode(control);
+DJ505.PadSection.prototype.padModeButtonPressed = function(channel, control, value, _status, _group) {
+    if (value) {
+        this.setPadMode(control);
+    }
 };
 
 DJ505.PadSection.prototype.paramButtonPressed = function(channel, control, value, status, group) {

--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -1415,7 +1415,7 @@ DJ505.CueLoopMode.prototype = Object.create(components.ComponentContainer.protot
 DJ505.EditMode = function(deck, offset) {
     components.ComponentContainer.call(this);
     this.ledControl = DJ505.PadMode.HOTCUE;
-    this.color = DJ505.PadColor.ORANGE;
+    this.color = DJ505.PadColor.RED;
 
     this.pads = new components.ComponentContainer();
     for (var i = 0; i <= 3; i++) {


### PR DESCRIPTION
Currently only the top pad row is used for editing the intro/outro cues,
but when downbeat support lands the bottom row could be used to edit
these and modify the beatgrid.

This is how it looks when intro start/end and outro end are set (but not outro start). 
![IMG_20200613_190055](https://user-images.githubusercontent.com/1834516/84574841-8cb56d80-ada9-11ea-8d16-be5f106f0187.jpg)

This is how it looks when all intro start/end and outro start/end cues are set. 
![IMG_20200613_190110](https://user-images.githubusercontent.com/1834516/84574842-8de69a80-ada9-11ea-817c-16852663cf1a.jpg)
