### PR TITLE
Library features: wrap controls into QWidget 'LibraryFeatureControls'

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -502,8 +502,6 @@ WSearchLineEdit {
   background-color: #1F1F1F;
   border: 1px solid #1A1A1A;
 }
-/* transition time in Auto DJ tab is styled pretty much the same as WBeatSpinBox above */
-#DlgAutoDJ QSpinBox {}
 
 /* Extra declaration for QRadionButton otherwise it shows up with wrong colors in Linux with Gnome */
 WLibrary QLabel, WLibrary QRadioButton {
@@ -528,40 +526,26 @@ WLibrary QRadioButton::indicator:unchecked {
 }
 /* buttons in library (in hierarchical order of appearance)
    Style them just as the other regular buttons */
-#DlgMissing > QPushButton,
-#DlgHidden > QPushButton,
-#DlgAutoDJ > QPushButton,
-#DlgRecording > QPushButton,
-#DlgAnalysis > QPushButton {
+#LibraryFeatureControls QPushButton {
   margin: 9px 3px 6px 3px;
+  padding: 3px 4px;
   color: #D2D2D2;
   background-color: #4B4B4B;
   border: 1px solid #4B4B4B;
   border-radius: 2px;
   outline: none;
   }
-  #DlgMissing > QPushButton,
-  #DlgHidden > QPushButton,
-  #DlgRecording > QPushButton,
-  #DlgAnalysis > QPushButton {
-    padding: 3px 4px;
-  }
-  #DlgAutoDJ > QPushButton {
+  #DlgAutoDJ > #LibraryFeatureControls QPushButton {
     padding: 0px 1px;
-  }
-  #DlgAutoDJ > QPushButton {
     width: 34px;
     height: 20px;
-  }
-  QPushButton#pushButtonAutoDJ {
-    width: 42px;
-  }
+    }
+    QPushButton#pushButtonAutoDJ {
+      width: 42px;
+    }
 
 
-#DlgMissing > QPushButton:!enabled,
-#DlgHidden > QPushButton:!enabled,
-#DlgAutoDJ > QPushButton:!enabled,
-#DlgAnalysis > QPushButton:!enabled {
+#LibraryFeatureControls QPushButton:!enabled {
   /* buttons in "disabled" (not click-able) state. They are nearly invisible
      by default QT palette, so style accordingly */
   color: #808080; /* Default #A3A3A3 -90L HSL*/
@@ -572,30 +556,24 @@ WLibrary QRadioButton::indicator:unchecked {
   outline: none;
 }
 
-#DlgMissing > QPushButton:hover,
-#DlgHidden > QPushButton:hover,
-#DlgAutoDJ > QPushButton:hover,
-#DlgRecording > QPushButton:hover,
-#DlgAnalysis > QPushButton:hover {
+#LibraryFeatureControls QPushButton:hover {
   color: #D2D2D2;
   background-color: #5F5F5F;
   border: 1px solid #5F5F5F;
   outline: none;
 }
 
-#DlgMissing > QPushButton:focus,
-#DlgHidden > QPushButton:focus,
-#DlgAutoDJ > QPushButton:focus,
-#DlgRecording > QPushButton:focus,
-#DlgAnalysis > QPushButton:focus,
+#LibraryFeatureControls QPushButton:focus,
 #fadeModeCombobox:focus,
-#DlgAutoDJ QSpinBox:focus {
+#spinBoxTransition:focus {
   outline: none;
 }
 
-#DlgAutoDJ > QPushButton:checked,
-#DlgRecording > QPushButton:checked,
-#DlgAnalysis > QPushButton:checked {
+
+QPushButton#pushButtonAutoDJ:checked,
+QPushButton#pushButtonRepeatPlaylist:checked,
+QPushButton#pushButtonAnalyze:checked,
+QPushButton#pushButtonRecording:checked {
   /* checkbuttons in active state */
   color: #FDFDFD;
   background-color: #006596;
@@ -603,9 +581,10 @@ WLibrary QRadioButton::indicator:unchecked {
   outline: none;
 }
 
-#DlgAutoDJ > QPushButton:checked:hover,
-#DlgRecording > QPushButton:checked:hover,
-#DlgAnalysis > QPushButton:checked:hover {
+QPushButton#pushButtonAutoDJ:checked:hover,
+QPushButton#pushButtonRepeatPlaylist:checked:hover,
+QPushButton#pushButtonAnalyze:checked:hover,
+QPushButton#pushButtonRecording:checked:hover {
   /* checkbuttons hovered over in "active" state */
   margin: 9px 3px 6px 3px;
   color: #FDFDFD;
@@ -614,10 +593,7 @@ WLibrary QRadioButton::indicator:unchecked {
   outline: none;
 }
 
-#DlgMissing > QPushButton:pressed,
-#DlgHidden > QPushButton:pressed,
-#DlgAutoDJ > QPushButton:pressed,
-#DlgAnalysis > QPushButton:pressed {
+#LibraryFeatureControls QPushButton:pressed {
   /* pushbuttons in "down" state */
   margin: 9px 3px 6px 3px;
   color: #FDFDFD;
@@ -938,7 +914,7 @@ WOverview #PassthroughLabel {
 }
 
 WBeatSpinBox,
-#DlgAutoDJ QSpinBox {
+#spinBoxTransition {
   color: #c1cabe;
   background-color: #1f1e1e;
   border: 1px solid #444342;
@@ -948,18 +924,18 @@ WBeatSpinBox,
   WBeatSpinBox {
     padding: 2px;
   }
-  #DlgAutoDJ QSpinBox {
+  #spinBoxTransition {
     padding: 1px 2px 2px 2px;
     margin: 3px 0px 0px 2px;
   }
   WBeatSpinBox:hover,
-  #DlgAutoDJ QSpinBox:hover,
+  #spinBoxTransition:hover,
   WBeatSpinBox:focus,
-  #DlgAutoDJ QSpinBox:focus {
+  #spinBoxTransition:focus {
     border: 1px ridge #015d8d;
   }
   WBeatSpinBox::down-button,
-  #DlgAutoDJ QSpinBox::down-button {
+  #spinBoxTransition::down-button {
     subcontrol-origin: border;
     subcontrol-position: bottom right; /* position at the top right corner */
     padding-right: 4px;
@@ -967,17 +943,17 @@ WBeatSpinBox,
     border: 0;
   }
   WBeatSpinBox::down-arrow,
-  #DlgAutoDJ QSpinBox::down-arrow {
+  #spinBoxTransition::down-arrow {
     width: 9px;
     height: 7px;
     image: url(skin:/icon/ic_chevron_down_selector.svg);
   }
   WBeatSpinBox::down-arrow:hover,
-  #DlgAutoDJ QSpinBox::down-arrow:hover {
+  #spinBoxTransition::down-arrow:hover {
     image: url(skin:/icon/ic_chevron_down_selector_hover.svg);
   }
   WBeatSpinBox::up-button,
-  #DlgAutoDJ QSpinBox::up-button {
+  #spinBoxTransition::up-button {
     subcontrol-origin: border;
     subcontrol-position: top right; /* position at the top right corner */
     padding-right: 4px;
@@ -985,13 +961,13 @@ WBeatSpinBox,
     border: 0;
   }
   WBeatSpinBox::up-arrow,
-  #DlgAutoDJ QSpinBox::up-arrow {
+  #spinBoxTransition::up-arrow {
     width: 9px;
     height: 7px;
     image: url(skin:/icon/ic_chevron_up_selector.svg);
   }
   WBeatSpinBox::up-arrow:hover,
-  #DlgAutoDJ QSpinBox::up-arrow:hover {
+  #spinBoxTransition::up-arrow:hover {
     image: url(skin:/icon/ic_chevron_up_selector_hover.svg);
   }
 

--- a/res/skins/LateNight/library.xml
+++ b/res/skins/LateNight/library.xml
@@ -1,5 +1,8 @@
 <Template>
   <WidgetGroup>
+    <!-- This extra wrapper with 'ignore' size policy allows to
+      shrink the library to zero height, while the inner LibraryContainer
+      expands to fill the available vertical space. -->
     <SizePolicy>me,i</SizePolicy>
     <Layout>vertical</Layout>
     <Children>
@@ -21,8 +24,9 @@
             <SplitSizesConfigKey>[Skin],librarySidebar_splitsize</SplitSizesConfigKey>
             <Collapsible>1,0</Collapsible>
             <Children>
+
               <WidgetGroup>
-                <ObjectName>SidebarSearchPreviewContainer</ObjectName>
+                <ObjectName>LibSidebarContainer</ObjectName>
                 <Layout>vertical</Layout>
                 <SizePolicy>min,me</SizePolicy>
                 <MinimumSize>100,</MinimumSize>
@@ -30,8 +34,7 @@
 
                   <Template src="skin:/decks/preview_deck.xml"/>
 
-                  <!--Search Input Field + Library Expand toggle -->
-                  <WidgetGroup>
+                  <WidgetGroup><!--SearchBox + Library expand toggle -->
                     <ObjectName></ObjectName>
                     <Layout>horizontal</Layout>
                     <SizePolicy>min,max</SizePolicy>
@@ -50,26 +53,16 @@
                         <ObjectName>LibExpandBox</ObjectName>
                         <Layout>vertical</Layout>
                         <Children>
-                          <PushButton>
-                            <TooltipId>maximize_library</TooltipId>
-                            <ObjectName>LibExpand</ObjectName>
-                            <Size>16f,18me</Size>
-                            <NumberStates>2</NumberStates>
-                            <State>
-                              <Number>0</Number>
-                            </State>
-                            <State>
-                              <Number>1</Number>
-                            </State>
-                            <Connection>
-                              <ConfigKey>[Master],maximize_library</ConfigKey>
-                              <ButtonState>LeftButton</ButtonState>
-                            </Connection>
-                          </PushButton>
+                          <Template src="skin:/controls/button_2state.xml">
+                            <SetVariable name="TooltipId">maximize_library</SetVariable>
+                            <SetVariable name="ObjectName">LibExpand</SetVariable>
+                            <SetVariable name="Size">16f,18me</SetVariable>
+                            <SetVariable name="ConfigKey">[Master],maximize_library</SetVariable>
+                          </Template>
                         </Children>
                       </WidgetGroup><!-- LibExpandBox -->
                     </Children>
-                  </WidgetGroup><!-- SearchLineBox -->
+                  </WidgetGroup><!--SearchBox + Library expand toggle -->
 
                   <WidgetGroup>
                     <ObjectName>SearchTreeSpacer</ObjectName>
@@ -109,10 +102,10 @@
                         </Connection>
                       </WidgetGroup><!--Cover Art-->
                     </Children>
-                  </Splitter><!-- HorizontalSplitter -->
+                  </Splitter><!-- SidebarCoverSplitter -->
 
                 </Children>
-              </WidgetGroup><!-- SidebarSearchPreviewContainer -->
+              </WidgetGroup><!-- LibSidebarContainer -->
 
               <!-- Library Table-->
               <Library>
@@ -121,7 +114,7 @@
               </Library>
 
             </Children>
-          </Splitter><!-- VerticalSplitter -->
+          </Splitter><!-- LibrarySplitter -->
 
         </Children>
       </WidgetGroup><!-- LibraryContainer -->

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -2,7 +2,8 @@
 
 /************** font settings *************************************************/
 
-#Mixxx, WWidget,
+#Mixxx,
+WWidget,
 QToolTip,
 WLabel, QLabel,
 WNumber, WNumberPos,
@@ -28,7 +29,7 @@ WEffect,
 WEffectSelector,
 WEffectSelector QAbstractScrollArea,
 #fadeModeCombobox,
-#fadeModeCombobox QAbstractScrollArea
+#fadeModeCombobox QAbstractScrollArea,
 #LibraryContainer QPushButton,
 #LibraryContainer QLabel,
 #LibraryContainer QRadioButton,
@@ -59,12 +60,8 @@ WOverview #PassthroughLabel,
 /* SKin settings & Library */
 #SkinSettingsToggle,
 #SkinSettingsNumToggle[value="1"],
-#DlgMissing > QPushButton,
-#DlgHidden > QPushButton,
-#DlgAutoDJ > QPushButton,
-#DlgRecording > QPushButton,
-#DlgAnalysis > QPushButton,
-#labelRecFilename,
+#LibraryFeatureControls QPushButton,
+QLabel#labelRecFilename, /* needs QLabel to override previous QLabel font definition*/
 WEffectSelector,
 #fadeModeCombobox,
 WOverview #PassthroughLabel {
@@ -82,7 +79,7 @@ WOverview #PassthroughLabel {
 #RecFeedback, #RecDuration,
 #BroadcastButton,
 #SkinSettingsToggle,
-WLibrary QPushButton {
+#LibraryFeatureControls QPushButton {
   text-transform: uppercase;
 }
 /* regular font weight */
@@ -98,8 +95,8 @@ WCoverArtMenu,
 WTrackMenu,
 WTrackMenu QMenu,
 WBeatSpinBox QMenu,
-#labelRecPrefix,
-#labelRecStatistics {
+QLabel#labelRecPrefix,
+QLabel#labelRecStatistics {
   font-weight: normal;
 }
 
@@ -115,7 +112,8 @@ WBeatSpinBox QMenu,
   text-align: center;
 }
 
-WPushButton, WLibrary QPushButton,
+WPushButton,
+#LibraryFeatureControls QPushButton,
 #RecDuration[highlight="0"],
 #RecDuration[highlight="1"] {
   font-size: 11px;
@@ -127,7 +125,7 @@ WPushButton, WLibrary QPushButton,
 #RateText,
 #SamplerBpmMini,
 #PreviewBPM,
-WLibrary QRadioButton {
+#LibraryFeatureControls QRadioButton {
 	font-size: 12px;
 }
 
@@ -137,9 +135,7 @@ WEffectSelector,
 WEffectSelector QAbstractScrollArea,
 #fadeModeCombobox,
 #fadeModeCombobox QAbstractScrollArea,
-#labelRecPrefix,
-#labelRecFilename,
-#labelRecStatistics,
+#LibraryFeatureControls QLabel,
 #SkinSettingsButton,
 #SkinSettingsNumToggle,
 #SkinSettingsMixerToggle,
@@ -698,66 +694,58 @@ WEffectSelector {
 
 /************ Library feature controls / tree view / table view *************/
 /* Extra declaration for QRadioButton otherwise it shows up with wrong colors in Linux with Gnome */
-WLibrary QLabel, WLibrary QRadioButton {
-  background: transparent;
-}
-
-/* Additional space for QRadionButtons */
-WLibrary QRadioButton {
-  /* bottom margin! */
-  margin: 2px 3px 2px 3px;
-}
-
-/* Additional space for QLabels */
-#DlgAnalysis QLabel,
-#DlgAutoDJ QLabel {
-  margin: 2px 5px 5px 1px;
-}
 
 /* Library feature pushbuttons
   Don't use 'WLibrary QPushButton' here, as this would apply padding
   to the Preview & BPM lock buttons as well.
   Define the buttons fore every Library feature instead. */
-#DlgMissing > QPushButton,
-#DlgHidden > QPushButton,
-#DlgAutoDJ > QPushButton,
-#DlgRecording > QPushButton,
-#DlgAnalysis > QPushButton {
+#LibraryFeatureControls QPushButton {
   margin: 0px 2px 3px 0px;
-  padding: 0px;
+  padding: 0px 5px;
   /* Note: border-width is added, so the effective minimal size
     is 24 x 36 px */
   height: 20px;
   min-width: 32px;
   }
-#DlgMissing > QPushButton,
-#DlgHidden > QPushButton,
-#DlgRecording > QPushButton,
-#DlgAnalysis > QPushButton {
-  padding: 0px 5px;
-  }
-  QPushButton#pushButtonAutoDJ {
-    min-width: 40px;
-  }
-  /* Space in between 'Enable AutoDJ' and transition time spinbox */
-  #DlgAutoDJ > #horizontalSpacer {
-    width: 100px;
+  #DlgAutoDJ #LibraryFeatureControls QPushButton {
+    padding: 0px;
+    }
+    QPushButton#pushButtonAutoDJ {
+      min-width: 40px;
+    }
+
+#LibraryFeatureControls QLabel,
+#LibraryFeatureControls QRadioButton {
+  background: transparent;
+}
+
+/* Additional space for QRadionButtons */
+#LibraryFeatureControls QRadioButton {
+  margin: 2px 3px 2px 3px;
   }
   /* Push 'New' radio button away from corner */
-  #radioButtonRecentlyAdded {
-    margin-left: 10px;
+  QRadioButton#radioButtonRecentlyAdded {
+    margin-left: 5px;
   }
   /* Space in between 'All' radio button and 'Select All' button */
-  QPushButton#pushButtonSelectAll {
-    margin-left: 12px;
+  QRadioButton#radioButtonAllSongs {
+    margin-right: 10px;
   }
 
-#labelRecPrefix,
-#labelRecFilename,
-#labelRecStatistics {
+/* Additional space for QLabels */
+QLabel#labelTransitionAppendix {
+  margin-left: 3px;
+}
+QLabel#labelProgress, /* Analysis progress */
+QLabel#labelSelectionInfo /* AutoDJ track selection info */ {
+  margin: 2px 5px 5px 1px;
+}
+QLabel#labelRecPrefix,
+QLabel#labelRecFilename,
+QLabel#labelRecStatistics {
   text-transform: none;
-  padding: 0px 0px 3px 0px;
-  }
+  margin: 3px 0px 3px 0px;
+}
 
 #LibraryContainer QTreeView {
   show-decoration-selected: 0;

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -182,20 +182,17 @@ WRecordingDuration {
 #MicAuxLabel,
 #MicAuxLabelUnconfigured,
 #PreviewTitle,
-#PreviewLabel,
-WBeatSpinBox,
-#spinBoxTransition {
+#PreviewLabel {
   text-align: left;
 }
 
 #RateText,
 #MicAuxLabel,
-#PreviewBPM,
-WBeatSpinBox,
-#spinBoxTransition {
+#PreviewBPM {
   text-align: center;
   }
-  WBeatSpinBox,#spinBoxTransition {
+  WBeatSpinBox,
+  #spinBoxTransition {
     qproperty-alignment: 'AlignHCenter';
   }
 

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -1030,10 +1030,11 @@ WSearchLineEdit,
 #LibraryBPMSpinBox,
 #LibraryBPMButton::item,
 #LibraryContainer QTableView,
+#LibraryContainer QTableView::indicator,
 #LibraryContainer QTextBrowser,
 #LibraryContainer QTreeView,
-WLibrary QLabel, WLibrary QRadioButton,
-WLibrary QTableView::indicator,
+#LibraryFeatureControls QLabel,
+#LibraryFeatureControls QRadioButton,
 QToolTip,
 WBeatSpinBox QMenu,
 #LibraryContainer QMenu,
@@ -1096,7 +1097,8 @@ WTrackMenu QMenu QCheckBox,
 WEffectSelector, WEffectSelector QAbstractScrollArea,
 #fadeModeCombobox, #fadeModeCombobox QAbstractScrollArea,
 WBeatSpinBox, #spinBoxTransition,
-WLibrary QLabel, WLibrary QRadioButton {
+#LibraryFeatureControls QLabel,
+#LibraryFeatureControls QRadioButton {
   color: #888;
 }
 
@@ -1106,11 +1108,7 @@ WLibrary QLabel, WLibrary QRadioButton {
 #FxButtonLabel,
 #FxUnitLabel[highlight="0"],
 #MicAuxLabelUnconfigured,
-#DlgMissing > QPushButton:!enabled,
-#DlgHidden > QPushButton:!enabled,
-#DlgAutoDJ > QPushButton:!enabled,
-#DlgRecording > QPushButton:!enabled,
-#DlgAnalysis > QPushButton:!enabled {
+#LibraryFeatureControls QPushButton:!enabled {
   color: #666;
 }
 
@@ -1138,16 +1136,12 @@ WLibrary QLabel, WLibrary QRadioButton {
 #SkinSettingsToggle[displayValue="1"],
 QPushButton#pushButtonAutoDJ:checked,
 QPushButton#pushButtonRepeatPlaylist:checked,
-#DlgAnalysis > QPushButton:checked,
+QPushButton#pushButtonAnalyze:checked,
 QPushButton#pushButtonRecording:checked {
   color: #000;
 }
 
-#DlgMissing > QPushButton:pressed,
-#DlgHidden > QPushButton:pressed,
-#DlgAutoDJ > QPushButton:pressed,
-#DlgRecording > QPushButton:pressed,
-#DlgAnalysis > QPushButton:pressed {
+#LibraryFeatureControls QPushButton:pressed {
   color: #999;
 }
 
@@ -1197,11 +1191,7 @@ WOverview #PassthroughLabel {
 
 
 /* Library controls in AutoDJ etc. */
-#DlgMissing > QPushButton,
-#DlgHidden > QPushButton,
-#DlgAutoDJ > QPushButton,
-#DlgRecording > QPushButton,
-#DlgAnalysis > QPushButton {
+#LibraryFeatureControls QPushButton {
   color: #bbb;
   }
 
@@ -1238,11 +1228,7 @@ WPushButton#FxAssignButton1[displayValue="0"],
 #RecFeedback[displayValue="0"],
 #BroadcastButton[displayValue="0"],
 #SkinSettingsToggle[displayValue="0"],
-#DlgMissing > QPushButton,
-#DlgHidden > QPushButton,
-#DlgAutoDJ > QPushButton,
-#DlgRecording > QPushButton,
-#DlgAnalysis > QPushButton,
+#LibraryFeatureControls QPushButton,
 WEffectSelector,
 WEffectSelector:on {
   border-width: 2px;
@@ -1258,14 +1244,10 @@ WPushButton#FxAssignButton1[displayValue="1"],
 #BroadcastButton[displayValue="2"],
 #BroadcastButton[displayValue="3"],
 #SkinSettingsToggle[displayValue="1"],
-#DlgMissing > QPushButton:pressed,
-#DlgHidden > QPushButton:pressed,
-#DlgAutoDJ > QPushButton:pressed,
-#DlgRecording > QPushButton:pressed,
-#DlgAnalysis > QPushButton:pressed,
+#LibraryFeatureControls QPushButton:pressed,
 QPushButton#pushButtonAutoDJ:checked,
 QPushButton#pushButtonRepeatPlaylist:checked,
-#DlgAnalysis > QPushButton:checked,
+QPushButton#pushButtonAnalyze:checked,
 QPushButton#pushButtonRecording:checked {
   border-width: 2px;
   border-image: url(skin:/classic/buttons/btn_embedded_library_active.svg) 2 2 2 2;
@@ -1280,11 +1262,7 @@ QPushButton#pushButtonRecording:checked {
     }
 
 /* Library controls in AutoDJ etc. */
-  #DlgMissing > QPushButton:focus,
-  #DlgHidden > QPushButton:focus,
-  #DlgAutoDJ > QPushButton:focus,
-  #DlgRecording > QPushButton:focus,
-  #DlgAnalysis > QPushButton:focus {
+  #LibraryFeatureControls QPushButton:focus {
     outline: none;
   }
 
@@ -1373,11 +1351,7 @@ WPushButton#SyncDeck[value="0"],
 #MicAuxRack WPushButton[displayValue="0"],
 /* library buttons */
 QPushButton#pushButtonAutoDJ:enabled:!checked,
-#DlgMissing > QPushButton:enabled,
-#DlgHidden > QPushButton:enabled,
-#DlgAutoDJ > QPushButton:enabled,
-#DlgRecording > QPushButton:enabled,
-#DlgAnalysis > QPushButton:enabled,
+#LibraryFeatureControls QPushButton:enabled,
 WPushButton#GuiToggleButton[displayValue="0"],
 #RecFeedback[displayValue="0"],
 WPushButton#BroadcastButton[displayValue="0"],
@@ -1462,7 +1436,7 @@ QPushButton#pushButtonRepeatPlaylist:checked {
 #RecFeedback[displayValue="1"],   /* initialize recording */
 #SkinSettingsToggle[displayValue="1"],
 QPushButton#pushButtonAutoDJ:checked,
-#DlgAnalysis > QPushButton:checked {
+QPushButton#pushButtonAnalyze:checked {
   background-color: #d09300;
 }
 

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -76,6 +76,7 @@
 #SidebarCoverSplitter,
 #SidebarCoverSplitter:handle,
 #LibrarySplitter::handle,
+#LibraryFeatureControls,
 QAbstractScrollArea::corner {
   border-top: 1px solid #212123;
   border-right: 1px solid #111;
@@ -134,8 +135,15 @@ QAbstractScrollArea::corner {
         min-height: 3px;
         max-height: 3px;
       }
-#LibraryContainer {
-}
+  /* Controls row in AutoDJ, Recording and other library features */
+  #LibraryFeatureControls {
+    border-width: 1px 0px 0px 0px;
+    border-radius: 0px;
+    margin-top: 1px;
+  }
+
+#LibraryContainer {}
+
   #LibraryContainer QScrollBar::handle:horizontal,
   #LibraryContainer QScrollBar::handle:vertical,
   WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal,
@@ -196,11 +204,10 @@ WSearchLineEdit {
   #DeckSettingsContainer,
   #DeckSettingsContainerCompact,
   #SamplerSettingsContainer,
-  #spinBoxTransition,
   /* Prevent cut-off or shifted stars on macOS */
   WStarRating {
     background-color: #19191a;
-  }
+    }
     #DeckSettingsContainer,
     #DeckSettingsContainerCompact,
     #SamplerSettingsContainer {
@@ -1188,15 +1195,12 @@ WSearchLineEdit, WTime,
 #LibraryBPMSpinBox,
 #LibraryBPMButton::item,
 #LibraryContainer QTableView,
+#LibraryContainer QTableView::indicator,
 #LibraryContainer QTextBrowser,
 #LibraryContainer QTreeView,
-WLibrary QLabel, WLibrary QRadioButton,
-WLibrary QTableView::indicator,
-#DlgMissing > QPushButton,
-#DlgHidden > QPushButton,
-#DlgAutoDJ > QPushButton,
-#DlgRecording > QPushButton,
-#DlgAnalysis > QPushButton,
+#LibraryFeatureControls QLabel,
+#LibraryFeatureControls QPushButton,
+#LibraryFeatureControls QRadioButton,
 /* Tooltip and menus */
 QToolTip,
 WBeatSpinBox QMenu,
@@ -1333,7 +1337,7 @@ WEffectSelector QAbstractScrollArea,
 #RecDuration[highlight="0"],
 #BroadcastButton[displayValue="0"],
 #SkinSettingsToggle[displayValue="0"],
-WLibrary QLabel {
+#LibraryFeatureControls QLabel {
   color: #777;
 }
 
@@ -1371,16 +1375,12 @@ WLibrary QLabel {
 #SkinSettingsToggle[displayValue="1"],
 QPushButton#pushButtonAutoDJ:checked,
 QPushButton#pushButtonRepeatPlaylist:checked,
-#DlgAnalysis > QPushButton:checked,
+QPushButton#pushButtonAnalyze:checked,
 QPushButton#pushButtonRecording:checked {
   color: #000;
 }
 
-#DlgMissing > QPushButton:!enabled,
-#DlgHidden > QPushButton:!enabled,
-#DlgAutoDJ > QPushButton:!enabled,
-#DlgRecording > QPushButton:!enabled,
-#DlgAnalysis > QPushButton:!enabled {
+#LibraryFeatureControls QPushButton:!enabled {
   color: #444443;
 }
 
@@ -1437,14 +1437,9 @@ WOverview #PassthroughLabel {
 WPushButton#VinylButton[displayValue="0"],
 WPushButton#FxAssignButton1[displayValue="0"],
 WEffectSelector,
-#DlgMissing > QPushButton:enabled,
-#DlgHidden > QPushButton:enabled,
-#DlgAutoDJ > QPushButton:enabled,
-#DlgRecording > QPushButton:enabled,
-#DlgAnalysis > QPushButton:enabled,
+#LibraryFeatureControls QPushButton:enabled,
 #fadeModeCombobox,
-#CueDeleteButton,
-#LibraryContainer WBeatSpinBox {
+#CueDeleteButton {
   outline: none;
   border-width: 2px;
   border-image: url(skin:/palemoon/buttons/btn_embedded_library.svg) 2 2 2 2;
@@ -1462,14 +1457,10 @@ WEffectSelector,
   #BroadcastButton[displayValue="2"],
   #BroadcastButton[displayValue="3"],
   #SkinSettingsToggle[displayValue="1"],
-  #DlgMissing > QPushButton:pressed,
-  #DlgHidden > QPushButton:pressed,
-  #DlgAutoDJ > QPushButton:pressed,
-  #DlgRecording > QPushButton:pressed,
-  #DlgAnalysis > QPushButton:pressed
+  #LibraryFeatureControls QPushButton:pressed
   QPushButton#pushButtonAutoDJ:checked,
   QPushButton#pushButtonRepeatPlaylist:checked,
-  #DlgAnalysis > QPushButton:checked,
+  QPushButton#pushButtonAnalyze:checked,
   QPushButton#pushButtonRecording:checked,
   #fadeModeCombobox:on,
   WEffectSelector:on,
@@ -1495,11 +1486,7 @@ WEffectSelector,
     border-image: url(skin:/palemoon/buttons/btn_embedded_library_header_sort.svg) 1 2 1 1; */
   }
 
-  #DlgMissing > QPushButton:!enabled,
-  #DlgHidden > QPushButton:!enabled,
-  #DlgAutoDJ > QPushButton:!enabled,
-  #DlgRecording > QPushButton:!enabled,
-  #DlgAnalysis > QPushButton:!enabled {
+  #LibraryFeatureControls QPushButton:!enabled {
     outline: none;
     border-width: 2px;
     border-image: url(skin:/palemoon/buttons/btn_embedded_library_disabled.svg) 2 2 2 2;
@@ -1629,11 +1616,7 @@ WBeatSpinBox::down-button {
   #spinBoxTransition::up-button,
   #spinBoxTransition::down-button,
   QPushButton#pushButtonAutoDJ:enabled:!checked,
-  #DlgMissing > QPushButton:enabled,
-  #DlgHidden > QPushButton:enabled,
-  #DlgAutoDJ > QPushButton:enabled,
-  #DlgRecording > QPushButton:enabled,
-  #DlgAnalysis > QPushButton:enabled {
+  #LibraryFeatureControls QPushButton:enabled {
     background-color: #222;
   }
   /* dark buttons in toolbar */
@@ -1660,7 +1643,7 @@ WPushButton#Reverse[pressed="true"],
 #VinylButton[displayValue="1"],
 #PassthroughButton[displayValue="1"],
 QPushButton#pushButtonAutoDJ:checked,
-#DlgAnalysis > QPushButton:checked {
+QPushButton#pushButtonAnalyze:checked {
   background-color: #b24c12;
   }
   /* Orange border for Play buttons when previewing from
@@ -2751,54 +2734,22 @@ WLibrary QRadioButton::indicator:unchecked {
   Don't use 'WLibrary QPushButton' here, as this would apply padding
   to the Preview & BPM lock buttons as well.
   Define the buttons fore every Library feature instead. */
-#DlgMissing > QPushButton,
-#DlgHidden > QPushButton,
-#DlgAutoDJ > QPushButton,
-#DlgRecording > QPushButton,
-#DlgAnalysis > QPushButton {
+#LibraryFeatureControls QPushButton {
   margin: 0px 6px 3px 0px;
-  padding: 0px;
-  height: 20px;
   }
 /* add margin to compensate for frameless library table */
-#DlgMissing > QPushButton,
-#DlgHidden > QPushButton,
-#DlgAutoDJ > QPushButton,
-#DlgRecording > QPushButton,
-#DlgAnalysis > QPushButton,
+#LibraryFeatureControls QPushButton,
 #fadeModeCombobox,
 #spinBoxTransition {
   margin-top: 4px;
   }
-  WLibrary QRadioButton {
+  #LibraryFeatureControls QRadioButton {
     /* bottom margin! */
     margin: 6px 3px 4px 3px;
   }
-  #DlgAnalysis QLabel,
-  #DlgAutoDJ QLabel {
-    margin: 6px 5px 5px 1px;
-  }
-
-#DlgMissing > QPushButton,
-#DlgHidden > QPushButton,
-#DlgRecording > QPushButton,
-#DlgAnalysis > QPushButton {
-  padding: 0px 5px;
-  }
-  QPushButton#pushButtonAutoDJ {
-    min-width: 40px;
-  }
-  /* Space in between 'Enable AutoDJ' and transition time spinbox */
-  #DlgAutoDJ > #horizontalSpacer {
-    width: 100px;
-  }
-  /* Push 'New' radio button away from corner */
-  #radioButtonRecentlyAdded {
-    margin-left: 10px;
-  }
-  /* Space in between 'All' radio button and 'Select All' button */
-  QPushButton#pushButtonSelectAll {
-    margin-left: 12px;
+  QLabel#labelProgress, /* Analysis progress */
+  QLabel#labelSelectionInfo /* AutoDJ track selection info */ {
+    margin: 4px 5px 5px 1px;
   }
 
 #LibraryContainer QTreeView {
@@ -2869,7 +2820,8 @@ WTrackMenu QMenu {
 #LibraryContainer QTextBrowser,
 #LibraryContainer QTreeView,
 #SkinSettings,
-WSearchLineEdit {
+WSearchLineEdit,
+#spinBoxTransition {
   background-color: #0f0f0f;
 }
 

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -90,7 +90,7 @@ QAbstractScrollArea::corner {
     border-radius: 0px;
   }
 
-  #SidebarSearchPreviewContainer {
+  #LibSidebarContainer {
     margin-top: 1px;
   }
   #SidebarBox {

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -826,11 +826,7 @@ WLibrary QRadioButton::indicator:unchecked {
   image: url(skin:/btn/btn_lib_radio_button_off.svg) center center;
 }
 
-#DlgMissing > QPushButton,
-#DlgHidden > QPushButton,
-#DlgAutoDJ > QPushButton,
-#DlgRecording > QPushButton,
-#DlgAnalysis > QPushButton {
+#LibraryFeatureControls QPushButton {
   text-align: center;
   font-size: 9pt;
   font-weight: normal;
@@ -848,7 +844,7 @@ WLibrary QRadioButton::indicator:unchecked {
   background-color: #99a0a4;
   border: 1px solid #99a0a4;
   }
-  #DlgAutoDJ > QPushButton {
+  #DlgAutoDJ > #LibraryFeatureControls QPushButton {
     padding: 0px;
     width: 32px;
     height: 18px;
@@ -857,37 +853,20 @@ WLibrary QRadioButton::indicator:unchecked {
       width: 40px;
     }
 
-  #DlgMissing > QPushButton:!enabled,
-  #DlgHidden > QPushButton:!enabled,
-  #DlgAutoDJ > QPushButton:!enabled,
-  #DlgRecording > QPushButton:!enabled,
-  #DlgAnalysis > QPushButton:!enabled {
+  #LibraryFeatureControls QPushButton:!enabled {
     background-color: #72777A;
     border: 1px solid #72777A;
     }
-  #DlgMissing > QPushButton:unchecked,
-  #DlgHidden > QPushButton:unchecked,
-  #DlgAutoDJ > QPushButton:unchecked,
-  #DlgRecording > QPushButton:unchecked,
-  #DlgAnalysis > QPushButton:unchecked {
+  #LibraryFeatureControls QPushButton:unchecked {
     color: #888;
     background-color: #444;
     }
-  #DlgMissing > QPushButton:checked,
-  #DlgHidden > QPushButton:checked,
-  #DlgAutoDJ > QPushButton:checked,
-  #DlgRecording > QPushButton:checked,
-  #DlgAnalysis > QPushButton:checked {
+  #LibraryFeatureControls QPushButton:checked {
     color: #000;
     background-color: #F90562;
     border: 1px solid #F90562;
     }
-  #DlgAnalysis > QPushButton:focus,
-  #DlgMissing > QPushButton:focus,
-  #DlgHidden > QPushButton:focus,
-  #DlgAutoDJ > QPushButton:focus,
-  #DlgRecording > QPushButton:focus,
-  #DlgAnalysis > QPushButton:focus {
+  #LibraryFeatureControls QPushButton:focus {
     outline: none;
   }
   /* Space in between 'Recording'	button and recording label */

--- a/res/skins/Shade/style_dark.qss
+++ b/res/skins/Shade/style_dark.qss
@@ -224,27 +224,15 @@ WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal,
   #LibraryContainer QHeaderView::down-arrow {
     image: url(skin:/btn/btn_lib_sort_down_green.png)
   }
-#DlgMissing > QPushButton:enabled,
-#DlgHidden > QPushButton:enabled,
-#DlgAutoDJ > QPushButton:enabled,
-#DlgRecording > QPushButton:enabled,
-#DlgAnalysis > QPushButton:enabled {
+#LibraryFeatureControls QPushButton:enabled {
   background-color: #5C5B5D;
   border: 1px solid #5C5B5D;
   }
-  #DlgMissing > QPushButton:!enabled,
-  #DlgHidden > QPushButton:!enabled,
-  #DlgAutoDJ > QPushButton:!enabled,
-  #DlgRecording > QPushButton:!enabled,
-  #DlgAnalysis > QPushButton:!enabled {
+  #LibraryFeatureControls QPushButton:!enabled {
     background-color: #3D3E3F;
     border: 1px solid #3D3E3F;
   }
-  #DlgMissing > QPushButton:checked,
-  #DlgHidden > QPushButton:checked,
-  #DlgAutoDJ > QPushButton:checked,
-  #DlgRecording > QPushButton:checked,
-  #DlgAnalysis > QPushButton:checked {
+  #LibraryFeatureControls QPushButton:checked {
     color: #000;
     background-color: #B79E00;
     border: 1px solid #B79E00;

--- a/res/skins/Shade/style_summer_sunset.qss
+++ b/res/skins/Shade/style_summer_sunset.qss
@@ -119,31 +119,19 @@ WOverview #PassthroughLabel {
   color: #FF9900;
 }
 
-#DlgMissing > QPushButton:enabled,
-#DlgHidden > QPushButton:enabled,
-#DlgAutoDJ > QPushButton:enabled,
-#DlgRecording > QPushButton:enabled,
-#DlgAnalysis > QPushButton:enabled {
+#LibraryFeatureControls QPushButton:enabled {
   background-color: #998A3C;
   border: 1px solid #998A3C;
   }
-  #DlgMissing > QPushButton:!enabled,
-  #DlgHidden > QPushButton:!enabled,
-  #DlgAutoDJ > QPushButton:!enabled,
-  #DlgRecording > QPushButton:!enabled,
-  #DlgAnalysis > QPushButton:!enabled {
+  #LibraryFeatureControls QPushButton:!enabled {
     background-color: #706633;
     border: 1px solid #706633;
     }
-  WLibrary QPushButton:unchecked {
+  #LibraryFeatureControls QPushButton:unchecked {
     color: #888;
     background-color: #444;
     }
-  #DlgMissing > QPushButton:checked,
-  #DlgHidden > QPushButton:checked,
-  #DlgAutoDJ > QPushButton:checked,
-  #DlgRecording > QPushButton:checked,
-  #DlgAnalysis > QPushButton:checked {
+  #LibraryFeatureControls QPushButton:checked {
     color: #000;
     background-color: #52F904;
     border: 1px solid #52F904;

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -1079,7 +1079,7 @@ WLabel#TrackComment {
     }
 
 WBeatSpinBox,
-#DlgAutoDJ QSpinBox {
+#spinBoxTransition {
   /* Note(ronso0):
   make it 2px smaller in each dimension,
   border is added for final size.
@@ -1103,26 +1103,26 @@ WBeatSpinBox,
     padding: 1px 0px 1px 3px;
     margin: 0px 15px 0px 0px;
   }
-  #DlgAutoDJ QSpinBox {
+  #spinBoxTransition {
     /* Note(ronso0):
     Individual padding/margin in AutoDJ feature */
     padding: -1px 3px -1px 3px;
     margin: 0px 17px 3px 3px;
   }
   WBeatSpinBox:hover,
-  #DlgAutoDJ QSpinBox:hover {
+  #spinBoxTransition:hover {
     border-color: #888;
   }
   WBeatSpinBox:focus,
-  #DlgAutoDJ QSpinBox:focus {
+  #spinBoxTransition:focus {
     border-color: #ff6600;
     color: #ccc;
   }
 
   WBeatSpinBox::up-button,
   WBeatSpinBox::down-button,
-  #DlgAutoDJ QSpinBox::up-button,
-  #DlgAutoDJ QSpinBox::down-button {
+  #spinBoxTransition::up-button,
+  #spinBoxTransition::down-button {
     subcontrol-origin: padding;
     position: relative;
     background-color: #1e1e1e;
@@ -1135,13 +1135,13 @@ WBeatSpinBox,
     }
     WBeatSpinBox::up-button:hover,
     WBeatSpinBox::down-button:hover,
-    #DlgAutoDJ QSpinBox::up-button:hover,
-    #DlgAutoDJ QSpinBox::down-button:hover {
+    #spinBoxTransition::up-button:hover,
+    #spinBoxTransition::down-button:hover {
       background-color: #0f0f0f;
       }
 
   WBeatSpinBox::up-button,
-  #DlgAutoDJ QSpinBox::up-button {
+  #spinBoxTransition::up-button {
     subcontrol-position: center right;
     /* Note(ronso0):
     Regularly, up/down buttons would be stacked vertically.
@@ -1152,18 +1152,18 @@ WBeatSpinBox,
     image: url(skin:/buttons/btn_beatbox_up.svg) no-repeat;
     }
     WBeatSpinBox::up-button:hover,
-    #DlgAutoDJ QSpinBox::up-button:hover {
+    #spinBoxTransition::up-button:hover {
       image: url(skin:/buttons/btn_beatbox_up_hover.svg) no-repeat;
     }
   WBeatSpinBox::down-button,
-  #DlgAutoDJ QSpinBox::down-button {
+  #spinBoxTransition::down-button {
     subcontrol-position: center right;
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
     image: url(skin:/buttons/btn_beatbox_down.svg) no-repeat;
     }
     WBeatSpinBox::down-button:hover,
-    #DlgAutoDJ QSpinBox::down-button:hover {
+    #spinBoxTransition::down-button:hover {
       image: url(skin:/buttons/btn_beatbox_down_hover.svg) no-repeat;
     }
 
@@ -2692,7 +2692,7 @@ Library features and their buttons:
     QPushButton#pushButtonRecording > un/checked
 
   	*/
-WLibrary QPushButton {
+#LibraryFeatureControls QPushButton {
   text-align: center;
   font-weight: normal;
   /* Note(ronso0)
@@ -2710,7 +2710,7 @@ WLibrary QPushButton {
   background-color: #333;
   background-position: center;
   }
-  #DlgAutoDJ > QPushButton {
+  #DlgAutoDJ > #LibraryFeatureControls QPushButton {
     padding: 1px 2px;
     height: 20px;
     min-width: 32px;
@@ -2719,22 +2719,22 @@ WLibrary QPushButton {
     width: 42px;
   }
 
-  WLibrary QPushButton:!enabled {
+  #LibraryFeatureControls QPushButton:!enabled {
     color: #888;
     }
-  WLibrary QPushButton:hover,
+  #LibraryFeatureControls QPushButton:hover,
   #fadeModeCombobox:hover {
     border: 1px solid #888;
     }
-  WLibrary QPushButton:unchecked {
+  #LibraryFeatureControls QPushButton:unchecked {
     color: #888;
     background-color: #444;
     }
-  WLibrary QPushButton:checked {
+  #LibraryFeatureControls QPushButton:checked {
     color: #000;
     background-color: #ff7b00;
     }
-  WLibrary QPushButton:checked:hover {
+  #LibraryFeatureControls QPushButton:checked:hover {
     border: 1px solid #fff;
     }
   QPushButton#pushButtonRecording:unchecked {
@@ -2825,12 +2825,12 @@ QPushButton#pushButtonRepeatPlaylist:!checked {
   }
 
   /* Recording info */
-  #labelRecFilename {
+  QLabel#labelRecFilename {
     font-weight: bold;
     margin: 0px 1px;
   }
-  #labelRecPrefix,
-  #labelRecStatistics {
+  QLabel#labelRecPrefix,
+  QLabel#labelRecStatistics {
     font-weight: normal;
   }
 
@@ -2951,13 +2951,13 @@ WLibrary QRadioButton {	/*
   color: #cfcfcf;
 }
 
-WLibrary QRadioButton#radioButtonRecentlyAdded,
-WLibrary QRadioButton#radioButtonAllSongs {
+QRadioButton#radioButtonRecentlyAdded,
+QRadioButton#radioButtonAllSongs {
   padding: 1px 3px 3px 1px;
   color: #cfcfcf;
 }
 
-WLibrary QRadioButton#radioButtonRecentlyAdded {
+QRadioButton#radioButtonRecentlyAdded {
   margin: 0px 3px 0px 5px;
 }
 

--- a/src/library/autodj/dlgautodj.ui
+++ b/src/library/autodj/dlgautodj.ui
@@ -30,195 +30,197 @@
     <number>0</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <property name="leftMargin">
-      <number>0</number>
-     </property>
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <property name="rightMargin">
-      <number>0</number>
-     </property>
-     <property name="bottomMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QPushButton" name="pushButtonAutoDJ">
-       <property name="focusPolicy">
-        <enum>Qt::NoFocus</enum>
+    <widget class="QWidget" name="LibraryFeatureControls">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <property name="spacing">
+        <number>0</number>
        </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
+       <property name="leftMargin">
+        <number>0</number>
        </property>
-       <property name="checkable">
-        <bool>true</bool>
+       <property name="topMargin">
+        <number>0</number>
        </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+       <property name="rightMargin">
+        <number>0</number>
        </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
+       <property name="bottomMargin">
+        <number>0</number>
        </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>10</width>
-         <height>1</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonFadeNow">
-       <property name="focusPolicy">
-        <enum>Qt::NoFocus</enum>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonSkipNext">
-       <property name="focusPolicy">
-        <enum>Qt::NoFocus</enum>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="checkable">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="fadeModeCombobox">
-      </widget>
-     </item>
-     <item>
-      <widget class="QSpinBox" name="spinBoxTransition">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="frame">
-        <bool>false</bool>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="minimum">
-        <number>-9</number>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="labelTransitionAppendix">
-       <property name="text">
-        <string>sec.</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>10</width>
-         <height>1</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonShuffle">
-       <property name="focusPolicy">
-        <enum>Qt::NoFocus</enum>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="checkable">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonAddRandom">
-       <property name="focusPolicy">
-        <enum>Qt::NoFocus</enum>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonRepeatPlaylist">
-       <property name="focusPolicy">
-        <enum>Qt::NoFocus</enum>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>1</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QLabel" name="labelSelectionInfo">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
+       <item>
+        <widget class="QPushButton" name="pushButtonAutoDJ">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_1">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>10</width>
+           <height>1</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushButtonFadeNow">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushButtonSkipNext">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="checkable">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="fadeModeCombobox">
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="spinBoxTransition">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="frame">
+          <bool>false</bool>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+         <property name="minimum">
+          <number>-9</number>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelTransitionAppendix">
+         <property name="text">
+          <string>sec.</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>10</width>
+           <height>1</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushButtonShuffle">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="checkable">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushButtonAddRandom">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushButtonRepeatPlaylist">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>1</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelSelectionInfo">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+      </layout>
+    </widget>
    </item>
    <item>
     <widget class="QTableView" name="m_pTrackTablePlaceholder">

--- a/src/library/dlganalysis.ui
+++ b/src/library/dlganalysis.ui
@@ -30,98 +30,100 @@
     <number>0</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <property name="leftMargin">
-      <number>0</number>
-     </property>
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <property name="rightMargin">
-      <number>0</number>
-     </property>
-     <property name="bottomMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QRadioButton" name="radioButtonRecentlyAdded">
-       <property name="focusPolicy">
-        <enum>Qt::NoFocus</enum>
+    <widget class="QWidget" name="LibraryFeatureControls">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <property name="spacing">
+        <number>0</number>
        </property>
-       <property name="toolTip">
-        <string>Shows tracks added to the library within the last 7 days.</string>
+       <property name="leftMargin">
+        <number>0</number>
        </property>
-       <property name="text">
-        <string>New</string>
+       <property name="topMargin">
+        <number>0</number>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QRadioButton" name="radioButtonAllSongs">
-       <property name="focusPolicy">
-        <enum>Qt::NoFocus</enum>
+       <property name="rightMargin">
+        <number>0</number>
        </property>
-       <property name="toolTip">
-        <string>Shows all tracks in the library.</string>
+       <property name="bottomMargin">
+        <number>0</number>
        </property>
-       <property name="text">
-        <string>All</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonSelectAll">
-       <property name="focusPolicy">
-        <enum>Qt::NoFocus</enum>
-       </property>
-       <property name="toolTip">
-        <string>Selects all tracks in the table below.</string>
-       </property>
-       <property name="text">
-        <string>Select All</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonAnalyze">
-       <property name="focusPolicy">
-        <enum>Qt::NoFocus</enum>
-       </property>
-       <property name="toolTip">
-        <string>Runs beatgrid, key, and ReplayGain detection on the selected tracks. Does not generate waveforms for the selected tracks to save disk space.</string>
-       </property>
-       <property name="text">
-        <string>Analyze</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="labelProgress">
-       <property name="text">
-        <string>Progress</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
+       <item>
+        <widget class="QRadioButton" name="radioButtonRecentlyAdded">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="toolTip">
+          <string>Shows tracks added to the library within the last 7 days.</string>
+         </property>
+         <property name="text">
+          <string>New</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="radioButtonAllSongs">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="toolTip">
+          <string>Shows all tracks in the library.</string>
+         </property>
+         <property name="text">
+          <string>All</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushButtonSelectAll">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="toolTip">
+          <string>Selects all tracks in the table below.</string>
+         </property>
+         <property name="text">
+          <string>Select All</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushButtonAnalyze">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="toolTip">
+          <string>Runs beatgrid, key, and ReplayGain detection on the selected tracks. Does not generate waveforms for the selected tracks to save disk space.</string>
+         </property>
+         <property name="text">
+          <string>Analyze</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelProgress">
+         <property name="text">
+          <string>Progress</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+    </widget>
    </item>
    <item>
     <widget class="QTableView" name="m_pTrackTablePlaceholder">

--- a/src/library/dlghidden.ui
+++ b/src/library/dlghidden.ui
@@ -30,84 +30,86 @@
     <number>0</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <property name="leftMargin">
-      <number>0</number>
-     </property>
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <property name="rightMargin">
-      <number>0</number>
-     </property>
-     <property name="bottomMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QPushButton" name="btnSelect">
-       <property name="focusPolicy">
-        <enum>Qt::NoFocus</enum>
+    <widget class="QWidget" name="LibraryFeatureControls">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <property name="spacing">
+        <number>0</number>
        </property>
-       <property name="toolTip">
-        <string>Selects all tracks in the table below.</string>
+       <property name="leftMargin">
+        <number>0</number>
        </property>
-       <property name="text">
-        <string>Select All</string>
+       <property name="topMargin">
+        <number>0</number>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btnPurge">
-       <property name="focusPolicy">
-        <enum>Qt::NoFocus</enum>
+       <property name="rightMargin">
+        <number>0</number>
        </property>
-       <property name="toolTip">
-        <string>Purge selected tracks from the library.</string>
+       <property name="bottomMargin">
+        <number>0</number>
        </property>
-       <property name="text">
-        <string>Purge</string>
-       </property>
-       <property name="checkable">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btnUnhide">
-       <property name="focusPolicy">
-        <enum>Qt::NoFocus</enum>
-       </property>
-       <property name="toolTip">
-        <string>Unhide selected tracks from the library.</string>
-       </property>
-       <property name="text">
-        <string>Unhide</string>
-       </property>
-       <property name="shortcut">
-        <string>Ctrl+S</string>
-       </property>
-       <property name="checkable">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
+       <item>
+        <widget class="QPushButton" name="btnSelect">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="toolTip">
+          <string>Selects all tracks in the table below.</string>
+         </property>
+         <property name="text">
+          <string>Select All</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="btnPurge">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="toolTip">
+          <string>Purge selected tracks from the library.</string>
+         </property>
+         <property name="text">
+          <string>Purge</string>
+         </property>
+         <property name="checkable">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="btnUnhide">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="toolTip">
+          <string>Unhide selected tracks from the library.</string>
+         </property>
+         <property name="text">
+          <string>Unhide</string>
+         </property>
+         <property name="shortcut">
+          <string>Ctrl+S</string>
+         </property>
+         <property name="checkable">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+    </widget>
    </item>
    <item>
     <widget class="QTableView" name="m_pTrackTablePlaceholder">

--- a/src/library/dlgmissing.ui
+++ b/src/library/dlgmissing.ui
@@ -30,65 +30,67 @@
     <number>0</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <property name="leftMargin">
-      <number>0</number>
-     </property>
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <property name="rightMargin">
-      <number>0</number>
-     </property>
-     <property name="bottomMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QPushButton" name="btnSelect">
-       <property name="focusPolicy">
-        <enum>Qt::NoFocus</enum>
+    <widget class="QWidget" name="LibraryFeatureControls">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <property name="spacing">
+        <number>0</number>
        </property>
-       <property name="toolTip">
-        <string>Selects all tracks in the table below.</string>
+       <property name="leftMargin">
+        <number>0</number>
        </property>
-       <property name="text">
-        <string>Select All</string>
+       <property name="topMargin">
+        <number>0</number>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btnPurge">
-       <property name="focusPolicy">
-        <enum>Qt::NoFocus</enum>
+       <property name="rightMargin">
+        <number>0</number>
        </property>
-       <property name="toolTip">
-        <string>Purge selected tracks from the library.</string>
+       <property name="bottomMargin">
+        <number>0</number>
        </property>
-       <property name="text">
-        <string>Purge</string>
-       </property>
-       <property name="checkable">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
+       <item>
+        <widget class="QPushButton" name="btnSelect">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="toolTip">
+          <string>Selects all tracks in the table below.</string>
+         </property>
+         <property name="text">
+          <string>Select All</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="btnPurge">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="toolTip">
+          <string>Purge selected tracks from the library.</string>
+         </property>
+         <property name="text">
+          <string>Purge</string>
+         </property>
+         <property name="checkable">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+    </widget>
    </item>
    <item>
     <widget class="QTableView" name="m_pTrackTablePlaceholder">

--- a/src/library/recording/dlgrecording.ui
+++ b/src/library/recording/dlgrecording.ui
@@ -30,58 +30,60 @@
     <number>0</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <property name="leftMargin">
-      <number>0</number>
-     </property>
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <property name="rightMargin">
-      <number>0</number>
-     </property>
-     <property name="bottomMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QPushButton" name="pushButtonRecording">
-       <property name="focusPolicy">
-        <enum>Qt::NoFocus</enum>
+    <widget class="QWidget" name="LibraryFeatureControls">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <property name="spacing">
+        <number>0</number>
        </property>
-       <property name="text">
-        <string>Start Recording</string>
+       <property name="leftMargin">
+        <number>0</number>
        </property>
-       <property name="checkable">
-        <bool>true</bool>
+       <property name="topMargin">
+        <number>0</number>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="labelRecPrefix"/>
-     </item>
-     <item>
-      <widget class="QLabel" name="labelRecFilename"/>
-     </item>
-     <item>
-      <widget class="QLabel" name="labelRecStatistics"/>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+       <property name="rightMargin">
+        <number>0</number>
        </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
+       <property name="bottomMargin">
+        <number>0</number>
        </property>
-      </spacer>
-     </item>
-    </layout>
+       <item>
+        <widget class="QPushButton" name="pushButtonRecording">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="text">
+          <string>Start Recording</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelRecPrefix"/>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelRecFilename"/>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelRecStatistics"/>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+    </widget>
    </item>
    <item>
     <widget class="QTableView" name="m_pTrackTablePlaceholder">


### PR DESCRIPTION
Fixes a regression from #3522 where lib feature controls don't have a background in LateNight PaleMoon.
Doesn't affect other skins except less qss lines :)

Finally allows styling the controls rows (WLibrary) independently from WTrackTableView without qss hacks.
= have a 'frameless' yet embedded tracks table
![image](https://user-images.githubusercontent.com/5934199/107718521-6815ea80-6cd6-11eb-85f0-79239a1ae57e.png)
AND styled borders for feature controls like in AutoDJ feature
![image](https://user-images.githubusercontent.com/5934199/107719008-7b758580-6cd7-11eb-9edb-bd07404ae21a.png)

