### PR TITLE
Externalize forward declarations for Track object

### DIFF
--- a/src/library/externaltrackcollection.h
+++ b/src/library/externaltrackcollection.h
@@ -4,12 +4,12 @@
 #include <QList>
 #include <QString>
 
-#include "preferences/usersettings.h"
 #include "library/relocatedtrack.h"
+#include "preferences/usersettings.h"
+#include "track/track_decl.h"
 
 class Library;
 class LibraryFeature;
-class Track;
 
 // This interface and base class enable to synchronize external
 // track collections with Mixxx. It provides methods that will

--- a/src/mixxx.h
+++ b/src/mixxx.h
@@ -9,7 +9,7 @@
 #include "preferences/constants.h"
 #include "preferences/usersettings.h"
 #include "soundio/sounddeviceerror.h"
-#include "track/track.h"
+#include "track/track_decl.h"
 #include "util/cmdlineargs.h"
 #include "util/db/dbconnectionpool.h"
 #include "util/parented_ptr.h"

--- a/src/sources/audiosourcetrackproxy.h
+++ b/src/sources/audiosourcetrackproxy.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "sources/audiosourceproxy.h"
-#include "track/track.h"
+#include "track/track_decl.h"
 
 namespace mixxx {
 

--- a/src/sources/soundsourceproxy.h
+++ b/src/sources/soundsourceproxy.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "track/track.h"
-
 #include "sources/soundsourceproviderregistry.h"
+#include "track/track_decl.h"
+#include "track/trackfile.h"
+#include "util/sandbox.h"
 
 // Creates sound sources for tracks. Only intended to be used
 // in a narrow scope and not shareable between multiple threads!

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -1,7 +1,9 @@
 #include <gtest/gtest.h>
+
 #include <QtDebug>
 
 #include "track/beatgrid.h"
+#include "track/track.h"
 #include "util/memory.h"
 
 using namespace mixxx;

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -1,8 +1,10 @@
 #include <gtest/gtest.h>
+#include <memory.h>
+
 #include <QtDebug>
 
 #include "track/beatmap.h"
-#include "util/memory.h"
+#include "track/track.h"
 
 using namespace mixxx;
 

--- a/src/test/globaltrackcache_test.cpp
+++ b/src/test/globaltrackcache_test.cpp
@@ -1,12 +1,11 @@
+#include "track/globaltrackcache.h"
+
 #include <QThread>
 #include <QtDebug>
-
 #include <atomic>
 
 #include "test/mixxxtest.h"
-
-#include "track/globaltrackcache.h"
-
+#include "track/track.h"
 
 namespace {
 

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -4,7 +4,7 @@
 #include "sources/audiosourcestereoproxy.h"
 #include "sources/soundsourceproxy.h"
 #include "test/mixxxtest.h"
-#include "track/trackmetadata.h"
+#include "track/track.h"
 #include "util/samplebuffer.h"
 
 namespace {

--- a/src/track/beatfactory.h
+++ b/src/track/beatfactory.h
@@ -4,7 +4,7 @@
 #include <QHash>
 
 #include "track/beats.h"
-#include "track/track.h"
+#include "track/track_decl.h"
 
 class BeatFactory {
   public:

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -1,7 +1,9 @@
+#include "track/beatgrid.h"
+
 #include <QMutexLocker>
 #include <QtDebug>
 
-#include "track/beatgrid.h"
+#include "track/track.h"
 #include "util/math.h"
 
 static const int kFrameSize = 2;

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -3,9 +3,9 @@
 
 #include <QMutex>
 
-#include "track/track.h"
-#include "track/beats.h"
 #include "proto/beats.pb.h"
+#include "track/beats.h"
+#include "track/track_decl.h"
 
 #define BEAT_GRID_1_VERSION "BeatGrid-1.0"
 #define BEAT_GRID_2_VERSION "BeatGrid-2.0"

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -5,13 +5,15 @@
  *      Author: vittorio
  */
 
-#include <algorithm>
+#include "track/beatmap.h"
+
+#include <QMutexLocker>
 #include <QtDebug>
 #include <QtGlobal>
-#include <QMutexLocker>
+#include <algorithm>
 
-#include "track/beatmap.h"
 #include "track/beatutils.h"
+#include "track/track.h"
 #include "util/math.h"
 
 using mixxx::track::io::Beat;

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -10,9 +10,9 @@
 
 #include <QMutex>
 
-#include "track/track.h"
-#include "track/beats.h"
 #include "proto/beats.pb.h"
+#include "track/beats.h"
+#include "track/track_decl.h"
 
 #define BEAT_MAP_VERSION "BeatMap-1.0"
 

--- a/src/track/cue.h
+++ b/src/track/cue.h
@@ -6,13 +6,13 @@
 
 #include "audio/types.h"
 #include "track/cueinfo.h"
+#include "track/track_decl.h"
 #include "track/trackid.h"
 #include "util/color/rgbcolor.h"
 #include "util/memory.h"
 
 class CuePosition;
 class CueDAO;
-class Track;
 
 class Cue : public QObject {
     Q_OBJECT

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -2,6 +2,7 @@
 
 #include <QCoreApplication>
 
+#include "track/track.h"
 #include "util/assert.h"
 #include "util/logger.h"
 #include "util/thread_affinity.h"

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -4,9 +4,9 @@
 #include <map>
 #include <unordered_map>
 
-#include "track/track.h"
+#include "track/track_decl.h"
 #include "track/trackref.h"
-
+#include "util/sandbox.h"
 
 // forward declaration(s)
 class GlobalTrackCache;

--- a/src/track/keyfactory.h
+++ b/src/track/keyfactory.h
@@ -2,12 +2,12 @@
 #define KEYFACTORY_H
 
 #include <QHash>
-#include <QVector>
 #include <QString>
+#include <QVector>
 
-#include "track/keys.h"
 #include "proto/keys.pb.h"
-#include "track/track.h"
+#include "track/keys.h"
+#include "track/track_decl.h"
 
 class KeyFactory {
   public:

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -10,26 +10,11 @@
 #include "track/beats.h"
 #include "track/cue.h"
 #include "track/cueinfoimporter.h"
+#include "track/track_decl.h"
 #include "track/trackfile.h"
 #include "track/trackrecord.h"
-#include "util/memory.h"
 #include "util/sandbox.h"
 #include "waveform/waveform.h"
-
-// forward declaration(s)
-class Track;
-
-typedef std::shared_ptr<Track> TrackPointer;
-typedef std::weak_ptr<Track> TrackWeakPointer;
-typedef QList<TrackPointer> TrackPointerList;
-
-Q_DECLARE_METATYPE(TrackPointer);
-
-enum class ExportTrackMetadataResult {
-    Succeeded,
-    Failed,
-    Skipped,
-};
 
 class Track : public QObject {
     Q_OBJECT

--- a/src/track/track_decl.h
+++ b/src/track/track_decl.h
@@ -1,0 +1,21 @@
+#pragma once
+
+/// Forward declarations for Track objects and their pointers
+
+#include <QList>
+#include <QMetaType>
+#include <memory>
+
+class Track;
+
+typedef std::shared_ptr<Track> TrackPointer;
+typedef std::weak_ptr<Track> TrackWeakPointer;
+typedef QList<TrackPointer> TrackPointerList;
+
+enum class ExportTrackMetadataResult {
+    Succeeded,
+    Failed,
+    Skipped,
+};
+
+Q_DECLARE_METATYPE(TrackPointer);

--- a/src/track/trackiterator.h
+++ b/src/track/trackiterator.h
@@ -5,7 +5,8 @@
 
 #include <QModelIndex>
 
-#include "track/track.h"
+#include "track/track_decl.h"
+#include "track/trackid.h"
 #include "util/itemiterator.h"
 
 namespace mixxx {

--- a/src/util/dnd.h
+++ b/src/util/dnd.h
@@ -8,7 +8,8 @@
 #include <QUrl>
 
 #include "preferences/usersettings.h"
-#include "track/track.h"
+#include "track/track_decl.h"
+#include "track/trackfile.h"
 #include "widget/trackdroptarget.h"
 
 class DragAndDropHelper final {

--- a/src/util/itemiterator.h
+++ b/src/util/itemiterator.h
@@ -7,6 +7,7 @@
 #include <QVector>
 
 #include "util/assert.h"
+#include "util/optional.h"
 
 namespace mixxx {
 

--- a/src/waveform/renderers/glvsynctestrenderer.cpp
+++ b/src/waveform/renderers/glvsynctestrenderer.cpp
@@ -1,10 +1,11 @@
 #include "waveform/renderers/glvsynctestrenderer.h"
 #if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
 
+#include "track/track.h"
+#include "util/performancetimer.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveform/waveform.h"
 #include "waveform/waveformwidgetfactory.h"
-#include "util/performancetimer.h"
 
 GLVSyncTestRenderer::GLVSyncTestRenderer(
         WaveformWidgetRenderer* waveformWidgetRenderer)

--- a/src/waveform/renderers/glwaveformrendererrgb.cpp
+++ b/src/waveform/renderers/glwaveformrendererrgb.cpp
@@ -1,12 +1,13 @@
 #include "waveform/renderers/glwaveformrendererrgb.h"
 #if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
 
-#include "waveformwidgetrenderer.h"
+#include "track/track.h"
+#include "util/math.h"
 #include "waveform/waveform.h"
 #include "waveform/waveformwidgetfactory.h"
-#include "widget/wwidget.h"
+#include "waveformwidgetrenderer.h"
 #include "widget/wskincolor.h"
-#include "util/math.h"
+#include "widget/wwidget.h"
 
 GLWaveformRendererRGB::GLWaveformRendererRGB(
         WaveformWidgetRenderer* waveformWidgetRenderer)

--- a/src/waveform/renderers/glwaveformrenderersimplesignal.cpp
+++ b/src/waveform/renderers/glwaveformrenderersimplesignal.cpp
@@ -1,6 +1,7 @@
 #include "waveform/renderers/glwaveformrenderersimplesignal.h"
 #if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
 
+#include "track/track.h"
 #include "util/math.h"
 #include "waveform/waveform.h"
 #include "waveform/waveformwidgetfactory.h"

--- a/src/waveform/renderers/qtvsynctestrenderer.cpp
+++ b/src/waveform/renderers/qtvsynctestrenderer.cpp
@@ -1,10 +1,11 @@
 #include "waveform/renderers/qtvsynctestrenderer.h"
 
+#include "track/track.h"
+#include "util/painterscope.h"
+#include "util/performancetimer.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveform/waveform.h"
 #include "waveform/waveformwidgetfactory.h"
-#include "util/painterscope.h"
-#include "util/performancetimer.h"
 
 QtVSyncTestRenderer::QtVSyncTestRenderer(
         WaveformWidgetRenderer* waveformWidgetRenderer)

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -5,6 +5,7 @@
 
 #include "control/controlobject.h"
 #include "control/controlproxy.h"
+#include "track/track.h"
 #include "util/math.h"
 #include "util/performancetimer.h"
 #include "waveform/visualplayposition.h"

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -6,7 +6,7 @@
 #include <QVector>
 #include <QtDebug>
 
-#include "track/track.h"
+#include "track/track_decl.h"
 #include "util/class.h"
 #include "util/performancetimer.h"
 #include "waveform/renderers/waveformmark.h"
@@ -15,7 +15,6 @@
 
 //#define WAVEFORMWIDGETRENDERER_DEBUG
 
-class Track;
 class ControlProxy;
 class VisualPlayPosition;
 class VSyncThread;

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -5,10 +5,12 @@
 #include <QPointer>
 #include <memory>
 
+#include "library/coverart.h"
 #include "library/dao/playlistdao.h"
 #include "library/trackprocessing.h"
 #include "preferences/usersettings.h"
 #include "track/trackref.h"
+#include "util/color/rgbcolor.h"
 
 class ControlProxy;
 class DlgTagFetcher;


### PR DESCRIPTION
New file `track_decl.h` with forward declarations and enum definitions for `class Track`.

I picked up this technique from customer projects.

Just a peek of what is actually possible. The majority of #include directives in header files should be replaceable, which in turn will reveal many other missing dependencies like in this PR.