### PR TITLE
Enforce offscreen rendering for all tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1425,6 +1425,12 @@ gtest_add_tests(
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
   TEST_LIST testsuite
 )
+if (NOT WIN32)
+  # Default to offscreen rendering during tests.
+  # This is required if the build system like Fedora koji/mock does not
+  # allow to pass environment variables into the ctest macro expansion.
+  set_tests_properties(${testsuite} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+endif()
 
 # Benchmarking
 add_custom_target(mixxx-benchmark


### PR DESCRIPTION
Enforce offscreen rendering for all tests except benchmark tests.

Background: In the RPM build `ctest` is invoked through a macro `%ctest3` that does not to allow setting initial environment variables. This change finally allows to enable and run the tests in the Fedora build system.