### PR TITLE
GitHub Actions: Disable Ubuntu 18.04 CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,27 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Ubuntu 18.04 (gcc)
-            os: ubuntu-18.04
-            cmake_args: >-
-              -DWARNINGS_FATAL=ON
-              -DFAAD=ON
-              -DLOCALECOMPARE=ON
-              -DMAD=ON
-              -DMODPLUG=ON
-              -DWAVPACK=ON
-              -INSTALL_USER_UDEV_RULES=OFF
-            cmake_generator: Unix Makefiles
-            cmake_build_type: RelWithDebInfo
-            ctest_args:
-            compiler_cache: ccache
-            compiler_cache_path: ~/.ccache
-            cpack_generator: DEB
-            buildenv_basepath: /home/runner/buildenv
-            buildenv_script: tools/debian_buildenv.sh
-            artifacts_name: Ubuntu 18.04 DEB
-            artifacts_path: build/*.deb
-            qt_qpa_platform: offscreen
           - name: Ubuntu 20.04 (gcc)
             os: ubuntu-20.04
             cmake_args: >-


### PR DESCRIPTION
Ubuntu 18.04 will not be supported for 2.4.

This is a prerequisite for PR #3038. Due to the old Qt 5.9 in Ubuntu the tests fail because `const` (ES6/7) does not work (Qt < 5.12 only supports ES3):

```
warning [0x56218251da90] LINT: "/home/runner/work/mixxx/mixxx/res/controllers/Traktor Kontrol Z2.hid.xml" has no forum link.
warning [0x56218251da90] LINT: "/home/runner/work/mixxx/mixxx/res/controllers/Traktor Kontrol Z2.hid.xml" has no wiki link.
warning [0x56218251da90] QFileSystemWatcher::removePaths: list is empty
warning [0x56218251da90] ControllerScriptHandlerBase: "Uncaught exception at line 12 in file /home/runner/work/mixxx/mixxx/res/controllers/Traktor-Kontrol-Z2-hid-scripts.js.\n\nException:\n  SyntaxError: Syntax error"
critical [0x56218251da90] DEBUG ASSERT: "m_pJSEngine" in function bool ControllerScriptEngineLegacy::callFunctionOnObjects(const QList<QString>&, const QString&, const QJSValueList&, bool) at /home/runner/work/mixxx/mixxx/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp:29
```