### PR TITLE
Qt 5.12: Delete obsolete QT_VERSION_CHECK workarounds

### DIFF
--- a/src/controllers/midi/portmidienumerator.cpp
+++ b/src/controllers/midi/portmidienumerator.cpp
@@ -16,11 +16,7 @@ bool recognizeDevice(const PmDeviceInfo& deviceInfo) {
     // In developer mode we show the MIDI Through Port, otherwise ignore it
     // since it routinely causes trouble.
     return CmdlineArgs::Instance().getDeveloper() ||
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
             !QLatin1String(deviceInfo.name)
-#else
-            !QString::fromLatin1(deviceInfo.name)
-#endif
                      .startsWith(kMidiThroughPortPrefix, Qt::CaseInsensitive);
 }
 

--- a/src/controllers/scripting/controllerscriptenginebase.cpp
+++ b/src/controllers/scripting/controllerscriptenginebase.cpp
@@ -207,13 +207,5 @@ void ControllerScriptEngineBase::errorDialogButton(
 }
 
 void ControllerScriptEngineBase::throwJSError(const QString& message) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
-    QString errorText = tr("Uncaught exception: %1").arg(message);
-    qWarning() << "ControllerEngine:" << errorText;
-    if (!m_bDisplayingExceptionDialog) {
-        scriptErrorDialog(errorText, errorText);
-    }
-#else
     m_pJSEngine->throwError(message);
-#endif
 }

--- a/src/controllers/scripting/controllerscriptmoduleengine.cpp
+++ b/src/controllers/scripting/controllerscriptmoduleengine.cpp
@@ -16,7 +16,6 @@ ControllerScriptModuleEngine::~ControllerScriptModuleEngine() {
 
 bool ControllerScriptModuleEngine::initialize() {
     ControllerScriptEngineBase::initialize();
-#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
     m_pJSEngine->installExtensions(QJSEngine::ConsoleExtension);
     // TODO: Add new ControlObject JS API to scripting environment.
 
@@ -44,7 +43,6 @@ bool ControllerScriptModuleEngine::initialize() {
     } else {
         qDebug() << "Module exports no shutdown function.";
     }
-#endif
     return true;
 }
 

--- a/src/encoder/encoderopus.cpp
+++ b/src/encoder/encoderopus.cpp
@@ -5,9 +5,7 @@
 #include <QByteArray>
 #include <QMapIterator>
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
 #include <QRandomGenerator>
-#endif
 #include <QtGlobal>
 
 #include "encoder/encoderopussettings.h"
@@ -65,11 +63,7 @@ int getSerial() {
 
     int serial;
     do {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
         serial = static_cast<int>(QRandomGenerator::global()->generate());
-#else
-        serial = qrand();
-#endif
     } while (prevSerial == serial);
 
     prevSerial = serial;
@@ -116,11 +110,7 @@ EncoderOpus::EncoderOpus(EncoderCallback* pCallback)
     // the Live Broadcasting implementation
 
     m_opusComments.insert("ENCODER", "mixxx/libopus");
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
     int serial = static_cast<int>(QRandomGenerator::global()->generate());
-#else
-    int serial = qrand();
-#endif
     ogg_stream_init(&m_oggStream, serial);
 }
 

--- a/src/library/coverart.cpp
+++ b/src/library/coverart.cpp
@@ -39,12 +39,7 @@ quint16 calculateLegacyHash(
         const QImage& image) {
     auto legacyHash = qChecksum(
             reinterpret_cast<const char*>(image.constBits()),
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
-            image.sizeInBytes()
-#else
-            image.byteCount()
-#endif
-    );
+            image.sizeInBytes());
     // In rare cases the calculated checksum could be equal to the
     // reserved value CoverInfo::defaultLegacyHash() which might cause
     // unexpected behavior. In this case we simply invert all bits to

--- a/src/library/dao/autodjcratesdao.cpp
+++ b/src/library/dao/autodjcratesdao.cpp
@@ -2,9 +2,7 @@
 
 #include "moc_autodjcratesdao.cpp"
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
 #include <QRandomGenerator>
-#endif
 #include <QtDebug>
 #include <QtSql>
 
@@ -53,11 +51,7 @@ const int kLeastPreferredPercentMax = 50;
 #endif
 
 int bounded_rand(int highest) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
     return QRandomGenerator::global()->bounded(highest);
-#else
-    return qrand() % highest;
-#endif
 }
 
 } // anonymous namespace

--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -2,9 +2,7 @@
 
 #include "moc_playlistdao.cpp"
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
 #include <QRandomGenerator>
-#endif
 #include <QtDebug>
 #include <QtSql>
 
@@ -967,10 +965,6 @@ void PlaylistDAO::shuffleTracks(const int playlistId,
         const QHash<int, TrackId>& allIds) {
     ScopedTransaction transaction(m_database);
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
-    // Seed the randomness generator
-    qsrand(QDateTime::currentDateTimeUtc().toTime_t());
-#endif
     QHash<int, TrackId> trackPositionIds = allIds;
     QList<int> newPositions = positions;
     const int searchDistance = math_max(trackPositionIds.count() / 4, 1);
@@ -1016,11 +1010,7 @@ void PlaylistDAO::shuffleTracks(const int playlistId,
 
         for (int limit = 10; limit > 0 && conflictFound; limit--) {
             int randomShuffleSetIndex = static_cast<int>(
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
                     QRandomGenerator::global()->generateDouble() *
-#else
-                    (qrand() / (RAND_MAX + 1.0)) *
-#endif
                     newPositions.count());
 
             trackBPosition = positions.at(randomShuffleSetIndex);

--- a/src/library/serato/seratofeature.cpp
+++ b/src/library/serato/seratofeature.cpp
@@ -143,12 +143,7 @@ inline quint32 bytesToUInt32(const QByteArray& data) {
     VERIFY_OR_DEBUG_ASSERT(data.size() >= static_cast<int>(sizeof(quint32))) {
         return 0;
     }
-#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
     return qFromBigEndian<quint32>(data.constData());
-#else
-    return qFromBigEndian<quint32>(
-            reinterpret_cast<const uchar*>(data.constData()));
-#endif
 }
 
 inline bool parseTrack(serato_track_t* track, QIODevice* buffer) {

--- a/src/library/trackloader.cpp
+++ b/src/library/trackloader.cpp
@@ -43,18 +43,10 @@ void TrackLoader::invokeSlotLoadTrack(
             (connectionType != Qt::DirectConnection));
     QMetaObject::invokeMethod(
             this,
-#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
-            "slotLoadTrack"
-#else
             [this, trackRef = std::move(trackRef)] {
                 this->slotLoadTrack(trackRef);
-            }
-#endif
-            , connectionType
-#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
-            , Q_ARG(TrackRef, std::move(trackRef))
-#endif
-            );
+            },
+            connectionType);
 }
 
 void TrackLoader::slotLoadTrack(

--- a/src/network/networktask.cpp
+++ b/src/network/networktask.cpp
@@ -34,29 +34,17 @@ NetworkTask::~NetworkTask() {
 void NetworkTask::invokeStart(int timeoutMillis) {
     QMetaObject::invokeMethod(
             this,
-#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
-            "slotStart",
-            Qt::AutoConnection,
-            Q_ARG(int, timeoutMillis)
-#else
             [this, timeoutMillis] {
                 this->slotStart(timeoutMillis);
-            }
-#endif
-    );
+            });
 }
 
 void NetworkTask::invokeAbort() {
     QMetaObject::invokeMethod(
             this,
-#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
-            "slotAbort"
-#else
             [this] {
                 this->slotAbort();
-            }
-#endif
-    );
+            });
 }
 
 void NetworkTask::abort() {

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -288,22 +288,13 @@ void GlobalTrackCache::evictAndSaveCachedTrack(GlobalTrackCacheEntryPointer cach
     if (s_pInstance) {
         QMetaObject::invokeMethod(
                 s_pInstance,
-#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
-                "slotEvictAndSave",
-#else
                 [cacheEntryPtr = std::move(cacheEntryPtr)] {
                     s_pInstance->slotEvictAndSave(cacheEntryPtr);
                 },
-#endif
                 // Qt will choose either a direct or a queued connection
                 // depending on the thread from which this method has
                 // been invoked!
-                Qt::AutoConnection
-#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
-                ,
-                Q_ARG(GlobalTrackCacheEntryPointer, std::move(cacheEntryPtr))
-#endif
-        );
+                Qt::AutoConnection);
     } else {
         // After the singular instance has been destroyed we are
         // not able to save pending changes. The track is deleted

--- a/src/track/serato/markers2.cpp
+++ b/src/track/serato/markers2.cpp
@@ -420,12 +420,7 @@ bool SeratoMarkers2::parseCommon(
         }
 
         // Entry Size
-#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
         auto entrySize = qFromBigEndian<quint32>(data.mid(offset, 4));
-#else
-        auto entrySize = qFromBigEndian<quint32>(
-                reinterpret_cast<const uchar*>(data.mid(offset, 4).constData()));
-#endif
         offset += 4;
 
         QByteArray entryData = data.mid(offset, entrySize);

--- a/src/util/compatibility.h
+++ b/src/util/compatibility.h
@@ -25,16 +25,7 @@ inline QScreen* getPrimaryScreen() {
 
 inline
 QString uuidToStringWithoutBraces(const QUuid& uuid) {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
     return uuid.toString(QUuid::WithoutBraces);
-#else
-    QString withBraces = uuid.toString();
-    DEBUG_ASSERT(withBraces.size() == 38);
-    DEBUG_ASSERT(withBraces.startsWith('{'));
-    DEBUG_ASSERT(withBraces.endsWith('}'));
-    // We need to strip off the heading/trailing curly braces after formatting
-    return withBraces.mid(1, 36);
-#endif
 }
 
 inline

--- a/src/util/imageutils.cpp
+++ b/src/util/imageutils.cpp
@@ -17,12 +17,7 @@ ImageDigest digestImage(const QImage& image) {
     QCryptographicHash cryptoHash(kImageHashAlgorithm);
     cryptoHash.addData(
             reinterpret_cast<const char*>(image.constBits()),
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
-            image.sizeInBytes()
-#else
-            image.byteCount()
-#endif
-    );
+            image.sizeInBytes());
     return cryptoHash.result();
 }
 

--- a/src/util/taskmonitor.cpp
+++ b/src/util/taskmonitor.cpp
@@ -129,13 +129,7 @@ void TaskMonitor::abortAllTasks() {
     for (auto* pTask : toBeAbortedTasks) {
         QMetaObject::invokeMethod(
                 pTask,
-#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
-                "slotAbortTask",
-                Qt::AutoConnection
-#else
-                &Task::slotAbortTask
-#endif
-        );
+                &Task::slotAbortTask);
     }
     // Finally update the progress bar, which should have
     // finished if no new tasks have been started in the

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -1206,17 +1206,7 @@ void WOverview::paintText(const QString& text, QPainter* pPainter) {
     QFont font = pPainter->font();
     QFontMetrics fm(font);
 
-// TODO: The following use of QFontMetrics::width(const QString&, int) const
-// is deprecated and should be replaced with
-// QFontMetrics::horizontalAdvance(const QString&, int) const. However, the
-// proposed alternative has just been introduced in Qt 5.11.
-// Until the minimum required Qt version of Mixxx is increased, we need a
-// version check here.
-#if (QT_VERSION < QT_VERSION_CHECK(5, 11, 0))
-    int textWidth = fm.width(text);
-    #else
     int textWidth = fm.horizontalAdvance(text);
-    #endif
 
     if (textWidth > length()) {
         qreal pointSize = font.pointSizeF();

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -199,14 +199,12 @@ void WSearchLineEdit::setup(const QDomNode& node, const SkinContext& context) {
     DEBUG_ASSERT(backgroundColor != foregroundColor);
     pal.setBrush(backgroundRole(), backgroundColor);
     pal.setBrush(foregroundRole(), foregroundColor);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
     auto placeholderColor = foregroundColor;
     placeholderColor.setAlpha(placeholderColor.alpha() * 3 / 4); // 75% opaque
     //kLogger.debug()
     //        << "Placeholder color:"
     //        << placeholderColor;
     pal.setBrush(QPalette::PlaceholderText, placeholderColor);
-#endif
     setPalette(pal);
 
     m_clearButton->setToolTip(tr("Clear input") + "\n" +


### PR DESCRIPTION
Finally get rid of some obsolete workarounds.