### PR TITLE
CMake fix passing multiple paths to libdjinterop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1722,6 +1722,11 @@ if(ENGINEPRIME)
     set(DJINTEROP_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/lib/libdjinterop-install")
     set(DJINTEROP_LIBRARY "lib/${CMAKE_STATIC_LIBRARY_PREFIX}djinterop${CMAKE_STATIC_LIBRARY_SUFFIX}")
     file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/download")
+
+    # CMake does not pass lists of paths properly to external projects.
+    # This is worked around by changing the list separator.
+    string(REPLACE ";" "|" PIPE_DELIMITED_CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH}")
+
     # External project sources must be downloaded as an archive into DOWNLOAD_DIR
     # from an URL to keep offline builds like for Fedora/RPM Fusion working!
     ExternalProject_Add(libdjinterop
@@ -1729,12 +1734,13 @@ if(ENGINEPRIME)
       URL_HASH SHA256=87b3e6c726c208333d55b7e7e3af0a7230c9ad9edb3ca0ca81feffe17b3fc008
       DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/download/libdjinterop"
       INSTALL_DIR ${DJINTEROP_INSTALL_DIR}
+      LIST_SEPARATOR "|"
       CMAKE_ARGS
         -DBUILD_SHARED_LIBS=OFF
         -DCMAKE_SKIP_INSTALL_ALL_DEPENDENCY=ON
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
-        -DCMAKE_PREFIX_PATH:PATH=${CMAKE_PREFIX_PATH}
+        -DCMAKE_PREFIX_PATH=${PIPE_DELIMITED_CMAKE_PREFIX_PATH}
         -DCMAKE_INSTALL_LIBDIR:PATH=lib
         -DCMAKE_MODULE_PATH:PATH=${CMAKE_MODULE_PATH}
         -DSYSTEM_SQLITE=${DJINTEROP_SYSTEM_SQLITE}


### PR DESCRIPTION
CMake does not appear to pass lists of paths correctly to external projects when invoking similarly to the below, affecting builds involving libdjinterop with sources fetched from GitHub:

```
ExternalProject_Add( ...
  -DCMAKE_PREFIX_PATH:PATH={CMAKE_PREFIX_PATH}
  ...)
```

The above causes path separators to be replaced with whitespace.  This breaks the Windows build when run from Visual Studio, where the path contains multiple elements as follows:

* C:\<path-to-buildenv>\mixxx-dependencies-2.3-x64-windows-3d70970e752542db9901e4aa2656f215699dc102
* C:\<path-to-buildenv>\mixxx-dependencies-2.3-x64-windows-3d70970e752542db9901e4aa2656f215699dc102\installed\x64-windows
* C:\<path-to-buildenv>\mixxx-dependencies-2.3-x64-windows-3d70970e752542db9901e4aa2656f215699dc102\installed\x64-windows\debug

When these paths are set in `CMAKE_PREFIX_PATH` with semicolon delimiter, it is transformed to whitespace upon invoking the external project, meaning only the first path gets searched.  Because the dependencies of libdjinterop can only be found in the second/third paths, this leads to a missing dependency error when trying to build libdjinterop.

A workaround (inspired by [this SO post](https://stackoverflow.com/questions/45414507/pass-a-list-of-prefix-paths-to-externalproject-add-in-cmake-args)) is to delimit the paths with something other than semicolon, which is what this PR does.