### PR TITLE
CmdlineArgs: load audio files to correct decks

### DIFF
--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -102,7 +102,8 @@ when a critical error occurs unless this is set properly.\n", stdout);
             m_safeMode = true;
         } else if (QString::fromLocal8Bit(argv[i]).contains("--debugAssertBreak", Qt::CaseInsensitive)) {
             m_debugAssertBreak = true;
-        } else {
+        } else if (i > 0) {
+            // Don't try to load the program name to a deck
             m_musicFiles += QString::fromLocal8Bit(argv[i]);
         }
     }


### PR DESCRIPTION
CmdlineArgs was interpreting the program name as the first file
to load, so the first file was getting loaded to deck 2 instead
of deck 1.