### PR TITLE
Fix inconsistent naming of hot cue "index" vs. "number"

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -48,9 +48,9 @@ inline mixxx::RgbColor::optional_t doubleToRgbColor(double value) {
 /// Works independent of if the hot cue index is either 0-based
 /// or 1..n-based.
 inline int hotcueIndexToHotcueNumber(int hotcueIndex) {
-    if (hotcueIndex >= Cue::kFirstHotCue) {
+    if (hotcueIndex >= mixxx::kFirstHotCueIndex) {
         DEBUG_ASSERT(hotcueIndex != Cue::kNoHotCue);
-        return (hotcueIndex - Cue::kFirstHotCue) + 1; // to 1-based numbering
+        return (hotcueIndex - mixxx::kFirstHotCueIndex) + 1; // to 1-based numbering
     } else {
         DEBUG_ASSERT(hotcueIndex == Cue::kNoHotCue);
         return kNoHotCueNumber;
@@ -64,7 +64,7 @@ inline int hotcueIndexToHotcueNumber(int hotcueIndex) {
 inline int hotcueNumberToHotcueIndex(int hotcueNumber) {
     if (hotcueNumber >= 1) {
         DEBUG_ASSERT(hotcueNumber != kNoHotCueNumber);
-        return Cue::kFirstHotCue + (hotcueNumber - 1); // from 1-based numbering
+        return mixxx::kFirstHotCueIndex + (hotcueNumber - 1); // from 1-based numbering
     } else {
         DEBUG_ASSERT(hotcueNumber == kNoHotCueNumber);
         return Cue::kNoHotCue;

--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -98,7 +98,7 @@ Cue::Cue(
                   positionMillisToSamples(
                           cueInfo.getEndPositionMillis(),
                           sampleRate)),
-          m_iHotCue(cueInfo.getHotCueNumber() ? *cueInfo.getHotCueNumber() : kNoHotCue),
+          m_iHotCue(cueInfo.getHotCueIndex() ? *cueInfo.getHotCueIndex() : kNoHotCue),
           m_label(cueInfo.getLabel()),
           m_color(cueInfo.getColor().value_or(mixxx::PredefinedColorPalettes::kDefaultCueColor)) {
     DEBUG_ASSERT(!m_dbId.isValid());

--- a/src/track/cue.h
+++ b/src/track/cue.h
@@ -4,6 +4,7 @@
 #include <QMutex>
 #include <QObject>
 #include <memory>
+#include <type_traits> // static_assert
 
 #include "audio/types.h"
 #include "track/cueinfo.h"
@@ -23,8 +24,8 @@ class Cue : public QObject {
     /// Invalid hot cue index
     static constexpr int kNoHotCue = -1;
 
-    /// Hot cues are sequentially indexed starting with kFirstHotCue (inclusive)
-    static constexpr int kFirstHotCue = 0;
+    static_assert(kNoHotCue != mixxx::kFirstHotCueIndex,
+            "Conflicting definitions of invalid and first hot cue index");
 
     Cue();
     Cue(

--- a/src/track/cueinfo.cpp
+++ b/src/track/cueinfo.cpp
@@ -8,7 +8,7 @@ CueInfo::CueInfo()
         : m_type(CueType::Invalid),
           m_startPositionMillis(std::nullopt),
           m_endPositionMillis(std::nullopt),
-          m_hotCueNumber(std::nullopt),
+          m_hotCueIndex(std::nullopt),
           m_color(std::nullopt) {
 }
 
@@ -16,13 +16,13 @@ CueInfo::CueInfo(
         CueType type,
         std::optional<double> startPositionMillis,
         std::optional<double> endPositionMillis,
-        std::optional<int> hotCueNumber,
+        std::optional<int> hotCueIndex,
         const QString& label,
         mixxx::RgbColor::optional_t color)
         : m_type(type),
           m_startPositionMillis(startPositionMillis),
           m_endPositionMillis(endPositionMillis),
-          m_hotCueNumber(hotCueNumber),
+          m_hotCueIndex(hotCueIndex),
           m_label(label),
           m_color(color) {
 }
@@ -51,12 +51,13 @@ std::optional<double> CueInfo::getEndPositionMillis() const {
     return m_endPositionMillis;
 }
 
-std::optional<int> CueInfo::getHotCueNumber() const {
-    return m_hotCueNumber;
+std::optional<int> CueInfo::getHotCueIndex() const {
+    return m_hotCueIndex;
 }
 
-void CueInfo::setHotCueNumber(std::optional<int> hotCueNumber) {
-    m_hotCueNumber = hotCueNumber;
+void CueInfo::setHotCueIndex(const std::optional<int> hotCueIndex) {
+    DEBUG_ASSERT(!hotCueIndex || *hotCueIndex >= kFirstHotCueIndex);
+    m_hotCueIndex = hotCueIndex;
 }
 
 QString CueInfo::getLabel() const {
@@ -81,7 +82,7 @@ bool operator==(
     return lhs.getType() == rhs.getType() &&
             lhs.getStartPositionMillis() == rhs.getStartPositionMillis() &&
             lhs.getEndPositionMillis() == rhs.getEndPositionMillis() &&
-            lhs.getHotCueNumber() == rhs.getHotCueNumber() &&
+            lhs.getHotCueIndex() == rhs.getHotCueIndex() &&
             lhs.getLabel() == rhs.getLabel() &&
             lhs.getColor() == rhs.getColor();
 }
@@ -125,7 +126,7 @@ QDebug operator<<(QDebug debug, const CueInfo& cueInfo) {
             << "type=" << cueInfo.getType()
             << ", startPos=" << cueInfo.getStartPositionMillis()
             << ", endPos=" << cueInfo.getEndPositionMillis()
-            << ", number=" << cueInfo.getHotCueNumber()
+            << ", index=" << cueInfo.getHotCueIndex()
             << ", label=" << cueInfo.getLabel()
             << ", color=" << cueInfo.getColor()
             << "]";

--- a/src/track/cueinfo.h
+++ b/src/track/cueinfo.h
@@ -21,6 +21,9 @@ enum class CueType {
                       // sound; not shown to user
 };
 
+/// Hot cues are sequentially indexed starting with kFirstHotCueIndex (inclusive)
+static constexpr int kFirstHotCueIndex = 0;
+
 // DTO for Cue information without dependencies on the actual Track object
 class CueInfo {
   public:
@@ -28,7 +31,7 @@ class CueInfo {
     CueInfo(CueType type,
             std::optional<double> startPositionMillis,
             std::optional<double> endPositionMillis,
-            std::optional<int> hotCueNumber,
+            const std::optional<int> hotCueIndex,
             const QString& label,
             RgbColor::optional_t color);
 
@@ -43,9 +46,9 @@ class CueInfo {
     void setEndPositionMillis(
             std::optional<double> positionMillis = std::nullopt);
 
-    std::optional<int> getHotCueNumber() const;
-    void setHotCueNumber(
-            std::optional<int> hotCueNumber = std::nullopt);
+    std::optional<int> getHotCueIndex() const;
+    void setHotCueIndex(
+            const std::optional<int> hotCueIndex = std::nullopt);
 
     QString getLabel() const;
     void setLabel(
@@ -59,7 +62,7 @@ class CueInfo {
     CueType m_type;
     std::optional<double> m_startPositionMillis;
     std::optional<double> m_endPositionMillis;
-    std::optional<int> m_hotCueNumber;
+    std::optional<int> m_hotCueIndex;
     QString m_label;
     RgbColor::optional_t m_color;
 };

--- a/src/track/serato/markers.cpp
+++ b/src/track/serato/markers.cpp
@@ -631,12 +631,12 @@ void SeratoMarkers::setCues(const QList<CueInfo>& cueInfos) {
     for (const CueInfo& cueInfo : cueInfos) {
         // All of these check can be debug assertions, as the list should be
         // pre-filtered by the seratoTags class.
-        VERIFY_OR_DEBUG_ASSERT(cueInfo.getHotCueNumber()) {
+        VERIFY_OR_DEBUG_ASSERT(cueInfo.getHotCueIndex()) {
             continue;
         }
-        int hotcueNumber = *cueInfo.getHotCueNumber();
+        int hotcueIndex = *cueInfo.getHotCueIndex();
 
-        VERIFY_OR_DEBUG_ASSERT(hotcueNumber >= 0) {
+        VERIFY_OR_DEBUG_ASSERT(hotcueIndex >= kFirstHotCueIndex) {
             continue;
         }
         VERIFY_OR_DEBUG_ASSERT(cueInfo.getColor()) {
@@ -648,13 +648,13 @@ void SeratoMarkers::setCues(const QList<CueInfo>& cueInfos) {
 
         switch (cueInfo.getType()) {
         case CueType::HotCue:
-            cueMap.insert(hotcueNumber, cueInfo);
+            cueMap.insert(hotcueIndex, cueInfo);
             break;
         case CueType::Loop:
             VERIFY_OR_DEBUG_ASSERT(cueInfo.getEndPositionMillis()) {
                 continue;
             }
-            loopMap.insert(hotcueNumber, cueInfo);
+            loopMap.insert(hotcueIndex, cueInfo);
             break;
         default:
             DEBUG_ASSERT(!"Invalid cue type");

--- a/src/track/serato/markers2.cpp
+++ b/src/track/serato/markers2.cpp
@@ -656,12 +656,12 @@ void SeratoMarkers2::setCues(const QList<CueInfo>& cueInfos) {
     for (const CueInfo& cueInfo : qAsConst(cueInfos)) {
         // All of these check can be debug assertions, as the list should be
         // pre-filtered by the seratoTags class.
-        VERIFY_OR_DEBUG_ASSERT(cueInfo.getHotCueNumber()) {
+        VERIFY_OR_DEBUG_ASSERT(cueInfo.getHotCueIndex()) {
             continue;
         }
-        int hotcueNumber = *cueInfo.getHotCueNumber();
+        int hotcueIndex = *cueInfo.getHotCueIndex();
 
-        VERIFY_OR_DEBUG_ASSERT(hotcueNumber >= 0) {
+        VERIFY_OR_DEBUG_ASSERT(hotcueIndex >= kFirstHotCueIndex) {
             continue;
         }
         VERIFY_OR_DEBUG_ASSERT(cueInfo.getColor()) {
@@ -673,13 +673,13 @@ void SeratoMarkers2::setCues(const QList<CueInfo>& cueInfos) {
 
         switch (cueInfo.getType()) {
         case CueType::HotCue:
-            cueMap.insert(hotcueNumber, cueInfo);
+            cueMap.insert(hotcueIndex, cueInfo);
             break;
         case CueType::Loop:
             VERIFY_OR_DEBUG_ASSERT(cueInfo.getEndPositionMillis()) {
                 continue;
             }
-            loopMap.insert(hotcueNumber, cueInfo);
+            loopMap.insert(hotcueIndex, cueInfo);
             break;
         default:
             DEBUG_ASSERT(!"Invalid cue type");
@@ -700,7 +700,7 @@ void SeratoMarkers2::setCues(const QList<CueInfo>& cueInfos) {
     for (auto it = cueMap.constBegin(); it != cueMap.constEnd(); ++it) {
         const CueInfo& cueInfo = it.value();
         auto pEntry = std::make_shared<SeratoMarkers2CueEntry>(
-                *cueInfo.getHotCueNumber(),
+                *cueInfo.getHotCueIndex(),
                 *cueInfo.getStartPositionMillis(),
                 *cueInfo.getColor(),
                 cueInfo.getLabel());
@@ -711,7 +711,7 @@ void SeratoMarkers2::setCues(const QList<CueInfo>& cueInfos) {
     for (auto it = loopMap.constBegin(); it != loopMap.constEnd(); ++it) {
         const CueInfo& cueInfo = it.value();
         auto pEntry = std::make_shared<SeratoMarkers2LoopEntry>(
-                *cueInfo.getHotCueNumber(),
+                *cueInfo.getHotCueIndex(),
                 *cueInfo.getStartPositionMillis(),
                 *cueInfo.getEndPositionMillis(),
                 *cueInfo.getColor(),

--- a/src/track/serato/tags.cpp
+++ b/src/track/serato/tags.cpp
@@ -35,7 +35,7 @@ QString getPrimaryDecoderNameForFilePath(const QString& filePath) {
 /// have a loop and a hotcue with the same number. In Mixxx, loops
 /// and hotcues share indices. Hence, we import them with an offset
 /// of 8 (the maximum number of hotcues in Serato).
-constexpr int kLoopIndexOffset = 8;
+constexpr int kFirstLoopIndex = mixxx::kFirstHotCueIndex + 8;
 constexpr int kNumCuesInMarkersTag = 5;
 
 mixxx::RgbColor getColorFromOtherPalette(
@@ -51,28 +51,28 @@ mixxx::RgbColor getColorFromOtherPalette(
 }
 
 std::optional<int> findIndexForCueInfo(const mixxx::CueInfo& cueInfo) {
-    VERIFY_OR_DEBUG_ASSERT(cueInfo.getHotCueNumber()) {
+    VERIFY_OR_DEBUG_ASSERT(cueInfo.getHotCueIndex()) {
         qWarning() << "SeratoTags::getCues: Cue without number found!";
         return std::nullopt;
     }
 
-    int index = *cueInfo.getHotCueNumber();
-    VERIFY_OR_DEBUG_ASSERT(index >= 0) {
+    int index = *cueInfo.getHotCueIndex();
+    VERIFY_OR_DEBUG_ASSERT(index >= mixxx::kFirstHotCueIndex) {
         qWarning() << "SeratoTags::getCues: Cue with number < 0 found!";
         return std::nullopt;
     }
 
     switch (cueInfo.getType()) {
     case mixxx::CueType::HotCue:
-        if (index >= kLoopIndexOffset) {
+        if (index >= kFirstLoopIndex) {
             qWarning()
                     << "SeratoTags::getCues: Non-loop Cue with number >="
-                    << kLoopIndexOffset << "found!";
+                    << kFirstLoopIndex << "found!";
             return std::nullopt;
         }
         break;
     case mixxx::CueType::Loop:
-        index += kLoopIndexOffset;
+        index += kFirstLoopIndex;
         break;
     default:
         return std::nullopt;
@@ -285,7 +285,7 @@ QList<CueInfo> SeratoTags::getCueInfos() const {
         }
 
         CueInfo newCueInfo(cueInfo);
-        newCueInfo.setHotCueNumber(index);
+        newCueInfo.setHotCueIndex(index);
 
         RgbColor::optional_t color = cueInfo.getColor();
         if (color) {
@@ -329,7 +329,7 @@ QList<CueInfo> SeratoTags::getCueInfos() const {
         newCueInfo.setType(cueInfo.getType());
         newCueInfo.setStartPositionMillis(cueInfo.getStartPositionMillis());
         newCueInfo.setEndPositionMillis(cueInfo.getEndPositionMillis());
-        newCueInfo.setHotCueNumber(index);
+        newCueInfo.setHotCueIndex(index);
 
         RgbColor::optional_t color = cueInfo.getColor();
         if (color) {
@@ -359,12 +359,12 @@ void SeratoTags::setCueInfos(const QList<CueInfo>& cueInfos, double timingOffset
     QMap<int, CueInfo> cueMap;
     QMap<int, CueInfo> loopMap;
     for (const CueInfo& cueInfo : qAsConst(cueInfos)) {
-        if (!cueInfo.getHotCueNumber()) {
+        if (!cueInfo.getHotCueIndex()) {
             continue;
         }
 
-        int hotcueNumber = *cueInfo.getHotCueNumber();
-        if (hotcueNumber < 0) {
+        int hotcueIndex = *cueInfo.getHotCueIndex();
+        if (hotcueIndex < kFirstHotCueIndex) {
             continue;
         }
 
@@ -388,10 +388,10 @@ void SeratoTags::setCueInfos(const QList<CueInfo>& cueInfos, double timingOffset
 
         switch (cueInfo.getType()) {
         case CueType::HotCue:
-            cueMap.insert(hotcueNumber, newCueInfo);
+            cueMap.insert(hotcueIndex, newCueInfo);
             break;
         case CueType::Loop:
-            loopMap.insert(hotcueNumber, newCueInfo);
+            loopMap.insert(hotcueIndex, newCueInfo);
             break;
         default:
             qWarning() << "Skipping incompatible cue type";
@@ -402,8 +402,8 @@ void SeratoTags::setCueInfos(const QList<CueInfo>& cueInfos, double timingOffset
     // Check if loops were imported or set using a constant offset
     int loopIndexOffset = 0;
     if (!loopMap.isEmpty()) {
-        if (loopMap.firstKey() >= kLoopIndexOffset) {
-            loopIndexOffset = kLoopIndexOffset;
+        if (loopMap.firstKey() >= kFirstLoopIndex) {
+            loopIndexOffset = kFirstLoopIndex;
         }
     }
 
@@ -412,7 +412,7 @@ void SeratoTags::setCueInfos(const QList<CueInfo>& cueInfos, double timingOffset
     auto it = loopMap.constBegin();
     while (it != loopMap.constEnd()) {
         CueInfo cueInfo(it.value());
-        cueInfo.setHotCueNumber(*cueInfo.getHotCueNumber() - loopIndexOffset);
+        cueInfo.setHotCueIndex(*cueInfo.getHotCueIndex() - loopIndexOffset);
         cueInfoList.append(cueInfo);
         it++;
     }


### PR DESCRIPTION
Follow-up to fix inconsistencies caused by the recent cue control fixes.

Noticed while trying to export cue markers using `CueInfo`.