### PR TITLE
DlgPrefInterface: Add missing override

### DIFF
--- a/src/preferences/dialog/dlgprefinterface.h
+++ b/src/preferences/dialog/dlgprefinterface.h
@@ -44,9 +44,9 @@ class DlgPrefInterface : public DlgPreferencePage, public Ui::DlgPrefControlsDlg
     ~DlgPrefInterface() override = default;
 
   public slots:
-    void slotUpdate();
-    void slotApply();
-    void slotResetToDefaults();
+    void slotUpdate() override;
+    void slotApply() override;
+    void slotResetToDefaults() override;
 
     void slotSetTooltips();
     void slotSetSkinDescription(QString skin);


### PR DESCRIPTION
Fixes these warnings:

    In file included from /home/runner/work/mixxx/mixxx/cmake_build/mixxx-lib_autogen/mocs_compilation.cpp:212:
    In file included from /home/runner/work/mixxx/mixxx/cmake_build/mixxx-lib_autogen/YGKOTPDTD4/moc_dlgprefinterface.cpp:9:
    /home/runner/work/mixxx/mixxx/src/preferences/dialog/dlgprefinterface.h:47:10: error: 'slotUpdate' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
        void slotUpdate();
             ^
    /home/runner/work/mixxx/mixxx/src/preferences/dlgpreferencepage.h:23:18: note: overridden virtual function is here
        virtual void slotUpdate() = 0;
                     ^
    In file included from /home/runner/work/mixxx/mixxx/cmake_build/mixxx-lib_autogen/mocs_compilation.cpp:212:
    In file included from /home/runner/work/mixxx/mixxx/cmake_build/mixxx-lib_autogen/YGKOTPDTD4/moc_dlgprefinterface.cpp:9:
    /home/runner/work/mixxx/mixxx/src/preferences/dialog/dlgprefinterface.h:48:10: error: 'slotApply' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
        void slotApply();
             ^
    /home/runner/work/mixxx/mixxx/src/preferences/dlgpreferencepage.h:27:18: note: overridden virtual function is here
        virtual void slotApply() = 0;
                     ^
    In file included from /home/runner/work/mixxx/mixxx/cmake_build/mixxx-lib_autogen/mocs_compilation.cpp:212:
    In file included from /home/runner/work/mixxx/mixxx/cmake_build/mixxx-lib_autogen/YGKOTPDTD4/moc_dlgprefinterface.cpp:9:
    /home/runner/work/mixxx/mixxx/src/preferences/dialog/dlgprefinterface.h:49:10: error: 'slotResetToDefaults' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
        void slotResetToDefaults();
             ^
    /home/runner/work/mixxx/mixxx/src/preferences/dlgpreferencepage.h:38:18: note: overridden virtual function is here
        virtual void slotResetToDefaults() = 0;
                     ^