### PR TITLE
AutoDJ: show playlist when clicking any AutoDJ tree child item

### DIFF
--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -287,6 +287,11 @@ void AutoDJFeature::constructCrateChildModel() {
     }
 }
 
+void AutoDJFeature::activateChild(const QModelIndex& index) {
+    Q_UNUSED(index);
+    activate();
+}
+
 void AutoDJFeature::onRightClickChild(const QPoint& globalPos,
                                       QModelIndex index) {
     TreeItem* pClickedItem = static_cast<TreeItem*>(index.internalPointer());

--- a/src/library/autodj/autodjfeature.h
+++ b/src/library/autodj/autodjfeature.h
@@ -59,6 +59,7 @@ class AutoDJFeature : public LibraryFeature {
 
     // Temporary, until WCrateTableView can be written.
     void onRightClickChild(const QPoint& globalPos, QModelIndex index) override;
+    void activateChild(const QModelIndex& index) override;
 
   private:
     TrackCollection* const m_pTrackCollection;


### PR DESCRIPTION
previous situation:
* activate Computer root item
* expand AutoDJ, activate Crates (or any crate)
= root view of Computer is still shown

now: show AutoDJ root view (controls & playlist)

https://bugs.launchpad.net/mixxx/+bug/1890969