### PR TITLE
CMake: Include Microsoft redistributable runtime libs in package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1032,6 +1032,7 @@ target_link_libraries(mixxx PUBLIC mixxx-lib)
 #
 # Installation and Packaging
 #
+include(InstallRequiredSystemLibraries)
 set(MIXXX_INSTALL_BINDIR ".")
 set(MIXXX_INSTALL_DATADIR ".")
 set(MIXXX_INSTALL_DOCDIR "./doc")
@@ -1049,6 +1050,16 @@ install(
     mixxx
   RUNTIME DESTINATION
     "${MIXXX_INSTALL_BINDIR}"
+)
+
+# System Runtime libraries
+install(
+  FILES
+    ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS}
+  DESTINATION
+    "${MIXXX_INSTALL_BINDIR}"
+  COMPONENT
+    Libraries
 )
 
 # Skins


### PR DESCRIPTION
See this blogpost for details:
https://braintrekking.wordpress.com/2013/04/27/dll-hell-how-to-include-microsoft-redistributable-runtime-libraries-in-your-cmakecpack-project/