### PR TITLE
pre-commit: Use qmlformat by default

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,10 +25,6 @@ jobs:
       # on Pull Requests!).
       env:
         SKIP: end-of-file-fixer,trailing-whitespace,clang-format,eslint,no-commit-to-branch
-      with:
-        # Enable extra hooks that require special system dependencies that we
-        # cannot expect to be installed on all contributor's systems.
-        extra_args: --hook-stage manual --all-files
 
     - name: "Detect code style issues (pull_request)"
       uses: pre-commit/action@v2.0.0
@@ -36,13 +32,9 @@ jobs:
       env:
         SKIP: no-commit-to-branch
       with:
-        # Enable extra hooks that require special system dependencies that are
-        # available in our custom docker container, but cannot be expected to
-        # be installed on all contributor's systems.
-        #
         # HEAD is the not yet integrated PR merge commit +refs/pull/xxxx/merge
         # HEAD^1 is the PR target branch and HEAD^2 is the HEAD of the source branch
-        extra_args: --hook-stage manual --from-ref HEAD^1 --to-ref HEAD
+        extra_args: --from-ref HEAD^1 --to-ref HEAD
 
     - name: "Generate patch file"
       if: failure()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -126,16 +126,11 @@ repos:
     - manual
   - id: qmlformat
     name: qmlformat
-    entry: qmlformat -i
+    entry: tools/qmlformat.py
     pass_filenames: true
-    require_serial: true
     language: system
     types: [text]
     files: ^.*\.qml$
-    # Not enabled in commit stage by default, because qmlformat requires Qt
-    # 5.15 to be installed
-    stages:
-    - manual
   - id: qmllint
     name: qmllint
     entry: qmllint

--- a/tools/qmlformat.py
+++ b/tools/qmlformat.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""
+Small qmlformat wrapper that warns the user if the tool is not installed.
+"""
+import argparse
+import shutil
+import subprocess
+import pathlib
+import sys
+
+QMLFORMAT_MISSING_MESSAGE = """
+qmlformat is not installed. It is included in Qt 5.15 and later. If that Qt
+version is not available on your system, please use the SKIP environment
+variable when committing:
+
+    $ SKIP=qmlformat git commit
+"""
+
+
+def main(argv=None):
+    qmlformat_executable = shutil.which("qmlformat")
+    if not qmlformat_executable:
+        print(QMLFORMAT_MISSING_MESSAGE.strip(), file=sys.stderr)
+        return 1
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("file", nargs="+", type=pathlib.Path)
+    args = parser.parse_args(argv)
+
+    for filename in args.file:
+        subprocess.call((qmlformat_executable, "-i", filename))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
@poelzi  [pointed out](https://github.com/mixxxdj/mixxx/pull/3915#discussion_r639749428) that it's easy to forget to use the manual hook stage to run `qmlformat` manually, and I agree.

The hook will only run if you changed QML files anyway. Therefore, I think we can just enable the hook by default. If `qmlformat` is not installed, the user may skip the hook manually.

For contributors without experience with `pre-commit`, I added a wrapper script that displays an error description and a way to work around it if `qmlformat` is missing:

```
$ git commit
<snip>
qmlformat................................................................Failed
- hook id: qmlformat
- exit code: 1

qmlformat is not installed. It is included in Qt 5.15 and later. If that Qt
version is not available on your system, please use the SKIP environment
variable when committing:

    $ SKIP=qmlformat git commit
```