### PR TITLE
Preferences > Sound Hardware: prevent changing combobox or spinbox values ...

### DIFF
--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -96,6 +96,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void loadSettings(const SoundManagerConfig &config);
     void insertItem(DlgPrefSoundItem *pItem, QVBoxLayout *pLayout);
     void checkLatencyCompensation();
+    bool eventFilter(QObject* object, QEvent* event) override;
 
     SoundManager *m_pSoundManager;
     PlayerManager *m_pPlayerManager;

--- a/src/preferences/dialog/dlgprefsounditem.h
+++ b/src/preferences/dialog/dlgprefsounditem.h
@@ -57,6 +57,7 @@ class DlgPrefSoundItem : public QWidget, public Ui::DlgPrefSoundItem {
     void setDevice(const SoundDeviceId& device);
     void setChannel(unsigned int channelBase, unsigned int channels);
     int hasSufficientChannels(const SoundDevice& device) const;
+    bool eventFilter(QObject* object, QEvent* event) override;
 
     AudioPathType m_type;
     unsigned int m_index;


### PR DESCRIPTION
... when scrolling the preferences page to avoid accidentally changing important sound settings and applying them unnoticed.
https://bugs.launchpad.net/mixxx/+bug/1885628

Boxes still accept scroll events when they're focused.

