### PR TITLE
Add groundwork for Controller COs

### DIFF
--- a/src/controllers/bulk/bulkcontroller.cpp
+++ b/src/controllers/bulk/bulkcontroller.cpp
@@ -70,10 +70,12 @@ static QString get_string(libusb_device_handle *handle, u_int8_t id) {
 }
 
 BulkController::BulkController(
+        const QString& group,
         libusb_context* context,
         libusb_device_handle* handle,
         struct libusb_device_descriptor* desc)
-        : m_context(context),
+        : Controller(group),
+          m_context(context),
           m_phandle(handle),
           in_epaddr(0),
           out_epaddr(0) {

--- a/src/controllers/bulk/bulkcontroller.h
+++ b/src/controllers/bulk/bulkcontroller.h
@@ -43,6 +43,7 @@ class BulkController : public Controller {
     Q_OBJECT
   public:
     BulkController(
+            const QString& group,
             libusb_context* context,
             libusb_device_handle* handle,
             struct libusb_device_descriptor* desc);

--- a/src/controllers/bulk/bulkenumerator.cpp
+++ b/src/controllers/bulk/bulkenumerator.cpp
@@ -59,7 +59,7 @@ QList<Controller*> BulkEnumerator::queryDevices() {
 
             // Generate a group for this controller
             QString group = QStringLiteral("[BulkController") +
-                    QString::number(index) + QStringLiteral("]");
+                    QString::number(index) + QChar(']');
             index++;
 
             BulkController* currentDevice =

--- a/src/controllers/bulk/bulkenumerator.cpp
+++ b/src/controllers/bulk/bulkenumerator.cpp
@@ -43,6 +43,7 @@ QList<Controller*> BulkEnumerator::queryDevices() {
     ssize_t i = 0;
     int err = 0;
 
+    int index = 1;
     for (i = 0; i < cnt; i++) {
         libusb_device *device = list[i];
         struct libusb_device_descriptor desc;
@@ -56,8 +57,13 @@ QList<Controller*> BulkEnumerator::queryDevices() {
                 continue;
             }
 
+            // Generate a group for this controller
+            QString group = QStringLiteral("[BulkController") +
+                    QString::number(index) + QStringLiteral("]");
+            index++;
+
             BulkController* currentDevice =
-                    new BulkController(m_context, handle, &desc);
+                    new BulkController(group, m_context, handle, &desc);
             m_devices.push_back(currentDevice);
         }
     }

--- a/src/controllers/controller.cpp
+++ b/src/controllers/controller.cpp
@@ -13,8 +13,9 @@
 #include "controllers/defs_controllers.h"
 #include "util/screensaver.h"
 
-Controller::Controller()
-        : m_pEngine(nullptr),
+Controller::Controller(const QString& group)
+        : m_group(group),
+          m_pEngine(nullptr),
           m_bIsOutputDevice(false),
           m_bIsInputDevice(false),
           m_bIsOpen(false),

--- a/src/controllers/controller.cpp
+++ b/src/controllers/controller.cpp
@@ -5,10 +5,12 @@
 * @brief Base class representing a physical (or software) controller.
 */
 
+#include "controllers/controller.h"
+
 #include <QApplication>
 #include <QJSValue>
 
-#include "controllers/controller.h"
+#include "control/controlobject.h"
 #include "controllers/controllerdebug.h"
 #include "controllers/defs_controllers.h"
 #include "util/screensaver.h"
@@ -21,6 +23,9 @@ Controller::Controller(const QString& group)
           m_bIsOpen(false),
           m_bLearning(false) {
     m_userActivityInhibitTimer.start();
+
+    m_pReloadScripts = make_parented<ControlObject>(ConfigKey(group, "reload_scripts"), this);
+    connect(m_pReloadScripts, &ControlObject::valueChanged, this, &Controller::slotReloadScripts);
 }
 
 Controller::~Controller() {
@@ -86,6 +91,14 @@ void Controller::stopLearning() {
     //qDebug() << m_sDeviceName << "stopped learning.";
     m_bLearning = false;
 
+}
+
+void Controller::slotReloadScripts(double v) {
+    if (!v || !m_pEngine) {
+        return;
+    }
+
+    m_pEngine->reloadScripts();
 }
 
 void Controller::send(QList<int> data, unsigned int length) {

--- a/src/controllers/controller.h
+++ b/src/controllers/controller.h
@@ -19,7 +19,9 @@
 #include "controllers/controllervisitor.h"
 #include "controllers/engine/controllerengine.h"
 #include "util/duration.h"
+#include "util/parented_ptr.h"
 
+class ControlObject;
 class ControllerJSProxy;
 
 class Controller : public QObject, ConstControllerPresetVisitor {
@@ -106,6 +108,8 @@ class Controller : public QObject, ConstControllerPresetVisitor {
     void startLearning();
     void stopLearning();
 
+    void slotReloadScripts(double v);
+
   protected:
     // The length parameter is here for backwards compatibility for when scripts
     // were required to specify it.
@@ -183,6 +187,8 @@ class Controller : public QObject, ConstControllerPresetVisitor {
     bool m_bIsOpen;
     bool m_bLearning;
     QElapsedTimer m_userActivityInhibitTimer;
+
+    parented_ptr<ControlObject> m_pReloadScripts;
 
     friend class ControllerJSProxy;
     // accesses lots of our stuff, but in the same thread

--- a/src/controllers/controller.h
+++ b/src/controllers/controller.h
@@ -25,7 +25,7 @@ class ControllerJSProxy;
 class Controller : public QObject, ConstControllerPresetVisitor {
     Q_OBJECT
   public:
-    Controller();
+    Controller(const QString& group);
     ~Controller() override;  // Subclass should call close() at minimum.
 
     /// The object that is exposed to the JS scripts as the "controller" object.
@@ -64,6 +64,10 @@ class Controller : public QObject, ConstControllerPresetVisitor {
     inline const QString& getCategory() const {
         return m_sDeviceCategory;
     }
+    const QString& getGroup() const {
+        return m_group;
+    }
+
     virtual bool isMappable() const = 0;
     inline bool isLearning() const {
         return m_bLearning;
@@ -160,6 +164,10 @@ class Controller : public QObject, ConstControllerPresetVisitor {
     // Returns a pointer to the currently loaded controller preset. For internal
     // use only.
     virtual ControllerPreset* preset() = 0;
+
+    /// Group name for control objects
+    const QString m_group;
+
     ControllerEngine* m_pEngine;
 
     // Verbose and unique device name suitable for display.

--- a/src/controllers/engine/controllerengine.cpp
+++ b/src/controllers/engine/controllerengine.cpp
@@ -277,6 +277,7 @@ void ControllerEngine::initializeScripts(const QList<ControllerPreset::ScriptFil
     QJSValueList args;
     args << QJSValue(m_pController->getName());
     args << QJSValue(ControllerDebug::enabled());
+    args << QJSValue(m_pController->getGroup());
 
     // Call the init method for all the prefixes.
     bool success = callFunctionOnObjects(m_scriptFunctionPrefixes, "init", args, true);

--- a/src/controllers/engine/controllerengine.h
+++ b/src/controllers/engine/controllerengine.h
@@ -51,6 +51,8 @@ class ControllerEngine : public QObject {
         m_bTesting = testing;
     };
 
+    void reloadScripts();
+
   protected:
     double getValue(QString group, QString name);
     void setValue(QString group, QString name, double newValue);
@@ -115,7 +117,6 @@ class ControllerEngine : public QObject {
     bool evaluateScriptFile(const QFileInfo& scriptFile);
     void initializeScriptEngine();
     void uninitializeScriptEngine();
-    void reloadScripts();
 
     void scriptErrorDialog(const QString& detailedError, const QString& key, bool bFatal = false);
     void generateScriptFunctions(const QString& code);

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -20,10 +20,11 @@ ControllerJSProxy* HidController::jsProxy() {
     return new HidControllerJSProxy(this);
 }
 
-HidController::HidController(const hid_device_info& deviceInfo)
-        : Controller(),
+HidController::HidController(
+        const QString& group,
+        const hid_device_info& deviceInfo)
+        : Controller(group),
           m_pHidDevice(NULL) {
-
     // Copy required variables from deviceInfo, which will be freed after
     // this class is initialized by caller.
     hid_vendor_id = deviceInfo.vendor_id;

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -20,7 +20,7 @@
 class HidController final : public Controller {
     Q_OBJECT
   public:
-    HidController(const hid_device_info& deviceInfo);
+    HidController(const QString& group, const hid_device_info& deviceInfo);
     ~HidController() override;
 
     ControllerJSProxy* jsProxy() override;

--- a/src/controllers/hid/hidenumerator.cpp
+++ b/src/controllers/hid/hidenumerator.cpp
@@ -102,7 +102,7 @@ QList<Controller*> HidEnumerator::queryDevices() {
 
         // Generate a group for this controller
         QString group = QStringLiteral("[HidController") +
-                QString::number(index) + QStringLiteral("]");
+                QString::number(index) + QChar(']');
         index++;
 
         HidController* currentDevice = new HidController(group, *cur_dev);

--- a/src/controllers/hid/hidenumerator.cpp
+++ b/src/controllers/hid/hidenumerator.cpp
@@ -68,6 +68,7 @@ QList<Controller*> HidEnumerator::queryDevices() {
     struct hid_device_info *devs, *cur_dev;
     devs = hid_enumerate(0x0, 0x0);
 
+    int index = 1;
     for (cur_dev = devs; cur_dev; cur_dev = cur_dev->next) {
         if (isDeviceBlacklisted(cur_dev)) {
             // OS/X and windows use usage_page/usage not interface_number
@@ -99,7 +100,12 @@ QList<Controller*> HidEnumerator::queryDevices() {
             continue;
         }
 
-        HidController* currentDevice = new HidController(*cur_dev);
+        // Generate a group for this controller
+        QString group = QStringLiteral("[HidController") +
+                QString::number(index) + QStringLiteral("]");
+        index++;
+
+        HidController* currentDevice = new HidController(group, *cur_dev);
         m_devices.push_back(currentDevice);
     }
     hid_free_enumeration(devs);

--- a/src/controllers/midi/hss1394controller.cpp
+++ b/src/controllers/midi/hss1394controller.cpp
@@ -65,10 +65,11 @@ void DeviceChannelListener::Reconnected() {
 }
 
 Hss1394Controller::Hss1394Controller(
+        const QString& group,
         const hss1394::TNodeInfo& deviceInfo,
         int deviceIndex,
         UserSettingsPointer pConfig)
-        : MidiController(),
+        : MidiController(group),
           m_deviceInfo(deviceInfo),
           m_iDeviceIndex(deviceIndex) {
     // Note: We prepend the input stream's index to the device's name to prevent

--- a/src/controllers/midi/hss1394controller.h
+++ b/src/controllers/midi/hss1394controller.h
@@ -44,6 +44,7 @@ class Hss1394Controller : public MidiController {
     Q_OBJECT
   public:
     Hss1394Controller(
+            const QString& group,
             const hss1394::TNodeInfo& deviceInfo,
             int deviceIndex,
             UserSettingsPointer pConfig);

--- a/src/controllers/midi/hss1394enumerator.cpp
+++ b/src/controllers/midi/hss1394enumerator.cpp
@@ -48,7 +48,7 @@ QList<Controller*> Hss1394Enumerator::queryDevices() {
 
             // Generate a group for this controller
             QString group = QStringLiteral("[Hss1374Controller") +
-                    QString::number(index) + QStringLiteral("]");
+                    QString::number(index) + QChar(']');
             index++;
 
             Hss1394Controller* currentDevice = new Hss1394Controller(

--- a/src/controllers/midi/hss1394enumerator.cpp
+++ b/src/controllers/midi/hss1394enumerator.cpp
@@ -32,6 +32,7 @@ QList<Controller*> Hss1394Enumerator::queryDevices() {
     hss1394::uint uNodes = Node::Instance()->GetNodeCount();
     qDebug() << "   Nodes detected:" << uNodes;
 
+    int index = 1;
     for(hss1394::uint i=0; i<40; i++) {
         TNodeInfo tNodeInfo;
         bool bInstalled;
@@ -44,8 +45,14 @@ QList<Controller*> Hss1394Enumerator::queryDevices() {
                          QString("%1").arg(tNodeInfo.uGUID.mu32Low, 0, 16),
                          QString("%1").arg(tNodeInfo.uProtocolVersion, 0, 16));
             qDebug() << " " << message;
+
+            // Generate a group for this controller
+            QString group = QStringLiteral("[Hss1374Controller") +
+                    QString::number(index) + QStringLiteral("]");
+            index++;
+
             Hss1394Controller* currentDevice = new Hss1394Controller(
-                    tNodeInfo, i, m_pConfig);
+                    group, tNodeInfo, i, m_pConfig);
             m_devices.push_back(currentDevice);
         }
     }

--- a/src/controllers/midi/midicontroller.cpp
+++ b/src/controllers/midi/midicontroller.cpp
@@ -17,8 +17,8 @@
 #include "util/math.h"
 #include "util/screensaver.h"
 
-MidiController::MidiController()
-        : Controller() {
+MidiController::MidiController(const QString& group)
+        : Controller(group) {
     setDeviceCategory(tr("MIDI Controller"));
 }
 

--- a/src/controllers/midi/midicontroller.h
+++ b/src/controllers/midi/midicontroller.h
@@ -23,7 +23,7 @@
 class MidiController : public Controller {
     Q_OBJECT
   public:
-    explicit MidiController();
+    explicit MidiController(const QString& group);
     ~MidiController() override;
 
     ControllerJSProxy* jsProxy() override;

--- a/src/controllers/midi/portmidicontroller.cpp
+++ b/src/controllers/midi/portmidicontroller.cpp
@@ -11,11 +11,12 @@
 #include "controllers/midi/portmidicontroller.h"
 #include "controllers/controllerdebug.h"
 
-PortMidiController::PortMidiController(const PmDeviceInfo* inputDeviceInfo,
+PortMidiController::PortMidiController(const QString& group,
+        const PmDeviceInfo* inputDeviceInfo,
         const PmDeviceInfo* outputDeviceInfo,
         int inputDeviceIndex,
         int outputDeviceIndex)
-        : MidiController(), m_cReceiveMsg_index(0), m_bInSysex(false) {
+        : MidiController(group), m_cReceiveMsg_index(0), m_bInSysex(false) {
     for (unsigned int k = 0; k < MIXXX_PORTMIDI_BUFFER_LEN; ++k) {
         // Can be shortened to `m_midiBuffer[k] = {}` with C++11.
         m_midiBuffer[k].message = 0;

--- a/src/controllers/midi/portmidicontroller.h
+++ b/src/controllers/midi/portmidicontroller.h
@@ -59,7 +59,8 @@
 class PortMidiController : public MidiController {
     Q_OBJECT
   public:
-    PortMidiController(const PmDeviceInfo* inputDeviceInfo,
+    PortMidiController(const QString& group,
+            const PmDeviceInfo* inputDeviceInfo,
             const PmDeviceInfo* outputDeviceInfo,
             int inputDeviceIndex,
             int outputDeviceIndex);

--- a/src/controllers/midi/portmidienumerator.cpp
+++ b/src/controllers/midi/portmidienumerator.cpp
@@ -218,6 +218,7 @@ QList<Controller*> PortMidiEnumerator::queryDevices() {
     }
 
     // Search for input devices and pair them with output devices if applicable
+    int index = 1;
     for (int i = 0; i < iNumDevices; i++) {
         const PmDeviceInfo* deviceInfo = Pm_GetDeviceInfo(i);
         if (shouldBlacklistDevice(deviceInfo)) {
@@ -253,13 +254,19 @@ QList<Controller*> PortMidiEnumerator::queryDevices() {
                 }
             }
 
+            // Generate a group for this controller
+            QString group = QStringLiteral("[PortMidiController") +
+                    QString::number(index) + QStringLiteral("]");
+            index++;
+
             // So at this point, we either have an input-only MIDI device
             // (outputDeviceInfo == NULL) or we've found a matching output MIDI
             // device (outputDeviceInfo != NULL).
 
             //.... so create our (aggregate) MIDI device!
             PortMidiController* currentDevice =
-                    new PortMidiController(inputDeviceInfo,
+                    new PortMidiController(group,
+                            inputDeviceInfo,
                             outputDeviceInfo,
                             inputDevIndex,
                             outputDevIndex);

--- a/src/controllers/midi/portmidienumerator.cpp
+++ b/src/controllers/midi/portmidienumerator.cpp
@@ -256,7 +256,7 @@ QList<Controller*> PortMidiEnumerator::queryDevices() {
 
             // Generate a group for this controller
             QString group = QStringLiteral("[PortMidiController") +
-                    QString::number(index) + QStringLiteral("]");
+                    QString::number(index) + QChar(']');
             index++;
 
             // So at this point, we either have an input-only MIDI device

--- a/src/test/controller_preset_validation_test.cpp
+++ b/src/test/controller_preset_validation_test.cpp
@@ -24,8 +24,9 @@ void FakeControllerJSProxy::sendShortMsg(unsigned char status,
     Q_UNUSED(byte2);
 }
 
-FakeController::FakeController()
-        : m_bMidiPreset(false),
+FakeController::FakeController(const QString& group)
+        : Controller(group),
+          m_bMidiPreset(false),
           m_bHidPreset(false) {
     startEngine();
     getEngine()->setTesting(true);
@@ -77,7 +78,7 @@ bool ControllerPresetValidationTest::testLoadPreset(const PresetInfo& preset) {
         return false;
     }
 
-    FakeController controller;
+    FakeController controller("[FakeController]");
     controller.setDeviceName("Test Controller");
     controller.setPreset(*pPreset);
     // Do not initialize the scripts.

--- a/src/test/controller_preset_validation_test.h
+++ b/src/test/controller_preset_validation_test.h
@@ -23,7 +23,7 @@ class FakeControllerJSProxy : public ControllerJSProxy {
 class FakeController : public Controller {
     Q_OBJECT
   public:
-    FakeController();
+    FakeController(const QString& group);
     ~FakeController() override;
 
     QString presetExtension() override {

--- a/src/test/midicontrollertest.cpp
+++ b/src/test/midicontrollertest.cpp
@@ -12,7 +12,9 @@
 
 class MockMidiController : public MidiController {
   public:
-    explicit MockMidiController(): MidiController() {}
+    explicit MockMidiController(const QString& group)
+            : MidiController(group) {
+    }
     ~MockMidiController() override { }
 
     MOCK_METHOD0(open, int());
@@ -27,7 +29,7 @@ class MockMidiController : public MidiController {
 class MidiControllerTest : public MixxxTest {
   protected:
     void SetUp() override {
-        m_pController.reset(new MockMidiController());
+        m_pController.reset(new MockMidiController("[MockMidiControler]"));
     }
 
     void addMapping(MidiInputMapping mapping) {

--- a/src/test/portmidicontroller_test.cpp
+++ b/src/test/portmidicontroller_test.cpp
@@ -15,11 +15,15 @@ using ::testing::SetArrayArgument;
 
 class MockPortMidiController : public PortMidiController {
   public:
-    MockPortMidiController(const PmDeviceInfo* inputDeviceInfo,
+    MockPortMidiController(
+            const QString& group,
+            const PmDeviceInfo* inputDeviceInfo,
             const PmDeviceInfo* outputDeviceInfo,
             int inputDeviceIndex,
             int outputDeviceIndex)
-            : PortMidiController(inputDeviceInfo,
+            : PortMidiController(
+                      group,
+                      inputDeviceInfo,
                       outputDeviceInfo,
                       inputDeviceIndex,
                       outputDeviceIndex) {
@@ -74,7 +78,11 @@ class PortMidiControllerTest : public MixxxTest {
         m_outputDeviceInfo.opened = 0;
 
         m_pController.reset(new MockPortMidiController(
-                &m_inputDeviceInfo, &m_outputDeviceInfo, 0, 0));
+                "[MockPortMidiController]",
+                &m_inputDeviceInfo,
+                &m_outputDeviceInfo,
+                0,
+                0));
         m_pController->setPortMidiInputDevice(m_mockInput);
         m_pController->setPortMidiOutputDevice(m_mockOutput);
     }


### PR DESCRIPTION
This add a group attribute to each controller, so that we can create COs for each controller. This group is passed as third parameter to the script's `init` function, so that controller-specific COs can be access from the controller itself.

Right now, this adds a `reload_scripts` CO for each controller. I know if this is actually useful, but in theory you could actually reload the controller script using a button press on the controller itself (although you should only need this if your controller script is buggy). I mostly implemented this as a Proof of Concept and can remove this if you want.

The actual reason why I implemented this is because I really want to have MIDI Clock support at some point, and one prerequisite is controller-specific COs to toggle sync lock (and disable/enable MTC output). So if I press the SYNC button for the drum machine on my controller, it would then set `[PortMidiControllerN],sync_enabled` to 1 and Mixxx could start sending/receiving MIDI timing clock signals.