### PR TITLE
Complete missing StreamInfo reported by source from metadata

### DIFF
--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -207,7 +207,27 @@ bool TrackRecord::mergeImportedMetadata(
 }
 
 bool TrackRecord::updateStreamInfoFromSource(
-        const mixxx::audio::StreamInfo& streamInfoFromSource) {
+        mixxx::audio::StreamInfo streamInfoFromSource) {
+    // Complete missing properties from metadata. Some properties
+    // are mandatory while others like the bitrate might not be
+    // reported by all decoders.
+    VERIFY_OR_DEBUG_ASSERT(streamInfoFromSource.getSignalInfo().getChannelCount().isValid()) {
+        streamInfoFromSource.refSignalInfo().setChannelCount(
+                getMetadata().getStreamInfo().getSignalInfo().getChannelCount());
+    }
+    VERIFY_OR_DEBUG_ASSERT(streamInfoFromSource.getSignalInfo().getSampleRate().isValid()) {
+        streamInfoFromSource.refSignalInfo().setSampleRate(
+                getMetadata().getStreamInfo().getSignalInfo().getSampleRate());
+    }
+    VERIFY_OR_DEBUG_ASSERT(streamInfoFromSource.getDuration() > Duration::empty()) {
+        streamInfoFromSource.setDuration(
+                getMetadata().getStreamInfo().getDuration());
+    }
+    if (!streamInfoFromSource.getBitrate().isValid()) {
+        // The bitrate might not be reported by the SoundSource
+        streamInfoFromSource.setBitrate(
+                getMetadata().getStreamInfo().getBitrate());
+    }
     // Stream properties are not expected to vary during a session
     VERIFY_OR_DEBUG_ASSERT(!m_streamInfoFromSource ||
             *m_streamInfoFromSource == streamInfoFromSource) {

--- a/src/track/trackrecord.h
+++ b/src/track/trackrecord.h
@@ -119,7 +119,7 @@ class TrackRecord final {
     /// Returns true if the corresponding metadata properties have been
     /// updated and false otherwise.
     bool updateStreamInfoFromSource(
-            const mixxx::audio::StreamInfo& streamInfoFromSource);
+            mixxx::audio::StreamInfo streamInfoFromSource);
     /// Check if the stream info is supposed to be reliable and accurate.
     /// TODO: Also flag the stream info as "accurate" in the database and
     /// invoke updateStreamInfoFromSource() accordingly when loading tracks


### PR DESCRIPTION
Fixes incomplete audio properties reported by the SoundSource (primary) by copying the corresponding value imported by TagLib (secondary).

@Holzhaus Does this make sense to you? Should also fix the issues we discovered in #3409.