### PR TITLE
Make sure unused places in ChannelHandleMap are initalized

### DIFF
--- a/src/engine/channelhandle.h
+++ b/src/engine/channelhandle.h
@@ -1,5 +1,4 @@
-#ifndef CHANNELHANDLE_H
-#define CHANNELHANDLE_H
+#pragma once
 // ChannelHandle defines a unique identifier for channels of audio in the engine
 // (e.g. headphone output, master output, deck 1, microphone 3). Previously we
 // used the group string of the channel in the engine to uniquely identify it
@@ -160,6 +159,10 @@ class ChannelHandleMap {
     typedef typename QVarLengthArray<T, kMaxExpectedGroups>::const_iterator const_iterator;
     typedef typename QVarLengthArray<T, kMaxExpectedGroups>::iterator iterator;
 
+    ChannelHandleMap()
+            : m_dummy(T()) {
+    }
+
     const T& at(const ChannelHandle& handle) const {
         if (!handle.valid()) {
             return m_dummy;
@@ -208,12 +211,18 @@ class ChannelHandleMap {
 
   private:
     inline void maybeExpand(int iSize) {
-        if (m_data.size() < iSize) {
-            m_data.resize(iSize);
+        if (QTypeInfo<T>::isComplex) {
+            // The value for complex types is initialized by QVarLengthArray
+            if (m_data.size() < iSize) {
+                m_data.resize(iSize);
+            }
+        } else {
+            // We need to initialize simple types ourselves
+            while (m_data.size() < iSize) {
+                m_data.append(T());
+            }
         }
     }
     container_type m_data;
     T m_dummy;
 };
-
-#endif /* CHANNELHANDLE,_H */

--- a/src/engine/channelhandle.h
+++ b/src/engine/channelhandle.h
@@ -160,7 +160,7 @@ class ChannelHandleMap {
     typedef typename QVarLengthArray<T, kMaxExpectedGroups>::iterator iterator;
 
     ChannelHandleMap()
-            : m_dummy(T()) {
+            : m_dummy{} {
     }
 
     const T& at(const ChannelHandle& handle) const {
@@ -219,7 +219,7 @@ class ChannelHandleMap {
         } else {
             // We need to initialize simple types ourselves
             while (m_data.size() < iSize) {
-                m_data.append(T());
+                m_data.append({});
             }
         }
     }


### PR DESCRIPTION
The using code assumes that empty places are nullptr, which is not the case:

https://doc.qt.io/qt-5/qvarlengtharray.html
> QVarLengthArray doesn't initialize the memory if the value is a basic type. (QVector always does.)

This PR fixes the assumption. And hopefully the rasher in https://bugs.launchpad.net/mixxx/+bug/1775497 

Unfortunately the over all design is still broken and instead of crashing it will probably now hit VERIFY_AND_DEBUG_ASSERTs that have been added as safety net. 

I think for 2.4 a bigger refactoring is required with a better memory management, fixing these edge cases. 
Before building on it in #2618

  
