### PR TITLE
TrackDAO/GlobalTrackCache: Handle file aliasing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 * Add controller mapping for Hercules DJControl Inpulse 200 #2542
 * Add controller mapping for Hercules DJControl Jogvision #2370
 * Fix missing manual in deb package lp:1889776
+* Fix caching of duplicate tracks that reference the same file #3027
 
 ==== 2.2.4 2020-05-10 ====
 

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1227,7 +1227,20 @@ TrackPointer TrackDAO::getTrackFromDB(TrackId trackId) const {
         // Just to be safe, but this should never happen!!
         return pTrack;
     }
-    DEBUG_ASSERT(pTrack->getId() == trackId);
+    if (pTrack->getId() != trackId) {
+        // This happens if two different tracks are referencing
+        // the same (physical) file on the file system!! Due to
+        // symbolic links different locations may resolve to the
+        // same canonical location. We can only load each file
+        // once at a time.
+        kLogger.warning()
+                << "Returning already loaded track"
+                << pTrack->getId()
+                << "instead of"
+                << trackId
+                << "with the same canonical file location"
+                << pTrack->getFileInfo().canonicalFilePath();
+    }
     if (cacheResolver.getLookupResult() == GlobalTrackCacheLookupResult::HIT) {
         // Due to race conditions the track might have been reloaded
         // from the database in the meantime. In this case we abort

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1228,11 +1228,13 @@ TrackPointer TrackDAO::getTrackFromDB(TrackId trackId) const {
         return pTrack;
     }
     if (pTrack->getId() != trackId) {
-        // This happens if two different tracks are referencing
-        // the same (physical) file on the file system!! Due to
-        // symbolic links different locations may resolve to the
-        // same canonical location. We can only load each file
-        // once at a time.
+        // The cacheResolver() failed to resolve the track by it's trackId,
+        // but has found a different track that has already been loaded and
+        // is stored in the cache. That track references the same (physical)
+        // file on the file system!! Due to symbolic links different locations
+        // may resolve to the same canonical location. We can only load and
+        // access each file once at a time to prevent corruption due to
+        // concurrent, non-exclusive (write) access.
         kLogger.warning()
                 << "Returning already loaded track"
                 << pTrack->getId()

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -709,9 +709,10 @@ TrackPointer TrackDAO::addTracksAddFile(const QFileInfo& fileInfo, bool unremove
         // must be detected reliably in any situation.
         if (fileInfo.absoluteFilePath() != trackLocation) {
             kLogger.warning()
-                    << "Both track locations"
+                    << "Cannot add track:"
+                    << "Both the new track at"
                     << fileInfo.absoluteFilePath()
-                    << "and"
+                    << "and an existing track at"
                     << trackLocation
                     << "are referencing the same file"
                     << fileInfo.canonicalFilePath();

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -702,6 +702,21 @@ TrackPointer TrackDAO::addTracksAddFile(const QFileInfo& fileInfo, bool unremove
         qDebug() << "TrackDAO::addTracksAddFile:"
                 << "Track has already been added to the database"
                 << oldTrackId;
+        DEBUG_ASSERT(pTrack->getDateAdded().isValid());
+        const auto trackLocation = pTrack->getLocation();
+        // TODO: These duplicates are only detected by chance when
+        // the other track is currently cached. Instead file aliasing
+        // must be detected reliably in any situation.
+        if (fileInfo.absoluteFilePath() != trackLocation) {
+            kLogger.warning()
+                    << "Both track locations"
+                    << fileInfo.absoluteFilePath()
+                    << "and"
+                    << trackLocation
+                    << "are referencing the same file"
+                    << fileInfo.canonicalFilePath();
+            return TrackPointer();
+        }
         return pTrack;
     }
     // Keep the GlobalTrackCache locked until the id of the Track

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -403,12 +403,14 @@ TrackPointer GlobalTrackCache::lookupByRef(
     if (trackRef.hasCanonicalLocation()) {
         trackPtr = lookupByCanonicalLocation(trackRef.getCanonicalLocation());
         if (trackPtr) {
-            if (trackRef.hasId() &&
-                    trackRef.getId() != trackPtr->getId()) {
+            const auto cachedRef = createTrackRef(*trackPtr);
+            if (cachedRef.hasId() &&
+                    trackRef.hasId() &&
+                    cachedRef.getId() != trackRef.getId()) {
                 kLogger.warning()
                         << "Found a different track with the same canonical location:"
                         << "expected =" << trackRef
-                        << "actual =" << createTrackRef(*trackPtr);
+                        << "actual =" << cachedRef;
             }
             return trackPtr;
         }
@@ -548,6 +550,15 @@ void GlobalTrackCache::resolve(
                         << "Cache hit - found track by canonical location"
                         << trackRef.getCanonicalLocation()
                         << strongPtr.get();
+            }
+            const auto cachedRef = createTrackRef(*strongPtr);
+            if (cachedRef.hasId() &&
+                    trackRef.hasId() &&
+                    cachedRef.getId() != trackRef.getId()) {
+                kLogger.warning()
+                        << "Found a different track with the same canonical location:"
+                        << "expected =" << trackRef
+                        << "actual =" << cachedRef;
             }
             pCacheResolver->initLookupResult(
                     GlobalTrackCacheLookupResult::HIT,

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -559,6 +559,8 @@ void GlobalTrackCache::resolve(
                         << "Found a different track with the same canonical location:"
                         << "expected =" << trackRef
                         << "actual =" << cachedRef;
+                // Replace expected with actual TrackRef to prevent inconcistencies
+                trackRef = cachedRef;
             }
             pCacheResolver->initLookupResult(
                     GlobalTrackCacheLookupResult::HIT,

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -403,6 +403,13 @@ TrackPointer GlobalTrackCache::lookupByRef(
     if (trackRef.hasCanonicalLocation()) {
         trackPtr = lookupByCanonicalLocation(trackRef.getCanonicalLocation());
         if (trackPtr) {
+            if (trackRef.hasId() &&
+                    trackRef.getId() != trackPtr->getId()) {
+                kLogger.warning()
+                        << "Found a different track with the same canonical location:"
+                        << "expected =" << trackRef
+                        << "actual =" << createTrackRef(*trackPtr);
+            }
             return trackPtr;
         }
     }

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -404,12 +404,14 @@ TrackPointer GlobalTrackCache::lookupByRef(
         trackPtr = lookupByCanonicalLocation(trackRef.getCanonicalLocation());
         if (trackPtr) {
             const auto cachedRef = createTrackRef(*trackPtr);
-            if (cachedRef.hasId() &&
-                    trackRef.hasId() &&
-                    cachedRef.getId() != trackRef.getId()) {
+            // If an id has been provided the caller expects that if a track
+            // is found it is supposed to have the exact same id. This cannot
+            // be guaranteed due to file system aliasing.
+            // The found track may or may not have a valid id.
+            if (trackRef.hasId() && trackRef.getId() != cachedRef.getId()) {
                 kLogger.warning()
-                        << "Found a different track with the same canonical location:"
-                        << "expected =" << trackRef
+                        << "Found a different track for the same canonical location:"
+                        << "requested =" << trackRef
                         << "actual =" << cachedRef;
             }
             return trackPtr;
@@ -552,14 +554,16 @@ void GlobalTrackCache::resolve(
                         << strongPtr.get();
             }
             const auto cachedRef = createTrackRef(*strongPtr);
-            if (cachedRef.hasId() &&
-                    trackRef.hasId() &&
-                    cachedRef.getId() != trackRef.getId()) {
+            // If an id has been provided the caller expects that if a track
+            // is found it is supposed to have the exact same id. This cannot
+            // be guaranteed due to file system aliasing.
+            // The found track may or may not have a valid id.
+            if (trackRef.hasId() && trackRef.getId() != cachedRef.getId()) {
                 kLogger.warning()
-                        << "Found a different track with the same canonical location:"
-                        << "expected =" << trackRef
+                        << "Found a different track for the same canonical location:"
+                        << "requested =" << trackRef
                         << "actual =" << cachedRef;
-                // Replace expected with actual TrackRef to prevent inconcistencies
+                // Replace requested with actual TrackRef to prevent inconcistencies
                 trackRef = cachedRef;
             }
             pCacheResolver->initLookupResult(

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -532,7 +532,8 @@ void GlobalTrackCache::resolve(
                     << "Resolving track by canonical location"
                     << trackRef.getCanonicalLocation();
         }
-        auto strongPtr = lookupByRef(trackRef);
+        auto strongPtr = lookupByCanonicalLocation(
+                trackRef.getCanonicalLocation());
         if (strongPtr) {
             // Cache hit
             if (debugLogEnabled()) {

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -226,10 +226,12 @@ private:
     void relocateTracks(
             GlobalTrackCacheRelocator* /*nullable*/ pRelocator);
 
-    TrackPointer lookupById(
-            const TrackId& trackId);
     TrackPointer lookupByRef(
             const TrackRef& trackRef);
+    TrackPointer lookupById(
+            const TrackId& trackId);
+    TrackPointer lookupByCanonicalLocation(
+            const QString& canonicalLocation);
 
     TrackPointer revive(GlobalTrackCacheEntryPointer entryPtr);
 

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -12,9 +12,10 @@
 class GlobalTrackCache;
 
 enum class GlobalTrackCacheLookupResult {
-    NONE,
-    HIT,
-    MISS
+    None,
+    Hit,
+    Miss,
+    ConflictCanonicalLocation
 };
 
 // Find the updated location of a track in the database when

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -226,12 +226,17 @@ private:
     void relocateTracks(
             GlobalTrackCacheRelocator* /*nullable*/ pRelocator);
 
-    TrackPointer lookupByRef(
-            const TrackRef& trackRef);
     TrackPointer lookupById(
             const TrackId& trackId);
     TrackPointer lookupByCanonicalLocation(
             const QString& canonicalLocation);
+
+    /// Lookup the track either by id (primary) or by
+    /// canonical location (secondary). The id of the
+    /// returned track might differ from the requested
+    /// id due to file system aliasing!!
+    TrackPointer lookupByRef(
+            const TrackRef& trackRef);
 
     TrackPointer revive(GlobalTrackCacheEntryPointer entryPtr);
 

--- a/src/track/trackref.cpp
+++ b/src/track/trackref.cpp
@@ -1,5 +1,6 @@
 #include "track/trackref.h"
 
+#include <QDebugStateSaver>
 
 bool TrackRef::verifyConsistency() const {
     // Class invariant: The location can only be set together with
@@ -16,17 +17,25 @@ bool TrackRef::verifyConsistency() const {
 }
 
 std::ostream& operator<<(std::ostream& os, const TrackRef& trackRef) {
-    return os << '[' << trackRef.getLocation().toStdString()
-            << " | " << trackRef.getCanonicalLocation().toStdString()
-            << " | " << trackRef.getId()
-            << ']';
-
+    return os
+            << "TrackRef{"
+            << trackRef.getLocation().toStdString()
+            << ','
+            << trackRef.getCanonicalLocation().toStdString()
+            << ','
+            << trackRef.getId()
+            << '}';
 }
 
-QDebug operator<<(QDebug debug, const TrackRef& trackRef) {
-    debug.nospace() << '[' << trackRef.getLocation()
-                    << " | " << trackRef.getCanonicalLocation()
-                    << " | " << trackRef.getId()
-                    << ']';
-    return debug.space();
+QDebug operator<<(QDebug dbg, const TrackRef& trackRef) {
+    const QDebugStateSaver saver(dbg);
+    dbg = dbg.maybeSpace() << "TrackRef";
+    return dbg.nospace()
+            << '{'
+            << trackRef.getLocation()
+            << ','
+            << trackRef.getCanonicalLocation()
+            << ','
+            << trackRef.getId()
+            << '}';
 }


### PR DESCRIPTION
Replaces #3026

Topic on Zulip: [DEBUG_ASSDERT in GlobalTrackCache::resolve](https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/DEBUG_ASSDERT.20in.20GlobalTrackCache.3A.3Aresolve)

Two tracks with different locations but the same canonical locations cause a debug assertion. This is possible by creating a symbolic link to an existing track in the music folder and rescanning the library. Both tracks are now shown in the library, but they refer to the same file.

Only one of those tracks could be loaded at the same time!! This might cause some inconvenience and inconsistencies in the UI when editing the track properties, but it prevents file corruption when exporting file tags.

~~Not sure if this is a critical bug. Backport to 2.2? I did not check if this is feasible.~~