### PR TITLE
fix cue preview 

### DIFF
--- a/src/engine/cuecontrol.cpp
+++ b/src/engine/cuecontrol.cpp
@@ -854,14 +854,13 @@ void CueControl::playStutter(double v) {
     }
 }
 
-bool CueControl::updateIndicatorsAndModifyPlay(bool newPlay, bool playPossible) {
+bool CueControl::updateIndicatorsAndModifyPlay(bool newPlay, bool oldPlay, bool playPossible) {
     //qDebug() << "updateIndicatorsAndModifyPlay" << newPlay << playPossible
     //        << m_iCurrentlyPreviewingHotcues << m_bPreviewing;
     QMutexLocker lock(&m_mutex);
     double cueMode = m_pCueMode->get();
     if ((cueMode == CUE_MODE_DENON || cueMode == CUE_MODE_NUMARK) &&
-        newPlay && playPossible &&
-        !m_pPlay->toBool() &&
+        newPlay && !oldPlay && playPossible &&
         !m_bypassCueSetByPlay) {
         // in Denon mode each play from pause moves the cue point
         // if not previewing
@@ -873,7 +872,7 @@ bool CueControl::updateIndicatorsAndModifyPlay(bool newPlay, bool playPossible) 
     // (play = 0.0) is used for latching play.
     bool previewing = false;
     if (m_bPreviewing || m_iCurrentlyPreviewingHotcues) {
-        if (!newPlay) {
+        if (!newPlay && oldPlay) {
             // play latch request: stop previewing and go into normal play mode.
             m_bPreviewing = false;
             m_iCurrentlyPreviewingHotcues = 0;

--- a/src/engine/cuecontrol.h
+++ b/src/engine/cuecontrol.h
@@ -97,7 +97,7 @@ class CueControl : public EngineControl {
     ~CueControl() override;
 
     void hintReader(HintVector* pHintList) override;
-    bool updateIndicatorsAndModifyPlay(bool newPlay, bool playPossible);
+    bool updateIndicatorsAndModifyPlay(bool newPlay, bool oldPlay, bool playPossible);
     void updateIndicators();
     void resetIndicators();
     bool isPlayingByPlayButton();

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -616,7 +616,7 @@ void EngineBuffer::doSeekPlayPos(double new_playpos, enum SeekRequest seekType) 
     queueNewPlaypos(new_playpos, seekType);
 }
 
-bool EngineBuffer::updateIndicatorsAndModifyPlay(bool newPlay) {
+bool EngineBuffer::updateIndicatorsAndModifyPlay(bool newPlay, bool oldPlay) {
     // If no track is currently loaded, turn play off. If a track is loading
     // allow the set since it might apply to a track we are loading due to the
     // asynchrony.
@@ -629,12 +629,12 @@ bool EngineBuffer::updateIndicatorsAndModifyPlay(bool newPlay) {
         playPossible = false;
     }
 
-    return m_pCueControl->updateIndicatorsAndModifyPlay(newPlay, playPossible);
+    return m_pCueControl->updateIndicatorsAndModifyPlay(newPlay, oldPlay, playPossible);
 }
 
 void EngineBuffer::verifyPlay() {
     bool play = m_playButton->toBool();
-    bool verifiedPlay = updateIndicatorsAndModifyPlay(play);
+    bool verifiedPlay = updateIndicatorsAndModifyPlay(play, play);
     if (play != verifiedPlay) {
         m_playButton->setAndConfirm(verifiedPlay ? 1.0 : 0.0);
     }
@@ -642,7 +642,7 @@ void EngineBuffer::verifyPlay() {
 
 void EngineBuffer::slotControlPlayRequest(double v) {
     bool oldPlay = m_playButton->toBool();
-    bool verifiedPlay = updateIndicatorsAndModifyPlay(v > 0.0);
+    bool verifiedPlay = updateIndicatorsAndModifyPlay(v > 0.0, oldPlay);
 
     if (!oldPlay && verifiedPlay) {
         if (m_pQuantize->toBool()

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -233,7 +233,7 @@ class EngineBuffer : public EngineObject {
     void processSyncRequests();
     void processSeek(bool paused);
 
-    bool updateIndicatorsAndModifyPlay(bool newPlay);
+    bool updateIndicatorsAndModifyPlay(bool newPlay, bool oldPlay);
     void verifyPlay();
     void notifyTrackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack);
     void processTrackLocked(CSAMPLE* pOutput, const int iBufferSize, int sample_rate);


### PR DESCRIPTION
Cue preview can latch undesired, due to a race condition. 
This is fixed here (lhttps://bugs.launchpad.net/mixxx/+bug/1903002)