### PR TITLE
Fix integer expressions of different signedness

### DIFF
--- a/src/effects/lv2/lv2effectprocessor.cpp
+++ b/src/effects/lv2/lv2effectprocessor.cpp
@@ -121,7 +121,7 @@ void LV2EffectProcessor::process(const ChannelHandle& inputHandle,
     }
 
     int j = 0;
-    for (unsigned int i = 0; i < bufferParameters.samplesPerBuffer(); i += 2) {
+    for (int i = 0; i < bufferParameters.samplesPerBuffer(); i += 2) {
         m_inputL[j] = pInput[i];
         m_inputR[j] = pInput[i + 1];
         j++;
@@ -130,7 +130,7 @@ void LV2EffectProcessor::process(const ChannelHandle& inputHandle,
     lilv_instance_run(pState->lilvIinstance(), bufferParameters.framesPerBuffer());
 
     j = 0;
-    for (unsigned int i = 0; i < bufferParameters.samplesPerBuffer(); i += 2) {
+    for (int i = 0; i < bufferParameters.samplesPerBuffer(); i += 2) {
         pOutput[i] = m_outputL[j];
         pOutput[i + 1] = m_outputR[j];
         j++;


### PR DESCRIPTION
This patch fixes the following warning:

../src/effects/lv2/lv2effectprocessor.cpp: In member function 'virtual void LV2EffectProcessor::process(const ChannelHandle&, const ChannelHandle&, const CSAMPLE*, CSAMPLE*, const mixxx::EngineParameters&, EffectEnableState, const GroupFeatureState&)':
../src/effects/lv2/lv2effectprocessor.cpp:124:32: error: comparison of integer expressions of different signedness: 'unsigned int' and 'SINT' {aka 'int'} [-Werror=sign-compare]
  124 |     for (unsigned int i = 0; i < bufferParameters.samplesPerBuffer(); i += 2) {
      |                              ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/effects/lv2/lv2effectprocessor.cpp:133:32: error: comparison of integer expressions of different signedness: 'unsigned int' and 'SINT' {aka 'int'} [-Werror=sign-compare]
  133 |     for (unsigned int i = 0; i < bufferParameters.samplesPerBuffer(); i += 2) {
      |                              ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors

As -Werror and -Werror=format-security are used during compilation theses are threated as errors.
Please notes that there is another occurence of this issue as:

But only -Werror=format-security is used, so it's not an error...

Signed-off-by: Nicolas Chauvet <kwizart@gmail.com>