### PR TITLE
DlgTrackInfo improvements pt.II

### DIFF
--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -399,7 +399,11 @@
             </item>
 
             <item row="7" column="1" colspan="3">
-             <widget class="QPlainTextEdit" name="txtComment"/>
+             <widget class="QPlainTextEdit" name="txtComment">
+              <property name="tabChangesFocus">
+               <bool>true</bool>
+              </property>
+             </widget>
             </item>
 
             <item row="8" column="1" colspan="3">

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -981,11 +981,6 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
  <layoutdefault spacing="6" margin="11"/>
  <tabstops>
   <tabstop>tabWidget</tabstop>
-  <tabstop>btnPrev</tabstop>
-  <tabstop>btnNext</tabstop>
-  <tabstop>btnCancel</tabstop>
-  <tabstop>btnApply</tabstop>
-  <tabstop>btnOK</tabstop>
   <tabstop>txtTrackName</tabstop>
   <tabstop>txtArtist</tabstop>
   <tabstop>txtAlbum</tabstop>
@@ -993,13 +988,13 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
   <tabstop>txtComposer</tabstop>
   <tabstop>txtGenre</tabstop>
   <tabstop>txtGrouping</tabstop>
+  <tabstop>txtComment</tabstop>
   <tabstop>txtYear</tabstop>
   <tabstop>txtKey</tabstop>
   <tabstop>txtTrackNumber</tabstop>
   <tabstop>btnImportMetadataFromMusicBrainz</tabstop>
   <tabstop>btnImportMetadataFromFile</tabstop>
   <tabstop>btnOpenFileBrowser</tabstop>
-  <tabstop>txtComment</tabstop>
   <tabstop>spinBpm</tabstop>
   <tabstop>bpmConst</tabstop>
   <tabstop>bpmTap</tabstop>
@@ -1010,6 +1005,11 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
   <tabstop>bpmThreeFourth</tabstop>
   <tabstop>bpmThreeHalves</tabstop>
   <tabstop>bpmFourThirds</tabstop>
+  <tabstop>btnPrev</tabstop>
+  <tabstop>btnNext</tabstop>
+  <tabstop>btnCancel</tabstop>
+  <tabstop>btnApply</tabstop>
+  <tabstop>btnOK</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
follow-up for #2991 

* don't allow tab insert in comment field, move focus instead
* reorder tabs tops:
left column down > comment > right column down > Metadata button > ...