### PR TITLE
Track: Fix beats/cue import DEBUG_ASSERT

### DIFF
--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -924,14 +924,15 @@ Track::ImportStatus Track::importBeats(
     }
     DEBUG_ASSERT(!m_pBeatsImporterPending);
     m_pBeatsImporterPending = pBeatsImporter;
-    if (m_streamInfo) {
+    if (m_pBeatsImporterPending->isEmpty()) {
+        // Just return the current import status without clearing any
+        // existing cue points.
+        m_pBeatsImporterPending.reset();
+        return ImportStatus::Complete;
+    } else if (m_streamInfo) {
         // Replace existing cue points with imported cue
         // points immediately
         importPendingBeatsMarkDirtyAndUnlock(&lock);
-        return ImportStatus::Complete;
-    } else if (m_pBeatsImporterPending->isEmpty()) {
-        // Just return the current import status without clearing any
-        // existing cue points.
         return ImportStatus::Complete;
     } else {
         kLogger.debug()
@@ -998,14 +999,15 @@ Track::ImportStatus Track::importCueInfos(
     }
     DEBUG_ASSERT(!m_pCueInfoImporterPending);
     m_pCueInfoImporterPending = pCueInfoImporter;
-    if (m_streamInfo) {
+    if (m_pCueInfoImporterPending->isEmpty()) {
+        // Just return the current import status without clearing any
+        // existing cue points.
+        m_pCueInfoImporterPending.reset();
+        return ImportStatus::Complete;
+    } else if (m_streamInfo) {
         // Replace existing cue points with imported cue
         // points immediately
         importPendingCueInfosMarkDirtyAndUnlock(&lock);
-        return ImportStatus::Complete;
-    } else if (m_pCueInfoImporterPending->isEmpty()) {
-        // Just return the current import status without clearing any
-        // existing cue points.
         return ImportStatus::Complete;
     } else {
         kLogger.debug()


### PR DESCRIPTION
If the Stream Info is already available but the BeatsImporter/CueInfoImporter is empty, this can trigger a debug assertion.

1. Load a file with the "Serato BeatGrid" tag that doesn't contain beatgrid data onto a deck.
2. Right click on Deck --> Metadata --> Import from File Tags

This leads to the following debug assertion:

   DEBUG ASSERT: "!m_pBeatsImporterPending->isEmpty()" in function bool Track::importPendingBeatsWhileLocked() at /home/jan/Projects/mixxx/src/track/track.cpp:959

This commit makes sure that the check if the importer is empty happens
*before* attempting to import data even if the steam info is already
available.

Resolves lp1903307 (https://bugs.launchpad.net/mixxx/+bug/1903307).