### PR TITLE
Allow to disable -pipe build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,9 +57,12 @@ endif()
 
 set(CMAKE_CXX_STANDARD 17)
 
-# Speed up builds on HDDs
+# Speed up builds on HDDs and prevent wearing of SDDs
 if(GNU_GCC OR LLVM_CLANG)
-  add_compile_options(-pipe)
+  option(BUILD_LOW_MEMORY "Store temporary build files on disk on low-memory systems" OFF)
+  if(NOT BUILD_LOW_MEMORY)
+    add_compile_options(-pipe)
+  endif()
 endif()
 
 # Profiling

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ set(CMAKE_CXX_STANDARD 17)
 
 # Speed up builds on HDDs and prevent wearing of SDDs
 if(GNU_GCC OR LLVM_CLANG)
-  option(BUILD_LOW_MEMORY "Store temporary build files on disk on low-memory systems" OFF)
+  option(BUILD_LOW_MEMORY "Store temporary build files on disk by disabling the build option -pipe" OFF)
   if(NOT BUILD_LOW_MEMORY)
     add_compile_options(-pipe)
   endif()


### PR DESCRIPTION
My recent ppc64le builds got killed: https://koji.rpmfusion.org/koji/getfile?taskID=451242&volume=DEFAULT&name=build.log&offset=-4000

Just in case someone needs it. It never happened before.