### PR TITLE
[WiP] Populate library.last_played_at on startup for backwards compatibility

### DIFF
--- a/res/schema.xml
+++ b/res/schema.xml
@@ -524,17 +524,25 @@ METADATA
     <description>
       Add last_played_at column to library table
     </description>
+    <!--
+      Populating the new column from history playlists has to be done
+      programmatically on every restart to ensure that missing values
+      are added even after using the database with an older Mixxx
+      version! Otherwise backwards compatibility is broken
+      -->
     <sql>
-      -- Add new column
       ALTER TABLE library ADD COLUMN last_played_at DATETIME DEFAULT NULL;
-      -- Populate new column from history playlists
-      UPDATE library SET last_played_at=(
-        SELECT MAX(PlaylistTracks.pl_datetime_added)
-          FROM PlaylistTracks
-          JOIN Playlists ON PlaylistTracks.playlist_id=Playlists.id
-          WHERE PlaylistTracks.track_id=library.id
-          AND Playlists.hidden=2
-          GROUP BY PlaylistTracks.track_id);
+    </sql>
+  </revision>
+  <revision version="36" min_compatible="3">
+    <description>
+      Add index for library.last_played_at
+    </description>
+    <sql>
+      -- Required for efficiently updating library.last_played_at on startup
+      CREATE INDEX IF NOT EXISTS idx_library_last_played_at ON library (
+          last_played_at
+      );
     </sql>
   </revision>
 </schema>

--- a/src/database/mixxxdb.cpp
+++ b/src/database/mixxxdb.cpp
@@ -10,7 +10,7 @@
 const QString MixxxDb::kDefaultSchemaFile(":/schema.xml");
 
 //static
-const int MixxxDb::kRequiredSchemaVersion = 35;
+const int MixxxDb::kRequiredSchemaVersion = 36;
 
 namespace {
 

--- a/src/test/schemamanager_test.cpp
+++ b/src/test/schemamanager_test.cpp
@@ -15,7 +15,7 @@ TEST_F(SchemaManagerTest, CanUpgradeFreshDatabaseToRequiredVersion) {
                 MixxxDb::kRequiredSchemaVersion, MixxxDb::kDefaultSchemaFile);
         EXPECT_EQ(SchemaManager::Result::UpgradeSucceeded, result);
     }
-    // Subsequent upgrade(s)
+    // Subsequent upgrade
     {
         SchemaManager schemaManager(dbConnection());
         SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
@@ -34,20 +34,18 @@ TEST_F(SchemaManagerTest, NonExistentSchema) {
 TEST_F(SchemaManagerTest, BackwardsCompatibleVersion) {
     // Establish preconditions for test
     {
-        // Upgrade to version 1 to get the settings table.
         SchemaManager schemaManager(dbConnection());
         SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
-                1, MixxxDb::kDefaultSchemaFile);
-        EXPECT_EQ(SchemaManager::Result::UpgradeSucceeded, result);
-
-        SettingsDAO settings(dbConnection());
+                MixxxDb::kRequiredSchemaVersion, MixxxDb::kDefaultSchemaFile);
+        ASSERT_EQ(SchemaManager::Result::UpgradeSucceeded, result);
 
         // Pretend the database version is one past the required version but
         // min_compatible is the required version.
-        settings.setValue(SchemaManager::SETTINGS_VERSION_STRING,
-                MixxxDb::kRequiredSchemaVersion + 1);
-        settings.setValue(SchemaManager::SETTINGS_MINCOMPATIBLE_STRING,
-                MixxxDb::kRequiredSchemaVersion);
+        SettingsDAO settings(dbConnection());
+        ASSERT_TRUE(settings.setValue(SchemaManager::SETTINGS_VERSION_STRING,
+                MixxxDb::kRequiredSchemaVersion + 1));
+        ASSERT_TRUE(settings.setValue(SchemaManager::SETTINGS_MINCOMPATIBLE_STRING,
+                MixxxDb::kRequiredSchemaVersion));
     }
 
     SchemaManager schemaManager(dbConnection());
@@ -59,20 +57,18 @@ TEST_F(SchemaManagerTest, BackwardsCompatibleVersion) {
 TEST_F(SchemaManagerTest, BackwardsIncompatibleVersion) {
     // Establish preconditions for test
     {
-        // Upgrade to version 1 to get the settings table.
         SchemaManager schemaManager(dbConnection());
         SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
-                1, MixxxDb::kDefaultSchemaFile);
-        EXPECT_EQ(SchemaManager::Result::UpgradeSucceeded, result);
-
-        SettingsDAO settings(dbConnection());
+                MixxxDb::kRequiredSchemaVersion, MixxxDb::kDefaultSchemaFile);
+        ASSERT_EQ(SchemaManager::Result::UpgradeSucceeded, result);
 
         // Pretend the database version is one past the required version and
         // min_compatible is one past the required version.
-        settings.setValue(SchemaManager::SETTINGS_VERSION_STRING,
-                MixxxDb::kRequiredSchemaVersion + 1);
-        settings.setValue(SchemaManager::SETTINGS_MINCOMPATIBLE_STRING,
-                MixxxDb::kRequiredSchemaVersion + 1);
+        SettingsDAO settings(dbConnection());
+        ASSERT_TRUE(settings.setValue(SchemaManager::SETTINGS_VERSION_STRING,
+                MixxxDb::kRequiredSchemaVersion + 1));
+        ASSERT_TRUE(settings.setValue(SchemaManager::SETTINGS_MINCOMPATIBLE_STRING,
+                MixxxDb::kRequiredSchemaVersion + 1));
     }
 
     SchemaManager schemaManager(dbConnection());
@@ -89,12 +85,12 @@ TEST_F(SchemaManagerTest, IgnoreDuplicateColumn) {
         SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
                 3, MixxxDb::kDefaultSchemaFile);
         ASSERT_EQ(SchemaManager::Result::UpgradeSucceeded, result);
-    }
 
-    // Add a column that will be added again in version 24.
-    QSqlQuery query(dbConnection());
-    ASSERT_TRUE(
-            query.exec("ALTER TABLE library ADD COLUMN coverart_source TEXT"));
+        // Add a column that will be added again in version 24.
+        QSqlQuery query(dbConnection());
+        ASSERT_TRUE(
+                query.exec("ALTER TABLE library ADD COLUMN coverart_source TEXT"));
+    }
 
     SchemaManager schemaManager(dbConnection());
     SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
@@ -109,12 +105,12 @@ TEST_F(SchemaManagerTest, UpgradeFailed) {
         SchemaManager schemaManager(dbConnection());
         SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
                 3, MixxxDb::kDefaultSchemaFile);
-        EXPECT_EQ(SchemaManager::Result::UpgradeSucceeded, result);
-    }
+        ASSERT_EQ(SchemaManager::Result::UpgradeSucceeded, result);
 
-    // Drop a table that is expected to exist.
-    QSqlQuery query(dbConnection());
-    EXPECT_TRUE(query.exec("DROP TABLE PlaylistTracks"));
+        // Drop a table that is expected to exist.
+        QSqlQuery query(dbConnection());
+        ASSERT_TRUE(query.exec("DROP TABLE PlaylistTracks"));
+    }
 
     SchemaManager schemaManager(dbConnection());
     SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(


### PR DESCRIPTION
- [x] ~~Fix SchemaManagerTest.BackwardsCompatibleVersion~~ It turned out that this test was invalid. Fixed.

https://mixxx.discourse.group/t/my-program-has-been-updated-prior-to-alpha-version/20465/9?u=tapir

Re-populates the `library.last_played_at` column on startup instead of only once during the schema migration.