### PR TITLE
Sandbox: remove erroneous and superfluous home directory check

### DIFF
--- a/src/util/sandbox.cpp
+++ b/src/util/sandbox.cpp
@@ -377,8 +377,8 @@ QString Sandbox::migrateOldSettings() {
     }
 
     QDir homeDir(homePath);
-    if (!homeDir.exists() || !homeDir.isReadable()) {
-        qCritical() << "Cannot read home directory" << homePath;
+    if (!homeDir.exists()) {
+        qCritical() << "Home directory does not exist" << homePath;
         return QString();
     }
 


### PR DESCRIPTION
This is only causing problems, not solving any:
https://mixxx.discourse.group/t/macos-big-sur-issue-and-temporary-resolution/20257/179