### PR TITLE
Fix some -Wfloat-conversion warnings (Pt. 7)

### DIFF
--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -709,7 +709,7 @@ double BpmControl::getNearestPositionInPhase(
 
             // Syncing to after the loop end.
             if (end_delta > 0 && loop_length > 0.0) {
-                int i = end_delta / loop_length;
+                double i = end_delta / loop_length;
                 dNewPlaypos = loop_start_position + end_delta - i * loop_length;
 
                 // Move new position after loop jump into phase as well.
@@ -885,7 +885,7 @@ double BpmControl::getBeatMatchPosition(
 
             // Syncing to after the loop end.
             if (end_delta > 0 && loop_length > 0.0) {
-                int i = end_delta / loop_length;
+                double i = end_delta / loop_length;
                 dNewPlaypos = loop_start_position + end_delta - i * loop_length;
 
                 // Move new position after loop jump into phase as well.

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -956,7 +956,7 @@ void BpmControl::slotBeatsTranslate(double v) {
     if (v > 0 && pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
         double currentSample = getSampleOfTrack().current;
         double closestBeat = pBeats->findClosestBeat(currentSample);
-        int delta = currentSample - closestBeat;
+        int delta = static_cast<int>(currentSample - closestBeat);
         if (delta % 2 != 0) {
             delta--;
         }

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -619,7 +619,7 @@ void LoopingControl::setLoopOutToCurrentPosition() {
     mixxx::BeatsPointer pBeats = m_pBeats;
     LoopSamples loopSamples = m_loopSamples.getValue();
     double quantizedBeat = -1;
-    int pos = m_currentSample.getValue();
+    double pos = m_currentSample.getValue();
     if (m_pQuantizeEnabled->toBool() && pBeats) {
         if (m_bAdjustingLoopOut) {
             double closestBeat = m_pClosestBeat->get();

--- a/src/engine/controls/vinylcontrolcontrol.cpp
+++ b/src/engine/controls/vinylcontrolcontrol.cpp
@@ -117,7 +117,7 @@ void VinylControlControl::slotControlVinylSeek(double fractionalPos) {
         }
 
         double shortest_distance = 0;
-        int nearest_playpos = -1;
+        double nearest_playpos = -1;
 
         const QList<CuePointer> cuePoints(pTrack->getCuePoints());
         QListIterator<CuePointer> it(cuePoints);
@@ -127,7 +127,7 @@ void VinylControlControl::slotControlVinylSeek(double fractionalPos) {
                 continue;
             }
 
-            int cue_position = pCue->getPosition();
+            double cue_position = pCue->getPosition();
             // pick cues closest to new_playpos
             if ((nearest_playpos == -1) ||
                 (fabs(new_playpos - cue_position) < shortest_distance)) {

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -1,9 +1,3 @@
-// Tests for Master Sync.
-// The following manual tests should probably be performed:
-// * Quantize mode nudges tracks in sync, whether internal or deck master.
-// * Flinging tracks with the waveform should work.
-// * vinyl??
-
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -21,6 +15,15 @@
 #include "track/beatmap.h"
 #include "util/memory.h"
 
+namespace {
+constexpr double kMaxFloatingPointError = 0.005;
+}
+
+/// Tests for Master Sync.
+/// The following manual tests should probably be performed:
+/// * Quantize mode nudges tracks in sync, whether internal or deck master.
+/// * Flinging tracks with the waveform should work.
+/// * vinyl??
 class EngineSyncTest : public MockedEngineBackendTest {
   public:
     QString getMasterGroup() {
@@ -149,7 +152,7 @@ TEST_F(EngineSyncTest, SetMasterSuccess) {
     ProcessBuffer();
 
     // No tracks are playing and we have no beats, SYNC_MASTER_EXPLICIT state is in stand-by
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             0.0, ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
     // The master sync should now be channel 1.
     ASSERT_TRUE(isExplicitMaster(m_sGroup1));
@@ -347,9 +350,9 @@ TEST_F(EngineSyncTest, InternalMasterSetFollowerSliderMoves) {
     pButtonMasterSync1->slotSet(SYNC_FOLLOWER);
     ProcessBuffer();
 
-    EXPECT_FLOAT_EQ(getRateSliderValue(1.25),
+    EXPECT_DOUBLE_EQ(getRateSliderValue(1.25),
             ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))->get());
-    EXPECT_FLOAT_EQ(100.0,
+    EXPECT_DOUBLE_EQ(100.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
 }
 
@@ -364,7 +367,7 @@ TEST_F(EngineSyncTest, AnySyncDeckSliderStays) {
     pButtonSyncEnabled1->set(1.0);
 
     // After setting up the first deck, the internal BPM should be 80.
-    EXPECT_FLOAT_EQ(80.0,
+    EXPECT_DOUBLE_EQ(80.0,
             ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))
                     ->get());
 
@@ -375,7 +378,7 @@ TEST_F(EngineSyncTest, AnySyncDeckSliderStays) {
     pButtonSyncEnabled2->set(1.0);
 
     // After the second one, though, the internal BPM should still be 80.
-    EXPECT_FLOAT_EQ(80.0,
+    EXPECT_DOUBLE_EQ(80.0,
             ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))
                     ->get());
 }
@@ -408,7 +411,7 @@ TEST_F(EngineSyncTest, InternalClockFollowsFirstPlayingDeck) {
 
     // The master sync should now be deck 1.
     ASSERT_TRUE(isSoftMaster(m_sGroup1));
-    EXPECT_FLOAT_EQ(100.0,
+    EXPECT_DOUBLE_EQ(100.0,
             ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 
     // Set channel 2 to be enabled.
@@ -421,7 +424,7 @@ TEST_F(EngineSyncTest, InternalClockFollowsFirstPlayingDeck) {
     ASSERT_TRUE(isFollower(m_sGroup2));
 
     // The rate should not have changed -- deck 1 still matches deck 2.
-    EXPECT_FLOAT_EQ(getRateSliderValue(1.0),
+    EXPECT_DOUBLE_EQ(getRateSliderValue(1.0),
             ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))->get());
 
     // Reset channel 2 rate, set channel 2 to play, and process a buffer.
@@ -442,7 +445,7 @@ TEST_F(EngineSyncTest, InternalClockFollowsFirstPlayingDeck) {
     ASSERT_TRUE(isFollower(m_sInternalClockGroup));
 
     // Rate should now match channel 2.
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             130.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 }
 
@@ -550,32 +553,32 @@ TEST_F(EngineSyncTest, RateChangeTest) {
     // Set the file bpm of channel 1 to 160bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sGroup1, "file_bpm")));
     ProcessBuffer();
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 
     // Set the rate of channel 1 to 1.2.
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.2));
-    EXPECT_FLOAT_EQ(getRateSliderValue(1.2),
+    EXPECT_DOUBLE_EQ(getRateSliderValue(1.2),
             ControlObject::get(ConfigKey(m_sGroup1, "rate")));
-    EXPECT_FLOAT_EQ(192.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
+    EXPECT_DOUBLE_EQ(192.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
 
     // Internal master should also be 192.
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             192.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
     m_pTrack2->setBeats(pBeats2);
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             120.0, ControlObject::get(ConfigKey(m_sGroup2, "file_bpm")));
 
     // rate slider for channel 2 should now be 1.6 = 160 * 1.2 / 120.
-    EXPECT_FLOAT_EQ(getRateSliderValue(1.6),
+    EXPECT_DOUBLE_EQ(getRateSliderValue(1.6),
             ControlObject::get(ConfigKey(m_sGroup2, "rate")));
-    EXPECT_FLOAT_EQ(192.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
+    EXPECT_DOUBLE_EQ(192.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
 }
 
 TEST_F(EngineSyncTest, RateChangeTestWeirdOrder) {
@@ -591,7 +594,7 @@ TEST_F(EngineSyncTest, RateChangeTestWeirdOrder) {
     // Set the file bpm of channel 1 to 160bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
@@ -602,12 +605,12 @@ TEST_F(EngineSyncTest, RateChangeTestWeirdOrder) {
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.2));
 
     // Rate slider for channel 2 should now be 1.6 = (160 * 1.2 / 120) - 1.0.
-    EXPECT_FLOAT_EQ(getRateSliderValue(1.6),
+    EXPECT_DOUBLE_EQ(getRateSliderValue(1.6),
             ControlObject::get(ConfigKey(m_sGroup2, "rate")));
-    EXPECT_FLOAT_EQ(192.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
+    EXPECT_DOUBLE_EQ(192.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
 
     // Internal Master BPM should read the same.
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             192.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 }
 
@@ -615,13 +618,13 @@ TEST_F(EngineSyncTest, RateChangeTestOrder3) {
     // Set the file bpm of channel 1 to 160bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sGroup1, "file_bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
     m_pTrack2->setBeats(pBeats2);
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             120.0, ControlObject::get(ConfigKey(m_sGroup2, "file_bpm")));
 
     // Turn on Master and Follower.
@@ -638,10 +641,11 @@ TEST_F(EngineSyncTest, RateChangeTestOrder3) {
     ProcessBuffer();
 
     // Follower should immediately set its slider.
-    EXPECT_FLOAT_EQ(getRateSliderValue(1.3333333333),
-            ControlObject::get(ConfigKey(m_sGroup2, "rate")));
-    EXPECT_FLOAT_EQ(160.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
-    EXPECT_FLOAT_EQ(
+    EXPECT_NEAR(getRateSliderValue(1.3333333333),
+            ControlObject::get(ConfigKey(m_sGroup2, "rate")),
+            kMaxFloatingPointError);
+    EXPECT_DOUBLE_EQ(160.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
+    EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 }
 
@@ -667,9 +671,9 @@ TEST_F(EngineSyncTest, FollowerRateChange) {
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.2));
 
     // Rate slider for channel 2 should now be 1.6 = (160 * 1.2 / 120).
-    EXPECT_FLOAT_EQ(getRateSliderValue(1.6),
+    EXPECT_DOUBLE_EQ(getRateSliderValue(1.6),
             ControlObject::get(ConfigKey(m_sGroup2, "rate")));
-    EXPECT_FLOAT_EQ(192.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
+    EXPECT_DOUBLE_EQ(192.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
 
     // Try to twiddle the rate slider on channel 2.
     auto pSlider2 = std::make_unique<ControlProxy>(m_sGroup2, "rate");
@@ -677,12 +681,12 @@ TEST_F(EngineSyncTest, FollowerRateChange) {
     ProcessBuffer();
 
     // Rates should still be changed even though it's a follower.
-    EXPECT_FLOAT_EQ(getRateSliderValue(0.8),
+    EXPECT_DOUBLE_EQ(getRateSliderValue(0.8),
             ControlObject::get(ConfigKey(m_sGroup2, "rate")));
-    EXPECT_FLOAT_EQ(96.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
-    EXPECT_FLOAT_EQ(getRateSliderValue(0.6),
+    EXPECT_DOUBLE_EQ(96.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
+    EXPECT_DOUBLE_EQ(getRateSliderValue(0.6),
             ControlObject::get(ConfigKey(m_sGroup1, "rate")));
-    EXPECT_FLOAT_EQ(96.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
+    EXPECT_DOUBLE_EQ(96.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
 }
 
 TEST_F(EngineSyncTest, InternalRateChangeTest) {
@@ -704,20 +708,20 @@ TEST_F(EngineSyncTest, InternalRateChangeTest) {
     // Set the file bpm of channel 1 to 160bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    EXPECT_FLOAT_EQ(160.0,
+    EXPECT_DOUBLE_EQ(160.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "file_bpm"))->get());
 
     // Set the file bpm of channel 2 to 120bpm.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
     m_pTrack2->setBeats(pBeats2);
-    EXPECT_FLOAT_EQ(120.0,
+    EXPECT_DOUBLE_EQ(120.0,
             ControlObject::getControl(ConfigKey(m_sGroup2, "file_bpm"))->get());
 
     // Set the internal rate to 150.
     auto pMasterSyncSlider =
             std::make_unique<ControlProxy>(m_sInternalClockGroup, "bpm");
     pMasterSyncSlider->set(150.0);
-    EXPECT_FLOAT_EQ(150.0,
+    EXPECT_DOUBLE_EQ(150.0,
             ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))
                     ->get());
     // Set decks playing, and process a buffer to update all the COs.
@@ -727,13 +731,13 @@ TEST_F(EngineSyncTest, InternalRateChangeTest) {
     ProcessBuffer();
 
     // Rate sliders for channels 1 and 2 should change appropriately.
-    EXPECT_FLOAT_EQ(getRateSliderValue(0.9375),
+    EXPECT_DOUBLE_EQ(getRateSliderValue(0.9375),
             ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))->get());
-    EXPECT_FLOAT_EQ(150.0,
+    EXPECT_DOUBLE_EQ(150.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
-    EXPECT_FLOAT_EQ(getRateSliderValue(1.25),
+    EXPECT_DOUBLE_EQ(getRateSliderValue(1.25),
             ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))->get());
-    EXPECT_FLOAT_EQ(150.0,
+    EXPECT_DOUBLE_EQ(150.0,
             ControlObject::getControl(ConfigKey(m_sGroup2, "bpm"))->get());
 
     // Set the internal rate to 140.
@@ -743,13 +747,14 @@ TEST_F(EngineSyncTest, InternalRateChangeTest) {
     ProcessBuffer();
 
     // Rate sliders for channels 1 and 2 should change appropriately.
-    EXPECT_FLOAT_EQ(getRateSliderValue(.875),
+    EXPECT_DOUBLE_EQ(getRateSliderValue(.875),
             ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))->get());
-    EXPECT_FLOAT_EQ(140.0,
+    EXPECT_DOUBLE_EQ(140.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
-    EXPECT_FLOAT_EQ(getRateSliderValue(1.16666667),
-            ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))->get());
-    EXPECT_FLOAT_EQ(140.0,
+    EXPECT_NEAR(getRateSliderValue(1.16666667),
+            ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))->get(),
+            kMaxFloatingPointError);
+    EXPECT_DOUBLE_EQ(140.0,
             ControlObject::getControl(ConfigKey(m_sGroup2, "bpm"))->get());
 }
 
@@ -778,16 +783,16 @@ TEST_F(EngineSyncTest, MasterStopSliderCheck) {
 
     ProcessBuffer();
 
-    EXPECT_FLOAT_EQ(120.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
-    EXPECT_FLOAT_EQ(getRateSliderValue(0.9375),
+    EXPECT_DOUBLE_EQ(120.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
+    EXPECT_DOUBLE_EQ(getRateSliderValue(0.9375),
             ControlObject::get(ConfigKey(m_sGroup2, "rate")));
 
     pChannel1Play->set(0.0);
 
     ProcessBuffer();
 
-    EXPECT_FLOAT_EQ(120.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
-    EXPECT_FLOAT_EQ(getRateSliderValue(0.9375),
+    EXPECT_DOUBLE_EQ(120.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
+    EXPECT_DOUBLE_EQ(getRateSliderValue(0.9375),
             ControlObject::get(ConfigKey(m_sGroup2, "rate")));
 }
 
@@ -816,12 +821,12 @@ TEST_F(EngineSyncTest, EnableOneDeckInitsMaster) {
     ASSERT_TRUE(isFollower(m_sInternalClockGroup));
 
     // Internal clock rate and beat distance should match that deck.
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             130.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
-    EXPECT_FLOAT_EQ(130.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(130.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
+    EXPECT_DOUBLE_EQ(
             0.2, ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")));
-    EXPECT_FLOAT_EQ(0.2,
+    EXPECT_DOUBLE_EQ(0.2,
             ControlObject::get(
                     ConfigKey(m_sInternalClockGroup, "beat_distance")));
 
@@ -840,12 +845,12 @@ TEST_F(EngineSyncTest, EnableOneDeckInitsMaster) {
     ASSERT_TRUE(isFollower(m_sGroup1));
     ASSERT_TRUE(isFollower(m_sGroup2));
 
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             130.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
-    EXPECT_FLOAT_EQ(130.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(130.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
+    EXPECT_DOUBLE_EQ(
             0.2, ControlObject::get(ConfigKey(m_sGroup2, "beat_distance")));
-    EXPECT_FLOAT_EQ(0.2,
+    EXPECT_DOUBLE_EQ(0.2,
             ControlObject::get(
                     ConfigKey(m_sInternalClockGroup, "beat_distance")));
 }
@@ -869,15 +874,15 @@ TEST_F(EngineSyncTest, EnableOneDeckInitializesMaster) {
     ASSERT_TRUE(isSoftMaster(m_sGroup1));
 
     // Internal clock rate should be set and beat distances reset.
-    EXPECT_FLOAT_EQ(130.0,
+    EXPECT_DOUBLE_EQ(130.0,
             ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))
                     ->get());
-    EXPECT_FLOAT_EQ(130.0,
+    EXPECT_DOUBLE_EQ(130.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
-    EXPECT_FLOAT_EQ(0.2,
+    EXPECT_DOUBLE_EQ(0.2,
             ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))
                     ->get());
-    EXPECT_FLOAT_EQ(0.2,
+    EXPECT_DOUBLE_EQ(0.2,
             ControlObject::getControl(
                     ConfigKey(m_sInternalClockGroup, "beat_distance"))
                     ->get());
@@ -895,13 +900,13 @@ TEST_F(EngineSyncTest, LoadTrackInitializesMaster) {
 
     // No master because this deck has no track.
     EXPECT_EQ(NULL, m_pEngineSync->getMaster());
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             0.0, ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
 
     // The track load trigger a master change.
     m_pMixerDeck1->loadFakeTrack(false, 140.0);
     ASSERT_TRUE(isSoftMaster(m_sGroup1));
-    EXPECT_FLOAT_EQ(140.0,
+    EXPECT_DOUBLE_EQ(140.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
 
     // But as soon as we play, deck 1 is master
@@ -924,7 +929,7 @@ TEST_F(EngineSyncTest, LoadTrackInitializesMaster) {
 
     // Deck 2 is still empty so Deck 1 becomes master again
     ASSERT_TRUE(isSoftMaster(m_sGroup1));
-    EXPECT_FLOAT_EQ(128.0,
+    EXPECT_DOUBLE_EQ(128.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
 
     // If sync is on two decks and one deck is loaded but not playing, we should
@@ -932,12 +937,12 @@ TEST_F(EngineSyncTest, LoadTrackInitializesMaster) {
     m_pMixerDeck2->loadFakeTrack(false, 110.0);
 
     ASSERT_TRUE(isSoftMaster(m_sInternalClockGroup));
-    EXPECT_FLOAT_EQ(128.0,
+    EXPECT_DOUBLE_EQ(128.0,
             ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))
                     ->get());
-    EXPECT_FLOAT_EQ(128.0,
+    EXPECT_DOUBLE_EQ(128.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
-    EXPECT_FLOAT_EQ(128.0,
+    EXPECT_DOUBLE_EQ(128.0,
             ControlObject::getControl(ConfigKey(m_sGroup2, "bpm"))->get());
 }
 
@@ -960,9 +965,9 @@ TEST_F(EngineSyncTest, LoadTrackResetTempoOption) {
     // If sync is on and we load a track, that should initialize master.
     TrackPointer track1 = m_pMixerDeck1->loadFakeTrack(false, 140.0);
 
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             140.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
-    EXPECT_FLOAT_EQ(140.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
+    EXPECT_DOUBLE_EQ(140.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
 
     // If sync is on two decks and we load a track while one is playing,
     // that should not change the playing deck.
@@ -970,10 +975,10 @@ TEST_F(EngineSyncTest, LoadTrackResetTempoOption) {
 
     TrackPointer track2 = m_pMixerDeck2->loadFakeTrack(false, 128.0);
 
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             140.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
-    EXPECT_FLOAT_EQ(140.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
-    EXPECT_FLOAT_EQ(140.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
+    EXPECT_DOUBLE_EQ(140.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
+    EXPECT_DOUBLE_EQ(140.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
 
     // Repeat with RESET_PITCH_AND_SPEED
     m_pConfig->set(ConfigKey("[Controls]", "SpeedAutoReset"),
@@ -983,10 +988,10 @@ TEST_F(EngineSyncTest, LoadTrackResetTempoOption) {
     track1 = m_pMixerDeck1->loadFakeTrack(false, 140.0);
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
     track2 = m_pMixerDeck2->loadFakeTrack(false, 128.0);
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             140.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
-    EXPECT_FLOAT_EQ(140.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
-    EXPECT_FLOAT_EQ(140.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
+    EXPECT_DOUBLE_EQ(140.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
+    EXPECT_DOUBLE_EQ(140.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
 
     // Repeat with RESET_NONE
     m_pConfig->set(ConfigKey("[Controls]", "SpeedAutoReset"),
@@ -997,10 +1002,10 @@ TEST_F(EngineSyncTest, LoadTrackResetTempoOption) {
     track1 = m_pMixerDeck1->loadFakeTrack(false, 140.0);
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
     track2 = m_pMixerDeck2->loadFakeTrack(false, 128.0);
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             128.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
-    EXPECT_FLOAT_EQ(128.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
-    EXPECT_FLOAT_EQ(128.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
+    EXPECT_DOUBLE_EQ(128.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
+    EXPECT_DOUBLE_EQ(128.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
 
     // Load two tracks with sync off and RESET_SPEED
     m_pConfig->set(ConfigKey("[Controls]", "SpeedAutoReset"),
@@ -1015,8 +1020,8 @@ TEST_F(EngineSyncTest, LoadTrackResetTempoOption) {
     track1 = m_pMixerDeck1->loadFakeTrack(false, 140.0);
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
     track2 = m_pMixerDeck2->loadFakeTrack(false, 128.0);
-    EXPECT_FLOAT_EQ(140.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
-    EXPECT_FLOAT_EQ(128.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
+    EXPECT_DOUBLE_EQ(140.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
+    EXPECT_DOUBLE_EQ(128.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
 
     // Load two tracks with sync off and RESET_PITCH_AND_SPEED
     m_pConfig->set(ConfigKey("[Controls]", "SpeedAutoReset"),
@@ -1031,9 +1036,9 @@ TEST_F(EngineSyncTest, LoadTrackResetTempoOption) {
     track1 = m_pMixerDeck1->loadFakeTrack(false, 140.0);
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
     track2 = m_pMixerDeck2->loadFakeTrack(false, 128.0);
-    EXPECT_FLOAT_EQ(140.0,
+    EXPECT_DOUBLE_EQ(140.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
-    EXPECT_FLOAT_EQ(128.0,
+    EXPECT_DOUBLE_EQ(128.0,
             ControlObject::getControl(ConfigKey(m_sGroup2, "bpm"))->get());
 }
 
@@ -1055,7 +1060,7 @@ TEST_F(EngineSyncTest, EnableOneDeckSliderUpdates) {
     ASSERT_TRUE(isSoftMaster(m_sGroup1));
 
     // Internal clock rate should be set.
-    EXPECT_FLOAT_EQ(130.0,
+    EXPECT_DOUBLE_EQ(130.0,
             ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))
                     ->get());
 }
@@ -1088,10 +1093,10 @@ TEST_F(EngineSyncTest, SyncToNonSyncDeck) {
     // There should be no master, and deck2 should match rate of deck1.  Sync slider should be
     // updated with the value, however.
     assertNoMaster();
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             130.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
     assertSyncOff(m_sGroup2);
-    EXPECT_FLOAT_EQ(getRateSliderValue(1.3),
+    EXPECT_DOUBLE_EQ(getRateSliderValue(1.3),
             ControlObject::get(ConfigKey(m_sGroup2, "rate")));
 
     // Reset the pitch of deck 2.
@@ -1106,14 +1111,14 @@ TEST_F(EngineSyncTest, SyncToNonSyncDeck) {
     EXPECT_EQ(0,
             ControlObject::get(
                     ConfigKey(m_sInternalClockGroup, "sync_master")));
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             100.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
     EXPECT_EQ(NULL, m_pEngineSync->getMaster());
     EXPECT_EQ(NULL, m_pEngineSync->getMasterSyncable());
     EXPECT_EQ(SYNC_NONE, ControlObject::get(ConfigKey(m_sGroup1, "sync_mode")));
     EXPECT_EQ(0, ControlObject::get(ConfigKey(m_sGroup1, "sync_enabled")));
     EXPECT_EQ(0, ControlObject::get(ConfigKey(m_sGroup1, "sync_master")));
-    EXPECT_FLOAT_EQ(getRateSliderValue(100.0 / 130.0),
+    EXPECT_DOUBLE_EQ(getRateSliderValue(100.0 / 130.0),
             ControlObject::get(ConfigKey(m_sGroup1, "rate")));
 
     // Reset again.
@@ -1131,14 +1136,14 @@ TEST_F(EngineSyncTest, SyncToNonSyncDeck) {
     EXPECT_EQ(0,
             ControlObject::get(
                     ConfigKey(m_sInternalClockGroup, "sync_master")));
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             100.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
     EXPECT_EQ(NULL, m_pEngineSync->getMaster());
     EXPECT_EQ(NULL, m_pEngineSync->getMasterSyncable());
     EXPECT_EQ(SYNC_NONE, ControlObject::get(ConfigKey(m_sGroup2, "sync_mode")));
     EXPECT_EQ(0, ControlObject::get(ConfigKey(m_sGroup2, "sync_enabled")));
     EXPECT_EQ(0, ControlObject::get(ConfigKey(m_sGroup2, "sync_master")));
-    EXPECT_FLOAT_EQ(getRateSliderValue(1.0),
+    EXPECT_DOUBLE_EQ(getRateSliderValue(1.0),
             ControlObject::get(ConfigKey(m_sGroup2, "rate")));
 }
 
@@ -1171,7 +1176,7 @@ TEST_F(EngineSyncTest, MomentarySyncDependsOnPlayingStates) {
     assertNoMaster();
     assertSyncOff(m_sGroup1);
     assertSyncOff(m_sGroup2);
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             130.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 
     // Also works if deck 1 is not playing.
@@ -1185,7 +1190,7 @@ TEST_F(EngineSyncTest, MomentarySyncDependsOnPlayingStates) {
     assertNoMaster();
     assertSyncOff(m_sGroup1);
     assertSyncOff(m_sGroup2);
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             130.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 
     // Also works if neither deck is playing.
@@ -1199,7 +1204,7 @@ TEST_F(EngineSyncTest, MomentarySyncDependsOnPlayingStates) {
     assertNoMaster();
     assertSyncOff(m_sGroup1);
     assertSyncOff(m_sGroup2);
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             130.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 
     // But it doesn't work if deck 2 isn't playing and deck 1 is. (This would
@@ -1214,7 +1219,7 @@ TEST_F(EngineSyncTest, MomentarySyncDependsOnPlayingStates) {
     assertNoMaster();
     assertSyncOff(m_sGroup1);
     assertSyncOff(m_sGroup2);
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             100.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 }
 
@@ -1239,7 +1244,7 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
     // When an eject happens, the bpm gets set to zero.
     ProcessBuffer();
 
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             0.0, ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
 
     // No valid tempo available all are waiting as follower
@@ -1248,7 +1253,7 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
     assertSyncOff(m_sGroup2);
 
     m_pMixerDeck1->loadFakeTrack(false, 128.0);
-    EXPECT_FLOAT_EQ(128.0,
+    EXPECT_DOUBLE_EQ(128.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 135, 0.0);
     m_pTrack2->setBeats(pBeats2);
@@ -1286,7 +1291,7 @@ TEST_F(EngineSyncTest, FileBpmChangesDontAffectMaster) {
 
     pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             100.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 }
 
@@ -1302,8 +1307,9 @@ TEST_F(EngineSyncTest, ExplicitMasterPostProcessed) {
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
     ProcessBuffer();
 
-    EXPECT_FLOAT_EQ(
-            0.0023219956, m_pChannel1->getEngineBuffer()->getVisualPlayPos());
+    EXPECT_NEAR(0.0023219956,
+            m_pChannel1->getEngineBuffer()->getVisualPlayPos(),
+            kMaxFloatingPointError);
 }
 
 TEST_F(EngineSyncTest, ZeroBPMRateAdjustIgnored) {
@@ -1328,7 +1334,7 @@ TEST_F(EngineSyncTest, ZeroBPMRateAdjustIgnored) {
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
             ->set(getRateSliderValue(1.3));
 
-    EXPECT_FLOAT_EQ(getRateSliderValue(1.0),
+    EXPECT_DOUBLE_EQ(getRateSliderValue(1.0),
             ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))->get());
 
     // Also try with explicit master/follower setting
@@ -1338,7 +1344,7 @@ TEST_F(EngineSyncTest, ZeroBPMRateAdjustIgnored) {
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
             ->set(getRateSliderValue(1.4));
-    EXPECT_FLOAT_EQ(getRateSliderValue(1.0),
+    EXPECT_DOUBLE_EQ(getRateSliderValue(1.0),
             ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))->get());
 
     pButtonSyncEnabled1->set(0.0);
@@ -1347,7 +1353,7 @@ TEST_F(EngineSyncTest, ZeroBPMRateAdjustIgnored) {
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
             ->set(getRateSliderValue(0.9));
-    EXPECT_FLOAT_EQ(getRateSliderValue(1.0),
+    EXPECT_DOUBLE_EQ(getRateSliderValue(1.0),
             ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))->get());
 }
 
@@ -1416,7 +1422,7 @@ TEST_F(EngineSyncTest, HalfDoubleBpmTest) {
     EXPECT_EQ(1.0,
             m_pChannel2->getEngineBuffer()
                     ->m_pSyncControl->m_masterBpmAdjustFactor);
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             m_pChannel1->getEngineBuffer()->m_pSyncControl->getBeatDistance(),
             m_pChannel2->getEngineBuffer()->m_pSyncControl->getBeatDistance());
     EXPECT_EQ(0, ControlObject::get(ConfigKey(m_sGroup1, "rate")));
@@ -1430,10 +1436,10 @@ TEST_F(EngineSyncTest, HalfDoubleBpmTest) {
         ProcessBuffer();
         // The beat distances are NOT as simple as x2 or /2.  Use the built-in functions
         // to do the proper conversion.
-        EXPECT_FLOAT_EQ(m_pChannel1->getEngineBuffer()
-                                ->m_pSyncControl->getBeatDistance(),
-                m_pChannel2->getEngineBuffer()
-                        ->m_pSyncControl->getBeatDistance());
+        EXPECT_NEAR(
+                m_pChannel1->getEngineBuffer()->m_pSyncControl->getBeatDistance(),
+                m_pChannel2->getEngineBuffer()->m_pSyncControl->getBeatDistance(),
+                kMaxFloatingPointError);
     }
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(0.0);
@@ -1477,8 +1483,8 @@ TEST_F(EngineSyncTest, HalfDoubleBpmTest) {
 
     for (int i = 0; i < 50; ++i) {
         ProcessBuffer();
-        EXPECT_FLOAT_EQ(m_pChannel1->getEngineBuffer()
-                                ->m_pSyncControl->getBeatDistance(),
+        EXPECT_DOUBLE_EQ(m_pChannel1->getEngineBuffer()
+                                 ->m_pSyncControl->getBeatDistance(),
                 m_pChannel2->getEngineBuffer()
                         ->m_pSyncControl->getBeatDistance());
     }
@@ -1506,30 +1512,30 @@ TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
     // We Expect that m_sGroup1 has adjusted its own bpm to the second deck and becomes a single master.
     // When the second deck is synced the master bpm is adopted by the interna clock, which becomes now
     // the master
-    EXPECT_FLOAT_EQ(87.5,
+    EXPECT_DOUBLE_EQ(87.5,
             ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))
                     ->get());
-    EXPECT_FLOAT_EQ(87.5,
+    EXPECT_DOUBLE_EQ(87.5,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
-    EXPECT_FLOAT_EQ(175.0,
+    EXPECT_DOUBLE_EQ(175.0,
             ControlObject::getControl(ConfigKey(m_sGroup2, "bpm"))->get());
-    EXPECT_FLOAT_EQ(87.5 / 80,
+    EXPECT_DOUBLE_EQ(87.5 / 80,
             ControlObject::getControl(ConfigKey(m_sGroup1, "rate_ratio"))
                     ->get());
-    EXPECT_FLOAT_EQ(1,
+    EXPECT_DOUBLE_EQ(1,
             ControlObject::getControl(ConfigKey(m_sGroup2, "rate_ratio"))
                     ->get());
-    EXPECT_FLOAT_EQ(80,
+    EXPECT_DOUBLE_EQ(80,
             ControlObject::getControl(ConfigKey(m_sGroup1, "local_bpm"))
                     ->get());
-    EXPECT_FLOAT_EQ(175.0,
+    EXPECT_DOUBLE_EQ(175.0,
             ControlObject::getControl(ConfigKey(m_sGroup2, "local_bpm"))
                     ->get());
 
     ControlObject::getControl(ConfigKey(m_sGroup2, "play"))->set(1.0);
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
 
-    EXPECT_FLOAT_EQ(175.0,
+    EXPECT_DOUBLE_EQ(175.0,
             ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))
                     ->get());
 
@@ -1537,7 +1543,7 @@ TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
     ProcessBuffer();
     ProcessBuffer();
 
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             m_pChannel1->getEngineBuffer()->m_pSyncControl->getBeatDistance(),
             m_pChannel2->getEngineBuffer()->m_pSyncControl->getBeatDistance());
 
@@ -1553,16 +1559,16 @@ TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
     ControlObject::getControl(ConfigKey(m_sGroup2, "play"))->set(1.0);
 
-    EXPECT_FLOAT_EQ(87.5 / 80,
+    EXPECT_DOUBLE_EQ(87.5 / 80,
             ControlObject::getControl(ConfigKey(m_sGroup1, "rate_ratio"))
                     ->get());
-    EXPECT_FLOAT_EQ(1,
+    EXPECT_DOUBLE_EQ(1,
             ControlObject::getControl(ConfigKey(m_sGroup2, "rate_ratio"))
                     ->get());
 
     ProcessBuffer();
 
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             (m_pChannel1->getEngineBuffer()->m_pSyncControl->getBeatDistance()),
             (m_pChannel2->getEngineBuffer()
                             ->m_pSyncControl->getBeatDistance()));
@@ -1570,10 +1576,10 @@ TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
     ProcessBuffer();
     ProcessBuffer();
 
-    EXPECT_FLOAT_EQ(87.5,
+    EXPECT_DOUBLE_EQ(87.5,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
 
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             (m_pChannel1->getEngineBuffer()->m_pSyncControl->getBeatDistance()),
             (m_pChannel2->getEngineBuffer()
                             ->m_pSyncControl->getBeatDistance()));
@@ -1582,7 +1588,7 @@ TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
     ProcessBuffer();
     ProcessBuffer();
 
-    EXPECT_FLOAT_EQ(
+    EXPECT_DOUBLE_EQ(
             m_pChannel1->getEngineBuffer()->m_pSyncControl->getBeatDistance(),
             m_pChannel2->getEngineBuffer()->m_pSyncControl->getBeatDistance());
 }
@@ -1600,12 +1606,12 @@ TEST_F(EngineSyncTest, HalfDoubleInternalClockTest) {
     ControlObject::getControl(ConfigKey(m_sGroup1, "sync_enabled"))->set(1);
     ControlObject::getControl(ConfigKey(m_sGroup2, "sync_enabled"))->set(1);
 
-    EXPECT_FLOAT_EQ(70.0,
+    EXPECT_DOUBLE_EQ(70.0,
             ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))
                     ->get());
-    EXPECT_FLOAT_EQ(getRateSliderValue(1.0),
+    EXPECT_DOUBLE_EQ(getRateSliderValue(1.0),
             ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))->get());
-    EXPECT_FLOAT_EQ(getRateSliderValue(1.0),
+    EXPECT_DOUBLE_EQ(getRateSliderValue(1.0),
             ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))->get());
 }
 
@@ -1638,23 +1644,23 @@ TEST_F(EngineSyncTest, HalfDoubleConsistency) {
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
     ControlObject::getControl(ConfigKey(m_sGroup2, "sync_enabled"))->set(1);
-    EXPECT_FLOAT_EQ(180.0,
+    EXPECT_DOUBLE_EQ(180.0,
             ControlObject::getControl(ConfigKey(m_sGroup2, "bpm"))->get());
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
     ControlObject::getControl(ConfigKey(m_sGroup1, "sync_enabled"))->set(1);
-    EXPECT_FLOAT_EQ(90.0,
+    EXPECT_DOUBLE_EQ(90.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
-    EXPECT_FLOAT_EQ(180.0,
+    EXPECT_DOUBLE_EQ(180.0,
             ControlObject::getControl(ConfigKey(m_sGroup2, "bpm"))->get());
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "sync_enabled"))->set(0);
     ProcessBuffer();
     ControlObject::getControl(ConfigKey(m_sGroup1, "sync_enabled"))->set(1);
     ProcessBuffer();
-    EXPECT_FLOAT_EQ(90.0,
+    EXPECT_DOUBLE_EQ(90.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
-    EXPECT_FLOAT_EQ(180.0,
+    EXPECT_DOUBLE_EQ(180.0,
             ControlObject::getControl(ConfigKey(m_sGroup2, "bpm"))->get());
 }
 
@@ -1693,20 +1699,18 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
     ProcessBuffer();
 
     // Internal clock rate should be set and beat distance already updated
-    EXPECT_FLOAT_EQ(100.0,
+    EXPECT_DOUBLE_EQ(100.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
-    EXPECT_FLOAT_EQ(0.019349962,
-            ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))
-                    ->get());
+    EXPECT_NEAR(0.019349962,
+            ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->get(),
+            kMaxFloatingPointError);
 
     // The internal clock must also have been advanced to the same fraction of a beat.
-    EXPECT_FLOAT_EQ(100.0,
-            ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))
-                    ->get());
-    EXPECT_FLOAT_EQ(0.019349962,
-            ControlObject::getControl(
-                    ConfigKey(m_sInternalClockGroup, "beat_distance"))
-                    ->get());
+    EXPECT_DOUBLE_EQ(100.0,
+            ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))->get());
+    EXPECT_NEAR(0.019349962,
+            ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "beat_distance"))->get(),
+            kMaxFloatingPointError);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(0.0);
 
@@ -1714,13 +1718,12 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
 
     // we expect that Deck 1 distance has not changed and the internal clock has continued
     // with the same rate
-    EXPECT_FLOAT_EQ(0.019349962,
-            ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))
-                    ->get());
-    EXPECT_FLOAT_EQ(0.019349962,
-            ControlObject::getControl(
-                    ConfigKey(m_sInternalClockGroup, "beat_distance"))
-                    ->get());
+    EXPECT_NEAR(0.019349962,
+            ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->get(),
+            kMaxFloatingPointError);
+    EXPECT_NEAR(0.019349962,
+            ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "beat_distance"))->get(),
+            kMaxFloatingPointError);
 
     // Now make the second deck playing and see if it works.
     ControlObject::getControl(ConfigKey(m_sGroup2, "play"))->set(1.0);
@@ -1735,24 +1738,22 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
     // rid of the additional buffer ahead
     // TODO: It does sounds odd to start the track 1 at a random position and adjust the
     // phase later. Seeking into phase is the best option even with quantize off.
-    EXPECT_FLOAT_EQ(100.0,
+    EXPECT_DOUBLE_EQ(100.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
     // The adjustment is calculated here: BpmControl::calcSyncAdjustment
-    EXPECT_GT(0.038699925,
-            ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))
-                    ->get());
-    EXPECT_FLOAT_EQ(100.0,
+    EXPECT_GT(0.038699925, ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->get());
+    EXPECT_DOUBLE_EQ(100.0,
             ControlObject::getControl(ConfigKey(m_sGroup2, "bpm"))->get());
-    EXPECT_FLOAT_EQ(0.019349962,
-            ControlObject::getControl(ConfigKey(m_sGroup2, "beat_distance"))
-                    ->get());
-    EXPECT_FLOAT_EQ(100.0,
-            ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))
-                    ->get());
-    EXPECT_FLOAT_EQ(0.038699925,
-            ControlObject::getControl(
-                    ConfigKey(m_sInternalClockGroup, "beat_distance"))
-                    ->get());
+    EXPECT_NEAR(
+            0.019349962,
+            ControlObject::getControl(ConfigKey(m_sGroup2, "beat_distance"))->get(),
+            kMaxFloatingPointError);
+    EXPECT_DOUBLE_EQ(100.0,
+            ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))->get());
+    EXPECT_NEAR(
+            0.038699925,
+            ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "beat_distance"))->get(),
+            kMaxFloatingPointError);
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 0.0);
     pButtonSyncEnabled1->set(0.0);
@@ -1772,11 +1773,11 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
     // This will sync to the first deck here and not the second (lp1784185)
     pButtonSyncEnabled3->set(1.0);
     ProcessBuffer();
-    EXPECT_FLOAT_EQ(130.0, ControlObject::get(ConfigKey(m_sGroup3, "bpm")));
+    EXPECT_DOUBLE_EQ(130.0, ControlObject::get(ConfigKey(m_sGroup3, "bpm")));
     // revert that
     ControlObject::set(ConfigKey(m_sGroup3, "rate_ratio"), 1.0);
     ProcessBuffer();
-    EXPECT_FLOAT_EQ(140.0, ControlObject::get(ConfigKey(m_sGroup3, "bpm")));
+    EXPECT_DOUBLE_EQ(140.0, ControlObject::get(ConfigKey(m_sGroup3, "bpm")));
     // now we have Deck 3 with 140 bpm and sync enabled
 
     pButtonSyncEnabled1->set(1.0);
@@ -1788,10 +1789,10 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
     ProcessBuffer();
 
     // We expect Deck 1 is Deck 3 bpm
-    EXPECT_FLOAT_EQ(140.0,
+    EXPECT_DOUBLE_EQ(140.0,
             ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))
                     ->get());
-    EXPECT_FLOAT_EQ(140.0,
+    EXPECT_DOUBLE_EQ(140.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
     // The exact beat distance will be one buffer past .6, but this is good
     // enough to confirm that it worked.
@@ -1851,7 +1852,7 @@ TEST_F(EngineSyncTest, UserTweakBeatDistance) {
                     ->get(),
             .00001);
 
-    EXPECT_FLOAT_EQ(0.0,
+    EXPECT_DOUBLE_EQ(0.0,
             m_pChannel1->getEngineBuffer()
                     ->m_pBpmControl->m_dUserOffset.getValue());
 }
@@ -1874,15 +1875,17 @@ TEST_F(EngineSyncTest, UserTweakPreservedInSeek) {
     ControlObject::set(ConfigKey(m_sGroup2, "play"), 1.0);
 
     ProcessBuffer();
-    EXPECT_FLOAT_EQ(kDivisibleBpm,
+    EXPECT_DOUBLE_EQ(kDivisibleBpm,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
-    EXPECT_FLOAT_EQ(kDivisibleBpm,
+    EXPECT_DOUBLE_EQ(kDivisibleBpm,
             ControlObject::getControl(ConfigKey(m_sGroup2, "bpm"))->get());
 
-    EXPECT_FLOAT_EQ(0.024806201,
-            ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")));
-    EXPECT_FLOAT_EQ(0.0023219956,
-            ControlObject::get(ConfigKey(m_sGroup1, "playposition")));
+    EXPECT_NEAR(0.024806201,
+            ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")),
+            kMaxFloatingPointError);
+    EXPECT_NEAR(0.0023219956,
+            ControlObject::get(ConfigKey(m_sGroup1, "playposition")),
+            kMaxFloatingPointError);
 
     ControlObject::set(ConfigKey(m_sGroup2, "playposition"), 0.2);
     ProcessBuffer();
@@ -1892,13 +1895,19 @@ TEST_F(EngineSyncTest, UserTweakPreservedInSeek) {
     // We are a few buffers past the seeked position.  It's less than 0.2 because
     // of quantizing.  The playpositions are different because the tracks are at
     // different bpms.
-    EXPECT_FLOAT_EQ(0.19417687, ControlObject::get(ConfigKey(m_sGroup1, "playposition")));
-    EXPECT_FLOAT_EQ(0.19148479, ControlObject::get(ConfigKey(m_sGroup2, "playposition")));
+    EXPECT_NEAR(0.19417687,
+            ControlObject::get(ConfigKey(m_sGroup1, "playposition")),
+            kMaxFloatingPointError);
+    EXPECT_NEAR(0.19148479,
+            ControlObject::get(ConfigKey(m_sGroup2, "playposition")),
+            kMaxFloatingPointError);
     // The beat distances are identical though.
-    EXPECT_FLOAT_EQ(0.074418604,
-            ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")));
-    EXPECT_FLOAT_EQ(0.074418604,
-            ControlObject::get(ConfigKey(m_sGroup2, "beat_distance")));
+    EXPECT_NEAR(0.074418604,
+            ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")),
+            kMaxFloatingPointError);
+    EXPECT_NEAR(0.074418604,
+            ControlObject::get(ConfigKey(m_sGroup2, "beat_distance")),
+            kMaxFloatingPointError);
 
     // Apply user tweak offset.
     m_pChannel1->getEngineBuffer()
@@ -1912,12 +1921,18 @@ TEST_F(EngineSyncTest, UserTweakPreservedInSeek) {
 
     // Now, the locations are much more different - but the beat distance appears
     // to be the same because beat distance CO hides the user offset.
-    EXPECT_FLOAT_EQ(0.2269025, ControlObject::get(ConfigKey(m_sGroup1, "playposition")));
-    EXPECT_FLOAT_EQ(0.1960644, ControlObject::get(ConfigKey(m_sGroup2, "playposition")));
-    EXPECT_FLOAT_EQ(0.12403101,
-            ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")));
-    EXPECT_FLOAT_EQ(0.12403101,
-            ControlObject::get(ConfigKey(m_sGroup2, "beat_distance")));
+    EXPECT_NEAR(0.2269025,
+            ControlObject::get(ConfigKey(m_sGroup1, "playposition")),
+            kMaxFloatingPointError);
+    EXPECT_NEAR(0.1960644,
+            ControlObject::get(ConfigKey(m_sGroup2, "playposition")),
+            kMaxFloatingPointError);
+    EXPECT_NEAR(0.12403101,
+            ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")),
+            kMaxFloatingPointError);
+    EXPECT_NEAR(0.12403101,
+            ControlObject::get(ConfigKey(m_sGroup2, "beat_distance")),
+            kMaxFloatingPointError);
 }
 
 TEST_F(EngineSyncTest, MasterBpmNeverZero) {
@@ -2178,8 +2193,8 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
     ProcessBuffer();
 
     ASSERT_TRUE(isSoftMaster(m_sGroup1));
-    EXPECT_FLOAT_EQ(130.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
-    EXPECT_FLOAT_EQ(130.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
+    EXPECT_DOUBLE_EQ(130.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
+    EXPECT_DOUBLE_EQ(130.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 
     // sync 0 bpm track to the first one
     pButtonSyncEnabled2->set(1.0);
@@ -2190,9 +2205,9 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
     // expect no change in Deck 1
     ASSERT_TRUE(isSoftMaster(m_sGroup1));
     ASSERT_TRUE(isFollower(m_sGroup2));
-    EXPECT_FLOAT_EQ(130.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
-    EXPECT_FLOAT_EQ(0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
-    EXPECT_FLOAT_EQ(130.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
+    EXPECT_DOUBLE_EQ(130.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
+    EXPECT_DOUBLE_EQ(0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
+    EXPECT_DOUBLE_EQ(130.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 0.0);
 
@@ -2211,9 +2226,9 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
     ASSERT_TRUE(isSoftMaster(m_sGroup2));
     ASSERT_TRUE(isFollower(m_sGroup1));
     ASSERT_TRUE(isFollower(m_sInternalClockGroup));
-    EXPECT_FLOAT_EQ(130.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
-    EXPECT_FLOAT_EQ(130.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
-    EXPECT_FLOAT_EQ(130.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
+    EXPECT_DOUBLE_EQ(130.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
+    EXPECT_DOUBLE_EQ(130.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
+    EXPECT_DOUBLE_EQ(130.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 
     // Play Both Tracks.
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
@@ -2231,10 +2246,10 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
 
     // we expect that the new beatgrid is aligned to the other playing track
     // Not the case before fixing lp1808698
-    EXPECT_FLOAT_EQ(130.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
+    EXPECT_DOUBLE_EQ(130.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
     // Expect to sync on half beats
-    EXPECT_FLOAT_EQ(65.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
-    EXPECT_FLOAT_EQ(130.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
+    EXPECT_DOUBLE_EQ(65.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
+    EXPECT_DOUBLE_EQ(130.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 }
 
 TEST_F(EngineSyncTest, BeatMapQantizePlay) {
@@ -2262,7 +2277,7 @@ TEST_F(EngineSyncTest, BeatMapQantizePlay) {
 
     ProcessBuffer();
 
-    EXPECT_FLOAT_EQ(m_pChannel1->getEngineBuffer()->m_pSyncControl->getBeatDistance(),
+    EXPECT_DOUBLE_EQ(m_pChannel1->getEngineBuffer()->m_pSyncControl->getBeatDistance(),
             m_pChannel2->getEngineBuffer()->m_pSyncControl->getBeatDistance());
 }
 
@@ -2273,8 +2288,8 @@ TEST_F(EngineSyncTest, BpmAdjustFactor) {
     m_pMixerDeck2->loadFakeTrack(false, 150.0);
     ProcessBuffer();
 
-    EXPECT_FLOAT_EQ(40.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
-    EXPECT_FLOAT_EQ(150.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
+    EXPECT_DOUBLE_EQ(40.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
+    EXPECT_DOUBLE_EQ(150.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
     ProcessBuffer();
@@ -2283,8 +2298,8 @@ TEST_F(EngineSyncTest, BpmAdjustFactor) {
     ProcessBuffer();
 
     // group 2 should be synced to the first playing deck and becomes master
-    EXPECT_FLOAT_EQ(40.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
-    EXPECT_FLOAT_EQ(80.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
+    EXPECT_DOUBLE_EQ(40.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
+    EXPECT_DOUBLE_EQ(80.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
     ASSERT_TRUE(isSoftMaster(m_sGroup2));
     assertSyncOff(m_sGroup1);
 
@@ -2300,8 +2315,8 @@ TEST_F(EngineSyncTest, BpmAdjustFactor) {
 
     // Group 1 should be already in sync, it must not change due to sync
     // and Group 2 must also remain.
-    EXPECT_FLOAT_EQ(40.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
-    EXPECT_FLOAT_EQ(80.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
+    EXPECT_DOUBLE_EQ(40.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
+    EXPECT_DOUBLE_EQ(80.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
     ASSERT_TRUE(isFollower(m_sGroup1));
     ASSERT_TRUE(isFollower(m_sGroup2));
     ASSERT_TRUE(isSoftMaster(m_sInternalClockGroup));

--- a/src/test/metaknob_link_test.cpp
+++ b/src/test/metaknob_link_test.cpp
@@ -259,5 +259,5 @@ TEST_F(MetaLinkTest, HalfLinkTakeover) {
     m_pEffectSlot->syncSofttakeover();
     newParam = 0.5 + SoftTakeover::kDefaultTakeoverThreshold * 1.5;
     m_pEffectSlot->slotEffectMetaParameter(newParam);
-    EXPECT_FLOAT_EQ(0.0703125, m_pControlValue->get());
+    EXPECT_DOUBLE_EQ(0.0703125, m_pControlValue->get());
 }

--- a/src/test/replaygaintest.cpp
+++ b/src/test/replaygaintest.cpp
@@ -15,7 +15,7 @@ class ReplayGainTest : public testing::Test {
         const double actualValue = mixxx::ReplayGain::ratioFromString(inputValue, &actualResult);
 
         EXPECT_EQ(expectedResult, actualResult);
-        EXPECT_FLOAT_EQ(expectedValue, actualValue);
+        EXPECT_NEAR(expectedValue, actualValue, 0.005);
 
         return actualResult;
     }
@@ -93,8 +93,7 @@ TEST_F(ReplayGainTest, RatioFromStringValidRange) {
                 QString("  %1 DB ").arg(replayGainDb),
                 QString("  %1db ").arg(replayGainDb)
         };
-        float expectedValue;
-        expectedValue = db2ratio(double(replayGainDb));
+        const auto expectedValue = static_cast<float>(db2ratio(static_cast<double>(replayGainDb)));
         for (size_t i = 0; i < sizeof(inputValues) / sizeof(inputValues[0]); ++i) {
             ratioFromString(inputValues[i], true, expectedValue);
             if (0 <= replayGainDb) {
@@ -133,8 +132,8 @@ TEST_F(ReplayGainTest, PeakFromStringValid) {
     peakFromString("+1", true, mixxx::ReplayGain::kPeakClip);
     peakFromString("1.0", true, mixxx::ReplayGain::kPeakClip);
     peakFromString("+1.0", true, mixxx::ReplayGain::kPeakClip);
-    peakFromString("  0.12345  ", true, 0.12345);
-    peakFromString("  1.2345", true, 1.2345);
+    peakFromString("  0.12345  ", true, 0.12345f);
+    peakFromString("  1.2345", true, 1.2345f);
 }
 
 TEST_F(ReplayGainTest, PeakFromStringInvalid) {

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -72,7 +72,8 @@ void BeatGrid::setGrid(double dBpm, double dFirstBeatSample) {
 
     QMutexLocker lock(&m_mutex);
     m_grid.mutable_bpm()->set_bpm(dBpm);
-    m_grid.mutable_first_beat()->set_frame_position(dFirstBeatSample / kFrameSize);
+    m_grid.mutable_first_beat()->set_frame_position(
+            static_cast<google::protobuf::int32>(dFirstBeatSample / kFrameSize));
     // Calculate beat length as sample offsets
     m_dBeatLength = (60.0 * m_iSampleRate / dBpm) * kFrameSize;
 }
@@ -320,7 +321,8 @@ void BeatGrid::translate(double dNumSamples) {
         return;
     }
     double newFirstBeatFrames = (firstBeatSample() + dNumSamples) / kFrameSize;
-    m_grid.mutable_first_beat()->set_frame_position(newFirstBeatFrames);
+    m_grid.mutable_first_beat()->set_frame_position(
+            static_cast<google::protobuf::int32>(newFirstBeatFrames));
     locker.unlock();
     emit updated();
 }

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -145,7 +145,7 @@ void BeatMap::createFromBeatVector(const QVector<double>& beats) {
             qDebug() << "BeatMap::createFromVector: beats not in increasing order or negative";
             qDebug() << "discarding beat " << beatpos;
         } else {
-            beat.set_frame_position(beatpos);
+            beat.set_frame_position(static_cast<google::protobuf::int32>(beatpos));
             m_beats.append(beat);
             previous_beatpos = beatpos;
         }
@@ -205,7 +205,7 @@ double BeatMap::findNthBeat(double dSamples, int n) const {
 
     Beat beat;
     // Reduce sample offset to a frame offset.
-    beat.set_frame_position(samplesToFrames(dSamples));
+    beat.set_frame_position(static_cast<google::protobuf::int32>(samplesToFrames(dSamples)));
 
     // it points at the first occurrence of beat or the next largest beat
     BeatList::const_iterator it =
@@ -296,7 +296,7 @@ bool BeatMap::findPrevNextBeats(double dSamples,
 
     Beat beat;
     // Reduce sample offset to a frame offset.
-    beat.set_frame_position(samplesToFrames(dSamples));
+    beat.set_frame_position(static_cast<google::protobuf::int32>(samplesToFrames(dSamples)));
 
     // it points at the first occurrence of beat or the next largest beat
     BeatList::const_iterator it =
@@ -379,8 +379,9 @@ std::unique_ptr<BeatIterator> BeatMap::findBeats(double startSample, double stop
     }
 
     Beat startBeat, stopBeat;
-    startBeat.set_frame_position(samplesToFrames(startSample));
-    stopBeat.set_frame_position(samplesToFrames(stopSample));
+    startBeat.set_frame_position(
+            static_cast<google::protobuf::int32>(samplesToFrames(startSample)));
+    stopBeat.set_frame_position(static_cast<google::protobuf::int32>(samplesToFrames(stopSample)));
 
     BeatList::const_iterator curBeat =
             std::lower_bound(m_beats.constBegin(), m_beats.constEnd(),
@@ -420,8 +421,9 @@ double BeatMap::getBpmRange(double startSample, double stopSample) const {
     if (!isValid())
         return -1;
     Beat startBeat, stopBeat;
-    startBeat.set_frame_position(samplesToFrames(startSample));
-    stopBeat.set_frame_position(samplesToFrames(stopSample));
+    startBeat.set_frame_position(
+            static_cast<google::protobuf::int32>(samplesToFrames(startSample)));
+    stopBeat.set_frame_position(static_cast<google::protobuf::int32>(samplesToFrames(stopSample)));
     return calculateBpm(startBeat, stopBeat);
 }
 
@@ -451,15 +453,16 @@ double BeatMap::getBpmAroundPosition(double curSample, int n) const {
     }
 
     Beat startBeat, stopBeat;
-    startBeat.set_frame_position(samplesToFrames(lower_bound));
-    stopBeat.set_frame_position(samplesToFrames(upper_bound));
+    startBeat.set_frame_position(
+            static_cast<google::protobuf::int32>(samplesToFrames(lower_bound)));
+    stopBeat.set_frame_position(static_cast<google::protobuf::int32>(samplesToFrames(upper_bound)));
     return calculateBpm(startBeat, stopBeat);
 }
 
 void BeatMap::addBeat(double dBeatSample) {
     QMutexLocker locker(&m_mutex);
     Beat beat;
-    beat.set_frame_position(samplesToFrames(dBeatSample));
+    beat.set_frame_position(static_cast<google::protobuf::int32>(samplesToFrames(dBeatSample)));
     BeatList::iterator it = std::lower_bound(
         m_beats.begin(), m_beats.end(), beat, BeatLessThan);
 
@@ -478,7 +481,7 @@ void BeatMap::addBeat(double dBeatSample) {
 void BeatMap::removeBeat(double dBeatSample) {
     QMutexLocker locker(&m_mutex);
     Beat beat;
-    beat.set_frame_position(samplesToFrames(dBeatSample));
+    beat.set_frame_position(static_cast<google::protobuf::int32>(samplesToFrames(dBeatSample)));
     BeatList::iterator it = std::lower_bound(
         m_beats.begin(), m_beats.end(), beat, BeatLessThan);
 
@@ -505,7 +508,7 @@ void BeatMap::translate(double dNumSamples) {
          it != m_beats.end(); ) {
         double newpos = it->frame_position() + dNumFrames;
         if (newpos >= 0) {
-            it->set_frame_position(newpos);
+            it->set_frame_position(static_cast<google::protobuf::int32>(newpos));
             ++it;
         } else {
             it = m_beats.erase(it);

--- a/src/track/keyfactory.cpp
+++ b/src/track/keyfactory.cpp
@@ -96,7 +96,7 @@ Keys KeyFactory::makePreferredKeys(
 
             KeyMap::KeyChange* pChange = key_map.add_key_change();
             pChange->set_key(it->first);
-            pChange->set_frame_position(frame);
+            pChange->set_frame_position(static_cast<int>(frame));
         }
         key_map.set_global_key(KeyUtils::calculateGlobalKey(key_changes, iTotalSamples, iSampleRate));
         key_map.set_source(mixxx::track::io::key::ANALYZER);


### PR DESCRIPTION
Only `beatgrid.cpp` and `beatmap.h` are left.