### PR TITLE
lp1913936: Remove unused sample layout property from SignalInfo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
           - name: Ubuntu 18.04 (gcc)
             os: ubuntu-18.04
             cmake_args: >-
+              -DWARNINGS_FATAL=ON
               -DFAAD=ON
               -DKEYFINDER=ON
               -DLOCALECOMPARE=ON
@@ -32,6 +33,7 @@ jobs:
           - name: Ubuntu 20.04 (gcc)
             os: ubuntu-20.04
             cmake_args: >-
+              -DWARNINGS_FATAL=ON
               -DFFMPEG=ON
               -DKEYFINDER=ON
               -DLOCALECOMPARE=ON

--- a/src/audio/signalinfo.cpp
+++ b/src/audio/signalinfo.cpp
@@ -8,7 +8,6 @@ bool operator==(
         const SignalInfo& lhs,
         const SignalInfo& rhs) {
     return lhs.getChannelCount() == rhs.getChannelCount() &&
-            lhs.getSampleLayout() == rhs.getSampleLayout() &&
             lhs.getSampleRate() == rhs.getSampleRate();
 }
 
@@ -16,7 +15,6 @@ QDebug
 operator<<(QDebug dbg, const SignalInfo& arg) {
     dbg << "SignalInfo{";
     arg.dbgChannelCount(dbg);
-    arg.dbgSampleLayout(dbg);
     arg.dbgSampleRate(dbg);
     dbg << '}';
     return dbg;

--- a/src/audio/signalinfo.h
+++ b/src/audio/signalinfo.h
@@ -14,21 +14,14 @@ class SignalInfo final {
     // Properties
     MIXXX_DECL_PROPERTY(ChannelCount, channelCount, ChannelCount)
     MIXXX_DECL_PROPERTY(SampleRate, sampleRate, SampleRate)
-    MIXXX_DECL_PROPERTY(OptionalSampleLayout, sampleLayout, SampleLayout)
 
   public:
     constexpr SignalInfo() = default;
-    constexpr explicit SignalInfo(
-            OptionalSampleLayout sampleLayout)
-            : m_sampleLayout(sampleLayout) {
-    }
     SignalInfo(
             ChannelCount channelCount,
-            SampleRate sampleRate,
-            OptionalSampleLayout sampleLayout = std::nullopt)
+            SampleRate sampleRate)
             : m_channelCount(channelCount),
-              m_sampleRate(sampleRate),
-              m_sampleLayout(sampleLayout) {
+              m_sampleRate(sampleRate) {
     }
     SignalInfo(SignalInfo&&) = default;
     SignalInfo(const SignalInfo&) = default;

--- a/src/audio/types.h
+++ b/src/audio/types.h
@@ -202,10 +202,10 @@ QDebug operator<<(QDebug dbg, Bitrate arg);
 Q_DECLARE_TYPEINFO(mixxx::audio::ChannelCount, Q_PRIMITIVE_TYPE);
 Q_DECLARE_METATYPE(mixxx::audio::ChannelCount)
 
-Q_DECLARE_TYPEINFO(mixxx::audio::OptionalChannelLayout, Q_PRIMITIVE_TYPE);
+Q_DECLARE_TYPEINFO(mixxx::audio::OptionalChannelLayout, Q_MOVABLE_TYPE);
 Q_DECLARE_METATYPE(mixxx::audio::OptionalChannelLayout)
 
-Q_DECLARE_TYPEINFO(mixxx::audio::OptionalSampleLayout, Q_PRIMITIVE_TYPE);
+Q_DECLARE_TYPEINFO(mixxx::audio::OptionalSampleLayout, Q_MOVABLE_TYPE);
 Q_DECLARE_METATYPE(mixxx::audio::OptionalSampleLayout)
 
 Q_DECLARE_TYPEINFO(mixxx::audio::SampleRate, Q_PRIMITIVE_TYPE);

--- a/src/audio/types.h
+++ b/src/audio/types.h
@@ -202,8 +202,14 @@ QDebug operator<<(QDebug dbg, Bitrate arg);
 Q_DECLARE_TYPEINFO(mixxx::audio::ChannelCount, Q_PRIMITIVE_TYPE);
 Q_DECLARE_METATYPE(mixxx::audio::ChannelCount)
 
+Q_DECLARE_TYPEINFO(mixxx::audio::ChannelLayout, Q_PRIMITIVE_TYPE);
+Q_DECLARE_METATYPE(mixxx::audio::ChannelLayout)
+
 Q_DECLARE_TYPEINFO(mixxx::audio::OptionalChannelLayout, Q_MOVABLE_TYPE);
 Q_DECLARE_METATYPE(mixxx::audio::OptionalChannelLayout)
+
+Q_DECLARE_TYPEINFO(mixxx::audio::SampleLayout, Q_PRIMITIVE_TYPE);
+Q_DECLARE_METATYPE(mixxx::audio::SampleLayout)
 
 Q_DECLARE_TYPEINFO(mixxx::audio::OptionalSampleLayout, Q_MOVABLE_TYPE);
 Q_DECLARE_METATYPE(mixxx::audio::OptionalSampleLayout)

--- a/src/engine/bufferscalers/enginebufferscale.cpp
+++ b/src/engine/bufferscalers/enginebufferscale.cpp
@@ -8,8 +8,7 @@ EngineBufferScale::EngineBufferScale()
         : m_outputSignal(
                   mixxx::audio::SignalInfo(
                           mixxx::kEngineChannelCount,
-                          mixxx::audio::SampleRate(),
-                          mixxx::kEngineSampleLayout)),
+                          mixxx::audio::SampleRate())),
           m_dBaseRate(1.0),
           m_bSpeedAffectsPitch(false),
           m_dTempoRatio(1.0),

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -7,8 +7,6 @@ namespace mixxx {
     // TODO(XXX): When we move from stereo to multi-channel this needs updating.
     static constexpr audio::ChannelCount kEngineChannelCount =
             audio::ChannelCount(2);
-    static constexpr audio::SampleLayout kEngineSampleLayout =
-            audio::SampleLayout::Interleaved;
 
     // Contains the information needed to process a buffer of audio
     class EngineParameters {
@@ -33,8 +31,7 @@ namespace mixxx {
                 SINT framesPerBuffer)
                 : m_outputSignal(
                           kEngineChannelCount,
-                          sampleRate,
-                          kEngineSampleLayout),
+                          sampleRate),
                   m_framesPerBuffer(framesPerBuffer) {
             DEBUG_ASSERT(framesPerBuffer > 0);
         }

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -67,7 +67,9 @@ MixxxApplication::MixxxApplication(int& argc, char** argv)
 void MixxxApplication::registerMetaTypes() {
     // PCM audio types
     qRegisterMetaType<mixxx::audio::ChannelCount>("mixxx::audio::ChannelCount");
+    qRegisterMetaType<mixxx::audio::ChannelLayout>("mixxx::audio::ChannelLayout");
     qRegisterMetaType<mixxx::audio::OptionalChannelLayout>("mixxx::audio::OptionalChannelLayout");
+    qRegisterMetaType<mixxx::audio::SampleLayout>("mixxx::audio::SampleLayout");
     qRegisterMetaType<mixxx::audio::OptionalSampleLayout>("mixxx::audio::OptionalSampleLayout");
     qRegisterMetaType<mixxx::audio::SampleRate>("mixxx::audio::SampleRate");
     qRegisterMetaType<mixxx::audio::Bitrate>("mixxx::audio::Bitrate");

--- a/src/sources/audiosource.cpp
+++ b/src/sources/audiosource.cpp
@@ -17,8 +17,7 @@ const SINT kVerifyReadableMaxFrameCount = 1;
 } // anonymous namespace
 
 AudioSource::AudioSource(const QUrl& url)
-        : UrlResource(url),
-          m_signalInfo(kSampleLayout) {
+        : UrlResource(url) {
 }
 
 AudioSource::AudioSource(
@@ -141,7 +140,6 @@ bool AudioSource::verifyReadable() {
     // No early return desired! All tests should be performed, even
     // if some fail.
     bool result = true;
-    DEBUG_ASSERT(m_signalInfo.getSampleLayout());
     if (!m_signalInfo.getChannelCount().isValid()) {
         kLogger.warning()
                 << "Invalid number of channels:"

--- a/src/sources/audiosource.h
+++ b/src/sources/audiosource.h
@@ -142,15 +142,6 @@ class AudioSource : public UrlResource, public virtual /*implements*/ IAudioSour
   public:
     ~AudioSource() override = default;
 
-    // All sources are required to produce a signal of frames
-    // where each frame contains samples from all channels that are
-    // coincident in time.
-    //
-    // A frame for a mono signal contains a single sample. A frame
-    // for a stereo signal contains a pair of samples, one for the
-    // left and right channel respectively.
-    static constexpr audio::SampleLayout kSampleLayout = mixxx::kEngineSampleLayout;
-
     /// Defines how thoroughly the stream properties should be verified
     /// when opening an audio stream.
     enum class OpenMode {
@@ -201,16 +192,13 @@ class AudioSource : public UrlResource, public virtual /*implements*/ IAudioSour
     // Parameters for opening audio sources
     class OpenParams {
       public:
-        OpenParams()
-                : m_signalInfo(kSampleLayout) {
-        }
+        OpenParams() = default;
         OpenParams(
                 audio::ChannelCount channelCount,
                 audio::SampleRate sampleRate)
                 : m_signalInfo(
                           channelCount,
-                          sampleRate,
-                          kSampleLayout) {
+                          sampleRate) {
         }
 
         const audio::SignalInfo& getSignalInfo() const {

--- a/src/sources/audiosourcestereoproxy.cpp
+++ b/src/sources/audiosourcestereoproxy.cpp
@@ -16,8 +16,7 @@ audio::SignalInfo proxySignalInfo(
     DEBUG_ASSERT(signalInfo.isValid());
     return audio::SignalInfo(
             kChannelCount,
-            signalInfo.getSampleRate(),
-            signalInfo.getSampleLayout());
+            signalInfo.getSampleRate());
 }
 
 } // anonymous namespace

--- a/src/util/color/rgbcolor.h
+++ b/src/util/color/rgbcolor.h
@@ -238,7 +238,5 @@ inline QDebug operator<<(QDebug dbg, RgbColor::optional_t optionalColor) {
 
 } // namespace mixxx
 
-// Assumption: A primitive type wrapped into std::optional is
-// still a primitive type.
-Q_DECLARE_TYPEINFO(std::optional<mixxx::RgbColor>, Q_PRIMITIVE_TYPE);
+Q_DECLARE_TYPEINFO(std::optional<mixxx::RgbColor>, Q_MOVABLE_TYPE);
 Q_DECLARE_METATYPE(std::optional<mixxx::RgbColor>)


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1913936