### PR TITLE
Use std math functions and remove #defines from fpclassify.h

### DIFF
--- a/src/analyzer/analyzerwaveform.h
+++ b/src/analyzer/analyzerwaveform.h
@@ -2,12 +2,11 @@
 
 #include <QImage>
 #include <QSqlDatabase>
-
+#include <cmath>
 #include <limits>
 
 #include "analyzer/analyzer.h"
 #include "library/dao/analysisdao.h"
-#include "util/math.h"
 #include "util/performancetimer.h"
 #include "waveform/waveform.h"
 
@@ -20,10 +19,10 @@ inline CSAMPLE scaleSignal(CSAMPLE invalue, FilterIndex index = FilterCount) {
     if (invalue == 0.0) {
         return 0;
     } else if (index == Low || index == Mid) {
-        //return pow(invalue, 2 * 0.5);
+        //return std::pow(invalue, 2 * 0.5);
         return invalue;
     } else {
-        return pow(invalue, 2.0f * 0.316f);
+        return std::pow(invalue, 2.0f * 0.316f);
     }
 }
 

--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -16,8 +16,7 @@
 #include "errordialoghandler.h"
 #include "mixer/playermanager.h"
 #include "moc_controllerengine.cpp"
-// to tell the msvs compiler about `isnan`
-#include "util/math.h"
+#include "util/fpclassify.h"
 #include "util/time.h"
 
 // Used for id's inside controlConnection objects
@@ -684,7 +683,7 @@ double ControllerEngine::getValue(const QString& group, const QString& name) {
    Output:  -
    -------- ------------------------------------------------------ */
 void ControllerEngine::setValue(const QString& group, const QString& name, double newValue) {
-    if (isnan(newValue)) {
+    if (util_isnan(newValue)) {
         qWarning() << "ControllerEngine: script setting [" << group << "," << name
                  << "] to NotANumber, ignoring.";
         return;
@@ -722,7 +721,7 @@ double ControllerEngine::getParameter(const QString& group, const QString& name)
    -------- ------------------------------------------------------ */
 void ControllerEngine::setParameter(
         const QString& group, const QString& name, double newParameter) {
-    if (isnan(newParameter)) {
+    if (util_isnan(newParameter)) {
         qWarning() << "ControllerEngine: script setting [" << group << "," << name
                  << "] to NotANumber, ignoring.";
         return;
@@ -746,7 +745,7 @@ void ControllerEngine::setParameter(
    -------- ------------------------------------------------------ */
 double ControllerEngine::getParameterForValue(
         const QString& group, const QString& name, double value) {
-    if (isnan(value)) {
+    if (util_isnan(value)) {
         qWarning() << "ControllerEngine: script setting [" << group << "," << name
                  << "] to NotANumber, ignoring.";
         return 0.0;

--- a/src/effects/builtin/autopaneffect.cpp
+++ b/src/effects/builtin/autopaneffect.cpp
@@ -156,8 +156,8 @@ void AutoPanEffect::processChannel(
         // part of the period fraction being a step (not in the slope)
         CSAMPLE stepsFractionPart = floorf((quarter + 1.0f) / 2.0f) * smoothing;
 
-        // float inInterval = fmod( periodFraction, (period / 2.0) );
-        float inStepInterval = fmod(periodFraction, 0.5f);
+        // float inInterval = std::fmod( periodFraction, (period / 2.0) );
+        float inStepInterval = std::fmod(periodFraction, 0.5f);
 
         CSAMPLE angleFraction;
         if (inStepInterval > u && inStepInterval < (u + smoothing)) {

--- a/src/effects/builtin/bitcrushereffect.cpp
+++ b/src/effects/builtin/bitcrushereffect.cpp
@@ -83,7 +83,7 @@ void BitCrusherEffect::processChannel(const ChannelHandle& handle,
             m_pBitDepthParameter ? m_pBitDepthParameter->value() : 16);
 
     // divided by two because we use float math which includes the sing bit anyway
-    const CSAMPLE scale = pow(2.0f, bit_depth) / 2;
+    const CSAMPLE scale = std::pow(2.0f, bit_depth) / 2;
     // Gain correction is required, because MSB (values above 0.5) is usually
     // rarely used, to achieve equal loudness and maximum dynamic
     const CSAMPLE gainCorrection = (17 - bit_depth) / 8;

--- a/src/effects/builtin/phasereffect.cpp
+++ b/src/effects/builtin/phasereffect.cpp
@@ -2,8 +2,6 @@
 
 #include <QDebug>
 
-#include "util/math.h"
-
 namespace {
 constexpr unsigned int updateCoef = 32;
 constexpr auto kDoublePi = static_cast<CSAMPLE>(2.0 * M_PI);
@@ -198,8 +196,8 @@ void PhaserEffect::processChannel(const ChannelHandle& handle,
     for (SINT i = 0;
             i < bufferParameters.samplesPerBuffer();
             i += bufferParameters.channelCount()) {
-        left = pInput[i] + tanh(left * feedback);
-        right = pInput[i + 1] + tanh(right * feedback);
+        left = pInput[i] + std::tanh(left * feedback);
+        right = pInput[i + 1] + std::tanh(right * feedback);
 
         // For stereo enabled, the channels are out of phase
         pState->leftPhase = fmodf(pState->leftPhase + freqSkip, kDoublePi);
@@ -218,8 +216,8 @@ void PhaserEffect::processChannel(const ChannelHandle& handle,
             CSAMPLE wLeft = range * delayLeft;
             CSAMPLE wRight = range * delayRight;
 
-            CSAMPLE tanwLeft = tanh(wLeft / 2);
-            CSAMPLE tanwRight = tanh(wRight / 2);
+            CSAMPLE tanwLeft = std::tanh(wLeft / 2);
+            CSAMPLE tanwRight = std::tanh(wRight / 2);
 
             filterCoefLeft = (1.0f - tanwLeft) / (1.0f + tanwLeft);
             filterCoefRight = (1.0f - tanwRight) / (1.0f + tanwRight);

--- a/src/effects/lv2/lv2manifest.cpp
+++ b/src/effects/lv2/lv2manifest.cpp
@@ -1,6 +1,7 @@
 #include "effects/lv2/lv2manifest.h"
+
 #include "effects/effectmanifestparameter.h"
-#include "util/math.h"
+#include "util/fpclassify.h"
 
 LV2Manifest::LV2Manifest(const LilvPlugin* plug,
                          QHash<QString, LilvNode*>& properties)
@@ -118,19 +119,19 @@ LV2Manifest::LV2Manifest(const LilvPlugin* plug,
             // Some plugins don't specify minimum, maximum and default values
             // In this case set the minimum and default values to 0 and
             // the maximum to the number of scale points
-            if (isnan(m_default[i])) {
+            if (util_isnan(m_default[i])) {
                 param->setDefault(0);
             } else {
                 param->setDefault(m_default[i]);
             }
 
-            if (isnan(m_minimum[i])) {
+            if (util_isnan(m_minimum[i])) {
                 param->setMinimum(0);
             } else {
                 param->setMinimum(m_minimum[i]);
             }
 
-            if (isnan(m_maximum[i])) {
+            if (util_isnan(m_maximum[i])) {
                 param->setMaximum(param->getSteps().size() - 1);
             } else {
                 param->setMaximum(m_maximum[i]);

--- a/src/engine/controls/ratecontrol.cpp
+++ b/src/engine/controls/ratecontrol.cpp
@@ -11,7 +11,6 @@
 #include "engine/controls/enginecontrol.h"
 #include "engine/positionscratchcontroller.h"
 #include "moc_ratecontrol.cpp"
-#include "util/math.h"
 #include "util/rotary.h"
 #include "vinylcontrol/defs_vinylcontrol.h"
 
@@ -376,7 +375,7 @@ double RateControl::getJogFactor() const {
     double jogValueFiltered = m_pJogFilter->filter(jogValue);
     double jogFactor = jogValueFiltered * jogSensitivity;
 
-    if (isnan(jogValue) || isnan(jogFactor)) {
+    if (util_isnan(jogValue) || util_isnan(jogFactor)) {
         jogFactor = 0.0;
     }
 
@@ -423,7 +422,7 @@ double RateControl::calculateSpeed(double baserate, double speed, bool paused,
         } else {
             double scratchFactor = m_pScratch2->get();
             // Don't trust values from m_pScratch2
-            if (isnan(scratchFactor)) {
+            if (util_isnan(scratchFactor)) {
                 scratchFactor = 0.0;
             }
             if (paused) {
@@ -575,7 +574,7 @@ void RateControl::setRateTemp(double v) {
         m_tempRateRatio = -1.0;
     } else if (m_tempRateRatio > 1.0) {
         m_tempRateRatio = 1.0;
-    } else if (isnan(m_tempRateRatio)) {
+    } else if (util_isnan(m_tempRateRatio)) {
         m_tempRateRatio = 0;
     }
 }

--- a/src/engine/controls/vinylcontrolcontrol.cpp
+++ b/src/engine/controls/vinylcontrolcontrol.cpp
@@ -2,7 +2,6 @@
 
 #include "moc_vinylcontrolcontrol.cpp"
 #include "track/track.h"
-#include "util/math.h"
 #include "vinylcontrol/vinylcontrol.h"
 
 VinylControlControl::VinylControlControl(const QString& group, UserSettingsPointer pConfig)
@@ -80,7 +79,7 @@ void VinylControlControl::notifySeekQueued() {
 
 void VinylControlControl::slotControlVinylSeek(double fractionalPos) {
     // Prevent NaN's from sneaking into the engine.
-    if (isnan(fractionalPos)) {
+    if (util_isnan(fractionalPos)) {
         return;
     }
 

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -34,7 +34,6 @@
 #include "util/compatibility.h"
 #include "util/defs.h"
 #include "util/logger.h"
-#include "util/math.h"
 #include "util/sample.h"
 #include "util/timer.h"
 #include "waveform/visualplayposition.h"
@@ -603,7 +602,7 @@ void EngineBuffer::slotControlSeekExact(double playPosition) {
 
 void EngineBuffer::doSeekFractional(double fractionalPos, enum SeekRequest seekType) {
     // Prevent NaN's from sneaking into the engine.
-    VERIFY_OR_DEBUG_ASSERT(!isnan(fractionalPos)) {
+    VERIFY_OR_DEBUG_ASSERT(!util_isnan(fractionalPos)) {
         return;
     }
     double newSamplePosition = fractionalPos * m_pTrackSamples->get();

--- a/src/engine/enginepregain.cpp
+++ b/src/engine/enginepregain.cpp
@@ -2,11 +2,11 @@
 
 #include <QtDebug>
 
-#include "preferences/usersettings.h"
 #include "control/controlaudiotaperpot.h"
 #include "control/controlobject.h"
 #include "control/controlpotmeter.h"
 #include "control/controlpushbutton.h"
+#include "preferences/usersettings.h"
 #include "util/math.h"
 #include "util/sample.h"
 
@@ -17,7 +17,7 @@ constexpr float kSpeedGainMultiplier = 4.0f;
 // -1 dB to not risk any clipping even for lossy track that may have samples above 1.0
 constexpr float kMaxTotalGainBySpeed = 0.9f;
 // value to normalize gain to 1 at speed one
-const float kSpeedOneDiv = log10((1 * kSpeedGainMultiplier) + 1);
+const float kSpeedOneDiv = std::log10((1 * kSpeedGainMultiplier) + 1);
 } // anonymous namespace
 
 ControlPotmeter* EnginePregain::s_pReplayGainBoost = nullptr;
@@ -134,8 +134,8 @@ void EnginePregain::process(CSAMPLE* pInOut, const int iBufferSize) {
     // we do not add more gain then we found in the original track.
     // This compensates a negative ReplayGain or PreGain setting.
 
-    CSAMPLE_GAIN speedGain = log10((fabs(static_cast<CSAMPLE_GAIN>(m_dSpeed)) *
-                                           kSpeedGainMultiplier) +
+    CSAMPLE_GAIN speedGain = std::log10((fabs(static_cast<CSAMPLE_GAIN>(m_dSpeed)) *
+                                                kSpeedGainMultiplier) +
                                      1) /
             kSpeedOneDiv;
     // Limit speed Gain to 0 dB if totalGain is already > 0.9 or Limit the

--- a/src/engine/enginevumeter.cpp
+++ b/src/engine/enginevumeter.cpp
@@ -3,7 +3,6 @@
 #include "control/controlpotmeter.h"
 #include "control/controlproxy.h"
 #include "moc_enginevumeter.cpp"
-#include "util/math.h"
 #include "util/sample.h"
 
 namespace {
@@ -68,11 +67,9 @@ void EngineVuMeter::process(CSAMPLE* pIn, const int iBufferSize) {
     // Are we ready to update the VU meter?:
     if (m_iSamplesCalculated > (sampleRate / kVuUpdateRate)) {
         doSmooth(m_fRMSvolumeL,
-                log10(SHRT_MAX * m_fRMSvolumeSumL
-                                / (m_iSamplesCalculated * 1000) + 1));
+                std::log10(SHRT_MAX * m_fRMSvolumeSumL / (m_iSamplesCalculated * 1000) + 1));
         doSmooth(m_fRMSvolumeR,
-                log10(SHRT_MAX * m_fRMSvolumeSumR
-                                / (m_iSamplesCalculated * 1000) + 1));
+                std::log10(SHRT_MAX * m_fRMSvolumeSumR / (m_iSamplesCalculated * 1000) + 1));
 
         const double epsilon = .0001;
 

--- a/src/test/mathutiltest.cpp
+++ b/src/test/mathutiltest.cpp
@@ -1,10 +1,10 @@
+#include <gtest/gtest.h>
+
+#include <QtDebug>
 #include <limits>
 
-#include <gtest/gtest.h>
-#include <QtDebug>
-
-#include "util/math.h"
 #include "util/denormalsarezero.h"
+#include "util/math.h"
 
 namespace {
 
@@ -40,22 +40,22 @@ TEST_F(MathUtilTest, MathClampUnsafe) {
 
 TEST_F(MathUtilTest, IsNaN) {
     // Test floats can be recognized as nan.
-    EXPECT_FALSE(isnan(0.0f));
-    EXPECT_TRUE(isnan(std::numeric_limits<float>::quiet_NaN()));
+    EXPECT_FALSE(util_isnan(0.0f));
+    EXPECT_TRUE(util_isnan(std::numeric_limits<float>::quiet_NaN()));
 
     // Test doubles can be recognized as nan.
-    EXPECT_FALSE(isnan(0.0));
-    EXPECT_TRUE(isnan(std::numeric_limits<double>::quiet_NaN()));
+    EXPECT_FALSE(util_isnan(0.0));
+    EXPECT_TRUE(util_isnan(std::numeric_limits<double>::quiet_NaN()));
 }
 
 TEST_F(MathUtilTest, IsInf) {
     // Test floats can be recognized as infinity.
-    EXPECT_FALSE(isinf(0.0f));
-    EXPECT_TRUE(isinf(std::numeric_limits<float>::infinity()));
+    EXPECT_FALSE(util_isinf(0.0f));
+    EXPECT_TRUE(util_isinf(std::numeric_limits<float>::infinity()));
 
     // Test doubles can be recognized as infinity.
-    EXPECT_FALSE(isinf(0.0f));
-    EXPECT_TRUE(isinf(std::numeric_limits<double>::infinity()));
+    EXPECT_FALSE(util_isinf(0.0f));
+    EXPECT_TRUE(util_isinf(std::numeric_limits<double>::infinity()));
 }
 
 TEST_F(MathUtilTest, Denormal) {

--- a/src/util/duration.cpp
+++ b/src/util/duration.cpp
@@ -1,11 +1,11 @@
 #include "util/duration.h"
 
-#include <QtGlobal>
 #include <QTime>
+#include <QtGlobal>
+#include <cmath>
 
 #include "util/assert.h"
 #include "util/fpclassify.h"
-#include "util/math.h"
 
 namespace mixxx {
 
@@ -26,7 +26,7 @@ QChar DurationBase::kDecimalSeparator = QChar(0x002E);
 
 // static
 QString DurationBase::formatTime(double dSeconds, Precision precision) {
-    if (dSeconds < 0.0 || !isfinite(dSeconds)
+    if (dSeconds < 0.0 || !util_isfinite(dSeconds)
             // Use >= instead of >: 2^63-1 (qint64) is rounded to 2^63 (double)
             || dSeconds >= static_cast<double>(std::numeric_limits<qint64>::max())) {
         // negative durations and infinity or isNaN values are not supported
@@ -114,7 +114,7 @@ QString DurationBase::formatKiloSeconds(double dSeconds, Precision precision) {
     }
 
     int kilos = (int)dSeconds / 1000;
-    double seconds = floor(fmod(dSeconds, 1000));
+    double seconds = std::floor(fmod(dSeconds, 1000));
     double subs = fmod(dSeconds, 1);
 
     QString durationString =

--- a/src/util/fpclassify.h
+++ b/src/util/fpclassify.h
@@ -1,24 +1,26 @@
 #pragma once
 
-// We define
-// these as macros to prevent clashing with c++11 built-ins in the global
-// namespace. If you say "using std::isnan;" then this will fail to build with
-// std=c++11. See https://bugs.webkit.org/show_bug.cgi?id=59249 for some
-// relevant discussion.
-
-#define isnan util_isnan
-#define isinf util_isinf
-#define isnormal util_isnormal
-#define fpclassify util_fpclassify
-#define isfinite util_isfinite
+/**
+ * Functions for testing special floating-point values that
+ * won't work with -ffast-math. This corresponding.cpp file
+ * is compiled without -ffast-math and allows to invoke these
+ * functions from -ffast-math code.
+ *
+ * NOTE: All usage of the corresponding std functions must be
+ * avoided because they don't work as expected!!!
+ */
 
 int util_fpclassify(float x);
-int util_isfinite(float x);
-int util_isnormal(float x);
-int util_isnan(float x);
-int util_isinf(float x);
 int util_fpclassify(double x);
+
+int util_isfinite(float x);
 int util_isfinite(double x);
+
+int util_isnormal(float x);
 int util_isnormal(double x);
+
+int util_isnan(float x);
 int util_isnan(double x);
+
+int util_isinf(float x);
 int util_isinf(double x);

--- a/src/util/math.h
+++ b/src/util/math.h
@@ -1,14 +1,7 @@
 #pragma once
 
-#include <math.h>
-
-#include <cmath>
-// Note: Because of our fpclassify hack, we actually need to include both,
-// the c and the c++ version of the math header.
-// From GCC 6.1.1 math.h depends on cmath, which fails to compile if included
-// after our fpclassify hack
-
 #include <algorithm>
+#include <cmath>
 #include <type_traits>
 
 #include "util/assert.h"

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -14,7 +14,6 @@
 #include "control/controlpushbutton.h"
 #include "moc_wpushbutton.cpp"
 #include "util/debug.h"
-#include "util/math.h"
 #include "widget/wpixmapstore.h"
 
 WPushButton::WPushButton(QWidget* pParent)
@@ -399,7 +398,7 @@ void WPushButton::mousePressEvent(QMouseEvent * e) {
         } else {
             // Toggle through the states
             emitValue = getControlParameterLeft();
-            if (!isnan(emitValue) && m_iNoStates > 0) {
+            if (!util_isnan(emitValue) && m_iNoStates > 0) {
                 emitValue = static_cast<int>(emitValue + 1.0) % m_iNoStates;
             }
             if (m_leftButtonMode == ControlPushButton::LONGPRESSLATCHING) {
@@ -500,7 +499,7 @@ void WPushButton::mouseReleaseEvent(QMouseEvent * e) {
             if (m_leftButtonMode == ControlPushButton::LONGPRESSLATCHING
                     && m_clickTimer.isActive() && emitValue >= 1.0) {
                 // revert toggle if button is released too early
-                if (!isnan(emitValue) && m_iNoStates > 0) {
+                if (!util_isnan(emitValue) && m_iNoStates > 0) {
                     emitValue = static_cast<int>(emitValue - 1.0) % m_iNoStates;
                 }
             } else {

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -1,20 +1,19 @@
 #pragma once
 
+#include <QFocusEvent>
+#include <QMouseEvent>
 #include <QPaintEvent>
 #include <QPixmap>
 #include <QString>
-#include <QPaintEvent>
-#include <QMouseEvent>
-#include <QFocusEvent>
 #include <QTimer>
 #include <QVector>
 
-#include "widget/wwidget.h"
-#include "widget/wpixmapstore.h"
 #include "control/controlpushbutton.h"
 #include "skin/skincontext.h"
+#include "util/fpclassify.h"
 #include "widget/controlwidgetconnection.h"
-#include "util/math.h"
+#include "widget/wpixmapstore.h"
+#include "widget/wwidget.h"
 
 class WPushButton : public WWidget {
     Q_OBJECT
@@ -47,7 +46,7 @@ class WPushButton : public WWidget {
 
     int readDisplayValue() const {
         double value = getControlParameterDisplay();
-        if (!isnan(value) && m_iNoStates > 0) {
+        if (!util_isnan(value) && m_iNoStates > 0) {
             return static_cast<int>(value) % m_iNoStates;
         }
         return 0;

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -15,7 +15,7 @@
 #include "track/track.h"
 #include "util/compatibility.h"
 #include "util/dnd.h"
-#include "util/math.h"
+#include "util/fpclassify.h"
 #include "vinylcontrol/vinylcontrol.h"
 #include "vinylcontrol/vinylcontrolmanager.h"
 #include "waveform/sharedglcontext.h"
@@ -442,8 +442,8 @@ void WSpinny::resizeEvent(QResizeEvent* /*unused*/) {
 double WSpinny::calculateAngle(double playpos) {
     double trackFrames = m_pTrackSamples->get() / 2;
     double trackSampleRate = m_pTrackSampleRate->get();
-    if (isnan(playpos) || isnan(trackFrames) || isnan(trackSampleRate) ||
-        trackFrames <= 0 || trackSampleRate <= 0) {
+    if (util_isnan(playpos) || util_isnan(trackFrames) || util_isnan(trackSampleRate) ||
+            trackFrames <= 0 || trackSampleRate <= 0) {
         return 0.0;
     }
 
@@ -451,7 +451,7 @@ double WSpinny::calculateAngle(double playpos) {
     double t = playpos * trackFrames / trackSampleRate;
 
     // Bad samplerate or number of track samples.
-    if (isnan(t)) {
+    if (util_isnan(t)) {
         return 0.0;
     }
 
@@ -488,7 +488,7 @@ double WSpinny::calculateAngle(double playpos) {
 /** Given a normalized playpos, calculate the integer number of rotations
     that it would take to wind the vinyl to that position. */
 int WSpinny::calculateFullRotations(double playpos) {
-    if (isnan(playpos)) {
+    if (util_isnan(playpos)) {
         return 0;
     }
     //Convert playpos to seconds.
@@ -504,7 +504,7 @@ int WSpinny::calculateFullRotations(double playpos) {
 
 //Inverse of calculateAngle()
 double WSpinny::calculatePositionFromAngle(double angle) {
-    if (isnan(angle)) {
+    if (util_isnan(angle)) {
         return 0.0;
     }
 
@@ -513,14 +513,14 @@ double WSpinny::calculatePositionFromAngle(double angle) {
 
     double trackFrames = m_pTrackSamples->get() / 2;
     double trackSampleRate = m_pTrackSampleRate->get();
-    if (isnan(trackFrames) || isnan(trackSampleRate) ||
-        trackFrames <= 0 || trackSampleRate <= 0) {
+    if (util_isnan(trackFrames) || util_isnan(trackSampleRate) ||
+            trackFrames <= 0 || trackSampleRate <= 0) {
         return 0.0;
     }
 
     // Convert t from seconds into a normalized playposition value.
     double playpos = t * trackSampleRate / trackFrames;
-    if (isnan(playpos)) {
+    if (util_isnan(playpos)) {
         return 0.0;
     }
     return playpos;


### PR DESCRIPTION
To get us back onto the `std` path after we no longer need to support legacy Microsoft compilers.

This PR is a prerequisite for upgrading googletest and replaces #3887.

Note: There are lots of files that include `"util/math.h"`. Probably only a few of these includes are actually needed or could be replaced by including `<cmath>` instead. Out of scope.