### PR TITLE
Fix -Wclazy-qstring-arg warnings

### DIFF
--- a/.github/workflows/clazy.yml
+++ b/.github/workflows/clazy.yml
@@ -22,4 +22,4 @@ jobs:
         LD: clang++
         CC: clang
         CXX: clazy
-        CLAZY_CHECKS: range-loop
+        CLAZY_CHECKS: range-loop,qstring-arg

--- a/src/controllers/bulk/bulkcontroller.cpp
+++ b/src/controllers/bulk/bulkcontroller.cpp
@@ -87,7 +87,7 @@ BulkController::BulkController(UserSettingsPointer pConfig,
 
     setDeviceCategory(tr("USB Controller"));
 
-    setDeviceName(QString("%1 %2").arg(product).arg(m_sUID));
+    setDeviceName(QString("%1 %2").arg(product, m_sUID));
 
     setInputDevice(true);
     setOutputDevice(true);

--- a/src/controllers/controller.cpp
+++ b/src/controllers/controller.cpp
@@ -121,7 +121,9 @@ void Controller::receive(const QByteArray data, mixxx::Duration timestamp) {
     if (ControllerDebug::enabled()) {
         // Formatted packet display
         QString message = QString("%1: t:%2, %3 bytes:\n")
-                .arg(m_sDeviceName).arg(timestamp.formatMillisWithUnit()).arg(length);
+                                  .arg(m_sDeviceName,
+                                          timestamp.formatMillisWithUnit(),
+                                          QString::number(length));
         for(int i=0; i<length; i++) {
             QString spacer=" ";
             if ((i+1) % 4 == 0) spacer="  ";

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -63,13 +63,12 @@ HidController::HidController(const hid_device_info& deviceInfo, UserSettingsPoin
     // which is which
     if (hid_interface_number < 0) {
         setDeviceName(
-            QString("%1 %2").arg(hid_product)
-            .arg(hid_serial.right(4)));
+                QString("%1 %2").arg(hid_product, hid_serial.right(4)));
     } else {
-        setDeviceName(
-            QString("%1 %2_%3").arg(hid_product)
-            .arg(hid_serial.right(4))
-            .arg(QString::number(hid_interface_number)));
+        setDeviceName(QString("%1 %2_%3")
+                              .arg(hid_product,
+                                      hid_serial.right(4),
+                                      QString::number(hid_interface_number)));
         m_sUID.append(QString::number(hid_interface_number));
     }
 

--- a/src/controllers/midi/midicontroller.cpp
+++ b/src/controllers/midi/midicontroller.cpp
@@ -103,10 +103,12 @@ void MidiController::createOutputHandlers() {
         MidiOutputHandler* moh = new MidiOutputHandler(this, mapping);
         if (!moh->validate()) {
             QString errorLog =
-                QString("MIDI output message 0x%1 0x%2 has invalid MixxxControl %3, %4")
-                        .arg(QString::number(status, 16).toUpper(),
-                             QString::number(control, 16).toUpper().rightJustified(2,'0'))
-                        .arg(group, key).toUtf8();
+                    QString("MIDI output message 0x%1 0x%2 has invalid MixxxControl %3, %4")
+                            .arg(QString::number(status, 16).toUpper(),
+                                    QString::number(control, 16).toUpper().rightJustified(2, '0'),
+                                    group,
+                                    key)
+                            .toUtf8();
             qWarning() << errorLog;
 
             int deckNum = 0;

--- a/src/controllers/midi/midiutils.cpp
+++ b/src/controllers/midi/midiutils.cpp
@@ -129,9 +129,9 @@ QString MidiUtils::formatSysexMessage(const QString& controllerName, const QByte
     } else {
       msg2 = QString("t:%1").arg(timestamp.formatMillisWithUnit());
     }
-    QString message = QString("%1: %2 %3 byte sysex: [")
-            .arg(controllerName).arg(msg2)
-            .arg(data.size());
+    QString message =
+            QString("%1: %2 %3 byte sysex: [")
+                    .arg(controllerName, msg2, QString::number(data.size()));
     for (int i = 0; i < data.size(); ++i) {
         message += QString("%1%2").arg(
             QString("%1").arg((unsigned char)(data.at(i)), 2, 16, QChar('0')).toUpper(),

--- a/src/effects/effectrack.h
+++ b/src/effects/effectrack.h
@@ -95,24 +95,23 @@ class StandardEffectRack : public EffectRack {
     virtual ~StandardEffectRack() {}
 
     static QString formatGroupString(const unsigned int iRackNumber) {
-        return QString("[EffectRack%1]")
-                .arg(QString::number(iRackNumber + 1));
+        return QString("[EffectRack%1]").arg(QString::number(iRackNumber + 1));
     }
 
     static QString formatEffectChainSlotGroupString(const unsigned int iRackNumber,
                                                     const unsigned int iChainSlotNumber) {
         return QString("[EffectRack%1_EffectUnit%2]")
-                .arg(QString::number(iRackNumber + 1))
-                .arg(QString::number(iChainSlotNumber + 1));
+                .arg(QString::number(iRackNumber + 1),
+                        QString::number(iChainSlotNumber + 1));
     }
 
     static QString formatEffectSlotGroupString(const unsigned int iRackNumber,
                                                const unsigned int iChainSlotNumber,
                                                const unsigned int iEffectSlotNumber) {
         return QString("[EffectRack%1_EffectUnit%2_Effect%3]")
-                .arg(QString::number(iRackNumber + 1))
-                .arg(QString::number(iChainSlotNumber + 1))
-                .arg(QString::number(iEffectSlotNumber + 1));
+                .arg(QString::number(iRackNumber + 1),
+                        QString::number(iChainSlotNumber + 1),
+                        QString::number(iEffectSlotNumber + 1));
     }
 
     EffectChainSlotPointer addEffectChainSlot();
@@ -166,24 +165,21 @@ class QuickEffectRack : public PerGroupRack {
     bool loadEffectToGroup(const QString& group, EffectPointer pEffect) override;
 
     static QString formatGroupString(const unsigned int iRackNumber) {
-        return QString("[QuickEffectRack%1]")
-                .arg(QString::number(iRackNumber + 1));
+        return QString("[QuickEffectRack%1]").arg(QString::number(iRackNumber + 1));
     }
 
     static QString formatEffectChainSlotGroupString(const unsigned int iRackNumber,
                                                     const QString& group) {
-        return QString("[QuickEffectRack%1_%2]")
-                .arg(QString::number(iRackNumber + 1))
-                .arg(group);
+        return QString("[QuickEffectRack%1_%2]").arg(QString::number(iRackNumber + 1), group);
     }
 
     static QString formatEffectSlotGroupString(const unsigned int iRackNumber,
                                                const unsigned int iEffectSlotNumber,
                                                const QString& group) {
         return QString("[QuickEffectRack%1_%2_Effect%3]")
-                .arg(QString::number(iRackNumber + 1))
-                .arg(group)
-                .arg(QString::number(iEffectSlotNumber + 1));
+                .arg(QString::number(iRackNumber + 1),
+                        group,
+                        QString::number(iEffectSlotNumber + 1));
     }
 
     QString formatEffectSlotGroupString(const unsigned int iEffectSlotNumber,
@@ -218,24 +214,21 @@ class EqualizerRack : public PerGroupRack {
     virtual ~EqualizerRack() {}
 
     static QString formatGroupString(const unsigned int iRackNumber) {
-        return QString("[EqualizerRack%1]")
-                .arg(QString::number(iRackNumber + 1));
+        return QString("[EqualizerRack%1]").arg(QString::number(iRackNumber + 1));
     }
 
     static QString formatEffectChainSlotGroupString(const unsigned int iRackNumber,
                                                     const QString& group) {
-        return QString("[EqualizerRack%1_%2]")
-                .arg(QString::number(iRackNumber + 1))
-                .arg(group);
+        return QString("[EqualizerRack%1_%2]").arg(QString::number(iRackNumber + 1), group);
     }
 
     static QString formatEffectSlotGroupString(const unsigned int iRackNumber,
                                                const unsigned int iEffectSlotNumber,
                                                const QString& group) {
         return QString("[EqualizerRack%1_%2_Effect%3]")
-                .arg(QString::number(iRackNumber + 1))
-                .arg(group)
-                .arg(QString::number(iEffectSlotNumber + 1));
+                .arg(QString::number(iRackNumber + 1),
+                        group,
+                        QString::number(iEffectSlotNumber + 1));
     }
 
     QString formatEffectSlotGroupString(const unsigned int iEffectSlotNumber,

--- a/src/library/analysisfeature.cpp
+++ b/src/library/analysisfeature.cpp
@@ -67,9 +67,9 @@ void AnalysisFeature::resetTitle() {
 
 void AnalysisFeature::setTitleProgress(int currentTrackNumber, int totalTracksCount) {
     m_title = QString("%1 (%2 / %3)")
-            .arg(m_baseTitle)
-            .arg(QString::number(currentTrackNumber))
-            .arg(QString::number(totalTracksCount));
+                      .arg(m_baseTitle,
+                              QString::number(currentTrackNumber),
+                              QString::number(totalTracksCount));
     emit featureIsLoading(this, false);
 }
 

--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -677,13 +677,14 @@ bool PlaylistDAO::copyPlaylistTracks(const int sourcePlaylistID, const int targe
     // INSERT INTO PlaylistTracks (playlist_id, track_id, position, pl_datetime_added) SELECT :target_plid, track_id, position + :position_offset, pl_datetime_added FROM PlaylistTracks WHERE playlist_id = :source_plid;
     QSqlQuery query(m_database);
     query.prepare(QString("INSERT INTO " PLAYLIST_TRACKS_TABLE
-        " (%1, %2, %3, %4) SELECT :target_plid, %2, "
-        "%3 + :position_offset, %4 FROM " PLAYLIST_TRACKS_TABLE
-        " WHERE %1 = :source_plid")
-        .arg(PLAYLISTTRACKSTABLE_PLAYLISTID)        // %1
-        .arg(PLAYLISTTRACKSTABLE_TRACKID)           // %2
-        .arg(PLAYLISTTRACKSTABLE_POSITION)          // %3
-        .arg(PLAYLISTTRACKSTABLE_DATETIMEADDED));   // %4
+                          " (%1, %2, %3, %4) SELECT :target_plid, %2, "
+                          "%3 + :position_offset, %4 FROM " PLAYLIST_TRACKS_TABLE
+                          " WHERE %1 = :source_plid")
+                          .arg(
+                                  PLAYLISTTRACKSTABLE_PLAYLISTID,      // %1
+                                  PLAYLISTTRACKSTABLE_TRACKID,         // %2
+                                  PLAYLISTTRACKSTABLE_POSITION,        // %3
+                                  PLAYLISTTRACKSTABLE_DATETIMEADDED)); // %4
     query.bindValue(":position_offset", positionOffset);
     query.bindValue(":source_plid", sourcePlaylistID);
     query.bindValue(":target_plid", targetPlaylistID);
@@ -696,10 +697,11 @@ bool PlaylistDAO::copyPlaylistTracks(const int sourcePlaylistID, const int targe
     // Query each added track and its new position.
     // SELECT track_id, position FROM PlaylistTracks WHERE playlist_id = :target_plid AND position > :position_offset;
     query.prepare(QString("SELECT %2, %3 FROM " PLAYLIST_TRACKS_TABLE
-        " WHERE %1 = :target_plid AND %3 > :position_offset")
-        .arg(PLAYLISTTRACKSTABLE_PLAYLISTID)    // %1
-        .arg(PLAYLISTTRACKSTABLE_TRACKID)       // %2
-        .arg(PLAYLISTTRACKSTABLE_POSITION));    // %3
+                          " WHERE %1 = :target_plid AND %3 > :position_offset")
+                          .arg(
+                                  PLAYLISTTRACKSTABLE_PLAYLISTID, // %1
+                                  PLAYLISTTRACKSTABLE_TRACKID,    // %2
+                                  PLAYLISTTRACKSTABLE_POSITION)); // %3
     query.bindValue(":target_plid", targetPlaylistID);
     query.bindValue(":position_offset", positionOffset);
     if (!query.exec()) {

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -186,9 +186,9 @@ void DlgRecording::slotDurationRecorded(QString durationRecorded) {
 // update label besides start/stop button
 void DlgRecording::refreshLabels() {
     QString recFile = m_pRecordingManager->getRecordingFile();
-    QString recData = QString(QStringLiteral("(") + tr("%1 MiB written in %2") + QStringLiteral(")"))
-            .arg(m_bytesRecordedStr)
-            .arg(m_durationRecordedStr);
+    QString recData = QString(QStringLiteral("(") + tr("%1 MiB written in %2") +
+            QStringLiteral(")"))
+                              .arg(m_bytesRecordedStr, m_durationRecordedStr);
     labelRecFilename->setText(recFile);
     labelRecStatistics->setText(recData);
 }

--- a/src/library/scanner/libraryscannerdlg.cpp
+++ b/src/library/scanner/libraryscannerdlg.cpp
@@ -73,9 +73,7 @@ void LibraryScannerDlg::slotUpdateCover(QString path) {
     }
 
     if (isVisible()) {
-        QString status = QString("%1: %2")
-                .arg(tr("Scanning cover art (safe to cancel)"))
-                .arg(path);
+        QString status = QString("%1: %2").arg(tr("Scanning cover art (safe to cancel)"), path);
         emit progress(status);
     }
 }

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -1101,9 +1101,7 @@ void MixxxMainWindow::slotUpdateWindowTitle(TrackPointer pTrack) {
     if (pTrack) {
         QString trackInfo = pTrack->getInfo();
         if (!trackInfo.isEmpty()) {
-            appTitle = QString("%1 | %2")
-                    .arg(trackInfo)
-                    .arg(appTitle);
+            appTitle = QString("%1 | %2").arg(trackInfo, appTitle);
         }
     }
     this->setWindowTitle(appTitle);

--- a/src/preferences/dialog/dlgprefbroadcast.cpp
+++ b/src/preferences/dialog/dlgprefbroadcast.cpp
@@ -222,11 +222,13 @@ void DlgPrefBroadcast::slotApply() {
                     == profile->getHost().toLower()
                     && profileWithSameMountpoint->getPort()
                     == profile->getPort() ) {
-                    QMessageBox::warning(
-                        this, tr("Action failed"),
-                        tr("'%1' has the same Icecast mountpoint as '%2'.\n"
-                           "Two source connections to the same server can't have the same mountpoint.")
-                        .arg(profileName).arg(profileNameWithSameMountpoint));
+                    QMessageBox::warning(this,
+                            tr("Action failed"),
+                            tr("'%1' has the same Icecast mountpoint as '%2'.\n"
+                               "Two source connections to the same server "
+                               "can't have the same mountpoint.")
+                                    .arg(profileName,
+                                            profileNameWithSameMountpoint));
                     return;
                 }
             }
@@ -593,9 +595,10 @@ void DlgPrefBroadcast::btnRenameConnectionClicked() {
                 getValuesFromProfile(m_pProfileListSelection);
             } else {
                 // Requested name different from current name but already used
-                QMessageBox::warning(this, tr("Action failed"),
+                QMessageBox::warning(this,
+                        tr("Action failed"),
                         tr("Can't rename '%1' to '%2': name already in use")
-                        .arg(profileName).arg(newName));
+                                .arg(profileName, newName));
             }
         }
     }

--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -96,7 +96,7 @@ DlgPrefInterface::DlgPrefInterface(QWidget * parent, MixxxMainWindow * mixxx,
         if (lang == "C") { // Ugly hack to remove the non-resolving locales
             continue;
         }
-        lang = QString("%1 (%2)").arg(lang).arg(country);
+        lang = QString("%1 (%2)").arg(lang, country);
         ComboBoxLocale->addItem(lang, locale); // locale as userdata (for storing to config)
     }
     ComboBoxLocale->model()->sort(0); // Sort languages list

--- a/src/preferences/dialog/dlgprefvinyl.cpp
+++ b/src/preferences/dialog/dlgprefvinyl.cpp
@@ -95,9 +95,10 @@ DlgPrefVinyl::DlgPrefVinyl(QWidget * parent, VinylControlManager *pVCMan,
     LeadinTime3->setSuffix(" s");
     LeadinTime4->setSuffix(" s");
 
-    TroubleshootingLink->setText(QString("<a href='%1%2'>Troubleshooting</a>")
-                                         .arg(MIXXX_MANUAL_URL)
-                                         .arg("/chapters/vinyl_control.html#troubleshooting"));
+    TroubleshootingLink->setText(
+            QString("<a href='%1%2'>Troubleshooting</a>")
+                    .arg(MIXXX_MANUAL_URL,
+                            "/chapters/vinyl_control.html#troubleshooting"));
 
     connect(VinylGain, SIGNAL(sliderReleased()),
             this, SLOT(slotVinylGainApply()));

--- a/src/widget/wcoverartmenu.cpp
+++ b/src/widget/wcoverartmenu.cpp
@@ -57,8 +57,7 @@ void WCoverArtMenu::slotChange() {
     for (auto&& extension : extensions) {
         extension.prepend("*.");
     }
-    QString supportedText = QString("%1 (%2)").arg(tr("Image Files"))
-            .arg(extensions.join(" "));
+    QString supportedText = QString("%1 (%2)").arg(tr("Image Files"), extensions.join(" "));
 
     // open file dialog
     QString selectedCoverPath = QFileDialog::getOpenFileName(


### PR DESCRIPTION
Avoids unnecessary memory allocations by using the multi-arg overload. See
https://github.com/KDE/clazy/blob/master/docs/checks/README-qstring-arg.md
for details.