### PR TITLE
GH Actions: don't run tests in parallel to avoid Windows failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -248,7 +248,8 @@ jobs:
         # Render analyzer waveform tests to an offscreen buffer
         QT_QPA_PLATFORM: ${{ matrix.qt_qpa_platform }}
         GTEST_COLOR: 1
-        CTEST_PARALLEL_LEVEL: 2
+        # Windows tests fail randomly if run in parallel
+        CTEST_PARALLEL_LEVEL: 1
         CTEST_OUTPUT_ON_FAILURE: 1
 
     - name: Benchmark


### PR DESCRIPTION
I pushed 20 branches of this to my fork and got no Windows build failures (although curiously I got [one macOS build failure](https://github.com/Be-ing/mixxx/actions/runs/516382378)). We enabled parallel testing when switching from AppVeyor to GitHub Actions which is when the Windows builds started failing randomly.