### PR TITLE
pre-commit: Do not exclude cpp files from end-of-file-fixer hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,6 @@ repos:
   - id: check-xml
   - id: check-yaml
   - id: end-of-file-fixer
-    exclude: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|mm|proto|vert)$
     stages:
     - commit
     - manual


### PR DESCRIPTION
I see a lot of missing newlines at EOF recently. I probably though clang-format would fix that automatically but apparently it doesn't.