### PR TITLE
Various minor code cleanups + SettingsDAO

### DIFF
--- a/src/database/schemamanager.cpp
+++ b/src/database/schemamanager.cpp
@@ -13,7 +13,7 @@ const QString SchemaManager::SETTINGS_MINCOMPATIBLE_STRING = "mixxx.schema.min_c
 namespace {
     mixxx::Logger kLogger("SchemaManager");
 
-    int readCurrentSchemaVersion(SettingsDAO& settings) {
+    int readCurrentSchemaVersion(const SettingsDAO& settings) {
         QString settingsValue = settings.getValue(SchemaManager::SETTINGS_VERSION_STRING);
         // May be a null string if the schema has not been created. We default the
         // startVersion to 0 so that we automatically try to upgrade to revision 1.
@@ -32,9 +32,9 @@ namespace {
 }
 
 SchemaManager::SchemaManager(const QSqlDatabase& database)
-    : m_database(database),
-      m_settingsDao(database),
-      m_currentVersion(readCurrentSchemaVersion(m_settingsDao)) {
+        : m_database(database),
+          m_settingsDao(m_database),
+          m_currentVersion(readCurrentSchemaVersion(m_settingsDao)) {
 }
 
 bool SchemaManager::isBackwardsCompatibleWithVersion(int targetVersion) const {

--- a/src/database/schemamanager.h
+++ b/src/database/schemamanager.h
@@ -33,8 +33,8 @@ class SchemaManager {
             int targetVersion);
 
   private:
-    QSqlDatabase m_database;
-    SettingsDAO m_settingsDao;
+    const QSqlDatabase m_database;
+    const SettingsDAO m_settingsDao;
 
     int m_currentVersion;
 };

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -18,7 +18,6 @@
 #include "library/treeitem.h"
 #include "track/track.h"
 #include "util/memory.h"
-#include "util/sandbox.h"
 #include "widget/wlibrary.h"
 #include "widget/wlibrarytextbrowser.h"
 #include "widget/wlibrarysidebar.h"

--- a/src/library/dao/analysisdao.cpp
+++ b/src/library/dao/analysisdao.cpp
@@ -26,11 +26,11 @@ AnalysisDao::AnalysisDao(UserSettingsPointer pConfig)
 }
 
 QList<AnalysisDao::AnalysisInfo> AnalysisDao::getAnalysesForTrack(TrackId trackId) {
-    if (!m_db.isOpen() || !trackId.isValid()) {
+    if (!m_database.isOpen() || !trackId.isValid()) {
         return QList<AnalysisInfo>();
     }
 
-    QSqlQuery query(m_db);
+    QSqlQuery query(m_database);
     query.prepare(QString(
         "SELECT id, type, description, version, data_checksum FROM %1 "
         "WHERE track_id=:trackId").arg(s_analysisTableName));
@@ -41,11 +41,11 @@ QList<AnalysisDao::AnalysisInfo> AnalysisDao::getAnalysesForTrack(TrackId trackI
 
 QList<AnalysisDao::AnalysisInfo> AnalysisDao::getAnalysesForTrackByType(
     TrackId trackId, AnalysisType type) {
-    if (!m_db.isOpen() || !trackId.isValid()) {
+    if (!m_database.isOpen() || !trackId.isValid()) {
         return QList<AnalysisInfo>();
     }
 
-    QSqlQuery query(m_db);
+    QSqlQuery query(m_database);
     query.prepare(QString(
         "SELECT id, type, description, version, data_checksum FROM %1 "
         "WHERE track_id=:trackId AND type=:type").arg(s_analysisTableName));
@@ -103,7 +103,7 @@ QList<AnalysisDao::AnalysisInfo> AnalysisDao::loadAnalysesFromQuery(TrackId trac
 }
 
 bool AnalysisDao::saveAnalysis(AnalysisDao::AnalysisInfo* info) {
-    if (!m_db.isOpen() || info == NULL) {
+    if (!m_database.isOpen() || info == NULL) {
         return false;
     }
 
@@ -118,7 +118,7 @@ bool AnalysisDao::saveAnalysis(AnalysisDao::AnalysisInfo* info) {
     int checksum = qChecksum(compressedData.constData(),
                              compressedData.length());
 
-    QSqlQuery query(m_db);
+    QSqlQuery query(m_database);
     if (info->analysisId == -1) {
         query.prepare(QString(
             "INSERT INTO %1 (track_id, type, description, version, data_checksum) "
@@ -178,7 +178,7 @@ bool AnalysisDao::deleteAnalysis(const int analysisId) {
     if (analysisId == -1) {
         return false;
     }
-    QSqlQuery query(m_db);
+    QSqlQuery query(m_database);
     query.prepare(QString(
         "DELETE FROM %1 WHERE id = :id").arg(s_analysisTableName));
     query.bindValue(":id", analysisId);
@@ -199,7 +199,7 @@ void AnalysisDao::deleteAnalyses(const QList<TrackId>& trackIds) {
     for (const auto& trackId: trackIds) {
         idList << trackId.toString();
     }
-    QSqlQuery query(m_db);
+    QSqlQuery query(m_database);
     query.prepare(QString("SELECT track_analysis.id FROM track_analysis WHERE "
                           "track_id in (%1)").arg(idList.join(",")));
     if (!query.exec()) {
@@ -223,7 +223,7 @@ bool AnalysisDao::deleteAnalysesForTrack(TrackId trackId) {
     if (!trackId.isValid()) {
         return false;
     }
-    QSqlQuery query(m_db);
+    QSqlQuery query(m_database);
     query.prepare(QString(
         "SELECT id FROM %1 where track_id = :track_id").arg(s_analysisTableName));
     query.bindValue(":track_id", trackId.toVariant());

--- a/src/library/dao/analysisdao.h
+++ b/src/library/dao/analysisdao.h
@@ -34,7 +34,7 @@ class AnalysisDao : public DAO {
     };
 
     explicit AnalysisDao(UserSettingsPointer pConfig);
-    ~AnalysisDao() override {}
+    ~AnalysisDao() override = default;
 
     // The following functions can be used with a custom database
     // connection and independent of whether the DAO has been
@@ -69,7 +69,7 @@ class AnalysisDao : public DAO {
     bool deleteFile(const QString& filename) const;
     QList<AnalysisInfo> loadAnalysesFromQuery(TrackId trackId, QSqlQuery* query);
 
-    UserSettingsPointer m_pConfig;
+    const UserSettingsPointer m_pConfig;
     QSqlDatabase m_db;
 };
 

--- a/src/library/dao/analysisdao.h
+++ b/src/library/dao/analysisdao.h
@@ -46,10 +46,6 @@ class AnalysisDao : public DAO {
             const QSqlDatabase& database,
             AnalysisType type) const;
 
-    void initialize(const QSqlDatabase& database) override {
-        m_db = database;
-    }
-
     QList<AnalysisInfo> getAnalysesForTrackByType(TrackId trackId, AnalysisType type);
     QList<AnalysisInfo> getAnalysesForTrack(TrackId trackId);
     bool saveAnalysis(AnalysisInfo* analysis);
@@ -70,7 +66,6 @@ class AnalysisDao : public DAO {
     QList<AnalysisInfo> loadAnalysesFromQuery(TrackId trackId, QSqlQuery* query);
 
     const UserSettingsPointer m_pConfig;
-    QSqlDatabase m_db;
 };
 
 #endif // ANALYSISDAO_H

--- a/src/library/dao/cuedao.h
+++ b/src/library/dao/cuedao.h
@@ -13,10 +13,6 @@ class CueDAO : public DAO {
   public:
     ~CueDAO() override = default;
 
-    void initialize(const QSqlDatabase& database) override {
-        m_database = database;
-    }
-
     QList<CuePointer> getCuesForTrack(TrackId trackId) const;
 
     void saveTrackCues(TrackId trackId, const QList<CuePointer>& cueList) const;
@@ -26,6 +22,4 @@ class CueDAO : public DAO {
   private:
     bool saveCue(Cue* pCue) const;
     bool deleteCue(Cue* pCue) const;
-
-    QSqlDatabase m_database;
 };

--- a/src/library/dao/dao.h
+++ b/src/library/dao/dao.h
@@ -1,13 +1,18 @@
-#ifndef DAO_H
-#define DAO_H
+#pragma once
 
 #include <QSqlDatabase>
 
+#include "util/assert.h"
+
 class DAO {
   public:
-    virtual ~DAO() {}
+    virtual ~DAO() = default;
 
-    virtual void initialize(const QSqlDatabase& database) = 0;
+    virtual void initialize(const QSqlDatabase& database) {
+        DEBUG_ASSERT(!m_database.isOpen());
+        m_database = database;
+    }
+
+  protected:
+    QSqlDatabase m_database;
 };
-
-#endif /* DAO_H */

--- a/src/library/dao/directorydao.cpp
+++ b/src/library/dao/directorydao.cpp
@@ -1,16 +1,34 @@
-#include <QtSql>
+#include "library/dao/directorydao.h"
+
 #include <QDir>
 #include <QtDebug>
-#include <QRegExp>
 
-#include "library/dao/directorydao.h"
 #include "library/queryutil.h"
-
-#include "util/db/sqllikewildcards.h"
 #include "util/db/sqllikewildcardescaper.h"
+#include "util/db/sqllikewildcards.h"
 
+namespace {
 
-int DirectoryDAO::addDirectory(const QString& newDir) {
+bool isChildDir(QString testDir, QString dirStr) {
+    QDir test = QDir(testDir);
+    QDir dir = QDir(dirStr);
+    bool child = dir == test;
+    while (test.cdUp()) {
+        if (dir == test) {
+            child = true;
+        }
+    }
+    // qDebug() << "--- test related function ---";
+    // qDebug() << "testDir " << testDir;
+    // qDebug() << "dir" << dirStr;
+    // qDebug() << "child = " << child;
+    // qDebug() << "-----------------------------";
+    return child;
+}
+
+} // anonymous namespace
+
+int DirectoryDAO::addDirectory(const QString& newDir) const {
     // Do nothing if the dir to add is a child of a directory that is already in
     // the db.
     QStringList dirs = getDirs();
@@ -47,24 +65,7 @@ int DirectoryDAO::addDirectory(const QString& newDir) {
     return ALL_FINE;
 }
 
-bool DirectoryDAO::isChildDir(QString testDir, QString dirStr) {
-    QDir test = QDir(testDir);
-    QDir dir = QDir(dirStr);
-    bool child = dir == test;
-    while (test.cdUp()) {
-        if (dir == test) {
-            child = true;
-        }
-    }
-    // qDebug() << "--- test related function ---";
-    // qDebug() << "testDir " << testDir;
-    // qDebug() << "dir" << dirStr;
-    // qDebug() << "child = " << child;
-    // qDebug() << "-----------------------------";
-    return child;
-}
-
-int DirectoryDAO::removeDirectory(const QString& dir) {
+int DirectoryDAO::removeDirectory(const QString& dir) const {
     QSqlQuery query(m_database);
     query.prepare("DELETE FROM " % DIRECTORYDAO_TABLE  % " WHERE "
                    % DIRECTORYDAO_DIR % "= :dir");
@@ -76,10 +77,9 @@ int DirectoryDAO::removeDirectory(const QString& dir) {
     return ALL_FINE;
 }
 
-
 QList<RelocatedTrack> DirectoryDAO::relocateDirectory(
         const QString& oldFolder,
-        const QString& newFolder) {
+        const QString& newFolder) const {
     // TODO(rryan): This method could use error reporting. It can fail in
     // mysterious ways for example if a track in the oldFolder also has a zombie
     // track location in newFolder then the replace query will fail because the
@@ -147,7 +147,7 @@ QList<RelocatedTrack> DirectoryDAO::relocateDirectory(
     return relocatedTracks;
 }
 
-QStringList DirectoryDAO::getDirs() {
+QStringList DirectoryDAO::getDirs() const {
     QSqlQuery query(m_database);
     query.prepare("SELECT " % DIRECTORYDAO_DIR % " FROM " % DIRECTORYDAO_TABLE);
     if (!query.exec()) {

--- a/src/library/dao/directorydao.h
+++ b/src/library/dao/directorydao.h
@@ -1,8 +1,9 @@
-#ifndef DIRECTORYDAO_H
-#define DIRECTORYDAO_H
+#pragma once
 
-#include <QSqlDatabase>
-#include "library/dao/trackdao.h"
+#include <QList>
+
+#include "library/dao/dao.h"
+#include "library/relocatedtrack.h"
 
 const QString DIRECTORYDAO_DIR = "directory";
 const QString DIRECTORYDAO_TABLE = "directories";
@@ -15,20 +16,21 @@ enum ReturnCodes {
 
 class DirectoryDAO : public DAO {
   public:
+    ~DirectoryDAO() override = default;
+
     void initialize(const QSqlDatabase& database) override {
         m_database = database;
     }
 
-    int addDirectory(const QString& dir);
-    int removeDirectory(const QString& dir);
+    QStringList getDirs() const;
+
+    int addDirectory(const QString& dir) const;
+    int removeDirectory(const QString& dir) const;
+
     QList<RelocatedTrack> relocateDirectory(
             const QString& oldFolder,
-            const QString& newFolder);
-    QStringList getDirs();
+            const QString& newFolder) const;
 
   private:
-    bool isChildDir(QString testDir, QString dirStr);
     QSqlDatabase m_database;
 };
-
-#endif //DIRECTORYDAO_H

--- a/src/library/dao/directorydao.h
+++ b/src/library/dao/directorydao.h
@@ -18,10 +18,6 @@ class DirectoryDAO : public DAO {
   public:
     ~DirectoryDAO() override = default;
 
-    void initialize(const QSqlDatabase& database) override {
-        m_database = database;
-    }
-
     QStringList getDirs() const;
 
     int addDirectory(const QString& dir) const;
@@ -30,7 +26,4 @@ class DirectoryDAO : public DAO {
     QList<RelocatedTrack> relocateDirectory(
             const QString& oldFolder,
             const QString& newFolder) const;
-
-  private:
-    QSqlDatabase m_database;
 };

--- a/src/library/dao/libraryhashdao.h
+++ b/src/library/dao/libraryhashdao.h
@@ -11,11 +11,7 @@
 
 class LibraryHashDAO : public DAO {
   public:
-    ~LibraryHashDAO() override {}
-
-    void initialize(const QSqlDatabase& database) override {
-        m_database = database;
-    };
+    ~LibraryHashDAO() override = default;
 
     QHash<QString, mixxx::cache_key_t> getDirectoryHashes();
     mixxx::cache_key_t getDirectoryHash(const QString& dirPath);
@@ -29,9 +25,6 @@ class LibraryHashDAO : public DAO {
     void updateDirectoryStatuses(const QStringList& dirPaths,
                                  const bool deleted, const bool verified);
     QStringList getDeletedDirectories();
-
-  private:
-    QSqlDatabase m_database;
 };
 
 #endif //LIBRARYHASHDAO_H

--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -18,7 +18,7 @@ PlaylistDAO::PlaylistDAO()
 }
 
 void PlaylistDAO::initialize(const QSqlDatabase& database) {
-    m_database = database;
+    DAO::initialize(database);
     populatePlaylistMembershipCache();
 }
 

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -49,7 +49,7 @@ class PlaylistDAO : public QObject, public virtual DAO {
     };
 
     PlaylistDAO();
-    ~PlaylistDAO() override {}
+    ~PlaylistDAO() override = default;
 
     void initialize(const QSqlDatabase& database) override;
 
@@ -142,7 +142,6 @@ class PlaylistDAO : public QObject, public virtual DAO {
                                  int* pTrackDistance);
     void populatePlaylistMembershipCache();
 
-    QSqlDatabase m_database;
     QMultiHash<TrackId, int> m_playlistsTrackIsIn;
     AutoDJProcessor* m_pAutoDJProcessor;
     DISALLOW_COPY_AND_ASSIGN(PlaylistDAO);

--- a/src/library/dao/settingsdao.cpp
+++ b/src/library/dao/settingsdao.cpp
@@ -1,5 +1,3 @@
-// settingsdao.cpp
-// Created 12/29/2009 by RJ Ryan (rryan@mit.edu)
 
 #include "library/dao/settingsdao.h"
 
@@ -42,7 +40,7 @@ QString SettingsDAO::getValue(const QString& name, QString defaultValue) const {
     return defaultValue;
 }
 
-bool SettingsDAO::setValue(const QString& name, const QVariant& value) {
+bool SettingsDAO::setValue(const QString& name, const QVariant& value) const {
     if (!value.canConvert(QMetaType::QString)) {
         return false;
     }

--- a/src/library/dao/settingsdao.cpp
+++ b/src/library/dao/settingsdao.cpp
@@ -1,33 +1,29 @@
-
 #include "library/dao/settingsdao.h"
 
-#include "util/logger.h"
+#include <QtSql>
+
 #include "util/assert.h"
+#include "util/logger.h"
 
 namespace {
 
 mixxx::Logger kLogger("SettingsDAO");
 
+const QString kTable = QStringLiteral("settings");
+
+const QString kColumnName = QStringLiteral("name");
+const QString kColumnValue = QStringLiteral("value");
+const QString kColumnLocked = QStringLiteral("locked");
+const QString kColumnHidden = QStringLiteral("hidden");
+
 } // anonymous namespace
 
-SettingsDAO::SettingsDAO(const QSqlDatabase& db)
-        : m_db(db) {
-}
-
 QString SettingsDAO::getValue(const QString& name, QString defaultValue) const {
-    QSqlQuery query(m_db);
-
-    if (query.prepare("SELECT value FROM settings WHERE name = :name")) {
-        query.bindValue(":name", name);
-        if (query.exec() && query.first()) {
-            QVariant value = query.value(query.record().indexOf("value"));
-            VERIFY_OR_DEBUG_ASSERT(value.isValid()) {
-                kLogger.warning() << "Invalid value:" << value;
-            } else {
-                return value.toString();
-            }
-        }
-    } else {
+    const auto statement =
+            QStringLiteral("SELECT %1 FROM %2 WHERE %3=:name")
+                    .arg(kColumnValue, kTable, kColumnName);
+    QSqlQuery query(m_database);
+    if (!query.prepare(statement)) {
         // Prepare is expected to fail for a fresh database
         // when the schema is still empty!
         kLogger.info()
@@ -37,22 +33,37 @@ QString SettingsDAO::getValue(const QString& name, QString defaultValue) const {
                 << "for"
                 << name;
     }
+    query.bindValue(QStringLiteral(":name"), name);
+    if (query.exec() && query.first()) {
+        QVariant value = query.value(query.record().indexOf(kColumnValue));
+        VERIFY_OR_DEBUG_ASSERT(value.isValid()) {
+            kLogger.warning() << "Invalid value:" << value;
+        }
+        else {
+            return value.toString();
+        }
+    }
     return defaultValue;
 }
 
 bool SettingsDAO::setValue(const QString& name, const QVariant& value) const {
-    if (!value.canConvert(QMetaType::QString)) {
+    VERIFY_OR_DEBUG_ASSERT(value.canConvert(QMetaType::QString)) {
         return false;
     }
 
-    QSqlQuery query(m_db);
-    query.prepare("REPLACE INTO settings (name, value) VALUES (:name, :value)");
-    query.bindValue(":name", name);
-    query.bindValue(":value", value.toString());
-
-    if (!query.exec()) {
-        qDebug() << "SettingsDAO::setValue() failed" << name << ":" << value
-                 << query.lastError();
+    const auto statement =
+            QStringLiteral("REPLACE INTO %1 (%2,%3) VALUES (:name,:value)")
+                    .arg(kTable, kColumnName, kColumnValue);
+    QSqlQuery query(m_database);
+    VERIFY_OR_DEBUG_ASSERT(query.prepare(statement)) {
+        return false;
+    }
+    query.bindValue(QStringLiteral(":name"), name);
+    query.bindValue(QStringLiteral(":value"), value.toString());
+    VERIFY_OR_DEBUG_ASSERT(query.exec()) {
+        kLogger.warning()
+                << "Failed to set" << name << "=" << value
+                << query.lastError();
         return false;
     }
     return true;

--- a/src/library/dao/settingsdao.cpp
+++ b/src/library/dao/settingsdao.cpp
@@ -19,9 +19,13 @@ const QString kColumnHidden = QStringLiteral("hidden");
 } // anonymous namespace
 
 QString SettingsDAO::getValue(const QString& name, QString defaultValue) const {
-    const auto statement =
-            QStringLiteral("SELECT %1 FROM %2 WHERE %3=:name")
-                    .arg(kColumnValue, kTable, kColumnName);
+    const QString statement =
+            QStringLiteral("SELECT ") +
+            kColumnValue +
+            QStringLiteral(" FROM ") +
+            kTable +
+            QStringLiteral(" WHERE ") +
+            kColumnName + QStringLiteral("=:name");
     QSqlQuery query(m_database);
     if (!query.prepare(statement)) {
         // Prepare is expected to fail for a fresh database
@@ -51,9 +55,14 @@ bool SettingsDAO::setValue(const QString& name, const QVariant& value) const {
         return false;
     }
 
-    const auto statement =
-            QStringLiteral("REPLACE INTO %1 (%2,%3) VALUES (:name,:value)")
-                    .arg(kTable, kColumnName, kColumnValue);
+    const QString statement =
+            QStringLiteral("REPLACE INTO ") +
+            kTable +
+            QStringLiteral(" (") +
+            kColumnName +
+            QChar(',') +
+            kColumnValue +
+            QStringLiteral(") VALUES (:name,:value)");
     QSqlQuery query(m_database);
     VERIFY_OR_DEBUG_ASSERT(query.prepare(statement)) {
         return false;

--- a/src/library/dao/settingsdao.h
+++ b/src/library/dao/settingsdao.h
@@ -1,6 +1,4 @@
-#ifndef SETTINGSDAO_H
-#define SETTINGSDAO_H
-
+#pragma once
 #include <QtSql>
 
 #define SETTINGS_TABLE "settings"
@@ -12,16 +10,17 @@
 
 
 // All library-specific preferences go in the library settings table
-class SettingsDAO final : public QObject {
+class SettingsDAO final {
   public:
     explicit SettingsDAO(const QSqlDatabase& db);
-    ~SettingsDAO() override = default;
 
-    QString getValue(const QString& name, QString defaultValue = QString()) const;
-    bool setValue(const QString& name, const QVariant& value);
+    QString getValue(
+            const QString& name,
+            QString defaultValue = QString()) const;
+    bool setValue(
+            const QString& name,
+            const QVariant& value) const;
 
   private:
     QSqlDatabase m_db;
 };
-
-#endif /* SETTINGSDAO_H */

--- a/src/library/dao/settingsdao.h
+++ b/src/library/dao/settingsdao.h
@@ -1,18 +1,15 @@
 #pragma once
-#include <QtSql>
 
-#define SETTINGS_TABLE "settings"
-
-#define SETTINGSTABLE_NAME "name"
-#define SETTINGSTABLE_VALUE "value"
-#define SETTINGSTABLE_LOCKED "locked"
-#define SETTINGSTABLE_HIDDEN "hidden"
-
+#include <QSqlDatabase>
+#include <QString>
+#include <QVariant>
 
 // All library-specific preferences go in the library settings table
 class SettingsDAO final {
   public:
-    explicit SettingsDAO(const QSqlDatabase& db);
+    explicit SettingsDAO(QSqlDatabase database)
+            : m_database(std::move(database)) {
+    }
 
     QString getValue(
             const QString& name,
@@ -22,5 +19,5 @@ class SettingsDAO final {
             const QVariant& value) const;
 
   private:
-    QSqlDatabase m_db;
+    const QSqlDatabase m_database;
 };

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -42,9 +42,6 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
             UserSettingsPointer pConfig);
     ~TrackDAO() override;
 
-    void initialize(const QSqlDatabase& database) override {
-        m_database = database;
-    }
     void finish();
 
     QList<TrackId> resolveTrackIds(
@@ -158,8 +155,6 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
             TrackId trackId,
             TrackFile fileInfo) override;
 
-    QSqlDatabase m_database;
-
     CueDAO& m_cueDao;
     PlaylistDAO& m_playlistDao;
     AnalysisDao& m_analysisDao;
@@ -181,7 +176,6 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
 
     DISALLOW_COPY_AND_ASSIGN(TrackDAO);
 };
-
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(TrackDAO::ResolveTrackIdFlags)
 

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -477,19 +477,19 @@ void Library::slotRequestAddDir(QString dir) {
 
 void Library::slotRequestRemoveDir(QString dir, RemovalType removalType) {
     switch (removalType) {
-        case Library::HideTracks:
-            // Mark all tracks in this directory as deleted but DON'T purge them
-            // in case the user re-adds them manually.
-            m_pTrackCollectionManager->hideAllTracks(dir);
-            break;
-        case Library::PurgeTracks:
-            // The user requested that we purge all metadata.
-            m_pTrackCollectionManager->purgeAllTracks(dir);
-            break;
-        case Library::LeaveTracksUnchanged:
-        default:
-            break;
-
+    case RemovalType::KeepTracks:
+        break;
+    case RemovalType::HideTracks:
+        // Mark all tracks in this directory as deleted but DON'T purge them
+        // in case the user re-adds them manually.
+        m_pTrackCollectionManager->hideAllTracks(dir);
+        break;
+    case RemovalType::PurgeTracks:
+        // The user requested that we purge all metadata.
+        m_pTrackCollectionManager->purgeAllTracks(dir);
+        break;
+    default:
+        DEBUG_ASSERT(!"unreachable");
     }
 
     // Remove the directory from the directory list.

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -77,8 +77,8 @@ class Library: public QObject {
 
     //static Library* buildDefaultLibrary();
 
-    enum RemovalType {
-        LeaveTracksUnchanged = 0,
+    enum class RemovalType {
+        KeepTracks,
         HideTracks,
         PurgeTracks
     };

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -13,11 +13,8 @@
 
 #include <mp3guessenc.h>
 
-#include "engine/engine.h"
 #include "library/dao/trackschema.h"
 #include "library/library.h"
-#include "library/librarytablemodel.h"
-#include "library/missingtablemodel.h"
 #include "library/queryutil.h"
 #include "library/trackcollection.h"
 #include "library/trackcollectionmanager.h"
@@ -28,9 +25,6 @@
 #include "util/color/color.h"
 #include "util/db/dbconnectionpooled.h"
 #include "util/db/dbconnectionpooler.h"
-#include "util/file.h"
-#include "util/sandbox.h"
-#include "waveform/waveform.h"
 
 #include "widget/wlibrary.h"
 #include "widget/wlibrarytextbrowser.h"

--- a/src/library/serato/seratofeature.cpp
+++ b/src/library/serato/seratofeature.cpp
@@ -9,11 +9,8 @@
 #include <QStandardPaths>
 #include <QtDebug>
 
-#include "engine/engine.h"
 #include "library/dao/trackschema.h"
 #include "library/library.h"
-#include "library/librarytablemodel.h"
-#include "library/missingtablemodel.h"
 #include "library/queryutil.h"
 #include "library/trackcollection.h"
 #include "library/trackcollectionmanager.h"
@@ -25,9 +22,6 @@
 #include "util/color/color.h"
 #include "util/db/dbconnectionpooled.h"
 #include "util/db/dbconnectionpooler.h"
-#include "util/file.h"
-#include "util/sandbox.h"
-#include "waveform/waveform.h"
 #include "widget/wlibrary.h"
 #include "widget/wlibrarytextbrowser.h"
 

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -52,12 +52,7 @@ MixxxApplication::MixxxApplication(int& argc, char** argv)
             math_max(4, QThreadPool::globalInstance()->maxThreadCount()));
 }
 
-MixxxApplication::~MixxxApplication() {
-}
-
 void MixxxApplication::registerMetaTypes() {
-    // Register custom data types
-
     // PCM audio types
     qRegisterMetaType<mixxx::audio::ChannelCount>("mixxx::audio::ChannelCount");
     qRegisterMetaType<mixxx::audio::OptionalChannelLayout>("mixxx::audio::OptionalChannelLayout");
@@ -65,24 +60,30 @@ void MixxxApplication::registerMetaTypes() {
     qRegisterMetaType<mixxx::audio::SampleRate>("mixxx::audio::SampleRate");
     qRegisterMetaType<mixxx::audio::Bitrate>("mixxx::audio::Bitrate");
 
-    // TrackId
+    // Tracks
     qRegisterMetaType<TrackId>();
     qRegisterMetaType<QSet<TrackId>>();
     qRegisterMetaType<QList<TrackId>>();
     qRegisterMetaType<TrackRef>();
     qRegisterMetaType<QList<TrackRef>>();
     qRegisterMetaType<QList<QPair<TrackRef, TrackRef>>>();
+    qRegisterMetaType<TrackPointer>();
+
+    // Crates
     qRegisterMetaType<CrateId>();
     qRegisterMetaType<QSet<CrateId>>();
     qRegisterMetaType<QList<CrateId>>();
-    qRegisterMetaType<TrackPointer>();
+
+    // Sound devices
+    qRegisterMetaType<SoundDeviceId>();
+    QMetaType::registerComparators<SoundDeviceId>();
+
+    // Various custom data types
     qRegisterMetaType<mixxx::ReplayGain>("mixxx::ReplayGain");
     qRegisterMetaType<mixxx::cache_key_t>("mixxx::cache_key_t");
     qRegisterMetaType<mixxx::Bpm>("mixxx::Bpm");
     qRegisterMetaType<mixxx::Duration>("mixxx::Duration");
     qRegisterMetaType<std::optional<mixxx::RgbColor>>("std::optional<mixxx::RgbColor>");
-    qRegisterMetaType<SoundDeviceId>("SoundDeviceId");
-    QMetaType::registerComparators<SoundDeviceId>();
 }
 
 bool MixxxApplication::touchIsRightButton() {

--- a/src/mixxxapplication.h
+++ b/src/mixxxapplication.h
@@ -9,7 +9,7 @@ class MixxxApplication : public QApplication {
     Q_OBJECT
   public:
     MixxxApplication(int& argc, char** argv);
-    ~MixxxApplication() override;
+    ~MixxxApplication() override = default;
 
   private:
     bool touchIsRightButton();

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -30,18 +30,30 @@ DlgPrefLibrary::DlgPrefLibrary(
           m_iOriginalTrackTableRowHeight(Library::kDefaultRowHeightPx) {
     setupUi(this);
 
-    connect(this, SIGNAL(requestAddDir(QString)),
-            m_pLibrary, SLOT(slotRequestAddDir(QString)));
-    connect(this, SIGNAL(requestRemoveDir(QString, Library::RemovalType)),
-            m_pLibrary, SLOT(slotRequestRemoveDir(QString, Library::RemovalType)));
-    connect(this, SIGNAL(requestRelocateDir(QString,QString)),
-            m_pLibrary, SLOT(slotRequestRelocateDir(QString,QString)));
-    connect(PushButtonAddDir, SIGNAL(clicked()),
-            this, SLOT(slotAddDir()));
-    connect(PushButtonRemoveDir, SIGNAL(clicked()),
-            this, SLOT(slotRemoveDir()));
-    connect(PushButtonRelocateDir, SIGNAL(clicked()),
-            this, SLOT(slotRelocateDir()));
+    connect(this,
+            &DlgPrefLibrary::requestAddDir,
+            m_pLibrary,
+            &Library::slotRequestAddDir);
+    connect(this,
+            &DlgPrefLibrary::requestRemoveDir,
+            m_pLibrary,
+            &Library::slotRequestRemoveDir);
+    connect(this,
+            &DlgPrefLibrary::requestRelocateDir,
+            m_pLibrary,
+            &Library::slotRequestRelocateDir);
+    connect(PushButtonAddDir,
+            &QPushButton::clicked,
+            this,
+            &DlgPrefLibrary::slotAddDir);
+    connect(PushButtonRemoveDir,
+            &QPushButton::clicked,
+            this,
+            &DlgPrefLibrary::slotRemoveDir);
+    connect(PushButtonRelocateDir,
+            &QPushButton::clicked,
+            this,
+            &DlgPrefLibrary::slotRelocateDir);
 
     // Set default direction as stored in config file
     int rowHeight = m_pLibrary->getTrackTableRowHeight();
@@ -259,17 +271,14 @@ void DlgPrefLibrary::slotRemoveDir() {
         return;
     }
 
-    bool deleteAll = removeMsgBox.clickedButton() == deleteAllButton;
-    bool hideAll = removeMsgBox.clickedButton() == hideAllButton;
-    bool leaveUnchanged = removeMsgBox.clickedButton() == leaveUnchangedButton;
-
-    Library::RemovalType removalType = Library::LeaveTracksUnchanged;
-    if (leaveUnchanged) {
-        removalType = Library::LeaveTracksUnchanged;
-    } else if (deleteAll) {
-        removalType = Library::PurgeTracks;
-    } else if (hideAll) {
-        removalType = Library::HideTracks;
+    Library::RemovalType removalType;
+    if (removeMsgBox.clickedButton() == hideAllButton) {
+        removalType = Library::RemovalType::HideTracks;
+    } else if (removeMsgBox.clickedButton() == deleteAllButton) {
+        removalType = Library::RemovalType::PurgeTracks;
+    } else {
+        DEBUG_ASSERT(removeMsgBox.clickedButton() == leaveUnchangedButton);
+        removalType = Library::RemovalType::KeepTracks;
     }
 
     emit requestRemoveDir(fd, removalType);

--- a/src/test/coverartcache_test.cpp
+++ b/src/test/coverartcache_test.cpp
@@ -72,8 +72,14 @@ const QString kTrackLocationTest(QDir::currentPath() %
 // - empty trackLocation
 // - absolute coverLocation
 
-TEST_F(CoverArtCacheTest, loadCover) {
+TEST_F(CoverArtCacheTest, loadCoverFromMetadata) {
     loadCoverFromMetadata(kTrackLocationTest);
-    loadCoverFromFile(kTrackLocationTest, kCoverFileTest, kCoverLocationTest); //relative
-    loadCoverFromFile(QString(), kCoverLocationTest, kCoverLocationTest); //absolute
+}
+
+TEST_F(CoverArtCacheTest, loadCoverFromFileRelative) {
+    loadCoverFromFile(kTrackLocationTest, kCoverFileTest, kCoverLocationTest);
+}
+
+TEST_F(CoverArtCacheTest, loadCoverFromFileAbsolute) {
+    loadCoverFromFile(QString(), kCoverLocationTest, kCoverLocationTest);
 }

--- a/src/test/coverartutils_test.cpp
+++ b/src/test/coverartutils_test.cpp
@@ -1,11 +1,10 @@
-#include <gtest/gtest.h>
+#include "library/coverartutils.h"
+
 #include <QFileInfo>
 #include <QTemporaryDir>
 
-#include "sources/soundsourceproxy.h"
 #include "library/coverartcache.h"
-#include "library/coverartutils.h"
-
+#include "sources/soundsourceproxy.h"
 #include "test/librarytest.h"
 
 namespace {
@@ -30,23 +29,10 @@ void extractEmbeddedCover(
 
 } // anonymous namespace
 
-// first inherit from MixxxTest to construct a QApplication to be able to
-// construct the default QPixmap in CoverArtCache
-class CoverArtUtilTest : public LibraryTest, public CoverArtCache {
-  protected:
-    void SetUp() override {
-    }
-
-    void TearDown() override {
-        // make sure we clean up the db
-        QSqlQuery query(dbConnection());
-        query.prepare("DELETE FROM " % DIRECTORYDAO_TABLE);
-        ASSERT_TRUE(query.exec());
-        query.prepare("DELETE FROM library");
-        ASSERT_TRUE(query.exec());
-        query.prepare("DELETE FROM track_locations");
-        ASSERT_TRUE(query.exec());
-    }
+// First inherit from LibraryTest to construct an QApplication instance
+// needed by CoverArtCache for the default QPixmapCache.
+// LibraryTest is required to instantiate the GlobalTrackCache singleton.
+class CoverArtUtilTest : public LibraryTest, CoverArtCache {
 };
 
 TEST_F(CoverArtUtilTest, extractEmbeddedCover) {

--- a/src/test/directorydaotest.cpp
+++ b/src/test/directorydaotest.cpp
@@ -20,8 +20,8 @@ namespace {
 
 class DirectoryDAOTest : public LibraryTest {
   protected:
-    void SetUp() override {
-        m_supportedFileExt = "." % SoundSourceProxy::getSupportedFileExtensions().first();
+    DirectoryDAOTest()
+            : m_supportedFileExt("." % SoundSourceProxy::getSupportedFileExtensions().first()) {
     }
 
     void TearDown() override {
@@ -35,7 +35,7 @@ class DirectoryDAOTest : public LibraryTest {
         query.exec();
     }
 
-    QString m_supportedFileExt;
+    const QString m_supportedFileExt;
 };
 
 TEST_F(DirectoryDAOTest, addDirTest) {

--- a/src/test/librarytest.cpp
+++ b/src/test/librarytest.cpp
@@ -34,7 +34,7 @@ LibraryTest::LibraryTest()
 }
 
 TrackPointer LibraryTest::getOrAddTrackByLocation(
-        const QString& trackLocation) {
+        const QString& trackLocation) const {
     return m_pTrackCollectionManager->getOrAddTrack(
             TrackRef::fromFileInfo(trackLocation));
 }

--- a/src/test/librarytest.h
+++ b/src/test/librarytest.h
@@ -23,16 +23,16 @@ class LibraryTest : public MixxxTest {
         return mixxx::DbConnectionPooled(m_dbConnectionPooler);
     }
 
-    TrackCollectionManager* trackCollections() {
+    TrackCollectionManager* trackCollections() const {
         return m_pTrackCollectionManager.get();
     }
 
-    TrackCollection* internalCollection() {
+    TrackCollection* internalCollection() const {
         return trackCollections()->internalCollection();
     }
 
     TrackPointer getOrAddTrackByLocation(
-            const QString& trackLocation);
+            const QString& trackLocation) const;
 
   private:
     const MixxxDb m_mixxxDb;

--- a/src/test/schemamanager_test.cpp
+++ b/src/test/schemamanager_test.cpp
@@ -1,16 +1,15 @@
+#include "database/schemamanager.h"
+
 #include <gtest/gtest.h>
 
-#include "test/mixxxtest.h"
+#include <QSqlQuery>
 
 #include "database/mixxxdb.h"
-#include "database/schemamanager.h"
-#include "util/db/dbconnectionpooler.h"
-#include "util/db/dbconnectionpooled.h"
-
 #include "library/dao/settingsdao.h"
-
+#include "test/mixxxtest.h"
 #include "util/assert.h"
-
+#include "util/db/dbconnectionpooled.h"
+#include "util/db/dbconnectionpooler.h"
 
 class SchemaManagerTest : public MixxxTest {
   protected:

--- a/src/util/file.cpp
+++ b/src/util/file.cpp
@@ -1,35 +1,5 @@
 #include "util/file.h"
 
-MFile::MFile() {
-}
-
-MFile::MFile(const QString& file)
-        : m_fileName(file),
-          m_file(file),
-          m_pSecurityToken(Sandbox::openSecurityToken(m_file, true)) {
-}
-
-MFile::MFile(const MFile& other)
-        : m_fileName(other.m_fileName),
-          m_file(m_fileName),
-          m_pSecurityToken(other.m_pSecurityToken) {
-}
-
-MFile::~MFile() {
-}
-
-MFile& MFile::operator=(const MFile& other) {
-    m_fileName = other.m_fileName;
-    m_file.setFileName(m_fileName);
-    m_pSecurityToken = other.m_pSecurityToken;
-    return *this;
-}
-
-bool MFile::canAccess() {
-    QFileInfo info(m_file);
-    return Sandbox::canAccessFile(info);
-}
-
 MDir::MDir() {
 }
 

--- a/src/util/file.h
+++ b/src/util/file.h
@@ -6,35 +6,6 @@
 
 #include "util/sandbox.h"
 
-class MFile {
-  public:
-    MFile();
-    MFile(const QString& name);
-    MFile(const MFile& other);
-    virtual ~MFile();
-
-    QFile& file() {
-        return m_file;
-    }
-
-    const QFile& file() const {
-        return m_file;
-    }
-
-    SecurityTokenPointer token() {
-        return m_pSecurityToken;
-    }
-
-    bool canAccess();
-
-    MFile& operator=(const MFile& other);
-
-  private:
-    QString m_fileName;
-    QFile m_file;
-    SecurityTokenPointer m_pSecurityToken;
-};
-
 class MDir {
   public:
     MDir();


### PR DESCRIPTION
Minor code cleanups that have piled up. Small, meaningful refactorings with real value instead of mass reformattings.

Only commit 822aee3 *Remove public #define directives from SettingsDAO* contains functional code changes, please review the changes in the .cpp file. Not a big deal, should be safe.

Scheduled for 2.3 to avoid merge conflicts in the future while master progresses.