### PR TITLE
Fix some ControlFlag debug assertions in tests

### DIFF
--- a/src/controllers/learningutils.cpp
+++ b/src/controllers/learningutils.cpp
@@ -219,7 +219,8 @@ MidiInputMappings LearningUtils::guessMidiInputMappings(
         // reset control.
         ConfigKey resetControl = control;
         resetControl.item.append("_set_default");
-        bool hasResetControl = ControlObject::getControl(resetControl) != NULL;
+        bool hasResetControl = ControlObject::getControl(resetControl,
+                                       ControlFlag::NoWarnIfMissing) != nullptr;
 
         // Find the CC control (based on the predicate one must exist) and add a
         // binding for it.

--- a/src/test/controlobjecttest.cpp
+++ b/src/test/controlobjecttest.cpp
@@ -32,7 +32,8 @@ TEST_F(ControlObjectTest, getControl) {
     EXPECT_EQ(ControlObject::getControl(ck1), co1.get());
     EXPECT_EQ(ControlObject::getControl(ck2), co2.get());
     co2.reset();
-    EXPECT_EQ(ControlObject::getControl(ck2), (ControlObject*)nullptr);
+    EXPECT_EQ(ControlObject::getControl(ck2, ControlFlag::NoAssertIfMissing),
+            (ControlObject*)nullptr);
 }
 
 TEST_F(ControlObjectTest, AliasRetrieval) {

--- a/src/test/librarytest.cpp
+++ b/src/test/librarytest.cpp
@@ -27,9 +27,10 @@ std::unique_ptr<TrackCollectionManager> newTrackCollectionManager(
 }
 
 LibraryTest::LibraryTest()
-    : m_mixxxDb(config(), kInMemoryDbConnection),
-      m_dbConnectionPooler(m_mixxxDb.connectionPool()),
-      m_pTrackCollectionManager(newTrackCollectionManager(config(), m_dbConnectionPooler)) {
+        : m_mixxxDb(config(), kInMemoryDbConnection),
+          m_dbConnectionPooler(m_mixxxDb.connectionPool()),
+          m_pTrackCollectionManager(newTrackCollectionManager(config(), m_dbConnectionPooler)),
+          m_keyNotationCO(ConfigKey("[Library]", "key_notation")) {
 }
 
 TrackPointer LibraryTest::getOrAddTrackByLocation(

--- a/src/test/librarytest.h
+++ b/src/test/librarytest.h
@@ -38,4 +38,5 @@ class LibraryTest : public MixxxTest {
     const MixxxDb m_mixxxDb;
     const mixxx::DbConnectionPooler m_dbConnectionPooler;
     const std::unique_ptr<TrackCollectionManager> m_pTrackCollectionManager;
+    ControlObject m_keyNotationCO;
 };

--- a/src/test/readaheadmanager_test.cpp
+++ b/src/test/readaheadmanager_test.cpp
@@ -12,10 +12,15 @@
 #include "util/defs.h"
 #include "util/sample.h"
 
+namespace {
+const QString kGroup = "[test]";
+}
+
 class StubReader : public CachingReader {
   public:
     StubReader()
-            : CachingReader("[test]", UserSettingsPointer()) { }
+            : CachingReader(kGroup, UserSettingsPointer()) {
+    }
 
     CachingReader::ReadResult read(SINT startSample, SINT numSamples, bool reverse,
              CSAMPLE* buffer) override {
@@ -29,7 +34,8 @@ class StubReader : public CachingReader {
 class StubLoopControl : public LoopingControl {
   public:
     StubLoopControl()
-            : LoopingControl("[test]", UserSettingsPointer()) { }
+            : LoopingControl(kGroup, UserSettingsPointer()) {
+    }
 
     void pushTriggerReturnValue(double value) {
         m_triggerReturnValues.push_back(value);
@@ -71,7 +77,17 @@ class StubLoopControl : public LoopingControl {
 
 class ReadAheadManagerTest : public MixxxTest {
   public:
-    ReadAheadManagerTest() : m_pBuffer(SampleUtil::alloc(MAX_BUFFER_LEN)) { }
+    ReadAheadManagerTest()
+            : m_beatClosestCO(ConfigKey(kGroup, "beat_closest")),
+              m_beatNextCO(ConfigKey(kGroup, "beat_next")),
+              m_beatPrevCO(ConfigKey(kGroup, "beat_prev")),
+              m_playCO(ConfigKey(kGroup, "play")),
+              m_quantizeCO(ConfigKey(kGroup, "quantize")),
+              m_slipEnabledCO(ConfigKey(kGroup, "slip_enabled")),
+              m_trackSamplesCO(ConfigKey(kGroup, "track_samples")),
+              m_pBuffer(SampleUtil::alloc(MAX_BUFFER_LEN)) {
+    }
+
   protected:
     void SetUp() override {
         SampleUtil::clear(m_pBuffer, MAX_BUFFER_LEN);
@@ -84,6 +100,13 @@ class ReadAheadManagerTest : public MixxxTest {
     QScopedPointer<StubReader> m_pReader;
     QScopedPointer<StubLoopControl> m_pLoopControl;
     QScopedPointer<ReadAheadManager> m_pReadAheadManager;
+    ControlObject m_beatClosestCO;
+    ControlObject m_beatNextCO;
+    ControlObject m_beatPrevCO;
+    ControlObject m_playCO;
+    ControlObject m_quantizeCO;
+    ControlObject m_slipEnabledCO;
+    ControlObject m_trackSamplesCO;
     CSAMPLE* m_pBuffer;
 };
 


### PR DESCRIPTION
First round of test fixes.

This brings the number of failing tests down to 14 (when using https://github.com/mixxxdj/mixxx/commit/4318d9a1a0418d1ef66b0630c55ec30ce1a454f6).