### PR TITLE
Serato Tags: Implement Mixxx Beats to Serato Beatgrid conversion

### DIFF
--- a/src/track/serato/beatgrid.cpp
+++ b/src/track/serato/beatgrid.cpp
@@ -417,6 +417,109 @@ QByteArray SeratoBeatGrid::dumpBase64Encoded() const {
     return base64EncodedData;
 }
 
+void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
+        const audio::StreamInfo& streamInfo,
+        double timingOffsetMillis) {
+    VERIFY_OR_DEBUG_ASSERT(pBeats) {
+        return;
+    }
+
+    const double timingOffsetSecs = timingOffsetMillis / 1000;
+
+    // Find at least the track duration in samples. This value might be longer
+    // than the actual track, to make sure we get all beats.
+    const SINT trackDurationSamples = streamInfo.getSignalInfo().frames2samples(
+            static_cast<SINT>(streamInfo.getSignalInfo().secs2frames(
+                    std::ceil(streamInfo.getDuration().toDoubleSeconds()))));
+    auto pBeatsIterator = pBeats->findBeats(0, trackDurationSamples);
+
+    // This might be null if the track doesn't contain any beats
+    if (!pBeatsIterator) {
+        setTerminalMarker(nullptr);
+        setNonTerminalMarkers({});
+        return;
+    }
+
+    SINT currentBeatPositionSamples = 0;
+    SINT previousBeatPositionSamples = 0;
+    double previousDeltaSamples = -1;
+    int beatsSinceLastMarker = 0;
+    QList<SeratoBeatGridNonTerminalMarkerPointer> nonTerminalMarkers;
+    while (pBeatsIterator->hasNext()) {
+        previousBeatPositionSamples = currentBeatPositionSamples;
+        currentBeatPositionSamples = static_cast<SINT>(pBeatsIterator->next());
+
+        // Calculate the delta between the current beat and the previous beat.
+        // If the distance is the same as the distance between the previous
+        // beat and the beat before that, we can just increment
+        // `beatsSinceLastMarker`. If not, we need to add a new marker.
+        const double currentDeltaSamples = currentBeatPositionSamples - previousBeatPositionSamples;
+        if (currentDeltaSamples != previousDeltaSamples) {
+            // We are adding a new beat marker, therefore we need to update the
+            // `beatsSinceLastMarker` variable of the last marker we added.
+            if (!nonTerminalMarkers.isEmpty()) {
+                DEBUG_ASSERT(beatsSinceLastMarker > 0);
+                const auto pNonTerminalMarker =
+                        nonTerminalMarkers.at(nonTerminalMarkers.size() - 1);
+                DEBUG_ASSERT(pNonTerminalMarker);
+                pNonTerminalMarker->setBeatsTillNextMarker(beatsSinceLastMarker);
+
+                // After adding the first marker, the the sample delta won't
+                // match, because it compares the distance between beats 1 and
+                // two with the distance between the start of the track and the
+                // first beat. This special case makes sure that we don't add
+                // an unnecessary additional marker that has
+                // beatsSinceLastMarker set to 1.
+                if (nonTerminalMarkers.size() == 1 && beatsSinceLastMarker == 1) {
+                    previousDeltaSamples = currentDeltaSamples;
+                    beatsSinceLastMarker++;
+                    continue;
+                }
+            }
+            // Don't create a SeratoBeatGridNonTerminalMarker entry for the
+            // last beat, this needs to be a terminal marker entry.
+            if (pBeatsIterator->hasNext()) {
+                const double positionSecs = streamInfo.getSignalInfo().frames2secs(
+                                                    streamInfo.getSignalInfo().samples2frames(
+                                                            currentBeatPositionSamples)) -
+                        timingOffsetSecs;
+                nonTerminalMarkers.append(
+                        std::make_shared<SeratoBeatGridNonTerminalMarker>(positionSecs, 0));
+            }
+            beatsSinceLastMarker = 0;
+        }
+        beatsSinceLastMarker++;
+        previousDeltaSamples = currentDeltaSamples;
+    }
+
+    // The track has no beats. This isn't possible because the `pBeatsIterator`
+    // check above should have caught this case already.
+    VERIFY_OR_DEBUG_ASSERT(currentBeatPositionSamples != -1) {
+        return;
+    }
+
+    // Update the `beatsSinceLastMarker` of the last non-terminal marker we inserted.
+    DEBUG_ASSERT(!nonTerminalMarkers.isEmpty());
+    DEBUG_ASSERT(beatsSinceLastMarker > 0);
+    const auto pNonTerminalMarker = nonTerminalMarkers.at(nonTerminalMarkers.size() - 1);
+    DEBUG_ASSERT(pNonTerminalMarker);
+    // We need to subtract 1 from `beatsSinceLastMarker`, because at the end of
+    // the last iteration the counter is incremented even though we didn't move
+    // a beat forwards.
+    pNonTerminalMarker->setBeatsTillNextMarker(beatsSinceLastMarker - 1);
+
+    // Finally, create the terminal marker.
+    const double positionSecs =
+            streamInfo.getSignalInfo().frames2secs(
+                    streamInfo.getSignalInfo().samples2frames(
+                            currentBeatPositionSamples)) -
+            timingOffsetSecs;
+    const double bpm = pBeats->getBpmAroundPosition(currentBeatPositionSamples, 1);
+
+    setTerminalMarker(std::make_shared<SeratoBeatGridTerminalMarker>(positionSecs, bpm));
+    setNonTerminalMarkers(nonTerminalMarkers);
+}
+
 QDebug operator<<(QDebug dbg, const SeratoBeatGridTerminalMarker& arg) {
     return dbg << "SeratoBeatGridTerminalMarker"
                << "PositionSecs =" << arg.positionSecs()

--- a/src/track/serato/beatgrid.h
+++ b/src/track/serato/beatgrid.h
@@ -6,6 +6,8 @@
 #include <QList>
 #include <memory>
 
+#include "audio/streaminfo.h"
+#include "track/beats.h"
 #include "track/cueinfo.h"
 #include "track/taglib/trackmetadata_file.h"
 #include "util/assert.h"
@@ -35,6 +37,10 @@ class SeratoBeatGridNonTerminalMarker final {
 
     quint32 beatsTillNextMarker() const {
         return m_beatsTillNextMarker;
+    }
+
+    void setBeatsTillNextMarker(quint32 beatsTillNextMarker) {
+        m_beatsTillNextMarker = beatsTillNextMarker;
     }
 
   private:
@@ -121,6 +127,10 @@ class SeratoBeatGrid final {
     void setTerminalMarker(SeratoBeatGridTerminalMarkerPointer pTerminalMarker) {
         m_pTerminalMarker = pTerminalMarker;
     }
+
+    void setBeats(BeatsPointer pBeats,
+            const audio::StreamInfo& streamInfo,
+            double timingOffsetMillis);
 
     quint8 footer() const {
         return m_footer;

--- a/src/track/serato/tags.h
+++ b/src/track/serato/tags.h
@@ -60,6 +60,12 @@ class SeratoTags final {
     QList<CueInfo> getCueInfos() const;
     void setCueInfos(const QList<CueInfo>& cueInfos, double timingOffset = 0);
 
+    void setBeats(BeatsPointer pBeats,
+            const audio::StreamInfo& streamInfo,
+            double timingOffset) {
+        m_seratoBeatGrid.setBeats(pBeats, streamInfo, timingOffset);
+    }
+
     RgbColor::optional_t getTrackColor() const;
     void setTrackColor(RgbColor::optional_t color);
 


### PR DESCRIPTION
This converts the mixxx beats to the Serato metadata format.

~~I'm not happy with all these integer operations, I need to check if that causes any precision loss. Unfortunately, `SignalInfo` doesn't provide support for `double` conversion yet.~~ Apparently it suffices for our purposes. 

If we merge this and #3409 and also apply the patch below, we can export track color, bpmlock state, hotcues, loops and beatgrid from Mixxx to Serato.
```udiff
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 303f47ab0a..2120b8bdbe 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -922,7 +922,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
 )
 set_target_properties(mixxx-lib PROPERTIES AUTOMOC ON AUTOUIC ON)
 target_include_directories(mixxx-lib PUBLIC src "${CMAKE_CURRENT_BINARY_DIR}/src")
-target_compile_definitions(mixxx-lib PRIVATE SETTINGS_FILE="mixxx.cfg")
+target_compile_definitions(mixxx-lib PRIVATE SETTINGS_FILE="mixxx.cfg" __EXPORT_SERATO_MARKERS__)
 if(UNIX AND NOT APPLE)
   target_compile_definitions(mixxx-lib PRIVATE SETTINGS_PATH=".mixxx/")
 endif()
diff --git a/src/track/track.cpp b/src/track/track.cpp
index 99d41c066f..432f51726b 100644
--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1368,6 +1368,8 @@ ExportTrackMetadataResult Track::exportMetadata(
             const double timingOffset = mixxx::SeratoTags::guessTimingOffsetMillis(
                     getLocation(), m_streamInfoFromSource->getSignalInfo());
             seratoTags->setCueInfos(cueInfos, timingOffset);
+
+            seratoTags->setBeats(m_pBeats, *m_streamInfoFromSource, timingOffset);
         }
     }
 #else
```