### PR TITLE
Beatsize spinbox: also reject focusIn from Shift+Tab

### DIFF
--- a/src/widget/wbeatspinbox.cpp
+++ b/src/widget/wbeatspinbox.cpp
@@ -23,9 +23,11 @@ WBeatSpinBox::WBeatSpinBox(QWidget* parent,
     setMinimum(minimum);
     setMaximum(maximum);
     setKeyboardTracking(false);
-    // Prevent this widget from getting focused with tab
+    // Prevent this widget from getting focused with Tab
     // to avoid interfering with using the library via keyboard.
     setFocusPolicy(Qt::ClickFocus);
+    // This is necessary to also ignore Shift+Tab (Qt::BacktabFocusReason).
+    lineEdit()->setFocusPolicy(Qt::ClickFocus);
 
     setValue(m_valueControl.get());
     connect(this, SIGNAL(valueChanged(double)),


### PR DESCRIPTION
Like `Tab` `Shift+Tab` is now also restricted to focus the searchbar, clear search button, sidebar or the tracks table only

for testing either disable debug_assert_fatal or pick 267a7d6557c754db174069674a0dd49545ed67d2, see #3240 

