### PR TITLE
QML GUI proof-of-concept

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -389,6 +389,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/control/controlobjectscript.cpp
   src/control/controlpotmeter.cpp
   src/control/controlproxy.cpp
+  src/control/controlproxyqml.cpp
   src/control/controlpushbutton.cpp
   src/control/controlttrotary.cpp
   src/controllers/controller.cpp
@@ -665,6 +666,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/coreservices.cpp
   src/mixxx.cpp
   src/mixxxapplication.cpp
+  src/qmlapplication.cpp
   src/musicbrainz/chromaprinter.cpp
   src/musicbrainz/crc.cpp
   src/musicbrainz/gzip.cpp
@@ -1875,6 +1877,7 @@ find_package(Qt5
     Network
     OpenGL
     Qml
+    Quick
     Sql
     Svg
     Test
@@ -1889,6 +1892,7 @@ target_link_libraries(mixxx-lib PUBLIC
   Qt5::Network
   Qt5::OpenGL
   Qt5::Qml
+  Qt5::Quick
   Qt5::Sql
   Qt5::Svg
   Qt5::Test

--- a/res/main.qml
+++ b/res/main.qml
@@ -16,6 +16,7 @@ ApplicationWindow {
             key: "volume"
             parameter: slider.value
         }
+        orientation: Qt.Vertical
         value: volume.parameter
 
         wheelEnabled: true
@@ -27,7 +28,7 @@ ApplicationWindow {
             width: 42
             height: 19
             x: slider.leftPadding + slider.availableWidth / 2 - width / 2
-            y: (1 - slider.visualPosition) * (slider.height - height)
+            y: slider.visualPosition * (slider.height - height)
         }
         background: Image {
             source: "skins/LateNight/classic/sliders/slider_volume_deck.svg"

--- a/res/main.qml
+++ b/res/main.qml
@@ -1,0 +1,36 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import Mixxx 1.0
+
+ApplicationWindow {
+    id: window
+    width: 34
+    height: 100
+    visible: true
+
+    Slider {
+        id: slider
+        Control {
+            id: volume
+            group: "[Channel1]"
+            key: "volume"
+            parameter: slider.value
+        }
+        value: volume.parameter
+
+        wheelEnabled: true
+
+        width: window.width
+        height: window.height
+        handle: Image {
+            source: "skins/LateNight/classic/sliders/knob_volume_deck.svg"
+            width: 42
+            height: 19
+            x: slider.leftPadding + slider.availableWidth / 2 - width / 2
+            y: (1 - slider.visualPosition) * (slider.height - height)
+        }
+        background: Image {
+            source: "skins/LateNight/classic/sliders/slider_volume_deck.svg"
+        }
+    }
+}

--- a/src/control/controlproxyqml.cpp
+++ b/src/control/controlproxyqml.cpp
@@ -1,0 +1,68 @@
+#include "control/controlproxyqml.h"
+
+#include "moc_controlproxyqml.cpp"
+
+ControlProxyQml::ControlProxyQml(QObject* parent)
+        : QObject(parent),
+          m_pControlProxy(nullptr) {
+}
+
+void ControlProxyQml::setGroup(const QString& group) {
+    m_coKey.group = group;
+    initialize();
+}
+
+const QString& ControlProxyQml::getGroup() const {
+    return m_coKey.group;
+}
+
+void ControlProxyQml::setKey(const QString& key) {
+    m_coKey.item = key;
+    initialize();
+}
+
+const QString& ControlProxyQml::getKey() const {
+    return m_coKey.item;
+}
+
+void ControlProxyQml::setValue(double newValue) {
+    if (!m_pControlProxy) {
+        return;
+    }
+    m_pControlProxy->set(newValue);
+}
+
+double ControlProxyQml::getValue() const {
+    if (!m_pControlProxy) {
+        return -1;
+    }
+    return m_pControlProxy->get();
+}
+
+void ControlProxyQml::setParameter(double newValue) {
+    if (!m_pControlProxy) {
+        return;
+    }
+    m_pControlProxy->setParameter(newValue);
+}
+
+double ControlProxyQml::getParameter() const {
+    if (!m_pControlProxy) {
+        return -1;
+    }
+    return m_pControlProxy->getParameter();
+}
+
+void ControlProxyQml::initialize() {
+    if (m_coKey.isValid()) {
+        m_pControlProxy = std::make_unique<ControlProxy>(
+                m_coKey, this, ControlFlag::AllowMissingOrInvalid);
+        m_pControlProxy->connectValueChanged(this, &ControlProxyQml::controlProxyValueChanged);
+        m_pControlProxy->emitValueChanged();
+    }
+}
+
+void ControlProxyQml::controlProxyValueChanged(double newValue) {
+    emit valueChanged(newValue);
+    emit parameterChanged(m_pControlProxy->getParameter());
+}

--- a/src/control/controlproxyqml.h
+++ b/src/control/controlproxyqml.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <QtQml>
+#include <memory>
+
+#include "control/controlproxy.h"
+
+class ControlProxyQml : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(QString group READ getGroup WRITE setGroup)
+    Q_PROPERTY(QString key READ getKey WRITE setKey)
+    Q_PROPERTY(double value READ getValue WRITE setValue NOTIFY valueChanged)
+    Q_PROPERTY(double parameter READ getParameter WRITE setParameter NOTIFY parameterChanged)
+
+  public:
+    ControlProxyQml(QObject* parent = nullptr);
+
+    void setGroup(const QString& group);
+    const QString& getGroup() const;
+
+    void setKey(const QString& key);
+    const QString& getKey() const;
+
+    void setValue(double newValue);
+    double getValue() const;
+
+    void setParameter(double newValue);
+    double getParameter() const;
+
+  signals:
+    void valueChanged(double newValue);
+    void parameterChanged(double newParameter);
+
+  private slots:
+    void controlProxyValueChanged(double newValue);
+
+  private:
+    // QML cannot pass arguments to C++ constructors so this class
+    // needs to rely on the QML object setting the group and key
+    // properties to initialize the ControlProxy.
+    void initialize();
+
+    QString m_emptyString;
+    ConfigKey m_coKey;
+    std::unique_ptr<ControlProxy> m_pControlProxy;
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <QApplication>
 #include <QDir>
+#include <QQmlApplicationEngine>
 #include <QString>
 #include <QStringList>
 #include <QTextCodec>
@@ -10,6 +11,7 @@
 #include "errordialoghandler.h"
 #include "mixxx.h"
 #include "mixxxapplication.h"
+#include "qmlapplication.h"
 #include "sources/soundsourceproxy.h"
 #include "util/cmdlineargs.h"
 #include "util/console.h"
@@ -28,16 +30,22 @@ constexpr int kParseCmdlineArgsErrorExitCode = 2;
 
 int runMixxx(MixxxApplication* app, const CmdlineArgs& args) {
     auto coreServices = std::make_shared<mixxx::CoreServices>(args);
-    MixxxMainWindow mainWindow(app, coreServices);
-    // If startup produced a fatal error, then don't even start the
-    // Qt event loop.
-    if (ErrorDialogHandler::instance()->checkError()) {
-        return kFatalErrorOnStartupExitCode;
-    } else {
-        qDebug() << "Displaying main window";
-        mainWindow.show();
 
-        qDebug() << "Running Mixxx";
+    if (args.getQmlPath().isEmpty()) {
+        MixxxMainWindow mainWindow(app, coreServices);
+        // If startup produced a fatal error, then don't even start the
+        // Qt event loop.
+        if (ErrorDialogHandler::instance()->checkError()) {
+            return kFatalErrorOnStartupExitCode;
+        } else {
+            qDebug() << "Displaying main window";
+            mainWindow.show();
+
+            qDebug() << "Running Mixxx";
+            return app->exec();
+        }
+    } else {
+        mixxx::QmlApplication qmlApplication(app, coreServices, args);
         return app->exec();
     }
 }

--- a/src/qmlapplication.cpp
+++ b/src/qmlapplication.cpp
@@ -1,0 +1,45 @@
+#include "qmlapplication.h"
+
+#include "control/controlproxyqml.h"
+#include "moc_qmlapplication.cpp"
+#include "soundio/soundmanager.h"
+
+namespace mixxx {
+
+QmlApplication::QmlApplication(
+        QApplication* app,
+        std::shared_ptr<CoreServices> pCoreServices,
+        const CmdlineArgs& args)
+        : m_pCoreServices(pCoreServices),
+          m_cmdlineArgs(args),
+          m_pQmlAppEngine(nullptr),
+          m_qmlFileWatcher({m_cmdlineArgs.getQmlPath()}) {
+    qmlRegisterType<ControlProxyQml>("Mixxx", 1, 0, "Control");
+
+    m_pCoreServices->initializeSettings();
+    m_pCoreServices->initializeKeyboard();
+    m_pCoreServices->initialize(app);
+    SoundDeviceError result = m_pCoreServices->getSoundManager()->setupDevices();
+    if (result != SOUNDDEVICE_ERROR_OK) {
+        qCritical() << "Error setting up sound devices" << result;
+        exit(result);
+    }
+
+    loadQml(m_cmdlineArgs.getQmlPath());
+
+    connect(&m_qmlFileWatcher,
+            &QFileSystemWatcher::fileChanged,
+            this,
+            &QmlApplication::loadQml);
+}
+
+void QmlApplication::loadQml(const QString& path) {
+    // QQmlApplicationEngine::load creates a new window but also leaves the old one,
+    // so it is necessary to destroy the old QQmlApplicationEngine and create a new one.
+    m_pQmlAppEngine = std::make_unique<QQmlApplicationEngine>(path);
+    if (m_pQmlAppEngine->rootObjects().isEmpty()) {
+        qCritical() << "Failed to load QML file" << path;
+    }
+}
+
+} // namespace mixxx

--- a/src/qmlapplication.h
+++ b/src/qmlapplication.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <coreservices.h>
+#include <util/cmdlineargs.h>
+
+#include <QApplication>
+#include <QFileSystemWatcher>
+#include <QQmlApplicationEngine>
+
+namespace mixxx {
+
+class QmlApplication : public QObject {
+    Q_OBJECT
+  public:
+    QmlApplication(
+            QApplication* app,
+            std::shared_ptr<CoreServices> pCoreServices,
+            const CmdlineArgs& args);
+    ~QmlApplication() = default;
+
+  public slots:
+    void loadQml(const QString& path);
+
+  private:
+    std::shared_ptr<CoreServices> m_pCoreServices;
+    const CmdlineArgs& m_cmdlineArgs;
+
+    std::unique_ptr<QQmlApplicationEngine> m_pQmlAppEngine;
+    QFileSystemWatcher m_qmlFileWatcher;
+};
+
+} // namespace mixxx

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -116,6 +116,8 @@ when a critical error occurs unless this is set properly.\n", stdout);
                            "--color", Qt::CaseInsensitive) &&
                 i + 1 < argc) {
             colorSettings = QString::fromLocal8Bit(argv[i + 1]);
+        } else if (QString::fromLocal8Bit(argv[i]).contains("--qml", Qt::CaseInsensitive)) {
+            m_qmlPath = QString::fromLocal8Bit(argv[i + 1]);
         } else if (i > 0) {
             // Don't try to load the program name to a deck
             m_musicFiles += QString::fromLocal8Bit(argv[i]);
@@ -183,6 +185,8 @@ void CmdlineArgs::printUsage() {
 \n\
 --developer             Enables developer-mode. Includes extra log info,\n\
                         stats on performance, and a Developer tools menu.\n\
+\n\
+--qml                   Load GUI from a QML file instead of legacy skin system\n\
 \n\
 --safeMode              Enables safe-mode. Disables OpenGL waveforms,\n\
                         and spinning vinyl widgets. Try this option if\n\

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -44,6 +44,9 @@ class CmdlineArgs final {
     const QString& getResourcePath() const { return m_resourcePath; }
     const QString& getPluginPath() const { return m_pluginPath; }
     const QString& getTimelinePath() const { return m_timelinePath; }
+    const QString& getQmlPath() const {
+        return m_qmlPath;
+    }
 
   private:
     QList<QString> m_musicFiles;    // List of files to load into players at startup
@@ -61,4 +64,5 @@ class CmdlineArgs final {
     QString m_resourcePath;
     QString m_pluginPath;
     QString m_timelinePath;
+    QString m_qmlPath;
 };


### PR DESCRIPTION
This adds a command line option `--qml` to specify a path to a QML file to load for the GUI instead of MixxxMainWindow with a legacy skin. Using this, I can load a track by specifying its path on the command line and play it using my controller.

The next step is to expose ControlObjects to QML and bind them to Qt Quick Item properties, then load images from our legacy skins for QQC2 Sliders and Dials.