### PR TITLE
Library: overhaul setting the font and row height

### DIFF
--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -529,7 +529,8 @@ void Library::setFont(const QFont& font) {
 
     m_trackTableFont = font;
     emit setTrackTableFont(font);
-    //  adapt the previous font heigh/row height ratio
+
+    // adapt the previous font height/row height ratio
     int scaledRowHeight = static_cast<int>(std::round(
             (newFontHeight / currFontHeight) * m_iTrackTableRowHeight));
     setRowHeight(scaledRowHeight);

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -522,8 +522,17 @@ QStringList Library::getDirs() {
 }
 
 void Library::setFont(const QFont& font) {
+    QFontMetrics currMetrics(m_trackTableFont);
+    QFontMetrics newMetrics(font);
+    double currFontHeight = currMetrics.height();
+    double newFontHeight = newMetrics.height();
+
     m_trackTableFont = font;
     emit setTrackTableFont(font);
+    //  adapt the previous font heigh/row height ratio
+    int scaledRowHeight = static_cast<int>(std::round(
+            (newFontHeight / currFontHeight) * m_iTrackTableRowHeight));
+    setRowHeight(scaledRowHeight);
 }
 
 void Library::setRowHeight(int rowHeight) {

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -383,13 +383,13 @@ void DlgPrefLibrary::setLibraryFont(const QFont& font) {
         font.family(), font.styleName(), QString::number(font.pointSizeF())));
     m_pLibrary->setFont(font);
 
-    // Don't let the row height exceed the library height.
+    // Don't let the font height exceed the row height.
     QFontMetrics metrics(font);
     int fontHeight = metrics.height();
-    if (fontHeight > spinBoxRowHeight->value()) {
-        spinBoxRowHeight->setValue(fontHeight);
-    }
     spinBoxRowHeight->setMinimum(fontHeight);
+    // library.cpp takes care of setting the new row height according to the
+    // previous font height/ row height ratio
+    spinBoxRowHeight->setValue(m_pLibrary->getTrackTableRowHeight());
 }
 
 void DlgPrefLibrary::slotSelectFont() {

--- a/src/widget/wlibrarytableview.cpp
+++ b/src/widget/wlibrarytableview.cpp
@@ -132,14 +132,13 @@ void WLibraryTableView::restoreVScrollBarPos(TrackModel* key){
 
 void WLibraryTableView::setTrackTableFont(const QFont& font) {
     setFont(font);
-    setTrackTableRowHeight(verticalHeader()->defaultSectionSize());
+    QFontMetrics metrics(font);
+    verticalHeader()->setMinimumSectionSize(metrics.height());
 }
 
 void WLibraryTableView::setTrackTableRowHeight(int rowHeight) {
-    QFontMetrics metrics(font());
-    int fontHeightPx = metrics.height();
     verticalHeader()->setDefaultSectionSize(math_max(
-                                                rowHeight, fontHeightPx));
+            rowHeight, verticalHeader()->minimumSectionSize()));
 }
 
 void WLibraryTableView::setSelectedClick(bool enable) {


### PR DESCRIPTION
Previously, there was an artificial lower limit for the row height (31px
for me) that would ignore lower values of the row height spinbox.

Now, the new font height is used as lower limit for the row height.
When changing the font (size) the row height is automatically adjusted by using the previous font height/row height ratio.

For adjustment via Preferences this is 'just' convenient, but for those doing the adjustment via controller this is probably very helpful.

Adjusting the row height is now done in library.cpp only.