### PR TITLE
Use int for CannelCount

### DIFF
--- a/src/audio/types.h
+++ b/src/audio/types.h
@@ -35,9 +35,7 @@ QDebug operator<<(QDebug dbg, ChannelLayout arg);
 
 class ChannelCount {
   public:
-    // Use a native type with more than 8 bits to avoid -Werror=type-limits
-    // errors on comparisons with the min/max constants.
-    typedef uint16_t value_t;
+    typedef int value_t;
 
   private:
     // The default value is invalid and indicates a missing or unknown value.
@@ -45,13 +43,9 @@ class ChannelCount {
 
   public:
     static constexpr value_t kValueMin = 1;   // lower bound (inclusive)
-    static constexpr value_t kValueMax = 255; // upper bound (inclusive, 8-bit unsigned integer)
 
     static constexpr ChannelCount min() {
         return ChannelCount(kValueMin);
-    }
-    static constexpr ChannelCount max() {
-        return ChannelCount(kValueMax);
     }
 
     static ChannelCount fromLayout(ChannelLayout layout) {
@@ -70,13 +64,14 @@ class ChannelCount {
             value_t value = kValueDefault)
             : m_value(value) {
     }
+
     explicit ChannelCount(
             ChannelLayout layout)
             : m_value(fromLayout(layout).m_value) {
     }
 
     constexpr bool isValid() const {
-        return kValueMin <= m_value && m_value <= kValueMax;
+        return kValueMin <= m_value;
     }
 
     /*implicit*/ constexpr operator value_t() const {

--- a/src/sources/audiosource.cpp
+++ b/src/sources/audiosource.cpp
@@ -144,11 +144,8 @@ bool AudioSource::verifyReadable() {
         kLogger.warning()
                 << "Invalid number of channels:"
                 << getSignalInfo().getChannelCount()
-                << "is out of range ["
-                << audio::ChannelCount::min()
-                << ","
-                << audio::ChannelCount::max()
-                << "]";
+                << "<"
+                << audio::ChannelCount::min();
         result = false;
     }
     if (!m_signalInfo.getSampleRate().isValid()) {

--- a/src/sources/audiosource.h
+++ b/src/sources/audiosource.h
@@ -305,7 +305,7 @@ class AudioSource : public UrlResource, public virtual /*implements*/ IAudioSour
     explicit AudioSource(const QUrl& url);
 
     bool initChannelCountOnce(audio::ChannelCount channelCount);
-    bool initChannelCountOnce(SINT channelCount) {
+    bool initChannelCountOnce(int channelCount) {
         return initChannelCountOnce(audio::ChannelCount(channelCount));
     }
 

--- a/src/sources/soundsourcemodplug.cpp
+++ b/src/sources/soundsourcemodplug.cpp
@@ -55,15 +55,6 @@ QString getModPlugTypeFromUrl(const QUrl& url) {
 } // anonymous namespace
 
 //static
-constexpr SINT SoundSourceModPlug::kChannelCount;
-
-//static
-constexpr SINT SoundSourceModPlug::kBitsPerSample;
-
-//static
-constexpr SINT SoundSourceModPlug::kSampleRate;
-
-//static
 unsigned int SoundSourceModPlug::s_bufferSizeLimit = 0;
 
 //static

--- a/src/sources/soundsourcemodplug.h
+++ b/src/sources/soundsourcemodplug.h
@@ -15,9 +15,9 @@ namespace mixxx {
 // in RAM to allow seeking and smooth operation in Mixxx.
 class SoundSourceModPlug : public SoundSource {
   public:
-    static constexpr SINT kChannelCount = 2;
-    static constexpr SINT kSampleRate = 44100;
-    static constexpr SINT kBitsPerSample = 16;
+    static constexpr int kChannelCount = 2;
+    static constexpr int kSampleRate = 44100;
+    static constexpr int kBitsPerSample = 16;
 
     // apply settings for decoding
     static void configure(unsigned int bufferSizeLimit,


### PR DESCRIPTION
This is an alternative solution for https://github.com/mixxxdj/mixxx/pull/3893

I like this more, because this avoids the situation that external libraries uses a greater value range than Mixxx for the channel count. Most are on int so Mixxx does the same. 