### PR TITLE
Revert "signalinfo: Add explicit double casts"

### DIFF
--- a/src/audio/signalinfo.h
+++ b/src/audio/signalinfo.h
@@ -46,7 +46,7 @@ class SignalInfo final {
     // Conversion: #samples / sample offset -> #frames / frame offset
     double samples2framesFractional(double samples) const {
         DEBUG_ASSERT(getChannelCount().isValid());
-        return samples / static_cast<double>(getChannelCount());
+        return samples / getChannelCount();
     }
 
     // Conversion: #frames / frame offset -> #samples / sample offset
@@ -58,7 +58,7 @@ class SignalInfo final {
     // Conversion: #frames / frame offset -> second offset
     double frames2secsFractional(double frames) const {
         DEBUG_ASSERT(getSampleRate().isValid());
-        return frames / static_cast<double>(getSampleRate());
+        return frames / getSampleRate();
     }
 
     // Conversion: #frames / frame offset -> second offset
@@ -69,7 +69,7 @@ class SignalInfo final {
     // Conversion: second offset -> #frames / frame offset
     double secs2frames(double seconds) const {
         DEBUG_ASSERT(getSampleRate().isValid());
-        return seconds * static_cast<double>(getSampleRate());
+        return seconds * getSampleRate();
     }
 
     // Conversion: #frames / frame offset -> millisecond offset


### PR DESCRIPTION
This reverts commit c22daf04c090ac73a5c410307efd1f28965c4687.