### PR TITLE
BaseTrackTableModel: Fix confusing DEBUG_ASSERT logic

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -468,17 +468,14 @@ bool BaseTrackTableModel::setData(
 QVariant BaseTrackTableModel::composeCoverArtToolTipHtml(
         const QModelIndex& index) const {
     // Determine height of the cover art image depending on the screen size
-    unsigned int absoluteHeightOfCoverartToolTip;
     const QScreen* primaryScreen = getPrimaryScreen();
-    if (primaryScreen) {
-        absoluteHeightOfCoverartToolTip = static_cast<int>(
-                primaryScreen->availableGeometry().height() *
-                kRelativeHeightOfCoverartToolTip);
-    } else {
-        VERIFY_OR_DEBUG_ASSERT(primaryScreen) {
-            return QVariant();
-        }
+    if (!primaryScreen) {
+        DEBUG_ASSERT(!"Primary screen not found!");
+        return QVariant();
     }
+    unsigned int absoluteHeightOfCoverartToolTip = static_cast<int>(
+            primaryScreen->availableGeometry().height() *
+            kRelativeHeightOfCoverartToolTip);
     // Get image from cover art cache
     CoverArtCache* pCache = CoverArtCache::instance();
     QPixmap pixmap = QPixmap(absoluteHeightOfCoverartToolTip,


### PR DESCRIPTION
Clang complains about this, and although it's a false positive the code
is confusing and can be simplified.

Fixes:

    /home/runner/work/mixxx/mixxx/src/library/basetracktablemodel.cpp:478:9: error: variable 'absoluteHeightOfCoverartToolTip' is used uninitialized whenever 'if' condition is false [-Werror,-Wsometimes-uninitialized]
            VERIFY_OR_DEBUG_ASSERT(primaryScreen) {
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /home/runner/work/mixxx/mixxx/src/util/assert.h:62:42: note: expanded from macro 'VERIFY_OR_DEBUG_ASSERT'
    #define VERIFY_OR_DEBUG_ASSERT(cond) if ((!(cond)) && mixxx_maybe_debug_assert_return_true(#cond, __FILE__, __LINE__, ASSERT_FUNCTION))
                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /home/runner/work/mixxx/mixxx/src/library/basetracktablemodel.cpp:484:30: note: uninitialized use occurs here
        QPixmap pixmap = QPixmap(absoluteHeightOfCoverartToolTip,
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /home/runner/work/mixxx/mixxx/src/library/basetracktablemodel.cpp:478:9: note: remove the 'if' if its condition is always true
            VERIFY_OR_DEBUG_ASSERT(primaryScreen) {
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /home/runner/work/mixxx/mixxx/src/util/assert.h:62:38: note: expanded from macro 'VERIFY_OR_DEBUG_ASSERT'
    #define VERIFY_OR_DEBUG_ASSERT(cond) if ((!(cond)) && mixxx_maybe_debug_assert_return_true(#cond, __FILE__, __LINE__, ASSERT_FUNCTION))
                                         ^
    /home/runner/work/mixxx/mixxx/src/library/basetracktablemodel.cpp:478:9: error: variable 'absoluteHeightOfCoverartToolTip' is used uninitialized whenever '&&' condition is false [-Werror,-Wsometimes-uninitialized]
            VERIFY_OR_DEBUG_ASSERT(primaryScreen) {
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /home/runner/work/mixxx/mixxx/src/util/assert.h:62:42: note: expanded from macro 'VERIFY_OR_DEBUG_ASSERT'
    #define VERIFY_OR_DEBUG_ASSERT(cond) if ((!(cond)) && mixxx_maybe_debug_assert_return_true(#cond, __FILE__, __LINE__, ASSERT_FUNCTION))
                                             ^~~~~~~~~
    /home/runner/work/mixxx/mixxx/src/library/basetracktablemodel.cpp:484:30: note: uninitialized use occurs here
        QPixmap pixmap = QPixmap(absoluteHeightOfCoverartToolTip,
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /home/runner/work/mixxx/mixxx/src/library/basetracktablemodel.cpp:478:9: note: remove the '&&' if its condition is always true
            VERIFY_OR_DEBUG_ASSERT(primaryScreen) {
            ^
    /home/runner/work/mixxx/mixxx/src/util/assert.h:62:42: note: expanded from macro 'VERIFY_OR_DEBUG_ASSERT'
    #define VERIFY_OR_DEBUG_ASSERT(cond) if ((!(cond)) && mixxx_maybe_debug_assert_return_true(#cond, __FILE__, __LINE__, ASSERT_FUNCTION))
                                             ^
    /home/runner/work/mixxx/mixxx/src/library/basetracktablemodel.cpp:471:49: note: initialize the variable 'absoluteHeightOfCoverartToolTip' to silence this warning
        unsigned int absoluteHeightOfCoverartToolTip;
                                                    ^