### PR TITLE
Cue: Fix conversion from samples to millis

### DIFF
--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -15,7 +15,7 @@ inline std::optional<double> positionSamplesToMillis(
         double positionSamples,
         mixxx::audio::SampleRate sampleRate) {
     VERIFY_OR_DEBUG_ASSERT(sampleRate.isValid()) {
-        return Cue::kNoPosition;
+        return std::nullopt;
     }
     if (positionSamples == Cue::kNoPosition) {
         return std::nullopt;


### PR DESCRIPTION
Only affects tracks with unknown or invalid sample rate