### PR TITLE
Use CMAKE_PROJECT_VERSION for URLs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1673,8 +1673,10 @@ endif()
 
 get_target_property(BUILD_FLAGS mixxx-lib COMPILE_OPTIONS)
 
-# uses CMAKE_PROJECT_VERSION MIXXX_VERSION_PRERELEASE GIT_BRANCH GIT_DESCRIBE GIT_COMMIT_DATE BUILD_FLAGS
+# uses CMAKE_PROJECT_VERSION MIXXX_VERSION_PRERELEASE
 configure_file(src/version.h.in src/version.h @ONLY)
+# uses GIT_BRANCH GIT_DESCRIBE GIT_COMMIT_DATE BUILD_FLAGS
+configure_file(src/versiondetails.h.in src/versiondetails.h @ONLY)
 
 # Windows-only resource file
 if(WIN32)

--- a/src/defs_urls.h
+++ b/src/defs_urls.h
@@ -1,4 +1,12 @@
 #pragma once
+#include "version.h"
+
+// Two-level macro to stringize the numeric version definitions to a version
+// string. See https://gcc.gnu.org/onlinedocs/cpp/Stringizing.html for details.
+#define TO_STR(x) #x
+#define TO_VERSION_STR(major, minor) \
+    TO_STR(major)                    \
+    "." TO_STR(minor)
 
 #define MIXXX_WEBSITE_URL       "https://www.mixxx.org"
 #define MIXXX_WEBSITE_SHORT_URL "www.mixxx.org"
@@ -20,7 +28,9 @@
 #define MIXXX_WIKI_MIDI_SCRIPTING_URL \
     MIXXX_WIKI_URL "/Midi-Scripting"
 
-#define MIXXX_MANUAL_URL "https://manual.mixxx.org/2.3"
+#define MIXXX_MANUAL_URL                        \
+    "https://manual.mixxx.org/" TO_VERSION_STR( \
+            MIXXX_VERSION_MAJOR, MIXXX_VERSION_MINOR)
 #define MIXXX_MANUAL_SHORTCUTS_URL \
     MIXXX_MANUAL_URL "/chapters/controlling_mixxx.html#using-a-keyboard"
 #define MIXXX_MANUAL_CONTROLLERS_URL \

--- a/src/defs_urls.h
+++ b/src/defs_urls.h
@@ -33,6 +33,8 @@
             MIXXX_VERSION_MAJOR, MIXXX_VERSION_MINOR)
 #define MIXXX_MANUAL_SHORTCUTS_URL \
     MIXXX_MANUAL_URL "/chapters/controlling_mixxx.html#using-a-keyboard"
+#define MIXXX_MANUAL_COMMANDLINEOPTIONS_URL \
+    MIXXX_MANUAL_URL "/chapters/appendix.html#command-line-options"
 #define MIXXX_MANUAL_CONTROLLERS_URL \
     MIXXX_MANUAL_URL "/chapters/controlling_mixxx.html#using-midi-hid-controllers"
 #define MIXXX_MANUAL_CONTROLLERMANUAL_PREFIX \

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -4,6 +4,7 @@
 
 #include <QStandardPaths>
 
+#include "defs_urls.h"
 #include "sources/soundsourceproxy.h"
 #include "util/versionstore.h"
 
@@ -172,8 +173,5 @@ void CmdlineArgs::printUsage() {
 "\
 -h, --help              Display this help message and exit", stdout);
 
-    fputs("\n\n(For more information, see "
-          "https://manual.mixxx.org/2.3/chapters/"
-          "appendix.html#command-line-options)\n",
-            stdout);
+    fputs("\n\n(For more information, see " MIXXX_MANUAL_COMMANDLINEOPTIONS_URL ")\n", stdout);
 }

--- a/src/util/versionstore.cpp
+++ b/src/util/versionstore.cpp
@@ -28,8 +28,9 @@
 #include <taglib/taglib.h>
 #include <vorbis/codec.h>
 
-#define VERSION_STORE
 #include "version.h"
+#define VERSION_STORE
+#include "versiondetails.h"
 
 namespace {
 

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -1,14 +1,9 @@
 #pragma once
-
-#ifndef VERSION_STORE
-    #error "Include only from versionstore.cpp do avoid unnecessary recompile on every commit."
-#endif
-
+// This file contains the basic Mixxx version and prerelease name. This doesn't
+// change very often, so this file can be included in other parts of the code
+// where the version number needs to be known at the preprocessor stage and
+// using the VersionInfo class is not an option.
 #define MIXXX_VERSION_MAJOR @CMAKE_PROJECT_VERSION_MAJOR@
 #define MIXXX_VERSION_MINOR @CMAKE_PROJECT_VERSION_MINOR@
 #define MIXXX_VERSION_PATCH @CMAKE_PROJECT_VERSION_PATCH@
 #define MIXXX_VERSION_SUFFIX "@MIXXX_VERSION_PRERELEASE@"
-#define GIT_BRANCH "@GIT_BRANCH@"
-#define GIT_DESCRIBE "@GIT_DESCRIBE@"
-#define GIT_COMMIT_DATE "@GIT_COMMIT_DATE@"
-#define BUILD_FLAGS "@BUILD_FLAGS@"

--- a/src/versiondetails.h.in
+++ b/src/versiondetails.h.in
@@ -1,0 +1,14 @@
+#pragma once
+// This file contains the exact Mixxx git version and commit date. Since this
+// changes on every single commit (or even if just the dirty flag changes), all
+// files that include this will be recompile very often. Therefore, this should
+// only be included from versionstore.cpp.
+
+#ifndef VERSION_STORE
+    #error "Include only from versionstore.cpp do avoid unnecessary recompile on every commit."
+#endif
+
+#define GIT_BRANCH "@GIT_BRANCH@"
+#define GIT_DESCRIBE "@GIT_DESCRIBE@"
+#define GIT_COMMIT_DATE "@GIT_COMMIT_DATE@"
+#define BUILD_FLAGS "@BUILD_FLAGS@"


### PR DESCRIPTION
This replaces #3792 by using the existing MIXXX_VERSION_MAJOR and MIXXX_VERSION_MINOR compile definitions.

@daschuer I opened this PR because I'm not that good with explaining my ideas, and it's easier to grasp the idea when looking at code rather. This change is what I meant with my second point here: https://github.com/mixxxdj/mixxx/pull/3822#discussion_r626518018