### PR TITLE
Clazy action: Add missing dependency qtdeclarative5-dev

### DIFF
--- a/.github/workflows/clazy.yml
+++ b/.github/workflows/clazy.yml
@@ -10,7 +10,42 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install build dependencies
-      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libavformat-dev libchromaprint-dev libebur128-dev libfftw3-dev libflac-dev libid3tag0-dev liblilv-dev libmad0-dev libmodplug-dev libmp3lame-dev libopus-dev libopusfile-dev libportmidi-dev libprotobuf-dev libqt5opengl5-dev libqt5sql5-sqlite libqt5svg5-dev libqt5x11extras5-dev librubberband-dev libshout3-dev libsndfile1-dev libsoundtouch-dev libsqlite3-dev libtag1-dev libupower-glib-dev libusb-1.0-0-dev libwavpack-dev portaudio19-dev protobuf-compiler qt5-default qtscript5-dev qt5keychain-dev clazy cmake
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends
+        clazy
+        cmake
+        libavformat-dev
+        libchromaprint-dev
+        libebur128-dev
+        libfftw3-dev
+        libflac-dev
+        libid3tag0-dev
+        liblilv-dev
+        libmad0-dev
+        libmodplug-dev
+        libmp3lame-dev
+        libopus-dev
+        libopusfile-dev
+        libportmidi-dev
+        libprotobuf-dev
+        libqt5opengl5-dev
+        libqt5sql5-sqlite
+        libqt5svg5-dev
+        libqt5x11extras5-dev
+        librubberband-dev
+        libshout3-dev
+        libsndfile1-dev
+        libsoundtouch-dev
+        libsqlite3-dev
+        libtag1-dev
+        libupower-glib-dev
+        libusb-1.0-0-dev
+        libwavpack-dev
+        portaudio19-dev
+        protobuf-compiler
+        qt5-default
+        qtdeclarative5-dev
+        qtscript5-dev
+        qt5keychain-dev
     - name: Build
       run: |
         mkdir cmake_build

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -721,7 +721,7 @@ void CueControl::hotcueSet(HotcueControl* pControl, double value, HotcueSetMode 
     double cueEndPosition = Cue::kNoPosition;
     mixxx::CueType cueType = mixxx::CueType::Invalid;
 
-    bool loopEnabled = m_pLoopEnabled->get();
+    bool loopEnabled = m_pLoopEnabled->toBool();
     if (mode == HotcueSetMode::Auto) {
         mode = loopEnabled ? HotcueSetMode::Loop : HotcueSetMode::Cue;
     }
@@ -974,7 +974,8 @@ void CueControl::hotcueCueLoop(HotcueControl* pControl, double value) {
         // mapping the CUE LOOP mode labeled on some controllers.
         setCurrentSavedLoopControlAndActivate(nullptr);
         double startPosition = pCue->getPosition();
-        bool loopActive = m_pLoopEnabled->get() && (startPosition == m_pLoopStartPosition->get());
+        bool loopActive = m_pLoopEnabled->toBool() &&
+                (startPosition == m_pLoopStartPosition->get());
         setBeatLoop(startPosition, !loopActive);
         break;
     }

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -823,10 +823,10 @@ void LoopingControl::slotLoopEnabledValueChangeRequest(double value) {
         return;
     }
 
-    if (value) {
+    if (value > 0.0) {
         // Requested to set loop_enabled to 1
         if (m_bLoopingEnabled) {
-            VERIFY_OR_DEBUG_ASSERT(m_pCOLoopEnabled->get()) {
+            VERIFY_OR_DEBUG_ASSERT(m_pCOLoopEnabled->toBool()) {
                 m_pCOLoopEnabled->setAndConfirm(1.0);
             }
         } else {
@@ -852,7 +852,7 @@ void LoopingControl::slotLoopEnabledValueChangeRequest(double value) {
             // setAndConfirm is called by setLoopingEnabled
             setLoopingEnabled(false);
         } else {
-            VERIFY_OR_DEBUG_ASSERT(!m_pCOLoopEnabled->get()) {
+            VERIFY_OR_DEBUG_ASSERT(!m_pCOLoopEnabled->toBool()) {
                 m_pCOLoopEnabled->setAndConfirm(0.0);
             }
         }

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -190,7 +190,8 @@ DlgPreferences::DlgPreferences(MixxxMainWindow* mixxx, SkinLoader* pSkinLoader, 
 #endif
 
     // Find accept and apply buttons
-    for (QAbstractButton* button : buttonBox->buttons()) {
+    const auto buttons = buttonBox->buttons();
+    for (QAbstractButton* button : buttons) {
         QDialogButtonBox::ButtonRole role = buttonBox->buttonRole(button);
         if (role == QDialogButtonBox::ButtonRole::ApplyRole) {
             m_pApplyButton = button;
@@ -254,7 +255,7 @@ void DlgPreferences::changePage(QTreeWidgetItem* current, QTreeWidgetItem* previ
         return;
     }
 
-    for (PreferencesPage page : m_allPages) {
+    for (PreferencesPage page : qAsConst(m_allPages)) {
         if (current == page.pTreeItem) {
             switchToPage(page.pDlg);
             break;

--- a/src/test/hotcuecontrol_test.cpp
+++ b/src/test/hotcuecontrol_test.cpp
@@ -56,7 +56,7 @@ class HotcueControlTest : public BaseSignalPathTest {
     }
 
     TrackPointer loadTestTrackWithBpm(double bpm) {
-        DEBUG_ASSERT(!m_pPlay->get());
+        DEBUG_ASSERT(!m_pPlay->toBool());
         // Setup fake track with 120 bpm can calculate loop size
         TrackPointer pTrack = createTestTrack();
         pTrack->setBpm(bpm);


### PR DESCRIPTION
Follow-up of #3295 for main

Using a single line per dependency will be easier to maintain.