### PR TITLE
PredefinedColorPalettes: Add Rekordbox CDJ Hotcue Color Palette

### DIFF
--- a/src/util/color/predefinedcolorpalettes.cpp
+++ b/src/util/color/predefinedcolorpalettes.cpp
@@ -43,6 +43,24 @@ constexpr mixxx::RgbColor kRekordboxTrackColorAqua(0x16C0F8);
 constexpr mixxx::RgbColor kRekordboxTrackColorBlue(0x0150F8);
 constexpr mixxx::RgbColor kRekordboxTrackColorPurple(0x9808F8);
 
+// Rekordbox Hotcue Color Palette
+constexpr mixxx::RgbColor kRekordboxHotcueColor1(0xDE44CF);
+constexpr mixxx::RgbColor kRekordboxHotcueColor2(0xB432FF);
+constexpr mixxx::RgbColor kRekordboxHotcueColor3(0xAA42FF);
+constexpr mixxx::RgbColor kRekordboxHotcueColor4(0x6473FF);
+constexpr mixxx::RgbColor kRekordboxHotcueColor5(0x305AFF);
+constexpr mixxx::RgbColor kRekordboxHotcueColor6(0x50B4FF);
+constexpr mixxx::RgbColor kRekordboxHotcueColor7(0x00E0FF);
+constexpr mixxx::RgbColor kRekordboxHotcueColor8(0x1FA382);
+constexpr mixxx::RgbColor kRekordboxHotcueColor9(0x10B176);
+constexpr mixxx::RgbColor kRekordboxHotcueColor10(0x28E214);
+constexpr mixxx::RgbColor kRekordboxHotcueColor11(0xA5E116);
+constexpr mixxx::RgbColor kRekordboxHotcueColor12(0xB4BE04);
+constexpr mixxx::RgbColor kRekordboxHotcueColor13(0xC3AF04);
+constexpr mixxx::RgbColor kRekordboxHotcueColor14(0xE0641B);
+constexpr mixxx::RgbColor kRekordboxHotcueColor15(0xE62828);
+constexpr mixxx::RgbColor kRekordboxHotcueColor16(0xFF127B);
+
 // Traktor Track Color Palette
 constexpr mixxx::RgbColor kTraktorProTrackColorRed(0xFA4B35);
 constexpr mixxx::RgbColor kTraktorProTrackColorOrange(0xFF8402);
@@ -203,6 +221,29 @@ const ColorPalette PredefinedColorPalettes::kSeratoDJProHotcueColorPalette =
                 },
                 {0, 2, 12, 3, 6, 15, 9, 14});
 
+const ColorPalette PredefinedColorPalettes::kRekordboxCDJHotcueColorPalette =
+        ColorPalette(
+                QStringLiteral("Rekordbox CDJ Hotcue Colors"),
+                {
+                        kRekordboxHotcueColor1,
+                        kRekordboxHotcueColor2,
+                        kRekordboxHotcueColor3,
+                        kRekordboxHotcueColor4,
+                        kRekordboxHotcueColor5,
+                        kRekordboxHotcueColor6,
+                        kRekordboxHotcueColor7,
+                        kRekordboxHotcueColor8,
+                        kRekordboxHotcueColor9,
+                        kRekordboxHotcueColor10,
+                        kRekordboxHotcueColor11,
+                        kRekordboxHotcueColor12,
+                        kRekordboxHotcueColor13,
+                        kRekordboxHotcueColor14,
+                        kRekordboxHotcueColor15,
+                        kRekordboxHotcueColor16,
+                },
+                {9});
+
 const ColorPalette PredefinedColorPalettes::kMixxxTrackColorPalette =
         ColorPalette(
                 QStringLiteral("Mixxx Track Colors"),
@@ -304,6 +345,7 @@ const QList<ColorPalette> PredefinedColorPalettes::kPalettes{
         // Hotcue Color Palettes
         mixxx::PredefinedColorPalettes::kMixxxHotcueColorPalette,
         mixxx::PredefinedColorPalettes::kSeratoDJProHotcueColorPalette,
+        mixxx::PredefinedColorPalettes::kRekordboxCDJHotcueColorPalette,
         // Track Color Palettes
         mixxx::PredefinedColorPalettes::kMixxxTrackColorPalette,
         mixxx::PredefinedColorPalettes::kRekordboxTrackColorPalette,

--- a/src/util/color/predefinedcolorpalettes.h
+++ b/src/util/color/predefinedcolorpalettes.h
@@ -8,6 +8,7 @@ class PredefinedColorPalettes {
     static const ColorPalette kMixxxHotcueColorPalette;
     static const ColorPalette kSeratoTrackMetadataHotcueColorPalette;
     static const ColorPalette kSeratoDJProHotcueColorPalette;
+    static const ColorPalette kRekordboxCDJHotcueColorPalette;
 
     static const ColorPalette kMixxxTrackColorPalette;
     static const ColorPalette kRekordboxTrackColorPalette;


### PR DESCRIPTION
See https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/Rekordbox.20hotcue.20color.20palette.3F.

There are four Rekordbox Hotcue Color Palettes:

CDJ:
![rb_hotcue_CDJ](https://user-images.githubusercontent.com/1834516/112148349-10747400-8bde-11eb-9882-fc4e81cddda1.png)

COLD1:
![rb_hotcue_COLD1](https://user-images.githubusercontent.com/1834516/112148454-3437ba00-8bde-11eb-8850-c134cae8132b.png)

COLD2:
![rb_hotcue_COLD2](https://user-images.githubusercontent.com/1834516/112148473-3863d780-8bde-11eb-9fec-2716b06cd656.png)

COLORFUL:
![rb_hotcue_COLORFUL](https://user-images.githubusercontent.com/1834516/112148520-44e83000-8bde-11eb-8ef8-200cc91dc5e1.png)

This adds the first one. @Swiftb0y Feel free to take over.