### PR TITLE
Keep QM key detection as default

### DIFF
--- a/src/analyzer/analyzerkey.cpp
+++ b/src/analyzer/analyzerkey.cpp
@@ -15,10 +15,10 @@
 QList<mixxx::AnalyzerPluginInfo> AnalyzerKey::availablePlugins() {
     QList<mixxx::AnalyzerPluginInfo> analyzers;
     // First one below is the default
+    analyzers.push_back(mixxx::AnalyzerQueenMaryKey::pluginInfo());
 #if defined __KEYFINDER__
     analyzers.push_back(mixxx::AnalyzerKeyFinder::pluginInfo());
 #endif
-    analyzers.push_back(mixxx::AnalyzerQueenMaryKey::pluginInfo());
     return analyzers;
 }
 


### PR DESCRIPTION
We will stick with the QM key detection for the 2.3 release so this should be the default if one is starting over with fresh preferences. This ensures test results are matching our release and users are not bothered with key detection in a productive setup. 