### PR TITLE
WSpinny: add makeCurrent() call in render()

### DIFF
--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -318,6 +318,8 @@ void WSpinny::render(VSyncThread* vSyncThread) {
         return;
     }
 
+    makeCurrent();
+
     if (!m_pVisualPlayPos.isNull() && vSyncThread != nullptr) {
         m_pVisualPlayPos->getPlaySlipAtNextVSync(
                 vSyncThread,


### PR DESCRIPTION
This improves performance on macOS.