### PR TITLE
Fix crash when right double clicking GLSL waveform

### DIFF
--- a/src/waveform/widgets/glslwaveformwidget.cpp
+++ b/src/waveform/widgets/glslwaveformwidget.cpp
@@ -97,7 +97,9 @@ void GLSLWaveformWidget::mouseDoubleClickEvent(QMouseEvent *event) {
     if (event->button() == Qt::RightButton) {
         makeCurrent();
 #if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
-        m_signalRenderer->debugClick();
+        if (m_signalRenderer) {
+            m_signalRenderer->debugClick();
+        }
 #endif // !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
     }
 }


### PR DESCRIPTION
Not sure why m_signalRenderer is even there, since I can't find GLSLWaveformRendererSignal beeing used anywhere,
but m_signalRenderer is definitly nullptr here.