### PR TITLE
MixxxMainWindow: Hide menubar during startup

### DIFF
--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -581,6 +581,7 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
     }
     emit skinLoaded();
 
+    m_pMenuBar->show();
 
     // Wait until all other ControlObjects are set up before initializing
     // controllers
@@ -687,7 +688,6 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
             &PlayerInfo::currentPlayingDeckChanged,
             this,
             &MixxxMainWindow::slotChangedPlayingDeck);
-    m_pMenuBar->show();
 
     // this has to be after the OpenGL widgets are created or depending on a
     // million different variables the first waveform may be horribly

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -211,6 +211,7 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
         m_pSettingsManager->settings(), pApp, args.getLocale());
 
     createMenuBar();
+    m_pMenuBar->hide();
 
     initializeWindow();
 
@@ -686,6 +687,7 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
             &PlayerInfo::currentPlayingDeckChanged,
             this,
             &MixxxMainWindow::slotChangedPlayingDeck);
+    m_pMenuBar->show();
 
     // this has to be after the OpenGL widgets are created or depending on a
     // million different variables the first waveform may be horribly


### PR DESCRIPTION
Right now, the style of the menu bar changes during startup. This
doesn't look nice. This commit simply hides the menubar during that
period.