### PR TITLE
Update database help message

### DIFF
--- a/src/database/mixxxdb.cpp
+++ b/src/database/mixxxdb.cpp
@@ -70,8 +70,8 @@ MixxxDb::MixxxDb(
 
 bool MixxxDb::initDatabaseSchema(
         const QSqlDatabase& database,
-        const QString& schemaFile,
-        int schemaVersion) {
+        int schemaVersion,
+        const QString& schemaFile) {
     QString okToExit = tr("Click OK to exit.");
     QString upgradeFailed = tr("Cannot upgrade database schema");
     QString upgradeToVersionFailed =
@@ -80,37 +80,37 @@ bool MixxxDb::initDatabaseSchema(
     QString helpContact = tr("For help with database issues consult:") + "\n" +
             "https://www.mixxx.org/support";
 
-    switch (SchemaManager(database).upgradeToSchemaVersion(schemaFile, schemaVersion)) {
-        case SchemaManager::Result::CurrentVersion:
-        case SchemaManager::Result::UpgradeSucceeded:
-        case SchemaManager::Result::NewerVersionBackwardsCompatible:
-            return true; // done
-        case SchemaManager::Result::UpgradeFailed:
-            QMessageBox::warning(0,
-                    upgradeFailed,
-                    upgradeToVersionFailed + "\n" +
-                            tr("Your mixxxdb.sqlite file may be corrupt.") +
-                            "\n" + tr("Try renaming it and restarting Mixxx.") +
-                            "\n" + helpContact + "\n\n" + okToExit,
-                    QMessageBox::Ok);
-            return false; // abort
-        case SchemaManager::Result::NewerVersionIncompatible:
-            QMessageBox::warning(0,
-                    upgradeFailed,
-                    upgradeToVersionFailed + "\n" +
-                            tr("Your mixxxdb.sqlite file was created by a newer "
-                               "version of Mixxx and is incompatible.") +
-                            "\n\n" + okToExit,
-                    QMessageBox::Ok);
-            return false; // abort
-        case SchemaManager::Result::SchemaError:
-            QMessageBox::warning(0,
-                    upgradeFailed,
-                    upgradeToVersionFailed + "\n" +
-                            tr("The database schema file is invalid.") + "\n" +
-                            helpContact + "\n\n" + okToExit,
-                    QMessageBox::Ok);
-            return false; // abort
+    switch (SchemaManager(database).upgradeToSchemaVersion(schemaVersion, schemaFile)) {
+    case SchemaManager::Result::CurrentVersion:
+    case SchemaManager::Result::UpgradeSucceeded:
+    case SchemaManager::Result::NewerVersionBackwardsCompatible:
+        return true; // done
+    case SchemaManager::Result::UpgradeFailed:
+        QMessageBox::warning(0,
+                upgradeFailed,
+                upgradeToVersionFailed + "\n" +
+                        tr("Your mixxxdb.sqlite file may be corrupt.") +
+                        "\n" + tr("Try renaming it and restarting Mixxx.") +
+                        "\n" + helpContact + "\n\n" + okToExit,
+                QMessageBox::Ok);
+        return false; // abort
+    case SchemaManager::Result::NewerVersionIncompatible:
+        QMessageBox::warning(0,
+                upgradeFailed,
+                upgradeToVersionFailed + "\n" +
+                        tr("Your mixxxdb.sqlite file was created by a newer "
+                           "version of Mixxx and is incompatible.") +
+                        "\n\n" + okToExit,
+                QMessageBox::Ok);
+        return false; // abort
+    case SchemaManager::Result::SchemaError:
+        QMessageBox::warning(0,
+                upgradeFailed,
+                upgradeToVersionFailed + "\n" +
+                        tr("The database schema file is invalid.") + "\n" +
+                        helpContact + "\n\n" + okToExit,
+                QMessageBox::Ok);
+        return false; // abort
     }
     // Suppress compiler warning
     DEBUG_ASSERT(!"unhandled switch/case");

--- a/src/database/mixxxdb.cpp
+++ b/src/database/mixxxdb.cpp
@@ -77,8 +77,8 @@ bool MixxxDb::initDatabaseSchema(
     QString upgradeToVersionFailed =
             tr("Unable to upgrade your database schema to version %1")
             .arg(QString::number(schemaVersion));
-    QString helpEmail = tr("For help with database issues contact:") + "\n" +
-                           "mixxx-devel@lists.sourceforge.net";
+    QString helpContact = tr("For help with database issues consult:") + "\n" +
+            "https://www.mixxx.org/support";
 
     switch (SchemaManager(database).upgradeToSchemaVersion(schemaFile, schemaVersion)) {
         case SchemaManager::Result::CurrentVersion:
@@ -86,29 +86,29 @@ bool MixxxDb::initDatabaseSchema(
         case SchemaManager::Result::NewerVersionBackwardsCompatible:
             return true; // done
         case SchemaManager::Result::UpgradeFailed:
-            QMessageBox::warning(
-                    0, upgradeFailed,
+            QMessageBox::warning(0,
+                    upgradeFailed,
                     upgradeToVersionFailed + "\n" +
-                    tr("Your mixxxdb.sqlite file may be corrupt.") + "\n" +
-                    tr("Try renaming it and restarting Mixxx.") + "\n" +
-                    helpEmail + "\n\n" + okToExit,
+                            tr("Your mixxxdb.sqlite file may be corrupt.") +
+                            "\n" + tr("Try renaming it and restarting Mixxx.") +
+                            "\n" + helpContact + "\n\n" + okToExit,
                     QMessageBox::Ok);
             return false; // abort
         case SchemaManager::Result::NewerVersionIncompatible:
-            QMessageBox::warning(
-                    0, upgradeFailed,
+            QMessageBox::warning(0,
+                    upgradeFailed,
                     upgradeToVersionFailed + "\n" +
-                    tr("Your mixxxdb.sqlite file was created by a newer "
-                       "version of Mixxx and is incompatible.") +
-                    "\n\n" + okToExit,
+                            tr("Your mixxxdb.sqlite file was created by a newer "
+                               "version of Mixxx and is incompatible.") +
+                            "\n\n" + okToExit,
                     QMessageBox::Ok);
             return false; // abort
         case SchemaManager::Result::SchemaError:
-            QMessageBox::warning(
-                    0, upgradeFailed,
+            QMessageBox::warning(0,
+                    upgradeFailed,
                     upgradeToVersionFailed + "\n" +
-                    tr("The database schema file is invalid.") + "\n" +
-                    helpEmail + "\n\n" + okToExit,
+                            tr("The database schema file is invalid.") + "\n" +
+                            helpContact + "\n\n" + okToExit,
                     QMessageBox::Ok);
             return false; // abort
     }

--- a/src/database/mixxxdb.h
+++ b/src/database/mixxxdb.h
@@ -19,8 +19,8 @@ class MixxxDb : public QObject {
 
     static bool initDatabaseSchema(
             const QSqlDatabase& database,
-            const QString& schemaFile = kDefaultSchemaFile,
-            int schemaVersion = kRequiredSchemaVersion);
+            int schemaVersion = kRequiredSchemaVersion,
+            const QString& schemaFile = kDefaultSchemaFile);
 
     explicit MixxxDb(
             const UserSettingsPointer& pConfig,

--- a/src/database/schemamanager.cpp
+++ b/src/database/schemamanager.cpp
@@ -65,8 +65,7 @@ bool SchemaManager::isBackwardsCompatibleWithVersion(int targetVersion) const {
 }
 
 SchemaManager::Result SchemaManager::upgradeToSchemaVersion(
-        const QString& schemaFilename,
-        int targetVersion) {
+        int targetVersion, const QString& schemaFilename) {
     VERIFY_OR_DEBUG_ASSERT(m_currentVersion >= 0) {
         return Result::UpgradeFailed;
     }

--- a/src/database/schemamanager.h
+++ b/src/database/schemamanager.h
@@ -28,9 +28,7 @@ class SchemaManager {
 
     bool isBackwardsCompatibleWithVersion(int targetVersion) const;
 
-    Result upgradeToSchemaVersion(
-            const QString& schemaFilename,
-            int targetVersion);
+    Result upgradeToSchemaVersion(int targetVersion, const QString& schemaFilename);
 
   private:
     QSqlDatabase m_database;

--- a/src/test/schemamanager_test.cpp
+++ b/src/test/schemamanager_test.cpp
@@ -35,14 +35,14 @@ TEST_F(SchemaManagerTest, CanUpgradeFreshDatabaseToRequiredVersion) {
     {
         SchemaManager schemaManager(dbConnection());
         SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
-                MixxxDb::kDefaultSchemaFile, MixxxDb::kRequiredSchemaVersion);
+                MixxxDb::kRequiredSchemaVersion, MixxxDb::kDefaultSchemaFile);
         EXPECT_EQ(SchemaManager::Result::UpgradeSucceeded, result);
     }
     // Subsequent upgrade(s)
     {
         SchemaManager schemaManager(dbConnection());
         SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
-                MixxxDb::kDefaultSchemaFile, MixxxDb::kRequiredSchemaVersion);
+                MixxxDb::kRequiredSchemaVersion, MixxxDb::kDefaultSchemaFile);
         EXPECT_EQ(SchemaManager::Result::CurrentVersion, result);
     }
 }
@@ -50,7 +50,7 @@ TEST_F(SchemaManagerTest, CanUpgradeFreshDatabaseToRequiredVersion) {
 TEST_F(SchemaManagerTest, NonExistentSchema) {
     SchemaManager schemaManager(dbConnection());
     SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
-            ":file_doesnt_exist.xml", MixxxDb::kRequiredSchemaVersion);
+            MixxxDb::kRequiredSchemaVersion, ":file_doesnt_exist.xml");
     EXPECT_EQ(SchemaManager::Result::SchemaError, result);
 }
 
@@ -60,7 +60,7 @@ TEST_F(SchemaManagerTest, BackwardsCompatibleVersion) {
         // Upgrade to version 1 to get the settings table.
         SchemaManager schemaManager(dbConnection());
         SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
-                MixxxDb::kDefaultSchemaFile, 1);
+                1, MixxxDb::kDefaultSchemaFile);
         EXPECT_EQ(SchemaManager::Result::UpgradeSucceeded, result);
 
         SettingsDAO settings(dbConnection());
@@ -68,14 +68,14 @@ TEST_F(SchemaManagerTest, BackwardsCompatibleVersion) {
         // Pretend the database version is one past the required version but
         // min_compatible is the required version.
         settings.setValue(SchemaManager::SETTINGS_VERSION_STRING,
-                          MixxxDb::kRequiredSchemaVersion + 1);
+                MixxxDb::kRequiredSchemaVersion + 1);
         settings.setValue(SchemaManager::SETTINGS_MINCOMPATIBLE_STRING,
-                          MixxxDb::kRequiredSchemaVersion);
+                MixxxDb::kRequiredSchemaVersion);
     }
 
     SchemaManager schemaManager(dbConnection());
     SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
-            MixxxDb::kDefaultSchemaFile, MixxxDb::kRequiredSchemaVersion);
+            MixxxDb::kRequiredSchemaVersion, MixxxDb::kDefaultSchemaFile);
     EXPECT_EQ(SchemaManager::Result::NewerVersionBackwardsCompatible, result);
 }
 
@@ -85,7 +85,7 @@ TEST_F(SchemaManagerTest, BackwardsIncompatibleVersion) {
         // Upgrade to version 1 to get the settings table.
         SchemaManager schemaManager(dbConnection());
         SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
-                MixxxDb::kDefaultSchemaFile, 1);
+                1, MixxxDb::kDefaultSchemaFile);
         EXPECT_EQ(SchemaManager::Result::UpgradeSucceeded, result);
 
         SettingsDAO settings(dbConnection());
@@ -93,14 +93,14 @@ TEST_F(SchemaManagerTest, BackwardsIncompatibleVersion) {
         // Pretend the database version is one past the required version and
         // min_compatible is one past the required version.
         settings.setValue(SchemaManager::SETTINGS_VERSION_STRING,
-                          MixxxDb::kRequiredSchemaVersion + 1);
+                MixxxDb::kRequiredSchemaVersion + 1);
         settings.setValue(SchemaManager::SETTINGS_MINCOMPATIBLE_STRING,
-                          MixxxDb::kRequiredSchemaVersion + 1);
+                MixxxDb::kRequiredSchemaVersion + 1);
     }
 
     SchemaManager schemaManager(dbConnection());
     SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
-            MixxxDb::kDefaultSchemaFile, MixxxDb::kRequiredSchemaVersion);
+            MixxxDb::kRequiredSchemaVersion, MixxxDb::kDefaultSchemaFile);
     EXPECT_EQ(SchemaManager::Result::NewerVersionIncompatible, result);
 }
 
@@ -110,18 +110,18 @@ TEST_F(SchemaManagerTest, IgnoreDuplicateColumn) {
         // Upgrade to version 3 to get the modern library table.
         SchemaManager schemaManager(dbConnection());
         SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
-                MixxxDb::kDefaultSchemaFile, 3);
+                3, MixxxDb::kDefaultSchemaFile);
         ASSERT_EQ(SchemaManager::Result::UpgradeSucceeded, result);
     }
 
     // Add a column that will be added again in version 24.
     QSqlQuery query(dbConnection());
-    ASSERT_TRUE(query.exec(
-            "ALTER TABLE library ADD COLUMN coverart_source TEXT"));
+    ASSERT_TRUE(
+            query.exec("ALTER TABLE library ADD COLUMN coverart_source TEXT"));
 
     SchemaManager schemaManager(dbConnection());
     SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
-            MixxxDb::kDefaultSchemaFile, MixxxDb::kRequiredSchemaVersion);
+            MixxxDb::kRequiredSchemaVersion, MixxxDb::kDefaultSchemaFile);
     EXPECT_EQ(SchemaManager::Result::UpgradeSucceeded, result);
 }
 
@@ -131,17 +131,16 @@ TEST_F(SchemaManagerTest, UpgradeFailed) {
         // Upgrade to version 3 to get the modern library table.
         SchemaManager schemaManager(dbConnection());
         SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
-                MixxxDb::kDefaultSchemaFile, 3);
+                3, MixxxDb::kDefaultSchemaFile);
         EXPECT_EQ(SchemaManager::Result::UpgradeSucceeded, result);
     }
 
     // Drop a table that is expected to exist.
     QSqlQuery query(dbConnection());
-    EXPECT_TRUE(query.exec(
-            "DROP TABLE PlaylistTracks"));
+    EXPECT_TRUE(query.exec("DROP TABLE PlaylistTracks"));
 
     SchemaManager schemaManager(dbConnection());
     SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
-            MixxxDb::kDefaultSchemaFile, MixxxDb::kRequiredSchemaVersion);
+            MixxxDb::kRequiredSchemaVersion, MixxxDb::kDefaultSchemaFile);
     EXPECT_EQ(SchemaManager::Result::UpgradeFailed, result);
 }

--- a/src/track/trackid.h
+++ b/src/track/trackid.h
@@ -1,9 +1,6 @@
-#ifndef TRACKID_H
-#define TRACKID_H
-
+#pragma once
 
 #include "util/db/dbid.h"
-
 
 class TrackId: public DbId {
 public:
@@ -15,5 +12,3 @@ Q_DECLARE_TYPEINFO(TrackId, Q_MOVABLE_TYPE);
 Q_DECLARE_METATYPE(TrackId)
 
 typedef QList<TrackId> TrackIdList;
-
-#endif // TRACKID_H

--- a/src/util/db/dbconnectionpooler.h
+++ b/src/util/db/dbconnectionpooler.h
@@ -1,9 +1,6 @@
-#ifndef MIXXX_DBCONNECTIONPOOLER_H
-#define MIXXX_DBCONNECTIONPOOLER_H
-
+#pragma once
 
 #include "util/db/dbconnectionpool.h"
-
 
 namespace mixxx {
 
@@ -47,6 +44,3 @@ class DbConnectionPooler final {
 };
 
 } // namespace mixxx
-
-
-#endif // MIXXX_DBCONNECTIONPOOLER_H


### PR DESCRIPTION
Users are still pointed to some ancient mailing list no-one uses anymore.
I changed "contact" to "consult" rather than "see" because it is reasonably general and thus allows us to point to almost anything without having to change the wording again.