### PR TITLE
WTrackTableViewHeader/HeaderViewState: Fix Qt 5.15.1 deprecation warning

### DIFF
--- a/src/widget/wtracktableviewheader.cpp
+++ b/src/widget/wtracktableviewheader.cpp
@@ -38,13 +38,11 @@ HeaderViewState::HeaderViewState(const QHeaderView& headers)
 }
 
 HeaderViewState::HeaderViewState(const QString& base64serialized) {
-    QByteArray array;
-    array.append(base64serialized);
     // First decode the array from Base64, then initialize the protobuf from it.
-    array = QByteArray::fromBase64(array);
+    QByteArray array = QByteArray::fromBase64(base64serialized.toLatin1());
     if (!m_view_state.ParseFromArray(array.constData(), array.size())) {
-        qDebug() << "ERROR: Could not parse m_view_state from QByteArray of size "
-                 << array.size();
+        qWarning() << "Could not parse m_view_state from QByteArray of size "
+                   << array.size();
         return;
     }
 }


### PR DESCRIPTION
This is a band-aid to fix compilation with `-Werror` using Qt 5.15.1:

    src/widget/wtracktableviewheader.cpp: In constructor ‘HeaderViewState::HeaderViewState(const QString&)’:
    src/widget/wtracktableviewheader.cpp:42:34: error: ‘QByteArray& QByteArray::append(const QString&)’ is de
    precated: Use QString's toUtf8(), toLatin1() or toLocal8Bit() [-Werror=deprecated-declarations]
       42 |     array.append(base64serialized);
          |                                  ^
    In file included from /usr/include/qt/QtCore/qhashfunctions.h:44,
                     from /usr/include/qt/QtCore/qlist.h:47,
                     from /usr/include/qt/QtCore/qhash.h:46,
                     from /usr/include/qt/QtCore/qdebug.h:45,
                     from /usr/include/qt/QtCore/QtDebug:1,
                     from /home/jan/Projects/mixxx/src/widget/wtracktableviewheader.cpp:4:
    /usr/include/qt/QtCore/qstring.h:1502:20: note: declared here
     1502 | inline QByteArray &QByteArray::append(const QString &s)
          |                    ^~~~~~~~~~
    cc1plus: all warnings being treated as errors