### PR TITLE
Sample Util fixes. 

### DIFF
--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -731,7 +731,7 @@ void EngineMaster::process(const int iBufferSize) {
     }
 
     if (m_pMasterMonoMixdown->toBool()) {
-        SampleUtil::mixStereoToMono(m_pMaster, m_pMaster, m_iBufferSize);
+        SampleUtil::mixStereoToMono(m_pMaster, m_iBufferSize);
     }
 
     if (masterEnabled) {

--- a/src/util/sample.cpp
+++ b/src/util/sample.cpp
@@ -370,7 +370,7 @@ void SampleUtil::convertS16ToFloat32(CSAMPLE* M_RESTRICT pDest,
     // is the highest valid sample. Note that this means that although some
     // sample values convert to -1.0, none will convert to +1.0.
     DEBUG_ASSERT(-SAMPLE_MINIMUM >= SAMPLE_MAXIMUM);
-    const CSAMPLE kConversionFactor = -SAMPLE_MINIMUM;
+    const CSAMPLE kConversionFactor = SAMPLE_MINIMUM * -1.0f;
     // note: LOOP VECTORIZED.
     for (SINT i = 0; i < numSamples; ++i) {
         pDest[i] = CSAMPLE(pSrc[i]) / kConversionFactor;
@@ -380,11 +380,15 @@ void SampleUtil::convertS16ToFloat32(CSAMPLE* M_RESTRICT pDest,
 //static
 void SampleUtil::convertFloat32ToS16(SAMPLE* pDest, const CSAMPLE* pSrc,
         SINT numSamples) {
+    // We use here -SAMPLE_MINIMUM for a perfect round trip with convertS16ToFloat32
+    // +1.0 is clamped to 32767 (0.99996942)
     DEBUG_ASSERT(-SAMPLE_MINIMUM >= SAMPLE_MAXIMUM);
-    const CSAMPLE kConversionFactor = -SAMPLE_MINIMUM;
+    const CSAMPLE kConversionFactor = SAMPLE_MINIMUM * -1.0f;
     // note: LOOP VECTORIZED only with "int i"
     for (int i = 0; i < numSamples; ++i) {
-        pDest[i] = SAMPLE(pSrc[i] * kConversionFactor);
+        pDest[i] = static_cast<SAMPLE>(math_clamp(pSrc[i] * kConversionFactor,
+                static_cast<CSAMPLE>(SAMPLE_MINIMUM),
+                static_cast<CSAMPLE>(SAMPLE_MAXIMUM)));
     }
 }
 

--- a/src/util/sample.cpp
+++ b/src/util/sample.cpp
@@ -16,7 +16,7 @@ typedef qint32 int32_t;
 // https://gcc.gnu.org/projects/tree-ssa/vectorization.html
 // This also utilizes AVX registers when compiled for a recent 64-bit CPU
 // using scons optimize=native.
-// "SINT i" is the prefered loop index type that should allow vectoszation in
+// "SINT i" is the preferred loop index type that should allow vectorization in
 // general. Unfortunatly there are expetions where "int i" is required for some reasons.
 
 namespace {

--- a/src/util/sample.cpp
+++ b/src/util/sample.cpp
@@ -189,7 +189,7 @@ void SampleUtil::applyRampingAlternatingGain(CSAMPLE* pBuffer,
         }
     } else {
         // not vectorized: vectorization not profitable.
-        for (int i = 0; i < numSamples; ++i) {
+        for (int i = 0; i < numSamples / 2; ++i) {
             pBuffer[i * 2] *= gain1Old;
         }
     }
@@ -205,7 +205,7 @@ void SampleUtil::applyRampingAlternatingGain(CSAMPLE* pBuffer,
         }
     } else {
         // not vectorized: vectorization not profitable.
-        for (int i = 0; i < numSamples; ++i) {
+        for (int i = 0; i < numSamples / 2; ++i) {
             pBuffer[i * 2 + 1] *= gain2Old;
         }
     }

--- a/src/util/sample.cpp
+++ b/src/util/sample.cpp
@@ -496,7 +496,8 @@ void SampleUtil::linearCrossfadeBuffersIn(
 }
 
 // static
-void SampleUtil::mixStereoToMono(CSAMPLE* pDest, const CSAMPLE* pSrc,
+void SampleUtil::mixStereoToMono(CSAMPLE* M_RESTRICT pDest,
+        const CSAMPLE* M_RESTRICT pSrc,
         SINT numSamples) {
     const CSAMPLE_GAIN mixScale = CSAMPLE_GAIN_ONE
             / (CSAMPLE_GAIN_ONE + CSAMPLE_GAIN_ONE);
@@ -504,6 +505,16 @@ void SampleUtil::mixStereoToMono(CSAMPLE* pDest, const CSAMPLE* pSrc,
     for (SINT i = 0; i < numSamples / 2; ++i) {
         pDest[i * 2] = (pSrc[i * 2] + pSrc[i * 2 + 1]) * mixScale;
         pDest[i * 2 + 1] = pDest[i * 2];
+    }
+}
+
+// static
+void SampleUtil::mixStereoToMono(CSAMPLE* pBuffer, SINT numSamples) {
+    const CSAMPLE_GAIN mixScale = CSAMPLE_GAIN_ONE / (CSAMPLE_GAIN_ONE + CSAMPLE_GAIN_ONE);
+    // note: LOOP VECTORIZED
+    for (SINT i = 0; i < numSamples / 2; ++i) {
+        pBuffer[i * 2] = (pBuffer[i * 2] + pBuffer[i * 2 + 1]) * mixScale;
+        pBuffer[i * 2 + 1] = pBuffer[i * 2];
     }
 }
 

--- a/src/util/sample.h
+++ b/src/util/sample.h
@@ -234,6 +234,8 @@ class SampleUtil {
     // "mono-compatible", ie there are no major out-of-phase parts of the signal.
     static void mixStereoToMono(CSAMPLE* pDest, const CSAMPLE* pSrc,
             SINT numSamples);
+    // In place version of the above.
+    static void mixStereoToMono(CSAMPLE* pBuffer, SINT numSamples);
 
     // In-place doubles the mono samples in pBuffer to dual mono samples.
     // (numFrames) samples will be read from pBuffer

--- a/src/util/sample.h
+++ b/src/util/sample.h
@@ -202,9 +202,7 @@ class SampleUtil {
             const CSAMPLE* pBuffer, SINT numSamples);
 
     // Copies every sample in pSrc to pDest, limiting the values in pDest
-    // to the valid range of CSAMPLE. If pDest and pSrc are aliases, will
-    // not copy will only clamp. Returns true if any samples in pSrc were
-    // outside the valid range of CSAMPLE.
+    // to the valid range of CSAMPLE. pDest and pSrc must not overlap.
     static void copyClampBuffer(CSAMPLE* pDest, const CSAMPLE* pSrc,
             SINT numSamples);
 

--- a/src/util/types.h
+++ b/src/util/types.h
@@ -19,17 +19,6 @@ constexpr SAMPLE SAMPLE_ZERO = 0;
 constexpr SAMPLE SAMPLE_MINIMUM = SHRT_MIN;
 constexpr SAMPLE SAMPLE_MAXIMUM = SHRT_MAX;
 
-// Limits the range of a SAMPLE value to [SAMPLE_MIN, SAMPLE_MAX].
-inline
-SAMPLE SAMPLE_clamp(SAMPLE in) {
-    return math_clamp(in, SAMPLE_MINIMUM, SAMPLE_MAXIMUM);
-}
-
-// Limits the range of a SAMPLE value to [-SAMPLE_MAX, SAMPLE_MAX].
-inline
-SAMPLE SAMPLE_clampSymmetric(SAMPLE in) {
-    return math_clamp(in, static_cast<SAMPLE>(-SAMPLE_MAXIMUM), SAMPLE_MAXIMUM);
-}
 
 // 32-bit single precision floating-point sample data
 // normalized within the range [-1.0, 1.0] with a peak


### PR DESCRIPTION
This fixes a buffer overflow in SampleUtil::applyRampingAlternatingGain() 
I found this while checking the vectorizations of the functions which is is also improved. 

In addition I have added clamping to convertFloat32ToS16 this should be applied allays, because a clamped float will still create a warp around, because +1.0 does not fit into a 16 bit int. 

This was introduced here https://github.com/mixxxdj/mixxx/pull/411
The underlying idea of allowing a perfect round trip, to avoid aliasing is a good trade of compared to loosing one sample which is most likely already clamped in most cases anyway. 