### PR TITLE
Fix TODO by renaming the property declaration macro

### DIFF
--- a/src/audio/signalinfo.h
+++ b/src/audio/signalinfo.h
@@ -12,9 +12,9 @@ namespace audio {
 // Properties that characterize an uncompressed PCM audio signal.
 class SignalInfo final {
     // Properties
-    PROPERTY_SET_BYVAL_GET_BYREF(ChannelCount, channelCount, ChannelCount)
-    PROPERTY_SET_BYVAL_GET_BYREF(SampleRate, sampleRate, SampleRate)
-    PROPERTY_SET_BYVAL_GET_BYREF(OptionalSampleLayout, sampleLayout, SampleLayout)
+    MIXXX_DECL_PROPERTY(ChannelCount, channelCount, ChannelCount)
+    MIXXX_DECL_PROPERTY(SampleRate, sampleRate, SampleRate)
+    MIXXX_DECL_PROPERTY(OptionalSampleLayout, sampleLayout, SampleLayout)
 
   public:
     constexpr SignalInfo() = default;

--- a/src/audio/streaminfo.h
+++ b/src/audio/streaminfo.h
@@ -13,9 +13,9 @@ namespace audio {
 // that is known upfront!
 class StreamInfo final {
     // Properties
-    PROPERTY_SET_BYVAL_GET_BYREF(SignalInfo, signalInfo, SignalInfo)
-    PROPERTY_SET_BYVAL_GET_BYREF(Bitrate, bitrate, Bitrate)
-    PROPERTY_SET_BYVAL_GET_BYREF(Duration, duration, Duration)
+    MIXXX_DECL_PROPERTY(SignalInfo, signalInfo, SignalInfo)
+    MIXXX_DECL_PROPERTY(Bitrate, bitrate, Bitrate)
+    MIXXX_DECL_PROPERTY(Duration, duration, Duration)
 
   public:
     constexpr StreamInfo() = default;

--- a/src/track/albuminfo.h
+++ b/src/track/albuminfo.h
@@ -12,19 +12,19 @@ namespace mixxx {
 
 class AlbumInfo final {
     // Properties in alphabetical order
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    artist,                    Artist)
+    MIXXX_DECL_PROPERTY(QString, artist, Artist)
 #if defined(__EXTRA_METADATA__)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    copyright,                 Copyright)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    license,                   License)
-    PROPERTY_SET_BYVAL_GET_BYREF(QUuid,      musicBrainzArtistId,       MusicBrainzArtistId)
-    PROPERTY_SET_BYVAL_GET_BYREF(QUuid,      musicBrainzReleaseGroupId, MusicBrainzReleaseGroupId)
-    PROPERTY_SET_BYVAL_GET_BYREF(QUuid,      musicBrainzReleaseId,      MusicBrainzReleaseId)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    recordLabel,               RecordLabel)
-    PROPERTY_SET_BYVAL_GET_BYREF(ReplayGain, replayGain,                ReplayGain)
+    MIXXX_DECL_PROPERTY(QString, copyright, Copyright)
+    MIXXX_DECL_PROPERTY(QString, license, License)
+    MIXXX_DECL_PROPERTY(QUuid, musicBrainzArtistId, MusicBrainzArtistId)
+    MIXXX_DECL_PROPERTY(QUuid, musicBrainzReleaseGroupId, MusicBrainzReleaseGroupId)
+    MIXXX_DECL_PROPERTY(QUuid, musicBrainzReleaseId, MusicBrainzReleaseId)
+    MIXXX_DECL_PROPERTY(QString, recordLabel, RecordLabel)
+    MIXXX_DECL_PROPERTY(ReplayGain, replayGain, ReplayGain)
 #endif // __EXTRA_METADATA__
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    title,                     Title)
+    MIXXX_DECL_PROPERTY(QString, title, Title)
 
-public:
+  public:
     AlbumInfo() = default;
     AlbumInfo(AlbumInfo&&) = default;
     AlbumInfo(const AlbumInfo&) = default;

--- a/src/track/trackinfo.h
+++ b/src/track/trackinfo.h
@@ -14,48 +14,48 @@ namespace mixxx {
 
 class TrackInfo final {
     // Properties in alphabetical order
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    artist,               Artist)
-    PROPERTY_SET_BYVAL_GET_BYREF(Bpm,        bpm,                  Bpm)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    comment,              Comment)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    composer,             Composer)
+    MIXXX_DECL_PROPERTY(QString, artist, Artist)
+    MIXXX_DECL_PROPERTY(Bpm, bpm, Bpm)
+    MIXXX_DECL_PROPERTY(QString, comment, Comment)
+    MIXXX_DECL_PROPERTY(QString, composer, Composer)
 #if defined(__EXTRA_METADATA__)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    conductor,            Conductor)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    discNumber,           DiscNumber)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    discTotal,            DiscTotal)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    encoder,              Encoder)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    encoderSettings,      EncoderSettings)
+    MIXXX_DECL_PROPERTY(QString, conductor, Conductor)
+    MIXXX_DECL_PROPERTY(QString, discNumber, DiscNumber)
+    MIXXX_DECL_PROPERTY(QString, discTotal, DiscTotal)
+    MIXXX_DECL_PROPERTY(QString, encoder, Encoder)
+    MIXXX_DECL_PROPERTY(QString, encoderSettings, EncoderSettings)
 #endif // __EXTRA_METADATA__
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    genre,                Genre)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    grouping,             Grouping)
+    MIXXX_DECL_PROPERTY(QString, genre, Genre)
+    MIXXX_DECL_PROPERTY(QString, grouping, Grouping)
 #if defined(__EXTRA_METADATA__)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    isrc,                 ISRC)
+    MIXXX_DECL_PROPERTY(QString, isrc, ISRC)
 #endif // __EXTRA_METADATA__
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    key,                  Key)
+    MIXXX_DECL_PROPERTY(QString, key, Key)
 #if defined(__EXTRA_METADATA__)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    language,             Language)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    lyricist,             Lyricist)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    mood,                 Mood)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    movement,             Movement)
-    PROPERTY_SET_BYVAL_GET_BYREF(QUuid,      musicBrainzArtistId,  MusicBrainzArtistId)
-    PROPERTY_SET_BYVAL_GET_BYREF(QUuid,      musicBrainzRecordingId, MusicBrainzRecordingId)
-    PROPERTY_SET_BYVAL_GET_BYREF(QUuid,      musicBrainzReleaseId, MusicBrainzReleaseId)
-    PROPERTY_SET_BYVAL_GET_BYREF(QUuid,      musicBrainzWorkId,    MusicBrainzWorkId)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    remixer,              Remixer)
+    MIXXX_DECL_PROPERTY(QString, language, Language)
+    MIXXX_DECL_PROPERTY(QString, lyricist, Lyricist)
+    MIXXX_DECL_PROPERTY(QString, mood, Mood)
+    MIXXX_DECL_PROPERTY(QString, movement, Movement)
+    MIXXX_DECL_PROPERTY(QUuid, musicBrainzArtistId, MusicBrainzArtistId)
+    MIXXX_DECL_PROPERTY(QUuid, musicBrainzRecordingId, MusicBrainzRecordingId)
+    MIXXX_DECL_PROPERTY(QUuid, musicBrainzReleaseId, MusicBrainzReleaseId)
+    MIXXX_DECL_PROPERTY(QUuid, musicBrainzWorkId, MusicBrainzWorkId)
+    MIXXX_DECL_PROPERTY(QString, remixer, Remixer)
 #endif // __EXTRA_METADATA__
-    PROPERTY_SET_BYVAL_GET_BYREF(ReplayGain, replayGain,           ReplayGain)
-    PROPERTY_SET_BYVAL_GET_BYREF(SeratoTags, seratoTags,           SeratoTags)
+    MIXXX_DECL_PROPERTY(ReplayGain, replayGain, ReplayGain)
+    MIXXX_DECL_PROPERTY(SeratoTags, seratoTags, SeratoTags)
 #if defined(__EXTRA_METADATA__)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    subtitle,             Subtitle)
+    MIXXX_DECL_PROPERTY(QString, subtitle, Subtitle)
 #endif // __EXTRA_METADATA__
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    title,                Title)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    trackNumber,          TrackNumber)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    trackTotal,           TrackTotal)
+    MIXXX_DECL_PROPERTY(QString, title, Title)
+    MIXXX_DECL_PROPERTY(QString, trackNumber, TrackNumber)
+    MIXXX_DECL_PROPERTY(QString, trackTotal, TrackTotal)
 #if defined(__EXTRA_METADATA__)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    work,                 Work)
+    MIXXX_DECL_PROPERTY(QString, work, Work)
 #endif // __EXTRA_METADATA__
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    year,                 Year) // = release date
+    MIXXX_DECL_PROPERTY(QString, year, Year) // = release date
 
-public:
+  public:
     TrackInfo() = default;
     TrackInfo(TrackInfo&&) = default;
     TrackInfo(const TrackInfo&) = default;

--- a/src/track/trackmetadata.h
+++ b/src/track/trackmetadata.h
@@ -19,16 +19,16 @@ class TrackMetadata final {
     //  - read-only
     //  - stored in file tags
     //  - adjusted when opening the audio stream (if available)
-    PROPERTY_SET_BYVAL_GET_BYREF(audio::ChannelCount, channels, ChannelCount)
-    PROPERTY_SET_BYVAL_GET_BYREF(audio::SampleRate, sampleRate, SampleRate)
-    PROPERTY_SET_BYVAL_GET_BYREF(audio::Bitrate, bitrate, Bitrate)
-    PROPERTY_SET_BYVAL_GET_BYREF(Duration, duration, Duration)
+    MIXXX_DECL_PROPERTY(audio::ChannelCount, channels, ChannelCount)
+    MIXXX_DECL_PROPERTY(audio::SampleRate, sampleRate, SampleRate)
+    MIXXX_DECL_PROPERTY(audio::Bitrate, bitrate, Bitrate)
+    MIXXX_DECL_PROPERTY(Duration, duration, Duration)
 
     // Track properties
     //   - read-write
     //   - stored in file tags
-    PROPERTY_SET_BYVAL_GET_BYREF(AlbumInfo, albumInfo, AlbumInfo)
-    PROPERTY_SET_BYVAL_GET_BYREF(TrackInfo, trackInfo, TrackInfo)
+    MIXXX_DECL_PROPERTY(AlbumInfo, albumInfo, AlbumInfo)
+    MIXXX_DECL_PROPERTY(TrackInfo, trackInfo, TrackInfo)
 
   public:
     TrackMetadata() = default;

--- a/src/track/trackrecord.h
+++ b/src/track/trackrecord.h
@@ -19,11 +19,11 @@ namespace mixxx {
 class TrackRecord final {
     // Properties that parsed from and (optionally) written back to their
     // source, i.e. the corresponding file
-    PROPERTY_SET_BYVAL_GET_BYREF(TrackMetadata,  metadata,       Metadata)
+    MIXXX_DECL_PROPERTY(TrackMetadata, metadata, Metadata)
 
     // The unique ID of track. This value is only set once after the track
     // has been inserted or is loaded from the library DB.
-    PROPERTY_SET_BYVAL_GET_BYREF(TrackId,        id,             Id)
+    MIXXX_DECL_PROPERTY(TrackId, id, Id)
 
     // TODO(uklotz): Change data type from bool to QDateTime
     //
@@ -37,20 +37,20 @@ class TrackRecord final {
     // Requires a database update! We could reuse the 'header_parsed' column.
     // During migration the boolean value will be substituted with either a
     // default time stamp 1970-01-01 00:00:00.000 or NULL respectively.
-    PROPERTY_SET_BYVAL_GET_BYREF(bool /*QDateTime*/, metadataSynchronized, MetadataSynchronized)
+    MIXXX_DECL_PROPERTY(bool /*QDateTime*/, metadataSynchronized, MetadataSynchronized)
 
-    PROPERTY_SET_BYVAL_GET_BYREF(CoverInfoRelative,  coverInfo,            CoverInfo)
+    MIXXX_DECL_PROPERTY(CoverInfoRelative, coverInfo, CoverInfo)
 
-    PROPERTY_SET_BYVAL_GET_BYREF(QDateTime,   dateAdded,      DateAdded)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,     fileType,       FileType)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,     url,            Url)
-    PROPERTY_SET_BYVAL_GET_BYREF(PlayCounter, playCounter,    PlayCounter)
-    PROPERTY_SET_BYVAL_GET_BYREF(RgbColor::optional_t, color, Color)
-    PROPERTY_SET_BYVAL_GET_BYREF(CuePosition, cuePoint,       CuePoint)
-    PROPERTY_SET_BYVAL_GET_BYREF(int,         rating,         Rating)
-    PROPERTY_SET_BYVAL_GET_BYREF(bool,        bpmLocked,      BpmLocked)
+    MIXXX_DECL_PROPERTY(QDateTime, dateAdded, DateAdded)
+    MIXXX_DECL_PROPERTY(QString, fileType, FileType)
+    MIXXX_DECL_PROPERTY(QString, url, Url)
+    MIXXX_DECL_PROPERTY(PlayCounter, playCounter, PlayCounter)
+    MIXXX_DECL_PROPERTY(RgbColor::optional_t, color, Color)
+    MIXXX_DECL_PROPERTY(CuePosition, cuePoint, CuePoint)
+    MIXXX_DECL_PROPERTY(int, rating, Rating)
+    MIXXX_DECL_PROPERTY(bool, bpmLocked, BpmLocked)
 
-public:
+  public:
     // Data migration: Reload track total from file tags if not initialized
     // yet. The added column "tracktotal" has been initialized with the
     // default value "//".

--- a/src/util/macros.h
+++ b/src/util/macros.h
@@ -18,14 +18,50 @@
 //
 // The ptrName() function is overloaded for both mutable and
 // immutable access by a pointer.
-//
-// TODO: Adjust the name of this macro, e.g. DECL_MIXXX_PROPERTY
-#define PROPERTY_SET_BYVAL_GET_BYREF(TYPE, NAME, CAP_NAME) \
-public: template <typename T> typename std::enable_if<(std::is_fundamental<TYPE>::value || std::is_same<TYPE, bool>::value) && std::is_same<TYPE, T>::value>::type set##CAP_NAME(T _val) { m_##NAME = _val; } \
-public: template <typename T> typename std::enable_if<!(std::is_fundamental<TYPE>::value || std::is_same<TYPE, bool>::value) && std::is_assignable<TYPE, T>::value>::type set##CAP_NAME(T&& _val) { m_##NAME = std::forward<T>(_val); } \
-public: constexpr std::conditional<std::is_fundamental<TYPE>::value, TYPE, const TYPE&>::type get##CAP_NAME() const { return m_##NAME; } \
-public: constexpr TYPE& ref##CAP_NAME() { return m_##NAME; } \
-public: constexpr TYPE* ptr##CAP_NAME() { return &m_##NAME; } \
-public: constexpr const TYPE* ptr##CAP_NAME() const { return &m_##NAME; } \
-public: QDebug dbg##CAP_NAME(QDebug dbg) const { return dbg << #NAME ":" << m_##NAME; } \
-private: TYPE m_##NAME;
+#define MIXXX_DECL_PROPERTY(TYPE, NAME, CAP_NAME)                       \
+  public:                                                               \
+    template<typename T>                                                \
+    typename std::enable_if<(std::is_fundamental<TYPE>::value ||        \
+                                    std::is_same<TYPE, bool>::value) && \
+            std::is_same<TYPE, T>::value>::type set##CAP_NAME(T _val) { \
+        m_##NAME = _val;                                                \
+    }                                                                   \
+                                                                        \
+  public:                                                               \
+    template<typename T>                                                \
+    typename std::enable_if<!(std::is_fundamental<TYPE>::value ||       \
+                                    std::is_same<TYPE, bool>::value) && \
+            std::is_assignable<TYPE, T>::value>::type                   \
+            set##CAP_NAME(T&& _val) {                                   \
+        m_##NAME = std::forward<T>(_val);                               \
+    }                                                                   \
+                                                                        \
+  public:                                                               \
+    constexpr std::conditional<std::is_fundamental<TYPE>::value,        \
+            TYPE,                                                       \
+            const TYPE&>::type get##CAP_NAME() const {                  \
+        return m_##NAME;                                                \
+    }                                                                   \
+                                                                        \
+  public:                                                               \
+    constexpr TYPE& ref##CAP_NAME() {                                   \
+        return m_##NAME;                                                \
+    }                                                                   \
+                                                                        \
+  public:                                                               \
+    constexpr TYPE* ptr##CAP_NAME() {                                   \
+        return &m_##NAME;                                               \
+    }                                                                   \
+                                                                        \
+  public:                                                               \
+    constexpr const TYPE* ptr##CAP_NAME() const {                       \
+        return &m_##NAME;                                               \
+    }                                                                   \
+                                                                        \
+  public:                                                               \
+    QDebug dbg##CAP_NAME(QDebug dbg) const {                            \
+        return dbg << #NAME ":" << m_##NAME;                            \
+    }                                                                   \
+                                                                        \
+  private:                                                              \
+    TYPE m_##NAME;


### PR DESCRIPTION
The old name doesn't match anymore:

`PROPERTY_SET_BYVAL_GET_BYREF` -> `MIXXX_DECL_PROPERTY`

The code has been reformatted by clang-format, i.e. no manual edits apart from search&replace!