### PR TITLE
WTrackMenu: Create DlgTrackInfo/DlgTagFetcher only on demand

### DIFF
--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -54,11 +54,14 @@ void addTrack(
 
 } // anonymous namespace
 
-DlgTagFetcher::DlgTagFetcher(QWidget* parent, const TrackModel* trackModel)
-        : QDialog(parent),
-          m_tagFetcher(parent),
-          m_networkResult(NetworkResult::Ok),
-          m_pTrackModel(trackModel) {
+DlgTagFetcher::DlgTagFetcher(
+        const TrackModel* pTrackModel)
+        // No parent because otherwise it inherits the style parent's
+        // style which can make it unreadable. Bug #673411
+        : QDialog(nullptr),
+          m_pTrackModel(pTrackModel),
+          m_tagFetcher(this),
+          m_networkResult(NetworkResult::Ok) {
     init();
 }
 

--- a/src/library/dlgtagfetcher.h
+++ b/src/library/dlgtagfetcher.h
@@ -13,12 +13,13 @@
 /// Use TrackPointer to load a track into the dialog or
 /// QModelIndex along with TrackModel to enable previous and next buttons
 /// to switch tracks within the context of the TrackModel.
-class DlgTagFetcher : public QDialog,  public Ui::DlgTagFetcher {
-  Q_OBJECT
+class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
+    Q_OBJECT
 
   public:
     // TODO: Remove dependency on TrackModel
-    explicit DlgTagFetcher(QWidget* parent, const TrackModel* trackModel = nullptr);
+    explicit DlgTagFetcher(
+            const TrackModel* pTrackModel = nullptr);
     ~DlgTagFetcher() override = default;
 
     void init();
@@ -49,12 +50,19 @@ class DlgTagFetcher : public QDialog,  public Ui::DlgTagFetcher {
     void updateStack();
     void addDivider(const QString& text, QTreeWidget* parent) const;
 
+    const TrackModel* const m_pTrackModel;
+
     TagFetcher m_tagFetcher;
 
     TrackPointer m_track;
 
+    QModelIndex m_currentTrackIndex;
+
     struct Data {
-        Data() : m_pending(true), m_selectedResult(-1) {}
+        Data()
+                : m_pending(true),
+                  m_selectedResult(-1) {
+        }
 
         bool m_pending;
         int m_selectedResult;
@@ -68,6 +76,4 @@ class DlgTagFetcher : public QDialog,  public Ui::DlgTagFetcher {
         UnknownError,
     };
     NetworkResult m_networkResult;
-    const TrackModel* m_pTrackModel;
-    QModelIndex m_currentTrackIndex;
 };

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -1,12 +1,13 @@
 #include "library/dlgtrackinfo.h"
 
-#include <QComboBox>
 #include <QDesktopServices>
 #include <QStringBuilder>
 #include <QtDebug>
 
 #include "library/coverartcache.h"
 #include "library/coverartutils.h"
+#include "library/dlgtagfetcher.h"
+#include "library/trackmodel.h"
 #include "preferences/colorpalettesettings.h"
 #include "sources/soundsourceproxy.h"
 #include "track/beatfactory.h"
@@ -15,9 +16,11 @@
 #include "track/keyutils.h"
 #include "util/color/colorpalette.h"
 #include "util/compatibility.h"
-#include "util/desktophelper.h"
 #include "util/datetime.h"
+#include "util/desktophelper.h"
 #include "util/duration.h"
+#include "widget/wcoverartlabel.h"
+#include "widget/wstarrating.h"
 
 const int kFilterLength = 80;
 const int kMinBpm = 30;
@@ -25,16 +28,16 @@ const int kMinBpm = 30;
 // Maximum allowed interval between beats (calculated from kMinBpm).
 const mixxx::Duration kMaxInterval = mixxx::Duration::fromMillis(1000.0 * (60.0 / kMinBpm));
 
-DlgTrackInfo::DlgTrackInfo(QWidget* parent,
-        UserSettingsPointer pConfig,
+DlgTrackInfo::DlgTrackInfo(
         const TrackModel* trackModel)
-        : QDialog(parent),
-          m_pTapFilter(new TapFilter(this, kFilterLength, kMaxInterval)),
+        // No parent because otherwise it inherits the style parent's
+        // style which can make it unreadable. Bug #673411
+        : QDialog(nullptr),
+          m_pTrackModel(trackModel),
+          m_tapFilter(this, kFilterLength, kMaxInterval),
           m_dLastTapedBpm(-1.),
-          m_pWCoverArtLabel(new WCoverArtLabel(this)),
-          m_pWStarRating(new WStarRating(nullptr, this)),
-          m_pConfig(pConfig),
-          m_pTrackModel(trackModel) {
+          m_pWCoverArtLabel(make_parented<WCoverArtLabel>(this)),
+          m_pWStarRating(make_parented<WStarRating>(nullptr, this)) {
     init();
 }
 
@@ -48,37 +51,24 @@ void DlgTrackInfo::init() {
     coverLayout->setAlignment(Qt::AlignRight | Qt::AlignTop);
     coverLayout->setSpacing(0);
     coverLayout->setContentsMargins(0, 0, 0, 0);
-    coverLayout->insertWidget(0, m_pWCoverArtLabel);
+    coverLayout->insertWidget(0, m_pWCoverArtLabel.get());
 
     starsLayout->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
     starsLayout->setSpacing(0);
     starsLayout->setContentsMargins(0, 0, 0, 0);
-    starsLayout->insertWidget(0, m_pWStarRating);
+    starsLayout->insertWidget(0, m_pWStarRating.get());
     // This is necessary to pass on mouseMove events to WStarRating
     m_pWStarRating->setMouseTracking(true);
 
-    m_pTagFetcher.reset(new DlgTagFetcher(this, m_pTrackModel));
     if (m_pTrackModel) {
         connect(btnNext,
                 &QPushButton::clicked,
                 this,
                 &DlgTrackInfo::slotNextButton);
-
         connect(btnPrev,
                 &QPushButton::clicked,
                 this,
                 &DlgTrackInfo::slotPrevButton);
-
-        connect(m_pTagFetcher.data(),
-                &DlgTagFetcher::next,
-                this,
-                &DlgTrackInfo::slotNextDlgTagFetcher);
-
-        connect(m_pTagFetcher.data(),
-                &DlgTagFetcher::previous,
-                this,
-                &DlgTrackInfo::slotPrevDlgTagFetcher);
-
     } else {
         btnNext->hide();
         btnPrev->hide();
@@ -145,9 +135,9 @@ void DlgTrackInfo::init() {
 
     connect(bpmTap,
             &QPushButton::pressed,
-            m_pTapFilter.data(),
+            &m_tapFilter,
             &TapFilter::tap);
-    connect(m_pTapFilter.data(),
+    connect(&m_tapFilter,
             &TapFilter::tapped,
             this,
             &DlgTrackInfo::slotBpmTap);
@@ -174,11 +164,11 @@ void DlgTrackInfo::init() {
                 this,
                 &DlgTrackInfo::slotCoverFound);
     }
-    connect(m_pWCoverArtLabel,
+    connect(m_pWCoverArtLabel.get(),
             &WCoverArtLabel::coverInfoSelected,
             this,
             &DlgTrackInfo::slotCoverInfoSelected);
-    connect(m_pWCoverArtLabel,
+    connect(m_pWCoverArtLabel.get(),
             &WCoverArtLabel::reloadCoverArt,
             this,
             &DlgTrackInfo::slotReloadCoverArt);
@@ -199,21 +189,14 @@ void DlgTrackInfo::slotCancel() {
 }
 
 void DlgTrackInfo::trackUpdated() {
-
 }
 
 void DlgTrackInfo::slotNextButton() {
     loadNextTrack();
-    if (m_pTagFetcher->isVisible()) {
-        m_pTagFetcher->loadTrack(m_currentTrackIndex);
-    }
 }
 
 void DlgTrackInfo::slotPrevButton() {
     loadPrevTrack();
-    if (m_pTagFetcher->isVisible()) {
-        m_pTagFetcher->loadTrack(m_currentTrackIndex);
-    }
 }
 
 void DlgTrackInfo::slotNextDlgTagFetcher() {
@@ -327,6 +310,9 @@ void DlgTrackInfo::loadTrack(TrackPointer pTrack) {
         return;
     }
     loadTrackInternal(pTrack);
+    if (m_pDlgTagFetcher && m_pLoadedTrack) {
+        m_pDlgTagFetcher->loadTrack(m_pLoadedTrack);
+    }
 }
 
 void DlgTrackInfo::loadTrack(QModelIndex index) {
@@ -336,6 +322,9 @@ void DlgTrackInfo::loadTrack(QModelIndex index) {
     TrackPointer pTrack = m_pTrackModel->getTrack(index);
     m_currentTrackIndex = index;
     loadTrackInternal(pTrack);
+    if (m_pDlgTagFetcher && m_currentTrackIndex.isValid()) {
+        m_pDlgTagFetcher->loadTrack(m_currentTrackIndex);
+    }
 }
 
 void DlgTrackInfo::slotCoverFound(
@@ -588,7 +577,7 @@ void DlgTrackInfo::slotKeyTextChanged() {
     // Try to parse the user's input as a key.
     const QString newKeyText = txtKey->text();
     Keys newKeys = KeyFactory::makeBasicKeysFromText(newKeyText,
-                                                     mixxx::track::io::key::USER);
+            mixxx::track::io::key::USER);
     const mixxx::track::io::key::ChromaticKey globalKey(newKeys.getGlobalKey());
 
     // If the new key string is invalid and not empty them reject the new key.
@@ -627,10 +616,34 @@ void DlgTrackInfo::slotTrackChanged(TrackId trackId) {
 }
 
 void DlgTrackInfo::slotImportMetadataFromMusicBrainz() {
-    if (m_pTrackModel) {
-        m_pTagFetcher->loadTrack(m_currentTrackIndex);
-    } else {
-        m_pTagFetcher->loadTrack(m_pLoadedTrack);
+    if (!m_pDlgTagFetcher) {
+        m_pDlgTagFetcher = std::make_unique<DlgTagFetcher>(
+                m_pTrackModel);
+        connect(m_pDlgTagFetcher.get(),
+                &QDialog::finished,
+                [this]() {
+                    if (m_pDlgTagFetcher.get() == sender()) {
+                        m_pDlgTagFetcher.release()->deleteLater();
+                    }
+                });
+        if (m_pTrackModel) {
+            connect(m_pDlgTagFetcher.get(),
+                    &DlgTagFetcher::next,
+                    this,
+                    &DlgTrackInfo::slotNextDlgTagFetcher);
+
+            connect(m_pDlgTagFetcher.get(),
+                    &DlgTagFetcher::previous,
+                    this,
+                    &DlgTrackInfo::slotPrevDlgTagFetcher);
+        }
     }
-    m_pTagFetcher->show();
+    if (m_pTrackModel) {
+        DEBUG_ASSERT(m_currentTrackIndex.isValid());
+        m_pDlgTagFetcher->loadTrack(m_currentTrackIndex);
+    } else {
+        DEBUG_ASSERT(m_pLoadedTrack);
+        m_pDlgTagFetcher->loadTrack(m_pLoadedTrack);
+    }
+    m_pDlgTagFetcher->show();
 }

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -1,22 +1,19 @@
-#ifndef DLGTRACKINFO_H
-#define DLGTRACKINFO_H
+#pragma once
 
 #include <QDialog>
-#include <QHash>
-#include <QList>
-#include <QMutex>
-#include <QScopedPointer>
+#include <QModelIndex>
+#include <memory>
 
 #include "library/coverart.h"
-#include "library/dlgtagfetcher.h"
-#include "library/trackmodel.h"
 #include "library/ui_dlgtrackinfo.h"
 #include "track/track.h"
+#include "util/parented_ptr.h"
 #include "util/tapfilter.h"
-#include "util/types.h"
-#include "widget/wcoverartlabel.h"
-#include "widget/wcoverartmenu.h"
-#include "widget/wstarrating.h"
+
+class TrackModel;
+class DlgTagFetcher;
+class WCoverArtLabel;
+class WStarRating;
 
 /// A dialog box to display and edit track properties.
 /// Use TrackPointer to load a track into the dialog or
@@ -26,10 +23,9 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     Q_OBJECT
   public:
     // TODO: Remove dependency on TrackModel
-    DlgTrackInfo(QWidget* parent,
-            UserSettingsPointer pConfig,
+    explicit DlgTrackInfo(
             const TrackModel* trackModel = nullptr);
-    virtual ~DlgTrackInfo();
+    ~DlgTrackInfo() override;
 
   public slots:
     // Not thread safe. Only invoke via AutoConnection or QueuedConnection, not
@@ -90,22 +86,24 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void unloadTrack(bool save);
     void clear();
     void init();
+
+    const TrackModel* const m_pTrackModel;
+
     TrackPointer m_pLoadedTrack;
+
+    QModelIndex m_currentTrackIndex;
+
     mixxx::BeatsPointer m_pBeatsClone;
     Keys m_keysClone;
     bool m_trackHasBeatMap;
 
-    QScopedPointer<TapFilter> m_pTapFilter;
-    QScopedPointer<DlgTagFetcher> m_pTagFetcher;
+    TapFilter m_tapFilter;
     double m_dLastTapedBpm;
 
     CoverInfo m_loadedCoverInfo;
-    WCoverArtLabel* m_pWCoverArtLabel;
-    WStarRating* m_pWStarRating;
-    UserSettingsPointer m_pConfig;
 
-    const TrackModel* m_pTrackModel;
-    QModelIndex m_currentTrackIndex;
+    parented_ptr<WCoverArtLabel> m_pWCoverArtLabel;
+    parented_ptr<WStarRating> m_pWStarRating;
+
+    std::unique_ptr<DlgTagFetcher> m_pDlgTagFetcher;
 };
-
-#endif /* DLGTRACKINFO_H */

--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -2,17 +2,38 @@
 
 #include <QtDebug>
 
-#include "library/dlgcoverartfullsize.h"
 #include "library/coverartutils.h"
+#include "library/dlgcoverartfullsize.h"
 #include "util/compatibility.h"
+#include "widget/wcoverartmenu.h"
 
-static const QSize s_labelDisplaySize = QSize(100, 100);
+namespace {
+
+constexpr QSize kDeviceIndependentCoverLabelSize = QSize(100, 100);
+
+inline QPixmap scaleCoverLabel(
+        QWidget* parent,
+        QPixmap pixmap) {
+    const auto devicePixelRatioF = getDevicePixelRatioF(parent);
+    pixmap.setDevicePixelRatio(devicePixelRatioF);
+    return pixmap.scaled(
+            kDeviceIndependentCoverLabelSize * devicePixelRatioF,
+            Qt::KeepAspectRatio,
+            Qt::SmoothTransformation);
+}
+
+QPixmap createDefaultCover(QWidget* parent) {
+    auto defaultCover = QPixmap(CoverArtUtils::defaultCoverLocation());
+    return scaleCoverLabel(parent, defaultCover);
+}
+
+} // anonymous namespace
 
 WCoverArtLabel::WCoverArtLabel(QWidget* parent)
         : QLabel(parent),
           m_pCoverMenu(make_parented<WCoverArtMenu>(this)),
           m_pDlgFullSize(make_parented<DlgCoverArtFullSize>(this)),
-          m_defaultCover(CoverArtUtils::defaultCoverLocation()) {
+          m_defaultCover(createDefaultCover(this)) {
     setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
     setFrameShape(QFrame::Box);
     setAlignment(Qt::AlignCenter);
@@ -22,16 +43,10 @@ WCoverArtLabel::WCoverArtLabel(QWidget* parent)
             &WCoverArtLabel::coverInfoSelected);
     connect(m_pCoverMenu, &WCoverArtMenu::reloadCoverArt, this, &WCoverArtLabel::reloadCoverArt);
 
-    m_defaultCover.setDevicePixelRatio(getDevicePixelRatioF(this));
-    m_defaultCover = m_defaultCover.scaled(s_labelDisplaySize * getDevicePixelRatioF(this),
-                                           Qt::KeepAspectRatio,
-                                           Qt::SmoothTransformation);
     setPixmap(m_defaultCover);
 }
 
-WCoverArtLabel::~WCoverArtLabel() {
-    // Nothing to do
-}
+WCoverArtLabel::~WCoverArtLabel() = default;
 
 void WCoverArtLabel::setCoverArt(const CoverInfo& coverInfo,
                                  QPixmap px) {
@@ -42,9 +57,7 @@ void WCoverArtLabel::setCoverArt(const CoverInfo& coverInfo,
         m_loadedCover = px;
         setPixmap(m_defaultCover);
     } else {
-        m_loadedCover = px.scaled(s_labelDisplaySize * getDevicePixelRatioF(this),
-                Qt::KeepAspectRatio, Qt::SmoothTransformation);
-        m_loadedCover.setDevicePixelRatio(getDevicePixelRatioF(this));
+        m_loadedCover = scaleCoverLabel(this, px);
         setPixmap(m_loadedCover);
     }
 

--- a/src/widget/wcoverartlabel.h
+++ b/src/widget/wcoverartlabel.h
@@ -2,13 +2,13 @@
 
 #include <QLabel>
 #include <QMouseEvent>
-#include <QWidget>
 #include <QPixmap>
+#include <QWidget>
 
 #include "track/track.h"
-#include "widget/wcoverartmenu.h"
 #include "util/parented_ptr.h"
 
+class WCoverArtMenu;
 class DlgCoverArtFullSize;
 
 class WCoverArtLabel : public QLabel {
@@ -32,9 +32,12 @@ class WCoverArtLabel : public QLabel {
       void slotCoverMenu(const QPoint& pos);
 
   private:
-    QPixmap m_loadedCover;
+    const parented_ptr<WCoverArtMenu> m_pCoverMenu;
+    const parented_ptr<DlgCoverArtFullSize> m_pDlgFullSize;
+
+    const QPixmap m_defaultCover;
+
     TrackPointer m_pLoadedTrack;
-    parented_ptr<WCoverArtMenu> m_pCoverMenu;
-    parented_ptr<DlgCoverArtFullSize> m_pDlgFullSize;
-    QPixmap m_defaultCover;
+
+    QPixmap m_loadedCover;
 };

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -28,7 +28,10 @@
 #include "util/parented_ptr.h"
 #include "util/qt.h"
 #include "widget/wcolorpickeraction.h"
+#include "widget/wcoverartlabel.h"
+#include "widget/wcoverartmenu.h"
 #include "widget/wskincolor.h"
+#include "widget/wstarrating.h"
 #include "widget/wwidget.h"
 
 WTrackMenu::WTrackMenu(QWidget* parent,
@@ -179,7 +182,7 @@ void WTrackMenu::createActions() {
 
     if (featureIsEnabled(Feature::Properties)) {
         m_pPropertiesAct = new QAction(tr("Properties"), this);
-        connect(m_pPropertiesAct, &QAction::triggered, this, &WTrackMenu::slotShowTrackInfo);
+        connect(m_pPropertiesAct, &QAction::triggered, this, &WTrackMenu::slotShowDlgTrackInfo);
     }
 
     if (featureIsEnabled(Feature::FileBrowser)) {
@@ -208,10 +211,6 @@ void WTrackMenu::createActions() {
                 &QAction::triggered,
                 this,
                 &WTrackMenu::slotExportMetadataIntoFileTags);
-
-        // Give a nullptr parent because otherwise it inherits our style which can
-        // make it unreadable. Bug #673411
-        m_pTagFetcher.reset(new DlgTagFetcher(nullptr, m_pTrackModel));
 
         for (const auto& externalTrackCollection : m_pTrackCollectionManager->externalCollections()) {
             UpdateExternalTrackCollection updateInExternalTrackCollection;
@@ -312,12 +311,6 @@ void WTrackMenu::createActions() {
                 &WColorPickerAction::colorPicked,
                 this,
                 &WTrackMenu::slotColorPicked);
-    }
-
-    if (featureIsEnabled(Feature::Properties)) {
-        // Give a nullptr parent because otherwise it inherits our style which can
-        // make it unreadable. Bug #673411
-        m_pTrackInfo.reset(new DlgTrackInfo(nullptr, m_pConfig, m_pTrackModel));
     }
 }
 
@@ -1478,30 +1471,50 @@ void WTrackMenu::slotClearAllMetadata() {
             &trackOperator);
 }
 
-void WTrackMenu::slotShowTrackInfo() {
+void WTrackMenu::slotShowDlgTrackInfo() {
     if (isEmpty()) {
         return;
     }
+    // Create a fresh dialog on invocation
+    m_pDlgTrackInfo = std::make_unique<DlgTrackInfo>(
+            m_pTrackModel);
+    connect(m_pDlgTrackInfo.get(),
+            &QDialog::finished,
+            [this]() {
+                if (m_pDlgTrackInfo.get() == sender()) {
+                    m_pDlgTrackInfo.release()->deleteLater();
+                }
+            });
     // Method getFirstTrackPointer() is not applicable here!
     if (m_pTrackModel) {
-        m_pTrackInfo->loadTrack(m_trackIndexList.at(0));
+        m_pDlgTrackInfo->loadTrack(m_trackIndexList.at(0));
     } else {
-        m_pTrackInfo->loadTrack(m_trackPointerList.at(0));
+        m_pDlgTrackInfo->loadTrack(m_trackPointerList.at(0));
     }
-    m_pTrackInfo->show();
+    m_pDlgTrackInfo->show();
 }
 
 void WTrackMenu::slotShowDlgTagFetcher() {
     if (isEmpty()) {
         return;
     }
+    // Create a fresh dialog on invocation
+    m_pDlgTagFetcher = std::make_unique<DlgTagFetcher>(
+            m_pTrackModel);
+    connect(m_pDlgTagFetcher.get(),
+            &QDialog::finished,
+            [this]() {
+                if (m_pDlgTagFetcher.get() == sender()) {
+                    m_pDlgTagFetcher.release()->deleteLater();
+                }
+            });
     // Method getFirstTrackPointer() is not applicable here!
     if (m_pTrackModel) {
-        m_pTagFetcher->loadTrack(m_trackIndexList.at(0));
+        m_pDlgTagFetcher->loadTrack(m_trackIndexList.at(0));
     } else {
-        m_pTagFetcher->loadTrack(m_trackPointerList.at(0));
+        m_pDlgTagFetcher->loadTrack(m_trackPointerList.at(0));
     }
-    m_pTagFetcher->show();
+    m_pDlgTagFetcher->show();
 }
 
 void WTrackMenu::slotAddToAutoDJBottom() {

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -67,7 +67,7 @@ class WTrackMenu : public QMenu {
     // WARNING: This function hides non-virtual QMenu::popup().
     // This has been done on purpose to ensure menu doesn't popup without loaded track(s).
     void popup(const QPoint& pos, QAction* at = nullptr);
-    void slotShowTrackInfo();
+    void slotShowDlgTrackInfo();
 
   signals:
     void loadTrackToPlayer(TrackPointer pTrack, QString group, bool play = false);
@@ -253,8 +253,8 @@ class WTrackMenu : public QMenu {
     const UserSettingsPointer m_pConfig;
     TrackCollectionManager* const m_pTrackCollectionManager;
 
-    QScopedPointer<DlgTrackInfo> m_pTrackInfo;
-    QScopedPointer<DlgTagFetcher> m_pTagFetcher;
+    std::unique_ptr<DlgTrackInfo> m_pDlgTrackInfo;
+    std::unique_ptr<DlgTagFetcher> m_pDlgTagFetcher;
 
     struct UpdateExternalTrackCollection {
         QPointer<ExternalTrackCollection> externalTrackCollection;

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -88,7 +88,7 @@ void WTrackProperty::mouseDoubleClickEvent(QMouseEvent* event) {
     Q_UNUSED(event);
     if (m_pCurrentTrack) {
         m_pTrackMenu->loadTrack(m_pCurrentTrack);
-        m_pTrackMenu->slotShowTrackInfo();
+        m_pTrackMenu->slotShowDlgTrackInfo();
     }
 }
 

--- a/src/widget/wtracktext.cpp
+++ b/src/widget/wtracktext.cpp
@@ -80,7 +80,7 @@ void WTrackText::mouseDoubleClickEvent(QMouseEvent* event) {
     Q_UNUSED(event);
     if (m_pCurrentTrack) {
         m_pTrackMenu->loadTrack(m_pCurrentTrack);
-        m_pTrackMenu->slotShowTrackInfo();
+        m_pTrackMenu->slotShowDlgTrackInfo();
     }
 }
 


### PR DESCRIPTION
Many unused instances of DlgTrackInfo are created by WTrackMenu. Noticed after adding a database query to the init code.

TODO(XXX): Initialize WTrackMenu lazily on-demand instead of eagerly.