### PR TITLE
SoundSources: prefer FFmpeg to MediaFoundation

### DIFF
--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -454,11 +454,7 @@ QStringList SoundSourceProviderFFmpeg::getSupportedFileExtensions() const {
 SoundSourceProviderPriority SoundSourceProviderFFmpeg::getPriorityHint(
         const QString& supportedFileExtension) const {
     Q_UNUSED(supportedFileExtension)
-    // TODO: Increase priority to Default or even Higher for all
-    // supported and tested file extension?
-    // Currently it is only used as a fallback after all other
-    // SoundSources failed to open a file or are otherwise unavailable.
-    return SoundSourceProviderPriority::Lowest;
+    return SoundSourceProviderPriority::Higher;
 }
 
 SoundSourceFFmpeg::SoundSourceFFmpeg(const QUrl& url)

--- a/src/sources/soundsourcemediafoundation.cpp
+++ b/src/sources/soundsourcemediafoundation.cpp
@@ -57,9 +57,9 @@ const QStringList SoundSourceProviderMediaFoundation::kSupportedFileExtensions =
 SoundSourceProviderPriority SoundSourceProviderMediaFoundation::getPriorityHint(
         const QString& supportedFileExtension) const {
     Q_UNUSED(supportedFileExtension)
-    // On Windows SoundSourceMediaFoundation is the preferred decoder for all
-    // supported audio formats.
-    return SoundSourceProviderPriority::Higher;
+    // Prefer FFMPEG because of known issues with this SoundSource and lack of maintenance
+    // https://bugs.launchpad.net/mixxx/+bug/1899242
+    return SoundSourceProviderPriority::Lower;
 }
 
 SoundSourcePointer SoundSourceProviderMediaFoundation::newSoundSource(const QUrl& url) {


### PR DESCRIPTION
SoundSourceMediaFoundation has known issues and has not been well
maintained. FFmpeg is now available on Windows with the new vcpkg
build environment.
https://bugs.launchpad.net/mixxx/+bug/1899242

What are the implications for shifted cues and beatgrids?