### PR TITLE
Turn a non const reference into a pointer.

### DIFF
--- a/src/effects/builtin/autopaneffect.cpp
+++ b/src/effects/builtin/autopaneffect.cpp
@@ -98,7 +98,6 @@ void AutoPanEffect::processChannel(
         return;
     }
 
-    AutoPanGroupState& gs = *pGroupState;
     double width = m_pWidthParameter->value();
     double period = m_pPeriodParameter->value();
     const auto smoothing = static_cast<float>(0.5 - m_pSmoothingParameter->value());
@@ -118,15 +117,15 @@ void AutoPanEffect::processChannel(
 
     // When the period is changed, the position of the sound shouldn't
     // so time need to be recalculated
-    if (gs.m_dPreviousPeriod != -1.0) {
-        gs.time = static_cast<unsigned int>(gs.time * period / gs.m_dPreviousPeriod);
+    if (pGroupState->m_dPreviousPeriod != -1.0) {
+        pGroupState->time = static_cast<unsigned int>(
+                pGroupState->time * period / pGroupState->m_dPreviousPeriod);
     }
 
+    pGroupState->m_dPreviousPeriod = period;
 
-    gs.m_dPreviousPeriod = period;
-
-    if (gs.time >= period || enableState == EffectEnableState::Enabling) {
-        gs.time = 0;
+    if (pGroupState->time >= period || enableState == EffectEnableState::Enabling) {
+        pGroupState->time = 0;
     }
 
     // Normally, the position goes from 0 to 1 linearly. Here we make steps at
@@ -142,13 +141,14 @@ void AutoPanEffect::processChannel(
     // size of a segment of slope (controlled by the "smoothing" parameter)
     float u = (0.5f - smoothing) / 2.0f;
 
-    gs.frac.setRampingThreshold(kPositionRampingThreshold);
+    pGroupState->frac.setRampingThreshold(kPositionRampingThreshold);
 
     double sinusoid = 0;
 
     // NOTE: Assuming engine is working in stereo.
     for (SINT i = 0; i + 1 < bufferParameters.samplesPerBuffer(); i += 2) {
-        const auto periodFraction = static_cast<CSAMPLE>(gs.time) / static_cast<CSAMPLE>(period);
+        const auto periodFraction = static_cast<CSAMPLE>(pGroupState->time) /
+                static_cast<CSAMPLE>(period);
 
         // current quarter in the trigonometric circle
         float quarter = floorf(periodFraction * 4.0f);
@@ -174,24 +174,28 @@ void AutoPanEffect::processChannel(
         // so the sound will be stuck at the center. If it values 1, the limits
         // will be 0 and 1 (full left and full right).
         sinusoid = sin(M_PI * 2.0f * angleFraction) * width;
-        gs.frac.setWithRampingApplied(static_cast<float>((sinusoid + 1.0f) / 2.0f));
+        pGroupState->frac.setWithRampingApplied(static_cast<float>((sinusoid + 1.0f) / 2.0f));
 
         // apply the delay
-        gs.delay->process(&pInput[i], &pOutput[i],
-                -0.005 * math_clamp(((gs.frac * 2.0) - 1.0f), -1.0, 1.0) * bufferParameters.sampleRate());
+        pGroupState->delay->process(&pInput[i],
+                &pOutput[i],
+                -0.005 *
+                        math_clamp(
+                                ((pGroupState->frac * 2.0) - 1.0f), -1.0, 1.0) *
+                        bufferParameters.sampleRate());
 
         double lawCoef = computeLawCoefficient(sinusoid);
-        pOutput[i] *= static_cast<CSAMPLE>(gs.frac * lawCoef);
-        pOutput[i + 1] *= static_cast<CSAMPLE>((1.0f - gs.frac) * lawCoef);
+        pOutput[i] *= static_cast<CSAMPLE>(pGroupState->frac * lawCoef);
+        pOutput[i + 1] *= static_cast<CSAMPLE>((1.0f - pGroupState->frac) * lawCoef);
 
-        gs.time++;
-        while (gs.time >= period) {
+        pGroupState->time++;
+        while (pGroupState->time >= period) {
             // Click for debug
             //pOutput[i] = 1.0f;
             //pOutput[i+1] = 1.0f;
 
             // The while loop is required in case period changes the value
-            gs.time -= static_cast<unsigned int>(period);
+            pGroupState->time -= static_cast<unsigned int>(period);
         }
     }
 }

--- a/src/effects/builtin/echoeffect.cpp
+++ b/src/effects/builtin/echoeffect.cpp
@@ -142,7 +142,6 @@ void EchoEffect::processChannel(const ChannelHandle& handle, EchoGroupState* pGr
                                 const GroupFeatureState& groupFeatures) {
     Q_UNUSED(handle);
 
-    EchoGroupState& gs = *pGroupState;
     // The minimum of the parameter is zero so the exact center of the knob is 1 beat.
     double period = m_pDelayParameter->value();
     const auto send_current = static_cast<CSAMPLE_GAIN>(m_pSendParameter->value());
@@ -172,21 +171,25 @@ void EchoEffect::processChannel(const ChannelHandle& handle, EchoGroupState* pGr
     }
 
     int delay_samples = delay_frames * bufferParameters.channelCount();
-    VERIFY_OR_DEBUG_ASSERT(delay_samples <= gs.delay_buf.size()) {
-        delay_samples = gs.delay_buf.size();
+    VERIFY_OR_DEBUG_ASSERT(delay_samples <= pGroupState->delay_buf.size()) {
+        delay_samples = pGroupState->delay_buf.size();
     }
 
-    int prev_read_position = gs.write_position;
-    decrementRing(&prev_read_position, gs.prev_delay_samples, gs.delay_buf.size());
-    int read_position = gs.write_position;
-    decrementRing(&read_position, delay_samples, gs.delay_buf.size());
+    int prev_read_position = pGroupState->write_position;
+    decrementRing(&prev_read_position,
+            pGroupState->prev_delay_samples,
+            pGroupState->delay_buf.size());
+    int read_position = pGroupState->write_position;
+    decrementRing(&read_position, delay_samples, pGroupState->delay_buf.size());
 
-    RampingValue<CSAMPLE_GAIN> send(send_current, gs.prev_send,
-                                    bufferParameters.framesPerBuffer());
+    RampingValue<CSAMPLE_GAIN> send(send_current,
+            pGroupState->prev_send,
+            bufferParameters.framesPerBuffer());
     // Feedback the delay buffer and then add the new input.
 
-    RampingValue<CSAMPLE_GAIN> feedback(feedback_current, gs.prev_feedback,
-                                        bufferParameters.framesPerBuffer());
+    RampingValue<CSAMPLE_GAIN> feedback(feedback_current,
+            pGroupState->prev_feedback,
+            bufferParameters.framesPerBuffer());
 
     //TODO: rewrite to remove assumption of stereo buffer
     for (SINT i = 0;
@@ -195,32 +198,34 @@ void EchoEffect::processChannel(const ChannelHandle& handle, EchoGroupState* pGr
         CSAMPLE_GAIN send_ramped = send.getNext();
         CSAMPLE_GAIN feedback_ramped = feedback.getNext();
 
-        CSAMPLE bufferedSampleLeft = gs.delay_buf[read_position];
-        CSAMPLE bufferedSampleRight = gs.delay_buf[read_position + 1];
+        CSAMPLE bufferedSampleLeft = pGroupState->delay_buf[read_position];
+        CSAMPLE bufferedSampleRight = pGroupState->delay_buf[read_position + 1];
         if (read_position != prev_read_position) {
             const CSAMPLE_GAIN frac = static_cast<CSAMPLE_GAIN>(i) /
                     bufferParameters.samplesPerBuffer();
             bufferedSampleLeft *= frac;
             bufferedSampleRight *= frac;
-            bufferedSampleLeft += gs.delay_buf[prev_read_position] * (1 - frac);
-            bufferedSampleRight += gs.delay_buf[prev_read_position + 1] * (1 - frac);
-            incrementRing(&prev_read_position, bufferParameters.channelCount(),
-                    gs.delay_buf.size());
+            bufferedSampleLeft += pGroupState->delay_buf[prev_read_position] * (1 - frac);
+            bufferedSampleRight += pGroupState->delay_buf[prev_read_position + 1] * (1 - frac);
+            incrementRing(&prev_read_position,
+                    bufferParameters.channelCount(),
+                    pGroupState->delay_buf.size());
         }
-        incrementRing(&read_position, bufferParameters.channelCount(),
-                gs.delay_buf.size());
+        incrementRing(&read_position,
+                bufferParameters.channelCount(),
+                pGroupState->delay_buf.size());
 
         // Actual delays distort and saturate, so clamp the buffer here.
-        gs.delay_buf[gs.write_position] = SampleUtil::clampSample(
+        pGroupState->delay_buf[pGroupState->write_position] = SampleUtil::clampSample(
                 pInput[i] * send_ramped +
                 bufferedSampleLeft * feedback_ramped);
-        gs.delay_buf[gs.write_position + 1] = SampleUtil::clampSample(
+        pGroupState->delay_buf[pGroupState->write_position + 1] = SampleUtil::clampSample(
                 pInput[i + 1] * send_ramped +
                 bufferedSampleLeft * feedback_ramped);
 
         // Pingpong the output.  If the pingpong value is zero, all of the
         // math below should result in a simple copy of delay buf to pOutput.
-        if (gs.ping_pong < delay_samples / 2) {
+        if (pGroupState->ping_pong < delay_samples / 2) {
             // Left sample plus a fraction of the right sample, normalized
             // by 1 + fraction.
             pOutput[i] =
@@ -238,12 +243,13 @@ void EchoEffect::processChannel(const ChannelHandle& handle, EchoGroupState* pGr
                     (1 + pingpong_frac);
         }
 
-        incrementRing(&gs.write_position, bufferParameters.channelCount(),
-                gs.delay_buf.size());
+        incrementRing(&pGroupState->write_position,
+                bufferParameters.channelCount(),
+                pGroupState->delay_buf.size());
 
-        ++gs.ping_pong;
-        if (gs.ping_pong >= delay_samples) {
-            gs.ping_pong = 0;
+        ++(pGroupState->ping_pong);
+        if (pGroupState->ping_pong >= delay_samples) {
+            pGroupState->ping_pong = 0;
         }
     }
 
@@ -252,12 +258,12 @@ void EchoEffect::processChannel(const ChannelHandle& handle, EchoGroupState* pGr
     // of being handled by EngineEffect::process).
     if (enableState == EffectEnableState::Disabling) {
         SampleUtil::applyRampingGain(pOutput, 1.0, 0.0, bufferParameters.samplesPerBuffer());
-        gs.delay_buf.clear();
-        gs.prev_send = 0;
+        pGroupState->delay_buf.clear();
+        pGroupState->prev_send = 0;
     } else {
-        gs.prev_send = send_current;
+        pGroupState->prev_send = send_current;
     }
 
-    gs.prev_feedback = feedback_current;
-    gs.prev_delay_samples = delay_samples;
+    pGroupState->prev_feedback = feedback_current;
+    pGroupState->prev_delay_samples = delay_samples;
 }


### PR DESCRIPTION
In bug https://bugs.launchpad.net/mixxx/+bug/1775497 it turns out that this non const reference can become invalid, even though the C++ standard predicts that this cannot be happen. A good chance to fix it by using a pointer and make this assumption true. 

This is only a syntax PR without fixing the real issue in the bug report. 