### PR TITLE
Fix warnings on initialization of MIDI controller

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -749,6 +749,7 @@
         this.setCurrentUnit = function(newNumber) {
             this.currentUnitNumber = newNumber;
             this.group = "[EffectRack1_EffectUnit" + newNumber + "]";
+
             if (allowFocusWhenParametersHidden) {
                 engine.setValue(this.group, "show_focus", 0);
             } else {
@@ -866,6 +867,7 @@
         };
         this.EffectUnitKnob.prototype = new Pot({
             group: this.group,
+            number: this.currentUnitNumber,
             unshift: function() {
                 this.input = function(channel, control, value, _status, _group) {
                     if (this.MSB !== undefined) {

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -748,6 +748,7 @@
 
         this.setCurrentUnit = function(newNumber) {
             this.currentUnitNumber = newNumber;
+            this.group = "[EffectRack1_EffectUnit" + newNumber + "]";
             if (allowFocusWhenParametersHidden) {
                 engine.setValue(this.group, "show_focus", 0);
             } else {
@@ -757,8 +758,6 @@
                 delete this.previouslyFocusedEffect;
             }
             engine.setValue(this.group, "controller_input_active", 0);
-
-            this.group = "[EffectRack1_EffectUnit" + newNumber + "]";
 
             if (allowFocusWhenParametersHidden) {
                 engine.setValue(this.group, "show_focus", 1);


### PR DESCRIPTION
This pull request avoids the following warnings when a MIDI controller is initialized that contains effect unit controls:
* ```Warning [Controller]: ControlDoublePrivate::getControl returning NULL for ( "[EffectRack1_EffectUnit2_Effectundefined]" , "meta" )```
* ```Warning [Controller]: ControlDoublePrivate::getControl returning NULL for ( "" , "show_focus" )```
