### PR TITLE
double-click WTrackProperty to open DlgTrackInfo

### DIFF
--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -67,6 +67,7 @@ class WTrackMenu : public QMenu {
     // WARNING: This function hides non-virtual QMenu::popup().
     // This has been done on purpose to ensure menu doesn't popup without loaded track(s).
     void popup(const QPoint& pos, QAction* at = nullptr);
+    void slotShowTrackInfo();
 
   signals:
     void loadTrackToPlayer(TrackPointer pTrack, QString group, bool play = false);
@@ -97,7 +98,6 @@ class WTrackMenu : public QMenu {
     void slotScaleBpm(int);
 
     // Info and metadata
-    void slotShowTrackInfo();
     void slotShowDlgTagFetcher();
     void slotImportMetadataFromFileTags();
     void slotExportMetadataIntoFileTags();

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -83,6 +83,13 @@ void WTrackProperty::mouseMoveEvent(QMouseEvent *event) {
         DragAndDropHelper::dragTrack(m_pCurrentTrack, this, m_group);
     }
 }
+void WTrackProperty::mouseDoubleClickEvent(QMouseEvent* event) {
+    Q_UNUSED(event);
+    if (m_pCurrentTrack) {
+        m_pTrackMenu->loadTrack(m_pCurrentTrack);
+        m_pTrackMenu->slotShowTrackInfo();
+    }
+}
 
 void WTrackProperty::dragEnterEvent(QDragEnterEvent *event) {
     DragAndDropHelper::handleTrackDragEnterEvent(event, m_group, m_pConfig);

--- a/src/widget/wtrackproperty.h
+++ b/src/widget/wtrackproperty.h
@@ -42,6 +42,7 @@ signals:
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dropEvent(QDropEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
+    void mouseDoubleClickEvent(QMouseEvent* event) override;
 
     void updateLabel();
 

--- a/src/widget/wtracktext.cpp
+++ b/src/widget/wtracktext.cpp
@@ -75,6 +75,14 @@ void WTrackText::mouseMoveEvent(QMouseEvent *event) {
     }
 }
 
+void WTrackText::mouseDoubleClickEvent(QMouseEvent* event) {
+    Q_UNUSED(event);
+    if (m_pCurrentTrack) {
+        m_pTrackMenu->loadTrack(m_pCurrentTrack);
+        m_pTrackMenu->slotShowTrackInfo();
+    }
+}
+
 void WTrackText::dragEnterEvent(QDragEnterEvent *event) {
     DragAndDropHelper::handleTrackDragEnterEvent(event, m_group, m_pConfig);
 }

--- a/src/widget/wtracktext.h
+++ b/src/widget/wtracktext.h
@@ -39,6 +39,7 @@ class WTrackText : public WLabel, public TrackDropTarget {
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dropEvent(QDropEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
+    void mouseDoubleClickEvent(QMouseEvent* event) override;
 
     void updateLabel();
 


### PR DESCRIPTION
Double-click any track property label in decks to quickly open the track metadata editor popup.
applies to WTrackProperty and WTrackText

Discussed there https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/Track.20property.3A.20quick.20edit.20mode.20in.20decks