### PR TITLE
library: Move color column to the left

### DIFF
--- a/src/library/basetrackcache.h
+++ b/src/library/basetrackcache.h
@@ -38,6 +38,10 @@ class SortColumn {
 class BaseTrackCache : public QObject {
     Q_OBJECT
   public:
+    /// Construct a BaseTrackCache object.
+    ///
+    /// The order of the `columns` list parameter defines the initial/default
+    /// order of columns in the library view.
     BaseTrackCache(TrackCollection* pTrackCollection,
                    const QString& tableName,
                    const QString& idColumn,

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -34,6 +34,7 @@ MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
           m_pHiddenView(nullptr) {
     QStringList columns;
     columns << "library." + LIBRARYTABLE_ID
+            << "library." + LIBRARYTABLE_COLOR
             << "library." + LIBRARYTABLE_PLAYED
             << "library." + LIBRARYTABLE_TIMESPLAYED
             //has to be up here otherwise Played and TimesPlayed are not show
@@ -60,7 +61,6 @@ MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
             << "track_locations.fs_deleted"
             << "library." + LIBRARYTABLE_COMMENT
             << "library." + LIBRARYTABLE_MIXXXDELETED
-            << "library." + LIBRARYTABLE_COLOR
             << "library." + LIBRARYTABLE_COVERART_SOURCE
             << "library." + LIBRARYTABLE_COVERART_TYPE
             << "library." + LIBRARYTABLE_COVERART_LOCATION


### PR DESCRIPTION
Move the "Color" column to the left of the library by default to make it more visible:
![Screenshot from 2020-09-07 18-36-56](https://user-images.githubusercontent.com/1834516/92406810-4322b780-f139-11ea-8ff5-6711960f2ef0.png)

Semi-related launchpad issue: https://bugs.launchpad.net/mixxx/+bug/1894428