### PR TITLE
loopcontrol: prevent moving a loop beyond track end

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * Fix missing manual in deb package lp:1889776
 * Fix caching of duplicate tracks that reference the same file #3027
 * Fix loss of precision when dealing with floating-point sample positions while setting loop out position and seeking using vinyl control #3126 #3127
+* prevent moving a loop beyond track end #3117 https://bugs.launchpad.net/mixxx/+bug/1799574
 
 ==== 2.2.4 2020-05-10 ====
 

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -1173,6 +1173,12 @@ void LoopingControl::slotLoopMove(double beats) {
                 pBeats->findNBeatsFromSample(new_loop_in, m_pCOBeatLoopSize->get()) :
                 pBeats->findNBeatsFromSample(loopSamples.end, beats);
 
+        // The track would stop as soon as the playhead crosses track end,
+        // so we don't allow moving a loop beyond end.
+        // https://bugs.launchpad.net/mixxx/+bug/1799574
+        if (new_loop_out > m_pTrackSamples->get()) {
+            return;
+        }
         // If we are looping make sure that the play head does not leave the
         // loop as a result of our adjustment.
         loopSamples.seek = m_bLoopingEnabled;


### PR DESCRIPTION
quick fix for https://bugs.launchpad.net/mixxx/+bug/1799574

bug:
we don't allow creating a loop with loop_out beyond the track end but it was possible to shift the loop there.
playback would stop unexpectedly.