### PR TITLE
Waveform: add track end markers

### DIFF
--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -35,6 +35,7 @@ WaveformWidgetRenderer::WaveformWidgetRenderer(const QString& group)
           m_visualPlayPosition(NULL),
           m_playPos(-1),
           m_playPosVSample(0),
+          m_totalVSamples(0),
           m_pRateRatioCO(NULL),
           m_rateRatio(1.0),
           m_pGainControlObject(NULL),
@@ -133,7 +134,8 @@ void WaveformWidgetRenderer::onPreRender(VSyncThread* vsyncThread) {
         // Avoid pixel jitter in play position by rounding to the nearest track
         // pixel.
         m_playPos = round(truePlayPos * m_trackPixelCount) / m_trackPixelCount;
-        m_playPosVSample = m_playPos * m_trackPixelCount * m_visualSamplePerPixel;
+        m_totalVSamples = m_trackPixelCount * m_visualSamplePerPixel;
+        m_playPosVSample = m_playPos * m_totalVSamples;
 
         double leftOffset = m_playMarkerPosition;
         double rightOffset = 1.0 - m_playMarkerPosition;

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -77,6 +77,7 @@ class WaveformWidgetRenderer {
 
     double getPlayPos() const { return m_playPos;}
     double getPlayPosVSample() const { return m_playPosVSample;}
+    double getTotalVSample() const { return m_totalVSamples;}
     double getZoomFactor() const { return m_zoomFactor;}
     double getGain() const { return m_gain;}
     int getTrackSamples() const { return m_trackSamples;}
@@ -140,6 +141,7 @@ class WaveformWidgetRenderer {
     QSharedPointer<VisualPlayPosition> m_visualPlayPosition;
     double m_playPos;
     int m_playPosVSample;
+    int m_totalVSamples;
     ControlProxy* m_pRateRatioCO;
     double m_rateRatio;
     ControlProxy* m_pGainControlObject;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5934199/94379983-e2810c00-0133-11eb-8758-8730eea6ee74.png)

https://bugs.launchpad.net/mixxx/+bug/1799576
This should help understand that no loops can be created (or resized) that would cross the track end, as well as the 
the protective loop move limitation in #3117 .

We could also use the end-of-track warning color for the post-roll triangles?