### PR TITLE
Add word to codespellignore

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,3 +1,4 @@
 Crate
 crate
 InOut
+copyable


### PR DESCRIPTION
Codespell suggests `copyable => copiable`
We don't want to use the word `copiable`.