### PR TITLE
beat grid re-analyze strategy

### DIFF
--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -256,7 +256,7 @@ void AnalyzerBeats::storeResults(TrackPointer pTrack) {
         pBeats = BeatFactory::makeBeatGrid(m_iSampleRate, bpm, 0.0f);
     }
 
-    pTrack->trySetBeats(pBeats, false);
+    pTrack->trySetBeats(pBeats);
 }
 
 // static

--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -256,23 +256,7 @@ void AnalyzerBeats::storeResults(TrackPointer pTrack) {
         pBeats = BeatFactory::makeBeatGrid(m_iSampleRate, bpm, 0.0f);
     }
 
-    mixxx::BeatsPointer pCurrentBeats = pTrack->getBeats();
-
-    // If the track has no beats object then set our newly generated one
-    // regardless of beat lock.
-    if (!pCurrentBeats) {
-        pTrack->setBeats(pBeats);
-        return;
-    }
-
-    // If the track received the beat lock while we were analyzing it then we
-    // abort setting it.
-    if (pTrack->isBpmLocked()) {
-        qDebug() << "Track was BPM-locked as we were analyzing it. Aborting analysis.";
-        return;
-    }
-
-    pTrack->setBeats(pBeats);
+    pTrack->trySetBeats(pBeats, false);
 }
 
 // static

--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -165,14 +165,20 @@ bool AnalyzerBeats::shouldAnalyze(TrackPointer pTrack) const {
         qDebug() << "Re-analyzing track with invalid BPM despite preference settings.";
         return true;
     }
-    if (pBeats->findNextBeat(0) <= 0.0) {
+
+    QString subVersion = pBeats->getSubVersion();
+    if (subVersion == mixxx::rekordboxconstants::beatsSubversion) {
+        return m_bPreferencesReanalyzeImported;
+    }
+
+    if (subVersion.isEmpty() && pBeats->findNextBeat(0) <= 0.0 &&
+            m_pluginId != mixxx::AnalyzerSoundTouchBeats::pluginInfo().id) {
+        // This happens if the beat grid was created from the metadata BPM value.
         qDebug() << "First beat is 0 for grid so analyzing track to find first beat.";
         return true;
     }
 
-    // Version check
     QString version = pBeats->getVersion();
-    QString subVersion = pBeats->getSubVersion();
     QHash<QString, QString> extraVersionInfo = getExtraVersionInfo(
             pluginID,
             m_bPreferencesFastAnalysis);
@@ -184,9 +190,7 @@ bool AnalyzerBeats::shouldAnalyze(TrackPointer pTrack) const {
             iMinBpm,
             iMaxBpm,
             extraVersionInfo);
-    if (subVersion == mixxx::rekordboxconstants::beatsSubversion) {
-        return m_bPreferencesReanalyzeImported;
-    }
+
     if (version == newVersion && subVersion == newSubVersion) {
         // If the version and settings have not changed then if the world is
         // sane, re-analyzing will do nothing.
@@ -268,25 +272,7 @@ void AnalyzerBeats::storeResults(TrackPointer pTrack) {
         return;
     }
 
-    // If the user prefers to replace old beatgrids with newly generated ones or
-    // the old beatgrid has 0-bpm then we replace it.
-    bool zeroCurrentBpm = pCurrentBeats->getBpm() == 0.0;
-    if (m_bPreferencesReanalyzeOldBpm || zeroCurrentBpm) {
-        if (zeroCurrentBpm) {
-            qDebug() << "Replacing 0-BPM beatgrid with a" << pBeats->getBpm()
-                     << "beatgrid.";
-        }
-        pTrack->setBeats(pBeats);
-        return;
-    }
-
-    // If we got here then the user doesn't want to replace the beatgrid but
-    // since the first beat is zero we'll apply the offset we just detected.
-    double currentFirstBeat = pCurrentBeats->findNextBeat(0);
-    double newFirstBeat = pBeats->findNextBeat(0);
-    if (currentFirstBeat == 0.0 && newFirstBeat > 0) {
-        pTrack->setBeats(pCurrentBeats->translate(newFirstBeat));
-    }
+    pTrack->setBeats(pBeats);
 }
 
 // static

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -172,7 +172,7 @@ void BpmControl::slotAdjustBeatsFaster(double v) {
     if (pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM)) {
         double bpm = pBeats->getBpm();
         double adjustedBpm = bpm + kBpmAdjustStep;
-        pTrack->trySetBeats(pBeats->setBpm(adjustedBpm), false);
+        pTrack->trySetBeats(pBeats->setBpm(adjustedBpm));
     }
 }
 
@@ -188,7 +188,7 @@ void BpmControl::slotAdjustBeatsSlower(double v) {
     if (pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM)) {
         double bpm = pBeats->getBpm();
         double adjustedBpm = math_max(kBpmAdjustMin, bpm - kBpmAdjustStep);
-        pTrack->trySetBeats(pBeats->setBpm(adjustedBpm), false);
+        pTrack->trySetBeats(pBeats->setBpm(adjustedBpm));
     }
 }
 
@@ -204,7 +204,7 @@ void BpmControl::slotTranslateBeatsEarlier(double v) {
     if (pBeats &&
             (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
         const double translate_dist = getSampleOfTrack().rate * -.01;
-        pTrack->trySetBeats(pBeats->translate(translate_dist), false);
+        pTrack->trySetBeats(pBeats->translate(translate_dist));
     }
 }
 
@@ -221,7 +221,7 @@ void BpmControl::slotTranslateBeatsLater(double v) {
             (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
         // TODO(rryan): Track::getSampleRate is possibly inaccurate!
         const double translate_dist = getSampleOfTrack().rate * .01;
-        pTrack->trySetBeats(pBeats->translate(translate_dist), false);
+        pTrack->trySetBeats(pBeats->translate(translate_dist));
     }
 }
 
@@ -255,7 +255,7 @@ void BpmControl::slotTapFilter(double averageLength, int numSamples) {
     // (60 seconds per minute) * (1000 milliseconds per second) / (X millis per
     // beat) = Y beats/minute
     double averageBpm = 60.0 * 1000.0 / averageLength / rateRatio;
-    pTrack->trySetBeats(pBeats->setBpm(averageBpm), false);
+    pTrack->trySetBeats(pBeats->setBpm(averageBpm));
 }
 
 void BpmControl::slotControlBeatSyncPhase(double value) {
@@ -1020,7 +1020,7 @@ void BpmControl::slotBeatsTranslate(double v) {
         if (delta % 2 != 0) {
             delta--;
         }
-        pTrack->trySetBeats(pBeats->translate(delta), false);
+        pTrack->trySetBeats(pBeats->translate(delta));
     }
 }
 
@@ -1039,7 +1039,7 @@ void BpmControl::slotBeatsTranslateMatchAlignment(double v) {
         m_dUserOffset.setValue(0.0);
 
         double offset = getPhaseOffset(getSampleOfTrack().current);
-        pTrack->trySetBeats(pBeats->translate(-offset), false);
+        pTrack->trySetBeats(pBeats->translate(-offset));
     }
 }
 

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -172,7 +172,7 @@ void BpmControl::slotAdjustBeatsFaster(double v) {
     if (pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM)) {
         double bpm = pBeats->getBpm();
         double adjustedBpm = bpm + kBpmAdjustStep;
-        pTrack->setBeats(pBeats->setBpm(adjustedBpm));
+        pTrack->trySetBeats(pBeats->setBpm(adjustedBpm), false);
     }
 }
 
@@ -188,7 +188,7 @@ void BpmControl::slotAdjustBeatsSlower(double v) {
     if (pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM)) {
         double bpm = pBeats->getBpm();
         double adjustedBpm = math_max(kBpmAdjustMin, bpm - kBpmAdjustStep);
-        pTrack->setBeats(pBeats->setBpm(adjustedBpm));
+        pTrack->trySetBeats(pBeats->setBpm(adjustedBpm), false);
     }
 }
 
@@ -204,7 +204,7 @@ void BpmControl::slotTranslateBeatsEarlier(double v) {
     if (pBeats &&
             (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
         const double translate_dist = getSampleOfTrack().rate * -.01;
-        pTrack->setBeats(pBeats->translate(translate_dist));
+        pTrack->trySetBeats(pBeats->translate(translate_dist), false);
     }
 }
 
@@ -221,7 +221,7 @@ void BpmControl::slotTranslateBeatsLater(double v) {
             (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
         // TODO(rryan): Track::getSampleRate is possibly inaccurate!
         const double translate_dist = getSampleOfTrack().rate * .01;
-        pTrack->setBeats(pBeats->translate(translate_dist));
+        pTrack->trySetBeats(pBeats->translate(translate_dist), false);
     }
 }
 
@@ -255,7 +255,7 @@ void BpmControl::slotTapFilter(double averageLength, int numSamples) {
     // (60 seconds per minute) * (1000 milliseconds per second) / (X millis per
     // beat) = Y beats/minute
     double averageBpm = 60.0 * 1000.0 / averageLength / rateRatio;
-    pTrack->setBeats(pBeats->setBpm(averageBpm));
+    pTrack->trySetBeats(pBeats->setBpm(averageBpm), false);
 }
 
 void BpmControl::slotControlBeatSyncPhase(double value) {
@@ -1020,7 +1020,7 @@ void BpmControl::slotBeatsTranslate(double v) {
         if (delta % 2 != 0) {
             delta--;
         }
-        pTrack->setBeats(pBeats->translate(delta));
+        pTrack->trySetBeats(pBeats->translate(delta), false);
     }
 }
 
@@ -1039,7 +1039,7 @@ void BpmControl::slotBeatsTranslateMatchAlignment(double v) {
         m_dUserOffset.setValue(0.0);
 
         double offset = getPhaseOffset(getSampleOfTrack().current);
-        pTrack->setBeats(pBeats->translate(-offset));
+        pTrack->trySetBeats(pBeats->translate(-offset), false);
     }
 }
 

--- a/src/library/banshee/bansheeplaylistmodel.cpp
+++ b/src/library/banshee/bansheeplaylistmodel.cpp
@@ -287,7 +287,7 @@ TrackPointer BansheePlaylistModel::getTrack(const QModelIndex& index) const {
         pTrack->setRating(getFieldString(index, CLM_RATING).toInt());
         pTrack->setTrackNumber(getFieldString(index, CLM_TRACKNUMBER));
         double bpm = getFieldString(index, CLM_BPM).toDouble();
-        bpm = pTrack->setBpm(bpm);
+        pTrack->trySetBpm(bpm, false);
         pTrack->setBitrate(getFieldString(index, CLM_BITRATE).toInt());
         pTrack->setComment(getFieldString(index, CLM_COMMENT));
         pTrack->setComposer(getFieldString(index, CLM_COMPOSER));

--- a/src/library/banshee/bansheeplaylistmodel.cpp
+++ b/src/library/banshee/bansheeplaylistmodel.cpp
@@ -287,7 +287,7 @@ TrackPointer BansheePlaylistModel::getTrack(const QModelIndex& index) const {
         pTrack->setRating(getFieldString(index, CLM_RATING).toInt());
         pTrack->setTrackNumber(getFieldString(index, CLM_TRACKNUMBER));
         double bpm = getFieldString(index, CLM_BPM).toDouble();
-        pTrack->trySetBpm(bpm, false);
+        pTrack->trySetBpm(bpm);
         pTrack->setBitrate(getFieldString(index, CLM_BITRATE).toInt());
         pTrack->setComment(getFieldString(index, CLM_COMMENT));
         pTrack->setComposer(getFieldString(index, CLM_COMPOSER));

--- a/src/library/baseexternalplaylistmodel.cpp
+++ b/src/library/baseexternalplaylistmodel.cpp
@@ -65,7 +65,7 @@ TrackPointer BaseExternalPlaylistModel::getTrack(const QModelIndex& index) const
 
         float bpm = index.sibling(
                 index.row(), fieldIndex("bpm")).data().toString().toFloat();
-        pTrack->trySetBpm(bpm, false);
+        pTrack->trySetBpm(bpm);
     }
     return pTrack;
 }

--- a/src/library/baseexternalplaylistmodel.cpp
+++ b/src/library/baseexternalplaylistmodel.cpp
@@ -65,7 +65,7 @@ TrackPointer BaseExternalPlaylistModel::getTrack(const QModelIndex& index) const
 
         float bpm = index.sibling(
                 index.row(), fieldIndex("bpm")).data().toString().toFloat();
-        pTrack->setBpm(bpm);
+        pTrack->trySetBpm(bpm, false);
     }
     return pTrack;
 }

--- a/src/library/baseexternaltrackmodel.cpp
+++ b/src/library/baseexternaltrackmodel.cpp
@@ -74,7 +74,7 @@ TrackPointer BaseExternalTrackModel::getTrack(const QModelIndex& index) const {
             pTrack->setAlbum(album);
             pTrack->setYear(year);
             pTrack->setGenre(genre);
-            pTrack->trySetBpm(bpm, false);
+            pTrack->trySetBpm(bpm);
         }
     } else {
         qWarning() << "Failed to load external track" << location;

--- a/src/library/baseexternaltrackmodel.cpp
+++ b/src/library/baseexternaltrackmodel.cpp
@@ -74,7 +74,7 @@ TrackPointer BaseExternalTrackModel::getTrack(const QModelIndex& index) const {
             pTrack->setAlbum(album);
             pTrack->setYear(year);
             pTrack->setGenre(genre);
-            pTrack->setBpm(bpm);
+            pTrack->trySetBpm(bpm, false);
         }
     } else {
         qWarning() << "Failed to load external track" << location;

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -702,7 +702,7 @@ bool BaseSqlTableModel::setTrackValueForColumn(
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COMMENT) == column) {
         pTrack->setComment(value.toString());
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM) == column) {
-        pTrack->trySetBpm(static_cast<double>(value.toDouble()), false);
+        pTrack->trySetBpm(static_cast<double>(value.toDouble()));
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_PLAYED) == column) {
         // Update both the played flag and the number of times played
         pTrack->updatePlayCounter(value.toBool());

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -702,7 +702,7 @@ bool BaseSqlTableModel::setTrackValueForColumn(
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COMMENT) == column) {
         pTrack->setComment(value.toString());
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM) == column) {
-        pTrack->setBpm(static_cast<double>(value.toDouble()));
+        pTrack->trySetBpm(static_cast<double>(value.toDouble()), false);
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_PLAYED) == column) {
         // Update both the played flag and the number of times played
         pTrack->updatePlayCounter(value.toBool());

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -397,7 +397,7 @@ bool BrowseTableModel::setData(
         pTrack->setAlbum(value.toString());
         break;
     case COLUMN_BPM:
-        pTrack->trySetBpm(value.toDouble(), false);
+        pTrack->trySetBpm(value.toDouble());
         break;
     case COLUMN_KEY:
         pTrack->setKeyText(value.toString());

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -397,7 +397,7 @@ bool BrowseTableModel::setData(
         pTrack->setAlbum(value.toString());
         break;
     case COLUMN_BPM:
-        pTrack->setBpm(value.toDouble());
+        pTrack->trySetBpm(value.toDouble(), false);
         break;
     case COLUMN_KEY:
         pTrack->setKeyText(value.toString());

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1092,7 +1092,9 @@ bool setTrackBeats(const QSqlRecord& record, const int column,
     if (pBeats) {
         pTrack->trySetBeats(pBeats, bpmLocked);
     } else {
-        pTrack->trySetBpm(bpm, bpmLocked);
+        // Load a temorary beat grid without offset that will be replaced by the analyzer.
+        const auto pBeats = BeatFactory::makeBeatGrid(pTrack->getSampleRate(), bpm, 0.0);
+        pTrack->trySetBeats(pBeats, false);
     }
     return false;
 }

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1090,11 +1090,10 @@ bool setTrackBeats(const QSqlRecord& record, const int column,
     const mixxx::BeatsPointer pBeats = BeatFactory::loadBeatsFromByteArray(
             pTrack->getSampleRate(), beatsVersion, beatsSubVersion, beatsBlob);
     if (pBeats) {
-        pTrack->setBeats(pBeats);
+        pTrack->trySetBeats(pBeats, bpmLocked);
     } else {
-        pTrack->setBpm(bpm);
+        pTrack->trySetBpm(bpm, bpmLocked);
     }
-    pTrack->setBpmLocked(bpmLocked);
     return false;
 }
 

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1090,11 +1090,15 @@ bool setTrackBeats(const QSqlRecord& record, const int column,
     const mixxx::BeatsPointer pBeats = BeatFactory::loadBeatsFromByteArray(
             pTrack->getSampleRate(), beatsVersion, beatsSubVersion, beatsBlob);
     if (pBeats) {
-        pTrack->trySetBeats(pBeats, bpmLocked);
+        if (bpmLocked) {
+            pTrack->trySetAndLockBeats(pBeats);
+        } else {
+            pTrack->trySetBeats(pBeats);
+        }
     } else {
         // Load a temorary beat grid without offset that will be replaced by the analyzer.
         const auto pBeats = BeatFactory::makeBeatGrid(pTrack->getSampleRate(), bpm, 0.0);
-        pTrack->trySetBeats(pBeats, false);
+        pTrack->trySetBeats(pBeats);
     }
     return false;
 }

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -396,10 +396,8 @@ void DlgTrackInfo::saveTrack() {
     m_pLoadedTrack->setTrackNumber(txtTrackNumber->text());
     m_pLoadedTrack->setComment(txtComment->toPlainText());
 
-    if (!m_pLoadedTrack->isBpmLocked()) {
-        m_pLoadedTrack->setBeats(m_pBeatsClone);
-        reloadTrackBeats(*m_pLoadedTrack);
-    }
+    m_pLoadedTrack->trySetBeats(m_pBeatsClone, false);
+    reloadTrackBeats(*m_pLoadedTrack);
 
     // If the user is editing the key and hits enter to close DlgTrackInfo, the
     // editingFinished signal will not fire in time. Run the key text changed

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -396,7 +396,7 @@ void DlgTrackInfo::saveTrack() {
     m_pLoadedTrack->setTrackNumber(txtTrackNumber->text());
     m_pLoadedTrack->setComment(txtComment->toPlainText());
 
-    m_pLoadedTrack->trySetBeats(m_pBeatsClone, false);
+    m_pLoadedTrack->trySetBeats(m_pBeatsClone);
     reloadTrackBeats(*m_pLoadedTrack);
 
     // If the user is editing the key and hits enter to close DlgTrackInfo, the

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -870,7 +870,7 @@ void readAnalyze(TrackPointer track,
                     static_cast<SINT>(sampleRate),
                     mixxx::rekordboxconstants::beatsSubversion,
                     beats);
-            track->trySetBeats(pBeats, false);
+            track->trySetBeats(pBeats);
         } break;
         case rekordbox_anlz_t::SECTION_TAGS_CUES: {
             if (ignoreCues) {

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -870,7 +870,7 @@ void readAnalyze(TrackPointer track,
                     static_cast<SINT>(sampleRate),
                     mixxx::rekordboxconstants::beatsSubversion,
                     beats);
-            track->setBeats(pBeats);
+            track->trySetBeats(pBeats, false);
         } break;
         case rekordbox_anlz_t::SECTION_TAGS_CUES: {
             if (ignoreCues) {

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -209,7 +209,7 @@ TrackPointer BaseTrackPlayerImpl::loadFakeTrack(bool bPlay, double filebpm) {
             mixxx::audio::Bitrate(),
             mixxx::Duration::fromSeconds(10));
     if (filebpm > 0) {
-        pTrack->trySetBpm(filebpm, false);
+        pTrack->trySetBpm(filebpm);
     }
 
     TrackPointer pOldTrack = m_pLoadedTrack;

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -209,7 +209,7 @@ TrackPointer BaseTrackPlayerImpl::loadFakeTrack(bool bPlay, double filebpm) {
             mixxx::audio::Bitrate(),
             mixxx::Duration::fromSeconds(10));
     if (filebpm > 0) {
-        pTrack->setBpm(filebpm);
+        pTrack->trySetBpm(filebpm, false);
     }
 
     TrackPointer pOldTrack = m_pLoadedTrack;

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -27,7 +27,7 @@ TEST(BeatGridTest, Scale) {
     TrackPointer pTrack = newTrack(sampleRate);
 
     double bpm = 60.0;
-    pTrack->setBpm(bpm);
+    pTrack->trySetBpm(bpm, false);
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(), QString(), bpm, 0);
 
@@ -57,7 +57,7 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat) {
 
     double bpm = 60.1;
     const int kFrameSize = 2;
-    pTrack->setBpm(bpm);
+    pTrack->trySetBpm(bpm, false);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(), QString(), bpm, 0);
@@ -91,7 +91,7 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
 
     double bpm = 60.1;
     const int kFrameSize = 2;
-    pTrack->setBpm(bpm);
+    pTrack->trySetBpm(bpm, false);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(), QString(), bpm, 0);
@@ -127,7 +127,7 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
 
     double bpm = 60.1;
     const int kFrameSize = 2;
-    pTrack->setBpm(bpm);
+    pTrack->trySetBpm(bpm, false);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(), QString(), bpm, 0);
@@ -163,7 +163,7 @@ TEST(BeatGridTest, TestNthBeatWhenNotOnBeat) {
 
     double bpm = 60.1;
     const int kFrameSize = 2;
-    pTrack->setBpm(bpm);
+    pTrack->trySetBpm(bpm, false);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(), QString(), bpm, 0);
@@ -195,13 +195,13 @@ TEST(BeatGridTest, FromMetadata) {
     TrackPointer pTrack = newTrack(sampleRate);
 
     double bpm = 60.1;
-    double echoBpm = pTrack->setBpm(bpm);
+    double echoBpm = pTrack->trySetBpm(bpm, false);
     EXPECT_DOUBLE_EQ(echoBpm, bpm);
 
     auto pBeats = pTrack->getBeats();
     EXPECT_DOUBLE_EQ(pBeats->getBpm(), bpm);
 
-    echoBpm = pTrack->setBpm(-60.1);
+    echoBpm = pTrack->trySetBpm(-60.1, false);
     EXPECT_DOUBLE_EQ(echoBpm, mixxx::Bpm::kValueUndefined);
 
     pBeats = pTrack->getBeats();

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -190,4 +190,22 @@ TEST(BeatGridTest, TestNthBeatWhenNotOnBeat) {
     EXPECT_NEAR(nextBeat, foundNextBeat, kMaxBeatError);
 }
 
+TEST(BeatGridTest, FromMetadata) {
+    int sampleRate = 44100;
+    TrackPointer pTrack = newTrack(sampleRate);
+
+    double bpm = 60.1;
+    double echoBpm = pTrack->setBpm(bpm);
+    EXPECT_DOUBLE_EQ(echoBpm, bpm);
+
+    auto pBeats = pTrack->getBeats();
+    EXPECT_DOUBLE_EQ(pBeats->getBpm(), bpm);
+
+    echoBpm = pTrack->setBpm(-60.1);
+    EXPECT_DOUBLE_EQ(echoBpm, mixxx::Bpm::kValueUndefined);
+
+    pBeats = pTrack->getBeats();
+    EXPECT_EQ(pBeats.isNull(), true);
+}
+
 }  // namespace

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -27,7 +27,7 @@ TEST(BeatGridTest, Scale) {
     TrackPointer pTrack = newTrack(sampleRate);
 
     double bpm = 60.0;
-    pTrack->trySetBpm(bpm, false);
+    pTrack->trySetBpm(bpm);
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(), QString(), bpm, 0);
 
@@ -57,7 +57,7 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat) {
 
     double bpm = 60.1;
     const int kFrameSize = 2;
-    pTrack->trySetBpm(bpm, false);
+    pTrack->trySetBpm(bpm);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(), QString(), bpm, 0);
@@ -91,7 +91,7 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
 
     double bpm = 60.1;
     const int kFrameSize = 2;
-    pTrack->trySetBpm(bpm, false);
+    pTrack->trySetBpm(bpm);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(), QString(), bpm, 0);
@@ -127,7 +127,7 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
 
     double bpm = 60.1;
     const int kFrameSize = 2;
-    pTrack->trySetBpm(bpm, false);
+    pTrack->trySetBpm(bpm);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(), QString(), bpm, 0);
@@ -163,7 +163,7 @@ TEST(BeatGridTest, TestNthBeatWhenNotOnBeat) {
 
     double bpm = 60.1;
     const int kFrameSize = 2;
-    pTrack->trySetBpm(bpm, false);
+    pTrack->trySetBpm(bpm);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(), QString(), bpm, 0);
@@ -195,13 +195,13 @@ TEST(BeatGridTest, FromMetadata) {
     TrackPointer pTrack = newTrack(sampleRate);
 
     double bpm = 60.1;
-    double echoBpm = pTrack->trySetBpm(bpm, false);
+    double echoBpm = pTrack->trySetBpm(bpm);
     EXPECT_DOUBLE_EQ(echoBpm, bpm);
 
     auto pBeats = pTrack->getBeats();
     EXPECT_DOUBLE_EQ(pBeats->getBpm(), bpm);
 
-    echoBpm = pTrack->trySetBpm(-60.1, false);
+    echoBpm = pTrack->trySetBpm(-60.1);
     EXPECT_DOUBLE_EQ(echoBpm, mixxx::Bpm::kValueUndefined);
 
     pBeats = pTrack->getBeats();

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -49,7 +49,7 @@ class BeatMapTest : public testing::Test {
 
 TEST_F(BeatMapTest, Scale) {
     const double bpm = 60.0;
-    m_pTrack->setBpm(bpm);
+    m_pTrack->trySetBpm(bpm, false);
     double beatLengthFrames = getBeatLengthFrames(bpm);
     double startOffsetFrames = 7;
     const int numBeats = 100;
@@ -79,7 +79,7 @@ TEST_F(BeatMapTest, Scale) {
 
 TEST_F(BeatMapTest, TestNthBeat) {
     const double bpm = 60.0;
-    m_pTrack->setBpm(bpm);
+    m_pTrack->trySetBpm(bpm, false);
     double beatLengthFrames = getBeatLengthFrames(bpm);
     double startOffsetFrames = 7;
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -111,7 +111,7 @@ TEST_F(BeatMapTest, TestNthBeat) {
 
 TEST_F(BeatMapTest, TestNthBeatWhenOnBeat) {
     const double bpm = 60.0;
-    m_pTrack->setBpm(bpm);
+    m_pTrack->trySetBpm(bpm, false);
     double beatLengthFrames = getBeatLengthFrames(bpm);
     double startOffsetFrames = 7;
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -148,7 +148,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat) {
 
 TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
     const double bpm = 60.0;
-    m_pTrack->setBpm(bpm);
+    m_pTrack->trySetBpm(bpm, false);
     double beatLengthFrames = getBeatLengthFrames(bpm);
     double startOffsetFrames = 7;
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -187,7 +187,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
 
 TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
     const double bpm = 60.0;
-    m_pTrack->setBpm(bpm);
+    m_pTrack->trySetBpm(bpm, false);
     double beatLengthFrames = getBeatLengthFrames(bpm);
     double startOffsetFrames = 7;
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -227,7 +227,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
 
 TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
     const double bpm = 60.0;
-    m_pTrack->setBpm(bpm);
+    m_pTrack->trySetBpm(bpm, false);
     double beatLengthFrames = getBeatLengthFrames(bpm);
     double startOffsetFrames = 7;
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -264,7 +264,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
 TEST_F(BeatMapTest, TestBpmAround) {
     const double filebpm = 60.0;
     double approx_beat_length = getBeatLengthSamples(filebpm);
-    m_pTrack->setBpm(filebpm);
+    m_pTrack->trySetBpm(filebpm, false);
     const int numBeats = 64;
 
     QVector<double> beats;

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -49,7 +49,7 @@ class BeatMapTest : public testing::Test {
 
 TEST_F(BeatMapTest, Scale) {
     const double bpm = 60.0;
-    m_pTrack->trySetBpm(bpm, false);
+    m_pTrack->trySetBpm(bpm);
     double beatLengthFrames = getBeatLengthFrames(bpm);
     double startOffsetFrames = 7;
     const int numBeats = 100;
@@ -79,7 +79,7 @@ TEST_F(BeatMapTest, Scale) {
 
 TEST_F(BeatMapTest, TestNthBeat) {
     const double bpm = 60.0;
-    m_pTrack->trySetBpm(bpm, false);
+    m_pTrack->trySetBpm(bpm);
     double beatLengthFrames = getBeatLengthFrames(bpm);
     double startOffsetFrames = 7;
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -111,7 +111,7 @@ TEST_F(BeatMapTest, TestNthBeat) {
 
 TEST_F(BeatMapTest, TestNthBeatWhenOnBeat) {
     const double bpm = 60.0;
-    m_pTrack->trySetBpm(bpm, false);
+    m_pTrack->trySetBpm(bpm);
     double beatLengthFrames = getBeatLengthFrames(bpm);
     double startOffsetFrames = 7;
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -148,7 +148,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat) {
 
 TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
     const double bpm = 60.0;
-    m_pTrack->trySetBpm(bpm, false);
+    m_pTrack->trySetBpm(bpm);
     double beatLengthFrames = getBeatLengthFrames(bpm);
     double startOffsetFrames = 7;
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -187,7 +187,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
 
 TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
     const double bpm = 60.0;
-    m_pTrack->trySetBpm(bpm, false);
+    m_pTrack->trySetBpm(bpm);
     double beatLengthFrames = getBeatLengthFrames(bpm);
     double startOffsetFrames = 7;
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -227,7 +227,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
 
 TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
     const double bpm = 60.0;
-    m_pTrack->trySetBpm(bpm, false);
+    m_pTrack->trySetBpm(bpm);
     double beatLengthFrames = getBeatLengthFrames(bpm);
     double startOffsetFrames = 7;
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -264,7 +264,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
 TEST_F(BeatMapTest, TestBpmAround) {
     const double filebpm = 60.0;
     double approx_beat_length = getBeatLengthSamples(filebpm);
-    m_pTrack->trySetBpm(filebpm, false);
+    m_pTrack->trySetBpm(filebpm);
     const int numBeats = 64;
 
     QVector<double> beats;

--- a/src/test/beatstranslatetest.cpp
+++ b/src/test/beatstranslatetest.cpp
@@ -11,12 +11,12 @@ TEST_F(BeatsTranslateTest, SimpleTranslateMatch) {
     const double firstBeat = 0.0;
     auto grid1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), QString(), bpm, firstBeat);
-    m_pTrack1->trySetBeats(grid1, false);
+    m_pTrack1->trySetBeats(grid1);
     ASSERT_DOUBLE_EQ(firstBeat, grid1->findClosestBeat(0));
 
     auto grid2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), QString(), bpm, firstBeat);
-    m_pTrack2->trySetBeats(grid2, false);
+    m_pTrack2->trySetBeats(grid2);
     ASSERT_DOUBLE_EQ(firstBeat, grid2->findClosestBeat(0));
 
     // Seek deck 1 forward a bit.

--- a/src/test/beatstranslatetest.cpp
+++ b/src/test/beatstranslatetest.cpp
@@ -11,12 +11,12 @@ TEST_F(BeatsTranslateTest, SimpleTranslateMatch) {
     const double firstBeat = 0.0;
     auto grid1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), QString(), bpm, firstBeat);
-    m_pTrack1->setBeats(mixxx::BeatsPointer(grid1));
+    m_pTrack1->trySetBeats(grid1, false);
     ASSERT_DOUBLE_EQ(firstBeat, grid1->findClosestBeat(0));
 
     auto grid2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), QString(), bpm, firstBeat);
-    m_pTrack2->setBeats(mixxx::BeatsPointer(grid2));
+    m_pTrack2->trySetBeats(grid2, false);
     ASSERT_DOUBLE_EQ(firstBeat, grid2->findClosestBeat(0));
 
     // Seek deck 1 forward a bit.

--- a/src/test/cuecontrol_test.cpp
+++ b/src/test/cuecontrol_test.cpp
@@ -169,7 +169,7 @@ TEST_F(CueControlTest, LoadAutodetectedCues_QuantizeEnabled) {
     m_pQuantizeEnabled->set(1);
 
     TrackPointer pTrack = createTestTrack();
-    pTrack->trySetBpm(120.0, false);
+    pTrack->trySetBpm(120.0);
 
     const int frameSize = 2;
     const int sampleRate = pTrack->getSampleRate();
@@ -201,7 +201,7 @@ TEST_F(CueControlTest, LoadAutodetectedCues_QuantizeEnabledNoBeats) {
     m_pQuantizeEnabled->set(1);
 
     TrackPointer pTrack = createTestTrack();
-    pTrack->trySetBpm(0.0, false);
+    pTrack->trySetBpm(0.0);
 
     pTrack->setCuePoint(CuePosition(100.0));
 
@@ -228,7 +228,7 @@ TEST_F(CueControlTest, LoadAutodetectedCues_QuantizeDisabled) {
     m_pQuantizeEnabled->set(0);
 
     TrackPointer pTrack = createTestTrack();
-    pTrack->trySetBpm(120.0, false);
+    pTrack->trySetBpm(120.0);
 
     pTrack->setCuePoint(CuePosition(240.0));
 
@@ -333,7 +333,7 @@ TEST_F(CueControlTest, FollowCueOnQuantize) {
     config()->set(ConfigKey("[Controls]", "CueRecall"),
             ConfigValue(static_cast<int>(SeekOnLoadMode::MainCue)));
     TrackPointer pTrack = createTestTrack();
-    pTrack->trySetBpm(120.0, false);
+    pTrack->trySetBpm(120.0);
 
     const int frameSize = 2;
     const int sampleRate = pTrack->getSampleRate();

--- a/src/test/cuecontrol_test.cpp
+++ b/src/test/cuecontrol_test.cpp
@@ -169,7 +169,7 @@ TEST_F(CueControlTest, LoadAutodetectedCues_QuantizeEnabled) {
     m_pQuantizeEnabled->set(1);
 
     TrackPointer pTrack = createTestTrack();
-    pTrack->setBpm(120.0);
+    pTrack->trySetBpm(120.0, false);
 
     const int frameSize = 2;
     const int sampleRate = pTrack->getSampleRate();
@@ -201,7 +201,7 @@ TEST_F(CueControlTest, LoadAutodetectedCues_QuantizeEnabledNoBeats) {
     m_pQuantizeEnabled->set(1);
 
     TrackPointer pTrack = createTestTrack();
-    pTrack->setBpm(0.0);
+    pTrack->trySetBpm(0.0, false);
 
     pTrack->setCuePoint(CuePosition(100.0));
 
@@ -228,7 +228,7 @@ TEST_F(CueControlTest, LoadAutodetectedCues_QuantizeDisabled) {
     m_pQuantizeEnabled->set(0);
 
     TrackPointer pTrack = createTestTrack();
-    pTrack->setBpm(120.0);
+    pTrack->trySetBpm(120.0, false);
 
     pTrack->setCuePoint(CuePosition(240.0));
 
@@ -333,7 +333,7 @@ TEST_F(CueControlTest, FollowCueOnQuantize) {
     config()->set(ConfigKey("[Controls]", "CueRecall"),
             ConfigValue(static_cast<int>(SeekOnLoadMode::MainCue)));
     TrackPointer pTrack = createTestTrack();
-    pTrack->setBpm(120.0);
+    pTrack->trySetBpm(120.0, false);
 
     const int frameSize = 2;
     const int sampleRate = pTrack->getSampleRate();

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -194,9 +194,9 @@ TEST_F(EngineSyncTest, ExplicitMasterPersists) {
     // If we set an explicit master, enabling sync or pressing play on other decks
     // doesn't cause the master to move around.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 120, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 124, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
 
     auto pButtonMasterSync1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
@@ -226,11 +226,11 @@ TEST_F(EngineSyncTest, ExplicitMasterPersists) {
 TEST_F(EngineSyncTest, SetMasterWhilePlaying) {
     // Make sure we don't get two master lights if we change masters while playing.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 120, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 124, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
     mixxx::BeatsPointer pBeats3 = BeatFactory::makeBeatGrid(m_pTrack3->getSampleRate(), 128, 0.0);
-    m_pTrack3->setBeats(pBeats3);
+    m_pTrack3->trySetBeats(pBeats3, false);
 
     auto pButtonMasterSync1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
@@ -260,7 +260,7 @@ TEST_F(EngineSyncTest, SetMasterWhilePlaying) {
 TEST_F(EngineSyncTest, SetEnabledBecomesMaster) {
     // If we set the first channel with a valid tempo to follower, it should be master.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 80, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     auto pButtonMasterSync1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     pButtonMasterSync1->slotSet(SYNC_FOLLOWER);
@@ -287,10 +287,10 @@ TEST_F(EngineSyncTest, DisableInternalMasterWhilePlaying) {
 
     // Make sure both decks are playing.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 80, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 80, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
     ControlObject::getControl(ConfigKey(m_sGroup2, "play"))->set(1.0);
     ProcessBuffer();
 
@@ -306,13 +306,13 @@ TEST_F(EngineSyncTest, DisableInternalMasterWhilePlaying) {
 TEST_F(EngineSyncTest, DisableSyncOnMaster) {
     // Channel 1 follower, channel 2 master.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     auto pButtonSyncMode1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     pButtonSyncMode1->slotSet(SYNC_FOLLOWER);
 
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 130, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
     auto pButtonSyncMaster2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_master");
     pButtonSyncMaster2->slotSet(1.0);
@@ -344,7 +344,7 @@ TEST_F(EngineSyncTest, InternalMasterSetFollowerSliderMoves) {
 
     // Set the file bpm of channel 1 to 80 bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 80, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
 
     auto pButtonMasterSync1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
@@ -362,7 +362,7 @@ TEST_F(EngineSyncTest, AnySyncDeckSliderStays) {
     // master BPM if a new deck enables sync.
 
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 80, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     pButtonSyncEnabled1->set(1.0);
@@ -373,7 +373,7 @@ TEST_F(EngineSyncTest, AnySyncDeckSliderStays) {
                     ->get());
 
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 100, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     pButtonSyncEnabled2->set(1.0);
@@ -397,11 +397,11 @@ TEST_F(EngineSyncTest, InternalClockFollowsFirstPlayingDeck) {
 
     // Set up decks so they can be playing, and start deck 1.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 100, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 130, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup2, "play"), 0.0);
     ProcessBuffer();
@@ -467,10 +467,10 @@ TEST_F(EngineSyncTest, SetExplicitMasterByLights) {
 
     // Set the file bpm of channel 1 to 160bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     // Set the file bpm of channel 2 to 150bpm.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 150, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
 
     // Set channel 1 to be explicit master.
     pButtonSyncMaster1->slotSet(1.0);
@@ -553,7 +553,7 @@ TEST_F(EngineSyncTest, RateChangeTest) {
 
     // Set the file bpm of channel 1 to 160bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sGroup1, "file_bpm")));
     ProcessBuffer();
@@ -572,7 +572,7 @@ TEST_F(EngineSyncTest, RateChangeTest) {
 
     // Set the file bpm of channel 2 to 120bpm.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 120, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
     EXPECT_DOUBLE_EQ(
             120.0, ControlObject::get(ConfigKey(m_sGroup2, "file_bpm")));
 
@@ -594,13 +594,13 @@ TEST_F(EngineSyncTest, RateChangeTestWeirdOrder) {
 
     // Set the file bpm of channel 1 to 160bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 120, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
 
     // Set the rate slider of channel 1 to 1.2.
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.2));
@@ -618,13 +618,13 @@ TEST_F(EngineSyncTest, RateChangeTestWeirdOrder) {
 TEST_F(EngineSyncTest, RateChangeTestOrder3) {
     // Set the file bpm of channel 1 to 160bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sGroup1, "file_bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 120, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
     EXPECT_DOUBLE_EQ(
             120.0, ControlObject::get(ConfigKey(m_sGroup2, "file_bpm")));
 
@@ -662,11 +662,11 @@ TEST_F(EngineSyncTest, FollowerRateChange) {
 
     // Set the file bpm of channel 1 to 160bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
 
     // Set the file bpm of channel 2 to 120bpm.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 120, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
 
     // Set the rate slider of channel 1 to 1.2.
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.2));
@@ -708,13 +708,13 @@ TEST_F(EngineSyncTest, InternalRateChangeTest) {
 
     // Set the file bpm of channel 1 to 160bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     EXPECT_DOUBLE_EQ(160.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "file_bpm"))->get());
 
     // Set the file bpm of channel 2 to 120bpm.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 120, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
     EXPECT_DOUBLE_EQ(120.0,
             ControlObject::getControl(ConfigKey(m_sGroup2, "file_bpm"))->get());
 
@@ -762,9 +762,9 @@ TEST_F(EngineSyncTest, InternalRateChangeTest) {
 TEST_F(EngineSyncTest, MasterStopSliderCheck) {
     // If the master is playing, and stop is pushed, the sliders should stay the same.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 120, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 128, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
 
     auto pButtonMasterSync1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
@@ -806,7 +806,7 @@ TEST_F(EngineSyncTest, EnableOneDeckInitsMaster) {
 
     // Set up the deck to play.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
             ->set(getRateSliderValue(1.0));
     ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->set(0.2);
@@ -833,7 +833,7 @@ TEST_F(EngineSyncTest, EnableOneDeckInitsMaster) {
 
     // Enable second deck, bpm and beat distance should still match original setting.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 140, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
     ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))
             ->set(getRateSliderValue(1.0));
     ControlObject::getControl(ConfigKey(m_sGroup2, "beat_distance"))->set(0.2);
@@ -860,7 +860,7 @@ TEST_F(EngineSyncTest, EnableOneDeckInitializesMaster) {
     // Enabling sync on a deck causes it to be master, and sets bpm and clock.
     // Set the deck to play.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
             ->set(getRateSliderValue(1.0));
     ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->set(0.2);
@@ -1049,7 +1049,7 @@ TEST_F(EngineSyncTest, EnableOneDeckSliderUpdates) {
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
 
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
             ->set(getRateSliderValue(1.0));
 
@@ -1076,11 +1076,11 @@ TEST_F(EngineSyncTest, SyncToNonSyncDeck) {
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
 
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     ProcessBuffer();
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 100, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
     ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))
             ->set(getRateSliderValue(1.0));
 
@@ -1159,11 +1159,11 @@ TEST_F(EngineSyncTest, MomentarySyncDependsOnPlayingStates) {
 
     // Set up decks so they can be playing, and start deck 1.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 100, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 130, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup2, "play"), 1.0);
     ProcessBuffer();
@@ -1232,7 +1232,7 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
     auto pButtonEject1 = std::make_unique<ControlProxy>(m_sGroup1, "eject");
 
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 120, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     pButtonSyncEnabled1->set(1.0);
     ProcessBuffer();
 
@@ -1257,7 +1257,7 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
     EXPECT_DOUBLE_EQ(128.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 135, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
     pButtonSyncEnabled2->set(1.0);
     ProcessBuffer();
 
@@ -1266,7 +1266,7 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
     ASSERT_TRUE(isFollower(m_sGroup2));
 
     pButtonEject1->set(1.0);
-    m_pTrack1->setBeats(mixxx::BeatsPointer());
+    m_pTrack1->trySetBeats(mixxx::BeatsPointer(), false);
     ProcessBuffer();
 
     ASSERT_TRUE(isFollower(m_sInternalClockGroup));
@@ -1277,21 +1277,21 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
 TEST_F(EngineSyncTest, FileBpmChangesDontAffectMaster) {
     // If filebpm changes, don't treat it like a rate change.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 100, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     pButtonSyncEnabled1->set(1.0);
     ProcessBuffer();
 
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 120, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     pButtonSyncEnabled2->set(1.0);
     ProcessBuffer();
 
     pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     EXPECT_DOUBLE_EQ(
             100.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 }
@@ -1303,7 +1303,7 @@ TEST_F(EngineSyncTest, ExplicitMasterPostProcessed) {
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     pButtonMasterSync1->slotSet(SYNC_MASTER_EXPLICIT);
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     ProcessBuffer();
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
     ProcessBuffer();
@@ -1317,7 +1317,7 @@ TEST_F(EngineSyncTest, ZeroBPMRateAdjustIgnored) {
     // If a track isn't loaded (0 bpm), but the deck has sync enabled,
     // don't pay attention to rate changes.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 0, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     pButtonSyncEnabled1->set(1.0);
@@ -1326,7 +1326,7 @@ TEST_F(EngineSyncTest, ZeroBPMRateAdjustIgnored) {
     ProcessBuffer();
 
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 120, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     pButtonSyncEnabled2->set(1.0);
@@ -1362,9 +1362,9 @@ TEST_F(EngineSyncTest, ZeroLatencyRateChangeNoQuant) {
     // Confirm that a rate change in an explicit master is instantly communicated
     // to followers.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 128, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 160, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
 
     // Make Channel2 master to weed out any channel ordering issues.
     ControlObject::getControl(ConfigKey(m_sGroup2, "sync_mode"))
@@ -1410,9 +1410,9 @@ TEST_F(EngineSyncTest, ZeroLatencyRateChangeQuant) {
     // Confirm that a rate change in an explicit master is instantly communicated
     // to followers.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 128, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 160, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
     ControlObject::getControl(ConfigKey(m_sGroup2, "quantize"))->set(1.0);
@@ -1461,9 +1461,9 @@ TEST_F(EngineSyncTest, ZeroLatencyRateDiffQuant) {
     // Confirm that a rate change in an explicit master is instantly communicated
     // to followers.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 128, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 160, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
 
     ControlObject::getControl(ConfigKey(m_sGroup2, "quantize"))->set(1.0);
 
@@ -1513,9 +1513,9 @@ TEST_F(EngineSyncTest, ZeroLatencyRateDiffQuant) {
 // This test exercises https://bugs.launchpad.net/mixxx/+bug/1884324
 TEST_F(EngineSyncTest, ActivatingSyncDoesNotCauseDrifting) {
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 150, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 150, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(0.0);
     ControlObject::getControl(ConfigKey(m_sGroup2, "quantize"))->set(1.0);
@@ -1557,9 +1557,9 @@ TEST_F(EngineSyncTest, ActivatingSyncDoesNotCauseDrifting) {
 
 TEST_F(EngineSyncTest, HalfDoubleBpmTest) {
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 70, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 140, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
     ControlObject::getControl(ConfigKey(m_sGroup2, "quantize"))->set(1.0);
@@ -1650,9 +1650,9 @@ TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
     // If a deck plays that had its multiplier set, we need to reset the
     // internal clock.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 80, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 175, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
             ->set(getRateSliderValue(1.0));
 
@@ -1753,9 +1753,9 @@ TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
 TEST_F(EngineSyncTest, HalfDoubleInternalClockTest) {
     // If we set the file_bpm CO's directly, the correct signals aren't fired.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 70, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 140, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
     ControlObject::getControl(ConfigKey(m_sGroup2, "quantize"))->set(1.0);
@@ -1791,13 +1791,13 @@ TEST_F(EngineSyncTest, HalfDoubleConsistency) {
     QVector<double> beats1 =
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
     auto pBeats1 = mixxx::BeatMap::makeBeatMap(m_pTrack1->getSampleRate(), QString(), beats1);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
 
     beatLengthFrames = 60.0 * 44100 / 145.0;
     QVector<double> beats2 =
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
     auto pBeats2 = mixxx::BeatMap::makeBeatMap(m_pTrack2->getSampleRate(), QString(), beats2);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
     ControlObject::getControl(ConfigKey(m_sGroup2, "sync_enabled"))->set(1);
@@ -1824,7 +1824,7 @@ TEST_F(EngineSyncTest, HalfDoubleConsistency) {
 TEST_F(EngineSyncTest, SetFileBpmUpdatesLocalBpm) {
     ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->set(0.2);
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     ASSERT_EQ(
             130.0, m_pEngineSync->getSyncableForGroup(m_sGroup1)->getBaseBpm());
 }
@@ -1836,14 +1836,14 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
 
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     ControlObject::set(ConfigKey(m_sGroup2, "rate_ratio"), 1.0);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 100, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
 
     // Set the sync deck playing with nothing else active.
     // Next Deck becomes master and the Master clock is set to 100 BPM
@@ -1926,7 +1926,7 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
     ControlObject::set(ConfigKey(m_sGroup3, "beat_distance"), 0.6);
     ControlObject::set(ConfigKey(m_sGroup2, "rate_ratio"), 1.0);
     mixxx::BeatsPointer pBeats3 = BeatFactory::makeBeatGrid(m_pTrack3->getSampleRate(), 140, 0.0);
-    m_pTrack3->setBeats(pBeats3);
+    m_pTrack3->trySetBeats(pBeats3, false);
     // This will sync to the first deck here and not the second (lp1784185)
     pButtonSyncEnabled3->set(1.0);
     ProcessBuffer();
@@ -1967,9 +1967,9 @@ TEST_F(EngineSyncTest, UserTweakBeatDistance) {
     // is used to reseed the master beat distance, make sure the user offset
     // is reset.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 128, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 128, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
     ControlObject::getControl(ConfigKey(m_sGroup2, "quantize"))->set(1.0);
@@ -2021,9 +2021,9 @@ TEST_F(EngineSyncTest, UserTweakPreservedInSeek) {
     const double kDivisibleBpm = 44100.0 / 344.0;
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
             m_pTrack1->getSampleRate(), kDivisibleBpm, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 130, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
 
     ControlObject::getControl(ConfigKey(m_sGroup2, "sync_enabled"))->set(1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "sync_enabled"))->set(1);
@@ -2095,12 +2095,12 @@ TEST_F(EngineSyncTest, UserTweakPreservedInSeek) {
 
 TEST_F(EngineSyncTest, MasterBpmNeverZero) {
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 128, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
 
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     pButtonSyncEnabled1->set(1.0);
 
-    m_pTrack1->setBeats(mixxx::BeatsPointer());
+    m_pTrack1->trySetBeats(mixxx::BeatsPointer(), false);
     EXPECT_EQ(128.0,
               ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))->get());
 }
@@ -2110,7 +2110,7 @@ TEST_F(EngineSyncTest, ZeroBpmNaturalRate) {
     // doesn't end up something crazy when sync is enabled..
     // Maybe the beatgrid ended up at zero also.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 0.0, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
 
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     pButtonSyncEnabled1->set(1.0);
@@ -2129,11 +2129,11 @@ TEST_F(EngineSyncTest, QuantizeImpliesSyncPhase) {
     auto pButtonBeatsyncPhase1 = std::make_unique<ControlProxy>(m_sGroup1, "beatsync_phase");
 
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
 
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 100, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
     ControlObject::set(ConfigKey(m_sGroup2, "play"), 1.0);
@@ -2222,7 +2222,7 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
     ControlObject::set(ConfigKey(m_sGroup1, "quantize"), 1.0);
 
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
     ProcessBuffer();
@@ -2243,7 +2243,7 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
     ProcessBuffer();
 
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
     ProcessBuffer();
@@ -2265,8 +2265,8 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
 TEST_F(EngineSyncTest, SyncWithoutBeatgrid) {
     // this tests bug lp1783020, notresetting rate when other deck has no beatgrid
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 128, 0.0);
-    m_pTrack1->setBeats(pBeats1);
-    m_pTrack2->setBeats(mixxx::BeatsPointer());
+    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack2->trySetBeats(mixxx::BeatsPointer(), false);
 
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), 0.5);
 
@@ -2284,12 +2284,12 @@ TEST_F(EngineSyncTest, SyncWithoutBeatgrid) {
 
 TEST_F(EngineSyncTest, QuantizeHotCueActivate) {
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
 
     auto pHotCue2Activate = std::make_unique<ControlProxy>(m_sGroup2, "hotcue_1_activate");
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 100, 0.0);
 
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
 
     ProcessBuffer();
 
@@ -2346,7 +2346,7 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
 
     // set beatgrid
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
     pButtonSyncEnabled1->set(1.0);
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
 
@@ -2378,7 +2378,7 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
 
     // Load a new beatgrid during playing, this happens when the analyser is finished
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 140, 0.0);
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
 
     ProcessBuffer();
 
@@ -2400,7 +2400,7 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
 
     // Load a new beatgrid again, this happens when the user adjusts the beatgrid
     mixxx::BeatsPointer pBeats2n = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 75, 0.0);
-    m_pTrack2->setBeats(pBeats2n);
+    m_pTrack2->trySetBeats(pBeats2n, false);
 
     ProcessBuffer();
 
@@ -2415,7 +2415,7 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
 TEST_F(EngineSyncTest, BeatMapQantizePlay) {
     // This test demonstates https://bugs.launchpad.net/mixxx/+bug/1874918
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 120, 0.0);
-    m_pTrack1->setBeats(pBeats1);
+    m_pTrack1->trySetBeats(pBeats1, false);
 
     constexpr int kSampleRate = 44100;
 
@@ -2424,7 +2424,7 @@ TEST_F(EngineSyncTest, BeatMapQantizePlay) {
             QString(),
             // Add two beats at 120 Bpm
             QVector<double>({kSampleRate / 2, kSampleRate}));
-    m_pTrack2->setBeats(pBeats2);
+    m_pTrack2->trySetBeats(pBeats2, false);
 
     ControlObject::set(ConfigKey(m_sGroup1, "quantize"), 1.0);
     ControlObject::set(ConfigKey(m_sGroup2, "quantize"), 1.0);

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -194,9 +194,9 @@ TEST_F(EngineSyncTest, ExplicitMasterPersists) {
     // If we set an explicit master, enabling sync or pressing play on other decks
     // doesn't cause the master to move around.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 120, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 124, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
 
     auto pButtonMasterSync1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
@@ -226,11 +226,11 @@ TEST_F(EngineSyncTest, ExplicitMasterPersists) {
 TEST_F(EngineSyncTest, SetMasterWhilePlaying) {
     // Make sure we don't get two master lights if we change masters while playing.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 120, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 124, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
     mixxx::BeatsPointer pBeats3 = BeatFactory::makeBeatGrid(m_pTrack3->getSampleRate(), 128, 0.0);
-    m_pTrack3->trySetBeats(pBeats3, false);
+    m_pTrack3->trySetBeats(pBeats3);
 
     auto pButtonMasterSync1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
@@ -260,7 +260,7 @@ TEST_F(EngineSyncTest, SetMasterWhilePlaying) {
 TEST_F(EngineSyncTest, SetEnabledBecomesMaster) {
     // If we set the first channel with a valid tempo to follower, it should be master.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 80, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     auto pButtonMasterSync1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     pButtonMasterSync1->slotSet(SYNC_FOLLOWER);
@@ -287,10 +287,10 @@ TEST_F(EngineSyncTest, DisableInternalMasterWhilePlaying) {
 
     // Make sure both decks are playing.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 80, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 80, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup2, "play"))->set(1.0);
     ProcessBuffer();
 
@@ -306,13 +306,13 @@ TEST_F(EngineSyncTest, DisableInternalMasterWhilePlaying) {
 TEST_F(EngineSyncTest, DisableSyncOnMaster) {
     // Channel 1 follower, channel 2 master.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     auto pButtonSyncMode1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     pButtonSyncMode1->slotSet(SYNC_FOLLOWER);
 
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 130, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
     auto pButtonSyncMaster2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_master");
     pButtonSyncMaster2->slotSet(1.0);
@@ -344,7 +344,7 @@ TEST_F(EngineSyncTest, InternalMasterSetFollowerSliderMoves) {
 
     // Set the file bpm of channel 1 to 80 bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 80, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
 
     auto pButtonMasterSync1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
@@ -362,7 +362,7 @@ TEST_F(EngineSyncTest, AnySyncDeckSliderStays) {
     // master BPM if a new deck enables sync.
 
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 80, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     pButtonSyncEnabled1->set(1.0);
@@ -373,7 +373,7 @@ TEST_F(EngineSyncTest, AnySyncDeckSliderStays) {
                     ->get());
 
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 100, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     pButtonSyncEnabled2->set(1.0);
@@ -397,11 +397,11 @@ TEST_F(EngineSyncTest, InternalClockFollowsFirstPlayingDeck) {
 
     // Set up decks so they can be playing, and start deck 1.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 100, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 130, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup2, "play"), 0.0);
     ProcessBuffer();
@@ -467,10 +467,10 @@ TEST_F(EngineSyncTest, SetExplicitMasterByLights) {
 
     // Set the file bpm of channel 1 to 160bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     // Set the file bpm of channel 2 to 150bpm.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 150, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
 
     // Set channel 1 to be explicit master.
     pButtonSyncMaster1->slotSet(1.0);
@@ -553,7 +553,7 @@ TEST_F(EngineSyncTest, RateChangeTest) {
 
     // Set the file bpm of channel 1 to 160bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sGroup1, "file_bpm")));
     ProcessBuffer();
@@ -572,7 +572,7 @@ TEST_F(EngineSyncTest, RateChangeTest) {
 
     // Set the file bpm of channel 2 to 120bpm.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 120, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
     EXPECT_DOUBLE_EQ(
             120.0, ControlObject::get(ConfigKey(m_sGroup2, "file_bpm")));
 
@@ -594,13 +594,13 @@ TEST_F(EngineSyncTest, RateChangeTestWeirdOrder) {
 
     // Set the file bpm of channel 1 to 160bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 120, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
 
     // Set the rate slider of channel 1 to 1.2.
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.2));
@@ -618,13 +618,13 @@ TEST_F(EngineSyncTest, RateChangeTestWeirdOrder) {
 TEST_F(EngineSyncTest, RateChangeTestOrder3) {
     // Set the file bpm of channel 1 to 160bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sGroup1, "file_bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 120, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
     EXPECT_DOUBLE_EQ(
             120.0, ControlObject::get(ConfigKey(m_sGroup2, "file_bpm")));
 
@@ -662,11 +662,11 @@ TEST_F(EngineSyncTest, FollowerRateChange) {
 
     // Set the file bpm of channel 1 to 160bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
 
     // Set the file bpm of channel 2 to 120bpm.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 120, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
 
     // Set the rate slider of channel 1 to 1.2.
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.2));
@@ -708,13 +708,13 @@ TEST_F(EngineSyncTest, InternalRateChangeTest) {
 
     // Set the file bpm of channel 1 to 160bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     EXPECT_DOUBLE_EQ(160.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "file_bpm"))->get());
 
     // Set the file bpm of channel 2 to 120bpm.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 120, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
     EXPECT_DOUBLE_EQ(120.0,
             ControlObject::getControl(ConfigKey(m_sGroup2, "file_bpm"))->get());
 
@@ -762,9 +762,9 @@ TEST_F(EngineSyncTest, InternalRateChangeTest) {
 TEST_F(EngineSyncTest, MasterStopSliderCheck) {
     // If the master is playing, and stop is pushed, the sliders should stay the same.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 120, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 128, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
 
     auto pButtonMasterSync1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
@@ -806,7 +806,7 @@ TEST_F(EngineSyncTest, EnableOneDeckInitsMaster) {
 
     // Set up the deck to play.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
             ->set(getRateSliderValue(1.0));
     ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->set(0.2);
@@ -833,7 +833,7 @@ TEST_F(EngineSyncTest, EnableOneDeckInitsMaster) {
 
     // Enable second deck, bpm and beat distance should still match original setting.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 140, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))
             ->set(getRateSliderValue(1.0));
     ControlObject::getControl(ConfigKey(m_sGroup2, "beat_distance"))->set(0.2);
@@ -860,7 +860,7 @@ TEST_F(EngineSyncTest, EnableOneDeckInitializesMaster) {
     // Enabling sync on a deck causes it to be master, and sets bpm and clock.
     // Set the deck to play.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
             ->set(getRateSliderValue(1.0));
     ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->set(0.2);
@@ -1049,7 +1049,7 @@ TEST_F(EngineSyncTest, EnableOneDeckSliderUpdates) {
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
 
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
             ->set(getRateSliderValue(1.0));
 
@@ -1076,11 +1076,11 @@ TEST_F(EngineSyncTest, SyncToNonSyncDeck) {
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
 
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     ProcessBuffer();
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 100, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))
             ->set(getRateSliderValue(1.0));
 
@@ -1159,11 +1159,11 @@ TEST_F(EngineSyncTest, MomentarySyncDependsOnPlayingStates) {
 
     // Set up decks so they can be playing, and start deck 1.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 100, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 130, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup2, "play"), 1.0);
     ProcessBuffer();
@@ -1232,7 +1232,7 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
     auto pButtonEject1 = std::make_unique<ControlProxy>(m_sGroup1, "eject");
 
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 120, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     pButtonSyncEnabled1->set(1.0);
     ProcessBuffer();
 
@@ -1257,7 +1257,7 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
     EXPECT_DOUBLE_EQ(128.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 135, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
     pButtonSyncEnabled2->set(1.0);
     ProcessBuffer();
 
@@ -1266,7 +1266,7 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
     ASSERT_TRUE(isFollower(m_sGroup2));
 
     pButtonEject1->set(1.0);
-    m_pTrack1->trySetBeats(mixxx::BeatsPointer(), false);
+    m_pTrack1->trySetBeats(mixxx::BeatsPointer());
     ProcessBuffer();
 
     ASSERT_TRUE(isFollower(m_sInternalClockGroup));
@@ -1277,21 +1277,21 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
 TEST_F(EngineSyncTest, FileBpmChangesDontAffectMaster) {
     // If filebpm changes, don't treat it like a rate change.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 100, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     pButtonSyncEnabled1->set(1.0);
     ProcessBuffer();
 
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 120, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     pButtonSyncEnabled2->set(1.0);
     ProcessBuffer();
 
     pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     EXPECT_DOUBLE_EQ(
             100.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 }
@@ -1303,7 +1303,7 @@ TEST_F(EngineSyncTest, ExplicitMasterPostProcessed) {
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     pButtonMasterSync1->slotSet(SYNC_MASTER_EXPLICIT);
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     ProcessBuffer();
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
     ProcessBuffer();
@@ -1317,7 +1317,7 @@ TEST_F(EngineSyncTest, ZeroBPMRateAdjustIgnored) {
     // If a track isn't loaded (0 bpm), but the deck has sync enabled,
     // don't pay attention to rate changes.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 0, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     pButtonSyncEnabled1->set(1.0);
@@ -1326,7 +1326,7 @@ TEST_F(EngineSyncTest, ZeroBPMRateAdjustIgnored) {
     ProcessBuffer();
 
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 120, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     pButtonSyncEnabled2->set(1.0);
@@ -1362,9 +1362,9 @@ TEST_F(EngineSyncTest, ZeroLatencyRateChangeNoQuant) {
     // Confirm that a rate change in an explicit master is instantly communicated
     // to followers.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 128, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 160, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
 
     // Make Channel2 master to weed out any channel ordering issues.
     ControlObject::getControl(ConfigKey(m_sGroup2, "sync_mode"))
@@ -1410,9 +1410,9 @@ TEST_F(EngineSyncTest, ZeroLatencyRateChangeQuant) {
     // Confirm that a rate change in an explicit master is instantly communicated
     // to followers.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 128, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 160, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
     ControlObject::getControl(ConfigKey(m_sGroup2, "quantize"))->set(1.0);
@@ -1461,9 +1461,9 @@ TEST_F(EngineSyncTest, ZeroLatencyRateDiffQuant) {
     // Confirm that a rate change in an explicit master is instantly communicated
     // to followers.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 128, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 160, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup2, "quantize"))->set(1.0);
 
@@ -1513,9 +1513,9 @@ TEST_F(EngineSyncTest, ZeroLatencyRateDiffQuant) {
 // This test exercises https://bugs.launchpad.net/mixxx/+bug/1884324
 TEST_F(EngineSyncTest, ActivatingSyncDoesNotCauseDrifting) {
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 150, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 150, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(0.0);
     ControlObject::getControl(ConfigKey(m_sGroup2, "quantize"))->set(1.0);
@@ -1557,9 +1557,9 @@ TEST_F(EngineSyncTest, ActivatingSyncDoesNotCauseDrifting) {
 
 TEST_F(EngineSyncTest, HalfDoubleBpmTest) {
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 70, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 140, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
     ControlObject::getControl(ConfigKey(m_sGroup2, "quantize"))->set(1.0);
@@ -1650,9 +1650,9 @@ TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
     // If a deck plays that had its multiplier set, we need to reset the
     // internal clock.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 80, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 175, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
             ->set(getRateSliderValue(1.0));
 
@@ -1753,9 +1753,9 @@ TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
 TEST_F(EngineSyncTest, HalfDoubleInternalClockTest) {
     // If we set the file_bpm CO's directly, the correct signals aren't fired.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 70, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 140, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
     ControlObject::getControl(ConfigKey(m_sGroup2, "quantize"))->set(1.0);
@@ -1791,13 +1791,13 @@ TEST_F(EngineSyncTest, HalfDoubleConsistency) {
     QVector<double> beats1 =
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
     auto pBeats1 = mixxx::BeatMap::makeBeatMap(m_pTrack1->getSampleRate(), QString(), beats1);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
 
     beatLengthFrames = 60.0 * 44100 / 145.0;
     QVector<double> beats2 =
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
     auto pBeats2 = mixxx::BeatMap::makeBeatMap(m_pTrack2->getSampleRate(), QString(), beats2);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
     ControlObject::getControl(ConfigKey(m_sGroup2, "sync_enabled"))->set(1);
@@ -1824,7 +1824,7 @@ TEST_F(EngineSyncTest, HalfDoubleConsistency) {
 TEST_F(EngineSyncTest, SetFileBpmUpdatesLocalBpm) {
     ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->set(0.2);
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     ASSERT_EQ(
             130.0, m_pEngineSync->getSyncableForGroup(m_sGroup1)->getBaseBpm());
 }
@@ -1836,14 +1836,14 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
 
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     ControlObject::set(ConfigKey(m_sGroup2, "rate_ratio"), 1.0);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 100, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
 
     // Set the sync deck playing with nothing else active.
     // Next Deck becomes master and the Master clock is set to 100 BPM
@@ -1926,7 +1926,7 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
     ControlObject::set(ConfigKey(m_sGroup3, "beat_distance"), 0.6);
     ControlObject::set(ConfigKey(m_sGroup2, "rate_ratio"), 1.0);
     mixxx::BeatsPointer pBeats3 = BeatFactory::makeBeatGrid(m_pTrack3->getSampleRate(), 140, 0.0);
-    m_pTrack3->trySetBeats(pBeats3, false);
+    m_pTrack3->trySetBeats(pBeats3);
     // This will sync to the first deck here and not the second (lp1784185)
     pButtonSyncEnabled3->set(1.0);
     ProcessBuffer();
@@ -1967,9 +1967,9 @@ TEST_F(EngineSyncTest, UserTweakBeatDistance) {
     // is used to reseed the master beat distance, make sure the user offset
     // is reset.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 128, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 128, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
     ControlObject::getControl(ConfigKey(m_sGroup2, "quantize"))->set(1.0);
@@ -2021,9 +2021,9 @@ TEST_F(EngineSyncTest, UserTweakPreservedInSeek) {
     const double kDivisibleBpm = 44100.0 / 344.0;
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
             m_pTrack1->getSampleRate(), kDivisibleBpm, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 130, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup2, "sync_enabled"))->set(1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "sync_enabled"))->set(1);
@@ -2095,12 +2095,12 @@ TEST_F(EngineSyncTest, UserTweakPreservedInSeek) {
 
 TEST_F(EngineSyncTest, MasterBpmNeverZero) {
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 128, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
 
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     pButtonSyncEnabled1->set(1.0);
 
-    m_pTrack1->trySetBeats(mixxx::BeatsPointer(), false);
+    m_pTrack1->trySetBeats(mixxx::BeatsPointer());
     EXPECT_EQ(128.0,
               ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))->get());
 }
@@ -2110,7 +2110,7 @@ TEST_F(EngineSyncTest, ZeroBpmNaturalRate) {
     // doesn't end up something crazy when sync is enabled..
     // Maybe the beatgrid ended up at zero also.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 0.0, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
 
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     pButtonSyncEnabled1->set(1.0);
@@ -2129,11 +2129,11 @@ TEST_F(EngineSyncTest, QuantizeImpliesSyncPhase) {
     auto pButtonBeatsyncPhase1 = std::make_unique<ControlProxy>(m_sGroup1, "beatsync_phase");
 
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
 
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 100, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
     ControlObject::set(ConfigKey(m_sGroup2, "play"), 1.0);
@@ -2222,7 +2222,7 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
     ControlObject::set(ConfigKey(m_sGroup1, "quantize"), 1.0);
 
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
     ProcessBuffer();
@@ -2243,7 +2243,7 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
     ProcessBuffer();
 
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
     ProcessBuffer();
@@ -2265,8 +2265,8 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
 TEST_F(EngineSyncTest, SyncWithoutBeatgrid) {
     // this tests bug lp1783020, notresetting rate when other deck has no beatgrid
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 128, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
-    m_pTrack2->trySetBeats(mixxx::BeatsPointer(), false);
+    m_pTrack1->trySetBeats(pBeats1);
+    m_pTrack2->trySetBeats(mixxx::BeatsPointer());
 
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), 0.5);
 
@@ -2284,12 +2284,12 @@ TEST_F(EngineSyncTest, SyncWithoutBeatgrid) {
 
 TEST_F(EngineSyncTest, QuantizeHotCueActivate) {
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
 
     auto pHotCue2Activate = std::make_unique<ControlProxy>(m_sGroup2, "hotcue_1_activate");
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 100, 0.0);
 
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
 
     ProcessBuffer();
 
@@ -2346,7 +2346,7 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
 
     // set beatgrid
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
     pButtonSyncEnabled1->set(1.0);
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
 
@@ -2378,7 +2378,7 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
 
     // Load a new beatgrid during playing, this happens when the analyser is finished
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 140, 0.0);
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
 
     ProcessBuffer();
 
@@ -2400,7 +2400,7 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
 
     // Load a new beatgrid again, this happens when the user adjusts the beatgrid
     mixxx::BeatsPointer pBeats2n = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 75, 0.0);
-    m_pTrack2->trySetBeats(pBeats2n, false);
+    m_pTrack2->trySetBeats(pBeats2n);
 
     ProcessBuffer();
 
@@ -2415,7 +2415,7 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
 TEST_F(EngineSyncTest, BeatMapQantizePlay) {
     // This test demonstates https://bugs.launchpad.net/mixxx/+bug/1874918
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 120, 0.0);
-    m_pTrack1->trySetBeats(pBeats1, false);
+    m_pTrack1->trySetBeats(pBeats1);
 
     constexpr int kSampleRate = 44100;
 
@@ -2424,7 +2424,7 @@ TEST_F(EngineSyncTest, BeatMapQantizePlay) {
             QString(),
             // Add two beats at 120 Bpm
             QVector<double>({kSampleRate / 2, kSampleRate}));
-    m_pTrack2->trySetBeats(pBeats2, false);
+    m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::set(ConfigKey(m_sGroup1, "quantize"), 1.0);
     ControlObject::set(ConfigKey(m_sGroup2, "quantize"), 1.0);

--- a/src/test/looping_control_test.cpp
+++ b/src/test/looping_control_test.cpp
@@ -276,7 +276,7 @@ TEST_F(LoopingControlTest, LoopOutButton_AdjustLoopOutPointInsideLoop) {
 }
 
 TEST_F(LoopingControlTest, LoopInOutButtons_QuantizeEnabled) {
-    m_pTrack1->setBpm(60.0);
+    m_pTrack1->trySetBpm(60.0, false);
     m_pQuantizeEnabled->set(1);
     seekToSampleAndProcess(500);
     m_pButtonLoopIn->set(1);
@@ -425,7 +425,7 @@ TEST_F(LoopingControlTest, LoopDoubleButton_IgnoresPastTrackEnd) {
 }
 
 TEST_F(LoopingControlTest, LoopDoubleButton_DoublesBeatloopSize) {
-    m_pTrack1->setBpm(120.0);
+    m_pTrack1->trySetBpm(120.0, false);
     m_pBeatLoopSize->set(16.0);
     m_pButtonBeatLoopActivate->set(1.0);
     m_pButtonBeatLoopActivate->set(0.0);
@@ -450,7 +450,7 @@ TEST_F(LoopingControlTest, LoopDoubleButton_DoesNotResizeManualLoop) {
 }
 
 TEST_F(LoopingControlTest, LoopDoubleButton_UpdatesNumberedBeatloopActivationControls) {
-    m_pTrack1->setBpm(120.0);
+    m_pTrack1->trySetBpm(120.0, false);
     m_pBeatLoopSize->set(2.0);
     m_pButtonBeatLoopActivate->set(1.0);
     m_pButtonBeatLoopActivate->set(0.0);
@@ -476,7 +476,7 @@ TEST_F(LoopingControlTest, LoopHalveButton_IgnoresTooSmall) {
 }
 
 TEST_F(LoopingControlTest, LoopHalveButton_HalvesBeatloopSize) {
-    m_pTrack1->setBpm(120.0);
+    m_pTrack1->trySetBpm(120.0, false);
     m_pBeatLoopSize->set(64.0);
     m_pButtonBeatLoopActivate->set(1.0);
     m_pButtonBeatLoopActivate->set(0.0);
@@ -501,7 +501,7 @@ TEST_F(LoopingControlTest, LoopHalveButton_DoesNotResizeManualLoop) {
 }
 
 TEST_F(LoopingControlTest, LoopHalveButton_UpdatesNumberedBeatloopActivationControls) {
-    m_pTrack1->setBpm(120.0);
+    m_pTrack1->trySetBpm(120.0, false);
     m_pBeatLoopSize->set(4.0);
     m_pButtonBeatLoopActivate->set(1.0);
     m_pButtonBeatLoopActivate->set(0.0);
@@ -515,7 +515,7 @@ TEST_F(LoopingControlTest, LoopHalveButton_UpdatesNumberedBeatloopActivationCont
 }
 
 TEST_F(LoopingControlTest, LoopMoveTest) {
-    m_pTrack1->setBpm(120);
+    m_pTrack1->trySetBpm(120, false);
     m_pLoopStartPoint->slotSet(0);
     m_pLoopEndPoint->slotSet(300);
     seekToSampleAndProcess(10);
@@ -585,7 +585,7 @@ TEST_F(LoopingControlTest, LoopResizeSeek) {
     // Disable quantize for this test
     m_pQuantizeEnabled->set(0.0);
 
-    m_pTrack1->setBpm(23520);
+    m_pTrack1->trySetBpm(23520, false);
     m_pLoopStartPoint->slotSet(0);
     m_pLoopEndPoint->slotSet(600);
     seekToSampleAndProcess(500);
@@ -626,7 +626,7 @@ TEST_F(LoopingControlTest, LoopResizeSeek) {
 }
 
 TEST_F(LoopingControlTest, BeatLoopSize_SetAndToggle) {
-    m_pTrack1->setBpm(120.0);
+    m_pTrack1->trySetBpm(120.0, false);
     // Setting beatloop_size should not activate a loop
     m_pBeatLoopSize->set(2.0);
     EXPECT_FALSE(m_pLoopEnabled->toBool());
@@ -652,7 +652,7 @@ TEST_F(LoopingControlTest, BeatLoopSize_SetWithoutTrackLoaded) {
 TEST_F(LoopingControlTest, BeatLoopSize_IgnoresPastTrackEnd) {
     // TODO: actually calculate that the beatloop would go beyond
     // the end of the track
-    m_pTrack1->setBpm(60.0);
+    m_pTrack1->trySetBpm(60.0, false);
     seekToSampleAndProcess(m_pTrackSamples->get() - 400);
     m_pBeatLoopSize->set(64.0);
     EXPECT_NE(64.0, m_pBeatLoopSize->get());
@@ -660,7 +660,7 @@ TEST_F(LoopingControlTest, BeatLoopSize_IgnoresPastTrackEnd) {
 }
 
 TEST_F(LoopingControlTest, BeatLoopSize_SetsNumberedControls) {
-    m_pTrack1->setBpm(120.0);
+    m_pTrack1->trySetBpm(120.0, false);
     m_pBeatLoopSize->set(2.0);
     m_pButtonBeatLoopActivate->set(1.0);
     m_pButtonBeatLoopActivate->set(0.0);
@@ -674,7 +674,7 @@ TEST_F(LoopingControlTest, BeatLoopSize_SetsNumberedControls) {
 }
 
 TEST_F(LoopingControlTest, BeatLoopSize_IsSetByNumberedControl) {
-    m_pTrack1->setBpm(120.0);
+    m_pTrack1->trySetBpm(120.0, false);
     m_pBeatLoopSize->set(4.0);
     m_pButtonBeatLoop2Activate->set(1.0);
     m_pButtonBeatLoop2Activate->set(0.0);
@@ -690,14 +690,14 @@ TEST_F(LoopingControlTest, BeatLoopSize_IsSetByNumberedControl) {
 }
 
 TEST_F(LoopingControlTest, BeatLoopSize_SetDoesNotStartLoop) {
-    m_pTrack1->setBpm(120.0);
+    m_pTrack1->trySetBpm(120.0, false);
     m_pBeatLoopSize->set(16.0);
     EXPECT_FALSE(m_pLoopEnabled->toBool());
 }
 
 TEST_F(LoopingControlTest, BeatLoopSize_ResizeKeepsStartPosition) {
     seekToSampleAndProcess(50);
-    m_pTrack1->setBpm(160.0);
+    m_pTrack1->trySetBpm(160.0, false);
     m_pBeatLoopSize->set(2.0);
     m_pButtonBeatLoopActivate->set(1.0);
     m_pButtonBeatLoopActivate->set(0.0);
@@ -713,7 +713,7 @@ TEST_F(LoopingControlTest, BeatLoopSize_ResizeKeepsStartPosition) {
 
 TEST_F(LoopingControlTest, BeatLoopSize_ValueChangeDoesNotActivateLoop) {
     seekToSampleAndProcess(50);
-    m_pTrack1->setBpm(160.0);
+    m_pTrack1->trySetBpm(160.0, false);
     m_pBeatLoopSize->set(2.0);
     m_pButtonBeatLoopActivate->set(1.0);
     m_pButtonBeatLoopActivate->set(0.0);
@@ -729,7 +729,7 @@ TEST_F(LoopingControlTest, BeatLoopSize_ValueChangeDoesNotActivateLoop) {
 
 TEST_F(LoopingControlTest, BeatLoopSize_ValueChangeResizesBeatLoop) {
     seekToSampleAndProcess(50);
-    m_pTrack1->setBpm(160.0);
+    m_pTrack1->trySetBpm(160.0, false);
     m_pBeatLoopSize->set(2.0);
     m_pButtonBeatLoopActivate->set(1.0);
     m_pButtonBeatLoopActivate->set(0.0);
@@ -753,7 +753,7 @@ TEST_F(LoopingControlTest, BeatLoopSize_ValueChangeResizesBeatLoop) {
 
 TEST_F(LoopingControlTest, BeatLoopSize_ValueChangeDoesNotResizeManualLoop) {
     seekToSampleAndProcess(50);
-    m_pTrack1->setBpm(160.0);
+    m_pTrack1->trySetBpm(160.0, false);
     m_pQuantizeEnabled->set(0);
     m_pBeatLoopSize->set(4.0);
     m_pButtonLoopIn->slotSet(1);
@@ -772,7 +772,7 @@ TEST_F(LoopingControlTest, BeatLoopSize_ValueChangeDoesNotResizeManualLoop) {
 }
 
 TEST_F(LoopingControlTest, LegacyBeatLoopControl) {
-    m_pTrack1->setBpm(120.0);
+    m_pTrack1->trySetBpm(120.0, false);
     m_pBeatLoop->set(2.0);
     EXPECT_TRUE(m_pBeatLoop2Enabled->toBool());
     EXPECT_TRUE(m_pLoopEnabled->toBool());
@@ -792,7 +792,7 @@ TEST_F(LoopingControlTest, LegacyBeatLoopControl) {
 }
 
 TEST_F(LoopingControlTest, Beatjump_JumpsByBeats) {
-    m_pTrack1->setBpm(120.0);
+    m_pTrack1->trySetBpm(120.0, false);
     ProcessBuffer();
 
     double beatLength = m_pNextBeat->get();
@@ -810,7 +810,7 @@ TEST_F(LoopingControlTest, Beatjump_JumpsByBeats) {
 }
 
 TEST_F(LoopingControlTest, Beatjump_MovesActiveLoop) {
-    m_pTrack1->setBpm(120.0);
+    m_pTrack1->trySetBpm(120.0, false);
     ProcessBuffer();
 
     m_pBeatLoopSize->set(4.0);
@@ -842,7 +842,7 @@ TEST_F(LoopingControlTest, Beatjump_MovesActiveLoop) {
 TEST_F(LoopingControlTest, Beatjump_MovesLoopBoundaries) {
     // Holding down the loop in/out buttons and using beatjump should
     // move only the loop in/out point, but not shift the entire loop forward/backward
-    m_pTrack1->setBpm(120.0);
+    m_pTrack1->trySetBpm(120.0, false);
     ProcessBuffer();
 
     m_pBeatLoopSize->set(4.0);
@@ -893,7 +893,7 @@ TEST_F(LoopingControlTest, LoopEscape) {
 }
 
 TEST_F(LoopingControlTest, BeatLoopRoll_Activation) {
-    m_pTrack1->setBpm(120.0);
+    m_pTrack1->trySetBpm(120.0, false);
 
     m_pButtonBeatLoopRoll2Activate->set(1.0);
     EXPECT_TRUE(m_pLoopEnabled->toBool());
@@ -905,7 +905,7 @@ TEST_F(LoopingControlTest, BeatLoopRoll_Activation) {
 }
 
 TEST_F(LoopingControlTest, BeatLoopRoll_Overlap) {
-    m_pTrack1->setBpm(120.0);
+    m_pTrack1->trySetBpm(120.0, false);
 
     m_pButtonBeatLoopRoll2Activate->set(1.0);
     EXPECT_TRUE(m_pLoopEnabled->toBool());
@@ -927,7 +927,7 @@ TEST_F(LoopingControlTest, BeatLoopRoll_Overlap) {
 }
 
 TEST_F(LoopingControlTest, BeatLoopRoll_OverlapStackUnwind) {
-    m_pTrack1->setBpm(120.0);
+    m_pTrack1->trySetBpm(120.0, false);
 
     // start a 2 beat loop roll
     m_pButtonBeatLoopRoll2Activate->set(1.0);
@@ -964,7 +964,7 @@ TEST_F(LoopingControlTest, BeatLoopRoll_OverlapStackUnwind) {
 }
 
 TEST_F(LoopingControlTest, BeatLoopRoll_StartPoint) {
-    m_pTrack1->setBpm(120.0);
+    m_pTrack1->trySetBpm(120.0, false);
 
     // start a 4 beat loop roll, start point should be overridden to play position
     m_pLoopStartPoint->slotSet(8);

--- a/src/test/looping_control_test.cpp
+++ b/src/test/looping_control_test.cpp
@@ -276,7 +276,7 @@ TEST_F(LoopingControlTest, LoopOutButton_AdjustLoopOutPointInsideLoop) {
 }
 
 TEST_F(LoopingControlTest, LoopInOutButtons_QuantizeEnabled) {
-    m_pTrack1->trySetBpm(60.0, false);
+    m_pTrack1->trySetBpm(60.0);
     m_pQuantizeEnabled->set(1);
     seekToSampleAndProcess(500);
     m_pButtonLoopIn->set(1);
@@ -425,7 +425,7 @@ TEST_F(LoopingControlTest, LoopDoubleButton_IgnoresPastTrackEnd) {
 }
 
 TEST_F(LoopingControlTest, LoopDoubleButton_DoublesBeatloopSize) {
-    m_pTrack1->trySetBpm(120.0, false);
+    m_pTrack1->trySetBpm(120.0);
     m_pBeatLoopSize->set(16.0);
     m_pButtonBeatLoopActivate->set(1.0);
     m_pButtonBeatLoopActivate->set(0.0);
@@ -450,7 +450,7 @@ TEST_F(LoopingControlTest, LoopDoubleButton_DoesNotResizeManualLoop) {
 }
 
 TEST_F(LoopingControlTest, LoopDoubleButton_UpdatesNumberedBeatloopActivationControls) {
-    m_pTrack1->trySetBpm(120.0, false);
+    m_pTrack1->trySetBpm(120.0);
     m_pBeatLoopSize->set(2.0);
     m_pButtonBeatLoopActivate->set(1.0);
     m_pButtonBeatLoopActivate->set(0.0);
@@ -476,7 +476,7 @@ TEST_F(LoopingControlTest, LoopHalveButton_IgnoresTooSmall) {
 }
 
 TEST_F(LoopingControlTest, LoopHalveButton_HalvesBeatloopSize) {
-    m_pTrack1->trySetBpm(120.0, false);
+    m_pTrack1->trySetBpm(120.0);
     m_pBeatLoopSize->set(64.0);
     m_pButtonBeatLoopActivate->set(1.0);
     m_pButtonBeatLoopActivate->set(0.0);
@@ -501,7 +501,7 @@ TEST_F(LoopingControlTest, LoopHalveButton_DoesNotResizeManualLoop) {
 }
 
 TEST_F(LoopingControlTest, LoopHalveButton_UpdatesNumberedBeatloopActivationControls) {
-    m_pTrack1->trySetBpm(120.0, false);
+    m_pTrack1->trySetBpm(120.0);
     m_pBeatLoopSize->set(4.0);
     m_pButtonBeatLoopActivate->set(1.0);
     m_pButtonBeatLoopActivate->set(0.0);
@@ -515,7 +515,7 @@ TEST_F(LoopingControlTest, LoopHalveButton_UpdatesNumberedBeatloopActivationCont
 }
 
 TEST_F(LoopingControlTest, LoopMoveTest) {
-    m_pTrack1->trySetBpm(120, false);
+    m_pTrack1->trySetBpm(120);
     m_pLoopStartPoint->slotSet(0);
     m_pLoopEndPoint->slotSet(300);
     seekToSampleAndProcess(10);
@@ -585,7 +585,7 @@ TEST_F(LoopingControlTest, LoopResizeSeek) {
     // Disable quantize for this test
     m_pQuantizeEnabled->set(0.0);
 
-    m_pTrack1->trySetBpm(23520, false);
+    m_pTrack1->trySetBpm(23520);
     m_pLoopStartPoint->slotSet(0);
     m_pLoopEndPoint->slotSet(600);
     seekToSampleAndProcess(500);
@@ -626,7 +626,7 @@ TEST_F(LoopingControlTest, LoopResizeSeek) {
 }
 
 TEST_F(LoopingControlTest, BeatLoopSize_SetAndToggle) {
-    m_pTrack1->trySetBpm(120.0, false);
+    m_pTrack1->trySetBpm(120.0);
     // Setting beatloop_size should not activate a loop
     m_pBeatLoopSize->set(2.0);
     EXPECT_FALSE(m_pLoopEnabled->toBool());
@@ -652,7 +652,7 @@ TEST_F(LoopingControlTest, BeatLoopSize_SetWithoutTrackLoaded) {
 TEST_F(LoopingControlTest, BeatLoopSize_IgnoresPastTrackEnd) {
     // TODO: actually calculate that the beatloop would go beyond
     // the end of the track
-    m_pTrack1->trySetBpm(60.0, false);
+    m_pTrack1->trySetBpm(60.0);
     seekToSampleAndProcess(m_pTrackSamples->get() - 400);
     m_pBeatLoopSize->set(64.0);
     EXPECT_NE(64.0, m_pBeatLoopSize->get());
@@ -660,7 +660,7 @@ TEST_F(LoopingControlTest, BeatLoopSize_IgnoresPastTrackEnd) {
 }
 
 TEST_F(LoopingControlTest, BeatLoopSize_SetsNumberedControls) {
-    m_pTrack1->trySetBpm(120.0, false);
+    m_pTrack1->trySetBpm(120.0);
     m_pBeatLoopSize->set(2.0);
     m_pButtonBeatLoopActivate->set(1.0);
     m_pButtonBeatLoopActivate->set(0.0);
@@ -674,7 +674,7 @@ TEST_F(LoopingControlTest, BeatLoopSize_SetsNumberedControls) {
 }
 
 TEST_F(LoopingControlTest, BeatLoopSize_IsSetByNumberedControl) {
-    m_pTrack1->trySetBpm(120.0, false);
+    m_pTrack1->trySetBpm(120.0);
     m_pBeatLoopSize->set(4.0);
     m_pButtonBeatLoop2Activate->set(1.0);
     m_pButtonBeatLoop2Activate->set(0.0);
@@ -690,14 +690,14 @@ TEST_F(LoopingControlTest, BeatLoopSize_IsSetByNumberedControl) {
 }
 
 TEST_F(LoopingControlTest, BeatLoopSize_SetDoesNotStartLoop) {
-    m_pTrack1->trySetBpm(120.0, false);
+    m_pTrack1->trySetBpm(120.0);
     m_pBeatLoopSize->set(16.0);
     EXPECT_FALSE(m_pLoopEnabled->toBool());
 }
 
 TEST_F(LoopingControlTest, BeatLoopSize_ResizeKeepsStartPosition) {
     seekToSampleAndProcess(50);
-    m_pTrack1->trySetBpm(160.0, false);
+    m_pTrack1->trySetBpm(160.0);
     m_pBeatLoopSize->set(2.0);
     m_pButtonBeatLoopActivate->set(1.0);
     m_pButtonBeatLoopActivate->set(0.0);
@@ -713,7 +713,7 @@ TEST_F(LoopingControlTest, BeatLoopSize_ResizeKeepsStartPosition) {
 
 TEST_F(LoopingControlTest, BeatLoopSize_ValueChangeDoesNotActivateLoop) {
     seekToSampleAndProcess(50);
-    m_pTrack1->trySetBpm(160.0, false);
+    m_pTrack1->trySetBpm(160.0);
     m_pBeatLoopSize->set(2.0);
     m_pButtonBeatLoopActivate->set(1.0);
     m_pButtonBeatLoopActivate->set(0.0);
@@ -729,7 +729,7 @@ TEST_F(LoopingControlTest, BeatLoopSize_ValueChangeDoesNotActivateLoop) {
 
 TEST_F(LoopingControlTest, BeatLoopSize_ValueChangeResizesBeatLoop) {
     seekToSampleAndProcess(50);
-    m_pTrack1->trySetBpm(160.0, false);
+    m_pTrack1->trySetBpm(160.0);
     m_pBeatLoopSize->set(2.0);
     m_pButtonBeatLoopActivate->set(1.0);
     m_pButtonBeatLoopActivate->set(0.0);
@@ -753,7 +753,7 @@ TEST_F(LoopingControlTest, BeatLoopSize_ValueChangeResizesBeatLoop) {
 
 TEST_F(LoopingControlTest, BeatLoopSize_ValueChangeDoesNotResizeManualLoop) {
     seekToSampleAndProcess(50);
-    m_pTrack1->trySetBpm(160.0, false);
+    m_pTrack1->trySetBpm(160.0);
     m_pQuantizeEnabled->set(0);
     m_pBeatLoopSize->set(4.0);
     m_pButtonLoopIn->slotSet(1);
@@ -772,7 +772,7 @@ TEST_F(LoopingControlTest, BeatLoopSize_ValueChangeDoesNotResizeManualLoop) {
 }
 
 TEST_F(LoopingControlTest, LegacyBeatLoopControl) {
-    m_pTrack1->trySetBpm(120.0, false);
+    m_pTrack1->trySetBpm(120.0);
     m_pBeatLoop->set(2.0);
     EXPECT_TRUE(m_pBeatLoop2Enabled->toBool());
     EXPECT_TRUE(m_pLoopEnabled->toBool());
@@ -792,7 +792,7 @@ TEST_F(LoopingControlTest, LegacyBeatLoopControl) {
 }
 
 TEST_F(LoopingControlTest, Beatjump_JumpsByBeats) {
-    m_pTrack1->trySetBpm(120.0, false);
+    m_pTrack1->trySetBpm(120.0);
     ProcessBuffer();
 
     double beatLength = m_pNextBeat->get();
@@ -810,7 +810,7 @@ TEST_F(LoopingControlTest, Beatjump_JumpsByBeats) {
 }
 
 TEST_F(LoopingControlTest, Beatjump_MovesActiveLoop) {
-    m_pTrack1->trySetBpm(120.0, false);
+    m_pTrack1->trySetBpm(120.0);
     ProcessBuffer();
 
     m_pBeatLoopSize->set(4.0);
@@ -842,7 +842,7 @@ TEST_F(LoopingControlTest, Beatjump_MovesActiveLoop) {
 TEST_F(LoopingControlTest, Beatjump_MovesLoopBoundaries) {
     // Holding down the loop in/out buttons and using beatjump should
     // move only the loop in/out point, but not shift the entire loop forward/backward
-    m_pTrack1->trySetBpm(120.0, false);
+    m_pTrack1->trySetBpm(120.0);
     ProcessBuffer();
 
     m_pBeatLoopSize->set(4.0);
@@ -893,7 +893,7 @@ TEST_F(LoopingControlTest, LoopEscape) {
 }
 
 TEST_F(LoopingControlTest, BeatLoopRoll_Activation) {
-    m_pTrack1->trySetBpm(120.0, false);
+    m_pTrack1->trySetBpm(120.0);
 
     m_pButtonBeatLoopRoll2Activate->set(1.0);
     EXPECT_TRUE(m_pLoopEnabled->toBool());
@@ -905,7 +905,7 @@ TEST_F(LoopingControlTest, BeatLoopRoll_Activation) {
 }
 
 TEST_F(LoopingControlTest, BeatLoopRoll_Overlap) {
-    m_pTrack1->trySetBpm(120.0, false);
+    m_pTrack1->trySetBpm(120.0);
 
     m_pButtonBeatLoopRoll2Activate->set(1.0);
     EXPECT_TRUE(m_pLoopEnabled->toBool());
@@ -927,7 +927,7 @@ TEST_F(LoopingControlTest, BeatLoopRoll_Overlap) {
 }
 
 TEST_F(LoopingControlTest, BeatLoopRoll_OverlapStackUnwind) {
-    m_pTrack1->trySetBpm(120.0, false);
+    m_pTrack1->trySetBpm(120.0);
 
     // start a 2 beat loop roll
     m_pButtonBeatLoopRoll2Activate->set(1.0);
@@ -964,7 +964,7 @@ TEST_F(LoopingControlTest, BeatLoopRoll_OverlapStackUnwind) {
 }
 
 TEST_F(LoopingControlTest, BeatLoopRoll_StartPoint) {
-    m_pTrack1->trySetBpm(120.0, false);
+    m_pTrack1->trySetBpm(120.0);
 
     // start a 4 beat loop roll, start point should be overridden to play position
     m_pLoopStartPoint->slotSet(8);

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -372,9 +372,9 @@ TEST_F(SearchQueryParserTest, NumericFilter) {
         m_parser.parseQuery("bpm:127.12", searchColumns, ""));
 
     TrackPointer pTrack = newTestTrack(44100);
-    pTrack->trySetBpm(127, false);
+    pTrack->trySetBpm(127);
     EXPECT_FALSE(pQuery->match(pTrack));
-    pTrack->trySetBpm(127.12, false);
+    pTrack->trySetBpm(127.12);
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
@@ -391,7 +391,7 @@ TEST_F(SearchQueryParserTest, NumericFilterEmpty) {
         m_parser.parseQuery("bpm:", searchColumns, ""));
 
     TrackPointer pTrack = newTestTrack(44100);
-    pTrack->trySetBpm(127, false);
+    pTrack->trySetBpm(127);
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
@@ -408,9 +408,9 @@ TEST_F(SearchQueryParserTest, NumericFilterNegation) {
         m_parser.parseQuery("-bpm:127.12", searchColumns, ""));
 
     TrackPointer pTrack = newTestTrack(44100);
-    pTrack->trySetBpm(127, false);
+    pTrack->trySetBpm(127);
     EXPECT_TRUE(pQuery->match(pTrack));
-    pTrack->trySetBpm(127.12, false);
+    pTrack->trySetBpm(127.12);
     EXPECT_FALSE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
@@ -427,9 +427,9 @@ TEST_F(SearchQueryParserTest, NumericFilterAllowsSpace) {
         m_parser.parseQuery("bpm: 127.12", searchColumns, ""));
 
     TrackPointer pTrack = newTestTrack(44100);
-    pTrack->trySetBpm(127, false);
+    pTrack->trySetBpm(127);
     EXPECT_FALSE(pQuery->match(pTrack));
-    pTrack->trySetBpm(127.12, false);
+    pTrack->trySetBpm(127.12);
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
@@ -446,9 +446,9 @@ TEST_F(SearchQueryParserTest, NumericFilterOperators) {
         m_parser.parseQuery("bpm:>127.12", searchColumns, ""));
 
     TrackPointer pTrack = newTestTrack(44100);
-    pTrack->trySetBpm(127.12, false);
+    pTrack->trySetBpm(127.12);
     EXPECT_FALSE(pQuery->match(pTrack));
-    pTrack->trySetBpm(127.13, false);
+    pTrack->trySetBpm(127.13);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
         qPrintable(QString("bpm > 127.12")),
@@ -456,27 +456,27 @@ TEST_F(SearchQueryParserTest, NumericFilterOperators) {
 
 
     pQuery = m_parser.parseQuery("bpm:>=127.12", searchColumns, "");
-    pTrack->trySetBpm(127.11, false);
+    pTrack->trySetBpm(127.11);
     EXPECT_FALSE(pQuery->match(pTrack));
-    pTrack->trySetBpm(127.12, false);
+    pTrack->trySetBpm(127.12);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
         qPrintable(QString("bpm >= 127.12")),
         qPrintable(pQuery->toSql()));
 
     pQuery = m_parser.parseQuery("bpm:<127.12", searchColumns, "");
-    pTrack->trySetBpm(127.12, false);
+    pTrack->trySetBpm(127.12);
     EXPECT_FALSE(pQuery->match(pTrack));
-    pTrack->trySetBpm(127.11, false);
+    pTrack->trySetBpm(127.11);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
         qPrintable(QString("bpm < 127.12")),
         qPrintable(pQuery->toSql()));
 
     pQuery = m_parser.parseQuery("bpm:<=127.12", searchColumns, "");
-    pTrack->trySetBpm(127.13, false);
+    pTrack->trySetBpm(127.13);
     EXPECT_FALSE(pQuery->match(pTrack));
-    pTrack->trySetBpm(127.12, false);
+    pTrack->trySetBpm(127.12);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
         qPrintable(QString("bpm <= 127.12")),
@@ -492,11 +492,11 @@ TEST_F(SearchQueryParserTest, NumericRangeFilter) {
         m_parser.parseQuery("bpm:127.12-129", searchColumns, ""));
 
     TrackPointer pTrack = newTestTrack(44100);
-    pTrack->trySetBpm(125, false);
+    pTrack->trySetBpm(125);
     EXPECT_FALSE(pQuery->match(pTrack));
-    pTrack->trySetBpm(127.12, false);
+    pTrack->trySetBpm(127.12);
     EXPECT_TRUE(pQuery->match(pTrack));
-    pTrack->trySetBpm(129, false);
+    pTrack->trySetBpm(129);
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
@@ -514,7 +514,7 @@ TEST_F(SearchQueryParserTest, MultipleFilters) {
                             searchColumns, ""));
 
     TrackPointer pTrack = newTestTrack(44100);
-    pTrack->trySetBpm(128, false);
+    pTrack->trySetBpm(128);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->setArtist("Com Truise");
     EXPECT_FALSE(pQuery->match(pTrack));

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -372,9 +372,9 @@ TEST_F(SearchQueryParserTest, NumericFilter) {
         m_parser.parseQuery("bpm:127.12", searchColumns, ""));
 
     TrackPointer pTrack = newTestTrack(44100);
-    pTrack->setBpm(127);
+    pTrack->trySetBpm(127, false);
     EXPECT_FALSE(pQuery->match(pTrack));
-    pTrack->setBpm(127.12);
+    pTrack->trySetBpm(127.12, false);
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
@@ -391,7 +391,7 @@ TEST_F(SearchQueryParserTest, NumericFilterEmpty) {
         m_parser.parseQuery("bpm:", searchColumns, ""));
 
     TrackPointer pTrack = newTestTrack(44100);
-    pTrack->setBpm(127);
+    pTrack->trySetBpm(127, false);
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
@@ -408,9 +408,9 @@ TEST_F(SearchQueryParserTest, NumericFilterNegation) {
         m_parser.parseQuery("-bpm:127.12", searchColumns, ""));
 
     TrackPointer pTrack = newTestTrack(44100);
-    pTrack->setBpm(127);
+    pTrack->trySetBpm(127, false);
     EXPECT_TRUE(pQuery->match(pTrack));
-    pTrack->setBpm(127.12);
+    pTrack->trySetBpm(127.12, false);
     EXPECT_FALSE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
@@ -427,9 +427,9 @@ TEST_F(SearchQueryParserTest, NumericFilterAllowsSpace) {
         m_parser.parseQuery("bpm: 127.12", searchColumns, ""));
 
     TrackPointer pTrack = newTestTrack(44100);
-    pTrack->setBpm(127);
+    pTrack->trySetBpm(127, false);
     EXPECT_FALSE(pQuery->match(pTrack));
-    pTrack->setBpm(127.12);
+    pTrack->trySetBpm(127.12, false);
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
@@ -446,9 +446,9 @@ TEST_F(SearchQueryParserTest, NumericFilterOperators) {
         m_parser.parseQuery("bpm:>127.12", searchColumns, ""));
 
     TrackPointer pTrack = newTestTrack(44100);
-    pTrack->setBpm(127.12);
+    pTrack->trySetBpm(127.12, false);
     EXPECT_FALSE(pQuery->match(pTrack));
-    pTrack->setBpm(127.13);
+    pTrack->trySetBpm(127.13, false);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
         qPrintable(QString("bpm > 127.12")),
@@ -456,27 +456,27 @@ TEST_F(SearchQueryParserTest, NumericFilterOperators) {
 
 
     pQuery = m_parser.parseQuery("bpm:>=127.12", searchColumns, "");
-    pTrack->setBpm(127.11);
+    pTrack->trySetBpm(127.11, false);
     EXPECT_FALSE(pQuery->match(pTrack));
-    pTrack->setBpm(127.12);
+    pTrack->trySetBpm(127.12, false);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
         qPrintable(QString("bpm >= 127.12")),
         qPrintable(pQuery->toSql()));
 
     pQuery = m_parser.parseQuery("bpm:<127.12", searchColumns, "");
-    pTrack->setBpm(127.12);
+    pTrack->trySetBpm(127.12, false);
     EXPECT_FALSE(pQuery->match(pTrack));
-    pTrack->setBpm(127.11);
+    pTrack->trySetBpm(127.11, false);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
         qPrintable(QString("bpm < 127.12")),
         qPrintable(pQuery->toSql()));
 
     pQuery = m_parser.parseQuery("bpm:<=127.12", searchColumns, "");
-    pTrack->setBpm(127.13);
+    pTrack->trySetBpm(127.13, false);
     EXPECT_FALSE(pQuery->match(pTrack));
-    pTrack->setBpm(127.12);
+    pTrack->trySetBpm(127.12, false);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
         qPrintable(QString("bpm <= 127.12")),
@@ -492,11 +492,11 @@ TEST_F(SearchQueryParserTest, NumericRangeFilter) {
         m_parser.parseQuery("bpm:127.12-129", searchColumns, ""));
 
     TrackPointer pTrack = newTestTrack(44100);
-    pTrack->setBpm(125);
+    pTrack->trySetBpm(125, false);
     EXPECT_FALSE(pQuery->match(pTrack));
-    pTrack->setBpm(127.12);
+    pTrack->trySetBpm(127.12, false);
     EXPECT_TRUE(pQuery->match(pTrack));
-    pTrack->setBpm(129);
+    pTrack->trySetBpm(129, false);
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
@@ -514,7 +514,7 @@ TEST_F(SearchQueryParserTest, MultipleFilters) {
                             searchColumns, ""));
 
     TrackPointer pTrack = newTestTrack(44100);
-    pTrack->setBpm(128);
+    pTrack->trySetBpm(128, false);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->setArtist("Com Truise");
     EXPECT_FALSE(pQuery->match(pTrack));

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -277,7 +277,7 @@ double Track::setBpm(double bpmValue) {
         // If the user sets the BPM to an invalid value, we assume
         // they want to clear the beatgrid.
         setBeats(mixxx::BeatsPointer());
-        return bpmValue;
+        return mixxx::Bpm::kValueUndefined;
     }
 
     QMutexLocker lock(&m_qMutex);
@@ -290,15 +290,16 @@ double Track::setBpm(double bpmValue) {
         return bpmValue;
     }
 
-    // Continue with the regular case
-    if (m_pBeats->getBpm() != bpmValue) {
+    // Continue with the regular cases
+    if ((m_pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM) &&
+            m_pBeats->getBpm() != bpmValue) {
         if (kLogger.debugEnabled()) {
             kLogger.debug() << "Updating BPM:" << getLocation();
         }
         setBeatsMarkDirtyAndUnlock(&lock, m_pBeats->setBpm(bpmValue));
     }
 
-    return bpmValue;
+    return m_pBeats->getBpm();
 }
 
 QString Track::getBpmText() const {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -302,9 +302,14 @@ QString Track::getBpmText() const {
     return QString("%1").arg(getBpm(), 3,'f',1);
 }
 
-bool Track::trySetBeats(mixxx::BeatsPointer pBeats, bool lockBpmAfterSet) {
+bool Track::trySetBeats(mixxx::BeatsPointer pBeats) {
     QMutexLocker lock(&m_qMutex);
-    return trySetBeatsMarkDirtyAndUnlock(&lock, pBeats, lockBpmAfterSet);
+    return trySetBeatsMarkDirtyAndUnlock(&lock, pBeats, false);
+}
+
+bool Track::trySetAndLockBeats(mixxx::BeatsPointer pBeats) {
+    QMutexLocker lock(&m_qMutex);
+    return trySetBeatsMarkDirtyAndUnlock(&lock, pBeats, true);
 }
 
 bool Track::setBeatsWhileLocked(mixxx::BeatsPointer pBeats) {

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -126,7 +126,7 @@ class Track : public QObject {
     }
 
     // Sets the BPM if not locked.
-    double trySetBpm(double bpm, bool lockBpmAfterSet);
+    double trySetBpm(double bpm);
     // Returns BPM
     double getBpm() const;
     // Returns BPM as a string

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -291,9 +291,9 @@ class Track : public QObject {
     ///
     /// If the list is empty it tries to complete any pending
     /// import and returns the corresponding status.
-    ImportStatus importBeats(
+    ImportStatus tryImportBeats(
             mixxx::BeatsImporterPointer pBeatsImporter,
-            bool bpmLocked);
+            bool lockBpmAfterSet);
     ImportStatus getBeatsImportStatus() const;
 
     void resetKeys();
@@ -415,9 +415,9 @@ class Track : public QObject {
             QMutexLocker* pLock,
             mixxx::BeatsPointer pBeats,
             bool lockBpmAfterSet);
-    void importPendingBeatsMarkDirtyAndUnlock(
+    bool tryImportPendingBeatsMarkDirtyAndUnlock(
             QMutexLocker* pLock,
-            bool bpmLocked);
+            bool lockBpmAfterSet);
 
     void setCuePointsMarkDirtyAndUnlock(
             QMutexLocker* pLock,

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -284,7 +284,8 @@ class Track : public QObject {
     mixxx::BeatsPointer getBeats() const;
 
     // Set the track's Beats if not locked
-    bool trySetBeats(mixxx::BeatsPointer beats, bool lockBpmAfterSet);
+    bool trySetBeats(mixxx::BeatsPointer pBeats);
+    bool trySetAndLockBeats(mixxx::BeatsPointer pBeats);
 
     /// Imports the given list of cue infos as cue points,
     /// thereby replacing all existing cue points!

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1131,7 +1131,7 @@ class ScaleBpmTrackPointerOperation : public mixxx::TrackPointerOperation {
         if (!pBeats) {
             return;
         }
-        pTrack->setBeats(pBeats->scale(m_bpmScale));
+        pTrack->trySetBeats(pBeats->scale(m_bpmScale), false);
     }
 
     const mixxx::Beats::BPMScale m_bpmScale;
@@ -1263,10 +1263,7 @@ class ResetBeatsTrackPointerOperation : public mixxx::TrackPointerOperation {
   private:
     void doApply(
             const TrackPointer& pTrack) const override {
-        if (pTrack->isBpmLocked()) {
-            return;
-        }
-        pTrack->setBeats(mixxx::BeatsPointer());
+        pTrack->trySetBeats(mixxx::BeatsPointer(), false);
     }
 };
 

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1131,7 +1131,7 @@ class ScaleBpmTrackPointerOperation : public mixxx::TrackPointerOperation {
         if (!pBeats) {
             return;
         }
-        pTrack->trySetBeats(pBeats->scale(m_bpmScale), false);
+        pTrack->trySetBeats(pBeats->scale(m_bpmScale));
     }
 
     const mixxx::Beats::BPMScale m_bpmScale;
@@ -1263,7 +1263,7 @@ class ResetBeatsTrackPointerOperation : public mixxx::TrackPointerOperation {
   private:
     void doApply(
             const TrackPointer& pTrack) const override {
-        pTrack->trySetBeats(mixxx::BeatsPointer(), false);
+        pTrack->trySetBeats(mixxx::BeatsPointer());
     }
 };
 


### PR DESCRIPTION
My original approach in https://github.com/mixxxdj/mixxx/pull/3665 to not use the file metadata bpm has failed, because of breaking the bpm import. 


I also have discarded the idea I had during development to give the beat grid created by metadata a new Version, because that breaks with the tracks the user has already in the library. 

During further testing I have found out the detecting these temporary beat grid by the first beat at 0.0 works OK. 

The real cause for my original issue was "only" the code that shift the beat-grid around without taking the related BPM value as well. This is now fixed here. 

The other issue fixed her is that the SoundTouch beat detector runs over and over again. 



