### PR TITLE
AutoDJ: make 'enable' shortcut work after startup 

### DIFF
--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -123,6 +123,7 @@ AutoDJProcessor::AutoDJProcessor(
     m_pAutoDJTableModel = new PlaylistTableModel(this, pTrackCollectionManager,
                                                  "mixxx.db.model.autodj");
     m_pAutoDJTableModel->setTableModel(iAutoDJPlaylistId);
+    m_pAutoDJTableModel->select();
 
     m_pShufflePlaylist = new ControlPushButton(
             ConfigKey("[AutoDJ]", "shuffle_playlist"));
@@ -829,7 +830,6 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
 
 TrackPointer AutoDJProcessor::getNextTrackFromQueue() {
     // Get the track at the top of the playlist.
-    m_pAutoDJTableModel->select();
     bool randomQueueEnabled = m_pConfig->getValue<bool>(
             ConfigKey("[Auto DJ]", "EnableRandomQueue"));
     int minAutoDJCrateTracks = m_pConfig->getValueString(

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -829,6 +829,7 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
 
 TrackPointer AutoDJProcessor::getNextTrackFromQueue() {
     // Get the track at the top of the playlist.
+    m_pAutoDJTableModel->select();
     bool randomQueueEnabled = m_pConfig->getValue<bool>(
             ConfigKey("[Auto DJ]", "EnableRandomQueue"));
     int minAutoDJCrateTracks = m_pConfig->getValueString(

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -179,6 +179,7 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
     m_pSettingsManager = std::make_unique<SettingsManager>(args.getSettingsPath());
 
     initializeKeyboard();
+    installEventFilter(m_pKeyboard);
 
     // Menubar depends on translations.
     mixxx::Translations::initializeTranslations(


### PR DESCRIPTION
I noticed two issue I need help with.
and I rather discuss them here to work around launchpad and ease code references.

**1)** before the AutoDJ hotkey Shift+F12 would toggle [AutoDJ],enable after startup any library feature must have had focus (Ctrl+F to focus the searchbar is sufficient, just ANY trackmodel needs to be selected?)

**2)** with 'Allow random track addition' disabled the above wouldn't work either:
- add some tracks to the AutoDJ queue, close Mixxx
- start Mixxx
- Ctrl+F to focus the searchbar
- press Shift + F12 to start AutoDJ
= log "Debug[Main] Queue is empty now"
from https://github.com/mixxxdj/mixxx/blob/2.3/src/library/autodj/autodjprocessor.cpp#L403
because getNextTrackFromQueue() returns 0 even though the queue holds enough tracks.
- click AutoDJ feature
- press Shift + F12 to start AutoDJ
= AutoDJ starts

**2** is solved with change added here: m_pAutoDJTableModel->select(); in autodjprocessor.
Though this is just a hack, I have no idea about the implications.

For **1** I have no idea..