### PR TITLE
Enable ENGINEPRIME feature on Debian builds

### DIFF
--- a/packaging/debian/control.in
+++ b/packaging/debian/control.in
@@ -55,6 +55,8 @@ Build-Depends: debhelper (>= 11),
                libmodplug-dev,
                libmp3lame-dev,
                libebur128-dev,
+# Note: libdjinterop is available within the Mixxx PPA
+               libdjinterop-dev,
 # for running mixxx-test
                xvfb
 Rules-Requires-Root: no

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -4,7 +4,7 @@
 
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DCMAKE_BUILD_TYPE=RelWithDebInfo -DINSTALL_USER_UDEV_RULES=OFF -DKEYFINDER=OFF -DENGINEPRIME=OFF
+	dh_auto_configure -- -DCMAKE_BUILD_TYPE=RelWithDebInfo -DINSTALL_USER_UDEV_RULES=OFF -DKEYFINDER=OFF
 
 override_dh_installudev:
 	dh_installudev --name=mixxx-usb-uaccess --priority 69


### PR DESCRIPTION
This PR enables the `ENGINEPRIME` feature in Debian builds, using the `libdjinterop-dev` development package.

The libdjinterop library is now available in the Mixxx PPA: https://launchpad.net/~mixxx/+archive/ubuntu/nightlies/+packages - provided this is available during the Debian packaging build phase, it can be built.

