### PR TITLE
EngineSyncTest: Fix double comparisons using EXPECT_NEAR

### DIFF
--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -16,7 +16,8 @@
 #include "util/memory.h"
 
 namespace {
-constexpr double kMaxFloatingPointError = 0.005;
+constexpr double kMaxFloatingPointErrorLowPrecision = 0.005;
+constexpr double kMaxFloatingPointErrorHighPrecision = 0.0000000000000005;
 }
 
 /// Tests for Master Sync.
@@ -643,7 +644,7 @@ TEST_F(EngineSyncTest, RateChangeTestOrder3) {
     // Follower should immediately set its slider.
     EXPECT_NEAR(getRateSliderValue(1.3333333333),
             ControlObject::get(ConfigKey(m_sGroup2, "rate")),
-            kMaxFloatingPointError);
+            kMaxFloatingPointErrorLowPrecision);
     EXPECT_DOUBLE_EQ(160.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
     EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
@@ -753,7 +754,7 @@ TEST_F(EngineSyncTest, InternalRateChangeTest) {
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
     EXPECT_NEAR(getRateSliderValue(1.16666667),
             ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))->get(),
-            kMaxFloatingPointError);
+            kMaxFloatingPointErrorLowPrecision);
     EXPECT_DOUBLE_EQ(140.0,
             ControlObject::getControl(ConfigKey(m_sGroup2, "bpm"))->get());
 }
@@ -1309,7 +1310,7 @@ TEST_F(EngineSyncTest, ExplicitMasterPostProcessed) {
 
     EXPECT_NEAR(0.0023219956,
             m_pChannel1->getEngineBuffer()->getVisualPlayPos(),
-            kMaxFloatingPointError);
+            kMaxFloatingPointErrorLowPrecision);
 }
 
 TEST_F(EngineSyncTest, ZeroBPMRateAdjustIgnored) {
@@ -1439,7 +1440,7 @@ TEST_F(EngineSyncTest, HalfDoubleBpmTest) {
         EXPECT_NEAR(
                 m_pChannel1->getEngineBuffer()->m_pSyncControl->getBeatDistance(),
                 m_pChannel2->getEngineBuffer()->m_pSyncControl->getBeatDistance(),
-                kMaxFloatingPointError);
+                kMaxFloatingPointErrorLowPrecision);
     }
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(0.0);
@@ -1568,10 +1569,10 @@ TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
 
     ProcessBuffer();
 
-    EXPECT_DOUBLE_EQ(
-            (m_pChannel1->getEngineBuffer()->m_pSyncControl->getBeatDistance()),
-            (m_pChannel2->getEngineBuffer()
-                            ->m_pSyncControl->getBeatDistance()));
+    EXPECT_NEAR(
+            m_pChannel1->getEngineBuffer()->m_pSyncControl->getBeatDistance(),
+            m_pChannel2->getEngineBuffer()->m_pSyncControl->getBeatDistance(),
+            kMaxFloatingPointErrorHighPrecision);
 
     ProcessBuffer();
     ProcessBuffer();
@@ -1579,18 +1580,19 @@ TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
     EXPECT_DOUBLE_EQ(87.5,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
 
-    EXPECT_DOUBLE_EQ(
-            (m_pChannel1->getEngineBuffer()->m_pSyncControl->getBeatDistance()),
-            (m_pChannel2->getEngineBuffer()
-                            ->m_pSyncControl->getBeatDistance()));
-
-    ProcessBuffer();
-    ProcessBuffer();
-    ProcessBuffer();
-
-    EXPECT_DOUBLE_EQ(
+    EXPECT_NEAR(
             m_pChannel1->getEngineBuffer()->m_pSyncControl->getBeatDistance(),
-            m_pChannel2->getEngineBuffer()->m_pSyncControl->getBeatDistance());
+            m_pChannel2->getEngineBuffer()->m_pSyncControl->getBeatDistance(),
+            kMaxFloatingPointErrorHighPrecision);
+
+    ProcessBuffer();
+    ProcessBuffer();
+    ProcessBuffer();
+
+    EXPECT_NEAR(
+            m_pChannel1->getEngineBuffer()->m_pSyncControl->getBeatDistance(),
+            m_pChannel2->getEngineBuffer()->m_pSyncControl->getBeatDistance(),
+            kMaxFloatingPointErrorHighPrecision);
 }
 
 TEST_F(EngineSyncTest, HalfDoubleInternalClockTest) {
@@ -1703,14 +1705,14 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
     EXPECT_NEAR(0.019349962,
             ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->get(),
-            kMaxFloatingPointError);
+            kMaxFloatingPointErrorLowPrecision);
 
     // The internal clock must also have been advanced to the same fraction of a beat.
     EXPECT_DOUBLE_EQ(100.0,
             ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))->get());
     EXPECT_NEAR(0.019349962,
             ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "beat_distance"))->get(),
-            kMaxFloatingPointError);
+            kMaxFloatingPointErrorLowPrecision);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(0.0);
 
@@ -1720,10 +1722,10 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
     // with the same rate
     EXPECT_NEAR(0.019349962,
             ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->get(),
-            kMaxFloatingPointError);
+            kMaxFloatingPointErrorLowPrecision);
     EXPECT_NEAR(0.019349962,
             ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "beat_distance"))->get(),
-            kMaxFloatingPointError);
+            kMaxFloatingPointErrorLowPrecision);
 
     // Now make the second deck playing and see if it works.
     ControlObject::getControl(ConfigKey(m_sGroup2, "play"))->set(1.0);
@@ -1747,13 +1749,13 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
     EXPECT_NEAR(
             0.019349962,
             ControlObject::getControl(ConfigKey(m_sGroup2, "beat_distance"))->get(),
-            kMaxFloatingPointError);
+            kMaxFloatingPointErrorLowPrecision);
     EXPECT_DOUBLE_EQ(100.0,
             ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))->get());
     EXPECT_NEAR(
             0.038699925,
             ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "beat_distance"))->get(),
-            kMaxFloatingPointError);
+            kMaxFloatingPointErrorLowPrecision);
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 0.0);
     pButtonSyncEnabled1->set(0.0);
@@ -1882,10 +1884,10 @@ TEST_F(EngineSyncTest, UserTweakPreservedInSeek) {
 
     EXPECT_NEAR(0.024806201,
             ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")),
-            kMaxFloatingPointError);
+            kMaxFloatingPointErrorLowPrecision);
     EXPECT_NEAR(0.0023219956,
             ControlObject::get(ConfigKey(m_sGroup1, "playposition")),
-            kMaxFloatingPointError);
+            kMaxFloatingPointErrorLowPrecision);
 
     ControlObject::set(ConfigKey(m_sGroup2, "playposition"), 0.2);
     ProcessBuffer();
@@ -1897,17 +1899,17 @@ TEST_F(EngineSyncTest, UserTweakPreservedInSeek) {
     // different bpms.
     EXPECT_NEAR(0.19417687,
             ControlObject::get(ConfigKey(m_sGroup1, "playposition")),
-            kMaxFloatingPointError);
+            kMaxFloatingPointErrorLowPrecision);
     EXPECT_NEAR(0.19148479,
             ControlObject::get(ConfigKey(m_sGroup2, "playposition")),
-            kMaxFloatingPointError);
+            kMaxFloatingPointErrorLowPrecision);
     // The beat distances are identical though.
     EXPECT_NEAR(0.074418604,
             ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")),
-            kMaxFloatingPointError);
+            kMaxFloatingPointErrorLowPrecision);
     EXPECT_NEAR(0.074418604,
             ControlObject::get(ConfigKey(m_sGroup2, "beat_distance")),
-            kMaxFloatingPointError);
+            kMaxFloatingPointErrorLowPrecision);
 
     // Apply user tweak offset.
     m_pChannel1->getEngineBuffer()
@@ -1923,16 +1925,16 @@ TEST_F(EngineSyncTest, UserTweakPreservedInSeek) {
     // to be the same because beat distance CO hides the user offset.
     EXPECT_NEAR(0.2269025,
             ControlObject::get(ConfigKey(m_sGroup1, "playposition")),
-            kMaxFloatingPointError);
+            kMaxFloatingPointErrorLowPrecision);
     EXPECT_NEAR(0.1960644,
             ControlObject::get(ConfigKey(m_sGroup2, "playposition")),
-            kMaxFloatingPointError);
+            kMaxFloatingPointErrorLowPrecision);
     EXPECT_NEAR(0.12403101,
             ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")),
-            kMaxFloatingPointError);
+            kMaxFloatingPointErrorLowPrecision);
     EXPECT_NEAR(0.12403101,
             ControlObject::get(ConfigKey(m_sGroup2, "beat_distance")),
-            kMaxFloatingPointError);
+            kMaxFloatingPointErrorLowPrecision);
 }
 
 TEST_F(EngineSyncTest, MasterBpmNeverZero) {


### PR DESCRIPTION
This fixes some issues on MSVC/Windows. The
EngineSyncTest.HalfDoubleThenPlay test fails on Appveyor (but not
gcc/clang on Linux). It looks like it's just some floating point
imprecision issue:

            Start 256: EngineSyncTest.HalfDoubleThenPlay
    256/628 Test #256: EngineSyncTest.HalfDoubleThenPlay ...............................................***Failed    1.09 sec
    Note: Google Test filter = EngineSyncTest.HalfDoubleThenPlay
    [==========] Running 1 test from 1 test case.
    [----------] Global test environment set-up.
    [----------] 1 test from EngineSyncTest
    [ RUN      ] EngineSyncTest.HalfDoubleThenPlay
    ..\src\test\enginesynctest.cpp(1574): error: Expected equality of these values:
      (m_pChannel1->getEngineBuffer()->m_pSyncControl->getBeatDistance())
        Which is: 0.067724867724867951
      (m_pChannel2->getEngineBuffer() ->m_pSyncControl->getBeatDistance())
        Which is: 0.067724867724867785
    ..\src\test\enginesynctest.cpp(1585): error: Expected equality of these values:
      (m_pChannel1->getEngineBuffer()->m_pSyncControl->getBeatDistance())
        Which is: 0.10158730158730181
      (m_pChannel2->getEngineBuffer() ->m_pSyncControl->getBeatDistance())
        Which is: 0.10158730158730164
    ..\src\test\enginesynctest.cpp(1593): error: Expected equality of these values:
      m_pChannel1->getEngineBuffer()->m_pSyncControl->getBeatDistance()
        Which is: 0.15238095238095259
      m_pChannel2->getEngineBuffer()->m_pSyncControl->getBeatDistance()
        Which is: 0.15238095238095245
    [  FAILED  ] EngineSyncTest.HalfDoubleThenPlay (946 ms)
    [----------] 1 test from EngineSyncTest (946 ms total)

    [----------] Global test environment tear-down
    [==========] 1 test from 1 test case ran. (946 ms total)
    [  PASSED  ] 0 tests.
    [  FAILED  ] 1 test, listed below:
    [  FAILED  ] EngineSyncTest.HalfDoubleThenPlay

     1 FAILED TEST

According to Owen Williams, the kMaxFloatingPointErrorHighPrecision
error suffices for this test.