### PR TITLE
make ControlPotmeter's '_set_default' an in/out CO

### DIFF
--- a/res/skins/LateNight/decks/rate_controls.xml
+++ b/res/skins/LateNight/decks/rate_controls.xml
@@ -109,8 +109,7 @@
                         <Size>5f,5f</Size>
                         <Pos>2,59</Pos>
                         <Connection>
-                          <ConfigKey><Variable name="Group"/>,rate</ConfigKey>
-                          <Transform><IsEqual>0.5</IsEqual></Transform>
+                          <ConfigKey><Variable name="Group"/>,rate_set_default</ConfigKey>
                           <BindProperty>highlight</BindProperty>
                         </Connection>
                       </Label>

--- a/res/skins/LateNight/decks/rate_controls_compact.xml
+++ b/res/skins/LateNight/decks/rate_controls_compact.xml
@@ -113,8 +113,7 @@
                             <Size>5f,5f</Size>
                             <Pos>2,39</Pos>
                             <Connection>
-                              <ConfigKey><Variable name="Group"/>,rate</ConfigKey>
-                              <Transform><IsEqual>0.5</IsEqual></Transform>
+                              <ConfigKey><Variable name="Group"/>,rate_set_default</ConfigKey>
                               <BindProperty>highlight</BindProperty>
                             </Connection>
                           </Label>
@@ -174,8 +173,7 @@
                         <Size>5f,5f</Size>
                         <Pos>2,47</Pos>
                         <Connection>
-                          <ConfigKey><Variable name="Group"/>,rate</ConfigKey>
-                          <Transform><IsEqual>0.5</IsEqual></Transform>
+                          <ConfigKey><Variable name="Group"/>,rate_set_default</ConfigKey>
                           <BindProperty>highlight</BindProperty>
                         </Connection>
                       </Label>

--- a/src/control/controlpotmeter.h
+++ b/src/control/controlpotmeter.h
@@ -41,9 +41,11 @@ class PotmeterControls : public QObject {
     void toggleValue(double);
     // Toggles the value between -1.0 and 0.0.
     void toggleMinusValue(double);
+    void setIsDefault(bool isDefault);
 
   private:
     ControlProxy* m_pControl;
+    ControlPushButton* m_pControlDefault;
     int m_stepCount;
     double m_smallStepCount;
 };
@@ -59,7 +61,7 @@ class ControlPotmeter : public ControlObject {
             bool bTrack = false,
             bool bPersist = false,
             double defaultValue = 0.0);
-    virtual ~ControlPotmeter();
+    ~ControlPotmeter() override = default;
 
     // Sets the step count of the associated PushButtons.
     void setStepCount(int count);
@@ -70,6 +72,10 @@ class ControlPotmeter : public ControlObject {
     // Sets the minimum and maximum allowed value. The control value is reset
     // when calling this method
     void setRange(double dMinValue, double dMaxValue, bool allowOutOfBounds);
+
+  private slots:
+    // Used to check if the current control value matches the default value.
+    void privateValueChanged(double dValue, QObject* pSender);
 
   protected:
     bool m_bAllowOutOfBounds;


### PR DESCRIPTION
inspired by the GUI lag probably caused by `<Transform><IsEqual>0.5</IsEqual></Transform>` when using a high-res pitch slider
https://mixxx.discourse.group/t/mixtrack-pro-3-tempo-slider-lag-on-w10/21835/18
``` xml
<Connection>
    <ConfigKey><Variable name="Group"/>,rate</ConfigKey>
    <Transform><IsEqual>0.5</IsEqual></Transform>
    <BindProperty>highlight</BindProperty>
</Connection>
```
~~It's not yet verified that this would fix the lag, but~~
it's handy anyway to have `group, control _set_default` with read/write capability.

**TODO**
- [x] Document new control in the manual