### PR TITLE
CMake: Reconfigure to update git-dirty version when source files are changed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1195,7 +1195,8 @@ target_link_libraries(mixxx PUBLIC mixxx-lib)
 # any source file or git file changes.
 set_property(DIRECTORY APPEND
   PROPERTY CMAKE_CONFIGURE_DEPENDS
-  "${CMAKE_SOURCE_DIR}/.git/index;src;res")
+  "${CMAKE_SOURCE_DIR}/.git/index;${CMAKE_SOURCE_DIR}/src/version.h.in"
+)
 
 #
 # Installation and Packaging
@@ -1683,7 +1684,12 @@ execute_process(
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "src/version.tmp.h" "src/version.h"
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
 )
-
+add_custom_target(
+  mixxx-version ALL
+  COMMAND ${CMAKE_COMMAND} -E touch "${CMAKE_CURRENT_SOURCE_DIR}/src/version.h.in"
+  COMMENT "Invalidate version and force reconfiguration."
+)
+add_dependencies(mixxx-lib mixxx-version)
 
 # Windows-only resource file
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,10 +417,6 @@ else()
   message(STATUS "Support for ccache: ${CCACHE_SUPPORT}")
 endif()
 
-set_property(DIRECTORY APPEND
-    PROPERTY CMAKE_CONFIGURE_DEPENDS
-    "${CMAKE_SOURCE_DIR}/.git/index")
-
 if(CMAKE_VERSION VERSION_LESS "3.7.0")
   set(CMAKE_INCLUDE_CURRENT_DIR ON)
 endif()
@@ -1194,6 +1190,14 @@ endif()
 add_executable(mixxx WIN32 src/main.cpp)
 set_target_properties(mixxx-lib PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY}")
 target_link_libraries(mixxx PUBLIC mixxx-lib)
+
+# Make sure that the git version data is updated by CMake reconfiguration when
+# any source file or git file changes.
+get_target_property(MIXXX_LIB_SOURCES mixxx-lib SOURCES)
+get_target_property(MIXXX_SOURCES mixxx SOURCES)
+set_property(DIRECTORY APPEND
+  PROPERTY CMAKE_CONFIGURE_DEPENDS
+  "${CMAKE_SOURCE_DIR}/.git/index;${MIXXX_SOURCES};${MIXXX_LIB_SOURCES};res")
 
 #
 # Installation and Packaging

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1193,11 +1193,9 @@ target_link_libraries(mixxx PUBLIC mixxx-lib)
 
 # Make sure that the git version data is updated by CMake reconfiguration when
 # any source file or git file changes.
-get_target_property(MIXXX_LIB_SOURCES mixxx-lib SOURCES)
-get_target_property(MIXXX_SOURCES mixxx SOURCES)
 set_property(DIRECTORY APPEND
   PROPERTY CMAKE_CONFIGURE_DEPENDS
-  "${CMAKE_SOURCE_DIR}/.git/index;${MIXXX_SOURCES};${MIXXX_LIB_SOURCES};res")
+  "${CMAKE_SOURCE_DIR}/.git/index;src;res")
 
 #
 # Installation and Packaging
@@ -1678,7 +1676,14 @@ endif()
 get_target_property(BUILD_FLAGS mixxx-lib COMPILE_OPTIONS)
 
 # uses CMAKE_PROJECT_VERSION MIXXX_VERSION_PRERELEASE GIT_BRANCH GIT_DESCRIBE GIT_COMMIT_DATE BUILD_FLAGS
-configure_file(src/version.h.in src/version.h @ONLY)
+configure_file(src/version.h.in src/version.tmp.h @ONLY)
+# By first writing into a temporaty file and only updating version.h if it's
+# actually different, we can avoid unnecessary recompilations.
+execute_process(
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "src/version.tmp.h" "src/version.h"
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+)
+
 
 # Windows-only resource file
 if(WIN32)


### PR DESCRIPTION

Creating a file that is not part of the mixxx build won't cause reconfiguration or relinking:
```
$ touch ../src/somefile.cpp
$ make
[  2%] Built target benchmark
[...]
[ 99%] Built target gtest_main
[100%] Built target benchmark_main
```

Touching a file that *is* part of the mixxx source will cause reconfiguration/relinking, but not because the version changed but because the file date of that file changed. This would be the same without reconfiguration.

```
$ touch ../src/mixxx.cpp
$ make
-- Optimization level: portable
-- Enabling SS2 CPU optimizations (>= Pentium 4)
-- Git describe: 2.3-beta-3885-g1bdc0103c9
-- Git commit date: 2021-05-06T12:24:10+02:00
-- Git branch: cmake-git-version
-- Git commit count: 8169
[...]
-- Build files have been written to: /home/jan/Projects/mixxx/build
Consolidate compiler generated dependencies of target benchmark
[  2%] Built target benchmark
[ 14%] Built target mixxx-lib_autogen
Consolidate compiler generated dependencies of target mixxx-lib
[ 14%] Building CXX object CMakeFiles/mixxx-lib.dir/src/mixxx.cpp.o
[ 14%] Linking CXX static library libmixxx-lib.a
[ 86%] Built target mixxx-lib
[...]
[ 87%] Linking CXX executable mixxx-test
[ 99%] Built target mixxx-test
Consolidate compiler generated dependencies of target mixxx
[ 99%] Linking CXX executable mixxx
[ 99%] Built target mixxx
[...]
[100%] Built target benchmark_main
```

If you actually change a source file, the version is updated:
```
$ printf "\n" >> ../src/mixxxapplication.cpp
$ make
-- Optimization level: portable
-- Enabling SS2 CPU optimizations (>= Pentium 4)
-- Git describe: 2.3-beta-3885-gc44b87007c-modified
-- Git commit date: 2021-05-06T13:09:23+02:00
-- Git branch: cmake-git-describe-dirty-fix
-- Git commit count: 8169+
-- Found ccache: /usr/bin/ccache
[...]
-- Build files have been written to: /home/jan/Projects/mixxx/build
Consolidate compiler generated dependencies of target benchmark
[  2%] Built target benchmark
[...]
Consolidate compiler generated dependencies of target mixxx-lib
[ 14%] Building CXX object CMakeFiles/mixxx-lib.dir/src/mixxxapplication.cpp.o
[ 14%] Building CXX object CMakeFiles/mixxx-lib.dir/src/util/versionstore.cpp.o
[ 14%] Linking CXX static library libmixxx-lib.a
[ 86%] Built target mixxx-lib
[...]
[ 87%] Linking CXX executable mixxx-test
[ 99%] Built target mixxx-test
Consolidate compiler generated dependencies of target mixxx
[ 99%] Linking CXX executable mixxx
[ 99%] Built target mixxx
[...]
[100%] Built target benchmark_main
```