### PR TITLE
GH Actions: disable fail-fast

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: Ubuntu 18.04 (gcc)


### PR DESCRIPTION
This stops GH Actions from cancelling unrelated jobs when one fails. I don't know why this is on by default...