### PR TITLE
TrackDAO: Do not write timesplayed/last_played_at

### DIFF
--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -72,7 +72,8 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     /// Update the play counter properties according to the corresponding
     /// aggregated properties obtained from the played history.
     bool updatePlayCounterFromPlayedHistory(
-            const QSet<TrackId>& trackIds) const;
+            const QSet<TrackId>& trackIds,
+            bool tracksChangedSignal = true) const;
 
   signals:
     // Forwarded from Track object


### PR DESCRIPTION
See my detailed comments in the code. This is just a quick fix, I do not plan to fix the actual cause!

Examples:
- Written by TrackDAO: 2020-12-21T18:35:48.290
- Generated by SQLite CURRENT_TIMESTAMP: 2020-12-21 17:35:48

~~CURRENT_TIMESTAMP obviously uses the local time zone. We might also need to take this into account when reading the last_played_at column, but I'll leave this to someone else. First we must prevent to end up with different formats in the database asap!~~ **Update, please verify using #3457**: Nothing to do. CURRENT_TIMESTAMP seems to generate and store UTC time stamps that are correctly converted to and displayed in local time in Mixxx.