### PR TITLE
New CO [Library],current_column to get/set the absolute column index

### DIFF
--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -106,6 +106,7 @@ LibraryControl::LibraryControl(Library* pLibrary)
     m_pMoveLeft = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveLeft"));
     m_pMoveRight = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveRight"));
     m_pMoveHorizontal = std::make_unique<ControlEncoder>(ConfigKey("[Library]", "MoveHorizontal"), false);
+	m_pCurrentColumn = std::make_unique<ControlEncoder>(ConfigKey("[Library]", "current_column"));
     connect(m_pMoveLeft.get(),
             &ControlPushButton::valueChanged,
             this,
@@ -118,6 +119,10 @@ LibraryControl::LibraryControl(Library* pLibrary)
             &ControlEncoder::valueChanged,
             this,
             &LibraryControl::slotMoveHorizontal);
+    connect(m_pCurrentColumn.get(),
+            &ControlEncoder::valueChanged,
+            this,
+            &LibraryControl::slotCurrentColumn);
 
     // Control to navigate between widgets (tab/shit+tab button)
     m_pMoveFocusForward = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveFocusForward"));
@@ -507,6 +512,11 @@ void LibraryControl::slotMoveHorizontal(double v) {
     const auto key = (v < 0) ? Qt::Key_Left: Qt::Key_Right;
     const auto times = static_cast<unsigned short>(std::abs(v));
     emitKeyEvent(QKeyEvent{QEvent::KeyPress, key, Qt::NoModifier, QString(), false, times});
+}
+
+void LibraryControl::slotCurrentColumn(double v) {
+qDebug() << "UUUUUUUUUUUUUUUUUUUUUUUUUUUUU" << "LibraryControl::slotCurrentColumn" << "UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU";
+	
 }
 
 void LibraryControl::slotMoveFocusForward(double v) {

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -66,6 +66,7 @@ class LibraryControl : public QObject {
     void slotMoveLeft(double);
     void slotMoveRight(double);
     void slotMoveHorizontal(double);
+    void slotCurrentColumn(double);
     void slotMoveFocusForward(double);
     void slotMoveFocusBackward(double);
     void slotMoveFocus(double);
@@ -121,6 +122,7 @@ class LibraryControl : public QObject {
     std::unique_ptr<ControlPushButton> m_pMoveLeft;
     std::unique_ptr<ControlPushButton> m_pMoveRight;
     std::unique_ptr<ControlEncoder> m_pMoveHorizontal;
+    std::unique_ptr<ControlEncoder> m_pCurrentColumn;
 
     // Controls to navigate between widgets (tab/shit+tab button)
     std::unique_ptr<ControlPushButton> m_pMoveFocusForward;

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -57,7 +57,10 @@ WTrackTableView::WTrackTableView(QWidget* parent,
     m_pSortColumn->connectValueChanged(this, &WTrackTableView::applySortingIfVisible);
     m_pSortOrder = new ControlProxy("[Library]", "sort_order", this);
     m_pSortOrder->connectValueChanged(this, &WTrackTableView::applySortingIfVisible);
-
+	
+	m_pCurrentColumn = new ControlProxy("[Library]", "current_column", this);
+    m_pCurrentColumn->connectValueChanged(this, &WTrackTableView::slotCurrentColumnChanged);
+				
     connect(this,
             &WTrackTableView::scrollValueChanged,
             this,
@@ -852,6 +855,24 @@ void WTrackTableView::slotAddToAutoDJReplace() {
     addToAutoDJ(PlaylistDAO::AutoDJSendLoc::REPLACE);
 }
 
+void WTrackTableView::slotCurrentColumnChanged() {
+	QAbstractItemModel* itemModel = model();	
+    TrackModel* trackModel = dynamic_cast<TrackModel*>(itemModel);
+   
+    this->selectionModel()->setCurrentIndex(this->model()->index(currentIndex().row(), trackModel->columnIndexFromSortColumnId(static_cast<TrackModel::SortColumnId>(static_cast<int>(m_pCurrentColumn->get())))), QItemSelectionModel::Current);
+}
+
+void  WTrackTableView::currentChanged(const QModelIndex &current, const QModelIndex &previous) {
+    QAbstractItemModel* itemModel = model();
+	TrackModel* trackModel = dynamic_cast<TrackModel*>(itemModel);
+
+    if (currentIndex().isValid()) {
+        m_pCurrentColumn->set(trackModel->sortColumnIdFromColumnIndex(currentIndex().column()));
+    }
+
+    return QTableView::currentChanged(current, previous);
+};
+	
 void WTrackTableView::doSortByColumn(int headerSection, Qt::SortOrder sortOrder) {
     TrackModel* trackModel = getTrackModel();
     QAbstractItemModel* itemModel = model();
@@ -863,12 +884,21 @@ void WTrackTableView::doSortByColumn(int headerSection, Qt::SortOrder sortOrder)
     // Save the selection
     const QList<TrackId> selectedTrackIds = getSelectedTrackIds();
     int savedHScrollBarPos = horizontalScrollBar()->value();
+    // Save the column of focused table cell.
+    // The cell is not necessarily part of the selection, but even if it's
+    // focused after deselecting a row we may assume the user clicked onto the
+    // column that will be used for sorting.
+    int prevColum = 0;
+    if (currentIndex().isValid()) {
+        prevColum = currentIndex().column();
+    }
 
     sortByColumn(headerSection, sortOrder);
 
     QItemSelectionModel* currentSelection = selectionModel();
     currentSelection->reset(); // remove current selection
 
+    // Find previously selected tracks and store respective rows for reselection.
     QMap<int, int> selectedRows;
     for (const auto& trackId : selectedTrackIds) {
         // TODO(rryan) slowly fixing the issues with BaseSqlTableModel. This
@@ -886,19 +916,32 @@ void WTrackTableView::doSortByColumn(int headerSection, Qt::SortOrder sortOrder)
         }
     }
 
-    QModelIndex first;
+    // Select the first row of the previous selection.
+    // This scrolls to that row and with the leftmost cell being focused we have
+    // a starting point (currentIndex) for navigation with Up/Down keys.
+    // Replaces broken scrollTo() (see comment below)
+    if (!selectedRows.isEmpty()) {
+        selectRow(selectedRows.firstKey());
+    }
+
+    // Refocus the cell in the column that was focused before sorting.
+    // With this, any Up/Down key press moves the selection and keeps the
+    // horizontal scrollbar position we will restore below.
+    QModelIndex restoreIndex = itemModel->index(currentIndex().row(), prevColum);
+    if (restoreIndex.isValid()) {
+        setCurrentIndex(restoreIndex);
+    }
+
+    // Restore previous selection (doesn't affect focused cell).
     QMapIterator<int, int> i(selectedRows);
     while (i.hasNext()) {
         i.next();
         QModelIndex tl = itemModel->index(i.key(), 0);
         currentSelection->select(tl, QItemSelectionModel::Rows | QItemSelectionModel::Select);
-
-        if (!first.isValid()) {
-            first = tl;
-        }
     }
 
-    scrollTo(first, QAbstractItemView::EnsureVisible);
+    // This seems to be broken since at least Qt 5.12: no scrolling is issued
+    //scrollTo(first, QAbstractItemView::EnsureVisible);
     horizontalScrollBar()->setValue(savedHScrollBarPos);
 }
 
@@ -963,17 +1006,14 @@ bool WTrackTableView::hasFocus() const {
     return QWidget::hasFocus();
 }
 
-void WTrackTableView::saveCurrentVScrollBarPos()
-{
+void WTrackTableView::saveCurrentVScrollBarPos() {
     saveVScrollBarPos(getTrackModel());
 }
 
-void WTrackTableView::restoreCurrentVScrollBarPos()
-{
+void WTrackTableView::restoreCurrentVScrollBarPos() {
     restoreVScrollBarPos(getTrackModel());
 }
 
-void WTrackTableView::keyNotationChanged()
-{
+void WTrackTableView::keyNotationChanged() {
     QWidget::update();
 }

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -45,6 +45,7 @@ class WTrackTableView : public WLibraryTableView {
     void setSelectedTracks(const QList<TrackId>& tracks);
     void saveCurrentVScrollBarPos();
     void restoreCurrentVScrollBarPos();
+	void currentChanged(const QModelIndex &current, const QModelIndex &previous);
 
     double getBackgroundColorOpacity() const {
         return m_backgroundColorOpacity;
@@ -62,6 +63,7 @@ class WTrackTableView : public WLibraryTableView {
 
   private slots:
     void doSortByColumn(int headerSection, Qt::SortOrder sortOrder);
+    void slotCurrentColumnChanged();
     void applySortingIfVisible();
     void applySorting();
 
@@ -107,6 +109,7 @@ class WTrackTableView : public WLibraryTableView {
 
     ControlProxy* m_pCOTGuiTick;
     ControlProxy* m_pKeyNotation;
+    ControlProxy* m_pCurrentColumn;
     ControlProxy* m_pSortColumn;
     ControlProxy* m_pSortOrder;
 };


### PR DESCRIPTION
Added new CO current_column to get/set the absolute column index of the current cell in the library table.

The current cell of the table is the cell with the text cursor, selected by mouse click or by COs MoveLeft, MoveRight or MoveHorizontal.

The use case are controllers which have a rotary knob or button to move the 'cursor' horizontal. Until now it's not possible to sort according this columns from the controler, because the the index of the current column is not accessible from the controler.