### PR TITLE
PlaylistDAO: Add missing spaces in SQL query

### DIFF
--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -402,9 +402,9 @@ void PlaylistDAO::removeHiddenTracks(const int playlistId) {
             "SELECT p1.position FROM PlaylistTracks AS p1 "
             "WHERE p1.id NOT IN ("
             "SELECT p2.id FROM PlaylistTracks AS p2 "
-            "INNER JOIN library ON library.id = p2.track_id "
-            "WHERE p2.playlist_id = p1.playlist_id "
-            "AND library.mixxx_deleted = 0 ) "
+            "INNER JOIN library ON library.id=p2.track_id "
+            "WHERE p2.playlist_id=p1.playlist_id "
+            "AND library.mixxx_deleted=0) "
             "AND p1.playlist_id=:id"));
     query.bindValue(":id", playlistId);
     query.setForwardOnly(true);

--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -399,9 +399,9 @@ void PlaylistDAO::removeHiddenTracks(const int playlistId) {
     // phantom track_ids with no match in the library table
     QSqlQuery query(m_database);
     query.prepare(QStringLiteral(
-            "SELECT p1.position FROM PlaylistTracks AS p1"
+            "SELECT p1.position FROM PlaylistTracks AS p1 "
             "WHERE p1.id NOT IN ("
-            "SELECT p2.id FROM PlaylistTracks AS p2"
+            "SELECT p2.id FROM PlaylistTracks AS p2 "
             "INNER JOIN library ON library.id = p2.track_id "
             "WHERE p2.playlist_id = p1.playlist_id "
             "AND library.mixxx_deleted = 0 ) "


### PR DESCRIPTION
Fixup of #2900, didn't notice in the logs:

```
Warning [Main]: /tmp/mixxx/src/library/dao/playlistdao.cpp 413 FAILED QUERY [ "SELECT p1.position FROM PlaylistTracks AS p1WHERE p1.id NOT IN (SELECT p2.id FROM PlaylistTracks AS p2INNER JOIN library ON library.id = p2.track_id WHERE p2.playlist_id = p1.playlist_id AND library.mixxx_deleted = 0 ) AND p1.playlist_id=:id" ] QSqlError("", "Parameter count mismatch", "")
```

That's the reason why I prefer to use VERIFY_OR_DEBUG_ASSERT around query preparation and execution to detect such errors early.