### PR TITLE
CMake: Use Ninja instead of GNU Make on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ jobs:
       install:
         - mkdir cmake_build
         - cd cmake_build
-        - cmake -L $CMAKEFLAGS $CMAKEFLAGS_EXTRA ..
+        - cmake -L -GNinja $CMAKEFLAGS $CMAKEFLAGS_EXTRA ..
         - cmake --build .
         - cpack -G DEB
       script:
@@ -245,6 +245,7 @@ addons:
       - libupower-glib-dev
       - libusb-1.0-0-dev
       - libwavpack-dev
+      - ninja-build
       - portaudio19-dev
       - protobuf-compiler
       - qt5-default

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,6 +88,7 @@ for:
       libupower-glib-dev
       libusb-1.0-0-dev
       libwavpack-dev
+      ninja-build
       portaudio19-dev
       protobuf-compiler
       qt5-default
@@ -109,6 +110,7 @@ for:
     # TODO: Set -DDEBUG_ASSERTIONS_FATAL=OFF before deploying CI builds as releases!!!
     - cmake
       -L
+      -GNinja
       -DCMAKE_BUILD_TYPE=Release
       -DWARNINGS_FATAL=ON
       -DDEBUG_ASSERTIONS_FATAL=ON


### PR DESCRIPTION
The speedup might not be essential for the CI builds. Nevertheless, it could serve as a blueprint and documentation on how to set up and build Mixxx on a local machine.

RPMFusion also uses Ninja for builds.