### PR TITLE
WTrackMenu: Fix display of crate/playlist names containing '&'

### DIFF
--- a/src/util/qt.h
+++ b/src/util/qt.h
@@ -1,0 +1,22 @@
+#pragma once
+
+/// Common utility functions and helpers that are needed for
+/// all Qt versions.
+
+#include <QString>
+
+namespace mixxx {
+
+/// Escape special characters in text properties to prevent
+/// the implicit creation of shortcuts for widgets.
+///
+/// The given text is supposed to be displayed literally on
+/// the screen and no shortcuts shall be created.
+///
+/// Needed for: QAction, QAbstractButton
+inline QString escapeTextPropertyWithoutShortcuts(QString text) {
+    text.replace(QChar('&'), QStringLiteral("&&"));
+    return text;
+}
+
+} // namespace mixxx

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -26,6 +26,7 @@
 #include "sources/soundsourceproxy.h"
 #include "util/desktophelper.h"
 #include "util/parented_ptr.h"
+#include "util/qt.h"
 #include "widget/wcolorpickeraction.h"
 #include "widget/wskincolor.h"
 #include "widget/wwidget.h"
@@ -924,7 +925,9 @@ void WTrackMenu::slotPopulatePlaylistMenu() {
         if (!playlistDao.isHidden(it.value())) {
             // No leak because making the menu the parent means they will be
             // auto-deleted
-            auto pAction = new QAction(it.key(), m_pPlaylistMenu);
+            auto pAction = new QAction(
+                    mixxx::escapeTextPropertyWithoutShortcuts(it.key()),
+                    m_pPlaylistMenu);
             bool locked = playlistDao.isPlaylistLocked(it.value());
             pAction->setEnabled(!locked);
             m_pPlaylistMenu->addAction(pAction);
@@ -1004,12 +1007,12 @@ void WTrackMenu::slotPopulateCrateMenu() {
 
     CrateSummary crate;
     while (allCrates.populateNext(&crate)) {
-        auto pAction = make_parented<QWidgetAction>(m_pCrateMenu);
-        auto pCheckBox = make_parented<QCheckBox>(m_pCrateMenu);
-
-        pCheckBox->setText(crate.getName());
-        pCheckBox->setProperty("crateId",
-                QVariant::fromValue(crate.getId()));
+        auto pAction = make_parented<QWidgetAction>(
+                m_pCrateMenu);
+        auto pCheckBox = make_parented<QCheckBox>(
+                mixxx::escapeTextPropertyWithoutShortcuts(crate.getName()),
+                m_pCrateMenu);
+        pCheckBox->setProperty("crateId", QVariant::fromValue(crate.getId()));
         pCheckBox->setEnabled(!crate.isLocked());
         // Strangely, the normal styling of QActions does not automatically
         // apply to QWidgetActions. The :selected pseudo-state unfortunately


### PR DESCRIPTION
The string in text properties needs to be escaped to prevent implicit creation of shortcuts.

![playlists](https://user-images.githubusercontent.com/1474154/92309089-b1814180-efa2-11ea-82c3-59e80594b429.png)
![crates](https://user-images.githubusercontent.com/1474154/92309093-bb0aa980-efa2-11ea-838f-db78dd019e90.png)
