### PR TITLE
Print leaked controls before DEBUG_ASSERT

### DIFF
--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -811,7 +811,7 @@ void MixxxMainWindow::finalize() {
     {
         QList<QSharedPointer<ControlDoublePrivate>> leakedControls =
                 ControlDoublePrivate::takeAllInstances();
-        VERIFY_OR_DEBUG_ASSERT(leakedControls.isEmpty()) {
+        if (!leakedControls.isEmpty()) {
             qWarning()
                     << "The following"
                     << leakedControls.size()
@@ -827,6 +827,7 @@ void MixxxMainWindow::finalize() {
                     pCDP->deleteCreatorCO();
                 }
             }
+            DEBUG_ASSERT(!"Controls were leaked!");
         }
         // Finally drop all shared pointers by exiting this scope
     }


### PR DESCRIPTION
This allows us to actually see the list of leaked controls even if
DEBUG_ASSERTIONS_FATAL is enabled.