### PR TITLE
Fix build of libshout-idjc on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2398,7 +2398,7 @@ if(BROADCAST)
   elseif(Shoutidjc_FOUND AND Shoutidjc_VERSION VERSION_LESS 2.4.6)
       message(STATUS "Installed libshout version: ${Shout_VERSION} is suffering from bug lp1913579")
   endif()
-  if(NOT Shsoutidjc_FOUND OR Shoutidjc_VERSION VERSION_LESS 2.4.6)
+  if(NOT Shoutidjc_FOUND OR Shoutidjc_VERSION VERSION_LESS 2.4.6)
     # Fall back to internal libraray in the lib tree
     message(STATUS "Using internal libshout-idjc")
     add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/lib/libshout-idjc")

--- a/lib/libshout-idjc/CMakeLists.txt
+++ b/lib/libshout-idjc/CMakeLists.txt
@@ -75,12 +75,10 @@ target_link_libraries(${PROJECT_NAME} PUBLIC Ogg::ogg)
 find_package(Vorbis REQUIRED)
 target_link_libraries(${PROJECT_NAME} PUBLIC Vorbis::vorbis Vorbis::vorbisenc)
 
-# Optional system dependencies
-find_package(OpenSSL)
-if(TARGET OpenSSL::SSL)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_OPENSSL)
-    target_link_libraries(${PROJECT_NAME} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
-endif()
+# OpenSSL
+find_package(OpenSSL REQUIRED)
+target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_OPENSSL)
+target_link_libraries(${PROJECT_NAME} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
 
 option(SPEEX "Speex support" OFF)
 if(SPEEX)

--- a/tools/debian_buildenv.sh
+++ b/tools/debian_buildenv.sh
@@ -74,6 +74,7 @@ case "$COMMAND" in
             libsndfile1-dev \
             libsoundtouch-dev \
             libsqlite3-dev \
+            libssl-dev \
             libtag1-dev \
             libupower-glib-dev \
             libusb-1.0-0-dev \


### PR DESCRIPTION
Related Zulip conversation: https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/2.2E3.3A.20Building.20on.20Ubuntu.2018.2E04/near/230430814