### PR TITLE
Exclude libshout 2.4.4 and 2.4.5 as well because of bug lp1913579

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2312,12 +2312,15 @@ option(BROADCAST "Live Broadcasting (Shoutcast) support" ON)
 if(BROADCAST)
   find_package(Shout)
   if(UNIX AND NOT APPLE)
-    # Check if system lib is at least 2.4.4 and not suffering bug
+    # Check if system lib is at least 2.4.6 and not suffering bugs
     # https://bugs.launchpad.net/mixxx/+bug/1833225
+    # https://bugs.launchpad.net/mixxx/+bug/1913579
     if(Shout_FOUND AND Shout_VERSION VERSION_LESS 2.4.4)
-        message(STATUS "Installed libshout version: ${Shout_VERSION} is suffering from bug lp1833225")
+        message(STATUS "Installed libshout version: ${Shout_VERSION} is suffering from bugs lp1833225 and lp1913579")
+    elseif(Shout_FOUND AND Shout_VERSION VERSION_LESS 2.4.6)
+        message(STATUS "Installed libshout version: ${Shout_VERSION} is suffering from bug lp1913579")
     endif()
-    if(NOT Shout_FOUND OR Shout_VERSION VERSION_LESS 2.4.4)
+    if(NOT Shout_FOUND OR Shout_VERSION VERSION_LESS 2.4.6)
       # Fall back to internal libraray in the lib tree
       message(STATUS "Using internal libshout")
       add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/lib/libshout")


### PR DESCRIPTION
Our Internal version 2.4.1 works well so far

https://bugs.launchpad.net/mixxx/+bug/1913579
https://gitlab.xiph.org/xiph/icecast-libshout/-/issues/2325

I assume that the issue will be fixed in a future version 2.4.6. 