### PR TITLE
SeratoBeatsImporter: Fix import/export of non-const beatgrids

### DIFF
--- a/src/test/seratobeatgridtest.cpp
+++ b/src/test/seratobeatgridtest.cpp
@@ -130,30 +130,40 @@ TEST_F(SeratoBeatGridTest, SerializeBeatgrid) {
 
 TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
     // Create a non-const beatmap
-    constexpr double bpm = 100.0;
+    constexpr double timingOffsetMillis = -10;
+    constexpr int bpm = 120;
     const auto sampleRate = mixxx::audio::SampleRate(44100);
     const auto signalInfo = mixxx::audio::SignalInfo(mixxx::audio::ChannelCount(2), sampleRate);
     const auto duration = mixxx::Duration::fromSeconds<int>(300);
     const double framesPerMinute = signalInfo.getSampleRate() * 60;
     const double framesPerBeat = framesPerMinute / bpm;
+    const double initialFrameOffset = framesPerBeat / 2;
 
     QVector<double> beatPositionsFrames;
-    double beatPositionFrames = 0;
-    // Add 2 minutes of beats at 100 bpm to the beatgrid
-    for (int i = 0; i < 2 * bpm; i++) {
+    double beatPositionFrames = initialFrameOffset;
+
+    constexpr int kNumBeats120BPM = 4;
+    qInfo() << "Step 1: Add" << kNumBeats120BPM << "beats at 100 bpm to the beatgrid";
+    for (int i = 0; i < kNumBeats120BPM; i++) {
         beatPositionsFrames.append(beatPositionFrames);
         beatPositionFrames += framesPerBeat;
     }
+    ASSERT_EQ(beatPositionsFrames.size(), kNumBeats120BPM);
 
     // Check the const beatmap
     {
         const auto pBeats = mixxx::BeatMap::makeBeatMap(
                 sampleRate, QString("Test"), beatPositionsFrames);
-        // At the 1 minute mark the BPM should be 100
-        EXPECT_EQ(pBeats->getBpmAroundPosition(framesPerMinute, 1), bpm);
+        // Check that the first section's BPM is 100
+        EXPECT_EQ(pBeats->getBpmAroundPosition(
+                          signalInfo.frames2samples(
+                                  static_cast<SINT>(initialFrameOffset +
+                                          framesPerBeat * kNumBeats120BPM / 2)),
+                          1),
+                bpm);
 
         mixxx::SeratoBeatGrid seratoBeatGrid;
-        seratoBeatGrid.setBeats(pBeats, signalInfo, duration, 0);
+        seratoBeatGrid.setBeats(pBeats, signalInfo, duration, timingOffsetMillis);
         EXPECT_EQ(seratoBeatGrid.nonTerminalMarkers().size(), 0);
         EXPECT_NE(seratoBeatGrid.terminalMarker(), nullptr);
         EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm));
@@ -163,31 +173,46 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
                 seratoBeatGrid.nonTerminalMarkers(),
                 seratoBeatGrid.terminalMarker());
         QVector<double> importedBeatPositionsFrames =
-                beatsImporter.importBeatsAndApplyTimingOffset(0, signalInfo);
+                beatsImporter.importBeatsAndApplyTimingOffset(timingOffsetMillis, signalInfo);
         ASSERT_EQ(beatPositionsFrames.size(), importedBeatPositionsFrames.size());
         for (int i = 0; i < beatPositionsFrames.size(); i++) {
             EXPECT_NEAR(beatPositionsFrames[i], importedBeatPositionsFrames[i], kEpsilon);
         }
     }
 
-    // Now add 3 minutes of beats at 50 bpm to the beatgrid
-    for (int i = 0; i < 3 * bpm / 2; i++) {
+    constexpr int kNumBeats60BPM = 4;
+    qInfo() << "Step 2: Add" << kNumBeats60BPM << "beats at 50 bpm to the beatgrid";
+    for (int i = 0; i < kNumBeats60BPM; i++) {
         beatPositionsFrames.append(beatPositionFrames);
         beatPositionFrames += framesPerBeat * 2;
     }
+    ASSERT_EQ(beatPositionsFrames.size(), kNumBeats120BPM + kNumBeats60BPM);
 
-    // Check the non-const beatmap
     {
         const auto pBeats = mixxx::BeatMap::makeBeatMap(
                 sampleRate, QString("Test"), beatPositionsFrames);
-        // At the 1 minute mark the BPM should be 100
-        EXPECT_EQ(pBeats->getBpmAroundPosition(framesPerMinute, 1), bpm);
-        // At the 4 minute mark the BPM should be 50
-        EXPECT_EQ(pBeats->getBpmAroundPosition(framesPerMinute * 4, 1), bpm / 2);
+        // Check that the first section'd BPM is 100
+        EXPECT_EQ(pBeats->getBpmAroundPosition(
+                          signalInfo.frames2samples(
+                                  static_cast<SINT>(initialFrameOffset +
+                                          framesPerBeat * kNumBeats120BPM / 2)),
+                          1),
+                bpm);
+        // Check that the second section'd BPM is 50
+        EXPECT_EQ(pBeats->getBpmAroundPosition(
+                          signalInfo.frames2samples(
+                                  static_cast<SINT>(initialFrameOffset +
+                                          framesPerBeat * kNumBeats120BPM +
+                                          framesPerBeat * kNumBeats60BPM / 2)),
+                          1),
+                bpm / 2);
 
         mixxx::SeratoBeatGrid seratoBeatGrid;
-        seratoBeatGrid.setBeats(pBeats, signalInfo, duration, 0);
-        EXPECT_EQ(seratoBeatGrid.nonTerminalMarkers().size(), 2);
+        seratoBeatGrid.setBeats(pBeats, signalInfo, duration, timingOffsetMillis);
+        ASSERT_EQ(seratoBeatGrid.nonTerminalMarkers().size(), 2);
+        ASSERT_EQ(seratoBeatGrid.nonTerminalMarkers()[0]->beatsTillNextMarker(), kNumBeats120BPM);
+        ASSERT_EQ(seratoBeatGrid.nonTerminalMarkers()[1]->beatsTillNextMarker(),
+                kNumBeats60BPM - 1);
         EXPECT_NE(seratoBeatGrid.terminalMarker(), nullptr);
         EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm / 2));
 
@@ -196,7 +221,65 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
                 seratoBeatGrid.nonTerminalMarkers(),
                 seratoBeatGrid.terminalMarker());
         QVector<double> importedBeatPositionsFrames =
-                beatsImporter.importBeatsAndApplyTimingOffset(0, signalInfo);
+                beatsImporter.importBeatsAndApplyTimingOffset(timingOffsetMillis, signalInfo);
+        ASSERT_EQ(beatPositionsFrames.size(), importedBeatPositionsFrames.size());
+        for (int i = 0; i < beatPositionsFrames.size(); i++) {
+            EXPECT_NEAR(beatPositionsFrames[i], importedBeatPositionsFrames[i], kEpsilon);
+        }
+    }
+
+    qInfo() << "Step 3: Add" << kNumBeats120BPM << "beats at 100 bpm to the beatgrid";
+    for (int i = 0; i < kNumBeats120BPM; i++) {
+        beatPositionsFrames.append(beatPositionFrames);
+        beatPositionFrames += framesPerBeat;
+    }
+    ASSERT_EQ(beatPositionsFrames.size(), 2 * kNumBeats120BPM + kNumBeats60BPM);
+
+    // Add the last beat
+    beatPositionsFrames.append(beatPositionFrames);
+
+    {
+        const auto pBeats = mixxx::BeatMap::makeBeatMap(
+                sampleRate, QString("Test"), beatPositionsFrames);
+        // Check that the first section's BPM is 100
+        EXPECT_EQ(pBeats->getBpmAroundPosition(
+                          signalInfo.frames2samples(
+                                  static_cast<SINT>(initialFrameOffset +
+                                          framesPerBeat * kNumBeats120BPM / 2)),
+                          1),
+                bpm);
+        // Check that the second section's BPM is 50
+        EXPECT_EQ(pBeats->getBpmAroundPosition(
+                          signalInfo.frames2samples(
+                                  static_cast<SINT>(initialFrameOffset +
+                                          framesPerBeat * kNumBeats120BPM +
+                                          framesPerBeat * kNumBeats60BPM / 2)),
+                          1),
+                bpm / 2);
+        // Check that the third section's BPM is 100
+        EXPECT_EQ(pBeats->getBpmAroundPosition(
+                          signalInfo.frames2samples(static_cast<SINT>(
+                                  initialFrameOffset +
+                                  framesPerBeat * kNumBeats120BPM * 1.5 +
+                                  framesPerBeat * kNumBeats60BPM)),
+                          1),
+                bpm / 2);
+
+        mixxx::SeratoBeatGrid seratoBeatGrid;
+        seratoBeatGrid.setBeats(pBeats, signalInfo, duration, timingOffsetMillis);
+        ASSERT_EQ(seratoBeatGrid.nonTerminalMarkers().size(), 3);
+        ASSERT_EQ(seratoBeatGrid.nonTerminalMarkers()[0]->beatsTillNextMarker(), kNumBeats120BPM);
+        ASSERT_EQ(seratoBeatGrid.nonTerminalMarkers()[1]->beatsTillNextMarker(), kNumBeats60BPM);
+        ASSERT_EQ(seratoBeatGrid.nonTerminalMarkers()[2]->beatsTillNextMarker(), kNumBeats60BPM);
+        EXPECT_NE(seratoBeatGrid.terminalMarker(), nullptr);
+        EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm));
+
+        // Check if the beats can be re-imported losslessly
+        mixxx::SeratoBeatsImporter beatsImporter(
+                seratoBeatGrid.nonTerminalMarkers(),
+                seratoBeatGrid.terminalMarker());
+        QVector<double> importedBeatPositionsFrames =
+                beatsImporter.importBeatsAndApplyTimingOffset(timingOffsetMillis, signalInfo);
         ASSERT_EQ(beatPositionsFrames.size(), importedBeatPositionsFrames.size());
         for (int i = 0; i < beatPositionsFrames.size(); i++) {
             EXPECT_NEAR(beatPositionsFrames[i], importedBeatPositionsFrames[i], kEpsilon);

--- a/src/track/serato/beatgrid.cpp
+++ b/src/track/serato/beatgrid.cpp
@@ -443,73 +443,59 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
     auto pBeatsIterator = pBeats->findBeats(0, trackDurationSamples);
 
     // This might be null if the track doesn't contain any beats
-    if (!pBeatsIterator) {
+    if (!pBeatsIterator || !pBeatsIterator->hasNext()) {
         qWarning() << "Serato Beatgrid: No beats available, exporting empty beatgrid!";
         setTerminalMarker(nullptr);
         setNonTerminalMarkers({});
         return;
     }
 
+    const double beatgridFrameOffset = signalInfo.samples2framesFractional(pBeatsIterator->next());
     double currentBeatPositionFrames = 0;
     double previousBeatPositionFrames = 0;
     double previousDeltaFrames = -1;
-    int beatsSinceLastMarker = 0;
     QList<SeratoBeatGridNonTerminalMarkerPointer> nonTerminalMarkers;
+    {
+        const double positionSecs =
+                signalInfo.frames2secsFractional(
+                        currentBeatPositionFrames + beatgridFrameOffset) -
+                timingOffsetSecs;
+        nonTerminalMarkers.append(
+                std::make_shared<SeratoBeatGridNonTerminalMarker>(positionSecs, 0));
+    }
     while (pBeatsIterator->hasNext()) {
         previousBeatPositionFrames = currentBeatPositionFrames;
         currentBeatPositionFrames =
-                signalInfo.samples2framesFractional(
-                        pBeatsIterator->next());
+                signalInfo.samples2framesFractional(pBeatsIterator->next()) -
+                beatgridFrameOffset;
 
         // Calculate the delta between the current beat and the previous beat.
         // If the distance is the same as the distance between the previous
         // beat and the beat before that, we can just increment
         // `beatsSinceLastMarker`. If not, we need to add a new marker.
         const double currentDeltaFrames = currentBeatPositionFrames - previousBeatPositionFrames;
+        if (previousDeltaFrames < 0) {
+            previousDeltaFrames = currentDeltaFrames;
+        }
+
         const double differenceBetweenCurrentAndPreviousDelta =
                 abs(currentDeltaFrames - previousDeltaFrames);
-        if (differenceBetweenCurrentAndPreviousDelta > kEpsilon || nonTerminalMarkers.isEmpty()) {
+        if (differenceBetweenCurrentAndPreviousDelta >= kEpsilon) {
+            const double positionSecs =
+                    signalInfo.frames2secsFractional(
+                            previousBeatPositionFrames + beatgridFrameOffset) -
+                    timingOffsetSecs;
+            nonTerminalMarkers.append(
+                    std::make_shared<SeratoBeatGridNonTerminalMarker>(positionSecs, 1));
+        } else {
             // We are adding a new beat marker, therefore we need to update the
             // `beatsSinceLastMarker` variable of the last marker we added.
-            if (!nonTerminalMarkers.isEmpty()) {
-                DEBUG_ASSERT(beatsSinceLastMarker > 0);
-                const auto pNonTerminalMarker =
-                        nonTerminalMarkers.at(nonTerminalMarkers.size() - 1);
-                DEBUG_ASSERT(pNonTerminalMarker);
-                pNonTerminalMarker->setBeatsTillNextMarker(beatsSinceLastMarker);
-
-                // After adding the first marker, the the sample delta won't
-                // match, because it compares the distance between beats 1 and
-                // two with the distance between the start of the track and the
-                // first beat. This special case makes sure that we don't add
-                // an unnecessary additional marker that has
-                // beatsSinceLastMarker set to 1.
-                if (nonTerminalMarkers.size() == 1 && beatsSinceLastMarker == 1) {
-                    previousDeltaFrames = currentDeltaFrames;
-                    beatsSinceLastMarker++;
-                    continue;
-                }
-            }
-            // Don't create a SeratoBeatGridNonTerminalMarker entry for the
-            // last beat, this needs to be a terminal marker entry.
-            if (pBeatsIterator->hasNext()) {
-                const double positionSecs =
-                        signalInfo.frames2secsFractional(
-                                currentBeatPositionFrames) -
-                        timingOffsetSecs;
-                nonTerminalMarkers.append(
-                        std::make_shared<SeratoBeatGridNonTerminalMarker>(positionSecs, 0));
-            }
-            beatsSinceLastMarker = 0;
+            const auto pNonTerminalMarker = nonTerminalMarkers.last();
+            pNonTerminalMarker->setBeatsTillNextMarker(
+                    pNonTerminalMarker->beatsTillNextMarker() + 1);
         }
-        beatsSinceLastMarker++;
-        previousDeltaFrames = currentDeltaFrames;
-    }
 
-    // The track has no beats. This isn't possible because the `pBeatsIterator`
-    // check above should have caught this case already.
-    VERIFY_OR_DEBUG_ASSERT(currentBeatPositionFrames != -1) {
-        return;
+        previousDeltaFrames = currentDeltaFrames;
     }
 
     // If the beatgrid is constant, i.e. if there is only a single non-terminal
@@ -520,26 +506,13 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
         nonTerminalMarkers.clear();
     }
 
-    // Update the `beatsSinceLastMarker` of the last non-terminal marker we inserted.
-    if (!nonTerminalMarkers.isEmpty()) {
-        DEBUG_ASSERT(beatsSinceLastMarker > 0);
-        const auto pNonTerminalMarker = nonTerminalMarkers.at(nonTerminalMarkers.size() - 1);
-        DEBUG_ASSERT(pNonTerminalMarker);
-        // We need to subtract 1 from `beatsSinceLastMarker`, because at the end of
-        // the last iteration the counter is incremented even though we didn't move
-        // a beat forwards.
-        pNonTerminalMarker->setBeatsTillNextMarker(beatsSinceLastMarker - 1);
-    }
-
     // Finally, create the terminal marker.
     const double positionSecs =
             signalInfo.frames2secsFractional(
-                    currentBeatPositionFrames) -
+                    currentBeatPositionFrames + beatgridFrameOffset) -
             timingOffsetSecs;
     const double bpm = pBeats->getBpmAroundPosition(
-            signalInfo.frames2samples(
-                    static_cast<SINT>(currentBeatPositionFrames)),
-            1);
+            signalInfo.getChannelCount() * (currentBeatPositionFrames + beatgridFrameOffset), 1);
 
     setTerminalMarker(std::make_shared<SeratoBeatGridTerminalMarker>(positionSecs, bpm));
     setNonTerminalMarkers(nonTerminalMarkers);

--- a/src/track/serato/beatgrid.cpp
+++ b/src/track/serato/beatgrid.cpp
@@ -468,7 +468,7 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
         const double currentDeltaFrames = currentBeatPositionFrames - previousBeatPositionFrames;
         const double differenceBetweenCurrentAndPreviousDelta =
                 abs(currentDeltaFrames - previousDeltaFrames);
-        if (differenceBetweenCurrentAndPreviousDelta > kEpsilon) {
+        if (differenceBetweenCurrentAndPreviousDelta > kEpsilon || nonTerminalMarkers.isEmpty()) {
             // We are adding a new beat marker, therefore we need to update the
             // `beatsSinceLastMarker` variable of the last marker we added.
             if (!nonTerminalMarkers.isEmpty()) {

--- a/src/track/serato/beatgrid.cpp
+++ b/src/track/serato/beatgrid.cpp
@@ -456,12 +456,11 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
     double previousDeltaFrames = -1;
     QList<SeratoBeatGridNonTerminalMarkerPointer> nonTerminalMarkers;
     {
-        const double positionSecs =
-                signalInfo.frames2secsFractional(
-                        currentBeatPositionFrames + beatgridFrameOffset) -
-                timingOffsetSecs;
+        const double positionSecs = signalInfo.frames2secsFractional(
+                currentBeatPositionFrames + beatgridFrameOffset);
         nonTerminalMarkers.append(
-                std::make_shared<SeratoBeatGridNonTerminalMarker>(positionSecs, 0));
+                std::make_shared<SeratoBeatGridNonTerminalMarker>(
+                        positionSecs - timingOffsetSecs, 0));
     }
     while (pBeatsIterator->hasNext()) {
         previousBeatPositionFrames = currentBeatPositionFrames;
@@ -481,12 +480,11 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
         const double differenceBetweenCurrentAndPreviousDelta =
                 abs(currentDeltaFrames - previousDeltaFrames);
         if (differenceBetweenCurrentAndPreviousDelta >= kEpsilon) {
-            const double positionSecs =
-                    signalInfo.frames2secsFractional(
-                            previousBeatPositionFrames + beatgridFrameOffset) -
-                    timingOffsetSecs;
+            const double positionSecs = signalInfo.frames2secsFractional(
+                    previousBeatPositionFrames + beatgridFrameOffset);
             nonTerminalMarkers.append(
-                    std::make_shared<SeratoBeatGridNonTerminalMarker>(positionSecs, 1));
+                    std::make_shared<SeratoBeatGridNonTerminalMarker>(
+                            positionSecs - timingOffsetSecs, 1));
         } else {
             // We are adding a new beat marker, therefore we need to update the
             // `beatsSinceLastMarker` variable of the last marker we added.
@@ -507,14 +505,16 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
     }
 
     // Finally, create the terminal marker.
-    const double positionSecs =
-            signalInfo.frames2secsFractional(
-                    currentBeatPositionFrames + beatgridFrameOffset) -
-            timingOffsetSecs;
+    const double currentBeatPositionFramesWithOffset =
+            currentBeatPositionFrames + beatgridFrameOffset;
+    const double positionSecs = signalInfo.frames2secsFractional(
+            currentBeatPositionFramesWithOffset);
     const double bpm = pBeats->getBpmAroundPosition(
-            signalInfo.getChannelCount() * (currentBeatPositionFrames + beatgridFrameOffset), 1);
+            signalInfo.getChannelCount() * currentBeatPositionFramesWithOffset,
+            1);
 
-    setTerminalMarker(std::make_shared<SeratoBeatGridTerminalMarker>(positionSecs, bpm));
+    setTerminalMarker(std::make_shared<SeratoBeatGridTerminalMarker>(
+            positionSecs - timingOffsetSecs, bpm));
     setNonTerminalMarkers(nonTerminalMarkers);
 }
 

--- a/src/track/serato/beatsimporter.cpp
+++ b/src/track/serato/beatsimporter.cpp
@@ -92,10 +92,18 @@ QVector<double> SeratoBeatsImporter::importBeatsAndApplyTimingOffset(
         // Add beatLengthMillis, otherwise we'd import the same beat position
         // twice (we already imported it above).
         beatPositionMillis += beatLengthMillis;
+
+        // Sometimes the previous calculation can lead to a position behind the
+        // terminal marker position, because the BPM value is inaccurate. In
+        // that case, use the rangeEndBeatPositionMillis directly.
+        if (beatPositionMillis > rangeEndBeatPositionMillis) {
+            beatPositionMillis = rangeEndBeatPositionMillis;
+        }
     }
 
-    // Now fill the range with beats until the end is reached
-    while (beatPositionMillis < rangeEndBeatPositionMillis) {
+    // Now fill the range with beats until the end is reached. Add a half beat
+    // length, to make sure that the last beat is actually included.
+    while (beatPositionMillis <= (rangeEndBeatPositionMillis + beatLengthMillis / 2)) {
         beats.append(streamInfo.getSignalInfo().millis2frames(
                 beatPositionMillis + timingOffsetMillis));
         beatPositionMillis += beatLengthMillis;

--- a/src/track/serato/beatsimporter.cpp
+++ b/src/track/serato/beatsimporter.cpp
@@ -32,7 +32,7 @@ QVector<double> SeratoBeatsImporter::importBeatsAndApplyTimingOffset(
             filePath, streamInfo.getSignalInfo());
 
     QVector<double> beats;
-    double beatPositionMillis;
+    double beatPositionMillis = 0;
     double beatLengthMillis;
     // Calculate beat positions for non-terminal markers
     for (int i = 0; i < m_nonTerminalMarkers.size(); ++i) {
@@ -59,20 +59,46 @@ QVector<double> SeratoBeatsImporter::importBeatsAndApplyTimingOffset(
 
         beats.reserve(beats.size() + pMarker->beatsTillNextMarker());
         for (quint32 j = 0; j < pMarker->beatsTillNextMarker(); ++j) {
-            beats.append(streamInfo.getSignalInfo().millis2frames(
-                    beatPositionMillis + (j * beatLengthMillis)));
+            beats.append(streamInfo.getSignalInfo().millis2frames(beatPositionMillis));
+            beatPositionMillis += beatLengthMillis;
         }
     }
 
-    // Calculate remaining beat positions until track end
-    beatPositionMillis =
-            static_cast<double>(m_pTerminalMarker->positionSecs()) * 1000 +
-            timingOffsetMillis;
+    // Calculate remaining beat positions between the last non-terminal marker
+    // beat (or the start of the track if none exist) and the terminal marker,
+    // using the given BPM.
+    //
+    //                beatPositionMillis          Terminal Marker
+    //                     v                              v
+    //     | | | | | | | | |[###### Remaining range ######]
     beatLengthMillis = 60000.0 / static_cast<double>(m_pTerminalMarker->bpm());
     VERIFY_OR_DEBUG_ASSERT(m_pTerminalMarker->positionSecs() >= 0 && beatLengthMillis > 0) {
         return {};
     }
-    while (beatPositionMillis < streamInfo.getDuration().toDoubleMillis()) {
+
+    const double rangeEndBeatPositionMillis =
+            static_cast<double>(m_pTerminalMarker->positionSecs()) * 1000 +
+            timingOffsetMillis;
+
+    if (beats.isEmpty()) {
+        VERIFY_OR_DEBUG_ASSERT(beatPositionMillis == 0) {
+            return {};
+        }
+        // If there are no beats yet (because there were no non-terminal
+        // markers), beatPositionMillis will be 0. In that case we have to find
+        // the offset backwards from the terminal marker position.
+        // Because we're working with doubles, we can't use modulo and need to
+        // implement it ourselves.
+        const double divisor = std::floor(rangeEndBeatPositionMillis / beatLengthMillis);
+        beatPositionMillis = rangeEndBeatPositionMillis - (divisor * beatLengthMillis);
+    } else {
+        // Add beatLengthMillis, otherwise we'd import the same beat position
+        // twice (we already imported it above).
+        beatPositionMillis += beatLengthMillis;
+    }
+
+    // Now fill the range with beats until the end is reached
+    while (beatPositionMillis < rangeEndBeatPositionMillis) {
         beats.append(streamInfo.getSignalInfo().millis2frames(beatPositionMillis));
         beatPositionMillis += beatLengthMillis;
     }

--- a/src/track/serato/beatsimporter.cpp
+++ b/src/track/serato/beatsimporter.cpp
@@ -33,7 +33,6 @@ QVector<double> SeratoBeatsImporter::importBeatsAndApplyTimingOffset(
 
     QVector<double> beats;
     double beatPositionMillis = 0;
-    double beatLengthMillis;
     // Calculate beat positions for non-terminal markers
     for (int i = 0; i < m_nonTerminalMarkers.size(); ++i) {
         SeratoBeatGridNonTerminalMarkerPointer pMarker = m_nonTerminalMarkers.at(i);
@@ -51,7 +50,8 @@ QVector<double> SeratoBeatsImporter::importBeatsAndApplyTimingOffset(
         VERIFY_OR_DEBUG_ASSERT(nextBeatPositionMillis > beatPositionMillis) {
             return {};
         }
-        beatLengthMillis = (nextBeatPositionMillis - beatPositionMillis) /
+        const double beatLengthMillis =
+                (nextBeatPositionMillis - beatPositionMillis) /
                 pMarker->beatsTillNextMarker();
 
         beats.reserve(beats.size() + pMarker->beatsTillNextMarker());
@@ -69,7 +69,7 @@ QVector<double> SeratoBeatsImporter::importBeatsAndApplyTimingOffset(
     //                beatPositionMillis          Terminal Marker
     //                     v                              v
     //     | | | | | | | | |[###### Remaining range ######]
-    beatLengthMillis = 60000.0 / static_cast<double>(m_pTerminalMarker->bpm());
+    const double beatLengthMillis = 60000.0 / static_cast<double>(m_pTerminalMarker->bpm());
     VERIFY_OR_DEBUG_ASSERT(m_pTerminalMarker->positionSecs() >= 0 && beatLengthMillis > 0) {
         return {};
     }

--- a/src/track/serato/beatsimporter.cpp
+++ b/src/track/serato/beatsimporter.cpp
@@ -84,9 +84,7 @@ QVector<double> SeratoBeatsImporter::importBeatsAndApplyTimingOffset(
             static_cast<double>(m_pTerminalMarker->positionSecs() * 1000);
 
     if (beats.isEmpty()) {
-        VERIFY_OR_DEBUG_ASSERT(beatPositionMillis == 0) {
-            return {};
-        }
+        DEBUG_ASSERT(beatPositionMillis == 0);
         // If there are no beats yet (because there were no non-terminal
         // markers), beatPositionMillis will be 0. In that case we have to find
         // the offset backwards from the terminal marker position.

--- a/src/track/serato/beatsimporter.cpp
+++ b/src/track/serato/beatsimporter.cpp
@@ -81,7 +81,7 @@ QVector<double> SeratoBeatsImporter::importBeatsAndApplyTimingOffset(
     }
 
     const double rangeEndBeatPositionMillis =
-            static_cast<double>(m_pTerminalMarker->positionSecs()) * 1000;
+            static_cast<double>(m_pTerminalMarker->positionSecs() * 1000);
 
     if (beats.isEmpty()) {
         VERIFY_OR_DEBUG_ASSERT(beatPositionMillis == 0) {
@@ -94,17 +94,8 @@ QVector<double> SeratoBeatsImporter::importBeatsAndApplyTimingOffset(
         // implement it ourselves.
         const double divisor = std::floor(rangeEndBeatPositionMillis / beatLengthMillis);
         beatPositionMillis = rangeEndBeatPositionMillis - (divisor * beatLengthMillis);
-    } else {
-        // Add beatLengthMillis, otherwise we'd import the same beat position
-        // twice (we already imported it above).
-        beatPositionMillis += beatLengthMillis;
-
-        // Sometimes the previous calculation can lead to a position behind the
-        // terminal marker position, because the BPM value is inaccurate. In
-        // that case, use the rangeEndBeatPositionMillis directly.
-        if (beatPositionMillis > rangeEndBeatPositionMillis) {
-            beatPositionMillis = rangeEndBeatPositionMillis;
-        }
+    } else if (beatPositionMillis > rangeEndBeatPositionMillis) {
+        beatPositionMillis = rangeEndBeatPositionMillis;
     }
 
     // Now fill the range with beats until the end is reached. Add a half beat

--- a/src/track/serato/beatsimporter.h
+++ b/src/track/serato/beatsimporter.h
@@ -21,6 +21,9 @@ class SeratoBeatsImporter : public BeatsImporter {
             const audio::StreamInfo& streamInfo) override;
 
   private:
+    QVector<double> importBeatsAndApplyTimingOffset(
+            double timingOffsetMillis, const audio::SignalInfo& signalInfo);
+
     QList<SeratoBeatGridNonTerminalMarkerPointer> m_nonTerminalMarkers;
     SeratoBeatGridTerminalMarkerPointer m_pTerminalMarker;
 };

--- a/src/track/serato/beatsimporter.h
+++ b/src/track/serato/beatsimporter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <gtest/gtest_prod.h>
+
 #include <QList>
 
 #include "track/beatsimporter.h"
@@ -21,6 +23,8 @@ class SeratoBeatsImporter : public BeatsImporter {
             const audio::StreamInfo& streamInfo) override;
 
   private:
+    FRIEND_TEST(SeratoBeatGridTest, SerializeBeatMap);
+
     QVector<double> importBeatsAndApplyTimingOffset(
             double timingOffsetMillis, const audio::SignalInfo& signalInfo);
 


### PR DESCRIPTION
This should fix the import of Serato BeatGrids where no non-terminal markers are present. The previous code was wrong, I don't know what I was thinking.