### PR TITLE
Preferences MIDI: remove redundant 'Script' prefix from mapping table

### DIFF
--- a/src/controllers/delegates/controldelegate.cpp
+++ b/src/controllers/delegates/controldelegate.cpp
@@ -48,7 +48,7 @@ QString ControlDelegate::displayText(const QVariant& value,
     }
 
     if (m_bIsIndexScript) {
-        return tr("%1 %2").arg(key.item, key.group);
+        return tr("%1 %2").arg(key.group, key.item);
     }
 
     QString description = m_pPicker->descriptionForConfigKey(key);

--- a/src/controllers/delegates/controldelegate.cpp
+++ b/src/controllers/delegates/controldelegate.cpp
@@ -48,7 +48,7 @@ QString ControlDelegate::displayText(const QVariant& value,
     }
 
     if (m_bIsIndexScript) {
-        return tr("Script: %1(%2)").arg(key.item, key.group);
+        return tr("%1 %2").arg(key.item, key.group);
     }
 
     QString description = m_pPicker->descriptionForConfigKey(key);


### PR DESCRIPTION
removes redundant `Script: ` prefix and confusing `([GroupFoo])` parenthesis.

before
![image](https://user-images.githubusercontent.com/5934199/96298660-1ba1f300-0ff3-11eb-90bc-e8036bfb1d92.png)

now
![image](https://user-images.githubusercontent.com/5934199/96355956-4c178900-10e8-11eb-87be-8d6d4a8ebca6.png)

