### PR TITLE
only start in fullscreen if enabled in Preferences or via command line arg

### DIFF
--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -699,7 +699,23 @@ void MixxxMainWindow::finalize() {
     m_pTrackCollectionManager->stopLibraryScan();
     m_pLibrary->stopPendingTasks();
 
-   // Save the current window state (position, maximized, etc)
+    // Save the current window state (position, maximized, etc)
+    // Note(ronso0): Unfortunately saveGeometry() also stores the fullscreen state.
+    // On next start restoreGeometry would enable fullscreen mode even though that
+    // might not be requested (no '--fullscreen' command line arg and
+    // [Config],StartInFullscreen is '0'.
+    // https://bugs.launchpad.net/mixxx/+bug/1882474
+    // https://bugs.launchpad.net/mixxx/+bug/1909485
+    // So let's quit fullscreen if StartInFullscreen is not checked in Preferences.
+    bool fullscreenPref = m_pSettingsManager->settings()->getValue<bool>(
+            ConfigKey("[Config]", "StartInFullscreen"));
+    if (isFullScreen() && !fullscreenPref) {
+        slotViewFullScreen(false);
+        // After returning from fullscreen the main window incl. window decoration
+        // may be too large for the screen.
+        // Maximize the window so we can store a geometry that fits the screen.
+        showMaximized();
+    }
     m_pSettingsManager->settings()->set(ConfigKey("[MainWindow]", "geometry"),
         QString(saveGeometry().toBase64()));
     m_pSettingsManager->settings()->set(ConfigKey("[MainWindow]", "state"),

--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -73,10 +73,7 @@ DlgPrefInterface::DlgPrefInterface(QWidget * parent, MixxxMainWindow * mixxx,
            m_bRebootMixxxView(false) {
     setupUi(this);
 
-    //
     // Locale setting
-    //
-
     // Iterate through the available locales and add them to the combobox
     // Borrowed following snippet from http://qt-project.org/wiki/How_to_create_a_multi_language_application
     QString translationsFolder = m_pConfig->getResourcePath() + "translations/";
@@ -161,15 +158,11 @@ DlgPrefInterface::DlgPrefInterface(QWidget * parent, MixxxMainWindow * mixxx,
     spinBoxScaleFactor->hide();
     labelScaleFactor->hide();
 
-    //
     // Start in fullscreen mode
-    //
     checkBoxStartFullScreen->setChecked(m_pConfig->getValueString(
                     ConfigKey("[Config]", "StartInFullscreen")).toInt()==1);
 
-    //
     // Screensaver mode
-    //
     comboBoxScreensaver->clear();
     comboBoxScreensaver->addItem(tr("Allow screensaver to run"),
             static_cast<int>(mixxx::ScreenSaverPreference::PREVENT_OFF));
@@ -181,10 +174,7 @@ DlgPrefInterface::DlgPrefInterface(QWidget * parent, MixxxMainWindow * mixxx,
     int inhibitsettings = static_cast<int>(mixxx->getInhibitScreensaver());
     comboBoxScreensaver->setCurrentIndex(comboBoxScreensaver->findData(inhibitsettings));
 
-    //
     // Tooltip configuration
-    //
-
     // Initialize checkboxes to match config
     loadTooltipPreferenceFromConfig();
     slotSetTooltips();  // Update disabled status of "only library" checkbox


### PR DESCRIPTION
... by simply exiting fullscreen and maximizing the window if fullscreen is not enabled in Preferences.

The issue is that saveGeometry() also saves the fullscreen state in `[MainWindow] geometry` which is restored on next start regardless of the explicit configuration. Then Mixxx doesn't see a fullscreen flag thus the Fullscreen checkbox is not updated programmatically.
I didn't investigate how that would affect other actions in the View menu and can render those hotkeys unfunctional when restoring unrequested fullscreen mode, but but hopefully that's fixed, too.

https://bugs.launchpad.net/mixxx/+bug/1882474
https://bugs.launchpad.net/mixxx/+bug/1904135
https://bugs.launchpad.net/mixxx/+bug/1909485

one small issue remains:
when Mixxx is started in fullscreen after being shutdown in windowed mode the launch progress is in windowed mode.
when starting in fullscreen mode repeatedly the launch progress is also fullscreen.

