### PR TITLE
demonstrate that Mixxx does not need to handle vsync itself

### DIFF
--- a/src/waveform/visualplayposition.cpp
+++ b/src/waveform/visualplayposition.cpp
@@ -59,7 +59,7 @@ double VisualPlayPosition::getAtNextVSync(VSyncThread* vSyncThread) {
     if (m_valid) {
         VisualPlayPositionData data = m_data.getValue();
         int refToVSync = vSyncThread->fromTimerToNextSyncMicros(data.m_referenceTime);
-        int offset = refToVSync - data.m_callbackEntrytoDac;
+        int offset = data.m_callbackEntrytoDac;
         offset = math_min(offset, m_audioBufferMicros * kMaxOffsetBufferCnt);
         double playPos = data.m_enginePlayPos;  // load playPos for the first sample in Buffer
         // add the offset for the position of the sample that will be transferred to the DAC
@@ -78,11 +78,9 @@ void VisualPlayPosition::getPlaySlipAtNextVSync(VSyncThread* vSyncThread, double
 
     if (m_valid) {
         VisualPlayPositionData data = m_data.getValue();
-        int refToVSync = vSyncThread->fromTimerToNextSyncMicros(data.m_referenceTime);
-        int offset = refToVSync - data.m_callbackEntrytoDac;
-        offset = math_min(offset, m_audioBufferMicros * kMaxOffsetBufferCnt);
         double playPos = data.m_enginePlayPos;  // load playPos for the first sample in Buffer
-        playPos += data.m_positionStep * offset * data.m_rate / m_audioBufferMicros;
+        playPos += data.m_positionStep * data.m_callbackEntrytoDac *
+                data.m_rate / m_audioBufferMicros;
         *pPlayPosition = playPos;
         *pSlipPosition = data.m_slipPosition;
     }

--- a/src/waveform/vsyncthread.cpp
+++ b/src/waveform/vsyncthread.cpp
@@ -64,7 +64,7 @@ void VSyncThread::run() {
                 m_timer.elapsed().toIntegerMicros());
             // waiting for interval by sleep
             if (remainingForSwap > 100) {
-                usleep(remainingForSwap);
+                //usleep(remainingForSwap);
             }
 
             // swaps the new waveform to front in case of gl-wf

--- a/src/waveform/vsyncthread.cpp
+++ b/src/waveform/vsyncthread.cpp
@@ -55,33 +55,9 @@ void VSyncThread::run() {
         } else { // if (m_vSyncMode == ST_TIMER) {
             emit vsyncRender(); // renders the new waveform.
 
-            // wait until rendering was scheduled. It might be delayed due a
-            // pending swap (depends one driver vSync settings)
             m_semaVsyncSlot.acquire();
 
-            // qDebug() << "ST_TIMER                      " << lastMicros << restMicros;
-            int remainingForSwap = m_waitToSwapMicros - static_cast<int>(
-                m_timer.elapsed().toIntegerMicros());
-            // waiting for interval by sleep
-            if (remainingForSwap > 100) {
-                //usleep(remainingForSwap);
-            }
-
-            // swaps the new waveform to front in case of gl-wf
-            emit vsyncSwap();
-
-            // wait until swap occurred. It might be delayed due to driver vSync
-            // settings.
-            m_semaVsyncSlot.acquire();
-
-            // <- Assume we are VSynced here ->
             int lastSwapTime = static_cast<int>(m_timer.restart().toIntegerMicros());
-            if (remainingForSwap < 0) {
-                // Our swapping call was already delayed
-                // The real swap might happens on the following VSync, depending on driver settings
-                m_droppedFrames++; // Count as Real Time Error
-            }
-            // try to stay in right intervals
             m_waitToSwapMicros = m_syncIntervalTimeMicros +
                     ((m_waitToSwapMicros - lastSwapTime) % m_syncIntervalTimeMicros);
         }

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -721,7 +721,7 @@ void WaveformWidgetFactory::swap() {
                     if (glw->context() != QGLContext::currentContext()) {
                         glw->makeCurrent();
                     }
-                    glw->swapBuffers();
+                    //glw->swapBuffers();
                 }
                 //qDebug() << "swap x" << m_vsyncThread->elapsed();
             }

--- a/src/waveform/widgets/glsimplewaveformwidget.cpp
+++ b/src/waveform/widgets/glsimplewaveformwidget.cpp
@@ -34,8 +34,6 @@ GLSimpleWaveformWidget::GLSimpleWaveformWidget(const QString& group, QWidget* pa
     setAttribute(Qt::WA_NoSystemBackground);
     setAttribute(Qt::WA_OpaquePaintEvent);
 
-    setAutoBufferSwap(false);
-
     m_initSuccess = init();
 }
 

--- a/src/waveform/widgets/glslwaveformwidget.cpp
+++ b/src/waveform/widgets/glslwaveformwidget.cpp
@@ -66,8 +66,6 @@ GLSLWaveformWidget::GLSLWaveformWidget(
     setAttribute(Qt::WA_NoSystemBackground);
     setAttribute(Qt::WA_OpaquePaintEvent);
 
-    setAutoBufferSwap(false);
-
     m_initSuccess = init();
 }
 

--- a/src/waveform/widgets/glvsynctestwidget.cpp
+++ b/src/waveform/widgets/glvsynctestwidget.cpp
@@ -36,8 +36,6 @@ GLVSyncTestWidget::GLVSyncTestWidget(const QString& group, QWidget* parent)
     setAttribute(Qt::WA_NoSystemBackground);
     setAttribute(Qt::WA_OpaquePaintEvent);
 
-    setAutoBufferSwap(false);
-
     m_initSuccess = init();
     qDebug() << "GLVSyncTestWidget.isSharing() =" << isSharing();
 }

--- a/src/waveform/widgets/glwaveformwidget.cpp
+++ b/src/waveform/widgets/glwaveformwidget.cpp
@@ -36,8 +36,6 @@ GLWaveformWidget::GLWaveformWidget(const QString& group, QWidget* parent)
     setAttribute(Qt::WA_NoSystemBackground);
     setAttribute(Qt::WA_OpaquePaintEvent);
 
-    setAutoBufferSwap(false);
-
     m_initSuccess = init();
 }
 


### PR DESCRIPTION
Waveform scrolling is still smooth without this sleep. Focus your eyes intently on the play position line or follow a section of the waveform scrolling all the way across the screen to avoid getting confused by your eyes saccading.

https://github.com/mixxxdj/mixxx/pull/1974#issuecomment-615429984 :
> I'm pretty sure the idea of a vsync is an illusion on modern OSes (in Qt 4 and Qt 5), which almost exclusively use compositing window managers. We were already being rendered to an offscreen surface. In my opinion, the key reason we were achieving dejerking before was probably more to do with rendering at a consistent rate than anything to do with a vsync.

This PR is not intended to be merged. It is only a proof of concept.