### PR TITLE
EngineBuffer: Verify that seek positions are valid numbers

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -603,7 +603,7 @@ void EngineBuffer::slotControlSeekExact(double playPosition) {
 
 void EngineBuffer::doSeekFractional(double fractionalPos, enum SeekRequest seekType) {
     // Prevent NaN's from sneaking into the engine.
-    if (isnan(fractionalPos)) {
+    VERIFY_OR_DEBUG_ASSERT(!isnan(fractionalPos)) {
         return;
     }
     double newSamplePosition = fractionalPos * m_pTrackSamples->get();


### PR DESCRIPTION
Invalid positions should never reach the engine.