### PR TITLE
Preferences > Vinyl: consolidate signal quality elements

### DIFF
--- a/src/preferences/dialog/dlgprefvinyldlg.ui
+++ b/src/preferences/dialog/dlgprefvinyldlg.ui
@@ -15,6 +15,125 @@
   </property>
   <layout class="QGridLayout" name="VinylPrefLayout">
 
+   <item row="0" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Input</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+
+      <item>
+       <widget class="QLabel" name="textLabel1_3">
+        <property name="text">
+         <string>Turntable Input Signal Boost</string>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+        <property name="buddy">
+         <cstring>VinylGain</cstring>
+        </property>
+       </widget>
+      </item>
+
+      <item>
+       <widget class="QSlider" name="VinylGain">
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>44</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="textLabelPreampMin">
+          <property name="text">
+           <string>0 dB</string>
+          </property>
+          <property name="wordWrap">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>30</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+
+        <item>
+         <widget class="QLabel" name="textLabelPreampCurrent">
+          <property name="text">
+           <string notr="true">TextLabel</string>
+          </property>
+         </widget>
+        </item>
+
+        <item>
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>30</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+
+        <item>
+         <widget class="QLabel" name="textLabelPreampMax">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>44 dB</string>
+          </property>
+          <property name="wordWrap">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+
    <item row="1" column="0" colspan="2">
     <widget class="QGroupBox" name="vinylConfigGroupBox">
      <property name="title">
@@ -424,183 +543,55 @@
        </widget>
       </item>
 
-      <item row="6" column="0" colspan="5">
+     </layout>
+    </widget>
+   </item>
+
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="groupBoxSignalQuality">
+     <property name="title">
+      <string>Signal Quality</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <layout class="QGridLayout">
+     </layout>
+    </widget>
+   </item>
+
+   <item row="3" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBoxSignalQuality2">
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <property name="leftMargin">
+      <number>6</number>
+     </property>
+     <layout class="QGridLayout">
+      <item row="0" column="0">
        <widget class="QCheckBox" name="SignalQualityEnable">
         <property name="text">
          <string>Show Signal Quality in Skin</string>
         </property>
        </widget>
       </item>
-
      </layout>
-    </widget>
-   </item>
-
-   <item row="0" column="0" colspan="2">
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>Input</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-
-      <item>
-       <widget class="QLabel" name="textLabel1_3">
-        <property name="text">
-         <string>Turntable Input Signal Boost</string>
-        </property>
-        <property name="wordWrap">
-         <bool>false</bool>
-        </property>
-        <property name="buddy">
-         <cstring>VinylGain</cstring>
-        </property>
-       </widget>
-      </item>
-
-      <item>
-       <widget class="QSlider" name="VinylGain">
-        <property name="minimum">
-         <number>0</number>
-        </property>
-        <property name="maximum">
-         <number>44</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QLabel" name="textLabelPreampMin">
-          <property name="text">
-           <string>0 dB</string>
-          </property>
-          <property name="wordWrap">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>30</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-
-        <item>
-         <widget class="QLabel" name="textLabelPreampCurrent">
-          <property name="text">
-           <string notr="true">TextLabel</string>
-          </property>
-         </widget>
-        </item>
-
-        <item>
-         <spacer name="horizontalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>30</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-
-        <item>
-         <widget class="QLabel" name="textLabelPreampMax">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>44 dB</string>
-          </property>
-          <property name="wordWrap">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-
-   <item row="2" column="0" rowspan="2">
-    <widget class="QGroupBox" name="groupBoxSignalQuality">
-     <property name="title">
-      <string>Signal Quality</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-     </property>
-     <layout class="QGridLayout">
-      <item row="0" column="0">
-       <spacer name="verticalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
-   </item>
-
-   <item row="5" column="0" colspan="2">
-    <widget class="QLabel" name="label">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="toolTip">
-      <string>http://www.xwax.co.uk</string>
-     </property>
-     <property name="text">
-      <string>Powered by xwax</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignRight</set>
-     </property>
     </widget>
    </item>
 
@@ -631,6 +622,29 @@
        </widget>
       </item>
      </layout>
+    </widget>
+   </item>
+
+   <item row="5" column="0" colspan="2">
+    <widget class="QLabel" name="label">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string>http://www.xwax.co.uk</string>
+     </property>
+     <property name="text">
+      <string>Powered by xwax</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignRight</set>
+     </property>
     </widget>
    </item>
 


### PR DESCRIPTION
follow-up for #2897
moves "Show signal quality in skins" checkbox below signal quality widgets, as suggested by @Holzhaus 

![Screenshot_2020-07-04_16-49-33](https://user-images.githubusercontent.com/5934199/86515119-26a38f80-be17-11ea-9c05-9f2dfcbbd8cc.png)
