### PR TITLE
add [group],CloneFromSampler control

### DIFF
--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -107,6 +107,15 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(QObject* pParent,
             this,
             &BaseTrackPlayerImpl::slotCloneFromDeck);
 
+    // Sampler cloning
+    m_pCloneFromSampler = std::make_unique<ControlObject>(
+            ConfigKey(getGroup(), "CloneFromSampler"),
+            false);
+    connect(m_pCloneFromSampler.get(),
+            &ControlObject::valueChanged,
+            this,
+            &BaseTrackPlayerImpl::slotCloneFromSampler);
+
     // Waveform controls
     // This acts somewhat like a ControlPotmeter, but the normal _up/_down methods
     // do not work properly with this CO.
@@ -545,6 +554,13 @@ void BaseTrackPlayerImpl::slotCloneFromDeck(double d) {
         slotCloneDeck();
     } else {
         slotCloneFromGroup(PlayerManager::groupForDeck(deck-1));
+    }
+}
+
+void BaseTrackPlayerImpl::slotCloneFromSampler(double d) {
+    int sampler = std::lround(d);
+    if (sampler >= 1) {
+        slotCloneFromGroup(PlayerManager::groupForSampler(sampler-1));
     }
 }
 

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -549,18 +549,18 @@ void BaseTrackPlayerImpl::slotCloneFromGroup(const QString& group) {
 }
 
 void BaseTrackPlayerImpl::slotCloneFromDeck(double d) {
-    int deck = std::lround(d);
+    int deck = static_cast<int>(d);
     if (deck < 1) {
         slotCloneDeck();
     } else {
-        slotCloneFromGroup(PlayerManager::groupForDeck(deck-1));
+        slotCloneFromGroup(PlayerManager::groupForDeck(deck - 1));
     }
 }
 
 void BaseTrackPlayerImpl::slotCloneFromSampler(double d) {
-    int sampler = std::lround(d);
+    int sampler = static_cast<int>(d);
     if (sampler >= 1) {
-        slotCloneFromGroup(PlayerManager::groupForSampler(sampler-1));
+        slotCloneFromGroup(PlayerManager::groupForSampler(sampler - 1));
     }
 }
 

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -90,6 +90,7 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
   private slots:
     void slotCloneChannel(EngineChannel* pChannel);
     void slotCloneFromDeck(double deck);
+    void slotCloneFromSampler(double sampler);
     void slotTrackColorChangeRequest(double value);
     void slotVinylControlEnabled(double v);
     void slotWaveformZoomValueChangeRequest(double pressed);
@@ -117,6 +118,7 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
 
     // Deck clone control
     std::unique_ptr<ControlObject> m_pCloneFromDeck;
+    std::unique_ptr<ControlObject> m_pCloneFromSampler;
 
     // Track color control
     std::unique_ptr<ControlObject> m_pTrackColor;


### PR DESCRIPTION
A simple addition to clone controls to be used in mappings:
`[AnyPlayer], CloneFromSampler, int samplerNum`

My use case:
* store several next track candidates in samplers
* clone tracks from samplers to decks (and vice versa if I notice a track would match better later on)

Will add this to the controls docu once it's merged.

_Initially I tried to create a general ..,CloneFromGroup" control for use in mappings but failed fetching the group string..._ 