### PR TITLE
CueControl: Remove redundant setting of m_pHotcueStatus

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -2399,7 +2399,6 @@ void HotcueControl::slotHotcueClear(double v) {
 }
 
 void HotcueControl::slotHotcuePositionChanged(double newPosition) {
-    m_pHotcueStatus->forceSet(newPosition == Cue::kNoPosition ? 0.0 : 1.0);
     emit hotcuePositionChanged(this, newPosition);
 }
 


### PR DESCRIPTION
If the new position equals `Cue::kNoPosition`, `detachCue()` and
`pControl->resetCue()` will be called in the event handler and the
status will be set to "Empty" anyway.