### PR TITLE
extend tooltips of track labels and cover art

### DIFF
--- a/src/skin/tooltips.cpp
+++ b/src/skin/tooltips.cpp
@@ -820,9 +820,12 @@ void Tooltips::addStandardTooltips() {
     add("coverart")
             << tr("Cover Art")
             << tr("Displays cover artwork of the loaded track.")
-            << QString("%1: %2").arg(rightClick, tr("Displays options for editing cover artwork."))
-            << dropTracksHere
-            << dragItem;
+            << QString("%1: %2").arg(
+                       leftClick, tr("Opens separate artwork viewer."))
+            << QString("%1: %2").arg(rightClick,
+                       tr("Displays options for editing cover artwork.")) +
+                    "\n"
+            << dropTracksHere << dragItem;
 
     add("starrating")
             << tr("Star Rating")

--- a/src/skin/tooltips.cpp
+++ b/src/skin/tooltips.cpp
@@ -29,6 +29,7 @@ QList<QString>& Tooltips::add(const QString& id) {
 void Tooltips::addStandardTooltips() {
     QString dropTracksHere = tr("Drop tracks from library, external file manager, or other decks/samplers here.");
     QString dragItem = tr("Drag this item to other decks/samplers, to crates and playlist or to external file manager.");
+    QString trackProperties = tr("Double-click to open the track properties editor");
     QString trackMenu = tr("Right-click to open the track context menu.");
     QString resetToDefault = tr("Reset to default value.");
     QString leftClick = tr("Left-click");
@@ -769,25 +770,28 @@ void Tooltips::addStandardTooltips() {
     add("track_artist")
             << tr("Track Artist")
             << tr("Displays the artist of the loaded track.")
-            << trackTags
+            << trackTags + "\n"
             << dropTracksHere
             << dragItem
+            << trackProperties
             << trackMenu;
 
     add("track_title")
             << tr("Track Title")
             << tr("Displays the title of the loaded track.")
-            << trackTags
+            << trackTags + "\n"
             << dropTracksHere
             << dragItem
+            << trackProperties
             << trackMenu;
 
     add("track_album")
             << tr("Track Album")
             << tr("Displays the album name of the loaded track.")
-            << trackTags
+            << trackTags + "\n"
             << dropTracksHere
             << dragItem
+            << trackProperties
             << trackMenu;
 
     add("track_key")
@@ -799,9 +803,11 @@ void Tooltips::addStandardTooltips() {
     add("text")
             << tr("Track Artist/Title")
             << tr("Displays the artist and title of the loaded track.")
-            << trackTags
+            << trackTags + "\n"
             << dropTracksHere
-            << dragItem;
+            << dragItem
+            << trackProperties
+            << trackMenu;
 
     add("time")
             << tr("Clock")

--- a/src/skin/tooltips.cpp
+++ b/src/skin/tooltips.cpp
@@ -29,11 +29,12 @@ QList<QString>& Tooltips::add(const QString& id) {
 void Tooltips::addStandardTooltips() {
     QString dropTracksHere = tr("Drop tracks from library, external file manager, or other decks/samplers here.");
     QString dragItem = tr("Drag this item to other decks/samplers, to crates and playlist or to external file manager.");
-    QString trackProperties = tr("Double-click to open the track properties editor");
-    QString trackMenu = tr("Right-click to open the track context menu.");
+    QString trackProperties = tr("Opens the track properties editor");
+    QString trackMenu = tr("Opens the track context menu.");
     QString resetToDefault = tr("Reset to default value.");
     QString leftClick = tr("Left-click");
     QString rightClick = tr("Right-click");
+    QString doubleClick = tr("Double-click");
     QString scrollWheel = tr("Scroll-wheel");
     QString shift = tr("Shift-key");
     QString loopActive = "(" + tr("loop active") + ")";
@@ -773,8 +774,8 @@ void Tooltips::addStandardTooltips() {
             << trackTags + "\n"
             << dropTracksHere
             << dragItem
-            << trackProperties
-            << trackMenu;
+            << QString("%1: %2").arg(doubleClick, trackProperties)
+            << QString("%1: %2").arg(rightClick, trackMenu);
 
     add("track_title")
             << tr("Track Title")
@@ -782,8 +783,8 @@ void Tooltips::addStandardTooltips() {
             << trackTags + "\n"
             << dropTracksHere
             << dragItem
-            << trackProperties
-            << trackMenu;
+            << QString("%1: %2").arg(doubleClick, trackProperties)
+            << QString("%1: %2").arg(rightClick, trackMenu);
 
     add("track_album")
             << tr("Track Album")
@@ -791,8 +792,8 @@ void Tooltips::addStandardTooltips() {
             << trackTags + "\n"
             << dropTracksHere
             << dragItem
-            << trackProperties
-            << trackMenu;
+            << QString("%1: %2").arg(doubleClick, trackProperties)
+            << QString("%1: %2").arg(rightClick, trackMenu);
 
     add("track_key")
             //: The musical key of a track
@@ -806,8 +807,8 @@ void Tooltips::addStandardTooltips() {
             << trackTags + "\n"
             << dropTracksHere
             << dragItem
-            << trackProperties
-            << trackMenu;
+            << QString("%1: %2").arg(doubleClick, trackProperties)
+            << QString("%1: %2").arg(rightClick, trackMenu);
 
     add("time")
             << tr("Clock")


### PR DESCRIPTION
Cover artwork
![image](https://user-images.githubusercontent.com/5934199/116833786-6c59f180-abbb-11eb-93ba-01fd08522207.png)

Tooltips of track labels artist, title, album or 'title, arttist'
![image](https://user-images.githubusercontent.com/5934199/116833801-8398df00-abbb-11eb-86ec-e24a77a033d3.png)

Tracl labels v2
The last commit streamlines that a bit by using the existing "Left-Click:" strings, but will violate string freeze I guess.
Either I revert that or we merge this for 2.3.1 to have as many completed translations as possible in 2.3.
![image](https://user-images.githubusercontent.com/5934199/116833915-12a5f700-abbc-11eb-91f9-7f205238ee62.png)

