### PR TITLE
Preferences: fix tab order in some pages

### DIFF
--- a/src/preferences/dialog/dlgprefbeats.cpp
+++ b/src/preferences/dialog/dlgprefbeats.cpp
@@ -25,19 +25,38 @@ DlgPrefBeats::DlgPrefBeats(QWidget* parent, UserSettingsPointer pConfig)
     loadSettings();
 
     // Connections
-    connect(comboBoxBeatPlugin, SIGNAL(activated(int)), this, SLOT(pluginSelected(int)));
-    connect(checkBoxAnalyzerEnabled, SIGNAL(stateChanged(int)), this, SLOT(analyzerEnabled(int)));
-    connect(checkBoxFixedTempo, SIGNAL(stateChanged(int)), this, SLOT(fixedtempoEnabled(int)));
-    connect(checkBoxOffsetCorr, SIGNAL(stateChanged(int)), this, SLOT(offsetEnabled(int)));
-
-    connect(checkBoxFastAnalysis, SIGNAL(stateChanged(int)), this, SLOT(fastAnalysisEnabled(int)));
-
-    connect(txtMinBpm, SIGNAL(valueChanged(int)),
-            this, SLOT(minBpmRangeChanged(int)));
-    connect(txtMaxBpm, SIGNAL(valueChanged(int)),
-            this, SLOT(maxBpmRangeChanged(int)));
-
-    connect(checkBoxReanalyse, SIGNAL(stateChanged(int)), this, SLOT(slotReanalyzeChanged(int)));
+    connect(comboBoxBeatPlugin,
+            QOverload<int>::of(&QComboBox::activated),
+            this,
+            &DlgPrefBeats::pluginSelected);
+    connect(checkBoxAnalyzerEnabled,
+            &QCheckBox::stateChanged,
+            this,
+            &DlgPrefBeats::analyzerEnabled);
+    connect(checkBoxFixedTempo,
+            &QCheckBox::stateChanged,
+            this,
+            &DlgPrefBeats::fixedtempoEnabled);
+    connect(checkBoxOffsetCorr,
+            &QCheckBox::stateChanged,
+            this,
+            &DlgPrefBeats::offsetEnabled);
+    connect(checkBoxFastAnalysis,
+            &QCheckBox::stateChanged,
+            this,
+            &DlgPrefBeats::fastAnalysisEnabled);
+    connect(txtMinBpm,
+            QOverload<int>::of(&QSpinBox::valueChanged),
+            this,
+            &DlgPrefBeats::minBpmRangeChanged);
+    connect(txtMaxBpm,
+            QOverload<int>::of(&QSpinBox::valueChanged),
+            this,
+            &DlgPrefBeats::maxBpmRangeChanged);
+    connect(checkBoxReanalyse,
+            &QCheckBox::stateChanged,
+            this,
+            &DlgPrefBeats::slotReanalyzeChanged);
     connect(checkBoxReanalyseImported,
             &QCheckBox::stateChanged,
             this,

--- a/src/preferences/dialog/dlgprefbeats.cpp
+++ b/src/preferences/dialog/dlgprefbeats.cpp
@@ -9,42 +9,36 @@ DlgPrefBeats::DlgPrefBeats(QWidget* parent, UserSettingsPointer pConfig)
           m_bpmSettings(pConfig),
           m_minBpm(m_bpmSettings.getBpmRangeStartDefault()),
           m_maxBpm(m_bpmSettings.getBpmRangeEndDefault()),
-          m_banalyzerEnabled(m_bpmSettings.getBpmDetectionEnabledDefault()),
-          m_bfixedtempoEnabled(m_bpmSettings.getFixedTempoAssumptionDefault()),
-          m_boffsetEnabled(m_bpmSettings.getFixedTempoOffsetCorrectionDefault()),
-          m_FastAnalysisEnabled(m_bpmSettings.getFastAnalysisDefault()),
+          m_bAnalyzerEnabled(m_bpmSettings.getBpmDetectionEnabledDefault()),
+          m_bFixedTempoEnabled(m_bpmSettings.getFixedTempoAssumptionDefault()),
+          m_bOffsetEnabled(m_bpmSettings.getFixedTempoOffsetCorrectionDefault()),
+          m_bFastAnalysisEnabled(m_bpmSettings.getFastAnalysisDefault()),
           m_bReanalyze(m_bpmSettings.getReanalyzeWhenSettingsChangeDefault()),
           m_bReanalyzeImported(m_bpmSettings.getReanalyzeImportedDefault()) {
     setupUi(this);
 
     m_availablePlugins = AnalyzerBeats::availablePlugins();
     for (const auto& info : m_availablePlugins) {
-        plugincombo->addItem(info.name, info.id);
+        comboBoxBeatPlugin->addItem(info.name, info.id);
     }
 
     loadSettings();
 
     // Connections
-    connect(plugincombo, SIGNAL(activated(int)),
-            this, SLOT(pluginSelected(int)));
-    connect(banalyzerenabled, SIGNAL(stateChanged(int)),
-            this, SLOT(analyzerEnabled(int)));
-    connect(bfixedtempo, SIGNAL(stateChanged(int)),
-            this, SLOT(fixedtempoEnabled(int)));
-    connect(boffset, SIGNAL(stateChanged(int)),
-            this, SLOT(offsetEnabled(int)));
+    connect(comboBoxBeatPlugin, SIGNAL(activated(int)), this, SLOT(pluginSelected(int)));
+    connect(checkBoxAnalyzerEnabled, SIGNAL(stateChanged(int)), this, SLOT(analyzerEnabled(int)));
+    connect(checkBoxFixedTempo, SIGNAL(stateChanged(int)), this, SLOT(fixedtempoEnabled(int)));
+    connect(checkBoxOffsetCorr, SIGNAL(stateChanged(int)), this, SLOT(offsetEnabled(int)));
 
-    connect(bFastAnalysis, SIGNAL(stateChanged(int)),
-            this, SLOT(fastAnalysisEnabled(int)));
+    connect(checkBoxFastAnalysis, SIGNAL(stateChanged(int)), this, SLOT(fastAnalysisEnabled(int)));
 
     connect(txtMinBpm, SIGNAL(valueChanged(int)),
             this, SLOT(minBpmRangeChanged(int)));
     connect(txtMaxBpm, SIGNAL(valueChanged(int)),
             this, SLOT(maxBpmRangeChanged(int)));
 
-    connect(bReanalyse,SIGNAL(stateChanged(int)),
-            this, SLOT(slotReanalyzeChanged(int)));
-    connect(bReanalyzeImported,
+    connect(checkBoxReanalyse, SIGNAL(stateChanged(int)), this, SLOT(slotReanalyzeChanged(int)));
+    connect(checkBoxReanalyseImported,
             &QCheckBox::stateChanged,
             this,
             &DlgPrefBeats::slotReanalyzeImportedChanged);
@@ -59,11 +53,11 @@ QUrl DlgPrefBeats::helpUrl() const {
 
 void DlgPrefBeats::loadSettings() {
     m_selectedAnalyzerId = m_bpmSettings.getBeatPluginId();
-    m_banalyzerEnabled = m_bpmSettings.getBpmDetectionEnabled();
-    m_bfixedtempoEnabled = m_bpmSettings.getFixedTempoAssumption();
-    m_boffsetEnabled = m_bpmSettings.getFixedTempoOffsetCorrection();
+    m_bAnalyzerEnabled = m_bpmSettings.getBpmDetectionEnabled();
+    m_bFixedTempoEnabled = m_bpmSettings.getFixedTempoAssumption();
+    m_bOffsetEnabled = m_bpmSettings.getFixedTempoOffsetCorrection();
     m_bReanalyze =  m_bpmSettings.getReanalyzeWhenSettingsChange();
-    m_FastAnalysisEnabled = m_bpmSettings.getFastAnalysis();
+    m_bFastAnalysisEnabled = m_bpmSettings.getFastAnalysis();
 
     // TODO(rryan): Above range enabled is not exposed?
     m_minBpm = m_bpmSettings.getBpmRangeStart();
@@ -76,10 +70,10 @@ void DlgPrefBeats::slotResetToDefaults() {
     if (m_availablePlugins.size() > 0) {
         m_selectedAnalyzerId = m_availablePlugins[0].id;
     }
-    m_banalyzerEnabled = m_bpmSettings.getBpmDetectionEnabledDefault();
-    m_bfixedtempoEnabled = m_bpmSettings.getFixedTempoAssumptionDefault();
-    m_boffsetEnabled = m_bpmSettings.getFixedTempoOffsetCorrectionDefault();
-    m_FastAnalysisEnabled = m_bpmSettings.getFastAnalysisDefault();
+    m_bAnalyzerEnabled = m_bpmSettings.getBpmDetectionEnabledDefault();
+    m_bFixedTempoEnabled = m_bpmSettings.getFixedTempoAssumptionDefault();
+    m_bOffsetEnabled = m_bpmSettings.getFixedTempoOffsetCorrectionDefault();
+    m_bFastAnalysisEnabled = m_bpmSettings.getFastAnalysisDefault();
     m_bReanalyze = m_bpmSettings.getReanalyzeWhenSettingsChangeDefault();
     // TODO(rryan): Above range enabled is not exposed?
     m_minBpm = m_bpmSettings.getBpmRangeStartDefault();
@@ -96,17 +90,17 @@ void DlgPrefBeats::pluginSelected(int i) {
 }
 
 void DlgPrefBeats::analyzerEnabled(int i) {
-    m_banalyzerEnabled = static_cast<bool>(i);
+    m_bAnalyzerEnabled = static_cast<bool>(i);
     slotUpdate();
 }
 
 void DlgPrefBeats::fixedtempoEnabled(int i) {
-    m_bfixedtempoEnabled = static_cast<bool>(i);
+    m_bFixedTempoEnabled = static_cast<bool>(i);
     slotUpdate();
 }
 
 void DlgPrefBeats::offsetEnabled(int i) {
-    m_boffsetEnabled = static_cast<bool>(i);
+    m_bOffsetEnabled = static_cast<bool>(i);
     slotUpdate();
 }
 
@@ -121,18 +115,18 @@ void DlgPrefBeats::maxBpmRangeChanged(int value) {
 }
 
 void DlgPrefBeats::slotUpdate() {
-    bfixedtempo->setEnabled(m_banalyzerEnabled);
-    boffset->setEnabled((m_banalyzerEnabled && m_bfixedtempoEnabled));
-    plugincombo->setEnabled(m_banalyzerEnabled);
-    banalyzerenabled->setChecked(m_banalyzerEnabled);
+    checkBoxFixedTempo->setEnabled(m_bAnalyzerEnabled);
+    checkBoxOffsetCorr->setEnabled((m_bAnalyzerEnabled && m_bFixedTempoEnabled));
+    comboBoxBeatPlugin->setEnabled(m_bAnalyzerEnabled);
+    checkBoxAnalyzerEnabled->setChecked(m_bAnalyzerEnabled);
     // Fast analysis cannot be combined with non-constant tempo beatgrids.
-    bFastAnalysis->setEnabled(m_banalyzerEnabled && m_bfixedtempoEnabled);
-    txtMaxBpm->setEnabled(m_banalyzerEnabled && m_bfixedtempoEnabled);
-    txtMinBpm->setEnabled(m_banalyzerEnabled && m_bfixedtempoEnabled);
-    bReanalyse->setEnabled(m_banalyzerEnabled);
-    bReanalyzeImported->setEnabled(m_bReanalyzeImported);
+    checkBoxFastAnalysis->setEnabled(m_bAnalyzerEnabled && m_bFixedTempoEnabled);
+    txtMaxBpm->setEnabled(m_bAnalyzerEnabled && m_bFixedTempoEnabled);
+    txtMinBpm->setEnabled(m_bAnalyzerEnabled && m_bFixedTempoEnabled);
+    checkBoxReanalyse->setEnabled(m_bAnalyzerEnabled);
+    checkBoxReanalyseImported->setEnabled(m_bReanalyzeImported);
 
-    if (!m_banalyzerEnabled) {
+    if (!m_bAnalyzerEnabled) {
         return;
     }
 
@@ -142,28 +136,28 @@ void DlgPrefBeats::slotUpdate() {
             const auto& info = m_availablePlugins.at(i);
             if (info.id == m_selectedAnalyzerId) {
                 found = true;
-                plugincombo->setCurrentIndex(i);
+                comboBoxBeatPlugin->setCurrentIndex(i);
                 if (!m_availablePlugins[i].constantTempoSupported) {
-                    bfixedtempo->setEnabled(false);
-                    boffset->setEnabled(false);
+                    checkBoxFixedTempo->setEnabled(false);
+                    checkBoxOffsetCorr->setEnabled(false);
                 }
                 break;
             }
         }
         if (!found) {
-            plugincombo->setCurrentIndex(0);
+            comboBoxBeatPlugin->setCurrentIndex(0);
             m_selectedAnalyzerId = m_availablePlugins[0].id;
         }
     }
 
-    bfixedtempo->setChecked(m_bfixedtempoEnabled);
-    boffset->setChecked(m_boffsetEnabled);
+    checkBoxFixedTempo->setChecked(m_bFixedTempoEnabled);
+    checkBoxOffsetCorr->setChecked(m_bOffsetEnabled);
     // Fast analysis cannot be combined with non-constant tempo beatgrids.
-    bFastAnalysis->setChecked(m_FastAnalysisEnabled && m_bfixedtempoEnabled);
+    checkBoxFastAnalysis->setChecked(m_bFastAnalysisEnabled && m_bFixedTempoEnabled);
 
     txtMaxBpm->setValue(m_maxBpm);
     txtMinBpm->setValue(m_minBpm);
-    bReanalyse->setChecked(m_bReanalyze);
+    checkBoxReanalyse->setChecked(m_bReanalyze);
 }
 
 void DlgPrefBeats::slotReanalyzeChanged(int value) {
@@ -177,18 +171,18 @@ void DlgPrefBeats::slotReanalyzeImportedChanged(int value) {
 }
 
 void DlgPrefBeats::fastAnalysisEnabled(int i) {
-    m_FastAnalysisEnabled = static_cast<bool>(i);
+    m_bFastAnalysisEnabled = static_cast<bool>(i);
     slotUpdate();
 }
 
 void DlgPrefBeats::slotApply() {
     m_bpmSettings.setBeatPluginId(m_selectedAnalyzerId);
-    m_bpmSettings.setBpmDetectionEnabled(m_banalyzerEnabled);
-    m_bpmSettings.setFixedTempoAssumption(m_bfixedtempoEnabled);
-    m_bpmSettings.setFixedTempoOffsetCorrection(m_boffsetEnabled);
+    m_bpmSettings.setBpmDetectionEnabled(m_bAnalyzerEnabled);
+    m_bpmSettings.setFixedTempoAssumption(m_bFixedTempoEnabled);
+    m_bpmSettings.setFixedTempoOffsetCorrection(m_bOffsetEnabled);
     m_bpmSettings.setReanalyzeWhenSettingsChange(m_bReanalyze);
     m_bpmSettings.setReanalyzeImported(m_bReanalyzeImported);
-    m_bpmSettings.setFastAnalysis(m_FastAnalysisEnabled);
+    m_bpmSettings.setFastAnalysis(m_bFastAnalysisEnabled);
     m_bpmSettings.setBpmRangeStart(m_minBpm);
     m_bpmSettings.setBpmRangeEnd(m_maxBpm);
 }

--- a/src/preferences/dialog/dlgprefbeats.h
+++ b/src/preferences/dialog/dlgprefbeats.h
@@ -48,10 +48,10 @@ class DlgPrefBeats : public DlgPreferencePage, public Ui::DlgBeatsDlg {
     QString m_selectedAnalyzerId;
     int m_minBpm;
     int m_maxBpm;
-    bool m_banalyzerEnabled;
-    bool m_bfixedtempoEnabled;
-    bool m_boffsetEnabled;
-    bool m_FastAnalysisEnabled;
+    bool m_bAnalyzerEnabled;
+    bool m_bFixedTempoEnabled;
+    bool m_bOffsetEnabled;
+    bool m_bFastAnalysisEnabled;
     bool m_bReanalyze;
     bool m_bReanalyzeImported;
 };

--- a/src/preferences/dialog/dlgprefbeatsdlg.ui
+++ b/src/preferences/dialog/dlgprefbeatsdlg.ui
@@ -15,9 +15,9 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
-    <widget class="QCheckBox" name="banalyzerenabled">
+    <widget class="QCheckBox" name="checkBoxAnalyzerEnabled">
      <property name="toolTip">
-      <string>When beat detection is enabled, Mixxx detects the beats per minute and beats of your tracks, 
+      <string>When beat detection is enabled, Mixxx detects the beats per minute and beats of your tracks,
 automatically shows a beat-grid for them, and allows you to synchronize tracks using their beat information.</string>
      </property>
      <property name="text">
@@ -104,10 +104,10 @@ automatically shows a beat-grid for them, and allows you to synchronize tracks u
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <widget class="QCheckBox" name="bFastAnalysis">
+       <widget class="QCheckBox" name="checkBoxFastAnalysis">
         <property name="toolTip">
-         <string>Enable fast beat detection. 
-If activated Mixxx only analyzes the first minute of a track for beat information. 
+         <string>Enable fast beat detection.
+If activated Mixxx only analyzes the first minute of a track for beat information.
 This can speed up beat detection on slower computers but may result in lower quality beatgrids.</string>
         </property>
         <property name="text">
@@ -116,10 +116,10 @@ This can speed up beat detection on slower computers but may result in lower qua
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="bfixedtempo">
+       <widget class="QCheckBox" name="checkBoxFixedTempo">
         <property name="toolTip">
-         <string>Converts beats detected by the analyzer into a fixed-tempo beatgrid. 
-Use this setting if your tracks have a constant tempo (e.g. most electronic music). 
+         <string>Converts beats detected by the analyzer into a fixed-tempo beatgrid.
+Use this setting if your tracks have a constant tempo (e.g. most electronic music).
 Often results in higher quality beatgrids, but will not do well on tracks that have tempo shifts.</string>
         </property>
         <property name="text">
@@ -128,9 +128,9 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="boffset">
+       <widget class="QCheckBox" name="checkBoxOffsetCorr">
         <property name="toolTip">
-         <string>Attempts to correct the phase (first beat) of fixed-tempo beatgrids 
+         <string>Attempts to correct the phase (first beat) of fixed-tempo beatgrids
 by analyzing the beats to discard outliers.</string>
         </property>
         <property name="text">
@@ -139,7 +139,7 @@ by analyzing the beats to discard outliers.</string>
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="bReanalyse">
+       <widget class="QCheckBox" name="checkBoxReanalyse">
         <property name="toolTip">
          <string>e.g. from 3rd-party programs or Mixxx versions before 1.11.
 (Not checked: Analyze only, if no beats exist.)</string>
@@ -150,7 +150,7 @@ by analyzing the beats to discard outliers.</string>
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="bReanalyzeImported">
+       <widget class="QCheckBox" name="checkBoxReanalyseImported">
         <property name="text">
          <string>Re-analyze beatgrids imported from other DJ software</string>
         </property>
@@ -188,7 +188,7 @@ by analyzing the beats to discard outliers.</string>
        </widget>
       </item>
       <item>
-       <widget class="QComboBox" name="plugincombo">
+       <widget class="QComboBox" name="comboBoxBeatPlugin">
         <property name="minimumSize">
          <size>
           <width>200</width>
@@ -215,6 +215,17 @@ by analyzing the beats to discard outliers.</string>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <tabstops>
+  <tabstop>checkBoxAnalyzerEnabled</tabstop>
+  <tabstop>comboBoxBeatPlugin</tabstop>
+  <tabstop>checkBoxFastAnalysis</tabstop>
+  <tabstop>checkBoxFixedTempo</tabstop>
+  <tabstop>checkBoxOffsetCorr</tabstop>
+  <tabstop>checkBoxReanalyse</tabstop>
+  <tabstop>checkBoxReanalyseImported</tabstop>
+  <tabstop>txtMinBpm</tabstop>
+  <tabstop>txtMaxBpm</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/preferences/dialog/dlgprefbroadcast.cpp
+++ b/src/preferences/dialog/dlgprefbroadcast.cpp
@@ -69,6 +69,7 @@ DlgPrefBroadcast::DlgPrefBroadcast(QWidget *parent,
 
     updateModel();
     connectionList->setModel(m_pSettingsModel);
+    connectionList->setTabKeyNavigation(false);
 
     connect(connectionList->selectionModel(),
             SIGNAL(currentRowChanged(const QModelIndex&, const QModelIndex&)),

--- a/src/preferences/dialog/dlgprefbroadcast.cpp
+++ b/src/preferences/dialog/dlgprefbroadcast.cpp
@@ -64,26 +64,35 @@ DlgPrefBroadcast::DlgPrefBroadcast(QWidget *parent,
     stream_ICQ->setVisible(false);
 #endif
 
-    connect(connectionList->horizontalHeader(), SIGNAL(sectionResized(int, int, int)),
-            this, SLOT(onSectionResized()));
+    connect(connectionList->horizontalHeader(),
+            &QHeaderView::sectionResized,
+            this,
+            &DlgPrefBroadcast::onSectionResized);
 
     updateModel();
     connectionList->setModel(m_pSettingsModel);
     connectionList->setTabKeyNavigation(false);
 
     connect(connectionList->selectionModel(),
-            SIGNAL(currentRowChanged(const QModelIndex&, const QModelIndex&)),
+            &QItemSelectionModel::currentRowChanged,
             this,
-            SLOT(connectionListItemSelected(const QModelIndex&)));
-    connect(btnRemoveConnection, SIGNAL(clicked(bool)),
-            this, SLOT(btnRemoveConnectionClicked()));
-    connect(btnRenameConnection, SIGNAL(clicked(bool)),
-            this, SLOT(btnRenameConnectionClicked()));
-    connect(btnCreateConnection, SIGNAL(clicked(bool)),
-            this, SLOT(btnCreateConnectionClicked()));
-
-    connect(btnDisconnectAll, SIGNAL(clicked(bool)),
-            this, SLOT(btnDisconnectAllClicked()));
+            &DlgPrefBroadcast::connectionListItemSelected);
+    connect(btnRemoveConnection,
+            &QPushButton::clicked,
+            this,
+            &DlgPrefBroadcast::btnRemoveConnectionClicked);
+    connect(btnRenameConnection,
+            &QPushButton::clicked,
+            this,
+            &DlgPrefBroadcast::btnRenameConnectionClicked);
+    connect(btnCreateConnection,
+            &QPushButton::clicked,
+            this,
+            &DlgPrefBroadcast::btnCreateConnectionClicked);
+    connect(btnDisconnectAll,
+            &QPushButton::clicked,
+            this,
+            &DlgPrefBroadcast::btnDisconnectAllClicked);
 
     // Highlight first row
     connectionList->selectRow(0);
@@ -133,14 +142,18 @@ DlgPrefBroadcast::DlgPrefBroadcast(QWidget *parent,
      comboBoxEncodingChannels->addItem(tr("Stereo"),
              static_cast<int>(EncoderSettings::ChannelMode::STEREO));
 
-     connect(checkBoxEnableReconnect, SIGNAL(stateChanged(int)),
-             this, SLOT(checkBoxEnableReconnectChanged(int)));
-
-     connect(checkBoxLimitReconnects, SIGNAL(stateChanged(int)),
-             this, SLOT(checkBoxLimitReconnectsChanged(int)));
-
-     connect(enableCustomMetadata, SIGNAL(stateChanged(int)),
-             this, SLOT(enableCustomMetadataChanged(int)));
+     connect(checkBoxEnableReconnect,
+             &QCheckBox::stateChanged,
+             this,
+             &DlgPrefBroadcast::checkBoxEnableReconnectChanged);
+     connect(checkBoxLimitReconnects,
+             &QCheckBox::stateChanged,
+             this,
+             &DlgPrefBroadcast::checkBoxLimitReconnectsChanged);
+     connect(enableCustomMetadata,
+             &QCheckBox::stateChanged,
+             this,
+             &DlgPrefBroadcast::enableCustomMetadataChanged);
 }
 
 DlgPrefBroadcast::~DlgPrefBroadcast() {

--- a/src/preferences/dialog/dlgprefbroadcastdlg.ui
+++ b/src/preferences/dialog/dlgprefbroadcastdlg.ui
@@ -859,6 +859,48 @@ p, li { white-space: pre-wrap; }
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <tabstops>
+  <tabstop>connectionList</tabstop>
+  <tabstop>btnRemoveConnection</tabstop>
+  <tabstop>btnRenameConnection</tabstop>
+  <tabstop>btnDisconnectAll</tabstop>
+  <tabstop>btnCreateConnection</tabstop>
+  <tabstop>connectOnApply</tabstop>
+
+  <tabstop>comboBoxServerType</tabstop>
+  <tabstop>mountpoint</tabstop>
+  <tabstop>host</tabstop>
+  <tabstop>port</tabstop>
+  <tabstop>login</tabstop>
+  <tabstop>password</tabstop>
+  <tabstop>rbPasswordCleartext</tabstop>
+
+  <tabstop>checkBoxEnableReconnect</tabstop>
+  <tabstop>spinBoxFirstDelay</tabstop>
+  <tabstop>spinBoxReconnectPeriod</tabstop>
+  <tabstop>checkBoxLimitReconnects</tabstop>
+  <tabstop>spinBoxMaximumRetries</tabstop>
+
+  <tabstop>comboBoxEncodingBitrate</tabstop>
+  <tabstop>comboBoxEncodingFormat</tabstop>
+  <tabstop>comboBoxEncodingChannels</tabstop>
+
+  <tabstop>stream_public</tabstop>
+  <tabstop>stream_name</tabstop>
+  <tabstop>stream_website</tabstop>
+  <tabstop>stream_desc</tabstop>
+  <tabstop>stream_genre</tabstop>
+  <tabstop>stream_IRC</tabstop>
+  <tabstop>stream_AIM</tabstop>
+  <tabstop>stream_ICQ</tabstop>
+
+  <tabstop>metadata_format</tabstop>
+  <tabstop>enableCustomMetadata</tabstop>
+  <tabstop>custom_artist</tabstop>
+  <tabstop>custom_title</tabstop>
+  <tabstop>ogg_dynamicupdate</tabstop>
+  <tabstop>enableUtf8Metadata</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
  <buttongroups>

--- a/src/preferences/dialog/dlgprefdeckdlg.ui
+++ b/src/preferences/dialog/dlgprefdeckdlg.ui
@@ -464,9 +464,6 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           <property name="text">
            <string>Speed/Tempo</string>
           </property>
-          <attribute name="buttonGroup">
-           <string notr="true">buttonGroupSpeedPitchReset</string>
-          </attribute>
          </widget>
         </item>
         <item row="1" column="1">
@@ -474,9 +471,6 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           <property name="text">
            <string>Key/Pitch</string>
           </property>
-          <attribute name="buttonGroup">
-           <string notr="true">buttonGroupSpeedPitchReset</string>
-          </attribute>
          </widget>
         </item>
         <item row="6" column="0">
@@ -648,10 +642,14 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
  <layoutdefault spacing="6" margin="11"/>
  <tabstops>
   <tabstop>ComboBoxCueMode</tabstop>
+  <tabstop>checkBoxIntroStartMove</tabstop>
   <tabstop>radioButtonElapsed</tabstop>
   <tabstop>radioButtonRemaining</tabstop>
   <tabstop>radioButtonElapsedAndRemaining</tabstop>
+  <tabstop>comboBoxTimeFormat</tabstop>
+  <tabstop>comboBoxLoadPoint</tabstop>
   <tabstop>checkBoxDisallowLoadToPlayingDeck</tabstop>
+  <tabstop>checkBoxCloneDeckOnLoadDoubleTap</tabstop>
   <tabstop>ComboBoxRateRange</tabstop>
   <tabstop>checkBoxInvertSpeedSlider</tabstop>
   <tabstop>checkBoxResetPitch</tabstop>
@@ -805,10 +803,5 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
   <buttongroup name="buttonGroupKeyUnlockMode"/>
   <buttongroup name="buttonGroupKeyLockMode"/>
   <buttongroup name="buttonGroupSpeedBendBehavior"/>
-  <buttongroup name="buttonGroupSpeedPitchReset">
-   <property name="exclusive">
-    <bool>false</bool>
-   </property>
-  </buttongroup>
  </buttongroups>
 </ui>

--- a/src/preferences/dialog/dlgprefeqdlg.ui
+++ b/src/preferences/dialog/dlgprefeqdlg.ui
@@ -410,6 +410,21 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <tabstops>
+  <tabstop>CheckBoxEqOnly</tabstop>
+  <tabstop>CheckBoxSingleEqEffect</tabstop>
+  <!-- TODO(ronso0)
+      Dynamically add Eq / Quick Effect comboboxes -->
+  <tabstop>SliderHiEQ</tabstop>
+  <tabstop>SliderLoEQ</tabstop>
+  <tabstop>comboBoxMasterEq</tabstop>
+  <tabstop>pbResetMasterEq</tabstop>
+  <!-- TODO(ronso0)
+      Dynamically add Master EQ sliders -->
+  <tabstop>CheckBoxEqAutoReset</tabstop>
+  <tabstop>CheckBoxGainAutoReset</tabstop>
+  <tabstop>CheckBoxBypass</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -433,10 +433,17 @@
   <tabstop>sampleRateComboBox</tabstop>
   <tabstop>audioBufferComboBox</tabstop>
   <tabstop>deviceSyncComboBox</tabstop>
-  <tabstop>headDelaySpinBox</tabstop>
+  <tabstop>engineClockComboBox</tabstop>
+  <tabstop>keylockComboBox</tabstop>
+  <tabstop>masterMixComboBox</tabstop>
+  <tabstop>masterOutputModeComboBox</tabstop>
+  <tabstop>micMonitorModeComboBox</tabstop>
+  <tabstop>latencyCompensationSpinBox</tabstop>
   <tabstop>masterDelaySpinBox</tabstop>
-  <tabstop>ioTabs</tabstop>
+  <tabstop>headDelaySpinBox</tabstop>
+  <tabstop>boothDelaySpinBox</tabstop>
   <tabstop>queryButton</tabstop>
+  <tabstop>ioTabs</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -571,6 +571,27 @@ Select from different types of displays for the waveform, which differ primarily
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>waveformTypeComboBox</tabstop>
+  <tabstop>waveformOverviewComboBox</tabstop>
+  <tabstop>frameRateSlider</tabstop>
+  <tabstop>frameRateSpinBox</tabstop>
+  <tabstop>endOfTrackWarningTimeSlider</tabstop>
+  <tabstop>endOfTrackWarningTimeSpinBox</tabstop>
+  <tabstop>beatGridAlphaSlider</tabstop>
+  <tabstop>beatGridAlphaSpinBox</tabstop>
+  <tabstop>playMarkerPositionSlider</tabstop>
+  <tabstop>defaultZoomComboBox</tabstop>
+  <tabstop>synchronizeZoomCheckBox</tabstop>
+  <tabstop>normalizeOverviewCheckBox</tabstop>
+  <tabstop>allVisualGain</tabstop>
+  <tabstop>lowVisualGain</tabstop>
+  <tabstop>midVisualGain</tabstop>
+  <tabstop>highVisualGain</tabstop>
+  <tabstop>enableWaveformCaching</tabstop>
+  <tabstop>enableWaveformGenerationWithAnalysis</tabstop>
+  <tabstop>clearCachedWaveforms</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -517,42 +517,42 @@ Select from different types of displays for the waveform, which differ primarily
       </widget>
      </item>
      <item row="5" column="0">
-        <widget class="QLabel" name="label">
-        <property name="text">
-                <string>Play marker position</string>
-        </property>
-        </widget>
-        </item>
-        <item row="5" column="1" colspan="3">
-        <widget class="QSlider" name="playMarkerPositionSlider">
-         <property name="toolTip">
-           <string>Moves the play marker position on the waveforms to the left, right or center (default).</string>
-         </property>
-         <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                 </sizepolicy>
-         </property>
-         <property name="maximumSize">
-                 <size>
-                 <width>16777215</width>
-                 <height>16777215</height>
-                 </size>
-         </property>
-         <property name="minimum">
-                 <number>0</number>
-         </property>
-         <property name="maximum">
-                 <number>100</number>
-         </property>
-         <property name="value">
-                 <number>50</number>
-         </property>
-         <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
+      <widget class="QLabel" name="label">
+      <property name="text">
+       <string>Play marker position</string>
+      </property>
+      </widget>
+      </item>
+      <item row="5" column="1" colspan="3">
+      <widget class="QSlider" name="playMarkerPositionSlider">
+       <property name="toolTip">
+        <string>Moves the play marker position on the waveforms to the left, right or center (default).</string>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="minimum">
+        <number>0</number>
+       </property>
+       <property name="maximum">
+        <number>100</number>
+       </property>
+       <property name="value">
+        <number>50</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1897802

and first step to fix https://bugs.launchpad.net/mixxx/+bug/1882262

- [x] Beat Analyzer
- [x] Decks
- [x] EQ (except the dynamically added Master EQ sliders)
- [x] Sound Hardware (except the random tab order in the input/output tabs)
- [x] Waveforms
- [x] Broadcasting