### PR TITLE
WLabel: define highlight property

### DIFF
--- a/src/widget/controlwidgetconnection.cpp
+++ b/src/widget/controlwidgetconnection.cpp
@@ -123,10 +123,10 @@ void ControlWidgetPropertyConnection::slotControlValueChanged(double v) {
     }
 
     if (!pWidget->setProperty(m_propertyName.constData(),parameter)) {
-        qDebug() << "Property" << m_propertyName
-                 << "was not defined for widget" << pWidget->objectName()
-                 << "of type" << pWidget->metaObject()->className()
-                 << "(parameter:" << parameter << ")";
+        qWarning() << "Property" << m_propertyName
+                   << "was not defined for widget" << pWidget->objectName()
+                   << "of type" << pWidget->metaObject()->className()
+                   << "(parameter:" << parameter << ")";
     }
 
     // According to http://stackoverflow.com/a/3822243 this is the least

--- a/src/widget/controlwidgetconnection.cpp
+++ b/src/widget/controlwidgetconnection.cpp
@@ -123,9 +123,10 @@ void ControlWidgetPropertyConnection::slotControlValueChanged(double v) {
     }
 
     if (!pWidget->setProperty(m_propertyName.constData(),parameter)) {
-        qDebug() << "Setting property" << m_propertyName
-                 << "to widget" << pWidget->objectName()
-                 << "failed. Value:" << parameter;
+        qDebug() << "Property" << m_propertyName
+                 << "was not defined for widget" << pWidget->objectName()
+                 << "of type" << pWidget->metaObject()->className()
+                 << "(parameter:" << parameter << ")";
     }
 
     // According to http://stackoverflow.com/a/3822243 this is the least

--- a/src/widget/wlabel.cpp
+++ b/src/widget/wlabel.cpp
@@ -155,6 +155,9 @@ int WLabel::getHighlight() const {
 }
 
 void WLabel::setHighlight(int highlight) {
+    if (m_highlight == highlight) {
+        return;
+    }
     m_highlight = highlight;
     emit highlightChanged(m_highlight);
 }

--- a/src/widget/wlabel.cpp
+++ b/src/widget/wlabel.cpp
@@ -27,7 +27,8 @@ WLabel::WLabel(QWidget* pParent)
           m_skinText(),
           m_longText(),
           m_elideMode(Qt::ElideNone),
-          m_scaleFactor(1.0) {
+          m_scaleFactor(1.0),
+          m_highlight(0) {
 }
 
 void WLabel::setup(const QDomNode& node, const SkinContext& context) {
@@ -147,4 +148,13 @@ void WLabel::resizeEvent(QResizeEvent* event) {
 void WLabel::fillDebugTooltip(QStringList* debug) {
     WBaseWidget::fillDebugTooltip(debug);
     *debug << QString("Text: \"%1\"").arg(text());
+}
+
+int WLabel::getHighlight() const {
+    return m_highlight;
+}
+
+void WLabel::setHighlight(int highlight) {
+    m_highlight = highlight;
+    emit highlightChanged(m_highlight);
 }

--- a/src/widget/wlabel.h
+++ b/src/widget/wlabel.h
@@ -34,6 +34,18 @@ class WLabel : public QLabel, public WBaseWidget {
     QString text() const;
     void setText(const QString& text);
 
+    // The highlight property is used to restyle the widget with CSS.
+    // The declaration #MyLabel[highlight="1"] { } will define the style
+    // for the highlighted state.
+    // See ../wwidgetgroup.h for more info
+    Q_PROPERTY(int highlight READ getHighlight WRITE setHighlight NOTIFY highlightChanged)
+
+    int getHighlight() const;
+    void setHighlight(int highlight);
+
+  signals:
+    void highlightChanged(int highlight);
+
   protected:
     bool event(QEvent* pEvent) override;
     void resizeEvent(QResizeEvent* event) override;
@@ -46,6 +58,7 @@ class WLabel : public QLabel, public WBaseWidget {
     QString m_longText;
     Qt::TextElideMode m_elideMode;
     double m_scaleFactor;
+    int m_highlight;
 };
 
 #endif

--- a/src/widget/wwidgetgroup.cpp
+++ b/src/widget/wwidgetgroup.cpp
@@ -225,6 +225,9 @@ int WWidgetGroup::getHighlight() const {
 }
 
 void WWidgetGroup::setHighlight(int highlight) {
+    if (m_highlight == highlight) {
+        return;
+    }
     m_highlight = highlight;
     style()->unpolish(this);
     style()->polish(this);


### PR DESCRIPTION
* a small follow-up for #2841:
extend the debugging message to include the affected widget's class name when setting the value for an undefined widget property

* define `highlight` property for WLabel
AFAICT -apart frtom WidgetGroup- this is the only widget that makes use of `highlight`.
At first I tried to define that for wbasewidget in order to make it available for all widgets, but that was too complex and took to long for the simple purpose. Someone can pick this up later on if desired.

As noted in #2841, the property is actually set and processed by style engine, but the error is thrown anyway.