### PR TITLE
revert using CPU rendered waveform by default on macOS

### DIFF
--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -734,9 +734,6 @@ void WaveformWidgetFactory::swap() {
 }
 
 WaveformWidgetType::Type WaveformWidgetFactory::autoChooseWidgetType() const {
-    // OpenGL waveform performance is bad on macOS with QGLWidget and Qt 5.
-    // TODO: remove this #ifndef when upgrading to QOpenGLWidget
-#ifndef __APPLE__
     if (m_openGlAvailable) {
         if (m_openGLShaderAvailable) {
             return WaveformWidgetType::GLSLRGBWaveform;
@@ -744,7 +741,6 @@ WaveformWidgetType::Type WaveformWidgetFactory::autoChooseWidgetType() const {
             return WaveformWidgetType::GLRGBWaveform;
         }
     }
-#endif
     return WaveformWidgetType::RGBWaveform;
 }
 


### PR DESCRIPTION
OpenGL works okay when Mixxx is built with the macOS 10.13 SDK