### PR TITLE
Reverse ordering of history playlists

### DIFF
--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -143,7 +143,7 @@ QList<BasePlaylistFeature::IdAndLabel> SetlogFeature::createPlaylistLabels() {
     playlistTableModel.setTable("Playlists");
     playlistTableModel.setFilter("hidden=2"); // PLHT_SET_LOG
     playlistTableModel.setSort(
-            playlistTableModel.fieldIndex("id"), Qt::AscendingOrder);
+            playlistTableModel.fieldIndex("id"), Qt::DescendingOrder);
     playlistTableModel.select();
     while (playlistTableModel.canFetchMore()) {
         playlistTableModel.fetchMore();


### PR DESCRIPTION
It's more common to look for newer playlists than older ones, so reversing the list makes for less scrolling.