### PR TITLE
Fix double jump when changing internal clock bpm 

### DIFF
--- a/src/engine/sync/internalclock.cpp
+++ b/src/engine/sync/internalclock.cpp
@@ -138,7 +138,7 @@ void InternalClock::setMasterParams(double beatDistance, double baseBpm, double 
     if (kLogger.traceEnabled()) {
         kLogger.trace() << "InternalClock::setMasterParams" << beatDistance << baseBpm << bpm;
     }
-    if (bpm == 0) {
+    if (bpm <= 0.0 || baseBpm <= 0.0) {
         return;
     }
     m_dBaseBpm = baseBpm;
@@ -147,7 +147,6 @@ void InternalClock::setMasterParams(double beatDistance, double baseBpm, double 
 }
 
 void InternalClock::slotBpmChanged(double bpm) {
-    m_dBaseBpm = bpm;
     updateBeatLength(m_iOldSampleRate, bpm);
     if (!isSynchronized()) {
         return;

--- a/src/engine/sync/internalclock.cpp
+++ b/src/engine/sync/internalclock.cpp
@@ -78,6 +78,9 @@ void InternalClock::slotSyncMasterEnabledChangeRequest(double state) {
             m_mode = SYNC_MASTER_EXPLICIT;
             return;
         }
+        if (mode == SYNC_NONE) {
+            m_dBaseBpm = m_dOldBpm;
+        }
         m_pEngineSync->requestSyncMode(this, SYNC_MASTER_EXPLICIT);
     } else {
         // Turning off master goes back to follower mode.

--- a/src/engine/sync/internalclock.h
+++ b/src/engine/sync/internalclock.h
@@ -73,6 +73,10 @@ class InternalClock : public QObject, public Clock, public Syncable {
 
     int m_iOldSampleRate;
     double m_dOldBpm;
+
+    // This is the BPM value at unity adopted when sync is enabled.
+    // It is used to relate the followers and must not change when
+    // the bpm is adjusted to avoid sudden double/half rate changes.
     double m_dBaseBpm;
 
     // The internal clock rate is stored in terms of samples per beat.

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -337,10 +337,11 @@ TEST_F(EngineSyncTest, InternalMasterSetFollowerSliderMoves) {
     // If internal is master, and we turn on a follower, the slider should move.
     auto pButtonMasterSyncInternal = std::make_unique<ControlProxy>(
             m_sInternalClockGroup, "sync_master");
-    pButtonMasterSyncInternal->slotSet(1);
     auto pMasterSyncSlider =
             std::make_unique<ControlProxy>(m_sInternalClockGroup, "bpm");
+
     pMasterSyncSlider->set(100.0);
+    pButtonMasterSyncInternal->slotSet(1);
 
     // Set the file bpm of channel 1 to 80 bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1->getSampleRate(), 80, 0.0);


### PR DESCRIPTION
This is an issue that only happens if the internal BPM or is exposed. Than the follower may change the double/halve sync settings resulting in a big rate jump.  

The baseBpm is the bpm at unity and must not be changed during sync is enabled. 