### PR TITLE
Fix sound device load from preferences 

### DIFF
--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -125,6 +125,9 @@ bool SoundManagerConfig::readFromDisk() {
             }
         }
 
+        QDomNodeList outElements(devElement.elementsByTagName(xmlElementOutput));
+        QDomNodeList inElements(devElement.elementsByTagName(xmlElementInput));
+
         if (devicesMatchingByName == 0) {
             continue;
         } else if (devicesMatchingByName == 1) {
@@ -157,13 +160,25 @@ bool SoundManagerConfig::readFromDisk() {
                     if (hardwareDeviceId.name == deviceIdFromFile.name
                             && hardwareDeviceId.alsaHwDevice == deviceIdFromFile.alsaHwDevice) {
                         deviceIdFromFile.portAudioIndex = hardwareDeviceId.portAudioIndex;
+                        break;
+                    }
+                }
+            } else {
+                // Check if the one of the matching devices has the configured in and output channels
+                for (const auto& soundDevice : soundDevices) {
+                    SoundDeviceId hardwareDeviceId = soundDevice->getDeviceId();
+                    if (hardwareDeviceId.name == deviceIdFromFile.name &&
+                            soundDevice->getNumOutputChannels() >=
+                                    outElements.count() &&
+                            soundDevice->getNumInputChannels() >=
+                                    inElements.count()) {
+                        deviceIdFromFile.portAudioIndex = hardwareDeviceId.portAudioIndex;
+                        break;
                     }
                 }
             }
         }
 
-        QDomNodeList outElements(devElement.elementsByTagName(xmlElementOutput));
-        QDomNodeList inElements(devElement.elementsByTagName(xmlElementInput));
         for (int j = 0; j < outElements.count(); ++j) {
             QDomElement outElement(outElements.at(j).toElement());
             if (outElement.isNull()) {


### PR DESCRIPTION
In case of duplicate Device names, it is checked if it is a sound sink or source device, to pick the right configured one. 
This is necessary for APIs that split hardware devices in its sink and source part like pulse audio. 