### PR TITLE
ARM compile options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,7 +201,7 @@ elseif(GNU_GCC OR LLVM_CLANG)
         # TODO(rryan): macOS can use SSE3, and possibly SSE 4.1 once
         # we require macOS 10.12.
         # https://stackoverflow.com/questions/45917280/mac-osx-minumum-support-sse-version
-elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm")
+        elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm")
         add_compile_options(
           -mflat-abi=hard
           -mfpu=neon

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,7 @@ elseif(GNU_GCC OR LLVM_CLANG)
         add_compile_options(
           -mflat-abi=hard
           -mfpu=neon
-      )
+        )
       endif()
       # this sets macros __SSE2_MATH__ __SSE_MATH__ __SSE2__ __SSE__
       # This should be our default build for distribution

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,11 +201,11 @@ elseif(GNU_GCC OR LLVM_CLANG)
         # TODO(rryan): macOS can use SSE3, and possibly SSE 4.1 once
         # we require macOS 10.12.
         # https://stackoverflow.com/questions/45917280/mac-osx-minumum-support-sse-version
-      elseif(CMAKE_SYSTEM_PROCESSOR EQUAL "arm")
+elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm")
         add_compile_options(
           -mflat-abi=hard
           -mfpu=neon
-        )
+       )
       endif()
       # this sets macros __SSE2_MATH__ __SSE_MATH__ __SSE2__ __SSE__
       # This should be our default build for distribution
@@ -224,7 +224,7 @@ elseif(GNU_GCC OR LLVM_CLANG)
       # Note: requires gcc >= 4.2.0
       # macros like __SSE2_MATH__ __SSE_MATH__ __SSE2__ __SSE__
       # are set automatically
-      if(CMAKE_SYSTEM_PROCESSOR EQUAL "arm")
+      if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm")
         add_compile_options(
           -mfloat-abi=hard
           -mfpu=neon

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,11 +201,11 @@ elseif(GNU_GCC OR LLVM_CLANG)
         # TODO(rryan): macOS can use SSE3, and possibly SSE 4.1 once
         # we require macOS 10.12.
         # https://stackoverflow.com/questions/45917280/mac-osx-minumum-support-sse-version
-        elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm")
+      elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm")
         add_compile_options(
           -mflat-abi=hard
           -mfpu=neon
-       )
+      )
       endif()
       # this sets macros __SSE2_MATH__ __SSE_MATH__ __SSE2__ __SSE__
       # This should be our default build for distribution


### PR DESCRIPTION
CMake documentation is clear: EQUAL in if blocks is for number comparison. Therefore we should use STREQUAL if we want to properly set the compiler options for aarch32.