### PR TITLE
Track: Preserve stream info on metadata import

### DIFF
--- a/src/audio/signalinfo.h
+++ b/src/audio/signalinfo.h
@@ -36,7 +36,6 @@ class SignalInfo final {
 
     constexpr bool isValid() const {
         return getChannelCount().isValid() &&
-                getSampleLayout() &&
                 getSampleRate().isValid();
     }
 

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -537,6 +537,10 @@ void SoundSourceProxy::updateTrackFromSource(
         mergeImportedMetadata = true;
     }
 
+    // Safe for later to replace the unreliable and imprecise audio
+    // properties imported from file tags (see below).
+    const auto preciseStreamInfo = trackMetadata.getStreamInfo();
+
     // Embedded cover art is imported together with the track's metadata.
     // But only if the user has not selected external cover art for this
     // track!
@@ -635,7 +639,24 @@ void SoundSourceProxy::updateTrackFromSource(
                         << getUrl().toString();
             }
         }
+
+        // Preserve the precise stream info data (if available) that has been
+        // obtained from the actual audio stream. If the file content itself
+        // has been modified the stream info data will be updated next time
+        // when opening and decoding the audio stream.
+        if (preciseStreamInfo.isValid()) {
+            trackMetadata.setStreamInfo(preciseStreamInfo);
+        } else if (preciseStreamInfo.getSignalInfo().isValid()) {
+            // Special case: Only the bitrate might be invalid or unknown
+            trackMetadata.refStreamInfo().setSignalInfo(
+                    preciseStreamInfo.getSignalInfo());
+            if (preciseStreamInfo.getDuration() > mixxx::Duration::empty()) {
+                trackMetadata.refStreamInfo().setDuration(preciseStreamInfo.getDuration());
+            }
+        }
+
         m_pTrack->importMetadata(trackMetadata, metadataImported.second);
+
         bool pendingBeatsImport = m_pTrack->getBeatsImportStatus() == Track::ImportStatus::Pending;
         bool pendingCueImport = m_pTrack->getCueImportStatus() == Track::ImportStatus::Pending;
         if (pendingBeatsImport || pendingCueImport) {

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -537,7 +537,7 @@ void SoundSourceProxy::updateTrackFromSource(
         mergeImportedMetadata = true;
     }
 
-    // Safe for later to replace the unreliable and imprecise audio
+    // Save for later to replace the unreliable and imprecise audio
     // properties imported from file tags (see below).
     const auto preciseStreamInfo = trackMetadata.getStreamInfo();
 

--- a/src/track/keys.cpp
+++ b/src/track/keys.cpp
@@ -51,3 +51,9 @@ bool Keys::readByteArray(const QByteArray& byteArray) {
     }
     return true;
 }
+
+bool operator==(const Keys& lhs, const Keys& rhs) {
+    return lhs.getSubVersion() == rhs.getSubVersion() &&
+            // TODO: Is there a more efficient way to compare protobuf types?
+            lhs.toByteArray() == rhs.toByteArray();
+}

--- a/src/track/keys.h
+++ b/src/track/keys.h
@@ -52,3 +52,9 @@ class Keys final {
     // For private constructor access.
     friend class KeyFactory;
 };
+
+bool operator==(const Keys& lhs, const Keys& rhs);
+
+inline bool operator!=(const Keys& lhs, const Keys& rhs) {
+    return !(lhs == rhs);
+}

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -419,12 +419,13 @@ void Track::setDateAdded(const QDateTime& dateAdded) {
 
 void Track::setDuration(mixxx::Duration duration) {
     QMutexLocker lock(&m_qMutex);
-    VERIFY_OR_DEBUG_ASSERT(!m_streamInfoFromSource ||
-            m_streamInfoFromSource->getDuration() <= mixxx::Duration::empty() ||
-            m_streamInfoFromSource->getDuration() == duration) {
+    // TODO: Move checks into TrackRecord
+    VERIFY_OR_DEBUG_ASSERT(!m_record.getStreamInfoFromSource() ||
+            m_record.getStreamInfoFromSource()->getDuration() <= mixxx::Duration::empty() ||
+            m_record.getStreamInfoFromSource()->getDuration() == duration) {
         kLogger.warning()
                 << "Cannot override stream duration:"
-                << m_streamInfoFromSource->getDuration()
+                << m_record.getStreamInfoFromSource()->getDuration()
                 << "->"
                 << duration;
         return;
@@ -668,12 +669,13 @@ QString Track::getBitrateText() const {
 void Track::setBitrate(int iBitrate) {
     QMutexLocker lock(&m_qMutex);
     const mixxx::audio::Bitrate bitrate(iBitrate);
-    VERIFY_OR_DEBUG_ASSERT(!m_streamInfoFromSource ||
-            !m_streamInfoFromSource->getBitrate().isValid() ||
-            m_streamInfoFromSource->getBitrate() == bitrate) {
+    // TODO: Move checks into TrackRecord
+    VERIFY_OR_DEBUG_ASSERT(!m_record.getStreamInfoFromSource() ||
+            !m_record.getStreamInfoFromSource()->getBitrate().isValid() ||
+            m_record.getStreamInfoFromSource()->getBitrate() == bitrate) {
         kLogger.warning()
                 << "Cannot override stream bitrate:"
-                << m_streamInfoFromSource->getBitrate()
+                << m_record.getStreamInfoFromSource()->getBitrate()
                 << "->"
                 << bitrate;
         return;
@@ -790,10 +792,10 @@ void Track::setCuePoint(CuePosition cue) {
 void Track::shiftCuePositionsMillis(double milliseconds) {
     QMutexLocker lock(&m_qMutex);
 
-    VERIFY_OR_DEBUG_ASSERT(m_streamInfoFromSource) {
+    VERIFY_OR_DEBUG_ASSERT(m_record.getStreamInfoFromSource()) {
         return;
     }
-    double frames = m_streamInfoFromSource->getSignalInfo().millis2frames(milliseconds);
+    double frames = m_record.getStreamInfoFromSource()->getSignalInfo().millis2frames(milliseconds);
     for (const CuePointer& pCue : qAsConst(m_cuePoints)) {
         pCue->shiftPositionFrames(frames);
     }
@@ -924,7 +926,7 @@ Track::ImportStatus Track::importBeats(
         // existing cue points.
         m_pBeatsImporterPending.reset();
         return ImportStatus::Complete;
-    } else if (m_streamInfoFromSource) {
+    } else if (m_record.hasStreamInfoFromSource()) {
         // Replace existing cue points with imported cue
         // points immediately
         importPendingBeatsMarkDirtyAndUnlock(&lock);
@@ -958,14 +960,14 @@ bool Track::importPendingBeatsWhileLocked() {
     }
     // The sample rate can only be trusted after the audio
     // stream has been opened.
-    DEBUG_ASSERT(m_streamInfoFromSource);
+    DEBUG_ASSERT(m_record.getStreamInfoFromSource());
     // The sample rate is supposed to be consistent
-    DEBUG_ASSERT(m_streamInfoFromSource->getSignalInfo().getSampleRate() ==
+    DEBUG_ASSERT(m_record.getStreamInfoFromSource()->getSignalInfo().getSampleRate() ==
             m_record.getMetadata().getStreamInfo().getSignalInfo().getSampleRate());
     mixxx::BeatsPointer pBeats(new mixxx::BeatMap(*this,
-            static_cast<SINT>(m_streamInfoFromSource->getSignalInfo().getSampleRate()),
+            static_cast<SINT>(m_record.getStreamInfoFromSource()->getSignalInfo().getSampleRate()),
             m_pBeatsImporterPending->importBeatsAndApplyTimingOffset(
-                    getLocation(), *m_streamInfoFromSource)));
+                    getLocation(), *m_record.getStreamInfoFromSource())));
     DEBUG_ASSERT(m_pBeatsImporterPending->isEmpty());
     m_pBeatsImporterPending.reset();
     return setBeatsWhileLocked(pBeats);
@@ -999,7 +1001,7 @@ Track::ImportStatus Track::importCueInfos(
         // existing cue points.
         m_pCueInfoImporterPending.reset();
         return ImportStatus::Complete;
-    } else if (m_streamInfoFromSource) {
+    } else if (m_record.hasStreamInfoFromSource()) {
         // Replace existing cue points with imported cue
         // points immediately
         importPendingCueInfosMarkDirtyAndUnlock(&lock);
@@ -1086,9 +1088,9 @@ bool Track::importPendingCueInfosWhileLocked() {
     }
     // The sample rate can only be trusted after the audio
     // stream has been opened.
-    DEBUG_ASSERT(m_streamInfoFromSource);
+    DEBUG_ASSERT(m_record.getStreamInfoFromSource());
     const auto sampleRate =
-            m_streamInfoFromSource->getSignalInfo().getSampleRate();
+            m_record.getStreamInfoFromSource()->getSignalInfo().getSampleRate();
     // The sample rate is supposed to be consistent
     DEBUG_ASSERT(sampleRate ==
             m_record.getMetadata().getStreamInfo().getSignalInfo().getSampleRate());
@@ -1097,7 +1099,7 @@ bool Track::importPendingCueInfosWhileLocked() {
     cuePoints.reserve(m_pCueInfoImporterPending->size());
     const auto cueInfos =
             m_pCueInfoImporterPending->importCueInfosAndApplyTimingOffset(
-                    getLocation(), m_streamInfoFromSource->getSignalInfo());
+                    getLocation(), m_record.getStreamInfoFromSource()->getSignalInfo());
     for (const auto& cueInfo : cueInfos) {
         CuePointer pCue(new Cue(cueInfo, sampleRate, true));
         // While this method could be called from any thread,
@@ -1464,7 +1466,7 @@ void Track::setAudioProperties(
     // and are also imported from file tags. They will be
     // overriden by the actual properties from the audio
     // source later.
-    DEBUG_ASSERT(!m_streamInfoFromSource);
+    DEBUG_ASSERT(!m_record.hasStreamInfoFromSource());
     if (compareAndSet(
                 m_record.refMetadata().ptrStreamInfo(),
                 streamInfo)) {
@@ -1475,17 +1477,7 @@ void Track::setAudioProperties(
 void Track::updateStreamInfoFromSource(
         mixxx::audio::StreamInfo&& streamInfo) {
     QMutexLocker lock(&m_qMutex);
-    VERIFY_OR_DEBUG_ASSERT(!m_streamInfoFromSource ||
-            *m_streamInfoFromSource == streamInfo) {
-        kLogger.warning()
-                << "Varying stream properties:"
-                << *m_streamInfoFromSource
-                << "->"
-                << streamInfo;
-    }
-    bool updated = m_record.refMetadata().updateStreamInfoFromSource(
-            streamInfo);
-    m_streamInfoFromSource = std::make_optional(std::move(streamInfo));
+    bool updated = m_record.updateStreamInfoFromSource(streamInfo);
 
     bool importBeats = m_pBeatsImporterPending && !m_pBeatsImporterPending->isEmpty();
     bool importCueInfos = m_pCueInfoImporterPending && !m_pCueInfoImporterPending->isEmpty();

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -439,7 +439,7 @@ class Track : public QObject {
     // these values.
     bool hasStreamInfoFromSource() const {
         QMutexLocker lock(&m_qMutex);
-        return static_cast<bool>(m_streamInfoFromSource);
+        return m_record.hasStreamInfoFromSource();
     }
     void updateStreamInfoFromSource(
             mixxx::audio::StreamInfo&& streamInfo);
@@ -461,11 +461,6 @@ class Track : public QObject {
     // Flag indicating that the user has explicitly requested to save
     // the metadata.
     bool m_bMarkedForMetadataExport;
-
-    // Reliable information about the PCM audio stream
-    // that only becomes available when opening the
-    // corresponding file.
-    std::optional<mixxx::audio::StreamInfo> m_streamInfoFromSource;
 
     // The list of cue points for the track
     QList<CuePointer> m_cuePoints;

--- a/src/track/trackmetadata.cpp
+++ b/src/track/trackmetadata.cpp
@@ -15,64 +15,55 @@ const Logger kLogger("TrackMetadata");
 
 bool TrackMetadata::updateStreamInfoFromSource(
         const audio::StreamInfo& streamInfo) {
-    bool changed = false;
+    if (getStreamInfo() == streamInfo) {
+        return false;
+    }
     const auto streamChannelCount =
             streamInfo.getSignalInfo().getChannelCount();
     if (streamChannelCount.isValid() &&
-            streamChannelCount != getStreamInfo().getSignalInfo().getChannelCount()) {
-        if (getStreamInfo().getSignalInfo().getChannelCount().isValid()) {
-            kLogger.debug()
-                    << "Modifying channel count:"
-                    << getStreamInfo().getSignalInfo().getChannelCount()
-                    << "->"
-                    << streamChannelCount;
-        }
-        refStreamInfo().refSignalInfo().setChannelCount(streamChannelCount);
-        changed = true;
+            streamChannelCount != getStreamInfo().getSignalInfo().getChannelCount() &&
+            getStreamInfo().getSignalInfo().getChannelCount().isValid()) {
+        kLogger.debug()
+                << "Modifying channel count:"
+                << getStreamInfo().getSignalInfo().getChannelCount()
+                << "->"
+                << streamChannelCount;
     }
     const auto streamSampleRate =
             streamInfo.getSignalInfo().getSampleRate();
     if (streamSampleRate.isValid() &&
-            streamSampleRate != getStreamInfo().getSignalInfo().getSampleRate()) {
-        if (getStreamInfo().getSignalInfo().getSampleRate().isValid()) {
-            kLogger.debug()
-                    << "Modifying sample rate:"
-                    << getStreamInfo().getSignalInfo().getSampleRate()
-                    << "->"
-                    << streamSampleRate;
-        }
-        refStreamInfo().refSignalInfo().setSampleRate(streamSampleRate);
-        changed = true;
+            streamSampleRate != getStreamInfo().getSignalInfo().getSampleRate() &&
+            getStreamInfo().getSignalInfo().getSampleRate().isValid()) {
+        kLogger.debug()
+                << "Modifying sample rate:"
+                << getStreamInfo().getSignalInfo().getSampleRate()
+                << "->"
+                << streamSampleRate;
     }
     const auto streamBitrate =
             streamInfo.getBitrate();
     if (streamBitrate.isValid() &&
-            streamBitrate != getStreamInfo().getBitrate()) {
-        if (getStreamInfo().getSignalInfo().isValid()) {
-            kLogger.debug()
-                    << "Modifying bitrate:"
-                    << getStreamInfo().getSignalInfo()
-                    << "->"
-                    << streamBitrate;
-        }
-        refStreamInfo().setBitrate(streamBitrate);
-        changed = true;
+            streamBitrate != getStreamInfo().getBitrate() &&
+            getStreamInfo().getSignalInfo().isValid()) {
+        kLogger.debug()
+                << "Modifying bitrate:"
+                << getStreamInfo().getSignalInfo()
+                << "->"
+                << streamBitrate;
     }
     const auto streamDuration =
             streamInfo.getDuration();
     if (streamDuration > Duration::empty() &&
-            streamDuration != getStreamInfo().getDuration()) {
-        if (getStreamInfo().getDuration() > Duration::empty()) {
-            kLogger.debug()
-                    << "Modifying duration:"
-                    << getStreamInfo().getDuration()
-                    << "->"
-                    << streamDuration;
-        }
-        refStreamInfo().setDuration(streamDuration);
-        changed = true;
+            streamDuration != getStreamInfo().getDuration() &&
+            getStreamInfo().getDuration() > Duration::empty()) {
+        kLogger.debug()
+                << "Modifying duration:"
+                << getStreamInfo().getDuration()
+                << "->"
+                << streamDuration;
     }
-    return changed;
+    setStreamInfo(streamInfo);
+    return true;
 }
 
 QString TrackMetadata::getBitrateText() const {

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -228,9 +228,6 @@ bool TrackRecord::updateStreamInfoFromSource(
 }
 
 bool operator==(const TrackRecord& lhs, const TrackRecord& rhs) {
-    // m_streamInfoFromSource must not be considered for equality
-    // comparisons! It is only needed for verifying consistency
-    // during updates and as a flags when a track is loaded.
     return lhs.getMetadata() == rhs.getMetadata() &&
             lhs.getCoverInfo() == rhs.getCoverInfo() &&
             lhs.getId() == rhs.getId() &&

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -1,8 +1,15 @@
 #include "track/trackrecord.h"
 
 #include "track/keyfactory.h"
+#include "util/logger.h"
 
 namespace mixxx {
+
+namespace {
+
+const Logger kLogger("TrackRecord");
+
+} // anonymous namespace
 
 /*static*/ const QString TrackRecord::kTrackTotalPlaceholder = QStringLiteral("//");
 
@@ -197,6 +204,46 @@ bool TrackRecord::mergeImportedMetadata(
             importedAlbumInfo.getRecordLabel());
 #endif // __EXTRA_METADATA__
     return modified;
+}
+
+bool TrackRecord::updateStreamInfoFromSource(
+        const mixxx::audio::StreamInfo& streamInfoFromSource) {
+    // Stream properties are not expected to vary during a session
+    VERIFY_OR_DEBUG_ASSERT(!m_streamInfoFromSource ||
+            *m_streamInfoFromSource == streamInfoFromSource) {
+        kLogger.warning()
+                << "Varying stream properties:"
+                << *m_streamInfoFromSource
+                << "->"
+                << streamInfoFromSource;
+    }
+    m_streamInfoFromSource = streamInfoFromSource;
+    // Stream info from source is always propagated to metadata and
+    // unconditionally overwrites any properties that have once been
+    // parsed from file tags! This is required to store the most
+    // accurate information about the audio stream in the database.
+    const bool metadataUpdated = refMetadata().updateStreamInfoFromSource(streamInfoFromSource);
+    DEBUG_ASSERT(getMetadata().getStreamInfo() == streamInfoFromSource);
+    return metadataUpdated;
+}
+
+bool operator==(const TrackRecord& lhs, const TrackRecord& rhs) {
+    // m_streamInfoFromSource must not be considered for equality
+    // comparisons! It is only needed for verifying consistency
+    // during updates and as a flags when a track is loaded.
+    return lhs.getMetadata() == rhs.getMetadata() &&
+            lhs.getCoverInfo() == rhs.getCoverInfo() &&
+            lhs.getId() == rhs.getId() &&
+            lhs.getMetadataSynchronized() == rhs.getMetadataSynchronized() &&
+            lhs.getDateAdded() == rhs.getDateAdded() &&
+            lhs.getFileType() == rhs.getFileType() &&
+            lhs.getUrl() == rhs.getUrl() &&
+            lhs.getPlayCounter() == rhs.getPlayCounter() &&
+            lhs.getColor() == rhs.getColor() &&
+            lhs.getCuePoint() == rhs.getCuePoint() &&
+            lhs.getBpmLocked() == rhs.getBpmLocked() &&
+            lhs.getKeys() == rhs.getKeys() &&
+            lhs.getRating() == rhs.getRating();
 }
 
 } // namespace mixxx

--- a/src/track/trackrecord.h
+++ b/src/track/trackrecord.h
@@ -134,6 +134,26 @@ class TrackRecord final {
 private:
     Keys m_keys;
 
+    // TODO: Use TrackMetadata as single source of truth and do not
+    // store this information redundantly.
+    //
+    // PROPOSAL (as implememted by https://gitlab.com/uklotzde/aoide-rs):
+    // This redesign requires to track the status of some or all track
+    // metadata (which includes the stream info properties) by a set of
+    // bitflags:
+    //  - UNRELIABLE = 0 (default)
+    //    Parsed from file tags which are considered inaccurate and
+    //    are often imprecise
+    //  - RELIABLE =   1 << 0
+    //    Reported by a decoder when opening an audio/video stream for
+    //    reading. Nevertheless different decoders may report slightly
+    //    differing values.
+    //  - LOCKED =     1 << 1
+    //    Locked metadata will not be updated automatically, neither when
+    //    parsing file tags nor when decoding an audio/video stream.
+    //    While locked the stale flag is never set.
+    //  - STALE =      1 << 2
+    //    Stale metadata should be re-imported depending on the other flags.
     std::optional<audio::StreamInfo> m_streamInfoFromSource;
 
     /// Equality comparison

--- a/src/track/trackrecord.h
+++ b/src/track/trackrecord.h
@@ -136,6 +136,11 @@ private:
 
     std::optional<audio::StreamInfo> m_streamInfoFromSource;
 
+    /// Equality comparison
+    ///
+    /// Exception: The member m_streamInfoFromSource must not be considered
+    /// for equality comparisons! It is only needed for verifying consistency
+    /// during updates and as a flags when a track is loaded.
     friend bool operator==(const TrackRecord& lhs, const TrackRecord& rhs);
 };
 

--- a/src/track/trackrecord.h
+++ b/src/track/trackrecord.h
@@ -114,8 +114,33 @@ class TrackRecord final {
     bool mergeImportedMetadata(
             const TrackMetadata& importedMetadata);
 
+    /// Update the stream info after opening the audio stream during
+    /// a session.
+    /// Returns true if the corresponding metadata properties have been
+    /// updated and false otherwise.
+    bool updateStreamInfoFromSource(
+            const mixxx::audio::StreamInfo& streamInfoFromSource);
+    /// Check if the stream info is supposed to be reliable and accurate.
+    /// TODO: Also flag the stream info as "accurate" in the database and
+    /// invoke updateStreamInfoFromSource() accordingly when loading tracks
+    /// from the database.
+    bool hasStreamInfoFromSource() const {
+        return static_cast<bool>(m_streamInfoFromSource);
+    }
+    const std::optional<audio::StreamInfo>& getStreamInfoFromSource() const {
+        return m_streamInfoFromSource;
+    }
+
 private:
     Keys m_keys;
+
+    std::optional<audio::StreamInfo> m_streamInfoFromSource;
+
+    friend bool operator==(const TrackRecord& lhs, const TrackRecord& rhs);
 };
+
+inline bool operator!=(const TrackRecord& lhs, const TrackRecord& rhs) {
+    return !(lhs == rhs);
+}
 
 } // namespace mixxx


### PR DESCRIPTION
Do not throw away the stream info properties when (re-)importing track metadata.