### PR TITLE
Make sure title from file fall back works also when reload metadata

### DIFF
--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -573,6 +573,8 @@ void SoundSourceProxy::updateTrackFromSource(
                 << (pCoverImg ? "and embedded cover art" : "")
                 << "from file"
                 << getUrl().toString();
+        // make sure that the trackMetadata was not messed up due to the failure
+        m_pTrack->readTrackMetadata(&trackMetadata, &metadataSynchronized);
     }
 
     // Partial import

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -593,9 +593,6 @@ void SoundSourceProxy::updateTrackFromSource(
         // once in the past. Only overwrite this information if
         // new data has actually been imported, otherwise abort
         // and preserve the existing data!
-        if (metadataImported.first != mixxx::MetadataSource::ImportResult::Succeeded) {
-            return; // abort
-        }
         if (kLogger.debugEnabled()) {
             kLogger.debug()
                     << "Updating track metadata"

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -227,11 +227,21 @@ TEST_F(SoundSourceProxyTest, readNoTitle) {
     proxy1.updateTrackFromSource();
     EXPECT_EQ("empty", pTrack1->getTitle());
 
+    // Test a reload also works
+    pTrack1->setTitle("");
+    proxy1.updateTrackFromSource(SoundSourceProxy::ImportTrackMetadataMode::Again);
+    EXPECT_EQ("empty", pTrack1->getTitle());
+
     // Test a file with other metadata but no title
     auto pTrack2 = Track::newTemporary(TrackFile(
             kTestDir, "cover-test-png.mp3"));
     SoundSourceProxy proxy2(pTrack2);
     proxy2.updateTrackFromSource();
+    EXPECT_EQ("cover-test-png", pTrack2->getTitle());
+
+    // Test a reload also works
+    pTrack2->setTitle("");
+    proxy2.updateTrackFromSource(SoundSourceProxy::ImportTrackMetadataMode::Again);
     EXPECT_EQ("cover-test-png", pTrack2->getTitle());
 
     // Test a file with a title


### PR DESCRIPTION
This fixes a inconsistent behavior between no meta data and empty metadata tacks.
This difference is not visible for the user.  

Found during testing of: https://github.com/mixxxdj/mixxx/pull/3610
