### PR TITLE
raspi: Fix QT onscreen keyboard masking.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,8 @@ int runMixxx(MixxxApplication* app, const CmdlineArgs& args) {
     }
 }
 
+// This method for fixing transparency of the on-screen keyboard copied from:
+// https://stackoverflow.com/a/63963718
 void handleInputMethodVisibleChanged() {
     if (!QGuiApplication::inputMethod()->isVisible()) {
         return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,6 @@
 #include <QThread>
 #include <QWindow>
 #include <QtDebug>
-
 #include <cstring>
 
 #include "errordialoghandler.h"
@@ -48,7 +47,7 @@ void handleInputMethodVisibleChanged() {
         if (std::strcmp(w->metaObject()->className(), "QtVirtualKeyboard::InputView") == 0) {
             if (QObject* keyboard = w->findChild<QObject*>("keyboard")) {
                 QRect r = w->geometry();
-                r.moveTop(keyboard->property("y").toDouble());
+                r.moveTop(keyboard->property("y").toInt());
                 w->setMask(r);
                 return;
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,7 +40,7 @@ int runMixxx(MixxxApplication* app, const CmdlineArgs& args) {
     }
 }
 
-void handleIMVisibleChanged() {
+void handleInputMethodVisibleChanged() {
     if (!QGuiApplication::inputMethod()->isVisible()) {
         return;
     }
@@ -128,7 +128,7 @@ int main(int argc, char * argv[]) {
     QObject::connect(&app, &MixxxApplication::lastWindowClosed, &app, &MixxxApplication::quit);
     QObject::connect(QGuiApplication::inputMethod(),
             &QInputMethod::visibleChanged,
-            &handleIMVisibleChanged);
+            &handleInputMethodVisibleChanged);
 
     int exitCode = runMixxx(&app, args);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,7 +43,8 @@ void handleInputMethodVisibleChanged() {
     if (!QGuiApplication::inputMethod()->isVisible()) {
         return;
     }
-    for (QWindow* w : QGuiApplication::allWindows()) {
+    const auto windowList = QGuiApplication::allWindows();
+    for (QWindow* w : windowList) {
         if (std::strcmp(w->metaObject()->className(), "QtVirtualKeyboard::InputView") == 0) {
             if (QObject* keyboard = w->findChild<QObject*>("keyboard")) {
                 QRect r = w->geometry();


### PR DESCRIPTION
Raspberry pi users (and others) may want to use the QT virtual keyboard
to do text input (like, in the Search bar).  This can be done by
setting the environment variable QT_IM_MODULE="qtvirtualkeyboard".

This patch fixes the opacity of the keyboard, which doesn't have its
masking set correctly.  This patch should be safe for non-raspi
situations -- when the input mode changes it specifically looks for
the virtual keyboard window and modifies it.