### PR TITLE
mixer/playerinfo: Make implicit PlayerInfo creation explicit

### DIFF
--- a/src/mixer/playerinfo.cpp
+++ b/src/mixer/playerinfo.cpp
@@ -42,9 +42,17 @@ PlayerInfo::~PlayerInfo() {
     clearControlCache();
 }
 
+PlayerInfo& PlayerInfo::create() {
+    VERIFY_OR_DEBUG_ASSERT(!s_pPlayerInfo) {
+        return *s_pPlayerInfo;
+    }
+    s_pPlayerInfo = new PlayerInfo();
+    return *s_pPlayerInfo;
+}
+
 // static
 PlayerInfo& PlayerInfo::instance() {
-    if (!s_pPlayerInfo) {
+    VERIFY_OR_DEBUG_ASSERT(s_pPlayerInfo) {
         s_pPlayerInfo = new PlayerInfo();
     }
     return *s_pPlayerInfo;

--- a/src/mixer/playerinfo.h
+++ b/src/mixer/playerinfo.h
@@ -28,6 +28,7 @@
 class PlayerInfo : public QObject {
     Q_OBJECT
   public:
+    static PlayerInfo& create();
     static PlayerInfo& instance();
     static void destroy();
     TrackPointer getTrackInfo(const QString& group);

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -321,6 +321,7 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
             &PlayerManager::noVinylControlInputConfigured,
             this,
             &MixxxMainWindow::slotNoVinylControlInputConfigured);
+    PlayerInfo::create();
 
     for (int i = 0; i < kMicrophoneCount; ++i) {
         m_pPlayerManager->addMicrophone();

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -1,19 +1,21 @@
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
-
-#include <QString>
-#include <QScopedPointer>
-
-#include "test/librarytest.h"
 #include "library/autodj/autodjprocessor.h"
-#include "control/controlpushbutton.h"
-#include "control/controlpotmeter.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <QScopedPointer>
+#include <QString>
+
 #include "control/controllinpotmeter.h"
+#include "control/controlpotmeter.h"
+#include "control/controlpushbutton.h"
 #include "engine/engine.h"
-#include "mixer/playermanager.h"
 #include "mixer/basetrackplayer.h"
-#include "track/track.h"
+#include "mixer/playerinfo.h"
+#include "mixer/playermanager.h"
 #include "sources/soundsourceproxy.h"
+#include "test/librarytest.h"
+#include "track/track.h"
 
 using ::testing::_;
 using ::testing::Return;
@@ -187,6 +189,7 @@ class AutoDJProcessorTest : public LibraryTest {
         }
 
         pPlayerManager.reset(new MockPlayerManager());
+        PlayerInfo::create();
 
         // Setup 4 fake decks.
         ON_CALL(*pPlayerManager, getPlayer(QString("[Channel1]")))
@@ -210,6 +213,7 @@ class AutoDJProcessorTest : public LibraryTest {
     }
 
     virtual ~AutoDJProcessorTest() {
+        PlayerInfo::destroy();
     }
 
     TrackId addTrackToCollection(const QString& trackLocation) {

--- a/src/test/signalpathtest.h
+++ b/src/test/signalpathtest.h
@@ -1,25 +1,25 @@
-#ifndef ENGINEBACKENDTEST_H_
-#define ENGINEBACKENDTEST_H_
+#pragma once
 
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
-#include <QtDebug>
 #include <QTest>
+#include <QtDebug>
 
-#include "preferences/usersettings.h"
 #include "control/controlobject.h"
-#include "mixer/deck.h"
 #include "effects/effectsmanager.h"
-#include "engine/enginebuffer.h"
 #include "engine/bufferscalers/enginebufferscale.h"
 #include "engine/channels/enginechannel.h"
 #include "engine/channels/enginedeck.h"
-#include "engine/enginemaster.h"
 #include "engine/controls/ratecontrol.h"
+#include "engine/enginebuffer.h"
+#include "engine/enginemaster.h"
 #include "engine/sync/enginesync.h"
+#include "mixer/deck.h"
+#include "mixer/playerinfo.h"
 #include "mixer/previewdeck.h"
 #include "mixer/sampler.h"
+#include "preferences/usersettings.h"
 #include "test/mixxxtest.h"
 #include "util/defs.h"
 #include "util/memory.h"
@@ -94,6 +94,8 @@ class BaseSignalPathTest : public MixxxTest {
 
         m_pEngineSync = m_pEngineMaster->getEngineSync();
         ControlObject::set(ConfigKey("[Master]", "enabled"), 1.0);
+
+        PlayerInfo::create();
     }
 
     ~BaseSignalPathTest() override {
@@ -111,6 +113,7 @@ class BaseSignalPathTest : public MixxxTest {
         delete m_pEffectsManager;
         delete m_pVisualsManager;
         delete m_pNumDecks;
+        PlayerInfo::destroy();
     }
 
     void addDeck(EngineDeck* pDeck) {
@@ -234,5 +237,3 @@ class SignalPathTest : public BaseSignalPathTest {
         loadTrack(m_pMixerDeck3, pTrack);
     }
 };
-
-#endif /* ENGINEBACKENDTEST_H_ */


### PR DESCRIPTION
Until now, the `PlayerInfo` singleton was instantiated implicitly when
it was first accessed. This commit makes the instantiation explicit by
adding a dedicated `PlayerInfo::create()` method.

When running tests directly via `mixxx-test` (i.e. not a via `ctest`),
all tests will be executed in the *same* process. Thus, the singleton
will be instantiated by the first test that accessses the instance, but
stay alive until `mixxx-test` is terminated.

The `PlayerInfo` instance will repeatedly call
`updateCurrentlyPlayingDeck()` through the `timerEvent()` mehtod during
its lifetime. This will access some COs, e.g. `[Master],num_decks`.
Depending on the currently running test, these COs may or may not be
present. When `QCoreApplication::processEvents()` is called, there might
be a `timerEvent()` in the queue and will cause CO access.  If the CO is
*not* present for that test, the test will throw a `DEBUG_ASSERT`.

By making the singleton instantiation more explicit, we can add
`PlayerInfo::create()` and `PlayerInfo::destroy()` calls only to the
constructor/destructor of text fixtures that need it, and ensure that
the timer doesn't cause failed debug assertions in unrelated tests.

This fixes the remaining `DEBUG_ASSERT` issues and paves the way for
merging PR #2911.