### PR TITLE
Adjust flake8 max-line-length

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,3 +3,4 @@
 # https://black.readthedocs.io/en/stable/the_black_code_style.html#slices
 # W503 conflicts with black, too.
 ignore = E203,W503
+max-line-length = 99

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,7 +118,7 @@ repos:
   hooks:
   - id: line-length
     name: line-length
-    description: Check for lines longer 100 and brakes them before 80.
+    description: Check for lines longer 100 and breaks them before 80.
     entry: ./tools/line_length.py
     stages:
     - commit


### PR DESCRIPTION
We allow a maximum line-length of 100, and Black breaks at 88 by default. Flake8 by default only allows 79 chars, which can be quite annoying, especially for comments, which Black doesn't seem to touch at all.