### PR TITLE
Stream_name: Adding a default stream name to the Stream Info.

### DIFF
--- a/src/preferences/broadcastprofile.cpp
+++ b/src/preferences/broadcastprofile.cpp
@@ -74,8 +74,7 @@ const bool kDefaultNoDelayFirstReconnect = true;
 const bool kDefaultOggDynamicupdate = false;
 double kDefaultReconnectFirstDelay = 0.0;
 double kDefaultReconnectPeriod = 5.0;
-const QString kDefaultStreamName =
-        QObject::tr("Mixxx");
+const QString kDefaultStreamName = QStringLiteral("Mixxx");
 const QString kDefaultStreamDesc =
         QObject::tr("This stream is online for testing purposes!");
 const QString kDefaultStreamGenre = QObject::tr("Live Mix");

--- a/src/preferences/broadcastprofile.cpp
+++ b/src/preferences/broadcastprofile.cpp
@@ -74,6 +74,8 @@ const bool kDefaultNoDelayFirstReconnect = true;
 const bool kDefaultOggDynamicupdate = false;
 double kDefaultReconnectFirstDelay = 0.0;
 double kDefaultReconnectPeriod = 5.0;
+const QString kDefaultStreamName =
+        QObject::tr("Mixxx");
 const QString kDefaultStreamDesc =
         QObject::tr("This stream is online for testing purposes!");
 const QString kDefaultStreamGenre = QObject::tr("Live Mix");
@@ -231,7 +233,7 @@ void BroadcastProfile::adoptDefaultValues() {
     m_mountpoint = QString();
     m_streamDesc = kDefaultStreamDesc;
     m_streamGenre = kDefaultStreamGenre;
-    m_streamName = QString();
+    m_streamName = kDefaultStreamName;
     m_streamPublic = kDefaultStreamPublic;
     m_streamWebsite = MIXXX_WEBSITE_URL;
     m_streamIRC.clear();


### PR DESCRIPTION
This PR aims to fix https://bugs.launchpad.net/mixxx/+bug/1818054.

Discussion on Zulip: https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/adding.20a.20default.20Stream.20Name.