### PR TITLE
Clang format wrapper fix for removed lines

### DIFF
--- a/tools/clang_format_wrapper.py
+++ b/tools/clang_format_wrapper.py
@@ -93,7 +93,12 @@ def run_clang_format(file_list: List[str]) -> bool:
     out = check_output(command, text=True)
     logger.debug(out)
 
-    return False if out == "clang-format did not modify any files\n" else True
+    if (
+        out == "clang-format did not modify any files\n"
+        or out == "no modified files to format\n"
+    ):
+        return False
+    return True
 
 
 def main():


### PR DESCRIPTION
This fixes a failing clang-format hook when we only remove lines. 
