### PR TITLE
DlgPrefController: display mapping info regardless of enabled state

### DIFF
--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -61,7 +61,7 @@ DlgPrefController::DlgPrefController(QWidget* parent,
 
     // When the user picks a preset, load it.
     connect(m_ui.comboBoxPreset,
-            QOverload<int>::of(&QComboBox::activated),
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
             this,
             &DlgPrefController::slotPresetSelected);
 
@@ -433,7 +433,7 @@ void DlgPrefController::slotApply() {
     }
     m_ui.chkEnabledDevice->setChecked(bEnabled);
 
-    // The shouldn't be dirty at this pint because we already tried to save
+    // The shouldn't be dirty at this point because we already tried to save
     // it. If that failed, don't apply the preset.
     if (m_pPreset && m_pPreset->isDirty()) {
         return;

--- a/src/preferences/dialog/dlgprefbeats.cpp
+++ b/src/preferences/dialog/dlgprefbeats.cpp
@@ -27,7 +27,7 @@ DlgPrefBeats::DlgPrefBeats(QWidget* parent, UserSettingsPointer pConfig)
 
     // Connections
     connect(comboBoxBeatPlugin,
-            QOverload<int>::of(&QComboBox::activated),
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
             this,
             &DlgPrefBeats::pluginSelected);
     connect(checkBoxAnalyzerEnabled,

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -76,7 +76,7 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent,
         pControl->set(static_cast<int>(m_cueMode));
     }
     connect(ComboBoxCueMode,
-            QOverload<int>::of(&QComboBox::activated),
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
             this,
             &DlgPrefDeck::slotCueModeCombobox);
 
@@ -227,7 +227,7 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent,
     ComboBoxRateRange->addItem(tr("50%"), 50);
     ComboBoxRateRange->addItem(tr("90%"), 90);
     connect(ComboBoxRateRange,
-            QOverload<int>::of(&QComboBox::activated),
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
             this,
             &DlgPrefDeck::slotRateRangeComboBox);
 

--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -149,11 +149,11 @@ DlgPrefInterface::DlgPrefInterface(QWidget * parent, MixxxMainWindow * mixxx,
     }
 
     connect(ComboBoxSkinconf,
-            QOverload<int>::of(&QComboBox::activated),
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
             this,
             &DlgPrefInterface::slotSetSkin);
     connect(ComboBoxSchemeconf,
-            QOverload<int>::of(&QComboBox::activated),
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
             this,
             &DlgPrefInterface::slotSetScheme);
 


### PR DESCRIPTION
Previously, mapping info was not displayed when a controller was not enabled, only after manually re-selecting the mapping.
Solved by connecting the respective slot to `&QComboBox::activated` instead of `&QComboBox::currentIndexChanged`
(took me 2 hours and mayn qDebug lines to figure this out...)

I changed this for a few other comboboxes in Preferences, too. Even though everything seems to work there the change doesn't hurt.