### PR TITLE
SoundSourceFFmpeg: Fix debug assert and offset/range calculation

### DIFF
--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -122,7 +122,7 @@ inline int64_t convertFrameIndexToStreamTime(const AVStream& avStream, SINT fram
 }
 
 IndexRange getStreamFrameIndexRange(const AVStream& avStream) {
-    return IndexRange::forward(
+    return IndexRange::between(
             convertStreamTimeToFrameIndex(avStream, getStreamStartTime(avStream)),
             convertStreamTimeToFrameIndex(avStream, getStreamEndTime(avStream)));
 }

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -12,11 +12,13 @@ namespace mixxx {
 
 namespace {
 
+// FFmpeg constants
+
 constexpr AVSampleFormat kavSampleFormat = AV_SAMPLE_FMT_FLT;
 
 constexpr uint64_t kavChannelLayoutUndefined = 0;
 
-constexpr int64_t kavDefaultStreamStartTime = 0;
+constexpr int64_t kavStreamDefaultStartTime = 0;
 
 // Use 0-based sample frame indexing
 constexpr SINT kMinFrameIndex = 0;
@@ -82,9 +84,9 @@ inline int64_t getStreamStartTime(const AVStream& avStream) {
 #if ENABLE_TRACING
         kLogger.trace()
                 << "Unknown start time -> using default value"
-                << kavDefaultStreamStartTime;
+                << kavStreamDefaultStartTime;
 #endif
-        start_time = kavDefaultStreamStartTime;
+        start_time = kavStreamDefaultStartTime;
     }
     return start_time;
 }

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -1,10 +1,10 @@
 #include "sources/soundsourceffmpeg.h"
 
-#include "util/logger.h"
-#include "util/sample.h"
-
 #include <limits>
 #include <mutex>
+
+#include "util/logger.h"
+#include "util/sample.h"
 
 #define ENABLE_TRACING false
 
@@ -183,29 +183,31 @@ QString formatErrorMessage(int errnum) {
 #if ENABLE_TRACING
 inline void avTrace(const char* preamble, const AVPacket& avPacket) {
     if (kLogger.traceEnabled()) {
-        kLogger.trace() << preamble
-                        << "{ stream_index" << avPacket.stream_index
-                        << "| pos" << avPacket.pos
-                        << "| size" << avPacket.size
-                        << "| dst" << avPacket.dts
-                        << "| pts" << avPacket.pts
-                        << "| duration" << avPacket.duration
-                        << '}';
+        kLogger.trace()
+                << preamble
+                << "{ stream_index" << avPacket.stream_index
+                << "| pos" << avPacket.pos
+                << "| size" << avPacket.size
+                << "| dst" << avPacket.dts
+                << "| pts" << avPacket.pts
+                << "| duration" << avPacket.duration
+                << '}';
     }
 }
 
 inline void avTrace(const char* preamble, const AVFrame& avFrame) {
     if (kLogger.traceEnabled()) {
-        kLogger.trace() << preamble
-                        << "{ channels" << avFrame.channels
-                        << "| channel_layout" << avFrame.channel_layout
-                        << "| format" << avFrame.format
-                        << "| sample_rate" << avFrame.sample_rate
-                        << "| pkt_dts" << avFrame.pkt_dts
-                        << "| pkt_duration" << avFrame.pkt_duration
-                        << "| pts" << avFrame.pts
-                        << "| nb_samples" << avFrame.nb_samples
-                        << '}';
+        kLogger.trace()
+                << preamble
+                << "{ channels" << avFrame.channels
+                << "| channel_layout" << avFrame.channel_layout
+                << "| format" << avFrame.format
+                << "| sample_rate" << avFrame.sample_rate
+                << "| pkt_dts" << avFrame.pkt_dts
+                << "| pkt_duration" << avFrame.pkt_duration
+                << "| pts" << avFrame.pts
+                << "| nb_samples" << avFrame.nb_samples
+                << '}';
     }
 }
 #endif // ENABLE_TRACING

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -1235,7 +1235,6 @@ ReadableSampleFrames SoundSourceFFmpeg::readSampleFramesClamped(
                     writableRange.shrinkFront(clearRange.length());
                 }
             }
-            DEBUG_ASSERT(writableRange.start() >= readFrameIndex);
 
             // Skip all missing and decoded ranges that do not overlap
             // with writableRange, i.e. that precede writableRange.


### PR DESCRIPTION
- 1st commit is only a reformatting
- Debug assertion: noticed while testing #2911
- The range/offset calculations affects files encoded with iTunes 12.3.0 that include a `start_time` were wrong. Comparison with the FFmpeg CLI revealed the differences.
- Files encoded with iTunes 12.7.0 always have this ~48 ms (2112 frames at 44.1 kHz) offset and longer duration, independent of the decoder (`start_time` is missing)

I also noticed that FAAD2 handles the affected AAC files differently and generates both an offset with silence at the start and the duration is longer than expected. But I won't mirror the wrong behavior of FAAD2.

Next step: Test the different MP3 encodings and compare with FFmpeg CLI/libMAD/MPG123.