### PR TITLE
Fix quantized play from the pre-roll in beatmap tracks 

### DIFF
--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -51,8 +51,7 @@ BpmControl::BpmControl(const QString& group,
         : EngineControl(group, pConfig),
           m_tapFilter(this, kBpmTapFilterLength, kBpmTapMaxInterval),
           m_dSyncInstantaneousBpm(0.0),
-          m_dLastSyncAdjustment(1.0),
-          m_dUserTweakingSync(false) {
+          m_dLastSyncAdjustment(1.0) {
     m_dSyncTargetBeatDistance.setValue(0.0);
     m_dUserOffset.setValue(0.0);
 
@@ -412,7 +411,6 @@ double BpmControl::calcSyncedRate(double userTweak) {
     if (kLogger.traceEnabled()) {
         kLogger.trace() << getGroup() << "BpmControl::calcSyncedRate, tweak " << userTweak;
     }
-    m_dUserTweakingSync = userTweak != 0.0;
     double rate = 1.0;
     // Don't know what to do if there's no bpm.
     if (m_pLocalBpm->toBool()) {
@@ -449,7 +447,7 @@ double BpmControl::calcSyncedRate(double userTweak) {
     }
 
     // Now we have all we need to calculate the sync adjustment if any.
-    double adjustment = calcSyncAdjustment(m_dUserTweakingSync);
+    double adjustment = calcSyncAdjustment(userTweak != 0.0);
     return (rate + userTweak) * adjustment;
 }
 

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -39,6 +39,11 @@ constexpr int kBpmTapFilterLength = 5;
 // the actual number of beats is this x2.
 constexpr int kLocalBpmSpan = 4;
 constexpr SINT kSamplesPerFrame = 2;
+
+// If we are 1 / 8.0 beat fraction near the previous beat we match that instead
+// of the next beat.
+constexpr double kPastBeatMatchThreshold = 1 / 8.0;
+
 } // namespace
 
 BpmControl::BpmControl(const QString& group,
@@ -898,7 +903,7 @@ double BpmControl::getBeatMatchPosition(
     // We prefer the next because this is what will be played,
     // unless we are close to the previous.
     // This happens if the user presses play too late.
-    if (dOtherBeatFraction > 7 / 8.0) {
+    if (dOtherBeatFraction > 1.0 - kPastBeatMatchThreshold) {
         // match the past beat
         dOtherBeatFraction -= 1.0;
     }

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -874,9 +874,6 @@ double BpmControl::getBeatMatchPosition(
             thisSecs2ToNextBeat * otherBeats->getSampleRate() * pOtherEngineBuffer->getRateRatio() +
             dOtherPosition;
 
-    qDebug() << "dOtherPositionOfThisNextBeat" << dOtherPositionOfThisNextBeat
-             << thisSecs2ToNextBeat;
-
     double dOtherPrevBeat = -1;
     double dOtherNextBeat = -1;
     double dOtherBeatLength = -1;
@@ -896,8 +893,6 @@ double BpmControl::getBeatMatchPosition(
         return dThisPosition;
     }
 
-    qDebug() << "other" << dOtherBeatFraction << dOtherPosition;
-
     // We can either match the past beat with dOtherBeatFraction 1.0
     // or the next beat with dOtherBeatFraction 0.0
     // We prefer the next because this is what will be played,
@@ -912,8 +907,6 @@ double BpmControl::getBeatMatchPosition(
             dOtherBeatLength / otherBeats->getSampleRate() / pOtherEngineBuffer->getRateRatio();
     // Transform for this track
     double seekMatch = otherDivSec2 * dThisSampleRate * dThisRateRatio;
-
-    qDebug() << seekMatch << m_dUserOffset.getValue() << dOtherBeatFraction;
 
     if (dThisBeatLength > 0) {
         // restore phase adjustment
@@ -969,9 +962,6 @@ double BpmControl::getBeatMatchPosition(
             // loops are catching
         }
     }
-
-    qDebug() << "dNewPlaypos" << dNewPlaypos << dThisPosition;
-
     return dNewPlaypos;
 }
 

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -161,7 +161,6 @@ class BpmControl : public EngineControl {
     // used in the engine thread only
     double m_dSyncInstantaneousBpm;
     double m_dLastSyncAdjustment;
-    bool m_dUserTweakingSync;
 
     // m_pBeats is written from an engine worker thread
     mixxx::BeatsPointer m_pBeats;

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -2213,9 +2213,10 @@ TEST_F(EngineSyncTest, QuantizeImpliesSyncPhase) {
     EXPECT_DOUBLE_EQ(100, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
 
     // we align here to the past beat, because beat_distance < 1.0/8
-    EXPECT_DOUBLE_EQ(
+    EXPECT_NEAR(
             ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")) / 130 * 100,
-            ControlObject::get(ConfigKey(m_sGroup2, "beat_distance")));
+            ControlObject::get(ConfigKey(m_sGroup2, "beat_distance")),
+            1e-15);
 }
 
 TEST_F(EngineSyncTest, SeekStayInPhase) {
@@ -2234,7 +2235,8 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
     ProcessBuffer();
 
     // We expect to be two buffers ahead in a beat near 0.2
-    EXPECT_DOUBLE_EQ(0.050309901738473183, ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")));
+    EXPECT_DOUBLE_EQ(0.050309901738473162,
+            ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")));
     EXPECT_DOUBLE_EQ(0.18925937554508981, ControlObject::get(ConfigKey(m_sGroup1, "playposition")));
 
     // The same again with a stopped track loaded in Channel 2
@@ -2257,7 +2259,7 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
     ProcessBuffer();
 
     // We expect to be two buffers ahead in a beat near 0.2
-    EXPECT_DOUBLE_EQ(0.050309901738473183,
+    EXPECT_DOUBLE_EQ(0.050309901738473162,
             ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")));
     EXPECT_DOUBLE_EQ(0.18925937554508981, ControlObject::get(ConfigKey(m_sGroup1, "playposition")));
 }
@@ -2323,9 +2325,12 @@ TEST_F(EngineSyncTest, QuantizeHotCueActivate) {
     pHotCue2Activate->set(1.0);
     ProcessBuffer();
 
+    // Beat_distance is the distance to the previous beat wich has already passed.
+    // We compare here the distance to the next beat (1 - beat_distance) and
+    // scale it by the different tempos.
     EXPECT_NEAR(
-            ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")) / 130 * 100,
-            ControlObject::get(ConfigKey(m_sGroup2, "beat_distance")),
+            (1 - ControlObject::get(ConfigKey(m_sGroup1, "beat_distance"))) / 130 * 100,
+            (1 - ControlObject::get(ConfigKey(m_sGroup2, "beat_distance"))),
             1e-15);
 
     pHotCue2Activate->set(0.0);
@@ -2440,8 +2445,12 @@ TEST_F(EngineSyncTest, BeatMapQantizePlay) {
 
     ProcessBuffer();
 
-    EXPECT_DOUBLE_EQ(m_pChannel1->getEngineBuffer()->m_pSyncControl->getBeatDistance(),
-            m_pChannel2->getEngineBuffer()->m_pSyncControl->getBeatDistance());
+    // Beat Distance shall be still 0, because we are before the first beat.
+    // This was fixed in https://bugs.launchpad.net/mixxx/+bug/1920084
+    EXPECT_DOUBLE_EQ(m_pChannel2->getEngineBuffer()->m_pSyncControl->getBeatDistance(), 0);
+    EXPECT_DOUBLE_EQ(
+            ControlObject::get(ConfigKey(m_sGroup1, "playposition")),
+            ControlObject::get(ConfigKey(m_sGroup2, "playposition")));
 }
 
 TEST_F(EngineSyncTest, BpmAdjustFactor) {


### PR DESCRIPTION
This fixes https://bugs.launchpad.net/mixxx/+bug/1920084

It also fixes a bug that the user offset during sync was applied to the wrong deck.
And that quantize play syncs sometimes to the last beat rather than the next.

Tests are in place.   
