### PR TITLE
Fix hazardous overloaded function in FwdSqlQuery

### DIFF
--- a/src/util/db/fwdsqlquery.cpp
+++ b/src/util/db/fwdsqlquery.cpp
@@ -105,7 +105,7 @@ constexpr int kBooleanTrue = 1;
 // Please do not try to unwrap the code! It is already declared "inline" ;)
 //
 // Recommended reading: "Refactoring" by Martin Fowler
-inline bool toBoolean(const QVariant& variant) {
+inline bool boolFromQVariantInt(const QVariant& variant) {
     bool ok = false;
     int value = variant.toInt(&ok);
     VERIFY_OR_DEBUG_ASSERT(ok) {
@@ -128,5 +128,5 @@ inline bool toBoolean(const QVariant& variant) {
 } // anonymous namespace
 
 bool FwdSqlQuery::fieldValueBoolean(DbFieldIndex fieldIndex) const {
-    return toBoolean(fieldValue(fieldIndex));
+    return boolFromQVariantInt(fieldValue(fieldIndex));
 }

--- a/src/util/db/fwdsqlquery.cpp
+++ b/src/util/db/fwdsqlquery.cpp
@@ -94,33 +94,37 @@ DbFieldIndex FwdSqlQuery::fieldIndex(const QString& fieldName) const {
 }
 
 namespace {
-    // NOTE(uklotzde): This conversion has been wrapped into a separate
-    // function, because the conversion is completely independent of the
-    // query, the current record and how values for individual fields are
-    // retrieved. For separation of concerns and to improve readability.
-    // Please do not try to unwrap the code! It is already declared "inline" ;)
-    //
-    // Recommended reading: "Refactoring" by Martin Fowler
-    inline
-    bool toBoolean(const QVariant& variant) {
-        bool ok = false;
-        int value = variant.toInt(&ok);
-        VERIFY_OR_DEBUG_ASSERT(ok) {
-            kLogger.critical()
-                    << "Invalid boolean value in database:"
-                    << variant;
-        }
-        VERIFY_OR_DEBUG_ASSERT(
-                (value == FwdSqlQuery::BOOLEAN_FALSE) ||
-                (value == FwdSqlQuery::BOOLEAN_TRUE)) {
-            kLogger.critical()
-                    << "Invalid boolean value in database:"
-                    << value;
-        }
-        // C-style conversion from int to bool
-        DEBUG_ASSERT(FwdSqlQuery::BOOLEAN_FALSE == 0);
-        return value != FwdSqlQuery::BOOLEAN_FALSE;
+
+constexpr int kBooleanFalse = 0;
+constexpr int kBooleanTrue = 1;
+
+// NOTE(uklotzde): This conversion has been wrapped into a separate
+// function, because the conversion is completely independent of the
+// query, the current record and how values for individual fields are
+// retrieved. For separation of concerns and to improve readability.
+// Please do not try to unwrap the code! It is already declared "inline" ;)
+//
+// Recommended reading: "Refactoring" by Martin Fowler
+inline bool toBoolean(const QVariant& variant) {
+    bool ok = false;
+    int value = variant.toInt(&ok);
+    VERIFY_OR_DEBUG_ASSERT(ok) {
+        kLogger.critical()
+                << "Invalid boolean value in database:"
+                << variant;
     }
+    VERIFY_OR_DEBUG_ASSERT(
+            (value == kBooleanFalse) ||
+            (value == kBooleanTrue)) {
+        kLogger.critical()
+                << "Invalid boolean value in database:"
+                << value;
+    }
+    // C-style conversion from int to bool
+    DEBUG_ASSERT(kBooleanFalse == 0);
+    return value != kBooleanFalse;
+}
+
 } // anonymous namespace
 
 bool FwdSqlQuery::fieldValueBoolean(DbFieldIndex fieldIndex) const {

--- a/src/util/db/fwdsqlquery.h
+++ b/src/util/db/fwdsqlquery.h
@@ -51,17 +51,8 @@ class FwdSqlQuery: protected QSqlQuery {
         return QSqlQuery::lastError();
     }
 
-    static const int BOOLEAN_FALSE = 0;
-    static const int BOOLEAN_TRUE = 1;
-
-    // Generic function for type QVariant
     void bindValue(const QString& placeholder, const QVariant& value) {
         QSqlQuery::bindValue(placeholder, value);
-    }
-
-    // Overloaded function for type bool
-    void bindValue(const QString& placeholder, bool value) {
-        bindValue(placeholder, value ? QVariant(BOOLEAN_TRUE) : QVariant(BOOLEAN_FALSE));
     }
 
     // Overloaded function for type DbId


### PR DESCRIPTION
When trying to store `double` values in the database all values != 0 ended up as 1.0. They were implicitly cast to `bool` because the wrong overloaded function was selected. The compiler didn't issue a warning about ambiguous casts.

I checked the code, this overload doesn't seem to be used yet. Nevertheless, targeted to master to avoid any unforeseeable new issues in the beta.