### PR TITLE
Removed fastbuild from windows_buildenv.bat and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ Please see our helpful guide on the [wiki] for more information: [Compiling on M
    - Generates the `CMakeSettings.json` with the matching build configurations for Visual Studio
 3. Start Visual Studio, choose "Open a local folder" select the `mixxx` directory containing `CMakeSettings.json`
 4. Menu "Project" -> "Generate Cache for mixxx"
-5. Select the build configuration in the toolbar (`x64__fastbuild` is recommended)
+5. Select the build configuration in the toolbar (`x64__portable` is recommended)
 6. Menu "Build" -> "Build All"
 ### Creating an .msi installer (optional)
 7. Than open the Visual Studio 'Developer Command Prompt' by Menu -> "Tools" -> "Command line" -> "Developer Command Prompt"
-8. Go to your build directory, e.g. by "cd .\build\x64-fastbuild"
+8. Go to your build directory, e.g. by "cd .\build\x64-portable"
 9. Run "cpack -G WIX"
 
 

--- a/tools/windows_buildenv.bat
+++ b/tools/windows_buildenv.bat
@@ -83,8 +83,6 @@ EXIT /B 0
         ECHO PATH=!PATH!>>!GITHUB_ENV!
     ) else (
         CALL :GENERATE_CMakeSettings_JSON
-        echo WARNING: CMakeSettings.json will include an invalid CMAKE_PREFIX_PATH
-        echo          for settings other than %CONFIGURATION% .
 
         IF NOT EXIST %BUILD_ROOT% (
             ECHO ### Create subdirectory build ###
@@ -154,7 +152,6 @@ REM Generate CMakeSettings.json which is read by MS Visual Studio to determine t
     CALL :Configuration2CMakeSettings_JSON off       Debug
     CALL :Configuration2CMakeSettings_JSON legacy    RelWithDebInfo
     CALL :Configuration2CMakeSettings_JSON portable  RelWithDebInfo
-    CALL :Configuration2CMakeSettings_JSON fastbuild RelWithDebInfo
     SET configElementTermination=
     CALL :Configuration2CMakeSettings_JSON native    Release
     >>%CMakeSettings% echo   ]
@@ -213,7 +210,8 @@ REM Generate CMakeSettings.json which is read by MS Visual Studio to determine t
     for /f "tokens=2 delims=:" %%I in ('chcp') do set "_codepage=%%I"
 
     >NUL chcp 1252
-
+    REM Remove suffix dot
+    set _codepage=%_codepage:.=%
     SET RETVAL=%_codepage%
   GOTO :EOF
 


### PR DESCRIPTION
Fastbuild was removed from CMakeList.txt, but was still the recommend…ed target in the Windows build instructions
Removed fastbuild also from windows_buildenv.bat
Codepage is a number suceeded by a dot in my case. Trim this dot now, if it's there
Warning about CMAKE_Prefix path seems to be no longer true, works for me with all targets now.