### PR TITLE
Waveform preferences: apply renderer when resetting to defaults

### DIFF
--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -39,51 +39,91 @@ DlgPrefWaveform::DlgPrefWaveform(QWidget* pParent, MixxxMainWindow* pMixxx,
     // slotUpdate can generate rebootMixxxView calls.
     // TODO(XXX): Improve this awkwardness.
     slotUpdate();
-    connect(frameRateSpinBox, SIGNAL(valueChanged(int)),
-            this, SLOT(slotSetFrameRate(int)));
-    connect(endOfTrackWarningTimeSpinBox, SIGNAL(valueChanged(int)),
-            this, SLOT(slotSetWaveformEndRender(int)));
-    connect(beatGridAlphaSpinBox, SIGNAL(valueChanged(int)),
-            this, SLOT(slotSetBeatGridAlpha(int)));
-    connect(frameRateSlider, SIGNAL(valueChanged(int)),
-            frameRateSpinBox, SLOT(setValue(int)));
-    connect(frameRateSpinBox, SIGNAL(valueChanged(int)),
-            frameRateSlider, SLOT(setValue(int)));
-    connect(endOfTrackWarningTimeSlider, SIGNAL(valueChanged(int)),
-            endOfTrackWarningTimeSpinBox, SLOT(setValue(int)));
-    connect(endOfTrackWarningTimeSpinBox, SIGNAL(valueChanged(int)),
-            endOfTrackWarningTimeSlider, SLOT(setValue(int)));
-    connect(beatGridAlphaSlider, SIGNAL(valueChanged(int)),
-            beatGridAlphaSpinBox, SLOT(setValue(int)));
-    connect(beatGridAlphaSpinBox, SIGNAL(valueChanged(int)),
-            beatGridAlphaSlider, SLOT(setValue(int)));
+    connect(frameRateSpinBox,
+            SIGNAL(valueChanged(int)),
+            this,
+            SLOT(slotSetFrameRate(int)));
+    connect(endOfTrackWarningTimeSpinBox,
+            SIGNAL(valueChanged(int)),
+            this,
+            SLOT(slotSetWaveformEndRender(int)));
+    connect(beatGridAlphaSpinBox,
+            SIGNAL(valueChanged(int)),
+            this,
+            SLOT(slotSetBeatGridAlpha(int)));
+    connect(frameRateSlider,
+            SIGNAL(valueChanged(int)),
+            frameRateSpinBox,
+            SLOT(setValue(int)));
+    connect(frameRateSpinBox,
+            SIGNAL(valueChanged(int)),
+            frameRateSlider,
+            SLOT(setValue(int)));
+    connect(endOfTrackWarningTimeSlider,
+            SIGNAL(valueChanged(int)),
+            endOfTrackWarningTimeSpinBox,
+            SLOT(setValue(int)));
+    connect(endOfTrackWarningTimeSpinBox,
+            SIGNAL(valueChanged(int)),
+            endOfTrackWarningTimeSlider,
+            SLOT(setValue(int)));
+    connect(beatGridAlphaSlider,
+            SIGNAL(valueChanged(int)),
+            beatGridAlphaSpinBox,
+            SLOT(setValue(int)));
+    connect(beatGridAlphaSpinBox,
+            SIGNAL(valueChanged(int)),
+            beatGridAlphaSlider,
+            SLOT(setValue(int)));
 
     connect(waveformTypeComboBox,
             SIGNAL(currentIndexChanged(int)),
             this,
             SLOT(slotSetWaveformType(int)));
-    connect(defaultZoomComboBox, SIGNAL(currentIndexChanged(int)),
-            this, SLOT(slotSetDefaultZoom(int)));
-    connect(synchronizeZoomCheckBox, SIGNAL(clicked(bool)),
-            this, SLOT(slotSetZoomSynchronization(bool)));
-    connect(allVisualGain, SIGNAL(valueChanged(double)),
-            this, SLOT(slotSetVisualGainAll(double)));
-    connect(lowVisualGain, SIGNAL(valueChanged(double)),
-            this, SLOT(slotSetVisualGainLow(double)));
-    connect(midVisualGain, SIGNAL(valueChanged(double)),
-            this, SLOT(slotSetVisualGainMid(double)));
-    connect(highVisualGain, SIGNAL(valueChanged(double)),
-            this, SLOT(slotSetVisualGainHigh(double)));
-    connect(normalizeOverviewCheckBox, SIGNAL(toggled(bool)),
-            this, SLOT(slotSetNormalizeOverview(bool)));
-    connect(factory, SIGNAL(waveformMeasured(float,int)),
-            this, SLOT(slotWaveformMeasured(float,int)));
-    connect(waveformOverviewComboBox, SIGNAL(currentIndexChanged(int)),
-            this, SLOT(slotSetWaveformOverviewType(int)));
-    connect(clearCachedWaveforms, SIGNAL(clicked()),
-            this, SLOT(slotClearCachedWaveforms()));
-    connect(playMarkerPositionSlider, SIGNAL(valueChanged(int)),
-            this, SLOT(slotSetPlayMarkerPosition(int)));
+    connect(defaultZoomComboBox,
+            SIGNAL(currentIndexChanged(int)),
+            this,
+            SLOT(slotSetDefaultZoom(int)));
+    connect(synchronizeZoomCheckBox,
+            SIGNAL(clicked(bool)),
+            this,
+            SLOT(slotSetZoomSynchronization(bool)));
+    connect(allVisualGain,
+            SIGNAL(valueChanged(double)),
+            this,
+            SLOT(slotSetVisualGainAll(double)));
+    connect(lowVisualGain,
+            SIGNAL(valueChanged(double)),
+            this,
+            SLOT(slotSetVisualGainLow(double)));
+    connect(midVisualGain,
+            SIGNAL(valueChanged(double)),
+            this,
+            SLOT(slotSetVisualGainMid(double)));
+    connect(highVisualGain,
+            SIGNAL(valueChanged(double)),
+            this,
+            SLOT(slotSetVisualGainHigh(double)));
+    connect(normalizeOverviewCheckBox,
+            SIGNAL(toggled(bool)),
+            this,
+            SLOT(slotSetNormalizeOverview(bool)));
+    connect(factory,
+            SIGNAL(waveformMeasured(float, int)),
+            this,
+            SLOT(slotWaveformMeasured(float, int)));
+    connect(waveformOverviewComboBox,
+            SIGNAL(currentIndexChanged(int)),
+            this,
+            SLOT(slotSetWaveformOverviewType(int)));
+    connect(clearCachedWaveforms,
+            SIGNAL(clicked()),
+            this,
+            SLOT(slotClearCachedWaveforms()));
+    connect(playMarkerPositionSlider,
+            SIGNAL(valueChanged(int)),
+            this,
+            SLOT(slotSetPlayMarkerPosition(int)));
 }
 
 DlgPrefWaveform::~DlgPrefWaveform() {

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -58,8 +58,10 @@ DlgPrefWaveform::DlgPrefWaveform(QWidget* pParent, MixxxMainWindow* pMixxx,
     connect(beatGridAlphaSpinBox, SIGNAL(valueChanged(int)),
             beatGridAlphaSlider, SLOT(setValue(int)));
 
-    connect(waveformTypeComboBox, SIGNAL(activated(int)),
-            this, SLOT(slotSetWaveformType(int)));
+    connect(waveformTypeComboBox,
+            SIGNAL(currentIndexChanged(int)),
+            this,
+            SLOT(slotSetWaveformType(int)));
     connect(defaultZoomComboBox, SIGNAL(currentIndexChanged(int)),
             this, SLOT(slotSetDefaultZoom(int)));
     connect(synchronizeZoomCheckBox, SIGNAL(clicked(bool)),


### PR DESCRIPTION
Previously, the renderer was selected in the combobox but not applied like when clicking it.
Fixed by `activated(int)` > `currentIndexChanged(int)`

The 2nd commit applies the new connect() format to other connections.