### PR TITLE
Preferences Lv2: fix parameter list

### DIFF
--- a/src/preferences/dialog/dlgpreflv2.cpp
+++ b/src/preferences/dialog/dlgpreflv2.cpp
@@ -35,6 +35,7 @@ DlgPrefLV2::DlgPrefLV2(QWidget* pParent, LV2Backend* lv2Backend,
 
         QPushButton* button = new QPushButton(this);
         button->setText(pEffectManifest->name());
+        button->setStyleSheet("text-align:left; padding: 5px;");
 
         if (!m_pLV2Backend->canInstantiateEffect(effectId)) {
             // Tooltip displaying why this effect is disabled
@@ -56,10 +57,11 @@ DlgPrefLV2::DlgPrefLV2(QWidget* pParent, LV2Backend* lv2Backend,
             button->setDisabled(false);
         }
 
-        lv2_vertical_layout_left->addWidget(button);
+        lv2_VLayout_effects->addWidget(button);
         button->setProperty("id", QVariant(pEffectManifest->id()));
         connect(button, SIGNAL(clicked()), this, SLOT(slotDisplayParameters()));
     }
+    effect_name_label->setText(QStringLiteral(""));
 }
 
 DlgPrefLV2::~DlgPrefLV2() {
@@ -76,8 +78,8 @@ void DlgPrefLV2::slotDisplayParameters() {
     m_pluginParameters.clear();
 
     QLayoutItem* item;
-    while ((item = lv2_vertical_layout_params->takeAt(1)) != 0) {
-        lv2_vertical_layout_params->removeWidget(item->widget());
+    while ((item = lv2_VLayout_parameters->takeAt(1)) != 0) {
+        lv2_VLayout_parameters->removeWidget(item->widget());
         delete item->widget();
     }
 
@@ -87,18 +89,22 @@ void DlgPrefLV2::slotDisplayParameters() {
 
     EffectManifestPointer pCurrentEffectManifest = m_pLV2Backend->getManifest(pluginId);
     if (pCurrentEffectManifest) {
+        // Show the effect name above the parameter list
+        effect_name_label->setText(QObject::tr("Parameters for %1")
+                                           .arg(pCurrentEffectManifest->name()));
+        // Populate the parameters list
         const QList<EffectManifestParameterPointer>& parameterList =
                 pCurrentEffectManifest->parameters();
-        for (const auto& pPrameter: parameterList) {
+        for (const auto& pParameter : parameterList) {
             QCheckBox* entry = new QCheckBox(this);
-            entry->setText(pPrameter->name());
-            if (pPrameter->showInParameterSlot()) {
+            entry->setText(pParameter->name());
+            if (pParameter->showInParameterSlot()) {
                 entry->setChecked(true);
             } else {
                 entry->setChecked(false);
                 entry->setEnabled(false);
             }
-            lv2_vertical_layout_params->addWidget(entry);
+            lv2_VLayout_parameters->addWidget(entry);
             m_pluginParameters.append(entry);
             connect(entry, SIGNAL(stateChanged(int)),
                     this, SLOT(slotUpdateOnParameterCheck(int)));
@@ -108,7 +114,7 @@ void DlgPrefLV2::slotDisplayParameters() {
     } else {
         m_iCheckedParameters = 0;
     }
-    lv2_vertical_layout_params->addStretch();
+    lv2_VLayout_parameters->addStretch();
 }
 
 void DlgPrefLV2::slotUpdate() {

--- a/src/preferences/dialog/dlgpreflv2.cpp
+++ b/src/preferences/dialog/dlgpreflv2.cpp
@@ -68,17 +68,19 @@ DlgPrefLV2::~DlgPrefLV2() {
 }
 
 void DlgPrefLV2::slotDisplayParameters() {
-    // Set the number of checked parameters to 0 because new parameters are
-    // displayed
-
-    // Clear the right vertical layout
+    // New parameters will be displayed.
+    // Reset the number of checked parameters to 0 and clear the layout.
     foreach (QCheckBox* box, m_pluginParameters) {
         delete box;
     }
     m_pluginParameters.clear();
 
-    QLayoutItem* item;
-    while ((item = lv2EffectParametersList->takeAt(0)) != 0) {
+    // isEmpty() doesn't consider spacers but count() does.
+    while (lv2EffectParametersList->count() > 0) {
+        QLayoutItem* item = lv2EffectParametersList->takeAt(0);
+        VERIFY_OR_DEBUG_ASSERT(item) {
+            continue;
+        }
         delete item;
     }
 

--- a/src/preferences/dialog/dlgpreflv2.cpp
+++ b/src/preferences/dialog/dlgpreflv2.cpp
@@ -78,9 +78,8 @@ void DlgPrefLV2::slotDisplayParameters() {
     m_pluginParameters.clear();
 
     QLayoutItem* item;
-    while ((item = lv2_VLayout_parameters->takeAt(1)) != 0) {
-        lv2_VLayout_parameters->removeWidget(item->widget());
-        delete item->widget();
+    while ((item = lv2_VLayout_parameters->takeAt(0)) != 0) {
+        delete item;
     }
 
     QPushButton* button = qobject_cast<QPushButton*>(sender());

--- a/src/preferences/dialog/dlgpreflv2.cpp
+++ b/src/preferences/dialog/dlgpreflv2.cpp
@@ -57,11 +57,11 @@ DlgPrefLV2::DlgPrefLV2(QWidget* pParent, LV2Backend* lv2Backend,
             button->setDisabled(false);
         }
 
-        lv2_VLayout_effects->addWidget(button);
+        lv2EffectsList->addWidget(button);
         button->setProperty("id", QVariant(pEffectManifest->id()));
         connect(button, SIGNAL(clicked()), this, SLOT(slotDisplayParameters()));
     }
-    effect_name_label->setText(QStringLiteral(""));
+    effectNameLabel->setText(QStringLiteral(""));
 }
 
 DlgPrefLV2::~DlgPrefLV2() {
@@ -78,7 +78,7 @@ void DlgPrefLV2::slotDisplayParameters() {
     m_pluginParameters.clear();
 
     QLayoutItem* item;
-    while ((item = lv2_VLayout_parameters->takeAt(0)) != 0) {
+    while ((item = lv2EffectParametersList->takeAt(0)) != 0) {
         delete item;
     }
 
@@ -89,8 +89,8 @@ void DlgPrefLV2::slotDisplayParameters() {
     EffectManifestPointer pCurrentEffectManifest = m_pLV2Backend->getManifest(pluginId);
     if (pCurrentEffectManifest) {
         // Show the effect name above the parameter list
-        effect_name_label->setText(QObject::tr("Parameters for %1")
-                                           .arg(pCurrentEffectManifest->name()));
+        effectNameLabel->setText(QObject::tr("Parameters of %1")
+                                         .arg(pCurrentEffectManifest->name()));
         // Populate the parameters list
         const QList<EffectManifestParameterPointer>& parameterList =
                 pCurrentEffectManifest->parameters();
@@ -103,7 +103,7 @@ void DlgPrefLV2::slotDisplayParameters() {
                 entry->setChecked(false);
                 entry->setEnabled(false);
             }
-            lv2_VLayout_parameters->addWidget(entry);
+            lv2EffectParametersList->addWidget(entry);
             m_pluginParameters.append(entry);
             connect(entry, SIGNAL(stateChanged(int)),
                     this, SLOT(slotUpdateOnParameterCheck(int)));
@@ -113,7 +113,7 @@ void DlgPrefLV2::slotDisplayParameters() {
     } else {
         m_iCheckedParameters = 0;
     }
-    lv2_VLayout_parameters->addStretch();
+    lv2EffectParametersList->addStretch();
 }
 
 void DlgPrefLV2::slotUpdate() {

--- a/src/preferences/dialog/dlgpreflv2dlg.ui
+++ b/src/preferences/dialog/dlgpreflv2dlg.ui
@@ -16,8 +16,9 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
+
      <item>
-      <layout class="QVBoxLayout" name="lv2_vertical_layout_left">
+      <layout class="QVBoxLayout" name="vertical_layout_left">
        <item>
         <widget class="QLabel" name="label">
          <property name="font">
@@ -34,8 +35,31 @@
          </property>
         </widget>
        </item>
+       <item>
+        <widget class="QScrollArea" name="scrollArea1">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+          <widget class="QWidget" name="verticalLayoutWidget1">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <layout class="QVBoxLayout" name="lv2_VLayout_effects"/>
+          </widget>
+        </widget>
+       </item>
       </layout>
      </item>
+
      <item>
       <layout class="QVBoxLayout" name="vertical_layout_center">
        <item>
@@ -48,7 +72,7 @@
          </property>
          <property name="sizeHint" stdset="0">
           <size>
-           <width>40</width>
+           <width>10</width>
            <height>20</height>
           </size>
          </property>
@@ -56,31 +80,69 @@
        </item>
       </layout>
      </item>
+
      <item>
-      <layout class="QVBoxLayout" name="lv2_vertical_layout_params">
+      <layout class="QVBoxLayout" name="vertical_layout_right">
        <item>
-        <widget class="QLabel" name="label_2">
+        <widget class="QLabel" name="effect_name_label">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
          <property name="text">
+          <string/>
          </property>
          <property name="alignment">
           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
          </property>
         </widget>
        </item>
+       <item>
+        <widget class="QScrollArea" name="scrollArea2">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+          <widget class="QWidget" name="verticalLayoutWidget2">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <layout class="QVBoxLayout" name="lv2_VLayout_parameters"/>
+          </widget>
+        </widget>
+       </item>
+<!--        <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Expanding</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>10</width>
+           <height>10000</height>
+          </size>
+         </property>
+        </spacer>
+       </item> -->
       </layout>
      </item>
+
     </layout>
    </item>
   </layout>

--- a/src/preferences/dialog/dlgpreflv2dlg.ui
+++ b/src/preferences/dialog/dlgpreflv2dlg.ui
@@ -18,9 +18,9 @@
     <layout class="QHBoxLayout" name="horizontalLayout">
 
      <item>
-      <layout class="QVBoxLayout" name="vertical_layout_left">
+      <layout class="QVBoxLayout" name="vLayoutLeft">
        <item>
-        <widget class="QLabel" name="label">
+        <widget class="QLabel" name="discoveredEffectsLabel">
          <property name="font">
           <font>
            <weight>75</weight>
@@ -46,14 +46,14 @@
          <property name="widgetResizable">
           <bool>true</bool>
          </property>
-          <widget class="QWidget" name="verticalLayoutWidget1">
+          <widget class="QWidget" name="vLayoutWidgetEffects">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
-           <layout class="QVBoxLayout" name="lv2_VLayout_effects"/>
+           <layout class="QVBoxLayout" name="lv2EffectsList"/>
           </widget>
         </widget>
        </item>
@@ -61,7 +61,7 @@
      </item>
 
      <item>
-      <layout class="QVBoxLayout" name="vertical_layout_center">
+      <layout class="QVBoxLayout" name="vLayoutCenter">
        <item>
         <spacer name="horizontalSpacer">
          <property name="orientation">
@@ -82,9 +82,9 @@
      </item>
 
      <item>
-      <layout class="QVBoxLayout" name="vertical_layout_right">
+      <layout class="QVBoxLayout" name="vLayoutRight">
        <item>
-        <widget class="QLabel" name="effect_name_label">
+        <widget class="QLabel" name="effectNameLabel">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -120,26 +120,10 @@
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
-           <layout class="QVBoxLayout" name="lv2_VLayout_parameters"/>
+           <layout class="QVBoxLayout" name="lv2EffectParametersList"/>
           </widget>
         </widget>
        </item>
-<!--        <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Expanding</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>10</width>
-           <height>10000</height>
-          </size>
-         </property>
-        </spacer>
-       </item> -->
       </layout>
      </item>
 


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1786361

![image](https://user-images.githubusercontent.com/5934199/94960436-2c327380-04f3-11eb-9fa3-22daefd159ed.png)

Also the effect names are now aligned left so that the list is easier to browse and the labels are not obscured that easy when the horizontal scrollbars are shown.