### PR TITLE
Overview waveform: fix default Passthrough cover color

### DIFF
--- a/src/waveform/renderers/waveformsignalcolors.cpp
+++ b/src/waveform/renderers/waveformsignalcolors.cpp
@@ -72,7 +72,7 @@ bool WaveformSignalColors::setup(const QDomNode &node, const SkinContext& contex
     m_passthroughOverlayColor = context.selectColor(node, "PassthroughOverlayColor");
     m_passthroughOverlayColor = WSkinColor::getCorrectColor(m_passthroughOverlayColor).toRgb();
     if (!m_passthroughOverlayColor.isValid()) {
-        m_passthroughOverlayColor = WSkinColor::getCorrectColor(QColor(187, 0, 0, 0)).toRgb();
+        m_passthroughOverlayColor = WSkinColor::getCorrectColor(QColor(0, 0, 0, 187)).toRgb();
     }
 
     m_bgColor = context.selectColor(node, "BgColor");


### PR DESCRIPTION
I don't understand why that's not working any more because it was obviously working in #2616.
RGBA arguments were in the wrong order.