### PR TITLE
Replace recursive QMutexes with QRecursiveMutex

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -83,9 +83,12 @@ CueControl::CueControl(const QString& group,
           m_pStopButton(ControlObject::getControl(ConfigKey(group, "stop"))),
           m_iCurrentlyPreviewingHotcues(0),
           m_bypassCueSetByPlay(false),
-          m_iNumHotCues(NUM_HOT_CUES),
-          m_pLoadedTrack(),
-          m_mutex(QMutex::Recursive) {
+          m_iNumHotCues(NUM_HOT_CUES)
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+          ,
+          m_mutex(QMutex::Recursive)
+#endif
+{
     // To silence a compiler warning about CUE_MODE_PIONEER.
     Q_UNUSED(CUE_MODE_PIONEER);
     createControls();

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -266,5 +266,9 @@ class CueControl : public EngineControl {
     // Tells us which controls map to which hotcue
     QMap<QObject*, int> m_controlMap;
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    QRecursiveMutex m_mutex;
+#else
     QMutex m_mutex;
+#endif
 };

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -47,7 +47,10 @@ PlayerManager::PlayerManager(UserSettingsPointer pConfig,
         EffectsManager* pEffectsManager,
         VisualsManager* pVisualsManager,
         EngineMaster* pEngine)
-        : m_mutex(QMutex::Recursive),
+        :
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+          m_mutex(QMutex::Recursive),
+#endif
           m_pConfig(pConfig),
           m_pSoundManager(pSoundManager),
           m_pEffectsManager(pEffectsManager),

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -260,7 +260,11 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     void addAuxiliaryInner();
 
     // Used to protect access to PlayerManager state across threads.
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    mutable QRecursiveMutex m_mutex;
+#else
     mutable QMutex m_mutex;
+#endif
 
     PerformanceTimer m_cloneTimer;
     QString m_lastLoadedPlayer;

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -319,10 +319,13 @@ void GlobalTrackCache::evictAndSaveCachedTrack(GlobalTrackCacheEntryPointer cach
 GlobalTrackCache::GlobalTrackCache(
         GlobalTrackCacheSaver* pSaver,
         deleteTrackFn_t deleteTrackFn)
-    : m_mutex(QMutex::Recursive),
-      m_pSaver(pSaver),
-      m_deleteTrackFn(deleteTrackFn),
-      m_tracksById(kUnorderedCollectionMinCapacity, DbId::hash_fun) {
+        :
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+          m_mutex(QMutex::Recursive),
+#endif
+          m_pSaver(pSaver),
+          m_deleteTrackFn(deleteTrackFn),
+          m_tracksById(kUnorderedCollectionMinCapacity, DbId::hash_fun) {
     DEBUG_ASSERT(m_pSaver);
     qRegisterMetaType<GlobalTrackCacheEntryPointer>("GlobalTrackCacheEntryPointer");
 }

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -278,7 +278,11 @@ class GlobalTrackCache : public QObject {
     void saveEvictedTrack(Track* pEvictedTrack) const;
 
     // Managed by GlobalTrackCacheLocker
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    mutable QRecursiveMutex m_mutex;
+#else
     mutable QMutex m_mutex;
+#endif
 
     GlobalTrackCacheSaver* m_pSaver;
 

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -61,7 +61,10 @@ Track::Track(
         TrackFile fileInfo,
         SecurityTokenPointer pSecurityToken,
         TrackId trackId)
-        : m_qMutex(QMutex::Recursive),
+        :
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+          m_qMutex(QMutex::Recursive),
+#endif
           m_fileInfo(std::move(fileInfo)),
           m_pSecurityToken(openSecurityToken(m_fileInfo, std::move(pSecurityToken))),
           m_record(trackId),

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -466,7 +466,11 @@ class Track : public QObject {
             mixxx::audio::StreamInfo&& streamInfo);
 
     // Mutex protecting access to object
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    mutable QRecursiveMutex m_qMutex;
+#else
     mutable QMutex m_qMutex;
+#endif
 
     // The file
     mutable TrackFile m_fileInfo;

--- a/src/util/mutex.h
+++ b/src/util/mutex.h
@@ -12,9 +12,7 @@
 
 class CAPABILITY("mutex") MMutex {
   public:
-    MMutex(QMutex::RecursionMode mode = QMutex::NonRecursive)
-            : m_mutex(mode) {
-    }
+    MMutex() = default;
 
     inline void lock() ACQUIRE() { m_mutex.lock(); }
     inline void unlock() RELEASE() { m_mutex.unlock(); }

--- a/src/util/sandbox.cpp
+++ b/src/util/sandbox.cpp
@@ -17,7 +17,11 @@
 
 const bool sDebug = false;
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+QRecursiveMutex Sandbox::s_mutex;
+#else
 QMutex Sandbox::s_mutex(QMutex::Recursive);
+#endif
 bool Sandbox::s_bInSandbox = false;
 QSharedPointer<ConfigObject<ConfigValue>> Sandbox::s_pSandboxPermissions;
 QHash<QString, SecurityTokenWeakPointer> Sandbox::s_activeTokens;

--- a/src/util/sandbox.h
+++ b/src/util/sandbox.h
@@ -76,7 +76,11 @@ class Sandbox {
     // Creates a security token. s_mutex is not needed for this method.
     static bool createSecurityToken(const QString& canonicalPath, bool isDirectory);
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    static QRecursiveMutex s_mutex;
+#else
     static QMutex s_mutex;
+#endif
     static bool s_bInSandbox;
     static QSharedPointer<ConfigObject<ConfigValue>> s_pSandboxPermissions;
     static QHash<QString, SecurityTokenWeakPointer> s_activeTokens;

--- a/src/vinylcontrol/vinylcontrolprocessor.cpp
+++ b/src/vinylcontrol/vinylcontrolprocessor.cpp
@@ -20,7 +20,9 @@ VinylControlProcessor::VinylControlProcessor(QObject* pParent, UserSettingsPoint
           m_pConfig(pConfig),
           m_pToggle(new ControlPushButton(ConfigKey(VINYL_PREF_KEY, "Toggle"))),
           m_pWorkBuffer(SampleUtil::alloc(MAX_BUFFER_LEN)),
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
           m_processorsLock(QMutex::Recursive),
+#endif
           m_processors(kMaximumVinylControlInputs, NULL),
           m_signalQualityFifo(SIGNAL_QUALITY_FIFO_SIZE),
           m_bReportSignalQuality(false),

--- a/src/vinylcontrol/vinylcontrolprocessor.h
+++ b/src/vinylcontrol/vinylcontrolprocessor.h
@@ -72,7 +72,11 @@ class VinylControlProcessor : public QThread, public AudioDestination {
     CSAMPLE* m_pWorkBuffer;
     QWaitCondition m_samplesAvailableSignal;
     QMutex m_waitForSampleMutex;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    QRecursiveMutex m_processorsLock;
+#else
     QMutex m_processorsLock;
+#endif
     QVector<VinylControl*> m_processors;
     FIFO<VinylSignalQualityReport> m_signalQualityFifo;
     volatile bool m_bReportSignalQuality;

--- a/src/widget/wlibrary.cpp
+++ b/src/widget/wlibrary.cpp
@@ -12,7 +12,9 @@
 WLibrary::WLibrary(QWidget* parent)
         : QStackedWidget(parent),
           WBaseWidget(this),
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
           m_mutex(QMutex::Recursive),
+#endif
           m_trackTableBackgroundColorOpacity(kDefaultTrackTableBackgroundColorOpacity),
           m_bShowButtonText(true) {
 }

--- a/src/widget/wlibrary.h
+++ b/src/widget/wlibrary.h
@@ -54,7 +54,11 @@ class WLibrary : public QStackedWidget, public WBaseWidget {
     bool event(QEvent* pEvent) override;
 
   private:
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    QRecursiveMutex m_mutex;
+#else
     QMutex m_mutex;
+#endif
     QMap<QString, QWidget*> m_viewMap;
     double m_trackTableBackgroundColorOpacity;
     bool m_bShowButtonText;


### PR DESCRIPTION
Recursive QMutexes have been deprecated since the 5.15.

Fixes warnings like these:

    src/vinylcontrol/vinylcontrolprocessor.cpp: In constructor ‘VinylControlProcessor::VinylControlProcessor(QObject*, UserSettingsPointer)’:
    src/vinylcontrol/vinylcontrolprocessor.cpp:28:32: error: ‘QMutex::QMutex(QMutex::RecursionMode)’ is deprecated: Use QRecursiveMutex instead of a recursive QMutex [-Werror=deprecated-declarations]
       28 |           m_bReloadConfig(false) {
          |                                ^
    In file included from /usr/include/qt/QtCore/QMutex:1,
                     from src/vinylcontrol/vinylcontrolprocessor.h:6,
                     from src/vinylcontrol/vinylcontrolprocessor.cpp:1:
    /usr/include/qt/QtCore/qmutex.h:140:14: note: declared here
      140 |     explicit QMutex(RecursionMode mode);
          |              ^~~~~~