### PR TITLE
Remove not working CMAKE_MSVC_RUNTIME_LIBRARY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,7 +254,6 @@ if(WIN32)
   # Add support for lib prefix on Windows
   set(CMAKE_FIND_LIBRARY_PREFIXES "" "lib")
 endif()
-set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 
 # Get the current working branch
 execute_process(


### PR DESCRIPTION
I have checked with https://github.com/mixxxdj/mixxx/pull/3561 that CMake picks the right /MDd / /MD flag by default. 

CMAKE_MSVC_RUNTIME_LIBRARY is an option to override the default behaviour. However, this is only working from cmake 3.15. and if explicit enabled by CMP0091.

See: https://cmake.org/cmake/help/git-stage/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html

During Debug it tricks me that it had no effect. 

So let's remove this pit fall.  