### PR TITLE
prevent changing the effects by scrolling hovered EffectSelector

### DIFF
--- a/src/widget/weffectselector.cpp
+++ b/src/widget/weffectselector.cpp
@@ -120,6 +120,9 @@ bool WEffectSelector::event(QEvent* pEvent) {
         }
         // repopulate to add text according to the new font measures
         populate();
+    } else if (pEvent->type() == QEvent::Wheel && !hasFocus()) {
+        // don't change effect by scrolling hovered effect selector
+        return false;
     }
 
     return QComboBox::event(pEvent);


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1881493

Changing the effect can happen quite easily, for example with trackpads in the heat of the night.