### PR TITLE
don't search for legacy controller mappings in subdirectories

### DIFF
--- a/src/controllers/controllerpresetinfoenumerator.cpp
+++ b/src/controllers/controllerpresetinfoenumerator.cpp
@@ -57,7 +57,7 @@ void PresetInfoEnumerator::loadSupportedPresets() {
     m_bulkPresets.clear();
 
     for (const QString& dirPath : m_controllerDirPaths) {
-        QDirIterator it(dirPath, QDirIterator::Subdirectories);
+        QDirIterator it(dirPath);
         while (it.hasNext()) {
             it.next();
             const QString path = it.filePath();


### PR DESCRIPTION
We'll use subdirectories for the new metadata format.