### PR TITLE
preferences/dialog/dlgprefcolors: Fix call to virtual method in constructor

### DIFF
--- a/src/preferences/dialog/dlgprefcolors.cpp
+++ b/src/preferences/dialog/dlgprefcolors.cpp
@@ -62,14 +62,17 @@ DlgPrefColors::DlgPrefColors(
             this,
             &DlgPrefColors::slotReplaceCueColorClicked);
 
-    slotUpdate();
+    loadSettings();
 }
 
 DlgPrefColors::~DlgPrefColors() {
 }
 
-// Loads the config keys and sets the widgets in the dialog to match
 void DlgPrefColors::slotUpdate() {
+    loadSettings();
+}
+
+void DlgPrefColors::loadSettings() {
     comboBoxHotcueColors->clear();
     comboBoxTrackColors->clear();
     for (const auto& palette : qAsConst(mixxx::PredefinedColorPalettes::kPalettes)) {

--- a/src/preferences/dialog/dlgprefcolors.h
+++ b/src/preferences/dialog/dlgprefcolors.h
@@ -40,6 +40,8 @@ class DlgPrefColors : public DlgPreferencePage, public Ui::DlgPrefColorsDlg {
     void slotEditHotcuePaletteClicked();
 
   private:
+    /// Loads the config keys and sets the widgets in the dialog to match
+    void loadSettings();
     void openColorPaletteEditor(
             const QString& paletteName,
             bool editHotcuePalette);


### PR DESCRIPTION
Fixes:

    src/preferences/dialog/dlgprefcolors.cpp:65:5: warning: Call to virtual method 'DlgPrefColors::slotUpdate' during construction bypasses virtual dispatch [clang-analyzer-optin.cplusplus.VirtualCall]
        slotUpdate();
        ^
    src/preferences/dialog/dlgprefcolors.cpp:65:5: note: Call to virtual method 'DlgPrefColors::slotUpdate' during construction bypasses virtual dispatch