### PR TITLE
LateNight: Fix undefined "highlight" property warnings for WBeatSpinBox

### DIFF
--- a/res/skins/LateNight/decks/row_5_transportLoopJump.xml
+++ b/res/skins/LateNight/decks/row_5_transportLoopJump.xml
@@ -248,10 +248,6 @@
                     <MinimumSize>46,26</MinimumSize>
                     <MaximumSize>72,26</MaximumSize>
                     <Value><Variable name="Group"/>,beatloop_size</Value>
-                    <Connection>
-                      <ConfigKey><Variable name="Group"/>,track_loaded</ConfigKey>
-                      <BindProperty>highlight</BindProperty>
-                    </Connection>
                   </BeatSpinBox>
                 </Children>
               </WidgetGroup>
@@ -314,10 +310,6 @@
                     <MinimumSize>46,26</MinimumSize>
                     <MaximumSize>72,26</MaximumSize>
                     <Value><Variable name="Group"/>,beatjump_size</Value>
-                    <Connection>
-                      <ConfigKey><Variable name="Group"/>,track_loaded</ConfigKey>
-                      <BindProperty>highlight</BindProperty>
-                    </Connection>
                   </BeatSpinBox>
                 </Children>
               </WidgetGroup>

--- a/res/skins/LateNight/decks/row_5_transportLoopJump_compact.xml
+++ b/res/skins/LateNight/decks/row_5_transportLoopJump_compact.xml
@@ -103,10 +103,6 @@
                 <MinimumSize>46,26</MinimumSize>
                 <MaximumSize>72,26</MaximumSize>
                 <Value><Variable name="Group"/>,beatloop_size</Value>
-                <Connection>
-                  <ConfigKey><Variable name="Group"/>,track_loaded</ConfigKey>
-                  <BindProperty>highlight</BindProperty>
-                </Connection>
               </BeatSpinBox>
 
               <WidgetGroup>
@@ -124,10 +120,6 @@
                 <Align>center</Align>
                 <Alignment>center</Alignment>
                 <Value><Variable name="Group"/>,beatjump_size</Value>
-                <Connection>
-                  <ConfigKey><Variable name="Group"/>,track_loaded</ConfigKey>
-                  <BindProperty>highlight</BindProperty>
-                </Connection>
               </BeatSpinBox>
             </Children>
             <Connection>

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -182,12 +182,9 @@ WSearchLineEdit {
   #OverviewBoxMini[highlight="1"] {
     background-color: #151515;
   }
-  WBeatSpinBox[highlight="0"] {
+  WBeatSpinBox {
     background-color: #171719;
-    }
-    WBeatSpinBox[highlight="1"] {
-      background-color: #121213;
-    }
+  }
   #KeyText,
   #DeckSettingsContainer,
   #DeckSettingsContainerCompact,


### PR DESCRIPTION
Fixes multiple warnings like these:

    Warning [Main]: Property "highlight" was not defined for widget "Spinbox_embedded" of type WBeatSpinBox (parameter: QVariant(double, 0) )