### PR TITLE
midi-components: Fix `[Channelundefined]` when using Deck with number

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -676,7 +676,7 @@
             print("ERROR! new Deck() called without specifying any deck numbers");
             return;
         }
-        this.currentDeck = "[Channel" + deckNumbers[0] + "]";
+        this.currentDeck = "[Channel" + this.deckNumbers[0] + "]";
     };
     Deck.prototype = new ComponentContainer({
         setCurrentDeck: function(newGroup) {


### PR DESCRIPTION
Fixed a bug introduced by #2948. Sorry!