### PR TITLE
Add support for exporting Serato Tags

### DIFF
--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -269,7 +269,7 @@ void TrackCollectionManager::exportTrackMetadata(
         switch (mode) {
         case TrackMetadataExportMode::Immediate:
             // Export track metadata now by saving as file tags.
-            SoundSourceProxy::exportTrackMetadataBeforeSaving(pTrack);
+            SoundSourceProxy::exportTrackMetadataBeforeSaving(pTrack, m_pConfig);
             break;
         case TrackMetadataExportMode::Deferred:
             // Export track metadata later when the track object goes out

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -339,11 +339,13 @@ void DlgPrefLibrary::slotSeratoMetadataExportClicked(bool checked) {
         if (QMessageBox::warning(this,
                     QStringLiteral("Serato Metadata Export"),
                     QStringLiteral(
-                            "Exporting Serato Metadata from Mixxx is highly "
+                            "Exporting Serato Metadata from Mixxx is "
                             "experimental. There is no official documentation "
-                            "of the format. Files with Serato metadata written "
-                            "by Mixxx might crash Serato DJ, therefore caution "
-                            "is advised. Do you really want to enable this "
+                            "of the format. Existing Serato Metadata might be "
+                            "lost and files with Serato metadata written by "
+                            "Mixxx could potentially crash Serato DJ, "
+                            "therefore caution is advised and backups are "
+                            "recommended. Do you really want to enable this "
                             "option?"),
                     QMessageBox::Yes | QMessageBox::No) == QMessageBox::No) {
             checkBox_SeratoMetadataExport->setChecked(false);

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -63,10 +63,6 @@ DlgPrefLibrary::DlgPrefLibrary(
                 QDesktopServices::openUrl(QUrl::fromLocalFile(settingsDir));
             });
 
-#if defined(__EXPORT_SERATO_MARKERS__)
-    checkBox_SeratoMetadataExport->show();
-#endif
-
     // Set default direction as stored in config file
     int rowHeight = m_pLibrary->getTrackTableRowHeight();
     spinBoxRowHeight->setValue(rowHeight);

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -345,7 +345,7 @@ void DlgPrefLibrary::slotSeratoMetadataExportClicked(bool checked) {
                             "lost and files with Serato metadata written by "
                             "Mixxx could potentially crash Serato DJ, "
                             "therefore caution is advised and backups are "
-                            "recommended. Do you really want to enable this "
+                            "recommended. Are you sure you want to enable this "
                             "option?"),
                     QMessageBox::Yes | QMessageBox::No) == QMessageBox::No) {
             checkBox_SeratoMetadataExport->setChecked(false);

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -56,6 +56,10 @@ DlgPrefLibrary::DlgPrefLibrary(
             &QPushButton::clicked,
             this,
             &DlgPrefLibrary::slotRelocateDir);
+    connect(checkBox_SeratoMetadataExport,
+            &QAbstractButton::clicked,
+            this,
+            &DlgPrefLibrary::slotSeratoMetadataExportClicked);
     const QString& settingsDir = m_pConfig->getSettingsPath();
     connect(PushButtonOpenSettingsDir,
             &QPushButton::clicked,
@@ -327,6 +331,23 @@ void DlgPrefLibrary::slotRelocateDir() {
     if (!fd.isEmpty()) {
         emit requestRelocateDir(currentFd, fd);
         slotUpdate();
+    }
+}
+
+void DlgPrefLibrary::slotSeratoMetadataExportClicked(bool checked) {
+    if (checked) {
+        if (QMessageBox::warning(this,
+                    QStringLiteral("Serato Metadata Export"),
+                    QStringLiteral(
+                            "Exporting Serato Metadata from Mixxx is highly "
+                            "experimental. There is no official documentation "
+                            "of the format. Files with Serato metadata written "
+                            "by Mixxx might crash Serato DJ, therefore caution "
+                            "is advised. Do you really want to enable this "
+                            "option?"),
+                    QMessageBox::Yes | QMessageBox::No) == QMessageBox::No) {
+            checkBox_SeratoMetadataExport->setChecked(false);
+        }
     }
 }
 

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -63,6 +63,10 @@ DlgPrefLibrary::DlgPrefLibrary(
                 QDesktopServices::openUrl(QUrl::fromLocalFile(settingsDir));
             });
 
+#if defined(__EXPORT_SERATO_MARKERS__)
+    checkBox_SeratoMetadataExport->show();
+#endif
+
     // Set default direction as stored in config file
     int rowHeight = m_pLibrary->getTrackTableRowHeight();
     spinBoxRowHeight->setValue(rowHeight);
@@ -168,6 +172,7 @@ void DlgPrefLibrary::initializeDirList() {
 void DlgPrefLibrary::slotResetToDefaults() {
     checkBox_library_scan->setChecked(false);
     checkBox_SyncTrackMetadataExport->setChecked(false);
+    checkBox_SeratoMetadataExport->setChecked(false);
     checkBox_use_relative_path->setChecked(false);
     checkBox_show_rhythmbox->setChecked(true);
     checkBox_show_banshee->setChecked(true);
@@ -188,6 +193,8 @@ void DlgPrefLibrary::slotUpdate() {
             ConfigKey("[Library]","RescanOnStartup"), false));
     checkBox_SyncTrackMetadataExport->setChecked(m_pConfig->getValue(
             ConfigKey("[Library]","SyncTrackMetadataExport"), false));
+    checkBox_SeratoMetadataExport->setChecked(m_pConfig->getValue(
+            ConfigKey("[Library]", "SeratoMetadataExport"), false));
     checkBox_use_relative_path->setChecked(m_pConfig->getValue(
             ConfigKey("[Library]","UseRelativePathOnExport"), false));
     checkBox_show_rhythmbox->setChecked(m_pConfig->getValue(
@@ -332,6 +339,8 @@ void DlgPrefLibrary::slotApply() {
                 ConfigValue((int)checkBox_library_scan->isChecked()));
     m_pConfig->set(ConfigKey("[Library]","SyncTrackMetadataExport"),
                 ConfigValue((int)checkBox_SyncTrackMetadataExport->isChecked()));
+    m_pConfig->set(ConfigKey("[Library]", "SeratoMetadataExport"),
+            ConfigValue(static_cast<int>(checkBox_SeratoMetadataExport->isChecked())));
     m_pConfig->set(ConfigKey("[Library]","UseRelativePathOnExport"),
                 ConfigValue((int)checkBox_use_relative_path->isChecked()));
     m_pConfig->set(ConfigKey("[Library]","ShowRhythmboxLibrary"),

--- a/src/preferences/dialog/dlgpreflibrary.h
+++ b/src/preferences/dialog/dlgpreflibrary.h
@@ -55,6 +55,7 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
     void slotSelectFont();
     void slotSyncTrackMetadataExportToggled();
     void slotSearchDebouncingTimeoutMillisChanged(int);
+    void slotSeratoMetadataExportClicked(bool);
 
   private:
     void initializeDirList();

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -141,7 +141,7 @@
       <item row="1" column="0">
        <widget class="QCheckBox" name="checkBox_SeratoMetadataExport">
         <property name="text">
-         <string>Write Serato Metadata to files</string>
+         <string>Write Serato Metadata to files (experimental)</string>
         </property>
        </widget>
       </item>

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>593</width>
-    <height>1049</height>
+    <height>1080</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -135,6 +135,16 @@
        <widget class="QCheckBox" name="checkBox_SyncTrackMetadataExport">
         <property name="text">
          <string>Automatically write modified track metadata from the library into file tags</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="checkBox_SeratoMetadataExport">
+        <property name="visible">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Write Serato Metadata to files (experimental)</string>
         </property>
        </widget>
       </item>

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -141,7 +141,7 @@
       <item row="1" column="0">
        <widget class="QCheckBox" name="checkBox_SeratoMetadataExport">
         <property name="text">
-         <string>Write Serato Metadata to files (experimental/potentially makes files unusable in Serato!)</string>
+         <string>Write Serato Metadata to files</string>
         </property>
        </widget>
       </item>

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>593</width>
-    <height>1080</height>
+    <width>661</width>
+    <height>1203</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -140,18 +140,14 @@
       </item>
       <item row="1" column="0">
        <widget class="QCheckBox" name="checkBox_SeratoMetadataExport">
-        <property name="visible">
-         <bool>false</bool>
-        </property>
         <property name="text">
-         <string>Write Serato Metadata to files (experimental)</string>
+         <string>Write Serato Metadata to files (experimental/potentially makes files unusable in Serato!)</string>
         </property>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
-
    <item>
     <widget class="QGroupBox" name="groupBox_Miscellaneous">
      <property name="title">

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -345,7 +345,7 @@ QImage SoundSourceProxy::importTemporaryCoverImage(
 
 //static
 ExportTrackMetadataResult
-SoundSourceProxy::exportTrackMetadataBeforeSaving(Track* pTrack) {
+SoundSourceProxy::exportTrackMetadataBeforeSaving(Track* pTrack, UserSettingsPointer pConfig) {
     DEBUG_ASSERT(pTrack);
     const auto fileInfo = pTrack->getFileInfo();
     mixxx::MetadataSourcePointer pMetadataSource;
@@ -370,7 +370,7 @@ SoundSourceProxy::exportTrackMetadataBeforeSaving(Track* pTrack) {
         pMetadataSource = proxy.m_pSoundSource;
     }
     if (pMetadataSource) {
-        return pTrack->exportMetadata(pMetadataSource);
+        return pTrack->exportMetadata(pMetadataSource, pConfig);
     } else {
         kLogger.warning()
                 << "Unable to export track metadata into file"

--- a/src/sources/soundsourceproxy.h
+++ b/src/sources/soundsourceproxy.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "preferences/usersettings.h"
 #include "sources/soundsourceproviderregistry.h"
 #include "track/track_decl.h"
 #include "track/trackfile.h"
@@ -145,7 +146,8 @@ class SoundSourceProxy {
     static QRegExp s_supportedFileNamesRegex;
 
     friend class TrackCollectionManager;
-    static ExportTrackMetadataResult exportTrackMetadataBeforeSaving(Track* pTrack);
+    static ExportTrackMetadataResult exportTrackMetadataBeforeSaving(
+            Track* pTrack, UserSettingsPointer pConfig);
 
     // Special case: Construction from a url is needed
     // for writing metadata immediately before the TIO is destroyed.

--- a/src/test/seratobeatgridtest.cpp
+++ b/src/test/seratobeatgridtest.cpp
@@ -109,14 +109,12 @@ TEST_F(SeratoBeatGridTest, SerializeBeatgrid) {
     const auto sampleRate = mixxx::audio::SampleRate(44100);
     EXPECT_EQ(sampleRate.isValid(), true);
     const auto pBeats = mixxx::BeatGrid::makeBeatGrid(sampleRate, QString("Test"), bpm, 0);
-    const auto streamInfo = mixxx::audio::StreamInfo(
-            mixxx::audio::SignalInfo(mixxx::audio::ChannelCount(2), sampleRate),
-            mixxx::audio::Bitrate(320),
-            mixxx::Duration::fromSeconds<int>(300));
+    const auto signalInfo = mixxx::audio::SignalInfo(mixxx::audio::ChannelCount(2), sampleRate);
+    const auto duration = mixxx::Duration::fromSeconds<int>(300);
 
     // Serialize that beatgrid into Serato BeatGrid data and check if it's correct
     mixxx::SeratoBeatGrid seratoBeatGrid;
-    seratoBeatGrid.setBeats(pBeats, streamInfo, 0);
+    seratoBeatGrid.setBeats(pBeats, signalInfo, duration, 0);
     EXPECT_EQ(seratoBeatGrid.nonTerminalMarkers().size(), 0);
     EXPECT_NE(seratoBeatGrid.terminalMarker(), nullptr);
     EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm));
@@ -127,12 +125,9 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
     constexpr double bpm = 100.0;
     const auto sampleRate = mixxx::audio::SampleRate(44100);
     const auto signalInfo = mixxx::audio::SignalInfo(mixxx::audio::ChannelCount(2), sampleRate);
+    const auto duration = mixxx::Duration::fromSeconds<int>(300);
     const double framesPerMinute = signalInfo.getSampleRate() * 60;
     const double framesPerBeat = framesPerMinute / bpm;
-
-    const auto streamInfo = mixxx::audio::StreamInfo(signalInfo,
-            mixxx::audio::Bitrate(320),
-            mixxx::Duration::fromSeconds<int>(300));
 
     QVector<double> beatPositionsFrames;
     double beatPositionFrames = 0;
@@ -150,7 +145,7 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
         EXPECT_EQ(pBeats->getBpmAroundPosition(framesPerMinute, 1), bpm);
 
         mixxx::SeratoBeatGrid seratoBeatGrid;
-        seratoBeatGrid.setBeats(pBeats, streamInfo, 0);
+        seratoBeatGrid.setBeats(pBeats, signalInfo, duration, 0);
         EXPECT_EQ(seratoBeatGrid.nonTerminalMarkers().size(), 0);
         EXPECT_NE(seratoBeatGrid.terminalMarker(), nullptr);
         EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm));
@@ -172,7 +167,7 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
         EXPECT_EQ(pBeats->getBpmAroundPosition(framesPerMinute * 4, 1), bpm / 2);
 
         mixxx::SeratoBeatGrid seratoBeatGrid;
-        seratoBeatGrid.setBeats(pBeats, streamInfo, 0);
+        seratoBeatGrid.setBeats(pBeats, signalInfo, duration, 0);
         EXPECT_EQ(seratoBeatGrid.nonTerminalMarkers().size(), 2);
         EXPECT_NE(seratoBeatGrid.terminalMarker(), nullptr);
         EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm / 2));

--- a/src/track/serato/beatgrid.cpp
+++ b/src/track/serato/beatgrid.cpp
@@ -424,7 +424,9 @@ QByteArray SeratoBeatGrid::dumpBase64Encoded() const {
 void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
         const audio::StreamInfo& streamInfo,
         double timingOffsetMillis) {
-    VERIFY_OR_DEBUG_ASSERT(pBeats) {
+    if (!pBeats) {
+        setTerminalMarker(nullptr);
+        setNonTerminalMarkers({});
         return;
     }
 

--- a/src/track/serato/beatgrid.cpp
+++ b/src/track/serato/beatgrid.cpp
@@ -422,7 +422,8 @@ QByteArray SeratoBeatGrid::dumpBase64Encoded() const {
 }
 
 void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
-        const audio::StreamInfo& streamInfo,
+        const audio::SignalInfo& signalInfo,
+        const Duration& duration,
         double timingOffsetMillis) {
     if (!pBeats) {
         setTerminalMarker(nullptr);
@@ -436,9 +437,9 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
     // in the track, therefore we calculate the track duration in samples and
     // round up. This value might be longer than the actual track, but that's
     // okay because we want to make sure we get all beats.
-    const SINT trackDurationSamples = streamInfo.getSignalInfo().frames2samples(
-            static_cast<SINT>(streamInfo.getSignalInfo().secs2frames(
-                    std::ceil(streamInfo.getDuration().toDoubleSeconds()))));
+    const SINT trackDurationSamples = signalInfo.frames2samples(
+            static_cast<SINT>(signalInfo.secs2frames(
+                    std::ceil(duration.toDoubleSeconds()))));
     auto pBeatsIterator = pBeats->findBeats(0, trackDurationSamples);
 
     // This might be null if the track doesn't contain any beats
@@ -457,7 +458,7 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
     while (pBeatsIterator->hasNext()) {
         previousBeatPositionFrames = currentBeatPositionFrames;
         currentBeatPositionFrames =
-                streamInfo.getSignalInfo().samples2framesFractional(
+                signalInfo.samples2framesFractional(
                         pBeatsIterator->next());
 
         // Calculate the delta between the current beat and the previous beat.
@@ -493,7 +494,7 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
             // last beat, this needs to be a terminal marker entry.
             if (pBeatsIterator->hasNext()) {
                 const double positionSecs =
-                        streamInfo.getSignalInfo().frames2secsFractional(
+                        signalInfo.frames2secsFractional(
                                 currentBeatPositionFrames) -
                         timingOffsetSecs;
                 nonTerminalMarkers.append(
@@ -532,11 +533,11 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
 
     // Finally, create the terminal marker.
     const double positionSecs =
-            streamInfo.getSignalInfo().frames2secsFractional(
+            signalInfo.frames2secsFractional(
                     currentBeatPositionFrames) -
             timingOffsetSecs;
     const double bpm = pBeats->getBpmAroundPosition(
-            streamInfo.getSignalInfo().frames2samples(
+            signalInfo.frames2samples(
                     static_cast<SINT>(currentBeatPositionFrames)),
             1);
 

--- a/src/track/serato/beatgrid.h
+++ b/src/track/serato/beatgrid.h
@@ -6,11 +6,12 @@
 #include <QList>
 #include <memory>
 
-#include "audio/streaminfo.h"
+#include "audio/signalinfo.h"
 #include "track/beats.h"
 #include "track/cueinfo.h"
 #include "track/taglib/trackmetadata_file.h"
 #include "util/assert.h"
+#include "util/duration.h"
 #include "util/types.h"
 
 namespace mixxx {
@@ -129,7 +130,8 @@ class SeratoBeatGrid final {
     }
 
     void setBeats(BeatsPointer pBeats,
-            const audio::StreamInfo& streamInfo,
+            const audio::SignalInfo& signalInfo,
+            const Duration& duration,
             double timingOffsetMillis);
 
     quint8 footer() const {

--- a/src/track/serato/tags.h
+++ b/src/track/serato/tags.h
@@ -13,6 +13,12 @@ namespace mixxx {
 /// Serato DJ Pro software.
 class SeratoTags final {
   public:
+    enum class ParserStatus {
+        None = 0,
+        Parsed = 1,
+        Failed = 2,
+    };
+
     static constexpr RgbColor kDefaultTrackColor = RgbColor(0xFF9999);
     static constexpr RgbColor kDefaultCueColor = RgbColor(0xCC0000);
     static constexpr RgbColor kFixedLoopColor = RgbColor(0x27AAE1);
@@ -31,16 +37,41 @@ class SeratoTags final {
                 m_seratoMarkers2.isEmpty();
     }
 
+    /// Return the cumulated parse status for all Serato tags. If no tags were parsed,
+    /// this returns `ParserStatus::None`. If any tag failed to parse, this
+    /// returns `ParserStatus::Failed`.
+    ParserStatus status() const {
+        if (m_seratoBeatGridParserStatus == ParserStatus::Failed ||
+                m_seratoMarkersParserStatus == ParserStatus::Failed ||
+                m_seratoMarkers2ParserStatus == ParserStatus::Failed) {
+            return ParserStatus::Failed;
+        }
+
+        if (m_seratoBeatGridParserStatus == ParserStatus::None ||
+                m_seratoMarkersParserStatus == ParserStatus::None ||
+                m_seratoMarkers2ParserStatus == ParserStatus::None) {
+            return ParserStatus::None;
+        }
+
+        return ParserStatus::Parsed;
+    }
+
     bool parseBeatGrid(const QByteArray& data, taglib::FileType fileType) {
-        return SeratoBeatGrid::parse(&m_seratoBeatGrid, data, fileType);
+        bool success = SeratoBeatGrid::parse(&m_seratoBeatGrid, data, fileType);
+        m_seratoBeatGridParserStatus = success ? ParserStatus::Parsed : ParserStatus::Failed;
+        return success;
     }
 
     bool parseMarkers(const QByteArray& data, taglib::FileType fileType) {
-        return SeratoMarkers::parse(&m_seratoMarkers, data, fileType);
+        bool success = SeratoMarkers::parse(&m_seratoMarkers, data, fileType);
+        m_seratoMarkersParserStatus = success ? ParserStatus::Parsed : ParserStatus::Failed;
+        return success;
     }
 
     bool parseMarkers2(const QByteArray& data, taglib::FileType fileType) {
-        return SeratoMarkers2::parse(&m_seratoMarkers2, data, fileType);
+        bool success = SeratoMarkers2::parse(&m_seratoMarkers2, data, fileType);
+        m_seratoMarkers2ParserStatus = success ? ParserStatus::Parsed : ParserStatus::Failed;
+        return success;
     }
 
     QByteArray dumpBeatGrid(taglib::FileType fileType) const {
@@ -75,8 +106,11 @@ class SeratoTags final {
 
   private:
     SeratoBeatGrid m_seratoBeatGrid;
+    ParserStatus m_seratoBeatGridParserStatus;
     SeratoMarkers m_seratoMarkers;
+    ParserStatus m_seratoMarkersParserStatus;
     SeratoMarkers2 m_seratoMarkers2;
+    ParserStatus m_seratoMarkers2ParserStatus;
 };
 
 inline bool operator==(const SeratoTags& lhs, const SeratoTags& rhs) {

--- a/src/track/serato/tags.h
+++ b/src/track/serato/tags.h
@@ -93,9 +93,10 @@ class SeratoTags final {
     void setCueInfos(const QList<CueInfo>& cueInfos, double timingOffset = 0);
 
     void setBeats(BeatsPointer pBeats,
-            const audio::StreamInfo& streamInfo,
+            const audio::SignalInfo& signalInfo,
+            const Duration& duration,
             double timingOffset) {
-        m_seratoBeatGrid.setBeats(pBeats, streamInfo, timingOffset);
+        m_seratoBeatGrid.setBeats(pBeats, signalInfo, duration, timingOffset);
     }
 
     RgbColor::optional_t getTrackColor() const;

--- a/src/track/taglib/trackmetadata_id3v2.cpp
+++ b/src/track/taglib/trackmetadata_id3v2.cpp
@@ -507,7 +507,6 @@ void writeUniqueFileIdentifierFrame(
 }
 #endif // __EXTRA_METADATA__
 
-#if defined(__EXPORT_SERATO_MARKERS__)
 void writeGeneralEncapsulatedObjectFrame(
         TagLib::ID3v2::Tag* pTag,
         const QString& description,
@@ -537,7 +536,6 @@ void writeGeneralEncapsulatedObjectFrame(
         }
     }
 }
-#endif // __EXPORT_SERATO_MARKERS__
 
 template<typename T>
 const T* downcastFrame(TagLib::ID3v2::Frame* frame) {
@@ -1282,7 +1280,6 @@ bool exportTrackMetadataIntoTag(TagLib::ID3v2::Tag* pTag,
 
     // Export of Serato markers is disabled, because Mixxx
     // does not modify them.
-#if defined(__EXPORT_SERATO_MARKERS__)
     // Serato tags
     if (trackMetadata.getTrackInfo().getSeratoTags().status() != SeratoTags::ParserStatus::Failed) {
         writeGeneralEncapsulatedObjectFrame(
@@ -1298,7 +1295,6 @@ bool exportTrackMetadataIntoTag(TagLib::ID3v2::Tag* pTag,
                 kFrameDescriptionSeratoMarkers2,
                 trackMetadata.getTrackInfo().getSeratoTags().dumpMarkers2(FileType::MP3));
     }
-#endif // __EXPORT_SERATO_MARKERS__
 
     return true;
 }

--- a/src/track/taglib/trackmetadata_id3v2.cpp
+++ b/src/track/taglib/trackmetadata_id3v2.cpp
@@ -1284,18 +1284,20 @@ bool exportTrackMetadataIntoTag(TagLib::ID3v2::Tag* pTag,
     // does not modify them.
 #if defined(__EXPORT_SERATO_MARKERS__)
     // Serato tags
-    writeGeneralEncapsulatedObjectFrame(
-            pTag,
-            kFrameDescriptionSeratoBeatGrid,
-            trackMetadata.getTrackInfo().getSeratoTags().dumpBeatGrid(FileType::MP3));
-    writeGeneralEncapsulatedObjectFrame(
-            pTag,
-            kFrameDescriptionSeratoMarkers,
-            trackMetadata.getTrackInfo().getSeratoTags().dumpMarkers(FileType::MP3));
-    writeGeneralEncapsulatedObjectFrame(
-            pTag,
-            kFrameDescriptionSeratoMarkers2,
-            trackMetadata.getTrackInfo().getSeratoTags().dumpMarkers2(FileType::MP3));
+    if (trackMetadata.getTrackInfo().getSeratoTags().status() != SeratoTags::ParserStatus::Failed) {
+        writeGeneralEncapsulatedObjectFrame(
+                pTag,
+                kFrameDescriptionSeratoBeatGrid,
+                trackMetadata.getTrackInfo().getSeratoTags().dumpBeatGrid(FileType::MP3));
+        writeGeneralEncapsulatedObjectFrame(
+                pTag,
+                kFrameDescriptionSeratoMarkers,
+                trackMetadata.getTrackInfo().getSeratoTags().dumpMarkers(FileType::MP3));
+        writeGeneralEncapsulatedObjectFrame(
+                pTag,
+                kFrameDescriptionSeratoMarkers2,
+                trackMetadata.getTrackInfo().getSeratoTags().dumpMarkers2(FileType::MP3));
+    }
 #endif // __EXPORT_SERATO_MARKERS__
 
     return true;

--- a/src/track/taglib/trackmetadata_mp4.cpp
+++ b/src/track/taglib/trackmetadata_mp4.cpp
@@ -454,18 +454,20 @@ bool exportTrackMetadataIntoTag(
     // does not modify them.
 #if defined(__EXPORT_SERATO_MARKERS__)
     // Serato tags
-    writeAtom(
-            pTag,
-            kAtomKeySeratoBeatGrid,
-            dumpSeratoBeatGrid(trackMetadata, FileType::MP4));
-    writeAtom(
-            pTag,
-            kAtomKeySeratoMarkers,
-            dumpSeratoMarkers(trackMetadata, FileType::MP4));
-    writeAtom(
-            pTag,
-            kAtomKeySeratoMarkers2,
-            dumpSeratoMarkers2(trackMetadata, FileType::MP4));
+    if (trackMetadata.getTrackInfo().getSeratoTags().status() != SeratoTags::ParserStatus::Failed) {
+        writeAtom(
+                pTag,
+                kAtomKeySeratoBeatGrid,
+                dumpSeratoBeatGrid(trackMetadata, FileType::MP4));
+        writeAtom(
+                pTag,
+                kAtomKeySeratoMarkers,
+                dumpSeratoMarkers(trackMetadata, FileType::MP4));
+        writeAtom(
+                pTag,
+                kAtomKeySeratoMarkers2,
+                dumpSeratoMarkers2(trackMetadata, FileType::MP4));
+    }
 #endif // __EXPORT_SERATO_MARKERS__
 
     return true;

--- a/src/track/taglib/trackmetadata_mp4.cpp
+++ b/src/track/taglib/trackmetadata_mp4.cpp
@@ -450,9 +450,6 @@ bool exportTrackMetadataIntoTag(
     writeAtom(pTag, "\251mvn", toTString(trackMetadata.getTrackInfo().getMovement()));
 #endif // __EXTRA_METADATA__
 
-    // Export of Serato markers is disabled, because Mixxx
-    // does not modify them.
-#if defined(__EXPORT_SERATO_MARKERS__)
     // Serato tags
     if (trackMetadata.getTrackInfo().getSeratoTags().status() != SeratoTags::ParserStatus::Failed) {
         writeAtom(
@@ -468,7 +465,6 @@ bool exportTrackMetadataIntoTag(
                 kAtomKeySeratoMarkers2,
                 dumpSeratoMarkers2(trackMetadata, FileType::MP4));
     }
-#endif // __EXPORT_SERATO_MARKERS__
 
     return true;
 }

--- a/src/track/taglib/trackmetadata_xiph.cpp
+++ b/src/track/taglib/trackmetadata_xiph.cpp
@@ -608,7 +608,9 @@ bool exportTrackMetadataIntoTag(
     //
     // FIXME: We're only dumping FLAC tags for now, since the Ogg format is
     // different we don't support it yet.
-    if (fileType == FileType::FLAC) {
+    if (fileType == FileType::FLAC &&
+            trackMetadata.getTrackInfo().getSeratoTags().status() !=
+                    SeratoTags::ParserStatus::Failed) {
         writeCommentField(
                 pTag,
                 kCommentFieldKeySeratoBeatGrid,

--- a/src/track/taglib/trackmetadata_xiph.cpp
+++ b/src/track/taglib/trackmetadata_xiph.cpp
@@ -601,9 +601,6 @@ bool exportTrackMetadataIntoTag(
             pTag, "DISCNUMBER", toTString(trackMetadata.getTrackInfo().getDiscNumber()));
 #endif // __EXTRA_METADATA__
 
-    // Export of Serato markers is disabled, because Mixxx
-    // does not modify them.
-#if defined(__EXPORT_SERATO_MARKERS__)
     // Serato tags
     //
     // FIXME: We're only dumping FLAC tags for now, since the Ogg format is
@@ -621,9 +618,6 @@ bool exportTrackMetadataIntoTag(
                 kCommentFieldKeySeratoMarkers2FLAC,
                 dumpSeratoMarkers2(trackMetadata, fileType));
     }
-#else
-    Q_UNUSED(fileType);
-#endif // __EXPORT_SERATO_MARKERS__
 
     return true;
 }

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1392,7 +1392,7 @@ ExportTrackMetadataResult Track::exportMetadata(
                 cueInfos.append(pCue->getCueInfo(sampleRate));
             }
 
-            double timingOffset = mixxx::SeratoTags::guessTimingOffsetMillis(
+            const double timingOffset = mixxx::SeratoTags::guessTimingOffsetMillis(
                     getLocation(), streamInfo->getSignalInfo());
             seratoTags->setCueInfos(cueInfos, timingOffset);
         }

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1394,6 +1394,8 @@ ExportTrackMetadataResult Track::exportMetadata(
             const double timingOffset = mixxx::SeratoTags::guessTimingOffsetMillis(
                     getLocation(), streamInfo->getSignalInfo());
             seratoTags->setCueInfos(cueInfos, timingOffset);
+
+            seratoTags->setBeats(m_pBeats, *streamInfo, timingOffset);
         }
     }
 

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -17,6 +17,7 @@ namespace {
 const mixxx::Logger kLogger("Track");
 
 constexpr bool kLogStats = false;
+const ConfigKey kConfigKeySeratoMetadataExport("[Library]", "SeratoMetadataExport");
 
 // Count the number of currently existing instances for detecting
 // memory leaks.
@@ -1333,7 +1334,8 @@ quint16 Track::getCoverHash() const {
 }
 
 ExportTrackMetadataResult Track::exportMetadata(
-        mixxx::MetadataSourcePointer pMetadataSource) {
+        mixxx::MetadataSourcePointer pMetadataSource,
+        UserSettingsPointer pConfig) {
     VERIFY_OR_DEBUG_ASSERT(pMetadataSource) {
         kLogger.warning()
                 << "Cannot export track metadata:"
@@ -1362,7 +1364,7 @@ ExportTrackMetadataResult Track::exportMetadata(
     }
 
 #if defined(__EXPORT_SERATO_MARKERS__)
-    {
+    if (pConfig->getValue<bool>(kConfigKeySeratoMetadataExport)) {
         const auto streamInfo = m_record.getStreamInfoFromSource();
         VERIFY_OR_DEBUG_ASSERT(streamInfo && streamInfo->isValid()) {
             kLogger.warning()
@@ -1386,6 +1388,8 @@ ExportTrackMetadataResult Track::exportMetadata(
                 getLocation(), streamInfo->getSignalInfo());
         seratoTags->setCueInfos(cueInfos, timingOffset);
     }
+#else
+    Q_UNUSED(pConfig);
 #endif
 
     // Normalize metadata before exporting to adjust the precision of

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1368,21 +1368,24 @@ ExportTrackMetadataResult Track::exportMetadata(
         const auto streamInfo = m_record.getStreamInfoFromSource();
         VERIFY_OR_DEBUG_ASSERT(streamInfo && streamInfo->isValid()) {
             kLogger.warning()
-                    << "Cannot write Serato Markers tag because stream info is not available:"
+                    << "Cannot write Serato metadata because stream info is not available:"
                     << getLocation();
+            return ExportTrackMetadataResult::Skipped;
         }
 
         const mixxx::audio::SampleRate sampleRate =
                 streamInfo->getSignalInfo().getSampleRate();
 
+        mixxx::SeratoTags* seratoTags = m_record.refMetadata().refTrackInfo().ptrSeratoTags();
+        DEBUG_ASSERT(seratoTags);
+
+        seratoTags->setTrackColor(getColor());
+        seratoTags->setBpmLocked(isBpmLocked());
+
         QList<mixxx::CueInfo> cueInfos;
         for (const CuePointer& pCue : qAsConst(m_cuePoints)) {
             cueInfos.append(pCue->getCueInfo(sampleRate));
         }
-
-        mixxx::SeratoTags* seratoTags = m_record.refMetadata().refTrackInfo().ptrSeratoTags();
-        seratoTags->setTrackColor(getColor());
-        seratoTags->setBpmLocked(isBpmLocked());
 
         double timingOffset = mixxx::SeratoTags::guessTimingOffsetMillis(
                 getLocation(), streamInfo->getSignalInfo());

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1365,10 +1365,12 @@ ExportTrackMetadataResult Track::exportMetadata(
 
     if (pConfig->getValue<bool>(kConfigKeySeratoMetadataExport)) {
         const auto streamInfo = m_record.getStreamInfoFromSource();
-        VERIFY_OR_DEBUG_ASSERT(streamInfo && streamInfo->isValid()) {
-            kLogger.warning()
-                    << "Cannot write Serato metadata because stream info is not available:"
-                    << getLocation();
+        VERIFY_OR_DEBUG_ASSERT(streamInfo &&
+                streamInfo->getSignalInfo().isValid() &&
+                streamInfo->getDuration() > mixxx::Duration::empty()) {
+            kLogger.warning() << "Cannot write Serato metadata because signal "
+                                 "info and/or duration is not available:"
+                              << getLocation();
             return ExportTrackMetadataResult::Skipped;
         }
 
@@ -1395,7 +1397,10 @@ ExportTrackMetadataResult Track::exportMetadata(
                     getLocation(), streamInfo->getSignalInfo());
             seratoTags->setCueInfos(cueInfos, timingOffset);
 
-            seratoTags->setBeats(m_pBeats, *streamInfo, timingOffset);
+            seratoTags->setBeats(m_pBeats,
+                    streamInfo->getSignalInfo(),
+                    streamInfo->getDuration(),
+                    timingOffset);
         }
     }
 

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1363,7 +1363,6 @@ ExportTrackMetadataResult Track::exportMetadata(
         return ExportTrackMetadataResult::Skipped;
     }
 
-#if defined(__EXPORT_SERATO_MARKERS__)
     if (pConfig->getValue<bool>(kConfigKeySeratoMetadataExport)) {
         const auto streamInfo = m_record.getStreamInfoFromSource();
         VERIFY_OR_DEBUG_ASSERT(streamInfo && streamInfo->isValid()) {
@@ -1397,9 +1396,6 @@ ExportTrackMetadataResult Track::exportMetadata(
             seratoTags->setCueInfos(cueInfos, timingOffset);
         }
     }
-#else
-    Q_UNUSED(pConfig);
-#endif
 
     // Normalize metadata before exporting to adjust the precision of
     // floating values, ... Otherwise the following comparisons may

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -433,7 +433,8 @@ class Track : public QObject {
     double getDuration(DurationRounding rounding) const;
 
     ExportTrackMetadataResult exportMetadata(
-            mixxx::MetadataSourcePointer pMetadataSource);
+            mixxx::MetadataSourcePointer pMetadataSource,
+            UserSettingsPointer pConfig);
 
     // Information about the actual properties of the
     // audio stream is only available after opening the


### PR DESCRIPTION
This adds basic support for exporting hotcues, BPM, beatgrid lock state and track color to Serato tags. Exporting the beatgrid is not supported at the moment, as I'm waiting for @hacksdump to finish #2961 first.

Props to @uklotzde for pointing me at the right location to retrieve the `StreamInfo`.

**Testing instructions:**

~~Build with this patch applied:~~ (not necessary anymore) 
```diff
$ git apply <<EOF
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 303f47ab0a..2120b8bdbe 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -922,7 +922,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
 )
 set_target_properties(mixxx-lib PROPERTIES AUTOMOC ON AUTOUIC ON)
 target_include_directories(mixxx-lib PUBLIC src "${CMAKE_CURRENT_BINARY_DIR}/src")
-target_compile_definitions(mixxx-lib PRIVATE SETTINGS_FILE="mixxx.cfg")
+target_compile_definitions(mixxx-lib PRIVATE SETTINGS_FILE="mixxx.cfg" __EXPORT_SERATO_MARKERS__)
 if(UNIX AND NOT APPLE)
   target_compile_definitions(mixxx-lib PRIVATE SETTINGS_PATH=".mixxx/")
 endif()
EOF
```
Set a few cue points, then restart Mixxx. Now you can export the metadata even when not loading the track onto a deck. Restart again, then reset all metadata, reimport it from file tags and your cue points should show up again.

**To Do:**
- [x] Rebase onto #3413 (after merging)
- [ ] ~~Add configuration options for Serato Tag export (always, don't overwrite, never).~~ On further thought this doesn't really make sense.
- [X] Get rid of the ifdef ~~(probably not in Mixxx 2.3 though)~~
- [ ] Test this with Serato