### PR TITLE
Fix missing connection of "Abort" button in progress dialog

### DIFF
--- a/src/util/taskmonitor.cpp
+++ b/src/util/taskmonitor.cpp
@@ -119,14 +119,14 @@ void TaskMonitor::reportTaskProgress(
 
 void TaskMonitor::abortAllTasks() {
     DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
+    const auto toBeAbortedTasks = m_taskInfos.keys();
     // Detach all monitored tasks before iterating over
-    // them to prevent any kind of side-effects. Aborting
+    // them to prevent any kind of side-effects! Aborting
     // a task may start new tasks in response.
-    const auto toBeAbortedTasks = m_taskInfos;
     m_taskInfos.clear();
     // Iterator over the detached, immutable copy of
     // the task list
-    for (auto* pTask : toBeAbortedTasks.keys()) {
+    for (auto* pTask : toBeAbortedTasks) {
         QMetaObject::invokeMethod(
                 pTask,
 #if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)

--- a/src/util/taskmonitor.cpp
+++ b/src/util/taskmonitor.cpp
@@ -123,7 +123,10 @@ void TaskMonitor::reportTaskProgress(
 }
 
 void TaskMonitor::abortAllTasks() {
-    for (auto* pTask : m_taskInfos.keys()) {
+    DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
+    const auto abortedTasks = m_taskInfos;
+    m_taskInfos.clear();
+    for (auto* pTask : abortedTasks.keys()) {
         QMetaObject::invokeMethod(
                 pTask,
 #if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
@@ -134,7 +137,6 @@ void TaskMonitor::abortAllTasks() {
 #endif
         );
     }
-    m_taskInfos.clear();
     updateProgress();
 }
 

--- a/src/util/taskmonitor.cpp
+++ b/src/util/taskmonitor.cpp
@@ -58,11 +58,6 @@ void TaskMonitor::slotReportTaskProgress(
             progressMessage);
 }
 
-void TaskMonitor::slotCanceled() {
-    DEBUG_ASSERT(m_pProgressDlg);
-    abortAllTasks();
-}
-
 void TaskMonitor::registerTask(
         Task* pTask,
         const QString& title) {
@@ -160,6 +155,15 @@ void TaskMonitor::updateProgress() {
                 static_cast<int>(kPercentageOfCompletionMax * m_taskInfos.size()));
         m_pProgressDlg->setWindowModality(Qt::ApplicationModal);
         m_pProgressDlg->setMinimumDuration(m_minimumProgressDuration.toIntegerMillis());
+        connect(m_pProgressDlg.get(),
+                &QProgressDialog::canceled,
+                this,
+                [this]() {
+                    VERIFY_OR_DEBUG_ASSERT(m_pProgressDlg) {
+                        return;
+                    }
+                    abortAllTasks();
+                });
     }
     // TODO: Display the title and optional progress message of each
     // task. Maybe also the individual progress and an option to abort

--- a/src/util/taskmonitor.h
+++ b/src/util/taskmonitor.h
@@ -79,9 +79,6 @@ class TaskMonitor
             PercentageOfCompletion estimatedPercentageOfCompletion,
             const QString& progressMessage);
 
-  private slots:
-    void slotCanceled();
-
   private:
     Task* senderTask() const;
     void updateProgress();


### PR DESCRIPTION
Looks like the connect() operation got lost along the way somehow.

Batch operations on multiple tracks in WTrackMenu are monitored and controlled by a progress dialog. But the *Abort* button from this dialog was not connected. Clicking on Abort only closed the progress dialog which was reopened again after processing the next track. As a consequence operations could not be aborted.

Minor changes:
- Use new thread affinity macros
- Safe aborting of multiple tasks to prevent side-effects