### PR TITLE
tools: Make clang_format_wrapper.py less brittle

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,3 +3,4 @@
 # https://black.readthedocs.io/en/stable/the_black_code_style.html#slices
 # W503 conflicts with black, too.
 ignore = E203,W503
+max-line-length = 99

--- a/tools/clang_format_wrapper.py
+++ b/tools/clang_format_wrapper.py
@@ -72,7 +72,7 @@ def get_git_status() -> Iterable[GitEdit]:
 def run_clang_format(file_list: List[str]) -> bool:
     """Execute git-clang-format for provided `file_list`.
 
-    Return True if `git-clang-format` has errors or has modified any file,
+    Return False if `git-clang-format` has errors or has modified any file,
     i.e. if it failed the formatting test.
     """
     if not file_list:
@@ -93,7 +93,9 @@ def run_clang_format(file_list: List[str]) -> bool:
     out = check_output(command, text=True)
     logger.debug(out)
 
-    return False if out == "clang-format did not modify any files\n" else True
+    # If there's only a single line of output, we can assume that nothing was changed.
+    # This is not very clean, but better than hard-coding the expected message.
+    return out.index("\n") == out.rindex("\n")
 
 
 def main():
@@ -120,7 +122,7 @@ def main():
     if paths_to_be_clang_formatted:
         logger.debug("Paths:\n%s", "\n".join(paths_to_be_clang_formatted))
 
-        if run_clang_format(paths_to_be_clang_formatted):
+        if not run_clang_format(paths_to_be_clang_formatted):
             return 1
 
     return 0


### PR DESCRIPTION
See https://mixxx.zulipchat.com/#narrow/stream/247620-development-help/topic/pre-commit.20fails.20when.20there.20are.20only.20line.20removals/near/205461210

Not extensively tested yet, but seems to work.