### PR TITLE
fix warning for missing btn__lib_sort_down.svg

### DIFF
--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -2090,7 +2090,7 @@ WCueMenuPopup QPushButton:focus {
       image: url(skin:/classic/buttons/btn__lib_sort_up.svg);
       }
     #LibraryContainer QHeaderView::down-arrow {
-      image: url(skin:/classic/style/btn__lib_sort_down.svg);
+      image: url(skin:/classic/buttons/btn__lib_sort_down.svg);
     }
 
 


### PR DESCRIPTION
on Latenight skin classic the Button lib_sort_down is not visible, this results also in the following warning:

```Warning [Main] qt.svg: Cannot open file '/home/stefan/mixxx_neu/mixxx/skin:/classic/style/btn__lib_sort_down.svg', because: No such file or directory```

Source of the error is a typo in res/skins/LateNight/style_classic.qss which is fixed with this PR
