### PR TITLE
Adopted link to forums

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ development and community news:
 - Follow us on [Twitter], [Facebook], and [G+].
 - Subscribe to the [Mixxx Development Blog][blog].
 - Join the developer [mailing list].
-- Post on the [Mixxx discourse channel][discourse].
+- Post on the [Mixxx forums][discourse].
 - Archive of the [Mixxx forums][forums].
 
 ## License

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ development and community news:
 - Follow us on [Twitter], [Facebook], and [G+].
 - Subscribe to the [Mixxx Development Blog][blog].
 - Join the developer [mailing list].
-- Post on the [Mixxx discord channel][discord].
+- Post on the [Mixxx discourse channel][discourse].
 - Archive of the [Mixxx forums][forums].
 
 ## License
@@ -107,4 +107,4 @@ license.
 [Mixxx glossary]: https://www.transifex.com/projects/p/mixxxdj/glossary/l/en/
 [hardware compatibility]: http://mixxx.org/wiki/doku.php/hardware_compatibility
 [zulip]: https://mixxx.zulipchat.com/
-[discord]: https://mixxx.discourse.group/
+[discourse]: https://mixxx.discourse.group/

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ development and community news:
 - Follow us on [Twitter], [Facebook], and [G+].
 - Subscribe to the [Mixxx Development Blog][blog].
 - Join the developer [mailing list].
-- Post on the [Mixxx forums][forums].
+- Post on the [Mixxx discord channel][discord].
+- Archive of the [Mixxx forums][forums].
 
 ## License
 
@@ -106,3 +107,4 @@ license.
 [Mixxx glossary]: https://www.transifex.com/projects/p/mixxxdj/glossary/l/en/
 [hardware compatibility]: http://mixxx.org/wiki/doku.php/hardware_compatibility
 [zulip]: https://mixxx.zulipchat.com/
+[discord]: https://mixxx.discourse.group/

--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ development and community news:
 - Subscribe to the [Mixxx Development Blog][blog].
 - Join the developer [mailing list].
 - Post on the [Mixxx forums][discourse].
-- Archive of the [Mixxx forums][forums].
 
 ## License
 
@@ -90,7 +89,6 @@ license.
 [manual]: http://www.mixxx.org/manual/latest/
 [wiki]: http://www.mixxx.org/wiki/
 [faq]: http://mixxx.org/wiki/doku.php/faq
-[forums]: http://www.mixxx.org/forums/
 [compiling on linux]: http://mixxx.org/wiki/doku.php/compiling_on_linux
 [compiling on os x]: http://mixxx.org/wiki/doku.php/compiling_on_os_x
 [compiling on windows]: http://mixxx.org/wiki/doku.php/compiling_on_windows


### PR DESCRIPTION
The switch to discord was not made public thus the README should be updates accordingly, especially as it was not directly obvious that the phpBB forum was no longer the 1st place for forum communication.