### PR TITLE
CI: Disable fatal debug assertions for 2.3 beta

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,6 @@ jobs:
               -DWAVPACK=ON
               -DINSTALL_USER_UDEV_RULES=OFF
             cmake_generator: Unix Makefiles
-            cmake_build_type: RelWithDebInfo
             ctest_args:
             compiler_cache: ccache
             compiler_cache_path: ~/.ccache
@@ -45,7 +44,6 @@ jobs:
               -DWAVPACK=ON
               -DINSTALL_USER_UDEV_RULES=OFF
             cmake_generator: Unix Makefiles
-            cmake_build_type: RelWithDebInfo
             ctest_args:
             compiler_cache: ccache
             compiler_cache_path: ~/.ccache
@@ -65,7 +63,6 @@ jobs:
               -DMODPLUG=OFF
               -DWAVPACK=OFF
             cmake_generator: Unix Makefiles
-            cmake_build_type: RelWithDebInfo
             # TODO: Fix this broken test on macOS
             ctest_args: --exclude-regex DirectoryDAOTest.relocateDirectory
             cpack_generator: DragNDrop
@@ -95,7 +92,6 @@ jobs:
             cc: cl
             cxx: cl
             cmake_generator: Ninja
-            cmake_build_type: RelWithDebInfo
             # TODO: Fix these broken tests on Windows
             ctest_args: --exclude-regex '^AutoDJProcessorTest.*$'
             cpack_generator: WIX
@@ -232,7 +228,7 @@ jobs:
       run: >-
         cmake
         -G "${{ matrix.cmake_generator }}"
-        -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }}
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo
         -DCMAKE_PREFIX_PATH="${{ env.CMAKE_PREFIX_PATH }}"
         -DDEBUG_ASSERTIONS_FATAL=ON
         -DQt5_DIR=${{ env.QT_PATH }} ${{ matrix.cmake_args }} ${{ env.CMAKE_ARGS_EXTRA }}
@@ -261,7 +257,7 @@ jobs:
       uses: ammaraskar/msvc-problem-matcher@master
 
     - name: "Build"
-      run: cmake --build . --config ${{ matrix.cmake_build_type }}
+      run: cmake --build . --config RelWithDebInfo
       working-directory: build
       env:
         CC: ${{ matrix.cc }}
@@ -286,7 +282,7 @@ jobs:
         CTEST_OUTPUT_ON_FAILURE: 1
 
     - name: Benchmark
-      run: cmake --build . --target mixxx-benchmark --config ${{ matrix.cmake_build_type }}
+      run: cmake --build . --target mixxx-benchmark --config RelWithDebInfo
       working-directory: build
       env:
         # Render analyzer waveform tests to an offscreen buffer

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,7 +230,7 @@ jobs:
         -G "${{ matrix.cmake_generator }}"
         -DCMAKE_BUILD_TYPE=RelWithDebInfo
         -DCMAKE_PREFIX_PATH="${{ env.CMAKE_PREFIX_PATH }}"
-        -DDEBUG_ASSERTIONS_FATAL=ON
+        -DDEBUG_ASSERTIONS_FATAL=OFF
         -DQt5_DIR=${{ env.QT_PATH }} ${{ matrix.cmake_args }} ${{ env.CMAKE_ARGS_EXTRA }}
         -DBATTERY=ON
         -DBROADCAST=ON


### PR DESCRIPTION
Prerequisite for the 2.3 release. More fixes will follow in separate PRs. 