### PR TITLE
controllers: Fix crash if controller mapping has no module

### DIFF
--- a/src/controllers/controller.cpp
+++ b/src/controllers/controller.cpp
@@ -74,7 +74,11 @@ bool Controller::applyPreset(bool initializeScripts) {
         m_pEngine->initializeScripts(scriptFiles);
     }
 
-    if (initializeScripts) {
+    // QFileInfo does not have a isValid/isEmpty/isNull method to check if it
+    // actually contains a reference, so we check if the filePath is empty as a
+    // workaround.
+    // See https://stackoverflow.com/a/45652741/1455128 for details.
+    if (initializeScripts && !pPreset->moduleFileInfo().filePath().isEmpty()) {
         m_pEngine->loadModule(pPreset->moduleFileInfo());
     }
     return success;

--- a/src/controllers/controllerpresetfilehandler.cpp
+++ b/src/controllers/controllerpresetfilehandler.cpp
@@ -146,7 +146,18 @@ void ControllerPresetFileHandler::addScriptFilesToPreset(
     }
 
     QString moduleFileName = controller.firstChildElement("module").text();
-    preset->setModuleFileInfo(preset->dirPath().absoluteFilePath(moduleFileName));
+
+    if (moduleFileName.isEmpty()) {
+        return;
+    }
+
+    QFileInfo moduleFileInfo(preset->dirPath().absoluteFilePath(moduleFileName));
+    if (!moduleFileInfo.isFile()) {
+        qWarning() << "Controller Module is not a file:" << moduleFileInfo.absoluteFilePath();
+        return;
+    }
+
+    preset->setModuleFileInfo(moduleFileInfo);
 }
 
 bool ControllerPresetFileHandler::writeDocument(

--- a/src/controllers/engine/controllerengine.cpp
+++ b/src/controllers/engine/controllerengine.cpp
@@ -230,6 +230,17 @@ void ControllerEngine::uninitializeScriptEngine() {
 }
 
 void ControllerEngine::loadModule(QFileInfo moduleFileInfo) {
+    // QFileInfo does not have a isValid/isEmpty/isNull method to check if it
+    // actually contains a reference, so we check if the filePath is empty as a
+    // workaround.
+    // See https://stackoverflow.com/a/45652741/1455128 for details.
+    VERIFY_OR_DEBUG_ASSERT(!moduleFileInfo.filePath().isEmpty()) {
+        return;
+    }
+
+    VERIFY_OR_DEBUG_ASSERT(moduleFileInfo.isFile()) {
+        return;
+    }
 #if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
     m_moduleFileInfo = moduleFileInfo;
 
@@ -318,7 +329,14 @@ void ControllerEngine::reloadScripts() {
 
     qDebug() << "Re-initializing scripts";
     initializeScripts(m_lastScriptFiles);
-    loadModule(m_moduleFileInfo);
+
+    // QFileInfo does not have a isValid/isEmpty/isNull method to check if it
+    // actually contains a reference, so we check if the filePath is empty as a
+    // workaround.
+    // See https://stackoverflow.com/a/45652741/1455128 for details.
+    if (!m_moduleFileInfo.filePath().isEmpty()) {
+        loadModule(m_moduleFileInfo);
+    }
 }
 
 void ControllerEngine::initializeScripts(const QList<ControllerPreset::ScriptFileInfo>& scripts) {


### PR DESCRIPTION
This fixes two bugs that were caused by #2868:

1. Mixxx didn't check if the JS module path was really a file. If
   you pass in a directory, QtJSEngine::importModule makes Mixxx
   crash (at least on Qt 5.15.0)
2. If a mapping does not have JS module associated with it, then the
   moduleFileInfo always pointed to the controller directory and
   hence triggered bug 1.

This fixes both of these issues and adds some debug assertions to make
sure it stays like that.