### PR TITLE
GitHub CI: Don't abort clazy build on errors

### DIFF
--- a/.github/workflows/clazy.yml
+++ b/.github/workflows/clazy.yml
@@ -50,11 +50,9 @@ jobs:
     - name: Create build directory
       run: mkdir cmake_build
     - name: Configure
-      # -DOPTIMIZE=off: Disable optimizations as workaround for Clang 9 bug: https://bugs.llvm.org/show_bug.cgi?id=45034
-      # -ferror-limit=0: Disable aborting on errors
+      # Disable optimizations as workaround for Clang 9 bug: https://bugs.llvm.org/show_bug.cgi?id=45034
       run: |
         cmake \
-          -DCMAKE_CXX_FLAGS="-ferror-limit=0" \
           -DCMAKE_BUILD_TYPE=Debug \
           -DWARNINGS_FATAL=ON \
           -DOPTIMIZE=off \

--- a/.github/workflows/clazy.yml
+++ b/.github/workflows/clazy.yml
@@ -50,9 +50,11 @@ jobs:
     - name: Create build directory
       run: mkdir cmake_build
     - name: Configure
-      # Disable optimizations as workaround for Clang 9 bug: https://bugs.llvm.org/show_bug.cgi?id=45034
+      # -DOPTIMIZE=off: Disable optimizations as workaround for Clang 9 bug: https://bugs.llvm.org/show_bug.cgi?id=45034
+      # -ferror-limit=0: Disable aborting on errors
       run: |
         cmake \
+          -DCMAKE_CXX_FLAGS="-ferror-limit=0" \
           -DCMAKE_BUILD_TYPE=Debug \
           -DWARNINGS_FATAL=ON \
           -DOPTIMIZE=off \

--- a/.github/workflows/clazy.yml
+++ b/.github/workflows/clazy.yml
@@ -79,7 +79,8 @@ jobs:
     - name: Set up problem matcher
       uses: ammaraskar/gcc-problem-matcher@master
     - name: Build
-      run: cmake --build . -j $(nproc)
+      # Do not abort on errors and build/check the whole project
+      run: cmake --build . -j $(nproc) -- --keep-going
       working-directory: cmake_build
       env:
         CLAZY_CHECKS: level2,no-rule-of-two-soft,no-non-pod-global-static,no-qproperty-without-notify,no-wrong-qevent-cast,no-qstring-allocations,no-function-args-by-value,no-copyable-polymorphic,no-ctor-missing-parent-argument,no-missing-qobject-macro,no-rule-of-three,no-returning-void-expression,no-missing-typeinfo,no-base-class-event


### PR DESCRIPTION
This change allows developers to review and fix all errors instead of only the first few.

Tested on the currently broken main clazy build that aborts after 20 errors.