### PR TITLE
Create a ControlObject function to actuate buttons programmatically

### DIFF
--- a/src/control/controlobject.cpp
+++ b/src/control/controlobject.cpp
@@ -122,7 +122,15 @@ void ControlObject::setParameterFrom(double v, QObject* pSender) {
 void ControlObject::set(const ConfigKey& key, const double& value) {
     QSharedPointer<ControlDoublePrivate> pCop = ControlDoublePrivate::getControl(key);
     if (pCop) {
-        pCop->set(value, NULL);
+        pCop->set(value, nullptr);
+    }
+}
+
+void ControlObject::toggle(const ConfigKey& key) {
+    QSharedPointer<ControlDoublePrivate> pCop = ControlDoublePrivate::getControl(key);
+    if (pCop) {
+        pCop->set(1, nullptr);
+        pCop->set(0, nullptr);
     }
 }
 

--- a/src/control/controlobject.h
+++ b/src/control/controlobject.h
@@ -110,6 +110,9 @@ class ControlObject : public QObject {
     // Instantly sets the value of the ControlObject
     static void set(const ConfigKey& key, const double& value);
 
+    // Instantly sets the value of the ControlObject to 1 and then to 0
+    static void toggle(const ConfigKey& key);
+
     // Sets the default value
     inline void reset() {
         if (m_pControl) {


### PR DESCRIPTION
If you want to trigger a button CO repeatedly in code, you always have to set it's value back to 0 first - obviously, since you can't press a button that is being pressed. This helper method simplifies that.