### PR TITLE
WEffectselector: make tooltips easier to read

### DIFF
--- a/src/widget/weffectselector.cpp
+++ b/src/widget/weffectselector.cpp
@@ -57,15 +57,12 @@ void WEffectSelector::populate() {
                                                        width() - 2);
         addItem(elidedDisplayName, QVariant(pManifest->id()));
 
-        // NOTE(Be): Using \n instead of : as the separator does not work in
-        // QComboBox item tooltips.
-        // TODO(Be): Check if this is also the case with Qt5.
-        //: %1 = effect name; %2 = effect description
-        QString description = tr("%1: %2").arg(pManifest->name(),
-                                               pManifest->description());
-        // The <span/> is a hack to get Qt to treat the string as rich text so
-        // it automatically wraps long lines.
-        setItemData(i, QVariant("<span/>" + description), Qt::ToolTipRole);
+        QString name = pManifest->name();
+        QString description = pManifest->description();
+        // <b> makes the effect name bold. Also, like <span> it serves as hack
+        // to get Qt to treat the string as rich text so it automatically wraps long lines.
+        setItemData(i, QVariant(QStringLiteral("<b>") + name + QStringLiteral("</b><br/>") +
+                description), Qt::ToolTipRole);
     }
 
     //: Displayed when no effect is loaded


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/5934199/85046582-e98d9b00-b190-11ea-92c2-c2159181fd45.png)

this PR
![image](https://user-images.githubusercontent.com/5934199/85046339-94ea2000-b190-11ea-94f3-3acce55256e6.png)