### PR TITLE
PLAYdifferently style semiparametric EQ effects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -560,6 +560,8 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/effects/backends/builtin/reverbeffect.cpp
   src/effects/backends/builtin/threebandbiquadeqeffect.cpp
   src/effects/backends/builtin/tremoloeffect.cpp
+  src/effects/backends/builtin/semiparametriceq3knobeffect.cpp
+  src/effects/backends/builtin/semiparametriceq4knobeffect.cpp
   src/effects/backends/builtin/whitenoiseeffect.cpp
   src/effects/backends/effectsbackendmanager.cpp
   src/effects/chains/equalizereffectchain.cpp

--- a/res/skins/Deere/mixer_column_eq_left.xml
+++ b/res/skins/Deere/mixer_column_eq_left.xml
@@ -10,6 +10,10 @@
     <SizePolicy>min,p</SizePolicy>
     <Children>
       <Template src="skin:equalizer_rack_parameter_left.xml">
+        <SetVariable name="parameter">4</SetVariable>
+      </Template>
+
+      <Template src="skin:equalizer_rack_parameter_left.xml">
         <SetVariable name="parameter">3</SetVariable>
       </Template>
 

--- a/res/skins/Deere/mixer_column_eq_right.xml
+++ b/res/skins/Deere/mixer_column_eq_right.xml
@@ -10,6 +10,10 @@
     <SizePolicy>min,min</SizePolicy>
     <Children>
       <Template src="skin:equalizer_rack_parameter_right.xml">
+        <SetVariable name="parameter">4</SetVariable>
+      </Template>
+
+      <Template src="skin:equalizer_rack_parameter_right.xml">
         <SetVariable name="parameter">3</SetVariable>
       </Template>
 

--- a/res/skins/LateNight/mixer/channel_4decks.xml
+++ b/res/skins/LateNight/mixer/channel_4decks.xml
@@ -37,6 +37,13 @@
       <WidgetGroup><Size>1min,3f</Size></WidgetGroup>
 
       <Template src="skin:/mixer/eq_knob_4decks.xml">
+        <SetVariable name="EqParameter">4</SetVariable>
+        <SetVariable name="EqRange"></SetVariable>
+      </Template>
+
+      <WidgetGroup><Size>1min,3f</Size></WidgetGroup>
+
+      <Template src="skin:/mixer/eq_knob_4decks.xml">
         <SetVariable name="EqParameter">3</SetVariable>
         <SetVariable name="EqRange">High</SetVariable>
       </Template>

--- a/res/skins/LateNight/mixer/channel_left.xml
+++ b/res/skins/LateNight/mixer/channel_left.xml
@@ -24,6 +24,13 @@ vertical layout and a side-by-side layout for two-deck mode -->
         <Children>
 
           <Template src="skin:/mixer/eq_knob_left.xml">
+            <SetVariable name="EqParameter">4</SetVariable>
+            <SetVariable name="EqRange"></SetVariable>
+          </Template>
+
+          <WidgetGroup><Size>1min,2f</Size></WidgetGroup>
+
+          <Template src="skin:/mixer/eq_knob_left.xml">
             <SetVariable name="EqParameter">3</SetVariable>
             <SetVariable name="EqRange">High</SetVariable>
           </Template>

--- a/res/skins/LateNight/mixer/channel_right.xml
+++ b/res/skins/LateNight/mixer/channel_right.xml
@@ -60,6 +60,13 @@ vertical layout and a reversed side-by-side layout for two-deck mode -->
         <Children>
 
           <Template src="skin:/mixer/eq_knob_right.xml">
+            <SetVariable name="EqParameter">4</SetVariable>
+            <SetVariable name="EqRange"></SetVariable>
+          </Template>
+
+          <WidgetGroup><Size>1min,2f</Size></WidgetGroup>
+
+          <Template src="skin:/mixer/eq_knob_right.xml">
             <SetVariable name="EqParameter">3</SetVariable>
             <SetVariable name="EqRange">High</SetVariable>
           </Template>

--- a/res/skins/Shade/mixer_panel.xml
+++ b/res/skins/Shade/mixer_panel.xml
@@ -339,6 +339,29 @@
                 </State>
                 <Pos>11,84</Pos>
                 <Connection>
+                  <ConfigKey>[EqualizerRack1_[Channel1]_Effect1],button_parameter4</ConfigKey>
+                  <EmitOnPressAndRelease>true</EmitOnPressAndRelease>
+                  <ButtonState>LeftButton</ButtonState>
+                </Connection>
+                <Connection>
+                  <ConfigKey>[EqualizerRack1_[Channel1]_Effect1],button_parameter4_loaded</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+              </EffectPushButton>
+              <EffectPushButton>
+                <NumberStates>2</NumberStates>
+                <State>
+                  <Number>0</Number>
+                  <Pressed>skin:/btn/btn_kill_down.png</Pressed>
+                  <Unpressed>skin:/btn/btn_kill.png</Unpressed>
+                </State>
+                <State>
+                  <Number>1</Number>
+                  <Pressed>skin:/btn/btn_kill_overdown.png</Pressed>
+                  <Unpressed>skin:/btn/btn_kill_over.png</Unpressed>
+                </State>
+                <Pos>11,84</Pos>
+                <Connection>
                   <ConfigKey>[EqualizerRack1_[Channel1]_Effect1],button_parameter3</ConfigKey>
                   <EmitOnPressAndRelease>true</EmitOnPressAndRelease>
                   <ButtonState>LeftButton</ButtonState>
@@ -405,6 +428,29 @@
                 <EffectUnitGroup>[EqualizerRack1_[Channel1]]</EffectUnitGroup>
                 <Effect>1</Effect>
                 <EffectButtonParameter>3</EffectButtonParameter>
+                <NumberStates>2</NumberStates>
+                <State>
+                  <Number>0</Number>
+                  <Pressed>skin:/btn/btn_kill_down.png</Pressed>
+                  <Unpressed>skin:/btn/btn_kill.png</Unpressed>
+                </State>
+                <State>
+                  <Number>1</Number>
+                  <Pressed>skin:/btn/btn_kill_overdown.png</Pressed>
+                  <Unpressed>skin:/btn/btn_kill_over.png</Unpressed>
+                </State>
+                <Pos>229,84</Pos>
+                <Connection>
+                  <ConfigKey>[EqualizerRack1_[Channel2]_Effect1],button_parameter4</ConfigKey>
+                  <EmitOnPressAndRelease>true</EmitOnPressAndRelease>
+                  <ButtonState>LeftButton</ButtonState>
+                </Connection>
+                <Connection>
+                  <ConfigKey>[EqualizerRack1_[Channel2]_Effect1],button_parameter4_loaded</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+              </EffectPushButton>
+              <EffectPushButton>
                 <NumberStates>2</NumberStates>
                 <State>
                   <Number>0</Number>
@@ -728,6 +774,18 @@
                 <Path>knobs/knob_rotary_s%1.png</Path>
                 <Pos>32,76</Pos>
                 <Connection>
+                  <ConfigKey>[EqualizerRack1_[Channel1]_Effect1],parameter4</ConfigKey>
+                </Connection>
+                <Connection>
+                  <ConfigKey>[EqualizerRack1_[Channel1]_Effect1],parameter4_loaded</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+              </EffectParameterKnob>
+              <EffectParameterKnob>
+                <NumberStates>64</NumberStates>
+                <Path>knobs/knob_rotary_s%1.png</Path>
+                <Pos>32,76</Pos>
+                <Connection>
                   <ConfigKey>[EqualizerRack1_[Channel1]_Effect1],parameter3</ConfigKey>
                 </Connection>
                 <Connection>
@@ -782,6 +840,18 @@
                 <NumberStates>64</NumberStates>
                 <Path>knobs/knob_rotary_s%1.png</Path>
                 <Pos>197,76</Pos>
+                <Connection>
+                  <ConfigKey>[EqualizerRack1_[Channel2]_Effect1],parameter4</ConfigKey>
+                </Connection>
+                <Connection>
+                  <ConfigKey>[EqualizerRack1_[Channel2]_Effect1],parameter4_loaded</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+              </EffectParameterKnob>
+              <EffectParameterKnob>
+                <NumberStates>64</NumberStates>
+                <Path>knobs/knob_rotary_s%1.png</Path>
+                <Pos>196,76</Pos>
                 <Connection>
                   <ConfigKey>[EqualizerRack1_[Channel2]_Effect1],parameter3</ConfigKey>
                 </Connection>

--- a/res/skins/Tango/mixer/mixer_channel_left.xml
+++ b/res/skins/Tango/mixer/mixer_channel_left.xml
@@ -25,6 +25,9 @@ Variables:
         <SizePolicy>max,min</SizePolicy>
         <Children>
           <WidgetGroup><Size>1min,4f</Size></WidgetGroup>
+          <Template src="skin:../Tango/mixer/eq_knob_left.xml"><!-- 4th EQ knob -->
+            <SetVariable name="FxParameter">4</SetVariable>
+          </Template>
           <Template src="skin:../Tango/mixer/eq_knob_left.xml"><!-- High EQ -->
             <SetVariable name="FxParameter">3</SetVariable>
           </Template>

--- a/res/skins/Tango/mixer/mixer_channel_right.xml
+++ b/res/skins/Tango/mixer/mixer_channel_right.xml
@@ -99,6 +99,9 @@ Variables:
         <SizePolicy>max,min</SizePolicy>
         <Children>
           <WidgetGroup><Size>1min,4f</Size></WidgetGroup>
+          <Template src="skin:../Tango/mixer/eq_knob_right.xml"><!-- 4th EQ knob -->
+            <SetVariable name="FxParameter">4</SetVariable>
+          </Template>
           <Template src="skin:../Tango/mixer/eq_knob_right.xml"><!-- High EQ -->
             <SetVariable name="FxParameter">3</SetVariable>
           </Template>

--- a/src/effects/backends/builtin/builtinbackend.cpp
+++ b/src/effects/backends/builtin/builtinbackend.cpp
@@ -14,6 +14,8 @@
 #include "effects/backends/builtin/linkwitzriley8eqeffect.h"
 #include "effects/backends/builtin/moogladder4filtereffect.h"
 #include "effects/backends/builtin/parametriceqeffect.h"
+#include "effects/backends/builtin/semiparametriceq3knobeffect.h"
+#include "effects/backends/builtin/semiparametriceq4knobeffect.h"
 #include "effects/backends/builtin/threebandbiquadeqeffect.h"
 #ifndef __MACAPPSTORE__
 #include "effects/backends/builtin/reverbeffect.h"
@@ -34,6 +36,8 @@ BuiltInBackend::BuiltInBackend() {
     registerEffect<LinkwitzRiley8EQEffect>();
     registerEffect<ThreeBandBiquadEQEffect>();
     registerEffect<BiquadFullKillEQEffect>();
+    registerEffect<SemiparametricEQEffect4Knob>();
+    registerEffect<SemiparametricEQEffect3Knob>();
     // Compensations EQs
     registerEffect<GraphicEQEffect>();
     registerEffect<ParametricEQEffect>();

--- a/src/effects/backends/builtin/equalizer_util.h
+++ b/src/effects/backends/builtin/equalizer_util.h
@@ -8,8 +8,11 @@ class EqualizerUtil {
   public:
     // Creates common EQ parameters like low/mid/high gain and kill buttons.
     static void createCommonParameters(EffectManifest* pManifest, bool linear) {
+        pManifest->setIsWaveformChangingEQ(true);
+
         EffectManifestParameter::ValueScaler valueScaler =
                 EffectManifestParameter::ValueScaler::Logarithmic;
+
         double maximum = 4.0;
         if (linear) {
             valueScaler = EffectManifestParameter::ValueScaler::Linear;

--- a/src/effects/backends/builtin/semiparametriceq3knobeffect.cpp
+++ b/src/effects/backends/builtin/semiparametriceq3knobeffect.cpp
@@ -1,0 +1,131 @@
+#include "semiparametriceq3knobeffect.h"
+
+#include "semiparametriceqconstants.h"
+
+using namespace mixxx::semiparametriceqs;
+
+SemiparametricEQEffect3KnobGroupState::SemiparametricEQEffect3KnobGroupState(
+        const mixxx::EngineParameters& engineParameters)
+        : EffectState(engineParameters),
+          m_highFilter(
+                  engineParameters.sampleRate(),
+                  kMinCornerHz / engineParameters.sampleRate(),
+                  kLpfHpfQ,
+                  true),
+          m_semiParametricFilter(
+                  engineParameters.sampleRate(), 1000, kSemiparametricQ),
+          m_lowFilter(
+                  engineParameters.sampleRate(),
+                  kMaxCornerHz / engineParameters.sampleRate(),
+                  kLpfHpfQ,
+                  true),
+          m_intermediateBuffer(engineParameters.samplesPerBuffer()),
+          m_filterBehavior(kMinCornerHz, kMaxCornerHz, -40),
+          m_dCenterOld(0),
+          m_dGainOld(0),
+          m_dFilterOld(0) {
+}
+
+// static
+QString SemiparametricEQEffect3Knob::getId() {
+    return QStringLiteral("org.mixxx.effects.semiparametriceq3knob");
+}
+
+EffectManifestPointer SemiparametricEQEffect3Knob::getManifest() {
+    EffectManifestPointer pManifest(new EffectManifest());
+    pManifest->setId(getId());
+    pManifest->setName(QObject::tr("Semiparametric Equalizer (3 knobs)"));
+    pManifest->setShortName(QObject::tr("Semiparam 3"));
+    pManifest->setAuthor(QStringLiteral("The Mixxx Team"));
+    pManifest->setVersion(QStringLiteral("1.0"));
+    pManifest->setDescription(
+            QObject::tr("A semiparametric EQ effect modeled after the "
+                        "PLAYdifferently Model 1 hardware mixer."));
+    pManifest->setEffectRampsFromDry(true);
+    pManifest->setIsMixingEQ(true);
+
+    EffectManifestParameterPointer filter = pManifest->addParameter();
+    filter->setId(QStringLiteral("filter"));
+    filter->setName(QObject::tr("Filter"));
+    filter->setDescription(
+            QObject::tr("Bipolar filter knob. Controls corner frequency ratio "
+                        "of the high pass filter on the left and corner "
+                        "frequency of the low pass filter on the right."));
+    filter->setRange(0, 0.5, 1);
+
+    EffectManifestParameterPointer gain = pManifest->addParameter();
+    gain->setId(QStringLiteral("gain"));
+    gain->setName(QObject::tr("Gain"));
+    gain->setDescription(QObject::tr("Gain of the semiparametric EQ"));
+    gain->setRange(0, 1, 4);
+    gain->setUnitsHint(EffectManifestParameter::UnitsHint::Decibels);
+
+    EffectManifestParameterPointer center = pManifest->addParameter();
+    center->setId(QStringLiteral("center"));
+    center->setName(QObject::tr("Center"));
+    center->setDescription(QObject::tr("Center frequency of the semiparametric EQ"));
+    center->setUnitsHint(EffectManifestParameter::UnitsHint::Hertz);
+    center->setRange(70, 1000, 7000);
+
+    return pManifest;
+}
+
+void SemiparametricEQEffect3Knob::loadEngineEffectParameters(
+        const QMap<QString, EngineEffectParameterPointer>& parameters) {
+    m_pCenter = parameters.value(QStringLiteral("center"));
+    m_pGain = parameters.value(QStringLiteral("gain"));
+    m_pFilter = parameters.value(QStringLiteral("filter"));
+}
+
+void SemiparametricEQEffect3Knob::processChannel(
+        SemiparametricEQEffect3KnobGroupState* channelState,
+        const CSAMPLE* pInput,
+        CSAMPLE* pOutput,
+        const mixxx::EngineParameters& engineParameters,
+        const EffectEnableState enableState,
+        const GroupFeatureState& groupFeatures) {
+    Q_UNUSED(enableState);
+    Q_UNUSED(groupFeatures);
+
+    double center = m_pCenter->value();
+    double gain = m_pGain->value();
+    double filter = m_pFilter->value();
+
+    if (center != channelState->m_dCenterOld || gain != channelState->m_dGainOld) {
+        double db = gain - 1.0;
+        if (db >= 0) {
+            db *= kSemiparametricMaxBoostDb;
+        } else {
+            db *= -kSemiparametricMaxCutDb;
+        }
+        channelState->m_semiParametricFilter.setFrequencyCorners(
+                engineParameters.sampleRate(), center, kSemiparametricQ, db);
+    }
+    if (filter != channelState->m_dFilterOld) {
+        double lpf = channelState->m_filterBehavior.parameterToValue(
+                             std::min((filter * 2.0), 1.0)) /
+                engineParameters.sampleRate();
+        double hpf = channelState->m_filterBehavior.parameterToValue(
+                             std::max((filter - 0.5) * 2.0, 0.0)) /
+                engineParameters.sampleRate();
+        channelState->m_lowFilter.setFrequencyCorners(1, lpf, kLpfHpfQ);
+        channelState->m_highFilter.setFrequencyCorners(1, hpf, kLpfHpfQ);
+    }
+
+    channelState->m_lowFilter.process(
+            pInput,
+            channelState->m_intermediateBuffer.data(),
+            engineParameters.samplesPerBuffer());
+    channelState->m_semiParametricFilter.process(
+            channelState->m_intermediateBuffer.data(),
+            channelState->m_intermediateBuffer.data(),
+            engineParameters.samplesPerBuffer());
+    channelState->m_highFilter.process(
+            channelState->m_intermediateBuffer.data(),
+            pOutput,
+            engineParameters.samplesPerBuffer());
+
+    channelState->m_dCenterOld = center;
+    channelState->m_dGainOld = gain;
+    channelState->m_dFilterOld = filter;
+}

--- a/src/effects/backends/builtin/semiparametriceq3knobeffect.h
+++ b/src/effects/backends/builtin/semiparametriceq3knobeffect.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "effects/backends/effectprocessor.h"
+#include "engine/effects/engineeffect.h"
+#include "engine/filters/enginefilterbiquad1.h"
+#include "util/samplebuffer.h"
+
+class SemiparametricEQEffect3KnobGroupState : public EffectState {
+  public:
+    SemiparametricEQEffect3KnobGroupState(const mixxx::EngineParameters& bufferParameters);
+
+    EngineFilterBiquad1High m_highFilter;
+    EngineFilterBiquad1Peaking m_semiParametricFilter;
+    EngineFilterBiquad1Low m_lowFilter;
+
+    mixxx::SampleBuffer m_intermediateBuffer;
+    ControlLogPotmeterBehavior m_filterBehavior;
+
+    double m_dCenterOld;
+    double m_dGainOld;
+    double m_dFilterOld;
+};
+
+class SemiparametricEQEffect3Knob
+        : public EffectProcessorImpl<SemiparametricEQEffect3KnobGroupState> {
+  public:
+    SemiparametricEQEffect3Knob() = default;
+
+    static QString getId();
+    static EffectManifestPointer getManifest();
+
+    void loadEngineEffectParameters(
+            const QMap<QString, EngineEffectParameterPointer>& parameters) override;
+
+    void processChannel(
+            SemiparametricEQEffect3KnobGroupState* channelState,
+            const CSAMPLE* pInput,
+            CSAMPLE* pOutput,
+            const mixxx::EngineParameters& engineParameters,
+            const EffectEnableState enableState,
+            const GroupFeatureState& groupFeatures) override;
+
+  private:
+    QString debugString() const {
+        return getId();
+    }
+
+    EngineEffectParameterPointer m_pCenter;
+    EngineEffectParameterPointer m_pGain;
+    EngineEffectParameterPointer m_pFilter;
+
+    unsigned int m_oldSampleRate;
+
+    DISALLOW_COPY_AND_ASSIGN(SemiparametricEQEffect3Knob);
+};

--- a/src/effects/backends/builtin/semiparametriceq4knobeffect.cpp
+++ b/src/effects/backends/builtin/semiparametriceq4knobeffect.cpp
@@ -1,0 +1,144 @@
+#include "semiparametriceq4knobeffect.h"
+
+#include "semiparametriceqconstants.h"
+
+using namespace mixxx::semiparametriceqs;
+
+SemiparametricEQEffect4KnobGroupState::SemiparametricEQEffect4KnobGroupState(
+        const mixxx::EngineParameters& engineParameters)
+        : EffectState(engineParameters),
+          m_highFilter(
+                  engineParameters.sampleRate(),
+                  kMinCornerHz / engineParameters.sampleRate(),
+                  kLpfHpfQ,
+                  true),
+          m_semiParametricFilter(
+                  engineParameters.sampleRate(), 1000, kSemiparametricQ),
+          m_lowFilter(
+                  engineParameters.sampleRate(),
+                  kMaxCornerHz / engineParameters.sampleRate(),
+                  kLpfHpfQ,
+                  true),
+          m_intermediateBuffer(engineParameters.samplesPerBuffer()),
+          m_dHpfOld(0),
+          m_dCenterOld(0),
+          m_dGainOld(0),
+          m_dLpfOld(0) {
+}
+// static
+QString SemiparametricEQEffect4Knob::getId() {
+    return QStringLiteral("org.mixxx.effects.semiparametriceq4knob");
+}
+
+EffectManifestPointer SemiparametricEQEffect4Knob::getManifest() {
+    EffectManifestPointer pManifest(new EffectManifest());
+    pManifest->setId(getId());
+    pManifest->setName(QObject::tr("Semiparametric Equalizer (4 knobs)"));
+    pManifest->setShortName(QObject::tr("Semiparam 4"));
+    pManifest->setAuthor(QStringLiteral("The Mixxx Team"));
+    pManifest->setVersion(QStringLiteral("1.0"));
+    pManifest->setDescription(
+            QObject::tr("A semiparametric EQ effect modeled after the "
+                        "PLAYdifferently Model 1 hardware mixer."));
+    pManifest->setEffectRampsFromDry(true);
+    pManifest->setIsMixingEQ(true);
+
+    EffectManifestParameterPointer filter = pManifest->addParameter();
+    filter->setId(QStringLiteral("filter"));
+    filter->setName(QObject::tr("Filter"));
+    filter->setDescription(
+            QObject::tr("Bipolar filter knob. Controls corner frequency ratio "
+                        "of the high pass filter on the left and corner "
+                        "frequency of the low pass filter on the right."));
+    filter->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    filter->setRange(0, 0.5, 1);
+
+    EffectManifestParameterPointer gain = pManifest->addParameter();
+    gain->setId(QStringLiteral("gain"));
+    gain->setName(QObject::tr("Gain"));
+    gain->setDescription(QObject::tr("Gain of the semiparametric EQ"));
+    gain->setRange(0, 1, 4);
+    gain->setUnitsHint(EffectManifestParameter::UnitsHint::Decibels);
+
+    EffectManifestParameterPointer center = pManifest->addParameter();
+    center->setId(QStringLiteral("center"));
+    center->setName(QObject::tr("Center"));
+    center->setDescription(QObject::tr("Center frequency of the semiparametric EQ"));
+    center->setUnitsHint(EffectManifestParameter::UnitsHint::Hertz);
+    center->setRange(70, 1000, 7000);
+
+    EffectManifestParameterPointer hpf = pManifest->addParameter();
+    hpf->setId(QStringLiteral("hpf"));
+    hpf->setName(QObject::tr("HPF"));
+    hpf->setDescription(QObject::tr("Corner frequency ratio of the high pass filter"));
+    hpf->setRange(kMaxCornerHz, kMaxCornerHz, kMinCornerHz);
+    hpf->setNeutralPointOnScale(0.0);
+
+    EffectManifestParameterPointer lpf = pManifest->addParameter();
+    lpf->setId(QStringLiteral("lpf"));
+    lpf->setName(QObject::tr("LPF"));
+    lpf->setDescription(QObject::tr("Corner frequency ratio of the low pass filter"));
+    lpf->setRange(kMinCornerHz, kMaxCornerHz, kMaxCornerHz);
+    lpf->setNeutralPointOnScale(1);
+
+    return pManifest;
+}
+
+void SemiparametricEQEffect4Knob::loadEngineEffectParameters(
+        const QMap<QString, EngineEffectParameterPointer>& parameters) {
+    m_pHPF = parameters.value(QStringLiteral("hpf"));
+    m_pCenter = parameters.value(QStringLiteral("center"));
+    m_pGain = parameters.value(QStringLiteral("gain"));
+    m_pLPF = parameters.value(QStringLiteral("lpf"));
+}
+
+void SemiparametricEQEffect4Knob::processChannel(
+        SemiparametricEQEffect4KnobGroupState* channelState,
+        const CSAMPLE* pInput,
+        CSAMPLE* pOutput,
+        const mixxx::EngineParameters& engineParameters,
+        const EffectEnableState enableState,
+        const GroupFeatureState& groupFeatures) {
+    Q_UNUSED(enableState);
+    Q_UNUSED(groupFeatures);
+
+    double hpf = m_pHPF->value();
+    double center = m_pCenter->value();
+    double gain = m_pGain->value();
+    double lpf = m_pLPF->value();
+
+    if (center != channelState->m_dCenterOld || gain != channelState->m_dGainOld) {
+        double db = gain - 1.0;
+        if (db >= 0) {
+            db *= kSemiparametricMaxBoostDb;
+        } else {
+            db *= -kSemiparametricMaxCutDb;
+        }
+        channelState->m_semiParametricFilter.setFrequencyCorners(
+                engineParameters.sampleRate(), center, kSemiparametricQ, db);
+    }
+    if (hpf != channelState->m_dHpfOld) {
+        channelState->m_lowFilter.setFrequencyCorners(engineParameters.sampleRate(), hpf, kLpfHpfQ);
+    }
+    if (lpf != channelState->m_dLpfOld) {
+        channelState->m_lowFilter.setFrequencyCorners(engineParameters.sampleRate(), lpf, kLpfHpfQ);
+    }
+
+    channelState->m_highFilter.process(
+            pInput,
+            channelState->m_intermediateBuffer.data(),
+            engineParameters.samplesPerBuffer());
+    channelState->m_semiParametricFilter.process(
+            channelState->m_intermediateBuffer.data(),
+            channelState->m_intermediateBuffer.data(),
+            engineParameters.samplesPerBuffer());
+    channelState->m_lowFilter.process(
+            channelState->m_intermediateBuffer.data(),
+            pOutput,
+            engineParameters.samplesPerBuffer());
+
+    channelState->m_dHpfOld = hpf;
+    channelState->m_dCenterOld = center;
+    channelState->m_dGainOld = gain;
+    channelState->m_dLpfOld = lpf;
+}

--- a/src/effects/backends/builtin/semiparametriceq4knobeffect.h
+++ b/src/effects/backends/builtin/semiparametriceq4knobeffect.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "effects/backends/effectprocessor.h"
+#include "engine/effects/engineeffect.h"
+#include "engine/filters/enginefilterbiquad1.h"
+#include "util/samplebuffer.h"
+
+class SemiparametricEQEffect4KnobGroupState : public EffectState {
+  public:
+    SemiparametricEQEffect4KnobGroupState(const mixxx::EngineParameters& bufferParameters);
+
+    EngineFilterBiquad1High m_highFilter;
+    EngineFilterBiquad1Peaking m_semiParametricFilter;
+    EngineFilterBiquad1Low m_lowFilter;
+
+    mixxx::SampleBuffer m_intermediateBuffer;
+
+    double m_dHpfOld;
+    double m_dCenterOld;
+    double m_dGainOld;
+    double m_dLpfOld;
+};
+
+class SemiparametricEQEffect4Knob
+        : public EffectProcessorImpl<SemiparametricEQEffect4KnobGroupState> {
+  public:
+    SemiparametricEQEffect4Knob() = default;
+
+    static QString getId();
+    static EffectManifestPointer getManifest();
+
+    void loadEngineEffectParameters(
+            const QMap<QString, EngineEffectParameterPointer>& parameters) override;
+
+    void processChannel(
+            SemiparametricEQEffect4KnobGroupState* channelState,
+            const CSAMPLE* pInput,
+            CSAMPLE* pOutput,
+            const mixxx::EngineParameters& engineParameters,
+            const EffectEnableState enableState,
+            const GroupFeatureState& groupFeatures) override;
+
+  private:
+    QString debugString() const {
+        return getId();
+    }
+
+    EngineEffectParameterPointer m_pHPF;
+    EngineEffectParameterPointer m_pCenter;
+    EngineEffectParameterPointer m_pGain;
+    EngineEffectParameterPointer m_pLPF;
+
+    unsigned int m_oldSampleRate;
+
+    DISALLOW_COPY_AND_ASSIGN(SemiparametricEQEffect4Knob);
+};

--- a/src/effects/backends/builtin/semiparametriceqconstants.h
+++ b/src/effects/backends/builtin/semiparametriceqconstants.h
@@ -1,0 +1,14 @@
+namespace mixxx {
+
+namespace semiparametriceqs {
+
+constexpr double kMinCornerHz = 13;
+constexpr double kMaxCornerHz = 22050;
+constexpr double kLpfHpfQ = 0.1;
+constexpr double kSemiparametricQ = 0.4;
+constexpr double kSemiparametricMaxBoostDb = 8;
+constexpr double kSemiparametricMaxCutDb = -20;
+
+} // namespace semiparametriceqs
+
+} // namespace mixxx

--- a/src/effects/backends/effectmanifest.h
+++ b/src/effects/backends/effectmanifest.h
@@ -27,6 +27,7 @@ class EffectManifest {
     EffectManifest()
             : m_backendType(EffectBackendType::Unknown),
               m_isMixingEQ(false),
+              m_isWaveformChangingEQ(false),
               m_isMasterEQ(false),
               m_effectRampsFromDry(false),
               m_bAddDryToWet(false),
@@ -102,6 +103,14 @@ class EffectManifest {
 
     void setIsMixingEQ(const bool value) {
         m_isMixingEQ = value;
+    }
+
+    bool isWaveformChangingEQ() const {
+        return m_isWaveformChangingEQ;
+    }
+
+    void setIsWaveformChangingEQ(const bool value) {
+        m_isWaveformChangingEQ = value;
     }
 
     const bool& isMasterEQ() const {
@@ -183,6 +192,7 @@ class EffectManifest {
     QString m_description;
     /// This helps us at DlgPrefEQ's basic selection of Equalizers
     bool m_isMixingEQ;
+    bool m_isWaveformChangingEQ;
     bool m_isMasterEQ;
     QList<EffectManifestParameterPointer> m_parameters;
     bool m_effectRampsFromDry;

--- a/src/effects/backends/effectmanifestparameter.h
+++ b/src/effects/backends/effectmanifestparameter.h
@@ -41,6 +41,7 @@ class EffectManifestParameter {
         SampleRate,
         /// Multiples of a Beat
         Beats,
+        Decibels,
     };
 
     enum class LinkType : int {

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -476,10 +476,8 @@ void DlgPrefEQ::applySelectionsToDecks() {
             auto pChainSlot = m_pEffectsManager->getEqualizerEffectChain(group);
             auto pEffectSlot = pChainSlot->getEffectSlot(0);
             pEffectSlot->loadEffectWithDefaults(pManifest);
-            if (pManifest && pManifest->isMixingEQ()) {
-                pChainSlot->setFilterWaveform(true);
-            } else {
-                pChainSlot->setFilterWaveform(false);
+            if (pManifest) {
+                pChainSlot->setFilterWaveform(pManifest->isWaveformChangingEQ());
             }
 
             if (!startingUp) {


### PR DESCRIPTION
Inspired by the [PLAYdifferently Model 1 hardware mixer](https://www.youtube.com/watch?v=x95YqztY_Yw&t=6m52s), these combine a semiparametric EQ with selectable frequency and boost/cut with a HPF & LPF. The Q is fixed at a wide setting. With the 3 knob version, the HPF & LPF are combined on one parameter knob like the metaknob of the Filter effect. With the 4 knob version, the HPF & LPF are controlled independently on different parameter knobs, which could be used with 3 EQ knobs + gain knob on a controller, or alternatively 3 EQ knobs + filter knob.

I still have to play around with the parameter ranges. For now they are meant to imitate the PLAYdifferently Model 1.

**_Please do not clutter this PR with tired discussion about magic hacks in the skins or controller system. I will not implement them._**