### PR TITLE
pre-commit: Add hooks for qmllint and qmlformat

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,17 +8,14 @@ jobs:
   pre-commit:
     name: Detecting code style issues
     runs-on: ubuntu-latest
+    # The Dockerfile for this container can be found at:
+    # https://github.com/Holzhaus/mixxx-ci-docker
+    container: holzhaus/mixxx-ci:20210526
     steps:
     - name: "Check out repository"
       uses: actions/checkout@v2
       with:
         fetch-depth: 2
-
-    - name: "Set up Python"
-      uses: actions/setup-python@v2
-
-    - name: Install clang-format
-      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang-format-10
 
     - name: "Detect code style issues (push)"
       uses: pre-commit/action@v2.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,6 +25,10 @@ jobs:
       # on Pull Requests!).
       env:
         SKIP: end-of-file-fixer,trailing-whitespace,clang-format,eslint,no-commit-to-branch
+      with:
+        # Enable extra hooks that require special system dependencies that we
+        # cannot expect to be installed on all contributor's systems.
+        extra_args: --hook-stage manual --all-files
 
     - name: "Detect code style issues (pull_request)"
       uses: pre-commit/action@v2.0.0
@@ -32,9 +36,13 @@ jobs:
       env:
         SKIP: no-commit-to-branch
       with:
+        # Enable extra hooks that require special system dependencies that are
+        # available in our custom docker container, but cannot be expected to
+        # be installed on all contributor's systems.
+        #
         # HEAD is the not yet integrated PR merge commit +refs/pull/xxxx/merge
         # HEAD^1 is the PR target branch and HEAD^2 is the HEAD of the source branch
-        extra_args: --from-ref HEAD^1 --to-ref HEAD
+        extra_args: --hook-stage manual --from-ref HEAD^1 --to-ref HEAD
 
     - name: "Generate patch file"
       if: failure()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,3 +124,23 @@ repos:
     stages:
     - commit
     - manual
+  - id: qmlformat
+    name: qmlformat
+    entry: qmlformat -i
+    pass_filenames: true
+    require_serial: true
+    language: system
+    types: [text]
+    files: ^.*\.qml$
+    # Not enabled in commit stage by default, because qmlformat requires Qt
+    # 5.15 to be installed
+    stages:
+    - manual
+  - id: qmllint
+    name: qmllint
+    entry: qmllint
+    pass_filenames: true
+    require_serial: true
+    language: system
+    types: [text]
+    files: ^.*\.qml$


### PR DESCRIPTION
This adds the [qmllint](https://doc-snapshots.qt.io/qt6-dev/qtquick-tools-and-utilities.html#qmllint) and [qmlformat](https://doc-snapshots.qt.io/qt6-dev/qtquick-tools-and-utilities.html#qmlformat) hooks to ensure our QML files are up to par.

Unfortunately, `qmlformat` is only part of Qt 5.15 and later. Therefore, we cannot expect our contributors to have it installed. Since it's a binary dependencies (i.e. not a python/npm package), we also can't provide convenient automatic installation.

Therefore, the qmlformat hook is restricted to the `manual` hook stage. This means that it's not run automatically when committing, only when you run:

    $ pre-commit run qmlformat --hook-stage manual --all-files

Not great and easy to forget, but we can let our pre-commit CI workflow assist us in noticing issues during PR review. However, this requires that our CI has Qt 5.15 available, which isn't the case with the current `ubuntu-latest` image.

Hence, I wrote a [small Dockerfile based on Arch Linux](https://github.com/Holzhaus/mixxx-ci-docker/tree/20210526) and [uploaded the image to DockerHub](https://hub.docker.com/layers/holzhaus/mixxx-ci/20210526/images/sha256-af57ff7576d943ce6ad0acabd2259c91730d13f2711fe226d91649e48456e920), so that we can use it in our pre-commit workflow.

TL;DR: With this PR, QML formatting issues  can be detected early on CI without requiring all contributors to install Qt 5.15 or later.