### PR TITLE
Use fixed-size integer types for audio stream properties

### DIFF
--- a/src/audio/types.h
+++ b/src/audio/types.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QtDebug>
+#include <cstdint>
 
 #include "util/assert.h"
 #include "util/optional.h"
@@ -34,7 +35,9 @@ QDebug operator<<(QDebug dbg, ChannelLayout arg);
 
 class ChannelCount {
   public:
-    typedef SINT value_t;
+    // Use a native type with more than 8 bits to avoid -Werror=type-limits
+    // errors on comparisons with the min/max constants.
+    typedef uint16_t value_t;
 
   private:
     // The default value is invalid and indicates a missing or unknown value.
@@ -73,8 +76,7 @@ class ChannelCount {
     }
 
     constexpr bool isValid() const {
-        return (kValueMin <= m_value) &&
-                (m_value <= kValueMax);
+        return kValueMin <= m_value && m_value <= kValueMax;
     }
 
     /*implicit*/ constexpr operator value_t() const {
@@ -87,7 +89,7 @@ class ChannelCount {
 
 class SampleRate {
   public:
-    typedef SINT value_t;
+    typedef uint32_t value_t;
 
   private:
     // The default value is invalid and indicates a missing or unknown value.
@@ -114,8 +116,7 @@ class SampleRate {
     }
 
     constexpr bool isValid() const {
-        return (kValueMin <= m_value) &&
-                (m_value <= kValueMax);
+        return kValueMin <= m_value && m_value <= kValueMax;
     }
 
     void operator=(const value_t& value) {
@@ -145,7 +146,7 @@ QDebug operator<<(QDebug dbg, SampleRate arg);
 // expected quality.
 class Bitrate {
   public:
-    typedef SINT value_t;
+    typedef uint32_t value_t;
 
   private:
     // The default value is invalid and indicates a missing or unknown value.

--- a/src/encoder/encoderopus.cpp
+++ b/src/encoder/encoderopus.cpp
@@ -23,7 +23,7 @@ constexpr int kMaxOpusBufferSize = 1+1275;
 constexpr int kOpusFrameMs = 60;
 constexpr int kOpusChannelCount = 2;
 // Opus only supports 48 and 96 kHz samplerates
-constexpr int kMasterSamplerate = 48000;
+constexpr mixxx::audio::SampleRate kMasterSamplerate = mixxx::audio::SampleRate(48000);
 
 const mixxx::Logger kLogger("EncoderOpus");
 
@@ -79,7 +79,7 @@ int getSerial() {
 } // namespace
 
 //static
-int EncoderOpus::getMasterSamplerate() {
+mixxx::audio::SampleRate EncoderOpus::getMasterSamplerate() {
     return kMasterSamplerate;
 }
 

--- a/src/encoder/encoderopus.h
+++ b/src/encoder/encoderopus.h
@@ -1,12 +1,13 @@
 #pragma once
 
+#include <ogg/ogg.h>
+#include <opus/opus.h>
+
 #include <QMap>
 #include <QString>
 #include <QVector>
 
-#include <ogg/ogg.h>
-#include <opus/opus.h>
-
+#include "audio/types.h"
 #include "encoder/encoder.h"
 #include "encoder/encodercallback.h"
 #include "util/fifo.h"
@@ -16,7 +17,7 @@
 
 class EncoderOpus: public Encoder {
   public:
-    static int getMasterSamplerate();
+    static mixxx::audio::SampleRate getMasterSamplerate();
     static QString getInvalidSamplerateMessage();
 
     explicit EncoderOpus(EncoderCallback* pCallback = nullptr);


### PR DESCRIPTION
This would allow us to revert the explicit double casts in main introduced by c22daf04c090ac73a5c410307efd1f28965c4687.