### PR TITLE
Shade: Fix invalid "alignment" property for LibraryBPMButton

### DIFF
--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -516,7 +516,6 @@ WTrackTableView {
     WLibrary QCheckBox {
       text-align: right;
       alignment: right;
-      qproperty-alignment: 'AlignRight';
     }
 
   #LibraryBPMSpinBox {


### PR DESCRIPTION
Fixes the following command-line warnings:

    Warning [Main]: QCheckBox(0x560803109c10, name="LibraryBPMButton")  does not have a property named  "alignment"
    [...]
    Warning [Main]: QCheckBox(0x560806004220, name="LibraryBPMButton")  does not have a property named  "alignment"