### PR TITLE
HidController: loop until no more messages are available on poll

### DIFF
--- a/src/controllers/controllermanager.cpp
+++ b/src/controllers/controllermanager.cpp
@@ -27,18 +27,18 @@
 #include "controllers/bulk/bulkenumerator.h"
 #endif
 
-namespace {
 // http://developer.qt.nokia.com/wiki/Threads_Events_QObjects
 
 // Poll every 1ms (where possible) for good controller response
 #ifdef __LINUX__
 // Many Linux distros ship with the system tick set to 250Hz so 1ms timer
 // reportedly causes CPU hosage. See Bug #990992 rryan 6/2012
-const int kPollIntervalMillis = 5;
+const mixxx::Duration ControllerManager::kPollInterval = mixxx::Duration::fromMillis(5);
 #else
-const int kPollIntervalMillis = 1;
+const mixxx::Duration ControllerManager::kPollInterval = mixxx::Duration::fromMillis(1);
 #endif
 
+namespace {
 /// Strip slashes and spaces from device name, so that it can be used as config
 /// key or a filename.
 QString sanitizeDeviceName(QString name) {
@@ -97,7 +97,7 @@ ControllerManager::ControllerManager(UserSettingsPointer pConfig)
         QDir().mkpath(userPresets);
     }
 
-    m_pollTimer.setInterval(kPollIntervalMillis);
+    m_pollTimer.setInterval(kPollInterval.toIntegerMillis());
     connect(&m_pollTimer, SIGNAL(timeout()),
             this, SLOT(pollDevices()));
 
@@ -359,7 +359,7 @@ void ControllerManager::pollDevices() {
     }
 
     mixxx::Duration duration = mixxx::Time::elapsed() - start;
-    if (duration > mixxx::Duration::fromMillis(kPollIntervalMillis)) {
+    if (duration > kPollInterval) {
         m_skipPoll = true;
     }
     //qDebug() << "ControllerManager::pollDevices()" << duration << start;

--- a/src/controllers/controllermanager.h
+++ b/src/controllers/controllermanager.h
@@ -30,6 +30,8 @@ class ControllerManager : public QObject {
     ControllerManager(UserSettingsPointer pConfig);
     virtual ~ControllerManager();
 
+    static const mixxx::Duration kPollInterval;
+
     QList<Controller*> getControllers() const;
     QList<Controller*> getControllerList(bool outputDevices=true, bool inputDevices=true);
     ControllerLearningEventFilter* getControllerLearningEventFilter() const;

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -76,6 +76,10 @@ HidController::HidController(const hid_device_info& deviceInfo, UserSettingsPoin
     // All HID devices are full-duplex
     setInputDevice(true);
     setOutputDevice(true);
+
+    for (int i = 0; i < m_iNumBuffers; i++) {
+        memset(m_pPollData[i], 0, m_iBufferSize);
+    }
 }
 
 HidController::~HidController() {

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -260,15 +260,15 @@ bool HidController::poll() {
             return false;
         } else if (result > 0) {
             Trace process("HidController process packet");
-            auto byteArray = QByteArray::fromRawData(
-                    reinterpret_cast<char*>(pCurrentBuffer), result);
             // Some controllers such as the Gemini GMX continuously send input packets even if it
             // is identical to the previous packet. If this loop processed all those redundant
             // packets, it would be a big performance problem.
             if (memcmp(pCurrentBuffer, pPreviousBuffer, m_iBufferSize) == 0) {
                 continue;
             }
-            receive(byteArray, mixxx::Time::elapsed());
+            auto incomingData = QByteArray::fromRawData(
+                    reinterpret_cast<char*>(pCurrentBuffer), result);
+            receive(incomingData, mixxx::Time::elapsed());
         }
     }
 

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -248,11 +248,7 @@ bool HidController::poll() {
     while (result > 0) {
         // Rotate between two buffers so the memcmp below does not require deep copying to another buffer.
         unsigned char* pCurrentBuffer = m_pPollData[m_iPollingBufferIndex];
-        if (m_iPollingBufferIndex == 0) {
-            m_iPollingBufferIndex = 1;
-        } else {
-            m_iPollingBufferIndex = 0;
-        }
+        m_iPollingBufferIndex = (m_iPollingBufferIndex + 1) % 2;
         unsigned char* pPreviousBuffer = m_pPollData[m_iPollingBufferIndex];
 
         result = hid_read(m_pHidDevice, pCurrentBuffer, m_iBufferSize);

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -216,8 +216,8 @@ int HidController::open() {
         return -1;
     }
 
-    for (int i = 0; i < m_iNumBuffers; i++) {
-        memset(m_pPollData[i], 0, m_iBufferSize);
+    for (int i = 0; i < kNumBuffers; i++) {
+        memset(m_pPollData[i], 0, kBufferSize);
     }
 
     setOpen(true);
@@ -252,10 +252,10 @@ bool HidController::poll() {
     while (result > 0) {
         // Rotate between two buffers so the memcmp below does not require deep copying to another buffer.
         unsigned char* pCurrentBuffer = m_pPollData[m_iPollingBufferIndex];
-        m_iPollingBufferIndex = (m_iPollingBufferIndex + 1) % m_iNumBuffers;
+        m_iPollingBufferIndex = (m_iPollingBufferIndex + 1) % kNumBuffers;
         unsigned char* pPreviousBuffer = m_pPollData[m_iPollingBufferIndex];
 
-        result = hid_read(m_pHidDevice, pCurrentBuffer, m_iBufferSize);
+        result = hid_read(m_pHidDevice, pCurrentBuffer, kBufferSize);
         if (result == -1) {
             return false;
         } else if (result > 0) {
@@ -263,7 +263,7 @@ bool HidController::poll() {
             // Some controllers such as the Gemini GMX continuously send input packets even if it
             // is identical to the previous packet. If this loop processed all those redundant
             // packets, it would be a big performance problem.
-            if (memcmp(pCurrentBuffer, pPreviousBuffer, m_iBufferSize) == 0) {
+            if (memcmp(pCurrentBuffer, pPreviousBuffer, kBufferSize) == 0) {
                 continue;
             }
             auto incomingData = QByteArray::fromRawData(

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -248,7 +248,7 @@ bool HidController::poll() {
     while (result > 0) {
         // Rotate between two buffers so the memcmp below does not require deep copying to another buffer.
         unsigned char* pCurrentBuffer = m_pPollData[m_iPollingBufferIndex];
-        m_iPollingBufferIndex = (m_iPollingBufferIndex + 1) % 2;
+        m_iPollingBufferIndex = (m_iPollingBufferIndex + 1) % m_iNumBuffers;
         unsigned char* pPreviousBuffer = m_pPollData[m_iPollingBufferIndex];
 
         result = hid_read(m_pHidDevice, pCurrentBuffer, m_iBufferSize);

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -250,8 +250,8 @@ bool HidController::poll() {
             return false;
         } else if (result > 0) {
             Trace process("HidController process packet");
-            QByteArray outData(reinterpret_cast<char*>(m_pPollData), result);
-            receive(outData, mixxx::Time::elapsed());
+            auto data = QByteArray::fromRawData(reinterpret_cast<char*>(m_pPollData), result);
+            receive(data, mixxx::Time::elapsed());
         }
     }
 

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -248,41 +248,40 @@ int HidController::close() {
 bool HidController::poll() {
     Trace hidRead("HidController poll");
 
-    int result = 1;
     // This loop risks becoming a high priority endless loop in case processing
     // the mapping JS code takes longer than the controller polling rate.
     // This could stall other low priority tasks.
     // There is no safety net for this because it has not been demonstrated to be
     // a problem in practice.
-    while (result > 0) {
+    while (true) {
         // Rotate between two buffers so the memcmp below does not require deep copying to another buffer.
         unsigned char* pPreviousBuffer = m_pPollData[m_iPollingBufferIndex];
         m_iPollingBufferIndex = (m_iPollingBufferIndex + 1) % kNumBuffers;
         unsigned char* pCurrentBuffer = m_pPollData[m_iPollingBufferIndex];
 
-        result = hid_read(m_pHidDevice, pCurrentBuffer, kBufferSize);
-        if (result == -1) {
+        int bytesRead = hid_read(m_pHidDevice, pCurrentBuffer, kBufferSize);
+        if (bytesRead == -1) {
             return false;
-        } else if (result > 0) {
-            Trace process("HidController process packet");
-            // Some controllers such as the Gemini GMX continuously send input packets even if it
-            // is identical to the previous packet. If this loop processed all those redundant
-            // packets, it would be a big performance problem to run JS code for every packet and
-            // would be unnecessary.
-            // This assumes that the redundant packets all use the same report ID. In practice we
-            // have not encountered any controllers that send redundant packets with different report
-            // IDs. If any such devices exist, this may be changed to use a separate buffer to store
-            // the last packet for each report ID.
-            if (memcmp(pCurrentBuffer, pPreviousBuffer, kBufferSize) == 0) {
-                continue;
-            }
-            auto incomingData = QByteArray::fromRawData(
-                    reinterpret_cast<char*>(pCurrentBuffer), result);
-            receive(incomingData, mixxx::Time::elapsed());
+        } else if (bytesRead == 0) {
+            return true;
         }
-    }
 
-    return true;
+        Trace process("HidController process packet");
+        // Some controllers such as the Gemini GMX continuously send input packets even if it
+        // is identical to the previous packet. If this loop processed all those redundant
+        // packets, it would be a big performance problem to run JS code for every packet and
+        // would be unnecessary.
+        // This assumes that the redundant packets all use the same report ID. In practice we
+        // have not encountered any controllers that send redundant packets with different report
+        // IDs. If any such devices exist, this may be changed to use a separate buffer to store
+        // the last packet for each report ID.
+        if (memcmp(pCurrentBuffer, pPreviousBuffer, kBufferSize) == 0) {
+            continue;
+        }
+        auto incomingData = QByteArray::fromRawData(
+                reinterpret_cast<char*>(pCurrentBuffer), bytesRead);
+        receive(incomingData, mixxx::Time::elapsed());
+    }
 }
 
 bool HidController::isPolling() const {

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -243,13 +243,16 @@ int HidController::close() {
 bool HidController::poll() {
     Trace hidRead("HidController poll");
 
-    int result = hid_read(m_pHidDevice, m_pPollData, sizeof(m_pPollData) / sizeof(m_pPollData[0]));
-    if (result == -1) {
-        return false;
-    } else if (result > 0) {
-        Trace process("HidController process packet");
-        QByteArray outData(reinterpret_cast<char*>(m_pPollData), result);
-        receive(outData, mixxx::Time::elapsed());
+    int result = 1;
+    while (result > 0) {
+        result = hid_read(m_pHidDevice, m_pPollData, sizeof(m_pPollData) / sizeof(m_pPollData[0]));
+        if (result == -1) {
+            return false;
+        } else if (result > 0) {
+            Trace process("HidController process packet");
+            QByteArray outData(reinterpret_cast<char*>(m_pPollData), result);
+            receive(outData, mixxx::Time::elapsed());
+        }
     }
 
     return true;

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -266,8 +266,6 @@ bool HidController::poll() {
             // Some controllers such as the Gemini GMX continuously send input packets even if it
             // is identical to the previous packet. If this loop processed all those redundant
             // packets, it would be a big performance problem.
-            // TODO: Test if this hack can be done with adequate performance in JS so a deep copy
-            // of each incoming packet isn't needed for most HID devices.
             if (memcmp(pCurrentBuffer, pPreviousBuffer, bufferSize) == 0) {
                 continue;
             }

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -260,7 +260,9 @@ bool HidController::poll() {
         unsigned char* pCurrentBuffer = m_pPollData[m_iPollingBufferIndex];
 
         int bytesRead = hid_read(m_pHidDevice, pCurrentBuffer, kBufferSize);
-        if (bytesRead == -1) {
+        if (bytesRead < 0) {
+            // -1 is the only error value according to hidapi documentation.
+            DEBUG_ASSERT(bytesRead == -1);
             return false;
         } else if (bytesRead == 0) {
             return true;

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -251,9 +251,9 @@ bool HidController::poll() {
     int result = 1;
     while (result > 0) {
         // Rotate between two buffers so the memcmp below does not require deep copying to another buffer.
-        unsigned char* pCurrentBuffer = m_pPollData[m_iPollingBufferIndex];
-        m_iPollingBufferIndex = (m_iPollingBufferIndex + 1) % kNumBuffers;
         unsigned char* pPreviousBuffer = m_pPollData[m_iPollingBufferIndex];
+        m_iPollingBufferIndex = (m_iPollingBufferIndex + 1) % kNumBuffers;
+        unsigned char* pCurrentBuffer = m_pPollData[m_iPollingBufferIndex];
 
         result = hid_read(m_pHidDevice, pCurrentBuffer, kBufferSize);
         if (result == -1) {

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -245,7 +245,6 @@ bool HidController::poll() {
     Trace hidRead("HidController poll");
 
     int result = 1;
-    int bufferSize = sizeof(m_pPollData[0]) / sizeof(m_pPollData[0][0]);
     while (result > 0) {
         // Rotate between two buffers so the memcmp below does not require deep copying to another buffer.
         unsigned char* pCurrentBuffer = m_pPollData[m_iPollingBufferIndex];
@@ -256,7 +255,7 @@ bool HidController::poll() {
         }
         unsigned char* pPreviousBuffer = m_pPollData[m_iPollingBufferIndex];
 
-        result = hid_read(m_pHidDevice, pCurrentBuffer, bufferSize);
+        result = hid_read(m_pHidDevice, pCurrentBuffer, m_iBufferSize);
         if (result == -1) {
             return false;
         } else if (result > 0) {
@@ -266,7 +265,7 @@ bool HidController::poll() {
             // Some controllers such as the Gemini GMX continuously send input packets even if it
             // is identical to the previous packet. If this loop processed all those redundant
             // packets, it would be a big performance problem.
-            if (memcmp(pCurrentBuffer, pPreviousBuffer, bufferSize) == 0) {
+            if (memcmp(pCurrentBuffer, pPreviousBuffer, m_iBufferSize) == 0) {
                 continue;
             }
             receive(byteArray, mixxx::Time::elapsed());

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -76,10 +76,6 @@ HidController::HidController(const hid_device_info& deviceInfo, UserSettingsPoin
     // All HID devices are full-duplex
     setInputDevice(true);
     setOutputDevice(true);
-
-    for (int i = 0; i < m_iNumBuffers; i++) {
-        memset(m_pPollData[i], 0, m_iBufferSize);
-    }
 }
 
 HidController::~HidController() {
@@ -218,6 +214,10 @@ int HidController::open() {
     if (hid_set_nonblocking(m_pHidDevice, 1) != 0) {
         qWarning() << "Unable to set HID device " << getName() << " to non-blocking";
         return -1;
+    }
+
+    for (int i = 0; i < m_iNumBuffers; i++) {
+        memset(m_pPollData[i], 0, m_iBufferSize);
     }
 
     setOpen(true);

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -254,7 +254,7 @@ bool HidController::poll() {
     // There is no safety net for this because it has not been demonstrated to be
     // a problem in practice.
     while (true) {
-        // Rotate between two buffers so the memcmp below does not require deep copying to another buffer.
+        // Cycle between buffers so the memcmp below does not require deep copying to another buffer.
         unsigned char* pPreviousBuffer = m_pPollData[m_iPollingBufferIndex];
         m_iPollingBufferIndex = (m_iPollingBufferIndex + 1) % kNumBuffers;
         unsigned char* pCurrentBuffer = m_pPollData[m_iPollingBufferIndex];

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -89,7 +89,8 @@ class HidController final : public Controller {
     hid_device* m_pHidDevice;
     HidControllerPreset m_preset;
 
-    unsigned char m_pPollData[2][255];
+    static constexpr int m_iBufferSize = 255;
+    unsigned char m_pPollData[2][m_iBufferSize];
     int m_iPollingBufferIndex;
 };
 

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -89,8 +89,9 @@ class HidController final : public Controller {
     hid_device* m_pHidDevice;
     HidControllerPreset m_preset;
 
+    static constexpr int m_iNumBuffers = 2;
     static constexpr int m_iBufferSize = 255;
-    unsigned char m_pPollData[2][m_iBufferSize];
+    unsigned char m_pPollData[m_iNumBuffers][m_iBufferSize];
     int m_iPollingBufferIndex;
 };
 

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -89,9 +89,9 @@ class HidController final : public Controller {
     hid_device* m_pHidDevice;
     HidControllerPreset m_preset;
 
-    static constexpr int m_iNumBuffers = 2;
-    static constexpr int m_iBufferSize = 255;
-    unsigned char m_pPollData[m_iNumBuffers][m_iBufferSize];
+    static constexpr int kNumBuffers = 2;
+    static constexpr int kBufferSize = 255;
+    unsigned char m_pPollData[kNumBuffers][kBufferSize];
     int m_iPollingBufferIndex;
 };
 

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -84,13 +84,13 @@ class HidController final : public Controller {
     QString hid_serial;
     QString hid_manufacturer;
     QString hid_product;
-    QByteArray m_lastIncomingData;
 
     QString m_sUID;
     hid_device* m_pHidDevice;
     HidControllerPreset m_preset;
 
-    unsigned char m_pPollData[255];
+    unsigned char m_pPollData[2][255];
+    int m_iPollingBufferIndex;
 };
 
 #endif

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -84,6 +84,7 @@ class HidController final : public Controller {
     QString hid_serial;
     QString hid_manufacturer;
     QString hid_product;
+    QByteArray m_lastIncomingData;
 
     QString m_sUID;
     hid_device* m_pHidDevice;


### PR DESCRIPTION
Otherwise, it seems messages build up in a queue which produces
a dramatic lag on Linux when moving faders quickly. This
regression was introduced between Mixxx 2.2 and 2.3 beta, likely
by switching HidController to nonblocking polling in PR #2179.

@codecat [previously tested this on Windows](https://github.com/mixxxdj/mixxx/pull/2179#issuecomment-505611444). @codecat if you could double check with this branch, that would be helpful.