### PR TITLE
Use qobject_cast

### DIFF
--- a/src/controllers/controllerlearningeventfilter.cpp
+++ b/src/controllers/controllerlearningeventfilter.cpp
@@ -19,14 +19,14 @@ ControllerLearningEventFilter::~ControllerLearningEventFilter() {
 bool ControllerLearningEventFilter::eventFilter(QObject* pObject, QEvent* pEvent) {
     //qDebug() << "ControllerLearningEventFilter::eventFilter" << pObject << pEvent;
 
-    WWidget* pWidget = dynamic_cast<WWidget*>(pObject);
+    WWidget* pWidget = qobject_cast<WWidget*>(pObject);
     if (!pWidget || !m_bListening) {
         return false;
     }
 
-    WKnob* pKnob = dynamic_cast<WKnob*>(pObject);
-    WKnobComposed* pKnobComposed = dynamic_cast<WKnobComposed*>(pObject);
-    WSliderComposed* pSlider = dynamic_cast<WSliderComposed*>(pObject);
+    WKnob* pKnob = qobject_cast<WKnob*>(pObject);
+    WKnobComposed* pKnobComposed = qobject_cast<WKnobComposed*>(pObject);
+    WSliderComposed* pSlider = qobject_cast<WSliderComposed*>(pObject);
     bool has_right_click_reset = pKnob || pKnobComposed || pSlider;
 
     if (pEvent->type() == QEvent::KeyPress) {

--- a/src/controllers/delegates/controldelegate.cpp
+++ b/src/controllers/delegates/controldelegate.cpp
@@ -63,7 +63,7 @@ void ControlDelegate::setEditorData(QWidget* editor,
                                     const QModelIndex& index) const {
     ConfigKey key = index.data(Qt::EditRole).value<ConfigKey>();
 
-    QLineEdit* pLineEdit = dynamic_cast<QLineEdit*>(editor);
+    QLineEdit* pLineEdit = qobject_cast<QLineEdit*>(editor);
     if (pLineEdit == NULL) {
         return;
     }

--- a/src/controllers/delegates/midibytedelegate.cpp
+++ b/src/controllers/delegates/midibytedelegate.cpp
@@ -30,7 +30,7 @@ QString MidiByteDelegate::displayText(const QVariant& value,
 void MidiByteDelegate::setEditorData(QWidget* editor,
                                      const QModelIndex& index) const {
     int control = index.data(Qt::EditRole).toInt();
-    HexSpinBox* pSpinBox = dynamic_cast<HexSpinBox*>(editor);
+    HexSpinBox* pSpinBox = qobject_cast<HexSpinBox*>(editor);
     if (pSpinBox == NULL) {
         return;
     }
@@ -40,7 +40,7 @@ void MidiByteDelegate::setEditorData(QWidget* editor,
 void MidiByteDelegate::setModelData(QWidget* editor,
                                     QAbstractItemModel* model,
                                     const QModelIndex& index) const {
-    HexSpinBox* pSpinBox = dynamic_cast<HexSpinBox*>(editor);
+    HexSpinBox* pSpinBox = qobject_cast<HexSpinBox*>(editor);
     if (pSpinBox == NULL) {
         return;
     }

--- a/src/controllers/delegates/midichanneldelegate.cpp
+++ b/src/controllers/delegates/midichanneldelegate.cpp
@@ -34,7 +34,7 @@ QString MidiChannelDelegate::displayText(const QVariant& value,
 void MidiChannelDelegate::setEditorData(QWidget* editor,
                                         const QModelIndex& index) const {
     int channel = index.data(Qt::EditRole).toInt();
-    QSpinBox* pSpinBox = dynamic_cast<QSpinBox*>(editor);
+    QSpinBox* pSpinBox = qobject_cast<QSpinBox*>(editor);
     if (pSpinBox == NULL) {
         return;
     }
@@ -45,7 +45,7 @@ void MidiChannelDelegate::setEditorData(QWidget* editor,
 void MidiChannelDelegate::setModelData(QWidget* editor,
                                       QAbstractItemModel* model,
                                       const QModelIndex& index) const {
-    QSpinBox* pSpinBox = dynamic_cast<QSpinBox*>(editor);
+    QSpinBox* pSpinBox = qobject_cast<QSpinBox*>(editor);
     if (pSpinBox == NULL) {
         return;
     }

--- a/src/controllers/delegates/midiopcodedelegate.cpp
+++ b/src/controllers/delegates/midiopcodedelegate.cpp
@@ -40,7 +40,7 @@ QString MidiOpCodeDelegate::displayText(const QVariant& value,
 void MidiOpCodeDelegate::setEditorData(QWidget* editor,
                                        const QModelIndex& index) const {
     int opCode = index.data(Qt::EditRole).toInt();
-    QComboBox* pComboBox = dynamic_cast<QComboBox*>(editor);
+    QComboBox* pComboBox = qobject_cast<QComboBox*>(editor);
     if (pComboBox == NULL) {
         return;
     }
@@ -55,7 +55,7 @@ void MidiOpCodeDelegate::setEditorData(QWidget* editor,
 void MidiOpCodeDelegate::setModelData(QWidget* editor,
                                       QAbstractItemModel* model,
                                       const QModelIndex& index) const {
-    QComboBox* pComboBox = dynamic_cast<QComboBox*>(editor);
+    QComboBox* pComboBox = qobject_cast<QComboBox*>(editor);
     if (pComboBox == NULL) {
         return;
     }

--- a/src/controllers/delegates/midioptionsdelegate.cpp
+++ b/src/controllers/delegates/midioptionsdelegate.cpp
@@ -66,7 +66,7 @@ void MidiOptionsDelegate::setEditorData(QWidget* editor,
                                         const QModelIndex& index) const {
     MidiOptions options = index.data(Qt::EditRole).value<MidiOptions>();
 
-    QComboBox* pComboBox = dynamic_cast<QComboBox*>(editor);
+    QComboBox* pComboBox = qobject_cast<QComboBox*>(editor);
     if (pComboBox == NULL) {
         return;
     }

--- a/src/controllers/softtakeover.cpp
+++ b/src/controllers/softtakeover.cpp
@@ -32,7 +32,7 @@ SoftTakeoverCtrl::~SoftTakeoverCtrl() {
 }
 
 void SoftTakeoverCtrl::enable(ControlObject* control) {
-    ControlPotmeter* cpo = dynamic_cast<ControlPotmeter*>(control);
+    ControlPotmeter* cpo = qobject_cast<ControlPotmeter*>(control);
     if (cpo == NULL) {
         // softtakecover works only for continuous ControlPotmeter based COs
         return;

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -66,7 +66,7 @@ DlgAutoDJ::DlgAutoDJ(
             m_pTrackTableView,
             &WTrackTableView::setSelectedClick);
 
-    QBoxLayout* box = dynamic_cast<QBoxLayout*>(layout());
+    QBoxLayout* box = qobject_cast<QBoxLayout*>(layout());
     VERIFY_OR_DEBUG_ASSERT(box) { //Assumes the form layout is a QVBox/QHBoxLayout!
     } else {
         box->removeWidget(m_pTrackTablePlaceholder);

--- a/src/library/coverartdelegate.cpp
+++ b/src/library/coverartdelegate.cpp
@@ -119,7 +119,7 @@ void CoverArtDelegate::paintItem(
             return;
         }
         const double scaleFactor =
-                getDevicePixelRatioF(static_cast<QWidget*>(parent()));
+                getDevicePixelRatioF(qobject_cast<QWidget*>(parent()));
         QPixmap pixmap = m_pCache->tryLoadCover(this,
                 coverInfo,
                 static_cast<int>(option.rect.width() * scaleFactor),

--- a/src/library/dlganalysis.cpp
+++ b/src/library/dlganalysis.cpp
@@ -40,7 +40,7 @@ DlgAnalysis::DlgAnalysis(WLibrary* parent,
             this,
             &DlgAnalysis::trackSelected);
 
-    QBoxLayout* box = dynamic_cast<QBoxLayout*>(layout());
+    QBoxLayout* box = qobject_cast<QBoxLayout*>(layout());
     VERIFY_OR_DEBUG_ASSERT(box) { // Assumes the form layout is a QVBox/QHBoxLayout!
     } else {
         box->removeWidget(m_pTrackTablePlaceholder);

--- a/src/library/dlghidden.cpp
+++ b/src/library/dlghidden.cpp
@@ -24,7 +24,7 @@ DlgHidden::DlgHidden(
     m_pTrackTableView->installEventFilter(pKeyboard);
 
     // Install our own trackTable
-    QBoxLayout* box = dynamic_cast<QBoxLayout*>(layout());
+    QBoxLayout* box = qobject_cast<QBoxLayout*>(layout());
     VERIFY_OR_DEBUG_ASSERT(box) { //Assumes the form layout is a QVBox/QHBoxLayout!
     } else {
         box->removeWidget(m_pTrackTablePlaceholder);

--- a/src/library/dlgmissing.cpp
+++ b/src/library/dlgmissing.cpp
@@ -24,7 +24,7 @@ DlgMissing::DlgMissing(
     m_pTrackTableView->installEventFilter(pKeyboard);
 
     // Install our own trackTable
-    QBoxLayout* box = dynamic_cast<QBoxLayout*>(layout());
+    QBoxLayout* box = qobject_cast<QBoxLayout*>(layout());
     VERIFY_OR_DEBUG_ASSERT(box) { //Assumes the form layout is a QVBox/QHBoxLayout!
     } else {
         box->removeWidget(m_pTrackTablePlaceholder);

--- a/src/library/previewbuttondelegate.h
+++ b/src/library/previewbuttondelegate.h
@@ -74,7 +74,7 @@ class PreviewButtonDelegate : public TableItemDelegate {
 
   private:
     QTableView* parentTableView() const {
-        return static_cast<QTableView*>(parent());
+        return qobject_cast<QTableView*>(parent());
     }
     bool isPreviewDeckPlaying() const;
     bool isTrackLoadedInPreviewDeck(

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -69,7 +69,7 @@ DlgRecording::DlgRecording(
             this,
             &DlgRecording::slotDurationRecorded);
 
-    QBoxLayout* box = dynamic_cast<QBoxLayout*>(layout());
+    QBoxLayout* box = qobject_cast<QBoxLayout*>(layout());
     VERIFY_OR_DEBUG_ASSERT(box) { //Assumes the form layout is a QVBox/QHBoxLayout!
     } else {
         box->removeWidget(m_pTrackTablePlaceholder);

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -531,7 +531,7 @@ DlgPreferencePage* DlgPreferences::currentPage() {
         }
         pObject = children[0];
     }
-    return dynamic_cast<DlgPreferencePage*>(pObject);
+    return qobject_cast<DlgPreferencePage*>(pObject);
 }
 
 void DlgPreferences::removePageWidget(DlgPreferencePage* pWidget) {

--- a/src/util/compatibility.h
+++ b/src/util/compatibility.h
@@ -107,7 +107,7 @@ QString uuidToNullableStringWithoutBraces(const QUuid& uuid) {
 
 inline QScreen* getPrimaryScreen() {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
-    QGuiApplication* app = static_cast<QGuiApplication*>(QCoreApplication::instance());
+    QGuiApplication* app = qobject_cast<QGuiApplication*>(QCoreApplication::instance());
     VERIFY_OR_DEBUG_ASSERT(app) {
         qWarning() << "Unable to get applications QCoreApplication instance, "
                       "cannot determine primary screen!";

--- a/src/util/taskmonitor.cpp
+++ b/src/util/taskmonitor.cpp
@@ -31,9 +31,8 @@ TaskMonitor::~TaskMonitor() {
 
 Task* TaskMonitor::senderTask() const {
     DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
-    auto* pTask = static_cast<Task*>(sender());
+    auto* pTask = qobject_cast<Task*>(sender());
     DEBUG_ASSERT(pTask);
-    DEBUG_ASSERT(dynamic_cast<Task*>(sender()));
     return pTask;
 }
 

--- a/src/util/widgethelper.h
+++ b/src/util/widgethelper.h
@@ -39,7 +39,7 @@ inline QScreen* getScreen(
     if (!pWindow && widget.parent()) {
         // The window might still be hidden and invisible. Then we
         // try to obtain the screen from its parent recursively.
-        return getScreen(*static_cast<QWidget*>(widget.parent()));
+        return getScreen(*qobject_cast<QWidget*>(widget.parent()));
     }
     if (!pWindow) {
         // This might happen if the widget is not yet displayed

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -46,10 +46,10 @@ bool shouldRenderWaveform(WaveformWidgetAbstract* pWaveformWidget) {
         return false;
     }
 
-    auto glw = dynamic_cast<QGLWidget*>(pWaveformWidget->getWidget());
+    auto* glw = qobject_cast<QGLWidget*>(pWaveformWidget->getWidget());
     if (glw == nullptr) {
         // Not a QGLWidget. We can simply use QWidget::isVisible.
-        auto qwidget = dynamic_cast<QWidget*>(pWaveformWidget->getWidget());
+        auto qwidget = qobject_cast<QWidget*>(pWaveformWidget->getWidget());
         return qwidget != nullptr && qwidget->isVisible();
     }
 
@@ -711,7 +711,7 @@ void WaveformWidgetFactory::swap() {
                 if (!shouldRenderWaveform(pWaveformWidget)) {
                     continue;
                 }
-                QGLWidget* glw = dynamic_cast<QGLWidget*>(pWaveformWidget->getWidget());
+                QGLWidget* glw = qobject_cast<QGLWidget*>(pWaveformWidget->getWidget());
                 if (glw != nullptr) {
                     glw->swapBuffers();
                 }

--- a/src/waveform/widgets/emptywaveformwidget.cpp
+++ b/src/waveform/widgets/emptywaveformwidget.cpp
@@ -21,7 +21,7 @@ EmptyWaveformWidget::~EmptyWaveformWidget() {
 }
 
 void EmptyWaveformWidget::castToQWidget() {
-    m_widget = static_cast<QWidget*>(this);
+    m_widget = this;
 }
 
 void EmptyWaveformWidget::paintEvent(QPaintEvent* event) {

--- a/src/waveform/widgets/glrgbwaveformwidget.cpp
+++ b/src/waveform/widgets/glrgbwaveformwidget.cpp
@@ -45,7 +45,7 @@ GLRGBWaveformWidget::~GLRGBWaveformWidget() {
 }
 
 void GLRGBWaveformWidget::castToQWidget() {
-    m_widget = static_cast<QWidget*>(static_cast<QGLWidget*>(this));
+    m_widget = this;
 }
 
 void GLRGBWaveformWidget::paintEvent(QPaintEvent* event) {

--- a/src/waveform/widgets/glsimplewaveformwidget.cpp
+++ b/src/waveform/widgets/glsimplewaveformwidget.cpp
@@ -47,7 +47,7 @@ GLSimpleWaveformWidget::~GLSimpleWaveformWidget() {
 }
 
 void GLSimpleWaveformWidget::castToQWidget() {
-    m_widget = static_cast<QWidget*>(static_cast<QGLWidget*>(this));
+    m_widget = this;
 }
 
 void GLSimpleWaveformWidget::paintEvent(QPaintEvent* event) {

--- a/src/waveform/widgets/glvsynctestwidget.cpp
+++ b/src/waveform/widgets/glvsynctestwidget.cpp
@@ -50,7 +50,7 @@ GLVSyncTestWidget::~GLVSyncTestWidget() {
 }
 
 void GLVSyncTestWidget::castToQWidget() {
-    m_widget = static_cast<QWidget*>(static_cast<QGLWidget*>(this));
+    m_widget = this;
 }
 
 void GLVSyncTestWidget::paintEvent(QPaintEvent* event) {

--- a/src/waveform/widgets/glwaveformwidget.cpp
+++ b/src/waveform/widgets/glwaveformwidget.cpp
@@ -47,7 +47,7 @@ GLWaveformWidget::~GLWaveformWidget() {
 }
 
 void GLWaveformWidget::castToQWidget() {
-    m_widget = static_cast<QWidget*>(static_cast<QGLWidget*>(this));
+    m_widget = this;
 }
 
 void GLWaveformWidget::paintEvent(QPaintEvent* event) {

--- a/src/waveform/widgets/hsvwaveformwidget.cpp
+++ b/src/waveform/widgets/hsvwaveformwidget.cpp
@@ -32,7 +32,7 @@ HSVWaveformWidget::~HSVWaveformWidget() {
 }
 
 void HSVWaveformWidget::castToQWidget() {
-    m_widget = static_cast<QWidget*>(this);
+    m_widget = this;
 }
 
 void HSVWaveformWidget::paintEvent(QPaintEvent* event) {

--- a/src/waveform/widgets/qthsvwaveformwidget.cpp
+++ b/src/waveform/widgets/qthsvwaveformwidget.cpp
@@ -37,7 +37,7 @@ QtHSVWaveformWidget::~QtHSVWaveformWidget() {
 }
 
 void QtHSVWaveformWidget::castToQWidget() {
-    m_widget = static_cast<QWidget*>(static_cast<QGLWidget*>(this));
+    m_widget = this;
 }
 
 void QtHSVWaveformWidget::paintEvent(QPaintEvent* event) {

--- a/src/waveform/widgets/qtrgbwaveformwidget.cpp
+++ b/src/waveform/widgets/qtrgbwaveformwidget.cpp
@@ -44,7 +44,7 @@ QtRGBWaveformWidget::~QtRGBWaveformWidget() {
 }
 
 void QtRGBWaveformWidget::castToQWidget() {
-    m_widget = static_cast<QWidget*>(static_cast<QGLWidget*>(this));
+    m_widget = this;
 }
 
 void QtRGBWaveformWidget::paintEvent(QPaintEvent* event) {

--- a/src/waveform/widgets/qtsimplewaveformwidget.cpp
+++ b/src/waveform/widgets/qtsimplewaveformwidget.cpp
@@ -47,7 +47,7 @@ QtSimpleWaveformWidget::~QtSimpleWaveformWidget() {
 }
 
 void QtSimpleWaveformWidget::castToQWidget() {
-    m_widget = static_cast<QWidget*>(static_cast<QGLWidget*>(this));
+    m_widget = this;
 }
 
 void QtSimpleWaveformWidget::paintEvent(QPaintEvent* event) {

--- a/src/waveform/widgets/qtvsynctestwidget.cpp
+++ b/src/waveform/widgets/qtvsynctestwidget.cpp
@@ -40,7 +40,7 @@ QtVSyncTestWidget::~QtVSyncTestWidget() {
 }
 
 void QtVSyncTestWidget::castToQWidget() {
-    m_widget = static_cast<QWidget*>(static_cast<QGLWidget*>(this));
+    m_widget = this;
 }
 
 void QtVSyncTestWidget::paintEvent(QPaintEvent* event) {

--- a/src/waveform/widgets/qtwaveformwidget.cpp
+++ b/src/waveform/widgets/qtwaveformwidget.cpp
@@ -46,7 +46,7 @@ QtWaveformWidget::~QtWaveformWidget() {
 }
 
 void QtWaveformWidget::castToQWidget() {
-    m_widget = static_cast<QWidget*>(static_cast<QGLWidget*>(this));
+    m_widget = this;
 }
 
 void QtWaveformWidget::paintEvent(QPaintEvent* event) {

--- a/src/waveform/widgets/rgbwaveformwidget.cpp
+++ b/src/waveform/widgets/rgbwaveformwidget.cpp
@@ -32,7 +32,7 @@ RGBWaveformWidget::~RGBWaveformWidget() {
 }
 
 void RGBWaveformWidget::castToQWidget() {
-    m_widget = static_cast<QWidget*>(this);
+    m_widget = this;
 }
 
 void RGBWaveformWidget::paintEvent(QPaintEvent* event) {

--- a/src/waveform/widgets/softwarewaveformwidget.cpp
+++ b/src/waveform/widgets/softwarewaveformwidget.cpp
@@ -32,7 +32,7 @@ SoftwareWaveformWidget::~SoftwareWaveformWidget() {
 }
 
 void SoftwareWaveformWidget::castToQWidget() {
-    m_widget = static_cast<QWidget*>(this);
+    m_widget = this;
 }
 
 void SoftwareWaveformWidget::paintEvent(QPaintEvent* event) {

--- a/src/widget/hexspinbox.h
+++ b/src/widget/hexspinbox.h
@@ -5,8 +5,9 @@
 #include <QValidator>
 
 class HexSpinBox : public QSpinBox {
+    Q_OBJECT
   public:
-    explicit HexSpinBox(QWidget *pParent);
+    explicit HexSpinBox(QWidget* pParent);
 
   protected:
     QString textFromValue(int value) const override;

--- a/src/widget/wbeatspinbox.cpp
+++ b/src/widget/wbeatspinbox.cpp
@@ -40,7 +40,7 @@ WBeatSpinBox::WBeatSpinBox(QWidget* parent,
 void WBeatSpinBox::setup(const QDomNode& node, const SkinContext& context) {
     Q_UNUSED(node);
     m_scaleFactor = context.getScaleFactor();
-    static_cast<WBeatLineEdit*>(lineEdit())->setScaleFactor(m_scaleFactor);
+    qobject_cast<WBeatLineEdit*>(lineEdit())->setScaleFactor(m_scaleFactor);
 }
 
 void WBeatSpinBox::stepBy(int steps) {

--- a/src/widget/wcolorpicker.cpp
+++ b/src/widget/wcolorpicker.cpp
@@ -74,7 +74,7 @@ WColorPicker::WColorPicker(Options options, const ColorPalette& palette, QWidget
 }
 
 void WColorPicker::removeColorButtons() {
-    QGridLayout* pLayout = static_cast<QGridLayout*>(layout());
+    QGridLayout* pLayout = qobject_cast<QGridLayout*>(layout());
     VERIFY_OR_DEBUG_ASSERT(pLayout) {
         qWarning() << "Color Picker has no layout!";
         return;
@@ -100,7 +100,7 @@ void WColorPicker::removeColorButtons() {
 }
 
 void WColorPicker::addColorButtons() {
-    QGridLayout* pLayout = static_cast<QGridLayout*>(layout());
+    QGridLayout* pLayout = qobject_cast<QGridLayout*>(layout());
     VERIFY_OR_DEBUG_ASSERT(pLayout) {
         qWarning() << "Color Picker has no layout!";
         return;

--- a/src/widget/wcuemenupopup.h
+++ b/src/widget/wcuemenupopup.h
@@ -32,7 +32,7 @@ class WCueMenuPopup : public QWidget {
     }
 
     void popup(const QPoint& p) {
-        auto parentWidget = static_cast<QWidget*>(parent());
+        auto parentWidget = qobject_cast<QWidget*>(parent());
         QPoint topLeft = mixxx::widgethelper::mapPopupToScreen(*parentWidget, p, size());
         move(topLeft);
         show();

--- a/src/widget/wlibrary.cpp
+++ b/src/widget/wlibrary.cpp
@@ -53,8 +53,8 @@ void WLibrary::switchToView(const QString& name) {
     QMutexLocker lock(&m_mutex);
     //qDebug() << "WLibrary::switchToView" << name;
 
-    WTrackTableView* ttView = dynamic_cast<WTrackTableView*>(
-                currentWidget());
+    WTrackTableView* ttView = qobject_cast<WTrackTableView*>(
+            currentWidget());
 
     if (ttView != nullptr){
         //qDebug("trying to save position");
@@ -76,8 +76,8 @@ void WLibrary::switchToView(const QString& name) {
             lview->onShow();
         }
 
-        WTrackTableView* ttWidgetView = dynamic_cast<WTrackTableView*>(
-                    widget);
+        WTrackTableView* ttWidgetView = qobject_cast<WTrackTableView*>(
+                widget);
 
         if (ttWidgetView != nullptr){
             qDebug("trying to restore position");

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -77,7 +77,7 @@ void WLibrarySidebar::dragMoveEvent(QDragMoveEvent * event) {
             // Do nothing.
             event->ignore();
         } else {
-            SidebarModel* sidebarModel = dynamic_cast<SidebarModel*>(model());
+            SidebarModel* sidebarModel = qobject_cast<SidebarModel*>(model());
             bool accepted = true;
             if (sidebarModel) {
                 accepted = false;
@@ -134,7 +134,7 @@ void WLibrarySidebar::dropEvent(QDropEvent * event) {
             //this->selectionModel()->clear();
             //Drag-and-drop from an external application or the track table widget
             //eg. dragging a track from Windows Explorer onto the sidebar
-            SidebarModel* sidebarModel = dynamic_cast<SidebarModel*>(model());
+            SidebarModel* sidebarModel = qobject_cast<SidebarModel*>(model());
             if (sidebarModel) {
                 QModelIndex destIndex = indexAt(event->pos());
                 // event->source() will return NULL if something is dropped from
@@ -173,7 +173,7 @@ bool WLibrarySidebar::isLeafNodeSelected() {
         if(!index.model()->hasChildren(index)) {
             return true;
         }
-        const SidebarModel* sidebarModel = dynamic_cast<const SidebarModel*>(index.model());
+        const SidebarModel* sidebarModel = qobject_cast<const SidebarModel*>(index.model());
         if (sidebarModel) {
             return sidebarModel->hasTrackTable(index);
         }

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -162,7 +162,7 @@ void WPushButton::setup(const QDomNode& node, const SkinContext& context) {
         m_leftButtonMode = ControlPushButton::PUSH;
         if (!leftClickForcePush) {
             const ConfigKey& configKey = leftConnection->getKey();
-            ControlPushButton* p = dynamic_cast<ControlPushButton*>(
+            ControlPushButton* p = qobject_cast<ControlPushButton*>(
                     ControlObject::getControl(configKey));
             if (p) {
                 m_leftButtonMode = p->getButtonMode();
@@ -205,7 +205,7 @@ void WPushButton::setup(const QDomNode& node, const SkinContext& context) {
         m_rightButtonMode = ControlPushButton::PUSH;
         if (!rightClickForcePush) {
             const ConfigKey configKey = rightConnection->getKey();
-            ControlPushButton* p = dynamic_cast<ControlPushButton*>(
+            ControlPushButton* p = qobject_cast<ControlPushButton*>(
                     ControlObject::getControl(configKey));
             if (p) {
                 m_rightButtonMode = p->getButtonMode();

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -73,7 +73,7 @@ WTrackTableView::WTrackTableView(QWidget* parent,
 
 WTrackTableView::~WTrackTableView() {
     WTrackTableViewHeader* pHeader =
-            dynamic_cast<WTrackTableViewHeader*>(horizontalHeader());
+            qobject_cast<WTrackTableViewHeader*>(horizontalHeader());
     if (pHeader) {
         pHeader->saveHeaderState();
     }
@@ -170,7 +170,7 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel* model) {
 
     // Save the previous track model's header state
     WTrackTableViewHeader* oldHeader =
-            dynamic_cast<WTrackTableViewHeader*>(horizontalHeader());
+            qobject_cast<WTrackTableViewHeader*>(horizontalHeader());
     if (oldHeader) {
         oldHeader->saveHeaderState();
     }


### PR DESCRIPTION
Straightforward replacements and removals:
- Replace `dynamic_cast`/`static_cast` with `qobject_cast`
- Delete redundant casts

I do **not** plan to refactor the waveform widgets and only removed some redundant casts! The code seems to be more complicated than it needs to be.