### PR TITLE
GitHub Actions: Add support for cla-assistant

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,32 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+jobs:
+  CLAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == "recheck" || github.event.comment.body == "I have read the CLA Document and I hereby sign the CLA") || github.event_name == "pull_request_target"
+        uses: cla-assistant/github-action@v2.0.1-alpha
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # the below token should have repo scope and must be manually added by you in the repository"s secret
+          PERSONAL_ACCESS_TOKEN : ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: ".github/cla.json"
+          path-to-document: "https://github.com/mixxxdj/mixxx/blob/master/CONTRIBUTOR_LICENSE_AGREEMENT.md"
+          branch: "master"
+          # allowlist: user1,bot*
+          use-dco-flag: false
+
+          remote-organization-name: mixxxdj
+          remote-repository-name: cla
+          create-file-commit-message: "CLA: Creating file for storing CLA signatures"
+          signed-commit-message: "CLA: Add '$contributorName' to signature list (#$pullRequestNo)"
+          custom-notsigned-prcomment: "Thank you for contributing to Mixxx! Before we merge your code into Mixxx, please sign the contributor agreement. In a nutshell, this gives us permission to distribute the code under the term of the GNU Public License (GPL) as well as in the Mac App Store (which has some terms incompatible with the GPL)."
+          custom-allsigned-prcomment: "Great, all contributors have signed the CLA! :tada:"
+

--- a/CONTRIBUTOR_LICENSE_AGREEMENT.md
+++ b/CONTRIBUTOR_LICENSE_AGREEMENT.md
@@ -1,0 +1,51 @@
+# Mixxx Contributor Agreement (CLA)
+
+Thank you for contributing to the Mixxx project!
+
+In order to distribute your changes with Mixxx, we need a record of your
+permission to distribute them under Mixxx's license.
+
+Mixxx is distributed under the GNU General Public License Version 2 (the
+GPLv2). The full text of the GPLv2 can be found at [1]. Because a significant
+number of Mixxx downloads are through the Mac OS X App Store, we also license
+Mixxx under the GPLv2 with a special "App Store Exception". For more details on
+GPL exceptions, see [2].
+
+The text of the Mixxx App Store Exception is as follows:
+
+13. In addition, as a special exception, you are granted the additional
+right to distribute this Program subject to the Mac App Store Product
+Usage Rules and Licensed Application End User License Agreement,
+if the source code is made available on the Mixxx Website under the
+terms of the GPL.
+
+By submitting this form, you agree to the following terms for your present and
+future contributions to Mixxx:
+
+* You retain the copyright on your contribution but give Mixxx irrevocable
+  permission to distribute your contribution under the above license. We will
+  contact you to obtain your permission to change the license terms of your
+  contributions. You agree that if we cannot reach you within 30 days by the
+  email address you provide below then you permit Mixxx to re-license your
+  contributions without your explicit permission. 
+
+* You represent that you are legally entitled to grant the above license. If
+  your employer has the rights to your contributions, you represent that you
+  have permission from your employer to grant the above license.
+
+* You represent that each of your contributions is your original creation. 
+
+* You represent that your contribution includes complete details of any
+  third-party license or other restriction (including, but not limited to,
+  related patents and trademarks) of which you are personally aware and which
+  are associated with any part of contributions.
+
+* You grant to Mixxx and to recipients of Mixxx a perpetual, worldwide,
+  non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this
+  section) patent license to make, have made, use, offer to sell, sell, import,
+  and otherwise transfer your contributions. 
+
+* Your contribution is provided without warranty of any kind.
+
+[1]: http://www.gnu.org/licenses/gpl-2.0.html
+[2]: http://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html


### PR DESCRIPTION
In order to not pollute the git history, I suggest to create a new mixxxdj/cla repository. The CLA signatures will be tracked there.

Unfortunately our current way of tracking CLA signatures does not include the GitHub username or the source PR. Therefore I cannot add existing users to the allowlist, but I think the additional work for contributors to re-sign the CLA is neglible. It suffices to post a comment on GitHub.

Related Zulip discussion: https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/tracking.20cla.20signage
CLA Assistant GitHub Actions README: https://github.com/cla-assistant/github-action#handling-clas-and-dcos-via-github-action-alpha

Example Screenshot:
![CLA bot](https://user-images.githubusercontent.com/33329946/90894332-b8179280-e3c0-11ea-9700-44d31a77b857.png)