### PR TITLE
fix crate export with missing files lp:1769355

### DIFF
--- a/src/library/export/trackexportdlg.cpp
+++ b/src/library/export/trackexportdlg.cpp
@@ -53,35 +53,46 @@ void TrackExportDlg::showEvent(QShowEvent* event) {
         return;
     }
 
-    //Checks if there are any files that are missing. If so, it will throw dialog informing the user
+    //Checks if there are any files that are missing. If so, it will throw dialog informing the user.
+    //User can then decide to either cancel the export or skip those files
     QList<QString> files = m_worker->getMissingTracks();
-    if (files.length() > 0) {
-        QDialog* notExportedDlg = new QDialog(nullptr);
-        notExportedDlg->setWindowTitle(tr("Export Track Files"));
-        QVBoxLayout* notExportedLayout = new QVBoxLayout;
-        QLabel* notExportedLabel = new QLabel;
-        notExportedLabel->setText(
-                tr("The following %1 files were not found at the specified "
-                   "file location and as a result were not exported")
-                        .arg(QString::number(files.length())));
-        notExportedLabel->setTextFormat(Qt::RichText);
+    {
+        if (!files.isEmpty()) {
+            QDialog notExportedDlg = QDialog();
+            notExportedDlg.setWindowTitle(tr("Export Track Files"));
+            QVBoxLayout notExportedLayout;
+            QLabel notExportedLabel;
+            notExportedLabel.setText(
+                    tr("The following %1 files were not found at the specified "
+                       "file location and as a result were not exported."
+                       "Click \"OK\" to skip these files. Click \"Cancel\" to cancel the export.")
+                            .arg(QString::number(files.length())));
+            notExportedLabel.setTextFormat(Qt::RichText);
 
-        QListWidget* notExportedList = new QListWidget;
-        notExportedList->addItems(files);
+            QListWidget notExportedList;
+            notExportedList.addItems(files);
 
-        QDialogButtonBox* exportedDlgButtons = new QDialogButtonBox();
-        QPushButton* okBtn = exportedDlgButtons->addButton(
-                tr("OK"),
-                QDialogButtonBox::AcceptRole);
-        connect(okBtn, &QPushButton::clicked, notExportedDlg, &QDialog::accept);
+            QDialogButtonBox exportedDlgButtons = QDialogButtonBox();
+            exportedDlgButtons.addButton(QDialogButtonBox::Ok);
+            exportedDlgButtons.addButton(QDialogButtonBox::Cancel);
+            connect(&exportedDlgButtons,
+                    &QDialogButtonBox::accepted,
+                    &notExportedDlg,
+                    &QDialog::accept);
+            connect(&exportedDlgButtons,
+                    &QDialogButtonBox::rejected,
+                    &notExportedDlg,
+                    &QDialog::reject);
 
-        notExportedLayout->addWidget(notExportedLabel);
-        notExportedLayout->addWidget(notExportedList);
-        notExportedLayout->addWidget(exportedDlgButtons);
-        notExportedDlg->setLayout(notExportedLayout);
-        notExportedDlg->exec();
+            notExportedLayout.addWidget(&notExportedLabel);
+            notExportedLayout.addWidget(&notExportedList);
+            notExportedLayout.addWidget(&exportedDlgButtons);
+            notExportedDlg.setLayout(&notExportedLayout);
+            if (notExportedDlg.exec() == 0) {
+                m_worker->m_skip = true;
+            }
+        }
     }
-
     m_worker->start();
 }
 
@@ -97,7 +108,6 @@ void TrackExportDlg::slotProgress(const QString& filename, int progress, int cou
     exportProgress->setValue(progress);
 }
 
-//TODO review this code to see how I can make a dialog box ask the user whether they want to skip importing the file or not
 void TrackExportDlg::slotAskOverwriteMode(
         const QString& filename,
         std::promise<TrackExportWorker::OverwriteAnswer>* promise) {

--- a/src/library/export/trackexportdlg.cpp
+++ b/src/library/export/trackexportdlg.cpp
@@ -55,42 +55,40 @@ void TrackExportDlg::showEvent(QShowEvent* event) {
 
     //Checks if there are any files that are missing. If so, it will throw dialog informing the user.
     //User can then decide to either cancel the export or skip those files
-    QList<QString> files = m_worker->getMissingTracks();
-    {
-        if (!files.isEmpty()) {
-            QDialog notExportedDlg = QDialog();
-            notExportedDlg.setWindowTitle(tr("Export Track Files"));
-            QVBoxLayout notExportedLayout;
-            QLabel notExportedLabel;
-            notExportedLabel.setText(
-                    tr("The following %1 files were not found at the specified "
-                       "file location and as a result were not exported."
-                       "Click \"OK\" to skip these files. Click \"Cancel\" to cancel the export.")
-                            .arg(QString::number(files.length())));
-            notExportedLabel.setTextFormat(Qt::RichText);
+    const QList<QString> files = m_worker->getMissingTracks();
+    if (!files.isEmpty()) {
+        QDialog notExportedDlg;
+        notExportedDlg.setWindowTitle(tr("Export Track Files"));
+        QVBoxLayout* notExportedLayout = new QVBoxLayout;
+        QLabel* notExportedLabel = new QLabel;
+        notExportedLabel->setText(
+                tr("The following %1 files were not found at the specified "
+                   "file location and as a result were not exported."
+                   "Click \"OK\" to skip these files. Click \"Cancel\" to cancel the export.")
+                        .arg(QString::number(files.length())));
+        notExportedLabel->setTextFormat(Qt::RichText);
 
-            QListWidget notExportedList;
-            notExportedList.addItems(files);
+        QListWidget* notExportedList = new QListWidget;
+        notExportedList->addItems(files);
 
-            QDialogButtonBox exportedDlgButtons = QDialogButtonBox();
-            exportedDlgButtons.addButton(QDialogButtonBox::Ok);
-            exportedDlgButtons.addButton(QDialogButtonBox::Cancel);
-            connect(&exportedDlgButtons,
-                    &QDialogButtonBox::accepted,
-                    &notExportedDlg,
-                    &QDialog::accept);
-            connect(&exportedDlgButtons,
-                    &QDialogButtonBox::rejected,
-                    &notExportedDlg,
-                    &QDialog::reject);
+        QDialogButtonBox* exportedDlgButtons = new QDialogButtonBox();
+        exportedDlgButtons->addButton(QDialogButtonBox::Ok);
+        exportedDlgButtons->addButton(QDialogButtonBox::Cancel);
+        connect(exportedDlgButtons,
+                &QDialogButtonBox::accepted,
+                &notExportedDlg,
+                &QDialog::accept);
+        connect(exportedDlgButtons,
+                &QDialogButtonBox::rejected,
+                &notExportedDlg,
+                &QDialog::reject);
 
-            notExportedLayout.addWidget(&notExportedLabel);
-            notExportedLayout.addWidget(&notExportedList);
-            notExportedLayout.addWidget(&exportedDlgButtons);
-            notExportedDlg.setLayout(&notExportedLayout);
-            if (notExportedDlg.exec() == 0) {
-                m_worker->m_skip = true;
-            }
+        notExportedLayout->addWidget(notExportedLabel);
+        notExportedLayout->addWidget(notExportedList);
+        notExportedLayout->addWidget(exportedDlgButtons);
+        notExportedDlg.setLayout(notExportedLayout);
+        if (notExportedDlg.exec() == QDialog::Rejected) {
+            m_worker->m_canceledByUser = true;
         }
     }
     m_worker->start();

--- a/src/library/export/trackexportworker.cpp
+++ b/src/library/export/trackexportworker.cpp
@@ -82,16 +82,18 @@ QList<QString> TrackExportWorker::getMissingTracks() {
 }
 
 void TrackExportWorker::run() {
+    //if user doesn't want to initiate export, immediately cancels the job
+    if (m_skip) {
+        emit canceled();
+        return;
+    }
+
     int i = 0;
     QMap<QString, TrackFile> copy_list = createCopylist(m_tracks);
 
-    /**
-     * TODO: if the copylist is empty, then end the process
-     */
-
     if (copy_list.empty()) {
-        emit canceled();
         m_errorMessage = tr("There were no files in the specified file locations to export!");
+        emit canceled();
         return;
     }
 

--- a/src/library/export/trackexportworker.cpp
+++ b/src/library/export/trackexportworker.cpp
@@ -70,7 +70,7 @@ QMap<QString, TrackFile> createCopylist(const TrackPointerList& tracks) {
 
 }  // namespace
 
-QList<QString> TrackExportWorker::getMissingTracks() {
+QList<QString> TrackExportWorker::getMissingTracks() const {
     QList<QString> missingFiles;
     for (const auto& it : m_tracks) {
         if (it->getCanonicalLocation().isEmpty()) {
@@ -83,7 +83,7 @@ QList<QString> TrackExportWorker::getMissingTracks() {
 
 void TrackExportWorker::run() {
     //if user doesn't want to initiate export, immediately cancels the job
-    if (m_skip) {
+    if (m_canceledByUser) {
         emit canceled();
         return;
     }

--- a/src/library/export/trackexportworker.h
+++ b/src/library/export/trackexportworker.h
@@ -50,10 +50,9 @@ class TrackExportWorker : public QThread {
     }
 
     //Get the list
-    QList<QString> getMissingTracks();
+    QList<QString> getMissingTracks() const;
 
-    //Boolean that lets the worker know if the job will be skipped due to missing files
-    bool m_skip = false;
+    bool m_canceledByUser = false;
 
     // Cancels the export after the current copy operation.
     // May be called from another thread.

--- a/src/library/export/trackexportworker.h
+++ b/src/library/export/trackexportworker.h
@@ -49,6 +49,9 @@ class TrackExportWorker : public QThread {
         return m_errorMessage;
     }
 
+    //Get the list
+    QList<QString> getMissingTracks();
+
     // Cancels the export after the current copy operation.
     // May be called from another thread.
     void stop();
@@ -63,6 +66,7 @@ class TrackExportWorker : public QThread {
             const QString& filename,
             std::promise<TrackExportWorker::OverwriteAnswer>* promise);
     void progress(const QString& filename, int progress, int count);
+    void missing();
     void canceled();
 
   private:

--- a/src/library/export/trackexportworker.h
+++ b/src/library/export/trackexportworker.h
@@ -52,6 +52,9 @@ class TrackExportWorker : public QThread {
     //Get the list
     QList<QString> getMissingTracks();
 
+    //Boolean that lets the worker know if the job will be skipped due to missing files
+    bool m_skip = false;
+
     // Cancels the export after the current copy operation.
     // May be called from another thread.
     void stop();
@@ -66,7 +69,6 @@ class TrackExportWorker : public QThread {
             const QString& filename,
             std::promise<TrackExportWorker::OverwriteAnswer>* promise);
     void progress(const QString& filename, int progress, int count);
-    void missing();
     void canceled();
 
   private:


### PR DESCRIPTION
Added in functionality so that if there a missing files in a users's crate and they export the crate's files, a dialog box will pop up notifying the user of the missing files. Also added a fix so that if there are no files to export, a message box pops up informing the user and then closes the export thread. I'm very inexperienced with qt and C++ so feedback would be great.

code followed this implementation of the "notDeletedDlg": https://github.com/mixxxdj/mixxx/pull/3212/commits/7688b29a43c16f3fbfeefcb478f77acafecfd81b