### PR TITLE
DlgPrefWaveform: remove option to not synchronize waveform zoom

### DIFF
--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -62,8 +62,6 @@ DlgPrefWaveform::DlgPrefWaveform(QWidget* pParent, MixxxMainWindow* pMixxx,
             this, SLOT(slotSetWaveformType(int)));
     connect(defaultZoomComboBox, SIGNAL(currentIndexChanged(int)),
             this, SLOT(slotSetDefaultZoom(int)));
-    connect(synchronizeZoomCheckBox, SIGNAL(clicked(bool)),
-            this, SLOT(slotSetZoomSynchronization(bool)));
     connect(allVisualGain, SIGNAL(valueChanged(double)),
             this, SLOT(slotSetVisualGainAll(double)));
     connect(lowVisualGain, SIGNAL(valueChanged(double)),
@@ -106,7 +104,6 @@ void DlgPrefWaveform::slotUpdate() {
     frameRateSlider->setValue(factory->getFrameRate());
     endOfTrackWarningTimeSpinBox->setValue(factory->getEndOfTrackWarningTime());
     endOfTrackWarningTimeSlider->setValue(factory->getEndOfTrackWarningTime());
-    synchronizeZoomCheckBox->setChecked(factory->isZoomSync());
     allVisualGain->setValue(factory->getVisualGain(WaveformWidgetFactory::All));
     lowVisualGain->setValue(factory->getVisualGain(WaveformWidgetFactory::Low));
     midVisualGain->setValue(factory->getVisualGain(WaveformWidgetFactory::Mid));
@@ -157,9 +154,6 @@ void DlgPrefWaveform::slotResetToDefaults() {
 
     // Default zoom level is 3 in WaveformWidgetFactory.
     defaultZoomComboBox->setCurrentIndex(3 + 1);
-
-    // Don't synchronize zoom by default.
-    synchronizeZoomCheckBox->setChecked(false);
 
     // RGB overview.
     waveformOverviewComboBox->setCurrentIndex(2);
@@ -214,10 +208,6 @@ void DlgPrefWaveform::slotSetWaveformOverviewType(int index) {
 
 void DlgPrefWaveform::slotSetDefaultZoom(int index) {
     WaveformWidgetFactory::instance()->setDefaultZoom(index + 1);
-}
-
-void DlgPrefWaveform::slotSetZoomSynchronization(bool checked) {
-    WaveformWidgetFactory::instance()->setZoomSync(checked);
 }
 
 void DlgPrefWaveform::slotSetVisualGainAll(double gain) {

--- a/src/preferences/dialog/dlgprefwaveform.h
+++ b/src/preferences/dialog/dlgprefwaveform.h
@@ -28,7 +28,6 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
     void slotSetWaveformType(int index);
     void slotSetWaveformOverviewType(int index);
     void slotSetDefaultZoom(int index);
-    void slotSetZoomSynchronization(bool checked);
     void slotSetVisualGainAll(double gain);
     void slotSetVisualGainLow(double gain);
     void slotSetVisualGainMid(double gain);

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -16,7 +16,7 @@
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout_2">
-     <item row="10" column="0">
+     <item row="9" column="0">
       <widget class="QLabel" name="visualGainLabel">
        <property name="text">
         <string>Visual gain</string>
@@ -57,14 +57,14 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="1">
+     <item row="8" column="1">
       <widget class="QCheckBox" name="normalizeOverviewCheckBox">
        <property name="text">
         <string>Normalize waveform overview</string>
        </property>
       </widget>
      </item>
-     <item row="13" column="1">
+     <item row="12" column="1">
       <widget class="QLabel" name="openGlStatusIcon">
        <property name="toolTip">
         <string>Displays which OpenGL version is supported by the current platform.</string>
@@ -93,7 +93,7 @@
        </property>
       </widget>
      </item>
-     <item row="14" column="0">
+     <item row="13" column="0">
       <widget class="QLabel" name="openGlStatusLabel_2">
        <property name="toolTip">
         <string/>
@@ -123,14 +123,14 @@
       <widget class="QComboBox" name="defaultZoomComboBox"/>
      </item>
 
-     <item row="12" column="0" colspan="4">
+     <item row="11" column="0" colspan="4">
       <widget class="Line" name="line">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
       </widget>
      </item>
-     <item row="13" column="0">
+     <item row="12" column="0">
       <widget class="QLabel" name="openGlStatusLabel">
        <property name="toolTip">
         <string/>
@@ -165,7 +165,7 @@
        </property>
       </widget>
      </item>
-     <item row="10" column="1" colspan="3">
+     <item row="9" column="1" colspan="3">
       <layout class="QGridLayout" name="gridLayout_3">
        <item row="1" column="2">
         <widget class="QDoubleSpinBox" name="midVisualGain">
@@ -323,7 +323,7 @@ Select from different types of displays for the waveform, which differ primarily
        </property>
       </widget>
      </item>
-     <item row="14" column="1">
+     <item row="13" column="1">
       <widget class="QLabel" name="frameRateAverage">
        <property name="toolTip">
         <string>Displays the actual frame rate.</string>
@@ -406,17 +406,7 @@ Select from different types of displays for the waveform, which differ primarily
        </property>
       </widget>
      </item>
-     <item row="7" column="1" colspan="3">
-      <widget class="QCheckBox" name="synchronizeZoomCheckBox">
-       <property name="toolTip">
-        <string>Synchronize zoom level across all waveform displays.</string>
-       </property>
-       <property name="text">
-        <string>Synchronize zoom level across all waveforms</string>
-       </property>
-      </widget>
-     </item>
-     <item row="11" column="0">
+     <item row="10" column="0">
       <widget class="QLabel" name="cachedWaveforms">
        <property name="text">
         <string>Caching</string>
@@ -426,7 +416,7 @@ Select from different types of displays for the waveform, which differ primarily
        </property>
       </widget>
      </item>
-     <item row="11" column="1" colspan="3">
+     <item row="10" column="1" colspan="3">
       <layout class="QGridLayout" name="cachingGridLayout">
        <item row="3" column="1">
         <widget class="QPushButton" name="clearCachedWaveforms">

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -105,7 +105,6 @@ WaveformWidgetFactory::WaveformWidgetFactory()
           m_frameRate(30),
           m_endOfTrackWarningTime(30),
           m_defaultZoom(WaveformWidgetRenderer::s_waveformDefaultZoom),
-          m_zoomSync(false),
           m_overviewNormalized(false),
           m_openGlAvailable(false),
           m_openGlesAvailable(false),
@@ -301,13 +300,6 @@ bool WaveformWidgetFactory::setConfig(UserSettingsPointer config) {
         setDefaultZoom(defaultZoom);
     } else{
         m_config->set(ConfigKey("[Waveform]","DefaultZoom"), ConfigValue(m_defaultZoom));
-    }
-
-    int zoomSync = m_config->getValueString(ConfigKey("[Waveform]","ZoomSynchronization")).toInt(&ok);
-    if (ok) {
-        setZoomSync(static_cast<bool>(zoomSync));
-    } else {
-        m_config->set(ConfigKey("[Waveform]","ZoomSynchronization"), ConfigValue(m_zoomSync));
     }
 
     int beatGridAlpha = m_config->getValue(ConfigKey("[Waveform]", "beatGridAlpha"), m_beatGridAlpha);
@@ -554,22 +546,6 @@ void WaveformWidgetFactory::setDefaultZoom(double zoom) {
     }
 }
 
-void WaveformWidgetFactory::setZoomSync(bool sync) {
-    m_zoomSync = sync;
-    if (m_config) {
-        m_config->set(ConfigKey("[Waveform]","ZoomSynchronization"), ConfigValue(m_zoomSync));
-    }
-
-    if (m_waveformWidgetHolders.size() == 0) {
-        return;
-    }
-
-    double refZoom = m_waveformWidgetHolders[0].m_waveformWidget->getZoomFactor();
-    for (std::size_t i = 1; i < m_waveformWidgetHolders.size(); i++) {
-        m_waveformWidgetHolders[i].m_waveformViewer->setZoom(refZoom);
-    }
-}
-
 void WaveformWidgetFactory::setDisplayBeatGridAlpha(int alpha) {
     m_beatGridAlpha = alpha;
     if (m_waveformWidgetHolders.size() == 0) {
@@ -613,7 +589,7 @@ void WaveformWidgetFactory::setPlayMarkerPosition(double position) {
 
 void WaveformWidgetFactory::notifyZoomChange(WWaveformViewer* viewer) {
     WaveformWidgetAbstract* pWaveformWidget = viewer->getWaveformWidget();
-    if (pWaveformWidget != NULL && isZoomSync()) {
+    if (pWaveformWidget != nullptr) {
         //qDebug() << "WaveformWidgetFactory::notifyZoomChange";
         double refZoom = pWaveformWidget->getZoomFactor();
 

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -587,18 +587,11 @@ void WaveformWidgetFactory::setPlayMarkerPosition(double position) {
     }
 }
 
-void WaveformWidgetFactory::notifyZoomChange(WWaveformViewer* viewer) {
-    WaveformWidgetAbstract* pWaveformWidget = viewer->getWaveformWidget();
-    if (pWaveformWidget != nullptr) {
-        //qDebug() << "WaveformWidgetFactory::notifyZoomChange";
-        double refZoom = pWaveformWidget->getZoomFactor();
-
-        for (std::size_t i = 0; i < m_waveformWidgetHolders.size(); ++i) {
-            WaveformWidgetHolder& holder = m_waveformWidgetHolders[i];
-            if (holder.m_waveformViewer != viewer) {
-                holder.m_waveformViewer->setZoom(refZoom);
-            }
-        }
+void WaveformWidgetFactory::setZoom(double zoom) {
+    // Waveforms always have the same zoom
+    for (std::size_t i = 0; i < m_waveformWidgetHolders.size(); ++i) {
+        WaveformWidgetHolder& holder = m_waveformWidgetHolders[i];
+        holder.m_waveformViewer->setZoom(zoom);
     }
 }
 

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -104,9 +104,6 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     void setDefaultZoom(double zoom);
     double getDefaultZoom() const { return m_defaultZoom;}
 
-    void setZoomSync(bool sync);
-    int isZoomSync() const { return m_zoomSync;}
-
     void setDisplayBeatGridAlpha(int alpha);
     int beatGridAlpha() const { return m_beatGridAlpha; }
 
@@ -176,7 +173,6 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     int m_frameRate;
     int m_endOfTrackWarningTime;
     double m_defaultZoom;
-    bool m_zoomSync;
     double m_visualGain[FilterCount];
     bool m_overviewNormalized;
 

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -126,7 +126,7 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     void setPlayMarkerPosition(double position);
     double getPlayMarkerPosition() const { return m_playMarkerPosition; }
 
-    void notifyZoomChange(WWaveformViewer *viewer);
+    void setZoom(double zoom);
 
     WaveformWidgetType::Type autoChooseWidgetType() const;
 

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -212,10 +212,8 @@ void WWaveformViewer::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOld
 }
 
 void WWaveformViewer::onZoomChange(double zoom) {
-    //qDebug() << "WaveformWidgetRenderer::onZoomChange" << this << zoom;
-    setZoom(zoom);
-    // notify back the factory to sync zoom if needed
-    WaveformWidgetFactory::instance()->notifyZoomChange(this);
+    // WaveformWidgetFactory sets the zoom for all waveforms together
+    WaveformWidgetFactory::instance()->setZoom(zoom);
 }
 
 void WWaveformViewer::setZoom(double zoom) {


### PR DESCRIPTION
There is no use case for this.