### PR TITLE
Delete obsolete doCreateCoverArtDelegate()

### DIFF
--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -6,7 +6,6 @@
 #include <QtDebug>
 #include <algorithm>
 
-#include "library/coverartdelegate.h"
 #include "library/dao/trackschema.h"
 #include "library/queryutil.h"
 #include "library/starrating.h"
@@ -816,11 +815,6 @@ void BaseSqlTableModel::tracksChanged(QSet<TrackId> trackIds) {
             emit dataChanged(topLeft, bottomRight);
         }
     }
-}
-
-CoverArtDelegate* BaseSqlTableModel::doCreateCoverArtDelegate(
-        QTableView* pTableView) const {
-    return new CoverArtDelegate(pTableView);
 }
 
 void BaseSqlTableModel::hideTracks(const QModelIndexList& indices) {

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -105,9 +105,6 @@ class BaseSqlTableModel : public BaseTrackTableModel {
     void tracksChanged(QSet<TrackId> trackIds);
 
   private:
-    CoverArtDelegate* doCreateCoverArtDelegate(
-            QTableView* pTableView) const final;
-
     void setTrackValueForColumn(
             TrackPointer pTrack, int column, QVariant value);
 

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -380,7 +380,7 @@ QAbstractItemDelegate* BaseTrackTableModel::delegateForColumn(
         return new ColorDelegate(pTableView);
     } else if (index == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COVERART)) {
         auto* pCoverArtDelegate =
-                doCreateCoverArtDelegate(pTableView);
+                new CoverArtDelegate(pTableView);
         // WLibraryTableView -> CoverArtDelegate
         connect(pTableView,
                 &WLibraryTableView::onlyCachedCoverArt,

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -9,7 +9,6 @@
 #include "library/trackmodel.h"
 #include "track/track_decl.h"
 
-class CoverArtDelegate;
 class TrackCollectionManager;
 
 class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
@@ -188,8 +187,6 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     // the internal database.
     virtual TrackId doGetTrackId(
             const TrackPointer& pTrack) const;
-    virtual CoverArtDelegate* doCreateCoverArtDelegate(
-            QTableView* pTableView) const = 0;
 
     QVariant composeCoverArtToolTipHtml(
             const QModelIndex& index) const;


### PR DESCRIPTION
Polymorphism no longer needed after integrated into `TrackModel` in #3132.