### PR TITLE
library/trackmodel: Remove invalid debug assertion

### DIFF
--- a/src/library/trackmodel.h
+++ b/src/library/trackmodel.h
@@ -22,7 +22,6 @@ class TrackModel {
               m_settingsNamespace(settingsNamespace),
               m_iDefaultSortColumn(-1),
               m_eDefaultSortOrder(Qt::AscendingOrder) {
-        DEBUG_ASSERT(db.isValid());
     }
     virtual ~TrackModel() {}
 


### PR DESCRIPTION
Follow up to #3028. This assertion is wrong (added in #3028), and I had already removed it locally but I forgot to ammend the bad commit, so this slipped in. Sorry!