### PR TITLE
Ignore log messages for disabled log levels

### DIFF
--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -155,6 +155,10 @@ void handleMessage(
         writeFlags = WriteFlag::All;
         break;
     }
+    if (!writeFlags) {
+        // Ignore message for disabled log level
+        return;
+    }
     VERIFY_OR_DEBUG_ASSERT(levelName) {
         return;
     }


### PR DESCRIPTION
This fix is required when merging #2911 with log level *Info* for tests into master.