### PR TITLE
Infobar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -976,6 +976,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/widget/weffectselector.cpp
   src/widget/whotcuebutton.cpp
   src/widget/wimagestore.cpp
+  src/widget/winfobar.cpp
   src/widget/wkey.cpp
   src/widget/wknob.cpp
   src/widget/wknobcomposed.cpp

--- a/res/images/library/ic_library_crates_grey.svg
+++ b/res/images/library/ic_library_crates_grey.svg
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="135"
+   inkscape:export-xdpi="135"
+   inkscape:export-filename=""
+   style="display:inline"
+   sodipodi:docname="ic_library_crates_grey.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   id="svg2"
+   height="32"
+   width="32"
+   version="1.1">
+  <sodipodi:namedview
+     inkscape:document-rotation="0"
+     inkscape:snap-midpoints="true"
+     inkscape:guide-bbox="true"
+     showguides="true"
+     inkscape:object-paths="true"
+     inkscape:current-layer="ic_library_crates"
+     inkscape:window-maximized="0"
+     inkscape:window-y="106"
+     inkscape:window-x="2797"
+     inkscape:cy="21.364243"
+     inkscape:cx="19.332022"
+     inkscape:zoom="16"
+     showgrid="false"
+     id="namedview26"
+     inkscape:window-height="1824"
+     inkscape:window-width="1898"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff">
+    <inkscape:grid
+       dotted="false"
+       originy="4"
+       empopacity="0.25098039"
+       empcolor="#0072ff"
+       opacity="0.1254902"
+       color="#00ffe0"
+       spacingy="1"
+       spacingx="1"
+       originx="4"
+       snapvisiblegridlinesonly="true"
+       enabled="true"
+       visible="true"
+       empspacing="4"
+       id="grid3788"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <title
+     id="title5647">Mixxx 1.12+ iconset</title>
+  <defs
+     id="defs28">
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5515">
+      <stop
+         id="stop5517"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4942">
+      <stop
+         id="stop4944"
+         offset="0"
+         style="stop-color:#ff6600;stop-opacity:1;" />
+      <stop
+         id="stop4946"
+         offset="1"
+         style="stop-color:#de5800;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5695-6">
+      <stop
+         id="stop5697-6"
+         offset="0"
+         style="stop-color:#3c3c3c;stop-opacity:1;" />
+      <stop
+         id="stop5699-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5695-4">
+      <stop
+         id="stop5697-7"
+         offset="0"
+         style="stop-color:#646464;stop-opacity:1;" />
+      <stop
+         id="stop5699-6"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4942-73">
+      <stop
+         id="stop4944-6"
+         offset="0"
+         style="stop-color:#ff6600;stop-opacity:1;" />
+      <stop
+         id="stop4946-6"
+         offset="1"
+         style="stop-color:#de5800;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4942-5">
+      <stop
+         id="stop4944-9"
+         offset="0"
+         style="stop-color:#ff6600;stop-opacity:1;" />
+      <stop
+         id="stop4946-5"
+         offset="1"
+         style="stop-color:#de5800;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="16.252333"
+       x2="10.624022"
+       y1="3.1950266"
+       x1="7.1253266"
+       id="linearGradient4996"
+       xlink:href="#linearGradient4942"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="32"
+       x2="16"
+       y1="8"
+       x1="16"
+       id="linearGradient4994"
+       xlink:href="#linearGradient5695-4"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="16.252333"
+       x2="10.624022"
+       y1="3.1950266"
+       x1="7.1253266"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient2263"
+       xlink:href="#linearGradient5695-4"
+       inkscape:collect="always" />
+  </defs>
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <rdf:Description
+         rdf:about="">
+        <dc:title />
+        <dc:creator />
+        <dc:rights />
+        <dc:description />
+        <dc:format>image/svg+xml</dc:format>
+        <dc:language>en</dc:language>
+      </rdf:Description>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mixxx 1.12+ iconset</dc:title>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>Mixxx</rdf:li>
+            <rdf:li>GUI</rdf:li>
+            <rdf:li>Interface</rdf:li>
+            <rdf:li>Icons</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>s.brandt@mixxx.org</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/publicdomain/" />
+        <dc:date>2014-04-18</dc:date>
+        <dc:source>www.mixxx.org</dc:source>
+        <dc:description>Iconset for use in Mixxx 1.12s+. Optimized for 48px (16px) icon size. Contains icons for preference menu and library widget
+
+Grid based on suggestions from http://techbase.kde.org/Projects/Oxygen/Style</dc:description>
+        <dc:coverage />
+        <dc:language>en</dc:language>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/publicdomain/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="#g6169"
+     id="ic_library_crates"
+     style="display:inline">
+    <g
+       style="display:inline;fill:url(#linearGradient4996);fill-opacity:1;stroke:none"
+       transform="matrix(1.7149251,0.45951286,-0.45951284,1.7149252,5.2487542,-0.75341108)"
+       id="g4345-3">
+      <title
+         style="fill-opacity:1"
+         id="title4347-8">Layer 1</title>
+      <path
+         style="fill:url(#linearGradient2263);fill-opacity:1;stroke:none"
+         id="path4349-3"
+         d="M 9.7493474,12.988007 14.528654,4.7100059 6.2506525,-0.06929989 1.4713466,8.2087009 Z"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       id="path4351-0"
+       d="M 1.9999999,18 V 28.181818 30 H 30 V 28 18 H 28 V 28 H 4 V 18 Z"
+       style="display:inline;fill:url(#linearGradient4994);fill-opacity:1.0;stroke:none"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+  </g>
+</svg>

--- a/res/images/library/ic_library_crates_half_grey.svg
+++ b/res/images/library/ic_library_crates_half_grey.svg
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="135"
+   inkscape:export-xdpi="135"
+   inkscape:export-filename=""
+   style="display:inline"
+   sodipodi:docname="ic_library_crates_half_grey.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   id="svg2"
+   height="32"
+   width="32"
+   version="1.1">
+  <sodipodi:namedview
+     inkscape:document-rotation="0"
+     inkscape:snap-midpoints="true"
+     inkscape:guide-bbox="true"
+     showguides="true"
+     inkscape:object-paths="true"
+     inkscape:current-layer="g4345-3"
+     inkscape:window-maximized="0"
+     inkscape:window-y="106"
+     inkscape:window-x="2797"
+     inkscape:cy="21.364243"
+     inkscape:cx="19.332022"
+     inkscape:zoom="16"
+     showgrid="false"
+     id="namedview26"
+     inkscape:window-height="1824"
+     inkscape:window-width="1898"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff">
+    <inkscape:grid
+       dotted="false"
+       originy="4"
+       empopacity="0.25098039"
+       empcolor="#0072ff"
+       opacity="0.1254902"
+       color="#00ffe0"
+       spacingy="1"
+       spacingx="1"
+       originx="4"
+       snapvisiblegridlinesonly="true"
+       enabled="true"
+       visible="true"
+       empspacing="4"
+       id="grid3788"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <title
+     id="title5647">Mixxx 1.12+ iconset</title>
+  <defs
+     id="defs28">
+    <linearGradient
+       id="linearGradient883">
+      <stop
+         style="stop-color:#ff6600;stop-opacity:1;"
+         offset="0"
+         id="stop879" />
+      <stop
+         style="stop-color:#de5800;stop-opacity:1;"
+         offset="1"
+         id="stop881" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4942">
+      <stop
+         style="stop-color:#ff6600;stop-opacity:1;"
+         offset="0"
+         id="stop874" />
+      <stop
+         style="stop-color:#de5800;stop-opacity:1;"
+         offset="1"
+         id="stop876" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5515">
+      <stop
+         id="stop5517"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4942-3">
+      <stop
+         id="stop4944"
+         offset="0"
+         style="stop-color:#ff6600;stop-opacity:1;" />
+      <stop
+         id="stop4946"
+         offset="1"
+         style="stop-color:#de5800;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5695-6">
+      <stop
+         id="stop5697-6"
+         offset="0"
+         style="stop-color:#3c3c3c;stop-opacity:1;" />
+      <stop
+         id="stop5699-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5695-4">
+      <stop
+         id="stop5697-7"
+         offset="0"
+         style="stop-color:#646464;stop-opacity:1;" />
+      <stop
+         id="stop5699-6"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4942-73">
+      <stop
+         id="stop4944-6"
+         offset="0"
+         style="stop-color:#ff6600;stop-opacity:1;" />
+      <stop
+         id="stop4946-6"
+         offset="1"
+         style="stop-color:#de5800;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4942-5">
+      <stop
+         id="stop4944-9"
+         offset="0"
+         style="stop-color:#ff6600;stop-opacity:1;" />
+      <stop
+         id="stop4946-5"
+         offset="1"
+         style="stop-color:#de5800;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="16.252333"
+       x2="10.624022"
+       y1="3.1950266"
+       x1="7.1253266"
+       id="linearGradient4996"
+       xlink:href="#linearGradient4942-3"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="32"
+       x2="16"
+       y1="8"
+       x1="16"
+       id="linearGradient4994"
+       xlink:href="#linearGradient5695-4"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="16.252333"
+       x2="10.624022"
+       y1="3.1950266"
+       x1="7.1253266"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient2263"
+       xlink:href="#linearGradient4942-3"
+       inkscape:collect="always" />
+  </defs>
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <rdf:Description
+         rdf:about="">
+        <dc:title />
+        <dc:creator />
+        <dc:rights />
+        <dc:description />
+        <dc:format>image/svg+xml</dc:format>
+        <dc:language>en</dc:language>
+      </rdf:Description>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mixxx 1.12+ iconset</dc:title>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>Mixxx</rdf:li>
+            <rdf:li>GUI</rdf:li>
+            <rdf:li>Interface</rdf:li>
+            <rdf:li>Icons</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>s.brandt@mixxx.org</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/publicdomain/" />
+        <dc:date>2014-04-18</dc:date>
+        <dc:source>www.mixxx.org</dc:source>
+        <dc:description>Iconset for use in Mixxx 1.12s+. Optimized for 48px (16px) icon size. Contains icons for preference menu and library widget
+
+Grid based on suggestions from http://techbase.kde.org/Projects/Oxygen/Style</dc:description>
+        <dc:coverage />
+        <dc:language>en</dc:language>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/publicdomain/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="#g6169"
+     id="ic_library_crates"
+     style="display:inline">
+    <g
+       style="display:inline;fill:url(#linearGradient4996);fill-opacity:1;stroke:none"
+       transform="matrix(1.7149251,0.45951286,-0.45951284,1.7149252,5.2487542,-0.75341108)"
+       id="g4345-3">
+      <title
+         style="fill-opacity:1"
+         id="title4347-8">Layer 1</title>
+      <path
+         style="fill:url(#linearGradient2263);fill-opacity:1.0;stroke:none"
+         id="path4349-3"
+         d="M 9.7493474,12.988007 14.528654,4.7100059 6.2506525,-0.06929989 1.4713466,8.2087009 Z"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       id="path4351-0"
+       d="M 1.9999999,18 V 28.181818 30 H 30 V 28 18 H 28 V 28 H 4 V 18 Z"
+       style="display:inline;fill:url(#linearGradient4994);fill-opacity:1;stroke:none"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+  </g>
+</svg>

--- a/res/images/library/ic_library_history_grey.svg
+++ b/res/images/library/ic_library_history_grey.svg
@@ -1,0 +1,272 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="135"
+   inkscape:export-xdpi="135"
+   inkscape:export-filename=""
+   style="display:inline"
+   sodipodi:docname="ic_library_history_grey.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   id="svg2"
+   height="32"
+   width="32"
+   version="1.1">
+  <sodipodi:namedview
+     inkscape:document-rotation="0"
+     inkscape:snap-midpoints="true"
+     inkscape:guide-bbox="true"
+     showguides="true"
+     inkscape:object-paths="true"
+     inkscape:current-layer="ic_library_history"
+     inkscape:window-maximized="1"
+     inkscape:window-y="32"
+     inkscape:window-x="2560"
+     inkscape:cy="18.688638"
+     inkscape:cx="18.878377"
+     inkscape:zoom="11.313708"
+     showgrid="true"
+     id="namedview26"
+     inkscape:window-height="2075"
+     inkscape:window-width="3840"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff">
+    <inkscape:grid
+       dotted="false"
+       originy="4"
+       empopacity="0.25098039"
+       empcolor="#0072ff"
+       opacity="0.1254902"
+       color="#00ffe0"
+       spacingy="1"
+       spacingx="1"
+       originx="4"
+       snapvisiblegridlinesonly="true"
+       enabled="true"
+       visible="true"
+       empspacing="4"
+       id="grid3788"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <title
+     id="title5647">Mixxx 1.12+ iconset</title>
+  <defs
+     id="defs28">
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5515">
+      <stop
+         id="stop5517"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4942">
+      <stop
+         id="stop4944"
+         offset="0"
+         style="stop-color:#ff6600;stop-opacity:1;" />
+      <stop
+         id="stop4946"
+         offset="1"
+         style="stop-color:#de5800;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5695-6">
+      <stop
+         id="stop5697-6"
+         offset="0"
+         style="stop-color:#3c3c3c;stop-opacity:1;" />
+      <stop
+         id="stop5699-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5695-4">
+      <stop
+         id="stop5697-7"
+         offset="0"
+         style="stop-color:#646464;stop-opacity:1;" />
+      <stop
+         id="stop5699-6"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4942-73">
+      <stop
+         id="stop4944-6"
+         offset="0"
+         style="stop-color:#ff6600;stop-opacity:1;" />
+      <stop
+         id="stop4946-6"
+         offset="1"
+         style="stop-color:#de5800;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4942-5">
+      <stop
+         id="stop4944-9"
+         offset="0"
+         style="stop-color:#ff6600;stop-opacity:1;" />
+      <stop
+         id="stop4946-5"
+         offset="1"
+         style="stop-color:#de5800;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="25.09091"
+       x2="-34.862213"
+       y1="8.090909"
+       x1="-34.862213"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4219"
+       xlink:href="#linearGradient5695-4"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="41.729565"
+       x2="24.27586"
+       y1="17.642313"
+       x1="24.275867"
+       gradientTransform="matrix(0.24166667,0,0,0.91334616,-4.866666,-8.1135391)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4215"
+       xlink:href="#linearGradient5695-4"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="27.496189"
+       x2="102.89655"
+       y1="27.496187"
+       x1="11.862065"
+       gradientTransform="matrix(0,0.24166667,-0.91334616,0,26.113539,5.133334)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4212"
+       xlink:href="#linearGradient5695-4"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="55.962944"
+       x2="15.999998"
+       y1="7.7884369"
+       x1="16.000013"
+       gradientTransform="matrix(0.12083333,0,0,0.45667308,-0.933333,4.4432303)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4209"
+       xlink:href="#linearGradient5695-4"
+       inkscape:collect="always" />
+  </defs>
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <rdf:Description
+         rdf:about="">
+        <dc:title />
+        <dc:creator />
+        <dc:rights />
+        <dc:description />
+        <dc:format>image/svg+xml</dc:format>
+        <dc:language>en</dc:language>
+      </rdf:Description>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mixxx 1.12+ iconset</dc:title>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>Mixxx</rdf:li>
+            <rdf:li>GUI</rdf:li>
+            <rdf:li>Interface</rdf:li>
+            <rdf:li>Icons</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>s.brandt@mixxx.org</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/publicdomain/" />
+        <dc:date>2014-04-18</dc:date>
+        <dc:source>www.mixxx.org</dc:source>
+        <dc:description>Iconset for use in Mixxx 1.12s+. Optimized for 48px (16px) icon size. Contains icons for preference menu and library widget
+
+Grid based on suggestions from http://techbase.kde.org/Projects/Oxygen/Style</dc:description>
+        <dc:coverage />
+        <dc:language>en</dc:language>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/publicdomain/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="#g6169"
+     id="ic_library_crates"
+     style="display:inline">
+    <g
+       inkscape:label="#g4221"
+       id="ic_library_history"
+       style="display:inline">
+      <rect
+         width="16"
+         height="16"
+         x="-28"
+         y="-26"
+         id="rect10837-5-8-4-4-2"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1;marker:none;enable-background:new"
+         transform="matrix(0,-1,-1,0,0,0)" />
+      <path
+         sodipodi:arc-type="arc"
+         sodipodi:type="arc"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient4219);stroke-width:3.09091;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
+         id="path7817"
+         sodipodi:cx="-22.5"
+         sodipodi:cy="13.5"
+         sodipodi:rx="8.5"
+         sodipodi:ry="8.5"
+         d="m -30.870866,12.02399 a 8.5,8.5 0 0 1 8.000101,-7.0158999 8.5,8.5 0 0 1 8.581135,6.2919479 8.5,8.5 0 0 1 -4.285507,9.739554 8.5,8.5 0 0 1 -10.436241,-2.075898"
+         transform="matrix(1.2941177,0,0,1.2941176,46.115809,-2.470588)"
+         sodipodi:start="3.3161256"
+         sodipodi:end="2.443461"
+         sodipodi:open="true" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient4215);stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="M 4,14 C 4,4 4,4 4,4"
+         id="path9802"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path9821"
+         d="m 4,14 c 10,0 10,0 10,0"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient4212);stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient4209);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="rect9825"
+         width="1"
+         height="1"
+         x="2.5"
+         y="14.5" />
+    </g>
+  </g>
+</svg>

--- a/res/images/library/ic_library_history_half_grey.svg
+++ b/res/images/library/ic_library_history_half_grey.svg
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="135"
+   inkscape:export-xdpi="135"
+   inkscape:export-filename=""
+   style="display:inline"
+   sodipodi:docname="ic_library_history_half_grey.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   id="svg2"
+   height="32"
+   width="32"
+   version="1.1">
+  <sodipodi:namedview
+     inkscape:document-rotation="0"
+     inkscape:snap-midpoints="true"
+     inkscape:guide-bbox="true"
+     showguides="true"
+     inkscape:object-paths="true"
+     inkscape:current-layer="ic_library_history"
+     inkscape:window-maximized="1"
+     inkscape:window-y="32"
+     inkscape:window-x="2560"
+     inkscape:cy="18.688638"
+     inkscape:cx="18.878377"
+     inkscape:zoom="11.313708"
+     showgrid="true"
+     id="namedview26"
+     inkscape:window-height="2075"
+     inkscape:window-width="3840"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff">
+    <inkscape:grid
+       dotted="false"
+       originy="4"
+       empopacity="0.25098039"
+       empcolor="#0072ff"
+       opacity="0.1254902"
+       color="#00ffe0"
+       spacingy="1"
+       spacingx="1"
+       originx="4"
+       snapvisiblegridlinesonly="true"
+       enabled="true"
+       visible="true"
+       empspacing="4"
+       id="grid3788"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <title
+     id="title5647">Mixxx 1.12+ iconset</title>
+  <defs
+     id="defs28">
+    <linearGradient
+       id="linearGradient5695-4">
+      <stop
+         style="stop-color:#646464;stop-opacity:1;"
+         offset="0"
+         id="stop2354" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="1"
+         id="stop2356" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5515">
+      <stop
+         id="stop5517"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4942">
+      <stop
+         id="stop4944"
+         offset="0"
+         style="stop-color:#ff6600;stop-opacity:1;" />
+      <stop
+         id="stop4946"
+         offset="1"
+         style="stop-color:#de5800;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5695-6">
+      <stop
+         id="stop5697-6"
+         offset="0"
+         style="stop-color:#3c3c3c;stop-opacity:1;" />
+      <stop
+         id="stop5699-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5695-4-3">
+      <stop
+         id="stop5697-7"
+         offset="0"
+         style="stop-color:#646464;stop-opacity:1;" />
+      <stop
+         id="stop5699-6"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4942-73">
+      <stop
+         id="stop4944-6"
+         offset="0"
+         style="stop-color:#ff6600;stop-opacity:1;" />
+      <stop
+         id="stop4946-6"
+         offset="1"
+         style="stop-color:#de5800;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4942-5">
+      <stop
+         id="stop4944-9"
+         offset="0"
+         style="stop-color:#ff6600;stop-opacity:1;" />
+      <stop
+         id="stop4946-5"
+         offset="1"
+         style="stop-color:#de5800;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="25.09091"
+       x2="-34.862213"
+       y1="8.090909"
+       x1="-34.862213"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4219"
+       xlink:href="#linearGradient5695-4"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="41.729565"
+       x2="24.27586"
+       y1="17.642313"
+       x1="24.275867"
+       gradientTransform="matrix(0.24166667,0,0,0.91334616,-4.866666,-8.1135391)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4215"
+       xlink:href="#linearGradient4942"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="27.496189"
+       x2="102.89655"
+       y1="27.496187"
+       x1="11.862065"
+       gradientTransform="matrix(0,0.24166667,-0.91334616,0,26.113539,5.133334)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4212"
+       xlink:href="#linearGradient4942"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="55.962944"
+       x2="15.999998"
+       y1="7.7884369"
+       x1="16.000013"
+       gradientTransform="matrix(0.12083333,0,0,0.45667308,-0.933333,4.4432303)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4209"
+       xlink:href="#linearGradient4942"
+       inkscape:collect="always" />
+  </defs>
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <rdf:Description
+         rdf:about="">
+        <dc:title />
+        <dc:creator />
+        <dc:rights />
+        <dc:description />
+        <dc:format>image/svg+xml</dc:format>
+        <dc:language>en</dc:language>
+      </rdf:Description>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mixxx 1.12+ iconset</dc:title>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>Mixxx</rdf:li>
+            <rdf:li>GUI</rdf:li>
+            <rdf:li>Interface</rdf:li>
+            <rdf:li>Icons</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>s.brandt@mixxx.org</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/publicdomain/" />
+        <dc:date>2014-04-18</dc:date>
+        <dc:source>www.mixxx.org</dc:source>
+        <dc:description>Iconset for use in Mixxx 1.12s+. Optimized for 48px (16px) icon size. Contains icons for preference menu and library widget
+
+Grid based on suggestions from http://techbase.kde.org/Projects/Oxygen/Style</dc:description>
+        <dc:coverage />
+        <dc:language>en</dc:language>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/publicdomain/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="#g6169"
+     id="ic_library_crates"
+     style="display:inline">
+    <g
+       inkscape:label="#g4221"
+       id="ic_library_history"
+       style="display:inline">
+      <rect
+         width="16"
+         height="16"
+         x="-28"
+         y="-26"
+         id="rect10837-5-8-4-4-2"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1;marker:none;enable-background:new"
+         transform="matrix(0,-1,-1,0,0,0)" />
+      <path
+         sodipodi:arc-type="arc"
+         sodipodi:type="arc"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient4219);stroke-width:3.09091;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
+         id="path7817"
+         sodipodi:cx="-22.5"
+         sodipodi:cy="13.5"
+         sodipodi:rx="8.5"
+         sodipodi:ry="8.5"
+         d="m -30.870866,12.02399 a 8.5,8.5 0 0 1 8.000101,-7.0158999 8.5,8.5 0 0 1 8.581135,6.2919479 8.5,8.5 0 0 1 -4.285507,9.739554 8.5,8.5 0 0 1 -10.436241,-2.075898"
+         transform="matrix(1.2941177,0,0,1.2941176,46.115809,-2.470588)"
+         sodipodi:start="3.3161256"
+         sodipodi:end="2.443461"
+         sodipodi:open="true" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient4215);stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="M 4,14 C 4,4 4,4 4,4"
+         id="path9802"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path9821"
+         d="m 4,14 c 10,0 10,0 10,0"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient4212);stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient4209);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="rect9825"
+         width="1"
+         height="1"
+         x="2.5"
+         y="14.5" />
+    </g>
+  </g>
+</svg>

--- a/res/images/library/ic_library_playlist_grey.svg
+++ b/res/images/library/ic_library_playlist_grey.svg
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="135"
+   inkscape:export-xdpi="135"
+   inkscape:export-filename=""
+   style="display:inline"
+   sodipodi:docname="ic_library_playlist_grey.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   id="svg2"
+   height="32"
+   width="32"
+   version="1.1">
+  <sodipodi:namedview
+     inkscape:document-rotation="0"
+     inkscape:snap-midpoints="true"
+     inkscape:guide-bbox="true"
+     showguides="true"
+     inkscape:object-paths="true"
+     inkscape:current-layer="ic_library_playlist"
+     inkscape:window-maximized="1"
+     inkscape:window-y="32"
+     inkscape:window-x="2560"
+     inkscape:cy="16.774952"
+     inkscape:cx="30.089766"
+     inkscape:zoom="16"
+     showgrid="true"
+     id="namedview26"
+     inkscape:window-height="2075"
+     inkscape:window-width="3840"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff">
+    <inkscape:grid
+       dotted="false"
+       originy="4"
+       empopacity="0.25098039"
+       empcolor="#0072ff"
+       opacity="0.1254902"
+       color="#00ffe0"
+       spacingy="1"
+       spacingx="1"
+       originx="4"
+       snapvisiblegridlinesonly="true"
+       enabled="true"
+       visible="true"
+       empspacing="4"
+       id="grid3788"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <title
+     id="title5647">Mixxx 1.12+ iconset</title>
+  <defs
+     id="defs28">
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5515">
+      <stop
+         id="stop5517"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4942">
+      <stop
+         id="stop4944"
+         offset="0"
+         style="stop-color:#ff6600;stop-opacity:1;" />
+      <stop
+         id="stop4946"
+         offset="1"
+         style="stop-color:#de5800;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5695-6">
+      <stop
+         id="stop5697-6"
+         offset="0"
+         style="stop-color:#3c3c3c;stop-opacity:1;" />
+      <stop
+         id="stop5699-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5695-4">
+      <stop
+         id="stop5697-7"
+         offset="0"
+         style="stop-color:#646464;stop-opacity:1;" />
+      <stop
+         id="stop5699-6"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4942-73">
+      <stop
+         id="stop4944-6"
+         offset="0"
+         style="stop-color:#ff6600;stop-opacity:1;" />
+      <stop
+         id="stop4946-6"
+         offset="1"
+         style="stop-color:#de5800;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4942-5">
+      <stop
+         id="stop4944-9"
+         offset="0"
+         style="stop-color:#ff6600;stop-opacity:1;" />
+      <stop
+         id="stop4946-5"
+         offset="1"
+         style="stop-color:#de5800;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="16"
+       y1="8"
+       x1="16"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5319"
+       xlink:href="#linearGradient5695-4"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="32"
+       x2="20"
+       y1="8"
+       x1="20"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5316"
+       xlink:href="#linearGradient5695-4"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="14"
+       x2="27"
+       y1="14"
+       x1="-1"
+       id="linearGradient1016"
+       xlink:href="#linearGradient5695-6"
+       inkscape:collect="always" />
+  </defs>
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <rdf:Description
+         rdf:about="">
+        <dc:title />
+        <dc:creator />
+        <dc:rights />
+        <dc:description />
+        <dc:format>image/svg+xml</dc:format>
+        <dc:language>en</dc:language>
+      </rdf:Description>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mixxx 1.12+ iconset</dc:title>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>Mixxx</rdf:li>
+            <rdf:li>GUI</rdf:li>
+            <rdf:li>Interface</rdf:li>
+            <rdf:li>Icons</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>s.brandt@mixxx.org</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/publicdomain/" />
+        <dc:date>2014-04-18</dc:date>
+        <dc:source>www.mixxx.org</dc:source>
+        <dc:description>Iconset for use in Mixxx 1.12s+. Optimized for 48px (16px) icon size. Contains icons for preference menu and library widget
+
+Grid based on suggestions from http://techbase.kde.org/Projects/Oxygen/Style</dc:description>
+        <dc:coverage />
+        <dc:language>en</dc:language>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/publicdomain/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="#g6169"
+     id="ic_library_crates"
+     style="display:inline">
+    <g
+       transform="translate(2)"
+       inkscape:label="#g6141"
+       id="ic_library_playlist"
+       style="display:inline">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient5319);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient1016);stroke-width:2;marker:none;enable-background:accumulate;stroke-opacity:1"
+         d="M 1,4 C 0.446,4 0,4.446 0,5 v 18 c 0,0.554 0.446,1 1,1 h 24 c 0.554,0 1,-0.446 1,-1 V 5 C 26,4.446 25.554,4 25,4 Z M 8.9375,8.03125 C 9.2716216,8.0083571 9.6883986,8.0774079 10.09375,8.25 l 4.625,2.40625 4.6875,2.375 c 0.771083,0.373736 0.885067,1.433886 0.21875,1.9375 -0.07084,0.04305 -0.13991,0.09421 -0.21875,0.125 l -4.75,2.3125 L 10,19.6875 C 9,20.243635 8,20 8,19 L 7.96875,14 8,9 C 8,8.375 8.3806306,8.0694048 8.9375,8.03125 Z"
+         id="rect10668"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient5316);stroke-width:1.99949;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 2.999743,27.000257 H 29.000256 V 6.9997433"
+         id="path10670"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/res/images/library/ic_library_playlist_half_grey.svg
+++ b/res/images/library/ic_library_playlist_half_grey.svg
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="135"
+   inkscape:export-xdpi="135"
+   inkscape:export-filename=""
+   style="display:inline"
+   sodipodi:docname="ic_library_playlist_half_grey.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   id="svg2"
+   height="32"
+   width="32"
+   version="1.1">
+  <sodipodi:namedview
+     inkscape:document-rotation="0"
+     inkscape:snap-midpoints="true"
+     inkscape:guide-bbox="true"
+     showguides="true"
+     inkscape:object-paths="true"
+     inkscape:current-layer="ic_library_playlist"
+     inkscape:window-maximized="1"
+     inkscape:window-y="32"
+     inkscape:window-x="2560"
+     inkscape:cy="16.774952"
+     inkscape:cx="30.089766"
+     inkscape:zoom="16"
+     showgrid="true"
+     id="namedview26"
+     inkscape:window-height="2075"
+     inkscape:window-width="3840"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff">
+    <inkscape:grid
+       dotted="false"
+       originy="4"
+       empopacity="0.25098039"
+       empcolor="#0072ff"
+       opacity="0.1254902"
+       color="#00ffe0"
+       spacingy="1"
+       spacingx="1"
+       originx="4"
+       snapvisiblegridlinesonly="true"
+       enabled="true"
+       visible="true"
+       empspacing="4"
+       id="grid3788"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <title
+     id="title5647">Mixxx 1.12+ iconset</title>
+  <defs
+     id="defs28">
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5515">
+      <stop
+         id="stop5517"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4942">
+      <stop
+         id="stop4944"
+         offset="0"
+         style="stop-color:#ff6600;stop-opacity:1;" />
+      <stop
+         id="stop4946"
+         offset="1"
+         style="stop-color:#de5800;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5695-6">
+      <stop
+         id="stop5697-6"
+         offset="0"
+         style="stop-color:#3c3c3c;stop-opacity:1;" />
+      <stop
+         id="stop5699-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5695-4">
+      <stop
+         id="stop5697-7"
+         offset="0"
+         style="stop-color:#646464;stop-opacity:1;" />
+      <stop
+         id="stop5699-6"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4942-73">
+      <stop
+         id="stop4944-6"
+         offset="0"
+         style="stop-color:#ff6600;stop-opacity:1;" />
+      <stop
+         id="stop4946-6"
+         offset="1"
+         style="stop-color:#de5800;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4942-5">
+      <stop
+         id="stop4944-9"
+         offset="0"
+         style="stop-color:#ff6600;stop-opacity:1;" />
+      <stop
+         id="stop4946-5"
+         offset="1"
+         style="stop-color:#de5800;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="16"
+       y1="8"
+       x1="16"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5319"
+       xlink:href="#linearGradient4942"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="32"
+       x2="20"
+       y1="8"
+       x1="20"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5316"
+       xlink:href="#linearGradient5695-4"
+       inkscape:collect="always" />
+  </defs>
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <rdf:Description
+         rdf:about="">
+        <dc:title />
+        <dc:creator />
+        <dc:rights />
+        <dc:description />
+        <dc:format>image/svg+xml</dc:format>
+        <dc:language>en</dc:language>
+      </rdf:Description>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mixxx 1.12+ iconset</dc:title>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>Mixxx</rdf:li>
+            <rdf:li>GUI</rdf:li>
+            <rdf:li>Interface</rdf:li>
+            <rdf:li>Icons</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>s.brandt@mixxx.org</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/publicdomain/" />
+        <dc:date>2014-04-18</dc:date>
+        <dc:source>www.mixxx.org</dc:source>
+        <dc:description>Iconset for use in Mixxx 1.12s+. Optimized for 48px (16px) icon size. Contains icons for preference menu and library widget
+
+Grid based on suggestions from http://techbase.kde.org/Projects/Oxygen/Style</dc:description>
+        <dc:coverage />
+        <dc:language>en</dc:language>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/publicdomain/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="#g6169"
+     id="ic_library_crates"
+     style="display:inline">
+    <g
+       transform="translate(2)"
+       inkscape:label="#g6141"
+       id="ic_library_playlist"
+       style="display:inline">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient5319);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         d="M 1,4 C 0.446,4 0,4.446 0,5 v 18 c 0,0.554 0.446,1 1,1 h 24 c 0.554,0 1,-0.446 1,-1 V 5 C 26,4.446 25.554,4 25,4 Z M 8.9375,8.03125 C 9.2716216,8.0083571 9.6883986,8.0774079 10.09375,8.25 l 4.625,2.40625 4.6875,2.375 c 0.771083,0.373736 0.885067,1.433886 0.21875,1.9375 -0.07084,0.04305 -0.13991,0.09421 -0.21875,0.125 l -4.75,2.3125 L 10,19.6875 C 9,20.243635 8,20 8,19 L 7.96875,14 8,9 C 8,8.375 8.3806306,8.0694048 8.9375,8.03125 Z"
+         id="rect10668"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient5316);stroke-width:1.99949;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 2.999743,27.000257 H 29.000256 V 6.9997433"
+         id="path10670"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/res/mixxx.qrc
+++ b/res/mixxx.qrc
@@ -14,13 +14,19 @@
         <file>images/library/ic_library_banshee.svg</file>
         <file>images/library/ic_library_computer.svg</file> <!-- from Gnome high contrast icons LGPL 2.1 -->
         <file>images/library/ic_library_crates.svg</file>
+        <file>images/library/ic_library_crates_half_grey.svg</file>
+        <file>images/library/ic_library_crates_grey.svg</file>
         <file>images/library/ic_library_cross_grey.svg</file>
         <file>images/library/ic_library_cross_orange.svg</file>
         <file>images/library/ic_library_history.svg</file>
+        <file>images/library/ic_library_history_half_grey.svg</file>
+        <file>images/library/ic_library_history_grey.svg</file>
         <file>images/library/ic_library_history_current.svg</file>
         <file>images/library/ic_library_itunes.svg</file>
         <file>images/library/ic_library_tracks.svg</file> <!-- from Gnome high contrast icons LGPL 2.1 -->
         <file>images/library/ic_library_playlist.svg</file>
+        <file>images/library/ic_library_playlist_half_grey.svg</file>
+        <file>images/library/ic_library_playlist_grey.svg</file>
         <file>images/library/ic_library_prepare.svg</file>
         <file>images/library/ic_library_preview_pause.svg</file>
         <file>images/library/ic_library_preview_play.svg</file>

--- a/res/skins/Deere/library.xml
+++ b/res/skins/Deere/library.xml
@@ -69,22 +69,34 @@
                 </Children>
               </WidgetGroup>
 
-              <Splitter>
-                <ObjectName>InfobarSplitter</ObjectName>
-                <Orientation>vertical</Orientation>
+              <!-- with infobar -->
+              <WidgetGroup>
+                <Layout>vertical</Layout>
                 <SizePolicy>me,me</SizePolicy>
-                <SplitSizesConfigKey>[Skin],libraryInfobar_splitsize</SplitSizesConfigKey>
-                <SplitSizes>8,1</SplitSizes>
+                <Orientation>vertical</Orientation>
                 <Children>
                   <Library>
                     <ShowButtonText>false</ShowButtonText>
                     <TrackTableBackgroundColorOpacity>0.175</TrackTableBackgroundColorOpacity>
                   </Library>
-                  <Infobar>
-                    <Group>[Library]</Group>
-                  </Infobar>
+
+                  <WidgetGroup>
+                    <Layout>vertical</Layout>
+                    <SizePolicy>m,m</SizePolicy>
+                    <Connection>
+                      <ConfigKey>[Library],show_infobar</ConfigKey>
+                      <BindProperty>visible</BindProperty>
+                    </Connection>
+                    <Children>
+                      <Infobar>
+                        <ObjectName>Infobar</ObjectName>
+                        <Group>[Library]</Group>
+                      </Infobar>
+                    </Children>
+                  </WidgetGroup>
                 </Children>
-              </Splitter>
+              </WidgetGroup>
+
 
             </Children>
             <!--Connection>

--- a/res/skins/Deere/library.xml
+++ b/res/skins/Deere/library.xml
@@ -69,10 +69,22 @@
                 </Children>
               </WidgetGroup>
 
-              <Library>
-                <ShowButtonText>false</ShowButtonText>
-                <TrackTableBackgroundColorOpacity>0.175</TrackTableBackgroundColorOpacity>
-              </Library>
+              <Splitter>
+                <ObjectName>InfobarSplitter</ObjectName>
+                <Orientation>vertical</Orientation>
+                <SizePolicy>me,me</SizePolicy>
+                <SplitSizesConfigKey>[Skin],libraryInfobar_splitsize</SplitSizesConfigKey>
+                <SplitSizes>8,1</SplitSizes>
+                <Children>
+                  <Library>
+                    <ShowButtonText>false</ShowButtonText>
+                    <TrackTableBackgroundColorOpacity>0.175</TrackTableBackgroundColorOpacity>
+                  </Library>
+                  <Infobar>
+                    <Group>[Library]</Group>
+                  </Infobar>
+                </Children>
+              </Splitter>
 
             </Children>
             <!--Connection>

--- a/res/skins/Deere/skin.xml
+++ b/res/skins/Deere/skin.xml
@@ -53,6 +53,7 @@
       <attribute config_key="[Master],maximize_library">0</attribute>
       <attribute persist="true" config_key="[PreviewDeck],show_previewdeck">0</attribute>
       <attribute persist="true" config_key="[Library],show_coverart">1</attribute>
+      <attribute persist="true" config_key="[Library],show_infobar">1</attribute>
       <!--Disable hidden effect routing Buttons-->
       <attribute persist="false" config_key="[EffectRack1_EffectUnit1],group_[MasterOutput]_enable">0</attribute>
       <attribute persist="false" config_key="[EffectRack1_EffectUnit1],group_[BusLeft]_enable">0</attribute>

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -526,6 +526,9 @@ WLibrary QRadioButton::indicator:unchecked {
 }
 /* buttons in library (in hierarchical order of appearance)
    Style them just as the other regular buttons */
+#InfobarCratesContainer > QPushButton,
+#InfobarPlaylistsContainer > QPushButton,
+#InfobarHistoryContainer > QPushButton,
 #LibraryFeatureControls QPushButton {
   margin: 9px 3px 6px 3px;
   padding: 3px 4px;
@@ -543,7 +546,12 @@ WLibrary QRadioButton::indicator:unchecked {
     QPushButton#pushButtonAutoDJ {
       width: 42px;
     }
-
+  #InfobarCratesContainer > QPushButton,
+  #InfobarPlaylistsContainer > QPushButton,
+  #InfobarHistoryContainer > QPushButton {
+    padding: 0px 3px 0px 3px;
+    margin: 0px;
+  }
 
 #LibraryFeatureControls QPushButton:!enabled {
   /* buttons in "disabled" (not click-able) state. They are nearly invisible
@@ -556,6 +564,9 @@ WLibrary QRadioButton::indicator:unchecked {
   outline: none;
 }
 
+#InfobarCratesContainer > QPushButton:hover,
+#InfobarPlaylistsContainer > QPushButton:hover,
+#InfobarHistoryContainer > QPushButton:hover,
 #LibraryFeatureControls QPushButton:hover {
   color: #D2D2D2;
   background-color: #5F5F5F;
@@ -593,6 +604,9 @@ QPushButton#pushButtonRecording:checked:hover {
   outline: none;
 }
 
+#InfobarCratesContainer > QPushButton:pressed,
+#InfobarPlaylistsContainer > QPushButton:pressed,
+#InfobarHistoryContainer > QPushButton:pressed,
 #LibraryFeatureControls QPushButton:pressed {
   /* pushbuttons in "down" state */
   margin: 9px 3px 6px 3px;
@@ -601,7 +615,12 @@ QPushButton#pushButtonRecording:checked:hover {
   border: 1px solid #006596;
   outline: none;
 }
-
+#InfobarCratesContainer > QPushButton:pressed,
+#InfobarPlaylistsContainer > QPushButton:pressed,
+#InfobarHistoryContainer > QPushButton:pressed {
+  margin: 0px;
+  border-right: 1px ridge #015d8d;
+}
 
 /* AutoDJ button icons */
 QPushButton#pushButtonAutoDJ {
@@ -1305,6 +1324,7 @@ WBeatSpinBox,
   qproperty-layoutSpacing: 0;
 }
 
+#Infobar,
 #MainDecks, #MainDeckContainer {
   background-color: #333333;
 }
@@ -2233,63 +2253,65 @@ WRateRange {
     qproperty-alignment: 'AlignRight | AlignTop';
 }
 
-#RateDisplayBottomPrefix {
-    qproperty-alignment: 'AlignLeft | AlignBottom';
-}
-#RateDisplayBottomRate {
-    qproperty-alignment: 'AlignRight | AlignBottom';
-}
-
 #InfobarSplitter {
   background-color: #222222;
 }
 
-#infobarContainer {
-  background-color: #ff00ff;
-}
 
-#infobarCrates {
-  border: 1px solid #ffff00;
-  border-width: 0px 1px 0px 1px;
-  background-color: #006f00;
-  border-radius: 2px;
-  margin: 0;
-  padding: 0 3px 0 3px;
-  Text-align:left;
-}
-
-WInfoBarItem {
-  background-color: #F0fff0;
-  margin: 0;
+WInfoBarContainer,
+WInfoBarContainer QWidget {
   padding: 0;
-  Text-align:left;
-}
-
-WInfoBarCrateItem {
-  background-color: #F00ff0;
-}
-
-#infobarCratesContainer {
   margin: 0;
-  padding: 0;
-  spacing: 0;
 }
 
-
-#infobarPlaylists {
-  border: 1px solid #ffff00;
-  border-width: 0px 1px 0px 1px;
-  background-color: #00fff0;
-  border-radius: 2px;
-  margin: 0;
-  padding: 0 3px 0 3px;
+WInfoBarButton {
+  /* tall button, about the same height as cue number + label edit box */
+    padding: 1px;
+    margin: 0 2px 0 0;
+    width: 20px;
+    height: 20px;
+    /* make the icon slightly larger than default 16px */
+    qproperty-iconSize: 20px;
+    background-color: #3B3B3B;
+    border-radius: 2px;
+    outline: none;
 }
 
-#infobarHistory {
-  border: 1px solid #ffff00;
-  border-width: 0px 1px 0px 1px;
-  background-color: #f03f00;
-  border-radius: 2px;
-  margin: 0;
-  padding: 0 3px 0 3px;
+/* normal */
+#InfobarCratesFrame WInfoBarButton[state="0"] {
+  qproperty-icon: url(:/images/library/ic_library_crates_half_grey.svg);
+}
+/* hidden */
+#InfobarCratesFrame WInfoBarButton[state="1"] {
+  qproperty-icon: url(:/images/library/ic_library_crates_grey.svg);
+}
+/* extended */
+#InfobarCratesFrame WInfoBarButton[state="2"] {
+  qproperty-icon: url(:/images/library/ic_library_crates.svg);
+}
+
+/* normal */
+#InfobarPlaylistsFrame WInfoBarButton[state="0"] {
+  qproperty-icon: url(:/images/library/ic_library_playlist_half_grey.svg);
+}
+/* hidden */
+#InfobarPlaylistsFrame WInfoBarButton[state="1"] {
+  qproperty-icon: url(:/images/library/ic_library_playlist_grey.svg);
+}
+/* extended */
+#InfobarPlaylistsFrame WInfoBarButton[state="2"] {
+  qproperty-icon: url(:/images/library/ic_library_playlist.svg);
+}
+
+/* normal */
+#InfobarHistoryFrame WInfoBarButton[state="0"] {
+  qproperty-icon: url(:/images/library/ic_library_history_half_grey.svg);
+}
+/* hidden */
+#InfobarHistoryFrame WInfoBarButton[state="1"] {
+  qproperty-icon: url(:/images/library/ic_library_history_grey.svg);
+}
+/* extended */
+#InfobarHistoryFrame WInfoBarButton[state="2"] {
+  qproperty-icon: url(:/images/library/ic_library_history.svg);
 }

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -2239,3 +2239,57 @@ WRateRange {
 #RateDisplayBottomRate {
     qproperty-alignment: 'AlignRight | AlignBottom';
 }
+
+#InfobarSplitter {
+  background-color: #222222;
+}
+
+#infobarContainer {
+  background-color: #ff00ff;
+}
+
+#infobarCrates {
+  border: 1px solid #ffff00;
+  border-width: 0px 1px 0px 1px;
+  background-color: #006f00;
+  border-radius: 2px;
+  margin: 0;
+  padding: 0 3px 0 3px;
+  Text-align:left;
+}
+
+WInfoBarItem {
+  background-color: #F0fff0;
+  margin: 0;
+  padding: 0;
+  Text-align:left;
+}
+
+WInfoBarCrateItem {
+  background-color: #F00ff0;
+}
+
+#infobarCratesContainer {
+  margin: 0;
+  padding: 0;
+  spacing: 0;
+}
+
+
+#infobarPlaylists {
+  border: 1px solid #ffff00;
+  border-width: 0px 1px 0px 1px;
+  background-color: #00fff0;
+  border-radius: 2px;
+  margin: 0;
+  padding: 0 3px 0 3px;
+}
+
+#infobarHistory {
+  border: 1px solid #ffff00;
+  border-width: 0px 1px 0px 1px;
+  background-color: #f03f00;
+  border-radius: 2px;
+  margin: 0;
+  padding: 0 3px 0 3px;
+}

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -1091,13 +1091,3 @@ QListView::branch:open:has-children:!has-siblings:selected,
 QListView::branch:open:has-children:has-siblings:selected { border-image: none; image: url(skin:/style/style_branch_open.png);
   background-color:qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #585858, stop:1 #0f0f0f);
 }
-
-WInfoBarCrateItem {
-  background-color: #FF0000;
-  color: black;
-}
-
-WInfoBarCrateMixedItem {
-  background-color: #FF0000;
-  color: black;
-}

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -1068,3 +1068,36 @@ QLabel#labelRecStatistics {
 #Border58 {
   border: 1px solid #585858;
 }
+
+/* Spacing between treeview and searchbar */
+QListView { margin: 10px 0px 0px 0px; }
+QListView:focus { border: 1px solid #8E5C00; }
+
+/* triangle for closed/opened branches in treeview */
+QListView { show-decoration-selected: 0; background-color: #151515; } /*  Suppresses that selected sidebar items branch indicator shows wrong color when out of focus ; lp:880588 */
+QListView::branch:has-children:!has-siblings:closed,
+QListView::branch:closed:has-children:has-siblings { border-image: none; image: url(skin:/style/style_branch_closed.png);
+  background-color:#0f0f0f;
+}
+QListView::branch:open:has-children:!has-siblings,
+QListView::branch:open:has-children:has-siblings { border-image: none; image: url(skin:/style/style_branch_open.png);
+  background-color:#0f0f0f;
+}
+QListView::branch:has-children:!has-siblings:closed:selected,
+QListView::branch:closed:has-children:has-siblings:selected { border-image: none; image: url(skin:/style/style_branch_closed.png);
+  background-color:qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #585858, stop:1 #0f0f0f);
+}
+QListView::branch:open:has-children:!has-siblings:selected,
+QListView::branch:open:has-children:has-siblings:selected { border-image: none; image: url(skin:/style/style_branch_open.png);
+  background-color:qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #585858, stop:1 #0f0f0f);
+}
+
+WInfoBarCrateItem {
+  background-color: #FF0000;
+  color: black;
+}
+
+WInfoBarCrateMixedItem {
+  background-color: #FF0000;
+  color: black;
+}

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -1128,11 +1128,6 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             tr("Cover Art Show/Hide (Library)"),
             tr("Show/hide cover art in the library"),
             guiMenu);
-    addControl("[Library]",
-            "show_infobar",
-            tr("Crates List Show/Hide"),
-            tr("Show/hide infobar"),
-            guiMenu);
     addControl("[Master]",
             "maximize_library",
             tr("Library Maximize/Restore"),

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -1129,9 +1129,9 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             tr("Show/hide cover art in the library"),
             guiMenu);
     addControl("[Library]",
-            "show_crates",
+            "show_infobar",
             tr("Crates List Show/Hide"),
-            tr("Show/hide list of crates"),
+            tr("Show/hide infobar"),
             guiMenu);
     addControl("[Master]",
             "maximize_library",
@@ -1151,6 +1151,11 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             "show_coverart",
             tr("Cover Art Show/Hide (Decks)"),
             tr("Show/hide cover art in the main decks"),
+            guiMenu);
+    addControl("[Library]",
+            "show_infobar",
+            tr("Infobar Show/Hide (Decks)"),
+            tr("Show/hide the infobar in the library"),
             guiMenu);
     addControl(VINYL_PREF_KEY,
             "show_vinylcontrol",

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -1128,6 +1128,11 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             tr("Cover Art Show/Hide (Library)"),
             tr("Show/hide cover art in the library"),
             guiMenu);
+    addControl("[Library]",
+            "show_crates",
+            tr("Crates List Show/Hide"),
+            tr("Show/hide list of crates"),
+            guiMenu);
     addControl("[Master]",
             "maximize_library",
             tr("Library Maximize/Restore"),

--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -12,6 +12,7 @@
 #include "track/track.h"
 #include "util/compatibility.h"
 #include "util/db/fwdsqlquery.h"
+#include "util/db/dbconnection.h"
 #include "util/math.h"
 
 PlaylistDAO::PlaylistDAO()
@@ -21,6 +22,32 @@ PlaylistDAO::PlaylistDAO()
 void PlaylistDAO::initialize(const QSqlDatabase& database) {
     DAO::initialize(database);
     populatePlaylistMembershipCache();
+
+    // create temporary views
+    QString queryString = QLatin1String(
+            "CREATE TEMPORARY VIEW IF NOT EXISTS PlaylistsCountsDurations "
+            "AS SELECT "
+            "  Playlists.id AS id, "
+            "  Playlists.name AS name, "
+            "  LOWER(Playlists.name) AS sort_name, "
+            "  COUNT(case library.mixxx_deleted when 0 then 1 else null end) "
+            "    AS count, "
+            "  SUM(case library.mixxx_deleted "
+            "    when 0 then library.duration else 0 end) AS durationSeconds "
+            "FROM Playlists "
+            "LEFT JOIN PlaylistTracks "
+            "  ON PlaylistTracks.playlist_id = Playlists.id "
+            "LEFT JOIN library "
+            "  ON PlaylistTracks.track_id = library.id "
+            "  WHERE Playlists.hidden = 0 "
+            "  GROUP BY Playlists.id");
+    queryString.append(
+            mixxx::DbConnection::collateLexicographically(
+                    " ORDER BY sort_name"));
+    QSqlQuery query(m_database);
+    if (!query.exec(queryString)) {
+        LOG_FAILED_QUERY(query);
+    }
 }
 
 void PlaylistDAO::populatePlaylistMembershipCache() {
@@ -1158,6 +1185,75 @@ void PlaylistDAO::getPlaylistsTrackIsIn(TrackId trackId,
             ++it) {
         playlistSet->insert(it.value());
     }
+}
+
+QList<PlaylistSummary> PlaylistDAO::createPlaylistSummaryForTracks(QList<TrackId> tracks) {
+    QSet<int> allPlaylistIds;
+    QSet<int> playlistIds;
+    QMap<int, int> trackCount;
+    for (TrackId trackId : qAsConst(tracks)) {
+        PlaylistDAO::getPlaylistsTrackIsIn(trackId, &playlistIds);
+        allPlaylistIds += playlistIds;
+        for (int playlistId : playlistIds) {
+            trackCount[playlistId] = trackCount.value(playlistId, 0) + 1;
+        }
+    }
+    QList<PlaylistSummary> summaries = PlaylistDAO::createPlaylistSummary(&allPlaylistIds);
+    for (PlaylistSummary summary : qAsConst(summaries)) {
+        DEBUG_ASSERT(trackCount.contains(summary.id()));
+        summary.setMatches(trackCount.value(summary.id()));
+    }
+    return summaries;
+}
+
+QList<PlaylistSummary> PlaylistDAO::createPlaylistSummary(QSet<int>* playlistIds) {
+    QList<PlaylistSummary> playlistLabels;
+
+    // Setup the sidebar playlist model
+    QSqlTableModel playlistTableModel(this, m_database);
+    playlistTableModel.setTable("PlaylistsCountsDurations");
+
+    if (playlistIds) {
+        QStringList idList;
+        for (const auto& playlistId : *playlistIds) {
+            idList.append(QString::number(playlistId));
+        }
+        playlistTableModel.setFilter(QString("Playlists.id in [%1]").arg(idList.join(",")));
+    }
+
+    playlistTableModel.select();
+    while (playlistTableModel.canFetchMore()) {
+        playlistTableModel.fetchMore();
+    }
+    QSqlRecord record = playlistTableModel.record();
+    int nameColumn = record.indexOf("name");
+    int idColumn = record.indexOf("id");
+    int countColumn = record.indexOf("count");
+    int durationColumn = record.indexOf("durationSeconds");
+
+    for (int row = 0; row < playlistTableModel.rowCount(); ++row) {
+        int id =
+                playlistTableModel
+                        .data(playlistTableModel.index(row, idColumn))
+                        .toInt();
+        QString name =
+                playlistTableModel
+                        .data(playlistTableModel.index(row, nameColumn))
+                        .toString();
+        int count =
+                playlistTableModel
+                        .data(playlistTableModel.index(row, countColumn))
+                        .toInt();
+        int duration =
+                playlistTableModel
+                        .data(playlistTableModel.index(row, durationColumn))
+                        .toInt();
+        PlaylistSummary playlist(id, name);
+        playlist.setCount(count);
+        playlist.setDuration(duration);
+        playlistLabels.append(playlist);
+    }
+    return playlistLabels;
 }
 
 void PlaylistDAO::setAutoDJProcessor(AutoDJProcessor* pAutoDJProcessor) {

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -118,8 +118,10 @@ class PlaylistDAO : public QObject, public virtual DAO {
     bool isTrackInPlaylist(TrackId trackId, const int playlistId) const;
 
     void getPlaylistsTrackIsIn(TrackId trackId, QSet<int>* playlistSet) const;
-    QList<PlaylistSummary> createPlaylistSummary(QSet<int>* playlistIds = nullptr);
-    QList<PlaylistSummary> createPlaylistSummaryForTracks(QList<TrackId> tracks);
+    QList<PlaylistSummary> createPlaylistSummary(QSet<int>* playlistIds = nullptr,
+            HiddenType type = PLHT_NOT_HIDDEN);
+    QList<PlaylistSummary> createPlaylistSummaryForTracks(QList<TrackId> tracks,
+            HiddenType type = PLHT_NOT_HIDDEN);
 
     void setAutoDJProcessor(AutoDJProcessor* pAutoDJProcessor);
 

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -2,10 +2,11 @@
 
 #include <QHash>
 #include <QObject>
-#include <QSqlDatabase>
 #include <QSet>
+#include <QSqlDatabase>
 
 #include "library/dao/dao.h"
+#include "library/trackset/playlistsummary.h"
 #include "track/trackid.h"
 #include "util/class.h"
 
@@ -117,6 +118,8 @@ class PlaylistDAO : public QObject, public virtual DAO {
     bool isTrackInPlaylist(TrackId trackId, const int playlistId) const;
 
     void getPlaylistsTrackIsIn(TrackId trackId, QSet<int>* playlistSet) const;
+    QList<PlaylistSummary> createPlaylistSummary(QSet<int>* playlistIds = nullptr);
+    QList<PlaylistSummary> createPlaylistSummaryForTracks(QList<TrackId> tracks);
 
     void setAutoDJProcessor(AutoDJProcessor* pAutoDJProcessor);
 

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -138,7 +138,8 @@ Library::Library(
     addFeature(browseFeature);
 
     addFeature(new RecordingFeature(this, m_pConfig, pRecordingManager));
-    addFeature(new SetlogFeature(this, UserSettingsPointer(m_pConfig)));
+    m_pSetlogFeature = new SetlogFeature(this, UserSettingsPointer(m_pConfig));
+    addFeature(m_pSetlogFeature);
 
     m_pAnalysisFeature = new AnalysisFeature(this, m_pConfig);
     connect(m_pPlaylistFeature,

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -360,6 +360,10 @@ void Library::bindLibraryWidget(
             &WTrackTableView::trackSelected,
             this,
             &Library::trackSelected);
+    connect(pTrackTableView,
+            &WTrackTableView::trackSelection,
+            this,
+            &Library::trackSelection);
 
     connect(this,
             &Library::setTrackTableFont,
@@ -425,6 +429,10 @@ void Library::addFeature(LibraryFeature* feature) {
             &LibraryFeature::trackSelected,
             this,
             &Library::trackSelected);
+    connect(feature,
+            &LibraryFeature::trackSelection,
+            this,
+            &Library::trackSelection);
 }
 
 void Library::onPlayerManagerTrackAnalyzerProgress(

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -27,6 +27,7 @@ class KeyboardEventFilter;
 class MixxxLibraryFeature;
 class PlayerManager;
 class PlaylistFeature;
+class SetlogFeature;
 class RecordingManager;
 class SidebarModel;
 class TrackCollection;
@@ -85,6 +86,15 @@ class Library: public QObject {
     }
 
     //static Library* buildDefaultLibrary();
+    CrateFeature* getCreateFeature() {
+        return m_pCrateFeature;
+    };
+    PlaylistFeature* getPlaylistFeature() {
+        return m_pPlaylistFeature;
+    };
+    SetlogFeature* getSetlogFeature() {
+        return m_pSetlogFeature;
+    };
 
     enum class RemovalType {
         KeepTracks,
@@ -161,6 +171,7 @@ class Library: public QObject {
     const static QString m_sAutoDJViewName;
     MixxxLibraryFeature* m_pMixxxLibraryFeature;
     PlaylistFeature* m_pPlaylistFeature;
+    SetlogFeature* m_pSetlogFeature;
     CrateFeature* m_pCrateFeature;
     AnalysisFeature* m_pAnalysisFeature;
     QFont m_trackTableFont;

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -135,6 +135,7 @@ class Library: public QObject {
     void exportLibrary();
     void exportCrate(CrateId crateId);
 #endif
+    void trackSelection(QList<TrackPointer> pTrack);
 
     void setTrackTableFont(const QFont& font);
     void setTrackTableRowHeight(int rowHeight);

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -123,6 +123,7 @@ class LibraryFeature : public QObject {
     // emit this signal to enable/disable the cover art widget
     void enableCoverArtDisplay(bool);
     void trackSelected(TrackPointer pTrack);
+    void trackSelection(QList<TrackPointer>);
 
   protected:
     // TODO: Move common crate/playlist functions into

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -12,6 +12,7 @@
 
 #include "library/dao/playlistdao.h"
 #include "library/trackset/basetracksetfeature.h"
+#include "library/trackset/playlistsummary.h"
 #include "track/track_decl.h"
 
 class WLibrary;
@@ -76,10 +77,6 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     void slotAnalyzePlaylist();
 
   protected:
-    struct IdAndLabel {
-        int id;
-        QString label;
-    };
 
     virtual void updateChildModel(int selected_id);
     virtual void clearChildModel();

--- a/src/library/trackset/crate/crate.h
+++ b/src/library/trackset/crate/crate.h
@@ -30,3 +30,5 @@ class Crate : public DbNamedEntity<CrateId> {
     bool m_locked;
     bool m_autoDjSource;
 };
+
+Q_DECLARE_METATYPE(Crate);

--- a/src/library/trackset/crate/cratefeature.h
+++ b/src/library/trackset/crate/cratefeature.h
@@ -42,6 +42,7 @@ class CrateFeature : public BaseTrackSetFeature {
     void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
 
     TreeItemModel* getChildModel() override;
+    bool activateCrate(CrateId crateId);
 
   public slots:
     void activateChild(const QModelIndex& index) override;
@@ -79,8 +80,6 @@ class CrateFeature : public BaseTrackSetFeature {
     void initActions();
     void connectLibrary(Library* pLibrary);
     void connectTrackCollection();
-
-    bool activateCrate(CrateId crateId);
 
     std::unique_ptr<TreeItem> newTreeItemForCrateSummary(
             const CrateSummary& crateSummary);

--- a/src/library/trackset/crate/cratesummary.h
+++ b/src/library/trackset/crate/cratesummary.h
@@ -37,3 +37,5 @@ class CrateSummary : public Crate {
     uint m_trackCount;
     double m_trackDuration;
 };
+
+Q_DECLARE_METATYPE(CrateSummary);

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -21,21 +21,6 @@
 #include "widget/wlibrarysidebar.h"
 #include "widget/wlibrarytextbrowser.h"
 
-namespace {
-
-QString createPlaylistLabel(
-        const QString& name,
-        int count,
-        int duration) {
-    return QStringLiteral("%1 (%2) %3")
-            .arg(name,
-                    QString::number(count),
-                    mixxx::Duration::formatTime(
-                            duration, mixxx::Duration::Precision::SECONDS));
-}
-
-} // anonymous namespace
-
 PlaylistFeature::PlaylistFeature(Library* pLibrary, UserSettingsPointer pConfig)
         : BasePlaylistFeature(pLibrary,
                   pConfig,
@@ -130,74 +115,6 @@ bool PlaylistFeature::dragMoveAcceptChild(const QModelIndex& index, const QUrl& 
     return !locked && formatSupported;
 }
 
-QList<BasePlaylistFeature::IdAndLabel> PlaylistFeature::createPlaylistLabels() {
-    QSqlDatabase database =
-            m_pLibrary->trackCollections()->internalCollection()->database();
-
-    QList<BasePlaylistFeature::IdAndLabel> playlistLabels;
-    QString queryString = QStringLiteral(
-            "CREATE TEMPORARY VIEW IF NOT EXISTS PlaylistsCountsDurations "
-            "AS SELECT "
-            "  Playlists.id AS id, "
-            "  Playlists.name AS name, "
-            "  LOWER(Playlists.name) AS sort_name, "
-            "  COUNT(case library.mixxx_deleted when 0 then 1 else null end) "
-            "    AS count, "
-            "  SUM(case library.mixxx_deleted "
-            "    when 0 then library.duration else 0 end) AS durationSeconds "
-            "FROM Playlists "
-            "LEFT JOIN PlaylistTracks "
-            "  ON PlaylistTracks.playlist_id = Playlists.id "
-            "LEFT JOIN library "
-            "  ON PlaylistTracks.track_id = library.id "
-            "  WHERE Playlists.hidden = 0 "
-            "  GROUP BY Playlists.id");
-    queryString.append(
-            mixxx::DbConnection::collateLexicographically(
-                    " ORDER BY sort_name"));
-    QSqlQuery query(database);
-    if (!query.exec(queryString)) {
-        LOG_FAILED_QUERY(query);
-    }
-
-    // Setup the sidebar playlist model
-    QSqlTableModel playlistTableModel(this, database);
-    playlistTableModel.setTable("PlaylistsCountsDurations");
-    playlistTableModel.select();
-    while (playlistTableModel.canFetchMore()) {
-        playlistTableModel.fetchMore();
-    }
-    QSqlRecord record = playlistTableModel.record();
-    int nameColumn = record.indexOf("name");
-    int idColumn = record.indexOf("id");
-    int countColumn = record.indexOf("count");
-    int durationColumn = record.indexOf("durationSeconds");
-
-    for (int row = 0; row < playlistTableModel.rowCount(); ++row) {
-        int id =
-                playlistTableModel
-                        .data(playlistTableModel.index(row, idColumn))
-                        .toInt();
-        QString name =
-                playlistTableModel
-                        .data(playlistTableModel.index(row, nameColumn))
-                        .toString();
-        int count =
-                playlistTableModel
-                        .data(playlistTableModel.index(row, countColumn))
-                        .toInt();
-        int duration =
-                playlistTableModel
-                        .data(playlistTableModel.index(row, durationColumn))
-                        .toInt();
-        BasePlaylistFeature::IdAndLabel idAndLabel;
-        idAndLabel.id = id;
-        idAndLabel.label = createPlaylistLabel(name, count, duration);
-        playlistLabels.append(idAndLabel);
-    }
-    return playlistLabels;
-}
-
 QString PlaylistFeature::fetchPlaylistLabel(int playlistId) {
     // Setup the sidebar playlist model
     QSqlDatabase database =
@@ -227,7 +144,7 @@ QString PlaylistFeature::fetchPlaylistLabel(int playlistId) {
                 playlistTableModel
                         .data(playlistTableModel.index(0, durationColumn))
                         .toInt();
-        return createPlaylistLabel(name, count, duration);
+        return PlaylistSummary::createPlaylistLabel(name, count, duration);
     }
     return QString();
 }
@@ -241,10 +158,10 @@ QModelIndex PlaylistFeature::constructChildModel(int selectedId) {
     int selectedRow = -1;
 
     int row = 0;
-    const QList<IdAndLabel> playlistLabels = createPlaylistLabels();
+    const QList<PlaylistSummary> playlistLabels = m_playlistDao.createPlaylistSummary();
     for (const auto& idAndLabel : playlistLabels) {
-        int playlistId = idAndLabel.id;
-        QString playlistLabel = idAndLabel.label;
+        int playlistId = idAndLabel.id();
+        QString playlistLabel = idAndLabel.getLabel();
 
         if (selectedId == playlistId) {
             // save index for selection

--- a/src/library/trackset/playlistfeature.h
+++ b/src/library/trackset/playlistfeature.h
@@ -9,6 +9,7 @@
 #include <QVariant>
 
 #include "library/trackset/baseplaylistfeature.h"
+#include "library/trackset/playlistsummary.h"
 #include "preferences/usersettings.h"
 
 class TrackCollection;
@@ -44,7 +45,6 @@ class PlaylistFeature : public BasePlaylistFeature {
   protected:
     QString fetchPlaylistLabel(int playlistId) override;
     void decorateChild(TreeItem* pChild, int playlistId) override;
-    QList<IdAndLabel> createPlaylistLabels();
     QModelIndex constructChildModel(int selectedId);
 
   private:

--- a/src/library/trackset/playlistsummary.h
+++ b/src/library/trackset/playlistsummary.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "util/duration.h"
+
+class PlaylistSummary {
+  public:
+    explicit PlaylistSummary(int id = -1, QString label = nullptr)
+            : m_id(id),
+              m_name(label),
+              m_count(0),
+              m_duration(0),
+              m_matches(0) {
+    }
+    ~PlaylistSummary() = default;
+
+    int id() const {
+        return m_id;
+    }
+
+    void setCount(int count) {
+        m_count = count;
+    }
+    int count() const {
+        return m_count;
+    }
+
+    void setDuration(int duration) {
+        m_duration = duration;
+    }
+    int duration() const {
+        return m_duration;
+    }
+
+    QString name() const {
+        return m_name;
+    }
+    void setName(QString name) {
+        m_name = name;
+    }
+
+    int matches() const {
+        return m_matches;
+    }
+    void setMatches(int matches) {
+        m_matches = matches;
+    }
+
+    QString getLabel() const {
+        return createPlaylistLabel(
+                m_name,
+                m_count,
+                m_duration);
+    }
+
+    static QString createPlaylistLabel(
+            const QString& name,
+            int count,
+            int duration) {
+        if (!count && !duration) {
+            return QString(name);
+        } else {
+            return QStringLiteral("%1 (%2) %3")
+                    .arg(name,
+                            QString::number(count),
+                            mixxx::Duration::formatTime(
+                                    duration, mixxx::Duration::Precision::SECONDS));
+        }
+    }
+
+  private:
+    int m_id;
+    QString m_name;
+    int m_count;
+    int m_duration;
+    /// m_matches is used when querying track playlists for
+    int m_matches;
+};
+
+Q_DECLARE_METATYPE(PlaylistSummary);

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -47,6 +47,7 @@
 #include "widget/weffectpushbutton.h"
 #include "widget/weffectselector.h"
 #include "widget/whotcuebutton.h"
+#include "widget/winfobar.h"
 #include "widget/wkey.h"
 #include "widget/wknob.h"
 #include "widget/wknobcomposed.h"
@@ -521,6 +522,8 @@ QList<QWidget*> LegacySkinParser::parseNode(const QDomElement& node) {
         result = wrapWidget(parseText(node));
     } else if (nodeName == "TrackProperty") {
         result = wrapWidget(parseTrackProperty(node));
+    } else if (nodeName == "Infobar") {
+        result = wrapWidget(parseInfobar(node));
     } else if (nodeName == "StarRating") {
         result = wrapWidget(parseStarRating(node));
     } else if (nodeName == "VuMeter") {
@@ -1302,6 +1305,54 @@ QWidget* LegacySkinParser::parseCoverArt(const QDomElement& node) {
     }
 
     return pCoverArt;
+}
+
+QWidget* LegacySkinParser::parseInfobar(const QDomElement& node) {
+    QString group = lookupNodeGroup(node);
+    BaseTrackPlayer* pPlayer = nullptr;
+    if (!group.isEmpty()) {
+        pPlayer = m_pPlayerManager->getPlayer(group);
+    }
+
+    if (!pPlayer && group.compare("[Library]", Qt::CaseInsensitive) != 0) {
+        SKIN_WARNING(node, *m_pContext)
+                << "Infobar widget requires a Deck or Library group";
+        return NULL;
+    }
+
+    WInfoBar* p = new WInfoBar(group, m_pConfig, m_pLibrary, m_pParent);
+
+    commonWidgetSetup(node, p);
+    p->setup(node, *m_pContext);
+
+    if (pPlayer) {
+        connect(pPlayer,
+                SIGNAL(newTrackLoaded(TrackPointer)),
+                p,
+                SLOT(slotTrackLoaded(TrackPointer)));
+        connect(pPlayer,
+                SIGNAL(loadingTrack(TrackPointer, TrackPointer)),
+                p,
+                SLOT(slotTrackLoaded(TrackPointer)));
+
+        // load if there is already a track in the deck
+        TrackPointer pTrack = pPlayer->getLoadedTrack();
+        if (pTrack) {
+            p->slotTrackLoaded(pTrack);
+        }
+    } else {
+        // hookup to library
+        // FIXME(poelzi) signals
+        connect(m_pLibrary,
+                &Library::switchToView,
+                p,
+                &WInfoBar::slotClear);
+        connect(m_pLibrary,
+                &Library::trackSelection,
+                p,
+                &WInfoBar::slotTrackSelection);
+    }
+    return p;
 }
 
 void LegacySkinParser::parseSingletonDefinition(const QDomElement& node) {

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1320,39 +1320,39 @@ QWidget* LegacySkinParser::parseInfobar(const QDomElement& node) {
         return NULL;
     }
 
-    WInfoBar* p = new WInfoBar(group, m_pConfig, m_pLibrary, m_pParent);
+    WInfoBar* pInfobar = new WInfoBar(group, m_pConfig, m_pLibrary, m_pParent);
 
-    commonWidgetSetup(node, p);
-    p->setup(node, *m_pContext);
+    commonWidgetSetup(node, pInfobar);
+    pInfobar->setup(node, *m_pContext);
 
     if (pPlayer) {
         connect(pPlayer,
                 SIGNAL(newTrackLoaded(TrackPointer)),
-                p,
+                pInfobar,
                 SLOT(slotTrackLoaded(TrackPointer)));
         connect(pPlayer,
                 SIGNAL(loadingTrack(TrackPointer, TrackPointer)),
-                p,
+                pInfobar,
                 SLOT(slotTrackLoaded(TrackPointer)));
 
         // load if there is already a track in the deck
         TrackPointer pTrack = pPlayer->getLoadedTrack();
         if (pTrack) {
-            p->slotTrackLoaded(pTrack);
+            pInfobar->slotTrackLoaded(pTrack);
         }
     } else {
         // hookup to library
         // FIXME(poelzi) signals
         connect(m_pLibrary,
                 &Library::switchToView,
-                p,
+                pInfobar,
                 &WInfoBar::slotClear);
         connect(m_pLibrary,
                 &Library::trackSelection,
-                p,
+                pInfobar,
                 &WInfoBar::slotTrackSelection);
     }
-    return p;
+    return pInfobar;
 }
 
 void LegacySkinParser::parseSingletonDefinition(const QDomElement& node) {

--- a/src/skin/legacyskinparser.h
+++ b/src/skin/legacyskinparser.h
@@ -78,6 +78,7 @@ class LegacySkinParser : public QObject, public SkinParser {
     void setupLabelWidget(const QDomElement& element, WLabel* pLabel);
     QWidget* parseText(const QDomElement& node);
     QWidget* parseTrackProperty(const QDomElement& node);
+    QWidget* parseInfobar(const QDomElement& node);
     QWidget* parseStarRating(const QDomElement& node);
     QWidget* parseRateRange(const QDomElement& node);
     QWidget* parseNumberRate(const QDomElement& node);

--- a/src/skin/tooltips.cpp
+++ b/src/skin/tooltips.cpp
@@ -254,6 +254,10 @@ void Tooltips::addStandardTooltips() {
             << tr("Cover Art")
             << tr("Show/hide Cover Art of the selected track in the library.");
 
+    add("show_infobar")
+            << tr("Infobar")
+            << tr("Show/hide Infobar.");
+
     add("toggle_4decks")
             << tr("Toggle 4 Decks")
             << tr("Switches between showing 2 decks and 4 decks.");

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -491,6 +491,9 @@ class Track : public QObject {
     // The list of cue points for the track
     QList<CuePointer> m_cuePoints;
 
+    // A resolved list of the crates the track is in
+    QStringList m_cratesList;
+
     // Storage for the track's beats
     mixxx::BeatsPointer m_pBeats;
 

--- a/src/widget/winfobar.cpp
+++ b/src/widget/winfobar.cpp
@@ -1,6 +1,7 @@
 
 #include "widget/winfobar.h"
 
+#include <QAction>
 #include <QDebug>
 #include <QFrame>
 #include <QHBoxLayout>
@@ -9,11 +10,16 @@
 #include <QMetaType>
 #include <QPushButton>
 #include <QScrollArea>
+#include <QSizePolicy>
 #include <QStringList>
 #include <QUrl>
 #include <QVBoxLayout>
+#include <Qt>
 
 #include "control/controlobject.h"
+#include "library/trackset/crate/cratefeature.h"
+#include "library/trackset/playlistfeature.h"
+#include "library/trackset/setlogfeature.h"
 #include "util/dnd.h"
 
 // crates which are only occupied by some tracks
@@ -26,14 +32,27 @@ WInfoBarItem::WInfoBarItem(const QString& text, QWidget* parent)
 }
 
 // crates in which all tracks are part of
-WInfoBarCrateItem::WInfoBarCrateItem(const CrateSummary crate, QWidget* parent)
-        : WInfoBarItem(crate.getName(), parent) {
-    //setText();
+WInfoBarCrateItem::WInfoBarCrateItem(const CrateSummary crt, QWidget* parent)
+        : WInfoBarItem(crt.getName(), parent),
+          m_crate(crt) {
+    connect(this,
+            &QAbstractButton::clicked,
+            [this] {
+                emit(activateCrate(m_crate));
+            });
 }
 
 // crates which are only occupied by some tracks
-WInfoBarCrateMixedItem::WInfoBarCrateMixedItem(const CrateSummary crate, QWidget* parent)
-        : WInfoBarCrateItem(crate, parent) {
+WInfoBarPlaylistItem::WInfoBarPlaylistItem(
+        const PlaylistSummary playlist, bool isHistory, QWidget* parent)
+        : WInfoBarItem(playlist.name(), parent),
+          m_playlist(playlist),
+          m_isHistory(isHistory) {
+    connect(this,
+            &QAbstractButton::clicked,
+            [this] {
+                emit(activatePlaylist(m_playlist, m_isHistory));
+            });
 }
 
 WInfoBarWorker::WInfoBarWorker(QObject* parent, TrackCollectionManager* manager)
@@ -43,6 +62,12 @@ WInfoBarWorker::WInfoBarWorker(QObject* parent, TrackCollectionManager* manager)
 }
 
 void WInfoBarWorker::query(int query, QList<TrackId> trackIds) {
+    queryCrates(query, trackIds);
+    queryPlaylists(query, trackIds);
+    queryHistory(query, trackIds);
+}
+
+void WInfoBarWorker::queryCrates(int query, QList<TrackId> trackIds) {
     QString where = QString(" WHERE %1 > 0 ").arg("track_count");
 
     QList<CrateSummary> rv = QList<CrateSummary>();
@@ -62,13 +87,146 @@ void WInfoBarWorker::query(int query, QList<TrackId> trackIds) {
     emit(crateResult(query, trackIds.length(), rv));
 }
 
+void WInfoBarWorker::queryPlaylists(int query, QList<TrackId> trackIds) {
+    //QString where = QString(" WHERE %1 > 0 ").arg("track_count");
+
+    QList<PlaylistSummary> rv = QList<PlaylistSummary>();
+    rv.reserve(trackIds.length());
+
+    QList<PlaylistSummary> results =
+            m_pTrackCollectionManager->internalCollection()
+                    ->getPlaylistDAO()
+                    .createPlaylistSummaryForTracks(trackIds);
+
+    emit(playlistResult(query, trackIds.length(), results));
+}
+
+void WInfoBarWorker::queryHistory(int query, QList<TrackId> trackIds) {
+    //QString where = QString(" WHERE %1 > 0 ").arg("track_count");
+
+    QList<PlaylistSummary> rv = QList<PlaylistSummary>();
+    rv.reserve(trackIds.length());
+
+    QList<PlaylistSummary> results =
+            m_pTrackCollectionManager->internalCollection()
+                    ->getPlaylistDAO()
+                    .createPlaylistSummaryForTracks(
+                            trackIds, PlaylistDAO::HiddenType::PLHT_SET_LOG);
+    qDebug() << "history result length" << results.length();
+
+    emit(historyResult(query, trackIds.length(), results));
+}
+
+WInfoBarButton::WInfoBarButton(QWidget* parent)
+        : QToolButton(parent) {
+    /*    connect(this,
+                &QToolButton::clicked,
+                this,
+                &WInfoBarButton::slotTriggered);
+*/
+    setState(State::VISIBLE);
+}
+
+void WInfoBarButton::setState(WInfoBarButton::State newState) {
+    m_state = newState;
+    qDebug() << "updated";
+    style()->unpolish(this);
+    style()->polish(this);
+    emit(stateChanged(m_state));
+};
+
+void WInfoBarButton::nextCheckState() {
+    //Q_UNUSED(action);
+    qDebug() << "triggered";
+    switch (m_state) {
+    case WInfoBarButton::State::VISIBLE:
+        m_state = WInfoBarButton::State::EXPANDED;
+        break;
+    case WInfoBarButton::State::EXPANDED:
+        m_state = WInfoBarButton::State::HIDDEN;
+        break;
+    default:
+        m_state = WInfoBarButton::State::VISIBLE;
+    }
+    style()->unpolish(this);
+    style()->polish(this);
+    emit(stateChanged(m_state));
+}
+
+WInfoBarContainer::WInfoBarContainer(QString name,
+        QWidget* pParent)
+        : QFrame(pParent),
+          m_pButton(new WInfoBarButton(this)),
+          m_pContainer(nullptr),
+          m_pMainLayout(nullptr),
+          m_pMainContainer(nullptr) {
+    setObjectName(QString("%1Frame").arg(name));
+
+    m_pContainer = new QHBoxLayout(this);
+    m_pContainer->setSpacing(2);
+    m_pContainer->setContentsMargins(QMargins(2, 0, 2, 0));
+
+    m_pMainContainer = new QWidget(this);
+    m_pMainContainer->setObjectName(QString("%1Container").arg(name));
+    m_pMainContainer->setLayout(m_pContainer);
+
+    m_pMainLayout = new QHBoxLayout(this);
+    m_pMainLayout->setContentsMargins(QMargins(0, 0, 0, 0));
+    m_pMainLayout->addWidget(m_pButton);
+    m_pMainLayout->addWidget(m_pMainContainer);
+
+    m_pButton->setObjectName(QString("%1Button").arg(name));
+    connect(m_pButton,
+            &WInfoBarButton::stateChanged,
+            this,
+            &WInfoBarContainer::slotStateChange);
+
+    setLayout(m_pMainLayout);
+}
+
+void WInfoBarContainer::slotStateChange(WInfoBarButton::State state) {
+    qDebug() << "stateChange" << static_cast<int>(state);
+    if (state == WInfoBarButton::State::HIDDEN) {
+        m_pMainContainer->setVisible(false);
+    } else {
+        m_pMainContainer->setVisible(true);
+    }
+    if (state == WInfoBarButton::State::EXPANDED) {
+        m_pMainContainer->setSizePolicy(QSizePolicy(QSizePolicy::Policy::Expanding,
+                QSizePolicy::Policy::Minimum));
+        m_pMainContainer->setMaximumSize(QSize(1000000, 20));
+    } else {
+        m_pMainContainer->setSizePolicy(QSizePolicy(QSizePolicy::Policy::Minimum,
+                QSizePolicy::Policy::Minimum));
+    }
+    emit(stateChanged(state));
+}
+
+void WInfoBarContainer::clear() {
+    QLayoutItem* child;
+    while ((child = m_pContainer->takeAt(0)) != nullptr) {
+        delete child->widget(); // delete the widget
+        delete child;           // delete the layout item
+    }
+}
+
+void WInfoBarContainer::addItem(WInfoBarItem* item) {
+    m_pContainer->addWidget(item);
+    m_pContainer->setAlignment(item, Qt::AlignLeft | Qt::AlignTop);
+}
+
+void WInfoBarContainer::addStretch(int factor) {
+    m_pContainer->addStretch(factor);
+}
+
+// WInfoBar implementation
 QThread* WInfoBar::s_worker_thread = nullptr; //QThread();
 
 WInfoBar::WInfoBar(QString group,
         UserSettingsPointer pConfig,
         Library* pLibrary,
         QWidget* pParent)
-        : QScrollArea(pParent),
+        : QStatusBar(pParent),
           WBaseWidget(pParent),
           m_pGroup(group),
           m_pConfig(pConfig),
@@ -76,10 +234,10 @@ WInfoBar::WInfoBar(QString group,
     // FIXME(poelzi): does it make sense to allow drops of certain stuff ???
     setAcceptDrops(false);
     setMinimumSize(0, 0);
-    setWidgetResizable(true);
+    //setWidgetResizable(true);
     setFocusPolicy(Qt::NoFocus);
-    setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    //setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    //setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
     // initialize the shared worker thread
     if (s_worker_thread == nullptr) {
@@ -92,14 +250,40 @@ WInfoBar::WInfoBar(QString group,
     m_pWorker = new WInfoBarWorker(this, pLibrary->trackCollections());
     m_pWorker->moveToThread(s_worker_thread);
 
+    // we use queued connections because they connect to a different thread
     connect(m_pWorker,
             &WInfoBarWorker::crateResult,
             this,
-            &WInfoBar::receiveCrateResults);
+            &WInfoBar::receiveCrateResults,
+            Qt::QueuedConnection);
+    connect(m_pWorker,
+            &WInfoBarWorker::playlistResult,
+            this,
+            &WInfoBar::receivePlaylistResults,
+            Qt::QueuedConnection);
+    connect(m_pWorker,
+            &WInfoBarWorker::historyResult,
+            this,
+            &WInfoBar::receiveHistoryResults,
+            Qt::QueuedConnection);
     connect(this,
             &WInfoBar::query,
             m_pWorker,
-            &WInfoBarWorker::query);
+            &WInfoBarWorker::query,
+            Qt::QueuedConnection);
+
+    // crate updates
+    connect(&m_pLibrary->trackCollection(),
+            &TrackCollection::crateTracksChanged,
+            this,
+            &WInfoBar::slotCrateTracksChanged);
+    // very seldom, so we build it eagerly
+    connect(&m_pLibrary->trackCollection(),
+            &TrackCollection::crateSummaryChanged,
+            [this](const QSet<CrateId>& crates) {
+                Q_UNUSED(crates);
+                queryCurrentTracks();
+            });
 }
 
 // generates unique id's for all worker requests
@@ -109,25 +293,130 @@ int WInfoBar::generateId() {
     return ++s_last_id;
 }
 
-void WInfoBar::receiveCrateResults(int query, uint total, QList<CrateSummary> crates) {
-    qDebug() << "WInfoBar::receiveCrateResults" << query << total;
-    // we are only interested in results we requested last
-    if (query != m_id) {
-        return;
-    }
-
-    foreach (CrateSummary crate, crates) {
-        if (crate.getTrackCount() == total) {
-            auto item = new WInfoBarCrateItem(crate, this);
-            m_pCratesContainer->addWidget(item);
-            m_pCratesContainer->setAlignment(item, Qt::AlignLeft | Qt::AlignTop);
-        } else {
-            auto item = new WInfoBarCrateMixedItem(crate, this);
-            m_pCratesContainer->addWidget(item);
-            m_pCratesContainer->setAlignment(item, Qt::AlignLeft | Qt::AlignTop);
+void WInfoBar::slotCrateTracksChanged(CrateId crate,
+        const QList<TrackId>& tracksAdded,
+        const QList<TrackId>& tracksRemoved) {
+    Q_UNUSED(crate);
+    bool rebuild = false;
+    for (TrackPointer track : qAsConst(m_currentTracks)) {
+        const TrackId id = track->getId();
+        if (tracksAdded.contains(id) || tracksRemoved.contains(id)) {
+            rebuild = true;
+            break;
         }
     }
-    m_pCratesContainer->addStretch();
+    if (rebuild) {
+        // A currently loaded track is affected, rebuild the bar
+        queryCurrentTracks();
+    }
+}
+
+void WInfoBar::receiveCrateResults(int queryId, int total, QList<CrateSummary> crates) {
+    qDebug() << "WInfoBar::receiveCrateResults" << queryId << total << crates.length();
+    // we are only interested in results we requested last
+    if (queryId != m_id) {
+        return;
+    }
+    m_pCratesContainer->clear();
+    foreach (CrateSummary crate, crates) {
+        auto item = new WInfoBarCrateItem(crate, m_pCratesContainer);
+        item->setTotals(total);
+
+        connect(item,
+                &WInfoBarCrateItem::activateCrate,
+                this,
+                &WInfoBar::slotActivateCrate);
+
+        m_pCratesContainer->addItem(item);
+    }
+    m_pCratesContainer->addStretch(0);
+    //m_pCratesContainer->
+    //updateVisibilty();
+    //m_pCratesContainer->addStretch();
+}
+
+void WInfoBar::slotActivateCrate(CrateSummary crate) {
+    VERIFY_OR_DEBUG_ASSERT(m_pLibrary && m_pLibrary->getCreateFeature()) {
+        return;
+    }
+    m_pLibrary->getCreateFeature()->activate();
+    m_pLibrary->getCreateFeature()->activateCrate(crate.getId());
+}
+
+void WInfoBar::slotActivatePlaylist(PlaylistSummary playlist, bool isHistory) {
+    VERIFY_OR_DEBUG_ASSERT(m_pLibrary) {
+        return;
+    }
+    if (isHistory) {
+        VERIFY_OR_DEBUG_ASSERT(m_pLibrary->getSetlogFeature()) {
+            return;
+        }
+        m_pLibrary->getSetlogFeature()->activate();
+        m_pLibrary->getSetlogFeature()->activatePlaylist(playlist.id());
+    } else {
+        VERIFY_OR_DEBUG_ASSERT(m_pLibrary->getPlaylistFeature()) {
+            return;
+        }
+        m_pLibrary->getPlaylistFeature()->activate();
+        m_pLibrary->getPlaylistFeature()->activatePlaylist(playlist.id());
+    }
+}
+
+void WInfoBar::receivePlaylistResults(int queryId, int total, QList<PlaylistSummary> playlists) {
+    addPlaylistResults(false, queryId, total, playlists);
+}
+
+void WInfoBar::receiveHistoryResults(int queryId, int total, QList<PlaylistSummary> playlists) {
+    addPlaylistResults(true, queryId, total, playlists);
+}
+
+void WInfoBar::addPlaylistResults(bool isHistory,
+        int queryId,
+        int total,
+        QList<PlaylistSummary> playlists) {
+    qDebug() << "WInfoBar::receivePlaylistResults" << isHistory << queryId
+             << total << playlists.length();
+    WInfoBarContainer* container;
+    if (isHistory) {
+        container = m_pHistoryContainer;
+    } else {
+        container = m_pPlaylistsContainer;
+    }
+    // we are only interested in results we requested last
+    if (queryId != m_id) {
+        return;
+    }
+    // clear the container in case this was a refresh request
+    container->clear();
+    foreach (PlaylistSummary playlist, playlists) {
+        auto item = new WInfoBarPlaylistItem(playlist, isHistory, container);
+        item->setTotals(total);
+
+        connect(item,
+                &WInfoBarPlaylistItem::activatePlaylist,
+                this,
+                &WInfoBar::slotActivatePlaylist);
+
+        container->addItem(item);
+    }
+    container->addStretch(0);
+
+    //updateVisibilty();
+    //m_pCratesContainer->addStretch();
+}
+
+void WInfoBar::clearCurrentTracks() {
+    foreach (TrackPointer track, qAsConst(m_currentTracks)) {
+        VERIFY_OR_DEBUG_ASSERT(track) {
+            continue;
+        }
+        disconnect(track.get(),
+                nullptr,
+                this,
+                nullptr);
+    }
+
+    m_currentTracks.clear();
 }
 
 void WInfoBar::slotTrackLoaded(TrackPointer track) {
@@ -137,21 +426,29 @@ void WInfoBar::slotTrackLoaded(TrackPointer track) {
     }
     m_id = generateId();
 
-    QList<TrackId> lst = QList<TrackId>();
-    lst.append(track->getId());
-    emit query(m_id, lst);
+    clearCurrentTracks();
+    m_currentTracks.append(track);
+
+    queryCurrentTracks();
 }
 
 void WInfoBar::slotTrackSelection(QList<TrackPointer> tracks) {
     clear();
     qDebug() << "WInfoBar::slotTrackSelection";
 
+    clearCurrentTracks();
+    m_currentTracks = tracks;
+
+    queryCurrentTracks();
+}
+
+void WInfoBar::queryCurrentTracks() {
     m_id = generateId();
 
     QList<TrackId> lst = QList<TrackId>();
-    lst.reserve(tracks.size());
+    lst.reserve(m_currentTracks.size());
 
-    foreach (auto track, tracks) {
+    foreach (auto track, qAsConst(m_currentTracks)) {
         if (track != nullptr) {
             lst.append(track->getId());
         }
@@ -167,81 +464,133 @@ void WInfoBar::setup(const QDomNode& node, const SkinContext& context) {
     setupUI();
 }
 
+void WInfoBar::prepareFrame(QFrame* frame) {
+    frame->setMinimumSize(0, 0);
+    frame->setSizePolicy(QSizePolicy(
+            QSizePolicy::Policy::Preferred, QSizePolicy::Policy::Minimum));
+}
+
 void WInfoBar::setupUI() {
-    m_pContainerFrame = new QFrame();
-    m_pContainerFrame->setObjectName(QString::fromUtf8("infobarFrame"));
+    /*
+    m_pContainerFrame = new QFrame(this);
+    m_pContainerFrame->setObjectName(QLatin1String("infobarFrame"));
     m_pContainerFrame->setMinimumSize(0, 0);
 
     m_pContainer = new QHBoxLayout();
     m_pContainer->setSpacing(0);
-    m_pContainer->setObjectName(QString::fromUtf8("infobarContainer"));
+    m_pContainer->setObjectName(QLatin1String("infobarContainer"));
+    m_pContainer->setContentsMargins(QMargins(0, 0, 0, 0));
+    m_pContainer->setSpacing(0);
     m_pContainerFrame->setLayout(m_pContainer);
 
-    m_pCratesFrame = new QFrame();
-    m_pCratesFrame->setObjectName(QString::fromUtf8("infobarCrates"));
-    m_pCratesFrame->setMinimumSize(0, 0);
-    m_pCratesFrame->setSizePolicy(QSizePolicy(
-            QSizePolicy::Policy::Preferred, QSizePolicy::Policy::Minimum));
+    m_pCratesFrame = new QFrame(this);
+    m_pCratesFrame->setObjectName(QLatin1String("infobarCrates"));
+    prepareFrame(m_pCratesFrame);
 
     m_pCratesContainer = new QHBoxLayout();
-    m_pCratesContainer->setObjectName(QString::fromUtf8("infobarCratesContainer"));
+    m_pCratesContainer->setObjectName(QLatin1String("infobarCratesContainer"));
+    m_pCratesContainer->setContentsMargins(QMargins(0, 0, 0, 0));
     m_pCratesContainer->setSpacing(0);
     //m_pCratesContainer->setMinimumSize(0, 0);
     m_pCratesFrame->setLayout(m_pCratesContainer);
 
-    m_pPlaylistsFrame = new QFrame();
-    m_pPlaylistsFrame->setObjectName(QString::fromUtf8("infobarPlaylists"));
-    m_pPlaylistsFrame->setMinimumSize(0, 0);
-    m_pPlaylistsFrame->setSizePolicy(QSizePolicy(
-            QSizePolicy::Policy::Preferred, QSizePolicy::Policy::Minimum));
+    m_pPlaylistsFrame = new QFrame(this);
+    m_pPlaylistsFrame->setObjectName(QLatin1String("infobarPlaylists"));
+    prepareFrame(m_pPlaylistsFrame);
+
 
     m_pPlaylistsContainer = new QHBoxLayout();
-    m_pPlaylistsContainer->setObjectName(QString::fromUtf8("infobarPlaylistsContainer"));
+    m_pPlaylistsContainer->setObjectName(QLatin1String("infobarPlaylistsContainer"));
     //m_pPlaylistsContainer->setMinimumSize(0, 0);
+    m_pPlaylistsContainer->setContentsMargins(QMargins(0, 0, 0, 0));
+    m_pPlaylistsContainer->setSpacing(0);
+
     m_pPlaylistsFrame->setLayout(m_pPlaylistsContainer);
 
-    m_pHistoryFrame = new QFrame();
-    m_pHistoryFrame->setObjectName(QString::fromUtf8("infobarHistory"));
-    m_pHistoryFrame->setMinimumSize(0, 0);
-    m_pHistoryFrame->setSizePolicy(QSizePolicy(
-            QSizePolicy::Policy::Preferred, QSizePolicy::Policy::Minimum));
+    m_pHistoryFrame = new QFrame(this);
+    m_pHistoryFrame->setObjectName(QLatin1String("infobarHistory"));
+    prepareFrame(m_pHistoryFrame);
 
     m_pHistoryContainer = new QHBoxLayout();
-    m_pHistoryContainer->setObjectName(QString::fromUtf8("infobarHistoryContainer"));
+    m_pHistoryContainer->setObjectName(QLatin1String("infobarHistoryContainer"));
+    m_pHistoryContainer->setContentsMargins(QMargins(0, 0, 0, 0));
+    m_pHistoryContainer->setSpacing(0);
+
     //m_pHistoryContainer->setMinimumSize(0, 0);
     m_pHistoryFrame->setLayout(m_pHistoryContainer);
+    */
+    m_pCratesContainer = new WInfoBarContainer("InfobarCrates", this);
+    connect(m_pCratesContainer,
+            &WInfoBarContainer::stateChanged,
+            this,
+            &WInfoBar::slotRebuildWidgets);
 
-    m_pContainer->addWidget(m_pCratesFrame, 0);
-    m_pContainer->addWidget(m_pPlaylistsFrame, 0);
-    m_pContainer->addWidget(m_pHistoryFrame, 0);
-    m_pContainer->addStretch();
+    m_pPlaylistsContainer = new WInfoBarContainer("InfobarPlaylists", this);
+    connect(m_pPlaylistsContainer,
+            &WInfoBarContainer::stateChanged,
+            this,
+            &WInfoBar::slotRebuildWidgets);
+
+    m_pHistoryContainer = new WInfoBarContainer("InfobarHistory", this);
+    connect(m_pHistoryContainer,
+            &WInfoBarContainer::stateChanged,
+            this,
+            &WInfoBar::slotRebuildWidgets);
+
+    //m_pContainer->addWidget(m_pCratesFrame, 0);
+    //m_pContainer->addWidget(m_pPlaylistsFrame, 0);
+    //m_pContainer->addWidget(m_pHistoryFrame, 0);
+    //m_pContainer->addStretch();
     //m_pContainer->addSpacing(0);
-    m_pContainerFrame->setLayout(m_pContainer);
-    setWidget(m_pContainerFrame);
+    //m_pContainerFrame->setLayout(m_pContainer);
+    //setWidget(m_pContainerFrame);
     //setLayout(m_pContainer);
+    setSizeGripEnabled(false);
+    setMinimumWidth(0);
+    rebuildWidgets();
+}
+
+void WInfoBar::rebuildWidgets() {
+    removeWidget(m_pCratesContainer);
+    removeWidget(m_pPlaylistsContainer);
+    removeWidget(m_pHistoryContainer);
+
+    insertWidget(0,
+            m_pCratesContainer,
+            m_pCratesContainer->state() == WInfoBarButton::State::EXPANDED ? 1
+                                                                           : 0);
+    insertWidget(1,
+            m_pPlaylistsContainer,
+            m_pPlaylistsContainer->state() == WInfoBarButton::State::EXPANDED
+                    ? 1
+                    : 0);
+    insertWidget(2,
+            m_pHistoryContainer,
+            m_pHistoryContainer->state() == WInfoBarButton::State::EXPANDED
+                    ? 1
+                    : 0);
+
+    m_pCratesContainer->show();
+    m_pPlaylistsContainer->show();
+    m_pHistoryContainer->show();
 }
 
 void WInfoBar::clear() {
-    QLayoutItem* child;
-    while ((child = m_pCratesContainer->takeAt(0)) != nullptr) {
-        delete child->widget(); // delete the widget
-        delete child;           // delete the layout item
-    }
-    while ((child = m_pPlaylistsContainer->takeAt(0)) != nullptr) {
-        delete child->widget(); // delete the widget
-        delete child;           // delete the layout item
-    }
-    while ((child = m_pHistoryContainer->takeAt(0)) != nullptr) {
-        delete child->widget(); // delete the widget
-        delete child;           // delete the layout item
-    }
+    m_pCratesContainer->clear();
+    m_pPlaylistsContainer->clear();
+    m_pHistoryContainer->clear();
 }
 
-void WInfoBar::mouseMoveEvent(QMouseEvent* event) {
-    if ((event->buttons() & Qt::LeftButton) && m_pCurrentTrack) {
-        DragAndDropHelper::dragTrack(m_pCurrentTrack, this, m_pGroup);
-    }
+void WInfoBar::contextMenuEvent(QContextMenuEvent* event) {
+    Q_UNUSED(event);
+    qDebug() << "contextmen";
 }
+
+// void WInfoBar::mouseMoveEvent(QMouseEvent* event) {
+//     if ((event->buttons() & Qt::LeftButton) && m_pCurrentTrack) {
+//         DragAndDropHelper::dragTrack(m_pCurrentTrack, this, m_pGroup);
+//     }
+// }
 
 void WInfoBar::dragEnterEvent(QDragEnterEvent* event) {
     event->ignore();

--- a/src/widget/winfobar.cpp
+++ b/src/widget/winfobar.cpp
@@ -1,0 +1,252 @@
+
+#include "widget/winfobar.h"
+
+#include <QDebug>
+#include <QFrame>
+#include <QHBoxLayout>
+#include <QListWidget>
+#include <QListWidgetItem>
+#include <QMetaType>
+#include <QPushButton>
+#include <QScrollArea>
+#include <QStringList>
+#include <QUrl>
+#include <QVBoxLayout>
+
+#include "control/controlobject.h"
+#include "util/dnd.h"
+
+// crates which are only occupied by some tracks
+WInfoBarItem::WInfoBarItem(const QString& text, QWidget* parent)
+        : QPushButton(text, parent) {
+    setFlat(true);
+    setMinimumSize(0, 0);
+    setFocusPolicy(Qt::NoFocus);
+    setSizePolicy(QSizePolicy(QSizePolicy::Policy::Preferred, sizePolicy().verticalPolicy()));
+}
+
+// crates in which all tracks are part of
+WInfoBarCrateItem::WInfoBarCrateItem(const CrateSummary crate, QWidget* parent)
+        : WInfoBarItem(crate.getName(), parent) {
+    //setText();
+}
+
+// crates which are only occupied by some tracks
+WInfoBarCrateMixedItem::WInfoBarCrateMixedItem(const CrateSummary crate, QWidget* parent)
+        : WInfoBarCrateItem(crate, parent) {
+}
+
+WInfoBarWorker::WInfoBarWorker(QObject* parent, TrackCollectionManager* manager)
+        : QObject(parent),
+          m_pTrackCollectionManager(manager) {
+    DEBUG_ASSERT(manager != nullptr);
+}
+
+void WInfoBarWorker::query(int query, QList<TrackId> trackIds) {
+    QString where = QString(" WHERE %1 > 0 ").arg("track_count");
+
+    QList<CrateSummary> rv = QList<CrateSummary>();
+    rv.reserve(trackIds.length());
+
+    CrateSummarySelectResult results =
+            m_pTrackCollectionManager->internalCollection()
+                    ->crates()
+                    .selectCratesWithTrackCount(trackIds);
+
+    CrateSummary crate;
+    while (results.populateNext(&crate)) {
+        if (crate.getTrackCount() == 0)
+            continue;
+        rv.append(crate);
+    }
+    emit(crateResult(query, trackIds.length(), rv));
+}
+
+QThread* WInfoBar::s_worker_thread = nullptr; //QThread();
+
+WInfoBar::WInfoBar(QString group,
+        UserSettingsPointer pConfig,
+        Library* pLibrary,
+        QWidget* pParent)
+        : QScrollArea(pParent),
+          WBaseWidget(pParent),
+          m_pGroup(group),
+          m_pConfig(pConfig),
+          m_pLibrary(pLibrary) {
+    // FIXME(poelzi): does it make sense to allow drops of certain stuff ???
+    setAcceptDrops(false);
+    setMinimumSize(0, 0);
+    setWidgetResizable(true);
+    setFocusPolicy(Qt::NoFocus);
+    setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+
+    // initialize the shared worker thread
+    if (s_worker_thread == nullptr) {
+        // initialize the worker thread shared between all widgets on first use
+        s_worker_thread = new QThread(nullptr);
+        s_worker_thread->setObjectName("WInfoBarworker");
+        s_worker_thread->start(QThread::LowPriority);
+        qDebug() << "worker thread initialized";
+    }
+    m_pWorker = new WInfoBarWorker(this, pLibrary->trackCollections());
+    m_pWorker->moveToThread(s_worker_thread);
+
+    connect(m_pWorker,
+            &WInfoBarWorker::crateResult,
+            this,
+            &WInfoBar::receiveCrateResults);
+    connect(this,
+            &WInfoBar::query,
+            m_pWorker,
+            &WInfoBarWorker::query);
+}
+
+// generates unique id's for all worker requests
+int WInfoBar::s_last_id = 0;
+
+int WInfoBar::generateId() {
+    return ++s_last_id;
+}
+
+void WInfoBar::receiveCrateResults(int query, uint total, QList<CrateSummary> crates) {
+    qDebug() << "WInfoBar::receiveCrateResults" << query << total;
+    // we are only interested in results we requested last
+    if (query != m_id) {
+        return;
+    }
+
+    foreach (CrateSummary crate, crates) {
+        if (crate.getTrackCount() == total) {
+            auto item = new WInfoBarCrateItem(crate, this);
+            m_pCratesContainer->addWidget(item);
+            m_pCratesContainer->setAlignment(item, Qt::AlignLeft | Qt::AlignTop);
+        } else {
+            auto item = new WInfoBarCrateMixedItem(crate, this);
+            m_pCratesContainer->addWidget(item);
+            m_pCratesContainer->setAlignment(item, Qt::AlignLeft | Qt::AlignTop);
+        }
+    }
+    m_pCratesContainer->addStretch();
+}
+
+void WInfoBar::slotTrackLoaded(TrackPointer track) {
+    clear();
+    if (track == nullptr) {
+        return;
+    }
+    m_id = generateId();
+
+    QList<TrackId> lst = QList<TrackId>();
+    lst.append(track->getId());
+    emit query(m_id, lst);
+}
+
+void WInfoBar::slotTrackSelection(QList<TrackPointer> tracks) {
+    clear();
+    qDebug() << "WInfoBar::slotTrackSelection";
+
+    m_id = generateId();
+
+    QList<TrackId> lst = QList<TrackId>();
+    lst.reserve(tracks.size());
+
+    foreach (auto track, tracks) {
+        if (track != nullptr) {
+            lst.append(track->getId());
+        }
+    }
+
+    emit query(m_id, lst);
+}
+
+void WInfoBar::setup(const QDomNode& node, const SkinContext& context) {
+    Q_UNUSED(node);
+    Q_UNUSED(context);
+
+    setupUI();
+}
+
+void WInfoBar::setupUI() {
+    m_pContainerFrame = new QFrame();
+    m_pContainerFrame->setObjectName(QString::fromUtf8("infobarFrame"));
+    m_pContainerFrame->setMinimumSize(0, 0);
+
+    m_pContainer = new QHBoxLayout();
+    m_pContainer->setSpacing(0);
+    m_pContainer->setObjectName(QString::fromUtf8("infobarContainer"));
+    m_pContainerFrame->setLayout(m_pContainer);
+
+    m_pCratesFrame = new QFrame();
+    m_pCratesFrame->setObjectName(QString::fromUtf8("infobarCrates"));
+    m_pCratesFrame->setMinimumSize(0, 0);
+    m_pCratesFrame->setSizePolicy(QSizePolicy(
+            QSizePolicy::Policy::Preferred, QSizePolicy::Policy::Minimum));
+
+    m_pCratesContainer = new QHBoxLayout();
+    m_pCratesContainer->setObjectName(QString::fromUtf8("infobarCratesContainer"));
+    m_pCratesContainer->setSpacing(0);
+    //m_pCratesContainer->setMinimumSize(0, 0);
+    m_pCratesFrame->setLayout(m_pCratesContainer);
+
+    m_pPlaylistsFrame = new QFrame();
+    m_pPlaylistsFrame->setObjectName(QString::fromUtf8("infobarPlaylists"));
+    m_pPlaylistsFrame->setMinimumSize(0, 0);
+    m_pPlaylistsFrame->setSizePolicy(QSizePolicy(
+            QSizePolicy::Policy::Preferred, QSizePolicy::Policy::Minimum));
+
+    m_pPlaylistsContainer = new QHBoxLayout();
+    m_pPlaylistsContainer->setObjectName(QString::fromUtf8("infobarPlaylistsContainer"));
+    //m_pPlaylistsContainer->setMinimumSize(0, 0);
+    m_pPlaylistsFrame->setLayout(m_pPlaylistsContainer);
+
+    m_pHistoryFrame = new QFrame();
+    m_pHistoryFrame->setObjectName(QString::fromUtf8("infobarHistory"));
+    m_pHistoryFrame->setMinimumSize(0, 0);
+    m_pHistoryFrame->setSizePolicy(QSizePolicy(
+            QSizePolicy::Policy::Preferred, QSizePolicy::Policy::Minimum));
+
+    m_pHistoryContainer = new QHBoxLayout();
+    m_pHistoryContainer->setObjectName(QString::fromUtf8("infobarHistoryContainer"));
+    //m_pHistoryContainer->setMinimumSize(0, 0);
+    m_pHistoryFrame->setLayout(m_pHistoryContainer);
+
+    m_pContainer->addWidget(m_pCratesFrame, 0);
+    m_pContainer->addWidget(m_pPlaylistsFrame, 0);
+    m_pContainer->addWidget(m_pHistoryFrame, 0);
+    m_pContainer->addStretch();
+    //m_pContainer->addSpacing(0);
+    m_pContainerFrame->setLayout(m_pContainer);
+    setWidget(m_pContainerFrame);
+    //setLayout(m_pContainer);
+}
+
+void WInfoBar::clear() {
+    QLayoutItem* child;
+    while ((child = m_pCratesContainer->takeAt(0)) != nullptr) {
+        delete child->widget(); // delete the widget
+        delete child;           // delete the layout item
+    }
+    while ((child = m_pPlaylistsContainer->takeAt(0)) != nullptr) {
+        delete child->widget(); // delete the widget
+        delete child;           // delete the layout item
+    }
+    while ((child = m_pHistoryContainer->takeAt(0)) != nullptr) {
+        delete child->widget(); // delete the widget
+        delete child;           // delete the layout item
+    }
+}
+
+void WInfoBar::mouseMoveEvent(QMouseEvent* event) {
+    if ((event->buttons() & Qt::LeftButton) && m_pCurrentTrack) {
+        DragAndDropHelper::dragTrack(m_pCurrentTrack, this, m_pGroup);
+    }
+}
+
+void WInfoBar::dragEnterEvent(QDragEnterEvent* event) {
+    event->ignore();
+}
+
+void WInfoBar::dropEvent(QDropEvent* event) {
+    event->ignore();
+}

--- a/src/widget/winfobar.h
+++ b/src/widget/winfobar.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#include <QDragEnterEvent>
+#include <QDropEvent>
+#include <QMouseEvent>
+#include <QPair>
+#include <QPushButton>
+#include <QScrollArea>
+#include <QSize>
+#include <QThread>
+
+#include "library/library.h"
+#include "library/trackcollection.h"
+#include "library/trackcollectionmanager.h"
+#include "library/trackset/crate/cratestorage.h"
+#include "preferences/usersettings.h"
+#include "skin/skincontext.h"
+#include "track/track.h"
+#include "widget/wlabel.h"
+
+/// Worker thread that fetches results from the library
+class WInfoBarWorker : public QObject {
+    Q_OBJECT
+  public:
+    WInfoBarWorker(QObject* parent, TrackCollectionManager* pTrackCollectionManager);
+    ~WInfoBarWorker() = default;
+
+  public slots:
+    void query(int query, QList<TrackId>);
+  signals:
+    void crateResult(int query, uint total, QList<CrateSummary>);
+
+  private:
+    // add your variables here
+    TrackCollectionManager* const m_pTrackCollectionManager;
+};
+
+class WInfoBarItem : public QPushButton {
+  public:
+    WInfoBarItem(const QString& text, QWidget* parent = nullptr);
+};
+
+class WInfoBarCrateItem : public WInfoBarItem {
+  public:
+    WInfoBarCrateItem(const CrateSummary crate, QWidget* parent = nullptr);
+};
+
+class WInfoBarCrateMixedItem : public WInfoBarCrateItem {
+  public:
+    WInfoBarCrateMixedItem(const CrateSummary crate, QWidget* parent = nullptr);
+};
+
+class QVBoxLayout;
+class QHBoxLayout;
+class QFrame;
+
+class WInfoBar : public QScrollArea, public WBaseWidget {
+    Q_OBJECT
+  public:
+    WInfoBar(QString group, UserSettingsPointer pConfig, Library* pLibrary, QWidget* pParent);
+
+    void setup(const QDomNode& node, const SkinContext& context);
+    int generateId();
+    void clear();
+    QSize minimumSize() const {
+        return QSize(0, 0);
+    }
+    QSize minimumSizeHint() const {
+        return QSize(0, 0);
+    }
+    //QSize const minimumSizeHint();
+
+    /*
+    Q_PROPERTY(bool multiLine READ getMultiline WRITE setMultiline)
+    Q_PROPERTY(bool showCrates READ getShowCrates WRITE setShowCrates)
+    Q_PROPERTY(bool showPlaylists READ getShowPlaylists WRITE setShowPlaylists)
+    Q_PROPERTY(bool showHistory READ getShowHistory WRITE setShowHistory)
+    Q_PROPERTY(double scrollSpeed READ getScrollSpeed WRITE setScrollSpeed)
+    */
+
+  signals:
+    void trackDropped(QString filename, QString group);
+    void query(int query, QList<TrackId>);
+
+  public slots:
+    void slotTrackLoaded(TrackPointer track);
+    void slotTrackSelection(QList<TrackPointer> tracks);
+    void slotClear() {
+        clear();
+    };
+    //void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
+
+  private slots:
+    //void updateLabel(Track*);
+    void receiveCrateResults(int query, uint total, QList<CrateSummary>);
+
+  private:
+    void dragEnterEvent(QDragEnterEvent* event) override;
+    void dropEvent(QDropEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void setupUI();
+
+    QFrame* m_pContainerFrame;
+    QHBoxLayout* m_pContainer;
+    QFrame* m_pCratesFrame;
+    QHBoxLayout* m_pCratesContainer;
+    QFrame* m_pPlaylistsFrame;
+    QHBoxLayout* m_pPlaylistsContainer;
+    QFrame* m_pHistoryFrame;
+    QHBoxLayout* m_pHistoryContainer;
+
+    QString m_pGroup;
+    UserSettingsPointer m_pConfig;
+    TrackPointer m_pCurrentTrack;
+    //QString m_property;
+    //QString m_separator;
+    //TrackCollectionManager* const m_pCollectionManager;
+    Library* m_pLibrary;
+    //const CrateStorage* m_cratestore;
+    int m_id;
+    WInfoBarWorker* m_pWorker;
+
+    // shared worker thread
+    static QThread* s_worker_thread;
+    // id generation
+    static int s_last_id;
+};

--- a/src/widget/winfobar.h
+++ b/src/widget/winfobar.h
@@ -2,17 +2,22 @@
 
 #include <QDragEnterEvent>
 #include <QDropEvent>
+#include <QHBoxLayout>
 #include <QMouseEvent>
 #include <QPair>
 #include <QPushButton>
 #include <QScrollArea>
 #include <QSize>
+#include <QStatusBar>
 #include <QThread>
+#include <QToolButton>
+#include <QWidget>
 
 #include "library/library.h"
 #include "library/trackcollection.h"
 #include "library/trackcollectionmanager.h"
 #include "library/trackset/crate/cratestorage.h"
+#include "library/trackset/playlistsummary.h"
 #include "preferences/usersettings.h"
 #include "skin/skincontext.h"
 #include "track/track.h"
@@ -27,8 +32,14 @@ class WInfoBarWorker : public QObject {
 
   public slots:
     void query(int query, QList<TrackId>);
+    void queryCrates(int query, QList<TrackId> trackIds);
+    void queryPlaylists(int query, QList<TrackId> trackIds);
+    void queryHistory(int query, QList<TrackId> trackIds);
+
   signals:
-    void crateResult(int query, uint total, QList<CrateSummary>);
+    void crateResult(int query, int total, QList<CrateSummary>);
+    void playlistResult(int query, int total, QList<PlaylistSummary>);
+    void historyResult(int query, int total, QList<PlaylistSummary>);
 
   private:
     // add your variables here
@@ -36,28 +47,128 @@ class WInfoBarWorker : public QObject {
 };
 
 class WInfoBarItem : public QPushButton {
+    Q_OBJECT
   public:
     WInfoBarItem(const QString& text, QWidget* parent = nullptr);
+    ~WInfoBarItem() = default;
+    void setTotals(int totals) {
+        m_totals = totals;
+    };
+    int totals() {
+        return m_totals;
+    };
+    void setMatches(int matches) {
+        m_matches = matches;
+    };
+    int matches() {
+        return m_matches;
+    };
+
+    bool notAll() {
+        return matches() != totals();
+    }
+
+    Q_PROPERTY(int totals READ totals WRITE setTotals);
+    Q_PROPERTY(int matches READ matches WRITE setMatches);
+    Q_PROPERTY(bool notAll READ notAll);
+
+  private:
+    int m_totals;
+    int m_matches;
 };
 
 class WInfoBarCrateItem : public WInfoBarItem {
+    Q_OBJECT
+
   public:
     WInfoBarCrateItem(const CrateSummary crate, QWidget* parent = nullptr);
+
+  signals:
+    void activateCrate(CrateSummary crate);
+
+  private:
+    const CrateSummary m_crate;
 };
 
-class WInfoBarCrateMixedItem : public WInfoBarCrateItem {
+class WInfoBarPlaylistItem : public WInfoBarItem {
+    Q_OBJECT
   public:
-    WInfoBarCrateMixedItem(const CrateSummary crate, QWidget* parent = nullptr);
+    WInfoBarPlaylistItem(const PlaylistSummary playlist, bool isHistory, QWidget* parent = nullptr);
+
+    Q_PROPERTY(bool isHistory MEMBER m_isHistory CONSTANT);
+  signals:
+    void activatePlaylist(PlaylistSummary playlist, bool isHistory);
+
+  private:
+    const PlaylistSummary m_playlist;
+    const bool m_isHistory;
 };
 
-class QVBoxLayout;
-class QHBoxLayout;
-class QFrame;
+//Q_DECLARE_METATYPE(WInfoBarButtonState);
 
-class WInfoBar : public QScrollArea, public WBaseWidget {
+class WInfoBarButton : public QToolButton {
+    Q_OBJECT
+  public:
+    enum State {
+        VISIBLE,
+        HIDDEN,
+        EXPANDED
+    };
+    Q_ENUM(State);
+    WInfoBarButton(QWidget* pParent);
+    ~WInfoBarButton() = default;
+    void setState(State newState);
+    State state() {
+        return m_state;
+    };
+    Q_PROPERTY(State state READ state WRITE setState NOTIFY stateChanged);
+    void nextCheckState() override;
+
+  signals:
+    void stateChanged(State newState);
+
+  private slots:
+    //void slotTriggered(QAction* action);
+
+  private:
+    State m_state;
+};
+
+//qRegisterMetaType<WInfoBarButton::States>("States");
+
+class WInfoBarContainer : public QFrame {
+    Q_OBJECT
+  public:
+    WInfoBarContainer(QString name, QWidget* pParent);
+    ~WInfoBarContainer() = default;
+
+    void addItem(WInfoBarItem* item);
+    void addStretch(int factor);
+    void clear();
+    void setState(WInfoBarButton::State state);
+    WInfoBarButton::State state() {
+        VERIFY_OR_DEBUG_ASSERT(m_pButton) {
+            return WInfoBarButton::State::VISIBLE;
+        }
+        return m_pButton->state();
+    }
+  signals:
+    void stateChanged(WInfoBarButton::State newState);
+
+  private:
+    void slotStateChange(WInfoBarButton::State state);
+
+    WInfoBarButton* m_pButton;
+    QHBoxLayout* m_pContainer;
+    QHBoxLayout* m_pMainLayout;
+    QWidget* m_pMainContainer;
+};
+
+class WInfoBar : public QStatusBar, public WBaseWidget {
     Q_OBJECT
   public:
     WInfoBar(QString group, UserSettingsPointer pConfig, Library* pLibrary, QWidget* pParent);
+    ~WInfoBar() = default;
 
     void setup(const QDomNode& node, const SkinContext& context);
     int generateId();
@@ -65,8 +176,13 @@ class WInfoBar : public QScrollArea, public WBaseWidget {
     QSize minimumSize() const {
         return QSize(0, 0);
     }
-    QSize minimumSizeHint() const {
+    QSize minimumSizeHint() const override {
         return QSize(0, 0);
+    }
+    QSize sizeHint() const override {
+        QSize rv = QStatusBar::sizeHint();
+        rv.setWidth(0);
+        return rv;
     }
     //QSize const minimumSizeHint();
 
@@ -91,27 +207,59 @@ class WInfoBar : public QScrollArea, public WBaseWidget {
     //void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
 
   private slots:
-    //void updateLabel(Track*);
-    void receiveCrateResults(int query, uint total, QList<CrateSummary>);
+    void receiveCrateResults(int queryId, int total, QList<CrateSummary> crates);
+    void receivePlaylistResults(int queryId, int total, QList<PlaylistSummary> playlists);
+    void receiveHistoryResults(int queryId, int total, QList<PlaylistSummary> playlists);
+    void slotActivateCrate(CrateSummary crate);
+    void slotActivatePlaylist(PlaylistSummary playlist, bool isHistory);
+    void slotRebuildWidgets(WInfoBarButton::State state) {
+        Q_UNUSED(state);
+        rebuildWidgets();
+    };
+    void slotCrateTracksChanged(CrateId crate,
+            const QList<TrackId>& tracksAdded,
+            const QList<TrackId>& tracksRemoved);
 
   private:
+    /*
+    void clearContainer(QHBoxLayout* layout);
+    void clearCrates() { clearContainer(m_pCratesContainer); }
+    void clearPlaylists() { clearContainer(m_pPlaylistsContainer); }
+    void clearHistory() { clearContainer(m_pHistoryContainer); }
+    */
+    void addPlaylistResults(bool isHistory,
+            int queryId,
+            int total,
+            QList<PlaylistSummary> playlists);
+    //void updateVisibilty();
     void dragEnterEvent(QDragEnterEvent* event) override;
     void dropEvent(QDropEvent* event) override;
-    void mouseMoveEvent(QMouseEvent* event) override;
+    void contextMenuEvent(QContextMenuEvent* event) override;
     void setupUI();
+    void prepareFrame(QFrame* frame);
+    void rebuildWidgets();
+    void queryCurrentTracks();
+    void clearCurrentTracks();
 
     QFrame* m_pContainerFrame;
     QHBoxLayout* m_pContainer;
+
+    /*
     QFrame* m_pCratesFrame;
     QHBoxLayout* m_pCratesContainer;
     QFrame* m_pPlaylistsFrame;
     QHBoxLayout* m_pPlaylistsContainer;
     QFrame* m_pHistoryFrame;
     QHBoxLayout* m_pHistoryContainer;
+    */
+    WInfoBarContainer* m_pCratesContainer;
+    WInfoBarContainer* m_pPlaylistsContainer;
+    WInfoBarContainer* m_pHistoryContainer;
 
     QString m_pGroup;
     UserSettingsPointer m_pConfig;
-    TrackPointer m_pCurrentTrack;
+    QList<TrackPointer> m_currentTracks{};
+
     //QString m_property;
     //QString m_separator;
     //TrackCollectionManager* const m_pCollectionManager;

--- a/src/widget/wlibrarytableview.h
+++ b/src/widget/wlibrarytableview.h
@@ -37,6 +37,7 @@ class WLibraryTableView : public QTableView, public virtual LibraryView {
     void loadTrack(TrackPointer pTrack);
     void loadTrackToPlayer(TrackPointer pTrack, const QString& group, bool play = false);
     void trackSelected(TrackPointer pTrack);
+    void trackSelection(QList<TrackPointer>);
     void onlyCachedCoverArt(bool);
     void scrollValueChanged(int);
 

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -270,6 +270,19 @@ void WMainMenuBar::initialize() {
     createVisibilityControl(pViewShowCoverArt, ConfigKey("[Library]", "show_coverart"));
     pViewMenu->addAction(pViewShowCoverArt);
 
+    QString showCratesTitle = tr("Show Crates List");
+    QString showCratesText = tr("Show a list with crates the selection is in") +
+            " " + mayNotBeSupported;
+    auto pViewShowCrates = new QAction(showCratesTitle, this);
+    pViewShowCrates->setCheckable(true);
+    pViewShowCrates->setShortcut(
+            QKeySequence(m_pKbdConfig->getValue(
+                    ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowCrates"),
+                    tr("Ctrl+7", "Menubar|View|Show Crates Section"))));
+    pViewShowCrates->setStatusTip(showCratesText);
+    pViewShowCrates->setWhatsThis(buildWhatsThis(showCratesTitle, showCratesText));
+    createVisibilityControl(pViewShowCrates, ConfigKey("[Library]", "show_crates"));
+    pViewMenu->addAction(pViewShowCrates);
 
     QString maximizeLibraryTitle = tr("Maximize Library");
     QString maximizeLibraryText = tr("Maximize the track library to take up all the available screen space.") +

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -270,19 +270,20 @@ void WMainMenuBar::initialize() {
     createVisibilityControl(pViewShowCoverArt, ConfigKey("[Library]", "show_coverart"));
     pViewMenu->addAction(pViewShowCoverArt);
 
-    QString showCratesTitle = tr("Show Crates List");
-    QString showCratesText = tr("Show a list with crates the selection is in") +
+    QString showInfobarTitle = tr("Show Infobar");
+    QString showInfobarText = tr("Show a infobar with crates/playlist "
+                                 "information about the selected track") +
             " " + mayNotBeSupported;
-    auto pViewShowCrates = new QAction(showCratesTitle, this);
-    pViewShowCrates->setCheckable(true);
-    pViewShowCrates->setShortcut(
+    auto pViewShowInfobar = new QAction(showInfobarTitle, this);
+    pViewShowInfobar->setCheckable(true);
+    pViewShowInfobar->setShortcut(
             QKeySequence(m_pKbdConfig->getValue(
-                    ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowCrates"),
-                    tr("Ctrl+7", "Menubar|View|Show Crates Section"))));
-    pViewShowCrates->setStatusTip(showCratesText);
-    pViewShowCrates->setWhatsThis(buildWhatsThis(showCratesTitle, showCratesText));
-    createVisibilityControl(pViewShowCrates, ConfigKey("[Library]", "show_crates"));
-    pViewMenu->addAction(pViewShowCrates);
+                    ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowInfobar"),
+                    tr("Ctrl+7", "Menubar|View|Show Infobar"))));
+    pViewShowInfobar->setStatusTip(showInfobarText);
+    pViewShowInfobar->setWhatsThis(buildWhatsThis(showInfobarTitle, showInfobarText));
+    createVisibilityControl(pViewShowInfobar, ConfigKey("[Library]", "show_infobar"));
+    pViewMenu->addAction(pViewShowInfobar);
 
     QString maximizeLibraryTitle = tr("Maximize Library");
     QString maximizeLibraryText = tr("Maximize the track library to take up all the available screen space.") +

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -1,6 +1,7 @@
 #include "widget/wtrackproperty.h"
 
 #include <QDebug>
+#include <QMetaType>
 #include <QUrl>
 
 #include "control/controlobject.h"

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -114,6 +114,7 @@ void WTrackTableView::slotGuiTick50ms(double /*unused*/) {
         // slows down scrolling performance so we wait until the user has
         // stopped interacting first.
         if (m_selectionChangedSinceLastGuiTick) {
+            qDebug() << "m_selectionChangedSinceLastGuiTick";
             const QModelIndexList indices = selectionModel()->selectedRows();
             if (indices.size() == 1 && indices.first().isValid()) {
                 // A single track has been selected
@@ -123,6 +124,17 @@ void WTrackTableView::slotGuiTick50ms(double /*unused*/) {
                     if (pTrack) {
                         emit trackSelected(pTrack);
                     }
+                    // emit list of all selected track
+                    auto signal_data = QList<TrackPointer>();
+                    signal_data.reserve(indices.size());
+                    foreach (auto track, indices) {
+                        pTrack = trackModel->getTrack(track);
+                        if (pTrack) {
+                            signal_data.append(pTrack);
+                        }
+                    }
+                    qDebug() << "emit";
+                    emit(trackSelection(signal_data));
                 }
             } else {
                 // None or multiple tracks have been selected


### PR DESCRIPTION
This PR adds a Infobar into the library to show additional information about track selection and later notifications that are not
well presented on the table view. This is the successor of #1656 

<img width="1325" alt="Screenshot_20201206_011916" src="https://user-images.githubusercontent.com/66107/101268236-28280980-3761-11eb-8a6e-421607c57647.png">


The infobar has currently 3 widgets:
- crates
- playlists
- history

Each widgets shows buttons for each entry. The widget itself has 3 visibility states:
- collapsed (only the button of the category in a grey symbol)
- visible (the widget has some medium size but grows if necessary)
- extended (widget takes as much space as possible)

## todo
- safe state
- context menu
- add to other skins
- finish styling

For later PRs:
- Add configuration panel to allow full configuration of the status bar
   - maybe DND of elements
- which widgets
- order of widgets
- Add more exotic but useful widgets
  - free space
- crate/playlist colors
- when notification infrastructure lands, show the last message for n seconds

