### PR TITLE
debian_buildenv.sh: add ninja-build package

### DIFF
--- a/tools/debian_buildenv.sh
+++ b/tools/debian_buildenv.sh
@@ -80,6 +80,7 @@ case "$COMMAND" in
             libusb-1.0-0-dev \
             libwavpack-dev \
             markdown \
+            ninja-build \
             portaudio19-dev \
             protobuf-compiler \
             qt5keychain-dev \


### PR DESCRIPTION
Ninja is not required for building but it is faster than the
default Unix Makefiles CMake generator and doesn not require
explicitly setting the --parallel level.