### PR TITLE
lp1912945 LibraryScanner: Fix incomplete migration to wider cache keys

### DIFF
--- a/src/library/scanner/recursivescandirectorytask.cpp
+++ b/src/library/scanner/recursivescandirectorytask.cpp
@@ -74,7 +74,6 @@ void RecursiveScanDirectoryTask::run() {
         }
     }
 
-    // Note: A hash of "0" is a real hash if the directory contains no files!
     // Calculate a hash of the directory's file list.
     const mixxx::cache_key_t newHash = mixxx::cacheKeyFromMessageDigest(hasher.result());
 

--- a/src/library/scanner/scannerglobal.h
+++ b/src/library/scanner/scannerglobal.h
@@ -63,9 +63,9 @@ class ScannerGlobal {
         return m_trackLocations.contains(trackLocation);
     }
 
-    // Returns the directory hash if it exists or -1 if it doesn't.
-    inline mixxx::cache_key_t directoryHashInDatabase(const QString& directoryPath) const {
-        return m_directoryHashes.value(directoryPath, -1);
+    // Returns the directory hash if it exists or mixxx::invalidCacheKey() if it doesn't.
+    mixxx::cache_key_t directoryHashInDatabase(const QString& directoryPath) const {
+        return m_directoryHashes.value(directoryPath, mixxx::invalidCacheKey());
     }
 
     inline bool directoryBlacklisted(const QString& directoryPath) const {


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1912945

The bug is caused by returning -1 if the directory is not yet hashed. But -1 is now also a valid cache key!

Use mixxx::invalidCacheKey() instead of the number literals 0 and -1 that are not suitable anymore.