### PR TITLE
Replace qWarning() with qInfo()

### DIFF
--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -219,7 +219,7 @@ void AnalyzerBeats::storeResults(TrackPointer tio) {
     }
 
     if (!m_pPlugin->finalize()) {
-        qWarning() << "Beat/BPM analysis failed";
+        qInfo() << "Beat/BPM analysis failed";
         return;
     }
 

--- a/src/analyzer/analyzerebur128.cpp
+++ b/src/analyzer/analyzerebur128.cpp
@@ -50,7 +50,7 @@ bool AnalyzerEbur128::processSamples(const CSAMPLE *pIn, const int iLen) {
     size_t frames = iLen / 2;
     int e = ebur128_add_frames_float(m_pState, pIn, frames);
     VERIFY_OR_DEBUG_ASSERT(e == EBUR128_SUCCESS) {
-        qWarning() << "AnalyzerEbur128::processSamples() failed with" << e;
+        qInfo() << "AnalyzerEbur128::processSamples() failed with" << e;
         return false;
     }
     return true;
@@ -63,12 +63,12 @@ void AnalyzerEbur128::storeResults(TrackPointer tio) {
     double averageLufs;
     int e = ebur128_loudness_global(m_pState, &averageLufs);
     VERIFY_OR_DEBUG_ASSERT(e == EBUR128_SUCCESS) {
-        qWarning() << "AnalyzerEbur128::storeResults() failed with" << e;
+        qInfo() << "AnalyzerEbur128::storeResults() failed with" << e;
         return;
     }
     if (averageLufs == -HUGE_VAL || averageLufs == 0.0) {
-        qWarning() << "AnalyzerEbur128::storeResults() averageLufs invalid:"
-                   << averageLufs;
+        qInfo() << "AnalyzerEbur128::storeResults() averageLufs invalid:"
+                << averageLufs;
         return;
     }
 

--- a/src/analyzer/analyzergain.cpp
+++ b/src/analyzer/analyzergain.cpp
@@ -58,7 +58,7 @@ void AnalyzerGain::storeResults(TrackPointer tio) {
 
     float fReplayGainOutput = m_pReplayGain->end();
     if (fReplayGainOutput == GAIN_NOT_ENOUGH_SAMPLES) {
-        qWarning() << "ReplayGain 1.0 analysis failed";
+        qInfo() << "ReplayGain 1.0 analysis failed";
         return;
     }
 

--- a/src/analyzer/analyzerkey.cpp
+++ b/src/analyzer/analyzerkey.cpp
@@ -168,7 +168,7 @@ void AnalyzerKey::storeResults(TrackPointer tio) {
     }
 
     if (!m_pPlugin->finalize()) {
-        qWarning() << "Key detection failed";
+        qInfo() << "Key detection failed";
         return;
     }
 

--- a/src/analyzer/analyzerwaveform.cpp
+++ b/src/analyzer/analyzerwaveform.cpp
@@ -36,7 +36,7 @@ AnalyzerWaveform::~AnalyzerWaveform() {
 
 bool AnalyzerWaveform::initialize(TrackPointer tio, int sampleRate, int totalSamples) {
     if (totalSamples == 0) {
-        qWarning() << "AnalyzerWaveform::initialize - no waveform/waveform summary";
+        qInfo() << "AnalyzerWaveform::initialize - no waveform/waveform summary";
         return false;
     }
 
@@ -221,7 +221,7 @@ bool AnalyzerWaveform::processSamples(const CSAMPLE* buffer, const int bufferLen
 
         if (fmod(m_stride.m_position, m_stride.m_length) < 1) {
             VERIFY_OR_DEBUG_ASSERT(m_currentStride + ChannelCount <= m_waveform->getDataSize()) {
-                qWarning() << "AnalyzerWaveform::process - currentStride > waveform size";
+                qInfo() << "AnalyzerWaveform::process - currentStride > waveform size";
                 return false;
             }
             m_stride.store(m_waveformData + m_currentStride);
@@ -231,7 +231,8 @@ bool AnalyzerWaveform::processSamples(const CSAMPLE* buffer, const int bufferLen
 
         if (fmod(m_stride.m_position, m_stride.m_averageLength) < 1) {
             VERIFY_OR_DEBUG_ASSERT(m_currentSummaryStride + ChannelCount <= m_waveformSummary->getDataSize()) {
-                qWarning() << "AnalyzerWaveform::process - current summary stride > waveform summary size";
+                qInfo() << "AnalyzerWaveform::process - current summary stride "
+                           "> waveform summary size";
                 return false;
             }
             m_stride.averageStore(m_waveformSummaryData + m_currentSummaryStride);

--- a/src/analyzer/plugins/analyzerqueenmarykey.cpp
+++ b/src/analyzer/plugins/analyzerqueenmarykey.cpp
@@ -62,7 +62,7 @@ bool AnalyzerQueenMaryKey::initialize(int samplerate) {
                 int iKey = m_pKeyMode->process(pWindow);
 
                 VERIFY_OR_DEBUG_ASSERT(ChromaticKey_IsValid(iKey)) {
-                    qWarning() << "No valid key detected in analyzed window:" << iKey;
+                    qInfo() << "No valid key detected in analyzed window:" << iKey;
                     return false;
                 }
                 const auto key = static_cast<ChromaticKey>(iKey);

--- a/src/analyzer/trackanalysisscheduler.cpp
+++ b/src/analyzer/trackanalysisscheduler.cpp
@@ -232,7 +232,7 @@ void TrackAnalysisScheduler::onWorkerThreadProgress(
 
 bool TrackAnalysisScheduler::scheduleTrackById(TrackId trackId) {
     VERIFY_OR_DEBUG_ASSERT(trackId.isValid()) {
-        qWarning()
+        qInfo()
                 << "Cannot schedule track with invalid id"
                 << trackId;
         return false;

--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -78,13 +78,13 @@ void ControlDoublePrivate::insertAlias(const ConfigKey& alias, const ConfigKey& 
 
     auto it = s_qCOHash.constFind(key);
     if (it == s_qCOHash.constEnd()) {
-        qWarning() << "WARNING: ControlDoublePrivate::insertAlias called for null control" << key;
+        qInfo() << "WARNING: ControlDoublePrivate::insertAlias called for null control" << key;
         return;
     }
 
     QSharedPointer<ControlDoublePrivate> pControl = it.value();
     if (pControl.isNull()) {
-        qWarning() << "WARNING: ControlDoublePrivate::insertAlias called for expired control" << key;
+        qInfo() << "WARNING: ControlDoublePrivate::insertAlias called for expired control" << key;
         return;
     }
 
@@ -102,8 +102,8 @@ QSharedPointer<ControlDoublePrivate> ControlDoublePrivate::getControl(
         bool bPersist,
         double defaultValue) {
     VERIFY_OR_DEBUG_ASSERT(key.isValid()) {
-        qWarning() << "ControlDoublePrivate::getControl returning nullptr"
-                   << "for invalid ConfigKey" << key;
+        qInfo() << "ControlDoublePrivate::getControl returning nullptr"
+                << "for invalid ConfigKey" << key;
         return nullptr;
     }
 
@@ -116,7 +116,7 @@ QSharedPointer<ControlDoublePrivate> ControlDoublePrivate::getControl(
             if (pControl) {
                 // Control object already exists
                 VERIFY_OR_DEBUG_ASSERT(!pCreatorCO) {
-                    qWarning()
+                    qInfo()
                             << "ControlObject"
                             << key.group << key.item
                             << "already created";
@@ -145,8 +145,8 @@ QSharedPointer<ControlDoublePrivate> ControlDoublePrivate::getControl(
     }
 
     if (!flags.testFlag(ControlFlag::NoWarnIfMissing)) {
-        qWarning() << "ControlDoublePrivate::getControl returning NULL for ("
-                   << key.group << "," << key.item << ")";
+        qInfo() << "ControlDoublePrivate::getControl returning NULL for ("
+                << key.group << "," << key.item << ")";
         DEBUG_ASSERT(flags.testFlag(ControlFlag::NoAssertIfMissing));
     }
     return nullptr;
@@ -256,7 +256,7 @@ double ControlDoublePrivate::getParameterForValue(double value) const {
 double ControlDoublePrivate::getParameterForMidi(double midiParam) const {
     QSharedPointer<ControlNumericBehavior> pBehavior = m_pBehavior;
     VERIFY_OR_DEBUG_ASSERT(pBehavior) {
-        qWarning() << "Cannot set" << m_key << "by Midi";
+        qInfo() << "Cannot set" << m_key << "by Midi";
         return 0;
     }
     return pBehavior->midiToParameter(midiParam);
@@ -265,7 +265,7 @@ double ControlDoublePrivate::getParameterForMidi(double midiParam) const {
 void ControlDoublePrivate::setValueFromMidi(MidiOpCode opcode, double midiParam) {
     QSharedPointer<ControlNumericBehavior> pBehavior = m_pBehavior;
     VERIFY_OR_DEBUG_ASSERT(pBehavior) {
-        qWarning() << "Cannot set" << m_key << "by Midi";
+        qInfo() << "Cannot set" << m_key << "by Midi";
         return;
     }
     pBehavior->setValueFromMidi(opcode, midiParam, this);
@@ -274,7 +274,7 @@ void ControlDoublePrivate::setValueFromMidi(MidiOpCode opcode, double midiParam)
 double ControlDoublePrivate::getMidiParameter() const {
     QSharedPointer<ControlNumericBehavior> pBehavior = m_pBehavior;
     VERIFY_OR_DEBUG_ASSERT(pBehavior) {
-        qWarning() << "Cannot get" << m_key << "by Midi";
+        qInfo() << "Cannot get" << m_key << "by Midi";
         return 0;
     }
     return pBehavior->valueToMidiParameter(get());

--- a/src/control/controlbehavior.cpp
+++ b/src/control/controlbehavior.cpp
@@ -108,7 +108,8 @@ ControlLogPotmeterBehavior::ControlLogPotmeterBehavior(double dMinValue,
         double dMaxValue, double minDB)
         : ControlPotmeterBehavior(dMinValue, dMaxValue, false) {
     if (minDB >= 0) {
-        qWarning() << "ControlLogPotmeterBehavior::ControlLogPotmeterBehavior() minDB must be negative";
+        qInfo() << "ControlLogPotmeterBehavior::ControlLogPotmeterBehavior() "
+                   "minDB must be negative";
         m_minDB = -1;
     } else {
         m_minDB = minDB;

--- a/src/control/controlobject.cpp
+++ b/src/control/controlobject.cpp
@@ -132,5 +132,5 @@ void ControlObject::setReadOnly() {
 }
 
 void ControlObject::readOnlyHandler(double v) {
-    qWarning() << m_key << "is read-only. Ignoring set of value:" << v;
+    qInfo() << m_key << "is read-only. Ignoring set of value:" << v;
 }

--- a/src/control/controlobjectscript.cpp
+++ b/src/control/controlobjectscript.cpp
@@ -24,10 +24,10 @@ bool ControlObjectScript::addScriptConnection(const ScriptConnection& conn) {
 
     for (const auto& priorConnection: m_scriptConnections) {
         if (conn == priorConnection) {
-            qWarning() << "Connection " + conn.id.toString() +
-                          " already connected to (" +
-                          conn.key.group + ", " + conn.key.item +
-                          "). Ignoring attempt to connect again.";
+            qInfo() << "Connection " + conn.id.toString() +
+                            " already connected to (" +
+                            conn.key.group + ", " + conn.key.item +
+                            "). Ignoring attempt to connect again.";
             return false;
         }
     }
@@ -46,9 +46,9 @@ bool ControlObjectScript::removeScriptConnection(const ScriptConnection& conn) {
                         conn.key.group + ", " + conn.key.item +
                         ") from connection " + conn.id.toString());
     } else {
-        qWarning() << "Failed to disconnect (" +
-                      conn.key.group + ", " + conn.key.item +
-                      ") from connection " + conn.id.toString();
+        qInfo() << "Failed to disconnect (" +
+                        conn.key.group + ", " + conn.key.item +
+                        ") from connection " + conn.id.toString();
     }
     if (m_scriptConnections.isEmpty()) {
         // no ScriptConnections left, so disconnect signals

--- a/src/controllers/bulk/bulkcontroller.cpp
+++ b/src/controllers/bulk/bulkcontroller.cpp
@@ -107,7 +107,7 @@ QString BulkController::presetExtension() {
 void BulkController::visit(const MidiControllerPreset* preset) {
     Q_UNUSED(preset);
     // TODO(XXX): throw a hissy fit.
-    qWarning() << "ERROR: Attempting to load a MidiControllerPreset to an HidController!";
+    qInfo() << "ERROR: Attempting to load a MidiControllerPreset to an HidController!";
 }
 
 void BulkController::visit(const HidControllerPreset* preset) {
@@ -157,7 +157,7 @@ int BulkController::open() {
     }
 
     if (bulk_supported[i].vendor_id == 0) {
-        qWarning() << "USB Bulk device" << getName() << "unsupported";
+        qInfo() << "USB Bulk device" << getName() << "unsupported";
         return -1;
     }
 
@@ -168,7 +168,7 @@ int BulkController::open() {
     }
 
     if (m_phandle == NULL) {
-        qWarning()  << "Unable to open USB Bulk device" << getName();
+        qInfo() << "Unable to open USB Bulk device" << getName();
         return -1;
     }
 
@@ -176,7 +176,7 @@ int BulkController::open() {
     startEngine();
 
     if (m_pReader != NULL) {
-        qWarning() << "BulkReader already present for" << getName();
+        qInfo() << "BulkReader already present for" << getName();
     } else {
         m_pReader = new BulkReader(m_phandle, in_epaddr);
         m_pReader->setObjectName(QString("BulkReader %1").arg(getName()));
@@ -201,8 +201,8 @@ int BulkController::close() {
 
     // Stop the reading thread
     if (m_pReader == NULL) {
-        qWarning() << "BulkReader not present for" << getName()
-                   << "yet the device is open!";
+        qInfo() << "BulkReader not present for" << getName()
+                << "yet the device is open!";
     } else {
         disconnect(m_pReader, &BulkReader::incomingData, this, &BulkController::receive);
         m_pReader->stop();
@@ -243,8 +243,8 @@ void BulkController::send(QByteArray data) {
                                (unsigned char *)data.constData(), data.size(),
                                &transferred, 0);
     if (ret < 0) {
-        qWarning() << "Unable to send data to" << getName()
-                   << "serial #" << m_sUID;
+        qInfo() << "Unable to send data to" << getName()
+                << "serial #" << m_sUID;
     } else {
         controllerDebug(ret << "bytes sent to" << getName()
                  << "serial #" << m_sUID);

--- a/src/controllers/bulk/bulkenumerator.cpp
+++ b/src/controllers/bulk/bulkenumerator.cpp
@@ -52,7 +52,7 @@ QList<Controller*> BulkEnumerator::queryDevices() {
             struct libusb_device_handle *handle = NULL;
             err = libusb_open(device, &handle);
             if (err) {
-                qWarning() << "Error opening a device";
+                qInfo() << "Error opening a device";
                 continue;
             }
 

--- a/src/controllers/controller.cpp
+++ b/src/controllers/controller.cpp
@@ -33,7 +33,7 @@ void Controller::startEngine()
 {
     controllerDebug("  Starting engine");
     if (m_pEngine != NULL) {
-        qWarning() << "Controller: Engine already exists! Restarting:";
+        qInfo() << "Controller: Engine already exists! Restarting:";
         stopEngine();
     }
     m_pEngine = new ControllerEngine(this, m_pConfig);
@@ -42,7 +42,7 @@ void Controller::startEngine()
 void Controller::stopEngine() {
     controllerDebug("  Shutting down engine");
     if (m_pEngine == NULL) {
-        qWarning() << "Controller::stopEngine(): No engine exists!";
+        qInfo() << "Controller::stopEngine(): No engine exists!";
         return;
     }
     m_pEngine->gracefulShutdown();
@@ -57,13 +57,14 @@ bool Controller::applyPreset(bool initializeScripts) {
 
     // Load the script code into the engine
     if (m_pEngine == NULL) {
-        qWarning() << "Controller::applyPreset(): No engine exists!";
+        qInfo() << "Controller::applyPreset(): No engine exists!";
         return false;
     }
 
     QList<ControllerPreset::ScriptFileInfo> scriptFiles = pPreset->getScriptFiles();
     if (scriptFiles.isEmpty()) {
-        qWarning() << "No script functions available! Did the XML file(s) load successfully? See above for any errors.";
+        qInfo() << "No script functions available! Did the XML file(s) load "
+                   "successfully? See above for any errors.";
         return true;
     }
 
@@ -110,7 +111,7 @@ void Controller::triggerActivity()
 void Controller::receive(const QByteArray data, mixxx::Duration timestamp) {
 
     if (m_pEngine == NULL) {
-        //qWarning() << "Controller::receive called with no active engine!";
+        //qInfo() << "Controller::receive called with no active engine!";
         // Don't complain, since this will always show after closing a device as
         //  queued signals flush out
         return;
@@ -140,7 +141,7 @@ void Controller::receive(const QByteArray data, mixxx::Duration timestamp) {
         function.append(".incomingData");
         QScriptValue incomingData = m_pEngine->wrapFunctionCode(function, 2);
         if (!m_pEngine->execute(incomingData, data, timestamp)) {
-            qWarning() << "Controller: Invalid script function" << function;
+            qInfo() << "Controller: Invalid script function" << function;
         }
     }
 }

--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -95,7 +95,7 @@ void ControllerEngine::callFunctionOnObjects(QList<QString> scriptFunctionPrefix
     for (const QString& prefixName : scriptFunctionPrefixes) {
         QScriptValue prefix = global.property(prefixName);
         if (!prefix.isValid() || !prefix.isObject()) {
-            qWarning() << "ControllerEngine: No" << prefixName << "object in script";
+            qInfo() << "ControllerEngine: No" << prefixName << "object in script";
             // Throw a debug assertion if controllerDebug is enabled
             DEBUG_ASSERT(!ControllerDebug::enabled());
             continue;
@@ -103,7 +103,7 @@ void ControllerEngine::callFunctionOnObjects(QList<QString> scriptFunctionPrefix
 
         QScriptValue init = prefix.property(function);
         if (!init.isValid() || !init.isFunction()) {
-            qWarning() << "ControllerEngine:" << prefixName << "has no" << function << " method";
+            qInfo() << "ControllerEngine:" << prefixName << "has no" << function << " method";
             // Throw a debug assertion if controllerDebug is enabled
             DEBUG_ASSERT(!ControllerDebug::enabled());
             continue;
@@ -277,7 +277,7 @@ bool ControllerEngine::loadScriptFiles(const QList<ControllerPreset::ScriptFileI
         }
 
         if (m_scriptErrors.contains(script.name)) {
-            qWarning() << "Errors occurred while loading" << script.name;
+            qInfo() << "Errors occurred while loading" << script.name;
         }
     }
 
@@ -406,7 +406,7 @@ bool ControllerEngine::syntaxIsValid(const QString& scriptCode, const QString& f
         error += QStringLiteral("\n\nCode:\n") + scriptCode;
     }
 
-    qWarning() << "ControllerEngine:" << error;
+    qInfo() << "ControllerEngine:" << error;
     scriptErrorDialog(error, error, true);
     return false;
 }
@@ -457,8 +457,8 @@ bool ControllerEngine::internalExecute(QScriptValue thisObject,
     }
 
     if (functionObject.isError()) {
-        qWarning() << "ControllerEngine::internalExecute:"
-                   << functionObject.toString();
+        qInfo() << "ControllerEngine::internalExecute:"
+                << functionObject.toString();
         // Throw a debug assertion if controllerDebug is enabled
         DEBUG_ASSERT(!ControllerDebug::enabled());
         return false;
@@ -466,8 +466,8 @@ bool ControllerEngine::internalExecute(QScriptValue thisObject,
 
     // If it's not a function, we're done.
     if (!functionObject.isFunction()) {
-        qWarning() << "ControllerEngine::internalExecute:"
-                   << functionObject.toVariant() << "Not a function";
+        qInfo() << "ControllerEngine::internalExecute:"
+                << functionObject.toVariant() << "Not a function";
         // Throw a debug assertion if controllerDebug is enabled
         DEBUG_ASSERT(!ControllerDebug::enabled());
         return false;
@@ -476,7 +476,7 @@ bool ControllerEngine::internalExecute(QScriptValue thisObject,
     // If it does happen to be a function, call it.
     QScriptValue rc = functionObject.call(thisObject, args);
     if (!rc.isValid()) {
-        qWarning() << "QScriptValue is not a function or ...";
+        qInfo() << "QScriptValue is not a function or ...";
         // Throw a debug assertion if controllerDebug is enabled
         DEBUG_ASSERT(!ControllerDebug::enabled());
         return false;
@@ -577,7 +577,7 @@ bool ControllerEngine::checkException(bool bFatal) {
     -------- ------------------------------------------------------ */
 void ControllerEngine::scriptErrorDialog(
         const QString& detailedError, const QString& key, bool bFatalError) {
-    qWarning() << "ControllerEngine:" << detailedError;
+    qInfo() << "ControllerEngine:" << detailedError;
 
     if (!m_bPopups) {
         return;
@@ -655,7 +655,7 @@ ControlObjectScript* ControllerEngine::getControlObjectScript(const QString& gro
     ConfigKey key = ConfigKey(group, name);
 
     if (!key.isValid()) {
-        qWarning() << "ControllerEngine: Requested control with invalid key" << key;
+        qInfo() << "ControllerEngine: Requested control with invalid key" << key;
         // Throw a debug assertion if controllerDebug is enabled
         DEBUG_ASSERT(!ControllerDebug::enabled());
         return nullptr;
@@ -683,7 +683,7 @@ ControlObjectScript* ControllerEngine::getControlObjectScript(const QString& gro
 double ControllerEngine::getValue(QString group, QString name) {
     ControlObjectScript* coScript = getControlObjectScript(group, name);
     if (coScript == nullptr) {
-        qWarning() << "ControllerEngine: Unknown control" << group << name << ", returning 0.0";
+        qInfo() << "ControllerEngine: Unknown control" << group << name << ", returning 0.0";
         return 0.0;
     }
     return coScript->get();
@@ -696,8 +696,8 @@ double ControllerEngine::getValue(QString group, QString name) {
    -------- ------------------------------------------------------ */
 void ControllerEngine::setValue(QString group, QString name, double newValue) {
     if (isnan(newValue)) {
-        qWarning() << "ControllerEngine: script setting [" << group << "," << name
-                 << "] to NotANumber, ignoring.";
+        qInfo() << "ControllerEngine: script setting [" << group << "," << name
+                << "] to NotANumber, ignoring.";
         return;
     }
 
@@ -720,7 +720,7 @@ void ControllerEngine::setValue(QString group, QString name, double newValue) {
 double ControllerEngine::getParameter(QString group, QString name) {
     ControlObjectScript* coScript = getControlObjectScript(group, name);
     if (coScript == nullptr) {
-        qWarning() << "ControllerEngine: Unknown control" << group << name << ", returning 0.0";
+        qInfo() << "ControllerEngine: Unknown control" << group << name << ", returning 0.0";
         return 0.0;
     }
     return coScript->getParameter();
@@ -733,8 +733,8 @@ double ControllerEngine::getParameter(QString group, QString name) {
    -------- ------------------------------------------------------ */
 void ControllerEngine::setParameter(QString group, QString name, double newParameter) {
     if (isnan(newParameter)) {
-        qWarning() << "ControllerEngine: script setting [" << group << "," << name
-                 << "] to NotANumber, ignoring.";
+        qInfo() << "ControllerEngine: script setting [" << group << "," << name
+                << "] to NotANumber, ignoring.";
         return;
     }
 
@@ -756,15 +756,15 @@ void ControllerEngine::setParameter(QString group, QString name, double newParam
    -------- ------------------------------------------------------ */
 double ControllerEngine::getParameterForValue(QString group, QString name, double value) {
     if (isnan(value)) {
-        qWarning() << "ControllerEngine: script setting [" << group << "," << name
-                 << "] to NotANumber, ignoring.";
+        qInfo() << "ControllerEngine: script setting [" << group << "," << name
+                << "] to NotANumber, ignoring.";
         return 0.0;
     }
 
     ControlObjectScript* coScript = getControlObjectScript(group, name);
 
     if (coScript == nullptr) {
-        qWarning() << "ControllerEngine: Unknown control" << group << name << ", returning 0.0";
+        qInfo() << "ControllerEngine: Unknown control" << group << name << ", returning 0.0";
         return 0.0;
     }
 
@@ -792,7 +792,7 @@ double ControllerEngine::getDefaultValue(QString group, QString name) {
     ControlObjectScript* coScript = getControlObjectScript(group, name);
 
     if (coScript == nullptr) {
-        qWarning() << "ControllerEngine: Unknown control" << group << name << ", returning 0.0";
+        qInfo() << "ControllerEngine: Unknown control" << group << name << ", returning 0.0";
         return 0.0;
     }
 
@@ -808,7 +808,7 @@ double ControllerEngine::getDefaultParameter(QString group, QString name) {
     ControlObjectScript* coScript = getControlObjectScript(group, name);
 
     if (coScript == nullptr) {
-        qWarning() << "ControllerEngine: Unknown control" << group << name << ", returning 0.0";
+        qInfo() << "ControllerEngine: Unknown control" << group << name << ", returning 0.0";
         return 0.0;
     }
 
@@ -833,21 +833,21 @@ void ControllerEngine::log(QString message) {
 QScriptValue ControllerEngine::makeConnection(QString group, QString name,
                                               const QScriptValue callback) {
     VERIFY_OR_DEBUG_ASSERT(m_pEngine != nullptr) {
-        qWarning() << "Tried to connect script callback, but there is no script engine!";
+        qInfo() << "Tried to connect script callback, but there is no script engine!";
         return QScriptValue();
     }
 
     ControlObjectScript* coScript = getControlObjectScript(group, name);
     if (coScript == nullptr) {
-        qWarning() << "ControllerEngine: script tried to connect to ControlObject (" +
-                      group + ", " + name +
-                      ") which is non-existent, ignoring.";
+        qInfo() << "ControllerEngine: script tried to connect to ControlObject (" +
+                        group + ", " + name +
+                        ") which is non-existent, ignoring.";
         return QScriptValue();
     }
 
     if (!callback.isFunction()) {
-        qWarning() << "Tried to connect (" + group + ", " + name + ")"
-                   << "to an invalid callback, ignoring.";
+        qInfo() << "Tried to connect (" + group + ", " + name + ")"
+                << "to an invalid callback, ignoring.";
         return QScriptValue();
     }
 
@@ -879,9 +879,9 @@ void ScriptConnection::executeCallback(double value) const {
     QScriptValue func = callback; // copy function because QScriptValue::call is not const
     QScriptValue result = func.call(context, args);
     if (result.isError()) {
-        qWarning() << "ControllerEngine: Invocation of connection " << id.toString()
-                   << "connected to (" + key.group + ", " + key.item + ") failed:"
-                   << result.toString();
+        qInfo() << "ControllerEngine: Invocation of connection " << id.toString()
+                << "connected to (" + key.group + ", " + key.item + ") failed:"
+                << result.toString();
     }
 }
 
@@ -956,11 +956,11 @@ QScriptValue ControllerEngine::connectControl(
     // ControlObjectScript is also needed here to check for duplicate connections.
     if (coScript == nullptr) {
         if (disconnect) {
-            qWarning() << "ControllerEngine: script tried to disconnect from ControlObject (" +
-                          group + ", " + name + ") which is non-existent, ignoring.";
+            qInfo() << "ControllerEngine: script tried to disconnect from ControlObject (" +
+                            group + ", " + name + ") which is non-existent, ignoring.";
         } else {
-            qWarning() << "ControllerEngine: script tried to connect to ControlObject (" +
-                           group + ", " + name + ") which is non-existent, ignoring.";
+            qInfo() << "ControllerEngine: script tried to connect to ControlObject (" +
+                            group + ", " + name + ") which is non-existent, ignoring.";
         }
         // This is inconsistent with other failures, which return false.
         // QScriptValue() with no arguments is undefined in JavaScript.
@@ -971,15 +971,15 @@ QScriptValue ControllerEngine::connectControl(
         // This check is redundant with makeConnection, but it must be done here
         // before evaluating the code string.
         VERIFY_OR_DEBUG_ASSERT(m_pEngine != nullptr) {
-            qWarning() << "Tried to connect script callback, but there is no script engine!";
+            qInfo() << "Tried to connect script callback, but there is no script engine!";
             return QScriptValue(false);
         }
 
         actualCallbackFunction = m_pEngine->evaluate(passedCallback.toString());
 
         if (checkException() || !actualCallbackFunction.isFunction()) {
-            qWarning() << "Could not evaluate callback function:"
-                        << passedCallback.toString();
+            qInfo() << "Could not evaluate callback function:"
+                    << passedCallback.toString();
             return QScriptValue(false);
         }
 
@@ -989,12 +989,12 @@ QScriptValue ControllerEngine::connectControl(
             // not break.
             ScriptConnection connection = coScript->firstConnection();
 
-            qWarning() << "Tried to make duplicate connection between (" +
-                          group + ", " + name + ") and " + passedCallback.toString() +
-                          " but this is not allowed when passing a callback as a string. " +
-                          "If you actually want to create duplicate connections, " +
-                          "use engine.makeConnection. Returning reference to connection " +
-                          connection.id.toString();
+            qInfo() << "Tried to make duplicate connection between (" +
+                            group + ", " + name + ") and " + passedCallback.toString() +
+                            " but this is not allowed when passing a callback as a string. " +
+                            "If you actually want to create duplicate connections, " +
+                            "use engine.makeConnection. Returning reference to connection " +
+                            connection.id.toString();
 
             return m_pEngine->newQObject(
                 new ScriptConnectionInvokableWrapper(connection),
@@ -1008,8 +1008,8 @@ QScriptValue ControllerEngine::connectControl(
         QObject *qobject = passedCallback.toQObject();
         const QMetaObject *qmeta = qobject->metaObject();
 
-        qWarning() << "QObject passed to engine.connectControl. Assuming it is"
-                  << "a connection object to disconnect and returning false.";
+        qInfo() << "QObject passed to engine.connectControl. Assuming it is"
+                << "a connection object to disconnect and returning false.";
         if (!strcmp(qmeta->className(),
                 "ScriptConnectionInvokableWrapper")) {
             ScriptConnectionInvokableWrapper* proxy =
@@ -1062,7 +1062,7 @@ bool ControllerEngine::evaluate(const QFileInfo& scriptFile) {
     }
 
     if (!scriptFile.exists()) {
-        qWarning() << "ControllerEngine: File does not exist:" << scriptFile.absoluteFilePath();
+        qInfo() << "ControllerEngine: File does not exist:" << scriptFile.absoluteFilePath();
         return false;
     }
     m_scriptWatcher.addPath(scriptFile.absoluteFilePath());
@@ -1073,8 +1073,8 @@ bool ControllerEngine::evaluate(const QFileInfo& scriptFile) {
     QString filename = scriptFile.absoluteFilePath();
     QFile input(filename);
     if (!input.open(QIODevice::ReadOnly)) {
-        qWarning() << QString("ControllerEngine: Problem opening the script file: %1, error # %2, %3")
-                .arg(filename, QString::number(input.error()), input.errorString());
+        qInfo() << QString("ControllerEngine: Problem opening the script file: %1, error # %2, %3")
+                           .arg(filename, QString::number(input.error()), input.errorString());
         if (m_bPopups) {
             // Set up error dialog
             ErrorDialogProperties* props = ErrorDialogHandler::instance()->newDialogProperties();
@@ -1133,14 +1133,14 @@ bool ControllerEngine::hasErrors(const QString& filename) {
 int ControllerEngine::beginTimer(int interval, QScriptValue timerCallback,
                                  bool oneShot) {
     if (!timerCallback.isFunction() && !timerCallback.isString()) {
-        qWarning() << "Invalid timer callback provided to beginTimer."
-                   << "Valid callbacks are strings and functions.";
+        qInfo() << "Invalid timer callback provided to beginTimer."
+                << "Valid callbacks are strings and functions.";
         return 0;
     }
 
     if (interval < 20) {
-        qWarning() << "Timer request for" << interval
-                   << "ms is too short. Setting to the minimum of 20ms.";
+        qInfo() << "Timer request for" << interval
+                << "ms is too short. Setting to the minimum of 20ms.";
         interval = 20;
     }
 
@@ -1154,7 +1154,7 @@ int ControllerEngine::beginTimer(int interval, QScriptValue timerCallback,
     info.oneShot = oneShot;
     m_timers[timerId] = info;
     if (timerId == 0) {
-        qWarning() << "Script timer could not be created";
+        qInfo() << "Script timer could not be created";
     } else if (oneShot) {
         controllerDebug("Starting one-shot timer:" << timerId);
     } else {
@@ -1170,7 +1170,7 @@ int ControllerEngine::beginTimer(int interval, QScriptValue timerCallback,
    -------- ------------------------------------------------------ */
 void ControllerEngine::stopTimer(int timerId) {
     if (!m_timers.contains(timerId)) {
-        qWarning() << "Killing timer" << timerId << ": That timer does not exist!";
+        qInfo() << "Killing timer" << timerId << ": That timer does not exist!";
         return;
     }
     controllerDebug("Killing timer:" << timerId);
@@ -1197,7 +1197,7 @@ void ControllerEngine::timerEvent(QTimerEvent *event) {
 
     auto it = m_timers.constFind(timerId);
     if (it == m_timers.constEnd()) {
-        qWarning() << "Timer" << timerId << "fired but there's no function mapped to it!";
+        qInfo() << "Timer" << timerId << "fired but there's no function mapped to it!";
         return;
     }
 
@@ -1270,7 +1270,7 @@ void ControllerEngine::scratchEnable(int deck, int intervalsPerRev, double rpm,
     double intervalsPerSecond = (rpm * intervalsPerRev) / 60.0;
 
     if (intervalsPerSecond == 0.0) {
-        qWarning() << "Invalid rpm or intervalsPerRev supplied to scratchEnable. Ignoring request.";
+        qInfo() << "Invalid rpm or intervalsPerRev supplied to scratchEnable. Ignoring request.";
         return;
     }
 
@@ -1347,7 +1347,7 @@ void ControllerEngine::scratchProcess(int timerId) {
     QString group = PlayerManager::groupForDeck(deck - 1);
     AlphaBetaFilter* filter = m_scratchFilters[deck];
     if (!filter) {
-        qWarning() << "Scratch filter pointer is null on deck" << deck;
+        qInfo() << "Scratch filter pointer is null on deck" << deck;
         return;
     }
 
@@ -1472,8 +1472,8 @@ void ControllerEngine::softTakeover(QString group, QString name, bool set) {
     ConfigKey key = ConfigKey(group, name);
     ControlObject* pControl = ControlObject::getControl(key, onlyAssertOnControllerDebug());
     if (!pControl) {
-        qWarning() << "Failed to" << (set ? "enable" : "disable")
-                   << "softTakeover for invalid control" << key;
+        qInfo() << "Failed to" << (set ? "enable" : "disable")
+                << "softTakeover for invalid control" << key;
         return;
     }
     if (set) {
@@ -1497,7 +1497,7 @@ void ControllerEngine::softTakeoverIgnoreNextValue(
     ConfigKey key = ConfigKey(group, name);
     ControlObject* pControl = ControlObject::getControl(key, onlyAssertOnControllerDebug());
     if (!pControl) {
-        qWarning() << "Failed to call softTakeoverIgnoreNextValue for invalid control" << key;
+        qInfo() << "Failed to call softTakeoverIgnoreNextValue for invalid control" << key;
         return;
     }
 

--- a/src/controllers/controllermanager.cpp
+++ b/src/controllers/controllermanager.cpp
@@ -180,7 +180,7 @@ void ControllerManager::slotShutdown() {
 void ControllerManager::updateControllerList() {
     QMutexLocker locker(&m_mutex);
     if (m_enumerators.isEmpty()) {
-        qWarning() << "updateControllerList called but no enumerators have been added!";
+        qInfo() << "updateControllerList called but no enumerators have been added!";
         return;
     }
     QList<ControllerEnumerator*> enumerators = m_enumerators;
@@ -283,7 +283,7 @@ void ControllerManager::slotSetUpDevices() {
 
         int value = pController->open();
         if (value != 0) {
-            qWarning() << "There was a problem opening" << name;
+            qInfo() << "There was a problem opening" << name;
             continue;
         }
         pController->applyPreset();
@@ -401,7 +401,7 @@ void ControllerManager::slotApplyPreset(Controller* pController,
         ControllerPresetPointer pPreset,
         bool bEnabled) {
     VERIFY_OR_DEBUG_ASSERT(pController) {
-        qWarning() << "slotApplyPreset got invalid controller!";
+        qInfo() << "slotApplyPreset got invalid controller!";
         return;
     }
 
@@ -414,7 +414,7 @@ void ControllerManager::slotApplyPreset(Controller* pController,
     }
 
     VERIFY_OR_DEBUG_ASSERT(!pPreset->isDirty()) {
-        qWarning() << "Preset is dirty, changes might be lost on restart!";
+        qInfo() << "Preset is dirty, changes might be lost on restart!";
     }
 
     pController->setPreset(*pPreset);

--- a/src/controllers/controllerpresetinfo.cpp
+++ b/src/controllers/controllerpresetinfo.cpp
@@ -39,7 +39,7 @@ PresetInfo::PresetInfo(const QString& preset_path)
 
     QDomElement root = XmlParse::openXMLFile(m_path, "controller");
     if (root.isNull()) {
-        qWarning() << "ERROR parsing" << m_path;
+        qInfo() << "ERROR parsing" << m_path;
         return;
     }
     QDomElement info = root.firstChildElement("info");

--- a/src/controllers/dlgcontrollerlearning.cpp
+++ b/src/controllers/dlgcontrollerlearning.cpp
@@ -271,7 +271,7 @@ void DlgControllerLearning::slotFirstMessageTimeout() {
     if (m_messages.length() == 0) {
         labelErrorText->setText(tr("Didn't get any midi messages.  Please try again."));
     } else {
-        qWarning() << "we shouldn't time out if we got something";
+        qInfo() << "we shouldn't time out if we got something";
         m_messages.clear();
     }
     stackedWidget->setCurrentWidget(page1Choose);
@@ -397,12 +397,12 @@ void DlgControllerLearning::visit(MidiController* pMidiController) {
 }
 
 void DlgControllerLearning::visit(HidController* pHidController) {
-    qWarning() << "ERROR: DlgControllerLearning does not support HID devices.";
+    qInfo() << "ERROR: DlgControllerLearning does not support HID devices.";
     Q_UNUSED(pHidController);
 }
 
 void DlgControllerLearning::visit(BulkController* pBulkController) {
-    qWarning() << "ERROR: DlgControllerLearning does not support Bulk devices.";
+    qInfo() << "ERROR: DlgControllerLearning does not support Bulk devices.";
     Q_UNUSED(pBulkController);
 }
 
@@ -463,8 +463,9 @@ void DlgControllerLearning::controlClicked(ControlObject* pControl) {
 
     ConfigKey key = pControl->getKey();
     if (!m_controlPickerMenu.controlExists(key)) {
-        qWarning() << "Mixxx UI element clicked for which there is no "
-                      "learnable control " << key.group << " " << key.item;
+        qInfo() << "Mixxx UI element clicked for which there is no "
+                   "learnable control "
+                << key.group << " " << key.item;
         QMessageBox::warning(
                     this,
                     Version::applicationName(),

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -92,7 +92,7 @@ QString HidController::presetExtension() {
 void HidController::visit(const MidiControllerPreset* preset) {
     Q_UNUSED(preset);
     // TODO(XXX): throw a hissy fit.
-    qWarning() << "ERROR: Attempting to load a MidiControllerPreset to an HidController!";
+    qInfo() << "ERROR: Attempting to load a MidiControllerPreset to an HidController!";
 }
 
 void HidController::visit(const HidControllerPreset* preset) {
@@ -197,21 +197,21 @@ int HidController::open() {
     // If it does fail, try without serial number WARNING: This will only open
     // one of multiple identical devices
     if (m_pHidDevice == NULL) {
-        qWarning() << "Unable to open specific HID device" << getName()
-                   << "Trying now with just make and model."
-                   << "(This may only open the first of multiple identical devices.)";
+        qInfo() << "Unable to open specific HID device" << getName()
+                << "Trying now with just make and model."
+                << "(This may only open the first of multiple identical devices.)";
         m_pHidDevice = hid_open(hid_vendor_id, hid_product_id, NULL);
     }
 
     // If that fails, we give up!
     if (m_pHidDevice == NULL) {
-        qWarning()  << "Unable to open HID device" << getName();
+        qInfo() << "Unable to open HID device" << getName();
         return -1;
     }
 
     // Set hid controller to non-blocking
     if (hid_set_nonblocking(m_pHidDevice, 1) != 0) {
-        qWarning() << "Unable to set HID device " << getName() << " to non-blocking";
+        qInfo() << "Unable to set HID device " << getName() << " to non-blocking";
         return -1;
     }
 
@@ -279,12 +279,12 @@ void HidController::send(QByteArray data, unsigned int reportID) {
     int result = hid_write(m_pHidDevice, (unsigned char*)data.constData(), data.size());
     if (result == -1) {
         if (ControllerDebug::enabled()) {
-            qWarning() << "Unable to send data to" << getName()
-                       << "serial #" << hid_serial << ":"
-                       << safeDecodeWideString(hid_error(m_pHidDevice), 512);
+            qInfo() << "Unable to send data to" << getName()
+                    << "serial #" << hid_serial << ":"
+                    << safeDecodeWideString(hid_error(m_pHidDevice), 512);
         } else {
-            qWarning() << "Unable to send data to" << getName() << ":"
-                       << safeDecodeWideString(hid_error(m_pHidDevice), 512);
+            qInfo() << "Unable to send data to" << getName() << ":"
+                    << safeDecodeWideString(hid_error(m_pHidDevice), 512);
         }
     } else {
         controllerDebug(result << "bytes sent to" << getName()

--- a/src/controllers/hid/hidenumerator.cpp
+++ b/src/controllers/hid/hidenumerator.cpp
@@ -95,7 +95,8 @@ QList<Controller*> HidEnumerator::queryDevices() {
                      QString("Interface %1").arg(cur_dev->interface_number));
 
         if (!cur_dev->serial_number && !cur_dev->product_string) {
-            qWarning() << "USB permissions problem (or device error.) Your account needs write access to USB HID controllers.";
+            qInfo() << "USB permissions problem (or device error.) Your "
+                       "account needs write access to USB HID controllers.";
             continue;
         }
 

--- a/src/controllers/midi/hss1394controller.cpp
+++ b/src/controllers/midi/hss1394controller.cpp
@@ -42,7 +42,7 @@ void DeviceChannelListener::Process(const hss1394::uint8 *pBuffer, hss1394::uint
                     velocity = pBuffer[i+2];
                     emit incomingData(status, note, velocity, timestamp);
                 } else {
-                    qWarning() << "Buffer underflow in DeviceChannelListener::Process()";
+                    qInfo() << "Buffer underflow in DeviceChannelListener::Process()";
                 }
                 i += 3;
                 break;
@@ -134,7 +134,7 @@ int Hss1394Controller::open() {
         int iPeriod = 60000/1000;   // 1000Hz = 1ms. (Internal clock is 60kHz.)
         int iTimer = 3; // 3 for new event timer, 4 for second �same position repeated� timer
         if (m_pChannel->SendUserControl(iTimer, (const hss1394::uint8*)&iPeriod, 3) == 0)
-            qWarning() << "Unable to set SCS.1d platter timer period.";
+            qInfo() << "Unable to set SCS.1d platter timer period.";
     }
 
     setOpen(true);

--- a/src/controllers/midi/midicontroller.cpp
+++ b/src/controllers/midi/midicontroller.cpp
@@ -44,7 +44,7 @@ int MidiController::close() {
 
 void MidiController::visit(const HidControllerPreset* preset) {
     Q_UNUSED(preset);
-    qWarning() << "ERROR: Attempting to load an HidControllerPreset to a MidiController!";
+    qInfo() << "ERROR: Attempting to load an HidControllerPreset to a MidiController!";
     // TODO(XXX): throw a hissy fit.
 }
 
@@ -107,7 +107,7 @@ void MidiController::createOutputHandlers() {
                         .arg(QString::number(status, 16).toUpper(),
                              QString::number(control, 16).toUpper().rightJustified(2,'0'))
                         .arg(group, key).toUtf8();
-            qWarning() << errorLog;
+            qInfo() << errorLog;
 
             int deckNum = 0;
             if (ControllerDebug::enabled()) {
@@ -270,9 +270,9 @@ void MidiController::processInputMapping(const MidiInputMapping& mapping,
     bool mapping_is_14bit = mapping.options.fourteen_bit_msb ||
             mapping.options.fourteen_bit_lsb;
     if (!mapping_is_14bit && !m_fourteen_bit_queued_mappings.isEmpty()) {
-        qWarning() << "MidiController was waiting for the MSB/LSB of a 14-bit"
-                   << "message but the next message received was not mapped as 14-bit."
-                   << "Ignoring the original message.";
+        qInfo() << "MidiController was waiting for the MSB/LSB of a 14-bit"
+                << "message but the next message received was not mapped as 14-bit."
+                << "Ignoring the original message.";
         m_fourteen_bit_queued_mappings.clear();
     }
 
@@ -285,8 +285,9 @@ void MidiController::processInputMapping(const MidiInputMapping& mapping,
             if (it->first.control == mapping.control) {
                 if ((it->first.options.fourteen_bit_lsb && mapping.options.fourteen_bit_lsb) ||
                     (it->first.options.fourteen_bit_msb && mapping.options.fourteen_bit_msb)) {
-                    qWarning() << "MidiController: 14-bit MIDI mapping has mis-matched LSB/MSB options."
-                               << "Ignoring both messages.";
+                    qInfo() << "MidiController: 14-bit MIDI mapping has "
+                               "mis-matched LSB/MSB options."
+                            << "Ignoring both messages.";
                     m_fourteen_bit_queued_mappings.erase(it);
                     return;
                 }
@@ -501,6 +502,6 @@ void MidiController::processInputMapping(const MidiInputMapping& mapping,
         }
         return;
     }
-    qWarning() << "MidiController: No script function specified for"
-               << MidiUtils::formatSysexMessage(getName(), data, timestamp);
+    qInfo() << "MidiController: No script function specified for"
+            << MidiUtils::formatSysexMessage(getName(), data, timestamp);
 }

--- a/src/controllers/midi/midioutputhandler.cpp
+++ b/src/controllers/midi/midioutputhandler.cpp
@@ -51,7 +51,7 @@ void MidiOutputHandler::controlChanged(double value) {
     }
 
     if (!m_pController->isOpen()) {
-        qWarning() << "MIDI device" << m_pController->getName() << "not open for output!";
+        qInfo() << "MIDI device" << m_pController->getName() << "not open for output!";
     } else if (byte3 != 0xFF) {
         controllerDebug("sending MIDI bytes:" << m_mapping.output.status
                      << "," << m_mapping.output.control << ","

--- a/src/controllers/midi/portmidicontroller.cpp
+++ b/src/controllers/midi/portmidicontroller.cpp
@@ -67,7 +67,7 @@ int PortMidiController::open() {
         PmError err = m_pInputDevice->openInput(MIXXX_PORTMIDI_BUFFER_LEN);
 
         if (err != pmNoError) {
-            qWarning() << "PortMidi error:" << Pm_GetErrorText(err);
+            qInfo() << "PortMidi error:" << Pm_GetErrorText(err);
             return -2;
         }
     }
@@ -78,7 +78,7 @@ int PortMidiController::open() {
 
         PmError err = m_pOutputDevice->openOutput();
         if (err != pmNoError) {
-            qWarning() << "PortMidi error:" << Pm_GetErrorText(err);
+            qInfo() << "PortMidi error:" << Pm_GetErrorText(err);
             return -2;
         }
     }
@@ -102,7 +102,7 @@ int PortMidiController::close() {
     if (m_pInputDevice && m_pInputDevice->isOpen()) {
         PmError err = m_pInputDevice->close();
         if (err != pmNoError) {
-            qWarning() << "PortMidi error:" << Pm_GetErrorText(err);
+            qInfo() << "PortMidi error:" << Pm_GetErrorText(err);
             result = -1;
         }
     }
@@ -110,7 +110,7 @@ int PortMidiController::close() {
     if (m_pOutputDevice && m_pOutputDevice->isOpen()) {
         PmError err = m_pOutputDevice->close();
         if (err != pmNoError) {
-            qWarning() << "PortMidi error:" << Pm_GetErrorText(err);
+            qInfo() << "PortMidi error:" << Pm_GetErrorText(err);
             result = -1;
         }
     }
@@ -131,7 +131,7 @@ bool PortMidiController::poll() {
         return false;
     }
     if (gotEvents < 0) {
-        qWarning() << "PortMidi error:" << Pm_GetErrorText(gotEvents);
+        qInfo() << "PortMidi error:" << Pm_GetErrorText(gotEvents);
         return false;
     }
 
@@ -140,7 +140,7 @@ bool PortMidiController::poll() {
     //qDebug() << "PortMidiController::poll()" << numEvents;
 
     if (numEvents < 0) {
-        qWarning() << "PortMidi error:" << Pm_GetErrorText((PmError)numEvents);
+        qInfo() << "PortMidi error:" << Pm_GetErrorText((PmError)numEvents);
         return false;
     }
 
@@ -174,7 +174,7 @@ bool PortMidiController::poll() {
             if (status > 0x7F && status < 0xF7) {
                 m_bInSysex = false;
                 m_cReceiveMsg_index = 0;
-                qWarning() << "Buggy MIDI device: SysEx interrupted!";
+                qInfo() << "Buggy MIDI device: SysEx interrupted!";
                 goto reprocessMessage;    // Don't lose the new message
             }
 
@@ -220,12 +220,14 @@ void PortMidiController::sendShortMsg(unsigned char status, unsigned char byte1,
                                                      MidiUtils::opCodeFromStatus(status)));
     } else {
         // Use two qWarnings() to ensure line break works on all operating systems
-        qWarning() << "Error sending short message"
-                      << MidiUtils::formatMidiMessage(getName(),
-                                                      status, byte1, byte2,
-                                                      MidiUtils::channelFromStatus(status),
-                                                      MidiUtils::opCodeFromStatus(status));
-        qWarning()    << "PortMidi error:" << Pm_GetErrorText(err);
+        qInfo() << "Error sending short message"
+                << MidiUtils::formatMidiMessage(getName(),
+                           status,
+                           byte1,
+                           byte2,
+                           MidiUtils::channelFromStatus(status),
+                           MidiUtils::opCodeFromStatus(status));
+        qInfo() << "PortMidi error:" << Pm_GetErrorText(err);
     }
 }
 
@@ -248,8 +250,8 @@ void PortMidiController::send(QByteArray data) {
         controllerDebug(MidiUtils::formatSysexMessage(getName(), data));
     } else {
         // Use two qWarnings() to ensure line break works on all operating systems
-        qWarning() << "Error sending SysEx message:"
-                   << MidiUtils::formatSysexMessage(getName(), data);
-        qWarning() << "PortMidi error:" << Pm_GetErrorText(err);
+        qInfo() << "Error sending SysEx message:"
+                << MidiUtils::formatSysexMessage(getName(), data);
+        qInfo() << "PortMidi error:" << Pm_GetErrorText(err);
     }
 }

--- a/src/controllers/midi/portmidienumerator.cpp
+++ b/src/controllers/midi/portmidienumerator.cpp
@@ -26,7 +26,7 @@ PortMidiEnumerator::PortMidiEnumerator(UserSettingsPointer pConfig)
     PmError err = Pm_Initialize();
     // Based on reading the source, it's not possible for this to fail.
     if (err != pmNoError) {
-        qWarning() << "PortMidi error:" << Pm_GetErrorText(err);
+        qInfo() << "PortMidi error:" << Pm_GetErrorText(err);
     }
 }
 
@@ -39,7 +39,7 @@ PortMidiEnumerator::~PortMidiEnumerator() {
     PmError err = Pm_Terminate();
     // Based on reading the source, it's not possible for this to fail.
     if (err != pmNoError) {
-        qWarning() << "PortMidi error:" << Pm_GetErrorText(err);
+        qInfo() << "PortMidi error:" << Pm_GetErrorText(err);
     }
 }
 

--- a/src/dialog/dlgabout.cpp
+++ b/src/dialog/dlgabout.cpp
@@ -27,7 +27,7 @@ DlgAbout::DlgAbout(QWidget* parent) : QDialog(parent), Ui::DlgAboutDlg() {
 
     QFile licenseFile(":/LICENSE");
     if (!licenseFile.open(QIODevice::ReadOnly)) {
-        qWarning() << "LICENSE file not found";
+        qInfo() << "LICENSE file not found";
     } else {
         licenseText->setPlainText(licenseFile.readAll());
     }

--- a/src/dialog/dlgdevelopertools.cpp
+++ b/src/dialog/dlgdevelopertools.cpp
@@ -56,7 +56,7 @@ DlgDeveloperTools::DlgDeveloperTools(QWidget* pParent,
     QString logFileName = QDir(pConfig->getSettingsPath()).filePath("mixxx.log");
     m_logFile.setFileName(logFileName);
     if (!m_logFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        qWarning() << "ERROR: Could not open log file:" << logFileName;
+        qInfo() << "ERROR: Could not open log file:" << logFileName;
     }
 
     // Connect search box signals to the library
@@ -140,7 +140,7 @@ void DlgDeveloperTools::slotControlDump() {
     // Note: QFile is closed if it falls out of scope
     dumpFile.setFileName(dumpFileName);
     if (!dumpFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
-        qWarning() << "open" << dumpFileName << "failed";
+        qInfo() << "open" << dumpFileName << "failed";
         return;
     }
 

--- a/src/dialog/dlgreplacecuecolor.cpp
+++ b/src/dialog/dlgreplacecuecolor.cpp
@@ -257,8 +257,8 @@ void DlgReplaceCueColor::slotApply() {
 
     // Open the database connection in this thread.
     VERIFY_OR_DEBUG_ASSERT(database.isOpen()) {
-        qWarning() << "Failed to open database for cue color replace dialog."
-                   << database.lastError();
+        qInfo() << "Failed to open database for cue color replace dialog."
+                << database.lastError();
         m_bDatabaseChangeInProgress = false;
         slotUpdateWidgets();
         return;

--- a/src/effects/effect.cpp
+++ b/src/effects/effect.cpp
@@ -23,7 +23,9 @@ Effect::Effect(EffectsManager* pEffectsManager,
                 this, pEffectsManager, m_parameters.size(), pManifestParameter);
         m_parameters.append(pParameter);
         if (m_parametersById.contains(pParameter->id())) {
-            qWarning() << debugString() << "WARNING: Loaded EffectManifest that had parameters with duplicate IDs. Dropping one of them.";
+            qInfo() << debugString()
+                    << "WARNING: Loaded EffectManifest that had parameters "
+                       "with duplicate IDs. Dropping one of them.";
         }
         m_parametersById[pParameter->id()] = pParameter;
     }
@@ -159,8 +161,8 @@ unsigned int Effect::numButtonParameters() const {
 EffectParameter* Effect::getParameterById(const QString& id) const {
     EffectParameter* pParameter = m_parametersById.value(id, NULL);
     if (pParameter == NULL) {
-        qWarning() << debugString() << "getParameterById"
-                   << "WARNING: parameter for id does not exist:" << id;
+        qInfo() << debugString() << "getParameterById"
+                << "WARNING: parameter for id does not exist:" << id;
     }
     return pParameter;
 }

--- a/src/effects/effectbuttonparameterslot.cpp
+++ b/src/effects/effectbuttonparameterslot.cpp
@@ -63,7 +63,9 @@ void EffectButtonParameterSlot::loadEffect(EffectPointer pEffect) {
             if (dValue > dMaximum || dValue < dMinimum ||
                 dMinimum < dMinimumLimit || dMaximum > dMaximumLimit ||
                 dDefault > dMaximum || dDefault < dMinimum) {
-                qWarning() << debugString() << "WARNING: EffectParameter does not satisfy basic sanity checks.";
+                qInfo() << debugString()
+                        << "WARNING: EffectParameter does not satisfy basic "
+                           "sanity checks.";
             }
 
             // qDebug() << debugString()

--- a/src/effects/effectchainmanager.cpp
+++ b/src/effects/effectchainmanager.cpp
@@ -119,7 +119,9 @@ EffectChainPointer EffectChainManager::getNextEffectChain(EffectChainPointer pEf
 
     int indexOf = m_effectChains.lastIndexOf(pEffectChain);
     if (indexOf == -1) {
-        qWarning() << debugString() << "WARNING: getNextEffectChain called for an unmanaged EffectChain";
+        qInfo() << debugString()
+                << "WARNING: getNextEffectChain called for an unmanaged "
+                   "EffectChain";
         return m_effectChains[0];
     }
 
@@ -136,7 +138,9 @@ EffectChainPointer EffectChainManager::getPrevEffectChain(EffectChainPointer pEf
 
     int indexOf = m_effectChains.lastIndexOf(pEffectChain);
     if (indexOf == -1) {
-        qWarning() << debugString() << "WARNING: getPrevEffectChain called for an unmanaged EffectChain";
+        qInfo() << debugString()
+                << "WARNING: getPrevEffectChain called for an unmanaged "
+                   "EffectChain";
         return m_effectChains[m_effectChains.size()-1];
     }
 

--- a/src/effects/effectchainslot.cpp
+++ b/src/effects/effectchainslot.cpp
@@ -174,7 +174,7 @@ void EffectChainSlot::slotChainEffectChanged(unsigned int effectSlotNumber,
         EffectPointer pEffect;
 
         if (effects.size() > m_slots.size()) {
-            qWarning() << debugString() << "has too few slots for effect";
+            qInfo() << debugString() << "has too few slots for effect";
         }
 
         if (effectSlotNumber < (unsigned) m_slots.size()) {
@@ -351,7 +351,7 @@ void EffectChainSlot::slotClearEffect(unsigned int iEffectSlotNumber) {
 EffectSlotPointer EffectChainSlot::getEffectSlot(unsigned int slotNumber) {
     //qDebug() << debugString() << "getEffectSlot" << slotNumber;
     if (slotNumber >= static_cast<unsigned int>(m_slots.size())) {
-        qWarning() << "WARNING: slotNumber out of range";
+        qInfo() << "WARNING: slotNumber out of range";
         return EffectSlotPointer();
     }
     return m_slots[slotNumber];
@@ -375,7 +375,7 @@ void EffectChainSlot::slotControlChainMix(double v) {
 
     // Clamp to [0.0, 1.0]
     if (v < 0.0 || v > 1.0) {
-        qWarning() << debugString() << "value out of limits";
+        qInfo() << debugString() << "value out of limits";
         v = math_clamp(v, 0.0, 1.0);
         m_pControlChainMix->set(v);
     }
@@ -389,7 +389,7 @@ void EffectChainSlot::slotControlChainSuperParameter(double v, bool force) {
 
     // Clamp to [0.0, 1.0]
     if (v < 0.0 || v > 1.0) {
-        qWarning() << debugString() << "value out of limits";
+        qInfo() << debugString() << "value out of limits";
         v = math_clamp(v, 0.0, 1.0);
         m_pControlChainSuperParameter->set(v);
     }

--- a/src/effects/effectparameter.cpp
+++ b/src/effects/effectparameter.cpp
@@ -20,7 +20,7 @@ EffectParameter::EffectParameter(Effect* pEffect, EffectsManager* pEffectsManage
      m_maximum = m_pParameter->getMaximum();
      // Sanity check the maximum and minimum
      if (m_minimum > m_maximum) {
-         qWarning() << debugString() << "WARNING: Parameter maximum is less than the minimum.";
+         qInfo() << debugString() << "WARNING: Parameter maximum is less than the minimum.";
          m_maximum = m_minimum;
      }
 
@@ -28,7 +28,9 @@ EffectParameter::EffectParameter(Effect* pEffect, EffectsManager* pEffectsManage
      // value.
      m_default = m_pParameter->getDefault();
      if (m_default < m_minimum || m_default > m_maximum) {
-         qWarning() << debugString() << "WARNING: Parameter default is outside of minimum/maximum range.";
+         qInfo() << debugString()
+                 << "WARNING: Parameter default is outside of minimum/maximum "
+                    "range.";
          m_default = m_minimum;
      }
 
@@ -110,7 +112,7 @@ void EffectParameter::setValue(double value) {
     m_value = value;
 
     if (clampValue()) {
-        qWarning() << debugString() << "WARNING: Value was outside of limits, clamped.";
+        qInfo() << debugString() << "WARNING: Value was outside of limits, clamped.";
     }
 
     updateEngineState();
@@ -125,7 +127,9 @@ void EffectParameter::setDefault(double dflt) {
     m_default = dflt;
 
     if (clampDefault()) {
-        qWarning() << debugString() << "WARNING: Default parameter value was outside of range, clamped.";
+        qInfo() << debugString()
+                << "WARNING: Default parameter value was outside of range, "
+                   "clamped.";
     }
 
     m_default = dflt;
@@ -149,21 +153,23 @@ void EffectParameter::setMinimum(double minimum) {
 
     m_minimum = minimum;
     if (m_minimum < m_pParameter->getMinimum()) {
-        qWarning() << debugString() << "WARNING: Minimum value is less than plugin's absolute minimum, clamping.";
+        qInfo() << debugString()
+                << "WARNING: Minimum value is less than plugin's absolute "
+                   "minimum, clamping.";
         m_minimum = m_pParameter->getMinimum();
     }
 
     if (m_minimum > m_maximum) {
-        qWarning() << debugString() << "WARNING: New minimum was above maximum, clamped.";
+        qInfo() << debugString() << "WARNING: New minimum was above maximum, clamped.";
         m_minimum = m_maximum;
     }
 
     if (clampValue()) {
-        qWarning() << debugString() << "WARNING: Value was outside of new minimum, clamped.";
+        qInfo() << debugString() << "WARNING: Value was outside of new minimum, clamped.";
     }
 
     if (clampDefault()) {
-        qWarning() << debugString() << "WARNING: Default was outside of new minimum, clamped.";
+        qInfo() << debugString() << "WARNING: Default was outside of new minimum, clamped.";
     }
 
     updateEngineState();
@@ -185,21 +191,23 @@ void EffectParameter::setMaximum(double maximum) {
 
     m_maximum = maximum;
     if (m_maximum > m_pParameter->getMaximum()) {
-        qWarning() << debugString() << "WARNING: Maximum value is less than plugin's absolute maximum, clamping.";
+        qInfo() << debugString()
+                << "WARNING: Maximum value is less than plugin's absolute "
+                   "maximum, clamping.";
         m_maximum = m_pParameter->getMaximum();
     }
 
     if (m_maximum < m_minimum) {
-        qWarning() << debugString() << "WARNING: New maximum was below the minimum, clamped.";
+        qInfo() << debugString() << "WARNING: New maximum was below the minimum, clamped.";
         m_maximum = m_minimum;
     }
 
     if (clampValue()) {
-        qWarning() << debugString() << "WARNING: Value was outside of new maximum, clamped.";
+        qInfo() << debugString() << "WARNING: Value was outside of new maximum, clamped.";
     }
 
     if (clampDefault()) {
-        qWarning() << debugString() << "WARNING: Default was outside of new maximum, clamped.";
+        qInfo() << debugString() << "WARNING: Default was outside of new maximum, clamped.";
     }
 
     updateEngineState();

--- a/src/effects/effectparameterslot.cpp
+++ b/src/effects/effectparameterslot.cpp
@@ -72,7 +72,9 @@ void EffectParameterSlot::loadEffect(EffectPointer pEffect) {
             if (dValue > dMaximum || dValue < dMinimum ||
                 dMinimum < dMinimumLimit || dMaximum > dMaximumLimit ||
                 dDefault > dMaximum || dDefault < dMinimum) {
-                qWarning() << debugString() << "WARNING: EffectParameter does not satisfy basic sanity checks.";
+                qInfo() << debugString()
+                        << "WARNING: EffectParameter does not satisfy basic "
+                           "sanity checks.";
             }
 
             //qDebug() << debugString()

--- a/src/effects/effectprocessor.h
+++ b/src/effects/effectprocessor.h
@@ -145,11 +145,12 @@ class EffectProcessorImpl : public EffectProcessor {
         EffectSpecificState* pState = m_channelStateMatrix[inputHandle][outputHandle];
         VERIFY_OR_DEBUG_ASSERT(pState != nullptr) {
             if (kEffectDebugOutput) {
-                qWarning() << "EffectProcessorImpl::process could not retrieve"
-                              "EffectState for input" << inputHandle
-                           << "and output" << outputHandle
-                           << "EffectState should have been preallocated in the"
-                              "main thread.";
+                qInfo() << "EffectProcessorImpl::process could not retrieve"
+                           "EffectState for input"
+                        << inputHandle
+                        << "and output" << outputHandle
+                        << "EffectState should have been preallocated in the"
+                           "main thread.";
             }
             pState = createSpecificState(bufferParameters);
             m_channelStateMatrix[inputHandle][outputHandle] = pState;

--- a/src/effects/effectrack.cpp
+++ b/src/effects/effectrack.cpp
@@ -99,7 +99,7 @@ void EffectRack::addEffectChainSlotInternal(EffectChainSlotPointer pChainSlot) {
 
 EffectChainSlotPointer EffectRack::getEffectChainSlot(int i) {
     if (i < 0 || i >= m_effectChainSlots.size()) {
-        qWarning() << "WARNING: Invalid index for getEffectChainSlot";
+        qInfo() << "WARNING: Invalid index for getEffectChainSlot";
         return EffectChainSlotPointer();
     }
     return m_effectChainSlots[i];

--- a/src/effects/effectsbackend.cpp
+++ b/src/effects/effectsbackend.cpp
@@ -18,7 +18,7 @@ void EffectsBackend::registerEffect(const QString& id,
                                     EffectManifestPointer pManifest,
                                     EffectInstantiatorPointer pInstantiator) {
     if (m_registeredEffects.contains(id)) {
-        qWarning() << "WARNING: Effect" << id << "already registered";
+        qInfo() << "WARNING: Effect" << id << "already registered";
         return;
     }
 
@@ -35,7 +35,7 @@ const QList<QString> EffectsBackend::getEffectIds() const {
 
 EffectManifestPointer EffectsBackend::getManifest(const QString& effectId) const {
     if (!m_registeredEffects.contains(effectId)) {
-        qWarning() << "WARNING: Effect" << effectId << "is not registered.";
+        qInfo() << "WARNING: Effect" << effectId << "is not registered.";
         return EffectManifestPointer();
     }
     return m_registeredEffects[effectId].manifest();
@@ -48,7 +48,7 @@ bool EffectsBackend::canInstantiateEffect(const QString& effectId) const {
 EffectPointer EffectsBackend::instantiateEffect(EffectsManager* pEffectsManager,
                                                 const QString& effectId) {
     if (!m_registeredEffects.contains(effectId)) {
-        qWarning() << "WARNING: Effect" << effectId << "is not registered.";
+        qInfo() << "WARNING: Effect" << effectId << "is not registered.";
         return EffectPointer();
     }
     RegisteredEffect& effectInfo = m_registeredEffects[effectId];

--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -135,7 +135,7 @@ void EffectSlot::slotEffectEnabledChanged(bool enabled) {
 EffectParameterSlotPointer EffectSlot::getEffectParameterSlot(unsigned int slotNumber) {
     //qDebug() << debugString() << "getEffectParameterSlot" << slotNumber;
     if (slotNumber >= static_cast<unsigned int>(m_parameters.size())) {
-        qWarning() << "WARNING: slotNumber out of range";
+        qInfo() << "WARNING: slotNumber out of range";
         return EffectParameterSlotPointer();
     }
     return m_parameters[slotNumber];
@@ -144,7 +144,7 @@ EffectParameterSlotPointer EffectSlot::getEffectParameterSlot(unsigned int slotN
 EffectButtonParameterSlotPointer EffectSlot::getEffectButtonParameterSlot(unsigned int slotNumber) {
     //qDebug() << debugString() << "getEffectParameterSlot" << slotNumber;
     if (slotNumber >= static_cast<unsigned int>(m_buttonParameters.size())) {
-        qWarning() << "WARNING: slotNumber out of range";
+        qInfo() << "WARNING: slotNumber out of range";
         return EffectButtonParameterSlotPointer();
     }
     return m_buttonParameters[slotNumber];
@@ -268,7 +268,7 @@ void EffectSlot::setMetaParameter(double v, bool force) {
 void EffectSlot::slotEffectMetaParameter(double v, bool force) {
     // Clamp to [0.0, 1.0]
     if (v < 0.0 || v > 1.0) {
-        qWarning() << debugString() << "value out of limits";
+        qInfo() << debugString() << "value out of limits";
         v = math_clamp(v, 0.0, 1.0);
         m_pControlMetaParameter->set(v);
     }
@@ -344,8 +344,8 @@ void EffectSlot::loadEffectSlotFromXml(const QDomElement& effectElement) {
     QDomElement effectIdElement = XmlParse::selectElement(effectElement,
                                                           EffectXml::EffectId);
     if (m_pEffect->getManifest()->id() != effectIdElement.text()) {
-        qWarning() << "EffectSlot::loadEffectSlotFromXml"
-                   << "effect ID in XML does not match presently loaded effect, ignoring.";
+        qInfo() << "EffectSlot::loadEffectSlotFromXml"
+                << "effect ID in XML does not match presently loaded effect, ignoring.";
         return;
     }
 

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -446,9 +446,9 @@ void EffectsManager::processEffectsResponses() {
                 m_activeRequests.find(response.request_id);
 
         VERIFY_OR_DEBUG_ASSERT(it != m_activeRequests.end()) {
-            qWarning() << debugString()
-                       << "WARNING: EffectsResponse with an inactive request_id:"
-                       << response.request_id;
+            qInfo() << debugString()
+                    << "WARNING: EffectsResponse with an inactive request_id:"
+                    << response.request_id;
         }
 
         while (it != m_activeRequests.end() &&

--- a/src/effects/lv2/lv2backend.cpp
+++ b/src/effects/lv2/lv2backend.cpp
@@ -85,7 +85,7 @@ LV2Manifest* LV2Backend::getLV2Manifest(const QString& effectId) const {
 EffectPointer LV2Backend::instantiateEffect(EffectsManager* pEffectsManager,
                                             const QString& effectId) {
     if (!canInstantiateEffect(effectId)) {
-        qWarning() << "WARNING: Effect" << effectId << "is not registered.";
+        qInfo() << "WARNING: Effect" << effectId << "is not registered.";
         return EffectPointer();
     }
     LV2Manifest* lv2manifest = m_registeredEffects[effectId];

--- a/src/effects/lv2/lv2effectprocessor.cpp
+++ b/src/effects/lv2/lv2effectprocessor.cpp
@@ -101,11 +101,12 @@ void LV2EffectProcessor::process(const ChannelHandle& inputHandle,
     LV2EffectGroupState* pState = m_channelStateMatrix[inputHandle][outputHandle];
     VERIFY_OR_DEBUG_ASSERT(pState != nullptr) {
         if (kEffectDebugOutput) {
-            qWarning() << "LV2EffectProcessor::process could not retrieve"
-                          "handle for input" << inputHandle
-                       << "and output" << outputHandle
-                       << "Handle should have been preallocated in the"
-                          "main thread.";
+            qInfo() << "LV2EffectProcessor::process could not retrieve"
+                       "handle for input"
+                    << inputHandle
+                    << "and output" << outputHandle
+                    << "Handle should have been preallocated in the"
+                       "main thread.";
         }
         pState = createGroupState(bufferParameters);
         m_channelStateMatrix[inputHandle][outputHandle] = pState;

--- a/src/encoder/encoder.cpp
+++ b/src/encoder/encoder.cpp
@@ -71,8 +71,8 @@ Encoder::Format EncoderFactory::getFormatFor(QString formatText) const
             return format;
         }
     }
-    qWarning() << "Format: " << formatText << " not recognized! Returning format "
-        << m_formats.first().internalName;
+    qInfo() << "Format: " << formatText << " not recognized! Returning format "
+            << m_formats.first().internalName;
     return m_formats.first();
 }
 
@@ -120,7 +120,7 @@ EncoderPointer EncoderFactory::createEncoder(
     }
 #endif
     else {
-        qWarning() << "Unsupported format requested! "
+        qInfo() << "Unsupported format requested! "
                 << QString(pSettings ? pSettings->getFormat() : QString("NULL"));
         DEBUG_ASSERT(false);
         pEncoder = std::make_shared<EncoderWave>(pCallback);;
@@ -144,7 +144,7 @@ EncoderRecordingSettingsPointer EncoderFactory::getEncoderRecordingSettings(Enco
     } else if (format.internalName == ENCODING_OPUS) {
         return std::make_shared<EncoderOpusSettings>(pConfig);
     } else {
-        qWarning() << "Unsupported format requested! " << format.internalName;
+        qInfo() << "Unsupported format requested! " << format.internalName;
         DEBUG_ASSERT(false);
         return std::make_shared<EncoderWaveSettings>(pConfig, ENCODING_WAVE);
     }

--- a/src/encoder/encoderbroadcastsettings.cpp
+++ b/src/encoder/encoderbroadcastsettings.cpp
@@ -37,8 +37,8 @@ int EncoderBroadcastSettings::getQuality() const {
         return bitrate;
     }
     else {
-        qWarning() << "Invalid bitrate in EncoderBroadcastSettings " 
-            << bitrate << ". Ignoring it and returning default";
+        qInfo() << "Invalid bitrate in EncoderBroadcastSettings "
+                << bitrate << ". Ignoring it and returning default";
     }
     return DEFAULT_BITRATE;
 }
@@ -59,4 +59,3 @@ EncoderSettings::ChannelMode EncoderBroadcastSettings::getChannelMode() const {
 QString EncoderBroadcastSettings::getFormat() const {
     return m_pProfile->getFormat();
 }
-

--- a/src/encoder/encoderflacsettings.cpp
+++ b/src/encoder/encoderflacsettings.cpp
@@ -54,7 +54,7 @@ void EncoderFlacSettings::setCompression(int compression) {
         m_pConfig->set(ConfigKey(RECORDING_PREF_KEY, GROUP_COMPRESSION),
             ConfigValue(compression));
     } else {
-        qWarning() << "Received a compression value out of range: " << compression;
+        qInfo() << "Received a compression value out of range: " << compression;
     }
 }
 int EncoderFlacSettings::getCompression() const
@@ -62,8 +62,8 @@ int EncoderFlacSettings::getCompression() const
     int value = m_pConfig->getValue(ConfigKey(RECORDING_PREF_KEY, GROUP_COMPRESSION),
             DEFAULT_QUALITY_VALUE);
     if (!m_qualList.contains(value)) {
-        qWarning() << "Value saved for compression on preferences is out of range "
-                   << value << ". Returning default compression";
+        qInfo() << "Value saved for compression on preferences is out of range "
+                << value << ". Returning default compression";
         value=DEFAULT_QUALITY_VALUE;
     }
     return value;
@@ -87,13 +87,13 @@ void EncoderFlacSettings::setGroupOption(QString groupCode, int optionIndex) {
                 m_pConfig->set(ConfigKey(RECORDING_PREF_KEY, groupCode),
                     ConfigValue(optionIndex));
             } else {
-                qWarning() << "Received an index out of range for: "
-                           << groupCode << ", index: " << optionIndex;
+                qInfo() << "Received an index out of range for: "
+                        << groupCode << ", index: " << optionIndex;
             }
         }
     }
     if (!found) {
-        qWarning() << "Received an unknown groupCode on setGroupOption: " << groupCode;
+        qInfo() << "Received an unknown groupCode on setGroupOption: " << groupCode;
     }
 }
 // Return the selected option of the group. If it is a single-element option,
@@ -105,15 +105,15 @@ int EncoderFlacSettings::getSelectedOption(QString groupCode) const {
         if (groupCode == group.groupCode) {
             found=true;
             if (value >= group.controlNames.size() && value > 1) {
-                qWarning() << "Value saved for " << groupCode
-                           << " on preferences is out of range " << value
-                           << ". Returning 0";
+                qInfo() << "Value saved for " << groupCode
+                        << " on preferences is out of range " << value
+                        << ". Returning 0";
                 value=0;
             }
         }
     }
     if (!found) {
-        qWarning() << "Received an unknown groupCode on getSelectedOption: " << groupCode;
+        qInfo() << "Received an unknown groupCode on getSelectedOption: " << groupCode;
     }
     return value;
 }

--- a/src/encoder/encodermp3settings.cpp
+++ b/src/encoder/encodermp3settings.cpp
@@ -63,8 +63,8 @@ void EncoderMp3Settings::setQualityByIndex(int qualityIndex)
     if (qualityIndex >= 0 && qualityIndex < m_qualList.size()) {
         m_pConfig->set(ConfigKey(RECORDING_PREF_KEY, "MP3_Quality"), ConfigValue(qualityIndex));
     } else {
-        qWarning() << "Invalid qualityIndex given to EncoderMp3Settings: "
-                   << qualityIndex << ". Ignoring it";
+        qInfo() << "Invalid qualityIndex given to EncoderMp3Settings: "
+                << qualityIndex << ". Ignoring it";
     }
 }
 
@@ -80,9 +80,9 @@ int EncoderMp3Settings::getQualityIndex() const
         return qualityIndex;
     }
     else {
-        qWarning() << "Invalid qualityIndex in EncoderMp3Settings"
-                   << qualityIndex << "(Max is:" << m_qualList.size() << "). Ignoring it"
-                   << "and returning default, which is:" << DEFAULT_BITRATE_INDEX;
+        qInfo() << "Invalid qualityIndex in EncoderMp3Settings"
+                << qualityIndex << "(Max is:" << m_qualList.size() << "). Ignoring it"
+                << "and returning default, which is:" << DEFAULT_BITRATE_INDEX;
     }
     return DEFAULT_BITRATE_INDEX;
 }
@@ -104,13 +104,13 @@ void EncoderMp3Settings::setGroupOption(QString groupCode, int optionIndex)
                 m_pConfig->set(ConfigKey(RECORDING_PREF_KEY, ENCODING_MODE_GROUP),
                     ConfigValue(optionIndex));
             } else {
-                qWarning() << "Received an index out of range for: "
-                           << groupCode << ", index: " << optionIndex;
+                qInfo() << "Received an index out of range for: "
+                        << groupCode << ", index: " << optionIndex;
             }
         }
     }
     if (!found) {
-        qWarning() << "Received an unknown groupCode on setGroupOption: " << groupCode;
+        qInfo() << "Received an unknown groupCode on setGroupOption: " << groupCode;
     }
 }
 // Return the selected option of the group. If it is a single-element option,
@@ -124,15 +124,15 @@ int EncoderMp3Settings::getSelectedOption(QString groupCode) const
         if (groupCode == group.groupCode) {
             found=true;
             if (value >= group.controlNames.size() && value > 1) {
-                qWarning() << "Value saved for " << groupCode
-                           << " on preferences is out of range " << value
-                           << ". Returning 0";
+                qInfo() << "Value saved for " << groupCode
+                        << " on preferences is out of range " << value
+                        << ". Returning 0";
                 value=0;
             }
         }
     }
     if (!found) {
-        qWarning() << "Received an unknown groupCode on getSelectedOption: " << groupCode;
+        qInfo() << "Received an unknown groupCode on getSelectedOption: " << groupCode;
     }
     return value;
 }

--- a/src/encoder/encodersndfileflac.cpp
+++ b/src/encoder/encodersndfileflac.cpp
@@ -29,8 +29,8 @@ void EncoderSndfileFlac::setEncoderSettings(const EncoderSettings& settings)
             break;
         default:
             m_sfInfo.format |= SF_FORMAT_PCM_16;
-            qWarning() << " Unexpected radio index on setEncoderSettings: "
-                       << radio << ". reverting to Flac 16bits";
+            qInfo() << " Unexpected radio index on setEncoderSettings: "
+                    << radio << ". reverting to Flac 16bits";
             break;
     }
 

--- a/src/encoder/encodervorbissettings.cpp
+++ b/src/encoder/encodervorbissettings.cpp
@@ -38,8 +38,8 @@ void EncoderVorbisSettings::setQualityByIndex(int qualityIndex)
     if (qualityIndex >= 0 && qualityIndex < m_qualList.size()) {
         m_pConfig->setValue<int>(ConfigKey(RECORDING_PREF_KEY, "OGG_Quality"), qualityIndex);
     } else {
-        qWarning() << "Invalid qualityIndex given to EncoderVorbisSettings: "
-                   << qualityIndex << ". Ignoring it";
+        qInfo() << "Invalid qualityIndex given to EncoderVorbisSettings: "
+                << qualityIndex << ". Ignoring it";
     }
 }
 
@@ -64,9 +64,9 @@ int EncoderVorbisSettings::getQualityIndex() const
         return qualityIndex;
     }
     else {
-        qWarning() << "Invalid qualityIndex in EncoderVorbisSettings "
-                   << qualityIndex << "(Max is:" << m_qualList.size() << ") . Ignoring it and"
-                   << "returning default which is" << DEFAULT_BITRATE_INDEX;
+        qInfo() << "Invalid qualityIndex in EncoderVorbisSettings "
+                << qualityIndex << "(Max is:" << m_qualList.size() << ") . Ignoring it and"
+                << "returning default which is" << DEFAULT_BITRATE_INDEX;
         return DEFAULT_BITRATE_INDEX;
     }
 }

--- a/src/encoder/encoderwave.cpp
+++ b/src/encoder/encoderwave.cpp
@@ -49,7 +49,7 @@ static sf_count_t  sf_f_read (void *ptr, sf_count_t count, void *user_data)
     Q_UNUSED(ptr);
     Q_UNUSED(count);
     Q_UNUSED(user_data);
-    qWarning() << "sf_f_read called for EncoderWave. Call not implemented!";
+    qInfo() << "sf_f_read called for EncoderWave. Call not implemented!";
     return 0;
 }
 
@@ -106,7 +106,7 @@ void EncoderWave::setEncoderSettings(const EncoderSettings& settings) {
     } else if (format == ENCODING_AIFF) {
         m_sfInfo.format = SF_FORMAT_AIFF;
     } else {
-        qWarning() << "Unexpected Format when setting EncoderWave: " << format << ". Reverting to wav";
+        qInfo() << "Unexpected Format when setting EncoderWave: " << format << ". Reverting to wav";
         // Other possibly interesting formats
         // There is a n option for RF64 to automatically downgrade to RIFF WAV if less than 4GB using an
         // sf_command, so it could be interesting to use it in place of FORMAT_WAVE.
@@ -132,7 +132,7 @@ void EncoderWave::setEncoderSettings(const EncoderSettings& settings) {
             break;
         default:
             m_sfInfo.format = SF_FORMAT_WAV | SF_FORMAT_PCM_16;
-            qWarning() << " Unexpected radio index on EncoderWave: "
+            qInfo() << " Unexpected radio index on EncoderWave: "
                     << radio << ". reverting to PCM 16bits";
             break;
     }

--- a/src/encoder/encoderwavesettings.cpp
+++ b/src/encoder/encoderwavesettings.cpp
@@ -16,8 +16,8 @@ EncoderWaveSettings::EncoderWaveSettings(UserSettingsPointer pConfig,
           m_format(std::move(format)) {
     VERIFY_OR_DEBUG_ASSERT(m_format == ENCODING_WAVE || m_format == ENCODING_AIFF) {
         m_format = ENCODING_WAVE;
-        qWarning() << "EncoderWaveSettings setup with " << m_format
-                   << ". This is an error! Changing it to " << m_format;
+        qInfo() << "EncoderWaveSettings setup with " << m_format
+                << ". This is an error! Changing it to " << m_format;
     }
     QList<QString> names;
     names.append(QObject::tr("16 bits"));
@@ -44,13 +44,13 @@ void EncoderWaveSettings::setGroupOption(QString groupCode, int optionIndex) {
                         ConfigKey(RECORDING_PREF_KEY, m_format + "_" + groupCode),
                         ConfigValue(optionIndex));
             } else {
-                qWarning() << "Received an index out of range for: "
-                           << groupCode << ", index: " << optionIndex;
+                qInfo() << "Received an index out of range for: "
+                        << groupCode << ", index: " << optionIndex;
             }
         }
     }
     if (!found) {
-        qWarning() << "Received an unknown groupCode on setGroupOption: " << groupCode;
+        qInfo() << "Received an unknown groupCode on setGroupOption: " << groupCode;
     }
 }
 // Return the selected option of the group. If it is a single-element option,
@@ -63,15 +63,15 @@ int EncoderWaveSettings::getSelectedOption(QString groupCode) const {
         if (groupCode == group.groupCode) {
             found=true;
             if (value >= group.controlNames.size() && value > 1) {
-                qWarning() << "Value saved for " << groupCode
-                           << " on preferences is out of range " << value
-                           << ". Returning 0";
+                qInfo() << "Value saved for " << groupCode
+                        << " on preferences is out of range " << value
+                        << ". Returning 0";
                 value=0;
             }
         }
     }
     if (!found) {
-        qWarning() << "Received an unknown groupCode on getSelectedOption: " << groupCode;
+        qInfo() << "Received an unknown groupCode on getSelectedOption: " << groupCode;
     }
     return value;
 }

--- a/src/engine/bufferscalers/enginebufferscalerubberband.cpp
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.cpp
@@ -80,10 +80,10 @@ void EngineBufferScaleRubberBand::setScaleParameters(double base_rate,
     }
 
     if (m_pRubberBand->getInputIncrement() == 0) {
-        qWarning() << "EngineBufferScaleRubberBand inputIncrement is 0."
-                   << "On RubberBand <=1.8.1 a SIGFPE is imminent despite"
-                   << "our workaround. Taking evasive action."
-                   << "Please report this message to mixxx-devel@lists.sourceforge.net.";
+        qInfo() << "EngineBufferScaleRubberBand inputIncrement is 0."
+                << "On RubberBand <=1.8.1 a SIGFPE is imminent despite"
+                << "our workaround. Taking evasive action."
+                << "Please report this message to mixxx-devel@lists.sourceforge.net.";
 
         // This is much slower than the minimum seek speed workaround above.
         while (m_pRubberBand->getInputIncrement() == 0) {

--- a/src/engine/channels/enginemicrophone.cpp
+++ b/src/engine/channels/enginemicrophone.cpp
@@ -46,7 +46,7 @@ bool EngineMicrophone::isActive() {
 void EngineMicrophone::onInputConfigured(AudioInput input) {
     if (input.getType() != AudioPath::MICROPHONE) {
         // This is an error!
-        qWarning() << "EngineMicrophone connected to AudioInput for a non-Microphone type!";
+        qInfo() << "EngineMicrophone connected to AudioInput for a non-Microphone type!";
         return;
     }
     m_sampleBuffer = NULL;
@@ -56,7 +56,7 @@ void EngineMicrophone::onInputConfigured(AudioInput input) {
 void EngineMicrophone::onInputUnconfigured(AudioInput input) {
     if (input.getType() != AudioPath::MICROPHONE) {
         // This is an error!
-        qWarning() << "EngineMicrophone connected to AudioInput for a non-Microphone type!";
+        qInfo() << "EngineMicrophone connected to AudioInput for a non-Microphone type!";
         return;
     }
     m_sampleBuffer = NULL;

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -1219,15 +1219,15 @@ void CueControl::introStartSet(double v) {
     double outroStart = m_pOutroStartPosition->get();
     double outroEnd = m_pOutroEndPosition->get();
     if (introEnd != Cue::kNoPosition && position >= introEnd) {
-        qWarning() << "Trying to place intro start cue on or after intro end cue.";
+        qInfo() << "Trying to place intro start cue on or after intro end cue.";
         return;
     }
     if (outroStart != Cue::kNoPosition && position >= outroStart) {
-        qWarning() << "Trying to place intro start cue on or after outro start cue.";
+        qInfo() << "Trying to place intro start cue on or after outro start cue.";
         return;
     }
     if (outroEnd != Cue::kNoPosition && position >= outroEnd) {
-        qWarning() << "Trying to place intro start cue on or after outro end cue.";
+        qInfo() << "Trying to place intro start cue on or after outro end cue.";
         return;
     }
 
@@ -1295,15 +1295,15 @@ void CueControl::introEndSet(double v) {
     double outroStart = m_pOutroStartPosition->get();
     double outroEnd = m_pOutroEndPosition->get();
     if (introStart != Cue::kNoPosition && position <= introStart) {
-        qWarning() << "Trying to place intro end cue on or before intro start cue.";
+        qInfo() << "Trying to place intro end cue on or before intro start cue.";
         return;
     }
     if (outroStart != Cue::kNoPosition && position >= outroStart) {
-        qWarning() << "Trying to place intro end cue on or after outro start cue.";
+        qInfo() << "Trying to place intro end cue on or after outro start cue.";
         return;
     }
     if (outroEnd != Cue::kNoPosition && position >= outroEnd) {
-        qWarning() << "Trying to place intro end cue on or after outro end cue.";
+        qInfo() << "Trying to place intro end cue on or after outro end cue.";
         return;
     }
 
@@ -1371,15 +1371,15 @@ void CueControl::outroStartSet(double v) {
     double introEnd = m_pIntroEndPosition->get();
     double outroEnd = m_pOutroEndPosition->get();
     if (introStart != Cue::kNoPosition && position <= introStart) {
-        qWarning() << "Trying to place outro start cue on or before intro start cue.";
+        qInfo() << "Trying to place outro start cue on or before intro start cue.";
         return;
     }
     if (introEnd != Cue::kNoPosition && position <= introEnd) {
-        qWarning() << "Trying to place outro start cue on or before intro end cue.";
+        qInfo() << "Trying to place outro start cue on or before intro end cue.";
         return;
     }
     if (outroEnd != Cue::kNoPosition && position >= outroEnd) {
-        qWarning() << "Trying to place outro start cue on or after outro end cue.";
+        qInfo() << "Trying to place outro start cue on or after outro end cue.";
         return;
     }
 
@@ -1447,15 +1447,15 @@ void CueControl::outroEndSet(double v) {
     double introEnd = m_pIntroEndPosition->get();
     double outroStart = m_pOutroStartPosition->get();
     if (introStart != Cue::kNoPosition && position <= introStart) {
-        qWarning() << "Trying to place outro end cue on or before intro start cue.";
+        qInfo() << "Trying to place outro end cue on or before intro start cue.";
         return;
     }
     if (introEnd != Cue::kNoPosition && position <= introEnd) {
-        qWarning() << "Trying to place outro end cue on or before intro end cue.";
+        qInfo() << "Trying to place outro end cue on or before intro end cue.";
         return;
     }
     if (outroStart != Cue::kNoPosition && position <= outroStart) {
-        qWarning() << "Trying to place outro end cue on or before outro start cue.";
+        qInfo() << "Trying to place outro end cue on or before outro start cue.";
         return;
     }
 
@@ -1920,7 +1920,7 @@ void HotcueControl::slotHotcuePositionChanged(double newPosition) {
 
 void HotcueControl::slotHotcueColorChangeRequest(double color) {
     if (color < 0 || color > 0xFFFFFF) {
-        qWarning() << "slotHotcueColorChanged got invalid value:" << color;
+        qInfo() << "slotHotcueColorChanged got invalid value:" << color;
         return;
     }
     m_hotcueColor->setAndConfirm(color);

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -1279,8 +1279,8 @@ double LoopingControl::seekInsideAdjustedLoop(
         VERIFY_OR_DEBUG_ASSERT(adjusted_position > new_loop_in) {
             // I'm not even sure this is possible.  The new loop would have to be bigger than the
             // old loop, and the playhead was somehow outside the old loop.
-            qWarning() << "SHOULDN'T HAPPEN: seekInsideAdjustedLoop couldn't find a new position --"
-                       << " seeking to in point";
+            qInfo() << "SHOULDN'T HAPPEN: seekInsideAdjustedLoop couldn't find a new position --"
+                    << " seeking to in point";
             adjusted_position = new_loop_in;
             break;
         }
@@ -1288,8 +1288,8 @@ double LoopingControl::seekInsideAdjustedLoop(
     while (adjusted_position < new_loop_in) {
         adjusted_position += new_loop_size;
         VERIFY_OR_DEBUG_ASSERT(adjusted_position < new_loop_out) {
-            qWarning() << "SHOULDN'T HAPPEN: seekInsideAdjustedLoop couldn't find a new position --"
-                       << " seeking to in point";
+            qInfo() << "SHOULDN'T HAPPEN: seekInsideAdjustedLoop couldn't find a new position --"
+                    << " seeking to in point";
             adjusted_position = new_loop_in;
             break;
         }

--- a/src/engine/controls/vinylcontrolcontrol.cpp
+++ b/src/engine/controls/vinylcontrolcontrol.cpp
@@ -112,7 +112,7 @@ void VinylControlControl::slotControlVinylSeek(double fractionalPos) {
             // Continue processing in this function.
             break;
         default:
-            qWarning() << "Invalid vinyl cue setting";
+            qInfo() << "Invalid vinyl cue setting";
             return;
         }
 

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1187,7 +1187,7 @@ void EngineBuffer::processSeek(bool paused) {
             // new position was already set above
             break;
         default:
-            qWarning() << "Unhandled seek request type: " << seekType;
+            qInfo() << "Unhandled seek request type: " << seekType;
             return;
     }
 

--- a/src/engine/enginesidechaincompressor.cpp
+++ b/src/engine/enginesidechaincompressor.cpp
@@ -67,7 +67,7 @@ double EngineSideChainCompressor::calculateCompressedGain(int frames) {
         }
     } else {
         VERIFY_OR_DEBUG_ASSERT(m_compressRatio >= 0) {
-            qWarning() << "Programming error, below-zero compression detected.";
+            qInfo() << "Programming error, below-zero compression detected.";
         }
         if (m_compressRatio < 1) {
             m_compressRatio += m_decayPerFrame * frames;

--- a/src/engine/sidechain/enginerecord.cpp
+++ b/src/engine/sidechain/enginerecord.cpp
@@ -64,7 +64,7 @@ void EngineRecord::updateFromPreferences() {
 
     QString errorMsg;
     if(m_pEncoder->initEncoder(m_sampleRate, errorMsg) < 0) {
-        qWarning() << errorMsg;
+        qInfo() << errorMsg;
         m_pEncoder.reset();
     }
 }

--- a/src/engine/sidechain/shoutconnection.cpp
+++ b/src/engine/sidechain/shoutconnection.cpp
@@ -123,7 +123,7 @@ ShoutConnection::~ShoutConnection() {
 
     // Signal user if thread doesn't die
     VERIFY_OR_DEBUG_ASSERT(!isRunning()) {
-       qWarning() << "ShoutOutput::~ShoutOutput(): Thread didn't die.\
+        qInfo() << "ShoutOutput::~ShoutOutput(): Thread didn't die.\
        Ignored but file a bug report if problems rise!";
     }
 }
@@ -370,7 +370,7 @@ void ShoutConnection::updateFromPreferences() {
     } else if (m_format_is_ov || m_format_is_opus) {
         format = SHOUT_FORMAT_OGG;
     } else {
-        qWarning() << "Error: unknown format:" << baFormat.constData();
+        qInfo() << "Error: unknown format:" << baFormat.constData();
         return;
     }
 
@@ -380,7 +380,7 @@ void ShoutConnection::updateFromPreferences() {
     }
 
     if (iBitrate < 0) {
-        qWarning() << "Error: unknown bit rate:" << iBitrate;
+        qInfo() << "Error: unknown bit rate:" << iBitrate;
     }
 
     int iMasterSamplerate = m_pMasterSamplerate->get();
@@ -521,8 +521,8 @@ bool ShoutConnection::processConnect() {
             m_iShoutStatus == SHOUTERR_NOLOGIN ||
             m_iShoutStatus == SHOUTERR_MALLOC) {
             m_lastErrorStr = shout_get_error(m_pShout);
-            qWarning() << "Streaming server made fatal error. Can't continue connecting:"
-                       << m_lastErrorStr;
+            qInfo() << "Streaming server made fatal error. Can't continue connecting:"
+                    << m_lastErrorStr;
             break;
         }
 
@@ -551,7 +551,7 @@ bool ShoutConnection::processConnect() {
             if (m_iShoutStatus != SHOUTERR_BUSY &&
                     m_iShoutStatus != SHOUTERR_SUCCESS &&
                     m_iShoutStatus != SHOUTERR_CONNECTED) {
-                qWarning() << "Streaming server made error:" << m_iShoutStatus;
+                qInfo() << "Streaming server made error:" << m_iShoutStatus;
             }
 
             // If socket is busy then we wait half second
@@ -860,7 +860,7 @@ void ShoutConnection::updateMetaData() {
 }
 
 void ShoutConnection::errorDialog(QString text, QString detailedError) {
-    qWarning() << "Streaming error: " << detailedError;
+    qInfo() << "Streaming error: " << detailedError;
     ErrorDialogProperties* props = ErrorDialogHandler::instance()->newDialogProperties();
     props->setType(DLG_WARNING);
     props->setTitle(tr("Connection error"));

--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -342,7 +342,7 @@ void EngineSync::notifyBeatDistanceChanged(Syncable* pSyncable, double beat_dist
 
 void EngineSync::activateFollower(Syncable* pSyncable) {
     if (pSyncable == nullptr) {
-        qWarning() << "WARNING: Logic Error: Called activateFollower on a nullptr Syncable.";
+        qInfo() << "WARNING: Logic Error: Called activateFollower on a nullptr Syncable.";
         return;
     }
 
@@ -353,7 +353,7 @@ void EngineSync::activateFollower(Syncable* pSyncable) {
 
 void EngineSync::activateMaster(Syncable* pSyncable, bool explicitMaster) {
     VERIFY_OR_DEBUG_ASSERT(pSyncable) {
-        qWarning() << "WARNING: Logic Error: Called activateMaster on a nullptr Syncable.";
+        qInfo() << "WARNING: Logic Error: Called activateMaster on a nullptr Syncable.";
         return;
     }
     if (kLogger.traceEnabled()) {

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -137,9 +137,9 @@ void SyncControl::setSyncMode(SyncMode mode) {
     if (mode != SYNC_NONE && m_pPassthroughEnabled->get()) {
         // If any sync mode is enabled and passthrough was on somehow, disable passthrough.
         // This is very unlikely to happen so this deserves a warning.
-        qWarning() << "Notified of sync mode change when passthrough was "
-                      "active -- "
-                      "must disable passthrough";
+        qInfo() << "Notified of sync mode change when passthrough was "
+                   "active -- "
+                   "must disable passthrough";
         m_pPassthroughEnabled->set(0.0);
     }
     if (isMaster(mode)) {
@@ -223,7 +223,7 @@ void SyncControl::setMasterBpm(double bpm) {
     }
 
     VERIFY_OR_DEBUG_ASSERT(isSynchronized()) {
-        qWarning() << "WARNING: Logic Error: setBpm called on SYNC_NONE syncable.";
+        qInfo() << "WARNING: Logic Error: setBpm called on SYNC_NONE syncable.";
         return;
     }
 

--- a/src/errordialoghandler.cpp
+++ b/src/errordialoghandler.cpp
@@ -149,7 +149,7 @@ void ErrorDialogHandler::errorDialog(ErrorDialogProperties* pProps) {
 
     // Check we are in the main thread.
     if (QThread::currentThread()->objectName() != "Main") {
-        qWarning() << "WARNING: errorDialog not called in the main thread. Not showing error dialog.";
+        qInfo() << "WARNING: errorDialog not called in the main thread. Not showing error dialog.";
         return;
     }
 
@@ -224,18 +224,18 @@ void ErrorDialogHandler::boxClosed(QString key, QMessageBox* msgBox) {
     // If the user clicks "Ignore," we leave the key in the list so the same
     // error is not displayed again for the duration of the session
     if (whichStdButton == QMessageBox::Ignore) {
-        qWarning() << "Suppressing this" << msgBox->windowTitle()
-                   << "error box for the duration of the application.";
+        qInfo() << "Suppressing this" << msgBox->windowTitle()
+                << "error box for the duration of the application.";
         return;
     }
 
     QMutexLocker locker2(&m_mutex);
     if (m_dialogKeys.contains(key)) {
         if (!m_dialogKeys.removeOne(key)) {
-            qWarning() << "Error dialog key removal from list failed!";
+            qInfo() << "Error dialog key removal from list failed!";
         }
     } else {
-        qWarning() << "Error dialog key is missing from key list!";
+        qInfo() << "Error dialog key is missing from key list!";
     }
 }
 

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -40,7 +40,7 @@ namespace {
             playlistId = playlistDAO.createPlaylist(
                     AUTODJ_TABLE, PlaylistDAO::PLHT_AUTO_DJ);
             VERIFY_OR_DEBUG_ASSERT(playlistId >= 0) {
-                qWarning() << "Failed to create Auto DJ playlist!";
+                qInfo() << "Failed to create Auto DJ playlist!";
             }
         }
         return playlistId;
@@ -254,14 +254,14 @@ void AutoDJFeature::slotAddRandomTrack() {
             if (randomTrackId.isValid()) {
                 pRandomTrack = m_pTrackCollection->getTrackById(randomTrackId);
                 VERIFY_OR_DEBUG_ASSERT(pRandomTrack) {
-                    qWarning() << "Track does not exist:"
+                    qInfo() << "Track does not exist:"
                             << randomTrackId;
                     continue;
                 }
                 if (!pRandomTrack->checkFileExists()) {
-                    qWarning() << "Track does not exist:"
-                               << pRandomTrack->getInfo()
-                               << pRandomTrack->getFileInfo();
+                    qInfo() << "Track does not exist:"
+                            << pRandomTrack->getInfo()
+                            << pRandomTrack->getFileInfo();
                     pRandomTrack.reset();
                 }
             }
@@ -273,7 +273,7 @@ void AutoDJFeature::slotAddRandomTrack() {
             return; // success
         }
     }
-    qWarning() << "Could not load random track.";
+    qInfo() << "Could not load random track.";
 }
 
 void AutoDJFeature::constructCrateChildModel() {

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -151,7 +151,7 @@ AutoDJProcessor::AutoDJProcessor(
         BaseTrackPlayer* pPlayer = pPlayerManager->getPlayer(group);
         // Shouldn't be possible.
         if (pPlayer == NULL) {
-            qWarning() << "PROGRAMMING ERROR deck does not exist" << i;
+            qInfo() << "PROGRAMMING ERROR deck does not exist" << i;
             continue;
         }
         EngineChannel::ChannelOrientation orientation =
@@ -1428,8 +1428,8 @@ void AutoDJProcessor::playerTrackLoaded(DeckAttributes* pDeck, TrackPointer pTra
     // the track duration.
     double duration = getEndSecond(pDeck);
     if (duration < 0.2) {
-        qWarning() << "Skip track with" << duration << "Duration"
-                   << pTrack->getLocation();
+        qInfo() << "Skip track with" << duration << "Duration"
+                << pTrack->getLocation();
         // Remove Tack with duration smaller than two callbacks
         removeTrackFromTopOfQueue(pTrack);
 

--- a/src/library/banshee/bansheedbconnection.cpp
+++ b/src/library/banshee/bansheedbconnection.cpp
@@ -26,7 +26,7 @@ bool BansheeDbConnection::open(const QString& databaseFile) {
     //Open the database connection in this thread.
     if (!m_database.open()) {
         m_database.setConnectOptions(); // clear options
-        qWarning() << "Failed to open Banshee database." << m_database.lastError();
+        qInfo() << "Failed to open Banshee database." << m_database.lastError();
         return false;
     } else {
         // TODO(DSC): Verify schema

--- a/src/library/baseexternaltrackmodel.cpp
+++ b/src/library/baseexternaltrackmodel.cpp
@@ -74,7 +74,7 @@ TrackPointer BaseExternalTrackModel::getTrack(const QModelIndex& index) const {
             pTrack->setBpm(bpm);
         }
     } else {
-        qWarning() << "Failed to load external track" << location;
+        qInfo() << "Failed to load external track" << location;
     }
     return pTrack;
 }

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -377,7 +377,7 @@ void BaseSqlTableModel::setSort(int column, Qt::SortOrder order) {
     if (column < 0 ||
             column >= trackSourceColumnCount + m_sortColumns.size() - 1) {
         // -1 because id column is in both tables
-        qWarning() << "BaseSqlTableModel::setSort invalid column:" << column;
+        qInfo() << "BaseSqlTableModel::setSort invalid column:" << column;
         return;
     }
 
@@ -691,9 +691,9 @@ bool BaseSqlTableModel::setTrackValueForColumn(
     } else {
         // We never should get up to this point!
         VERIFY_OR_DEBUG_ASSERT(false) {
-            qWarning() << "Column"
-                       << columnNameForFieldIndex(column)
-                       << "is not editable!";
+            qInfo() << "Column"
+                    << columnNameForFieldIndex(column)
+                    << "is not editable!";
         }
         return false;
     }

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -191,7 +191,7 @@ TrackId BrowseTableModel::getTrackId(const QModelIndex& index) const {
     if (pTrack) {
         return pTrack->getId();
     } else {
-        qWarning()
+        qInfo()
                 << "Track is not available in library"
                 << getTrackLocation(index);
         return TrackId();
@@ -329,7 +329,7 @@ bool BrowseTableModel::setData(
 
     TrackPointer pTrack(getTrack(index));
     if (!pTrack) {
-        qWarning() << "BrowseTableModel::setData():"
+        qInfo() << "BrowseTableModel::setData():"
                 << "Failed to resolve track"
                 << getTrackLocation(index);
         // restore previous item content
@@ -378,8 +378,8 @@ bool BrowseTableModel::setData(
         pTrack->setGrouping(value.toString());
         break;
     default:
-        qWarning() << "BrowseTableModel::setData():"
-            << "No tagger column";
+        qInfo() << "BrowseTableModel::setData():"
+                << "No tagger column";
         // restore previous item context
         item->setText(index.data().toString());
         item->setToolTip(item->text());

--- a/src/library/crate/cratefeature.cpp
+++ b/src/library/crate/cratefeature.cpp
@@ -313,11 +313,11 @@ bool CrateFeature::activateCrate(CrateId crateId) {
 bool CrateFeature::readLastRightClickedCrate(Crate* pCrate) const {
     CrateId crateId(crateIdFromIndex(m_lastRightClickedIndex));
     VERIFY_OR_DEBUG_ASSERT(crateId.isValid()) {
-        qWarning() << "Failed to determine id of selected crate";
+        qInfo() << "Failed to determine id of selected crate";
         return false;
     }
     VERIFY_OR_DEBUG_ASSERT(m_pTrackCollection->crates().readCrateById(crateId, pCrate)) {
-        qWarning() << "Failed to read selected crate with id" << crateId;
+        qInfo() << "Failed to read selected crate with id" << crateId;
         return false;
     }
     return true;
@@ -384,7 +384,7 @@ void CrateFeature::slotDeleteCrate() {
     Crate crate;
     if (readLastRightClickedCrate(&crate)) {
         if (crate.isLocked()) {
-            qWarning() << "Refusing to delete locked crate" << crate;
+            qInfo() << "Refusing to delete locked crate" << crate;
             return;
         }
         if (m_pTrackCollection->deleteCrate(crate.getId())) {
@@ -392,7 +392,7 @@ void CrateFeature::slotDeleteCrate() {
             return;
         }
     }
-    qWarning() << "Failed to delete selected crate";
+    qInfo() << "Failed to delete selected crate";
 }
 
 void CrateFeature::slotRenameCrate() {

--- a/src/library/crate/cratefeaturehelper.cpp
+++ b/src/library/crate/cratefeaturehelper.cpp
@@ -74,8 +74,8 @@ CrateId CrateFeatureHelper::createEmptyCrate() {
         qDebug() << "Created new crate" << newCrate;
     } else {
         DEBUG_ASSERT(!newCrateId.isValid());
-        qWarning() << "Failed to create new crate"
-                << "->"  << newCrate.getName();
+        qInfo() << "Failed to create new crate"
+                << "->" << newCrate.getName();
         QMessageBox::warning(
                 nullptr,
                 tr("Creating Crate Failed"),
@@ -141,11 +141,11 @@ CrateId CrateFeatureHelper::duplicateCrate(const Crate& oldCrate) {
             qDebug() << "Duplicated crate"
                 << oldCrate << "->" << newCrate;
         } else {
-            qWarning() << "Failed to copy tracks from"
+            qInfo() << "Failed to copy tracks from"
                     << oldCrate << "into" << newCrate;
         }
     } else {
-        qWarning() << "Failed to duplicate crate"
+        qInfo() << "Failed to duplicate crate"
                 << oldCrate << "->" << newCrate.getName();
         QMessageBox::warning(
                 nullptr,

--- a/src/library/crate/cratetablemodel.cpp
+++ b/src/library/crate/cratetablemodel.cpp
@@ -121,7 +121,7 @@ TrackModel::CapabilitiesFlags CrateTableModel::getCapabilities() const {
                 caps |= TRACKMODELCAPS_LOCKED;
             }
         } else {
-            qWarning() << "Failed to read create" << m_selectedCrate;
+            qInfo() << "Failed to read create" << m_selectedCrate;
         }
     }
     return caps;
@@ -150,9 +150,9 @@ int CrateTableModel::addTracks(const QModelIndex& index,
     QList<TrackId> trackIds = m_pTrackCollectionManager->internalCollection()->resolveTrackIdsFromLocations(
             locations);
     if (!m_pTrackCollectionManager->internalCollection()->addCrateTracks(m_selectedCrate, trackIds)) {
-        qWarning() << "CrateTableModel::addTracks could not add"
-                 << locations.size()
-                 << "tracks to crate" << m_selectedCrate;
+        qInfo() << "CrateTableModel::addTracks could not add"
+                << locations.size()
+                << "tracks to crate" << m_selectedCrate;
         return 0;
     }
 
@@ -170,7 +170,7 @@ void CrateTableModel::removeTracks(const QModelIndexList& indices) {
 
     Crate crate;
     if (!m_pTrackCollectionManager->internalCollection()->crates().readCrateById(m_selectedCrate, &crate)) {
-        qWarning() << "Failed to read create" << m_selectedCrate;
+        qInfo() << "Failed to read create" << m_selectedCrate;
         return;
     }
 
@@ -184,7 +184,7 @@ void CrateTableModel::removeTracks(const QModelIndexList& indices) {
         trackIds.append(getTrackId(index));
     }
     if (!m_pTrackCollectionManager->internalCollection()->removeCrateTracks(crate.getId(), trackIds)) {
-        qWarning() << "Failed to remove tracks from crate" << crate;
+        qInfo() << "Failed to remove tracks from crate" << crate;
         return;
     }
 

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -658,7 +658,7 @@ TrackPointer TrackDAO::addTracksAddFile(const TrackFile& trackFile, bool unremov
     // the track is already in the library. A refactoring is
     // needed to detect this before calling addTracksAddTrack().
     if (!SoundSourceProxy::isFileSupported(trackFile)) {
-        qWarning() << "TrackDAO::addTracksAddFile:"
+        qInfo() << "TrackDAO::addTracksAddFile:"
                 << "Unsupported file type"
                 << trackFile.location();
         return TrackPointer();
@@ -667,7 +667,7 @@ TrackPointer TrackDAO::addTracksAddFile(const TrackFile& trackFile, bool unremov
     GlobalTrackCacheResolver cacheResolver(trackFile);
     TrackPointer pTrack = cacheResolver.getTrack();
     if (!pTrack) {
-        qWarning() << "TrackDAO::addTracksAddFile:"
+        qInfo() << "TrackDAO::addTracksAddFile:"
                 << "File not found"
                 << trackFile.location();
         return TrackPointer();
@@ -702,7 +702,7 @@ TrackPointer TrackDAO::addTracksAddFile(const TrackFile& trackFile, bool unremov
     // from the file.
     SoundSourceProxy(pTrack).updateTrackFromSource();
     if (!pTrack->isMetadataSynchronized()) {
-        qWarning() << "TrackDAO::addTracksAddFile:"
+        qInfo() << "TrackDAO::addTracksAddFile:"
                 << "Failed to parse track metadata from file"
                 << pTrack->getLocation();
         // Continue with adding the track to the library, no matter
@@ -711,7 +711,7 @@ TrackPointer TrackDAO::addTracksAddFile(const TrackFile& trackFile, bool unremov
 
     const TrackId newTrackId = addTracksAddTrack(pTrack, unremove);
     if (!newTrackId.isValid()) {
-        qWarning() << "TrackDAO::addTracksAddTrack:"
+        qInfo() << "TrackDAO::addTracksAddTrack:"
                 << "Failed to add track to database"
                 << pTrack->getFileInfo();
         // GlobalTrackCache will be unlocked implicitly
@@ -1393,7 +1393,7 @@ TrackPointer TrackDAO::getTrackByRef(
         trackId = getTrackIdByLocation(trackRef.getLocation());
     }
     if (!trackId.isValid()) {
-        qWarning() << "Track not found:" << trackRef;
+        qInfo() << "Track not found:" << trackRef;
         return TrackPointer();
     }
     return getTrackById(trackId);
@@ -1468,7 +1468,7 @@ bool TrackDAO::updateTrack(Track* pTrack) const {
     }
 
     if (query.numRowsAffected() == 0) {
-        qWarning() << "updateTrack had no effect: trackId" << trackId << "invalid";
+        qInfo() << "updateTrack had no effect: trackId" << trackId << "invalid";
         return false;
     }
 
@@ -1897,8 +1897,8 @@ void TrackDAO::detectCoverArtForTracksWithoutCover(volatile const bool* pCancel,
         CoverInfo::Source source = static_cast<CoverInfo::Source>(
             query.value(4).toInt());
         VERIFY_OR_DEBUG_ASSERT(source != CoverInfo::USER_SELECTED) {
-            qWarning() << "PROGRAMMING ERROR! detectCoverArtForTracksWithoutCover()"
-                       << "got a USER_SELECTED track. Skipping.";
+            qInfo() << "PROGRAMMING ERROR! detectCoverArtForTracksWithoutCover()"
+                    << "got a USER_SELECTED track. Skipping.";
             continue;
         }
         tracksWithoutCover.append(track);
@@ -1975,7 +1975,7 @@ TrackPointer TrackDAO::getOrAddTrack(
             return pTrack;
         }
         if (!trackRef.hasLocation()) {
-            qWarning()
+            qInfo()
                     << "Failed to get track"
                     << trackRef;
             return TrackPointer();
@@ -1987,7 +1987,7 @@ TrackPointer TrackDAO::getOrAddTrack(
     const auto pTrack = addTracksAddFile(trackRef.getLocation(), true);
     addTracksFinish(!pTrack);
     if (!pTrack) {
-        qWarning()
+        qInfo()
                 << "Failed to add track"
                 << trackRef;
         return TrackPointer();

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -140,7 +140,7 @@ void DlgCoverArtFullSize::slotCoverFound(
         if (primaryScreen) {
             availableScreenGeometry = primaryScreen->availableGeometry();
         } else {
-            qWarning() << "Assuming screen size of 800x600px.";
+            qInfo() << "Assuming screen size of 800x600px.";
             availableScreenGeometry = QRect(0, 0, 800, 600);
         }
         const QSize availableScreenSpace = availableScreenGeometry.size() * 0.9;

--- a/src/library/export/trackexportworker.cpp
+++ b/src/library/export/trackexportworker.cpp
@@ -26,7 +26,7 @@ QMap<QString, TrackFile> createCopylist(const QList<TrackPointer>& tracks) {
     QMap<QString, TrackFile> copylist;
     for (const auto& it : tracks) {
         if (it->getCanonicalLocation().isEmpty()) {
-            qWarning()
+            qInfo()
                     << "File not found or inaccessible while exporting"
                     << it->getFileInfo();
             // Skip file
@@ -53,7 +53,7 @@ QMap<QString, TrackFile> createCopylist(const QList<TrackPointer>& tracks) {
                 break;
             }
             if (++duplicateCounter >= 10000) {
-                qWarning()
+                qInfo()
                         << "Failed to generate a unique file name from"
                         << fileName
                         << "while exporting"
@@ -125,7 +125,7 @@ void TrackExportWorker::copyFile(const QFileInfo& source_fileinfo,
             const QString error_message = tr(
                     "Error removing file %1: %2. Stopping.").arg(
                     dest_path, dest_file.errorString());
-            qWarning() << error_message;
+            qInfo() << error_message;
             m_errorMessage = error_message;
             stop();
             return;
@@ -138,7 +138,7 @@ void TrackExportWorker::copyFile(const QFileInfo& source_fileinfo,
         const QString error_message = tr(
                 "Error exporting track %1 to %2: %3. Stopping.").arg(
                 sourceFilename, dest_path, source_file.errorString());
-        qWarning() << error_message;
+        qInfo() << error_message;
         m_errorMessage = error_message;
         stop();
         return;
@@ -165,7 +165,7 @@ TrackExportWorker::OverwriteAnswer TrackExportWorker::makeOverwriteRequest(
     }
 
     if (!mode_future.valid()) {
-        qWarning() << "TrackExportWorker::makeOverwriteRequest invalid answer from future";
+        qInfo() << "TrackExportWorker::makeOverwriteRequest invalid answer from future";
         m_errorMessage = tr("Error exporting tracks");
         stop();
         return OverwriteAnswer::CANCEL;

--- a/src/library/parserm3u.cpp
+++ b/src/library/parserm3u.cpp
@@ -53,7 +53,7 @@ QList<QString> ParserM3u::parse(QString sFilename)
 
     QFile file(sFilename);
     if (isBinary(sFilename) || !file.open(QIODevice::ReadOnly)) {
-        qWarning()
+        qInfo()
                 << "Failed to open playlist file"
                 << sFilename;
         return m_sLocations;
@@ -105,7 +105,7 @@ QString ParserM3u::getFilePath(QTextStream* stream, const QString& basePath) {
             return trackFile.location();
         }
         // We couldn't match this to a real file so ignore it
-        qWarning() << trackFile << "not found";
+        qInfo() << trackFile << "not found";
     }
     // Signal we reached the end
     return QString();

--- a/src/library/parserpls.cpp
+++ b/src/library/parserpls.cpp
@@ -119,7 +119,7 @@ QString ParserPls::getFilePath(QTextStream *stream, const QString& basePath) {
                 return trackFile.location();
             }
             // We couldn't match this to a real file so ignore it
-            qWarning() << trackFile << "not found";
+            qInfo() << trackFile << "not found";
         }
         textline = stream->readLine();
     }

--- a/src/library/queryutil.h
+++ b/src/library/queryutil.h
@@ -4,9 +4,8 @@
 #include <QtDebug>
 #include <QtSql>
 
-
-#define LOG_FAILED_QUERY(query) qWarning() << __FILE__ << __LINE__ << "FAILED QUERY [" \
-    << (query).executedQuery() << "]" << (query).lastError()
+#define LOG_FAILED_QUERY(query) qInfo() << __FILE__ << __LINE__ << "FAILED QUERY [" \
+                                        << (query).executedQuery() << "]" << (query).lastError()
 
 class ScopedTransaction {
   public:

--- a/src/library/scanner/importfilestask.cpp
+++ b/src/library/scanner/importfilestask.cpp
@@ -44,7 +44,7 @@ void ImportFilesTask::run() {
             emit trackExists(trackLocation);
         } else {
             if (!fileInfo.exists()) {
-                qWarning() << "ImportFilesTask: Skipping inaccessible file"
+                qInfo() << "ImportFilesTask: Skipping inaccessible file"
                         << trackLocation;
                 continue;
             }

--- a/src/library/serato/seratofeature.cpp
+++ b/src/library/serato/seratofeature.cpp
@@ -163,11 +163,11 @@ inline bool parseTrack(serato_track_t* track, QIODevice* buffer) {
         QByteArray data = buffer->read(fieldSize);
         if (static_cast<quint32>(data.length()) != fieldSize) {
             QString fieldName = QString(headerData.mid(0, sizeof(quint32)));
-            qWarning() << "Failed to read "
-                       << fieldSize
-                       << " bytes for "
-                       << fieldName
-                       << " field.";
+            qInfo() << "Failed to read "
+                    << fieldSize
+                    << " bytes for "
+                    << fieldName
+                    << " field.";
             return false;
         }
 
@@ -274,16 +274,16 @@ inline bool parseTrack(serato_track_t* track, QIODevice* buffer) {
     }
 
     if (headerData.length() != 0) {
-        qWarning() << "Found "
-                   << headerData.length()
-                   << " extra bytes at end of track definition.";
+        qInfo() << "Found "
+                << headerData.length()
+                << " extra bytes at end of track definition.";
         return false;
     }
 
     // Ignore tracks with empty location fields. The track location is used as
     // identifier by Serato (e.g. it's also used to reference them in Crates).
     if (track->location.isEmpty()) {
-        qWarning() << "Found track with empty location field.";
+        qInfo() << "Found track with empty location field.";
         return false;
     }
 
@@ -301,11 +301,11 @@ inline QString parseCrateTrackPath(QIODevice* buffer) {
         QByteArray data = buffer->read(fieldSize);
         if (static_cast<quint32>(data.length()) != fieldSize) {
             QString fieldName = QString(headerData.mid(0, sizeof(quint32)));
-            qWarning() << "Failed to read "
-                       << fieldSize
-                       << " bytes for "
-                       << fieldName
-                       << " field.";
+            qInfo() << "Failed to read "
+                    << fieldSize
+                    << " bytes for "
+                    << fieldName
+                    << " field.";
             return QString();
         }
 
@@ -328,9 +328,9 @@ inline QString parseCrateTrackPath(QIODevice* buffer) {
     }
 
     if (headerData.length() != 0) {
-        qWarning() << "Found "
-                   << headerData.length()
-                   << " extra bytes at end of track definition.";
+        qInfo() << "Found "
+                << headerData.length()
+                << " extra bytes at end of track definition.";
         return QString();
     }
 
@@ -349,23 +349,23 @@ QString parseCrate(
 
     //Open the database connection in this thread.
     VERIFY_OR_DEBUG_ASSERT(database.isOpen()) {
-        qWarning() << "Failed to open database for Serato parser."
-                   << database.lastError();
+        qInfo() << "Failed to open database for Serato parser."
+                << database.lastError();
         return QString();
     }
 
     QFile crateFile(crateFilePath);
     if (!crateFile.open(QIODevice::ReadOnly)) {
-        qWarning() << "Failed to open file "
-                   << crateFilePath
-                   << " for reading.";
+        qInfo() << "Failed to open file "
+                << crateFilePath
+                << " for reading.";
         return QString();
     }
 
     int playlistId = createPlaylist(database, crateFilePath, databasePath);
     if (playlistId < 0) {
-        qWarning() << "Failed to create library playlist for "
-                   << crateFilePath;
+        qInfo() << "Failed to create library playlist for "
+                << crateFilePath;
         return QString();
     }
 
@@ -379,13 +379,13 @@ QString parseCrate(
         QByteArray data = crateFile.read(fieldSize);
         if (static_cast<quint32>(data.length()) != fieldSize) {
             QString fieldName = QString(headerData.mid(0, sizeof(quint32)));
-            qWarning() << "Failed to read "
-                       << fieldSize
-                       << " bytes for "
-                       << fieldName
-                       << " field from "
-                       << crateFilePath
-                       << ".";
+            qInfo() << "Failed to read "
+                    << fieldSize
+                    << " bytes for "
+                    << fieldName
+                    << " field from "
+                    << crateFilePath
+                    << ".";
             return QString();
         }
 
@@ -425,11 +425,11 @@ QString parseCrate(
     }
 
     if (headerData.length() != 0) {
-        qWarning() << "Found "
-                   << headerData.length()
-                   << " extra bytes at end of Serato database file "
-                   << crateFilePath
-                   << ".";
+        qInfo() << "Found "
+                << headerData.length()
+                << " extra bytes at end of Serato database file "
+                << crateFilePath
+                << ".";
     }
 
     return crateName;
@@ -470,8 +470,8 @@ QString parseDatabase(mixxx::DbConnectionPoolPtr dbConnectionPool, TreeItem* dat
              << "at" << databaseFilePath;
 
     if (!QFile(databaseFilePath).exists()) {
-        qWarning() << "Serato database file not found: "
-                   << databaseFilePath;
+        qInfo() << "Serato database file not found: "
+                << databaseFilePath;
         return databaseFilePath;
     }
 
@@ -482,8 +482,8 @@ QString parseDatabase(mixxx::DbConnectionPoolPtr dbConnectionPool, TreeItem* dat
 
     //Open the database connection in this thread.
     VERIFY_OR_DEBUG_ASSERT(database.isOpen()) {
-        qWarning() << "Failed to open database for Serato parser."
-                   << database.lastError();
+        qInfo() << "Failed to open database for Serato parser."
+                << database.lastError();
         return QString();
     }
 
@@ -537,16 +537,16 @@ QString parseDatabase(mixxx::DbConnectionPoolPtr dbConnectionPool, TreeItem* dat
 
     QFile databaseFile(databaseFilePath);
     if (!databaseFile.open(QIODevice::ReadOnly)) {
-        qWarning() << "Failed to open file "
-                   << databaseFilePath
-                   << " for reading.";
+        qInfo() << "Failed to open file "
+                << databaseFilePath
+                << " for reading.";
         return QString();
     }
 
     int playlistId = createPlaylist(database, databaseFilePath, databaseDir.path());
     if (playlistId < 0) {
-        qWarning() << "Failed to create library playlist for "
-                   << databaseFilePath;
+        qInfo() << "Failed to create library playlist for "
+                << databaseFilePath;
         return QString();
     }
 
@@ -561,13 +561,13 @@ QString parseDatabase(mixxx::DbConnectionPoolPtr dbConnectionPool, TreeItem* dat
         QByteArray data = databaseFile.read(fieldSize);
         if (static_cast<quint32>(data.length()) != fieldSize) {
             QString fieldName = QString(headerData.mid(0, sizeof(quint32)));
-            qWarning() << "Failed to read "
-                       << fieldSize
-                       << " bytes for "
-                       << fieldName
-                       << " field from "
-                       << databaseFilePath
-                       << ".";
+            qInfo() << "Failed to read "
+                    << fieldSize
+                    << " bytes for "
+                    << fieldName
+                    << " field from "
+                    << databaseFilePath
+                    << ".";
             return QString();
         }
 
@@ -631,11 +631,11 @@ QString parseDatabase(mixxx::DbConnectionPoolPtr dbConnectionPool, TreeItem* dat
     }
 
     if (headerData.length() != 0) {
-        qWarning() << "Found "
-                   << headerData.length()
-                   << " extra bytes at end of Serato database file "
-                   << databaseFilePath
-                   << ".";
+        qInfo() << "Found "
+                << headerData.length()
+                << " extra bytes at end of Serato database file "
+                << databaseFilePath
+                << ".";
     }
 
     // Parse Crates
@@ -659,8 +659,8 @@ QString parseDatabase(mixxx::DbConnectionPoolPtr dbConnectionPool, TreeItem* dat
             }
         }
     } else {
-        qWarning() << "Failed to open crate directory: "
-                   << databaseDir.filePath(kCrateDirectory);
+        qInfo() << "Failed to open crate directory: "
+                << databaseDir.filePath(kCrateDirectory);
     }
 
     // TODO: Parse Smart Crates

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -267,9 +267,9 @@ void PlayerManager::slotChangeNumDecks(double v) {
     int num = (int)v;
 
     VERIFY_OR_DEBUG_ASSERT(num <= kMaxNumberOfDecks) {
-        qWarning() << "Number of decks exceeds the maximum we expect."
-                   << num << "vs" << kMaxNumberOfDecks
-                   << " Refusing to add another deck. Please update util/defs.h";
+        qInfo() << "Number of decks exceeds the maximum we expect."
+                << num << "vs" << kMaxNumberOfDecks
+                << " Refusing to add another deck. Please update util/defs.h";
         return;
     }
 
@@ -573,7 +573,7 @@ void PlayerManager::slotCloneDeck(QString source_group, QString target_group) {
     BaseTrackPlayer* pPlayer = getPlayer(target_group);
 
     if (pPlayer == nullptr) {
-        qWarning() << "Invalid group argument " << target_group << " to slotCloneDeck.";
+        qInfo() << "Invalid group argument " << target_group << " to slotCloneDeck.";
         return;
     }
 

--- a/src/mixer/samplerbank.cpp
+++ b/src/mixer/samplerbank.cpp
@@ -66,14 +66,14 @@ bool SamplerBank::saveSamplerBankToPath(const QString& samplerBankPath) {
     // register a security bookmark.
 
     VERIFY_OR_DEBUG_ASSERT(m_pPlayerManager != nullptr) {
-        qWarning() << "SamplerBank::saveSamplerBankToPath called with no PlayerManager";
+        qInfo() << "SamplerBank::saveSamplerBankToPath called with no PlayerManager";
         return false;
     }
 
     QFile file(samplerBankPath);
     if (!file.open(QIODevice::WriteOnly)) {
-        qWarning() << "Error saving sampler bank: Could not write to file"
-                   << samplerBankPath;
+        qInfo() << "Error saving sampler bank: Could not write to file"
+                << samplerBankPath;
         return false;
     }
 
@@ -136,26 +136,26 @@ bool SamplerBank::loadSamplerBankFromPath(const QString& samplerBankPath) {
     // register a security bookmark.
 
     VERIFY_OR_DEBUG_ASSERT(m_pPlayerManager != nullptr) {
-        qWarning() << "SamplerBank::loadSamplerBankFromPath called with no PlayerManager";
+        qInfo() << "SamplerBank::loadSamplerBankFromPath called with no PlayerManager";
         return false;
     }
 
     QFile file(samplerBankPath);
     if (!file.open(QIODevice::ReadOnly)) {
-        qWarning() << "Could not read sampler bank file" << samplerBankPath;
+        qInfo() << "Could not read sampler bank file" << samplerBankPath;
         return false;
     }
 
     QDomDocument doc;
 
     if (!doc.setContent(file.readAll())) {
-        qWarning() << "Could not read sampler bank file" << samplerBankPath;
+        qInfo() << "Could not read sampler bank file" << samplerBankPath;
         return false;
     }
 
     QDomElement root = doc.documentElement();
     if (root.tagName() != "samplerbank") {
-        qWarning() << "Could not read sampler bank file" << samplerBankPath;
+        qInfo() << "Could not read sampler bank file" << samplerBankPath;
         return false;
     }
 

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -503,7 +503,7 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
                                                fileBytes.length());
         setStyleSheet(style);
     } else {
-        qWarning() << "Failed to load default skin styles!";
+        qInfo() << "Failed to load default skin styles!";
     }
 
     // Load skin to a QWidget that we set as the central widget. Assignment
@@ -699,7 +699,7 @@ void MixxxMainWindow::finalize() {
     }
     // Our central widget is now deleted.
     VERIFY_OR_DEBUG_ASSERT(pSkin.isNull()) {
-        qWarning() << "Central widget was not deleted by our sendPostedEvents trick.";
+        qInfo() << "Central widget was not deleted by our sendPostedEvents trick.";
     }
 
     // Delete Controls created by skins
@@ -726,7 +726,7 @@ void MixxxMainWindow::finalize() {
     }
     // Our main menu is now deleted.
     VERIFY_OR_DEBUG_ASSERT(pMenuBar.isNull()) {
-        qWarning() << "WMainMenuBar was not deleted by our sendPostedEvents trick.";
+        qInfo() << "WMainMenuBar was not deleted by our sendPostedEvents trick.";
     }
 
     // SoundManager depend on Engine and Config
@@ -813,13 +813,13 @@ void MixxxMainWindow::finalize() {
         QList<QSharedPointer<ControlDoublePrivate>> leakedControls =
                 ControlDoublePrivate::takeAllInstances();
         if (!leakedControls.isEmpty()) {
-            qWarning()
+            qInfo()
                     << "The following"
                     << leakedControls.size()
                     << "controls were leaked:";
             for (auto pCDP : leakedControls) {
                 ConfigKey key = pCDP->getKey();
-                qWarning() << key.group << key.item << pCDP->getCreatorCO();
+                qInfo() << key.group << key.item << pCDP->getCreatorCO();
                 // Deleting leaked objects helps to satisfy valgrind.
                 // These delete calls could cause crashes if a destructor for a control
                 // we thought was leaked is triggered after this one exits.
@@ -1509,7 +1509,7 @@ void MixxxMainWindow::rebootMixxxView() {
             newY = std::max(0, std::min(newY, primaryScreen->geometry().height() - m_pWidgetParent->height()));
             move(newX,newY);
         } else {
-            qWarning() << "Unable to move window inside screen borders.";
+            qInfo() << "Unable to move window inside screen borders.";
         }
     }
 

--- a/src/musicbrainz/chromaprinter.cpp
+++ b/src/musicbrainz/chromaprinter.cpp
@@ -44,7 +44,7 @@ QString calcFingerprint(
                             fingerprintRange,
                             mixxx::SampleBuffer::WritableSlice(sampleBuffer)));
     if (fingerprintRange != readableSampleFrames.frameIndexRange()) {
-        qWarning() << "Failed to read sample data for fingerprint";
+        qInfo() << "Failed to read sample data for fingerprint";
         return QString();
     }
 
@@ -73,7 +73,7 @@ QString calcFingerprint(
             static_cast<int>(fingerprintSamples.size()));
     chromaprint_finish(ctx);
     if (!success) {
-        qWarning() << "Failed to generate fingerprint from sample data";
+        qInfo() << "Failed to generate fingerprint from sample data";
         chromaprint_free(ctx);
         return QString();
     }

--- a/src/preferences/colorpalettesettings.cpp
+++ b/src/preferences/colorpalettesettings.cpp
@@ -76,7 +76,7 @@ ColorPalette ColorPaletteSettings::getColorPalette(
 
 void ColorPaletteSettings::setColorPalette(const QString& name, const ColorPalette& colorPalette) {
     VERIFY_OR_DEBUG_ASSERT(!name.isEmpty()) {
-        qWarning() << "Palette name must not be empty!";
+        qInfo() << "Palette name must not be empty!";
         return;
     }
 
@@ -128,7 +128,7 @@ ColorPalette ColorPaletteSettings::getHotcueColorPalette(
 void ColorPaletteSettings::setHotcueColorPalette(const ColorPalette& colorPalette) {
     QString name = colorPalette.getName();
     VERIFY_OR_DEBUG_ASSERT(!name.isEmpty()) {
-        qWarning() << "Palette name must not be empty!";
+        qInfo() << "Palette name must not be empty!";
         return;
     }
     m_pConfig->setValue(kHotcueColorPaletteConfigKey, name);
@@ -150,7 +150,7 @@ ColorPalette ColorPaletteSettings::getTrackColorPalette() const {
 void ColorPaletteSettings::setTrackColorPalette(const ColorPalette& colorPalette) {
     QString name = colorPalette.getName();
     VERIFY_OR_DEBUG_ASSERT(!name.isEmpty()) {
-        qWarning() << "Palette name must not be empty!";
+        qInfo() << "Palette name must not be empty!";
         return;
     }
     m_pConfig->setValue(kTrackColorPaletteConfigKey, name);

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -759,7 +759,7 @@ int DlgPrefDeck::cueDefaultIndexByData(int userData) const {
             return i;
         }
     }
-    qWarning() << "No default cue behavior found for value" << userData
-               << "returning default";
+    qInfo() << "No default cue behavior found for value" << userData
+            << "returning default";
     return 0;
 }

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -424,7 +424,7 @@ void DlgPreferences::onShow() {
     if (primaryScreen) {
         screenSpace = primaryScreen->geometry().size();
     } else {
-        qWarning() << "Assuming screen size of 800x600px.";
+        qInfo() << "Assuming screen size of 800x600px.";
         screenSpace = QSize(800, 600);
     }
     newX = std::max(0, std::min(newX, screenSpace.width()- m_geometry[2].toInt()));

--- a/src/preferences/dialog/dlgprefrecord.cpp
+++ b/src/preferences/dialog/dlgprefrecord.cpp
@@ -54,7 +54,9 @@ DlgPrefRecord::DlgPrefRecord(QWidget* parent, UserSettingsPointer pConfig)
     if (!found) {
         // If no format was available, set to WAVE as default.
         if (!prefformat.isEmpty()) {
-            qWarning() << prefformat <<" format was set in the configuration, but it is not recognized!";
+            qInfo() << prefformat
+                    << " format was set in the configuration, but it is not "
+                       "recognized!";
         }
         m_selFormat = EncoderFactory::getFactory().getFormats().first();
         m_formatButtons.first()->setChecked(true);

--- a/src/preferences/dialog/dlgprefvinyl.cpp
+++ b/src/preferences/dialog/dlgprefvinyl.cpp
@@ -297,7 +297,7 @@ int DlgPrefVinyl::getDefaultLeadIn(QString vinyl_type) const {
     } else if (vinyl_type == MIXXX_VINYL_MIXVIBESDVS) {
         return MIXXX_VINYL_MIXVIBESDVS_LEADIN;
     }
-    qWarning() << "Unknown vinyl type " << vinyl_type;
+    qInfo() << "Unknown vinyl type " << vinyl_type;
     return 0;
 }
 
@@ -374,7 +374,7 @@ void DlgPrefVinyl::VinylTypeSlotApply()
         }
         break;
     default:
-        qWarning() << "Unexpected number of vinyl speed preference items";
+        qInfo() << "Unexpected number of vinyl speed preference items";
     }
 }
 
@@ -414,7 +414,7 @@ void DlgPrefVinyl::setDeckWidgetsVisible(int deck, bool visible) {
         setDeck4WidgetsVisible(visible);
         break;
     default:
-        qWarning() << "Tried to set a vinyl preference widget visible that doesn't exist: " << deck;
+        qInfo() << "Tried to set a vinyl preference widget visible that doesn't exist: " << deck;
     }
 }
 

--- a/src/preferences/upgrade.cpp
+++ b/src/preferences/upgrade.cpp
@@ -116,7 +116,10 @@ UserSettingsPointer Upgrade::versionUpgrade(const QString& settingsPath) {
         newFilePath = newLocation.filePath("MixxxMIDIBindings.xml");
         oldFile = new QFile(oldFilePath);
         if (oldFile->exists()) {
-            qWarning() << "The MIDI mapping file format has changed in this version of Mixxx. You will need to reconfigure your MIDI controller. See the Wiki for full details on the new format.";
+            qInfo() << "The MIDI mapping file format has changed in this "
+                       "version of Mixxx. You will need to reconfigure your "
+                       "MIDI controller. See the Wiki for full details on the "
+                       "new format.";
             if (oldFile->copy(newFilePath))
                 oldFile->remove();
             else {
@@ -422,8 +425,8 @@ UserSettingsPointer Upgrade::versionUpgrade(const QString& settingsPath) {
 
     if (configVersion == MIXXX_VERSION) qDebug() << "Configuration file is now at the current version" << MIXXX_VERSION;
     else {
-        qWarning() << "Configuration file is at version" << configVersion
-                   << "instead of the current" << MIXXX_VERSION;
+        qInfo() << "Configuration file is at version" << configVersion
+                << "instead of the current" << MIXXX_VERSION;
     }
 
     return config;

--- a/src/recording/recordingmanager.cpp
+++ b/src/recording/recordingmanager.cpp
@@ -267,7 +267,7 @@ void RecordingManager::slotBytesRecorded(int bytes)
 }
 
 void RecordingManager::warnFreespace() {
-    qWarning() << "RecordingManager: less than 1 GiB free space";
+    qInfo() << "RecordingManager: less than 1 GiB free space";
     ErrorDialogProperties* props = ErrorDialogHandler::instance()->newDialogProperties();
     props->setType(DLG_WARNING);
     props->setTitle(tr("Low Disk Space Warning"));

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -109,9 +109,9 @@ ControlObject* LegacySkinParser::controlFromConfigKey(
 
     // TODO(rryan): Make this configurable by the skin.
     if (CmdlineArgs::Instance().getDeveloper()) {
-        qWarning() << "Requested control does not exist:"
-                   << QString("%1,%2").arg(key.group, key.item)
-                   << "Creating it.";
+        qInfo() << "Requested control does not exist:"
+                << QString("%1,%2").arg(key.group, key.item)
+                << "Creating it.";
     }
     // Since the usual behavior here is to create a skin-defined push
     // button, actually make it a push button and set it to toggle.
@@ -126,7 +126,7 @@ ControlObject* LegacySkinParser::controlFromConfigKey(
     // controls, so that it can be deleted when the MixxxMainWindow is
     // destroyed.
     VERIFY_OR_DEBUG_ASSERT(m_pSkinCreatedControls) {
-        qWarning() << "Can't add skin-created control" << key << "to set, control will be leaked!";
+        qInfo() << "Can't add skin-created control" << key << "to set, control will be leaked!";
         return controlButton;
     }
     DEBUG_ASSERT(!m_pSkinCreatedControls->contains(controlButton));
@@ -1491,7 +1491,7 @@ QDomElement LegacySkinParser::loadTemplate(const QString& path) {
     QFile templateFile(absolutePath);
 
     if (!templateFile.open(QIODevice::ReadOnly)) {
-        qWarning() << "Could not open template file:" << absolutePath;
+        qInfo() << "Could not open template file:" << absolutePath;
     }
 
     QDomDocument tmpl("template");
@@ -1501,9 +1501,9 @@ QDomElement LegacySkinParser::loadTemplate(const QString& path) {
 
     if (!tmpl.setContent(&templateFile, &errorMessage,
                          &errorLine, &errorColumn)) {
-        qWarning() << "LegacySkinParser::loadTemplate - setContent failed see"
-                   << absolutePath << "line:" << errorLine << "column:" << errorColumn;
-        qWarning() << "LegacySkinParser::loadTemplate - message:" << errorMessage;
+        qInfo() << "LegacySkinParser::loadTemplate - setContent failed see"
+                << absolutePath << "line:" << errorLine << "column:" << errorColumn;
+        qInfo() << "LegacySkinParser::loadTemplate - message:" << errorMessage;
         return QDomElement();
     }
 

--- a/src/skin/skincontext.cpp
+++ b/src/skin/skincontext.cpp
@@ -222,7 +222,7 @@ QScriptValue SkinContext::evaluateScript(const QString& expression,
 QScriptValue SkinContext::importScriptExtension(const QString& extensionName) {
     QScriptValue out = m_pSharedState->scriptEngine.importExtension(extensionName);
     if (m_pSharedState->scriptEngine.hasUncaughtException()) {
-        qWarning() << out.toString();
+        qInfo() << out.toString();
     }
     return out;
 }
@@ -240,12 +240,14 @@ void SkinContext::enableDebugger(bool state) const {
 
 QDebug SkinContext::logWarning(const char* file, const int line,
                                const QDomNode& node) const {
-    return qWarning() << QString("%1:%2 SKIN ERROR at %3:%4 <%5>:")
-                             .arg(file, QString::number(line), m_xmlPath,
-                                  QString::number(node.lineNumber()),
-                                  node.nodeName())
-                             .toUtf8()
-                             .constData();
+    return qInfo() << QString("%1:%2 SKIN ERROR at %3:%4 <%5>:")
+                              .arg(file,
+                                      QString::number(line),
+                                      m_xmlPath,
+                                      QString::number(node.lineNumber()),
+                                      node.nodeName())
+                              .toUtf8()
+                              .constData();
 }
 
 int SkinContext::scaleToWidgetSize(QString& size) const {

--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -434,12 +434,14 @@ void SoundDeviceNetwork::callbackProcessClkRef() {
         // test passes if one of the two flag is set.
         volatile double doubleMin = DBL_MIN; // the smallest normalized double
         VERIFY_OR_DEBUG_ASSERT(doubleMin / 2 == 0.0) {
-            qWarning() << "SSE: Denormals to zero mode is not working. EQs and effects may suffer high CPU load";
+            qInfo() << "SSE: Denormals to zero mode is not working. EQs and "
+                       "effects may suffer high CPU load";
         } else {
             qDebug() << "SSE: Denormals to zero mode is working";
         }
 #else
-        qWarning() << "No SSE: No denormals to zero mode available. EQs and effects may suffer high CPU load";
+        qInfo() << "No SSE: No denormals to zero mode available. EQs and "
+                   "effects may suffer high CPU load";
 #endif
     }
 

--- a/src/soundio/sounddevicenetwork.h
+++ b/src/soundio/sounddevicenetwork.h
@@ -92,7 +92,7 @@ class SoundDeviceNetworkThread : public QThread {
         struct sched_param spm = { 0 };
         spm.sched_priority = 1;
         if (pthread_setschedparam(pthread_self(), SCHED_FIFO, &spm)) {
-            qWarning() << "SoundDeviceNetworkThread: Failed bumping priority";
+            qInfo() << "SoundDeviceNetworkThread: Failed bumping priority";
         }
 #endif
 

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -343,7 +343,7 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
                         (void*) this); // pointer passed to the callback function
 
     if (err != paNoError) {
-        qWarning() << "Error opening stream:" << Pa_GetErrorText(err);
+        qInfo() << "Error opening stream:" << Pa_GetErrorText(err);
         m_lastError = QString::fromUtf8(Pa_GetErrorText(err));
         return SOUNDDEVICE_ERROR_ERR;
     } else {
@@ -356,7 +356,7 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
     //in order to enable RT priority with ALSA.
     QLibrary portaudio("libportaudio.so.2");
     if (!portaudio.load())
-       qWarning() << "Failed to dynamically load PortAudio library";
+        qInfo() << "Failed to dynamically load PortAudio library";
     else
        qDebug() << "Dynamically loaded PortAudio library";
 
@@ -371,12 +371,12 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
     // Start stream
     err = Pa_StartStream(pStream);
     if (err != paNoError) {
-        qWarning() << "PortAudio: Start stream error:" << Pa_GetErrorText(err);
+        qInfo() << "PortAudio: Start stream error:" << Pa_GetErrorText(err);
         m_lastError = QString::fromUtf8(Pa_GetErrorText(err));
         err = Pa_CloseStream(pStream);
         if (err != paNoError) {
-            qWarning() << "PortAudio: Close stream error:"
-                       << Pa_GetErrorText(err) << m_deviceId;
+            qInfo() << "PortAudio: Close stream error:"
+                    << Pa_GetErrorText(err) << m_deviceId;
         }
         return SOUNDDEVICE_ERROR_ERR;
     } else {
@@ -421,8 +421,8 @@ SoundDeviceError SoundDevicePortAudio::close() {
         }
         // Real PaErrors are always negative.
         if (err < 0) {
-            qWarning() << "PortAudio: Stream already stopped:"
-                       << Pa_GetErrorText(err) << m_deviceId;
+            qInfo() << "PortAudio: Stream already stopped:"
+                    << Pa_GetErrorText(err) << m_deviceId;
             return SOUNDDEVICE_ERROR_ERR;
         }
 
@@ -437,16 +437,16 @@ SoundDeviceError SoundDevicePortAudio::close() {
                                                    //state. Don't use it!
 
         if (err != paNoError) {
-            qWarning() << "PortAudio: Stop stream error:"
-                       << Pa_GetErrorText(err) << m_deviceId;
+            qInfo() << "PortAudio: Stop stream error:"
+                    << Pa_GetErrorText(err) << m_deviceId;
             return SOUNDDEVICE_ERROR_ERR;
         }
 
         // Close stream
         err = Pa_CloseStream(pStream);
         if (err != paNoError) {
-            qWarning() << "PortAudio: Close stream error:"
-                       << Pa_GetErrorText(err) << m_deviceId;
+            qInfo() << "PortAudio: Close stream error:"
+                    << Pa_GetErrorText(err) << m_deviceId;
             return SOUNDDEVICE_ERROR_ERR;
         }
 
@@ -928,14 +928,16 @@ int SoundDevicePortAudio::callbackProcessClkRef(
 #else
 #if defined( __i386__ ) || defined( __i486__ ) || defined( __i586__ ) || \
          defined( __i686__ ) || defined( __x86_64__ ) || defined (_M_I86)
-        qWarning() << "No SSE: No denormals to zero mode available. EQs and effects may suffer high CPU load";
+        qInfo() << "No SSE: No denormals to zero mode available. EQs and "
+                   "effects may suffer high CPU load";
 #endif
 #endif
         // verify if flush to zero or denormals to zero works
         // test passes if one of the two flag is set.
         volatile double doubleMin = DBL_MIN; // the smallest normalized double
         VERIFY_OR_DEBUG_ASSERT(doubleMin / 2 == 0.0) {
-            qWarning() << "Denormals to zero mode is not working. EQs and effects may suffer high CPU load";
+            qInfo() << "Denormals to zero mode is not working. EQs and effects "
+                       "may suffer high CPU load";
         } else {
             qDebug() << "Denormals to zero mode is working";
         }
@@ -983,7 +985,7 @@ int SoundDevicePortAudio::callbackProcessClkRef(
                 m_deviceId.debugName());
 
         if (m_outputParams.channelCount <= 0) {
-            qWarning()
+            qInfo()
                     << "SoundDevicePortAudio::callbackProcess m_outputParams channel count is zero or less:"
                     << m_outputParams.channelCount;
             // Bail out.
@@ -1050,12 +1052,12 @@ void SoundDevicePortAudio::updateCallbackEntryToDacTime(
 
         if (m_invalidTimeInfoCount == m_invalidTimeInfoWarningCount) {
             if (CmdlineArgs::Instance().getDeveloper()) {
-                qWarning() << "SoundDevicePortAudio: Audio API provides invalid time stamps,"
-                           << "syncing waveforms with a CPU Timer"
-                           << "DacTime:" << timeInfo->outputBufferDacTime
-                           << "EntrytoDac:" << callbackEntrytoDacSecs
-                           << "TimeSinceLastCb:" << timeSinceLastCbSecs
-                           << "diff:" << diff;
+                qInfo() << "SoundDevicePortAudio: Audio API provides invalid time stamps,"
+                        << "syncing waveforms with a CPU Timer"
+                        << "DacTime:" << timeInfo->outputBufferDacTime
+                        << "EntrytoDac:" << callbackEntrytoDacSecs
+                        << "TimeSinceLastCb:" << timeSinceLastCbSecs
+                        << "diff:" << diff;
             }
         }
 

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -466,8 +466,8 @@ SoundDeviceError SoundManager::setupDevices() {
         if (pNewMasterClockRef.isNull() &&
                 (!haveOutput || mode.isOutput)) {
             pNewMasterClockRef = pDevice;
-            qWarning() << "Output sound device clock reference not set! Using"
-                       << pDevice->getDisplayName();
+            qInfo() << "Output sound device clock reference not set! Using"
+                    << pDevice->getDisplayName();
         }
 
         int syncBuffers = m_config.getSyncBuffers();
@@ -491,13 +491,13 @@ SoundDeviceError SoundManager::setupDevices() {
         qDebug() << "Using" << pNewMasterClockRef->getDisplayName()
                  << "as output sound device clock reference";
     } else {
-        qWarning() << "No output devices opened, no clock reference device set";
+        qInfo() << "No output devices opened, no clock reference device set";
     }
 
     qDebug() << outputDevicesOpened << "output sound devices opened";
     qDebug() << inputDevicesOpened << "input sound devices opened";
     for (const auto& device: devicesNotFound) {
-        qWarning() << device << "not found";
+        qInfo() << device << "not found";
     }
 
     m_pControlObjectSoundStatusCO->set(
@@ -673,10 +673,10 @@ void SoundManager::setJACKName() const {
             char* jackNameCopy = strdup(Version::applicationName().toLocal8Bit().constData());
             if (!func(jackNameCopy)) qDebug() << "JACK client name set";
         } else {
-            qWarning() << "failed to resolve JACK name method";
+            qInfo() << "failed to resolve JACK name method";
         }
     } else {
-        qWarning() << "failed to load portaudio for JACK rename";
+        qInfo() << "failed to load portaudio for JACK rename";
     }
 #endif
 }

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -121,7 +121,7 @@ class SoundManager : public QObject {
         // Disable the engine warnings by default, because printing a warning is a
         // locking function that will make the problem worse
         if (CmdlineArgs::Instance().getDeveloper()) {
-            qWarning() << "underflowHappened code:" << code;
+            qInfo() << "underflowHappened code:" << code;
         }
     }
 

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -502,7 +502,7 @@ void SoundManagerConfig::loadDefaults(SoundManager *soundManager, unsigned int f
         } else if (!sampleRates.isEmpty()) {
             m_sampleRate = sampleRates.first();
         } else {
-            qWarning() << "got empty sample rate list from SoundManager, this is a bug";
+            qInfo() << "got empty sample rate list from SoundManager, this is a bug";
             m_sampleRate = kFallbackSampleRate;
         }
         m_audioBufferSizeIndex = kDefaultAudioBufferSizeIndex;

--- a/src/sources/audiosource.cpp
+++ b/src/sources/audiosource.cpp
@@ -40,10 +40,10 @@ AudioSource::OpenResult AudioSource::open(
     try {
         result = tryOpen(mode, params);
     } catch (const std::exception& e) {
-        qWarning() << "Caught unexpected exception from SoundSource::tryOpen():" << e.what();
+        qInfo() << "Caught unexpected exception from SoundSource::tryOpen():" << e.what();
         result = OpenResult::Failed;
     } catch (...) {
-        qWarning() << "Caught unknown exception from SoundSource::tryOpen()";
+        qInfo() << "Caught unknown exception from SoundSource::tryOpen()";
         result = OpenResult::Failed;
     }
     if (OpenResult::Succeeded != result) {

--- a/src/test/controller_preset_validation_test.cpp
+++ b/src/test/controller_preset_validation_test.cpp
@@ -152,29 +152,29 @@ bool checkUrl(const QString& url) {
 bool lintPresetInfo(const PresetInfo& preset) {
     bool result = true;
     if (preset.getName().trimmed().isEmpty()) {
-        qWarning() << "LINT:" << preset.getPath() << "has no name.";
+        qInfo() << "LINT:" << preset.getPath() << "has no name.";
         result = false;
     }
 
     if (preset.getAuthor().trimmed().isEmpty()) {
-        qWarning() << "LINT:" << preset.getPath() << "has no author.";
+        qInfo() << "LINT:" << preset.getPath() << "has no author.";
     }
 
     if (preset.getDescription().trimmed().isEmpty()) {
-        qWarning() << "LINT:" << preset.getPath() << "has no description.";
+        qInfo() << "LINT:" << preset.getPath() << "has no description.";
     }
 
     if (preset.getForumLink().trimmed().isEmpty()) {
-        qWarning() << "LINT:" << preset.getPath() << "has no forum link.";
+        qInfo() << "LINT:" << preset.getPath() << "has no forum link.";
     } else if (!checkUrl(preset.getForumLink())) {
-        qWarning() << "LINT:" << preset.getPath() << "has invalid forum link";
+        qInfo() << "LINT:" << preset.getPath() << "has invalid forum link";
         result = false;
     }
 
     if (preset.getWikiLink().trimmed().isEmpty()) {
-        qWarning() << "LINT:" << preset.getPath() << "has no wiki link.";
+        qInfo() << "LINT:" << preset.getPath() << "has no wiki link.";
     } else if (!checkUrl(preset.getWikiLink())) {
-        qWarning() << "LINT:" << preset.getPath() << "has invalid wiki link";
+        qInfo() << "LINT:" << preset.getPath() << "has invalid wiki link";
         result = false;
     }
     return result;

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -95,7 +95,7 @@ class EngineSyncTest : public MockedEngineBackendTest {
             }
             // Internal Clock doesn't have explicit mode
             if (explicitMaster) {
-                qWarning() << "test error, internal clock can never be explicit master";
+                qInfo() << "test error, internal clock can never be explicit master";
                 return false;
             }
             return true;

--- a/src/test/signalpathtest.h
+++ b/src/test/signalpathtest.h
@@ -156,7 +156,7 @@ class BaseSignalPathTest : public MixxxTest {
             for (; i < iBufferSize && !in.atEnd(); i += 2) {
                 QStringList line = in.readLine().split(',');
                 if (line.length() != 2) {
-                    qWarning() << "Unexpected line length in reference file";
+                    qInfo() << "Unexpected line length in reference file";
                     pass = false;
                     break;
                 }
@@ -165,13 +165,13 @@ class BaseSignalPathTest : public MixxxTest {
                 double gold_value1 = line[1].toDouble(&ok);
                 EXPECT_TRUE(ok);
                 if (fabs(gold_value0 - pBuffer[i]) > delta) {
-                    qWarning() << "Golden check failed at index" << i << ", "
-                               << gold_value0 << "vs" << pBuffer[i];
+                    qInfo() << "Golden check failed at index" << i << ", "
+                            << gold_value0 << "vs" << pBuffer[i];
                     pass = false;
                 }
                 if (fabs(gold_value1 - pBuffer[i + 1]) > delta) {
-                    qWarning() << "Golden check failed at index" << i + 1 << ", "
-                               << gold_value1 << "vs" << pBuffer[i + 1];
+                    qInfo() << "Golden check failed at index" << i + 1 << ", "
+                            << gold_value1 << "vs" << pBuffer[i + 1];
                     pass = false;
                 }
             }
@@ -179,9 +179,9 @@ class BaseSignalPathTest : public MixxxTest {
         // Fail if either we didn't pass, or the comparison file was empty.
         if (!pass || i == 0) {
             QString fname_actual = reference_title + ".actual";
-            qWarning() << "Buffer does not match" << reference_title
-                       << ", actual buffer written to "
-                       << "reference_buffers/" + fname_actual;
+            qInfo() << "Buffer does not match" << reference_title
+                    << ", actual buffer written to "
+                    << "reference_buffers/" + fname_actual;
             QFile actual(QDir::currentPath() + "/src/test/reference_buffers/" + fname_actual);
             ASSERT_TRUE(actual.open(QFile::WriteOnly | QFile::Text));
             QTextStream out(&actual);

--- a/src/test/taglibtest.cpp
+++ b/src/test/taglibtest.cpp
@@ -27,7 +27,7 @@ class TagLibTest : public testing::Test {
         QFile srcFile(srcFileName);
         DEBUG_ASSERT(srcFile.exists());
         if (!srcFile.copy(dstFileName)) {
-            qWarning()
+            qInfo()
                     << srcFile.errorString()
                     << "- Failed to copy file"
                     << srcFileName

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -188,7 +188,7 @@ void KeyUtils::setNotation(const QMap<ChromaticKey, QString>& notation) {
 
     for (auto it = s_notation.constBegin(); it != s_notation.constEnd(); ++it) {
         if (s_reverseNotation.contains(it.value())) {
-            qWarning() << "Key notation is surjective (has duplicate values).";
+            qInfo() << "Key notation is surjective (has duplicate values).";
         }
         s_reverseNotation.insert(it.value(), it.key());
     }

--- a/src/track/serato/tags.cpp
+++ b/src/track/serato/tags.cpp
@@ -39,20 +39,20 @@ mixxx::RgbColor getColorFromOtherPalette(
 
 std::optional<int> findIndexForCueInfo(const mixxx::CueInfo& cueInfo) {
     VERIFY_OR_DEBUG_ASSERT(cueInfo.getHotCueNumber()) {
-        qWarning() << "SeratoTags::getCues: Cue without number found!";
+        qInfo() << "SeratoTags::getCues: Cue without number found!";
         return std::nullopt;
     }
 
     int index = *cueInfo.getHotCueNumber();
     VERIFY_OR_DEBUG_ASSERT(index >= 0) {
-        qWarning() << "SeratoTags::getCues: Cue with number < 0 found!";
+        qInfo() << "SeratoTags::getCues: Cue with number < 0 found!";
         return std::nullopt;
     }
 
     switch (cueInfo.getType()) {
     case mixxx::CueType::HotCue:
         if (index >= kLoopIndexOffset) {
-            qWarning()
+            qInfo()
                     << "SeratoTags::getCues: Non-loop Cue with number >="
                     << kLoopIndexOffset << "found!";
             return std::nullopt;
@@ -183,7 +183,7 @@ double SeratoTags::guessTimingOffsetMillis(
             timingOffset = -26;
             break;
         default:
-            qWarning()
+            qInfo()
                     << "Unknown timing offset for Serato tags with sample rate"
                     << signalInfo.getSampleRate();
         }

--- a/src/util/compatibility.h
+++ b/src/util/compatibility.h
@@ -84,14 +84,15 @@ inline QScreen* getPrimaryScreen() {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     QGuiApplication* app = static_cast<QGuiApplication*>(QCoreApplication::instance());
     VERIFY_OR_DEBUG_ASSERT(app) {
-        qWarning() << "Unable to get applications QCoreApplication instance, cannot determine primary screen!";
+        qInfo() << "Unable to get applications QCoreApplication instance, "
+                   "cannot determine primary screen!";
     } else {
         return app->primaryScreen();
     }
 #endif
     const QList<QScreen*> screens = QGuiApplication::screens();
     VERIFY_OR_DEBUG_ASSERT(!screens.isEmpty()) {
-        qWarning() << "No screens found, cannot determine primary screen!";
+        qInfo() << "No screens found, cannot determine primary screen!";
     } else {
         return screens.first();
     }

--- a/src/util/console.cpp
+++ b/src/util/console.cpp
@@ -43,7 +43,7 @@ Console::Console()
             // the input is not already redirected
             FILE* pStdin = stdin;
             if (freopen_s(&pStdin, "CONIN$", "r", stdin)) {
-                qWarning() << "Could not open stdin. Error code:" << GetLastError();
+                qInfo() << "Could not open stdin. Error code:" << GetLastError();
             }
         }
 
@@ -51,10 +51,10 @@ Console::Console()
             // the output is not already redirected
             FILE* pStdout = stdout;
             if (freopen_s(&pStdout, "CONOUT$", "w", stdout)) {
-                qWarning() << "Could not open stdout. Error code:" << GetLastError();
+                qInfo() << "Could not open stdout. Error code:" << GetLastError();
             } else {
                 if (setvbuf(stdout, NULL, _IONBF, 0) != 0) {
-                    qWarning() << "Setting no buffer for stdout failed.";
+                    qInfo() << "Setting no buffer for stdout failed.";
                 }
             }
         }
@@ -63,10 +63,10 @@ Console::Console()
             // the error is not already redirected
             FILE* pStderr = stderr;
             if (freopen_s(&pStderr, "CONOUT$", "w", stderr)) {
-                qWarning() << "Could not open stderr. Error code:" << GetLastError();
+                qInfo() << "Could not open stderr. Error code:" << GetLastError();
             } else {
                 if (setvbuf(stdout, NULL, _IONBF, 0) != 0) {
-                    qWarning() << "Setting no buffer for stderr failed.";
+                    qInfo() << "Setting no buffer for stderr failed.";
                 }
             }
         }
@@ -110,8 +110,8 @@ Console::Console()
                     pfSCCFX(hStdOut, FALSE, &newFont);
                 } else {
                     // This happens on Windows XP
-                    qWarning() << "The console font may not support non ANSI characters." <<
-                                  "In case of character issues switch to font \"Lucida Console\"";
+                    qInfo() << "The console font may not support non ANSI characters."
+                            << "In case of character issues switch to font \"Lucida Console\"";
                 }
             }
 
@@ -130,7 +130,7 @@ Console::Console()
                 if (SetConsoleTitle(szNewTitle)) {
                     m_shouldResetConsoleTitle = true;
                 } else {
-                    qWarning() << "SetConsoleTitle failed" << GetLastError();
+                    qInfo() << "SetConsoleTitle failed" << GetLastError();
                 }
             }
         }
@@ -156,7 +156,7 @@ Console::Console()
                           sizeof(defaultCodePage)) != 0) {
             SetConsoleOutputCP(defaultCodePage);
         } else {
-            qWarning() << "GetLocaleInfo failed. Error code:" << GetLastError();
+            qInfo() << "GetLocaleInfo failed. Error code:" << GetLastError();
         }
     } else {
         // started by double click
@@ -173,7 +173,7 @@ Console::~Console() {
     }
     if (m_shouldResetConsoleTitle) {
         if (!SetConsoleTitle(m_oldTitle)) {
-            qWarning() << "SetConsoleTitle failed" << GetLastError();
+            qInfo() << "SetConsoleTitle failed" << GetLastError();
         }
     }
     if (m_shouldFreeConsole) {

--- a/src/util/font.h
+++ b/src/util/font.h
@@ -36,7 +36,7 @@ class FontUtils {
     static bool addFont(const QString& path) {
         int result = QFontDatabase::addApplicationFont(path);
         if (result == -1) {
-            qWarning() << "Failed to add font:" << path;
+            qInfo() << "Failed to add font:" << path;
             return false;
         }
 

--- a/src/util/logger.h
+++ b/src/util/logger.h
@@ -63,7 +63,7 @@ public:
     }
 
     QDebug warning() const {
-        return log(qWarning());
+        return log(qInfo());
     }
 
     QDebug critical() const {

--- a/src/util/screensaver.cpp
+++ b/src/util/screensaver.cpp
@@ -216,7 +216,7 @@ void ScreenSaverHelper::triggerUserActivity()
         } 
     }
     if (!s_sendActivity) {
-        qWarning() << "Could not send activity using the registered DBus methods. " 
+        qInfo() << "Could not send activity using the registered DBus methods. " 
         << "Errors were: " << errors << 
         "\nWill try to use the Xlib XResetScreensaver instead.";
     }
@@ -246,8 +246,8 @@ void ScreenSaverHelper::inhibitInternal()
                 qDebug() << "DBus screensaver " << SCREENSAVERS[i][0] <<" inhibited";
                 break;
             } else {
-                qWarning() << "Call to inhibit for " << SCREENSAVERS[i][0] << " failed: " 
-                    << reply.error().message();
+                qInfo() << "Call to inhibit for " << SCREENSAVERS[i][0] << " failed: "
+                        << reply.error().message();
             }
         } else {
             qDebug() << "DBus interface " << SCREENSAVERS[i][0] << " not valid";
@@ -266,8 +266,8 @@ void ScreenSaverHelper::uninhibitInternal()
                 s_cookie = 0;
                 qDebug() << "DBus screensaver " << SCREENSAVERS[s_saverindex][0] << " uninhibited";
             } else {
-                qWarning() << "Call to uninhibit for " << SCREENSAVERS[s_saverindex][0] << " failed: " 
-                    << reply.error().message();
+                qInfo() << "Call to uninhibit for " << SCREENSAVERS[s_saverindex][0] << " failed: "
+                        << reply.error().message();
             }
         } else {
             qDebug() << "DBus interface " << SCREENSAVERS[s_saverindex][0] << " not valid";
@@ -336,4 +336,3 @@ void ScreenSaverHelper::uninhibitInternal()
 
 
 } // namespace mixxx
-

--- a/src/util/singleton.h
+++ b/src/util/singleton.h
@@ -10,7 +10,7 @@ class Singleton {
   public:
     static T* createInstance() {
         VERIFY_OR_DEBUG_ASSERT(!m_instance) {
-            qWarning() << "Singleton class has already been created!";
+            qInfo() << "Singleton class has already been created!";
             return m_instance;
         }
 
@@ -20,14 +20,14 @@ class Singleton {
 
     static T* instance() {
         VERIFY_OR_DEBUG_ASSERT(m_instance) {
-            qWarning() << "Singleton class has not been created yet, returning nullptr";
+            qInfo() << "Singleton class has not been created yet, returning nullptr";
         }
         return m_instance;
     }
 
     static void destroy() {
         VERIFY_OR_DEBUG_ASSERT(m_instance) {
-            qWarning() << "Singleton class has already been destroyed!";
+            qInfo() << "Singleton class has already been destroyed!";
             return;
         }
         delete m_instance;

--- a/src/util/statsmanager.cpp
+++ b/src/util/statsmanager.cpp
@@ -189,8 +189,8 @@ bool StatsManager::maybeWriteReport(StatReport report) {
     }
     static bool warnedAboutOverflow = false;
     if (!success && !warnedAboutOverflow) {
-        qWarning() << "StatsManager FIFO for thread overflowed at least once."
-                   << "Some stats are lost. Your measurements may be affected.";
+        qInfo() << "StatsManager FIFO for thread overflowed at least once."
+                << "Some stats are lost. Your measurements may be affected.";
         warnedAboutOverflow = true;
     }
     return success;

--- a/src/util/task.cpp
+++ b/src/util/task.cpp
@@ -8,7 +8,7 @@ TaskWatcher::TaskWatcher(QObject* pParent) : QObject(pParent) {
 
 TaskWatcher::~TaskWatcher() {
     if (atomicLoadRelaxed(m_activeTasks) > 0) {
-        qWarning() << "TaskWatcher destroyed before all tasks were done.";
+        qInfo() << "TaskWatcher destroyed before all tasks were done.";
     }
 }
 

--- a/src/util/taskmonitor.cpp
+++ b/src/util/taskmonitor.cpp
@@ -20,7 +20,7 @@ TaskMonitor::TaskMonitor(
 TaskMonitor::~TaskMonitor() {
     VERIFY_OR_DEBUG_ASSERT(m_taskInfos.isEmpty()) {
         // All tasks should have finished now!
-        qWarning()
+        qInfo()
                 << "Aborting"
                 << m_taskInfos.size()
                 << "pending tasks";

--- a/src/util/xml.cpp
+++ b/src/util/xml.cpp
@@ -69,7 +69,7 @@ QDomElement XmlParse::openXMLFile(const QString& path, const QString& name) {
 
         QString errorLog = QString("Error parsing XML file %1: %2")
                             .arg(file.fileName(), errorString);
-        qWarning() << errorLog;
+        qInfo() << errorLog;
 
         // Set up error dialog
         ErrorDialogProperties* props = ErrorDialogHandler::instance()->newDialogProperties();

--- a/src/vinylcontrol/vinylcontrolmanager.cpp
+++ b/src/vinylcontrol/vinylcontrolmanager.cpp
@@ -71,9 +71,9 @@ void VinylControlManager::slotNumDecksChanged(double dNumDecks) {
 
     // Complain if we try to create more decks than we can handle.
     if (num_decks > kMaxNumberOfDecks) {
-        qWarning() << "Number of decks increased to " << num_decks << ", but Mixxx only supports "
-                   << kMaxNumberOfDecks << " vinyl inputs.  Decks above the maximum will not have "
-                   << " vinyl control";
+        qInfo() << "Number of decks increased to " << num_decks << ", but Mixxx only supports "
+                << kMaxNumberOfDecks << " vinyl inputs.  Decks above the maximum will not have "
+                << " vinyl control";
         num_decks = kMaxNumberOfDecks;
     }
 

--- a/src/vinylcontrol/vinylcontrolprocessor.cpp
+++ b/src/vinylcontrol/vinylcontrolprocessor.cpp
@@ -97,7 +97,8 @@ void VinylControlProcessor::run() {
                 int samplesRead = pSamplePipe->read(m_pWorkBuffer, MAX_BUFFER_LEN);
 
                 if (samplesRead % 2 != 0) {
-                    qWarning() << "VinylControlProcessor received non-even number of samples via sample FIFO.";
+                    qInfo() << "VinylControlProcessor received non-even number "
+                               "of samples via sample FIFO.";
                     samplesRead--;
                 }
                 int framesRead = samplesRead / 2;
@@ -106,7 +107,7 @@ void VinylControlProcessor::run() {
                     pProcessor->analyzeSamples(m_pWorkBuffer, framesRead);
                 } else {
                     // Samples are being written to a non-existent processor. Warning?
-                    qWarning() << "Samples written to non-existent VinylControl processor:" << i;
+                    qInfo() << "Samples written to non-existent VinylControl processor:" << i;
                 }
             }
 
@@ -117,7 +118,9 @@ void VinylControlProcessor::run() {
                 if (pProcessor->writeQualityReport(&report)) {
                     report.processor = i;
                     if (m_signalQualityFifo.write(&report, 1) != 1) {
-                        qWarning() << "VinylControlProcessor could not write signal quality report for VC index:" << i;
+                        qInfo() << "VinylControlProcessor could not write "
+                                   "signal quality report for VC index:"
+                                << i;
                     }
                 }
             }
@@ -162,7 +165,7 @@ void VinylControlProcessor::onInputConfigured(AudioInput input) {
 
     if (index >= kMaximumVinylControlInputs) {
         // Should not be possible.
-        qWarning() << "VinylControlProcessor::onInputConnected got invalid index:" << index;
+        qInfo() << "VinylControlProcessor::onInputConnected got invalid index:" << index;
         return;
     }
 
@@ -187,7 +190,7 @@ void VinylControlProcessor::onInputUnconfigured(AudioInput input) {
 
     if (index >= kMaximumVinylControlInputs) {
         // Should not be possible.
-        qWarning() << "VinylControlProcessor::onInputDisconnected got invalid index:" << index;
+        qInfo() << "VinylControlProcessor::onInputDisconnected got invalid index:" << index;
         return;
     }
 
@@ -231,8 +234,8 @@ void VinylControlProcessor::receiveBuffer(AudioInput input,
     int samplesWritten = pSamplePipe->write(pBuffer, nSamples);
 
     if (samplesWritten < nSamples) {
-        qWarning() << "ERROR: Buffer overflow in VinylControlProcessor. Dropping samples on the floor."
-                   << "VCIndex:" << vcIndex;
+        qInfo() << "ERROR: Buffer overflow in VinylControlProcessor. Dropping samples on the floor."
+                << "VCIndex:" << vcIndex;
     }
 
     m_samplesAvailableSignal.wakeAll();

--- a/src/waveform/renderers/glslwaveformrenderersignal.cpp
+++ b/src/waveform/renderers/glslwaveformrenderersignal.cpp
@@ -181,7 +181,7 @@ void GLSLWaveformRendererSignal::createFrameBuffers() {
                                                            bufferHeight);
 
     if (!m_framebuffer->isValid()) {
-        qWarning() << "GLSLWaveformRendererSignal::createFrameBuffer - frame buffer not valid";
+        qInfo() << "GLSLWaveformRendererSignal::createFrameBuffer - frame buffer not valid";
     }
 }
 

--- a/src/waveform/renderers/waveformmarkset.cpp
+++ b/src/waveform/renderers/waveformmarkset.cpp
@@ -36,7 +36,7 @@ void WaveformMarkSet::setup(const QString& group, const QDomNode& node,
                 // guarantee uniqueness even if there is a misdesigned skin
                 QString item = pMark->getItem();
                 if (!controlItemSet.insert(item).second) {
-                    qWarning() << "WaveformRenderMark::setup - redefinition of" << item;
+                    qInfo() << "WaveformRenderMark::setup - redefinition of" << item;
                 } else  {
                     m_marks.push_back(pMark);
                     if (pMark->getHotCue() >= 0) {

--- a/src/waveform/renderers/waveformsignalcolors.cpp
+++ b/src/waveform/renderers/waveformsignalcolors.cpp
@@ -92,7 +92,7 @@ bool WaveformSignalColors::setup(const QDomNode &node, const SkinContext& contex
 }
 
 void WaveformSignalColors::fallBackFromSignalColor() {
-    // qWarning() << "WaveformSignalColors::fallBackFromSignalColor - "
+    // qInfo() << "WaveformSignalColors::fallBackFromSignalColor - "
     //           << "skin do not provide low/mid/high signal colors";
 
     // NOTE(rryan): On ARM, qreal is float so it's important we use qreal here
@@ -141,8 +141,8 @@ void WaveformSignalColors::fallBackFromSignalColor() {
 }
 
 void WaveformSignalColors::fallBackDefaultColor() {
-    qWarning() << "WaveformSignalColors::fallBackDefaultColor - " \
-                  "skin do not provide valid signal colors ! Default colors is use ...";
+    qInfo() << "WaveformSignalColors::fallBackDefaultColor - "
+               "skin do not provide valid signal colors ! Default colors is use ...";
 
     m_signalColor = Qt::green;
     m_signalColor = m_signalColor.toRgb();

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -964,12 +964,12 @@ WaveformWidgetAbstract* WaveformWidgetFactory::createWaveformWidget(
         }
         widget->castToQWidget();
         if (!widget->isValid()) {
-            qWarning() << "failed to init WafeformWidget" << type << "fall back to \"Empty\"";
+            qInfo() << "failed to init WafeformWidget" << type << "fall back to \"Empty\"";
             delete widget;
             widget = new EmptyWaveformWidget(viewer->getGroup(), viewer);
             widget->castToQWidget();
             if (!widget->isValid()) {
-                qWarning() << "failed to init EmptyWaveformWidget";
+                qInfo() << "failed to init EmptyWaveformWidget";
                 delete widget;
                 widget = NULL;
             }

--- a/src/widget/controlwidgetconnection.cpp
+++ b/src/widget/controlwidgetconnection.cpp
@@ -123,10 +123,10 @@ void ControlWidgetPropertyConnection::slotControlValueChanged(double v) {
     }
 
     if (!pWidget->setProperty(m_propertyName.constData(),parameter)) {
-        qWarning() << "Property" << m_propertyName
-                   << "was not defined for widget" << pWidget->objectName()
-                   << "of type" << pWidget->metaObject()->className()
-                   << "(parameter:" << parameter << ")";
+        qInfo() << "Property" << m_propertyName
+                << "was not defined for widget" << pWidget->objectName()
+                << "of type" << pWidget->metaObject()->className()
+                << "(parameter:" << parameter << ")";
     }
 
     // According to http://stackoverflow.com/a/3822243 this is the least

--- a/src/widget/paintable.cpp
+++ b/src/widget/paintable.cpp
@@ -24,8 +24,8 @@ Paintable::DrawMode Paintable::DrawModeFromString(const QString& str) {
     }
 
     // Fall back on the implicit default from before Mixxx supported draw modes.
-    qWarning() << "Unknown DrawMode string in DrawModeFromString:"
-               << str << "using FIXED";
+    qInfo() << "Unknown DrawMode string in DrawModeFromString:"
+            << str << "using FIXED";
     return FIXED;
 }
 
@@ -42,8 +42,8 @@ QString Paintable::DrawModeToString(DrawMode mode) {
             return "TILE";
     }
     // Fall back on the implicit default from before Mixxx supported draw modes.
-    qWarning() << "Unknown DrawMode in DrawModeToString " << mode
-               << "using FIXED";
+    qInfo() << "Unknown DrawMode in DrawModeToString " << mode
+            << "using FIXED";
     return "FIXED";
 }
 
@@ -239,7 +239,7 @@ void Paintable::drawInternal(const QRectF& targetRect, QPainter* pPainter,
         }
     } else if (m_pSvg) {
         if (m_drawMode == TILE) {
-            qWarning() << "Tiled SVG should have been rendered to pixmap!";
+            qInfo() << "Tiled SVG should have been rendered to pixmap!";
         } else {
             // NOTE(rryan): QSvgRenderer render does not clip for us -- it
             // applies a world transformation using viewBox and renders the

--- a/src/widget/wcolorpicker.cpp
+++ b/src/widget/wcolorpicker.cpp
@@ -76,7 +76,7 @@ WColorPicker::WColorPicker(Options options, const ColorPalette& palette, QWidget
 void WColorPicker::removeColorButtons() {
     QGridLayout* pLayout = static_cast<QGridLayout*>(layout());
     VERIFY_OR_DEBUG_ASSERT(pLayout) {
-        qWarning() << "Color Picker has no layout!";
+        qInfo() << "Color Picker has no layout!";
         return;
     }
 
@@ -102,7 +102,7 @@ void WColorPicker::removeColorButtons() {
 void WColorPicker::addColorButtons() {
     QGridLayout* pLayout = static_cast<QGridLayout*>(layout());
     VERIFY_OR_DEBUG_ASSERT(pLayout) {
-        qWarning() << "Color Picker has no layout!";
+        qInfo() << "Color Picker has no layout!";
         return;
     }
 

--- a/src/widget/wdisplay.cpp
+++ b/src/widget/wdisplay.cpp
@@ -83,7 +83,7 @@ void WDisplay::setPositions(int iNoPos) {
     resetPositions();
 
     if (iNoPos < 0) {
-        qWarning() << "Negative NumberStates for Display.";
+        qInfo() << "Negative NumberStates for Display.";
         iNoPos = 0;
     }
 

--- a/src/widget/weffectparameterknob.cpp
+++ b/src/widget/weffectparameterknob.cpp
@@ -5,8 +5,7 @@ void WEffectParameterKnob::setupEffectParameterSlot(const ConfigKey& configKey) 
     EffectParameterSlotPointer pParameterSlot =
             m_pEffectsManager->getEffectParameterSlot(configKey);
     if (!pParameterSlot) {
-        qWarning() << "EffectParameterKnob" << configKey <<
-                "is not an effect parameter.";
+        qInfo() << "EffectParameterKnob" << configKey << "is not an effect parameter.";
         return;
     }
     setEffectParameterSlot(pParameterSlot);

--- a/src/widget/weffectparameterknobcomposed.cpp
+++ b/src/widget/weffectparameterknobcomposed.cpp
@@ -10,8 +10,7 @@ void WEffectParameterKnobComposed::setupEffectParameterSlot(const ConfigKey& con
     EffectParameterSlotPointer pParameterSlot =
             m_pEffectsManager->getEffectParameterSlot(configKey);
     if (!pParameterSlot) {
-        qWarning() << "EffectParameterKnobComposed" << configKey <<
-                "is not an effect parameter.";
+        qInfo() << "EffectParameterKnobComposed" << configKey << "is not an effect parameter.";
         return;
     }
     setEffectParameterSlot(pParameterSlot);

--- a/src/widget/weffectpushbutton.cpp
+++ b/src/widget/weffectpushbutton.cpp
@@ -24,8 +24,7 @@ void WEffectPushButton::setupEffectParameterSlot(const ConfigKey& configKey) {
     EffectButtonParameterSlotPointer pParameterSlot =
             m_pEffectsManager->getEffectButtonParameterSlot(configKey);
     if (!pParameterSlot) {
-        qWarning() << "EffectPushButton" << configKey <<
-                "is not an effect button parameter.";
+        qInfo() << "EffectPushButton" << configKey << "is not an effect button parameter.";
         return;
     }
     setEffectParameterSlot(pParameterSlot);

--- a/src/widget/wsingletoncontainer.cpp
+++ b/src/widget/wsingletoncontainer.cpp
@@ -60,8 +60,8 @@ void WSingletonContainer::showEvent(QShowEvent* event) {
 
 void SingletonMap::insertSingleton(QString objectName, QWidget* widget) {
     if (m_singletons.contains(objectName)){
-        qWarning() << "ERROR: Tried to insert a singleton with a name that has"
-                   << "already been inserted:" << objectName;
+        qInfo() << "ERROR: Tried to insert a singleton with a name that has"
+                << "already been inserted:" << objectName;
         return;
     }
     m_singletons.insert(objectName, widget);

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -942,7 +942,7 @@ void WTrackMenu::slotPopulatePlaylistMenu() {
 void WTrackMenu::addSelectionToPlaylist(int iPlaylistId) {
     const TrackIdList trackIds = getTrackIds();
     if (trackIds.isEmpty()) {
-        qWarning() << "No tracks selected for playlist";
+        qInfo() << "No tracks selected for playlist";
         return;
     }
 
@@ -1051,7 +1051,7 @@ void WTrackMenu::slotPopulateCrateMenu() {
 void WTrackMenu::updateSelectionCrates(QWidget* pWidget) {
     auto pCheckBox = qobject_cast<QCheckBox*>(pWidget);
     VERIFY_OR_DEBUG_ASSERT(pCheckBox) {
-        qWarning() << "crateId is not of CrateId type";
+        qInfo() << "crateId is not of CrateId type";
         return;
     }
     CrateId crateId = pCheckBox->property("crateId").value<CrateId>();
@@ -1059,7 +1059,7 @@ void WTrackMenu::updateSelectionCrates(QWidget* pWidget) {
     const TrackIdList trackIds = getTrackIds();
 
     if (trackIds.isEmpty()) {
-        qWarning() << "No tracks selected for crate";
+        qInfo() << "No tracks selected for crate";
         return;
     }
 
@@ -1086,7 +1086,7 @@ void WTrackMenu::addSelectionToNewCrate() {
     const TrackIdList trackIds = getTrackIds();
 
     if (trackIds.isEmpty()) {
-        qWarning() << "No tracks selected for crate";
+        qInfo() << "No tracks selected for crate";
         return;
     }
 
@@ -1517,7 +1517,7 @@ void WTrackMenu::slotAddToAutoDJReplace() {
 void WTrackMenu::addToAutoDJ(PlaylistDAO::AutoDJSendLoc loc) {
     const TrackIdList trackIds = getTrackIds();
     if (trackIds.empty()) {
-        qWarning() << "No tracks selected for AutoDJ";
+        qInfo() << "No tracks selected for AutoDJ";
         return;
     }
 

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -772,13 +772,13 @@ QList<TrackId> WTrackTableView::getSelectedTrackIds() const {
 
     QItemSelectionModel* pSelectionModel = selectionModel();
     VERIFY_OR_DEBUG_ASSERT(pSelectionModel != nullptr) {
-        qWarning() << "No selected tracks available";
+        qInfo() << "No selected tracks available";
         return trackIds;
     }
 
     TrackModel* pTrackModel = getTrackModel();
     VERIFY_OR_DEBUG_ASSERT(pTrackModel != nullptr) {
-        qWarning() << "No selected tracks available";
+        qInfo() << "No selected tracks available";
         return trackIds;
     }
 
@@ -801,13 +801,13 @@ QList<TrackId> WTrackTableView::getSelectedTrackIds() const {
 void WTrackTableView::setSelectedTracks(const QList<TrackId>& trackIds) {
     QItemSelectionModel* pSelectionModel = selectionModel();
     VERIFY_OR_DEBUG_ASSERT(pSelectionModel != nullptr) {
-        qWarning() << "No selected tracks available";
+        qInfo() << "No selected tracks available";
         return;
     }
 
     TrackModel* pTrackModel = getTrackModel();
     VERIFY_OR_DEBUG_ASSERT(pTrackModel != nullptr) {
-        qWarning() << "No selected tracks available";
+        qInfo() << "No selected tracks available";
         return;
     }
 
@@ -829,7 +829,7 @@ void WTrackTableView::addToAutoDJ(PlaylistDAO::AutoDJSendLoc loc) {
 
     const QList<TrackId> trackIds = getSelectedTrackIds();
     if (trackIds.isEmpty()) {
-        qWarning() << "No tracks selected for AutoDJ";
+        qInfo() << "No tracks selected for AutoDJ";
         return;
     }
 

--- a/src/widget/wwidgetgroup.cpp
+++ b/src/widget/wwidgetgroup.cpp
@@ -161,8 +161,8 @@ void WWidgetGroup::setPixmapBackground(
     // Load background pixmap
     m_pPixmapBack = WPixmapStore::getPaintable(source, mode, scaleFactor);
     if (!m_pPixmapBack) {
-        qWarning() << "WWidgetGroup: Error loading background pixmap:"
-                 << source.getPath();
+        qInfo() << "WWidgetGroup: Error loading background pixmap:"
+                << source.getPath();
     }
 }
 
@@ -173,8 +173,8 @@ void WWidgetGroup::setPixmapBackgroundHighlighted(
     // Load background pixmap for the highlighted state
     m_pPixmapBackHighlighted = WPixmapStore::getPaintable(source, mode, scaleFactor);
     if (!m_pPixmapBackHighlighted) {
-        qWarning() << "WWidgetGroup: Error loading background highlighted pixmap:"
-                 << source.getPath();
+        qInfo() << "WWidgetGroup: Error loading background highlighted pixmap:"
+                << source.getPath();
     }
 }
 


### PR DESCRIPTION
qWarning() is used by Qt classes, e.g. when you try to use QList::insert
at an invalid index. To debug this, you can set the Q_FATAL_WARNINGS
environment variable.

Unfortunately, this is currently not feasible because we're using
qWarning() elsewhere in our code (we already have DEBUG_ASSERT for
potentially fatal programming errors).

Hence, this commit replaces all occurrences of qWarning() with qInfo(),
so that the environment variable can be used to debug these issues.