### PR TITLE
legacyskinparser: accept WCoverArt with empty <Group> in library

### DIFF
--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1246,10 +1246,13 @@ QWidget* LegacySkinParser::parseSearchBox(const QDomElement& node) {
 
 QWidget* LegacySkinParser::parseCoverArt(const QDomElement& node) {
     QString group = lookupNodeGroup(node);
-    BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
-    if (!pPlayer) {
-        SKIN_WARNING(node, *m_pContext) << "No player found for group:" << group;
-        return nullptr;
+    BaseTrackPlayer* pPlayer = nullptr;
+    if (!group.isEmpty()) {
+        pPlayer = m_pPlayerManager->getPlayer(group);
+        if (!pPlayer) {
+            SKIN_WARNING(node, *m_pContext) << "No player found for group:" << group;
+            return nullptr;
+        }
     }
     WCoverArt* pCoverArt = new WCoverArt(m_pParent, m_pConfig, group, pPlayer);
     commonWidgetSetup(node, pCoverArt);


### PR DESCRIPTION
... and link to tracks table as before

broken by https://github.com/mixxxdj/mixxx/pull/2834/commits/c0f067aa6e9547ff391cd0844a6bec8f04e8159d

https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/Libary.20CoverArt.20not.20displayed