### PR TITLE
WTrackTableView: don't use header section highlight…

### DIFF
--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -26,7 +26,8 @@ WEffectSelector QAbstractScrollArea,
 #LibraryContainer QPushButton,
 #LibraryContainer QLabel,
 #LibraryContainer QRadioButton,
-#LibraryContainer QHeaderView {
+#LibraryContainer QHeaderView,
+#LibraryContainer QHeaderView::section {
   /* On Linux all weight variants of Open Sans are identified
   as "Open Sans".
   On Windows however, the semi-bold variant is identified as

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -213,7 +213,12 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel* model) {
     setHorizontalHeader(header);
     header->setSectionsMovable(true);
     header->setSectionsClickable(true);
-    header->setHighlightSections(true);
+    // Setting this to true would render all column labels BOLD as soon as the
+    // tableview is focused -- and would not restore the previous style when
+    // it's unfocused. This can not be overwritten with qss, so it can screw up
+    // the skin design. Also, due to selectionModel()->selectedRows() it is not
+    // even useful to highlight the focused column because all colmsn are highlighted.
+    header->setHighlightSections(false);
     header->setSortIndicatorShown(m_sorting);
     header->setDefaultAlignment(Qt::AlignLeft);
 


### PR DESCRIPTION
...explicitely style with qss only.

As soon as the tableview is focused all column labels would be automatically rendered **bold** -- and previous style is not restored when the tableview is unfocused, only when the table content changes. This can not be overwritten with qss, so it can screw up the skin design.
Also, due to selectionModel()->selectedRows() it is not even useful to highlight the focused column.

I did not find a qss way to override the hader font for focused table views -- doing this in c++ is the last resort (and I have no idea why it would be enabled in the first place because I don't see UI benefit).
No side effects to be expected https://doc.qt.io/qt-5/qheaderview.html#highlightSections-prop

- [ ] double check skins after #3788 is merged