### PR TITLE
Fix manual link to point to new manual website

### DIFF
--- a/src/defs_urls.h
+++ b/src/defs_urls.h
@@ -21,8 +21,8 @@
 #define MIXXX_SUPPORT_URL       "https://www.mixxx.org/support/"
 #define MIXXX_TRANSLATION_URL   "https://www.transifex.com/projects/p/mixxxdj/"
 #define MIXXX_FEEDBACK_URL      "https://goo.gl/forms/IHf3JK7Q9DXmExXc2"
-#define MIXXX_MANUAL_URL        "https://mixxx.org/manual/2.2"
-#define MIXXX_SHORTCUTS_URL     "https://mixxx.org/manual/2.2/chapters/appendix.html#keyboard-mapping-table"
+#define MIXXX_MANUAL_URL        "https://manual.mixxx.org/2.2"
+#define MIXXX_SHORTCUTS_URL     "https://manual.mixxx.org/2.2/chapters/appendix.html#keyboard-mapping-table"
 #define MIXXX_MANUAL_FILENAME   "Mixxx-Manual.pdf"
 
 #endif


### PR DESCRIPTION
The manual link still points to the old manual site which apparently is not updated anymore (I notices that when testing #3108).