### PR TITLE
Improve DirectoryDAOTest::relocateDirectory()

### DIFF
--- a/src/test/directorydaotest.cpp
+++ b/src/test/directorydaotest.cpp
@@ -138,11 +138,11 @@ TEST_F(DirectoryDAOTest, relocateDirectory) {
     ASSERT_TRUE(tempDir2.isValid());
 
     //create temp dirs
-    QString testdir(tempDir1.path() + "/TestDir");
+    QString testdir(tempDir1.filePath("TestDir"));
     ASSERT_TRUE(QDir(tempDir1.path()).mkpath(testdir));
-    QString test2(tempDir2.path() + "/TestDir2");
+    QString test2(tempDir2.filePath("TestDir2"));
     ASSERT_TRUE(QDir(tempDir2.path()).mkpath(test2));
-    QString testnew(tempDir2.path() + "/TestDirNew");
+    QString testnew(tempDir2.filePath("TestDirNew"));
     ASSERT_TRUE(QDir(tempDir2.path()).mkpath(testnew));
 
     const DirectoryDAO& dao = internalCollection()->getDirectoryDAO();

--- a/src/test/directorydaotest.cpp
+++ b/src/test/directorydaotest.cpp
@@ -130,16 +130,25 @@ TEST_F(DirectoryDAOTest, getDirTest) {
     EXPECT_QSTRING_EQ(testdir2, dirs.at(1));
 }
 
-TEST_F(DirectoryDAOTest, relocateDirTest) {
-    DirectoryDAO& directoryDao = internalCollection()->getDirectoryDAO();
+TEST_F(DirectoryDAOTest, relocateDirectory) {
+    // Test with 2 independent root directories for relocation
+    const QTemporaryDir tempDir1;
+    ASSERT_TRUE(tempDir1.isValid());
+    const QTemporaryDir tempDir2;
+    ASSERT_TRUE(tempDir2.isValid());
 
-    // use a temp dir so that we always use a real existing system path
-    QString testdir(QDir::tempPath() + "/TestDir");
-    QString test2(QDir::tempPath() + "/TestDir2");
-    QString testnew(QDir::tempPath() + "/TestDirNew");
+    //create temp dirs
+    QString testdir(tempDir1.path() + "/TestDir");
+    ASSERT_TRUE(QDir(tempDir1.path()).mkpath(testdir));
+    QString test2(tempDir2.path() + "/TestDir2");
+    ASSERT_TRUE(QDir(tempDir2.path()).mkpath(test2));
+    QString testnew(tempDir2.path() + "/TestDirNew");
+    ASSERT_TRUE(QDir(tempDir2.path()).mkpath(testnew));
 
-    directoryDao.addDirectory(testdir);
-    directoryDao.addDirectory(test2);
+    const DirectoryDAO& dao = internalCollection()->getDirectoryDAO();
+
+    ASSERT_EQ(ALL_FINE, dao.addDirectory(testdir));
+    ASSERT_EQ(ALL_FINE, dao.addDirectory(test2));
 
     // ok now lets create some tracks here
     ASSERT_TRUE(internalCollection()
@@ -168,10 +177,10 @@ TEST_F(DirectoryDAOTest, relocateDirTest) {
                         .isValid());
 
     QList<RelocatedTrack> relocatedTracks =
-            directoryDao.relocateDirectory(testdir, testnew);
+            dao.relocateDirectory(testdir, testnew);
     EXPECT_EQ(2, relocatedTracks.size());
 
-    QStringList dirs = directoryDao.getDirs();
-    EXPECT_EQ(2, dirs.size());
-    EXPECT_THAT(dirs, UnorderedElementsAre(test2, testnew));
+    const QStringList allDirs = dao.getDirs();
+    EXPECT_EQ(2, allDirs.size());
+    EXPECT_THAT(allDirs, UnorderedElementsAre(test2, testnew));
 }


### PR DESCRIPTION
As requested: https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/cmake.20on.20macOS/near/216786005

Not sure if this fixes the actual issues, but it already contains some changes from a future PR. If it doesn't fix the macOS issues it is still an improvement with additional checks during the test run.