### PR TITLE
Remove install path dependency from Linux builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1075,12 +1075,6 @@ elseif (UNIX)
   set(MIXXX_INSTALL_LICENSEDIR "${CMAKE_INSTALL_DOCDIR}")
 endif()
 
-# Required to find the resource files when running from the build dir
-target_compile_definitions(
-      mixxx-lib PUBLIC CMAKE_CURRENT_BINARY_DIR="${CMAKE_CURRENT_BINARY_DIR}")
-target_compile_definitions(
-      mixxx-lib PUBLIC CMAKE_CURRENT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
-
 if(WIN32)
   target_compile_definitions(mixxx-lib PRIVATE __WINDOWS__)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1075,6 +1075,12 @@ elseif (UNIX)
   set(MIXXX_INSTALL_LICENSEDIR "${CMAKE_INSTALL_DOCDIR}")
 endif()
 
+# Required to find the resource files when running from the build dir
+target_compile_definitions(
+      mixxx-lib PUBLIC CMAKE_CURRENT_BINARY_DIR="${CMAKE_CURRENT_BINARY_DIR}")
+target_compile_definitions(
+      mixxx-lib PUBLIC CMAKE_CURRENT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
+
 if(WIN32)
   target_compile_definitions(mixxx-lib PRIVATE __WINDOWS__)
 
@@ -1110,10 +1116,6 @@ elseif(UNIX)
     target_compile_definitions(mixxx-lib PUBLIC __APPLE__)
   else()
     target_compile_definitions(mixxx-lib PRIVATE __UNIX__)
-    # UNIX_SHARE_PATH must be set to the absolute path
-    # including the install prefix!
-    target_compile_definitions(
-      mixxx-lib PUBLIC UNIX_SHARE_PATH="${CMAKE_INSTALL_PREFIX}/${MIXXX_INSTALL_DATADIR}")
     if(CMAKE_SYSTEM_NAME STREQUAL Linux)
       target_compile_definitions(mixxx-lib PUBLIC __LINUX__)
     elseif(CMAKE_SYSTEM_NAME MATCHES "^.*BSD$")
@@ -1538,40 +1540,6 @@ set_target_properties(mixxx-qrc PROPERTIES AUTORCC ON)
 # at: https://doc.qt.io/qt5/resources.html#using-resources-in-a-library
 target_sources(mixxx PRIVATE $<TARGET_OBJECTS:mixxx-qrc>)
 target_sources(mixxx-test PRIVATE $<TARGET_OBJECTS:mixxx-qrc>)
-
-if(UNIX AND USE_SYMLINKS)
-  add_custom_target(mixxx-res
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/res" "${CMAKE_CURRENT_BINARY_DIR}/res"
-    COMMENT "Symlinking resources to build directory..."
-  )
-  add_custom_target(mixxx-script
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/script" "${CMAKE_CURRENT_BINARY_DIR}/script"
-    COMMENT "Symlinking to build directory..."
-  )
-elseif(WIN32)
-  file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/res" CMAKE_CURRENT_SOURCE_RES_DIR_NATIVE)
-  file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/res/" CMAKE_CURRENT_BINARY_RES_DIR_NATIVE)
-  add_custom_target(mixxx-res
-    COMMAND xcopy ${CMAKE_CURRENT_SOURCE_RES_DIR_NATIVE} ${CMAKE_CURRENT_BINARY_RES_DIR_NATIVE} /s /d /q /y
-    COMMENT "Copying missing or modified resources files to build directory..."
-  )
-  file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/script" CMAKE_CURRENT_SOURCE_SCRIPT_DIR_NATIVE)
-  file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/script/" CMAKE_CURRENT_BINARY_SCRIPT_DIR_NATIVE)
-  add_custom_target(mixxx-script
-    COMMAND xcopy ${CMAKE_CURRENT_SOURCE_SCRIPT_DIR_NATIVE} ${CMAKE_CURRENT_BINARY_SCRIPT_DIR_NATIVE} /s /d /q /y
-    COMMENT "Copying missing or modified QScriptEngine extension files to build directory..."
-  )
-else()
-  add_custom_target(mixxx-res
-    COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/res" "${CMAKE_CURRENT_BINARY_DIR}/res"
-    COMMENT "Copying all resources files to build directory..."
-  )
-  add_custom_target(mixxx-script
-    COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/script" "${CMAKE_CURRENT_BINARY_DIR}/script"
-    COMMENT "Copying all QScriptEngine extension files to build directory..."
-  )
-endif()
-add_dependencies(mixxx-lib mixxx-res mixxx-script)
 
 file(READ src/_version.h MIXXX_VERSION_FILECONTENT)
 string(REGEX REPLACE "^.*#define MIXXX_VERSION \"(.*)\".*$" "\\1" MIXXX_VERSION "${MIXXX_VERSION_FILECONTENT}")

--- a/src/preferences/configobject.cpp
+++ b/src/preferences/configobject.cpp
@@ -31,17 +31,17 @@ QString computeResourcePath() {
             // We are running form a build dir, use resources from the source path
             qResourcePath = QStringLiteral(CMAKE_CURRENT_SOURCE_DIR) + QStringLiteral("/res");
         }
-#ifdef __UNIX__
+#if defined(__UNIX__)
         else if (mixxxDir.cdUp() && mixxxDir.cd(QStringLiteral("/share/mixxx"))) {
             qResourcePath = mixxxDir.absolutePath();
         }
-#elif __WINDOWS__
+#elif defined(__WINDOWS__)
         // On Windows, set the config dir relative to the application dir if all
         // of the above fail.
         else {
             qResourcePath = QCoreApplication::applicationDirPath();
         }
-#elif __APPLE__
+#elif defined(__APPLE__)
         else if (mixxxDir.cdUp() && mixxxDir.cd("Resources")) {
             // Release configuration
             qResourcePath = mixxxDir.absolutePath();


### PR DESCRIPTION
This is required because the install path is changed by cpack -G deb after building the binaries. 

Now it creates the install prefix from the binary location. 

For debugging, it holds now the cmake bin and source directory to find the resources without copying them around.
This has already caused some issues on windows, because there we cant use a symlink. 