### PR TITLE
Follow-up: Move definition of library default columns out of header file

### DIFF
--- a/src/library/dao/trackschema.h
+++ b/src/library/dao/trackschema.h
@@ -1,8 +1,6 @@
-#ifndef MIXXX_TRACKSCHEMA_H
-#define MIXXX_TRACKSCHEMA_H
+#pragma once
 
 #include <QString>
-#include <QStringList>
 
 #define LIBRARY_TABLE "library"
 #define TRACKLOCATIONS_TABLE "track_locations"
@@ -56,45 +54,9 @@ const QString TRACKLOCATIONSTABLE_NEEDSVERIFICATION = "needs_verification";
 
 const QString REKORDBOX_ANALYZE_PATH = "analyze_path";
 
-const QStringList DEFAULT_COLUMNS = {
-        LIBRARYTABLE_ID,
-        LIBRARYTABLE_PLAYED,
-        LIBRARYTABLE_TIMESPLAYED,
-        //has to be up here otherwise Played and TimesPlayed are not shown
-        LIBRARYTABLE_ALBUMARTIST,
-        LIBRARYTABLE_ALBUM,
-        LIBRARYTABLE_ARTIST,
-        LIBRARYTABLE_TITLE,
-        LIBRARYTABLE_YEAR,
-        LIBRARYTABLE_RATING,
-        LIBRARYTABLE_GENRE,
-        LIBRARYTABLE_COMPOSER,
-        LIBRARYTABLE_GROUPING,
-        LIBRARYTABLE_TRACKNUMBER,
-        LIBRARYTABLE_KEY,
-        LIBRARYTABLE_KEY_ID,
-        LIBRARYTABLE_BPM,
-        LIBRARYTABLE_BPM_LOCK,
-        LIBRARYTABLE_DURATION,
-        LIBRARYTABLE_BITRATE,
-        LIBRARYTABLE_REPLAYGAIN,
-        LIBRARYTABLE_FILETYPE,
-        LIBRARYTABLE_DATETIMEADDED,
-        TRACKLOCATIONSTABLE_LOCATION,
-        TRACKLOCATIONSTABLE_FSDELETED,
-        LIBRARYTABLE_COMMENT,
-        LIBRARYTABLE_MIXXXDELETED,
-        LIBRARYTABLE_COLOR,
-        LIBRARYTABLE_COVERART_SOURCE,
-        LIBRARYTABLE_COVERART_TYPE,
-        LIBRARYTABLE_COVERART_LOCATION,
-        LIBRARYTABLE_COVERART_HASH};
-
 namespace mixxx {
 namespace trackschema {
 // TableForColumn returns the name of the table that contains the named column.
 QString tableForColumn(const QString& columnName);
 } // namespace trackschema
 } // namespace mixxx
-
-#endif //MIXXX_TRACKSCHEMA_H

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -20,6 +20,44 @@
 #include "util/dnd.h"
 #include "widget/wlibrary.h"
 
+namespace {
+
+const QStringList DEFAULT_COLUMNS = {
+        LIBRARYTABLE_ID,
+        LIBRARYTABLE_PLAYED,
+        LIBRARYTABLE_TIMESPLAYED,
+        //has to be up here otherwise Played and TimesPlayed are not shown
+        LIBRARYTABLE_ALBUMARTIST,
+        LIBRARYTABLE_ALBUM,
+        LIBRARYTABLE_ARTIST,
+        LIBRARYTABLE_TITLE,
+        LIBRARYTABLE_YEAR,
+        LIBRARYTABLE_RATING,
+        LIBRARYTABLE_GENRE,
+        LIBRARYTABLE_COMPOSER,
+        LIBRARYTABLE_GROUPING,
+        LIBRARYTABLE_TRACKNUMBER,
+        LIBRARYTABLE_KEY,
+        LIBRARYTABLE_KEY_ID,
+        LIBRARYTABLE_BPM,
+        LIBRARYTABLE_BPM_LOCK,
+        LIBRARYTABLE_DURATION,
+        LIBRARYTABLE_BITRATE,
+        LIBRARYTABLE_REPLAYGAIN,
+        LIBRARYTABLE_FILETYPE,
+        LIBRARYTABLE_DATETIMEADDED,
+        TRACKLOCATIONSTABLE_LOCATION,
+        TRACKLOCATIONSTABLE_FSDELETED,
+        LIBRARYTABLE_COMMENT,
+        LIBRARYTABLE_MIXXXDELETED,
+        LIBRARYTABLE_COLOR,
+        LIBRARYTABLE_COVERART_SOURCE,
+        LIBRARYTABLE_COVERART_TYPE,
+        LIBRARYTABLE_COVERART_LOCATION,
+        LIBRARYTABLE_COVERART_HASH};
+
+} // namespace
+
 MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
                                          UserSettingsPointer pConfig)
         : LibraryFeature(pLibrary, pConfig),


### PR DESCRIPTION
Follow-up of #3328. The definition of this constant does not belong in a header file.

Be careful when merging to main! The COVERART_DIGEST column probably needs to be added manually.