### PR TITLE
Intro/Outro: Add APIs for detecting if we're in intro/outro

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -1990,6 +1990,24 @@ bool CueControl::isTrackAtIntroCue() {
             1.0f);
 }
 
+bool CueControl::inIntro() const {
+    if (!m_pIntroStartEnabled->toBool() || !m_pIntroEndEnabled->toBool()) {
+        return false;
+    }
+
+    const double pos = getSampleOfTrack().current;
+    return (pos >= m_pIntroStartPosition->get() && pos <= m_pIntroEndPosition->get());
+}
+
+bool CueControl::inOutro() const {
+    if (!m_pOutroStartEnabled->toBool() || !m_pOutroEndEnabled->toBool()) {
+        return false;
+    }
+
+    const double pos = getSampleOfTrack().current;
+    return (pos >= m_pOutroStartPosition->get() && pos <= m_pOutroEndPosition->get());
+}
+
 SeekOnLoadMode CueControl::getSeekOnLoadPreference() {
     int configValue =
             getConfig()->getValue(ConfigKey("[Controls]", "CueRecall"),

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -195,7 +195,16 @@ class CueControl : public EngineControl {
     void hintReader(HintVector* pHintList) override;
     bool updateIndicatorsAndModifyPlay(bool newPlay, bool oldPlay, bool playPossible);
     void updateIndicators();
+
     bool isTrackAtIntroCue();
+    /// Returns true if the current position is inside the intro.
+    /// Returns false if not, or if the intro is not enabled.
+    bool inIntro() const;
+
+    /// Returns true if the current position is inside the outro.
+    /// Returns false if not, or if the outro is not enabled.
+    bool inOutro() const;
+
     void resetIndicators();
     bool isPlayingByPlayButton();
     bool getPlayFlashingAtPause();

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -384,6 +384,14 @@ void EngineBuffer::setEngineMaster(EngineMaster* pEngineMaster) {
     }
 }
 
+bool EngineBuffer::inIntro() const {
+    return m_pCueControl->inIntro();
+}
+
+bool EngineBuffer::inOutro() const {
+    return m_pCueControl->inOutro();
+}
+
 void EngineBuffer::queueNewPlaypos(double newpos, enum SeekRequest seekType) {
     // All seeks need to be done in the Engine thread so queue it up.
     // Write the position before the seek type, to reduce a possible race

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -108,6 +108,9 @@ class EngineBuffer : public EngineObject {
     // Sets pointer to other engine buffer/channel
     void setEngineMaster(EngineMaster*);
 
+    bool inIntro() const;
+    bool inOutro() const;
+
     // Queues a new seek position. Use SEEK_EXACT or SEEK_STANDARD as seekType
     void queueNewPlaypos(double newpos, enum SeekRequest seekType);
     void requestSyncPhase();


### PR DESCRIPTION
This can be used by Sync Lock to inform Implicit Leader.

(synccontrol gets updates per-buffer on play position, and it can figure out when it has crossed an intro/outro border, and notify the sync engine when that happens)