### PR TITLE
Remove obsolete pre-C++17 workarounds in util/optional.h

### DIFF
--- a/src/util/optional.h
+++ b/src/util/optional.h
@@ -1,33 +1,7 @@
 #pragma once
 
-#if __has_include(<optional>) || \
-    (defined(__cpp_lib_optional) && __cpp_lib_optional >= 201606L)
-
-#include <optional>
-
-#else
-
-#ifdef __clang__
-#pragma clang diagnostic ignored "-Winvalid-constexpr"
-#endif
-
-#include <experimental/optional>
-
-namespace std {
-
-using std::experimental::make_optional;
-using std::experimental::nullopt;
-using std::experimental::optional;
-
-// Workarounds for missing member functions:
-// option::has_value() -> explicit operator bool()
-// option::value() -> operator*()
-
-} // namespace std
-
-#endif
-
 #include <QtDebug>
+#include <optional>
 
 template<typename T>
 QDebug operator<<(QDebug dbg, std::optional<T> arg) {

--- a/src/util/optional.h
+++ b/src/util/optional.h
@@ -4,7 +4,7 @@
 #include <optional>
 
 template<typename T>
-QDebug operator<<(QDebug dbg, std::optional<T> arg) {
+inline QDebug operator<<(QDebug dbg, std::optional<T> arg) {
     if (arg) {
         return dbg << *arg;
     } else {


### PR DESCRIPTION
This requires now a recent macOS version. On CI we use 10.15.

Not mandatory, to be discussed.