### PR TITLE
SoundSourceMediaFoundation: add aac to list of supported file types

### DIFF
--- a/src/sources/soundsourcemediafoundation.cpp
+++ b/src/sources/soundsourcemediafoundation.cpp
@@ -50,6 +50,7 @@ const QString SoundSourceProviderMediaFoundation::kDisplayName =
 
 //static
 const QStringList SoundSourceProviderMediaFoundation::kSupportedFileExtensions = {
+        QStringLiteral("aac"),
         QStringLiteral("m4a"),
         QStringLiteral("mp4"),
 };


### PR DESCRIPTION
This crashes on some files with:
```
DEBUG ASSERT: "m_currentFrameIndex == readerFrameIndex" in function class mixxx::ReadableSampleFrames __cdecl mixxx::SoundSourceMediaFoundation::readSampleFramesClamped(const class mixxx::WritableSampleFrames &) at ..\src\sources\soundsourcemediafoundation.cpp:388
```