### PR TITLE
AppVeyor: Remove Ubuntu 18.04 build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ max_jobs: 1
 image:
   - Visual Studio 2017
   - Ubuntu2004
-  - Ubuntu1804
 
 configuration:
   - release-fastbuild
@@ -23,8 +22,6 @@ platform:
 matrix:
   exclude:
     # Ubuntu doesn't support "release-fastbuild".
-    - image: Ubuntu1804
-      configuration: release-fastbuild
     - image: Ubuntu2004
       configuration: release-fastbuild
     # We only want "release-fastbuild" for Windows since "release" consumes too
@@ -130,91 +127,10 @@ for:
     - xsltproc -o ctest-to-junit-results.xml ../cmake/ctest-to-junit.xsl Testing/*/Test.xml
     - curl -F 'file=@ctest-to-junit-results.xml' "https://ci.appveyor.com/api/testresults/junit/$APPVEYOR_JOB_ID"
 
--
-  matrix:
-    only:
-      - image: Ubuntu1804
-
-  clone_folder: /home/appveyor/projects/mixxx
-
-  cache:
-    - /home/appveyor/.ccache
-
-  install:
-    - sudo apt-get update
-    - sudo apt-get -y install
-      ccache
-      libavformat-dev
-      libchromaprint-dev
-      libfaad-dev
-      libflac-dev
-      libid3tag0-dev
-      liblilv-dev
-      libmad0-dev
-      libmodplug-dev
-      libmp3lame-dev
-      libmp4v2-dev
-      libopus-dev
-      libopusfile-dev
-      libportmidi-dev
-      libprotobuf-dev
-      libqt5opengl5-dev
-      libqt5sql5-sqlite
-      libqt5svg5-dev
-      libqt5x11extras5-dev
-      librubberband-dev
-      libshout3-dev
-      libsndfile1-dev
-      libsoundtouch-dev
-      libsqlite3-dev
-      libtag1-dev
-      libupower-glib-dev
-      libusb-1.0-0-dev
-      libwavpack-dev
-      portaudio19-dev
-      protobuf-compiler
-      python3-pip
-      qt5-default
-      qt5keychain-dev
-      qtscript5-dev
-      xsltproc
-    - sudo pip3 install cmake
-
-  before_build:
-     # Limit cache size to 100 MB
-    - ccache -M 100M
-    - ccache -c
-    - ccache -s
-
-  build_script:
-    - export CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
-    - mkdir cmake_build
-    - cd cmake_build
-    - cmake
-      -L
-      -DFAAD=ON
-      -DHSS1394=OFF
-      -DLOCALECOMPARE=ON
-      -DMAD=ON
-      -DMODPLUG=ON
-      -DOPUS=ON
-      -DWAVPACK=ON
-      ..
-    - cmake --build .
-    - sudo cmake --build . --target install
-
-  test_script:
-    - export CTEST_OUTPUT_ON_FAILURE=1
-    - xvfb-run -- ctest -T test --no-compress-output
-    - xvfb-run -- cmake --build . --target benchmark
-
-  after_test:
-    - xsltproc -o ctest-to-junit-results.xml ../cmake/ctest-to-junit.xsl Testing/*/Test.xml
-    - curl -F 'file=@ctest-to-junit-results.xml' "https://ci.appveyor.com/api/testresults/junit/$APPVEYOR_JOB_ID"
-
 ########## END UBUNTU SPECIFIC CONFIGURATION ##########
 
 ########## WINDOWS SPECIFIC CONFIGURATION ##########
+
 -
   matrix:
     only:


### PR DESCRIPTION
This is not needed, because we already build Ubuntu 18.04 on Travis. To reduce the precious build times.