### PR TITLE
Database: Fix kRequiredSchemaVersion

### DIFF
--- a/src/database/mixxxdb.cpp
+++ b/src/database/mixxxdb.cpp
@@ -12,7 +12,7 @@
 const QString MixxxDb::kDefaultSchemaFile(":/schema.xml");
 
 //static
-const int MixxxDb::kRequiredSchemaVersion = 35;
+const int MixxxDb::kRequiredSchemaVersion = 36;
 
 namespace {
 


### PR DESCRIPTION
Probably got lost due to a merge conflict, see schema.xml. This would explain some complaints about why the last played column didn't work as expected in some cases.