### PR TITLE
Implement CO for waveform alpha and prefilter waveform

### DIFF
--- a/res/shaders/filteredsignal.frag
+++ b/res/shaders/filteredsignal.frag
@@ -16,6 +16,8 @@ uniform float midGain;
 uniform float highGain;
 uniform float firstVisualIndex;
 uniform float lastVisualIndex;
+uniform float alpha;
+uniform float alphaUnscaled;
 
 uniform sampler2D waveformDataTexture;
 
@@ -90,35 +92,35 @@ void main(void) {
     }
 
     if (lowShowingUnscaled) {
-      float lowAlpha = 0.2;
+      float lowAlpha = alphaUnscaled;
       outputColor.xyz = mix(outputColor.xyz, lowColor.xyz, lowAlpha);
       outputColor.w = 1.0;
     }
     if (midShowingUnscaled) {
-      float midAlpha = 0.2;
+      float midAlpha = alphaUnscaled;
       outputColor.xyz = mix(outputColor.xyz, midColor.xyz, midAlpha);
       outputColor.w = 1.0;
     }
     if (highShowingUnscaled) {
-      float highAlpha = 0.2;
+      float highAlpha = alphaUnscaled;
       outputColor.xyz = mix(outputColor.xyz, highColor.xyz, highAlpha);
       outputColor.w = 1.0;
     }
 
     if (lowShowing) {
-      float lowAlpha = 0.8;
+      float lowAlpha = alpha;
       outputColor.xyz = mix(outputColor.xyz, lowColor.xyz, lowAlpha);
       outputColor.w = 1.0;
     }
 
     if (midShowing) {
-      float midAlpha = 0.85;
+      float midAlpha = min(alpha+0.05, 1.0);
       outputColor.xyz = mix(outputColor.xyz, midColor.xyz, midAlpha);
       outputColor.w = 1.0;
     }
 
     if (highShowing) {
-      float highAlpha = 0.9;
+      float highAlpha = min(alpha+0.1, 1.0);
       outputColor.xyz = mix(outputColor.xyz, highColor.xyz, highAlpha);
       outputColor.w = 1.0;
     }

--- a/res/shaders/rgbsignal.frag
+++ b/res/shaders/rgbsignal.frag
@@ -16,6 +16,9 @@ uniform float midGain;
 uniform float highGain;
 uniform float firstVisualIndex;
 uniform float lastVisualIndex;
+uniform float alpha;
+uniform float alphaUnscaled;
+
 
 uniform sampler2D waveformDataTexture;
 
@@ -116,13 +119,11 @@ void main(void) {
     }
 
     if (showingUnscaled) {
-      float alpha = 0.4;
-      outputColor.xyz = mix(outputColor.xyz, showingUnscaledColor.xyz, alpha);
+      outputColor.xyz = mix(outputColor.xyz, showingUnscaledColor.xyz, alphaUnscaled);
       outputColor.w = 1.0;
     }
 
     if (showing) {
-      float alpha = 0.8;
       outputColor.xyz = mix(outputColor.xyz, showingColor.xyz, alpha);
       outputColor.w = 1.0;
     }

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -103,6 +103,9 @@ DlgPrefEQ::~DlgPrefEQ() {
 
     qDeleteAll(m_filterWaveformEnableCOs);
     m_filterWaveformEnableCOs.clear();
+
+    qDeleteAll(m_filterWaveformPrefilterAlphaCOs);
+    m_filterWaveformPrefilterAlphaCOs.clear();
 }
 
 void DlgPrefEQ::slotNumDecksChanged(double numDecks) {

--- a/src/preferences/dialog/dlgprefeq.h
+++ b/src/preferences/dialog/dlgprefeq.h
@@ -96,6 +96,7 @@ class DlgPrefEQ : public DlgPreferencePage, public Ui::DlgPrefEQDlg  {
     QList<QComboBox*> m_deckQuickEffectSelectors;
     QList<bool> m_filterWaveformEffectLoaded;
     QList<ControlObject*> m_filterWaveformEnableCOs;
+    QList<ControlObject*> m_filterWaveformPrefilterAlphaCOs;
     ControlProxy* m_pNumDecks;
 
     bool m_inSlotPopulateDeckEffectSelectors;

--- a/src/preferences/dialog/dlgprefwaveform.h
+++ b/src/preferences/dialog/dlgprefwaveform.h
@@ -6,6 +6,7 @@
 #include "preferences/dialog/ui_dlgprefwaveformdlg.h"
 #include "preferences/usersettings.h"
 #include "preferences/dlgpreferencepage.h"
+#include "control/controlobject.h"
 
 class MixxxMainWindow;
 class Library;
@@ -38,6 +39,10 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
     void slotClearCachedWaveforms();
     void slotSetBeatGridAlpha(int alpha);
     void slotSetPlayMarkerPosition(int position);
+    void slotSetWaveformAlpha(int alpha);
+    void slotSetWaveformPrefilterAlpha(int alpha);
+    void slotCOWaveformAlpha(double alpha);
+    void slotCOWaveformPrefilterAlpha(double alpha);
 
   private:
     void initWaveformControl();
@@ -46,6 +51,8 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
     UserSettingsPointer m_pConfig;
     Library* m_pLibrary;
     MixxxMainWindow* m_pMixxx;
+    ControlObject* m_pCOWaveformAlpha;
+    ControlObject* m_pCOWaveformAlphaPrefilter;
 };
 
 

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -6,162 +6,39 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>677</width>
-    <height>528</height>
+    <width>741</width>
+    <height>776</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Waveform Preferences</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout_2">
-     <item row="10" column="0">
-      <widget class="QLabel" name="visualGainLabel">
-       <property name="text">
-        <string>Visual gain</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-       </property>
-       <property name="buddy">
-        <cstring>allVisualGain</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1" colspan="2">
-      <widget class="QSlider" name="endOfTrackWarningTimeSlider">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="minimum">
-        <number>0</number>
-       </property>
+     <item row="12" column="1">
+      <widget class="QSlider" name="waveformAlphaPrefilterSlider">
        <property name="maximum">
-        <number>60</number>
+        <number>100</number>
        </property>
-       <property name="value">
-        <number>30</number>
+       <property name="sliderPosition">
+        <number>0</number>
        </property>
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="1">
-      <widget class="QCheckBox" name="normalizeOverviewCheckBox">
-       <property name="text">
-        <string>Normalize waveform overview</string>
-       </property>
-      </widget>
-     </item>
-     <item row="13" column="1">
-      <widget class="QLabel" name="openGlStatusIcon">
-       <property name="toolTip">
-        <string>Displays which OpenGL version is supported by the current platform.</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="3">
-      <widget class="QSpinBox" name="endOfTrackWarningTimeSpinBox">
-       <property name="toolTip">
-        <string>Highlight the waveforms when the last seconds of a track remains.</string>
-       </property>
-       <property name="suffix">
-        <string> seconds</string>
-       </property>
-       <property name="minimum">
-        <number>0</number>
-       </property>
-       <property name="maximum">
-        <number>60</number>
-       </property>
-       <property name="value">
-        <number>30</number>
-       </property>
-      </widget>
-     </item>
-     <item row="14" column="0">
-      <widget class="QLabel" name="openGlStatusLabel_2">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>Average frame rate</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="frameRateLabel">
-       <property name="text">
-        <string>Frame rate</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-       </property>
-       <property name="buddy">
-        <cstring>frameRateSlider</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="1" colspan="3">
-      <widget class="QComboBox" name="defaultZoomComboBox"/>
-     </item>
-
-     <item row="12" column="0" colspan="4">
-      <widget class="Line" name="line">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="13" column="0">
-      <widget class="QLabel" name="openGlStatusLabel">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>OpenGL status</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="waveformTypeLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string extracomment="The big waveform summary shows the waveform envelope of the track near the current playback position."/>
-       </property>
-       <property name="text">
-        <string>Waveform type</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-       </property>
-       <property name="buddy">
-        <cstring>waveformTypeComboBox</cstring>
        </property>
       </widget>
      </item>
@@ -297,39 +174,29 @@
        </item>
       </layout>
      </item>
-     <item row="1" column="1" colspan="3">
-      <widget class="QComboBox" name="waveformOverviewComboBox">
-       <property name="toolTip">
-        <string>The waveform overview shows the waveform envelope of the entire track.
-Select from different types of displays for the waveform overview, which differ primarily in the level of detail shown in the waveform.</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1" colspan="3">
-      <widget class="QComboBox" name="waveformTypeComboBox">
-       <property name="toolTip">
-        <string>The waveform shows the waveform envelope of the track near the current playback position.
-Select from different types of displays for the waveform, which differ primarily in the level of detail shown in the waveform.</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="waveformOverviewLabel">
-       <property name="toolTip">
-        <string extracomment="The smaller, zoomed-out version of the waveform shows the various markers within the track as well as the waveform envelope of the entire track."/>
-       </property>
+     <item row="13" column="0">
+      <widget class="QLabel" name="cachedWaveforms">
        <property name="text">
-        <string>Waveform overview type</string>
+        <string>Caching</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
        </property>
       </widget>
      </item>
-     <item row="14" column="1">
-      <widget class="QLabel" name="frameRateAverage">
+     <item row="4" column="0">
+      <widget class="QLabel" name="BeatgridWaveform">
        <property name="toolTip">
-        <string>Displays the actual frame rate.</string>
-       </property>
-       <property name="text">
         <string/>
+       </property>
+       <property name="midLineWidth">
+        <number>6</number>
+       </property>
+       <property name="text">
+        <string>Beat grid opacity</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
        </property>
       </widget>
      </item>
@@ -374,59 +241,7 @@ Select from different types of displays for the waveform, which differ primarily
        </property>
       </widget>
      </item>
-     <item row="2" column="3">
-      <widget class="QSpinBox" name="frameRateSpinBox">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="suffix">
-        <string> fps</string>
-       </property>
-       <property name="minimum">
-        <number>10</number>
-       </property>
-       <property name="maximum">
-        <number>60</number>
-       </property>
-       <property name="value">
-        <number>30</number>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="defaultZoomLabel">
-       <property name="text">
-        <string extracomment="Waveform zoom">Default zoom level</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-       </property>
-       <property name="buddy">
-        <cstring>defaultZoomComboBox</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="1" colspan="3">
-      <widget class="QCheckBox" name="synchronizeZoomCheckBox">
-       <property name="toolTip">
-        <string>Synchronize zoom level across all waveform displays.</string>
-       </property>
-       <property name="text">
-        <string>Synchronize zoom level across all waveforms</string>
-       </property>
-      </widget>
-     </item>
-     <item row="11" column="0">
-      <widget class="QLabel" name="cachedWaveforms">
-       <property name="text">
-        <string>Caching</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-       </property>
-      </widget>
-     </item>
-     <item row="11" column="1" colspan="3">
+     <item row="13" column="1" colspan="3">
       <layout class="QGridLayout" name="cachingGridLayout">
        <item row="3" column="1">
         <widget class="QPushButton" name="clearCachedWaveforms">
@@ -471,29 +286,281 @@ Select from different types of displays for the waveform, which differ primarily
        </item>
       </layout>
      </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="BeatgridWaveform">
+     <item row="2" column="3">
+      <widget class="QSpinBox" name="frameRateSpinBox">
        <property name="toolTip">
         <string/>
        </property>
-       <property name="midLineWidth">
-        <number>6</number>
+       <property name="suffix">
+        <string> fps</string>
+       </property>
+       <property name="minimum">
+        <number>10</number>
+       </property>
+       <property name="maximum">
+        <number>60</number>
+       </property>
+       <property name="value">
+        <number>30</number>
+       </property>
+      </widget>
+     </item>
+     <item row="15" column="0">
+      <widget class="QLabel" name="openGlStatusLabel">
+       <property name="toolTip">
+        <string/>
        </property>
        <property name="text">
-        <string>Beat grid opacity</string>
+        <string>OpenGL status</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
-      <widget class="QSlider" name="beatGridAlphaSlider">
+     <item row="3" column="1" colspan="2">
+      <widget class="QSlider" name="endOfTrackWarningTimeSlider">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="minimum">
+        <number>0</number>
+       </property>
+       <property name="maximum">
+        <number>60</number>
+       </property>
+       <property name="value">
+        <number>30</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="16" column="1">
+      <widget class="QLabel" name="frameRateAverage">
+       <property name="toolTip">
+        <string>Displays the actual frame rate.</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="waveformOverviewLabel">
+       <property name="toolTip">
+        <string extracomment="The smaller, zoomed-out version of the waveform shows the various markers within the track as well as the waveform envelope of the entire track."/>
+       </property>
+       <property name="text">
+        <string>Waveform overview type</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="frameRateLabel">
+       <property name="text">
+        <string>Frame rate</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+       <property name="buddy">
+        <cstring>frameRateSlider</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="0">
+      <widget class="QLabel" name="waveformAlphaLabel">
+       <property name="text">
+        <string>Waveform opacity</string>
+       </property>
+      </widget>
+     </item>
+     <item row="15" column="1">
+      <widget class="QLabel" name="openGlStatusIcon">
+       <property name="toolTip">
+        <string>Displays which OpenGL version is supported by the current platform.</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="1">
+      <widget class="QCheckBox" name="normalizeOverviewCheckBox">
+       <property name="text">
+        <string>Normalize waveform overview</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1" colspan="3">
+      <widget class="QSlider" name="playMarkerPositionSlider">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Moves the play marker position on the waveforms to the left, right or center (default).</string>
+       </property>
+       <property name="minimum">
+        <number>0</number>
+       </property>
        <property name="maximum">
         <number>100</number>
        </property>
        <property name="value">
-        <number>90</number>
+        <number>50</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1" colspan="3">
+      <widget class="QComboBox" name="defaultZoomComboBox"/>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Play marker position</string>
+       </property>
+      </widget>
+     </item>
+     <item row="12" column="3">
+      <widget class="QSpinBox" name="waveformAlphaPrefilterSpinBox">
+       <property name="suffix">
+        <string>%</string>
+       </property>
+       <property name="maximum">
+        <number>100</number>
+       </property>
+      </widget>
+     </item>
+     <item row="16" column="0">
+      <widget class="QLabel" name="openGlStatusLabel_2">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Average frame rate</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="3">
+      <widget class="QSpinBox" name="waveformAlphaSpinBox">
+       <property name="suffix">
+        <string>%</string>
+       </property>
+       <property name="maximum">
+        <number>100</number>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="waveformTypeLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string extracomment="The big waveform summary shows the waveform envelope of the track near the current playback position."/>
+       </property>
+       <property name="text">
+        <string>Waveform type</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+       <property name="buddy">
+        <cstring>waveformTypeComboBox</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1" colspan="3">
+      <widget class="QCheckBox" name="synchronizeZoomCheckBox">
+       <property name="toolTip">
+        <string>Synchronize zoom level across all waveform displays.</string>
+       </property>
+       <property name="text">
+        <string>Synchronize zoom level across all waveforms</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1" colspan="3">
+      <widget class="QComboBox" name="waveformTypeComboBox">
+       <property name="toolTip">
+        <string>The waveform shows the waveform envelope of the track near the current playback position.
+Select from different types of displays for the waveform, which differ primarily in the level of detail shown in the waveform.</string>
+       </property>
+      </widget>
+     </item>
+     <item row="14" column="0" colspan="4">
+      <widget class="Line" name="line">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="visualGainLabel">
+       <property name="text">
+        <string>Visual gain</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+       </property>
+       <property name="buddy">
+        <cstring>allVisualGain</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="defaultZoomLabel">
+       <property name="text">
+        <string extracomment="Waveform zoom">Default zoom level</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+       <property name="buddy">
+        <cstring>defaultZoomComboBox</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="12" column="0">
+      <widget class="QLabel" name="waveformAlphaPrefilterLabel">
+       <property name="text">
+        <string>Waveform prefilter opacity</string>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="1">
+      <widget class="QSlider" name="waveformAlphaSlider">
+       <property name="maximum">
+        <number>100</number>
        </property>
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -516,58 +583,47 @@ Select from different types of displays for the waveform, which differ primarily
        </property>
       </widget>
      </item>
-     <item row="5" column="0">
-        <widget class="QLabel" name="label">
-        <property name="text">
-                <string>Play marker position</string>
-        </property>
-        </widget>
-        </item>
-        <item row="5" column="1" colspan="3">
-        <widget class="QSlider" name="playMarkerPositionSlider">
-         <property name="toolTip">
-           <string>Moves the play marker position on the waveforms to the left, right or center (default).</string>
-         </property>
-         <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                 </sizepolicy>
-         </property>
-         <property name="maximumSize">
-                 <size>
-                 <width>16777215</width>
-                 <height>16777215</height>
-                 </size>
-         </property>
-         <property name="minimum">
-                 <number>0</number>
-         </property>
-         <property name="maximum">
-                 <number>100</number>
-         </property>
-         <property name="value">
-                 <number>50</number>
-         </property>
-         <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
+     <item row="3" column="3">
+      <widget class="QSpinBox" name="endOfTrackWarningTimeSpinBox">
+       <property name="toolTip">
+        <string>Highlight the waveforms when the last seconds of a track remains.</string>
+       </property>
+       <property name="suffix">
+        <string> seconds</string>
+       </property>
+       <property name="minimum">
+        <number>0</number>
+       </property>
+       <property name="maximum">
+        <number>60</number>
+       </property>
+       <property name="value">
+        <number>30</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1" colspan="3">
+      <widget class="QComboBox" name="waveformOverviewComboBox">
+       <property name="toolTip">
+        <string>The waveform overview shows the waveform envelope of the entire track.
+Select from different types of displays for the waveform overview, which differ primarily in the level of detail shown in the waveform.</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QSlider" name="beatGridAlphaSlider">
+       <property name="maximum">
+        <number>100</number>
+       </property>
+       <property name="value">
+        <number>90</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
      </item>
     </layout>
-   </item>
-   <item row="1" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/waveform/renderers/glslwaveformrenderersignal.cpp
+++ b/src/waveform/renderers/glslwaveformrenderersignal.cpp
@@ -326,6 +326,8 @@ void GLSLWaveformRendererSignal::draw(QPainter* painter, QPaintEvent* /*event*/)
         m_frameShaderProgram->setUniformValue("lowGain", lowGain);
         m_frameShaderProgram->setUniformValue("midGain", midGain);
         m_frameShaderProgram->setUniformValue("highGain", highGain);
+        m_frameShaderProgram->setUniformValue("alpha", (float)m_pAlphaControlObject->get());
+        m_frameShaderProgram->setUniformValue("alphaUnscaled", (float)m_pAlphaPrefilterControlObject->get());
 
         m_frameShaderProgram->setUniformValue("axesColor", QVector4D(m_axesColor_r, m_axesColor_g,
                                                                      m_axesColor_b, m_axesColor_a));

--- a/src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
@@ -2,6 +2,7 @@
 #if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
 
 #include <QDomNode>
+#include <QtGlobal>
 
 #include "track/track.h"
 #include "waveform/waveform.h"
@@ -62,146 +63,159 @@ void GLWaveformRendererFilteredSignal::draw(QPainter* painter, QPaintEvent* /*ev
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
     // Per-band gain from the EQ knobs.
-    float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0);
-    getGains(&allGain, &lowGain, &midGain, &highGain);
+    float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0), alpha(1.0);
 
-    if (m_alignment == Qt::AlignCenter) {
-        glMatrixMode(GL_PROJECTION);
-        glPushMatrix();
-        glLoadIdentity();
-        if (m_orientation == Qt::Vertical) {
-            glRotatef(90.0f, 0.0f, 0.0f, 1.0f);
-            glScalef(-1.0f, 1.0f, 1.0f);
+    for (int i = 0; i < 2; i++) {
+        if (i == 0) {
+            // first pass in the unfiltered value, only master gain is added
+            getGains(&allGain, nullptr, nullptr, nullptr);
+            alpha = m_pAlphaPrefilterControlObject->get();
+        } else {
+            // now the filtered value is overdrawn
+            getGains(&allGain, &lowGain, &midGain, &highGain);
+            alpha = m_pAlphaControlObject->get();
         }
-        glOrtho(firstVisualIndex, lastVisualIndex, -255.0, 255.0, -10.0, 10.0);
-
-        glMatrixMode(GL_MODELVIEW);
-        glPushMatrix();
-        glLoadIdentity();
-
-        glScalef(1.f,allGain,1.f);
-
-        glLineWidth(1.0);
-        glDisable(GL_LINE_SMOOTH);
-
-        //draw reference line
-        glBegin(GL_LINES); {
-            glColor4f(m_axesColor_r, m_axesColor_g,
-                      m_axesColor_b, m_axesColor_a);
-            glVertex2f(firstVisualIndex,0);
-            glVertex2f(lastVisualIndex,0);
+        if (alpha <= 0.0) {
+            continue;
         }
-        glEnd();
-
-        glLineWidth(lineWidth);
-        glEnable(GL_LINE_SMOOTH);
-
-        glBegin(GL_LINES); {
-
-            int firstIndex = math_max(static_cast<int>(firstVisualIndex), 0);
-            int lastIndex = math_min(static_cast<int>(lastVisualIndex), dataSize);
-
-            glColor4f(m_lowColor_r, m_lowColor_g, m_lowColor_b, 0.8);
-            for (int visualIndex = firstIndex;
-                    visualIndex < lastIndex;
-                    visualIndex += 2) {
-
-                GLfloat maxLow0 = data[visualIndex].filtered.low;
-                GLfloat maxLow1 = data[visualIndex+1].filtered.low;
-
-                glVertex2f(visualIndex,lowGain*maxLow0);
-                glVertex2f(visualIndex,-1.f*lowGain*maxLow1);
+        if (m_alignment == Qt::AlignCenter) {
+            glMatrixMode(GL_PROJECTION);
+            glPushMatrix();
+            glLoadIdentity();
+            if (m_orientation == Qt::Vertical) {
+                glRotatef(90.0f, 0.0f, 0.0f, 1.0f);
+                glScalef(-1.0f, 1.0f, 1.0f);
             }
+            glOrtho(firstVisualIndex, lastVisualIndex, -255.0, 255.0, -10.0, 10.0);
 
-            glColor4f(m_midColor_r, m_midColor_g, m_midColor_b, 0.85);
-            for (int visualIndex = firstIndex;
-                    visualIndex < lastIndex;
-                    visualIndex += 2) {
+            glMatrixMode(GL_MODELVIEW);
+            glPushMatrix();
+            glLoadIdentity();
 
-                GLfloat maxMid0 = data[visualIndex].filtered.mid;
-                GLfloat maxMid1 = data[visualIndex+1].filtered.mid;
+            glScalef(1.f,allGain,1.f);
 
-                glVertex2f(visualIndex, midGain * maxMid0);
-                glVertex2f(visualIndex,-1.f * midGain * maxMid1);
+            glLineWidth(1.0);
+            glDisable(GL_LINE_SMOOTH);
+
+            //draw reference line
+            glBegin(GL_LINES); {
+                glColor4f(m_axesColor_r, m_axesColor_g,
+                        m_axesColor_b, m_axesColor_a);
+                glVertex2f(firstVisualIndex,0);
+                glVertex2f(lastVisualIndex,0);
             }
+            glEnd();
 
-            glColor4f(m_highColor_r, m_highColor_g, m_highColor_b, 0.9);
-            for (int visualIndex = firstIndex;
-                    visualIndex < lastIndex;
-                    visualIndex += 2) {
+            glLineWidth(lineWidth);
+            glEnable(GL_LINE_SMOOTH);
 
-                GLfloat maxHigh0 = data[visualIndex].filtered.high;
-                GLfloat maxHigh1 = data[visualIndex + 1].filtered.high;
+            glBegin(GL_LINES); {
 
-                glVertex2f(visualIndex, highGain * maxHigh0);
-                glVertex2f(visualIndex, -1.f * highGain * maxHigh1);
+                int firstIndex = math_max(static_cast<int>(firstVisualIndex), 0);
+                int lastIndex = math_min(static_cast<int>(lastVisualIndex), dataSize);
+
+                glColor4f(m_lowColor_r, m_lowColor_g, m_lowColor_b, alpha);
+                for (int visualIndex = firstIndex;
+                        visualIndex < lastIndex;
+                        visualIndex += 2) {
+
+                    GLfloat maxLow0 = data[visualIndex].filtered.low;
+                    GLfloat maxLow1 = data[visualIndex+1].filtered.low;
+
+                    glVertex2f(visualIndex,lowGain*maxLow0);
+                    glVertex2f(visualIndex,-1.f*lowGain*maxLow1);
+                }
+
+                glColor4f(m_midColor_r, m_midColor_g, m_midColor_b, qMin(alpha + 0.05f, 1.0f));
+                for (int visualIndex = firstIndex;
+                        visualIndex < lastIndex;
+                        visualIndex += 2) {
+
+                    GLfloat maxMid0 = data[visualIndex].filtered.mid;
+                    GLfloat maxMid1 = data[visualIndex+1].filtered.mid;
+
+                    glVertex2f(visualIndex, midGain * maxMid0);
+                    glVertex2f(visualIndex,-1.f * midGain * maxMid1);
+                }
+
+                glColor4f(m_highColor_r, m_highColor_g, m_highColor_b, qMin(alpha + 0.1f, 1.0f));
+                for (int visualIndex = firstIndex;
+                        visualIndex < lastIndex;
+                        visualIndex += 2) {
+
+                    GLfloat maxHigh0 = data[visualIndex].filtered.high;
+                    GLfloat maxHigh1 = data[visualIndex + 1].filtered.high;
+
+                    glVertex2f(visualIndex, highGain * maxHigh0);
+                    glVertex2f(visualIndex, -1.f * highGain * maxHigh1);
+                }
             }
-        }
-        glEnd();
-    } else { //top || bottom
-        glMatrixMode(GL_PROJECTION);
-        glPushMatrix();
-        glLoadIdentity();
-        if (m_orientation == Qt::Vertical) {
-            glRotatef(90.0f, 0.0f, 0.0f, 1.0f);
-            glScalef(-1.0f, 1.0f, 1.0f);
-        }
-        if (m_alignment == Qt::AlignBottom || m_alignment == Qt::AlignRight)
-            glOrtho(firstVisualIndex, lastVisualIndex, 0.0, 255.0, -10.0, 10.0);
-        else
-            glOrtho(firstVisualIndex, lastVisualIndex, 255.0, 0.0, -10.0, 10.0);
-
-        glMatrixMode(GL_MODELVIEW);
-        glPushMatrix();
-        glLoadIdentity();
-
-        glScalef(1.f,allGain,1.f);
-
-        glLineWidth(lineWidth);
-        glEnable(GL_LINE_SMOOTH);
-
-        glBegin(GL_LINES); {
-
-            int firstIndex = math_max(static_cast<int>(firstVisualIndex), 0);
-            int lastIndex = math_min(static_cast<int>(lastVisualIndex), dataSize);
-
-            glColor4f(m_lowColor_r, m_lowColor_g, m_lowColor_b, 0.8);
-            for (int visualIndex = firstIndex;
-                    visualIndex < lastIndex;
-                    visualIndex += 2) {
-
-                GLfloat maxLow = math_max(
-                        data[visualIndex].filtered.low,
-                        data[visualIndex+1].filtered.low);
-
-                glVertex2f(visualIndex, 0);
-                glVertex2f(visualIndex, lowGain * maxLow);
+            glEnd();
+        } else { //top || bottom
+            glMatrixMode(GL_PROJECTION);
+            glPushMatrix();
+            glLoadIdentity();
+            if (m_orientation == Qt::Vertical) {
+                glRotatef(90.0f, 0.0f, 0.0f, 1.0f);
+                glScalef(-1.0f, 1.0f, 1.0f);
             }
+            if (m_alignment == Qt::AlignBottom || m_alignment == Qt::AlignRight)
+                glOrtho(firstVisualIndex, lastVisualIndex, 0.0, 255.0, -10.0, 10.0);
+            else
+                glOrtho(firstVisualIndex, lastVisualIndex, 255.0, 0.0, -10.0, 10.0);
 
-            glColor4f(m_midColor_r, m_midColor_g, m_midColor_b, 0.85);
-            for (int visualIndex = firstIndex;
-                    visualIndex < lastIndex;
-                    visualIndex += 2) {
+            glMatrixMode(GL_MODELVIEW);
+            glPushMatrix();
+            glLoadIdentity();
 
-                GLfloat maxMid = math_max(
-                        data[visualIndex].filtered.mid,
-                        data[visualIndex+1].filtered.mid);
+            glScalef(1.f,allGain,1.f);
 
-                glVertex2f(visualIndex, 0.f);
-                glVertex2f(visualIndex, midGain * maxMid);
-            }
+            glLineWidth(lineWidth);
+            glEnable(GL_LINE_SMOOTH);
 
-            glColor4f(m_highColor_r, m_highColor_g, m_highColor_b, 0.9);
-            for (int visualIndex = firstIndex;
-                    visualIndex < lastIndex;
-                    visualIndex += 2) {
+            glBegin(GL_LINES); {
 
-                GLfloat maxHigh = math_max(
-                        data[visualIndex].filtered.high,
-                        data[visualIndex + 1].filtered.high);
+                int firstIndex = math_max(static_cast<int>(firstVisualIndex), 0);
+                int lastIndex = math_min(static_cast<int>(lastVisualIndex), dataSize);
 
-                glVertex2f(visualIndex, 0.f);
-                glVertex2f(visualIndex, highGain * maxHigh);
+                glColor4f(m_lowColor_r, m_lowColor_g, m_lowColor_b, alpha);
+                for (int visualIndex = firstIndex;
+                        visualIndex < lastIndex;
+                        visualIndex += 2) {
+
+                    GLfloat maxLow = math_max(
+                            data[visualIndex].filtered.low,
+                            data[visualIndex+1].filtered.low);
+
+                    glVertex2f(visualIndex, 0);
+                    glVertex2f(visualIndex, lowGain * maxLow);
+                }
+
+                glColor4f(m_midColor_r, m_midColor_g, m_midColor_b, qMin(alpha + 0.05f, 1.0f));
+                for (int visualIndex = firstIndex;
+                        visualIndex < lastIndex;
+                        visualIndex += 2) {
+
+                    GLfloat maxMid = math_max(
+                            data[visualIndex].filtered.mid,
+                            data[visualIndex+1].filtered.mid);
+
+                    glVertex2f(visualIndex, 0.f);
+                    glVertex2f(visualIndex, midGain * maxMid);
+                }
+
+                glColor4f(m_highColor_r, m_highColor_g, m_highColor_b, qMin(alpha + 0.1f, 1.0f));
+                for (int visualIndex = firstIndex;
+                        visualIndex < lastIndex;
+                        visualIndex += 2) {
+
+                    GLfloat maxHigh = math_max(
+                            data[visualIndex].filtered.high,
+                            data[visualIndex + 1].filtered.high);
+
+                    glVertex2f(visualIndex, 0.f);
+                    glVertex2f(visualIndex, highGain * maxHigh);
+                }
             }
         }
         glEnd();

--- a/src/waveform/renderers/glwaveformrendererrgb.cpp
+++ b/src/waveform/renderers/glwaveformrendererrgb.cpp
@@ -58,134 +58,148 @@ void GLWaveformRendererRGB::draw(QPainter* painter, QPaintEvent* /*event*/) {
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
     // Per-band gain from the EQ knobs.
-    float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0);
-    getGains(&allGain, &lowGain, &midGain, &highGain);
+    float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0), alpha(1.0);
 
     const float kHeightScaleFactor = 255.0 / sqrtf(255 * 255 * 3);
 
-    if (m_alignment == Qt::AlignCenter) {
-        glMatrixMode(GL_PROJECTION);
-        glPushMatrix();
-        glLoadIdentity();
-        if (m_orientation == Qt::Vertical) {
-            glRotatef(90.0f, 0.0f, 0.0f, 1.0f);
-            glScalef(-1.0f, 1.0f, 1.0f);
-        }
-        glOrtho(firstVisualIndex, lastVisualIndex, -255.0, 255.0, -10.0, 10.0);
-
-        glMatrixMode(GL_MODELVIEW);
-        glPushMatrix();
-        glLoadIdentity();
-
-        glScalef(1.0f, allGain, 1.0f);
-
-        glLineWidth(1.2);
-        glDisable(GL_LINE_SMOOTH);
-
-        // Draw reference line
-        glBegin(GL_LINES); {
-            glColor4f(m_axesColor_r, m_axesColor_g, m_axesColor_b, m_axesColor_a);
-            glVertex2f(firstVisualIndex, 0);
-            glVertex2f(lastVisualIndex,  0);
-        }
-        glEnd();
-
-        glLineWidth(lineWidth);
-        glEnable(GL_LINE_SMOOTH);
-
-        glBegin(GL_LINES); {
-
-            int firstIndex = math_max(static_cast<int>(firstVisualIndex), 0);
-            int lastIndex = math_min(static_cast<int>(lastVisualIndex), dataSize);
-
-            for (int visualIndex = firstIndex;
-                    visualIndex < lastIndex;
-                    visualIndex += 2) {
-
-                float left_low    = lowGain  * (float) data[visualIndex].filtered.low;
-                float left_mid    = midGain  * (float) data[visualIndex].filtered.mid;
-                float left_high   = highGain * (float) data[visualIndex].filtered.high;
-                float left_all    = sqrtf(left_low * left_low + left_mid * left_mid + left_high * left_high) * kHeightScaleFactor;
-                float left_red    = left_low  * m_rgbLowColor_r + left_mid  * m_rgbMidColor_r + left_high  * m_rgbHighColor_r;
-                float left_green  = left_low  * m_rgbLowColor_g + left_mid  * m_rgbMidColor_g + left_high  * m_rgbHighColor_g;
-                float left_blue   = left_low  * m_rgbLowColor_b + left_mid  * m_rgbMidColor_b + left_high  * m_rgbHighColor_b;
-                float left_max    = math_max3(left_red, left_green, left_blue);
-                if (left_max > 0.0f) {  // Prevent division by zero
-                    glColor4f(left_red / left_max, left_green / left_max, left_blue / left_max, 0.8f);
-                    glVertex2f(visualIndex, 0.0f);
-                    glVertex2f(visualIndex, left_all);
-                }
-
-                float right_low   = lowGain  * (float) data[visualIndex+1].filtered.low;
-                float right_mid   = midGain  * (float) data[visualIndex+1].filtered.mid;
-                float right_high  = highGain * (float) data[visualIndex+1].filtered.high;
-                float right_all   = sqrtf(right_low * right_low + right_mid * right_mid + right_high * right_high) * kHeightScaleFactor;
-                float right_red   = right_low * m_rgbLowColor_r + right_mid * m_rgbMidColor_r + right_high * m_rgbHighColor_r;
-                float right_green = right_low * m_rgbLowColor_g + right_mid * m_rgbMidColor_g + right_high * m_rgbHighColor_g;
-                float right_blue  = right_low * m_rgbLowColor_b + right_mid * m_rgbMidColor_b + right_high * m_rgbHighColor_b;
-                float right_max   = math_max3(right_red, right_green, right_blue);
-                if (right_max > 0.0f) {  // Prevent division by zero
-                    glColor4f(right_red / right_max, right_green / right_max, right_blue / right_max, 0.8f);
-                    glVertex2f(visualIndex, 0.0f);
-                    glVertex2f(visualIndex, -1.0f * right_all);
-                }
-            }
-        }
-
-        glEnd();
-
-    } else {  // top || bottom
-        glMatrixMode(GL_PROJECTION);
-        glPushMatrix();
-        glLoadIdentity();
-        if (m_orientation == Qt::Vertical) {
-            glRotatef(90.0f, 0.0f, 0.0f, 1.0f);
-            glScalef(-1.0f, 1.0f, 1.0f);
-        }
-        if (m_alignment == Qt::AlignBottom || m_alignment == Qt::AlignRight) {
-            glOrtho(firstVisualIndex, lastVisualIndex, 0.0, 255.0, -10.0, 10.0);
+    for (int i = 0; i < 2; i++) {
+        if (i == 0) {
+            // first pass in the unfiltered value, only master gain is added
+            getGains(&allGain, nullptr, nullptr, nullptr);
+            alpha = m_pAlphaPrefilterControlObject->get();
         } else {
-            glOrtho(firstVisualIndex, lastVisualIndex, 255.0, 0.0, -10.0, 10.0);
+            // now the filtered value is overdrawn
+            getGains(&allGain, &lowGain, &midGain, &highGain);
+            alpha = m_pAlphaControlObject->get();
+        }
+        if (alpha <= 0.0) {
+            continue;
         }
 
-        glMatrixMode(GL_MODELVIEW);
-        glPushMatrix();
-        glLoadIdentity();
+        if (m_alignment == Qt::AlignCenter) {
+            glMatrixMode(GL_PROJECTION);
+            glPushMatrix();
+            glLoadIdentity();
+            if (m_orientation == Qt::Vertical) {
+                glRotatef(90.0f, 0.0f, 0.0f, 1.0f);
+                glScalef(-1.0f, 1.0f, 1.0f);
+            }
+            glOrtho(firstVisualIndex, lastVisualIndex, -255.0, 255.0, -10.0, 10.0);
 
-        glScalef(1.0f, allGain, 1.0f);
+            glMatrixMode(GL_MODELVIEW);
+            glPushMatrix();
+            glLoadIdentity();
 
-        glLineWidth(lineWidth);
-        glEnable(GL_LINE_SMOOTH);
+            glScalef(1.0f, allGain, 1.0f);
 
-        glBegin(GL_LINES); {
+            glLineWidth(1.2);
+            glDisable(GL_LINE_SMOOTH);
 
-            int firstIndex = math_max(static_cast<int>(firstVisualIndex), 0);
-            int lastIndex = math_min(static_cast<int>(lastVisualIndex), dataSize);
+            // Draw reference line
+            glBegin(GL_LINES); {
+                glColor4f(m_axesColor_r, m_axesColor_g, m_axesColor_b, m_axesColor_a);
+                glVertex2f(firstVisualIndex, 0);
+                glVertex2f(lastVisualIndex,  0);
+            }
+            glEnd();
 
-            for (int visualIndex = firstIndex;
-                    visualIndex < lastIndex;
-                    visualIndex += 2) {
+            glLineWidth(lineWidth);
+            glEnable(GL_LINE_SMOOTH);
 
-                float low  = lowGain  * (float) math_max(data[visualIndex].filtered.low,  data[visualIndex+1].filtered.low);
-                float mid  = midGain  * (float) math_max(data[visualIndex].filtered.mid,  data[visualIndex+1].filtered.mid);
-                float high = highGain * (float) math_max(data[visualIndex].filtered.high, data[visualIndex+1].filtered.high);
+            glBegin(GL_LINES); {
 
-                float all = sqrtf(low * low + mid * mid + high * high) * kHeightScaleFactor;
+                int firstIndex = math_max(static_cast<int>(firstVisualIndex), 0);
+                int lastIndex = math_min(static_cast<int>(lastVisualIndex), dataSize);
 
-                float red   = low * m_rgbLowColor_r + mid * m_rgbMidColor_r + high * m_rgbHighColor_r;
-                float green = low * m_rgbLowColor_g + mid * m_rgbMidColor_g + high * m_rgbHighColor_g;
-                float blue  = low * m_rgbLowColor_b + mid * m_rgbMidColor_b + high * m_rgbHighColor_b;
+                for (int visualIndex = firstIndex;
+                        visualIndex < lastIndex;
+                        visualIndex += 2) {
 
-                float max = math_max3(red, green, blue);
-                if (max > 0.0f) {  // Prevent division by zero
-                    glColor4f(red / max, green / max, blue / max, 0.9f);
-                    glVertex2f(float(visualIndex), 0.0f);
-                    glVertex2f(float(visualIndex), all);
+                    float left_low    = lowGain  * (float) data[visualIndex].filtered.low;
+                    float left_mid    = midGain  * (float) data[visualIndex].filtered.mid;
+                    float left_high   = highGain * (float) data[visualIndex].filtered.high;
+                    float left_all    = sqrtf(left_low * left_low + left_mid * left_mid + left_high * left_high) * kHeightScaleFactor;
+                    float left_red    = left_low  * m_rgbLowColor_r + left_mid  * m_rgbMidColor_r + left_high  * m_rgbHighColor_r;
+                    float left_green  = left_low  * m_rgbLowColor_g + left_mid  * m_rgbMidColor_g + left_high  * m_rgbHighColor_g;
+                    float left_blue   = left_low  * m_rgbLowColor_b + left_mid  * m_rgbMidColor_b + left_high  * m_rgbHighColor_b;
+                    float left_max    = math_max3(left_red, left_green, left_blue);
+                    if (left_max > 0.0f) {  // Prevent division by zero
+                        glColor4f(left_red / left_max, left_green / left_max, left_blue / left_max, alpha);
+                        glVertex2f(visualIndex, 0.0f);
+                        glVertex2f(visualIndex, left_all);
+                    }
+
+                    float right_low   = lowGain  * (float) data[visualIndex+1].filtered.low;
+                    float right_mid   = midGain  * (float) data[visualIndex+1].filtered.mid;
+                    float right_high  = highGain * (float) data[visualIndex+1].filtered.high;
+                    float right_all   = sqrtf(right_low * right_low + right_mid * right_mid + right_high * right_high) * kHeightScaleFactor;
+                    float right_red   = right_low * m_rgbLowColor_r + right_mid * m_rgbMidColor_r + right_high * m_rgbHighColor_r;
+                    float right_green = right_low * m_rgbLowColor_g + right_mid * m_rgbMidColor_g + right_high * m_rgbHighColor_g;
+                    float right_blue  = right_low * m_rgbLowColor_b + right_mid * m_rgbMidColor_b + right_high * m_rgbHighColor_b;
+                    float right_max   = math_max3(right_red, right_green, right_blue);
+                    if (right_max > 0.0f) {  // Prevent division by zero
+                        glColor4f(right_red / right_max, right_green / right_max, right_blue / right_max, alpha);
+                        glVertex2f(visualIndex, 0.0f);
+                        glVertex2f(visualIndex, -1.0f * right_all);
+                    }
                 }
             }
-        }
 
-        glEnd();
+            glEnd();
+
+        } else {  // top || bottom
+            glMatrixMode(GL_PROJECTION);
+            glPushMatrix();
+            glLoadIdentity();
+            if (m_orientation == Qt::Vertical) {
+                glRotatef(90.0f, 0.0f, 0.0f, 1.0f);
+                glScalef(-1.0f, 1.0f, 1.0f);
+            }
+            if (m_alignment == Qt::AlignBottom || m_alignment == Qt::AlignRight) {
+                glOrtho(firstVisualIndex, lastVisualIndex, 0.0, 255.0, -10.0, 10.0);
+            } else {
+                glOrtho(firstVisualIndex, lastVisualIndex, 255.0, 0.0, -10.0, 10.0);
+            }
+
+            glMatrixMode(GL_MODELVIEW);
+            glPushMatrix();
+            glLoadIdentity();
+
+            glScalef(1.0f, allGain, 1.0f);
+
+            glLineWidth(lineWidth);
+            glEnable(GL_LINE_SMOOTH);
+
+            glBegin(GL_LINES); {
+
+                int firstIndex = math_max(static_cast<int>(firstVisualIndex), 0);
+                int lastIndex = math_min(static_cast<int>(lastVisualIndex), dataSize);
+
+                for (int visualIndex = firstIndex;
+                        visualIndex < lastIndex;
+                        visualIndex += 2) {
+
+                    float low  = lowGain  * (float) math_max(data[visualIndex].filtered.low,  data[visualIndex+1].filtered.low);
+                    float mid  = midGain  * (float) math_max(data[visualIndex].filtered.mid,  data[visualIndex+1].filtered.mid);
+                    float high = highGain * (float) math_max(data[visualIndex].filtered.high, data[visualIndex+1].filtered.high);
+
+                    float all = sqrtf(low * low + mid * mid + high * high) * kHeightScaleFactor;
+
+                    float red   = low * m_rgbLowColor_r + mid * m_rgbMidColor_r + high * m_rgbHighColor_r;
+                    float green = low * m_rgbLowColor_g + mid * m_rgbMidColor_g + high * m_rgbHighColor_g;
+                    float blue  = low * m_rgbLowColor_b + mid * m_rgbMidColor_b + high * m_rgbHighColor_b;
+
+                    float max = math_max3(red, green, blue);
+                    if (max > 0.0f) {  // Prevent division by zero
+                        glColor4f(red / max, green / max, blue / max, alpha);
+                        glVertex2f(float(visualIndex), 0.0f);
+                        glVertex2f(float(visualIndex), all);
+                    }
+                }
+            }
+
+            glEnd();
+        }
     }
 
     glPopMatrix();

--- a/src/waveform/renderers/glwaveformrenderersimplesignal.cpp
+++ b/src/waveform/renderers/glwaveformrenderersimplesignal.cpp
@@ -61,95 +61,107 @@ void GLWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-    float allGain(1.0);
+    float allGain(1.0), alpha(1.0);
     getGains(&allGain, NULL, NULL, NULL);
 
-    if (m_alignment == Qt::AlignCenter) {
-        glMatrixMode(GL_PROJECTION);
-        glPushMatrix();
-        glLoadIdentity();
-        if (m_orientation == Qt::Vertical) {
-            glRotatef(90.0f, 0.0f, 0.0f, 1.0f);
-            glScalef(-1.0f, 1.0f, 1.0f);
+    for (int i = 0; i < 2; i++) {
+        if (i == 0) {
+            // first pass in the unfiltered value, only master gain is added
+            alpha = m_pAlphaPrefilterControlObject->get();
+        } else {
+            // now the filtered value is overdrawn
+            alpha = m_pAlphaControlObject->get();
         }
-        glOrtho(firstVisualIndex, lastVisualIndex, -255.0, 255.0, -10.0, 10.0);
-
-        glMatrixMode(GL_MODELVIEW);
-        glPushMatrix();
-        glLoadIdentity();
-
-        glScalef(1.f, allGain, 1.f);
-
-        glLineWidth(1.0);
-        glDisable(GL_LINE_SMOOTH);
-
-        //draw reference line
-        glBegin(GL_LINES); {
-            glColor4f(m_axesColor_r, m_axesColor_g,
-                      m_axesColor_b, m_axesColor_a);
-            glVertex2f(firstVisualIndex,0);
-            glVertex2f(lastVisualIndex,0);
+        if (alpha <= 0.0) {
+            continue;
         }
-        glEnd();
-
-        glLineWidth(lineWidth);
-        glEnable(GL_LINE_SMOOTH);
-
-        glBegin(GL_LINES); {
-            int firstIndex = math_max(static_cast<int>(firstVisualIndex), 0);
-            int lastIndex = math_min(static_cast<int>(lastVisualIndex), dataSize);
-
-            glColor4f(m_signalColor_r, m_signalColor_g, m_signalColor_b, 0.9);
-            for (int visualIndex = firstIndex;
-                    visualIndex < lastIndex;
-                    visualIndex += 2) {
-
-                GLfloat maxAll0 = data[visualIndex].filtered.all;
-                GLfloat maxAll1 = data[visualIndex+1].filtered.all;
-                glVertex2f(visualIndex, maxAll0);
-                glVertex2f(visualIndex, -1.f * maxAll1);
+        if (m_alignment == Qt::AlignCenter) {
+            glMatrixMode(GL_PROJECTION);
+            glPushMatrix();
+            glLoadIdentity();
+            if (m_orientation == Qt::Vertical) {
+                glRotatef(90.0f, 0.0f, 0.0f, 1.0f);
+                glScalef(-1.0f, 1.0f, 1.0f);
             }
-        }
-        glEnd();
-    } else { //top || bottom
-        glMatrixMode(GL_PROJECTION);
-        glPushMatrix();
-        glLoadIdentity();
-        if (m_orientation == Qt::Vertical) {
-            glRotatef(90.0f, 0.0f, 0.0f, 1.0f);
-            glScalef(-1.0f, 1.0f, 1.0f);
-        }
-        if (m_alignment == Qt::AlignBottom || m_alignment == Qt::AlignRight)
-            glOrtho(firstVisualIndex, lastVisualIndex, 0.0, 255.0, -10.0, 10.0);
-        else
-            glOrtho(firstVisualIndex, lastVisualIndex, 255.0, 0.0, -10.0, 10.0);
+            glOrtho(firstVisualIndex, lastVisualIndex, -255.0, 255.0, -10.0, 10.0);
 
-        glMatrixMode(GL_MODELVIEW);
-        glPushMatrix();
-        glLoadIdentity();
+            glMatrixMode(GL_MODELVIEW);
+            glPushMatrix();
+            glLoadIdentity();
 
-        glScalef(1.f, allGain, 1.f);
+            glScalef(1.f, allGain, 1.f);
 
-        glLineWidth(lineWidth);
-        glEnable(GL_LINE_SMOOTH);
+            glLineWidth(1.0);
+            glDisable(GL_LINE_SMOOTH);
 
-        glBegin(GL_LINES); {
-            int firstIndex = math_max(static_cast<int>(firstVisualIndex), 0);
-            int lastIndex = math_min(static_cast<int>(lastVisualIndex), dataSize);
-
-            glColor4f(m_signalColor_r, m_signalColor_g, m_signalColor_b, 0.8);
-            for (int visualIndex = firstIndex;
-                    visualIndex < lastIndex;
-                    visualIndex += 2) {
-
-                GLfloat maxAll = math_max(
-                        data[visualIndex].filtered.all,
-                        data[visualIndex+1].filtered.all);
-                glVertex2f(float(visualIndex), 0.f);
-                glVertex2f(float(visualIndex), maxAll);
+            //draw reference line
+            glBegin(GL_LINES); {
+                glColor4f(m_axesColor_r, m_axesColor_g,
+                        m_axesColor_b, m_axesColor_a);
+                glVertex2f(firstVisualIndex,0);
+                glVertex2f(lastVisualIndex,0);
             }
+            glEnd();
+
+            glLineWidth(lineWidth);
+            glEnable(GL_LINE_SMOOTH);
+
+            glBegin(GL_LINES); {
+                int firstIndex = math_max(static_cast<int>(firstVisualIndex), 0);
+                int lastIndex = math_min(static_cast<int>(lastVisualIndex), dataSize);
+
+                glColor4f(m_signalColor_r, m_signalColor_g, m_signalColor_b, alpha);
+                for (int visualIndex = firstIndex;
+                        visualIndex < lastIndex;
+                        visualIndex += 2) {
+
+                    GLfloat maxAll0 = data[visualIndex].filtered.all;
+                    GLfloat maxAll1 = data[visualIndex+1].filtered.all;
+                    glVertex2f(visualIndex, maxAll0);
+                    glVertex2f(visualIndex, -1.f * maxAll1);
+                }
+            }
+            glEnd();
+        } else { //top || bottom
+            glMatrixMode(GL_PROJECTION);
+            glPushMatrix();
+            glLoadIdentity();
+            if (m_orientation == Qt::Vertical) {
+                glRotatef(90.0f, 0.0f, 0.0f, 1.0f);
+                glScalef(-1.0f, 1.0f, 1.0f);
+            }
+            if (m_alignment == Qt::AlignBottom || m_alignment == Qt::AlignRight)
+                glOrtho(firstVisualIndex, lastVisualIndex, 0.0, 255.0, -10.0, 10.0);
+            else
+                glOrtho(firstVisualIndex, lastVisualIndex, 255.0, 0.0, -10.0, 10.0);
+
+            glMatrixMode(GL_MODELVIEW);
+            glPushMatrix();
+            glLoadIdentity();
+
+            glScalef(1.f, allGain, 1.f);
+
+            glLineWidth(lineWidth);
+            glEnable(GL_LINE_SMOOTH);
+
+            glBegin(GL_LINES); {
+                int firstIndex = math_max(static_cast<int>(firstVisualIndex), 0);
+                int lastIndex = math_min(static_cast<int>(lastVisualIndex), dataSize);
+
+                glColor4f(m_signalColor_r, m_signalColor_g, m_signalColor_b, alpha);
+                for (int visualIndex = firstIndex;
+                        visualIndex < lastIndex;
+                        visualIndex += 2) {
+
+                    GLfloat maxAll = math_max(
+                            data[visualIndex].filtered.all,
+                            data[visualIndex+1].filtered.all);
+                    glVertex2f(float(visualIndex), 0.f);
+                    glVertex2f(float(visualIndex), maxAll);
+                }
+            }
+            glEnd();
         }
-        glEnd();
     }
     glPopMatrix();
     glMatrixMode(GL_PROJECTION);

--- a/src/waveform/renderers/qtwaveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/qtwaveformrendererfilteredsignal.cpp
@@ -20,6 +20,9 @@ QtWaveformRendererFilteredSignal::~QtWaveformRendererFilteredSignal() {
 }
 
 void QtWaveformRendererFilteredSignal::onSetup(const QDomNode& /*node*/) {
+}
+
+void QtWaveformRendererFilteredSignal::configure() {
     QColor low = m_pColors->getLowColor();
     QColor mid = m_pColors->getMidColor();
     QColor high = m_pColors->getHighColor();
@@ -27,14 +30,15 @@ void QtWaveformRendererFilteredSignal::onSetup(const QDomNode& /*node*/) {
     QColor lowCenter = low;
     QColor midCenter = mid;
     QColor highCenter = high;
+    double alpha = m_pAlphaControlObject->get();
 
-    low.setAlphaF(0.9);
-    mid.setAlphaF(0.9);
-    high.setAlphaF(0.9);
+    low.setAlphaF(alpha);
+    mid.setAlphaF(alpha);
+    high.setAlphaF(alpha);
 
-    lowCenter.setAlphaF(0.5);
-    midCenter.setAlphaF(0.5);
-    highCenter.setAlphaF(0.5);
+    lowCenter.setAlphaF(qMax(alpha-0.4, 0.0));
+    midCenter.setAlphaF(qMax(alpha-0.4, 0.0));
+    highCenter.setAlphaF(qMax(alpha-0.4, 0.0));
 
     QLinearGradient gradientLow(QPointF(0.0,-255.0/2.0),QPointF(0.0,255.0/2.0));
     gradientLow.setColorAt(0.0, low);
@@ -60,9 +64,10 @@ void QtWaveformRendererFilteredSignal::onSetup(const QDomNode& /*node*/) {
     gradientHigh.setColorAt(1.0, high);
     m_highBrush = QBrush(gradientHigh);
 
-    low.setAlphaF(0.3);
-    mid.setAlphaF(0.3);
-    high.setAlphaF(0.3);
+    alpha = m_pAlphaPrefilterControlObject->get();
+    low.setAlphaF(alpha);
+    mid.setAlphaF(alpha);
+    high.setAlphaF(alpha);
 
     QLinearGradient gradientKilledLow(QPointF(0.0,-255.0/2.0),QPointF(0.0,255.0/2.0));
     gradientKilledLow.setColorAt(0.0,low.darker(80));
@@ -138,6 +143,7 @@ int QtWaveformRendererFilteredSignal::buildPolygon() {
     // Represents the # of waveform data points per horizontal pixel.
     const double gain = (lastVisualIndex - firstVisualIndex) /
             (double)m_waveformRenderer->getLength();
+
 
     float lowGain(1.0), midGain(1.0), highGain(1.0);
     getGains(NULL, &lowGain, &midGain, &highGain);
@@ -275,6 +281,8 @@ void QtWaveformRendererFilteredSignal::draw(QPainter* painter, QPaintEvent* /*ev
     const TrackPointer pTrack = m_waveformRenderer->getTrackInfo();
     if (!pTrack)
         return;
+
+    configure();
 
     PainterScope PainterScope(painter);
 

--- a/src/waveform/renderers/qtwaveformrendererfilteredsignal.h
+++ b/src/waveform/renderers/qtwaveformrendererfilteredsignal.h
@@ -19,6 +19,7 @@ class QtWaveformRendererFilteredSignal : public WaveformRendererSignalBase {
   protected:
     virtual void onResize();
     int buildPolygon();
+    void configure();
 
   protected:
     QBrush m_lowBrush;

--- a/src/waveform/renderers/qtwaveformrenderersimplesignal.h
+++ b/src/waveform/renderers/qtwaveformrenderersimplesignal.h
@@ -22,7 +22,6 @@ protected:
     virtual void onResize();
 
 private:
-    QBrush m_brush;
     QPen m_borderPen;
     QVector<QPointF> m_polygon;
 };

--- a/src/waveform/renderers/waveformrenderersignalbase.cpp
+++ b/src/waveform/renderers/waveformrenderersignalbase.cpp
@@ -19,6 +19,8 @@ WaveformRendererSignalBase::WaveformRendererSignalBase(
       m_pLowKillControlObject(NULL),
       m_pMidKillControlObject(NULL),
       m_pHighKillControlObject(NULL),
+      m_pAlphaControlObject(NULL),
+      m_pAlphaPrefilterControlObject(NULL),
       m_alignment(Qt::AlignCenter),
       m_orientation(Qt::Horizontal),
       m_pColors(NULL),
@@ -68,6 +70,10 @@ void WaveformRendererSignalBase::deleteControls() {
         delete m_pMidKillControlObject;
     if (m_pHighKillControlObject)
         delete m_pHighKillControlObject;
+    if (m_pAlphaControlObject)
+        delete m_pAlphaControlObject;
+    if (m_pAlphaPrefilterControlObject)
+        delete m_pAlphaPrefilterControlObject;
 }
 
 bool WaveformRendererSignalBase::init() {
@@ -88,6 +94,10 @@ bool WaveformRendererSignalBase::init() {
             m_waveformRenderer->getGroup(), "filterMidKill");
     m_pHighKillControlObject = new ControlProxy(
             m_waveformRenderer->getGroup(), "filterHighKill");
+    m_pAlphaControlObject = new ControlProxy(
+            "[Controls]", "waveform_alpha");
+    m_pAlphaPrefilterControlObject = new ControlProxy(
+            "[Controls]", "waveform_alpha_prefilter");
 
     return onInit();
 }

--- a/src/waveform/renderers/waveformrenderersignalbase.h
+++ b/src/waveform/renderers/waveformrenderersignalbase.h
@@ -33,6 +33,8 @@ public:
     ControlProxy* m_pLowKillControlObject;
     ControlProxy* m_pMidKillControlObject;
     ControlProxy* m_pHighKillControlObject;
+    ControlProxy* m_pAlphaControlObject;
+    ControlProxy* m_pAlphaPrefilterControlObject;
 
     Qt::Alignment m_alignment;
     Qt::Orientation m_orientation;


### PR DESCRIPTION
Add two COs to control the waveform alpha as well as the prefilter
waveform alpha.

Adapt existing waveform renderers to use the CO.
Implement prefilter waveforms on the missing waveform renderers.
