### PR TITLE
Fix flac encoding 

### DIFF
--- a/src/encoder/encodersndfileflac.cpp
+++ b/src/encoder/encodersndfileflac.cpp
@@ -7,21 +7,21 @@
 
 namespace {
 constexpr SINT kEncBufferSize = 8192; // used inside libsndfile for flac
+constexpr CSAMPLE_GAIN kFloatToIntConversionFactor = INT_MIN * -1.0f;
 
 //static
 void convertFloat32ToIntFormat(int* pDest, const CSAMPLE* pSrc, SINT numSamples, int format) {
-    const CSAMPLE kConversionFactor = INT_MIN * -1.0f;
     if (format & SF_FORMAT_PCM_16) {
-        // note: LOOP VECTORIZED only with "int i"
-        for (int i = 0; i < numSamples; ++i) {
-            pDest[i] = static_cast<int>(math_clamp(pSrc[i] * kConversionFactor,
+        // note: LOOP VECTORIZED"
+        for (SINT i = 0; i < numSamples; ++i) {
+            pDest[i] = static_cast<int>(math_clamp(pSrc[i] * kFloatToIntConversionFactor,
                     static_cast<CSAMPLE>(static_cast<int>(INT_MIN & 0xFFFF0000)),
                     static_cast<CSAMPLE>(static_cast<int>(INT_MAX & 0xFFFF0000))));
         }
     } else if (format & SF_FORMAT_PCM_24) {
-        // note: LOOP VECTORIZED only with "int i"
-        for (int i = 0; i < numSamples; ++i) {
-            pDest[i] = static_cast<int>(math_clamp(pSrc[i] * kConversionFactor,
+        // note: LOOP VECTORIZED"
+        for (SINT i = 0; i < numSamples; ++i) {
+            pDest[i] = static_cast<int>(math_clamp(pSrc[i] * kFloatToIntConversionFactor,
                     static_cast<CSAMPLE>(static_cast<int>(INT_MIN & 0xFFFFFF00)),
                     static_cast<CSAMPLE>(static_cast<int>(INT_MAX & 0xFFFFFF00))));
         }

--- a/src/encoder/encodersndfileflac.cpp
+++ b/src/encoder/encodersndfileflac.cpp
@@ -86,7 +86,7 @@ void EncoderSndfileFlac::initStream() {
 #endif //SFC_SUPPORTS_SET_COMPRESSION_LEVEL
 
     // Version 1.0.28 suffers broken clamping https://bugs.launchpad.net/mixxx/+bug/1915298
-    // We receive "libsndfile-1.0.28" on Ubuntu Bionic/Focal/Grovy
+    // We receive "libsndfile-1.0.28" on Ubuntu Bionic 18.04 LTS/Focal 20.04 LTS/Grovy 20.10
     // Older versions are not expected. All newer version have a working internal clamping
     const char* sf_version = sf_version_string();
     if (strstr(sf_version, "-1.0.28") != nullptr) {

--- a/src/encoder/encodersndfileflac.cpp
+++ b/src/encoder/encodersndfileflac.cpp
@@ -62,17 +62,16 @@ void EncoderSndfileFlac::setEncoderSettings(const EncoderSettings& settings)
 void EncoderSndfileFlac::encodeBuffer(const CSAMPLE* pBuffer, const int iBufferSize) {
     if (m_pClampBuffer) {
         SINT numSamplesLeft = iBufferSize;
-        while (numSamplesLeft > kEncBufferSize) {
+        while (numSamplesLeft > 0) {
+            const SINT numSamplesToWrite = math_min(numSamplesLeft, kEncBufferSize);
             convertFloat32ToIntFormat(m_pClampBuffer.get(),
                     pBuffer,
-                    kEncBufferSize,
+                    numSamplesToWrite,
                     m_sfInfo.format);
-            sf_write_int(m_pSndfile, m_pClampBuffer.get(), kEncBufferSize);
-            pBuffer += kEncBufferSize;
-            numSamplesLeft -= kEncBufferSize;
+            sf_write_int(m_pSndfile, m_pClampBuffer.get(), numSamplesToWrite);
+            pBuffer += numSamplesToWrite;
+            numSamplesLeft -= numSamplesToWrite;
         }
-        convertFloat32ToIntFormat(m_pClampBuffer.get(), pBuffer, numSamplesLeft, m_sfInfo.format);
-        sf_write_int(m_pSndfile, m_pClampBuffer.get(), numSamplesLeft);
     } else {
         sf_write_float(m_pSndfile, pBuffer, iBufferSize);
     }

--- a/src/encoder/encodersndfileflac.h
+++ b/src/encoder/encodersndfileflac.h
@@ -21,9 +21,11 @@ class EncoderSndfileFlac : public EncoderWave {
     ~EncoderSndfileFlac() override = default;
 
     void setEncoderSettings(const EncoderSettings& settings) override;
+    void encodeBuffer(const CSAMPLE* samples, const int size) override;
 
   protected:
     void initStream() override;
   private:
     double m_compression;
+    std::unique_ptr<int[]> m_pClampBuffer;
 };


### PR DESCRIPTION
This fixes https://bugs.launchpad.net/mixxx/+bug/1915298
for distros not yet updated to  libsndfile  > 1.0.28 like Ubuntu Bionic/Focal/Grovy