### PR TITLE
Fix event/eventfilter warnings from clazy 1.8

### DIFF
--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -1508,9 +1508,12 @@ bool MixxxMainWindow::eventFilter(QObject* obj, QEvent* event) {
         // return true for no tool tips
         switch (m_toolTipsCfg) {
             case mixxx::TooltipsPreference::TOOLTIPS_ONLY_IN_LIBRARY:
-                return dynamic_cast<WBaseWidget*>(obj) != nullptr;
+                if (dynamic_cast<WBaseWidget*>(obj) != nullptr) {
+                    return true;
+                }
+                break;
             case mixxx::TooltipsPreference::TOOLTIPS_ON:
-                return false;
+                break;
             case mixxx::TooltipsPreference::TOOLTIPS_OFF:
                 return true;
             default:
@@ -1519,7 +1522,7 @@ bool MixxxMainWindow::eventFilter(QObject* obj, QEvent* event) {
         }
     }
     // standard event processing
-    return QObject::eventFilter(obj, event);
+    return QMainWindow::eventFilter(obj, event);
 }
 
 void MixxxMainWindow::closeEvent(QCloseEvent *event) {

--- a/src/widget/weffectselector.cpp
+++ b/src/widget/weffectselector.cpp
@@ -129,7 +129,7 @@ bool WEffectSelector::event(QEvent* pEvent) {
         populate();
     } else if (pEvent->type() == QEvent::Wheel && !hasFocus()) {
         // don't change effect by scrolling hovered effect selector
-        return false;
+        return true;
     }
 
     return QComboBox::event(pEvent);


### PR DESCRIPTION
returning false from event/eventFilter is discouraged
as further processing is prevented, only true is allowed.