### PR TITLE
Added Controller-Scripting property "current_trackid" to EngineBuffer.

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -184,7 +184,7 @@ EngineBuffer::EngineBuffer(const QString& group,
     m_pTrackLoaded = new ControlObject(ConfigKey(m_group, "track_loaded"), false);
     m_pTrackLoaded->setReadOnly();
 	
-	m_pTrackID = new ControlObject(ConfigKey(m_group, "current_trackid"), false, false, false, -1.0);
+    m_pTrackID = new ControlObject(ConfigKey(m_group, "current_trackid"), false, false, false, -1.0);
     m_pTrackID->setReadOnly();
 
     // Quantization Controller for enabling and disabling the
@@ -321,7 +321,7 @@ EngineBuffer::~EngineBuffer() {
     delete m_pKeylock;
     delete m_pEject;
 
-	delete m_pTrackID;
+    delete m_pTrackID;
 	
     SampleUtil::free(m_pCrossfadeBuffer);
 
@@ -591,7 +591,7 @@ void EngineBuffer::ejectTrack() {
     m_pTrackSamples->set(0);
     m_pTrackSampleRate->set(0);
     m_pTrackLoaded->forceSet(0);
-	m_pTrackID->forceSet(-1.0);
+    m_pTrackID->forceSet(-1.0);
 
     m_playButton->set(0.0);
     m_playposSlider->set(0);

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -183,6 +183,9 @@ EngineBuffer::EngineBuffer(const QString& group,
 
     m_pTrackLoaded = new ControlObject(ConfigKey(m_group, "track_loaded"), false);
     m_pTrackLoaded->setReadOnly();
+	
+	m_pTrackID = new ControlObject(ConfigKey(m_group, "current_trackid"), false, false, false, -1.0);
+    m_pTrackID->setReadOnly();
 
     // Quantization Controller for enabling and disabling the
     // quantization (alignment) of loop in/out positions and (hot)cues with
@@ -318,6 +321,8 @@ EngineBuffer::~EngineBuffer() {
     delete m_pKeylock;
     delete m_pEject;
 
+	delete m_pTrackID;
+	
     SampleUtil::free(m_pCrossfadeBuffer);
 
     qDeleteAll(m_engineControls);
@@ -542,7 +547,8 @@ void EngineBuffer::slotTrackLoaded(TrackPointer pTrack,
     m_pTrackSamples->set(iTrackNumSamples);
     m_pTrackSampleRate->set(iTrackSampleRate);
     m_pTrackLoaded->forceSet(1);
-
+    m_pTrackID->forceSet(m_pCurrentTrack->getId().value());
+	
     // Reset slip mode
     m_pSlipButton->set(0);
     m_bSlipEnabledProcessing = false;
@@ -585,6 +591,7 @@ void EngineBuffer::ejectTrack() {
     m_pTrackSamples->set(0);
     m_pTrackSampleRate->set(0);
     m_pTrackLoaded->forceSet(0);
+	m_pTrackID->forceSet(-1.0);
 
     m_playButton->set(0.0);
     m_playposSlider->set(0);

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -344,7 +344,7 @@ class EngineBuffer : public EngineObject {
 
     ControlPushButton* m_pEject;
     ControlObject* m_pTrackLoaded;
-	ControlObject* m_pTrackID;
+    ControlObject* m_pTrackID;
 
     // Whether or not to repeat the track when at the end
     ControlPushButton* m_pRepeat;

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -344,6 +344,7 @@ class EngineBuffer : public EngineObject {
 
     ControlPushButton* m_pEject;
     ControlObject* m_pTrackLoaded;
+	ControlObject* m_pTrackID;
 
     // Whether or not to repeat the track when at the end
     ControlPushButton* m_pRepeat;


### PR DESCRIPTION
# Why?
There is currently no way (from what i was able to find) to get the current loaded track of a deck. `current_trackid` returns `m_pCurrentTrack->getId().value()`. This way you are able to query all the further required metadata from the sqlite database.

# Use cases
One use case would be using this to identify the current track for syncing up DMX devices or LED screens that get the required data from track-specific keyframed events provided by further software with the audio.

# Usage
**[ChannelN]** current_trackid
**[PreviewDeckN]** current_trackid
**[SamplerN]** current_trackid
The current track id loaded within the deck
**Range:** binary, read only
**Feedback:** None