### PR TITLE
Pref > EQ comboboxes: show empty items always at the top

### DIFF
--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -110,7 +110,7 @@ void DlgPrefEQ::slotNumDecksChanged(double numDecks) {
                 new ControlObject(ConfigKey(group, "filterWaveformEnable")));
         m_filterWaveformEffectLoaded.append(false);
 
-        // Create the drop down list for EQs
+        // Create the drop down list for deck EQs
         QComboBox* eqComboBox = new QComboBox(this);
         m_deckEqEffectSelectors.append(eqComboBox);
         connect(eqComboBox,
@@ -118,7 +118,7 @@ void DlgPrefEQ::slotNumDecksChanged(double numDecks) {
                 this,
                 &DlgPrefEQ::slotEqEffectChangedOnDeck);
 
-        // Create the drop down list for EQs
+        // Create the drop down list for Quick Effects
         QComboBox* quickEffectComboBox = new QComboBox(this);
         m_deckQuickEffectSelectors.append(quickEffectComboBox);
         connect(quickEffectComboBox,
@@ -217,20 +217,20 @@ void DlgPrefEQ::slotPopulateDeckEffectSelectors() {
         box->clear();
         int currentIndex = -1; // Nothing selected
 
+        // Add empty item at the top: no deck EQ
+        box->addItem(EffectsManager::kNoEffectString);
         int i;
         for (i = 0; i < availableEQEffects.size(); ++i) {
             EffectManifestPointer pManifest = availableEQEffects.at(i);
             box->addItem(pManifest->name(), QVariant(pManifest->id()));
             if (selectedEffectId == pManifest->id()) {
-                currentIndex = i;
+                currentIndex = i + 1;
             }
         }
-        // Add empty item, no effect
-        box->addItem(EffectsManager::kNoEffectString);
 
         if (selectedEffectId.isEmpty()) {
             // Configured effect has no id, clear selection
-            currentIndex = availableEQEffects.size();
+            currentIndex = 0;
         } else if (currentIndex < 0 && !selectedEffectName.isEmpty() ) {
             // current selection is not part of the new list
             // So we need to add it
@@ -248,20 +248,21 @@ void DlgPrefEQ::slotPopulateDeckEffectSelectors() {
         box->clear();
         int currentIndex = -1;// Nothing selected
 
+        // Add empty item at the top: no Quick Effect
+        box->addItem(EffectsManager::kNoEffectString);
+
         int i;
         for (i = 0; i < availableQuickEffects.size(); ++i) {
             EffectManifestPointer pManifest = availableQuickEffects.at(i);
             box->addItem(pManifest->name(), QVariant(pManifest->id()));
             if (selectedEffectId == pManifest->id()) {
-                currentIndex = i;
+                currentIndex = i + 1;
             }
         }
-        // Add empty item, no effect
-        box->addItem(EffectsManager::kNoEffectString);
 
         if (selectedEffectId.isEmpty()) {
             // Configured effect has no id, clear selection
-            currentIndex = availableQuickEffects.size();
+            currentIndex = 0;
         } else if (currentIndex < 0 && !selectedEffectName.isEmpty()) {
             // current selection is not part of the new list
             // So we need to add it
@@ -672,16 +673,16 @@ void DlgPrefEQ::setUpMasterEQ() {
     const QList<EffectManifestPointer> availableMasterEQEffects =
         m_pEffectsManager->getAvailableEffectManifestsFiltered(isMasterEQ);
 
+    // Add empty item at the top: no Master EQ
+    comboBoxMasterEq->addItem(EffectsManager::kNoEffectString);
     for (const auto& pManifest : availableMasterEQEffects) {
         comboBoxMasterEq->addItem(pManifest->name(), QVariant(pManifest->id()));
     }
-    // Add empty item, no effect
-    comboBoxMasterEq->addItem(EffectsManager::kNoEffectString);
 
     int masterEqIndex = comboBoxMasterEq->findData(configuredEffect);
     if (masterEqIndex < 0) {
         // Configured effect not in list, clear selection
-        masterEqIndex = availableMasterEQEffects.size();
+        masterEqIndex = 0;
     }
     comboBoxMasterEq->setCurrentIndex(masterEqIndex);
 

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -100,8 +100,7 @@ void DlgPrefEQ::slotNumDecksChanged(double numDecks) {
     while (m_deckEqEffectSelectors.size() < static_cast<int>(numDecks)) {
         int deckNo = m_deckEqEffectSelectors.size() + 1;
 
-        QLabel* label = new QLabel(QObject::tr("Deck %1 EQ Effect").
-                             arg(deckNo), this);
+        QLabel* label = new QLabel(QObject::tr("Deck %1").arg(deckNo), this);
 
         QString group = PlayerManager::groupForDeck(
                 m_deckEqEffectSelectors.size());
@@ -129,7 +128,7 @@ void DlgPrefEQ::slotNumDecksChanged(double numDecks) {
         if (deckNo == 1) {
             m_firstSelectorLabel = label;
             if (CheckBoxEqOnly->isChecked()) {
-                m_firstSelectorLabel->setText(QObject::tr("EQ Effect"));
+                m_firstSelectorLabel->clear();
             }
         }
 
@@ -293,9 +292,9 @@ void DlgPrefEQ::slotSingleEqChecked(int checked) {
 
     if (m_firstSelectorLabel != nullptr) {
         if (do_hide) {
-            m_firstSelectorLabel->setText(QObject::tr("EQ Effect"));
+            m_firstSelectorLabel->clear();
         } else {
-            m_firstSelectorLabel->setText(QObject::tr("Deck 1 EQ Effect"));
+            m_firstSelectorLabel->setText(QObject::tr("Deck 1"));
         }
     }
 

--- a/src/widget/weffectselector.cpp
+++ b/src/widget/weffectselector.cpp
@@ -57,6 +57,10 @@ void WEffectSelector::populate() {
             m_pEffectsManager->getVisibleEffectManifests();
     QFontMetrics metrics(font());
 
+    // Add empty item: no effect
+    addItem(EffectsManager::kNoEffectString);
+    setItemData(0, QVariant(tr("No effect loaded.")), Qt::ToolTipRole);
+
     for (int i = 0; i < visibleEffectManifests.size(); ++i) {
         const EffectManifestPointer pManifest = visibleEffectManifests.at(i);
         QString elidedDisplayName = metrics.elidedText(pManifest->displayName(),
@@ -68,13 +72,11 @@ void WEffectSelector::populate() {
         QString description = pManifest->description();
         // <b> makes the effect name bold. Also, like <span> it serves as hack
         // to get Qt to treat the string as rich text so it automatically wraps long lines.
-        setItemData(i, QVariant(QStringLiteral("<b>") + name + QStringLiteral("</b><br/>") +
-                description), Qt::ToolTipRole);
-    }
-    // Add empty item, no effect
-    addItem(EffectsManager::kNoEffectString);
-    setItemData(visibleEffectManifests.size(), QVariant(tr("No effect loaded.")),
+        setItemData(i + 1,
+                QVariant(QStringLiteral("<b>") + name +
+                        QStringLiteral("</b><br/>") + description),
                 Qt::ToolTipRole);
+    }
 
     slotEffectUpdated();
     blockSignals(false);


### PR DESCRIPTION
For a consistent UI, let's move all 'empty' combobox items to the top
- Pref EQ > deck EQ + Quick Effect + Master EQ
- WEffectSelector

as it is already the case in
- Pref Sound Hardware > Sound API + Sound devices

continues #3485 as proposed in https://github.com/mixxxdj/mixxx/pull/3549#issuecomment-758135887

Also, the last commit removes some noise from the EQ/QuickEffect grid (tr string changes, deletions). If this is not desired I can revert that.

![image](https://user-images.githubusercontent.com/5934199/109232934-539f1b00-77c9-11eb-8cd3-8f9f26fcc88d.png)

before
![image](https://user-images.githubusercontent.com/5934199/109233179-b8f30c00-77c9-11eb-9483-9bb596e61dc0.png)