### PR TITLE
Don't trash userconfig on errors

### DIFF
--- a/src/preferences/configobject.cpp
+++ b/src/preferences/configobject.cpp
@@ -13,6 +13,7 @@
 
 // TODO(rryan): Move to a utility file.
 namespace {
+const char* kTempFilenameExtension = "-tmp";
 
 QString computeResourcePath() {
     // Try to read in the resource directory from the command line
@@ -191,45 +192,61 @@ template <class ValueType> void ConfigObject<ValueType>::reopen(const QString& f
 template<class ValueType>
 bool ConfigObject<ValueType>::save() {
     QReadLocker lock(&m_valuesLock); // we only read the m_values here.
-    QString tmpFilename(m_filename + ".tmp");
-    QFile file(tmpFilename);
-    if (!QDir(QFileInfo(file).absolutePath()).exists()) {
-        QDir().mkpath(QFileInfo(file).absolutePath());
+    QFile tmpFile(m_filename + kTempFilenameExtension);
+    if (!QDir(QFileInfo(tmpFile).absolutePath()).exists()) {
+        QDir().mkpath(QFileInfo(tmpFile).absolutePath());
     }
-    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
-        qWarning() << "Could not write config file: " << m_filename;
+    if (!tmpFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        qWarning() << "Could not write config file: " << tmpFile.fileName();
         return false;
-    } else {
-        QTextStream stream(&file);
-        stream.setCodec("UTF-8");
-
-        QString grp = "";
-
-        for (auto i = m_values.constBegin(); i != m_values.constEnd(); ++i) {
-            //qDebug() << "group:" << it.key().group << "item" << it.key().item << "val" << it.value()->value;
-            if (i.key().group != grp) {
-                grp = i.key().group;
-                stream << "\n" << grp << "\n";
-            }
-            stream << i.key().item << " " << i.value().value << "\n";
-        }
-        file.close();
-        if (file.error()!=QFile::NoError) { //could be better... should actually say what the error was..
-            qWarning() << "Error while writing configuration file: " << file.errorString();
-        } else {
-            QFile oldConfig(m_filename);
-            if (!oldConfig.remove()) {
-                qWarning() << "Could not remove old config file: " << oldConfig.errorString();
-                return false;
-            }
-            if (file.rename(m_filename)) {
-                return true;
-            } else {
-                qWarning() << "Could not rename tmp file to config file: " << file.errorString();
-            }
-        }
     }
-    return false;
+    QTextStream stream(&tmpFile);
+    stream.setCodec("UTF-8");
+
+    QString grp = "";
+
+    uint minLength = 0;
+    for (auto i = m_values.constBegin(); i != m_values.constEnd(); ++i) {
+        //qDebug() << "group:" << it.key().group << "item" << it.key().item << "val" << it.value()->value;
+        if (i.key().group != grp) {
+            grp = i.key().group;
+            stream << "\n"
+                   << grp << "\n";
+            minLength += i.key().group.length() + 2;
+        }
+        stream << i.key().item << " " << i.value().value << "\n";
+        minLength += i.key().item.length() + i.value().value.length() + 1;
+    }
+
+    stream.flush();
+    tmpFile.flush();
+    // the stream is usually longer, depending on the amount of encoded data.
+    if (stream.pos() < minLength || QFileInfo(tmpFile).size() != stream.pos()) {
+        qWarning() << "Error while writing configuration file: " << tmpFile.fileName();
+        return false;
+    }
+
+    tmpFile.close();
+    if (tmpFile.error() !=
+            QFile::NoError) { //could be better... should actually say what the error was..
+        qWarning() << "Error while writing configuration file: "
+                   << tmpFile.fileName() << ":" << tmpFile.errorString();
+        return false;
+    }
+
+    QFile oldConfig(m_filename);
+    if (!oldConfig.remove()) {
+        qWarning() << "Could not remove old config file: "
+                   << oldConfig.fileName() << ":" << oldConfig.errorString();
+        return false;
+    }
+    if (!tmpFile.rename(m_filename)) {
+        qWarning() << "Could not rename tmp file to config file: "
+                   << tmpFile.fileName() << ":" << tmpFile.errorString();
+        return false;
+    }
+
+    return true;
 }
 
 template<class ValueType>

--- a/src/preferences/configobject.cpp
+++ b/src/preferences/configobject.cpp
@@ -197,7 +197,7 @@ bool ConfigObject<ValueType>::save() {
         QDir().mkpath(QFileInfo(file).absolutePath());
     }
     if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
-        qWarning() << "Could not write file" << m_filename << ", don't worry.";
+        qWarning() << "Could not write config file: " << m_filename;
         return false;
     } else {
         QTextStream stream(&file);
@@ -215,15 +215,17 @@ bool ConfigObject<ValueType>::save() {
         }
         file.close();
         if (file.error()!=QFile::NoError) { //could be better... should actually say what the error was..
-            qWarning() << "Error while writing configuration file:" << file.errorString();
+            qWarning() << "Error while writing configuration file: " << file.errorString();
         } else {
             QFile oldConfig(m_filename);
             if (!oldConfig.remove()) {
-                qWarning() << "Could not remove old config file:" << oldConfig.errorString();
+                qWarning() << "Could not remove old config file: " << oldConfig.errorString();
                 return false;
-            } else {
-                file.rename(m_filename);
+            }
+            if (file.rename(m_filename)) {
                 return true;
+            } else {
+                qWarning() << "Could not rename tmp file to config file: " << file.errorString();
             }
         }
     }

--- a/src/preferences/configobject.cpp
+++ b/src/preferences/configobject.cpp
@@ -205,7 +205,7 @@ bool ConfigObject<ValueType>::save() {
 
     QString group = "";
 
-    uint minLength = 0;
+    qint64 minLength = 0;
     for (auto i = m_values.constBegin(); i != m_values.constEnd(); ++i) {
         //qDebug() << "group:" << it.key().group << "item" << it.key().item << "val" << it.value()->value;
         if (i.key().group != group) {
@@ -219,7 +219,6 @@ bool ConfigObject<ValueType>::save() {
     }
 
     stream.flush();
-    tmpFile.flush();
     // the stream is usually longer, depending on the amount of encoded data.
     if (stream.pos() < minLength || QFileInfo(tmpFile).size() != stream.pos()) {
         qWarning().nospace() << "Error while writing configuration file: " << tmpFile.fileName();

--- a/src/preferences/configobject.cpp
+++ b/src/preferences/configobject.cpp
@@ -205,6 +205,9 @@ bool ConfigObject<ValueType>::save() {
 
     QString group = "";
 
+    // Since it is legit to have a ConfigObject with 0 values, checking
+    // the stream.pos alone will yield wrong warnings. We therefore estimate
+    // a minimum length as an additional safety check.
     qint64 minLength = 0;
     for (auto i = m_values.constBegin(); i != m_values.constEnd(); ++i) {
         //qDebug() << "group:" << it.key().group << "item" << it.key().item << "val" << it.value()->value;

--- a/src/preferences/configobject.cpp
+++ b/src/preferences/configobject.cpp
@@ -13,7 +13,7 @@
 
 // TODO(rryan): Move to a utility file.
 namespace {
-const char* kTempFilenameExtension = "-tmp";
+const QString kTempFilenameExtension = QStringLiteral(".tmp");
 
 QString computeResourcePath() {
     // Try to read in the resource directory from the command line
@@ -203,15 +203,15 @@ bool ConfigObject<ValueType>::save() {
     QTextStream stream(&tmpFile);
     stream.setCodec("UTF-8");
 
-    QString grp = "";
+    QString group = "";
 
     uint minLength = 0;
     for (auto i = m_values.constBegin(); i != m_values.constEnd(); ++i) {
         //qDebug() << "group:" << it.key().group << "item" << it.key().item << "val" << it.value()->value;
-        if (i.key().group != grp) {
-            grp = i.key().group;
+        if (i.key().group != group) {
+            group = i.key().group;
             stream << "\n"
-                   << grp << "\n";
+                   << group << "\n";
             minLength += i.key().group.length() + 2;
         }
         stream << i.key().item << " " << i.value().value << "\n";
@@ -222,27 +222,27 @@ bool ConfigObject<ValueType>::save() {
     tmpFile.flush();
     // the stream is usually longer, depending on the amount of encoded data.
     if (stream.pos() < minLength || QFileInfo(tmpFile).size() != stream.pos()) {
-        qWarning() << "Error while writing configuration file: " << tmpFile.fileName();
+        qWarning().nospace() << "Error while writing configuration file: " << tmpFile.fileName();
         return false;
     }
 
     tmpFile.close();
     if (tmpFile.error() !=
             QFile::NoError) { //could be better... should actually say what the error was..
-        qWarning() << "Error while writing configuration file: "
-                   << tmpFile.fileName() << ":" << tmpFile.errorString();
+        qWarning().nospace() << "Error while writing configuration file: "
+                             << tmpFile.fileName() << ": " << tmpFile.errorString();
         return false;
     }
 
     QFile oldConfig(m_filename);
     if (!oldConfig.remove()) {
-        qWarning() << "Could not remove old config file: "
-                   << oldConfig.fileName() << ":" << oldConfig.errorString();
+        qWarning().nospace() << "Could not remove old config file: "
+                             << oldConfig.fileName() << ": " << oldConfig.errorString();
         return false;
     }
     if (!tmpFile.rename(m_filename)) {
-        qWarning() << "Could not rename tmp file to config file: "
-                   << tmpFile.fileName() << ":" << tmpFile.errorString();
+        qWarning().nospace() << "Could not rename tmp file to config file: "
+                             << tmpFile.fileName() << ": " << tmpFile.errorString();
         return false;
     }
 

--- a/src/preferences/configobject.h
+++ b/src/preferences/configobject.h
@@ -169,7 +169,7 @@ template <class ValueType> class ConfigObject {
     QMultiHash<ValueType, ConfigKey> transpose() const;
 
     void reopen(const QString& file);
-    void save();
+    bool save();
 
     // Returns the resource path -- the path where controller presets, skins,
     // library schema, keyboard mappings, and more are stored.


### PR DESCRIPTION
Instead of opening the current config file for write operations,
write the user config file into a new file and rename after success.

This will no longer trash the config file if the file-system is full.

fixes launchpad bug #1881997