### PR TITLE
Get rid of the not working binary file check

### DIFF
--- a/src/library/parser.cpp
+++ b/src/library/parser.cpp
@@ -33,33 +33,6 @@ long Parser::countParsed() {
     return (long)m_sLocations.count();
 }
 
-bool Parser::isBinary(const QString& filename) {
-    char firstByte;
-    QFile file(filename);
-    if (file.open(QIODevice::ReadOnly) && file.getChar(&firstByte)) {
-        // If starting byte is not an ASCII character then the file
-        // probably contains binary data.
-        if (firstByte >= 32 && firstByte <= 126) {
-            // Valid ASCII character
-            return false;
-        }
-        // Check for UTF-8 BOM
-        if (firstByte == '\xEF') {
-            char nextChar;
-            if (file.getChar(&nextChar) &&
-                    nextChar == '\xBB' &&
-                    file.getChar(&nextChar) &&
-                    nextChar == '\xBF') {
-                // UTF-8 text file
-                return false;
-            }
-            return true;
-        }
-    }
-    qDebug() << "Parser: Error reading from" << filename;
-    return true; //should this raise an exception?
-}
-
 // The following public domain code is taken from
 // http://stackoverflow.com/questions/1031645/how-to-detect-utf-8-in-plain-c
 // Thank you Christoph!

--- a/src/library/parser.h
+++ b/src/library/parser.h
@@ -50,8 +50,6 @@ class Parser : public QObject {
     long countParsed();
     // Clears m_psLocations
     void clearLocations();
-    // Checks if the file does contain binary content
-    bool isBinary(const QString&);
     // check for Utf8 encoding
     static bool isUtf8(const char* string);
     // Resolve an absolute or relative file path

--- a/src/library/parsercsv.cpp
+++ b/src/library/parsercsv.cpp
@@ -33,7 +33,7 @@ QList<QString> ParserCsv::parse(const QString& sFilename) {
 
     clearLocations();
     //qDebug() << "ParserCsv: Starting to parse.";
-    if (file.open(QIODevice::ReadOnly) && !isBinary(sFilename)) {
+    if (file.open(QIODevice::ReadOnly)) {
         QByteArray ba = file.readAll();
 
         QList<QList<QString> > tokens = tokenize(ba, ',');

--- a/src/library/parserm3u.cpp
+++ b/src/library/parserm3u.cpp
@@ -49,7 +49,7 @@ QList<QString> ParserM3u::parse(const QString& sFilename) {
     clearLocations();
 
     QFile file(sFilename);
-    if (isBinary(sFilename) || !file.open(QIODevice::ReadOnly)) {
+    if (!file.open(QIODevice::ReadOnly)) {
         qWarning()
                 << "Failed to open playlist file"
                 << sFilename;

--- a/src/library/parserpls.cpp
+++ b/src/library/parserpls.cpp
@@ -39,8 +39,7 @@ QList<QString> ParserPls::parse(const QString& sFilename) {
 
     clearLocations();
 
-    if (file.open(QIODevice::ReadOnly) && !isBinary(sFilename)) {
-
+    if (file.open(QIODevice::ReadOnly)) {
         /* Unfortunately, QT 4.7 does not handle <CR> (=\r or asci value 13) line breaks.
          * This is important on OS X where iTunes, e.g., exports M3U playlists using <CR>
          * rather that <LF>


### PR DESCRIPTION
The code requires that the first Char is either ASCII or a BOM, which is not the case if the file starts with a cyrilic char or a Windows-1252 char like Ü 

This issue was reported here: 
https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/Mixxx.20can.20not.20load.20m3u8.20playlist




 