### PR TITLE
lp1929311: Fix update of nominal bpm from beat grid

### DIFF
--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -343,7 +343,12 @@ bool Track::trySetAndLockBeats(mixxx::BeatsPointer pBeats) {
 }
 
 bool Track::setBeatsWhileLocked(mixxx::BeatsPointer pBeats) {
-    if (m_pBeats == pBeats) {
+    if (m_pBeats == pBeats &&
+            // Changing the BPM of the indirectly referenced beat grid object does not
+            // immediately affect the track's nominal BPM!
+            // TODO: Using two disjunct QObject instances is a design flaw that needs
+            // to be fixed eventually.
+            m_record.getMetadata().getTrackInfo().getBpm() == getBeatsPointerBpm(pBeats)) {
         return false;
     }
     m_pBeats = std::move(pBeats);


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1929311

Introduced by the new beat grid handling.

~~2nd fix (TagLib): Do not create additional file tags if they do not already exist.~~ Separate PR #3898 