### PR TITLE
midi-components: Fix undefined CO group on EffectUnit initialization

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -818,20 +818,19 @@
             this.setCurrentUnit(this.unitNumbers[index]);
         };
 
-        if (unitNumbers !== undefined) {
-            if (Array.isArray(unitNumbers)) {
-                this.unitNumbers = unitNumbers;
-                this.setCurrentUnit(unitNumbers[0]);
-            } else if (typeof unitNumbers === "number" &&
-                      Math.floor(unitNumbers) === unitNumbers &&
-                      isFinite(unitNumbers)) {
-                this.unitNumbers = [unitNumbers];
-                this.setCurrentUnit(unitNumbers);
-            }
+        if (Array.isArray(unitNumbers)) {
+            this.unitNumbers = unitNumbers;
+        } else if (typeof unitNumbers === "number" &&
+                  Math.floor(unitNumbers) === unitNumbers &&
+                  isFinite(unitNumbers)) {
+            this.unitNumbers = [unitNumbers];
         } else {
             print("ERROR! new EffectUnit() called without specifying any unit numbers!");
             return;
         }
+
+        this.group = "[EffectRack1_EffectUnit" + this.unitNumbers[0] + "]";
+        this.setCurrentUnit(this.unitNumbers[0]);
 
         this.dryWetKnob = new Pot({
             group: this.group,

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -818,9 +818,9 @@
             this.setCurrentUnit(this.unitNumbers[index]);
         };
 
-        if (Array.isArray(unitNumbers)) {
+        if (unitNumbers !== undefined && Array.isArray(unitNumbers)) {
             this.unitNumbers = unitNumbers;
-        } else if (typeof unitNumbers === "number" &&
+        } else if (unitNumbers !== undefined && typeof unitNumbers === "number" &&
                   Math.floor(unitNumbers) === unitNumbers &&
                   isFinite(unitNumbers)) {
             this.unitNumbers = [unitNumbers];

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -664,22 +664,19 @@
     };
 
     var Deck = function(deckNumbers) {
-        if (deckNumbers !== undefined) {
-            if (Array.isArray(deckNumbers)) {
-                // These must be unique to each instance,
-                // so they cannot be in the prototype.
-                this.currentDeck = "[Channel" + deckNumbers[0] + "]";
-                this.deckNumbers = deckNumbers;
-            } else if (typeof deckNumbers === "number" &&
-                      Math.floor(deckNumbers) === deckNumbers &&
-                      isFinite(deckNumbers)) {
-                this.currentDeck = "[Channel" + deckNumbers + "]";
-                this.deckNumbers = [deckNumbers];
-            }
+        if (deckNumbers !== undefined && Array.isArray(deckNumbers)) {
+            // These must be unique to each instance,
+            // so they cannot be in the prototype.
+            this.deckNumbers = deckNumbers;
+        } else if (deckNumbers !== undefined && typeof deckNumbers === "number" &&
+                Math.floor(deckNumbers) === deckNumbers &&
+                isFinite(deckNumbers)) {
+            this.deckNumbers = [deckNumbers];
         } else {
             print("ERROR! new Deck() called without specifying any deck numbers");
             return;
         }
+        this.currentDeck = "[Channel" + deckNumbers[0] + "]";
     };
     Deck.prototype = new ComponentContainer({
         setCurrentDeck: function(newGroup) {


### PR DESCRIPTION
Before, the code caused a warning like this for each EffectUnit on
script load:

    Warning [Controller]: ControlDoublePrivate::getControl returning NULL for ( "" , "controller_input_active" )

This was caused by PR #2322. The code tries to use the component's group
in `setCurrentUnit` even though it's not set until later in the code.