### PR TITLE
Update to djinterop 0.15.2 to fix cmaj key bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1730,8 +1730,8 @@ if(ENGINEPRIME)
     # External project sources must be downloaded as an archive into DOWNLOAD_DIR
     # from an URL to keep offline builds like for Fedora/RPM Fusion working!
     ExternalProject_Add(libdjinterop
-      URL "https://github.com/xsco/libdjinterop/archive/0.15.1.tar.gz"
-      URL_HASH SHA256=87b3e6c726c208333d55b7e7e3af0a7230c9ad9edb3ca0ca81feffe17b3fc008
+      URL "https://github.com/xsco/libdjinterop/archive/0.15.2.tar.gz"
+      URL_HASH SHA256=66f64c0b38a53936ba1b471524905e35afd605bc05d29e7aa6fa7ea0005c7d54
       DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/download/libdjinterop"
       INSTALL_DIR ${DJINTEROP_INSTALL_DIR}
       LIST_SEPARATOR "|"


### PR DESCRIPTION
Version 0.15.2 of libdjinterop fixes a bug whereby tracks in the key of C Major would be exported to Engine format with the wrong enum ordinal (24 instead of 0).  This resulted in Denon hardware players inconsistently displaying or not displaying the key of CMaj tracks during playback.  With the bug-fix, CMaj tracks are shown properly.

Upstream PR for reference: https://github.com/xsco/libdjinterop/pull/57/files