### PR TITLE
lp1903604: Mark imported cues dirty before storing them in the database

### DIFF
--- a/src/test/cue_test.cpp
+++ b/src/test/cue_test.cpp
@@ -20,7 +20,8 @@ TEST(CueTest, DefaultCueInfoToCueRoundtrip) {
     const CueInfo cueInfo1;
     const Cue cueObject(
             cueInfo1,
-            audio::SampleRate(44100));
+            audio::SampleRate(44100),
+            true);
     auto cueInfo2 = cueObject.getCueInfo(
             audio::SampleRate(44100));
     cueInfo2.setColor(std::nullopt);
@@ -40,7 +41,8 @@ TEST(CueTest, ConvertCueInfoToCueRoundtrip) {
             RgbColor::optional(0xABCDEF));
     const Cue cueObject(
             cueInfo1,
-            audio::SampleRate(44100));
+            audio::SampleRate(44100),
+            true);
     const auto cueInfo2 = cueObject.getCueInfo(
             audio::SampleRate(44100));
     EXPECT_EQ(cueInfo1, cueInfo2);

--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -88,7 +88,8 @@ Cue::Cue(
 Cue::Cue(
         const mixxx::CueInfo& cueInfo,
         mixxx::audio::SampleRate sampleRate)
-        : m_bDirty(false),
+        // Mark imported cues dirty before storing them in the database
+        : m_bDirty(cueInfo != mixxx::CueInfo()),
           m_iId(-1),
           m_type(cueInfo.getType()),
           m_sampleStartPosition(

--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -89,7 +89,6 @@ Cue::Cue(
         const mixxx::CueInfo& cueInfo,
         mixxx::audio::SampleRate sampleRate,
         bool setDirty)
-        // Mark imported cues dirty before storing them in the database
         : m_bDirty(setDirty),
           m_iId(-1),
           m_type(cueInfo.getType()),

--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -87,9 +87,10 @@ Cue::Cue(
 
 Cue::Cue(
         const mixxx::CueInfo& cueInfo,
-        mixxx::audio::SampleRate sampleRate)
+        mixxx::audio::SampleRate sampleRate,
+        bool setDirty)
         // Mark imported cues dirty before storing them in the database
-        : m_bDirty(cueInfo != mixxx::CueInfo()),
+        : m_bDirty(setDirty),
           m_iId(-1),
           m_type(cueInfo.getType()),
           m_sampleStartPosition(

--- a/src/track/cue.h
+++ b/src/track/cue.h
@@ -24,7 +24,8 @@ class Cue : public QObject {
     Cue();
     Cue(
             const mixxx::CueInfo& cueInfo,
-            mixxx::audio::SampleRate sampleRate);
+            mixxx::audio::SampleRate sampleRate,
+            bool setDirty);
     Cue(
             int id,
             TrackId trackId,

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1102,7 +1102,7 @@ bool Track::importPendingCueInfosWhileLocked() {
     cuePoints.reserve(m_pCueInfoImporterPending->size());
     for (const auto& cueInfo : m_pCueInfoImporterPending->importCueInfosAndApplyTimingOffset(
                  getLocation(), m_streamInfo->getSignalInfo())) {
-        CuePointer pCue(new Cue(cueInfo, sampleRate));
+        CuePointer pCue(new Cue(cueInfo, sampleRate, true));
         // While this method could be called from any thread,
         // associated Cue objects should always live on the
         // same thread as their host, namely this->thread().


### PR DESCRIPTION
Untested, might fix https://bugs.launchpad.net/mixxx/+bug/1903604