### PR TITLE
skin change: save fullscreen state before destroying main widget

### DIFF
--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -512,7 +512,6 @@ QDialog::DialogCode MixxxMainWindow::soundDeviceBusyDlg(bool* retryClicked) {
     return soundDeviceErrorDlg(title, text, retryClicked);
 }
 
-
 QDialog::DialogCode MixxxMainWindow::soundDeviceErrorMsgDlg(
         SoundDeviceError err, bool* retryClicked) {
     QString title(tr("Sound Device Error"));
@@ -862,17 +861,21 @@ void MixxxMainWindow::slotDeveloperToolsClosed() {
 }
 
 void MixxxMainWindow::slotViewFullScreen(bool toggle) {
-    qDebug() << "";
+    qDebug() << "....";
     qDebug() << "   slotViewFullScreen(" << toggle << ")";
-    qDebug() << "   isFullScreen() before" << isFullScreen();
+    qDebug() << "     isFullScreen() before" << isFullScreen();
+    qDebug() << "     windowState() before " << windowState();
     if (isFullScreen() == toggle) {
-        qDebug() << "   > return";
+        qDebug() << "     isFullScreen() == toggle";
+        qDebug() << "     > return";
         return;
     }
+    qDebug() << ".";
 
     if (toggle) {
-        qDebug() << "   > showFullScreen()";
-        showFullScreen();
+        qDebug() << "     > set Qt::WindowFullScreen";
+        // showFullScreen();
+        setWindowState(Qt::WindowFullScreen);
 #ifdef __LINUX__
         // Fix for "No menu bar with ubuntu unity in full screen mode" Bug
         // #885890 and Bug #1076789. Before touching anything here, please read
@@ -888,13 +891,15 @@ void MixxxMainWindow::slotViewFullScreen(bool toggle) {
         createMenuBar();
         connectMenuBar();
 #endif
-        qDebug() << "   > showNormal()";
-        showNormal();
+        qDebug() << "   > unset Qt::WindowFullScreen";
+        //showNormal();
+        setWindowState(windowState() & ~Qt::WindowFullScreen);
     }
-    qDebug() << "";
-    qDebug() << "   isFullScreen after" << isFullScreen();
-    qDebug() << "   emit fullScreenChanged(" << toggle << ")";
-    qDebug() << "";
+    qDebug() << ".";
+    qDebug() << "     isFullScreen() after" << isFullScreen();
+    qDebug() << "     windowState() after " << windowState();
+    qDebug() << "     emit fullScreenChanged(" << toggle << ")";
+    qDebug() << ".";
     emit fullScreenChanged(toggle);
 }
 
@@ -987,9 +992,9 @@ void MixxxMainWindow::slotTooltipModeChanged(mixxx::TooltipsPreference tt) {
 }
 
 void MixxxMainWindow::rebootMixxxView() {
-    qDebug() << "";
-    qDebug() << "";
-    qDebug() << "";
+    qDebug() << ".";
+    qDebug() << ".";
+    qDebug() << ".";
     qDebug() << "Now in rebootMixxxView...";
 
     // safe geometry for later restoration
@@ -997,9 +1002,9 @@ void MixxxMainWindow::rebootMixxxView() {
 
     // store the fullscreen state and restore after skin change
     bool wasFullScreen = isFullScreen();
-    qDebug() << "";
+    qDebug() << ".";
     qDebug() << "   wasFullScreen" << wasFullScreen;
-    qDebug() << "";
+    qDebug() << ".";
 
     // We need to tell the menu bar that we are about to delete the old skin and
     // create a new one. It holds "visibility" controls (e.g. "Show Samplers")
@@ -1013,17 +1018,17 @@ void MixxxMainWindow::rebootMixxxView() {
         delete m_pCentralWidget;
         m_pCentralWidget = nullptr;
         qDebug() << "   m_pWidgetParent deleted";
-        qDebug() << "";
+        qDebug() << ".";
     }
 
     // Workaround for changing skins while fullscreen, just go out of fullscreen
     // mode. If you change skins while in fullscreen (on Linux, at least) the
-    // window returns to 0,0 but and the backdrop disappears so it looks as if
+    // window returns to 0,0 but the backdrop disappears so it looks as if
     // it is not fullscreen, but acts as if it is.
     qDebug() << "   1 isFullScreen()" << isFullScreen();
     slotViewFullScreen(false);
     qDebug() << "   2 isFullScreen()" << isFullScreen();
-    qDebug() << "";
+    qDebug() << ".";
 
     if (!loadConfiguredSkin()) {
         QMessageBox::critical(this,
@@ -1033,7 +1038,7 @@ void MixxxMainWindow::rebootMixxxView() {
         return;
     }
     qDebug() << "   new skin loaded";
-    qDebug() << "";
+    qDebug() << ".";
     m_pMenuBar->setStyleSheet(m_pCentralWidget->styleSheet());
 
     setCentralWidget(m_pCentralWidget);
@@ -1046,7 +1051,7 @@ void MixxxMainWindow::rebootMixxxView() {
     qDebug() << "   adjustSize()";
     adjustSize();
     qDebug() << "   4 isFullScreen()" << isFullScreen();
-    qDebug() << "";
+    qDebug() << ".";
 #endif
 
     qDebug() << "   wasFullScreen" << wasFullScreen;
@@ -1065,7 +1070,7 @@ void MixxxMainWindow::rebootMixxxView() {
         setGeometry(initGeometry);
     }
     qDebug() << "   5 isFullScreen()" << isFullScreen();
-    qDebug() << "";
+    qDebug() << ".";
 
     qDebug() << "rebootMixxxView DONE";
 }
@@ -1120,7 +1125,6 @@ void MixxxMainWindow::closeEvent(QCloseEvent *event) {
     }
     QMainWindow::closeEvent(event);
 }
-
 
 void MixxxMainWindow::checkDirectRendering() {
     // IF

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -862,11 +862,16 @@ void MixxxMainWindow::slotDeveloperToolsClosed() {
 }
 
 void MixxxMainWindow::slotViewFullScreen(bool toggle) {
+    qDebug() << "";
+    qDebug() << "   slotViewFullScreen(" << toggle << ")";
+    qDebug() << "   isFullScreen() before" << isFullScreen();
     if (isFullScreen() == toggle) {
+        qDebug() << "   > return";
         return;
     }
 
     if (toggle) {
+        qDebug() << "   > showFullScreen()";
         showFullScreen();
 #ifdef __LINUX__
         // Fix for "No menu bar with ubuntu unity in full screen mode" Bug
@@ -883,8 +888,13 @@ void MixxxMainWindow::slotViewFullScreen(bool toggle) {
         createMenuBar();
         connectMenuBar();
 #endif
+        qDebug() << "   > showNormal()";
         showNormal();
     }
+    qDebug() << "";
+    qDebug() << "   isFullScreen after" << isFullScreen();
+    qDebug() << "   emit fullScreenChanged(" << toggle << ")";
+    qDebug() << "";
     emit fullScreenChanged(toggle);
 }
 
@@ -977,6 +987,9 @@ void MixxxMainWindow::slotTooltipModeChanged(mixxx::TooltipsPreference tt) {
 }
 
 void MixxxMainWindow::rebootMixxxView() {
+    qDebug() << "";
+    qDebug() << "";
+    qDebug() << "";
     qDebug() << "Now in rebootMixxxView...";
 
     // safe geometry for later restoration
@@ -984,6 +997,9 @@ void MixxxMainWindow::rebootMixxxView() {
 
     // store the fullscreen state and restore after skin change
     bool wasFullScreen = isFullScreen();
+    qDebug() << "";
+    qDebug() << "   wasFullScreen" << wasFullScreen;
+    qDebug() << "";
 
     // We need to tell the menu bar that we are about to delete the old skin and
     // create a new one. It holds "visibility" controls (e.g. "Show Samplers")
@@ -996,13 +1012,18 @@ void MixxxMainWindow::rebootMixxxView() {
         WaveformWidgetFactory::instance()->destroyWidgets();
         delete m_pCentralWidget;
         m_pCentralWidget = nullptr;
+        qDebug() << "   m_pWidgetParent deleted";
+        qDebug() << "";
     }
 
     // Workaround for changing skins while fullscreen, just go out of fullscreen
     // mode. If you change skins while in fullscreen (on Linux, at least) the
     // window returns to 0,0 but and the backdrop disappears so it looks as if
     // it is not fullscreen, but acts as if it is.
+    qDebug() << "   1 isFullScreen()" << isFullScreen();
     slotViewFullScreen(false);
+    qDebug() << "   2 isFullScreen()" << isFullScreen();
+    qDebug() << "";
 
     if (!loadConfiguredSkin()) {
         QMessageBox::critical(this,
@@ -1011,6 +1032,8 @@ void MixxxMainWindow::rebootMixxxView() {
         // m_pWidgetParent is NULL, we can't continue.
         return;
     }
+    qDebug() << "   new skin loaded";
+    qDebug() << "";
     m_pMenuBar->setStyleSheet(m_pCentralWidget->styleSheet());
 
     setCentralWidget(m_pCentralWidget);
@@ -1019,9 +1042,14 @@ void MixxxMainWindow::rebootMixxxView() {
     // to paint the new skin with X11
     // https://bugs.launchpad.net/mixxx/+bug/1773587
 #else
+    qDebug() << "   3 isFullScreen()" << isFullScreen();
+    qDebug() << "   adjustSize()";
     adjustSize();
+    qDebug() << "   4 isFullScreen()" << isFullScreen();
+    qDebug() << "";
 #endif
 
+    qDebug() << "   wasFullScreen" << wasFullScreen;
     if (wasFullScreen) {
         slotViewFullScreen(true);
     } else {
@@ -1033,8 +1061,11 @@ void MixxxMainWindow::rebootMixxxView() {
         // If the minimum size of the new skin is larger then the restored
         // geometry, the window will be enlarged right & bottom which is
         // safe as the menu is still reachable.
+        qDebug() << "   setGeometry(initGeometry)";
         setGeometry(initGeometry);
     }
+    qDebug() << "   5 isFullScreen()" << isFullScreen();
+    qDebug() << "";
 
     qDebug() << "rebootMixxxView DONE";
 }

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -982,6 +982,9 @@ void MixxxMainWindow::rebootMixxxView() {
     // safe geometry for later restoration
     const QRect initGeometry = geometry();
 
+    // store the fullscreen state and restore after skin change
+    bool wasFullScreen = isFullScreen();
+
     // We need to tell the menu bar that we are about to delete the old skin and
     // create a new one. It holds "visibility" controls (e.g. "Show Samplers")
     // that need to be deleted -- otherwise we can't tell what features the skin
@@ -999,7 +1002,6 @@ void MixxxMainWindow::rebootMixxxView() {
     // mode. If you change skins while in fullscreen (on Linux, at least) the
     // window returns to 0,0 but and the backdrop disappears so it looks as if
     // it is not fullscreen, but acts as if it is.
-    bool wasFullScreen = isFullScreen();
     slotViewFullScreen(false);
 
     if (!loadConfiguredSkin()) {

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -314,7 +314,10 @@ void WMainMenuBar::initialize() {
     pViewFullScreen->setChecked(false);
     pViewFullScreen->setStatusTip(fullScreenText);
     pViewFullScreen->setWhatsThis(buildWhatsThis(fullScreenTitle, fullScreenText));
-    connect(pViewFullScreen, &QAction::triggered, this, &WMainMenuBar::toggleFullScreen);
+    connect(pViewFullScreen,
+            &QAction::triggered,
+            this,
+            &WMainMenuBar::toggleFullScreen);
     connect(this,
             &WMainMenuBar::internalFullScreenStateChange,
             pViewFullScreen,


### PR DESCRIPTION
maybe this fixes [lp:1777328 macOS: mixxx leaves fullscreen view when switching skins](https://bugs.launchpad.net/mixxx/+bug/1777328)

just a guess: macOS quits fullscreen when the skin widget is destroyed?
store fullscreen state beforehand.