### PR TITLE
Missing SVG icons in skins

### DIFF
--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -298,7 +298,7 @@
       <!-- ToDo ronso0 :: Unfortunately, variables are not considered here, yet ;)
           because the launch screen appears while the skin is parsed.
       image: url(skin:/style_<Variable name="scheme"/>/mixxx_logo.svg); -->
-      image: url(skin:/palemoon/style/mixxx_logo.svg);
+      background: transparent url(skin:/palemoon/style/mixxx_logo.svg) no-repeat center center;
       padding: 0;
       margin: 0px 2px 0px 2px;
       border: none;

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -322,7 +322,7 @@ WSearchLineEdit {
 
   #FxFlowIndicatorCollapsed {
     margin: 0px 0px 0px 0px;
-    background-image: url(skin:/palemoon/style/fx_flow_horizontal.svg) no-repeat center center;
+    background: url(skin:/palemoon/style/fx_flow_horizontal.svg) no-repeat center center;
   }
   #ToolbarSeparator {
     margin: 0px 5px;
@@ -1832,305 +1832,305 @@ WPushButton#RecButton[displayValue="1"],
 
 /************** Button icons **************************************************/
 WPushButton#PlayDeck[value="0"] {
-  image: url(skin:/palemoon/buttons/btn__play_deck.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__play_deck.svg) no-repeat center center;
   }
   WPushButton#PlayDeck[value="1"] {
-    image: url(skin:/palemoon/buttons/btn__play_deck_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__play_deck_active.svg) no-repeat center center;
   }
 
 #PlayDeckMini[value="0"] {
-  image: url(skin:/palemoon/buttons/btn__play_deck_mini.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__play_deck_mini.svg) no-repeat center center;
   }
   #PlayDeckMini[value="1"] {
-    image: url(skin:/palemoon/buttons/btn__pause_deck_mini.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__pause_deck_mini.svg) no-repeat center center;
   }
 #PlaySampler[value="0"],
 #PlayPreview[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__play_sampler.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__play_sampler.svg) no-repeat center center;
   }
   #PlaySampler[value="1"],
   #PlayPreview[displayValue="1"] {
-    image: url(skin:/palemoon/buttons/btn__pause_sampler.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__pause_sampler.svg) no-repeat center center;
   }
 
 #CueDeck[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__cue_deck.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__cue_deck.svg) no-repeat center center;
   }
   #CueDeck[displayValue="1"] {
-    image: url(skin:/palemoon/buttons/btn__cue_deck_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__cue_deck_active.svg) no-repeat center center;
   }
 
 #Reverse {
-  image: url(skin:/palemoon/buttons/btn__reverse.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__reverse.svg) no-repeat center center;
   }
   #Reverse[pressed="true"] {
-    image: url(skin:/palemoon/buttons/btn__reverse_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__reverse_active.svg) no-repeat center center;
   }
 
 #Hotcue1 WPushButton[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__1.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__1.svg) no-repeat center center;
   }
   #Hotcue1 WPushButton[displayValue="1"][dark="false"] {
-    image: url(skin:/palemoon/buttons/btn__1_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__1_active.svg) no-repeat center center;
   }
   #Hotcue1 WPushButton[displayValue="1"][dark="true"] {
-    image: url(skin:/palemoon/buttons/btn__1_active_dark.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__1_active_dark.svg) no-repeat center center;
   }
 
 #Hotcue2 WPushButton[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__2.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__2.svg) no-repeat center center;
   }
   #Hotcue2 WPushButton[displayValue="1"] {
-    image: url(skin:/palemoon/buttons/btn__2_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__2_active.svg) no-repeat center center;
   }
   #Hotcue2 WPushButton[displayValue="1"][dark="true"] {
-    image: url(skin:/palemoon/buttons/btn__2_active_dark.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__2_active_dark.svg) no-repeat center center;
   }
 
 #Hotcue3 WPushButton[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__3.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__3.svg) no-repeat center center;
   }
   #Hotcue3 WPushButton[displayValue="1"] {
-    image: url(skin:/palemoon/buttons/btn__3_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__3_active.svg) no-repeat center center;
   }
   #Hotcue3 WPushButton[displayValue="1"][dark="true"] {
-    image: url(skin:/palemoon/buttons/btn__3_active_dark.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__3_active_dark.svg) no-repeat center center;
   }
 
 #Hotcue4 WPushButton[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__4.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__4.svg) no-repeat center center;
   }
   #Hotcue4 WPushButton[displayValue="1"] {
-    image: url(skin:/palemoon/buttons/btn__4_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__4_active.svg) no-repeat center center;
   }
   #Hotcue4 WPushButton[displayValue="1"][dark="true"] {
-    image: url(skin:/palemoon/buttons/btn__4_active_dark.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__4_active_dark.svg) no-repeat center center;
   }
 
 #Hotcue5 WPushButton[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__5.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__5.svg) no-repeat center center;
   }
   #Hotcue5 WPushButton[displayValue="1"] {
-    image: url(skin:/palemoon/buttons/btn__5_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__5_active.svg) no-repeat center center;
   }
   #Hotcue5 WPushButton[displayValue="1"][dark="true"] {
-    image: url(skin:/palemoon/buttons/btn__5_active_dark.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__5_active_dark.svg) no-repeat center center;
   }
 
 #Hotcue6 WPushButton[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__6.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__6.svg) no-repeat center center;
   }
   #Hotcue6 WPushButton[displayValue="1"] {
-    image: url(skin:/palemoon/buttons/btn__6_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__6_active.svg) no-repeat center center;
   }
   #Hotcue6 WPushButton[displayValue="1"][dark="true"] {
-    image: url(skin:/palemoon/buttons/btn__6_active_dark.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__6_active_dark.svg) no-repeat center center;
   }
 
 #Hotcue7 WPushButton[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__7.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__7.svg) no-repeat center center;
   }
   #Hotcue7 WPushButton[displayValue="1"] {
-    image: url(skin:/palemoon/buttons/btn__7_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__7_active.svg) no-repeat center center;
   }
   #Hotcue7 WPushButton[displayValue="1"][dark="true"] {
-    image: url(skin:/palemoon/buttons/btn__7_active_dark.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__7_active_dark.svg) no-repeat center center;
   }
 
 #Hotcue8 WPushButton[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__8.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__8.svg) no-repeat center center;
   }
   #Hotcue8 WPushButton[displayValue="1"] {
-    image: url(skin:/palemoon/buttons/btn__8_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__8_active.svg) no-repeat center center;
   }
   #Hotcue8 WPushButton[displayValue="1"][dark="true"] {
-    image: url(skin:/palemoon/buttons/btn__8_active_dark.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__8_active_dark.svg) no-repeat center center;
   }
 
 #SpecialCueButton_intro_start WPushButton[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__intro_start.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__intro_start.svg) no-repeat center center;
   }
   #SpecialCueButton_intro_start WPushButton[displayValue="1"] {
-    image: url(skin:/palemoon/buttons/btn__intro_start_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__intro_start_active.svg) no-repeat center center;
   }
 #SpecialCueButton_intro_end WPushButton[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__intro_end.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__intro_end.svg) no-repeat center center;
   }
   #SpecialCueButton_intro_end WPushButton[displayValue="1"] {
-    image: url(skin:/palemoon/buttons/btn__intro_end_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__intro_end_active.svg) no-repeat center center;
   }
 #SpecialCueButton_outro_start WPushButton[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__outro_start.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__outro_start.svg) no-repeat center center;
   }
   #SpecialCueButton_outro_start WPushButton[displayValue="1"] {
-    image: url(skin:/palemoon/buttons/btn__outro_start_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__outro_start_active.svg) no-repeat center center;
   }
 #SpecialCueButton_outro_end WPushButton[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__outro_end.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__outro_end.svg) no-repeat center center;
   }
   #SpecialCueButton_outro_end WPushButton[displayValue="1"] {
-    image: url(skin:/palemoon/buttons/btn__outro_end_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__outro_end_active.svg) no-repeat center center;
   }
 
 #LoopActivate[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__loop.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__loop.svg) no-repeat center center;
   }
   #LoopActivate[displayValue="1"], #LoopActivate[pressed="true"] {
-    image: url(skin:/palemoon/buttons/btn__loop_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__loop_active.svg) no-repeat center center;
   }
 #Reloop[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__reloop.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__reloop.svg) no-repeat center center;
   }
   #Reloop[displayValue="1"] {
-    image: url(skin:/palemoon/buttons/btn__reloop_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__reloop_active.svg) no-repeat center center;
   }
 
 #LoopIn {
-  image: url(skin:/palemoon/buttons/btn__loop_in.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__loop_in.svg) no-repeat center center;
   }
   #LoopIn[pressed="true"] {
-    image: url(skin:/palemoon/buttons/btn__loop_in_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__loop_in_active.svg) no-repeat center center;
   }
 #LoopOut {
-  image: url(skin:/palemoon/buttons/btn__loop_out.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__loop_out.svg) no-repeat center center;
   }
   #LoopOut[pressed="true"] {
-    image: url(skin:/palemoon/buttons/btn__loop_out_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__loop_out_active.svg) no-repeat center center;
   }
 
 #JumpForward {
-  image: url(skin:/palemoon/buttons/btn__beatjump_right.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__beatjump_right.svg) no-repeat center center;
   }
   #JumpForward[pressed="true"] {
-    image: url(skin:/palemoon/buttons/btn__beatjump_right_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__beatjump_right_active.svg) no-repeat center center;
   }
 #JumpBack {
-  image: url(skin:/palemoon/buttons/btn__beatjump_left.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__beatjump_left.svg) no-repeat center center;
   }
   #JumpBack[pressed="true"] {
-    image: url(skin:/palemoon/buttons/btn__beatjump_left_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__beatjump_left_active.svg) no-repeat center center;
   }
 
 /* Key buttons */
 #KeyMatchReset {
-  image: url(skin:/palemoon/buttons/btn__key_match.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__key_match.svg) no-repeat center center;
   }
   #KeyMatchReset[pressed="true"] {
-    image: url(skin:/palemoon/buttons/btn__key_match_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__key_match_active.svg) no-repeat center center;
   }
 
 #KeyUp {
-  image: url(skin:/palemoon/buttons/btn__key_up.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__key_up.svg) no-repeat center center;
   }
   #KeyUp[pressed="true"] {
-    image: url(skin:/palemoon/buttons/btn__key_up_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__key_up_active.svg) no-repeat center center;
   }
 
 #KeyDown {
-  image: url(skin:/palemoon/buttons/btn__key_down.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__key_down.svg) no-repeat center center;
   }
   #KeyDown[pressed="true"] {
-    image: url(skin:/palemoon/buttons/btn__key_down_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__key_down_active.svg) no-repeat center center;
   }
 
 /* Rate buttons */
 #SyncDeck[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__sync_deck.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__sync_deck.svg) no-repeat center center;
   }
   #SyncDeck[displayValue="1"] {
-    image: url(skin:/palemoon/buttons/btn__sync_deck_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__sync_deck_active.svg) no-repeat center center;
   }
 
   #SyncSampler {
-    image: url(skin:/palemoon/buttons/btn__sync_sampler.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__sync_sampler.svg) no-repeat center center;
     }
     #SyncSampler[displayValue="1"] {
-      image: url(skin:/palemoon/buttons/btn__sync_sampler_active.svg) no-repeat center center;
+      background: url(skin:/palemoon/buttons/btn__sync_sampler_active.svg) no-repeat center center;
     }
 
   #RatePermUp {
-    image: url(skin:/palemoon/buttons/btn__plus.svg) no-repeat center center;}
+    background: url(skin:/palemoon/buttons/btn__plus.svg) no-repeat center center;}
   #RatePermUp[pressed="true"] {
-    image: url(skin:/palemoon/buttons/btn__plus_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__plus_active.svg) no-repeat center center;
     }
 
   #RatePermDown {
-    image: url(skin:/palemoon/buttons/btn__minus.svg) no-repeat center center;}
+    background: url(skin:/palemoon/buttons/btn__minus.svg) no-repeat center center;}
   #RatePermDown[pressed="true"] {
-    image: url(skin:/palemoon/buttons/btn__minus_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__minus_active.svg) no-repeat center center;
     }
 
   #RateTempUp {
-    image: url(skin:/palemoon/buttons/btn__arrow_right_up.svg) no-repeat center center;}
+    background: url(skin:/palemoon/buttons/btn__arrow_right_up.svg) no-repeat center center;}
   #RateTempUp[pressed="true"] {
-    image: url(skin:/palemoon/buttons/btn__arrow_right_up_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__arrow_right_up_active.svg) no-repeat center center;
     }
   #RateTempDown {
-    image: url(skin:/palemoon/buttons/btn__arrow_left_down.svg) no-repeat center center;}
+    background: url(skin:/palemoon/buttons/btn__arrow_left_down.svg) no-repeat center center;}
   #RateTempDown[pressed="true"] {
-    image: url(skin:/palemoon/buttons/btn__arrow_left_down_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__arrow_left_down_active.svg) no-repeat center center;
     }
 
   #RateTempUpRev {
-    image: url(skin:/palemoon/buttons/btn__arrow_right_down.svg) no-repeat center center;}
+    background: url(skin:/palemoon/buttons/btn__arrow_right_down.svg) no-repeat center center;}
   #RateTempUpRev[pressed="true"] {
-    image: url(skin:/palemoon/buttons/btn__arrow_right_down_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__arrow_right_down_active.svg) no-repeat center center;
     }
 
   #RateTempDownRev {
-    image: url(skin:/palemoon/buttons/btn__arrow_left_up.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__arrow_left_up.svg) no-repeat center center;
     }
     #RateTempDownRev[pressed="true"] {
-      image: url(skin:/palemoon/buttons/btn__arrow_left_up_active.svg) no-repeat center center;
+      background: url(skin:/palemoon/buttons/btn__arrow_left_up_active.svg) no-repeat center center;
     }
 
 /* Mixer buttons */
 #PflButton[value="0"] {
-  image: url(skin:/palemoon/buttons/btn__pfl.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__pfl.svg) no-repeat center center;
   }
   #PflButton[value="1"] {
-    image: url(skin:/palemoon/buttons/btn__pfl_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__pfl_active.svg) no-repeat center center;
   }
 
 #QuickEffectButton[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__star.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__star.svg) no-repeat center center;
 }
 
 /* EQ Kill button icons H / M / L */
 #EQKillButton_High[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__eq_kill_high.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__eq_kill_high.svg) no-repeat center center;
 }
 #EQKillButton_Mid[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__eq_kill_mid.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__eq_kill_mid.svg) no-repeat center center;
 }
 #EQKillButton_Low[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__eq_kill_low.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__eq_kill_low.svg) no-repeat center center;
 }
 
 /* EQ Kill / QuickEffect dots */
 #EQKillDot[displayValue="0"],
 #QuickEffectDot[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__eq_kill_dot_off.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__eq_kill_dot_off.svg) no-repeat center center;
   }
   #EQKillDot[displayValue="1"] {
-    image: url(skin:/palemoon/buttons/btn__eq_kill_dot_active_red.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__eq_kill_dot_active_red.svg) no-repeat center center;
   }
   #QuickEffectDot[displayValue="1"] {
-    image: url(skin:/palemoon/buttons/btn__eq_kill_dot_active_green.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__eq_kill_dot_active_green.svg) no-repeat center center;
   }
 
 #RateCenter[highlight="0"] {
-  image: url(skin:/palemoon/buttons/btn__rate_center_off.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__rate_center_off.svg) no-repeat center center;
   }
   #RateCenter[highlight="1"] {
-    image: url(skin:/palemoon/buttons/btn__rate_center_cyan.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__rate_center_cyan.svg) no-repeat center center;
   }
 
 #SplitCue[value="0"] {
-  image: url(skin:/palemoon/buttons/btn__split.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__split.svg) no-repeat center center;
   }
   #SplitCue[value="1"] {
-    image: url(skin:/palemoon/buttons/btn__split_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__split_active.svg) no-repeat center center;
   }
 
 #FxExpand,
@@ -2151,240 +2151,240 @@ WPushButton#PlayDeck[value="0"] {
   }
 
 #MixModeButton[value="0"] {
-  image: url(skin:/palemoon/buttons/btn__fx_mixmode_d-w.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__fx_mixmode_d-w.svg) no-repeat center center;
   }
   #MixModeButton[value="1"] {
-    image: url(skin:/palemoon/buttons/btn__fx_mixmode_d+w.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__fx_mixmode_d+w.svg) no-repeat center center;
   }
 
 #FxToggleButton[value="0"] {
-  image: url(skin:/palemoon/buttons/btn__fx_toggle.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__fx_toggle.svg) no-repeat center center;
   }
   #FxToggleButton[value="1"] {
-    image: url(skin:/palemoon/buttons/btn__fx_toggle_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__fx_toggle_active.svg) no-repeat center center;
   }
 
 #FxFocusButton[value="0"] {
-  image: url(skin:/palemoon/buttons/btn__fx_focus.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__fx_focus.svg) no-repeat center center;
   }
   #FxFocusButton[value="1"] {
-    image: url(skin:/palemoon/buttons/btn__fx_focus_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__fx_focus_active.svg) no-repeat center center;
   }
 
 /* deck controls for decks 1-4 and samplers */
 #CurposButton12[displayValue="0"], #CurposButton34[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__beat_curpos.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__beat_curpos.svg) no-repeat center center;
   }
   #CurposButton12[value="1"] {
-    image: url(skin:/palemoon/buttons/btn__beat_curpos_active_12.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__beat_curpos_active_12.svg) no-repeat center center;
   }
   #CurposButton34[value="1"] {
-    image: url(skin:/palemoon/buttons/btn__beat_curpos_active_34.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__beat_curpos_active_34.svg) no-repeat center center;
   }
 
   #EjectButton12[displayValue="0"], #EjectButton34[displayValue="0"] {
-    image: url(skin:/palemoon/buttons/btn__eject.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__eject.svg) no-repeat center center;
     }
     #EjectButton12[value="1"] {
-      image: url(skin:/palemoon/buttons/btn__eject_active_12.svg) no-repeat center center;
+      background: url(skin:/palemoon/buttons/btn__eject_active_12.svg) no-repeat center center;
     }
     #EjectButton34[value="1"] {
-      image: url(skin:/palemoon/buttons/btn__eject_active_34.svg) no-repeat center center;
+      background: url(skin:/palemoon/buttons/btn__eject_active_34.svg) no-repeat center center;
     }
 
   #RepeatButton12[displayValue="0"], #RepeatButton34[displayValue="0"] {
-    image: url(skin:/palemoon/buttons/btn__repeat.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__repeat.svg) no-repeat center center;
     }
     #RepeatButton12[displayValue="1"] {
-      image: url(skin:/palemoon/buttons/btn__repeat_active_12.svg) no-repeat center center;
+      background: url(skin:/palemoon/buttons/btn__repeat_active_12.svg) no-repeat center center;
     }
     #RepeatButton34[displayValue="1"] {
-      image: url(skin:/palemoon/buttons/btn__repeat_active_34.svg) no-repeat center center;
+      background: url(skin:/palemoon/buttons/btn__repeat_active_34.svg) no-repeat center center;
     }
 
   #QuantizeButton12[displayValue="0"], #QuantizeButton34[displayValue="0"] {
-    image: url(skin:/palemoon/buttons/btn__quantize.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__quantize.svg) no-repeat center center;
     }
     #QuantizeButton12[displayValue="1"] {
-      image: url(skin:/palemoon/buttons/btn__quantize_active_12.svg) no-repeat center center;
+      background: url(skin:/palemoon/buttons/btn__quantize_active_12.svg) no-repeat center center;
     }
     #QuantizeButton34[displayValue="1"] {
-      image: url(skin:/palemoon/buttons/btn__quantize_active_34.svg) no-repeat center center;
+      background: url(skin:/palemoon/buttons/btn__quantize_active_34.svg) no-repeat center center;
     }
 
   #SlipmodeButton12[displayValue="0"], #SlipmodeButton34[displayValue="0"] {
-    image: url(skin:/palemoon/buttons/btn__slip.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__slip.svg) no-repeat center center;
     }
     #SlipmodeButton12[displayValue="1"] {
-      image: url(skin:/palemoon/buttons/btn__slip_active_12.svg) no-repeat center center;
+      background: url(skin:/palemoon/buttons/btn__slip_active_12.svg) no-repeat center center;
     }
     #SlipmodeButton34[displayValue="1"] {
-      image: url(skin:/palemoon/buttons/btn__slip_active_34.svg) no-repeat center center;
+      background: url(skin:/palemoon/buttons/btn__slip_active_34.svg) no-repeat center center;
     }
 
   #KeylockButton12[displayValue="0"], #KeylockButton34[displayValue="0"] {
-    image: url(skin:/palemoon/buttons/btn__keylock.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__keylock.svg) no-repeat center center;
     }
     #KeylockButton12[displayValue="1"] {
-      image: url(skin:/palemoon/buttons/btn__keylock_active_12.svg) no-repeat center center;
+      background: url(skin:/palemoon/buttons/btn__keylock_active_12.svg) no-repeat center center;
     }
     #KeylockButton34[displayValue="1"] {
-      image: url(skin:/palemoon/buttons/btn__keylock_active_34.svg) no-repeat center center;
+      background: url(skin:/palemoon/buttons/btn__keylock_active_34.svg) no-repeat center center;
     }
 
 #BeatgridControlsToggle[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__beatgrid_controls_expand.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__beatgrid_controls_expand.svg) no-repeat center center;
   }
   #BeatgridControlsToggle[displayValue="1"] {
-    image: url(skin:/palemoon/buttons/btn__beatgrid_controls_collapse.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__beatgrid_controls_collapse.svg) no-repeat center center;
   }
 
   #BeatCurposLarge[displayValue="0"] {
-    image: url(skin:/palemoon/buttons/btn__beat_curpos_large.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__beat_curpos_large.svg) no-repeat center center;
     }
     #BeatCurposLarge[pressed="true"] {
-      image: url(skin:/palemoon/buttons/btn__beat_curpos_large_active.svg) no-repeat center center;
+      background: url(skin:/palemoon/buttons/btn__beat_curpos_large_active.svg) no-repeat center center;
     }
 
   #BeatsEarlier {
-    image: url(skin:/palemoon/buttons/btn__beats_earlier.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__beats_earlier.svg) no-repeat center center;
     }
     #BeatsEarlier[pressed="true"] {
-      image: url(skin:/palemoon/buttons/btn__beats_earlier_active.svg) no-repeat center center;
+      background: url(skin:/palemoon/buttons/btn__beats_earlier_active.svg) no-repeat center center;
     }
 
   #BeatsLater {
-    image: url(skin:/palemoon/buttons/btn__beats_later.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__beats_later.svg) no-repeat center center;
     }
     #BeatsLater[pressed="true"] {
-      image: url(skin:/palemoon/buttons/btn__beats_later_active.svg) no-repeat center center;
+      background: url(skin:/palemoon/buttons/btn__beats_later_active.svg) no-repeat center center;
     }
 
   #BeatsSlower {
-    image: url(skin:/palemoon/buttons/btn__beats_slower.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__beats_slower.svg) no-repeat center center;
     }
     #BeatsSlower[pressed="true"] {
-      image: url(skin:/palemoon/buttons/btn__beats_slower_active.svg) no-repeat center center;
+      background: url(skin:/palemoon/buttons/btn__beats_slower_active.svg) no-repeat center center;
     }
 
   #BeatsFaster {
-    image: url(skin:/palemoon/buttons/btn__beats_faster.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__beats_faster.svg) no-repeat center center;
     }
     #BeatsFaster[pressed="true"] {
-      image: url(skin:/palemoon/buttons/btn__beats_faster_active.svg) no-repeat center center;
+      background: url(skin:/palemoon/buttons/btn__beats_faster_active.svg) no-repeat center center;
     }
   #HotcuesEarlier {
-    image: url(skin:/palemoon/buttons/btn__beats_hotcues_earlier.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__beats_hotcues_earlier.svg) no-repeat center center;
   }
     #HotcuesEarlier[pressed="true"] {
-      image: url(skin:/palemoon/buttons/btn__beats_hotcues_earlier_active.svg) no-repeat center center;
+      background: url(skin:/palemoon/buttons/btn__beats_hotcues_earlier_active.svg) no-repeat center center;
     }
   #HotcuesLater {
-    image: url(skin:/palemoon/buttons/btn__beats_hotcues_later.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__beats_hotcues_later.svg) no-repeat center center;
   }
     #HotcuesLater[pressed="true"] {
-      image: url(skin:/palemoon/buttons/btn__beats_hotcues_later_active.svg) no-repeat center center;
+      background: url(skin:/palemoon/buttons/btn__beats_hotcues_later_active.svg) no-repeat center center;
     }
 
 #MicTalk[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__mic_talk.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__mic_talk.svg) no-repeat center center;
   }
   #MicTalk[displayValue="1"] {
-    image: url(skin:/palemoon/buttons/btn__mic_talk_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__mic_talk_active.svg) no-repeat center center;
   }
 
 #AuxPlay[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__aux_play.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__aux_play.svg) no-repeat center center;
   }
   #AuxPlay[displayValue="1"] {
-    image: url(skin:/palemoon/buttons/btn__aux_play_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__aux_play_active.svg) no-repeat center center;
   }
 
 #MicAuxAdd {
-  image: url(skin:/palemoon/buttons/btn__plus_flat.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__plus_flat.svg) no-repeat center center;
 }
 
 #MicDucking[value="0"] {
-  image: url(skin:/palemoon/buttons/btn__mic_duck_off.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__mic_duck_off.svg) no-repeat center center;
   }
   #MicDucking[value="1"] {
-    image: url(skin:/palemoon/buttons/btn__mic_duck_auto.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__mic_duck_auto.svg) no-repeat center center;
   }
   #MicDucking[value="2"] {
-    image: url(skin:/palemoon/buttons/btn__mic_duck_manual.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__mic_duck_manual.svg) no-repeat center center;
   }
 
 #RecDot[highlight="0"] {
-  image: url(skin:/palemoon/buttons/btn__rec_dot.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__rec_dot.svg) no-repeat center center;
   }
   #RecDot[highlight="1"], #RecDot[highlight="2"] {
-    image: url(skin:/palemoon/buttons/btn__rec_dot_active.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__rec_dot_active.svg) no-repeat center center;
   }
 
 #BroadcastButton[displayValue="0"] {
   /* for some reason the alignment isn't rescpected, so the icons
     have to be sized like available area (button size - margin) */
-  image: url(skin:/palemoon/buttons/btn__broadcast_off.svg) no-repeat left top;
+  background: url(skin:/palemoon/buttons/btn__broadcast_off.svg) no-repeat left top;
   }
   #BroadcastButton[displayValue="1"],
   #BroadcastButton[displayValue="2"],
   #BroadcastButton[displayValue="3"] {
-    image: url(skin:/palemoon/buttons/btn__broadcast_on.svg) no-repeat left top;
+    background: url(skin:/palemoon/buttons/btn__broadcast_on.svg) no-repeat left top;
   }
 
 #SkinSettingsToggle[displayValue="0"] {
-  image: url(skin:/palemoon/buttons/btn__settings_off.svg) no-repeat left top;
+  background: url(skin:/palemoon/buttons/btn__settings_off.svg) no-repeat left top;
   }
   #SkinSettingsToggle[displayValue="1"] {
-    image: url(skin:/palemoon/buttons/btn__settings_on.svg) no-repeat left top;
+    background: url(skin:/palemoon/buttons/btn__settings_on.svg) no-repeat left top;
   }
 
 #ToolbarLogo {
-  image: url(skin:/palemoon/style/mixxx_logo_small.svg) no-repeat center center;
+  background: url(skin:/palemoon/style/mixxx_logo_small.svg) no-repeat center center;
 }
 
 WSearchLineEdit QToolButton:!focus {
-  image: url(skin:/palemoon/buttons/btn__lib_clear_search.svg);
+  background: url(skin:/palemoon/buttons/btn__lib_clear_search.svg);
   }
   WSearchLineEdit QToolButton:focus {
-    image: url(skin:/palemoon/buttons/btn__lib_clear_search_focus.svg);
+    background: url(skin:/palemoon/buttons/btn__lib_clear_search_focus.svg);
   }
 
 /* AutoDJ button icons */
 QPushButton#pushButtonAutoDJ:!checked {
-  image: url(skin:/palemoon/buttons/btn__autodj_enable_off.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__autodj_enable_off.svg) no-repeat center center;
   }
   QPushButton#pushButtonAutoDJ:checked {
-    image: url(skin:/palemoon/buttons/btn__autodj_enable_on.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__autodj_enable_on.svg) no-repeat center center;
   }
 
 QPushButton#pushButtonFadeNow:!enabled {
-  image: url(skin:/palemoon/buttons/btn__autodj_fade_disabled.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__autodj_fade_disabled.svg) no-repeat center center;
   }
   QPushButton#pushButtonFadeNow:enabled {
-    image: url(skin:/palemoon/buttons/btn__autodj_fade.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__autodj_fade.svg) no-repeat center center;
   }
 
 QPushButton#pushButtonSkipNext:!enabled {
-  image: url(skin:/palemoon/buttons/btn__autodj_skip_disabled.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__autodj_skip_disabled.svg) no-repeat center center;
   }
   QPushButton#pushButtonSkipNext:enabled {
-    image: url(skin:/palemoon/buttons/btn__autodj_skip.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__autodj_skip.svg) no-repeat center center;
   }
 
 QPushButton#pushButtonShuffle:enabled {
-  image: url(skin:/palemoon/buttons/btn__autodj_shuffle.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__autodj_shuffle.svg) no-repeat center center;
 }
 
 QPushButton#pushButtonAddRandom:enabled {
-  image: url(skin:/palemoon/buttons/btn__autodj_addrandom.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__autodj_addrandom.svg) no-repeat center center;
 }
 
 QPushButton#pushButtonRepeatPlaylist:!checked {
-  image: url(skin:/palemoon/buttons/btn__autodj_repeat_playlist_off.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__autodj_repeat_playlist_off.svg) no-repeat center center;
   }
   QPushButton#pushButtonRepeatPlaylist:checked {
-    image: url(skin:/palemoon/buttons/btn__autodj_repeat_playlist_on.svg) no-repeat center center;
+    background: url(skin:/palemoon/buttons/btn__autodj_repeat_playlist_on.svg) no-repeat center center;
   }
 /* AutoDJ button icons */
 

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -1551,285 +1551,6 @@ WPushButton#CrossfaderButton,
 
 
 
-/************** button background colors **************************************/
-
-/* top-level buttons in transport, fx, micaux and others */
-#DeckRow_5_LoopCuesTransport WPushButton[displayValue="0"],
-#PlayCueMini WPushButton[displayValue="0"],
-WPushButton#PlayIndicator[displayValue="0"],
-WPushButton#CueDeck[displayValue="0"],
-#SamplerPlayBox WPushButton#PreviewIndicator,
-WPushButton#LoopActivate[displayValue="0"],
-#KeyControls WPushButton[displayValue="0"],
-#EQKillButtonBox WPushButton[displayValue="0"],
-WPushButton#QuickEffectButton[displayValue="0"],
-WPushButton#FxToggleButton[displayValue="0"],
-#MicAuxUnit WPushButton[displayValue="0"],
-#MicDuckingContainer WPushButton[displayValue="0"],
-WBeatSpinBox,
-WBeatSpinBox::up-button,
-WBeatSpinBox::down-button {
-  background-color: #121213;
-  }
-  /* dim buttons in top-level containers */
-  #LoopControls WPushButton[displayValue="0"],
-  #BeatjumpControls WPushButton[displayValue="0"],
-  WPushButton#SyncDeck[value="0"],
-  WBeatSpinBox::up-button,
-  WBeatSpinBox::down-button,
-  WPushButton#LoopActivate[displayValue="0"], /* in compact deck */
-  WPushButton#FxParameterButton[displayValue="0"],
-  #LibraryContainer QHeaderView,
-  #LibraryContainer QHeaderView::section {
-    background-color: #171719;
-  }
-  /* even buttons in 2nd level containers */
-  #FxAssignButtons WPushButton[displayValue="0"],
-  #VinylControls WPushButton[displayValue="0"],
-  #KeyControls WPushButton[displayValue="0"],
-  WPushButton#VinylModeButton[displayValue="1"],
-  WPushButton#VinylModeButton[displayValue="2"],
-  WPushButton#HotcueButton[displayValue="0"],
-  WPushButton#SpecialCueButton[displayValue="0"],
-  #RateControls WPushButton[displayValue="0"],
-  WPushButton#PflButton[displayValue="0"],
-  WPushButton#MixModeButton[displayValue="0"],
-  WPushButton#MixModeButton[displayValue="1"],
-  WEffectSelector,
-  #fadeModeCombobox,
-  #SamplerContainer WPushButton#SyncSampler[displayValue="0"],
-  #SamplerContainer WPushButton#PflButton[displayValue="0"],
-  #MicAuxUnit WPushButton#PflButton[displayValue="0"],
-  WPushButton#MicAuxAdd {
-    background-color: #1e1e20;
-  }
-  /* brigth buttons in dimmed containers
-  #BeatgridControls WPushButton[displayValue="0"], */
-  #CueDeleteButton,
-  #SplitCue[displayValue="0"],
-  #PlayPreview[displayValue="0"],
-  /* library controls */
-  #spinBoxTransition::up-button,
-  #spinBoxTransition::down-button,
-  QPushButton#pushButtonAutoDJ:enabled:!checked,
-  #LibraryFeatureControls QPushButton:enabled {
-    background-color: #222;
-  }
-  /* dark buttons in toolbar */
-  #ToolBar WPushButton[displayValue="0"],
-  #MixerMasterHeadphone #FxAssignButtons WPushButton[displayValue="0"] {
-    background-color: #151517;
-  }
-
-/* Orange for 'active' status */
-WPushButton#PlayDeck[displayValue="1"],
-WPushButton#PlayDeckMini[displayValue="1"],
-WPushButton#PlaySampler[displayValue="1"],
-WPushButton#PlayPreview[displayValue="1"],
-WPushButton#PlayIndicator[displayValue="1"],
-#LibraryPreviewButton:checked,
-#CueDeck[displayValue="1"],
-WPushButton#Reverse[pressed="true"],
-#LoopActivate[value="1"],
-#Reloop[value="1"],
-#SyncSampler[displayValue="1"],
-#MicTalk[value="1"], #AuxPlay[value="1"],
-#MicDucking[value="1"],
-#MicDucking[value="2"],
-#VinylButton[displayValue="1"],
-#PassthroughButton[displayValue="1"],
-QPushButton#pushButtonAutoDJ:checked,
-QPushButton#pushButtonAnalyze:checked {
-  background-color: #b24c12;
-  }
-  /* Orange border for Play buttons when previewing from
-    Cue or Hotcue */
-  WPushButton#PreviewIndicator[value="1"] {
-    border: 3px solid #b24c12;
-    /* work around round borders being painted outside the actual border area */
-    border-radius: 0px;
-  }
-/* dim orange for momentary controls */
-#KeyControls WPushButton[pressed="true"],
-#SyncDeck[value="1"],
-WPushButton#LoopIn[pressed="true"],
-WPushButton#LoopOut[pressed="true"],
-#BeatjumpControls WPushButton[value="1"],
-#RateControls WPushButton[value="1"],
-#BeatgridControls WPushButton[pressed="true"]/*,
-#CueDeleteButton[pressed="true"]*/ {
-  background-color: #7d350d;
-  }
-  #BpmTap[pressed="true"] {
-   border: 1px solid #7d350d;
-  }
-
-/* Red */
-#EQKillButtonBox WPushButton[displayValue="1"],
-QPushButton#pushButtonRecording:checked,
-#RecFeedback[displayValue="2"] {
-  background-color: #a80000;
-}
-
-/* Green for Fx toggles, QuickEffect + Fx12 */
-#FxUnit1 #FxToggleButton[displayValue="1"],
-#FxUnit2 #FxToggleButton[displayValue="1"],
-#BroadcastButton[displayValue="2"] {
-  background-color: #438225;
-  }
-  /* Dim green for assign buttons Fx12 */
-  WPushButton#QuickEffectButton[displayValue="1"],
-  #FxAssignButton1[displayValue="1"],
-  #FxAssignButton2[displayValue="1"] {
-    background-color: #236b00;
-  }
-/* Blue for Fx buttons 3/4 */
-#FxUnit3 #FxToggleButton[displayValue="1"],
-#FxUnit4 #FxToggleButton[displayValue="1"],
-WBeatSpinBox::up-button:pressed,
-WBeatSpinBox::down-button:pressed,
-#spinBoxTransition::up-button:pressed,
-#spinBoxTransition::down-button:pressed {
-  background-color: #257b82;
-  }
-  /* Dim blue for assign buttons Fx34 */
-  #FxAssignButton3[displayValue="1"],
-  #FxAssignButton4[displayValue="1"] {
-    background-color: #146674;
-  }
-
-WPushButton#FxSuperLinkButton[value="0"],
-WPushButton#FxSuperLinkInvertButton[displayValue="0"] {
-  background-color: #333;
-  }
-  #FxSuperLinkInvertButton[displayValue="1"] {
-    background-color: #9C0900;
-    }
-
-/* Green for Fx1 / Fx2 */
-#FxUnit1 #FxSuperLinkButton[value="1"],
-#FxUnit2 #FxSuperLinkButton[value="1"] {
-  background-color: #236b00;
-  }
-#FxUnit1 #FxSuperLinkButton[value="2"],
-#FxUnit2 #FxSuperLinkButton[value="2"] {
-/* a simple way to achieve a partitioning in thirds  */
-  background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0,
-    stop: 0 #236b00,
-    stop: 0.33 #236b00,
-    stop: 0.34 #333,
-    stop: 1 #333);
-  }
-#FxUnit1 #FxSuperLinkButton[value="3"],
-#FxUnit2 #FxSuperLinkButton[value="3"] {
-  background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0,
-    stop: 0 #333,
-    stop: 0.66 #333,
-    stop: 0.67 #236b00,
-    stop: 1 #236b00);
-  }
-#FxUnit1 #FxSuperLinkButton[value="4"],
-#FxUnit2 #FxSuperLinkButton[value="4"] {
-  background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0,
-    stop: 0 #236b00,
-    stop: 0.330000 #236b00,
-    stop: 0.340000 #333,
-    stop: 0.660000 #333,
-    stop: 0.670000 #236b00,
-    stop: 1 #236b00);
-  }
-
-/* Blue for Fx3 / Fx4 */
-#FxUnit3 #FxSuperLinkButton[value="1"],
-#FxUnit4 #FxSuperLinkButton[value="1"] {
-  background-color: #146674;
-  }
-#FxUnit3 #FxSuperLinkButton[value="2"],
-#FxUnit4 #FxSuperLinkButton[value="2"] {  /*
-  a simple way to achieve a partitioning in thirds  */
-  background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0,
-    stop: 0 #146674,
-    stop: 0.33 #146674,
-    stop: 0.34 #333,
-    stop: 1 #333);
-  }
-#FxUnit3 #FxSuperLinkButton[value="3"],
-#FxUnit4 #FxSuperLinkButton[value="3"] {
-  background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0,
-    stop: 0 #333,
-    stop: 0.66 #333,
-    stop: 0.67 #146674,
-    stop: 1 #146674);
-  }
-#FxUnit3 #FxSuperLinkButton[value="4"],
-#FxUnit4 #FxSuperLinkButton[value="4"] {
-  background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0,
-    stop: 0 #146674,
-    stop: 0.330000 #146674,
-    stop: 0.340000 #333,
-    stop: 0.660000 #333,
-    stop: 0.670000 #146674,
-    stop: 1 #146674);
-  }
-
-/* Yellow */
-#RecFeedback[displayValue="1"],     /* initialize recording */
-#BroadcastButton[displayValue="1"]  /* connecting */ {
-  background-color: #d09300;
-}
-
-#SpecialCueButton[value="1"] {
-  background-color: #395579;
-}
-
-/* pink */
-#BroadcastButton[displayValue="3"], /* failure */
-#RecFeedback[displayValue="3"] {
-  background-color: #f856e7;
-}
-
-/* Grey for GUI toggles */
-#GuiToggleButton[displayValue="1"],
-#SkinSettingsToggle[displayValue="1"] {
-  background-color: #777;
-}
-
-/* Grey */
-#VinylCueButton[displayValue="1"],
-#VinylCueButton[displayValue="2"],
-#PflButton[value="1"],
-#FxParameterButton[displayValue="1"],
-QPushButton#pushButtonRepeatPlaylist:checked {
-  background-color: #666;
-}
-
-/* Darker grey */
-#SplitCue[value="1"] {
-  background-color: #555;
-}
-
-/* Special flat/invisible buttons */
-#BeatgridControlsToggle,
-WPushButton#PlayDeck[displayValue="0"],
-WPushButton#PlayDeckMini[displayValue="0"],
-WPushButton#PlaySampler[displayValue="0"],
-#DeckRow_5_LoopCuesTransport WPushButton#PreviewIndicator,
-#PlayCueMini WPushButton#PreviewIndicator,
-WPushButton#FxFocusButton[displayValue="0"],
-#SamplerSettings WPushButton[displayValue="0"],
-#SamplerSettingsMini WPushButton[displayValue="0"],
-WPushButton#FxExpand[displayValue="0"],
-WPushButton#SamplerExpand[displayValue="0"],
-WPushButton#CrossfaderButton[displayValue="0"],
-WPushButton#CrossfaderButton[displayValue="1"],
-WPushButton#RecButton[displayValue="0"],
-WPushButton#RecButton[displayValue="1"],
-#RecDot {
-  background-color: transparent;
-}
-
-
-
 /************** Button icons **************************************************/
 WPushButton#PlayDeck[value="0"] {
   background: url(skin:/palemoon/buttons/btn__play_deck.svg) no-repeat center center;
@@ -2435,6 +2156,285 @@ WColorPicker QPushButton[checked="true"] {
 }
 
 /************** Button icons **************************************************/
+
+/************** button background colors **************************************/
+
+/* top-level buttons in transport, fx, micaux and others */
+#DeckRow_5_LoopCuesTransport WPushButton[displayValue="0"],
+#PlayCueMini WPushButton[displayValue="0"],
+WPushButton#PlayIndicator[displayValue="0"],
+WPushButton#CueDeck[displayValue="0"],
+#SamplerPlayBox WPushButton#PreviewIndicator,
+WPushButton#LoopActivate[displayValue="0"],
+#KeyControls WPushButton[displayValue="0"],
+#EQKillButtonBox WPushButton[displayValue="0"],
+WPushButton#QuickEffectButton[displayValue="0"],
+WPushButton#FxToggleButton[displayValue="0"],
+#MicAuxUnit WPushButton[displayValue="0"],
+#MicDuckingContainer WPushButton[displayValue="0"],
+WBeatSpinBox,
+WBeatSpinBox::up-button,
+WBeatSpinBox::down-button {
+  background-color: #121213;
+  }
+  /* dim buttons in top-level containers */
+  #LoopControls WPushButton[displayValue="0"],
+  #BeatjumpControls WPushButton[displayValue="0"],
+  WPushButton#SyncDeck[value="0"],
+  WBeatSpinBox::up-button,
+  WBeatSpinBox::down-button,
+  WPushButton#LoopActivate[displayValue="0"], /* in compact deck */
+  WPushButton#FxParameterButton[displayValue="0"],
+  #LibraryContainer QHeaderView,
+  #LibraryContainer QHeaderView::section {
+    background-color: #171719;
+  }
+  /* even buttons in 2nd level containers */
+  #FxAssignButtons WPushButton[displayValue="0"],
+  #VinylControls WPushButton[displayValue="0"],
+  #KeyControls WPushButton[displayValue="0"],
+  WPushButton#VinylModeButton[displayValue="1"],
+  WPushButton#VinylModeButton[displayValue="2"],
+  WPushButton#HotcueButton[displayValue="0"],
+  WPushButton#SpecialCueButton[displayValue="0"],
+  #RateControls WPushButton[displayValue="0"],
+  WPushButton#PflButton[displayValue="0"],
+  WPushButton#MixModeButton[displayValue="0"],
+  WPushButton#MixModeButton[displayValue="1"],
+  WEffectSelector,
+  #fadeModeCombobox,
+  #SamplerContainer WPushButton#SyncSampler[displayValue="0"],
+  #SamplerContainer WPushButton#PflButton[displayValue="0"],
+  #MicAuxUnit WPushButton#PflButton[displayValue="0"],
+  WPushButton#MicAuxAdd {
+    background-color: #1e1e20;
+  }
+  /* brigth buttons in dimmed containers
+  #BeatgridControls WPushButton[displayValue="0"], */
+  #CueDeleteButton,
+  #SplitCue[displayValue="0"],
+  #PlayPreview[displayValue="0"],
+  /* library controls */
+  #spinBoxTransition::up-button,
+  #spinBoxTransition::down-button,
+  QPushButton#pushButtonAutoDJ:enabled:!checked,
+  #LibraryFeatureControls QPushButton:enabled {
+    background-color: #222;
+  }
+  /* dark buttons in toolbar */
+  #ToolBar WPushButton[displayValue="0"],
+  #MixerMasterHeadphone #FxAssignButtons WPushButton[displayValue="0"] {
+    background-color: #151517;
+  }
+
+/* Orange for 'active' status */
+WPushButton#PlayDeck[displayValue="1"],
+WPushButton#PlayDeckMini[displayValue="1"],
+WPushButton#PlaySampler[displayValue="1"],
+WPushButton#PlayPreview[displayValue="1"],
+WPushButton#PlayIndicator[displayValue="1"],
+#LibraryPreviewButton:checked,
+#CueDeck[displayValue="1"],
+WPushButton#Reverse[pressed="true"],
+#LoopActivate[value="1"],
+#Reloop[value="1"],
+#SyncSampler[displayValue="1"],
+#MicTalk[value="1"], #AuxPlay[value="1"],
+#MicDucking[value="1"],
+#MicDucking[value="2"],
+#VinylButton[displayValue="1"],
+#PassthroughButton[displayValue="1"],
+QPushButton#pushButtonAutoDJ:checked,
+QPushButton#pushButtonAnalyze:checked {
+  background-color: #b24c12;
+  }
+  /* Orange border for Play buttons when previewing from
+    Cue or Hotcue */
+  WPushButton#PreviewIndicator[value="1"] {
+    border: 3px solid #b24c12;
+    /* work around round borders being painted outside the actual border area */
+    border-radius: 0px;
+  }
+/* dim orange for momentary controls */
+#KeyControls WPushButton[pressed="true"],
+#SyncDeck[value="1"],
+WPushButton#LoopIn[pressed="true"],
+WPushButton#LoopOut[pressed="true"],
+#BeatjumpControls WPushButton[value="1"],
+#RateControls WPushButton[value="1"],
+#BeatgridControls WPushButton[pressed="true"]/*,
+#CueDeleteButton[pressed="true"]*/ {
+  background-color: #7d350d;
+  }
+  #BpmTap[pressed="true"] {
+   border: 1px solid #7d350d;
+  }
+
+/* Red */
+#EQKillButtonBox WPushButton[displayValue="1"],
+QPushButton#pushButtonRecording:checked,
+#RecFeedback[displayValue="2"] {
+  background-color: #a80000;
+}
+
+/* Green for Fx toggles, QuickEffect + Fx12 */
+#FxUnit1 #FxToggleButton[displayValue="1"],
+#FxUnit2 #FxToggleButton[displayValue="1"],
+#BroadcastButton[displayValue="2"] {
+  background-color: #438225;
+  }
+  /* Dim green for assign buttons Fx12 */
+  WPushButton#QuickEffectButton[displayValue="1"],
+  #FxAssignButton1[displayValue="1"],
+  #FxAssignButton2[displayValue="1"] {
+    background-color: #236b00;
+  }
+/* Blue for Fx buttons 3/4 */
+#FxUnit3 #FxToggleButton[displayValue="1"],
+#FxUnit4 #FxToggleButton[displayValue="1"],
+WBeatSpinBox::up-button:pressed,
+WBeatSpinBox::down-button:pressed,
+#spinBoxTransition::up-button:pressed,
+#spinBoxTransition::down-button:pressed {
+  background-color: #257b82;
+  }
+  /* Dim blue for assign buttons Fx34 */
+  #FxAssignButton3[displayValue="1"],
+  #FxAssignButton4[displayValue="1"] {
+    background-color: #146674;
+  }
+
+WPushButton#FxSuperLinkButton[value="0"],
+WPushButton#FxSuperLinkInvertButton[displayValue="0"] {
+  background-color: #333;
+  }
+  #FxSuperLinkInvertButton[displayValue="1"] {
+    background-color: #9C0900;
+    }
+
+/* Green for Fx1 / Fx2 */
+#FxUnit1 #FxSuperLinkButton[value="1"],
+#FxUnit2 #FxSuperLinkButton[value="1"] {
+  background-color: #236b00;
+  }
+#FxUnit1 #FxSuperLinkButton[value="2"],
+#FxUnit2 #FxSuperLinkButton[value="2"] {
+/* a simple way to achieve a partitioning in thirds  */
+  background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0,
+    stop: 0 #236b00,
+    stop: 0.33 #236b00,
+    stop: 0.34 #333,
+    stop: 1 #333);
+  }
+#FxUnit1 #FxSuperLinkButton[value="3"],
+#FxUnit2 #FxSuperLinkButton[value="3"] {
+  background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0,
+    stop: 0 #333,
+    stop: 0.66 #333,
+    stop: 0.67 #236b00,
+    stop: 1 #236b00);
+  }
+#FxUnit1 #FxSuperLinkButton[value="4"],
+#FxUnit2 #FxSuperLinkButton[value="4"] {
+  background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0,
+    stop: 0 #236b00,
+    stop: 0.330000 #236b00,
+    stop: 0.340000 #333,
+    stop: 0.660000 #333,
+    stop: 0.670000 #236b00,
+    stop: 1 #236b00);
+  }
+
+/* Blue for Fx3 / Fx4 */
+#FxUnit3 #FxSuperLinkButton[value="1"],
+#FxUnit4 #FxSuperLinkButton[value="1"] {
+  background-color: #146674;
+  }
+#FxUnit3 #FxSuperLinkButton[value="2"],
+#FxUnit4 #FxSuperLinkButton[value="2"] {  /*
+  a simple way to achieve a partitioning in thirds  */
+  background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0,
+    stop: 0 #146674,
+    stop: 0.33 #146674,
+    stop: 0.34 #333,
+    stop: 1 #333);
+  }
+#FxUnit3 #FxSuperLinkButton[value="3"],
+#FxUnit4 #FxSuperLinkButton[value="3"] {
+  background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0,
+    stop: 0 #333,
+    stop: 0.66 #333,
+    stop: 0.67 #146674,
+    stop: 1 #146674);
+  }
+#FxUnit3 #FxSuperLinkButton[value="4"],
+#FxUnit4 #FxSuperLinkButton[value="4"] {
+  background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0,
+    stop: 0 #146674,
+    stop: 0.330000 #146674,
+    stop: 0.340000 #333,
+    stop: 0.660000 #333,
+    stop: 0.670000 #146674,
+    stop: 1 #146674);
+  }
+
+/* Yellow */
+#RecFeedback[displayValue="1"],     /* initialize recording */
+#BroadcastButton[displayValue="1"]  /* connecting */ {
+  background-color: #d09300;
+}
+
+WPushButton#SpecialCueButton[value="1"] {
+  background-color: #395579;
+}
+
+/* pink */
+#BroadcastButton[displayValue="3"], /* failure */
+#RecFeedback[displayValue="3"] {
+  background-color: #f856e7;
+}
+
+/* Grey for GUI toggles */
+#GuiToggleButton[displayValue="1"],
+#SkinSettingsToggle[displayValue="1"] {
+  background-color: #777;
+}
+
+/* Grey */
+#VinylCueButton[displayValue="1"],
+#VinylCueButton[displayValue="2"],
+#PflButton[value="1"],
+#FxParameterButton[displayValue="1"],
+QPushButton#pushButtonRepeatPlaylist:checked {
+  background-color: #666;
+}
+
+/* Darker grey */
+#SplitCue[value="1"] {
+  background-color: #555;
+}
+
+/* Special flat/invisible buttons */
+#BeatgridControlsToggle,
+WPushButton#PlayDeck[displayValue="0"],
+WPushButton#PlayDeckMini[displayValue="0"],
+WPushButton#PlaySampler[displayValue="0"],
+#DeckRow_5_LoopCuesTransport WPushButton#PreviewIndicator,
+#PlayCueMini WPushButton#PreviewIndicator,
+WPushButton#FxFocusButton[displayValue="0"],
+#SamplerSettings WPushButton[displayValue="0"],
+#SamplerSettingsMini WPushButton[displayValue="0"],
+WPushButton#FxExpand[displayValue="0"],
+WPushButton#SamplerExpand[displayValue="0"],
+WPushButton#CrossfaderButton[displayValue="0"],
+WPushButton#CrossfaderButton[displayValue="1"],
+WPushButton#RecButton[displayValue="0"],
+WPushButton#RecButton[displayValue="1"],
+#RecDot {
+  background-color: transparent;
+}
+
+
 /************** Button styles *************************************************/
 
 


### PR DESCRIPTION
WIP
For those affected by https://bugs.launchpad.net/mixxx/+bug/1922966
(Arch, Ubuntu 21.04 with kiconthemes installed)

Choose LateNight PaleMoon theme and test
* if all icons show up with appropriate size
* all button states have the correct background color
* the logo in the launch screen is sized correctly

the `background` shorthand is the only one-line way to achieve the previous look
(alternative: separate `background-image`, `background-position` and `background-repeat` lines...)
``` diff
 #Hotcue1 WPushButton[displayValue="1"][dark="false"] {
-  image: url(skin:/palemoon/buttons/btn__1_active.svg) no-repeat center center;
+  background: url(skin:/palemoon/buttons/btn__1_active.svg) no-repeat center center;
 }
```
BUT since we omit `background-color` transprent bg color is assumed, thus all button background color definitions must be moved after setting the icons.

If that pattern works and is applicable to the other skins I'll fix those, too.