### PR TITLE
WLibraryTableView: Refocus or reselect on FocusIn events 

### DIFF
--- a/src/widget/wlibrarytableview.cpp
+++ b/src/widget/wlibrarytableview.cpp
@@ -1,16 +1,15 @@
-// wlibrarytableview.cpp
-// Created 10/19/2009 by RJ Ryan (rryan@mit.edu)
+#include "widget/wlibrarytableview.h"
 
+#include <QFocusEvent>
+#include <QFontMetrics>
 #include <QHeaderView>
 #include <QPalette>
 #include <QScrollBar>
-#include <QFontMetrics>
 
 #include "library/trackmodel.h"
-#include "widget/wwidget.h"
-#include "widget/wskincolor.h"
-#include "widget/wlibrarytableview.h"
 #include "util/math.h"
+#include "widget/wskincolor.h"
+#include "widget/wwidget.h"
 
 WLibraryTableView::WLibraryTableView(QWidget* parent,
                                      UserSettingsPointer pConfig,
@@ -149,17 +148,38 @@ void WLibraryTableView::setSelectedClick(bool enable) {
     }
 }
 
-bool WLibraryTableView::event(QEvent* e) {
-    // On FocusIn, with no focused item, select the first track which can then
-    // instantly be loaded to a deck.
-    // This is especially helpful if the table has only one track, which can not
-    // be selected with up/down buttons, either physical or emulated via
-    // [Library],MoveVertical controls. See lp:1808632
-    if (e->type() == QEvent::FocusIn &&
-            model()->rowCount() > 0 &&
-            currentIndex().row() == -1) {
-        selectRow(0);
-    }
+void WLibraryTableView::focusInEvent(QFocusEvent* event) {
+    QTableView::focusInEvent(event);
 
-    return QTableView::event(e);
+    if (event->reason() == Qt::TabFocusReason ||
+            event->reason() == Qt::BacktabFocusReason) {
+        // On FocusIn caused by a tab action with no focused item, select the
+        // current or first track which can then instantly be loaded to a deck.
+        // This is especially helpful if the table has only one track, which can
+        // not be selected with up/down buttons, either physical or emulated via
+        // [Library],MoveVertical controls. See lp:1808632
+        if (model()->rowCount() > 0) {
+            if (selectionModel()->hasSelection()) {
+                DEBUG_ASSERT(!selectionModel()->selectedIndexes().isEmpty());
+                if (!currentIndex().isValid() ||
+                        !selectionModel()->isSelected(currentIndex())) {
+                    // Refocus the first selected index
+                    setCurrentIndex(selectionModel()->selectedIndexes().first());
+                }
+            } else {
+                if (currentIndex().isValid()) {
+                    // Select the first row if no row is focused
+                    selectRow(0);
+                    DEBUG_ASSERT(currentIndex().row() == 0);
+                } else {
+                    // Select the focused row
+                    selectRow(currentIndex().row());
+                }
+            }
+            DEBUG_ASSERT(currentIndex().isValid());
+            DEBUG_ASSERT(selectionModel()->isSelected(currentIndex()));
+            // scrollTo() doesn't always seem to work!?
+            scrollTo(currentIndex());
+        }
+    }
 }

--- a/src/widget/wlibrarytableview.h
+++ b/src/widget/wlibrarytableview.h
@@ -52,13 +52,14 @@ class WLibraryTableView : public QTableView, public virtual LibraryView {
     void setSelectedClick(bool enable);
 
   protected:
+    void focusInEvent(QFocusEvent* event) override;
+
     void saveNoSearchVScrollBarPos();
     void restoreNoSearchVScrollBarPos();
 
   private:
     void loadVScrollBarPosState();
     void saveVScrollBarPosState();
-    bool event(QEvent* e);
 
     const UserSettingsPointer m_pConfig;
     const ConfigKey m_vScrollBarPosKey;


### PR DESCRIPTION
Fix unintended side-effects caused by de62420846846a2d5bfb72961c654affdbaa8cf3

I have no time to work on this. Instead of requesting changes please use this branch as a base for your own fix, then I will close this PR.