### PR TITLE
[Do not merge] Add very hacky way to bypass keylock when 1.0 tempo ratio

### DIFF
--- a/src/engine/bufferscalers/enginebufferscalerubberband.h
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "engine/bufferscalers/enginebufferscale.h"
+#include "util/defs.h"
 #include "util/memory.h"
 
 namespace RubberBand {
@@ -45,4 +46,8 @@ class EngineBufferScaleRubberBand : public EngineBufferScale {
 
     // Holds the playback direction
     bool m_bBackwards;
+
+    // Needed for special case when tempo slider is set to 0.0
+    // Just copies the samples over
+    SINT do_copy(CSAMPLE* buf, SINT buf_size);
 };

--- a/src/engine/bufferscalers/enginebufferscalest.cpp
+++ b/src/engine/bufferscalers/enginebufferscalest.cpp
@@ -1,5 +1,7 @@
 #include "engine/bufferscalers/enginebufferscalest.h"
 
+#include <QtDebug>
+
 #include "moc_enginebufferscalest.cpp"
 
 // Fixes redefinition warnings from SoundTouch.
@@ -133,6 +135,19 @@ double EngineBufferScaleST::scaleBuffer(
     SINT remaining_frames = getOutputSignal().samples2frames(iOutputBufferSize);
     CSAMPLE* read = pOutputBuffer;
     bool last_read_failed = false;
+
+    if (m_dTempoRatio == 1.0) {
+        qDebug() << "Soundtouch: tempo slider is at 0.00";
+        SINT samples_copied;
+
+        samples_copied = do_copy(pOutputBuffer, iOutputBufferSize);
+
+        double framesRead = m_dBaseRate * m_dTempoRatio *
+                getOutputSignal().samples2frames(samples_copied);
+
+        return framesRead;
+    }
+
     while (remaining_frames > 0) {
         SINT received_frames = m_pSoundTouch->receiveSamples(
                 read, remaining_frames);
@@ -172,5 +187,42 @@ double EngineBufferScaleST::scaleBuffer(
     // (*m_dPitchAdjust) so these two cancel out.
     double framesRead = m_dBaseRate * m_dTempoRatio * total_received_frames;
 
+    qDebug() << "Soundtouch: done scaling buffer";
+
     return framesRead;
+}
+
+SINT EngineBufferScaleST::do_copy(CSAMPLE* buf, SINT buf_size) {
+    SINT samples_needed = buf_size;
+    CSAMPLE* write_buf = buf;
+    // Protection against infinite read loops when (for example) we are
+    // reading from a broken file.
+    int read_failed_count = 0;
+    // We need to repeatedly call the RAMAN because the RAMAN does not bend
+    // over backwards to satisfy our request. It assumes you will continue
+    // to call getNextSamples until you receive the number of samples you
+    // wanted.
+    while (samples_needed > 0) {
+        SINT read_size = m_pReadAheadManager->getNextSamples(
+                (m_bBackwards ? -1.0 : 1.0) * m_dBaseRate * m_dTempoRatio,
+                write_buf,
+                samples_needed);
+        if (read_size == 0) {
+            if (++read_failed_count > 1) {
+                break;
+            } else {
+                continue;
+            }
+        }
+        samples_needed -= read_size;
+        write_buf += read_size;
+    }
+
+    // Instead of counting how many samples we got from the internal buffer
+    // and the RAMAN calls, just measure the difference between what we
+    // requested and what we still need.
+    SINT read_samples = buf_size - samples_needed;
+    // Zero the remaining samples if we didn't fill them.
+    SampleUtil::clear(write_buf, samples_needed);
+    return read_samples;
 }

--- a/src/engine/bufferscalers/enginebufferscalest.h
+++ b/src/engine/bufferscalers/enginebufferscalest.h
@@ -44,4 +44,8 @@ class EngineBufferScaleST : public EngineBufferScale {
 
     // Holds the playback direction.
     bool m_bBackwards;
+
+    // Needed for special case when tempo slider is set to 0.0
+    // Just copies the samples over
+    SINT do_copy(CSAMPLE* buf, SINT buf_size);
 };


### PR DESCRIPTION
This is not for merge specially after @daschuer pointed out that it will hurt performance more than solve anything even if it's worked on and fully optimized.

In case you want to test this, be sure the file you load to play matches your master sampling rate or it may sound sped up or down. I tried implementing resampling from the qm-dsp lib but it was helll and since this is sure not to be merged, why waste more time, right?

How to know if it's working: you should see lower CPU usage when tempo slider is set to 0.00 (centered).
What can happen: glitches specially when right-click resetting or moving up or down the tempo quickly