### PR TITLE
Load tracks via TrackCollectionManager

### DIFF
--- a/src/analyzer/trackanalysisscheduler.cpp
+++ b/src/analyzer/trackanalysisscheduler.cpp
@@ -1,7 +1,7 @@
 #include "analyzer/trackanalysisscheduler.h"
 
 #include "library/library.h"
-#include "library/trackcollection.h"
+#include "library/trackcollectionmanager.h"
 #include "moc_trackanalysisscheduler.cpp"
 #include "util/logger.h"
 
@@ -275,7 +275,7 @@ bool TrackAnalysisScheduler::submitNextTrack(Worker* worker) {
         DEBUG_ASSERT(nextTrackId.isValid());
         if (nextTrackId.isValid()) {
             TrackPointer nextTrack =
-                    m_library->trackCollection().getTrackById(nextTrackId);
+                    m_library->trackCollections()->getTrackById(nextTrackId);
             if (nextTrack) {
                 if (m_pendingTrackIds.insert(nextTrackId).second) {
                     if (worker->submitNextTrack(std::move(nextTrack))) {

--- a/src/analyzer/trackanalysisscheduler.cpp
+++ b/src/analyzer/trackanalysisscheduler.cpp
@@ -275,7 +275,7 @@ bool TrackAnalysisScheduler::submitNextTrack(Worker* worker) {
         DEBUG_ASSERT(nextTrackId.isValid());
         if (nextTrackId.isValid()) {
             TrackPointer nextTrack =
-                    m_library->trackCollections()->getTrackById(nextTrackId);
+                    m_library->trackCollectionManager()->getTrackById(nextTrackId);
             if (nextTrack) {
                 if (m_pendingTrackIds.insert(nextTrackId).second) {
                     if (worker->submitNextTrack(std::move(nextTrack))) {

--- a/src/library/analysisfeature.cpp
+++ b/src/library/analysisfeature.cpp
@@ -6,7 +6,7 @@
 #include "library/dlganalysis.h"
 #include "library/library.h"
 #include "library/librarytablemodel.h"
-#include "library/trackcollection.h"
+#include "library/trackcollectionmanager.h"
 #include "moc_analysisfeature.cpp"
 #include "sources/soundsourceproxy.h"
 #include "util/debug.h"
@@ -226,8 +226,10 @@ void AnalysisFeature::onTrackAnalysisSchedulerFinished() {
 }
 
 bool AnalysisFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) {
-    QList<TrackId> trackIds = m_pLibrary->trackCollection().resolveTrackIdsFromUrls(urls,
-            !pSource);
+    const QList<TrackId> trackIds =
+            m_pLibrary->trackCollections()->resolveTrackIdsFromUrls(
+                    urls,
+                    !pSource);
     analyzeTracks(trackIds);
     return trackIds.size() > 0;
 }

--- a/src/library/analysisfeature.cpp
+++ b/src/library/analysisfeature.cpp
@@ -227,7 +227,7 @@ void AnalysisFeature::onTrackAnalysisSchedulerFinished() {
 
 bool AnalysisFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) {
     const QList<TrackId> trackIds =
-            m_pLibrary->trackCollections()->resolveTrackIdsFromUrls(
+            m_pLibrary->trackCollectionManager()->resolveTrackIdsFromUrls(
                     urls,
                     !pSource);
     analyzeTracks(trackIds);

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -46,17 +46,16 @@ namespace {
 } // anonymous namespace
 
 AutoDJFeature::AutoDJFeature(Library* pLibrary,
-                             UserSettingsPointer pConfig,
-                             PlayerManagerInterface* pPlayerManager)
+        UserSettingsPointer pConfig,
+        PlayerManagerInterface* pPlayerManager)
         : LibraryFeature(pLibrary, pConfig),
           m_pTrackCollection(pLibrary->trackCollections()->internalCollection()),
           m_playlistDao(m_pTrackCollection->getPlaylistDAO()),
           m_iAutoDJPlaylistId(findOrCrateAutoDjPlaylistId(m_playlistDao)),
           m_pAutoDJProcessor(nullptr),
           m_pAutoDJView(nullptr),
-          m_autoDjCratesDao(m_iAutoDJPlaylistId, m_pTrackCollection, m_pConfig),
+          m_autoDjCratesDao(m_iAutoDJPlaylistId, pLibrary->trackCollections(), m_pConfig),
           m_icon(":/images/library/ic_library_autodj.svg") {
-
     qRegisterMetaType<AutoDJProcessor::AutoDJState>("AutoDJState");
     m_pAutoDJProcessor = new AutoDJProcessor(
             this, m_pConfig, pPlayerManager, pLibrary->trackCollections(), m_iAutoDJPlaylistId);
@@ -169,7 +168,7 @@ bool AutoDJFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) {
     // Auto DJ playlist.
     // pSource != nullptr it is a drop from inside Mixxx and indicates all
     // tracks already in the DB
-    QList<TrackId> trackIds = m_pTrackCollection->resolveTrackIdsFromUrls(urls,
+    QList<TrackId> trackIds = m_pLibrary->trackCollections()->resolveTrackIdsFromUrls(urls,
             !pSource);
     if (trackIds.isEmpty()) {
         return false;
@@ -250,7 +249,7 @@ void AutoDJFeature::slotAddRandomTrack() {
             }
 
             if (randomTrackId.isValid()) {
-                pRandomTrack = m_pTrackCollection->getTrackById(randomTrackId);
+                pRandomTrack = m_pLibrary->trackCollections()->getTrackById(randomTrackId);
                 VERIFY_OR_DEBUG_ASSERT(pRandomTrack) {
                     qWarning() << "Track does not exist:"
                             << randomTrackId;

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -49,16 +49,19 @@ AutoDJFeature::AutoDJFeature(Library* pLibrary,
         UserSettingsPointer pConfig,
         PlayerManagerInterface* pPlayerManager)
         : LibraryFeature(pLibrary, pConfig),
-          m_pTrackCollection(pLibrary->trackCollections()->internalCollection()),
+          m_pTrackCollection(pLibrary->trackCollectionManager()->internalCollection()),
           m_playlistDao(m_pTrackCollection->getPlaylistDAO()),
           m_iAutoDJPlaylistId(findOrCrateAutoDjPlaylistId(m_playlistDao)),
           m_pAutoDJProcessor(nullptr),
           m_pAutoDJView(nullptr),
-          m_autoDjCratesDao(m_iAutoDJPlaylistId, pLibrary->trackCollections(), m_pConfig),
+          m_autoDjCratesDao(m_iAutoDJPlaylistId, pLibrary->trackCollectionManager(), m_pConfig),
           m_icon(":/images/library/ic_library_autodj.svg") {
     qRegisterMetaType<AutoDJProcessor::AutoDJState>("AutoDJState");
-    m_pAutoDJProcessor = new AutoDJProcessor(
-            this, m_pConfig, pPlayerManager, pLibrary->trackCollections(), m_iAutoDJPlaylistId);
+    m_pAutoDJProcessor = new AutoDJProcessor(this,
+            m_pConfig,
+            pPlayerManager,
+            pLibrary->trackCollectionManager(),
+            m_iAutoDJPlaylistId);
     connect(m_pAutoDJProcessor,
             &AutoDJProcessor::loadTrackToPlayer,
             this,
@@ -168,7 +171,7 @@ bool AutoDJFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) {
     // Auto DJ playlist.
     // pSource != nullptr it is a drop from inside Mixxx and indicates all
     // tracks already in the DB
-    QList<TrackId> trackIds = m_pLibrary->trackCollections()->resolveTrackIdsFromUrls(urls,
+    QList<TrackId> trackIds = m_pLibrary->trackCollectionManager()->resolveTrackIdsFromUrls(urls,
             !pSource);
     if (trackIds.isEmpty()) {
         return false;
@@ -249,7 +252,7 @@ void AutoDJFeature::slotAddRandomTrack() {
             }
 
             if (randomTrackId.isValid()) {
-                pRandomTrack = m_pLibrary->trackCollections()->getTrackById(randomTrackId);
+                pRandomTrack = m_pLibrary->trackCollectionManager()->getTrackById(randomTrackId);
                 VERIFY_OR_DEBUG_ASSERT(pRandomTrack) {
                     qWarning() << "Track does not exist:"
                             << randomTrackId;

--- a/src/library/banshee/bansheefeature.cpp
+++ b/src/library/banshee/bansheefeature.cpp
@@ -21,7 +21,8 @@ BansheeFeature::BansheeFeature(Library* pLibrary, UserSettingsPointer pConfig)
           m_cancelImport(false),
           m_icon(":/images/library/ic_library_banshee.svg") {
     Q_UNUSED(pConfig);
-    m_pBansheePlaylistModel = new BansheePlaylistModel(this, m_pLibrary->trackCollections(), &m_connection);
+    m_pBansheePlaylistModel = new BansheePlaylistModel(
+            this, m_pLibrary->trackCollectionManager(), &m_connection);
     m_isActivated = false;
     m_title = tr("Banshee");
 }
@@ -140,7 +141,10 @@ void BansheeFeature::appendTrackIdsFromRightClickIndex(QList<TrackId>* trackIds,
         int playlistID = item->getData().toInt();
         qDebug() << "BansheeFeature::appendTrackIdsFromRightClickIndex " << *pPlaylist << " " << playlistID;
         if (playlistID > 0) {
-            BansheePlaylistModel* pPlaylistModelToAdd = new BansheePlaylistModel(this, m_pLibrary->trackCollections(), &m_connection);
+            BansheePlaylistModel* pPlaylistModelToAdd =
+                    new BansheePlaylistModel(this,
+                            m_pLibrary->trackCollectionManager(),
+                            &m_connection);
             pPlaylistModelToAdd->setTableModel(playlistID);
             pPlaylistModelToAdd->select();
 

--- a/src/library/baseexternallibraryfeature.cpp
+++ b/src/library/baseexternallibraryfeature.cpp
@@ -20,7 +20,7 @@ BaseExternalLibraryFeature::BaseExternalLibraryFeature(
         Library* pLibrary,
         UserSettingsPointer pConfig)
         : LibraryFeature(pLibrary, pConfig),
-          m_pTrackCollection(pLibrary->trackCollections()->internalCollection()) {
+          m_pTrackCollection(pLibrary->trackCollectionManager()->internalCollection()) {
     m_pAddToAutoDJAction = make_parented<QAction>(tr("Add to Auto DJ Queue (bottom)"), this);
     connect(m_pAddToAutoDJAction,
             &QAction::triggered,

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -741,7 +741,7 @@ bool BaseSqlTableModel::setTrackValueForColumn(
 }
 
 TrackPointer BaseSqlTableModel::getTrack(const QModelIndex& index) const {
-    return m_pTrackCollectionManager->internalCollection()->getTrackById(getTrackId(index));
+    return m_pTrackCollectionManager->getTrackById(getTrackId(index));
 }
 
 TrackId BaseSqlTableModel::getTrackId(const QModelIndex& index) const {

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -1026,7 +1026,7 @@ void BaseTrackTableModel::emitDataChangedForMultipleRowsInColumn(
 
 TrackPointer BaseTrackTableModel::getTrackByRef(
         const TrackRef& trackRef) const {
-    return m_pTrackCollectionManager->internalCollection()->getTrackByRef(trackRef);
+    return m_pTrackCollectionManager->getTrackByRef(trackRef);
 }
 
 TrackId BaseTrackTableModel::doGetTrackId(

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -32,8 +32,8 @@ BrowseFeature::BrowseFeature(
         UserSettingsPointer pConfig,
         RecordingManager* pRecordingManager)
         : LibraryFeature(pLibrary, pConfig),
-          m_pTrackCollection(pLibrary->trackCollections()->internalCollection()),
-          m_browseModel(this, pLibrary->trackCollections(), pRecordingManager),
+          m_pTrackCollection(pLibrary->trackCollectionManager()->internalCollection()),
+          m_browseModel(this, pLibrary->trackCollectionManager(), pRecordingManager),
           m_proxyModel(&m_browseModel),
           m_pLastRightClickedItem(nullptr),
           m_icon(":/images/library/ic_library_computer.svg") {
@@ -485,7 +485,9 @@ QStringList BrowseFeature::getDefaultQuickLinks() const {
     bool osDownloadsDirIncluded = false;
     bool osDesktopDirIncluded = false;
     bool osDocumentsDirIncluded = false;
-    const auto rootDirs = m_pLibrary->trackCollections()->internalCollection()->loadRootDirs();
+    const auto rootDirs = m_pLibrary->trackCollectionManager()
+                                  ->internalCollection()
+                                  ->loadRootDirs();
     for (mixxx::FileInfo fileInfo : rootDirs) {
         // Skip directories we don't have permission to.
         if (!Sandbox::canAccess(&fileInfo)) {

--- a/src/library/dao/autodjcratesdao.h
+++ b/src/library/dao/autodjcratesdao.h
@@ -9,14 +9,14 @@
 #include "track/trackid.h"
 #include "util/class.h"
 
-class TrackCollection;
+class TrackCollectionManager;
 
 class AutoDJCratesDAO : public QObject {
     Q_OBJECT
   public:
     AutoDJCratesDAO(
             int iAutoDjPlaylistId,
-            TrackCollection* pTrackCollection,
+            TrackCollectionManager* pTrackCollectionManager,
             UserSettingsPointer a_pConfig);
     ~AutoDJCratesDAO() override;
 
@@ -99,7 +99,7 @@ class AutoDJCratesDAO : public QObject {
     // The auto-DJ playlist's ID.
     const int m_iAutoDjPlaylistId;
 
-    TrackCollection* m_pTrackCollection;
+    TrackCollectionManager* m_pTrackCollectionManager;
 
     // The SQL database we interact with.
     QSqlDatabase m_database;

--- a/src/library/dlganalysis.cpp
+++ b/src/library/dlganalysis.cpp
@@ -50,7 +50,8 @@ DlgAnalysis::DlgAnalysis(WLibrary* parent,
         box->insertWidget(1, m_pAnalysisLibraryTableView);
     }
 
-    m_pAnalysisLibraryTableModel = new AnalysisLibraryTableModel(this, pLibrary->trackCollections());
+    m_pAnalysisLibraryTableModel = new AnalysisLibraryTableModel(
+            this, pLibrary->trackCollectionManager());
     m_pAnalysisLibraryTableView->loadTrackModel(m_pAnalysisLibraryTableModel);
 
     connect(radioButtonRecentlyAdded,

--- a/src/library/dlghidden.cpp
+++ b/src/library/dlghidden.cpp
@@ -33,7 +33,7 @@ DlgHidden::DlgHidden(
         box->insertWidget(1, m_pTrackTableView);
     }
 
-    m_pHiddenTableModel = new HiddenTableModel(this, pLibrary->trackCollections());
+    m_pHiddenTableModel = new HiddenTableModel(this, pLibrary->trackCollectionManager());
     m_pTrackTableView->loadTrackModel(m_pHiddenTableModel);
 
     connect(btnUnhide,

--- a/src/library/dlgmissing.cpp
+++ b/src/library/dlgmissing.cpp
@@ -33,7 +33,7 @@ DlgMissing::DlgMissing(
         box->insertWidget(1, m_pTrackTableView);
     }
 
-    m_pMissingTableModel = new MissingTableModel(this, pLibrary->trackCollections());
+    m_pMissingTableModel = new MissingTableModel(this, pLibrary->trackCollectionManager());
     m_pTrackTableView->loadTrackModel(m_pMissingTableModel);
 
     connect(btnPurge, &QPushButton::clicked, m_pTrackTableView, &WTrackTableView::slotPurge);

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -85,24 +85,31 @@ ITunesFeature::ITunesFeature(Library* pLibrary, UserSettingsPointer pConfig)
             << "bpm"
             << "rating";
 
-    m_trackSource = QSharedPointer<BaseTrackCache>(
-            new BaseTrackCache(m_pLibrary->trackCollections()->internalCollection(), tableName, idColumn,
-                               columns, false));
-    m_pITunesTrackModel = new BaseExternalTrackModel(
-        this, m_pLibrary->trackCollections(),
-        "mixxx.db.model.itunes",
-        "itunes_library",
-        m_trackSource);
-    m_pITunesPlaylistModel = new BaseExternalPlaylistModel(
-        this, m_pLibrary->trackCollections(),
-        "mixxx.db.model.itunes_playlist",
-        "itunes_playlists",
-        "itunes_playlist_tracks",
-        m_trackSource);
+    m_trackSource = QSharedPointer<BaseTrackCache>(new BaseTrackCache(
+            m_pLibrary->trackCollectionManager()->internalCollection(),
+            tableName,
+            idColumn,
+            columns,
+            false));
+    m_pITunesTrackModel = new BaseExternalTrackModel(this,
+            m_pLibrary->trackCollectionManager(),
+            "mixxx.db.model.itunes",
+            "itunes_library",
+            m_trackSource);
+    m_pITunesPlaylistModel = new BaseExternalPlaylistModel(this,
+            m_pLibrary->trackCollectionManager(),
+            "mixxx.db.model.itunes_playlist",
+            "itunes_playlists",
+            "itunes_playlist_tracks",
+            m_trackSource);
     m_isActivated = false;
     m_title = tr("iTunes");
 
-    m_database = QSqlDatabase::cloneDatabase(m_pLibrary->trackCollections()->internalCollection()->database(), "ITUNES_SCANNER");
+    m_database =
+            QSqlDatabase::cloneDatabase(m_pLibrary->trackCollectionManager()
+                                                ->internalCollection()
+                                                ->database(),
+                    "ITUNES_SCANNER");
 
     // Open the database connection in this thread.
     if (!m_database.open()) {
@@ -123,12 +130,12 @@ ITunesFeature::~ITunesFeature() {
 }
 
 BaseSqlTableModel* ITunesFeature::getPlaylistModelForPlaylist(const QString& playlist) {
-    BaseExternalPlaylistModel* pModel = new BaseExternalPlaylistModel(
-        this, m_pLibrary->trackCollections(),
-        "mixxx.db.model.itunes_playlist",
-        "itunes_playlists",
-        "itunes_playlist_tracks",
-        m_trackSource);
+    BaseExternalPlaylistModel* pModel = new BaseExternalPlaylistModel(this,
+            m_pLibrary->trackCollectionManager(),
+            "mixxx.db.model.itunes_playlist",
+            "itunes_playlists",
+            "itunes_playlist_tracks",
+            m_trackSource);
     pModel->setPlaylist(playlist);
     return pModel;
 }

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -590,12 +590,6 @@ void Library::setEditMedatataSelectedClick(bool enabled) {
     emit setSelectedClick(enabled);
 }
 
-TrackCollection& Library::trackCollection() {
-    DEBUG_ASSERT(m_pTrackCollectionManager);
-    DEBUG_ASSERT(m_pTrackCollectionManager->internalCollection());
-    return *m_pTrackCollectionManager->internalCollection();
-}
-
 void Library::searchTracksInCollection(const QString& query) {
     VERIFY_OR_DEBUG_ASSERT(m_pMixxxLibraryFeature) {
         return;

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -257,7 +257,7 @@ Library::~Library() {
     // Empty but required due to forward declarations in header file!
 }
 
-TrackCollectionManager* Library::trackCollections() const {
+TrackCollectionManager* Library::trackCollectionManager() const {
     // Cannot be implemented inline due to forward declarations
     return m_pTrackCollectionManager;
 }

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -64,7 +64,7 @@ class Library: public QObject {
         return m_pDbConnectionPool;
     }
 
-    TrackCollectionManager* trackCollections() const;
+    TrackCollectionManager* trackCollectionManager() const;
 
     void bindSearchboxWidget(WSearchLineEdit* pSearchboxWidget);
     void bindSidebarWidget(WLibrarySidebar* sidebarWidget);

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -66,9 +66,6 @@ class Library: public QObject {
 
     TrackCollectionManager* trackCollections() const;
 
-    // Deprecated: Obtain directly from TrackCollectionManager
-    TrackCollection& trackCollection();
-
     void bindSearchboxWidget(WSearchLineEdit* pSearchboxWidget);
     void bindSidebarWidget(WLibrarySidebar* sidebarWidget);
     void bindLibraryWidget(WLibrary* libraryWidget,

--- a/src/library/librarytablemodel.cpp
+++ b/src/library/librarytablemodel.cpp
@@ -58,7 +58,7 @@ void LibraryTableModel::setTableModel() {
 int LibraryTableModel::addTracks(const QModelIndex& index,
         const QList<QString>& locations) {
     Q_UNUSED(index);
-    QList<TrackId> trackIds = m_pTrackCollectionManager->internalCollection()->resolveTrackIdsFromLocations(
+    QList<TrackId> trackIds = m_pTrackCollectionManager->resolveTrackIdsFromLocations(
             locations);
     select();
     return trackIds.size();

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -197,7 +197,7 @@ bool MixxxLibraryFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) 
     if (pSource) {
         return false;
     } else {
-        QList<TrackId> trackIds = m_pTrackCollection->resolveTrackIdsFromUrls(
+        QList<TrackId> trackIds = m_pLibrary->trackCollections()->resolveTrackIdsFromUrls(
                 urls, true);
         return trackIds.size() > 0;
     }

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -68,12 +68,12 @@ const QStringList DEFAULT_COLUMNS = {
 } // namespace
 
 MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
-                                         UserSettingsPointer pConfig)
+        UserSettingsPointer pConfig)
         : LibraryFeature(pLibrary, pConfig),
           kMissingTitle(tr("Missing Tracks")),
           kHiddenTitle(tr("Hidden Tracks")),
           m_icon(":/images/library/ic_library_tracks.svg"),
-          m_pTrackCollection(pLibrary->trackCollections()->internalCollection()),
+          m_pTrackCollection(pLibrary->trackCollectionManager()->internalCollection()),
           m_pLibraryTableModel(nullptr),
           m_pMissingView(nullptr),
           m_pHiddenView(nullptr) {
@@ -102,7 +102,9 @@ MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
     m_pTrackCollection->connectTrackSource(m_pBaseTrackCache);
 
     // These rely on the 'default' track source being present.
-    m_pLibraryTableModel = new LibraryTableModel(this, pLibrary->trackCollections(), "mixxx.db.model.library");
+    m_pLibraryTableModel = new LibraryTableModel(this,
+            pLibrary->trackCollectionManager(),
+            "mixxx.db.model.library");
 
     std::unique_ptr<TreeItem> pRootItem = TreeItem::newRoot(this);
     pRootItem->appendChild(kMissingTitle);
@@ -197,7 +199,7 @@ bool MixxxLibraryFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) 
     if (pSource) {
         return false;
     } else {
-        QList<TrackId> trackIds = m_pLibrary->trackCollections()->resolveTrackIdsFromUrls(
+        QList<TrackId> trackIds = m_pLibrary->trackCollectionManager()->resolveTrackIdsFromUrls(
                 urls, true);
         return trackIds.size() > 0;
     }

--- a/src/library/playlisttablemodel.cpp
+++ b/src/library/playlisttablemodel.cpp
@@ -172,7 +172,7 @@ int PlaylistTableModel::addTracks(const QModelIndex& index,
         return 0;
     }
 
-    QList<TrackId> trackIds = m_pTrackCollectionManager->internalCollection()->resolveTrackIdsFromLocations(
+    QList<TrackId> trackIds = m_pTrackCollectionManager->resolveTrackIdsFromLocations(
             locations);
 
     const int positionColumn = fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_POSITION);

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -26,7 +26,7 @@ DlgRecording::DlgRecording(
                           pLibrary,
                           parent->getTrackTableBackgroundColorOpacity(),
                           true)),
-          m_browseModel(this, pLibrary->trackCollections(), pRecordingManager),
+          m_browseModel(this, pLibrary->trackCollectionManager(), pRecordingManager),
           m_proxyModel(&m_browseModel),
           m_bytesRecordedStr("--"),
           m_durationRecordedStr("--:--"),

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -1364,7 +1364,8 @@ RekordboxFeature::RekordboxFeature(
             << LIBRARYTABLE_KEY;
     m_trackSource->setSearchColumns(searchColumns);
 
-    m_pRekordboxPlaylistModel = new RekordboxPlaylistModel(this, pLibrary->trackCollections(), m_trackSource);
+    m_pRekordboxPlaylistModel = new RekordboxPlaylistModel(
+            this, pLibrary->trackCollectionManager(), m_trackSource);
 
     m_title = tr("Rekordbox");
 
@@ -1427,7 +1428,8 @@ void RekordboxFeature::htmlLinkClicked(const QUrl& link) {
 }
 
 BaseSqlTableModel* RekordboxFeature::getPlaylistModelForPlaylist(const QString& playlist) {
-    RekordboxPlaylistModel* model = new RekordboxPlaylistModel(this, m_pLibrary->trackCollections(), m_trackSource);
+    RekordboxPlaylistModel* model = new RekordboxPlaylistModel(
+            this, m_pLibrary->trackCollectionManager(), m_trackSource);
     model->setPlaylist(playlist);
     return model;
 }

--- a/src/library/rhythmbox/rhythmboxfeature.cpp
+++ b/src/library/rhythmbox/rhythmboxfeature.cpp
@@ -46,23 +46,26 @@ RhythmboxFeature::RhythmboxFeature(Library* pLibrary, UserSettingsPointer pConfi
                   << "genre";
     m_trackSource->setSearchColumns(searchColumns);
 
-    m_pRhythmboxTrackModel = new BaseExternalTrackModel(
-        this, pLibrary->trackCollections(),
-        "mixxx.db.model.rhythmbox",
-        "rhythmbox_library",
-        m_trackSource);
-    m_pRhythmboxPlaylistModel = new BaseExternalPlaylistModel(
-        this, pLibrary->trackCollections(),
-        "mixxx.db.model.rhythmbox_playlist",
-        "rhythmbox_playlists",
-        "rhythmbox_playlist_tracks",
-        m_trackSource);
+    m_pRhythmboxTrackModel = new BaseExternalTrackModel(this,
+            pLibrary->trackCollectionManager(),
+            "mixxx.db.model.rhythmbox",
+            "rhythmbox_library",
+            m_trackSource);
+    m_pRhythmboxPlaylistModel = new BaseExternalPlaylistModel(this,
+            pLibrary->trackCollectionManager(),
+            "mixxx.db.model.rhythmbox_playlist",
+            "rhythmbox_playlists",
+            "rhythmbox_playlist_tracks",
+            m_trackSource);
 
     m_isActivated =  false;
     m_title = tr("Rhythmbox");
 
-    m_database = QSqlDatabase::cloneDatabase(pLibrary->trackCollections()->internalCollection()->database(),
-                                             "RHYTHMBOX_SCANNER");
+    m_database =
+            QSqlDatabase::cloneDatabase(pLibrary->trackCollectionManager()
+                                                ->internalCollection()
+                                                ->database(),
+                    "RHYTHMBOX_SCANNER");
 
     //Open the database connection in this thread.
     if (!m_database.open()) {
@@ -86,12 +89,12 @@ RhythmboxFeature::~RhythmboxFeature() {
 }
 
 BaseSqlTableModel* RhythmboxFeature::getPlaylistModelForPlaylist(const QString& playlist) {
-    BaseExternalPlaylistModel* pModel = new BaseExternalPlaylistModel(
-                                            this, m_pLibrary->trackCollections(),
-                                            "mixxx.db.model.rhythmbox_playlist",
-                                            "rhythmbox_playlists",
-                                            "rhythmbox_playlist_tracks",
-                                            m_trackSource);
+    BaseExternalPlaylistModel* pModel = new BaseExternalPlaylistModel(this,
+            m_pLibrary->trackCollectionManager(),
+            "mixxx.db.model.rhythmbox_playlist",
+            "rhythmbox_playlists",
+            "rhythmbox_playlist_tracks",
+            m_trackSource);
     pModel->setPlaylist(playlist);
     return pModel;
 }

--- a/src/library/serato/seratofeature.cpp
+++ b/src/library/serato/seratofeature.cpp
@@ -884,7 +884,8 @@ SeratoFeature::SeratoFeature(
     m_trackSource = QSharedPointer<BaseTrackCache>(
             new BaseTrackCache(m_pTrackCollection, kSeratoLibraryTable, LIBRARYTABLE_ID, columns, false));
     m_trackSource->setSearchColumns(searchColumns);
-    m_pSeratoPlaylistModel = new SeratoPlaylistModel(this, pLibrary->trackCollections(), m_trackSource);
+    m_pSeratoPlaylistModel = new SeratoPlaylistModel(
+            this, pLibrary->trackCollectionManager(), m_trackSource);
 
     m_title = tr("Serato");
 
@@ -948,7 +949,8 @@ void SeratoFeature::htmlLinkClicked(const QUrl& link) {
 }
 
 BaseSqlTableModel* SeratoFeature::getPlaylistModelForPlaylist(const QString& playlist) {
-    SeratoPlaylistModel* model = new SeratoPlaylistModel(this, m_pLibrary->trackCollections(), m_trackSource);
+    SeratoPlaylistModel* model = new SeratoPlaylistModel(
+            this, m_pLibrary->trackCollectionManager(), m_trackSource);
     model->setPlaylist(playlist);
     return model;
 }

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -76,17 +76,6 @@ class TrackCollection : public QObject,
         return m_pTrackSource;
     }
 
-    // This function returns a track ID of all file in the list not already visible,
-    // it adds and unhides the tracks as well.
-    QList<TrackId> resolveTrackIds(
-            const QList<mixxx::FileInfo>& trackFiles,
-            TrackDAO::ResolveTrackIdFlags flags);
-    QList<TrackId> resolveTrackIdsFromUrls(
-            const QList<QUrl>& urls,
-            bool addMissing);
-    QList<TrackId> resolveTrackIdsFromLocations(
-            const QList<QString>& locations);
-
     bool insertCrate(const Crate& crate, CrateId* pCrateId = nullptr);
     bool updateCrate(const Crate& crate);
     bool deleteCrate(CrateId crateId);
@@ -95,11 +84,6 @@ class TrackCollection : public QObject,
 
     bool updateAutoDjCrate(CrateId crateId, bool isAutoDjSource);
 
-    TrackPointer getTrackById(
-            TrackId trackId) const;
-
-    TrackPointer getTrackByRef(
-            const TrackRef& trackRef) const;
     TrackId getTrackIdByRef(
             const TrackRef& trackRef) const;
 
@@ -134,6 +118,29 @@ class TrackCollection : public QObject,
     explicit TrackCollection(const UserSettingsPointer& pConfig)
             : TrackCollection(nullptr, pConfig) {
     }
+
+    // TODO: All functions that load tracks or that may add tracks
+    // will soon require additional context data that is provided
+    // by TrackCollectionManager as an additional parameter. These
+    // functions must only be invoked by TrackCollectionManager and
+    // therefore don't appear in the public interface of this class.
+    // See also: https://github.com/mixxxdj/mixxx/pull/2656
+
+    // This function returns a track ID of all file in the list not already visible,
+    // it adds and unhides the tracks as well.
+    QList<TrackId> resolveTrackIds(
+            const QList<mixxx::FileInfo>& trackFiles,
+            TrackDAO::ResolveTrackIdFlags flags);
+    QList<TrackId> resolveTrackIdsFromUrls(
+            const QList<QUrl>& urls,
+            bool addMissing);
+    QList<TrackId> resolveTrackIdsFromLocations(
+            const QList<QString>& locations);
+
+    TrackPointer getTrackById(
+            TrackId trackId) const;
+    TrackPointer getTrackByRef(
+            const TrackRef& trackRef) const;
 
     TrackPointer getOrAddTrack(
             const TrackRef& trackRef,

--- a/src/library/trackcollectioniterator.cpp
+++ b/src/library/trackcollectioniterator.cpp
@@ -1,6 +1,6 @@
 #include "library/trackcollectioniterator.h"
 
-#include "library/trackcollection.h"
+#include "library/trackcollectionmanager.h"
 
 namespace mixxx {
 
@@ -11,7 +11,7 @@ std::optional<TrackPointer> TrackByIdCollectionIterator::nextItem() {
         return std::nullopt;
     }
     const auto trackPtr =
-            m_pTrackCollection->getTrackById(*nextTrackId);
+            m_pTrackCollectionManager->getTrackById(*nextTrackId);
     if (!trackPtr) {
         return std::nullopt;
     }

--- a/src/library/trackcollectioniterator.h
+++ b/src/library/trackcollectioniterator.h
@@ -7,7 +7,7 @@
 
 #include "track/trackiterator.h"
 
-class TrackCollection;
+class TrackCollectionManager;
 
 namespace mixxx {
 
@@ -17,11 +17,11 @@ class TrackByIdCollectionIterator final
         : public virtual TrackPointerIterator {
   public:
     TrackByIdCollectionIterator(
-            const TrackCollection* pTrackCollection,
+            const TrackCollectionManager* pTrackCollectionManager,
             const TrackIdList& trackIds)
-            : m_pTrackCollection(pTrackCollection),
+            : m_pTrackCollectionManager(pTrackCollectionManager),
               m_trackIdListIter(trackIds) {
-        DEBUG_ASSERT(m_pTrackCollection);
+        DEBUG_ASSERT(m_pTrackCollectionManager);
     }
     ~TrackByIdCollectionIterator() override = default;
 
@@ -36,7 +36,7 @@ class TrackByIdCollectionIterator final
     std::optional<TrackPointer> nextItem() override;
 
   private:
-    const TrackCollection* const m_pTrackCollection;
+    const TrackCollectionManager* const m_pTrackCollectionManager;
     TrackIdListIterator m_trackIdListIter;
 };
 

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -521,3 +521,29 @@ void TrackCollectionManager::afterTracksRelocated(
         externalTrackCollection->relocateTracks(relocatedTracks);
     }
 }
+
+TrackPointer TrackCollectionManager::getTrackById(
+        TrackId trackId) const {
+    return internalCollection()->getTrackById(
+            trackId);
+}
+
+TrackPointer TrackCollectionManager::getTrackByRef(
+        const TrackRef& trackRef) const {
+    return internalCollection()->getTrackByRef(
+            trackRef);
+}
+
+QList<TrackId> TrackCollectionManager::resolveTrackIdsFromUrls(
+        const QList<QUrl>& urls,
+        bool addMissing) const {
+    return internalCollection()->resolveTrackIdsFromUrls(
+            urls,
+            addMissing);
+}
+
+QList<TrackId> TrackCollectionManager::resolveTrackIdsFromLocations(
+        const QList<QString>& locations) const {
+    return internalCollection()->resolveTrackIdsFromLocations(
+            locations);
+}

--- a/src/library/trackcollectionmanager.h
+++ b/src/library/trackcollectionmanager.h
@@ -47,6 +47,16 @@ class TrackCollectionManager: public QObject,
         return m_externalCollections;
     }
 
+    TrackPointer getTrackById(
+            TrackId trackId) const;
+    TrackPointer getTrackByRef(
+            const TrackRef& trackRef) const;
+    QList<TrackId> resolveTrackIdsFromUrls(
+            const QList<QUrl>& urls,
+            bool addMissing) const;
+    QList<TrackId> resolveTrackIdsFromLocations(
+            const QList<QString>& locations) const;
+
     bool hideTracks(const QList<TrackId>& trackIds) const;
     bool unhideTracks(const QList<TrackId>& trackIds) const;
     void hideAllTracks(const QDir& rootDir) const;

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -28,13 +28,14 @@ namespace {
 constexpr QChar kUnsafeFilenameReplacement = '-';
 }
 
-BasePlaylistFeature::BasePlaylistFeature(
-        Library* pLibrary,
+BasePlaylistFeature::BasePlaylistFeature(Library* pLibrary,
         UserSettingsPointer pConfig,
         PlaylistTableModel* pModel,
         const QString& rootViewName)
         : BaseTrackSetFeature(pLibrary, pConfig, rootViewName),
-          m_playlistDao(pLibrary->trackCollections()->internalCollection()->getPlaylistDAO()),
+          m_playlistDao(pLibrary->trackCollectionManager()
+                                ->internalCollection()
+                                ->getPlaylistDAO()),
           m_pPlaylistTableModel(pModel) {
     pModel->setParent(this);
 
@@ -557,7 +558,7 @@ void BasePlaylistFeature::slotExportPlaylist() {
     // This will only export songs that we think exist on default
     QScopedPointer<PlaylistTableModel> pPlaylistTableModel(
             new PlaylistTableModel(this,
-                    m_pLibrary->trackCollections(),
+                    m_pLibrary->trackCollectionManager(),
                     "mixxx.db.model.playlist_export"));
 
     pPlaylistTableModel->setTableModel(m_pPlaylistTableModel->getPlaylist());
@@ -599,7 +600,7 @@ void BasePlaylistFeature::slotExportPlaylist() {
 void BasePlaylistFeature::slotExportTrackFiles() {
     QScopedPointer<PlaylistTableModel> pPlaylistTableModel(
             new PlaylistTableModel(this,
-                    m_pLibrary->trackCollections(),
+                    m_pLibrary->trackCollectionManager(),
                     "mixxx.db.model.playlist_export"));
 
     pPlaylistTableModel->setTableModel(m_pPlaylistTableModel->getPlaylist());

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -44,8 +44,8 @@ CrateFeature::CrateFeature(Library* pLibrary,
         : BaseTrackSetFeature(pLibrary, pConfig, "CRATEHOME"),
           m_cratesIcon(":/images/library/ic_library_crates.svg"),
           m_lockedCrateIcon(":/images/library/ic_library_locked_tracklist.svg"),
-          m_pTrackCollection(pLibrary->trackCollections()->internalCollection()),
-          m_crateTableModel(this, pLibrary->trackCollections()) {
+          m_pTrackCollection(pLibrary->trackCollectionManager()->internalCollection()),
+          m_crateTableModel(this, pLibrary->trackCollectionManager()) {
     initActions();
 
     // construct child model
@@ -238,7 +238,7 @@ bool CrateFeature::dropAcceptChild(
     // pSource != nullptr it is a drop from inside Mixxx and indicates all
     // tracks already in the DB
     QList<TrackId> trackIds =
-            m_pLibrary->trackCollections()->resolveTrackIdsFromUrls(urls, !pSource);
+            m_pLibrary->trackCollectionManager()->resolveTrackIdsFromUrls(urls, !pSource);
     if (!trackIds.size()) {
         return false;
     }
@@ -729,7 +729,7 @@ void CrateFeature::slotExportPlaylist() {
     // Create list of files of the crate
     // Create a new table model since the main one might have an active search.
     QScopedPointer<CrateTableModel> pCrateTableModel(
-            new CrateTableModel(this, m_pLibrary->trackCollections()));
+            new CrateTableModel(this, m_pLibrary->trackCollectionManager()));
     pCrateTableModel->selectCrate(m_crateTableModel.selectedCrate());
     pCrateTableModel->select();
 
@@ -755,7 +755,7 @@ void CrateFeature::slotExportPlaylist() {
 void CrateFeature::slotExportTrackFiles() {
     // Create a new table model since the main one might have an active search.
     QScopedPointer<CrateTableModel> pCrateTableModel(
-            new CrateTableModel(this, m_pLibrary->trackCollections()));
+            new CrateTableModel(this, m_pLibrary->trackCollectionManager()));
     pCrateTableModel->selectCrate(m_crateTableModel.selectedCrate());
     pCrateTableModel->select();
 

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -238,7 +238,7 @@ bool CrateFeature::dropAcceptChild(
     // pSource != nullptr it is a drop from inside Mixxx and indicates all
     // tracks already in the DB
     QList<TrackId> trackIds =
-            m_pTrackCollection->resolveTrackIdsFromUrls(urls, !pSource);
+            m_pLibrary->trackCollections()->resolveTrackIdsFromUrls(urls, !pSource);
     if (!trackIds.size()) {
         return false;
     }

--- a/src/library/trackset/crate/cratetablemodel.cpp
+++ b/src/library/trackset/crate/cratetablemodel.cpp
@@ -132,8 +132,8 @@ int CrateTableModel::addTracks(
     Q_UNUSED(index);
     // If a track is dropped but it isn't in the library, then add it because
     // the user probably dropped a file from outside Mixxx into this crate.
-    QList<TrackId> trackIds = m_pTrackCollectionManager->internalCollection()
-                                      ->resolveTrackIdsFromLocations(locations);
+    QList<TrackId> trackIds =
+            m_pTrackCollectionManager->resolveTrackIdsFromLocations(locations);
     if (!m_pTrackCollectionManager->internalCollection()->addCrateTracks(
                 m_selectedCrate, trackIds)) {
         qWarning() << "CrateTableModel::addTracks could not add"

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -40,7 +40,7 @@ PlaylistFeature::PlaylistFeature(Library* pLibrary, UserSettingsPointer pConfig)
         : BasePlaylistFeature(pLibrary,
                   pConfig,
                   new PlaylistTableModel(nullptr,
-                          pLibrary->trackCollections(),
+                          pLibrary->trackCollectionManager(),
                           "mixxx.db.model.playlist"),
                   QStringLiteral("PLAYLISTHOME")),
           m_icon(QStringLiteral(":/images/library/ic_library_playlist.svg")) {
@@ -110,7 +110,7 @@ bool PlaylistFeature::dropAcceptChild(
     // playlist.
     // pSource != nullptr it is a drop from inside Mixxx and indicates all
     // tracks already in the DB
-    QList<TrackId> trackIds = m_pLibrary->trackCollections()
+    QList<TrackId> trackIds = m_pLibrary->trackCollectionManager()
                                       ->resolveTrackIdsFromUrls(urls, !pSource);
     if (!trackIds.size()) {
         return false;
@@ -131,7 +131,7 @@ bool PlaylistFeature::dragMoveAcceptChild(const QModelIndex& index, const QUrl& 
 
 QList<BasePlaylistFeature::IdAndLabel> PlaylistFeature::createPlaylistLabels() {
     QSqlDatabase database =
-            m_pLibrary->trackCollections()->internalCollection()->database();
+            m_pLibrary->trackCollectionManager()->internalCollection()->database();
 
     QList<BasePlaylistFeature::IdAndLabel> playlistLabels;
     QString queryString = QStringLiteral(
@@ -200,7 +200,7 @@ QList<BasePlaylistFeature::IdAndLabel> PlaylistFeature::createPlaylistLabels() {
 QString PlaylistFeature::fetchPlaylistLabel(int playlistId) {
     // Setup the sidebar playlist model
     QSqlDatabase database =
-            m_pLibrary->trackCollections()->internalCollection()->database();
+            m_pLibrary->trackCollectionManager()->internalCollection()->database();
     QSqlTableModel playlistTableModel(this, database);
     playlistTableModel.setTable("PlaylistsCountsDurations");
     QString filter = "id=" + QString::number(playlistId);

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -111,7 +111,6 @@ bool PlaylistFeature::dropAcceptChild(
     // pSource != nullptr it is a drop from inside Mixxx and indicates all
     // tracks already in the DB
     QList<TrackId> trackIds = m_pLibrary->trackCollections()
-                                      ->internalCollection()
                                       ->resolveTrackIdsFromUrls(urls, !pSource);
     if (!trackIds.size()) {
         return false;

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -32,7 +32,7 @@ SetlogFeature::SetlogFeature(
                   pConfig,
                   new PlaylistTableModel(
                           nullptr,
-                          pLibrary->trackCollections(),
+                          pLibrary->trackCollectionManager(),
                           "mixxx.db.model.setlog",
                           /*keep deleted tracks*/ true),
                   QStringLiteral("SETLOGHOME")),
@@ -40,7 +40,9 @@ SetlogFeature::SetlogFeature(
           m_libraryWidget(nullptr),
           m_icon(QStringLiteral(":/images/library/ic_library_history.svg")) {
     // clear old empty entries
-    ScopedTransaction transaction(pLibrary->trackCollections()->internalCollection()->database());
+    ScopedTransaction transaction(pLibrary->trackCollectionManager()
+                                          ->internalCollection()
+                                          ->database());
     m_playlistDao.deleteAllPlaylistsWithFewerTracks(PlaylistDAO::HiddenType::PLHT_SET_LOG, 1);
     transaction.commit();
 
@@ -154,7 +156,7 @@ void SetlogFeature::onRightClickChild(const QPoint& globalPos, const QModelIndex
 QModelIndex SetlogFeature::constructChildModel(int selectedId) {
     // Setup the sidebar playlist model
     QSqlTableModel playlistTableModel(this,
-            m_pLibrary->trackCollections()->internalCollection()->database());
+            m_pLibrary->trackCollectionManager()->internalCollection()->database());
     playlistTableModel.setTable("Playlists");
     playlistTableModel.setFilter("hidden=" + QString::number(PlaylistDAO::PLHT_SET_LOG));
     playlistTableModel.setSort(
@@ -230,7 +232,7 @@ QModelIndex SetlogFeature::constructChildModel(int selectedId) {
 QString SetlogFeature::fetchPlaylistLabel(int playlistId) {
     // Setup the sidebar playlist model
     QSqlTableModel playlistTableModel(this,
-            m_pLibrary->trackCollections()->internalCollection()->database());
+            m_pLibrary->trackCollectionManager()->internalCollection()->database());
     playlistTableModel.setTable("Playlists");
     QString filter = "id=" + QString::number(playlistId);
     playlistTableModel.setFilter(filter);

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -84,9 +84,12 @@ TraktorFeature::TraktorFeature(Library* pLibrary, UserSettingsPointer pConfig)
             << "bitrate"
             << "bpm"
             << "key";
-    m_trackSource = QSharedPointer<BaseTrackCache>(
-            new BaseTrackCache(pLibrary->trackCollections()->internalCollection(), tableName, idColumn,
-                           columns, false));
+    m_trackSource = QSharedPointer<BaseTrackCache>(new BaseTrackCache(
+            pLibrary->trackCollectionManager()->internalCollection(),
+            tableName,
+            idColumn,
+            columns,
+            false));
     QStringList searchColumns;
     searchColumns << "artist"
                   << "album"
@@ -97,13 +100,18 @@ TraktorFeature::TraktorFeature(Library* pLibrary, UserSettingsPointer pConfig)
     m_trackSource->setSearchColumns(searchColumns);
 
     m_isActivated = false;
-    m_pTraktorTableModel = new TraktorTrackModel(this, pLibrary->trackCollections(), m_trackSource);
-    m_pTraktorPlaylistModel = new TraktorPlaylistModel(this, pLibrary->trackCollections(), m_trackSource);
+    m_pTraktorTableModel = new TraktorTrackModel(
+            this, pLibrary->trackCollectionManager(), m_trackSource);
+    m_pTraktorPlaylistModel = new TraktorPlaylistModel(
+            this, pLibrary->trackCollectionManager(), m_trackSource);
 
     m_title = tr("Traktor");
 
-    m_database = QSqlDatabase::cloneDatabase(pLibrary->trackCollections()->internalCollection()->database(),
-                                             "TRAKTOR_SCANNER");
+    m_database =
+            QSqlDatabase::cloneDatabase(pLibrary->trackCollectionManager()
+                                                ->internalCollection()
+                                                ->database(),
+                    "TRAKTOR_SCANNER");
 
     //Open the database connection in this thread.
     if (!m_database.open()) {
@@ -125,7 +133,8 @@ TraktorFeature::~TraktorFeature() {
 }
 
 BaseSqlTableModel* TraktorFeature::getPlaylistModelForPlaylist(const QString& playlist) {
-    TraktorPlaylistModel* pModel = new TraktorPlaylistModel(this, m_pLibrary->trackCollections(), m_trackSource);
+    TraktorPlaylistModel* pModel = new TraktorPlaylistModel(
+            this, m_pLibrary->trackCollectionManager(), m_trackSource);
     pModel->setPlaylist(playlist);
     return pModel;
 }

--- a/src/preferences/dialog/dlgprefcolors.cpp
+++ b/src/preferences/dialog/dlgprefcolors.cpp
@@ -37,7 +37,7 @@ DlgPrefColors::DlgPrefColors(
           m_pReplaceCueColorDlg(new DlgReplaceCueColor(
                   pConfig,
                   pLibrary->dbConnectionPool(),
-                  pLibrary->trackCollections(),
+                  pLibrary->trackCollectionManager(),
                   this)) {
     setupUi(this);
     comboBoxHotcueColors->setIconSize(kPalettePreviewSize);
@@ -46,7 +46,7 @@ DlgPrefColors::DlgPrefColors(
     m_pReplaceCueColorDlg->setHidden(true);
     connect(m_pReplaceCueColorDlg,
             &DlgReplaceCueColor::databaseTracksChanged,
-            &(pLibrary->trackCollections()->internalCollection()->getTrackDAO()),
+            &(pLibrary->trackCollectionManager()->internalCollection()->getTrackDAO()),
             &TrackDAO::slotDatabaseTracksChanged);
 
     connect(comboBoxHotcueColors,

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -107,7 +107,7 @@ DlgPreferences::DlgPreferences(
     DlgPrefLibrary* plibraryPage = new DlgPrefLibrary(this, m_pConfig, pLibrary);
     connect(plibraryPage,
             &DlgPrefLibrary::scanLibrary,
-            pLibrary->trackCollections(),
+            pLibrary->trackCollectionManager(),
             &TrackCollectionManager::startLibraryScan);
     addPageWidget(PreferencesPage(plibraryPage,
                           new QTreeWidgetItem(contentsTreeWidget, QTreeWidgetItem::Type)),

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -156,7 +156,9 @@ void DlgPrefLibrary::initializeDirList() {
     const QString selected = dirList->currentIndex().data().toString();
     // clear and fill model
     m_dirListModel.clear();
-    const auto rootDirs = m_pLibrary->trackCollections()->internalCollection()->loadRootDirs();
+    const auto rootDirs = m_pLibrary->trackCollectionManager()
+                                  ->internalCollection()
+                                  ->loadRootDirs();
     for (const mixxx::FileInfo& rootDir : rootDirs) {
         m_dirListModel.appendRow(new QStandardItem(rootDir.location()));
     }

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -620,7 +620,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped) {
 
     // Load the track and mark it playing (as the loadTrackToPlayer signal would
     // have connected to this eventually).
-    TrackPointer pTrack = internalCollection()->getTrackById(testId);
+    TrackPointer pTrack = trackCollections()->getTrackById(testId);
     deck1.slotLoadTrack(pTrack, true);
 
     // Signal that the request to load pTrack succeeded.

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -208,9 +208,11 @@ class AutoDJProcessorTest : public LibraryTest {
         EXPECT_CALL(*pPlayerManager, getPlayer(QString("[Channel3]"))).Times(1);
         EXPECT_CALL(*pPlayerManager, getPlayer(QString("[Channel4]"))).Times(1);
 
-        pProcessor.reset(new MockAutoDJProcessor(
-                nullptr, config(), pPlayerManager.data(),
-                trackCollections(), m_iAutoDJPlaylistId));
+        pProcessor.reset(new MockAutoDJProcessor(nullptr,
+                config(),
+                pPlayerManager.data(),
+                trackCollectionManager(),
+                m_iAutoDJPlaylistId));
     }
 
     virtual ~AutoDJProcessorTest() {
@@ -553,9 +555,11 @@ TEST_F(AutoDJProcessorTest, TransitionTimeLoadedFromConfig) {
     // because otherwise the new object will try to create COs that already
     // exist because they were created by the previous instance.
     pProcessor.reset();
-    pProcessor.reset(new MockAutoDJProcessor(
-            nullptr, config(), pPlayerManager.data(),
-            trackCollections(), m_iAutoDJPlaylistId));
+    pProcessor.reset(new MockAutoDJProcessor(nullptr,
+            config(),
+            pPlayerManager.data(),
+            trackCollectionManager(),
+            m_iAutoDJPlaylistId));
     EXPECT_EQ(25, pProcessor->getTransitionTime());
 }
 
@@ -620,7 +624,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped) {
 
     // Load the track and mark it playing (as the loadTrackToPlayer signal would
     // have connected to this eventually).
-    TrackPointer pTrack = trackCollections()->getTrackById(testId);
+    TrackPointer pTrack = trackCollectionManager()->getTrackById(testId);
     deck1.slotLoadTrack(pTrack, true);
 
     // Signal that the request to load pTrack succeeded.

--- a/src/test/librarytest.h
+++ b/src/test/librarytest.h
@@ -15,12 +15,12 @@ class LibraryTest : public MixxxDbTest {
     LibraryTest();
     ~LibraryTest() override = default;
 
-    TrackCollectionManager* trackCollections() const {
+    TrackCollectionManager* trackCollectionManager() const {
         return m_pTrackCollectionManager.get();
     }
 
     TrackCollection* internalCollection() const {
-        return trackCollections()->internalCollection();
+        return trackCollectionManager()->internalCollection();
     }
 
     TrackPointer getOrAddTrackByLocation(

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -242,9 +242,9 @@ void WTrackMenu::createActions() {
                 &WTrackMenu::slotExportMetadataIntoFileTags);
 
         m_updateInExternalTrackCollections.reserve(
-                m_pLibrary->trackCollections()->externalCollections().size());
+                m_pLibrary->trackCollectionManager()->externalCollections().size());
         for (auto* const pExternalTrackCollection :
-                m_pLibrary->trackCollections()->externalCollections()) {
+                m_pLibrary->trackCollectionManager()->externalCollections()) {
             UpdateExternalTrackCollection updateInExternalTrackCollection;
             updateInExternalTrackCollection.externalTrackCollection = pExternalTrackCollection;
             updateInExternalTrackCollection.action = new QAction(
@@ -877,7 +877,7 @@ int WTrackMenu::applyTrackPointerOperation(
             operationMode);
     return modalOperation.processTracks(
             progressLabelText,
-            m_pLibrary->trackCollections(),
+            m_pLibrary->trackCollectionManager(),
             pTrackPointerIter.get());
 }
 
@@ -975,7 +975,7 @@ void WTrackMenu::slotPopulatePlaylistMenu() {
         return;
     }
     m_pPlaylistMenu->clear();
-    const PlaylistDAO& playlistDao = m_pLibrary->trackCollections()
+    const PlaylistDAO& playlistDao = m_pLibrary->trackCollectionManager()
                                              ->internalCollection()
                                              ->getPlaylistDAO();
     QMap<QString, int> playlists;
@@ -1014,7 +1014,7 @@ void WTrackMenu::addSelectionToPlaylist(int iPlaylistId) {
         return;
     }
 
-    PlaylistDAO& playlistDao = m_pLibrary->trackCollections()
+    PlaylistDAO& playlistDao = m_pLibrary->trackCollectionManager()
                                        ->internalCollection()
                                        ->getPlaylistDAO();
 
@@ -1056,7 +1056,7 @@ void WTrackMenu::addSelectionToPlaylist(int iPlaylistId) {
     }
 
     // TODO(XXX): Care whether the append succeeded.
-    m_pLibrary->trackCollections()->unhideTracks(trackIds);
+    m_pLibrary->trackCollectionManager()->unhideTracks(trackIds);
     playlistDao.appendTracksToPlaylist(trackIds, iPlaylistId);
 }
 
@@ -1071,7 +1071,7 @@ void WTrackMenu::slotPopulateCrateMenu() {
     const TrackIdList trackIds = getTrackIds();
 
     CrateSummarySelectResult allCrates(
-            m_pLibrary->trackCollections()
+            m_pLibrary->trackCollectionManager()
                     ->internalCollection()
                     ->crates()
                     .selectCratesWithTrackCount(trackIds));
@@ -1141,19 +1141,21 @@ void WTrackMenu::updateSelectionCrates(QWidget* pWidget) {
     pCheckBox->setTristate(false);
     if (!pCheckBox->isChecked()) {
         if (crateId.isValid()) {
-            m_pLibrary->trackCollections()
+            m_pLibrary->trackCollectionManager()
                     ->internalCollection()
                     ->removeCrateTracks(crateId, trackIds);
         }
     } else {
         if (!crateId.isValid()) { // i.e. a new crate is suppose to be created
             crateId = CrateFeatureHelper(
-                    m_pLibrary->trackCollections()->internalCollection(), m_pConfig)
+                    m_pLibrary->trackCollectionManager()->internalCollection(), m_pConfig)
                               .createEmptyCrate();
         }
         if (crateId.isValid()) {
-            m_pLibrary->trackCollections()->unhideTracks(trackIds);
-            m_pLibrary->trackCollections()->internalCollection()->addCrateTracks(crateId, trackIds);
+            m_pLibrary->trackCollectionManager()->unhideTracks(trackIds);
+            m_pLibrary->trackCollectionManager()
+                    ->internalCollection()
+                    ->addCrateTracks(crateId, trackIds);
         }
     }
 }
@@ -1167,12 +1169,14 @@ void WTrackMenu::addSelectionToNewCrate() {
     }
 
     CrateId crateId = CrateFeatureHelper(
-            m_pLibrary->trackCollections()->internalCollection(), m_pConfig)
+            m_pLibrary->trackCollectionManager()->internalCollection(), m_pConfig)
                               .createEmptyCrate();
 
     if (crateId.isValid()) {
-        m_pLibrary->trackCollections()->unhideTracks(trackIds);
-        m_pLibrary->trackCollections()->internalCollection()->addCrateTracks(crateId, trackIds);
+        m_pLibrary->trackCollectionManager()->unhideTracks(trackIds);
+        m_pLibrary->trackCollectionManager()
+                ->internalCollection()
+                ->addCrateTracks(crateId, trackIds);
     }
 }
 
@@ -1511,7 +1515,7 @@ void WTrackMenu::slotClearWaveform() {
     const auto progressLabelText =
             tr("Resetting waveform of %n track(s)", "", getTrackCount());
     AnalysisDao& analysisDao =
-            m_pLibrary->trackCollections()->internalCollection()->getAnalysisDAO();
+            m_pLibrary->trackCollectionManager()->internalCollection()->getAnalysisDAO();
     const auto trackOperator =
             ResetWaveformTrackPointerOperation(analysisDao);
     applyTrackPointerOperation(
@@ -1567,7 +1571,7 @@ void WTrackMenu::slotClearAllMetadata() {
     const auto progressLabelText =
             tr("Resetting all performance metadata of %n track(s)", "", getTrackCount());
     AnalysisDao& analysisDao =
-            m_pLibrary->trackCollections()->internalCollection()->getAnalysisDAO();
+            m_pLibrary->trackCollectionManager()->internalCollection()->getAnalysisDAO();
     const auto trackOperator =
             ClearAllPerformanceMetadataTrackPointerOperation(analysisDao);
     applyTrackPointerOperation(
@@ -1643,12 +1647,12 @@ void WTrackMenu::addToAutoDJ(PlaylistDAO::AutoDJSendLoc loc) {
         return;
     }
 
-    PlaylistDAO& playlistDao = m_pLibrary->trackCollections()
+    PlaylistDAO& playlistDao = m_pLibrary->trackCollectionManager()
                                        ->internalCollection()
                                        ->getPlaylistDAO();
 
     // TODO(XXX): Care whether the append succeeded.
-    m_pLibrary->trackCollections()->unhideTracks(trackIds);
+    m_pLibrary->trackCollectionManager()->unhideTracks(trackIds);
     playlistDao.addTracksToAutoDJQueue(trackIds, loc);
 }
 

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -851,12 +851,12 @@ void WTrackTableView::addToAutoDJ(PlaylistDAO::AutoDJSendLoc loc) {
         return;
     }
 
-    PlaylistDAO& playlistDao = m_pLibrary->trackCollections()
+    PlaylistDAO& playlistDao = m_pLibrary->trackCollectionManager()
                                        ->internalCollection()
                                        ->getPlaylistDAO();
 
     // TODO(XXX): Care whether the append succeeded.
-    m_pLibrary->trackCollections()->unhideTracks(trackIds);
+    m_pLibrary->trackCollectionManager()->unhideTracks(trackIds);
     playlistDao.addTracksToAutoDJQueue(trackIds, loc);
 }
 


### PR DESCRIPTION
The TrackCollectionManager will soon store and provide additional configuration data like the custom tags mapping that is required as context data when loading tracks.

- `TrackCollection`: Reduce visibility of functions that should not be invoked without `TrackCollectionManager` (see TODO comment in TrackCollection.h)
- Use `TrackCollectionManager` instead of accessing the internal `TrackCollection` directly

No functional changes.