### PR TITLE
Fix asan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2008,6 +2008,7 @@ if(NOT CLANG_SANITIZERS STREQUAL "")
   endif()
   list(JOIN CLANG_SANITIZERS "," CLANG_SANITZERS_JOINED)
   target_compile_options(mixxx-lib PUBLIC -fsanitize=${CLANG_SANITZERS_JOINED})
+  target_link_options(mixxx-lib PUBLIC -fsanitize=${CLANG_SANITZERS_JOINED})
 endif()
 
 # CoreAudio MP3/AAC Decoder


### PR DESCRIPTION
Clang sanitizers need to be set on the linker as well as the compiler. Fixes asan builds