### PR TITLE
Add manual help viewer based on Qt Help Framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -894,6 +894,8 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/waveform/widgets/softwarewaveformwidget.cpp
   src/waveform/widgets/waveformwidgetabstract.cpp
   src/widget/controlwidgetconnection.cpp
+  src/widget/helpbrowser.cpp
+  src/widget/helpviewer.cpp
   src/widget/hexspinbox.cpp
   src/widget/paintable.cpp
   src/widget/wanalysislibrarytableview.cpp
@@ -1957,6 +1959,7 @@ find_package(Qt5
     Concurrent
     Core
     Gui
+    Help
     Network
     OpenGL
     Qml
@@ -1971,6 +1974,7 @@ target_link_libraries(mixxx-lib PUBLIC
   Qt5::Concurrent
   Qt5::Core
   Qt5::Gui
+  Qt5::Help
   Qt5::Network
   Qt5::OpenGL
   Qt5::Qml

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -105,6 +105,22 @@ DlgPrefController::DlgPrefController(
                 QDesktopServices::openUrl(QUrl::fromLocalFile(path));
             });
 
+    // Open mapping support links
+    connect(m_ui.labelLoadedMappingSupportLinks,
+            &QLabel::linkActivated,
+            [this](const QString& link) {
+                const QUrl url(link);
+                qWarning() << url.scheme() << url.path();
+                VERIFY_OR_DEBUG_ASSERT(url.isValid()) {
+                    return;
+                }
+                if (url.scheme() == "manual") {
+                    emit showHelp(url.path());
+                    return;
+                }
+                QDesktopServices::openUrl(url);
+            });
+
     // Input mappings
     connect(m_ui.btnAddInputMapping,
             &QAbstractButton::clicked,
@@ -319,12 +335,12 @@ QString DlgPrefController::mappingSupportLinks(
                 wikiLink);
     }
 
-    QString manualLink = pMapping->manualLink();
-    if (!manualLink.isEmpty()) {
+    QString helpDocument = pMapping->manualDocument();
+    if (!helpDocument.isEmpty()) {
         linkList << coloredLinkString(
                 m_pLinkColor,
                 "Mixxx Manual",
-                manualLink);
+                QStringLiteral("manual://") + helpDocument);
     }
 
     // There is always at least one support link.

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -530,8 +530,8 @@ void DlgPrefController::slotApply() {
     setDirty(false);
 }
 
-QUrl DlgPrefController::helpUrl() const {
-    return QUrl(MIXXX_MANUAL_CONTROLLERS_URL);
+QString DlgPrefController::helpDocument() const {
+    return QString(MIXXX_MANUAL_CONTROLLERS_PATH);
 }
 
 QString DlgPrefController::mappingPathFromIndex(int index) const {

--- a/src/controllers/dlgprefcontroller.h
+++ b/src/controllers/dlgprefcontroller.h
@@ -28,7 +28,7 @@ class DlgPrefController : public DlgPreferencePage {
             UserSettingsPointer pConfig);
     virtual ~DlgPrefController();
 
-    QUrl helpUrl() const override;
+    QString helpDocument() const override;
 
   public slots:
     /// Called when the preference dialog (not this page) is shown to the user.

--- a/src/controllers/dlgprefcontrollerdlg.ui
+++ b/src/controllers/dlgprefcontrollerdlg.ui
@@ -361,7 +361,7 @@
              <string notr="true">(forum link for mapping goes here)</string>
             </property>
             <property name="openExternalLinks">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="textInteractionFlags">
              <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse</set>

--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -103,8 +103,8 @@ void DlgPrefControllers::slotResetToDefaults() {
     }
 }
 
-QUrl DlgPrefControllers::helpUrl() const {
-    return QUrl(MIXXX_MANUAL_CONTROLLERS_URL);
+QString DlgPrefControllers::helpDocument() const {
+    return QString(MIXXX_MANUAL_CONTROLLERS_PATH);
 }
 
 bool DlgPrefControllers::handleTreeItemClick(QTreeWidgetItem* clickedItem) {

--- a/src/controllers/dlgprefcontrollers.h
+++ b/src/controllers/dlgprefcontrollers.h
@@ -25,7 +25,7 @@ class DlgPrefControllers : public DlgPreferencePage, public Ui::DlgPrefControlle
     virtual ~DlgPrefControllers();
 
     bool handleTreeItemClick(QTreeWidgetItem* clickedItem);
-    QUrl helpUrl() const override;
+    QString helpDocument() const override;
 
   public slots:
     /// Called when the preference dialog (not this page) is shown to the user.

--- a/src/controllers/legacycontrollermapping.h
+++ b/src/controllers/legacycontrollermapping.h
@@ -129,7 +129,7 @@ class LegacyControllerMapping {
         return m_manualPage;
     }
 
-    QString manualLink() const {
+    QString manualDocument() const {
         QString page = manualPage();
         if (page.isEmpty()) {
             return {};

--- a/src/defs_urls.h
+++ b/src/defs_urls.h
@@ -32,6 +32,7 @@
 #define MIXXX_MANUAL_URL                        \
     "https://manual.mixxx.org/" TO_VERSION_STR( \
             MIXXX_VERSION_MAJOR, MIXXX_VERSION_MINOR)
+#define MIXXX_MANUAL_INDEX_PATH "/index.html"
 #define MIXXX_MANUAL_SHORTCUTS_URL \
     MIXXX_MANUAL_URL "/chapters/controlling_mixxx.html#using-a-keyboard"
 #define MIXXX_MANUAL_COMMANDLINEOPTIONS_URL \

--- a/src/defs_urls.h
+++ b/src/defs_urls.h
@@ -33,8 +33,8 @@
     "https://manual.mixxx.org/" TO_VERSION_STR( \
             MIXXX_VERSION_MAJOR, MIXXX_VERSION_MINOR)
 #define MIXXX_MANUAL_INDEX_PATH "/index.html"
-#define MIXXX_MANUAL_SHORTCUTS_URL \
-    MIXXX_MANUAL_URL "/chapters/controlling_mixxx.html#using-a-keyboard"
+#define MIXXX_MANUAL_SHORTCUTS_PATH \
+    "/chapters/controlling_mixxx.html#using-a-keyboard"
 #define MIXXX_MANUAL_COMMANDLINEOPTIONS_URL \
     MIXXX_MANUAL_URL "/chapters/appendix.html#command-line-options"
 #define MIXXX_MANUAL_CONTROLLERS_URL \
@@ -62,5 +62,3 @@
     MIXXX_MANUAL_URL "/chapters/vinyl_control.html#configuring-vinyl-control"
 #define MIXXX_MANUAL_VINYL_TROUBLESHOOTING_URL \
     MIXXX_MANUAL_URL "/chapters/vinyl_control.html#troubleshooting"
-#define MIXXX_MANUAL_FILENAME   "Mixxx-Manual.pdf"
-#define MIXXX_KBD_SHORTCUTS_FILENAME "Mixxx-Keyboard-Shortcuts.pdf"

--- a/src/defs_urls.h
+++ b/src/defs_urls.h
@@ -33,32 +33,32 @@
     "https://manual.mixxx.org/" TO_VERSION_STR( \
             MIXXX_VERSION_MAJOR, MIXXX_VERSION_MINOR)
 #define MIXXX_MANUAL_INDEX_PATH "/index.html"
-#define MIXXX_MANUAL_SHORTCUTS_PATH \
-    "/chapters/controlling_mixxx.html#using-a-keyboard"
 #define MIXXX_MANUAL_COMMANDLINEOPTIONS_URL \
     MIXXX_MANUAL_URL "/chapters/appendix.html#command-line-options"
-#define MIXXX_MANUAL_CONTROLLERS_URL \
-    MIXXX_MANUAL_URL "/chapters/controlling_mixxx.html#using-midi-hid-controllers"
+#define MIXXX_MANUAL_SHORTCUTS_PATH \
+    "/chapters/controlling_mixxx.html#using-a-keyboard"
+#define MIXXX_MANUAL_CONTROLLERS_PATH \
+    "/chapters/controlling_mixxx.html#using-midi-hid-controllers"
 #define MIXXX_MANUAL_CONTROLLERMANUAL_PREFIX \
-    MIXXX_MANUAL_URL "/hardware/controllers/"
+    "/hardware/controllers/"
 #define MIXXX_MANUAL_CONTROLLERMANUAL_SUFFIX ".html"
 #define MIXXX_MANUAL_CONTROLS_URL \
     MIXXX_MANUAL_URL "/chapters/advanced_topics.html#mixxx-controls"
-#define MIXXX_MANUAL_SOUND_URL \
-    MIXXX_MANUAL_URL "/chapters/preferences.html#sound-hardware"
-#define MIXXX_MANUAL_LIBRARY_URL \
-    MIXXX_MANUAL_URL "/chapters/preferences.html#library"
+#define MIXXX_MANUAL_SOUND_PATH \
+    "/chapters/preferences.html#sound-hardware"
+#define MIXXX_MANUAL_LIBRARY_PATH \
+    "/chapters/preferences.html#library"
 #define MIXXX_MANUAL_CUE_MODES_URL \
     MIXXX_MANUAL_URL "/chapters/user_interface.html#using-cue-modes"
-#define MIXXX_MANUAL_BEATS_URL \
-    MIXXX_MANUAL_URL "/chapters/preferences.html#beat-detection"
-#define MIXXX_MANUAL_KEY_URL \
-    MIXXX_MANUAL_URL "/chapters/preferences.html#key-detection"
-#define MIXXX_MANUAL_EQ_URL \
-    MIXXX_MANUAL_URL "/chapters/preferences.html#equalizers"
-#define MIXXX_MANUAL_BROADCAST_URL \
-    MIXXX_MANUAL_URL "/chapters/livebroadcasting.html#configuring-mixxx"
-#define MIXXX_MANUAL_VINYL_URL \
-    MIXXX_MANUAL_URL "/chapters/vinyl_control.html#configuring-vinyl-control"
+#define MIXXX_MANUAL_BEATS_PATH \
+    "/chapters/preferences.html#beat-detection"
+#define MIXXX_MANUAL_KEY_PATH \
+    "/chapters/preferences.html#key-detection"
+#define MIXXX_MANUAL_EQ_PATH \
+    "/chapters/preferences.html#equalizers"
+#define MIXXX_MANUAL_BROADCAST_PATH \
+    "/chapters/livebroadcasting.html#configuring-mixxx"
+#define MIXXX_MANUAL_VINYL_PATH \
+    "/chapters/vinyl_control.html#configuring-vinyl-control"
 #define MIXXX_MANUAL_VINYL_TROUBLESHOOTING_URL \
     MIXXX_MANUAL_URL "/chapters/vinyl_control.html#troubleshooting"

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -68,6 +68,7 @@
 #include "waveform/sharedglcontext.h"
 #include "waveform/visualsmanager.h"
 #include "waveform/waveformwidgetfactory.h"
+#include "widget/helpviewer.h"
 #include "widget/wmainmenubar.h"
 
 #ifdef __VINYLCONTROL__
@@ -107,6 +108,8 @@ MixxxMainWindow::MixxxMainWindow(
     DEBUG_ASSERT(pCoreServices);
     m_pCoreServices->initializeSettings();
     m_pCoreServices->initializeKeyboard();
+
+    m_pHelpViewer = new mixxx::HelpViewer(pCoreServices->getSettings());
     // These depend on the settings
     createMenuBar();
     m_pMenuBar->hide();
@@ -623,8 +626,10 @@ void MixxxMainWindow::slotUpdateWindowTitle(TrackPointer pTrack) {
 void MixxxMainWindow::createMenuBar() {
     ScopedTimer t("MixxxMainWindow::createMenuBar");
     DEBUG_ASSERT(m_pCoreServices->getKeyboardConfig());
-    m_pMenuBar = make_parented<WMainMenuBar>(
-            this, m_pCoreServices->getSettings(), m_pCoreServices->getKeyboardConfig().get());
+    m_pMenuBar = make_parented<WMainMenuBar>(this,
+            m_pCoreServices->getSettings(),
+            m_pCoreServices->getKeyboardConfig().get(),
+            m_pHelpViewer->hasLocalHelp());
     if (m_pCentralWidget) {
         m_pMenuBar->setStyleSheet(m_pCentralWidget->styleSheet());
     }
@@ -686,6 +691,12 @@ void MixxxMainWindow::connectMenuBar() {
             Qt::UniqueConnection);
 
     // Help
+    connect(m_pMenuBar,
+            &WMainMenuBar::showManual,
+            this,
+            &MixxxMainWindow::slotHelpShowManual,
+            Qt::UniqueConnection);
+
     connect(m_pMenuBar,
             &WMainMenuBar::showAbout,
             this,
@@ -971,6 +982,10 @@ void MixxxMainWindow::slotChangedPlayingDeck(int deck) {
             mixxx::ScreenSaverHelper::inhibit();
         }
     }
+}
+
+void MixxxMainWindow::slotHelpShowManual(const QString& documentPath) {
+    m_pHelpViewer->open(documentPath);
 }
 
 void MixxxMainWindow::slotHelpAbout() {

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -228,6 +228,10 @@ MixxxMainWindow::MixxxMainWindow(
             m_pCoreServices->getLibrary());
     m_pPrefDlg->setWindowIcon(QIcon(":/images/mixxx_icon.svg"));
     m_pPrefDlg->setHidden(true);
+    connect(m_pPrefDlg,
+            &DlgPreferences::showHelp,
+            this,
+            &MixxxMainWindow::slotHelpShowManual);
 
     // Connect signals to the menubar. Should be done before emit newSkinLoaded.
     connectMenuBar();

--- a/src/mixxx.h
+++ b/src/mixxx.h
@@ -39,11 +39,12 @@ class VinylControlManager;
 class VisualsManager;
 class WMainMenuBar;
 
-#ifdef __ENGINEPRIME__
 namespace mixxx {
+#ifdef __ENGINEPRIME__
 class LibraryExporter;
-} // namespace mixxx
 #endif
+class HelpViewer;
+} // namespace mixxx
 
 /// This Class is the base class for Mixxx.
 /// It sets up the main window providing a menubar.
@@ -72,6 +73,8 @@ class MixxxMainWindow : public QMainWindow {
     void slotFileLoadSongPlayer(int deck);
     /// show the preferences dialog
     void slotOptionsPreferences();
+    /// show the manual
+    void slotHelpShowManual(const QString& documentPath);
     /// show the about dialog
     void slotHelpAbout();
     // show keywheel
@@ -132,6 +135,7 @@ class MixxxMainWindow : public QMainWindow {
 
     parented_ptr<WMainMenuBar> m_pMenuBar;
 
+    mixxx::HelpViewer* m_pHelpViewer;
     DlgDeveloperTools* m_pDeveloperToolsDlg;
 
     DlgPreferences* m_pPrefDlg;

--- a/src/preferences/dialog/dlgprefbeats.cpp
+++ b/src/preferences/dialog/dlgprefbeats.cpp
@@ -52,8 +52,8 @@ DlgPrefBeats::DlgPrefBeats(QWidget* parent, UserSettingsPointer pConfig)
 DlgPrefBeats::~DlgPrefBeats() {
 }
 
-QUrl DlgPrefBeats::helpUrl() const {
-    return QUrl(MIXXX_MANUAL_BEATS_URL);
+QString DlgPrefBeats::helpDocument() const {
+    return QString(MIXXX_MANUAL_BEATS_PATH);
 }
 
 void DlgPrefBeats::loadSettings() {

--- a/src/preferences/dialog/dlgprefbeats.h
+++ b/src/preferences/dialog/dlgprefbeats.h
@@ -16,7 +16,7 @@ class DlgPrefBeats : public DlgPreferencePage, public Ui::DlgBeatsDlg {
     DlgPrefBeats(QWidget *parent, UserSettingsPointer _config);
     virtual ~DlgPrefBeats();
 
-    QUrl helpUrl() const override;
+    QString helpDocument() const override;
 
   public slots:
     // Apply changes to widget

--- a/src/preferences/dialog/dlgprefbroadcast.cpp
+++ b/src/preferences/dialog/dlgprefbroadcast.cpp
@@ -187,8 +187,8 @@ void DlgPrefBroadcast::slotUpdate() {
     btnDisconnectAll->setEnabled(enabled);
 }
 
-QUrl DlgPrefBroadcast::helpUrl() const {
-    return QUrl(MIXXX_MANUAL_BROADCAST_URL);
+QString DlgPrefBroadcast::helpDocument() const {
+    return QString(MIXXX_MANUAL_BROADCAST_PATH);
 }
 
 void DlgPrefBroadcast::applyModel() {

--- a/src/preferences/dialog/dlgprefbroadcast.h
+++ b/src/preferences/dialog/dlgprefbroadcast.h
@@ -20,7 +20,7 @@ class DlgPrefBroadcast : public DlgPreferencePage, public Ui::DlgPrefBroadcastDl
                      BroadcastSettingsPointer pBroadcastSettings);
     virtual ~DlgPrefBroadcast();
 
-    QUrl helpUrl() const override;
+    QString helpDocument() const override;
 
   public slots:
     /** Apply changes to widget */

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -304,8 +304,8 @@ void DlgPrefEQ::slotSingleEqChecked(int checked) {
     applySelections();
 }
 
-QUrl DlgPrefEQ::helpUrl() const {
-    return QUrl(MIXXX_MANUAL_EQ_URL);
+QString DlgPrefEQ::helpDocument() const {
+    return QString(MIXXX_MANUAL_EQ_PATH);
 }
 
 void DlgPrefEQ::loadSettings() {

--- a/src/preferences/dialog/dlgprefeq.h
+++ b/src/preferences/dialog/dlgprefeq.h
@@ -19,7 +19,7 @@ class DlgPrefEQ : public DlgPreferencePage, public Ui::DlgPrefEQDlg  {
             UserSettingsPointer _config);
     virtual ~DlgPrefEQ();
 
-    QUrl helpUrl() const override;
+    QString helpDocument() const override;
 
     QString getEQEffectGroupForDeck(int deck) const;
     QString getQuickEffectGroupForDeck(int deck) const;

--- a/src/preferences/dialog/dlgpreferencepage.cpp
+++ b/src/preferences/dialog/dlgpreferencepage.cpp
@@ -10,6 +10,6 @@ DlgPreferencePage::DlgPreferencePage(QWidget* pParent)
 DlgPreferencePage::~DlgPreferencePage() {
 }
 
-QUrl DlgPreferencePage::helpUrl() const {
-    return QUrl();
+QString DlgPreferencePage::helpDocument() const {
+    return QString();
 }

--- a/src/preferences/dialog/dlgpreferencepage.h
+++ b/src/preferences/dialog/dlgpreferencepage.h
@@ -21,6 +21,9 @@ class DlgPreferencePage : public QWidget {
 
     QColor m_pLinkColor;
 
+  signals:
+    void showHelp(const QString& documentPath);
+
   public slots:
     /// Called when the preference dialog is shown to the user (not necessarily
     /// when this PreferencePage is shown to the user). At this point, the

--- a/src/preferences/dialog/dlgpreferencepage.h
+++ b/src/preferences/dialog/dlgpreferencepage.h
@@ -14,10 +14,10 @@ class DlgPreferencePage : public QWidget {
     DlgPreferencePage(QWidget* pParent);
     virtual ~DlgPreferencePage();
 
-    /// Returns the help URL for the current page.
+    /// Returns the help document for the current page.
     /// Subclasses can provide a path to the appropriate manual page by
-    /// overriding this. The default implementation returns an invalid QUrl.
-    virtual QUrl helpUrl() const;
+    /// overriding this. The default implementation returns an empty QString.
+    virtual QString helpDocument() const;
 
     QColor m_pLinkColor;
 

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -429,6 +429,8 @@ void DlgPreferences::addPageWidget(PreferencesPage page,
             page.pDlg,
             &DlgPreferencePage::slotResetToDefaults);
 
+    connect(page.pDlg, &DlgPreferencePage::showHelp, this, &DlgPreferences::showHelp);
+
     // Add a new scroll area to the stacked pages widget containing the page
     QScrollArea* sa = new QScrollArea(pagesWidget);
     sa->setWidgetResizable(true);

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -401,9 +401,7 @@ void DlgPreferences::slotButtonPressed(QAbstractButton* pButton) {
             break;
         case QDialogButtonBox::HelpRole:
             if (pCurrentPage) {
-                QUrl helpUrl = pCurrentPage->helpUrl();
-                DEBUG_ASSERT(helpUrl.isValid());
-                QDesktopServices::openUrl(helpUrl);
+                emit showHelp(pCurrentPage->helpDocument());
             }
             break;
         default:
@@ -475,7 +473,7 @@ void DlgPreferences::switchToPage(DlgPreferencePage* pWidget) {
         return;
     }
 
-    if (pWidget->helpUrl().isValid()) {
+    if (!pWidget->helpDocument().isEmpty()) {
         pButton->show();
     } else {
         pButton->hide();

--- a/src/preferences/dialog/dlgpreferences.h
+++ b/src/preferences/dialog/dlgpreferences.h
@@ -91,6 +91,7 @@ class DlgPreferences : public QDialog, public Ui::DlgPreferencesDlg {
   signals:
     void closeDlg();
     void showDlg();
+    void showHelp(const QString& documentPath);
 
     // Emitted just after the user clicks Apply or OK.
     void applyPreferences();

--- a/src/preferences/dialog/dlgprefkey.cpp
+++ b/src/preferences/dialog/dlgprefkey.cpp
@@ -79,8 +79,8 @@ DlgPrefKey::DlgPrefKey(QWidget* parent, UserSettingsPointer pConfig)
 DlgPrefKey::~DlgPrefKey() {
 }
 
-QUrl DlgPrefKey::helpUrl() const {
-    return QUrl(MIXXX_MANUAL_KEY_URL);
+QString DlgPrefKey::helpDocument() const {
+    return QString(MIXXX_MANUAL_KEY_PATH);
 }
 
 void DlgPrefKey::loadSettings() {

--- a/src/preferences/dialog/dlgprefkey.h
+++ b/src/preferences/dialog/dlgprefkey.h
@@ -19,7 +19,7 @@ class DlgPrefKey : public DlgPreferencePage, Ui::DlgPrefKeyDlg {
     DlgPrefKey(QWidget *parent, UserSettingsPointer _config);
     virtual ~DlgPrefKey();
 
-    QUrl helpUrl() const override;
+    QString helpDocument() const override;
 
   public slots:
     // Apply changes to widget

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -147,8 +147,8 @@ void DlgPrefLibrary::slotHide() {
     }
 }
 
-QUrl DlgPrefLibrary::helpUrl() const {
-    return QUrl(MIXXX_MANUAL_LIBRARY_URL);
+QString DlgPrefLibrary::helpDocument() const {
+    return QString(MIXXX_MANUAL_LIBRARY_PATH);
 }
 
 void DlgPrefLibrary::initializeDirList() {

--- a/src/preferences/dialog/dlgpreflibrary.h
+++ b/src/preferences/dialog/dlgpreflibrary.h
@@ -27,7 +27,7 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
             std::shared_ptr<Library> pLibrary);
     ~DlgPrefLibrary() override {}
 
-    QUrl helpUrl() const override;
+    QString helpDocument() const override;
 
   public slots:
     // Common preference page slots.

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -330,8 +330,8 @@ void DlgPrefSound::slotApply() {
     m_bSkipConfigClear = false;
 }
 
-QUrl DlgPrefSound::helpUrl() const {
-    return QUrl(MIXXX_MANUAL_SOUND_URL);
+QString DlgPrefSound::helpDocument() const {
+    return QString(MIXXX_MANUAL_SOUND_PATH);
 }
 
 /**

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -34,7 +34,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
             UserSettingsPointer pSettings);
     virtual ~DlgPrefSound();
 
-    QUrl helpUrl() const override;
+    QString helpDocument() const override;
 
   signals:
     void loadPaths(const SoundManagerConfig &config);

--- a/src/preferences/dialog/dlgprefvinyl.cpp
+++ b/src/preferences/dialog/dlgprefvinyl.cpp
@@ -399,8 +399,8 @@ void DlgPrefVinyl::slotUpdateVinylGain() {
             QString("%1 dB").arg(value));
 }
 
-QUrl DlgPrefVinyl::helpUrl() const {
-    return QUrl(MIXXX_MANUAL_VINYL_URL);
+QString DlgPrefVinyl::helpDocument() const {
+    return QString(MIXXX_MANUAL_VINYL_PATH);
 }
 
 void DlgPrefVinyl::setDeckWidgetsVisible(int deck, bool visible) {

--- a/src/preferences/dialog/dlgprefvinyl.h
+++ b/src/preferences/dialog/dlgprefvinyl.h
@@ -21,7 +21,7 @@ class DlgPrefVinyl : public DlgPreferencePage, Ui::DlgPrefVinylDlg  {
             UserSettingsPointer _config);
     virtual ~DlgPrefVinyl();
 
-    QUrl helpUrl() const override;
+    QString helpDocument() const override;
 
   public slots:
     void slotUpdate() override;

--- a/src/widget/helpbrowser.cpp
+++ b/src/widget/helpbrowser.cpp
@@ -1,0 +1,74 @@
+#include "widget/helpbrowser.h"
+
+#include <QDesktopServices>
+#include <QHelpEngine>
+#include <QMenu>
+
+#include "defs_urls.h"
+
+namespace {
+
+const QString kHelpUrlScheme = QStringLiteral("qthelp");
+
+} // anonymous namespace
+
+namespace mixxx {
+
+HelpBrowser::HelpBrowser(QHelpEngine* pHelpEngine, QWidget* parent)
+        : QTextBrowser(parent),
+          m_pHelpEngine(pHelpEngine) {
+    // Add custom link handling
+    setOpenLinks(false);
+    connect(this,
+            &QTextBrowser::anchorClicked,
+            this,
+            &HelpBrowser::slotAnchorClicked);
+
+    // Add custom context menu
+    setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(this,
+            &QTextBrowser::customContextMenuRequested,
+            this,
+            &HelpBrowser::slotCustomContextMenu);
+}
+
+QVariant HelpBrowser::loadResource(int type, const QUrl& name) {
+    if (name.scheme() == kHelpUrlScheme) {
+        return QVariant(m_pHelpEngine->fileData(name));
+    }
+
+    return QTextBrowser::loadResource(type, name);
+}
+
+void HelpBrowser::slotAnchorClicked(const QUrl& link) {
+    if (link.scheme() == kHelpUrlScheme) {
+        setSource(link);
+        return;
+    }
+
+    // Load external links in Webbrowser
+    QDesktopServices::openUrl(link);
+}
+
+void HelpBrowser::slotCustomContextMenu(const QPoint& pos) {
+    QMenu* menu = createStandardContextMenu();
+
+    // Add "Open in Browser" action
+    QUrl helpUrl = source();
+    if (helpUrl.scheme() == kHelpUrlScheme && helpUrl.path().startsWith("/doc/")) {
+        QUrl webUrl(MIXXX_MANUAL_URL + helpUrl.path(QUrl::FullyEncoded).mid(4));
+        if (helpUrl.hasQuery()) {
+            webUrl.setQuery(helpUrl.query());
+        }
+        if (helpUrl.hasFragment()) {
+            webUrl.setFragment(helpUrl.fragment());
+        }
+        menu->addSeparator();
+        menu->addAction(tr("Open in Browser"), [webUrl]() {
+            QDesktopServices::openUrl(webUrl);
+        });
+    }
+    menu->exec(mapToGlobal(pos));
+}
+
+} // namespace mixxx

--- a/src/widget/helpbrowser.h
+++ b/src/widget/helpbrowser.h
@@ -1,0 +1,27 @@
+#include <QPoint>
+#include <QTextBrowser>
+#include <QUrl>
+#include <QVariant>
+
+// forward declarations
+QT_FORWARD_DECLARE_CLASS(QHelpEngine);
+QT_FORWARD_DECLARE_CLASS(QWidget);
+
+namespace mixxx {
+
+/// This is the HTML renderer that shows Qt Help files and supports
+/// loading `qthelp://` URLs and has a custom context menu.
+class HelpBrowser : public QTextBrowser {
+  public:
+    HelpBrowser(QHelpEngine* pHelpEngine, QWidget* parent = nullptr);
+    QVariant loadResource(int type, const QUrl& name);
+
+  private slots:
+    void slotAnchorClicked(const QUrl& link);
+    void slotCustomContextMenu(const QPoint& pos);
+
+  private:
+    QHelpEngine* m_pHelpEngine;
+};
+
+} // namespace mixxx

--- a/src/widget/helpviewer.cpp
+++ b/src/widget/helpviewer.cpp
@@ -1,0 +1,229 @@
+#include "widget/helpviewer.h"
+
+#include <QAction>
+#include <QDesktopServices>
+#include <QDir>
+#include <QHBoxLayout>
+#include <QHelpContentWidget>
+#include <QHelpEngine>
+#include <QHelpIndexWidget>
+#include <QHelpSearchEngine>
+#include <QHelpSearchQueryWidget>
+#include <QHelpSearchResultWidget>
+#include <QRegExp>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+#include <QHelpLink>
+#endif
+#include <QSplitter>
+#include <QTabWidget>
+#include <QToolBar>
+
+#include "defs_urls.h"
+#include "util/assert.h"
+#include "widget/helpbrowser.h"
+
+namespace {
+const QRegExp kSlugifyRegExp("[\\W+]");
+const QString kSlugifyReplacement = QStringLiteral("-");
+const QString kIndexDocument = QStringLiteral(MIXXX_MANUAL_INDEX_PATH);
+
+QFileInfo getHelpPath(const UserSettingsPointer& pConfig) {
+    QDir helpPath(pConfig->getResourcePath());
+    if (helpPath.cd("help")) {
+        QFileInfo fileInfo(helpPath, QStringLiteral("mixxx-manual.qhc"));
+        if (fileInfo.exists()) {
+            return fileInfo;
+        }
+    }
+    return QFileInfo();
+}
+
+QUrl toLocalizedUrl(const QUrl& url, const QString& language) {
+    DEBUG_ASSERT(url.isValid());
+    DEBUG_ASSERT(!language.isEmpty());
+    QUrl localizedUrl = url;
+    QString path = url.path();
+    path.replace(QStringLiteral(".html"), QStringLiteral(".") + language + QStringLiteral(".html"));
+    localizedUrl.setPath(path);
+    return localizedUrl;
+}
+
+} // namespace
+
+namespace mixxx {
+
+HelpViewer::HelpViewer(const UserSettingsPointer& pConfig, QWidget* parent)
+        : QWidget(parent),
+          m_pHelpEngine(nullptr) {
+    QFileInfo helpPath = getHelpPath(pConfig);
+    if (!helpPath.isFile()) {
+        return;
+    }
+
+    QHelpEngine* pHelpEngine = new QHelpEngine(helpPath.filePath());
+    if (!pHelpEngine) {
+        return;
+    }
+
+    if (!pHelpEngine->setupData()) {
+        delete pHelpEngine;
+        return;
+    }
+
+    QString namespaceName(pHelpEngine->namespaceName(helpPath.filePath()));
+    if (namespaceName.isEmpty()) {
+        delete pHelpEngine;
+        return;
+    }
+    const QStringList customFilters = pHelpEngine->customFilters();
+    if (!customFilters.contains(QStringLiteral("en"))) {
+        delete pHelpEngine;
+        return;
+    }
+
+    m_pHelpEngine = pHelpEngine;
+    m_pHelpEngine->searchEngine()->reindexDocumentation();
+    m_pHelpEngine->setAutoSaveFilter(false);
+    m_documentUrlPrefix = QStringLiteral("qthelp://") + namespaceName + QStringLiteral("/doc");
+
+    m_language = QStringLiteral("en");
+    {
+        const QStringList customFilters = m_pHelpEngine->customFilters();
+        QLocale locale;
+        QList<QString> languages;
+        for (const QString& language : locale.uiLanguages()) {
+            if (customFilters.contains(language)) {
+                m_language = language;
+                break;
+            }
+        }
+    }
+    m_pHelpEngine->setCurrentFilter(m_language);
+
+    QVBoxLayout* pSidebarLayout = new QVBoxLayout(this);
+    pSidebarLayout->addWidget(m_pHelpEngine->searchEngine()->queryWidget());
+
+    m_pTabWidget = new QTabWidget(this);
+    m_pTabWidget->addTab(m_pHelpEngine->contentWidget(), tr("Contents"));
+    m_pTabWidget->addTab(m_pHelpEngine->indexWidget(), tr("Index"));
+    m_pTabWidget->addTab(m_pHelpEngine->searchEngine()->resultWidget(), tr("Search"));
+    pSidebarLayout->addWidget(m_pTabWidget);
+
+    QWidget* pSidebarWidget = new QWidget(this);
+    pSidebarWidget->setLayout(pSidebarLayout);
+
+    m_pHelpBrowser = new HelpBrowser(m_pHelpEngine, this);
+
+    QToolBar* pToolBar = new QToolBar(this);
+    pToolBar->addAction(QIcon::fromTheme("go-home"), tr("Main Page"), [this] {
+        openDocument(kIndexDocument);
+    });
+    QAction* pBackwardAction = pToolBar->addAction(
+            QIcon::fromTheme("go-previous"), tr("Back"), [this] {
+                m_pHelpBrowser->backward();
+            });
+    connect(m_pHelpBrowser, &HelpBrowser::backwardAvailable, [pBackwardAction](bool available) {
+        pBackwardAction->setEnabled(available);
+    });
+    QAction* pForwardAction = pToolBar->addAction(QIcon::fromTheme("go-next"),
+            tr("Forward"),
+            [this] { m_pHelpBrowser->forward(); });
+    connect(m_pHelpBrowser, &HelpBrowser::forwardAvailable, [pForwardAction](bool available) {
+        pForwardAction->setEnabled(available);
+    });
+
+    QVBoxLayout* pBrowserLayout = new QVBoxLayout(this);
+    pBrowserLayout->addWidget(pToolBar);
+    pBrowserLayout->addWidget(m_pHelpBrowser);
+
+    QWidget* pBrowserWidget = new QWidget(this);
+    pBrowserWidget->setLayout(pBrowserLayout);
+
+    QSplitter* pSplitter = new QSplitter(Qt::Horizontal);
+    pSplitter->insertWidget(0, pSidebarWidget);
+    pSplitter->insertWidget(1, pBrowserWidget);
+
+    QHBoxLayout* pLayout = new QHBoxLayout();
+    pLayout->addWidget(pSplitter);
+    setLayout(pLayout);
+    setWindowFlags(Qt::Window);
+
+    connect(m_pHelpEngine->searchEngine(),
+            &QHelpSearchEngine::searchingFinished,
+            [this](int searchResultCount) {
+                Q_UNUSED(searchResultCount);
+                m_pTabWidget->setCurrentWidget(m_pHelpEngine->searchEngine()->resultWidget());
+            });
+    connect(m_pHelpEngine->searchEngine()->queryWidget(),
+            &QHelpSearchQueryWidget::search,
+            [this] {
+                m_pHelpEngine->searchEngine()->search(
+                        m_pHelpEngine->searchEngine()
+                                ->queryWidget()
+                                ->searchInput());
+            });
+    connect(m_pHelpEngine->searchEngine()->resultWidget(),
+            &QHelpSearchResultWidget::requestShowLink,
+            [this](const QUrl& url) { m_pHelpBrowser->setSource(url); });
+
+    connect(m_pHelpEngine->contentWidget(),
+            &QHelpContentWidget::linkActivated,
+            [this](const QUrl& url) { m_pHelpBrowser->setSource(url); });
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    // FIXME: This is a very ugly hack that works around the non-working
+    // documentActivated/documentsActivate signals. See QTBUG-84727.
+    connect(m_pHelpEngine->indexWidget(),
+            &QHelpIndexWidget::activated,
+            [this](const QModelIndex& index) {
+                QString keyword = m_pHelpEngine->indexModel()->data(index).toString();
+                m_pHelpBrowser->setSource(QUrl(m_documentUrlPrefix +
+                        QStringLiteral("/glossary.") + m_language + QStringLiteral(".html#term-") +
+                        keyword.replace(kSlugifyRegExp, kSlugifyReplacement)));
+            });
+    // connect(m_pHelpEngine->indexWidget(),
+    //         &QHelpIndexWidget::documentActivated,
+    //         [this](const QHelpLink& document, const QString& keyword) {
+    //             Q_UNUSED(keyword);
+    //             m_pHelpBrowser->setSource(document.url);
+    //         });
+    // connect(m_pHelpEngine->indexWidget(),
+    //         &QHelpIndexWidget::documentsActivated,
+    //         [this](const QList<QHelpLink>& documents, const QString& keyword) {
+    //             Q_UNUSED(keyword);
+    //             if (documents.isEmpty()) {
+    //                 return;
+    //             }
+    //             m_pHelpBrowser->setSource(documents.first().url);
+    //         });
+#else
+    connect(m_pHelpEngine->indexWidget(),
+            &QHelpIndexWidget::linkActivated,
+            [this](const QUrl& url, QString) { m_pHelpBrowser->setSource(url); });
+#endif
+
+    openDocument(kIndexDocument);
+}
+
+void HelpViewer::openDocument(const QString& documentPath) {
+    const QUrl url = toLocalizedUrl(QUrl(m_documentUrlPrefix + documentPath), m_language);
+    m_pHelpBrowser->setSource(url);
+}
+
+void HelpViewer::open(const QString& documentPath) {
+    if (m_pHelpEngine) {
+        if (!documentPath.isEmpty()) {
+            openDocument(documentPath);
+        }
+        show();
+        return;
+    }
+
+    if (documentPath.isEmpty()) {
+        QDesktopServices::openUrl(QUrl(QString(MIXXX_MANUAL_URL)));
+    } else {
+        QDesktopServices::openUrl(QUrl(QString(MIXXX_MANUAL_URL) + documentPath));
+    }
+}
+
+} // namespace mixxx

--- a/src/widget/helpviewer.h
+++ b/src/widget/helpviewer.h
@@ -1,0 +1,41 @@
+#include <QFileInfo>
+#include <QString>
+#include <QWidget>
+
+#include "preferences/usersettings.h"
+
+// forward declarations
+QT_FORWARD_DECLARE_CLASS(QHelpEngine);
+QT_FORWARD_DECLARE_CLASS(QTabWidget);
+
+namespace mixxx {
+
+class HelpBrowser;
+
+/// The help viewer class represents the whole help window, consisting of a
+/// tabbed sidebar (content/index/search) and the HelpBrowser (i.e. the HTML
+/// renderer).
+class HelpViewer : public QWidget {
+  public:
+    explicit HelpViewer(const UserSettingsPointer& helpFile, QWidget* parent = nullptr);
+
+    void open(const QString& documentPath);
+
+    /// Returns true if local help is available. Needed to add a web suffix on
+    /// the menubar if local help is not available.
+    bool hasLocalHelp() {
+        return m_pHelpEngine != nullptr;
+    }
+
+  private:
+    void openDocument(const QString& documentPath);
+
+    QHelpEngine* m_pHelpEngine;
+    HelpBrowser* m_pHelpBrowser;
+    QTabWidget* m_pTabWidget;
+
+    QString m_documentUrlPrefix;
+    QString m_language;
+};
+
+} // namespace mixxx

--- a/src/widget/wmainmenubar.h
+++ b/src/widget/wmainmenubar.h
@@ -33,8 +33,10 @@ class VisibilityControlConnection : public QObject {
 class WMainMenuBar : public QMenuBar {
     Q_OBJECT
   public:
-    WMainMenuBar(QWidget* pParent, UserSettingsPointer pConfig,
-                 ConfigObject<ConfigValueKbd>* pKbdConfig);
+    WMainMenuBar(QWidget* pParent,
+            UserSettingsPointer pConfig,
+            ConfigObject<ConfigValueKbd>* pKbdConfig,
+            bool hasLocalHelp);
 
   public slots:
     void onLibraryScanStarted();
@@ -61,6 +63,7 @@ class WMainMenuBar : public QMenuBar {
 #endif
     void showAbout();
     void showKeywheel(bool visible);
+    void showManual(const QString& documentPath);
     void showPreferences();
     void toggleDeveloperTools(bool toggle);
     void toggleFullScreen(bool toggle);
@@ -87,7 +90,7 @@ class WMainMenuBar : public QMenuBar {
     void slotVisitUrl(const QString& url);
 
   private:
-    void initialize();
+    void initialize(bool hasLocalHelp);
     void createVisibilityControl(QAction* pAction, const ConfigKey& key);
 
     UserSettingsPointer m_pConfig;


### PR DESCRIPTION
This allows reading the manual inside Mixxx instead of opening webbrowser (which requires an internet connection) or opening a PDF reader. If the help files are missing, Mixxx will fall back to open the requested manual page in a webbrowser.