### PR TITLE
Fix play indicator visibility during play state

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -1593,8 +1593,7 @@ WPushButton {
     font-weight: bold;
 }
 
-WPushButton:hover,
-#PlayToggle:hover {
+WPushButton:hover {
     color: #D2D2D2;
     background-color: #5F5F5F;
     border: 1px solid #5F5F5F;
@@ -1602,16 +1601,14 @@ WPushButton:hover,
 
 /*"Pressed" state*/
 WPushButton[value="1"],
-WPushButton[value="2"],
-#PlayToggle[value="1"] {
+WPushButton[value="2"] {
     color: #FDFDFD;
     background-color: #006596;
     border: 1px solid #006596;
 }
 
 WPushButton[value="1"]:hover,
-WPushButton[value="2"]:hover,
-#PlayToggle[value="1"]:hover {
+WPushButton[value="2"]:hover {
     color: #FDFDFD;
     background-color: #0080BE;
     border: 1px solid #0080BE;
@@ -1625,16 +1622,15 @@ WPushButton[value="2"]:hover,
     color: #1f1e1e;
 }
 
-#PlayToggle {
-  background-color: none;
-  border: 1px solid transparent;
-}
-
 #PlayToggle[value="0"] {
+  background-color:  transparent;
+  border-color: transparent;
   image: url(skin:/icon/ic_play_48px.svg) no-repeat center center;
 }
 
 #PlayToggle[value="1"] {
+  background-color:  transparent;
+  border-color: transparent;
   image: url(skin:/icon/ic_pause_48px.svg) no-repeat center center;
 }
 

--- a/res/skins/LateNight/decks/deck_mini.xml
+++ b/res/skins/LateNight/decks/deck_mini.xml
@@ -60,7 +60,7 @@
                     <Layout>stacked</Layout>
                     <Size>42f,26f</Size>
                     <Children>
-                      <Template src="skin:/controls/button_2state_right_display.xml">
+                      <Template src="skin:/controls/button_2state_right.xml">
                         <SetVariable name="TooltipId">play_cue_default</SetVariable>
                         <SetVariable name="ObjectName">PlayDeckMini</SetVariable>
                         <SetVariable name="Size">42f,26f</SetVariable>

--- a/res/skins/LateNight/decks/row_5_transportLoopJump.xml
+++ b/res/skins/LateNight/decks/row_5_transportLoopJump.xml
@@ -71,22 +71,15 @@
                 <Layout>stacked</Layout>
                 <Size>68f,26f</Size>
                 <Children>
-                  <Template src="skin:/controls/button_2state_right.xml">
+                  <Template src="skin:/controls/button_2state_right_display.xml">
                     <SetVariable name="TooltipId">play_cue_set</SetVariable>
                     <SetVariable name="ObjectName">PlayDeck</SetVariable>
                     <SetVariable name="Size">68f,26f</SetVariable>
                     <SetVariable name="BtnSize">play</SetVariable>
                     <SetVariable name="ConfigKey"><Variable name="Group"/>,play</SetVariable>
                     <SetVariable name="ConfigKeyRight"><Variable name="Group"/>,cue_set</SetVariable>
+                    <SetVariable name="ConfigKeyDisp"><Variable name="Group"/>,play_indicator</SetVariable>
                   </Template>
-                  <PushButton>
-                    <ObjectName>PlayIndicator</ObjectName>
-                    <Size>68f,26f</Size>
-                    <NumberStates>2</NumberStates>
-                    <Connection>
-                      <ConfigKey><Variable name="Group"/>,play_indicator</ConfigKey>
-                    </Connection>
-                  </PushButton>
                   <WidgetGroup>
                     <ObjectName>PlayBg</ObjectName>
                     <Size>68f,26f</Size>

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -1302,7 +1302,7 @@ QPushButton#pushButtonRecording:checked {
 #BeatgridControls WPushButton, #BeatgridControlsToggle,
 #DeckRow_5_LoopCuesTransport WPushButton,
 #PlayDeck, #PlayIndicator, #PlayBg,
-#CueDeck, #PlayCueMini WPushButton,
+#CueDeck,
 #LoopActivate,
 #RateControls WPushButton, #SyncDeck,
 #MixerContainer WPushButton,
@@ -1336,7 +1336,7 @@ WPushButton#FxExpandOverlay,
 /************** button background colors **************************************/
 #BeatgridControls WPushButton[displayValue="0"],
 #DeckRow_5_LoopCuesTransport WPushButton[displayValue="0"],
-#PlayBg, #PlayCueMini WPushButton[displayValue="0"],
+#PlayBg,
 #CueDeck[displayValue="0"], #LoopActivate[displayValue="0"],
 #FxAssignButtons WPushButton[displayValue="0"],
 #VinylControls WPushButton[displayValue="0"],
@@ -1366,7 +1366,6 @@ QPushButton#pushButtonAutoDJ:enabled:!checked,
 #RateControls WPushButton[value="1"],
 #SyncDeck[value="1"], #SyncSampler[displayValue="1"],
 WPushButton#PlayDeck[displayValue="1"],
-WPushButton#PlayDeckMini[displayValue="1"],
 #PlaySampler[displayValue="1"], #PlayPreview[displayValue="1"],
 WPushButton#PlayIndicator[displayValue="1"],
 #LibraryPreviewButton:checked,
@@ -1513,7 +1512,6 @@ QPushButton#pushButtonAutoDJ:checked,
 
 /* Special flat buttons */
 WPushButton#PlayDeck[displayValue="0"],
-WPushButton#PlayDeckMini[displayValue="0"],
 WPushButton#PlayIndicator[value="0"],
 WPushButton#BpmTap[displayValue="0"],
 WPushButton#FxFocusButton[displayValue="0"],
@@ -1534,13 +1532,13 @@ WPushButton#SamplerExpand[displayValue="0"],
   image: url(skin:/classic/buttons/btn__play_deck.svg) no-repeat center center;
 }
 
-#PlayDeckMini[value="0"] {
+#PlayDeckMini[displayValue="0"] {
   image: url(skin:/classic/buttons/btn__play_deck_mini.svg) no-repeat center center;
   }
-  #PlayDeckMini[value="1"] {
+  #PlayDeckMini[displayValue="1"] {
     image: url(skin:/classic/buttons/btn__pause_deck_mini.svg) no-repeat center center;
   }
-#PlaySampler[value="0"],
+#PlaySampler[displayValue="0"],
 #PlayPreview[displayValue="0"] {
   image: url(skin:/classic/buttons/btn__play_sampler.svg) no-repeat center center;
   }

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -1520,7 +1520,7 @@ WEffectSelector,
 #BeatgridControls WPushButton, #BeatgridControlsToggle,
 #DeckRow_5_LoopCuesTransport WPushButton,
 #PlayDeck, #PlayIndicator, #PlayBg,
-#CueDeck, #PlayCueMini WPushButton,
+#CueDeck,
 #LoopActivate,
 #RateControls WPushButton,
 #SyncDeck, #SyncSampler,
@@ -1556,7 +1556,7 @@ WPushButton#CrossfaderButton,
 
 /* top-level buttons in transport, fx, micaux and others */
 #DeckRow_5_LoopCuesTransport WPushButton[displayValue="0"],
-#PlayBg, #PlayCueMini WPushButton[displayValue="0"],
+#PlayBg,
 #CueDeck[displayValue="0"], #LoopActivate[displayValue="0"],
 #KeyControls WPushButton[displayValue="0"],
 #EQKillButtonBox WPushButton[displayValue="0"],
@@ -1626,7 +1626,6 @@ WBeatSpinBox::down-button {
 
 /* Orange for 'active' status */
 WPushButton#PlayDeck[displayValue="1"],
-WPushButton#PlayDeckMini[displayValue="1"],
 WPushButton#PlaySampler[displayValue="1"],
 WPushButton#PlayPreview[displayValue="1"],
 WPushButton#PlayIndicator[displayValue="1"],
@@ -1804,7 +1803,6 @@ QPushButton#pushButtonRepeatPlaylist:checked {
 /* Special flat/invisible buttons */
 #BeatgridControlsToggle,
 WPushButton#PlayDeck[displayValue="0"],
-WPushButton#PlayDeckMini[displayValue="0"],
 WPushButton#PlayIndicator[value="0"],
 WPushButton#FxFocusButton[displayValue="0"],
 #SamplerSettings WPushButton[displayValue="0"],
@@ -1829,17 +1827,17 @@ WPushButton#RecButton[displayValue="1"],
     image: url(skin:/palemoon/buttons/btn__play_deck_active.svg) no-repeat center center;
   }
 
-#PlayDeckMini[value="0"] {
+#PlayDeckMini[displayValue="0"] {
   image: url(skin:/palemoon/buttons/btn__play_deck_mini.svg) no-repeat center center;
   }
-  #PlayDeckMini[value="1"] {
+  #PlayDeckMini[displayValue="1"] {
     image: url(skin:/palemoon/buttons/btn__pause_deck_mini.svg) no-repeat center center;
   }
-#PlaySampler[value="0"],
+#PlaySampler[displayValue="0"],
 #PlayPreview[displayValue="0"] {
   image: url(skin:/palemoon/buttons/btn__play_sampler.svg) no-repeat center center;
   }
-  #PlaySampler[value="1"],
+  #PlaySampler[displayValue="1"],
   #PlayPreview[displayValue="1"] {
     image: url(skin:/palemoon/buttons/btn__pause_sampler.svg) no-repeat center center;
   }

--- a/res/skins/Shade/deck_small.xml
+++ b/res/skins/Shade/deck_small.xml
@@ -180,30 +180,13 @@
                 <BackPath>style/style_bg_deck_blank.png</BackPath>
                 <Children>
                   <PushButton>
-                    <Pos>5,8</Pos>
-                    <NumberStates>2</NumberStates>
-                    <State>
-                      <Number>0</Number>
-                      <Pressed>skin:/btn/btn_play_deck_small.png</Pressed>
-                      <Unpressed>skin:/btn/btn_play_deck_small.png</Unpressed>
-                    </State>
-                    <State>
-                      <Number>1</Number>
-                      <Pressed>skin:/btn/btn_play_deck_small_over.png</Pressed>
-                      <Unpressed>skin:/btn/btn_play_deck_small_over.png</Unpressed>
-                    </State>
-                    <Connection>
-                      <ConfigKey><Variable name="group"/>,play_indicator</ConfigKey>
-                    </Connection>
-                  </PushButton>
-                  <PushButton>
                     <TooltipId>play_cue_default</TooltipId>
                     <Pos>5,8</Pos>
                     <NumberStates>2</NumberStates>
                     <State>
                       <Number>0</Number>
                       <Pressed>skin:/btn/btn_play_deck_small_down.png</Pressed>
-                      <Unpressed></Unpressed>
+                      <Unpressed>skin:/btn/btn_play_deck_small.png</Unpressed>
                     </State>
                     <State>
                       <Number>1</Number>
@@ -217,6 +200,9 @@
                     <Connection>
                       <ConfigKey><Variable name="group"/>,cue_default</ConfigKey>
                       <ButtonState>RightButton</ButtonState>
+                    </Connection>
+                    <Connection>
+                      <ConfigKey><Variable name="group"/>,play_indicator</ConfigKey>
                     </Connection>
                   </PushButton>
                 </Children>

--- a/res/skins/Shade/mixer_panel.xml
+++ b/res/skins/Shade/mixer_panel.xml
@@ -85,31 +85,13 @@
               Button- Play
               ****************************************
               -->
-              <!-- Play deck 1 -->
-              <PushButton>
-                <NumberStates>2</NumberStates>
-                <State>
-                  <Number>0</Number>
-                  <Pressed>skin:/btn/btn_play_deck.png</Pressed>
-                  <Unpressed>skin:/btn/btn_play_deck.png</Unpressed>
-                </State>
-                <State>
-                  <Number>1</Number>
-                  <Pressed>skin:/btn/btn_play_deck_over.png</Pressed>
-                  <Unpressed>skin:/btn/btn_play_deck_over.png</Unpressed>
-                </State>
-                <Pos>11,200</Pos>
-                <Connection>
-                  <ConfigKey>[Channel1],play_indicator</ConfigKey>
-                </Connection>
-              </PushButton>
               <PushButton>
                 <TooltipId>play_cue_set</TooltipId>
                 <NumberStates>2</NumberStates>
                 <State>
                   <Number>0</Number>
                   <Pressed>skin:/btn/btn_play_deck_down.png</Pressed>
-                  <Unpressed></Unpressed>
+                  <Unpressed>skin:/btn/btn_play_deck.png</Unpressed>
                 </State>
                 <State>
                   <Number>1</Number>
@@ -125,23 +107,8 @@
                   <ConfigKey>[Channel1],cue_set</ConfigKey>
                   <ButtonState>RightButton</ButtonState>
                 </Connection>
-              </PushButton>
-              <!-- Play deck 2 -->
-              <PushButton>
-                <NumberStates>2</NumberStates>
-                <State>
-                  <Number>0</Number>
-                  <Pressed>skin:/btn/btn_play_deck.png</Pressed>
-                  <Unpressed>skin:/btn/btn_play_deck.png</Unpressed>
-                </State>
-                <State>
-                  <Number>1</Number>
-                  <Pressed>skin:/btn/btn_play_deck_over.png</Pressed>
-                  <Unpressed>skin:/btn/btn_play_deck_over.png</Unpressed>
-                </State>
-                <Pos>203,200</Pos>
                 <Connection>
-                  <ConfigKey>[Channel2],play_indicator</ConfigKey>
+                  <ConfigKey>[Channel1],play_indicator</ConfigKey>
                 </Connection>
               </PushButton>
               <PushButton>
@@ -150,7 +117,7 @@
                 <State>
                   <Number>0</Number>
                   <Pressed>skin:/btn/btn_play_deck_down.png</Pressed>
-                  <Unpressed></Unpressed>
+                  <Unpressed>skin:/btn/btn_play_deck.png</Unpressed>
                 </State>
                 <State>
                   <Number>1</Number>
@@ -165,6 +132,9 @@
                 <Connection>
                   <ConfigKey>[Channel2],cue_set</ConfigKey>
                   <ButtonState>RightButton</ButtonState>
+                </Connection>
+                <Connection>
+                  <ConfigKey>[Channel2],play_indicator</ConfigKey>
                 </Connection>
               </PushButton>
 

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -896,12 +896,11 @@ WLabel#TrackComment {
  #######  Play, Cue and HotCue buttons  #########################
 ##############################################################*/
 
-/* Actual Play button. Receives click events, turns red
-  when playing regularly, not from Cue or HotCue */
-#PlayCue[displayValue="0"],
-#PlayCue[displayValue="0"]:hover {
+/* Actual Play button. Chanegs the play/pause icon only */
+#PlayCue {
   background-color: transparent;
-  }
+  border-color: transparent;
+}
 
 #SamplerPlayCue[displayValue="0"] {
   /* different than decks' Play button, this has some soft shadow to distinguish
@@ -924,7 +923,6 @@ WLabel#TrackComment {
   image: url(skin:/buttons/btn_mic_aux_mute.svg) no-repeat center center;
 }
 
-#PlayCue[displayValue="0"]:hover,
 #SamplerPlayCue[displayValue="0"]:hover,
 #MicTalkover[displayValue="0"]:hover,
 #AuxEnable[displayValue="0"]:hover,
@@ -935,11 +933,9 @@ WLabel#TrackComment {
     background-color: rgba(255, 128, 0, 210);
   }
 
-#PlayCue[displayValue="1"],
 #SamplerPlayCue[displayValue="1"] { /*
   image: url(skin:/buttons/btn_pause.svg) no-repeat center center;  */
 }
-#PlayCue[value="1"],
 #PlayIndicator[value="1"],
 #SamplerPlayCue[displayValue="1"],
 #MicTalkover[displayValue="1"],
@@ -949,7 +945,6 @@ WLabel#TrackComment {
   background-color: #ff8000;
   border: 1px solid #ff9900;
 }
-  #PlayCue[displayValue="1"]:hover,
   #SamplerPlayCue[displayValue="1"]:hover,
   #MicTalkover[displayValue="1"]:hover,
   #AuxEnable[displayValue="1"]:hover {


### PR DESCRIPTION
According to the CD player templates, the play button should stay dark during cue preview. 
When you hit play the play button lit to acknowledge the latched state. 

This fixes a regression from https://github.com/mixxxdj/mixxx/pull/2619

A minor remaining issue is that the play button icon changes to pause during preview. 
We can "fix" this only by introducing a state-full new play_indicator cluttering the CO interface.  
This is not worth the work IMHO.  
