### PR TITLE
Fix crash on case sensitive filesystems on Macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2664,7 +2664,7 @@ if(APPLE AND MACOS_BUNDLE)
             get_filename_component(_qt_plugin_file "${_qt_plugin_path}" NAME)
             get_filename_component(_qt_plugin_type "${_qt_plugin_path}" PATH)
             get_filename_component(_qt_plugin_type "${_qt_plugin_type}" NAME)
-            set(_qt_plugin_dest "${_prefix}/Contents/plugins/${_qt_plugin_type}")
+            set(_qt_plugin_dest "${_prefix}/Contents/PlugIns/${_qt_plugin_type}")
             install(FILES "${_qt_plugin_path}"
                 DESTINATION "${_qt_plugin_dest}")
             set(${_qt_plugins_var}


### PR DESCRIPTION
Mixxx failed to launch on case-sensitive filesystems on MacOS because it was unable to find its Qt plugins: it looks for `PlugIns` rather than `plugins`, which is what the directory was called.

NB. the build also doesn't work on case-sensitive file systems (I've filed https://bugs.launchpad.net/mixxx/+bug/1911064 for this) so I haven't been able to produce a working package, but I'll test this once the autobuilder runs and confirm it works.