### PR TITLE
Fix crash in ~GLSLWaveformWidget()

### DIFF
--- a/src/waveform/widgets/glslwaveformwidget.cpp
+++ b/src/waveform/widgets/glslwaveformwidget.cpp
@@ -65,7 +65,7 @@ GLSLWaveformWidget::GLSLWaveformWidget(
 }
 
 void GLSLWaveformWidget::castToQWidget() {
-    m_widget = static_cast<QWidget*>(static_cast<QGLWidget*>(this));
+    m_widget = this;
 }
 
 void GLSLWaveformWidget::paintEvent(QPaintEvent* event) {

--- a/src/waveform/widgets/glslwaveformwidget.cpp
+++ b/src/waveform/widgets/glslwaveformwidget.cpp
@@ -64,10 +64,6 @@ GLSLWaveformWidget::GLSLWaveformWidget(
     m_initSuccess = init();
 }
 
-GLSLWaveformWidget::~GLSLWaveformWidget() {
-    makeCurrent();
-}
-
 void GLSLWaveformWidget::castToQWidget() {
     m_widget = static_cast<QWidget*>(static_cast<QGLWidget*>(this));
 }

--- a/src/waveform/widgets/glslwaveformwidget.h
+++ b/src/waveform/widgets/glslwaveformwidget.h
@@ -1,5 +1,4 @@
-#ifndef GLWAVEFORMWIDGETSHADER_H
-#define GLWAVEFORMWIDGETSHADER_H
+#pragma once
 
 #include <QGLWidget>
 
@@ -14,7 +13,7 @@ class GLSLWaveformWidget : public QGLWidget, public WaveformWidgetAbstract {
             const QString& group,
             QWidget* parent,
             bool rgbRenderer);
-    ~GLSLWaveformWidget() override;
+    ~GLSLWaveformWidget() override = default;
 
     void resize(int width, int height) override;
 
@@ -59,6 +58,3 @@ class GLSLRGBWaveformWidget : public GLSLWaveformWidget {
     static inline bool useOpenGLShaders() { return true; }
     static inline bool developerOnly() { return false; }
 };
-
-
-#endif // GLWAVEFORMWIDGETSHADER_H


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1877487
https://bugs.launchpad.net/mixxx/+bug/1856888

This at least fixes the Alt+F4 crash on Linux.