### PR TITLE
Backport minor changes from #2656 (Custom Tags)

### DIFF
--- a/src/audio/types.h
+++ b/src/audio/types.h
@@ -165,9 +165,12 @@ class Bitrate {
         return m_value > kValueDefault;
     }
 
-    /*implicit*/ operator value_t() const {
+    value_t value() const {
         DEBUG_ASSERT(m_value >= kValueDefault); // unsigned value
         return m_value;
+    }
+    /*implicit*/ operator value_t() const {
+        return value();
     }
 
   private:

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -522,8 +522,10 @@ void EngineBuffer::loadFakeTrack(TrackPointer pTrack, bool bPlay) {
     if (bPlay) {
         m_playButton->set((double)bPlay);
     }
-    slotTrackLoaded(pTrack, pTrack->getSampleRate(),
-                    pTrack->getSampleRate() * pTrack->getDurationInt());
+    slotTrackLoaded(
+            pTrack,
+            pTrack->getSampleRate(),
+            pTrack->getSampleRate() * pTrack->getDurationSecondsInt());
 }
 
 // WARNING: Always called from the EngineWorker thread pool

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -525,6 +525,8 @@ void EngineBuffer::loadFakeTrack(TrackPointer pTrack, bool bPlay) {
     slotTrackLoaded(
             pTrack,
             pTrack->getSampleRate(),
+            // TODO: Round to integer after multiplication with sample rate
+            // and not before?
             pTrack->getSampleRate() * pTrack->getDurationSecondsInt());
 }
 

--- a/src/library/trackcollectionmanager.h
+++ b/src/library/trackcollectionmanager.h
@@ -37,7 +37,7 @@ class TrackCollectionManager: public QObject,
             deleteTrackFn_t deleteTrackForTestingFn = nullptr);
     ~TrackCollectionManager() override;
 
-    TrackCollection* internalCollection() {
+    TrackCollection* internalCollection() const {
         DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
         return m_pInternalCollection;
     }

--- a/src/musicbrainz/tagfetcher.cpp
+++ b/src/musicbrainz/tagfetcher.cpp
@@ -79,7 +79,7 @@ void TagFetcher::slotFingerprintReady() {
     m_pAcoustIdTask = make_parented<mixxx::AcoustIdLookupTask>(
             &m_network,
             fingerprint,
-            m_pTrack->getDurationInt(),
+            m_pTrack->getDurationSecondsInt(),
             this);
     connect(m_pAcoustIdTask,
             &mixxx::AcoustIdLookupTask::succeeded,

--- a/src/track/bpm.cpp
+++ b/src/track/bpm.cpp
@@ -57,4 +57,12 @@ double Bpm::normalizeValue(double value) {
     }
 }
 
+//static
+QString Bpm::displayValueText(double value) {
+    if (!isValidValue(value)) {
+        return QString();
+    }
+    return QString("%1").arg(value, 3, 'f', 1);
+}
+
 } // namespace mixxx

--- a/src/track/bpm.h
+++ b/src/track/bpm.h
@@ -22,6 +22,8 @@ public:
 
     static double normalizeValue(double value);
 
+    static QString displayValueText(double value);
+
     // Adjusts floating-point values to match their string representation
     // in file tags to account for rounding errors and false positives
     // when checking for modifications.
@@ -75,6 +77,10 @@ public:
         default:
             return getValue() == bpm.getValue();
         }
+    }
+
+    QString displayText() const {
+        return displayValueText(m_value);
     }
 
 private:

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -297,8 +297,9 @@ bool Track::trySetBpmWhileLocked(double bpmValue) {
     return false;
 }
 
-QString Track::getBpmText() const {
-    return QString("%1").arg(getBpm(), 3,'f',1);
+double Track::getBpm() const {
+    const QMutexLocker lock(&m_qMutex);
+    return getBpmWhileLocked().getValue();
 }
 
 bool Track::trySetBpm(double bpmValue) {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -454,19 +454,18 @@ void Track::setDuration(double duration) {
     setDuration(mixxx::Duration::fromSeconds(duration));
 }
 
-double Track::getDuration(DurationRounding rounding) const {
+double Track::getDuration() const {
     QMutexLocker lock(&m_qMutex);
-    const auto durationSeconds =
-            m_record.getMetadata().getStreamInfo().getDuration().toDoubleSeconds();
-    switch (rounding) {
-    case DurationRounding::SECONDS:
-        return std::round(durationSeconds);
-    default:
-        return durationSeconds;
-    }
+    return m_record.getMetadata().getStreamInfo().getDuration().toDoubleSeconds();
 }
 
-QString Track::getDurationText(mixxx::Duration::Precision precision) const {
+int Track::getDurationSecondsInt() const {
+    QMutexLocker lock(&m_qMutex);
+    return static_cast<int>(m_record.getMetadata().getDurationSecondsRounded());
+}
+
+QString Track::getDurationText(
+        mixxx::Duration::Precision precision) const {
     QMutexLocker lock(&m_qMutex);
     return m_record.getMetadata().getDurationText(precision);
 }

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -108,13 +108,9 @@ class Track : public QObject {
 
     void setDuration(mixxx::Duration duration);
     void setDuration(double duration);
-    double getDuration() const {
-        return getDuration(DurationRounding::NONE);
-    }
+    double getDuration() const;
     // Returns the duration rounded to seconds
-    int getDurationInt() const {
-        return static_cast<int>(getDuration(DurationRounding::SECONDS));
-    }
+    int getDurationSecondsInt() const;
     // Returns the duration formatted as a string (H:MM:SS or H:MM:SS.cc or H:MM:SS.mmm)
     QString getDurationText(mixxx::Duration::Precision precision) const;
 
@@ -449,11 +445,6 @@ class Track : public QObject {
     void importPendingCueInfosMarkDirtyAndUnlock(
             QMutexLocker* pLock);
 
-    enum class DurationRounding {
-        SECONDS, // rounded to full seconds
-        NONE     // unmodified
-    };
-    double getDuration(DurationRounding rounding) const;
 
     ExportTrackMetadataResult exportMetadata(
             mixxx::MetadataSourcePointer pMetadataSource,

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -133,12 +133,11 @@ class Track : public QObject {
     bool trySetBpm(double bpm);
 
     // Returns BPM
-    double getBpm() const {
-        const QMutexLocker lock(&m_qMutex);
-        return getBpmWhileLocked().getValue();
-    }
+    double getBpm() const;
     // Returns BPM as a string
-    QString getBpmText() const;
+    QString getBpmText() const {
+        return mixxx::Bpm::displayValueText(getBpm());
+    }
 
     // A track with a locked BPM will not be re-analyzed by the beats or bpm
     // analyzer.

--- a/src/track/trackinfo.h
+++ b/src/track/trackinfo.h
@@ -64,6 +64,10 @@ class TrackInfo final {
     TrackInfo& operator=(TrackInfo&&) = default;
     TrackInfo& operator=(const TrackInfo&) = default;
 
+    QString getBpmText() const {
+        return getBpm().displayText();
+    }
+
     // Returns true if modified
     bool parseArtistTitleFromFileName(
             QString fileName,

--- a/src/util/db/fwdsqlquery.h
+++ b/src/util/db/fwdsqlquery.h
@@ -1,19 +1,16 @@
 #pragma once
 
-
+#include <QSqlError>
 #include <QSqlQuery>
 #include <QSqlRecord>
-#include <QSqlError>
-
-#include "util/db/dbid.h"
-#include "util/db/dbfieldindex.h"
 
 #include "util/assert.h"
+#include "util/db/dbfieldindex.h"
+#include "util/db/dbid.h"
 
 // forward declarations
 class SqlQueryFinisher;
 class FwdSqlQuerySelectResult;
-
 
 // A forward-only QSqlQuery that is prepared immediately
 // during initialization. It offers a limited set of functions
@@ -30,11 +27,14 @@ class FwdSqlQuerySelectResult;
 //
 // Please note that forward-only queries don't provide information
 // about the size of the result set!
-class FwdSqlQuery: protected QSqlQuery {
+class FwdSqlQuery : protected QSqlQuery {
     friend class SqlQueryFinisher;
     friend class FwdSqlQuerySelectResult;
 
   public:
+    FwdSqlQuery()
+            : m_prepared(false) {
+    }
     FwdSqlQuery(
             const QSqlDatabase& database,
             const QString& statement);
@@ -106,7 +106,5 @@ class FwdSqlQuery: protected QSqlQuery {
     bool fieldValueBoolean(DbFieldIndex fieldIndex) const;
 
   private:
-    FwdSqlQuery() = default; // hidden
-
     bool m_prepared;
 };

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -63,22 +63,29 @@ void WStarRating::slotTrackLoaded(TrackPointer pTrack) {
                     &WStarRating::slotTrackChanged);
             m_pCurrentTrack = pTrack;
         }
-        updateRating();
+        updateRatingFromTrack();
     }
 }
 
-void WStarRating::updateRating() {
-    if (m_pCurrentTrack) {
-        m_starRating.setStarCount(m_pCurrentTrack->getRating());
-    } else {
-        m_starRating.setStarCount(0);
-    }
+void WStarRating::setRating(int rating) {
+    // Check consistency with the connected track
+    DEBUG_ASSERT(!m_pCurrentTrack ||
+            m_pCurrentTrack->getRating() == rating);
+    m_starRating.setStarCount(rating);
     update();
+}
+
+void WStarRating::updateRatingFromTrack() {
+    if (m_pCurrentTrack) {
+        setRating(m_pCurrentTrack->getRating());
+    } else {
+        setRating(0);
+    }
 }
 
 void WStarRating::slotTrackChanged(TrackId trackId) {
     Q_UNUSED(trackId);
-    updateRating();
+    updateRatingFromTrack();
 }
 
 void WStarRating::paintEvent(QPaintEvent * /*unused*/) {
@@ -132,7 +139,7 @@ void WStarRating::slotStarsDown(double v) {
 
 void WStarRating::leaveEvent(QEvent* /*unused*/) {
     m_focused = false;
-    updateRating();
+    updateRatingFromTrack();
 }
 
 // The method uses basic linear algebra to find out which star is under the cursor.

--- a/src/widget/wstarrating.h
+++ b/src/widget/wstarrating.h
@@ -22,6 +22,11 @@ class WStarRating : public WWidget {
     virtual void setup(const QDomNode& node, const SkinContext& context);
     QSize sizeHint() const override;
 
+    /// Manually set a custom rating
+    ///
+    /// The value must be consistent with the current track if connected.
+    void setRating(int rating);
+
   public slots:
     void slotTrackLoaded(TrackPointer pTrack = TrackPointer());
 
@@ -44,7 +49,7 @@ class WStarRating : public WWidget {
     mutable QRect m_contentRect;
 
   private:
-    void updateRating();
+    void updateRatingFromTrack();
     int starAtPosition(int x);
     std::unique_ptr<ControlPushButton> m_pStarsUp;
     std::unique_ptr<ControlPushButton> m_pStarsDown;


### PR DESCRIPTION
A first set of minor changes backported from #2656. Please refer to the individual commit messages. Some extensions are not used yet, but extracting them beforehand helps to shrink the scope of #2656.

More PRs to follow. One after another.