### PR TITLE
CI: Improve deployment directory structure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -349,9 +349,9 @@ jobs:
       run: >
         if [[ "${GITHUB_REF}" =~ ^refs/tags/.* ]];
         then
-          export DEPLOY_PATH='mixxx-{git_describe}/mixxx-{git_describe}-{package_slug}{ext}';
+          export DEPLOY_PATH='releases/mixxx-{git_describe}/mixxx-{git_describe}-{package_slug}{ext}';
         else
-          export DEPLOY_PATH='builds/{git_branch}/mixxx-{git_describe}-{package_slug}{ext}';
+          export DEPLOY_PATH='snapshots/{git_branch}/mixxx-{git_describe}-{package_slug}{ext}';
         fi;
         python3 tools/deploy.py prepare-deployment
         --slug '${{ matrix.artifacts_slug }}'
@@ -416,9 +416,9 @@ jobs:
       run: >
         if [[ "${GITHUB_REF}" =~ ^refs/tags/.* ]];
         then
-          export DEPLOY_PATH='mixxx-{git_describe}/manifest.json';
+          export DEPLOY_PATH='releases/mixxx-{git_describe}/manifest.json';
         else
-          export DEPLOY_PATH='builds/{git_branch}/manifest.json';
+          export DEPLOY_PATH='snapshots/{git_branch}/manifest.json';
         fi;
         python3 tools/deploy.py generate-manifest
         --output-dir 'deploy/'


### PR DESCRIPTION
I think this directory structure is less confusing (`builds` could mean anything, even release builds, therefore `snapshots` better reflects the meaning).

If you agree with this change I'll go ahead and move the existing releases on the server into `releases/` as well.