### PR TITLE
Fix some clang-tidy warnings

### DIFF
--- a/src/engine/controls/ratecontrol.cpp
+++ b/src/engine/controls/ratecontrol.cpp
@@ -392,7 +392,7 @@ double RateControl::calculateSpeed(double baserate, double speed, bool paused,
 
     processTempRate(iSamplesPerBuffer);
 
-    double rate = (paused ? 0 : 1.0);
+    double rate;
     double searching = m_pRateSearch->get();
     if (searching) {
         // If searching is in progress, it overrides everything else

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -923,7 +923,6 @@ void EngineBuffer::processTrackLocked(
         rate = m_rate_old;
     }
 
-    bool at_start = m_filepos_play <= 0;
     bool at_end = m_filepos_play >= m_trackSamplesOld;
     bool backwards = rate < 0;
 
@@ -997,7 +996,7 @@ void EngineBuffer::processTrackLocked(
     m_scratching_old = is_scratching;
 
     // Handle repeat mode
-    at_start = m_filepos_play <= 0;
+    bool at_start = m_filepos_play <= 0;
     at_end = m_filepos_play >= m_trackSamplesOld;
 
     bool repeat_enabled = m_pRepeat->toBool();

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1249,13 +1249,6 @@ void EngineBuffer::updateIndicators(double speed, int iBufferSize) {
 
     const double fFractionalPlaypos = fractionalPlayposFromAbsolute(m_filepos_play);
 
-    double ratio = m_tempo_ratio_old;
-    if (ratio == 0.0) {
-        // In case the track is slowed done to zero we will have INF remaining seconds.
-        // We jump back to a rate of 1.0 to show a useful time.
-        ratio = 1.0;
-    }
-
     const double tempoTrackSeconds = m_trackSamplesOld / kSamplesPerFrame
             / m_trackSampleRateOld / m_tempo_ratio_old;
     if(speed > 0 && fFractionalPlaypos == 1.0) {

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -36,7 +36,7 @@ EngineMaster::EngineMaster(
         ChannelHandleFactoryPointer pChannelHandleFactory,
         bool bEnableSidechain)
         : m_pChannelHandleFactory(pChannelHandleFactory),
-          m_pEngineEffectsManager(pEffectsManager ? pEffectsManager->getEngineEffectsManager() : NULL),
+          m_pEngineEffectsManager(pEffectsManager->getEngineEffectsManager()),
           m_masterGainOld(0.0),
           m_boothGainOld(0.0),
           m_headphoneMasterGainOld(0.0),

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -465,11 +465,15 @@ void EngineMaster::process(const int iBufferSize) {
     // Process effects on all microphones mixed together
     // We have no metadata for mixed effect buses, so use an empty GroupFeatureState.
     GroupFeatureState busFeatures;
-    m_pEngineEffectsManager->processPostFaderInPlace(
-            m_busTalkoverHandle.handle(),
-            m_masterHandle.handle(),
-            m_pTalkover,
-            m_iBufferSize, m_iSampleRate, busFeatures);
+    if (m_pEngineEffectsManager) {
+        m_pEngineEffectsManager->processPostFaderInPlace(
+                m_busTalkoverHandle.handle(),
+                m_masterHandle.handle(),
+                m_pTalkover,
+                m_iBufferSize,
+                m_iSampleRate,
+                busFeatures);
+    }
 
     switch (m_pTalkoverDucking->getMode()) {
     case EngineTalkoverDucking::OFF:

--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -915,7 +915,6 @@ void PlaylistDAO::shuffleTracks(const int playlistId, const QList<int>& position
 
             trackBPosition = positions.at(randomShuffleSetIndex);
             trackBId = trackPositionIds.value(trackBPosition);
-            conflictFound = false;
             int trackDistance = -1;
             int playlistEnd = trackPositionIds.count();
 

--- a/src/test/directorydaotest.cpp
+++ b/src/test/directorydaotest.cpp
@@ -76,6 +76,7 @@ TEST_F(DirectoryDAOTest, addDirTest) {
     QSqlQuery query(dbConnection());
     query.prepare("SELECT " % DIRECTORYDAO_DIR % " FROM " % DIRECTORYDAO_TABLE);
     success = query.exec();
+    ASSERT_TRUE(success);
 
     // we do not trust what directory dao thinks and better check up on it
     QStringList dirs;
@@ -102,6 +103,8 @@ TEST_F(DirectoryDAOTest, removeDirTest) {
     QSqlQuery query(dbConnection());
     query.prepare("SELECT " % DIRECTORYDAO_DIR % " FROM " % DIRECTORYDAO_TABLE);
     success = query.exec();
+    ASSERT_TRUE(success);
+
     QStringList dirs;
     while (query.next()) {
         dirs << query.value(0).toString();

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -693,7 +693,7 @@ void Track::initId(TrackId id) {
         return; // abort
     }
     m_record.setId(id);
-    for (const auto pCue : qAsConst(m_cuePoints)) {
+    for (const CuePointer& pCue : qAsConst(m_cuePoints)) {
         pCue->setTrackId(id);
     }
     // Changing the Id does not make the track dirty because the Id is always
@@ -703,7 +703,7 @@ void Track::initId(TrackId id) {
 void Track::resetId() {
     QMutexLocker lock(&m_qMutex);
     m_record.setId(TrackId());
-    for (const auto pCue : qAsConst(m_cuePoints)) {
+    for (const CuePointer& pCue : qAsConst(m_cuePoints)) {
         pCue->setTrackId(TrackId());
     }
 }


### PR DESCRIPTION
This fixes some of the issues that clang-tidy complains about.

Found by running cmake with the `-DCMAKE_CXX_CLANG_TIDY=clang-tidy` argument. 