### PR TITLE
Fix "Mixx" typos in code

### DIFF
--- a/res/controllers/Numark-DJ2Go-scripts.js
+++ b/res/controllers/Numark-DJ2Go-scripts.js
@@ -138,7 +138,7 @@ NumarkDJ2Go.deck = function(deckNum) {
 	this.pitchTimer= 0;
 	//The alternative mode to scratching for the jog wheel.
 	this.pitchBend = function(forwards) {
-		//For some reason the ramping pitchbend option in Mixx menu together with temp_rate_up/down doesn't seem
+		//For some reason the ramping pitchbend option in Mixxx menu together with temp_rate_up/down doesn't seem
 		//to work for the jog wheel. So this function allows the pitch bend to ramp the faster/more
 		//revolutions of the wheel.
 		if (this.pitchTimer !== 0)

--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -467,7 +467,7 @@ DJ505.Deck = function(deckNumbers, offset) {
      *
      * TODO: Add proper bar support for the LED indicators
      *
-     * Mixx currently does not support bar detection, so we don't know which
+     * Mixxx currently does not support bar detection, so we don't know which
      * of the 4 beats in a we are on. This has been worked around by counting
      * beats manually, but this is error prone and does not support moving
      * backwards in a track, has problems with loops, does not detect hotcue

--- a/res/controllers/mixco/novation_twitch.mixco.js
+++ b/res/controllers/mixco/novation_twitch.mixco.js
@@ -5,7 +5,7 @@
 // > - **View me [on a static web](http://sinusoid.es/mixco/script/novation_twitch.mixco.html)**
 // > - **View me [on GitHub](https://github.com/arximboldi/mixco/blob/master/script/novation_twitch.mixco.litcoffee)**
 //
-// Mixx script file for the **Novation Twitch** controller.
+// Mixxx script file for the **Novation Twitch** controller.
 //
 // This script serves as **tutorial** for creating scripts using the
 // *Mixco* framework, but programming directly in JavaScript.  Still,

--- a/res/controllers/novation_twitch.mixco.output.js
+++ b/res/controllers/novation_twitch.mixco.output.js
@@ -5860,7 +5860,7 @@ string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
 // > - **View me [on a static web](http://sinusoid.es/mixco/script/novation_twitch.mixco.html)**
 // > - **View me [on GitHub](https://github.com/arximboldi/mixco/blob/master/script/novation_twitch.mixco.litcoffee)**
 //
-// Mixx script file for the **Novation Twitch** controller.
+// Mixxx script file for the **Novation Twitch** controller.
 //
 // This script serves as **tutorial** for creating scripts using the
 // *Mixco* framework, but programming directly in JavaScript.  Still,

--- a/res/schema.xml
+++ b/res/schema.xml
@@ -472,7 +472,7 @@ METADATA
     <sql>
       <!-- No Color becomes Orange (not in default palette) -->
       UPDATE cues SET color=0xFF8C00 WHERE color=0;
-      <!-- Mixx Hotcue Color Palette (also defined in src/util/color/colorpalette.h) -->
+      <!-- Mixxx Hotcue Color Palette (also defined in src/util/color/colorpalette.h) -->
       <!-- Red -->
       UPDATE cues SET color=0xC50A08 WHERE color=1;
       <!-- Green -->

--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -989,7 +989,7 @@ void PlaylistDAO::shuffleTracks(const int playlistId, const QList<int>& position
         // TODO: The following use of QList<T>::swap(int, int) is deprecated
         // and should be replaced with QList<T>::swapItemsAt(int, int)
         // However, the proposed alternative has just been introduced in Qt
-        // 5.13. Until the minimum required Qt version of Mixx is increased,
+        // 5.13. Until the minimum required Qt version of Mixxx is increased,
         // we need a version check here.
         #if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
         newPositions.swap(newPositions.indexOf(trackAPosition),

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -750,7 +750,7 @@ void TrackDAO::afterHidingTracks(
     // TODO: QSet<T>::fromList(const QList<T>&) is deprecated and should be
     // replaced with QSet<T>(list.begin(), list.end()).
     // However, the proposed alternative has just been introduced in Qt
-    // 5.14. Until the minimum required Qt version of Mixx is increased,
+    // 5.14. Until the minimum required Qt version of Mixxx is increased,
     // we need a version check here
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     emit tracksRemoved(QSet<TrackId>(trackIds.begin(), trackIds.end()));
@@ -783,7 +783,7 @@ void TrackDAO::afterUnhidingTracks(
     // TODO: QSet<T>::fromList(const QList<T>&) is deprecated and should be
     // replaced with QSet<T>(list.begin(), list.end()).
     // However, the proposed alternative has just been introduced in Qt
-    // 5.14. Until the minimum required Qt version of Mixx is increased,
+    // 5.14. Until the minimum required Qt version of Mixxx is increased,
     // we need a version check here
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     emit tracksAdded(QSet<TrackId>(trackIds.begin(), trackIds.end()));
@@ -902,7 +902,7 @@ void TrackDAO::afterPurgingTracks(
     // TODO: QSet<T>::fromList(const QList<T>&) is deprecated and should be
     // replaced with QSet<T>(list.begin(), list.end()).
     // However, the proposed alternative has just been introduced in Qt
-    // 5.14. Until the minimum required Qt version of Mixx is increased,
+    // 5.14. Until the minimum required Qt version of Mixxx is increased,
     // we need a version check here
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     QSet<TrackId> tracksRemovedSet = QSet<TrackId>(trackIds.begin(), trackIds.end());

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -571,7 +571,7 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
     // TODO: QSet<T>::fromList(const QList<T>&) is deprecated and should be
     // replaced with QSet<T>(list.begin(), list.end()).
     // However, the proposed alternative has just been introduced in Qt
-    // 5.14. Until the minimum required Qt version of Mixx is increased,
+    // 5.14. Until the minimum required Qt version of Mixxx is increased,
     // we need a version check here
     QSet<QString> prev_plugins =
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)

--- a/src/util/compatibility.h
+++ b/src/util/compatibility.h
@@ -133,7 +133,7 @@ inline T atomicLoadAcquire(const QAtomicInteger<T>& atomicInt) {
     // TODO: QBasicAtomicInteger<T>::load() is deprecated and should be
     // replaced with QBasicAtomicInteger<T>::loadRelaxed() However, the
     // proposed alternative has just been introduced in Qt 5.14. Until the
-    // minimum required Qt version of Mixx is increased, we need a version
+    // minimum required Qt version of Mixxx is increased, we need a version
     // check here
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     return atomicInt.loadAcquire();
@@ -147,7 +147,7 @@ inline T* atomicLoadAcquire(const QAtomicPointer<T>& atomicPtr) {
     // TODO: QBasicAtomicPointer<T>::load() is deprecated and should be
     // replaced with QBasicAtomicPointer<T>::loadRelaxed() However, the
     // proposed alternative has just been introduced in Qt 5.14. Until the
-    // minimum required Qt version of Mixx is increased, we need a version
+    // minimum required Qt version of Mixxx is increased, we need a version
     // check here
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     return atomicPtr.loadAcquire();
@@ -161,7 +161,7 @@ inline T atomicLoadRelaxed(const QAtomicInteger<T>& atomicInt) {
     // TODO: QBasicAtomicInteger<T>::load() is deprecated and should be
     // replaced with QBasicAtomicInteger<T>::loadRelaxed() However, the
     // proposed alternative has just been introduced in Qt 5.14. Until the
-    // minimum required Qt version of Mixx is increased, we need a version
+    // minimum required Qt version of Mixxx is increased, we need a version
     // check here
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     return atomicInt.loadRelaxed();
@@ -175,7 +175,7 @@ inline T* atomicLoadRelaxed(const QAtomicPointer<T>& atomicPtr) {
     // TODO: QBasicAtomicPointer<T>::load() is deprecated and should be
     // replaced with QBasicAtomicPointer<T>::loadRelaxed() However, the
     // proposed alternative has just been introduced in Qt 5.14. Until the
-    // minimum required Qt version of Mixx is increased, we need a version
+    // minimum required Qt version of Mixxx is increased, we need a version
     // check here
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     return atomicPtr.loadRelaxed();
@@ -189,7 +189,7 @@ inline void atomicStoreRelaxed(QAtomicInteger<T>& atomicInt, T newValue) {
     // TODO: QBasicAtomicInteger<T>::store(T newValue) is deprecated and should
     // be replaced with QBasicAtomicInteger<T>::storeRelaxed(T newValue)
     // However, the proposed alternative has just been introduced in Qt 5.14.
-    // Until the minimum required Qt version of Mixx is increased, we need a
+    // Until the minimum required Qt version of Mixxx is increased, we need a
     // version check here
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     atomicInt.storeRelaxed(newValue);
@@ -203,7 +203,7 @@ inline void atomicStoreRelaxed(QAtomicPointer<T>& atomicPtr, T* newValue) {
     // TODO: QBasicAtomicPointer<T>::store(T* newValue) is deprecated and
     // should be replaced with QBasicAtomicPointer<T>::storeRelaxed(T*
     // newValue) However, the proposed alternative has just been introduced in
-    // Qt 5.14. Until the minimum required Qt version of Mixx is increased, we
+    // Qt 5.14. Until the minimum required Qt version of Mixxx is increased, we
     // need a version check here
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     atomicPtr.storeRelaxed(newValue);

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -1183,7 +1183,7 @@ void WOverview::paintText(const QString& text, QPainter* pPainter) {
     // is deprecated and should be replaced with
     // QFontMetrics::horizontalAdvance(const QString&, int) const. However, the
     // proposed alternative has just been introduced in Qt 5.11.
-    // Until the minimum required Qt version of Mixx is increased, we need a
+    // Until the minimum required Qt version of Mixxx is increased, we need a
     // version check here.
     #if (QT_VERSION < QT_VERSION_CHECK(5, 11, 0))
     int textWidth = fm.width(text);

--- a/tools/qsscheck.py
+++ b/tools/qsscheck.py
@@ -228,7 +228,7 @@ def get_skins(path):
 
 
 def get_global_names(mixxx_path):
-    """Returns 2 sets with all class and object names in the Mixx codebase."""
+    """Returns 2 sets with all class and object names in the Mixxx codebase."""
     classnames = set()
     objectnames = set()
     for root, dirs, fnames in os.walk(os.path.join(mixxx_path, "src")):


### PR DESCRIPTION
Trivial fixes in code comments. CI builds could be aborted.

- Not in translations which are pulled from Transifex
- Disabled pre-commit hooks to avoid mass-reformatting

Add this common typo to codespell dictionary somehow?