### PR TITLE
Add missing null check

### DIFF
--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -1012,6 +1012,9 @@ void BpmControl::slotBeatsTranslate(double v) {
         return;
     }
     TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    if (!pTrack) {
+        return;
+    }
     const mixxx::BeatsPointer pBeats = pTrack->getBeats();
     if (pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
         double currentSample = getSampleOfTrack().current;


### PR DESCRIPTION
This fixes a segfault reported in https://bugs.launchpad.net/mixxx/+bug/1918671
When trying to adjust the beats offset in an empty deck. 
A regression from https://github.com/mixxxdj/mixxx/pull/3668.
