### PR TITLE
DB: Do not add column last_played_at twice

### DIFF
--- a/res/schema.xml
+++ b/res/schema.xml
@@ -534,8 +534,6 @@ METADATA
       Populate last_played_at column in library table from play history
     </description>
     <sql>
-      -- Add new column
-      ALTER TABLE library ADD COLUMN last_played_at DATETIME DEFAULT NULL;
       -- Populate new column from history playlists
       UPDATE library SET last_played_at=(
         SELECT MAX(PlaylistTracks.pl_datetime_added)


### PR DESCRIPTION
Probably introduced when resolving merge conflicts. Does not cause any issues other than a *critical* log on schema migration.

```
critical [Main] FwdSqlQuery - Failed to prepare "-- Add new column\n      ALTER TABLE library ADD COLUMN last_played_at DATETIME DEFAULT NULL" : QSqlError("1", "Unable to execute statement", "duplicate column name: last_played_at")
```

Test: New profile with empty database