### PR TITLE
Fix AutoMoc warning

### DIFF
--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -1,7 +1,5 @@
 #include "track/beats.h"
 
-#include "moc_beats.cpp"
-
 namespace mixxx {
 
 int Beats::numBeatsInRange(double dStartSample, double dEndSample) const {

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <QObject>
 #include <QString>
 #include <QList>
 #include <QByteArray>


### PR DESCRIPTION
/mixxx/src/track/beats.h:0: Note:
No relevant classes found. No output generated.