### PR TITLE
library/searchqueryparser: Fix non-const global char pointer

### DIFF
--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -4,8 +4,8 @@
 
 #include "track/keyutils.h"
 
-const char* kNegatePrefix = "-";
-const char* kFuzzyPrefix = "~";
+constexpr char kNegatePrefix[] = "-";
+constexpr char kFuzzyPrefix[] = "~";
 
 SearchQueryParser::SearchQueryParser(TrackCollection* pTrackCollection)
     : m_pTrackCollection(pTrackCollection) {


### PR DESCRIPTION
This fixes a clazy warning:

    src/library/searchqueryparser.cpp:7:1: warning: non const global char * [-Wclazy-global-const-char-pointer]
    const char* kNegatePrefix = "-";
    ^
    src/library/searchqueryparser.cpp:8:1: warning: non const global char * [-Wclazy-global-const-char-pointer]
    const char* kFuzzyPrefix = "~";
    ^

See https://github.com/KDE/clazy/blob/master/docs/checks/README-global-const-char-pointer.md
for details