### PR TITLE
Preferences > Interface: restore skin size warning

### DIFF
--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -64,12 +64,13 @@ DlgPrefInterface::DlgPrefInterface(QWidget * parent, MixxxMainWindow * mixxx,
     ComboBoxLocale->model()->sort(0); // Sort languages list
     ComboBoxLocale->insertItem(0, "System", ""); // System default locale - insert at the top
 
-    //
     // Skin configurations
-    //
-    QString warningString = "<img src=\":/images/preferences/ic_preferences_warning.png\") width=16 height=16 />"
-        + tr("The minimum size of the selected skin is bigger than your screen resolution.");
-    warningLabel->setText(warningString);
+    QString sizeWarningString =
+            "<img src=\":/images/preferences/ic_preferences_warning.svg\") "
+            "width=16 height=16 />   " +
+            tr("The minimum size of the selected skin is bigger than your "
+               "screen resolution.");
+    warningLabel->setText(sizeWarningString);
 
     ComboBoxSkinconf->clear();
     // align left edge of preview image and skin description with comboboxes
@@ -103,7 +104,7 @@ DlgPrefInterface::DlgPrefInterface(QWidget * parent, MixxxMainWindow * mixxx,
             // schemes must be updated here to populate the drop-down box and set m_colorScheme
             slotUpdateSchemes();
             skinPreviewLabel->setPixmap(m_pSkinLoader->getSkinPreview(m_skin, m_colorScheme));
-            if (size_ok) {
+            if (checkSkinResolution(configuredSkinPath)) {
                 warningLabel->hide();
             } else {
                 warningLabel->show();
@@ -313,8 +314,13 @@ void DlgPrefInterface::slotSetSkin(int) {
     if (newSkin != m_skin) {
         m_skin = newSkin;
         m_bRebootMixxxView = newSkin != m_skinOnUpdate;
-        checkSkinResolution(ComboBoxSkinconf->currentText())
-            ? warningLabel->hide() : warningLabel->show();
+
+        if (checkSkinResolution(m_pSkinLoader->getSkinPath(m_skin))) {
+            warningLabel->hide();
+        } else {
+            warningLabel->show();
+        }
+
         slotUpdateSchemes();
         slotSetSkinDescription(m_skin);
     }

--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -88,15 +88,9 @@ DlgPrefInterface::DlgPrefInterface(QWidget * parent, MixxxMainWindow * mixxx,
     }
 
     QString configuredSkinPath = m_pSkinLoader->getConfiguredSkinPath();
-    QIcon sizeWarningIcon(":/images/preferences/ic_preferences_warning.png");
     int index = 0;
     for (const QFileInfo& skinInfo : skins) {
-        bool size_ok = checkSkinResolution(skinInfo.absoluteFilePath());
-        if (size_ok) {
-            ComboBoxSkinconf->insertItem(index, skinInfo.fileName());
-        } else {
-            ComboBoxSkinconf->insertItem(index, sizeWarningIcon, skinInfo.fileName());
-        }
+        ComboBoxSkinconf->insertItem(index, skinInfo.fileName());
 
         if (skinInfo.absoluteFilePath() == configuredSkinPath) {
             m_skin = skinInfo.fileName();

--- a/src/preferences/dialog/dlgprefinterfacedlg.ui
+++ b/src/preferences/dialog/dlgprefinterfacedlg.ui
@@ -32,6 +32,7 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
+
       <item row="0" column="0">
        <widget class="QLabel" name="lableSkin_2">
         <property name="enabled">
@@ -127,15 +128,7 @@
        </widget>
       </item>
 
-      <item row="6" column="1">
-       <widget class="QLabel" name="skinPreviewLabel">
-        <property name="text">
-         <string notr="true">skin preview screenshot goes here</string>
-        </property>
-       </widget>
-      </item>
-
-      <item row="7" column="1">
+      <item row="6" column="1" colspan="2">
        <widget class="QLabel" name="warningLabel">
         <property name="text">
          <string/>
@@ -145,6 +138,15 @@
         </property>
        </widget>
       </item>
+
+      <item row="7" column="1">
+       <widget class="QLabel" name="skinPreviewLabel">
+        <property name="text">
+         <string notr="true">skin preview screenshot goes here</string>
+        </property>
+       </widget>
+      </item>
+
       <item row="8" column="0">
        <spacer name="verticalSpacer1">
         <property name="orientation">
@@ -158,6 +160,7 @@
         </property>
        </spacer>
       </item>
+
       <item row="9" column="0">
        <widget class="QLabel" name="textLabelLocale">
         <property name="text">


### PR DESCRIPTION
Also I moved the warning label above the skin preview.

![image](https://user-images.githubusercontent.com/5934199/97763973-77996b00-1b0d-11eb-96cb-17d5c22358e3.png)

Btw: do we need both the warning icon in the skin list AND the label below?