### PR TITLE
WCueMenuPopup: ensure popup is always shown on screen

### DIFF
--- a/src/widget/wcuemenupopup.h
+++ b/src/widget/wcuemenupopup.h
@@ -7,6 +7,7 @@
 #include "preferences/colorpalettesettings.h"
 #include "track/cue.h"
 #include "track/track.h"
+#include "util/widgethelper.h"
 #include "widget/wcolorpicker.h"
 
 class WCueMenuPopup : public QWidget {
@@ -30,10 +31,10 @@ class WCueMenuPopup : public QWidget {
         }
     }
 
-    void popup(const QPoint& p, QAction* atAction = nullptr) {
-        Q_UNUSED(atAction);
-        qDebug() << "Showing menu at" << p;
-        move(p);
+    void popup(const QPoint& p) {
+        auto parentWidget = static_cast<QWidget*>(parent());
+        QPoint topLeft = mixxx::widgethelper::mapPopupToScreen(*parentWidget, p, size());
+        move(topLeft);
         show();
     }
 

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -34,7 +34,6 @@
 #include "util/math.h"
 #include "util/painterscope.h"
 #include "util/timer.h"
-#include "util/widgethelper.h"
 #include "waveform/waveform.h"
 #include "waveform/waveformwidgetfactory.h"
 #include "widget/controlwidgetconnection.h"
@@ -533,11 +532,7 @@ void WOverview::mousePressEvent(QMouseEvent* e) {
             }
             if (pHoveredCue != nullptr) {
                 m_pCueMenuPopup->setTrackAndCue(m_pCurrentTrack, pHoveredCue);
-                QPoint cueMenuTopLeft = mixxx::widgethelper::mapPopupToScreen(
-                        *this,
-                        e->globalPos(),
-                        m_pCueMenuPopup->size());
-                m_pCueMenuPopup->popup(cueMenuTopLeft);
+                m_pCueMenuPopup->popup(e->globalPos());
             }
         }
     }

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -13,7 +13,6 @@
 #include "track/track.h"
 #include "util/dnd.h"
 #include "util/math.h"
-#include "util/widgethelper.h"
 #include "waveform/waveformwidgetfactory.h"
 #include "waveform/widgets/waveformwidgetabstract.h"
 
@@ -88,11 +87,7 @@ void WWaveformViewer::mousePressEvent(QMouseEvent* event) {
             auto cueAtClickPos = getCuePointerFromCueMark(m_pHoveredMark);
             if (cueAtClickPos) {
                 m_pCueMenuPopup->setTrackAndCue(currentTrack, cueAtClickPos);
-                QPoint cueMenuTopLeft = mixxx::widgethelper::mapPopupToScreen(
-                        *this,
-                        event->globalPos(),
-                        m_pCueMenuPopup->size());
-                m_pCueMenuPopup->popup(cueMenuTopLeft);
+                m_pCueMenuPopup->popup(event->globalPos());
             }
         } else {
             // If we are scratching then disable and reset because the two shouldn't


### PR DESCRIPTION
Testing #2860, I got confused because the cue menu was getting cut off when right clicking WHotcueButton. This change ensures that widgethelper::mapPopupToScreen is always used everywhere WCueMenuPopup is.