### PR TITLE
Fix some -Wfloat-conversion warnings (Pt. 9)

### DIFF
--- a/src/effects/builtin/whitenoiseeffect.cpp
+++ b/src/effects/builtin/whitenoiseeffect.cpp
@@ -57,7 +57,7 @@ void WhiteNoiseEffect::processChannel(
 
     WhiteNoiseGroupState& gs = *pGroupState;
 
-    CSAMPLE drywet = m_pDryWetParameter->value();
+    CSAMPLE drywet = static_cast<CSAMPLE>(m_pDryWetParameter->value());
     RampingValue<CSAMPLE_GAIN> drywet_ramping_value(
             drywet, gs.previous_drywet, bufferParameters.framesPerBuffer());
 


### PR DESCRIPTION
Just a single line fix for `master`.