### PR TITLE
InternalClock: Use forward declaration for EngineChannel

### DIFF
--- a/src/engine/sync/internalclock.h
+++ b/src/engine/sync/internalclock.h
@@ -6,12 +6,12 @@
 
 #include "engine/sync/clock.h"
 #include "engine/sync/syncable.h"
-#include "engine/channels/enginechannel.h"
 
 class ControlObject;
 class ControlLinPotmeter;
 class ControlPushButton;
 class EngineSync;
+class EngineChannel;
 
 /// Internal Clock is a Master Sync object that provides a source of constant
 /// tempo when needed.  The EngineSync will decide when to make the Internal


### PR DESCRIPTION
No need to include the full header.