### PR TITLE
DlgPrefInterface: Fix crash if no skin is available

### DIFF
--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -40,6 +40,11 @@ DlgPrefInterface::DlgPrefInterface(
           m_bRebootMixxxView(false) {
     setupUi(this);
 
+    VERIFY_OR_DEBUG_ASSERT(m_pSkin != nullptr) {
+        qWarning() << "Skipping creation of DlgPrefInterface because there is no skin available.";
+        return;
+    }
+
     // Locale setting
     // Iterate through the available locales and add them to the combobox
     // Borrowed following snippet from http://qt-project.org/wiki/How_to_create_a_multi_language_application


### PR DESCRIPTION
Only happens when neither the configured not the default skin is available (so that mixxx needs to shut down anyway), but should be fixed nonetheless.