### PR TITLE
last_played_at: Fix debug assertion for invalid/missing time stamps

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -633,6 +633,9 @@ QVariant BaseTrackTableModel::roleValue(
                 // cached in memory (local time)
                 lastPlayedAt = rawValue.toDateTime().toUTC();
             }
+            if (!lastPlayedAt.isValid()) {
+                return QVariant();
+            }
             DEBUG_ASSERT(lastPlayedAt.timeSpec() == Qt::UTC);
             return mixxx::localDateTimeFromUtc(lastPlayedAt);
         }


### PR DESCRIPTION
A debug assertion is triggered for tracks that have never been played before, i.e. where last_played_at is NULL.