### PR TITLE
Exclude libdjinterop from DEB/PPA build

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -4,7 +4,7 @@
 
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DCMAKE_BUILD_TYPE=RelWithDebInfo -DINSTALL_USER_UDEV_RULES=OFF -DKEYFINDER=OFF
+	dh_auto_configure -- -DCMAKE_BUILD_TYPE=RelWithDebInfo -DINSTALL_USER_UDEV_RULES=OFF -DKEYFINDER=OFF -DENGINEPRIME=OFF
 
 override_dh_installudev:
 	dh_installudev --name=mixxx-usb-uaccess --priority 69


### PR DESCRIPTION
Follow-up: https://github.com/mixxxdj/mixxx/pull/2753