### PR TITLE
Fix icon quality in about-dialog by using QSvgWidget

### DIFF
--- a/src/dialog/dlgabout.cpp
+++ b/src/dialog/dlgabout.cpp
@@ -10,6 +10,9 @@
 DlgAbout::DlgAbout(QWidget* parent) : QDialog(parent), Ui::DlgAboutDlg() {
     setupUi(this);
 
+    mixxx_icon->load(QString(":/images/mixxx_icon.svg"));
+    mixxx_logo->load(QString(":/images/mixxx_logo.svg"));
+
     QString mixxxVersion = Version::version();
     QString buildBranch = Version::developmentBranch();
     QString buildRevision = Version::developmentRevision();

--- a/src/dialog/dlgaboutdlg.ui
+++ b/src/dialog/dlgaboutdlg.ui
@@ -29,43 +29,22 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QLabel" name="mixxx_icon">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
+      <widget class="QSvgWidget" name="mixxx_icon">
        <property name="maximumSize">
         <size>
-         <width>48</width>
-         <height>68</height>
+         <width>32</width>
+         <height>32</height>
         </size>
-       </property>
-       <property name="pixmap">
-        <pixmap resource="../../res/mixxx.qrc">:/images/mixxx_icon.svg</pixmap>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="mixxx_logo">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
+      <widget class="QSvgWidget" name="mixxx_logo">
        <property name="maximumSize">
         <size>
          <width>170</width>
          <height>68</height>
         </size>
-       </property>
-       <property name="pixmap">
-        <pixmap resource="../../res/mixxx.qrc">:/images/mixxx_logo.svg</pixmap>
-       </property>
-       <property name="scaledContents">
-        <bool>true</bool>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
The problem is visible on on high-dpi screens:

Before:
![before](https://user-images.githubusercontent.com/20947558/110816953-1c7e3e80-828c-11eb-8d79-a919d3d62523.png)
After:
![after](https://user-images.githubusercontent.com/20947558/110816975-23a54c80-828c-11eb-8cbb-0ff396cb7ee1.png)

(See also #2274)