### PR TITLE
Help menu: use north-east arrow as hyperlink suffix

### DIFF
--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -521,7 +521,14 @@ void WMainMenuBar::initialize() {
     // HELP MENU
     QMenu* pHelpMenu = new QMenu(tr("&Help"), this);
 
-    QString externalLinkSuffix = QChar(' ') + QChar(0x2197); // north-east arrow
+    QString externalLinkSuffix;
+#ifndef __APPLE__
+    // According to Apple's Human Interface Guidelines devs are encouraged
+    // to not use custom icons in menus.
+    // https://developer.apple.com/design/human-interface-guidelines/macos/menus/menu-anatomy/
+    externalLinkSuffix = QChar(' ') + QChar(0x2197); // north-east arrow
+#endif
+
     QString supportTitle = tr("&Community Support") + externalLinkSuffix;
     QString supportText = tr("Get help with Mixxx");
     auto* pHelpSupport = new QAction(supportTitle, this);

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -541,6 +541,7 @@ void WMainMenuBar::initialize() {
     QDir resourceDir(m_pConfig->getResourcePath());
     // Default to the mixxx.org hosted version of the manual.
     QUrl qManualUrl(MIXXX_MANUAL_URL);
+    QString manualSuffix;
 #if defined(__APPLE__)
     // FIXME: We don't include the PDF manual in the bundle on OSX.
     // Default to the web-hosted version.
@@ -549,18 +550,23 @@ void WMainMenuBar::initialize() {
     if (resourceDir.exists(MIXXX_MANUAL_FILENAME)) {
         qManualUrl = QUrl::fromLocalFile(
                 resourceDir.absoluteFilePath(MIXXX_MANUAL_FILENAME));
+    } else {
+        manualSuffix = externalLinkSuffix;
     }
 #elif defined(__LINUX__)
     // On GNU/Linux, the manual is installed to e.g. /usr/share/doc/mixxx/
     if (resourceDir.cd("../doc/mixxx") && resourceDir.exists(MIXXX_MANUAL_FILENAME)) {
         qManualUrl = QUrl::fromLocalFile(
                 resourceDir.absoluteFilePath(MIXXX_MANUAL_FILENAME));
+    } else {
+        manualSuffix = externalLinkSuffix;
     }
 #else
     // No idea, default to the mixxx.org hosted version.
+    manualSuffix = externalLinkSuffix;
 #endif
 
-    QString manualTitle = tr("&User Manual") + externalLinkSuffix;
+    QString manualTitle = tr("&User Manual") + manualSuffix;
     QString manualText = tr("Read the Mixxx user manual.");
     auto* pHelpManual = new QAction(manualTitle, this);
     pHelpManual->setStatusTip(manualText);

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -521,8 +521,7 @@ void WMainMenuBar::initialize() {
     // HELP MENU
     QMenu* pHelpMenu = new QMenu(tr("&Help"), this);
 
-    QString externalLinkSuffix = " =>";
-
+    QString externalLinkSuffix = QChar(' ') + QChar(0x2197); // north-east arrow
     QString supportTitle = tr("&Community Support") + externalLinkSuffix;
     QString supportText = tr("Get help with Mixxx");
     auto* pHelpSupport = new QAction(supportTitle, this);
@@ -545,7 +544,7 @@ void WMainMenuBar::initialize() {
                 resourceDir.absoluteFilePath(MIXXX_MANUAL_FILENAME));
     }
 #elif defined(__LINUX__)
-    // On GNU/Linux, the manual is installed to e.g. /usr/share/mixxx/doc/
+    // On GNU/Linux, the manual is installed to e.g. /usr/share/doc/mixxx/
     if (resourceDir.cd("../doc/mixxx") && resourceDir.exists(MIXXX_MANUAL_FILENAME)) {
         qManualUrl = QUrl::fromLocalFile(
                 resourceDir.absoluteFilePath(MIXXX_MANUAL_FILENAME));


### PR DESCRIPTION
Restore the north-east arrow for external links.

*ubuntu with xfce
![image](https://user-images.githubusercontent.com/5934199/111089122-b9f69e00-852a-11eb-9906-32fa8b5b5f1b.png)

Windows10
![image](https://user-images.githubusercontent.com/5934199/111880133-d91d8180-89a9-11eb-9228-0c05103686e7.png)

I also considered 🌐
![image](https://user-images.githubusercontent.com/5934199/111089222-312c3200-852b-11eb-8d07-28043640fc0f.png)
but it may look really sh*#ty on various OS, also it's colored and distracting.

I think the arrow is fine, and much better than current ` => `
Looks fine on
- [x] *ubuntu
- [x] Windows
- [x] ~~macOS~~ excluded