### PR TITLE
SkinLoader: Skip skin directory if "skin.xml" is missing

### DIFF
--- a/src/skin/skinloader.cpp
+++ b/src/skin/skinloader.cpp
@@ -49,6 +49,11 @@ QString SkinLoader::getSkinPath(const QString& skinName) const {
     const QList<QDir> skinSearchPaths = getSkinSearchPaths();
     for (QDir dir : skinSearchPaths) {
         if (dir.cd(skinName)) {
+            if (!dir.exists("skin.xml")) {
+                qWarning() << "Skipping skin directory" << dir.absolutePath()
+                           << "because \"skin.xml\" is missing";
+                continue;
+            }
             return dir.absolutePath();
         }
     }


### PR DESCRIPTION
This is a small fix that is useful on it's own, but also improves
forward compatibility with the new QML skin system.

If you work on a QML skin and have it configured in the settings, then
switch to a 2.3-based branch, the skin obviously won't load. But if the
skin directory exists (e.g. because you have unstages files in it),
Mixxx will refuse to start at all instead of falling back to the default
skin. The only way to fix this is editing `mixxx.cfg` by hand or
removing the directory.

This fix adds an additional check if the `skin.xml` exists, and skips
the skin if not. That allows Mixxx to fall back to the default skin.