### PR TITLE
[WIP] Implement cpu pinning and cgroup cpuset support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1285,6 +1285,14 @@ install(
     .
 )
 
+install(
+  FILES
+    tools/mixxx-isolate.py
+  DESTINATION
+    "${MIXXX_INSTALL_BINDIR}"
+  RENAME "mixxx-isolate"
+)
+
 # Skins
 install(
   DIRECTORY

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -852,6 +852,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/util/color/colorpalette.cpp
   src/util/color/predefinedcolorpalettes.cpp
   src/util/console.cpp
+  src/util/cpupinning.cpp
   src/util/db/dbconnection.cpp
   src/util/db/dbconnectionpool.cpp
   src/util/db/dbconnectionpooled.cpp

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -49,7 +49,9 @@ EngineMaster::EngineMaster(
           m_busTalkoverHandle(registerChannelGroup("[BusTalkover]")),
           m_busCrossfaderLeftHandle(registerChannelGroup("[BusLeft]")),
           m_busCrossfaderCenterHandle(registerChannelGroup("[BusCenter]")),
-          m_busCrossfaderRightHandle(registerChannelGroup("[BusRight]")) {
+          m_busCrossfaderRightHandle(registerChannelGroup("[BusRight]")),
+          m_cpuId(CmdlineArgs::Instance().getEngineCpuId()),
+          m_cpuSet(CmdlineArgs::Instance().getEngineCpuSet()) {
     pEffectsManager->registerInputChannel(m_masterHandle);
     pEffectsManager->registerInputChannel(m_headphoneHandle);
     pEffectsManager->registerOutputChannel(m_masterHandle);
@@ -385,14 +387,12 @@ void EngineMaster::processChannels(int iBufferSize) {
 void EngineMaster::finishStartup() {
     QThread::currentThread()->setObjectName("Engine");
 #ifdef __LINUX__
-    const auto cpuSet = CmdlineArgs::Instance().getEngineCpuSet();
-    if (!cpuSet.isNull() && !cpuSet.isEmpty()) {
-        mixxx::CpuPinning::moveThreadToCpuset(cpuSet);
+    if (!m_cpuSet.isNull() && !m_cpuSet.isEmpty()) {
+        mixxx::CpuPinning::moveThreadToCpuset(m_cpuSet);
     }
 #endif
-    auto cpuId = CmdlineArgs::Instance().getEngineCpuId();
-    if (cpuId != -1) {
-        mixxx::CpuPinning::pinThreadToCpu(cpuId);
+    if (m_cpuId != -1) {
+        mixxx::CpuPinning::pinThreadToCpu(m_cpuId);
     }
 }
 

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -348,4 +348,7 @@ class EngineMaster : public QObject, public AudioSource {
 
     volatile bool m_bBusOutputConnected[3];
     bool m_bExternalRecordBroadcastInputConnected;
+
+    const qint64 m_cpuId;
+    const QString m_cpuSet;
 };

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -258,6 +258,7 @@ class EngineMaster : public QObject, public AudioSource {
     // m_activeTalkoverChannels with each channel that is active for the
     // respective output.
     void processChannels(int iBufferSize);
+    void finishStartup();
 
     ChannelHandleFactoryPointer m_pChannelHandleFactory;
     void applyMasterEffects();

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -156,7 +156,7 @@ bool CmdlineArgs::parse(const QStringList& arguments) {
             QStringLiteral("logFlushLevel"));
     parser.addOption(logFlushLevel);
 
-    const QCommandLineOption engineCpuId(QStringList() << "engine-cpu-id"
+    const QCommandLineOption engineCpuId(QStringList() << "engine-cpu-id",
             QCoreApplication::translate("main",
                     "Bind mixxx to a specific CPU Core. Use mixxx-isolate if possible"),
             QStringLiteral("engineCpuId"));
@@ -217,7 +217,7 @@ bool CmdlineArgs::parse(const QStringList& arguments) {
 
     if (parser.isSet(engineCpuId)) {
         bool ok = false;
-        quint32 engineCpu = QString(argv[i + 1]).toUInt(&ok);
+        quint32 engineCpu = parser.value(engineCpuId).toUInt(&ok);
         if (!ok) {
             qWarning() << "engine-cpu-id is not a valid number";
         } else {
@@ -226,7 +226,7 @@ bool CmdlineArgs::parse(const QStringList& arguments) {
     }
 
     if (parser.isSet(engineCpuSet)) {
-        m_engineCpuSet = QString::fromLocal8Bit(parser.value(engineCpuSet));
+        m_engineCpuSet = parser.value(engineCpuSet);
     }
 
     if (parser.isSet(resourcePath)) {

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -28,6 +28,12 @@ class CmdlineArgs final {
     bool getMidiDebug() const { return m_midiDebug; }
     bool getDeveloper() const { return m_developer; }
     bool getSafeMode() const { return m_safeMode; }
+    qint64 getEngineCpuId() const {
+        return m_engineCpuId;
+    }
+    const QString& getEngineCpuSet() const {
+        return m_engineCpuSet;
+    }
     bool useColors() const {
         return m_useColors;
     }
@@ -53,6 +59,8 @@ class CmdlineArgs final {
     bool m_debugAssertBreak;
     bool m_settingsPathSet; // has --settingsPath been set on command line ?
     bool m_useColors;       // should colors be used
+    qint64 m_engineCpuId;
+    QString m_engineCpuSet;
     mixxx::LogLevel m_logLevel; // Level of stderr logging message verbosity
     mixxx::LogLevel m_logFlushLevel; // Level of mixx.log file flushing
     QString m_locale;

--- a/src/util/cpupinning.cpp
+++ b/src/util/cpupinning.cpp
@@ -1,0 +1,80 @@
+#ifdef __LINUX__
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <QFile>
+#endif
+
+#include <QThread>
+#include <QtDebug>
+
+#include "util/cpupinning.h"
+
+namespace mixxx {
+
+#ifdef __LINUX__
+bool CpuPinning::moveThreadToCpuset(const QString& cgroup) {
+    qDebug() << "Move task" << gettid() << "to cpuset" << cgroup;
+    QString filename = QLatin1String("/sys/fs/cgroup/cpuset/") + cgroup + QLatin1String("/tasks");
+    auto tasksFile = QFile(filename);
+    if (!tasksFile.exists()) {
+        qWarning() << "cgroup cpuset:" << cgroup << "does not exist" << tasksFile.errorString();
+        return false;
+    }
+    if (!tasksFile.open(QIODevice::WriteOnly)) {
+        qWarning() << "Error writing into cpuset cgroup" << tasksFile.errorString();
+        return false;
+    }
+    QTextStream out(&tasksFile);
+    out << QString::number(gettid());
+    tasksFile.close();
+    return true;
+}
+#endif
+
+bool CpuPinning::pinThreadToCpu(qint32 cpuid) {
+#ifdef __LINUX__
+    qDebug() << "Set CPU affinity for Thread ID" << gettid();
+
+    pthread_t thread = pthread_self();
+    cpu_set_t cpuset;
+    int status;
+    /* Set affinity mask to include CPUs 0 to 7 */
+    qDebug() << "Set CPU affinity for Thread ID" << gettid();
+
+    CPU_ZERO(&cpuset);
+    CPU_SET(cpuid, &cpuset);
+
+    status = pthread_setaffinity_np(thread, sizeof(cpu_set_t), &cpuset);
+    if (status != 0) {
+        qWarning() << "Error setting cpu affinity" << status;
+        return false;
+    }
+
+    /* Check the actual affinity mask assigned to the thread */
+
+    status = pthread_getaffinity_np(thread, sizeof(cpu_set_t), &cpuset);
+    if (status != 0) {
+        qWarning() << "Error getting cpu affinity" << status;
+        return false;
+    }
+
+    qDebug() << "Set returned by pthread_getaffinity_np() contained:\n";
+    for (int j = 0; j < CPU_SETSIZE; j++) {
+        if (CPU_ISSET(j, &cpuset)) {
+            qDebug() << "Use CPU " << j;
+        }
+    }
+    return true;
+
+#else
+    qWarning() << "CPU pinning not implemented on this platform";
+    return false;
+#endif
+}
+
+} // namespace mixxx

--- a/src/util/cpupinning.h
+++ b/src/util/cpupinning.h
@@ -1,0 +1,13 @@
+#include <Qt>
+
+namespace mixxx {
+
+class CpuPinning {
+  public:
+    /// Pin the current thread to cpuid
+    static bool pinThreadToCpu(qint32 cpuid);
+    /// Moves the thread to a cpuset cgroup
+    static bool moveThreadToCpuset(const QString& cgroup);
+};
+
+} // namespace mixxx

--- a/tools/mixxx-isolate.py
+++ b/tools/mixxx-isolate.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+import sys
+import os
+import signal
+import re
+
+try:
+    # import cpuset
+    from cpuset.commands import set as ccset
+    from cpuset import cset
+    from cpuset.commands import proc
+    from cpuset.util import CpusetExists
+
+except ImportError as e:
+    sys.stderr.write(e.msg)
+    sys.stderr.write("\nplease install cpuset\n")
+    sys.exit(1)
+
+
+import argparse
+import logging
+import subprocess
+from shutil import which
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger("mixxx-isolate")
+
+
+def selectCpus(userCpu=-1):
+    """
+    Selects the most fitting cpu and it's ht companions.
+    Returns {"use": cpuid, "isolate": [cpuid, ...], "system": [cpuid, ...]}
+    """
+    cpuinfo = ""
+    with open("/proc/cpuinfo") as fp:
+        cpuinfo = fp.read(-1)
+
+    cpuToCore = {}
+    currentCpu = -1
+    lastCore = -1
+    for line in cpuinfo.splitlines():
+        if not line.strip():
+            continue
+        topic, data = line.split(":")
+        topic = topic.strip()
+        if topic == "processor":
+            currentCpu = int(data)
+        elif topic == "core id":
+            coreId = int(data)
+            cpuToCore[currentCpu] = coreId
+            lastCore = max(lastCore, coreId)
+
+    useCore = -1
+    if userCpu == -1:
+        useCore = lastCore
+    else:
+        useCore = cpuToCore.get(userCpu, -1)
+        if useCore == -1:
+            print("Selected CPU does not exist. Using autodetect.")
+            useCore = lastCore
+
+    useCpu = -1
+    isolate = []
+    system = []
+    for cpu, core in cpuToCore.items():
+        if core == useCore and useCpu == -1:
+            useCpu = cpu
+        elif core == useCore:
+            isolate.append(cpu)
+        else:
+            system.append(cpu)
+
+    return {"use": useCpu, "isolate": isolate, "system": system}
+
+
+def cpusetname(name):
+    if name and name[0] == "/":
+        return name
+    return "/%s" % name
+
+
+def deleteCpuset(name, debug):
+    try:
+        setInstance = cset.unique_set(name)
+    except cset.CpusetNotFound:
+        return True
+    # move processes until empty
+    processes = 1
+    while processes:
+        try:
+            log.debug("Move processes from cpuset %s %s", setInstance, name)
+            proc.move(setInstance, "/", None, False)
+            processes = setInstance.tasks
+            log.debug("Processes left: %s", processes)
+            break
+        except BrokenPipeError:
+            continue
+        except Exception as e:
+            log.exception(e)
+            print(e)
+
+    ccset.destroy(name)
+    return True
+
+
+def teardown(args, isolate):
+    cset.CpuSet(None)
+
+    if not args.no_offline:
+        if args.cleanup:
+            # since our detection algorithm can't detect isolation cpus
+            # form offline CPUs, we will just bring up all cores on teardown
+            for fname in os.listdir("/sys/devices/system/cpu"):
+                try:
+                    if re.match("cpu[0-9]+", fname):
+                        with open(
+                            "/sys/devices/system/cpu/%s/online" % fname, "w"
+                        ) as fp:
+                            fp.write("1")
+                except OSError:
+                    pass
+                except Exception as e:
+                    print(e)
+
+        for iso in isolate:
+            with open("/sys/devices/system/cpu/cpu%d/online" % iso, "w") as fp:
+                fp.write("1")
+
+    log.info("deactivate cpusets")
+    deleteCpuset(args.cpuset_engine, args.debug)
+    deleteCpuset(args.cpuset_isolation, args.debug)
+    deleteCpuset(args.cpuset_system, args.debug)
+
+    log.info("Cleanup finished")
+    print("STATUS: CLEAN")
+
+
+def createcpuset(name, cpuspec, memspec, cx, mx):
+    try:
+        ccset.create(name, cpuspec, memspec, cx, mx)
+    except CpusetExists:
+        pass
+    except Exception as e:
+        raise e
+
+
+def joinCpuIds(lst):
+    return ",".join((str(x) for x in lst))
+
+
+def isolateSystem(args):
+    conf = selectCpus(args.cpu)
+
+    memspec = "0"
+    log.info("created cpuset groups")
+    try:
+        createcpuset(
+            args.cpuset_engine, str(conf["use"]), memspec, False, False
+        )
+        createcpuset(
+            args.cpuset_system,
+            joinCpuIds(conf["system"]),
+            memspec,
+            False,
+            False,
+        )
+        if args.isolate and conf["isolate"]:
+            createcpuset(
+                args.cpuset_isolation,
+                joinCpuIds(conf["isolate"]),
+                memspec,
+                False,
+                False,
+            )
+    except Exception as instance:
+        teardown(args, conf["isolate"])
+        # unroll
+        log.exception(instance)
+        log.critical("Failed to create shield, hint: do other cpusets exist?")
+        sys.exit(23)
+
+    # move all processes to the system cpuset
+    log.info("move processes into system group")
+    root_tasks = cset.unique_set("/").tasks
+    while True:
+        try:
+            proc.move("root", args.cpuset_system, root_tasks, args.debug)
+            break
+        except cset.CpusetException:
+            pass
+
+    if not args.no_offline:
+        for iso in conf["isolate"]:
+            with open("/sys/devices/system/cpu/cpu%d/online" % iso, "w") as fp:
+                fp.write("0")
+
+    # make the task file own by the user, so the engine can add itself later
+    taskFile = (
+        cset.CpuSet.basepath + args.cpuset_engine + cset.CpuSet.tasks_path
+    )
+    os.chown(taskFile, args.uid, -1)
+
+    print("STATUS: ISOLATION")
+
+    def signalHandler(signum, frame):
+        teardown(args, conf["isolate"])
+
+    signal.signal(signal.SIGUSR1, signalHandler)
+
+    while True:
+        try:
+            s = input(">>>")
+            if s == "exit":
+                break
+            else:
+                print("unknown command")
+        except KeyboardInterrupt:
+            break
+        except EOFError:
+            break
+
+    teardown(args, conf["isolate"])
+    sys.exit(0)
+
+
+def selectCommand(args):
+    if sys.stdin.isatty() and which("sudo"):
+        return ["sudo", "-u", "root", "--preserve-env=PYTHONPATH,PATH"]
+
+    if which("pkexec"):
+        return ["pkexec", "--user", "root"]
+
+    if which("qsudo"):
+        return ["qsudo", "-u", "root", "--preserve-env=PYTHONPATH,PATH"]
+
+    log.error("No supported sudo/pkexec/gksudo/ksudo executable found")
+    return None
+
+
+def elevatePermissions(args):
+    helperArgs = [sys.executable, os.path.abspath(__file__), "--worker"]
+
+    if args.cleanup:
+        helperArgs.append("--cleanup")
+    else:
+        helperArgs += [
+            "--cpuset_engine",
+            args.cpuset_engine,
+            "--cpuset_system",
+            args.cpuset_system,
+            "--cpuset_isolation",
+            args.cpuset_isolation,
+            "--cpu-id",
+            str(args.cpu),
+            "--uid",
+            str(os.getuid()),
+        ]
+        if not args.isolate:
+            helperArgs.append("--no-isolate-ht")
+
+    if args.debug:
+        helperArgs.append("--debug")
+
+    command = selectCommand(args)
+    if not command:
+        return None
+
+    fullCommand = command + helperArgs
+    log.info("Execute %s", fullCommand)
+
+    return subprocess.Popen(
+        fullCommand,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=sys.stderr,
+    )
+
+
+def startHelper(args):
+    """Execute $self with adjusted arguments under privilege elevation"""
+
+    helper = elevatePermissions(args)
+    mixxxProc = None
+    if not helper:
+        log.critical("Could not spawn with elevated permissions")
+    while True:
+        try:
+            helper.poll()
+            if helper.returncode == 127:
+                # user aborted password request, nothing happend so its
+                # save to exit
+                log.error("Could not run elevate process. Aborting")
+                sys.exit(1)
+            elif helper.returncode == 23:
+                # Error setting up isolation
+                log.critical("Error creating isolation. Aborting")
+                sys.exit(1)
+            elif helper.returncode is not None:
+                # helper process died
+                log.info(helper.stdout.read(-1))
+                log.error(
+                    "Helper process died: %s."
+                    "Cleanup might be required required",
+                    helper.returncode,
+                )
+                break
+
+            line = helper.stdout.readline().decode("utf-8", "ignore")
+            if line.startswith("STATUS:"):
+                status = line[7:].strip()
+                print("GOT STATUS:" + status)
+                if status == "ISOLATION":
+                    log.info("Isolation setup complete. Starting mixxx....")
+                    mixxxProc = subprocess.Popen(
+                        [args.mixxx, "--engineCpuSet", args.cpuset_engine]
+                        + args.mixxx_args
+                    )
+                    mixxxProc.wait()
+                    log.info("Mixxx finished")
+                    helper.stdin.write("exit\n".encode("ASCII"))
+                    try:
+                        # this might likely not work
+                        helper.send_signal(signal.SIGUSR1)
+                    except PermissionError:
+                        pass
+                    break
+                elif status == "CLEAN":
+                    # cleanup finished.
+                    log.info("Exit successfully")
+                    sys.exit(0)
+            else:
+                print(line)
+
+        except KeyboardInterrupt:
+            log.info("Received keyboard interrupt. Stopping")
+            if mixxxProc and mixxxProc.returncode is None:
+                mixxxProc.send_signal(signal.SIGINT)
+            break
+        except Exception as e:
+            log.exception(e)
+    # trigger system cleanup
+    try:
+        # this might likely not work
+        helper.send_signal(signal.SIGUSR1)
+    except PermissionError:
+        pass
+
+    helper.stdin.write("exit\n".encode("ASCII"))
+    helper.communicate()
+    log.info("Exit successfully")
+    sys.exit(0)
+
+
+def main():
+    defaultMixxx = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "mixxx"
+    )
+
+    parser = argparse.ArgumentParser(
+        description="""Runs mixxx with isolated engine on a dedicated CPU.
+    You can pass mixxx arguments using ' -- 'after mixxx-isolate arguments.
+
+    This program will seperate one CPU core from the system and place the
+    mixxx engine thread on a dedicated CPU.
+    Hyperthreading siblings will be isolated and taken offline if possible.
+
+    The normal system state is restored when mixxx is closed.
+    """
+    )
+    parser.add_argument(
+        "--cpuset_engine",
+        dest="cpuset_engine",
+        default="mixxx",
+        help="cpuset name for the mixxx engine",
+        type=cpusetname,
+    )
+    parser.add_argument(
+        "--cpuset_system",
+        dest="cpuset_system",
+        default="system",
+        help="cpuset name for the mixxx engine",
+        type=cpusetname,
+    )
+    parser.add_argument(
+        "--cpuset_isolation",
+        dest="cpuset_isolation",
+        default="mixxx-isolate",
+        help="cpuset name for the mixxx engine",
+        type=cpusetname,
+    )
+    parser.add_argument(
+        "--no-isolate-ht",
+        dest="isolate",
+        action="store_false",
+        default=True,
+        help="don't isolate hyperthreading partner (not recommended)",
+    )
+    parser.add_argument(
+        "--no-offline",
+        dest="no_offline",
+        action="store_true",
+        help="don't take hyperthreading cpus offline",
+    )
+    parser.add_argument(
+        "--cpu-id",
+        dest="cpu",
+        type=int,
+        default=-1,
+        help="ID of the cpu to use for the engine. -1 for autoselect",
+    )
+    parser.add_argument(
+        "--cleanup",
+        dest="cleanup",
+        action="store_true",
+        help="Cleanup old isolation settings",
+    )
+    parser.add_argument(
+        "--mixxx", dest="mixxx", default=defaultMixxx, help="Mixxx executable"
+    )
+    parser.add_argument(
+        "mixxx_args", nargs="*", help="Arguments passed to mixxx"
+    )
+    parser.add_argument(
+        "--debug",
+        dest="debug",
+        action="store_true",
+        default=False,
+        help="Debug output",
+    )
+    parser.add_argument(
+        "--worker",
+        dest="worker",
+        action="store_true",
+        default=False,
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--uid", dest="uid", default=None, type=int, help=argparse.SUPPRESS
+    )
+
+    args = parser.parse_args()
+
+    # initialize CpuSet
+    cset.CpuSet(None)
+
+    if args.debug:
+        logging.root.setLevel(logging.DEBUG)
+
+    if args.worker:
+        if args.cleanup:
+            log.info("Cleanup old isolation")
+            teardown(args, [])
+            log.info("done")
+            sys.exit(0)
+        if not args.uid:
+            log.critical("No uid passed to worker.")
+            sys.exit(1)
+        isolateSystem(args)
+    else:
+        startHelper(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add command line argument to specify a cpuid and cpuset
cgroup name for the engine.
The engine tries at startup to move itself to the cpuset
provided or set the cpu affinity.
This will allow a wrapper program to free a core for the engine,
minimizing latency jitter or CPU starvating.

## Instructions

after installing https://github.com/lpechacek/cpuset/releases/tag/v1.6
start with mixxx-isolate
`tools/mixxx-isolate.py -- [mixxx args]`

The script will start itself as root in the background to do the necessary system changes. After that, it starts
mixxx which will itself move the engine into a special cpuset group.
After mixxx exists, the system is restored.
The script also takes the hyperthreading cpus offline that are siblings of the engine cpu.
This way, you get the most power out of your CPU but have none of the negative effects of hyperthreading.
You can customize the behaviour:

```
usage: mixxx-isolate.py [-h] [--cpuset_engine CPUSET_ENGINE] [--cpuset_system CPUSET_SYSTEM] [--cpuset_isolation CPUSET_ISOLATION] [--no-isolate-ht] [--no-offline] [--cpu-id CPU] [--cleanup] [--mixxx MIXXX] [--debug]
                        [mixxx_args [mixxx_args ...]]

Runs mixxx with isolated engine on a dedicated CPU. You can pass mixxx arguments using ' -- 'after mixxx-isolate arguments. This program will seperate one CPU core from the system and place the mixxx engine thread on a dedicated CPU.
Hyperthreading siblings will be isolated and taken offline if possible. The normal system state is restored when mixxx is closed.

positional arguments:
  mixxx_args            Arguments passed to mixxx

optional arguments:
  -h, --help            show this help message and exit
  --cpuset_engine CPUSET_ENGINE
                        cpuset name for the mixxx engine
  --cpuset_system CPUSET_SYSTEM
                        cpuset name for the mixxx engine
  --cpuset_isolation CPUSET_ISOLATION
                        cpuset name for the mixxx engine
  --no-isolate-ht       don't isolate hyperthreading partner (not recommended)
  --no-offline          don't take hyperthreading cpus offline
  --cpu-id CPU          ID of the cpu to use for the engine. -1 for autoselect
  --cleanup             Cleanup old isolation settings
  --mixxx MIXXX         Mixxx executable
  --debug               Debug output
```

## Manual Instructions


You need to find out which cpu id's are one core by looking at /proc/cpuinfo and compare the core id.
In my case I use cpu 3 and it's hyperthreading partner 7

```sh
sudo cset shield --cpu 3,7 --kthread=on
echo 3 | sudo tee -a /sys/fs/cgroup/cpuset/user/cpuset.cpus
sudo chown $(id -u) /sys/fs/cgroup/cpuset/user/tasks
mixxx  --settingsPath ~/Projects/mixxx-devsettings/ --logLevel debug --developer --controllerDebug --engineCpuSet user
```

This logic will be put into mixxx-isolate (python script) and it will try to request the proper credentials through modern desktop techniques. This is only the mixxx part yet.

## Restore system
Stop the shield after you finished your usage:
```
sudo cset shield -r
```

### Find out which CPU to use

Look at the cpuinfo file
```sh
cat /proc/cpuinfo
```
The output looks like this:
```
processor       : 0
vendor_id       : GenuineIntel
cpu family      : 6
model           : 158
model name      : Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
stepping        : 9
microcode       : 0xde
cpu MHz         : 2839.943
cache size      : 8192 KB
physical id     : 0
siblings        : 8
core id         : 0
cpu cores       : 4
apicid          : 0
initial apicid  : 0
fpu             : yes
fpu_exception   : yes
cpuid level     : 22
wp              : yes
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single pti ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d
bugs            : cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs taa itlb_multihit srbds
bogomips        : 5799.77
clflush size    : 64
cache_alignment : 64
address sizes   : 39 bits physical, 48 bits virtual
power management:

[...]
```
You can now choose any cpu, and find the matching entries which have the same *core id*. Use those in the instructions above.
Be aware that CPU Ids start at 0.
