### PR TITLE
Fix typo in makeConstBpm() and improve BPM precison for long tracks

### DIFF
--- a/src/track/beatfactory.cpp
+++ b/src/track/beatfactory.cpp
@@ -84,8 +84,16 @@ mixxx::BeatsPointer BeatFactory::makePreferredBeats(
     const QString version = getPreferredVersion(fixedTempo);
     const QString subVersion = getPreferredSubVersion(extraVersionInfo);
 
+    //for (double beat : beats) {
+    //	qDebug().noquote() << QString::number(beat,'g',8);
+    //}
+
     QVector<BeatUtils::ConstRegion> constantRegions =
             BeatUtils::retrieveConstRegions(beats, sampleRate);
+
+    //for (auto& region : constantRegions) {
+    //	qDebug().noquote() << QString::number(region.firstBeat,'g',8) << QString::number(region.beatLength,'g',8);
+    //}
 
     if (version == BEAT_GRID_2_VERSION) {
         double firstBeat = 0;

--- a/src/track/beatfactory.cpp
+++ b/src/track/beatfactory.cpp
@@ -84,16 +84,21 @@ mixxx::BeatsPointer BeatFactory::makePreferredBeats(
     const QString version = getPreferredVersion(fixedTempo);
     const QString subVersion = getPreferredSubVersion(extraVersionInfo);
 
-    //for (double beat : beats) {
-    //	qDebug().noquote() << QString::number(beat,'g',8);
-    //}
+#ifdef DEBUG_PRINT_BEATS
+    for (double beat : beats) {
+        qDebug().noquote() << QString::number(beat, 'g', 8);
+    }
+#endif
 
     QVector<BeatUtils::ConstRegion> constantRegions =
             BeatUtils::retrieveConstRegions(beats, sampleRate);
 
-    //for (auto& region : constantRegions) {
-    //	qDebug().noquote() << QString::number(region.firstBeat,'g',8) << QString::number(region.beatLength,'g',8);
-    //}
+#ifdef DEBUG_PRINT_BEATS
+    for (auto& region : constantRegions) {
+        qDebug().noquote() << QString::number(region.firstBeat, 'g', 8)
+                           << QString::number(region.beatLength, 'g', 8);
+    }
+#endif
 
     if (version == BEAT_GRID_2_VERSION) {
         double firstBeat = 0;

--- a/src/track/beatfactory.cpp
+++ b/src/track/beatfactory.cpp
@@ -8,7 +8,7 @@
 
 namespace {
 
-const QString kRoundingVersion = QStringLiteral("V2");
+const QString kRoundingVersion = QStringLiteral("V3");
 
 } // namespace
 

--- a/src/track/beatutils.cpp
+++ b/src/track/beatutils.cpp
@@ -183,8 +183,6 @@ double BeatUtils::makeConstBpm(
 
     int startRegion = midRegion;
 
-    qDebug() << "longestRegionBeatLenth" << longestRegionBeatLenth;
-
     // Find a region at the beginning of the track with a similar tempo and phase
     for (int i = 0; i < midRegion; ++i) {
         const double length = constantRegions[i + 1].firstBeat - constantRegions[i].firstBeat;
@@ -229,7 +227,6 @@ double BeatUtils::makeConstBpm(
                 longestRegionMaxRoundSamples = longestRegionBeatLenth +
                         ((kMaxSecsPhaseError * sampleRate) / longestRegionNumberOfBeats);
                 startRegion = i;
-                // qDebug() << "start region" << i;
                 break;
             }
         }
@@ -271,7 +268,6 @@ double BeatUtils::makeConstBpm(
                 longestRegionLength = newLength;
                 longestRegionBeatLenth = newBeatLength;
                 longestRegionNumberOfBeats = numberOfBeats;
-                //qDebug() << "end region" << i;
                 break;
             }
         }

--- a/src/track/beatutils.cpp
+++ b/src/track/beatutils.cpp
@@ -187,7 +187,6 @@ double BeatUtils::makeConstBpm(
     for (int i = 0; i < midRegion; ++i) {
         const double length = constantRegions[i + 1].firstBeat - constantRegions[i].firstBeat;
         const int numberOfBeats = static_cast<int>((length / constantRegions[i].beatLength) + 0.5);
-        qDebug() << i << numberOfBeats << constantRegions[i].firstBeat;
         if (numberOfBeats < kMinRegionBeatCount) {
             // Request short regions, too unstable.
             continue;

--- a/src/track/beatutils.cpp
+++ b/src/track/beatutils.cpp
@@ -231,8 +231,8 @@ double BeatUtils::makeConstBpm(
                 ((kMaxSecsPhaseError * sampleRate) / numberOfBeats);
         const double maxRoundSamples = constantRegions[i].beatLength +
                 ((kMaxSecsPhaseError * sampleRate) / numberOfBeats);
-        if (longestRegionLength > minRoundSamples &&
-                longestRegionLength < maxRoundSamples) {
+        if (longestRegionBeatLenth > minRoundSamples &&
+                longestRegionBeatLenth < maxRoundSamples) {
             // Now check if both regions are at the same phase.
             const double newLength = constantRegions[i + 1].firstBeat -
                     constantRegions[startRegion].firstBeat;

--- a/src/track/beatutils.cpp
+++ b/src/track/beatutils.cpp
@@ -158,12 +158,12 @@ double BeatUtils::makeConstBpm(
     // At least this region will be have finally correct annotated beats.
     int midRegion = 0;
     double longestRegionLength = 0;
-    double longestRegionBeatLenth = 0;
+    double longestRegionBeatLength = 0;
     for (int i = 0; i < constantRegions.size() - 1; ++i) {
         double length = constantRegions[i + 1].firstBeat - constantRegions[i].firstBeat;
         if (length > longestRegionLength) {
             longestRegionLength = length;
-            longestRegionBeatLenth = constantRegions[i].beatLength;
+            longestRegionBeatLength = constantRegions[i].beatLength;
             midRegion = i;
         }
         //qDebug() << i << length << constantRegions[i].beatLength;
@@ -175,10 +175,10 @@ double BeatUtils::makeConstBpm(
     }
 
     int longestRegionNumberOfBeats = static_cast<int>(
-            (longestRegionLength / longestRegionBeatLenth) + 0.5);
-    double longestRegionMinRoundSamples = longestRegionBeatLenth -
+            (longestRegionLength / longestRegionBeatLength) + 0.5);
+    double longestRegionMinRoundSamples = longestRegionBeatLength -
             ((kMaxSecsPhaseError * sampleRate) / longestRegionNumberOfBeats);
-    double longestRegionMaxRoundSamples = longestRegionBeatLenth +
+    double longestRegionMaxRoundSamples = longestRegionBeatLength +
             ((kMaxSecsPhaseError * sampleRate) / longestRegionNumberOfBeats);
 
     int startRegion = midRegion;
@@ -196,8 +196,8 @@ double BeatUtils::makeConstBpm(
         const double maxRoundSamples = constantRegions[i].beatLength +
                 ((kMaxSecsPhaseError * sampleRate) / numberOfBeats);
         // check if the tempo of the longest region is part of the rounding range of this region
-        if (longestRegionBeatLenth > minRoundSamples &&
-                longestRegionBeatLenth < maxRoundSamples) {
+        if (longestRegionBeatLength > minRoundSamples &&
+                longestRegionBeatLength < maxRoundSamples) {
             // Now check if both regions are at the same phase.
             const double newLength = constantRegions[midRegion + 1].firstBeat -
                     constantRegions[i].firstBeat;
@@ -219,11 +219,11 @@ double BeatUtils::makeConstBpm(
             if (newBeatLength > longestRegionMinRoundSamples &&
                     newBeatLength < longestRegionMaxRoundSamples) {
                 longestRegionLength = newLength;
-                longestRegionBeatLenth = newBeatLength;
+                longestRegionBeatLength = newBeatLength;
                 longestRegionNumberOfBeats = numberOfBeats;
-                longestRegionMinRoundSamples = longestRegionBeatLenth -
+                longestRegionMinRoundSamples = longestRegionBeatLength -
                         ((kMaxSecsPhaseError * sampleRate) / longestRegionNumberOfBeats);
-                longestRegionMaxRoundSamples = longestRegionBeatLenth +
+                longestRegionMaxRoundSamples = longestRegionBeatLength +
                         ((kMaxSecsPhaseError * sampleRate) / longestRegionNumberOfBeats);
                 startRegion = i;
                 break;
@@ -242,8 +242,8 @@ double BeatUtils::makeConstBpm(
                 ((kMaxSecsPhaseError * sampleRate) / numberOfBeats);
         const double maxRoundSamples = constantRegions[i].beatLength +
                 ((kMaxSecsPhaseError * sampleRate) / numberOfBeats);
-        if (longestRegionBeatLenth > minRoundSamples &&
-                longestRegionBeatLenth < maxRoundSamples) {
+        if (longestRegionBeatLength > minRoundSamples &&
+                longestRegionBeatLength < maxRoundSamples) {
             // Now check if both regions are at the same phase.
             const double newLength = constantRegions[i + 1].firstBeat -
                     constantRegions[startRegion].firstBeat;
@@ -265,16 +265,16 @@ double BeatUtils::makeConstBpm(
             if (newBeatLength > longestRegionMinRoundSamples &&
                     newBeatLength < longestRegionMaxRoundSamples) {
                 longestRegionLength = newLength;
-                longestRegionBeatLenth = newBeatLength;
+                longestRegionBeatLength = newBeatLength;
                 longestRegionNumberOfBeats = numberOfBeats;
                 break;
             }
         }
     }
 
-    longestRegionMinRoundSamples = longestRegionBeatLenth -
+    longestRegionMinRoundSamples = longestRegionBeatLength -
             ((kMaxSecsPhaseError * sampleRate) / longestRegionNumberOfBeats);
-    longestRegionMaxRoundSamples = longestRegionBeatLenth +
+    longestRegionMaxRoundSamples = longestRegionBeatLength +
             ((kMaxSecsPhaseError * sampleRate) / longestRegionNumberOfBeats);
 
     // qDebug() << startRegion << midRegion << constantRegions.size()
@@ -287,7 +287,7 @@ double BeatUtils::makeConstBpm(
 
     const double minRoundBpm = 60 * sampleRate / longestRegionMaxRoundSamples;
     const double maxRoundBpm = 60 * sampleRate / longestRegionMinRoundSamples;
-    const double centerBpm = 60 * sampleRate / longestRegionBeatLenth;
+    const double centerBpm = 60 * sampleRate / longestRegionBeatLength;
 
     //qDebug() << "minRoundBpm" << minRoundBpm;
     //qDebug() << "maxRoundBpm" << maxRoundBpm;

--- a/src/track/beatutils.cpp
+++ b/src/track/beatutils.cpp
@@ -207,9 +207,9 @@ double BeatUtils::makeConstBpm(
             double maxBeatLength = math_min(longestRegionMaxRoundSamples, maxRoundSamples);
 
             const int maxNumberOfBeats =
-                    static_cast<int>((newLength / minBeatLength) + 0.5);
+                    static_cast<int>(round(newLength / minBeatLength));
             const int minNumberOfBeats =
-                    static_cast<int>((newLength / maxBeatLength) + 0.5);
+                    static_cast<int>(round(newLength / maxBeatLength));
 
             if (minNumberOfBeats != maxNumberOfBeats) {
                 // Ambiguous number of beats, find a closer region.
@@ -253,9 +253,9 @@ double BeatUtils::makeConstBpm(
             double maxBeatLength = math_min(longestRegionMaxRoundSamples, maxRoundSamples);
 
             const int maxNumberOfBeats =
-                    static_cast<int>((newLength / minBeatLength) + 0.5);
+                    static_cast<int>(round(newLength / minBeatLength));
             const int minNumberOfBeats =
-                    static_cast<int>((newLength / maxBeatLength) + 0.5);
+                    static_cast<int>(round(newLength / maxBeatLength));
 
             if (minNumberOfBeats != maxNumberOfBeats) {
                 // Ambiguous number of beats, find a closer region.


### PR DESCRIPTION
This fixes two issues in makeConstBpm()

An a obvious typo slipped through my original tests. 

Now the https://sanatonrecords.bandcamp.com/track/procs-frigolitpuffens-magiska-trampdyna is detected correctly as 139,98 BPM instead of rounding to 140,00 BPM. 
This track is a good example why too aggressive rounding is not always a good solution.   

And an issues with long tracks where the number of beats is ambiguous. 
Like: 
https://sanatonrecords.bandcamp.com/track/already-maged-circle-dance-of-cold-constellations 

Now we continue searching until a single number of beats is returned for the whole possible BPM range. 