### PR TITLE
No grid from bpm

### DIFF
--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -281,14 +281,6 @@ void AnalyzerBeats::storeResults(TrackPointer tio) {
         tio->setBeats(pBeats);
         return;
     }
-
-    // If we got here then the user doesn't want to replace the beatgrid but
-    // since the first beat is zero we'll apply the offset we just detected.
-    double currentFirstBeat = pCurrentBeats->findNextBeat(0);
-    double newFirstBeat = pBeats->findNextBeat(0);
-    if (currentFirstBeat == 0.0 && newFirstBeat > 0) {
-        pCurrentBeats->translate(newFirstBeat);
-    }
 }
 
 // static

--- a/src/library/banshee/bansheeplaylistmodel.cpp
+++ b/src/library/banshee/bansheeplaylistmodel.cpp
@@ -286,16 +286,10 @@ TrackPointer BansheePlaylistModel::getTrack(const QModelIndex& index) const {
         pTrack->setGrouping(getFieldString(index, CLM_GROUPING));
         pTrack->setRating(getFieldString(index, CLM_RATING).toInt());
         pTrack->setTrackNumber(getFieldString(index, CLM_TRACKNUMBER));
-        double bpm = getFieldString(index, CLM_BPM).toDouble();
-        bpm = pTrack->setBpm(bpm);
+        // Note: We do not import CLM_BPM here, because we don't know the mandatory phase.
         pTrack->setBitrate(getFieldString(index, CLM_BITRATE).toInt());
         pTrack->setComment(getFieldString(index, CLM_COMMENT));
         pTrack->setComposer(getFieldString(index, CLM_COMPOSER));
-        // If the track has a BPM, then give it a static beatgrid.
-        if (bpm > 0) {
-            mixxx::BeatsPointer pBeats = BeatFactory::makeBeatGrid(*pTrack, bpm, 0.0);
-            pTrack->setBeats(pBeats);
-        }
     }
     return pTrack;
 }

--- a/src/library/baseexternalplaylistmodel.cpp
+++ b/src/library/baseexternalplaylistmodel.cpp
@@ -63,9 +63,7 @@ TrackPointer BaseExternalPlaylistModel::getTrack(const QModelIndex& index) const
                 index.row(), fieldIndex("genre")).data().toString();
         pTrack->setGenre(genre);
 
-        float bpm = index.sibling(
-                index.row(), fieldIndex("bpm")).data().toString().toFloat();
-        pTrack->setBpm(bpm);
+        // Note: We do not import BPM here, because we don't know the mandatory phase.
     }
     return pTrack;
 }

--- a/src/library/baseexternaltrackmodel.cpp
+++ b/src/library/baseexternaltrackmodel.cpp
@@ -48,7 +48,6 @@ TrackPointer BaseExternalTrackModel::getTrack(const QModelIndex& index) const {
     QString album = index.sibling(index.row(), fieldIndex("album")).data().toString();
     QString year = index.sibling(index.row(), fieldIndex("year")).data().toString();
     QString genre = index.sibling(index.row(), fieldIndex("genre")).data().toString();
-    float bpm = index.sibling(index.row(), fieldIndex("bpm")).data().toString().toFloat();
 
     QString nativeLocation = index.sibling(index.row(), fieldIndex("location")).data().toString();
     QString location = QDir::fromNativeSeparators(nativeLocation);
@@ -74,7 +73,7 @@ TrackPointer BaseExternalTrackModel::getTrack(const QModelIndex& index) const {
             pTrack->setAlbum(album);
             pTrack->setYear(year);
             pTrack->setGenre(genre);
-            pTrack->setBpm(bpm);
+            // Note: We do not import BPM here, because we don't know the mandatory phase.
         }
     } else {
         qWarning() << "Failed to load external track" << location;

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1082,7 +1082,6 @@ bool setTrackAudioProperties(
 
 bool setTrackBeats(const QSqlRecord& record, const int column,
                    TrackPointer pTrack) {
-    double bpm = record.value(column).toDouble();
     QString beatsVersion = record.value(column + 1).toString();
     QString beatsSubVersion = record.value(column + 2).toString();
     QByteArray beatsBlob = record.value(column + 3).toByteArray();
@@ -1091,8 +1090,6 @@ bool setTrackBeats(const QSqlRecord& record, const int column,
             *pTrack, beatsVersion, beatsSubVersion, beatsBlob);
     if (pBeats) {
         pTrack->setBeats(pBeats);
-    } else {
-        pTrack->setBpm(bpm);
     }
     pTrack->setBpmLocked(bpmLocked);
     return false;
@@ -1169,60 +1166,58 @@ TrackPointer TrackDAO::getTrackById(TrackId trackId) const {
     QSqlQuery query(m_database);
 
     ColumnPopulator columns[] = {
-        // Location must be first.
-        { "track_locations.location", nullptr },
-        { "artist", setTrackArtist },
-        { "title", setTrackTitle },
-        { "album", setTrackAlbum },
-        { "album_artist", setTrackAlbumArtist },
-        { "year", setTrackYear },
-        { "genre", setTrackGenre },
-        { "composer", setTrackComposer },
-        { "grouping", setTrackGrouping },
-        { "tracknumber", setTrackNumber },
-        { "tracktotal", setTrackTotal },
-        { "filetype", setTrackFiletype },
-        { "rating", setTrackRating },
-        { "color", setTrackColor },
-        { "comment", setTrackComment },
-        { "url", setTrackUrl },
-        { "cuepoint", setTrackCuePoint },
-        { "replaygain", setTrackReplayGainRatio },
-        { "replaygain_peak", setTrackReplayGainPeak },
-        { "timesplayed", setTrackTimesPlayed },
-        { "played", setTrackPlayed },
-        { "datetime_added", setTrackDateAdded },
-        { "header_parsed", setTrackMetadataSynchronized },
+            // Location must be first.
+            {"track_locations.location", nullptr},
+            {"artist", setTrackArtist},
+            {"title", setTrackTitle},
+            {"album", setTrackAlbum},
+            {"album_artist", setTrackAlbumArtist},
+            {"year", setTrackYear},
+            {"genre", setTrackGenre},
+            {"composer", setTrackComposer},
+            {"grouping", setTrackGrouping},
+            {"tracknumber", setTrackNumber},
+            {"tracktotal", setTrackTotal},
+            {"filetype", setTrackFiletype},
+            {"rating", setTrackRating},
+            {"color", setTrackColor},
+            {"comment", setTrackComment},
+            {"url", setTrackUrl},
+            {"cuepoint", setTrackCuePoint},
+            {"replaygain", setTrackReplayGainRatio},
+            {"replaygain_peak", setTrackReplayGainPeak},
+            {"timesplayed", setTrackTimesPlayed},
+            {"played", setTrackPlayed},
+            {"datetime_added", setTrackDateAdded},
+            {"header_parsed", setTrackMetadataSynchronized},
 
-        // Audio properties are set together at once. Do not change the
-        // ordering of these columns or put other columns in between them!
-        { "channels", setTrackAudioProperties },
-        { "samplerate", nullptr },
-        { "bitrate", nullptr },
-        { "duration", nullptr },
+            // Audio properties are set together at once. Do not change the
+            // ordering of these columns or put other columns in between them!
+            {"channels", setTrackAudioProperties},
+            {"samplerate", nullptr},
+            {"bitrate", nullptr},
+            {"duration", nullptr},
 
-        // Beat detection columns are handled by setTrackBeats. Do not change
-        // the ordering of these columns or put other columns in between them!
-        { "bpm", setTrackBeats },
-        { "beats_version", nullptr },
-        { "beats_sub_version", nullptr },
-        { "beats", nullptr },
-        { "bpm_lock", nullptr },
+            // Beat detection columns are handled by setTrackBeats. Do not change
+            // the ordering of these columns or put other columns in between them!
+            {"beats_version", setTrackBeats},
+            {"beats_sub_version", nullptr},
+            {"beats", nullptr},
+            {"bpm_lock", nullptr},
 
-        // Beat detection columns are handled by setTrackKey. Do not change the
-        // ordering of these columns or put other columns in between them!
-        { "key", setTrackKey },
-        { "keys_version", nullptr },
-        { "keys_sub_version", nullptr },
-        { "keys", nullptr },
+            // Beat detection columns are handled by setTrackKey. Do not change the
+            // ordering of these columns or put other columns in between them!
+            {"key", setTrackKey},
+            {"keys_version", nullptr},
+            {"keys_sub_version", nullptr},
+            {"keys", nullptr},
 
-        // Cover art columns are handled by setTrackCoverInfo. Do not change the
-        // ordering of these columns or put other columns in between them!
-        { "coverart_source", setTrackCoverInfo },
-        { "coverart_type", nullptr },
-        { "coverart_location", nullptr },
-        { "coverart_hash", nullptr }
-    };
+            // Cover art columns are handled by setTrackCoverInfo. Do not change the
+            // ordering of these columns or put other columns in between them!
+            {"coverart_source", setTrackCoverInfo},
+            {"coverart_type", nullptr},
+            {"coverart_location", nullptr},
+            {"coverart_hash", nullptr}};
 
     QString columnsStr;
     int columnsSize = 0;

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1082,10 +1082,10 @@ bool setTrackAudioProperties(
 
 bool setTrackBeats(const QSqlRecord& record, const int column,
                    TrackPointer pTrack) {
-    QString beatsVersion = record.value(column + 1).toString();
-    QString beatsSubVersion = record.value(column + 2).toString();
-    QByteArray beatsBlob = record.value(column + 3).toByteArray();
-    bool bpmLocked = record.value(column + 4).toBool();
+    QString beatsVersion = record.value(column).toString();
+    QString beatsSubVersion = record.value(column + 1).toString();
+    QByteArray beatsBlob = record.value(column + 2).toByteArray();
+    bool bpmLocked = record.value(column + 3).toBool();
     mixxx::BeatsPointer pBeats = BeatFactory::loadBeatsFromByteArray(
             *pTrack, beatsVersion, beatsSubVersion, beatsBlob);
     if (pBeats) {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -142,10 +142,10 @@ void Track::importMetadata(
         mixxx::TrackMetadata importedMetadata,
         const QDateTime& metadataSynchronized) {
     // Safe some values that are needed after move assignment and unlocking(see below)
-    const auto newBpm = importedMetadata.getTrackInfo().getBpm();
     const auto newKey = importedMetadata.getTrackInfo().getKey();
     const auto newReplayGain = importedMetadata.getTrackInfo().getReplayGain();
     const auto newSeratoTags = importedMetadata.getTrackInfo().getSeratoTags();
+    // Note: We do not import BPM here, because we don't know the mandatory phase.
     {
         // enter locking scope
         QMutexLocker lock(&m_qMutex);
@@ -194,13 +194,6 @@ void Track::importMetadata(
         }
 
         // implicitly unlocked when leaving scope
-    }
-
-    // Need to set BPM after sample rate since beat grid creation depends on
-    // knowing the sample rate. Bug #1020438.
-    const auto actualBpm = getActualBpm(newBpm, m_pBeats);
-    if (actualBpm.hasValue()) {
-        setBpm(actualBpm.getValue());
     }
 
     if (!newKey.isEmpty()

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -270,7 +270,7 @@ double Track::setBpm(double bpmValue) {
         // If the user sets the BPM to an invalid value, we assume
         // they want to clear the beatgrid.
         setBeats(mixxx::BeatsPointer());
-        return bpmValue;
+        return mixxx::Bpm::kValueUndefined;
     }
 
     QMutexLocker lock(&m_qMutex);
@@ -283,8 +283,9 @@ double Track::setBpm(double bpmValue) {
         return bpmValue;
     }
 
-    // Continue with the regular case
-    if (m_pBeats->getBpm() != bpmValue) {
+    // Continue with the regular cases
+    if ((m_pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM) &&
+            m_pBeats->getBpm() != bpmValue) {
         if (kLogger.debugEnabled()) {
             kLogger.debug() << "Updating BPM:" << getLocation();
         }
@@ -295,7 +296,7 @@ double Track::setBpm(double bpmValue) {
         emit bpmUpdated(bpmValue);
     }
 
-    return bpmValue;
+    return m_pBeats->getBpm();
 }
 
 QString Track::getBpmText() const {


### PR DESCRIPTION
This removed the partially broken code that generates a beat-grid from a bpm value without knowing the offset. 
This ensures that Mixxx's beat detector is run and a consistent offset bpm pair is used to create the beat-grid according to the beat detection preferences. 

The issue has cased wrong assumptions when testing https://github.com/mixxxdj/mixxx/pull/3626

This PR was planned here: 
https://mixxx.zulipchat.com/#narrow/stream/109122-general/topic/BeatGrid.20from.20file.20BPM.20value
