### PR TITLE
channel count limits check 

### DIFF
--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -5,39 +5,39 @@
 
 namespace mixxx {
     // TODO(XXX): When we move from stereo to multi-channel this needs updating.
-    static constexpr audio::ChannelCount kEngineChannelCount =
-            audio::ChannelCount(2);
+static constexpr audio::ChannelCount kEngineChannelCount =
+        audio::ChannelCount::stereo();
 
-    // Contains the information needed to process a buffer of audio
-    class EngineParameters {
-      public:
-        SINT framesPerBuffer() const {
-            return m_framesPerBuffer;
-        }
-        SINT samplesPerBuffer() const {
-            return m_outputSignal.frames2samples(framesPerBuffer());
-        }
+// Contains the information needed to process a buffer of audio
+class EngineParameters {
+  public:
+    SINT framesPerBuffer() const {
+        return m_framesPerBuffer;
+    }
+    SINT samplesPerBuffer() const {
+        return m_outputSignal.frames2samples(framesPerBuffer());
+    }
 
-        audio::ChannelCount channelCount() const {
-            return m_outputSignal.getChannelCount();
-        }
+    audio::ChannelCount channelCount() const {
+        return m_outputSignal.getChannelCount();
+    }
 
-        audio::SampleRate sampleRate() const {
-            return m_outputSignal.getSampleRate();
-        }
+    audio::SampleRate sampleRate() const {
+        return m_outputSignal.getSampleRate();
+    }
 
-        explicit EngineParameters(
-                audio::SampleRate sampleRate,
-                SINT framesPerBuffer)
-                : m_outputSignal(
-                          kEngineChannelCount,
-                          sampleRate),
-                  m_framesPerBuffer(framesPerBuffer) {
-            DEBUG_ASSERT(framesPerBuffer > 0);
-        }
+    explicit EngineParameters(
+            audio::SampleRate sampleRate,
+            SINT framesPerBuffer)
+            : m_outputSignal(
+                      kEngineChannelCount,
+                      sampleRate),
+              m_framesPerBuffer(framesPerBuffer) {
+        DEBUG_ASSERT(framesPerBuffer > 0);
+    }
 
-      private:
-        const audio::SignalInfo m_outputSignal;
-        const SINT m_framesPerBuffer;
-    };
+  private:
+    const audio::SignalInfo m_outputSignal;
+    const SINT m_framesPerBuffer;
+};
 }

--- a/src/sources/audiosource.h
+++ b/src/sources/audiosource.h
@@ -305,7 +305,7 @@ class AudioSource : public UrlResource, public virtual /*implements*/ IAudioSour
     explicit AudioSource(const QUrl& url);
 
     bool initChannelCountOnce(audio::ChannelCount channelCount);
-    bool initChannelCountOnce(SINT channelCount) {
+    bool initChannelCountOnce(int channelCount) {
         return initChannelCountOnce(audio::ChannelCount(channelCount));
     }
 

--- a/src/sources/audiosourcestereoproxy.cpp
+++ b/src/sources/audiosourcestereoproxy.cpp
@@ -9,7 +9,7 @@ namespace {
 
 const Logger kLogger("AudioSourceStereoProxy");
 
-constexpr audio::ChannelCount kChannelCount = audio::ChannelCount(2);
+constexpr audio::ChannelCount kChannelCount = audio::ChannelCount::stereo();
 
 audio::SignalInfo proxySignalInfo(
         const audio::SignalInfo& signalInfo) {

--- a/src/sources/soundsourcemodplug.cpp
+++ b/src/sources/soundsourcemodplug.cpp
@@ -55,15 +55,6 @@ QString getModPlugTypeFromUrl(const QUrl& url) {
 } // anonymous namespace
 
 //static
-constexpr SINT SoundSourceModPlug::kChannelCount;
-
-//static
-constexpr SINT SoundSourceModPlug::kBitsPerSample;
-
-//static
-constexpr SINT SoundSourceModPlug::kSampleRate;
-
-//static
 unsigned int SoundSourceModPlug::s_bufferSizeLimit = 0;
 
 //static

--- a/src/sources/soundsourcemodplug.h
+++ b/src/sources/soundsourcemodplug.h
@@ -15,9 +15,9 @@ namespace mixxx {
 // in RAM to allow seeking and smooth operation in Mixxx.
 class SoundSourceModPlug : public SoundSource {
   public:
-    static constexpr SINT kChannelCount = 2;
-    static constexpr SINT kSampleRate = 44100;
-    static constexpr SINT kBitsPerSample = 16;
+    static constexpr int kChannelCount = 2;
+    static constexpr int kSampleRate = 44100;
+    static constexpr int kBitsPerSample = 16;
 
     // apply settings for decoding
     static void configure(unsigned int bufferSizeLimit,


### PR DESCRIPTION
This is a PR that introduces a limit checking constructor for the most common int channel count in the outside world. 
I did this to keep the 255 channels limit.

It was introduced here: 
https://github.com/mixxxdj/mixxx/commit/829ec47831e22bb0afae953faaafd59e24aca608
And I don't know why. 

I think we have an issue here, that the ChannelCount class is used for SoundSources and Sound Devices and its limits is not related to the real limits of the using code. 
So the decision in is valid() is not reliable. 

So an alternative solution would be to use int as value_t and remove the upper limit. 

@uklotzde 
What do you think? 






