### PR TITLE
libebur128: Enable dynamic linking on Debian/Ubuntu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -198,6 +198,7 @@ addons:
     packages:
       - libavformat-dev
       - libchromaprint-dev
+      - libebur128-dev
       - libfaad-dev
       - libflac-dev
       - libid3tag0-dev

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,6 +63,7 @@ for:
       libavformat-dev
       libavutil-dev
       libchromaprint-dev
+      libebur128-dev
       libflac-dev
       libid3tag0-dev
       liblilv-dev

--- a/build/debian/control
+++ b/build/debian/control
@@ -51,6 +51,7 @@ Build-Depends: debhelper (>= 9),
                liblilv-dev,
                libmodplug-dev,
                libmp3lame-dev,
+               libebur128-dev,
 # for running mixxx-test
                xvfb
 Standards-Version: 3.9.8

--- a/cmake/modules/FindEbur128.cmake
+++ b/cmake/modules/FindEbur128.cmake
@@ -45,7 +45,7 @@ The following cache variables may also be set:
 
 find_package(PkgConfig QUIET)
 if(PkgConfig_FOUND)
-  pkg_check_modules(PC_Ebur128 QUIET libebur128)
+  pkg_check_modules(PC_Ebur128 QUIET libebur128>=1.2.4)
 endif()
 
 find_path(Ebur128_INCLUDE_DIR


### PR DESCRIPTION
We still link our bundled version statically even though this is not necessary on Ubuntu 18.04.

I also added a lower bound for the version on CMake, just in case. The current, official version has proven to work for us.