### PR TITLE
Preferences / Effect widgets: use '---' placeholder instead of 'None'

### DIFF
--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -13,6 +13,8 @@
 #include "moc_effectsmanager.cpp"
 #include "util/assert.h"
 
+const QString EffectsManager::kNoEffectString = QStringLiteral("---");
+
 namespace {
 const QString kEffectGroupSeparator = "_";
 const QString kGroupClose = "]";

--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -23,6 +23,8 @@ class EffectsBackend;
 class EffectsManager : public QObject {
     Q_OBJECT
   public:
+    static const QString kNoEffectString;
+
     typedef bool (*EffectManifestFilterFnc)(EffectManifest* pManifest);
 
     EffectsManager(QObject* pParent,

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -225,11 +225,12 @@ void DlgPrefEQ::slotPopulateDeckEffectSelectors() {
                 currentIndex = i;
             }
         }
-        //: Displayed when no effect is selected
+        // Add empty item, no effect
         box->addItem(EffectsManager::kNoEffectString);
 
         if (selectedEffectId.isEmpty()) {
-            currentIndex = availableEQEffects.size(); // Discards the current selection
+            // Configured effect has no id, clear selection
+            currentIndex = availableEQEffects.size();
         } else if (currentIndex < 0 && !selectedEffectName.isEmpty() ) {
             // current selection is not part of the new list
             // So we need to add it
@@ -255,11 +256,12 @@ void DlgPrefEQ::slotPopulateDeckEffectSelectors() {
                 currentIndex = i;
             }
         }
-        //: Displayed when no effect is selected
+        // Add empty item, no effect
         box->addItem(EffectsManager::kNoEffectString);
 
         if (selectedEffectId.isEmpty()) {
-            currentIndex = availableQuickEffects.size(); // Discards the current selection
+            // Configured effect has no id, clear selection
+            currentIndex = availableQuickEffects.size();
         } else if (currentIndex < 0 && !selectedEffectName.isEmpty()) {
             // current selection is not part of the new list
             // So we need to add it
@@ -673,12 +675,13 @@ void DlgPrefEQ::setUpMasterEQ() {
     for (const auto& pManifest : availableMasterEQEffects) {
         comboBoxMasterEq->addItem(pManifest->name(), QVariant(pManifest->id()));
     }
-    //: Displayed when no effect is selected
+    // Add empty item, no effect
     comboBoxMasterEq->addItem(EffectsManager::kNoEffectString);
 
     int masterEqIndex = comboBoxMasterEq->findData(configuredEffect);
     if (masterEqIndex < 0) {
-        masterEqIndex = availableMasterEQEffects.size(); // Discards the current selection
+        // Configured effect not in list, clear selection
+        masterEqIndex = availableMasterEQEffects.size();
     }
     comboBoxMasterEq->setCurrentIndex(masterEqIndex);
 

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -226,9 +226,10 @@ void DlgPrefEQ::slotPopulateDeckEffectSelectors() {
             }
         }
         //: Displayed when no effect is selected
-        box->addItem(tr("None"), QVariant(QString("")));
+        box->addItem(EffectsManager::kNoEffectString);
+
         if (selectedEffectId.isEmpty()) {
-            currentIndex = availableEQEffects.size(); // selects "None"
+            currentIndex = availableEQEffects.size(); // Discards the current selection
         } else if (currentIndex < 0 && !selectedEffectName.isEmpty() ) {
             // current selection is not part of the new list
             // So we need to add it
@@ -255,9 +256,10 @@ void DlgPrefEQ::slotPopulateDeckEffectSelectors() {
             }
         }
         //: Displayed when no effect is selected
-        box->addItem(tr("None"), QVariant(QString("")));
+        box->addItem(EffectsManager::kNoEffectString);
+
         if (selectedEffectId.isEmpty()) {
-            currentIndex = availableQuickEffects.size(); // selects "None"
+            currentIndex = availableQuickEffects.size(); // Discards the current selection
         } else if (currentIndex < 0 && !selectedEffectName.isEmpty()) {
             // current selection is not part of the new list
             // So we need to add it
@@ -672,11 +674,11 @@ void DlgPrefEQ::setUpMasterEQ() {
         comboBoxMasterEq->addItem(pManifest->name(), QVariant(pManifest->id()));
     }
     //: Displayed when no effect is selected
-    comboBoxMasterEq->addItem(tr("None"), QVariant());
+    comboBoxMasterEq->addItem(EffectsManager::kNoEffectString);
 
     int masterEqIndex = comboBoxMasterEq->findData(configuredEffect);
     if (masterEqIndex < 0) {
-        masterEqIndex = availableMasterEQEffects.size(); // selects "None"
+        masterEqIndex = availableMasterEQEffects.size(); // Discards the current selection
     }
     comboBoxMasterEq->setCurrentIndex(masterEqIndex);
 

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -30,10 +30,14 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
           m_loading(false) {
     setupUi(this);
 
-    connect(m_pSoundManager, &SoundManager::devicesUpdated, this, &DlgPrefSound::refreshDevices);
+    connect(m_pSoundManager,
+            &SoundManager::devicesUpdated,
+            this,
+            &DlgPrefSound::refreshDevices);
 
     apiComboBox->clear();
-    apiComboBox->addItem(tr("None"), "None");
+    apiComboBox->addItem(SoundManagerConfig::kEmptyComboBox,
+            SoundManagerConfig::kDefaultAPI);
     updateAPIs();
     connect(apiComboBox,
             QOverload<int>::of(&QComboBox::currentIndexChanged),
@@ -611,7 +615,7 @@ void DlgPrefSound::updateAudioBufferSizes(int sampleRateIndex) {
  * just changes and we need to display new devices.
  */
 void DlgPrefSound::refreshDevices() {
-    if (m_config.getAPI() == "None") {
+    if (m_config.getAPI() == SoundManagerConfig::kDefaultAPI) {
         m_outputDevices.clear();
         m_inputDevices.clear();
     } else {

--- a/src/preferences/dialog/dlgprefsounditem.cpp
+++ b/src/preferences/dialog/dlgprefsounditem.cpp
@@ -16,9 +16,12 @@
  * @param isInput true if this is representing an AudioInput, false otherwise
  * @param index the index of the represented AudioPath, if applicable
  */
-DlgPrefSoundItem::DlgPrefSoundItem(QWidget* parent, AudioPathType type,
-                                   const QList<SoundDevicePointer>& devices, bool isInput,
-                                   unsigned int index)
+DlgPrefSoundItem::DlgPrefSoundItem(
+        QWidget* parent,
+        AudioPathType type,
+        const QList<SoundDevicePointer>& devices,
+        bool isInput,
+        unsigned int index)
         : QWidget(parent),
           m_type(type),
           m_index(index),
@@ -27,7 +30,8 @@ DlgPrefSoundItem::DlgPrefSoundItem(QWidget* parent, AudioPathType type,
     setupUi(this);
     typeLabel->setText(AudioPath::getTrStringFromType(type, index));
 
-    deviceComboBox->addItem(tr("None"), QVariant::fromValue(SoundDeviceId()));
+    deviceComboBox->addItem(SoundManagerConfig::kEmptyComboBox,
+            QVariant::fromValue(SoundDeviceId()));
 
     // Set the focus policy for QComboBoxes (and wide QDoubleSpinBoxes) and
     // connect them to the custom event filter below so they don't accept focus

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -106,7 +106,7 @@ QList<SoundDevicePointer> SoundManager::getDeviceList(
         const QString& filterAPI, bool bOutputDevices, bool bInputDevices) const {
     //qDebug() << "SoundManager::getDeviceList";
 
-    if (filterAPI == "None") {
+    if (filterAPI == SoundManagerConfig::kDefaultAPI) {
         return QList<SoundDevicePointer>();
     }
 

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -11,7 +11,8 @@
 // this (7) represents latency values from 1 ms to about 80 ms -- bkgood
 const unsigned int SoundManagerConfig::kMaxAudioBufferSizeIndex = 7;
 
-const QString SoundManagerConfig::kDefaultAPI = QString("None");
+const QString SoundManagerConfig::kDefaultAPI = QStringLiteral("None");
+const QString SoundManagerConfig::kEmptyComboBox = QStringLiteral("---");
 // Sample Rate even the cheap sound Devices will support most likely
 const unsigned int SoundManagerConfig::kFallbackSampleRate = 48000;
 const unsigned int SoundManagerConfig::kDefaultDeckCount = 2;

--- a/src/soundio/soundmanagerconfig.h
+++ b/src/soundio/soundmanagerconfig.h
@@ -25,6 +25,7 @@ public:
     };
     static const unsigned int kMaxAudioBufferSizeIndex;
     static const QString kDefaultAPI;
+    static const QString kEmptyComboBox;
     static const unsigned int kFallbackSampleRate;
     static const unsigned int kDefaultDeckCount;
     static const int kDefaultAudioBufferSizeIndex;

--- a/src/widget/weffect.cpp
+++ b/src/widget/weffect.cpp
@@ -49,7 +49,7 @@ void WEffect::effectUpdated() {
             description = tr("%1: %2").arg(pManifest->name(), pManifest->description());
         }
     } else {
-        name = tr("None");
+        name = EffectsManager::kNoEffectString;
         description = tr("No effect loaded.");
     }
     setText(name);

--- a/src/widget/weffectchain.cpp
+++ b/src/widget/weffectchain.cpp
@@ -39,7 +39,7 @@ void WEffectChain::setEffectChainSlot(EffectChainSlotPointer pEffectChainSlot) {
 }
 
 void WEffectChain::chainUpdated() {
-    QString name = tr("None");
+    QString name = EffectsManager::kNoEffectString;
     QString description = tr("No effect chain loaded.");
     if (m_pEffectChainSlot) {
         EffectChainPointer pChain = m_pEffectChainSlot->getEffectChain();

--- a/src/widget/weffectparameterbase.cpp
+++ b/src/widget/weffectparameterbase.cpp
@@ -34,7 +34,7 @@ void WEffectParameterBase::parameterUpdated() {
                        m_pEffectParameterSlot->name(),
                        m_pEffectParameterSlot->description()));
     } else {
-        setText(tr("None"));
+        setText(EffectsManager::kNoEffectString);
         setBaseTooltip(tr("No effect loaded."));
     }
 }

--- a/src/widget/weffectselector.cpp
+++ b/src/widget/weffectselector.cpp
@@ -71,8 +71,7 @@ void WEffectSelector::populate() {
         setItemData(i, QVariant(QStringLiteral("<b>") + name + QStringLiteral("</b><br/>") +
                 description), Qt::ToolTipRole);
     }
-
-    //: Displayed when no effect is loaded
+    // Add empty item, no effect
     addItem(EffectsManager::kNoEffectString);
     setItemData(visibleEffectManifests.size(), QVariant(tr("No effect loaded.")),
                 Qt::ToolTipRole);

--- a/src/widget/weffectselector.cpp
+++ b/src/widget/weffectselector.cpp
@@ -73,7 +73,7 @@ void WEffectSelector::populate() {
     }
 
     //: Displayed when no effect is loaded
-    addItem(tr("None"), QVariant());
+    addItem(EffectsManager::kNoEffectString);
     setItemData(visibleEffectManifests.size(), QVariant(tr("No effect loaded.")),
                 Qt::ToolTipRole);
 


### PR DESCRIPTION
... because in the Sound I/O tabs and in skins' effect regions ` --- ` is much easier to spot/recognize than `None`.

https://bugs.launchpad.net/mixxx/+bug/1892048