### PR TITLE
PaAlsa_EnableRealtimeScheduling fix 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,9 @@
 * Add controller mapping for Hercules DJControl Jogvision #2370
 * Fix missing manual in deb package lp:1889776
 * Fix caching of duplicate tracks that reference the same file #3027
-* Fix loss of precision when dealing with floating-point sample positions while setting loop out position and seeking using vinyl control #3126 #3127
+* Fix loss of precision when dealing with floating-point sample 
+  positions while setting loop out position and seeking using vinyl control #3126 #3127
+* Fix possible memory corruption using JACK on Linux 
 
 ==== 2.2.4 2020-05-10 ====
 

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -6,6 +6,8 @@
 #include <QThread>
 #include <QtDebug>
 
+
+
 #include "control/controlobject.h"
 #include "control/controlproxy.h"
 #include "soundio/sounddevice.h"
@@ -21,12 +23,8 @@
 #include "waveform/visualplayposition.h"
 
 #ifdef __LINUX__
-extern "C" {
-
-// Declare the following function to enable real-time priority callback
-// thread from ALSA/PortAudio. This is not part of the generic interface.
-extern void PaAlsa_EnableRealtimeScheduling(PaStream* s, int enable);
-}
+// for PaAlsa_EnableRealtimeScheduling
+#include <pa_linux_alsa.h>
 #endif
 
 namespace {

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -1,33 +1,13 @@
-/***************************************************************************
-                          sounddeviceportaudio.cpp
-                             -------------------
-    begin                : Sun Aug 15, 2007 (Stardate -315378.5417935057)
-    copyright            : (C) 2007 Albert Santoni
-    email                : gamegod \a\t users.sf.net
- ***************************************************************************/
+#pragma once
 
-/***************************************************************************
- *                                                                         *
- *   This program is free software; you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation; either version 2 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- ***************************************************************************/
-
-#ifndef SOUNDDEVICEPORTAUDIO_H
-#define SOUNDDEVICEPORTAUDIO_H
 
 #include <portaudio.h>
-
+#include <QHash>
 #include <QString>
-#include "util/performancetimer.h"
 
 #include "soundio/sounddevice.h"
 #include "util/duration.h"
-#include "util/fifo.h"
-
-#define CPU_USAGE_UPDATE_RATE 30 // in 1/s, fits to display frame rate
+#include "util/performancetimer.h"
 
 class SoundManager;
 class ControlProxy;
@@ -99,4 +79,3 @@ class SoundDevicePortAudio : public SoundDevice {
     PaTime m_lastCallbackEntrytoDacSecs;
 };
 
-#endif

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -32,11 +32,6 @@
 class SoundManager;
 class ControlProxy;
 
-/** Dynamically resolved function which allows us to enable a realtime-priority callback
-    thread from ALSA/PortAudio. This must be dynamically resolved because PortAudio can't
-    tell us if ALSA is compiled into it or not. */
-typedef int (*EnableAlsaRT)(PaStream* s, int enable);
-
 class SoundDevicePortAudio : public SoundDevice {
   public:
     SoundDevicePortAudio(UserSettingsPointer config,


### PR DESCRIPTION
This fixes a crash I have uncounted during my testes with different Portaudio version. 
Without this patch, the PaAlsa_EnableRealtimeScheduling writes a random byte in the JACK case and if the PaAlsaStream structure changes. 
  