### PR TITLE
library BrowseFeature: add threading for IO

### DIFF
--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -404,7 +404,7 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
     if (path == DEVICE_NODE) {
         folders += getRemovableDevices();
     } else {
-        m_childModel.processFolder(index, path);
+        m_pSidebarModel->processFolder(index, path);
         // FIXME: create QTimer to update label
         /*
         auto title = m_childModel.data(index, Qt::DisplayRole);

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -403,38 +403,8 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
     if (path == DEVICE_NODE) {
         folders += getRemovableDevices();
     } else {
-        auto listWorker = [=]() mutable -> void {
-            // we assume that the path refers to a folder in the file system
-            // populate childs
-            const auto dirAccess = mixxx::FileAccess(mixxx::FileInfo(path));
-            QList<TreeItem*> children;
-            QFileInfoList all = dirAccess.info().toQDir().entryInfoList(
-                    QDir::Dirs | QDir::NoDotAndDotDot);
-
-            // loop through all the item and construct the childs
-            foreach (QFileInfo one, all) {
-#if defined(__APPLE__)
-                if (one.isDir() && one.fileName().endsWith(".app"))
-                    continue;
-#endif
-                // We here create new items for the sidebar models
-                // Once the items are added to the TreeItemModel,
-                // the models takes ownership of them and ensures their deletion
-                auto* folder = new TreeItem(
-                        one.fileName(),
-                        QVariant(one.absoluteFilePath() + QStringLiteral("/")));
-                children << folder;
-            }
-            if (!children.isEmpty()) {
-                m_childModel.insertTreeItemRows(children, 0, index);
-            }
-        };
-        /*
-        auto title = m_childModel.data(index, Qt::DisplayRole);
-        m_childModel.setData(index, QString("loading"));
-        m_childModel.triggerRepaint(index);
-        */
-        auto result = QtConcurrent::run(listWorker);
+        const auto dirAccess = mixxx::FileAccess(mixxx::FileInfo(path));
+        m_childModel.processFolder(index, dirAccess);
         // FIXME: create QTimer to update label
         /*
         auto title = m_childModel.data(index, Qt::DisplayRole);

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -104,7 +104,7 @@ BrowseFeature::BrowseFeature(
 #elif defined(__APPLE__)
     // Apple hides the base Linux file structure But all devices are mounted at
     // /Volumes
-    pRootItem->appendChild(tr("Devices"), "/Volumes/");
+    pRootItem->appendChild(tr("Devices"), "/Volumes");
 #else  // LINUX
     // DEVICE_NODE contents will be rendered lazily in onLazyChildExpandation.
     pRootItem->appendChild(tr("Removable Devices"), DEVICE_NODE);
@@ -403,8 +403,7 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
     if (path == DEVICE_NODE) {
         folders += getRemovableDevices();
     } else {
-        const auto dirAccess = mixxx::FileAccess(mixxx::FileInfo(path));
-        m_childModel.processFolder(index, dirAccess);
+        m_childModel.processFolder(index, path);
         // FIXME: create QTimer to update label
         /*
         auto title = m_childModel.data(index, Qt::DisplayRole);

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -7,6 +7,7 @@
 #include <QPushButton>
 #include <QStringList>
 #include <QTreeView>
+#include <QtConcurrent>
 
 #include "controllers/keyboard/keyboardeventfilter.h"
 #include "library/library.h"
@@ -26,8 +27,7 @@ const QString kQuickLinksSeparator = QStringLiteral("-+-");
 
 } // anonymous namespace
 
-BrowseFeature::BrowseFeature(
-        Library* pLibrary,
+BrowseFeature::BrowseFeature(Library* pLibrary,
         UserSettingsPointer pConfig,
         RecordingManager* pRecordingManager)
         : LibraryFeature(pLibrary, pConfig, QString("computer")),
@@ -45,19 +45,19 @@ BrowseFeature::BrowseFeature(
             this,
             &LibraryFeature::restoreModelState);
 
-    m_pAddQuickLinkAction = new QAction(tr("Add to Quick Links"),this);
+    m_pAddQuickLinkAction = new QAction(tr("Add to Quick Links"), this);
     connect(m_pAddQuickLinkAction,
             &QAction::triggered,
             this,
             &BrowseFeature::slotAddQuickLink);
 
-    m_pRemoveQuickLinkAction = new QAction(tr("Remove from Quick Links"),this);
+    m_pRemoveQuickLinkAction = new QAction(tr("Remove from Quick Links"), this);
     connect(m_pRemoveQuickLinkAction,
             &QAction::triggered,
             this,
             &BrowseFeature::slotRemoveQuickLink);
 
-    m_pAddtoLibraryAction = new QAction(tr("Add to Library"),this);
+    m_pAddtoLibraryAction = new QAction(tr("Add to Library"), this);
     connect(m_pAddtoLibraryAction,
             &QAction::triggered,
             this,
@@ -74,7 +74,8 @@ BrowseFeature::BrowseFeature(
     // The invisible root item of the child model
     std::unique_ptr<TreeItem> pRootItem = TreeItem::newRoot(this);
 
-    m_pQuickLinkItem = pRootItem->appendChild(tr("Quick Links"), QUICK_LINK_NODE);
+    m_pQuickLinkItem =
+            pRootItem->appendChild(tr("Quick Links"), QUICK_LINK_NODE);
 
     // Create the 'devices' shortcut
 #if defined(__WINDOWS__)
@@ -97,15 +98,14 @@ BrowseFeature::BrowseFeature(
             display_path.chop(1);
         }
         TreeItem* driveLetter =
-        devices_link->appendChild(
-                display_path, // Displays C:
-                drive.filePath()); // Displays C:/
+                devices_link->appendChild(display_path, // Displays C:
+                        drive.filePath());              // Displays C:/
     }
 #elif defined(__APPLE__)
     // Apple hides the base Linux file structure But all devices are mounted at
     // /Volumes
     pRootItem->appendChild(tr("Devices"), "/Volumes");
-#else  // LINUX
+#else // LINUX
     // DEVICE_NODE contents will be rendered lazily in onLazyChildExpandation.
     pRootItem->appendChild(tr("Removable Devices"), DEVICE_NODE);
 
@@ -175,11 +175,12 @@ void BrowseFeature::slotAddToLibrary() {
     msgBox.setIcon(QMessageBox::Warning);
     // strings are dupes from DlgPrefLibrary
     msgBox.setWindowTitle(tr("Music Directory Added"));
-    msgBox.setText(tr("You added one or more music directories. The tracks in "
-                      "these directories won't be available until you rescan "
-                      "your library. Would you like to rescan now?"));
-    QPushButton* scanButton = msgBox.addButton(
-        tr("Scan"), QMessageBox::AcceptRole);
+    msgBox.setText(
+            tr("You added one or more music directories. The tracks in "
+               "these directories won't be available until you rescan "
+               "your library. Would you like to rescan now?"));
+    QPushButton* scanButton =
+            msgBox.addButton(tr("Scan"), QMessageBox::AcceptRole);
     msgBox.addButton(QMessageBox::Cancel);
     msgBox.setDefaultButton(scanButton);
     msgBox.exec();
@@ -220,8 +221,8 @@ TreeItemModel* BrowseFeature::sidebarModel() const {
     return m_pSidebarModel;
 }
 
-void BrowseFeature::bindLibraryWidget(WLibrary* libraryWidget,
-                               KeyboardEventFilter* keyboard) {
+void BrowseFeature::bindLibraryWidget(
+        WLibrary* libraryWidget, KeyboardEventFilter* keyboard) {
     Q_UNUSED(keyboard);
     WLibraryTextBrowser* edit = new WLibraryTextBrowser(libraryWidget);
     edit->setHtml(getRootViewHtml());
@@ -242,7 +243,7 @@ void BrowseFeature::activate() {
 // Note: This is executed whenever you single click on an child item
 // Single clicks will not populate sub folders
 void BrowseFeature::activateChild(const QModelIndex& index) {
-    TreeItem *item = static_cast<TreeItem*>(index.internalPointer());
+    TreeItem* item = static_cast<TreeItem*>(index.internalPointer());
     qDebug() << "BrowseFeature::activateChild " << item->getLabel() << " "
              << item->getData();
 
@@ -272,8 +273,9 @@ void BrowseFeature::activateChild(const QModelIndex& index) {
     emit enableCoverArtDisplay(false);
 }
 
-void BrowseFeature::onRightClickChild(const QPoint& globalPos, const QModelIndex& index) {
-    TreeItem *item = static_cast<TreeItem*>(index.internalPointer());
+void BrowseFeature::onRightClickChild(
+        const QPoint& globalPos, const QModelIndex& index) {
+    TreeItem* item = static_cast<TreeItem*>(index.internalPointer());
     m_pLastRightClickedItem = item;
 
     if (!item) {
@@ -303,12 +305,12 @@ void BrowseFeature::onRightClickChild(const QPoint& globalPos, const QModelIndex
             onLazyChildExpandation(index);
             return;
         }
-     }
+    }
 
-     menu.addAction(m_pAddQuickLinkAction);
-     menu.addAction(m_pAddtoLibraryAction);
-     menu.exec(globalPos);
-     onLazyChildExpandation(index);
+    menu.addAction(m_pAddQuickLinkAction);
+    menu.addAction(m_pAddtoLibraryAction);
+    menu.exec(globalPos);
+    onLazyChildExpandation(index);
 }
 
 namespace {
@@ -332,9 +334,8 @@ QList<TreeItem*> getRemovableDevices() {
         if (display_path.endsWith("/")) {
             display_path.chop(1);
         }
-        TreeItem* driveLetter = new TreeItem(
-            display_path, // Displays C:
-            drive.filePath()); // Displays C:/
+        TreeItem* driveLetter = new TreeItem(display_path, // Displays C:
+                drive.filePath());                         // Displays C:/
         ret << driveLetter;
     }
 #elif defined(__LINUX__)
@@ -343,19 +344,19 @@ QList<TreeItem*> getRemovableDevices() {
     QFileInfoList devices;
 
     // Add folders under /media to devices.
-    devices += QDir("/media").entryInfoList(
-        QDir::AllDirs | QDir::NoDotAndDotDot);
+    devices +=
+            QDir("/media").entryInfoList(QDir::AllDirs | QDir::NoDotAndDotDot);
 
     // Add folders under /run/media/$USER to devices.
-    QDir run_media_user_dir(QStringLiteral("/run/media/") + QString::fromLocal8Bit(qgetenv("USER")));
+    QDir run_media_user_dir(QStringLiteral("/run/media/") +
+            QString::fromLocal8Bit(qgetenv("USER")));
     devices += run_media_user_dir.entryInfoList(
-        QDir::AllDirs | QDir::NoDotAndDotDot);
+            QDir::AllDirs | QDir::NoDotAndDotDot);
 
     // Convert devices into a QList<TreeItem*> for display.
-    foreach(QFileInfo device, devices) {
-        TreeItem* folder = new TreeItem(
-            device.fileName(),
-            QVariant(device.filePath() + QStringLiteral("/")));
+    foreach (QFileInfo device, devices) {
+        TreeItem* folder = new TreeItem(device.fileName(),
+                QVariant(device.filePath() + QStringLiteral("/")));
         ret << folder;
     }
 #endif
@@ -378,7 +379,7 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
     if (!index.isValid()) {
         return;
     }
-    TreeItem *item = static_cast<TreeItem*>(index.internalPointer());
+    TreeItem* item = static_cast<TreeItem*>(index.internalPointer());
     if (!(item && item->getData().isValid())) {
         return;
     }
@@ -410,7 +411,7 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
         m_childModel.setData(index, QString("loading"));
         m_childModel.triggerRepaint(index);
         */
-        
+
         //auto foundFolders = result.result();
         //folders += foundFolders;
     }
@@ -424,8 +425,9 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
 
 QString BrowseFeature::getRootViewHtml() const {
     QString browseTitle = tr("Computer");
-    QString browseSummary = tr("\"Computer\" lets you navigate, view, and load tracks"
-                        " from folders on your hard disk and external devices.");
+    QString browseSummary =
+            tr("\"Computer\" lets you navigate, view, and load tracks"
+               " from folders on your hard disk and external devices.");
 
     QString html;
     html.append(QString("<h2>%1</h2>").arg(browseTitle));
@@ -434,23 +436,25 @@ QString BrowseFeature::getRootViewHtml() const {
 }
 
 void BrowseFeature::saveQuickLinks() {
-    m_pConfig->set(ConfigKey("[Browse]","QuickLinks"),ConfigValue(
-        m_quickLinkList.join(kQuickLinksSeparator)));
+    m_pConfig->set(ConfigKey("[Browse]", "QuickLinks"),
+            ConfigValue(m_quickLinkList.join(kQuickLinksSeparator)));
 }
 
 void BrowseFeature::loadQuickLinks() {
-    if (m_pConfig->getValueString(ConfigKey("[Browse]","QuickLinks")).isEmpty()) {
+    if (m_pConfig->getValueString(ConfigKey("[Browse]", "QuickLinks"))
+                    .isEmpty()) {
         m_quickLinkList = getDefaultQuickLinks();
     } else {
-        m_quickLinkList = m_pConfig->getValueString(
-            ConfigKey("[Browse]","QuickLinks")).split(kQuickLinksSeparator);
+        m_quickLinkList =
+                m_pConfig->getValueString(ConfigKey("[Browse]", "QuickLinks"))
+                        .split(kQuickLinksSeparator);
     }
 }
 
 QString BrowseFeature::extractNameFromPath(const QString& spath) {
-    QString path = spath.left(spath.count()-1);
+    QString path = spath.left(spath.count() - 1);
     int index = path.lastIndexOf("/");
-    QString name = (spath.count() > 1) ? path.mid(index+1) : spath;
+    QString name = (spath.count() > 1) ? path.mid(index + 1) : spath;
     return name;
 }
 
@@ -460,10 +464,10 @@ QStringList BrowseFeature::getDefaultQuickLinks() const {
             QStandardPaths::MusicLocation));
     QDir osDocumentsDir(QStandardPaths::writableLocation(
             QStandardPaths::DocumentsLocation));
-    QDir osHomeDir(QStandardPaths::writableLocation(
-            QStandardPaths::HomeLocation));
-    QDir osDesktopDir(QStandardPaths::writableLocation(
-            QStandardPaths::DesktopLocation));
+    QDir osHomeDir(
+            QStandardPaths::writableLocation(QStandardPaths::HomeLocation));
+    QDir osDesktopDir(
+            QStandardPaths::writableLocation(QStandardPaths::DesktopLocation));
     QDir osDownloadsDir(osHomeDir);
     // TODO(XXX) i18n -- no good way to get the download path. We could tr() it
     // but the translator may not realize we want the usual name of the

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -1,7 +1,6 @@
 #include "library/browse/browsefeature.h"
 
 #include <QAction>
-#include <QtConcurrent>
 #include <QFileInfo>
 #include <QMenu>
 #include <QPushButton>

--- a/src/library/browse/browsefeature.h
+++ b/src/library/browse/browsefeature.h
@@ -1,19 +1,19 @@
 #pragma once
 
-#include <QStringListModel>
-#include <QSortFilterProxyModel>
-#include <QObject>
-#include <QVariant>
 #include <QIcon>
 #include <QModelIndex>
+#include <QObject>
 #include <QPoint>
+#include <QSortFilterProxyModel>
 #include <QString>
+#include <QStringListModel>
+#include <QVariant>
 
-#include "preferences/usersettings.h"
 #include "library/browse/browsetablemodel.h"
 #include "library/browse/foldertreemodel.h"
 #include "library/libraryfeature.h"
 #include "library/proxytrackmodel.h"
+#include "preferences/usersettings.h"
 
 #define QUICK_LINK_NODE "::mixxx_quick_lnk_node::"
 #define DEVICE_NODE "::mixxx_device_node::"

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -5,7 +5,6 @@
 #include <QStringList>
 #include <QTableView>
 #include <QUrl>
-#include <QtConcurrentRun>
 #include <QtSql>
 
 #include "control/controlobject.h"

--- a/src/library/browse/foldertreemodel.cpp
+++ b/src/library/browse/foldertreemodel.cpp
@@ -54,7 +54,7 @@ FolderTreeModel::FolderTreeModel(QObject* parent)
 
                 auto* folders = new QList<TreeItem*>();
                 QFutureSynchronizer<void> sync;
-                // loop through all the item and construct the childs
+                // loop through all the item and construct the children
                 foreach (QFileInfo one, all) {
 #if defined(__APPLE__)
                     if (one.isDir() && one.fileName().endsWith(".app")) {

--- a/src/library/browse/foldertreemodel.cpp
+++ b/src/library/browse/foldertreemodel.cpp
@@ -166,8 +166,8 @@ void FolderTreeModel::directoryHasChildren(const QString& path) {
     // http://stackoverflow.com/questions/2579948/checking-if-subfolders-exist-linux
 
     std::string dot("."), dotdot("..");
-    QByteArray ba = QFile::encodeName(path);
-    DIR* directory = opendir(ba);
+    QByteArray directory_name = QFile::encodeName(path);
+    DIR* directory = opendir(directory_name);
     int unknown_count = 0;
     int total_count = 0;
     if (directory != nullptr) {

--- a/src/library/browse/foldertreemodel.cpp
+++ b/src/library/browse/foldertreemodel.cpp
@@ -70,7 +70,7 @@ FolderTreeModel::FolderTreeModel(QObject *parent)
 }
 
 FolderTreeModel::~FolderTreeModel() {
-    m_isRunning.store(true, std::memory_order_release);
+    m_isRunning.store(false, std::memory_order_release);
 }
 
 /* A tree model of the filesystem should be initialized lazy.
@@ -183,6 +183,7 @@ void FolderTreeModel::processFolder(const QModelIndex& parent, const FileAccess&
 }
 
 void FolderTreeModel::addChildren(const QModelIndex& parent, TreeItemList children) {
+    kLogger.debug() << "adding " << children->size() << " to the list";
     TreeItemModel::insertTreeItemRows(*children, 0, parent);
     delete children;
 }

--- a/src/library/browse/foldertreemodel.cpp
+++ b/src/library/browse/foldertreemodel.cpp
@@ -1,7 +1,7 @@
 #if defined(__WINDOWS__)
+#include <windows.h>
 #include <Shellapi.h>
 #include <Shlobj.h>
-#include <windows.h>
 #else
 #include <dirent.h>
 #include <errno.h>
@@ -17,6 +17,7 @@
 #include "library/browse/foldertreemodel.h"
 #include "library/treeitem.h"
 #include "moc_foldertreemodel.cpp"
+#include "util/qt.h"
 
 FolderTreeModel::FolderTreeModel(QObject* parent)
         : TreeItemModel(parent), m_isRunning(true) {
@@ -120,7 +121,7 @@ bool FolderTreeModel::hasChildren(const QModelIndex& parent) const {
         if (it != m_directoryCache.end()) {
             return it->second;
         }
-        emit hasSubDirectory(folder);
+        emit mixxx::thisAsNonConst(this)->hasSubDirectory(folder);
     }
     return true;
 }

--- a/src/library/browse/foldertreemodel.cpp
+++ b/src/library/browse/foldertreemodel.cpp
@@ -1,16 +1,7 @@
-#if defined (__WINDOWS__)
-#include <windows.h>
-#include <Shellapi.h>
-#include <Shlobj.h>
-#else
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <dirent.h>
-#include <unistd.h>
-#include <errno.h>
-#endif
+#include <filesystem>
 
 #include <QFileInfo>
+#include <QtConcurrent>
 
 #include "library/browse/browsefeature.h"
 #include "library/browse/foldertreemodel.h"
@@ -19,6 +10,8 @@
 
 FolderTreeModel::FolderTreeModel(QObject *parent)
         : TreeItemModel(parent) {
+    QObject::connect(&m_fsWatcher, SIGNAL(directoryChanged(QString)), this, SLOT(showModified(QString)));
+    m_pool.setMaxThreadCount(5);
 }
 
 FolderTreeModel::~FolderTreeModel() {
@@ -48,75 +41,47 @@ bool FolderTreeModel::hasChildren(const QModelIndex& parent) const {
 
     // In all other cases the getData() points to a folder
     QString folder = item->getData().toString();
-    return directoryHasChildren(folder);
+    return checkFS(folder);
 }
 
-bool FolderTreeModel::directoryHasChildren(const QString& path) const {
-    auto it = m_directoryCache.constFind(path);
-    if (it != m_directoryCache.constEnd()) {
-        return it.value();
+void FolderTreeModel::directoryModified(const QString& str) {
+    if (m_directoryCache.count(str)) {
+        m_directoryCache.erase(str);
     }
+}
 
-    // Acquire a security token for the path.
-    const auto dirAccess = mixxx::FileAccess(mixxx::FileInfo(path));
+void FolderTreeModel::insertTreeItemRows(QList<TreeItem*> &rows, int position, const QModelIndex& parent) {
+    if (rows.isEmpty()) {
+        return;
+    }
+    QFutureSynchronizer<void> sync;
+    foreach(const TreeItem* row, rows) {
+        // init cache
+        sync.addFuture(QtConcurrent::run(&m_pool, [=]() {
+            auto absolutePath = row->getData().toString();
+            this->checkFS(absolutePath);
+        }));
+    }
+    sync.waitForFinished();
+    TreeItemModel::insertTreeItemRows(rows, position, parent);
+}
 
-    /*
-     *  The following code is too expensive, general and SLOW since
-     *  QDIR::EntryInfoList returns a full QFileInfolist
-     *
-     *
-     *  QDir dir(item->getData().toString());
-     *  QFileInfoList all = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
-     *  return (all.count() > 0);
-     *
-     *  We can benefit from low-level filesystem APIs, i.e.,
-     *  Windows API or SystemCalls
-     */
-
-    bool has_children = false;
-
-#if defined (__WINDOWS__)
-    QString folder = path;
-    folder.replace("/","\\");
-
-    //quick subfolder test
-    SHFILEINFOW sfi;
-    SHGetFileInfo((LPCWSTR) folder.constData(), NULL, &sfi, sizeof(sfi), SHGFI_ATTRIBUTES);
-    has_children = (sfi.dwAttributes & SFGAO_HASSUBFOLDER);
-#else
-    // For OS X and Linux
-    // http://stackoverflow.com/questions/2579948/checking-if-subfolders-exist-linux
-
-    std::string dot("."), dotdot("..");
-    QByteArray ba = QFile::encodeName(path);
-    DIR *directory = opendir(ba);
-    int unknown_count = 0;
-    int total_count = 0;
-    if (directory != nullptr) {
-        struct dirent *entry;
-        while (!has_children && ((entry = readdir(directory)) != nullptr)) {
-            if (entry->d_name != dot && entry->d_name != dotdot) {
-                total_count++;
-                if (entry->d_type == DT_UNKNOWN) {
-                    unknown_count++;
+bool FolderTreeModel::checkFS(const QString& path) const { 
+    const auto it = m_directoryCache.find(path);
+    if (it != m_directoryCache.end()) {
+        return it->second;
+    }
+    std::filesystem::path fsPath(path.toStdString());
+    try {
+        for (const auto& c: std::filesystem::directory_iterator(fsPath)) {
+                if (c.is_directory()) {
+                    m_directoryCache.emplace(path, true);
+                    return true;
                 }
-                has_children = (entry->d_type == DT_DIR || entry->d_type == DT_LNK);
-            }
         }
-        closedir(directory);
+    } catch (const std::filesystem::filesystem_error& e) {
+        qDebug() << e.what();
     }
-
-    // If all files are of type DH_UNKNOWN then do a costlier analysis to
-    // determine if the directory has subdirectories. This affects folders on
-    // filesystems that do not fully implement readdir such as JFS.
-    if (directory == nullptr || (unknown_count == total_count && total_count > 0)) {
-        QDir dir(path);
-        QFileInfoList all = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
-        has_children = all.count() > 0;
-    }
-#endif
-
-    // Cache and return the result
-    m_directoryCache[path] = has_children;
-    return has_children;
+    m_directoryCache.emplace(path, false);
+    return false;
 }

--- a/src/library/browse/foldertreemodel.cpp
+++ b/src/library/browse/foldertreemodel.cpp
@@ -21,10 +21,10 @@
 
 FolderTreeModel::FolderTreeModel(QObject* parent)
         : TreeItemModel(parent), m_isRunning(true) {
-    QObject::connect(&m_fsWatcher,
-            SIGNAL(directoryChanged(QString)),
+    connect(&m_fsWatcher,
+            &QFileSystemWatcher::directoryChanged,
             this,
-            SLOT(dirModified(QString)));
+            &FolderTreeModel::dirModified);
     connect(this,
             &FolderTreeModel::newChildren,
             this,
@@ -33,8 +33,7 @@ FolderTreeModel::FolderTreeModel(QObject* parent)
     connect(this,
             &FolderTreeModel::hasSubDirectory,
             this,
-            &FolderTreeModel::onHasSubDirectory,
-            Qt::QueuedConnection);
+            &FolderTreeModel::onHasSubDirectory);
 
     m_pool.setMaxThreadCount(4);
     QtConcurrent::run(&m_pool, [&]() {

--- a/src/library/browse/foldertreemodel.cpp
+++ b/src/library/browse/foldertreemodel.cpp
@@ -1,4 +1,14 @@
-#include <filesystem>
+#if defined (__WINDOWS__)
+#include <windows.h>
+#include <Shellapi.h>
+#include <Shlobj.h>
+#else
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <errno.h>
+#endif
 
 #include <QFileInfo>
 #include <QtConcurrent>
@@ -7,14 +17,60 @@
 #include "library/browse/foldertreemodel.h"
 #include "library/treeitem.h"
 #include "moc_foldertreemodel.cpp"
+#include "util/logger.h"
+
+namespace {
+
+mixxx::Logger kLogger("FolderTreeModel");
+
+} // namespace
 
 FolderTreeModel::FolderTreeModel(QObject *parent)
-        : TreeItemModel(parent) {
-    QObject::connect(&m_fsWatcher, SIGNAL(directoryChanged(QString)), this, SLOT(showModified(QString)));
-    m_pool.setMaxThreadCount(5);
+        : TreeItemModel(parent), m_isRunning(true) {
+    QObject::connect(&m_fsWatcher, SIGNAL(directoryChanged(QString)), this, SLOT(dirModified(QString)));
+    connect(this, &FolderTreeModel::newChildren, this, &FolderTreeModel::addChildren, Qt::QueuedConnection);
+
+    m_pool.setMaxThreadCount(4);
+    QtConcurrent::run(&m_pool, [&]() {
+        while (m_isRunning.load(std::memory_order_consume)) {
+            if (!m_folderQueue.isEmpty()) {
+                const auto& [parent, dir] = m_folderQueue.dequeue();
+                kLogger.debug() << "processing " << dir.dir().dirName();
+                QFileInfoList all = dir.info().toQDir().entryInfoList(
+                        QDir::Dirs | QDir::NoDotAndDotDot);
+
+                auto* folders = new QList<TreeItem*>();
+                QFutureSynchronizer<void> sync;
+                // loop through all the item and construct the childs
+                foreach (QFileInfo one, all) {
+#if defined(__APPLE__)
+                    if (one.isDir() && one.fileName().endsWith(".app"))
+                        continue;
+#endif
+                    // We here create new items for the sidebar models
+                    // Once the items are added to the TreeItemModel,
+                    // the models takes ownership of them and ensures their deletion
+                    auto* folder = new TreeItem(
+                            one.fileName(),
+                            QVariant(one.absoluteFilePath() + QStringLiteral("/")));
+                    // init cache
+                    sync.addFuture(QtConcurrent::run(&m_pool, [&]() {
+                        this->directoryHasChildren(one.absoluteFilePath());
+                    }));
+                    folders->push_back(folder);
+                }
+                if (!folders->isEmpty()) {
+                    sync.waitForFinished();
+                    emit newChildren(parent, folders);
+                }
+            }
+            QThread::sleep(1);
+        }
+    });
 }
 
 FolderTreeModel::~FolderTreeModel() {
+    m_isRunning.store(true, std::memory_order_release);
 }
 
 /* A tree model of the filesystem should be initialized lazy.
@@ -41,47 +97,93 @@ bool FolderTreeModel::hasChildren(const QModelIndex& parent) const {
 
     // In all other cases the getData() points to a folder
     QString folder = item->getData().toString();
-    return checkFS(folder);
+    return directoryHasChildren(folder);
 }
 
-void FolderTreeModel::directoryModified(const QString& str) {
-    if (m_directoryCache.count(str)) {
-        m_directoryCache.erase(str);
-    }
-}
-
-void FolderTreeModel::insertTreeItemRows(QList<TreeItem*> &rows, int position, const QModelIndex& parent) {
-    if (rows.isEmpty()) {
-        return;
-    }
-    QFutureSynchronizer<void> sync;
-    foreach(const TreeItem* row, rows) {
-        // init cache
-        sync.addFuture(QtConcurrent::run(&m_pool, [=]() {
-            auto absolutePath = row->getData().toString();
-            this->checkFS(absolutePath);
-        }));
-    }
-    sync.waitForFinished();
-    TreeItemModel::insertTreeItemRows(rows, position, parent);
-}
-
-bool FolderTreeModel::checkFS(const QString& path) const { 
+bool FolderTreeModel::directoryHasChildren(const QString& path) const {
+    MReadLocker readLock(&m_cacheLock);
     const auto it = m_directoryCache.find(path);
     if (it != m_directoryCache.end()) {
         return it->second;
     }
-    std::filesystem::path fsPath(path.toStdString());
-    try {
-        for (const auto& c: std::filesystem::directory_iterator(fsPath)) {
-                if (c.is_directory()) {
-                    m_directoryCache.emplace(path, true);
-                    return true;
+    readLock.unlock();
+
+    MWriteLocker writeLock(&m_cacheLock);
+    // Acquire a security token for the path.
+    const auto dirAccess = mixxx::FileAccess(mixxx::FileInfo(path));
+
+    /*
+     *  The following code is too expensive, general and SLOW since
+     *  QDIR::EntryInfoList returns a full QFileInfolist
+     *
+     *
+     *  QDir dir(item->getData().toString());
+     *  QFileInfoList all = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
+     *  return (all.count() > 0);
+     *
+     *  We can benefit from low-level filesystem APIs, i.e.,
+     *  Windows API or SystemCalls
+     */
+
+    bool has_children = false;
+
+#if defined (__WINDOWS__)
+    QString folder = path;
+    folder.replace("/","\\");
+
+    //quick subfolder test
+    SHFILEINFOW sfi;
+    SHGetFileInfo((LPCWSTR) folder.constData(), NULL, &sfi, sizeof(sfi), SHGFI_ATTRIBUTES);
+    has_children = (sfi.dwAttributes & SFGAO_HASSUBFOLDER);
+#else
+    // For OS X and Linux
+    // http://stackoverflow.com/questions/2579948/checking-if-subfolders-exist-linux
+
+    std::string dot("."), dotdot("..");
+    QByteArray ba = QFile::encodeName(path);
+    DIR *directory = opendir(ba);
+    int unknown_count = 0;
+    int total_count = 0;
+    if (directory != nullptr) {
+        struct dirent *entry;
+        while (!has_children && ((entry = readdir(directory)) != nullptr)) {
+            if (entry->d_name != dot && entry->d_name != dotdot) {
+                total_count++;
+                if (entry->d_type == DT_UNKNOWN) {
+                    unknown_count++;
                 }
+                has_children = (entry->d_type == DT_DIR || entry->d_type == DT_LNK);
+            }
         }
-    } catch (const std::filesystem::filesystem_error& e) {
-        qDebug() << e.what();
+        closedir(directory);
     }
-    m_directoryCache.emplace(path, false);
-    return false;
+
+    // If all files are of type DH_UNKNOWN then do a costlier analysis to
+    // determine if the directory has subdirectories. This affects folders on
+    // filesystems that do not fully implement readdir such as JFS.
+    if (directory == nullptr || (unknown_count == total_count && total_count > 0)) {
+        QDir dir(path);
+        QFileInfoList all = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
+        has_children = all.count() > 0;
+    }
+#endif
+
+    // Cache and return the result
+    return m_directoryCache.emplace(path, has_children).first->second;
 }
+
+void FolderTreeModel::dirModified(const QString& str) {
+    if (m_directoryCache.count(str.toUtf8().data())) {
+        //m_directoryCache.erase(str);
+    }
+}
+
+void FolderTreeModel::processFolder(const QModelIndex& parent, const FileAccess& path) {
+    m_folderQueue.enqueue(std::make_pair(parent, path));
+}
+
+void FolderTreeModel::addChildren(const QModelIndex& parent, TreeItemList children) {
+    TreeItemModel::insertTreeItemRows(*children, 0, parent);
+    delete children;
+}
+

--- a/src/library/browse/foldertreemodel.h
+++ b/src/library/browse/foldertreemodel.h
@@ -9,6 +9,7 @@
 #include <QThreadPool>
 #include <QVariant>
 #include <functional>
+#include <mutex>
 #include <unordered_map>
 
 #include "library/treeitem.h"
@@ -16,12 +17,13 @@
 #include "util/mutex.h"
 
 namespace std {
-  template<> struct hash<QString> {
+template<>
+struct hash<QString> {
     std::size_t operator()(const QString& s) const noexcept {
-      return (size_t) qHash(s);
+        return (size_t)qHash(s);
     }
-  };
-}
+};
+} // namespace std
 
 class TreeItem;
 // This class represents a folder item within the Browse Feature

--- a/src/library/browse/foldertreemodel.h
+++ b/src/library/browse/foldertreemodel.h
@@ -1,10 +1,14 @@
 #pragma once
 
 #include <QAbstractItemModel>
+#include <QFileSystemWatcher>
 #include <QModelIndex>
 #include <QVariant>
 #include <QList>
 #include <QHash>
+#include <QThreadPool>
+
+#include <unordered_map>
 
 #include "library/treeitemmodel.h"
 #include "library/treeitem.h"
@@ -20,9 +24,21 @@ class FolderTreeModel : public TreeItemModel {
     FolderTreeModel(QObject *parent = 0);
     virtual ~FolderTreeModel();
     virtual bool hasChildren(const QModelIndex& parent = QModelIndex()) const;
-    bool directoryHasChildren(const QString& path) const;
+    void insertTreeItemRows(QList<TreeItem*> &rows, int position, const QModelIndex& parent = QModelIndex()) override;
 
   private:
+    bool checkFS(const QString& path) const;
+
+/*
+  protected:
+    bool canFetchMore(const QModelIndex &parent) const override;
+    void fetchMore(const QModelIndex &parent) override;
+*/
+  private slots:
+    void directoryModified(const QString& str);
+  private:
     // Used for memoizing the results of directoryHasChildren
-    mutable QHash<QString, bool> m_directoryCache;
+    mutable std::unordered_map<QString, bool> m_directoryCache;
+    mutable QFileSystemWatcher m_fsWatcher;
+    QThreadPool m_pool;
 };

--- a/src/library/browse/foldertreemodel.h
+++ b/src/library/browse/foldertreemodel.h
@@ -16,6 +16,7 @@
 #include "library/treeitemmodel.h"
 #include "util/mutex.h"
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
 namespace std {
 template<>
 struct hash<QString> {
@@ -24,6 +25,7 @@ struct hash<QString> {
     }
 };
 } // namespace std
+#endif
 
 class TreeItem;
 // This class represents a folder item within the Browse Feature

--- a/src/library/browse/foldertreemodel.h
+++ b/src/library/browse/foldertreemodel.h
@@ -36,6 +36,7 @@ class FolderTreeModel : public TreeItemModel {
     Q_OBJECT
 
     using FolderQueue = QQueue<std::pair<QModelIndex, QString>>;
+    // FIXME: this should be a Trie (prefix tree)
     using Cache = std::unordered_map<QString, bool>;
 
   public:
@@ -56,7 +57,7 @@ class FolderTreeModel : public TreeItemModel {
 
   signals:
     void newChildren(const QModelIndex& parent, TreeItemList hildren);
-    void hasSubDirectory(const QString& path) const;
+    void hasSubDirectory(const QString& path);
 
   private:
     // Used for memoizing the results of directoryHasChildren

--- a/src/library/browse/foldertreemodel.h
+++ b/src/library/browse/foldertreemodel.h
@@ -2,6 +2,7 @@
 
 #include <QAbstractItemModel>
 #include <QFileSystemWatcher>
+#include <QFuture>
 #include <QHash>
 #include <QList>
 #include <QModelIndex>
@@ -68,6 +69,7 @@ class FolderTreeModel : public TreeItemModel {
     mutable FolderQueue m_folderQueue;
     mutable std::mutex m_queueLock;
     std::atomic<bool> m_isRunning;
+    QFuture<void> m_folderProcess;
 };
 Q_DECLARE_METATYPE(FolderTreeModel::TreeItemList);
 Q_DECLARE_OPAQUE_POINTER(FolderTreeModel::TreeItemList);

--- a/src/library/browse/foldertreemodel.h
+++ b/src/library/browse/foldertreemodel.h
@@ -9,12 +9,21 @@
 #include <QThreadPool>
 #include <QQueue>
 
+#include <functional>
 #include <unordered_map>
 
 #include "library/treeitemmodel.h"
 #include "library/treeitem.h"
 #include "util/fileaccess.h"
 #include "util/mutex.h"
+
+namespace std {
+  template<> struct hash<QString> {
+    std::size_t operator()(const QString& s) const noexcept {
+      return (size_t) qHash(s);
+    }
+  };
+}
 
 class TreeItem;
 // This class represents a folder item within the Browse Feature

--- a/src/library/treeitem.cpp
+++ b/src/library/treeitem.cpp
@@ -106,9 +106,8 @@ void TreeItem::insertChildren(int row, QList<TreeItem*>& children) {
     DEBUG_ASSERT(row >= 0);
     DEBUG_ASSERT(row <= m_children.size());
     while (!children.isEmpty()) {
-        TreeItem* pChild = children.front();
+        TreeItem* pChild = children.takeFirst();
         insertChild(row++, pChild);
-        children.pop_front();
     }
 }
 

--- a/src/library/treeitemmodel.h
+++ b/src/library/treeitemmodel.h
@@ -30,7 +30,7 @@ class TreeItemModel : public QAbstractItemModel {
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
 
-    virtual void insertTreeItemRows(QList<TreeItem*> &rows, int position, const QModelIndex& parent = QModelIndex());
+    void insertTreeItemRows(QList<TreeItem*> &rows, int position, const QModelIndex& parent = QModelIndex());
 
     TreeItem* setRootItem(std::unique_ptr<TreeItem> pRootItem);
     TreeItem* getRootItem() const {

--- a/src/library/treeitemmodel.h
+++ b/src/library/treeitemmodel.h
@@ -30,7 +30,7 @@ class TreeItemModel : public QAbstractItemModel {
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
 
-    void insertTreeItemRows(QList<TreeItem*> &rows, int position, const QModelIndex& parent = QModelIndex());
+    virtual void insertTreeItemRows(QList<TreeItem*> &rows, int position, const QModelIndex& parent = QModelIndex());
 
     TreeItem* setRootItem(std::unique_ptr<TreeItem> pRootItem);
     TreeItem* getRootItem() const {


### PR DESCRIPTION
It's never a good idea to call IO in a UI thread as anything can go wrong, see for example [this bug](https://bugs.launchpad.net/mixxx/+bug/1488046).

some other details of this patch:
 - since the project requires c++17 feature, i've replaced the directory checking logic using `std::filesystem`
 - switched to `std::unordered_map` instead of `QHash` in `FolderTreeModel` for performance reasons

Tasks that still needs to be done:
- [ ] ~~handle the returned Future of `QtConcurrent::run` and update the UI based on a timer if loading takes more time than n seconds~~ WONTFIX
- [x] add Read/Write mutex protecting `FolderTreeModel::m_directoryCache`
- [x] finish `QFileSystemWatcher` logic for monitoring FS changes.
- [x] only specialize `std::hash<QString>` when needed (avoid redefinition error)