### PR TITLE
ColumnCache: Fix inconsistent column sorting

### DIFF
--- a/src/library/columncache.cpp
+++ b/src/library/columncache.cpp
@@ -120,8 +120,8 @@ void ColumnCache::setColumns(const QStringList& columns) {
     insertColumnSortByEnum(COLUMN_LIBRARYTABLE_TIMESPLAYED, kSortInt);
 
     insertColumnSortByEnum(COLUMN_PLAYLISTTRACKSTABLE_LOCATION, kSortNoCase);
-    insertColumnSortByEnum(COLUMN_PLAYLISTTRACKSTABLE_ARTIST, kSortNoCase);
-    insertColumnSortByEnum(COLUMN_PLAYLISTTRACKSTABLE_TITLE, kSortNoCase);
+    insertColumnSortByEnum(COLUMN_PLAYLISTTRACKSTABLE_ARTIST, kSortNoCaseLex);
+    insertColumnSortByEnum(COLUMN_PLAYLISTTRACKSTABLE_TITLE, kSortNoCaseLex);
 
     slotSetKeySortOrder(m_pKeyNotationCP->get());
 }

--- a/src/library/columncache.h
+++ b/src/library/columncache.h
@@ -110,7 +110,8 @@ class ColumnCache : public QObject {
         if (index < 0) {
             return;
         }
-        DEBUG_ASSERT(!m_columnSortByIndex.contains(index));
+        DEBUG_ASSERT(!m_columnSortByIndex.contains(index) ||
+                m_columnSortByIndex[index] == sortFormat);
         m_columnSortByIndex.insert(index, sortFormat);
     }
 


### PR DESCRIPTION
The modified debug assertion is wrong, i.e. too strict.