### PR TITLE
Fix MSVC_REDIST_DIR issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,6 +110,10 @@ jobs:
       if: runner.os == 'Windows'
       run: python -m pip install ninja git+https://github.com/frerich/clcache.git
 
+    - name: "[Windows] Set up MSVC Developer Command Prompt"
+      if: runner.os == 'Windows'
+      uses: seanmiddleditch/gha-setup-vsdevenv@v3
+
     - name: "[macOS/Windows] Get build environment name"
       if: runner.os != 'Linux'
       id: buildenv_name
@@ -167,12 +171,6 @@ jobs:
 
     - name: "Create build directory"
       run: mkdir cmake_build
-
-    - name: "[Windows] Set up MSVC Developer Command Prompt"
-      if: runner.os == 'Windows'
-      uses: ilammy/msvc-dev-cmd@v1
-      with:
-        toolset: 14.16
 
     - name: "Configure"
       run: >-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1640,11 +1640,12 @@ target_include_directories(mixxx-lib SYSTEM PUBLIC ${PortMidi_INCLUDE_DIRS})
 target_link_libraries(mixxx-lib PUBLIC ${PortMidi_LIBRARIES})
 
 # Protobuf
+if(STATIC_DEPS)
+  set(Protobuf_USE_STATIC_LIBS ON)
+  mark_as_advanced(Protobuf_USE_STATIC_LIBS)
+endif()
 add_subdirectory(src/proto)
 target_link_libraries(mixxx-lib PUBLIC mixxx-proto)
-if(WIN32 AND NOT STATIC_DEPS)
-  target_compile_definitions(mixxx-lib PUBLIC PROTOBUF_USE_DLLS)
-endif()
 
 # Rigtorp SPSC Queue
 # https://github.com/rigtorp/SPSCQueue


### PR DESCRIPTION
Fixes these warnings during configuration:

```
CMake Warning at C:/hostedtoolcache/windows/cmake/3.13.5/x64/cmake-3.13.5-win32-x86/share/cmake-3.13/Modules/InstallRequiredSystemLibraries.cmake:549 (message):
  system runtime library file does not exist:
  'MSVC_REDIST_DIR-NOTFOUND/x64/Microsoft.VC141.CRT/msvcp140.dll'
Call Stack (most recent call first):
  CMakeLists.txt:1089 (include)
```

I suspect this prevents that the MSVC redistributable is currently not included in the build.