### PR TITLE
Tooltips and CVS Export: Use BPM precision of four integer digits 

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -638,7 +638,11 @@ QVariant BaseTrackTableModel::roleValue(
                 }
             }
             if (bpm.hasValue()) {
-                return QString("%1").arg(bpm.getValue(), 0, 'f', 1);
+                if (role == Qt::ToolTipRole) {
+                    return QString::number(bpm.getValue(), 'f', 4);
+                } else {
+                    return QString::number(bpm.getValue(), 'f', 1);
+                }
             } else {
                 return QChar('-');
             }

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -548,8 +548,20 @@ QVariant BaseTrackTableModel::roleValue(
     }
     switch (role) {
     case Qt::ToolTipRole:
-    case Qt::DisplayRole:
     case kDataExportRole:
+        switch (field) {
+        case ColumnCache::COLUMN_LIBRARYTABLE_COLOR:
+            return mixxx::RgbColor::toQString(mixxx::RgbColor::fromQVariant(rawValue));
+        case ColumnCache::COLUMN_LIBRARYTABLE_COVERART:
+            return composeCoverArtToolTipHtml(index);
+        case ColumnCache::COLUMN_LIBRARYTABLE_PREVIEW:
+            return QVariant();
+        default:
+            // Same value as for Qt::DisplayRole (see below)
+            break;
+        }
+        M_FALLTHROUGH_INTENDED;
+    case Qt::DisplayRole:
         switch (field) {
         case ColumnCache::COLUMN_LIBRARYTABLE_DURATION: {
             if (rawValue.isNull()) {
@@ -734,24 +746,6 @@ QVariant BaseTrackTableModel::roleValue(
         case ColumnCache::COLUMN_LIBRARYTABLE_URL:
             // Not yet supported
             DEBUG_ASSERT(rawValue.isNull());
-            break;
-        case ColumnCache::COLUMN_LIBRARYTABLE_COLOR:
-            if (role == Qt::ToolTipRole || role == kDataExportRole) {
-                return mixxx::RgbColor::toQString(mixxx::RgbColor::fromQVariant(rawValue));
-            }
-            // Otherwise, just use the column value
-            break;
-        case ColumnCache::COLUMN_LIBRARYTABLE_COVERART:
-            if (role == Qt::ToolTipRole || role == kDataExportRole) {
-                return composeCoverArtToolTipHtml(index);
-            }
-            // Otherwise, just use the column value
-            break;
-        case ColumnCache::COLUMN_LIBRARYTABLE_PREVIEW:
-            if (role == Qt::ToolTipRole || role == kDataExportRole) {
-                return QVariant();
-            }
-            // Otherwise, just use the column value
             break;
         default:
             // Otherwise, just use the column value

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -422,7 +422,8 @@ QVariant BaseTrackTableModel::data(
     if (role != Qt::DisplayRole &&
             role != Qt::EditRole &&
             role != Qt::CheckStateRole &&
-            role != Qt::ToolTipRole) {
+            role != Qt::ToolTipRole &&
+            role != kDataExportRole) {
         return QVariant();
     }
 
@@ -547,19 +548,8 @@ QVariant BaseTrackTableModel::roleValue(
     }
     switch (role) {
     case Qt::ToolTipRole:
-        switch (field) {
-        case ColumnCache::COLUMN_LIBRARYTABLE_COLOR:
-            return mixxx::RgbColor::toQString(mixxx::RgbColor::fromQVariant(rawValue));
-        case ColumnCache::COLUMN_LIBRARYTABLE_COVERART:
-            return composeCoverArtToolTipHtml(index);
-        case ColumnCache::COLUMN_LIBRARYTABLE_PREVIEW:
-            return QVariant();
-        default:
-            // Same value as for Qt::DisplayRole (see below)
-            break;
-        }
-        M_FALLTHROUGH_INTENDED;
     case Qt::DisplayRole:
+    case kDataExportRole:
         switch (field) {
         case ColumnCache::COLUMN_LIBRARYTABLE_DURATION: {
             if (rawValue.isNull()) {
@@ -638,7 +628,7 @@ QVariant BaseTrackTableModel::roleValue(
                 }
             }
             if (bpm.hasValue()) {
-                if (role == Qt::ToolTipRole) {
+                if (role == Qt::ToolTipRole || role == kDataExportRole) {
                     return QString::number(bpm.getValue(), 'f', 4);
                 } else {
                     return QString::number(bpm.getValue(), 'f', 1);
@@ -744,6 +734,24 @@ QVariant BaseTrackTableModel::roleValue(
         case ColumnCache::COLUMN_LIBRARYTABLE_URL:
             // Not yet supported
             DEBUG_ASSERT(rawValue.isNull());
+            break;
+        case ColumnCache::COLUMN_LIBRARYTABLE_COLOR:
+            if (role == Qt::ToolTipRole || role == kDataExportRole) {
+                return mixxx::RgbColor::toQString(mixxx::RgbColor::fromQVariant(rawValue));
+            }
+            // Otherwise, just use the column value
+            break;
+        case ColumnCache::COLUMN_LIBRARYTABLE_COVERART:
+            if (role == Qt::ToolTipRole || role == kDataExportRole) {
+                return composeCoverArtToolTipHtml(index);
+            }
+            // Otherwise, just use the column value
+            break;
+        case ColumnCache::COLUMN_LIBRARYTABLE_PREVIEW:
+            if (role == Qt::ToolTipRole || role == kDataExportRole) {
+                return QVariant();
+            }
+            // Otherwise, just use the column value
             break;
         default:
             // Otherwise, just use the column value

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -16,9 +16,6 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     DISALLOW_COPY_AND_ASSIGN(BaseTrackTableModel);
 
   public:
-    // This role is used for data export like in CSV files
-    static constexpr int kDataExportRole = Qt::UserRole + 1;
-
     explicit BaseTrackTableModel(
             const char* settingsNamespace,
             TrackCollectionManager* const pTrackCollectionManager,

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -205,9 +205,7 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
             const QModelIndex& index,
             ColumnCache::Column siblingField) const;
 
-    // Reimplement in derived classes to handle columns other
-    // then COLUMN_LIBRARYTABLE
-    virtual QVariant roleValue(
+    QVariant roleValue(
             const QModelIndex& index,
             QVariant&& rawValue,
             int role) const;

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -16,6 +16,9 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     DISALLOW_COPY_AND_ASSIGN(BaseTrackTableModel);
 
   public:
+    // This role is used for data export like in CSV files
+    static constexpr int kDataExportRole = Qt::UserRole + 1;
+
     explicit BaseTrackTableModel(
             const char* settingsNamespace,
             TrackCollectionManager* const pTrackCollectionManager,

--- a/src/library/parsercsv.cpp
+++ b/src/library/parsercsv.cpp
@@ -181,21 +181,21 @@ bool ParserCsv::writeCSVFile(const QString &file_str, BaseSqlTableModel* pPlayli
             }
             out << "\"";
             QString field;
-            if (i == pPlaylistTableModel->fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM)) {
-                // Use ToolTip Role for full precision.
-                field = pPlaylistTableModel
-                                ->data(pPlaylistTableModel->index(j, i),
-                                        Qt::ToolTipRole)
-                                .toString();
-            } else if (i ==
+            if (i ==
                     pPlaylistTableModel->fieldIndex(
                             ColumnCache::COLUMN_TRACKLOCATIONSTABLE_LOCATION)) {
-                field = pPlaylistTableModel->data(pPlaylistTableModel->index(j, i)).toString();
+                field = pPlaylistTableModel
+                                ->data(pPlaylistTableModel->index(j, i),
+                                        BaseTrackTableModel::kDataExportRole)
+                                .toString();
                 if (useRelativePath) {
                     field = base_dir.relativeFilePath(field);
                 }
             } else {
-                field = pPlaylistTableModel->data(pPlaylistTableModel->index(j, i)).toString();
+                field = pPlaylistTableModel
+                                ->data(pPlaylistTableModel->index(j, i),
+                                        BaseTrackTableModel::kDataExportRole)
+                                .toString();
             }
             out << field.replace('\"', "\"\"");  // escape "
             out << "\"";
@@ -232,14 +232,21 @@ bool ParserCsv::writeReadableTextFile(const QString &file_str, BaseSqlTableModel
         // writing fields section
         i = pPlaylistTableModel->fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_POSITION);
         if (i >= 0) {
-            int nr = pPlaylistTableModel->data(pPlaylistTableModel->index(j,i)).toInt();
+            int nr = pPlaylistTableModel
+                             ->data(pPlaylistTableModel->index(j, i),
+                                     BaseSqlTableModel::kDataExportRole)
+                             .toInt();
             out << QString("%1.").arg(nr,2,10,QLatin1Char('0'));
         }
 
         if (writeTimestamp) {
             i = pPlaylistTableModel->fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_DATETIMEADDED);
             if (i >= 0) {
-                QTime time = pPlaylistTableModel->data(pPlaylistTableModel->index(j,i)).toTime();
+                QTime time =
+                        pPlaylistTableModel
+                                ->data(pPlaylistTableModel->index(j, i),
+                                        BaseTrackTableModel::kDataExportRole)
+                                .toTime();
                 if (j == 0) {
                     msecsFromStartToMidnight = time.msecsTo(QTime(0,0,0,0));
                 }
@@ -252,7 +259,10 @@ bool ParserCsv::writeReadableTextFile(const QString &file_str, BaseSqlTableModel
         i = pPlaylistTableModel->fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ARTIST);
         if (i >= 0) {
             out << " ";
-            out << pPlaylistTableModel->data(pPlaylistTableModel->index(j,i)).toString();
+            out << pPlaylistTableModel
+                            ->data(pPlaylistTableModel->index(j, i),
+                                    BaseTrackTableModel::kDataExportRole)
+                            .toString();
         }
         i = pPlaylistTableModel->fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TITLE);
         if (i >= 0) {

--- a/src/library/parsercsv.cpp
+++ b/src/library/parsercsv.cpp
@@ -180,12 +180,22 @@ bool ParserCsv::writeCSVFile(const QString &file_str, BaseSqlTableModel* pPlayli
                 first = false;
             }
             out << "\"";
-            QString field = pPlaylistTableModel->data(pPlaylistTableModel->index(j,i)).toString();
-            if (useRelativePath &&
-                    i ==
-                            pPlaylistTableModel->fieldIndex(ColumnCache::
-                                            COLUMN_TRACKLOCATIONSTABLE_LOCATION)) {
-                field = base_dir.relativeFilePath(field);
+            QString field;
+            if (i == pPlaylistTableModel->fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM)) {
+                // Use ToolTip Role for full precision.
+                field = pPlaylistTableModel
+                                ->data(pPlaylistTableModel->index(j, i),
+                                        Qt::ToolTipRole)
+                                .toString();
+            } else if (i ==
+                    pPlaylistTableModel->fieldIndex(
+                            ColumnCache::COLUMN_TRACKLOCATIONSTABLE_LOCATION)) {
+                field = pPlaylistTableModel->data(pPlaylistTableModel->index(j, i)).toString();
+                if (useRelativePath) {
+                    field = base_dir.relativeFilePath(field);
+                }
+            } else {
+                field = pPlaylistTableModel->data(pPlaylistTableModel->index(j, i)).toString();
             }
             out << field.replace('\"', "\"\"");  // escape "
             out << "\"";

--- a/src/library/trackmodel.h
+++ b/src/library/trackmodel.h
@@ -16,6 +16,8 @@ class TrackModel {
   public:
     static const int kHeaderWidthRole = Qt::UserRole + 0;
     static const int kHeaderNameRole = Qt::UserRole + 1;
+    // This role is used for data export like in CSV files
+    static constexpr int kDataExportRole = Qt::UserRole + 2;
 
     TrackModel(const QSqlDatabase& db,
             const char* settingsNamespace)


### PR DESCRIPTION
This is required to verify if a track is at a full 1/12 bpm.

The idea to use the tool-tips to show a higher precision was discussed here https://github.com/mixxxdj/mixxx/pull/2001
but it looks like it has slipped through the original review. 

We want also full precision in cvs exports. This way we export the truth and not the optimized value for displaying purpose.