### PR TITLE
SoundSource: Dynamically determine audio decoder for fixing timing offsets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -705,6 +705,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/sources/soundsource.cpp
   src/sources/soundsourceflac.cpp
   src/sources/soundsourceoggvorbis.cpp
+  src/sources/soundsourceprovider.cpp
   src/sources/soundsourceproviderregistry.cpp
   src/sources/soundsourceproxy.cpp
   src/sources/soundsourcesndfile.cpp

--- a/build/depends.py
+++ b/build/depends.py
@@ -950,6 +950,7 @@ class MixxxCore(Feature):
                    "src/sources/metadatasourcetaglib.cpp",
                    "src/sources/readaheadframebuffer.cpp",
                    "src/sources/soundsource.cpp",
+                   "src/sources/soundsourceprovider.cpp",
                    "src/sources/soundsourceproviderregistry.cpp",
                    "src/sources/soundsourceproxy.cpp",
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -108,7 +108,7 @@ int main(int argc, char * argv[]) {
 
     MixxxApplication app(argc, argv);
 
-    VERIFY_OR_DEBUG_ASSERT(SoundSourceProxy::registerSoundSourceProviders()) {
+    VERIFY_OR_DEBUG_ASSERT(SoundSourceProxy::registerProviders()) {
         qCritical() << "Failed to register any SoundSource providers";
         return kFatalErrorOnStartupExitCode;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -105,7 +105,10 @@ int main(int argc, char * argv[]) {
 
     MixxxApplication app(argc, argv);
 
-    SoundSourceProxy::registerSoundSourceProviders();
+    VERIFY_OR_DEBUG_ASSERT(SoundSourceProxy::registerSoundSourceProviders()) {
+        qCritical() << "Failed to register any SoundSource providers";
+        return -1;
+    }
 
 #ifdef __APPLE__
     QDir dir(QApplication::applicationDirPath());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,21 +38,24 @@
 
 namespace {
 
+// Exit codes
+constexpr int kFatalErrorOnStartupExitCode = 1;
+constexpr int kParseCmdlineArgsErrorExitCode = 2;
+
 int runMixxx(MixxxApplication* app, const CmdlineArgs& args) {
-    int result = -1;
     MixxxMainWindow mainWindow(app, args);
     // If startup produced a fatal error, then don't even start the
     // Qt event loop.
     if (ErrorDialogHandler::instance()->checkError()) {
         mainWindow.finalize();
+        return kFatalErrorOnStartupExitCode;
     } else {
         qDebug() << "Displaying main window";
         mainWindow.show();
 
         qDebug() << "Running Mixxx";
-        result = app->exec();
+        return app->exec();
     }
-    return result;
 }
 
 } // anonymous namespace
@@ -86,7 +89,7 @@ int main(int argc, char * argv[]) {
     CmdlineArgs& args = CmdlineArgs::Instance();
     if (!args.Parse(argc, argv)) {
         args.printUsage();
-        return 0;
+        return kParseCmdlineArgsErrorExitCode;
     }
 
     // If you change this here, you also need to change it in
@@ -107,7 +110,7 @@ int main(int argc, char * argv[]) {
 
     VERIFY_OR_DEBUG_ASSERT(SoundSourceProxy::registerSoundSourceProviders()) {
         qCritical() << "Failed to register any SoundSource providers";
-        return -1;
+        return kFatalErrorOnStartupExitCode;
     }
 
 #ifdef __APPLE__
@@ -130,11 +133,11 @@ int main(int argc, char * argv[]) {
     // When the last window is closed, terminate the Qt event loop.
     QObject::connect(&app, &MixxxApplication::lastWindowClosed, &app, &MixxxApplication::quit);
 
-    int result = runMixxx(&app, args);
+    int exitCode = runMixxx(&app, args);
 
-    qDebug() << "Mixxx shutdown complete with code" << result;
+    qDebug() << "Mixxx shutdown complete with code" << exitCode;
 
     mixxx::Logging::shutdown();
 
-    return result;
+    return exitCode;
 }

--- a/src/sources/soundsourcecoreaudio.cpp
+++ b/src/sources/soundsourcecoreaudio.cpp
@@ -11,8 +11,19 @@ namespace {
 
 const Logger kLogger("SoundSourceCoreAudio");
 
+const QString kDisplayName = QStringLiteral("Apple Core Audio");
+
+const QStringList kSupportedFileExtensions = {
+        QStringLiteral("m4a"),
+        QStringLiteral("mp4"),
+        QStringLiteral("mp3"),
+        QStringLiteral("mp2"),
+        // Can add mp3, mp2, ac3, and others here if you want:
+        // http://developer.apple.com/library/mac/documentation/MusicAudio/Reference/AudioFileConvertRef/Reference/reference.html#//apple_ref/doc/c_ref/AudioFileTypeID
+};
+
 // The maximum number of samples per MP3 frame
-const SINT kMp3MaxFrameSize = 1152;
+constexpr SINT kMp3MaxFrameSize = 1152;
 
 // NOTE(rryan): For every MP3 seek we jump back kMp3MaxSeekPrefetchFrames frames from
 // the seek position and read forward to allow the decoder to stabilize. The
@@ -21,7 +32,7 @@ const SINT kMp3MaxFrameSize = 1152;
 // appropriate amount to pre-fetch from the ExtAudioFile API. Oddly, the "prime"
 // information -- which AIUI is supposed to tell us this information -- is zero
 // for this file. We use the same frame pre-fetch count from SoundSourceMp3.
-const SINT kMp3MaxSeekPrefetchFrames =
+constexpr SINT kMp3MaxSeekPrefetchFrames =
         kMp3SeekFramePrefetchCount * kMp3MaxFrameSize;
 
 } // namespace
@@ -267,18 +278,11 @@ SINT SoundSourceCoreAudio::readSampleFrames(
 }
 
 QString SoundSourceProviderCoreAudio::getName() const {
-    return "Apple Core Audio";
+    return kDisplayName;
 }
 
 QStringList SoundSourceProviderCoreAudio::getSupportedFileExtensions() const {
-    QStringList supportedFileExtensions;
-    supportedFileExtensions.append("m4a");
-    supportedFileExtensions.append("mp4");
-    supportedFileExtensions.append("mp3");
-    supportedFileExtensions.append("mp2");
-    // Can add mp3, mp2, ac3, and others here if you want:
-    // http://developer.apple.com/library/mac/documentation/MusicAudio/Reference/AudioFileConvertRef/Reference/reference.html#//apple_ref/doc/c_ref/AudioFileTypeID
-    return supportedFileExtensions;
+    return kSupportedFileExtensions;
 }
 
 SoundSourceProviderPriority SoundSourceProviderCoreAudio::getPriorityHint(

--- a/src/sources/soundsourcecoreaudio.cpp
+++ b/src/sources/soundsourcecoreaudio.cpp
@@ -11,15 +11,6 @@ namespace {
 
 const Logger kLogger("SoundSourceCoreAudio");
 
-const QStringList kSupportedFileExtensions = {
-        QStringLiteral("m4a"),
-        QStringLiteral("mp4"),
-        QStringLiteral("mp3"),
-        QStringLiteral("mp2"),
-        // Can add mp3, mp2, ac3, and others here if you want:
-        // http://developer.apple.com/library/mac/documentation/MusicAudio/Reference/AudioFileConvertRef/Reference/reference.html#//apple_ref/doc/c_ref/AudioFileTypeID
-};
-
 // The maximum number of samples per MP3 frame
 constexpr SINT kMp3MaxFrameSize = 1152;
 
@@ -38,9 +29,15 @@ constexpr SINT kMp3MaxSeekPrefetchFrames =
 //static
 const QString SoundSourceProviderCoreAudio::kDisplayName = QStringLiteral("Apple Core Audio");
 
-QStringList SoundSourceProviderCoreAudio::getSupportedFileExtensions() const {
-    return kSupportedFileExtensions;
-}
+//static
+const QStringList SoundSourceProviderCoreAudio::kSupportedFileExtensions = {
+        QStringLiteral("m4a"),
+        QStringLiteral("mp4"),
+        QStringLiteral("mp3"),
+        QStringLiteral("mp2"),
+        // Can add mp3, mp2, ac3, and others here if you want:
+        // http://developer.apple.com/library/mac/documentation/MusicAudio/Reference/AudioFileConvertRef/Reference/reference.html#//apple_ref/doc/c_ref/AudioFileTypeID
+};
 
 SoundSourceProviderPriority SoundSourceProviderCoreAudio::getPriorityHint(
         const QString& supportedFileExtension) const {

--- a/src/sources/soundsourcecoreaudio.cpp
+++ b/src/sources/soundsourcecoreaudio.cpp
@@ -11,8 +11,6 @@ namespace {
 
 const Logger kLogger("SoundSourceCoreAudio");
 
-const QString kDisplayName = QStringLiteral("Apple Core Audio");
-
 const QStringList kSupportedFileExtensions = {
         QStringLiteral("m4a"),
         QStringLiteral("mp4"),
@@ -36,6 +34,21 @@ constexpr SINT kMp3MaxSeekPrefetchFrames =
         kMp3SeekFramePrefetchCount * kMp3MaxFrameSize;
 
 } // namespace
+
+//static
+const QString SoundSourceProviderCoreAudio::kDisplayName = QStringLiteral("Apple Core Audio");
+
+QStringList SoundSourceProviderCoreAudio::getSupportedFileExtensions() const {
+    return kSupportedFileExtensions;
+}
+
+SoundSourceProviderPriority SoundSourceProviderCoreAudio::getPriorityHint(
+        const QString& supportedFileExtension) const {
+    Q_UNUSED(supportedFileExtension)
+    // On macOS SoundSourceCoreAudio is the preferred decoder for all
+    // supported audio formats.
+    return SoundSourceProviderPriority::Higher;
+}
 
 SoundSourceCoreAudio::SoundSourceCoreAudio(QUrl url)
         : SoundSource(url),
@@ -275,22 +288,6 @@ SINT SoundSourceCoreAudio::readSampleFrames(
         numFramesRead += numFramesToReadInOut;
     }
     return numFramesRead;
-}
-
-QString SoundSourceProviderCoreAudio::getName() const {
-    return kDisplayName;
-}
-
-QStringList SoundSourceProviderCoreAudio::getSupportedFileExtensions() const {
-    return kSupportedFileExtensions;
-}
-
-SoundSourceProviderPriority SoundSourceProviderCoreAudio::getPriorityHint(
-        const QString& supportedFileExtension) const {
-    Q_UNUSED(supportedFileExtension)
-    // On macOS SoundSourceCoreAudio is the preferred decoder for all
-    // supported audio formats.
-    return SoundSourceProviderPriority::HIGHER;
 }
 
 } // namespace mixxx

--- a/src/sources/soundsourcecoreaudio.cpp
+++ b/src/sources/soundsourcecoreaudio.cpp
@@ -273,6 +273,7 @@ QString SoundSourceProviderCoreAudio::getName() const {
 QStringList SoundSourceProviderCoreAudio::getSupportedFileExtensions() const {
     QStringList supportedFileExtensions;
     supportedFileExtensions.append("m4a");
+    supportedFileExtensions.append("mp4");
     supportedFileExtensions.append("mp3");
     supportedFileExtensions.append("mp2");
     // Can add mp3, mp2, ac3, and others here if you want:
@@ -281,11 +282,10 @@ QStringList SoundSourceProviderCoreAudio::getSupportedFileExtensions() const {
 }
 
 SoundSourceProviderPriority SoundSourceProviderCoreAudio::getPriorityHint(
-        const QString& /*supportedFileExtension*/) const {
-    // On macOS CoreAudio is used both for decoding MP3 and M4A files. Neither
-    // FFmpeg nor libMAD are enabled in the release builds. In order to avoid
-    // priority conflicts with libMAD when enabled in the future the priority
-    // of this SoundSource is set to HIGHER.
+        const QString& supportedFileExtension) const {
+    Q_UNUSED(supportedFileExtension)
+    // On macOS SoundSourceCoreAudio is the preferred decoder for all
+    // supported audio formats.
     return SoundSourceProviderPriority::HIGHER;
 }
 

--- a/src/sources/soundsourcecoreaudio.h
+++ b/src/sources/soundsourcecoreaudio.h
@@ -55,12 +55,15 @@ class SoundSourceCoreAudio
 class SoundSourceProviderCoreAudio : public SoundSourceProvider {
   public:
     static const QString kDisplayName;
+    static const QStringList kSupportedFileExtensions;
 
     QString getDisplayName() const override {
         return kDisplayName;
     }
 
-    QStringList getSupportedFileExtensions() const override;
+    QStringList getSupportedFileExtensions() const override {
+        return kSupportedFileExtensions;
+    }
 
     SoundSourceProviderPriority getPriorityHint(
             const QString& supportedFileExtension) const override;

--- a/src/sources/soundsourcecoreaudio.h
+++ b/src/sources/soundsourcecoreaudio.h
@@ -23,7 +23,10 @@
 
 namespace mixxx {
 
-class SoundSourceCoreAudio : public SoundSource, public virtual /*implements*/ LegacyAudioSource, public LegacyAudioSourceAdapter {
+class SoundSourceCoreAudio
+        : public SoundSource,
+          public virtual /*implements*/ LegacyAudioSource,
+          public LegacyAudioSourceAdapter {
   public:
     explicit SoundSourceCoreAudio(QUrl url);
     ~SoundSourceCoreAudio() override;
@@ -51,7 +54,11 @@ class SoundSourceCoreAudio : public SoundSource, public virtual /*implements*/ L
 
 class SoundSourceProviderCoreAudio : public SoundSourceProvider {
   public:
-    QString getName() const override;
+    static const QString kDisplayName;
+
+    QString getDisplayName() const override {
+        return kDisplayName;
+    }
 
     QStringList getSupportedFileExtensions() const override;
 

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -13,6 +13,8 @@ namespace mixxx {
 
 namespace {
 
+const QString kDisplayName = QStringLiteral("FFmpeg");
+
 // FFmpeg constants
 
 constexpr AVSampleFormat kavSampleFormat = AV_SAMPLE_FMT_FLT;
@@ -1204,7 +1206,7 @@ ReadableSampleFrames SoundSourceFFmpeg::readSampleFramesClamped(
 }
 
 QString SoundSourceProviderFFmpeg::getName() const {
-    return "FFmpeg";
+    return kDisplayName;
 }
 
 SoundSourceProviderPriority SoundSourceProviderFFmpeg::getPriorityHint(

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -13,8 +13,6 @@ namespace mixxx {
 
 namespace {
 
-const QString kDisplayName = QStringLiteral("FFmpeg");
-
 // FFmpeg constants
 
 constexpr AVSampleFormat kavSampleFormat = AV_SAMPLE_FMT_FLT;
@@ -339,6 +337,8 @@ void SoundSourceFFmpeg::SwrContextPtr::close() {
     }
 }
 
+const QString SoundSourceProviderFFmpeg::kDisplayName = QStringLiteral("FFmpeg");
+
 SoundSourceProviderFFmpeg::SoundSourceProviderFFmpeg() {
     std::call_once(initFFmpegLibFlag, initFFmpegLib);
 }
@@ -449,6 +449,16 @@ QStringList SoundSourceProviderFFmpeg::getSupportedFileExtensions() const {
     }
 
     return list;
+}
+
+SoundSourceProviderPriority SoundSourceProviderFFmpeg::getPriorityHint(
+        const QString& supportedFileExtension) const {
+    Q_UNUSED(supportedFileExtension)
+    // TODO: Increase priority to Default or even Higher for all
+    // supported and tested file extension?
+    // Currently it is only used as a fallback after all other
+    // SoundSources failed to open a file or are otherwise unavailable.
+    return SoundSourceProviderPriority::Lowest;
 }
 
 SoundSourceFFmpeg::SoundSourceFFmpeg(const QUrl& url)
@@ -1203,19 +1213,6 @@ ReadableSampleFrames SoundSourceFFmpeg::readSampleFramesClamped(
             SampleBuffer::ReadableSlice(
                     readableData,
                     getSignalInfo().frames2samples(readableRange.length())));
-}
-
-QString SoundSourceProviderFFmpeg::getName() const {
-    return kDisplayName;
-}
-
-SoundSourceProviderPriority SoundSourceProviderFFmpeg::getPriorityHint(
-        const QString& /*supportedFileExtension*/) const {
-    // TODO: Increase priority to HIGHER if FFmpeg should be used as the
-    // default decoder instead of other SoundSources?
-    // Currently it is only used as a fallback after all other SoundSources
-    // failed to open a file or are otherwise unavailable.
-    return SoundSourceProviderPriority::LOWEST;
 }
 
 } // namespace mixxx

--- a/src/sources/soundsourceffmpeg.h
+++ b/src/sources/soundsourceffmpeg.h
@@ -188,14 +188,18 @@ class SoundSourceFFmpeg : public SoundSource {
 
 class SoundSourceProviderFFmpeg : public SoundSourceProvider {
   public:
+    static const QString kDisplayName;
+
     SoundSourceProviderFFmpeg();
 
-    QString getName() const override;
+    QString getDisplayName() const override {
+        return kDisplayName;
+    }
+
+    QStringList getSupportedFileExtensions() const override;
 
     SoundSourceProviderPriority getPriorityHint(
             const QString& supportedFileExtension) const override;
-
-    QStringList getSupportedFileExtensions() const override;
 
     SoundSourcePointer newSoundSource(const QUrl& url) override {
         return newSoundSourceFromUrl<SoundSourceFFmpeg>(url);

--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -10,10 +10,16 @@ namespace {
 
 const Logger kLogger("SoundSourceFLAC");
 
+const QString kDisplayName = QStringLiteral("Xiph.org libFLAC");
+
+const QStringList kSupportedFileExtensions = {
+        QStringLiteral("flac"),
+};
+
 // The maximum number of retries to fix seek errors. On a seek error
 // the next seek will start one (or more) sample blocks before the
 // position of the preceding seek operation that has failed.
-const int kSeekErrorMaxRetryCount = 3;
+constexpr int kSeekErrorMaxRetryCount = 3;
 
 // begin callbacks (have to be regular functions because normal libFLAC isn't C++-aware)
 
@@ -72,7 +78,7 @@ const unsigned kBitsPerSampleDefault = 0;
 } // namespace
 
 SoundSourceFLAC::SoundSourceFLAC(const QUrl& url)
-        : SoundSource(url, "flac"),
+        : SoundSource(url),
           m_file(getLocalFileName()),
           m_decoder(nullptr),
           m_maxBlocksize(0),
@@ -552,13 +558,11 @@ void SoundSourceFLAC::flacError(FLAC__StreamDecoderErrorStatus status) {
 }
 
 QString SoundSourceProviderFLAC::getName() const {
-    return "Xiph.org libFLAC";
+    return kDisplayName;
 }
 
 QStringList SoundSourceProviderFLAC::getSupportedFileExtensions() const {
-    QStringList supportedFileExtensions;
-    supportedFileExtensions.append("flac");
-    return supportedFileExtensions;
+    return kSupportedFileExtensions;
 }
 
 SoundSourceProviderPriority SoundSourceProviderFLAC::getPriorityHint(

--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -10,8 +10,6 @@ namespace {
 
 const Logger kLogger("SoundSourceFLAC");
 
-const QString kDisplayName = QStringLiteral("Xiph.org libFLAC");
-
 const QStringList kSupportedFileExtensions = {
         QStringLiteral("flac"),
 };
@@ -76,6 +74,20 @@ void FLAC_error_cb(const FLAC__StreamDecoder*,
 const unsigned kBitsPerSampleDefault = 0;
 
 } // namespace
+
+//static
+const QString SoundSourceProviderFLAC::kDisplayName = QStringLiteral("Xiph.org libFLAC");
+
+QStringList SoundSourceProviderFLAC::getSupportedFileExtensions() const {
+    return kSupportedFileExtensions;
+}
+
+SoundSourceProviderPriority SoundSourceProviderFLAC::getPriorityHint(
+        const QString& /*supportedFileExtension*/) const {
+    // This reference decoder is supposed to produce more accurate
+    // and reliable results than any other DEFAULT provider.
+    return SoundSourceProviderPriority::Higher;
+}
 
 SoundSourceFLAC::SoundSourceFLAC(const QUrl& url)
         : SoundSource(url),
@@ -555,21 +567,6 @@ void SoundSourceFLAC::flacError(FLAC__StreamDecoderErrorStatus status) {
     // not much else to do here... whatever function that initiated whatever
     // decoder method resulted in this error will return an error, and the caller
     // will bail. libFLAC docs say to not close the decoder here -- bkgood
-}
-
-QString SoundSourceProviderFLAC::getName() const {
-    return kDisplayName;
-}
-
-QStringList SoundSourceProviderFLAC::getSupportedFileExtensions() const {
-    return kSupportedFileExtensions;
-}
-
-SoundSourceProviderPriority SoundSourceProviderFLAC::getPriorityHint(
-        const QString& /*supportedFileExtension*/) const {
-    // This reference decoder is supposed to produce more accurate
-    // and reliable results than any other DEFAULT provider.
-    return SoundSourceProviderPriority::HIGHER;
 }
 
 } // namespace mixxx

--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -83,7 +83,8 @@ QStringList SoundSourceProviderFLAC::getSupportedFileExtensions() const {
 }
 
 SoundSourceProviderPriority SoundSourceProviderFLAC::getPriorityHint(
-        const QString& /*supportedFileExtension*/) const {
+        const QString& supportedFileExtension) const {
+    Q_UNUSED(supportedFileExtension)
     // This reference decoder is supposed to produce more accurate
     // and reliable results than any other DEFAULT provider.
     return SoundSourceProviderPriority::Higher;

--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -10,10 +10,6 @@ namespace {
 
 const Logger kLogger("SoundSourceFLAC");
 
-const QStringList kSupportedFileExtensions = {
-        QStringLiteral("flac"),
-};
-
 // The maximum number of retries to fix seek errors. On a seek error
 // the next seek will start one (or more) sample blocks before the
 // position of the preceding seek operation that has failed.
@@ -78,9 +74,10 @@ const unsigned kBitsPerSampleDefault = 0;
 //static
 const QString SoundSourceProviderFLAC::kDisplayName = QStringLiteral("Xiph.org libFLAC");
 
-QStringList SoundSourceProviderFLAC::getSupportedFileExtensions() const {
-    return kSupportedFileExtensions;
-}
+//static
+const QStringList SoundSourceProviderFLAC::kSupportedFileExtensions = {
+        QStringLiteral("flac"),
+};
 
 SoundSourceProviderPriority SoundSourceProviderFLAC::getPriorityHint(
         const QString& supportedFileExtension) const {

--- a/src/sources/soundsourceflac.h
+++ b/src/sources/soundsourceflac.h
@@ -59,12 +59,15 @@ class SoundSourceFLAC final : public SoundSource {
 class SoundSourceProviderFLAC : public SoundSourceProvider {
   public:
     static const QString kDisplayName;
+    static const QStringList kSupportedFileExtensions;
 
     QString getDisplayName() const override {
         return kDisplayName;
     }
 
-    QStringList getSupportedFileExtensions() const override;
+    QStringList getSupportedFileExtensions() const override {
+        return kSupportedFileExtensions;
+    }
 
     SoundSourceProviderPriority getPriorityHint(
             const QString& supportedFileExtension) const override;

--- a/src/sources/soundsourceflac.h
+++ b/src/sources/soundsourceflac.h
@@ -1,13 +1,11 @@
-#ifndef MIXXX_SOUNDSOURCEFLAC_H
-#define MIXXX_SOUNDSOURCEFLAC_H
-
-#include "sources/soundsourceprovider.h"
-
-#include "util/readaheadsamplebuffer.h"
+#pragma once
 
 #include <FLAC/stream_decoder.h>
 
 #include <QFile>
+
+#include "sources/soundsourceprovider.h"
+#include "util/readaheadsamplebuffer.h"
 
 namespace mixxx {
 
@@ -60,7 +58,11 @@ class SoundSourceFLAC final : public SoundSource {
 
 class SoundSourceProviderFLAC : public SoundSourceProvider {
   public:
-    QString getName() const override;
+    static const QString kDisplayName;
+
+    QString getDisplayName() const override {
+        return kDisplayName;
+    }
 
     QStringList getSupportedFileExtensions() const override;
 
@@ -73,5 +75,3 @@ class SoundSourceProviderFLAC : public SoundSourceProvider {
 };
 
 } // namespace mixxx
-
-#endif // MIXXX_SOUNDSOURCEFLAC_H

--- a/src/sources/soundsourcem4a.cpp
+++ b/src/sources/soundsourcem4a.cpp
@@ -21,11 +21,6 @@ namespace {
 
 const Logger kLogger("SoundSourceM4A");
 
-const QStringList kSupportedFileExtensions = {
-        QStringLiteral("m4a"),
-        QStringLiteral("mp4"),
-};
-
 // MP4SampleId is 1-based
 constexpr MP4SampleId kSampleBlockIdMin = 1;
 
@@ -192,6 +187,12 @@ inline bool startsWithADTSHeader(
 
 //static
 const QString SoundSourceProviderM4A::kDisplayName = QStringLiteral("Nero FAAD2");
+
+//static
+const QStringList SoundSourceProviderM4A::kSupportedFileExtensions = {
+        QStringLiteral("m4a"),
+        QStringLiteral("mp4"),
+};
 
 QStringList SoundSourceProviderM4A::getSupportedFileExtensions() const {
     if (faad2::LibLoader::Instance()->isLoaded()) {

--- a/src/sources/soundsourcem4a.cpp
+++ b/src/sources/soundsourcem4a.cpp
@@ -21,8 +21,6 @@ namespace {
 
 const Logger kLogger("SoundSourceM4A");
 
-const QString kDisplayName = QStringLiteral("Nero FAAD2");
-
 const QStringList kSupportedFileExtensions = {
         QStringLiteral("m4a"),
         QStringLiteral("mp4"),
@@ -191,6 +189,21 @@ inline bool startsWithADTSHeader(
 }
 
 } // anonymous namespace
+
+//static
+const QString SoundSourceProviderM4A::kDisplayName = QStringLiteral("Nero FAAD2");
+
+QStringList SoundSourceProviderM4A::getSupportedFileExtensions() const {
+    if (faad2::LibLoader::Instance()->isLoaded()) {
+        return kSupportedFileExtensions;
+    } else {
+        return QStringList(); // none available
+    }
+}
+
+SoundSourcePointer SoundSourceProviderM4A::newSoundSource(const QUrl& url) {
+    return newSoundSourceFromUrl<SoundSourceM4A>(url);
+}
 
 SoundSourceM4A::SoundSourceM4A(const QUrl& url)
         : SoundSource(url),
@@ -823,22 +836,6 @@ ReadableSampleFrames SoundSourceM4A::readSampleFramesClamped(
     } while (retryAfterReopeningDecoder);
     DEBUG_ASSERT(!"unreachable");
     return {};
-}
-
-QString SoundSourceProviderM4A::getName() const {
-    return kDisplayName;
-}
-
-QStringList SoundSourceProviderM4A::getSupportedFileExtensions() const {
-    if (faad2::LibLoader::Instance()->isLoaded()) {
-        return kSupportedFileExtensions;
-    } else {
-        return QStringList(); // none available
-    }
-}
-
-SoundSourcePointer SoundSourceProviderM4A::newSoundSource(const QUrl& url) {
-    return newSoundSourceFromUrl<SoundSourceM4A>(url);
 }
 
 } // namespace mixxx

--- a/src/sources/soundsourcem4a.cpp
+++ b/src/sources/soundsourcem4a.cpp
@@ -21,6 +21,13 @@ namespace {
 
 const Logger kLogger("SoundSourceM4A");
 
+const QString kDisplayName = QStringLiteral("Nero FAAD2");
+
+const QStringList kSupportedFileExtensions = {
+        QStringLiteral("m4a"),
+        QStringLiteral("mp4"),
+};
+
 // MP4SampleId is 1-based
 constexpr MP4SampleId kSampleBlockIdMin = 1;
 
@@ -186,7 +193,7 @@ inline bool startsWithADTSHeader(
 } // anonymous namespace
 
 SoundSourceM4A::SoundSourceM4A(const QUrl& url)
-        : SoundSource(url, "m4a"),
+        : SoundSource(url),
           m_pFaad(faad2::LibLoader::Instance()),
           m_hFile(MP4_INVALID_FILE_HANDLE),
           m_trackId(MP4_INVALID_TRACK_ID),
@@ -819,16 +826,15 @@ ReadableSampleFrames SoundSourceM4A::readSampleFramesClamped(
 }
 
 QString SoundSourceProviderM4A::getName() const {
-    return "Nero FAAD2";
+    return kDisplayName;
 }
 
 QStringList SoundSourceProviderM4A::getSupportedFileExtensions() const {
-    QStringList supportedFileExtensions;
     if (faad2::LibLoader::Instance()->isLoaded()) {
-        supportedFileExtensions.append("m4a");
-        supportedFileExtensions.append("mp4");
+        return kSupportedFileExtensions;
+    } else {
+        return QStringList(); // none available
     }
-    return supportedFileExtensions;
 }
 
 SoundSourcePointer SoundSourceProviderM4A::newSoundSource(const QUrl& url) {

--- a/src/sources/soundsourcem4a.h
+++ b/src/sources/soundsourcem4a.h
@@ -80,6 +80,7 @@ class SoundSourceM4A : public SoundSource {
 class SoundSourceProviderM4A : public SoundSourceProvider {
   public:
     static const QString kDisplayName;
+    static const QStringList kSupportedFileExtensions;
 
     QString getDisplayName() const override {
         return kDisplayName;

--- a/src/sources/soundsourcem4a.h
+++ b/src/sources/soundsourcem4a.h
@@ -1,5 +1,4 @@
-#ifndef MIXXX_SOUNDSOURCEM4A_H
-#define MIXXX_SOUNDSOURCEM4A_H
+#pragma once
 
 #include "sources/soundsource.h"
 #include "sources/soundsourceprovider.h"
@@ -80,7 +79,11 @@ class SoundSourceM4A : public SoundSource {
 
 class SoundSourceProviderM4A : public SoundSourceProvider {
   public:
-    QString getName() const override;
+    static const QString kDisplayName;
+
+    QString getDisplayName() const override {
+        return kDisplayName;
+    }
 
     QStringList getSupportedFileExtensions() const override;
 
@@ -88,5 +91,3 @@ class SoundSourceProviderM4A : public SoundSourceProvider {
 };
 
 } // namespace mixxx
-
-#endif // MIXXX_SOUNDSOURCEM4A_H

--- a/src/sources/soundsourcemediafoundation.cpp
+++ b/src/sources/soundsourcemediafoundation.cpp
@@ -11,6 +11,13 @@ namespace {
 
 const mixxx::Logger kLogger("SoundSourceMediaFoundation");
 
+const QString kDisplayName = QStringLiteral("Microsoft Media Foundation");
+
+const QStringList kSupportedFileExtensions = {
+        QStringLiteral("m4a"),
+        QStringLiteral("mp4"),
+};
+
 constexpr SINT kUnknownFrameIndex = -1;
 
 constexpr SINT kBytesPerSample = sizeof(CSAMPLE);
@@ -45,7 +52,7 @@ static void safeRelease(T** ppT) {
 namespace mixxx {
 
 SoundSourceMediaFoundation::SoundSourceMediaFoundation(const QUrl& url)
-        : SoundSource(url, "m4a"),
+        : SoundSource(url),
           m_hrCoInitialize(E_FAIL),
           m_hrMFStartup(E_FAIL),
           m_pSourceReader(nullptr),
@@ -783,14 +790,11 @@ bool SoundSourceMediaFoundation::readProperties() {
 }
 
 QString SoundSourceProviderMediaFoundation::getName() const {
-    return "Microsoft Media Foundation";
+    return kDisplayName;
 }
 
 QStringList SoundSourceProviderMediaFoundation::getSupportedFileExtensions() const {
-    QStringList supportedFileExtensions;
-    supportedFileExtensions.append("m4a");
-    supportedFileExtensions.append("mp4");
-    return supportedFileExtensions;
+    return kSupportedFileExtensions;
 }
 
 SoundSourceProviderPriority SoundSourceProviderMediaFoundation::getPriorityHint(

--- a/src/sources/soundsourcemediafoundation.cpp
+++ b/src/sources/soundsourcemediafoundation.cpp
@@ -11,8 +11,6 @@ namespace {
 
 const mixxx::Logger kLogger("SoundSourceMediaFoundation");
 
-const QString kDisplayName = QStringLiteral("Microsoft Media Foundation");
-
 const QStringList kSupportedFileExtensions = {
         QStringLiteral("m4a"),
         QStringLiteral("mp4"),
@@ -50,6 +48,26 @@ static void safeRelease(T** ppT) {
 } // anonymous namespace
 
 namespace mixxx {
+
+//static
+const QString SoundSourceProviderMediaFoundation::kDisplayName =
+        QStringLiteral("Microsoft Media Foundation");
+
+QStringList SoundSourceProviderMediaFoundation::getSupportedFileExtensions() const {
+    return kSupportedFileExtensions;
+}
+
+SoundSourceProviderPriority SoundSourceProviderMediaFoundation::getPriorityHint(
+        const QString& supportedFileExtension) const {
+    Q_UNUSED(supportedFileExtension)
+    // On Windows SoundSourceMediaFoundation is the preferred decoder for all
+    // supported audio formats.
+    return SoundSourceProviderPriority::Higher;
+}
+
+SoundSourcePointer SoundSourceProviderMediaFoundation::newSoundSource(const QUrl& url) {
+    return newSoundSourceFromUrl<SoundSourceMediaFoundation>(url);
+}
 
 SoundSourceMediaFoundation::SoundSourceMediaFoundation(const QUrl& url)
         : SoundSource(url),
@@ -787,26 +805,6 @@ bool SoundSourceMediaFoundation::readProperties() {
     PropVariantClear(&prop);
 
     return true;
-}
-
-QString SoundSourceProviderMediaFoundation::getName() const {
-    return kDisplayName;
-}
-
-QStringList SoundSourceProviderMediaFoundation::getSupportedFileExtensions() const {
-    return kSupportedFileExtensions;
-}
-
-SoundSourceProviderPriority SoundSourceProviderMediaFoundation::getPriorityHint(
-        const QString& supportedFileExtension) const {
-    Q_UNUSED(supportedFileExtension)
-    // On Windows SoundSourceMediaFoundation is the preferred decoder for all
-    // supported audio formats.
-    return SoundSourceProviderPriority::HIGHER;
-}
-
-SoundSourcePointer SoundSourceProviderMediaFoundation::newSoundSource(const QUrl& url) {
-    return newSoundSourceFromUrl<SoundSourceMediaFoundation>(url);
 }
 
 } // namespace mixxx

--- a/src/sources/soundsourcemediafoundation.cpp
+++ b/src/sources/soundsourcemediafoundation.cpp
@@ -11,11 +11,6 @@ namespace {
 
 const mixxx::Logger kLogger("SoundSourceMediaFoundation");
 
-const QStringList kSupportedFileExtensions = {
-        QStringLiteral("m4a"),
-        QStringLiteral("mp4"),
-};
-
 constexpr SINT kUnknownFrameIndex = -1;
 
 constexpr SINT kBytesPerSample = sizeof(CSAMPLE);
@@ -53,9 +48,11 @@ namespace mixxx {
 const QString SoundSourceProviderMediaFoundation::kDisplayName =
         QStringLiteral("Microsoft Media Foundation");
 
-QStringList SoundSourceProviderMediaFoundation::getSupportedFileExtensions() const {
-    return kSupportedFileExtensions;
-}
+//static
+const QStringList SoundSourceProviderMediaFoundation::kSupportedFileExtensions = {
+        QStringLiteral("m4a"),
+        QStringLiteral("mp4"),
+};
 
 SoundSourceProviderPriority SoundSourceProviderMediaFoundation::getPriorityHint(
         const QString& supportedFileExtension) const {

--- a/src/sources/soundsourcemediafoundation.cpp
+++ b/src/sources/soundsourcemediafoundation.cpp
@@ -793,6 +793,14 @@ QStringList SoundSourceProviderMediaFoundation::getSupportedFileExtensions() con
     return supportedFileExtensions;
 }
 
+SoundSourceProviderPriority SoundSourceProviderMediaFoundation::getPriorityHint(
+        const QString& supportedFileExtension) const {
+    Q_UNUSED(supportedFileExtension)
+    // On Windows SoundSourceMediaFoundation is the preferred decoder for all
+    // supported audio formats.
+    return SoundSourceProviderPriority::HIGHER;
+}
+
 SoundSourcePointer SoundSourceProviderMediaFoundation::newSoundSource(const QUrl& url) {
     return newSoundSourceFromUrl<SoundSourceMediaFoundation>(url);
 }

--- a/src/sources/soundsourcemediafoundation.h
+++ b/src/sources/soundsourcemediafoundation.h
@@ -90,9 +90,16 @@ class SoundSourceMediaFoundation : public SoundSource {
 
 class SoundSourceProviderMediaFoundation : public SoundSourceProvider {
   public:
-    QString getDisplayName() const override;
+    static const QString kDisplayName;
+    static const QStringList kSupportedFileExtensions;
 
-    QStringList getSupportedFileExtensions() const override;
+    QString getDisplayName() const override {
+        return kDisplayName;
+    }
+
+    QStringList getSupportedFileExtensions() const override {
+        return kSupportedFileExtensions;
+    }
 
     SoundSourceProviderPriority getPriorityHint(
             const QString& supportedFileExtension) const override;

--- a/src/sources/soundsourcemediafoundation.h
+++ b/src/sources/soundsourcemediafoundation.h
@@ -93,6 +93,9 @@ class SoundSourceProviderMediaFoundation : public SoundSourceProvider {
 
     QStringList getSupportedFileExtensions() const override;
 
+    SoundSourceProviderPriority getPriorityHint(
+            const QString& supportedFileExtension) const override;
+
     SoundSourcePointer newSoundSource(const QUrl& url) override;
 };
 

--- a/src/sources/soundsourcemediafoundation.h
+++ b/src/sources/soundsourcemediafoundation.h
@@ -1,5 +1,4 @@
-#ifndef MIXXX_SOUNDSOURCEMEDIAFOUNDATION_H
-#define MIXXX_SOUNDSOURCEMEDIAFOUNDATION_H
+#pragma once
 
 #include <mfidl.h>
 #include <mfreadwrite.h>
@@ -56,6 +55,8 @@ class StreamUnitConverter final {
 
 class SoundSourceMediaFoundation : public SoundSource {
   public:
+    static const QString kDisplayName;
+
     explicit SoundSourceMediaFoundation(const QUrl& url);
     ~SoundSourceMediaFoundation() override;
 
@@ -89,7 +90,7 @@ class SoundSourceMediaFoundation : public SoundSource {
 
 class SoundSourceProviderMediaFoundation : public SoundSourceProvider {
   public:
-    QString getName() const override;
+    QString getDisplayName() const override;
 
     QStringList getSupportedFileExtensions() const override;
 
@@ -100,5 +101,3 @@ class SoundSourceProviderMediaFoundation : public SoundSourceProvider {
 };
 
 } // namespace mixxx
-
-#endif // MIXXX_SOUNDSOURCEMEDIAFOUNDATION_H

--- a/src/sources/soundsourcemodplug.cpp
+++ b/src/sources/soundsourcemodplug.cpp
@@ -17,8 +17,6 @@ namespace {
 
 const Logger kLogger("SoundSourceModPlug");
 
-const QString kDisplayName = QStringLiteral("MODPlug");
-
 const QStringList kSupportedFileExtensions = {
         // ModPlug supports more formats but file name
         // extensions are not always present with modules.
@@ -57,17 +55,30 @@ QString getModPlugTypeFromUrl(QUrl url) {
 
 } // anonymous namespace
 
-/*static*/ constexpr SINT SoundSourceModPlug::kChannelCount;
-/*static*/ constexpr SINT SoundSourceModPlug::kBitsPerSample;
-/*static*/ constexpr SINT SoundSourceModPlug::kSampleRate;
+//static
+constexpr SINT SoundSourceModPlug::kChannelCount;
 
+//static
+constexpr SINT SoundSourceModPlug::kBitsPerSample;
+
+//static
+constexpr SINT SoundSourceModPlug::kSampleRate;
+
+//static
 unsigned int SoundSourceModPlug::s_bufferSizeLimit = 0;
 
-// reserve some static space for settings...
+//static
 void SoundSourceModPlug::configure(unsigned int bufferSizeLimit,
         const ModPlug::ModPlug_Settings& settings) {
     s_bufferSizeLimit = bufferSizeLimit;
     ModPlug::ModPlug_SetSettings(&settings);
+}
+
+//static
+const QString SoundSourceProviderModPlug::kDisplayName = QStringLiteral("MODPlug");
+
+QStringList SoundSourceProviderModPlug::getSupportedFileExtensions() const {
+    return kSupportedFileExtensions;
 }
 
 SoundSourceModPlug::SoundSourceModPlug(const QUrl& url)
@@ -209,14 +220,6 @@ ReadableSampleFrames SoundSourceModPlug::readSampleFramesClamped(
             SampleBuffer::ReadableSlice(
                     writableSampleFrames.writableData(),
                     writableSampleFrames.writableLength()));
-}
-
-QString SoundSourceProviderModPlug::getName() const {
-    return kDisplayName;
-}
-
-QStringList SoundSourceProviderModPlug::getSupportedFileExtensions() const {
-    return kSupportedFileExtensions;
 }
 
 } // namespace mixxx

--- a/src/sources/soundsourcemodplug.cpp
+++ b/src/sources/soundsourcemodplug.cpp
@@ -17,8 +17,22 @@ namespace {
 
 const Logger kLogger("SoundSourceModPlug");
 
+const QString kDisplayName = QStringLiteral("MODPlug");
+
+const QStringList kSupportedFileExtensions = {
+        // ModPlug supports more formats but file name
+        // extensions are not always present with modules.
+        QStringLiteral("mod"),
+        QStringLiteral("med"),
+        QStringLiteral("okt"),
+        QStringLiteral("s3m"),
+        QStringLiteral("stm"),
+        QStringLiteral("xm"),
+        QStringLiteral("it"),
+};
+
 /* read files in 512k chunks */
-const SINT kChunkSizeInBytes = SINT(1) << 19;
+constexpr SINT kChunkSizeInBytes = SINT(1) << 19;
 
 QString getModPlugTypeFromUrl(QUrl url) {
     const QString fileExtension(SoundSource::getFileExtensionFromUrl(url));
@@ -198,21 +212,11 @@ ReadableSampleFrames SoundSourceModPlug::readSampleFramesClamped(
 }
 
 QString SoundSourceProviderModPlug::getName() const {
-    return "MODPlug";
+    return kDisplayName;
 }
 
 QStringList SoundSourceProviderModPlug::getSupportedFileExtensions() const {
-    QStringList supportedFileExtensions;
-    // ModPlug supports more formats but file name
-    // extensions are not always present with modules.
-    supportedFileExtensions.append("mod");
-    supportedFileExtensions.append("med");
-    supportedFileExtensions.append("okt");
-    supportedFileExtensions.append("s3m");
-    supportedFileExtensions.append("stm");
-    supportedFileExtensions.append("xm");
-    supportedFileExtensions.append("it");
-    return supportedFileExtensions;
+    return kSupportedFileExtensions;
 }
 
 } // namespace mixxx

--- a/src/sources/soundsourcemodplug.h
+++ b/src/sources/soundsourcemodplug.h
@@ -1,5 +1,4 @@
-#ifndef MIXXX_SOUNDSOURCEMODPLUG_H
-#define MIXXX_SOUNDSOURCEMODPLUG_H
+#pragma once
 
 #include "sources/soundsourceprovider.h"
 
@@ -53,7 +52,11 @@ class SoundSourceModPlug : public SoundSource {
 
 class SoundSourceProviderModPlug : public SoundSourceProvider {
   public:
-    QString getName() const override;
+    static const QString kDisplayName;
+
+    QString getDisplayName() const override {
+        return kDisplayName;
+    }
 
     QStringList getSupportedFileExtensions() const override;
 
@@ -63,5 +66,3 @@ class SoundSourceProviderModPlug : public SoundSourceProvider {
 };
 
 } // namespace mixxx
-
-#endif // MIXXX_SOUNDSOURCEMODPLUG_H

--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -12,8 +12,6 @@ namespace {
 
 const Logger kLogger("SoundSourceMP3");
 
-const QString kDisplayName = QStringLiteral("MAD: MPEG Audio Decoder");
-
 const QStringList kSupportedFileExtensions = {
         QStringLiteral("mp3"),
 };
@@ -164,6 +162,13 @@ bool decodeFrameHeader(
 }
 
 } // anonymous namespace
+
+//static
+const QString SoundSourceProviderMp3::kDisplayName = QStringLiteral("MAD: MPEG Audio Decoder");
+
+QStringList SoundSourceProviderMp3::getSupportedFileExtensions() const {
+    return kSupportedFileExtensions;
+}
 
 SoundSourceMp3::SoundSourceMp3(const QUrl& url)
         : SoundSource(url),
@@ -776,14 +781,6 @@ ReadableSampleFrames SoundSourceMp3::readSampleFramesClamped(
             SampleBuffer::ReadableSlice(
                     writableSampleFrames.writableData(),
                     std::min(writableSampleFrames.writableLength(), getSignalInfo().frames2samples(numberOfFrames))));
-}
-
-QString SoundSourceProviderMp3::getName() const {
-    return kDisplayName;
-}
-
-QStringList SoundSourceProviderMp3::getSupportedFileExtensions() const {
-    return kSupportedFileExtensions;
 }
 
 } // namespace mixxx

--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -12,13 +12,19 @@ namespace {
 
 const Logger kLogger("SoundSourceMP3");
 
-// MP3 does only support 1 or 2 channels
-const SINT kChannelCountMax = 2;
+const QString kDisplayName = QStringLiteral("MAD: MPEG Audio Decoder");
 
-const SINT kMaxBytesPerMp3Frame = 1441;
+const QStringList kSupportedFileExtensions = {
+        QStringLiteral("mp3"),
+};
+
+// MP3 does only support 1 or 2 channels
+constexpr SINT kChannelCountMax = 2;
+
+constexpr SINT kMaxBytesPerMp3Frame = 1441;
 
 // mp3 supports 9 different sample rates
-const int kSampleRateCount = 9;
+constexpr int kSampleRateCount = 9;
 
 int getIndexBySampleRate(audio::SampleRate sampleRate) {
     switch (sampleRate) {
@@ -72,17 +78,18 @@ audio::SampleRate getSampleRateByIndex(int sampleRateIndex) {
     }
 }
 
-const CSAMPLE kMadScale = CSAMPLE_PEAK / CSAMPLE(MAD_F_ONE);
+constexpr CSAMPLE kMadScale = CSAMPLE_PEAK / CSAMPLE(MAD_F_ONE);
 
 inline CSAMPLE madScaleSampleValue(mad_fixed_t sampleValue) {
     return sampleValue * kMadScale;
 }
 
 // Optimization: Reserve initial capacity for seek frame list
-const SINT kMinutesPerFile = 10;        // enough for the majority of files (tunable)
-const SINT kSecondsPerMinute = 60;      // fixed
-const SINT kMaxMp3FramesPerSecond = 39; // fixed: 1 MP3 frame = 26 ms -> ~ 1000 / 26
-const SINT kSeekFrameListCapacity = kMinutesPerFile * kSecondsPerMinute * kMaxMp3FramesPerSecond;
+constexpr SINT kMinutesPerFile = 10;        // enough for the majority of files (tunable)
+constexpr SINT kSecondsPerMinute = 60;      // fixed
+constexpr SINT kMaxMp3FramesPerSecond = 39; // fixed: 1 MP3 frame = 26 ms -> ~ 1000 / 26
+constexpr SINT kSeekFrameListCapacity =
+        kMinutesPerFile * kSecondsPerMinute * kMaxMp3FramesPerSecond;
 
 inline QString formatHeaderFlags(int headerFlags) {
     return QString("0x%1").arg(headerFlags, 4, 16, QLatin1Char('0'));
@@ -159,7 +166,7 @@ bool decodeFrameHeader(
 } // anonymous namespace
 
 SoundSourceMp3::SoundSourceMp3(const QUrl& url)
-        : SoundSource(url, "mp3"),
+        : SoundSource(url),
           m_file(getLocalFileName()),
           m_fileSize(0),
           m_pFileData(nullptr),
@@ -772,13 +779,11 @@ ReadableSampleFrames SoundSourceMp3::readSampleFramesClamped(
 }
 
 QString SoundSourceProviderMp3::getName() const {
-    return "MAD: MPEG Audio Decoder";
+    return kDisplayName;
 }
 
 QStringList SoundSourceProviderMp3::getSupportedFileExtensions() const {
-    QStringList supportedFileExtensions;
-    supportedFileExtensions.append("mp3");
-    return supportedFileExtensions;
+    return kSupportedFileExtensions;
 }
 
 } // namespace mixxx

--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -10,11 +10,7 @@ namespace mixxx {
 
 namespace {
 
-const Logger kLogger("SoundSourceMP3");
-
-const QStringList kSupportedFileExtensions = {
-        QStringLiteral("mp3"),
-};
+const Logger kLogger("SoundSourceMp3");
 
 // MP3 does only support 1 or 2 channels
 constexpr SINT kChannelCountMax = 2;
@@ -166,9 +162,10 @@ bool decodeFrameHeader(
 //static
 const QString SoundSourceProviderMp3::kDisplayName = QStringLiteral("MAD: MPEG Audio Decoder");
 
-QStringList SoundSourceProviderMp3::getSupportedFileExtensions() const {
-    return kSupportedFileExtensions;
-}
+//static
+const QStringList SoundSourceProviderMp3::kSupportedFileExtensions = {
+        QStringLiteral("mp3"),
+};
 
 SoundSourceMp3::SoundSourceMp3(const QUrl& url)
         : SoundSource(url),

--- a/src/sources/soundsourcemp3.h
+++ b/src/sources/soundsourcemp3.h
@@ -77,12 +77,15 @@ class SoundSourceMp3 final : public SoundSource {
 class SoundSourceProviderMp3 : public SoundSourceProvider {
   public:
     static const QString kDisplayName;
+    static const QStringList kSupportedFileExtensions;
 
     QString getDisplayName() const override {
         return kDisplayName;
     }
 
-    QStringList getSupportedFileExtensions() const override;
+    QStringList getSupportedFileExtensions() const override {
+        return kSupportedFileExtensions;
+    }
 
     SoundSourcePointer newSoundSource(const QUrl& url) override {
         return newSoundSourceFromUrl<SoundSourceMp3>(url);

--- a/src/sources/soundsourcemp3.h
+++ b/src/sources/soundsourcemp3.h
@@ -1,5 +1,4 @@
-#ifndef MIXXX_SOUNDSOURCEMP3_H
-#define MIXXX_SOUNDSOURCEMP3_H
+#pragma once
 
 #include "sources/soundsourceprovider.h"
 
@@ -77,7 +76,11 @@ class SoundSourceMp3 final : public SoundSource {
 
 class SoundSourceProviderMp3 : public SoundSourceProvider {
   public:
-    QString getName() const override;
+    static const QString kDisplayName;
+
+    QString getDisplayName() const override {
+        return kDisplayName;
+    }
 
     QStringList getSupportedFileExtensions() const override;
 
@@ -87,5 +90,3 @@ class SoundSourceProviderMp3 : public SoundSourceProvider {
 };
 
 } // namespace mixxx
-
-#endif // MIXXX_SOUNDSOURCEMP3_H

--- a/src/sources/soundsourceoggvorbis.cpp
+++ b/src/sources/soundsourceoggvorbis.cpp
@@ -10,8 +10,6 @@ namespace {
 
 const Logger kLogger("SoundSourceOggVorbis");
 
-const QString kDisplayName = QStringLiteral("Xiph.org OggVorbis");
-
 const QStringList kSupportedFileExtensions = {
         QStringLiteral("ogg"),
 };
@@ -32,6 +30,21 @@ ov_callbacks SoundSourceOggVorbis::s_callbacks = {
         SoundSourceOggVorbis::SeekCallback,
         SoundSourceOggVorbis::CloseCallback,
         SoundSourceOggVorbis::TellCallback};
+
+//static
+const QString SoundSourceProviderOggVorbis::kDisplayName = QStringLiteral("Xiph.org OggVorbis");
+
+QStringList SoundSourceProviderOggVorbis::getSupportedFileExtensions() const {
+    return kSupportedFileExtensions;
+}
+
+SoundSourceProviderPriority SoundSourceProviderOggVorbis::getPriorityHint(
+        const QString& supportedFileExtension) const {
+    Q_UNUSED(supportedFileExtension)
+    // This reference decoder is supposed to produce more accurate
+    // and reliable results than any other DEFAULT provider.
+    return SoundSourceProviderPriority::Higher;
+}
 
 SoundSourceOggVorbis::SoundSourceOggVorbis(const QUrl& url)
         : SoundSource(url),
@@ -250,22 +263,6 @@ long SoundSourceOggVorbis::TellCallback(void* datasource) {
         return 0;
     }
     return pFile->pos();
-}
-
-QString SoundSourceProviderOggVorbis::getName() const {
-    return kDisplayName;
-}
-
-QStringList SoundSourceProviderOggVorbis::getSupportedFileExtensions() const {
-    return kSupportedFileExtensions;
-}
-
-SoundSourceProviderPriority SoundSourceProviderOggVorbis::getPriorityHint(
-        const QString& supportedFileExtension) const {
-    Q_UNUSED(supportedFileExtension)
-    // This reference decoder is supposed to produce more accurate
-    // and reliable results than any other DEFAULT provider.
-    return SoundSourceProviderPriority::HIGHER;
 }
 
 } // namespace mixxx

--- a/src/sources/soundsourceoggvorbis.cpp
+++ b/src/sources/soundsourceoggvorbis.cpp
@@ -10,10 +10,6 @@ namespace {
 
 const Logger kLogger("SoundSourceOggVorbis");
 
-const QStringList kSupportedFileExtensions = {
-        QStringLiteral("ogg"),
-};
-
 // Parameter for ov_info()
 // See also: https://xiph.org/vorbis/doc/vorbisfile/ov_info.html
 constexpr int kCurrentBitstreamLink = -1; // retrieve ... for the current bitstream
@@ -34,9 +30,10 @@ ov_callbacks SoundSourceOggVorbis::s_callbacks = {
 //static
 const QString SoundSourceProviderOggVorbis::kDisplayName = QStringLiteral("Xiph.org OggVorbis");
 
-QStringList SoundSourceProviderOggVorbis::getSupportedFileExtensions() const {
-    return kSupportedFileExtensions;
-}
+//static
+const QStringList SoundSourceProviderOggVorbis::kSupportedFileExtensions = {
+        QStringLiteral("ogg"),
+};
 
 SoundSourceProviderPriority SoundSourceProviderOggVorbis::getPriorityHint(
         const QString& supportedFileExtension) const {

--- a/src/sources/soundsourceoggvorbis.cpp
+++ b/src/sources/soundsourceoggvorbis.cpp
@@ -10,13 +10,19 @@ namespace {
 
 const Logger kLogger("SoundSourceOggVorbis");
 
+const QString kDisplayName = QStringLiteral("Xiph.org OggVorbis");
+
+const QStringList kSupportedFileExtensions = {
+        QStringLiteral("ogg"),
+};
+
 // Parameter for ov_info()
 // See also: https://xiph.org/vorbis/doc/vorbisfile/ov_info.html
-const int kCurrentBitstreamLink = -1; // retrieve ... for the current bitstream
+constexpr int kCurrentBitstreamLink = -1; // retrieve ... for the current bitstream
 
 // Parameter for ov_pcm_total()
 // See also: https://xiph.org/vorbis/doc/vorbisfile/ov_pcm_total.html
-const int kEntireBitstreamLink = -1; // retrieve ... for the entire physical bitstream
+constexpr int kEntireBitstreamLink = -1; // retrieve ... for the entire physical bitstream
 
 } // anonymous namespace
 
@@ -28,7 +34,7 @@ ov_callbacks SoundSourceOggVorbis::s_callbacks = {
         SoundSourceOggVorbis::TellCallback};
 
 SoundSourceOggVorbis::SoundSourceOggVorbis(const QUrl& url)
-        : SoundSource(url, "ogg"),
+        : SoundSource(url),
           m_curFrameIndex(0) {
     memset(&m_vf, 0, sizeof(m_vf));
 }
@@ -247,17 +253,16 @@ long SoundSourceOggVorbis::TellCallback(void* datasource) {
 }
 
 QString SoundSourceProviderOggVorbis::getName() const {
-    return "Xiph.org OggVorbis";
+    return kDisplayName;
 }
 
 QStringList SoundSourceProviderOggVorbis::getSupportedFileExtensions() const {
-    QStringList supportedFileExtensions;
-    supportedFileExtensions.append("ogg");
-    return supportedFileExtensions;
+    return kSupportedFileExtensions;
 }
 
 SoundSourceProviderPriority SoundSourceProviderOggVorbis::getPriorityHint(
-        const QString& /*supportedFileExtension*/) const {
+        const QString& supportedFileExtension) const {
+    Q_UNUSED(supportedFileExtension)
     // This reference decoder is supposed to produce more accurate
     // and reliable results than any other DEFAULT provider.
     return SoundSourceProviderPriority::HIGHER;

--- a/src/sources/soundsourceoggvorbis.h
+++ b/src/sources/soundsourceoggvorbis.h
@@ -42,12 +42,15 @@ class SoundSourceOggVorbis final : public SoundSource {
 class SoundSourceProviderOggVorbis : public SoundSourceProvider {
   public:
     static const QString kDisplayName;
+    static const QStringList kSupportedFileExtensions;
 
     QString getDisplayName() const override {
         return kDisplayName;
     }
 
-    QStringList getSupportedFileExtensions() const override;
+    QStringList getSupportedFileExtensions() const override {
+        return kSupportedFileExtensions;
+    }
 
     SoundSourceProviderPriority getPriorityHint(
             const QString& supportedFileExtension) const override;

--- a/src/sources/soundsourceoggvorbis.h
+++ b/src/sources/soundsourceoggvorbis.h
@@ -41,7 +41,11 @@ class SoundSourceOggVorbis final : public SoundSource {
 
 class SoundSourceProviderOggVorbis : public SoundSourceProvider {
   public:
-    QString getName() const override;
+    static const QString kDisplayName;
+
+    QString getDisplayName() const override {
+        return kDisplayName;
+    }
 
     QStringList getSupportedFileExtensions() const override;
 

--- a/src/sources/soundsourceopus.cpp
+++ b/src/sources/soundsourceopus.cpp
@@ -9,8 +9,6 @@ namespace {
 
 const Logger kLogger("SoundSourceOpus");
 
-const QString kDisplayName = QStringLiteral("Xiph.org libopusfile");
-
 const QStringList kSupportedFileExtensions = {
         QStringLiteral("opus"),
 };
@@ -70,6 +68,20 @@ class OggOpusFileOwner {
 };
 
 } // anonymous namespace
+
+//static
+const QString SoundSourceProviderOpus::kDisplayName = QStringLiteral("Xiph.org libopusfile");
+
+QStringList SoundSourceProviderOpus::getSupportedFileExtensions() const {
+    return kSupportedFileExtensions;
+}
+
+SoundSourceProviderPriority SoundSourceProviderOpus::getPriorityHint(
+        const QString& /*supportedFileExtension*/) const {
+    // This reference decoder is supposed to produce more accurate
+    // and reliable results than any other DEFAULT provider.
+    return SoundSourceProviderPriority::Higher;
+}
 
 SoundSourceOpus::SoundSourceOpus(const QUrl& url)
         : SoundSource(url),
@@ -384,21 +396,6 @@ ReadableSampleFrames SoundSourceOpus::readSampleFramesClamped(
             SampleBuffer::ReadableSlice(
                     writableSampleFrames.writableData(),
                     std::min(writableSampleFrames.writableLength(), getSignalInfo().frames2samples(numberOfFrames))));
-}
-
-QString SoundSourceProviderOpus::getName() const {
-    return kDisplayName;
-}
-
-QStringList SoundSourceProviderOpus::getSupportedFileExtensions() const {
-    return kSupportedFileExtensions;
-}
-
-SoundSourceProviderPriority SoundSourceProviderOpus::getPriorityHint(
-        const QString& /*supportedFileExtension*/) const {
-    // This reference decoder is supposed to produce more accurate
-    // and reliable results than any other DEFAULT provider.
-    return SoundSourceProviderPriority::HIGHER;
 }
 
 } // namespace mixxx

--- a/src/sources/soundsourceopus.cpp
+++ b/src/sources/soundsourceopus.cpp
@@ -77,7 +77,8 @@ QStringList SoundSourceProviderOpus::getSupportedFileExtensions() const {
 }
 
 SoundSourceProviderPriority SoundSourceProviderOpus::getPriorityHint(
-        const QString& /*supportedFileExtension*/) const {
+        const QString& supportedFileExtension) const {
+    Q_UNUSED(supportedFileExtension)
     // This reference decoder is supposed to produce more accurate
     // and reliable results than any other DEFAULT provider.
     return SoundSourceProviderPriority::Higher;

--- a/src/sources/soundsourceopus.cpp
+++ b/src/sources/soundsourceopus.cpp
@@ -9,10 +9,6 @@ namespace {
 
 const Logger kLogger("SoundSourceOpus");
 
-const QStringList kSupportedFileExtensions = {
-        QStringLiteral("opus"),
-};
-
 // Decoded output of opusfile has a fixed sample rate of 48 kHz (fullband)
 constexpr audio::SampleRate kSampleRate = audio::SampleRate(48000);
 
@@ -72,9 +68,10 @@ class OggOpusFileOwner {
 //static
 const QString SoundSourceProviderOpus::kDisplayName = QStringLiteral("Xiph.org libopusfile");
 
-QStringList SoundSourceProviderOpus::getSupportedFileExtensions() const {
-    return kSupportedFileExtensions;
-}
+//static
+const QStringList SoundSourceProviderOpus::kSupportedFileExtensions = {
+        QStringLiteral("opus"),
+};
 
 SoundSourceProviderPriority SoundSourceProviderOpus::getPriorityHint(
         const QString& supportedFileExtension) const {

--- a/src/sources/soundsourceopus.cpp
+++ b/src/sources/soundsourceopus.cpp
@@ -9,6 +9,12 @@ namespace {
 
 const Logger kLogger("SoundSourceOpus");
 
+const QString kDisplayName = QStringLiteral("Xiph.org libopusfile");
+
+const QStringList kSupportedFileExtensions = {
+        QStringLiteral("opus"),
+};
+
 // Decoded output of opusfile has a fixed sample rate of 48 kHz (fullband)
 constexpr audio::SampleRate kSampleRate = audio::SampleRate(48000);
 
@@ -66,7 +72,7 @@ class OggOpusFileOwner {
 } // anonymous namespace
 
 SoundSourceOpus::SoundSourceOpus(const QUrl& url)
-        : SoundSource(url, "opus"),
+        : SoundSource(url),
           m_pOggOpusFile(nullptr),
           m_curFrameIndex(0) {
 }
@@ -381,13 +387,11 @@ ReadableSampleFrames SoundSourceOpus::readSampleFramesClamped(
 }
 
 QString SoundSourceProviderOpus::getName() const {
-    return "Xiph.org libopusfile";
+    return kDisplayName;
 }
 
 QStringList SoundSourceProviderOpus::getSupportedFileExtensions() const {
-    QStringList supportedFileExtensions;
-    supportedFileExtensions.append("opus");
-    return supportedFileExtensions;
+    return kSupportedFileExtensions;
 }
 
 SoundSourceProviderPriority SoundSourceProviderOpus::getPriorityHint(

--- a/src/sources/soundsourceopus.h
+++ b/src/sources/soundsourceopus.h
@@ -38,12 +38,15 @@ class SoundSourceOpus final : public SoundSource {
 class SoundSourceProviderOpus : public SoundSourceProvider {
   public:
     static const QString kDisplayName;
+    static const QStringList kSupportedFileExtensions;
 
     QString getDisplayName() const override {
         return kDisplayName;
     }
 
-    QStringList getSupportedFileExtensions() const override;
+    QStringList getSupportedFileExtensions() const override {
+        return kSupportedFileExtensions;
+    }
 
     SoundSourceProviderPriority getPriorityHint(
             const QString& supportedFileExtension) const override;

--- a/src/sources/soundsourceopus.h
+++ b/src/sources/soundsourceopus.h
@@ -1,5 +1,4 @@
-#ifndef MIXXX_SOUNDSOURCEOPUS_H
-#define MIXXX_SOUNDSOURCEOPUS_H
+#pragma once
 
 #define OV_EXCLUDE_STATIC_CALLBACKS
 #include <opus/opusfile.h>
@@ -38,7 +37,11 @@ class SoundSourceOpus final : public SoundSource {
 
 class SoundSourceProviderOpus : public SoundSourceProvider {
   public:
-    QString getName() const override;
+    static const QString kDisplayName;
+
+    QString getDisplayName() const override {
+        return kDisplayName;
+    }
 
     QStringList getSupportedFileExtensions() const override;
 
@@ -51,5 +54,3 @@ class SoundSourceProviderOpus : public SoundSourceProvider {
 };
 
 } // namespace mixxx
-
-#endif // MIXXX_SOUNDSOURCEOPUS_H

--- a/src/sources/soundsourceprovider.cpp
+++ b/src/sources/soundsourceprovider.cpp
@@ -1,0 +1,23 @@
+#include "sources/soundsourceprovider.h"
+
+namespace mixxx {
+
+QDebug operator<<(QDebug dbg, SoundSourceProviderPriority arg) {
+    switch (arg) {
+    case SoundSourceProviderPriority::Lowest:
+        return dbg << static_cast<int>(arg) << "(lowest)";
+    case SoundSourceProviderPriority::Lower:
+        return dbg << static_cast<int>(arg) << "(lower)";
+    case SoundSourceProviderPriority::Default:
+        return dbg << static_cast<int>(arg) << "(default)";
+    case SoundSourceProviderPriority::Higher:
+        return dbg << static_cast<int>(arg) << "(higher)";
+    case SoundSourceProviderPriority::Highest:
+        return dbg << static_cast<int>(arg) << "(highest)";
+    default:
+        DEBUG_ASSERT(!"reachable");
+        return dbg;
+    }
+}
+
+} // namespace mixxx

--- a/src/sources/soundsourceprovider.cpp
+++ b/src/sources/soundsourceprovider.cpp
@@ -15,7 +15,7 @@ QDebug operator<<(QDebug dbg, SoundSourceProviderPriority arg) {
     case SoundSourceProviderPriority::Highest:
         return dbg << static_cast<int>(arg) << "(highest)";
     default:
-        DEBUG_ASSERT(!"reachable");
+        DEBUG_ASSERT(!"unexpected SoundSourceProviderPriority");
         return dbg;
     }
 }

--- a/src/sources/soundsourceprovider.h
+++ b/src/sources/soundsourceprovider.h
@@ -1,5 +1,4 @@
-#ifndef MIXXX_SOUNDSOURCEPROVIDER_H
-#define MIXXX_SOUNDSOURCEPROVIDER_H
+#pragma once
 
 #include <QString>
 #include <QStringList>
@@ -14,49 +13,48 @@ namespace mixxx {
 // a single provider will be registered for each file extension
 // and priority.
 enum class SoundSourceProviderPriority {
-    LOWEST,
-    LOWER,
-    DEFAULT,
-    HIGHER,
-    HIGHEST
+    Lowest,
+    Lower,
+    Default,
+    Higher,
+    Highest,
 };
 
-// Factory interface for SoundSources
-//
-// The implementation of a SoundSourceProvider must be thread-safe, because
-// a single instance might be accessed concurrently from different threads.
+/// Factory interface for SoundSources
+///
+/// The implementation of a SoundSourceProvider must be thread-safe, because
+/// a single instance might be accessed concurrently from different threads.
 class SoundSourceProvider {
   public:
     virtual ~SoundSourceProvider() = default;
 
-    // A user-readable name that identifies this provider.
-    virtual QString getName() const = 0;
+    /// A user-readable, unique display name that identifies
+    /// the corresponding SoundSource.
+    virtual QString getDisplayName() const = 0;
 
-    // A list of supported file extensions in any order.
+    /// A list of supported file extensions in any order.
     virtual QStringList getSupportedFileExtensions() const = 0;
 
-    // The default cooperative priority of this provider compared to
-    // others supporting the same file extension(s). Please note that
-    // an application may override the returned value to support
-    // customization.
-    //
-    // The priority may vary with the file type that is currently
-    // represented by the file extension.
+    /// The default cooperative priority of this provider compared to
+    /// others supporting the same file extension(s). Please note that
+    /// an application may override the returned value to support
+    /// customization.
+    ///
+    /// The priority may vary with the file type that is currently
+    /// represented by the file extension.
     virtual SoundSourceProviderPriority getPriorityHint(
             const QString& supportedFileExtension) const {
         Q_UNUSED(supportedFileExtension);
-        return SoundSourceProviderPriority::DEFAULT;
+        return SoundSourceProviderPriority::Default;
     }
 
-    // Creates a new SoundSource for the file referenced by the URL.
-    // This function should return a nullptr pointer if it is already
-    // able to decide that the file is not supported even though it
-    // has one of the supported file extensions.
+    /// Creates a new SoundSource for the file referenced by the URL.
+    /// This function should return a nullptr pointer if it is already
+    /// able to decide that the file is not supported even though it
+    /// has one of the supported file extensions.
     virtual SoundSourcePointer newSoundSource(const QUrl& url) = 0;
 };
 
 typedef std::shared_ptr<SoundSourceProvider> SoundSourceProviderPointer;
 
 } // namespace mixxx
-
-#endif // MIXXX_SOUNDSOURCEPROVIDER_H

--- a/src/sources/soundsourceprovider.h
+++ b/src/sources/soundsourceprovider.h
@@ -2,7 +2,9 @@
 
 #include <QString>
 #include <QStringList>
-#include <QUrl>
+#include <QtDebug>
+
+QT_FORWARD_DECLARE_CLASS(QUrl);
 
 #include "sources/soundsource.h"
 
@@ -12,13 +14,15 @@ namespace mixxx {
 // to the priority for which they have been registered. Only
 // a single provider will be registered for each file extension
 // and priority.
-enum class SoundSourceProviderPriority {
-    Lowest,
-    Lower,
-    Default,
-    Higher,
-    Highest,
+enum class SoundSourceProviderPriority : int {
+    Lowest = 1,
+    Lower = 2,
+    Default = 3,
+    Higher = 4,
+    Highest = 5,
 };
+
+QDebug operator<<(QDebug dbg, SoundSourceProviderPriority arg);
 
 /// Factory interface for SoundSources
 ///
@@ -44,7 +48,7 @@ class SoundSourceProvider {
     /// represented by the file extension.
     virtual SoundSourceProviderPriority getPriorityHint(
             const QString& supportedFileExtension) const {
-        Q_UNUSED(supportedFileExtension);
+        Q_UNUSED(supportedFileExtension)
         return SoundSourceProviderPriority::Default;
     }
 

--- a/src/sources/soundsourceproviderregistry.cpp
+++ b/src/sources/soundsourceproviderregistry.cpp
@@ -8,48 +8,10 @@ namespace {
 
 const Logger kLogger("SoundSourceProviderRegistry");
 
-} // anonymous namespace
-
-void SoundSourceProviderRegistry::registerProvider(
-        const SoundSourceProviderPointer& pProvider) {
-    const QStringList supportedFileExtensions(
-            pProvider->getSupportedFileExtensions());
-    if (supportedFileExtensions.isEmpty()) {
-        kLogger.warning() << "SoundSource provider"
-                          << pProvider->getDisplayName()
-                          << "does not support any file extensions";
-        return; // abort registration
-    }
-    for (const auto& fileExt : supportedFileExtensions) {
-        SoundSourceProviderPriority providerPriority(
-                pProvider->getPriorityHint(fileExt));
-        registerProviderForFileExtension(
-                fileExt,
-                pProvider,
-                providerPriority);
-    }
-}
-
-void SoundSourceProviderRegistry::registerProviderForFileExtension(
-        const QString& fileExtension,
-        const SoundSourceProviderPointer& pProvider,
-        SoundSourceProviderPriority providerPriority) {
-    SoundSourceProviderRegistration registration(pProvider, providerPriority);
-    addRegistrationForFileExtension(fileExtension, std::move(registration));
-}
-
-void SoundSourceProviderRegistry::addRegistrationForFileExtension(
-        const QString& fileExtension,
-        SoundSourceProviderRegistration registration) {
-    DEBUG_ASSERT(registration.getProvider());
-    QList<SoundSourceProviderRegistration>& registrationsForFileExtension =
-            m_registry[fileExtension];
-    insertRegistration(&registrationsForFileExtension, registration);
-}
-
-void SoundSourceProviderRegistry::insertRegistration(
+void insertRegistration(
         QList<SoundSourceProviderRegistration>* pRegistrations,
-        SoundSourceProviderRegistration registration) {
+        SoundSourceProviderRegistration&& registration) {
+    DEBUG_ASSERT(pRegistrations);
     QList<SoundSourceProviderRegistration>::iterator listIter(
             pRegistrations->begin());
     // Perform a linear search through the list & insert
@@ -71,33 +33,65 @@ void SoundSourceProviderRegistry::insertRegistration(
     }
 }
 
-void SoundSourceProviderRegistry::deregisterProvider(
+} // anonymous namespace
+
+int SoundSourceProviderRegistry::registerProvider(
         const SoundSourceProviderPointer& pProvider) {
+    VERIFY_OR_DEBUG_ASSERT(pProvider) {
+        return 0;
+    }
+    const QString displayName = pProvider->getDisplayName();
+    VERIFY_OR_DEBUG_ASSERT(!displayName.isEmpty()) {
+        return 0;
+    }
+    kLogger.debug()
+            << "Registering provider"
+            << displayName;
+    {
+        // Due to the debug assertion this code is not testable
+        const auto pProviderByDisplayName = m_providersByDisplayName.value(displayName);
+        VERIFY_OR_DEBUG_ASSERT(!pProviderByDisplayName) {
+            if (pProviderByDisplayName == pProvider) {
+                kLogger.info()
+                        << "Ignoring repeated registration of the same provider"
+                        << displayName;
+            } else {
+                kLogger.warning()
+                        << "Cannot register different providers with the same display name"
+                        << displayName;
+            }
+            return 0;
+        }
+    }
     const QStringList supportedFileExtensions(
             pProvider->getSupportedFileExtensions());
-    for (const auto& fileExt : supportedFileExtensions) {
-        deregisterProviderForFileExtension(fileExt, pProvider);
+    if (supportedFileExtensions.isEmpty()) {
+        kLogger.warning()
+                << "SoundSource provider"
+                << displayName
+                << "does not support any file extensions";
+        return 0; // abort registration
     }
-}
-
-void SoundSourceProviderRegistry::deregisterProviderForFileExtension(
-        const QString& fileExtension,
-        const SoundSourceProviderPointer& pProvider) {
-    auto registryIter(m_registry.find(fileExtension));
-    if (m_registry.end() != registryIter) {
-        QList<SoundSourceProviderRegistration>& registrationsForFileExtension = registryIter.value();
-        auto listIter = registrationsForFileExtension.begin();
-        while (registrationsForFileExtension.end() != listIter) {
-            if (listIter->getProvider() == pProvider) {
-                listIter = registrationsForFileExtension.erase(listIter);
-            } else {
-                ++listIter;
-            }
-        }
-        if (registrationsForFileExtension.isEmpty()) {
-            m_registry.erase(registryIter);
-        }
+    for (const auto& fileExtension : supportedFileExtensions) {
+        const auto priority =
+                pProvider->getPriorityHint(fileExtension);
+        kLogger.debug()
+                << "Registering file extension"
+                << fileExtension
+                << "for provider"
+                << displayName
+                << "with priority"
+                << priority;
+        SoundSourceProviderRegistration registration(pProvider, priority);
+        QList<SoundSourceProviderRegistration>& registrationsForFileExtension =
+                m_registry[fileExtension];
+        insertRegistration(
+                &registrationsForFileExtension,
+                std::move(registration));
     }
+    m_providersByDisplayName.insert(displayName, pProvider);
+    DEBUG_ASSERT(m_providersByDisplayName.count(displayName) == 1);
+    return supportedFileExtensions.size();
 }
 
 QList<SoundSourceProviderRegistration>
@@ -105,8 +99,12 @@ SoundSourceProviderRegistry::getRegistrationsForFileExtension(
         const QString& fileExtension) const {
     auto i = m_registry.constFind(fileExtension);
     if (m_registry.constEnd() != i) {
+        DEBUG_ASSERT(!i.value().isEmpty());
         return i.value();
     } else {
+        kLogger.debug()
+                << "No provider(s) registered for file extension"
+                << fileExtension;
         return QList<SoundSourceProviderRegistration>();
     }
 }

--- a/src/sources/soundsourceproviderregistry.cpp
+++ b/src/sources/soundsourceproviderregistry.cpp
@@ -84,7 +84,7 @@ int SoundSourceProviderRegistry::registerProvider(
                 << priority;
         SoundSourceProviderRegistration registration(pProvider, priority);
         QList<SoundSourceProviderRegistration>& registrationsForFileExtension =
-                m_registry[fileExtension];
+                m_registrationListsByFileExtension[fileExtension];
         insertRegistration(
                 &registrationsForFileExtension,
                 std::move(registration));
@@ -97,8 +97,8 @@ int SoundSourceProviderRegistry::registerProvider(
 QList<SoundSourceProviderRegistration>
 SoundSourceProviderRegistry::getRegistrationsForFileExtension(
         const QString& fileExtension) const {
-    auto i = m_registry.constFind(fileExtension);
-    if (m_registry.constEnd() != i) {
+    auto i = m_registrationListsByFileExtension.constFind(fileExtension);
+    if (m_registrationListsByFileExtension.constEnd() != i) {
         DEBUG_ASSERT(!i.value().isEmpty());
         return i.value();
     } else {

--- a/src/sources/soundsourceproviderregistry.cpp
+++ b/src/sources/soundsourceproviderregistry.cpp
@@ -16,7 +16,7 @@ void SoundSourceProviderRegistry::registerProvider(
             pProvider->getSupportedFileExtensions());
     if (supportedFileExtensions.isEmpty()) {
         kLogger.warning() << "SoundSource provider"
-                          << pProvider->getName()
+                          << pProvider->getDisplayName()
                           << "does not support any file extensions";
         return; // abort registration
     }

--- a/src/sources/soundsourceproviderregistry.h
+++ b/src/sources/soundsourceproviderregistry.h
@@ -47,7 +47,7 @@ class SoundSourceProviderRegistry {
             const SoundSourceProviderPointer& pProvider);
 
     QStringList getRegisteredFileExtensions() const {
-        return m_registry.keys();
+        return m_registrationListsByFileExtension.keys();
     }
 
     /// Returns all registrations for the given file extension.
@@ -70,11 +70,12 @@ class SoundSourceProviderRegistry {
     }
 
   private:
-    typedef QMap<QString, QList<SoundSourceProviderRegistration>> FileExtension2RegistrationList;
-    FileExtension2RegistrationList m_registry;
+    typedef QMap<QString, QList<SoundSourceProviderRegistration>>
+            RegistrationListByFileExtensionMap;
+    RegistrationListByFileExtensionMap m_registrationListsByFileExtension;
 
-    typedef QMap<QString, SoundSourceProviderPointer> DisplayName2Provider;
-    DisplayName2Provider m_providersByDisplayName;
+    typedef QMap<QString, SoundSourceProviderPointer> ProviderByDisplayNameMap;
+    ProviderByDisplayNameMap m_providersByDisplayName;
 };
 
 } // namespace mixxx

--- a/src/sources/soundsourceproviderregistry.h
+++ b/src/sources/soundsourceproviderregistry.h
@@ -1,17 +1,23 @@
-#ifndef MIXXX_SOUNDSOURCEPROVIDERREGISTRY_H
-#define MIXXX_SOUNDSOURCEPROVIDERREGISTRY_H
+#pragma once
 
 #include <QMap>
 
 #include "sources/soundsourceprovider.h"
+#include "util/optional.h"
 
 namespace mixxx {
 
-class SoundSourceProviderRegistration {
+class SoundSourceProviderRegistration final {
   public:
+    SoundSourceProviderRegistration(SoundSourceProviderRegistration&&) = default;
+    SoundSourceProviderRegistration(const SoundSourceProviderRegistration&) = default;
+    SoundSourceProviderRegistration& operator=(SoundSourceProviderRegistration&&) = default;
+    SoundSourceProviderRegistration& operator=(const SoundSourceProviderRegistration&) = default;
+
     const SoundSourceProviderPointer& getProvider() const {
         return m_pProvider;
     }
+
     SoundSourceProviderPriority getProviderPriority() const {
         return m_providerPriority;
     }
@@ -21,62 +27,54 @@ class SoundSourceProviderRegistration {
     SoundSourceProviderRegistration(
             SoundSourceProviderPointer pProvider,
             SoundSourceProviderPriority providerPriority)
-            : m_pProvider(pProvider),
+            : m_pProvider(std::move(pProvider)),
               m_providerPriority(providerPriority) {
+        DEBUG_ASSERT(m_pProvider);
     }
 
     SoundSourceProviderPointer m_pProvider;
     SoundSourceProviderPriority m_providerPriority;
 };
 
-// Registry for SoundSourceProviders
+/// Registry for SoundSourceProviders
 class SoundSourceProviderRegistry {
   public:
-    // Registers a provider for all supported file extensions
-    // with their cooperative priority hint.
-    void registerProvider(
-            const SoundSourceProviderPointer& pProvider);
-
-    // Registers a provider for a single file extension with an
-    // explicitly specified priority. The provider must support
-    // the given file extension.
-    void registerProviderForFileExtension(
-            const QString& fileExtension,
-            const SoundSourceProviderPointer& pProvider,
-            SoundSourceProviderPriority providerPriority);
-
-    // Deregisters a provider for all supported file extensions.
-    void deregisterProvider(
-            const SoundSourceProviderPointer& pProvider);
-    // Deregisters a provider for a single file extension.
-    void deregisterProviderForFileExtension(
-            const QString& fileExtension,
+    /// Register a provider for all supported file extensions
+    /// with their cooperative priority hint.
+    ///
+    /// Returns the number of registered file extensions.
+    int registerProvider(
             const SoundSourceProviderPointer& pProvider);
 
     QStringList getRegisteredFileExtensions() const {
         return m_registry.keys();
     }
 
-    // Returns all registrations for the given file extension.
-    // If no providers have been registered for this file extension
-    // an empty list will be returned.
+    /// Returns all registrations for the given file extension.
+    /// If no providers have been registered for this file extension
+    /// an empty list will be returned.
     QList<SoundSourceProviderRegistration> getRegistrationsForFileExtension(
             const QString& fileExtension) const;
 
+    /// Returns the primary provider registration for the given file
+    /// extensions if available.
+    std::optional<SoundSourceProviderRegistration> getPrimaryRegistrationForFileExtension(
+            const QString& fileExtension) const {
+        const auto registrations =
+                getRegistrationsForFileExtension(fileExtension);
+        if (registrations.isEmpty()) {
+            return std::nullopt;
+        } else {
+            return std::make_optional(registrations.first());
+        }
+    }
+
   private:
-    void addRegistrationForFileExtension(
-            const QString& fileExtension,
-            SoundSourceProviderRegistration registration);
-
-    static void insertRegistration(
-            QList<SoundSourceProviderRegistration>* pRegistrations,
-            SoundSourceProviderRegistration registration);
-
     typedef QMap<QString, QList<SoundSourceProviderRegistration>> FileExtension2RegistrationList;
-
     FileExtension2RegistrationList m_registry;
+
+    typedef QMap<QString, SoundSourceProviderPointer> DisplayName2Provider;
+    DisplayName2Provider m_providersByDisplayName;
 };
 
 } // namespace mixxx
-
-#endif // MIXXX_SOUNDSOURCEPROVIDERREGISTRY_H

--- a/src/sources/soundsourceproviderregistry.h
+++ b/src/sources/soundsourceproviderregistry.h
@@ -69,6 +69,19 @@ class SoundSourceProviderRegistry {
         }
     }
 
+    /// Returns the primary provider for the given file
+    /// extensions if available.
+    SoundSourceProviderPointer getPrimaryProviderForFileExtension(
+            const QString& fileExtension) const {
+        const auto optProviderRegistration =
+                getPrimaryRegistrationForFileExtension(fileExtension);
+        if (optProviderRegistration) {
+            return optProviderRegistration->getProvider();
+        } else {
+            return nullptr;
+        }
+    }
+
   private:
     typedef QMap<QString, QList<SoundSourceProviderRegistration>>
             RegistrationListByFileExtensionMap;

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -113,7 +113,7 @@ void SoundSourceProxy::registerSoundSourceProviders() {
                             supportedFileExtension));
             for (const auto& registration : registrationsForFileExtension) {
                 kLogger.info() << " " << static_cast<int>(registration.getProviderPriority())
-                               << ":" << registration.getProvider()->getName();
+                               << ":" << registration.getProvider()->getDisplayName();
             }
         }
     }
@@ -284,7 +284,7 @@ void SoundSourceProxy::initSoundSource() {
         m_pSoundSource = pProvider->newSoundSource(m_url);
         if (!m_pSoundSource) {
             kLogger.warning() << "SoundSourceProvider"
-                              << pProvider->getName()
+                              << pProvider->getDisplayName()
                               << "failed to create a SoundSource for file"
                               << getUrl().toString();
             // Switch to next provider...
@@ -294,7 +294,7 @@ void SoundSourceProxy::initSoundSource() {
         } else {
             if (kLogger.debugEnabled()) {
                 kLogger.debug() << "SoundSourceProvider"
-                                << pProvider->getName()
+                                << pProvider->getDisplayName()
                                 << "created a SoundSource for file"
                                 << getUrl().toString()
                                 << "of type"
@@ -513,14 +513,14 @@ mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const mixxx::AudioSo
                     << "Failed to read file"
                     << getUrl().toString()
                     << "with provider"
-                    << getSoundSourceProvider()->getName();
+                    << getSoundSourceProvider()->getDisplayName();
             m_pSoundSource->close(); // cleanup
         } else {
             kLogger.warning()
                     << "Failed to open file"
                     << getUrl().toString()
                     << "with provider"
-                    << getSoundSourceProvider()->getName()
+                    << getSoundSourceProvider()->getDisplayName()
                     << "using mode"
                     << openMode;
             if (openMode == mixxx::SoundSource::OpenMode::Permissive) {

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -176,7 +176,7 @@ mixxx::SoundSourceProviderPointer SoundSourceProxy::getPrimaryProviderForFileExt
     if (optProviderRegistration) {
         return optProviderRegistration->getProvider();
     } else {
-        return {};
+        return nullptr;
     }
 }
 

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -167,6 +167,19 @@ bool SoundSourceProxy::isFileExtensionSupported(const QString& fileExtension) {
     return !s_soundSourceProviders.getRegistrationsForFileExtension(fileExtension).isEmpty();
 }
 
+//static
+mixxx::SoundSourceProviderPointer SoundSourceProxy::getPrimaryProviderForFileExtension(
+        const QString& fileExtension) {
+    const auto optProviderRegistration =
+            s_soundSourceProviders.getPrimaryRegistrationForFileExtension(
+                    fileExtension);
+    if (optProviderRegistration) {
+        return optProviderRegistration->getProvider();
+    } else {
+        return {};
+    }
+}
+
 // static
 QList<mixxx::SoundSourceProviderRegistration>
 SoundSourceProxy::findSoundSourceProviderRegistrations(

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -365,7 +365,7 @@ SoundSourceProxy::SoundSourceProxy(
         : m_pTrack(std::move(pTrack)),
           m_url(m_pTrack ? m_pTrack->getFileInfo().toUrl() : QUrl()),
           m_providerRegistrations(allProviderRegistrationsForUrl(m_url)),
-          m_providerRegistrationIndex(pProvider ? -1 : 0) {
+          m_providerRegistrationIndex(-1) {
     initSoundSource(pProvider);
 }
 
@@ -374,7 +374,7 @@ SoundSourceProxy::SoundSourceProxy(
         const mixxx::SoundSourceProviderPointer& pProvider)
         : m_url(url),
           m_providerRegistrations(allProviderRegistrationsForUrl(m_url)),
-          m_providerRegistrationIndex(pProvider ? -1 : 0) {
+          m_providerRegistrationIndex(-1) {
     initSoundSource(pProvider);
 }
 

--- a/src/sources/soundsourceproxy.h
+++ b/src/sources/soundsourceproxy.h
@@ -5,14 +5,17 @@
 #include "track/trackfile.h"
 #include "util/sandbox.h"
 
-// Creates sound sources for tracks. Only intended to be used
-// in a narrow scope and not shareable between multiple threads!
+/// Creates sound sources for tracks. Only intended to be used
+/// in a narrow scope and not shareable between multiple threads!
 class SoundSourceProxy {
   public:
-    // Initially registers all built-in SoundSource providers. This function is
-    // not thread-safe and must be called only once upon startup of the
-    // application.
-    static void registerSoundSourceProviders();
+    /// Initially registers all built-in SoundSource providers. This function is
+    /// not thread-safe and must be called only once upon startup of the
+    /// application.
+    ///
+    /// Returns true if providers for one or more file extensions have been
+    /// registered.
+    static bool registerSoundSourceProviders();
 
     static QStringList getSupportedFileExtensions() {
         return s_soundSourceProviders.getRegisteredFileExtensions();

--- a/src/sources/soundsourceproxy.h
+++ b/src/sources/soundsourceproxy.h
@@ -55,16 +55,30 @@ class SoundSourceProxy {
             TrackPointer pTrack,
             const mixxx::SoundSourceProviderPointer& pProvider = nullptr);
 
+    /// The track object that has been passed at construction.
+    ///
+    /// Holding an internal pointer to the track object ensures
+    /// that all write operations to this file are deferred until
+    /// the track object is released and not accessed concurrently.
     const TrackPointer& getTrack() const {
         return m_pTrack;
     }
 
+    /// The URL of the audio file referenced by the track.
     const QUrl& getUrl() const {
         return m_url;
     }
 
-    // Controls which (metadata/coverart) and how tags are (re-)imported from
-    // audio files when creating a SoundSourceProxy.
+    /// The provider that is currently in use.
+    ///
+    /// Note: This might change later after construction when actually
+    /// trying to read the audio stream with openAudioSource()!
+    const mixxx::SoundSourceProviderPointer& getProvider() const {
+        return m_pProvider;
+    }
+
+    /// Controls which (metadata/coverart) and how tags are (re-)imported from
+    /// audio files when creating a SoundSourceProxy.
     enum class ImportTrackMetadataMode {
         // Import both track metadata and cover image once for new track objects.
         // Otherwise the request is ignored and the track object is not modified.
@@ -79,40 +93,50 @@ class SoundSourceProxy {
         Default = Once,
     };
 
-    // Updates file type, metadata, and cover image of the track object
-    // from the source file according to the given mode.
-    //
-    // The track's type will always be set as recognized by the corresponding
-    // SoundSource.
-    //
-    // Importing of metadata and cover image is skipped if the track object
-    // is marked as dirty or if mode=Once and the import has already been
-    // performed once. Otherwise track metadata is set according to the metadata
-    // imported from the file.
-    //
-    // An existing cover image is only replaced if it also has been imported
-    // from the file. Custom cover images that have been selected by the user
-    // are preserved.
-    //
-    // This function works in a best effort manner without returning a value.
-    // Only the track object will be modified as a side effect. There are simply
-    // too many possible reasons for failure to consider that cannot be handled
-    // properly. The application log will contain warning messages for a detailed
-    // analysis in case unexpected behavior has been reported.
+    /// Updates file type, metadata, and cover image of the track object
+    /// from the source file according to the given mode.
+    ///
+    /// The track's type will always be set as recognized by the corresponding
+    /// SoundSource.
+    ///
+    /// Importing of metadata and cover image is skipped if the track object
+    /// is marked as dirty or if mode=Once and the import has already been
+    /// performed once. Otherwise track metadata is set according to the metadata
+    /// imported from the file.
+    ///
+    /// An existing cover image is only replaced if it also has been imported
+    /// from the file. Custom cover images that have been selected by the user
+    /// are preserved.
+    ///
+    /// This function works in a best effort manner without returning a value.
+    /// Only the track object will be modified as a side effect. There are simply
+    /// too many possible reasons for failure to consider that cannot be handled
+    /// properly. The application log will contain warning messages for a detailed
+    /// analysis in case unexpected behavior has been reported.
     void updateTrackFromSource(
             ImportTrackMetadataMode importTrackMetadataMode = ImportTrackMetadataMode::Default);
 
-    // Parse only the metadata from the file without modifying
-    // the referenced track.
+    /// Parse only the metadata from the file without modifying
+    /// the referenced track.
     mixxx::MetadataSource::ImportResult importTrackMetadata(
             mixxx::TrackMetadata* pTrackMetadata) const;
 
-    // Opening the audio source through the proxy will update the
-    // audio properties of the corresponding track object. Returns
-    // a null pointer on failure.
+    /// Opening the audio source through the proxy will update the
+    /// audio properties of the corresponding track object. Returns
+    /// a null pointer on failure.
+    ///
+    /// Note: If opening the audio stream fails the selection
+    /// process may continue among the available providers and
+    /// sound sources might be resumed and continue until a
+    /// usable provider that could open the stream has been
+    /// found.
     mixxx::AudioSourcePointer openAudioSource(
             const mixxx::AudioSource::OpenParams& params = mixxx::AudioSource::OpenParams());
 
+    /// Explicitly close the AudioSource.
+    ///
+    /// This will happen implicitly when the instance goes out
+    /// of scope, i.e. upon destruction.
     void closeAudioSource();
 
   private:
@@ -138,6 +162,10 @@ class SoundSourceProxy {
     const QUrl m_url;
 
     const QList<mixxx::SoundSourceProviderRegistration> m_providerRegistrations;
+
+    // Keeps track of the provider selection when creating the proxy
+    // and while trying to open audio files. Starts at 0 for the primary
+    // provider and is initialized with -1 if no
     int m_providerRegistrationIndex;
 
     void initSoundSource(
@@ -149,6 +177,9 @@ class SoundSourceProxy {
     std::pair<mixxx::SoundSourceProviderPointer, mixxx::SoundSource::OpenMode>
             nextProviderWithOpenMode(mixxx::SoundSource::OpenMode);
 
+    // The provider that has actually been used to create the
+    // SoundSource (see below). Always set in conjunction with
+    // the SoundSource.
     mixxx::SoundSourceProviderPointer m_pProvider;
 
     // This pointer must stay in this class together with

--- a/src/sources/soundsourceproxy.h
+++ b/src/sources/soundsourceproxy.h
@@ -32,6 +32,8 @@ class SoundSourceProxy {
     static bool isFileSupported(const QFileInfo& fileInfo);
     static bool isFileNameSupported(const QString& fileName);
     static bool isFileExtensionSupported(const QString& fileExtension);
+    static mixxx::SoundSourceProviderPointer getPrimaryProviderForFileExtension(
+            const QString& fileExtension);
 
     // The following import functions ensure that the file will not be
     // written while reading it!

--- a/src/sources/soundsourcesndfile.cpp
+++ b/src/sources/soundsourcesndfile.cpp
@@ -10,6 +10,20 @@ namespace {
 
 const Logger kLogger("SoundSourceSndFile");
 
+const QString kDisplayName = QStringLiteral("libsndfile");
+
+const QStringList kSupportedFileExtensions = {
+        QStringLiteral("aif"),
+        QStringLiteral("aiff"),
+        // ALAC/CAF has been added in version 1.0.26
+        // NOTE(uklotzde, 2015-05-26): Unfortunately ALAC in M4A containers
+        // is still not supported https://github.com/mixxxdj/mixxx/pull/904#issuecomment-221928362
+        QStringLiteral("caf"),
+        QStringLiteral("flac"),
+        QStringLiteral("ogg"),
+        QStringLiteral("wav"),
+};
+
 } // anonymous namespace
 
 SoundSourceSndFile::SoundSourceSndFile(const QUrl& url)
@@ -128,27 +142,17 @@ ReadableSampleFrames SoundSourceSndFile::readSampleFramesClamped(
 }
 
 QString SoundSourceProviderSndFile::getName() const {
-    return "libsndfile";
+    return kDisplayName;
 }
 
 QStringList SoundSourceProviderSndFile::getSupportedFileExtensions() const {
-    QStringList supportedFileExtensions;
-    supportedFileExtensions.append("aif");
-    supportedFileExtensions.append("aiff");
-    // ALAC/CAF has been added in version 1.0.26
-    // NOTE(uklotzde, 2015-05-26): Unfortunately ALAC in M4A containers
-    // is still not supported https://github.com/mixxxdj/mixxx/pull/904#issuecomment-221928362
-    supportedFileExtensions.append("caf");
-    supportedFileExtensions.append("flac");
-    supportedFileExtensions.append("ogg");
-    supportedFileExtensions.append("wav");
-    return supportedFileExtensions;
+    return kSupportedFileExtensions;
 }
 
 SoundSourceProviderPriority SoundSourceProviderSndFile::getPriorityHint(
         const QString& supportedFileExtension) const {
-    if (supportedFileExtension.startsWith("aif") ||
-            supportedFileExtension == "wav") {
+    if (supportedFileExtension.startsWith(QStringLiteral("aif")) ||
+            supportedFileExtension == QStringLiteral("wav")) {
         // Default decoder for AIFF and WAV
         return SoundSourceProviderPriority::DEFAULT;
     } else {

--- a/src/sources/soundsourcesndfile.cpp
+++ b/src/sources/soundsourcesndfile.cpp
@@ -10,8 +10,6 @@ namespace {
 
 const Logger kLogger("SoundSourceSndFile");
 
-const QString kDisplayName = QStringLiteral("libsndfile");
-
 const QStringList kSupportedFileExtensions = {
         QStringLiteral("aif"),
         QStringLiteral("aiff"),
@@ -25,6 +23,25 @@ const QStringList kSupportedFileExtensions = {
 };
 
 } // anonymous namespace
+
+//static
+const QString SoundSourceProviderSndFile::kDisplayName = QStringLiteral("libsndfile");
+
+QStringList SoundSourceProviderSndFile::getSupportedFileExtensions() const {
+    return kSupportedFileExtensions;
+}
+
+SoundSourceProviderPriority SoundSourceProviderSndFile::getPriorityHint(
+        const QString& supportedFileExtension) const {
+    if (supportedFileExtension.startsWith(QStringLiteral("aif")) ||
+            supportedFileExtension == QStringLiteral("wav")) {
+        // Default decoder for AIFF and WAV
+        return SoundSourceProviderPriority::Default;
+    } else {
+        // Otherwise only used as fallback
+        return SoundSourceProviderPriority::Lower;
+    }
+}
 
 SoundSourceSndFile::SoundSourceSndFile(const QUrl& url)
         : SoundSource(url),
@@ -138,26 +155,6 @@ ReadableSampleFrames SoundSourceSndFile::readSampleFramesClamped(
                 IndexRange::between(
                         m_curFrameIndex,
                         m_curFrameIndex));
-    }
-}
-
-QString SoundSourceProviderSndFile::getName() const {
-    return kDisplayName;
-}
-
-QStringList SoundSourceProviderSndFile::getSupportedFileExtensions() const {
-    return kSupportedFileExtensions;
-}
-
-SoundSourceProviderPriority SoundSourceProviderSndFile::getPriorityHint(
-        const QString& supportedFileExtension) const {
-    if (supportedFileExtension.startsWith(QStringLiteral("aif")) ||
-            supportedFileExtension == QStringLiteral("wav")) {
-        // Default decoder for AIFF and WAV
-        return SoundSourceProviderPriority::DEFAULT;
-    } else {
-        // Otherwise only used as fallback
-        return SoundSourceProviderPriority::LOWER;
     }
 }
 

--- a/src/sources/soundsourcesndfile.h
+++ b/src/sources/soundsourcesndfile.h
@@ -37,6 +37,8 @@ class SoundSourceProviderSndFile : public SoundSourceProvider {
   public:
     static const QString kDisplayName;
 
+    SoundSourceProviderSndFile();
+
     QString getDisplayName() const override {
         return kDisplayName;
     }
@@ -49,6 +51,9 @@ class SoundSourceProviderSndFile : public SoundSourceProvider {
     SoundSourcePointer newSoundSource(const QUrl& url) override {
         return newSoundSourceFromUrl<SoundSourceSndFile>(url);
     }
+
+  private:
+    const QStringList m_supportedFileExtensions;
 };
 
 } // namespace mixxx

--- a/src/sources/soundsourcesndfile.h
+++ b/src/sources/soundsourcesndfile.h
@@ -1,5 +1,4 @@
-#ifndef MIXXX_SOUNDSOURCESNDFILE_H
-#define MIXXX_SOUNDSOURCESNDFILE_H
+#pragma once
 
 #include "sources/soundsourceprovider.h"
 
@@ -36,7 +35,11 @@ class SoundSourceSndFile final : public SoundSource {
 
 class SoundSourceProviderSndFile : public SoundSourceProvider {
   public:
-    QString getName() const override;
+    static const QString kDisplayName;
+
+    QString getDisplayName() const override {
+        return kDisplayName;
+    }
 
     QStringList getSupportedFileExtensions() const override;
 
@@ -49,5 +52,3 @@ class SoundSourceProviderSndFile : public SoundSourceProvider {
 };
 
 } // namespace mixxx
-
-#endif // MIXXX_SOUNDSOURCESNDFILE_H

--- a/src/sources/soundsourcewv.cpp
+++ b/src/sources/soundsourcewv.cpp
@@ -11,6 +11,12 @@ namespace {
 
 const Logger kLogger("SoundSourceWV");
 
+const QString kDisplayName = QStringLiteral("WavPack");
+
+const QStringList kSupportedFileExtensions = {
+        QStringLiteral("wv"),
+};
+
 static WavpackStreamReader s_streamReader = {
         SoundSourceWV::ReadBytesCallback,
         SoundSourceWV::GetPosCallback,
@@ -24,7 +30,7 @@ static WavpackStreamReader s_streamReader = {
 } // anonymous namespace
 
 SoundSourceWV::SoundSourceWV(const QUrl& url)
-        : SoundSource(url, "wv"),
+        : SoundSource(url),
           m_wpc(nullptr),
           m_sampleScaleFactor(CSAMPLE_ZERO),
           m_pWVFile(nullptr),
@@ -156,10 +162,6 @@ ReadableSampleFrames SoundSourceWV::readSampleFramesClamped(
                     getSignalInfo().frames2samples(unpackCount)));
 }
 
-QString SoundSourceProviderWV::getName() const {
-    return "WavPack";
-}
-
 //static
 int32_t SoundSourceWV::ReadBytesCallback(void* id, void* data, int bcount) {
     QFile* pFile = static_cast<QFile*>(id);
@@ -243,10 +245,12 @@ int32_t SoundSourceWV::WriteBytesCallback(void* id, void* data, int32_t bcount) 
     return (int32_t)pFile->write((char*)data, bcount);
 }
 
+QString SoundSourceProviderWV::getName() const {
+    return kDisplayName;
+}
+
 QStringList SoundSourceProviderWV::getSupportedFileExtensions() const {
-    QStringList supportedFileExtensions;
-    supportedFileExtensions.append("wv");
-    return supportedFileExtensions;
+    return kSupportedFileExtensions;
 }
 
 SoundSourceProviderPriority SoundSourceProviderWV::getPriorityHint(

--- a/src/sources/soundsourcewv.cpp
+++ b/src/sources/soundsourcewv.cpp
@@ -10,10 +10,6 @@ namespace {
 
 const Logger kLogger("SoundSourceWV");
 
-const QStringList kSupportedFileExtensions = {
-        QStringLiteral("wv"),
-};
-
 static WavpackStreamReader s_streamReader = {
         SoundSourceWV::ReadBytesCallback,
         SoundSourceWV::GetPosCallback,
@@ -29,9 +25,10 @@ static WavpackStreamReader s_streamReader = {
 //static
 const QString SoundSourceProviderWV::kDisplayName = QStringLiteral("WavPack");
 
-QStringList SoundSourceProviderWV::getSupportedFileExtensions() const {
-    return kSupportedFileExtensions;
-}
+//static
+const QStringList SoundSourceProviderWV::kSupportedFileExtensions = {
+        QStringLiteral("wv"),
+};
 
 SoundSourceProviderPriority SoundSourceProviderWV::getPriorityHint(
         const QString& supportedFileExtension) const {

--- a/src/sources/soundsourcewv.cpp
+++ b/src/sources/soundsourcewv.cpp
@@ -1,7 +1,6 @@
-#include <wavpack/wavpack.h>
-#include <QFile>
-
 #include "sources/soundsourcewv.h"
+
+#include <wavpack/wavpack.h>
 
 #include "util/logger.h"
 
@@ -10,8 +9,6 @@ namespace mixxx {
 namespace {
 
 const Logger kLogger("SoundSourceWV");
-
-const QString kDisplayName = QStringLiteral("WavPack");
 
 const QStringList kSupportedFileExtensions = {
         QStringLiteral("wv"),
@@ -28,6 +25,24 @@ static WavpackStreamReader s_streamReader = {
         SoundSourceWV::WriteBytesCallback};
 
 } // anonymous namespace
+
+//static
+const QString SoundSourceProviderWV::kDisplayName = QStringLiteral("WavPack");
+
+QStringList SoundSourceProviderWV::getSupportedFileExtensions() const {
+    return kSupportedFileExtensions;
+}
+
+SoundSourceProviderPriority SoundSourceProviderWV::getPriorityHint(
+        const QString& /*supportedFileExtension*/) const {
+    // This reference decoder is supposed to produce more accurate
+    // and reliable results than any other DEFAULT provider.
+    return SoundSourceProviderPriority::Higher;
+}
+
+SoundSourcePointer SoundSourceProviderWV::newSoundSource(const QUrl& url) {
+    return newSoundSourceFromUrl<SoundSourceWV>(url);
+}
 
 SoundSourceWV::SoundSourceWV(const QUrl& url)
         : SoundSource(url),
@@ -243,25 +258,6 @@ int32_t SoundSourceWV::WriteBytesCallback(void* id, void* data, int32_t bcount) 
         return 0;
     }
     return (int32_t)pFile->write((char*)data, bcount);
-}
-
-QString SoundSourceProviderWV::getName() const {
-    return kDisplayName;
-}
-
-QStringList SoundSourceProviderWV::getSupportedFileExtensions() const {
-    return kSupportedFileExtensions;
-}
-
-SoundSourceProviderPriority SoundSourceProviderWV::getPriorityHint(
-        const QString& /*supportedFileExtension*/) const {
-    // This reference decoder is supposed to produce more accurate
-    // and reliable results than any other DEFAULT provider.
-    return SoundSourceProviderPriority::HIGHER;
-}
-
-SoundSourcePointer SoundSourceProviderWV::newSoundSource(const QUrl& url) {
-    return newSoundSourceFromUrl<SoundSourceWV>(url);
 }
 
 } // namespace mixxx

--- a/src/sources/soundsourcewv.cpp
+++ b/src/sources/soundsourcewv.cpp
@@ -34,7 +34,8 @@ QStringList SoundSourceProviderWV::getSupportedFileExtensions() const {
 }
 
 SoundSourceProviderPriority SoundSourceProviderWV::getPriorityHint(
-        const QString& /*supportedFileExtension*/) const {
+        const QString& supportedFileExtension) const {
+    Q_UNUSED(supportedFileExtension)
     // This reference decoder is supposed to produce more accurate
     // and reliable results than any other DEFAULT provider.
     return SoundSourceProviderPriority::Higher;

--- a/src/sources/soundsourcewv.h
+++ b/src/sources/soundsourcewv.h
@@ -33,12 +33,12 @@ class SoundSourceWV : public SoundSource {
             const OpenParams& params) override;
 
     // A WavpackContext* type
-    // we cannot use the type directly, because it has 
-    // changing definitions with different wavpack.h versions. 
-    // wavpack.h can't be included here, because it has concurrent definitions 
-    // with other decoder's header.     
+    // we cannot use the type directly, because it has
+    // changing definitions with different wavpack.h versions.
+    // wavpack.h can't be included here, because it has concurrent definitions
+    // with other decoder's header.
     void* m_wpc;
- 
+
     CSAMPLE m_sampleScaleFactor;
     QFile* m_pWVFile;
     QFile* m_pWVCFile;
@@ -48,7 +48,11 @@ class SoundSourceWV : public SoundSource {
 
 class SoundSourceProviderWV : public SoundSourceProvider {
   public:
-    QString getName() const override;
+    static const QString kDisplayName;
+
+    QString getDisplayName() const override {
+        return kDisplayName;
+    }
 
     QStringList getSupportedFileExtensions() const override;
 

--- a/src/sources/soundsourcewv.h
+++ b/src/sources/soundsourcewv.h
@@ -49,12 +49,15 @@ class SoundSourceWV : public SoundSource {
 class SoundSourceProviderWV : public SoundSourceProvider {
   public:
     static const QString kDisplayName;
+    static const QStringList kSupportedFileExtensions;
 
     QString getDisplayName() const override {
         return kDisplayName;
     }
 
-    QStringList getSupportedFileExtensions() const override;
+    QStringList getSupportedFileExtensions() const override {
+        return kSupportedFileExtensions;
+    }
 
     SoundSourceProviderPriority getPriorityHint(
             const QString& supportedFileExtension) const override;

--- a/src/test/directorydaotest.cpp
+++ b/src/test/directorydaotest.cpp
@@ -16,14 +16,8 @@
 
 using ::testing::UnorderedElementsAre;
 
-namespace {
-
 class DirectoryDAOTest : public LibraryTest {
   protected:
-    DirectoryDAOTest()
-            : m_supportedFileExt("." % SoundSourceProxy::getSupportedFileExtensions().first()) {
-    }
-
     void TearDown() override {
         // make sure we clean up the db
         QSqlQuery query(dbConnection());
@@ -35,7 +29,14 @@ class DirectoryDAOTest : public LibraryTest {
         query.exec();
     }
 
-    const QString m_supportedFileExt;
+    static QString getSupportedFileExt() {
+        const auto defaultFileExt = QStringLiteral("mp3");
+        if (SoundSourceProxy::isFileExtensionSupported(defaultFileExt)) {
+            return defaultFileExt;
+        } else {
+            return SoundSourceProxy::getSupportedFileExtensions().first();
+        }
+    }
 };
 
 TEST_F(DirectoryDAOTest, addDirTest) {
@@ -130,7 +131,7 @@ TEST_F(DirectoryDAOTest, getDirTest) {
 }
 
 TEST_F(DirectoryDAOTest, relocateDirTest) {
-    DirectoryDAO &directoryDao = internalCollection()->getDirectoryDAO();
+    DirectoryDAO& directoryDao = internalCollection()->getDirectoryDAO();
 
     // use a temp dir so that we always use a real existing system path
     QString testdir(QDir::tempPath() + "/TestDir");
@@ -141,10 +142,30 @@ TEST_F(DirectoryDAOTest, relocateDirTest) {
     directoryDao.addDirectory(test2);
 
     // ok now lets create some tracks here
-    internalCollection()->addTrack(Track::newTemporary(TrackFile(testdir, "a" + m_supportedFileExt)), false);
-    internalCollection()->addTrack(Track::newTemporary(TrackFile(testdir, "b" + m_supportedFileExt)), false);
-    internalCollection()->addTrack(Track::newTemporary(TrackFile(test2, "c" + m_supportedFileExt)), false);
-    internalCollection()->addTrack(Track::newTemporary(TrackFile(test2, "d" + m_supportedFileExt)), false);
+    ASSERT_TRUE(internalCollection()
+                        ->addTrack(
+                                Track::newTemporary(
+                                        TrackFile(testdir, "a." + getSupportedFileExt())),
+                                false)
+                        .isValid());
+    ASSERT_TRUE(internalCollection()
+                        ->addTrack(
+                                Track::newTemporary(
+                                        TrackFile(testdir, "b." + getSupportedFileExt())),
+                                false)
+                        .isValid());
+    ASSERT_TRUE(internalCollection()
+                        ->addTrack(
+                                Track::newTemporary(
+                                        TrackFile(test2, "c." + getSupportedFileExt())),
+                                false)
+                        .isValid());
+    ASSERT_TRUE(internalCollection()
+                        ->addTrack(
+                                Track::newTemporary(
+                                        TrackFile(test2, "d." + getSupportedFileExt())),
+                                false)
+                        .isValid());
 
     QList<RelocatedTrack> relocatedTracks =
             directoryDao.relocateDirectory(testdir, testnew);
@@ -154,5 +175,3 @@ TEST_F(DirectoryDAOTest, relocateDirTest) {
     EXPECT_EQ(2, dirs.size());
     EXPECT_THAT(dirs, UnorderedElementsAre(test2, testnew));
 }
-
-}  // namespace

--- a/src/test/mixxxtest.cpp
+++ b/src/test/mixxxtest.cpp
@@ -25,8 +25,10 @@ QScopedPointer<MixxxApplication> MixxxTest::s_pApplication;
 MixxxTest::ApplicationScope::ApplicationScope(int& argc, char** argv) {
     // Construct a list of strings based on the command line arguments
     CmdlineArgs args;
-    VERIFY_OR_DEBUG_ASSERT(args.Parse(argc, argv)) {
-    }
+    const bool argsParsed = args.Parse(argc, argv);
+    Q_UNUSED(argsParsed);
+    DEBUG_ASSERT(argsParsed);
+
     mixxx::LogLevel logLevel = args.getLogLevel();
 
     // Log level Debug would produce too many log messages that
@@ -45,8 +47,10 @@ MixxxTest::ApplicationScope::ApplicationScope(int& argc, char** argv) {
     DEBUG_ASSERT(s_pApplication.isNull());
     s_pApplication.reset(new MixxxApplication(argc, argv));
 
-    VERIFY_OR_DEBUG_ASSERT(SoundSourceProxy::registerSoundSourceProviders()) {
-    }
+    const bool providersRegistered =
+            SoundSourceProxy::registerSoundSourceProviders();
+    Q_UNUSED(providersRegistered);
+    DEBUG_ASSERT(providersRegistered);
 }
 
 MixxxTest::ApplicationScope::~ApplicationScope() {

--- a/src/test/mixxxtest.cpp
+++ b/src/test/mixxxtest.cpp
@@ -48,7 +48,7 @@ MixxxTest::ApplicationScope::ApplicationScope(int& argc, char** argv) {
     s_pApplication.reset(new MixxxApplication(argc, argv));
 
     const bool providersRegistered =
-            SoundSourceProxy::registerSoundSourceProviders();
+            SoundSourceProxy::registerProviders();
     Q_UNUSED(providersRegistered);
     DEBUG_ASSERT(providersRegistered);
 }

--- a/src/test/mixxxtest.h
+++ b/src/test/mixxxtest.h
@@ -15,13 +15,13 @@
 class MixxxTest : public testing::Test {
   public:
     MixxxTest();
-    virtual ~MixxxTest();
+    ~MixxxTest() override;
 
     // ApplicationScope creates QApplication as a singleton and keeps
     // it alive during all tests. This prevents issues with creating
     // and destroying the QApplication multiple times in the same process.
     // http://stackoverflow.com/questions/14243858/qapplication-segfaults-in-googletest
-    class ApplicationScope {
+    class ApplicationScope final {
       public:
         ApplicationScope(int& argc, char** argv);
         ~ApplicationScope();
@@ -47,7 +47,7 @@ class MixxxTest : public testing::Test {
   private:
     static QScopedPointer<MixxxApplication> s_pApplication;
 
-    QTemporaryDir m_testDataDir;
+    const QTemporaryDir m_testDataDir;
 
   protected:
     UserSettingsPointer m_pConfig;

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -83,9 +83,11 @@ class SoundSourceProxyTest : public MixxxTest {
         return filePaths;
     }
 
-    static mixxx::AudioSourcePointer openAudioSource(const QString& filePath) {
+    static mixxx::AudioSourcePointer openAudioSource(
+            const QString& filePath,
+            const mixxx::SoundSourceProviderPointer& pProvider = nullptr) {
         auto pTrack = Track::newTemporary(filePath);
-        SoundSourceProxy proxy(pTrack);
+        SoundSourceProxy proxy(pTrack, pProvider);
 
         // All test files are mono, but we are requesting a stereo signal
         // to test the upscaling of channels
@@ -160,20 +162,25 @@ class SoundSourceProxyTest : public MixxxTest {
 
 TEST_F(SoundSourceProxyTest, open) {
     // This test piggy-backs off of the cover-test files.
-    for (const auto& filePath: getFilePaths()) {
+    for (const auto& filePath : getFilePaths()) {
         ASSERT_TRUE(SoundSourceProxy::isFileNameSupported(filePath));
-
-        mixxx::AudioSourcePointer pAudioSource = openAudioSource(filePath);
-        // Obtaining an AudioSource may fail for unsupported file formats,
-        // even if the corresponding file extension is supported, e.g.
-        // AAC vs. ALAC in .m4a files
-        if (!pAudioSource) {
-            // skip test file
-            continue;
+        const auto fileUrl = QUrl::fromLocalFile(filePath);
+        for (const auto& providerRegistration :
+                SoundSourceProxy::allProviderRegistrationsForUrl(fileUrl)) {
+            mixxx::AudioSourcePointer pAudioSource = openAudioSource(
+                    filePath,
+                    providerRegistration.getProvider());
+            // Obtaining an AudioSource may fail for unsupported file formats,
+            // even if the corresponding file extension is supported, e.g.
+            // AAC vs. ALAC in .m4a files
+            if (!pAudioSource) {
+                // skip test file
+                continue;
+            }
+            EXPECT_LT(0, pAudioSource->getSignalInfo().getChannelCount());
+            EXPECT_LT(0, pAudioSource->getSignalInfo().getSampleRate());
+            EXPECT_FALSE(pAudioSource->frameIndexRange().empty());
         }
-        EXPECT_LT(0, pAudioSource->getSignalInfo().getChannelCount());
-        EXPECT_LT(0, pAudioSource->getSignalInfo().getSampleRate());
-        EXPECT_FALSE(pAudioSource->frameIndexRange().empty());
     }
 }
 
@@ -219,92 +226,17 @@ TEST_F(SoundSourceProxyTest, TOAL_TPE2) {
 TEST_F(SoundSourceProxyTest, seekForwardBackward) {
     const SINT kReadFrameCount = 10000;
 
-    for (const auto& filePath: getFilePaths()) {
+    for (const auto& filePath : getFilePaths()) {
         ASSERT_TRUE(SoundSourceProxy::isFileNameSupported(filePath));
-
         qDebug() << "Seek forward/backward test:" << filePath;
 
-        mixxx::AudioSourcePointer pContReadSource(openAudioSource(filePath));
-        // Obtaining an AudioSource may fail for unsupported file formats,
-        // even if the corresponding file extension is supported, e.g.
-        // AAC vs. ALAC in .m4a files
-        if (!pContReadSource) {
-            // skip test file
-            continue;
-        }
-        mixxx::SampleBuffer contReadData(
-                pContReadSource->getSignalInfo().frames2samples(kReadFrameCount));
-        mixxx::SampleBuffer seekReadData(
-                pContReadSource->getSignalInfo().frames2samples(kReadFrameCount));
+        const auto fileUrl = QUrl::fromLocalFile(filePath);
+        for (const auto& providerRegistration :
+                SoundSourceProxy::allProviderRegistrationsForUrl(fileUrl)) {
+            mixxx::AudioSourcePointer pContReadSource = openAudioSource(
+                    filePath,
+                    providerRegistration.getProvider());
 
-        SINT contFrameIndex = pContReadSource->frameIndexMin();
-        while (pContReadSource->frameIndexRange().containsIndex(contFrameIndex)) {
-            const auto readFrameIndexRange =
-                    mixxx::IndexRange::forward(contFrameIndex, kReadFrameCount);
-            qDebug() << "Seeking and reading" << readFrameIndexRange;
-
-            // Read next chunk of frames for Cont source without seeking
-            const auto contSampleFrames =
-                    pContReadSource->readSampleFrames(
-                            mixxx::WritableSampleFrames(
-                                    readFrameIndexRange,
-                                    mixxx::SampleBuffer::WritableSlice(contReadData)));
-            ASSERT_FALSE(contSampleFrames.frameIndexRange().empty());
-            ASSERT_LE(contSampleFrames.frameIndexRange(), readFrameIndexRange);
-            ASSERT_EQ(contSampleFrames.frameIndexRange().start(), readFrameIndexRange.start());
-            contFrameIndex += contSampleFrames.frameLength();
-
-            const SINT sampleCount =
-                    pContReadSource->getSignalInfo().frames2samples(contSampleFrames.frameLength());
-
-            mixxx::AudioSourcePointer pSeekReadSource(openAudioSource(filePath));
-            ASSERT_FALSE(!pSeekReadSource);
-            ASSERT_EQ(
-                    pContReadSource->getSignalInfo().getChannelCount(),
-                    pSeekReadSource->getSignalInfo().getChannelCount());
-            ASSERT_EQ(pContReadSource->frameIndexRange(), pSeekReadSource->frameIndexRange());
-
-            // Seek source to next chunk and read it
-            auto seekSampleFrames =
-                    pSeekReadSource->readSampleFrames(
-                            mixxx::WritableSampleFrames(
-                                    readFrameIndexRange,
-                                    mixxx::SampleBuffer::WritableSlice(seekReadData)));
-
-            // Both buffers should be equal
-            ASSERT_EQ(contSampleFrames.frameIndexRange(), seekSampleFrames.frameIndexRange());
-            expectDecodedSamplesEqual(
-                    sampleCount,
-                    &contReadData[0],
-                    &seekReadData[0],
-                    "Decoding mismatch after seeking forward");
-
-            // Seek backwards to beginning of chunk and read again
-            seekSampleFrames =
-                    pSeekReadSource->readSampleFrames(
-                            mixxx::WritableSampleFrames(
-                                    readFrameIndexRange,
-                                    mixxx::SampleBuffer::WritableSlice(seekReadData)));
-
-            // Both buffers should again be equal
-            ASSERT_EQ(contSampleFrames.frameIndexRange(), seekSampleFrames.frameIndexRange());
-            expectDecodedSamplesEqual(
-                    sampleCount,
-                    &contReadData[0],
-                    &seekReadData[0],
-                    "Decoding mismatch after seeking backward");
-        }
-    }
-}
-
-TEST_F(SoundSourceProxyTest, skipAndRead) {
-    for (auto kReadFrameCount: kBufferSizes) {
-        for (const auto& filePath: getFilePaths()) {
-            ASSERT_TRUE(SoundSourceProxy::isFileNameSupported(filePath));
-
-            qDebug() << "Skip and read test:" << filePath;
-
-            mixxx::AudioSourcePointer pContReadSource(openAudioSource(filePath));
             // Obtaining an AudioSource may fail for unsupported file formats,
             // even if the corresponding file extension is supported, e.g.
             // AAC vs. ALAC in .m4a files
@@ -312,49 +244,18 @@ TEST_F(SoundSourceProxyTest, skipAndRead) {
                 // skip test file
                 continue;
             }
-            SINT contFrameIndex = pContReadSource->frameIndexMin();
-
-            mixxx::AudioSourcePointer pSkipReadSource(openAudioSource(filePath));
-            ASSERT_FALSE(!pSkipReadSource);
-            ASSERT_EQ(
-                    pContReadSource->getSignalInfo().getChannelCount(),
-                    pSkipReadSource->getSignalInfo().getChannelCount());
-            ASSERT_EQ(pContReadSource->frameIndexRange(), pSkipReadSource->frameIndexRange());
-            SINT skipFrameIndex = pSkipReadSource->frameIndexMin();
-
             mixxx::SampleBuffer contReadData(
                     pContReadSource->getSignalInfo().frames2samples(kReadFrameCount));
-            mixxx::SampleBuffer skipReadData(
-                    pSkipReadSource->getSignalInfo().frames2samples(kReadFrameCount));
+            mixxx::SampleBuffer seekReadData(
+                    pContReadSource->getSignalInfo().frames2samples(kReadFrameCount));
 
-            SINT minFrameIndex = pContReadSource->frameIndexMin();
-            SINT skipCount = 1;
-            while (pContReadSource->frameIndexRange().containsIndex(minFrameIndex += skipCount)) {
-                skipCount = minFrameIndex / 4 + 1; // for next iteration
-
-                qDebug() << "Skipping to:" << minFrameIndex;
-
+            SINT contFrameIndex = pContReadSource->frameIndexMin();
+            while (pContReadSource->frameIndexRange().containsIndex(contFrameIndex)) {
                 const auto readFrameIndexRange =
-                        mixxx::IndexRange::forward(minFrameIndex, kReadFrameCount);
+                        mixxx::IndexRange::forward(contFrameIndex, kReadFrameCount);
+                qDebug() << "Seeking and reading" << readFrameIndexRange;
 
-                // Read (and discard samples) until reaching the desired frame index
-                // and read next chunk
-                ASSERT_LE(contFrameIndex, minFrameIndex);
-                while (contFrameIndex < minFrameIndex) {
-                    auto skippingFrameIndexRange =
-                            mixxx::IndexRange::forward(
-                                    contFrameIndex,
-                                    std::min(minFrameIndex - contFrameIndex, kReadFrameCount));
-                    auto const skippedSampleFrames =
-                            pContReadSource->readSampleFrames(
-                                    mixxx::WritableSampleFrames(
-                                            skippingFrameIndexRange,
-                                            mixxx::SampleBuffer::WritableSlice(contReadData)));
-                    ASSERT_FALSE(skippedSampleFrames.frameIndexRange().empty());
-                    ASSERT_EQ(skippedSampleFrames.frameIndexRange().start(), contFrameIndex);
-                    contFrameIndex += skippedSampleFrames.frameLength();
-                }
-                ASSERT_EQ(minFrameIndex, contFrameIndex);
+                // Read next chunk of frames for Cont source without seeking
                 const auto contSampleFrames =
                         pContReadSource->readSampleFrames(
                                 mixxx::WritableSampleFrames(
@@ -368,34 +269,160 @@ TEST_F(SoundSourceProxyTest, skipAndRead) {
                 const SINT sampleCount =
                         pContReadSource->getSignalInfo().frames2samples(contSampleFrames.frameLength());
 
-                // Skip until reaching the frame index and read next chunk
-                ASSERT_LE(skipFrameIndex, minFrameIndex);
-                while (skipFrameIndex < minFrameIndex) {
-                    auto const skippedFrameIndexRange =
-                            skipSampleFrames(pSkipReadSource,
-                                    mixxx::IndexRange::between(skipFrameIndex, minFrameIndex));
-                    ASSERT_FALSE(skippedFrameIndexRange.empty());
-                    ASSERT_EQ(skippedFrameIndexRange.start(), skipFrameIndex);
-                    skipFrameIndex += skippedFrameIndexRange.length();
-                }
-                ASSERT_EQ(minFrameIndex, skipFrameIndex);
-                const auto skippedSampleFrames =
-                        pSkipReadSource->readSampleFrames(
+                mixxx::AudioSourcePointer pSeekReadSource = openAudioSource(
+                        filePath,
+                        providerRegistration.getProvider());
+
+                ASSERT_FALSE(!pSeekReadSource);
+                ASSERT_EQ(
+                        pContReadSource->getSignalInfo().getChannelCount(),
+                        pSeekReadSource->getSignalInfo().getChannelCount());
+                ASSERT_EQ(pContReadSource->frameIndexRange(), pSeekReadSource->frameIndexRange());
+
+                // Seek source to next chunk and read it
+                auto seekSampleFrames =
+                        pSeekReadSource->readSampleFrames(
                                 mixxx::WritableSampleFrames(
                                         readFrameIndexRange,
-                                        mixxx::SampleBuffer::WritableSlice(skipReadData)));
-
-                skipFrameIndex += skippedSampleFrames.frameLength();
+                                        mixxx::SampleBuffer::WritableSlice(seekReadData)));
 
                 // Both buffers should be equal
-                ASSERT_EQ(contSampleFrames.frameIndexRange(), skippedSampleFrames.frameIndexRange());
+                ASSERT_EQ(contSampleFrames.frameIndexRange(), seekSampleFrames.frameIndexRange());
                 expectDecodedSamplesEqual(
                         sampleCount,
                         &contReadData[0],
-                        &skipReadData[0],
-                        "Decoding mismatch after skipping");
+                        &seekReadData[0],
+                        "Decoding mismatch after seeking forward");
 
-                minFrameIndex = contFrameIndex;
+                // Seek backwards to beginning of chunk and read again
+                seekSampleFrames =
+                        pSeekReadSource->readSampleFrames(
+                                mixxx::WritableSampleFrames(
+                                        readFrameIndexRange,
+                                        mixxx::SampleBuffer::WritableSlice(seekReadData)));
+
+                // Both buffers should again be equal
+                ASSERT_EQ(contSampleFrames.frameIndexRange(), seekSampleFrames.frameIndexRange());
+                expectDecodedSamplesEqual(
+                        sampleCount,
+                        &contReadData[0],
+                        &seekReadData[0],
+                        "Decoding mismatch after seeking backward");
+            }
+        }
+    }
+}
+
+TEST_F(SoundSourceProxyTest, skipAndRead) {
+    for (auto kReadFrameCount : kBufferSizes) {
+        for (const auto& filePath : getFilePaths()) {
+            ASSERT_TRUE(SoundSourceProxy::isFileNameSupported(filePath));
+            qDebug() << "Skip and read test:" << filePath;
+
+            const auto fileUrl = QUrl::fromLocalFile(filePath);
+            for (const auto& providerRegistration :
+                    SoundSourceProxy::allProviderRegistrationsForUrl(fileUrl)) {
+                mixxx::AudioSourcePointer pContReadSource = openAudioSource(
+                        filePath,
+                        providerRegistration.getProvider());
+                // Obtaining an AudioSource may fail for unsupported file formats,
+                // even if the corresponding file extension is supported, e.g.
+                // AAC vs. ALAC in .m4a files
+                if (!pContReadSource) {
+                    // skip test file
+                    continue;
+                }
+                SINT contFrameIndex = pContReadSource->frameIndexMin();
+
+                mixxx::AudioSourcePointer pSkipReadSource = openAudioSource(
+                        filePath,
+                        providerRegistration.getProvider());
+                ASSERT_FALSE(!pSkipReadSource);
+                ASSERT_EQ(
+                        pContReadSource->getSignalInfo().getChannelCount(),
+                        pSkipReadSource->getSignalInfo().getChannelCount());
+                ASSERT_EQ(pContReadSource->frameIndexRange(), pSkipReadSource->frameIndexRange());
+                SINT skipFrameIndex = pSkipReadSource->frameIndexMin();
+
+                mixxx::SampleBuffer contReadData(
+                        pContReadSource->getSignalInfo().frames2samples(kReadFrameCount));
+                mixxx::SampleBuffer skipReadData(
+                        pSkipReadSource->getSignalInfo().frames2samples(kReadFrameCount));
+
+                SINT minFrameIndex = pContReadSource->frameIndexMin();
+                SINT skipCount = 1;
+                while (pContReadSource->frameIndexRange().containsIndex(
+                        minFrameIndex += skipCount)) {
+                    skipCount = minFrameIndex / 4 + 1; // for next iteration
+
+                    qDebug() << "Skipping to:" << minFrameIndex;
+
+                    const auto readFrameIndexRange =
+                            mixxx::IndexRange::forward(minFrameIndex, kReadFrameCount);
+
+                    // Read (and discard samples) until reaching the desired frame index
+                    // and read next chunk
+                    ASSERT_LE(contFrameIndex, minFrameIndex);
+                    while (contFrameIndex < minFrameIndex) {
+                        auto skippingFrameIndexRange =
+                                mixxx::IndexRange::forward(
+                                        contFrameIndex,
+                                        std::min(minFrameIndex - contFrameIndex, kReadFrameCount));
+                        auto const skippedSampleFrames =
+                                pContReadSource->readSampleFrames(
+                                        mixxx::WritableSampleFrames(
+                                                skippingFrameIndexRange,
+                                                mixxx::SampleBuffer::WritableSlice(contReadData)));
+                        ASSERT_FALSE(skippedSampleFrames.frameIndexRange().empty());
+                        ASSERT_EQ(skippedSampleFrames.frameIndexRange().start(), contFrameIndex);
+                        contFrameIndex += skippedSampleFrames.frameLength();
+                    }
+                    ASSERT_EQ(minFrameIndex, contFrameIndex);
+                    const auto contSampleFrames =
+                            pContReadSource->readSampleFrames(
+                                    mixxx::WritableSampleFrames(
+                                            readFrameIndexRange,
+                                            mixxx::SampleBuffer::WritableSlice(contReadData)));
+                    ASSERT_FALSE(contSampleFrames.frameIndexRange().empty());
+                    ASSERT_LE(contSampleFrames.frameIndexRange(), readFrameIndexRange);
+                    ASSERT_EQ(contSampleFrames.frameIndexRange().start(),
+                            readFrameIndexRange.start());
+                    contFrameIndex += contSampleFrames.frameLength();
+
+                    const SINT sampleCount =
+                            pContReadSource->getSignalInfo().frames2samples(
+                                    contSampleFrames.frameLength());
+
+                    // Skip until reaching the frame index and read next chunk
+                    ASSERT_LE(skipFrameIndex, minFrameIndex);
+                    while (skipFrameIndex < minFrameIndex) {
+                        auto const skippedFrameIndexRange =
+                                skipSampleFrames(pSkipReadSource,
+                                        mixxx::IndexRange::between(skipFrameIndex, minFrameIndex));
+                        ASSERT_FALSE(skippedFrameIndexRange.empty());
+                        ASSERT_EQ(skippedFrameIndexRange.start(), skipFrameIndex);
+                        skipFrameIndex += skippedFrameIndexRange.length();
+                    }
+                    ASSERT_EQ(minFrameIndex, skipFrameIndex);
+                    const auto skippedSampleFrames =
+                            pSkipReadSource->readSampleFrames(
+                                    mixxx::WritableSampleFrames(
+                                            readFrameIndexRange,
+                                            mixxx::SampleBuffer::WritableSlice(skipReadData)));
+
+                    skipFrameIndex += skippedSampleFrames.frameLength();
+
+                    // Both buffers should be equal
+                    ASSERT_EQ(contSampleFrames.frameIndexRange(),
+                            skippedSampleFrames.frameIndexRange());
+                    expectDecodedSamplesEqual(
+                            sampleCount,
+                            &contReadData[0],
+                            &skipReadData[0],
+                            "Decoding mismatch after skipping");
+
+                    minFrameIndex = contFrameIndex;
+                }
             }
         }
     }
@@ -403,112 +430,111 @@ TEST_F(SoundSourceProxyTest, skipAndRead) {
 
 TEST_F(SoundSourceProxyTest, seekBoundaries) {
     const SINT kReadFrameCount = 1000;
-    for (const auto& filePath: getFilePaths()) {
+    for (const auto& filePath : getFilePaths()) {
         ASSERT_TRUE(SoundSourceProxy::isFileNameSupported(filePath));
-
         qDebug() << "Seek boundaries test:" << filePath;
 
-        // TODO(XXX): Fix SoundSourceFFmpeg and re-enable testing
-        mixxx::AudioSourcePointer pSeekReadSource(openAudioSource(filePath));
-        // Obtaining an AudioSource may fail for unsupported file formats,
-        // even if the corresponding file extension is supported, e.g.
-        // AAC vs. ALAC in .m4a files
-        if (!pSeekReadSource) {
-            // skip test file
-            continue;
-        }
-        mixxx::SampleBuffer seekReadData(
-                pSeekReadSource->getSignalInfo().frames2samples(kReadFrameCount));
-
-        std::vector<SINT> seekFrameIndices;
-        // Seek to boundaries (alternating)...
-        seekFrameIndices.push_back(pSeekReadSource->frameIndexMin());
-        seekFrameIndices.push_back(pSeekReadSource->frameIndexMax() - 1);
-        seekFrameIndices.push_back(pSeekReadSource->frameIndexMin() + 1);
-        seekFrameIndices.push_back(pSeekReadSource->frameIndexMax());
-        // ...seek to middle of the stream...
-        seekFrameIndices.push_back(
-                pSeekReadSource->frameIndexMin() +
-                pSeekReadSource->frameLength() / 2);
-        // ...and to the boundaries again in opposite order...
-        seekFrameIndices.push_back(pSeekReadSource->frameIndexMax());
-        seekFrameIndices.push_back(pSeekReadSource->frameIndexMin() + 1);
-        seekFrameIndices.push_back(pSeekReadSource->frameIndexMax() - 1);
-        seekFrameIndices.push_back(pSeekReadSource->frameIndexMin());
-        // ...near the end and back to middle of the stream...
-        seekFrameIndices.push_back(
-                pSeekReadSource->frameIndexMax()
-                - 4 * kReadFrameCount);
-        seekFrameIndices.push_back(
-                pSeekReadSource->frameIndexMin()
-                + pSeekReadSource->frameLength() / 2);
-        // ...before the middle and then near the end of the stream...
-        seekFrameIndices.push_back(
-                pSeekReadSource->frameIndexMin()
-                + pSeekReadSource->frameLength() / 2
-                - 4 * kReadFrameCount);
-        seekFrameIndices.push_back(
-                pSeekReadSource->frameIndexMax()
-                - 4 * kReadFrameCount);
-        // ...to the moddle of the stream and then skipping kReadFrameCount samples.
-        seekFrameIndices.push_back(
-                pSeekReadSource->frameIndexMin()
-                + pSeekReadSource->frameLength() / 2);
-        seekFrameIndices.push_back(
-                pSeekReadSource->frameIndexMin()
-                + pSeekReadSource->frameLength() / 2
-                + 2 * kReadFrameCount);
-
-        // Read and verify results
-        for (SINT seekFrameIndex: seekFrameIndices) {
-            const auto readFrameIndexRange =
-                    mixxx::IndexRange::forward(seekFrameIndex, kReadFrameCount);
-            qDebug() << "Reading and verifying" << readFrameIndexRange;
-
-            const auto expectedFrameIndexRange = intersect(
-                    readFrameIndexRange,
-                    pSeekReadSource->frameIndexRange());
-
-            mixxx::AudioSourcePointer pContReadSource(openAudioSource(filePath));
-            ASSERT_FALSE(!pContReadSource);
-            ASSERT_EQ(
-                    pSeekReadSource->getSignalInfo().getChannelCount(),
-                    pContReadSource->getSignalInfo().getChannelCount());
-            ASSERT_EQ(pSeekReadSource->frameIndexRange(), pContReadSource->frameIndexRange());
-            const auto skipFrameIndexRange =
-                    skipSampleFrames(pContReadSource,
-                            mixxx::IndexRange::between(
-                                    pContReadSource->frameIndexMin(),
-                                    seekFrameIndex));
-            ASSERT_TRUE(skipFrameIndexRange.empty() ||
-                    (skipFrameIndexRange.end() == seekFrameIndex));
-            mixxx::SampleBuffer contReadData(
-                    pContReadSource->getSignalInfo().frames2samples(kReadFrameCount));
-            const auto contSampleFrames =
-                    pContReadSource->readSampleFrames(
-                            mixxx::WritableSampleFrames(
-                                    readFrameIndexRange,
-                                    mixxx::SampleBuffer::WritableSlice(contReadData)));
-                    ASSERT_EQ(expectedFrameIndexRange, contSampleFrames.frameIndexRange());
-
-            const auto seekSampleFrames =
-                    pSeekReadSource->readSampleFrames(
-                            mixxx::WritableSampleFrames(
-                                    readFrameIndexRange,
-                                    mixxx::SampleBuffer::WritableSlice(seekReadData)));
-            ASSERT_EQ(expectedFrameIndexRange, seekSampleFrames.frameIndexRange());
-
-            if (seekSampleFrames.frameIndexRange().empty()) {
-                continue; // nothing to do
+        const auto fileUrl = QUrl::fromLocalFile(filePath);
+        for (const auto& providerRegistration :
+                SoundSourceProxy::allProviderRegistrationsForUrl(fileUrl)) {
+            mixxx::AudioSourcePointer pSeekReadSource = openAudioSource(
+                    filePath,
+                    providerRegistration.getProvider());
+            // Obtaining an AudioSource may fail for unsupported file formats,
+            // even if the corresponding file extension is supported, e.g.
+            // AAC vs. ALAC in .m4a files
+            if (!pSeekReadSource) {
+                // skip test file
+                continue;
             }
+            mixxx::SampleBuffer seekReadData(
+                    pSeekReadSource->getSignalInfo().frames2samples(kReadFrameCount));
 
-            const SINT sampleCount =
-                    pSeekReadSource->getSignalInfo().frames2samples(seekSampleFrames.frameLength());
-            expectDecodedSamplesEqual(
-                    sampleCount,
-                    &contReadData[0],
-                    &seekReadData[0],
-                    "Decoding mismatch after seeking");
+            std::vector<SINT> seekFrameIndices;
+            // Seek to boundaries (alternating)...
+            seekFrameIndices.push_back(pSeekReadSource->frameIndexMin());
+            seekFrameIndices.push_back(pSeekReadSource->frameIndexMax() - 1);
+            seekFrameIndices.push_back(pSeekReadSource->frameIndexMin() + 1);
+            seekFrameIndices.push_back(pSeekReadSource->frameIndexMax());
+            // ...seek to middle of the stream...
+            seekFrameIndices.push_back(
+                    pSeekReadSource->frameIndexMin() +
+                    pSeekReadSource->frameLength() / 2);
+            // ...and to the boundaries again in opposite order...
+            seekFrameIndices.push_back(pSeekReadSource->frameIndexMax());
+            seekFrameIndices.push_back(pSeekReadSource->frameIndexMin() + 1);
+            seekFrameIndices.push_back(pSeekReadSource->frameIndexMax() - 1);
+            seekFrameIndices.push_back(pSeekReadSource->frameIndexMin());
+            // ...near the end and back to middle of the stream...
+            seekFrameIndices.push_back(
+                    pSeekReadSource->frameIndexMax() - 4 * kReadFrameCount);
+            seekFrameIndices.push_back(
+                    pSeekReadSource->frameIndexMin() + pSeekReadSource->frameLength() / 2);
+            // ...before the middle and then near the end of the stream...
+            seekFrameIndices.push_back(pSeekReadSource->frameIndexMin() +
+                    pSeekReadSource->frameLength() / 2 - 4 * kReadFrameCount);
+            seekFrameIndices.push_back(
+                    pSeekReadSource->frameIndexMax() - 4 * kReadFrameCount);
+            // ...to the moddle of the stream and then skipping kReadFrameCount samples.
+            seekFrameIndices.push_back(
+                    pSeekReadSource->frameIndexMin() + pSeekReadSource->frameLength() / 2);
+            seekFrameIndices.push_back(pSeekReadSource->frameIndexMin() +
+                    pSeekReadSource->frameLength() / 2 + 2 * kReadFrameCount);
+
+            // Read and verify results
+            for (SINT seekFrameIndex : seekFrameIndices) {
+                const auto readFrameIndexRange =
+                        mixxx::IndexRange::forward(seekFrameIndex, kReadFrameCount);
+                qDebug() << "Reading and verifying" << readFrameIndexRange;
+
+                const auto expectedFrameIndexRange = intersect(
+                        readFrameIndexRange,
+                        pSeekReadSource->frameIndexRange());
+
+                mixxx::AudioSourcePointer pContReadSource = openAudioSource(
+                        filePath,
+                        providerRegistration.getProvider());
+                ASSERT_FALSE(!pContReadSource);
+                ASSERT_EQ(
+                        pSeekReadSource->getSignalInfo().getChannelCount(),
+                        pContReadSource->getSignalInfo().getChannelCount());
+                ASSERT_EQ(pSeekReadSource->frameIndexRange(), pContReadSource->frameIndexRange());
+                const auto skipFrameIndexRange =
+                        skipSampleFrames(pContReadSource,
+                                mixxx::IndexRange::between(
+                                        pContReadSource->frameIndexMin(),
+                                        seekFrameIndex));
+                ASSERT_TRUE(skipFrameIndexRange.empty() ||
+                        (skipFrameIndexRange.end() == seekFrameIndex));
+                mixxx::SampleBuffer contReadData(
+                        pContReadSource->getSignalInfo().frames2samples(kReadFrameCount));
+                const auto contSampleFrames =
+                        pContReadSource->readSampleFrames(
+                                mixxx::WritableSampleFrames(
+                                        readFrameIndexRange,
+                                        mixxx::SampleBuffer::WritableSlice(contReadData)));
+                ASSERT_EQ(expectedFrameIndexRange, contSampleFrames.frameIndexRange());
+
+                const auto seekSampleFrames =
+                        pSeekReadSource->readSampleFrames(
+                                mixxx::WritableSampleFrames(
+                                        readFrameIndexRange,
+                                        mixxx::SampleBuffer::WritableSlice(seekReadData)));
+                ASSERT_EQ(expectedFrameIndexRange, seekSampleFrames.frameIndexRange());
+
+                if (seekSampleFrames.frameIndexRange().empty()) {
+                    continue; // nothing to do
+                }
+
+                const SINT sampleCount =
+                        pSeekReadSource->getSignalInfo().frames2samples(
+                                seekSampleFrames.frameLength());
+                expectDecodedSamplesEqual(
+                        sampleCount,
+                        &contReadData[0],
+                        &seekReadData[0],
+                        "Decoding mismatch after seeking");
+            }
         }
     }
 }
@@ -516,58 +542,63 @@ TEST_F(SoundSourceProxyTest, seekBoundaries) {
 TEST_F(SoundSourceProxyTest, readBeyondEnd) {
     const SINT kReadFrameCount = 1000;
 
-    for (const auto& filePath: getFilePaths()) {
+    for (const auto& filePath : getFilePaths()) {
         ASSERT_TRUE(SoundSourceProxy::isFileNameSupported(filePath));
-
         qDebug() << "read beyond end test:" << filePath;
 
-        mixxx::AudioSourcePointer pAudioSource(openAudioSource(filePath));
-        // Obtaining an AudioSource may fail for unsupported file formats,
-        // even if the corresponding file extension is supported, e.g.
-        // AAC vs. ALAC in .m4a files
-        if (!pAudioSource) {
-            // skip test file
-            continue;
+        const auto fileUrl = QUrl::fromLocalFile(filePath);
+        for (const auto& providerRegistration :
+                SoundSourceProxy::allProviderRegistrationsForUrl(fileUrl)) {
+            mixxx::AudioSourcePointer pAudioSource = openAudioSource(
+                    filePath,
+                    providerRegistration.getProvider());
+            // Obtaining an AudioSource may fail for unsupported file formats,
+            // even if the corresponding file extension is supported, e.g.
+            // AAC vs. ALAC in .m4a files
+            if (!pAudioSource) {
+                // skip test file
+                continue;
+            }
+
+            // Seek to position near the end
+            const SINT seekIndex = pAudioSource->frameIndexMax() - (kReadFrameCount / 2);
+            const SINT remainingFrames = pAudioSource->frameIndexMax() - seekIndex;
+            ASSERT_GT(remainingFrames, 0);
+            ASSERT_LT(remainingFrames, kReadFrameCount);
+
+            mixxx::SampleBuffer readBuffer(
+                    pAudioSource->getSignalInfo().frames2samples(kReadFrameCount));
+
+            // Read beyond the end, starting within the valid range
+            EXPECT_EQ(mixxx::IndexRange::forward(seekIndex, remainingFrames),
+                    pAudioSource
+                            ->readSampleFrames(mixxx::WritableSampleFrames(
+                                    mixxx::IndexRange::forward(
+                                            seekIndex, kReadFrameCount),
+                                    mixxx::SampleBuffer::WritableSlice(
+                                            readBuffer)))
+                            .frameIndexRange());
+
+            // Read beyond the end, starting at the upper boundary of the valid range
+            EXPECT_EQ(mixxx::IndexRange::forward(pAudioSource->frameIndexMax(), 0),
+                    pAudioSource
+                            ->readSampleFrames(mixxx::WritableSampleFrames(
+                                    mixxx::IndexRange::forward(
+                                            pAudioSource->frameIndexMax(), kReadFrameCount),
+                                    mixxx::SampleBuffer::WritableSlice(
+                                            readBuffer)))
+                            .frameIndexRange());
+
+            // Read beyond the end, starting beyond the upper boundary of the valid range
+            EXPECT_EQ(mixxx::IndexRange::forward(pAudioSource->frameIndexMax() + 1, 0),
+                    pAudioSource
+                            ->readSampleFrames(mixxx::WritableSampleFrames(
+                                    mixxx::IndexRange::forward(
+                                            pAudioSource->frameIndexMax() + 1, kReadFrameCount),
+                                    mixxx::SampleBuffer::WritableSlice(
+                                            readBuffer)))
+                            .frameIndexRange());
         }
-
-        // Seek to position near the end
-        const SINT seekIndex = pAudioSource->frameIndexMax() - (kReadFrameCount / 2);
-        const SINT remainingFrames = pAudioSource->frameIndexMax() - seekIndex;
-        ASSERT_GT(remainingFrames, 0);
-        ASSERT_LT(remainingFrames, kReadFrameCount);
-
-        mixxx::SampleBuffer readBuffer(
-                pAudioSource->getSignalInfo().frames2samples(kReadFrameCount));
-
-        // Read beyond the end, starting within the valid range
-        EXPECT_EQ(mixxx::IndexRange::forward(seekIndex, remainingFrames),
-                pAudioSource
-                        ->readSampleFrames(mixxx::WritableSampleFrames(
-                                mixxx::IndexRange::forward(
-                                        seekIndex, kReadFrameCount),
-                                mixxx::SampleBuffer::WritableSlice(
-                                        readBuffer)))
-                        .frameIndexRange());
-
-        // Read beyond the end, starting at the upper boundary of the valid range
-        EXPECT_EQ(mixxx::IndexRange::forward(pAudioSource->frameIndexMax(), 0),
-                pAudioSource
-                        ->readSampleFrames(mixxx::WritableSampleFrames(
-                                mixxx::IndexRange::forward(
-                                        pAudioSource->frameIndexMax(), kReadFrameCount),
-                                mixxx::SampleBuffer::WritableSlice(
-                                        readBuffer)))
-                        .frameIndexRange());
-
-        // Read beyond the end, starting beyond the upper boundary of the valid range
-        EXPECT_EQ(mixxx::IndexRange::forward(pAudioSource->frameIndexMax() + 1, 0),
-                pAudioSource
-                        ->readSampleFrames(mixxx::WritableSampleFrames(
-                                mixxx::IndexRange::forward(
-                                        pAudioSource->frameIndexMax() + 1, kReadFrameCount),
-                                mixxx::SampleBuffer::WritableSlice(
-                                        readBuffer)))
-                        .frameIndexRange());
     }
 }
 
@@ -577,40 +608,52 @@ TEST_F(SoundSourceProxyTest, regressionTestCachingReaderChunkJumpForward) {
     // test doesn't fail even prior to fixing the reported bug.
     // https://github.com/mixxxdj/mixxx/pull/1317#issuecomment-349674161
 
-    for (auto kReadFrameCount: kBufferSizes) {
-        for (const auto& filePath: getFilePaths()) {
+    for (auto kReadFrameCount : kBufferSizes) {
+        for (const auto& filePath : getFilePaths()) {
             ASSERT_TRUE(SoundSourceProxy::isFileNameSupported(filePath));
 
-            mixxx::AudioSourcePointer pAudioSource(openAudioSource(filePath));
-            // Obtaining an AudioSource may fail for unsupported file formats,
-            // even if the corresponding file extension is supported, e.g.
-            // AAC vs. ALAC in .m4a files
-            if (!pAudioSource) {
-                // skip test file
-                continue;
+            const auto fileUrl = QUrl::fromLocalFile(filePath);
+            for (const auto& providerRegistration :
+                    SoundSourceProxy::allProviderRegistrationsForUrl(fileUrl)) {
+                mixxx::AudioSourcePointer pAudioSource = openAudioSource(
+                        filePath,
+                        providerRegistration.getProvider());
+                // Obtaining an AudioSource may fail for unsupported file formats,
+                // even if the corresponding file extension is supported, e.g.
+                // AAC vs. ALAC in .m4a files
+                if (!pAudioSource) {
+                    // skip test file
+                    continue;
+                }
+
+                mixxx::SampleBuffer readBuffer(
+                        pAudioSource->getSignalInfo().frames2samples(kReadFrameCount));
+
+                // Read chunk from beginning
+                auto firstChunkRange = mixxx::IndexRange::forward(
+                        pAudioSource->frameIndexMin(), kReadFrameCount);
+                EXPECT_EQ(
+                        firstChunkRange,
+                        pAudioSource->readSampleFrames(
+                                            mixxx::WritableSampleFrames(
+                                                    firstChunkRange,
+                                                    mixxx::SampleBuffer::WritableSlice(readBuffer)))
+                                .frameIndexRange());
+
+                // Read chunk from near the end, rounded to chunk boundary
+                auto secondChunkRange = mixxx::IndexRange::forward(
+                        ((pAudioSource->frameIndexMax() - 2 * kReadFrameCount) /
+                                kReadFrameCount) *
+                                kReadFrameCount,
+                        kReadFrameCount);
+                EXPECT_EQ(
+                        secondChunkRange,
+                        pAudioSource->readSampleFrames(
+                                            mixxx::WritableSampleFrames(
+                                                    secondChunkRange,
+                                                    mixxx::SampleBuffer::WritableSlice(readBuffer)))
+                                .frameIndexRange());
             }
-            mixxx::SampleBuffer readBuffer(
-                    pAudioSource->getSignalInfo().frames2samples(kReadFrameCount));
-
-            // Read chunk from beginning
-            auto firstChunkRange = mixxx::IndexRange::forward(
-                    pAudioSource->frameIndexMin(), kReadFrameCount);
-            EXPECT_EQ(
-                    firstChunkRange,
-                    pAudioSource->readSampleFrames(
-                            mixxx::WritableSampleFrames(
-                                    firstChunkRange,
-                                    mixxx::SampleBuffer::WritableSlice(readBuffer))).frameIndexRange());
-
-            // Read chunk from near the end, rounded to chunk boundary
-            auto secondChunkRange = mixxx::IndexRange::forward(
-                    ((pAudioSource->frameIndexMax() - 2 * kReadFrameCount) / kReadFrameCount) * kReadFrameCount, kReadFrameCount);
-            EXPECT_EQ(
-                    secondChunkRange,
-                    pAudioSource->readSampleFrames(
-                            mixxx::WritableSampleFrames(
-                                    secondChunkRange,
-                                    mixxx::SampleBuffer::WritableSlice(readBuffer))).frameIndexRange());
         }
     }
 }

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -103,6 +103,9 @@ class SoundSourceProxyTest : public MixxxTest {
                         kMaxReadFrameCount);
             }
             EXPECT_EQ(pAudioSource->getSignalInfo().getChannelCount(), channelCount);
+            qInfo()
+                    << "Opened file" << filePath
+                    << "using provider" << proxy.getProvider()->getDisplayName();
         }
         return pAudioSource;
     }

--- a/src/test/soundsourceproviderregistrytest.cpp
+++ b/src/test/soundsourceproviderregistrytest.cpp
@@ -1,25 +1,25 @@
-#include <QtDebug>
-
 #include <gtest/gtest.h>
+
+#include <QtDebug>
 
 #include "sources/soundsourceproviderregistry.h"
 
 namespace mixxx {
 
-class TestSoundSourceProvider: public SoundSourceProvider {
-public:
-  TestSoundSourceProvider(
-          QString displayName,
-          QStringList supportedFileExtensions,
-          SoundSourceProviderPriority priorityHint)
-          : m_displayName(displayName),
-            m_supportedFileExtensions(supportedFileExtensions),
-            m_priorityHint(priorityHint) {
-  }
+class TestSoundSourceProvider : public SoundSourceProvider {
+  public:
+    TestSoundSourceProvider(
+            QString displayName,
+            QStringList supportedFileExtensions,
+            SoundSourceProviderPriority priorityHint)
+            : m_displayName(displayName),
+              m_supportedFileExtensions(supportedFileExtensions),
+              m_priorityHint(priorityHint) {
+    }
 
-  QString getDisplayName() const override {
-      return m_displayName;
-  }
+    QString getDisplayName() const override {
+        return m_displayName;
+    }
 
     // A list of supported file extensions in any order.
     QStringList getSupportedFileExtensions() const override {
@@ -36,10 +36,10 @@ public:
         return SoundSourcePointer();
     }
 
-private:
-  const QString m_displayName;
-  const QStringList m_supportedFileExtensions;
-  const SoundSourceProviderPriority m_priorityHint;
+  private:
+    const QString m_displayName;
+    const QStringList m_supportedFileExtensions;
+    const SoundSourceProviderPriority m_priorityHint;
 };
 
 class SoundSourceProviderRegistryTest : public testing::Test {
@@ -64,21 +64,13 @@ class SoundSourceProviderRegistryTest : public testing::Test {
                         name, supportedFileExtensions, priorityHint));
     }
 
-    SoundSourceProviderPointer createProvider(
-            QString name,
-            SoundSourceProviderPriority priorityHint = SoundSourceProviderPriority::Default) {
-        return SoundSourceProviderPointer(
-                new TestSoundSourceProvider(
-                        name, m_supportedFileExtensions, priorityHint));
-    }
-
     static QStringList getAllRegisteredProviderDisplayNamesForFileExtension(
             const SoundSourceProviderRegistry& cut, QString fileExt) {
         QStringList displayNames;
         const QList<SoundSourceProviderRegistration> registrations(
                 cut.getRegistrationsForFileExtension(fileExt));
         displayNames.reserve(registrations.size());
-        for (auto const& registration: registrations) {
+        for (auto const& registration : registrations) {
             displayNames.append(registration.getProvider()->getDisplayName());
         }
         return displayNames;
@@ -86,7 +78,7 @@ class SoundSourceProviderRegistryTest : public testing::Test {
 
     static bool expectSortedStringList(const QStringList& sortedStrings) {
         QString previousString; // start with an empty string
-        for (const auto& nextString: sortedStrings) {
+        for (const auto& nextString : sortedStrings) {
             EXPECT_TRUE(previousString < nextString);
             if (previousString >= nextString) {
                 return false;
@@ -104,28 +96,47 @@ class SoundSourceProviderRegistryTest : public testing::Test {
 TEST_F(SoundSourceProviderRegistryTest, registerProviders) {
     SoundSourceProviderRegistry cut;
 
-    // 1st round - registration using priority hint
-    cut.registerProvider(createProvider("Test04", SoundSourceProviderPriority::Default));
-    cut.registerProvider(createProvider("Test02", SoundSourceProviderPriority::Lower));
-    cut.registerProvider(createProvider("Test00", SoundSourceProviderPriority::Lowest));
-    cut.registerProvider(createProvider("Test01", SoundSourceProviderPriority::Lowest));
-    cut.registerProvider(createProvider("Test10", SoundSourceProviderPriority::Highest));
-    // 1st round - registration with explicit priority for FILE_EXT1
-    cut.registerProviderForFileExtension(FILE_EXT1,
-            createProvider("Test05"),
-            SoundSourceProviderPriority::Default);
-    cut.registerProviderForFileExtension(FILE_EXT1,
-            createProvider("Test11"),
-            SoundSourceProviderPriority::Highest);
-    cut.registerProviderForFileExtension(FILE_EXT1,
-            createProvider("Test03"),
-            SoundSourceProviderPriority::Lower);
-    cut.registerProviderForFileExtension(FILE_EXT1,
-            createProvider("Test08"),
-            SoundSourceProviderPriority::Higher);
-    cut.registerProviderForFileExtension(FILE_EXT1,
-            createProvider("Test09"),
-            SoundSourceProviderPriority::Higher);
+    // 1st round
+    cut.registerProvider(createProvider(
+            "Test04",
+            QStringList{FILE_EXT1, FILE_EXT2},
+            SoundSourceProviderPriority::Default));
+    cut.registerProvider(createProvider(
+            "Test02",
+            QStringList{FILE_EXT1, FILE_EXT2},
+            SoundSourceProviderPriority::Lower));
+    cut.registerProvider(createProvider(
+            "Test00",
+            QStringList{FILE_EXT1, FILE_EXT2},
+            SoundSourceProviderPriority::Lowest));
+    cut.registerProvider(createProvider(
+            "Test01",
+            QStringList{FILE_EXT1, FILE_EXT2},
+            SoundSourceProviderPriority::Lowest));
+    cut.registerProvider(createProvider(
+            "Test10",
+            QStringList{FILE_EXT1, FILE_EXT2},
+            SoundSourceProviderPriority::Highest));
+    cut.registerProvider(createProvider(
+            "Test05",
+            QStringList{FILE_EXT1},
+            SoundSourceProviderPriority::Default));
+    cut.registerProvider(createProvider(
+            "Test11",
+            QStringList{FILE_EXT1},
+            SoundSourceProviderPriority::Highest));
+    cut.registerProvider(createProvider(
+            "Test03",
+            QStringList{FILE_EXT1},
+            SoundSourceProviderPriority::Lower));
+    cut.registerProvider(createProvider(
+            "Test08",
+            QStringList{FILE_EXT1},
+            SoundSourceProviderPriority::Higher));
+    cut.registerProvider(createProvider(
+            "Test09",
+            QStringList{FILE_EXT1},
+            SoundSourceProviderPriority::Higher));
 
     // 1st round - validation
     EXPECT_EQ(m_supportedFileExtensions, cut.getRegisteredFileExtensions());
@@ -138,21 +149,15 @@ TEST_F(SoundSourceProviderRegistryTest, registerProviders) {
     EXPECT_EQ(5, displayNames2Round1.size());
     EXPECT_TRUE(expectSortedStringList(displayNames2Round1));
 
-    // 2nd round - registration using priority hint for FILE_EXT2
-    cut.registerProvider(
-            createProvider(
-                    "Test06",
-                    QStringList(FILE_EXT2),
-                    SoundSourceProviderPriority::Default));
-    // 2nd round - registration with explicit priority for FILE_EXT2
-    cut.registerProviderForFileExtension(
-            FILE_EXT2,
-            createProvider(
-                    "Test07",
-                    QStringList(FILE_EXT2),
-                    // priority hint should be overridden by registration
-                    SoundSourceProviderPriority::Highest),
-            SoundSourceProviderPriority::Default);
+    // 2nd round
+    cut.registerProvider(createProvider(
+            "Test06",
+            QStringList{FILE_EXT2},
+            SoundSourceProviderPriority::Default));
+    cut.registerProvider(createProvider(
+            "Test07",
+            QStringList{FILE_EXT2},
+            SoundSourceProviderPriority::Default));
 
     // 2nd round - validation
     EXPECT_EQ(cut.getRegisteredFileExtensions(), m_supportedFileExtensions);
@@ -165,4 +170,4 @@ TEST_F(SoundSourceProviderRegistryTest, registerProviders) {
     EXPECT_TRUE(expectSortedStringList(displayNames2Round2));
 }
 
-}  // namespace mixxx
+} // namespace mixxx

--- a/src/track/serato/tags.cpp
+++ b/src/track/serato/tags.cpp
@@ -202,7 +202,6 @@ double SeratoTags::guessTimingOffsetMillis(
 #endif
 #if defined(__MAD__) || defined(__FFMPEG__)
         bool usingMadOrFFmpeg = false;
-#endif
 #if defined(__MAD__)
         if (primaryDecoderName == mixxx::SoundSourceProviderMp3::kDisplayName) {
             DEBUG_ASSERT(!usingMadOrFFmpeg);
@@ -215,7 +214,6 @@ double SeratoTags::guessTimingOffsetMillis(
             usingMadOrFFmpeg = true;
         }
 #endif
-#if defined(__MAD__) || defined(__FFMPEG__)
         if (usingMadOrFFmpeg) {
             DEBUG_ASSERT(!timingOffsetGuessed);
             DEBUG_ASSERT(timingOffset == 0);

--- a/src/track/serato/tags.cpp
+++ b/src/track/serato/tags.cpp
@@ -2,6 +2,16 @@
 
 #include <mp3guessenc.h>
 
+#include "sources/soundsourceproxy.h"
+#if defined(__COREAUDIO__)
+#include "sources/soundsourcecoreaudio.h"
+#endif
+#if defined(__FFMPEG__)
+#include "sources/soundsourceffmpeg.h"
+#endif
+#if defined(__MAD__)
+#include "sources/soundsourcemp3.h"
+#endif
 #include "track/serato/beatsimporter.h"
 #include "track/serato/cueinfoimporter.h"
 #include "track/taglib/trackmetadata_file.h"
@@ -9,15 +19,18 @@
 
 namespace {
 
-#ifdef __COREAUDIO__
-const QString kDecoderName(QStringLiteral("CoreAudio"));
-#elif defined(__MAD__)
-const QString kDecoderName(QStringLiteral("MAD"));
-#elif defined(__FFMPEG__)
-const QString kDecoderName(QStringLiteral("FFMPEG"));
-#else
-const QString kDecoderName(QStringLiteral("Unknown"));
-#endif
+QString getPrimaryDecoderNameForFilePath(const QString& filePath) {
+    const QString fileExtension =
+            mixxx::SoundSource::getFileExtensionFromUrl(QUrl::fromLocalFile(filePath));
+    const mixxx::SoundSourceProviderPointer pPrimaryProvider =
+            SoundSourceProxy::getPrimaryProviderForFileExtension(fileExtension);
+    QString decoderName;
+    if (pPrimaryProvider) {
+        return pPrimaryProvider->getDisplayName();
+    } else {
+        return QString(); // unknown
+    }
+}
 
 /// In Serato, loops and hotcues are kept separate, i. e. you can
 /// have a loop and a hotcue with the same number. In Mixxx, loops
@@ -153,49 +166,94 @@ double SeratoTags::guessTimingOffsetMillis(
     // used to determine which case the MP3 is classified in. See the following
     // PR for more detailed information:
     // https://github.com/mixxxdj/mixxx/pull/2119
-
     double timingOffset = 0;
     if (taglib::getFileTypeFromFileName(filePath) == taglib::FileType::MP3) {
-#if defined(__COREAUDIO__)
-        Q_UNUSED(signalInfo);
-
-        int timingShiftCase = mp3guessenc_timing_shift_case(filePath.toStdString().c_str());
-
-        // TODO: Find missing timing offsets
-        switch (timingShiftCase) {
-        case EXIT_CODE_CASE_A:
-            timingOffset = -12;
-            break;
-        case EXIT_CODE_CASE_B:
-            timingOffset = -40;
-            break;
-        case EXIT_CODE_CASE_C:
-        case EXIT_CODE_CASE_D:
-            timingOffset = -60;
-            break;
+        const QString primaryDecoderName =
+                getPrimaryDecoderNameForFilePath(filePath);
+        // There should always be an MP3 decoder available
+        VERIFY_OR_DEBUG_ASSERT(!primaryDecoderName.isEmpty()) {
+            return 0;
         }
-#elif defined(__MAD__) || defined(__FFMPEG__)
-        switch (signalInfo.getSampleRate()) {
-        case 48000:
-            timingOffset = -24;
-            break;
-        case 44100:
-            // This is an estimate and tracks will vary unpredictably within ~1 ms
-            timingOffset = -26;
-            break;
-        default:
-            qWarning()
-                    << "Unknown timing offset for Serato tags with sample rate"
-                    << signalInfo.getSampleRate();
+        bool timingOffsetGuessed = false;
+#if defined(__COREAUDIO__)
+        if (primaryDecoderName == mixxx::SoundSourceProviderCoreAudio::kDisplayName) {
+            DEBUG_ASSERT(!timingOffsetGuessed);
+            DEBUG_ASSERT(timingOffset == 0);
+
+            Q_UNUSED(signalInfo)
+            int timingShiftCase = mp3guessenc_timing_shift_case(filePath.toStdString().c_str());
+
+            // TODO: Find missing timing offsets
+            switch (timingShiftCase) {
+            case EXIT_CODE_CASE_A:
+                timingOffset = -12;
+                break;
+            case EXIT_CODE_CASE_B:
+                timingOffset = -40;
+                break;
+            case EXIT_CODE_CASE_C:
+            case EXIT_CODE_CASE_D:
+                timingOffset = -60;
+                break;
+            }
+
+            timingOffsetGuessed = true;
         }
 #endif
-        qDebug()
-                << "Detected timing offset "
-                << timingOffset
-                << "("
-                << kDecoderName
-                << ") for MP3 file:"
-                << filePath;
+#if defined(__MAD__) || defined(__FFMPEG__)
+        bool usingMadOrFFmpeg = false;
+#endif
+#if defined(__MAD__)
+        if (primaryDecoderName == mixxx::SoundSourceProviderMp3::kDisplayName) {
+            DEBUG_ASSERT(!usingMadOrFFmpeg);
+            usingMadOrFFmpeg = true;
+        }
+#endif
+#if defined(__FFMPEG__)
+        if (primaryDecoderName == mixxx::SoundSourceProviderFFmpeg::kDisplayName) {
+            DEBUG_ASSERT(!usingMadOrFFmpeg);
+            usingMadOrFFmpeg = true;
+        }
+#endif
+#if defined(__MAD__) || defined(__FFMPEG__)
+        if (usingMadOrFFmpeg) {
+            DEBUG_ASSERT(!timingOffsetGuessed);
+            DEBUG_ASSERT(timingOffset == 0);
+
+            switch (signalInfo.getSampleRate()) {
+            case 48000:
+                timingOffset = -24;
+                break;
+            case 44100:
+                // This is an estimate and tracks will vary unpredictably within ~1 ms
+                timingOffset = -26;
+                break;
+            default:
+                qWarning()
+                        << "Unknown timing offset for Serato tags with sample rate"
+                        << signalInfo.getSampleRate();
+            }
+
+            timingOffsetGuessed = true;
+        }
+#endif
+        if (timingOffsetGuessed) {
+            qDebug()
+                    << "Detected timing offset"
+                    << timingOffset
+                    << "using"
+                    << primaryDecoderName
+                    << "for MP3 file"
+                    << filePath;
+        } else {
+            qDebug()
+                    << "Unknown timing offset"
+                    << timingOffset
+                    << "using"
+                    << primaryDecoderName
+                    << "for MP3 file"
+                    << filePath;
+        }
     }
 
     return timingOffset;

--- a/src/track/serato/tags.cpp
+++ b/src/track/serato/tags.cpp
@@ -187,17 +187,18 @@ double SeratoTags::guessTimingOffsetMillis(
             switch (timingShiftCase) {
             case EXIT_CODE_CASE_A:
                 timingOffset = -12;
+                timingOffsetGuessed = true;
                 break;
             case EXIT_CODE_CASE_B:
                 timingOffset = -40;
+                timingOffsetGuessed = true;
                 break;
             case EXIT_CODE_CASE_C:
             case EXIT_CODE_CASE_D:
                 timingOffset = -60;
+                timingOffsetGuessed = true;
                 break;
             }
-
-            timingOffsetGuessed = true;
         }
 #endif
 #if defined(__MAD__) || defined(__FFMPEG__)
@@ -221,18 +222,18 @@ double SeratoTags::guessTimingOffsetMillis(
             switch (signalInfo.getSampleRate()) {
             case 48000:
                 timingOffset = -24;
+                timingOffsetGuessed = true;
                 break;
             case 44100:
                 // This is an estimate and tracks will vary unpredictably within ~1 ms
                 timingOffset = -26;
+                timingOffsetGuessed = true;
                 break;
             default:
                 qWarning()
                         << "Unknown timing offset for Serato tags with sample rate"
                         << signalInfo.getSampleRate();
             }
-
-            timingOffsetGuessed = true;
         }
 #endif
         if (timingOffsetGuessed) {


### PR DESCRIPTION
TODO:
- ~~[ ] Determine audio decoder for rekordbox import: https://github.com/mixxxdj/mixxx/blob/master/src/library/rekordbox/rekordboxfeature.cpp#L1073-L1120~~ ***Could and should be done in a separate, follow-up PR***
- ~~[ ] ~~Rebase~~ Merge 2.3 after #3050 has been merged~~ ***no agreement yet***
- [x] Allow to explicitly select a SoundSource provider
- [x] Run the tests for all available providers, not only the primary one
- [x] Fix FFmpeg issues on Ubuntu 20.04, probably by finishing #3073 first
- [x] SCons/macOS: Fix decoding issues with libsndfile-1.0.30 (pulled by homebrew) for .ogg files

An extension of the SoundSource framework that allows to dynamically determine the primary decoder for a given file. This is needed for fixing timing offsets when importing data from external applications like Serato or Rekordbox.

Minor improvements:
- Use `const`/`constexpr` for hard-coded data
- Improved logging and error handling
- Removed unused code, i.e. we never need to deregister any `SoundSourceProvider` at runtime