### PR TITLE
util/color/predefinedcolorpalettes: Add Mixxx Track Color Palette

### DIFF
--- a/src/util/color/predefinedcolorpalettes.cpp
+++ b/src/util/color/predefinedcolorpalettes.cpp
@@ -17,7 +17,7 @@ constexpr mixxx::RgbColor kMixxxTrackColorDarkRed(0x880000);
 constexpr mixxx::RgbColor kMixxxTrackColorRed(0xFF0000);
 constexpr mixxx::RgbColor kMixxxTrackColorDarkOrange(0xFF8800);
 constexpr mixxx::RgbColor kMixxxTrackColorLemonGlacier(0xFFFF00);
-constexpr mixxx::RgbColor kMixxxTrackColorChartreuseGreen(0x88FF00);
+constexpr mixxx::RgbColor kMixxxTrackColorBitterLime(0xBBEE00);
 constexpr mixxx::RgbColor kMixxxTrackColorElectricGreen(0x00FF00);
 constexpr mixxx::RgbColor kMixxxTrackColorIndiaGreen(0x008800);
 constexpr mixxx::RgbColor kMixxxTrackColorDarkCyan(0x008888);
@@ -27,7 +27,7 @@ constexpr mixxx::RgbColor kMixxxTrackColorDodgerBlue(0x0088FF);
 constexpr mixxx::RgbColor kMixxxTrackColorBlue(0x0000FF);
 constexpr mixxx::RgbColor kMixxxTrackColorNavyBlue(0x000088);
 constexpr mixxx::RgbColor kMixxxTrackColorMardiGras(0x8800088);
-constexpr mixxx::RgbColor kMixxxTrackColorElectricViolet(0x8800FF);
+constexpr mixxx::RgbColor kMixxxTrackColorVividViolet(0xAA00FF);
 constexpr mixxx::RgbColor kMixxxTrackColorFuchsia(0xFF00FF);
 constexpr mixxx::RgbColor kMixxxTrackColorViolet(0xFF88FF);
 constexpr mixxx::RgbColor kMixxxTrackColorWhite(0xFFFFFF);
@@ -211,7 +211,7 @@ const ColorPalette PredefinedColorPalettes::kMixxxTrackColorPalette =
                         kMixxxTrackColorRed,
                         kMixxxTrackColorDarkOrange,
                         kMixxxTrackColorLemonGlacier,
-                        kMixxxTrackColorChartreuseGreen,
+                        kMixxxTrackColorBitterLime,
                         kMixxxTrackColorElectricGreen,
                         kMixxxTrackColorIndiaGreen,
                         kMixxxTrackColorDarkCyan,
@@ -221,7 +221,7 @@ const ColorPalette PredefinedColorPalettes::kMixxxTrackColorPalette =
                         kMixxxTrackColorBlue,
                         kMixxxTrackColorNavyBlue,
                         kMixxxTrackColorMardiGras,
-                        kMixxxTrackColorElectricViolet,
+                        kMixxxTrackColorVividViolet,
                         kMixxxTrackColorFuchsia,
                         kMixxxTrackColorViolet,
                         kMixxxTrackColorWhite,

--- a/src/util/color/predefinedcolorpalettes.cpp
+++ b/src/util/color/predefinedcolorpalettes.cpp
@@ -137,7 +137,7 @@ namespace mixxx {
 const ColorPalette PredefinedColorPalettes::kMixxxHotcueColorPalette =
         ColorPalette(
                 QStringLiteral("Mixxx Hotcue Colors"),
-                QList<mixxx::RgbColor>{
+                {
                         kColorMixxxRed,
                         kColorMixxxYellow,
                         kColorMixxxGreen,
@@ -151,12 +151,12 @@ const ColorPalette PredefinedColorPalettes::kMixxxHotcueColorPalette =
                 // Exclude kSchemaMigrationReplacementColor from the colors assigned to hotcues.
                 // If there were 9 colors assigned to hotcues, that would look weird on
                 // controllers with >8 hotcue buttons, for example a Novation Launchpad.
-                QList<int>{0, 1, 2, 3, 4, 5, 6, 7});
+                {0, 1, 2, 3, 4, 5, 6, 7});
 
 const ColorPalette PredefinedColorPalettes::kSeratoTrackMetadataHotcueColorPalette =
         ColorPalette(
                 QStringLiteral("Serato DJ Track Metadata Hotcue Colors"),
-                QList<mixxx::RgbColor>{
+                {
                         kSeratoTrackMetadataHotcueColorRed,
                         kSeratoTrackMetadataHotcueColorOrange,
                         kSeratoTrackMetadataHotcueColorBrown,
@@ -176,12 +176,12 @@ const ColorPalette PredefinedColorPalettes::kSeratoTrackMetadataHotcueColorPalet
                         kSeratoTrackMetadataHotcueColorMagenta,
                         kSeratoTrackMetadataHotcueColorCarmine,
                 },
-                QList<int>{0, 2, 12, 3, 6, 15, 9, 14});
+                {0, 2, 12, 3, 6, 15, 9, 14});
 
 const ColorPalette PredefinedColorPalettes::kSeratoDJProHotcueColorPalette =
         ColorPalette(
                 QStringLiteral("Serato DJ Pro Hotcue Colors"),
-                QList<mixxx::RgbColor>{
+                {
                         kSeratoDJProHotcueColorRed1,
                         kSeratoDJProHotcueColorOrange1,
                         kSeratoDJProHotcueColorOrange2,
@@ -201,12 +201,12 @@ const ColorPalette PredefinedColorPalettes::kSeratoDJProHotcueColorPalette =
                         kSeratoDJProHotcueColorPurple,
                         kSeratoDJProHotcueColorRed2,
                 },
-                QList<int>{0, 2, 12, 3, 6, 15, 9, 14});
+                {0, 2, 12, 3, 6, 15, 9, 14});
 
 const ColorPalette PredefinedColorPalettes::kMixxxTrackColorPalette =
         ColorPalette(
                 QStringLiteral("Mixxx Track Colors"),
-                QList<mixxx::RgbColor>{
+                {
                         kMixxxTrackColorDarkRed,
                         kMixxxTrackColorRed,
                         kMixxxTrackColorDarkOrange,
@@ -231,7 +231,7 @@ const ColorPalette PredefinedColorPalettes::kMixxxTrackColorPalette =
 const ColorPalette PredefinedColorPalettes::kRekordboxTrackColorPalette =
         ColorPalette(
                 QStringLiteral("Rekordbox Track Colors"),
-                QList<mixxx::RgbColor>{
+                {
                         kRekordboxTrackColorPink,
                         kRekordboxTrackColorRed,
                         kRekordboxTrackColorOrange,
@@ -245,7 +245,7 @@ const ColorPalette PredefinedColorPalettes::kRekordboxTrackColorPalette =
 const ColorPalette PredefinedColorPalettes::kSeratoDJProTrackColorPalette =
         ColorPalette(
                 QStringLiteral("Serato DJ Pro Track Colors"),
-                QList<mixxx::RgbColor>{
+                {
                         kSeratoDJProTrackColorGrey1,
                         kSeratoDJProTrackColorGrey2,
                         kSeratoDJProTrackColorPink1,
@@ -271,7 +271,7 @@ const ColorPalette PredefinedColorPalettes::kSeratoDJProTrackColorPalette =
 const ColorPalette PredefinedColorPalettes::kTraktorProTrackColorPalette =
         ColorPalette(
                 QStringLiteral("Traktor Pro Track Colors"),
-                QList<mixxx::RgbColor>{
+                {
                         kTraktorProTrackColorRed,
                         kTraktorProTrackColorOrange,
                         kTraktorProTrackColorYellow,
@@ -284,7 +284,7 @@ const ColorPalette PredefinedColorPalettes::kTraktorProTrackColorPalette =
 const ColorPalette PredefinedColorPalettes::kVirtualDJTrackColorPalette =
         ColorPalette(
                 QStringLiteral("VirtualDJ Track Colors"),
-                QList<mixxx::RgbColor>{
+                {
                         kVirtualDJTrackColorRed,
                         kVirtualDJTrackColorYellow,
                         kVirtualDJTrackColorGreen,

--- a/src/util/color/predefinedcolorpalettes.cpp
+++ b/src/util/color/predefinedcolorpalettes.cpp
@@ -12,6 +12,27 @@ constexpr mixxx::RgbColor kColorMixxxPurple(0xAF00CC);
 constexpr mixxx::RgbColor kColorMixxxPink(0xFCA6D7);
 constexpr mixxx::RgbColor kColorMixxxWhite(0xF2F2FF);
 
+// Default Mixxx Track Color Palette
+constexpr mixxx::RgbColor kMixxxTrackColorDarkRed(0x880000);
+constexpr mixxx::RgbColor kMixxxTrackColorRed(0xFF0000);
+constexpr mixxx::RgbColor kMixxxTrackColorDarkOrange(0xFF8800);
+constexpr mixxx::RgbColor kMixxxTrackColorLemonGlacier(0xFFFF00);
+constexpr mixxx::RgbColor kMixxxTrackColorChartreuseGreen(0x88FF00);
+constexpr mixxx::RgbColor kMixxxTrackColorElectricGreen(0x00FF00);
+constexpr mixxx::RgbColor kMixxxTrackColorIndiaGreen(0x008800);
+constexpr mixxx::RgbColor kMixxxTrackColorDarkCyan(0x008888);
+constexpr mixxx::RgbColor kMixxxTrackColorSpringGreen(0x00FF88);
+constexpr mixxx::RgbColor kMixxxTrackColorAqua(0x00FFFF);
+constexpr mixxx::RgbColor kMixxxTrackColorDodgerBlue(0x0088FF);
+constexpr mixxx::RgbColor kMixxxTrackColorBlue(0x0000FF);
+constexpr mixxx::RgbColor kMixxxTrackColorNavyBlue(0x000088);
+constexpr mixxx::RgbColor kMixxxTrackColorMardiGras(0x8800088);
+constexpr mixxx::RgbColor kMixxxTrackColorElectricViolet(0x8800FF);
+constexpr mixxx::RgbColor kMixxxTrackColorFuchsia(0xFF00FF);
+constexpr mixxx::RgbColor kMixxxTrackColorViolet(0xFF88FF);
+constexpr mixxx::RgbColor kMixxxTrackColorWhite(0xFFFFFF);
+constexpr mixxx::RgbColor kMixxxTrackColorBattleshipGrey(0x888888);
+
 // Rekordbox Track Color Palette
 constexpr mixxx::RgbColor kRekordboxTrackColorPink(0xF870F8);
 constexpr mixxx::RgbColor kRekordboxTrackColorRed(0xF870900);
@@ -182,6 +203,31 @@ const ColorPalette PredefinedColorPalettes::kSeratoDJProHotcueColorPalette =
                 },
                 QList<int>{0, 2, 12, 3, 6, 15, 9, 14});
 
+const ColorPalette PredefinedColorPalettes::kMixxxTrackColorPalette =
+        ColorPalette(
+                QStringLiteral("Mixxx Track Colors"),
+                QList<mixxx::RgbColor>{
+                        kMixxxTrackColorDarkRed,
+                        kMixxxTrackColorRed,
+                        kMixxxTrackColorDarkOrange,
+                        kMixxxTrackColorLemonGlacier,
+                        kMixxxTrackColorChartreuseGreen,
+                        kMixxxTrackColorElectricGreen,
+                        kMixxxTrackColorIndiaGreen,
+                        kMixxxTrackColorDarkCyan,
+                        kMixxxTrackColorSpringGreen,
+                        kMixxxTrackColorAqua,
+                        kMixxxTrackColorDodgerBlue,
+                        kMixxxTrackColorBlue,
+                        kMixxxTrackColorNavyBlue,
+                        kMixxxTrackColorMardiGras,
+                        kMixxxTrackColorElectricViolet,
+                        kMixxxTrackColorFuchsia,
+                        kMixxxTrackColorViolet,
+                        kMixxxTrackColorWhite,
+                        kMixxxTrackColorBattleshipGrey,
+                });
+
 const ColorPalette PredefinedColorPalettes::kRekordboxTrackColorPalette =
         ColorPalette(
                 QStringLiteral("Rekordbox Track Colors"),
@@ -252,13 +298,14 @@ const ColorPalette PredefinedColorPalettes::kDefaultHotcueColorPalette =
         mixxx::PredefinedColorPalettes::kMixxxHotcueColorPalette;
 
 const ColorPalette PredefinedColorPalettes::kDefaultTrackColorPalette =
-        mixxx::PredefinedColorPalettes::kMixxxHotcueColorPalette;
+        mixxx::PredefinedColorPalettes::kMixxxTrackColorPalette;
 
 const QList<ColorPalette> PredefinedColorPalettes::kPalettes{
         // Hotcue Color Palettes
         mixxx::PredefinedColorPalettes::kMixxxHotcueColorPalette,
         mixxx::PredefinedColorPalettes::kSeratoDJProHotcueColorPalette,
         // Track Color Palettes
+        mixxx::PredefinedColorPalettes::kMixxxTrackColorPalette,
         mixxx::PredefinedColorPalettes::kRekordboxTrackColorPalette,
         mixxx::PredefinedColorPalettes::kSeratoDJProTrackColorPalette,
         mixxx::PredefinedColorPalettes::kTraktorProTrackColorPalette,

--- a/src/util/color/predefinedcolorpalettes.cpp
+++ b/src/util/color/predefinedcolorpalettes.cpp
@@ -17,12 +17,10 @@ constexpr mixxx::RgbColor kMixxxTrackColorDarkRed(0x880000);
 constexpr mixxx::RgbColor kMixxxTrackColorRed(0xFF0000);
 constexpr mixxx::RgbColor kMixxxTrackColorDarkOrange(0xFF8800);
 constexpr mixxx::RgbColor kMixxxTrackColorLemonGlacier(0xFFFF00);
-constexpr mixxx::RgbColor kMixxxTrackColorBitterLime(0xBBEE00);
+constexpr mixxx::RgbColor kMixxxTrackColorChartreuse(0x88FF00);
 constexpr mixxx::RgbColor kMixxxTrackColorElectricGreen(0x00FF00);
 constexpr mixxx::RgbColor kMixxxTrackColorIndiaGreen(0x008800);
 constexpr mixxx::RgbColor kMixxxTrackColorDarkCyan(0x008888);
-constexpr mixxx::RgbColor kMixxxTrackColorSpringGreen(0x00FF88);
-constexpr mixxx::RgbColor kMixxxTrackColorAqua(0x00FFFF);
 constexpr mixxx::RgbColor kMixxxTrackColorDodgerBlue(0x0088FF);
 constexpr mixxx::RgbColor kMixxxTrackColorBlue(0x0000FF);
 constexpr mixxx::RgbColor kMixxxTrackColorNavyBlue(0x000088);
@@ -31,6 +29,8 @@ constexpr mixxx::RgbColor kMixxxTrackColorVividViolet(0xAA00FF);
 constexpr mixxx::RgbColor kMixxxTrackColorFuchsia(0xFF00FF);
 constexpr mixxx::RgbColor kMixxxTrackColorViolet(0xFF88FF);
 constexpr mixxx::RgbColor kMixxxTrackColorWhite(0xFFFFFF);
+constexpr mixxx::RgbColor kMixxxTrackColorAqua(0x00FFFF);
+constexpr mixxx::RgbColor kMixxxTrackColorSpringGreen(0x00FF88);
 constexpr mixxx::RgbColor kMixxxTrackColorBattleshipGrey(0x888888);
 
 // Rekordbox Track Color Palette
@@ -211,12 +211,10 @@ const ColorPalette PredefinedColorPalettes::kMixxxTrackColorPalette =
                         kMixxxTrackColorRed,
                         kMixxxTrackColorDarkOrange,
                         kMixxxTrackColorLemonGlacier,
-                        kMixxxTrackColorBitterLime,
+                        kMixxxTrackColorChartreuse,
                         kMixxxTrackColorElectricGreen,
                         kMixxxTrackColorIndiaGreen,
                         kMixxxTrackColorDarkCyan,
-                        kMixxxTrackColorSpringGreen,
-                        kMixxxTrackColorAqua,
                         kMixxxTrackColorDodgerBlue,
                         kMixxxTrackColorBlue,
                         kMixxxTrackColorNavyBlue,
@@ -225,6 +223,8 @@ const ColorPalette PredefinedColorPalettes::kMixxxTrackColorPalette =
                         kMixxxTrackColorFuchsia,
                         kMixxxTrackColorViolet,
                         kMixxxTrackColorWhite,
+                        kMixxxTrackColorAqua,
+                        kMixxxTrackColorSpringGreen,
                         kMixxxTrackColorBattleshipGrey,
                 });
 

--- a/src/util/color/predefinedcolorpalettes.h
+++ b/src/util/color/predefinedcolorpalettes.h
@@ -9,6 +9,7 @@ class PredefinedColorPalettes {
     static const ColorPalette kSeratoTrackMetadataHotcueColorPalette;
     static const ColorPalette kSeratoDJProHotcueColorPalette;
 
+    static const ColorPalette kMixxxTrackColorPalette;
     static const ColorPalette kRekordboxTrackColorPalette;
     static const ColorPalette kSeratoDJProTrackColorPalette;
     static const ColorPalette kTraktorProTrackColorPalette;


### PR DESCRIPTION
The current default track color palette is "Mixxx Hotcue Color Palette", which is confusing and doesn't really fit well for track colors. The "Serato DJ Pro Track Color Palette" works much better.

Originally I wanted to make a PR that switches the default track color palette to that one, but on second thought using Serato's palette in Mixxx by default is weird and looks unprofessional IMHO.

So here's my lazy attempt at making a Mixxx Track Color palette:

![colorpalette](https://user-images.githubusercontent.com/1834516/90941814-795ef800-e413-11ea-9474-1db889c0e69d.png)

**EDIT:** New version:
![90941814-795ef800-e413-11ea-9474-1db889c0e69d](https://user-images.githubusercontent.com/1834516/90979379-fb0a6f00-e554-11ea-9f51-826567650292.png)
