### PR TITLE
Trackmodel: Make some functions const and remove unused implementations

### DIFF
--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -373,7 +373,7 @@ void BaseSqlTableModel::setTable(const QString& tableName,
     m_bInitialized = true;
 }
 
-int BaseSqlTableModel::columnIndexFromSortColumnId(TrackModel::SortColumnId column) {
+int BaseSqlTableModel::columnIndexFromSortColumnId(TrackModel::SortColumnId column) const {
     if (column == TrackModel::SortColumnId::Invalid) {
         return -1;
     }
@@ -381,7 +381,7 @@ int BaseSqlTableModel::columnIndexFromSortColumnId(TrackModel::SortColumnId colu
     return m_columnIndexBySortColumnId[static_cast<int>(column)];
 }
 
-TrackModel::SortColumnId BaseSqlTableModel::sortColumnIdFromColumnIndex(int index) {
+TrackModel::SortColumnId BaseSqlTableModel::sortColumnIdFromColumnIndex(int index) const {
     return m_sortColumnIdByColumnIndex.value(index, TrackModel::SortColumnId::Invalid);
 }
 

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -58,8 +58,8 @@ class BaseSqlTableModel : public BaseTrackTableModel {
     void search(const QString& searchText, const QString& extraFilter = QString()) override;
     const QString currentSearch() const override;
 
-    TrackModel::SortColumnId sortColumnIdFromColumnIndex(int column) override;
-    int columnIndexFromSortColumnId(TrackModel::SortColumnId sortColumn) override;
+    TrackModel::SortColumnId sortColumnIdFromColumnIndex(int column) const override;
+    int columnIndexFromSortColumnId(TrackModel::SortColumnId sortColumn) const override;
 
     void hideTracks(const QModelIndexList& indices) override;
 

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -163,7 +163,7 @@ BrowseTableModel::BrowseTableModel(QObject* parent,
 BrowseTableModel::~BrowseTableModel() {
 }
 
-int BrowseTableModel::columnIndexFromSortColumnId(TrackModel::SortColumnId column) {
+int BrowseTableModel::columnIndexFromSortColumnId(TrackModel::SortColumnId column) const {
     if (column < TrackModel::SortColumnId::IdMin ||
             column >= TrackModel::SortColumnId::IdMax) {
         return -1;
@@ -172,7 +172,7 @@ int BrowseTableModel::columnIndexFromSortColumnId(TrackModel::SortColumnId colum
     return m_columnIndexBySortColumnId[static_cast<int>(column)];
 }
 
-TrackModel::SortColumnId BrowseTableModel::sortColumnIdFromColumnIndex(int index) {
+TrackModel::SortColumnId BrowseTableModel::sortColumnIdFromColumnIndex(int index) const {
     return m_sortColumnIdByColumnIndex.value(index, TrackModel::SortColumnId::Invalid);
 }
 
@@ -461,7 +461,7 @@ void BrowseTableModel::trackLoaded(const QString& group, TrackPointer pTrack) {
     }
 }
 
-bool BrowseTableModel::isColumnSortable(int column) {
+bool BrowseTableModel::isColumnSortable(int column) const {
     return COLUMN_PREVIEW != column;
 }
 

--- a/src/library/browse/browsetablemodel.h
+++ b/src/library/browse/browsetablemodel.h
@@ -69,9 +69,9 @@ class BrowseTableModel final : public QStandardItemModel, public virtual TrackMo
     Qt::ItemFlags flags(const QModelIndex &index) const override;
     bool setData(const QModelIndex& index, const QVariant& value, int role=Qt::EditRole) override;
     QAbstractItemDelegate* delegateForColumn(const int i, QObject* pParent) override;
-    bool isColumnSortable(int column) override;
-    TrackModel::SortColumnId sortColumnIdFromColumnIndex(int index) override;
-    int columnIndexFromSortColumnId(TrackModel::SortColumnId sortColumn) override;
+    bool isColumnSortable(int column) const override;
+    TrackModel::SortColumnId sortColumnIdFromColumnIndex(int index) const override;
+    int columnIndexFromSortColumnId(TrackModel::SortColumnId sortColumn) const override;
 
   public slots:
     void slotClear(BrowseTableModel*);

--- a/src/library/proxytrackmodel.cpp
+++ b/src/library/proxytrackmodel.cpp
@@ -21,14 +21,14 @@ ProxyTrackModel::ProxyTrackModel(QAbstractItemModel* pTrackModel,
 ProxyTrackModel::~ProxyTrackModel() {
 }
 
-TrackModel::SortColumnId ProxyTrackModel::sortColumnIdFromColumnIndex(int index) {
+TrackModel::SortColumnId ProxyTrackModel::sortColumnIdFromColumnIndex(int index) const {
     return (m_pTrackModel ? m_pTrackModel->sortColumnIdFromColumnIndex(index)
-            : TrackModel::sortColumnIdFromColumnIndex(index));
+                          : TrackModel::SortColumnId::Invalid);
 }
 
-int ProxyTrackModel::columnIndexFromSortColumnId(TrackModel::SortColumnId sortColumn) {
+int ProxyTrackModel::columnIndexFromSortColumnId(TrackModel::SortColumnId sortColumn) const {
     return (m_pTrackModel ? m_pTrackModel->columnIndexFromSortColumnId(sortColumn)
-            : TrackModel::columnIndexFromSortColumnId(sortColumn));
+                          : -1);
 }
 
 TrackId ProxyTrackModel::getTrackId(const QModelIndex& index) const {

--- a/src/library/proxytrackmodel.h
+++ b/src/library/proxytrackmodel.h
@@ -38,8 +38,8 @@ class ProxyTrackModel : public QSortFilterProxyModel, public TrackModel {
     QAbstractItemDelegate* delegateForColumn(const int i, QObject* pParent) final;
     QString getModelSetting(const QString& name) final;
     bool setModelSetting(const QString& name, const QVariant& value) final;
-    TrackModel::SortColumnId sortColumnIdFromColumnIndex(int index) override;
-    int columnIndexFromSortColumnId(TrackModel::SortColumnId sortColumn) override;
+    TrackModel::SortColumnId sortColumnIdFromColumnIndex(int index) const override;
+    int columnIndexFromSortColumnId(TrackModel::SortColumnId sortColumn) const override;
 
     // Inherited from QSortFilterProxyModel
     bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const final;

--- a/src/library/trackmodel.h
+++ b/src/library/trackmodel.h
@@ -184,20 +184,14 @@ class TrackModel {
         m_eDefaultSortOrder = sortOrder;
     }
 
-    virtual bool isColumnSortable(int column) {
+    virtual bool isColumnSortable(int column) const {
         Q_UNUSED(column);
         return true;
     }
 
-    virtual SortColumnId sortColumnIdFromColumnIndex(int index) {
-        Q_UNUSED(index);
-        return TrackModel::SortColumnId::Invalid;
-    }
+    virtual SortColumnId sortColumnIdFromColumnIndex(int index) const = 0;
 
-    virtual int columnIndexFromSortColumnId(TrackModel::SortColumnId sortColumn) {
-        Q_UNUSED(sortColumn);
-        return -1;
-    }
+    virtual int columnIndexFromSortColumnId(TrackModel::SortColumnId sortColumn) const = 0;
 
     virtual int fieldIndex(const QString& fieldName) const {
         Q_UNUSED(fieldName);


### PR DESCRIPTION
This was a drive by change during debugging. 