### PR TITLE
Demonstrate that beatgrid implementation is broken

### DIFF
--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -141,13 +141,17 @@ bool BeatGrid::isValid() const {
 // This could be implemented in the Beats Class itself.
 // If necessary, the child class can redefine it.
 double BeatGrid::findNextBeat(double dSamples) const {
-    return findNthBeat(dSamples, +1);
+    const double position = findNthBeat(dSamples, +1);
+    DEBUG_ASSERT(position >= dSamples || position == -1);
+    return position;
 }
 
 // This could be implemented in the Beats Class itself.
 // If necessary, the child class can redefine it.
 double BeatGrid::findPrevBeat(double dSamples) const {
-    return findNthBeat(dSamples, -1);
+    const double position = findNthBeat(dSamples, -1);
+    DEBUG_ASSERT(position <= dSamples || position == -1);
+    return position;
 }
 
 // This is an internal call. This could be implemented in the Beats Class itself.


### PR DESCRIPTION
Documentation from the `Beats` class header file:

```
    // Starting from sample dSamples, return the sample of the next beat in the
    // track, or -1 if none exists. If dSamples refers to the location of a
    // beat, dSamples is returned.
    virtual double findNextBeat(double dSamples) const = 0;

    // Starting from sample dSamples, return the sample of the previous beat in
    // the track, or -1 if none exists. If dSamples refers to the location of
    // beat, dSamples is returned.
    virtual double findPrevBeat(double dSamples) const = 0;
```

If the code actually behaves as described here, these `DEBUG_ASSERT` statements should not be a problem. But they make tests fail on my machine.