### PR TITLE
common-hid-packet-parser.js: fix parsing COs that share a name

### DIFF
--- a/res/controllers/common-hid-packet-parser.js
+++ b/res/controllers/common-hid-packet-parser.js
@@ -632,7 +632,7 @@ HIDPacket.prototype.parse = function(data) {
                     field.delta = value - field.value
                 }
                 if (field.mindelta == undefined || change > field.mindelta) {
-                    field_changes[field.name] = field
+                    field_changes[field.id] = field
                     field.value = value
                 }
             }


### PR DESCRIPTION
Before, changes in the packet fields were only being identified
by the CO name. So if one packet had COs mapped that shared a name
but had different groups, for example
[Channel1], volume
[Channel2], volume
Only the last one would get processed. Now, the changes are
identified by both group and name.