### PR TITLE
clang-tidy fixes (part 2)

### DIFF
--- a/src/effects/builtin/graphiceqeffect.cpp
+++ b/src/effects/builtin/graphiceqeffect.cpp
@@ -221,7 +221,6 @@ void GraphicEQEffect::processChannel(const ChannelHandle& handle,
     if (fHigh) {
         pState->m_high->process(pState->m_pBufs[bufIndex],
                                 pOutput, bufferParameters.samplesPerBuffer());
-        bufIndex = 1 - bufIndex;
     } else {
         SampleUtil::copy(pOutput, pState->m_pBufs[bufIndex], bufferParameters.samplesPerBuffer());
         pState->m_high->pauseFilter();

--- a/src/effects/lv2/lv2manifest.cpp
+++ b/src/effects/lv2/lv2manifest.cpp
@@ -41,11 +41,9 @@ LV2Manifest::LV2Manifest(const LilvPlugin* plug,
             if (lilv_port_is_a(m_pLV2plugin, port, properties["input_port"])) {
                 audioPortIndices.append(i);
                 inputPorts++;
-                info = lilv_port_get_name(m_pLV2plugin, port);
             } else if (lilv_port_is_a(m_pLV2plugin, port, properties["output_port"])) {
                 audioPortIndices.append(i);
                 outputPorts++;
-                info = lilv_port_get_name(m_pLV2plugin, port);
             }
         }
 

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -62,6 +62,7 @@ inline QSqlDatabase cloneDatabase(
     auto cloned = QSqlDatabase::cloneDatabase(
             prototype,
             connectionName);
+    DEBUG_ASSERT(cloned.isValid());
     if (prototype.isOpen() && !cloned.open()) {
         kLogger.warning()
                 << "Failed to open cloned database connection"
@@ -73,8 +74,10 @@ inline QSqlDatabase cloneDatabase(
 
 QSqlDatabase cloneDatabase(
         TrackCollectionManager* pTrackCollectionManager) {
-    DEBUG_ASSERT(pTrackCollectionManager);
-    DEBUG_ASSERT(pTrackCollectionManager->internalCollection());
+    VERIFY_OR_DEBUG_ASSERT(pTrackCollectionManager &&
+            pTrackCollectionManager->internalCollection()) {
+        return QSqlDatabase();
+    }
     const auto connectionName =
             uuidToStringWithoutBraces(QUuid::createUuid());
     return cloneDatabase(

--- a/src/library/coverartutils.cpp
+++ b/src/library/coverartutils.cpp
@@ -110,9 +110,8 @@ CoverInfoRelative CoverArtUtils::selectCoverArtForTrack(
             if (bestType > TRACK_BASENAME &&
                 coverBaseName.compare(trackFile.baseName(),
                                       Qt::CaseInsensitive) == 0) {
-                bestType = TRACK_BASENAME;
                 bestInfo = &file;
-                // This is the best type so we know we're done.
+                // This is the best type (TRACK_BASENAME) so we know we're done.
                 break;
             } else if (bestType > ALBUM_NAME &&
                        coverBaseName.compare(albumName,

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -487,7 +487,6 @@ void ITunesFeature::parseTracks(QXmlStreamReader& xml) {
                 continue;
             } else if (in_container_dictionary && !in_track_dictionary) {
                 // Done parsing tracks.
-                in_container_dictionary = false;
                 break;
             }
         }

--- a/src/library/setlogfeature.cpp
+++ b/src/library/setlogfeature.cpp
@@ -224,7 +224,7 @@ void SetlogFeature::slotGetNewPlaylist() {
         qDebug() << "An unknown error occurred while creating playlist: " << set_log_name;
     }
 
-    slotPlaylistTableChanged(m_playlistId); // For moving selection
+    reloadChildModel(m_playlistId); // For moving selection
     emit showTrackModel(m_pPlaylistTableModel);
 }
 
@@ -270,7 +270,7 @@ void SetlogFeature::slotJoinWithPrevious() {
                 qDebug() << "slotJoinWithPrevious() current:" << currentPlaylistId << " previous:" << previousPlaylistId;
                 if (m_playlistDao.copyPlaylistTracks(currentPlaylistId, previousPlaylistId)) {
                     m_playlistDao.deletePlaylist(currentPlaylistId);
-                    slotPlaylistTableChanged(previousPlaylistId); // For moving selection
+                    reloadChildModel(previousPlaylistId); // For moving selection
                     emit showTrackModel(m_pPlaylistTableModel);
                 }
             }
@@ -345,7 +345,11 @@ void SetlogFeature::slotPlayingTrackChanged(TrackPointer currentPlayingTrack) {
 }
 
 void SetlogFeature::slotPlaylistTableChanged(int playlistId) {
-    //qDebug() << "slotPlaylistTableChanged() playlistId:" << playlistId;
+    reloadChildModel(playlistId);
+}
+
+void SetlogFeature::reloadChildModel(int playlistId) {
+    //qDebug() << "updateChildModel() playlistId:" << playlistId;
     PlaylistDAO::HiddenType type = m_playlistDao.getHiddenType(playlistId);
     if (type == PlaylistDAO::PLHT_SET_LOG ||
             type == PlaylistDAO::PLHT_UNKNOWN) { // In case of a deleted Playlist
@@ -368,7 +372,7 @@ void SetlogFeature::slotPlaylistTableRenamed(
         int playlistId,
         QString newName) {
     Q_UNUSED(newName);
-    //qDebug() << "slotPlaylistTableChanged() playlistId:" << playlistId;
+    //qDebug() << "slotPlaylistTableRenamed() playlistId:" << playlistId;
     enum PlaylistDAO::HiddenType type = m_playlistDao.getHiddenType(playlistId);
     if (type == PlaylistDAO::PLHT_SET_LOG ||
             type == PlaylistDAO::PLHT_UNKNOWN) { // In case of a deleted Playlist

--- a/src/library/setlogfeature.h
+++ b/src/library/setlogfeature.h
@@ -39,6 +39,7 @@ class SetlogFeature : public BasePlaylistFeature {
     void slotPlaylistTableRenamed(int playlistId, QString newName) override;
 
   private:
+    void reloadChildModel(int playlistId);
     QString getRootViewHtml() const override;
 
     std::list<TrackId> m_recentTracks;

--- a/src/library/trackmodel.h
+++ b/src/library/trackmodel.h
@@ -22,6 +22,7 @@ class TrackModel {
               m_settingsNamespace(settingsNamespace),
               m_iDefaultSortColumn(-1),
               m_eDefaultSortOrder(Qt::AscendingOrder) {
+        DEBUG_ASSERT(db.isValid());
     }
     virtual ~TrackModel() {}
 

--- a/src/track/serato/beatgrid.cpp
+++ b/src/track/serato/beatgrid.cpp
@@ -395,7 +395,7 @@ QByteArray SeratoBeatGrid::dumpID3() const {
     stream.setByteOrder(QDataStream::BigEndian);
     stream.setFloatingPointPrecision(QDataStream::SinglePrecision);
     stream << kVersion << numMarkers;
-    for (const SeratoBeatGridNonTerminalMarkerPointer pMarker : m_nonTerminalMarkers) {
+    for (const SeratoBeatGridNonTerminalMarkerPointer& pMarker : m_nonTerminalMarkers) {
         stream.writeRawData(pMarker->dumpID3(), kMarkerSizeID3);
     }
     stream.writeRawData(m_pTerminalMarker->dumpID3(), kMarkerSizeID3);

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -496,9 +496,8 @@ void WOverview::mousePressEvent(QMouseEvent* e) {
             m_iPickupPos = math_clamp(e->y(), 0, height() - 1);
         }
 
-        double dValue = positionToValue(m_iPickupPos);
         if (m_pHoveredMark != nullptr) {
-            dValue = m_pHoveredMark->getSamplePosition() / m_trackSamplesControl->get();
+            double dValue = m_pHoveredMark->getSamplePosition() / m_trackSamplesControl->get();
             m_iPickupPos = valueToPosition(dValue);
             m_iPlayPos = m_iPickupPos;
             setControlParameterUp(dValue);

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -85,7 +85,7 @@ WOverview::WOverview(
     m_pPassthroughControl =
             new ControlProxy(m_group, "passthrough", this, ControlFlag::NoAssertIfMissing);
     m_pPassthroughControl->connectValueChanged(this, &WOverview::onPassthroughChange);
-    onPassthroughChange(m_pPassthroughControl->get());
+    m_bPassthroughEnabled = static_cast<bool>(m_pPassthroughControl->get());
 
     setAcceptDrops(true);
 


### PR DESCRIPTION
Mostly some small cleanups and improvements, but I'd consider this an important bug fix due to: https://github.com/mixxxdj/mixxx/commit/1def3e8f122a201747d441ee0869f8e68feac341 (UB because we're calling a pure-virtual method during construction)

See the individual commit messages for details.