### PR TITLE
CoverInfo: Fix missing conversion from native separators

### DIFF
--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -792,12 +792,7 @@ CoverInfo BaseSqlTableModel::getCoverInfo(const QModelIndex& index) const {
                                          COLUMN_LIBRARYTABLE_COVERART_LOCATION))
                     .data()
                     .toString();
-    coverInfo.trackLocation =
-            index.sibling(index.row(),
-                         fieldIndex(ColumnCache::
-                                         COLUMN_LIBRARYTABLE_NATIVELOCATION))
-                    .data()
-                    .toString();
+    coverInfo.trackLocation = getTrackLocation(index);
     return coverInfo;
 }
 

--- a/src/library/coverartdelegate.cpp
+++ b/src/library/coverartdelegate.cpp
@@ -111,6 +111,9 @@ void CoverArtDelegate::paintItem(
     paintItemBackground(painter, option, index);
 
     CoverInfo coverInfo = m_pTrackModel->getCoverInfo(index);
+    VERIFY_OR_DEBUG_ASSERT(m_pTrackModel) {
+        return;
+    }
     if (CoverImageUtils::isValidHash(coverInfo.hash)) {
         VERIFY_OR_DEBUG_ASSERT(m_pCache) {
             return;


### PR DESCRIPTION
Unfortunately, I missed one issue during the review of #3132.