### PR TITLE
Skins: transform qss icon urls into absolute paths

### DIFF
--- a/src/skin/legacyskinparser.h
+++ b/src/skin/legacyskinparser.h
@@ -143,6 +143,7 @@ class LegacySkinParser : public QObject, public SkinParser {
             bool* pCreated = nullptr);
 
     QString parseLaunchImageStyle(const QDomNode& node);
+    QString stylesheetAbsIconPaths(QString& style);
     void parseChildren(const QDomElement& node, WWidgetGroup* pGroup);
 
     UserSettingsPointer m_pConfig;

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -261,6 +261,10 @@ class SkinContext {
         return m_pConfig;
     }
 
+    QString getSkinBasePath() const {
+        return m_skinBasePath;
+    }
+
   private:
     PixmapSource getPixmapSourceInner(const QString& filename) const;
 


### PR DESCRIPTION
work around https://bugs.launchpad.net/mixxx/+bug/1922966

actually we could use the `background` shorthand in qss instead of the affected `image` #3863 
but that is a lot of work with (see that PR description) and also doesn't work satisfactory for library widgets, since `background` wouldn't scale images to the actual button size (which varies depending on the library font and the width of the preview column for example).

This pr simply adds absolute file paths where we use **skin:**/colortheme/icons.