### PR TITLE
Detect and prevent duplicate signals on network errors

### DIFF
--- a/src/musicbrainz/web/musicbrainzrecordingstask.cpp
+++ b/src/musicbrainz/web/musicbrainzrecordingstask.cpp
@@ -118,18 +118,11 @@ bool MusicBrainzRecordingsTask::doStart(
         return false;
     }
 
+    // It is not necessary to connect the QNetworkReply::errorOccurred
+    // signal (since Qt 5.15). Network errors are also received trough
+    // the QNetworkReply::finished signal.
     connect(m_pendingNetworkReply,
             &QNetworkReply::finished,
-            this,
-            &MusicBrainzRecordingsTask::slotNetworkReplyFinished,
-            Qt::UniqueConnection);
-
-    connect(m_pendingNetworkReply,
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
-            &QNetworkReply::errorOccurred,
-#else
-            QOverload<QNetworkReply::NetworkError>::of(&QNetworkReply::error),
-#endif
             this,
             &MusicBrainzRecordingsTask::slotNetworkReplyFinished,
             Qt::UniqueConnection);

--- a/src/musicbrainz/web/musicbrainzrecordingstask.cpp
+++ b/src/musicbrainz/web/musicbrainzrecordingstask.cpp
@@ -118,9 +118,8 @@ bool MusicBrainzRecordingsTask::doStart(
         return false;
     }
 
-    // It is not necessary to connect the QNetworkReply::errorOccurred
-    // signal (since Qt 5.15). Network errors are also received trough
-    // the QNetworkReply::finished signal.
+    // It is not necessary to connect the QNetworkReply::errorOccurred signal.
+    // Network errors are also received trough the QNetworkReply::finished signal.
     connect(m_pendingNetworkReply,
             &QNetworkReply::finished,
             this,

--- a/src/musicbrainz/web/musicbrainzrecordingstask.cpp
+++ b/src/musicbrainz/web/musicbrainzrecordingstask.cpp
@@ -119,7 +119,7 @@ bool MusicBrainzRecordingsTask::doStart(
     }
 
     // It is not necessary to connect the QNetworkReply::errorOccurred signal.
-    // Network errors are also received trough the QNetworkReply::finished signal.
+    // Network errors are also received through the QNetworkReply::finished signal.
     connect(m_pendingNetworkReply,
             &QNetworkReply::finished,
             this,

--- a/src/network/jsonwebtask.cpp
+++ b/src/network/jsonwebtask.cpp
@@ -277,9 +277,8 @@ bool JsonWebTask::doStart(
         return false;
     }
 
-    // It is not necessary to connect the QNetworkReply::errorOccurred
-    // signal (since Qt 5.15). Network errors are also received trough
-    // the QNetworkReply::finished signal.
+    // It is not necessary to connect the QNetworkReply::errorOccurred signal.
+    // Network errors are also received trough the QNetworkReply::finished signal.
     connect(m_pendingNetworkReply,
             &QNetworkReply::finished,
             this,

--- a/src/network/jsonwebtask.cpp
+++ b/src/network/jsonwebtask.cpp
@@ -143,6 +143,7 @@ JsonWebTask::~JsonWebTask() {
 void JsonWebTask::onFinished(
         JsonWebResponse&& response) {
     kLogger.info()
+            << this
             << "Response received"
             << response.replyUrl
             << response.statusCode
@@ -153,6 +154,7 @@ void JsonWebTask::onFinished(
 void JsonWebTask::onFinishedCustom(
         CustomWebResponse&& response) {
     kLogger.info()
+            << this
             << "Custom response received"
             << response.replyUrl
             << response.statusCode
@@ -170,6 +172,7 @@ QNetworkReply* JsonWebTask::sendNetworkRequest(
         DEBUG_ASSERT(m_request.content.isEmpty());
         if (kLogger.debugEnabled()) {
             kLogger.debug()
+                    << this
                     << "GET"
                     << url;
         }
@@ -180,6 +183,7 @@ QNetworkReply* JsonWebTask::sendNetworkRequest(
         const auto body = content.toJson(QJsonDocument::Compact);
         if (kLogger.debugEnabled()) {
             kLogger.debug()
+                    << this
                     << "PUT"
                     << url
                     << body;
@@ -192,6 +196,7 @@ QNetworkReply* JsonWebTask::sendNetworkRequest(
         const auto body = content.toJson(QJsonDocument::Compact);
         if (kLogger.debugEnabled()) {
             kLogger.debug()
+                    << this
                     << "POST"
                     << url
                     << body;
@@ -204,6 +209,7 @@ QNetworkReply* JsonWebTask::sendNetworkRequest(
         const auto body = m_request.content.toJson(QJsonDocument::Compact);
         if (kLogger.debugEnabled()) {
             kLogger.debug()
+                    << this
                     << "PATCH"
                     << url
                     << body;
@@ -226,6 +232,7 @@ QNetworkReply* JsonWebTask::sendNetworkRequest(
         DEBUG_ASSERT(content.isEmpty());
         if (kLogger.debugEnabled()) {
             kLogger.debug()
+                    << this
                     << "DELETE"
                     << url;
         }
@@ -245,6 +252,7 @@ bool JsonWebTask::doStart(
     DEBUG_ASSERT(networkAccessManager);
     VERIFY_OR_DEBUG_ASSERT(!m_pendingNetworkReply) {
         kLogger.warning()
+                << this
                 << "Task has already been started";
         return false;
     }
@@ -264,6 +272,7 @@ bool JsonWebTask::doStart(
             m_request.content);
     VERIFY_OR_DEBUG_ASSERT(m_pendingNetworkReply) {
         kLogger.warning()
+                << this
                 << "Request not sent";
         return false;
     }
@@ -344,6 +353,7 @@ void JsonWebTask::emitFailed(
     VERIFY_OR_DEBUG_ASSERT(
             isSignalFuncConnected(&JsonWebTask::failed)) {
         kLogger.warning()
+                << this
                 << "Unhandled failed signal"
                 << response;
         deleteLater();

--- a/src/network/jsonwebtask.cpp
+++ b/src/network/jsonwebtask.cpp
@@ -268,18 +268,11 @@ bool JsonWebTask::doStart(
         return false;
     }
 
+    // It is not necessary to connect the QNetworkReply::errorOccurred
+    // signal (since Qt 5.15). Network errors are also received trough
+    // the QNetworkReply::finished signal.
     connect(m_pendingNetworkReply,
             &QNetworkReply::finished,
-            this,
-            &JsonWebTask::slotNetworkReplyFinished,
-            Qt::UniqueConnection);
-
-    connect(m_pendingNetworkReply,
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
-            &QNetworkReply::errorOccurred,
-#else
-            QOverload<QNetworkReply::NetworkError>::of(&QNetworkReply::error),
-#endif
             this,
             &JsonWebTask::slotNetworkReplyFinished,
             Qt::UniqueConnection);

--- a/src/network/jsonwebtask.cpp
+++ b/src/network/jsonwebtask.cpp
@@ -278,7 +278,7 @@ bool JsonWebTask::doStart(
     }
 
     // It is not necessary to connect the QNetworkReply::errorOccurred signal.
-    // Network errors are also received trough the QNetworkReply::finished signal.
+    // Network errors are also received through the QNetworkReply::finished signal.
     connect(m_pendingNetworkReply,
             &QNetworkReply::finished,
             this,

--- a/src/network/webtask.cpp
+++ b/src/network/webtask.cpp
@@ -92,7 +92,10 @@ WebTask::~WebTask() {
 
 void WebTask::onAborted(
         QUrl&& requestUrl) {
-    DEBUG_ASSERT(m_status == Status::Aborted);
+    VERIFY_OR_DEBUG_ASSERT(m_status == Status::Aborting) {
+        return;
+    }
+    m_status = Status::Aborted;
     VERIFY_OR_DEBUG_ASSERT(
             isSignalFuncConnected(&WebTask::aborted)) {
         kLogger.warning()
@@ -107,7 +110,13 @@ void WebTask::onAborted(
 
 void WebTask::onTimedOut(
         QUrl&& requestUrl) {
-    DEBUG_ASSERT(m_status == Status::TimedOut);
+    VERIFY_OR_DEBUG_ASSERT(m_status == Status::Pending) {
+        return;
+    }
+    if (m_timeoutTimerId != kInvalidTimerId) {
+        killTimer(m_timeoutTimerId);
+        m_timeoutTimerId = kInvalidTimerId;
+    }
     onNetworkError(
             std::move(requestUrl),
             QNetworkReply::TimeoutError,
@@ -120,10 +129,20 @@ void WebTask::onNetworkError(
         QNetworkReply::NetworkError errorCode,
         QString&& errorString,
         QByteArray&& errorContent) {
+    DEBUG_ASSERT(m_timeoutTimerId == kInvalidTimerId);
+    VERIFY_OR_DEBUG_ASSERT(m_status == Status::Pending) {
+        return;
+    }
+    DEBUG_ASSERT(errorCode != QNetworkReply::NoError);
+    if (errorCode == QNetworkReply::TimeoutError) {
+        m_status = Status::TimedOut;
+    } else {
+        m_status = Status::Failed;
+    }
     VERIFY_OR_DEBUG_ASSERT(
             isSignalFuncConnected(&WebTask::networkError)) {
         kLogger.warning()
-                << "Unhandled network error signal"
+                << "Unhandled network error:"
                 << requestUrl
                 << errorCode
                 << errorString
@@ -168,8 +187,13 @@ void WebTask::invokeAbort() {
 
 void WebTask::slotStart(int timeoutMillis) {
     DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
-    DEBUG_ASSERT(m_status != Status::Pending);
+    VERIFY_OR_DEBUG_ASSERT(m_status != Status::Pending) {
+        return;
+    }
+    m_status = Status::Idle;
+
     VERIFY_OR_DEBUG_ASSERT(m_networkAccessManager) {
+        m_status = Status::Pending;
         onNetworkError(
                 QUrl(),
                 QNetworkReply::NetworkSessionFailedError,
@@ -180,12 +204,12 @@ void WebTask::slotStart(int timeoutMillis) {
 
     kLogger.debug()
             << "Starting...";
-    m_status = Status::Idle;
     if (!doStart(m_networkAccessManager, timeoutMillis)) {
         // Still idle, because we are in the same thread.
         // The callee is not supposed to abort a request
         // before it has beeen started successfully.
         DEBUG_ASSERT(m_status == Status::Idle);
+        m_status = Status::Pending;
         onNetworkError(
                 QUrl(),
                 QNetworkReply::OperationCanceledError,
@@ -240,7 +264,7 @@ QUrl WebTask::abort() {
         killTimer(m_timeoutTimerId);
         m_timeoutTimerId = kInvalidTimerId;
     }
-    m_status = Status::Aborted;
+    m_status = Status::Aborting;
     kLogger.debug()
             << "Aborting...";
     QUrl url = doAbort();
@@ -256,14 +280,13 @@ void WebTask::timerEvent(QTimerEvent* event) {
     DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
     const auto timerId = event->timerId();
     DEBUG_ASSERT(timerId != kInvalidTimerId);
-    if (timerId != m_timeoutTimerId) {
-        // ignore
+    VERIFY_OR_DEBUG_ASSERT(timerId == m_timeoutTimerId) {
         return;
     }
     killTimer(m_timeoutTimerId);
     m_timeoutTimerId = kInvalidTimerId;
-    if (m_status != Status::Aborted) {
-        m_status = Status::TimedOut;
+    VERIFY_OR_DEBUG_ASSERT(m_status == Status::Pending) {
+        return;
     }
     kLogger.debug()
             << "Timed out";
@@ -280,26 +303,6 @@ QPair<QNetworkReply*, HttpStatusCode> WebTask::receiveNetworkReply() {
     }
     networkReply->deleteLater();
 
-    if (m_timeoutTimerId != kInvalidTimerId) {
-        killTimer(m_timeoutTimerId);
-        m_timeoutTimerId = kInvalidTimerId;
-    }
-
-    if (m_status == Status::Aborted) {
-        onAborted(networkReply->request().url());
-        return qMakePair(nullptr, statusCode);
-    }
-    m_status = Status::Finished;
-
-    if (networkReply->error() != QNetworkReply::NetworkError::NoError) {
-        onNetworkError(
-                networkReply->request().url(),
-                networkReply->error(),
-                networkReply->errorString(),
-                networkReply->readAll());
-        return qMakePair(nullptr, statusCode);
-    }
-
     if (kLogger.debugEnabled()) {
         if (networkReply->url() == networkReply->request().url()) {
             kLogger.debug()
@@ -314,6 +317,35 @@ QPair<QNetworkReply*, HttpStatusCode> WebTask::receiveNetworkReply() {
                     << networkReply->url();
         }
     }
+
+    if (m_status == Status::Aborted ||
+            m_status == Status::TimedOut) {
+        // Already aborted or timed out by the client
+        DEBUG_ASSERT(m_timeoutTimerId == kInvalidTimerId);
+        kLogger.debug()
+                << this
+                << "Ignoring obsolete network reply";
+        return qMakePair(nullptr, statusCode);
+    }
+    VERIFY_OR_DEBUG_ASSERT(m_status == Status::Pending) {
+        DEBUG_ASSERT(m_timeoutTimerId == kInvalidTimerId);
+        return qMakePair(nullptr, statusCode);
+    }
+
+    if (m_timeoutTimerId != kInvalidTimerId) {
+        killTimer(m_timeoutTimerId);
+        m_timeoutTimerId = kInvalidTimerId;
+    }
+
+    if (networkReply->error() != QNetworkReply::NetworkError::NoError) {
+        onNetworkError(
+                networkReply->request().url(),
+                networkReply->error(),
+                networkReply->errorString(),
+                networkReply->readAll());
+        return qMakePair(nullptr, statusCode);
+    }
+    m_status = Status::Finished;
 
     DEBUG_ASSERT(statusCode == kHttpStatusCodeInvalid);
     VERIFY_OR_DEBUG_ASSERT(readStatusCode(networkReply, &statusCode)) {

--- a/src/network/webtask.cpp
+++ b/src/network/webtask.cpp
@@ -99,6 +99,7 @@ void WebTask::onAborted(
     VERIFY_OR_DEBUG_ASSERT(
             isSignalFuncConnected(&WebTask::aborted)) {
         kLogger.warning()
+                << this
                 << "Unhandled abort signal"
                 << requestUrl;
         deleteLater();
@@ -142,6 +143,7 @@ void WebTask::onNetworkError(
     VERIFY_OR_DEBUG_ASSERT(
             isSignalFuncConnected(&WebTask::networkError)) {
         kLogger.warning()
+                << this
                 << "Unhandled network error:"
                 << requestUrl
                 << errorCode
@@ -203,6 +205,7 @@ void WebTask::slotStart(int timeoutMillis) {
     }
 
     kLogger.debug()
+            << this
             << "Starting...";
     if (!doStart(m_networkAccessManager, timeoutMillis)) {
         // Still idle, because we are in the same thread.
@@ -266,6 +269,7 @@ QUrl WebTask::abort() {
     }
     m_status = Status::Aborting;
     kLogger.debug()
+            << this
             << "Aborting...";
     QUrl url = doAbort();
     onAborted(QUrl(url));
@@ -288,7 +292,8 @@ void WebTask::timerEvent(QTimerEvent* event) {
     VERIFY_OR_DEBUG_ASSERT(m_status == Status::Pending) {
         return;
     }
-    kLogger.debug()
+    kLogger.info()
+            << this
             << "Timed out";
     onTimedOut(doTimeOut());
 }
@@ -306,11 +311,13 @@ QPair<QNetworkReply*, HttpStatusCode> WebTask::receiveNetworkReply() {
     if (kLogger.debugEnabled()) {
         if (networkReply->url() == networkReply->request().url()) {
             kLogger.debug()
+                    << this
                     << "Received reply for request"
                     << networkReply->url();
         } else {
             // Redirected
             kLogger.debug()
+                    << this
                     << "Received reply for redirected request"
                     << networkReply->request().url()
                     << "->"
@@ -350,6 +357,7 @@ QPair<QNetworkReply*, HttpStatusCode> WebTask::receiveNetworkReply() {
     DEBUG_ASSERT(statusCode == kHttpStatusCodeInvalid);
     VERIFY_OR_DEBUG_ASSERT(readStatusCode(networkReply, &statusCode)) {
         kLogger.warning()
+                << this
                 << "Failed to read HTTP status code";
     }
 

--- a/src/network/webtask.h
+++ b/src/network/webtask.h
@@ -148,8 +148,10 @@ class WebTask : public QObject {
     enum class Status {
         Idle,
         Pending,
+        Aborting,
         Aborted,
         TimedOut,
+        Failed,
         Finished,
     };
 


### PR DESCRIPTION
- The implementations of `JsonWebTask` and `MusicBrainzRecordingsTask` produced duplicate signals in case of network errors.
- The additional states in `WebTask` now allow to detect any unexpected behavior in the future.

This bug became obvious while keeping the currently non-working aoide integration enabled during development. It generates lots of these failed network requests and helped debugging and fixing those issues ;)