### PR TITLE
Added PDB file option to windows installer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1348,7 +1348,7 @@ if(UNIX AND NOT APPLE)
 endif()
 
 if(MSVC)
-  # install debug symbols if any where generated
+  # install debug symbols if any were generated
   install(
     FILES $<TARGET_PDB_FILE:mixxx>
     CONFIGURATIONS Debug RelWithDebInfo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1347,6 +1347,17 @@ if(UNIX AND NOT APPLE)
   endif()
 endif()
 
+if(MSVC)
+  # install debug symbols if any where generated
+  install(
+    FILES $<TARGET_PDB_FILE:mixxx>
+    CONFIGURATIONS Debug RelWithDebInfo
+    DESTINATION "${MIXXX_INSTALL_BINDIR}"
+    COMPONENT PDB
+  )
+endif()
+
+
 #
 # Tests
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1353,7 +1353,7 @@ if(MSVC)
     FILES $<TARGET_PDB_FILE:mixxx>
     CONFIGURATIONS Debug RelWithDebInfo
     DESTINATION "${MIXXX_INSTALL_BINDIR}"
-    COMPONENT PDB
+    COMPONENT "Debug Information (PDB)"
   )
 endif()
 


### PR DESCRIPTION
This optional installs debug Symbols on windows. 

https://bugs.launchpad.net/mixxx/+bug/1912546 