### PR TITLE
partially revert #3902 Skins: fix qss icons with kIconThemes 5.80

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -307,16 +307,15 @@ WLibrary QLineEdit,
 
 /* button in library "Preview" column */
 QPushButton#LibraryPreviewButton {
-  background: transparent;
+  background-color: transparent;
   margin: 0px;
-  padding: 3px;
+  padding: 0px;
   border: 1px solid transparent;
   border-radius: 2px;
 }
 
 QPushButton#LibraryPreviewButton:!checked {
-  /* TODO ronso0 Restore once fixed lib linKIconThemes (vers. <..80) is in *ubuntu main repos */
-  /*image: url(skin:/../Deere/icon/ic_library_preview_play.svg);*/
+  image: url(skin:/../Deere/icon/ic_library_preview_play.svg);
 }
 
 QPushButton#LibraryPreviewButton:!checked:hover {
@@ -325,7 +324,7 @@ QPushButton#LibraryPreviewButton:!checked:hover {
 }
 
 QPushButton#LibraryPreviewButton:checked {
-  /*image: url(skin:/../Deere/icon/ic_library_preview_pause.svg);*/
+  image: url(skin:/../Deere/icon/ic_library_preview_pause.svg);
   background-color: #0f0f0f;
   border: 1px solid #006596;
 }
@@ -338,7 +337,7 @@ QPushButton#LibraryPreviewButton:checked:hover {
 #LibraryContainer QHeaderView {
   /* Don't set a font size to pick up the system font size. */
   color: #d2d2d2;
-  background: #1A1A1A;
+  background-color: #1A1A1A;
   border-bottom: 1px solid #141414;
 }
 
@@ -346,7 +345,7 @@ QPushButton#LibraryPreviewButton:checked:hover {
   height: 1.1em;
   font-weight: bold;
   padding: 2px;
-  background: #1A1A1A;
+  background-color: #1A1A1A;
   border-top: none;
   border-left: none;
   border-bottom: 1px solid #141414;
@@ -468,14 +467,14 @@ WSearchLineEdit {
 #LibraryVerticalSplitter::handle,
 #WaveformSplitter::handle {
   image: url(skin:/../Deere/image/style_handle_vertical_unchecked.svg);
-  background: #222;
+  background-color: #222;
 }
 
 #LibraryCoverArtSplitter::handle:pressed,
 #LibraryVerticalSplitter::handle:pressed,
 #WaveformSplitter::handle:pressed {
   image: url(skin:/../Deere/image/style_handle_vertical_checked.svg);
-  background: #222;
+  background-color: #222;
 }
 
 #LibraryCoverArtSplitter::handle:horizontal,
@@ -650,7 +649,7 @@ WEffectSelector QAbstractScrollArea QScrollBar:horizontal,
   border-top: 1px solid #141414;
   min-width: 12px;
   height: 15px;
-  background: #222222;
+  background-color: #222222;
   padding: 3px;
 }
 #LibraryContainer QScrollBar:vertical,
@@ -659,7 +658,7 @@ WEffectSelector QAbstractScrollArea QScrollBar:vertical,
   border-left: 1px solid #141414;
   min-height: 12px;
   width: 15px;
-  background: #222222;
+  background-color: #222222;
   padding: 3px;
 }
 /* "add-page" and "sub-page" are the gutter of the scrollbar */
@@ -675,7 +674,7 @@ WEffectSelector QAbstractScrollArea QScrollBar::sub-page,
 WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::handle:horizontal {
   min-width: 25px;
-  background: #5F5F5F;
+  background-color: #5F5F5F;
   border-radius: 3px;
   border: none;
 }
@@ -683,7 +682,7 @@ WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal,
 WEffectSelector QAbstractScrollArea QScrollBar::handle:vertical,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::handle:vertical {
   min-height: 25px;
-  background: #5F5F5F;
+  background-color: #5F5F5F;
   border-radius: 3px;
   border: none;
 }
@@ -693,7 +692,7 @@ WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal:hover,
 WEffectSelector QAbstractScrollArea QScrollBar::handle:vertical:hover,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::handle:horizontal:hover,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::handle:vertical:hover {
-  background: #B3B3B3;
+  background-color: #B3B3B3;
 }
 
 /* Turn off buttons */
@@ -777,7 +776,7 @@ WEffectSelector QAbstractScrollArea::corner,
 #SkinSettings > #h3 WPushButton:hover,
 #SkinSettingsButton:hover,
 #SkinSettingsCategoryButton:hover {
-  background: #222222;
+  background-color: #222222;
 }
 
 /*******************************************************************************
@@ -1064,7 +1063,7 @@ WBeatSpinBox,
 #BpmKeyEditRowExpanded {
   /* emphasize active widget */
   border: 1px solid #FF6600;
-  background: rgba(255, 102, 0, 64);
+  background-color: rgba(255, 102, 0, 64);
   color: #D6D6D6;
 }
 

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -298,7 +298,7 @@
       <!-- ToDo ronso0 :: Unfortunately, variables are not considered here, yet ;)
           because the launch screen appears while the skin is parsed.
       image: url(skin:/style_<Variable name="scheme"/>/mixxx_logo.svg); -->
-      background: transparent url(skin:/palemoon/style/mixxx_logo.svg) no-repeat center center;
+      image: url(skin:/palemoon/style/mixxx_logo.svg);
       padding: 0;
       margin: 0px 2px 0px 2px;
       border: none;

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -635,11 +635,11 @@ WLibrary {
     #spinBoxTransition::up-button {
       height: 11px;
       subcontrol-position: top right;
-      background-image: url(skin:/classic/buttons/spinbox_up.svg);
+      image: url(skin:/classic/buttons/spinbox_up.svg) no-repeat;
       }
       WBeatSpinBox::up-button:pressed,
       #spinBoxTransition::up-button:pressed {
-        background-image: url(skin:/classic/buttons/spinbox_up_pressed.svg);
+        image: url(skin:/classic/buttons/spinbox_up_pressed.svg) no-repeat;
       }
       WBeatSpinBox::up-button {
         margin: -1px 0px 0px 0px;
@@ -651,11 +651,11 @@ WLibrary {
     #spinBoxTransition::down-button {
       height: 11px;
       subcontrol-position: bottom right;
-      background-image: url(skin:/classic/buttons/spinbox_down.svg);
+      image: url(skin:/classic/buttons/spinbox_down.svg) no-repeat;
       }
       WBeatSpinBox::down-button:pressed,
       #spinBoxTransition::down-button:pressed {
-        background-image: url(skin:/classic/buttons/spinbox_down_pressed.svg);
+        image: url(skin:/classic/buttons/spinbox_down_pressed.svg) no-repeat;
       }
       WBeatSpinBox::down-button {
         margin: 0px 0px -2px 0px;
@@ -860,11 +860,11 @@ WEffectSelector,
   }
   WEffectSelector::down-arrow,
   #fadeModeCombobox::down-arrow {
-    background: url(skin:/classic/buttons/btn__fx_selector_down.svg) no-repeat center center;
+    image: url(skin:/classic/buttons/btn__fx_selector_down.svg);
     }
     WEffectSelector::down-arrow:hover,
     #fadeModeCombobox::down-arrow:hover {
-      background: url(skin:/classic/buttons/btn__fx_selector_down_pressed.svg) no-repeat center center;
+      image: url(skin:/classic/buttons/btn__fx_selector_down_pressed.svg);
     }
 
 
@@ -1346,417 +1346,6 @@ WPushButton#LibExpand,
 
 
 
-
-/************** Button icons **************************************************/
-
-#PlayDeck {
-  background: url(skin:/classic/buttons/btn__play_deck.svg) no-repeat center center;
-}
-
-#PlayDeckMini[value="0"] {
-  background: url(skin:/classic/buttons/btn__play_deck_mini.svg) no-repeat center center;
-  }
-  #PlayDeckMini[value="1"] {
-    background: url(skin:/classic/buttons/btn__pause_deck_mini.svg) no-repeat center center;
-  }
-#PlaySampler[value="0"],
-#PlayPreview[displayValue="0"] {
-  background: url(skin:/classic/buttons/btn__play_sampler.svg) no-repeat center center;
-  }
-  #PlaySampler[value="1"],
-  #PlayPreview[displayValue="1"] {
-    background: url(skin:/classic/buttons/btn__pause_sampler.svg) no-repeat center center;
-  }
-
-#CueDeck {
-  background: url(skin:/classic/buttons/btn__cue_deck.svg) no-repeat center center;
-}
-
-#Reverse {
-  background: url(skin:/classic/buttons/btn__reverse.svg) no-repeat center center;
-}
-
-#Hotcue1 WPushButton {
-  background: url(skin:/classic/buttons/btn__1.svg) no-repeat center center;
-  }
-  #Hotcue2 WPushButton {
-    background: url(skin:/classic/buttons/btn__2.svg) no-repeat center center;
-  }
-  #Hotcue3 WPushButton {
-    background: url(skin:/classic/buttons/btn__3.svg) no-repeat center center;
-  }
-  #Hotcue4 WPushButton {
-    background: url(skin:/classic/buttons/btn__4.svg) no-repeat center center;
-  }
-  #Hotcue5 WPushButton {
-    background: url(skin:/classic/buttons/btn__5.svg) no-repeat center center;
-  }
-  #Hotcue6 WPushButton {
-    background: url(skin:/classic/buttons/btn__6.svg) no-repeat center center;
-  }
-  #Hotcue7 WPushButton {
-    background: url(skin:/classic/buttons/btn__7.svg) no-repeat center center;
-  }
-  #Hotcue8 WPushButton {
-    background: url(skin:/classic/buttons/btn__8.svg) no-repeat center center;
-  }
-
-#SpecialCueButton_intro_start WPushButton {
-  background: url(skin:/classic/buttons/btn__intro_start.svg) no-repeat center center;
-  }
-  #SpecialCueButton_intro_end WPushButton {
-    background: url(skin:/classic/buttons/btn__intro_end.svg) no-repeat center center;
-  }
-  #SpecialCueButton_outro_start WPushButton {
-    background: url(skin:/classic/buttons/btn__outro_start.svg) no-repeat center center;
-  }
-  #SpecialCueButton_outro_end WPushButton {
-    background: url(skin:/classic/buttons/btn__outro_end.svg) no-repeat center center;
-  }
-
-#LoopActivate {
-  background: url(skin:/classic/buttons/btn__loop.svg) no-repeat center center;
-}
-#Reloop {
-  background: url(skin:/classic/buttons/btn__reloop.svg) no-repeat center center;
-}
-
-#LoopIn {
-  background: url(skin:/classic/buttons/btn__loop_in.svg) no-repeat center center;
-}
-#LoopOut {
-  background: url(skin:/classic/buttons/btn__loop_out.svg) no-repeat center center;
-}
-
-#JumpForward {
-  background: url(skin:/classic/buttons/btn__beatjump_right.svg) no-repeat center center;
-}
-#JumpBack {
-  background: url(skin:/classic/buttons/btn__beatjump_left.svg) no-repeat center center;
-}
-
-/* Key buttons */
-#KeyMatchReset {
-  background: url(skin:/classic/buttons/btn__key_match.svg) no-repeat center center;
-}
-
-#KeyUp {
-  background: url(skin:/classic/buttons/btn__key_up.svg) no-repeat center center;
-}
-
-#KeyDown {
-  background: url(skin:/classic/buttons/btn__key_down.svg) no-repeat center center;
-}
-
-/* Rate buttons */
-#SyncDeck {
-  background: url(skin:/classic/buttons/btn__sync_deck.svg) no-repeat center center;
-  }
-
-  #SyncSampler {
-    background: url(skin:/classic/buttons/btn__sync_sampler.svg) no-repeat center center;
-    }
-
-  #RatePermUp {
-    background: url(skin:/classic/buttons/btn__plus.svg) no-repeat center center;
-  }
-
-  #RatePermDown {
-    background: url(skin:/classic/buttons/btn__minus.svg) no-repeat center center;
-  }
-
-  #RateTempUp {
-    background: url(skin:/classic/buttons/btn__arrow_right_up.svg) no-repeat center center;
-  }
-  #RateTempDown {
-    background: url(skin:/classic/buttons/btn__arrow_left_down.svg) no-repeat center center;
-  }
-
-  #RateTempUpRev {
-    background: url(skin:/classic/buttons/btn__arrow_right_down.svg) no-repeat center center;
-  }
-
-  #RateTempDownRev {
-    background: url(skin:/classic/buttons/btn__arrow_left_up.svg) no-repeat center center;
-  }
-
-/* Mixer buttons */
-#PflButton {
-  background: url(skin:/classic/buttons/btn__pfl.svg) no-repeat center center;
-}
-
-#QuickEffectButton[displayValue="0"] {
-  background: url(skin:/classic/buttons/btn__star.svg) no-repeat center center;
-}
-
-/* EQ Kill button icons H / M / L */
-#EQKillButton_High[displayValue="0"] {
-  background: url(skin:/classic/buttons/btn__eq_kill_high.svg) no-repeat center center;
-}
-#EQKillButton_Mid[displayValue="0"] {
-  background: url(skin:/classic/buttons/btn__eq_kill_mid.svg) no-repeat center center;
-}
-#EQKillButton_Low[displayValue="0"] {
-  background: url(skin:/classic/buttons/btn__eq_kill_low.svg) no-repeat center center;
-}
-
-#SplitCue[displayValue="0"] {
-  background: url(skin:/classic/buttons/btn__split.svg) no-repeat center center;
-  }
-  #SplitCue[displayValue="1"] {
-    background: url(skin:/classic/buttons/btn__split_active.svg) no-repeat center center;
-  }
-
-#FxExpand[value="0"],
-#LibExpand[value="0"] {
-  background: url(skin:/classic/buttons/btn__expand.svg) no-repeat left center;
-  }
-  #FxExpand[value="1"],
-  #LibExpand[value="1"] {
-    background: url(skin:/classic/buttons/btn__collapse.svg) no-repeat left center;
-  }
-#SamplerExpand[value="0"] {
-  background: url(skin:/classic/buttons/btn__expand_dim.svg) no-repeat left center;
-  }
-  #SamplerExpand[value="1"] {
-    background: url(skin:/classic/buttons/btn__collapse_dim.svg) no-repeat left center;
-  }
-
-#MixModeButton[value="0"] {
-  background: url(skin:/classic/buttons/btn__fx_mixmode_d-w.svg) no-repeat center center;
-  }
-  #MixModeButton[value="1"] {
-    background: url(skin:/classic/buttons/btn__fx_mixmode_d+w.svg) no-repeat center center;
-  }
-
-#FxToggleButton[value="0"] {
-  background: url(skin:/classic/buttons/btn__fx_toggle.svg) no-repeat center center;
-  }
-  #FxToggleButton[value="1"] {
-    background: url(skin:/classic/buttons/btn__fx_toggle_active.svg) no-repeat center center;
-  }
-
-#FxFocusButton[value="0"] {
-  background: url(skin:/classic/buttons/btn__fx_focus.svg) no-repeat center center;
-  }
-  #FxFocusButton[value="1"] {
-    background: url(skin:/classic/buttons/btn__fx_focus_active.svg) no-repeat center center;
-  }
-
-/* deck controls for decks 1-4 and samplers */
-#CurposButton12[displayValue="0"], #CurposButton34[displayValue="0"] {
-  background: url(skin:/classic/buttons/btn__beat_curpos.svg) no-repeat center center;
-  }
-  #CurposButton12[value="1"] {
-    background: url(skin:/classic/buttons/btn__beat_curpos_active_12.svg) no-repeat center center;
-  }
-  #CurposButton34[value="1"] {
-    background: url(skin:/classic/buttons/btn__beat_curpos_active_34.svg) no-repeat center center;
-  }
-
-  #EjectButton12[displayValue="0"], #EjectButton34[displayValue="0"] {
-    background: url(skin:/classic/buttons/btn__eject.svg) no-repeat center center;
-    }
-    #EjectButton12[value="1"] {
-      background: url(skin:/classic/buttons/btn__eject_active_12.svg) no-repeat center center;
-    }
-    #EjectButton34[value="1"] {
-      background: url(skin:/classic/buttons/btn__eject_active_34.svg) no-repeat center center;
-    }
-
-  #RepeatButton12[displayValue="0"], #RepeatButton34[displayValue="0"] {
-    background: url(skin:/classic/buttons/btn__repeat.svg) no-repeat center center;
-    }
-    #RepeatButton12[displayValue="1"] {
-      background: url(skin:/classic/buttons/btn__repeat_active_12.svg) no-repeat center center;
-    }
-    #RepeatButton34[displayValue="1"] {
-      background: url(skin:/classic/buttons/btn__repeat_active_34.svg) no-repeat center center;
-    }
-
-  #QuantizeButton12[displayValue="0"], #QuantizeButton34[displayValue="0"] {
-    background: url(skin:/classic/buttons/btn__quantize.svg) no-repeat center center;
-    }
-    #QuantizeButton12[displayValue="1"] {
-      background: url(skin:/classic/buttons/btn__quantize_active_12.svg) no-repeat center center;
-    }
-    #QuantizeButton34[displayValue="1"] {
-      background: url(skin:/classic/buttons/btn__quantize_active_34.svg) no-repeat center center;
-    }
-
-  #SlipmodeButton12[displayValue="0"], #SlipmodeButton34[displayValue="0"] {
-    background: url(skin:/classic/buttons/btn__slip.svg) no-repeat center center;
-    }
-    #SlipmodeButton12[displayValue="1"] {
-      background: url(skin:/classic/buttons/btn__slip_active_12.svg) no-repeat center center;
-    }
-    #SlipmodeButton34[displayValue="1"] {
-      background: url(skin:/classic/buttons/btn__slip_active_34.svg) no-repeat center center;
-    }
-
-  #KeylockButton12[displayValue="0"], #KeylockButton34[displayValue="0"] {
-    background: url(skin:/classic/buttons/btn__keylock.svg) no-repeat center center;
-    }
-    #KeylockButton12[displayValue="1"] {
-      background: url(skin:/classic/buttons/btn__keylock_active_12.svg) no-repeat center center;
-    }
-    #KeylockButton34[displayValue="1"] {
-      background: url(skin:/classic/buttons/btn__keylock_active_34.svg) no-repeat center center;
-    }
-
-#BeatgridControlsToggle[displayValue="0"] {
-  background: url(skin:/classic/buttons/btn__beatgrid_controls_expand.svg) no-repeat center center;
-  }
-  #BeatgridControlsToggle[displayValue="1"] {
-    background: url(skin:/classic/buttons/btn__beatgrid_controls_collapse.svg) no-repeat center center;
-  }
-  #BeatCurposLarge {
-    background: url(skin:/classic/buttons/btn__beat_curpos_large.svg) no-repeat center center;
-    }
-    #BeatsEarlier {
-      background: url(skin:/classic/buttons/btn__beats_earlier.svg) no-repeat center center;
-    }
-    #BeatsLater {
-      background: url(skin:/classic/buttons/btn__beats_later.svg) no-repeat center center;
-    }
-    #BeatsSlower {
-      background: url(skin:/classic/buttons/btn__beats_slower.svg) no-repeat center center;
-    }
-    #BeatsFaster {
-      background: url(skin:/classic/buttons/btn__beats_faster.svg) no-repeat center center;
-    }
-    #HotcuesEarlier {
-      background: url(skin:/classic/buttons/btn__beats_hotcues_earlier.svg) no-repeat center center;
-    }
-    #HotcuesLater {
-      background: url(skin:/classic/buttons/btn__beats_hotcues_later.svg) no-repeat center center;
-    }
-
-#MicTalk {
-  background: url(skin:/classic/buttons/btn__mic_talk.svg) no-repeat center center;
-}
-
-#AuxPlay {
-  background: url(skin:/classic/buttons/btn__aux_play.svg) no-repeat center center;
-}
-
-#MicAuxAdd {
-  background: url(skin:/classic/buttons/btn__plus_flat.svg) no-repeat center center;
-}
-
-#MicDucking[value="0"] {
-  background: url(skin:/classic/buttons/btn__mic_duck_off.svg) no-repeat center center;
-  }
-  #MicDucking[value="1"] {
-    background: url(skin:/classic/buttons/btn__mic_duck_auto.svg) no-repeat center center;
-  }
-  #MicDucking[value="2"] {
-    background: url(skin:/classic/buttons/btn__mic_duck_manual.svg) no-repeat center center;
-  }
-
-#RecDot[highlight="0"] {
-  background: url(skin:/classic/buttons/btn__rec_dot.svg) no-repeat center center;
-  }
-  #RecDot[highlight="1"],
-  #RecDot[highlight="2"] {
-    background: url(skin:/classic/buttons/btn__rec_dot_active.svg) no-repeat center center;
-  }
-
-#BroadcastButton[displayValue="0"] {
-  /* for some reason the alignment isn't rescpected, so the icons
-    have to be sized like available area (button size - margin) */
-  background: url(skin:/classic/buttons/btn__broadcast_off.svg) no-repeat left top;
-  }
-  #BroadcastButton[displayValue="1"],
-  #BroadcastButton[displayValue="2"],
-  #BroadcastButton[displayValue="3"] {
-    background: url(skin:/classic/buttons/btn__broadcast_on.svg) no-repeat left top;
-  }
-
-#SkinSettingsToggle[displayValue="0"] {
-  background: url(skin:/classic/buttons/btn__settings_off.svg) no-repeat left top;
-  }
-  #SkinSettingsToggle[displayValue="1"] {
-    background: url(skin:/classic/buttons/btn__settings_on.svg) no-repeat left top;
-  }
-
-#ToolbarLogo {
-  background: url(skin:/classic/style/mixxx_logo_small.svg) no-repeat center center;
-}
-#ToolbarSeparator {
-  background: url(skin:/classic/style/toolbar_separator.svg) no-repeat center center;
-  margin: 0px 3px;
-}
-
-WSearchLineEdit QToolButton:!focus {
-  background: url(skin:/classic/buttons/btn__lib_clear_search.svg);
-  }
-  WSearchLineEdit QToolButton:focus {
-    background: url(skin:/classic/buttons/btn__lib_clear_search_focus.svg);
-  }
-
-/* AutoDJ button icons */
-QPushButton#pushButtonAutoDJ:!checked {
-  background: url(skin:/classic/buttons/btn__autodj_enable_off.svg) no-repeat center center;
-  }
-  QPushButton#pushButtonAutoDJ:checked {
-    background: url(skin:/classic/buttons/btn__autodj_enable_on.svg) no-repeat center center;
-  }
-
-QPushButton#pushButtonFadeNow:!enabled {
-  background: url(skin:/classic/buttons/btn__autodj_fade_disabled.svg) no-repeat center center;
-  }
-  QPushButton#pushButtonFadeNow:enabled {
-    background: url(skin:/classic/buttons/btn__autodj_fade.svg) no-repeat center center;
-  }
-
-QPushButton#pushButtonSkipNext:!enabled {
-  background: url(skin:/classic/buttons/btn__autodj_skip_disabled.svg) no-repeat center center;
-  }
-  QPushButton#pushButtonSkipNext:enabled {
-    background: url(skin:/classic/buttons/btn__autodj_skip.svg) no-repeat center center;
-  }
-
-QPushButton#pushButtonShuffle:enabled {
-  background: url(skin:/classic/buttons/btn__autodj_shuffle.svg) no-repeat center center;
-  }
-
-QPushButton#pushButtonAddRandom:enabled {
-  background: url(skin:/classic/buttons/btn__autodj_addrandom.svg) no-repeat center center;
-  }
-
-QPushButton#pushButtonRepeatPlaylist:!checked {
-  background: url(skin:/classic/buttons/btn__autodj_repeat_playlist_off.svg) no-repeat center center;
-  }
-  QPushButton#pushButtonRepeatPlaylist:checked {
-    background: url(skin:/classic/buttons/btn__autodj_repeat_playlist_on.svg) no-repeat center center;
-  }
-
-/* widgets in cue popup menu */
-#CueDeleteButton {  /*
-  padding: 3px 6px; */
-  qproperty-icon: url(skin:/classic/buttons/btn__delete.svg);
-  /* color buttons are 42x24 px.
-  To get the final size for the Delete button consider border width.
-  It's a tall button, about the same height as cue number + label edit box */
-  width: 24px;
-  height: 42px;
-  border-width: 2px;
-  border-image: url(skin:/classic/buttons/btn_embedded_library.svg) 2 2 2 2;
-  /* make the icon slightly larger than default 16px */
-  qproperty-iconSize: 20px;
-  /* has no effect
-  padding: 0px; */
-}
-
-#CueLabelEdit {
-  border: 1px solid #f0bb2b;
-  border-radius: 0px;
-  background-color: #000;
-  selection-color: #000;
-  selection-background-color: #ccc;
-  padding: 2px;
-}
 /************** button background colors **************************************/
 
 /* top-level buttons in transport, fx, micaux and others */
@@ -1797,8 +1386,7 @@ WPushButton#PlayDeckMini[displayValue="1"],
 WPushButton#PlaySampler[displayValue="1"],
 WPushButton#PlayPreview[displayValue="1"],
 WPushButton#PlayIndicator[displayValue="1"],
-/* TODO ronso0 Restore once fixed lib linKIconThemes (vers. <..80) is in *ubuntu main repos */
-/*#LibraryPreviewButton:checked,*/
+#LibraryPreviewButton:checked,
 #CueDeck[displayValue="1"],
 WPushButton#Reverse[pressed="true"],
 #KeyControls WPushButton[pressed="true"],
@@ -1965,6 +1553,417 @@ WPushButton#SamplerExpand[displayValue="0"],
 #RecDot {
   background-color: transparent;
 }
+
+/************** Button icons **************************************************/
+
+#PlayDeck {
+  image: url(skin:/classic/buttons/btn__play_deck.svg) no-repeat center center;
+}
+
+#PlayDeckMini[value="0"] {
+  image: url(skin:/classic/buttons/btn__play_deck_mini.svg) no-repeat center center;
+  }
+  #PlayDeckMini[value="1"] {
+    image: url(skin:/classic/buttons/btn__pause_deck_mini.svg) no-repeat center center;
+  }
+#PlaySampler[value="0"],
+#PlayPreview[displayValue="0"] {
+  image: url(skin:/classic/buttons/btn__play_sampler.svg) no-repeat center center;
+  }
+  #PlaySampler[value="1"],
+  #PlayPreview[displayValue="1"] {
+    image: url(skin:/classic/buttons/btn__pause_sampler.svg) no-repeat center center;
+  }
+
+#CueDeck {
+  image: url(skin:/classic/buttons/btn__cue_deck.svg) no-repeat center center;
+}
+
+#Reverse {
+  image: url(skin:/classic/buttons/btn__reverse.svg) no-repeat center center;
+}
+
+#Hotcue1 WPushButton {
+  image: url(skin:/classic/buttons/btn__1.svg) no-repeat center center;
+  }
+  #Hotcue2 WPushButton {
+    image: url(skin:/classic/buttons/btn__2.svg) no-repeat center center;
+  }
+  #Hotcue3 WPushButton {
+    image: url(skin:/classic/buttons/btn__3.svg) no-repeat center center;
+  }
+  #Hotcue4 WPushButton {
+    image: url(skin:/classic/buttons/btn__4.svg) no-repeat center center;
+  }
+  #Hotcue5 WPushButton {
+    image: url(skin:/classic/buttons/btn__5.svg) no-repeat center center;
+  }
+  #Hotcue6 WPushButton {
+    image: url(skin:/classic/buttons/btn__6.svg) no-repeat center center;
+  }
+  #Hotcue7 WPushButton {
+    image: url(skin:/classic/buttons/btn__7.svg) no-repeat center center;
+  }
+  #Hotcue8 WPushButton {
+    image: url(skin:/classic/buttons/btn__8.svg) no-repeat center center;
+  }
+
+#SpecialCueButton_intro_start WPushButton {
+  image: url(skin:/classic/buttons/btn__intro_start.svg) no-repeat center center;
+  }
+  #SpecialCueButton_intro_end WPushButton {
+    image: url(skin:/classic/buttons/btn__intro_end.svg) no-repeat center center;
+  }
+  #SpecialCueButton_outro_start WPushButton {
+    image: url(skin:/classic/buttons/btn__outro_start.svg) no-repeat center center;
+  }
+  #SpecialCueButton_outro_end WPushButton {
+    image: url(skin:/classic/buttons/btn__outro_end.svg) no-repeat center center;
+  }
+
+#LoopActivate {
+  image: url(skin:/classic/buttons/btn__loop.svg) no-repeat center center;
+}
+#Reloop {
+  image: url(skin:/classic/buttons/btn__reloop.svg) no-repeat center center;
+}
+
+#LoopIn {
+  image: url(skin:/classic/buttons/btn__loop_in.svg) no-repeat center center;
+}
+#LoopOut {
+  image: url(skin:/classic/buttons/btn__loop_out.svg) no-repeat center center;
+}
+
+#JumpForward {
+  image: url(skin:/classic/buttons/btn__beatjump_right.svg) no-repeat center center;
+}
+#JumpBack {
+  image: url(skin:/classic/buttons/btn__beatjump_left.svg) no-repeat center center;
+}
+
+/* Key buttons */
+#KeyMatchReset {
+  image: url(skin:/classic/buttons/btn__key_match.svg) no-repeat center center;
+}
+
+#KeyUp {
+  image: url(skin:/classic/buttons/btn__key_up.svg) no-repeat center center;
+}
+
+#KeyDown {
+  image: url(skin:/classic/buttons/btn__key_down.svg) no-repeat center center;
+}
+
+/* Rate buttons */
+#SyncDeck {
+  image: url(skin:/classic/buttons/btn__sync_deck.svg) no-repeat center center;
+  }
+
+  #SyncSampler {
+    image: url(skin:/classic/buttons/btn__sync_sampler.svg) no-repeat center center;
+    }
+
+  #RatePermUp {
+    image: url(skin:/classic/buttons/btn__plus.svg) no-repeat center center;
+  }
+
+  #RatePermDown {
+    image: url(skin:/classic/buttons/btn__minus.svg) no-repeat center center;
+  }
+
+  #RateTempUp {
+    image: url(skin:/classic/buttons/btn__arrow_right_up.svg) no-repeat center center;
+  }
+  #RateTempDown {
+    image: url(skin:/classic/buttons/btn__arrow_left_down.svg) no-repeat center center;
+  }
+
+  #RateTempUpRev {
+    image: url(skin:/classic/buttons/btn__arrow_right_down.svg) no-repeat center center;
+  }
+
+  #RateTempDownRev {
+    image: url(skin:/classic/buttons/btn__arrow_left_up.svg) no-repeat center center;
+  }
+
+/* Mixer buttons */
+#PflButton {
+  image: url(skin:/classic/buttons/btn__pfl.svg) no-repeat center center;
+}
+
+#QuickEffectButton[displayValue="0"] {
+  image: url(skin:/classic/buttons/btn__star.svg) no-repeat center center;
+}
+
+/* EQ Kill button icons H / M / L */
+#EQKillButton_High[displayValue="0"] {
+  image: url(skin:/classic/buttons/btn__eq_kill_high.svg) no-repeat center center;
+}
+#EQKillButton_Mid[displayValue="0"] {
+  image: url(skin:/classic/buttons/btn__eq_kill_mid.svg) no-repeat center center;
+}
+#EQKillButton_Low[displayValue="0"] {
+  image: url(skin:/classic/buttons/btn__eq_kill_low.svg) no-repeat center center;
+}
+
+#SplitCue[displayValue="0"] {
+  image: url(skin:/classic/buttons/btn__split.svg) no-repeat center center;
+  }
+  #SplitCue[displayValue="1"] {
+    image: url(skin:/classic/buttons/btn__split_active.svg) no-repeat center center;
+  }
+
+#FxExpand[value="0"],
+#LibExpand[value="0"] {
+  image: url(skin:/classic/buttons/btn__expand.svg) no-repeat left center;
+  }
+  #FxExpand[value="1"],
+  #LibExpand[value="1"] {
+    image: url(skin:/classic/buttons/btn__collapse.svg) no-repeat left center;
+  }
+#SamplerExpand[value="0"] {
+  image: url(skin:/classic/buttons/btn__expand_dim.svg) no-repeat left center;
+  }
+  #SamplerExpand[value="1"] {
+    image: url(skin:/classic/buttons/btn__collapse_dim.svg) no-repeat left center;
+  }
+
+#MixModeButton[value="0"] {
+  image: url(skin:/classic/buttons/btn__fx_mixmode_d-w.svg) no-repeat center center;
+  }
+  #MixModeButton[value="1"] {
+    image: url(skin:/classic/buttons/btn__fx_mixmode_d+w.svg) no-repeat center center;
+  }
+
+#FxToggleButton[value="0"] {
+  image: url(skin:/classic/buttons/btn__fx_toggle.svg) no-repeat center center;
+  }
+  #FxToggleButton[value="1"] {
+    image: url(skin:/classic/buttons/btn__fx_toggle_active.svg) no-repeat center center;
+  }
+
+#FxFocusButton[value="0"] {
+  image: url(skin:/classic/buttons/btn__fx_focus.svg) no-repeat center center;
+  }
+  #FxFocusButton[value="1"] {
+    image: url(skin:/classic/buttons/btn__fx_focus_active.svg) no-repeat center center;
+  }
+
+/* deck controls for decks 1-4 and samplers */
+#CurposButton12[displayValue="0"], #CurposButton34[displayValue="0"] {
+  image: url(skin:/classic/buttons/btn__beat_curpos.svg) no-repeat center center;
+  }
+  #CurposButton12[value="1"] {
+    image: url(skin:/classic/buttons/btn__beat_curpos_active_12.svg) no-repeat center center;
+  }
+  #CurposButton34[value="1"] {
+    image: url(skin:/classic/buttons/btn__beat_curpos_active_34.svg) no-repeat center center;
+  }
+
+  #EjectButton12[displayValue="0"], #EjectButton34[displayValue="0"] {
+    image: url(skin:/classic/buttons/btn__eject.svg) no-repeat center center;
+    }
+    #EjectButton12[value="1"] {
+      image: url(skin:/classic/buttons/btn__eject_active_12.svg) no-repeat center center;
+    }
+    #EjectButton34[value="1"] {
+      image: url(skin:/classic/buttons/btn__eject_active_34.svg) no-repeat center center;
+    }
+
+  #RepeatButton12[displayValue="0"], #RepeatButton34[displayValue="0"] {
+    image: url(skin:/classic/buttons/btn__repeat.svg) no-repeat center center;
+    }
+    #RepeatButton12[displayValue="1"] {
+      image: url(skin:/classic/buttons/btn__repeat_active_12.svg) no-repeat center center;
+    }
+    #RepeatButton34[displayValue="1"] {
+      image: url(skin:/classic/buttons/btn__repeat_active_34.svg) no-repeat center center;
+    }
+
+  #QuantizeButton12[displayValue="0"], #QuantizeButton34[displayValue="0"] {
+    image: url(skin:/classic/buttons/btn__quantize.svg) no-repeat center center;
+    }
+    #QuantizeButton12[displayValue="1"] {
+      image: url(skin:/classic/buttons/btn__quantize_active_12.svg) no-repeat center center;
+    }
+    #QuantizeButton34[displayValue="1"] {
+      image: url(skin:/classic/buttons/btn__quantize_active_34.svg) no-repeat center center;
+    }
+
+  #SlipmodeButton12[displayValue="0"], #SlipmodeButton34[displayValue="0"] {
+    image: url(skin:/classic/buttons/btn__slip.svg) no-repeat center center;
+    }
+    #SlipmodeButton12[displayValue="1"] {
+      image: url(skin:/classic/buttons/btn__slip_active_12.svg) no-repeat center center;
+    }
+    #SlipmodeButton34[displayValue="1"] {
+      image: url(skin:/classic/buttons/btn__slip_active_34.svg) no-repeat center center;
+    }
+
+  #KeylockButton12[displayValue="0"], #KeylockButton34[displayValue="0"] {
+    image: url(skin:/classic/buttons/btn__keylock.svg) no-repeat center center;
+    }
+    #KeylockButton12[displayValue="1"] {
+      image: url(skin:/classic/buttons/btn__keylock_active_12.svg) no-repeat center center;
+    }
+    #KeylockButton34[displayValue="1"] {
+      image: url(skin:/classic/buttons/btn__keylock_active_34.svg) no-repeat center center;
+    }
+
+#BeatgridControlsToggle[displayValue="0"] {
+  image: url(skin:/classic/buttons/btn__beatgrid_controls_expand.svg) no-repeat center center;
+  }
+  #BeatgridControlsToggle[displayValue="1"] {
+    image: url(skin:/classic/buttons/btn__beatgrid_controls_collapse.svg) no-repeat center center;
+  }
+  #BeatCurposLarge {
+    image: url(skin:/classic/buttons/btn__beat_curpos_large.svg) no-repeat center center;
+    }
+    #BeatsEarlier {
+      image: url(skin:/classic/buttons/btn__beats_earlier.svg) no-repeat center center;
+    }
+    #BeatsLater {
+      image: url(skin:/classic/buttons/btn__beats_later.svg) no-repeat center center;
+    }
+    #BeatsSlower {
+      image: url(skin:/classic/buttons/btn__beats_slower.svg) no-repeat center center;
+    }
+    #BeatsFaster {
+      image: url(skin:/classic/buttons/btn__beats_faster.svg) no-repeat center center;
+    }
+    #HotcuesEarlier {
+      image: url(skin:/classic/buttons/btn__beats_hotcues_earlier.svg) no-repeat center center;
+    }
+    #HotcuesLater {
+      image: url(skin:/classic/buttons/btn__beats_hotcues_later.svg) no-repeat center center;
+    }
+
+#MicTalk {
+  image: url(skin:/classic/buttons/btn__mic_talk.svg) no-repeat center center;
+}
+
+#AuxPlay {
+  image: url(skin:/classic/buttons/btn__aux_play.svg) no-repeat center center;
+}
+
+#MicAuxAdd {
+  image: url(skin:/classic/buttons/btn__plus_flat.svg) no-repeat center center;
+}
+
+#MicDucking[value="0"] {
+  image: url(skin:/classic/buttons/btn__mic_duck_off.svg) no-repeat center center;
+  }
+  #MicDucking[value="1"] {
+    image: url(skin:/classic/buttons/btn__mic_duck_auto.svg) no-repeat center center;
+  }
+  #MicDucking[value="2"] {
+    image: url(skin:/classic/buttons/btn__mic_duck_manual.svg) no-repeat center center;
+  }
+
+#RecDot[highlight="0"] {
+  image: url(skin:/classic/buttons/btn__rec_dot.svg) no-repeat center center;
+  }
+  #RecDot[highlight="1"],
+  #RecDot[highlight="2"] {
+    image: url(skin:/classic/buttons/btn__rec_dot_active.svg) no-repeat center center;
+  }
+
+#BroadcastButton[displayValue="0"] {
+  /* for some reason the alignment isn't rescpected, so the icons
+    have to be sized like available area (button size - margin) */
+  image: url(skin:/classic/buttons/btn__broadcast_off.svg) no-repeat left top;
+  }
+  #BroadcastButton[displayValue="1"],
+  #BroadcastButton[displayValue="2"],
+  #BroadcastButton[displayValue="3"] {
+    image: url(skin:/classic/buttons/btn__broadcast_on.svg) no-repeat left top;
+  }
+
+#SkinSettingsToggle[displayValue="0"] {
+  image: url(skin:/classic/buttons/btn__settings_off.svg) no-repeat left top;
+  }
+  #SkinSettingsToggle[displayValue="1"] {
+    image: url(skin:/classic/buttons/btn__settings_on.svg) no-repeat left top;
+  }
+
+#ToolbarLogo {
+  image: url(skin:/classic/style/mixxx_logo_small.svg) no-repeat center center;
+}
+#ToolbarSeparator {
+  image: url(skin:/classic/style/toolbar_separator.svg) no-repeat center center;
+  margin: 0px 3px;
+}
+
+WSearchLineEdit QToolButton:!focus {
+  image: url(skin:/classic/buttons/btn__lib_clear_search.svg);
+  }
+  WSearchLineEdit QToolButton:focus {
+    image: url(skin:/classic/buttons/btn__lib_clear_search_focus.svg);
+  }
+
+/* AutoDJ button icons */
+QPushButton#pushButtonAutoDJ:!checked {
+  image: url(skin:/classic/buttons/btn__autodj_enable_off.svg) no-repeat center center;
+  }
+  QPushButton#pushButtonAutoDJ:checked {
+    image: url(skin:/classic/buttons/btn__autodj_enable_on.svg) no-repeat center center;
+  }
+
+QPushButton#pushButtonFadeNow:!enabled {
+  image: url(skin:/classic/buttons/btn__autodj_fade_disabled.svg) no-repeat center center;
+  }
+  QPushButton#pushButtonFadeNow:enabled {
+    image: url(skin:/classic/buttons/btn__autodj_fade.svg) no-repeat center center;
+  }
+
+QPushButton#pushButtonSkipNext:!enabled {
+  image: url(skin:/classic/buttons/btn__autodj_skip_disabled.svg) no-repeat center center;
+  }
+  QPushButton#pushButtonSkipNext:enabled {
+    image: url(skin:/classic/buttons/btn__autodj_skip.svg) no-repeat center center;
+  }
+
+QPushButton#pushButtonShuffle:enabled {
+  image: url(skin:/classic/buttons/btn__autodj_shuffle.svg) no-repeat center center;
+  }
+
+QPushButton#pushButtonAddRandom:enabled {
+  image: url(skin:/classic/buttons/btn__autodj_addrandom.svg) no-repeat center center;
+  }
+
+QPushButton#pushButtonRepeatPlaylist:!checked {
+  image: url(skin:/classic/buttons/btn__autodj_repeat_playlist_off.svg) no-repeat center center;
+  }
+  QPushButton#pushButtonRepeatPlaylist:checked {
+    image: url(skin:/classic/buttons/btn__autodj_repeat_playlist_on.svg) no-repeat center center;
+  }
+
+/* widgets in cue popup menu */
+#CueDeleteButton {  /*
+  padding: 3px 6px; */
+  qproperty-icon: url(skin:/classic/buttons/btn__delete.svg);
+  /* color buttons are 42x24 px.
+  To get the final size for the Delete button consider border width.
+  It's a tall button, about the same height as cue number + label edit box */
+  width: 24px;
+  height: 42px;
+  border-width: 2px;
+  border-image: url(skin:/classic/buttons/btn_embedded_library.svg) 2 2 2 2;
+  /* make the icon slightly larger than default 16px */
+  qproperty-iconSize: 20px;
+  /* has no effect
+  padding: 0px; */
+}
+
+#CueLabelEdit {
+  border: 1px solid #f0bb2b;
+  border-radius: 0px;
+  background-color: #000;
+  selection-color: #000;
+  selection-background-color: #ccc;
+  padding: 2px;
+}
 /************** Button icons **************************************************/
 /************** Button styles *************************************************/
 
@@ -2090,17 +2089,15 @@ WCueMenuPopup QPushButton:focus {
 /* Button in library "Preview" column */
 #LibraryPreviewButton {
   margin: 0px;
-  padding: 3px;
+  padding: 0px;
   border-radius: 2px;
   border: 1px solid transparent;
   }
   #LibraryPreviewButton:!checked {
-    /* TODO ronso0 Restore once fixed lib linKIconThemes (vers. <..80) is in *ubuntu main repos */
-    /* image: url(skin:/classic/buttons/btn__lib_preview_play.svg); */
+    image: url(skin:/classic/buttons/btn__lib_preview_play.svg);
     }
   #LibraryPreviewButton:checked {
-    /* image: url(skin:/classic/buttons/btn__lib_preview_pause.svg); */
-    border: 1px solid red;
+    image: url(skin:/classic/buttons/btn__lib_preview_pause.svg);
     }
 
 
@@ -2122,12 +2119,6 @@ WCueMenuPopup QPushButton:focus {
     border-right: 1px solid #000;
     border-bottom: 1px solid #000;
   }
-    #LibraryContainer QHeaderView::up-arrow {
-      background: url(skin:/classic/buttons/btn__lib_sort_up.svg)  no-repeat center center;
-      }
-    #LibraryContainer QHeaderView::down-arrow {
-      background: url(skin:/classic/buttons/btn__lib_sort_down.svg) no-repeat center center;
-    }
   #LibraryContainer QHeaderView::up-arrow,
   #LibraryContainer QHeaderView::down-arrow {
     border-right: 1px solid #000;
@@ -2136,6 +2127,12 @@ WCueMenuPopup QPushButton:focus {
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
       stop:0 rgba(34,34,34,190),
       stop:1 rgba(17,17,17,190));
+    }
+    #LibraryContainer QHeaderView::up-arrow {
+      image: url(skin:/classic/buttons/btn__lib_sort_up.svg);
+      }
+    #LibraryContainer QHeaderView::down-arrow {
+      image: url(skin:/classic/buttons/btn__lib_sort_down.svg);
     }
 
 
@@ -2249,14 +2246,14 @@ WSearchLineEdit {
 
 #WaveformSplitter::handle,
 #SidebarCoverSplitter::handle {
-    background: url(skin:/classic/style/splitter_handle_horizontal.png) no-repeat center center; /*
+    image: url(skin:/classic/style/splitter_handle_horizontal.png); /*
     border-top: 1px solid #000; */
   }
   #WaveformSplitter::handle:pressed,
   #WaveformSplitter::handle:hover,
   #SidebarCoverSplitter::handle:pressed,
   #SidebarCoverSplitter::handle:hover {
-    background: url(skin:/classic/style/splitter_handle_horizontal_pressed.png) no-repeat center center;
+    image: url(skin:/classic/style/splitter_handle_horizontal_pressed.png);
   }
   #WaveformSplitter::handle:vertical,
   #SidebarCoverSplitter::handle:vertical {
@@ -2267,12 +2264,12 @@ WSearchLineEdit {
   (the splitter itself is vertical)
   Used to split Library sidebar & Tracks table */
 #LibrarySplitter::handle {
-  background: url(skin:/classic/style/splitter_handle_vertical.png) no-repeat center center;
+  image: url(skin:/classic/style/splitter_handle_vertical.png);
   background-color: #1e1e1e;
 }
 #LibrarySplitter::handle:pressed,
 #LibrarySplitter::handle:hover {
-  background: url(skin:/classic/style/splitter_handle_vertical_pressed.png) no-repeat center center;
+  image: url(skin:/classic/style/splitter_handle_vertical_pressed.png);
 }
 #LibrarySplitter::handle:vertical {
   /* 'height' works although it's actually the width of the handle */
@@ -2451,6 +2448,11 @@ QLineEdit QMenu::item:disabled {
     image: url(skin:/classic/buttons/btn__lib_checkmark_orange.svg);
     }
   /* disabled menu item and checkbox */
+  WTrackMenu QMenu QCheckBox::indicator:disabled:unchecked,
+  WTrackMenu QMenu QCheckBox::indicator:disabled:checked,
+  WTrackMenu QMenu QCheckBox::indicator:indeterminate {
+    background-color: #222;
+  }
   WTrackMenu QMenu QCheckBox::indicator:disabled:checked {
     image: url(skin:/classic/buttons/btn__lib_checkmark_grey.svg);
   }

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -322,7 +322,7 @@ WSearchLineEdit {
 
   #FxFlowIndicatorCollapsed {
     margin: 0px 0px 0px 0px;
-    background: url(skin:/palemoon/style/fx_flow_horizontal.svg) no-repeat center center;
+    background-image: url(skin:/palemoon/style/fx_flow_horizontal.svg) no-repeat center center;
   }
   #ToolbarSeparator {
     margin: 0px 5px;
@@ -695,7 +695,7 @@ WBeatSpinBox::down-button,
   #spinBoxTransition::up-button {
     height: 11px;
     subcontrol-position: top right;
-    background-image: url(skin:/palemoon/buttons/btn__spinbox_up.svg);
+    image: url(skin:/palemoon/buttons/btn__spinbox_up.svg) no-repeat;
     }
     WBeatSpinBox::up-button {
       margin: -2px -1px 0px 0px;
@@ -707,7 +707,7 @@ WBeatSpinBox::down-button,
   #spinBoxTransition::down-button {
     height: 11px;
     subcontrol-position: bottom right;
-    background-image: url(skin:/palemoon/buttons/btn__spinbox_down.svg);
+    image: url(skin:/palemoon/buttons/btn__spinbox_down.svg) no-repeat;
     }
     WBeatSpinBox::down-button {
       margin: 0px -1px -3px 0px;
@@ -924,7 +924,7 @@ WEffectSelector:!editable:on {
   }
   WEffectSelector::down-arrow,
   #fadeModeCombobox::down-arrow {
-    background: url(skin:/palemoon/buttons/btn__fx_selector_down.svg) no-repeat center center;
+    image: url(skin:/palemoon/buttons/btn__fx_selector_down.svg);
   }
 
 
@@ -1460,7 +1460,7 @@ WEffectSelector:!editable,
   #BroadcastButton[displayValue="2"],
   #BroadcastButton[displayValue="3"],
   #SkinSettingsToggle[displayValue="1"],
-  #LibraryFeatureControls QPushButton:pressed,
+  #LibraryFeatureControls QPushButton:pressed
   QPushButton#pushButtonAutoDJ:checked,
   QPushButton#pushButtonRepeatPlaylist:checked,
   QPushButton#pushButtonAnalyze:checked,
@@ -1484,9 +1484,9 @@ WEffectSelector:!editable,
   #LibraryContainer QHeaderView::up-arrow,
   #LibraryContainer QHeaderView::down-arrow {
     outline: none;
-    /* ToDo: restore image */
-    /* border-width: 1px 2px 1px 0px;
-    border-image: url(skin:/palemoon/buttons/btn_embedded_library_header.svg) 1 2 1 3; */
+    /* ToDo: restore image
+    border-width: 1px 2px 1px 0px;
+    border-image: url(skin:/palemoon/buttons/btn_embedded_library_header_sort.svg) 1 2 1 1; */
   }
 
   #LibraryFeatureControls QPushButton:!enabled {
@@ -1550,612 +1550,6 @@ WPushButton#CrossfaderButton,
 }
 
 
-
-/************** Button icons **************************************************/
-WPushButton#PlayDeck[value="0"] {
-  background: url(skin:/palemoon/buttons/btn__play_deck.svg) no-repeat center center;
-  }
-  WPushButton#PlayDeck[value="1"] {
-    background: url(skin:/palemoon/buttons/btn__play_deck_active.svg) no-repeat center center;
-  }
-
-#PlayDeckMini[value="0"] {
-  background: url(skin:/palemoon/buttons/btn__play_deck_mini.svg) no-repeat center center;
-  }
-  #PlayDeckMini[value="1"] {
-    background: url(skin:/palemoon/buttons/btn__pause_deck_mini.svg) no-repeat center center;
-  }
-#PlaySampler[value="0"],
-#PlayPreview[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__play_sampler.svg) no-repeat center center;
-  }
-  #PlaySampler[value="1"],
-  #PlayPreview[displayValue="1"] {
-    background: url(skin:/palemoon/buttons/btn__pause_sampler.svg) no-repeat center center;
-  }
-
-#CueDeck[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__cue_deck.svg) no-repeat center center;
-  }
-  #CueDeck[displayValue="1"] {
-    background: url(skin:/palemoon/buttons/btn__cue_deck_active.svg) no-repeat center center;
-  }
-
-#Reverse {
-  background: url(skin:/palemoon/buttons/btn__reverse.svg) no-repeat center center;
-  }
-  #Reverse[pressed="true"] {
-    background: url(skin:/palemoon/buttons/btn__reverse_active.svg) no-repeat center center;
-  }
-
-#Hotcue1 WPushButton[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__1.svg) no-repeat center center;
-  }
-  #Hotcue1 WPushButton[displayValue="1"][dark="false"] {
-    background: url(skin:/palemoon/buttons/btn__1_active.svg) no-repeat center center;
-  }
-  #Hotcue1 WPushButton[displayValue="1"][dark="true"] {
-    background: url(skin:/palemoon/buttons/btn__1_active_dark.svg) no-repeat center center;
-  }
-
-#Hotcue2 WPushButton[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__2.svg) no-repeat center center;
-  }
-  #Hotcue2 WPushButton[displayValue="1"] {
-    background: url(skin:/palemoon/buttons/btn__2_active.svg) no-repeat center center;
-  }
-  #Hotcue2 WPushButton[displayValue="1"][dark="true"] {
-    background: url(skin:/palemoon/buttons/btn__2_active_dark.svg) no-repeat center center;
-  }
-
-#Hotcue3 WPushButton[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__3.svg) no-repeat center center;
-  }
-  #Hotcue3 WPushButton[displayValue="1"] {
-    background: url(skin:/palemoon/buttons/btn__3_active.svg) no-repeat center center;
-  }
-  #Hotcue3 WPushButton[displayValue="1"][dark="true"] {
-    background: url(skin:/palemoon/buttons/btn__3_active_dark.svg) no-repeat center center;
-  }
-
-#Hotcue4 WPushButton[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__4.svg) no-repeat center center;
-  }
-  #Hotcue4 WPushButton[displayValue="1"] {
-    background: url(skin:/palemoon/buttons/btn__4_active.svg) no-repeat center center;
-  }
-  #Hotcue4 WPushButton[displayValue="1"][dark="true"] {
-    background: url(skin:/palemoon/buttons/btn__4_active_dark.svg) no-repeat center center;
-  }
-
-#Hotcue5 WPushButton[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__5.svg) no-repeat center center;
-  }
-  #Hotcue5 WPushButton[displayValue="1"] {
-    background: url(skin:/palemoon/buttons/btn__5_active.svg) no-repeat center center;
-  }
-  #Hotcue5 WPushButton[displayValue="1"][dark="true"] {
-    background: url(skin:/palemoon/buttons/btn__5_active_dark.svg) no-repeat center center;
-  }
-
-#Hotcue6 WPushButton[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__6.svg) no-repeat center center;
-  }
-  #Hotcue6 WPushButton[displayValue="1"] {
-    background: url(skin:/palemoon/buttons/btn__6_active.svg) no-repeat center center;
-  }
-  #Hotcue6 WPushButton[displayValue="1"][dark="true"] {
-    background: url(skin:/palemoon/buttons/btn__6_active_dark.svg) no-repeat center center;
-  }
-
-#Hotcue7 WPushButton[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__7.svg) no-repeat center center;
-  }
-  #Hotcue7 WPushButton[displayValue="1"] {
-    background: url(skin:/palemoon/buttons/btn__7_active.svg) no-repeat center center;
-  }
-  #Hotcue7 WPushButton[displayValue="1"][dark="true"] {
-    background: url(skin:/palemoon/buttons/btn__7_active_dark.svg) no-repeat center center;
-  }
-
-#Hotcue8 WPushButton[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__8.svg) no-repeat center center;
-  }
-  #Hotcue8 WPushButton[displayValue="1"] {
-    background: url(skin:/palemoon/buttons/btn__8_active.svg) no-repeat center center;
-  }
-  #Hotcue8 WPushButton[displayValue="1"][dark="true"] {
-    background: url(skin:/palemoon/buttons/btn__8_active_dark.svg) no-repeat center center;
-  }
-
-#SpecialCueButton_intro_start WPushButton[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__intro_start.svg) no-repeat center center;
-  }
-  #SpecialCueButton_intro_start WPushButton[displayValue="1"] {
-    background: url(skin:/palemoon/buttons/btn__intro_start_active.svg) no-repeat center center;
-  }
-#SpecialCueButton_intro_end WPushButton[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__intro_end.svg) no-repeat center center;
-  }
-  #SpecialCueButton_intro_end WPushButton[displayValue="1"] {
-    background: url(skin:/palemoon/buttons/btn__intro_end_active.svg) no-repeat center center;
-  }
-#SpecialCueButton_outro_start WPushButton[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__outro_start.svg) no-repeat center center;
-  }
-  #SpecialCueButton_outro_start WPushButton[displayValue="1"] {
-    background: url(skin:/palemoon/buttons/btn__outro_start_active.svg) no-repeat center center;
-  }
-#SpecialCueButton_outro_end WPushButton[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__outro_end.svg) no-repeat center center;
-  }
-  #SpecialCueButton_outro_end WPushButton[displayValue="1"] {
-    background: url(skin:/palemoon/buttons/btn__outro_end_active.svg) no-repeat center center;
-  }
-
-#LoopActivate[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__loop.svg) no-repeat center center;
-  }
-  #LoopActivate[displayValue="1"], #LoopActivate[pressed="true"] {
-    background: url(skin:/palemoon/buttons/btn__loop_active.svg) no-repeat center center;
-  }
-#Reloop[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__reloop.svg) no-repeat center center;
-  }
-  #Reloop[displayValue="1"] {
-    background: url(skin:/palemoon/buttons/btn__reloop_active.svg) no-repeat center center;
-  }
-
-#LoopIn {
-  background: url(skin:/palemoon/buttons/btn__loop_in.svg) no-repeat center center;
-  }
-  #LoopIn[pressed="true"] {
-    background: url(skin:/palemoon/buttons/btn__loop_in_active.svg) no-repeat center center;
-  }
-#LoopOut {
-  background: url(skin:/palemoon/buttons/btn__loop_out.svg) no-repeat center center;
-  }
-  #LoopOut[pressed="true"] {
-    background: url(skin:/palemoon/buttons/btn__loop_out_active.svg) no-repeat center center;
-  }
-
-#JumpForward {
-  background: url(skin:/palemoon/buttons/btn__beatjump_right.svg) no-repeat center center;
-  }
-  #JumpForward[pressed="true"] {
-    background: url(skin:/palemoon/buttons/btn__beatjump_right_active.svg) no-repeat center center;
-  }
-#JumpBack {
-  background: url(skin:/palemoon/buttons/btn__beatjump_left.svg) no-repeat center center;
-  }
-  #JumpBack[pressed="true"] {
-    background: url(skin:/palemoon/buttons/btn__beatjump_left_active.svg) no-repeat center center;
-  }
-
-/* Key buttons */
-#KeyMatchReset {
-  background: url(skin:/palemoon/buttons/btn__key_match.svg) no-repeat center center;
-  }
-  #KeyMatchReset[pressed="true"] {
-    background: url(skin:/palemoon/buttons/btn__key_match_active.svg) no-repeat center center;
-  }
-
-#KeyUp {
-  background: url(skin:/palemoon/buttons/btn__key_up.svg) no-repeat center center;
-  }
-  #KeyUp[pressed="true"] {
-    background: url(skin:/palemoon/buttons/btn__key_up_active.svg) no-repeat center center;
-  }
-
-#KeyDown {
-  background: url(skin:/palemoon/buttons/btn__key_down.svg) no-repeat center center;
-  }
-  #KeyDown[pressed="true"] {
-    background: url(skin:/palemoon/buttons/btn__key_down_active.svg) no-repeat center center;
-  }
-
-/* Rate buttons */
-#SyncDeck[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__sync_deck.svg) no-repeat center center;
-  }
-  #SyncDeck[displayValue="1"] {
-    background: url(skin:/palemoon/buttons/btn__sync_deck_active.svg) no-repeat center center;
-  }
-
-  #SyncSampler {
-    background: url(skin:/palemoon/buttons/btn__sync_sampler.svg) no-repeat center center;
-    }
-    #SyncSampler[displayValue="1"] {
-      background: url(skin:/palemoon/buttons/btn__sync_sampler_active.svg) no-repeat center center;
-    }
-
-  #RatePermUp {
-    background: url(skin:/palemoon/buttons/btn__plus.svg) no-repeat center center;}
-  #RatePermUp[pressed="true"] {
-    background: url(skin:/palemoon/buttons/btn__plus_active.svg) no-repeat center center;
-    }
-
-  #RatePermDown {
-    background: url(skin:/palemoon/buttons/btn__minus.svg) no-repeat center center;}
-  #RatePermDown[pressed="true"] {
-    background: url(skin:/palemoon/buttons/btn__minus_active.svg) no-repeat center center;
-    }
-
-  #RateTempUp {
-    background: url(skin:/palemoon/buttons/btn__arrow_right_up.svg) no-repeat center center;}
-  #RateTempUp[pressed="true"] {
-    background: url(skin:/palemoon/buttons/btn__arrow_right_up_active.svg) no-repeat center center;
-    }
-  #RateTempDown {
-    background: url(skin:/palemoon/buttons/btn__arrow_left_down.svg) no-repeat center center;}
-  #RateTempDown[pressed="true"] {
-    background: url(skin:/palemoon/buttons/btn__arrow_left_down_active.svg) no-repeat center center;
-    }
-
-  #RateTempUpRev {
-    background: url(skin:/palemoon/buttons/btn__arrow_right_down.svg) no-repeat center center;}
-  #RateTempUpRev[pressed="true"] {
-    background: url(skin:/palemoon/buttons/btn__arrow_right_down_active.svg) no-repeat center center;
-    }
-
-  #RateTempDownRev {
-    background: url(skin:/palemoon/buttons/btn__arrow_left_up.svg) no-repeat center center;
-    }
-    #RateTempDownRev[pressed="true"] {
-      background: url(skin:/palemoon/buttons/btn__arrow_left_up_active.svg) no-repeat center center;
-    }
-
-/* Mixer buttons */
-#PflButton[value="0"] {
-  background: url(skin:/palemoon/buttons/btn__pfl.svg) no-repeat center center;
-  }
-  #PflButton[value="1"] {
-    background: url(skin:/palemoon/buttons/btn__pfl_active.svg) no-repeat center center;
-  }
-
-#QuickEffectButton[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__star.svg) no-repeat center center;
-}
-
-/* EQ Kill button icons H / M / L */
-#EQKillButton_High[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__eq_kill_high.svg) no-repeat center center;
-}
-#EQKillButton_Mid[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__eq_kill_mid.svg) no-repeat center center;
-}
-#EQKillButton_Low[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__eq_kill_low.svg) no-repeat center center;
-}
-
-/* EQ Kill / QuickEffect dots */
-#EQKillDot[displayValue="0"],
-#QuickEffectDot[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__eq_kill_dot_off.svg) no-repeat center center;
-  }
-  #EQKillDot[displayValue="1"] {
-    background: url(skin:/palemoon/buttons/btn__eq_kill_dot_active_red.svg) no-repeat center center;
-  }
-  #QuickEffectDot[displayValue="1"] {
-    background: url(skin:/palemoon/buttons/btn__eq_kill_dot_active_green.svg) no-repeat center center;
-  }
-
-#RateCenter[highlight="0"] {
-  background: url(skin:/palemoon/buttons/btn__rate_center_off.svg) no-repeat center center;
-  }
-  #RateCenter[highlight="1"] {
-    background: url(skin:/palemoon/buttons/btn__rate_center_cyan.svg) no-repeat center center;
-  }
-
-#SplitCue[value="0"] {
-  background: url(skin:/palemoon/buttons/btn__split.svg) no-repeat center center;
-  }
-  #SplitCue[value="1"] {
-    background: url(skin:/palemoon/buttons/btn__split_active.svg) no-repeat center center;
-  }
-
-#FxExpand,
-#SamplerExpand,
-#LibExpand {
-  background-repeat: no-repeat;
-  background-position: center center;
-}
-#FxExpand[value="0"],
-#SamplerExpand[value="0"],
-#LibExpand[value="0"] {
-  background: url(skin:/palemoon/buttons/btn__expand_dim.svg) no-repeat center center;
-  }
-  #FxExpand[value="1"],
-  #SamplerExpand[value="1"],
-  #LibExpand[value="1"] {
-    background: url(skin:/palemoon/buttons/btn__collapse_dim.svg) no-repeat center center;
-  }
-
-#MixModeButton[value="0"] {
-  background: url(skin:/palemoon/buttons/btn__fx_mixmode_d-w.svg) no-repeat center center;
-  }
-  #MixModeButton[value="1"] {
-    background: url(skin:/palemoon/buttons/btn__fx_mixmode_d+w.svg) no-repeat center center;
-  }
-
-#FxToggleButton[value="0"] {
-  background: url(skin:/palemoon/buttons/btn__fx_toggle.svg) no-repeat center center;
-  }
-  #FxToggleButton[value="1"] {
-    background: url(skin:/palemoon/buttons/btn__fx_toggle_active.svg) no-repeat center center;
-  }
-
-#FxFocusButton[value="0"] {
-  background: url(skin:/palemoon/buttons/btn__fx_focus.svg) no-repeat center center;
-  }
-  #FxFocusButton[value="1"] {
-    background: url(skin:/palemoon/buttons/btn__fx_focus_active.svg) no-repeat center center;
-  }
-
-/* deck controls for decks 1-4 and samplers */
-#CurposButton12[displayValue="0"], #CurposButton34[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__beat_curpos.svg) no-repeat center center;
-  }
-  #CurposButton12[value="1"] {
-    background: url(skin:/palemoon/buttons/btn__beat_curpos_active_12.svg) no-repeat center center;
-  }
-  #CurposButton34[value="1"] {
-    background: url(skin:/palemoon/buttons/btn__beat_curpos_active_34.svg) no-repeat center center;
-  }
-
-  #EjectButton12[displayValue="0"], #EjectButton34[displayValue="0"] {
-    background: url(skin:/palemoon/buttons/btn__eject.svg) no-repeat center center;
-    }
-    #EjectButton12[value="1"] {
-      background: url(skin:/palemoon/buttons/btn__eject_active_12.svg) no-repeat center center;
-    }
-    #EjectButton34[value="1"] {
-      background: url(skin:/palemoon/buttons/btn__eject_active_34.svg) no-repeat center center;
-    }
-
-  #RepeatButton12[displayValue="0"], #RepeatButton34[displayValue="0"] {
-    background: url(skin:/palemoon/buttons/btn__repeat.svg) no-repeat center center;
-    }
-    #RepeatButton12[displayValue="1"] {
-      background: url(skin:/palemoon/buttons/btn__repeat_active_12.svg) no-repeat center center;
-    }
-    #RepeatButton34[displayValue="1"] {
-      background: url(skin:/palemoon/buttons/btn__repeat_active_34.svg) no-repeat center center;
-    }
-
-  #QuantizeButton12[displayValue="0"], #QuantizeButton34[displayValue="0"] {
-    background: url(skin:/palemoon/buttons/btn__quantize.svg) no-repeat center center;
-    }
-    #QuantizeButton12[displayValue="1"] {
-      background: url(skin:/palemoon/buttons/btn__quantize_active_12.svg) no-repeat center center;
-    }
-    #QuantizeButton34[displayValue="1"] {
-      background: url(skin:/palemoon/buttons/btn__quantize_active_34.svg) no-repeat center center;
-    }
-
-  #SlipmodeButton12[displayValue="0"], #SlipmodeButton34[displayValue="0"] {
-    background: url(skin:/palemoon/buttons/btn__slip.svg) no-repeat center center;
-    }
-    #SlipmodeButton12[displayValue="1"] {
-      background: url(skin:/palemoon/buttons/btn__slip_active_12.svg) no-repeat center center;
-    }
-    #SlipmodeButton34[displayValue="1"] {
-      background: url(skin:/palemoon/buttons/btn__slip_active_34.svg) no-repeat center center;
-    }
-
-  #KeylockButton12[displayValue="0"], #KeylockButton34[displayValue="0"] {
-    background: url(skin:/palemoon/buttons/btn__keylock.svg) no-repeat center center;
-    }
-    #KeylockButton12[displayValue="1"] {
-      background: url(skin:/palemoon/buttons/btn__keylock_active_12.svg) no-repeat center center;
-    }
-    #KeylockButton34[displayValue="1"] {
-      background: url(skin:/palemoon/buttons/btn__keylock_active_34.svg) no-repeat center center;
-    }
-
-#BeatgridControlsToggle[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__beatgrid_controls_expand.svg) no-repeat center center;
-  }
-  #BeatgridControlsToggle[displayValue="1"] {
-    background: url(skin:/palemoon/buttons/btn__beatgrid_controls_collapse.svg) no-repeat center center;
-  }
-
-  #BeatCurposLarge[displayValue="0"] {
-    background: url(skin:/palemoon/buttons/btn__beat_curpos_large.svg) no-repeat center center;
-    }
-    #BeatCurposLarge[pressed="true"] {
-      background: url(skin:/palemoon/buttons/btn__beat_curpos_large_active.svg) no-repeat center center;
-    }
-
-  #BeatsEarlier {
-    background: url(skin:/palemoon/buttons/btn__beats_earlier.svg) no-repeat center center;
-    }
-    #BeatsEarlier[pressed="true"] {
-      background: url(skin:/palemoon/buttons/btn__beats_earlier_active.svg) no-repeat center center;
-    }
-
-  #BeatsLater {
-    background: url(skin:/palemoon/buttons/btn__beats_later.svg) no-repeat center center;
-    }
-    #BeatsLater[pressed="true"] {
-      background: url(skin:/palemoon/buttons/btn__beats_later_active.svg) no-repeat center center;
-    }
-
-  #BeatsSlower {
-    background: url(skin:/palemoon/buttons/btn__beats_slower.svg) no-repeat center center;
-    }
-    #BeatsSlower[pressed="true"] {
-      background: url(skin:/palemoon/buttons/btn__beats_slower_active.svg) no-repeat center center;
-    }
-
-  #BeatsFaster {
-    background: url(skin:/palemoon/buttons/btn__beats_faster.svg) no-repeat center center;
-    }
-    #BeatsFaster[pressed="true"] {
-      background: url(skin:/palemoon/buttons/btn__beats_faster_active.svg) no-repeat center center;
-    }
-  #HotcuesEarlier {
-    background: url(skin:/palemoon/buttons/btn__beats_hotcues_earlier.svg) no-repeat center center;
-  }
-    #HotcuesEarlier[pressed="true"] {
-      background: url(skin:/palemoon/buttons/btn__beats_hotcues_earlier_active.svg) no-repeat center center;
-    }
-  #HotcuesLater {
-    background: url(skin:/palemoon/buttons/btn__beats_hotcues_later.svg) no-repeat center center;
-  }
-    #HotcuesLater[pressed="true"] {
-      background: url(skin:/palemoon/buttons/btn__beats_hotcues_later_active.svg) no-repeat center center;
-    }
-
-#MicTalk[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__mic_talk.svg) no-repeat center center;
-  }
-  #MicTalk[displayValue="1"] {
-    background: url(skin:/palemoon/buttons/btn__mic_talk_active.svg) no-repeat center center;
-  }
-
-#AuxPlay[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__aux_play.svg) no-repeat center center;
-  }
-  #AuxPlay[displayValue="1"] {
-    background: url(skin:/palemoon/buttons/btn__aux_play_active.svg) no-repeat center center;
-  }
-
-#MicAuxAdd {
-  background: url(skin:/palemoon/buttons/btn__plus_flat.svg) no-repeat center center;
-}
-
-#MicDucking[value="0"] {
-  background: url(skin:/palemoon/buttons/btn__mic_duck_off.svg) no-repeat center center;
-  }
-  #MicDucking[value="1"] {
-    background: url(skin:/palemoon/buttons/btn__mic_duck_auto.svg) no-repeat center center;
-  }
-  #MicDucking[value="2"] {
-    background: url(skin:/palemoon/buttons/btn__mic_duck_manual.svg) no-repeat center center;
-  }
-
-#RecDot[highlight="0"] {
-  background: url(skin:/palemoon/buttons/btn__rec_dot.svg) no-repeat center center;
-  }
-  #RecDot[highlight="1"], #RecDot[highlight="2"] {
-    background: url(skin:/palemoon/buttons/btn__rec_dot_active.svg) no-repeat center center;
-  }
-
-#BroadcastButton[displayValue="0"] {
-  /* for some reason the alignment isn't rescpected, so the icons
-    have to be sized like available area (button size - margin) */
-  background: url(skin:/palemoon/buttons/btn__broadcast_off.svg) no-repeat left top;
-  }
-  #BroadcastButton[displayValue="1"],
-  #BroadcastButton[displayValue="2"],
-  #BroadcastButton[displayValue="3"] {
-    background: url(skin:/palemoon/buttons/btn__broadcast_on.svg) no-repeat left top;
-  }
-
-#SkinSettingsToggle[displayValue="0"] {
-  background: url(skin:/palemoon/buttons/btn__settings_off.svg) no-repeat left top;
-  }
-  #SkinSettingsToggle[displayValue="1"] {
-    background: url(skin:/palemoon/buttons/btn__settings_on.svg) no-repeat left top;
-  }
-
-#ToolbarLogo {
-  background: url(skin:/palemoon/style/mixxx_logo_small.svg) no-repeat center center;
-}
-
-WSearchLineEdit QToolButton:!focus {
-  background: url(skin:/palemoon/buttons/btn__lib_clear_search.svg);
-  }
-  WSearchLineEdit QToolButton:focus {
-    background: url(skin:/palemoon/buttons/btn__lib_clear_search_focus.svg);
-  }
-
-/* AutoDJ button icons */
-QPushButton#pushButtonAutoDJ:!checked {
-  background: url(skin:/palemoon/buttons/btn__autodj_enable_off.svg) no-repeat center center;
-  }
-  QPushButton#pushButtonAutoDJ:checked {
-    background: url(skin:/palemoon/buttons/btn__autodj_enable_on.svg) no-repeat center center;
-  }
-
-QPushButton#pushButtonFadeNow:!enabled {
-  background: url(skin:/palemoon/buttons/btn__autodj_fade_disabled.svg) no-repeat center center;
-  }
-  QPushButton#pushButtonFadeNow:enabled {
-    background: url(skin:/palemoon/buttons/btn__autodj_fade.svg) no-repeat center center;
-  }
-
-QPushButton#pushButtonSkipNext:!enabled {
-  background: url(skin:/palemoon/buttons/btn__autodj_skip_disabled.svg) no-repeat center center;
-  }
-  QPushButton#pushButtonSkipNext:enabled {
-    background: url(skin:/palemoon/buttons/btn__autodj_skip.svg) no-repeat center center;
-  }
-
-QPushButton#pushButtonShuffle:enabled {
-  background: url(skin:/palemoon/buttons/btn__autodj_shuffle.svg) no-repeat center center;
-}
-
-QPushButton#pushButtonAddRandom:enabled {
-  background: url(skin:/palemoon/buttons/btn__autodj_addrandom.svg) no-repeat center center;
-}
-
-QPushButton#pushButtonRepeatPlaylist:!checked {
-  background: url(skin:/palemoon/buttons/btn__autodj_repeat_playlist_off.svg) no-repeat center center;
-  }
-  QPushButton#pushButtonRepeatPlaylist:checked {
-    background: url(skin:/palemoon/buttons/btn__autodj_repeat_playlist_on.svg) no-repeat center center;
-  }
-/* AutoDJ button icons */
-
-/* widgets in cue popup menu */
-WCueMenuPopup #CueDeleteButton {
-  qproperty-icon: url(skin:/palemoon/buttons/btn__delete.svg);
-  width: 24px;
-  height: 42px;
-  /* make the icon slightly larger than default 16px */
-  qproperty-iconSize: 20px;
-}
-
-WCueMenuPopup #CueDeleteButton:pressed {
-  background-color: #b24c12;
-  outline: none;
-  /* not applied: */
-  qproperty-icon: url(skin:/palemoon/buttons/btn__delete_active.svg);
-}
-WCueMenuPopup #CueLabelEdit {
-  /*border: 1px solid #c2b3a5;*/
-  border-radius: 0px;
-  background-color: #000;
-  selection-color: #000;
-  selection-background-color: #ccc;
-  padding: 2px;
-}
-
-/* Color picker in WCueMenuPopup and WTrackMenu (library and decks) */
-WColorPicker QPushButton {
-}
-WColorPicker QPushButton[checked="false"] {
-  outline: none;
-  border-width: 2px 2px 2px 2px;
-  border-image: url(skin:/palemoon/buttons/btn_colorpicker.svg) 2 2 2 2;
-  margin: 0px;
-  padding: 0px;
-}
-WColorPicker QPushButton[checked="true"] {
-  outline: none;
-  border-width: 2px 2px 2px 2px;
-  border-image: url(skin:/palemoon/buttons/btn_colorpicker_active.svg) 2 2 2 2;
-  margin: 0px;
-  padding: 0px;
-  /* This property behaves really strange:
-  * set to 20px it's 2px too tall
-  * set to 18px it's 2px too small
-  qproperty-iconSize: 20px;*/
-}
-
-/************** Button icons **************************************************/
 
 /************** button background colors **************************************/
 
@@ -2233,8 +1627,7 @@ WPushButton#PlayDeckMini[displayValue="1"],
 WPushButton#PlaySampler[displayValue="1"],
 WPushButton#PlayPreview[displayValue="1"],
 WPushButton#PlayIndicator[displayValue="1"],
-/* TODO ronso0 Restore once fixed lib linKIconThemes (vers. <..80) is in *ubuntu main repos */
-/*#LibraryPreviewButton:checked,*/
+#LibraryPreviewButton:checked,
 #CueDeck[displayValue="1"],
 WPushButton#Reverse[pressed="true"],
 #LoopActivate[value="1"],
@@ -2263,9 +1656,8 @@ WPushButton#LoopIn[pressed="true"],
 WPushButton#LoopOut[pressed="true"],
 #BeatjumpControls WPushButton[value="1"],
 #RateControls WPushButton[value="1"],
-#BeatgridControls WPushButton[pressed="true"],
-/* #CueDeleteButton[pressed="true"], */
-#LibraryFeatureControls QPushButton:pressed {
+#BeatgridControls WPushButton[pressed="true"]/*,
+#CueDeleteButton[pressed="true"]*/ {
   background-color: #7d350d;
   }
   #BpmTap[pressed="true"] {
@@ -2386,7 +1778,7 @@ WPushButton#FxSuperLinkInvertButton[displayValue="0"] {
   background-color: #d09300;
 }
 
-WPushButton#SpecialCueButton[value="1"] {
+#SpecialCueButton[value="1"] {
   background-color: #395579;
 }
 
@@ -2437,6 +1829,612 @@ WPushButton#RecButton[displayValue="1"],
 }
 
 
+
+/************** Button icons **************************************************/
+WPushButton#PlayDeck[value="0"] {
+  image: url(skin:/palemoon/buttons/btn__play_deck.svg) no-repeat center center;
+  }
+  WPushButton#PlayDeck[value="1"] {
+    image: url(skin:/palemoon/buttons/btn__play_deck_active.svg) no-repeat center center;
+  }
+
+#PlayDeckMini[value="0"] {
+  image: url(skin:/palemoon/buttons/btn__play_deck_mini.svg) no-repeat center center;
+  }
+  #PlayDeckMini[value="1"] {
+    image: url(skin:/palemoon/buttons/btn__pause_deck_mini.svg) no-repeat center center;
+  }
+#PlaySampler[value="0"],
+#PlayPreview[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__play_sampler.svg) no-repeat center center;
+  }
+  #PlaySampler[value="1"],
+  #PlayPreview[displayValue="1"] {
+    image: url(skin:/palemoon/buttons/btn__pause_sampler.svg) no-repeat center center;
+  }
+
+#CueDeck[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__cue_deck.svg) no-repeat center center;
+  }
+  #CueDeck[displayValue="1"] {
+    image: url(skin:/palemoon/buttons/btn__cue_deck_active.svg) no-repeat center center;
+  }
+
+#Reverse {
+  image: url(skin:/palemoon/buttons/btn__reverse.svg) no-repeat center center;
+  }
+  #Reverse[pressed="true"] {
+    image: url(skin:/palemoon/buttons/btn__reverse_active.svg) no-repeat center center;
+  }
+
+#Hotcue1 WPushButton[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__1.svg) no-repeat center center;
+  }
+  #Hotcue1 WPushButton[displayValue="1"][dark="false"] {
+    image: url(skin:/palemoon/buttons/btn__1_active.svg) no-repeat center center;
+  }
+  #Hotcue1 WPushButton[displayValue="1"][dark="true"] {
+    image: url(skin:/palemoon/buttons/btn__1_active_dark.svg) no-repeat center center;
+  }
+
+#Hotcue2 WPushButton[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__2.svg) no-repeat center center;
+  }
+  #Hotcue2 WPushButton[displayValue="1"] {
+    image: url(skin:/palemoon/buttons/btn__2_active.svg) no-repeat center center;
+  }
+  #Hotcue2 WPushButton[displayValue="1"][dark="true"] {
+    image: url(skin:/palemoon/buttons/btn__2_active_dark.svg) no-repeat center center;
+  }
+
+#Hotcue3 WPushButton[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__3.svg) no-repeat center center;
+  }
+  #Hotcue3 WPushButton[displayValue="1"] {
+    image: url(skin:/palemoon/buttons/btn__3_active.svg) no-repeat center center;
+  }
+  #Hotcue3 WPushButton[displayValue="1"][dark="true"] {
+    image: url(skin:/palemoon/buttons/btn__3_active_dark.svg) no-repeat center center;
+  }
+
+#Hotcue4 WPushButton[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__4.svg) no-repeat center center;
+  }
+  #Hotcue4 WPushButton[displayValue="1"] {
+    image: url(skin:/palemoon/buttons/btn__4_active.svg) no-repeat center center;
+  }
+  #Hotcue4 WPushButton[displayValue="1"][dark="true"] {
+    image: url(skin:/palemoon/buttons/btn__4_active_dark.svg) no-repeat center center;
+  }
+
+#Hotcue5 WPushButton[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__5.svg) no-repeat center center;
+  }
+  #Hotcue5 WPushButton[displayValue="1"] {
+    image: url(skin:/palemoon/buttons/btn__5_active.svg) no-repeat center center;
+  }
+  #Hotcue5 WPushButton[displayValue="1"][dark="true"] {
+    image: url(skin:/palemoon/buttons/btn__5_active_dark.svg) no-repeat center center;
+  }
+
+#Hotcue6 WPushButton[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__6.svg) no-repeat center center;
+  }
+  #Hotcue6 WPushButton[displayValue="1"] {
+    image: url(skin:/palemoon/buttons/btn__6_active.svg) no-repeat center center;
+  }
+  #Hotcue6 WPushButton[displayValue="1"][dark="true"] {
+    image: url(skin:/palemoon/buttons/btn__6_active_dark.svg) no-repeat center center;
+  }
+
+#Hotcue7 WPushButton[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__7.svg) no-repeat center center;
+  }
+  #Hotcue7 WPushButton[displayValue="1"] {
+    image: url(skin:/palemoon/buttons/btn__7_active.svg) no-repeat center center;
+  }
+  #Hotcue7 WPushButton[displayValue="1"][dark="true"] {
+    image: url(skin:/palemoon/buttons/btn__7_active_dark.svg) no-repeat center center;
+  }
+
+#Hotcue8 WPushButton[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__8.svg) no-repeat center center;
+  }
+  #Hotcue8 WPushButton[displayValue="1"] {
+    image: url(skin:/palemoon/buttons/btn__8_active.svg) no-repeat center center;
+  }
+  #Hotcue8 WPushButton[displayValue="1"][dark="true"] {
+    image: url(skin:/palemoon/buttons/btn__8_active_dark.svg) no-repeat center center;
+  }
+
+#SpecialCueButton_intro_start WPushButton[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__intro_start.svg) no-repeat center center;
+  }
+  #SpecialCueButton_intro_start WPushButton[displayValue="1"] {
+    image: url(skin:/palemoon/buttons/btn__intro_start_active.svg) no-repeat center center;
+  }
+#SpecialCueButton_intro_end WPushButton[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__intro_end.svg) no-repeat center center;
+  }
+  #SpecialCueButton_intro_end WPushButton[displayValue="1"] {
+    image: url(skin:/palemoon/buttons/btn__intro_end_active.svg) no-repeat center center;
+  }
+#SpecialCueButton_outro_start WPushButton[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__outro_start.svg) no-repeat center center;
+  }
+  #SpecialCueButton_outro_start WPushButton[displayValue="1"] {
+    image: url(skin:/palemoon/buttons/btn__outro_start_active.svg) no-repeat center center;
+  }
+#SpecialCueButton_outro_end WPushButton[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__outro_end.svg) no-repeat center center;
+  }
+  #SpecialCueButton_outro_end WPushButton[displayValue="1"] {
+    image: url(skin:/palemoon/buttons/btn__outro_end_active.svg) no-repeat center center;
+  }
+
+#LoopActivate[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__loop.svg) no-repeat center center;
+  }
+  #LoopActivate[displayValue="1"], #LoopActivate[pressed="true"] {
+    image: url(skin:/palemoon/buttons/btn__loop_active.svg) no-repeat center center;
+  }
+#Reloop[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__reloop.svg) no-repeat center center;
+  }
+  #Reloop[displayValue="1"] {
+    image: url(skin:/palemoon/buttons/btn__reloop_active.svg) no-repeat center center;
+  }
+
+#LoopIn {
+  image: url(skin:/palemoon/buttons/btn__loop_in.svg) no-repeat center center;
+  }
+  #LoopIn[pressed="true"] {
+    image: url(skin:/palemoon/buttons/btn__loop_in_active.svg) no-repeat center center;
+  }
+#LoopOut {
+  image: url(skin:/palemoon/buttons/btn__loop_out.svg) no-repeat center center;
+  }
+  #LoopOut[pressed="true"] {
+    image: url(skin:/palemoon/buttons/btn__loop_out_active.svg) no-repeat center center;
+  }
+
+#JumpForward {
+  image: url(skin:/palemoon/buttons/btn__beatjump_right.svg) no-repeat center center;
+  }
+  #JumpForward[pressed="true"] {
+    image: url(skin:/palemoon/buttons/btn__beatjump_right_active.svg) no-repeat center center;
+  }
+#JumpBack {
+  image: url(skin:/palemoon/buttons/btn__beatjump_left.svg) no-repeat center center;
+  }
+  #JumpBack[pressed="true"] {
+    image: url(skin:/palemoon/buttons/btn__beatjump_left_active.svg) no-repeat center center;
+  }
+
+/* Key buttons */
+#KeyMatchReset {
+  image: url(skin:/palemoon/buttons/btn__key_match.svg) no-repeat center center;
+  }
+  #KeyMatchReset[pressed="true"] {
+    image: url(skin:/palemoon/buttons/btn__key_match_active.svg) no-repeat center center;
+  }
+
+#KeyUp {
+  image: url(skin:/palemoon/buttons/btn__key_up.svg) no-repeat center center;
+  }
+  #KeyUp[pressed="true"] {
+    image: url(skin:/palemoon/buttons/btn__key_up_active.svg) no-repeat center center;
+  }
+
+#KeyDown {
+  image: url(skin:/palemoon/buttons/btn__key_down.svg) no-repeat center center;
+  }
+  #KeyDown[pressed="true"] {
+    image: url(skin:/palemoon/buttons/btn__key_down_active.svg) no-repeat center center;
+  }
+
+/* Rate buttons */
+#SyncDeck[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__sync_deck.svg) no-repeat center center;
+  }
+  #SyncDeck[displayValue="1"] {
+    image: url(skin:/palemoon/buttons/btn__sync_deck_active.svg) no-repeat center center;
+  }
+
+  #SyncSampler {
+    image: url(skin:/palemoon/buttons/btn__sync_sampler.svg) no-repeat center center;
+    }
+    #SyncSampler[displayValue="1"] {
+      image: url(skin:/palemoon/buttons/btn__sync_sampler_active.svg) no-repeat center center;
+    }
+
+  #RatePermUp {
+    image: url(skin:/palemoon/buttons/btn__plus.svg) no-repeat center center;}
+  #RatePermUp[pressed="true"] {
+    image: url(skin:/palemoon/buttons/btn__plus_active.svg) no-repeat center center;
+    }
+
+  #RatePermDown {
+    image: url(skin:/palemoon/buttons/btn__minus.svg) no-repeat center center;}
+  #RatePermDown[pressed="true"] {
+    image: url(skin:/palemoon/buttons/btn__minus_active.svg) no-repeat center center;
+    }
+
+  #RateTempUp {
+    image: url(skin:/palemoon/buttons/btn__arrow_right_up.svg) no-repeat center center;}
+  #RateTempUp[pressed="true"] {
+    image: url(skin:/palemoon/buttons/btn__arrow_right_up_active.svg) no-repeat center center;
+    }
+  #RateTempDown {
+    image: url(skin:/palemoon/buttons/btn__arrow_left_down.svg) no-repeat center center;}
+  #RateTempDown[pressed="true"] {
+    image: url(skin:/palemoon/buttons/btn__arrow_left_down_active.svg) no-repeat center center;
+    }
+
+  #RateTempUpRev {
+    image: url(skin:/palemoon/buttons/btn__arrow_right_down.svg) no-repeat center center;}
+  #RateTempUpRev[pressed="true"] {
+    image: url(skin:/palemoon/buttons/btn__arrow_right_down_active.svg) no-repeat center center;
+    }
+
+  #RateTempDownRev {
+    image: url(skin:/palemoon/buttons/btn__arrow_left_up.svg) no-repeat center center;
+    }
+    #RateTempDownRev[pressed="true"] {
+      image: url(skin:/palemoon/buttons/btn__arrow_left_up_active.svg) no-repeat center center;
+    }
+
+/* Mixer buttons */
+#PflButton[value="0"] {
+  image: url(skin:/palemoon/buttons/btn__pfl.svg) no-repeat center center;
+  }
+  #PflButton[value="1"] {
+    image: url(skin:/palemoon/buttons/btn__pfl_active.svg) no-repeat center center;
+  }
+
+#QuickEffectButton[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__star.svg) no-repeat center center;
+}
+
+/* EQ Kill button icons H / M / L */
+#EQKillButton_High[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__eq_kill_high.svg) no-repeat center center;
+}
+#EQKillButton_Mid[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__eq_kill_mid.svg) no-repeat center center;
+}
+#EQKillButton_Low[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__eq_kill_low.svg) no-repeat center center;
+}
+
+/* EQ Kill / QuickEffect dots */
+#EQKillDot[displayValue="0"],
+#QuickEffectDot[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__eq_kill_dot_off.svg) no-repeat center center;
+  }
+  #EQKillDot[displayValue="1"] {
+    image: url(skin:/palemoon/buttons/btn__eq_kill_dot_active_red.svg) no-repeat center center;
+  }
+  #QuickEffectDot[displayValue="1"] {
+    image: url(skin:/palemoon/buttons/btn__eq_kill_dot_active_green.svg) no-repeat center center;
+  }
+
+#RateCenter[highlight="0"] {
+  image: url(skin:/palemoon/buttons/btn__rate_center_off.svg) no-repeat center center;
+  }
+  #RateCenter[highlight="1"] {
+    image: url(skin:/palemoon/buttons/btn__rate_center_cyan.svg) no-repeat center center;
+  }
+
+#SplitCue[value="0"] {
+  image: url(skin:/palemoon/buttons/btn__split.svg) no-repeat center center;
+  }
+  #SplitCue[value="1"] {
+    image: url(skin:/palemoon/buttons/btn__split_active.svg) no-repeat center center;
+  }
+
+#FxExpand,
+#SamplerExpand,
+#LibExpand {
+  background-repeat: no-repeat;
+  background-position: center center;
+}
+#FxExpand[value="0"],
+#SamplerExpand[value="0"],
+#LibExpand[value="0"] {
+  background: url(skin:/palemoon/buttons/btn__expand_dim.svg) no-repeat center center;
+  }
+  #FxExpand[value="1"],
+  #SamplerExpand[value="1"],
+  #LibExpand[value="1"] {
+    background: url(skin:/palemoon/buttons/btn__collapse_dim.svg) no-repeat center center;
+  }
+
+#MixModeButton[value="0"] {
+  image: url(skin:/palemoon/buttons/btn__fx_mixmode_d-w.svg) no-repeat center center;
+  }
+  #MixModeButton[value="1"] {
+    image: url(skin:/palemoon/buttons/btn__fx_mixmode_d+w.svg) no-repeat center center;
+  }
+
+#FxToggleButton[value="0"] {
+  image: url(skin:/palemoon/buttons/btn__fx_toggle.svg) no-repeat center center;
+  }
+  #FxToggleButton[value="1"] {
+    image: url(skin:/palemoon/buttons/btn__fx_toggle_active.svg) no-repeat center center;
+  }
+
+#FxFocusButton[value="0"] {
+  image: url(skin:/palemoon/buttons/btn__fx_focus.svg) no-repeat center center;
+  }
+  #FxFocusButton[value="1"] {
+    image: url(skin:/palemoon/buttons/btn__fx_focus_active.svg) no-repeat center center;
+  }
+
+/* deck controls for decks 1-4 and samplers */
+#CurposButton12[displayValue="0"], #CurposButton34[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__beat_curpos.svg) no-repeat center center;
+  }
+  #CurposButton12[value="1"] {
+    image: url(skin:/palemoon/buttons/btn__beat_curpos_active_12.svg) no-repeat center center;
+  }
+  #CurposButton34[value="1"] {
+    image: url(skin:/palemoon/buttons/btn__beat_curpos_active_34.svg) no-repeat center center;
+  }
+
+  #EjectButton12[displayValue="0"], #EjectButton34[displayValue="0"] {
+    image: url(skin:/palemoon/buttons/btn__eject.svg) no-repeat center center;
+    }
+    #EjectButton12[value="1"] {
+      image: url(skin:/palemoon/buttons/btn__eject_active_12.svg) no-repeat center center;
+    }
+    #EjectButton34[value="1"] {
+      image: url(skin:/palemoon/buttons/btn__eject_active_34.svg) no-repeat center center;
+    }
+
+  #RepeatButton12[displayValue="0"], #RepeatButton34[displayValue="0"] {
+    image: url(skin:/palemoon/buttons/btn__repeat.svg) no-repeat center center;
+    }
+    #RepeatButton12[displayValue="1"] {
+      image: url(skin:/palemoon/buttons/btn__repeat_active_12.svg) no-repeat center center;
+    }
+    #RepeatButton34[displayValue="1"] {
+      image: url(skin:/palemoon/buttons/btn__repeat_active_34.svg) no-repeat center center;
+    }
+
+  #QuantizeButton12[displayValue="0"], #QuantizeButton34[displayValue="0"] {
+    image: url(skin:/palemoon/buttons/btn__quantize.svg) no-repeat center center;
+    }
+    #QuantizeButton12[displayValue="1"] {
+      image: url(skin:/palemoon/buttons/btn__quantize_active_12.svg) no-repeat center center;
+    }
+    #QuantizeButton34[displayValue="1"] {
+      image: url(skin:/palemoon/buttons/btn__quantize_active_34.svg) no-repeat center center;
+    }
+
+  #SlipmodeButton12[displayValue="0"], #SlipmodeButton34[displayValue="0"] {
+    image: url(skin:/palemoon/buttons/btn__slip.svg) no-repeat center center;
+    }
+    #SlipmodeButton12[displayValue="1"] {
+      image: url(skin:/palemoon/buttons/btn__slip_active_12.svg) no-repeat center center;
+    }
+    #SlipmodeButton34[displayValue="1"] {
+      image: url(skin:/palemoon/buttons/btn__slip_active_34.svg) no-repeat center center;
+    }
+
+  #KeylockButton12[displayValue="0"], #KeylockButton34[displayValue="0"] {
+    image: url(skin:/palemoon/buttons/btn__keylock.svg) no-repeat center center;
+    }
+    #KeylockButton12[displayValue="1"] {
+      image: url(skin:/palemoon/buttons/btn__keylock_active_12.svg) no-repeat center center;
+    }
+    #KeylockButton34[displayValue="1"] {
+      image: url(skin:/palemoon/buttons/btn__keylock_active_34.svg) no-repeat center center;
+    }
+
+#BeatgridControlsToggle[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__beatgrid_controls_expand.svg) no-repeat center center;
+  }
+  #BeatgridControlsToggle[displayValue="1"] {
+    image: url(skin:/palemoon/buttons/btn__beatgrid_controls_collapse.svg) no-repeat center center;
+  }
+
+  #BeatCurposLarge[displayValue="0"] {
+    image: url(skin:/palemoon/buttons/btn__beat_curpos_large.svg) no-repeat center center;
+    }
+    #BeatCurposLarge[pressed="true"] {
+      image: url(skin:/palemoon/buttons/btn__beat_curpos_large_active.svg) no-repeat center center;
+    }
+
+  #BeatsEarlier {
+    image: url(skin:/palemoon/buttons/btn__beats_earlier.svg) no-repeat center center;
+    }
+    #BeatsEarlier[pressed="true"] {
+      image: url(skin:/palemoon/buttons/btn__beats_earlier_active.svg) no-repeat center center;
+    }
+
+  #BeatsLater {
+    image: url(skin:/palemoon/buttons/btn__beats_later.svg) no-repeat center center;
+    }
+    #BeatsLater[pressed="true"] {
+      image: url(skin:/palemoon/buttons/btn__beats_later_active.svg) no-repeat center center;
+    }
+
+  #BeatsSlower {
+    image: url(skin:/palemoon/buttons/btn__beats_slower.svg) no-repeat center center;
+    }
+    #BeatsSlower[pressed="true"] {
+      image: url(skin:/palemoon/buttons/btn__beats_slower_active.svg) no-repeat center center;
+    }
+
+  #BeatsFaster {
+    image: url(skin:/palemoon/buttons/btn__beats_faster.svg) no-repeat center center;
+    }
+    #BeatsFaster[pressed="true"] {
+      image: url(skin:/palemoon/buttons/btn__beats_faster_active.svg) no-repeat center center;
+    }
+  #HotcuesEarlier {
+    image: url(skin:/palemoon/buttons/btn__beats_hotcues_earlier.svg) no-repeat center center;
+  }
+    #HotcuesEarlier[pressed="true"] {
+      image: url(skin:/palemoon/buttons/btn__beats_hotcues_earlier_active.svg) no-repeat center center;
+    }
+  #HotcuesLater {
+    image: url(skin:/palemoon/buttons/btn__beats_hotcues_later.svg) no-repeat center center;
+  }
+    #HotcuesLater[pressed="true"] {
+      image: url(skin:/palemoon/buttons/btn__beats_hotcues_later_active.svg) no-repeat center center;
+    }
+
+#MicTalk[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__mic_talk.svg) no-repeat center center;
+  }
+  #MicTalk[displayValue="1"] {
+    image: url(skin:/palemoon/buttons/btn__mic_talk_active.svg) no-repeat center center;
+  }
+
+#AuxPlay[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__aux_play.svg) no-repeat center center;
+  }
+  #AuxPlay[displayValue="1"] {
+    image: url(skin:/palemoon/buttons/btn__aux_play_active.svg) no-repeat center center;
+  }
+
+#MicAuxAdd {
+  image: url(skin:/palemoon/buttons/btn__plus_flat.svg) no-repeat center center;
+}
+
+#MicDucking[value="0"] {
+  image: url(skin:/palemoon/buttons/btn__mic_duck_off.svg) no-repeat center center;
+  }
+  #MicDucking[value="1"] {
+    image: url(skin:/palemoon/buttons/btn__mic_duck_auto.svg) no-repeat center center;
+  }
+  #MicDucking[value="2"] {
+    image: url(skin:/palemoon/buttons/btn__mic_duck_manual.svg) no-repeat center center;
+  }
+
+#RecDot[highlight="0"] {
+  image: url(skin:/palemoon/buttons/btn__rec_dot.svg) no-repeat center center;
+  }
+  #RecDot[highlight="1"], #RecDot[highlight="2"] {
+    image: url(skin:/palemoon/buttons/btn__rec_dot_active.svg) no-repeat center center;
+  }
+
+#BroadcastButton[displayValue="0"] {
+  /* for some reason the alignment isn't rescpected, so the icons
+    have to be sized like available area (button size - margin) */
+  image: url(skin:/palemoon/buttons/btn__broadcast_off.svg) no-repeat left top;
+  }
+  #BroadcastButton[displayValue="1"],
+  #BroadcastButton[displayValue="2"],
+  #BroadcastButton[displayValue="3"] {
+    image: url(skin:/palemoon/buttons/btn__broadcast_on.svg) no-repeat left top;
+  }
+
+#SkinSettingsToggle[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__settings_off.svg) no-repeat left top;
+  }
+  #SkinSettingsToggle[displayValue="1"] {
+    image: url(skin:/palemoon/buttons/btn__settings_on.svg) no-repeat left top;
+  }
+
+#ToolbarLogo {
+  image: url(skin:/palemoon/style/mixxx_logo_small.svg) no-repeat center center;
+}
+
+WSearchLineEdit QToolButton:!focus {
+  image: url(skin:/palemoon/buttons/btn__lib_clear_search.svg);
+  }
+  WSearchLineEdit QToolButton:focus {
+    image: url(skin:/palemoon/buttons/btn__lib_clear_search_focus.svg);
+  }
+
+/* AutoDJ button icons */
+QPushButton#pushButtonAutoDJ:!checked {
+  image: url(skin:/palemoon/buttons/btn__autodj_enable_off.svg) no-repeat center center;
+  }
+  QPushButton#pushButtonAutoDJ:checked {
+    image: url(skin:/palemoon/buttons/btn__autodj_enable_on.svg) no-repeat center center;
+  }
+
+QPushButton#pushButtonFadeNow:!enabled {
+  image: url(skin:/palemoon/buttons/btn__autodj_fade_disabled.svg) no-repeat center center;
+  }
+  QPushButton#pushButtonFadeNow:enabled {
+    image: url(skin:/palemoon/buttons/btn__autodj_fade.svg) no-repeat center center;
+  }
+
+QPushButton#pushButtonSkipNext:!enabled {
+  image: url(skin:/palemoon/buttons/btn__autodj_skip_disabled.svg) no-repeat center center;
+  }
+  QPushButton#pushButtonSkipNext:enabled {
+    image: url(skin:/palemoon/buttons/btn__autodj_skip.svg) no-repeat center center;
+  }
+
+QPushButton#pushButtonShuffle:enabled {
+  image: url(skin:/palemoon/buttons/btn__autodj_shuffle.svg) no-repeat center center;
+}
+
+QPushButton#pushButtonAddRandom:enabled {
+  image: url(skin:/palemoon/buttons/btn__autodj_addrandom.svg) no-repeat center center;
+}
+
+QPushButton#pushButtonRepeatPlaylist:!checked {
+  image: url(skin:/palemoon/buttons/btn__autodj_repeat_playlist_off.svg) no-repeat center center;
+  }
+  QPushButton#pushButtonRepeatPlaylist:checked {
+    image: url(skin:/palemoon/buttons/btn__autodj_repeat_playlist_on.svg) no-repeat center center;
+  }
+/* AutoDJ button icons */
+
+/* widgets in cue popup menu */
+WCueMenuPopup #CueDeleteButton {
+  qproperty-icon: url(skin:/palemoon/buttons/btn__delete.svg);
+  width: 24px;
+  height: 42px;
+  /* make the icon slightly larger than default 16px */
+  qproperty-iconSize: 20px;
+}
+
+WCueMenuPopup #CueDeleteButton:pressed {
+  background-color: #b24c12;
+  outline: none;
+  /* not applied: */
+  qproperty-icon: url(skin:/palemoon/buttons/btn__delete_active.svg);
+}
+WCueMenuPopup #CueLabelEdit {
+  /*border: 1px solid #c2b3a5;*/
+  border-radius: 0px;
+  background-color: #000;
+  selection-color: #000;
+  selection-background-color: #ccc;
+  padding: 2px;
+}
+
+/* Color picker in WCueMenuPopup and WTrackMenu (library and decks) */
+WColorPicker QPushButton {
+}
+WColorPicker QPushButton[checked="false"] {
+  outline: none;
+  border-width: 2px 2px 2px 2px;
+  border-image: url(skin:/palemoon/buttons/btn_colorpicker.svg) 2 2 2 2;
+  margin: 0px;
+  padding: 0px;
+}
+WColorPicker QPushButton[checked="true"] {
+  outline: none;
+  border-width: 2px 2px 2px 2px;
+  border-image: url(skin:/palemoon/buttons/btn_colorpicker_active.svg) 2 2 2 2;
+  margin: 0px;
+  padding: 0px;
+  /* This property behaves really strange:
+  * set to 20px it's 2px too tall
+  * set to 18px it's 2px too small
+  qproperty-iconSize: 20px;*/
+}
+
+/************** Button icons **************************************************/
 /************** Button styles *************************************************/
 
 
@@ -2563,18 +2561,15 @@ WLibrary QLineEdit,
 /* Button in library "Preview" column */
 #LibraryPreviewButton {
   margin: 0px;
-  padding: 3px;
+  padding: 0px;
   border-radius: 2px;
   border: 1px solid transparent;
   }
   #LibraryPreviewButton:!checked {
-    /* TODO ronso0 Restore once fixed lib linKIconThemes (vers. <..80) is in *ubuntu main repos */
-    /*image: url(skin:/palemoon/buttons/btn__lib_preview_play.svg);*/
+    image: url(skin:/palemoon/buttons/btn__lib_preview_play.svg);
     }
   #LibraryPreviewButton:checked {
-    /*image: url(skin:/palemoon/buttons/btn__lib_preview_pause.svg);*/
-    border:  1px solid #b24c12;
-    background-color: #000;
+    image: url(skin:/palemoon/buttons/btn__lib_preview_pause.svg);
     }
 
 
@@ -2586,20 +2581,11 @@ WLibrary QLineEdit,
     padding: 2px 1px 0px 3px;
     }
     #LibraryContainer QHeaderView::up-arrow {
-      background: url(skin:/palemoon/buttons/btn__lib_sort_up.svg) no-repeat center center;
+      image: url(skin:/palemoon/buttons/btn__lib_sort_up.svg);
     }
     #LibraryContainer QHeaderView::down-arrow {
-      background: url(skin:/palemoon/buttons/btn__lib_sort_down.svg) no-repeat center center;
+      image: url(skin:/palemoon/buttons/btn__lib_sort_down.svg);
     }
-    #LibraryContainer QHeaderView::up-arrow,
-    #LibraryContainer QHeaderView::down-arrow {
-      /* color should match that of QHeaderView::section,
-        with a little transparency added to not cut off the header label.
-        Hex >  2^8 = */
-      background-color: rgba(23,23,25,190);
-      /* add margin to not overlap the ::section border-image */
-      margin: 1px 2px 1px 0px;
-      }
 
 
 

--- a/res/skins/Shade/skin.xml
+++ b/res/skins/Shade/skin.xml
@@ -224,7 +224,7 @@
     <LaunchImageStyle>
       LaunchImage { background-color: #202020; }
         QLabel {
-          background-image: url(skin:/style/mixxx-icon-logo-symbolic.png);
+          image: url(skin:/style/mixxx-icon-logo-symbolic.png);
           padding:0;
           margin:0;
           border:none;

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -616,22 +616,20 @@ WTrackTableView {
 
   /* Button in library "Preview" column */
   #LibraryPreviewButton {
-    /* TODO ronso0 Restore once fixed lib linKIconThemes (vers. <..80) is in *ubuntu main repos */
-    /*background: transparent;*/
+    background: transparent;
     margin: 0px;
-    padding: 3px;
+    padding: 0px;
     border: 1px solid transparent;
   }
   #LibraryPreviewButton:!checked{
-    /* TODO ronso0 Restore once fixed lib linKIconThemes (vers. <..80) is in *ubuntu main repos */
-    /*image: url(skin:/btn/btn_lib_preview_play.svg);*/
+    image: url(skin:/btn/btn_lib_preview_play.svg);
   }
   #LibraryPreviewButton:!checked:hover {
     border: 1px solid #666;
     background: #0f0f0f;
   }
   #LibraryPreviewButton:checked {
-    /*image: url(skin:/btn/btn_lib_preview_pause.svg);*/
+    image: url(skin:/btn/btn_lib_preview_pause.svg);
     background-color: #0f0f0f;
     border: 1px solid #444;
   }

--- a/res/skins/Tango (64 Samplers)/skin.xml
+++ b/res/skins/Tango (64 Samplers)/skin.xml
@@ -143,7 +143,7 @@
         background-color: #0f0f0f;
       }
       QLabel {
-        background-image: url(skin:/../Tango/graphics/logo_160x40.svg);
+        image: url(skin:../Tango//graphics/logo_160x40.svg);
         padding: 0;
         margin: 0px 2px 0px 2px;
         border: none;

--- a/res/skins/Tango/buttons/btn_library_sort_down.svg
+++ b/res/skins/Tango/buttons/btn_library_sort_down.svg
@@ -1,3 +1,0 @@
-<svg width="24" height="16" version="1.1" viewBox="0 0 24 16" xmlns="http://www.w3.org/2000/svg">
-  <path d="m0 3.415 2.83-2.83 9.17 9.17 9.17-9.17 2.83 2.83-12 12z" fill="#ff7100"/>
-</svg>

--- a/res/skins/Tango/buttons/btn_library_sort_up.svg
+++ b/res/skins/Tango/buttons/btn_library_sort_up.svg
@@ -1,5 +1,0 @@
-<svg width="24" height="16" version="1.1" viewBox="0 0 24 16" xmlns="http://www.w3.org/2000/svg">
-  <g transform="translate(-315.44,-310.075)">
-    <path d="m315.44 322.66 2.83 2.83 9.17-9.17 9.17 9.17 2.83-2.83-12-12z" fill="#ff7100"/>
-  </g>
-</svg>

--- a/res/skins/Tango/graphics/library_sort_down.svg
+++ b/res/skins/Tango/graphics/library_sort_down.svg
@@ -1,0 +1,1 @@
+<svg id="svg2" width="24" height="14.83" version="1.1" viewBox="0 0 24 14.83" xmlns="http://www.w3.org/2000/svg"><g id="g4" transform="translate(-315.44,-310.66)"><path id="path6" d="m315.44 313.49 2.83-2.83 9.17 9.17 9.17-9.17 2.83 2.83-12 12z" fill="#FF7100"/></g></svg>

--- a/res/skins/Tango/graphics/library_sort_up.svg
+++ b/res/skins/Tango/graphics/library_sort_up.svg
@@ -1,0 +1,1 @@
+<svg id="svg2" width="24" height="14.83" version="1.1" viewBox="0 0 24 14.83" xmlns="http://www.w3.org/2000/svg"><g id="g4" transform="translate(-315.44 -310.66)"><path id="path6" d="m315.44 322.66 2.83 2.83 9.17-9.17 9.17 9.17 2.83-2.83-12-12z" fill="#FF7100"/></g></svg>

--- a/res/skins/Tango/skin.xml
+++ b/res/skins/Tango/skin.xml
@@ -137,7 +137,7 @@
         background-color: #0f0f0f;
       }
       QLabel {
-        background-image: url(skin:/../Tango/graphics/logo_160x40.svg);
+        image: url(skin:../Tango/graphics/logo_160x40.svg);
         padding: 0;
         margin: 0px 2px 0px 2px;
         border: none;

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -146,11 +146,13 @@ WWidgetGroup {
   }
   #SkinSettingsClose {
     border-radius:2px;
-    background: transparent url(skin:/../Tango/buttons/btn_skinsettings_close.svg) no-repeat center top;
+    background-color: transparent;
+    image: url(skin:/../Tango/buttons/btn_skinsettings_close.svg) no-repeat center top;
     }
     #SkinSettingsClose:hover {
       border-radius:2px;
-      background: #0f0f0f url(skin:/../Tango/buttons/btn_skinsettings_close_hover.svg) no-repeat center top;
+      background-color: #0f0f0f;
+      image: url(skin:/../Tango/buttons/btn_skinsettings_close_hover.svg) no-repeat center top;
     }
 
 #SkinSettingsSeparator {
@@ -277,16 +279,16 @@ WWidgetGroup {
   }
 
 #MasterHeadMixerLabel {
-  background: url(skin:/../Tango/buttons/btn_master_head_mixer.svg) no-repeat center center;
+  image: url(skin:/../Tango/buttons/btn_master_head_mixer.svg) no-repeat center center;
   }
   #MasterMixerLabel {
-    background: url(skin:/../Tango/buttons/btn_master.svg) no-repeat center center;
+    image: url(skin:/../Tango/buttons/btn_master.svg) no-repeat center center;
   }
   #HeadphoneMixerLabel {
-    background: url(skin:/../Tango/buttons/btn_head.svg) no-repeat center center;
+    image: url(skin:/../Tango/buttons/btn_head.svg) no-repeat center center;
   }
 #BoothMixerLabel {
-  background: url(skin:/../Tango/buttons/btn_booth.svg) no-repeat center center;
+  image: url(skin:/../Tango/buttons/btn_booth.svg) no-repeat center center;
 }
 #MixerbarKnob {
   qproperty-layoutAlignment: 'AlignCenter';
@@ -359,7 +361,7 @@ WWidgetGroup {
     }
   #RecDot {
     background-color: transparent;  /*
-    background: url(skin:/../Tango/graphics/rec_dot.svg) no-repeat center center; */
+    image: url(skin:/../Tango/graphics/rec_dot.svg) no-repeat center center; */
     font-size: 12px/12px;
     margin: 2px 0px 0px 0px;
     }
@@ -391,36 +393,39 @@ WWidgetGroup {
 
 #BroadcastButton,
 #SkinSettingsToggler {
+  background-color: transparent;
   padding: 0px;
   margin: 0px;
   }
   #BroadcastButton[displayValue="0"] {
-    background: url(skin:/../Tango/buttons/btn_broadcast_off.svg) no-repeat center center;
+    image: url(skin:/../Tango/buttons/btn_broadcast_off.svg) no-repeat center center;
     }
     #BroadcastButton[displayValue="0"]:hover {
-      background: url(skin:/../Tango/buttons/btn_broadcast_off_hover.svg) no-repeat center center;
+      image: url(skin:/../Tango/buttons/btn_broadcast_off_hover.svg) no-repeat center center;
       }
   #BroadcastButton[displayValue="1"] {
-    background: url(skin:/../Tango/buttons/btn_broadcast_connecting.svg) no-repeat center center;
+    image: url(skin:/../Tango/buttons/btn_broadcast_connecting.svg) no-repeat center center;
     }
   #BroadcastButton[displayValue="2"] {
-    background: url(skin:/../Tango/buttons/btn_broadcast_connected.svg) no-repeat center center;
+    image: url(skin:/../Tango/buttons/btn_broadcast_connected.svg) no-repeat center center;
     }
   #BroadcastButton[displayValue="3"] {
-    background: url(skin:/../Tango/buttons/btn_broadcast_failure.svg) no-repeat center center;
+    image: url(skin:/../Tango/buttons/btn_broadcast_failure.svg) no-repeat center center;
     }
   #BroadcastButton[displayValue="4"] {
-    background: url(skin:/../Tango/buttons/btn_broadcast_warning.svg) no-repeat center center;
+    image: url(skin:/../Tango/buttons/btn_broadcast_warning.svg) no-repeat center center;
     }
     #BroadcastButton:hover {
       background-color: #0f0f0f;
     }
 
 #SkinSettingsToggler[displayValue="0"] {
-  background: transparent url(skin:/../Tango/buttons/btn_skinsettings_off.svg) no-repeat center center;
+  background-color: transparent;
+  image: url(skin:/../Tango/buttons/btn_skinsettings_off.svg) no-repeat center center;
   }
   #SkinSettingsToggler[displayValue="0"]:hover {
-    background: #0f0f0f url(skin:/../Tango/buttons/btn_skinsettings_on.svg) no-repeat center center;
+    background-color: #0f0f0f;
+    image: url(skin:/../Tango/buttons/btn_skinsettings_on.svg) no-repeat center center;
   }
 
 
@@ -455,40 +460,22 @@ WWidgetGroup {
   margin-left: -350px;  */
 }
 
-#BeatgridButtonToggler[displayValue="0"] {
-  background: #333 url(skin:/../Tango/buttons/btn_arrow_left.svg) no-repeat center center;
+#BeatgridButtonToggler {
+  background-color: #333;
+  }
+  #BeatgridButtonToggler[displayValue="0"] {
+    image: url(skin:/../Tango/buttons/btn_arrow_left.svg) no-repeat center center;
   }
   #BeatgridButtonToggler[displayValue="0"]:hover {
-    background: #333 url(skin:/../Tango/buttons/btn_arrow_left_hover.svg) no-repeat center center;
+    image: url(skin:/../Tango/buttons/btn_arrow_left_hover.svg) no-repeat center center;
   }
 #BeatgridButtonToggler[displayValue="1"] {
-  background: #333 url(skin:/../Tango/buttons/btn_arrow_right.svg) no-repeat center center;
-  }
+  image: url(skin:/../Tango/buttons/btn_arrow_right.svg) no-repeat center center;
+}
   #BeatgridButtonToggler[displayValue="1"]:hover {
-    background: #333 url(skin:/../Tango/buttons/btn_arrow_right_hover.svg) no-repeat center center;
+    image: url(skin:/../Tango/buttons/btn_arrow_right_hover.svg) no-repeat center center;
   }
 
-  #BeatgridCurpos {
-    background: url(skin:/../Tango/buttons/btn_beats_curpos.svg) no-repeat center center;
-  }
-  #BeatgridSlower {
-    background: url(skin:/../Tango/buttons/btn_beats_slower.svg) no-repeat center center;
-  }
-  #BeatgridFaster {
-    background: url(skin:/../Tango/buttons/btn_beats_faster.svg) no-repeat center center;
-  }
-  #BeatgridEarlier {
-    background: url(skin:/../Tango/buttons/btn_beats_earlier.svg) no-repeat center center;
-  }
-  #BeatgridLater {
-    background: url(skin:/../Tango/buttons/btn_beats_later.svg) no-repeat center center;
-  }
-  #HotcuesEarlier {
-    background: url(skin:/../Tango/buttons/btn_hotcues_earlier.svg) no-repeat center center;
-  }
-  #HotcuesLater {
-    background: url(skin:/../Tango/buttons/btn_hotcues_later.svg) no-repeat center center;
-  }
 #BeatgridCurpos,
 #BeatgridSlower,
 #BeatgridFaster,
@@ -505,7 +492,28 @@ WWidgetGroup {
   #BeatgridLater:hover,
   #HotcuesEarlier:hover,
   #HotcuesLater:hover {
-    background-color: #414141;
+    background-color: #0f0f0f;
+  }
+  #BeatgridCurpos {
+    image: url(skin:/../Tango/buttons/btn_beats_curpos.svg) no-repeat center center;
+  }
+  #BeatgridSlower {
+    image: url(skin:/../Tango/buttons/btn_beats_slower.svg) no-repeat center center;
+  }
+  #BeatgridFaster {
+    image: url(skin:/../Tango/buttons/btn_beats_faster.svg) no-repeat center center;
+  }
+  #BeatgridEarlier {
+    image: url(skin:/../Tango/buttons/btn_beats_earlier.svg) no-repeat center center;
+  }
+  #BeatgridLater {
+    image: url(skin:/../Tango/buttons/btn_beats_later.svg) no-repeat center center;
+  }
+  #HotcuesEarlier {
+    image: url(skin:/../Tango/buttons/btn_hotcues_earlier.svg) no-repeat center center;
+  }
+  #HotcuesLater {
+    image: url(skin:/../Tango/buttons/btn_hotcues_later.svg) no-repeat center center;
   }
 
 /*################################################################
@@ -522,10 +530,10 @@ WWidgetGroup {
   qproperty-layoutAlignment: 'AlignLeft | AlignTop';
   }
   #MicSectionIcon {
-    background: url(skin:/../Tango/buttons/btn_mic_section.svg) no-repeat center center;
+    image: url(skin:/../Tango/buttons/btn_mic_section.svg) no-repeat center center;
   }
   #AuxSectionLabel {
-    background: url(skin:/../Tango/buttons/btn_aux_section.svg) no-repeat center center;
+    image: url(skin:/../Tango/buttons/btn_aux_section.svg) no-repeat center center;
   }
 
 #MicUnit, #AuxUnit {
@@ -535,10 +543,10 @@ WWidgetGroup {
   padding-left: 2px;
   }
   #MicUnitIcon {
-    background: url(skin:/../Tango/buttons/btn_mic_unit.svg) no-repeat center left;
+    image: url(skin:/../Tango/buttons/btn_mic_unit.svg) no-repeat center left;
   }
   #AuxUnitIcon {
-    background: url(skin:/../Tango/buttons/btn_aux_unit.svg) no-repeat center left;
+    image: url(skin:/../Tango/buttons/btn_aux_unit.svg) no-repeat center left;
   }
   #MicUnitLabel, #AuxUnitLabel {
     padding-bottom: 8px;
@@ -638,42 +646,44 @@ WLabel#TrackComment {
   #VinylTogglerLeft[displayValue="0"],
   #VinylTogglerRightPassthrough[displayValue="1"],
   #VinylTogglerRight[displayValue="1"] {
-    background: url(skin:/../Tango/buttons/btn_vinyl_left.svg) no-repeat top center;
+    background-color: transparent;
+    image: url(skin:/../Tango/buttons/btn_vinyl_left.svg) no-repeat top center;
     }
     #VinylTogglerLeft[displayValue="0"]:hover,
     #VinylTogglerRightPassthrough[displayValue="1"]:hover,
     #VinylTogglerRight[displayValue="1"]:hover {
-      background: url(skin:/../Tango/buttons/btn_vinyl_left_hover.svg) no-repeat top center;
+      background-color: transparent;
+      image: url(skin:/../Tango/buttons/btn_vinyl_left_hover.svg) no-repeat top center;
     }
   #VinylTogglerLeft[displayValue="1"],
   #VinylTogglerLeftPassthrough[displayValue="1"],
   #VinylTogglerRight[displayValue="0"] {
-    background: url(skin:/../Tango/buttons/btn_vinyl_right.svg) no-repeat top center;
+    background-color: transparent;
+    image: url(skin:/../Tango/buttons/btn_vinyl_right.svg) no-repeat top center;
     }
     #VinylTogglerLeft[displayValue="1"]:hover,
     #VinylTogglerLeftPassthrough[displayValue="1"]:hover,
     #VinylTogglerRight[displayValue="0"]:hover {
-      background: url(skin:/../Tango/buttons/btn_vinyl_right_hover.svg) no-repeat top center;
+      background-color: transparent;
+      image: url(skin:/../Tango/buttons/btn_vinyl_right_hover.svg) no-repeat top center;
     }
   /* When passthrough is active but Vinyl Controls are hidden,
     yellow background indicates passthrough, similar to how
     the FX expand toggle does */
   #VinylTogglerLeftPassthrough[displayValue="0"] {
-    background: url(skin:/../Tango/buttons/btn_vinyl_pass_left.svg) no-repeat top center;
+    background: #00ffff;
+    image: url(skin:/../Tango/buttons/btn_vinyl_pass_left.svg) no-repeat top center;
     }
     #VinylTogglerLeftPassthrough[displayValue="0"]:hover {
-      background: url(skin:/../Tango/buttons/btn_vinyl_pass_left_hover.svg) no-repeat top center;
+      image: url(skin:/../Tango/buttons/btn_vinyl_pass_left_hover.svg) no-repeat top center;
     }
   #VinylTogglerRightPassthrough[displayValue="0"] {
-    background: url(skin:/../Tango/buttons/btn_vinyl_pass_right.svg) no-repeat top center;
+    background: #00ffff;
+    image: url(skin:/../Tango/buttons/btn_vinyl_pass_right.svg) no-repeat top center;
     }
     #VinylTogglerRightPassthrough[displayValue="0"]:hover {
-      background: url(skin:/../Tango/buttons/btn_vinyl_pass_right_hover.svg) no-repeat top center;
+      image: url(skin:/../Tango/buttons/btn_vinyl_pass_right_hover.svg) no-repeat top center;
     }
-  #VinylTogglerLeftPassthrough,
-  #VinylTogglerRightPassthrough {
-    background-color: #00ffff;
-  }
 
   #VinylControlButton,
   #VinylControlStatus,
@@ -790,7 +800,7 @@ WLabel#TrackComment {
     border: 1px solid #fff;
     }
     #LoopIndicator[displayValue="1"] {
-      background: url(skin:/../Tango/buttons/btn_reloop_on.svg) no-repeat center center;
+      image: url(skin:/../Tango/buttons/btn_reloop_on.svg) no-repeat center center;
     }
 
 #DeckRowTransport {
@@ -808,6 +818,16 @@ WLabel#TrackComment {
     border-radius: 0px;
   }
 
+#DeckControlsExpandedLeft,
+#DeckControlsExpandedRight,
+#DeckButton:hover,
+#DeckControlsToggle_Left[displayValue="1"],
+#DeckControlsToggle_Right[displayValue="1"] {
+  background-color: #151515;
+}
+#DeckButtonExpanded:hover {
+  background-color: #000;
+}
 #DeckControlsExpandedLeft {
   border-radius: 0px;
   border-top-right-radius: 3px;
@@ -829,53 +849,40 @@ WLabel#TrackComment {
 
   #DeckControlsToggle_Left[displayValue="0"],
   #MasterHeadMixerToggle[displayValue="0"] {
-    background: url(skin:/../Tango/buttons/btn_arrow_right.svg) no-repeat center center;
+    image: url(skin:/../Tango/buttons/btn_arrow_right.svg) no-repeat center center;
     }
     #DeckControlsToggle_Left[displayValue="0"]:hover,
     #MasterHeadMixerToggle[displayValue="0"]:hover {
-      background: url(skin:/../Tango/buttons/btn_arrow_right_hover.svg) no-repeat center center;
+      image: url(skin:/../Tango/buttons/btn_arrow_right_hover.svg) no-repeat center center;
     }
     #DeckControlsToggle_Left[displayValue="1"],
     #MasterHeadMixerToggle[displayValue="1"] {
-      background: url(skin:/../Tango/buttons/btn_arrow_left.svg) no-repeat center center;
+      image: url(skin:/../Tango/buttons/btn_arrow_left.svg) no-repeat center center;
     }
     #DeckControlsToggle_Left[displayValue="1"]:hover,
     #MasterHeadMixerToggle[displayValue="1"]:hover {
-      background: url(skin:/../Tango/buttons/btn_arrow_left_hover.svg) no-repeat center center;
+      image: url(skin:/../Tango/buttons/btn_arrow_left_hover.svg) no-repeat center center;
     }
 
   #DeckControlsToggle_Right[displayValue="0"] {
-    background: url(skin:/../Tango/buttons/btn_arrow_left.svg) no-repeat center center;
+    image: url(skin:/../Tango/buttons/btn_arrow_left.svg) no-repeat center center;
     }
     #DeckControlsToggle_Right[displayValue="0"]:hover {
-      background: url(skin:/../Tango/buttons/btn_arrow_left_hover.svg) no-repeat center center;
+      image: url(skin:/../Tango/buttons/btn_arrow_left_hover.svg) no-repeat center center;
     }
     #DeckControlsToggle_Right[displayValue="1"] {
-      background: url(skin:/../Tango/buttons/btn_arrow_right.svg) no-repeat center center;
+      image: url(skin:/../Tango/buttons/btn_arrow_right.svg) no-repeat center center;
     }
     #DeckControlsToggle_Right[displayValue="1"]:hover {
-      background: url(skin:/../Tango/buttons/btn_arrow_right_hover.svg) no-repeat center center;
+      image: url(skin:/../Tango/buttons/btn_arrow_right_hover.svg) no-repeat center center;
     }
-
-  #DeckControlsExpandedLeft,
-  #DeckControlsExpandedRight,
-  #DeckButton:hover,
-  #DeckControlsToggle_Left[displayValue="1"],
-  #DeckControlsToggle_Right[displayValue="1"]
-  #DeckControlsToggle_Left[displayValue="1"]:hover,
-  #DeckControlsToggle_Right[displayValue="1"]:hover,
-  #DeckStars:hover {
-    background-color: #151515;
-  }
-  #DeckButtonExpanded:hover {
-    background-color: #000;
-  }
 
   #Keylock[displayValue="1"]:hover {
     border: 1px solid #d2d2d2;
   }
 
   #DeckStars:hover {
+    background-color: #151515;
     border-radius: 2px;
     }
   /* Starrating in deck_buttons.xml for loaded tracks */
@@ -896,18 +903,18 @@ WLabel#TrackComment {
   background-color: transparent;
   }
   #SamplerPlayCueUnderlay[displayValue="1"] {
-    background-color: #a90000;
+    background: #a90000;
   }
 
 #PassthroughPlayCover {
   background-color: transparent;
-  background: url(skin:/../Tango/buttons/btn_mic_aux_mute.svg) no-repeat center center;
+  image: url(skin:/../Tango/buttons/btn_mic_aux_mute.svg) no-repeat center center;
 }
 
 #MicTalkover,
 #AuxEnable {
   background-color: transparent;
-  background: url(skin:/../Tango/buttons/btn_mic_aux_mute.svg) no-repeat center center;
+  image: url(skin:/../Tango/buttons/btn_mic_aux_mute.svg) no-repeat center center;
 }
 
 #PlayCue[displayValue="0"]:hover,
@@ -1114,32 +1121,6 @@ WBeatSpinBox,
   }
 
   WBeatSpinBox::up-button,
-  #spinBoxTransition::up-button {
-    subcontrol-position: center right;
-    /* Note(ronso0):
-    Regularly, up/down buttons would be stacked vertically.
-    Here, they're both aligned 'center right' and have the same size.
-    This would make them overlap so we need to move one of those two
-    buttons out of the way: */
-    right: -16px;
-    background: url(skin:/../Tango/buttons/btn_beatbox_up.svg) no-repeat center center;
-    }
-    WBeatSpinBox::up-button:hover,
-    #spinBoxTransition::up-button:hover {
-      background: url(skin:/../Tango/buttons/btn_beatbox_up_hover.svg) no-repeat center center;
-    }
-  WBeatSpinBox::down-button,
-  #spinBoxTransition::down-button {
-    subcontrol-position: center right;
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
-    background: url(skin:/../Tango/buttons/btn_beatbox_down.svg) no-repeat center center;
-    }
-    WBeatSpinBox::down-button:hover,
-    #spinBoxTransition::down-button:hover {
-      background: url(skin:/../Tango/buttons/btn_beatbox_down_hover.svg) no-repeat center center;
-    }
-  WBeatSpinBox::up-button,
   WBeatSpinBox::down-button,
   #spinBoxTransition::up-button,
   #spinBoxTransition::down-button {
@@ -1148,8 +1129,6 @@ WBeatSpinBox,
     background-color: #1e1e1e;
     border: 1px solid #1e1e1e;
     border-width: 1px 0px 1px 0px;
-    width: 16px;
-    height: 20px;
     }
     WBeatSpinBox::up-button:hover,
     WBeatSpinBox::down-button:hover,
@@ -1157,6 +1136,33 @@ WBeatSpinBox,
     #spinBoxTransition::down-button:hover {
       background-color: #0f0f0f;
       }
+
+  WBeatSpinBox::up-button,
+  #spinBoxTransition::up-button {
+    subcontrol-position: center right;
+    /* Note(ronso0):
+    Regularly, up/down buttons would be stacked vertically.
+    Here, they're both aligned 'center right' and have the same size.
+    This would make them overlap so we need to move one of those two
+    buttons out of the way: */
+    right: -16px;
+    image: url(skin:/../Tango/buttons/btn_beatbox_up.svg) no-repeat;
+    }
+    WBeatSpinBox::up-button:hover,
+    #spinBoxTransition::up-button:hover {
+      image: url(skin:/../Tango/buttons/btn_beatbox_up_hover.svg) no-repeat;
+    }
+  WBeatSpinBox::down-button,
+  #spinBoxTransition::down-button {
+    subcontrol-position: center right;
+    border-top-left-radius: 3px;
+    border-bottom-left-radius: 3px;
+    image: url(skin:/../Tango/buttons/btn_beatbox_down.svg) no-repeat;
+    }
+    WBeatSpinBox::down-button:hover,
+    #spinBoxTransition::down-button:hover {
+      image: url(skin:/../Tango/buttons/btn_beatbox_down_hover.svg) no-repeat;
+    }
 
 /*################################################################
  #######  Rate Container  #######################################
@@ -1181,6 +1187,13 @@ WBeatSpinBox,
   /*margin-top: 1px;*/
 }
 
+#Bpm, #KeyDisplayMatch,
+#RateUp, #RateDown,
+#KeyUp, #KeyDown,
+#PitchSliderGroup {
+  background-color: #252525;
+  border-radius: 3px;
+}
 #BpmLabel,
 #BpmLabelMini {
   qproperty-alignment: 'AlignHCenter | AlignVCenter';
@@ -1189,63 +1202,16 @@ WBeatSpinBox,
   text-align: center;
   padding-top: 1px;
   }
+  #BpmLabel {
+    background-color: #252525;
+  }
+  #BpmLabelMini {
+    background-color: #252525;
+  }
   #SyncButtonOverlay[displayValue="0"]:hover,
   #SyncButtonOverlayMini[displayValue="0"]:hover {
-    background: url(skin:/../Tango/buttons/btn_key_match_hover.svg) no-repeat center center;
+    image: url(skin:/../Tango/buttons/btn_key_match_hover.svg) no-repeat center center;
   }
-
-  #RateUp {
-    background: url(skin:/../Tango/buttons/btn_rate_up.svg) no-repeat center center;
-    }
-    #RateUp:hover {
-      background: url(skin:/../Tango/buttons/btn_rate_up_hover.svg) no-repeat center center;
-    }
-  #RateDown {
-    background: url(skin:/../Tango/buttons/btn_rate_down.svg) no-repeat center center;
-    }
-    #RateDown:hover {
-      background: url(skin:/../Tango/buttons/btn_rate_down_hover.svg) no-repeat center center;
-    }
-
-  #KeyDisplay, #KeyDisplayMini {
-    font-size: 14px/14px;
-  }
-  #KeyDisplay {
-    padding: 0px;
-  }
-  #KeyDisplayMini {
-    padding: 0px 0px 0px 0px;
-  }
-  #KeyMatch {
-    border: 1px solid #444;
-  }
-    #KeyMatch:hover,
-    #KeyMatchMini:hover {
-      background: url(skin:/../Tango/buttons/btn_key_match_hover.svg) no-repeat center center;
-    }
-    #KeyUp {
-      background: url(skin:/../Tango/buttons/btn_key_up.svg) no-repeat center center;
-      }
-      #KeyUp:hover {
-        background: url(skin:/../Tango/buttons/btn_key_up_hover.svg) no-repeat center center;
-      }
-    #KeyDown {
-      background: url(skin:/../Tango/buttons/btn_key_down.svg) no-repeat center center;
-      }
-      #KeyDown:hover {
-        background: url(skin:/../Tango/buttons/btn_key_down_hover.svg) no-repeat center center;
-      }
-  #Bpm, #KeyDisplayMatch,
-  #RateUp, #RateDown,
-  #KeyUp, #KeyDown,
-  #PitchSliderGroup {
-    background-color: #252525;
-    border-radius: 3px;
-    }
-    #RateUp:hover, #RateDown:hover,
-    #KeyUp:hover, #KeyDown:hover {
-      background-color: #333;
-    }
   #SyncButtonOverlay[displayValue="0"] {
     border: 1px solid #444;
   }
@@ -1273,12 +1239,52 @@ WBeatSpinBox,
   #SamplerSyncButton[displayValue="1"]:hover {
     border: 1px solid #eeeeee;
   }
-  #BpmLabel {
-    background-color: #252525;
+
+    #RateUp:hover, #RateDown:hover,
+    #KeyUp:hover, #KeyDown:hover {
+      background-color: #333;
+    }
+  #RateUp {
+    image: url(skin:/../Tango/buttons/btn_rate_up.svg) no-repeat center center;
+    }
+    #RateUp:hover {
+      image: url(skin:/../Tango/buttons/btn_rate_up_hover.svg) no-repeat center center;
+    }
+  #RateDown {
+    image: url(skin:/../Tango/buttons/btn_rate_down.svg) no-repeat center center;
+    }
+    #RateDown:hover {
+      image: url(skin:/../Tango/buttons/btn_rate_down_hover.svg) no-repeat center center;
+    }
+
+  #KeyDisplay, #KeyDisplayMini {
+    font-size: 14px/14px;
   }
-  #BpmLabelMini {
-    background-color: #252525;
+  #KeyDisplay {
+    padding: 0px;
   }
+  #KeyDisplayMini {
+    padding: 0px 0px 0px 0px;
+  }
+  #KeyMatch {
+    border: 1px solid #444;
+  }
+    #KeyMatch:hover,
+    #KeyMatchMini:hover {
+      image: url(skin:/../Tango/buttons/btn_key_match_hover.svg) no-repeat center center;
+    }
+    #KeyUp {
+      image: url(skin:/../Tango/buttons/btn_key_up.svg) no-repeat center center;
+      }
+      #KeyUp:hover {
+        image: url(skin:/../Tango/buttons/btn_key_up_hover.svg) no-repeat center center;
+      }
+    #KeyDown {
+      image: url(skin:/../Tango/buttons/btn_key_down.svg) no-repeat center center;
+      }
+      #KeyDown:hover {
+        image: url(skin:/../Tango/buttons/btn_key_down_hover.svg) no-repeat center center;
+      }
 
 
 /* ################################################################
@@ -1374,10 +1380,10 @@ WLabel#TrackComment {
 
 /* Kill indicators underneath EQ knobs */
 #EQKilledUnderlay[displayValue="1"] {
-  background: url(skin:/../Tango/knobs_sliders/knob_eq_killed.svg) no-repeat center center;
+  image: url(skin:/../Tango/knobs_sliders/knob_eq_killed.svg) no-repeat center center;
 }
 #QuickFxDisabledUnderlay[displayValue="0"] {
-  background: url(skin:/../Tango/knobs_sliders/knob_quickFX_disabled.svg) no-repeat center center;
+  image: url(skin:/../Tango/knobs_sliders/knob_quickFX_disabled.svg) no-repeat center center;
 }
 
 #QuickFXSide {
@@ -1409,7 +1415,7 @@ WLabel#TrackComment {
   This is a workaround to scale and center the image, but image would appear blurred
   if it is scaled up too much (>120). Source:
   https://forum.qt.io/topic/40151/solved-scaled-background-image-using-stylesheet/6
-  border-background: url(skin:/../Tango/buttons/btn_pfl_off.svg) 0 0 0 0 stretch stretch; */
+  border-image: url(skin:/../Tango/buttons/btn_pfl_off.svg) 0 0 0 0 stretch stretch; */
 #PflBoxLeft,
 #PflBoxRight {
   background-color: #0f0f0f;
@@ -1487,19 +1493,19 @@ decks, samplers, mic, aux, fx */
   }
 
 #VUMeterLabelMaster {
-  background: url(skin:/../Tango/buttons/btn_master_vu_label.svg) no-repeat center center;
+  image: url(skin:/../Tango/buttons/btn_master_vu_label.svg) no-repeat center center;
 }
 #VUMeterLabelDeck1 {
-  background: url(skin:/../Tango/buttons/btn_deck1_vu_label.svg) no-repeat center center;
+  image: url(skin:/../Tango/buttons/btn_deck1_vu_label.svg) no-repeat center center;
 }
 #VUMeterLabelDeck2 {
-  background: url(skin:/../Tango/buttons/btn_deck2_vu_label.svg) no-repeat center center;
+  image: url(skin:/../Tango/buttons/btn_deck2_vu_label.svg) no-repeat center center;
 }
 #VUMeterLabelDeck3 {
-  background: url(skin:/../Tango/buttons/btn_deck3_vu_label.svg) no-repeat center center;
+  image: url(skin:/../Tango/buttons/btn_deck3_vu_label.svg) no-repeat center center;
 }
 #VUMeterLabelDeck4 {
-  background: url(skin:/../Tango/buttons/btn_deck4_vu_label.svg) no-repeat center center;
+  image: url(skin:/../Tango/buttons/btn_deck4_vu_label.svg) no-repeat center center;
 }
 
 
@@ -1588,12 +1594,12 @@ decks, samplers, mic, aux, fx */
 /* no focus */
 #FxFlow_mini_separator {
   background-color: transparent;
-  background: url(skin:/../Tango/graphics/fxFlow_mini_noFocus_Fx1-2-3.svg) no-repeat center center;
+  image: url(skin:/../Tango/graphics/fxFlow_mini_noFocus_Fx1-2-3.svg) no-repeat center center;
 }
 #FxFlow_maxi_separator {
   background-color: transparent;
   border-radius: 0px;
-  background: url(skin:/../Tango/graphics/fxFlow_maxi_noFocus_Fx1-2-3.svg) no-repeat right center;
+  image: url(skin:/../Tango/graphics/fxFlow_maxi_noFocus_Fx1-2-3.svg) no-repeat right center;
 }
 
 #FxFlow_focus_background,
@@ -1604,22 +1610,25 @@ decks, samplers, mic, aux, fx */
   }
   #FxFlow_focus_background[highlight="1"] {
     background-color: transparent;
-    border-radius: 0px;
+  border-radius: 0px;
   }
 /* collapsed effect slots, horizontal layout */
 #FxFlow_mini_focus_separator1-2[highlight="0"],
 #FxFlow_mini_focus_separator1-2[highlight="3"],
 #FxFlow_mini_focus_separator2-3[highlight="0"],
 #FxFlow_mini_focus_separator2-3[highlight="1"] {
-  background: transparent url(skin:/../Tango/graphics/fxFlow_mini_noFocus_Fx1-2-3.svg) no-repeat center center;
+  background-color: transparent;
+  image: url(skin:/../Tango/graphics/fxFlow_mini_noFocus_Fx1-2-3.svg) no-repeat center center;
   }
   #FxFlow_mini_focus_separator1-2[highlight="1"],
   #FxFlow_mini_focus_separator2-3[highlight="2"] {
-    background: transparent url(skin:/../Tango/graphics/fxFlow_mini_focus_left.svg) no-repeat center center;
+    background-color: transparent;
+    image: url(skin:/../Tango/graphics/fxFlow_mini_focus_left.svg) no-repeat center center;
   }
   #FxFlow_mini_focus_separator1-2[highlight="2"],
   #FxFlow_mini_focus_separator2-3[highlight="3"] {
-    background: transparent url(skin:/../Tango/graphics/fxFlow_mini_focus_right.svg) no-repeat center center;
+    background-color: transparent;
+    image: url(skin:/../Tango/graphics/fxFlow_mini_focus_right.svg) no-repeat center center;
   }
 
 /* expanded effect slots, vertical layout */
@@ -1627,31 +1636,35 @@ decks, samplers, mic, aux, fx */
 #FxFlow_maxi_focus_separator1-2[highlight="3"],
 #FxFlow_maxi_focus_separator2-3[highlight="0"],
 #FxFlow_maxi_focus_separator2-3[highlight="1"] {
-  background: transparent url(skin:/../Tango/graphics/fxFlow_maxi_noFocus_Fx1-2-3.svg) no-repeat center center;
+  background-color: transparent;
+  image: url(skin:/../Tango/graphics/fxFlow_maxi_noFocus_Fx1-2-3.svg) no-repeat center center;
   }
   #FxFlow_maxi_focus_separator1-2[highlight="1"],
   #FxFlow_maxi_focus_separator2-3[highlight="2"] {
-    background: transparent url(skin:/../Tango/graphics/fxFlow_maxi_focus_top.svg) no-repeat center center;
+    background-color: transparent;
+    image: url(skin:/../Tango/graphics/fxFlow_maxi_focus_top.svg) no-repeat center center;
   }
   #FxFlow_maxi_focus_separator1-2[highlight="2"],
   #FxFlow_maxi_focus_separator2-3[highlight="3"] {
-    background: transparent url(skin:/../Tango/graphics/fxFlow_maxi_focus_bottom.svg) no-repeat center center;
+    background-color: transparent;
+    image: url(skin:/../Tango/graphics/fxFlow_maxi_focus_bottom.svg) no-repeat center center;
   }
 /* /effect slot focus indicators */
 
 #FxFocusButton {
+  background-color: transparent;
 }
   #FxFocusButton[displayValue="0"] {
-    background: transparent url(skin:/../Tango/buttons/btn_fx_focus_off.svg) no-repeat center center;
+    image: url(skin:/../Tango/buttons/btn_fx_focus_off.svg) no-repeat center center;
     }
     #FxFocusButton[displayValue="0"]:hover {
-      background: transparent url(skin:/../Tango/buttons/btn_fx_focus_off_hover.svg) no-repeat center center;
+      image: url(skin:/../Tango/buttons/btn_fx_focus_off_hover.svg) no-repeat center center;
     }
   #FxFocusButton[displayValue="1"] {
-    background: transparent url(skin:/../Tango/buttons/btn_fx_focus_on.svg) no-repeat center center;
+    image: url(skin:/../Tango/buttons/btn_fx_focus_on.svg) no-repeat center center;
     }
     #FxFocusButton[displayValue="1"]:hover {
-      background: transparent url(skin:/../Tango/buttons/btn_fx_focus_on_hover.svg) no-repeat center center;
+      image: url(skin:/../Tango/buttons/btn_fx_focus_on_hover.svg) no-repeat center center;
     }
 
 #FxMetaknob {
@@ -1730,11 +1743,11 @@ decks, samplers, mic, aux, fx */
       background-color: #101010;
       width: 11px;
       height: 20px; */
-      background: url(skin:/../Tango/buttons/btn_fx_selector_list.svg) no-repeat center center;
+      image: url(skin:/../Tango/buttons/btn_fx_selector_list.svg) no-repeat center center;
       }
       WEffectSelector::down-arrow:hover,
       #fadeModeCombobox::down-arrow:hover {
-        background: url(skin:/../Tango/buttons/btn_fx_selector_list_hover.svg) no-repeat center center;
+        image: url(skin:/../Tango/buttons/btn_fx_selector_list_hover.svg) no-repeat center center;
       }
 
     WEffectSelector QAbstractScrollArea,
@@ -1773,13 +1786,13 @@ decks, samplers, mic, aux, fx */
       /* Image is rendered correctly but size of the tick mark containers
       won't change. Also, only with this option the hover bg color defined
       above will be applied... it's qt magic
-      background-color: #0081B7; */
+      background: #0081B7; */
       margin: 3px;
-      background: url(skin:/../Tango/buttons/btn_lib_checkmark_white.svg) no-repeat center center;
+      image: url(skin:/../Tango/buttons/btn_lib_checkmark_white.svg) no-repeat center center;
     }
     WEffectSelector::indicator:!checked,
     #fadeModeCombobox::indicator:!checked {
-      background: url(skin:/../Tango/buttons/btn_.svg) no-repeat center center;
+      image: url(skin:/../Tango/buttons/btn_.svg) no-repeat center center;
     }
 
 #FxParametersLeft {
@@ -1951,6 +1964,7 @@ styled differently because of their importance */
   }
   #FxMasterButton[displayValue="0"] {
     color: #888;
+    background: #1e1e1e;
     }
     #FxMasterButton[displayValue="0"]:hover {
       border: 1px solid #ff8f00;
@@ -2476,16 +2490,16 @@ WTrackMenu QMenu QCheckBox::indicator {
 #LibMiniMaxiButton {
   }
   #LibMiniMaxiButton[displayValue="0"] {
-    background: url(skin:/../Tango/buttons/btn_lib_maxi.svg) no-repeat center top;
+    image: url(skin:/../Tango/buttons/btn_lib_maxi.svg) no-repeat center top;
     }
     #LibMiniMaxiButton[displayValue="0"]:hover {
-      background: url(skin:/../Tango/buttons/btn_lib_maxi_hover.svg) no-repeat center top;
+      image: url(skin:/../Tango/buttons/btn_lib_maxi_hover.svg) no-repeat center top;
     }
   #LibMiniMaxiButton[displayValue="1"] {
-    background: url(skin:/../Tango/buttons/btn_lib_mini.svg) no-repeat center top;
+    image: url(skin:/../Tango/buttons/btn_lib_mini.svg) no-repeat center top;
     }
     #LibMiniMaxiButton[displayValue="1"]:hover {
-      background: url(skin:/../Tango/buttons/btn_lib_mini_hover.svg) no-repeat center top;
+      image: url(skin:/../Tango/buttons/btn_lib_mini_hover.svg) no-repeat center top;
     }
 
 #LibraryContainer QTableView,
@@ -2626,19 +2640,29 @@ WTrackTableView {
     border-radius: 0px;
   }
 
-  #LibraryContainer QHeaderView::up-arrow {
-    background: url(skin:/../Tango/buttons/btn_library_sort_up.svg) no-repeat center center;
-  }
-  #LibraryContainer QHeaderView::down-arrow {
-    background: url(skin:/../Tango/buttons/btn_library_sort_down.svg) no-repeat center center;
-  }
   #LibraryContainer QHeaderView::up-arrow,
   #LibraryContainer QHeaderView::down-arrow {
-    width: 1.0em;
-    height: 0.67em;
-    margin-right: 0.2em;
+    width: 12px;
+    padding-right: 2px;
+    border-right: 1px solid #585858;
     background-color: rgba(51,51,51,200);
     }
+    #LibraryContainer QHeaderView::up-arrow:hover,
+    #LibraryContainer QHeaderView::down-arrow:hover {
+      background-color: rgba(88,88,88,200);
+    }
+    #LibraryContainer QHeaderView::up-arrow {
+      image: url(skin:/../Tango/graphics/library_sort_up.svg);
+      }
+      #LibraryContainer QHeaderView::up-arrow:hover {
+        image: url(skin:/../Tango/graphics/library_sort_down.svg);
+      }
+    #LibraryContainer QHeaderView::down-arrow {
+      image: url(skin:/../Tango/graphics/library_sort_down.svg);
+      }
+      #LibraryContainer QHeaderView::down-arrow:hover {
+        image: url(skin:/../Tango/graphics/library_sort_up.svg);
+      }
 
 QTextBrowser {
   padding-left: 5px;
@@ -2655,7 +2679,7 @@ WEffectSelector QAbstractScrollArea QScrollBar:horizontal,
 #fadeModeCombobox QAbstractScrollArea QScrollBar:horizontal {
   min-width: 12px;
   height: 10px;
-  background-color: #000;
+  background: #000;
   border-radius: 2px;
   }
   #LibraryContainer QScrollBar:vertical,
@@ -2663,7 +2687,7 @@ WEffectSelector QAbstractScrollArea QScrollBar:horizontal,
   #fadeModeCombobox QAbstractScrollArea QScrollBar:vertical {
     min-height: 12px;
     width: 10px;
-    background-color: #000;
+    background: #000;
     border-radius: 2px;
     }
   /* "add-page" and "sub-page" are the gutter of the scrollbar */
@@ -2681,25 +2705,25 @@ WEffectSelector QAbstractScrollArea QScrollBar:horizontal,
   WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal,
   #fadeModeCombobox QAbstractScrollArea QScrollBar::handle:horizontal {
     min-width: 25px;
-    background-color: #595959;
+    background: #595959;
     border-radius:2px;
     }
     #LibraryContainer QScrollBar::handle:horizontal:hover,
     WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal:hover,
     #fadeModeCombobox QAbstractScrollArea QScrollBar::handle:horizontal:hover {
-      background-color: #888;
+      background: #888;
     }
   #LibraryContainer QScrollBar::handle:vertical,
   WEffectSelector QAbstractScrollArea QScrollBar::handle:vertical,
   #fadeModeCombobox QAbstractScrollArea QScrollBar::handle:vertical {
     min-height: 25px;
-    background-color: #595959;
+    background: #595959;
     border-radius:2px;
     }
     #LibraryContainer QScrollBar::handle:vertical:hover,
     WEffectSelector QAbstractScrollArea QScrollBar::handle:vertical:hover,
     #fadeModeCombobox QAbstractScrollArea QScrollBar::handle:vertical:hover {
-      background-color: #888;
+      background: #888;
     }
   /* Turn off scroll buttons */
   #LibraryContainer QScrollBar::add-line:horizontal,
@@ -2761,13 +2785,20 @@ Library features and their buttons:
 #LibraryFeatureControls QPushButton {
   text-align: center;
   font-weight: normal;
+  /* Note(ronso0)
+  Interferes with skin scaling, system font size respectively
+  font-size: 14px/14px;
+  Setting height/width here will prevent the buttons being scaled properly
+  min-height: 22px;
+  max-height: 22px;
+  height: 22px; */
   color: #ccc;
   border-radius: 2px;
   border: 1px solid #333;
   margin: 1px 2px 4px 1px;
   padding: 3px 6px 3px 6px;
-  background-position: center center;
-  background-repeat: no-repeat;
+  background-color: #333;
+  background-position: center;
   }
   #DlgAutoDJ > #LibraryFeatureControls QPushButton {
     padding: 1px 2px;
@@ -2776,6 +2807,43 @@ Library features and their buttons:
   }
   #pushButtonAutoDJ {
     width: 42px;
+  }
+
+  #LibraryFeatureControls QPushButton:!enabled {
+    color: #888;
+    }
+  #LibraryFeatureControls QPushButton:hover,
+  #fadeModeCombobox:hover {
+    border: 1px solid #888;
+    }
+  #LibraryFeatureControls QPushButton:unchecked {
+    color: #888;
+    background-color: #444;
+    }
+  #LibraryFeatureControls QPushButton:checked {
+    color: #000;
+    background-color: #ff7b00;
+    }
+  #LibraryFeatureControls QPushButton:checked:hover {
+    border: 1px solid #fff;
+    }
+  QPushButton#pushButtonRecording:unchecked {
+    color: #888;
+    background-color: #444;
+    border: 1px solid #444;
+  }
+  QPushButton#pushButtonAutoDJ:checked {
+    border: 1px solid #ff9900;
+  }
+  QPushButton#pushButtonRepeatPlaylist:checked {
+    background-color: #888;
+    border: 1px solid #bbb;
+  }
+  QPushButton#pushButtonRecording:unchecked:hover,
+  QPushButton#pushButtonRecording:checked {
+    color: #dddddd;
+    background-color: #a90000;
+    border: 1px solid #ca0000;
   }
 
   /* make library action buttons bold */
@@ -2803,79 +2871,36 @@ Library features and their buttons:
 
 /* AutoDJ button icons */
 QPushButton#pushButtonAutoDJ:!checked {
-  background-image: url(skin:/../Tango/buttons/btn_autodj_enable_off.svg);
+  image: url(skin:/../Tango/buttons/btn_autodj_enable_off.svg) no-repeat center center;
   }
   QPushButton#pushButtonAutoDJ:checked {
-    background-image: url(skin:/../Tango/buttons/btn_autodj_enable_on.svg);
+    image: url(skin:/../Tango/buttons/btn_autodj_enable_on.svg) no-repeat center center;
   }
 QPushButton#pushButtonFadeNow:!enabled {
-  background-image: url(skin:/../Tango/buttons/btn_autodj_fade_disabled.svg);
+  image: url(skin:/../Tango/buttons/btn_autodj_fade_disabled.svg) no-repeat center center;
   }
   QPushButton#pushButtonFadeNow:enabled {
-    background-image: url(skin:/../Tango/buttons/btn_autodj_fade.svg);
+    image: url(skin:/../Tango/buttons/btn_autodj_fade.svg) no-repeat center center;
   }
 QPushButton#pushButtonSkipNext:!enabled {
-  background-image: url(skin:/../Tango/buttons/btn_autodj_skip_disabled.svg);
+  image: url(skin:/../Tango/buttons/btn_autodj_skip_disabled.svg) no-repeat center center;
   }
   QPushButton#pushButtonSkipNext:enabled {
-    background-image: url(skin:/../Tango/buttons/btn_autodj_skip.svg);
+    image: url(skin:/../Tango/buttons/btn_autodj_skip.svg) no-repeat center center;
   }
 QPushButton#pushButtonShuffle {
-  background-image: url(skin:/../Tango/buttons/btn_autodj_shuffle.svg);
+  image: url(skin:/../Tango/buttons/btn_autodj_shuffle.svg) no-repeat center center;
 }
 QPushButton#pushButtonAddRandom {
-  background-image: url(skin:/../Tango/buttons/btn_autodj_addrandom.svg);
+  image: url(skin:/../Tango/buttons/btn_autodj_addrandom.svg) no-repeat center center;
 }
 QPushButton#pushButtonRepeatPlaylist:!checked {
-  background-image: url(skin:/../Tango/buttons/btn_autodj_repeat_playlist_off.svg);
+  image: url(skin:/../Tango/buttons/btn_autodj_repeat_playlist_off.svg) no-repeat center center;
   }
   QPushButton#pushButtonRepeatPlaylist:checked {
-    background-image: url(skin:/../Tango/buttons/btn_autodj_repeat_playlist_on.svg);
+    image: url(skin:/../Tango/buttons/btn_autodj_repeat_playlist_on.svg) no-repeat center center;
   }
 /* AutoDJ button icons */
-
-#LibraryFeatureControls QPushButton {
-  background-color: #333;
-  }
-#LibraryFeatureControls QPushButton:!enabled {
-  color: #888;
-  }
-#LibraryFeatureControls QPushButton:hover,
-#fadeModeCombobox:hover {
-  border: 1px solid #888;
-  }
-#LibraryFeatureControls QPushButton:unchecked {
-  color: #888;
-  background-color: #444;
-  }
-#LibraryFeatureControls QPushButton:checked {
-  color: #000;
-  background-color: #ff7b00;
-  }
-#LibraryFeatureControls QPushButton:checked:hover {
-  border: 1px solid #fff;
-  }
-#LibraryFeatureControls QPushButton:pressed {
-  background-color: #444;
-  }
-QPushButton#pushButtonRecording:unchecked {
-  color: #888;
-  background-color: #444;
-  border: 1px solid #444;
-}
-QPushButton#pushButtonAutoDJ:checked {
-  border: 1px solid #ff9900;
-}
-QPushButton#pushButtonRepeatPlaylist:checked {
-  background-color: #888;
-  border: 1px solid #bbb;
-}
-QPushButton#pushButtonRecording:unchecked:hover,
-QPushButton#pushButtonRecording:checked {
-  color: #dddddd;
-  background-color: #a90000;
-  border: 1px solid #ca0000;
-}
 
   /* align/center AutoDJ transition label vertically with spinbox */
   QLabel#labelTransitionAppendix {
@@ -2917,29 +2942,33 @@ QPushButton#pushButtonRecording:checked {
   margin: 0px;
   border-left: 0px;
   }
-  #LibraryBPMSpinBox::up-button {
-    background: #0f0f0f url(skin:/../Tango/buttons/btn_lib_spinbox_up_white.svg) no-repeat;
-    }
+  #LibraryBPMSpinBox::up-button,
   #LibraryBPMSpinBox::down-button {
-    background: #0f0f0f url(skin:/../Tango/buttons/btn_lib_spinbox_down_white.svg) no-repeat;
-  }
+    background-color: #0f0f0f;
+    }
+    #LibraryBPMSpinBox::up-button {
+      image: url(skin:/../Tango/buttons/btn_lib_spinbox_up_white.svg) no-repeat;
+      }
+    #LibraryBPMSpinBox::down-button {
+      image: url(skin:/../Tango/buttons/btn_lib_spinbox_down_white.svg) no-repeat;
+    }
 
   /* Button in library "Preview" column */
   #LibraryPreviewButton {
+    background: transparent;
     margin: 0px;
-    padding: 3px;
+    padding: 0px;
     border: 1px solid transparent;
     }
     #LibraryPreviewButton:!checked {
-    /* TODO ronso0 Restore once fixed lib linKIconThemes (vers. <..80) is in *ubuntu main repos */
-    /*  image: url(skin:/../Tango/buttons/btn_lib_preview_play.svg); */
+      image: url(skin:/../Tango/buttons/btn_lib_preview_play.svg);
       }
       #LibraryPreviewButton:!checked:hover {
         border: 1px solid #888;
-        background-color: #0f0f0f;
+        background: #0f0f0f;
       }
     #LibraryPreviewButton:checked {
-    /*  background: url(skin:/../Tango/buttons/btn_lib_preview_pause.svg); */
+      image: url(skin:/../Tango/buttons/btn_lib_preview_pause.svg);
       background-color: #000;
       border: 1px solid #555;
       }
@@ -2955,7 +2984,7 @@ QPushButton#pushButtonRecording:checked {
     #LibraryPreviewButton::item,
     #LibraryPreviewButton::item:selected,
     #LibraryPreviewButton:focus {
-      background-color: #451212;
+      background: #451212;
     }*/
 
   /* checkbox in library "Played" column */
@@ -2972,7 +3001,7 @@ QPushButton#pushButtonRecording:checked {
       border: 1px solid #888;
     }
   #LibraryContainer QTableView::indicator:checked {
-    background: url(skin:/../Tango/buttons/btn_lib_checkmark.svg);
+    image: url(skin:/../Tango/buttons/btn_lib_checkmark.svg);
     }
   #LibraryContainer QTableView::indicator:unchecked {
     background: none;
@@ -3023,11 +3052,11 @@ QRadioButton#radioButtonRecentlyAdded {
 }
 
 WLibrary QRadioButton::indicator:checked {
-  background: url(skin:/../Tango/buttons/btn_lib_radio_button_on.svg) center center;
+  image: url(skin:/../Tango/buttons/btn_lib_radio_button_on.svg) center center;
 }
 
 WLibrary QRadioButton::indicator:unchecked {
-  background: url(skin:/../Tango/buttons/btn_lib_radio_button_off.svg) center center;
+  image: url(skin:/../Tango/buttons/btn_lib_radio_button_off.svg) center center;
 }
 
 /* explicitly remove icons from unchecked items otherwise

--- a/res/skins/default.qss
+++ b/res/skins/default.qss
@@ -1,16 +1,14 @@
 /* Style the library preview button with a default image */
 #LibraryPreviewButton {
-  /* TODO ronso0 Restore once fixed lib linKIconThemes (vers. <..80) is in *ubuntu main repos */
-  /*background: transparent; border: 0;*/
+  background: transparent; border: 0;
 }
 
 #LibraryPreviewButton:checked {
-  /* TODO ronso0 Restore once fixed lib linKIconThemes (vers. <..80) is in *ubuntu main repos */
-  background: url(:/images/library/ic_library_preview_pause.svg) no-repeat center center;
+  image: url(:/images/library/ic_library_preview_pause.svg);
 }
 
 #LibraryPreviewButton:!checked {
-  background: url(:/images/library/ic_library_preview_play.svg) no-repeat center center;
+  image: url(:/images/library/ic_library_preview_play.svg);
 }
 
 /* Style the library BPM Button with a default image */
@@ -70,8 +68,8 @@ WOverview #PassthroughLabel {
   border: 0px solid #fff;
 }
 #SearchClearButton:!focus {
-  image: url(:/images/library/ic_library_cross_grey.svg)
+  image: url(:/images/library/ic_library_cross_grey.svg);
 }
 #SearchClearButton:focus {
-  image: url(:/images/library/ic_library_cross_orange.svg)
+  image: url(:/images/library/ic_library_cross_orange.svg);
 }

--- a/src/skin/legacy/launchimage.cpp
+++ b/src/skin/legacy/launchimage.cpp
@@ -15,7 +15,7 @@ LaunchImage::LaunchImage(QWidget* pParent, const QString& styleSheet)
         setStyleSheet(
                 "LaunchImage { background-color: #202020; }"
                 "QLabel { "
-                "background-image: url(:/images/mixxx-icon-logo-symbolic.svg);"
+                "image: url(:/images/mixxx-icon-logo-symbolic.svg);"
                 "padding:0;"
                 "margin:0;"
                 "border:none;"


### PR DESCRIPTION
because with scale factors >100% the (vector) icons set with 'background[-mage]' are not truely scaled up, only their 100% pixmap, which results in blurry/pixelated icons.
Users still with broken libKIconThemes5 v5.80 have to live with squeezed icons until they (can) update that lib.

https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/2.2E3.20planning.3A.20https.3A.2F.2Fgithub.2Ecom.2Fmixxxdj.2Fmixxx.2Fprojects.2F2/near/240843338