### PR TITLE
Track: Add missing `NOTIFY` signals for `Q_PROPERTY` declarations

### DIFF
--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -303,6 +303,7 @@ bool Track::replaceRecord(
     if (bpmUpdatedFlag) {
         emit bpmUpdated(newBpm.getValue());
         emit beatsUpdated();
+        emit bpmTextChanged();
     }
     if (oldKey != newKey) {
         emitKeysUpdated(newKey);
@@ -440,6 +441,7 @@ void Track::emitBeatsAndBpmUpdated(
         mixxx::Bpm newBpm) {
     emit bpmUpdated(newBpm.getValue());
     emit beatsUpdated();
+    emit bpmTextChanged();
 }
 
 void Track::setMetadataSynchronized(bool metadataSynchronized) {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -84,9 +84,6 @@ Track::Track(
                 << "->"
                 << numberOfInstancesBefore + 1;
     }
-
-    connect(this, &Track::titleChanged, this, &Track::infoChanged);
-    connect(this, &Track::artistChanged, this, &Track::infoChanged);
 }
 
 Track::~Track() {
@@ -544,6 +541,7 @@ void Track::setTitle(const QString& s) {
     if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrTitle(), value)) {
         markDirtyAndUnlock(&lock);
         emit titleChanged(value);
+        emit infoChanged();
     }
 }
 
@@ -558,6 +556,7 @@ void Track::setArtist(const QString& s) {
     if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrArtist(), value)) {
         markDirtyAndUnlock(&lock);
         emit artistChanged(value);
+        emit infoChanged();
     }
 }
 

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -216,7 +216,7 @@ void Track::replaceMetadataFromSource(
             emit colorUpdated(newColor);
         }
 
-        emitMetadataChanged();
+        emitChangedSignalsForAllMetadata();
     }
 
     // TODO: Import Serato metadata within the locking scope and not
@@ -240,7 +240,7 @@ bool Track::mergeExtraMetadataFromSource(
     }
     markDirtyAndUnlock(&lock);
     // Modified
-    emitMetadataChanged();
+    emitChangedSignalsForAllMetadata();
     return true;
 }
 
@@ -314,7 +314,7 @@ bool Track::replaceRecord(
         emit colorUpdated(newColor);
     }
 
-    emitMetadataChanged();
+    emitChangedSignalsForAllMetadata();
     return true;
 }
 
@@ -442,7 +442,7 @@ void Track::emitBeatsAndBpmUpdated() {
     emit beatsUpdated();
 }
 
-void Track::emitMetadataChanged() {
+void Track::emitChangedSignalsForAllMetadata() {
     emit artistChanged(getArtist());
     emit titleChanged(getTitle());
     emit albumChanged(getAlbum());

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -84,6 +84,9 @@ Track::Track(
                 << "->"
                 << numberOfInstancesBefore + 1;
     }
+
+    connect(this, &Track::titleChanged, this, &Track::infoChanged);
+    connect(this, &Track::artistChanged, this, &Track::infoChanged);
 }
 
 Track::~Track() {
@@ -506,6 +509,7 @@ void Track::setDuration(mixxx::Duration duration) {
                 m_record.refMetadata().refStreamInfo().ptrDuration(),
                 duration)) {
         markDirtyAndUnlock(&lock);
+        emit durationChanged();
     }
 }
 
@@ -536,8 +540,10 @@ QString Track::getTitle() const {
 
 void Track::setTitle(const QString& s) {
     QMutexLocker lock(&m_qMutex);
-    if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrTitle(), s.trimmed())) {
+    const QString value = s.trimmed();
+    if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrTitle(), value)) {
         markDirtyAndUnlock(&lock);
+        emit titleChanged(value);
     }
 }
 
@@ -548,8 +554,10 @@ QString Track::getArtist() const {
 
 void Track::setArtist(const QString& s) {
     QMutexLocker lock(&m_qMutex);
-    if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrArtist(), s.trimmed())) {
+    const QString value = s.trimmed();
+    if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrArtist(), value)) {
         markDirtyAndUnlock(&lock);
+        emit artistChanged(value);
     }
 }
 
@@ -560,8 +568,10 @@ QString Track::getAlbum() const {
 
 void Track::setAlbum(const QString& s) {
     QMutexLocker lock(&m_qMutex);
-    if (compareAndSet(m_record.refMetadata().refAlbumInfo().ptrTitle(), s.trimmed())) {
+    const QString value = s.trimmed();
+    if (compareAndSet(m_record.refMetadata().refAlbumInfo().ptrTitle(), value)) {
         markDirtyAndUnlock(&lock);
+        emit albumChanged(value);
     }
 }
 
@@ -572,8 +582,10 @@ QString Track::getAlbumArtist()  const {
 
 void Track::setAlbumArtist(const QString& s) {
     QMutexLocker lock(&m_qMutex);
-    if (compareAndSet(m_record.refMetadata().refAlbumInfo().ptrArtist(), s.trimmed())) {
+    const QString value = s.trimmed();
+    if (compareAndSet(m_record.refMetadata().refAlbumInfo().ptrArtist(), value)) {
         markDirtyAndUnlock(&lock);
+        emit albumArtistChanged(value);
     }
 }
 
@@ -584,8 +596,10 @@ QString Track::getYear()  const {
 
 void Track::setYear(const QString& s) {
     QMutexLocker lock(&m_qMutex);
-    if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrYear(), s.trimmed())) {
+    const QString value = s.trimmed();
+    if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrYear(), value)) {
         markDirtyAndUnlock(&lock);
+        emit yearChanged(value);
     }
 }
 
@@ -596,8 +610,10 @@ QString Track::getGenre() const {
 
 void Track::setGenre(const QString& s) {
     QMutexLocker lock(&m_qMutex);
-    if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrGenre(), s.trimmed())) {
+    const QString value = s.trimmed();
+    if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrGenre(), value)) {
         markDirtyAndUnlock(&lock);
+        emit genreChanged(value);
     }
 }
 
@@ -608,8 +624,10 @@ QString Track::getComposer() const {
 
 void Track::setComposer(const QString& s) {
     QMutexLocker lock(&m_qMutex);
-    if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrComposer(), s.trimmed())) {
+    const QString value = s.trimmed();
+    if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrComposer(), value)) {
         markDirtyAndUnlock(&lock);
+        emit composerChanged(value);
     }
 }
 
@@ -620,8 +638,10 @@ QString Track::getGrouping()  const {
 
 void Track::setGrouping(const QString& s) {
     QMutexLocker lock(&m_qMutex);
-    if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrGrouping(), s.trimmed())) {
+    const QString value = s.trimmed();
+    if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrGrouping(), value)) {
         markDirtyAndUnlock(&lock);
+        emit groupingChanged(value);
     }
 }
 
@@ -637,15 +657,19 @@ QString Track::getTrackTotal()  const {
 
 void Track::setTrackNumber(const QString& s) {
     QMutexLocker lock(&m_qMutex);
-    if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrTrackNumber(), s.trimmed())) {
+    const QString value = s.trimmed();
+    if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrTrackNumber(), value)) {
         markDirtyAndUnlock(&lock);
+        emit trackNumberChanged(value);
     }
 }
 
 void Track::setTrackTotal(const QString& s) {
     QMutexLocker lock(&m_qMutex);
-    if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrTrackTotal(), s.trimmed())) {
+    const QString value = s.trimmed();
+    if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrTrackTotal(), value)) {
         markDirtyAndUnlock(&lock);
+        emit trackTotalChanged(value);
     }
 }
 
@@ -658,6 +682,7 @@ void Track::setPlayCounter(const PlayCounter& playCounter) {
     QMutexLocker lock(&m_qMutex);
     if (compareAndSet(m_record.ptrPlayCounter(), playCounter)) {
         markDirtyAndUnlock(&lock);
+        emit timesPlayedChanged();
     }
 }
 
@@ -667,6 +692,7 @@ void Track::updatePlayCounter(bool bPlayed) {
     playCounter.updateLastPlayedNowAndTimesPlayed(bPlayed);
     if (compareAndSet(m_record.ptrPlayCounter(), playCounter)) {
         markDirtyAndUnlock(&lock);
+        emit timesPlayedChanged();
     }
 }
 
@@ -692,6 +718,7 @@ void Track::setComment(const QString& s) {
     QMutexLocker lock(&m_qMutex);
     if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrComment(), s)) {
         markDirtyAndUnlock(&lock);
+        emit commentChanged(s);
     }
 }
 

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1616,6 +1616,7 @@ void Track::setAudioProperties(
                 m_record.refMetadata().ptrStreamInfo(),
                 streamInfo)) {
         markDirtyAndUnlock(&lock);
+        emit durationChanged();
     }
 }
 
@@ -1631,6 +1632,7 @@ void Track::updateStreamInfoFromSource(
         // Nothing more to do
         if (updated) {
             markDirtyAndUnlock(&lock);
+            emit durationChanged();
         }
         return;
     }

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1672,6 +1672,7 @@ void Track::updateStreamInfoFromSource(
         afterBeatsAndBpmUpdated(&lock);
     } else {
         markDirtyAndUnlock(&lock);
+        emit durationChanged();
     }
     if (cuesImported) {
         emit cuesUpdated();

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -217,6 +217,8 @@ void Track::replaceMetadataFromSource(
         if (colorModified) {
             emit colorUpdated(newColor);
         }
+
+        emitMetadataChanged();
     }
 
     // TODO: Import Serato metadata within the locking scope and not
@@ -240,6 +242,7 @@ bool Track::mergeExtraMetadataFromSource(
     }
     markDirtyAndUnlock(&lock);
     // Modified
+    emitMetadataChanged();
     return true;
 }
 
@@ -314,6 +317,8 @@ bool Track::replaceRecord(
     if (oldColor != newColor) {
         emit colorUpdated(newColor);
     }
+
+    emitMetadataChanged();
     return true;
 }
 
@@ -442,6 +447,26 @@ void Track::emitBeatsAndBpmUpdated(
     emit bpmUpdated(newBpm.getValue());
     emit beatsUpdated();
     emit bpmTextChanged();
+}
+
+void Track::emitMetadataChanged() {
+    emit artistChanged(getArtist());
+    emit titleChanged(getTitle());
+    emit albumChanged(getAlbum());
+    emit albumArtistChanged(getAlbumArtist());
+    emit genreChanged(getGenre());
+    emit composerChanged(getComposer());
+    emit groupingChanged(getGrouping());
+    emit yearChanged(getYear());
+    emit trackNumberChanged(getTrackNumber());
+    emit trackTotalChanged(getTrackTotal());
+    emit commentChanged(getComment());
+    emit bpmTextChanged();
+    emit timesPlayedChanged();
+    emit durationChanged();
+    emit infoChanged();
+    emit keysUpdated();
+    emit bpmUpdated(getBpm());
 }
 
 void Track::setMetadataSynchronized(bool metadataSynchronized) {

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -61,18 +61,15 @@ class Track : public QObject {
     Q_PROPERTY(QString trackTotal READ getTrackTotal WRITE setTrackTotal NOTIFY trackTotalChanged)
     Q_PROPERTY(int timesPlayed READ getTimesPlayed NOTIFY timesPlayedChanged)
     Q_PROPERTY(QString comment READ getComment WRITE setComment NOTIFY commentChanged)
-    Q_PROPERTY(double bpm READ getBpm NOTIFY bpmUpdated)
-    Q_PROPERTY(QString bpmFormatted READ getBpmText STORED false NOTIFY bpmTextChanged)
-    Q_PROPERTY(QString key READ getKeyText WRITE setKeyText NOTIFY keysUpdated)
+    Q_PROPERTY(double bpm READ getBpm NOTIFY bpmChanged)
+    Q_PROPERTY(QString bpmText READ getBpmText STORED false NOTIFY bpmChanged)
+    Q_PROPERTY(QString keyText READ getKeyText WRITE setKeyText NOTIFY keyChanged)
     Q_PROPERTY(double duration READ getDuration NOTIFY durationChanged)
-    Q_PROPERTY(QString durationFormatted READ getDurationTextSeconds
+    Q_PROPERTY(QString durationText READ getDurationTextSeconds STORED false NOTIFY durationChanged)
+    Q_PROPERTY(QString durationTextCentiseconds READ getDurationTextCentiseconds
                     STORED false NOTIFY durationChanged)
-    Q_PROPERTY(QString durationFormattedCentiseconds READ
-                    getDurationTextCentiseconds
-                            STORED false NOTIFY durationChanged)
-    Q_PROPERTY(QString durationFormattedMilliseconds READ
-                    getDurationTextMilliseconds
-                            STORED false NOTIFY durationChanged)
+    Q_PROPERTY(QString durationTextMilliseconds READ getDurationTextMilliseconds
+                    STORED false NOTIFY durationChanged)
     Q_PROPERTY(QString info READ getInfo STORED false NOTIFY infoChanged)
     Q_PROPERTY(QString titleInfo READ getTitleInfo STORED false NOTIFY infoChanged)
 
@@ -381,7 +378,8 @@ class Track : public QObject {
     void trackNumberChanged(const QString&);
     void trackTotalChanged(const QString&);
     void commentChanged(const QString&);
-    void bpmTextChanged();
+    void bpmChanged();
+    void keyChanged();
     void timesPlayedChanged();
     void durationChanged();
     void infoChanged();
@@ -389,10 +387,7 @@ class Track : public QObject {
     void waveformUpdated();
     void waveformSummaryUpdated();
     void coverArtUpdated();
-    void bpmUpdated(double bpm);
     void beatsUpdated();
-    void keyUpdated(double key);
-    void keysUpdated();
     void replayGainUpdated(mixxx::ReplayGain replayGain);
     void colorUpdated(const mixxx::RgbColor::optional_t& color);
     void cuesUpdated();
@@ -424,10 +419,9 @@ class Track : public QObject {
     void setDirtyAndUnlock(QMutexLocker* pLock, bool bDirty);
 
     void afterKeysUpdated(QMutexLocker* pLock);
-    void emitKeysUpdated(mixxx::track::io::key::ChromaticKey newKey);
 
     void afterBeatsAndBpmUpdated(QMutexLocker* pLock);
-    void emitBeatsAndBpmUpdated(mixxx::Bpm newBpm);
+    void emitBeatsAndBpmUpdated();
 
     /// Emits a changed signal for each Q_PROPERTY
     void emitMetadataChanged();

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -62,7 +62,7 @@ class Track : public QObject {
     Q_PROPERTY(int timesPlayed READ getTimesPlayed NOTIFY timesPlayedChanged)
     Q_PROPERTY(QString comment READ getComment WRITE setComment NOTIFY commentChanged)
     Q_PROPERTY(double bpm READ getBpm NOTIFY bpmUpdated)
-    Q_PROPERTY(QString bpmFormatted READ getBpmText STORED false NOTIFY bpmUpdated)
+    Q_PROPERTY(QString bpmFormatted READ getBpmText STORED false NOTIFY bpmTextChanged)
     Q_PROPERTY(QString key READ getKeyText WRITE setKeyText NOTIFY keysUpdated)
     Q_PROPERTY(double duration READ getDuration NOTIFY durationChanged)
     Q_PROPERTY(QString durationFormatted READ getDurationTextSeconds
@@ -381,6 +381,7 @@ class Track : public QObject {
     void trackNumberChanged(const QString&);
     void trackTotalChanged(const QString&);
     void commentChanged(const QString&);
+    void bpmTextChanged();
     void timesPlayedChanged();
     void durationChanged();
     void infoChanged();

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -429,6 +429,9 @@ class Track : public QObject {
     void afterBeatsAndBpmUpdated(QMutexLocker* pLock);
     void emitBeatsAndBpmUpdated(mixxx::Bpm newBpm);
 
+    /// Emits a changed signal for each Q_PROPERTY
+    void emitMetadataChanged();
+
     /// Sets beats and returns a boolean to indicate if BPM/Beats were updated.
     /// Only supposed to be called while the caller guards this a lock.
     bool setBeatsWhileLocked(mixxx::BeatsPointer pBeats);

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -47,27 +47,34 @@ class Track : public QObject {
             const QString& filePath,
             TrackId trackId);
 
-    Q_PROPERTY(QString artist READ getArtist WRITE setArtist)
-    Q_PROPERTY(QString title READ getTitle WRITE setTitle)
-    Q_PROPERTY(QString album READ getAlbum WRITE setAlbum)
-    Q_PROPERTY(QString albumArtist READ getAlbumArtist WRITE setAlbumArtist)
-    Q_PROPERTY(QString genre READ getGenre WRITE setGenre)
-    Q_PROPERTY(QString composer READ getComposer WRITE setComposer)
-    Q_PROPERTY(QString grouping READ getGrouping WRITE setGrouping)
-    Q_PROPERTY(QString year READ getYear WRITE setYear)
-    Q_PROPERTY(QString track_number READ getTrackNumber WRITE setTrackNumber)
-    Q_PROPERTY(QString track_total READ getTrackTotal WRITE setTrackTotal)
-    Q_PROPERTY(int times_played READ getTimesPlayed)
-    Q_PROPERTY(QString comment READ getComment WRITE setComment)
-    Q_PROPERTY(double bpm READ getBpm)
-    Q_PROPERTY(QString bpmFormatted READ getBpmText STORED false)
-    Q_PROPERTY(QString key READ getKeyText WRITE setKeyText)
-    Q_PROPERTY(double duration READ getDuration)
-    Q_PROPERTY(QString durationFormatted READ getDurationTextSeconds STORED false)
-    Q_PROPERTY(QString durationFormattedCentiseconds READ getDurationTextCentiseconds STORED false)
-    Q_PROPERTY(QString durationFormattedMilliseconds READ getDurationTextMilliseconds STORED false)
-    Q_PROPERTY(QString info READ getInfo STORED false)
-    Q_PROPERTY(QString titleInfo READ getTitleInfo STORED false)
+    Q_PROPERTY(QString artist READ getArtist WRITE setArtist NOTIFY artistChanged)
+    Q_PROPERTY(QString title READ getTitle WRITE setTitle NOTIFY titleChanged)
+    Q_PROPERTY(QString album READ getAlbum WRITE setAlbum NOTIFY albumChanged)
+    Q_PROPERTY(QString albumArtist READ getAlbumArtist WRITE setAlbumArtist
+                    NOTIFY albumArtistChanged)
+    Q_PROPERTY(QString genre READ getGenre WRITE setGenre NOTIFY genreChanged)
+    Q_PROPERTY(QString composer READ getComposer WRITE setComposer NOTIFY composerChanged)
+    Q_PROPERTY(QString grouping READ getGrouping WRITE setGrouping NOTIFY groupingChanged)
+    Q_PROPERTY(QString year READ getYear WRITE setYear NOTIFY yearChanged)
+    Q_PROPERTY(QString trackNumber READ getTrackNumber WRITE setTrackNumber
+                    NOTIFY trackNumberChanged)
+    Q_PROPERTY(QString trackTotal READ getTrackTotal WRITE setTrackTotal NOTIFY trackTotalChanged)
+    Q_PROPERTY(int timesPlayed READ getTimesPlayed NOTIFY timesPlayedChanged)
+    Q_PROPERTY(QString comment READ getComment WRITE setComment NOTIFY commentChanged)
+    Q_PROPERTY(double bpm READ getBpm NOTIFY bpmUpdated)
+    Q_PROPERTY(QString bpmFormatted READ getBpmText STORED false NOTIFY bpmUpdated)
+    Q_PROPERTY(QString key READ getKeyText WRITE setKeyText NOTIFY keysUpdated)
+    Q_PROPERTY(double duration READ getDuration NOTIFY durationChanged)
+    Q_PROPERTY(QString durationFormatted READ getDurationTextSeconds
+                    STORED false NOTIFY durationChanged)
+    Q_PROPERTY(QString durationFormattedCentiseconds READ
+                    getDurationTextCentiseconds
+                            STORED false NOTIFY durationChanged)
+    Q_PROPERTY(QString durationFormattedMilliseconds READ
+                    getDurationTextMilliseconds
+                            STORED false NOTIFY durationChanged)
+    Q_PROPERTY(QString info READ getInfo STORED false NOTIFY infoChanged)
+    Q_PROPERTY(QString titleInfo READ getTitleInfo STORED false NOTIFY infoChanged)
 
     mixxx::FileAccess getFileAccess() const {
         // Copying QFileInfo is thread-safe due to implicit sharing,
@@ -363,6 +370,21 @@ class Track : public QObject {
             const mixxx::audio::StreamInfo& streamInfo);
 
   signals:
+    void artistChanged(const QString&);
+    void titleChanged(const QString&);
+    void albumChanged(const QString&);
+    void albumArtistChanged(const QString&);
+    void genreChanged(const QString&);
+    void composerChanged(const QString&);
+    void groupingChanged(const QString&);
+    void yearChanged(const QString&);
+    void trackNumberChanged(const QString&);
+    void trackTotalChanged(const QString&);
+    void commentChanged(const QString&);
+    void timesPlayedChanged();
+    void durationChanged();
+    void infoChanged();
+
     void waveformUpdated();
     void waveformSummaryUpdated();
     void coverArtUpdated();

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -424,7 +424,7 @@ class Track : public QObject {
     void emitBeatsAndBpmUpdated();
 
     /// Emits a changed signal for each Q_PROPERTY
-    void emitMetadataChanged();
+    void emitChangedSignalsForAllMetadata();
 
     /// Sets beats and returns a boolean to indicate if BPM/Beats were updated.
     /// Only supposed to be called while the caller guards this a lock.


### PR DESCRIPTION
This fixes some clazy-qproperty-without-notify warnings. Every
`Q_PROPERTY` should either have a `NOTIFY` signal or be declared as
`CONSTANT`.

See this for details:
- https://github.com/KDE/clazy/blob/master/docs/checks/README-qproperty-without-notify.md
- https://doc.qt.io/qt-5.12/properties.html