### PR TITLE
Track: Polish Beats/Bpm functions

### DIFF
--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -195,14 +195,15 @@ TEST(BeatGridTest, FromMetadata) {
     TrackPointer pTrack = newTrack(sampleRate);
 
     double bpm = 60.1;
-    double echoBpm = pTrack->trySetBpm(bpm);
-    EXPECT_DOUBLE_EQ(echoBpm, bpm);
+    ASSERT_TRUE(pTrack->trySetBpm(bpm));
+    EXPECT_DOUBLE_EQ(pTrack->getBpm(), bpm);
 
     auto pBeats = pTrack->getBeats();
     EXPECT_DOUBLE_EQ(pBeats->getBpm(), bpm);
 
-    echoBpm = pTrack->trySetBpm(-60.1);
-    EXPECT_DOUBLE_EQ(echoBpm, mixxx::Bpm::kValueUndefined);
+    // Invalid bpm resets the bpm
+    ASSERT_TRUE(pTrack->trySetBpm(-60.1));
+    EXPECT_DOUBLE_EQ(pTrack->getBpm(), mixxx::Bpm::kValueUndefined);
 
     pBeats = pTrack->getBeats();
     EXPECT_EQ(pBeats.isNull(), true);

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -33,8 +33,7 @@ SecurityTokenPointer openSecurityToken(
 }
 
 template<typename T>
-inline
-bool compareAndSet(T* pField, const T& value) {
+inline bool compareAndSet(T* pField, const T& value) {
     if (*pField != value) {
         *pField = value;
         return true;
@@ -43,17 +42,10 @@ bool compareAndSet(T* pField, const T& value) {
     }
 }
 
-inline mixxx::Bpm getActualBpm(
-        mixxx::Bpm bpm,
-        mixxx::BeatsPointer pBeats = mixxx::BeatsPointer()) {
-    // Only use the imported BPM if the beat grid is not valid!
-    // Reason: The BPM value in the metadata might be normalized
-    // or rounded, e.g. ID3v2 only supports integer values.
-    if (pBeats) {
-        return mixxx::Bpm(pBeats->getBpm());
-    } else {
-        return bpm;
-    }
+inline mixxx::Bpm getBeatsPointerBpm(
+        const mixxx::BeatsPointer& pBeats,
+        mixxx::Bpm defaultBpm = mixxx::Bpm{}) {
+    return pBeats ? mixxx::Bpm{pBeats->getBpm()} : defaultBpm;
 }
 
 } // anonymous namespace
@@ -197,7 +189,11 @@ void Track::importMetadata(
 
     // Need to set BPM after sample rate since beat grid creation depends on
     // knowing the sample rate. Bug #1020438.
-    const auto actualBpm = getActualBpm(newBpm, m_pBeats);
+
+    // Only use the imported BPM if the beat grid is not valid!
+    // Reason: The BPM value in the metadata might be normalized
+    // or rounded, e.g. ID3v2 only supports integer values.
+    const auto actualBpm = getBeatsPointerBpm(m_pBeats, newBpm);
     if (actualBpm.hasValue()) {
         trySetBpm(actualBpm.getValue());
     }
@@ -256,47 +252,44 @@ void Track::setReplayGain(const mixxx::ReplayGain& replayGain) {
     }
 }
 
-double Track::getBpm() const {
-    double bpm = mixxx::Bpm::kValueUndefined;
-    QMutexLocker lock(&m_qMutex);
-    if (m_pBeats) {
-        // BPM from beat grid overrides BPM from metadata
-        // Reason: The BPM value in the metadata might be imprecise,
-        // e.g. ID3v2 only supports integer values!
-        double beatsBpm = m_pBeats->getBpm();
-        if (mixxx::Bpm::isValidValue(beatsBpm)) {
-            bpm = beatsBpm;
-        }
-    }
-    return bpm;
+double Track::getBpmWhileLocked() const {
+    // BPM values must synchronized at all times!
+    DEBUG_ASSERT(m_record.getMetadata().getTrackInfo().getBpm() == getBeatsPointerBpm(m_pBeats));
+    return m_record.getMetadata().getTrackInfo().getBpm().getValue();
 }
 
-bool Track::trySetBpm(double bpmValue) {
-    QMutexLocker lock(&m_qMutex);
-
+bool Track::trySetBpmWhileLocked(double bpmValue) {
     if (!mixxx::Bpm::isValidValue(bpmValue)) {
         // If the user sets the BPM to an invalid value, we assume
         // they want to clear the beatgrid.
-        return trySetBeatsMarkDirtyAndUnlock(&lock, nullptr, false);
+        return trySetBeatsWhileLocked(nullptr);
     } else if (!m_pBeats) {
         // No beat grid available -> create and initialize
         double cue = m_record.getCuePoint().getPosition();
-        const auto pBeats = BeatFactory::makeBeatGrid(getSampleRate(), bpmValue, cue);
-        return trySetBeatsMarkDirtyAndUnlock(&lock, pBeats, false);
+        auto pBeats = BeatFactory::makeBeatGrid(getSampleRate(), bpmValue, cue);
+        return trySetBeatsWhileLocked(std::move(pBeats));
     } else if ((m_pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM) &&
             m_pBeats->getBpm() != bpmValue) {
         // Continue with the regular cases
         if (kLogger.debugEnabled()) {
             kLogger.debug() << "Updating BPM:" << getLocation();
         }
-        return trySetBeatsMarkDirtyAndUnlock(&lock, m_pBeats->setBpm(bpmValue), false);
+        return trySetBeatsWhileLocked(m_pBeats->setBpm(bpmValue));
     }
-
     return false;
 }
 
 QString Track::getBpmText() const {
     return QString("%1").arg(getBpm(), 3,'f',1);
+}
+
+bool Track::trySetBpm(double bpmValue) {
+    QMutexLocker lock(&m_qMutex);
+    if (!trySetBpmWhileLocked(bpmValue)) {
+        return false;
+    }
+    afterBeatsOrBpmUpdated(&lock);
+    return true;
 }
 
 bool Track::trySetBeats(mixxx::BeatsPointer pBeats) {
@@ -310,21 +303,31 @@ bool Track::trySetAndLockBeats(mixxx::BeatsPointer pBeats) {
 }
 
 bool Track::setBeatsWhileLocked(mixxx::BeatsPointer pBeats) {
-    // This whole method is not so great. The fact that Beats is an ABC is
-    // limiting with respect to QObject and signals/slots.
-
     if (m_pBeats == pBeats) {
         return false;
     }
-
     m_pBeats = std::move(pBeats);
-
-    auto bpmValue = mixxx::Bpm::kValueUndefined;
-    if (m_pBeats) {
-        bpmValue = m_pBeats->getBpm();
-    }
-    m_record.refMetadata().refTrackInfo().setBpm(mixxx::Bpm(bpmValue));
+    m_record.refMetadata().refTrackInfo().setBpm(getBeatsPointerBpm(m_pBeats));
     return true;
+}
+
+bool Track::trySetBeatsWhileLocked(
+        mixxx::BeatsPointer pBeats,
+        bool lockBpmAfterSet) {
+    if (m_pBeats && m_record.getBpmLocked()) {
+        // Track has already a valid and locked beats object, abbort.
+        qDebug() << "Track beats is already set and BPM-locked. Discard the new beats";
+        return false;
+    }
+
+    bool dirty = false;
+    if (setBeatsWhileLocked(pBeats)) {
+        dirty = true;
+    }
+    if (compareAndSet(m_record.ptrBpmLocked(), lockBpmAfterSet)) {
+        dirty = true;
+    }
+    return dirty;
 }
 
 bool Track::trySetBeatsMarkDirtyAndUnlock(
@@ -333,39 +336,27 @@ bool Track::trySetBeatsMarkDirtyAndUnlock(
         bool lockBpmAfterSet) {
     DEBUG_ASSERT(pLock);
 
-    if (m_pBeats && m_record.getBpmLocked()) {
-        // Track has already a valid and locked beats object, abbort.
-        qDebug() << "Track beats is already set and BPM-locked. Discard the new beats";
+    if (!trySetBeatsWhileLocked(pBeats, lockBpmAfterSet)) {
         return false;
     }
 
-    bool dirty = false;
-
-    if (setBeatsWhileLocked(pBeats)) {
-        dirty = true;
-    }
-
-    if (compareAndSet(m_record.ptrBpmLocked(), lockBpmAfterSet)) {
-        dirty = true;
-    }
-
-    if (!dirty) {
-        // Already set, nothing todo
-        pLock->unlock();
-        return false;
-    }
-
-    auto bpmValue = m_pBeats ? m_pBeats->getBpm() : mixxx::Bpm::kValueUndefined;
-
-    markDirtyAndUnlock(pLock);
-    emit bpmUpdated(bpmValue);
-    emit beatsUpdated();
+    afterBeatsOrBpmUpdated(pLock);
     return true;
 }
 
 mixxx::BeatsPointer Track::getBeats() const {
     QMutexLocker lock(&m_qMutex);
     return m_pBeats;
+}
+
+void Track::afterBeatsOrBpmUpdated(
+        QMutexLocker* pLock) {
+    DEBUG_ASSERT(pLock);
+
+    const auto bpmValue = getBpmWhileLocked();
+    markDirtyAndUnlock(pLock);
+    emit bpmUpdated(bpmValue);
+    emit beatsUpdated();
 }
 
 void Track::setMetadataSynchronized(bool metadataSynchronized) {
@@ -1000,12 +991,7 @@ bool Track::tryImportPendingBeatsMarkDirtyAndUnlock(
         return true;
     }
 
-    auto bpmValue = m_pBeats ? m_pBeats->getBpm() : mixxx::Bpm::kValueUndefined;
-
-    markDirtyAndUnlock(pLock);
-    emit bpmUpdated(bpmValue);
-    emit beatsUpdated();
-
+    afterBeatsOrBpmUpdated(pLock);
     return true;
 }
 
@@ -1089,10 +1075,12 @@ void Track::setCuePointsMarkDirtyAndUnlock(
         QMutexLocker* pLock,
         const QList<CuePointer>& cuePoints) {
     DEBUG_ASSERT(pLock);
+
     if (!setCuePointsWhileLocked(cuePoints)) {
         pLock->unlock();
         return;
     }
+
     markDirtyAndUnlock(pLock);
     emit cuesUpdated();
 }
@@ -1500,8 +1488,8 @@ void Track::updateStreamInfoFromSource(
     QMutexLocker lock(&m_qMutex);
     bool updated = m_record.updateStreamInfoFromSource(streamInfo);
 
-    bool importBeats = m_pBeatsImporterPending && !m_pBeatsImporterPending->isEmpty();
-    bool importCueInfos = m_pCueInfoImporterPending && !m_pCueInfoImporterPending->isEmpty();
+    const bool importBeats = m_pBeatsImporterPending && !m_pBeatsImporterPending->isEmpty();
+    const bool importCueInfos = m_pCueInfoImporterPending && !m_pCueInfoImporterPending->isEmpty();
 
     if (!importBeats && !importCueInfos) {
         // Nothing more to do
@@ -1511,36 +1499,33 @@ void Track::updateStreamInfoFromSource(
         return;
     }
 
-    auto bpmValue = mixxx::Bpm::kValueUndefined;
-
+    auto beatsImported = false;
     if (importBeats) {
         kLogger.debug() << "Finishing deferred import of beats because stream "
                            "audio properties are available now";
-        importBeats = importPendingBeatsWhileLocked();
-        if (m_pBeats) {
-            bpmValue = m_pBeats->getBpm();
-        }
+        beatsImported = importPendingBeatsWhileLocked();
     }
 
+    auto cuesImported = false;
     if (importCueInfos) {
         DEBUG_ASSERT(m_cuePoints.isEmpty());
         kLogger.debug()
                 << "Finishing deferred import of"
                 << m_pCueInfoImporterPending->size()
                 << "cue(s) because stream audio properties are available now";
-        importCueInfos = importPendingCueInfosWhileLocked();
+        cuesImported = importPendingCueInfosWhileLocked();
     }
 
-    if (!importBeats && !importCueInfos) {
+    if (!beatsImported && !cuesImported) {
         return;
     }
 
-    markDirtyAndUnlock(&lock);
-    if (importBeats) {
-        emit bpmUpdated(bpmValue);
-        emit beatsUpdated();
+    if (beatsImported) {
+        afterBeatsOrBpmUpdated(&lock);
+    } else {
+        markDirtyAndUnlock(&lock);
     }
-    if (importCueInfos) {
+    if (cuesImported) {
         emit cuesUpdated();
     }
 }

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -142,6 +142,11 @@ void Track::importMetadata(
         // enter locking scope
         QMutexLocker lock(&m_qMutex);
 
+        // Preserve the current bpm temprarily (see below) to avoid overwriting
+        // it with an inconsistent value compared to the beat grid, e.g. after
+        // reloading the bpm from file tags.
+        importedMetadata.refTrackInfo().setBpm(mixxx::Bpm(getBpmWhileLocked()));
+
         bool modified = false;
         // Only set the metadata synchronized flag (column `header_parsed`
         // in the database) from false to true, but never reset it back to

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -43,9 +43,8 @@ inline bool compareAndSet(T* pField, const T& value) {
 }
 
 inline mixxx::Bpm getBeatsPointerBpm(
-        const mixxx::BeatsPointer& pBeats,
-        mixxx::Bpm defaultBpm = mixxx::Bpm{}) {
-    return pBeats ? mixxx::Bpm{pBeats->getBpm()} : defaultBpm;
+        const mixxx::BeatsPointer& pBeats) {
+    return pBeats ? mixxx::Bpm{pBeats->getBpm()} : mixxx::Bpm{};
 }
 
 } // anonymous namespace
@@ -198,9 +197,8 @@ void Track::importMetadata(
     // Only use the imported BPM if the beat grid is not valid!
     // Reason: The BPM value in the metadata might be normalized
     // or rounded, e.g. ID3v2 only supports integer values.
-    const auto actualBpm = getBeatsPointerBpm(m_pBeats, newBpm);
-    if (actualBpm.hasValue()) {
-        trySetBpm(actualBpm.getValue());
+    if (!m_pBeats || !mixxx::Bpm::isValidValue(m_pBeats->getBpm())) {
+        trySetBpm(newBpm.getValue());
     }
 
     if (!newKey.isEmpty()

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -142,7 +142,7 @@ void Track::importMetadata(
         // enter locking scope
         QMutexLocker lock(&m_qMutex);
 
-        // Preserve the current bpm temprarily (see below) to avoid overwriting
+        // Preserve the current bpm temporarily (see below) to avoid overwriting
         // it with an inconsistent value compared to the beat grid, e.g. after
         // reloading the bpm from file tags.
         importedMetadata.refTrackInfo().setBpm(mixxx::Bpm(getBpmWhileLocked()));
@@ -258,7 +258,7 @@ void Track::setReplayGain(const mixxx::ReplayGain& replayGain) {
 }
 
 double Track::getBpmWhileLocked() const {
-    // BPM values must synchronized at all times!
+    // BPM values must be synchronized at all times!
     DEBUG_ASSERT(m_record.getMetadata().getTrackInfo().getBpm() == getBeatsPointerBpm(m_pBeats));
     return m_record.getMetadata().getTrackInfo().getBpm().getValue();
 }

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -280,7 +280,7 @@ bool Track::trySetBpm(double bpmValue) {
         return trySetBeatsMarkDirtyAndUnlock(&lock, nullptr, false);
     } else if (!m_pBeats) {
         // No beat grid available -> create and initialize
-        double cue = getCuePoint().getPosition();
+        double cue = m_record.getCuePoint().getPosition();
         const auto pBeats = BeatFactory::makeBeatGrid(getSampleRate(), bpmValue, cue);
         return trySetBeatsMarkDirtyAndUnlock(&lock, pBeats, false);
     } else if ((m_pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM) &&

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -352,7 +352,7 @@ bool Track::trySetBeatsMarkDirtyAndUnlock(
     if (!dirty) {
         // Already set, nothing todo
         pLock->unlock();
-        return true;
+        return false;
     }
 
     auto bpmValue = m_pBeats ? m_pBeats->getBpm() : mixxx::Bpm::kValueUndefined;

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -126,7 +126,7 @@ class Track : public QObject {
     }
 
     // Sets the BPM if not locked.
-    double trySetBpm(double bpm);
+    bool trySetBpm(double bpm);
     // Returns BPM
     double getBpm() const;
     // Returns BPM as a string

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -128,7 +128,10 @@ class Track : public QObject {
     // Sets the BPM if not locked.
     bool trySetBpm(double bpm);
     // Returns BPM
-    double getBpm() const;
+    double getBpm() const {
+        const QMutexLocker lock(&m_qMutex);
+        return getBpmWhileLocked();
+    }
     // Returns BPM as a string
     QString getBpmText() const;
 
@@ -401,6 +404,7 @@ class Track : public QObject {
 
     /// Imports pending beats from a BeatImporter and returns a boolean to
     /// indicate if BPM/beats were updated. Only supposed to be called while
+    /// the caller guards this a lock.
     bool importPendingBeatsWhileLocked();
 
     /// Sets cue points and returns a boolean to indicate if cues were updated.
@@ -412,6 +416,12 @@ class Track : public QObject {
     /// caller guards this a lock.
     bool importPendingCueInfosWhileLocked();
 
+    double getBpmWhileLocked() const;
+    bool trySetBpmWhileLocked(double bpmValue);
+    bool trySetBeatsWhileLocked(
+            mixxx::BeatsPointer pBeats,
+            bool lockBpmAfterSet = false);
+
     bool trySetBeatsMarkDirtyAndUnlock(
             QMutexLocker* pLock,
             mixxx::BeatsPointer pBeats,
@@ -419,6 +429,9 @@ class Track : public QObject {
     bool tryImportPendingBeatsMarkDirtyAndUnlock(
             QMutexLocker* pLock,
             bool lockBpmAfterSet);
+
+    void afterBeatsOrBpmUpdated(
+            QMutexLocker* pLock);
 
     void setCuePointsMarkDirtyAndUnlock(
             QMutexLocker* pLock,


### PR DESCRIPTION
I had a hard time to rebase my pending branches due to subtle differences, inconsistencies in function signatures and behavior of the Beats/Bpm functions.

As a consequence I have decided to split the functions into signalling and reusable, non-signalling versions. The former invoke the latter. This will be needed later, prevents merge conflicts and enables us to get rid of some redundant code.