### PR TITLE
metainfo (AppStream): fix donate link

### DIFF
--- a/res/linux/mixxx.metainfo.xml
+++ b/res/linux/mixxx.metainfo.xml
@@ -64,7 +64,7 @@
   </screenshots>
   <url type="homepage">https://mixxx.org</url>
   <url type="bugtracker">https://bugs.launchpad.net/mixxx</url>
-  <url type="donation">https://www.mixxx.org/support</url>
+  <url type="donation">https://mixxx.org/donate</url>
   <url type="help">https://www.mixxx.org/support</url>
   <url type="translate">https://www.transifex.com/mixxx-dj-software/public</url>
   <update_contact>mixxx-devel@lists.sourceforge.net</update_contact>


### PR DESCRIPTION
#3833 brought my attention to the metainfo file used by Gnome/KDE Appstream.
This updates the Donate link so users end up a little closer to the actual Donate button (don't wanna link the button directly because that might change and it's always nice to have visitors : )