### PR TITLE
ControllerManager: poll every 1ms on Linux

### DIFF
--- a/src/controllers/controllermanager.cpp
+++ b/src/controllers/controllermanager.cpp
@@ -31,13 +31,7 @@ namespace {
 // http://developer.qt.nokia.com/wiki/Threads_Events_QObjects
 
 // Poll every 1ms (where possible) for good controller response
-#ifdef __LINUX__
-// Many Linux distros ship with the system tick set to 250Hz so 1ms timer
-// reportedly causes CPU hosage. See Bug #990992 rryan 6/2012
-const int kPollIntervalMillis = 5;
-#else
 const int kPollIntervalMillis = 1;
-#endif
 
 /// Strip slashes and spaces from device name, so that it can be used as config
 /// key or a filename.


### PR DESCRIPTION
Polling at 5ms causes a noticable lag with the GUI. If the audio
buffer is set low, it also produces a lag with the audio. The
bug report ( https://bugs.launchpad.net/mixxx/+bug/990992 )
referenced for why this was increased to 5 ms on Linux is 8 years
old. The root cause of that bug was not identified, but increasing
the controller polling latency to 5ms worked around it. After
setting the polling latency back to 1ms, I can not reproduce the
bug with high CPU usage on modern Linux (Fedora 32 running kernel
5.4.39-rt23.fc32.x86_64 with realtime patch set).