### PR TITLE
lp1911196: Do no print a warning if fonts directory is missing

### DIFF
--- a/src/util/font.h
+++ b/src/util/font.h
@@ -12,7 +12,15 @@ class FontUtils {
     static void initializeFonts(const QString& resourcePath) {
         QDir fontsDir(resourcePath);
         if (!fontsDir.cd("fonts")) {
-            qWarning("FontUtils::initializeFonts: cd fonts failed");
+#ifdef __LINUX__
+            // If the fonts already have been installed via the package
+            // manager, this is okay. We currently have no way to verify that
+            // though.
+            qDebug()
+#else
+            qWarning()
+#endif
+                    << "No fonts directory found in" << resourcePath;
             return;
         }
 


### PR DESCRIPTION
On Linux, the `fonts/` directory might not exist if Mixxx was installed via
package manager.

You might say "this is a hack" and you'd be right. Ideally, a skin
should request what font it needs, then we check if that font is
available in the Qt Font Database, and if not, we try to load it from
the `fonts/` directory. This is just a band-aid.

See this for details:
- https://bugs.launchpad.net/mixxx/+bug/1911196
- https://github.com/mixxxdj/mixxx/pull/3458#discussion_r545470642