### PR TITLE
.travis.yml: Turn on WARNINGS_FATAL for CMake builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ jobs:
       compiler: gcc
       cache: ccache
       # Ubuntu Bionic build prerequisites
-      env: CMAKEFLAGS_EXTRA="-DLOCALECOMPARE=ON -DFAAD=ON -DWAVPACK=ON -DMAD=ON -DMODPLUG=ON"
+      env: CMAKEFLAGS_EXTRA="-DLOCALECOMPARE=ON -DFAAD=ON -DWAVPACK=ON -DMAD=ON -DMODPLUG=ON -DWARNINGS_FATAL=ON"
       before_install:
         - export CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
         - export CTEST_PARALLEL_LEVEL="$(nproc)"


### PR DESCRIPTION
This should make sure that our code is and stays warning free.