### PR TITLE
macOS: Add audio-input entitlement for hardened runtime

### DIFF
--- a/packaging/macos/entitlements.plist
+++ b/packaging/macos/entitlements.plist
@@ -10,7 +10,11 @@
     <true/>
     <key>com.apple.security.device.firewire</key>
     <true/>
+    <!-- Required for microphone access in sandboxed app -->
     <key>com.apple.security.device.microphone</key>
+    <true/>
+    <!-- Required for microphone access in app built with the hardened runtime -->
+    <key>com.apple.security.device.audio-input</key>
     <true/>
     <key>com.apple.security.device.usb</key>
     <true/>


### PR DESCRIPTION
Fixes [lp1917530](https://bugs.launchpad.net/mixxx/+bug/1917530).

I have no way to test this, please verify if this works.