### PR TITLE
lp1912965: Mark newly created cues as dirty

### DIFF
--- a/src/test/cue_test.cpp
+++ b/src/test/cue_test.cpp
@@ -8,6 +8,15 @@
 
 namespace mixxx {
 
+TEST(CueTest, NewCueIsDirty) {
+    const auto cue = Cue(
+            mixxx::CueType::HotCue,
+            1,
+            0.0,
+            Cue::kNoPosition);
+    EXPECT_TRUE(cue.isDirty());
+}
+
 TEST(CueTest, DefaultCueInfoToCueRoundtrip) {
     const CueInfo cueInfo1;
     const Cue cueObject(
@@ -35,6 +44,7 @@ TEST(CueTest, ConvertCueInfoToCueRoundtrip) {
             cueInfo1,
             audio::SampleRate(44100),
             true);
+    EXPECT_TRUE(cueObject.isDirty());
     const auto cueInfo2 = cueObject.getCueInfo(
             audio::SampleRate(44100));
     EXPECT_EQ(cueInfo1, cueInfo2);

--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -98,7 +98,7 @@ Cue::Cue(
         int hotCueIndex,
         double sampleStartPosition,
         double sampleEndPosition)
-        : m_bDirty(false), // not yet in database
+        : m_bDirty(true), // not yet in database, needs to be saved
           m_type(type),
           m_sampleStartPosition(sampleStartPosition),
           m_sampleEndPosition(sampleEndPosition),


### PR DESCRIPTION
...otherwise they won't be saved.

Obviously caused by a refactoring. Since recently new cues are **initialized when created** instead of populating them incrementally which would then set the dirty flag.

Fixes https://bugs.launchpad.net/mixxx/+bug/1912965

Supercedes #3544