### PR TITLE
read Shout_VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2346,7 +2346,7 @@ if(BROADCAST)
     # Check if system lib is at least 2.4.4 and not suffering bug
     # https://bugs.launchpad.net/mixxx/+bug/1833225
     if(Shout_FOUND AND Shout_VERSION VERSION_LESS 2.4.4)
-        message(STATUS "Installed libshout version is suffering from bug lp1833225")
+        message(STATUS "Installed libshout version: ${Shout_VERSION} is suffering from bug lp1833225")
     endif()
     if(NOT Shout_FOUND OR Shout_VERSION VERSION_LESS 2.4.4)
       # Fall back to internal libraray in the lib tree

--- a/cmake/modules/FindShout.cmake
+++ b/cmake/modules/FindShout.cmake
@@ -30,6 +30,8 @@ This will define the following variables:
   Libraries needed to link to Shout.
 ``Shout_DEFINITIONS``
   Compile definitions needed to use Shout.
+``Shout_VERSION``
+  Shout Version.
 
 Cache Variables
 ^^^^^^^^^^^^^^^
@@ -73,6 +75,7 @@ if(Shout_FOUND)
   set(Shout_LIBRARIES "${Shout_LIBRARY}")
   set(Shout_INCLUDE_DIRS "${Shout_INCLUDE_DIR}")
   set(Shout_DEFINITIONS ${PC_Shout_CFLAGS_OTHER})
+  set(Shout_VERSION ${PC_Shout_VERSION})
 
   if(NOT TARGET Shout::Shout)
     add_library(Shout::Shout UNKNOWN IMPORTED)


### PR DESCRIPTION
This fixed the issue that cmake uses always the internal shout version. 
Reported here: 
https://github.com/mixxxdj/mixxx/pull/2714#issuecomment-753219898