### PR TITLE
No malloc in engine calls to beat class

### DIFF
--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -286,6 +286,7 @@ double BeatGrid::getBpm() const {
     return bpm();
 }
 
+// Note: Also called from the engine thread
 double BeatGrid::getBpmAroundPosition(double curSample, int n) const {
     Q_UNUSED(curSample);
     Q_UNUSED(n);

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -286,14 +286,6 @@ double BeatGrid::getBpm() const {
     return bpm();
 }
 
-double BeatGrid::getBpmRange(double startSample, double stopSample) const {
-    QMutexLocker locker(&m_mutex);
-    if (!isValid() || startSample > stopSample) {
-        return -1;
-    }
-    return bpm();
-}
-
 double BeatGrid::getBpmAroundPosition(double curSample, int n) const {
     Q_UNUSED(curSample);
     Q_UNUSED(n);

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -59,7 +59,6 @@ class BeatGrid final : public Beats {
     std::unique_ptr<BeatIterator> findBeats(double startSample, double stopSample) const override;
     bool hasBeatInRange(double startSample, double stopSample) const override;
     double getBpm() const override;
-    double getBpmRange(double startSample, double stopSample) const override;
     double getBpmAroundPosition(double curSample, int n) const override;
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -66,7 +66,7 @@ class BeatMapIterator : public BeatIterator {
 BeatMap::BeatMap(const Track& track, SINT iSampleRate)
         : m_mutex(QMutex::Recursive),
           m_iSampleRate(iSampleRate > 0 ? iSampleRate : track.getSampleRate()),
-          m_dCachedBpm(0) {
+          m_nominalBpm(0) {
     // BeatMap should live in the same thread as the track it is associated
     // with.
     moveToThread(track.thread());
@@ -86,11 +86,11 @@ BeatMap::BeatMap(const Track& track, SINT iSampleRate,
     }
 }
 
-BeatMap::BeatMap (const BeatMap& other)
+BeatMap::BeatMap(const BeatMap& other)
         : m_mutex(QMutex::Recursive),
           m_subVersion(other.m_subVersion),
           m_iSampleRate(other.m_iSampleRate),
-          m_dCachedBpm(other.m_dCachedBpm),
+          m_nominalBpm(other.m_nominalBpm),
           m_beats(other.m_beats) {
     moveToThread(other.thread());
 }
@@ -414,7 +414,7 @@ double BeatMap::getBpm() const {
     if (!isValid()) {
         return -1;
     }
-    return m_dCachedBpm;
+    return m_nominalBpm;
 }
 
 double BeatMap::getBpmRange(double startSample, double stopSample) const {
@@ -696,12 +696,12 @@ void BeatMap::setBpm(double dBpm) {
 
 void BeatMap::onBeatlistChanged() {
     if (!isValid()) {
-        m_dCachedBpm = 0;
+        m_nominalBpm = 0;
         return;
     }
     Beat startBeat = m_beats.first();
     Beat stopBeat =  m_beats.last();
-    m_dCachedBpm = calculateBpm(startBeat, stopBeat);
+    m_nominalBpm = calculateBpm(startBeat, stopBeat);
 }
 
 double BeatMap::calculateBpm(const Beat& startBeat, const Beat& stopBeat) const {

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -437,18 +437,6 @@ double BeatMap::getBpm() const {
     return m_nominalBpm;
 }
 
-double BeatMap::getBpmRange(double startSample, double stopSample) const {
-    QMutexLocker locker(&m_mutex);
-    if (!isValid()) {
-        return -1;
-    }
-    Beat startBeat, stopBeat;
-    startBeat.set_frame_position(
-            static_cast<google::protobuf::int32>(samplesToFrames(startSample)));
-    stopBeat.set_frame_position(static_cast<google::protobuf::int32>(samplesToFrames(stopSample)));
-    return calculateBpm(startBeat, stopBeat);
-}
-
 double BeatMap::getBpmAroundPosition(double curSample, int n) const {
     QMutexLocker locker(&m_mutex);
     if (!isValid()) {

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -18,6 +18,8 @@
 
 using mixxx::track::io::Beat;
 
+namespace {
+
 const int kFrameSize = 2;
 
 inline double samplesToFrames(const double samples) {
@@ -31,6 +33,24 @@ inline double framesToSamples(const int frames) {
 bool BeatLessThan(const Beat& beat1, const Beat& beat2) {
     return beat1.frame_position() < beat2.frame_position();
 }
+
+double calculateNominalBpm(const BeatList& beats, SINT sampleRate) {
+    QVector<double> beatvect;
+    beatvect.reserve(beats.size());
+    for (const auto& beat : beats) {
+        if (beat.enabled()) {
+            beatvect.append(beat.frame_position());
+        }
+    }
+
+    if (beatvect.isEmpty()) {
+        return -1;
+    }
+
+    return BeatUtils::calculateBpm(beatvect, sampleRate, 0, 9999);
+}
+
+} // namespace
 
 namespace mixxx {
 
@@ -699,9 +719,7 @@ void BeatMap::onBeatlistChanged() {
         m_nominalBpm = 0;
         return;
     }
-    Beat startBeat = m_beats.first();
-    Beat stopBeat =  m_beats.last();
-    m_nominalBpm = calculateBpm(startBeat, stopBeat);
+    m_nominalBpm = calculateNominalBpm(m_beats, m_iSampleRate);
 }
 
 double BeatMap::calculateBpm(const Beat& startBeat, const Beat& stopBeat) const {

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -66,8 +66,7 @@ class BeatMapIterator : public BeatIterator {
 BeatMap::BeatMap(const Track& track, SINT iSampleRate)
         : m_mutex(QMutex::Recursive),
           m_iSampleRate(iSampleRate > 0 ? iSampleRate : track.getSampleRate()),
-          m_dCachedBpm(0),
-          m_dLastFrame(0) {
+          m_dCachedBpm(0) {
     // BeatMap should live in the same thread as the track it is associated
     // with.
     moveToThread(track.thread());
@@ -92,7 +91,6 @@ BeatMap::BeatMap (const BeatMap& other)
           m_subVersion(other.m_subVersion),
           m_iSampleRate(other.m_iSampleRate),
           m_dCachedBpm(other.m_dCachedBpm),
-          m_dLastFrame(other.m_dLastFrame),
           m_beats(other.m_beats) {
     moveToThread(other.thread());
 }
@@ -698,11 +696,9 @@ void BeatMap::setBpm(double dBpm) {
 
 void BeatMap::onBeatlistChanged() {
     if (!isValid()) {
-        m_dLastFrame = 0;
         m_dCachedBpm = 0;
         return;
     }
-    m_dLastFrame = m_beats.last().frame_position();
     Beat startBeat = m_beats.first();
     Beat stopBeat =  m_beats.last();
     m_dCachedBpm = calculateBpm(startBeat, stopBeat);

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -106,7 +106,7 @@ class BeatMap final : public Beats {
     mutable QMutex m_mutex;
     QString m_subVersion;
     SINT m_iSampleRate;
-    double m_dCachedBpm;
+    double m_nominalBpm;
     BeatList m_beats;
 };
 

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -68,7 +68,6 @@ class BeatMap final : public Beats {
     bool hasBeatInRange(double startSample, double stopSample) const override;
 
     double getBpm() const override;
-    double getBpmRange(double startSample, double stopSample) const override;
     double getBpmAroundPosition(double curSample, int n) const override;
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -90,8 +90,6 @@ class BeatMap final : public Beats {
     void createFromBeatVector(const QVector<double>& beats);
     void onBeatlistChanged();
 
-    double calculateBpm(const mixxx::track::io::Beat& startBeat,
-                        const mixxx::track::io::Beat& stopBeat) const;
     // For internal use only.
     bool isValid() const;
 

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -107,7 +107,6 @@ class BeatMap final : public Beats {
     QString m_subVersion;
     SINT m_iSampleRate;
     double m_dCachedBpm;
-    double m_dLastFrame;
     BeatList m_beats;
 };
 

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -128,10 +128,6 @@ class Beats : public QObject {
     // valid, otherwise returns -1
     virtual double getBpm() const = 0;
 
-    // Return the average BPM over the range from startSample to endSample,
-    // specified in samples if the BPM is valid, otherwise returns -1
-    virtual double getBpmRange(double startSample, double stopSample) const = 0;
-
     // Return the average BPM over the range of n*2 beats centered around
     // curSample.  (An n of 4 results in an averaging of 8 beats).  Invalid
     // BPM returns -1.

--- a/src/track/beatutils.cpp
+++ b/src/track/beatutils.cpp
@@ -149,6 +149,18 @@ double BeatUtils::computeFilteredWeightedAverage(
     return filterWeightedAverage / static_cast<double>(filterSum);
 }
 
+double BeatUtils::calculateAverageBpm(int numberOfBeats,
+        int sampleRate,
+        double lowerFrame,
+        double upperFrame) {
+    double frames = upperFrame - lowerFrame;
+    DEBUG_ASSERT(frames > 0);
+    if (numberOfBeats < 1) {
+        return 0;
+    }
+    return 60.0 * numberOfBeats * sampleRate / frames;
+}
+
 double BeatUtils::calculateBpm(const QVector<double>& beats, int SampleRate,
                                int min_bpm, int max_bpm) {
     /*
@@ -184,14 +196,10 @@ double BeatUtils::calculateBpm(const QVector<double>& beats, int SampleRate,
      * BPM.
      */
 
-    if (beats.size() < 2) {
-        return 0;
-    }
-
     // If we don't have enough beats for our regular approach, just divide the #
     // of beats by the duration in minutes.
     if (beats.size() <= N) {
-        return 60.0 * (beats.size()-1) * SampleRate / (beats.last() - beats.first());
+        return calculateAverageBpm(beats.size() - 1, SampleRate, beats.first(), beats.last());
     }
 
     QMap<double, int> frequency_table;

--- a/src/track/beatutils.h
+++ b/src/track/beatutils.h
@@ -33,6 +33,10 @@ class BeatUtils {
         return bpm;
     }
 
+    static double calculateAverageBpm(int numberOfBeats,
+            int sampleRate,
+            double lowerFrame,
+            double upperFrame);
 
     /*
      * This method detects the BPM given a set of beat positions.


### PR DESCRIPTION
During testing https://github.com/mixxxdj/mixxx/pull/3626 I have noticed that we create a temporary heap vector to use a BeatUtil function.
This PR fixes that by inlining the code to BeatMap.

In addition this PR removes some unused stuff. See commits.   

