### PR TITLE
Fix ANGLE/OpenGL swap buffer issues under Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1135,28 +1135,28 @@ install(
     "*.qm"
 )
 if(WIN32)
-install(
-  # I haven't seen a way to determine where the translations dir is, so I am making
-  # some assumptions here, and assuming that Qt5_DIR points to Qt-5.14.2/lib/cmake/Qt5
-  # which is what my configuration tells me.
-  DIRECTORY
-    "${Qt5_DIR}/../../../translations"
-  DESTINATION
-    "${MIXXX_INSTALL_DATADIR}"
-  # QT 5 translations have been separated into several files, and most of the qt_xx.qm files
-  # contain just shortcuts to load the qtbase, qtmultimedia etc files.
-  FILES_MATCHING REGEX
-    "qt_.+\.qm|qtbase_.*\.qm|qtmultimedia_.*\.qm|qtscript_.*\.qm|qtxmlpatterns_.*\.qm"
-)
+    install(
+        # I haven't seen a way to determine where the translations dir is, so I am making
+        # some assumptions here, and assuming that Qt5_DIR points to Qt-5.14.2/lib/cmake/Qt5
+        # which is what my configuration tells me.
+        DIRECTORY
+            "${Qt5_DIR}/../../../translations"
+        DESTINATION
+            "${MIXXX_INSTALL_DATADIR}"
+        # QT 5 translations have been separated into several files, and most of the qt_xx.qm files
+        # contain just shortcuts to load the qtbase, qtmultimedia etc files.
+        FILES_MATCHING REGEX
+            "qt_.+\.qm|qtbase_.*\.qm|qtmultimedia_.*\.qm|qtscript_.*\.qm|qtxmlpatterns_.*\.qm"
+    )
 
-# Qt loads the ANGLE libraries dynamically, even when Qt itself is linked statically
-install(
-  FILES
-    "${Qt5_DIR}/bin/libEGL.dll"
-    "${Qt5_DIR}/bin/libGLESv2.dll"
-  DESTINATION
-    "${MIXXX_INSTALL_DATADIR}"
-)
+    # Qt loads the ANGLE libraries dynamically, even when Qt itself is linked statically
+    install(
+        FILES
+            "${Qt5_DIR}/bin/libEGL.dll"
+            "${Qt5_DIR}/bin/libGLESv2.dll"
+        DESTINATION
+            "${MIXXX_INSTALL_DATADIR}"
+    )
 endif()
 
 # Font files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1151,11 +1151,12 @@ if(WIN32)
 
   # Qt loads the ANGLE libraries dynamically, even when Qt itself is linked statically
   install(
-    FILES
-      "${Qt5_DIR}/../../../bin/libEGL.dll"
-      "${Qt5_DIR}/../../../bin/libGLESv2.dll"
+    DIRECTORY
+      "${Qt5_DIR}/../../../bin"
     DESTINATION
       "${MIXXX_INSTALL_DATADIR}"
+    FILES_MATCHING REGEX
+      "libEGL.dll|libGLESv2.dll"
   )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1135,28 +1135,28 @@ install(
     "*.qm"
 )
 if(WIN32)
-    install(
-        # I haven't seen a way to determine where the translations dir is, so I am making
-        # some assumptions here, and assuming that Qt5_DIR points to Qt-5.14.2/lib/cmake/Qt5
-        # which is what my configuration tells me.
-        DIRECTORY
-            "${Qt5_DIR}/../../../translations"
-        DESTINATION
-            "${MIXXX_INSTALL_DATADIR}"
-        # QT 5 translations have been separated into several files, and most of the qt_xx.qm files
-        # contain just shortcuts to load the qtbase, qtmultimedia etc files.
-        FILES_MATCHING REGEX
-            "qt_.+\.qm|qtbase_.*\.qm|qtmultimedia_.*\.qm|qtscript_.*\.qm|qtxmlpatterns_.*\.qm"
-    )
+  install(
+    # I haven't seen a way to determine where the translations dir is, so I am making
+    # some assumptions here, and assuming that Qt5_DIR points to Qt-5.14.2/lib/cmake/Qt5
+    # which is what my configuration tells me.
+    DIRECTORY
+      "${Qt5_DIR}/../../../translations"
+    DESTINATION
+      "${MIXXX_INSTALL_DATADIR}"
+    # QT 5 translations have been separated into several files, and most of the qt_xx.qm files
+    # contain just shortcuts to load the qtbase, qtmultimedia etc files.
+    FILES_MATCHING REGEX
+      "qt_.+\.qm|qtbase_.*\.qm|qtmultimedia_.*\.qm|qtscript_.*\.qm|qtxmlpatterns_.*\.qm"
+  )
 
-    # Qt loads the ANGLE libraries dynamically, even when Qt itself is linked statically
-    install(
-        FILES
-            "${Qt5_DIR}/bin/libEGL.dll"
-            "${Qt5_DIR}/bin/libGLESv2.dll"
-        DESTINATION
-            "${MIXXX_INSTALL_DATADIR}"
-    )
+  # Qt loads the ANGLE libraries dynamically, even when Qt itself is linked statically
+  install(
+    FILES
+      "${Qt5_DIR}/bin/libEGL.dll"
+      "${Qt5_DIR}/bin/libGLESv2.dll"
+    DESTINATION
+      "${MIXXX_INSTALL_DATADIR}"
+  )
 endif()
 
 # Font files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1149,7 +1149,7 @@ install(
     "qt_.+\.qm|qtbase_.*\.qm|qtmultimedia_.*\.qm|qtscript_.*\.qm|qtxmlpatterns_.*\.qm"
 )
 
-# Qt loads the ANGLE libraries dynamical, also when Qt itself is linked static 
+# Qt loads the ANGLE libraries dynamically, even when Qt itself is linked statically
 install(
   FILES
     "${Qt5_DIR}/bin/libEGL.dll"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1152,8 +1152,8 @@ if(WIN32)
   # Qt loads the ANGLE libraries dynamically, even when Qt itself is linked statically
   install(
     FILES
-      "${Qt5_DIR}/bin/libEGL.dll"
-      "${Qt5_DIR}/bin/libGLESv2.dll"
+      "${Qt5_DIR}/../../../bin/libEGL.dll"
+      "${Qt5_DIR}/../../../bin/libGLESv2.dll"
     DESTINATION
       "${MIXXX_INSTALL_DATADIR}"
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1148,6 +1148,15 @@ install(
   FILES_MATCHING REGEX
     "qt_.+\.qm|qtbase_.*\.qm|qtmultimedia_.*\.qm|qtscript_.*\.qm|qtxmlpatterns_.*\.qm"
 )
+
+# Qt loads the ANGLE libraries dynamical, also when Qt itself is linked static 
+install(
+  FILES
+    "${Qt5_DIR}/bin/libEGL.dll"
+    "${Qt5_DIR}/bin/libGLESv2.dll"
+  DESTINATION
+    "${MIXXX_INSTALL_DATADIR}"
+)
 endif()
 
 # Font files

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -713,7 +713,9 @@ void WaveformWidgetFactory::swap() {
                 }
                 QGLWidget* glw = qobject_cast<QGLWidget*>(pWaveformWidget->getWidget());
                 if (glw != nullptr) {
-                    glw->makeCurrent();
+                    if (QGLContext::currentContext() != glw->context()) {
+                        glw->makeCurrent();
+                    }
                     glw->swapBuffers();
                 }
                 //qDebug() << "swap x" << m_vsyncThread->elapsed();

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -713,6 +713,7 @@ void WaveformWidgetFactory::swap() {
                 }
                 QGLWidget* glw = qobject_cast<QGLWidget*>(pWaveformWidget->getWidget());
                 if (glw != nullptr) {
+                    glw->makeCurrent();
                     glw->swapBuffers();
                 }
                 //qDebug() << "swap x" << m_vsyncThread->elapsed();

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -403,7 +403,9 @@ void WSpinny::swap() {
     if (window == nullptr || !window->isExposed()) {
         return;
     }
-    makeCurrent();
+    if (QGLContext::currentContext() != context()) {
+        makeCurrent();
+    }
     swapBuffers();
 }
 

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -403,6 +403,7 @@ void WSpinny::swap() {
     if (window == nullptr || !window->isExposed()) {
         return;
     }
+    makeCurrent();
     swapBuffers();
 }
 


### PR DESCRIPTION
This fixes the bugs https://bugs.launchpad.net/mixxx/+bug/1895427 and https://bugs.launchpad.net/mixxx/+bug/1872172 under the OpenGL emulation ANGLE.

I tested this fix with ANGLE the angle library, that comes with 2.3-j00019-x64-release-fastbuild-static-55e94982-minimal as part of the Qt 5.14.2.
It also works if I set QT_OPENGL to desktop to use the native OpenGL driver of my Intel HD Graphics 3000 GPU.

I can't test the behaviour on other platforms.

Furthermore it fixes issue https://bugs.launchpad.net/mixxx/+bug/1905123 by adding the missing ANGLE DLLs to the windows installer.