### PR TITLE
GitHub Workflow: Individual Build Types 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
               -DMODPLUG=ON
               -DWAVPACK=ON
             cmake_generator: Unix Makefiles
+            cmake_build_type: Release
             ctest_args:
             compiler_cache: ccache
             compiler_cache_path: ~/.ccache
@@ -38,6 +39,7 @@ jobs:
               -DMODPLUG=ON
               -DWAVPACK=ON
             cmake_generator: Unix Makefiles
+            cmake_build_type: Release
             ctest_args:
             compiler_cache: ccache
             compiler_cache_path: ~/.ccache
@@ -54,6 +56,7 @@ jobs:
               -DHSS1394=ON
               -DMACOS_BUNDLE=ON
             cmake_generator: Unix Makefiles
+            cmake_build_type: Release
             # TODO: Fix this broken test on macOS
             ctest_args: --exclude-regex DirectoryDAOTest.relocateDirectory
             cpack_generator: DragNDrop
@@ -76,6 +79,7 @@ jobs:
             cc: cl
             cxx: cl
             cmake_generator: Ninja
+            cmake_build_type: Release
             # TODO: Fix these broken tests on Windows
             ctest_args: --exclude-regex '^AutoDJProcessorTest.*$'
             cpack_generator: WIX
@@ -195,7 +199,7 @@ jobs:
       run: >-
         cmake
         -G "${{ matrix.cmake_generator }}"
-        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }}
         "-DCMAKE_PREFIX_PATH=${{ env.CMAKE_PREFIX_PATH }}"
         -DDEBUG_ASSERTIONS_FATAL=ON
         -DQt5_DIR=${{ env.QT_PATH }} ${{ matrix.cmake_args }} ${{ env.CMAKE_ARGS_EXTRA }}
@@ -207,6 +211,7 @@ jobs:
         -DOPUS=ON
         -DQTKEYCHAIN=ON
         -DVINYLCONTROL=ON
+        -DCMAKE_VERBOSE_MAKEFILE=OFF
         ..
       working-directory: build
       env:
@@ -222,7 +227,7 @@ jobs:
       uses: ammaraskar/msvc-problem-matcher@master
 
     - name: "Build"
-      run: cmake --build .
+      run: cmake --build . --config ${{ matrix.cmake_build_type }}
       working-directory: build
       env:
         CC: ${{ matrix.cc }}
@@ -247,7 +252,7 @@ jobs:
         CTEST_OUTPUT_ON_FAILURE: 1
 
     - name: Benchmark
-      run: cmake --build . --target mixxx-benchmark
+      run: cmake --build . --target mixxx-benchmark --config Release
       working-directory: build
       env:
         # Render analyzer waveform tests to an offscreen buffer

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,7 +211,7 @@ jobs:
         -DOPUS=ON
         -DQTKEYCHAIN=ON
         -DVINYLCONTROL=ON
-        -DCMAKE_VERBOSE_MAKEFILE=ON
+        -DCMAKE_VERBOSE_MAKEFILE=OFF
         ..
       working-directory: build
       env:
@@ -252,7 +252,7 @@ jobs:
         CTEST_OUTPUT_ON_FAILURE: 1
 
     - name: Benchmark
-      run: cmake --build . --target mixxx-benchmark --config RelWithDebInfo
+      run: cmake --build . --target mixxx-benchmark --config ${{ matrix.cmake_build_type }}
       working-directory: build
       env:
         # Render analyzer waveform tests to an offscreen buffer


### PR DESCRIPTION
This makes the build type individual configurable. 
And supports multi config generators. 

Since Ninja does not a support fully verbose builds, temporary using Visual Studio is useful.  
This fails in 2.3 with obscure link errors because it build the Debug Build even though Release is requested during the configure stage.  