### PR TITLE
CMake: Update libkeyfinder URL sha256sum

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1695,10 +1695,10 @@ if(KEYFINDER)
     set(KeyFinder_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/lib/keyfinder-install")
     set(KeyFinder_LIBRARY "lib/${CMAKE_STATIC_LIBRARY_PREFIX}keyfinder${CMAKE_STATIC_LIBRARY_SUFFIX}")
     file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/download")
-    ExternalProject_Add(libKeyFinder
-      URL "https://github.com/mixxxdj/libKeyFinder/archive/v2.2.3.zip"
+    ExternalProject_Add(libkeyfinder
+      URL "https://github.com/mixxxdj/libkeyfinder/archive/v2.2.3.zip"
       URL_HASH SHA256=ad43ca006e3bbed0810ff62e170d04522a64f8606c2166bfa5a9b9158b7ebc11
-      DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/download/libKeyFinder"
+      DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/download/libkeyfinder"
       INSTALL_DIR "${KeyFinder_INSTALL_DIR}"
       CMAKE_ARGS
         -DBUILD_STATIC_LIBS=ON
@@ -1722,7 +1722,7 @@ if(KEYFINDER)
     file(MAKE_DIRECTORY "${KeyFinder_INSTALL_DIR}/include")
 
     add_library(mixxx-keyfinder STATIC IMPORTED)
-    add_dependencies(mixxx-keyfinder libKeyFinder)
+    add_dependencies(mixxx-keyfinder libkeyfinder)
     set_target_properties(mixxx-keyfinder PROPERTIES IMPORTED_LOCATION "${KeyFinder_INSTALL_DIR}/${KeyFinder_LIBRARY}")
     target_link_libraries(mixxx-keyfinder INTERFACE FFTW::FFTW)
     target_include_directories(mixxx-keyfinder INTERFACE "${KeyFinder_INSTALL_DIR}/include")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1697,7 +1697,7 @@ if(KEYFINDER)
     file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/download")
     ExternalProject_Add(libKeyFinder
       URL "https://github.com/mixxxdj/libKeyFinder/archive/v2.2.3.zip"
-      URL_HASH SHA256=56887e7b51834223d4264f4ea9acf16f0b6a0c706c218478afbaf89ad1f9c6ea
+      URL_HASH SHA256=ad43ca006e3bbed0810ff62e170d04522a64f8606c2166bfa5a9b9158b7ebc11
       DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/download/libKeyFinder"
       INSTALL_DIR "${KeyFinder_INSTALL_DIR}"
       CMAKE_ARGS


### PR DESCRIPTION
I have absolutely no idea why the hash changed. It's a tag archive, so it shouldn't change. Maybe GitHub changed something about the way these are generated?

Both point to the same commit (mixxxdj/libKeyFinder@442a3bf4256819117de5f908571337cfeba41939).

**Old archive:**

    $ unzip -l download/libKeyFinder/v2.2.3.zip | head -n 2
    Archive:  download/libKeyFinder/v2.2.3.zip
    442a3bf4256819117de5f908571337cfeba41939

**New archive:**

    $ unzip -l /tmp/v2.2.3.zip | head -n 2
    Archive:  /tmp/v2.2.3.zip
    442a3bf4256819117de5f908571337cfeba41939

**Checksums:**

    $ sha256sum download/libKeyFinder/v2.2.3.zip /tmp/v2.2.3.zip
    56887e7b51834223d4264f4ea9acf16f0b6a0c706c218478afbaf89ad1f9c6ea  download/libKeyFinder/v2.2.3.zip
    ad43ca006e3bbed0810ff62e170d04522a64f8606c2166bfa5a9b9158b7ebc11  /tmp/v2.2.3.zip
