### PR TITLE
Skins: allow menubar to be styled

### DIFF
--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -522,6 +522,8 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
 
         m_pWidgetParent = oldWidget;
         //TODO (XXX) add dialog to warn user and launch skin choice page
+    } else {
+        m_pMenuBar->setStyleSheet(m_pWidgetParent->styleSheet());
     }
 
     // Fake a 100 % progress here.
@@ -1111,6 +1113,9 @@ void MixxxMainWindow::createMenuBar() {
     ScopedTimer t("MixxxMainWindow::createMenuBar");
     DEBUG_ASSERT(m_pKbdConfig != nullptr);
     m_pMenuBar = make_parented<WMainMenuBar>(this, m_pSettingsManager->settings(), m_pKbdConfig);
+    if (m_pWidgetParent) {
+        m_pMenuBar->setStyleSheet(m_pWidgetParent->styleSheet());
+    }
     setMenuBar(m_pMenuBar);
 }
 
@@ -1475,6 +1480,7 @@ void MixxxMainWindow::rebootMixxxView() {
         // m_pWidgetParent is NULL, we can't continue.
         return;
     }
+    m_pMenuBar->setStyleSheet(m_pWidgetParent->styleSheet());
 
     setCentralWidget(m_pWidgetParent);
 #ifdef __LINUX__

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -56,12 +56,13 @@ WMainMenuBar::WMainMenuBar(QWidget* pParent, UserSettingsPointer pConfig,
         : QMenuBar(pParent),
           m_pConfig(pConfig),
           m_pKbdConfig(pKbdConfig) {
+    setObjectName(QStringLiteral("MainMenu"));
     initialize();
 }
 
 void WMainMenuBar::initialize() {
     // FILE MENU
-    QMenu* pFileMenu = new QMenu(tr("&File"));
+    QMenu* pFileMenu = new QMenu(tr("&File"), this);
 
     QString loadTrackText = tr("Load Track to Deck &%1");
     QString loadTrackStatusText = tr("Loads a track in deck %1");
@@ -109,7 +110,7 @@ void WMainMenuBar::initialize() {
     addMenu(pFileMenu);
 
     // LIBRARY MENU
-    QMenu* pLibraryMenu = new QMenu(tr("&Library"));
+    QMenu* pLibraryMenu = new QMenu(tr("&Library"), this);
 
     QString rescanTitle = tr("&Rescan Library");
     QString rescanText = tr("Rescans library folders for changes to tracks.");
@@ -158,9 +159,9 @@ void WMainMenuBar::initialize() {
     // Add an invisible suffix to the View item string so it doesn't string-equal "View" ,
     // and the magic menu items won't get injected.
     // https://bugs.launchpad.net/mixxx/+bug/1534292
-    QMenu* pViewMenu = new QMenu(tr("&View") + QStringLiteral("\u200C"));
+    QMenu* pViewMenu = new QMenu(tr("&View") + QStringLiteral("\u200C"), this);
 #else
-    QMenu* pViewMenu = new QMenu(tr("&View"));
+    QMenu* pViewMenu = new QMenu(tr("&View"), this);
 #endif
 
     // Skin Settings Menu
@@ -295,10 +296,10 @@ void WMainMenuBar::initialize() {
     addMenu(pViewMenu);
 
     // OPTIONS MENU
-    QMenu* pOptionsMenu = new QMenu(tr("&Options"));
+    QMenu* pOptionsMenu = new QMenu(tr("&Options"), this);
 
 #ifdef __VINYLCONTROL__
-    QMenu* pVinylControlMenu = new QMenu(tr("&Vinyl Control"));
+    QMenu* pVinylControlMenu = new QMenu(tr("&Vinyl Control"), this);
     QString vinylControlText = tr(
             "Use timecoded vinyls on external turntables to control Mixxx");
 
@@ -414,7 +415,7 @@ void WMainMenuBar::initialize() {
 
     // DEVELOPER MENU
     if (CmdlineArgs::Instance().getDeveloper()) {
-        QMenu* pDeveloperMenu = new QMenu(tr("&Developer"));
+        QMenu* pDeveloperMenu = new QMenu(tr("&Developer"), this);
 
         QString reloadSkinTitle = tr("&Reload Skin");
         QString reloadSkinText = tr("Reload the skin");


### PR DESCRIPTION
cherry-picked from @poelzi's #3285 
By default this should have no effect but allows adding individual skin styles piece by piece.
So IMO this can be merged after folks on Windows and macOS have verified that without style additions the menubar looks like before.

I'll try to catch all elements and pseudo-states with qss and also use relative sizes for checkboxes etc. to respect the custom os sizes. That doesn't have to happen here, but maybe it does, depending on what happens first: merge or style experiments.

In a few days I'll check if my Win10 installation is still alive to double-check my experiments on Windows.