### PR TITLE
Fix warnings in macOS build

### DIFF
--- a/src/sources/soundsourcecoreaudio.cpp
+++ b/src/sources/soundsourcecoreaudio.cpp
@@ -185,7 +185,8 @@ SoundSource::OpenResult SoundSourceCoreAudio::tryOpen(
     }
 
     initChannelCountOnce(m_outputFormat.NumberChannels());
-    initSampleRateOnce(m_inputFormat.mSampleRate);
+    DEBUG_ASSERT(std::round(m_inputFormat.mSampleRate) == m_inputFormat.mSampleRate);
+    initSampleRateOnce(static_cast<SINT>(m_inputFormat.mSampleRate));
     // TODO(XXX): Reduce totalFrameCount by m_leadingFrames???
     initFrameIndexRangeOnce(IndexRange::forward(m_leadingFrames, totalFrameCount));
 

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -448,7 +448,7 @@ bool WTrackMenu::isAnyTrackBpmLocked() const {
     if (m_pTrackModel) {
         const int column =
                 m_pTrackModel->fieldIndex(LIBRARYTABLE_BPM_LOCK);
-        for (const auto trackIndex : m_trackIndexList) {
+        for (const auto& trackIndex : m_trackIndexList) {
             QModelIndex bpmLockedIndex =
                     trackIndex.sibling(trackIndex.row(), column);
             if (bpmLockedIndex.data().toBool()) {
@@ -475,7 +475,7 @@ std::optional<std::optional<mixxx::RgbColor>> WTrackMenu::getCommonTrackColor() 
                 m_pTrackModel->fieldIndex(LIBRARYTABLE_COLOR);
         commonColor = mixxx::RgbColor::fromQVariant(
                 m_trackIndexList.first().sibling(m_trackIndexList.first().row(), column).data());
-        for (const auto trackIndex : m_trackIndexList) {
+        for (const auto& trackIndex : m_trackIndexList) {
             const auto otherColor = mixxx::RgbColor::fromQVariant(
                     trackIndex.sibling(trackIndex.row(), column).data());
             if (commonColor != otherColor) {


### PR DESCRIPTION
Follow-up of #3356 

~~Don't know why it only logs a warning instead of failing the job?~~ Compiler warnings are stil non-fatal on macOS.