### PR TITLE
test: Use tempdir for broadcast profiles

### DIFF
--- a/src/test/broadcastprofile_test.cpp
+++ b/src/test/broadcastprofile_test.cpp
@@ -42,40 +42,39 @@ TEST(BroadcastProfileTest, SaveAndLoadXML) {
     // Preliminary: set a discriminating value in one of the profile fields
     QString streamName("unit testing in progress");
 
-    BroadcastProfile profile("Unit Testing Profile");
+    BroadcastProfile profile("Broadcast Profile test");
     profile.setStreamName(streamName);
 
-    QString filename = profile.getProfileName() + QString(".bcp.xml");
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+    QString filename = tempDir.filePath(profile.getProfileName() + QString(".bcp.xml"));
 
-    // Call save() on a profile and assert it actually exists
-    QFile::remove(filename); // First, make sure it doesn't exists
     profile.save(filename);
     ASSERT_TRUE(QFile::exists(filename));
 
     // Load XML file using static loadFromFile and assert
     // the discriminating value is present
     BroadcastProfilePtr savedProfile = BroadcastProfile::loadFromFile(filename);
-    ASSERT_NE(savedProfile, nullptr);
-    ASSERT_TRUE(savedProfile->getStreamName() == streamName);
+    EXPECT_NE(savedProfile, nullptr);
+    EXPECT_TRUE(savedProfile->getStreamName() == streamName);
 }
 
 TEST(BroadcastProfileTest, SaveAndLoadXMLDotName) {
-    QString profileName("profile has a dot. (in the name)");
-
+    QString profileName("broadcast profile has a dot. (in the name) test");
     BroadcastProfile profile(profileName);
 
-    QString filename = profile.getProfileName() + QString(".bcp.xml");
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+    QString filename = tempDir.filePath(profile.getProfileName() + QString(".bcp.xml"));
 
-    // Call save() on a profile and assert it actually exists
-    QFile::remove(filename); // First, make sure it doesn't exists
     profile.save(filename);
     ASSERT_TRUE(QFile::exists(filename));
 
     // Load XML file using static loadFromFile and assert
     // the discriminating value is present
     BroadcastProfilePtr savedProfile = BroadcastProfile::loadFromFile(filename);
-    ASSERT_NE(savedProfile, nullptr);
-    ASSERT_TRUE(savedProfile->getProfileName() == profileName);
+    EXPECT_NE(savedProfile, nullptr);
+    EXPECT_TRUE(savedProfile->getProfileName() == profileName);
 }
 
 TEST(BroadcastProfileTest, SetGetValues) {


### PR DESCRIPTION
Follow-up to https://github.com/mixxxdj/mixxx/pull/2938 and https://github.com/mixxxdj/mixxx/pull/2943

I am taking a different approach now - instead of changing where the tests are run, adjust where the temporary files are written. Still added them to gitignore as a fallback.