### PR TITLE
test/effectchainslottest: Fix group_[Master]_enable CO debug assertion

### DIFF
--- a/src/test/effectchainslottest.cpp
+++ b/src/test/effectchainslottest.cpp
@@ -35,6 +35,7 @@ TEST_F(EffectChainSlotTest, ChainSlotMirrorsLoadedChain) {
 
     StandardEffectRackPointer pRack = m_pEffectsManager->addStandardEffectRack();
     EffectChainSlotPointer pChainSlot = pRack->getEffectChainSlot(iChainNumber);
+    pChainSlot->registerInputChannel(m_master);
 
     QString group = StandardEffectRack::formatEffectChainSlotGroupString(
         iRackNumber, iChainNumber);


### PR DESCRIPTION
This fixes a debug assertion that is raised because the group_[Master]_enable control object does not exist when the test runs. That CO is created inside the EffectChainSlot's registerInputChannel method.

**Important:** This prevents the DEBUG_ASSERT from being thrown, but please double-check if this is *really* a bug in the test code, and not in the Mixxx code itself. I'm not familiar enough with the effect system code to know for sure.