### PR TITLE
Bypass quantize setting when beat jumping. Fixing lp1904132

### DIFF
--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -1209,7 +1209,8 @@ void LoopingControl::slotBeatJump(double beats) {
         // If inside an active loop, move loop
         slotLoopMove(beats);
     } else {
-        seekAbs(pBeats->findNBeatsFromSample(currentSample, beats));
+        // seekExact bypasses Quantize, because a beat jump is implicit quantized
+        seekExact(pBeats->findNBeatsFromSample(currentSample, beats));
     }
 }
 


### PR DESCRIPTION
Beat-Jumps are implicit quantized. 