### PR TITLE
engine/enginebuffer: Move CO setting into locking scope

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -486,11 +486,11 @@ void EngineBuffer::slotTrackLoading() {
     // Setting m_iTrackLoading inside a m_pause.lock ensures that
     // track buffer is not processed when starting to load a new one
     m_iTrackLoading = 1;
-    m_pause.unlock();
 
     // Set play here, to signal the user that the play command is adopted
     m_playButton->set(m_bPlayAfterLoading ? 1.0 : 0.0);
     m_pTrackSamples->set(0); // Stop renderer
+    m_pause.unlock();
 }
 
 void EngineBuffer::loadFakeTrack(TrackPointer pTrack, bool bPlay) {

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -489,7 +489,7 @@ void EngineBuffer::slotTrackLoading() {
     m_pause.unlock();
 
     // Set play here, to signal the user that the play command is adopted
-    m_playButton->set((double)m_bPlayAfterLoading);
+    m_playButton->set(m_bPlayAfterLoading ? 1.0 : 0.0);
     m_pTrackSamples->set(0); // Stop renderer
 }
 


### PR DESCRIPTION
I sometimes see random segfauls in the enginebuffer tests. According to
the backtrace it happens when calling m_pPlayButton->set(v) in the
EngineBuffer::slotTrackLoading() method.

I'm not really familiar with the code but I think it's possible that
this happens because the settings of `m_pTrackLoaded` and `m_pTrackSamples`
are not inside the lock. If the track loads very fast, then
`slotTrackLoaded`/`slotLoadTrackFailed` could be called before
`slotTrackLoading` is finished, which could lead to inconstencies of
the `m_pTrackSamples` value.

**NOTE:** The explanation above is just a guess, so please be extra thorough during review. I have no idea why the actual crash happens. I tried to verify my assumption, but I'm not familiar enough with the code for a definitive verdict. Unfortunately, the issue is not easily reproducible.