### PR TITLE
Abort update of track metadata after unsuccessful metadata import

### DIFF
--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -650,12 +650,20 @@ void SoundSourceProxy::updateTrackFromSource(
                 << "from file name:"
                 << trackFile;
         if (trackMetadata.refTrackInfo().parseArtistTitleFromFileName(
-                    trackFile.fileName(), splitArtistTitle) &&
-                metadataImported.second.isNull()) {
-            // Since this is also some kind of metadata import, we mark the
-            // track's metadata as synchronized with the time stamp of the file.
-            metadataImported.second = trackFile.fileLastModified();
+                    trackFile.fileName(), splitArtistTitle)) {
+            // Pretend that metadata import succeeded
+            metadataImported.first = mixxx::MetadataSource::ImportResult::Succeeded;
+            if (metadataImported.second.isNull()) {
+                // Since this is also some kind of metadata import, we mark the
+                // track's metadata as synchronized with the time stamp of the file.
+                metadataImported.second = trackFile.fileLastModified();
+            }
         }
+    }
+
+    // Do not continue with unknown and maybe invalid metadata!
+    if (metadataImported.first != mixxx::MetadataSource::ImportResult::Succeeded) {
+        return;
     }
 
     m_pTrack->importMetadata(trackMetadata, metadataImported.second);


### PR DESCRIPTION
Continuing with updating the track metadata even after metadata import failed was a bad idea. It may have unintended side-effects if this happens for deleted tracks where the file is no longer available.

Generating artificial artist/title metadata already adds a lot of unneeded complexity. This code was already a nightmare with a lot of special case handling before and now it has become even worse. 

Please don't make me explain in detail why this is a problem. I won't. Continuing with invalid data just for the sake of this naive file name parser is just wrong. This PR simply adds an escape hatch before it is too late.