### PR TITLE
Fix loadling of libfaad2 on Fedora

### DIFF
--- a/src/sources/libfaadloader.cpp
+++ b/src/sources/libfaadloader.cpp
@@ -40,7 +40,8 @@ LibLoader::LibLoader()
     // Using MacPorts ('sudo port install faad2' command):
     libnames << "/opt/local/lib/libfaad2.dylib";
 #else
-    libnames << "libfaad.so";
+    libnames << "libfaad.so.2"
+             << "libfaad.so";
 #endif
 
     for (const auto& libname : qAsConst(libnames)) {


### PR DESCRIPTION
Tests failing with a debug assertion otherwise. Probably the fallback to FFmpeg is currently in use.

Noticed after removing the devel package locally.