### PR TITLE
Fix some -Wfloat-conversion warnings (Pt. 8)

### DIFF
--- a/src/waveform/renderers/waveformrendererpreroll.cpp
+++ b/src/waveform/renderers/waveformrendererpreroll.cpp
@@ -65,7 +65,7 @@ void WaveformRendererPreroll::draw(QPainter* painter, QPaintEvent* event) {
         painter->setPen(QPen(QBrush(m_color), std::max(1.0, scaleFactor())));
 
         const double polyPixelWidth = 40.0 / vSamplesPerPixel;
-        const double polyPixelOffset = polyPixelWidth + 1;
+        const double polyPixelOffset = polyPixelWidth + painter->pen().widthF();
         const double polyVSampleOffset = polyPixelOffset * vSamplesPerPixel;
 
         // Rotate if drawing vertical waveforms

--- a/src/waveform/renderers/waveformrendererpreroll.cpp
+++ b/src/waveform/renderers/waveformrendererpreroll.cpp
@@ -44,8 +44,8 @@ void WaveformRendererPreroll::draw(QPainter* painter, QPaintEvent* event) {
         const double vSamplesPerPixel = m_waveformRenderer->getVisualSamplePerPixel();
         const double numberOfVSamples = m_waveformRenderer->getLength() * vSamplesPerPixel;
 
-        int currentVSamplePosition = m_waveformRenderer->getPlayPosVSample();
-        int totalVSamples = m_waveformRenderer->getTotalVSample();
+        const int currentVSamplePosition = m_waveformRenderer->getPlayPosVSample();
+        const int totalVSamples = m_waveformRenderer->getTotalVSample();
         // qDebug() << "currentVSamplePosition" << currentVSamplePosition
         //          << "lastDisplayedPosition" << lastDisplayedPosition
         //          << "vSamplesPerPixel" << vSamplesPerPixel

--- a/src/waveform/renderers/waveformrendererpreroll.cpp
+++ b/src/waveform/renderers/waveformrendererpreroll.cpp
@@ -53,8 +53,6 @@ void WaveformRendererPreroll::draw(QPainter* painter, QPaintEvent* event) {
         //          << "totalVSamples" << totalVSamples
         //          << "WaveformRendererPreroll::playMarkerPosition=" << playMarkerPositionFrac;
 
-        const double polyLength = 40.0 / vSamplesPerPixel;
-        const double polyVSampleSize = (polyLength + 1) * vSamplesPerPixel;
         const float halfBreadth = m_waveformRenderer->getBreadth() / 2.0f;
         const float halfPolyBreadth = m_waveformRenderer->getBreadth() / 5.0f;
 
@@ -65,6 +63,10 @@ void WaveformRendererPreroll::draw(QPainter* painter, QPaintEvent* event) {
         //painter->setBackgroundMode(Qt::TransparentMode);
         painter->setWorldMatrixEnabled(false);
         painter->setPen(QPen(QBrush(m_color), std::max(1.0, scaleFactor())));
+
+        const double polyPixelWidth = 40.0 / vSamplesPerPixel;
+        const double polyPixelOffset = polyPixelWidth + 1;
+        const double polyVSampleOffset = polyPixelOffset * vSamplesPerPixel;
 
         // Rotate if drawing vertical waveforms
         if (m_waveformRenderer->getOrientation() == Qt::Vertical) {
@@ -79,13 +81,14 @@ void WaveformRendererPreroll::draw(QPainter* painter, QPaintEvent* event) {
 
             QPolygonF polygon;
             polygon << QPointF(0, halfBreadth)
-                    << QPointF(-polyLength, halfBreadth - halfPolyBreadth)
-                    << QPointF(-polyLength, halfBreadth + halfPolyBreadth);
+                    << QPointF(-polyPixelWidth, halfBreadth - halfPolyBreadth)
+                    << QPointF(-polyPixelWidth, halfBreadth + halfPolyBreadth);
             polygon.translate(triangleTipVSamplePosition / vSamplesPerPixel, 0);
 
-            for (; triangleTipVSamplePosition > 0; triangleTipVSamplePosition -= polyVSampleSize) {
+            for (; triangleTipVSamplePosition > 0;
+                    triangleTipVSamplePosition -= polyVSampleOffset) {
                 painter->drawPolygon(polygon);
-                polygon.translate(-(polyLength + 1), 0);
+                polygon.translate(-polyPixelOffset, 0);
             }
         }
 
@@ -98,14 +101,14 @@ void WaveformRendererPreroll::draw(QPainter* painter, QPaintEvent* event) {
 
             QPolygonF polygon;
             polygon << QPointF(0, halfBreadth)
-                    << QPointF(polyLength, halfBreadth - halfPolyBreadth)
-                    << QPointF(polyLength, halfBreadth + halfPolyBreadth);
+                    << QPointF(polyPixelWidth, halfBreadth - halfPolyBreadth)
+                    << QPointF(polyPixelWidth, halfBreadth + halfPolyBreadth);
             polygon.translate(triangleTipVSamplePosition / vSamplesPerPixel, 0);
 
             for (; triangleTipVSamplePosition < numberOfVSamples;
-                    triangleTipVSamplePosition += polyVSampleSize) {
+                    triangleTipVSamplePosition += polyVSampleOffset) {
                 painter->drawPolygon(polygon);
-                polygon.translate(polyLength + 1, 0);
+                polygon.translate(polyPixelOffset, 0);
             }
         }
     }

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -75,8 +75,12 @@ class WaveformWidgetRenderer {
     }
 
     double getPlayPos() const { return m_playPos;}
-    double getPlayPosVSample() const { return m_playPosVSample;}
-    double getTotalVSample() const { return m_totalVSamples;}
+    int getPlayPosVSample() const {
+        return m_playPosVSample;
+    }
+    int getTotalVSample() const {
+        return m_totalVSamples;
+    }
     double getZoomFactor() const { return m_zoomFactor;}
     double getGain() const { return m_gain;}
     int getTrackSamples() const { return m_trackSamples;}

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -518,7 +518,7 @@ bool WaveformWidgetFactory::setWidgetTypeFromHandle(int handleIndex, bool force)
         //previousWidget->hold();
         double previousZoom = previousWidget->getZoomFactor();
         double previousPlayMarkerPosition = previousWidget->getPlayMarkerPosition();
-        double previousbeatgridAlpha = previousWidget->getBeatGridAlpha();
+        int previousbeatgridAlpha = previousWidget->getBeatGridAlpha();
         delete previousWidget;
         WWaveformViewer* viewer = holder.m_waveformViewer;
         WaveformWidgetAbstract* widget = createWaveformWidget(m_type, holder.m_waveformViewer);


### PR DESCRIPTION
Fixes the remaining `-Wfloat-conversion` warnings and cleans up the `WaveformRendererPreroll` drawing code as requested by @daschuer here: https://github.com/mixxxdj/mixxx/pull/3129#discussion_r506197742