### PR TITLE
Travis: Don't install homebrew dev env for macOS CMake build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,28 @@ jobs:
         directories:
           - $HOME/Library/Caches/Homebrew
           - /usr/local/Homebrew
+      addons:
+        homebrew:
+          update: true
+          packages:
+            - chromaprint
+            - flac
+            - lame
+            - libsndfile
+            - libogg
+            - libvorbis
+            - libshout
+            - libid3tag
+            - libmad
+            - lilv
+            - opusfile
+            - portaudio
+            - portmidi
+            - protobuf
+            - qt5
+            - rubberband
+            - sound-touch
+            - taglib
       # Workaround for bug in libopus's opus.h including <opus_multistream.h>
       # instead of <opus/opus_multistream.h>.
       # Virtual X (Xvfb) is needed for analyzer waveform tests
@@ -226,32 +248,6 @@ addons:
       - qt5-default
       - qtscript5-dev
       - qt5keychain-dev
-  homebrew:
-    update: true
-    packages:
-      - chromaprint
-      - faad2
-      - ffmpeg
-      - flac
-      - lame
-      - libsndfile
-      - libogg
-      - libvorbis
-      - libshout
-      - libmodplug
-      - libid3tag
-      - libmad
-      - lilv
-      - mp4v2
-      - opusfile
-      - portaudio
-      - portmidi
-      - protobuf
-      - qt5
-      - rubberband
-      - sound-touch
-      - taglib
-      - wavpack
 
 
 notifications:


### PR DESCRIPTION
Instead only the packages from the buildserver golden environment should be used.

The homebrew packages are only needed for the legacy SCons build.