### PR TITLE
QML: Add support for Waveform Overviews

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -737,6 +737,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/skin/qml/qmlplayermanagerproxy.cpp
   src/skin/qml/qmlplayerproxy.cpp
   src/skin/qml/qmlskin.cpp
+  src/skin/qml/qmlwaveformoverview.cpp
   src/skin/legacy/skincontext.cpp
   src/skin/legacy/tooltips.cpp
   src/skin/skinloader.cpp

--- a/res/skins/QMLDemo/Mixxx/Controls/WaveformOverview.qml
+++ b/res/skins/QMLDemo/Mixxx/Controls/WaveformOverview.qml
@@ -1,0 +1,35 @@
+import Mixxx 0.1 as Mixxx
+import QtQuick 2.12
+import QtQuick.Shapes 1.12
+
+Mixxx.WaveformOverview {
+    id: root
+
+    property string group // required
+
+    player: Mixxx.PlayerManager.getPlayer(root.group)
+
+    Mixxx.ControlProxy {
+        id: playPositionControl
+
+        group: root.group
+        key: "playposition"
+    }
+
+    MouseArea {
+        id: mousearea
+
+        anchors.fill: parent
+        cursorShape: Qt.PointingHandCursor
+        hoverEnabled: true
+        onPressed: {
+            playPositionControl.value = mouse.x / width;
+        }
+        onPositionChanged: {
+            if (containsPress)
+                playPositionControl.value = mouse.x / width;
+
+        }
+    }
+
+}

--- a/res/skins/QMLDemo/Mixxx/Controls/WaveformOverview.qml
+++ b/res/skins/QMLDemo/Mixxx/Controls/WaveformOverview.qml
@@ -1,4 +1,5 @@
 import Mixxx 0.1 as Mixxx
+import Mixxx.Controls 0.1 as MixxxControls
 import QtQuick 2.12
 import QtQuick.Shapes 1.12
 
@@ -10,10 +11,45 @@ Mixxx.WaveformOverview {
     player: Mixxx.PlayerManager.getPlayer(root.group)
 
     Mixxx.ControlProxy {
+        id: trackLoadedControl
+
+        group: root.group
+        key: "track_loaded"
+        onValueChanged: markers.visible = value
+    }
+
+    Mixxx.ControlProxy {
         id: playPositionControl
 
         group: root.group
         key: "playposition"
+    }
+
+    Item {
+        id: markers
+
+        anchors.fill: parent
+        visible: trackLoadedControl.value
+
+        Repeater {
+            model: 8
+
+            MixxxControls.WaveformOverviewHotcueMarker {
+                anchors.fill: parent
+                group: root.group
+                hotcueNumber: index + 1
+            }
+
+        }
+
+        MixxxControls.WaveformOverviewMarker {
+            id: playPositionMarker
+
+            anchors.fill: parent
+            group: root.group
+            key: "playposition"
+        }
+
     }
 
     MouseArea {
@@ -23,7 +59,7 @@ Mixxx.WaveformOverview {
         cursorShape: Qt.PointingHandCursor
         hoverEnabled: true
         onPressed: {
-            playPositionControl.value = mouse.x / width;
+            playPositionControl.value = mouse.x / mousearea.width;
         }
         onPositionChanged: {
             if (containsPress)

--- a/res/skins/QMLDemo/Mixxx/Controls/WaveformOverviewHotcueMarker.qml
+++ b/res/skins/QMLDemo/Mixxx/Controls/WaveformOverviewHotcueMarker.qml
@@ -1,0 +1,80 @@
+import Mixxx 0.1 as Mixxx
+import QtQuick 2.12
+import QtQuick.Shapes 1.12
+
+Item {
+    id: root
+
+    property string group // required
+    property int hotcueNumber // required
+
+    function updatePosition() {
+        let totalSamples = trackSamplesControl.value;
+        marker.x = (totalSamples > 0) ? root.width * (positionControl.value / totalSamples) : 0;
+    }
+
+    onWidthChanged: updatePosition()
+
+    Shape {
+        id: shape
+
+        visible: statusControl.value >= 0
+        anchors.fill: parent
+        antialiasing: true
+        layer.smooth: true
+        layer.samples: 2
+
+        ShapePath {
+            startX: marker.x
+            startY: 0
+            strokeColor: colorControl.hotcueColor
+            strokeWidth: 1
+
+            PathLine {
+                id: marker
+
+                x: 0
+                y: root.height
+            }
+
+        }
+
+    }
+
+    Mixxx.ControlProxy {
+        id: trackSamplesControl
+
+        group: root.group
+        key: "track_samples"
+    }
+
+    Mixxx.ControlProxy {
+        id: statusControl
+
+        group: root.group
+        key: "hotcue_" + root.hotcueNumber + "_status"
+    }
+
+    Mixxx.ControlProxy {
+        id: positionControl
+
+        group: root.group
+        key: "hotcue_" + root.hotcueNumber + "_position"
+        onValueChanged: updatePosition()
+    }
+
+    Mixxx.ControlProxy {
+        id: colorControl
+
+        property color hotcueColor: updateColor()
+
+        function updateColor() {
+            hotcueColor = (value >= 0) ? "#" + value.toString(16) : "transparent";
+        }
+
+        group: root.group
+        key: "hotcue_" + root.hotcueNumber + "_color"
+        onValueChanged: updateColor()
+    }
+
+}

--- a/res/skins/QMLDemo/Mixxx/Controls/WaveformOverviewMarker.qml
+++ b/res/skins/QMLDemo/Mixxx/Controls/WaveformOverviewMarker.qml
@@ -1,0 +1,48 @@
+import Mixxx 0.1 as Mixxx
+import QtQuick 2.12
+import QtQuick.Shapes 1.12
+
+Item {
+    id: root
+
+    required property string group
+    required property string key
+    property string color: "white"
+
+    Shape {
+        id: shape
+
+        visible: control.value >= 0
+        anchors.fill: parent
+        antialiasing: true
+        layer.smooth: true
+        layer.samples: 2
+
+        ShapePath {
+            startX: marker.x
+            startY: 0
+            strokeColor: root.color
+            strokeWidth: 1
+
+            PathLine {
+                id: marker
+
+                property bool hovered: false
+
+                x: 0
+                y: root.height
+            }
+
+        }
+
+    }
+
+    Mixxx.ControlProxy {
+        id: control
+
+        group: root.group
+        key: root.key
+        onValueChanged: marker.x = parent.width * value
+    }
+
+}

--- a/res/skins/QMLDemo/Mixxx/Controls/qmldir
+++ b/res/skins/QMLDemo/Mixxx/Controls/qmldir
@@ -3,3 +3,4 @@ ToggleButton 0.1 ToggleButton.qml
 Knob 0.1 Knob.qml
 Slider 0.1 Slider.qml
 Spinny 0.1 Spinny.qml
+WaveformOverview 0.1 WaveformOverview.qml

--- a/res/skins/QMLDemo/Mixxx/Controls/qmldir
+++ b/res/skins/QMLDemo/Mixxx/Controls/qmldir
@@ -4,3 +4,5 @@ Knob 0.1 Knob.qml
 Slider 0.1 Slider.qml
 Spinny 0.1 Spinny.qml
 WaveformOverview 0.1 WaveformOverview.qml
+WaveformOverviewMarker 0.1 WaveformOverviewMarker.qml
+WaveformOverviewHotcueMarker 0.1 WaveformOverviewHotcueMarker.qml

--- a/res/skins/QMLDemo/WaveformOverview.qml
+++ b/res/skins/QMLDemo/WaveformOverview.qml
@@ -125,6 +125,7 @@ Item {
 
         MixxxControls.WaveformOverview {
             anchors.fill: parent
+            channels: Mixxx.WaveformOverview.Channels.LeftChannel
             group: root.group
         }
 

--- a/res/skins/QMLDemo/WaveformOverview.qml
+++ b/res/skins/QMLDemo/WaveformOverview.qml
@@ -1,4 +1,5 @@
 import Mixxx 0.1 as Mixxx
+import Mixxx.Controls 0.1 as MixxxControls
 import QtQuick 2.12
 import QtQuick.Shapes 1.12
 import "Theme"
@@ -122,12 +123,9 @@ Item {
         anchors.fill: parent
         color: Theme.deckBackgroundColor
 
-        Text {
-            anchors.centerIn: parent
-            font.family: Theme.fontFamily
-            font.pixelSize: Theme.textFontPixelSize
-            color: Theme.deckTextColor
-            text: "Waveform Placeholder"
+        MixxxControls.WaveformOverview {
+            anchors.fill: parent
+            group: root.group
         }
 
     }

--- a/res/skins/QMLDemo/WaveformOverview.qml
+++ b/res/skins/QMLDemo/WaveformOverview.qml
@@ -126,6 +126,10 @@ Item {
         MixxxControls.WaveformOverview {
             anchors.fill: parent
             channels: Mixxx.WaveformOverview.Channels.LeftChannel
+            renderer: Mixxx.WaveformOverview.Renderer.Filtered
+            colorHigh: Theme.white
+            colorMid: Theme.blue
+            colorLow: Theme.green
             group: root.group
         }
 

--- a/src/skin/qml/qmlplayerproxy.h
+++ b/src/skin/qml/qmlplayerproxy.h
@@ -46,6 +46,11 @@ class QmlPlayerProxy : public QObject {
     QString getKeyText() const;
     QColor getColor() const;
 
+    /// Needed for interacting with the raw track player object.
+    BaseTrackPlayer* internalTrackPlayer() const {
+        return m_pTrackPlayer;
+    }
+
   public slots:
     void slotTrackLoaded(TrackPointer pTrack);
     void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);

--- a/src/skin/qml/qmlskin.cpp
+++ b/src/skin/qml/qmlskin.cpp
@@ -8,6 +8,7 @@
 #include "skin/qml/qmlcontrolproxy.h"
 #include "skin/qml/qmlplayermanagerproxy.h"
 #include "skin/qml/qmlplayerproxy.h"
+#include "skin/qml/qmlwaveformoverview.h"
 #include "util/assert.h"
 
 namespace {
@@ -123,6 +124,7 @@ QWidget* QmlSkin::loadSkin(QWidget* pParent,
     }
 
     qmlRegisterType<QmlControlProxy>("Mixxx", 0, 1, "ControlProxy");
+    qmlRegisterType<QmlWaveformOverview>("Mixxx", 0, 1, "WaveformOverview");
 
     qmlRegisterSingletonType<QmlPlayerManagerProxy>("Mixxx",
             0,

--- a/src/skin/qml/qmlwaveformoverview.cpp
+++ b/src/skin/qml/qmlwaveformoverview.cpp
@@ -1,0 +1,187 @@
+#include "skin/qml/qmlwaveformoverview.h"
+
+#include "mixer/basetrackplayer.h"
+#include "skin/qml/qmlplayerproxy.h"
+
+namespace {
+constexpr double kDesiredHeight = 255 * 2.0;
+
+constexpr qreal lowColorR = 0;
+constexpr qreal lowColorG = 0;
+constexpr qreal lowColorB = 1;
+constexpr qreal midColorR = 0;
+constexpr qreal midColorG = 1;
+constexpr qreal midColorB = 0;
+constexpr qreal highColorR = 1;
+constexpr qreal highColorG = 0;
+constexpr qreal highColorB = 0;
+
+QColor getPenColor(ConstWaveformPointer pWaveform, int completion) {
+    // Retrieve "raw" LMH values from waveform
+    qreal low = static_cast<qreal>(pWaveform->getLow(completion));
+    qreal mid = static_cast<qreal>(pWaveform->getMid(completion));
+    qreal high = static_cast<qreal>(pWaveform->getHigh(completion));
+
+    // Do matrix multiplication
+    qreal red = low * lowColorR + mid * midColorR + high * highColorR;
+    qreal green = low * lowColorG + mid * midColorG + high * highColorG;
+    qreal blue = low * lowColorB + mid * midColorB + high * highColorB;
+
+    // Normalize and draw
+    qreal max = math_max3(red, green, blue);
+    if (max > 0.0) {
+        QColor color;
+        color.setRgbF(red / max, green / max, blue / max);
+        return color;
+    }
+    return QColor();
+}
+} // namespace
+
+namespace mixxx {
+namespace skin {
+namespace qml {
+
+QmlWaveformOverview::QmlWaveformOverview(QQuickItem* parent)
+        : QQuickPaintedItem(parent), m_pPlayer(nullptr) {
+}
+
+QmlPlayerProxy* QmlWaveformOverview::getPlayer() const {
+    return m_pPlayer;
+}
+
+void QmlWaveformOverview::setPlayer(QmlPlayerProxy* pPlayer) {
+    if (m_pPlayer == pPlayer) {
+        return;
+    }
+
+    if (m_pPlayer != nullptr) {
+        disconnect(m_pPlayer->internalTrackPlayer(), nullptr, this, nullptr);
+    }
+
+    m_pPlayer = pPlayer;
+
+    if (pPlayer != nullptr) {
+        connect(m_pPlayer->internalTrackPlayer(),
+                &BaseTrackPlayer::newTrackLoaded,
+                this,
+                &QmlWaveformOverview::slotTrackLoaded);
+        connect(m_pPlayer->internalTrackPlayer(),
+                &BaseTrackPlayer::loadingTrack,
+                this,
+                &QmlWaveformOverview::slotTrackLoading);
+        connect(m_pPlayer->internalTrackPlayer(),
+                &BaseTrackPlayer::playerEmpty,
+                this,
+                &QmlWaveformOverview::slotTrackUnloaded);
+    }
+
+    emit playerChanged();
+    update();
+}
+
+void QmlWaveformOverview::slotTrackLoaded(TrackPointer pTrack) {
+    // TODO: Investigate if it's a bug that this debug assertion fails when
+    // passing tracks on the command line
+    // DEBUG_ASSERT(m_pCurrentTrack == pTrack);
+    setCurrentTrack(pTrack);
+}
+
+void QmlWaveformOverview::slotTrackLoading(TrackPointer pNewTrack, TrackPointer pOldTrack) {
+    Q_UNUSED(pOldTrack); // only used in DEBUG_ASSERT
+    DEBUG_ASSERT(m_pCurrentTrack == pOldTrack);
+    setCurrentTrack(pNewTrack);
+}
+
+void QmlWaveformOverview::slotTrackUnloaded() {
+    setCurrentTrack(nullptr);
+}
+
+void QmlWaveformOverview::setCurrentTrack(TrackPointer pTrack) {
+    // TODO: Check if this is actually possible
+    if (m_pCurrentTrack == pTrack) {
+        return;
+    }
+
+    if (m_pCurrentTrack != nullptr) {
+        disconnect(m_pCurrentTrack.get(), nullptr, this, nullptr);
+    }
+
+    m_pCurrentTrack = pTrack;
+    if (pTrack != nullptr) {
+        connect(pTrack.get(),
+                &Track::waveformSummaryUpdated,
+                this,
+                &QmlWaveformOverview::slotWaveformUpdated);
+    }
+    slotWaveformUpdated();
+}
+
+void QmlWaveformOverview::slotWaveformUpdated() {
+    update();
+}
+
+void QmlWaveformOverview::paint(QPainter* pPainter) {
+    TrackPointer pTrack = m_pCurrentTrack;
+    if (!pTrack) {
+        return;
+    }
+
+    ConstWaveformPointer pWaveform = pTrack->getWaveformSummary();
+    if (!pWaveform) {
+        return;
+    }
+
+    const int dataSize = pWaveform->getDataSize();
+    if (dataSize == 0) {
+        return;
+    }
+
+    const int actualCompletion = 0;
+    // Always multiple of 2
+    const int waveformCompletion = pWaveform->getCompletion();
+    // Test if there is some new to draw (at least of pixel width)
+    const int completionIncrement = waveformCompletion - actualCompletion;
+
+    const qreal desiredWidth = static_cast<qreal>(dataSize) / 2;
+    const double visiblePixelIncrement = completionIncrement * desiredWidth / dataSize;
+    if (waveformCompletion < (dataSize - 2) &&
+            (completionIncrement < 2 || visiblePixelIncrement == 0)) {
+        return;
+    }
+
+    const int nextCompletion = actualCompletion + completionIncrement;
+
+    pPainter->save();
+    // Set the y axis to half the height of the item
+    pPainter->translate(0.0, height() / 2);
+    // Set the x axis to half the height of the item
+    pPainter->scale(width() / desiredWidth, height() / kDesiredHeight);
+
+    for (int currentCompletion = actualCompletion;
+            currentCompletion < nextCompletion;
+            currentCompletion += 2) {
+        const double offsetX = currentCompletion / 2.0;
+
+        // Draw left channel
+        const QColor leftColor = getPenColor(pWaveform, currentCompletion);
+        if (leftColor.isValid()) {
+            const uint8_t leftValue = pWaveform->getAll(currentCompletion);
+            pPainter->setPen(leftColor);
+            pPainter->drawLine(QPointF(offsetX, -leftValue), QPointF(offsetX, 0.0));
+        }
+
+        // Draw right channel
+        QColor rightColor = getPenColor(pWaveform, currentCompletion + 1);
+        if (rightColor.isValid()) {
+            const uint8_t rightValue = pWaveform->getAll(currentCompletion + 1);
+            pPainter->setPen(rightColor);
+            pPainter->drawLine(QPointF(offsetX, 0.0), QPointF(offsetX, rightValue));
+        }
+    }
+    pPainter->restore();
+}
+
+} // namespace qml
+} // namespace skin
+} // namespace mixxx

--- a/src/skin/qml/qmlwaveformoverview.cpp
+++ b/src/skin/qml/qmlwaveformoverview.cpp
@@ -31,7 +31,7 @@ void QmlWaveformOverview::setPlayer(QmlPlayerProxy* pPlayer) {
     }
 
     if (m_pPlayer != nullptr) {
-        disconnect(m_pPlayer->internalTrackPlayer(), nullptr, this, nullptr);
+        m_pPlayer->internalTrackPlayer()->disconnect(this);
     }
 
     m_pPlayer = pPlayer;

--- a/src/skin/qml/qmlwaveformoverview.cpp
+++ b/src/skin/qml/qmlwaveformoverview.cpp
@@ -168,6 +168,9 @@ void QmlWaveformOverview::paint(QPainter* pPainter) {
             currentCompletion < nextCompletion;
             currentCompletion += 2) {
         switch (renderer) {
+        case Renderer::Filtered:
+            drawFiltered(pPainter, channels, pWaveform, currentCompletion);
+            break;
         default:
             drawRgb(pPainter, channels, pWaveform, currentCompletion);
         }
@@ -199,6 +202,41 @@ void QmlWaveformOverview::drawRgb(QPainter* pPainter,
             pPainter->setPen(rightColor);
             pPainter->drawLine(QPointF(offsetX, 0.0), QPointF(offsetX, rightValue));
         }
+    }
+}
+
+void QmlWaveformOverview::drawFiltered(QPainter* pPainter,
+        Channels channels,
+        ConstWaveformPointer pWaveform,
+        int completion) const {
+    const double offsetX = completion / 2.0;
+
+    if (channels.testFlag(ChannelFlag::LeftChannel)) {
+        const uint8_t leftHigh = pWaveform->getHigh(completion);
+        pPainter->setPen(m_colorHigh);
+        pPainter->drawLine(QPointF(offsetX, 2 * -leftHigh), QPointF(offsetX, 0.0));
+
+        const uint8_t leftMid = pWaveform->getMid(completion);
+        pPainter->setPen(m_colorMid);
+        pPainter->drawLine(QPointF(offsetX, 1.5 * -leftMid), QPointF(offsetX, 0.0));
+
+        const uint8_t leftLow = pWaveform->getLow(completion);
+        pPainter->setPen(m_colorLow);
+        pPainter->drawLine(QPointF(offsetX, -leftLow), QPointF(offsetX, 0.0));
+    }
+
+    if (channels.testFlag(ChannelFlag::RightChannel)) {
+        const uint8_t rightHigh = pWaveform->getHigh(completion + 1);
+        pPainter->setPen(m_colorHigh);
+        pPainter->drawLine(QPointF(offsetX, 0), QPointF(offsetX, 2 * rightHigh));
+
+        const uint8_t rightMid = pWaveform->getMid(completion + 1) * 2;
+        pPainter->setPen(m_colorMid);
+        pPainter->drawLine(QPointF(offsetX, 0), QPointF(offsetX, 1.5 * rightMid));
+
+        const uint8_t rightLow = pWaveform->getLow(completion + 1);
+        pPainter->setPen(m_colorLow);
+        pPainter->drawLine(QPointF(offsetX, 0), QPointF(offsetX, rightLow));
     }
 }
 

--- a/src/skin/qml/qmlwaveformoverview.cpp
+++ b/src/skin/qml/qmlwaveformoverview.cpp
@@ -5,37 +5,6 @@
 
 namespace {
 constexpr double kDesiredHeight = 255 * 2.0;
-
-constexpr qreal lowColorR = 0;
-constexpr qreal lowColorG = 0;
-constexpr qreal lowColorB = 1;
-constexpr qreal midColorR = 0;
-constexpr qreal midColorG = 1;
-constexpr qreal midColorB = 0;
-constexpr qreal highColorR = 1;
-constexpr qreal highColorG = 0;
-constexpr qreal highColorB = 0;
-
-QColor getPenColor(ConstWaveformPointer pWaveform, int completion) {
-    // Retrieve "raw" LMH values from waveform
-    qreal low = static_cast<qreal>(pWaveform->getLow(completion));
-    qreal mid = static_cast<qreal>(pWaveform->getMid(completion));
-    qreal high = static_cast<qreal>(pWaveform->getHigh(completion));
-
-    // Do matrix multiplication
-    qreal red = low * lowColorR + mid * midColorR + high * highColorR;
-    qreal green = low * lowColorG + mid * midColorG + high * highColorG;
-    qreal blue = low * lowColorB + mid * midColorB + high * highColorB;
-
-    // Normalize and draw
-    qreal max = math_max3(red, green, blue);
-    if (max > 0.0) {
-        QColor color;
-        color.setRgbF(red / max, green / max, blue / max);
-        return color;
-    }
-    return QColor();
-}
 } // namespace
 
 namespace mixxx {
@@ -43,7 +12,11 @@ namespace skin {
 namespace qml {
 
 QmlWaveformOverview::QmlWaveformOverview(QQuickItem* parent)
-        : QQuickPaintedItem(parent), m_pPlayer(nullptr) {
+        : QQuickPaintedItem(parent),
+          m_pPlayer(nullptr),
+          m_colorHigh(0xFF0000),
+          m_colorMid(0x00FF00),
+          m_colorLow(0x0000FF) {
 }
 
 QmlPlayerProxy* QmlWaveformOverview::getPlayer() const {
@@ -180,6 +153,28 @@ void QmlWaveformOverview::paint(QPainter* pPainter) {
         }
     }
     pPainter->restore();
+}
+
+QColor QmlWaveformOverview::getPenColor(ConstWaveformPointer pWaveform, int completion) const {
+    // Retrieve "raw" LMH values from waveform
+    qreal low = static_cast<qreal>(pWaveform->getLow(completion));
+    qreal mid = static_cast<qreal>(pWaveform->getMid(completion));
+    qreal high = static_cast<qreal>(pWaveform->getHigh(completion));
+
+    // Do matrix multiplication
+    qreal red = low * m_colorLow.redF() + mid * m_colorMid.redF() + high * m_colorHigh.redF();
+    qreal green = low * m_colorLow.greenF() + mid * m_colorMid.greenF() +
+            high * m_colorHigh.greenF();
+    qreal blue = low * m_colorLow.blueF() + mid * m_colorMid.blueF() + high * m_colorHigh.blueF();
+
+    // Normalize and draw
+    qreal max = math_max3(red, green, blue);
+    if (max > 0.0) {
+        QColor color;
+        color.setRgbF(red / max, green / max, blue / max);
+        return color;
+    }
+    return QColor();
 }
 
 } // namespace qml

--- a/src/skin/qml/qmlwaveformoverview.h
+++ b/src/skin/qml/qmlwaveformoverview.h
@@ -17,6 +17,9 @@ class QmlWaveformOverview : public QQuickPaintedItem {
     Q_OBJECT
     Q_PROPERTY(mixxx::skin::qml::QmlPlayerProxy* player READ getPlayer
                     WRITE setPlayer NOTIFY playerChanged)
+    Q_PROPERTY(QColor colorHigh MEMBER m_colorHigh NOTIFY colorHighChanged)
+    Q_PROPERTY(QColor colorMid MEMBER m_colorMid NOTIFY colorMidChanged)
+    Q_PROPERTY(QColor colorLow MEMBER m_colorLow NOTIFY colorLowChanged)
 
   public:
     QmlWaveformOverview(QQuickItem* parent = nullptr);
@@ -24,7 +27,6 @@ class QmlWaveformOverview : public QQuickPaintedItem {
 
     void setPlayer(QmlPlayerProxy* player);
     QmlPlayerProxy* getPlayer() const;
-
   private slots:
     void slotTrackLoaded(TrackPointer pLoadedTrack);
     void slotTrackLoading(TrackPointer pNewTrack, TrackPointer pOldTrack);
@@ -33,12 +35,19 @@ class QmlWaveformOverview : public QQuickPaintedItem {
 
   signals:
     void playerChanged();
+    void colorHighChanged(const QColor& color);
+    void colorMidChanged(const QColor& color);
+    void colorLowChanged(const QColor& color);
 
   private:
     void setCurrentTrack(TrackPointer pTrack);
+    QColor getPenColor(ConstWaveformPointer pWaveform, int completion) const;
 
     QmlPlayerProxy* m_pPlayer;
     TrackPointer m_pCurrentTrack;
+    QColor m_colorHigh;
+    QColor m_colorMid;
+    QColor m_colorLow;
 };
 
 } // namespace qml

--- a/src/skin/qml/qmlwaveformoverview.h
+++ b/src/skin/qml/qmlwaveformoverview.h
@@ -34,6 +34,7 @@ class QmlWaveformOverview : public QQuickPaintedItem {
 
     enum class Renderer {
         RGB = 1,
+        Filtered = 2,
     };
     Q_ENUM(Renderer)
 
@@ -61,6 +62,10 @@ class QmlWaveformOverview : public QQuickPaintedItem {
 
   private:
     void setCurrentTrack(TrackPointer pTrack);
+    void drawFiltered(QPainter* pPainter,
+            Channels channels,
+            ConstWaveformPointer pWaveform,
+            int completion) const;
     void drawRgb(QPainter* pPainter,
             Channels channels,
             ConstWaveformPointer pWaveform,

--- a/src/skin/qml/qmlwaveformoverview.h
+++ b/src/skin/qml/qmlwaveformoverview.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <QPainter>
+#include <QQuickItem>
+#include <QQuickPaintedItem>
+#include <QtQml>
+
+#include "track/track.h"
+
+namespace mixxx {
+namespace skin {
+namespace qml {
+
+class QmlPlayerProxy;
+
+class QmlWaveformOverview : public QQuickPaintedItem {
+    Q_OBJECT
+    Q_PROPERTY(mixxx::skin::qml::QmlPlayerProxy* player READ getPlayer
+                    WRITE setPlayer NOTIFY playerChanged)
+
+  public:
+    QmlWaveformOverview(QQuickItem* parent = nullptr);
+    void paint(QPainter* painter);
+
+    void setPlayer(QmlPlayerProxy* player);
+    QmlPlayerProxy* getPlayer() const;
+
+  private slots:
+    void slotTrackLoaded(TrackPointer pLoadedTrack);
+    void slotTrackLoading(TrackPointer pNewTrack, TrackPointer pOldTrack);
+    void slotTrackUnloaded();
+    void slotWaveformUpdated();
+
+  signals:
+    void playerChanged();
+
+  private:
+    void setCurrentTrack(TrackPointer pTrack);
+
+    QmlPlayerProxy* m_pPlayer;
+    TrackPointer m_pCurrentTrack;
+};
+
+} // namespace qml
+} // namespace skin
+} // namespace mixxx

--- a/src/skin/qml/qmlwaveformoverview.h
+++ b/src/skin/qml/qmlwaveformoverview.h
@@ -15,18 +15,30 @@ class QmlPlayerProxy;
 
 class QmlWaveformOverview : public QQuickPaintedItem {
     Q_OBJECT
+    Q_FLAGS(Channels)
     Q_PROPERTY(mixxx::skin::qml::QmlPlayerProxy* player READ getPlayer
                     WRITE setPlayer NOTIFY playerChanged)
+    Q_PROPERTY(Channels channels READ getChannels WRITE setChannels NOTIFY channelsChanged)
     Q_PROPERTY(QColor colorHigh MEMBER m_colorHigh NOTIFY colorHighChanged)
     Q_PROPERTY(QColor colorMid MEMBER m_colorMid NOTIFY colorMidChanged)
     Q_PROPERTY(QColor colorLow MEMBER m_colorLow NOTIFY colorLowChanged)
 
   public:
+    enum class ChannelFlag : int {
+        LeftChannel = 1,
+        RightChannel = 2,
+        BothChannels = LeftChannel | RightChannel,
+    };
+    Q_DECLARE_FLAGS(Channels, ChannelFlag)
+
     QmlWaveformOverview(QQuickItem* parent = nullptr);
     void paint(QPainter* painter);
 
     void setPlayer(QmlPlayerProxy* player);
     QmlPlayerProxy* getPlayer() const;
+
+    void setChannels(Channels channels);
+    Channels getChannels() const;
   private slots:
     void slotTrackLoaded(TrackPointer pLoadedTrack);
     void slotTrackLoading(TrackPointer pNewTrack, TrackPointer pOldTrack);
@@ -35,6 +47,7 @@ class QmlWaveformOverview : public QQuickPaintedItem {
 
   signals:
     void playerChanged();
+    void channelsChanged(mixxx::skin::qml::QmlWaveformOverview::Channels channels);
     void colorHighChanged(const QColor& color);
     void colorMidChanged(const QColor& color);
     void colorLowChanged(const QColor& color);
@@ -45,6 +58,7 @@ class QmlWaveformOverview : public QQuickPaintedItem {
 
     QmlPlayerProxy* m_pPlayer;
     TrackPointer m_pCurrentTrack;
+    Channels m_channels;
     QColor m_colorHigh;
     QColor m_colorMid;
     QColor m_colorLow;

--- a/src/skin/qml/qmlwaveformoverview.h
+++ b/src/skin/qml/qmlwaveformoverview.h
@@ -19,6 +19,7 @@ class QmlWaveformOverview : public QQuickPaintedItem {
     Q_PROPERTY(mixxx::skin::qml::QmlPlayerProxy* player READ getPlayer
                     WRITE setPlayer NOTIFY playerChanged)
     Q_PROPERTY(Channels channels READ getChannels WRITE setChannels NOTIFY channelsChanged)
+    Q_PROPERTY(Renderer renderer MEMBER m_renderer NOTIFY rendererChanged)
     Q_PROPERTY(QColor colorHigh MEMBER m_colorHigh NOTIFY colorHighChanged)
     Q_PROPERTY(QColor colorMid MEMBER m_colorMid NOTIFY colorMidChanged)
     Q_PROPERTY(QColor colorLow MEMBER m_colorLow NOTIFY colorLowChanged)
@@ -30,6 +31,11 @@ class QmlWaveformOverview : public QQuickPaintedItem {
         BothChannels = LeftChannel | RightChannel,
     };
     Q_DECLARE_FLAGS(Channels, ChannelFlag)
+
+    enum class Renderer {
+        RGB = 1,
+    };
+    Q_ENUM(Renderer)
 
     QmlWaveformOverview(QQuickItem* parent = nullptr);
     void paint(QPainter* painter);
@@ -48,17 +54,23 @@ class QmlWaveformOverview : public QQuickPaintedItem {
   signals:
     void playerChanged();
     void channelsChanged(mixxx::skin::qml::QmlWaveformOverview::Channels channels);
+    void rendererChanged(mixxx::skin::qml::QmlWaveformOverview::Renderer renderer);
     void colorHighChanged(const QColor& color);
     void colorMidChanged(const QColor& color);
     void colorLowChanged(const QColor& color);
 
   private:
     void setCurrentTrack(TrackPointer pTrack);
-    QColor getPenColor(ConstWaveformPointer pWaveform, int completion) const;
+    void drawRgb(QPainter* pPainter,
+            Channels channels,
+            ConstWaveformPointer pWaveform,
+            int completion) const;
+    QColor getRgbPenColor(ConstWaveformPointer pWaveform, int completion) const;
 
     QmlPlayerProxy* m_pPlayer;
     TrackPointer m_pCurrentTrack;
     Channels m_channels;
+    Renderer m_renderer;
     QColor m_colorHigh;
     QColor m_colorMid;
     QColor m_colorLow;

--- a/src/skin/qml/qmlwaveformoverview.h
+++ b/src/skin/qml/qmlwaveformoverview.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QPainter>
+#include <QPointer>
 #include <QQuickItem>
 #include <QQuickPaintedItem>
 #include <QtQml>
@@ -72,7 +73,7 @@ class QmlWaveformOverview : public QQuickPaintedItem {
             int completion) const;
     QColor getRgbPenColor(ConstWaveformPointer pWaveform, int completion) const;
 
-    QmlPlayerProxy* m_pPlayer;
+    QPointer<QmlPlayerProxy> m_pPlayer;
     TrackPointer m_pCurrentTrack;
     Channels m_channels;
     Renderer m_renderer;


### PR DESCRIPTION
Implements a custom QQuickPaintItem that draws the waveform overviews as a QML component.

No support for markers, clicking, etc. has been added. IMHO this should be implemented using COs on the QML level for maximum flexibility.

Depends on #3911. 