### PR TITLE
WaveformWidgetRenderer: Fix playPosVSample rounding error

### DIFF
--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -136,7 +136,7 @@ void WaveformWidgetRenderer::onPreRender(VSyncThread* vsyncThread) {
         // pixel.
         m_playPos = round(truePlayPos * m_trackPixelCount) / m_trackPixelCount;
         m_totalVSamples = static_cast<int>(m_trackPixelCount * m_visualSamplePerPixel);
-        m_playPosVSample = static_cast<int>(m_playPos) * m_totalVSamples;
+        m_playPosVSample = static_cast<int>(m_playPos * m_totalVSamples);
 
         double leftOffset = m_playMarkerPosition;
         double rightOffset = 1.0 - m_playMarkerPosition;


### PR DESCRIPTION
This is a bug that was introduced by #3125 (one of the `-Wfloat-conversion`
cleanups) and lead to `m_playPosVSample` always being 0. This affects the
preroll waveform renderer which moves the triangles to the playposition
instead of the start of the track.