### PR TITLE
LegacySkinParser: Persist skin-created COs even on skin changes

### DIFF
--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -507,13 +507,15 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
 
     // Load skin to a QWidget that we set as the central widget. Assignment
     // intentional in next line.
-    if (!(m_pWidgetParent = m_pSkinLoader->loadConfiguredSkin(this, m_pKeyboard,
-                                                              m_pPlayerManager,
-                                                              m_pControllerManager,
-                                                              m_pLibrary,
-                                                              m_pVCManager,
-                                                              m_pEffectsManager,
-                                                              m_pRecordingManager))) {
+    m_pWidgetParent = m_pSkinLoader->loadConfiguredSkin(this,
+            m_pKeyboard,
+            m_pPlayerManager,
+            m_pControllerManager,
+            m_pLibrary,
+            m_pVCManager,
+            m_pEffectsManager,
+            m_pRecordingManager);
+    if (!m_pWidgetParent) {
         reportCriticalErrorAndQuit(
                 "default skin cannot be loaded see <b>mixxx</b> trace for more information.");
 
@@ -1461,15 +1463,15 @@ void MixxxMainWindow::rebootMixxxView() {
 
     // Load skin to a QWidget that we set as the central widget. Assignment
     // intentional in next line.
-    if (!(m_pWidgetParent = m_pSkinLoader->loadConfiguredSkin(this,
-                                                              m_pKeyboard,
-                                                              m_pPlayerManager,
-                                                              m_pControllerManager,
-                                                              m_pLibrary,
-                                                              m_pVCManager,
-                                                              m_pEffectsManager,
-                                                              m_pRecordingManager))) {
-
+    m_pWidgetParent = m_pSkinLoader->loadConfiguredSkin(this,
+            m_pKeyboard,
+            m_pPlayerManager,
+            m_pControllerManager,
+            m_pLibrary,
+            m_pVCManager,
+            m_pEffectsManager,
+            m_pRecordingManager);
+    if (!m_pWidgetParent) {
         QMessageBox::critical(this,
                               tr("Error in skin file"),
                               tr("The selected skin cannot be loaded."));

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -702,12 +702,7 @@ void MixxxMainWindow::finalize() {
     }
 
     // Delete Controls created by skins
-    for (ControlObject* pControl : m_skinCreatedControls) {
-        VERIFY_OR_DEBUG_ASSERT(pControl) {
-            continue;
-        }
-        delete pControl;
-    }
+    qDeleteAll(m_skinCreatedControls);
     m_skinCreatedControls.clear();
 
     // TODO() Verify if this comment still applies:

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -508,6 +508,7 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
     // Load skin to a QWidget that we set as the central widget. Assignment
     // intentional in next line.
     m_pWidgetParent = m_pSkinLoader->loadConfiguredSkin(this,
+            &m_skinCreatedControls,
             m_pKeyboard,
             m_pPlayerManager,
             m_pControllerManager,
@@ -699,6 +700,15 @@ void MixxxMainWindow::finalize() {
     VERIFY_OR_DEBUG_ASSERT(pSkin.isNull()) {
         qWarning() << "Central widget was not deleted by our sendPostedEvents trick.";
     }
+
+    // Delete Controls created by skins
+    for (ControlObject* pControl : m_skinCreatedControls) {
+        VERIFY_OR_DEBUG_ASSERT(pControl) {
+            continue;
+        }
+        delete pControl;
+    }
+    m_skinCreatedControls.clear();
 
     // TODO() Verify if this comment still applies:
     // WMainMenuBar holds references to controls so we need to delete it
@@ -1464,6 +1474,7 @@ void MixxxMainWindow::rebootMixxxView() {
     // Load skin to a QWidget that we set as the central widget. Assignment
     // intentional in next line.
     m_pWidgetParent = m_pSkinLoader->loadConfiguredSkin(this,
+            &m_skinCreatedControls,
             m_pKeyboard,
             m_pPlayerManager,
             m_pControllerManager,

--- a/src/mixxx.h
+++ b/src/mixxx.h
@@ -184,6 +184,8 @@ class MixxxMainWindow : public QMainWindow {
     ControlPushButton* m_pTouchShift;
     mixxx::ScreenSaverPreference m_inhibitScreensaver;
 
+    QSet<ControlObject*> m_skinCreatedControls;
+
     static const int kMicrophoneCount;
     static const int kAuxiliaryCount;
 };

--- a/src/skin/legacyskinparser.h
+++ b/src/skin/legacyskinparser.h
@@ -134,9 +134,12 @@ class LegacySkinParser : public QObject, public SkinParser {
 
     QString lookupNodeGroup(const QDomElement& node);
     static QString getSharedGroupString(const QString& channelStr);
+    ControlObject* controlFromConfigKey(const ConfigKey& element,
+            bool bPersist,
+            bool* pCreated = nullptr);
     ControlObject* controlFromConfigNode(const QDomElement& element,
-                                         const QString& nodeName,
-                                         bool* created);
+            const QString& nodeName,
+            bool* pCreated = nullptr);
 
     QString parseLaunchImageStyle(const QDomNode& node);
     void parseChildren(const QDomElement& node, WWidgetGroup* pGroup);

--- a/src/skin/legacyskinparser.h
+++ b/src/skin/legacyskinparser.h
@@ -1,18 +1,18 @@
-#ifndef LEGACYSKINPARSER_H
-#define LEGACYSKINPARSER_H
+#pragma once
 
-#include <QObject>
-#include <QString>
-#include <QList>
 #include <QDomElement>
+#include <QList>
 #include <QMutex>
+#include <QObject>
+#include <QSet>
+#include <QString>
 
 #include "preferences/usersettings.h"
-#include "skin/skinparser.h"
-#include "vinylcontrol/vinylcontrolmanager.h"
-#include "skin/tooltips.h"
 #include "proto/skin.pb.h"
+#include "skin/skinparser.h"
+#include "skin/tooltips.h"
 #include "util/memory.h"
+#include "vinylcontrol/vinylcontrolmanager.h"
 
 class WBaseWidget;
 class Library;
@@ -32,11 +32,14 @@ class LegacySkinParser : public QObject, public SkinParser {
   public:
     LegacySkinParser(UserSettingsPointer pConfig);
     LegacySkinParser(UserSettingsPointer pConfig,
-                     KeyboardEventFilter* pKeyboard, PlayerManager* pPlayerManager,
-                     ControllerManager* pControllerManager,
-                     Library* pLibrary, VinylControlManager* pVCMan,
-                     EffectsManager* pEffectsManager,
-                     RecordingManager* pRecordingManager);
+            QSet<ControlObject*>* pSkinCreatedControls,
+            KeyboardEventFilter* pKeyboard,
+            PlayerManager* pPlayerManager,
+            ControllerManager* pControllerManager,
+            Library* pLibrary,
+            VinylControlManager* pVCMan,
+            EffectsManager* pEffectsManager,
+            RecordingManager* pRecordingManager);
     virtual ~LegacySkinParser();
 
     virtual bool canParse(const QString& skinPath);
@@ -139,6 +142,7 @@ class LegacySkinParser : public QObject, public SkinParser {
     void parseChildren(const QDomElement& node, WWidgetGroup* pGroup);
 
     UserSettingsPointer m_pConfig;
+    QSet<ControlObject*>* m_pSkinCreatedControls;
     KeyboardEventFilter* m_pKeyboard;
     PlayerManager* m_pPlayerManager;
     ControllerManager* m_pControllerManager;
@@ -153,6 +157,3 @@ class LegacySkinParser : public QObject, public SkinParser {
     QHash<QString, QDomElement> m_templateCache;
     static QSet<QString> s_sharedGroupStrings;
 };
-
-
-#endif /* LEGACYSKINPARSER_H */

--- a/src/skin/skinloader.cpp
+++ b/src/skin/skinloader.cpp
@@ -106,13 +106,14 @@ QString SkinLoader::getDefaultSkinName() const {
 }
 
 QWidget* SkinLoader::loadConfiguredSkin(QWidget* pParent,
-                                        KeyboardEventFilter* pKeyboard,
-                                        PlayerManager* pPlayerManager,
-                                        ControllerManager* pControllerManager,
-                                        Library* pLibrary,
-                                        VinylControlManager* pVCMan,
-                                        EffectsManager* pEffectsManager,
-                                        RecordingManager* pRecordingManager) {
+        QSet<ControlObject*>* pSkinCreatedControls,
+        KeyboardEventFilter* pKeyboard,
+        PlayerManager* pPlayerManager,
+        ControllerManager* pControllerManager,
+        Library* pLibrary,
+        VinylControlManager* pVCMan,
+        EffectsManager* pEffectsManager,
+        RecordingManager* pRecordingManager) {
     ScopedTimer timer("SkinLoader::loadConfiguredSkin");
     QString skinPath = getConfiguredSkinPath();
 
@@ -121,9 +122,15 @@ QWidget* SkinLoader::loadConfiguredSkin(QWidget* pParent,
         return NULL;
     }
 
-    LegacySkinParser legacy(m_pConfig, pKeyboard, pPlayerManager,
-                            pControllerManager, pLibrary, pVCMan,
-                            pEffectsManager, pRecordingManager);
+    LegacySkinParser legacy(m_pConfig,
+            pSkinCreatedControls,
+            pKeyboard,
+            pPlayerManager,
+            pControllerManager,
+            pLibrary,
+            pVCMan,
+            pEffectsManager,
+            pRecordingManager);
     return legacy.parseSkin(skinPath, pParent);
 }
 

--- a/src/skin/skinloader.h
+++ b/src/skin/skinloader.h
@@ -1,15 +1,16 @@
-#ifndef SKINLOADER_H
-#define SKINLOADER_H
+#pragma once
 
-#include <QWidget>
-#include <QList>
 #include <QDir>
+#include <QList>
+#include <QSet>
+#include <QWidget>
 
 #include "preferences/usersettings.h"
 
 class KeyboardEventFilter;
 class PlayerManager;
 class ControllerManager;
+class ControlObject;
 class Library;
 class VinylControlManager;
 class EffectsManager;
@@ -22,13 +23,14 @@ class SkinLoader {
     virtual ~SkinLoader();
 
     QWidget* loadConfiguredSkin(QWidget* pParent,
-                                KeyboardEventFilter* pKeyboard,
-                                PlayerManager* pPlayerManager,
-                                ControllerManager* pControllerManager,
-                                Library* pLibrary,
-                                VinylControlManager* pVCMan,
-                                EffectsManager* pEffectsManager,
-                                RecordingManager* pRecordingManager);
+            QSet<ControlObject*>* skinCreatedControls,
+            KeyboardEventFilter* pKeyboard,
+            PlayerManager* pPlayerManager,
+            ControllerManager* pControllerManager,
+            Library* pLibrary,
+            VinylControlManager* pVCMan,
+            EffectsManager* pEffectsManager,
+            RecordingManager* pRecordingManager);
 
     LaunchImage* loadLaunchImage(QWidget* pParent);
 
@@ -43,6 +45,3 @@ class SkinLoader {
 
     UserSettingsPointer m_pConfig;
 };
-
-
-#endif /* SKINLOADER_H */


### PR DESCRIPTION
Up until now, Skin-created COs were parented to a skin widget, which
means that they will be deleted when the skin is unloaded and the skin
widget is destroyed. This sounds like a good idea, but it's actually
quite problematic.

Controller mappings may connect to these COs, and as they are not
reloaded when the skin is changed these ControlProxy objects will still
hold a reference to the internal ControlDoublePrivate, even though the
actual ControlObject has been deleted.
When switching to a skin that attempts to create a CO that has been
destroyed earlier, this causes a DEBUG_ASSERT.

This commit removes the parenting of skin-created control objects.
Instead, all skin-created COs are put into a global set of skin COs, and
its contents will only be destroyed in MixxxMainWindow::finalize(), i.e.
when Mixxx is exited. That way, all skin-created COs persist accross
skin changes and skins can reuse COs created by other skins.

This is definitely not a pretty "solution", but it does the job:
It fixes the DEBUG_ASSERT that was thrown on skin change when a
controller mapping was connected a CO that was destroyed and the new
skin tries to create a new CO under the same key. The controller mapping
keeps working even after the skin change.

Related Zulip discussion: https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/DEBUG_ASSERT.20on.20skin.20change