### PR TITLE
i18n: Fix ambiguous display names of translations

### DIFF
--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -79,29 +79,56 @@ DlgPrefInterface::DlgPrefInterface(QWidget * parent, MixxxMainWindow * mixxx,
 
     // Iterate through the available locales and add them to the combobox
     // Borrowed following snippet from http://qt-project.org/wiki/How_to_create_a_multi_language_application
-    QString translationsFolder = m_pConfig->getResourcePath() + "translations/";
+    const auto translationsDir = QDir(
+            m_pConfig->getResourcePath() +
+            QStringLiteral("translations/"));
+    DEBUG_ASSERT(translationsDir.exists());
 
-    QDir translationsDir(translationsFolder);
     QStringList fileNames = translationsDir.entryList(QStringList("mixxx_*.qm"));
-    fileNames.push_back("mixxx_en_US.qm"); // add source language as a fake value
+    // Add source language as a fake value
+    DEBUG_ASSERT(!fileNames.contains(QStringLiteral("mixxx_en_US.qm")));
+    fileNames.push_back(QStringLiteral("mixxx_en_US.qm"));
 
-    for (int i = 0; i < fileNames.size(); ++i) {
-        // Extract locale from filename
-        QString locale = fileNames[i];
-        locale.truncate(locale.lastIndexOf('.'));
-        locale.remove(0, locale.indexOf('_') + 1);
-        QLocale qlocale = QLocale(locale);
+    for (const auto& fileName : qAsConst(fileNames)) {
+        // Extract locale name from file name
+        QString localeName = fileName;
+        // Strip prefix
+        DEBUG_ASSERT(localeName.startsWith(QStringLiteral("mixxx_")));
+        localeName.remove(0, QStringLiteral("mixxx_").length());
+        // Strip file extension
+        localeName.truncate(localeName.lastIndexOf('.'));
+        // Convert to QLocale name format. Unfortunately the translation files
+        // use inconsistent language/country separators, i.e. both '-' and '_'.
+        auto localeNameFixed = localeName;
+        localeNameFixed.replace('-', '_');
+        const auto locale = QLocale(localeNameFixed);
 
-        QString lang = QLocale::languageToString(qlocale.language());
-        QString country = QLocale::countryToString(qlocale.country());
-        if (lang == "C") { // Ugly hack to remove the non-resolving locales
+        const QString languageName = QLocale::languageToString(locale.language());
+        // Ugly hack to skip non-resolvable locales
+        if (languageName == QStringLiteral("C")) {
+            qWarning() << "Unsupported locale" << localeNameFixed;
             continue;
         }
-        lang = QString("%1 (%2)").arg(lang, country);
-        ComboBoxLocale->addItem(lang, locale); // locale as userdata (for storing to config)
+        QString countryName;
+        // Ugly hack to detect locales with an explicitly specified country.
+        // https://doc.qt.io/qt-5/qlocale.html#QLocale-1
+        // "If country is not present, or is not a valid ISO 3166 code, the most
+        // appropriate country is chosen for the specified language."
+        if (localeNameFixed.contains('_')) {
+            countryName = QLocale::countryToString(locale.country());
+            DEBUG_ASSERT(!countryName.isEmpty());
+        }
+        QString displayName = languageName;
+        if (!countryName.isEmpty()) {
+            displayName += QStringLiteral(" (") + countryName + ')';
+        }
+        // The locale name is stored in the config
+        ComboBoxLocale->addItem(displayName, localeName);
     }
-    ComboBoxLocale->model()->sort(0); // Sort languages list
-    ComboBoxLocale->insertItem(0, "System", ""); // System default locale - insert at the top
+    // Sort languages list...
+    ComboBoxLocale->model()->sort(0);
+    // ...and then insert entry for default system locale at the top
+    ComboBoxLocale->insertItem(0, QStringLiteral("System"), "");
 
     // Skin configurations
     QString sizeWarningString =


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1898469

Still ugly, but works.

I will not resolve the mentioned inconsistencies nor polish the code. Otherwise, please close this PR and open a new PR.