### PR TITLE
Library table: allow to ignore Track double-click

### DIFF
--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -626,7 +626,9 @@ void LibraryControl::slotGoToItem(double v) {
 
     // Focus the library if this is a leaf node in the tree
     if (m_pSidebarWidget->hasFocus()) {
-        // ToDo can't expand Tracks and AutoDJ, always returns false for those root items
+        // Note that Tracks and AutoDJ always return 'false':
+        // expanding those root items via controllers is considered dispensable
+        // because the subfeatures' actions can't be accessed by controllers anyway.
         if (m_pSidebarWidget->isLeafNodeSelected()) {
             return setLibraryFocus();
         } else {
@@ -636,8 +638,9 @@ void LibraryControl::slotGoToItem(double v) {
     }
 
     // Load current track if a LibraryView object has focus
-    if (m_pLibraryWidget->hasFocus()) {
-        return slotLoadSelectedIntoFirstStopped(v);
+    LibraryView* activeView = m_pLibraryWidget->getActiveView();
+    if (activeView && activeView->hasFocus()) {
+        return activeView->loadSelectedTrack();
     }
 
     // Clear the search if the searchbox has focus

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -191,16 +191,17 @@ void DlgPrefLibrary::slotUpdate() {
             ConfigKey("[Library]", "ShowSeratoLibrary"), true));
 
     switch (m_pConfig->getValue<int>(
-            ConfigKey("[Library]","TrackLoadAction"), LOAD_TO_DECK)) {
-    case ADD_TO_AUTODJ_BOTTOM:
-            radioButton_dbclick_bottom->setChecked(true);
-            break;
-    case ADD_TO_AUTODJ_TOP:
-            radioButton_dbclick_top->setChecked(true);
-            break;
-    case DO_NOTHING:
-            radioButton_dbclick_ignore->setChecked(true);
-            break;
+            ConfigKey("[Library]", "TrackLoadAction"),
+            static_cast<int>(TrackDoubleClickAction::LoadToDeck))) {
+    case static_cast<int>(TrackDoubleClickAction::AddToAutoDJBottom):
+        radioButton_dbclick_bottom->setChecked(true);
+        break;
+    case static_cast<int>(TrackDoubleClickAction::AddToAutoDJTop):
+        radioButton_dbclick_top->setChecked(true);
+        break;
+    case static_cast<int>(TrackDoubleClickAction::Ignore):
+        radioButton_dbclick_ignore->setChecked(true);
+        break;
     default:
             radioButton_dbclick_deck->setChecked(true);
             break;
@@ -334,13 +335,13 @@ void DlgPrefLibrary::slotApply() {
             ConfigValue((int)checkBox_show_serato->isChecked()));
     int dbclick_status;
     if (radioButton_dbclick_bottom->isChecked()) {
-            dbclick_status = ADD_TO_AUTODJ_BOTTOM;
+        dbclick_status = static_cast<int>(TrackDoubleClickAction::AddToAutoDJBottom);
     } else if (radioButton_dbclick_top->isChecked()) {
-            dbclick_status = ADD_TO_AUTODJ_TOP;
-    } else if (radioButton_dbclick_deck->isChecked()){
-            dbclick_status = LOAD_TO_DECK;
+        dbclick_status = static_cast<int>(TrackDoubleClickAction::AddToAutoDJTop);
+    } else if (radioButton_dbclick_deck->isChecked()) {
+        dbclick_status = static_cast<int>(TrackDoubleClickAction::LoadToDeck);
     } else { // radioButton_dbclick_ignore
-            dbclick_status = DO_NOTHING;
+        dbclick_status = static_cast<int>(TrackDoubleClickAction::Ignore);
     }
     m_pConfig->set(ConfigKey("[Library]","TrackLoadAction"),
                 ConfigValue(dbclick_status));

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -198,6 +198,9 @@ void DlgPrefLibrary::slotUpdate() {
     case ADD_TO_AUTODJ_TOP:
             radioButton_dbclick_top->setChecked(true);
             break;
+    case DO_NOTHING:
+            radioButton_dbclick_ignore->setChecked(true);
+            break;
     default:
             radioButton_dbclick_deck->setChecked(true);
             break;
@@ -334,8 +337,10 @@ void DlgPrefLibrary::slotApply() {
             dbclick_status = ADD_TO_AUTODJ_BOTTOM;
     } else if (radioButton_dbclick_top->isChecked()) {
             dbclick_status = ADD_TO_AUTODJ_TOP;
-    } else {
+    } else if (radioButton_dbclick_deck->isChecked()){
             dbclick_status = LOAD_TO_DECK;
+    } else { // radioButton_dbclick_ignore
+            dbclick_status = DO_NOTHING;
     }
     m_pConfig->set(ConfigKey("[Library]","TrackLoadAction"),
                 ConfigValue(dbclick_status));

--- a/src/preferences/dialog/dlgpreflibrary.h
+++ b/src/preferences/dialog/dlgpreflibrary.h
@@ -19,11 +19,11 @@
 class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
     Q_OBJECT
   public:
-    enum TrackDoubleClickAction {
-        LOAD_TO_DECK,
-        ADD_TO_AUTODJ_BOTTOM,
-        ADD_TO_AUTODJ_TOP,
-        DO_NOTHING
+    enum class TrackDoubleClickAction : int {
+        LoadToDeck = 0,
+        AddToAutoDJBottom = 1,
+        AddToAutoDJTop = 2,
+        Ignore = 3,
     };
 
     DlgPrefLibrary(

--- a/src/preferences/dialog/dlgpreflibrary.h
+++ b/src/preferences/dialog/dlgpreflibrary.h
@@ -22,7 +22,8 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
     enum TrackDoubleClickAction {
         LOAD_TO_DECK,
         ADD_TO_AUTODJ_BOTTOM,
-        ADD_TO_AUTODJ_TOP
+        ADD_TO_AUTODJ_TOP,
+        DO_NOTHING
     };
 
     DlgPrefLibrary(

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -244,9 +244,9 @@
       <string/>
      </property>
      <property name="title">
-      <string extracomment="Sets default action when double-clicking a track in the library.">Track Load Action</string>
+      <string extracomment="Sets default action when double-clicking a track in the library.">Track Double-Click Action</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_5">
+     <layout class="QGridLayout" name="gridLayout_dblick">
       <item row="0" column="0">
        <widget class="QRadioButton" name="radioButton_dbclick_deck">
         <property name="text">
@@ -260,14 +260,21 @@
       <item row="1" column="0">
        <widget class="QRadioButton" name="radioButton_dbclick_bottom">
         <property name="text">
-         <string>Add track to Auto DJ Queue (bottom)</string>
+         <string>Add track to Auto DJ queue (bottom)</string>
         </property>
        </widget>
       </item>
       <item row="2" column="0">
        <widget class="QRadioButton" name="radioButton_dbclick_top">
         <property name="text">
-         <string>Add track to Auto DJ Queue (top)</string>
+         <string>Add track to Auto DJ queue (top)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QRadioButton" name="radioButton_dbclick_ignore">
+        <property name="text">
+         <string>Ignore</string>
         </property>
        </widget>
       </item>
@@ -396,6 +403,7 @@
   <tabstop>radioButton_dbclick_deck</tabstop>
   <tabstop>radioButton_dbclick_bottom</tabstop>
   <tabstop>radioButton_dbclick_top</tabstop>
+  <tabstop>radioButton_dbclick_ignore</tabstop>
   <tabstop>checkBox_show_rhythmbox</tabstop>
   <tabstop>checkBox_show_banshee</tabstop>
   <tabstop>checkBox_show_itunes</tabstop>

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -340,6 +340,10 @@ void WTrackTableView::slotMouseDoubleClicked(const QModelIndex& index) {
             static_cast<DlgPrefLibrary::TrackDoubleClickAction>(
                     doubleClickActionConfigValue);
 
+    if (doubleClickAction == DlgPrefLibrary::DO_NOTHING) {
+        return;
+    }
+
     auto trackModel = getTrackModel();
     VERIFY_OR_DEBUG_ASSERT(trackModel) {
         return;

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -335,12 +335,12 @@ void WTrackTableView::slotMouseDoubleClicked(const QModelIndex& index) {
     // Read the current TrackLoadAction settings
     int doubleClickActionConfigValue =
             m_pConfig->getValue(ConfigKey("[Library]", "TrackLoadAction"),
-                    static_cast<int>(DlgPrefLibrary::LOAD_TO_DECK));
+                    static_cast<int>(DlgPrefLibrary::TrackDoubleClickAction::LoadToDeck));
     DlgPrefLibrary::TrackDoubleClickAction doubleClickAction =
             static_cast<DlgPrefLibrary::TrackDoubleClickAction>(
                     doubleClickActionConfigValue);
 
-    if (doubleClickAction == DlgPrefLibrary::DO_NOTHING) {
+    if (doubleClickAction == DlgPrefLibrary::TrackDoubleClickAction::Ignore) {
         return;
     }
 
@@ -349,18 +349,18 @@ void WTrackTableView::slotMouseDoubleClicked(const QModelIndex& index) {
         return;
     }
 
-    if (doubleClickAction == DlgPrefLibrary::LOAD_TO_DECK &&
+    if (doubleClickAction == DlgPrefLibrary::TrackDoubleClickAction::LoadToDeck &&
             trackModel->hasCapabilities(
                     TrackModel::TRACKMODELCAPS_LOADTODECK)) {
         TrackPointer pTrack = trackModel->getTrack(index);
         if (pTrack) {
             emit loadTrack(pTrack);
         }
-    } else if (doubleClickAction == DlgPrefLibrary::ADD_TO_AUTODJ_BOTTOM &&
+    } else if (doubleClickAction == DlgPrefLibrary::TrackDoubleClickAction::AddToAutoDJBottom &&
             trackModel->hasCapabilities(
                     TrackModel::TRACKMODELCAPS_ADDTOAUTODJ)) {
         addToAutoDJ(PlaylistDAO::AutoDJSendLoc::BOTTOM);
-    } else if (doubleClickAction == DlgPrefLibrary::ADD_TO_AUTODJ_TOP &&
+    } else if (doubleClickAction == DlgPrefLibrary::TrackDoubleClickAction::AddToAutoDJTop &&
             trackModel->hasCapabilities(
                     TrackModel::TRACKMODELCAPS_ADDTOAUTODJ)) {
         addToAutoDJ(PlaylistDAO::AutoDJSendLoc::TOP);


### PR DESCRIPTION
Many times a accidental touchpad double-click has caused a PITA in live sessions because it cleared an already prepared deck.
Setting track double-click to "AutoDJ add ..." would protect the decks but pollute the AutoDJ queue.

So I'm adding the valid 'Ignore' option here. Default is untouched (load to deck).
![image](https://user-images.githubusercontent.com/5934199/96598895-a0d92080-12ef-11eb-8199-e880512e9f8c.png)

Also the options section is renamed: `Track Load Action` >> `Track Double Click Action` (as the labels extracomment="" already says)