### PR TITLE
[Debug] Skin crash fix // Singletons

### DIFF
--- a/res/skins/Deere/skin.xml
+++ b/res/skins/Deere/skin.xml
@@ -136,6 +136,19 @@
     main_decks.xml, left_deck.xml, and right_deck.xml, so define them in singletons. This makes
     toggling between 2/4 decks and stacked/split waveforms slower, but it makes Mixxx startup
     and shutdown much faster and saves a lot of memory.-->
+    <Template src="skin:../Deere/spinny_singleton.xml">
+      <SetVariable name="group">[Channel1]</SetVariable>
+    </Template>
+    <Template src="skin:../Deere/spinny_singleton.xml">
+      <SetVariable name="group">[Channel2]</SetVariable>
+    </Template>
+    <Template src="skin:../Deere/spinny_singleton.xml">
+      <SetVariable name="group">[Channel3]</SetVariable>
+    </Template>
+    <Template src="skin:../Deere/spinny_singleton.xml">
+      <SetVariable name="group">[Channel4]</SetVariable>
+    </Template>
+
     <SingletonDefinition>
       <ObjectName>DeckVisualRow1</ObjectName>
       <Children>

--- a/res/skins/Deere/spinny.xml
+++ b/res/skins/Deere/spinny.xml
@@ -8,36 +8,6 @@ in the deck text row.
 Use smaller spinny sizes for 4 decks than 2 decks.
 -->
 <Template>
-  <SingletonDefinition>
-    <ObjectName>SpinnySingletonWithCover<Variable name="group"/></ObjectName>
-    <Children>
-      <Spinny>
-        <TooltipId>spinny</TooltipId>
-        <Group><Variable name="group"/></Group>
-        <PathBackground scalemode="STRETCH">image/vinyl_spinny_background.svg</PathBackground>
-        <PathForeground>image/vinyl_spinny_foreground.svg</PathForeground>
-        <PathGhost>image/vinyl_spinny_foreground_ghost.svg</PathGhost>
-        <PathMask>image/vinyl_spinny_cover_mask.svg</PathMask>
-        <ShowCover>true</ShowCover>
-      </Spinny>
-    </Children>
-  </SingletonDefinition>
-
-  <SingletonDefinition>
-    <ObjectName>SpinnySingletonNoCover<Variable name="group"/></ObjectName>
-    <Children>
-      <Spinny>
-        <TooltipId>spinny</TooltipId>
-        <Group><Variable name="group"/></Group>
-        <PathBackground scalemode="STRETCH">image/vinyl_spinny_background.svg</PathBackground>
-        <PathForeground>image/vinyl_spinny_foreground.svg</PathForeground>
-        <PathGhost>image/vinyl_spinny_foreground_ghost.svg</PathGhost>
-        <PathMask>image/vinyl_spinny_cover_mask.svg</PathMask>
-        <ShowCover>false</ShowCover>
-      </Spinny>
-    </Children>
-  </SingletonDefinition>
-
   <WidgetGroup>
     <ObjectName>SpinnyHolder</ObjectName>
     <Layout>horizontal</Layout>
@@ -57,8 +27,8 @@ Use smaller spinny sizes for 4 decks than 2 decks.
             </Connection>
             <Children>
               <SingletonContainer>
-                  <ObjectName>SpinnySingletonWithCover<Variable name="group"/></ObjectName>
-                  <Size>75f,75f</Size>
+                <ObjectName>SpinnySingletonWithCover<Variable name="group"/></ObjectName>
+                <Size>75f,75f</Size>
               </SingletonContainer>
             </Children>
           </WidgetGroup>
@@ -82,8 +52,8 @@ Use smaller spinny sizes for 4 decks than 2 decks.
                 </Connection>
                 <Children>
                   <SingletonContainer>
-                      <ObjectName>SpinnySingletonNoCover<Variable name="group"/></ObjectName>
-                      <Size>75f,75f</Size>
+                    <ObjectName>SpinnySingletonNoCover<Variable name="group"/></ObjectName>
+                    <Size>75f,75f</Size>
                   </SingletonContainer>
                 </Children>
               </WidgetGroup>
@@ -99,8 +69,8 @@ Use smaller spinny sizes for 4 decks than 2 decks.
                 </Connection>
                 <Children>
                   <SingletonContainer>
-                      <ObjectName>SpinnySingletonWithCover<Variable name="group"/></ObjectName>
-                      <Size>75f,75f</Size>
+                    <ObjectName>SpinnySingletonWithCover<Variable name="group"/></ObjectName>
+                    <Size>75f,75f</Size>
                   </SingletonContainer>
                 </Children>
               </WidgetGroup>
@@ -131,8 +101,8 @@ Use smaller spinny sizes for 4 decks than 2 decks.
             </Connection>
             <Children>
               <SingletonContainer>
-                  <ObjectName>SpinnySingletonWithCover<Variable name="group"/></ObjectName>
-                  <Size>55f,55f</Size>
+                <ObjectName>SpinnySingletonWithCover<Variable name="group"/></ObjectName>
+                <Size>55f,55f</Size>
               </SingletonContainer>
             </Children>
           </WidgetGroup>
@@ -156,8 +126,8 @@ Use smaller spinny sizes for 4 decks than 2 decks.
                 </Connection>
                 <Children>
                   <SingletonContainer>
-                      <ObjectName>SpinnySingletonNoCover<Variable name="group"/></ObjectName>
-                      <Size>55f,55f</Size>
+                    <ObjectName>SpinnySingletonNoCover<Variable name="group"/></ObjectName>
+                    <Size>55f,55f</Size>
                   </SingletonContainer>
                 </Children>
               </WidgetGroup>
@@ -173,8 +143,8 @@ Use smaller spinny sizes for 4 decks than 2 decks.
                 </Connection>
                 <Children>
                   <SingletonContainer>
-                      <ObjectName>SpinnySingletonWithCover<Variable name="group"/></ObjectName>
-                      <Size>55f,55f</Size>
+                    <ObjectName>SpinnySingletonWithCover<Variable name="group"/></ObjectName>
+                    <Size>55f,55f</Size>
                   </SingletonContainer>
                 </Children>
               </WidgetGroup>

--- a/res/skins/Deere/spinny.xml
+++ b/res/skins/Deere/spinny.xml
@@ -158,9 +158,5 @@ Use smaller spinny sizes for 4 decks than 2 decks.
         </Connection>
       </WidgetGroup>
     </Children>
-    <Connection>
-      <ConfigKey>[Skin],show_spinnies</ConfigKey>
-      <BindProperty>visible</BindProperty>
-    </Connection>
   </WidgetGroup>
 </Template>

--- a/res/skins/Deere/spinny_singleton.xml
+++ b/res/skins/Deere/spinny_singleton.xml
@@ -1,0 +1,50 @@
+<!--
+Spinny template
+Stacked waveforms: always show cover art in spinny
+Split waveforms: show cover art in spinny when it is not showing in deck text row,
+but do not show cover art in spinny when the cover art is showing right above it
+in the deck text row.
+
+Use smaller spinny sizes for 4 decks than 2 decks.
+-->
+<Template>
+  <SingletonDefinition>
+    <ObjectName>SpinnySingletonWithCover<Variable name="group"/></ObjectName>
+    <Children>
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <Children>
+          <Spinny>
+            <TooltipId>spinny</TooltipId>
+            <Group><Variable name="group"/></Group>
+            <PathBackground scalemode="STRETCH">image/vinyl_spinny_background.svg</PathBackground>
+            <PathForeground>image/vinyl_spinny_foreground.svg</PathForeground>
+            <PathGhost>image/vinyl_spinny_foreground_ghost.svg</PathGhost>
+            <PathMask>image/vinyl_spinny_cover_mask.svg</PathMask>
+            <ShowCover>true</ShowCover>
+          </Spinny>
+        </Children>
+      </WidgetGroup>
+    </Children>
+  </SingletonDefinition>
+
+  <SingletonDefinition>
+    <ObjectName>SpinnySingletonWithCover<Variable name="group"/></ObjectName>
+    <Children>
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <Children>
+          <Spinny>
+            <TooltipId>spinny</TooltipId>
+            <Group><Variable name="group"/></Group>
+            <PathBackground scalemode="STRETCH">image/vinyl_spinny_background.svg</PathBackground>
+            <PathForeground>image/vinyl_spinny_foreground.svg</PathForeground>
+            <PathGhost>image/vinyl_spinny_foreground_ghost.svg</PathGhost>
+            <PathMask>image/vinyl_spinny_cover_mask.svg</PathMask>
+            <ShowCover>false</ShowCover>
+          </Spinny>
+        </Children>
+      </WidgetGroup>
+    </Children>
+  </SingletonDefinition>
+</Template>

--- a/res/skins/Deere/spinny_singleton.xml
+++ b/res/skins/Deere/spinny_singleton.xml
@@ -24,6 +24,10 @@ Use smaller spinny sizes for 4 decks than 2 decks.
             <ShowCover>true</ShowCover>
           </Spinny>
         </Children>
+        <Connection>
+          <ConfigKey>[Skin],show_spinnies</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
       </WidgetGroup>
     </Children>
   </SingletonDefinition>
@@ -44,6 +48,10 @@ Use smaller spinny sizes for 4 decks than 2 decks.
             <ShowCover>false</ShowCover>
           </Spinny>
         </Children>
+        <Connection>
+          <ConfigKey>[Skin],show_spinnies</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
       </WidgetGroup>
     </Children>
   </SingletonDefinition>

--- a/res/skins/Shade/waveform.xml
+++ b/res/skins/Shade/waveform.xml
@@ -1,111 +1,116 @@
 <Template>
-  <Visual>
-    <TooltipId>waveform_display</TooltipId>
-    <Channel><Variable name="channum"/></Channel>
-    <Size>0e,81f</Size>
-    <BgColor>#8D98A3</BgColor>
-    <!--<BgPixmap>style/style_bg_waveform.png</BgPixmap>-->
-    <SignalHighColor></SignalHighColor>
-    <SignalMidColor></SignalMidColor>
-    <SignalLowColor></SignalLowColor>
-    <SignalColor>#191F24</SignalColor>
-    <BeatColor>#FFFFFF</BeatColor>
-    <PlayPosColor>#00FF00</PlayPosColor>
-    <EndOfTrackColor>#EA0000</EndOfTrackColor>
-    <AxesColor>#00FF00</AxesColor>
-    <Align></Align>
-    <DefaultMark>
-      <Align>top</Align>
-      <Color>#FD0564</Color>
-      <TextColor>#FFFFFF</TextColor>
-      <Text> %1 </Text>
-    </DefaultMark>
-    <Mark>
-      <Control>cue_point</Control>
-      <Text>CUE</Text>
-      <Align>top</Align>
-      <Color>#FF001C</Color>
-      <TextColor>#FFFFFF</TextColor>
-    </Mark>
-    <!-- Loop -->
-    <MarkRange>
-      <StartControl>loop_start_position</StartControl>
-      <EndControl>loop_end_position</EndControl>
-      <EnabledControl>loop_enabled</EnabledControl>
-      <Color>#00FF00</Color>
-      <Opacity>0.8</Opacity>
-      <DisabledColor>#BCDBFB</DisabledColor>
-      <DisabledOpacity>0.5</DisabledOpacity>
-    </MarkRange>
-    <Mark>
-      <Control>loop_start_position</Control>
-      <Text>IN</Text>
-      <Align>bottom</Align>
-      <Color>#00FF00</Color>
-      <TextColor>#FFFFFF</TextColor>
-    </Mark>
-    <Mark>
-      <Control>loop_end_position</Control>
-      <Text>OUT</Text>
-      <Align>bottom</Align>
-      <Color>#00FF00</Color>
-      <TextColor>#FFFFFF</TextColor>
-    </Mark>
-    <!-- Intro -->
-    <MarkRange>
-      <StartControl>intro_start_position</StartControl>
-      <EndControl>intro_end_position</EndControl>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-      <Color>#0000FF</Color>
-      <Opacity>0.1</Opacity>
-    </MarkRange>
-    <MarkRange>
-      <StartControl>outro_start_position</StartControl>
-      <EndControl>outro_end_position</EndControl>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-      <Color>#0000FF</Color>
-    </MarkRange>
-    <Mark>
-      <Control>intro_start_position</Control>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-      <Text>|&#9698;</Text>
-      <Align>bottom</Align>
-      <Color>#0000FF</Color>
-      <TextColor>#FFFFFF</TextColor>
-    </Mark>
-    <!-- Outro -->
-    <Mark>
-      <Control>intro_end_position</Control>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-      <Text>&#9698;|</Text>
-      <Align>bottom</Align>
-      <Color>#0000FF</Color>
-      <Opacity>0.1</Opacity>
-      <TextColor>#FFFFFF</TextColor>
-    </Mark>
-    <Mark>
-      <Control>outro_start_position</Control>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-      <Text>|&#9699;</Text>
-      <Align>bottom</Align>
-      <Color>#0000FF</Color>
-      <TextColor>#FFFFFF</TextColor>
-    </Mark>
-    <Mark>
-      <Control>outro_end_position</Control>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-      <Text>&#9699;|</Text>
-      <Align>bottom</Align>
-      <Color>#0000FF</Color>
-      <TextColor>#FFFFFF</TextColor>
-    </Mark>
-    <!--
-    The hotcues not represented by a button in the current skin
-    show only in the waveform under two circumstances:
-    - if a MIDI device which supports more hotcues than buttons
-      are in the current skin has them activated
-    - if you change from a skin which supports more hotcues
-      than buttons are in the current skin (and has them activated)
-    -->
-  </Visual>
+  <WidgetGroup>
+    <Layout>horizontal</Layout>
+    <Children>
+      <Visual>
+        <TooltipId>waveform_display</TooltipId>
+        <Channel><Variable name="channum"/></Channel>
+        <Size>0e,81f</Size>
+        <BgColor>#8D98A3</BgColor>
+        <!--<BgPixmap>style/style_bg_waveform.png</BgPixmap>-->
+        <SignalHighColor></SignalHighColor>
+        <SignalMidColor></SignalMidColor>
+        <SignalLowColor></SignalLowColor>
+        <SignalColor>#191F24</SignalColor>
+        <BeatColor>#FFFFFF</BeatColor>
+        <PlayPosColor>#00FF00</PlayPosColor>
+        <EndOfTrackColor>#EA0000</EndOfTrackColor>
+        <AxesColor>#00FF00</AxesColor>
+        <Align></Align>
+        <DefaultMark>
+          <Align>top</Align>
+          <Color>#FD0564</Color>
+          <TextColor>#FFFFFF</TextColor>
+          <Text> %1 </Text>
+        </DefaultMark>
+        <Mark>
+          <Control>cue_point</Control>
+          <Text>CUE</Text>
+          <Align>top</Align>
+          <Color>#FF001C</Color>
+          <TextColor>#FFFFFF</TextColor>
+        </Mark>
+        <!-- Loop -->
+        <MarkRange>
+          <StartControl>loop_start_position</StartControl>
+          <EndControl>loop_end_position</EndControl>
+          <EnabledControl>loop_enabled</EnabledControl>
+          <Color>#00FF00</Color>
+          <Opacity>0.8</Opacity>
+          <DisabledColor>#BCDBFB</DisabledColor>
+          <DisabledOpacity>0.5</DisabledOpacity>
+        </MarkRange>
+        <Mark>
+          <Control>loop_start_position</Control>
+          <Text>IN</Text>
+          <Align>bottom</Align>
+          <Color>#00FF00</Color>
+          <TextColor>#FFFFFF</TextColor>
+        </Mark>
+        <Mark>
+          <Control>loop_end_position</Control>
+          <Text>OUT</Text>
+          <Align>bottom</Align>
+          <Color>#00FF00</Color>
+          <TextColor>#FFFFFF</TextColor>
+        </Mark>
+        <!-- Intro -->
+        <MarkRange>
+          <StartControl>intro_start_position</StartControl>
+          <EndControl>intro_end_position</EndControl>
+          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+          <Color>#0000FF</Color>
+          <Opacity>0.1</Opacity>
+        </MarkRange>
+        <MarkRange>
+          <StartControl>outro_start_position</StartControl>
+          <EndControl>outro_end_position</EndControl>
+          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+          <Color>#0000FF</Color>
+        </MarkRange>
+        <Mark>
+          <Control>intro_start_position</Control>
+          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+          <Text>|&#9698;</Text>
+          <Align>bottom</Align>
+          <Color>#0000FF</Color>
+          <TextColor>#FFFFFF</TextColor>
+        </Mark>
+        <!-- Outro -->
+        <Mark>
+          <Control>intro_end_position</Control>
+          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+          <Text>&#9698;|</Text>
+          <Align>bottom</Align>
+          <Color>#0000FF</Color>
+          <Opacity>0.1</Opacity>
+          <TextColor>#FFFFFF</TextColor>
+        </Mark>
+        <Mark>
+          <Control>outro_start_position</Control>
+          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+          <Text>|&#9699;</Text>
+          <Align>bottom</Align>
+          <Color>#0000FF</Color>
+          <TextColor>#FFFFFF</TextColor>
+        </Mark>
+        <Mark>
+          <Control>outro_end_position</Control>
+          <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+          <Text>&#9699;|</Text>
+          <Align>bottom</Align>
+          <Color>#0000FF</Color>
+          <TextColor>#FFFFFF</TextColor>
+        </Mark>
+        <!--
+        The hotcues not represented by a button in the current skin
+        show only in the waveform under two circumstances:
+        - if a MIDI device which supports more hotcues than buttons
+          are in the current skin has them activated
+        - if you change from a skin which supports more hotcues
+          than buttons are in the current skin (and has them activated)
+        -->
+      </Visual>
+    </Children>
+  </WidgetGroup>
 </Template>


### PR DESCRIPTION
more detailed steps to solve the skin crash for Deere

**Deere**
Ouutsourcing the Spinny Singleton creation to a separate file alone doesn't fix it.
What helped was moving a `visible` Connection `[Skin],show_spinnies` from the Spinny holder to the Spinny's parent WidgetGroup in the SingletonDefinition.

**Shade**
The crash is also fixed if we wrap the `Visual` node into a WidgetGroup.