### PR TITLE
Remove unused SampleLayout

### DIFF
--- a/src/audio/types.cpp
+++ b/src/audio/types.cpp
@@ -17,17 +17,6 @@ QDebug operator<<(QDebug dbg, ChannelLayout arg) {
     return dbg;
 }
 
-QDebug operator<<(QDebug dbg, SampleLayout arg) {
-    switch (arg) {
-    case SampleLayout::Planar:
-        return dbg << "Planar";
-    case SampleLayout::Interleaved:
-        return dbg << "Interleaved";
-    }
-    DEBUG_ASSERT(!"unreachable code");
-    return dbg;
-}
-
 QDebug operator<<(QDebug dbg, SampleRate arg) {
     return dbg
             << static_cast<SampleRate::value_t>(arg)

--- a/src/audio/types.h
+++ b/src/audio/types.h
@@ -100,8 +100,6 @@ enum class SampleLayout {
     Interleaved
 };
 
-typedef std::optional<SampleLayout> OptionalSampleLayout;
-
 QDebug operator<<(QDebug dbg, SampleLayout arg);
 
 class SampleRate {
@@ -210,9 +208,6 @@ Q_DECLARE_METATYPE(mixxx::audio::OptionalChannelLayout)
 
 Q_DECLARE_TYPEINFO(mixxx::audio::SampleLayout, Q_PRIMITIVE_TYPE);
 Q_DECLARE_METATYPE(mixxx::audio::SampleLayout)
-
-Q_DECLARE_TYPEINFO(mixxx::audio::OptionalSampleLayout, Q_MOVABLE_TYPE);
-Q_DECLARE_METATYPE(mixxx::audio::OptionalSampleLayout)
 
 Q_DECLARE_TYPEINFO(mixxx::audio::SampleRate, Q_PRIMITIVE_TYPE);
 Q_DECLARE_METATYPE(mixxx::audio::SampleRate)

--- a/src/audio/types.h
+++ b/src/audio/types.h
@@ -85,23 +85,6 @@ class ChannelCount {
     value_t m_value;
 };
 
-// Defines the ordering of how samples from multiple channels are
-// stored in contiguous buffers:
-//    - Planar: Channel by channel
-//    - Interleaved: Frame by frame
-// The samples from all channels that are coincident in time are
-// called a "frame" (or more specific "sample frame").
-//
-// Example: 10 stereo samples from left (L) and right (R) channel
-// Planar layout:      LLLLLLLLLLRRRRRRRRRR
-// Interleaved layout: LRLRLRLRLRLRLRLRLRLR
-enum class SampleLayout {
-    Planar,
-    Interleaved
-};
-
-QDebug operator<<(QDebug dbg, SampleLayout arg);
-
 class SampleRate {
   public:
     typedef SINT value_t;
@@ -205,9 +188,6 @@ Q_DECLARE_METATYPE(mixxx::audio::ChannelLayout)
 
 Q_DECLARE_TYPEINFO(mixxx::audio::OptionalChannelLayout, Q_MOVABLE_TYPE);
 Q_DECLARE_METATYPE(mixxx::audio::OptionalChannelLayout)
-
-Q_DECLARE_TYPEINFO(mixxx::audio::SampleLayout, Q_PRIMITIVE_TYPE);
-Q_DECLARE_METATYPE(mixxx::audio::SampleLayout)
 
 Q_DECLARE_TYPEINFO(mixxx::audio::SampleRate, Q_PRIMITIVE_TYPE);
 Q_DECLARE_METATYPE(mixxx::audio::SampleRate)

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -69,7 +69,6 @@ void MixxxApplication::registerMetaTypes() {
     qRegisterMetaType<mixxx::audio::ChannelCount>("mixxx::audio::ChannelCount");
     qRegisterMetaType<mixxx::audio::ChannelLayout>("mixxx::audio::ChannelLayout");
     qRegisterMetaType<mixxx::audio::OptionalChannelLayout>("mixxx::audio::OptionalChannelLayout");
-    qRegisterMetaType<mixxx::audio::SampleLayout>("mixxx::audio::SampleLayout");
     qRegisterMetaType<mixxx::audio::SampleRate>("mixxx::audio::SampleRate");
     qRegisterMetaType<mixxx::audio::Bitrate>("mixxx::audio::Bitrate");
 

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -70,7 +70,6 @@ void MixxxApplication::registerMetaTypes() {
     qRegisterMetaType<mixxx::audio::ChannelLayout>("mixxx::audio::ChannelLayout");
     qRegisterMetaType<mixxx::audio::OptionalChannelLayout>("mixxx::audio::OptionalChannelLayout");
     qRegisterMetaType<mixxx::audio::SampleLayout>("mixxx::audio::SampleLayout");
-    qRegisterMetaType<mixxx::audio::OptionalSampleLayout>("mixxx::audio::OptionalSampleLayout");
     qRegisterMetaType<mixxx::audio::SampleRate>("mixxx::audio::SampleRate");
     qRegisterMetaType<mixxx::audio::Bitrate>("mixxx::audio::Bitrate");
 


### PR DESCRIPTION
I have notice that OptionalSampleLayout and SampleLayout is now unused.

This is a follow up of: 
https://github.com/mixxxdj/mixxx/pull/3606