### PR TITLE
SoundSourceModPlug: Remove unused unistd.h header file

### DIFF
--- a/src/sources/soundsourcemodplug.cpp
+++ b/src/sources/soundsourcemodplug.cpp
@@ -9,7 +9,6 @@
 #include <QFile>
 
 #include <stdlib.h>
-#include <unistd.h>
 
 namespace mixxx {
 


### PR DESCRIPTION
Apparently this isn't needed and it breaks the build on Windows.