### PR TITLE
lp1885631: Fix broken double click action in Quick Links

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -794,8 +794,3 @@ TrackPointer BaseTrackTableModel::getTrackByRef(
         const TrackRef& trackRef) const {
     return m_pTrackCollectionManager->internalCollection()->getTrackByRef(trackRef);
 }
-
-bool BaseTrackTableModel::hasCapabilities(
-        TrackModel::CapabilitiesFlags capabilities) const {
-    return (getCapabilities() & capabilities) == capabilities;
-}

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -89,9 +89,6 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     TrackPointer getTrackByRef(
             const TrackRef& trackRef) const override;
 
-    bool hasCapabilities(
-            TrackModel::CapabilitiesFlags capabilities) const final;
-
   protected:
     static constexpr int defaultColumnWidth() {
         return 50;

--- a/src/library/trackmodel.h
+++ b/src/library/trackmodel.h
@@ -146,9 +146,8 @@ class TrackModel {
     virtual TrackModel::CapabilitiesFlags getCapabilities() const {
         return TRACKMODELCAPS_NONE;
     }
-    virtual bool hasCapabilities(TrackModel::CapabilitiesFlags flags) const {
-        Q_UNUSED(flags);
-        return false;
+    /*non-virtual*/ bool hasCapabilities(TrackModel::CapabilitiesFlags caps) const {
+        return (getCapabilities() & caps) == caps;
     }
     virtual QString getModelSetting(QString name) {
         SettingsDAO settings(m_db);

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -341,13 +341,13 @@ void WTrackTableView::slotMouseDoubleClicked(const QModelIndex& index) {
                     doubleClickActionConfigValue);
 
     auto trackModel = getTrackModel();
+    VERIFY_OR_DEBUG_ASSERT(trackModel) {
+        return;
+    }
+
     if (doubleClickAction == DlgPrefLibrary::LOAD_TO_DECK &&
             trackModel->hasCapabilities(
                     TrackModel::TRACKMODELCAPS_LOADTODECK)) {
-        VERIFY_OR_DEBUG_ASSERT(trackModel) {
-            return;
-        }
-
         TrackPointer pTrack = trackModel->getTrack(index);
         if (pTrack) {
             emit loadTrack(pTrack);


### PR DESCRIPTION
Caused by 0143e7e03020e45fe9badb8e9c080d8e4b2f023c. Not every child class derives from `BaseTrackModel`. The utility function `TrackModel::hasCapabilities()` should not be *virtual* since there is no reason for different implementations.