### PR TITLE
Allow assigning more than one Hotcue to a Color in a Colorpalette

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1513,6 +1513,7 @@ add_executable(mixxx-test
   src/test/portmidicontroller_test.cpp
   src/test/portmidienumeratortest.cpp
   src/test/queryutiltest.cpp
+  src/test/rangelist_test.cpp
   src/test/readaheadmanager_test.cpp
   src/test/replaygaintest.cpp
   src/test/rescalertest.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -864,6 +864,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/util/mac.cpp
   src/util/movinginterquartilemean.cpp
   src/util/performancetimer.cpp
+  src/util/rangelist.cpp
   src/util/readaheadsamplebuffer.cpp
   src/util/rlimit.cpp
   src/util/rotary.cpp

--- a/src/preferences/colorpaletteeditor.cpp
+++ b/src/preferences/colorpaletteeditor.cpp
@@ -186,7 +186,7 @@ void ColorPaletteEditor::slotTableViewDoubleClicked(const QModelIndex& index) {
 }
 
 void ColorPaletteEditor::slotAddColor() {
-    m_pModel->appendRow(kDefaultPaletteColor);
+    m_pModel->appendRow(kDefaultPaletteColor, {});
     m_pTableView->scrollToBottom();
     m_pTableView->setCurrentIndex(
             m_pModel->index(m_pModel->rowCount() - 1, 0));

--- a/src/preferences/colorpaletteeditormodel.cpp
+++ b/src/preferences/colorpaletteeditormodel.cpp
@@ -144,7 +144,7 @@ void ColorPaletteEditorModel::setColorPalette(const ColorPalette& palette) {
     QList<int> colorIndicesByHotcue = palette.getIndicesByHotcue();
     for (int i = 0; i < colorIndicesByHotcue.size(); i++) {
         int colorIndex = colorIndicesByHotcue.at(i);
-        hotcueColorIndicesMap.insert(colorIndex, i);
+        hotcueColorIndicesMap.insert(colorIndex, i + 1);
     }
 
     for (int i = 0; i < palette.size(); i++) {

--- a/src/preferences/colorpaletteeditormodel.cpp
+++ b/src/preferences/colorpaletteeditormodel.cpp
@@ -1,97 +1,17 @@
 #include "preferences/colorpaletteeditormodel.h"
 
 #include <util/assert.h>
+#include <util/rangelist.h>
 
 #include <QList>
 #include <QMap>
 #include <QMultiMap>
-#include <QRegularExpression>
 #include <algorithm>
 
 #include "engine/controls/cuecontrol.h"
 #include "moc_colorpaletteeditormodel.cpp"
 
 namespace {
-
-const QString kGroupSeparator = QStringLiteral(", ");
-const QString kRangeSeparator = QStringLiteral(" - ");
-// when changing groupSeparator or rangeSeparator, rangeListMatchingRegex must
-// be adjusted as well.
-const QRegularExpression kRangeListMatchingRegex(
-        QStringLiteral("(?:(\\d+)(?:\\s*-\\s*(\\d+))?)[\\s,]*"));
-
-/// parses a comma-separated list of positive ints and range if ints (eg `n - m`)
-/// and returns a sorted list of all the ints described.
-/// inverse counterpart of `stringifyRangeList`
-QList<int> parseRangeList(const QString& input) {
-    QList<int> intList;
-    auto matchGroups = kRangeListMatchingRegex.globalMatch(input);
-    while (matchGroups.hasNext()) {
-        const auto group = matchGroups.next();
-        const QString rangeStart = group.captured(1);
-        const QString rangeEnd = group.captured(2);
-        bool startOk, endOk;
-        int startIndex = rangeStart.toInt(&startOk);
-        if (!startOk) {
-            continue;
-        }
-        int endIndex = rangeEnd.toInt(&endOk);
-        if (!endOk) {
-            endIndex = startIndex;
-        }
-        for (int currentIndex = startIndex; currentIndex <= endIndex; currentIndex++) {
-            intList.append(currentIndex);
-        }
-    }
-
-    std::sort(intList.begin(), intList.end());
-    const auto end = std::unique(intList.begin(), intList.end());
-    intList.erase(end, intList.end());
-
-    return intList;
-}
-
-/// take a list of positive integers and stringify them into a neat
-/// user friendly representation (eg {1, 2, 3} => "1 - 3").
-/// inverse counterpart of `parseRangeList`.
-/// rangeList must be sorted!
-QString stringifyRangeList(const QList<int>& rangeList) {
-    DEBUG_ASSERT(std::is_sorted(rangeList.cbegin(), rangeList.cend()));
-
-    QString stringifiedRangeList;
-
-    for (int i = 0; i < rangeList.size();) {
-        int rangeStartIndex = i;
-        int rangeStartValue = rangeList.at(i);
-
-        while (i < rangeList.size() && rangeList.at(i) == rangeStartValue + (i - rangeStartIndex)) {
-            i++;
-        }
-
-        int rangeEndIndex = i - 1;
-
-        stringifiedRangeList += QString::number(rangeStartValue);
-
-        switch (rangeEndIndex - rangeStartIndex) {
-        case 0:
-            // not a range
-            break;
-        case 1:
-            // treat ranges of (i..i+1) as separate groups: "i, i+1"
-            stringifiedRangeList += kGroupSeparator + QString::number(rangeList.at(rangeEndIndex));
-            break;
-        default:
-            // range where the end is >=2 than the start
-            stringifiedRangeList += kRangeSeparator + QString::number(rangeList.at(rangeEndIndex));
-            break;
-        }
-
-        if (i < rangeList.size()) {
-            stringifiedRangeList += kGroupSeparator;
-        }
-    }
-    return stringifiedRangeList;
-}
 
 QIcon toQIcon(const QColor& color) {
     QPixmap pixmap(50, 50);
@@ -264,7 +184,7 @@ QVariant HotcueIndexListItem::data(int role) const {
     switch (role) {
     case Qt::DisplayRole:
     case Qt::EditRole: {
-        return QVariant(stringifyRangeList(m_hotcueIndexList));
+        return QVariant(mixxx::stringifyRangeList(m_hotcueIndexList));
         break;
     }
     default:
@@ -276,7 +196,7 @@ QVariant HotcueIndexListItem::data(int role) const {
 void HotcueIndexListItem::setData(const QVariant& value, int role) {
     switch (role) {
     case Qt::EditRole: {
-        QList<int> newHotcueIndicies = parseRangeList(value.toString());
+        QList<int> newHotcueIndicies = mixxx::parseRangeList(value.toString());
 
         if (m_hotcueIndexList != newHotcueIndicies) {
             m_hotcueIndexList = newHotcueIndicies;

--- a/src/preferences/colorpaletteeditormodel.cpp
+++ b/src/preferences/colorpaletteeditormodel.cpp
@@ -8,6 +8,7 @@
 #include <QRegularExpression>
 #include <algorithm>
 
+#include "engine/controls/cuecontrol.h"
 #include "moc_colorpaletteeditormodel.cpp"
 
 namespace {
@@ -161,7 +162,7 @@ bool ColorPaletteEditorModel::setData(const QModelIndex& modelIndex, const QVari
         // make sure no index is outside of range
         DEBUG_ASSERT(std::is_sorted(hotcueIndexList.cbegin(), hotcueIndexList.cend()));
         auto endUpper = std::upper_bound(
-                hotcueIndexList.begin(), hotcueIndexList.end(), rowCount());
+                hotcueIndexList.begin(), hotcueIndexList.end(), NUM_HOT_CUES);
         hotcueIndexList.erase(endUpper, hotcueIndexList.end());
         auto endLower = std::upper_bound(hotcueIndexList.begin(), hotcueIndexList.end(), 0);
         hotcueIndexList.erase(hotcueIndexList.begin(), endLower);

--- a/src/preferences/colorpaletteeditormodel.cpp
+++ b/src/preferences/colorpaletteeditormodel.cpp
@@ -19,11 +19,11 @@ QIcon toQIcon(const QColor& color) {
     return QIcon(pixmap);
 }
 
-HotcueIndexListItem* toHotcueIndexListItem(QStandardItem* from) {
-    VERIFY_OR_DEBUG_ASSERT(from->type() == QStandardItem::UserType) {
+HotcueIndexListItem* toHotcueIndexListItem(QStandardItem* pFrom) {
+    VERIFY_OR_DEBUG_ASSERT(pFrom->type() == QStandardItem::UserType) {
         return nullptr;
     }
-    return static_cast<HotcueIndexListItem*>(from);
+    return static_cast<HotcueIndexListItem*>(pFrom);
 }
 
 } // namespace
@@ -71,12 +71,12 @@ bool ColorPaletteEditorModel::setData(const QModelIndex& modelIndex, const QVari
     if (modelIndex.isValid() && modelIndex.column() == 1) {
         const bool initialAttemptSuccessful = QStandardItemModel::setData(modelIndex, value, role);
 
-        const auto* hotcueIndexListItem = toHotcueIndexListItem(itemFromIndex(modelIndex));
-        VERIFY_OR_DEBUG_ASSERT(hotcueIndexListItem) {
+        const auto* pHotcueIndexListItem = toHotcueIndexListItem(itemFromIndex(modelIndex));
+        VERIFY_OR_DEBUG_ASSERT(pHotcueIndexListItem) {
             return false;
         }
 
-        auto hotcueIndexList = hotcueIndexListItem->getHotcueIndexList();
+        auto hotcueIndexList = pHotcueIndexListItem->getHotcueIndexList();
 
         // make sure no index is outside of range
         DEBUG_ASSERT(std::is_sorted(hotcueIndexList.cbegin(), hotcueIndexList.cend()));
@@ -87,13 +87,13 @@ bool ColorPaletteEditorModel::setData(const QModelIndex& modelIndex, const QVari
         hotcueIndexList.erase(hotcueIndexList.begin(), endLower);
 
         for (int i = 0; i < rowCount(); ++i) {
-            auto* hotcueIndexListItem = toHotcueIndexListItem(item(i, 1));
+            auto* pHotcueIndexListItem = toHotcueIndexListItem(item(i, 1));
 
-            if (hotcueIndexListItem) {
+            if (pHotcueIndexListItem) {
                 if (i == modelIndex.row()) {
-                    hotcueIndexListItem->setHotcueIndexList(hotcueIndexList);
+                    pHotcueIndexListItem->setHotcueIndexList(hotcueIndexList);
                 } else {
-                    hotcueIndexListItem->removeIndicies(hotcueIndexList);
+                    pHotcueIndexListItem->removeIndicies(hotcueIndexList);
                 }
             }
         }

--- a/src/preferences/colorpaletteeditormodel.cpp
+++ b/src/preferences/colorpaletteeditormodel.cpp
@@ -89,12 +89,14 @@ bool ColorPaletteEditorModel::setData(const QModelIndex& modelIndex, const QVari
         for (int i = 0; i < rowCount(); ++i) {
             auto* pHotcueIndexListItem = toHotcueIndexListItem(item(i, 1));
 
-            if (pHotcueIndexListItem) {
-                if (i == modelIndex.row()) {
-                    pHotcueIndexListItem->setHotcueIndexList(hotcueIndexList);
-                } else {
-                    pHotcueIndexListItem->removeIndicies(hotcueIndexList);
-                }
+            if (pHotcueIndexListItem == nullptr) {
+                continue;
+            }
+
+            if (i == modelIndex.row()) {
+                pHotcueIndexListItem->setHotcueIndexList(hotcueIndexList);
+            } else {
+                pHotcueIndexListItem->removeIndicies(hotcueIndexList);
             }
         }
 

--- a/src/preferences/colorpaletteeditormodel.cpp
+++ b/src/preferences/colorpaletteeditormodel.cpp
@@ -157,8 +157,9 @@ ColorPalette ColorPaletteEditorModel::getColorPalette(
         QStandardItem* pColorItem = item(i, 0);
 
         auto* pHotcueIndexItem = toHotcueIndexListItem(item(i, 1));
-        if (!pHotcueIndexItem)
+        if (!pHotcueIndexItem) {
             continue;
+        }
 
         mixxx::RgbColor::optional_t color =
                 mixxx::RgbColor::fromQString(pColorItem->text());

--- a/src/preferences/colorpaletteeditormodel.cpp
+++ b/src/preferences/colorpaletteeditormodel.cpp
@@ -21,7 +21,6 @@ QIcon toQIcon(const QColor& color) {
 
 HotcueIndexListItem* toHotcueIndexListItem(QStandardItem* from) {
     VERIFY_OR_DEBUG_ASSERT(from->type() == QStandardItem::UserType) {
-        // does std::optional make sense for pointers?
         return nullptr;
     }
     return static_cast<HotcueIndexListItem*>(from);

--- a/src/preferences/colorpaletteeditormodel.cpp
+++ b/src/preferences/colorpaletteeditormodel.cpp
@@ -156,7 +156,7 @@ ColorPalette ColorPaletteEditorModel::getColorPalette(
     for (int i = 0; i < rowCount(); i++) {
         QStandardItem* pColorItem = item(i, 0);
 
-        auto* pHotcueIndexItem = toHotcueIndexListItem(item(i, 1));
+        const auto* pHotcueIndexItem = toHotcueIndexListItem(item(i, 1));
         if (!pHotcueIndexItem) {
             continue;
         }
@@ -165,10 +165,10 @@ ColorPalette ColorPaletteEditorModel::getColorPalette(
                 mixxx::RgbColor::fromQString(pColorItem->text());
 
         if (color) {
-            QList<int> hotcueIndexes = pHotcueIndexItem->getHotcueIndexList();
+            const QList<int> hotcueIndexes = pHotcueIndexItem->getHotcueIndexList();
             colors << *color;
 
-            for (int index : qAsConst(hotcueIndexes)) {
+            for (int index : hotcueIndexes) {
                 hotcueColorIndices.insert(index - 1, colors.size() - 1);
             }
         }
@@ -198,7 +198,7 @@ QVariant HotcueIndexListItem::data(int role) const {
 void HotcueIndexListItem::setData(const QVariant& value, int role) {
     switch (role) {
     case Qt::EditRole: {
-        QList<int> newHotcueIndicies = mixxx::parseRangeList(value.toString());
+        const QList<int> newHotcueIndicies = mixxx::parseRangeList(value.toString());
 
         if (m_hotcueIndexList != newHotcueIndicies) {
             m_hotcueIndexList = newHotcueIndicies;

--- a/src/preferences/colorpaletteeditormodel.cpp
+++ b/src/preferences/colorpaletteeditormodel.cpp
@@ -95,7 +95,8 @@ bool ColorPaletteEditorModel::setData(const QModelIndex& modelIndex, const QVari
         const auto end = std::unique(allHotcueIndicies.begin(), allHotcueIndicies.end());
         allHotcueIndicies.erase(end, allHotcueIndicies.end());
 
-        const bool isOutsidePalette = allHotcueIndicies.last() > rowCount();
+        const bool isOutsidePalette = !allHotcueIndicies.empty() &&
+                allHotcueIndicies.last() > rowCount();
 
         if (preDedupLen != allHotcueIndicies.length() || isOutsidePalette) {
             // checks failed!

--- a/src/preferences/colorpaletteeditormodel.cpp
+++ b/src/preferences/colorpaletteeditormodel.cpp
@@ -12,11 +12,11 @@
 
 namespace {
 
-const auto groupSeparator = QStringLiteral(", ");
-const auto rangeSeparator = QStringLiteral(" - ");
+const QString kGroupSeparator = QStringLiteral(", ");
+const QString kRangeSeparator = QStringLiteral(" - ");
 // when changing groupSeparator or rangeSeparator, rangeListMatchingRegex must
 // be adjusted as well.
-const QRegularExpression rangeListMatchingRegex(
+const QRegularExpression kRangeListMatchingRegex(
         QStringLiteral("(?:(\\d+)(?:\\s*-\\s*(\\d+))?)[\\s,]*"));
 
 /// parses a comma-separated list of positive ints and range if ints (eg `n - m`)
@@ -24,7 +24,7 @@ const QRegularExpression rangeListMatchingRegex(
 /// inverse counterpart of `stringifyRangeList`
 QList<int> parseRangeList(const QString& input) {
     QList<int> intList;
-    auto matchGroups = rangeListMatchingRegex.globalMatch(input);
+    auto matchGroups = kRangeListMatchingRegex.globalMatch(input);
     while (matchGroups.hasNext()) {
         const auto group = matchGroups.next();
         const QString rangeStart = group.captured(1);
@@ -77,16 +77,16 @@ QString stringifyRangeList(const QList<int>& rangeList) {
             break;
         case 1:
             // treat ranges of (i..i+1) as separate groups: "i, i+1"
-            stringifiedRangeList += groupSeparator + QString::number(rangeList.at(rangeEndIndex));
+            stringifiedRangeList += kGroupSeparator + QString::number(rangeList.at(rangeEndIndex));
             break;
         default:
             // range where the end is >=2 than the start
-            stringifiedRangeList += rangeSeparator + QString::number(rangeList.at(rangeEndIndex));
+            stringifiedRangeList += kRangeSeparator + QString::number(rangeList.at(rangeEndIndex));
             break;
         }
 
         if (i < rangeList.size()) {
-            stringifiedRangeList += groupSeparator;
+            stringifiedRangeList += kGroupSeparator;
         }
     }
     return stringifiedRangeList;

--- a/src/preferences/colorpaletteeditormodel.h
+++ b/src/preferences/colorpaletteeditormodel.h
@@ -1,23 +1,23 @@
 #pragma once
+#include <QStandardItem>
 #include <QStandardItemModel>
+#include <QVariant>
 
 #include "util/color/colorpalette.h"
 
 // Model that is used by the QTableView of the ColorPaletteEditor.
-// Takes of displaying palette colors and provides a getter/setter for
+// Takes care of displaying palette colors and provides a getter/setter for
 // ColorPalette instances.
 class ColorPaletteEditorModel : public QStandardItemModel {
     Q_OBJECT
   public:
-    static constexpr int kNoHotcueIndex = -1;
-
     ColorPaletteEditorModel(QObject* parent = nullptr);
 
     bool dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column, const QModelIndex& parent) override;
     bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole) override;
 
     void setColor(int row, const QColor& color);
-    void appendRow(const QColor& color, int hotcueIndex = kNoHotcueIndex);
+    void appendRow(const QColor& color, const QList<int>& hotcueIndicies);
 
     void setDirty(bool bDirty) {
         if (m_bDirty == bDirty) {
@@ -45,4 +45,26 @@ class ColorPaletteEditorModel : public QStandardItemModel {
   private:
     bool m_bEmpty;
     bool m_bDirty;
+};
+
+class HotcueIndexListItem : public QStandardItem {
+  public:
+    HotcueIndexListItem(const QList<int>& hotcueList = {});
+
+    void setData(const QVariant& value, int role = Qt::UserRole + 1) override;
+    QVariant data(int role = Qt::UserRole + 1) const;
+
+    int type() const {
+        return QStandardItem::UserType;
+    };
+
+    const QList<int>& getHotcueIndexList() const {
+        return m_hotcueIndexList;
+    }
+    void setHotcueIndexList(const QList<int>& list) {
+        m_hotcueIndexList = std::move(list);
+    }
+
+  private:
+    QList<int> m_hotcueIndexList;
 };

--- a/src/preferences/colorpaletteeditormodel.h
+++ b/src/preferences/colorpaletteeditormodel.h
@@ -62,8 +62,10 @@ class HotcueIndexListItem : public QStandardItem {
         return m_hotcueIndexList;
     }
     void setHotcueIndexList(const QList<int>& list) {
-        m_hotcueIndexList = std::move(list);
+        m_hotcueIndexList = QList(list);
     }
+
+    void removeIndicies(const QList<int>& otherIndicies);
 
   private:
     QList<int> m_hotcueIndexList;

--- a/src/preferences/colorpaletteeditormodel.h
+++ b/src/preferences/colorpaletteeditormodel.h
@@ -52,9 +52,9 @@ class HotcueIndexListItem : public QStandardItem {
     HotcueIndexListItem(const QList<int>& hotcueList = {});
 
     void setData(const QVariant& value, int role = Qt::UserRole + 1) override;
-    QVariant data(int role = Qt::UserRole + 1) const;
+    QVariant data(int role = Qt::UserRole + 1) const override;
 
-    int type() const {
+    int type() const override {
         return QStandardItem::UserType;
     };
 

--- a/src/test/rangelist_test.cpp
+++ b/src/test/rangelist_test.cpp
@@ -49,9 +49,6 @@ TEST(DisplayIntListTest, largeRangesAreExpanded) {
 
 TEST(DisplayIntListTest, duplicateValuesAreIgnored) {
     EXPECT_EQ(QList<int>({1, 2, 3}), mixxx::parseRangeList("1, 1, 1, 1, 2, 2, 3"));
-
-    // currently only works from string to list, not the other way around
-    // EXPECT_QSTRING_EQ("1, 2, 3", mixxx::stringifyRangeList(QList<int>({1, 1, 1, 1, 2, 2, 3})));
 }
 
 // TEST(DisplayIntListTest, negativeValuesAreIgnored) {

--- a/src/test/rangelist_test.cpp
+++ b/src/test/rangelist_test.cpp
@@ -1,0 +1,74 @@
+#include "util/rangelist.h"
+
+#include <gtest/gtest.h>
+
+#include <QString>
+#include <algorithm>
+
+#include "test/mixxxtest.h"
+
+void roundTripTestStr(const QString& in, const QString* out = nullptr) {
+    const QString roundTrip = mixxx::stringifyRangeList(mixxx::parseRangeList(in));
+    if (out == nullptr) {
+        EXPECT_QSTRING_EQ(in, roundTrip);
+    } else {
+        EXPECT_QSTRING_EQ(*out, roundTrip);
+    }
+}
+
+void roundTripTestList(const QList<int>& in, const QList<int>* out = nullptr) {
+    const QList<int> roundTrip = mixxx::parseRangeList(mixxx::stringifyRangeList(in));
+    if (out == nullptr) {
+        EXPECT_EQ(in, roundTrip);
+    } else {
+        EXPECT_EQ(*out, roundTrip);
+    }
+}
+
+TEST(DisplayIntListTest, ListEmpty) {
+    roundTripTestList({});
+    roundTripTestStr("");
+}
+
+TEST(DisplayIntListTest, smallContinousRangeIsSeparate) {
+    const QList<int> list = mixxx::parseRangeList(QStringLiteral("1 - 2"));
+    EXPECT_EQ(list, QList({1, 2}));
+    EXPECT_QSTRING_EQ("1, 2", mixxx::stringifyRangeList(list));
+}
+
+TEST(DisplayIntListTest, whiteSpaceAreIgnored) {
+    EXPECT_EQ(QList<int>({1, 2, 3, 4}), mixxx::parseRangeList("   1,2  ,  3, 4"));
+}
+
+TEST(DisplayIntListTest, trailingCommaIsIgnored) {
+    EXPECT_EQ(QList<int>({1}), mixxx::parseRangeList("1,"));
+}
+TEST(DisplayIntListTest, largeRangesAreExpanded) {
+    EXPECT_EQ(QList<int>({1, 2, 3, 4, 5, 6, 7}), mixxx::parseRangeList("1 - 7"));
+}
+
+TEST(DisplayIntListTest, duplicateValuesAreIgnored) {
+    EXPECT_EQ(QList<int>({1, 2, 3}), mixxx::parseRangeList("1, 1, 1, 1, 2, 2, 3"));
+
+    // currently only works from string to list, not the other way around
+    // EXPECT_QSTRING_EQ("1, 2, 3", mixxx::stringifyRangeList(QList<int>({1, 1, 1, 1, 2, 2, 3})));
+}
+
+// TEST(DisplayIntListTest, negativeValuesAreIgnored) {
+//     EXPECT_EQ(QList<int>({}), mixxx::parseRangeList("-1,-2,-3"));
+//     EXPECT_QSTRING_EQ("", mixxx::stringifyRangeList(QList<int>({-1, -2, -3})));
+// }
+
+TEST(DisplayIntListTest, resultingListIsSortedAscending) {
+    const auto list = mixxx::parseRangeList("4, 2, 3, 1, 6, 5");
+    EXPECT_TRUE(std::is_sorted(list.cbegin(), list.cend()));
+}
+TEST(DisplayIntListTest, consequitiveValuesAreRanges) {
+    EXPECT_QSTRING_EQ("1 - 4", mixxx::stringifyRangeList(QList<int>({1, 2, 3, 4})));
+}
+TEST(DisplayIntListTest, adjacentRangeAndLiteralGetsCollapsed) {
+    EXPECT_EQ(QList<int>({1, 2, 3, 4, 5}), mixxx::parseRangeList("1, 2 - 4, 5"));
+}
+TEST(DisplayIntListTest, overLappingRangesGetUnionized) {
+    EXPECT_EQ(QList<int>({1, 2, 3, 4}), mixxx::parseRangeList("1 - 3, 2 - 4"));
+}

--- a/src/test/rangelist_test.cpp
+++ b/src/test/rangelist_test.cpp
@@ -51,11 +51,6 @@ TEST(DisplayIntListTest, duplicateValuesAreIgnored) {
     EXPECT_EQ(QList<int>({1, 2, 3}), mixxx::parseRangeList("1, 1, 1, 1, 2, 2, 3"));
 }
 
-// TEST(DisplayIntListTest, negativeValuesAreIgnored) {
-//     EXPECT_EQ(QList<int>({}), mixxx::parseRangeList("-1,-2,-3"));
-//     EXPECT_QSTRING_EQ("", mixxx::stringifyRangeList(QList<int>({-1, -2, -3})));
-// }
-
 TEST(DisplayIntListTest, resultingListIsSortedAscending) {
     const auto list = mixxx::parseRangeList("4, 2, 3, 1, 6, 5");
     EXPECT_TRUE(std::is_sorted(list.cbegin(), list.cend()));

--- a/src/util/rangelist.cpp
+++ b/src/util/rangelist.cpp
@@ -48,6 +48,13 @@ QList<int> parseRangeList(const QString& input) {
 
 QString stringifyRangeList(const QList<int>& rangeList) {
     DEBUG_ASSERT(std::is_sorted(rangeList.cbegin(), rangeList.cend()));
+    DEBUG_ASSERT([&rangeList]() {
+        // Immediately-invoked function expression
+
+        // assumes list is sorted!
+        auto first_duplicate = std::adjacent_find(rangeList.cbegin(), rangeList.cend());
+        return first_duplicate == rangeList.cend();
+    }());
 
     QString stringifiedRangeList;
 

--- a/src/util/rangelist.cpp
+++ b/src/util/rangelist.cpp
@@ -55,6 +55,9 @@ QString stringifyRangeList(const QList<int>& rangeList) {
         auto first_duplicate = std::adjacent_find(rangeList.cbegin(), rangeList.cend());
         return first_duplicate == rangeList.cend();
     }());
+    DEBUG_ASSERT(std::all_of(rangeList.cbegin(), rangeList.cend(), [](int val) {
+        return val >= 0;
+    }));
 
     QString stringifiedRangeList;
 

--- a/src/util/rangelist.cpp
+++ b/src/util/rangelist.cpp
@@ -1,0 +1,87 @@
+#include "rangelist.h"
+
+#include <util/assert.h>
+
+#include <QRegularExpression>
+#include <algorithm>
+
+namespace {
+
+const QString kGroupSeparator = QStringLiteral(", ");
+const QString kRangeSeparator = QStringLiteral(" - ");
+// when changing groupSeparator or rangeSeparator, rangeListMatchingRegex must
+// be adjusted as well.
+const QRegularExpression kRangeListMatchingRegex(
+        QStringLiteral("(?:(\\d+)(?:\\s*-\\s*(\\d+))?)[\\s,]*"));
+
+} // namespace
+
+namespace mixxx {
+
+QList<int> parseRangeList(const QString& input) {
+    QList<int> intList;
+    auto matchGroups = kRangeListMatchingRegex.globalMatch(input);
+    while (matchGroups.hasNext()) {
+        const auto group = matchGroups.next();
+        const QString rangeStart = group.captured(1);
+        const QString rangeEnd = group.captured(2);
+        bool startOk, endOk;
+        int startIndex = rangeStart.toInt(&startOk);
+        if (!startOk) {
+            continue;
+        }
+        int endIndex = rangeEnd.toInt(&endOk);
+        if (!endOk) {
+            endIndex = startIndex;
+        }
+        for (int currentIndex = startIndex; currentIndex <= endIndex; currentIndex++) {
+            intList.append(currentIndex);
+        }
+    }
+
+    std::sort(intList.begin(), intList.end());
+    const auto end = std::unique(intList.begin(), intList.end());
+    intList.erase(end, intList.end());
+
+    return intList;
+}
+
+QString stringifyRangeList(const QList<int>& rangeList) {
+    DEBUG_ASSERT(std::is_sorted(rangeList.cbegin(), rangeList.cend()));
+
+    QString stringifiedRangeList;
+
+    for (int i = 0; i < rangeList.size();) {
+        int rangeStartIndex = i;
+        int rangeStartValue = rangeList.at(i);
+
+        while (i < rangeList.size() && rangeList.at(i) == rangeStartValue + (i - rangeStartIndex)) {
+            i++;
+        }
+
+        int rangeEndIndex = i - 1;
+
+        stringifiedRangeList += QString::number(rangeStartValue);
+
+        switch (rangeEndIndex - rangeStartIndex) {
+        case 0:
+            // not a range
+            break;
+        case 1:
+            // treat ranges of (i..i+1) as separate groups: "i, i+1"
+            stringifiedRangeList += kGroupSeparator + QString::number(rangeList.at(rangeEndIndex));
+            break;
+        default:
+            // range where the end is >=2 than the start
+            stringifiedRangeList += kRangeSeparator + QString::number(rangeList.at(rangeEndIndex));
+            break;
+        }
+
+        if (i < rangeList.size()) {
+            stringifiedRangeList += kGroupSeparator;
+        }
+    }
+    return stringifiedRangeList;
+}
+
+} // namespace mixxx

--- a/src/util/rangelist.h
+++ b/src/util/rangelist.h
@@ -11,7 +11,7 @@ QList<int> parseRangeList(const QString& input);
 /// take a list of positive integers and stringify them into a neat
 /// user friendly representation (eg {1, 2, 3} => "1 - 3").
 /// inverse counterpart of `parseRangeList`.
-/// rangeList must be sorted!
+/// assumes rangeList is well-formed (sorted and not containing duplicates)
 QString stringifyRangeList(const QList<int>& rangeList);
 
 } // namespace mixxx

--- a/src/util/rangelist.h
+++ b/src/util/rangelist.h
@@ -1,90 +1,17 @@
-#include <util/assert.h>
-
 #include <QList>
-#include <QRegularExpression>
 #include <QString>
-#include <algorithm>
 
 namespace mixxx {
-
-const QString kGroupSeparator = QStringLiteral(", ");
-const QString kRangeSeparator = QStringLiteral(" - ");
-// when changing groupSeparator or rangeSeparator, rangeListMatchingRegex must
-// be adjusted as well.
-const QRegularExpression kRangeListMatchingRegex(
-        QStringLiteral("(?:(\\d+)(?:\\s*-\\s*(\\d+))?)[\\s,]*"));
 
 /// parses a comma-separated list of positive ints and range if ints (eg `n - m`)
 /// and returns a sorted list of all the ints described.
 /// inverse counterpart of `stringifyRangeList`
-QList<int> parseRangeList(const QString& input) {
-    QList<int> intList;
-    auto matchGroups = kRangeListMatchingRegex.globalMatch(input);
-    while (matchGroups.hasNext()) {
-        const auto group = matchGroups.next();
-        const QString rangeStart = group.captured(1);
-        const QString rangeEnd = group.captured(2);
-        bool startOk, endOk;
-        int startIndex = rangeStart.toInt(&startOk);
-        if (!startOk) {
-            continue;
-        }
-        int endIndex = rangeEnd.toInt(&endOk);
-        if (!endOk) {
-            endIndex = startIndex;
-        }
-        for (int currentIndex = startIndex; currentIndex <= endIndex; currentIndex++) {
-            intList.append(currentIndex);
-        }
-    }
-
-    std::sort(intList.begin(), intList.end());
-    const auto end = std::unique(intList.begin(), intList.end());
-    intList.erase(end, intList.end());
-
-    return intList;
-}
+QList<int> parseRangeList(const QString& input);
 
 /// take a list of positive integers and stringify them into a neat
 /// user friendly representation (eg {1, 2, 3} => "1 - 3").
 /// inverse counterpart of `parseRangeList`.
 /// rangeList must be sorted!
-QString stringifyRangeList(const QList<int>& rangeList) {
-    DEBUG_ASSERT(std::is_sorted(rangeList.cbegin(), rangeList.cend()));
-
-    QString stringifiedRangeList;
-
-    for (int i = 0; i < rangeList.size();) {
-        int rangeStartIndex = i;
-        int rangeStartValue = rangeList.at(i);
-
-        while (i < rangeList.size() && rangeList.at(i) == rangeStartValue + (i - rangeStartIndex)) {
-            i++;
-        }
-
-        int rangeEndIndex = i - 1;
-
-        stringifiedRangeList += QString::number(rangeStartValue);
-
-        switch (rangeEndIndex - rangeStartIndex) {
-        case 0:
-            // not a range
-            break;
-        case 1:
-            // treat ranges of (i..i+1) as separate groups: "i, i+1"
-            stringifiedRangeList += kGroupSeparator + QString::number(rangeList.at(rangeEndIndex));
-            break;
-        default:
-            // range where the end is >=2 than the start
-            stringifiedRangeList += kRangeSeparator + QString::number(rangeList.at(rangeEndIndex));
-            break;
-        }
-
-        if (i < rangeList.size()) {
-            stringifiedRangeList += kGroupSeparator;
-        }
-    }
-    return stringifiedRangeList;
-}
+QString stringifyRangeList(const QList<int>& rangeList);
 
 } // namespace mixxx

--- a/src/util/rangelist.h
+++ b/src/util/rangelist.h
@@ -11,7 +11,8 @@ QList<int> parseRangeList(const QString& input);
 /// take a list of positive integers and stringify them into a neat
 /// user friendly representation (eg {1, 2, 3} => "1 - 3").
 /// inverse counterpart of `parseRangeList`.
-/// assumes rangeList is well-formed (sorted and not containing duplicates)
+/// assumes rangeList is well-formed
+/// (sorted, not containing duplicates, and positive integers only)
 QString stringifyRangeList(const QList<int>& rangeList);
 
 } // namespace mixxx

--- a/src/util/rangelist.h
+++ b/src/util/rangelist.h
@@ -1,0 +1,90 @@
+#include <util/assert.h>
+
+#include <QList>
+#include <QRegularExpression>
+#include <QString>
+#include <algorithm>
+
+namespace mixxx {
+
+const QString kGroupSeparator = QStringLiteral(", ");
+const QString kRangeSeparator = QStringLiteral(" - ");
+// when changing groupSeparator or rangeSeparator, rangeListMatchingRegex must
+// be adjusted as well.
+const QRegularExpression kRangeListMatchingRegex(
+        QStringLiteral("(?:(\\d+)(?:\\s*-\\s*(\\d+))?)[\\s,]*"));
+
+/// parses a comma-separated list of positive ints and range if ints (eg `n - m`)
+/// and returns a sorted list of all the ints described.
+/// inverse counterpart of `stringifyRangeList`
+QList<int> parseRangeList(const QString& input) {
+    QList<int> intList;
+    auto matchGroups = kRangeListMatchingRegex.globalMatch(input);
+    while (matchGroups.hasNext()) {
+        const auto group = matchGroups.next();
+        const QString rangeStart = group.captured(1);
+        const QString rangeEnd = group.captured(2);
+        bool startOk, endOk;
+        int startIndex = rangeStart.toInt(&startOk);
+        if (!startOk) {
+            continue;
+        }
+        int endIndex = rangeEnd.toInt(&endOk);
+        if (!endOk) {
+            endIndex = startIndex;
+        }
+        for (int currentIndex = startIndex; currentIndex <= endIndex; currentIndex++) {
+            intList.append(currentIndex);
+        }
+    }
+
+    std::sort(intList.begin(), intList.end());
+    const auto end = std::unique(intList.begin(), intList.end());
+    intList.erase(end, intList.end());
+
+    return intList;
+}
+
+/// take a list of positive integers and stringify them into a neat
+/// user friendly representation (eg {1, 2, 3} => "1 - 3").
+/// inverse counterpart of `parseRangeList`.
+/// rangeList must be sorted!
+QString stringifyRangeList(const QList<int>& rangeList) {
+    DEBUG_ASSERT(std::is_sorted(rangeList.cbegin(), rangeList.cend()));
+
+    QString stringifiedRangeList;
+
+    for (int i = 0; i < rangeList.size();) {
+        int rangeStartIndex = i;
+        int rangeStartValue = rangeList.at(i);
+
+        while (i < rangeList.size() && rangeList.at(i) == rangeStartValue + (i - rangeStartIndex)) {
+            i++;
+        }
+
+        int rangeEndIndex = i - 1;
+
+        stringifiedRangeList += QString::number(rangeStartValue);
+
+        switch (rangeEndIndex - rangeStartIndex) {
+        case 0:
+            // not a range
+            break;
+        case 1:
+            // treat ranges of (i..i+1) as separate groups: "i, i+1"
+            stringifiedRangeList += kGroupSeparator + QString::number(rangeList.at(rangeEndIndex));
+            break;
+        default:
+            // range where the end is >=2 than the start
+            stringifiedRangeList += kRangeSeparator + QString::number(rangeList.at(rangeEndIndex));
+            break;
+        }
+
+        if (i < rangeList.size()) {
+            stringifiedRangeList += kGroupSeparator;
+        }
+    }
+    return stringifiedRangeList;
+}
+
+} // namespace mixxx


### PR DESCRIPTION
See [Zulip Topic for Context](https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/cue.20color.20palette.20preferences)

The current commit is broken and I'm only pushing it like this because I need some help implementing it.
I had implemented an approach previously that just parses the comma separated list using a regex using
a simple pure function but that led to a bunch of duplicated code later. So I instead decided to subclass
QStandardItem and parse the data in there. However, this is where I kinda got stuck. First of all because
I was unable to find answers to some questions in the Qt docs and second of all because I'm not familiar
enough with C++ to know whether my solution could even work.