### PR TITLE
optimize some Preferences pages

### DIFF
--- a/src/preferences/dialog/dlgprefautodj.cpp
+++ b/src/preferences/dialog/dlgprefautodj.cpp
@@ -7,48 +7,58 @@ DlgPrefAutoDJ::DlgPrefAutoDJ(QWidget* pParent,
     setupUi(this);
 
     // The minimum available for randomly-selected tracks
-    autoDjMinimumAvailableSpinBox->setValue(
+    MinimumAvailableSpinBox->setValue(
             m_pConfig->getValue(
                     ConfigKey("[Auto DJ]", "MinimumAvailable"), 20));
-    connect(autoDjMinimumAvailableSpinBox, SIGNAL(valueChanged(int)), this,
-            SLOT(slotSetAutoDjMinimumAvailable(int)));
+    connect(MinimumAvailableSpinBox,
+            SIGNAL(valueChanged(int)),
+            this,
+            SLOT(slotSetMinimumAvailable(int)));
 
     // The auto-DJ replay-age for randomly-selected tracks
-    autoDjIgnoreTimeCheckBox->setChecked(
-            (bool) m_pConfig->getValue(
+    RequeueIgnoreCheckBox->setChecked(
+            (bool)m_pConfig->getValue(
                     ConfigKey("[Auto DJ]", "UseIgnoreTime"), 0));
-    connect(autoDjIgnoreTimeCheckBox, SIGNAL(stateChanged(int)), this,
-            SLOT(slotSetAutoDjUseIgnoreTime(int)));
-    autoDjIgnoreTimeEdit->setTime(
+    connect(RequeueIgnoreCheckBox,
+            SIGNAL(stateChanged(int)),
+            this,
+            SLOT(slotToggleRequeueIgnore(int)));
+    RequeueIgnoreTimeEdit->setTime(
             QTime::fromString(
                     m_pConfig->getValue(
                             ConfigKey("[Auto DJ]", "IgnoreTime"), "23:59"),
-                    autoDjIgnoreTimeEdit->displayFormat()));
-    autoDjIgnoreTimeEdit->setEnabled(
-            autoDjIgnoreTimeCheckBox->checkState() == Qt::Checked);
-    connect(autoDjIgnoreTimeEdit, SIGNAL(timeChanged(const QTime &)), this,
-            SLOT(slotSetAutoDjIgnoreTime(const QTime &)));
+                    RequeueIgnoreTimeEdit->displayFormat()));
+    RequeueIgnoreTimeEdit->setEnabled(
+            RequeueIgnoreCheckBox->checkState() == Qt::Checked);
+    connect(RequeueIgnoreTimeEdit,
+            SIGNAL(timeChanged(const QTime&)),
+            this,
+            SLOT(slotSetRequeueIgnoreTime(const QTime&)));
 
     // Auto DJ random enqueue
-    ComboBoxAutoDjRandomQueue->addItem(tr("Off"));
-    ComboBoxAutoDjRandomQueue->addItem(tr("On"));
-    ComboBoxAutoDjRandomQueue->setCurrentIndex(
-            m_pConfig->getValue(
+    RandomQueueCheckBox->setChecked(
+            (bool)m_pConfig->getValue(
                     ConfigKey("[Auto DJ]", "EnableRandomQueue"), 0));
     // 5-arbitrary
-    autoDJRandomQueueMinimumSpinBox->setValue(
+    RandomQueueMinimumSpinBox->setValue(
             m_pConfig->getValue(
                     ConfigKey("[Auto DJ]", "RandomQueueMinimumAllowed"), 5));
-    slotEnableAutoDJRandomQueueComboBox(
+    // "[Auto DJ], Requeue" is set by 'Repeat Playlist' toggle in DlgAutoDj GUI.
+    // If it's checked un-check 'Random Queue'
+    slotConsiderRepeatPlaylistState(
             m_pConfig->getValueString(ConfigKey("[Auto DJ]", "Requeue")).toInt());
-    slotEnableAutoDJRandomQueue(
+    slotToggleRandomQueue(
             m_pConfig->getValue<int>(
                     ConfigKey("[Auto DJ]", "EnableRandomQueue")));
-    // Be ready to enable and modify the minimum number and enable disable the spinbox
-    connect(ComboBoxAutoDjRandomQueue, SIGNAL(activated(int)), this,
-            SLOT(slotEnableAutoDJRandomQueue(int)));
-    connect(autoDJRandomQueueMinimumSpinBox, SIGNAL(valueChanged(int)), this,
-            SLOT(slotSetAutoDJRandomQueueMin(int)));
+    // Be ready to enable and modify the minimum number and un/check the checkbox
+    connect(RandomQueueCheckBox,
+            SIGNAL(stateChanged(int)),
+            this,
+            SLOT(slotToggleRandomQueue(int)));
+    connect(RandomQueueMinimumSpinBox,
+            SIGNAL(valueChanged(int)),
+            this,
+            SLOT(slotSetRandomQueueMin(int)));
 }
 
 DlgPrefAutoDJ::~DlgPrefAutoDJ() {
@@ -80,106 +90,106 @@ void DlgPrefAutoDJ::slotApply() {
 
 void DlgPrefAutoDJ::slotCancel() {
     // Load actual values and reset Buffer Values where ever needed
-    autoDjMinimumAvailableSpinBox->setValue(
+    MinimumAvailableSpinBox->setValue(
             m_pConfig->getValue(
-                      ConfigKey("[Auto DJ]", "MinimumAvailable"), 20));
+                    ConfigKey("[Auto DJ]", "MinimumAvailable"), 20));
 
-    autoDjIgnoreTimeEdit->setTime(
+    RequeueIgnoreTimeEdit->setTime(
             QTime::fromString(
-            m_pConfig->getValue(
-                      ConfigKey("[Auto DJ]", "IgnoreTime"), "23:59"),
-                                autoDjIgnoreTimeEdit->displayFormat()));
-    autoDjIgnoreTimeCheckBox->setChecked(
+                    m_pConfig->getValue(
+                            ConfigKey("[Auto DJ]", "IgnoreTime"), "23:59"),
+                    RequeueIgnoreTimeEdit->displayFormat()));
+    RequeueIgnoreCheckBox->setChecked(
             m_pConfig->getValue(
                     ConfigKey("[Auto DJ]", "UseIgnoreTime"), false));
-    autoDjIgnoreTimeEdit->setEnabled(
-            autoDjIgnoreTimeCheckBox->checkState() == Qt::Checked);
+    RequeueIgnoreTimeEdit->setEnabled(
+            RequeueIgnoreCheckBox->checkState() == Qt::Checked);
     m_pConfig->setValue(ConfigKey("[Auto DJ]", "UseIgnoreTimeBuff"),
             m_pConfig->getValue(
                     ConfigKey("[Auto DJ]", "UseIgnoreTime"), 0));
 
-    autoDJRandomQueueMinimumSpinBox->setValue(
+    RandomQueueMinimumSpinBox->setValue(
             m_pConfig->getValue(
                     ConfigKey("[Auto DJ]", "RandomQueueMinimumAllowed"), 5));
-    ComboBoxAutoDjRandomQueue->setCurrentIndex(
+    RandomQueueCheckBox->setChecked(
             m_pConfig->getValue(
-                    ConfigKey("[Auto DJ]", "EnableRandomQueue"), 0));
+                    ConfigKey("[Auto DJ]", "EnableRandomQueue"), false));
     m_pConfig->setValue(ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"),
             m_pConfig->getValue(
                     ConfigKey("[Auto DJ]", "EnableRandomQueue"), 0));
-    slotEnableAutoDJRandomQueue(
+    slotToggleRandomQueue(
             m_pConfig->getValue(
                     ConfigKey("[Auto DJ]", "EnableRandomQueue"), 0));
-    slotEnableAutoDJRandomQueueComboBox(
+    slotToggleRandomQueue(
             m_pConfig->getValue<int>(ConfigKey("[Auto DJ]", "Requeue")));
 }
 
 void DlgPrefAutoDJ::slotResetToDefaults() {
     // Re-queue tracks in AutoDJ
-    autoDjMinimumAvailableSpinBox->setValue(20);
+    MinimumAvailableSpinBox->setValue(20);
 
-    autoDjIgnoreTimeEdit->setTime(QTime::fromString(
-            "23:59", autoDjIgnoreTimeEdit->displayFormat()));
-    autoDjIgnoreTimeCheckBox->setChecked(false);
+    RequeueIgnoreTimeEdit->setTime(QTime::fromString(
+            "23:59", RequeueIgnoreTimeEdit->displayFormat()));
+    RequeueIgnoreCheckBox->setChecked(false);
     m_pConfig->set(ConfigKey("[Auto DJ]", "UseIgnoreTimeBuff"),QString("0"));
-    autoDjIgnoreTimeEdit->setEnabled(false);
+    RequeueIgnoreTimeEdit->setEnabled(false);
 
-    autoDJRandomQueueMinimumSpinBox->setValue(5);
-    ComboBoxAutoDjRandomQueue->setCurrentIndex(0);
+    RandomQueueMinimumSpinBox->setValue(5);
+    RandomQueueCheckBox->setChecked(false);
     m_pConfig->set(ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"),QString("0"));
-    autoDJRandomQueueMinimumSpinBox->setEnabled(false);
-    ComboBoxAutoDjRandomQueue->setEnabled(true);
+    RandomQueueMinimumSpinBox->setEnabled(false);
+    RandomQueueCheckBox->setEnabled(true);
 }
 
-void DlgPrefAutoDJ::slotSetAutoDjMinimumAvailable(int a_iValue) {
+void DlgPrefAutoDJ::slotSetMinimumAvailable(int a_iValue) {
     QString str;
     str.setNum(a_iValue);
     m_pConfig->set(ConfigKey("[Auto DJ]","MinimumAvailableBuff"),str);
 }
 
-void DlgPrefAutoDJ::slotSetAutoDjUseIgnoreTime(int a_iState) {
+void DlgPrefAutoDJ::slotToggleRequeueIgnore(int a_iState) {
     bool bChecked = (a_iState == Qt::Checked);
     QString strChecked = (bChecked) ? "1" : "0";
     m_pConfig->set(ConfigKey("[Auto DJ]", "UseIgnoreTimeBuff"), strChecked);
-    autoDjIgnoreTimeEdit->setEnabled(bChecked);
+    RequeueIgnoreTimeEdit->setEnabled(bChecked);
 }
 
-void DlgPrefAutoDJ::slotSetAutoDjIgnoreTime(const QTime &a_rTime) {
-    QString str = a_rTime.toString(autoDjIgnoreTimeEdit->displayFormat());
+void DlgPrefAutoDJ::slotSetRequeueIgnoreTime(const QTime& a_rTime) {
+    QString str = a_rTime.toString(RequeueIgnoreTimeEdit->displayFormat());
     m_pConfig->set(ConfigKey("[Auto DJ]", "IgnoreTimeBuff"),str);
 }
 
-void DlgPrefAutoDJ::slotSetAutoDJRandomQueueMin(int a_iValue) {
+void DlgPrefAutoDJ::slotSetRandomQueueMin(int a_iValue) {
     QString str;
     //qDebug() << "min allowed " << a_iValue;
     str.setNum(a_iValue);
     m_pConfig->set(ConfigKey("[Auto DJ]", "RandomQueueMinimumAllowedBuff"), str);
 }
 
-void DlgPrefAutoDJ::slotEnableAutoDJRandomQueueComboBox(int a_iValue) {
+void DlgPrefAutoDJ::slotConsiderRepeatPlaylistState(int a_iValue) {
     if (a_iValue == 1) {
         // Requeue is enabled
+        RandomQueueCheckBox->setChecked(false);
+        // ToDo(ronso0): Redundant? If programmatic checkbox change is signaled
+        // to slotToggleRandomQueue
+        RandomQueueMinimumSpinBox->setEnabled(false);
         m_pConfig->set(ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"),
                 ConfigValue(0));
-        ComboBoxAutoDjRandomQueue->setCurrentIndex(0);
-        ComboBoxAutoDjRandomQueue->setEnabled(false);
-        autoDJRandomQueueMinimumSpinBox->setEnabled(false);
     } else {
-        ComboBoxAutoDjRandomQueue->setEnabled(true);
-        autoDJRandomQueueMinimumSpinBox->setEnabled(
+        RandomQueueMinimumSpinBox->setEnabled(
                 m_pConfig->getValue(
                         ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"), false));
     }
 }
 
-void DlgPrefAutoDJ::slotEnableAutoDJRandomQueue(int a_iValue) {
-    // Disable enable the option to select minimum tracks
+void DlgPrefAutoDJ::slotToggleRandomQueue(int a_iValue) {
+    // Toggle the option to select minimum tracks
     if (a_iValue == 0) {
-        autoDJRandomQueueMinimumSpinBox->setEnabled(false);
+        RandomQueueMinimumSpinBox->setEnabled(false);
         m_pConfig->set(ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"),
                 ConfigValue(0));
     } else {
-        autoDJRandomQueueMinimumSpinBox->setEnabled(true);
+        RandomQueueMinimumSpinBox->setEnabled(true);
         m_pConfig->set(ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"),
                 ConfigValue(1));
     }

--- a/src/preferences/dialog/dlgprefautodj.h
+++ b/src/preferences/dialog/dlgprefautodj.h
@@ -20,12 +20,12 @@ class DlgPrefAutoDJ : public DlgPreferencePage, public Ui::DlgPrefAutoDJDlg {
     void slotCancel() override;
 
   private slots:
-    void slotSetAutoDjMinimumAvailable(int);
-    void slotSetAutoDjUseIgnoreTime(int);
-    void slotSetAutoDjIgnoreTime(const QTime &a_rTime);
-    void slotSetAutoDJRandomQueueMin(int);
-    void slotEnableAutoDJRandomQueueComboBox(int);
-    void slotEnableAutoDJRandomQueue(int);
+    void slotSetMinimumAvailable(int);
+    void slotToggleRequeueIgnore(int);
+    void slotSetRequeueIgnoreTime(const QTime& a_rTime);
+    void slotSetRandomQueueMin(int);
+    void slotConsiderRepeatPlaylistState(int);
+    void slotToggleRandomQueue(int);
 
   private:
     UserSettingsPointer m_pConfig;

--- a/src/preferences/dialog/dlgprefautodjdlg.ui
+++ b/src/preferences/dialog/dlgprefautodjdlg.ui
@@ -13,117 +13,260 @@
   <property name="windowTitle">
    <string>Auto DJ Preferences</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_2">
-   <item row="0" column="0">
-    <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="autoDjMinimumAvailableLabel">
-       <property name="text">
-        <string>Minimum available tracks in Track Source</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QSpinBox" name="autoDjMinimumAvailableSpinBox">
-       <property name="toolTip">
-        <string>This percentage of tracks are always available for selecting, regardless of when they were last played.</string>
-       </property>
-       <property name="suffix">
-        <string>%</string>
-       </property>
-       <property name="maximum">
-        <number>100</number>
-       </property>
-       <property name="value">
-        <number>20</number>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QCheckBox" name="autoDjIgnoreTimeCheckBox">
-       <property name="toolTip">
-        <string>Uncheck, to ignore all played tracks.</string>
-       </property>
-       <property name="text">
-        <string>Suspend track in Track Source from re-queue</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="autoDjMinimumAvailableLabel_2">
-       <property name="text">
-        <string>Suspension period for track selection</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QTimeEdit" name="autoDjIgnoreTimeEdit">
-       <property name="toolTip">
-        <string>Duration after which a track is eligible for selection by Auto DJ again</string>
-       </property>
-       <property name="displayFormat">
-        <string>hh:mm</string>
-       </property>
-       <property name="timeSpec">
-        <enum>Qt::LocalTime</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="textAutoDJRandomQueue">
-       <property name="text">
-        <string>Enable random track addition to queue</string>
-       </property>
-       <property name="buddy">
-        <cstring>ComboBoxAutoDjRandomQueue</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QComboBox" name="ComboBoxAutoDjRandomQueue">
-       <property name="toolTip">
-        <string>Add random tracks from Track Source if the specified minimum tracks remain</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="autoDJRandomQueueMinimumLabel">
-       <property name="text">
-        <string>Minimum allowed tracks before addition</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QSpinBox" name="autoDJRandomQueueMinimumSpinBox">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="toolTip">
-        <string>Minimum number of tracks after which random tracks may be added</string>
-       </property>
-       <property name="minimum">
-        <number>1</number>
-       </property>
-       <property name="maximum">
-        <number>20</number>
-       </property>
-      </widget>
-     </item>
-    </layout>
+  <layout class="QVBoxLayout" name="AutoDJGridLayout">
+
+   <item>
+    <widget class="QGroupBox" name="RequeueOptions">
+      <property name="title">
+       <string>Re-queue Tracks</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+      </property>
+      <layout class="QGridLayout" name="RequeGridLayout">
+
+       <item row="0" column="0">
+        <widget class="QLabel" name="MinimumAvailableLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Minimum available tracks in Track Source</string>
+         </property>
+        </widget>
+       </item>
+
+       <item row="0" column="1">
+        <widget class="QSpinBox" name="MinimumAvailableSpinBox">
+         <property name="toolTip">
+          <string>This percentage of tracks are always available for selecting, regardless of when they were last played.</string>
+         </property>
+         <property name="suffix">
+          <string>%</string>
+         </property>
+         <property name="maximum">
+          <number>100</number>
+         </property>
+         <property name="value">
+          <number>20</number>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>60</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>80</width>
+           <height>16777215</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+
+       <item row="1" column="0">
+        <widget class="QLabel" name="RequeueIgnoreLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Uncheck, to ignore all played tracks.</string>
+         </property>
+         <property name="text">
+          <string>Suspend track in Track Source from re-queue</string>
+         </property>
+          <property name="buddy">
+           <cstring>RequeueIgnoreCheckBox</cstring>
+          </property>
+        </widget>
+       </item>
+
+       <item row="1" column="1">
+        <widget class="QCheckBox" name="RequeueIgnoreCheckBox">
+         <property name="toolTip">
+          <string>Uncheck, to ignore all played tracks.</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+
+       <item row="2" column="0">
+        <widget class="QLabel" name="RequeueIgnoreTimeLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Suspension period for track selection</string>
+         </property>
+        </widget>
+       </item>
+
+       <item row="2" column="1">
+        <widget class="QTimeEdit" name="RequeueIgnoreTimeEdit">
+         <property name="toolTip">
+          <string>Duration after which a track is eligible for selection by Auto DJ again</string>
+         </property>
+         <property name="displayFormat">
+          <string>hh:mm</string>
+         </property>
+         <property name="timeSpec">
+          <enum>Qt::LocalTime</enum>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>60</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>80</width>
+           <height>16777215</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+
+       <item row="2" column="2">
+        <spacer name="horizontalSpacerRequeue">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+        </spacer>
+       </item>
+
+      </layout>
+    </widget>
    </item>
-   <item row="1" column="0">
+
+   <item>
+    <widget class="QGroupBox" name="AddRandomOptions">
+      <property name="title">
+       <string>Add Random Tracks</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+      </property>
+      <layout class="QGridLayout" name="AddRandomGridLayout">
+
+       <item row="0" column="0">
+        <widget class="QLabel" name="RandomQueueLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Enable random track addition to queue</string>
+         </property>
+         <property name="buddy">
+          <cstring>RandomQueueCheckBox</cstring>
+         </property>
+        </widget>
+       </item>
+
+       <item row="0" column="1">
+        <widget class="QCheckBox" name="RandomQueueCheckBox">
+         <property name="toolTip">
+          <string>Add random tracks from Track Source if the specified minimum tracks remain</string>
+         </property>
+        </widget>
+       </item>
+
+       <item row="1" column="0">
+        <widget class="QLabel" name="RandomQueueMinimumLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Minimum allowed tracks before addition</string>
+         </property>
+        </widget>
+       </item>
+
+       <item row="1" column="1">
+        <widget class="QSpinBox" name="RandomQueueMinimumSpinBox">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="toolTip">
+          <string>Minimum number of tracks after which random tracks may be added</string>
+         </property>
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>20</number>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>60</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>80</width>
+           <height>16777215</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+
+       <item row="1" column="2">
+        <spacer name="horizontalSpacerRandom">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+        </spacer>
+       </item>
+
+      </layout>
+    </widget>
+   </item>
+
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>30</height>
-      </size>
-     </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>1</verstretch>
+       </sizepolicy>
+      </property>
     </spacer>
    </item>
+
   </layout>
  </widget>
  <resources/>

--- a/src/preferences/dialog/dlgprefeffects.cpp
+++ b/src/preferences/dialog/dlgprefeffects.cpp
@@ -16,12 +16,13 @@ DlgPrefEffects::DlgPrefEffects(QWidget* pParent,
     for (auto& profile : m_availableEffectsModel.profiles()) {
         EffectManifestPointer pManifest = profile->pManifest;
 
-        // Users are likely to have lots of external plugins installed and 
-        // many of them are useless for DJing. To avoid cluttering the list 
+        // Users are likely to have lots of external plugins installed and
+        // many of them are useless for DJing. To avoid cluttering the list
         // shown in WEffectSelector, blacklist external plugins by default.
         bool defaultValue = (pManifest->backendType() == EffectBackendType::BuiltIn);
-        bool visible = m_pConfig->getValue<bool>(ConfigKey("[Visible " + pManifest->backendName() + " Effects]", 
-                                                 pManifest->id()), defaultValue);
+        bool visible = m_pConfig->getValue<bool>(ConfigKey("[Visible " + pManifest->backendName() + " Effects]",
+                                                         pManifest->id()),
+                defaultValue);
         profile->bIsVisible = visible;
         m_pEffectsManager->setEffectVisibility(pManifest, visible);
     }
@@ -50,22 +51,32 @@ void DlgPrefEffects::slotUpdate() {
     if (!m_availableEffectsModel.isEmpty()) {
         availableEffectsList->selectRow(0);
     }
+
+    bool effectAdoptMetaknobValue = m_pConfig->getValue(
+            ConfigKey("[Effects]", "AdoptMetaknobValue"), true);
+    radioButtonKeepMetaknobPosition->setChecked(effectAdoptMetaknobValue);
+    radioButtonMetaknobLoadDefault->setChecked(!effectAdoptMetaknobValue);
 }
 
 void DlgPrefEffects::slotApply() {
     for (EffectProfilePtr profile : m_availableEffectsModel.profiles()) {
         EffectManifestPointer pManifest = profile->pManifest;
         m_pEffectsManager->setEffectVisibility(pManifest, profile->bIsVisible);
-        
+
         // Effects from different backends can have same Effect IDs.
         // Add backend name to group to uniquely identify those effects.
         // Use untranslated value to keep the group language independent.
-        m_pConfig->set(ConfigKey("[Visible " + pManifest->backendName() + " Effects]", pManifest->id()), 
-                       ConfigValue(profile->bIsVisible));
+        m_pConfig->set(ConfigKey("[Visible " + pManifest->backendName() + " Effects]", pManifest->id()),
+                ConfigValue(profile->bIsVisible));
     }
+
+    m_pConfig->set(ConfigKey("[Effects]", "AdoptMetaknobValue"),
+            ConfigValue(radioButtonKeepMetaknobPosition->isChecked()));
 }
 
 void DlgPrefEffects::slotResetToDefaults() {
+    radioButtonKeepMetaknobPosition->setChecked(true);
+
     slotUpdate();
 }
 

--- a/src/preferences/dialog/dlgprefeffects.h
+++ b/src/preferences/dialog/dlgprefeffects.h
@@ -1,10 +1,12 @@
 #ifndef DLGPREFEFFECTS_H
 #define DLGPREFEFFECTS_H
 
-#include "preferences/usersettings.h"
+#include <QButtonGroup>
+
 #include "preferences/dialog/ui_dlgprefeffectsdlg.h"
 #include "preferences/dlgpreferencepage.h"
 #include "preferences/effectsettingsmodel.h"
+#include "preferences/usersettings.h"
 
 class EffectsManager;
 

--- a/src/preferences/dialog/dlgprefeffectsdlg.ui
+++ b/src/preferences/dialog/dlgprefeffectsdlg.ui
@@ -20,8 +20,39 @@
    <string>Effects Preferences</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+
    <item>
-    <widget class="QTabWidget" name="effectsTabs">
+    <widget class="QGroupBox" name="groupMetaKnobOption">
+     <property name="title">
+      <string>Effect load behavior</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayoutMetaKnob">
+      <item>
+       <widget class="QRadioButton" name="radioButtonKeepMetaknobPosition">
+        <property name="text">
+         <string>Keep metaknob position</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">buttonGroupEffectLoadBehavior</string>
+        </attribute>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radioButtonMetaknobLoadDefault">
+        <property name="text">
+         <string>Reset metaknob to effect default</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">buttonGroupEffectLoadBehavior</string>
+        </attribute>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+
+   <item>
+    <widget class="QGroupBox" name="availableEffects">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Ignored" vsizetype="Expanding">
        <horstretch>0</horstretch>

--- a/src/preferences/dialog/dlgprefeffectsdlg.ui
+++ b/src/preferences/dialog/dlgprefeffectsdlg.ui
@@ -59,249 +59,255 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="currentIndex">
-      <number>0</number>
+     <property name="title">
+      <string>Available Effects</string>
      </property>
-     <widget class="QWidget" name="availableEffectsTab">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
+     <layout class="QVBoxLayout" name="horizontalLayout">
+      <property name="leftMargin">
+       <number>0</number>
       </property>
-      <attribute name="title">
-       <string>Available Effects</string>
-      </attribute>
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="QTableView" name="availableEffectsList">
-         <property name="maximumSize">
-          <size>
-           <width>400</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="styleSheet">
-          <string notr="true"/>
-         </property>
-         <property name="selectionMode">
-          <enum>QAbstractItemView::SingleSelection</enum>
-         </property>
-         <property name="selectionBehavior">
-          <enum>QAbstractItemView::SelectRows</enum>
-         </property>
-         <property name="showGrid">
-          <bool>true</bool>
-         </property>
-         <property name="gridStyle">
-          <enum>Qt::NoPen</enum>
-         </property>
-         <attribute name="horizontalHeaderHighlightSections">
-          <bool>true</bool>
-         </attribute>
-         <attribute name="horizontalHeaderStretchLastSection">
-          <bool>true</bool>
-         </attribute>
-         <attribute name="verticalHeaderVisible">
-          <bool>false</bool>
-         </attribute>
-         <attribute name="verticalHeaderHighlightSections">
-          <bool>false</bool>
-         </attribute>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="groupBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="title">
-          <string>Effect Info</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout">
-          <item row="4" column="1">
-           <widget class="QLabel" name="effectDescription">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string notr="true">(effect description)</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLabel" name="effectName">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string notr="true">(effect name)</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="effectVersionLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Version:</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLabel" name="effectVersion">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string notr="true">(effect version)</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QLabel" name="effectAuthor">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string notr="true">(effect author)</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="effectDescriptionLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Description:</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="effectAuthorLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Author:</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="0">
-           <spacer name="verticalSpacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="effectNameLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Name:</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="effectTypeLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Type:</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QLabel" name="effectType">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string notr="true">(effect type)</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-      </layout>
-     </widget>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+
+      <item>
+       <widget class="QTableView" name="availableEffectsList">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+          <horstretch>0</horstretch>
+          <verstretch>1</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="styleSheet">
+         <string notr="true"/>
+        </property>
+        <property name="selectionMode">
+         <enum>QAbstractItemView::SingleSelection</enum>
+        </property>
+        <property name="selectionBehavior">
+         <enum>QAbstractItemView::SelectRows</enum>
+        </property>
+        <property name="showGrid">
+         <bool>true</bool>
+        </property>
+        <property name="gridStyle">
+         <enum>Qt::NoPen</enum>
+        </property>
+        <attribute name="horizontalHeaderHighlightSections">
+         <bool>true</bool>
+        </attribute>
+        <attribute name="horizontalHeaderStretchLastSection">
+         <bool>true</bool>
+        </attribute>
+        <attribute name="verticalHeaderVisible">
+         <bool>false</bool>
+        </attribute>
+        <attribute name="verticalHeaderHighlightSections">
+         <bool>false</bool>
+        </attribute>
+       </widget>
+      </item>
+
+      <item>
+       <widget class="QGroupBox" name="groupBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="title">
+         <string>Effect Info</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayoutAvailableEffects">
+         <item row="4" column="1">
+          <widget class="QLabel" name="effectDescription">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string notr="true">(effect description)</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLabel" name="effectName">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string notr="true">(effect name)</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="effectVersionLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Version:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLabel" name="effectVersion">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string notr="true">(effect version)</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QLabel" name="effectAuthor">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string notr="true">(effect author)</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="effectDescriptionLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Description:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="effectAuthorLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Author:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
+          <spacer name="verticalSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="effectNameLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Name:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="effectTypeLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Type:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLabel" name="effectType">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string notr="true">(effect type)</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+
+     </layout>
     </widget>
    </item>
+
+
   </layout>
  </widget>
  <resources/>

--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -220,11 +220,6 @@ void DlgPrefInterface::slotUpdate() {
 
     int inhibitsettings = static_cast<int>(m_mixxx->getInhibitScreensaver());
     comboBoxScreensaver->setCurrentIndex(comboBoxScreensaver->findData(inhibitsettings));
-
-    bool effectAdoptMetaknobValue = m_pConfig->getValue(
-            ConfigKey("[Effects]", "AdoptMetaknobValue"), true);
-    radioButtonKeepMetaknobPosition->setChecked(effectAdoptMetaknobValue);
-    radioButtonMetaknobLoadDefault->setChecked(!effectAdoptMetaknobValue);
 }
 
 void DlgPrefInterface::slotResetToDefaults() {
@@ -251,8 +246,6 @@ void DlgPrefInterface::slotResetToDefaults() {
 
     // Tooltips on everywhere.
     radioButtonTooltipsLibraryAndSkin->setChecked(true);
-
-    radioButtonKeepMetaknobPosition->setChecked(true);
 }
 
 void DlgPrefInterface::slotSetScaleFactor(double newValue) {
@@ -348,9 +341,6 @@ void DlgPrefInterface::slotApply() {
 
     m_pConfig->set(ConfigKey("[Config]", "StartInFullscreen"),
             ConfigValue(checkBoxStartFullScreen->isChecked()));
-
-    m_pConfig->set(ConfigKey("[Effects]", "AdoptMetaknobValue"),
-            ConfigValue(radioButtonKeepMetaknobPosition->isChecked()));
 
     m_mixxx->setToolTipsCfg(m_tooltipMode);
 

--- a/src/preferences/dialog/dlgprefinterfacedlg.ui
+++ b/src/preferences/dialog/dlgprefinterfacedlg.ui
@@ -17,10 +17,21 @@
    <item row="0" column="0">
     <widget class="QGroupBox" name="groupBoxSkinOptions">
      <property name="title">
-      <string>Interface options</string>
+      <string/>
      </property>
      <layout class="QGridLayout" name="GridLayout1">
-
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
       <item row="0" column="0">
        <widget class="QLabel" name="lableSkin_2">
         <property name="enabled">
@@ -290,52 +301,9 @@
       <item row="13" column="1" colspan="2">
        <widget class="QComboBox" name="comboBoxScreensaver"/>
       </item>
-
      </layout>
     </widget>
    </item>
-
-   <item row="1" column="0">
-    <widget class="QGroupBox" name="groupBoxEffectOption">
-     <property name="title">
-      <string>Effect options</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="labelLoadBehavior">
-        <property name="text">
-         <string>Load behavior</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1" colspan="2">
-       <layout class="QHBoxLayout" name="horizontalLayoutEffects">
-        <item>
-         <widget class="QRadioButton" name="radioButtonKeepMetaknobPosition">
-          <property name="text">
-           <string>Keep metaknob position</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">buttonGroupEffectLoadBehavior</string>
-          </attribute>
-         </widget>
-        </item>
-        <item>
-         <widget class="QRadioButton" name="radioButtonMetaknobLoadDefault">
-          <property name="text">
-           <string>Reset metaknob to effect default</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">buttonGroupEffectLoadBehavior</string>
-          </attribute>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-
    <item row="2" column="0">
     <spacer name="verticalSpacer2">
      <property name="orientation">
@@ -366,6 +334,5 @@
  <connections/>
  <buttongroups>
   <buttongroup name="buttonGroupTooltips"/>
-  <buttongroup name="buttonGroupEffectLoadBehavior"/>
  </buttongroups>
 </ui>

--- a/src/preferences/dialog/dlgprefkeydlg.ui
+++ b/src/preferences/dialog/dlgprefkeydlg.ui
@@ -14,10 +14,11 @@
    <string>Key Notation Format Settings</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+
    <item>
     <widget class="QCheckBox" name="banalyzerenabled">
      <property name="toolTip">
-      <string>When key detection is enabled, Mixxx detects the musical key of your tracks 
+      <string>When key detection is enabled, Mixxx detects the musical key of your tracks
 and allows you to pitch adjust them for harmonic mixing.</string>
      </property>
      <property name="text">
@@ -25,6 +26,7 @@ and allows you to pitch adjust them for harmonic mixing.</string>
      </property>
     </widget>
    </item>
+
    <item>
     <widget class="QGroupBox" name="groupPlugin">
      <property name="title">
@@ -78,6 +80,7 @@ and allows you to pitch adjust them for harmonic mixing.</string>
      </layout>
     </widget>
    </item>
+
    <item>
     <widget class="QGroupBox" name="groupOptions">
      <property name="title">
@@ -101,6 +104,7 @@ and allows you to pitch adjust them for harmonic mixing.</string>
      </layout>
     </widget>
    </item>
+
    <item>
     <widget class="QGroupBox" name="groupNotation">
      <property name="minimumSize">
@@ -113,8 +117,9 @@ and allows you to pitch adjust them for harmonic mixing.</string>
       <string>Key Notation</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
+
       <item>
-       <layout class="QHBoxLayout" name="notationChoice">
+       <layout class="QHBoxLayout" name="notationChoice1">
         <item>
          <widget class="QRadioButton" name="radioNotationLancelot">
           <property name="text">
@@ -136,6 +141,11 @@ and allows you to pitch adjust them for harmonic mixing.</string>
           </property>
          </widget>
         </item>
+       </layout>
+      </item>
+
+      <item>
+       <layout class="QHBoxLayout" name="notationChoice2">
         <item>
          <widget class="QRadioButton" name="radioNotationOpenKeyAndTraditional">
           <property name="text">
@@ -159,6 +169,7 @@ and allows you to pitch adjust them for harmonic mixing.</string>
         </item>
        </layout>
       </item>
+
       <item>
        <layout class="QGridLayout" name="customNotation">
         <item row="0" column="0">

--- a/src/preferences/dialog/dlgprefvinyl.cpp
+++ b/src/preferences/dialog/dlgprefvinyl.cpp
@@ -90,6 +90,11 @@ DlgPrefVinyl::DlgPrefVinyl(QWidget * parent, VinylControlManager *pVCMan,
     ComboBoxVinylSpeed4->addItem(MIXXX_VINYL_SPEED_33);
     ComboBoxVinylSpeed4->addItem(MIXXX_VINYL_SPEED_45);
 
+    LeadinTime1->setSuffix(" s");
+    LeadinTime2->setSuffix(" s");
+    LeadinTime3->setSuffix(" s");
+    LeadinTime4->setSuffix(" s");
+
     TroubleshootingLink->setText(QString("<a href='%1%2'>Troubleshooting</a>")
                                          .arg(MIXXX_MANUAL_URL)
                                          .arg("/chapters/vinyl_control.html#troubleshooting"));
@@ -136,19 +141,19 @@ void DlgPrefVinyl::slotNumDecksChanged(double dNumDecks) {
 }
 
 void DlgPrefVinyl::slotVinylType1Changed(QString text) {
-    LeadinTime1->setText(QString("%1").arg(getDefaultLeadIn(text)));
+    LeadinTime1->setValue(getDefaultLeadIn(text));
 }
 
 void DlgPrefVinyl::slotVinylType2Changed(QString text) {
-    LeadinTime2->setText(QString("%1").arg(getDefaultLeadIn(text)));
+    LeadinTime2->setValue(getDefaultLeadIn(text));
 }
 
 void DlgPrefVinyl::slotVinylType3Changed(QString text) {
-    LeadinTime3->setText(QString("%1").arg(getDefaultLeadIn(text)));
+    LeadinTime3->setValue(getDefaultLeadIn(text));
 }
 
 void DlgPrefVinyl::slotVinylType4Changed(QString text) {
-    LeadinTime4->setText(QString("%1").arg(getDefaultLeadIn(text)));
+    LeadinTime4->setValue(getDefaultLeadIn(text));
 }
 
 /** @brief Performs any necessary actions that need to happen when the prefs dialog is opened */
@@ -185,10 +190,11 @@ void DlgPrefVinyl::slotResetToDefaults() {
     ComboBoxVinylSpeed2->setCurrentIndex(0);
     ComboBoxVinylSpeed3->setCurrentIndex(0);
     ComboBoxVinylSpeed4->setCurrentIndex(0);
-    LeadinTime1->setText(QString("%1").arg(MIXXX_VINYL_SERATOCV02VINYLSIDEA_LEADIN));
-    LeadinTime2->setText(QString("%1").arg(MIXXX_VINYL_SERATOCV02VINYLSIDEA_LEADIN));
-    LeadinTime3->setText(QString("%1").arg(MIXXX_VINYL_SERATOCV02VINYLSIDEA_LEADIN));
-    LeadinTime4->setText(QString("%1").arg(MIXXX_VINYL_SERATOCV02VINYLSIDEA_LEADIN));
+
+    LeadinTime1->setValue(MIXXX_VINYL_SERATOCV02VINYLSIDEA_LEADIN);
+    LeadinTime2->setValue(MIXXX_VINYL_SERATOCV02VINYLSIDEA_LEADIN);
+    LeadinTime3->setValue(MIXXX_VINYL_SERATOCV02VINYLSIDEA_LEADIN);
+    LeadinTime4->setValue(MIXXX_VINYL_SERATOCV02VINYLSIDEA_LEADIN);
     SignalQualityEnable->setChecked(true);
     VinylGain->setValue(0);
     slotUpdateVinylGain();
@@ -246,14 +252,10 @@ void DlgPrefVinyl::slotUpdate() {
         ComboBoxVinylSpeed4->setCurrentIndex(combo_index);
 
     // set lead-in time
-    LeadinTime1->setText(config->getValue(
-            ConfigKey("[Channel1]", "vinylcontrol_lead_in_time"), "0"));
-    LeadinTime2->setText(config->getValue(
-            ConfigKey("[Channel2]", "vinylcontrol_lead_in_time"), "0"));
-    LeadinTime3->setText(config->getValue(
-            ConfigKey("[Channel3]", "vinylcontrol_lead_in_time"), "0"));
-    LeadinTime4->setText(config->getValue(
-            ConfigKey("[Channel4]", "vinylcontrol_lead_in_time"), "0"));
+    LeadinTime1->setValue((config->getValue(ConfigKey("[Channel1]", "vinylcontrol_lead_in_time"), "0")).toInt());
+    LeadinTime2->setValue((config->getValue(ConfigKey("[Channel2]", "vinylcontrol_lead_in_time"), "0")).toInt());
+    LeadinTime3->setValue((config->getValue(ConfigKey("[Channel3]", "vinylcontrol_lead_in_time"), "0")).toInt());
+    LeadinTime4->setValue((config->getValue(ConfigKey("[Channel4]", "vinylcontrol_lead_in_time"), "0")).toInt());
 
     SignalQualityEnable->setChecked(
             (bool)config->getValue<bool>(ConfigKey(VINYL_PREF_KEY, "show_signal_quality")));
@@ -269,7 +271,7 @@ void DlgPrefVinyl::slotUpdate() {
     }
 }
 
-void DlgPrefVinyl::verifyAndSaveLeadInTime(QLineEdit* widget, QString group, QString vinyl_type) {
+void DlgPrefVinyl::verifyAndSaveLeadInTime(QSpinBox* widget, QString group, QString vinyl_type) {
     QString strLeadIn = widget->text();
     bool isInteger;
     strLeadIn.toInt(&isInteger);
@@ -424,9 +426,7 @@ void DlgPrefVinyl::setDeck1WidgetsVisible(bool visible) {
         if (m_signalWidgets.length() > 0) {
             m_signalWidgets[0]->show();
         }
-        LeadinLabel1->show();
         LeadinTime1->show();
-        SecondsLabel1->show();
     } else {
         VinylLabel1->hide();
         ComboBoxVinylType1->hide();
@@ -434,9 +434,7 @@ void DlgPrefVinyl::setDeck1WidgetsVisible(bool visible) {
         if (m_signalWidgets.length() > 0) {
             m_signalWidgets[0]->hide();
         }
-        LeadinLabel1->hide();
         LeadinTime1->hide();
-        SecondsLabel1->hide();
     }
 }
 
@@ -448,9 +446,7 @@ void DlgPrefVinyl::setDeck2WidgetsVisible(bool visible) {
         if (m_signalWidgets.length() > 1) {
             m_signalWidgets[1]->show();
         }
-        LeadinLabel2->show();
         LeadinTime2->show();
-        SecondsLabel2->show();
     } else {
         VinylLabel2->hide();
         ComboBoxVinylType2->hide();
@@ -458,9 +454,7 @@ void DlgPrefVinyl::setDeck2WidgetsVisible(bool visible) {
         if (m_signalWidgets.length() > 1) {
             m_signalWidgets[1]->hide();
         }
-        LeadinLabel2->hide();
         LeadinTime2->hide();
-        SecondsLabel2->hide();
     }
 }
 
@@ -472,9 +466,7 @@ void DlgPrefVinyl::setDeck3WidgetsVisible(bool visible) {
         if (m_signalWidgets.length() > 2) {
             m_signalWidgets[2]->show();
         }
-        LeadinLabel3->show();
         LeadinTime3->show();
-        SecondsLabel3->show();
     } else {
         VinylLabel3->hide();
         ComboBoxVinylType3->hide();
@@ -482,9 +474,7 @@ void DlgPrefVinyl::setDeck3WidgetsVisible(bool visible) {
         if (m_signalWidgets.length() > 2) {
             m_signalWidgets[2]->hide();
         }
-        LeadinLabel3->hide();
         LeadinTime3->hide();
-        SecondsLabel3->hide();
     }
 }
 
@@ -496,9 +486,7 @@ void DlgPrefVinyl::setDeck4WidgetsVisible(bool visible) {
         if (m_signalWidgets.length() > 3) {
             m_signalWidgets[3]->show();
         }
-        LeadinLabel4->show();
         LeadinTime4->show();
-        SecondsLabel4->show();
     } else {
         VinylLabel4->hide();
         ComboBoxVinylType4->hide();
@@ -506,8 +494,6 @@ void DlgPrefVinyl::setDeck4WidgetsVisible(bool visible) {
         if (m_signalWidgets.length() > 3) {
             m_signalWidgets[3]->hide();
         }
-        LeadinLabel4->hide();
         LeadinTime4->hide();
-        SecondsLabel4->hide();
     }
 }

--- a/src/preferences/dialog/dlgprefvinyl.h
+++ b/src/preferences/dialog/dlgprefvinyl.h
@@ -18,12 +18,13 @@
 #ifndef DLGPREFVINYL_H
 #define DLGPREFVINYL_H
 
+#include <QSpinBox>
 #include <QWidget>
 
 #include "preferences/dialog/ui_dlgprefvinyldlg.h"
+#include "preferences/dlgpreferencepage.h"
 #include "preferences/usersettings.h"
 #include "vinylcontrol/vinylcontrolsignalwidget.h"
-#include "preferences/dlgpreferencepage.h"
 
 class ControlProxy;
 class VinylControlManager;
@@ -60,7 +61,7 @@ class DlgPrefVinyl : public DlgPreferencePage, Ui::DlgPrefVinylDlg  {
     void setDeck2WidgetsVisible(bool visible);
     void setDeck3WidgetsVisible(bool visible);
     void setDeck4WidgetsVisible(bool visible);
-    void verifyAndSaveLeadInTime(QLineEdit* widget, QString group, QString vinyl_type);
+    void verifyAndSaveLeadInTime(QSpinBox* widget, QString group, QString vinyl_type);
     int getDefaultLeadIn(QString vinyl_type) const;
 
 

--- a/src/preferences/dialog/dlgprefvinyldlg.ui
+++ b/src/preferences/dialog/dlgprefvinyldlg.ui
@@ -13,14 +13,62 @@
   <property name="windowTitle">
    <string>Vinyl Control Preferences</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_3">
-   <item row="1" column="0" colspan="3">
-    <widget class="QGroupBox" name="groupBox_3">
+  <layout class="QGridLayout" name="VinylPrefLayout">
+
+   <item row="1" column="0" colspan="2">
+    <widget class="QGroupBox" name="vinylConfigGroupBox">
      <property name="title">
       <string>Vinyl Configuration</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
+
+      <item row="0" column="1" colspan="2">
+       <widget class="QLabel" name="VinylTypeLabel">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="leftMargin">
+         <number>3</number>
+        </property>
+        <property name="text">
+         <string>Vinyl Type</string>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+
+      <item row="0" column="3">
+       <widget class="QLabel" name="LeadInLabel">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="leftMargin">
+         <number>3</number>
+        </property>
+        <property name="text">
+         <string>Lead-In</string>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+
+      <item row="1" column="0">
        <widget class="QLabel" name="VinylLabel1">
         <property name="enabled">
          <bool>true</bool>
@@ -35,7 +83,7 @@
          <font/>
         </property>
         <property name="text">
-         <string>Deck 1 Vinyl Type</string>
+         <string>Deck 1</string>
         </property>
         <property name="wordWrap">
          <bool>false</bool>
@@ -45,7 +93,86 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="2">
+
+      <item row="2" column="0">
+       <widget class="QLabel" name="VinylLabel2">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font/>
+        </property>
+        <property name="text">
+         <string>Deck 2</string>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+        <property name="buddy">
+         <cstring>ComboBoxVinylType2</cstring>
+        </property>
+       </widget>
+      </item>
+
+      <item row="3" column="0">
+       <widget class="QLabel" name="VinylLabel3">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font/>
+        </property>
+        <property name="text">
+         <string>Deck 3</string>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+        <property name="buddy">
+         <cstring>ComboBoxVinylType3</cstring>
+        </property>
+       </widget>
+      </item>
+
+      <item row="4" column="0">
+       <widget class="QLabel" name="VinylLabel4">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font/>
+        </property>
+        <property name="text">
+         <string>Deck 4</string>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+        <property name="buddy">
+         <cstring>ComboBoxVinylType4</cstring>
+        </property>
+       </widget>
+      </item>
+
+      <item row="1" column="1">
        <widget class="QComboBox" name="ComboBoxVinylType1">
         <property name="enabled">
          <bool>true</bool>
@@ -61,130 +188,8 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="3">
-       <widget class="QComboBox" name="ComboBoxVinylSpeed1">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="font">
-         <font/>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="4">
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::MinimumExpanding</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="0" column="5">
-       <widget class="QLabel" name="LeadinLabel1">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="font">
-         <font/>
-        </property>
-        <property name="text">
-         <string>Lead-in</string>
-        </property>
-        <property name="wordWrap">
-         <bool>false</bool>
-        </property>
-        <property name="buddy">
-         <cstring>LeadinTime1</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="6">
-       <widget class="QLineEdit" name="LeadinTime1">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>45</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>50</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="7">
-       <widget class="QLabel" name="SecondsLabel1">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="font">
-         <font/>
-        </property>
-        <property name="text">
-         <string>seconds</string>
-        </property>
-        <property name="wordWrap">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="VinylLabel2">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="font">
-         <font/>
-        </property>
-        <property name="text">
-         <string>Deck 2 Vinyl Type</string>
-        </property>
-        <property name="wordWrap">
-         <bool>false</bool>
-        </property>
-        <property name="buddy">
-         <cstring>ComboBoxVinylType2</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
+
+      <item row="2" column="1">
        <widget class="QComboBox" name="ComboBoxVinylType2">
         <property name="enabled">
          <bool>true</bool>
@@ -200,130 +205,8 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="3">
-       <widget class="QComboBox" name="ComboBoxVinylSpeed2">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="font">
-         <font/>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="4">
-       <spacer name="horizontalSpacer_21">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::MinimumExpanding</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="1" column="5">
-       <widget class="QLabel" name="LeadinLabel2">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="font">
-         <font/>
-        </property>
-        <property name="text">
-         <string>Lead-in</string>
-        </property>
-        <property name="wordWrap">
-         <bool>false</bool>
-        </property>
-        <property name="buddy">
-         <cstring>LeadinTime2</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="6">
-       <widget class="QLineEdit" name="LeadinTime2">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>45</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>50</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="7">
-       <widget class="QLabel" name="SecondsLabel2">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="font">
-         <font/>
-        </property>
-        <property name="text">
-         <string>seconds</string>
-        </property>
-        <property name="wordWrap">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="VinylLabel3">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="font">
-         <font/>
-        </property>
-        <property name="text">
-         <string>Deck 3 Vinyl Type</string>
-        </property>
-        <property name="wordWrap">
-         <bool>false</bool>
-        </property>
-        <property name="buddy">
-         <cstring>ComboBoxVinylType3</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
+
+      <item row="3" column="1">
        <widget class="QComboBox" name="ComboBoxVinylType3">
         <property name="enabled">
          <bool>true</bool>
@@ -339,130 +222,8 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="3">
-       <widget class="QComboBox" name="ComboBoxVinylSpeed3">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="font">
-         <font/>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="4">
-       <spacer name="horizontalSpacer_22">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::MinimumExpanding</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="2" column="5">
-       <widget class="QLabel" name="LeadinLabel3">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="font">
-         <font/>
-        </property>
-        <property name="text">
-         <string>Lead-in</string>
-        </property>
-        <property name="wordWrap">
-         <bool>false</bool>
-        </property>
-        <property name="buddy">
-         <cstring>LeadinTime3</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="6">
-       <widget class="QLineEdit" name="LeadinTime3">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>45</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>50</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="7">
-       <widget class="QLabel" name="SecondsLabel3">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="font">
-         <font/>
-        </property>
-        <property name="text">
-         <string>seconds</string>
-        </property>
-        <property name="wordWrap">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="VinylLabel4">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="font">
-         <font/>
-        </property>
-        <property name="text">
-         <string>Deck 4 Vinyl Type</string>
-        </property>
-        <property name="wordWrap">
-         <bool>false</bool>
-        </property>
-        <property name="buddy">
-         <cstring>ComboBoxVinylType4</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="2">
+
+      <item row="4" column="1">
        <widget class="QComboBox" name="ComboBoxVinylType4">
         <property name="enabled">
          <bool>true</bool>
@@ -478,7 +239,59 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="3">
+
+      <item row="1" column="2">
+       <widget class="QComboBox" name="ComboBoxVinylSpeed1">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font/>
+        </property>
+       </widget>
+      </item>
+
+      <item row="2" column="2">
+       <widget class="QComboBox" name="ComboBoxVinylSpeed2">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font/>
+        </property>
+       </widget>
+      </item>
+
+      <item row="3" column="2">
+       <widget class="QComboBox" name="ComboBoxVinylSpeed3">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font/>
+        </property>
+       </widget>
+      </item>
+
+      <item row="4" column="2">
        <widget class="QComboBox" name="ComboBoxVinylSpeed4">
         <property name="enabled">
          <bool>true</bool>
@@ -494,49 +307,12 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="4">
-       <spacer name="horizontalSpacer_23">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+
+      <item row="1" column="3">
+       <widget class="QSpinBox" name="LeadinTime1">
+        <property name="minimum">
+         <number>0</number>
         </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::MinimumExpanding</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="3" column="5">
-       <widget class="QLabel" name="LeadinLabel4">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="font">
-         <font/>
-        </property>
-        <property name="text">
-         <string>Lead-in</string>
-        </property>
-        <property name="wordWrap">
-         <bool>false</bool>
-        </property>
-        <property name="buddy">
-         <cstring>LeadinTime4</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="6">
-       <widget class="QLineEdit" name="LeadinTime4">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -545,13 +321,13 @@
         </property>
         <property name="minimumSize">
          <size>
-          <width>45</width>
+          <width>55</width>
           <height>0</height>
          </size>
         </property>
         <property name="maximumSize">
          <size>
-          <width>50</width>
+          <width>70</width>
           <height>16777215</height>
          </size>
         </property>
@@ -560,38 +336,113 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="7">
-       <widget class="QLabel" name="SecondsLabel4">
-        <property name="enabled">
-         <bool>true</bool>
+
+      <item row="2" column="3">
+       <widget class="QSpinBox" name="LeadinTime2">
+        <property name="minimum">
+         <number>0</number>
         </property>
-        <property name="font">
-         <font/>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-        <property name="text">
-         <string>seconds</string>
+        <property name="minimumSize">
+         <size>
+          <width>55</width>
+          <height>0</height>
+         </size>
         </property>
-        <property name="wordWrap">
-         <bool>false</bool>
+        <property name="maximumSize">
+         <size>
+          <width>70</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
-      <item row="5" column="0" colspan="3">
+
+      <item row="3" column="3">
+       <widget class="QSpinBox" name="LeadinTime3">
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>55</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>70</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+
+      <item row="4" column="3">
+       <widget class="QSpinBox" name="LeadinTime4">
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>55</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>70</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+
+      <item row="6" column="0" colspan="5">
        <widget class="QCheckBox" name="SignalQualityEnable">
         <property name="text">
          <string>Show Signal Quality in Skin</string>
         </property>
        </widget>
       </item>
+
      </layout>
     </widget>
    </item>
-   <item row="0" column="0" colspan="3">
+
+   <item row="0" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
       <string>Input</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
+
       <item>
        <widget class="QLabel" name="textLabel1_3">
         <property name="text">
@@ -605,6 +456,7 @@
         </property>
        </widget>
       </item>
+
       <item>
        <widget class="QSlider" name="VinylGain">
         <property name="minimum">
@@ -618,6 +470,7 @@
         </property>
        </widget>
       </item>
+
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
@@ -630,19 +483,27 @@
           </property>
          </widget>
         </item>
+
         <item>
          <spacer name="horizontalSpacer">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>30</width>
             <height>20</height>
            </size>
           </property>
          </spacer>
         </item>
+
         <item>
          <widget class="QLabel" name="textLabelPreampCurrent">
           <property name="text">
@@ -650,19 +511,27 @@
           </property>
          </widget>
         </item>
+
         <item>
          <spacer name="horizontalSpacer_3">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>30</width>
             <height>20</height>
            </size>
           </property>
          </spacer>
         </item>
+
         <item>
          <widget class="QLabel" name="textLabelPreampMax">
           <property name="sizePolicy">
@@ -679,11 +548,13 @@
           </property>
          </widget>
         </item>
+
        </layout>
       </item>
      </layout>
     </widget>
    </item>
+
    <item row="2" column="0" rowspan="2">
     <widget class="QGroupBox" name="groupBoxSignalQuality">
      <property name="title">
@@ -709,10 +580,17 @@
      </layout>
     </widget>
    </item>
-   <item row="5" column="1">
+
+   <item row="5" column="0" colspan="2">
     <widget class="QLabel" name="label">
      <property name="enabled">
       <bool>false</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="toolTip">
       <string>http://www.xwax.co.uk</string>
@@ -721,11 +599,12 @@
       <string>Powered by xwax</string>
      </property>
      <property name="alignment">
-      <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+      <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignRight</set>
      </property>
     </widget>
    </item>
-   <item row="4" column="0" colspan="3">
+
+   <item row="4" column="0" colspan="2">
     <widget class="QGroupBox" name="Hints">
      <property name="title">
       <string>Hints</string>
@@ -754,6 +633,7 @@
      </layout>
     </widget>
    </item>
+
    <item row="6" column="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
@@ -767,6 +647,7 @@
      </property>
     </spacer>
    </item>
+
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>


### PR DESCRIPTION
Some small & big measures to make the preferences pages cleaner and reduce the need for horizontal scrollbars.

* Interface: move Meta knob behaviour to Effects
* Effects: put effect info below effect list
* Key Detection: transform notation selection to 3x2 grid to avoid overlapping names
* AutoDJ: reduce required width, more ambigious slots and objectnames, add documentation
* Vinyl Control: reduce required width, make Lead-In a spinbox

this PR | before:
![pref-opti2_auto](https://user-images.githubusercontent.com/5934199/85471134-500b2280-b5b0-11ea-849e-1d19e1917302.png)
![pref-opti2_effects](https://user-images.githubusercontent.com/5934199/85471144-51d4e600-b5b0-11ea-8562-d002a45bde43.png)
![pref-opti2_interface](https://user-images.githubusercontent.com/5934199/85471149-54374000-b5b0-11ea-8f8b-9ac3ffb7b319.png)
![pref-opti2_key](https://user-images.githubusercontent.com/5934199/85471158-56999a00-b5b0-11ea-8cbf-779f7c949364.png)
![pref-opti2_vinyl](https://user-images.githubusercontent.com/5934199/85471163-57cac700-b5b0-11ea-8eee-bf8e6a7bb42c.png)









ToDo
- [x] Vinyl Control > Lead-In: NN s / NN sec ?
- [ ] double-check AutoDJ defaults
- [ ] double-check relations of AutoDj options, adjust section titles accordingly
- [x] minor alignment fixes