### PR TITLE
Revert "library: Move color column to the left" (again)

### DIFF
--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -24,7 +24,6 @@ namespace {
 
 const QStringList DEFAULT_COLUMNS = {
         LIBRARYTABLE_ID,
-        LIBRARYTABLE_COLOR,
         LIBRARYTABLE_PLAYED,
         LIBRARYTABLE_TIMESPLAYED,
         //has to be up here otherwise Played and TimesPlayed are not shown
@@ -51,6 +50,7 @@ const QStringList DEFAULT_COLUMNS = {
         TRACKLOCATIONSTABLE_FSDELETED,
         LIBRARYTABLE_COMMENT,
         LIBRARYTABLE_MIXXXDELETED,
+        LIBRARYTABLE_COLOR,
         LIBRARYTABLE_COVERART_SOURCE,
         LIBRARYTABLE_COVERART_TYPE,
         LIBRARYTABLE_COVERART_LOCATION,


### PR DESCRIPTION
Please test if this really fixes the issues I mentioned on [Zulip](https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/Column.20selection.20and.20sorting/near/231209412)!