### PR TITLE
Remove lock from the engine thread.

### DIFF
--- a/src/engine/cuecontrol.cpp
+++ b/src/engine/cuecontrol.cpp
@@ -854,10 +854,10 @@ void CueControl::playStutter(double v) {
     }
 }
 
+// This is also called from the engine thread. No locking allowed.
 bool CueControl::updateIndicatorsAndModifyPlay(bool newPlay, bool oldPlay, bool playPossible) {
     //qDebug() << "updateIndicatorsAndModifyPlay" << newPlay << playPossible
     //        << m_iCurrentlyPreviewingHotcues << m_bPreviewing;
-    QMutexLocker lock(&m_mutex);
     double cueMode = m_pCueMode->get();
     if ((cueMode == CUE_MODE_DENON || cueMode == CUE_MODE_NUMARK) &&
         newPlay && !oldPlay && playPossible &&


### PR DESCRIPTION
 After #3268 it is no longer necessary, because the protected code is only run from the main and controller thread. 
The order of code ensures that it has no harm. 

The mutex mainly protect the cue points and related data structures, these are not touched anyway. 

This is considered as a band aid for 2.2 only. 

I have a real solution in progress fixing the root cause for 2.3 that has a big impact that does not suit to go into a bugfix release. 
 
 