### PR TITLE
remove date and time from binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1965,19 +1965,6 @@ if(BATTERY)
   target_compile_definitions(mixxx-lib PUBLIC __BATTERY__)
 endif()
 
-
-# Build Time
-option(BUILDTIME "Use __DATE__ and __TIME__" ON)
-if(NOT BUILDTIME)
-  # Distributions like openSUSE use tools (e. g. build-compare) to detect
-  # whether a built binary differs from a former build to avoid unneeded
-  # publishing of packages.
-  # If __DATE__ and __TIME__ are used the built binary differs always but
-  # the tools cannot detect the root and publish a new package although
-  # the only change is caused by __DATE__ and __TIME__.
-  target_compile_definitions(mixxx-lib PUBLIC DISABLE_BUILDTIME)
-endif()
-
 # Clang Color Diagnostics
 option(CLANG_COLORDIAG "Clang color diagnostics" OFF)
 if(CLANG_COLORDIAG)

--- a/build/features.py
+++ b/build/features.py
@@ -545,33 +545,6 @@ class AsmLib(Feature):
             build.env.Append(CCFLAGS='/Oi-')
             build.env.Prepend(LIBS='libacof%so' % build.bitwidth)
 
-
-class BuildTime(Feature):
-    def description(self):
-        return "Use __DATE__ and __TIME__"
-
-    def enabled(self, build):
-        build.flags['buildtime'] = util.get_flags(build.env, 'buildtime', 1)
-        if int(build.flags['buildtime']):
-            return True
-        return False
-
-    def add_options(self, build, vars):
-        vars.Add(
-            'buildtime', 'Set to 0 to disable build time (__DATE__ and __TIME__) usage.', 1)
-
-    def configure(self, build, conf):
-        # Distributions like openSUSE use tools (e. g. build-compare) to detect
-        # whether a built binary differs from a former build to avoid unneeded
-        # publishing of packages.
-        # If __DATE__ and __TIME__ are used the built binary differs always but
-        # the tools cannot detect the root and publish a new package although
-        # the only change is caused by __DATE__ and __TIME__.
-        # So let distributions disable __DATE__ and __TIME__ via buildtime=0.
-        if not self.enabled(build):
-            build.env.Append(CPPDEFINES='DISABLE_BUILDTIME')
-
-
 class Verbose(Feature):
     def description(self):
         return "Verbose compilation output"

--- a/lib/mp3guessenc-0.27.4/mp3guessenc.c
+++ b/lib/mp3guessenc-0.27.4/mp3guessenc.c
@@ -2676,7 +2676,6 @@ void print_version(char verbose)
 #endif
 
         printf("\nLarge file support: %s\n",(sizeof(off_t)==SIZEOF_OFF64_T)?"yes":"no");
-        printf("Executable built on %s.", __DATE__);
     }
     printf("\n");
 }

--- a/src/util/version.cpp
+++ b/src/util/version.cpp
@@ -144,9 +144,6 @@ void Version::logBuildDetails() {
         buildInfo.append(
             QString("git r%2").arg(buildRevision));
     }
-#ifndef DISABLE_BUILDTIME // buildtime=1, on by default
-    buildInfo.append("built on: " __DATE__ " @ " __TIME__);
-#endif
     if (!buildFlags.isEmpty()) {
         buildInfo.append(QString("flags: %1").arg(buildFlags.trimmed()));
     }


### PR DESCRIPTION
These are a source of nondeterminism in the build. The date and time
were printed in the log, but this information isn't so helpful. What is
helpful there is the Git commit hash.

This does not make the build reproducible, but it is one step towards
that.