### PR TITLE
CMake: do not use /OPT:ICF link option on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,8 @@ if(MSVC)
       string(REPLACE "/RTC1" "" CMAKE_C_FLAGS_DEBUG  "${CMAKE_C_FLAGS_DEBUG}")
     else()
       # Reduce the size of the binary in Release & RelWithDebInfo builds
+      # Do not use /OPT:ICF because it has no effect.
+      # https://github.com/mixxxdj/mixxx/pull/3660#pullrequestreview-600137258
       add_link_options(/OPT:REF)
       # /INCREMENTAL is incompatible with /OPT:REF
       string(REPLACE "/INCREMENTAL" "/INCREMENTAL:NO" CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,8 +133,11 @@ if(MSVC)
       string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG  "${CMAKE_CXX_FLAGS_DEBUG}")
       string(REPLACE "/RTC1" "" CMAKE_C_FLAGS_DEBUG  "${CMAKE_C_FLAGS_DEBUG}")
     else()
-      # Squeeze binary in Release builds
+      # Reduce the size of the binary in Release & RelWithDebInfo builds
       add_link_options(/OPT:REF)
+      # /INCREMENTAL is incompatible with /OPT:REF
+      string(REPLACE "/INCREMENTAL" "/INCREMENTAL:NO" CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE}")
+      string(REPLACE "/INCREMENTAL" "/INCREMENTAL:NO" CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO}")
       # Note: CMAKE_INTERPROCEDURAL_OPTIMIZATION sets the /GL and /LTCG flags for us
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ if(MSVC)
       string(REPLACE "/RTC1" "" CMAKE_C_FLAGS_DEBUG  "${CMAKE_C_FLAGS_DEBUG}")
     else()
       # Squeeze binary in Release builds
-      add_link_options(/OPT:REF /OPT:ICF)
+      add_link_options(/OPT:REF)
       # Note: CMAKE_INTERPROCEDURAL_OPTIMIZATION sets the /GL and /LTCG flags for us
     endif()
 


### PR DESCRIPTION
This caused a linker warning:
LINK : warning LNK4075: ignoring '/INCREMENTAL' due to '/OPT:ICF' specification

Also, it makes debugging confusing. From
https://docs.microsoft.com/en-us/cpp/build/reference/opt-optimizations?view=msvc-160

because /OPT:ICF can merge identical data or functions, it can
change the function names that appear in stack traces. It can also
make it impossible to set breakpoints in certain functions or to
examine some data in the debugger, and can take you into
unexpected functions when you single-step through your code. The
behavior of the code is identical, but the debugger presentation
can be very confusing. Therefore, we do not recommend that you use
/OPT:ICF in debug builds unless the advantages of smaller code
outweigh these disadvantages.