### PR TITLE
WTrackMenu: Cleanup & optimization

### DIFF
--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -791,7 +791,7 @@ TrackPointer WTrackMenu::getFirstTrackPointer() const {
     }
 }
 
-QModelIndexList WTrackMenu::getTrackIndices() const {
+const QModelIndexList& WTrackMenu::getTrackIndices() const {
     // Indices are associated with a TrackModel. Can only be obtained
     // if a TrackModel is available.
     DEBUG_ASSERT(m_pTrackModel);

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -7,6 +7,7 @@
 #include "library/dao/playlistdao.h"
 #include "preferences/usersettings.h"
 #include "track/track.h"
+#include "track/trackref.h"
 
 class ControlProxy;
 class DlgTagFetcher;
@@ -127,6 +128,7 @@ class WTrackMenu : public QMenu {
     QModelIndexList getTrackIndices() const;
 
     TrackIdList getTrackIds() const;
+    QList<TrackRef> getTrackRefs() const;
 
     // TODO: This function desperately needs to be replaced
     // by an iterator pattern that loads (and drops) tracks

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -131,7 +131,9 @@ class WTrackMenu : public QMenu {
     // TODO: This function desperately needs to be replaced
     // by an iterator pattern that loads (and drops) tracks
     // lazily one-by-one during the traversal!!
-    TrackPointerList getTrackPointers(int maxSize = -1) const;
+    TrackPointerList getTrackPointers() const;
+
+    TrackPointer getFirstTrackPointer() const;
 
     bool isEmpty() const {
         return getTrackCount() == 0;

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -125,7 +125,7 @@ class WTrackMenu : public QMenu {
   private:
     // This getter verifies that m_pTrackModel is set when
     // invoked.
-    QModelIndexList getTrackIndices() const;
+    const QModelIndexList& getTrackIndices() const;
 
     TrackIdList getTrackIds() const;
     QList<TrackRef> getTrackRefs() const;


### PR DESCRIPTION
A minor refactoring for 2.3 before introducing new stuff on master:

- Explicitly load the first selected track, thereby avoiding to load and then discard all remaining selected track objects
- Avoid loading of track objects when only the locations or `TrackRef`s are needed

The getTrackPointers() method is still a killer and all the batch processing operations are not suitable for huge track selections. This especially affects the migration to 2.4 where users might want to reload all their cover art in advance to avoid performance regressions during performance. Otherwise cover art is migrated lazily while browsing the library. This may cause frequent UI freezes as reported for macOS.