### PR TITLE
Fallback solution: Parse "artist-title" with a single dash from file name

### DIFF
--- a/src/test/trackmetadata_test.cpp
+++ b/src/test/trackmetadata_test.cpp
@@ -14,19 +14,19 @@ TEST_F(TrackMetadataTest, parseArtistTitleFromFileName) {
     }
     {
         mixxx::TrackInfo trackInfo;
-        trackInfo.parseArtistTitleFromFileName(" only-title ", true);
-        EXPECT_EQ(QString(), trackInfo.getArtist());
-        EXPECT_EQ("only-title", trackInfo.getTitle());
+        trackInfo.parseArtistTitleFromFileName(" artist-title ", true);
+        EXPECT_EQ("artist", trackInfo.getArtist());
+        EXPECT_EQ("title", trackInfo.getTitle());
     }
     {
         mixxx::TrackInfo trackInfo;
-        trackInfo.parseArtistTitleFromFileName(" only -_title ", true);
-        EXPECT_EQ(QString(), trackInfo.getArtist());
-        EXPECT_EQ("only -_title", trackInfo.getTitle());
+        trackInfo.parseArtistTitleFromFileName(" artist -_title ", true);
+        EXPECT_EQ("artist", trackInfo.getArtist());
+        EXPECT_EQ("_title", trackInfo.getTitle());
     }
     {
         mixxx::TrackInfo trackInfo;
-        trackInfo.parseArtistTitleFromFileName(" only  -  title ", false);
+        trackInfo.parseArtistTitleFromFileName(" only  -  title.mp3", false);
         EXPECT_EQ(QString(), trackInfo.getArtist());
         EXPECT_EQ("only  -  title", trackInfo.getTitle());
     }
@@ -38,9 +38,39 @@ TEST_F(TrackMetadataTest, parseArtistTitleFromFileName) {
     }
     {
         mixxx::TrackInfo trackInfo;
-        trackInfo.parseArtistTitleFromFileName(" only -\ttitle\t", true);
+        trackInfo.parseArtistTitleFromFileName(" ar.tist -\tti.tle\t.mp3", true);
+        EXPECT_EQ("ar.tist", trackInfo.getArtist());
+        EXPECT_EQ("ti.tle", trackInfo.getTitle());
+    }
+    {
+        mixxx::TrackInfo trackInfo;
+        trackInfo.parseArtistTitleFromFileName(" -artist - -title-.mp3", true);
+        EXPECT_EQ("-artist", trackInfo.getArtist());
+        EXPECT_EQ("-title-", trackInfo.getTitle());
+    }
+    {
+        mixxx::TrackInfo trackInfo;
+        trackInfo.parseArtistTitleFromFileName(" -artist ti-tle- ", true);
         EXPECT_EQ(QString(), trackInfo.getArtist());
-        EXPECT_EQ("only -\ttitle", trackInfo.getTitle());
+        EXPECT_EQ("-artist ti-tle-", trackInfo.getTitle());
+    }
+    {
+        mixxx::TrackInfo trackInfo;
+        trackInfo.parseArtistTitleFromFileName(" artist- title ", true);
+        EXPECT_EQ("artist", trackInfo.getArtist());
+        EXPECT_EQ("title", trackInfo.getTitle());
+    }
+    {
+        mixxx::TrackInfo trackInfo;
+        trackInfo.parseArtistTitleFromFileName(" artist- ", true);
+        EXPECT_EQ("artist", trackInfo.getArtist());
+        EXPECT_EQ(QString(), trackInfo.getTitle());
+    }
+    {
+        mixxx::TrackInfo trackInfo;
+        trackInfo.parseArtistTitleFromFileName(" -title ", true);
+        EXPECT_EQ(QString(), trackInfo.getArtist());
+        EXPECT_EQ("title", trackInfo.getTitle());
     }
     {
         mixxx::TrackInfo trackInfo;

--- a/src/track/trackinfo.h
+++ b/src/track/trackinfo.h
@@ -66,7 +66,7 @@ class TrackInfo final {
 
     // Returns true if modified
     bool parseArtistTitleFromFileName(
-            QString fileName,
+            const QString& fileName,
             bool splitArtistTitle);
 
     // Adjusts floating-point properties to match their string representation


### PR DESCRIPTION
As requested and suggested on *Discourse*:

https://mixxx.discourse.group/t/metadata-from-filename-not-creating-artist-title/19901

Could be considered a regression from 2.2. This simple fallback solution should not cause any unintended side-effects.