### PR TITLE
EffectChainManager: Fix range loop pointer type

### DIFF
--- a/src/effects/effectchainmanager.cpp
+++ b/src/effects/effectchainmanager.cpp
@@ -166,7 +166,7 @@ bool EffectChainManager::saveEffectChains() {
 
     QDomElement rootNode = doc.documentElement();
 
-    for (const EffectRackPointer& pRack : qAsConst(m_standardEffectRacks)) {
+    for (const StandardEffectRackPointer& pRack : qAsConst(m_standardEffectRacks)) {
         rootNode.appendChild(pRack->toXml(&doc));
     }
     // TODO? Save QuickEffects in effects.xml too, or keep stored in ConfigObjects?


### PR DESCRIPTION
We're actually using the wrong pointer type here:

```
src/effects/effectchainmanager.cpp:169:35: error: loop variable 'pRack' has type 'const EffectRackPointer &' (aka 'const QSharedPointer<EffectRack> &') but is initialized with type 'const QSharedPointer<StandardEffectRack>' resulting in a copy [-Werror,-Wrange-loop-construct]
    for (const EffectRackPointer& pRack : qAsConst(m_standardEffectRacks)) {
                                  ^
src/effects/effectchainmanager.cpp:169:10: note: use non-reference type 'EffectRackPointer' (aka 'QSharedPointer<EffectRack>') to keep the copy or type 'const QSharedPointer<StandardEffectRack> &' to prevent copying
    for (const EffectRackPointer& pRack : qAsConst(m_standardEffectRacks)) {
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```