### PR TITLE
VisualStudio debugger start performance - use xcopy instead fo CMake copy_directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1510,10 +1510,17 @@ if(UNIX AND USE_SYMLINKS)
     COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/src/test" "${CMAKE_CURRENT_BINARY_DIR}/src/test"
     COMMENT "Symlinking test data to build directory..."
   )
+elseif(WIN32)
+  file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/test" CMAKE_CURRENT_SOURCE_TESTDATA_DIR_NATIVE)
+  file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/src/test/" CMAKE_CURRENT_BINARY_TESTDATA_DIR_NATIVE)
+  add_custom_target(mixxx-testdata
+    COMMAND xcopy ${CMAKE_CURRENT_SOURCE_TESTDATA_DIR_NATIVE} ${CMAKE_CURRENT_BINARY_TESTDATA_DIR_NATIVE} /s /d /q /y
+    COMMENT "Copying missing or modified test data files to build directory..."
+  )
 else()
   add_custom_target(mixxx-testdata
     COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/src/test" "${CMAKE_CURRENT_BINARY_DIR}/src/test"
-    COMMENT "Copying test data to build directory..."
+    COMMENT "Copying all test data files to build directory..."
   )
 endif()
 add_dependencies(mixxx-test mixxx-testdata)
@@ -1540,14 +1547,27 @@ if(UNIX AND USE_SYMLINKS)
     COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/script" "${CMAKE_CURRENT_BINARY_DIR}/script"
     COMMENT "Symlinking to build directory..."
   )
+elseif(WIN32)
+  file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/res" CMAKE_CURRENT_SOURCE_RES_DIR_NATIVE)
+  file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/res/" CMAKE_CURRENT_BINARY_RES_DIR_NATIVE)
+  add_custom_target(mixxx-res
+    COMMAND xcopy ${CMAKE_CURRENT_SOURCE_RES_DIR_NATIVE} ${CMAKE_CURRENT_BINARY_RES_DIR_NATIVE} /s /d /q /y
+    COMMENT "Copying missing or modified resources files to build directory..."
+  )
+  file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/script" CMAKE_CURRENT_SOURCE_SCRIPT_DIR_NATIVE)
+  file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/script/" CMAKE_CURRENT_BINARY_SCRIPT_DIR_NATIVE)
+  add_custom_target(mixxx-script
+    COMMAND xcopy ${CMAKE_CURRENT_SOURCE_SCRIPT_DIR_NATIVE} ${CMAKE_CURRENT_BINARY_SCRIPT_DIR_NATIVE} /s /d /q /y
+    COMMENT "Copying missing or modified QScriptEngine extension files to build directory..."
+  )
 else()
   add_custom_target(mixxx-res
     COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/res" "${CMAKE_CURRENT_BINARY_DIR}/res"
-    COMMENT "Copying resources to build directory..."
+    COMMENT "Copying all resources files to build directory..."
   )
   add_custom_target(mixxx-script
     COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/script" "${CMAKE_CURRENT_BINARY_DIR}/script"
-    COMMENT "Copying QScriptEngine extensions to build directory..."
+    COMMENT "Copying all QScriptEngine extension files to build directory..."
   )
 endif()
 add_dependencies(mixxx-lib mixxx-res mixxx-script)


### PR DESCRIPTION
Use xcopy <source> <target> /s /d /q /y instead of CMake copy_directory now, which is faster and copies only changed or missing files.
This only copies files, which were touched since last build or debugger start.