### PR TITLE
Mapping Hercule P32: Add pitch management

### DIFF
--- a/res/controllers/Hercules P32 DJ.midi.xml
+++ b/res/controllers/Hercules P32 DJ.midi.xml
@@ -708,6 +708,42 @@
                     <script-binding/>
                 </options>
             </control>
+           <control>
+                <group>[Channel1]</group>
+                <key>P32.leftDeck.syncKey.input</key>
+                <status>0x91</status>
+                <midino>0x53</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>P32.leftDeck.pitchUp.input</key>
+                <status>0x91</status>
+                <midino>0x4F</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>P32.leftDeck.pitchDown.input</key>
+                <status>0x91</status>
+                <midino>0x4B</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>P32.leftDeck.resetKey.input</key>
+                <status>0x91</status>
+                <midino>0x47</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
             <control>
                 <group>[Channel1]</group>
                 <key>P32.leftDeck.enableEffectUnitButtons[0].input</key>
@@ -2280,6 +2316,42 @@
                 <key>P32.rightDeck.alignBeats.input</key>
                 <status>0x95</status>
                 <midino>0x46</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+           <control>
+                <group>[Channel1]</group>
+                <key>P32.rightDeck.syncKey.input</key>
+                <status>0x92</status>
+                <midino>0x53</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>P32.rightDeck.pitchUp.input</key>
+                <status>0x92</status>
+                <midino>0x4F</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>P32.rightDeck.pitchDown.input</key>
+                <status>0x92</status>
+                <midino>0x4B</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>P32.rightDeck.resetKey.input</key>
+                <status>0x92</status>
+                <midino>0x47</midino>
                 <options>
                     <script-binding/>
                 </options>

--- a/res/controllers/Hercules-P32-scripts.js
+++ b/res/controllers/Hercules-P32-scripts.js
@@ -464,6 +464,31 @@ P32.Deck = function(deckNumbers, channel) {
         off: P32.padColors.blue,
     });
 
+    this.syncKey = new components.Button({
+        midi: [0x90 + channel, 0x53],
+        key: "sync_key",
+        on: P32.padColors.red,
+        off: P32.padColors.purple,
+    });
+    this.pitchUp = new components.Button({
+        midi: [0x90 + channel, 0x4F],
+        key: "pitch_up",
+        on: P32.padColors.blue,
+        off: P32.padColors.purple,
+    });
+    this.pitchDown = new components.Button({
+        midi: [0x90 + channel, 0x4B],
+        key: "pitch_down",
+        on: P32.padColors.blue,
+        off: P32.padColors.purple,
+    });
+    this.resetKey = new components.Button({
+        midi: [0x90 + channel, 0x47],
+        key: "reset_key",
+        on: P32.padColors.red,
+        off: P32.padColors.purple,
+    });
+
     // SLICER layer
     this.enableEffectUnitButtons = [0x40, 0x41, 0x3C, 0x3D].map(
         function(midiByte, index) {

--- a/res/controllers/Hercules-P32-scripts.js
+++ b/res/controllers/Hercules-P32-scripts.js
@@ -467,26 +467,26 @@ P32.Deck = function(deckNumbers, channel) {
     this.syncKey = new components.Button({
         midi: [0x90 + channel, 0x53],
         key: "sync_key",
-        on: P32.padColors.red,
-        off: P32.padColors.purple,
+        on: P32.padColors.blue,
+        off: P32.padColors.red,
     });
     this.pitchUp = new components.Button({
         midi: [0x90 + channel, 0x4F],
         key: "pitch_up",
-        on: P32.padColors.blue,
-        off: P32.padColors.purple,
+        on: P32.padColors.purple,
+        off: P32.padColors.red,
     });
     this.pitchDown = new components.Button({
         midi: [0x90 + channel, 0x4B],
         key: "pitch_down",
-        on: P32.padColors.blue,
-        off: P32.padColors.purple,
+        on: P32.padColors.purple,
+        off: P32.padColors.red,
     });
     this.resetKey = new components.Button({
         midi: [0x90 + channel, 0x47],
         key: "reset_key",
-        on: P32.padColors.red,
-        off: P32.padColors.purple,
+        on: P32.padColors.blue,
+        off: P32.padColors.red,
     });
 
     // SLICER layer


### PR DESCRIPTION
The pitch management inputs (`sync_key`, `pitch_up`, `pitch_down` and `reset_key`) have been added to the 4 right pad buttons of the loop mode.