### PR TITLE
LateNight: Fix vertical splitter handle warning in PaleMoon

### DIFF
--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -2647,7 +2647,7 @@ WSearchLineEdit {
   }
   #LibrarySplitter::handle:pressed,
   #LibrarySplitter::handle:hover {
-    image: url(skin:/palemoon/style/splitter_handle_vertical_pressed.svg);
+    image: url(skin:/palemoon/style/splitter_handle_vertical_pressed.png);
   }
 /************ splitters ***********************/
 


### PR DESCRIPTION
The SVG file does not exist and throws a warning.