### PR TITLE
Midiwizard: improve UX in controls menus

### DIFF
--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -1099,11 +1099,11 @@ void ControlPickerMenu::addPlayerControl(QString control, QString controlTitle,
     }
 
     if (samplerControls) {
-        parented_ptr<QMenu> samplerControlMenu = make_parented<QMenu>(tr("Samplers"), controlMenu);
+        QMenu* samplerControlMenu = new QMenu(tr("Samplers"), controlMenu);
         controlMenu->addMenu(samplerControlMenu);
-        parented_ptr<QMenu> samplerResetControlMenu = nullptr;
+        QMenu* samplerResetControlMenu = nullptr;
         if (resetControlMenu) {
-            samplerResetControlMenu = make_parented<QMenu>(tr("Samplers"), resetControlMenu);
+            samplerResetControlMenu = new QMenu(tr("Samplers"), resetControlMenu);
             resetControlMenu->addMenu(samplerResetControlMenu);
         }
         for (int i = 1; i <= iNumSamplers; ++i) {

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -374,58 +374,112 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
 
     // Library Controls
     QMenu* libraryMenu = addSubmenu(tr("Library"));
-    addControl("[Library]", "MoveUp",
-               tr("Move up"),
-               tr("Equivalent to pressing the UP key on the keyboard"),
-               libraryMenu, false, m_libraryStr);
-    addControl("[Library]", "MoveDown",
-               tr("Move down"),
-               tr("Equivalent to pressing the DOWN key on the keyboard"),
-               libraryMenu, false, m_libraryStr);
-    addControl("[Library]", "MoveVertical",
-               tr("Move up/down"),
-               tr("Move vertically in either direction using a knob, as if pressing UP/DOWN keys"),
-               libraryMenu, false, m_libraryStr);
-    addControl("[Library]", "ScrollUp",
-               tr("Scroll Up"),
-               tr("Equivalent to pressing the PAGE UP key on the keyboard"),
-               libraryMenu, false, m_libraryStr);
-    addControl("[Library]", "ScrollDown",
-               tr("Scroll Down"),
-               tr("Equivalent to pressing the PAGE DOWN key on the keyboard"),
-               libraryMenu, false, m_libraryStr);
-    addControl("[Library]", "ScrollVertical",
-               tr("Scroll up/down"),
-               tr("Scroll vertically in either direction using a knob, as if pressing PGUP/PGDOWN keys"),
-               libraryMenu, false, m_libraryStr);
-    addControl("[Library]", "MoveLeft",
-               tr("Move left"),
-               tr("Equivalent to pressing the LEFT key on the keyboard"),
-               libraryMenu, false, m_libraryStr);
-    addControl("[Library]", "MoveRight",
-               tr("Move right"),
-               tr("Equivalent to pressing the RIGHT key on the keyboard"),
-               libraryMenu, false, m_libraryStr);
-    addControl("[Library]", "MoveHorizontal",
-               tr("Move left/right"),
-               tr("Move horizontally in either direction using a knob, as if pressing LEFT/RIGHT keys"),
-               libraryMenu, false, m_libraryStr);
-    addControl("[Library]", "MoveFocusForward",
-               tr("Move focus to right pane"),
-               tr("Equivalent to pressing the TAB key on the keyboard"),
-               libraryMenu, false, m_libraryStr);
-    addControl("[Library]", "MoveFocusBackward",
-               tr("Move focus to left pane"),
-               tr("Equivalent to pressing the SHIFT+TAB key on the keyboard"),
-               libraryMenu, false, m_libraryStr);
-    addControl("[Library]", "MoveFocus",
-               tr("Move focus to right/left pane"),
-               tr("Move focus one pane to right or left using a knob, as if pressing TAB/SHIFT+TAB keys"),
-               libraryMenu, false, m_libraryStr);
+    QMenu* navigationMenu = addSubmenu(tr("Navigation"), libraryMenu);
+    addControl("[Library]",
+            "MoveUp",
+            tr("Move up"),
+            tr("Equivalent to pressing the UP key on the keyboard"),
+            navigationMenu,
+            false,
+            m_libraryStr);
+    addControl("[Library]",
+            "MoveDown",
+            tr("Move down"),
+            tr("Equivalent to pressing the DOWN key on the keyboard"),
+            navigationMenu,
+            false,
+            m_libraryStr);
+    addControl("[Library]",
+            "MoveVertical",
+            tr("Move up/down"),
+            tr("Move vertically in either direction using a knob, as if "
+               "pressing UP/DOWN keys"),
+            navigationMenu,
+            false,
+            m_libraryStr);
+    addControl("[Library]",
+            "ScrollUp",
+            tr("Scroll Up"),
+            tr("Equivalent to pressing the PAGE UP key on the keyboard"),
+            navigationMenu,
+            false,
+            m_libraryStr);
+    addControl("[Library]",
+            "ScrollDown",
+            tr("Scroll Down"),
+            tr("Equivalent to pressing the PAGE DOWN key on the keyboard"),
+            navigationMenu,
+            false,
+            m_libraryStr);
+    addControl("[Library]",
+            "ScrollVertical",
+            tr("Scroll up/down"),
+            tr("Scroll vertically in either direction using a knob, as if "
+               "pressing PGUP/PGDOWN keys"),
+            navigationMenu,
+            false,
+            m_libraryStr);
+    addControl("[Library]",
+            "MoveLeft",
+            tr("Move left"),
+            tr("Equivalent to pressing the LEFT key on the keyboard"),
+            navigationMenu,
+            false,
+            m_libraryStr);
+    addControl("[Library]",
+            "MoveRight",
+            tr("Move right"),
+            tr("Equivalent to pressing the RIGHT key on the keyboard"),
+            navigationMenu,
+            false,
+            m_libraryStr);
+    addControl("[Library]",
+            "MoveHorizontal",
+            tr("Move left/right"),
+            tr("Move horizontally in either direction using a knob, as if "
+               "pressing LEFT/RIGHT keys"),
+            navigationMenu,
+            false,
+            m_libraryStr);
+    navigationMenu->addSeparator();
+    addControl("[Library]",
+            "MoveFocusForward",
+            tr("Move focus to right pane"),
+            tr("Equivalent to pressing the TAB key on the keyboard"),
+            navigationMenu,
+            false,
+            m_libraryStr);
+    addControl("[Library]",
+            "MoveFocusBackward",
+            tr("Move focus to left pane"),
+            tr("Equivalent to pressing the SHIFT+TAB key on the keyboard"),
+            navigationMenu,
+            false,
+            m_libraryStr);
+    addControl("[Library]",
+            "MoveFocus",
+            tr("Move focus to right/left pane"),
+            tr("Move focus one pane to right or left using a knob, as if "
+               "pressing TAB/SHIFT+TAB keys"),
+            navigationMenu,
+            false,
+            m_libraryStr);
+    libraryMenu->addSeparator();
     addControl("[Library]", "GoToItem",
                tr("Go to the currently selected item"),
                tr("Choose the currently selected item and advance forward one pane if appropriate"),
                libraryMenu, false, m_libraryStr);
+    // Load track (these can be loaded into any channel)
+    addDeckAndSamplerControl("LoadSelectedTrack",
+            tr("Load Track"),
+            tr("Load selected track"),
+            libraryMenu);
+    addDeckAndSamplerAndPreviewDeckControl("LoadSelectedTrackAndPlay",
+            tr("Load Track and Play"),
+            tr("Load selected track and play"),
+            libraryMenu);
+    libraryMenu->addSeparator();
+    // Auto DJ
     addControl("[Library]", "AutoDjAddBottom",
                tr("Add to Auto DJ Queue (bottom)"),
                tr("Append the selected track to the Auto DJ Queue"),
@@ -438,15 +492,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                tr("Add to Auto DJ Queue (replace)"),
                tr("Replace Auto DJ Queue with selected tracks"),
                libraryMenu, false, m_libraryStr);
-
-
-    // Load track (these can be loaded into any channel)
-    addDeckAndSamplerControl("LoadSelectedTrack",
-                             tr("Load Track"),
-                             tr("Load selected track"), libraryMenu);
-    addDeckAndSamplerAndPreviewDeckControl("LoadSelectedTrackAndPlay", tr("Track Load and Play"),
-                                           tr("Load selected track and play"), libraryMenu);
-
+    libraryMenu->addSeparator();
     addControl("[Recording]", "toggle_recording",
                tr("Record Mix"),
                tr("Toggle mix recording"),

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -384,16 +384,10 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     QString beatloopActivateDescription = tr("Create a beat loop of selected beat size");
     QString beatloopRollActivateTitle = tr("Loop Roll Selected Beats");
     QString beatloopRollActivateDescription = tr("Create a rolling beat loop of selected beat size");
-
-    addDeckControl("loop_in", tr("Loop In"), tr("Loop In button"), loopMenu);
-    addDeckControl("loop_out", tr("Loop Out"), tr("Loop Out button"), loopMenu);
-    addDeckControl("loop_exit", tr("Loop Exit"), tr("Loop Exit button"), loopMenu);
-    addDeckControl("reloop_toggle", tr("Reloop/Exit Loop"), tr("Toggle loop on/off and jump to Loop In point if loop is behind play position"), loopMenu);
-    addDeckControl("reloop_andstop", tr("Reloop And Stop"), tr("Enable loop, jump to Loop In point, and stop"), loopMenu);
-    addDeckControl("loop_halve", tr("Loop Halve"), tr("Halve the loop length"), loopMenu);
-    addDeckControl("loop_double", tr("Loop Double"), tr("Double the loop length"), loopMenu);
-    addDeckControl("beatloop_activate", beatloopActivateTitle, beatloopActivateDescription, loopMenu);
-    addDeckControl("beatlooproll_activate", beatloopRollActivateTitle, beatloopRollActivateDescription, loopMenu);
+    QString beatLoopTitle = tr("Loop %1 Beats");
+    QString beatLoopRollTitle = tr("Loop Roll %1 Beats");
+    QString beatLoopDescription = tr("Create %1-beat loop");
+    QString beatLoopRollDescription = tr("Create temporary %1-beat loop roll");
 
     QList<double> beatSizes = LoopingControl::getBeatSizes();
 
@@ -411,50 +405,51 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     humanBeatSizes[32] = tr("32");
     humanBeatSizes[64] = tr("64");
 
-    // Loop moving
-    QString loopMoveForwardTitle = tr("Move Loop +%1 Beats");
-    QString loopMoveBackwardTitle = tr("Move Loop -%1 Beats");
-    QString loopMoveForwardDescription = tr("Move loop forward by %1 beats");
-    QString loopMoveBackwardDescription = tr("Move loop backward by %1 beats");
-
-    foreach (double beats, beatSizes) {
-        QString humanBeats = humanBeatSizes.value(beats, QString::number(beats));
-        addDeckControl(QString("loop_move_%1_forward").arg(beats),
-                       loopMoveForwardTitle.arg(humanBeats),
-                       loopMoveForwardDescription.arg(humanBeats), loopMenu);
-    }
-
-    foreach (double beats, beatSizes) {
-        QString humanBeats = humanBeatSizes.value(beats, QString::number(beats));
-        addDeckControl(QString("loop_move_%1_backward").arg(beats),
-                       loopMoveBackwardTitle.arg(humanBeats),
-                       loopMoveBackwardDescription.arg(humanBeats), loopMenu);
-    }
-
     // Beatloops
-    QMenu* beatLoopMenu = addSubmenu(tr("Beat-Looping"));
-    QString beatLoopTitle = tr("Loop %1 Beats");
-    QString beatLoopRollTitle = tr("Loop Roll %1 Beats");
-    QString beatLoopDescription = tr("Create %1-beat loop");
-    QString beatLoopRollDescription = tr("Create temporary %1-beat loop roll");
-
-    addDeckControl("beatloop_activate", beatloopActivateTitle, beatloopActivateDescription, beatLoopMenu);
-    addDeckControl("beatlooproll_activate", beatloopRollActivateTitle, beatloopRollActivateDescription, beatLoopMenu);
+    addDeckControl("beatloop_activate",
+            beatloopActivateTitle,
+            beatloopActivateDescription,
+            loopMenu);
+    QMenu* loopActivateMenu = addSubmenu(tr("Loop Beats"), loopMenu);
     foreach (double beats, beatSizes) {
         QString humanBeats = humanBeatSizes.value(beats, QString::number(beats));
         addDeckControl(QString("beatloop_%1_toggle").arg(beats),
-                       beatLoopTitle.arg(humanBeats),
-                       beatLoopDescription.arg(humanBeats), beatLoopMenu);
+                beatLoopTitle.arg(humanBeats),
+                beatLoopDescription.arg(humanBeats),
+                loopActivateMenu);
     }
+    loopMenu->addSeparator();
 
+    addDeckControl("beatlooproll_activate",
+            beatloopRollActivateTitle,
+            beatloopRollActivateDescription,
+            loopMenu);
+    QMenu* looprollActivateMenu = addSubmenu(tr("Loop Roll Beats"), loopMenu);
     foreach (double beats, beatSizes) {
         QString humanBeats = humanBeatSizes.value(beats, QString::number(beats));
         addDeckControl(QString("beatlooproll_%1_activate").arg(beats),
-                       beatLoopRollTitle.arg(humanBeats),
-                       beatLoopRollDescription.arg(humanBeats), beatLoopMenu);
+                beatLoopRollTitle.arg(humanBeats),
+                beatLoopRollDescription.arg(humanBeats),
+                looprollActivateMenu);
     }
+    loopMenu->addSeparator();
 
-    // Beat jumping
+    addDeckControl("loop_in", tr("Loop In"), tr("Loop In button"), loopMenu);
+    addDeckControl("loop_out", tr("Loop Out"), tr("Loop Out button"), loopMenu);
+    addDeckControl("loop_exit", tr("Loop Exit"), tr("Loop Exit button"), loopMenu);
+    addDeckControl("reloop_toggle",
+            tr("Reloop/Exit Loop"),
+            tr("Toggle loop on/off and jump to Loop In point if loop is behind "
+               "play position"),
+            loopMenu);
+    addDeckControl("reloop_andstop",
+            tr("Reloop And Stop"),
+            tr("Enable loop, jump to Loop In point, and stop"),
+            loopMenu);
+    addDeckControl("loop_halve", tr("Loop Halve"), tr("Halve the loop length"), loopMenu);
+    addDeckControl("loop_double", tr("Loop Double"), tr("Double the loop length"), loopMenu);
+
+    // Beat Jump / Loop Move
     QMenu* beatJumpMenu = addSubmenu(tr("Beat Jump / Loop Move"));
     QString beatJumpForwardTitle = tr("Jump / Move Loop Forward %1 Beats");
     QString beatJumpBackwardTitle = tr("Jump / Move Loop Backward %1 Beats");
@@ -462,19 +457,48 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     QString beatJumpBackwardDescription = tr("Jump backward by %1 beats, or if a loop is enabled, move the loop backward %1 beats");
     addDeckControl("beatjump_forward", tr("Beat Jump / Loop Move Forward Selected Beats"), tr("Jump forward by the selected number of beats, or if a loop is enabled, move the loop forward by the selected number of beats"), beatJumpMenu);
     addDeckControl("beatjump_backward", tr("Beat Jump / Loop Move Backward Selected Beats"), tr("Jump backward by the selected number of beats, or if a loop is enabled, move the loop backward by the selected number of beats"), beatJumpMenu);
+    beatJumpMenu->addSeparator();
 
+    QMenu* beatjumpFwdSubmenu = addSubmenu(tr("Beat Jump / Loop Move Forward"), beatJumpMenu);
     foreach (double beats, beatSizes) {
         QString humanBeats = humanBeatSizes.value(beats, QString::number(beats));
         addDeckControl(QString("beatjump_%1_forward").arg(beats),
-                       beatJumpForwardTitle.arg(humanBeats),
-                       beatJumpForwardDescription.arg(humanBeats), beatJumpMenu);
+                beatJumpForwardTitle.arg(humanBeats),
+                beatJumpForwardDescription.arg(humanBeats),
+                beatjumpFwdSubmenu);
     }
 
+    QMenu* beatjumpBwdSubmenu = addSubmenu(tr("Beat Jump / Loop Move Backward"), beatJumpMenu);
     foreach (double beats, beatSizes) {
         QString humanBeats = humanBeatSizes.value(beats, QString::number(beats));
         addDeckControl(QString("beatjump_%1_backward").arg(beats),
-                       beatJumpBackwardTitle.arg(humanBeats),
-                       beatJumpBackwardDescription.arg(humanBeats), beatJumpMenu);
+                beatJumpBackwardTitle.arg(humanBeats),
+                beatJumpBackwardDescription.arg(humanBeats),
+                beatjumpBwdSubmenu);
+    }
+
+    // Loop moving
+    QString loopMoveForwardTitle = tr("Move Loop +%1 Beats");
+    QString loopMoveBackwardTitle = tr("Move Loop -%1 Beats");
+    QString loopMoveForwardDescription = tr("Move loop forward by %1 beats");
+    QString loopMoveBackwardDescription = tr("Move loop backward by %1 beats");
+
+    QMenu* loopmoveFwdSubmenu = addSubmenu(tr("Loop Move Forward"), beatJumpMenu);
+    foreach (double beats, beatSizes) {
+        QString humanBeats = humanBeatSizes.value(beats, QString::number(beats));
+        addDeckControl(QString("loop_move_%1_forward").arg(beats),
+                loopMoveForwardTitle.arg(humanBeats),
+                loopMoveForwardDescription.arg(humanBeats),
+                loopmoveFwdSubmenu);
+    }
+
+    QMenu* loopmoveBwdSubmenu = addSubmenu(tr("Loop Move Backward"), beatJumpMenu);
+    foreach (double beats, beatSizes) {
+        QString humanBeats = humanBeatSizes.value(beats, QString::number(beats));
+        addDeckControl(QString("loop_move_%1_backward").arg(beats),
+                loopMoveBackwardTitle.arg(humanBeats),
+                loopMoveBackwardDescription.arg(humanBeats),
+                loopmoveBwdSubmenu);
     }
 
     addSeparator();
@@ -620,6 +644,8 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                    tr("Quick Effect Enable Button"),
                    quickEffectMenu, false, tr("Quick Effect"));
     }
+
+    effectsMenu->addSeparator();
 
     const int kNumEffectRacks = 1;
     for (int iRackNumber = 1; iRackNumber <= kNumEffectRacks; ++iRackNumber) {

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -44,6 +44,8 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     addDeckAndSamplerControl("orientation_right", tr("Orient Right"),
                              tr("Set mix orientation to right"), mixerMenu);
 
+    addSeparator();
+
     // Transport
     QMenu* transportMenu = addSubmenu(tr("Transport"));
     addDeckAndSamplerAndPreviewDeckControl("play", tr("Play"), tr("Play button"), transportMenu);
@@ -367,6 +369,8 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                        beatJumpBackwardTitle.arg(humanBeats),
                        beatJumpBackwardDescription.arg(humanBeats), beatJumpMenu);
     }
+
+    addSeparator();
 
     // Library Controls
     QMenu* libraryMenu = addSubmenu(tr("Library"));
@@ -693,6 +697,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                                tr("Auxiliary on/off"),
                                microphoneMenu,
                                false, true);
+    microphoneMenu->addSeparator();
     addMicrophoneAndAuxControl("pregain",
                                tr("Gain"),
                                tr("Gain knob"), microphoneMenu,
@@ -713,6 +718,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                                tr("Mute"),
                                tr("Mute button"), microphoneMenu,
                                true, true);
+    microphoneMenu->addSeparator();
     addMicrophoneAndAuxControl("orientation",
                                tr("Orientation"),
                                tr("Mix orientation (e.g. left, right, center)"),
@@ -774,6 +780,9 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                tr("Library Maximize/Restore"),
                tr("Maximize the track library to take up all the available screen space."), guiMenu);
 
+    guiMenu->addSeparator();
+
+    // TODO(ronso0) Add hint that this currently only affects the Shade skin
     QString spinnyTitle = tr("Vinyl Spinner Show/Hide");
     QString spinnyDescription = tr("Show/hide spinning vinyl widget");
     for (int i = 1; i <= iNumDecks; ++i) {
@@ -783,9 +792,13 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
 
     }
 
+    guiMenu->addSeparator();
+
     addDeckControl("waveform_zoom", tr("Waveform Zoom"), tr("Waveform zoom"), guiMenu);
     addDeckControl("waveform_zoom_down", tr("Waveform Zoom In"), tr("Zoom waveform in"), guiMenu);
     addDeckControl("waveform_zoom_up", tr("Waveform Zoom Out"), tr("Zoom waveform out"), guiMenu);
+
+    guiMenu->addSeparator();
 
     // Controls to change a deck's star rating
     addDeckAndPreviewDeckControl("stars_up", tr("Star Rating Up"),

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -329,7 +329,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                        tr("Go to cue point and play after release"), cueMenu);
 
     // Hotcues
-    QMenu* hotcueMenu = addSubmenu(tr("Hotcues"));
+    QMenu* hotcueMainMenu = addSubmenu(tr("Hotcues"));
     QString hotcueActivateTitle = tr("Hotcue %1");
     QString hotcueClearTitle = tr("Clear Hotcue %1");
     QString hotcueSetTitle = tr("Set Hotcue %1");
@@ -344,8 +344,25 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     QString hotcueGotoAndStopDescription = tr("Jump to hotcue %1 and stop");
     QString hotcueGotoAndPlayDescription = tr("Jump to hotcue %1 and play");
     QString hotcuePreviewDescription = tr("Preview from hotcue %1");
+    // add menus for hotcues 1-16.
+    // though, keep the menu small put additional hotcues in a separate menu,
+    // but don't create that submenu for less than 4 additional hotcues.
+    int preferredHotcuesVisible = 16;
+    int moreMenuThreshold = 4;
+    QMenu* parentMenu = hotcueMainMenu;
+    QMenu* hotcueMoreMenu = nullptr;
+    bool moreHotcues = NUM_HOT_CUES >= preferredHotcuesVisible + moreMenuThreshold;
+    if (moreHotcues) {
+        // populate menu here, add it below #preferredHotcuesVisible
+        hotcueMoreMenu = new QMenu(
+                tr("Hotcues %1-%2").arg(preferredHotcuesVisible + 1).arg(NUM_HOT_CUES),
+                hotcueMainMenu);
+    }
     for (int i = 1; i <= NUM_HOT_CUES; ++i) {
-        QMenu* hotcueSubMenu = addSubmenu(tr("Hotcue %1").arg(QString::number(i)), hotcueMenu);
+        if (moreHotcues && i > preferredHotcuesVisible) {
+            parentMenu = hotcueMoreMenu;
+        }
+        QMenu* hotcueSubMenu = addSubmenu(tr("Hotcue %1").arg(QString::number(i)), parentMenu);
         addDeckAndSamplerControl(QString("hotcue_%1_activate").arg(i),
                                  hotcueActivateTitle.arg(QString::number(i)),
                                  hotcueActivateDescription.arg(QString::number(i)),
@@ -374,6 +391,10 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                                  hotcuePreviewTitle.arg(QString::number(i)),
                                  hotcuePreviewDescription.arg(QString::number(i)),
                                  hotcueSubMenu);
+    }
+    if (moreHotcues) {
+        hotcueMainMenu->addSeparator();
+        hotcueMainMenu->addMenu(hotcueMoreMenu);
     }
 
     // Loops

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -20,7 +20,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     m_auxStr = tr("Auxiliary %1");
     m_resetStr = tr("Reset to default");
     m_effectRackStr = tr("Effect Rack %1");
-    m_effectUnitStr = tr("Unit %1");
+    m_effectUnitStr = tr("Effect Unit %1");
     m_effectStr = tr("Slot %1");
     m_parameterStr = tr("Parameter %1");
     m_libraryStr = tr("Library");
@@ -647,16 +647,13 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
 
     effectsMenu->addSeparator();
 
+    // When kNumEffectRacks is changed to >1 put effect unit actions into
+    // separate "Effect Rack N" submenus.
     const int kNumEffectRacks = 1;
     for (int iRackNumber = 1; iRackNumber <= kNumEffectRacks; ++iRackNumber) {
         const QString rackGroup = StandardEffectRack::formatGroupString(
                 iRackNumber - 1);
-        QMenu* rackMenu = addSubmenu(m_effectRackStr.arg(iRackNumber), effectsMenu);
         QString descriptionPrefix = m_effectRackStr.arg(iRackNumber);
-
-        addControl(rackGroup, "clear",
-                   tr("Clear Effect Rack"), tr("Clear effect rack"),
-                   rackMenu, false, descriptionPrefix);
 
         const int numEffectUnits = static_cast<int>(ControlObject::get(
                 ConfigKey(rackGroup, "num_effectunits")));
@@ -666,11 +663,10 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                     StandardEffectRack::formatEffectChainSlotGroupString(
                         iRackNumber - 1, iEffectUnitNumber - 1);
 
-            descriptionPrefix = QString("%1, %2").arg(m_effectRackStr.arg(iRackNumber),
-                                                      m_effectUnitStr.arg(iEffectUnitNumber));
+            descriptionPrefix = QString("%1").arg(m_effectUnitStr.arg(iEffectUnitNumber));
 
             QMenu* effectUnitMenu = addSubmenu(m_effectUnitStr.arg(iEffectUnitNumber),
-                                               rackMenu);
+                    effectsMenu);
             addControl(effectUnitGroup, "clear",
                        tr("Clear Unit"),
                        tr("Clear effect unit"),
@@ -708,33 +704,39 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                        tr("Show Effect Parameters"),
                        effectUnitMenu, false, descriptionPrefix);
 
-            QString enableOn = tr("Toggle Effect Unit");
-            QMenu* effectUnitGroups = addSubmenu(enableOn,
-                                                 effectUnitMenu);
+            QString assignMenuTitle = tr("Effect Unit Assignment");
+            QString assignString = tr("Assign ");
+            QMenu* effectUnitGroups = addSubmenu(assignMenuTitle,
+                    effectUnitMenu);
 
-            QString groupDescriptionPrefix = QString("%1, %2 %3").arg(
-                    m_effectRackStr.arg(iRackNumber),
-                    m_effectUnitStr.arg(iEffectUnitNumber),
-                    enableOn);
+            QString groupDescriptionPrefix = QString("%1").arg(
+                    m_effectUnitStr.arg(iEffectUnitNumber));
 
             addControl(effectUnitGroup, "group_[Master]_enable",
-                       m_effectMasterOutputStr,
-                       m_effectMasterOutputStr,
-                       effectUnitGroups, false, groupDescriptionPrefix);
-            addControl(effectUnitGroup, "group_[Headphone]_enable",
-                       m_effectHeadphoneOutputStr,
-                       m_effectHeadphoneOutputStr,
-                       effectUnitGroups, false, groupDescriptionPrefix);
+                    assignString + m_effectMasterOutputStr, // in ComboBox
+                    assignString + m_effectMasterOutputStr, // description below
+                    effectUnitGroups,
+                    false,
+                    groupDescriptionPrefix);
+            addControl(effectUnitGroup,
+                    "group_[Headphone]_enable",
+                    assignString + m_effectHeadphoneOutputStr,
+                    assignString + m_effectHeadphoneOutputStr,
+                    effectUnitGroups,
+                    false,
+                    groupDescriptionPrefix);
 
             for (int iDeckNumber = 1; iDeckNumber <= iNumDecks; ++iDeckNumber) {
                 // PlayerManager::groupForDeck is 0-indexed.
                 QString playerGroup = PlayerManager::groupForDeck(iDeckNumber - 1);
                 // TODO(owen): Fix bad i18n here.
                 addControl(effectUnitGroup,
-                           QString("group_%1_enable").arg(playerGroup),
-                           tr("Assign ") + m_deckStr.arg(iDeckNumber),
-                           tr("Assign ") + m_deckStr.arg(iDeckNumber),
-                           effectUnitGroups, false, groupDescriptionPrefix);
+                        QString("group_%1_enable").arg(playerGroup),
+                        assignString + m_deckStr.arg(iDeckNumber),
+                        assignString + m_deckStr.arg(iDeckNumber),
+                        effectUnitGroups,
+                        false,
+                        groupDescriptionPrefix);
             }
 
             const int iNumSamplers = static_cast<int>(ControlObject::get(
@@ -745,11 +747,12 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                 QString playerGroup = PlayerManager::groupForSampler(iSamplerNumber - 1);
                 // TODO(owen): Fix bad i18n here.
                 addControl(effectUnitGroup,
-                           QString("group_%1_enable").arg(playerGroup),
-                           tr("Assign ") + m_samplerStr.arg(iSamplerNumber),
-                           tr("Assign ") + m_samplerStr.arg(iSamplerNumber),
-                           effectUnitGroups, false, groupDescriptionPrefix);
-
+                        QString("group_%1_enable").arg(playerGroup),
+                        assignString + m_samplerStr.arg(iSamplerNumber),
+                        assignString + m_samplerStr.arg(iSamplerNumber),
+                        effectUnitGroups,
+                        false,
+                        groupDescriptionPrefix);
             }
 
             const int iNumMicrophones = static_cast<int>(ControlObject::get(
@@ -759,10 +762,12 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                 QString micGroup = PlayerManager::groupForMicrophone(iMicrophoneNumber - 1);
                 // TODO(owen): Fix bad i18n here.
                 addControl(effectUnitGroup,
-                           QString("group_%1_enable").arg(micGroup),
-                           tr("Assign ") + m_microphoneStr.arg(iMicrophoneNumber),
-                           tr("Assign ") + m_microphoneStr.arg(iMicrophoneNumber),
-                           effectUnitGroups, false, groupDescriptionPrefix);
+                        QString("group_%1_enable").arg(micGroup),
+                        assignString + m_microphoneStr.arg(iMicrophoneNumber),
+                        assignString + m_microphoneStr.arg(iMicrophoneNumber),
+                        effectUnitGroups,
+                        false,
+                        groupDescriptionPrefix);
             }
 
             const int iNumAuxiliaries = static_cast<int>(ControlObject::get(
@@ -772,10 +777,12 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                 QString auxGroup = PlayerManager::groupForAuxiliary(iAuxiliaryNumber - 1);
                 // TODO(owen): Fix bad i18n here.
                 addControl(effectUnitGroup,
-                           QString("group_%1_enable").arg(auxGroup),
-                           tr("Assign ") + m_auxStr.arg(iAuxiliaryNumber),
-                           tr("Assign ") + m_auxStr.arg(iAuxiliaryNumber),
-                           effectUnitGroups, false, groupDescriptionPrefix);
+                        QString("group_%1_enable").arg(auxGroup),
+                        assignString + m_auxStr.arg(iAuxiliaryNumber),
+                        assignString + m_auxStr.arg(iAuxiliaryNumber),
+                        effectUnitGroups,
+                        false,
+                        groupDescriptionPrefix);
             }
 
             const int numEffectSlots = static_cast<int>(ControlObject::get(
@@ -850,10 +857,17 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                                tr("Invert how linked effect parameters change when turning the Meta Knob."),
                                parameterSlotMenu, false,
                                parameterDescriptionPrefix);
-
                 }
             }
         }
+        // Clear Effect Rack
+        addControl(rackGroup,
+                "clear",
+                tr("Clear Effect Rack"),
+                tr("Clear effect rack"),
+                effectsMenu,
+                false,
+                descriptionPrefix);
     }
 
     // Microphone Controls

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -183,14 +183,15 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     addDeckAndSamplerControl("repeat", tr("Repeat Mode"), tr("Toggle repeat mode"), transportMenu);
     addDeckAndSamplerControl("slip_enabled", tr("Slip Mode"), tr("Toggle slip mode"), transportMenu);
 
-    // BPM & Sync
-    QMenu* bpmMenu = addSubmenu(tr("BPM"));
+    // BPM / Beatgrid
+    QMenu* bpmMenu = addSubmenu(tr("BPM / Beatgrid"));
     addDeckAndSamplerControl("bpm", tr("BPM"), tr("BPM"), bpmMenu, true);
     addDeckAndSamplerControl("bpm_up", tr("BPM +1"), tr("Increase BPM by 1"), bpmMenu);
     addDeckAndSamplerControl("bpm_down", tr("BPM -1"), tr("Decrease BPM by 1"), bpmMenu);
     addDeckAndSamplerControl("bpm_up_small", tr("BPM +0.1"), tr("Increase BPM by 0.1"), bpmMenu);
     addDeckAndSamplerControl("bpm_down_small", tr("BPM -0.1"), tr("Decrease BPM by 0.1"), bpmMenu);
     addDeckAndSamplerControl("bpm_tap", tr("BPM Tap"), tr("BPM tap button"), bpmMenu);
+    bpmMenu->addSeparator();
     addDeckAndSamplerControl("beats_adjust_faster", tr("Adjust Beatgrid Faster +.01"), tr("Increase track's average BPM by 0.01"), bpmMenu);
     addDeckAndSamplerControl("beats_adjust_slower", tr("Adjust Beatgrid Slower -.01"), tr("Decrease track's average BPM by 0.01"), bpmMenu);
     addDeckAndSamplerControl("beats_translate_earlier", tr("Move Beatgrid Earlier"), tr("Adjust the beatgrid to the left"), bpmMenu);
@@ -199,11 +200,28 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                    tr("Align beatgrid to current position"), bpmMenu);
     addDeckControl("beats_translate_match_alignment", tr("Adjust Beatgrid - Match Alignment"),
                    tr("Adjust beatgrid to match another playing deck."), bpmMenu);
+    bpmMenu->addSeparator();
     addDeckAndSamplerControl("quantize", tr("Quantize Mode"), tr("Toggle quantize mode"), bpmMenu);
 
     QMenu* syncMenu = addSubmenu(tr("Sync"));
-    addDeckAndSamplerControl("sync_enabled", tr("Sync Mode"),
-                             tr("Tap to sync tempo (and phase with quantize enabled), hold to enable permanent sync"), syncMenu);
+    addDeckAndSamplerControl("sync_enabled",
+            tr("Sync / Sync Lock"),
+            tr("Tap to sync tempo (and phase with quantize enabled), hold to "
+               "enable permanent sync"),
+            syncMenu);
+    addDeckAndSamplerControl("beatsync",
+            tr("Beat Sync One-Shot"),
+            tr("One-time beat sync tempo (and phase with quantize enabled)"),
+            syncMenu);
+    addDeckAndSamplerControl("beatsync_tempo",
+            tr("Sync Tempo One-Shot"),
+            tr("One-time beat sync (tempo only)"),
+            syncMenu);
+    addDeckAndSamplerControl("beatsync_phase",
+            tr("Sync Phase One-Shot"),
+            tr("One-time beat sync (phase only)"),
+            syncMenu);
+    syncMenu->addSeparator();
     addControl("[InternalClock]", "sync_master", tr("Internal Sync Master"),
                tr("Toggle Internal Sync Master"), syncMenu);
     addControl("[InternalClock]", "bpm", tr("Internal Master BPM"),
@@ -218,36 +236,16 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                tr("Increase internal master BPM by 0.1"), syncMenu);
     addControl("[InternalClock]", "bpm_down_small", tr("Internal Master BPM -0.1"),
                tr("Decrease internal master BPM by 0.1"), syncMenu);
+    syncMenu->addSeparator();
     addDeckAndSamplerControl("sync_master", tr("Sync Master"), tr("Toggle sync master"), syncMenu);
     addDeckAndSamplerControl("sync_mode", tr("Sync Mode"),
                              tr("Sync mode 3-state toggle (OFF, FOLLOWER, MASTER)"), syncMenu);
-    addDeckAndSamplerControl("beatsync", tr("Beat Sync One-Shot"),
-                             tr("One-time beat sync tempo (and phase with quantize enabled)"), syncMenu);
-    addDeckAndSamplerControl("beatsync_tempo", tr("Sync Tempo One-Shot"),
-                             tr("One-time beat sync (tempo only)"), syncMenu);
-    addDeckAndSamplerControl("beatsync_phase", tr("Sync Phase One-Shot"),
-                             tr("One-time beat sync (phase only)"), syncMenu);
 
     // Speed
-    QMenu* speedMenu = addSubmenu(tr("Speed (Pitch/Tempo)"));
-    addDeckAndSamplerControl("keylock", tr("Keylock Mode"),
-                             tr("Toggle keylock mode"), speedMenu);
+    QMenu* speedMenu = addSubmenu(tr("Speed"));
     addDeckAndSamplerControl("rate", tr("Playback Speed"),
                              tr("Playback speed control (Vinyl \"Pitch\" slider)"), speedMenu, true);
-    addDeckAndSamplerControl("pitch", tr("Pitch (Musical key)"),
-                             tr("Pitch control (does not affect tempo), center is original pitch"), speedMenu, true);
-    addDeckAndSamplerControl("pitch_up", tr("Increase Pitch"),
-                            tr("Increases the pitch by one semitone"), speedMenu);
-    addDeckAndSamplerControl("pitch_up_small", tr("Increase Pitch (Fine)"),
-                            tr("Increases the pitch by 10 cents"), speedMenu);
-    addDeckAndSamplerControl("pitch_down", tr("Decrease Pitch"),
-                            tr("Decreases the pitch by one semitone"), speedMenu);
-    addDeckAndSamplerControl("pitch_down_small", tr("Decrease Pitch (Fine)"),
-                            tr("Decreases the pitch by 10 cents"), speedMenu);
-    addDeckAndSamplerControl("pitch_adjust", tr("Pitch Adjust"),
-                             tr("Adjust pitch from speed slider pitch"), speedMenu, true);
-    addDeckAndSamplerControl("sync_key", tr("Match Key"), tr("Match musical key"), speedMenu);
-    addDeckAndSamplerControl("reset_key", tr("Reset Key"), tr("Resets key to original"), speedMenu);
+    speedMenu->addSeparator();
     addDeckAndSamplerControl("rate_perm_up", tr("Increase Speed"),
                              tr("Adjust speed faster (coarse)"), speedMenu);
     addDeckAndSamplerControl("rate_perm_up_small", tr("Increase Speed (Fine)"),
@@ -256,6 +254,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                              tr("Adjust speed slower (coarse)"), speedMenu);
     addDeckAndSamplerControl("rate_perm_down_small", tr("Increase Speed (Fine)"),
                              tr("Adjust speed slower (fine)"), speedMenu);
+    speedMenu->addSeparator();
     addDeckAndSamplerControl("rate_temp_up", tr("Temporarily Increase Speed"),
                              tr("Temporarily increase speed (coarse)"), speedMenu);
     addDeckAndSamplerControl("rate_temp_up_small", tr("Temporarily Increase Speed (Fine)"),
@@ -264,6 +263,39 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                              tr("Temporarily decrease speed (coarse)"), speedMenu);
     addDeckAndSamplerControl("rate_temp_down_small", tr("Temporarily Decrease Speed (Fine)"),
                              tr("Temporarily decrease speed (fine)"), speedMenu);
+    // Pitch (Musical Key)
+    QMenu* pitchMenu = addSubmenu(tr("Pitch (Musical Key)"));
+    addDeckAndSamplerControl("pitch",
+            tr("Pitch (Musical key)"),
+            tr("Pitch control (does not affect tempo), center is original "
+               "pitch"),
+            pitchMenu,
+            true);
+    addDeckAndSamplerControl("pitch_up",
+            tr("Increase Pitch"),
+            tr("Increases the pitch by one semitone"),
+            pitchMenu);
+    addDeckAndSamplerControl("pitch_up_small",
+            tr("Increase Pitch (Fine)"),
+            tr("Increases the pitch by 10 cents"),
+            pitchMenu);
+    addDeckAndSamplerControl("pitch_down",
+            tr("Decrease Pitch"),
+            tr("Decreases the pitch by one semitone"),
+            pitchMenu);
+    addDeckAndSamplerControl("pitch_down_small",
+            tr("Decrease Pitch (Fine)"),
+            tr("Decreases the pitch by 10 cents"),
+            pitchMenu);
+    addDeckAndSamplerControl("pitch_adjust",
+            tr("Pitch Adjust"),
+            tr("Adjust pitch from speed slider pitch"),
+            pitchMenu,
+            true);
+    pitchMenu->addSeparator();
+    addDeckAndSamplerControl("sync_key", tr("Match Key"), tr("Match musical key"), pitchMenu);
+    addDeckAndSamplerControl("reset_key", tr("Reset Key"), tr("Resets key to original"), pitchMenu);
+    addDeckAndSamplerControl("keylock", tr("Keylock"), tr("Toggle keylock mode"), pitchMenu);
 
     // Vinyl Control
     QMenu* vinylControlMenu = addSubmenu(tr("Vinyl Control"));

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -951,18 +951,37 @@ void ControlPickerMenu::addPlayerControl(QString control, QString controlTitle,
         }
     }
 
-    for (int i = 1; samplerControls && i <= iNumSamplers; ++i) {
-        // PlayerManager::groupForSampler is 0-indexed.
-        QString prefix = m_samplerStr.arg(i);
-        QString group = PlayerManager::groupForSampler(i - 1);
-        addSingleControl(group, control, controlTitle, controlDescription,
-                         controlMenu, prefix, prefix);
-
+    if (samplerControls) {
+        parented_ptr<QMenu> samplerControlMenu = make_parented<QMenu>(tr("Samplers"), controlMenu);
+        controlMenu->addMenu(samplerControlMenu);
+        parented_ptr<QMenu> samplerResetControlMenu = nullptr;
         if (resetControlMenu) {
-            QString resetTitle = QString("%1 (%2)").arg(controlTitle, m_resetStr);
-            QString resetDescription = QString("%1 (%2)").arg(controlDescription, m_resetStr);
-            addSingleControl(group, resetControl, resetTitle, resetDescription,
-                    resetControlMenu, prefix, prefix);
+            samplerResetControlMenu = make_parented<QMenu>(tr("Samplers"), resetControlMenu);
+            resetControlMenu->addMenu(samplerResetControlMenu);
+        }
+        for (int i = 1; i <= iNumSamplers; ++i) {
+            // PlayerManager::groupForSampler is 0-indexed.
+            QString prefix = m_samplerStr.arg(i);
+            QString group = PlayerManager::groupForSampler(i - 1);
+            addSingleControl(group,
+                    control,
+                    controlTitle,
+                    controlDescription,
+                    samplerControlMenu,
+                    prefix,
+                    prefix);
+
+            if (resetControlMenu) {
+                QString resetTitle = QString("%1 (%2)").arg(controlTitle, m_resetStr);
+                QString resetDescription = QString("%1 (%2)").arg(controlDescription, m_resetStr);
+                addSingleControl(group,
+                        resetControl,
+                        resetTitle,
+                        resetDescription,
+                        samplerResetControlMenu,
+                        prefix,
+                        prefix);
+            }
         }
     }
 }

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -764,6 +764,12 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                                tr("Mute"),
                                tr("Mute button"), microphoneMenu,
                                true, true);
+    addMicrophoneAndAuxControl("pfl",
+            tr("Headphone Listen"),
+            tr("Headphone listen button"),
+            microphoneMenu,
+            true,
+            true);
     microphoneMenu->addSeparator();
     addMicrophoneAndAuxControl("orientation",
                                tr("Orientation"),
@@ -781,10 +787,6 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     addMicrophoneAndAuxControl("orientation_right",
                                tr("Orient Right"),
                                tr("Set mix orientation to right"), microphoneMenu,
-                               true, true);
-    addMicrophoneAndAuxControl("pfl",
-                               tr("Headphone Listen"),
-                               tr("Headphone listen button"), microphoneMenu,
                                true, true);
 
     // AutoDJ Controls


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1901107

- [x] add separators in many places
- [x] move _Sampler 1-64_ controls into submenus
- [x] group **Libary** navigation controls into submenu
- [x] **Mixer**: create submenus _Crossfader /Orientation_, _Main_, _Headphone_
- [x] **Equalizers**: move to _Mixer_
- [x] **Transport**: move _Volume_, _Mute_ & _Pfl_ to Mixer
- [x] split _Speed / Pitch_ menu into **Speed / Tempo** and **Pitch (Musical Key)**
- [x] **Looping** & **Beat-Looping**: merge, sort controls into submenus _Loop_ & _Loop Roll_, remove redundant _Loopmove_ actions
- [x] **Effects**: _Unit N_ > _Effect Unit N_, move unit menus to main _Effects_ menu (remove _Effect Rack 1_ level)
- [x] **Effects**: unclutter Fx assign GUI strings

Anything else ?