### PR TITLE
show preferences when configured skin failed to load

### DIFF
--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -545,12 +545,28 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
             m_pVCManager,
             m_pEffectsManager,
             m_pRecordingManager);
+    // TODO(ronso0) After failed skin load user may just hit Okay without
+    // having chosen another skin. Show menubar so the user can quit or open
+    // the preferences again manually.
+    // #3839
     if (!m_pWidgetParent) {
-        reportCriticalErrorAndQuit(
-                "default skin cannot be loaded see <b>mixxx</b> trace for more information.");
-
         m_pWidgetParent = oldWidget;
-        //TODO (XXX) add dialog to warn user and launch skin choice page
+        QMessageBox::StandardButton btn = QMessageBox::warning(
+                this,
+                VersionStore::applicationName(),
+                tr("The configured skin <b>%1</b> can not be loaded.<br>"
+                   "Choose another skin?")
+                        .arg(pConfig->getValueString(ConfigKey("[Config]", "ResizableSkin"))),
+                QMessageBox::Ok | QMessageBox::Cancel,
+                QMessageBox::Ok);
+        if (btn == QMessageBox::Ok) {
+            m_pPrefDlg->show();
+            m_pPrefDlg->showInterfacePage();
+        } else {
+            reportCriticalErrorAndQuit(tr(
+                    "See the Mixxx log file for more information about the skin error.\n"
+                    "Mixxx will now close"));
+        }
     } else {
         m_pMenuBar->setStyleSheet(m_pWidgetParent->styleSheet());
     }

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -326,6 +326,11 @@ void DlgPreferences::showSoundHardwarePage() {
     contentsTreeWidget->setCurrentItem(m_pSoundButton);
 }
 
+void DlgPreferences::showInterfacePage() {
+    switchToPage(m_interfacePage);
+    contentsTreeWidget->setCurrentItem(m_pInterfaceButton);
+}
+
 bool DlgPreferences::eventFilter(QObject* o, QEvent* e) {
     // Send a close signal if dialog is closing
     if (e->type() == QEvent::Hide) {

--- a/src/preferences/dialog/dlgpreferences.h
+++ b/src/preferences/dialog/dlgpreferences.h
@@ -76,6 +76,7 @@ class DlgPreferences : public QDialog, public Ui::DlgPreferencesDlg {
   public slots:
     void changePage(QTreeWidgetItem* pCurrent, QTreeWidgetItem* pPrevious);
     void showSoundHardwarePage();
+    void showInterfacePage();
     void slotButtonPressed(QAbstractButton* pButton);
   signals:
     void closeDlg();


### PR DESCRIPTION
WIP
Addressing a 9 year old TODO
Actually this should happen only with a broken skin from the user directory.
Though, in that case the user has no chance to get back to a working state from within the GUI.
(only by editing mixxx.cfg)

Candidate for 2.3, though when no one wants to squeeze that in right now it can wait for 2.3.1 We got along without it until now.
rebase after #3839 is merged