### PR TITLE
Lock free beats 

### DIFF
--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -287,7 +287,7 @@ void AnalyzerBeats::storeResults(TrackPointer tio) {
     double currentFirstBeat = pCurrentBeats->findNextBeat(0);
     double newFirstBeat = pBeats->findNextBeat(0);
     if (currentFirstBeat == 0.0 && newFirstBeat > 0) {
-        pCurrentBeats->translate(newFirstBeat);
+        tio->setBeats(pCurrentBeats->translate(newFirstBeat));
     }
 }
 

--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -46,7 +46,7 @@ AnalyzerBeats::AnalyzerBeats(UserSettingsPointer pConfig, bool enforceBpmDetecti
           m_iMaxBpm(9999) {
 }
 
-bool AnalyzerBeats::initialize(TrackPointer tio, int sampleRate, int totalSamples) {
+bool AnalyzerBeats::initialize(TrackPointer pTrack, int sampleRate, int totalSamples) {
     if (totalSamples == 0) {
         return false;
     }
@@ -58,7 +58,7 @@ bool AnalyzerBeats::initialize(TrackPointer tio, int sampleRate, int totalSample
         return false;
     }
 
-    bool bpmLock = tio->isBpmLocked();
+    bool bpmLock = pTrack->isBpmLocked();
     if (bpmLock) {
         qDebug() << "Track is BpmLocked: Beat calculation will not start";
         return false;
@@ -106,8 +106,7 @@ bool AnalyzerBeats::initialize(TrackPointer tio, int sampleRate, int totalSample
     m_iCurrentSample = 0;
 
     // if we can load a stored track don't reanalyze it
-    bool bShouldAnalyze = shouldAnalyze(tio);
-
+    bool bShouldAnalyze = shouldAnalyze(pTrack);
 
     DEBUG_ASSERT(!m_pPlugin);
     if (bShouldAnalyze) {
@@ -136,11 +135,11 @@ bool AnalyzerBeats::initialize(TrackPointer tio, int sampleRate, int totalSample
     return bShouldAnalyze;
 }
 
-bool AnalyzerBeats::shouldAnalyze(TrackPointer tio) const {
+bool AnalyzerBeats::shouldAnalyze(TrackPointer pTrack) const {
     int iMinBpm = m_bpmSettings.getBpmRangeStart();
     int iMaxBpm = m_bpmSettings.getBpmRangeEnd();
 
-    bool bpmLock = tio->isBpmLocked();
+    bool bpmLock = pTrack->isBpmLocked();
     if (bpmLock) {
         qDebug() << "Track is BpmLocked: Beat calculation will not start";
         return false;
@@ -153,7 +152,7 @@ bool AnalyzerBeats::shouldAnalyze(TrackPointer tio) const {
 
     // If the track already has a Beats object then we need to decide whether to
     // analyze this track or not.
-    mixxx::BeatsPointer pBeats = tio->getBeats();
+    mixxx::BeatsPointer pBeats = pTrack->getBeats();
     if (!pBeats) {
         return true;
     }
@@ -221,7 +220,7 @@ void AnalyzerBeats::cleanup() {
     m_pPlugin.reset();
 }
 
-void AnalyzerBeats::storeResults(TrackPointer tio) {
+void AnalyzerBeats::storeResults(TrackPointer pTrack) {
     VERIFY_OR_DEBUG_ASSERT(m_pPlugin) {
         return;
     }
@@ -253,18 +252,18 @@ void AnalyzerBeats::storeResults(TrackPointer tio) {
         pBeats = BeatFactory::makeBeatGrid(m_iSampleRate, bpm, 0.0f);
     }
 
-    mixxx::BeatsPointer pCurrentBeats = tio->getBeats();
+    mixxx::BeatsPointer pCurrentBeats = pTrack->getBeats();
 
     // If the track has no beats object then set our newly generated one
     // regardless of beat lock.
     if (!pCurrentBeats) {
-        tio->setBeats(pBeats);
+        pTrack->setBeats(pBeats);
         return;
     }
 
     // If the track received the beat lock while we were analyzing it then we
     // abort setting it.
-    if (tio->isBpmLocked()) {
+    if (pTrack->isBpmLocked()) {
         qDebug() << "Track was BPM-locked as we were analyzing it. Aborting analysis.";
         return;
     }
@@ -277,7 +276,7 @@ void AnalyzerBeats::storeResults(TrackPointer tio) {
             qDebug() << "Replacing 0-BPM beatgrid with a" << pBeats->getBpm()
                      << "beatgrid.";
         }
-        tio->setBeats(pBeats);
+        pTrack->setBeats(pBeats);
         return;
     }
 
@@ -286,7 +285,7 @@ void AnalyzerBeats::storeResults(TrackPointer tio) {
     double currentFirstBeat = pCurrentBeats->findNextBeat(0);
     double newFirstBeat = pBeats->findNextBeat(0);
     if (currentFirstBeat == 0.0 && newFirstBeat > 0) {
-        tio->setBeats(pCurrentBeats->translate(newFirstBeat));
+        pTrack->setBeats(pCurrentBeats->translate(newFirstBeat));
     }
 }
 

--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -152,7 +152,7 @@ bool AnalyzerBeats::shouldAnalyze(TrackPointer pTrack) const {
 
     // If the track already has a Beats object then we need to decide whether to
     // analyze this track or not.
-    mixxx::BeatsPointer pBeats = pTrack->getBeats();
+    const mixxx::BeatsPointer pBeats = pTrack->getBeats();
     if (!pBeats) {
         return true;
     }

--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -237,7 +237,6 @@ void AnalyzerBeats::storeResults(TrackPointer tio) {
         QHash<QString, QString> extraVersionInfo = getExtraVersionInfo(
                 m_pluginId, m_bPreferencesFastAnalysis);
         pBeats = BeatFactory::makePreferredBeats(
-                *tio,
                 beats,
                 extraVersionInfo,
                 m_bPreferencesFixedTempo,
@@ -251,7 +250,7 @@ void AnalyzerBeats::storeResults(TrackPointer tio) {
     } else {
         float bpm = m_pPlugin->getBpm();
         qDebug() << "AnalyzerBeats plugin detected constant BPM: " << bpm;
-        pBeats = BeatFactory::makeBeatGrid(*tio, bpm, 0.0f);
+        pBeats = BeatFactory::makeBeatGrid(m_iSampleRate, bpm, 0.0f);
     }
 
     mixxx::BeatsPointer pCurrentBeats = tio->getBeats();

--- a/src/analyzer/analyzerbeats.h
+++ b/src/analyzer/analyzerbeats.h
@@ -26,13 +26,13 @@ class AnalyzerBeats : public Analyzer {
     static QList<mixxx::AnalyzerPluginInfo> availablePlugins();
     static mixxx::AnalyzerPluginInfo defaultPlugin();
 
-    bool initialize(TrackPointer tio, int sampleRate, int totalSamples) override;
+    bool initialize(TrackPointer pTrack, int sampleRate, int totalSamples) override;
     bool processSamples(const CSAMPLE *pIn, const int iLen) override;
     void storeResults(TrackPointer tio) override;
     void cleanup() override;
 
   private:
-    bool shouldAnalyze(TrackPointer tio) const;
+    bool shouldAnalyze(TrackPointer pTrack) const;
     static QHash<QString, QString> getExtraVersionInfo(
             const QString& pluginId, bool bPreferencesFastAnalysis);
 

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -164,7 +164,7 @@ void BpmControl::slotAdjustBeatsFaster(double v) {
     if (v <= 0) {
         return;
     }
-    TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    const TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
     if (!pTrack) {
         return;
     }
@@ -180,7 +180,7 @@ void BpmControl::slotAdjustBeatsSlower(double v) {
     if (v <= 0) {
         return;
     }
-    TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    const TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
     if (!pTrack) {
         return;
     }
@@ -196,7 +196,7 @@ void BpmControl::slotTranslateBeatsEarlier(double v) {
     if (v <= 0) {
         return;
     }
-    TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    const TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
     if (!pTrack) {
         return;
     }
@@ -212,7 +212,7 @@ void BpmControl::slotTranslateBeatsLater(double v) {
     if (v <= 0) {
         return;
     }
-    TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    const TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
     if (!pTrack) {
         return;
     }
@@ -239,7 +239,7 @@ void BpmControl::slotTapFilter(double averageLength, int numSamples) {
         return;
     }
 
-    TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    const TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
     if (!pTrack) {
         return;
     }

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -161,20 +161,34 @@ double BpmControl::getBpm() const {
 }
 
 void BpmControl::slotAdjustBeatsFaster(double v) {
-    mixxx::BeatsPointer pBeats = m_pBeats;
-    if (v > 0 && pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM)) {
+    if (v <= 0) {
+        return;
+    }
+    TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    if (!pTrack) {
+        return;
+    }
+    mixxx::BeatsPointer pBeats = pTrack->getBeats();
+    if (pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM)) {
         double bpm = pBeats->getBpm();
         double adjustedBpm = bpm + kBpmAdjustStep;
-        pBeats->setBpm(adjustedBpm);
+        pTrack->setBeats(pBeats->setBpm(adjustedBpm));
     }
 }
 
 void BpmControl::slotAdjustBeatsSlower(double v) {
-    mixxx::BeatsPointer pBeats = m_pBeats;
-    if (v > 0 && pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM)) {
+    if (v <= 0) {
+        return;
+    }
+    TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    if (!pTrack) {
+        return;
+    }
+    mixxx::BeatsPointer pBeats = pTrack->getBeats();
+    if (pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM)) {
         double bpm = pBeats->getBpm();
         double adjustedBpm = math_max(kBpmAdjustMin, bpm - kBpmAdjustStep);
-        pBeats->setBpm(adjustedBpm);
+        pTrack->setBeats(pBeats->setBpm(adjustedBpm));
     }
 }
 
@@ -225,11 +239,14 @@ void BpmControl::slotTapFilter(double averageLength, int numSamples) {
         return;
     }
 
-    mixxx::BeatsPointer pBeats = m_pBeats;
+    TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    if (!pTrack) {
+        return;
+    }
+    mixxx::BeatsPointer pBeats = pTrack->getBeats();
     if (!pBeats) {
         return;
     }
-
     double rateRatio = m_pRateRatio->get();
     if (rateRatio == 0.0) {
         return;
@@ -238,7 +255,7 @@ void BpmControl::slotTapFilter(double averageLength, int numSamples) {
     // (60 seconds per minute) * (1000 milliseconds per second) / (X millis per
     // beat) = Y beats/minute
     double averageBpm = 60.0 * 1000.0 / averageLength / rateRatio;
-    pBeats->setBpm(averageBpm);
+    pTrack->setBeats(pBeats->setBpm(averageBpm));
 }
 
 void BpmControl::slotControlBeatSyncPhase(double value) {

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -168,7 +168,7 @@ void BpmControl::slotAdjustBeatsFaster(double v) {
     if (!pTrack) {
         return;
     }
-    mixxx::BeatsPointer pBeats = pTrack->getBeats();
+    const mixxx::BeatsPointer pBeats = pTrack->getBeats();
     if (pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM)) {
         double bpm = pBeats->getBpm();
         double adjustedBpm = bpm + kBpmAdjustStep;
@@ -184,7 +184,7 @@ void BpmControl::slotAdjustBeatsSlower(double v) {
     if (!pTrack) {
         return;
     }
-    mixxx::BeatsPointer pBeats = pTrack->getBeats();
+    const mixxx::BeatsPointer pBeats = pTrack->getBeats();
     if (pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM)) {
         double bpm = pBeats->getBpm();
         double adjustedBpm = math_max(kBpmAdjustMin, bpm - kBpmAdjustStep);
@@ -200,7 +200,7 @@ void BpmControl::slotTranslateBeatsEarlier(double v) {
     if (!pTrack) {
         return;
     }
-    mixxx::BeatsPointer pBeats = pTrack->getBeats();
+    const mixxx::BeatsPointer pBeats = pTrack->getBeats();
     if (pBeats &&
             (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
         const double translate_dist = getSampleOfTrack().rate * -.01;
@@ -216,7 +216,7 @@ void BpmControl::slotTranslateBeatsLater(double v) {
     if (!pTrack) {
         return;
     }
-    mixxx::BeatsPointer pBeats = pTrack->getBeats();
+    const mixxx::BeatsPointer pBeats = pTrack->getBeats();
     if (pBeats &&
             (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
         // TODO(rryan): Track::getSampleRate is possibly inaccurate!
@@ -243,7 +243,7 @@ void BpmControl::slotTapFilter(double averageLength, int numSamples) {
     if (!pTrack) {
         return;
     }
-    mixxx::BeatsPointer pBeats = pTrack->getBeats();
+    const mixxx::BeatsPointer pBeats = pTrack->getBeats();
     if (!pBeats) {
         return;
     }
@@ -621,7 +621,7 @@ bool BpmControl::getBeatContextNoLookup(
 double BpmControl::getNearestPositionInPhase(
         double dThisPosition, bool respectLoops, bool playing) {
     // Without a beatgrid, we don't know the phase offset.
-    mixxx::BeatsPointer pBeats = m_pBeats;
+    const mixxx::BeatsPointer pBeats = m_pBeats;
     if (!pBeats) {
         return dThisPosition;
     }
@@ -1012,7 +1012,7 @@ void BpmControl::slotBeatsTranslate(double v) {
         return;
     }
     TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
-    mixxx::BeatsPointer pBeats = pTrack->getBeats();
+    const mixxx::BeatsPointer pBeats = pTrack->getBeats();
     if (pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
         double currentSample = getSampleOfTrack().current;
         double closestBeat = pBeats->findClosestBeat(currentSample);
@@ -1032,7 +1032,7 @@ void BpmControl::slotBeatsTranslateMatchAlignment(double v) {
     if (!pTrack) {
         return;
     }
-    mixxx::BeatsPointer pBeats = pTrack->getBeats();
+    const mixxx::BeatsPointer pBeats = pTrack->getBeats();
     if (pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
         // Must reset the user offset *before* calling getPhaseOffset(),
         // otherwise it will always return 0 if master sync is active.
@@ -1046,7 +1046,7 @@ void BpmControl::slotBeatsTranslateMatchAlignment(double v) {
 double BpmControl::updateLocalBpm() {
     double prev_local_bpm = m_pLocalBpm->get();
     double local_bpm = 0;
-    mixxx::BeatsPointer pBeats = m_pBeats;
+    const mixxx::BeatsPointer pBeats = m_pBeats;
     if (pBeats) {
         local_bpm = pBeats->getBpmAroundPosition(
                 getSampleOfTrack().current, kLocalBpmSpan);

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -179,21 +179,35 @@ void BpmControl::slotAdjustBeatsSlower(double v) {
 }
 
 void BpmControl::slotTranslateBeatsEarlier(double v) {
-    mixxx::BeatsPointer pBeats = m_pBeats;
-    if (v > 0 && pBeats &&
+    if (v <= 0) {
+        return;
+    }
+    TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    if (!pTrack) {
+        return;
+    }
+    mixxx::BeatsPointer pBeats = pTrack->getBeats();
+    if (pBeats &&
             (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
         const double translate_dist = getSampleOfTrack().rate * -.01;
-        pBeats->translate(translate_dist);
+        pTrack->setBeats(pBeats->translate(translate_dist));
     }
 }
 
 void BpmControl::slotTranslateBeatsLater(double v) {
-    mixxx::BeatsPointer pBeats = m_pBeats;
-    if (v > 0 && pBeats &&
+    if (v <= 0) {
+        return;
+    }
+    TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    if (!pTrack) {
+        return;
+    }
+    mixxx::BeatsPointer pBeats = pTrack->getBeats();
+    if (pBeats &&
             (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
         // TODO(rryan): Track::getSampleRate is possibly inaccurate!
         const double translate_dist = getSampleOfTrack().rate * .01;
-        pBeats->translate(translate_dist);
+        pTrack->setBeats(pBeats->translate(translate_dist));
     }
 }
 
@@ -977,27 +991,38 @@ void BpmControl::trackBeatsUpdated(mixxx::BeatsPointer pBeats) {
 }
 
 void BpmControl::slotBeatsTranslate(double v) {
-    mixxx::BeatsPointer pBeats = m_pBeats;
-    if (v > 0 && pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
+    if (v <= 0) {
+        return;
+    }
+    TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    mixxx::BeatsPointer pBeats = pTrack->getBeats();
+    if (pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
         double currentSample = getSampleOfTrack().current;
         double closestBeat = pBeats->findClosestBeat(currentSample);
         int delta = static_cast<int>(currentSample - closestBeat);
         if (delta % 2 != 0) {
             delta--;
         }
-        pBeats->translate(delta);
+        pTrack->setBeats(pBeats->translate(delta));
     }
 }
 
 void BpmControl::slotBeatsTranslateMatchAlignment(double v) {
-    mixxx::BeatsPointer pBeats = m_pBeats;
-    if (v > 0 && pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
+    if (v <= 0) {
+        return;
+    }
+    TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    if (!pTrack) {
+        return;
+    }
+    mixxx::BeatsPointer pBeats = pTrack->getBeats();
+    if (pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
         // Must reset the user offset *before* calling getPhaseOffset(),
         // otherwise it will always return 0 if master sync is active.
         m_dUserOffset.setValue(0.0);
 
         double offset = getPhaseOffset(getSampleOfTrack().current);
-        pBeats->translate(-offset);
+        pTrack->setBeats(pBeats->translate(-offset));
     }
 }
 

--- a/src/engine/controls/clockcontrol.cpp
+++ b/src/engine/controls/clockcontrol.cpp
@@ -47,7 +47,7 @@ void ClockControl::process(const double dRate,
     // by the rate.
     const double blinkIntervalSamples = 2.0 * samplerate * (1.0 * dRate) * blinkSeconds;
 
-    mixxx::BeatsPointer pBeats = m_pBeats;
+    const mixxx::BeatsPointer pBeats = m_pBeats;
     if (pBeats) {
         double closestBeat = pBeats->findClosestBeat(currentSample);
         double distanceToClosestBeat = fabs(currentSample - closestBeat);

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -1768,7 +1768,7 @@ double CueControl::quantizeCuePoint(double cuePos) {
         return cuePos;
     }
 
-    mixxx::BeatsPointer pBeats = m_pLoadedTrack->getBeats();
+    const mixxx::BeatsPointer pBeats = m_pLoadedTrack->getBeats();
     if (!pBeats) {
         return cuePos;
     }

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -510,7 +510,7 @@ double LoopingControl::getSyncPositionInsideLoop(double dRequestedPlaypos, doubl
 
 void LoopingControl::setLoopInToCurrentPosition() {
     // set loop-in position
-    mixxx::BeatsPointer pBeats = m_pBeats;
+    const mixxx::BeatsPointer pBeats = m_pBeats;
     LoopSamples loopSamples = m_loopSamples.getValue();
     double quantizedBeat = -1;
     double pos = m_currentSample.getValue();
@@ -954,7 +954,7 @@ void LoopingControl::clearActiveBeatLoop() {
 }
 
 bool LoopingControl::currentLoopMatchesBeatloopSize() {
-    mixxx::BeatsPointer pBeats = m_pBeats;
+    const mixxx::BeatsPointer pBeats = m_pBeats;
     if (!pBeats) {
         return false;
     }
@@ -970,7 +970,7 @@ bool LoopingControl::currentLoopMatchesBeatloopSize() {
 }
 
 double LoopingControl::findBeatloopSizeForLoop(double start, double end) const {
-    mixxx::BeatsPointer pBeats = m_pBeats;
+    const mixxx::BeatsPointer pBeats = m_pBeats;
     if (!pBeats) {
         return -1;
     }
@@ -1028,7 +1028,7 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable
     }
 
     int samples = static_cast<int>(m_pTrackSamples->get());
-    mixxx::BeatsPointer pBeats = m_pBeats;
+    const mixxx::BeatsPointer pBeats = m_pBeats;
     if (samples == 0 || !pBeats) {
         clearActiveBeatLoop();
         m_pCOBeatLoopSize->setAndConfirm(beats);
@@ -1194,7 +1194,7 @@ void LoopingControl::slotBeatLoopRollActivate(double pressed) {
 }
 
 void LoopingControl::slotBeatJump(double beats) {
-    mixxx::BeatsPointer pBeats = m_pBeats;
+    const mixxx::BeatsPointer pBeats = m_pBeats;
     if (!pBeats) {
         return;
     }
@@ -1226,7 +1226,7 @@ void LoopingControl::slotBeatJumpBackward(double pressed) {
 }
 
 void LoopingControl::slotLoopMove(double beats) {
-    mixxx::BeatsPointer pBeats = m_pBeats;
+    const mixxx::BeatsPointer pBeats = m_pBeats;
     if (!pBeats || beats == 0) {
         return;
     }

--- a/src/library/banshee/bansheeplaylistmodel.cpp
+++ b/src/library/banshee/bansheeplaylistmodel.cpp
@@ -291,11 +291,6 @@ TrackPointer BansheePlaylistModel::getTrack(const QModelIndex& index) const {
         pTrack->setBitrate(getFieldString(index, CLM_BITRATE).toInt());
         pTrack->setComment(getFieldString(index, CLM_COMMENT));
         pTrack->setComposer(getFieldString(index, CLM_COMPOSER));
-        // If the track has a BPM, then give it a static beatgrid.
-        if (bpm > 0) {
-            mixxx::BeatsPointer pBeats = BeatFactory::makeBeatGrid(*pTrack, bpm, 0.0);
-            pTrack->setBeats(pBeats);
-        }
     }
     return pTrack;
 }

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1088,7 +1088,7 @@ bool setTrackBeats(const QSqlRecord& record, const int column,
     QByteArray beatsBlob = record.value(column + 3).toByteArray();
     bool bpmLocked = record.value(column + 4).toBool();
     mixxx::BeatsPointer pBeats = BeatFactory::loadBeatsFromByteArray(
-            *pTrack, beatsVersion, beatsSubVersion, beatsBlob);
+            pTrack->getSampleRate(), beatsVersion, beatsSubVersion, beatsBlob);
     if (pBeats) {
         pTrack->setBeats(pBeats);
     } else {

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1087,7 +1087,7 @@ bool setTrackBeats(const QSqlRecord& record, const int column,
     QString beatsSubVersion = record.value(column + 2).toString();
     QByteArray beatsBlob = record.value(column + 3).toByteArray();
     bool bpmLocked = record.value(column + 4).toBool();
-    mixxx::BeatsPointer pBeats = BeatFactory::loadBeatsFromByteArray(
+    const mixxx::BeatsPointer pBeats = BeatFactory::loadBeatsFromByteArray(
             pTrack->getSampleRate(), beatsVersion, beatsSubVersion, beatsBlob);
     if (pBeats) {
         pTrack->setBeats(pBeats);

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -268,7 +268,7 @@ void DlgTrackInfo::populateFields(const Track& track) {
 }
 
 void DlgTrackInfo::reloadTrackBeats(const Track& track) {
-    mixxx::BeatsPointer pBeats = track.getBeats();
+    const mixxx::BeatsPointer pBeats = track.getBeats();
     if (pBeats) {
         spinBpm->setValue(pBeats->getBpm());
         m_pBeatsClone = pBeats->clone();

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -465,42 +465,42 @@ void DlgTrackInfo::clear() {
 }
 
 void DlgTrackInfo::slotBpmDouble() {
-    m_pBeatsClone->scale(mixxx::Beats::DOUBLE);
+    m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::DOUBLE);
     // read back the actual value
     double newValue = m_pBeatsClone->getBpm();
     spinBpm->setValue(newValue);
 }
 
 void DlgTrackInfo::slotBpmHalve() {
-    m_pBeatsClone->scale(mixxx::Beats::HALVE);
+    m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::HALVE);
     // read back the actual value
     double newValue = m_pBeatsClone->getBpm();
     spinBpm->setValue(newValue);
 }
 
 void DlgTrackInfo::slotBpmTwoThirds() {
-    m_pBeatsClone->scale(mixxx::Beats::TWOTHIRDS);
+    m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::TWOTHIRDS);
     // read back the actual value
     double newValue = m_pBeatsClone->getBpm();
     spinBpm->setValue(newValue);
 }
 
 void DlgTrackInfo::slotBpmThreeFourth() {
-    m_pBeatsClone->scale(mixxx::Beats::THREEFOURTHS);
+    m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::THREEFOURTHS);
     // read back the actual value
     double newValue = m_pBeatsClone->getBpm();
     spinBpm->setValue(newValue);
 }
 
 void DlgTrackInfo::slotBpmFourThirds() {
-    m_pBeatsClone->scale(mixxx::Beats::FOURTHIRDS);
+    m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::FOURTHIRDS);
     // read back the actual value
     double newValue = m_pBeatsClone->getBpm();
     spinBpm->setValue(newValue);
 }
 
 void DlgTrackInfo::slotBpmThreeHalves() {
-    m_pBeatsClone->scale(mixxx::Beats::THREEHALVES);
+    m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::THREEHALVES);
     // read back the actual value
     double newValue = m_pBeatsClone->getBpm();
     spinBpm->setValue(newValue);

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -524,11 +524,11 @@ void DlgTrackInfo::slotBpmConstChanged(int state) {
             // it is hard to predict a fitting beat. We know that we
             // cannot use the first beat, since it is out of sync in
             // almost all cases.
-            // The cue point should be set on a beat, so this seams
+            // The cue point should be set on a beat, so this seems
             // to be a good alternative
             CuePosition cue = m_pLoadedTrack->getCuePoint();
             m_pBeatsClone = BeatFactory::makeBeatGrid(
-                    *m_pLoadedTrack, spinBpm->value(), cue.getPosition());
+                    m_pLoadedTrack->getSampleRate(), spinBpm->value(), cue.getPosition());
         } else {
             m_pBeatsClone.clear();
         }
@@ -562,7 +562,7 @@ void DlgTrackInfo::slotSpinBpmValueChanged(double value) {
     if (!m_pBeatsClone) {
         CuePosition cue = m_pLoadedTrack->getCuePoint();
         m_pBeatsClone = BeatFactory::makeBeatGrid(
-                *m_pLoadedTrack, value, cue.getPosition());
+                m_pLoadedTrack->getSampleRate(), value, cue.getPosition());
     }
 
     double oldValue = m_pBeatsClone->getBpm();

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -866,9 +866,11 @@ void readAnalyze(TrackPointer track,
                 beats << (sampleRateKhz * static_cast<double>(time));
             }
 
-            auto* pBeats = new mixxx::BeatMap(*track, static_cast<SINT>(sampleRate), beats);
-            pBeats->setSubVersion(mixxx::rekordboxconstants::beatsSubversion);
-            track->setBeats(mixxx::BeatsPointer(pBeats));
+            auto pBeats = mixxx::BeatMap::makeBeatMap(*track,
+                    static_cast<SINT>(sampleRate),
+                    mixxx::rekordboxconstants::beatsSubversion,
+                    beats);
+            track->setBeats(pBeats);
         } break;
         case rekordbox_anlz_t::SECTION_TAGS_CUES: {
             if (ignoreCues) {

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -866,7 +866,7 @@ void readAnalyze(TrackPointer track,
                 beats << (sampleRateKhz * static_cast<double>(time));
             }
 
-            auto pBeats = mixxx::BeatMap::makeBeatMap(
+            const auto pBeats = mixxx::BeatMap::makeBeatMap(
                     static_cast<SINT>(sampleRate),
                     mixxx::rekordboxconstants::beatsSubversion,
                     beats);

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -866,7 +866,7 @@ void readAnalyze(TrackPointer track,
                 beats << (sampleRateKhz * static_cast<double>(time));
             }
 
-            auto pBeats = mixxx::BeatMap::makeBeatMap(*track,
+            auto pBeats = mixxx::BeatMap::makeBeatMap(
                     static_cast<SINT>(sampleRate),
                     mixxx::rekordboxconstants::beatsSubversion,
                     beats);

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -30,7 +30,7 @@ TEST(BeatGridTest, Scale) {
     pTrack->setBpm(bpm);
 
     mixxx::BeatsPointer pGrid(new BeatGrid(*pTrack, 0));
-    pGrid->setBpm(bpm);
+    pGrid = pGrid->setBpm(bpm);
 
     EXPECT_DOUBLE_EQ(bpm, pGrid->getBpm());
     pGrid = pGrid->scale(Beats::DOUBLE);
@@ -61,8 +61,8 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat) {
     pTrack->setBpm(bpm);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
-    auto pGrid = std::make_unique<BeatGrid>(*pTrack, 0);
-    pGrid->setBpm(bpm);
+    mixxx::BeatsPointer pGrid(new BeatGrid(*pTrack, 0));
+    pGrid = pGrid->setBpm(bpm);
     // Pretend we're on the 20th beat;
     double position = beatLength * 20;
 
@@ -96,8 +96,8 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
     pTrack->setBpm(bpm);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
-    auto pGrid = std::make_unique<BeatGrid>(*pTrack, 0);
-    pGrid->setBpm(bpm);
+    mixxx::BeatsPointer pGrid(new BeatGrid(*pTrack, 0));
+    pGrid = pGrid->setBpm(bpm);
 
     // Pretend we're just before the 20th beat.
     const double kClosestBeat = 20 * beatLength;
@@ -133,8 +133,8 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
     pTrack->setBpm(bpm);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
-    auto pGrid = std::make_unique<BeatGrid>(*pTrack, 0);
-    pGrid->setBpm(bpm);
+    mixxx::BeatsPointer pGrid(new BeatGrid(*pTrack, 0));
+    pGrid = pGrid->setBpm(bpm);
 
     // Pretend we're just before the 20th beat.
     const double kClosestBeat = 20 * beatLength;
@@ -170,8 +170,8 @@ TEST(BeatGridTest, TestNthBeatWhenNotOnBeat) {
     pTrack->setBpm(bpm);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
-    auto pGrid = std::make_unique<BeatGrid>(*pTrack, 0);
-    pGrid->setBpm(bpm);
+    mixxx::BeatsPointer pGrid(new BeatGrid(*pTrack, 0));
+    pGrid = pGrid->setBpm(bpm);
 
     // Pretend we're half way between the 20th and 21st beat
     double previousBeat = beatLength * 20.0;

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -29,26 +29,26 @@ TEST(BeatGridTest, Scale) {
     double bpm = 60.0;
     pTrack->setBpm(bpm);
 
-    auto pGrid = std::make_unique<BeatGrid>(*pTrack, 0);
+    mixxx::BeatsPointer pGrid(new BeatGrid(*pTrack, 0));
     pGrid->setBpm(bpm);
 
     EXPECT_DOUBLE_EQ(bpm, pGrid->getBpm());
-    pGrid->scale(Beats::DOUBLE);
+    pGrid = pGrid->scale(Beats::DOUBLE);
     EXPECT_DOUBLE_EQ(2 * bpm, pGrid->getBpm());
 
-    pGrid->scale(Beats::HALVE);
+    pGrid = pGrid->scale(Beats::HALVE);
     EXPECT_DOUBLE_EQ(bpm, pGrid->getBpm());
 
-    pGrid->scale(Beats::TWOTHIRDS);
+    pGrid = pGrid->scale(Beats::TWOTHIRDS);
     EXPECT_DOUBLE_EQ(bpm * 2 / 3, pGrid->getBpm());
 
-    pGrid->scale(Beats::THREEHALVES);
+    pGrid = pGrid->scale(Beats::THREEHALVES);
     EXPECT_DOUBLE_EQ(bpm, pGrid->getBpm());
 
-    pGrid->scale(Beats::THREEFOURTHS);
+    pGrid = pGrid->scale(Beats::THREEFOURTHS);
     EXPECT_DOUBLE_EQ(bpm * 3 / 4, pGrid->getBpm());
 
-    pGrid->scale(Beats::FOURTHIRDS);
+    pGrid = pGrid->scale(Beats::FOURTHIRDS);
     EXPECT_DOUBLE_EQ(bpm, pGrid->getBpm());
 }
 

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -29,8 +29,7 @@ TEST(BeatGridTest, Scale) {
     double bpm = 60.0;
     pTrack->setBpm(bpm);
 
-    mixxx::BeatsPointer pGrid(new BeatGrid(*pTrack, 0));
-    pGrid = pGrid->setBpm(bpm);
+    auto pGrid = BeatGrid::makeBeatGrid(*pTrack, 0, QString(), bpm, 0);
 
     EXPECT_DOUBLE_EQ(bpm, pGrid->getBpm());
     pGrid = pGrid->scale(Beats::DOUBLE);
@@ -61,8 +60,7 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat) {
     pTrack->setBpm(bpm);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
-    mixxx::BeatsPointer pGrid(new BeatGrid(*pTrack, 0));
-    pGrid = pGrid->setBpm(bpm);
+    auto pGrid = BeatGrid::makeBeatGrid(*pTrack, 0, QString(), bpm, 0);
     // Pretend we're on the 20th beat;
     double position = beatLength * 20;
 
@@ -96,8 +94,7 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
     pTrack->setBpm(bpm);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
-    mixxx::BeatsPointer pGrid(new BeatGrid(*pTrack, 0));
-    pGrid = pGrid->setBpm(bpm);
+    auto pGrid = BeatGrid::makeBeatGrid(*pTrack, 0, QString(), bpm, 0);
 
     // Pretend we're just before the 20th beat.
     const double kClosestBeat = 20 * beatLength;
@@ -133,8 +130,7 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
     pTrack->setBpm(bpm);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
-    mixxx::BeatsPointer pGrid(new BeatGrid(*pTrack, 0));
-    pGrid = pGrid->setBpm(bpm);
+    auto pGrid = BeatGrid::makeBeatGrid(*pTrack, 0, QString(), bpm, 0);
 
     // Pretend we're just before the 20th beat.
     const double kClosestBeat = 20 * beatLength;
@@ -170,8 +166,7 @@ TEST(BeatGridTest, TestNthBeatWhenNotOnBeat) {
     pTrack->setBpm(bpm);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
-    mixxx::BeatsPointer pGrid(new BeatGrid(*pTrack, 0));
-    pGrid = pGrid->setBpm(bpm);
+    auto pGrid = BeatGrid::makeBeatGrid(*pTrack, 0, QString(), bpm, 0);
 
     // Pretend we're half way between the 20th and 21st beat
     double previousBeat = beatLength * 20.0;

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -29,7 +29,7 @@ TEST(BeatGridTest, Scale) {
     double bpm = 60.0;
     pTrack->setBpm(bpm);
 
-    auto pGrid = BeatGrid::makeBeatGrid(*pTrack, 0, QString(), bpm, 0);
+    auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(), QString(), bpm, 0);
 
     EXPECT_DOUBLE_EQ(bpm, pGrid->getBpm());
     pGrid = pGrid->scale(Beats::DOUBLE);
@@ -60,7 +60,7 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat) {
     pTrack->setBpm(bpm);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
-    auto pGrid = BeatGrid::makeBeatGrid(*pTrack, 0, QString(), bpm, 0);
+    auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(), QString(), bpm, 0);
     // Pretend we're on the 20th beat;
     double position = beatLength * 20;
 
@@ -94,7 +94,7 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
     pTrack->setBpm(bpm);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
-    auto pGrid = BeatGrid::makeBeatGrid(*pTrack, 0, QString(), bpm, 0);
+    auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(), QString(), bpm, 0);
 
     // Pretend we're just before the 20th beat.
     const double kClosestBeat = 20 * beatLength;
@@ -130,7 +130,7 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
     pTrack->setBpm(bpm);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
-    auto pGrid = BeatGrid::makeBeatGrid(*pTrack, 0, QString(), bpm, 0);
+    auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(), QString(), bpm, 0);
 
     // Pretend we're just before the 20th beat.
     const double kClosestBeat = 20 * beatLength;
@@ -166,7 +166,7 @@ TEST(BeatGridTest, TestNthBeatWhenNotOnBeat) {
     pTrack->setBpm(bpm);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
-    auto pGrid = BeatGrid::makeBeatGrid(*pTrack, 0, QString(), bpm, 0);
+    auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(), QString(), bpm, 0);
 
     // Pretend we're half way between the 20th and 21st beat
     double previousBeat = beatLength * 20.0;

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -55,25 +55,25 @@ TEST_F(BeatMapTest, Scale) {
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<double> beats = createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pMap = std::make_unique<BeatMap>(*m_pTrack, 0, beats);
+    mixxx::BeatsPointer pMap(new BeatMap(*m_pTrack, 0, beats));
 
     EXPECT_DOUBLE_EQ(bpm, pMap->getBpm());
-    pMap->scale(Beats::DOUBLE);
+    pMap = pMap->scale(Beats::DOUBLE);
     EXPECT_DOUBLE_EQ(2 * bpm, pMap->getBpm());
 
-    pMap->scale(Beats::HALVE);
+    pMap = pMap->scale(Beats::HALVE);
     EXPECT_DOUBLE_EQ(bpm, pMap->getBpm());
 
-    pMap->scale(Beats::TWOTHIRDS);
+    pMap = pMap->scale(Beats::TWOTHIRDS);
     EXPECT_DOUBLE_EQ(bpm * 2 / 3, pMap->getBpm());
 
-    pMap->scale(Beats::THREEHALVES);
+    pMap = pMap->scale(Beats::THREEHALVES);
     EXPECT_DOUBLE_EQ(bpm, pMap->getBpm());
 
-    pMap->scale(Beats::THREEFOURTHS);
+    pMap = pMap->scale(Beats::THREEFOURTHS);
     EXPECT_DOUBLE_EQ(bpm * 3 / 4, pMap->getBpm());
 
-    pMap->scale(Beats::FOURTHIRDS);
+    pMap = pMap->scale(Beats::FOURTHIRDS);
     EXPECT_DOUBLE_EQ(bpm, pMap->getBpm());
 }
 

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -55,7 +55,7 @@ TEST_F(BeatMapTest, Scale) {
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<double> beats = createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pMap = BeatMap::makeBeatMap(*m_pTrack, 0, QString(), beats);
+    auto pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
 
     EXPECT_DOUBLE_EQ(bpm, pMap->getBpm());
     pMap = pMap->scale(Beats::DOUBLE);
@@ -87,7 +87,7 @@ TEST_F(BeatMapTest, TestNthBeat) {
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<double> beats = createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pMap = BeatMap::makeBeatMap(*m_pTrack, 0, QString(), beats);
+    auto pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
 
     // Check edge cases
     double firstBeat = startOffsetSamples + beatLengthSamples * 0;
@@ -119,7 +119,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat) {
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<double> beats = createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pMap = BeatMap::makeBeatMap(*m_pTrack, 0, QString(), beats);
+    auto pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
 
     // Pretend we're on the 20th beat;
     const int curBeat = 20;
@@ -156,7 +156,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<double> beats = createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pMap = BeatMap::makeBeatMap(*m_pTrack, 0, QString(), beats);
+    auto pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
 
     // Pretend we're just before the 20th beat;
     const int curBeat = 20;
@@ -195,7 +195,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<double> beats = createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pMap = BeatMap::makeBeatMap(*m_pTrack, 0, QString(), beats);
+    auto pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
 
     // Pretend we're just after the 20th beat;
     const int curBeat = 20;
@@ -235,7 +235,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<double> beats = createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pMap = BeatMap::makeBeatMap(*m_pTrack, 0, QString(), beats);
+    auto pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
 
     // Pretend we're half way between the 20th and 21st beat
     double previousBeat = startOffsetSamples + beatLengthSamples * 20.0;
@@ -275,7 +275,7 @@ TEST_F(BeatMapTest, TestBpmAround) {
         beat_pos += beat_length;
     }
 
-    auto pMap = BeatMap::makeBeatMap(*m_pTrack, 0, QString(), beats);
+    auto pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
 
     // The average of the first 8 beats should be different than the average
     // of the last 8 beats.
@@ -291,7 +291,7 @@ TEST_F(BeatMapTest, TestBpmAround) {
 
     // Try a really, really short track
     beats = createBeatVector(10, 3, getBeatLengthFrames(filebpm));
-    pMap = BeatMap::makeBeatMap(*m_pTrack, 0, QString(), beats);
+    pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
     EXPECT_DOUBLE_EQ(filebpm, pMap->getBpmAroundPosition(1 * approx_beat_length, 4));
 }
 

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -55,7 +55,7 @@ TEST_F(BeatMapTest, Scale) {
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<double> beats = createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    mixxx::BeatsPointer pMap(new BeatMap(*m_pTrack, 0, beats));
+    auto pMap = BeatMap::makeBeatMap(*m_pTrack, 0, QString(), beats);
 
     EXPECT_DOUBLE_EQ(bpm, pMap->getBpm());
     pMap = pMap->scale(Beats::DOUBLE);
@@ -87,7 +87,7 @@ TEST_F(BeatMapTest, TestNthBeat) {
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<double> beats = createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pMap = std::make_unique<BeatMap>(*m_pTrack, 0, beats);
+    auto pMap = BeatMap::makeBeatMap(*m_pTrack, 0, QString(), beats);
 
     // Check edge cases
     double firstBeat = startOffsetSamples + beatLengthSamples * 0;
@@ -119,7 +119,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat) {
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<double> beats = createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pMap = std::make_unique<BeatMap>(*m_pTrack, 0, beats);
+    auto pMap = BeatMap::makeBeatMap(*m_pTrack, 0, QString(), beats);
 
     // Pretend we're on the 20th beat;
     const int curBeat = 20;
@@ -156,7 +156,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<double> beats = createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pMap = std::make_unique<BeatMap>(*m_pTrack, 0, beats);
+    auto pMap = BeatMap::makeBeatMap(*m_pTrack, 0, QString(), beats);
 
     // Pretend we're just before the 20th beat;
     const int curBeat = 20;
@@ -195,7 +195,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<double> beats = createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pMap = std::make_unique<BeatMap>(*m_pTrack, 0, beats);
+    auto pMap = BeatMap::makeBeatMap(*m_pTrack, 0, QString(), beats);
 
     // Pretend we're just after the 20th beat;
     const int curBeat = 20;
@@ -235,7 +235,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<double> beats = createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pMap = std::make_unique<BeatMap>(*m_pTrack, 0, beats);
+    auto pMap = BeatMap::makeBeatMap(*m_pTrack, 0, QString(), beats);
 
     // Pretend we're half way between the 20th and 21st beat
     double previousBeat = startOffsetSamples + beatLengthSamples * 20.0;
@@ -275,7 +275,7 @@ TEST_F(BeatMapTest, TestBpmAround) {
         beat_pos += beat_length;
     }
 
-    auto pMap = std::make_unique<BeatMap>(*m_pTrack, 0, beats);
+    auto pMap = BeatMap::makeBeatMap(*m_pTrack, 0, QString(), beats);
 
     // The average of the first 8 beats should be different than the average
     // of the last 8 beats.
@@ -291,7 +291,7 @@ TEST_F(BeatMapTest, TestBpmAround) {
 
     // Try a really, really short track
     beats = createBeatVector(10, 3, getBeatLengthFrames(filebpm));
-    pMap = std::make_unique<BeatMap>(*m_pTrack, 0, beats);
+    pMap = BeatMap::makeBeatMap(*m_pTrack, 0, QString(), beats);
     EXPECT_DOUBLE_EQ(filebpm, pMap->getBpmAroundPosition(1 * approx_beat_length, 4));
 }
 

--- a/src/test/beatstranslatetest.cpp
+++ b/src/test/beatstranslatetest.cpp
@@ -9,11 +9,13 @@ TEST_F(BeatsTranslateTest, SimpleTranslateMatch) {
     // Set up BeatGrids for decks 1 and 2.
     const double bpm = 60.0;
     const double firstBeat = 0.0;
-    auto grid1 = mixxx::BeatGrid::makeBeatGrid(*m_pTrack1, 0, QString(), bpm, firstBeat);
+    auto grid1 = mixxx::BeatGrid::makeBeatGrid(
+            m_pTrack1->getSampleRate(), QString(), bpm, firstBeat);
     m_pTrack1->setBeats(mixxx::BeatsPointer(grid1));
     ASSERT_DOUBLE_EQ(firstBeat, grid1->findClosestBeat(0));
 
-    auto grid2 = mixxx::BeatGrid::makeBeatGrid(*m_pTrack2, 0, QString(), bpm, firstBeat);
+    auto grid2 = mixxx::BeatGrid::makeBeatGrid(
+            m_pTrack2->getSampleRate(), QString(), bpm, firstBeat);
     m_pTrack2->setBeats(mixxx::BeatsPointer(grid2));
     ASSERT_DOUBLE_EQ(firstBeat, grid2->findClosestBeat(0));
 

--- a/src/test/beatstranslatetest.cpp
+++ b/src/test/beatstranslatetest.cpp
@@ -9,13 +9,11 @@ TEST_F(BeatsTranslateTest, SimpleTranslateMatch) {
     // Set up BeatGrids for decks 1 and 2.
     const double bpm = 60.0;
     const double firstBeat = 0.0;
-    auto grid1 = new mixxx::BeatGrid(*m_pTrack1, m_pTrack1->getSampleRate());
-    grid1->setGrid(bpm, firstBeat);
+    auto grid1 = mixxx::BeatGrid::makeBeatGrid(*m_pTrack1, 0, bpm, firstBeat);
     m_pTrack1->setBeats(mixxx::BeatsPointer(grid1));
     ASSERT_DOUBLE_EQ(firstBeat, grid1->findClosestBeat(0));
 
-    auto grid2 = new mixxx::BeatGrid(*m_pTrack2, m_pTrack2->getSampleRate());
-    grid2->setGrid(bpm, firstBeat);
+    auto grid2 = mixxx::BeatGrid::makeBeatGrid(*m_pTrack2, 0, bpm, firstBeat);
     m_pTrack2->setBeats(mixxx::BeatsPointer(grid2));
     ASSERT_DOUBLE_EQ(firstBeat, grid2->findClosestBeat(0));
 

--- a/src/test/beatstranslatetest.cpp
+++ b/src/test/beatstranslatetest.cpp
@@ -9,11 +9,11 @@ TEST_F(BeatsTranslateTest, SimpleTranslateMatch) {
     // Set up BeatGrids for decks 1 and 2.
     const double bpm = 60.0;
     const double firstBeat = 0.0;
-    auto grid1 = mixxx::BeatGrid::makeBeatGrid(*m_pTrack1, 0, bpm, firstBeat);
+    auto grid1 = mixxx::BeatGrid::makeBeatGrid(*m_pTrack1, 0, QString(), bpm, firstBeat);
     m_pTrack1->setBeats(mixxx::BeatsPointer(grid1));
     ASSERT_DOUBLE_EQ(firstBeat, grid1->findClosestBeat(0));
 
-    auto grid2 = mixxx::BeatGrid::makeBeatGrid(*m_pTrack2, 0, bpm, firstBeat);
+    auto grid2 = mixxx::BeatGrid::makeBeatGrid(*m_pTrack2, 0, QString(), bpm, firstBeat);
     m_pTrack2->setBeats(mixxx::BeatsPointer(grid2));
     ASSERT_DOUBLE_EQ(firstBeat, grid2->findClosestBeat(0));
 

--- a/src/test/beatstranslatetest.cpp
+++ b/src/test/beatstranslatetest.cpp
@@ -46,5 +46,6 @@ TEST_F(BeatsTranslateTest, SimpleTranslateMatch) {
     // Deck 1 is +delta away from its closest beat (which is at 0).
     // Deck 2 was left at 0. We translated grid 2 so that it is also +delta
     // away from its closest beat, so that beat should be at -delta.
-    ASSERT_DOUBLE_EQ(-delta, grid2->findClosestBeat(0));
+    mixxx::BeatsPointer beats = m_pTrack2->getBeats();
+    ASSERT_DOUBLE_EQ(-delta, beats->findClosestBeat(0));
 }

--- a/src/test/bpmcontrol_test.cpp
+++ b/src/test/bpmcontrol_test.cpp
@@ -37,7 +37,7 @@ TEST_F(BpmControlTest, BeatContext_BeatGrid) {
     const int kFrameSize = 2;
     const double expectedBeatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
-    mixxx::BeatsPointer pBeats = BeatFactory::makeBeatGrid(*pTrack, bpm, 0);
+    mixxx::BeatsPointer pBeats = BeatFactory::makeBeatGrid(pTrack->getSampleRate(), bpm, 0);
 
     // On a beat.
     double prevBeat, nextBeat, beatLength, beatPercentage;

--- a/src/test/bpmcontrol_test.cpp
+++ b/src/test/bpmcontrol_test.cpp
@@ -37,7 +37,7 @@ TEST_F(BpmControlTest, BeatContext_BeatGrid) {
     const int kFrameSize = 2;
     const double expectedBeatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
-    mixxx::BeatsPointer pBeats = BeatFactory::makeBeatGrid(pTrack->getSampleRate(), bpm, 0);
+    const mixxx::BeatsPointer pBeats = BeatFactory::makeBeatGrid(pTrack->getSampleRate(), bpm, 0);
 
     // On a beat.
     double prevBeat, nextBeat, beatLength, beatPercentage;

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -1790,14 +1790,14 @@ TEST_F(EngineSyncTest, HalfDoubleConsistency) {
     const int numBeats = 100;
     QVector<double> beats1 =
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pBeats1 = new mixxx::BeatMap(*m_pTrack1, 0, beats1);
-    m_pTrack1->setBeats(mixxx::BeatsPointer(pBeats1));
+    auto pBeats1 = mixxx::BeatMap::makeBeatMap(*m_pTrack1, 0, QString(), beats1);
+    m_pTrack1->setBeats(pBeats1);
 
     beatLengthFrames = 60.0 * 44100 / 145.0;
     QVector<double> beats2 =
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pBeats2 = new mixxx::BeatMap(*m_pTrack2, 0, beats2);
-    m_pTrack2->setBeats(mixxx::BeatsPointer(pBeats2));
+    auto pBeats2 = mixxx::BeatMap::makeBeatMap(*m_pTrack2, 0, QString(), beats2);
+    m_pTrack2->setBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
     ControlObject::getControl(ConfigKey(m_sGroup2, "sync_enabled"))->set(1);
@@ -2418,11 +2418,12 @@ TEST_F(EngineSyncTest, BeatMapQantizePlay) {
 
     constexpr int kSampleRate = 44100;
 
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatsPointer(new mixxx::BeatMap(
+    auto pBeats2 = mixxx::BeatMap::makeBeatMap(
             *m_pTrack2,
             kSampleRate,
+            QString(),
             // Add two beats at 120 Bpm
-            QVector<double>({kSampleRate / 2, kSampleRate})));
+            QVector<double>({kSampleRate / 2, kSampleRate}));
     m_pTrack2->setBeats(pBeats2);
 
     ControlObject::set(ConfigKey(m_sGroup1, "quantize"), 1.0);

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -2416,10 +2416,13 @@ TEST_F(EngineSyncTest, BeatMapQantizePlay) {
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 120, 0.0);
     m_pTrack1->setBeats(pBeats1);
 
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatsPointer(new mixxx::BeatMap(*m_pTrack2, 44100));
-    // Add two beats at 120 Bpm
-    pBeats2->addBeat(44100 / 2);
-    pBeats2->addBeat(44100);
+    constexpr int kSampleRate = 44100;
+
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatsPointer(new mixxx::BeatMap(
+            *m_pTrack2,
+            kSampleRate,
+            // Add two beats at 120 Bpm
+            QVector<double>({kSampleRate / 2, kSampleRate})));
     m_pTrack2->setBeats(pBeats2);
 
     ControlObject::set(ConfigKey(m_sGroup1, "quantize"), 1.0);

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -193,9 +193,9 @@ TEST_F(EngineSyncTest, SetMasterSuccess) {
 TEST_F(EngineSyncTest, ExplicitMasterPersists) {
     // If we set an explicit master, enabling sync or pressing play on other decks
     // doesn't cause the master to move around.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 120, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 120, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 124, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 124, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     auto pButtonMasterSync1 =
@@ -225,11 +225,11 @@ TEST_F(EngineSyncTest, ExplicitMasterPersists) {
 
 TEST_F(EngineSyncTest, SetMasterWhilePlaying) {
     // Make sure we don't get two master lights if we change masters while playing.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 120, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 120, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 124, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 124, 0.0);
     m_pTrack2->setBeats(pBeats2);
-    mixxx::BeatsPointer pBeats3 = BeatFactory::makeBeatGrid(*m_pTrack3, 128, 0.0);
+    mixxx::BeatsPointer pBeats3 = BeatFactory::makeBeatGrid(m_pTrack3->getSampleRate(), 128, 0.0);
     m_pTrack3->setBeats(pBeats3);
 
     auto pButtonMasterSync1 =
@@ -259,7 +259,7 @@ TEST_F(EngineSyncTest, SetMasterWhilePlaying) {
 
 TEST_F(EngineSyncTest, SetEnabledBecomesMaster) {
     // If we set the first channel with a valid tempo to follower, it should be master.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 80, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 80, 0.0);
     m_pTrack1->setBeats(pBeats1);
     auto pButtonMasterSync1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
@@ -286,10 +286,10 @@ TEST_F(EngineSyncTest, DisableInternalMasterWhilePlaying) {
     ASSERT_TRUE(isSoftMaster(m_sInternalClockGroup));
 
     // Make sure both decks are playing.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 80, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 80, 0.0);
     m_pTrack1->setBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 80, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 80, 0.0);
     m_pTrack2->setBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup2, "play"))->set(1.0);
     ProcessBuffer();
@@ -305,13 +305,13 @@ TEST_F(EngineSyncTest, DisableInternalMasterWhilePlaying) {
 
 TEST_F(EngineSyncTest, DisableSyncOnMaster) {
     // Channel 1 follower, channel 2 master.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
     auto pButtonSyncMode1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     pButtonSyncMode1->slotSet(SYNC_FOLLOWER);
 
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 130, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 130, 0.0);
     m_pTrack2->setBeats(pBeats2);
     auto pButtonSyncMaster2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_master");
@@ -343,7 +343,7 @@ TEST_F(EngineSyncTest, InternalMasterSetFollowerSliderMoves) {
     pMasterSyncSlider->set(100.0);
 
     // Set the file bpm of channel 1 to 80 bpm.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 80, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 80, 0.0);
     m_pTrack1->setBeats(pBeats1);
 
     auto pButtonMasterSync1 =
@@ -361,7 +361,7 @@ TEST_F(EngineSyncTest, AnySyncDeckSliderStays) {
     // If there exists a sync deck, even if it's not playing, don't change the
     // master BPM if a new deck enables sync.
 
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 80, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 80, 0.0);
     m_pTrack1->setBeats(pBeats1);
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
@@ -372,7 +372,7 @@ TEST_F(EngineSyncTest, AnySyncDeckSliderStays) {
             ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))
                     ->get());
 
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 100, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 100, 0.0);
     m_pTrack2->setBeats(pBeats2);
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
@@ -396,11 +396,11 @@ TEST_F(EngineSyncTest, InternalClockFollowsFirstPlayingDeck) {
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
 
     // Set up decks so they can be playing, and start deck 1.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 100, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 100, 0.0);
     m_pTrack1->setBeats(pBeats1);
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 130, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 130, 0.0);
     m_pTrack2->setBeats(pBeats2);
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup2, "play"), 0.0);
@@ -466,10 +466,10 @@ TEST_F(EngineSyncTest, SetExplicitMasterByLights) {
             std::make_unique<ControlProxy>(m_sGroup2, "sync_master");
 
     // Set the file bpm of channel 1 to 160bpm.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
     m_pTrack1->setBeats(pBeats1);
     // Set the file bpm of channel 2 to 150bpm.
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack1, 150, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 150, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     // Set channel 1 to be explicit master.
@@ -552,7 +552,7 @@ TEST_F(EngineSyncTest, RateChangeTest) {
     ProcessBuffer();
 
     // Set the file bpm of channel 1 to 160bpm.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
     m_pTrack1->setBeats(pBeats1);
     EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sGroup1, "file_bpm")));
@@ -571,7 +571,7 @@ TEST_F(EngineSyncTest, RateChangeTest) {
             192.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 120, 0.0);
     m_pTrack2->setBeats(pBeats2);
     EXPECT_DOUBLE_EQ(
             120.0, ControlObject::get(ConfigKey(m_sGroup2, "file_bpm")));
@@ -593,13 +593,13 @@ TEST_F(EngineSyncTest, RateChangeTestWeirdOrder) {
     ProcessBuffer();
 
     // Set the file bpm of channel 1 to 160bpm.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
     m_pTrack1->setBeats(pBeats1);
     EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 120, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     // Set the rate slider of channel 1 to 1.2.
@@ -617,13 +617,13 @@ TEST_F(EngineSyncTest, RateChangeTestWeirdOrder) {
 
 TEST_F(EngineSyncTest, RateChangeTestOrder3) {
     // Set the file bpm of channel 1 to 160bpm.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
     m_pTrack1->setBeats(pBeats1);
     EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sGroup1, "file_bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 120, 0.0);
     m_pTrack2->setBeats(pBeats2);
     EXPECT_DOUBLE_EQ(
             120.0, ControlObject::get(ConfigKey(m_sGroup2, "file_bpm")));
@@ -661,11 +661,11 @@ TEST_F(EngineSyncTest, FollowerRateChange) {
     ProcessBuffer();
 
     // Set the file bpm of channel 1 to 160bpm.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
     m_pTrack1->setBeats(pBeats1);
 
     // Set the file bpm of channel 2 to 120bpm.
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 120, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     // Set the rate slider of channel 1 to 1.2.
@@ -707,13 +707,13 @@ TEST_F(EngineSyncTest, InternalRateChangeTest) {
     ASSERT_TRUE(isFollower(m_sGroup2));
 
     // Set the file bpm of channel 1 to 160bpm.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
     m_pTrack1->setBeats(pBeats1);
     EXPECT_DOUBLE_EQ(160.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "file_bpm"))->get());
 
     // Set the file bpm of channel 2 to 120bpm.
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 120, 0.0);
     m_pTrack2->setBeats(pBeats2);
     EXPECT_DOUBLE_EQ(120.0,
             ControlObject::getControl(ConfigKey(m_sGroup2, "file_bpm"))->get());
@@ -761,9 +761,9 @@ TEST_F(EngineSyncTest, InternalRateChangeTest) {
 
 TEST_F(EngineSyncTest, MasterStopSliderCheck) {
     // If the master is playing, and stop is pushed, the sliders should stay the same.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 120, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 120, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 128, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 128, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     auto pButtonMasterSync1 =
@@ -805,7 +805,7 @@ TEST_F(EngineSyncTest, EnableOneDeckInitsMaster) {
     ProcessBuffer();
 
     // Set up the deck to play.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
             ->set(getRateSliderValue(1.0));
@@ -832,7 +832,7 @@ TEST_F(EngineSyncTest, EnableOneDeckInitsMaster) {
                     ConfigKey(m_sInternalClockGroup, "beat_distance")));
 
     // Enable second deck, bpm and beat distance should still match original setting.
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 140, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 140, 0.0);
     m_pTrack2->setBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))
             ->set(getRateSliderValue(1.0));
@@ -859,7 +859,7 @@ TEST_F(EngineSyncTest, EnableOneDeckInitsMaster) {
 TEST_F(EngineSyncTest, EnableOneDeckInitializesMaster) {
     // Enabling sync on a deck causes it to be master, and sets bpm and clock.
     // Set the deck to play.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
             ->set(getRateSliderValue(1.0));
@@ -1048,7 +1048,7 @@ TEST_F(EngineSyncTest, EnableOneDeckSliderUpdates) {
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
 
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
             ->set(getRateSliderValue(1.0));
@@ -1075,11 +1075,11 @@ TEST_F(EngineSyncTest, SyncToNonSyncDeck) {
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
 
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
     ProcessBuffer();
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 100, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 100, 0.0);
     m_pTrack2->setBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))
             ->set(getRateSliderValue(1.0));
@@ -1158,11 +1158,11 @@ TEST_F(EngineSyncTest, MomentarySyncDependsOnPlayingStates) {
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
 
     // Set up decks so they can be playing, and start deck 1.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 100, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 100, 0.0);
     m_pTrack1->setBeats(pBeats1);
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 130, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 130, 0.0);
     m_pTrack2->setBeats(pBeats2);
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup2, "play"), 1.0);
@@ -1231,7 +1231,7 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     auto pButtonEject1 = std::make_unique<ControlProxy>(m_sGroup1, "eject");
 
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 120, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 120, 0.0);
     m_pTrack1->setBeats(pBeats1);
     pButtonSyncEnabled1->set(1.0);
     ProcessBuffer();
@@ -1256,7 +1256,7 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
     m_pMixerDeck1->loadFakeTrack(false, 128.0);
     EXPECT_DOUBLE_EQ(128.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 135, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 135, 0.0);
     m_pTrack2->setBeats(pBeats2);
     pButtonSyncEnabled2->set(1.0);
     ProcessBuffer();
@@ -1276,21 +1276,21 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
 
 TEST_F(EngineSyncTest, FileBpmChangesDontAffectMaster) {
     // If filebpm changes, don't treat it like a rate change.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 100, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 100, 0.0);
     m_pTrack1->setBeats(pBeats1);
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     pButtonSyncEnabled1->set(1.0);
     ProcessBuffer();
 
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 120, 0.0);
     m_pTrack2->setBeats(pBeats2);
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     pButtonSyncEnabled2->set(1.0);
     ProcessBuffer();
 
-    pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
+    pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
     m_pTrack1->setBeats(pBeats1);
     EXPECT_DOUBLE_EQ(
             100.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
@@ -1302,7 +1302,7 @@ TEST_F(EngineSyncTest, ExplicitMasterPostProcessed) {
     auto pButtonMasterSync1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     pButtonMasterSync1->slotSet(SYNC_MASTER_EXPLICIT);
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 160, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 160, 0.0);
     m_pTrack1->setBeats(pBeats1);
     ProcessBuffer();
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
@@ -1316,7 +1316,7 @@ TEST_F(EngineSyncTest, ExplicitMasterPostProcessed) {
 TEST_F(EngineSyncTest, ZeroBPMRateAdjustIgnored) {
     // If a track isn't loaded (0 bpm), but the deck has sync enabled,
     // don't pay attention to rate changes.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 0, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 0, 0.0);
     m_pTrack1->setBeats(pBeats1);
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
@@ -1325,7 +1325,7 @@ TEST_F(EngineSyncTest, ZeroBPMRateAdjustIgnored) {
             ->set(getRateSliderValue(1.0));
     ProcessBuffer();
 
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 120, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 120, 0.0);
     m_pTrack2->setBeats(pBeats2);
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
@@ -1361,9 +1361,9 @@ TEST_F(EngineSyncTest, ZeroBPMRateAdjustIgnored) {
 TEST_F(EngineSyncTest, ZeroLatencyRateChangeNoQuant) {
     // Confirm that a rate change in an explicit master is instantly communicated
     // to followers.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 128, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 128, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 160, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 160, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     // Make Channel2 master to weed out any channel ordering issues.
@@ -1409,9 +1409,9 @@ TEST_F(EngineSyncTest, ZeroLatencyRateChangeNoQuant) {
 TEST_F(EngineSyncTest, ZeroLatencyRateChangeQuant) {
     // Confirm that a rate change in an explicit master is instantly communicated
     // to followers.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 128, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 128, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 160, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 160, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
@@ -1460,9 +1460,9 @@ TEST_F(EngineSyncTest, ZeroLatencyRateChangeQuant) {
 TEST_F(EngineSyncTest, ZeroLatencyRateDiffQuant) {
     // Confirm that a rate change in an explicit master is instantly communicated
     // to followers.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 128, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 128, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 160, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 160, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup2, "quantize"))->set(1.0);
@@ -1512,9 +1512,9 @@ TEST_F(EngineSyncTest, ZeroLatencyRateDiffQuant) {
 // need to check. The Sync feature is unfortunately brittle.
 // This test exercises https://bugs.launchpad.net/mixxx/+bug/1884324
 TEST_F(EngineSyncTest, ActivatingSyncDoesNotCauseDrifting) {
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 150, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 150, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 150, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 150, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(0.0);
@@ -1556,9 +1556,9 @@ TEST_F(EngineSyncTest, ActivatingSyncDoesNotCauseDrifting) {
 }
 
 TEST_F(EngineSyncTest, HalfDoubleBpmTest) {
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 70, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 70, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 140, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 140, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
@@ -1649,9 +1649,9 @@ TEST_F(EngineSyncTest, HalfDoubleBpmTest) {
 TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
     // If a deck plays that had its multiplier set, we need to reset the
     // internal clock.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 80, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 80, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 175, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 175, 0.0);
     m_pTrack2->setBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
             ->set(getRateSliderValue(1.0));
@@ -1752,9 +1752,9 @@ TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
 
 TEST_F(EngineSyncTest, HalfDoubleInternalClockTest) {
     // If we set the file_bpm CO's directly, the correct signals aren't fired.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 70, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 70, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 140, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 140, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
@@ -1790,13 +1790,13 @@ TEST_F(EngineSyncTest, HalfDoubleConsistency) {
     const int numBeats = 100;
     QVector<double> beats1 =
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pBeats1 = mixxx::BeatMap::makeBeatMap(*m_pTrack1, 0, QString(), beats1);
+    auto pBeats1 = mixxx::BeatMap::makeBeatMap(m_pTrack1->getSampleRate(), QString(), beats1);
     m_pTrack1->setBeats(pBeats1);
 
     beatLengthFrames = 60.0 * 44100 / 145.0;
     QVector<double> beats2 =
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pBeats2 = mixxx::BeatMap::makeBeatMap(*m_pTrack2, 0, QString(), beats2);
+    auto pBeats2 = mixxx::BeatMap::makeBeatMap(m_pTrack2->getSampleRate(), QString(), beats2);
     m_pTrack2->setBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
@@ -1823,7 +1823,7 @@ TEST_F(EngineSyncTest, HalfDoubleConsistency) {
 
 TEST_F(EngineSyncTest, SetFileBpmUpdatesLocalBpm) {
     ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->set(0.2);
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
     ASSERT_EQ(
             130.0, m_pEngineSync->getSyncableForGroup(m_sGroup1)->getBaseBpm());
@@ -1835,14 +1835,14 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
 
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
 
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     ControlObject::set(ConfigKey(m_sGroup2, "rate_ratio"), 1.0);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 100, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 100, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     // Set the sync deck playing with nothing else active.
@@ -1925,7 +1925,7 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
             std::make_unique<ControlProxy>(m_sGroup3, "sync_enabled");
     ControlObject::set(ConfigKey(m_sGroup3, "beat_distance"), 0.6);
     ControlObject::set(ConfigKey(m_sGroup2, "rate_ratio"), 1.0);
-    mixxx::BeatsPointer pBeats3 = BeatFactory::makeBeatGrid(*m_pTrack3, 140, 0.0);
+    mixxx::BeatsPointer pBeats3 = BeatFactory::makeBeatGrid(m_pTrack3->getSampleRate(), 140, 0.0);
     m_pTrack3->setBeats(pBeats3);
     // This will sync to the first deck here and not the second (lp1784185)
     pButtonSyncEnabled3->set(1.0);
@@ -1966,9 +1966,9 @@ TEST_F(EngineSyncTest, UserTweakBeatDistance) {
     // If a deck has a user tweak, and another deck stops such that the first
     // is used to reseed the master beat distance, make sure the user offset
     // is reset.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 128, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 128, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 128, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 128, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
@@ -2019,9 +2019,10 @@ TEST_F(EngineSyncTest, UserTweakPreservedInSeek) {
 
     // This is about 128 bpm, but results in nice round numbers of samples.
     const double kDivisibleBpm = 44100.0 / 344.0;
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, kDivisibleBpm, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+            m_pTrack1->getSampleRate(), kDivisibleBpm, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 130, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 130, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup2, "sync_enabled"))->set(1);
@@ -2093,7 +2094,7 @@ TEST_F(EngineSyncTest, UserTweakPreservedInSeek) {
 }
 
 TEST_F(EngineSyncTest, MasterBpmNeverZero) {
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 128, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 128, 0.0);
     m_pTrack1->setBeats(pBeats1);
 
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
@@ -2108,7 +2109,7 @@ TEST_F(EngineSyncTest, ZeroBpmNaturalRate) {
     // If a track has a zero bpm and a bad beatgrid, make sure the rate
     // doesn't end up something crazy when sync is enabled..
     // Maybe the beatgrid ended up at zero also.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 0.0, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 0.0, 0.0);
     m_pTrack1->setBeats(pBeats1);
 
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
@@ -2127,11 +2128,11 @@ TEST_F(EngineSyncTest, QuantizeImpliesSyncPhase) {
     auto pButtonBeatsync1 = std::make_unique<ControlProxy>(m_sGroup1, "beatsync");
     auto pButtonBeatsyncPhase1 = std::make_unique<ControlProxy>(m_sGroup1, "beatsync_phase");
 
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
 
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 100, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 100, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
@@ -2220,7 +2221,7 @@ TEST_F(EngineSyncTest, QuantizeImpliesSyncPhase) {
 TEST_F(EngineSyncTest, SeekStayInPhase) {
     ControlObject::set(ConfigKey(m_sGroup1, "quantize"), 1.0);
 
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
@@ -2241,7 +2242,7 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 0.0);
     ProcessBuffer();
 
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
@@ -2263,7 +2264,7 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
 
 TEST_F(EngineSyncTest, SyncWithoutBeatgrid) {
     // this tests bug lp1783020, notresetting rate when other deck has no beatgrid
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 128, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 128, 0.0);
     m_pTrack1->setBeats(pBeats1);
     m_pTrack2->setBeats(mixxx::BeatsPointer());
 
@@ -2282,11 +2283,11 @@ TEST_F(EngineSyncTest, SyncWithoutBeatgrid) {
 }
 
 TEST_F(EngineSyncTest, QuantizeHotCueActivate) {
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
 
     auto pHotCue2Activate = std::make_unique<ControlProxy>(m_sGroup2, "hotcue_1_activate");
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 100, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 100, 0.0);
 
     m_pTrack2->setBeats(pBeats2);
 
@@ -2344,7 +2345,7 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
     auto pButtonSyncEnabled2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
 
     // set beatgrid
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
     pButtonSyncEnabled1->set(1.0);
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
@@ -2376,7 +2377,7 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
     ASSERT_TRUE(isFollower(m_sGroup2));
 
     // Load a new beatgrid during playing, this happens when the analyser is finished
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 140, 0.0);
+    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 140, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     ProcessBuffer();
@@ -2398,7 +2399,7 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
     ASSERT_TRUE(isFollower(m_sGroup2));
 
     // Load a new beatgrid again, this happens when the user adjusts the beatgrid
-    mixxx::BeatsPointer pBeats2n = BeatFactory::makeBeatGrid(*m_pTrack2, 75, 0.0);
+    mixxx::BeatsPointer pBeats2n = BeatFactory::makeBeatGrid(m_pTrack2->getSampleRate(), 75, 0.0);
     m_pTrack2->setBeats(pBeats2n);
 
     ProcessBuffer();
@@ -2413,13 +2414,12 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
 
 TEST_F(EngineSyncTest, BeatMapQantizePlay) {
     // This test demonstates https://bugs.launchpad.net/mixxx/+bug/1874918
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 120, 0.0);
+    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 120, 0.0);
     m_pTrack1->setBeats(pBeats1);
 
     constexpr int kSampleRate = 44100;
 
     auto pBeats2 = mixxx::BeatMap::makeBeatMap(
-            *m_pTrack2,
             kSampleRate,
             QString(),
             // Add two beats at 120 Bpm

--- a/src/track/beatfactory.cpp
+++ b/src/track/beatfactory.cpp
@@ -12,8 +12,7 @@ mixxx::BeatsPointer BeatFactory::loadBeatsFromByteArray(const Track& track,
         const QByteArray& beatsSerialized) {
     if (beatsVersion == BEAT_GRID_1_VERSION ||
         beatsVersion == BEAT_GRID_2_VERSION) {
-        auto pGrid = mixxx::BeatGrid::makeBeatGrid(track, 0, beatsSerialized);
-        pGrid->setSubVersion(beatsSubVersion);
+        auto pGrid = mixxx::BeatGrid::makeBeatGrid(track, 0, beatsSubVersion, beatsSerialized);
         qDebug() << "Successfully deserialized BeatGrid";
         return pGrid;
     } else if (beatsVersion == BEAT_MAP_VERSION) {
@@ -27,7 +26,7 @@ mixxx::BeatsPointer BeatFactory::loadBeatsFromByteArray(const Track& track,
 
 mixxx::BeatsPointer BeatFactory::makeBeatGrid(
         const Track& track, double dBpm, double dFirstBeatSample) {
-    return mixxx::BeatGrid::makeBeatGrid(track, 0, dBpm, dFirstBeatSample);
+    return mixxx::BeatGrid::makeBeatGrid(track, 0, QString(), dBpm, dFirstBeatSample);
 }
 
 // static
@@ -110,8 +109,8 @@ mixxx::BeatsPointer BeatFactory::makePreferredBeats(const Track& track,
         double firstBeat = BeatUtils::calculateFixedTempoFirstBeat(
             bEnableOffsetCorrection,
             beats, iSampleRate, iTotalSamples, globalBpm);
-        auto pGrid = mixxx::BeatGrid::makeBeatGrid(track, iSampleRate, globalBpm, firstBeat * 2);
-        pGrid->setSubVersion(subVersion);
+        auto pGrid = mixxx::BeatGrid::makeBeatGrid(
+                track, iSampleRate, subVersion, globalBpm, firstBeat * 2);
         return pGrid;
     } else if (version == BEAT_MAP_VERSION) {
         auto pBeatMap = mixxx::BeatMap::makeBeatMap(track, iSampleRate, subVersion, beats);

--- a/src/track/beatfactory.cpp
+++ b/src/track/beatfactory.cpp
@@ -121,12 +121,3 @@ mixxx::BeatsPointer BeatFactory::makePreferredBeats(
         return mixxx::BeatsPointer();
     }
 }
-
-void BeatFactory::deleteBeats(mixxx::Beats* pBeats) {
-    // BeatGrid/BeatMap objects have no parent and live in the same thread as
-    // their associated TIO. QObject::deleteLater does not have the desired
-    // effect when the QObject's thread does not have an event loop (i.e. when
-    // the main thread has already shut down) so we delete the BeatMap/BeatGrid
-    // directly when its reference count drops to zero.
-    delete pBeats;
-}

--- a/src/track/beatfactory.cpp
+++ b/src/track/beatfactory.cpp
@@ -17,10 +17,9 @@ mixxx::BeatsPointer BeatFactory::loadBeatsFromByteArray(const Track& track,
         qDebug() << "Successfully deserialized BeatGrid";
         return pGrid;
     } else if (beatsVersion == BEAT_MAP_VERSION) {
-        mixxx::BeatMap* pMap = new mixxx::BeatMap(track, 0, beatsSerialized);
-        pMap->setSubVersion(beatsSubVersion);
+        auto pMap = mixxx::BeatMap::makeBeatMap(track, 0, beatsSubVersion, beatsSerialized);
         qDebug() << "Successfully deserialized BeatMap";
-        return mixxx::BeatsPointer(pMap, &BeatFactory::deleteBeats);
+        return pMap;
     }
     qDebug() << "BeatFactory::loadBeatsFromByteArray could not parse serialized beats.";
     return mixxx::BeatsPointer();
@@ -115,9 +114,8 @@ mixxx::BeatsPointer BeatFactory::makePreferredBeats(const Track& track,
         pGrid->setSubVersion(subVersion);
         return pGrid;
     } else if (version == BEAT_MAP_VERSION) {
-        mixxx::BeatMap* pBeatMap = new mixxx::BeatMap(track, iSampleRate, beats);
-        pBeatMap->setSubVersion(subVersion);
-        return mixxx::BeatsPointer(pBeatMap, &BeatFactory::deleteBeats);
+        auto pBeatMap = mixxx::BeatMap::makeBeatMap(track, iSampleRate, subVersion, beats);
+        return pBeatMap;
     } else {
         qDebug() << "ERROR: Could not determine what type of beatgrid to create.";
         return mixxx::BeatsPointer();

--- a/src/track/beatfactory.cpp
+++ b/src/track/beatfactory.cpp
@@ -12,10 +12,10 @@ mixxx::BeatsPointer BeatFactory::loadBeatsFromByteArray(const Track& track,
         const QByteArray& beatsSerialized) {
     if (beatsVersion == BEAT_GRID_1_VERSION ||
         beatsVersion == BEAT_GRID_2_VERSION) {
-        mixxx::BeatGrid* pGrid = new mixxx::BeatGrid(track, 0, beatsSerialized);
+        auto pGrid = mixxx::BeatGrid::makeBeatGrid(track, 0, beatsSerialized);
         pGrid->setSubVersion(beatsSubVersion);
         qDebug() << "Successfully deserialized BeatGrid";
-        return mixxx::BeatsPointer(pGrid, &BeatFactory::deleteBeats);
+        return pGrid;
     } else if (beatsVersion == BEAT_MAP_VERSION) {
         mixxx::BeatMap* pMap = new mixxx::BeatMap(track, 0, beatsSerialized);
         pMap->setSubVersion(beatsSubVersion);
@@ -28,9 +28,7 @@ mixxx::BeatsPointer BeatFactory::loadBeatsFromByteArray(const Track& track,
 
 mixxx::BeatsPointer BeatFactory::makeBeatGrid(
         const Track& track, double dBpm, double dFirstBeatSample) {
-    mixxx::BeatGrid* pGrid = new mixxx::BeatGrid(track, 0);
-    pGrid->setGrid(dBpm, dFirstBeatSample);
-    return mixxx::BeatsPointer(pGrid, &BeatFactory::deleteBeats);
+    return mixxx::BeatGrid::makeBeatGrid(track, 0, dBpm, dFirstBeatSample);
 }
 
 // static
@@ -113,11 +111,9 @@ mixxx::BeatsPointer BeatFactory::makePreferredBeats(const Track& track,
         double firstBeat = BeatUtils::calculateFixedTempoFirstBeat(
             bEnableOffsetCorrection,
             beats, iSampleRate, iTotalSamples, globalBpm);
-        mixxx::BeatGrid* pGrid = new mixxx::BeatGrid(track, iSampleRate);
-        // firstBeat is in frames here and setGrid() takes samples.
-        pGrid->setGrid(globalBpm, firstBeat * 2);
+        auto pGrid = mixxx::BeatGrid::makeBeatGrid(track, iSampleRate, globalBpm, firstBeat * 2);
         pGrid->setSubVersion(subVersion);
-        return mixxx::BeatsPointer(pGrid, &BeatFactory::deleteBeats);
+        return pGrid;
     } else if (version == BEAT_MAP_VERSION) {
         mixxx::BeatMap* pBeatMap = new mixxx::BeatMap(track, iSampleRate, beats);
         pBeatMap->setSubVersion(subVersion);

--- a/src/track/beatfactory.cpp
+++ b/src/track/beatfactory.cpp
@@ -6,17 +6,18 @@
 #include "track/beatfactory.h"
 #include "track/beatutils.h"
 
-mixxx::BeatsPointer BeatFactory::loadBeatsFromByteArray(const Track& track,
+mixxx::BeatsPointer BeatFactory::loadBeatsFromByteArray(
+        SINT sampleRate,
         const QString& beatsVersion,
         const QString& beatsSubVersion,
         const QByteArray& beatsSerialized) {
     if (beatsVersion == BEAT_GRID_1_VERSION ||
         beatsVersion == BEAT_GRID_2_VERSION) {
-        auto pGrid = mixxx::BeatGrid::makeBeatGrid(track, 0, beatsSubVersion, beatsSerialized);
+        auto pGrid = mixxx::BeatGrid::makeBeatGrid(sampleRate, beatsSubVersion, beatsSerialized);
         qDebug() << "Successfully deserialized BeatGrid";
         return pGrid;
     } else if (beatsVersion == BEAT_MAP_VERSION) {
-        auto pMap = mixxx::BeatMap::makeBeatMap(track, 0, beatsSubVersion, beatsSerialized);
+        auto pMap = mixxx::BeatMap::makeBeatMap(sampleRate, beatsSubVersion, beatsSerialized);
         qDebug() << "Successfully deserialized BeatMap";
         return pMap;
     }
@@ -25,8 +26,8 @@ mixxx::BeatsPointer BeatFactory::loadBeatsFromByteArray(const Track& track,
 }
 
 mixxx::BeatsPointer BeatFactory::makeBeatGrid(
-        const Track& track, double dBpm, double dFirstBeatSample) {
-    return mixxx::BeatGrid::makeBeatGrid(track, 0, QString(), dBpm, dFirstBeatSample);
+        SINT sampleRate, double dBpm, double dFirstBeatSample) {
+    return mixxx::BeatGrid::makeBeatGrid(sampleRate, QString(), dBpm, dFirstBeatSample);
 }
 
 // static
@@ -88,7 +89,7 @@ QString BeatFactory::getPreferredSubVersion(
                                   : "";
 }
 
-mixxx::BeatsPointer BeatFactory::makePreferredBeats(const Track& track,
+mixxx::BeatsPointer BeatFactory::makePreferredBeats(
         const QVector<double>& beats,
         const QHash<QString, QString>& extraVersionInfo,
         const bool bEnableFixedTempoCorrection,
@@ -110,10 +111,10 @@ mixxx::BeatsPointer BeatFactory::makePreferredBeats(const Track& track,
             bEnableOffsetCorrection,
             beats, iSampleRate, iTotalSamples, globalBpm);
         auto pGrid = mixxx::BeatGrid::makeBeatGrid(
-                track, iSampleRate, subVersion, globalBpm, firstBeat * 2);
+                iSampleRate, subVersion, globalBpm, firstBeat * 2);
         return pGrid;
     } else if (version == BEAT_MAP_VERSION) {
-        auto pBeatMap = mixxx::BeatMap::makeBeatMap(track, iSampleRate, subVersion, beats);
+        auto pBeatMap = mixxx::BeatMap::makeBeatMap(iSampleRate, subVersion, beats);
         return pBeatMap;
     } else {
         qDebug() << "ERROR: Could not determine what type of beatgrid to create.";

--- a/src/track/beatfactory.h
+++ b/src/track/beatfactory.h
@@ -36,7 +36,4 @@ class BeatFactory {
             const int iTotalSamples,
             const int iMinBpm,
             const int iMaxBpm);
-
-  private:
-    static void deleteBeats(mixxx::Beats* pBeats);
 };

--- a/src/track/beatfactory.h
+++ b/src/track/beatfactory.h
@@ -8,11 +8,13 @@ class Track;
 
 class BeatFactory {
   public:
-    static mixxx::BeatsPointer loadBeatsFromByteArray(const Track& track,
+    static mixxx::BeatsPointer loadBeatsFromByteArray(
+            SINT sampleRat,
             const QString& beatsVersion,
             const QString& beatsSubVersion,
             const QByteArray& beatsSerialized);
-    static mixxx::BeatsPointer makeBeatGrid(const Track& track,
+    static mixxx::BeatsPointer makeBeatGrid(
+            SINT sampleRat,
             double dBpm,
             double dFirstBeatSample);
 
@@ -25,7 +27,7 @@ class BeatFactory {
             const int iMaxBpm,
             const QHash<QString, QString>& extraVersionInfo);
 
-    static mixxx::BeatsPointer makePreferredBeats(const Track& track,
+    static mixxx::BeatsPointer makePreferredBeats(
             const QVector<double>& beats,
             const QHash<QString, QString>& extraVersionInfo,
             const bool bEnableFixedTempoCorrection,

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -298,12 +298,6 @@ double BeatGrid::getBpmAroundPosition(double curSample, int n) const {
     return bpm();
 }
 
-void BeatGrid::removeBeat(double dBeatSample) {
-    Q_UNUSED(dBeatSample);
-    //QMutexLocker locker(&m_mutex);
-    return;
-}
-
 void BeatGrid::translate(double dNumSamples) {
     QMutexLocker locker(&m_mutex);
     if (!isValid()) {

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -298,12 +298,6 @@ double BeatGrid::getBpmAroundPosition(double curSample, int n) const {
     return bpm();
 }
 
-void BeatGrid::addBeat(double dBeatSample) {
-    Q_UNUSED(dBeatSample);
-    //QMutexLocker locker(&m_mutex);
-    return;
-}
-
 void BeatGrid::removeBeat(double dBeatSample) {
     Q_UNUSED(dBeatSample);
     //QMutexLocker locker(&m_mutex);

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -52,7 +52,6 @@ BeatGrid::BeatGrid(
           m_dBeatLength(beatLength) {
     // BeatGrid should live in the same thread as the track it is associated
     // with.
-    moveToThread(track.thread());
 }
 
 BeatGrid::BeatGrid(const BeatGrid& other, const mixxx::track::io::BeatGrid& grid, double beatLength)
@@ -61,7 +60,6 @@ BeatGrid::BeatGrid(const BeatGrid& other, const mixxx::track::io::BeatGrid& grid
           m_iSampleRate(other.m_iSampleRate),
           m_grid(grid),
           m_dBeatLength(beatLength) {
-    moveToThread(other.thread());
 }
 
 BeatGrid::BeatGrid(const BeatGrid& other)

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -78,7 +78,7 @@ BeatGrid::BeatGrid(const BeatGrid& other)
 }
 
 // static
-mixxx::BeatsPointer BeatGrid::makeBeatGrid(const Track& track,
+BeatsPointer BeatGrid::makeBeatGrid(const Track& track,
         SINT iSampleRate,
         double dBpm,
         double dFirstBeatSample) {
@@ -98,11 +98,11 @@ mixxx::BeatsPointer BeatGrid::makeBeatGrid(const Track& track,
     // Calculate beat length as sample offsets
     double beatLength = (60.0 * iSampleRate / dBpm) * kFrameSize;
 
-    return mixxx::BeatsPointer(new BeatGrid(track, iSampleRate, grid, beatLength));
+    return BeatsPointer(new BeatGrid(track, iSampleRate, grid, beatLength));
 }
 
 // static
-mixxx::BeatsPointer BeatGrid::makeBeatGrid(
+BeatsPointer BeatGrid::makeBeatGrid(
         const Track& track, SINT sampleRate, const QByteArray& byteArray) {
     if (sampleRate <= 0) {
         sampleRate = track.getSampleRate();
@@ -111,12 +111,12 @@ mixxx::BeatsPointer BeatGrid::makeBeatGrid(
     mixxx::track::io::BeatGrid grid;
     if (grid.ParseFromArray(byteArray.constData(), byteArray.length())) {
         double beatLength = (60.0 * sampleRate / grid.bpm().bpm()) * kFrameSize;
-        return mixxx::BeatsPointer(new BeatGrid(track, sampleRate, grid, beatLength));
+        return BeatsPointer(new BeatGrid(track, sampleRate, grid, beatLength));
     }
 
     // Legacy fallback for BeatGrid-1.0
     if (byteArray.size() != sizeof(BeatGridData)) {
-        return mixxx::BeatsPointer(new BeatGrid(track, sampleRate));
+        return BeatsPointer(new BeatGrid(track, sampleRate));
     }
     const BeatGridData* blob = reinterpret_cast<const BeatGridData*>(byteArray.constData());
 
@@ -324,19 +324,19 @@ double BeatGrid::getBpmAroundPosition(double curSample, int n) const {
     return bpm();
 }
 
-mixxx::BeatsPointer BeatGrid::translate(double dNumSamples) const {
+BeatsPointer BeatGrid::translate(double dNumSamples) const {
     if (!isValid()) {
-        return mixxx::BeatsPointer(new BeatGrid(*this));
+        return BeatsPointer(new BeatGrid(*this));
     }
     mixxx::track::io::BeatGrid grid = m_grid;
     double newFirstBeatFrames = (firstBeatSample() + dNumSamples) / kFrameSize;
     grid.mutable_first_beat()->set_frame_position(
             static_cast<google::protobuf::int32>(newFirstBeatFrames));
 
-    return mixxx::BeatsPointer(new BeatGrid(*this, grid, m_dBeatLength));
+    return BeatsPointer(new BeatGrid(*this, grid, m_dBeatLength));
 }
 
-mixxx::BeatsPointer BeatGrid::scale(enum BPMScale scale) const {
+BeatsPointer BeatGrid::scale(enum BPMScale scale) const {
     mixxx::track::io::BeatGrid grid = m_grid;
     double bpm = grid.bpm().bpm();
 
@@ -361,26 +361,26 @@ mixxx::BeatsPointer BeatGrid::scale(enum BPMScale scale) const {
         break;
     default:
         DEBUG_ASSERT(!"scale value invalid");
-        return mixxx::BeatsPointer(new BeatGrid(*this));
+        return BeatsPointer(new BeatGrid(*this));
     }
 
     if (bpm > getMaxBpm()) {
-        return mixxx::BeatsPointer(new BeatGrid(*this));
+        return BeatsPointer(new BeatGrid(*this));
     }
     grid.mutable_bpm()->set_bpm(bpm);
 
     double beatLength = (60.0 * m_iSampleRate / bpm) * kFrameSize;
-    return mixxx::BeatsPointer(new BeatGrid(*this, grid, beatLength));
+    return BeatsPointer(new BeatGrid(*this, grid, beatLength));
 }
 
-mixxx::BeatsPointer BeatGrid::setBpm(double dBpm) {
+BeatsPointer BeatGrid::setBpm(double dBpm) {
     if (dBpm > getMaxBpm()) {
         dBpm = getMaxBpm();
     }
     mixxx::track::io::BeatGrid grid = m_grid;
     grid.mutable_bpm()->set_bpm(dBpm);
     double beatLength = (60.0 * m_iSampleRate / dBpm) * kFrameSize;
-    return mixxx::BeatsPointer(new BeatGrid(*this, grid, beatLength));
+    return BeatsPointer(new BeatGrid(*this, grid, beatLength));
 }
 
 } // namespace mixxx

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -351,15 +351,14 @@ mixxx::BeatsPointer BeatGrid::scale(enum BPMScale scale) const {
     return mixxx::BeatsPointer(new BeatGrid(*this, grid, beatLength));
 }
 
-void BeatGrid::setBpm(double dBpm) {
-    QMutexLocker locker(&m_mutex);
+mixxx::BeatsPointer BeatGrid::setBpm(double dBpm) {
     if (dBpm > getMaxBpm()) {
         dBpm = getMaxBpm();
     }
-    m_grid.mutable_bpm()->set_bpm(dBpm);
-    m_dBeatLength = (60.0 * m_iSampleRate / dBpm) * kFrameSize;
-    locker.unlock();
-    emit updated();
+    mixxx::track::io::BeatGrid grid = m_grid;
+    grid.mutable_bpm()->set_bpm(dBpm);
+    double beatLength = (60.0 * m_iSampleRate / dBpm) * kFrameSize;
+    return mixxx::BeatsPointer(new BeatGrid(*this, grid, beatLength));
 }
 
 } // namespace mixxx

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -44,8 +44,7 @@ BeatGrid::BeatGrid(
         const QString& subVersion,
         const mixxx::track::io::BeatGrid& grid,
         double beatLength)
-        : m_mutex(QMutex::Recursive),
-          m_subVersion(subVersion),
+        : m_subVersion(subVersion),
           m_iSampleRate(iSampleRate),
           m_grid(grid),
           m_dBeatLength(beatLength) {
@@ -54,8 +53,7 @@ BeatGrid::BeatGrid(
 }
 
 BeatGrid::BeatGrid(const BeatGrid& other, const mixxx::track::io::BeatGrid& grid, double beatLength)
-        : m_mutex(QMutex::Recursive),
-          m_subVersion(other.m_subVersion),
+        : m_subVersion(other.m_subVersion),
           m_iSampleRate(other.m_iSampleRate),
           m_grid(grid),
           m_dBeatLength(beatLength) {
@@ -108,14 +106,12 @@ BeatsPointer BeatGrid::makeBeatGrid(
 }
 
 QByteArray BeatGrid::toByteArray() const {
-    QMutexLocker locker(&m_mutex);
     std::string output;
     m_grid.SerializeToString(&output);
     return QByteArray(output.data(), static_cast<int>(output.length()));
 }
 
 BeatsPointer BeatGrid::clone() const {
-    QMutexLocker locker(&m_mutex);
     BeatsPointer other(new BeatGrid(*this));
     return other;
 }
@@ -129,12 +125,10 @@ double BeatGrid::bpm() const {
 }
 
 QString BeatGrid::getVersion() const {
-    QMutexLocker locker(&m_mutex);
     return BEAT_GRID_2_VERSION;
 }
 
 QString BeatGrid::getSubVersion() const {
-    QMutexLocker locker(&m_mutex);
     return m_subVersion;
 }
 
@@ -157,7 +151,6 @@ double BeatGrid::findPrevBeat(double dSamples) const {
 
 // This is an internal call. This could be implemented in the Beats Class itself.
 double BeatGrid::findClosestBeat(double dSamples) const {
-    QMutexLocker locker(&m_mutex);
     if (!isValid()) {
         return -1;
     }
@@ -174,7 +167,6 @@ double BeatGrid::findClosestBeat(double dSamples) const {
 }
 
 double BeatGrid::findNthBeat(double dSamples, int n) const {
-    QMutexLocker locker(&m_mutex);
     if (!isValid() || n == 0) {
         return -1;
     }
@@ -223,16 +215,13 @@ bool BeatGrid::findPrevNextBeats(double dSamples,
                                  double* dpNextBeatSamples) const {
     double dFirstBeatSample;
     double dBeatLength;
-    {
-        QMutexLocker locker(&m_mutex);
-        if (!isValid()) {
-            *dpPrevBeatSamples = -1.0;
-            *dpNextBeatSamples = -1.0;
-            return false;
-        }
-        dFirstBeatSample = firstBeatSample();
-        dBeatLength = m_dBeatLength;
+    if (!isValid()) {
+        *dpPrevBeatSamples = -1.0;
+        *dpNextBeatSamples = -1.0;
+        return false;
     }
+    dFirstBeatSample = firstBeatSample();
+    dBeatLength = m_dBeatLength;
 
     double beatFraction = (dSamples - dFirstBeatSample) / dBeatLength;
     double prevBeat = floor(beatFraction);
@@ -258,7 +247,6 @@ bool BeatGrid::findPrevNextBeats(double dSamples,
 
 
 std::unique_ptr<BeatIterator> BeatGrid::findBeats(double startSample, double stopSample) const {
-    QMutexLocker locker(&m_mutex);
     if (!isValid() || startSample > stopSample) {
         return std::unique_ptr<BeatIterator>();
     }
@@ -272,7 +260,6 @@ std::unique_ptr<BeatIterator> BeatGrid::findBeats(double startSample, double sto
 }
 
 bool BeatGrid::hasBeatInRange(double startSample, double stopSample) const {
-    QMutexLocker locker(&m_mutex);
     if (!isValid() || startSample > stopSample) {
         return false;
     }
@@ -284,7 +271,6 @@ bool BeatGrid::hasBeatInRange(double startSample, double stopSample) const {
 }
 
 double BeatGrid::getBpm() const {
-    QMutexLocker locker(&m_mutex);
     if (!isValid()) {
         return 0;
     }
@@ -296,7 +282,6 @@ double BeatGrid::getBpmAroundPosition(double curSample, int n) const {
     Q_UNUSED(curSample);
     Q_UNUSED(n);
 
-    QMutexLocker locker(&m_mutex);
     if (!isValid()) {
         return -1;
     }

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -17,22 +17,15 @@ namespace mixxx {
 // first beat and the song's average beats-per-minute.
 class BeatGrid final : public Beats {
   public:
-    // Construct a BeatGrid. If a more accurate sample rate is known, provide it
-    // in the iSampleRate parameter -- otherwise pass 0.
     ~BeatGrid() override = default;
 
-    // Initializes the BeatGrid to have a BPM of dBpm and the first beat offset
-    // of dFirstBeatSample. Does not generate an updated() signal, since it is
-    // meant for initialization.
-    static BeatsPointer makeBeatGrid(const Track& track,
+    static BeatsPointer makeBeatGrid(
             SINT iSampleRate,
             const QString& subVersion,
             double dBpm,
             double dFirstBeatSample);
-    // Construct a BeatGrid. If a more accurate sample rate is known, provide it
-    // in the iSampleRate parameter -- otherwise pass 0. The BeatGrid will be
-    // deserialized from the byte array.
-    static BeatsPointer makeBeatGrid(const Track& track,
+
+    static BeatsPointer makeBeatGrid(
             SINT iSampleRate,
             const QString& subVersion,
             const QByteArray& byteArray);
@@ -78,14 +71,15 @@ class BeatGrid final : public Beats {
     BeatsPointer setBpm(double dBpm) override;
 
   private:
-    BeatGrid(const BeatGrid& other);
-    // Constructor to update the beat grid
-    BeatGrid(const BeatGrid& other, const mixxx::track::io::BeatGrid& grid, double beatLength);
-    BeatGrid(const Track& track,
+    BeatGrid(
             SINT iSampleRate,
             const QString& subVersion,
             const mixxx::track::io::BeatGrid& grid,
             double beatLength);
+    // Constructor to update the beat grid
+    BeatGrid(const BeatGrid& other, const mixxx::track::io::BeatGrid& grid, double beatLength);
+    BeatGrid(const BeatGrid& other);
+
     double firstBeatSample() const;
     double bpm() const;
 

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -65,7 +65,6 @@ class BeatGrid final : public Beats {
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
-    void addBeat(double dBeatSample) override;
     void removeBeat(double dBeatSample) override;
     void translate(double dNumSamples) override;
     void scale(enum BPMScale scale) override;

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -20,17 +20,20 @@ class BeatGrid final : public Beats {
     // Construct a BeatGrid. If a more accurate sample rate is known, provide it
     // in the iSampleRate parameter -- otherwise pass 0.
     BeatGrid(const Track& track, SINT iSampleRate);
-    // Construct a BeatGrid. If a more accurate sample rate is known, provide it
-    // in the iSampleRate parameter -- otherwise pass 0. The BeatGrid will be
-    // deserialized from the byte array.
-    BeatGrid(const Track& track, SINT iSampleRate,
-             const QByteArray& byteArray);
     ~BeatGrid() override = default;
 
     // Initializes the BeatGrid to have a BPM of dBpm and the first beat offset
     // of dFirstBeatSample. Does not generate an updated() signal, since it is
     // meant for initialization.
-    void setGrid(double dBpm, double dFirstBeatSample);
+    static mixxx::BeatsPointer makeBeatGrid(const Track& track,
+            SINT iSampleRate,
+            double dBpm,
+            double dFirstBeatSample);
+    // Construct a BeatGrid. If a more accurate sample rate is known, provide it
+    // in the iSampleRate parameter -- otherwise pass 0. The BeatGrid will be
+    // deserialized from the byte array.
+    static mixxx::BeatsPointer makeBeatGrid(
+            const Track& track, SINT iSampleRate, const QByteArray& byteArray);
 
     // The following are all methods from the Beats interface, see method
     // comments in beats.h
@@ -43,7 +46,7 @@ class BeatGrid final : public Beats {
     BeatsPointer clone() const override;
     QString getVersion() const override;
     QString getSubVersion() const override;
-    virtual void setSubVersion(const QString& subVersion);
+    void setSubVersion(const QString& subVersion) override;
 
     ////////////////////////////////////////////////////////////////////////////
     // Beat calculations
@@ -77,10 +80,13 @@ class BeatGrid final : public Beats {
     BeatGrid(const BeatGrid& other);
     // Constructor to update the beat grid
     BeatGrid(const BeatGrid& other, const mixxx::track::io::BeatGrid& grid, double beatLength);
+    BeatGrid(const Track& track,
+            SINT iSampleRate,
+            const mixxx::track::io::BeatGrid& grid,
+            double beatLength);
     double firstBeatSample() const;
     double bpm() const;
 
-    void readByteArray(const QByteArray& byteArray);
     // For internal use only.
     bool isValid() const;
 

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -66,7 +66,7 @@ class BeatGrid final : public Beats {
     ////////////////////////////////////////////////////////////////////////////
 
     mixxx::BeatsPointer translate(double dNumSamples) const override;
-    void scale(enum BPMScale scale) override;
+    mixxx::BeatsPointer scale(enum BPMScale scale) const override;
     void setBpm(double dBpm) override;
 
     SINT getSampleRate() const override {
@@ -76,7 +76,7 @@ class BeatGrid final : public Beats {
   private:
     BeatGrid(const BeatGrid& other);
     // Constructor to update the beat grid
-    BeatGrid(const BeatGrid& other, const mixxx::track::io::BeatGrid& grid);
+    BeatGrid(const BeatGrid& other, const mixxx::track::io::BeatGrid& grid, double beatLength);
     double firstBeatSample() const;
     double bpm() const;
 

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -65,7 +65,7 @@ class BeatGrid final : public Beats {
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
-    void translate(double dNumSamples) override;
+    mixxx::BeatsPointer translate(double dNumSamples) const override;
     void scale(enum BPMScale scale) override;
     void setBpm(double dBpm) override;
 
@@ -75,6 +75,8 @@ class BeatGrid final : public Beats {
 
   private:
     BeatGrid(const BeatGrid& other);
+    // Constructor to update the beat grid
+    BeatGrid(const BeatGrid& other, const mixxx::track::io::BeatGrid& grid);
     double firstBeatSample() const;
     double bpm() const;
 

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -86,7 +86,6 @@ class BeatGrid final : public Beats {
     // For internal use only.
     bool isValid() const;
 
-    mutable QMutex m_mutex;
     // The sub-version of this beatgrid.
     const QString m_subVersion;
     // The number of samples per second

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -65,7 +65,6 @@ class BeatGrid final : public Beats {
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
-    void removeBeat(double dBeatSample) override;
     void translate(double dNumSamples) override;
     void scale(enum BPMScale scale) override;
     void setBpm(double dBpm) override;

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -19,7 +19,6 @@ class BeatGrid final : public Beats {
   public:
     // Construct a BeatGrid. If a more accurate sample rate is known, provide it
     // in the iSampleRate parameter -- otherwise pass 0.
-    BeatGrid(const Track& track, SINT iSampleRate);
     ~BeatGrid() override = default;
 
     // Initializes the BeatGrid to have a BPM of dBpm and the first beat offset
@@ -27,13 +26,16 @@ class BeatGrid final : public Beats {
     // meant for initialization.
     static BeatsPointer makeBeatGrid(const Track& track,
             SINT iSampleRate,
+            const QString& subVersion,
             double dBpm,
             double dFirstBeatSample);
     // Construct a BeatGrid. If a more accurate sample rate is known, provide it
     // in the iSampleRate parameter -- otherwise pass 0. The BeatGrid will be
     // deserialized from the byte array.
-    static BeatsPointer makeBeatGrid(
-            const Track& track, SINT iSampleRate, const QByteArray& byteArray);
+    static BeatsPointer makeBeatGrid(const Track& track,
+            SINT iSampleRate,
+            const QString& subVersion,
+            const QByteArray& byteArray);
 
     // The following are all methods from the Beats interface, see method
     // comments in beats.h
@@ -45,7 +47,6 @@ class BeatGrid final : public Beats {
     QByteArray toByteArray() const override;
     QString getVersion() const override;
     QString getSubVersion() const override;
-    void setSubVersion(const QString& subVersion) override;
 
     ////////////////////////////////////////////////////////////////////////////
     // Beat calculations
@@ -82,6 +83,7 @@ class BeatGrid final : public Beats {
     BeatGrid(const BeatGrid& other, const mixxx::track::io::BeatGrid& grid, double beatLength);
     BeatGrid(const Track& track,
             SINT iSampleRate,
+            const QString& subVersion,
             const mixxx::track::io::BeatGrid& grid,
             double beatLength);
     double firstBeatSample() const;

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -61,17 +61,17 @@ class BeatGrid final : public Beats {
     double getBpm() const override;
     double getBpmAroundPosition(double curSample, int n) const override;
 
+    SINT getSampleRate() const override {
+        return m_iSampleRate;
+    }
+
     ////////////////////////////////////////////////////////////////////////////
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
     mixxx::BeatsPointer translate(double dNumSamples) const override;
     mixxx::BeatsPointer scale(enum BPMScale scale) const override;
-    void setBpm(double dBpm) override;
-
-    SINT getSampleRate() const override {
-        return m_iSampleRate;
-    }
+    mixxx::BeatsPointer setBpm(double dBpm) override;
 
   private:
     BeatGrid(const BeatGrid& other);

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -25,14 +25,14 @@ class BeatGrid final : public Beats {
     // Initializes the BeatGrid to have a BPM of dBpm and the first beat offset
     // of dFirstBeatSample. Does not generate an updated() signal, since it is
     // meant for initialization.
-    static mixxx::BeatsPointer makeBeatGrid(const Track& track,
+    static BeatsPointer makeBeatGrid(const Track& track,
             SINT iSampleRate,
             double dBpm,
             double dFirstBeatSample);
     // Construct a BeatGrid. If a more accurate sample rate is known, provide it
     // in the iSampleRate parameter -- otherwise pass 0. The BeatGrid will be
     // deserialized from the byte array.
-    static mixxx::BeatsPointer makeBeatGrid(
+    static BeatsPointer makeBeatGrid(
             const Track& track, SINT iSampleRate, const QByteArray& byteArray);
 
     // The following are all methods from the Beats interface, see method
@@ -43,7 +43,6 @@ class BeatGrid final : public Beats {
     }
 
     QByteArray toByteArray() const override;
-    BeatsPointer clone() const override;
     QString getVersion() const override;
     QString getSubVersion() const override;
     void setSubVersion(const QString& subVersion) override;
@@ -72,9 +71,10 @@ class BeatGrid final : public Beats {
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
-    mixxx::BeatsPointer translate(double dNumSamples) const override;
-    mixxx::BeatsPointer scale(enum BPMScale scale) const override;
-    mixxx::BeatsPointer setBpm(double dBpm) override;
+    BeatsPointer clone() const override;
+    BeatsPointer translate(double dNumSamples) const override;
+    BeatsPointer scale(enum BPMScale scale) const override;
+    BeatsPointer setBpm(double dBpm) override;
 
   private:
     BeatGrid(const BeatGrid& other);

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -88,13 +88,13 @@ class BeatGrid final : public Beats {
 
     mutable QMutex m_mutex;
     // The sub-version of this beatgrid.
-    QString m_subVersion;
+    const QString m_subVersion;
     // The number of samples per second
-    SINT m_iSampleRate;
+    const SINT m_iSampleRate;
     // Data storage for BeatGrid
-    mixxx::track::io::BeatGrid m_grid;
+    const mixxx::track::io::BeatGrid m_grid;
     // The length of a beat in samples
-    double m_dBeatLength;
+    const double m_dBeatLength;
 };
 
 } // namespace mixxx

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -215,7 +215,7 @@ BeatsPointer BeatMap::makeBeatMap(
         nominalBpm = calculateNominalBpm(beatList, sampleRate);
     } else {
         qDebug() << "ERROR: Could not parse BeatMap from QByteArray of size"
-                << byteArray.size();
+                 << byteArray.size();
     }
     return BeatsPointer(new BeatMap(sampleRate, subVersion, beatList, nominalBpm));
 }

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -655,10 +655,10 @@ mixxx::BeatsPointer BeatMap::scale(enum BPMScale scale) const {
     return mixxx::BeatsPointer(new BeatMap(*this, beats, bpm));
 }
 
-void BeatMap::setBpm(double dBpm) {
+mixxx::BeatsPointer BeatMap::setBpm(double dBpm) {
     Q_UNUSED(dBpm);
     DEBUG_ASSERT(!"BeatMap::setBpm() not implemented");
-    return;
+    return mixxx::BeatsPointer(new BeatMap(*this));
 
     /*
      * One of the problems of beattracking algorithms is the so called "octave error"

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -487,24 +487,6 @@ double BeatMap::getBpmAroundPosition(double curSample, int n) const {
     return BeatUtils::calculateAverageBpm(numberOfBeats, m_iSampleRate, lowerFrame, upperFrame);
 }
 
-void BeatMap::removeBeat(double dBeatSample) {
-    QMutexLocker locker(&m_mutex);
-    Beat beat;
-    beat.set_frame_position(static_cast<google::protobuf::int32>(samplesToFrames(dBeatSample)));
-    BeatList::iterator it = std::lower_bound(
-        m_beats.begin(), m_beats.end(), beat, BeatLessThan);
-
-    // In case there are duplicates, remove every instance of dBeatSample
-    // TODO(XXX) add invariant checks against this
-    // TODO(XXX) determine what epsilon to consider a beat identical to another
-    while (it->frame_position() == beat.frame_position()) {
-        it = m_beats.erase(it);
-    }
-    onBeatlistChanged();
-    locker.unlock();
-    emit updated();
-}
-
 void BeatMap::translate(double dNumSamples) {
     QMutexLocker locker(&m_mutex);
     // Converting to frame offset

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -176,7 +176,7 @@ class BeatMapIterator : public BeatIterator {
     BeatList::const_iterator m_endBeat;
 };
 
-BeatMap::BeatMap(const Track& track,
+BeatMap::BeatMap(
         SINT sampleRate,
         const QString& subVersion,
         BeatList beats,
@@ -201,14 +201,10 @@ BeatMap::BeatMap(const BeatMap& other)
 }
 
 // static
-BeatsPointer BeatMap::makeBeatMap(const Track& track,
+BeatsPointer BeatMap::makeBeatMap(
         SINT sampleRate,
         const QString& subVersion,
         const QByteArray& byteArray) {
-    if (sampleRate <= 0) {
-        sampleRate = track.getSampleRate();
-    }
-
     double nominalBpm = 0.0;
     BeatList beatList;
 
@@ -223,18 +219,14 @@ BeatsPointer BeatMap::makeBeatMap(const Track& track,
         qDebug() << "ERROR: Could not parse BeatMap from QByteArray of size"
                 << byteArray.size();
     }
-    return BeatsPointer(new BeatMap(track, sampleRate, subVersion, beatList, nominalBpm));
+    return BeatsPointer(new BeatMap(sampleRate, subVersion, beatList, nominalBpm));
 }
 
 // static
-BeatsPointer BeatMap::makeBeatMap(const Track& track,
+BeatsPointer BeatMap::makeBeatMap(
         SINT sampleRate,
         const QString& subVersion,
         const QVector<double>& beats) {
-    if (sampleRate <= 0) {
-        sampleRate = track.getSampleRate();
-    }
-
     BeatList beatList;
 
     double previous_beatpos = -1;
@@ -253,7 +245,7 @@ BeatsPointer BeatMap::makeBeatMap(const Track& track,
         }
     }
     double nominalBpm = calculateNominalBpm(beatList, sampleRate);
-    return BeatsPointer(new BeatMap(track, sampleRate, subVersion, beatList, nominalBpm));
+    return BeatsPointer(new BeatMap(sampleRate, subVersion, beatList, nominalBpm));
 }
 
 QByteArray BeatMap::toByteArray() const {

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -176,12 +176,16 @@ class BeatMapIterator : public BeatIterator {
     BeatList::const_iterator m_endBeat;
 };
 
-BeatMap::BeatMap(const Track& track, SINT iSampleRate)
+BeatMap::BeatMap(const Track& track,
+        SINT sampleRate,
+        const QString& subVersion,
+        BeatList beats,
+        double nominalBpm)
         : m_mutex(QMutex::Recursive),
-          m_iSampleRate(iSampleRate > 0 ? iSampleRate : track.getSampleRate()),
-          m_nominalBpm(0) {
-    // BeatMap should live in the same thread as the track it is associated
-    // with.
+          m_subVersion(subVersion),
+          m_iSampleRate(sampleRate),
+          m_nominalBpm(nominalBpm),
+          m_beats(std::move(beats)) {
     moveToThread(track.thread());
 }
 
@@ -196,19 +200,6 @@ BeatMap::BeatMap(const BeatMap& other, BeatList beats, double nominalBpm)
 
 BeatMap::BeatMap(const BeatMap& other)
         : BeatMap(other, other.m_beats, other.m_nominalBpm) {
-}
-
-BeatMap::BeatMap(const Track& track,
-        SINT sampleRate,
-        const QString& subVersion,
-        BeatList beats,
-        double nominalBpm)
-        : m_mutex(QMutex::Recursive),
-          m_subVersion(subVersion),
-          m_iSampleRate(sampleRate),
-          m_nominalBpm(nominalBpm),
-          m_beats(std::move(beats)) {
-    moveToThread(track.thread());
 }
 
 // static
@@ -296,10 +287,6 @@ QString BeatMap::getVersion() const {
 QString BeatMap::getSubVersion() const {
     QMutexLocker locker(&m_mutex);
     return m_subVersion;
-}
-
-void BeatMap::setSubVersion(const QString& subVersion) {
-    m_subVersion = subVersion;
 }
 
 bool BeatMap::isValid() const {

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -181,16 +181,14 @@ BeatMap::BeatMap(
         const QString& subVersion,
         BeatList beats,
         double nominalBpm)
-        : m_mutex(QMutex::Recursive),
-          m_subVersion(subVersion),
+        : m_subVersion(subVersion),
           m_iSampleRate(sampleRate),
           m_nominalBpm(nominalBpm),
           m_beats(std::move(beats)) {
 }
 
 BeatMap::BeatMap(const BeatMap& other, BeatList beats, double nominalBpm)
-        : m_mutex(QMutex::Recursive),
-          m_subVersion(other.m_subVersion),
+        : m_subVersion(other.m_subVersion),
           m_iSampleRate(other.m_iSampleRate),
           m_nominalBpm(nominalBpm),
           m_beats(std::move(beats)) {
@@ -249,7 +247,6 @@ BeatsPointer BeatMap::makeBeatMap(
 }
 
 QByteArray BeatMap::toByteArray() const {
-    QMutexLocker locker(&m_mutex);
     // No guarantees BeatLists are made of a data type which located adjacent
     // items in adjacent memory locations.
     mixxx::track::io::BeatMap map;
@@ -264,18 +261,15 @@ QByteArray BeatMap::toByteArray() const {
 }
 
 BeatsPointer BeatMap::clone() const {
-    QMutexLocker locker(&m_mutex);
     BeatsPointer other(new BeatMap(*this));
     return other;
 }
 
 QString BeatMap::getVersion() const {
-    QMutexLocker locker(&m_mutex);
     return BEAT_MAP_VERSION;
 }
 
 QString BeatMap::getSubVersion() const {
-    QMutexLocker locker(&m_mutex);
     return m_subVersion;
 }
 
@@ -292,7 +286,6 @@ double BeatMap::findPrevBeat(double dSamples) const {
 }
 
 double BeatMap::findClosestBeat(double dSamples) const {
-    QMutexLocker locker(&m_mutex);
     if (!isValid()) {
         return -1;
     }
@@ -309,8 +302,6 @@ double BeatMap::findClosestBeat(double dSamples) const {
 }
 
 double BeatMap::findNthBeat(double dSamples, int n) const {
-    QMutexLocker locker(&m_mutex);
-
     if (!isValid() || n == 0) {
         return -1;
     }
@@ -395,11 +386,10 @@ double BeatMap::findNthBeat(double dSamples, int n) const {
     return -1;
 }
 
-bool BeatMap::findPrevNextBeats(double dSamples,
-                                double* dpPrevBeatSamples,
-                                double* dpNextBeatSamples) const {
-    QMutexLocker locker(&m_mutex);
-
+bool BeatMap::findPrevNextBeats(
+        double dSamples,
+        double* dpPrevBeatSamples,
+        double* dpNextBeatSamples) const {
     if (!isValid()) {
         *dpPrevBeatSamples = -1;
         *dpNextBeatSamples = -1;
@@ -483,7 +473,6 @@ bool BeatMap::findPrevNextBeats(double dSamples,
 }
 
 std::unique_ptr<BeatIterator> BeatMap::findBeats(double startSample, double stopSample) const {
-    QMutexLocker locker(&m_mutex);
     //startSample and stopSample are sample offsets, converting them to
     //frames
     if (!isValid() || startSample > stopSample) {
@@ -510,7 +499,6 @@ std::unique_ptr<BeatIterator> BeatMap::findBeats(double startSample, double stop
 }
 
 bool BeatMap::hasBeatInRange(double startSample, double stopSample) const {
-    QMutexLocker locker(&m_mutex);
     if (!isValid() || startSample > stopSample) {
         return false;
     }
@@ -522,7 +510,6 @@ bool BeatMap::hasBeatInRange(double startSample, double stopSample) const {
 }
 
 double BeatMap::getBpm() const {
-    QMutexLocker locker(&m_mutex);
     if (!isValid()) {
         return -1;
     }
@@ -531,7 +518,6 @@ double BeatMap::getBpm() const {
 
 // Note: Also called from the engine thread
 double BeatMap::getBpmAroundPosition(double curSample, int n) const {
-    QMutexLocker locker(&m_mutex);
     if (!isValid()) {
         return -1;
     }
@@ -602,7 +588,6 @@ BeatsPointer BeatMap::translate(double dNumSamples) const {
 }
 
 BeatsPointer BeatMap::scale(enum BPMScale scale) const {
-    QMutexLocker locker(&m_mutex);
     if (!isValid() || m_beats.isEmpty()) {
         return BeatsPointer(new BeatMap(*this));
     }

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -186,7 +186,6 @@ BeatMap::BeatMap(const Track& track,
           m_iSampleRate(sampleRate),
           m_nominalBpm(nominalBpm),
           m_beats(std::move(beats)) {
-    moveToThread(track.thread());
 }
 
 BeatMap::BeatMap(const BeatMap& other, BeatList beats, double nominalBpm)
@@ -195,7 +194,6 @@ BeatMap::BeatMap(const BeatMap& other, BeatList beats, double nominalBpm)
           m_iSampleRate(other.m_iSampleRate),
           m_nominalBpm(nominalBpm),
           m_beats(std::move(beats)) {
-    moveToThread(other.thread());
 }
 
 BeatMap::BeatMap(const BeatMap& other)

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -584,10 +584,10 @@ double BeatMap::getBpmAroundPosition(double curSample, int n) const {
     return BeatUtils::calculateAverageBpm(numberOfBeats, m_iSampleRate, lowerFrame, upperFrame);
 }
 
-mixxx::BeatsPointer BeatMap::translate(double dNumSamples) const {
+BeatsPointer BeatMap::translate(double dNumSamples) const {
     // Converting to frame offset
     if (!isValid()) {
-        return mixxx::BeatsPointer(new BeatMap(*this));
+        return BeatsPointer(new BeatMap(*this));
     }
 
     BeatList beats = m_beats;
@@ -603,13 +603,13 @@ mixxx::BeatsPointer BeatMap::translate(double dNumSamples) const {
         }
     }
 
-    return mixxx::BeatsPointer(new BeatMap(*this, beats, m_nominalBpm));
+    return BeatsPointer(new BeatMap(*this, beats, m_nominalBpm));
 }
 
-mixxx::BeatsPointer BeatMap::scale(enum BPMScale scale) const {
+BeatsPointer BeatMap::scale(enum BPMScale scale) const {
     QMutexLocker locker(&m_mutex);
     if (!isValid() || m_beats.isEmpty()) {
-        return mixxx::BeatsPointer(new BeatMap(*this));
+        return BeatsPointer(new BeatMap(*this));
     }
 
     BeatList beats = m_beats;
@@ -648,17 +648,17 @@ mixxx::BeatsPointer BeatMap::scale(enum BPMScale scale) const {
         break;
     default:
         DEBUG_ASSERT(!"scale value invalid");
-        return mixxx::BeatsPointer(new BeatMap(*this));
+        return BeatsPointer(new BeatMap(*this));
     }
 
     double bpm = calculateNominalBpm(beats, m_iSampleRate);
-    return mixxx::BeatsPointer(new BeatMap(*this, beats, bpm));
+    return BeatsPointer(new BeatMap(*this, beats, bpm));
 }
 
-mixxx::BeatsPointer BeatMap::setBpm(double dBpm) {
+BeatsPointer BeatMap::setBpm(double dBpm) {
     Q_UNUSED(dBpm);
     DEBUG_ASSERT(!"BeatMap::setBpm() not implemented");
-    return mixxx::BeatsPointer(new BeatMap(*this));
+    return BeatsPointer(new BeatMap(*this));
 
     /*
      * One of the problems of beattracking algorithms is the so called "octave error"

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -487,25 +487,6 @@ double BeatMap::getBpmAroundPosition(double curSample, int n) const {
     return BeatUtils::calculateAverageBpm(numberOfBeats, m_iSampleRate, lowerFrame, upperFrame);
 }
 
-void BeatMap::addBeat(double dBeatSample) {
-    QMutexLocker locker(&m_mutex);
-    Beat beat;
-    beat.set_frame_position(static_cast<google::protobuf::int32>(samplesToFrames(dBeatSample)));
-    BeatList::iterator it = std::lower_bound(
-        m_beats.begin(), m_beats.end(), beat, BeatLessThan);
-
-    // Don't insert a duplicate beat. TODO(XXX) determine what epsilon to
-    // consider a beat identical to another.
-    if (it != m_beats.end() && it->frame_position() == beat.frame_position()) {
-        return;
-    }
-
-    m_beats.insert(it, beat);
-    onBeatlistChanged();
-    locker.unlock();
-    emit updated();
-}
-
 void BeatMap::removeBeat(double dBeatSample) {
     QMutexLocker locker(&m_mutex);
     Beat beat;

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -51,7 +51,7 @@ class BeatMap final : public Beats {
     BeatsPointer clone() const override;
     QString getVersion() const override;
     QString getSubVersion() const override;
-    virtual void setSubVersion(const QString& subVersion);
+    void setSubVersion(const QString& subVersion) override;
 
     ////////////////////////////////////////////////////////////////////////////
     // Beat calculations

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -74,7 +74,7 @@ class BeatMap final : public Beats {
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
-    void translate(double dNumSamples) override;
+    mixxx::BeatsPointer translate(double dNumSamples) const override;
     void scale(enum BPMScale scale) override;
     void setBpm(double dBpm) override;
 
@@ -84,6 +84,8 @@ class BeatMap final : public Beats {
 
   private:
     BeatMap(const BeatMap& other);
+    // Constructor to update the beat grid
+    BeatMap(const BeatMap& other, BeatList beats, double nominalBpm);
     bool readByteArray(const QByteArray& byteArray);
     void createFromBeatVector(const QVector<double>& beats);
     void onBeatlistChanged();

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -70,17 +70,17 @@ class BeatMap final : public Beats {
     double getBpm() const override;
     double getBpmAroundPosition(double curSample, int n) const override;
 
+    SINT getSampleRate() const override {
+        return m_iSampleRate;
+    }
+
     ////////////////////////////////////////////////////////////////////////////
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
     mixxx::BeatsPointer translate(double dNumSamples) const override;
     mixxx::BeatsPointer scale(enum BPMScale scale) const override;
-    void setBpm(double dBpm) override;
-
-    SINT getSampleRate() const override {
-        return m_iSampleRate;
-    }
+    mixxx::BeatsPointer setBpm(double dBpm) override;
 
   private:
     BeatMap(const BeatMap& other);

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -87,10 +87,10 @@ class BeatMap final : public Beats {
     bool isValid() const;
 
     mutable QMutex m_mutex;
-    QString m_subVersion;
-    SINT m_iSampleRate;
-    double m_nominalBpm;
-    BeatList m_beats;
+    const QString m_subVersion;
+    const SINT m_iSampleRate;
+    const double m_nominalBpm;
+    const BeatList m_beats;
 };
 
 } // namespace mixxx

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -74,7 +74,6 @@ class BeatMap final : public Beats {
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
-    void removeBeat(double dBeatSample) override;
     void translate(double dNumSamples) override;
     void scale(enum BPMScale scale) override;
     void setBpm(double dBpm) override;

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -25,20 +25,12 @@ class BeatMap final : public Beats {
 
     ~BeatMap() override = default;
 
-    // Construct a BeatMap. iSampleRate may be provided if a more accurate
-    // sample rate is known than the one associated with the Track. If it is
-    // zero then the track's sample rate will be used. The BeatMap will be
-    // deserialized from the byte array.
-    static BeatsPointer makeBeatMap(const Track& track,
+    static BeatsPointer makeBeatMap(
             SINT sampleRate,
             const QString& subVersion,
             const QByteArray& byteArray);
 
-    // Construct a BeatMap. iSampleRate may be provided if a more accurate
-    // sample rate is known than the one associated with the Track. If it is
-    // zero then the track's sample rate will be used. A list of beat locations
-    // in audio frames may be provided.
-    static BeatsPointer makeBeatMap(const Track& track,
+    static BeatsPointer makeBeatMap(
             SINT sampleRate,
             const QString& subVersion,
             const QVector<double>& beats);
@@ -83,12 +75,11 @@ class BeatMap final : public Beats {
     BeatsPointer setBpm(double dBpm) override;
 
   private:
-    BeatMap(const Track& track,
-            SINT sampleRate,
+    BeatMap(SINT sampleRate,
             const QString& subVersion,
             BeatList beats,
             double nominalBpm);
-    // Constructor to update the beat grid
+    // Constructor to update the beat map
     BeatMap(const BeatMap& other, BeatList beats, double nominalBpm);
     BeatMap(const BeatMap& other);
 

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -22,15 +22,6 @@ namespace mixxx {
 
 class BeatMap final : public Beats {
   public:
-    // Construct a BeatMap. iSampleRate may be provided if a more accurate
-    // sample rate is known than the one associated with the Track.
-    BeatMap(const Track& track, SINT iSampleRate);
-
-    BeatMap(const Track& track,
-            SINT sampleRate,
-            const QString& subVersion,
-            BeatList beats,
-            double nominalBpm);
 
     ~BeatMap() override = default;
 
@@ -92,9 +83,14 @@ class BeatMap final : public Beats {
     BeatsPointer setBpm(double dBpm) override;
 
   private:
-    BeatMap(const BeatMap& other);
+    BeatMap(const Track& track,
+            SINT sampleRate,
+            const QString& subVersion,
+            BeatList beats,
+            double nominalBpm);
     // Constructor to update the beat grid
     BeatMap(const BeatMap& other, BeatList beats, double nominalBpm);
+    BeatMap(const BeatMap& other);
 
     // For internal use only.
     bool isValid() const;

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -74,7 +74,6 @@ class BeatMap final : public Beats {
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
-    void addBeat(double dBeatSample) override;
     void removeBeat(double dBeatSample) override;
     void translate(double dNumSamples) override;
     void scale(enum BPMScale scale) override;

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -25,22 +25,32 @@ class BeatMap final : public Beats {
     // Construct a BeatMap. iSampleRate may be provided if a more accurate
     // sample rate is known than the one associated with the Track.
     BeatMap(const Track& track, SINT iSampleRate);
+
+    BeatMap(const Track& track,
+            SINT sampleRate,
+            const QString& subVersion,
+            BeatList beats,
+            double nominalBpm);
+
+    ~BeatMap() override = default;
+
     // Construct a BeatMap. iSampleRate may be provided if a more accurate
     // sample rate is known than the one associated with the Track. If it is
     // zero then the track's sample rate will be used. The BeatMap will be
     // deserialized from the byte array.
-    BeatMap(const Track& track, SINT iSampleRate,
+    static BeatsPointer makeBeatMap(const Track& track,
+            SINT sampleRate,
+            const QString& subVersion,
             const QByteArray& byteArray);
+
     // Construct a BeatMap. iSampleRate may be provided if a more accurate
     // sample rate is known than the one associated with the Track. If it is
     // zero then the track's sample rate will be used. A list of beat locations
     // in audio frames may be provided.
-    BeatMap(const Track& track, SINT iSampleRate,
+    static BeatsPointer makeBeatMap(const Track& track,
+            SINT sampleRate,
+            const QString& subVersion,
             const QVector<double>& beats);
-
-    ~BeatMap() override = default;
-
-    // See method comments in beats.h
 
     Beats::CapabilitiesFlags getCapabilities() const override {
         return BEATSCAP_TRANSLATE | BEATSCAP_SCALE | BEATSCAP_ADDREMOVE |
@@ -86,9 +96,6 @@ class BeatMap final : public Beats {
     BeatMap(const BeatMap& other);
     // Constructor to update the beat grid
     BeatMap(const BeatMap& other, BeatList beats, double nominalBpm);
-    bool readByteArray(const QByteArray& byteArray);
-    void createFromBeatVector(const QVector<double>& beats);
-    void onBeatlistChanged();
 
     // For internal use only.
     bool isValid() const;

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -60,7 +60,6 @@ class BeatMap final : public Beats {
     QByteArray toByteArray() const override;
     QString getVersion() const override;
     QString getSubVersion() const override;
-    void setSubVersion(const QString& subVersion) override;
 
     ////////////////////////////////////////////////////////////////////////////
     // Beat calculations

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -75,7 +75,7 @@ class BeatMap final : public Beats {
     ////////////////////////////////////////////////////////////////////////////
 
     mixxx::BeatsPointer translate(double dNumSamples) const override;
-    void scale(enum BPMScale scale) override;
+    mixxx::BeatsPointer scale(enum BPMScale scale) const override;
     void setBpm(double dBpm) override;
 
     SINT getSampleRate() const override {
@@ -92,13 +92,6 @@ class BeatMap final : public Beats {
 
     // For internal use only.
     bool isValid() const;
-
-    void scaleDouble();
-    void scaleTriple();
-    void scaleQuadruple();
-    void scaleHalve();
-    void scaleThird();
-    void scaleFourth();
 
     mutable QMutex m_mutex;
     QString m_subVersion;

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -86,7 +86,6 @@ class BeatMap final : public Beats {
     // For internal use only.
     bool isValid() const;
 
-    mutable QMutex m_mutex;
     const QString m_subVersion;
     const SINT m_iSampleRate;
     const double m_nominalBpm;

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -48,7 +48,6 @@ class BeatMap final : public Beats {
     }
 
     QByteArray toByteArray() const override;
-    BeatsPointer clone() const override;
     QString getVersion() const override;
     QString getSubVersion() const override;
     void setSubVersion(const QString& subVersion) override;
@@ -78,9 +77,10 @@ class BeatMap final : public Beats {
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
-    mixxx::BeatsPointer translate(double dNumSamples) const override;
-    mixxx::BeatsPointer scale(enum BPMScale scale) const override;
-    mixxx::BeatsPointer setBpm(double dBpm) override;
+    BeatsPointer clone() const override;
+    BeatsPointer translate(double dNumSamples) const override;
+    BeatsPointer scale(enum BPMScale scale) const override;
+    BeatsPointer setBpm(double dBpm) override;
 
   private:
     BeatMap(const BeatMap& other);

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -4,7 +4,7 @@
 
 namespace mixxx {
 
-int Beats::numBeatsInRange(double dStartSample, double dEndSample) {
+int Beats::numBeatsInRange(double dStartSample, double dEndSample) const {
     double dLastCountedBeat = 0.0;
     int iBeatsCounter;
     for (iBeatsCounter = 1; dLastCountedBeat < dEndSample; iBeatsCounter++) {

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -25,7 +25,7 @@ class BeatIterator {
     virtual double next() = 0;
 };
 
-// Beats is a pure abstract base class for BPM and beat management classes. It
+// Beats is the base class for BPM and beat management classes. It
 // provides a specification of all methods a beat-manager class must provide, as
 // well as a capability model for representing optional features.
 class Beats : public QObject {
@@ -108,7 +108,7 @@ class Beats : public QObject {
     // then dSamples is returned. If no beat can be found, returns -1.
     virtual double findNthBeat(double dSamples, int n) const = 0;
 
-    int numBeatsInRange(double dStartSample, double dEndSample);
+    int numBeatsInRange(double dStartSample, double dEndSample) const;
 
     // Find the sample N beats away from dSample. The number of beats may be
     // negative and does not need to be an integer.
@@ -140,10 +140,6 @@ class Beats : public QObject {
     ////////////////////////////////////////////////////////////////////////////
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
-
-    // Add a beat at location dBeatSample. Beats instance must have the
-    // capability BEATSCAP_ADDREMOVE.
-    virtual void addBeat(double dBeatSample) = 0;
 
     // Remove a beat at location dBeatSample. Beats instance must have the
     // capability BEATSCAP_ADDREMOVE.

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -141,10 +141,6 @@ class Beats : public QObject {
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
-    // Remove a beat at location dBeatSample. Beats instance must have the
-    // capability BEATSCAP_ADDREMOVE.
-    virtual void removeBeat(double dBeatSample) = 0;
-
     // Translate all beats in the song by dNumSamples samples. Beats that lie
     // before the start of the track or after the end of the track are not
     // removed. Beats instance must have the capability BEATSCAP_TRANSLATE.

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -144,7 +144,7 @@ class Beats : public QObject {
     // Translate all beats in the song by dNumSamples samples. Beats that lie
     // before the start of the track or after the end of the track are not
     // removed. Beats instance must have the capability BEATSCAP_TRANSLATE.
-    virtual void translate(double dNumSamples) = 0;
+    virtual mixxx::BeatsPointer translate(double dNumSamples) const = 0;
 
     // Scale the position of every beat in the song by dScalePercentage. Beats
     // class must have the capability BEATSCAP_SCALE.

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -137,6 +137,8 @@ class Beats : public QObject {
         return kMaxBpm;
     }
 
+    virtual SINT getSampleRate() const = 0;
+
     ////////////////////////////////////////////////////////////////////////////
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
@@ -152,9 +154,7 @@ class Beats : public QObject {
 
     // Adjust the beats so the global average BPM matches dBpm. Beats class must
     // have the capability BEATSCAP_SET.
-    virtual void setBpm(double dBpm) = 0;
-
-    virtual SINT getSampleRate() const = 0;
+    virtual mixxx::BeatsPointer setBpm(double dBpm) = 0;
 
   signals:
     void updated();

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -66,6 +66,7 @@ class Beats : public QObject {
     // A sub-version can be used to represent the preferences used to generate
     // the beats object.
     virtual QString getSubVersion() const = 0;
+    virtual void setSubVersion(const QString& subVersion) = 0;
 
     ////////////////////////////////////////////////////////////////////////////
     // Beat calculations

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -156,9 +156,6 @@ class Beats : public QObject {
     // Adjust the beats so the global average BPM matches dBpm. Beats class must
     // have the capability BEATSCAP_SET.
     virtual BeatsPointer setBpm(double dBpm) = 0;
-
-  signals:
-    void updated();
 };
 
 } // namespace mixxx

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -57,7 +57,6 @@ class Beats : public QObject {
 
     // Serialization
     virtual QByteArray toByteArray() const = 0;
-    virtual BeatsPointer clone() const = 0;
 
     // A string representing the version of the beat-processing code that
     // produced this Beats instance. Used by BeatsFactory for associating a
@@ -144,18 +143,20 @@ class Beats : public QObject {
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
+    virtual BeatsPointer clone() const = 0;
+
     // Translate all beats in the song by dNumSamples samples. Beats that lie
     // before the start of the track or after the end of the track are not
     // removed. Beats instance must have the capability BEATSCAP_TRANSLATE.
-    virtual mixxx::BeatsPointer translate(double dNumSamples) const = 0;
+    virtual BeatsPointer translate(double dNumSamples) const = 0;
 
     // Scale the position of every beat in the song by dScalePercentage. Beats
     // class must have the capability BEATSCAP_SCALE.
-    virtual mixxx::BeatsPointer scale(enum BPMScale scale) const = 0;
+    virtual BeatsPointer scale(enum BPMScale scale) const = 0;
 
     // Adjust the beats so the global average BPM matches dBpm. Beats class must
     // have the capability BEATSCAP_SET.
-    virtual mixxx::BeatsPointer setBpm(double dBpm) = 0;
+    virtual BeatsPointer setBpm(double dBpm) = 0;
 
   signals:
     void updated();

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -148,7 +148,7 @@ class Beats : public QObject {
 
     // Scale the position of every beat in the song by dScalePercentage. Beats
     // class must have the capability BEATSCAP_SCALE.
-    virtual void scale(enum BPMScale scale) = 0;
+    virtual mixxx::BeatsPointer scale(enum BPMScale scale) const = 0;
 
     // Adjust the beats so the global average BPM matches dBpm. Beats class must
     // have the capability BEATSCAP_SET.

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -28,11 +28,9 @@ class BeatIterator {
 // Beats is the base class for BPM and beat management classes. It
 // provides a specification of all methods a beat-manager class must provide, as
 // well as a capability model for representing optional features.
-class Beats : public QObject {
-    Q_OBJECT
+class Beats {
   public:
-    Beats() { }
-    ~Beats() override = default;
+    virtual ~Beats() = default;
 
     enum Capabilities {
         BEATSCAP_NONE          = 0x0000,

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -65,7 +65,6 @@ class Beats : public QObject {
     // A sub-version can be used to represent the preferences used to generate
     // the beats object.
     virtual QString getSubVersion() const = 0;
-    virtual void setSubVersion(const QString& subVersion) = 0;
 
     ////////////////////////////////////////////////////////////////////////////
     // Beat calculations

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -285,7 +285,7 @@ double Track::setBpm(double bpmValue) {
     if (!m_pBeats) {
         // No beat grid available -> create and initialize
         double cue = getCuePoint().getPosition();
-        mixxx::BeatsPointer pBeats(BeatFactory::makeBeatGrid(getSampleRate(), bpmValue, cue));
+        const auto pBeats = BeatFactory::makeBeatGrid(getSampleRate(), bpmValue, cue);
         setBeatsMarkDirtyAndUnlock(&lock, pBeats);
         return bpmValue;
     }
@@ -941,7 +941,7 @@ bool Track::importPendingBeatsWhileLocked() {
     // The sample rate is supposed to be consistent
     DEBUG_ASSERT(m_record.getStreamInfoFromSource()->getSignalInfo().getSampleRate() ==
             m_record.getMetadata().getStreamInfo().getSignalInfo().getSampleRate());
-    auto pBeats = mixxx::BeatMap::makeBeatMap(
+    const auto pBeats = mixxx::BeatMap::makeBeatMap(
             static_cast<SINT>(m_record.getStreamInfoFromSource()->getSignalInfo().getSampleRate()),
             QString(),
             m_pBeatsImporterPending->importBeatsAndApplyTimingOffset(

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -960,10 +960,12 @@ bool Track::importPendingBeatsWhileLocked() {
     // The sample rate is supposed to be consistent
     DEBUG_ASSERT(m_record.getStreamInfoFromSource()->getSignalInfo().getSampleRate() ==
             m_record.getMetadata().getStreamInfo().getSignalInfo().getSampleRate());
-    mixxx::BeatsPointer pBeats(new mixxx::BeatMap(*this,
+    auto pBeats = mixxx::BeatMap::makeBeatMap(
+            *this,
             static_cast<SINT>(m_record.getStreamInfoFromSource()->getSignalInfo().getSampleRate()),
+            QString(),
             m_pBeatsImporterPending->importBeatsAndApplyTimingOffset(
-                    getLocation(), *m_record.getStreamInfoFromSource())));
+                    getLocation(), *m_record.getStreamInfoFromSource()));
     DEBUG_ASSERT(m_pBeatsImporterPending->isEmpty());
     m_pBeatsImporterPending.reset();
     return setBeatsWhileLocked(pBeats);

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -285,7 +285,7 @@ double Track::setBpm(double bpmValue) {
     if (!m_pBeats) {
         // No beat grid available -> create and initialize
         double cue = getCuePoint().getPosition();
-        mixxx::BeatsPointer pBeats(BeatFactory::makeBeatGrid(*this, bpmValue, cue));
+        mixxx::BeatsPointer pBeats(BeatFactory::makeBeatGrid(getSampleRate(), bpmValue, cue));
         setBeatsMarkDirtyAndUnlock(&lock, pBeats);
         return bpmValue;
     }
@@ -942,7 +942,6 @@ bool Track::importPendingBeatsWhileLocked() {
     DEBUG_ASSERT(m_record.getStreamInfoFromSource()->getSignalInfo().getSampleRate() ==
             m_record.getMetadata().getStreamInfo().getSignalInfo().getSampleRate());
     auto pBeats = mixxx::BeatMap::makeBeatMap(
-            *this,
             static_cast<SINT>(m_record.getStreamInfoFromSource()->getSignalInfo().getSampleRate()),
             QString(),
             m_pBeatsImporterPending->importBeatsAndApplyTimingOffset(

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -318,16 +318,11 @@ bool Track::setBeatsWhileLocked(mixxx::BeatsPointer pBeats) {
         return false;
     }
 
-    if (m_pBeats) {
-        disconnect(m_pBeats.data(), &mixxx::Beats::updated, this, &Track::slotBeatsUpdated);
-    }
-
     m_pBeats = std::move(pBeats);
 
     auto bpmValue = mixxx::Bpm::kValueUndefined;
     if (m_pBeats) {
         bpmValue = m_pBeats->getBpm();
-        connect(m_pBeats.data(), &mixxx::Beats::updated, this, &Track::slotBeatsUpdated);
     }
     m_record.refMetadata().refTrackInfo().setBpm(mixxx::Bpm(bpmValue));
     return true;
@@ -350,20 +345,6 @@ void Track::setBeatsMarkDirtyAndUnlock(QMutexLocker* pLock, mixxx::BeatsPointer 
 mixxx::BeatsPointer Track::getBeats() const {
     QMutexLocker lock(&m_qMutex);
     return m_pBeats;
-}
-
-void Track::slotBeatsUpdated() {
-    QMutexLocker lock(&m_qMutex);
-
-    auto bpmValue = mixxx::Bpm::kValueUndefined;
-    if (m_pBeats) {
-        bpmValue = m_pBeats->getBpm();
-    }
-    m_record.refMetadata().refTrackInfo().setBpm(mixxx::Bpm(bpmValue));
-
-    markDirtyAndUnlock(&lock);
-    emit bpmUpdated(bpmValue);
-    emit beatsUpdated();
 }
 
 void Track::setMetadataSynchronized(bool metadataSynchronized) {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -295,11 +295,7 @@ double Track::setBpm(double bpmValue) {
         if (kLogger.debugEnabled()) {
             kLogger.debug() << "Updating BPM:" << getLocation();
         }
-        m_pBeats->setBpm(bpmValue);
-        markDirtyAndUnlock(&lock);
-        // Tell the GUI to update the bpm label...
-        //qDebug() << "Track signaling BPM update to" << f;
-        emit bpmUpdated(bpmValue);
+        setBeatsMarkDirtyAndUnlock(&lock, m_pBeats->setBpm(bpmValue));
     }
 
     return bpmValue;

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -371,7 +371,6 @@ class Track : public QObject {
 
   private slots:
     void slotCueUpdated();
-    void slotBeatsUpdated();
 
   private:
     // Set a unique identifier for the track. Only used by

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1127,7 +1127,7 @@ class ScaleBpmTrackPointerOperation : public mixxx::TrackPointerOperation {
         if (pTrack->isBpmLocked()) {
             return;
         }
-        mixxx::BeatsPointer pBeats = pTrack->getBeats();
+        const mixxx::BeatsPointer pBeats = pTrack->getBeats();
         if (!pBeats) {
             return;
         }

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1131,7 +1131,7 @@ class ScaleBpmTrackPointerOperation : public mixxx::TrackPointerOperation {
         if (!pBeats) {
             return;
         }
-        pBeats->scale(m_bpmScale);
+        pTrack->setBeats(pBeats->scale(m_bpmScale));
     }
 
     const mixxx::Beats::BPMScale m_bpmScale;


### PR DESCRIPTION
This removed some locking calls from the engine thread. These locks may cause a priority inversion when enable sync and using quantize. As a side effect the QObject base class has become useless and was also removed, along with the thread affinity code. 

The lock was original introduced to protect the engine from reading half way edited data when the beat grid is changed. As a side effect also concurrent read calls are locking each other. 

The solution implemented here, makes the beat classes const. This way they can't be edited and there is no reason for locking anymore. If changes are required they are introduced to a copy of the original object. Due to the wrapping shared pointer the old copy is valid until the last reader is finished. Changing to the new beats object is a atomic pointer replace. 

This PR heavily conflicts with the new betas object https://github.com/mixxxdj/mixxx/pull/2961. This is luckily no issue at all, because the beat classes changed in this PR were removed. In a merge we can just discard the changes here.
 
The new beats class still has locking. This can be removed using this PR as a template. 

This PR has grown larger than I have initially expected due to many similar changes in the code using the beats interface.  That's hopefully no problem during review. 
  


   

