### PR TITLE
TrackDAO: Remove const qualifiers from signals to suppress clazy warnings

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1,43 +1,43 @@
 #include "library/dao/trackdao.h"
 
-#include <QtDebug>
+#include <QChar>
 #include <QDir>
 #include <QDirIterator>
 #include <QFileInfo>
-#include <QtSql>
 #include <QImage>
 #include <QRegExp>
-#include <QChar>
+#include <QtDebug>
+#include <QtSql>
 
-#include "sources/soundsourceproxy.h"
-#include "track/track.h"
-#include "library/queryutil.h"
-#include "util/db/sqlstringformatter.h"
-#include "util/db/sqllikewildcards.h"
-#include "util/db/sqllikewildcardescaper.h"
-#include "util/db/sqltransaction.h"
 #include "library/coverart.h"
 #include "library/coverartutils.h"
-#include "library/dao/trackschema.h"
 #include "library/crate/cratestorage.h"
-#include "library/dao/cuedao.h"
-#include "library/dao/playlistdao.h"
 #include "library/dao/analysisdao.h"
+#include "library/dao/cuedao.h"
 #include "library/dao/libraryhashdao.h"
+#include "library/dao/playlistdao.h"
+#include "library/dao/trackschema.h"
+#include "library/queryutil.h"
+#include "sources/soundsourceproxy.h"
 #include "track/beatfactory.h"
 #include "track/beats.h"
+#include "track/globaltrackcache.h"
 #include "track/keyfactory.h"
 #include "track/keyutils.h"
-#include "track/globaltrackcache.h"
+#include "track/track.h"
 #include "track/tracknumbers.h"
 #include "util/assert.h"
 #include "util/compatibility.h"
 #include "util/datetime.h"
+#include "util/db/sqllikewildcardescaper.h"
+#include "util/db/sqllikewildcards.h"
+#include "util/db/sqlstringformatter.h"
+#include "util/db/sqltransaction.h"
 #include "util/file.h"
 #include "util/logger.h"
-#include "util/timer.h"
 #include "util/math.h"
-
+#include "util/qt.h"
+#include "util/timer.h"
 
 namespace {
 
@@ -286,7 +286,7 @@ void TrackDAO::saveTrack(Track* pTrack) const {
         // not receive any signals that are usually forwarded to
         // BaseTrackCache.
         DEBUG_ASSERT(!pTrack->isDirty());
-        emit trackClean(trackId);
+        emit mixxx::thisAsNonConst(this)->trackClean(trackId);
     }
 }
 
@@ -1345,7 +1345,7 @@ TrackPointer TrackDAO::getTrackById(TrackId trackId) const {
             this,
             [this](TrackId trackId) {
                 // Adapt and forward signal
-                emit tracksChanged(QSet<TrackId>{trackId});
+                emit mixxx::thisAsNonConst(this)->tracksChanged(QSet<TrackId>{trackId});
             });
 
     // BaseTrackCache cares about track trackDirty/trackClean notifications
@@ -1353,9 +1353,9 @@ TrackPointer TrackDAO::getTrackById(TrackId trackId) const {
     // track modifications above have been sent before the TrackDAO has been
     // connected to the track's signals and need to be replayed manually.
     if (pTrack->isDirty()) {
-        emit trackDirty(trackId);
+        emit mixxx::thisAsNonConst(this)->trackDirty(trackId);
     } else {
-        emit trackClean(trackId);
+        emit mixxx::thisAsNonConst(this)->trackClean(trackId);
     }
 
     return pTrack;

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -71,13 +71,13 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
 
   signals:
     // Forwarded from Track object
-    void trackDirty(TrackId trackId) const;
-    void trackClean(TrackId trackId) const;
+    void trackDirty(TrackId trackId);
+    void trackClean(TrackId trackId);
 
     // Multiple tracks
-    void tracksAdded(QSet<TrackId> trackIds) const;
-    void tracksChanged(QSet<TrackId> trackIds) const;
-    void tracksRemoved(QSet<TrackId> trackIds) const;
+    void tracksAdded(QSet<TrackId> trackIds);
+    void tracksChanged(QSet<TrackId> trackIds);
+    void tracksRemoved(QSet<TrackId> trackIds);
 
     void progressVerifyTracksOutside(QString path);
     void progressCoverArt(QString file);

--- a/src/util/qt.h
+++ b/src/util/qt.h
@@ -7,6 +7,20 @@
 
 namespace mixxx {
 
+/// Allow to emit non-const signals from a const member function.
+///
+/// https://github.com/KDE/clazy/blob/master/docs/checks/README-const-signal-or-slot.md
+///
+/// This is needed as a workaround for many DAO classes. Most member
+/// functions should be const and those classes should not emit any
+/// signals.
+///
+/// Usage: emit thisAsNonConst(this)->signalName(<signal args>);
+template<typename T>
+inline T* thisAsNonConst(const T* constThisPointer) {
+    return const_cast<T*>(constThisPointer);
+}
+
 /// Escape special characters in text properties to prevent
 /// the implicit creation of shortcuts for widgets.
 ///


### PR DESCRIPTION
As requested: https://github.com/mixxxdj/mixxx/pull/2718#discussion_r522247765

Ugly. But it makes the design flaws obvious and suppresses the warnings.