### PR TITLE
Remove last column of table in ColorPaletteEditor

### DIFF
--- a/src/preferences/colorpaletteeditor.cpp
+++ b/src/preferences/colorpaletteeditor.cpp
@@ -78,10 +78,9 @@ ColorPaletteEditor::ColorPaletteEditor(QWidget* parent, bool showHotcueNumbers)
     setContentsMargins(0, 0, 0, 0);
 
     // Set up model
-    m_pModel->setColumnCount(3);
+    m_pModel->setColumnCount(2);
     m_pModel->setHeaderData(0, Qt::Horizontal, tr("Color"), Qt::DisplayRole);
     m_pModel->setHeaderData(1, Qt::Horizontal, tr("Assign to Hotcue Number"), Qt::DisplayRole);
-    m_pModel->setHeaderData(2, Qt::Horizontal, QString(), Qt::DisplayRole);
     connect(m_pModel,
             &ColorPaletteEditorModel::dirtyChanged,
             this,
@@ -102,7 +101,7 @@ ColorPaletteEditor::ColorPaletteEditor(QWidget* parent, bool showHotcueNumbers)
 
     m_pTableView->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
     m_pTableView->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
-    m_pTableView->horizontalHeader()->setSectionResizeMode(2, QHeaderView::Stretch);
+    m_pTableView->horizontalHeader()->setStretchLastSection(true);
 
     if (!showHotcueNumbers) {
         m_pTableView->hideColumn(1);


### PR DESCRIPTION
this PR removes the last column of the table of the `ColorPaletteEditor`
which was solely used for cosmetic purposes. The cells of that
column were editable even though they were meaningless and thus
could cause confusion for the user. This commit removes the
cosmetic column and tells the last header section to fill
the space automatically.

![Screenshot from 2020-06-21 17-51-58](https://user-images.githubusercontent.com/12380386/85229071-f2c47500-b3e7-11ea-8a1a-54457f5a6cea.png)

![Screenshot from 2020-06-21 17-51-48](https://user-images.githubusercontent.com/12380386/85229072-f3f5a200-b3e7-11ea-89f9-57a4202f1bba.png)

I also explored two other solutions which both seemed inferior to this one.
1. override the editordelegate for the cosmetic column to a read-only delegate.
probably the cleanest approach but adds a lot of unnecessary boilerplate code.
2. reimplement `QAbstractItemModel::flags` and remove `Qt::ItemIsEditable` from
all columns after the first two. I didn't opt for this path because it pollutes the model
with code responsible for its view.

Please tell me if another approach is preferred.