### PR TITLE
CachingReader: Fix debug assertion when hintFrameCount == 0

### DIFF
--- a/src/engine/cachingreader/cachingreader.cpp
+++ b/src/engine/cachingreader/cachingreader.cpp
@@ -530,8 +530,8 @@ void CachingReader::hintAndMaybeWake(const HintVector& hintList) {
             }
         }
 
-        VERIFY_OR_DEBUG_ASSERT(hintFrameCount > 0) {
-            kLogger.warning() << "ERROR: Negative hint length. Ignoring.";
+        VERIFY_OR_DEBUG_ASSERT(hintFrameCount >= 0) {
+            kLogger.warning() << "CachingReader: Ignoring negative hint length.";
             continue;
         }
 


### PR DESCRIPTION
This also rephrases the warning message a bit.

Fixes:

    Critical [Engine]: DEBUG ASSERT: "hintFrameCount > 0" in function void CachingReader::hintAndMaybeWake(const HintVector&) at src/engine/cachingreader/cachingreader.cpp:533

**NOTE:** I didn't really look into the code, but I encountered this debug assertion while writing tests for #2194. This fixes the issue for me and is also consistent with the text of the warning message. Please double-check if this is actually correct or if the warning message is wrong!