### PR TITLE
SoundSourceCoreAudio: add aac to list of supported file extensions

### DIFF
--- a/src/sources/soundsourcecoreaudio.cpp
+++ b/src/sources/soundsourcecoreaudio.cpp
@@ -31,6 +31,7 @@ const QString SoundSourceProviderCoreAudio::kDisplayName = QStringLiteral("Apple
 
 //static
 const QStringList SoundSourceProviderCoreAudio::kSupportedFileExtensions = {
+        QStringLiteral("aac"),
         QStringLiteral("m4a"),
         QStringLiteral("mp4"),
         QStringLiteral("mp3"),


### PR DESCRIPTION
Testing https://github.com/daschuer/mixxx/pull/66 I noticed that Mixxx could not play its own recording.