### PR TITLE
logging: Add support for QT_MESSAGE_PATTERN env var

### DIFF
--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -56,7 +56,6 @@ inline QString formatLogFileMessage(
         QtMsgType type,
         const QString& message,
         const QString& threadName) {
-
     QString levelName;
     switch (type) {
     case QtDebugMsg:

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -33,6 +33,8 @@ QFile s_logfile;
 bool s_debugAssertBreak = false;
 
 const QString kThreadNamePattern = QStringLiteral("{{threadname}}");
+const QString kDefaultMessagePattern = QStringLiteral("%{type} [") +
+        kThreadNamePattern + QStringLiteral("] %{message}");
 
 const QLoggingCategory kDefaultLoggingCategory = QLoggingCategory(nullptr);
 
@@ -308,11 +310,8 @@ void Logging::initialize(
 
     s_debugAssertBreak = debugAssertBreak;
 
-    // Set the default message pattern if the QT_MESSAGE_PATTERN variable is
-    // not set.
     if (qgetenv("QT_MESSAGE_PATTERN").isEmpty()) {
-        qSetMessagePattern(QStringLiteral("%{type} [") + kThreadNamePattern +
-                QStringLiteral("] %{message}"));
+        qSetMessagePattern(kDefaultMessagePattern);
     }
 
     // Install the Qt message handler.

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -21,6 +21,7 @@ namespace {
 
 // Mutex guarding s_logfile.
 QMutex s_mutexLogfile;
+QMutex s_mutexStdErr;
 
 // The file handle for Mixxx's log file.
 QFile s_logfile;
@@ -112,6 +113,8 @@ inline void writeToStdErr(
     const QByteArray formattedMessage =
             formattedMessageStr.replace("{{threadname}}", threadName)
                     .toLocal8Bit();
+
+    QMutexLocker locked(&s_mutexStdErr);
     const size_t written = fwrite(
             formattedMessage.constData(), sizeof(char), formattedMessage.size(), stderr);
     Q_UNUSED(written);


### PR DESCRIPTION
This allows customizing the output of the log messages. The default should look almost exactly as before (except that the message type is lowercase).

If you want to customize, you can do that by setting the `QT_MESSAGE_PATTERN` variable, e.g.:

```
export QT_MESSAGE_PATTERN="`echo -e "\033[32m%{time h:mm:ss.zzz}%{if-category}\033[32m %{type}:%{endif} %{if-debug}\033[34m%{type}%{endif}%{if-warning}\033[31m%{type}%{endif}%{if-critical}\033[31m%{type}%{endif}%{if-fatal}\033[31m%{type}%{endif}\033[36m %{function} \033[33m[{{threadname}}]\033[0m %{message}"`"
```