### PR TITLE
Fix touch control

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c++
 matrix:
   include:
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
       compiler: gcc
 
@@ -37,7 +37,7 @@ addons:
       - libtag1-dev
       - libupower-glib-dev
       - libusb-1.0-0-dev
-      - libvamp-hostsdk3
+      - libvamp-hostsdk3v5
       - libwavpack-dev
       - portaudio19-dev
       - protobuf-compiler
@@ -65,7 +65,7 @@ install:
   - export COMMON="-j4 qt5=1 test=1 mad=1 faad=1 ffmpeg=1 opus=1 modplug=1 wv=1 hss1394=0 virtualize=0 debug_assertions_fatal=1 verbose=0"
 
   #####
-  # Ubuntu Trusty Build
+  # Ubuntu Xenial Build
 
   ####
   # OS X Build

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,9 @@
 * Add controller mapping for Hercules DJControl Jogvision #2370
 * Fix missing manual in deb package lp:1889776
 * Fix caching of duplicate tracks that reference the same file #3027
-* Fix loss of precision when dealing with floating-point sample positions while setting loop out position and seeking using vinyl control #3126 #3127
+* Fix loss of precision when dealing with floating-point sample positions 
+  while setting loop out position and seeking using vinyl control #3126 #3127
+* Fix touch control lp:1895431
 
 ==== 2.2.4 2020-05-10 ====
 

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -219,7 +219,6 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
         pConfig->getValue(ConfigKey("[Controls]", "Tooltips"),
                 static_cast<int>(mixxx::TooltipsPreference::TOOLTIPS_ON)));
 
-    setAttribute(Qt::WA_AcceptTouchEvents);
     m_pTouchShift = new ControlPushButton(ConfigKey("[Controls]", "touch_shift"));
 
     m_pChannelHandleFactory = new ChannelHandleFactory();
@@ -1363,26 +1362,6 @@ bool MixxxMainWindow::eventFilter(QObject* obj, QEvent* event) {
     }
     // standard event processing
     return QObject::eventFilter(obj, event);
-}
-
-bool MixxxMainWindow::event(QEvent* e) {
-    switch(e->type()) {
-    case QEvent::TouchBegin:
-    case QEvent::TouchUpdate:
-    case QEvent::TouchEnd:
-    {
-        // If the touch event falls through to the main widget, no touch widget
-        // was touched, so we resend it as a mouse event.
-        // We have to accept it here, so QApplication will continue to deliver
-        // the following events of this touch point as well.
-        QTouchEvent* touchEvent = static_cast<QTouchEvent*>(e);
-        touchEvent->accept();
-        return true;
-    }
-    default:
-        break;
-    }
-    return QWidget::event(e);
 }
 
 void MixxxMainWindow::closeEvent(QCloseEvent *event) {

--- a/src/mixxx.h
+++ b/src/mixxx.h
@@ -110,9 +110,8 @@ class MixxxMainWindow : public QMainWindow {
 
   protected:
     // Event filter to block certain events (eg. tooltips if tooltips are disabled)
-    virtual bool eventFilter(QObject *obj, QEvent *event);
-    virtual void closeEvent(QCloseEvent *event);
-    virtual bool event(QEvent* e);
+    bool eventFilter(QObject *obj, QEvent *event) override;
+    void closeEvent(QCloseEvent *event) override;
 
   private:
     void initialize(QApplication *app, const CmdlineArgs& args);

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -43,10 +43,11 @@ Q_IMPORT_PLUGIN(qtaccessiblewidgets)
 
 namespace {
 
+/// This class allows to change the button of a mouse event on the fly. 
+/// This is required because we want to change the behaviour of Qts mouse
+/// buttony synthesizer without duplicate all the code. 
 class QMouseEventEditable : public QMouseEvent {
   public:
-    // Inherit constructors from base class
-    using QMouseEvent::QMouseEvent;
     void setButton(Qt::MouseButton button) {
         b = button;
     }

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -57,7 +57,7 @@ class QMouseEventEditable : public QMouseEvent {
 
 MixxxApplication::MixxxApplication(int& argc, char** argv)
         : QApplication(argc, argv),
-          m_rightPessedButtons(0),
+          m_rightPressedButtons(0),
           m_pTouchShift(nullptr) {
     registerMetaTypes();
 }
@@ -231,11 +231,11 @@ bool MixxxApplication::notify(QObject* target, QEvent* event) {
                 touchIsRightButton()) {
             // Assert the assumption that QT synthesizes only one click at a time
             // = two events (see above)
-            VERIFY_OR_DEBUG_ASSERT(m_rightPessedButtons < 2) {
+            VERIFY_OR_DEBUG_ASSERT(m_rightPressedButtons < 2) {
                 break;
             }
             mouseEvent->setButton(Qt::RightButton);
-            m_rightPessedButtons++;
+            m_rightPressedButtons++;
         }
         break;
     }
@@ -243,9 +243,9 @@ bool MixxxApplication::notify(QObject* target, QEvent* event) {
         QMouseEventEditable* mouseEvent = static_cast<QMouseEventEditable*>(event);
         if (mouseEvent->source() == Qt::MouseEventSynthesizedByQt &&
                 mouseEvent->button() == Qt::LeftButton &&
-                m_rightPessedButtons > 0) {
+                m_rightPressedButtons > 0) {
             mouseEvent->setButton(Qt::RightButton);
-            m_rightPessedButtons--;
+            m_rightPressedButtons--;
         }
         break;
     }

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -255,5 +255,5 @@ bool MixxxApplication::touchIsRightButton() {
         m_pTouchShift = new ControlProxy(
                 "[Controls]", "touch_shift", this);
     }
-    return (m_pTouchShift->toBool());
+    return m_pTouchShift->toBool();
 }

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -41,13 +41,23 @@ Q_IMPORT_PLUGIN(qtaccessiblewidgets)
 #endif
 #endif
 
+namespace {
+
+class QMouseEventEditable : public QMouseEvent {
+  public:
+    // Inherit constructors from base class
+    using QMouseEvent::QMouseEvent;
+    void setButton(Qt::MouseButton button) {
+        b = button;
+    }
+};
+
+} // anonymous namespace
 
 MixxxApplication::MixxxApplication(int& argc, char** argv)
         : QApplication(argc, argv),
-          m_fakeMouseSourcePointId(0),
-          m_fakeMouseWidget(NULL),
-          m_activeTouchButton(Qt::NoButton),
-          m_pTouchShift(NULL) {
+          m_rightPessedButtons(0),
+          m_pTouchShift(nullptr) {
     registerMetaTypes();
 }
 
@@ -206,6 +216,39 @@ bool MixxxApplication::notify(QObject* target, QEvent* event) {
 }
 #endif // QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
 #endif // Q_OS_MAC
+
+bool MixxxApplication::notify(QObject* target, QEvent* event) {
+    // All touch events are translated in two simultaneous events one for
+    // target QWidgetWindow and one for the target QWidget
+    // A second touch becomes a mouse move without additional press and release
+    // events
+    switch (event->type()) {
+    case QEvent::MouseButtonPress: {
+        QMouseEventEditable* mouseEvent = static_cast<QMouseEventEditable*>(event);
+        if (mouseEvent->source() == Qt::MouseEventSynthesizedByQt &&
+                mouseEvent->button() == Qt::LeftButton &&
+                touchIsRightButton()) {
+            mouseEvent->setButton(Qt::RightButton);
+            m_rightPessedButtons++;
+            DEBUG_ASSERT(m_rightPessedButtons <= 2);
+        }
+        break;
+    }
+    case QEvent::MouseButtonRelease: {
+        QMouseEventEditable* mouseEvent = static_cast<QMouseEventEditable*>(event);
+        if (mouseEvent->source() == Qt::MouseEventSynthesizedByQt &&
+                mouseEvent->button() == Qt::LeftButton &&
+                m_rightPessedButtons > 0) {
+            mouseEvent->setButton(Qt::RightButton);
+            m_rightPessedButtons--;
+        }
+        break;
+    }
+    default:
+        break;
+    }
+    return QApplication::notify(target, event);
+}
 
 bool MixxxApplication::touchIsRightButton() {
     if (!m_pTouchShift) {

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -212,5 +212,5 @@ bool MixxxApplication::touchIsRightButton() {
         m_pTouchShift = new ControlProxy(
                 "[Controls]", "touch_shift", this);
     }
-    return (m_pTouchShift->get() != 0.0);
+    return (m_pTouchShift->toBool());
 }

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -228,9 +228,13 @@ bool MixxxApplication::notify(QObject* target, QEvent* event) {
         if (mouseEvent->source() == Qt::MouseEventSynthesizedByQt &&
                 mouseEvent->button() == Qt::LeftButton &&
                 touchIsRightButton()) {
+            // Assert the assumption that QT synthesizes only one click at a time
+            // = two events (see above)
+            VERIFY_OR_DEBUG_ASSERT(m_rightPessedButtons < 2) {
+                break;
+            }
             mouseEvent->setButton(Qt::RightButton);
             m_rightPessedButtons++;
-            DEBUG_ASSERT(m_rightPessedButtons <= 2);
         }
         break;
     }

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -219,10 +219,10 @@ bool MixxxApplication::notify(QObject* target, QEvent* event) {
 #endif // Q_OS_MAC
 
 bool MixxxApplication::notify(QObject* target, QEvent* event) {
-    // All touch events are translated in two simultaneous events one for
-    // target QWidgetWindow and one for the target QWidget
+    // All touch events are translated into two simultaneous events: one for
+    // the target QWidgetWindow and one for the target QWidget.
     // A second touch becomes a mouse move without additional press and release
-    // events
+    // events.
     switch (event->type()) {
     case QEvent::MouseButtonPress: {
         QMouseEventEditable* mouseEvent = static_cast<QMouseEventEditable*>(event);

--- a/src/mixxxapplication.h
+++ b/src/mixxxapplication.h
@@ -23,7 +23,7 @@ class MixxxApplication : public QApplication {
     bool touchIsRightButton();
     void registerMetaTypes();
 
-    int m_rightPessedButtons;
+    int m_rightPressedButtons;
     ControlProxy* m_pTouchShift;
 
 };

--- a/src/mixxxapplication.h
+++ b/src/mixxxapplication.h
@@ -17,13 +17,13 @@ class MixxxApplication : public QApplication {
 #endif
 #endif
 
+    bool notify(QObject*, QEvent*) override;
+
   private:
     bool touchIsRightButton();
     void registerMetaTypes();
 
-    int m_fakeMouseSourcePointId;
-    QWidget* m_fakeMouseWidget;
-    enum Qt::MouseButton m_activeTouchButton;
+    int m_rightPessedButtons;
     ControlProxy* m_pTouchShift;
 
 };

--- a/src/widget/wwidget.cpp
+++ b/src/widget/wwidget.cpp
@@ -38,7 +38,7 @@ WWidget::~WWidget() {
 }
 
 bool WWidget::touchIsRightButton() {
-    return (m_pTouchShift->toBool());
+    return m_pTouchShift->toBool();
 }
 
 bool WWidget::event(QEvent* e) {

--- a/src/widget/wwidget.cpp
+++ b/src/widget/wwidget.cpp
@@ -38,7 +38,7 @@ WWidget::~WWidget() {
 }
 
 bool WWidget::touchIsRightButton() {
-    return (m_pTouchShift->get() != 0.0);
+    return (m_pTouchShift->toBool());
 }
 
 bool WWidget::event(QEvent* e) {

--- a/src/widget/wwidget.cpp
+++ b/src/widget/wwidget.cpp
@@ -91,11 +91,13 @@ bool WWidget::event(QEvent* e) {
             const QTouchEvent::TouchPoint &touchPoint =
                     touchEvent->touchPoints().first();
             QMouseEvent mouseEvent(eventType,
-                    touchPoint.pos().toPoint(),
-                    touchPoint.screenPos().toPoint(),
+                    touchPoint.pos(),
+                    touchPoint.pos(),
+                    touchPoint.screenPos(),
                     m_activeTouchButton, // Button that causes the event
                     Qt::NoButton, // Not used, so no need to fake a proper value.
-                    touchEvent->modifiers());
+                    touchEvent->modifiers(), 
+                    Qt::MouseEventSynthesizedByApplication);
 
             return QWidget::event(&mouseEvent);
         }


### PR DESCRIPTION
This fixes the broken touch control, reported here: 
https://bugs.launchpad.net/mixxx/+bug/1895431

We rely here on our own touch solution for skin buttons. The rest uses the synthesized Qt events. 

This was tested with Ubuntu Bionic
 