### PR TITLE
Try to fix arm test failures Lp1927859

### DIFF
--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -867,6 +867,9 @@ double BpmControl::getBeatMatchPosition(
     const double dOtherPosition = pOtherEngineBuffer->getExactPlayPos();
     const double dThisSampleRate = m_pBeats->getSampleRate();
     const double dThisRateRatio = m_pRateRatio->get();
+    if (dThisRateRatio == 0.0) {
+        return dThisPosition;
+    }
 
     // Seek our next beat to the other next beat near our beat.
     // This is the only thing we can do if the track has different BPM,

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -793,6 +793,13 @@ double BpmControl::getBeatMatchPosition(
     if (!m_pBeats) {
         return dThisPosition;
     }
+    const double dThisRateRatio = m_pRateRatio->get();
+    if (dThisRateRatio == 0.0) {
+        // We can't continue without a rate.
+        // This avoids also a division by zero in the following calculations
+        return dThisPosition;
+    }
+
     // Explicit master buffer is always in sync!
     if (getSyncMode() == SYNC_MASTER_EXPLICIT) {
         return dThisPosition;
@@ -866,10 +873,6 @@ double BpmControl::getBeatMatchPosition(
 
     const double dOtherPosition = pOtherEngineBuffer->getExactPlayPos();
     const double dThisSampleRate = m_pBeats->getSampleRate();
-    const double dThisRateRatio = m_pRateRatio->get();
-    if (dThisRateRatio == 0.0) {
-        return dThisPosition;
-    }
 
     // Seek our next beat to the other next beat near our beat.
     // This is the only thing we can do if the track has different BPM,

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1335,13 +1335,8 @@ bool EngineBuffer::isTrackLoaded() {
 
 bool EngineBuffer::getQueuedSeekPosition(double* pSeekPosition) {
     const QueuedSeek queuedSeek = m_queuedSeek.getValue();
-    bool isSeekQueued = queuedSeek.seekType != SEEK_NONE;
-    if (isSeekQueued) {
-        *pSeekPosition = queuedSeek.position;
-    } else {
-        *pSeekPosition = -1;
-    }
-    return isSeekQueued;
+    *pSeekPosition = queuedSeek.position;
+    return (queuedSeek.seekType != SEEK_NONE);
 }
 
 void EngineBuffer::slotEjectTrack(double v) {

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1157,8 +1157,6 @@ void EngineBuffer::processSeek(bool paused) {
     SeekRequests seekType = queuedSeek.seekType;
     double position = queuedSeek.position;
 
-    m_queuedSeek.setValue(kNoQueuedSeek);
-
     // Don't allow the playposition to go past the end.
     if (position > m_trackSamplesOld) {
         position = m_trackSamplesOld;
@@ -1188,7 +1186,8 @@ void EngineBuffer::processSeek(bool paused) {
             // new position was already set above
             break;
         default:
-            qWarning() << "Unhandled seek request type: " << seekType;
+            DEBUG_ASSERT(!"Unhandled seek request type");
+            m_queuedSeek.setValue(kNoQueuedSeek);
             return;
     }
 
@@ -1211,6 +1210,10 @@ void EngineBuffer::processSeek(bool paused) {
         }
         setNewPlaypos(position);
     }
+    // Reset the m_queuedSeek value after it has been processed in
+    // setNewPlaypos() so that the Engine Controls have always access to the
+    // position of the upcoming buffer cycle (used for loop cues)
+    m_queuedSeek.setValue(kNoQueuedSeek);
 }
 
 void EngineBuffer::postProcess(const int iBufferSize) {

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -47,12 +47,13 @@
 namespace {
 const mixxx::Logger kLogger("EngineBuffer");
 
-const double kLinearScalerElipsis = 1.00058; // 2^(0.01/12): changes < 1 cent allows a linear scaler
+constexpr double kLinearScalerElipsis =
+        1.00058; // 2^(0.01/12): changes < 1 cent allows a linear scaler
 
-const SINT kSamplesPerFrame = 2; // Engine buffer uses Stereo frames only
+constexpr SINT kSamplesPerFrame = 2; // Engine buffer uses Stereo frames only
 
 // Rate at which the playpos slider is updated
-const int kPlaypositionUpdateRate = 15; // updates per second
+constexpr int kPlaypositionUpdateRate = 15; // updates per second
 
 } // anonymous namespace
 
@@ -96,6 +97,8 @@ EngineBuffer::EngineBuffer(const QString& group,
           m_pCrossfadeBuffer(SampleUtil::alloc(MAX_BUFFER_LEN)),
           m_bCrossfadeReady(false),
           m_iLastBufferSize(0) {
+    m_queuedSeek.setValue(kNoQueuedSeek);
+
     // zero out crossfade buffer
     SampleUtil::clear(m_pCrossfadeBuffer, MAX_BUFFER_LEN);
 
@@ -1154,7 +1157,7 @@ void EngineBuffer::processSeek(bool paused) {
     SeekRequests seekType = queuedSeek.seekType;
     double position = queuedSeek.position;
 
-    m_queuedSeek.setValue({-1, SEEK_NONE});
+    m_queuedSeek.setValue(kNoQueuedSeek);
 
     // Don't allow the playposition to go past the end.
     if (position > m_trackSamplesOld) {

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -374,8 +374,7 @@ void EngineBuffer::queueNewPlaypos(double newpos, enum SeekRequest seekType) {
         // use SEEK_STANDARD for that
         seekType = SEEK_STANDARD;
     }
-    struct QueuedSeek queuedSeek = {newpos, seekType};
-    m_queuedSeek.setValue(queuedSeek);
+    m_queuedSeek.setValue({newpos, seekType});
 }
 
 void EngineBuffer::requestSyncPhase() {
@@ -625,7 +624,7 @@ bool EngineBuffer::updateIndicatorsAndModifyPlay(bool newPlay, bool oldPlay) {
     // allow the set since it might apply to a track we are loading due to the
     // asynchrony.
     bool playPossible = true;
-    struct QueuedSeek queuedSeek = m_queuedSeek.getValue();
+    const QueuedSeek queuedSeek = m_queuedSeek.getValue();
     if ((!m_pCurrentTrack && atomicLoadRelaxed(m_iTrackLoading) == 0) ||
             (m_pCurrentTrack && atomicLoadRelaxed(m_iTrackLoading) == 0 &&
                     m_filepos_play >= m_pTrackSamples->get() &&
@@ -1150,13 +1149,12 @@ void EngineBuffer::processSeek(bool paused) {
         seekCloneBuffer(pChannel->getEngineBuffer());
     }
 
-    struct QueuedSeek queuedSeek = m_queuedSeek.getValue();
+    const QueuedSeek queuedSeek = m_queuedSeek.getValue();
 
     SeekRequests seekType = queuedSeek.seekType;
     double position = queuedSeek.position;
 
-    queuedSeek = {-1, SEEK_NONE};
-    m_queuedSeek.setValue(queuedSeek);
+    m_queuedSeek.setValue({-1, SEEK_NONE});
 
     // Don't allow the playposition to go past the end.
     if (position > m_trackSamplesOld) {
@@ -1333,7 +1331,7 @@ bool EngineBuffer::isTrackLoaded() {
 }
 
 bool EngineBuffer::getQueuedSeekPosition(double* pSeekPosition) {
-    struct QueuedSeek queuedSeek = m_queuedSeek.getValue();
+    const QueuedSeek queuedSeek = m_queuedSeek.getValue();
     bool isSeekQueued = queuedSeek.seekType != SEEK_NONE;
     if (isSeekQueued) {
         *pSeekPosition = queuedSeek.position;

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -191,6 +191,11 @@ class EngineBuffer : public EngineObject {
     void slotUpdatedTrackBeats();
 
   private:
+    struct QueuedSeek {
+        double position;
+        enum SeekRequest seekType;
+    };
+
     // Add an engine control to the EngineBuffer
     // must not be called outside the Constructor
     void addControl(EngineControl* pControl);
@@ -375,11 +380,10 @@ class EngineBuffer : public EngineObject {
     // Indicates that dependency injection has taken place.
     bool m_bScalerOverride;
 
-    QAtomicInt m_iSeekQueued;
     QAtomicInt m_iSeekPhaseQueued;
     QAtomicInt m_iEnableSyncQueued;
     QAtomicInt m_iSyncModeQueued;
-    ControlValueAtomic<double> m_queuedSeekPosition;
+    ControlValueAtomic<struct QueuedSeek> m_queuedSeek;
     QAtomicPointer<EngineChannel> m_pChannelToCloneFrom;
 
     // Is true if the previous buffer was silent due to pausing

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -383,7 +383,7 @@ class EngineBuffer : public EngineObject {
     QAtomicInt m_iSeekPhaseQueued;
     QAtomicInt m_iEnableSyncQueued;
     QAtomicInt m_iSyncModeQueued;
-    ControlValueAtomic<struct QueuedSeek> m_queuedSeek;
+    ControlValueAtomic<QueuedSeek> m_queuedSeek;
     QAtomicPointer<EngineChannel> m_pChannelToCloneFrom;
 
     // Is true if the previous buffer was silent due to pausing

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -384,6 +384,8 @@ class EngineBuffer : public EngineObject {
     QAtomicInt m_iEnableSyncQueued;
     QAtomicInt m_iSyncModeQueued;
     ControlValueAtomic<QueuedSeek> m_queuedSeek;
+    static constexpr QueuedSeek kNoQueuedSeek = {
+            -1.0, SEEK_NONE}; // value used if no seek is queued
     QAtomicPointer<EngineChannel> m_pChannelToCloneFrom;
 
     // Is true if the previous buffer was silent due to pausing


### PR DESCRIPTION
This is the attempt to fix the arm test failures. 
They are probably cause by a div by zero operation using 0.0 rate_ratio. 
In addition this fixes doubtful code around the seek queue. Now the position and the type are stored as a single atomic which guarantees that they will always belong together.

https://bugs.launchpad.net/mixxx/+bug/1927859