### PR TITLE
Disable speex and theora in internal libshout

### DIFF
--- a/lib/libshout/CMakeLists.txt
+++ b/lib/libshout/CMakeLists.txt
@@ -30,14 +30,12 @@ add_library(shout_mixxx STATIC
   src/format_mp3.c
   src/codec_vorbis.c
   src/codec_opus.c
-  src/codec_theora.c
-  src/codec_speex.c
   src/tls.c
 )
 
 target_compile_definitions(shout_mixxx PRIVATE HAVE_CONFIG_H)
 target_compile_options(shout_mixxx PRIVATE -pthread -Wall)
 
-target_link_libraries(shout_mixxx ogg vorbis theora speex OpenSSL::SSL OpenSSL::Crypto)
+target_link_libraries(shout_mixxx ogg vorbis OpenSSL::SSL OpenSSL::Crypto)
 
 

--- a/lib/libshout/config.h
+++ b/lib/libshout/config.h
@@ -59,7 +59,7 @@
 #define HAVE_SOCKLEN_T 1
 
 /* Define if you want speex streams supported */
-#define HAVE_SPEEX 1
+//define HAVE_SPEEX 1
 
 /* Define to 1 if you have the <stdint.h> header file. */
 #define HAVE_STDINT_H 1
@@ -95,7 +95,7 @@
 #define HAVE_SYS_UIO_H 1
 
 /* Define if you want theora streams supported */
-#define HAVE_THEORA 1
+//define HAVE_THEORA 1
 
 /* Define to 1 if you have the <unistd.h> header file. */
 #define HAVE_UNISTD_H 1


### PR DESCRIPTION
Hey, everyone!

Doing a fresh build on a gentoo arm64 box it turned out that speex and libtheora are hard dependencies for the internal libshout.

They aren't included as dependencies on CMakeLists.txt which causes the build to just error out if you don't have speex and libtheora installed on your system.

@Be-ing suggested building the internal libshout without support for speex and libtheora, and this is the approach I have taken since it reduces bloat and it's two unneeded dependencies less to tackle with.

I do not have access to a ShoutCast server to test this doesn't break ShoutCast though and also, I wasn't really sure about styling when it comes to the #defines in config.h. I commented it out. Should I yank it out?