### PR TITLE
[Do not merge] SoundSource range issues

### DIFF
--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -535,15 +535,38 @@ TEST_F(SoundSourceProxyTest, readBeyondEnd) {
         ASSERT_GT(remainingFrames, 0);
         ASSERT_LT(remainingFrames, kReadFrameCount);
 
-        // Read beyond the end
         mixxx::SampleBuffer readBuffer(
                 pAudioSource->getSignalInfo().frames2samples(kReadFrameCount));
-        EXPECT_EQ(
-                mixxx::IndexRange::forward(seekIndex, remainingFrames),
-                pAudioSource->readSampleFrames(
-                        mixxx::WritableSampleFrames(
-                                mixxx::IndexRange::forward(seekIndex, kReadFrameCount),
-                                mixxx::SampleBuffer::WritableSlice(readBuffer))).frameIndexRange());
+
+        // Read beyond the end, starting within the valid range
+        EXPECT_EQ(mixxx::IndexRange::forward(seekIndex, remainingFrames),
+                pAudioSource
+                        ->readSampleFrames(mixxx::WritableSampleFrames(
+                                mixxx::IndexRange::forward(
+                                        seekIndex, kReadFrameCount),
+                                mixxx::SampleBuffer::WritableSlice(
+                                        readBuffer)))
+                        .frameIndexRange());
+
+        // Read beyond the end, starting at the upper boundary of the valid range
+        EXPECT_EQ(mixxx::IndexRange::forward(pAudioSource->frameIndexMax(), 0),
+                pAudioSource
+                        ->readSampleFrames(mixxx::WritableSampleFrames(
+                                mixxx::IndexRange::forward(
+                                        pAudioSource->frameIndexMax(), kReadFrameCount),
+                                mixxx::SampleBuffer::WritableSlice(
+                                        readBuffer)))
+                        .frameIndexRange());
+
+        // Read beyond the end, starting beyond the upper boundary of the valid range
+        EXPECT_EQ(mixxx::IndexRange::forward(pAudioSource->frameIndexMax() + 1, 0),
+                pAudioSource
+                        ->readSampleFrames(mixxx::WritableSampleFrames(
+                                mixxx::IndexRange::forward(
+                                        pAudioSource->frameIndexMax() + 1, kReadFrameCount),
+                                mixxx::SampleBuffer::WritableSlice(
+                                        readBuffer)))
+                        .frameIndexRange());
     }
 }
 


### PR DESCRIPTION
Justification for the fixes introduced in #3073.

@daschuer: This regression test demonstrates the issues caused by the ~~invalid~~sloppy `RangeIndex` intersection results.