### PR TITLE
Remove getBroadcastManager() if Mixxx is build without broadcast support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,7 +478,6 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/effects/effectslot.cpp
   src/effects/effectsmanager.cpp
   src/encoder/encoder.cpp
-  src/encoder/encoderbroadcastsettings.cpp
   src/encoder/encoderflacsettings.cpp
   src/encoder/encodermp3.cpp
   src/encoder/encodermp3settings.cpp
@@ -676,10 +675,6 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/musicbrainz/web/musicbrainzrecordingstask.cpp
   src/network/jsonwebtask.cpp
   src/network/webtask.cpp
-  src/preferences/broadcastprofile.cpp
-  src/preferences/broadcastsettings.cpp
-  src/preferences/broadcastsettings_legacy.cpp
-  src/preferences/broadcastsettingsmodel.cpp
   src/preferences/configobject.cpp
   src/preferences/dialog/dlgprefautodj.cpp
   src/preferences/dialog/dlgprefautodjdlg.ui
@@ -2408,6 +2403,11 @@ if(BROADCAST)
     src/preferences/dialog/dlgprefbroadcast.cpp
     src/broadcast/broadcastmanager.cpp
     src/engine/sidechain/shoutconnection.cpp
+    src/preferences/broadcastprofile.cpp
+    src/preferences/broadcastsettings.cpp
+    src/preferences/broadcastsettings_legacy.cpp
+    src/preferences/broadcastsettingsmodel.cpp
+    src/encoder/encoderbroadcastsettings.cpp
   )
   target_compile_definitions(mixxx-lib PUBLIC __BROADCAST__)
 endif()

--- a/src/coreservices.h
+++ b/src/coreservices.h
@@ -16,7 +16,9 @@ class EngineMaster;
 class SoundManager;
 class PlayerManager;
 class RecordingManager;
+#ifdef __BROADCAST__
 class BroadcastManager;
+#endif
 class ControllerManager;
 class VinylControlManager;
 class TrackCollectionManager;

--- a/src/coreservices.h
+++ b/src/coreservices.h
@@ -60,9 +60,11 @@ class CoreServices : public QObject {
         return m_pRecordingManager;
     }
 
+#ifdef __BROADCAST__
     std::shared_ptr<BroadcastManager> getBroadcastManager() const {
         return m_pBroadcastManager;
     }
+#endif
 
     std::shared_ptr<ControllerManager> getControllerManager() const {
         return m_pControllerManager;

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -23,7 +23,9 @@
 #ifdef __LILV__
 #include "effects/lv2/lv2backend.h"
 #endif
+#ifdef __BROADCAST__
 #include "broadcast/broadcastmanager.h"
+#endif
 #include "control/controlpushbutton.h"
 #include "controllers/controllermanager.h"
 #include "controllers/keyboard/keyboardeventfilter.h"

--- a/src/preferences/settingsmanager.cpp
+++ b/src/preferences/settingsmanager.cpp
@@ -27,8 +27,10 @@ SettingsManager::SettingsManager(const QString& settingsPath)
 
     ControlDoublePrivate::setUserConfig(m_pSettings);
 
+#ifdef __BROADCAST__
     m_pBroadcastSettings = BroadcastSettingsPointer(
                                new BroadcastSettings(m_pSettings));
+#endif
 }
 
 SettingsManager::~SettingsManager() {

--- a/src/preferences/settingsmanager.h
+++ b/src/preferences/settingsmanager.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#ifdef __BROADCAST__
 #include "preferences/broadcastsettings.h"
+#endif
 #include "preferences/usersettings.h"
 
 class SettingsManager {
@@ -12,9 +14,11 @@ class SettingsManager {
         return m_pSettings;
     }
 
+#ifdef __BROADCAST__
     BroadcastSettingsPointer broadcastSettings() const {
         return m_pBroadcastSettings;
     }
+#endif
 
     void save() {
         m_pSettings->save();
@@ -29,5 +33,7 @@ class SettingsManager {
 
     UserSettingsPointer m_pSettings;
     bool m_bShouldRescanLibrary;
+#ifdef __BROADCAST__
     BroadcastSettingsPointer m_pBroadcastSettings;
+#endif
 };

--- a/src/test/broadcastprofile_test.cpp
+++ b/src/test/broadcastprofile_test.cpp
@@ -1,3 +1,5 @@
+#ifdef __BROADCAST__
+
 #include <QFile>
 #include <QString>
 
@@ -215,3 +217,5 @@ TEST(BroadcastProfileTest, DefaultValues) {
 }
 
 } // namespace
+
+#endif // __BROADCAST__

--- a/src/test/broadcastsettings_test.cpp
+++ b/src/test/broadcastsettings_test.cpp
@@ -1,3 +1,5 @@
+#ifdef __BROADCAST__
+
 #include <QFile>
 #include <QString>
 
@@ -102,3 +104,5 @@ TEST_F(BroadcastSettingsTest, AddRemoveUpdateFromModel) {
 }
 
 } // namespace
+
+#endif // __BROADCAST__


### PR DESCRIPTION
This fixes building Mixxx with -DBROADCAST=off

My local build works now fine without broadcast. 