### PR TITLE
Coverart popup fixes

### DIFF
--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -47,11 +47,11 @@ DlgCoverArtFullSize::DlgCoverArtFullSize(QWidget* parent, BaseTrackPlayer* pPlay
 }
 
 void DlgCoverArtFullSize::closeEvent(QCloseEvent* event) {
-    hide();
-    slotLoadTrack(nullptr);
     if (parentWidget()) {
         // Since the widget has a parent, this instance will be reused again.
         // We need to prevent qt from destroying it's children
+        hide();
+        slotLoadTrack(nullptr);
         event->ignore();
     } else {
         QDialog::closeEvent(event);
@@ -163,13 +163,13 @@ void DlgCoverArtFullSize::slotCoverFound(
     // whitespace appearing on the side when resizing a window whose
     // borders touch the edges of the screen.
     QSize dialogSize = m_pixmap.size();
-    QWidget* parent = parentWidget();
-    VERIFY_OR_DEBUG_ASSERT(parent) {
+    QWidget* centerOverWidget = parentWidget();
+    VERIFY_OR_DEBUG_ASSERT(centerOverWidget) {
         qWarning() << "DlgCoverArtFullSize does not have a parent.";
-        parent = this;
+        centerOverWidget = this;
     }
 
-    const QScreen* const pScreen = mixxx::widgethelper::getScreen(*parent);
+    const QScreen* const pScreen = mixxx::widgethelper::getScreen(*centerOverWidget);
     QRect screenGeometry;
     VERIFY_OR_DEBUG_ASSERT(pScreen) {
         qWarning() << "Assuming screen size of 800x600px.";

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -47,11 +47,15 @@ DlgCoverArtFullSize::DlgCoverArtFullSize(QWidget* parent, BaseTrackPlayer* pPlay
 }
 
 void DlgCoverArtFullSize::closeEvent(QCloseEvent* event) {
-    // Since the same instance if opened again by the same parent widget
-    // we need to prevent qt from destroying it's children
     hide();
     slotLoadTrack(nullptr);
-    event->ignore();
+    if (parentWidget()) {
+        // If the widget has a parent. Since the same instance will be reused again.
+        // we need to prevent qt from destroying it's children
+        event->ignore();
+    } else {
+        QDialog::closeEvent(event);
+    }
 }
 
 void DlgCoverArtFullSize::init(TrackPointer pTrack) {

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -46,6 +46,12 @@ DlgCoverArtFullSize::DlgCoverArtFullSize(QWidget* parent, BaseTrackPlayer* pPlay
     setupUi(this);
 }
 
+void DlgCoverArtFullSize::closeEvent(QCloseEvent* event) {
+    // prevent the window from being destroyed
+    hide();
+    event->ignore();
+}
+
 void DlgCoverArtFullSize::init(TrackPointer pTrack) {
     if (!pTrack) {
         return;

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -62,6 +62,11 @@ void DlgCoverArtFullSize::init(TrackPointer pTrack) {
     if (!pTrack) {
         return;
     }
+    // The real size will be calculated later.
+    // If you zoom in so the window is larger then the desktop, close the
+    // window and reopen, the window will not be resized correctly
+    // by slotCoverFound. Setting a small fixed size before show fixes this
+    resize(100, 100);
     show();
     raise();
     activateWindow();

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -50,8 +50,8 @@ void DlgCoverArtFullSize::closeEvent(QCloseEvent* event) {
     hide();
     slotLoadTrack(nullptr);
     if (parentWidget()) {
-        // If the widget has a parent. Since the same instance will be reused again.
-        // we need to prevent qt from destroying it's children
+        // Since the widget has a parent, this instance will be reused again.
+        // We need to prevent qt from destroying it's children
         event->ignore();
     } else {
         QDialog::closeEvent(event);

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -47,8 +47,10 @@ DlgCoverArtFullSize::DlgCoverArtFullSize(QWidget* parent, BaseTrackPlayer* pPlay
 }
 
 void DlgCoverArtFullSize::closeEvent(QCloseEvent* event) {
-    // prevent the window from being destroyed
+    // Since the same instance if opened again by the same parent widget
+    // we need to prevent qt from destroying it's children
     hide();
+    slotLoadTrack(nullptr);
     event->ignore();
 }
 
@@ -121,6 +123,8 @@ void DlgCoverArtFullSize::slotLoadTrack(TrackPointer pTrack) {
 void DlgCoverArtFullSize::slotTrackCoverArtUpdated() {
     if (m_pLoadedTrack) {
         CoverArtCache::requestTrackCover(this, m_pLoadedTrack);
+    } else {
+        coverArt->setPixmap(QPixmap());
     }
 }
 
@@ -157,20 +161,20 @@ void DlgCoverArtFullSize::slotCoverFound(
     }
 
     const QScreen* const pScreen = mixxx::widgethelper::getScreen(*parent);
-    QRect availableScreenGeometry;
+    QRect screenGeometry;
     VERIFY_OR_DEBUG_ASSERT(pScreen) {
         qWarning() << "Assuming screen size of 800x600px.";
-        availableScreenGeometry = QRect(0, 0, 800, 600);
+        screenGeometry = QRect(0, 0, 800, 600);
     }
     else {
-        availableScreenGeometry = pScreen->geometry();
+        screenGeometry = pScreen->geometry();
     }
 
-    const QSize availableScreenSpace = availableScreenGeometry.size() * 0.9;
+    const QSize availableScreenSpace = screenGeometry.size() * 0.9;
     if (dialogSize.height() > availableScreenSpace.height()) {
-        dialogSize.scale(dialogSize.width(), availableScreenSpace.height(), Qt::KeepAspectRatio);
-    } else if (dialogSize.width() > availableScreenSpace.width()) {
-        dialogSize.scale(availableScreenSpace.width(), dialogSize.height(), Qt::KeepAspectRatio);
+        dialogSize.scale(dialogSize.width(), screenGeometry.height(), Qt::KeepAspectRatio);
+    } else if (dialogSize.width() > screenGeometry.width()) {
+        dialogSize.scale(screenGeometry.width(), dialogSize.height(), Qt::KeepAspectRatio);
     }
     QPixmap resizedPixmap = m_pixmap.scaled(size() * getDevicePixelRatioF(this),
             Qt::KeepAspectRatio,
@@ -183,7 +187,7 @@ void DlgCoverArtFullSize::slotCoverFound(
             Qt::LeftToRight,
             Qt::AlignCenter,
             dialogSize,
-            availableScreenGeometry));
+            screenGeometry));
 }
 
 // slots to handle signals from the context menu

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -150,15 +150,20 @@ void DlgCoverArtFullSize::slotCoverFound(
     // whitespace appearing on the side when resizing a window whose
     // borders touch the edges of the screen.
     QSize dialogSize = m_pixmap.size();
+    QWidget* parent = parentWidget();
+    VERIFY_OR_DEBUG_ASSERT(parent) {
+        qWarning() << "DlgCoverArtFullSize does not have a parent.";
+        parent = this;
+    }
 
-    const QScreen* const pScreen = mixxx::widgethelper::getScreen(*this);
+    const QScreen* const pScreen = mixxx::widgethelper::getScreen(*parent);
     QRect availableScreenGeometry;
     VERIFY_OR_DEBUG_ASSERT(pScreen) {
         qWarning() << "Assuming screen size of 800x600px.";
         availableScreenGeometry = QRect(0, 0, 800, 600);
     }
     else {
-        availableScreenGeometry = pScreen->availableGeometry();
+        availableScreenGeometry = pScreen->geometry();
     }
 
     const QSize availableScreenSpace = availableScreenGeometry.size() * 0.9;

--- a/src/library/dlgcoverartfullsize.h
+++ b/src/library/dlgcoverartfullsize.h
@@ -25,6 +25,7 @@ class DlgCoverArtFullSize
     void mouseMoveEvent(QMouseEvent* ) override;
     void resizeEvent(QResizeEvent* event) override;
     void wheelEvent(QWheelEvent* event) override;
+    void closeEvent(QCloseEvent* event) override;
 
   public slots:
     void slotLoadTrack(TrackPointer);


### PR DESCRIPTION
Small fixes to the coverart window popup.

* If the window is closed from the window manager, it's internal state gets destroyed.
Reopening the window only shows a empty window and error codes:

`warning [Main] QXcbConnection: XCB error: 8 (BadMatch), sequence: 32110, resource id: 68218659, major code: 130 (Unknown), minor code: 3
`

* Place the window in the center of the mixxx window, not on the center of the first screen.