### PR TITLE
lp1903462: PortAudio: Map host API index to type id

### DIFF
--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -75,16 +75,15 @@ const QRegularExpression kAlsaHwDeviceRegex("(.*) \\((plug)?(hw:(\\d)+(,(\\d)+))
 
 } // anonymous namespace
 
-
-
 SoundDevicePortAudio::SoundDevicePortAudio(UserSettingsPointer config,
-                                           SoundManager* sm,
-                                           const PaDeviceInfo* deviceInfo,
-                                           unsigned int devIndex,
-                                           QHash<PaHostApiIndex, PaHostApiTypeId> apiIndexToTypeId)
+        SoundManager* sm,
+        const PaDeviceInfo* deviceInfo,
+        PaHostApiTypeId deviceTypeId,
+        unsigned int devIndex)
         : SoundDevice(config, sm),
           m_pStream(NULL),
           m_deviceInfo(deviceInfo),
+          m_deviceTypeId(deviceTypeId),
           m_outputFifo(NULL),
           m_inputFifo(NULL),
           m_outputDrift(false),
@@ -97,7 +96,7 @@ SoundDevicePortAudio::SoundDevicePortAudio(UserSettingsPointer config,
     // Setting parent class members:
     m_hostAPI = Pa_GetHostApiInfo(deviceInfo->hostApi)->name;
     m_dSampleRate = deviceInfo->defaultSampleRate;
-    if (apiIndexToTypeId.value(deviceInfo->hostApi) == paALSA) {
+    if (m_deviceTypeId == paALSA) {
         // PortAudio gives the device name including the ALSA hw device. The
         // ALSA hw device is an only somewhat reliable identifier; it may change
         // when an audio interface is unplugged or Linux is restarted. Separating
@@ -196,7 +195,7 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
     // in stereo and only take the first channel.
     // TODO(rryan): Remove once PortAudio has a solution built in (and
     // released).
-    if (m_deviceInfo->hostApi == paALSA) {
+    if (m_deviceTypeId == paALSA) {
         // Only engage workaround if the device has enough input and output
         // channels.
         if (m_deviceInfo->maxInputChannels >= 2 &&
@@ -208,7 +207,6 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
             m_outputParams.channelCount = 2;
         }
     }
-
 
     // Sample rate
     if (m_dSampleRate <= 0) {
@@ -323,7 +321,8 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
 
 
 #ifdef __LINUX__
-    if (m_deviceInfo->hostApi == paALSA) {
+    if (m_deviceTypeId == paALSA) {
+        qInfo() << "Enabling ALSA real-time scheduling";
         PaAlsa_EnableRealtimeScheduling(pStream, 1);
     }
 #endif

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -2,7 +2,6 @@
 
 
 #include <portaudio.h>
-#include <QHash>
 #include <QString>
 
 #include "soundio/sounddevice.h"
@@ -15,8 +14,10 @@ class ControlProxy;
 class SoundDevicePortAudio : public SoundDevice {
   public:
     SoundDevicePortAudio(UserSettingsPointer config,
-                         SoundManager* sm, const PaDeviceInfo* deviceInfo,
-                         unsigned int devIndex, QHash<PaHostApiIndex, PaHostApiTypeId> apiIndexToTypeId);
+            SoundManager* sm,
+            const PaDeviceInfo* deviceInfo,
+            PaHostApiTypeId deviceTypeId,
+            unsigned int devIndex);
     ~SoundDevicePortAudio() override;
 
     SoundDeviceError open(bool isClkRefDevice, int syncBuffers) override;
@@ -57,6 +58,7 @@ class SoundDevicePortAudio : public SoundDevice {
     // Struct containing information about this device. Don't free() it, it
     // belongs to PortAudio.
     const PaDeviceInfo* m_deviceInfo;
+    const PaHostApiTypeId m_deviceTypeId;
     // Description of the output stream going to the soundcard.
     PaStreamParameters m_outputParams;
     // Description of the input stream coming from the soundcard.
@@ -78,4 +80,3 @@ class SoundDevicePortAudio : public SoundDevice {
     PerformanceTimer m_clkRefTimer;
     PaTime m_lastCallbackEntrytoDacSecs;
 };
-

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -330,8 +330,9 @@ void SoundManager::queryDevicesPortaudio() {
             PaTime  defaultHighOutputLatency
             double  defaultSampleRate
          */
+        const auto deviceTypeId = paApiIndexToTypeId.value(deviceInfo->hostApi);
         auto currentDevice = SoundDevicePointer(new SoundDevicePortAudio(
-                m_pConfig, this, deviceInfo, i, paApiIndexToTypeId));
+                m_pConfig, this, deviceInfo, deviceTypeId, i));
         m_devices.push_back(currentDevice);
         if (!strcmp(Pa_GetHostApiInfo(deviceInfo->hostApi)->name,
                     MIXXX_PORTAUDIO_JACK_STRING)) {


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1903462

Fixes wrong usage of host API index vs. type id that has been picked up by #3160.