### PR TITLE
fullscreen keyboard shortcut: on macOS use only the OS shortcut

### DIFF
--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -265,7 +265,13 @@ void WMainMenuBar::initialize() {
     QString fullScreenTitle = tr("&Full Screen");
     QString fullScreenText = tr("Display Mixxx using the full screen");
     auto pViewFullScreen = new QAction(fullScreenTitle, this);
-    QList<QKeySequence> shortcuts{QKeySequence("F11")};
+    QList<QKeySequence> shortcuts;
+    // We use F11 _AND_ the OS shortcut only on Linux and Windows because on
+    // newer macOS versions there might be issues with getting F11 working.
+    // https://github.com/mixxxdj/mixxx/pull/3011#issuecomment-678678328
+#ifndef __APPLE__
+    shortcuts << QKeySequence("F11");
+#endif
     QKeySequence osShortcut = QKeySequence::FullScreen;
     // Note(ronso0) Only add the OS shortcut if it's not empty and not F11.
     // In some Linux distros the window managers doesn't pass the OS fullscreen


### PR DESCRIPTION
follow up to #3011 due to [issues with F11](https://github.com/mixxxdj/mixxx/pull/3011#issuecomment-678678328)
