### PR TITLE
engine/loopingcontrol: Fix precision loss (wrong use of int)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * Add controller mapping for Hercules DJControl Jogvision #2370
 * Fix missing manual in deb package lp:1889776
 * Fix caching of duplicate tracks that reference the same file #3027
+* Fix loss of precision when dealing with floating-point sample positions while setting loop out position and seeking using vinyl control #3126 #3127
 
 ==== 2.2.4 2020-05-10 ====
 

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -613,7 +613,7 @@ void LoopingControl::setLoopOutToCurrentPosition() {
     BeatsPointer pBeats = m_pBeats;
     LoopSamples loopSamples = m_loopSamples.getValue();
     double quantizedBeat = -1;
-    int pos = m_currentSample.getValue();
+    double pos = m_currentSample.getValue();
     if (m_pQuantizeEnabled->toBool() && pBeats) {
         if (m_bAdjustingLoopOut) {
             double closestBeat = m_pClosestBeat->get();


### PR DESCRIPTION
Found thanks to `-Wfloat-conversion`. There is no comment that indicates that this loss of precision is intended, so I think this is a bug.