### PR TITLE
Fix restrict warnings

### DIFF
--- a/src/engine/effects/engineeffect.cpp
+++ b/src/engine/effects/engineeffect.cpp
@@ -205,16 +205,16 @@ bool EngineEffect::process(const ChannelHandle& inputHandle,
             if (effectiveEffectEnableState == EffectEnableState::Disabling) {
                 DEBUG_ASSERT(pInput != pOutput); // Fade to dry only works if pInput is not touched by pOutput
                 // Fade out (fade to dry signal)
-                SampleUtil::copy2WithRampingGain(pOutput,
-                        pInput, 0.0, 1.0,
-                        pOutput, 1.0, 0.0,
+                SampleUtil::linearCrossfadeBuffersOut(
+                        pOutput,
+                        pInput,
                         numSamples);
             } else if (effectiveEffectEnableState == EffectEnableState::Enabling) {
                 DEBUG_ASSERT(pInput != pOutput); // Fade to dry only works if pInput is not touched by pOutput
                 // Fade in (fade to wet signal)
-                SampleUtil::copy2WithRampingGain(pOutput,
-                        pInput, 1.0, 0.0,
-                        pOutput, 0.0, 1.0,
+                SampleUtil::linearCrossfadeBuffersIn(
+                        pOutput,
+                        pInput,
                         numSamples);
             }
         }

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -967,8 +967,10 @@ void EngineBuffer::processTrackLocked(
         // callback and the m_filepos_play is advanced behind the end of the track.
 
         if (m_bCrossfadeReady) {
-           SampleUtil::linearCrossfadeBuffers(
-                    pOutput, m_pCrossfadeBuffer, pOutput, iBufferSize);
+            // Bring pOutput with the new parameters in and fade out the old one,
+            // stored with the old parameters in m_pCrossfadeBuffer
+            SampleUtil::linearCrossfadeBuffersIn(
+                    pOutput, m_pCrossfadeBuffer, iBufferSize);
         }
         // Note: we do not fade here if we pass the end or the start of
         // the track in reverse direction

--- a/src/engine/filters/enginefilteriir.h
+++ b/src/engine/filters/enginefilteriir.h
@@ -62,9 +62,10 @@ class EngineFilterIIR : public EngineFilterIIRBase {
     // this is can be used instead off a final process() call before pause
     // It fades to dry or 0 according to the m_startFromDry parameter
     // it is an alternative for using pauseFillter() calls
-    void processAndPauseFilter(const CSAMPLE* M_RESTRICT pIn,
-            CSAMPLE* M_RESTRICT pOutput,
-            const int iBufferSize) {
+    void processAndPauseFilter(
+            const CSAMPLE* pIn,
+            CSAMPLE* pOutput,
+            int iBufferSize) {
         process(pIn, pOutput, iBufferSize);
         if (m_startFromDry) {
             SampleUtil::linearCrossfadeBuffersOut(

--- a/src/engine/filters/enginefilteriir.h
+++ b/src/engine/filters/enginefilteriir.h
@@ -62,13 +62,20 @@ class EngineFilterIIR : public EngineFilterIIRBase {
     // this is can be used instead off a final process() call before pause
     // It fades to dry or 0 according to the m_startFromDry parameter
     // it is an alternative for using pauseFillter() calls
-    void processAndPauseFilter(const CSAMPLE* pIn, CSAMPLE* pOutput,
-                       const int iBufferSize) {
+    void processAndPauseFilter(const CSAMPLE* M_RESTRICT pIn,
+            CSAMPLE* M_RESTRICT pOutput,
+            const int iBufferSize) {
         process(pIn, pOutput, iBufferSize);
-        SampleUtil::copy2WithRampingGain(pOutput,
-                pOutput, 1.0, 0,  // fade out filtered
-                pIn, 0, m_startFromDry ? 1.0 : 0,  // fade in dry if requested
-                iBufferSize);
+        if (m_startFromDry) {
+            SampleUtil::linearCrossfadeBuffersOut(
+                    pOutput, // fade out filtered
+                    pIn,     // fade in dry
+                    iBufferSize);
+        } else {
+            SampleUtil::applyRampingGain(
+                    pOutput, 1.0, 0, // fade out filtered
+                    iBufferSize);
+        }
         pauseFilterInner();
     }
 

--- a/src/engine/filters/enginefiltermoogladder4.h
+++ b/src/engine/filters/enginefiltermoogladder4.h
@@ -108,12 +108,13 @@ class EngineFilterMoogLadderBase : public EngineObjectConstIn {
     // this is can be used instead off a final process() call before pause
     // It fades to dry or 0 according to the m_startFromDry parameter
     // it is an alternative for using pauseFillter() calls
-    void processAndPauseFilter(const CSAMPLE* pIn, CSAMPLE* pOutput,
-                       const int iBufferSize) {
+    void processAndPauseFilter(const CSAMPLE* M_RESTRICT pIn,
+            CSAMPLE* M_RESTRICT pOutput,
+            const int iBufferSize) {
         process(pIn, pOutput, iBufferSize);
-        SampleUtil::copy2WithRampingGain(pOutput,
-                pOutput, 1.0, 0,  // fade out filtered
-                pIn, 0, 1.0,  // fade in dry
+        SampleUtil::linearCrossfadeBuffersOut(
+                pOutput, // fade out filtered
+                pIn,     // fade in dry
                 iBufferSize);
         initBuffers();
     }
@@ -143,7 +144,7 @@ class EngineFilterMoogLadderBase : public EngineObjectConstIn {
                 pOutput[i] = processSample(pIn[i], &m_buf[0]);
                 pOutput[i+1] = processSample(pIn[i+1], &m_buf[1]);
             }
-            
+
         } else {
             m_postGain = m_postGainNew;
             m_kacr = m_kacrNew;

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -156,7 +156,10 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
 
         // do crossfade from the current buffer into the new loop beginning
         if (samples_from_reader != 0) { // avoid division by zero
-            SampleUtil::linearCrossfadeBuffers(pOutput, pOutput, m_pCrossFadeBuffer, samples_from_reader);
+            SampleUtil::linearCrossfadeBuffersOut(
+                    pOutput,
+                    m_pCrossFadeBuffer,
+                    samples_from_reader);
         }
     }
 

--- a/src/test/sampleutiltest.cpp
+++ b/src/test/sampleutiltest.cpp
@@ -224,24 +224,6 @@ TEST_F(SampleUtilTest, copy2WithGain) {
     }
 }
 
-TEST_F(SampleUtilTest, copy2WithGainAliased) {
-    for (int i = 0; i < buffers.size(); ++i) {
-        CSAMPLE* buffer = buffers[i];
-        int size = sizes[i];
-        FillBuffer(buffer, 1.0f, size);
-        SampleUtil::copy2WithGain(buffer,
-                                  buffer, 1.0,
-                                  buffer, 1.0,
-                                  size);
-        AssertWholeBufferEquals(buffer, 2.0f, size);
-        SampleUtil::copy2WithGain(buffer,
-                                  buffer, 2.0,
-                                  buffer, 3.0,
-                                  size);
-        AssertWholeBufferEquals(buffer, 10.0f, size);
-    }
-}
-
 TEST_F(SampleUtilTest, copy3WithGain) {
     for (int i = 0; i < buffers.size(); ++i) {
         CSAMPLE* buffer = buffers[i];
@@ -268,26 +250,6 @@ TEST_F(SampleUtilTest, copy3WithGain) {
         SampleUtil::free(buffer2);
         SampleUtil::free(buffer3);
         SampleUtil::free(buffer4);
-    }
-}
-
-TEST_F(SampleUtilTest, copy3WithGainAliased) {
-    for (int i = 0; i < buffers.size(); ++i) {
-        CSAMPLE* buffer = buffers[i];
-        int size = sizes[i];
-        FillBuffer(buffer, 1.0f, size);
-        SampleUtil::copy3WithGain(buffer,
-                                  buffer, 1.0,
-                                  buffer, 1.0,
-                                  buffer, 1.0,
-                                  size);
-        AssertWholeBufferEquals(buffer, 3.0f, size);
-        SampleUtil::copy3WithGain(buffer,
-                                  buffer, 2.0,
-                                  buffer, 3.0,
-                                  buffer, 4.0,
-                                  size);
-        AssertWholeBufferEquals(buffer, 27.0f, size);
     }
 }
 

--- a/src/util/sample.cpp
+++ b/src/util/sample.cpp
@@ -446,19 +446,37 @@ void SampleUtil::deinterleaveBuffer(CSAMPLE* M_RESTRICT pDest1,
 }
 
 // static
-void SampleUtil::linearCrossfadeBuffers(CSAMPLE* pDest,
-        const CSAMPLE* pSrcFadeOut, const CSAMPLE* pSrcFadeIn,
+void SampleUtil::linearCrossfadeBuffersOut(
+        CSAMPLE* pDestSrcFadeOut,
+        const CSAMPLE* pSrcFadeIn,
         SINT numSamples) {
+    // M_RESTRICT unoptimizes the function for some reason.
     const CSAMPLE_GAIN cross_inc = CSAMPLE_GAIN_ONE
             / CSAMPLE_GAIN(numSamples / 2);
     // note: LOOP VECTORIZED. only with "int i"
     for (int i = 0; i < numSamples / 2; ++i) {
         const CSAMPLE_GAIN cross_mix = cross_inc * i;
-        pDest[i * 2] = pSrcFadeIn[i * 2] * cross_mix
-                + pSrcFadeOut[i * 2] * (CSAMPLE_GAIN_ONE - cross_mix);
-        pDest[i * 2 + 1] = pSrcFadeIn[i * 2 + 1] * cross_mix
-                + pSrcFadeOut[i * 2 + 1] * (CSAMPLE_GAIN_ONE - cross_mix);
+        pDestSrcFadeOut[i * 2] *= (CSAMPLE_GAIN_ONE - cross_mix);
+        pDestSrcFadeOut[i * 2] += pSrcFadeIn[i * 2] * cross_mix;
+        pDestSrcFadeOut[i * 2 + 1] *= (CSAMPLE_GAIN_ONE - cross_mix);
+        pDestSrcFadeOut[i * 2 + 1] += pSrcFadeIn[i * 2 + 1] * cross_mix;
+    }
+}
 
+// static
+void SampleUtil::linearCrossfadeBuffersIn(
+        CSAMPLE* pDestSrcFadeIn,
+        const CSAMPLE* pSrcFadeOut,
+        SINT numSamples) {
+    // M_RESTRICT unoptimizes the function for some reason.
+    const CSAMPLE_GAIN cross_inc = CSAMPLE_GAIN_ONE / CSAMPLE_GAIN(numSamples / 2);
+    // note: LOOP VECTORIZED. only with "int i"
+    for (int i = 0; i < numSamples / 2; ++i) {
+        const CSAMPLE_GAIN cross_mix = cross_inc * i;
+        pDestSrcFadeIn[i * 2] *= cross_mix;
+        pDestSrcFadeIn[i * 2] += pSrcFadeOut[i * 2] * (CSAMPLE_GAIN_ONE - cross_mix);
+        pDestSrcFadeIn[i * 2 + 1] *= cross_mix;
+        pDestSrcFadeIn[i * 2 + 1] += pSrcFadeOut[i * 2 + 1] * (CSAMPLE_GAIN_ONE - cross_mix);
     }
 }
 

--- a/src/util/sample.h
+++ b/src/util/sample.h
@@ -223,13 +223,12 @@ class SampleUtil {
     static void deinterleaveBuffer(CSAMPLE* pDest1, CSAMPLE* pDest2,
             const CSAMPLE* pSrc, SINT numSamples);
 
-    // Crossfade two buffers together and put the result in pDest.  All the
-    // buffers must be the same length.  pDest may be an alias of the source
-    // buffers.  It is preferable to use the copyWithRamping functions, but
-    // sometimes this function is necessary.
-    static void linearCrossfadeBuffers(CSAMPLE* pDest,
-            const CSAMPLE* pSrcFadeOut, const CSAMPLE* pSrcFadeIn,
-            SINT numSamples);
+    /// Crossfade two buffers together. All the buffers must be the same length.
+    /// pDest is in one version the Out and in the other version the In buffer.
+    static void linearCrossfadeBuffersOut(
+            CSAMPLE* pDestSrcFadeOut, const CSAMPLE* pSrcFadeIn, SINT numSamples);
+    static void linearCrossfadeBuffersIn(
+            CSAMPLE* pDestSrcFadeIn, const CSAMPLE* pSrcFadeOut, SINT numSamples);
 
     // Mix a buffer down to mono, putting the result in both of the channels.
     // This uses a simple (L+R)/2 method, which assumes that the audio is


### PR DESCRIPTION
I have created new in place cross fading functions, which surprisingly perform much faster, because the compiler makes use of the SSE commands.   

This fixes the use of copy2WithRampingGain which relies on undefined behavior of the compiler. 