### PR TITLE
macOS 2.3: revert restart to change skin

### DIFF
--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -335,17 +335,11 @@ void DlgPrefInterface::slotSetTooltips() {
     }
 }
 
-void DlgPrefInterface::notifyLocaleRebootNecessary() {
+void DlgPrefInterface::notifyRebootNecessary() {
     // make the fact that you have to restart mixxx more obvious
     QMessageBox::information(
         this, tr("Information"),
         tr("Mixxx must be restarted before the new locale setting will take effect."));
-}
-
-void DlgPrefInterface::notifySkinRebootNecessary() {
-    // make the fact that you have to restart mixxx more obvious
-    QMessageBox::information(
-            this, tr("Information"), tr("Mixxx must be restarted to load the new skin."));
 }
 
 void DlgPrefInterface::slotSetScheme(int) {
@@ -420,21 +414,15 @@ void DlgPrefInterface::slotApply() {
     }
 
     if (locale != m_localeOnUpdate) {
-        notifyLocaleRebootNecessary();
+        notifyRebootNecessary();
         // hack to prevent showing the notification when pressing "Okay" after "Apply"
         m_localeOnUpdate = locale;
     }
 
     if (m_bRebootMixxxView) {
-        // Require restarting Mixxx to apply the new skin in order to work around
-        // macOS skin change crash. https://bugs.launchpad.net/mixxx/+bug/1877487
-#ifdef __APPLE__
-        notifySkinRebootNecessary();
-#else
         m_mixxx->rebootMixxxView();
         // Allow switching skins multiple times without closing the dialog
         m_skinOnUpdate = m_skin;
-#endif
     }
     m_bRebootMixxxView = false;
 }

--- a/src/preferences/dialog/dlgprefinterface.h
+++ b/src/preferences/dialog/dlgprefinterface.h
@@ -57,8 +57,7 @@ class DlgPrefInterface : public DlgPreferencePage, public Ui::DlgPrefControlsDlg
     void slotSetScaleFactorAuto(bool checked);
 
   private:
-    void notifyLocaleRebootNecessary();
-    void notifySkinRebootNecessary();
+    void notifyRebootNecessary();
     void loadTooltipPreferenceFromConfig();
 
     // Because the CueDefault list is out of order, we have to set the combo


### PR DESCRIPTION
Reverts "Preferences Interface: on macOS require restart applying a new skin" f8530b87cfa23aabc1cb52b38c333e49263ec771

maybe #3370 fixed the skin crash, too.
Please test!
Read [backup-settings-and-database](https://github.com/mixxxdj/mixxx/wiki/Testing#backup-settings-and-database)
and [github-pull-requests](https://github.com/mixxxdj/mixxx/wiki/Testing#github-pull-requests)