### PR TITLE
CmdlineArgs: remove unused pluginPath argument

### DIFF
--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -52,9 +52,6 @@ bool CmdlineArgs::Parse(int &argc, char **argv) {
         } else if (argv[i] == QString("--resourcePath") && i+1 < argc) {
             m_resourcePath = QString::fromLocal8Bit(argv[i+1]);
             i++;
-        } else if (argv[i] == QString("--pluginPath") && i+1 < argc) {
-            m_pluginPath = QString::fromLocal8Bit(argv[i+1]);
-            i++;
         } else if (argv[i] == QString("--timelinePath") && i+1 < argc) {
             m_timelinePath = QString::fromLocal8Bit(argv[i+1]);
             i++;
@@ -131,10 +128,6 @@ void CmdlineArgs::printUsage() {
 --resourcePath PATH     Top-level directory where Mixxx should look\n\
                         for its resource files such as MIDI mappings,\n\
                         overriding the default installation location.\n\
-\n\
---pluginPath PATH       Top-level directory where Mixxx should look\n\
-                        for sound source plugins in addition to default\n\
-                        locations.\n\
 \n\
 --settingsPath PATH     Top-level directory where Mixxx should look\n\
                         for settings. Default is:\n", stdout);

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -39,7 +39,6 @@ class CmdlineArgs final {
         m_settingsPath = newSettingsPath;
     }
     const QString& getResourcePath() const { return m_resourcePath; }
-    const QString& getPluginPath() const { return m_pluginPath; }
     const QString& getTimelinePath() const { return m_timelinePath; }
 
   private:
@@ -55,6 +54,5 @@ class CmdlineArgs final {
     QString m_locale;
     QString m_settingsPath;
     QString m_resourcePath;
-    QString m_pluginPath;
     QString m_timelinePath;
 };


### PR DESCRIPTION
This is obsolete since SoundSource plugins were removed.