### PR TITLE
Save CUE Sheet text as UTF-8

### DIFF
--- a/src/engine/sidechain/enginerecord.cpp
+++ b/src/engine/sidechain/enginerecord.cpp
@@ -328,11 +328,19 @@ bool EngineRecord::openCueFile() {
                                 .toUtf8());
     }
 
-    m_cueFile.write(QString("FILE \"%1\" %2\n").arg(QFileInfo(m_fileName).fileName()                                                                        //strip path
-                                                               .replace(QString("\""), QString("\\\"")),                                                    // escape doublequote
-                                                       (m_encoding == ENCODING_MP3) ? ENCODING_MP3 : (m_encoding == ENCODING_AIFF) ? ENCODING_AIFF : "WAVE" // MP3 and AIFF are recognized but other formats just use WAVE.
-                                                       )
-                            .toUtf8());
+    m_cueFile.write(
+            QString("FILE \"%1\" %2\n")
+                    .arg(QFileInfo(m_fileName)
+                                    .fileName() //strip path
+                                    .replace(QString("\""),
+                                            QString("\\\"")), // escape doublequote
+                            (m_encoding == ENCODING_MP3)
+                                    ? ENCODING_MP3
+                                    : (m_encoding == ENCODING_AIFF)
+                                            ? ENCODING_AIFF
+                                            : "WAVE" // MP3 and AIFF are recognized but other formats just use WAVE.
+                            )
+                    .toUtf8());
     return true;
 }
 

--- a/src/engine/sidechain/enginerecord.cpp
+++ b/src/engine/sidechain/enginerecord.cpp
@@ -317,7 +317,8 @@ bool EngineRecord::openCueFile() {
     }
 
     // Write UTF-8 BOM at the start of the file
-    m_cueFile.write(QByteArray("\xef\xbb\xbf"));
+    const char* const kUtf8Bom = "\xef\xbb\xbf";
+    m_cueFile.write(kUtf8Bom);
 
     if (m_baAuthor.length() > 0) {
         m_cueFile.write(QString("PERFORMER \"%1\"\n")

--- a/src/engine/sidechain/enginerecord.cpp
+++ b/src/engine/sidechain/enginerecord.cpp
@@ -239,7 +239,7 @@ void EngineRecord::writeCueLine() {
     // for the track detection code.
     m_cueFile.write(QString("    INDEX 01 %1:%2\n")
                             .arg(getRecordedDurationStr())
-                            .arg((double)cueFrame, 2, 'f', 0, '0')
+                            .arg(static_cast<double>(cueFrame), 2, 'f', 0, '0')
                             .toUtf8());
 }
 

--- a/src/engine/sidechain/enginerecord.cpp
+++ b/src/engine/sidechain/enginerecord.cpp
@@ -316,6 +316,10 @@ bool EngineRecord::openCueFile() {
         return false;
     }
 
+    // Write UTF-8 BOM at the start of the file
+    unsigned char bom[] = { 0xEF,0xBB,0xBF };
+    m_cueFile.write((char*)bom, sizeof(bom));
+
     if (m_baAuthor.length() > 0) {
         m_cueFile.write(QString("PERFORMER \"%1\"\n")
                                 .arg(QString(m_baAuthor).replace(QString("\""), QString("\\\"")))

--- a/src/engine/sidechain/enginerecord.cpp
+++ b/src/engine/sidechain/enginerecord.cpp
@@ -316,10 +316,6 @@ bool EngineRecord::openCueFile() {
         return false;
     }
 
-    // Write UTF-8 BOM at the start of the file
-    const char* const kUtf8Bom = "\xef\xbb\xbf";
-    m_cueFile.write(kUtf8Bom);
-
     if (m_baAuthor.length() > 0) {
         m_cueFile.write(QString("PERFORMER \"%1\"\n")
                                 .arg(QString(m_baAuthor).replace(QString("\""), QString("\\\"")))

--- a/src/engine/sidechain/enginerecord.cpp
+++ b/src/engine/sidechain/enginerecord.cpp
@@ -317,8 +317,7 @@ bool EngineRecord::openCueFile() {
     }
 
     // Write UTF-8 BOM at the start of the file
-    unsigned char bom[] = { 0xEF,0xBB,0xBF };
-    m_cueFile.write((char*)bom, sizeof(bom));
+    m_cueFile.write(QByteArray("\xef\xbb\xbf"));
 
     if (m_baAuthor.length() > 0) {
         m_cueFile.write(QString("PERFORMER \"%1\"\n")

--- a/src/engine/sidechain/enginerecord.cpp
+++ b/src/engine/sidechain/enginerecord.cpp
@@ -224,20 +224,23 @@ void EngineRecord::writeCueLine() {
                                     % 75);
 
     m_cueFile.write(QString("  TRACK %1 AUDIO\n")
-                    .arg((double)m_cueTrack, 2, 'f', 0, '0')
-                    .toUtf8());
+                            .arg((double)m_cueTrack, 2, 'f', 0, '0')
+                            .toUtf8());
 
     m_cueFile.write(QString("    TITLE \"%1\"\n")
-        .arg(m_pCurrentTrack->getTitle()).toUtf8());
+                            .arg(m_pCurrentTrack->getTitle())
+                            .toUtf8());
     m_cueFile.write(QString("    PERFORMER \"%1\"\n")
-        .arg(m_pCurrentTrack->getArtist()).toUtf8());
+                            .arg(m_pCurrentTrack->getArtist())
+                            .toUtf8());
 
     // Woefully inaccurate (at the seconds level anyways).
     // We'd need a signal fired state tracker
     // for the track detection code.
     m_cueFile.write(QString("    INDEX 01 %1:%2\n")
-                    .arg(getRecordedDurationStr())
-                    .arg((double)cueFrame, 2, 'f', 0, '0').toUtf8());
+                            .arg(getRecordedDurationStr())
+                            .arg((double)cueFrame, 2, 'f', 0, '0')
+                            .toUtf8());
 }
 
 // Encoder calls this method to write compressed audio
@@ -315,23 +318,21 @@ bool EngineRecord::openCueFile() {
 
     if (m_baAuthor.length() > 0) {
         m_cueFile.write(QString("PERFORMER \"%1\"\n")
-                        .arg(QString(m_baAuthor).replace(QString("\""), QString("\\\"")))
-                        .toUtf8());
+                                .arg(QString(m_baAuthor).replace(QString("\""), QString("\\\"")))
+                                .toUtf8());
     }
 
     if (m_baTitle.length() > 0) {
         m_cueFile.write(QString("TITLE \"%1\"\n")
-                        .arg(QString(m_baTitle).replace(QString("\""), QString("\\\"")))
-                        .toUtf8());
+                                .arg(QString(m_baTitle).replace(QString("\""), QString("\\\"")))
+                                .toUtf8());
     }
 
-    m_cueFile.write(QString("FILE \"%1\" %2\n").arg(
-            QFileInfo(m_fileName).fileName() //strip path
-                .replace(QString("\""), QString("\\\"")), // escape doublequote
-            (m_encoding == ENCODING_MP3) ? ENCODING_MP3  :
-            (m_encoding == ENCODING_AIFF) ? ENCODING_AIFF :
-            "WAVE" // MP3 and AIFF are recognized but other formats just use WAVE.
-        ).toUtf8());
+    m_cueFile.write(QString("FILE \"%1\" %2\n").arg(QFileInfo(m_fileName).fileName()                                                                        //strip path
+                                                               .replace(QString("\""), QString("\\\"")),                                                    // escape doublequote
+                                                       (m_encoding == ENCODING_MP3) ? ENCODING_MP3 : (m_encoding == ENCODING_AIFF) ? ENCODING_AIFF : "WAVE" // MP3 and AIFF are recognized but other formats just use WAVE.
+                                                       )
+                            .toUtf8());
     return true;
 }
 

--- a/src/engine/sidechain/enginerecord.cpp
+++ b/src/engine/sidechain/enginerecord.cpp
@@ -225,19 +225,19 @@ void EngineRecord::writeCueLine() {
 
     m_cueFile.write(QString("  TRACK %1 AUDIO\n")
                     .arg((double)m_cueTrack, 2, 'f', 0, '0')
-                    .toLatin1());
+                    .toUtf8());
 
     m_cueFile.write(QString("    TITLE \"%1\"\n")
-        .arg(m_pCurrentTrack->getTitle()).toLatin1());
+        .arg(m_pCurrentTrack->getTitle()).toUtf8());
     m_cueFile.write(QString("    PERFORMER \"%1\"\n")
-        .arg(m_pCurrentTrack->getArtist()).toLatin1());
+        .arg(m_pCurrentTrack->getArtist()).toUtf8());
 
     // Woefully inaccurate (at the seconds level anyways).
     // We'd need a signal fired state tracker
     // for the track detection code.
     m_cueFile.write(QString("    INDEX 01 %1:%2\n")
                     .arg(getRecordedDurationStr())
-                    .arg((double)cueFrame, 2, 'f', 0, '0').toLatin1());
+                    .arg((double)cueFrame, 2, 'f', 0, '0').toUtf8());
 }
 
 // Encoder calls this method to write compressed audio
@@ -316,13 +316,13 @@ bool EngineRecord::openCueFile() {
     if (m_baAuthor.length() > 0) {
         m_cueFile.write(QString("PERFORMER \"%1\"\n")
                         .arg(QString(m_baAuthor).replace(QString("\""), QString("\\\"")))
-                        .toLatin1());
+                        .toUtf8());
     }
 
     if (m_baTitle.length() > 0) {
         m_cueFile.write(QString("TITLE \"%1\"\n")
                         .arg(QString(m_baTitle).replace(QString("\""), QString("\\\"")))
-                        .toLatin1());
+                        .toUtf8());
     }
 
     m_cueFile.write(QString("FILE \"%1\" %2\n").arg(
@@ -331,7 +331,7 @@ bool EngineRecord::openCueFile() {
             (m_encoding == ENCODING_MP3) ? ENCODING_MP3  :
             (m_encoding == ENCODING_AIFF) ? ENCODING_AIFF :
             "WAVE" // MP3 and AIFF are recognized but other formats just use WAVE.
-        ).toLatin1());
+        ).toUtf8());
     return true;
 }
 


### PR DESCRIPTION
About a year ago I noticed that track and artist names with non-Latin characters are rendered as question marks in the CUE files created by Mixxx when recording a set.

I saw a [bug about this](https://bugs.launchpad.net/mixxx/+bug/1856890) in Launchpad, but it did not look as it had much activity.

Two days ago I recorded a set full of Japanese characters, and the result is a total mess, so I gave a go at making Mixxx save CUE files in UTF-8 instead of Latin1.

I have built the code with the patch I am submitting, and the resulting CUE file has been saved in UTF-8 with all names intact.

If you (Mixxx developers) think this patch is suitable for inclusion in Mixxx and will not break anything else, please do merge it. I think many will find it of use.

I am not a C++ developer by any means, I just looked for the code that deals with CUE sheets and edited it.