### PR TITLE
optimize use of compiler caches on AppVeyor Ubuntu

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -98,8 +98,12 @@ for:
       xsltproc
 
   before_build:
-     # Limit cache size to 100 MB
-    - ccache -M 100M
+    # Limit cache size to 4 GB.
+    # AppVeyor allows 1 GB cache for the free plan but stores it compressed.
+    # Compression ratio is ~80%, so we could have ~10 GB uncompressed total cache.
+    # Split cache in half with Ubuntu ccache and underestimate compression ratio a little to
+    # avoid going over the limit.
+    - ccache -M 4G
     - ccache -s
 
   build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -100,7 +100,6 @@ for:
   before_build:
      # Limit cache size to 100 MB
     - ccache -M 100M
-    - ccache -c
     - ccache -s
 
   build_script:


### PR DESCRIPTION
clcache has not been used on Windows:
```
[00:02:02] clcache -s
[00:02:03] clcache statistics:
[00:02:03]   current cache dir         : Disk cache at C:\Users\appveyor\clcache
[00:02:03]   cache size                : 92,836,139 bytes
[00:02:03]   maximum cache size        : 100,000,000 bytes
[00:02:03]   cache entries             : 19
[00:02:03]   cache hits                : 0
[00:02:03]   cache misses
[00:02:03]     total                      : 24306
[00:02:03]     evicted                    : 0
[00:02:03]     header changed             : 0
[00:02:03]     source changed             : 24306
[00:02:03]   passed to real compiler
[00:02:03]     called w/ invalid argument : 0
[00:02:03]     called for preprocessing   : 60
[00:02:03]     called for linking         : 617
[00:02:03]     called for external debug  : 210
[00:02:03]     called w/o source          : 0
[00:02:03]     called w/ multiple sources : 0
[00:02:03]     called w/ PCH              : 0
```

ccache has been used for Ubuntu but builds are still taking 35 minutes...
```
[00:01:46] cache directory                     /home/appveyor/.ccache
[00:01:46] primary config                      /home/appveyor/.ccache/ccache.conf
[00:01:46] secondary config      (readonly)    /etc/ccache.conf
[00:01:46] stats updated                       Mon Nov  2 04:52:26 2020
[00:01:46] cache hit (direct)                 70568
[00:01:46] cache hit (preprocessed)           17846
[00:01:46] cache miss                        111718
[00:01:46] cache hit rate                     44.18 %
[00:01:46] called for link                    10680
[00:01:46] cleanups performed                  7054
[00:01:46] files in cache                      1794
[00:01:46] cache size                          86.1 MB
[00:01:46] max cache size                     100.0 MB
```