### PR TITLE
remove Beats::clone()

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -268,15 +268,14 @@ void DlgTrackInfo::populateFields(const Track& track) {
 }
 
 void DlgTrackInfo::reloadTrackBeats(const Track& track) {
-    const mixxx::BeatsPointer pBeats = track.getBeats();
-    if (pBeats) {
-        spinBpm->setValue(pBeats->getBpm());
-        m_pBeatsClone = pBeats->clone();
+    m_pBeatsClone = track.getBeats();
+    if (m_pBeatsClone) {
+        spinBpm->setValue(m_pBeatsClone->getBpm());
     } else {
-        m_pBeatsClone.clear();
         spinBpm->setValue(0.0);
     }
-    m_trackHasBeatMap = pBeats && !(pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM);
+    m_trackHasBeatMap = m_pBeatsClone &&
+            !(m_pBeatsClone->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM);
     bpmConst->setChecked(!m_trackHasBeatMap);
     bpmConst->setEnabled(m_trackHasBeatMap); // We cannot make turn a BeatGrid to a BeatMap
     spinBpm->setEnabled(!m_trackHasBeatMap); // We cannot change bpm continuously or tab them

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -111,11 +111,6 @@ QByteArray BeatGrid::toByteArray() const {
     return QByteArray(output.data(), static_cast<int>(output.length()));
 }
 
-BeatsPointer BeatGrid::clone() const {
-    BeatsPointer other(new BeatGrid(*this));
-    return other;
-}
-
 double BeatGrid::firstBeatSample() const {
     return m_grid.first_beat().frame_position() * kFrameSize;
 }

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -65,7 +65,6 @@ class BeatGrid final : public Beats {
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
-    BeatsPointer clone() const override;
     BeatsPointer translate(double dNumSamples) const override;
     BeatsPointer scale(enum BPMScale scale) const override;
     BeatsPointer setBpm(double dBpm) override;

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -260,11 +260,6 @@ QByteArray BeatMap::toByteArray() const {
     return QByteArray(output.data(), static_cast<int>(output.length()));
 }
 
-BeatsPointer BeatMap::clone() const {
-    BeatsPointer other(new BeatMap(*this));
-    return other;
-}
-
 QString BeatMap::getVersion() const {
     return BEAT_MAP_VERSION;
 }

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -69,7 +69,6 @@ class BeatMap final : public Beats {
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
-    BeatsPointer clone() const override;
     BeatsPointer translate(double dNumSamples) const override;
     BeatsPointer scale(enum BPMScale scale) const override;
     BeatsPointer setBpm(double dBpm) override;

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -139,8 +139,6 @@ class Beats {
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
-    virtual BeatsPointer clone() const = 0;
-
     // Translate all beats in the song by dNumSamples samples. Beats that lie
     // before the start of the track or after the end of the track are not
     // removed. Beats instance must have the capability BEATSCAP_TRANSLATE.


### PR DESCRIPTION
Cloning a const beats object has no benefit. 