### PR TITLE
Remove HIDAPI_STATIC, calculate it on the fly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2582,19 +2582,11 @@ endif()
 find_package(LibUSB)
 
 # USB HID controller support
-find_package(hidapi)
 option(HID "USB HID controller support" ON)
-# hidapi_VERSION is only available starting with 0.10.0
-default_option(HIDAPI_STATIC "Link HIDAPI library statically" "NOT hidapi_FOUND OR NOT hidapi_VERSION OR hidapi_VERSION VERSION_LESS 0.10.0")
 if(HID)
-  target_sources(mixxx-lib PRIVATE
-    src/controllers/hid/hidcontroller.cpp
-    src/controllers/hid/hidenumerator.cpp
-    src/controllers/hid/hidcontrollerpreset.cpp
-    src/controllers/hid/hidcontrollerpresetfilehandler.cpp
-  )
-  target_compile_definitions(mixxx-lib PUBLIC __HID__)
-  if(HIDAPI_STATIC)
+  find_package(hidapi)
+  # hidapi_VERSION is only available starting with 0.10.0
+  if(NOT hidapi_FOUND OR NOT hidapi_VERSION OR hidapi_VERSION VERSION_LESS 0.10.0)
     message(STATUS "Linking internal libhidapi statically")
     add_library(mixxx-hidapi STATIC EXCLUDE_FROM_ALL)
     target_include_directories(mixxx-hidapi SYSTEM PUBLIC lib/hidapi/hidapi)
@@ -2623,6 +2615,13 @@ if(HID)
     endif()
     target_link_libraries(mixxx-lib PUBLIC hidapi::hidapi)
   endif()
+  target_sources(mixxx-lib PRIVATE
+    src/controllers/hid/hidcontroller.cpp
+    src/controllers/hid/hidenumerator.cpp
+    src/controllers/hid/hidcontrollerpreset.cpp
+    src/controllers/hid/hidcontrollerpresetfilehandler.cpp
+  )
+  target_compile_definitions(mixxx-lib PUBLIC __HID__)
 endif()
 
 # USB Bulk controller support


### PR DESCRIPTION
The caching nature of this flag has caused a build error with obscure error messages when changing from 2.3 to main branch. 
Let's remove it. I don't see a use case for it. 

This is a side effect of the missing version support fixed here: 
https://github.com/mixxxdj/mixxx/pull/3730