### PR TITLE
Removed dependency for clang-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,8 +92,6 @@ repos:
     - manual
     language: python
     files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|m|mm|proto|vert)$
-    additional_dependencies:
-    - clang-format
 - repo: https://github.com/psf/black
   rev: stable
   hooks:


### PR DESCRIPTION
this will make the CI rely on it to be on system path.

Will work for all OS provided clang is installed manually from its original site
https://releases.llvm.org/download.html
