### PR TITLE
WSearchRelatedTracksMenu: Elide action text

### DIFF
--- a/src/widget/wsearchrelatedtracksmenu.cpp
+++ b/src/widget/wsearchrelatedtracksmenu.cpp
@@ -9,7 +9,9 @@
 
 namespace {
 
-constexpr double kMaxMenuToAvailableScreenWidthRatio = 0.2; // 20%
+// Occupying up to 20% of the screen's width has been considered
+// a viable upper bound for the context menu.
+constexpr double kMaxMenuToAvailableScreenWidthRatio = 0.2;
 
 constexpr int kMinMenuWidthInPixels = 100;
 

--- a/src/widget/wsearchrelatedtracksmenu.cpp
+++ b/src/widget/wsearchrelatedtracksmenu.cpp
@@ -321,15 +321,21 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
     {
         const auto locationPath = track.getFileInfo().directory();
         if (!locationPath.isEmpty()) {
+            // Search folder and all subfolders, i.e. for "path/to/folder"
+            // also find files in "path/to/folder/subfolder" but not in
+            // "path/to/folder copy".
+            DEBUG_ASSERT(!locationPath.endsWith(QChar('/')));
+            const auto locationPathWithTerminator =
+                    locationPath + QChar('/');
             const QString searchQuery =
                     QStringLiteral("location:\"") +
-                    locationPath +
+                    locationPathWithTerminator +
                     QChar('"');
             addTriggerSearchAction(
                     &addSeparatorBeforeNextAction,
                     searchQuery,
                     tr("Folder: "),
-                    quoteText(locationPath));
+                    quoteText(locationPathWithTerminator));
         }
     }
 }

--- a/src/widget/wsearchrelatedtracksmenu.cpp
+++ b/src/widget/wsearchrelatedtracksmenu.cpp
@@ -178,7 +178,7 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
             // Search tracks with similar artist(s)
             {
                 const auto actionTextPrefix = tr("Artist");
-                const auto searchQueryPrefix = QStringLiteral("artist:\"");
+                const auto searchQueryPrefix = QStringLiteral("artist:");
                 {
                     const QString searchQuery =
                             searchQueryPrefix +
@@ -202,7 +202,7 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
             }
             {
                 const auto actionTextPrefix = tr("Album Artist");
-                const auto searchQueryPrefix = QStringLiteral("album_artist:\"");
+                const auto searchQueryPrefix = QStringLiteral("album_artist:");
                 {
                     const QString searchQuery =
                             searchQueryPrefix +

--- a/src/widget/wsearchrelatedtracksmenu.cpp
+++ b/src/widget/wsearchrelatedtracksmenu.cpp
@@ -15,7 +15,7 @@ constexpr double kMaxMenuToAvailableScreenWidthRatio = 0.2;
 
 constexpr double kRelativeBpmRange = 0.06; // +/-6 %
 
-const QString kActionTextPrefixSuffixSeparator = QString::fromUtf8(" ▶ ");
+const QString kActionTextPrefixSuffixSeparator = QStringLiteral(" | ");
 
 inline int bpmLowerBound(double bpm) {
     return static_cast<int>(std::floor((1 - kRelativeBpmRange) * bpm));

--- a/src/widget/wsearchrelatedtracksmenu.cpp
+++ b/src/widget/wsearchrelatedtracksmenu.cpp
@@ -13,8 +13,6 @@ namespace {
 // a viable upper bound for the context menu.
 constexpr double kMaxMenuToAvailableScreenWidthRatio = 0.2;
 
-constexpr int kMinMenuWidthInPixels = 100;
-
 constexpr double kRelativeBpmRange = 0.06; // +/-6 %
 
 inline int bpmLowerBound(double bpm) {
@@ -89,24 +87,20 @@ QString WSearchRelatedTracksMenu::elideActionText(
     if (elidableTextSuffix.isEmpty()) {
         return actionTextPrefix;
     }
-    const auto prefixWidthInPixels =
-            fontMetrics().boundingRect(actionTextPrefix).width();
-    const auto minWidthInPixels =
-            math_max(
-                    prefixWidthInPixels,
-                    kMinMenuWidthInPixels);
     const auto* const pScreen =
             mixxx::widgethelper::getScreen(*this);
     VERIFY_OR_DEBUG_ASSERT(pScreen) {
         // This should never fail
         return actionTextPrefix;
     }
+    const auto prefixWidthInPixels =
+            fontMetrics().boundingRect(actionTextPrefix).width();
     const auto maxWidthInPixels =
             math_max(
-                    static_cast<int>(
+                    static_cast<int>(std::ceil(
                             pScreen->availableSize().width() *
-                            kMaxMenuToAvailableScreenWidthRatio),
-                    minWidthInPixels);
+                            kMaxMenuToAvailableScreenWidthRatio)),
+                    prefixWidthInPixels);
     const auto elidedTextSuffix =
             fontMetrics().elidedText(
                     elidableTextSuffix,

--- a/src/widget/wsearchrelatedtracksmenu.h
+++ b/src/widget/wsearchrelatedtracksmenu.h
@@ -21,6 +21,10 @@ class WSearchRelatedTracksMenu : public QMenu {
   private:
     void addTriggerSearchAction(
             bool* /*in/out*/ pAddSeparatorBeforeNextAction,
-            const QString& actionText,
-            QString searchQuery);
+            QString searchQuery,
+            const QString& actionTextPrefix,
+            const QString& elidableTextSuffix = QString());
+    QString elideActionText(
+            const QString& actionTextPrefix,
+            const QString& elidableTextSuffix) const;
 };


### PR DESCRIPTION
TODO:

- [x] Rebase after #3215 has been merged

Turned out to be trickier than expected.

- Separate query field and value by a right arrow an unquote the value
- Elide query values in the middle

![Screenshot from 2020-10-29 10-49-40](https://user-images.githubusercontent.com/1474154/97552650-d14a4a00-19d4-11eb-89c2-503cf028df69.png)