### PR TITLE
SeratoBeatGrid: Fix handling of subsample positions

### DIFF
--- a/src/audio/signalinfo.h
+++ b/src/audio/signalinfo.h
@@ -43,6 +43,12 @@ class SignalInfo final {
         return samples / getChannelCount();
     }
 
+    // Conversion: #samples / sample offset -> #frames / frame offset
+    double samples2framesFractional(double samples) const {
+        DEBUG_ASSERT(getChannelCount().isValid());
+        return samples / getChannelCount();
+    }
+
     // Conversion: #frames / frame offset -> #samples / sample offset
     SINT frames2samples(SINT frames) const {
         DEBUG_ASSERT(getChannelCount().isValid());

--- a/src/audio/signalinfo.h
+++ b/src/audio/signalinfo.h
@@ -56,9 +56,14 @@ class SignalInfo final {
     }
 
     // Conversion: #frames / frame offset -> second offset
-    double frames2secs(SINT frames) const {
+    double frames2secsFractional(double frames) const {
         DEBUG_ASSERT(getSampleRate().isValid());
-        return static_cast<double>(frames) / getSampleRate();
+        return frames / getSampleRate();
+    }
+
+    // Conversion: #frames / frame offset -> second offset
+    double frames2secs(SINT frames) const {
+        return frames2secsFractional(static_cast<double>(frames));
     }
 
     // Conversion: second offset -> #frames / frame offset

--- a/src/test/seratobeatgridtest.cpp
+++ b/src/test/seratobeatgridtest.cpp
@@ -6,6 +6,7 @@
 #include <QtDebug>
 
 #include "track/beatgrid.h"
+#include "track/beatmap.h"
 #include "track/serato/beatgrid.h"
 #include "util/memory.h"
 
@@ -120,4 +121,45 @@ TEST_F(SeratoBeatGridTest, SerializeConstBeatgrid) {
     EXPECT_NE(seratoBeatGrid.terminalMarker(), nullptr);
     EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm));
 }
+
+TEST_F(SeratoBeatGridTest, SerializeNonConstBeatgrid) {
+    // Create a non-const beatmap
+    constexpr double bpm = 100.0;
+    const auto sampleRate = mixxx::audio::SampleRate(44100);
+    const auto signalInfo = mixxx::audio::SignalInfo(mixxx::audio::ChannelCount(2), sampleRate);
+    const double framesPerMinute = signalInfo.getSampleRate() * 60;
+    const double framesPerBeat = framesPerMinute / bpm;
+
+    QVector<double> beatPositionsFrames;
+    double beatPositionFrames = 0;
+    // Add 2 minutes of beats at 100 bpm to the beatgrid
+    for (int i = 0; i < 2 * bpm; i++) {
+        beatPositionsFrames.append(beatPositionFrames);
+        beatPositionFrames += framesPerBeat;
+    }
+
+    // Now add 3 minutes of beats at 50 bpm to the beatgrid
+    for (int i = 0; i < 3 * bpm / 2; i++) {
+        beatPositionsFrames.append(beatPositionFrames);
+        beatPositionFrames += framesPerBeat * 2;
+    }
+    qWarning() << "beats" << beatPositionsFrames;
+
+    const auto pBeats = mixxx::BeatMap::makeBeatMap(
+            sampleRate, QString("Test"), beatPositionsFrames);
+    // At the 1 minute mark the BPM should be 100
+    EXPECT_EQ(pBeats->getBpmAroundPosition(framesPerMinute, 1), bpm);
+    // At the 4 minute mark the BPM should be 50
+    EXPECT_EQ(pBeats->getBpmAroundPosition(framesPerMinute * 4, 1), bpm / 2);
+    const auto streamInfo = mixxx::audio::StreamInfo(signalInfo,
+            mixxx::audio::Bitrate(320),
+            mixxx::Duration::fromSeconds<int>(300));
+
+    mixxx::SeratoBeatGrid seratoBeatGrid;
+    seratoBeatGrid.setBeats(pBeats, streamInfo, 0);
+    EXPECT_EQ(seratoBeatGrid.nonTerminalMarkers().size(), 2);
+    EXPECT_NE(seratoBeatGrid.terminalMarker(), nullptr);
+    EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm / 2));
+}
+
 } // namespace

--- a/src/track/serato/beatgrid.cpp
+++ b/src/track/serato/beatgrid.cpp
@@ -430,8 +430,10 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
 
     const double timingOffsetSecs = timingOffsetMillis / 1000;
 
-    // Find at least the track duration in samples. This value might be longer
-    // than the actual track, to make sure we get all beats.
+    // Beats::findBeats expects a sample range. We want to retrieve all beats
+    // in the track, therefore we calculate the track duration in samples and
+    // round up. This value might be longer than the actual track, but that's
+    // okay because we want to make sure we get all beats.
     const SINT trackDurationSamples = streamInfo.getSignalInfo().frames2samples(
             static_cast<SINT>(streamInfo.getSignalInfo().secs2frames(
                     std::ceil(streamInfo.getDuration().toDoubleSeconds()))));

--- a/src/track/serato/beatgrid.cpp
+++ b/src/track/serato/beatgrid.cpp
@@ -7,6 +7,10 @@
 namespace {
 
 mixxx::Logger kLogger("SeratoBeatGrid");
+
+/// Max difference of two beat distances so that they can still be considered equal
+constexpr double kEpsilon = 1.0;
+
 constexpr quint16 kVersion = 0x0100;
 constexpr int kMarkerSizeID3 = 8;
 constexpr char kSeratoBeatGridBase64EncodedPrefixStr[] =
@@ -456,7 +460,9 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
         // beat and the beat before that, we can just increment
         // `beatsSinceLastMarker`. If not, we need to add a new marker.
         const double currentDeltaFrames = currentBeatPositionFrames - previousBeatPositionFrames;
-        if (currentDeltaFrames != previousDeltaFrames) {
+        const double differenceBetweenCurrentAndPreviousDelta =
+                abs(currentDeltaFrames - previousDeltaFrames);
+        if (differenceBetweenCurrentAndPreviousDelta > kEpsilon) {
             // We are adding a new beat marker, therefore we need to update the
             // `beatsSinceLastMarker` variable of the last marker we added.
             if (!nonTerminalMarkers.isEmpty()) {

--- a/src/track/serato/beatgrid.cpp
+++ b/src/track/serato/beatgrid.cpp
@@ -439,6 +439,7 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
 
     // This might be null if the track doesn't contain any beats
     if (!pBeatsIterator) {
+        qWarning() << "Serato Beatgrid: No beats available, exporting empty beatgrid!";
         setTerminalMarker(nullptr);
         setNonTerminalMarkers({});
         return;

--- a/src/track/serato/beatgrid.cpp
+++ b/src/track/serato/beatgrid.cpp
@@ -482,8 +482,8 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
             // last beat, this needs to be a terminal marker entry.
             if (pBeatsIterator->hasNext()) {
                 const double positionSecs =
-                        streamInfo.getSignalInfo().frames2secs(
-                                static_cast<SINT>(currentBeatPositionFrames)) -
+                        streamInfo.getSignalInfo().frames2secsFractional(
+                                currentBeatPositionFrames) -
                         timingOffsetSecs;
                 nonTerminalMarkers.append(
                         std::make_shared<SeratoBeatGridNonTerminalMarker>(positionSecs, 0));
@@ -512,8 +512,8 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
 
     // Finally, create the terminal marker.
     const double positionSecs =
-            streamInfo.getSignalInfo().frames2secs(
-                    static_cast<SINT>(currentBeatPositionFrames)) -
+            streamInfo.getSignalInfo().frames2secsFractional(
+                    currentBeatPositionFrames) -
             timingOffsetSecs;
     const double bpm = pBeats->getBpmAroundPosition(
             streamInfo.getSignalInfo().frames2samples(

--- a/src/track/serato/beatgrid.cpp
+++ b/src/track/serato/beatgrid.cpp
@@ -506,15 +506,24 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
         return;
     }
 
+    // If the beatgrid is constant, i.e. if there is only a single non-terminal
+    // beatgrid marker at the start of the beatgrid and a terminal marker at
+    // the end, then Serato discards the non-terminal marker and just saves the
+    // terminal marker instead.
+    if (nonTerminalMarkers.size() == 1) {
+        nonTerminalMarkers.clear();
+    }
+
     // Update the `beatsSinceLastMarker` of the last non-terminal marker we inserted.
-    DEBUG_ASSERT(!nonTerminalMarkers.isEmpty());
-    DEBUG_ASSERT(beatsSinceLastMarker > 0);
-    const auto pNonTerminalMarker = nonTerminalMarkers.at(nonTerminalMarkers.size() - 1);
-    DEBUG_ASSERT(pNonTerminalMarker);
-    // We need to subtract 1 from `beatsSinceLastMarker`, because at the end of
-    // the last iteration the counter is incremented even though we didn't move
-    // a beat forwards.
-    pNonTerminalMarker->setBeatsTillNextMarker(beatsSinceLastMarker - 1);
+    if (!nonTerminalMarkers.isEmpty()) {
+        DEBUG_ASSERT(beatsSinceLastMarker > 0);
+        const auto pNonTerminalMarker = nonTerminalMarkers.at(nonTerminalMarkers.size() - 1);
+        DEBUG_ASSERT(pNonTerminalMarker);
+        // We need to subtract 1 from `beatsSinceLastMarker`, because at the end of
+        // the last iteration the counter is incremented even though we didn't move
+        // a beat forwards.
+        pNonTerminalMarker->setBeatsTillNextMarker(beatsSinceLastMarker - 1);
+    }
 
     // Finally, create the terminal marker.
     const double positionSecs =


### PR DESCRIPTION
Unsure if that is the best way to handle this. I appreciate comments.

TODO:
- [x] Add test for non-const beatgrid
- [x] Use fuzzy comparison for beat distance values, because right now a const beatgrid is exported like this:
```
Debug [Main]: SeratoBeatGrid - SeratoBeatGridNonTerminalMarker SeratoBeatGridNonTerminalMarker PositionSecs = 114.297 BeatTillNextMarker =  12
Debug [Main]: SeratoBeatGrid - SeratoBeatGridNonTerminalMarker SeratoBeatGridNonTerminalMarker PositionSecs = 120.3 BeatTillNextMarker =  1
Debug [Main]: SeratoBeatGrid - SeratoBeatGridNonTerminalMarker SeratoBeatGridNonTerminalMarker PositionSecs = 120.799 BeatTillNextMarker =  1
Debug [Main]: SeratoBeatGrid - SeratoBeatGridNonTerminalMarker SeratoBeatGridNonTerminalMarker PositionSecs = 121.286 BeatTillNextMarker =  1
Debug [Main]: SeratoBeatGrid - SeratoBeatGridNonTerminalMarker SeratoBeatGridNonTerminalMarker PositionSecs = 121.797 BeatTillNextMarker =  1
Debug [Main]: SeratoBeatGrid - SeratoBeatGridNonTerminalMarker SeratoBeatGridNonTerminalMarker PositionSecs = 122.296 BeatTillNextMarker =  16
Debug [Main]: SeratoBeatGrid - SeratoBeatGridNonTerminalMarker SeratoBeatGridNonTerminalMarker PositionSecs = 130.296 BeatTillNextMarker =  1
Debug [Main]: SeratoBeatGrid - SeratoBeatGridNonTerminalMarker SeratoBeatGridNonTerminalMarker PositionSecs = 130.795 BeatTillNextMarker =  12
Debug [Main]: SeratoBeatGrid - SeratoBeatGridNonTerminalMarker SeratoBeatGridNonTerminalMarker PositionSecs = 136.797 BeatTillNextMarker =  1
Debug [Main]: SeratoBeatGrid - SeratoBeatGridNonTerminalMarker SeratoBeatGridNonTerminalMarker PositionSecs = 137.297 BeatTillNextMarker =  15
Debug [Main]: SeratoBeatGrid - SeratoBeatGridNonTerminalMarker SeratoBeatGridNonTerminalMarker PositionSecs = 144.797 BeatTillNextMarker =  1
Debug [Main]: SeratoBeatGrid - SeratoBeatGridNonTerminalMarker SeratoBeatGridNonTerminalMarker PositionSecs = 145.296 BeatTillNextMarker =  13
Debug [Main]: SeratoBeatGrid - SeratoBeatGridNonTerminalMarker SeratoBeatGridNonTerminalMarker PositionSecs = 151.797 BeatTillNextMarker =  1
Debug [Main]: SeratoBeatGrid - SeratoBeatGridNonTerminalMarker SeratoBeatGridNonTerminalMarker PositionSecs = 152.297 BeatTillNextMarker =  16
Debug [Main]: SeratoBeatGrid - SeratoBeatGridNonTerminalMarker SeratoBeatGridNonTerminalMarker PositionSecs = 160.296 BeatTillNextMarker =  1
Debug [Main]: SeratoBeatGrid - SeratoBeatGridNonTerminalMarker SeratoBeatGridNonTerminalMarker PositionSecs = 160.795 BeatTillNextMarker =  15
Debug [Main]: SeratoBeatGrid - SeratoBeatGridNonTerminalMarker SeratoBeatGridNonTerminalMarker PositionSecs = 168.295 BeatTillNextMarker =  1
Debug [Main]: SeratoBeatGrid - SeratoBeatGridNonTerminalMarker SeratoBeatGridNonTerminalMarker PositionSecs = 168.794 BeatTillNextMarker =  19
Debug [Main]: SeratoBeatGrid - SeratoBeatGridNonTerminalMarker SeratoBeatGridNonTerminalMarker PositionSecs = 178.291 BeatTillNextMarker =  1
Debug [Main]: SeratoBeatGrid - SeratoBeatGridNonTerminalMarker SeratoBeatGridNonTerminalMarker PositionSecs = 178.791 BeatTillNextMarker =  12
Debug [Main]: SeratoBeatGrid - SeratoBeatGridNonTerminalMarker SeratoBeatGridNonTerminalMarker PositionSecs = 184.793 BeatTillNextMarker =  1
Debug [Main]: SeratoBeatGrid - SeratoBeatGridNonTerminalMarker SeratoBeatGridNonTerminalMarker PositionSecs = 185.281 BeatTillNextMarker =  1
Debug [Main]: SeratoBeatGrid - SeratoBeatGridNonTerminalMarker SeratoBeatGridNonTerminalMarker PositionSecs = 185.791 BeatTillNextMarker =  1
```