### PR TITLE
Security: update the libkeyfinder2.2.3.zip SHA256

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1697,7 +1697,7 @@ if(KEYFINDER)
     file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/download")
     ExternalProject_Add(libKeyFinder
       URL "https://github.com/mixxxdj/libKeyFinder/archive/v2.2.3.zip"
-      URL_HASH SHA256=56887e7b51834223d4264f4ea9acf16f0b6a0c706c218478afbaf89ad1f9c6ea
+      URL_HASH SHA256=ad43ca006e3bbed0810ff62e170d04522a64f8606c2166bfa5a9b9158b7ebc11
       DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/download/libKeyFinder"
       INSTALL_DIR "${KeyFinder_INSTALL_DIR}"
       CMAKE_ARGS


### PR DESCRIPTION
I have updated the libkeyfinder2.2.3.zip SHA256 to pass the build.

Maybe I just don't know what I am doing and the build fail hide another true issue.

Poke @Be-ing (who released libkeyfinder2.2.3.zip here: https://github.com/mixxxdj/libkeyfinder).