### PR TITLE
Fix unused variable warning in release build

### DIFF
--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -264,6 +264,7 @@ void DlgPrefLibrary::slotRemoveDir() {
         tr("Delete Track Metadata"), QMessageBox::AcceptRole);
     QPushButton* leaveUnchangedButton = removeMsgBox.addButton(
         tr("Leave Tracks Unchanged"), QMessageBox::AcceptRole);
+    Q_UNUSED(leaveUnchangedButton); // Only used in DEBUG_ASSERT
     removeMsgBox.setDefaultButton(cancelButton);
     removeMsgBox.exec();
 


### PR DESCRIPTION
Detected while trying to prepare an RPMFusion release.

We need CI release builds to detect these issues earlier.