### PR TITLE
CMake: Restrict transitive dependencies between libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1098,7 +1098,7 @@ if(WIN32)
     target_compile_definitions(mixxx-lib PUBLIC WIN64)
   endif()
 
-  target_link_libraries(mixxx-lib PUBLIC shell32)
+  target_link_libraries(mixxx-lib PRIVATE shell32)
 
   if(MSVC)
     if(NOT STATIC_DEPS OR CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -1124,7 +1124,7 @@ endif()
 # The mixxx executable
 add_executable(mixxx WIN32 src/main.cpp)
 set_target_properties(mixxx-lib PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY}")
-target_link_libraries(mixxx PUBLIC mixxx-lib)
+target_link_libraries(mixxx PRIVATE mixxx-lib)
 
 #
 # Installation and Packaging
@@ -1500,7 +1500,7 @@ add_executable(mixxx-test
   src/test/wwidgetstack_test.cpp
 )
 set_target_properties(mixxx-test PROPERTIES AUTOMOC ON)
-target_link_libraries(mixxx-test PUBLIC mixxx-lib gtest gmock)
+target_link_libraries(mixxx-test PRIVATE mixxx-lib gtest gmock)
 
 #
 # Benchmark tests
@@ -1516,7 +1516,7 @@ add_subdirectory(
   "${CMAKE_CURRENT_SOURCE_DIR}/lib/benchmark"
   "${CMAKE_CURRENT_BINARY_DIR}/lib/benchmark"
 )
-target_link_libraries(mixxx-test PUBLIC benchmark)
+target_link_libraries(mixxx-test PRIVATE benchmark)
 
 # Test Suite
 include(CTest)
@@ -1665,14 +1665,14 @@ option(STATIC_DEPS "Link dependencies statically" OFF)
 
 # Chromaprint
 find_package(Chromaprint REQUIRED)
-target_link_libraries(mixxx-lib PUBLIC Chromaprint::Chromaprint)
+target_link_libraries(mixxx-lib PRIVATE Chromaprint::Chromaprint)
 if(WIN32)
   if(STATIC_DEPS)
     target_compile_definitions(mixxx-lib PUBLIC CHROMAPRINT_NODLL)
   endif()
    # Chromaprint is always built statically and needs fftw.
   find_package(FFTW REQUIRED)
-  target_link_libraries(mixxx-lib PUBLIC FFTW::FFTW)
+  target_link_libraries(mixxx-lib PRIVATE FFTW::FFTW)
 endif()
 
 # Ebur128
@@ -1707,10 +1707,10 @@ if(EBUR128_STATIC)
     IMPORTED_LOCATION "${EBUR128_LIBRARY_LOCATION}"
     INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/lib/libebur128/ebur128"
   )
-  target_link_libraries(mixxx-lib PUBLIC mixxx-libebur128)
+  target_link_libraries(mixxx-lib PRIVATE mixxx-libebur128)
 else()
   message(STATUS "Linking libebur128 dynamically")
-  target_link_libraries(mixxx-lib PUBLIC Ebur128::Ebur128)
+  target_link_libraries(mixxx-lib PRIVATE Ebur128::Ebur128)
 endif()
 
 # FidLib
@@ -1724,14 +1724,14 @@ else()
   target_compile_definitions(fidlib PRIVATE T_LINUX)
 endif()
 target_include_directories(mixxx-lib SYSTEM PUBLIC lib/fidlib)
-target_link_libraries(mixxx-lib PUBLIC fidlib)
+target_link_libraries(mixxx-lib PRIVATE fidlib)
 
 # KeyFinder
 find_package(KeyFinder)
 option(KEYFINDER "KeyFinder support" ON)
 if(KEYFINDER)
   if (KeyFinder_FOUND)
-    target_link_libraries(mixxx-lib PUBLIC KeyFinder::KeyFinder)
+    target_link_libraries(mixxx-lib PRIVATE KeyFinder::KeyFinder)
   else()
     # If KeyFinder is built statically, we need FFTW
     find_package(FFTW REQUIRED)
@@ -1770,7 +1770,7 @@ if(KEYFINDER)
     set_target_properties(mixxx-keyfinder PROPERTIES IMPORTED_LOCATION "${KeyFinder_INSTALL_DIR}/${KeyFinder_LIBRARY}")
     target_link_libraries(mixxx-keyfinder INTERFACE FFTW::FFTW)
     target_include_directories(mixxx-keyfinder INTERFACE "${KeyFinder_INSTALL_DIR}/include")
-    target_link_libraries(mixxx-lib PUBLIC mixxx-keyfinder)
+    target_link_libraries(mixxx-lib PRIVATE mixxx-keyfinder)
   endif()
 
   target_sources(mixxx-lib PRIVATE src/analyzer/plugins/analyzerkeyfinder.cpp)
@@ -1779,7 +1779,7 @@ endif()
 
 # FLAC
 find_package(FLAC REQUIRED)
-target_link_libraries(mixxx-lib PUBLIC FLAC::FLAC)
+target_link_libraries(mixxx-lib PRIVATE FLAC::FLAC)
 if(WIN32 AND STATIC_DEPS)
   target_compile_definitions(mixxx-lib PUBLIC FLAC__NO_DLL)
 endif()
@@ -1791,7 +1791,7 @@ add_library(FpClassify STATIC EXCLUDE_FROM_ALL src/util/fpclassify.cpp)
 if(GNU_GCC OR LLVM_CLANG)
   target_compile_options(FpClassify PRIVATE -fno-fast-math)
 endif()
-target_link_libraries(mixxx-lib PUBLIC FpClassify)
+target_link_libraries(mixxx-lib PRIVATE FpClassify)
 
 # googletest
 # Required to use the macro FRIEND_TEST from <gtest/gtest_prod.h>
@@ -1800,7 +1800,7 @@ target_include_directories(mixxx-lib SYSTEM PUBLIC "${gtest_SOURCE_DIR}/include"
 
 # LAME
 find_package(mp3lame REQUIRED)
-target_link_libraries(mixxx-lib PUBLIC mp3lame::mp3lame)
+target_link_libraries(mixxx-lib PRIVATE mp3lame::mp3lame)
 
 # Kaitai for reading Rekordbox libraries
 add_library(Kaitai STATIC EXCLUDE_FROM_ALL
@@ -1808,7 +1808,7 @@ add_library(Kaitai STATIC EXCLUDE_FROM_ALL
 )
 target_include_directories(Kaitai SYSTEM PUBLIC lib/kaitai)
 target_compile_definitions(Kaitai PRIVATE KS_STR_ENCODING_NONE)
-target_link_libraries(mixxx-lib PUBLIC Kaitai)
+target_link_libraries(mixxx-lib PRIVATE Kaitai)
 
 # For determining MP3 timing offset cases in Rekordbox library feature
 add_library(MP3GuessEnc STATIC EXCLUDE_FROM_ALL
@@ -1821,37 +1821,37 @@ if(WIN32)
   target_compile_definitions(MP3GuessEnc PRIVATE __WINDOWS__)
 endif()
 target_include_directories(MP3GuessEnc SYSTEM PUBLIC lib/mp3guessenc-0.27.4)
-target_link_libraries(mixxx-lib PUBLIC MP3GuessEnc)
+target_link_libraries(mixxx-lib PRIVATE MP3GuessEnc)
 
 # OpenGL
 set(OpenGL_GL_PREFERENCE "GLVND")
 find_package(OpenGL REQUIRED)
-target_link_libraries(mixxx-lib PUBLIC OpenGL::GL)
+target_link_libraries(mixxx-lib PRIVATE OpenGL::GL)
 
 # Ogg
 find_package(Ogg REQUIRED)
-target_link_libraries(mixxx-lib PUBLIC Ogg::ogg)
+target_link_libraries(mixxx-lib PRIVATE Ogg::ogg)
 
 # Vorbis
 find_package(Vorbis REQUIRED)
-target_link_libraries(mixxx-lib PUBLIC Vorbis::vorbis Vorbis::vorbisenc Vorbis::vorbisfile)
+target_link_libraries(mixxx-lib PRIVATE Vorbis::vorbis Vorbis::vorbisenc Vorbis::vorbisfile)
 
 # PortAudio
 find_package(PortAudio REQUIRED)
 target_include_directories(mixxx-lib SYSTEM PUBLIC ${PortAudio_INCLUDE_DIRS})
-target_link_libraries(mixxx-lib PUBLIC ${PortAudio_LIBRARIES})
+target_link_libraries(mixxx-lib PRIVATE ${PortAudio_LIBRARIES})
 
 # PortAudio Ring Buffer
 add_library(PortAudioRingBuffer STATIC EXCLUDE_FROM_ALL
   lib/portaudio/pa_ringbuffer.c
 )
 target_include_directories(mixxx-lib SYSTEM PUBLIC lib/portaudio)
-target_link_libraries(mixxx-lib PUBLIC PortAudioRingBuffer)
+target_link_libraries(mixxx-lib PRIVATE PortAudioRingBuffer)
 
 # PortMidi
 find_package(PortMidi REQUIRED)
 target_include_directories(mixxx-lib SYSTEM PUBLIC ${PortMidi_INCLUDE_DIRS})
-target_link_libraries(mixxx-lib PUBLIC ${PortMidi_LIBRARIES})
+target_link_libraries(mixxx-lib PRIVATE ${PortMidi_LIBRARIES})
 
 # Protobuf
 if(STATIC_DEPS)
@@ -1859,7 +1859,7 @@ if(STATIC_DEPS)
   mark_as_advanced(Protobuf_USE_STATIC_LIBS)
 endif()
 add_subdirectory(src/proto)
-target_link_libraries(mixxx-lib PUBLIC mixxx-proto)
+target_link_libraries(mixxx-lib PRIVATE mixxx-proto)
 
 # Rigtorp SPSC Queue
 # https://github.com/rigtorp/SPSCQueue
@@ -1900,7 +1900,7 @@ if(UNIX AND NOT APPLE)
   find_package(X11 REQUIRED)
   find_package(Qt5 COMPONENTS X11Extras DBus REQUIRED)
   target_include_directories(mixxx-lib SYSTEM PUBLIC "${X11_INCLUDE_DIR}")
-  target_link_libraries(mixxx-lib PUBLIC
+  target_link_libraries(mixxx-lib PRIVATE
     "${X11_LIBRARIES}"
     Qt5::X11Extras
     Qt5::DBus
@@ -1909,7 +1909,7 @@ elseif(WIN32)
   get_target_property(QT5_TYPE Qt5::Core TYPE)
   if(QT5_TYPE STREQUAL "STATIC_LIBRARY")
     target_compile_definitions(mixxx-lib PUBLIC QT_NODLL)
-    target_link_libraries(mixxx-lib PUBLIC
+    target_link_libraries(mixxx-lib PRIVATE
       # Pulled from qt-4.8.2-source\mkspecs\win32-msvc2010\qmake.conf
       # QtCore
       kernel32
@@ -1971,25 +1971,25 @@ elseif(WIN32)
     )
 
     find_library(QT5FONTDATABASESUPPORT_LIBRARY Qt5FontDatabaseSupport)
-    target_link_libraries(mixxx-lib PUBLIC "${QT5FONTDATABASESUPPORT_LIBRARY}")
+    target_link_libraries(mixxx-lib PRIVATE "${QT5FONTDATABASESUPPORT_LIBRARY}")
     find_library(QT5WINDOWSUIAUTOMATIONSUPPORT_LIBRARY Qt5WindowsUIAutomationSupport)
-    target_link_libraries(mixxx-lib PUBLIC "${QT5WINDOWSUIAUTOMATIONSUPPORT_LIBRARY}")
+    target_link_libraries(mixxx-lib PRIVATE "${QT5WINDOWSUIAUTOMATIONSUPPORT_LIBRARY}")
     find_library(QT5EVENTDISPATCHERSUPPORT_LIBRARY Qt5EventDispatcherSupport)
-    target_link_libraries(mixxx-lib PUBLIC "${QT5EVENTDISPATCHERSUPPORT_LIBRARY}")
+    target_link_libraries(mixxx-lib PRIVATE "${QT5EVENTDISPATCHERSUPPORT_LIBRARY}")
     find_library(QT5THEMESUPPORT_LIBRARY Qt5ThemeSupport)
-    target_link_libraries(mixxx-lib PUBLIC "${QT5THEMESUPPORT_LIBRARY}")
+    target_link_libraries(mixxx-lib PRIVATE "${QT5THEMESUPPORT_LIBRARY}")
 
     find_library(QTFREETYPE_LIBRARY qtfreetype)
-    target_link_libraries(mixxx-lib PUBLIC "${QTFREETYPE_LIBRARY}")
+    target_link_libraries(mixxx-lib PRIVATE "${QTFREETYPE_LIBRARY}")
     find_library(QTHARFBUZZ_LIBRARY qtharfbuzz)
-    target_link_libraries(mixxx-lib PUBLIC "${QTHARFBUZZ_LIBRARY}")
+    target_link_libraries(mixxx-lib PRIVATE "${QTHARFBUZZ_LIBRARY}")
     find_library(QTLIBPNG_LIBRARY qtlibpng)
-    target_link_libraries(mixxx-lib PUBLIC "${QTLIBPNG_LIBRARY}")
+    target_link_libraries(mixxx-lib PRIVATE "${QTLIBPNG_LIBRARY}")
     find_library(QTPCRE2_LIBRARY qtpcre2)
-    target_link_libraries(mixxx-lib PUBLIC "${QTPCRE2_LIBRARY}")
+    target_link_libraries(mixxx-lib PRIVATE "${QTPCRE2_LIBRARY}")
   else()
     #libshout is always built statically
-    target_link_libraries(mixxx-lib PUBLIC
+    target_link_libraries(mixxx-lib PRIVATE
       ws2_32      # libshout
       gdi32       # libshout
     )
@@ -2004,7 +2004,7 @@ add_library(QtScriptByteArray STATIC EXCLUDE_FROM_ALL
 set_target_properties(QtScriptByteArray PROPERTIES AUTOMOC ON)
 target_link_libraries(QtScriptByteArray Qt5::Core)
 target_include_directories(mixxx-lib SYSTEM PUBLIC lib/qtscript-bytearray)
-target_link_libraries(mixxx-lib PUBLIC QtScriptByteArray)
+target_link_libraries(mixxx-lib PRIVATE QtScriptByteArray)
 
 # Queen Mary DSP
 add_library(QueenMaryDsp STATIC EXCLUDE_FROM_ALL
@@ -2059,7 +2059,7 @@ elseif(MSVC)
   target_compile_definitions(QueenMaryDsp PRIVATE _USE_MATH_DEFINES)
 endif()
 target_include_directories(QueenMaryDsp SYSTEM PUBLIC lib/qm-dsp lib/qm-dsp/include)
-target_link_libraries(mixxx-lib PUBLIC QueenMaryDsp)
+target_link_libraries(mixxx-lib PRIVATE QueenMaryDsp)
 
 # ReplayGain
 add_library(ReplayGain STATIC EXCLUDE_FROM_ALL
@@ -2074,24 +2074,24 @@ if(MSVC)
   target_compile_definitions(Reverb PRIVATE _USE_MATH_DEFINES)
 endif()
 target_include_directories(Reverb PRIVATE src)
-target_link_libraries(Reverb PUBLIC Qt5::Core)
+target_link_libraries(Reverb PRIVATE Qt5::Core)
 target_include_directories(mixxx-lib SYSTEM PRIVATE lib/reverb)
-target_link_libraries(mixxx-lib PUBLIC Reverb)
+target_link_libraries(mixxx-lib PRIVATE Reverb)
 
 # Rubberband
 find_package(rubberband REQUIRED)
-target_link_libraries(mixxx-lib PUBLIC rubberband::rubberband)
+target_link_libraries(mixxx-lib PRIVATE rubberband::rubberband)
 
 # SndFile
 find_package(SndFile REQUIRED)
-target_link_libraries(mixxx-lib PUBLIC SndFile::sndfile)
+target_link_libraries(mixxx-lib PRIVATE SndFile::sndfile)
 target_compile_definitions(mixxx-lib PUBLIC __SNDFILE__)
 if(SndFile_SUPPORTS_SET_COMPRESSION_LEVEL)
   target_compile_definitions(mixxx-lib PUBLIC SFC_SUPPORTS_SET_COMPRESSION_LEVEL)
 endif()
 if(WIN32 AND STATIC_DEPS)
   find_package(G72X REQUIRED)
-  target_link_libraries(mixxx-lib PUBLIC G72X::G72X)
+  target_link_libraries(mixxx-lib PRIVATE G72X::G72X)
 endif()
 
 # SoundTouch
@@ -2116,15 +2116,15 @@ if(SoundTouch_STATIC)
     lib/soundtouch/sse_optimized.cpp
   )
   target_include_directories(SoundTouch SYSTEM PUBLIC lib)
-  target_link_libraries(mixxx-lib PUBLIC SoundTouch)
+  target_link_libraries(mixxx-lib PRIVATE SoundTouch)
 else()
   message(STATUS "Linking libSoundTouch dynamically")
-  target_link_libraries(mixxx-lib PUBLIC SoundTouch::SoundTouch)
+  target_link_libraries(mixxx-lib PRIVATE SoundTouch::SoundTouch)
 endif()
 
 # TagLib
 find_package(TagLib REQUIRED)
-target_link_libraries(mixxx-lib PUBLIC TagLib::TagLib)
+target_link_libraries(mixxx-lib PRIVATE TagLib::TagLib)
 if(WIN32 AND STATIC_DEPS)
   target_compile_definitions(mixxx-lib PUBLIC TAGLIB_STATIC)
 endif()
@@ -2132,35 +2132,35 @@ endif()
 # Threads
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
-target_link_libraries(mixxx-lib PUBLIC Threads::Threads)
+target_link_libraries(mixxx-lib PRIVATE Threads::Threads)
 
 # Upower
 if(UNIX AND NOT APPLE)
   find_package(GLIB COMPONENTS gobject REQUIRED)
   find_package(Upower REQUIRED)
   target_include_directories(mixxx-lib SYSTEM PUBLIC ${GLIB_INCLUDE_DIRS})
-  target_link_libraries(mixxx-lib PUBLIC ${GLIB_LIBRARIES} ${GLIB_GOBJECT_LIBRARIES})
-  target_link_libraries(mixxx-lib PUBLIC Upower::Upower)
+  target_link_libraries(mixxx-lib PRIVATE ${GLIB_LIBRARIES} ${GLIB_GOBJECT_LIBRARIES})
+  target_link_libraries(mixxx-lib PRIVATE Upower::Upower)
 endif()
 
 # iOS/OS X Frameworks
 if(APPLE)
   find_library(COREFOUNDATION_LIBRARY CoreFoundation REQUIRED)
-  target_link_libraries(mixxx-lib PUBLIC ${COREFOUNDATION_LIBRARY})
+  target_link_libraries(mixxx-lib PRIVATE ${COREFOUNDATION_LIBRARY})
 
   # The iOS/OS X security framework is used to implement sandboxing.
   find_library(SECURITY_LIBRARY Security REQUIRED)
-  target_link_libraries(mixxx-lib PUBLIC ${SECURITY_LIBRARY})
+  target_link_libraries(mixxx-lib PRIVATE ${SECURITY_LIBRARY})
 
   find_library(CORESERVICES_LIBRARY CoreServices REQUIRED)
-  target_link_libraries(mixxx-lib PUBLIC ${CORESERVICES_LIBRARY})
+  target_link_libraries(mixxx-lib PRIVATE ${CORESERVICES_LIBRARY})
 
   find_library(FOUNDATION_LIBRARY Foundation REQUIRED)
-  target_link_libraries(mixxx-lib PUBLIC ${FOUNDATION_LIBRARY})
+  target_link_libraries(mixxx-lib PRIVATE ${FOUNDATION_LIBRARY})
 
   # Used for battery measurements and controlling the screensaver on OS X and iOS.
   find_library(IOKIT_LIBRARY IOKit REQUIRED)
-  target_link_libraries(mixxx-lib PUBLIC ${IOKIT_LIBRARY})
+  target_link_libraries(mixxx-lib PRIVATE ${IOKIT_LIBRARY})
 endif()
 
 #
@@ -2242,7 +2242,7 @@ if(COREAUDIO)
     lib/apple/CAStreamBasicDescription.cpp
   )
   find_library(AUDIOTOOLBOX_LIBRARY AudioToolbox REQUIRED)
-  target_link_libraries(mixxx-lib PUBLIC ${AUDIOTOOLBOX_LIBRARY})
+  target_link_libraries(mixxx-lib PRIVATE ${AUDIOTOOLBOX_LIBRARY})
   target_compile_definitions(mixxx-lib PRIVATE __COREAUDIO__)
   target_include_directories(mixxx-lib SYSTEM PUBLIC lib/apple)
 endif()
@@ -2264,9 +2264,9 @@ if(FAAD)
   target_compile_definitions(mixxx-lib PRIVATE __FAAD__)
   if(MP4v2_FOUND)
     target_compile_definitions(mixxx-lib PRIVATE __MP4V2__)
-    target_link_libraries(mixxx-lib PUBLIC MP4v2::MP4v2)
+    target_link_libraries(mixxx-lib PRIVATE MP4v2::MP4v2)
   else()
-    target_link_libraries(mixxx-lib PUBLIC MP4::MP4)
+    target_link_libraries(mixxx-lib PRIVATE MP4::MP4)
   endif()
 endif()
 
@@ -2324,7 +2324,7 @@ if(FFMPEG)
     __STDC_LIMIT_MACROS
     __STDC_FORMAT_MACROS
   )
-  target_link_libraries(mixxx-lib PUBLIC "${FFMPEG_LIBRARIES}")
+  target_link_libraries(mixxx-lib PRIVATE "${FFMPEG_LIBRARIES}")
   target_include_directories(mixxx-lib PUBLIC "${FFMPEG_INCLUDE_DIRS}")
 endif()
 
@@ -2334,10 +2334,10 @@ option(GPERFTOOLSPROFILER "Google PerfTools libprofiler linkage" OFF)
 if(GPERFTOOLS OR GPERFTOOLSPROFILER)
   find_package(GPerfTools REQUIRED)
   if(GPERFTOOLS)
-    target_link_libraries(mixxx-lib PUBLIC GPerfTools::tcmalloc)
+    target_link_libraries(mixxx-lib PRIVATE GPerfTools::tcmalloc)
   endif()
   if(PERFTOOLSPROFILER)
-    target_link_libraries(mixxx-lib PUBLIC GPerfTools::profiler)
+    target_link_libraries(mixxx-lib PRIVATE GPerfTools::profiler)
   endif()
 endif()
 
@@ -2360,7 +2360,7 @@ if(HSS1394)
   if(NOT HSS1394_FOUND)
     message(FATAL_ERROR "HSS1394 MIDI device support requires the libhss1394 and its development headers.")
   endif()
-  target_link_libraries(mixxx-lib PUBLIC HSS1394::HSS1394)
+  target_link_libraries(mixxx-lib PRIVATE HSS1394::HSS1394)
 endif()
 
 # Lilv (LV2)
@@ -2377,7 +2377,8 @@ if(LILV)
     src/preferences/dialog/dlgpreflv2.cpp
   )
   target_compile_definitions(mixxx-lib PUBLIC __LILV__)
-  target_link_libraries(mixxx-lib PUBLIC lilv::lilv)
+  target_link_libraries(mixxx-lib PRIVATE lilv::lilv)
+  target_link_libraries(mixxx-test PRIVATE lilv::lilv)
 endif()
 
 # Live Broadcasting (Shoutcast)
@@ -2397,9 +2398,9 @@ if(BROADCAST)
     message(STATUS "Using internal libshout-idjc")
     add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/lib/libshout-idjc")
     target_include_directories(mixxx-lib SYSTEM PUBLIC lib/libshout-idjc/include)
-    target_link_libraries(mixxx-lib PUBLIC shout_mixxx)
+    target_link_libraries(mixxx-lib PRIVATE shout_mixxx)
   else()
-    target_link_libraries(mixxx-lib PUBLIC Shoutidjc::Shoutidjc)
+    target_link_libraries(mixxx-lib PRIVATE Shoutidjc::Shoutidjc)
   endif()
   target_sources(mixxx-lib PRIVATE
     src/preferences/dialog/dlgprefbroadcastdlg.ui
@@ -2423,7 +2424,7 @@ if(LOCALECOMPARE)
   endif()
   target_compile_definitions(mixxx-lib PUBLIC __SQLITE3__)
   target_include_directories(mixxx-lib SYSTEM PRIVATE ${SQLite3_INCLUDE_DIRS})
-  target_link_libraries(mixxx-lib PUBLIC ${SQLite3_LIBRARIES})
+  target_link_libraries(mixxx-lib PRIVATE ${SQLite3_LIBRARIES})
 endif()
 
 # Opus (RFC 6716)
@@ -2440,19 +2441,19 @@ if(OPUS)
   )
   target_compile_definitions(mixxx-lib PUBLIC __OPUS__)
   target_include_directories(mixxx-lib SYSTEM PUBLIC ${Opus_INCLUDE_DIRS})
-  target_link_libraries(mixxx-lib PUBLIC ${Opus_LIBRARIES})
+  target_link_libraries(mixxx-lib PRIVATE ${Opus_LIBRARIES})
   if(WIN32 AND STATIC_DEPS)
     find_package(Celt)
     if(NOT Celt_FOUND)
       message(FATAL_ERROR "Opus support with static dependencies requires the celt library.")
     endif()
-    target_link_libraries(mixxx-lib PUBLIC Celt::Celt)
+    target_link_libraries(mixxx-lib PRIVATE Celt::Celt)
 
     find_package(Silk)
     if(NOT Silk_FOUND)
       message(FATAL_ERROR "Opus support with static dependencies requires the silk library.")
     endif()
-    target_link_libraries(mixxx-lib PUBLIC Silk::Float)
+    target_link_libraries(mixxx-lib PRIVATE Silk::Float)
   endif()
 endif()
 
@@ -2469,7 +2470,7 @@ if(MAD)
   endif()
   target_sources(mixxx-lib PRIVATE src/sources/soundsourcemp3.cpp)
   target_compile_definitions(mixxx-lib PUBLIC __MAD__)
-  target_link_libraries(mixxx-lib PUBLIC MAD::MAD ID3Tag::ID3Tag)
+  target_link_libraries(mixxx-lib PRIVATE MAD::MAD ID3Tag::ID3Tag)
 endif()
 
 # Media Foundation AAC Decoder Plugin
@@ -2486,7 +2487,7 @@ if(MEDIAFOUNDATION)
   target_include_directories(mixxx-lib SYSTEM PRIVATE
     ${MediaFoundation_INCLUDE_DIRS}
   )
-  target_link_libraries(mixxx-lib PUBLIC
+  target_link_libraries(mixxx-lib PRIVATE
     ${MediaFoundation_LIBRARIES}
   )
 endif()
@@ -2504,7 +2505,7 @@ if(MODPLUG)
     src/preferences/dialog/dlgprefmodplug.cpp
   )
   target_compile_definitions(mixxx-lib PUBLIC __MODPLUG__)
-  target_link_libraries(mixxx-lib PUBLIC Modplug::Modplug)
+  target_link_libraries(mixxx-lib PRIVATE Modplug::Modplug)
 endif()
 
 # QtKeychain
@@ -2515,7 +2516,7 @@ if(QTKEYCHAIN)
     message(FATAL_ERROR "Secure credential storage support requires the Qt5::Keychain component.")
   endif()
   target_compile_definitions(mixxx-lib PUBLIC __QTKEYCHAIN__)
-  target_link_libraries(mixxx-lib PUBLIC ${QTKEYCHAIN_LIBRARIES})
+  target_link_libraries(mixxx-lib PRIVATE ${QTKEYCHAIN_LIBRARIES})
   target_include_directories(mixxx-lib SYSTEM PUBLIC ${QTKEYCHAIN_INCLUDE_DIRS})
 endif()
 
@@ -2548,13 +2549,13 @@ if(HID)
     else()
       message(FATAL_ERROR "USB HID controller support only possible on Windows/Mac OS/Linux/BSD.")
     endif()
-    target_link_libraries(mixxx-lib PUBLIC mixxx-hidapi)
+    target_link_libraries(mixxx-lib PRIVATE mixxx-hidapi)
   else()
     message(STATUS "Linking libhidapi dynamically")
     if(NOT HIDAPI_FOUND)
       message(FATAL_ERROR "USB HID controller support requires libhidapi-libusb and its development headers.")
     endif()
-    target_link_libraries(mixxx-lib PUBLIC hidapi::hidapi)
+    target_link_libraries(mixxx-lib PRIVATE hidapi::hidapi)
   endif()
   target_sources(mixxx-lib PRIVATE
     src/controllers/hid/hidcontroller.cpp
@@ -2582,7 +2583,7 @@ if(BULK)
     )
   endif()
   target_compile_definitions(mixxx-lib PUBLIC __BULK__)
-  target_link_libraries(mixxx-lib PUBLIC LibUSB::LibUSB)
+  target_link_libraries(mixxx-lib PRIVATE LibUSB::LibUSB)
 endif()
 
 # Vinyl Control
@@ -2612,7 +2613,7 @@ if(VINYLCONTROL)
     target_sources(mixxx-xwax PRIVATE lib/xwax/timecoder.c lib/xwax/lut.c)
   endif()
   target_include_directories(mixxx-xwax SYSTEM PUBLIC lib/xwax)
-  target_link_libraries(mixxx-lib PUBLIC mixxx-xwax)
+  target_link_libraries(mixxx-lib PRIVATE mixxx-xwax)
 endif()
 
 # WavPack audio file support
@@ -2624,7 +2625,7 @@ if(WAVPACK)
   endif()
   target_sources(mixxx-lib PRIVATE src/sources/soundsourcewv.cpp)
   target_compile_definitions(mixxx-lib PUBLIC __WV__)
-  target_link_libraries(mixxx-lib PUBLIC WavPack::wavpack)
+  target_link_libraries(mixxx-lib PRIVATE WavPack::wavpack)
 endif()
 
 # Configure file with build options

--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -13,9 +13,9 @@ protobuf_generate(
 )
 
 if(TARGET protobuf::libprotobuf-lite)
-    target_link_libraries(mixxx-proto PUBLIC protobuf::libprotobuf-lite)
+    target_link_libraries(mixxx-proto PRIVATE protobuf::libprotobuf-lite)
 elseif(TARGET protobuf::libprotobuf)
-    target_link_libraries(mixxx-proto PUBLIC protobuf::libprotobuf)
+    target_link_libraries(mixxx-proto PRIVATE protobuf::libprotobuf)
 else()
     message(FATAL_ERROR "Protobuf or Protobuf-lite libraries are required to compile Mixxx.")
 endif()


### PR DESCRIPTION
...to prevent accidental dependencies.

Unfortunately, this doesn't resolve the RubberBand issues caused by duplicate and incompatible symbols when linking.

After merging to main the libdjinterop dependencies should be adjusted, too.