### PR TITLE
Use low priority in library analyze queue

### DIFF
--- a/src/analyzer/analyzerthread.cpp
+++ b/src/analyzer/analyzerthread.cpp
@@ -78,7 +78,9 @@ AnalyzerThread::AnalyzerThread(
         mixxx::DbConnectionPoolPtr dbConnectionPool,
         UserSettingsPointer pConfig,
         AnalyzerModeFlags modeFlags)
-        : WorkerThread(QString("AnalyzerThread %1").arg(id)),
+        : WorkerThread(
+            QString("AnalyzerThread %1").arg(id),
+            (modeFlags & AnalyzerModeFlags::LowPriority ? QThread::LowPriority : QThread::InheritPriority)),
           m_id(id),
           m_dbConnectionPool(std::move(dbConnectionPool)),
           m_pConfig(pConfig),
@@ -87,9 +89,6 @@ AnalyzerThread::AnalyzerThread(
           m_sampleBuffer(mixxx::kAnalysisSamplesPerChunk),
           m_emittedState(AnalyzerThreadState::Void) {
     std::call_once(registerMetaTypesOnceFlag, registerMetaTypesOnce);
-    if (modeFlags & AnalyzerModeFlags::LowPriority) {
-        setPriority(QThread::LowPriority);
-    }
 }
 
 void AnalyzerThread::doRun() {

--- a/src/analyzer/analyzerthread.cpp
+++ b/src/analyzer/analyzerthread.cpp
@@ -87,6 +87,9 @@ AnalyzerThread::AnalyzerThread(
           m_sampleBuffer(mixxx::kAnalysisSamplesPerChunk),
           m_emittedState(AnalyzerThreadState::Void) {
     std::call_once(registerMetaTypesOnceFlag, registerMetaTypesOnce);
+    if (modeFlags & AnalyzerModeFlags::LowPriority) {
+        setPriority(QThread::LowPriority);
+    }
 }
 
 void AnalyzerThread::doRun() {

--- a/src/analyzer/analyzerthread.h
+++ b/src/analyzer/analyzerthread.h
@@ -19,6 +19,7 @@ enum AnalyzerModeFlags {
     None = 0x00,
     WithBeats = 0x01,
     WithWaveform = 0x02,
+    LowPriority = 0x04,
     All = WithBeats | WithWaveform,
 };
 

--- a/src/analyzer/trackanalysisscheduler.cpp
+++ b/src/analyzer/trackanalysisscheduler.cpp
@@ -63,7 +63,10 @@ TrackAnalysisScheduler::TrackAnalysisScheduler(
         kLogger.debug()
                 << "Starting"
                 << numWorkerThreads
-                << "worker threads";
+                << "worker threads. Ideal: "
+                << QThread::idealThreadCount()
+                << ". Priority: "
+                << (modeFlags & AnalyzerModeFlags::LowPriority ? "low" : "normal");
     }
     // 1st pass: Create worker threads
     m_workers.reserve(numWorkerThreads);

--- a/src/library/analysisfeature.cpp
+++ b/src/library/analysisfeature.cpp
@@ -40,7 +40,7 @@ AnalyzerModeFlags getAnalyzerModeFlags(
     // NOTE(uklotzde, 2018-12-26): The previous comment just states the status-quo
     // of the existing code. We should rethink the configuration of analyzers when
     // refactoring/redesigning the analyzer framework.
-    int modeFlags = AnalyzerModeFlags::WithBeats;
+    int modeFlags = AnalyzerModeFlags::WithBeats | AnalyzerModeFlags::LowPriority;
     if (pConfig->getValue<bool>(ConfigKey("[Library]", "EnableWaveformGenerationWithAnalysis"), true)) {
         modeFlags |= AnalyzerModeFlags::WithWaveform;
     }

--- a/src/util/workerthread.cpp
+++ b/src/util/workerthread.cpp
@@ -19,8 +19,10 @@ std::atomic<int> s_threadCounter(0);
 } // anonymous namespace
 
 WorkerThread::WorkerThread(
-        const QString& name)
+        const QString& name,
+        const QThread::Priority priority)
         : m_name(name),
+          m_priority(priority),
           m_logger(m_name.isEmpty() ? "WorkerThread" : m_name.toLatin1().constData()),
           m_suspend(false),
           m_stop(false) {
@@ -58,6 +60,11 @@ void WorkerThread::run() {
     const QString threadName =
             m_name.isEmpty() ? QString::number(threadNumber) : QString("%1 #%2").arg(m_name, QString::number(threadNumber));
     QThread::currentThread()->setObjectName(threadName);
+
+    if (m_priority != QThread::InheritPriority) {
+        m_logger.debug() << "Set priority to: " << m_priority;
+        setPriority(m_priority);
+    }
 
     m_logger.debug() << "Running";
 

--- a/src/util/workerthread.h
+++ b/src/util/workerthread.h
@@ -30,7 +30,8 @@ class WorkerThread : public QThread {
 
   public:
     explicit WorkerThread(
-            const QString& name = QString());
+            const QString& name = QString(),
+            QThread::Priority priority = QThread::InheritPriority);
     /// The destructor must be triggered by calling deleteLater() to
     /// ensure that the thread has already finished and is not running
     /// while destroyed! Connect finished() to deleteAfter() and then
@@ -134,6 +135,7 @@ class WorkerThread : public QThread {
 
   private:
     const QString m_name;
+    QThread::Priority m_priority;
 
     const mixxx::Logger m_logger;
 


### PR DESCRIPTION
The TrackAnalysisScheduler for the library analyze queue uses all CPU cores
which speeds up analysis a lot. Unfortunately those threads fight
heavy with the rest of mixxx when decks are running.
The new LowPriority AnalyzerMode schedules the analyzer thread in QThread::LowPriority
and therefor the other threads more CPU time.
No more skipping audio and super laggy GUI.