### PR TITLE
engine/controls: Remove superfluous notifySeek implementations

### DIFF
--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -1001,11 +1001,6 @@ void BpmControl::slotUpdateRateSlider(double value) {
     m_pRateRatio->set(dRateRatio);
 }
 
-void BpmControl::notifySeek(double dNewPlaypos) {
-    EngineControl::notifySeek(dNewPlaypos);
-    updateBeatDistance();
-}
-
 // called from an engine worker thread
 void BpmControl::trackLoaded(TrackPointer pNewTrack) {
     mixxx::BeatsPointer pBeats;

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -82,7 +82,6 @@ class BpmControl : public EngineControl {
     static double shortestPercentageChange(const double& current_percentage,
                                            const double& target_percentage);
     double getRateRatio() const;
-    void notifySeek(double dNewPlaypos) override;
     void trackLoaded(TrackPointer pNewTrack) override;
     void trackBeatsUpdated(mixxx::BeatsPointer pBeats) override;
 

--- a/src/engine/controls/enginecontrol.cpp
+++ b/src/engine/controls/enginecontrol.cpp
@@ -100,12 +100,6 @@ void EngineControl::seek(double sample) {
     }
 }
 
-void EngineControl::notifySeek(double dNewPlaypos) {
-    SampleOfTrack sot = m_sampleOfTrack.getValue();
-    sot.current = dNewPlaypos;
-    m_sampleOfTrack.setValue(sot);
-}
-
 EngineBuffer* EngineControl::pickSyncTarget() {
     EngineMaster* pMaster = getEngineMaster();
     if (!pMaster) {

--- a/src/engine/controls/enginecontrol.h
+++ b/src/engine/controls/enginecontrol.h
@@ -65,8 +65,11 @@ class EngineControl : public QObject {
         Q_UNUSED(pGroupFeatures);
     }
 
-    // Called whenever a seek occurs to allow the EngineControl to respond.
-    virtual void notifySeek(double dNewPlaypos);
+    /// Called whenever a seek occurs to allow the EngineControl to respond.
+    virtual void notifySeek(double dNewPlaypos) {
+        Q_UNUSED(dNewPlaypos);
+    };
+
     virtual void trackLoaded(TrackPointer pNewTrack);
     virtual void trackBeatsUpdated(mixxx::BeatsPointer pBeats);
 

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -976,7 +976,6 @@ void LoopingControl::notifySeek(double dNewPlaypos) {
             setLoopingEnabled(false);
         }
     }
-    EngineControl::notifySeek(dNewPlaypos);
 }
 
 void LoopingControl::setLoopingEnabled(bool enabled) {

--- a/src/engine/controls/quantizecontrol.cpp
+++ b/src/engine/controls/quantizecontrol.cpp
@@ -59,11 +59,6 @@ void QuantizeControl::setCurrentSample(const double dCurrentSample,
     playPosChanged(dCurrentSample);
 }
 
-void QuantizeControl::notifySeek(double dNewPlaypos) {
-    EngineControl::notifySeek(dNewPlaypos);
-    playPosChanged(dNewPlaypos);
-}
-
 void QuantizeControl::playPosChanged(double dNewPlaypos) {
     // We only need to update the prev or next if the current sample is
     // out of range of the existing beat positions or if we've been forced to

--- a/src/engine/controls/quantizecontrol.h
+++ b/src/engine/controls/quantizecontrol.h
@@ -16,9 +16,10 @@ class QuantizeControl : public EngineControl {
     QuantizeControl(const QString& group, UserSettingsPointer pConfig);
     ~QuantizeControl() override;
 
-    void setCurrentSample(const double dCurrentSample,
-            const double dTotalSamples, const double dTrackSampleRate) override;
-    void notifySeek(double dNewPlaypos) override;
+    void setCurrentSample(
+            const double dCurrentSample,
+            const double dTotalSamples,
+            const double dTrackSampleRate) override;
     void trackLoaded(TrackPointer pNewTrack) override;
     void trackBeatsUpdated(mixxx::BeatsPointer pBeats) override;
 

--- a/src/engine/controls/ratecontrol.cpp
+++ b/src/engine/controls/ratecontrol.cpp
@@ -592,11 +592,6 @@ void RateControl::resetRateTemp(void)
     setRateTemp(0.0);
 }
 
-void RateControl::notifySeek(double playPos) {
-    m_pScratchController->notifySeek(playPos);
-    EngineControl::notifySeek(playPos);
-}
-
 bool RateControl::isReverseButtonPressed() {
     if (m_pReverseButton) {
         return m_pReverseButton->toBool();

--- a/src/engine/controls/ratecontrol.h
+++ b/src/engine/controls/ratecontrol.h
@@ -71,7 +71,6 @@ public:
   // Set Rate Ramp Sensitivity
   static void setRateRampSensitivity(int);
   static int getRateRampSensitivity();
-  void notifySeek(double dNewPlaypos) override;
   bool isReverseButtonPressed();
 
 public slots:

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -506,13 +506,6 @@ void SyncControl::reportPlayerSpeed(double speed, bool scratching) {
     m_pEngineSync->notifyInstantaneousBpmChanged(this, instantaneous_bpm);
 }
 
-void SyncControl::notifySeek(double dNewPlaypos) {
-    // qDebug() << "SyncControl::notifySeek" << dNewPlaypos;
-    EngineControl::notifySeek(dNewPlaypos);
-    m_pBpmControl->notifySeek(dNewPlaypos);
-    updateTargetBeatDistance();
-}
-
 double SyncControl::fileBpm() const {
     mixxx::BeatsPointer pBeats = m_pBeats;
     if (pBeats) {

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -63,7 +63,6 @@ class SyncControl : public EngineControl, public Syncable {
 
     void reportTrackPosition(double fractionalPlaypos);
     void reportPlayerSpeed(double speed, bool scratching);
-    void notifySeek(double dNewPlaypos) override;
     void trackLoaded(TrackPointer pNewTrack) override;
     void trackBeatsUpdated(mixxx::BeatsPointer pBeats) override;
 

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -2263,11 +2263,9 @@ TEST_F(EngineSyncTest, UserTweakBeatDistance) {
     // Play a buffer, which is enough to see if the beat distances align.
     ProcessBuffer();
 
-    EXPECT_NEAR(ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))
-                        ->get(),
-            ControlObject::getControl(
-                    ConfigKey(m_sInternalClockGroup, "beat_distance"))
-                    ->get(),
+    EXPECT_NEAR(
+            ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->get(),
+            ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "beat_distance"))->get(),
             .00001);
 
     EXPECT_DOUBLE_EQ(0.0,

--- a/src/test/readaheadmanager_test.cpp
+++ b/src/test/readaheadmanager_test.cpp
@@ -57,19 +57,6 @@ class StubLoopControl : public LoopingControl {
         return m_triggerReturnValues.takeFirst();
     }
 
-    // hintReader has no effect in this stubbed class
-    void hintReader(HintVector* pHintList) override {
-        Q_UNUSED(pHintList);
-    }
-
-    void notifySeek(double dNewPlaypos) override {
-        Q_UNUSED(dNewPlaypos);
-    }
-
-    void trackLoaded(TrackPointer pTrack) override {
-        Q_UNUSED(pTrack);
-    }
-
   protected:
     QList<double> m_triggerReturnValues;
     QList<double> m_targetReturnValues;


### PR DESCRIPTION
Most of the time this isn't needed, because the `process` method is called afterwards and sets the new position anyways.

Hand-checked them all, not sure about the scratching yet though.

Tests haven't finished yet.