### PR TITLE
tools: Add clang tidy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,7 +118,7 @@ repos:
   hooks:
   - id: line-length
     name: line-length
-    description: Check for lines longer 100 and brakes them before 80.
+    description: Check for lines longer than 100 chars and break them before 80.
     entry: ./tools/line_length.py
     stages:
     - commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -119,6 +119,7 @@ repos:
   - id: line-length
     name: line-length
     description: Check for lines longer than 100 chars and break them before 80.
+      Also runs some uncontroversial clang-tidy modernizations if possible.
     entry: ./tools/line_length.py
     stages:
     - commit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,10 @@ endif()
 
 #######################################################################
 
+# Export compile_commands.json for clang-tidy
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+file(CREATE_LINK ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json SYMBOLIC)
+
 set(CMAKE_CXX_STANDARD 17)
 
 # Speed up builds on HDDs

--- a/tools/line_length.py
+++ b/tools/line_length.py
@@ -150,6 +150,27 @@ def main(argv: typing.Optional[typing.List[str]] = None) -> int:
     )
     proc_dump_config.check_returncode()
 
+    for changed_file in changed_files_all:
+        line_arguments = [
+            "[{},{}]".format(start, end) for start, end in changed_file.lines
+        ]
+
+        if not line_arguments:
+            continue
+
+        cmd = [
+            "clang-tidy",
+            "--checks=-*,modernize-use-nullptr",
+            "--fix",
+            '--header-filter=""',
+            '--line-filter=[{{"name":"{}","lines":[{}]}}]'.format(
+                changed_file.filename, ",".join(line_arguments)
+            ),
+            changed_file.filename,
+        ]
+        if not run_on(os.path.join(rootdir, changed_file.filename), cmd):
+            return 1
+
     with tempfile.TemporaryDirectory(prefix="clang-format") as tempdir:
         # Create temporary config with ColumnLimit enabled
         configfile = os.path.join(tempdir, ".clang-format")

--- a/tools/line_length.py
+++ b/tools/line_length.py
@@ -124,7 +124,7 @@ def main(argv: typing.Optional[typing.List[str]] = None) -> int:
 
         cmd = [
             "clang-tidy",
-            "--checks=-*,modernize-use-nullptr",
+            "--checks=-*,modernize-use-nullptr,modernize-use-auto",
             "--fix",
             '--header-filter=""',
             '--line-filter=[{{"name":"{}","lines":[{}]}}]'.format(


### PR DESCRIPTION
This way, whenever you commit, clang-tidy will perform uncontroversial modernizations in the changed lines, which avoids unnecessary work in reviews. Originally started with modernize-use-nullptr (replace NULL with nullptr), I now also added modernize-use-auto, which automatically uses auto if the type would be duplicated otherwise (i.e. when constructing an object) - but we can remove that if it is debatable.

Note that it currently only works after a compilation, since it needs the compile_commands.json which is generated by cmake. A check for that is in progress.

I didn't talk this over beforehand because I myself will use it anyways.

For now it is meshed into line_length.py because it laid a lot of necessary groundwork.
If you want to accept this, we should consider renaming it or splitting it up.