### PR TITLE
allow to hide the menu bar with [Controls],show_menubar

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -1574,6 +1574,18 @@ WPushButton[value="2"]:hover,
     border: 1px solid #0080BE;
 }
 
+#MenubarToggle {
+  font-size: 14px;
+  font-weight: bold;
+  color: #888;
+  margin-top: 2px;
+  background-color: transparent;
+  border: none;
+  }
+  #MenubarToggle[hover="true"] {
+    color: #aaa;
+  }
+
 #HotcueButton {
   border: none;
 }

--- a/res/skins/Deere/tool_bar.xml
+++ b/res/skins/Deere/tool_bar.xml
@@ -11,6 +11,19 @@
     <SizePolicy>min,f</SizePolicy>
     <Children>
 
+      <!-- If [Controls],show_menubar is not available on macOS,
+        hide this with "max-width: 0px;" in style-mac.qss -->
+      <Template src="skin:left_2state_button.xml">
+        <SetVariable name="TooltipId">FIXME</SetVariable>
+        <SetVariable name="ObjectName">MenubarToggle</SetVariable>
+        <SetVariable name="MinimumSize">70,22</SetVariable>
+        <SetVariable name="MaximumSize">70,22</SetVariable>
+        <SetVariable name="SizePolicy">f,f</SetVariable>
+        <SetVariable name="state_0_text">&#x2630; MENU</SetVariable>
+        <SetVariable name="state_1_text">&#x2630; MENU</SetVariable>
+        <SetVariable name="left_connection_control">[Controls],show_menubar</SetVariable>
+      </Template>
+
       <Battery>
         <ObjectName>Battery</ObjectName>
         <Size>24,24</Size>

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -151,7 +151,8 @@ WEffectSelector QAbstractScrollArea,
 #PreviewLabel,
 WBeatSpinBox,
 #spinBoxTransition,
-WTime {
+WTime,
+#MenubarToggle {
   font-size: 14px;
   text-align: left;
 }

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -1267,13 +1267,16 @@ WEffectSelector,
 #PreviewLabel,
 WEffectSelector QAbstractScrollArea,
 #fadeModeCombobox QAbstractScrollArea,
-#GuiToggleButton[displayValue="0"],
+#GuiToggleButton[displayValue="0"], #MenubarToggle,
 #RecDuration[highlight="0"],
 #BroadcastButton[displayValue="0"],
 #SkinSettingsToggle[displayValue="0"],
 WLibrary QLabel {
   color: #777;
-}
+  }/*
+  #MenubarToggle[hover="true"] {
+    color: #999;
+  }*/
 
 /* Darker grey for knob labels & inactive decks/units */
 #KnobLabel,

--- a/res/skins/LateNight/toolbar.xml
+++ b/res/skins/LateNight/toolbar.xml
@@ -5,6 +5,22 @@
     <SizePolicy>e,min</SizePolicy>
     <Children>
 
+      <!-- If [Controls],show_menubar is not available on macOS,
+        hide those two items with stylesheet with "max-width: 0px;" -->
+      <Template src="skin:/controls/button_2state.xml">
+        <SetVariable name="TooltipId">FIXME</SetVariable>
+        <SetVariable name="ObjectName">MenubarToggle</SetVariable>
+        <SetVariable name="Size">70f,20f</SetVariable>
+        <SetVariable name="state_0_text">&#x2630; MENU</SetVariable>
+        <SetVariable name="state_1_text">&#x2630; MENU</SetVariable>
+        <SetVariable name="ConfigKey">[Controls],show_menubar</SetVariable>
+      </Template>
+
+      <WidgetGroup>
+        <ObjectName>MenubarToggleSeparator</ObjectName>
+        <Size>12f,9min</Size>
+      </WidgetGroup>
+
       <Template src="skin:/controls/button_2state.xml">
         <SetVariable name="TooltipId">maximize_library</SetVariable>
         <SetVariable name="ObjectName">GuiToggleButton</SetVariable>

--- a/res/skins/Shade/skin.xml
+++ b/res/skins/Shade/skin.xml
@@ -61,6 +61,7 @@
       <attribute config_key="[Master],num_decks">2</attribute>
       <attribute config_key="[Master],num_samplers">8</attribute>
       <attribute config_key="[Master],num_preview_decks">1</attribute>
+      <attribute config_key="[Controls],show_menubar">1</attribute>
       <!--Optionally, make elements visible on skin load-->
       <attribute persist="true" config_key="[Spinny1],show_spinny">1</attribute>
       <attribute persist="true" config_key="[Spinny2],show_spinny">1</attribute>

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -291,6 +291,16 @@ WWidgetGroup {
   qproperty-layoutAlignment: 'AlignLeft | AlignVCenter';
 }
 
+#MenubarToggle {
+  font-size: 14px;
+  font-weight: bold;
+  color: #888;
+  margin-top: 2px;
+  }
+  #MenubarToggle[hover="true"] {
+    color: #aaa;
+  }
+
 #GuiToggleButton,
 #GuiToggleButton2,
 #RecordingButton {

--- a/res/skins/Tango/topbar.xml
+++ b/res/skins/Tango/topbar.xml
@@ -32,6 +32,18 @@ Description:
 
               <WidgetGroup><Size>2f,0min</Size></WidgetGroup>
 
+
+              <!-- If [Controls],show_menubar is not available on macOS,
+                hide this with "max-width: 0px;" in style-mac.qss -->
+              <Template src="skin:button_2state.xml">
+                <SetVariable name="TooltipId">FIXME</SetVariable>
+                <SetVariable name="ObjectName">MenubarToggle</SetVariable>
+                <SetVariable name="Size">70f,22f</SetVariable>
+                <SetVariable name="state_0_text">&#x2630; MENU</SetVariable>
+                <SetVariable name="state_1_text">&#x2630; MENU</SetVariable>
+                <SetVariable name="ConfigKey">[Controls],show_menubar</SetVariable>
+              </Template>
+
               <PushButton>
                 <Size>102f,24f</Size>
                 <NumberStates>2</NumberStates>

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -60,6 +60,14 @@ WMainMenuBar::WMainMenuBar(QWidget* pParent, UserSettingsPointer pConfig,
 }
 
 void WMainMenuBar::initialize() {
+    // Allow hiding the menu bar
+    m_bShowMenuBar = std::make_unique<ControlPushButton>(ConfigKey("[Controls]", "show_menubar"), false, 1.0);
+    m_bShowMenuBar->setButtonMode(ControlPushButton::TOGGLE);
+    connect(m_bShowMenuBar.get(),
+            &ControlPushButton::valueChanged,
+            this,
+            &WMainMenuBar::showHideMenuBar);
+
     // FILE MENU
     QMenu* pFileMenu = new QMenu(tr("&File"));
 
@@ -597,6 +605,17 @@ void WMainMenuBar::initialize() {
 
     pHelpMenu->addAction(pHelpAboutApp);
     addMenu(pHelpMenu);
+}
+
+void WMainMenuBar::showHideMenuBar(double v) {
+    if (v > 0) {
+        int minHeight = sizeHint().height();
+        if (minHeight > 0) {
+            setFixedHeight(minHeight);
+        }
+    } else {
+        setFixedHeight(0);
+    }
 }
 
 void WMainMenuBar::onLibraryScanStarted() {

--- a/src/widget/wmainmenubar.h
+++ b/src/widget/wmainmenubar.h
@@ -8,8 +8,11 @@
 #include <QScopedPointer>
 
 #include "control/controlproxy.h"
+#include "control/controlobject.h"
+#include "control/controlpushbutton.h"
 #include "preferences/configobject.h"
 #include "preferences/usersettings.h"
+#include "util/memory.h"
 
 class VisibilityControlConnection : public QObject {
     Q_OBJECT
@@ -36,6 +39,7 @@ class WMainMenuBar : public QMenuBar {
                  ConfigObject<ConfigValueKbd>* pKbdConfig);
 
   public slots:
+    void showHideMenuBar(double v);
     void onLibraryScanStarted();
     void onLibraryScanFinished();
     void onRecordingStateChange(bool recording);
@@ -83,6 +87,7 @@ class WMainMenuBar : public QMenuBar {
     void initialize();
     void createVisibilityControl(QAction* pAction, const ConfigKey& key);
 
+    std::unique_ptr<ControlPushButton> m_bShowMenuBar;
     UserSettingsPointer m_pConfig;
     ConfigObject<ConfigValueKbd>* m_pKbdConfig;
     QList<QAction*> m_loadToDeckActions;


### PR DESCRIPTION
supersede #927
https://bugs.launchpad.net/mixxx/+bug/1703777

Allows to hide the main menubar with `[Controls],show_menubar`.
I added a toolbar button to all skins except Shade. State is not persistent across restarts.
![image](https://user-images.githubusercontent.com/5934199/96509899-03351100-125d-11eb-9a95-6c8e1a63d170.png)

All keyboard shortcuts work regardless of the show/hide state.
Menus can be opened as before (like Alt + F for File menu).

**ToDo**
- [ ] ifdef APPLE: what happens to macOS global menu when hiding?
- [ ] hide the skin pushbutton via stylesheet if hiding isn't allowed in OS

**Nice to have**
- [ ] toggle menubar by pressing `Alt`
- [ ] bind to fullscreen?