### PR TITLE
Library: enable sorting in Hidden and Missing

### DIFF
--- a/src/library/dlghidden.cpp
+++ b/src/library/dlghidden.cpp
@@ -20,7 +20,7 @@ DlgHidden::DlgHidden(
                           pConfig,
                           pLibrary->trackCollections(),
                           parent->getTrackTableBackgroundColorOpacity(),
-                          false)) {
+                          true)) {
     setupUi(this);
     m_pTrackTableView->installEventFilter(pKeyboard);
 

--- a/src/library/dlgmissing.cpp
+++ b/src/library/dlgmissing.cpp
@@ -20,7 +20,7 @@ DlgMissing::DlgMissing(
                           pConfig,
                           pLibrary->trackCollections(),
                           parent->getTrackTableBackgroundColorOpacity(),
-                          false)) {
+                          true)) {
     setupUi(this);
     m_pTrackTableView->installEventFilter(pKeyboard);
 


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1924616
https://bugs.launchpad.net/mixxx/+bug/1828555
finally looked into a minor annoyance..and solving it was just flipping a bool.


Question is: why was it disabled int the first place? DlgHidden and DlgMissing were created with sorting=false in 2013 https://github.com/mixxxdj/mixxx/commit/ba0bd8db85c1c173f9dea662dc9f112264c47f2f and there's no comment about it, neither in the earlier nor in the current code.