### PR TITLE
Make HIDPackets own a link to HIDControllers

### DIFF
--- a/res/controllers/EKS-Otus.js
+++ b/res/controllers/EKS-Otus.js
@@ -27,7 +27,7 @@ function EKSOtusController() {
         var name = undefined;
         var offset = 0;
 
-        packet = new HIDPacket("control", 0, undefined, [0x35]);
+        packet = new HIDPacket(this.controller, "control", 0, undefined, [0x35]);
         packet.addControl("hid","wheel_position",2,"H");
         packet.addControl("hid","wheel_speed",4,"h");
         packet.addControl("hid","timestamp",6,"I");
@@ -87,12 +87,12 @@ function EKSOtusController() {
         packet.addControl("hid","deck_status",52,"B");
         this.controller.registerInputPacket(packet);
 
-        packet = new HIDPacket("firmware_version", 0xa, undefined, [0x4]);
+        packet = new HIDPacket(this.controller, "firmware_version", 0xa, undefined, [0x4]);
         packet.addControl("hid","major",2,"B");
         packet.addControl("hid","minor",3,"B");
         this.controller.registerInputPacket(packet);
 
-        packet = new HIDPacket("trackpad_mode", 0x5, undefined, [0x3]);
+        packet = new HIDPacket(this.controller, "trackpad_mode", 0x5, undefined, [0x3]);
         packet.addControl("hid","status",2,"B");
         this.controller.registerInputPacket(packet);
 
@@ -103,7 +103,7 @@ function EKSOtusController() {
         var name = undefined;
         var offset = 0;
 
-        packet = new HIDPacket("button_leds", 0x16, undefined, [0x18]);
+        packet = new HIDPacket(this.controller, "button_leds", 0x16, undefined, [0x18]);
         offset = 1;
         packet.addOutput("hid","jog_nw",offset++,"B");
         packet.addOutput("hid","jog_ne",offset++,"B");
@@ -129,7 +129,7 @@ function EKSOtusController() {
         packet.addOutput("hid","fastforward",offset++,"B");
         this.controller.registerOutputPacket(packet);
 
-        packet = new HIDPacket("slider_leds", 0x17, undefined, [0x16]);
+        packet = new HIDPacket(this.controller, "slider_leds", 0x17, undefined, [0x16]);
         offset = 1;
         packet.addOutput("pitch","slider_1",offset++,"B");
         packet.addOutput("pitch","slider_2",offset++,"B");
@@ -153,26 +153,26 @@ function EKSOtusController() {
         packet.addOutput("pitch","slider_scale_3",offset++,"B");
         this.controller.registerOutputPacket(packet);
 
-        packet = new HIDPacket("led_wheel_left", 0x14, undefined, [0x20]);
+        packet = new HIDPacket(this.controller, "led_wheel_left", 0x14, undefined, [0x20]);
         offset = 1;
         for (var led_index=1;led_index<=this.wheelLEDCount/2;led_index++)
             packet.addOutput("hid","wheel_" + led_index,offset++,"B");
         this.controller.registerOutputPacket(packet);
 
-        packet = new HIDPacket("led_wheel_right", 0x15, undefined, [0x20]);
+        packet = new HIDPacket(this.controller, "led_wheel_right", 0x15, undefined, [0x20]);
         offset = 1;
         for (var led_index=this.wheelLEDCount/2+1;led_index<=this.wheelLEDCount;led_index++)
             packet.addOutput("hid","wheel_" + led_index,offset++,"B");
         this.controller.registerOutputPacket(packet);
 
-        packet = new HIDPacket("request_firmware_version", 0xa, undefined, [0x2]);
+        packet = new HIDPacket(this.controller, "request_firmware_version", 0xa, undefined, [0x2]);
         this.controller.registerOutputPacket(packet);
 
-        packet = new HIDPacket("set_trackpad_mode", 0x5, undefined, [0x3]);
+        packet = new HIDPacket(this.controller, "set_trackpad_mode", 0x5, undefined, [0x3]);
         packet.addControl("hid","mode",2,"B");
         this.controller.registerOutputPacket(packet);
 
-        packet = new HIDPacket("set_ledcontrol_mode", 0x1d, undefined, [0x3]);
+        packet = new HIDPacket(this.controller, "set_ledcontrol_mode", 0x1d, undefined, [0x3]);
         packet.addControl("hid","mode",2,"B");
         this.controller.registerOutputPacket(packet);
     }

--- a/res/controllers/Nintendo-Wiimote.js
+++ b/res/controllers/Nintendo-Wiimote.js
@@ -30,7 +30,7 @@ function WiimoteController() {
         this.controller.defaultPacket = "coreaccel";
 
         // Core buttons input packet
-        packet = new HIDPacket("buttons", 0x30);
+        packet = new HIDPacket(this.controller, "buttons", 0x30);
         packet.addControl("buttons","arrow_left",1,"B",0x1);
         packet.addControl("buttons","arrow_right",1,"B",0x2);
         packet.addControl("buttons","arrow_down",1,"B",0x4);
@@ -45,7 +45,7 @@ function WiimoteController() {
         this.controller.registerInputPacket(packet);
 
         // Core buttons and accelerometer data
-        packet = new HIDPacket("coreaccel", 0x31);
+        packet = new HIDPacket(this.controller, "coreaccel", 0x31);
         packet.addControl("coreaccel","arrow_left",1,"B",0x1);
         packet.addControl("coreaccel","arrow_right",1,"B",0x2);
         packet.addControl("coreaccel","arrow_down",1,"B",0x4);
@@ -64,7 +64,7 @@ function WiimoteController() {
 
         // Core buttons and accelerometer data with 8 bytes
         // from extension module
-        packet = new HIDPacket("coreaccel_ext8", 0x32);
+        packet = new HIDPacket(this.controller, "coreaccel_ext8", 0x32);
         packet.addControl("coreaccel_ext8","arrow_left",1,"B",0x1);
         packet.addControl("coreaccel_ext8","arrow_right",1,"B",0x2);
         packet.addControl("coreaccel_ext8","arrow_down",1,"B",0x4);
@@ -91,7 +91,7 @@ function WiimoteController() {
 
         // Core buttons and accelerometer data with 12 bytes
         // from IR camera
-        packet = new HIDPacket("coreaccel_ir12", 0x33);
+        packet = new HIDPacket(this.controller, "coreaccel_ir12", 0x33);
         packet.addControl("coreaccel_ir12","arrow_left",1,"B",0x1);
         packet.addControl("coreaccel_ir12","arrow_right",1,"B",0x2);
         packet.addControl("coreaccel_ir12","arrow_down",1,"B",0x4);
@@ -122,7 +122,7 @@ function WiimoteController() {
 
         // Core buttons and 19 bytes from extension module,
         // no accelerometer data
-        packet = new HIDPacket("corebuttons_ext19", 0x34);
+        packet = new HIDPacket(this.controller, "corebuttons_ext19", 0x34);
         packet.addControl("corebuttons_ext19","arrow_left",1,"B",0x1);
         packet.addControl("corebuttons_ext19","arrow_right",1,"B",0x2);
         packet.addControl("corebuttons_ext19","arrow_down",1,"B",0x4);
@@ -157,7 +157,7 @@ function WiimoteController() {
 
         // Core buttons, accelerometer and 16 bytes from
         // extension module
-        packet = new HIDPacket("coreaccel_ext16", 0x35);
+        packet = new HIDPacket(this.controller, "coreaccel_ext16", 0x35);
         packet.addControl("coreaccel_ext16","arrow_left",1,"B",0x1);
         packet.addControl("coreaccel_ext16","arrow_right",1,"B",0x2);
         packet.addControl("coreaccel_ext16","arrow_down",1,"B",0x4);
@@ -192,7 +192,7 @@ function WiimoteController() {
 
         // Core buttons, no accelerometer and 10 IR bytes and
         // 9 bytes from extension module
-        packet = new HIDPacket("corebuttons_ir10_ext9", 0x36);
+        packet = new HIDPacket(this.controller, "corebuttons_ir10_ext9", 0x36);
         packet.addControl("corebuttons_ir10_ext9","arrow_left",1,"B",0x1);
         packet.addControl("corebuttons_ir10_ext9","arrow_right",1,"B",0x2);
         packet.addControl("corebuttons_ir10_ext9","arrow_down",1,"B",0x4);
@@ -227,7 +227,7 @@ function WiimoteController() {
 
         // Core buttons, accelerometer and 10 IR bytes and
         // 6 bytes from extension module
-        packet = new HIDPacket("coreaccel_ir10_ext6", 0x37);
+        packet = new HIDPacket(this.controller, "coreaccel_ir10_ext6", 0x37);
         packet.addControl("coreaccel_ir10_ext6","arrow_left",1,"B",0x1);
         packet.addControl("coreaccel_ir10_ext6","arrow_right",1,"B",0x2);
         packet.addControl("coreaccel_ir10_ext6","arrow_down",1,"B",0x4);
@@ -262,7 +262,7 @@ function WiimoteController() {
 
         // No core buttons, no accelerometer, 21 bytes from
         // extension module
-        packet = new HIDPacket("ext_21", 0x3d);
+        packet = new HIDPacket(this.controller, "ext_21", 0x3d);
         packet.addControl("ext_21","extension_1",1,"B");
         packet.addControl("ext_21","extension_2",2,"B");
         packet.addControl("ext_21","extension_3",3,"B");
@@ -288,7 +288,7 @@ function WiimoteController() {
 
         // Interleaved packet 1: core buttons, accelerometer,
         // first 16 bytes from IR camera
-        packet = new HIDPacket("coreaccel_interleaved_1", 0x3e);
+        packet = new HIDPacket(this.controller, "coreaccel_interleaved_1", 0x3e);
         packet.addControl("coreaccel_interleaved_1","arrow_left",1,"B",0x1);
         packet.addControl("coreaccel_interleaved_1","arrow_right",1,"B",0x2);
         packet.addControl("coreaccel_interleaved_1","arrow_down",1,"B",0x4);
@@ -323,7 +323,7 @@ function WiimoteController() {
 
         // Interleaved packet 2: core buttons, accelerometer,
         // last 16 bytes from IR camera
-        packet = new HIDPacket("coreaccel_interleaved_2", 0x3f);
+        packet = new HIDPacket(this.controller, "coreaccel_interleaved_2", 0x3f);
         packet.addControl("coreaccel_interleaved_2","arrow_left",1,"B",0x1);
         packet.addControl("coreaccel_interleaved_2","arrow_right",1,"B",0x2);
         packet.addControl("coreaccel_interleaved_2","arrow_down",1,"B",0x4);
@@ -358,7 +358,7 @@ function WiimoteController() {
     }
 
     this.registerOutputPackets = function() {
-        packet = new HIDPacket("feedback", 0x11);
+        packet = new HIDPacket(this.controller, "feedback", 0x11);
         packet.addControl("state","rumble",1,"B",0x1);
         packet.addControl("state","led_1",1,"B",0x10);
         packet.addControl("state","led_2",1,"B",0x20);
@@ -366,16 +366,16 @@ function WiimoteController() {
         packet.addControl("state","led_4",1,"B",0x80);
         this.controller.registerOutputPacket(packet);
 
-        packet = new HIDPacket("setreportmode", 0x12);
+        packet = new HIDPacket(this.controller, "setreportmode", 0x12);
         packet.addControl("reportmode","continuous",1,"B",0x4);
         packet.addControl("reportmode","code",2,"B");
         this.controller.registerOutputPacket(packet);
 
-        packet = new HIDPacket("ircamera", 0x13);
+        packet = new HIDPacket(this.controller, "ircamera", 0x13);
         packet.addControl("ircontrol","enabled",1,"B",0x4);
         this.controller.registerOutputPacket(packet);
 
-        packet = new HIDPacket("ircamerastate", 0x1a);
+        packet = new HIDPacket(this.controller, "ircamerastate", 0x1a);
         packet.addControl("irstate","enabled",1,"B",0x4);
         this.controller.registerOutputPacket(packet);
     }

--- a/res/controllers/Pioneer-CDJ-HID.js
+++ b/res/controllers/Pioneer-CDJ-HID.js
@@ -21,7 +21,7 @@ function PioneerCDJController() {
         var name = undefined;
         var offset = 0;
 
-        packet = new HIDPacket("control", 0);
+        packet = new HIDPacket(this.controller, "control", 0);
         packet.addControl("hid","eject",0,"B",0x1);
         packet.addControl("hid","previous_track",0,"B",0x4);
         packet.addControl("hid","next_track",0,"B",0x8);
@@ -79,7 +79,7 @@ function PioneerCDJController() {
         // TODO - Sean: this is just example, fill in correct packet
         // size, header bytes control field offesets but bits to make
         // it work.
-        packet = new HIDPacket("lights", 0x1);
+        packet = new HIDPacket(this.controller, "lights", 0x1);
         packet.addOutput("hid","screen_acue",4,"B",0x1);
         packet.addOutput("hid","remain",4,"B",0x2);
         packet.addOutput("hid","screen_flag_1",4,"B",0x4);
@@ -142,7 +142,7 @@ function PioneerCDJController() {
         // TODO - Sean: This is arbitrary example packet, fix the
         // bytes to get it working. Need to add a response packet
         // to input packets as well, if we receive acknowledgement
-        packet = new HIDPacket("request_hid_mode", 0x1);
+        packet = new HIDPacket(this.controller, "request_hid_mode", 0x1);
         packet.addControl("hid","mode",0,"B",1);
         this.controller.registerOutputPacket(packet);
 
@@ -155,7 +155,7 @@ function PioneerCDJController() {
         var chars = 1;
         var offset = 2;
         // Register 2 bytes for each letter, I expect UTF-8 output
-        packet = new HIDPacket("display", 0x2, undefined, [0x2]);
+        packet = new HIDPacket(this.controller, "display", 0x2, undefined, [0x2]);
         for (var i=0;i<textlines;i++) {
             for (var c=0;c<chars;c++) {
                 var name = "line_"+(i+1)+"letter_"+(c+1);
@@ -170,7 +170,7 @@ function PioneerCDJController() {
         // anyway when implemented. When I know what data is sent, I
         // will add a helper function to actually do something with it!
         var waveform_packet_datalen = 400;
-        packet = new HIDPacket("waveform", 0x1, undefined, [0x2]);;
+        packet = new HIDPacket(this.controller, "waveform", 0x1, undefined, [0x2]);;
         for (var i=0;i<waveform_packet_datalen;i++)
             packet.addControl("hid","byte_"+i,i,"B");
         //this.controller.registerOutputPacket(packet);

--- a/res/controllers/Sony-SixxAxis.js
+++ b/res/controllers/Sony-SixxAxis.js
@@ -10,7 +10,7 @@ function SonySixxAxisController() {
     this.controller.activeDeck = 1;
 
     this.registerInputPackets = function() {
-        packet = new HIDPacket("control",[],49);
+        packet = new HIDPacket(this.controller, "control",[],49);
 
         // Toggle buttons
         packet.addControl("hid","select",2,"B",0x1);

--- a/res/controllers/Traktor-Kontrol-F1-scripts.js
+++ b/res/controllers/Traktor-Kontrol-F1-scripts.js
@@ -25,7 +25,7 @@ function KontrolF1Controller() {
     ];
 
     this.registerInputPackets = function() {
-        var packet = new HIDPacket("control", 0x1);
+        var packet = new HIDPacket(this.controller, "control", 0x1);
         packet.addControl("hid", "grid_8", 1,"I", 0x1);
         packet.addControl("hid", "grid_7", 1,"I", 0x2);
         packet.addControl("hid", "grid_6", 1,"I", 0x4);
@@ -73,7 +73,7 @@ function KontrolF1Controller() {
     }
 
     this.registerOutputPackets = function() {
-        var packet = new HIDPacket("lights", 0x80);
+        var packet = new HIDPacket(this.controller, "lights", 0x80);
         // Right 7-segment element - 0x0 off, 0x40 on
         packet.addControl("hid", "right_segment_dp", 0,"B");
         packet.addControl("hid", "right_segment_1", 1,"B");

--- a/res/controllers/Traktor-Kontrol-S2-MK3-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S2-MK3-hid-scripts.js
@@ -64,8 +64,8 @@ TraktorS2MK3.init = function (id) {
 };
 
 TraktorS2MK3.registerInputPackets = function () {
-    var messageShort = new HIDPacket("shortmessage", 0x01, this.messageCallback);
-    var messageLong = new HIDPacket("longmessage", 0x02, this.messageCallback);
+    var messageShort = new HIDPacket(this.controller, "shortmessage", 0x01, this.messageCallback);
+    var messageLong = new HIDPacket(this.controller, "longmessage", 0x02, this.messageCallback);
 
     this.registerInputButton(messageShort, "[Channel1]", "!play", 0x02, 0x08, this.playHandler);
     this.registerInputButton(messageShort, "[Channel2]", "!play", 0x05, 0x20, this.playHandler);
@@ -625,7 +625,7 @@ TraktorS2MK3.beatgridHandler = function (field) {
 };
 
 TraktorS2MK3.registerOutputPackets = function () {
-    var output = new HIDPacket("output", 0x80);
+    var output = new HIDPacket(this.controller, "output", 0x80);
 
     output.addOutput("[Channel1]", "play_indicator", 0x0C, "B");
     output.addOutput("[Channel2]", "play_indicator", 0x33, "B");

--- a/res/controllers/Traktor-Kontrol-S4-MK2-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK2-hid-scripts.js
@@ -79,8 +79,8 @@ TraktorS4MK2 = new function() {
 }
 
 TraktorS4MK2.registerInputPackets = function() {
-  MessageShort = new HIDPacket("shortmessage", 0x01, this.shortMessageCallback);
-  MessageLong = new HIDPacket("longmessage", 0x02, this.longMessageCallback);
+  MessageShort = new HIDPacket(this.controller, "shortmessage", 0x01, this.shortMessageCallback);
+  MessageLong = new HIDPacket(this.controller, "longmessage", 0x02, this.longMessageCallback);
 
   // Values in the short message are all buttons, except the jog wheels.
   // An exclamation point indicates a specially-handled function.  Everything else is a standard
@@ -312,9 +312,9 @@ TraktorS4MK2.registerInputPackets = function() {
 }
 
 TraktorS4MK2.registerOutputPackets = function() {
-  Output1 = new HIDPacket("output1", 0x80);
-  Output2 = new HIDPacket("output2", 0x81);
-  Output3 = new HIDPacket("output3", 0x82);
+  Output1 = new HIDPacket(this.controller, "output1", 0x80);
+  Output2 = new HIDPacket(this.controller, "output2", 0x81);
+  Output3 = new HIDPacket(this.controller, "output3", 0x82);
 
   Output1.addOutput("[Channel1]", "track_samples", 0x10, "B");
   Output1.addOutput("[Channel2]", "track_samples", 0x18, "B");

--- a/res/controllers/common-hid-devices.js
+++ b/res/controllers/common-hid-devices.js
@@ -1,77 +1,77 @@
 // Generic HID trackpad implementation
 HIDTrackpadDevice = function() {
-    this.controller = new HIDController()
+    this.controller = new HIDController();
 
     this.registerInputPackets = function() {
         // Example how to register a callback directly on a packet
-        packet = new HIDPacket("control", 0, this.mouseInput)
-        packet.addControl("hid", "byte_1", 3, "B")
-        packet.addControl("hid", "byte_2", 4, "B")
-        packet.addControl("hid", "byte_3", 5, "B")
-        packet.addControl("hid", "byte_4", 6, "B")
-        this.controller.registerInputPacket(packet)
-    }
+        packet = new HIDPacket(this.controller, "control", 0, this.mouseInput);
+        packet.addControl("hid", "byte_1", 3, "B");
+        packet.addControl("hid", "byte_2", 4, "B");
+        packet.addControl("hid", "byte_3", 5, "B");
+        packet.addControl("hid", "byte_4", 6, "B");
+        this.controller.registerInputPacket(packet);
+    };
 
     // HID trackpads have no output controls
-    this.registerOutputPackets = function() { }
+    this.registerOutputPackets = function() { };
 
     // No need to do scaling for keyboard presses
-    this.registerScalers = function() { }
+    this.registerScalers = function() { };
 
     // No need for callbacks here, we bound whole input packet to mouseInput
-    this.registerCallbacks = function() { }
+    this.registerCallbacks = function() { };
 
     // Example to process the mouse input packet all yourself
     this.mouseInput = function(packet, delta) {
-        HIDDebug("Trackpad INPUT " + packet.name)
+        HIDDebug("Trackpad INPUT " + packet.name);
         if (!delta.length) {
-            HIDDebug("No changed data received in HID packet")
-            return
+            HIDDebug("No changed data received in HID packet");
+            return;
         }
         for (var field_name in delta) {
-            var field = delta[field_name]
-            HIDDebug("FIELD " + field.id + " VALUE " + value)
+            var field = delta[field_name];
+            HIDDebug("FIELD " + field.id + " VALUE " + value);
         }
-    }
-}
+    };
+};
 
 // Generic HID keyboard implementation
 HIDKeyboardDevice = function() {
-    this.controller = new HIDController()
+    this.controller = new HIDController();
 
     this.registerInputPackets = function() {
-        packet = new HIDPacket("control", 0x1)
-        packet.addControl("hid", "keycode_1", 3, "B")
-        packet.addControl("hid", "keycode_2", 4, "B")
-        packet.addControl("hid", "keycode_3", 5, "B")
-        packet.addControl("hid", "keycode_4", 6, "B")
-        packet.addControl("hid", "keycode_5", 7, "B")
-        packet.addControl("hid", "keycode_6", 8, "B")
-        this.controller.registerInputPacket(packet)
-    }
+        packet = new HIDPacket(this.controller, "control", 0x1);
+        packet.addControl("hid", "keycode_1", 3, "B");
+        packet.addControl("hid", "keycode_2", 4, "B");
+        packet.addControl("hid", "keycode_3", 5, "B");
+        packet.addControl("hid", "keycode_4", 6, "B");
+        packet.addControl("hid", "keycode_5", 7, "B");
+        packet.addControl("hid", "keycode_6", 8, "B");
+        this.controller.registerInputPacket(packet);
+    };
 
     // HID keyboards have no output controls
-    this.registerOutputPackets = function() { }
+    this.registerOutputPackets = function() { };
 
     // No need to do scaling for keyboard presses
-    this.registerScalers = function() { }
+    this.registerScalers = function() { };
 
     // Example to bind the bytes to a callback
     this.registerCallbacks = function() {
-        this.controller.setCallback("control", "hid", "keycode_1", this.keyPress)
-        this.controller.setCallback("control", "hid", "keycode_2", this.keyPress)
-        this.controller.setCallback("control", "hid", "keycode_3", this.keyPress)
-        this.controller.setCallback("control", "hid", "keycode_4", this.keyPress)
-        this.controller.setCallback("control", "hid", "keycode_5", this.keyPress)
-        this.controller.setCallback("control", "hid", "keycode_6", this.keyPress)
-    }
+        this.controller.setCallback("control", "hid", "keycode_1", this.keyPress);
+        this.controller.setCallback("control", "hid", "keycode_2", this.keyPress);
+        this.controller.setCallback("control", "hid", "keycode_3", this.keyPress);
+        this.controller.setCallback("control", "hid", "keycode_4", this.keyPress);
+        this.controller.setCallback("control", "hid", "keycode_5", this.keyPress);
+        this.controller.setCallback("control", "hid", "keycode_6", this.keyPress);
+    };
 
     // Example to do something with the keycodes received
     this.keyPress = function(field) {
         if (field.value != 0)
-            HIDDebug("KEY PRESS " + field.id + " CODE " + field.value)
+            HIDDebug("KEY PRESS " + field.id + " CODE " + field.value);
         else
-            HIDDebug("KEY RELEASE " + field.id)
-    }
-}
+            HIDDebug("KEY RELEASE " + field.id);
+    };
+};
 

--- a/res/controllers/common-hid-packet-parser.js
+++ b/res/controllers/common-hid-packet-parser.js
@@ -112,6 +112,7 @@ HIDModifierList.prototype.setCallback = function(name, callback) {
  * HID Packet object
  *
  * One HID input/output packet to register to HIDController
+ * @param controller the controller object which is this packet's parent.
  * @param name     name of packet
  * @param reportId report ID of the packet. If the device only uses
  *          one report type, this must be 0.
@@ -122,7 +123,8 @@ HIDModifierList.prototype.setCallback = function(name, callback) {
  * @param header   (optional) list of bytes to match from beginning
  *          of packet. Do NOT put the report ID in this; use
  *          the reportId parameter instead. */
-HIDPacket = function(name, reportId, callback, header) {
+HIDPacket = function(controller, name, reportId, callback, header) {
+    this.controller = controller
     this.name = name
     this.header = header
     this.callback = callback


### PR DESCRIPTION
This should be a relatively safe noop.  Creating an HIDPacket now also requires a controller parameter.  This will enable better callbacks for virtual "deckX" connections.  We should do some basic checking just to make sure this doesn't break anything.

Linter made some changes to common-hid-devices.js that should also be noop.