### PR TITLE
Dirty flag fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1180,7 +1180,22 @@ endif()
 # The mixxx executable
 add_executable(mixxx WIN32 src/main.cpp)
 set_target_properties(mixxx-lib PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY}")
-target_link_libraries(mixxx PUBLIC mixxx-lib)
+target_link_libraries(mixxx PUBLIC mixxx-lib mixxx-build-date)
+
+add_library(mixxx-build-date STATIC EXCLUDE_FROM_ALL
+    ${CMAKE_BINARY_DIR}/src/builddate.cpp
+)
+target_include_directories(mixxx-build-date PUBLIC src)
+
+add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/src/builddate.cpp
+    DEPENDS mixxx-lib src/builddate.cpp.in
+    COMMAND ${CMAKE_COMMAND}
+        -D CMAKE_BINARY_DIR_=${CMAKE_BINARY_DIR}
+        -D CMAKE_SOURCE_DIR_=${CMAKE_SOURCE_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/builddate.cmake
+    VERBATIM
+)
 
 #
 # Installation and Packaging
@@ -1556,7 +1571,7 @@ add_executable(mixxx-test
   src/test/wwidgetstack_test.cpp
 )
 set_target_properties(mixxx-test PROPERTIES AUTOMOC ON)
-target_link_libraries(mixxx-test PUBLIC mixxx-lib gtest gmock)
+target_link_libraries(mixxx-test PUBLIC mixxx-lib mixxx-build-date gtest gmock)
 
 #
 # Benchmark tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,7 +321,7 @@ endif()
 
 # Get the current commit ref
 execute_process(
-  COMMAND git describe --tags --always --dirty=-modified
+  COMMAND git describe --tags --always
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   OUTPUT_VARIABLE GIT_DESCRIBE
   OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -372,18 +372,8 @@ execute_process(
 if(NOT GIT_COMMIT_COUNT)
     set(GIT_COMMIT_COUNT "unknown")
 endif()
-
-# Check if the worktree is dirty
-execute_process(
-  COMMAND git diff --quiet
-  RESULT_VARIABLE GIT_WORKTREE_DIRTY
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  ERROR_QUIET
-)
-if(GIT_WORKTREE_DIRTY EQUAL "1")
-  set(GIT_COMMIT_COUNT "${GIT_COMMIT_COUNT}+")
-endif()
 message(STATUS "Git commit count: ${GIT_COMMIT_COUNT}")
+
 if(MSVC)
   # sccache support
   find_program(SCCACHE_EXECUTABLE "sccache")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,59 +320,67 @@ if(WIN32)
 endif()
 
 # Get the current commit ref
-execute_process(
-  COMMAND git describe --tags --always
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  OUTPUT_VARIABLE GIT_DESCRIBE
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  ERROR_QUIET
-)
 if(NOT GIT_DESCRIBE)
-  message(STATUS "Git describe: unknown")
+  execute_process(
+    COMMAND git describe --tags --always
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_DESCRIBE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+  )
+  if(NOT GIT_DESCRIBE)
+     message(STATUS "Git describe: unknown")
+  else()
+     message(STATUS "Git describe: ${GIT_DESCRIBE}")
+  endif()
+
+  # Get the current working branch
+  execute_process(
+    COMMAND git rev-parse --abbrev-ref HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_BRANCH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+  )
+  if(NOT GIT_BRANCH)
+    message(STATUS "Git branch: unknown")
+  else()
+    message(STATUS "Git branch: ${GIT_BRANCH}")
+  endif()
+
+  # Get the number of commits on the working branch
+  execute_process(
+    COMMAND git rev-list --count --first-parent HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_COMMIT_COUNT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+  )
+  if(NOT GIT_COMMIT_COUNT)
+    set(GIT_COMMIT_COUNT "unknown")
+  endif()
+  message(STATUS "Git commit count: ${GIT_COMMIT_COUNT}")
 else()
-  message(STATUS "Git describe: ${GIT_DESCRIBE}")
+  set(GIT_COMMIT_COUNT "unknown")
+  message(STATUS "Use custom git describe: ${GIT_DESCRIBE}")
 endif()
 
 # Get the current commit date
-execute_process(
-  COMMAND git show --quiet --format=%cI --date=short
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  OUTPUT_VARIABLE GIT_COMMIT_DATE
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  ERROR_QUIET
-)
+if(NOT GIT_COMMIT_DATE)
+  execute_process(
+    COMMAND git show --quiet --format=%cI --date=short
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_COMMIT_DATE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+  )
+endif()
 if(NOT GIT_COMMIT_DATE)
   message(STATUS "Git commit date: unknown")
 else()
   message(STATUS "Git commit date: ${GIT_COMMIT_DATE}")
 endif()
 
-# Get the current working branch
-execute_process(
-  COMMAND git rev-parse --abbrev-ref HEAD
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  OUTPUT_VARIABLE GIT_BRANCH
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  ERROR_QUIET
-)
-if(NOT GIT_BRANCH)
-  message(STATUS "Git branch: unknown")
-else()
-  message(STATUS "Git branch: ${GIT_BRANCH}")
-endif()
-
-# Get the number of commits on the working branch
-execute_process(
-  COMMAND git rev-list --count --first-parent HEAD
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  OUTPUT_VARIABLE GIT_COMMIT_COUNT
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  ERROR_QUIET
-)
-if(NOT GIT_COMMIT_COUNT)
-    set(GIT_COMMIT_COUNT "unknown")
-endif()
-message(STATUS "Git commit count: ${GIT_COMMIT_COUNT}")
 
 if(MSVC)
   # sccache support
@@ -1699,7 +1707,6 @@ if(WIN32)
   set(MIXXX_FILEVERSION "${CMAKE_PROJECT_VERSION_MAJOR},${CMAKE_PROJECT_VERSION_MINOR},${CMAKE_PROJECT_VERSION_PATCH}")
   if(NOT GIT_COMMIT_COUNT STREQUAL "unknown")
     set(MIXXX_FILEVERSION "${MIXXX_FILEVERSION},${GIT_COMMIT_COUNT}")
-    string(REPLACE "+" "" MIXXX_FILEVERSION "${MIXXX_FILEVERSION}")
   endif()
   set(MIXXX_PRODUCTVERSION "${MIXXX_FILEVERSION}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,10 +417,6 @@ else()
   message(STATUS "Support for ccache: ${CCACHE_SUPPORT}")
 endif()
 
-set_property(DIRECTORY APPEND
-    PROPERTY CMAKE_CONFIGURE_DEPENDS
-    "${CMAKE_SOURCE_DIR}/.git/index")
-
 if(CMAKE_VERSION VERSION_LESS "3.7.0")
   set(CMAKE_INCLUDE_CURRENT_DIR ON)
 endif()
@@ -1676,6 +1672,12 @@ get_target_property(BUILD_FLAGS mixxx-lib COMPILE_OPTIONS)
 
 # uses CMAKE_PROJECT_VERSION MIXXX_VERSION_PRERELEASE GIT_BRANCH GIT_DESCRIBE GIT_COMMIT_DATE BUILD_FLAGS
 configure_file(src/version.h.in src/version.h @ONLY)
+set_property(
+    DIRECTORY ${CMAKE_SOURCE_DIR}
+    APPEND
+    PROPERTY CMAKE_CONFIGURE_DEPENDS
+    "${CMAKE_SOURCE_DIR}/.git/index"
+)
 
 # Windows-only resource file
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1672,12 +1672,20 @@ get_target_property(BUILD_FLAGS mixxx-lib COMPILE_OPTIONS)
 
 # uses CMAKE_PROJECT_VERSION MIXXX_VERSION_PRERELEASE GIT_BRANCH GIT_DESCRIBE GIT_COMMIT_DATE BUILD_FLAGS
 configure_file(src/version.h.in src/version.h @ONLY)
-set_property(
-    DIRECTORY ${CMAKE_SOURCE_DIR}
-    APPEND
-    PROPERTY CMAKE_CONFIGURE_DEPENDS
-    "${CMAKE_SOURCE_DIR}/.git/index"
+execute_process(
+  COMMAND git rev-parse --git-dir
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_DIR
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  ERROR_QUIET
 )
+if(GIT_DIR)
+  set_property(
+    DIRECTORY ${CMAKE_SOURCE_DIR}
+    PROPERTY CMAKE_CONFIGURE_DEPENDS
+    "${GIT_DIR}/index"
+  )
+endif()
 
 # Windows-only resource file
 if(WIN32)

--- a/cmake/builddate.cmake
+++ b/cmake/builddate.cmake
@@ -1,0 +1,21 @@
+# Check if the worktree is dirty
+execute_process(
+  COMMAND git diff --quiet
+  RESULT_VARIABLE DIRTY
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR_}
+  ERROR_QUIET
+)
+if(DIRTY EQUAL "0")
+  message(STATUS "Git worktree is clean")
+else()
+  if(DIRTY EQUAL "1")
+     message(STATUS "Git worktree is dirty")
+  else()
+     message(STATUS "Not in a Git worktree")
+  endif()
+  # This depends on mixxx-lib so it will pick a new date
+  # Whenever mixxx-lib has changed.
+  string(TIMESTAMP BUILD_DATE "%Y-%m-%dT%H:%M:%SZ" UTC)
+endif()
+
+configure_file(${CMAKE_SOURCE_DIR_}/src/builddate.cpp.in ${CMAKE_BINARY_DIR_}/src/builddate.cpp @ONLY)

--- a/src/builddate.cpp.in
+++ b/src/builddate.cpp.in
@@ -1,0 +1,19 @@
+#include "builddate.h"
+
+#define VERSION_STORE
+#include "version.h"
+
+//static
+const char* BuildDate::date() {
+    // This condition is const and discarded during compileing
+    if (@DIRTY@ == 1 || sizeof(GIT_COMMIT_DATE) == 1) {
+       return "@BUILD_DATE@";
+    } else {
+       return GIT_COMMIT_DATE;
+    }
+};
+
+//static
+bool BuildDate::dirty() {
+    return static_cast<bool>(@DIRTY@ == 1);
+};

--- a/src/builddate.h
+++ b/src/builddate.h
@@ -1,0 +1,7 @@
+#pragma once
+
+class BuildDate {
+  public:
+    static const char* date();
+    static bool dirty();
+};

--- a/src/dialog/dlgaboutdlg.ui
+++ b/src/dialog/dlgaboutdlg.ui
@@ -91,7 +91,7 @@
         <item row="1" column="0">
          <widget class="QLabel" name="label_2">
           <property name="text">
-           <string>Git Commit Date:</string>
+           <string>Date:</string>
           </property>
          </widget>
         </item>
@@ -135,6 +135,9 @@
          <widget class="QLabel" name="date_label">
           <property name="text">
            <string>Unknown</string>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
           </property>
          </widget>
         </item>

--- a/src/util/versionstore.cpp
+++ b/src/util/versionstore.cpp
@@ -29,6 +29,7 @@
 #include <vorbis/codec.h>
 
 #define VERSION_STORE
+#include "builddate.h"
 #include "version.h"
 
 namespace {
@@ -39,7 +40,6 @@ const QString kMixxxVersionSuffix = QString(MIXXX_VERSION_SUFFIX);
 const QString kMixxx = QStringLiteral("Mixxx");
 const QString kGitBranch = QString(GIT_BRANCH);
 const QString kGitDescribe = QString(GIT_DESCRIBE);
-const QDateTime kGitCommitDate = QDateTime::fromString(GIT_COMMIT_DATE, Qt::ISODate);
 const QString kBuildFlags = QString(BUILD_FLAGS);
 
 } // namespace
@@ -64,7 +64,7 @@ QString VersionStore::versionSuffix() {
 }
 
 QDateTime VersionStore::date() {
-    return kGitCommitDate;
+    return QDateTime::fromString(BuildDate::date(), Qt::ISODate);
 }
 
 // static
@@ -126,6 +126,8 @@ QString VersionStore::gitVersion() {
     QString gitVersion = VersionStore::gitDescribe();
     if (gitVersion.isEmpty()) {
         gitVersion = QStringLiteral("unknown");
+    } else if (BuildDate::dirty()) {
+        gitVersion.append(QStringLiteral("-modified"));
     }
 
     QString gitBranch = VersionStore::gitBranch();


### PR DESCRIPTION
Since the git folder is not changed when a source file changes without a commit, cmake was not reconfigured and the dirty flag was not updated. 

This PR uses an extra cmake script that is executed whenever mixxx-lib has been updated, to update the dirty state. 
In case of dirty. it used the current time instead of the commit time as date in the about box. 