### PR TITLE
Fix cue dirtiness

### DIFF
--- a/src/library/dao/cuedao.cpp
+++ b/src/library/dao/cuedao.cpp
@@ -208,12 +208,8 @@ void CueDAO::saveTrackCues(
     QStringList cueIds;
     cueIds.reserve(cueList.size());
     for (const auto& pCue : cueList) {
-        // New cues (without an id) must always be marked as dirty
-        VERIFY_OR_DEBUG_ASSERT(pCue->getId().isValid() || pCue->isDirty()) {
-            pCue->setDirty(true);
-        }
         // Update or save cue
-        if (pCue->isDirty()) {
+        if (!pCue->getId().isValid() || pCue->isDirty()) {
             saveCue(trackId, pCue.get());
         }
         // After saving each cue must have a valid id

--- a/src/test/cue_test.cpp
+++ b/src/test/cue_test.cpp
@@ -10,12 +10,8 @@ namespace mixxx {
 
 TEST(CueTest, DefaultCueInfoToCueRoundtrip) {
     const CueInfo cueInfo1;
-    const Cue cueObject(
-            cueInfo1,
-            audio::SampleRate(44100),
-            true);
-    auto cueInfo2 = cueObject.getCueInfo(
-            audio::SampleRate(44100));
+    const Cue cueObject(cueInfo1, audio::SampleRate(44100));
+    auto cueInfo2 = cueObject.getCueInfo(audio::SampleRate(44100));
     cueInfo2.setColor(std::nullopt);
     EXPECT_EQ(cueInfo1, cueInfo2);
 }
@@ -31,12 +27,8 @@ TEST(CueTest, ConvertCueInfoToCueRoundtrip) {
             std::make_optional(3),
             QStringLiteral("label"),
             RgbColor::optional(0xABCDEF));
-    const Cue cueObject(
-            cueInfo1,
-            audio::SampleRate(44100),
-            true);
-    const auto cueInfo2 = cueObject.getCueInfo(
-            audio::SampleRate(44100));
+    const Cue cueObject(cueInfo1, audio::SampleRate(44100));
+    const auto cueInfo2 = cueObject.getCueInfo(audio::SampleRate(44100));
     EXPECT_EQ(cueInfo1, cueInfo2);
 }
 

--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -74,9 +74,8 @@ Cue::Cue(
 
 Cue::Cue(
         const mixxx::CueInfo& cueInfo,
-        mixxx::audio::SampleRate sampleRate,
-        bool setDirty)
-        : m_bDirty(setDirty),
+        mixxx::audio::SampleRate sampleRate)
+        : m_bDirty(true),
           m_type(cueInfo.getType()),
           m_sampleStartPosition(
                   positionMillisToSamples(
@@ -98,7 +97,7 @@ Cue::Cue(
         int hotCueIndex,
         double sampleStartPosition,
         double sampleEndPosition)
-        : m_bDirty(false), // not yet in database
+        : m_bDirty(true),
           m_type(type),
           m_sampleStartPosition(sampleStartPosition),
           m_sampleEndPosition(sampleEndPosition),

--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -75,7 +75,7 @@ Cue::Cue(
 Cue::Cue(
         const mixxx::CueInfo& cueInfo,
         mixxx::audio::SampleRate sampleRate)
-        : m_bDirty(true),
+        : m_bDirty(false), // not in db yet, will be saved anyways
           m_type(cueInfo.getType()),
           m_sampleStartPosition(
                   positionMillisToSamples(
@@ -97,7 +97,7 @@ Cue::Cue(
         int hotCueIndex,
         double sampleStartPosition,
         double sampleEndPosition)
-        : m_bDirty(true),
+        : m_bDirty(false), // not in db yet, will be saved anyways
           m_type(type),
           m_sampleStartPosition(sampleStartPosition),
           m_sampleEndPosition(sampleEndPosition),

--- a/src/track/cue.h
+++ b/src/track/cue.h
@@ -35,8 +35,7 @@ class Cue : public QObject {
     /// For roundtrips during tests
     Cue(
             const mixxx::CueInfo& cueInfo,
-            mixxx::audio::SampleRate sampleRate,
-            bool setDirty);
+            mixxx::audio::SampleRate sampleRate);
 
     /// Load entity from database.
     Cue(

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1094,7 +1094,7 @@ bool Track::importPendingCueInfosWhileLocked() {
             m_pCueInfoImporterPending->importCueInfosAndApplyTimingOffset(
                     getLocation(), m_streamInfoFromSource->getSignalInfo());
     for (const auto& cueInfo : cueInfos) {
-        CuePointer pCue(new Cue(cueInfo, sampleRate, true));
+        CuePointer pCue(new Cue(cueInfo, sampleRate));
         // While this method could be called from any thread,
         // associated Cue objects should always live on the
         // same thread as their host, namely this->thread().


### PR DESCRIPTION
This fixes a regression introduced by #3016 which I am baffled stayed unnoticed for months:

Since new cues are now not assigned a track, they are never marked dirty and thus not saved. I haven't tested it extensively, but it seems that before this patch no new cues were ever saved.

It was fixed by marking cues as dirty upon initialization. It also makes the debug assertion more graceful.

Now that I write this, there would be an alternative solution: Do not mark new cues as dirty, but simply always save them when they don't have a valid id. Why that extra roundtrip?