### PR TITLE
AutoDJ: Add Random Track Control to AutoDJ.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Cover art: Prevent wrong cover art display due to hash conflicts
 * Cover art: Add background color for quick cover art preview
+* Add Random Track Control to AutoDJ [#3076](https://github.com/mixxxdj/mixxx/pull/3076)
 
 ## [2.3.0](https://launchpad.net/mixxx/+milestone/2.3.0) (Unreleased)
 ### Hotcues ###

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -640,7 +640,7 @@ QPushButton#pushButtonSkipNext:!enabled {
 QPushButton#pushButtonShuffle {
   image: url(skin:/icon/ic_autodj_shuffle.svg) no-repeat center center;
 }
-QPushButton#pushButtonAddRandom {
+QPushButton#pushButtonAddRandomTrack {
   image: url(skin:/icon/ic_autodj_addrandom.svg) no-repeat center center;
 }
 QPushButton#pushButtonRepeatPlaylist {

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -1867,7 +1867,7 @@ QPushButton#pushButtonShuffle:enabled {
   image: url(skin:/classic/buttons/btn__autodj_shuffle.svg) no-repeat center center;
   }
 
-QPushButton#pushButtonAddRandom:enabled {
+QPushButton#pushButtonAddRandomTrack:enabled {
   image: url(skin:/classic/buttons/btn__autodj_addrandom.svg) no-repeat center center;
   }
 

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -2302,7 +2302,7 @@ QPushButton#pushButtonShuffle:enabled {
   image: url(skin:/palemoon/buttons/btn__autodj_shuffle.svg) no-repeat center center;
 }
 
-QPushButton#pushButtonAddRandom:enabled {
+QPushButton#pushButtonAddRandomTrack:enabled {
   image: url(skin:/palemoon/buttons/btn__autodj_addrandom.svg) no-repeat center center;
 }
 

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -872,7 +872,7 @@ QPushButton#pushButtonSkipNext:!enabled {
 QPushButton#pushButtonShuffle {
   image: url(skin:/btn/btn_autodj_shuffle.svg) no-repeat center center;
 }
-QPushButton#pushButtonAddRandom {
+QPushButton#pushButtonAddRandomTrack {
   image: url(skin:/btn/btn_autodj_addrandom.svg) no-repeat center center;
 }
 QPushButton#pushButtonRepeatPlaylist {

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -2689,7 +2689,7 @@ Library features and their buttons:
     QPushButton#
   DlgAutoDJ
     QPushButton#pushButtonShuffle
-    QPushButton#pushButtonAddRandom
+    QPushButton#pushButtonAddRandomTrack
     QPushButton#pushButtonSkipNext
     QPushButton#pushButtonFadeNow
     QSpinBox#spinBoxTransition
@@ -2826,7 +2826,7 @@ QPushButton#pushButtonSkipNext:!enabled {
 QPushButton#pushButtonShuffle {
   image: url(skin:/buttons/btn_autodj_shuffle.svg) no-repeat center center;
 }
-QPushButton#pushButtonAddRandom {
+QPushButton#pushButtonAddRandomTrack {
   image: url(skin:/buttons/btn_autodj_addrandom.svg) no-repeat center center;
 }
 QPushButton#pushButtonRepeatPlaylist:!checked {

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -737,6 +737,9 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     addControl("[AutoDJ]", "skip_next",
                tr("Auto DJ Skip Next"),
                tr("Skip the next track in the Auto DJ queue"), autodjMenu);
+    addControl("[AutoDJ]", "add_random_track",
+               tr("Auto DJ Add Random Track"),
+               tr("Add random track to the Auto DJ queue"), autodjMenu);
     addControl("[AutoDJ]", "fade_now",
                tr("Auto DJ Fade To Next"),
                tr("Trigger the transition to the next track"), autodjMenu);

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -737,9 +737,11 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     addControl("[AutoDJ]", "skip_next",
                tr("Auto DJ Skip Next"),
                tr("Skip the next track in the Auto DJ queue"), autodjMenu);
-    addControl("[AutoDJ]", "add_random_track",
-               tr("Auto DJ Add Random Track"),
-               tr("Add a random track to the Auto DJ queue"), autodjMenu);
+    addControl("[AutoDJ]",
+            "add_random_track",
+            tr("Auto DJ Add Random Track"),
+            tr("Add a random track to the Auto DJ queue"),
+            autodjMenu);
     addControl("[AutoDJ]", "fade_now",
                tr("Auto DJ Fade To Next"),
                tr("Trigger the transition to the next track"), autodjMenu);

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -739,7 +739,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                tr("Skip the next track in the Auto DJ queue"), autodjMenu);
     addControl("[AutoDJ]", "add_random_track",
                tr("Auto DJ Add Random Track"),
-               tr("Add random track to the Auto DJ queue"), autodjMenu);
+               tr("Add a random track to the Auto DJ queue"), autodjMenu);
     addControl("[AutoDJ]", "fade_now",
                tr("Auto DJ Fade To Next"),
                tr("Trigger the transition to the next track"), autodjMenu);

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -144,7 +144,7 @@ void AutoDJFeature::bindLibraryWidget(
             this,
             &AutoDJFeature::slotRandomQueue);
     connect(m_pAutoDJView,
-            &DlgAutoDJ::addRandomButton,
+            &DlgAutoDJ::addRandomTrackButton,
             this,
             &AutoDJFeature::slotAddRandomTrack);
 }

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -135,8 +135,10 @@ AutoDJProcessor::AutoDJProcessor(
 
     m_pAddRandomTrack = new ControlPushButton(
             ConfigKey("[AutoDJ]", "add_random_track"));
-    connect(m_pAddRandomTrack, &ControlObject::valueChanged,
-            this, &AutoDJProcessor::controlAddRandomTrack);
+    connect(m_pAddRandomTrack,
+            &ControlObject::valueChanged,
+            this,
+            &AutoDJProcessor::controlAddRandomTrack);
 
     m_pFadeNow = new ControlPushButton(
             ConfigKey("[AutoDJ]", "fade_now"));

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -133,6 +133,11 @@ AutoDJProcessor::AutoDJProcessor(
     connect(m_pSkipNext, &ControlObject::valueChanged,
             this, &AutoDJProcessor::controlSkipNext);
 
+    m_pAddRandomTrack = new ControlPushButton(
+            ConfigKey("[AutoDJ]", "add_random_track"));
+    connect(m_pAddRandomTrack, &ControlObject::valueChanged,
+            this, &AutoDJProcessor::controlAddRandomTrack);
+
     m_pFadeNow = new ControlPushButton(
             ConfigKey("[AutoDJ]", "fade_now"));
     connect(m_pFadeNow, &ControlObject::valueChanged,
@@ -183,6 +188,7 @@ AutoDJProcessor::~AutoDJProcessor() {
     delete m_pCOCrossfaderReverse;
 
     delete m_pSkipNext;
+    delete m_pAddRandomTrack;
     delete m_pShufflePlaylist;
     delete m_pEnabledAutoDJ;
     delete m_pFadeNow;
@@ -575,6 +581,12 @@ void AutoDJProcessor::controlShuffle(double value) {
 void AutoDJProcessor::controlSkipNext(double value) {
     if (value > 0.0) {
         skipNext();
+    }
+}
+
+void AutoDJProcessor::controlAddRandomTrack(double value) {
+    if (value > 0.0) {
+        emit randomTrackRequested(1);
     }
 }
 

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -227,6 +227,7 @@ class AutoDJProcessor : public QObject {
     void controlFadeNow(double value);
     void controlShuffle(double value);
     void controlSkipNext(double value);
+    void controlAddRandomTrack(double value);
 
   protected:
     // The following virtual signal wrappers are used for testing
@@ -293,6 +294,7 @@ class AutoDJProcessor : public QObject {
     ControlProxy* m_pCOCrossfaderReverse;
 
     ControlPushButton* m_pSkipNext;
+    ControlPushButton* m_pAddRandomTrack;
     ControlPushButton* m_pFadeNow;
     ControlPushButton* m_pShufflePlaylist;
     ControlPushButton* m_pEnabledAutoDJ;

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -319,8 +319,7 @@ void DlgAutoDJ::autoDJStateChanged(AutoDJProcessor::AutoDJState state) {
             pushButtonFadeNow->setEnabled(true);
         }
 
-        // You can always skip the next track if we are enabled.
-        pushButtonSkipNext->setEnabled(true);   
+        pushButtonSkipNext->setEnabled(true);
     }
 }
 

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -90,7 +90,7 @@ DlgAutoDJ::DlgAutoDJ(
     setupActionButton(pushButtonFadeNow, &DlgAutoDJ::fadeNowButton, tr("Fade"));
     setupActionButton(pushButtonSkipNext, &DlgAutoDJ::skipNextButton, tr("Skip"));
     setupActionButton(pushButtonShuffle, &DlgAutoDJ::shufflePlaylistButton, tr("Shuffle"));
-    setupActionButton(pushButtonAddRandom, &DlgAutoDJ::addRandomButton, tr("Random"));
+    setupActionButton(pushButtonAddRandomTrack, &DlgAutoDJ::addRandomTrackButton, tr("Random"));
 
     m_enableBtnTooltip = tr(
             "Enable Auto DJ\n"
@@ -112,7 +112,7 @@ DlgAutoDJ::DlgAutoDJ(
             "Shuffle the content of the Auto DJ queue\n"
             "\n"
             "Shortcut: Shift+F9");
-    QString addRandomBtnTooltip = tr(
+    QString addRandomTrackBtnTooltip = tr(
             "Adds a random track from track sources (crates) to the Auto DJ queue.\n"
             "If no track sources are configured, the track is added from the library instead.");
     QString repeatBtnTooltip = tr(
@@ -149,7 +149,7 @@ DlgAutoDJ::DlgAutoDJ(
     pushButtonFadeNow->setToolTip(fadeBtnTooltip);
     pushButtonSkipNext->setToolTip(skipBtnTooltip);
     pushButtonShuffle->setToolTip(shuffleBtnTooltip);
-    pushButtonAddRandom->setToolTip(addRandomBtnTooltip);
+    pushButtonAddRandomTrack->setToolTip(addRandomTrackBtnTooltip);
     pushButtonRepeatPlaylist->setToolTip(repeatBtnTooltip);
     spinBoxTransition->setToolTip(spinBoxTransitionTooltip);
     labelTransitionAppendix->setToolTip(labelTransitionTooltip);
@@ -320,7 +320,7 @@ void DlgAutoDJ::autoDJStateChanged(AutoDJProcessor::AutoDJState state) {
         }
 
         // You can always skip the next track if we are enabled.
-        pushButtonSkipNext->setEnabled(true);
+        pushButtonSkipNext->setEnabled(true);   
     }
 }
 

--- a/src/library/autodj/dlgautodj.h
+++ b/src/library/autodj/dlgautodj.h
@@ -47,7 +47,7 @@ class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
     void slotRepeatPlaylistChanged(int checkedState);
 
   signals:
-    void addRandomButton(bool buttonChecked);
+    void addRandomTrackButton(bool buttonChecked);
     void loadTrack(TrackPointer tio);
     void loadTrackToPlayer(TrackPointer tio, QString group, bool);
     void trackSelected(TrackPointer pTrack);

--- a/src/library/autodj/dlgautodj.ui
+++ b/src/library/autodj/dlgautodj.ui
@@ -176,7 +176,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="pushButtonAddRandom">
+      <widget class="QPushButton" name="pushButtonAddRandomTrack">
        <property name="focusPolicy">
         <enum>Qt::NoFocus</enum>
        </property>


### PR DESCRIPTION
This PR aims to implement the wishlist Feature Request, Adding Control to Add Random Track to AutoDJ.
Discussions:-https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/Add.20Control.20to.20Add.20Random.20Track.20to.20AutoDJ
Feature Request:-https://bugs.launchpad.net/mixxx/+bug/1887845