### PR TITLE
QML: Add ImageProvider for Cover Art

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -733,6 +733,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/skin/legacy/legacyskinparser.cpp
   src/skin/legacy/pixmapsource.cpp
   src/skin/legacy/legacyskin.cpp
+  src/skin/qml/asyncimageprovider.cpp
   src/skin/qml/qmlcontrolproxy.cpp
   src/skin/qml/qmlplayermanagerproxy.cpp
   src/skin/qml/qmlplayerproxy.cpp

--- a/res/skins/QMLDemo/DeckInfoBar.qml
+++ b/res/skins/QMLDemo/DeckInfoBar.qml
@@ -1,6 +1,7 @@
 import "." as Skin
 import Mixxx 0.1 as Mixxx
 import Mixxx.Controls 0.1 as MixxxControls
+import QtGraphicalEffects 1.12
 import QtQuick 2.12
 import "Theme"
 
@@ -15,7 +16,7 @@ Rectangle {
     radius: 5
     height: 56
 
-    Rectangle {
+    Image {
         id: coverArt
 
         anchors.top: parent.top
@@ -23,6 +24,28 @@ Rectangle {
         anchors.bottom: parent.bottom
         anchors.margins: 5
         width: height
+        source: root.deckPlayer.coverArtUrl
+        visible: false
+    }
+
+    Rectangle {
+        id: coverArtCircle
+
+        anchors.fill: coverArt
+        radius: height / 2
+        visible: false
+    }
+
+    OpacityMask {
+        anchors.fill: coverArt
+        source: coverArt
+        maskSource: coverArtCircle
+    }
+
+    Rectangle {
+        id: spinnyCircle
+
+        anchors.fill: coverArt
         radius: height / 2
         border.width: 2
         border.color: Theme.deckLineColor

--- a/src/skin/qml/asyncimageprovider.cpp
+++ b/src/skin/qml/asyncimageprovider.cpp
@@ -2,6 +2,10 @@
 
 #include "library/coverartcache.h"
 
+namespace {
+const QString kCoverArtPrefix = QStringLiteral("coverart/");
+}
+
 namespace mixxx {
 namespace skin {
 namespace qml {
@@ -16,9 +20,8 @@ QQuickTextureFactory* AsyncImageResponse::textureFactory() const {
 }
 
 void AsyncImageResponse::run() {
-    if (m_id.startsWith(QStringLiteral("coverart/"))) {
-        QString trackLocation = QString::fromUtf8(QByteArray::fromBase64(
-                m_id.mid(9).toLatin1(), QByteArray::Base64UrlEncoding));
+    if (m_id.startsWith(kCoverArtPrefix)) {
+        QString trackLocation = AsyncImageProvider::coverArtUrlIdToTrackLocation(m_id);
 
         // TODO: This code does not allow to override embedded cover art with
         // a custom image, which is possible in Mixxx. We need to access the
@@ -48,6 +51,23 @@ QQuickImageResponse* AsyncImageProvider::requestImageResponse(
     AsyncImageResponse* response = new AsyncImageResponse(id, requestedSize);
     pool.start(response);
     return response;
+}
+
+// static
+const QString AsyncImageProvider::kProviderName = QStringLiteral("mixxx");
+
+// static
+QUrl AsyncImageProvider::trackLocationToCoverArtUrl(const QString& trackLocation) {
+    QUrl url("image://" + kProviderName + "/" + kCoverArtPrefix);
+    return url.resolved(
+            QString::fromLatin1(trackLocation.toUtf8().toBase64(
+                    QByteArray::Base64UrlEncoding)));
+}
+
+//static
+QString AsyncImageProvider::coverArtUrlIdToTrackLocation(const QString& coverArtUrlId) {
+    return QString::fromUtf8(QByteArray::fromBase64(
+            coverArtUrlId.mid(kCoverArtPrefix.size()).toLatin1(), QByteArray::Base64UrlEncoding));
 }
 
 } // namespace qml

--- a/src/skin/qml/asyncimageprovider.cpp
+++ b/src/skin/qml/asyncimageprovider.cpp
@@ -1,0 +1,55 @@
+#include "skin/qml/asyncimageprovider.h"
+
+#include "library/coverartcache.h"
+
+namespace mixxx {
+namespace skin {
+namespace qml {
+
+AsyncImageResponse::AsyncImageResponse(const QString& id, const QSize& requestedSize)
+        : m_id(id), m_requestedSize(requestedSize) {
+    setAutoDelete(false);
+}
+
+QQuickTextureFactory* AsyncImageResponse::textureFactory() const {
+    return QQuickTextureFactory::textureFactoryForImage(m_image);
+}
+
+void AsyncImageResponse::run() {
+    if (m_id.startsWith(QStringLiteral("coverart/"))) {
+        QString trackLocation = QString::fromUtf8(QByteArray::fromBase64(
+                m_id.mid(9).toLatin1(), QByteArray::Base64UrlEncoding));
+
+        // TODO: This code does not allow to override embedded cover art with
+        // a custom image, which is possible in Mixxx. We need to access the
+        // actual CoverInfo of the track instead of constructing a default
+        // instance on the fly.
+        CoverInfo coverInfo(CoverInfoRelative(), trackLocation);
+        coverInfo.type = CoverInfoRelative::METADATA;
+        CoverInfo::LoadedImage loadedImage = coverInfo.loadImage();
+        if (loadedImage.result != CoverInfo::LoadedImage::Result::Ok) {
+            coverInfo.type = CoverInfoRelative::FILE;
+            loadedImage = coverInfo.loadImage();
+        }
+        m_image = loadedImage.image;
+    } else {
+        qWarning() << "ImageProvider: Unknown ID " << m_id;
+    }
+
+    if (!m_image.isNull() && m_requestedSize.isValid()) {
+        m_image = m_image.scaled(m_requestedSize);
+    }
+
+    emit finished();
+}
+
+QQuickImageResponse* AsyncImageProvider::requestImageResponse(
+        const QString& id, const QSize& requestedSize) {
+    AsyncImageResponse* response = new AsyncImageResponse(id, requestedSize);
+    pool.start(response);
+    return response;
+}
+
+} // namespace qml
+} // namespace skin
+} // namespace mixxx

--- a/src/skin/qml/asyncimageprovider.cpp
+++ b/src/skin/qml/asyncimageprovider.cpp
@@ -27,6 +27,10 @@ void AsyncImageResponse::run() {
         // a custom image, which is possible in Mixxx. We need to access the
         // actual CoverInfo of the track instead of constructing a default
         // instance on the fly.
+        //
+        // Unfortunately, TrackCollectionManager::getTrackByRef will not work
+        // when called from another thread (like this one). We need a solution
+        // for that.
         CoverInfo coverInfo(CoverInfoRelative(), trackLocation);
         coverInfo.type = CoverInfoRelative::METADATA;
         CoverInfo::LoadedImage loadedImage = coverInfo.loadImage();

--- a/src/skin/qml/asyncimageprovider.h
+++ b/src/skin/qml/asyncimageprovider.h
@@ -27,6 +27,10 @@ class AsyncImageProvider : public QQuickAsyncImageProvider {
     QQuickImageResponse* requestImageResponse(
             const QString& id, const QSize& requestedSize) override;
 
+    static const QString kProviderName;
+    static QUrl trackLocationToCoverArtUrl(const QString& trackLocation);
+    static QString coverArtUrlIdToTrackLocation(const QString& coverArtUrlId);
+
   private:
     QThreadPool pool;
 };

--- a/src/skin/qml/asyncimageprovider.h
+++ b/src/skin/qml/asyncimageprovider.h
@@ -1,0 +1,36 @@
+#include <QImage>
+#include <QQuickAsyncImageProvider>
+#include <QRunnable>
+#include <QSize>
+#include <QString>
+#include <QThreadPool>
+
+#include "library/coverart.h"
+
+namespace mixxx {
+namespace skin {
+namespace qml {
+
+class AsyncImageResponse : public QQuickImageResponse, public QRunnable {
+  public:
+    AsyncImageResponse(const QString& id, const QSize& requestedSize);
+    QQuickTextureFactory* textureFactory() const override;
+    void run() override;
+
+    QString m_id;
+    QSize m_requestedSize;
+    QImage m_image;
+};
+
+class AsyncImageProvider : public QQuickAsyncImageProvider {
+  public:
+    QQuickImageResponse* requestImageResponse(
+            const QString& id, const QSize& requestedSize) override;
+
+  private:
+    QThreadPool pool;
+};
+
+} // namespace qml
+} // namespace skin
+} // namespace mixxx

--- a/src/skin/qml/qmlplayerproxy.cpp
+++ b/src/skin/qml/qmlplayerproxy.cpp
@@ -125,6 +125,7 @@ void QmlPlayerProxy::slotTrackChanged() {
     emit commentChanged();
     emit keyTextChanged();
     emit colorChanged();
+    emit coverArtUrlChanged();
 }
 
 PROPERTY_IMPL(QString, artist, getArtist, setArtist)
@@ -154,6 +155,19 @@ void QmlPlayerProxy::setColor(const QColor& value) {
         std::optional<RgbColor> color = RgbColor::fromQColor(value);
         pTrack->setColor(color);
     }
+}
+
+QUrl QmlPlayerProxy::getCoverArtUrl() const {
+    const TrackPointer pTrack = m_pCurrentTrack;
+    if (pTrack == nullptr) {
+        return QUrl();
+    }
+
+    const CoverInfo coverInfo = pTrack->getCoverInfoWithLocation();
+    QUrl url("image://mixxx/coverart/");
+    return url.resolved(
+            QString::fromLatin1(coverInfo.trackLocation.toUtf8().toBase64(
+                    QByteArray::Base64UrlEncoding)));
 }
 
 } // namespace qml

--- a/src/skin/qml/qmlplayerproxy.cpp
+++ b/src/skin/qml/qmlplayerproxy.cpp
@@ -1,6 +1,7 @@
 #include "skin/qml/qmlplayerproxy.h"
 
 #include "mixer/basetrackplayer.h"
+#include "skin/qml/asyncimageprovider.h"
 
 #define PROPERTY_IMPL(TYPE, NAME, GETTER, SETTER)    \
     TYPE QmlPlayerProxy::GETTER() const {            \
@@ -164,10 +165,7 @@ QUrl QmlPlayerProxy::getCoverArtUrl() const {
     }
 
     const CoverInfo coverInfo = pTrack->getCoverInfoWithLocation();
-    QUrl url("image://mixxx/coverart/");
-    return url.resolved(
-            QString::fromLatin1(coverInfo.trackLocation.toUtf8().toBase64(
-                    QByteArray::Base64UrlEncoding)));
+    return AsyncImageProvider::trackLocationToCoverArtUrl(coverInfo.trackLocation);
 }
 
 } // namespace qml

--- a/src/skin/qml/qmlplayerproxy.h
+++ b/src/skin/qml/qmlplayerproxy.h
@@ -1,6 +1,7 @@
 #include <QColor>
 #include <QObject>
 #include <QString>
+#include <QUrl>
 
 #include "track/track.h"
 
@@ -27,6 +28,7 @@ class QmlPlayerProxy : public QObject {
     Q_PROPERTY(QString comment READ getComment WRITE setComment NOTIFY commentChanged)
     Q_PROPERTY(QString keyText READ getKeyText WRITE setKeyText NOTIFY keyTextChanged)
     Q_PROPERTY(QColor color READ getColor WRITE setColor NOTIFY colorChanged)
+    Q_PROPERTY(QUrl coverArtUrl READ getCoverArtUrl NOTIFY coverArtUrlChanged)
 
   public:
     explicit QmlPlayerProxy(BaseTrackPlayer* pTrackPlayer, QObject* parent);
@@ -45,6 +47,7 @@ class QmlPlayerProxy : public QObject {
     QString getComment() const;
     QString getKeyText() const;
     QColor getColor() const;
+    QUrl getCoverArtUrl() const;
 
   public slots:
     void slotTrackLoaded(TrackPointer pTrack);
@@ -84,6 +87,7 @@ class QmlPlayerProxy : public QObject {
     void commentChanged();
     void keyTextChanged();
     void colorChanged();
+    void coverArtUrlChanged();
 
   private:
     BaseTrackPlayer* m_pTrackPlayer;

--- a/src/skin/qml/qmlskin.cpp
+++ b/src/skin/qml/qmlskin.cpp
@@ -159,7 +159,7 @@ QWidget* QmlSkin::loadSkin(QWidget* pParent,
 
     // No memory leak here, the QQmlENgine takes ownership of the provider
     QQuickAsyncImageProvider* pImageProvider = new AsyncImageProvider();
-    pWidget->engine()->addImageProvider(QStringLiteral("mixxx"), pImageProvider);
+    pWidget->engine()->addImageProvider(AsyncImageProvider::kProviderName, pImageProvider);
 
     pWidget->setSource(QUrl::fromLocalFile(dir().absoluteFilePath(kMainQmlFileName)));
     pWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);

--- a/src/skin/qml/qmlskin.cpp
+++ b/src/skin/qml/qmlskin.cpp
@@ -5,6 +5,7 @@
 #include <functional>
 
 #include "coreservices.h"
+#include "skin/qml/asyncimageprovider.h"
 #include "skin/qml/qmlcontrolproxy.h"
 #include "skin/qml/qmlplayermanagerproxy.h"
 #include "skin/qml/qmlplayerproxy.h"
@@ -155,6 +156,11 @@ QWidget* QmlSkin::loadSkin(QWidget* pParent,
 
     pWidget->engine()->setBaseUrl(QUrl::fromLocalFile(m_path.absoluteFilePath()));
     pWidget->engine()->addImportPath(m_path.absoluteFilePath());
+
+    // No memory leak here, the QQmlENgine takes ownership of the provider
+    QQuickAsyncImageProvider* pImageProvider = new AsyncImageProvider();
+    pWidget->engine()->addImageProvider(QStringLiteral("mixxx"), pImageProvider);
+
     pWidget->setSource(QUrl::fromLocalFile(dir().absoluteFilePath(kMainQmlFileName)));
     pWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
     if (pWidget->status() != QQuickWidget::Ready) {


### PR DESCRIPTION
This allows displaying cover art in QML skins.

![Screenshot from 2021-05-25 23-20-40](https://user-images.githubusercontent.com/1834516/119570244-2524e200-bdb0-11eb-8968-a210aa323a3d.png)

Depends on #3911. 