### PR TITLE
Pref Library: add button 'Open Settings Folder'

### DIFF
--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -56,6 +56,12 @@ DlgPrefLibrary::DlgPrefLibrary(
             &QPushButton::clicked,
             this,
             &DlgPrefLibrary::slotRelocateDir);
+    const QString& settingsDir = m_pConfig->getSettingsPath();
+    connect(PushButtonOpenSettingsDir,
+            &QPushButton::clicked,
+            [settingsDir] {
+                QDesktopServices::openUrl(QUrl::fromLocalFile(settingsDir));
+            });
 
     // Set default direction as stored in config file
     int rowHeight = m_pLibrary->getTrackTableRowHeight();

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -14,6 +14,7 @@
    <string notr="true">Library Preferences</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+
    <item>
     <widget class="QGroupBox" name="groupBoxLibrary">
      <property name="title">
@@ -100,6 +101,7 @@
      </layout>
     </widget>
    </item>
+
    <item>
     <widget class="QGroupBox" name="groupBox_AudioFileFormats">
      <property name="title">
@@ -122,6 +124,7 @@
      </layout>
     </widget>
    </item>
+
    <item>
     <widget class="QGroupBox" name="groupBox_AudioFileTags">
      <property name="title">
@@ -138,6 +141,7 @@
      </layout>
     </widget>
    </item>
+
    <item>
     <widget class="QGroupBox" name="groupBox_Miscellaneous">
      <property name="title">
@@ -238,6 +242,7 @@
      </layout>
     </widget>
    </item>
+
    <item>
     <widget class="QGroupBox" name="groupBox_4">
      <property name="toolTip">
@@ -281,6 +286,7 @@
      </layout>
     </widget>
    </item>
+
    <item>
     <widget class="QGroupBox" name="groupBox_3">
      <property name="title">
@@ -348,23 +354,62 @@
        </widget>
       </item>
       <item row="6" column="0">
-       <widget class="Line" name="line">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="0">
        <widget class="QLabel" name="label_4">
         <property name="text">
          <string>All external libraries shown are write protected.</string>
         </property>
+        <property name="topMargin">
+         <number>10</number>
+        </property>
        </widget>
       </item>
-      <item row="8" column="0">
+      <item row="7" column="0">
        <widget class="QLabel" name="label_10">
         <property name="text">
          <string>You will need to restart Mixxx for these settings to take effect.</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+
+   <item>
+    <widget class="QGroupBox" name="groupBox_settingsDir">
+     <property name="title">
+      <string>Settings Folder</string>
+     </property>
+     <layout class="QVBoxLayout" name="vlayout_settingsDir">
+      <item>
+       <widget class="QLabel" name="label_settingsDir">
+        <property name="text">
+         <string>The Mixxx settings folder contains the library database, various configuration files, log files, track analysis data, as well as custom controller mappings.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_settingsWarning">
+        <property name="text">
+         <string>Edit those files only if you know what you are doing and only while Mixxx is not running.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="PushButtonOpenSettingsDir">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Open Mixxx Settings Folder</string>
         </property>
        </widget>
       </item>
@@ -410,6 +455,7 @@
   <tabstop>checkBox_show_traktor</tabstop>
   <tabstop>checkBox_show_rekordbox</tabstop>
   <tabstop>checkBox_show_serato</tabstop>
+  <tabstop>PushButtonOpenSettingsDir</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
I think this simplifies the actual backup process for most users.

Main motivation was to streamline the support workflow. Currently, if we request log files, or something's wrong with the library, or some config, we need to send users to the wiki and they need to figure out the location themselves, which is not easy for really unexperienced users, or _we_ have to copy/paste the paths again and again.

Now it's all just one click away :)

![image](https://user-images.githubusercontent.com/5934199/110189840-e589d200-7e20-11eb-9cd1-8b6e7a8be902.png)

Downside: now it's also easier for 'curious users' to screw things up...
Do you think the warning is sufficient?
