### PR TITLE
Pref > Effects: remove 'buttonGroup' attribute from Meta knob option

### DIFF
--- a/src/preferences/dialog/dlgprefeffectsdlg.ui
+++ b/src/preferences/dialog/dlgprefeffectsdlg.ui
@@ -32,9 +32,6 @@
         <property name="text">
          <string>Keep metaknob position</string>
         </property>
-        <attribute name="buttonGroup">
-         <string notr="true">buttonGroupEffectLoadBehavior</string>
-        </attribute>
        </widget>
       </item>
       <item>
@@ -42,9 +39,6 @@
         <property name="text">
          <string>Reset metaknob to effect default</string>
         </property>
-        <attribute name="buttonGroup">
-         <string notr="true">buttonGroupEffectLoadBehavior</string>
-        </attribute>
        </widget>
       </item>
      </layout>


### PR DESCRIPTION
to resolve a ui compiler warning.

https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/AutoUIC.20warning.20in.20dlgprefeffectsdlg.2Eui