### PR TITLE
Enable flush-to-zero on aarch64

### DIFF
--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -435,15 +435,9 @@ void SoundDeviceNetwork::callbackProcessClkRef() {
         } else {
              qDebug() << "SSE: Flush to zero mode already enabled";
         }
-        // verify if flush to zero or denormals to zero works
-        // test passes if one of the two flag is set.
-        volatile double doubleMin = DBL_MIN; // the smallest normalized double
-        VERIFY_OR_DEBUG_ASSERT(doubleMin / 2 == 0.0) {
-            qWarning() << "SSE: Denormals to zero mode is not working. EQs and effects may suffer high CPU load";
-        } else {
-            qDebug() << "SSE: Denormals to zero mode is working";
-        }
-#elif defined(aarch64)
+#endif
+
+#ifdef aarch64
         // Flush-to-zero on aarch64 is controlled by the Floating-point Control Register
         // Load the register into our variable.
         int savedFPCR;
@@ -455,21 +449,17 @@ void SoundDeviceNetwork::callbackProcessClkRef() {
         asm volatile("msr FPCR, %[src]"
                      :
                      : [ src ] "r"(savedFPCR | (1 << 24)));
-
+#endif
         // verify if flush to zero or denormals to zero works
         // test passes if one of the two flag is set.
         volatile double doubleMin = DBL_MIN; // the smallest normalized double
         VERIFY_OR_DEBUG_ASSERT(doubleMin / 2 == 0.0) {
-            qWarning() << "aarch64 FPCR: Flush-to-zero mode is not working. "
+            qWarning() << "Network Sound: Denormals to zero mode is not working. "
                           "EQs and effects may suffer high CPU load";
         }
         else {
-            qDebug() << "aarch64 FPCR: Flush-to-zero mode is working";
+            qDebug() << "Network Sound: Denormals to zero mode is working";
         }
-#else
-        qWarning() << "No SSE or aarch64 FPCR: No denormals to zero mode "
-                      "available. EQs and effects may suffer high CPU load";
-#endif
     }
 
     m_pSoundManager->readProcess();

--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -443,8 +443,32 @@ void SoundDeviceNetwork::callbackProcessClkRef() {
         } else {
             qDebug() << "SSE: Denormals to zero mode is working";
         }
+#elif defined(aarch64)
+        // Flush-to-zero on aarch64 is controlled by the Floating-point Control Register
+        // Load the register into our variable.
+        int savedFPCR;
+        asm volatile("mrs %[savedFPCR], FPCR"
+                     : [ savedFPCR ] "=r"(savedFPCR));
+
+        qDebug() << "aarch64 FPCR: setting bit 24 to 1 to enable Flush-to-zero";
+        // Bit 24 is the flush-to-zero mode control bit. Setting it to 1 flushes denormals to 0.
+        asm volatile("msr FPCR, %[src]"
+                     :
+                     : [ src ] "r"(savedFPCR | (1 << 24)));
+
+        // verify if flush to zero or denormals to zero works
+        // test passes if one of the two flag is set.
+        volatile double doubleMin = DBL_MIN; // the smallest normalized double
+        VERIFY_OR_DEBUG_ASSERT(doubleMin / 2 == 0.0) {
+            qWarning() << "aarch64 FPCR: Flush-to-zero mode is not working. "
+                          "EQs and effects may suffer high CPU load";
+        }
+        else {
+            qDebug() << "aarch64 FPCR: Flush-to-zero mode is working";
+        }
 #else
-        qWarning() << "No SSE: No denormals to zero mode available. EQs and effects may suffer high CPU load";
+        qWarning() << "No SSE or aarch64 FPCR: No denormals to zero mode "
+                      "available. EQs and effects may suffer high CPU load";
 #endif
     }
 

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -904,6 +904,21 @@ int SoundDevicePortAudio::callbackProcessClkRef(
         qWarning() << "No SSE: No denormals to zero mode available. EQs and effects may suffer high CPU load";
 #endif
 #endif
+
+#ifdef aarch64
+        // Flush-to-zero on aarch64 is controlled by the Floating-point Control Register
+        // Load the register into our variable.
+        int savedFPCR;
+        asm volatile("mrs %[savedFPCR], FPCR"
+                     : [ savedFPCR ] "=r"(savedFPCR));
+
+        qDebug() << "aarch64 FPCR: setting bit 24 to 1 to enable Flush-to-zero";
+        // Bit 24 is the flush-to-zero mode control bit. Setting it to 1 flushes denormals to 0.
+        asm volatile("msr FPCR, %[src]"
+                     :
+                     : [ src ] "r"(savedFPCR | (1 << 24)));
+#endif
+
         // verify if flush to zero or denormals to zero works
         // test passes if one of the two flag is set.
         volatile double doubleMin = DBL_MIN; // the smallest normalized double


### PR DESCRIPTION
Flush-to-zero on the aarch64 architecture is controlled by bit 24 of the FPCR register. This commit enables that and thus theoretically improves performance. Should I add a qDebug() to it, saying that it's setting that bit? Also, I don't know how to test the performance increase, if somebody would like to direct me I'd be happy to test it.