### PR TITLE
changelog: fix library focus crash #3201

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * Prevent moving a loop beyond track end #3117 lp:1799574
 * Use 6 instead of only 4 compatible musical keys (major/minor) #3205
 * Fix possible memory corruption using JACK on Linux
+* Fix possible crash when trying to refocus the tracks table while another Mixxx window has focus #3201
 
 ==== 2.2.4 2020-05-10 ====
 


### PR DESCRIPTION
~~shall I update the changelog to use the link syntax like we do for the 2.3 changelog?~~