### PR TITLE
remove use of deprecated TagLib::String::null

### DIFF
--- a/src/track/taglib/trackmetadata_common.cpp
+++ b/src/track/taglib/trackmetadata_common.cpp
@@ -56,14 +56,25 @@ bool parseReplayGainPeak(
 
 namespace taglib {
 
-TagLib::String toTString(
-        const QString& str) {
-    if (str.isEmpty()) {
-        return TagLib::String();
-    } else {
-        const QByteArray qba(str.toUtf8());
-        return TagLib::String(qba.constData(), TagLib::String::UTF8);
+QString toQString(
+        const TagLib::String& tString) {
+    if (tString.isEmpty()) {
+        // TagLib::null/isNull() is deprecated so we cannot distinguish
+        // between null and empty strings.
+        return QString();
     }
+    return TStringToQString(tString);
+}
+
+TagLib::String toTString(
+        const QString& qString) {
+    if (qString.isEmpty()) {
+        // TagLib::null/isNull() is deprecated so we cannot distinguish
+        // between null and empty strings.
+        return TagLib::String();
+    }
+    const QByteArray qba(qString.toUtf8());
+    return TagLib::String(qba.constData(), TagLib::String::UTF8);
 }
 
 TagLib::String firstNonEmptyStringListItem(

--- a/src/track/taglib/trackmetadata_common.cpp
+++ b/src/track/taglib/trackmetadata_common.cpp
@@ -58,8 +58,8 @@ namespace taglib {
 
 TagLib::String toTString(
         const QString& str) {
-    if (str.isNull()) {
-        return TagLib::String::null;
+    if (str.isEmpty()) {
+        return TagLib::String();
     } else {
         const QByteArray qba(str.toUtf8());
         return TagLib::String(qba.constData(), TagLib::String::UTF8);

--- a/src/track/taglib/trackmetadata_common.h
+++ b/src/track/taglib/trackmetadata_common.h
@@ -66,7 +66,7 @@ inline QByteArray toQByteArrayRaw(
 inline TagLib::ByteVector toTByteVector(
         const QByteArray& byteArray) {
     if (byteArray.isNull()) {
-        return TagLib::ByteVector::null;
+        return TagLib::ByteVector();
     } else {
         return TagLib::ByteVector(byteArray.constData(), byteArray.size());
     }

--- a/src/track/taglib/trackmetadata_common.h
+++ b/src/track/taglib/trackmetadata_common.h
@@ -27,18 +27,11 @@ namespace mixxx {
 
 namespace taglib {
 
-inline QString toQString(
-        const TagLib::String& tString) {
-    if (tString.isNull()) {
-        // null -> null
-        return QString();
-    } else {
-        return TStringToQString(tString);
-    }
-}
+QString toQString(
+        const TagLib::String& tString);
 
 TagLib::String toTString(
-        const QString& str);
+        const QString& qString);
 
 /// Returns the first element of TagLib string list that is not empty.
 TagLib::String firstNonEmptyStringListItem(

--- a/src/track/taglib/trackmetadata_xiph.cpp
+++ b/src/track/taglib/trackmetadata_xiph.cpp
@@ -79,7 +79,7 @@ void writeCommentField(
         const TagLib::String& value) {
     if (value.isEmpty()) {
         // Purge empty fields
-        pTag->removeField(key);
+        pTag->removeFields(key);
     } else {
         const bool replace = true;
         pTag->addField(key, value, replace);


### PR DESCRIPTION
This causes link errors on Windows when TagLib is built dynamically
https://github.com/taglib/taglib/issues/651