### PR TITLE
show the menubar after replacing the launch image

### DIFF
--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -583,8 +583,6 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
                                     // Mixxx class as a callback.
     emit skinLoaded();
 
-    m_pMenuBar->show();
-
     // Wait until all other ControlObjects are set up before initializing
     // controllers
     m_pControllerManager->setUpDevices();
@@ -695,6 +693,11 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
     // million different variables the first waveform may be horribly
     // corrupted. See bug 521509 -- bkgood ?? -- vrince
     setCentralWidget(m_pWidgetParent);
+
+    // Show the menubar after the launch image is replaced by the skin widget,
+    // otherwise it would shift the launch image shortly before the skin is visible.
+    m_pMenuBar->show();
+
     // The launch image widget is automatically disposed, but we still have a
     // pointer to it.
     m_pLaunchImage = nullptr;


### PR DESCRIPTION
@holzhaus In #3839 I was wrong with showing the menubar earlier because I totally missed that loading the skin != showing the skin.
Currently the menubar is shown for a very short period before the skin widget is shown `setCentralWidget(m_pWidgetParent);`, thus the launch image is shifted downwards before it is replaced by the skin.