### PR TITLE
DlgPrefInterface: Fix missing preview image for skins without schemes

### DIFF
--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -361,7 +361,14 @@ void DlgPrefInterface::notifyRebootNecessary() {
 }
 
 void DlgPrefInterface::slotSetScheme(int) {
-    QString newScheme = ComboBoxSchemeconf->currentText();
+    // This slot can be triggered by opening the preferences. If the current
+    // skin does not support color schemes, this would treat the string in the
+    // combobox as color scheme name. Therefore we need to check if the
+    // checkbox is actually enabled.
+    QString newScheme = ComboBoxSchemeconf->isEnabled()
+            ? ComboBoxSchemeconf->currentText()
+            : QString();
+
     if (m_colorScheme != newScheme) {
         m_colorScheme = newScheme;
         m_bRebootMixxxView = true;


### PR DESCRIPTION
When opening the preferences and the current skin doesn't support color
schems, the preview image is missing, it will try to open the preview image
"res/skins/MySkin/skin_preview_Thisskindoesnotsupportcolorschemes.png" which
is obviously wrong.

Fixes lp1918983: https://bugs.launchpad.net/mixxx/+bug/1918983