### PR TITLE
Partly revert 6af7b84e4c49b369838949ccbc1fbe703e13afc7

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -50,11 +50,6 @@ let inherit (nixroot) stdenv pkgs lib
     cd cbuild
     cmake .. "$@"
     cd ..
-    if [ ! -e venv/bin/pre-commit ]; then
-      virtualenv -p python3 venv
-      ./venv/bin/pip install pre-commit
-      ./venv/bin/pre-commit install
-    fi
   '';
 
   shell-build = nixroot.writeShellScriptBin "build" ''


### PR DESCRIPTION
This removes the "pull code from the internet and execute it" part of
6af7b84e4c49b369838949ccbc1fbe703e13afc7.

---

I don't care whether this is necessary for something or what it does. It pulls code from the internet and does **not** give me the time to check it before running it. This is a no-go.