### PR TITLE
tools: Reset start line number after group of lines has been found

### DIFF
--- a/tools/clang_format.py
+++ b/tools/clang_format.py
@@ -42,7 +42,12 @@ def run_clang_format_on_lines(rootdir, file_to_format, stylepath=None):
     ]
     assert line_arguments
 
-    logger.info("Reformatting %s...", file_to_format.filename)
+    logger.info(
+        "Reformatting %s [%s]...",
+        file_to_format.filename,
+        ", ".join("{}-{}".format(*x) for x in file_to_format.lines),
+    )
+
     filename = os.path.join(rootdir, file_to_format.filename)
     cmd = [
         "clang-format",

--- a/tools/githelper.py
+++ b/tools/githelper.py
@@ -121,6 +121,7 @@ def get_changed_lines_grouped(
                     grouped_linenumbers.append(
                         (start_linenumber, last_linenumber)
                     )
+                    start_linenumber = None
 
             if start_linenumber is None:
                 start_linenumber = line.number


### PR DESCRIPTION
Without this commit, start line number was never reset. This means that
if you changed lines 10-12 and 230-235 in a file, the
`githelper.get_changed_lines_grouped()` would actually mark lines
10-12 and 10-235 as changed.

This leads to unnecessary and undesired changes made by the clang-format
pre-commit hook.