### PR TITLE
shell.nix: Set maintainers to same list as in nixpkgs

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -129,7 +129,7 @@ in stdenv.mkDerivation rec {
     homepage = https://mixxx.org;
     description = "Digital DJ mixing software";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.aszlig maintainers.goibhniu ];
+    maintainers = nixroot.pkgs.mixxx.meta.maintainers;
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
This patch changes the maintainers in the meta information for the
derivation to be the same as in nixpkgs.
This way, only one list needs to be maintained (the one in nixpkgs).

---

I want @haslersn to have a look before this is merged.