### PR TITLE
Serato BeatsGrid: Fix wrong beat at position 0 on import

### DIFF
--- a/src/track/serato/beatsimporter.cpp
+++ b/src/track/serato/beatsimporter.cpp
@@ -57,7 +57,7 @@ QVector<double> SeratoBeatsImporter::importBeatsAndApplyTimingOffset(
         beatLengthMillis = (nextBeatPositionMillis - beatPositionMillis) /
                 pMarker->beatsTillNextMarker();
 
-        beats.resize(beats.size() + pMarker->beatsTillNextMarker());
+        beats.reserve(beats.size() + pMarker->beatsTillNextMarker());
         for (quint32 j = 0; j < pMarker->beatsTillNextMarker(); ++j) {
             beats.append(streamInfo.getSignalInfo().millis2frames(
                     beatPositionMillis + (j * beatLengthMillis)));


### PR DESCRIPTION
The wrong usage of `QVector<T>::resize(int)` instead of
`QVector<T>::reserve(int)` always created a bunch of beats at sample
position 0, even if there is no actual beat at that position. This could
lead to audible sudden tempo changes when sync is used.