### PR TITLE
Delete obsolete slots

### DIFF
--- a/src/library/banshee/bansheeplaylistmodel.cpp
+++ b/src/library/banshee/bansheeplaylistmodel.cpp
@@ -234,10 +234,6 @@ Qt::ItemFlags BansheePlaylistModel::flags(const QModelIndex &index) const {
     return readOnlyFlags(index);
 }
 
-void BansheePlaylistModel::tracksChanged(QSet<TrackId> trackIds) {
-    Q_UNUSED(trackIds);
-}
-
 TrackId BansheePlaylistModel::doGetTrackId(const TrackPointer& pTrack) const {
     if (pTrack) {
         for (int row = 0; row < rowCount(); ++row) {

--- a/src/library/banshee/bansheeplaylistmodel.h
+++ b/src/library/banshee/bansheeplaylistmodel.h
@@ -28,9 +28,6 @@ class BansheePlaylistModel final : public BaseSqlTableModel {
     Qt::ItemFlags flags(const QModelIndex &index) const final;
     CapabilitiesFlags getCapabilities() const final;
 
-  private slots:
-    void tracksChanged(QSet<TrackId> trackIds);
-
   private:
     TrackId doGetTrackId(const TrackPointer& pTrack) const final;
 

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -746,17 +746,6 @@ BaseCoverArtDelegate* BaseSqlTableModel::doCreateCoverArtDelegate(
     return new CoverArtDelegate(pTableView);
 }
 
-void BaseSqlTableModel::slotRefreshCoverRows(QList<int> rows) {
-    if (rows.isEmpty()) {
-        return;
-    }
-    const int column = fieldIndex(LIBRARYTABLE_COVERART);
-    VERIFY_OR_DEBUG_ASSERT(column >= 0) {
-        return;
-    }
-    emitDataChangedForMultipleRowsInColumn(rows, column);
-}
-
 void BaseSqlTableModel::hideTracks(const QModelIndexList& indices) {
     QList<TrackId> trackIds;
     foreach (QModelIndex index, indices) {

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -106,8 +106,6 @@ class BaseSqlTableModel : public BaseTrackTableModel {
   private slots:
     void tracksChanged(QSet<TrackId> trackIds);
 
-    void slotRefreshCoverRows(QList<int> rows);
-
   private:
     BaseCoverArtDelegate* doCreateCoverArtDelegate(
             QTableView* pTableView) const final;


### PR DESCRIPTION
Both slots override and hide non-virtual(!) slots from their base classes. Probably leftovers from extracting the base classes.

Follow-up TODO: Enable warning `-Woverloaded-virtual` in build to detect unwanted hiding of base class methods.