### PR TITLE
fix fullscreen shortcut issues

### DIFF
--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -265,9 +265,17 @@ void WMainMenuBar::initialize() {
     QString fullScreenTitle = tr("&Full Screen");
     QString fullScreenText = tr("Display Mixxx using the full screen");
     auto pViewFullScreen = new QAction(fullScreenTitle, this);
-    QList<QKeySequence> shortcuts;
-    shortcuts << QKeySequence::FullScreen;
-    shortcuts << QKeySequence("F11");
+    QList<QKeySequence> shortcuts{QKeySequence("F11")};
+    QKeySequence osShortcut = QKeySequence::FullScreen;
+    // Note(ronso0) Only add the OS shortcut if it's not empty and not F11.
+    // In some Linux distros the window managers doesn't pass the OS fullscreen
+    // key sequence to Mixxx for some reason.
+    // Both adding an empty key sequence or the same sequence twice can render
+    // the fullscreen shortcut nonfunctional.
+    // https://bugs.launchpad.net/mixxx/+bug/1882474  PR #3011
+    if (!osShortcut.isEmpty() && !shortcuts.contains(osShortcut)) {
+        shortcuts << osShortcut;
+    }
 
     pViewFullScreen->setShortcuts(shortcuts);
     pViewFullScreen->setShortcutContext(Qt::ApplicationShortcut);


### PR DESCRIPTION
follow-up to #2735 

[lp:1882474](https://bugs.launchpad.net/mixxx/+bug/1882474) "Unable to exit fullscreen mode Windows 2.3.0-beta"
maybe also [lp:1888455](https://bugs.launchpad.net/mixxx/+bug/1888455) "F11 to Fullscreen Crashes 2.3 on Ubuntu Studio 20.04"

* add `F11`
* add OS shortcut only if it's
    * not F11 and
    * not empty F11

**ToDo**
Test on Linux:
- [x] xfwm4
- [x] GNOME Shell
- [x] Cinnamon
- [ ] other window managers?


* [x] test on Windows
* [ ] test on MacOS

- [x] remove debug output >simplify