### PR TITLE
History improvements

### DIFF
--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -262,19 +262,15 @@ int PlaylistDAO::deleteAllPlaylistsWithFewerTracks(
     auto deleteTracks = FwdSqlQuery(m_database,
             QString("DELETE FROM PlaylistTracks WHERE playlist_id IN (%1)")
                     .arg(idString));
-    if (deleteTracks.hasError()) {
-        LOG_FAILED_QUERY(deleteTracks);
+    if (!deleteTracks.execPrepared()) {
         return -1;
     }
-    deleteTracks.execPrepared();
 
     auto deletePlaylists = FwdSqlQuery(m_database,
             QString("DELETE FROM Playlists WHERE id IN (%1)").arg(idString));
-    if (deletePlaylists.hasError()) {
-        LOG_FAILED_QUERY(deletePlaylists);
+    if (!deletePlaylists.execPrepared()) {
         return -1;
     }
-    deletePlaylists.execPrepared();
 
     return idStringList.length();
 }

--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -227,7 +227,7 @@ void PlaylistDAO::deletePlaylist(const int playlistId) {
     }
 }
 
-void PlaylistDAO::deleteEmptyPlaylists(const PlaylistDAO::HiddenType type) {
+void PlaylistDAO::deleteAllEmptyPlaylists(PlaylistDAO::HiddenType type) {
     //qDebug() << "PlaylistDAO::deletePlaylist" << QThread::currentThread() << m_database.connectionName();
     ScopedTransaction transaction(m_database);
 
@@ -237,7 +237,8 @@ void PlaylistDAO::deleteEmptyPlaylists(const PlaylistDAO::HiddenType type) {
     // Delete the row in the Playlists table.
     query.prepare(QStringLiteral(
             "DELETE FROM Playlists  "
-            "WHERE NOT EXISTS (SELECT playlist_id FROM PlaylistTracks WHERE Playlists.ID = PlaylistTracks.playlist_id) AND "
+            "WHERE NOT EXISTS (SELECT playlist_id FROM PlaylistTracks WHERE "
+            "Playlists.ID = PlaylistTracks.playlist_id) AND "
             "Playlists.hidden = :hidden"));
     query.bindValue(":hidden", static_cast<int>(type));
     if (!query.exec()) {

--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -229,8 +229,6 @@ void PlaylistDAO::deletePlaylist(const int playlistId) {
 
 void PlaylistDAO::deleteAllEmptyPlaylists(PlaylistDAO::HiddenType type) {
     //qDebug() << "PlaylistDAO::deletePlaylist" << QThread::currentThread() << m_database.connectionName();
-    ScopedTransaction transaction(m_database);
-
     // Get the playlist id for this
     QSqlQuery query(m_database);
 
@@ -245,8 +243,6 @@ void PlaylistDAO::deleteAllEmptyPlaylists(PlaylistDAO::HiddenType type) {
         LOG_FAILED_QUERY(query);
         return;
     }
-
-    transaction.commit();
 }
 
 void PlaylistDAO::renamePlaylist(const int playlistId, const QString& newName) {

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -59,8 +59,9 @@ class PlaylistDAO : public QObject, public virtual DAO {
     int createUniquePlaylist(QString* pName, const HiddenType type = PLHT_NOT_HIDDEN);
     // Delete a playlist
     void deletePlaylist(const int playlistId);
-    /// Deletes all empty Playlist
-    void deleteAllPlaylistsWithFewerItems(PlaylistDAO::HiddenType type, int length);
+    /// Delete Playlists with fewer entries then "length"
+    /// @return number of deleted playlists, -1 on error
+    int deleteAllPlaylistsWithFewerItems(PlaylistDAO::HiddenType type, int length);
     // Rename a playlist
     void renamePlaylist(const int playlistId, const QString& newName);
     // Lock or unlock a playlist

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -60,7 +60,7 @@ class PlaylistDAO : public QObject, public virtual DAO {
     // Delete a playlist
     void deletePlaylist(const int playlistId);
     /// Deletes all empty Playlist
-    void deleteAllEmptyPlaylists(PlaylistDAO::HiddenType type);
+    void deleteAllPlaylistsWithFewerItems(PlaylistDAO::HiddenType type, int length);
     // Rename a playlist
     void renamePlaylist(const int playlistId, const QString& newName);
     // Lock or unlock a playlist

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -59,8 +59,8 @@ class PlaylistDAO : public QObject, public virtual DAO {
     int createUniquePlaylist(QString* pName, const HiddenType type = PLHT_NOT_HIDDEN);
     // Delete a playlist
     void deletePlaylist(const int playlistId);
-    /// Deletes an empty Playlist
-    void deleteEmptyPlaylists(const PlaylistDAO::HiddenType type);
+    /// Deletes all empty Playlist
+    void deleteAllEmptyPlaylists(PlaylistDAO::HiddenType type);
     // Rename a playlist
     void renamePlaylist(const int playlistId, const QString& newName);
     // Lock or unlock a playlist

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -60,8 +60,9 @@ class PlaylistDAO : public QObject, public virtual DAO {
     // Delete a playlist
     void deletePlaylist(const int playlistId);
     /// Delete Playlists with fewer entries then "length"
+    /// Needs to be called inside a transaction.
     /// @return number of deleted playlists, -1 on error
-    int deleteAllPlaylistsWithFewerItems(PlaylistDAO::HiddenType type, int length);
+    int deleteAllPlaylistsWithFewerTracks(PlaylistDAO::HiddenType type, int minNumberOfTracks);
     // Rename a playlist
     void renamePlaylist(const int playlistId, const QString& newName);
     // Lock or unlock a playlist

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -59,6 +59,8 @@ class PlaylistDAO : public QObject, public virtual DAO {
     int createUniquePlaylist(QString* pName, const HiddenType type = PLHT_NOT_HIDDEN);
     // Delete a playlist
     void deletePlaylist(const int playlistId);
+    /// Deletes an empty Playlist
+    void deleteEmptyPlaylists(const PlaylistDAO::HiddenType type);
     // Rename a playlist
     void renamePlaylist(const int playlistId, const QString& newName);
     // Lock or unlock a playlist

--- a/src/library/queryutil.h
+++ b/src/library/queryutil.h
@@ -42,9 +42,14 @@ class ScopedTransaction {
             return false;
         }
         bool result = m_database.commit();
-        qDebug() << "Committing transaction on"
-                 << m_database.connectionName()
-                 << "result:" << result;
+        if (result) {
+            qDebug() << "Committing transaction successfully on"
+                     << m_database.connectionName();
+        } else {
+            qInfo() << "Committing transaction failed on"
+                    << m_database.connectionName()
+                    << ":" << m_database.lastError();
+        }
         m_active = false;
         return result;
     }

--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -374,8 +374,6 @@ bool SidebarModel::dragMoveAccept(const QModelIndex& index, const QUrl& url) {
 
 // Translates an index from the child models to an index of the sidebar models
 QModelIndex SidebarModel::translateSourceIndex(const QModelIndex& index) {
-    QModelIndex translatedIndex;
-
     /* These method is called from the slot functions below.
      * QObject::sender() return the object which emitted the signal
      * handled by the slot functions.
@@ -387,6 +385,13 @@ QModelIndex SidebarModel::translateSourceIndex(const QModelIndex& index) {
     VERIFY_OR_DEBUG_ASSERT(model != NULL) {
         return QModelIndex();
     }
+
+    return translateIndex(index, model);
+}
+
+QModelIndex SidebarModel::translateIndex(
+        const QModelIndex& index, const QAbstractItemModel* model) {
+    QModelIndex translatedIndex;
 
     if (index.isValid()) {
        TreeItem* item = (TreeItem*)index.internalPointer();

--- a/src/library/sidebarmodel.h
+++ b/src/library/sidebarmodel.h
@@ -40,6 +40,9 @@ class SidebarModel : public QAbstractItemModel {
     bool dragMoveAccept(const QModelIndex& index, const QUrl& url);
     bool hasChildren(const QModelIndex& parent = QModelIndex()) const override;
     bool hasTrackTable(const QModelIndex& index) const;
+    QModelIndex translateChildIndex(const QModelIndex& index) {
+        return translateIndex(index, index.model());
+    }
 
   public slots:
     void pressed(const QModelIndex& index);
@@ -76,6 +79,7 @@ class SidebarModel : public QAbstractItemModel {
 
   private:
     QModelIndex translateSourceIndex(const QModelIndex& parent);
+    QModelIndex translateIndex(const QModelIndex& index, const QAbstractItemModel* model);
     void featureRenamed(LibraryFeature*);
     QList<LibraryFeature*> m_sFeatures;
     unsigned int m_iDefaultSelectedIndex; /** Index of the item in the sidebar model to select at startup. */

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -173,14 +173,18 @@ void BasePlaylistFeature::selectPlaylistInSidebar(int playlistId) {
 void BasePlaylistFeature::activateChild(const QModelIndex& index) {
     //qDebug() << "BasePlaylistFeature::activateChild()" << index;
     int playlistId = playlistIdFromIndex(index);
-    if (playlistId != kInvalidPlaylistId) {
-        m_pPlaylistTableModel->setTableModel(playlistId);
-        emit showTrackModel(m_pPlaylistTableModel);
-        emit enableCoverArtDisplay(true);
-        if (m_pSidebarWidget) {
-            m_pSidebarWidget->selectChildIndex(index);
-        }
+    if (playlistId == kInvalidPlaylistId) {
+        return;
     }
+
+    m_pPlaylistTableModel->setTableModel(playlistId);
+    emit showTrackModel(m_pPlaylistTableModel);
+    emit enableCoverArtDisplay(true);
+
+    if (!m_pSidebarWidget) {
+        return;
+    }
+    m_pSidebarWidget->selectChildIndex(index);
 }
 
 void BasePlaylistFeature::activatePlaylist(int playlistId) {
@@ -189,15 +193,17 @@ void BasePlaylistFeature::activatePlaylist(int playlistId) {
         return;
     }
     QModelIndex index = indexFromPlaylistId(playlistId);
-    if (index.isValid()) {
-        m_lastRightClickedIndex = index;
-        m_pPlaylistTableModel->setTableModel(playlistId);
-        emit showTrackModel(m_pPlaylistTableModel);
-        emit enableCoverArtDisplay(true);
-        // Update selection
-        emit featureSelect(this, m_lastRightClickedIndex);
-        activateChild(m_lastRightClickedIndex);
+    if (!index.isValid()) {
+        return;
     }
+
+    m_lastRightClickedIndex = index;
+    m_pPlaylistTableModel->setTableModel(playlistId);
+    emit showTrackModel(m_pPlaylistTableModel);
+    emit enableCoverArtDisplay(true);
+    // Update selection
+    emit featureSelect(this, m_lastRightClickedIndex);
+    activateChild(m_lastRightClickedIndex);
 }
 
 void BasePlaylistFeature::slotRenamePlaylist() {
@@ -389,6 +395,7 @@ void BasePlaylistFeature::slotDeletePlaylist() {
 
     m_playlistDao.deletePlaylist(playlistId);
     activate();
+
     if (nextId != kInvalidPlaylistId) {
         activatePlaylist(nextId);
     }

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -706,8 +706,8 @@ void BasePlaylistFeature::markTreeItem(TreeItem* pTreeItem) {
     if (pTreeItem->hasChildren()) {
         QList<TreeItem*> children = pTreeItem->children();
 
-        for (auto i = children.constBegin(); i != children.constEnd(); ++i) {
-            markTreeItem(*i);
+        for (int i = 0; i < children.size(); i++) {
+            markTreeItem(children.at(i));
         }
     }
 }

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -359,7 +359,7 @@ void BasePlaylistFeature::slotDeletePlaylist() {
             if (m_pSidebarWidget) {
                 // FIXME: this does not scroll to the correct position for some reason
                 nextIndex = indexFromPlaylistId(nextId);
-                m_pSidebarWidget->scrollTo(nextIndex);
+                m_pSidebarWidget->selectIndex(nextIndex);
             }
         }
     }

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -333,7 +333,9 @@ void BasePlaylistFeature::slotCreatePlaylist() {
 void BasePlaylistFeature::slotDeletePlaylist() {
     //qDebug() << "slotDeletePlaylist() row:" << m_lastRightClickedIndex.data();
     int playlistId = playlistIdFromIndex(m_lastRightClickedIndex);
-    QModelIndex nextIndex = m_lastRightClickedIndex.sibling(m_lastRightClickedIndex.row() + 1, m_lastRightClickedIndex.column());
+    QModelIndex nextIndex =
+            m_lastRightClickedIndex.sibling(m_lastRightClickedIndex.row() + 1,
+                    m_lastRightClickedIndex.column());
     int nextId = playlistIdFromIndex(nextIndex);
     if (playlistId == -1) {
         return;

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -697,7 +697,8 @@ void BasePlaylistFeature::markTreeItem(TreeItem* pTreeItem) {
         pTreeItem->setBold(shouldBold);
         if (shouldBold && pTreeItem->hasParent()) {
             TreeItem* item = pTreeItem;
-            while (item = item->parent()) {
+            // extra parents, because -Werror=parentheses
+            while ((item = item->parent())) {
                 item->setBold(true);
             }
         }

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -24,7 +24,7 @@
 #include "widget/wlibrarytextbrowser.h"
 
 namespace {
-auto kUnsafeFilenameReplacement = QLatin1String("-");
+constexpr QChar kUnsafeFilenameReplacement = '-';
 }
 
 BasePlaylistFeature::BasePlaylistFeature(

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -351,10 +351,9 @@ void BasePlaylistFeature::slotDeletePlaylist() {
         if (nextId != -1) {
             activatePlaylist(nextId);
             if (m_pSidebarWidget) {
-                // FIXME: this index is for the current model of the feature, while
-                // the sidebar uses the sidebarmodel. Using the scrollTo on this index
-                // crashes the widget
-                // m_pSidebarWidget->scrollTo(next);
+                // FIXME: this does not scroll to the correct position for some reason
+                next = indexFromPlaylistId(nextId);
+                m_pSidebarWidget->scrollTo(next);
             }
         }
     }

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -367,8 +367,15 @@ int BasePlaylistFeature::selectSiblingPlaylistId(QModelIndex& start) {
 
 void BasePlaylistFeature::slotDeletePlaylist() {
     //qDebug() << "slotDeletePlaylist() row:" << m_lastRightClickedIndex.data();
+    if (!m_lastRightClickedIndex.isValid()) {
+        return;
+    }
+
     int playlistId = playlistIdFromIndex(m_lastRightClickedIndex);
     if (playlistId == kInvalidPlaylistId) {
+        return;
+    }
+    VERIFY_OR_DEBUG_ASSERT(playlistId >= 0) {
         return;
     }
 
@@ -378,17 +385,12 @@ void BasePlaylistFeature::slotDeletePlaylist() {
         return;
     }
 
-    if (m_lastRightClickedIndex.isValid()) {
-        VERIFY_OR_DEBUG_ASSERT(playlistId >= 0) {
-            return;
-        }
-        int nextId = selectSiblingPlaylistId(m_lastRightClickedIndex);
+    int nextId = selectSiblingPlaylistId(m_lastRightClickedIndex);
 
-        m_playlistDao.deletePlaylist(playlistId);
-        activate();
-        if (nextId != kInvalidPlaylistId) {
-            activatePlaylist(nextId);
-        }
+    m_playlistDao.deletePlaylist(playlistId);
+    activate();
+    if (nextId != kInvalidPlaylistId) {
+        activatePlaylist(nextId);
     }
 }
 

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -24,7 +24,7 @@
 #include "widget/wlibrarytextbrowser.h"
 
 namespace {
-const char* kUnsafeFilenameReplacement = "-";
+auto kUnsafeFilenameReplacement = QLatin1String("-");
 }
 
 BasePlaylistFeature::BasePlaylistFeature(
@@ -180,6 +180,8 @@ void BasePlaylistFeature::activateChild(const QModelIndex& index) {
     m_pPlaylistTableModel->setTableModel(playlistId);
     emit showTrackModel(m_pPlaylistTableModel);
     emit enableCoverArtDisplay(true);
+    // Update selection
+    emit featureSelect(this, m_lastRightClickedIndex);
 
     if (!m_pSidebarWidget) {
         return;
@@ -203,7 +205,10 @@ void BasePlaylistFeature::activatePlaylist(int playlistId) {
     emit enableCoverArtDisplay(true);
     // Update selection
     emit featureSelect(this, m_lastRightClickedIndex);
-    activateChild(m_lastRightClickedIndex);
+    if (!m_pSidebarWidget) {
+        return;
+    }
+    m_pSidebarWidget->selectChildIndex(m_lastRightClickedIndex);
 }
 
 void BasePlaylistFeature::slotRenamePlaylist() {

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -329,8 +329,8 @@ void BasePlaylistFeature::slotCreatePlaylist() {
 void BasePlaylistFeature::slotDeletePlaylist() {
     //qDebug() << "slotDeletePlaylist() row:" << m_lastRightClickedIndex.data();
     int playlistId = playlistIdFromIndex(m_lastRightClickedIndex);
-    QModelIndex next = m_lastRightClickedIndex.siblingAtRow(m_lastRightClickedIndex.row() + 1);
-    int nextId = playlistIdFromIndex(next);
+    QModelIndex nextIndex = m_lastRightClickedIndex.siblingAtRow(m_lastRightClickedIndex.row() + 1);
+    int nextId = playlistIdFromIndex(nextIndex);
     if (playlistId == -1) {
         return;
     }
@@ -352,8 +352,8 @@ void BasePlaylistFeature::slotDeletePlaylist() {
             activatePlaylist(nextId);
             if (m_pSidebarWidget) {
                 // FIXME: this does not scroll to the correct position for some reason
-                next = indexFromPlaylistId(nextId);
-                m_pSidebarWidget->scrollTo(next);
+                nextIndex = indexFromPlaylistId(nextId);
+                m_pSidebarWidget->scrollTo(nextIndex);
             }
         }
     }
@@ -653,14 +653,14 @@ void BasePlaylistFeature::clearChildModel() {
 
 QModelIndex BasePlaylistFeature::indexFromPlaylistId(int playlistId) {
     QVariant variantId = QVariant(playlistId);
-    auto results = m_childModel.match(
-                        m_childModel.getRootIndex(),
-                        TreeItemModel::kDataRole,
-                        variantId,
-                        1,
-                        Qt::MatchWrap | Qt::MatchExactly | Qt::MatchRecursive);
+    QModelIndexList results = m_childModel.match(
+                                m_childModel.getRootIndex(),
+                                TreeItemModel::kDataRole,
+                                variantId,
+                                1,
+                                Qt::MatchWrap | Qt::MatchExactly | Qt::MatchRecursive);
     qDebug() << "indexFromPlaylistId: len:" << results.length();
-    if (results.length()) {
+    if (!results.isEmpty()) {
         return results.front();
     }
     return QModelIndex();
@@ -698,10 +698,9 @@ void BasePlaylistFeature::markTreeItem(TreeItem* pTreeItem) {
         }
     }
     if (pTreeItem->hasChildren()) {
-        auto children = pTreeItem->children();
-        QList<TreeItem*>::const_iterator i;
+        QList<TreeItem*> children = pTreeItem->children();
 
-        for (i = children.constBegin(); i != children.constEnd(); ++i) {
+        for (auto i = children.constBegin(); i != children.constEnd(); ++i) {
             markTreeItem(*i);
         }
     }

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -607,44 +607,6 @@ void BasePlaylistFeature::htmlLinkClicked(const QUrl& link) {
     }
 }
 
-/**
-  * Purpose: When inserting or removing playlists,
-  * we require the sidebar model not to reset.
-  * This method queries the database and does dynamic insertion
-*/
-QModelIndex BasePlaylistFeature::constructChildModel(int selected_id) {
-    QList<TreeItem*> data_list;
-    int selected_row = -1;
-
-    int row = 0;
-    const QList<IdAndLabel> playlistLabels = createPlaylistLabels();
-    for (const auto& idAndLabel : playlistLabels) {
-        int playlistId = idAndLabel.id;
-        QString playlistLabel = idAndLabel.label;
-
-        if (selected_id == playlistId) {
-            // save index for selection
-            selected_row = row;
-        }
-
-        // Create the TreeItem whose parent is the invisible root item
-        TreeItem* item = new TreeItem(playlistLabel, playlistId);
-        item->setBold(m_playlistsSelectedTrackIsIn.contains(playlistId));
-
-        decorateChild(item, playlistId);
-        data_list.append(item);
-
-        ++row;
-    }
-
-    // Append all the newly created TreeItems in a dynamic way to the childmodel
-    m_childModel.insertTreeItemRows(data_list, 0);
-    if (selected_row == -1) {
-        return QModelIndex();
-    }
-    return m_childModel.index(selected_row, 0);
-}
-
 void BasePlaylistFeature::updateChildModel(int playlistId) {
     QString playlistLabel = fetchPlaylistLabel(playlistId);
 

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -23,6 +23,10 @@
 #include "widget/wlibrarysidebar.h"
 #include "widget/wlibrarytextbrowser.h"
 
+namespace {
+const char* kUnsafeFilenameReplacement = "-";
+}
+
 BasePlaylistFeature::BasePlaylistFeature(
         Library* pLibrary,
         UserSettingsPointer pConfig,
@@ -463,7 +467,7 @@ void BasePlaylistFeature::slotExportPlaylist() {
     }
     QString playlistName = m_playlistDao.getPlaylistName(playlistId);
     // replace separator character with something generic
-    playlistName = playlistName.replace(QDir::separator(), "-");
+    playlistName = playlistName.replace(QDir::separator(), kUnsafeFilenameReplacement);
     qDebug() << "Export playlist" << playlistName;
 
     QString lastPlaylistDirectory = m_pConfig->getValue(
@@ -654,12 +658,11 @@ void BasePlaylistFeature::clearChildModel() {
 QModelIndex BasePlaylistFeature::indexFromPlaylistId(int playlistId) {
     QVariant variantId = QVariant(playlistId);
     QModelIndexList results = m_childModel.match(
-                                m_childModel.getRootIndex(),
-                                TreeItemModel::kDataRole,
-                                variantId,
-                                1,
-                                Qt::MatchWrap | Qt::MatchExactly | Qt::MatchRecursive);
-    qDebug() << "indexFromPlaylistId: len:" << results.length();
+            m_childModel.getRootIndex(),
+            TreeItemModel::kDataRole,
+            variantId,
+            1,
+            Qt::MatchWrap | Qt::MatchExactly | Qt::MatchRecursive);
     if (!results.isEmpty()) {
         return results.front();
     }
@@ -687,7 +690,7 @@ void BasePlaylistFeature::slotTrackSelected(TrackPointer pTrack) {
 void BasePlaylistFeature::markTreeItem(TreeItem* pTreeItem) {
     bool ok;
     int playlistId = pTreeItem->getData().toInt(&ok);
-    if(ok) {
+    if (ok) {
         bool shouldBold = m_playlistsSelectedTrackIsIn.contains(playlistId);
         pTreeItem->setBold(shouldBold);
         if (shouldBold && pTreeItem->hasParent()) {

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -359,7 +359,7 @@ void BasePlaylistFeature::slotDeletePlaylist() {
             if (m_pSidebarWidget) {
                 // FIXME: this does not scroll to the correct position for some reason
                 nextIndex = indexFromPlaylistId(nextId);
-                m_pSidebarWidget->selectIndex(nextIndex);
+                m_pSidebarWidget->selectChildIndex(nextIndex);
             }
         }
     }

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -463,6 +463,8 @@ void BasePlaylistFeature::slotExportPlaylist() {
         return;
     }
     QString playlistName = m_playlistDao.getPlaylistName(playlistId);
+    // replace separator character with something generic
+    playlistName = playlistName.replace(QDir::separator(), "-");
     qDebug() << "Export playlist" << playlistName;
 
     QString lastPlaylistDirectory = m_pConfig->getValue(

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -185,8 +185,11 @@ void BasePlaylistFeature::activateChild(const QModelIndex& index) {
 
 void BasePlaylistFeature::activatePlaylist(int playlistId) {
     // qDebug() << "BasePlaylistFeature::activatePlaylist()" << playlistId;
+    if (playlistId == kInvalidPlaylistId) {
+        return;
+    }
     QModelIndex index = indexFromPlaylistId(playlistId);
-    if (playlistId != kInvalidPlaylistId && index.isValid()) {
+    if (index.isValid()) {
         m_lastRightClickedIndex = index;
         m_pPlaylistTableModel->setTableModel(playlistId);
         emit showTrackModel(m_pPlaylistTableModel);

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -702,7 +702,7 @@ void BasePlaylistFeature::slotTrackSelected(TrackPointer pTrack) {
     if (pTrack) {
         trackId = pTrack->getId();
     }
-    m_playlistDao.getPlaylistsTrackIsIn(trackId, &m_playlistsSelectedTrackIsIn);
+    m_playlistDao.getPlaylistsTrackIsIn(trackId, &m_playlistIdsOfSelectedTrack);
 
     for (int row = 0; row < m_childModel.rowCount(); ++row) {
         QModelIndex index = m_childModel.index(row, 0);
@@ -718,7 +718,7 @@ void BasePlaylistFeature::markTreeItem(TreeItem* pTreeItem) {
     bool ok;
     int playlistId = pTreeItem->getData().toInt(&ok);
     if (ok) {
-        bool shouldBold = m_playlistsSelectedTrackIsIn.contains(playlistId);
+        bool shouldBold = m_playlistIdsOfSelectedTrack.contains(playlistId);
         pTreeItem->setBold(shouldBold);
         if (shouldBold && pTreeItem->hasParent()) {
             TreeItem* item = pTreeItem;

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -697,7 +697,7 @@ void BasePlaylistFeature::markTreeItem(TreeItem* pTreeItem) {
         pTreeItem->setBold(shouldBold);
         if (shouldBold && pTreeItem->hasParent()) {
             TreeItem* item = pTreeItem;
-            while ((item = item->parent())) {
+            while (item = item->parent()) {
                 item->setBold(true);
             }
         }

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -333,7 +333,7 @@ void BasePlaylistFeature::slotCreatePlaylist() {
 void BasePlaylistFeature::slotDeletePlaylist() {
     //qDebug() << "slotDeletePlaylist() row:" << m_lastRightClickedIndex.data();
     int playlistId = playlistIdFromIndex(m_lastRightClickedIndex);
-    QModelIndex nextIndex = m_lastRightClickedIndex.siblingAtRow(m_lastRightClickedIndex.row() + 1);
+    QModelIndex nextIndex = m_lastRightClickedIndex.sibling(m_lastRightClickedIndex.row() + 1, m_lastRightClickedIndex.column());
     int nextId = playlistIdFromIndex(nextIndex);
     if (playlistId == -1) {
         return;

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -114,17 +114,11 @@ void BasePlaylistFeature::initActions() {
     connect(&m_playlistDao,
             &PlaylistDAO::added,
             this,
-            [this](int playlistId) {
-                slotPlaylistTableChanged(playlistId);
-                selectPlaylistInSidebar(playlistId);
-            });
+            &BasePlaylistFeature::slotPlaylistTableChangedAndSelect);
     connect(&m_playlistDao,
             &PlaylistDAO::lockChanged,
             this,
-            [this](int playlistId) {
-                slotPlaylistTableChanged(playlistId);
-                selectPlaylistInSidebar(playlistId);
-            });
+            &BasePlaylistFeature::slotPlaylistTableChangedAndSelect);
     connect(&m_playlistDao,
             &PlaylistDAO::deleted,
             this,

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -346,6 +346,22 @@ void BasePlaylistFeature::slotCreatePlaylist() {
     }
 }
 
+/// Returns a playlist that is a sibling inside the same parent
+/// as the start index
+int BasePlaylistFeature::selectSiblingPlaylistId(QModelIndex& start) {
+    for (int i = start.row() + 1; i >= (start.row() - 1); i -= 2) {
+        QModelIndex nextIndex = start.sibling(i, start.column());
+        if (nextIndex.isValid()) {
+            TreeItem* pTreeItem = m_childModel.getItem(nextIndex);
+            DEBUG_ASSERT(pTreeItem != nullptr);
+            if (!pTreeItem->hasChildren()) {
+                return playlistIdFromIndex(nextIndex);
+            }
+        }
+    }
+    return kInvalidPlaylistId;
+}
+
 void BasePlaylistFeature::slotDeletePlaylist() {
     //qDebug() << "slotDeletePlaylist() row:" << m_lastRightClickedIndex.data();
     int playlistId = playlistIdFromIndex(m_lastRightClickedIndex);
@@ -363,6 +379,7 @@ void BasePlaylistFeature::slotDeletePlaylist() {
         VERIFY_OR_DEBUG_ASSERT(playlistId >= 0) {
             return;
         }
+        int nextId = selectSiblingPlaylistId(m_lastRightClickedIndex);
 
         m_playlistDao.deletePlaylist(playlistId);
         activate();
@@ -629,6 +646,7 @@ void BasePlaylistFeature::bindLibraryWidget(WLibrary* libraryWidget,
 
 void BasePlaylistFeature::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
     // store the sidebar widget pointer for later use in onRightClickChild
+    DEBUG_ASSERT(!m_pSidebarWidget);
     m_pSidebarWidget = pSidebarWidget;
 }
 

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -21,7 +21,7 @@ class TrackCollectionManager;
 class TreeItem;
 class WLibrarySidebar;
 
-const int kInvalidPlaylistId = -1;
+constexpr int kInvalidPlaylistId = -1;
 
 class BasePlaylistFeature : public BaseTrackSetFeature {
     Q_OBJECT

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -4,8 +4,8 @@
 #include <QList>
 #include <QModelIndex>
 #include <QObject>
-#include <QPointer>
 #include <QPair>
+#include <QPointer>
 #include <QSet>
 #include <QString>
 #include <QUrl>

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -4,6 +4,7 @@
 #include <QList>
 #include <QModelIndex>
 #include <QObject>
+#include <QPointer>
 #include <QPair>
 #include <QSet>
 #include <QString>
@@ -18,6 +19,7 @@ class KeyboardEventFilter;
 class PlaylistTableModel;
 class TrackCollectionManager;
 class TreeItem;
+class WLibrarySidebar;
 
 class BasePlaylistFeature : public BaseTrackSetFeature {
     Q_OBJECT
@@ -33,6 +35,7 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
 
     void bindLibraryWidget(WLibrary* libraryWidget,
             KeyboardEventFilter* keyboard) override;
+    void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
 
   public slots:
     void activateChild(const QModelIndex& index) override;
@@ -79,6 +82,7 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
 
     PlaylistDAO& m_playlistDao;
     QModelIndex m_lastRightClickedIndex;
+    QPointer<WLibrarySidebar> m_pSidebarWidget;
 
     QAction* m_pCreatePlaylistAction;
     QAction* m_pDeletePlaylistAction;
@@ -104,6 +108,7 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
   private:
     void initActions();
     virtual QString getRootViewHtml() const = 0;
+    void markTreeItem(TreeItem* pTreeItem);
 
     TrackPointer m_pSelectedTrack;
 };

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -36,6 +36,7 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     void bindLibraryWidget(WLibrary* libraryWidget,
             KeyboardEventFilter* keyboard) override;
     void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
+    void selectPlaylistInSidebar(int playlistId);
 
   public slots:
     void activateChild(const QModelIndex& index) override;

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -107,7 +107,7 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     QAction* m_pAnalyzePlaylistAction;
 
     PlaylistTableModel* m_pPlaylistTableModel;
-    QSet<int> m_playlistsSelectedTrackIsIn;
+    QSet<int> m_playlistIdsOfSelectedTrack;
 
   private slots:
     void slotTrackSelected(TrackPointer pTrack);

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -102,11 +102,12 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     void slotTrackSelected(TrackPointer pTrack);
     void slotResetSelectedTrack();
 
+  protected:
+    QSet<int> m_playlistsSelectedTrackIsIn;
+
   private:
     void initActions();
     virtual QString getRootViewHtml() const = 0;
 
     TrackPointer m_pSelectedTrack;
-
-    QSet<int> m_playlistsSelectedTrackIsIn;
 };

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -21,6 +21,8 @@ class TrackCollectionManager;
 class TreeItem;
 class WLibrarySidebar;
 
+const int kInvalidPlaylistId = -1;
+
 class BasePlaylistFeature : public BaseTrackSetFeature {
     Q_OBJECT
 

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -38,8 +38,8 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     void bindLibraryWidget(WLibrary* libraryWidget,
             KeyboardEventFilter* keyboard) override;
     void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
-    void selectPlaylistInSidebar(int playlistId);
-    int selectSiblingPlaylistId(QModelIndex& start);
+    void selectPlaylistInSidebar(int playlistId, bool select = true);
+    int getSiblingPlaylistIdOf(QModelIndex& start);
 
   public slots:
     void activateChild(const QModelIndex& index) override;
@@ -50,6 +50,10 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     void slotPlaylistTableChangedAndSelect(int playlistId) {
         slotPlaylistTableChanged(playlistId);
         selectPlaylistInSidebar(playlistId);
+    };
+    void slotPlaylistTableChangedAndScrollTo(int playlistId) {
+        slotPlaylistTableChanged(playlistId);
+        selectPlaylistInSidebar(playlistId, false);
     };
     virtual void slotPlaylistTableRenamed(int playlistId, const QString& newName) = 0;
     virtual void slotPlaylistContentChanged(QSet<int> playlistIds) = 0;

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -44,6 +44,10 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     virtual void htmlLinkClicked(const QUrl& link);
 
     virtual void slotPlaylistTableChanged(int playlistId) = 0;
+    void slotPlaylistTableChangedAndSelect(int playlistId) {
+        slotPlaylistTableChanged(playlistId);
+        selectPlaylistInSidebar(playlistId);
+    };
     virtual void slotPlaylistTableRenamed(int playlistId, const QString& newName) = 0;
     virtual void slotPlaylistContentChanged(QSet<int> playlistIds) = 0;
     void slotCreatePlaylist();

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -39,6 +39,7 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
             KeyboardEventFilter* keyboard) override;
     void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
     void selectPlaylistInSidebar(int playlistId);
+    int selectSiblingPlaylistId(QModelIndex& start);
 
   public slots:
     void activateChild(const QModelIndex& index) override;

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -66,10 +66,8 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
         QString label;
     };
 
-    virtual QModelIndex constructChildModel(int selected_id);
     virtual void updateChildModel(int selected_id);
     virtual void clearChildModel();
-    virtual QList<IdAndLabel> createPlaylistLabels() = 0;
     virtual QString fetchPlaylistLabel(int playlistId) = 0;
     virtual void decorateChild(TreeItem* pChild, int playlistId) = 0;
     virtual void addToAutoDJ(PlaylistDAO::AutoDJSendLoc loc);
@@ -97,13 +95,11 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     QAction* m_pAnalyzePlaylistAction;
 
     PlaylistTableModel* m_pPlaylistTableModel;
+    QSet<int> m_playlistsSelectedTrackIsIn;
 
   private slots:
     void slotTrackSelected(TrackPointer pTrack);
     void slotResetSelectedTrack();
-
-  protected:
-    QSet<int> m_playlistsSelectedTrackIsIn;
 
   private:
     void initActions();

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -57,11 +57,6 @@ QIcon PlaylistFeature::getIcon() {
     return m_icon;
 }
 
-void PlaylistFeature::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
-    // store the sidebar widget pointer for later use in onRightClickChild
-    m_pSidebarWidget = pSidebarWidget;
-}
-
 void PlaylistFeature::onRightClick(const QPoint& globalPos) {
     m_lastRightClickedIndex = QModelIndex();
     QMenu menu(m_pSidebarWidget);

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -252,7 +252,7 @@ QModelIndex PlaylistFeature::constructChildModel(int selectedId) {
 
         // Create the TreeItem whose parent is the invisible root item
         TreeItem* item = new TreeItem(playlistLabel, playlistId);
-        item->setBold(m_playlistsSelectedTrackIsIn.contains(playlistId));
+        item->setBold(m_playlistIdsOfSelectedTrack.contains(playlistId));
 
         decorateChild(item, playlistId);
         data_list.append(item);

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -240,7 +240,8 @@ QModelIndex PlaylistFeature::constructChildModel(int selectedId) {
     int selectedRow = -1;
 
     int row = 0;
-    for (const IdAndLabel& idAndLabel : createPlaylistLabels()) {
+    const QList<IdAndLabel> playlistLabels = createPlaylistLabels();
+    for (const auto& idAndLabel : playlistLabels) {
         int playlistId = idAndLabel.id;
         QString playlistLabel = idAndLabel.label;
 

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -46,7 +46,7 @@ PlaylistFeature::PlaylistFeature(Library* pLibrary, UserSettingsPointer pConfig)
     // construct child model
     std::unique_ptr<TreeItem> pRootItem = TreeItem::newRoot(this);
     m_childModel.setRootItem(std::move(pRootItem));
-    constructChildModel(-1);
+    constructChildModel(kInvalidPlaylistId);
 }
 
 QVariant PlaylistFeature::title() {

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -231,12 +231,10 @@ QString PlaylistFeature::fetchPlaylistLabel(int playlistId) {
     return QString();
 }
 
-/**
-  * Purpose: When inserting or removing playlists,
-  * we require the sidebar model not to reset.
-  * This method queries the database and does dynamic insertion
-  * @param selectedId entry which should be selected
-*/
+/// Purpose: When inserting or removing playlists,
+/// we require the sidebar model not to reset.
+/// This method queries the database and does dynamic insertion
+/// @param selectedId entry which should be selected
 QModelIndex PlaylistFeature::constructChildModel(int selectedId) {
     QList<TreeItem*> data_list;
     int selectedRow = -1;

--- a/src/library/trackset/playlistfeature.h
+++ b/src/library/trackset/playlistfeature.h
@@ -27,8 +27,6 @@ class PlaylistFeature : public BasePlaylistFeature {
     QVariant title() override;
     QIcon getIcon() override;
 
-    void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
-
     bool dropAcceptChild(const QModelIndex& index,
             const QList<QUrl>& urls,
             QObject* pSource) override;
@@ -52,5 +50,4 @@ class PlaylistFeature : public BasePlaylistFeature {
   private:
     QString getRootViewHtml() const override;
     const QIcon m_icon;
-    QPointer<WLibrarySidebar> m_pSidebarWidget;
 };

--- a/src/library/trackset/playlistfeature.h
+++ b/src/library/trackset/playlistfeature.h
@@ -44,9 +44,10 @@ class PlaylistFeature : public BasePlaylistFeature {
     void slotPlaylistTableRenamed(int playlistId, const QString& newName) override;
 
   protected:
-    QList<BasePlaylistFeature::IdAndLabel> createPlaylistLabels() override;
     QString fetchPlaylistLabel(int playlistId) override;
-    void decorateChild(TreeItem* pChild, int playlist_id) override;
+    void decorateChild(TreeItem* pChild, int playlistId) override;
+    virtual QList<IdAndLabel> createPlaylistLabels();
+    QModelIndex constructChildModel(int selectedId);
 
   private:
     QString getRootViewHtml() const override;

--- a/src/library/trackset/playlistfeature.h
+++ b/src/library/trackset/playlistfeature.h
@@ -44,7 +44,7 @@ class PlaylistFeature : public BasePlaylistFeature {
   protected:
     QString fetchPlaylistLabel(int playlistId) override;
     void decorateChild(TreeItem* pChild, int playlistId) override;
-    virtual QList<IdAndLabel> createPlaylistLabels();
+    QList<IdAndLabel> createPlaylistLabels();
     QModelIndex constructChildModel(int selectedId);
 
   private:

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -394,28 +394,25 @@ void SetlogFeature::slotPlaylistTableRenamed(int playlistId, const QString& newN
     }
 }
 
-QString SetlogFeature::getRootViewHtml() const {
-    QString playlistsTitle = tr("History");
-    QString playlistsSummary =
-            tr("The history section automatically keeps a list of tracks you "
-               "play in your DJ sets.");
-    QString playlistsSummary2 =
-            tr("This is handy for remembering what worked in your DJ sets, "
-               "posting set-lists, or reporting your plays to licensing "
-               "organizations.");
-    QString playlistsSummary3 =
-            tr("Every time you start Mixxx, a new history section is created. "
-               "You can export it as a playlist in various formats or play it "
-               "again with Auto DJ.");
-    QString playlistsSummary4 =
-            tr("You can join the current history session with a previous one "
-               "by right-clicking and selecting \"Join with previous\".");
+void SetlogFeature::activate() {
+    activatePlaylist(m_playlistId);
+}
 
-    QString html;
-    html.append(QStringLiteral("<h2>%1</h2>").arg(playlistsTitle));
-    html.append(QStringLiteral("<p>%1</p>").arg(playlistsSummary));
-    html.append(QStringLiteral("<p>%1</p>").arg(playlistsSummary2));
-    html.append(QStringLiteral("<p>%1</p>").arg(playlistsSummary3));
-    html.append(QStringLiteral("<p>%1</p>").arg(playlistsSummary4));
-    return html;
+void SetlogFeature::activatePlaylist(int playlistId) {
+    //qDebug() << "BasePlaylistFeature::activatePlaylist()" << playlistId;
+    QModelIndex index = indexFromPlaylistId(playlistId);
+    if (playlistId != -1 && index.isValid()) {
+        m_pPlaylistTableModel->setTableModel(playlistId);
+        emit showTrackModel(m_pPlaylistTableModel);
+        emit enableCoverArtDisplay(true);
+        // Update selection only, if it is not the current playlist
+        if (playlistId != m_playlistId) {
+            emit featureSelect(this, m_lastRightClickedIndex);
+            activateChild(m_lastRightClickedIndex);
+        }
+    }
+}
+
+QString SetlogFeature::getRootViewHtml() const {
+    return QString();
 }

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -50,8 +50,8 @@ SetlogFeature::SetlogFeature(
             this,
             &SetlogFeature::slotJoinWithPrevious);
 
-    m_pGetNewPlaylist = new QAction(tr("Create new history playlist"), this);
-    connect(m_pGetNewPlaylist,
+    m_pStartNewPlaylist = new QAction(tr("Finish current and start new"), this);
+    connect(m_pStartNewPlaylist,
             &QAction::triggered,
             this,
             &SetlogFeature::slotGetNewPlaylist);
@@ -132,9 +132,10 @@ void SetlogFeature::onRightClickChild(const QPoint& globalPos, const QModelIndex
         // The very first setlog cannot be joint
         menu.addAction(m_pJoinWithPreviousAction);
     }
-    if (playlistId == m_playlistId && m_playlistDao.tracksInPlaylist(m_playlistId) != 0) {
+    if (playlistId == m_playlistId) {
         // Todays playlists can change !
-        menu.addAction(m_pGetNewPlaylist);
+        m_pStartNewPlaylist->setEnabled(m_playlistDao.tracksInPlaylist(m_playlistId) > 0);
+        menu.addAction(m_pStartNewPlaylist);
     }
     menu.addSeparator();
     menu.addAction(m_pExportPlaylistAction);
@@ -282,6 +283,7 @@ void SetlogFeature::slotGetNewPlaylist() {
 
     reloadChildModel(m_playlistId); // For moving selection
     emit showTrackModel(m_pPlaylistTableModel);
+    activatePlaylist(m_playlistId);
 }
 
 void SetlogFeature::slotJoinWithPrevious() {

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -144,7 +144,7 @@ QList<BasePlaylistFeature::IdAndLabel> SetlogFeature::createPlaylistLabels() {
     playlistTableModel.setTable("Playlists");
     playlistTableModel.setFilter("hidden=2"); // PLHT_SET_LOG
     playlistTableModel.setSort(
-            playlistTableModel.fieldIndex("id"), Qt::AscendingOrder);
+            playlistTableModel.fieldIndex("id"), Qt::DescendingOrder);
     playlistTableModel.select();
     while (playlistTableModel.canFetchMore()) {
         playlistTableModel.fetchMore();

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -199,7 +199,7 @@ QModelIndex SetlogFeature::constructChildModel(int selectedId) {
             if (i != groups.end() && i.key() == yearCreated) {
                 groupItem = i.value();
             } else {
-                groupItem = new TreeItem(QString("%1").arg(yearCreated), -1);
+                groupItem = new TreeItem(QString::number(yearCreated), -1);
                 groups.insert(yearCreated, groupItem);
                 itemList.append(groupItem);
             }
@@ -474,5 +474,6 @@ void SetlogFeature::activatePlaylist(int playlistId) {
 }
 
 QString SetlogFeature::getRootViewHtml() const {
+    // Instead of the help text, the history shows the current entry instead
     return QString();
 }

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -19,7 +19,7 @@
 #include "widget/wtracktableview.h"
 
 namespace {
-constexpr int kNumDirectHistoryEntries = 5;
+constexpr int kNumToplevelHistoryEntries = 5;
 }
 
 SetlogFeature::SetlogFeature(
@@ -167,7 +167,7 @@ QModelIndex SetlogFeature::constructChildModel(int selectedId) {
 
     QList<TreeItem*> itemList;
     // Generous estimate (number of years the db is used ;))
-    itemList.reserve(kNumDirectHistoryEntries + 15);
+    itemList.reserve(kNumToplevelHistoryEntries + 15);
 
     for (int row = 0; row < playlistTableModel.rowCount(); ++row) {
         int id =
@@ -184,7 +184,7 @@ QModelIndex SetlogFeature::constructChildModel(int selectedId) {
                         .toDateTime();
 
         // Create the TreeItem whose parent is the invisible root item
-        if (row >= kNumDirectHistoryEntries) {
+        if (row >= kNumToplevelHistoryEntries) {
             int yearCreated = dateCreated.date().year();
 
             auto i = groups.find(yearCreated);
@@ -198,14 +198,14 @@ QModelIndex SetlogFeature::constructChildModel(int selectedId) {
             }
 
             auto item = std::make_unique<TreeItem>(name, id);
-            item->setBold(m_playlistsSelectedTrackIsIn.contains(id));
+            item->setBold(m_playlistIdsOfSelectedTrack.contains(id));
 
             decorateChild(item.get(), id);
 
             groupItem->appendChild(std::move(item));
         } else {
             TreeItem* item = new TreeItem(name, id);
-            item->setBold(m_playlistsSelectedTrackIsIn.contains(id));
+            item->setBold(m_playlistIdsOfSelectedTrack.contains(id));
 
             decorateChild(item, id);
 
@@ -463,11 +463,10 @@ void SetlogFeature::activatePlaylist(int playlistId) {
         emit showTrackModel(m_pPlaylistTableModel);
         emit enableCoverArtDisplay(true);
         // Update selection only, if it is not the current playlist
+        // since we want the root item to be the current playlist as well
         if (playlistId != m_playlistId) {
             emit featureSelect(this, index);
             activateChild(index);
-        } else if (m_pSidebarWidget) {
-            m_pSidebarWidget->selectChildIndex(index);
         }
     }
 }

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -85,11 +85,6 @@ void SetlogFeature::bindLibraryWidget(
     m_libraryWidget = libraryWidget;
 }
 
-void SetlogFeature::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
-    // store the sidebar widget pointer for later use in onRightClickChild
-    m_pSidebarWidget = pSidebarWidget;
-}
-
 void SetlogFeature::onRightClick(const QPoint& globalPos) {
     Q_UNUSED(globalPos);
     m_lastRightClickedIndex = QModelIndex();
@@ -340,9 +335,11 @@ void SetlogFeature::slotJoinWithPrevious() {
                          << " previous:" << previousPlaylistId;
                 if (m_playlistDao.copyPlaylistTracks(
                             currentPlaylistId, previousPlaylistId)) {
+                    m_lastRightClickedIndex = constructChildModel(previousPlaylistId);
                     m_playlistDao.deletePlaylist(currentPlaylistId);
                     reloadChildModel(previousPlaylistId); // For moving selection
                     emit showTrackModel(m_pPlaylistTableModel);
+                    emit activatePlaylist(previousPlaylistId);
                 }
             }
         }

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -341,7 +341,7 @@ void SetlogFeature::slotJoinWithPrevious() {
                     m_playlistDao.deletePlaylist(currentPlaylistId);
                     reloadChildModel(previousPlaylistId); // For moving selection
                     emit showTrackModel(m_pPlaylistTableModel);
-                    emit activatePlaylist(previousPlaylistId);
+                    activatePlaylist(previousPlaylistId);
                 }
             }
         }

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -47,7 +47,7 @@ SetlogFeature::SetlogFeature(
     m_childModel.setRootItem(TreeItem::newRoot(this));
     constructChildModel(kInvalidPlaylistId);
 
-    m_pJoinWithPreviousAction = new QAction(tr("Join with previous"), this);
+    m_pJoinWithPreviousAction = new QAction(tr("Join with previous (below)"), this);
     connect(m_pJoinWithPreviousAction,
             &QAction::triggered,
             this,
@@ -425,9 +425,6 @@ void SetlogFeature::reloadChildModel(int playlistId) {
             type == PlaylistDAO::PLHT_UNKNOWN) { // In case of a deleted Playlist
         clearChildModel();
         m_lastRightClickedIndex = constructChildModel(playlistId);
-        if (m_pSidebarWidget) {
-            m_pSidebarWidget->selectChildIndex(m_lastRightClickedIndex);
-        }
     }
 }
 
@@ -451,7 +448,11 @@ void SetlogFeature::slotPlaylistTableRenamed(int playlistId, const QString& newN
         clearChildModel();
         m_lastRightClickedIndex = constructChildModel(playlistId);
         if (type != PlaylistDAO::PLHT_UNKNOWN) {
-            activatePlaylist(playlistId);
+            if (playlistId == m_pPlaylistTableModel->getPlaylist()) {
+                activatePlaylist(playlistId);
+            } else if (m_pSidebarWidget) {
+                m_pSidebarWidget->selectChildIndex(indexFromPlaylistId(playlistId), false);
+            }
         }
     }
 }

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -204,7 +204,7 @@ QModelIndex SetlogFeature::constructChildModel(int selectedId) {
                 itemList.append(groupItem);
             }
 
-            std::unique_ptr<TreeItem> item(new TreeItem(name, id));
+            auto item = std::make_unique<TreeItem>(name, id);
             item->setBold(m_playlistsSelectedTrackIsIn.contains(id));
 
             decorateChild(item.get(), id);

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -269,7 +269,7 @@ void SetlogFeature::slotGetNewPlaylist() {
     QString set_log_name;
 
     set_log_name = QDate::currentDate().toString(Qt::ISODate);
-    set_log_name_format = set_log_name + " / %1";
+    set_log_name_format = set_log_name + " #%1";
     int i = 1;
 
     // calculate name of the todays setlog

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -38,7 +38,7 @@ SetlogFeature::SetlogFeature(
           m_libraryWidget(nullptr),
           m_icon(QStringLiteral(":/images/library/ic_library_history.svg")) {
     // clear old empty entries
-    m_playlistDao.deleteAllEmptyPlaylists(PlaylistDAO::HiddenType::PLHT_SET_LOG);
+    m_playlistDao.deleteAllPlaylistsWithFewerItems(PlaylistDAO::HiddenType::PLHT_SET_LOG, 1);
 
     //construct child model
     m_childModel.setRootItem(TreeItem::newRoot(this));

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -19,7 +19,7 @@
 #include "widget/wtracktableview.h"
 
 namespace {
-    constexpr int kNumDirectHistoryEntries = 5;
+constexpr int kNumDirectHistoryEntries = 5;
 }
 
 SetlogFeature::SetlogFeature(
@@ -38,7 +38,7 @@ SetlogFeature::SetlogFeature(
           m_libraryWidget(nullptr),
           m_icon(QStringLiteral(":/images/library/ic_library_history.svg")) {
     // clear old empty entries
-    m_playlistDao.deleteEmptyPlaylists(PlaylistDAO::HiddenType::PLHT_SET_LOG);
+    m_playlistDao.deleteAllEmptyPlaylists(PlaylistDAO::HiddenType::PLHT_SET_LOG);
 
     //construct child model
     m_childModel.setRootItem(TreeItem::newRoot(this));
@@ -191,7 +191,7 @@ QModelIndex SetlogFeature::constructChildModel(int selectedId) {
         }
 
         // Create the TreeItem whose parent is the invisible root item
-        if (row >= kNumDirectHistoryEntries ) {
+        if (row >= kNumDirectHistoryEntries) {
             int yearCreated = dateCreated.date().year();
 
             auto i = groups.find(yearCreated);
@@ -204,7 +204,7 @@ QModelIndex SetlogFeature::constructChildModel(int selectedId) {
                 itemList.append(groupItem);
             }
 
-            std::unique_ptr<TreeItem> item (new TreeItem(name, id));
+            std::unique_ptr<TreeItem> item(new TreeItem(name, id));
             item->setBold(m_playlistsSelectedTrackIsIn.contains(id));
 
             decorateChild(item.get(), id);

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -128,7 +128,7 @@ void SetlogFeature::onRightClickChild(const QPoint& globalPos, const QModelIndex
         menu.addAction(m_pDeletePlaylistAction);
         menu.addAction(m_pLockPlaylistAction);
     }
-    if (index.row() > 0) {
+    if (index.sibling(index.row() + 1, index.column()).isValid()) {
         // The very first setlog cannot be joint
         menu.addAction(m_pJoinWithPreviousAction);
     }

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -37,6 +37,9 @@ SetlogFeature::SetlogFeature(
           m_playlistId(-1),
           m_libraryWidget(nullptr),
           m_icon(QStringLiteral(":/images/library/ic_library_history.svg")) {
+    // clear old empty entries
+    m_playlistDao.deleteEmptyPlaylists(PlaylistDAO::HiddenType::PLHT_SET_LOG);
+
     //construct child model
     m_childModel.setRootItem(TreeItem::newRoot(this));
     constructChildModel(-1);

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -269,7 +269,7 @@ void SetlogFeature::slotGetNewPlaylist() {
     QString set_log_name;
 
     set_log_name = QDate::currentDate().toString(Qt::ISODate);
-    set_log_name_format = set_log_name + " (%1)";
+    set_log_name_format = set_log_name + " / %1";
     int i = 1;
 
     // calculate name of the todays setlog

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -342,6 +342,8 @@ void SetlogFeature::slotJoinWithPrevious() {
                     reloadChildModel(previousPlaylistId); // For moving selection
                     emit showTrackModel(m_pPlaylistTableModel);
                     activatePlaylist(previousPlaylistId);
+                    QModelIndex previousIndex = indexFromPlaylistId(previousPlaylistId);
+                    m_pSidebarWidget->selectChildIndex(previousIndex);
                 }
             }
         }

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -34,7 +34,7 @@ SetlogFeature::SetlogFeature(
                           "mixxx.db.model.setlog",
                           /*keep deleted tracks*/ true),
                   QStringLiteral("SETLOGHOME")),
-          m_playlistId(-1),
+          m_playlistId(kInvalidPlaylistId),
           m_libraryWidget(nullptr),
           m_icon(QStringLiteral(":/images/library/ic_library_history.svg")) {
     // clear old empty entries
@@ -42,7 +42,7 @@ SetlogFeature::SetlogFeature(
 
     //construct child model
     m_childModel.setRootItem(TreeItem::newRoot(this));
-    constructChildModel(-1);
+    constructChildModel(kInvalidPlaylistId);
 
     m_pJoinWithPreviousAction = new QAction(tr("Join with previous"), this);
     connect(m_pJoinWithPreviousAction,
@@ -64,7 +64,7 @@ SetlogFeature::~SetlogFeature() {
     // If the history playlist we created doesn't have any tracks in it then
     // delete it so we don't end up with tons of empty playlists. This is mostly
     // for developers since they regularly open Mixxx without loading a track.
-    if (m_playlistId != -1 &&
+    if (m_playlistId != kInvalidPlaylistId &&
             m_playlistDao.tracksInPlaylist(m_playlistId) == 0) {
         m_playlistDao.deletePlaylist(m_playlistId);
     }
@@ -105,7 +105,7 @@ void SetlogFeature::onRightClickChild(const QPoint& globalPos, const QModelIndex
 
     int playlistId = index.data(TreeItemModel::kDataRole).toInt();
     // not a real entry
-    if (playlistId == -1) {
+    if (playlistId == kInvalidPlaylistId) {
         return;
     }
 
@@ -192,7 +192,7 @@ QModelIndex SetlogFeature::constructChildModel(int selectedId) {
             if (i != groups.end() && i.key() == yearCreated) {
                 groupItem = i.value();
             } else {
-                groupItem = new TreeItem(QString::number(yearCreated), -1);
+                groupItem = new TreeItem(QString::number(yearCreated), kInvalidPlaylistId);
                 groups.insert(yearCreated, groupItem);
                 itemList.append(groupItem);
             }
@@ -266,7 +266,7 @@ void SetlogFeature::slotGetNewPlaylist() {
     int i = 1;
 
     // calculate name of the todays setlog
-    while (m_playlistDao.getPlaylistIdFromName(set_log_name) != -1) {
+    while (m_playlistDao.getPlaylistIdFromName(set_log_name) != kInvalidPlaylistId) {
         set_log_name = set_log_name_format.arg(++i);
     }
 
@@ -274,7 +274,7 @@ void SetlogFeature::slotGetNewPlaylist() {
     m_playlistId = m_playlistDao.createPlaylist(
             set_log_name, PlaylistDAO::PLHT_SET_LOG);
 
-    if (m_playlistId == -1) {
+    if (m_playlistId == kInvalidPlaylistId) {
         qDebug() << "Setlog playlist Creation Failed";
         qDebug() << "An unknown error occurred while creating playlist: "
                  << set_log_name;
@@ -458,7 +458,7 @@ void SetlogFeature::activate() {
 void SetlogFeature::activatePlaylist(int playlistId) {
     //qDebug() << "BasePlaylistFeature::activatePlaylist()" << playlistId;
     QModelIndex index = indexFromPlaylistId(playlistId);
-    if (playlistId != -1 && index.isValid()) {
+    if (playlistId != kInvalidPlaylistId && index.isValid()) {
         m_pPlaylistTableModel->setTableModel(playlistId);
         emit showTrackModel(m_pPlaylistTableModel);
         emit enableCoverArtDisplay(true);

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -7,6 +7,7 @@
 #include "control/controlobject.h"
 #include "library/library.h"
 #include "library/playlisttablemodel.h"
+#include "library/queryutil.h"
 #include "library/trackcollection.h"
 #include "library/trackcollectionmanager.h"
 #include "library/treeitem.h"
@@ -38,7 +39,9 @@ SetlogFeature::SetlogFeature(
           m_libraryWidget(nullptr),
           m_icon(QStringLiteral(":/images/library/ic_library_history.svg")) {
     // clear old empty entries
-    m_playlistDao.deleteAllPlaylistsWithFewerItems(PlaylistDAO::HiddenType::PLHT_SET_LOG, 1);
+    ScopedTransaction transaction(pLibrary->trackCollections()->internalCollection()->database());
+    m_playlistDao.deleteAllPlaylistsWithFewerTracks(PlaylistDAO::HiddenType::PLHT_SET_LOG, 1);
+    transaction.commit();
 
     //construct child model
     m_childModel.setRootItem(TreeItem::newRoot(this));

--- a/src/library/trackset/setlogfeature.h
+++ b/src/library/trackset/setlogfeature.h
@@ -46,7 +46,7 @@ class SetlogFeature : public BasePlaylistFeature {
 
     std::list<TrackId> m_recentTracks;
     QAction* m_pJoinWithPreviousAction;
-    QAction* m_pGetNewPlaylist;
+    QAction* m_pStartNewPlaylist;
     int m_playlistId;
     WLibrary* m_libraryWidget;
     const QIcon m_icon;

--- a/src/library/trackset/setlogfeature.h
+++ b/src/library/trackset/setlogfeature.h
@@ -32,6 +32,7 @@ class SetlogFeature : public BasePlaylistFeature {
 
   protected:
     QList<BasePlaylistFeature::IdAndLabel> createPlaylistLabels() override;
+    QModelIndex constructChildModel(int selected_id) override;
     QString fetchPlaylistLabel(int playlistId) override;
     void decorateChild(TreeItem* pChild, int playlistId) override;
 

--- a/src/library/trackset/setlogfeature.h
+++ b/src/library/trackset/setlogfeature.h
@@ -31,8 +31,7 @@ class SetlogFeature : public BasePlaylistFeature {
     void activate() override;
 
   protected:
-    QList<BasePlaylistFeature::IdAndLabel> createPlaylistLabels() override;
-    QModelIndex constructChildModel(int selected_id) override;
+    QModelIndex constructChildModel(int selectedId);
     QString fetchPlaylistLabel(int playlistId) override;
     void decorateChild(TreeItem* pChild, int playlistId) override;
 

--- a/src/library/trackset/setlogfeature.h
+++ b/src/library/trackset/setlogfeature.h
@@ -21,12 +21,14 @@ class SetlogFeature : public BasePlaylistFeature {
     void bindLibraryWidget(WLibrary* libraryWidget,
             KeyboardEventFilter* keyboard) override;
     void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
+    void activatePlaylist(int playlistId) override;
 
   public slots:
     void onRightClick(const QPoint& globalPos) override;
     void onRightClickChild(const QPoint& globalPos, const QModelIndex& index) override;
     void slotJoinWithPrevious();
     void slotGetNewPlaylist();
+    void activate() override;
 
   protected:
     QList<BasePlaylistFeature::IdAndLabel> createPlaylistLabels() override;

--- a/src/library/trackset/setlogfeature.h
+++ b/src/library/trackset/setlogfeature.h
@@ -20,7 +20,6 @@ class SetlogFeature : public BasePlaylistFeature {
 
     void bindLibraryWidget(WLibrary* libraryWidget,
             KeyboardEventFilter* keyboard) override;
-    void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
     void activatePlaylist(int playlistId) override;
 
   public slots:
@@ -50,6 +49,5 @@ class SetlogFeature : public BasePlaylistFeature {
     QAction* m_pGetNewPlaylist;
     int m_playlistId;
     WLibrary* m_libraryWidget;
-    QPointer<WLibrarySidebar> m_pSidebarWidget;
     const QIcon m_icon;
 };

--- a/src/library/treeitem.h
+++ b/src/library/treeitem.h
@@ -95,7 +95,7 @@ class TreeItem final {
     // take ownership of children items
     void insertChildren(int row, QList<TreeItem*>& children);
     void removeChildren(int row, int count);
-
+    void insertChild(int row, TreeItem* pChild);
 
     /////////////////////////////////////////////////////////////////////////
     // Payload
@@ -135,7 +135,6 @@ class TreeItem final {
             QString label = QString(),
             QVariant data = QVariant());
 
-    void insertChild(int row, TreeItem* pChild);
     void initFeatureRecursively(LibraryFeature* pFeature);
 
     // The library feature is inherited from the parent.

--- a/src/library/treeitemmodel.cpp
+++ b/src/library/treeitemmodel.cpp
@@ -129,7 +129,7 @@ QModelIndex TreeItemModel::parent(const QModelIndex& index) const {
 
     TreeItem *childItem = static_cast<TreeItem*>(index.internalPointer());
     TreeItem *parentItem = childItem->parent();
-    if (parentItem == nullptr) {
+    if (!parentItem) {
         return QModelIndex();
     } if (parentItem == getRootItem()) {
         return createIndex(0, 0, getRootItem());
@@ -163,12 +163,11 @@ TreeItem* TreeItemModel::setRootItem(std::unique_ptr<TreeItem> pRootItem) {
     return getRootItem();
 }
 
-/**
- * Returns the QModelIndex of the Root element.
- */
+/// Returns the QModelIndex of the Root element.
 QModelIndex TreeItemModel::getRootIndex() {
     return createIndex(0, 0, getRootItem());
 }
+
 /**
  * Before you can resize the data model dynamically by using 'insertRows' and 'removeRows'
  * make sure you have initialized

--- a/src/library/treeitemmodel.cpp
+++ b/src/library/treeitemmodel.cpp
@@ -131,7 +131,7 @@ QModelIndex TreeItemModel::parent(const QModelIndex& index) const {
     TreeItem *parentItem = childItem->parent();
     if (!parentItem) {
         return QModelIndex();
-    } if (parentItem == getRootItem()) {
+    } else if (parentItem == getRootItem()) {
         return createIndex(0, 0, getRootItem());
     } else {
         return createIndex(parentItem->parentRow(), 0, parentItem);
@@ -163,8 +163,7 @@ TreeItem* TreeItemModel::setRootItem(std::unique_ptr<TreeItem> pRootItem) {
     return getRootItem();
 }
 
-/// Returns the QModelIndex of the Root element.
-QModelIndex TreeItemModel::getRootIndex() {
+const QModelIndex TreeItemModel::getRootIndex() {
     return createIndex(0, 0, getRootItem());
 }
 

--- a/src/library/treeitemmodel.cpp
+++ b/src/library/treeitemmodel.cpp
@@ -129,8 +129,10 @@ QModelIndex TreeItemModel::parent(const QModelIndex& index) const {
 
     TreeItem *childItem = static_cast<TreeItem*>(index.internalPointer());
     TreeItem *parentItem = childItem->parent();
-    if (parentItem == getRootItem()) {
+    if (parentItem == nullptr) {
         return QModelIndex();
+    } if (parentItem == getRootItem()) {
+        return createIndex(0, 0, getRootItem());
     } else {
         return createIndex(parentItem->parentRow(), 0, parentItem);
     }
@@ -161,6 +163,12 @@ TreeItem* TreeItemModel::setRootItem(std::unique_ptr<TreeItem> pRootItem) {
     return getRootItem();
 }
 
+/**
+ * Returns the QModelIndex of the Root element.
+ */
+QModelIndex TreeItemModel::getRootIndex() {
+    return createIndex(0, 0, getRootItem());
+}
 /**
  * Before you can resize the data model dynamically by using 'insertRows' and 'removeRows'
  * make sure you have initialized

--- a/src/library/treeitemmodel.h
+++ b/src/library/treeitemmodel.h
@@ -37,6 +37,7 @@ class TreeItemModel : public QAbstractItemModel {
     TreeItem* getRootItem() const {
         return m_pRootItem.get();
     }
+    QModelIndex getRootIndex();
 
     // Return the underlying TreeItem.
     // If the index is invalid, the root item is returned.

--- a/src/library/treeitemmodel.h
+++ b/src/library/treeitemmodel.h
@@ -37,7 +37,8 @@ class TreeItemModel : public QAbstractItemModel {
     TreeItem* getRootItem() const {
         return m_pRootItem.get();
     }
-    QModelIndex getRootIndex();
+    /// Returns the QModelIndex of the Root element.
+    const QModelIndex getRootIndex();
 
     // Return the underlying TreeItem.
     // If the index is invalid, the root item is returned.

--- a/src/util/db/fwdsqlquery.h
+++ b/src/util/db/fwdsqlquery.h
@@ -60,6 +60,10 @@ class FwdSqlQuery: protected QSqlQuery {
         bindValue(placeholder, value.toVariant());
     }
 
+    QString executedQuery() const {
+        return QSqlQuery::executedQuery();
+    }
+
     // Execute the prepared query and log errors on failure.
     //
     // Please note, that the member function exec() inherited

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -215,17 +215,27 @@ void WLibrarySidebar::selectIndex(const QModelIndex& index) {
     pModel->select(index, QItemSelectionModel::Select);
     setSelectionModel(pModel);
 
-//FIXME(XXX): use expandRecursively when
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-    QModelIndex parentIndex = index.parent();
+    scrollTo(index);
+}
+
+/// Selects a child index from a feature and ensures visibility
+void WLibrarySidebar::selectChildIndex(const QModelIndex& index) {
+    auto pModel = new QItemSelectionModel(model());
+    SidebarModel* sidebarModel = qobject_cast<SidebarModel*>(model());
+    VERIFY_OR_DEBUG_ASSERT(sidebarModel) {
+        qDebug() << "model() is not SidebarModel";
+        return;
+    }
+    QModelIndex translated = sidebarModel->translateChildIndex(index);
+    pModel->select(index, QItemSelectionModel::Select);
+    setSelectionModel(pModel);
+
+    QModelIndex parentIndex = translated.parent();
     if (parentIndex.isValid()) {
         expand(parentIndex);
         parentIndex = parentIndex.parent();
     }
-#else
-    expandRecursively(index);
-#endif
-    scrollTo(index);
+    scrollTo(translated, PositionAtCenter);
 }
 
 bool WLibrarySidebar::event(QEvent* pEvent) {

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -237,7 +237,7 @@ void WLibrarySidebar::selectChildIndex(const QModelIndex& index) {
         expand(parentIndex);
         parentIndex = parentIndex.parent();
     }
-    scrollTo(translated, PositionAtCenter);
+    scrollTo(translated, EnsureVisible);
 }
 
 bool WLibrarySidebar::event(QEvent* pEvent) {

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -215,9 +215,16 @@ void WLibrarySidebar::selectIndex(const QModelIndex& index) {
     pModel->select(index, QItemSelectionModel::Select);
     setSelectionModel(pModel);
 
-    if (index.parent().isValid()) {
-        expand(index.parent());
+//FIXME(XXX): use expandRecursively when
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+    QModelIndex parentIndex = index.parent();
+    if (parentIndex.isValid()) {
+        expand(parentIndex);
+        parentIndex = parentIndex.parent();
     }
+#else
+    expandRecursively(index);
+#endif
     scrollTo(index);
 }
 

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -214,7 +214,9 @@ void WLibrarySidebar::selectIndex(const QModelIndex& index) {
     auto pModel = new QItemSelectionModel(model());
     pModel->select(index, QItemSelectionModel::Select);
     setSelectionModel(pModel);
-
+    if (index.parent().isValid()) {
+        expand(index.parent());
+    }
     scrollTo(index);
 }
 
@@ -231,7 +233,7 @@ void WLibrarySidebar::selectChildIndex(const QModelIndex& index) {
     setSelectionModel(pModel);
 
     QModelIndex parentIndex = translated.parent();
-    if (parentIndex.isValid()) {
+    while (parentIndex.isValid()) {
         expand(parentIndex);
         parentIndex = parentIndex.parent();
     }

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -213,6 +213,9 @@ void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
 void WLibrarySidebar::selectIndex(const QModelIndex& index) {
     auto pModel = new QItemSelectionModel(model());
     pModel->select(index, QItemSelectionModel::Select);
+    if (selectionModel()) {
+        selectionModel()->deleteLater();
+    }
     setSelectionModel(pModel);
     if (index.parent().isValid()) {
         expand(index.parent());
@@ -222,14 +225,17 @@ void WLibrarySidebar::selectIndex(const QModelIndex& index) {
 
 /// Selects a child index from a feature and ensures visibility
 void WLibrarySidebar::selectChildIndex(const QModelIndex& index) {
-    auto pModel = new QItemSelectionModel(model());
     SidebarModel* sidebarModel = qobject_cast<SidebarModel*>(model());
     VERIFY_OR_DEBUG_ASSERT(sidebarModel) {
         qDebug() << "model() is not SidebarModel";
         return;
     }
     QModelIndex translated = sidebarModel->translateChildIndex(index);
-    pModel->select(index, QItemSelectionModel::Select);
+    auto pModel = new QItemSelectionModel(sidebarModel);
+    pModel->select(translated, QItemSelectionModel::Select);
+    if (selectionModel()) {
+        selectionModel()->deleteLater();
+    }
     setSelectionModel(pModel);
 
     QModelIndex parentIndex = translated.parent();

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -224,19 +224,22 @@ void WLibrarySidebar::selectIndex(const QModelIndex& index) {
 }
 
 /// Selects a child index from a feature and ensures visibility
-void WLibrarySidebar::selectChildIndex(const QModelIndex& index) {
+void WLibrarySidebar::selectChildIndex(const QModelIndex& index, bool selectItem) {
     SidebarModel* sidebarModel = qobject_cast<SidebarModel*>(model());
     VERIFY_OR_DEBUG_ASSERT(sidebarModel) {
         qDebug() << "model() is not SidebarModel";
         return;
     }
     QModelIndex translated = sidebarModel->translateChildIndex(index);
-    auto pModel = new QItemSelectionModel(sidebarModel);
-    pModel->select(translated, QItemSelectionModel::Select);
-    if (selectionModel()) {
-        selectionModel()->deleteLater();
+
+    if (selectItem) {
+        auto pModel = new QItemSelectionModel(sidebarModel);
+        pModel->select(translated, QItemSelectionModel::Select);
+        if (selectionModel()) {
+            selectionModel()->deleteLater();
+        }
+        setSelectionModel(pModel);
     }
-    setSelectionModel(pModel);
 
     QModelIndex parentIndex = translated.parent();
     while (parentIndex.isValid()) {

--- a/src/widget/wlibrarysidebar.h
+++ b/src/widget/wlibrarysidebar.h
@@ -30,6 +30,7 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
 
   public slots:
     void selectIndex(const QModelIndex&);
+    void selectChildIndex(const QModelIndex&);
     void slotSetFont(const QFont& font);
 
   signals:

--- a/src/widget/wlibrarysidebar.h
+++ b/src/widget/wlibrarysidebar.h
@@ -30,7 +30,7 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
 
   public slots:
     void selectIndex(const QModelIndex&);
-    void selectChildIndex(const QModelIndex&);
+    void selectChildIndex(const QModelIndex&, bool selectItem = true);
     void slotSetFont(const QFont& font);
 
   signals:


### PR DESCRIPTION
The history feature has quite some usability issues. The list gets very long very quickly and the most useful entries are at the bottom of the list.

Edit(ronso0) #6917

* Stop wasting the root window with information that are easily discoverable, but instead display the current playlist at the root entry. This way, the menu does not need to be open to jump to the current list.
* Instead of putting the newest entry at the bottom, use descending order and show the last entries first.
* Only show the last 5 playlists and group later entries by year.

![mixxx-history](https://user-images.githubusercontent.com/66107/89414657-1428b880-d72b-11ea-8cb5-7c78e88c5aee.png)

Todo: highlight group if any child is highlighted
