### PR TITLE
Tracks table selection fix for [Library],MoveVertical controls

### DIFF
--- a/src/widget/wlibrarytableview.cpp
+++ b/src/widget/wlibrarytableview.cpp
@@ -148,3 +148,18 @@ void WLibraryTableView::setSelectedClick(bool enable) {
         setEditTriggers(QAbstractItemView::EditKeyPressed);
     }
 }
+
+bool WLibraryTableView::event(QEvent* e) {
+    // On FocusIn, with no focused item, select the first track which can then
+    // instantly be loaded to a deck.
+    // This is especially helpful if the table has only one track, which can not
+    // be selected with up/down buttons, either physical or emulated via
+    // [Library],MoveVertical controls. See lp:1808632
+    if (e->type() == QEvent::FocusIn &&
+            model()->rowCount() > 0 &&
+            currentIndex().row() == -1) {
+        selectRow(0);
+    }
+
+    return QTableView::event(e);
+}

--- a/src/widget/wlibrarytableview.h
+++ b/src/widget/wlibrarytableview.h
@@ -58,6 +58,7 @@ class WLibraryTableView : public QTableView, public virtual LibraryView {
   private:
     void loadVScrollBarPosState();
     void saveVScrollBarPosState();
+    bool event(QEvent* e);
 
     const UserSettingsPointer m_pConfig;
     const ConfigKey m_vScrollBarPosKey;


### PR DESCRIPTION
Aims to fix [lp:1808632](https://bugs.launchpad.net/mixxx/+bug/1808632) "controllers can't focus tracks table item if there is only one" with `[Library],MoveVertical` and related controls.
Also, one doesn't have to move down & up again with keyboard/controller to select the top-most track.

This is just a quick attempt after some discussion on [Zulip](https://mixxx.zulipchat.com/#narrow/stream/113295-controller-mapping/topic/Library.3A.20Track.20Selection.20on.20MC7000.20-.20Bug.201893131).
~~WIP until we figure it works and/or find & fix more related issues with table selection.~~

Related: #2378 
Complementary for [Playlist],.. controls: #3063 