### PR TITLE
Overview: allow custom range opacity, improve mark rendering

### DIFF
--- a/res/skins/Deere/deck_overview.xml
+++ b/res/skins/Deere/deck_overview.xml
@@ -29,67 +29,74 @@
       <TextColor>#FFFFFF</TextColor>
       <Text> %1 </Text>
     </DefaultMark>
-    <MarkRange>
-      <StartControl>loop_start_position</StartControl>
-      <EndControl>loop_end_position</EndControl>
-      <EnabledControl>loop_enabled</EnabledControl>
-      <Color>#00FF00</Color>
-      <DisabledColor>#FFFFFF</DisabledColor>
-    </MarkRange>
-    <MarkRange>
-      <StartControl>intro_start_position</StartControl>
-      <EndControl>intro_end_position</EndControl>
-      <Color>#0000FF</Color>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-      <DurationTextColor>#ffffff</DurationTextColor>
-      <DurationTextLocation>after</DurationTextLocation>
-    </MarkRange>
-    <MarkRange>
-      <StartControl>outro_start_position</StartControl>
-      <EndControl>outro_end_position</EndControl>
-      <Color>#0000FF</Color>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-      <DurationTextColor>#ffffff</DurationTextColor>
-      <DurationTextLocation>before</DurationTextLocation>
-    </MarkRange>
-    <Mark>
-      <Control>intro_start_position</Control>
-      <Text></Text>
-      <Align>top|right</Align>
-      <Color>#0000FF</Color>
-      <TextColor>#FFFFFF</TextColor>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-    </Mark>
-    <Mark>
-      <Control>intro_end_position</Control>
-      <Text>&#9698;</Text>
-      <Align>top|left</Align>
-      <Color>#0000FF</Color>
-      <TextColor>#FFFFFF</TextColor>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-    </Mark>
-    <Mark>
-      <Control>outro_start_position</Control>
-      <Text>&#9699;</Text>
-      <Align>top|right</Align>
-      <Color>#0000FF</Color>
-      <TextColor>#FFFFFF</TextColor>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-    </Mark>
-    <Mark>
-      <Control>outro_end_position</Control>
-      <Text></Text>
-      <Align>top|left</Align>
-      <Color>#0000FF</Color>
-      <TextColor>#FFFFFF</TextColor>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-    </Mark>
     <Mark>
       <Control>cue_point</Control>
       <Align>top|right</Align>
       <Color>#FF001C</Color>
       <TextColor>#FFFFFF</TextColor>
       <Text>C</Text>
+    </Mark>
+    <!-- Loop -->
+    <MarkRange>
+      <StartControl>loop_start_position</StartControl>
+      <EndControl>loop_end_position</EndControl>
+      <EnabledControl>loop_enabled</EnabledControl>
+      <Color>#00FF00</Color>
+      <Opacity>0.7</Opacity>
+      <DisabledColor>#FFFFFF</DisabledColor>
+      <DisabledOpacity>0.6</DisabledOpacity>
+    </MarkRange>
+    <!-- Intro -->
+    <MarkRange>
+      <StartControl>intro_start_position</StartControl>
+      <EndControl>intro_end_position</EndControl>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <Color>#0000FF</Color>
+      <Opacity>0.6</Opacity>
+      <DurationTextColor>#ffffff</DurationTextColor>
+      <DurationTextLocation>after</DurationTextLocation>
+    </MarkRange>
+    <Mark>
+      <Control>intro_start_position</Control>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <Text></Text>
+      <Align>top|right</Align>
+      <Color>#0000FF</Color>
+      <TextColor>#FFFFFF</TextColor>
+    </Mark>
+    <Mark>
+      <Control>intro_end_position</Control>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <Text>&#9698;</Text>
+      <Align>top|left</Align>
+      <Color>#0000FF</Color>
+      <TextColor>#FFFFFF</TextColor>
+    </Mark>
+    <!-- Outro -->
+    <MarkRange>
+      <StartControl>outro_start_position</StartControl>
+      <EndControl>outro_end_position</EndControl>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <Color>#0000FF</Color>
+      <Opacity>0.6</Opacity>
+      <DurationTextColor>#ffffff</DurationTextColor>
+      <DurationTextLocation>before</DurationTextLocation>
+    </MarkRange>
+    <Mark>
+      <Control>outro_start_position</Control>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <Text>&#9699;</Text>
+      <Align>top|right</Align>
+      <Color>#0000FF</Color>
+      <TextColor>#FFFFFF</TextColor>
+    </Mark>
+    <Mark>
+      <Control>outro_end_position</Control>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <Text></Text>
+      <Align>top|left</Align>
+      <Color>#0000FF</Color>
+      <TextColor>#FFFFFF</TextColor>
     </Mark>
     <Connection>
       <ConfigKey><Variable name="group"/>,playposition</ConfigKey>

--- a/res/skins/Deere/deck_visual_row.xml
+++ b/res/skins/Deere/deck_visual_row.xml
@@ -38,12 +38,23 @@
           <TextColor>#000000</TextColor>
           <Text> %1 </Text>
         </DefaultMark>
+        <Mark>
+          <Control>cue_point</Control>
+          <Pixmap>image/marker_cue.png</Pixmap>
+          <Text>CUE</Text>
+          <Align>bottom</Align>
+          <Color>#FF001C</Color>
+          <TextColor>#FFFFFF</TextColor>
+        </Mark>
+        <!-- Loop -->
         <MarkRange>
           <StartControl>loop_start_position</StartControl>
           <EndControl>loop_end_position</EndControl>
           <EnabledControl>loop_enabled</EnabledControl>
           <Color>#00FF00</Color>
+          <Opacity>0.8</Opacity>
           <DisabledColor>#FFFFFF</DisabledColor>
+          <DisabledOpacity>0.5</DisabledOpacity>
         </MarkRange>
         <Mark>
           <Control>loop_start_position</Control>
@@ -61,63 +72,59 @@
           <Color>#00FF00</Color>
           <TextColor>#FFFFFF</TextColor>
         </Mark>
+        <!-- Intro -->
         <MarkRange>
           <StartControl>intro_start_position</StartControl>
           <EndControl>intro_end_position</EndControl>
-          <Color>#0000FF</Color>
           <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-        </MarkRange>
-        <MarkRange>
-          <StartControl>outro_start_position</StartControl>
-          <EndControl>outro_end_position</EndControl>
           <Color>#0000FF</Color>
-          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+          <Opacity>0.1</Opacity>
         </MarkRange>
         <Mark>
           <Control>intro_start_position</Control>
+          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
           <Text>|&#9698;</Text>
           <Align>bottom</Align>
           <Color>#0000FF</Color>
           <TextColor>#FFFFFF</TextColor>
-          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
         </Mark>
         <Mark>
           <Control>intro_end_position</Control>
+          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
           <Text>&#9698;|</Text>
           <Align>bottom</Align>
           <Color>#0000FF</Color>
           <TextColor>#FFFFFF</TextColor>
-          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
         </Mark>
+        <!-- Outro -->
+        <MarkRange>
+          <StartControl>outro_start_position</StartControl>
+          <EndControl>outro_end_position</EndControl>
+          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+          <Color>#0000FF</Color>
+          <Opacity>0.1</Opacity>
+        </MarkRange>
         <Mark>
           <Control>outro_start_position</Control>
+          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
           <Text>|&#9699;</Text>
           <Align>bottom</Align>
           <Color>#0000FF</Color>
           <TextColor>#FFFFFF</TextColor>
-          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
         </Mark>
         <Mark>
           <Control>outro_end_position</Control>
+          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
           <Text>&#9699;|</Text>
           <Align>bottom</Align>
           <Color>#0000FF</Color>
           <TextColor>#FFFFFF</TextColor>
-          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
         </Mark>
         <!--
         The hotcues not represented by a button in the current skin show only in the waveform under two circumstances:
         - if a MIDI device which supports more hotcues than buttons are in the current skin has them activated
         - if you change from a skin which supports more hotcues than buttons are in the current skin (and has them activated)
         -->
-        <Mark>
-          <Control>cue_point</Control>
-          <Pixmap>image/marker_cue.png</Pixmap>
-          <Text>CUE</Text>
-          <Align>bottom</Align>
-          <Color>#FF001C</Color>
-          <TextColor>#FFFFFF</TextColor>
-        </Mark>
       </Visual>
 
       <WidgetGroup>

--- a/res/skins/LateNight/decks/overview.xml
+++ b/res/skins/LateNight/decks/overview.xml
@@ -40,17 +40,20 @@
       <EndControl>loop_end_position</EndControl>
       <EnabledControl>loop_enabled</EnabledControl>
       <Color><Variable name="LoopColor"/></Color>
+      <Opacity>0.7</Opacity>
       <DisabledColor>#FFFFFF</DisabledColor>
+      <DisabledOpacity>0.6</DisabledOpacity>
     </MarkRange>
     <Mark>
       <Control>loop_start_position</Control>
-      <!--Text>IN</Text-->
-      <Align>bottom|right</Align>
+      <Text>&#8635;</Text>
+      <Align>top|left</Align>
       <Color><Variable name="LoopColor"/></Color>
       <TextColor>#FFFFFF</TextColor>
     </Mark>
     <Mark>
       <Control>loop_end_position</Control>
+      <VisibilityControl><Variable name="Group"/>,loop_enabled</VisibilityControl>
       <!--Text>OUT</Text-->
       <Align>bottom|right</Align>
       <Color><Variable name="LoopColor"/></Color>
@@ -60,51 +63,53 @@
     <MarkRange>
       <StartControl>intro_start_position</StartControl>
       <EndControl>intro_end_position</EndControl>
-      <Color><Variable name="IntroOutroColor"/></Color>
       <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <Color><Variable name="IntroOutroColor"/></Color>
+      <Opacity>0.6</Opacity>
       <DurationTextColor>#ffffff</DurationTextColor>
       <DurationTextLocation>after</DurationTextLocation>
     </MarkRange>
     <Mark>
       <Control>intro_start_position</Control>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
       <Text></Text>
       <Align>top|right</Align>
       <Color><Variable name="IntroOutroColor"/></Color>
       <TextColor>#FFFFFF</TextColor>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
     </Mark>
     <Mark>
       <Control>intro_end_position</Control>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
       <Text>&#9698;</Text>
       <Align>top|left</Align>
       <Color><Variable name="IntroOutroColor"/></Color>
       <TextColor>#FFFFFF</TextColor>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
     </Mark>
     <!-- Outro -->
     <MarkRange>
       <StartControl>outro_start_position</StartControl>
       <EndControl>outro_end_position</EndControl>
-      <Color><Variable name="IntroOutroColor"/></Color>
       <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <Color><Variable name="IntroOutroColor"/></Color>
+      <Opacity>0.6</Opacity>
       <DurationTextColor>#ffffff</DurationTextColor>
       <DurationTextLocation>before</DurationTextLocation>
     </MarkRange>
     <Mark>
       <Control>outro_start_position</Control>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
       <Text>&#9699;</Text>
       <Align>top|right</Align>
       <Color><Variable name="IntroOutroColor"/></Color>
       <TextColor>#FFFFFF</TextColor>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
     </Mark>
     <Mark>
       <Control>outro_end_position</Control>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
       <Text></Text>
       <Align>top|left</Align>
       <Color><Variable name="IntroOutroColor"/></Color>
       <TextColor>#FFFFFF</TextColor>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
     </Mark>
   </Overview>
 </Template>

--- a/res/skins/LateNight/waveform.xml
+++ b/res/skins/LateNight/waveform.xml
@@ -49,18 +49,19 @@
               <EndControl>loop_end_position</EndControl>
               <EnabledControl>loop_enabled</EnabledControl>
               <Color><Variable name="LoopColor"/></Color>
+              <Opacity>0.8</Opacity>
               <DisabledColor>#FFFFFF</DisabledColor>
+              <DisabledOpacity>0.5</DisabledOpacity>
             </MarkRange>
             <Mark>
               <Control>loop_start_position</Control>
-              <!--Text>IN</Text-->
-              <Align>bottom|right</Align>
+              <Text>&#8635;</Text>
+              <Align>top|left</Align>
               <Color><Variable name="LoopColor"/></Color>
               <TextColor>#FFFFFF</TextColor>
             </Mark>
             <Mark>
               <Control>loop_end_position</Control>
-              <!--Text>OUT</Text-->
               <Align>bottom|right</Align>
               <Color><Variable name="LoopColor"/></Color>
               <TextColor>#FFFFFF</TextColor>
@@ -69,51 +70,53 @@
             <MarkRange>
               <StartControl>intro_start_position</StartControl>
               <EndControl>intro_end_position</EndControl>
-              <Color><Variable name="IntroOutroColor"/></Color>
               <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+              <Color><Variable name="IntroOutroColor"/></Color>
+              <Opacity>0.1</Opacity>
               <DurationTextColor>#ffffff</DurationTextColor>
               <DurationTextLocation>after</DurationTextLocation>
             </MarkRange>
             <Mark>
               <Control>intro_start_position</Control>
+              <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
               <Text></Text>
               <Align>top|right</Align>
               <Color><Variable name="IntroOutroColor"/></Color>
               <TextColor>#FFFFFF</TextColor>
-              <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
             </Mark>
             <Mark>
               <Control>intro_end_position</Control>
+              <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
               <Text>&#9698;</Text>
               <Align>top|left</Align>
               <Color><Variable name="IntroOutroColor"/></Color>
               <TextColor>#FFFFFF</TextColor>
-              <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
             </Mark>
             <!-- Outro -->
             <MarkRange>
               <StartControl>outro_start_position</StartControl>
               <EndControl>outro_end_position</EndControl>
-              <Color><Variable name="IntroOutroColor"/></Color>
               <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+              <Color><Variable name="IntroOutroColor"/></Color>
+              <Opacity>0.1</Opacity>
               <DurationTextColor>#ffffff</DurationTextColor>
               <DurationTextLocation>before</DurationTextLocation>
             </MarkRange>
             <Mark>
               <Control>outro_start_position</Control>
+              <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
               <Text>&#9699;</Text>
               <Align>top|right</Align>
               <Color><Variable name="IntroOutroColor"/></Color>
               <TextColor>#FFFFFF</TextColor>
-              <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
             </Mark>
             <Mark>
               <Control>outro_end_position</Control>
+              <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
               <Text></Text>
               <Align>top|left</Align>
               <Color><Variable name="IntroOutroColor"/></Color>
               <TextColor>#FFFFFF</TextColor>
-              <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
             </Mark>
           </Visual>
         </Children>

--- a/res/skins/Shade/deck_overview.xml
+++ b/res/skins/Shade/deck_overview.xml
@@ -19,66 +19,73 @@
       <TextColor>#FFFFFF</TextColor>
       <Text> %1 </Text>
     </DefaultMark>
-    <MarkRange>
-      <StartControl>loop_start_position</StartControl>
-      <EndControl>loop_end_position</EndControl>
-      <EnabledControl>loop_enabled</EnabledControl>
-      <Color>#00FF00</Color>
-      <DisabledColor>#FFFFFF</DisabledColor>
-    </MarkRange>
-    <MarkRange>
-      <StartControl>intro_start_position</StartControl>
-      <EndControl>intro_end_position</EndControl>
-      <Color>#0000FF</Color>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-      <DurationTextColor>#ffffff</DurationTextColor>
-      <DurationTextLocation>after</DurationTextLocation>
-    </MarkRange>
-    <MarkRange>
-      <StartControl>outro_start_position</StartControl>
-      <EndControl>outro_end_position</EndControl>
-      <Color>#0000FF</Color>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-      <DurationTextColor>#ffffff</DurationTextColor>
-      <DurationTextLocation>before</DurationTextLocation>
-    </MarkRange>
-    <Mark>
-      <Control>intro_start_position</Control>
-      <Text></Text>
-      <Align>top|right</Align>
-      <Color>#0000FF</Color>
-      <TextColor>#FFFFFF</TextColor>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-    </Mark>
-    <Mark>
-      <Control>intro_end_position</Control>
-      <Text>&#9698;</Text>
-      <Align>top|left</Align>
-      <Color>#0000FF</Color>
-      <TextColor>#FFFFFF</TextColor>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-    </Mark>
-    <Mark>
-      <Control>outro_start_position</Control>
-      <Text>&#9699;</Text>
-      <Align>top|right</Align>
-      <Color>#0000FF</Color>
-      <TextColor>#FFFFFF</TextColor>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-    </Mark>
-    <Mark>
-      <Control>outro_end_position</Control>
-      <Text></Text>
-      <Align>top|left</Align>
-      <Color>#0000FF</Color>
-      <TextColor>#FFFFFF</TextColor>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-    </Mark>
     <Mark>
       <Control>cue_point</Control>
       <Text>C</Text>
       <Align>top|right</Align>
       <Color>#FF001C</Color>
+      <TextColor>#FFFFFF</TextColor>
+    </Mark>
+    <!-- Loop -->
+    <MarkRange>
+      <StartControl>loop_start_position</StartControl>
+      <EndControl>loop_end_position</EndControl>
+      <EnabledControl>loop_enabled</EnabledControl>
+      <Color>#00FF00</Color>
+      <Opacity>0.7</Opacity>
+      <DisabledColor>#FFFFFF</DisabledColor>
+      <DisabledOpacity>0.6</DisabledOpacity>
+    </MarkRange>
+    <!-- Intro -->
+    <MarkRange>
+      <StartControl>intro_start_position</StartControl>
+      <EndControl>intro_end_position</EndControl>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <Color>#0000FF</Color>
+      <Opacity>0.6</Opacity>
+      <DurationTextColor>#ffffff</DurationTextColor>
+      <DurationTextLocation>after</DurationTextLocation>
+    </MarkRange>
+    <Mark>
+      <Control>intro_start_position</Control>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <Text></Text>
+      <Align>top|right</Align>
+      <Color>#0000FF</Color>
+      <TextColor>#FFFFFF</TextColor>
+    </Mark>
+    <Mark>
+      <Control>intro_end_position</Control>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <Text>&#9698;</Text>
+      <Align>top|left</Align>
+      <Color>#0000FF</Color>
+      <TextColor>#FFFFFF</TextColor>
+    </Mark>
+    <!-- Outro -->
+    <MarkRange>
+      <StartControl>outro_start_position</StartControl>
+      <EndControl>outro_end_position</EndControl>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <Color>#0000FF</Color>
+      <Opacity>0.6</Opacity>
+      <DurationTextColor>#ffffff</DurationTextColor>
+      <DurationTextLocation>before</DurationTextLocation>
+    </MarkRange>
+    <Mark>
+      <Control>outro_start_position</Control>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <Text>&#9699;</Text>
+      <Align>top|right</Align>
+      <Color>#0000FF</Color>
+      <TextColor>#FFFFFF</TextColor>
+    </Mark>
+    <Mark>
+      <Control>outro_end_position</Control>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <Text></Text>
+      <Align>top|left</Align>
+      <Color>#0000FF</Color>
       <TextColor>#FFFFFF</TextColor>
     </Mark>
     <Connection>

--- a/res/skins/Shade/waveform.xml
+++ b/res/skins/Shade/waveform.xml
@@ -20,12 +20,22 @@
       <TextColor>#FFFFFF</TextColor>
       <Text> %1 </Text>
     </DefaultMark>
+    <Mark>
+      <Control>cue_point</Control>
+      <Text>CUE</Text>
+      <Align>top</Align>
+      <Color>#FF001C</Color>
+      <TextColor>#FFFFFF</TextColor>
+    </Mark>
+    <!-- Loop -->
     <MarkRange>
       <StartControl>loop_start_position</StartControl>
       <EndControl>loop_end_position</EndControl>
       <EnabledControl>loop_enabled</EnabledControl>
       <Color>#00FF00</Color>
+      <Opacity>0.8</Opacity>
       <DisabledColor>#BCDBFB</DisabledColor>
+      <DisabledOpacity>0.5</DisabledOpacity>
     </MarkRange>
     <Mark>
       <Control>loop_start_position</Control>
@@ -41,49 +51,53 @@
       <Color>#00FF00</Color>
       <TextColor>#FFFFFF</TextColor>
     </Mark>
+    <!-- Intro -->
     <MarkRange>
       <StartControl>intro_start_position</StartControl>
       <EndControl>intro_end_position</EndControl>
-      <Color>#0000FF</Color>
       <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <Color>#0000FF</Color>
+      <Opacity>0.1</Opacity>
     </MarkRange>
     <MarkRange>
       <StartControl>outro_start_position</StartControl>
       <EndControl>outro_end_position</EndControl>
-      <Color>#0000FF</Color>
       <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <Color>#0000FF</Color>
     </MarkRange>
     <Mark>
       <Control>intro_start_position</Control>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
       <Text>|&#9698;</Text>
       <Align>bottom</Align>
       <Color>#0000FF</Color>
       <TextColor>#FFFFFF</TextColor>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
     </Mark>
+    <!-- Outro -->
     <Mark>
       <Control>intro_end_position</Control>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
       <Text>&#9698;|</Text>
       <Align>bottom</Align>
       <Color>#0000FF</Color>
+      <Opacity>0.1</Opacity>
       <TextColor>#FFFFFF</TextColor>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
     </Mark>
     <Mark>
       <Control>outro_start_position</Control>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
       <Text>|&#9699;</Text>
       <Align>bottom</Align>
       <Color>#0000FF</Color>
       <TextColor>#FFFFFF</TextColor>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
     </Mark>
     <Mark>
       <Control>outro_end_position</Control>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
       <Text>&#9699;|</Text>
       <Align>bottom</Align>
       <Color>#0000FF</Color>
       <TextColor>#FFFFFF</TextColor>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
     </Mark>
     <!--
     The hotcues not represented by a button in the current skin
@@ -93,13 +107,5 @@
     - if you change from a skin which supports more hotcues
       than buttons are in the current skin (and has them activated)
     -->
-    <Mark>
-      <Control>cue_point</Control>
-      <Text>CUE</Text>
-      <Align>top</Align>
-      <Color>#FF001C</Color>
-      <TextColor>#FFFFFF</TextColor>
-    </Mark>
   </Visual>
 </Template>
-

--- a/res/skins/Tango/deck_overview.xml
+++ b/res/skins/Tango/deck_overview.xml
@@ -34,12 +34,22 @@ Variables:
       <TextColor>#FFFFFF</TextColor>
       <Text> %1 </Text>
     </DefaultMark>
+    <Mark>
+      <Control>cue_point</Control>
+      <Text>Q</Text>
+      <Align>vcenter|right</Align>
+      <Color>#FF0080</Color>
+      <TextColor>#FFFFFF</TextColor>
+    </Mark>
+    <!-- Loop -->
     <MarkRange>
       <StartControl>loop_start_position</StartControl>
       <EndControl>loop_end_position</EndControl>
       <EnabledControl>loop_enabled</EnabledControl>
       <Color>#00FF00</Color>
+      <Opacity>0.7</Opacity>
       <DisabledColor>#FFFFFF</DisabledColor>
+      <DisabledOpacity>0.6</DisabledOpacity>
     </MarkRange>
     <Mark>
       <Control>loop_start_position</Control>
@@ -57,59 +67,56 @@ Variables:
       <Align>top|right</Align>
       <TextColor>#FFFFFF</TextColor>
     </Mark>
+    <!-- Intro -->
     <MarkRange>
       <StartControl>intro_start_position</StartControl>
       <EndControl>intro_end_position</EndControl>
-      <Color>#0000FF</Color>
       <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <Color>#0000FF</Color>
+      <Opacity>0.6</Opacity>
       <DurationTextColor>#ffffff</DurationTextColor>
       <DurationTextLocation>after</DurationTextLocation>
     </MarkRange>
-    <MarkRange>
-      <StartControl>outro_start_position</StartControl>
-      <EndControl>outro_end_position</EndControl>
-      <Color>#0000FF</Color>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-      <DurationTextColor>#ffffff</DurationTextColor>
-      <DurationTextLocation>before</DurationTextLocation>
-    </MarkRange>
     <Mark>
       <Control>intro_start_position</Control>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
       <Text></Text>
       <Align>top|right</Align>
       <Color>#0000FF</Color>
       <TextColor>#FFFFFF</TextColor>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
     </Mark>
     <Mark>
       <Control>intro_end_position</Control>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
       <Text>&#9698;</Text>
       <Align>top|left</Align>
       <Color>#0000FF</Color>
       <TextColor>#FFFFFF</TextColor>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
     </Mark>
+    <!-- Outro -->
+    <MarkRange>
+      <StartControl>outro_start_position</StartControl>
+      <EndControl>outro_end_position</EndControl>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <Color>#0000FF</Color>
+      <Opacity>0.6</Opacity>
+      <DurationTextColor>#ffffff</DurationTextColor>
+      <DurationTextLocation>before</DurationTextLocation>
+    </MarkRange>
     <Mark>
       <Control>outro_start_position</Control>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
       <Text>&#9699;</Text>
       <Align>top|right</Align>
       <Color>#0000FF</Color>
       <TextColor>#FFFFFF</TextColor>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
     </Mark>
     <Mark>
       <Control>outro_end_position</Control>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
       <Text></Text>
       <Align>top|left</Align>
       <Color>#0000FF</Color>
-      <TextColor>#FFFFFF</TextColor>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-    </Mark>
-    <Mark>
-      <Control>cue_point</Control>
-      <Text>Q</Text>
-      <Align>vcenter|right</Align>
-      <Color>#FF0080</Color>
       <TextColor>#FFFFFF</TextColor>
     </Mark>
     <Connection>

--- a/res/skins/Tango/waveform.xml
+++ b/res/skins/Tango/waveform.xml
@@ -37,50 +37,6 @@ Variables:
           <TextColor>#FFFFFF</TextColor>
           <Text> %1 </Text>
         </DefaultMark>
-        <MarkRange>
-          <StartControl>intro_start_position</StartControl>
-          <EndControl>intro_end_position</EndControl>
-          <Color>#0000FF</Color>
-          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-        </MarkRange>
-        <MarkRange>
-          <StartControl>outro_start_position</StartControl>
-          <EndControl>outro_end_position</EndControl>
-          <Color>#0000FF</Color>
-          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-        </MarkRange>
-        <Mark>
-          <Control>intro_start_position</Control>
-          <Text>|&#9698;</Text>
-          <Align>bottom</Align>
-          <Color>#0000FF</Color>
-          <TextColor>#FFFFFF</TextColor>
-          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-        </Mark>
-        <Mark>
-          <Control>intro_end_position</Control>
-          <Text>&#9698;|</Text>
-          <Align>bottom</Align>
-          <Color>#0000FF</Color>
-          <TextColor>#FFFFFF</TextColor>
-          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-        </Mark>
-        <Mark>
-          <Control>outro_start_position</Control>
-          <Text>|&#9699;</Text>
-          <Align>bottom</Align>
-          <Color>#0000FF</Color>
-          <TextColor>#FFFFFF</TextColor>
-          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-        </Mark>
-        <Mark>
-          <Control>outro_end_position</Control>
-          <Text>&#9699;|</Text>
-          <Align>bottom</Align>
-          <Color>#0000FF</Color>
-          <TextColor>#FFFFFF</TextColor>
-          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-        </Mark>
         <Mark>
           <Control>cue_point</Control>
           <Text>Q</Text>
@@ -88,6 +44,7 @@ Variables:
           <Color>#FF0080</Color>
           <TextColor>#FFFFFF</TextColor>
         </Mark>
+        <!-- Loop -->
         <MarkRange>
           <StartControl>loop_start_position</StartControl>
           <EndControl>loop_end_position</EndControl>
@@ -109,20 +66,57 @@ Variables:
           <Color>#00FF00</Color>
           <TextColor>#FFFFFF</TextColor>
         </Mark>
+        <!-- Intro -->
+        <MarkRange>
+          <StartControl>intro_start_position</StartControl>
+          <EndControl>intro_end_position</EndControl>
+          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+          <Color>#0000FF</Color>
+        </MarkRange>
+        <Mark>
+          <Control>intro_start_position</Control>
+          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+          <Text>|&#9698;</Text>
+          <Align>bottom</Align>
+          <Color>#0000FF</Color>
+          <TextColor>#FFFFFF</TextColor>
+        </Mark>
+        <Mark>
+          <Control>intro_end_position</Control>
+          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+          <Text>&#9698;|</Text>
+          <Align>bottom</Align>
+          <Color>#0000FF</Color>
+          <TextColor>#FFFFFF</TextColor>
+        </Mark>
+        <!-- Outro -->
+        <MarkRange>
+          <StartControl>outro_start_position</StartControl>
+          <EndControl>outro_end_position</EndControl>
+          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+          <Color>#0000FF</Color>
+        </MarkRange>
+        <Mark>
+          <Control>outro_start_position</Control>
+          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+          <Text>|&#9699;</Text>
+          <Align>bottom</Align>
+          <Color>#0000FF</Color>
+          <TextColor>#FFFFFF</TextColor>
+        </Mark>
+        <Mark>
+          <Control>outro_end_position</Control>
+          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+          <Text>&#9699;|</Text>
+          <Align>bottom</Align>
+          <Color>#0000FF</Color>
+          <TextColor>#FFFFFF</TextColor>
+        </Mark>
         <!--
         The hotcues not represented by a button in the current skin show only in the waveform under two circumstances:
           - if a MIDI device which supports more hotcues than buttons are in the current skin has them activated
           - if you change from a skin which supports more hotcues than buttons are in the current skin
           (and has them activated)
-        -->
-        <!--
-        <Mark>
-          <Control>cue_point</Control>
-          <Text>C</Text>
-          <Align>bottom</Align>
-          <Color>#FF001C</Color>
-          <TextColor>#FFFFFF</TextColor>
-        </Mark>
         -->
       </Visual>
 

--- a/src/waveform/renderers/waveformmarkrange.cpp
+++ b/src/waveform/renderers/waveformmarkrange.cpp
@@ -14,6 +14,8 @@ WaveformMarkRange::WaveformMarkRange(
         const WaveformSignalColors& signalColors)
         : m_activeColor(context.selectString(node, "Color")),
           m_disabledColor(context.selectString(node, "DisabledColor")),
+          m_enabledOpacity(context.selectDouble(node, "Opacity", 0.5)),
+          m_disabledOpacity(context.selectDouble(node, "DisabledOpacity", 0.5)),
           m_durationTextColor(context.selectString(node, "DurationTextColor")) {
     if (!m_activeColor.isValid()) {
         //vRince kind of legacy fallback ...

--- a/src/waveform/renderers/waveformmarkrange.h
+++ b/src/waveform/renderers/waveformmarkrange.h
@@ -60,6 +60,8 @@ class WaveformMarkRange {
 
     QColor m_activeColor;
     QColor m_disabledColor;
+    double m_enabledOpacity;
+    double m_disabledOpacity;
     QColor m_durationTextColor;
 
     QImage m_activeImage;

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -740,11 +740,11 @@ void WOverview::drawRangeMarks(QPainter* pPainter, const float& offset, const fl
         PainterScope painterScope(pPainter);
 
         if (markRange.enabled()) {
-            pPainter->setOpacity(0.4);
+            pPainter->setOpacity(markRange.m_enabledOpacity);
             pPainter->setPen(markRange.m_activeColor);
             pPainter->setBrush(markRange.m_activeColor);
         } else {
-            pPainter->setOpacity(0.2);
+            pPainter->setOpacity(markRange.m_disabledOpacity);
             pPainter->setPen(markRange.m_disabledColor);
             pPainter->setBrush(markRange.m_disabledColor);
         }

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -573,6 +573,8 @@ void WOverview::paintEvent(QPaintEvent* pEvent) {
         drawEndOfTrackBackground(&painter);
         drawAxis(&painter);
         drawWaveformPixmap(&painter);
+        drawPlayedOverlay(&painter);
+        drawPlayPosition(&painter);
         drawEndOfTrackFrame(&painter);
         drawAnalyzerProgress(&painter);
 
@@ -643,16 +645,24 @@ void WOverview::drawWaveformPixmap(QPainter* pPainter) {
         }
 
         pPainter->drawImage(rect(), m_waveformImageScaled);
+    }
+}
 
-        // Overlay the played part of the overview-waveform with a skin defined color
-        if (m_playedOverlayColor.alpha() > 0) {
-            if (m_orientation == Qt::Vertical) {
-                pPainter->fillRect(0, 0, m_waveformImageScaled.width(), m_iPlayPos, m_playedOverlayColor);
-            } else {
-                pPainter->fillRect(0, 0, m_iPlayPos, m_waveformImageScaled.height(), m_playedOverlayColor);
-            }
+void WOverview::drawPlayedOverlay(QPainter* pPainter) {
+    // Overlay the played part of the overview-waveform with a skin defined color
+    if (!m_waveformSourceImage.isNull() && m_playedOverlayColor.alpha() > 0) {
+        if (m_orientation == Qt::Vertical) {
+            pPainter->fillRect(0, 0, m_waveformImageScaled.width(), m_iPlayPos, m_playedOverlayColor);
+        } else {
+            pPainter->fillRect(0, 0, m_iPlayPos, m_waveformImageScaled.height(), m_playedOverlayColor);
         }
     }
+}
+
+void WOverview::drawPlayPosition(QPainter* pPainter) {
+    // When the position line is currently dragged with the left mouse button
+    // draw a thin line -without triangles or shadow- at the playposition.
+    // The new playposition is drawn by drawPickupPosition()
     if (m_bLeftClickDragging) {
         PainterScope painterScope(pPainter);
         QLineF line;

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -789,16 +789,18 @@ void WOverview::drawMarks(QPainter* pPainter, const float offset, const float ga
                 static_cast<qreal>(width()));
         pMark->m_linePosition = markPosition;
 
-        QPen shadowPen(QBrush(pMark->borderColor()), 2.5 * m_scaleFactor);
-
         QLineF line;
+        QLineF bgLine;
         if (m_orientation == Qt::Horizontal) {
             line.setLine(markPosition, 0.0, markPosition, height());
+            bgLine.setLine(markPosition - 1.0, 0.0, markPosition - 1.0, height());
         } else {
             line.setLine(0.0, markPosition, width(), markPosition);
+            bgLine.setLine(0.0, markPosition - 1.0, width(), markPosition - 1.0);
         }
-        pPainter->setPen(shadowPen);
-        pPainter->drawLine(line);
+
+        pPainter->setPen(pMark->borderColor());
+        pPainter->drawLine(bgLine);
 
         pPainter->setPen(pMark->fillColor());
         pPainter->drawLine(line);

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -968,19 +968,23 @@ void WOverview::drawPickupPosition(QPainter* pPainter) {
         pPainter->setTransform(QTransform(0, 1, 1, 0, 0, 0));
     }
 
+    // draw dark play position outlines
     pPainter->setPen(QPen(QBrush(m_backgroundColor), m_scaleFactor));
     pPainter->setOpacity(0.5);
     pPainter->drawLine(m_iPickupPos + 1, 0, m_iPickupPos + 1, breadth());
     pPainter->drawLine(m_iPickupPos - 1, 0, m_iPickupPos - 1, breadth());
 
+    // draw colored play position line
     pPainter->setPen(QPen(m_playPosColor, m_scaleFactor));
     pPainter->setOpacity(1.0);
     pPainter->drawLine(m_iPickupPos, 0, m_iPickupPos, breadth());
 
+    // draw triangle at the top
     pPainter->drawLine(m_iPickupPos - 2, 0, m_iPickupPos, 2);
     pPainter->drawLine(m_iPickupPos, 2, m_iPickupPos + 2, 0);
     pPainter->drawLine(m_iPickupPos - 2, 0, m_iPickupPos + 2, 0);
 
+    // draw triangle at the bottom
     pPainter->drawLine(m_iPickupPos - 2, breadth() - 1, m_iPickupPos, breadth() - 3);
     pPainter->drawLine(m_iPickupPos, breadth() - 3, m_iPickupPos + 2, breadth() - 1);
     pPainter->drawLine(m_iPickupPos - 2, breadth() - 1, m_iPickupPos + 2, breadth() - 1);

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -110,6 +110,8 @@ class WOverview : public WWidget, public TrackDropTarget {
     void drawEndOfTrackBackground(QPainter* pPainter);
     void drawAxis(QPainter* pPainter);
     void drawWaveformPixmap(QPainter* pPainter);
+    void drawPlayedOverlay(QPainter* pPainter);
+    void drawPlayPosition(QPainter* pPainter);
     void drawEndOfTrackFrame(QPainter* pPainter);
     void drawAnalyzerProgress(QPainter* pPainter);
     void drawRangeMarks(QPainter* pPainter, const float& offset, const float& gain);

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -165,12 +165,16 @@ class WOverview : public WWidget, public TrackDropTarget {
 
     QPixmap m_backgroundPixmap;
     QString m_backgroundPixmapPath;
-    QColor m_qColorBackground;
+    QColor m_backgroundColor;
     int m_iLabelFontSize;
     QColor m_labelTextColor;
     QColor m_labelBackgroundColor;
+    QColor m_axesColor;
+    QColor m_playPosColor;
     QColor m_endOfTrackColor;
     QColor m_passthroughOverlayColor;
+    QColor m_playedOverlayColor;
+    QColor m_lowColor;
     QLabel* m_pPassthroughLabel;
 
     // All WaveformMarks


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1842338
[Zulip: Improve visibility of loops on overview waveforms](https://mixxx.zulipchat.com/#narrow/stream/247619-design/topic/Improve.20visibility.20of.20loops.20on.20overview.20waveforms)

Before, marker contrast borders looked like double strokes when `color.isDimColor()` which made them appear like a tiny ranges. Due to rounding issue it was also not drawn consistently: sometime it's a single stroke at one side, sometimes it's a double stroke.

- [x] allow custom opacities for disabled & enabled mark ranges, allows more appearance control in conjunction with different range colors https://github.com/mixxxdj/mixxx/pull/3003/commits/427f3f8dbf7370833ffd808fe542ff5febcdb072: `<MarkRange>` accepts nodes `<Opacity>` and `<DisabledOpacity>`, both default to `0.5` (0.4 and 0.2 before)
- [x] improve mark rendering: Before, marker contrast borders looked like double strokes when `color.isDimColor()` which made them appear like a tiny ranges. Due to rounding issue it was also not drawn consistently: sometime it's a single stroke at one side, sometimes it's a double stroke.
- [x] move drawing of playedOverlay & playPosition to separate functions
- [x] add skin changes
- [ ] test & adjust opacity values

before: Note that 2, 3, 6 & 8 are all hotcues with the same color
![image](https://user-images.githubusercontent.com/5934199/89561715-33057880-d819-11ea-98a0-90ca676e99f9.png)
this PR:
![image](https://user-images.githubusercontent.com/5934199/89561738-3c8ee080-d819-11ea-9206-459bb269d16f.png)



* draw mark ranges _behind_ waveform ?
ranges render may-be relevant parts of waveform unreadable
ranges stand out to much over played part of the overview