### PR TITLE
LateNight: fix cut-off star rating on macOS

### DIFF
--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -40,7 +40,9 @@ WLibrary,
 #PreviewDeck,
 #LibExpandBox,
 #SearchLineBox,
-QAbstractScrollArea::corner {
+QAbstractScrollArea::corner,
+/* Prevent cut-off or shifted stars on macOS */
+WStarRating {
   background-color: #1e1e1e;
 }
 

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -191,7 +191,9 @@ WSearchLineEdit {
   #KeyText,
   #DeckSettingsContainer,
   #DeckSettingsContainerCompact,
-  #spinBoxTransition  {
+  #spinBoxTransition,
+  /* Prevent cut-off or shifted stars on macOS */
+  WStarRating {
     background-color: #19191a;
     }
     #KeyText,


### PR DESCRIPTION
simply by adding a bg color to WStarRating
tested & confirmed by @foss-
