### PR TITLE
Fix hotcue preview playback behaviour

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -823,7 +823,6 @@ void CueControl::hotcueActivatePreview(HotcueControl* pControl, double v) {
             m_iCurrentlyPreviewingHotcues++;
             double position = pCue->getPosition();
             m_bypassCueSetByPlay = true;
-            m_pPlay->set(1.0);
             pControl->setPreviewing(true);
             pControl->setPreviewingPosition(position);
 
@@ -831,6 +830,7 @@ void CueControl::hotcueActivatePreview(HotcueControl* pControl, double v) {
             lock.unlock();
 
             seekAbs(position);
+            m_pPlay->set(1.0);
         }
     } else if (m_iCurrentlyPreviewingHotcues) {
         // This is a activate release and we are previewing at least one


### PR DESCRIPTION
Creating this PR as requested by @ronso0 in https://bugs.launchpad.net/mixxx/+bug/1656590 (this is my first time ever creating a pull request, so I hope I'm doing it correctly)

This commit only moves one line of code, to start playback after seeking to the hotcue position rather than before, but that seems to be enough to solve the issue. However, I'm not familiar enough with the code to feel confident that this won't cause any unintended side effects (although I haven't been able to find any in my testing), so I'd say it needs someone who is familiar with everything that could be affected by this change to test it thoroughly.