### PR TITLE
Read device names as Uft8.

### DIFF
--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -113,7 +113,7 @@ SoundDevicePortAudio::SoundDevicePortAudio(UserSettingsPointer config,
         m_deviceId.name = deviceInfo->name;
     }
     m_deviceId.portAudioIndex = devIndex;
-    m_strDisplayName = QString::fromLocal8Bit(deviceInfo->name);
+    m_strDisplayName = QString::fromUtf8(deviceInfo->name);
     m_iNumInputChannels = m_deviceInfo->maxInputChannels;
     m_iNumOutputChannels = m_deviceInfo->maxOutputChannels;
 


### PR DESCRIPTION
This is a API change in Portaudio 19.7 introduced in https://github.com/PortAudio/portaudio/pull/391.
Since we use patched Portaudio 19.6 including this PR, we can't add a version guard.

Fixing https://bugs.launchpad.net/mixxx/+bug/1923215