### PR TITLE
Fix a major connect bug

### DIFF
--- a/src/library/playlisttablemodel.cpp
+++ b/src/library/playlisttablemodel.cpp
@@ -15,6 +15,10 @@ PlaylistTableModel::PlaylistTableModel(QObject* parent,
         : BaseSqlTableModel(parent, pTrackCollectionManager, settingsNamespace),
           m_iPlaylistId(-1),
           m_showAll(showAll) {
+    connect(&m_pTrackCollectionManager->internalCollection()->getPlaylistDAO(),
+            &PlaylistDAO::tracksChanged,
+            this,
+            &PlaylistTableModel::playlistsChanged);
 }
 
 void PlaylistTableModel::initSortColumnMapping() {
@@ -155,11 +159,6 @@ void PlaylistTableModel::setTableModel(int playlistId) {
     setSearch("");
     setDefaultSort(fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_POSITION), Qt::AscendingOrder);
     setSort(defaultSortColumn(), defaultSortOrder());
-
-    connect(&m_pTrackCollectionManager->internalCollection()->getPlaylistDAO(),
-            &PlaylistDAO::tracksChanged,
-            this,
-            &PlaylistTableModel::playlistsChanged);
 }
 
 int PlaylistTableModel::addTracks(const QModelIndex& index,


### PR DESCRIPTION
loadModel method caused more and more connection to the tracksChanged
signals. After each reload, one more select is issued by the next
playlist change