### PR TITLE
remove LegacyControllerMappingVisitor

### DIFF
--- a/src/controllers/controllermappingtablemodel.cpp
+++ b/src/controllers/controllermappingtablemodel.cpp
@@ -4,8 +4,7 @@
 
 ControllerMappingTableModel::ControllerMappingTableModel(QObject* pParent)
         : QAbstractTableModel(pParent),
-          m_pMidiMapping(nullptr),
-          m_pHidMapping(nullptr) {
+          m_pMidiMapping(nullptr) {
 }
 
 ControllerMappingTableModel::~ControllerMappingTableModel() {
@@ -13,10 +12,11 @@ ControllerMappingTableModel::~ControllerMappingTableModel() {
 }
 
 void ControllerMappingTableModel::setMapping(LegacyControllerMappingPointer pMapping) {
-    m_pMapping = pMapping;
-    if (m_pMapping) {
-        // This immediately calls one of the two visit() methods below.
-        m_pMapping->accept(this);
+    m_pMidiMapping = dynamic_cast<LegacyMidiControllerMapping*>(pMapping.data());
+    // Only legacy MIDI mappings are supported
+    // TODO: prevent calling this code for unsupported mapping types?
+    if (!m_pMidiMapping) {
+        return;
     }
 
     // Notify the child class a mapping was loaded.
@@ -25,16 +25,8 @@ void ControllerMappingTableModel::setMapping(LegacyControllerMappingPointer pMap
 
 void ControllerMappingTableModel::cancel() {
     // Apply mutates the mapping so to revert to the time just before the last
-    // apply, simply call setMapping again.
-    setMapping(m_pMapping);
-}
-
-void ControllerMappingTableModel::visit(LegacyMidiControllerMapping* pMidiMapping) {
-    m_pMidiMapping = pMidiMapping;
-}
-
-void ControllerMappingTableModel::visit(LegacyHidControllerMapping* pHidMapping) {
-    m_pHidMapping = pHidMapping;
+    // apply, simply reload the mapping.
+    onMappingLoaded();
 }
 
 bool ControllerMappingTableModel::setHeaderData(int section,

--- a/src/controllers/controllermappingtablemodel.h
+++ b/src/controllers/controllermappingtablemodel.h
@@ -12,16 +12,13 @@
 #include "controllers/legacycontrollermapping.h"
 #include "controllers/midi/legacymidicontrollermapping.h"
 
-class ControllerMappingTableModel : public QAbstractTableModel,
-                                    public LegacyControllerMappingVisitor {
+class ControllerMappingTableModel : public QAbstractTableModel {
     Q_OBJECT
   public:
     ControllerMappingTableModel(QObject* pParent);
     ~ControllerMappingTableModel() override;
 
     void setMapping(LegacyControllerMappingPointer pMapping);
-    void visit(LegacyHidControllerMapping* pHidMapping) override;
-    void visit(LegacyMidiControllerMapping* pMidiMapping) override;
 
     // Revert changes made since the last apply.
     virtual void cancel();
@@ -42,7 +39,5 @@ class ControllerMappingTableModel : public QAbstractTableModel,
     virtual void onMappingLoaded() = 0;
 
     QVector<QHash<int, QVariant> > m_headerInfo;
-    LegacyControllerMappingPointer m_pMapping;
     LegacyMidiControllerMapping* m_pMidiMapping;
-    LegacyHidControllerMapping* m_pHidMapping;
 };

--- a/src/controllers/controllermappingvisitor.h
+++ b/src/controllers/controllermappingvisitor.h
@@ -3,14 +3,6 @@
 class LegacyMidiControllerMapping;
 class LegacyHidControllerMapping;
 
-class LegacyControllerMappingVisitor {
-  public:
-    virtual ~LegacyControllerMappingVisitor() {
-    }
-    virtual void visit(LegacyMidiControllerMapping* mapping) = 0;
-    virtual void visit(LegacyHidControllerMapping* mapping) = 0;
-};
-
 class ConstLegacyControllerMappingVisitor {
   public:
     virtual ~ConstLegacyControllerMappingVisitor() {

--- a/src/controllers/hid/legacyhidcontrollermapping.cpp
+++ b/src/controllers/hid/legacyhidcontrollermapping.cpp
@@ -14,12 +14,6 @@ bool LegacyHidControllerMapping::saveMapping(const QString& fileName) const {
     return handler.save(*this, fileName);
 }
 
-void LegacyHidControllerMapping::accept(LegacyControllerMappingVisitor* visitor) {
-    if (visitor) {
-        visitor->visit(this);
-    }
-}
-
 void LegacyHidControllerMapping::accept(ConstLegacyControllerMappingVisitor* visitor) const {
     if (visitor) {
         visitor->visit(this);

--- a/src/controllers/hid/legacyhidcontrollermapping.h
+++ b/src/controllers/hid/legacyhidcontrollermapping.h
@@ -15,7 +15,6 @@ class LegacyHidControllerMapping : public LegacyControllerMapping {
 
     bool saveMapping(const QString& fileName) const override;
 
-    void accept(LegacyControllerMappingVisitor* visitor) override;
     void accept(ConstLegacyControllerMappingVisitor* visitor) const override;
     bool isMappable() const override;
 };

--- a/src/controllers/legacycontrollermapping.h
+++ b/src/controllers/legacycontrollermapping.h
@@ -172,7 +172,6 @@ class LegacyControllerMapping {
 
     virtual bool saveMapping(const QString& filename) const = 0;
 
-    virtual void accept(LegacyControllerMappingVisitor* visitor) = 0;
     virtual void accept(ConstLegacyControllerMappingVisitor* visitor) const = 0;
     virtual bool isMappable() const = 0;
 

--- a/src/controllers/midi/legacymidicontrollermapping.cpp
+++ b/src/controllers/midi/legacymidicontrollermapping.cpp
@@ -8,12 +8,6 @@ bool LegacyMidiControllerMapping::saveMapping(const QString& fileName) const {
     return handler.save(*this, fileName);
 }
 
-void LegacyMidiControllerMapping::accept(LegacyControllerMappingVisitor* visitor) {
-    if (visitor) {
-        visitor->visit(this);
-    }
-}
-
 void LegacyMidiControllerMapping::accept(ConstLegacyControllerMappingVisitor* visitor) const {
     if (visitor) {
         visitor->visit(this);

--- a/src/controllers/midi/legacymidicontrollermapping.h
+++ b/src/controllers/midi/legacymidicontrollermapping.h
@@ -15,7 +15,6 @@ class LegacyMidiControllerMapping : public LegacyControllerMapping {
 
     bool saveMapping(const QString& fileName) const override;
 
-    virtual void accept(LegacyControllerMappingVisitor* visitor) override;
     virtual void accept(ConstLegacyControllerMappingVisitor* visitor) const override;
     virtual bool isMappable() const override;
 


### PR DESCRIPTION
This class increased coupling and made the code very confusing for
no benefit.