### PR TITLE
TrackDAO/GlobalTrackCache: Handle file aliasing

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1227,7 +1227,20 @@ TrackPointer TrackDAO::getTrackFromDB(TrackId trackId) const {
         // Just to be safe, but this should never happen!!
         return pTrack;
     }
-    DEBUG_ASSERT(pTrack->getId() == trackId);
+    if (pTrack->getId() != trackId) {
+        // This happens if two different tracks are referencing
+        // the same (physical) file on the file system!! Due to
+        // symbolic links different locations may resolve to the
+        // same canonical location. We can only load each file
+        // once at a time.
+        kLogger.warning()
+                << "Returning already loaded track"
+                << pTrack->getId()
+                << "instead of"
+                << trackId
+                << "with the same canonical file location"
+                << pTrack->getFileInfo().canonicalFilePath();
+    }
     if (cacheResolver.getLookupResult() == GlobalTrackCacheLookupResult::HIT) {
         // Due to race conditions the track might have been reloaded
         // from the database in the meantime. In this case we abort

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -403,6 +403,13 @@ TrackPointer GlobalTrackCache::lookupByRef(
     if (trackRef.hasCanonicalLocation()) {
         trackPtr = lookupByCanonicalLocation(trackRef.getCanonicalLocation());
         if (trackPtr) {
+            if (trackRef.hasId() &&
+                    trackRef.getId() != trackPtr->getId()) {
+                kLogger.warning()
+                        << "Found a different track with the same canonical location:"
+                        << "expected =" << trackRef
+                        << "actual =" << createTrackRef(*trackPtr);
+            }
             return trackPtr;
         }
     }

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -532,7 +532,8 @@ void GlobalTrackCache::resolve(
                     << "Resolving track by canonical location"
                     << trackRef.getCanonicalLocation();
         }
-        auto strongPtr = lookupByRef(trackRef);
+        auto strongPtr = lookupByCanonicalLocation(
+                trackRef.getCanonicalLocation());
         if (strongPtr) {
             // Cache hit
             if (debugLogEnabled()) {

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -226,10 +226,12 @@ private:
     void relocateTracks(
             GlobalTrackCacheRelocator* /*nullable*/ pRelocator);
 
-    TrackPointer lookupById(
-            const TrackId& trackId);
     TrackPointer lookupByRef(
             const TrackRef& trackRef);
+    TrackPointer lookupById(
+            const TrackId& trackId);
+    TrackPointer lookupByCanonicalLocation(
+            const QString& canonicalLocation);
 
     TrackPointer revive(GlobalTrackCacheEntryPointer entryPtr);
 

--- a/src/track/trackref.cpp
+++ b/src/track/trackref.cpp
@@ -1,5 +1,6 @@
 #include "track/trackref.h"
 
+#include <QDebugStateSaver>
 
 bool TrackRef::verifyConsistency() const {
     // Class invariant: The location can only be set together with
@@ -16,17 +17,25 @@ bool TrackRef::verifyConsistency() const {
 }
 
 std::ostream& operator<<(std::ostream& os, const TrackRef& trackRef) {
-    return os << '[' << trackRef.getLocation().toStdString()
-            << " | " << trackRef.getCanonicalLocation().toStdString()
-            << " | " << trackRef.getId()
-            << ']';
-
+    return os
+            << "TrackRef{"
+            << trackRef.getLocation().toStdString()
+            << ','
+            << trackRef.getCanonicalLocation().toStdString()
+            << ','
+            << trackRef.getId()
+            << '}';
 }
 
-QDebug operator<<(QDebug debug, const TrackRef& trackRef) {
-    debug.nospace() << '[' << trackRef.getLocation()
-                    << " | " << trackRef.getCanonicalLocation()
-                    << " | " << trackRef.getId()
-                    << ']';
-    return debug.space();
+QDebug operator<<(QDebug dbg, const TrackRef& trackRef) {
+    const QDebugStateSaver saver(dbg);
+    dbg = dbg.maybeSpace() << "TrackRef";
+    return dbg.nospace()
+            << '{'
+            << trackRef.getLocation()
+            << ','
+            << trackRef.getCanonicalLocation()
+            << ','
+            << trackRef.getId()
+            << '}';
 }


### PR DESCRIPTION
Topic on Zulip: [DEBUG_ASSDERT in GlobalTrackCache::resolve](https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/DEBUG_ASSDERT.20in.20GlobalTrackCache.3A.3Aresolve)

Two tracks with different locations but the same canonical locations cause a debug assertion. This is possible by creating a symbolic link to an existing track in the music folder and rescanning the library. Both tracks are now shown in the library, but they refer to the same file.

Only one of those tracks could be loaded at the same time!! This might cause some inconvenience and inconsistencies in the UI when editing the track properties, but it prevents file corruption when exporting file tags.

Not sure if this is a critical bug. Backport to 2.2? I did not check if this is feasible.