### PR TITLE
Prevent wrong usage of Control Objects with assertions

### DIFF
--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -145,9 +145,7 @@ QSharedPointer<ControlDoublePrivate> ControlDoublePrivate::getControl(
         } else if (!flags.testFlag(ControlFlag::NoWarnIfMissing)) {
             qWarning() << "ControlDoublePrivate::getControl returning NULL for ("
                        << key.group << "," << key.item << ")";
-            if (!flags.testFlag(ControlFlag::NoAssertIfMissing)) {
-                DEBUG_ASSERT(!"ControlObject not found");
-            }
+            DEBUG_ASSERT(flags.testFlag(ControlFlag::NoAssertIfMissing));
         }
     }
     return pControl;

--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -126,7 +126,7 @@ QSharedPointer<ControlDoublePrivate> ControlDoublePrivate::getControl(
         auto it = s_qCOHash.constFind(key);
         if (it != s_qCOHash.constEnd()) {
             if (pCreatorCO) {
-                qDebug() << "ControlObject" << key.group << key.item << "already created";
+                qWarning() << "ControlObject" << key.group << key.item << "already created";
                 DEBUG_ASSERT(!"ControlObject already created");
             } else {
                 pControl = it.value();

--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -115,6 +115,10 @@ QSharedPointer<ControlDoublePrivate> ControlDoublePrivate::getControl(
         return QSharedPointer<ControlDoublePrivate>();
     }
 
+    // Setting this flag makes no sense here and indicates that the programmer
+    // is confused and should consider taking a little break.
+    DEBUG_ASSERT(!flags.testFlag(ControlFlag::InitializeLater));
+
     QSharedPointer<ControlDoublePrivate> pControl;
     // Scope for MMutexLocker.
     {

--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -115,10 +115,6 @@ QSharedPointer<ControlDoublePrivate> ControlDoublePrivate::getControl(
         return QSharedPointer<ControlDoublePrivate>();
     }
 
-    // Setting this flag makes no sense here and indicates that the programmer
-    // is confused and should consider taking a little break.
-    DEBUG_ASSERT(!flags.testFlag(ControlFlag::InitializeLater));
-
     QSharedPointer<ControlDoublePrivate> pControl;
     // Scope for MMutexLocker.
     {

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -15,7 +15,6 @@ class ControlObject;
 
 enum class ControlFlag {
     None = 0,
-    InitializeLater = 1,
     AllowEmptyKey = 1 << 1,
     NoAssertIfMissing = 1 << 2,
     NoWarnIfMissing = (1 << 3) | NoAssertIfMissing,

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -15,8 +15,10 @@ class ControlObject;
 
 enum class ControlFlag {
     None = 0,
-    NoWarnIfMissing = 1,
-    NoAssertIfMissing = 2,
+    InitializeLater = 1,
+    AllowEmptyKey = 1 << 1,
+    NoAssertIfMissing = 1 << 2,
+    NoWarnIfMissing = (1 << 3) | NoAssertIfMissing,
 };
 
 Q_DECLARE_FLAGS(ControlFlags, ControlFlag)

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -13,6 +13,15 @@
 
 class ControlObject;
 
+enum class ControlFlag {
+    None = 0,
+    NoWarnIfMissing = 1,
+    NoAssertIfMissing = 2,
+};
+
+Q_DECLARE_FLAGS(ControlFlags, ControlFlag)
+Q_DECLARE_OPERATORS_FOR_FLAGS(ControlFlags)
+
 class ControlDoublePrivate : public QObject {
     Q_OBJECT
   public:
@@ -33,10 +42,13 @@ class ControlDoublePrivate : public QObject {
     // Gets the ControlDoublePrivate matching the given ConfigKey. If pCreatorCO
     // is non-NULL, allocates a new ControlDoublePrivate for the ConfigKey if
     // one does not exist.
-    static QSharedPointer<ControlDoublePrivate> getControl(
-            const ConfigKey& key, bool warn = true,
-            ControlObject* pCreatorCO = NULL, bool bIgnoreNops = true, bool bTrack = false,
-            bool bPersist = false, double defaultValue = 0.0);
+    static QSharedPointer<ControlDoublePrivate> getControl(const ConfigKey& key,
+            ControlFlags flags = ControlFlag::None,
+            ControlObject* pCreatorCO = NULL,
+            bool bIgnoreNops = true,
+            bool bTrack = false,
+            bool bPersist = false,
+            double defaultValue = 0.0);
 
     // Adds all ControlDoublePrivate that currently exist to pControlList
     static void getControls(QList<QSharedPointer<ControlDoublePrivate> >* pControlsList);

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -15,9 +15,9 @@ class ControlObject;
 
 enum class ControlFlag {
     None = 0,
-    AllowEmptyKey = 1 << 1,
-    NoAssertIfMissing = 1 << 2,
-    NoWarnIfMissing = (1 << 3) | NoAssertIfMissing,
+    AllowEmptyKey = 1,
+    NoAssertIfMissing = 1 << 1,
+    NoWarnIfMissing = (1 << 2) | NoAssertIfMissing,
 };
 
 Q_DECLARE_FLAGS(ControlFlags, ControlFlag)

--- a/src/control/controlmodel.cpp
+++ b/src/control/controlmodel.cpp
@@ -21,8 +21,8 @@ void ControlModel::addControl(const ConfigKey& key,
     info.key = key;
     info.title = title;
     info.description = description;
-    info.pControl = new ControlProxy(this);
-    info.pControl->initialize(info.key);
+    info.pControl = new ControlProxy(info.key, this);
+    info.pControl->initialize();
 
     beginInsertRows(QModelIndex(), m_controls.size(),
                     m_controls.size());

--- a/src/control/controlobject.cpp
+++ b/src/control/controlobject.cpp
@@ -33,8 +33,13 @@ ControlObject::ControlObject(ConfigKey key, bool bIgnoreNops, bool bTrack,
         : m_key(key) {
     // Don't bother looking up the control if key is NULL. Prevents log spew.
     if (!m_key.isNull()) {
-        m_pControl = ControlDoublePrivate::getControl(m_key, true, this,
-                bIgnoreNops, bTrack, bPersist, defaultValue);
+        m_pControl = ControlDoublePrivate::getControl(m_key,
+                ControlFlag::None,
+                this,
+                bIgnoreNops,
+                bTrack,
+                bPersist,
+                defaultValue);
     }
 
     // getControl can fail and return a NULL control even with the create flag.
@@ -62,9 +67,9 @@ void ControlObject::privateValueChanged(double dValue, QObject* pSender) {
 }
 
 // static
-ControlObject* ControlObject::getControl(const ConfigKey& key, bool warn) {
+ControlObject* ControlObject::getControl(const ConfigKey& key, ControlFlags flags) {
     //qDebug() << "ControlObject::getControl for (" << key.group << "," << key.item << ")";
-    QSharedPointer<ControlDoublePrivate> pCDP = ControlDoublePrivate::getControl(key, warn);
+    QSharedPointer<ControlDoublePrivate> pCDP = ControlDoublePrivate::getControl(key, flags);
     if (pCDP) {
         return pCDP->getCreatorCO();
     }

--- a/src/control/controlobject.h
+++ b/src/control/controlobject.h
@@ -42,10 +42,12 @@ class ControlObject : public QObject {
     virtual ~ControlObject();
 
     // Returns a pointer to the ControlObject matching the given ConfigKey
-    static ControlObject* getControl(const ConfigKey& key, bool warn = true);
-    static inline ControlObject* getControl(const QString& group, const QString& item, bool warn = true) {
+    static ControlObject* getControl(const ConfigKey& key, ControlFlags flags = ControlFlag::None);
+    static inline ControlObject* getControl(const QString& group,
+            const QString& item,
+            ControlFlags flags = ControlFlag::None) {
         ConfigKey key(group, item);
-        return getControl(key, warn);
+        return getControl(key, flags);
     }
 
     QString name() const {

--- a/src/control/controlobject.h
+++ b/src/control/controlobject.h
@@ -15,8 +15,7 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef CONTROLOBJECT_H
-#define CONTROLOBJECT_H
+#pragma once
 
 #include <QObject>
 #include <QEvent>
@@ -43,7 +42,7 @@ class ControlObject : public QObject {
 
     // Returns a pointer to the ControlObject matching the given ConfigKey
     static ControlObject* getControl(const ConfigKey& key, ControlFlags flags = ControlFlag::None);
-    static inline ControlObject* getControl(const QString& group,
+    static ControlObject* getControl(const QString& group,
             const QString& item,
             ControlFlags flags = ControlFlag::None) {
         ConfigKey key(group, item);
@@ -185,5 +184,3 @@ class ControlObject : public QObject {
         return m_pControl ? m_pControl->ignoreNops() : true;
     }
 };
-
-#endif

--- a/src/control/controlobjectscript.cpp
+++ b/src/control/controlobjectscript.cpp
@@ -3,7 +3,7 @@
 #include "control/controlobjectscript.h"
 
 ControlObjectScript::ControlObjectScript(const ConfigKey& key, QObject* pParent)
-        : ControlProxy(key, pParent) {
+        : ControlProxy(key, pParent, ControlFlag::NoAssertIfMissing) {
 }
 
 bool ControlObjectScript::addScriptConnection(const ScriptConnection& conn) {

--- a/src/control/controlproxy.cpp
+++ b/src/control/controlproxy.cpp
@@ -8,26 +8,26 @@ ControlProxy::ControlProxy(QObject* pParent)
           m_pControl(NULL) {
 }
 
-ControlProxy::ControlProxy(const QString& g, const QString& i, QObject* pParent)
+ControlProxy::ControlProxy(const QString& g, const QString& i, QObject* pParent, ControlFlags flags)
         : QObject(pParent) {
-    initialize(ConfigKey(g, i));
+    initialize(ConfigKey(g, i), flags);
 }
 
-ControlProxy::ControlProxy(const char* g, const char* i, QObject* pParent)
+ControlProxy::ControlProxy(const char* g, const char* i, QObject* pParent, ControlFlags flags)
         : QObject(pParent) {
-    initialize(ConfigKey(g, i));
+    initialize(ConfigKey(g, i), flags);
 }
 
-ControlProxy::ControlProxy(const ConfigKey& key, QObject* pParent)
+ControlProxy::ControlProxy(const ConfigKey& key, QObject* pParent, ControlFlags flags)
         : QObject(pParent) {
-    initialize(key);
+    initialize(key, flags);
 }
 
-void ControlProxy::initialize(const ConfigKey& key, bool warn) {
+void ControlProxy::initialize(const ConfigKey& key, ControlFlags flags) {
     m_key = key;
     // Don't bother looking up the control if key is NULL. Prevents log spew.
     if (!key.isNull()) {
-        m_pControl = ControlDoublePrivate::getControl(key, warn);
+        m_pControl = ControlDoublePrivate::getControl(key, flags);
     }
 }
 

--- a/src/control/controlproxy.cpp
+++ b/src/control/controlproxy.cpp
@@ -18,7 +18,6 @@ ControlProxy::ControlProxy(const ConfigKey& key, QObject* pParent, ControlFlags 
     m_key = key;
 
     if (!flags.testFlag(ControlFlag::InitializeLater)) {
-        flags.setFlag(ControlFlag::InitializeLater, false);
         initialize(flags);
     }
 }

--- a/src/control/controlproxy.cpp
+++ b/src/control/controlproxy.cpp
@@ -17,7 +17,7 @@ ControlProxy::ControlProxy(const ConfigKey& key, QObject* pParent, ControlFlags 
     DEBUG_ASSERT(!key.isNull() || flags.testFlag(ControlFlag::AllowEmptyKey));
     m_key = key;
 
-    if (!m_key.isNull() && !flags.testFlag(ControlFlag::InitializeLater)) {
+    if (!m_key.isNull()) {
         initialize(flags);
     }
 }

--- a/src/control/controlproxy.cpp
+++ b/src/control/controlproxy.cpp
@@ -27,14 +27,13 @@ void ControlProxy::initialize(ControlFlags flags) {
     DEBUG_ASSERT(!m_pControl);
 
     // Prevent empty keys
-    if (m_key.isNull()) {
-        DEBUG_ASSERT(flags.testFlag(ControlFlag::AllowEmptyKey));
+    VERIFY_OR_DEBUG_ASSERT(!m_key.isNull() || flags.testFlag(ControlFlag::AllowEmptyKey)) {
         return;
     }
 
     m_pControl = ControlDoublePrivate::getControl(m_key, flags);
-    DEBUG_ASSERT(flags.testFlag(ControlFlag::NoAssertIfMissing) || m_pControl);
-    DEBUG_ASSERT(flags.testFlag(ControlFlag::NoAssertIfMissing) || valid());
+    DEBUG_ASSERT(m_pControl || flags.testFlag(ControlFlag::NoAssertIfMissing));
+    DEBUG_ASSERT(valid() || flags.testFlag(ControlFlag::NoAssertIfMissing));
 }
 
 ControlProxy::~ControlProxy() {

--- a/src/control/controlproxy.cpp
+++ b/src/control/controlproxy.cpp
@@ -17,7 +17,7 @@ ControlProxy::ControlProxy(const ConfigKey& key, QObject* pParent, ControlFlags 
     DEBUG_ASSERT(!key.isNull() || flags.testFlag(ControlFlag::AllowEmptyKey));
     m_key = key;
 
-    if (!flags.testFlag(ControlFlag::InitializeLater)) {
+    if (!m_key.isNull() && !flags.testFlag(ControlFlag::InitializeLater)) {
         initialize(flags);
     }
 }

--- a/src/control/controlproxy.h
+++ b/src/control/controlproxy.h
@@ -19,7 +19,6 @@
 class ControlProxy : public QObject {
     Q_OBJECT
   public:
-    ControlProxy(QObject* pParent = NULL);
     ControlProxy(const QString& g,
             const QString& i,
             QObject* pParent = NULL,
@@ -33,7 +32,7 @@ class ControlProxy : public QObject {
             ControlFlags flags = ControlFlag::None);
     virtual ~ControlProxy();
 
-    void initialize(const ConfigKey& key, ControlFlags flags = ControlFlag::None);
+    void initialize(ControlFlags flags = ControlFlag::None);
 
     const ConfigKey& getKey() const {
         return m_key;

--- a/src/control/controlproxy.h
+++ b/src/control/controlproxy.h
@@ -21,14 +21,14 @@ class ControlProxy : public QObject {
   public:
     ControlProxy(const QString& g,
             const QString& i,
-            QObject* pParent = NULL,
+            QObject* pParent = nullptr,
             ControlFlags flags = ControlFlag::None);
     ControlProxy(const char* g,
             const char* i,
-            QObject* pParent = NULL,
+            QObject* pParent = nullptr,
             ControlFlags flags = ControlFlag::None);
     ControlProxy(const ConfigKey& key,
-            QObject* pParent = NULL,
+            QObject* pParent = nullptr,
             ControlFlags flags = ControlFlag::None);
     virtual ~ControlProxy();
 
@@ -115,7 +115,7 @@ class ControlProxy : public QObject {
     }
 
     inline bool valid() const {
-        return m_pControl != NULL;
+        return m_pControl != nullptr;
     }
 
     // Returns the value of the object. Thread safe, non-blocking.
@@ -166,7 +166,7 @@ class ControlProxy : public QObject {
             // NOTE(rryan): This is important. The originator of this action does
             // not know the resulting value so it makes sense that we should emit a
             // general valueChanged() signal even though the change originated from
-            // us. For this reason, we provide NULL here so that the change is
+            // us. For this reason, we provide nullptr here so that the change is
             // not filtered in valueChanged()
             m_pControl->reset();
         }

--- a/src/control/controlproxy.h
+++ b/src/control/controlproxy.h
@@ -20,12 +20,20 @@ class ControlProxy : public QObject {
     Q_OBJECT
   public:
     ControlProxy(QObject* pParent = NULL);
-    ControlProxy(const QString& g, const QString& i, QObject* pParent = NULL);
-    ControlProxy(const char* g, const char* i, QObject* pParent = NULL);
-    ControlProxy(const ConfigKey& key, QObject* pParent = NULL);
+    ControlProxy(const QString& g,
+            const QString& i,
+            QObject* pParent = NULL,
+            ControlFlags flags = ControlFlag::None);
+    ControlProxy(const char* g,
+            const char* i,
+            QObject* pParent = NULL,
+            ControlFlags flags = ControlFlag::None);
+    ControlProxy(const ConfigKey& key,
+            QObject* pParent = NULL,
+            ControlFlags flags = ControlFlag::None);
     virtual ~ControlProxy();
 
-    void initialize(const ConfigKey& key, bool warn = true);
+    void initialize(const ConfigKey& key, ControlFlags flags = ControlFlag::None);
 
     const ConfigKey& getKey() const {
         return m_key;

--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -676,13 +676,13 @@ void ControllerEngine::setValue(QString group, QString name, double newValue) {
     ControlObjectScript* coScript = getControlObjectScript(group, name);
 
     if (coScript != nullptr) {
-        ControlObject* pControl = ControlObject::getControl(coScript->getKey());
+        ControlObject* pControl = ControlObject::getControl(
+                coScript->getKey(), ControlFlag::NoAssertIfMissing);
         if (pControl && !m_st.ignore(pControl, coScript->getParameterForValue(newValue))) {
             coScript->slotSet(newValue);
         }
     }
 }
-
 
 /* -------- ------------------------------------------------------
    Purpose: Returns the normalized value of a Mixxx control (for scripts)
@@ -713,7 +713,8 @@ void ControllerEngine::setParameter(QString group, QString name, double newParam
     ControlObjectScript* coScript = getControlObjectScript(group, name);
 
     if (coScript != nullptr) {
-        ControlObject* pControl = ControlObject::getControl(coScript->getKey());
+        ControlObject* pControl = ControlObject::getControl(
+                coScript->getKey(), ControlFlag::NoAssertIfMissing);
         if (pControl && !m_st.ignore(pControl, newParameter)) {
           coScript->setParameter(newParameter);
         }
@@ -1440,7 +1441,8 @@ bool ControllerEngine::isScratching(int deck) {
     Output:  -
     -------- ------------------------------------------------------ */
 void ControllerEngine::softTakeover(QString group, QString name, bool set) {
-    ControlObject* pControl = ControlObject::getControl(ConfigKey(group, name));
+    ControlObject* pControl = ControlObject::getControl(
+            ConfigKey(group, name), ControlFlag::NoAssertIfMissing);
     if (!pControl) {
         return;
     }
@@ -1460,8 +1462,10 @@ void ControllerEngine::softTakeover(QString group, QString name, bool set) {
      Input:   ControlObject group and key values
      Output:  -
      -------- ------------------------------------------------------ */
-void ControllerEngine::softTakeoverIgnoreNextValue(QString group, const QString name) {
-    ControlObject* pControl = ControlObject::getControl(ConfigKey(group, name));
+void ControllerEngine::softTakeoverIgnoreNextValue(
+        QString group, const QString name) {
+    ControlObject* pControl = ControlObject::getControl(
+            ConfigKey(group, name), ControlFlag::NoAssertIfMissing);
     if (!pControl) {
         return;
     }

--- a/src/controllers/midi/midioutputhandler.cpp
+++ b/src/controllers/midi/midioutputhandler.cpp
@@ -14,10 +14,10 @@
 #include "control/controlobject.h"
 
 MidiOutputHandler::MidiOutputHandler(MidiController* controller,
-                                     const MidiOutputMapping& mapping)
+        const MidiOutputMapping& mapping)
         : m_pController(controller),
           m_mapping(mapping),
-          m_cos(mapping.controlKey, this),
+          m_cos(mapping.controlKey, this, ControlFlag::NoAssertIfMissing),
           m_lastVal(-1) { // -1 = virgin
     m_cos.connectValueChanged(this, &MidiOutputHandler::controlChanged);
 }

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -42,30 +42,31 @@ QAtomicPointer<ControlProxy> PlayerManager::m_pCOPNumSamplers;
 QAtomicPointer<ControlProxy> PlayerManager::m_pCOPNumPreviewDecks;
 
 PlayerManager::PlayerManager(UserSettingsPointer pConfig,
-                             SoundManager* pSoundManager,
-                             EffectsManager* pEffectsManager,
-                             VisualsManager* pVisualsManager,
-                             EngineMaster* pEngine) :
-        m_mutex(QMutex::Recursive),
-        m_pConfig(pConfig),
-        m_pSoundManager(pSoundManager),
-        m_pEffectsManager(pEffectsManager),
-        m_pVisualsManager(pVisualsManager),
-        m_pEngine(pEngine),
-        // NOTE(XXX) LegacySkinParser relies on these controls being Controls
-        // and not ControlProxies.
-        m_pCONumDecks(new ControlObject(
-                ConfigKey("[Master]", "num_decks"), true, true)),
-        m_pCONumSamplers(new ControlObject(
-                ConfigKey("[Master]", "num_samplers"), true, true)),
-        m_pCONumPreviewDecks(new ControlObject(
-                ConfigKey("[Master]", "num_preview_decks"), true, true)),
-        m_pCONumMicrophones(new ControlObject(
-                ConfigKey("[Master]", "num_microphones"), true, true)),
-        m_pCONumAuxiliaries(new ControlObject(
-                ConfigKey("[Master]", "num_auxiliaries"), true, true)),
-        m_pAutoDjEnabled(make_parented<ControlProxy>("[AutoDJ]", "enabled", this)),
-        m_pTrackAnalysisScheduler(TrackAnalysisScheduler::NullPointer()) {
+        SoundManager* pSoundManager,
+        EffectsManager* pEffectsManager,
+        VisualsManager* pVisualsManager,
+        EngineMaster* pEngine)
+        : m_mutex(QMutex::Recursive),
+          m_pConfig(pConfig),
+          m_pSoundManager(pSoundManager),
+          m_pEffectsManager(pEffectsManager),
+          m_pVisualsManager(pVisualsManager),
+          m_pEngine(pEngine),
+          // NOTE(XXX) LegacySkinParser relies on these controls being Controls
+          // and not ControlProxies.
+          m_pCONumDecks(new ControlObject(
+                  ConfigKey("[Master]", "num_decks"), true, true)),
+          m_pCONumSamplers(new ControlObject(
+                  ConfigKey("[Master]", "num_samplers"), true, true)),
+          m_pCONumPreviewDecks(new ControlObject(
+                  ConfigKey("[Master]", "num_preview_decks"), true, true)),
+          m_pCONumMicrophones(new ControlObject(
+                  ConfigKey("[Master]", "num_microphones"), true, true)),
+          m_pCONumAuxiliaries(new ControlObject(
+                  ConfigKey("[Master]", "num_auxiliaries"), true, true)),
+          m_pAutoDjEnabled(make_parented<ControlProxy>(
+                  "[AutoDJ]", "enabled", this, ControlFlag::NoWarnIfMissing)),
+          m_pTrackAnalysisScheduler(TrackAnalysisScheduler::NullPointer()) {
     m_pCONumDecks->connectValueChangeRequest(this,
             &PlayerManager::slotChangeNumDecks, Qt::DirectConnection);
     m_pCONumSamplers->connectValueChangeRequest(this,

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -64,8 +64,6 @@ PlayerManager::PlayerManager(UserSettingsPointer pConfig,
                   ConfigKey("[Master]", "num_microphones"), true, true)),
           m_pCONumAuxiliaries(new ControlObject(
                   ConfigKey("[Master]", "num_auxiliaries"), true, true)),
-          m_pAutoDjEnabled(make_parented<ControlProxy>(
-                  "[AutoDJ]", "enabled", this, ControlFlag::InitializeLater)),
           m_pTrackAnalysisScheduler(TrackAnalysisScheduler::NullPointer()) {
     m_pCONumDecks->connectValueChangeRequest(this,
             &PlayerManager::slotChangeNumDecks, Qt::DirectConnection);
@@ -603,8 +601,8 @@ void PlayerManager::slotLoadTrackToPlayer(TrackPointer pTrack, QString group, bo
     // button repeatedly.
     // AutoDJProcessor is initialized after PlayerManager, so check that the
     // ControlProxy is pointing to the real ControlObject.
-    if (!m_pAutoDjEnabled->valid()) {
-        m_pAutoDjEnabled->initialize();
+    if (!m_pAutoDjEnabled) {
+        m_pAutoDjEnabled = make_parented<ControlProxy>("[AutoDJ]", "enabled", this);
     }
     bool autoDjSkipClone = m_pAutoDjEnabled->get() && (pPlayer == m_decks.at(0) || pPlayer == m_decks.at(1));
 

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -604,7 +604,7 @@ void PlayerManager::slotLoadTrackToPlayer(TrackPointer pTrack, QString group, bo
     // AutoDJProcessor is initialized after PlayerManager, so check that the
     // ControlProxy is pointing to the real ControlObject.
     if (!m_pAutoDjEnabled->valid()) {
-        m_pAutoDjEnabled->initialize(ConfigKey("[AutoDJ]", "enabled"));
+        m_pAutoDjEnabled->initialize();
     }
     bool autoDjSkipClone = m_pAutoDjEnabled->get() && (pPlayer == m_decks.at(0) || pPlayer == m_decks.at(1));
 

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -65,7 +65,7 @@ PlayerManager::PlayerManager(UserSettingsPointer pConfig,
           m_pCONumAuxiliaries(new ControlObject(
                   ConfigKey("[Master]", "num_auxiliaries"), true, true)),
           m_pAutoDjEnabled(make_parented<ControlProxy>(
-                  "[AutoDJ]", "enabled", this, ControlFlag::NoWarnIfMissing)),
+                  "[AutoDJ]", "enabled", this, ControlFlag::InitializeLater)),
           m_pTrackAnalysisScheduler(TrackAnalysisScheduler::NullPointer()) {
     m_pCONumDecks->connectValueChangeRequest(this,
             &PlayerManager::slotChangeNumDecks, Qt::DirectConnection);

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -804,7 +804,7 @@ void MixxxMainWindow::finalize() {
                 // A deletion early in the list may trigger a destructor
                 // for a control later in the list, so we check for a null
                 // pointer each time.
-                ControlObject* pCo = ControlObject::getControl(key, false);
+                ControlObject* pCo = ControlObject::getControl(key, ControlFlag::NoAssertIfMissing);
                 if (pCo) {
                     delete pCo;
                 }

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -102,7 +102,7 @@ ControlObject* controlFromConfigKey(const ConfigKey& key, bool bPersist,
     }
     // Don't warn if the control doesn't exist. Skins use this to create
     // controls.
-    ControlObject* pControl = ControlObject::getControl(key, false);
+    ControlObject* pControl = ControlObject::getControl(key, ControlFlag::NoWarnIfMissing);
 
     if (pControl) {
         if (pCreated) {

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -102,7 +102,7 @@ ControlObject* controlFromConfigKey(const ConfigKey& key, bool bPersist,
     }
     // Don't warn if the control doesn't exist. Skins use this to create
     // controls.
-    ControlObject* pControl = ControlObject::getControl(key, ControlFlag::NoAssertIfMissing);
+    ControlObject* pControl = ControlObject::getControl(key, ControlFlag::NoWarnIfMissing);
 
     if (pControl) {
         if (pCreated) {

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -102,7 +102,7 @@ ControlObject* controlFromConfigKey(const ConfigKey& key, bool bPersist,
     }
     // Don't warn if the control doesn't exist. Skins use this to create
     // controls.
-    ControlObject* pControl = ControlObject::getControl(key, ControlFlag::NoWarnIfMissing);
+    ControlObject* pControl = ControlObject::getControl(key, ControlFlag::NoAssertIfMissing);
 
     if (pControl) {
         if (pCreated) {

--- a/src/test/beatstranslatetest.cpp
+++ b/src/test/beatstranslatetest.cpp
@@ -26,8 +26,8 @@ TEST_F(BeatsTranslateTest, SimpleTranslateMatch) {
     EXPECT_TRUE(m_pChannel1->getEngineBuffer()->getVisualPlayPos() > 0);
 
     // Make both decks playing.
-    ControlObject::getControl(m_sGroup1, "play", true)->set(1.0);
-    ControlObject::getControl(m_sGroup2, "play", true)->set(1.0);
+    ControlObject::getControl(m_sGroup1, "play", ControlFlag::None)->set(1.0);
+    ControlObject::getControl(m_sGroup2, "play", ControlFlag::None)->set(1.0);
     ProcessBuffer();
     // Manually set the "bpm" control... I would like to figure out why this
     // doesn't get set naturally, but this will do for now.

--- a/src/test/beatstranslatetest.cpp
+++ b/src/test/beatstranslatetest.cpp
@@ -26,8 +26,8 @@ TEST_F(BeatsTranslateTest, SimpleTranslateMatch) {
     EXPECT_TRUE(m_pChannel1->getEngineBuffer()->getVisualPlayPos() > 0);
 
     // Make both decks playing.
-    ControlObject::getControl(m_sGroup1, "play", ControlFlag::None)->set(1.0);
-    ControlObject::getControl(m_sGroup2, "play", ControlFlag::None)->set(1.0);
+    ControlObject::getControl(m_sGroup1, "play")->set(1.0);
+    ControlObject::getControl(m_sGroup2, "play")->set(1.0);
     ProcessBuffer();
     // Manually set the "bpm" control... I would like to figure out why this
     // doesn't get set naturally, but this will do for now.

--- a/src/widget/controlwidgetconnection.cpp
+++ b/src/widget/controlwidgetconnection.cpp
@@ -13,7 +13,7 @@ ControlWidgetConnection::ControlWidgetConnection(
         ValueTransformer* pTransformer)
         : m_pWidget(pBaseWidget),
           m_pValueTransformer(pTransformer) {
-    m_pControl = new ControlProxy(key, this);
+    m_pControl = new ControlProxy(key, this, ControlFlag::NoAssertIfMissing);
     m_pControl->connectValueChanged(this, &ControlWidgetConnection::slotControlValueChanged);
 }
 

--- a/src/widget/wbeatspinbox.cpp
+++ b/src/widget/wbeatspinbox.cpp
@@ -8,11 +8,14 @@
 
 QRegExp WBeatSpinBox::s_regexpBlacklist("[^0-9.,/ ]");
 
-WBeatSpinBox::WBeatSpinBox(QWidget* parent, const ConfigKey& configKey,
-                           int decimals, double minimum, double maximum)
+WBeatSpinBox::WBeatSpinBox(QWidget* parent,
+        const ConfigKey& configKey,
+        int decimals,
+        double minimum,
+        double maximum)
         : QDoubleSpinBox(parent),
           WBaseWidget(this),
-          m_valueControl(configKey, this),
+          m_valueControl(configKey, this, ControlFlag::NoAssertIfMissing),
           m_scaleFactor(1.0) {
     // replace the original QLineEdit by one that supports font scaling.
     setLineEdit(new WBeatLineEdit(this));

--- a/src/widget/whotcuebutton.cpp
+++ b/src/widget/whotcuebutton.cpp
@@ -37,7 +37,10 @@ void WHotcueButton::setup(const QDomNode& node, const SkinContext& context) {
 
     setFocusPolicy(Qt::NoFocus);
 
-    m_pCoColor = make_parented<ControlProxy>(createConfigKey(QStringLiteral("color")), this);
+    m_pCoColor = make_parented<ControlProxy>(
+            createConfigKey(QStringLiteral("color")),
+            this,
+            ControlFlag::NoAssertIfMissing);
     m_pCoColor->connectValueChanged(this, &WHotcueButton::slotColorChanged);
     slotColorChanged(m_pCoColor->get());
 

--- a/src/widget/wkey.cpp
+++ b/src/widget/wkey.cpp
@@ -6,7 +6,7 @@ WKey::WKey(const QString& group, QWidget* pParent)
         : WLabel(pParent),
           m_dOldValue(0),
           m_keyNotation("[Library]", "key_notation", this),
-          m_engineKeyDistance(group, "visual_key_distance", this) {
+          m_engineKeyDistance(group, "visual_key_distance", this, ControlFlag::NoAssertIfMissing) {
     setValue(m_dOldValue);
     m_keyNotation.connectValueChanged(this, &WKey::keyNotationChanged);
     m_engineKeyDistance.connectValueChanged(this, &WKey::setCents);

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -679,7 +679,6 @@ VisibilityControlConnection::VisibilityControlConnection(
         : QObject(pParent),
           m_key(key),
           m_pAction(pAction) {
-    slotReconnectControl();
     connect(m_pAction, SIGNAL(triggered(bool)),
             this, SLOT(slotActionToggled(bool)));
 }

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -691,7 +691,7 @@ void VisibilityControlConnection::slotClearControl() {
 
 void VisibilityControlConnection::slotReconnectControl() {
     m_pControl.reset(new ControlProxy(this));
-    m_pControl->initialize(m_key, false);
+    m_pControl->initialize(m_key, ControlFlag::NoAssertIfMissing);
     m_pControl->connectValueChanged(this, &VisibilityControlConnection::slotControlChanged);
     m_pAction->setEnabled(m_pControl->valid());
     slotControlChanged();

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -690,8 +690,7 @@ void VisibilityControlConnection::slotClearControl() {
 }
 
 void VisibilityControlConnection::slotReconnectControl() {
-    m_pControl.reset(new ControlProxy(this));
-    m_pControl->initialize(m_key, ControlFlag::NoAssertIfMissing);
+    m_pControl.reset(new ControlProxy(m_key, this, ControlFlag::NoAssertIfMissing));
     m_pControl->connectValueChanged(this, &VisibilityControlConnection::slotControlChanged);
     m_pAction->setEnabled(m_pControl->valid());
     slotControlChanged();

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -10,9 +10,10 @@ WNumberPos::WNumberPos(const QString& group, QWidget* parent)
         : WNumber(parent),
           m_displayFormat(TrackTime::DisplayFormat::TRADITIONAL),
           m_dOldTimeElapsed(0.0) {
-    m_pTimeElapsed = new ControlProxy(group, "time_elapsed", this);
+    m_pTimeElapsed = new ControlProxy(group, "time_elapsed", this, ControlFlag::NoAssertIfMissing);
     m_pTimeElapsed->connectValueChanged(this, &WNumberPos::slotSetTimeElapsed);
-    m_pTimeRemaining = new ControlProxy(group, "time_remaining", this);
+    m_pTimeRemaining = new ControlProxy(
+            group, "time_remaining", this, ControlFlag::NoAssertIfMissing);
     m_pTimeRemaining->connectValueChanged(
             this, &WNumberPos::slotTimeRemainingUpdated);
 

--- a/src/widget/wnumberrate.cpp
+++ b/src/widget/wnumberrate.cpp
@@ -18,7 +18,7 @@
 
 WNumberRate::WNumberRate(const QString& group, QWidget* parent)
         : WNumber(parent) {
-    m_pRateRatio = new ControlProxy(group, "rate_ratio", this);
+    m_pRateRatio = new ControlProxy(group, "rate_ratio", this, ControlFlag::NoAssertIfMissing);
     m_pRateRatio->connectValueChanged(this, &WNumberRate::setValue);
 }
 

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -71,17 +71,20 @@ WOverview::WOverview(
           m_trackLoaded(false),
           m_scaleFactor(1.0) {
     m_endOfTrackControl = new ControlProxy(
-            m_group, "end_of_track", this);
+            m_group, "end_of_track", this, ControlFlag::NoAssertIfMissing);
     m_endOfTrackControl->connectValueChanged(this, &WOverview::onEndOfTrackChange);
-    m_pRateRatioControl = new ControlProxy(m_group, "rate_ratio", this);
+    m_pRateRatioControl = new ControlProxy(
+            m_group, "rate_ratio", this, ControlFlag::NoAssertIfMissing);
     // Needed to recalculate range durations when rate slider is moved without the deck playing
-    m_pRateRatioControl->connectValueChanged(this, &WOverview::onRateRatioChange);
-    m_trackSampleRateControl = new ControlProxy(m_group, "track_samplerate", this);
-    m_trackSamplesControl =
-            new ControlProxy(m_group, "track_samples", this);
-    m_playpositionControl = new ControlProxy(m_group, "playposition", this);
+    m_pRateRatioControl->connectValueChanged(
+            this, &WOverview::onRateRatioChange);
+    m_trackSampleRateControl = new ControlProxy(
+            m_group, "track_samplerate", this, ControlFlag::NoAssertIfMissing);
+    m_trackSamplesControl = new ControlProxy(m_group, "track_samples", this);
+    m_playpositionControl = new ControlProxy(
+            m_group, "playposition", this, ControlFlag::NoAssertIfMissing);
     m_pPassthroughControl =
-            new ControlProxy(m_group, "passthrough", this);
+            new ControlProxy(m_group, "passthrough", this, ControlFlag::NoAssertIfMissing);
     m_pPassthroughControl->connectValueChanged(this, &WOverview::onPassthroughChange);
     onPassthroughChange(m_pPassthroughControl->get());
 

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -189,35 +189,35 @@ void WSpinny::setup(const QDomNode& node, const SkinContext& context) {
 #endif
 
     m_pPlayPos = new ControlProxy(
-            m_group, "playposition", this);
+            m_group, "playposition", this, ControlFlag::NoAssertIfMissing);
     m_pVisualPlayPos = VisualPlayPosition::getVisualPlayPosition(m_group);
     m_pTrackSamples = new ControlProxy(
-            m_group, "track_samples", this);
+            m_group, "track_samples", this, ControlFlag::NoAssertIfMissing);
     m_pTrackSampleRate = new ControlProxy(
-            m_group, "track_samplerate", this);
+            m_group, "track_samplerate", this, ControlFlag::NoAssertIfMissing);
 
     m_pScratchToggle = new ControlProxy(
-            m_group, "scratch_position_enable", this);
+            m_group, "scratch_position_enable", this, ControlFlag::NoAssertIfMissing);
     m_pScratchPos = new ControlProxy(
-            m_group, "scratch_position", this);
+            m_group, "scratch_position", this, ControlFlag::NoAssertIfMissing);
 
     m_pSlipEnabled = new ControlProxy(
-            m_group, "slip_enabled", this);
+            m_group, "slip_enabled", this, ControlFlag::NoAssertIfMissing);
     m_pSlipEnabled->connectValueChanged(this, &WSpinny::updateSlipEnabled);
 
 #ifdef __VINYLCONTROL__
     m_pVinylControlSpeedType = new ControlProxy(
-            m_group, "vinylcontrol_speed_type", this);
+            m_group, "vinylcontrol_speed_type", this, ControlFlag::NoAssertIfMissing);
     // Initialize the rotational speed.
     updateVinylControlSpeed(m_pVinylControlSpeedType->get());
 
     m_pVinylControlEnabled = new ControlProxy(
-            m_group, "vinylcontrol_enabled", this);
+            m_group, "vinylcontrol_enabled", this, ControlFlag::NoAssertIfMissing);
     m_pVinylControlEnabled->connectValueChanged(this,
             &WSpinny::updateVinylControlEnabled);
 
     m_pSignalEnabled = new ControlProxy(
-            m_group, "vinylcontrol_signal_enabled", this);
+            m_group, "vinylcontrol_signal_enabled", this, ControlFlag::NoAssertIfMissing);
     m_pSignalEnabled->connectValueChanged(this,
             &WSpinny::updateVinylControlSignalEnabled);
 

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -31,16 +31,16 @@ WWaveformViewer::WWaveformViewer(
           m_waveformWidget(nullptr) {
     setMouseTracking(true);
     setAcceptDrops(true);
-    m_pZoom = new ControlProxy(group, "waveform_zoom", this);
+    m_pZoom = new ControlProxy(group, "waveform_zoom", this, ControlFlag::NoAssertIfMissing);
     m_pZoom->connectValueChanged(this, &WWaveformViewer::onZoomChange);
 
     m_pScratchPositionEnable = new ControlProxy(
-            group, "scratch_position_enable", this);
+            group, "scratch_position_enable", this, ControlFlag::NoAssertIfMissing);
     m_pScratchPosition = new ControlProxy(
-            group, "scratch_position", this);
+            group, "scratch_position", this, ControlFlag::NoAssertIfMissing);
     m_pWheel = new ControlProxy(
-            group, "wheel", this);
-    m_pPlayEnabled = new ControlProxy(group, "play", this);
+            group, "wheel", this, ControlFlag::NoAssertIfMissing);
+    m_pPlayEnabled = new ControlProxy(group, "play", this, ControlFlag::NoAssertIfMissing);
 
     setAttribute(Qt::WA_OpaquePaintEvent);
 }

--- a/src/widget/wwidgetstack.cpp
+++ b/src/widget/wwidgetstack.cpp
@@ -28,13 +28,16 @@ void WidgetStackControlListener::onCurrentWidgetChanged(int index) {
     }
 }
 
-WWidgetStack::WWidgetStack(QWidget* pParent, const ConfigKey& nextConfigKey,
-        const ConfigKey& prevConfigKey, const ConfigKey& currentPageConfigKey)
+WWidgetStack::WWidgetStack(QWidget* pParent,
+        const ConfigKey& nextConfigKey,
+        const ConfigKey& prevConfigKey,
+        const ConfigKey& currentPageConfigKey)
         : QStackedWidget(pParent),
           WBaseWidget(this),
-          m_nextControl(nextConfigKey, this),
-          m_prevControl(prevConfigKey, this),
-          m_currentPageControl(currentPageConfigKey, this) {
+          m_nextControl(nextConfigKey, this, ControlFlag::AllowEmptyKey),
+          m_prevControl(prevConfigKey, this, ControlFlag::AllowEmptyKey),
+          m_currentPageControl(
+                  currentPageConfigKey, this, ControlFlag::AllowEmptyKey) {
     m_nextControl.connectValueChanged(this, &WWidgetStack::onNextControlChanged);
     m_prevControl.connectValueChanged(this, &WWidgetStack::onPrevControlChanged);
     m_currentPageControl.connectValueChanged(this, &WWidgetStack::onCurrentPageControlChanged);

--- a/src/widget/wwidgetstack.cpp
+++ b/src/widget/wwidgetstack.cpp
@@ -4,10 +4,10 @@
 #include "widget/wwidgetstack.h"
 
 WidgetStackControlListener::WidgetStackControlListener(QObject* pParent,
-                                                       ControlObject* pControl,
-                                                       int index)
+        ControlObject* pControl,
+        int index)
         : QObject(pParent),
-          m_control(pControl ? pControl->getKey() : ConfigKey(), this),
+          m_control(pControl ? pControl->getKey() : ConfigKey(), this, ControlFlag::AllowEmptyKey),
           m_index(index) {
     m_control.connectValueChanged(this, &WidgetStackControlListener::slotValueChanged);
 }


### PR DESCRIPTION
This should prevent CO failures from going unnoticed. Right now, only a warning is displayed in the log, which can easily be overlooked.

Zulip discussion that prompted this PR: https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/Macros.2FSaved.20Hotcue.20Routines.2F.22Serato.20Flip.22/near/201478587