### PR TITLE
Fix empty library table after start 

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -232,10 +232,7 @@ void BaseTrackTableModel::setHeaderProperties(
         int defaultWidth) {
     int section = fieldIndex(column);
     if (section < 0) {
-        kLogger.debug()
-                << "Skipping header properties for unsupported column"
-                << column
-                << title;
+        // Skipping header properties for unsupported column
         return;
     }
     if (section >= m_columnHeaders.size()) {

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -273,13 +273,12 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel* model) {
             // If the TrackModel has an invalid or internal column as its default
             // sort, find the first valid sort column and sort by that.
             int sortColumnIndex = -1;
-            constexpr int kMaxProbeIndex = 10; // just to avoid an endless while loop
+            const int columnCount = model->columnCount(); // just to avoid an endless while loop
             while (sortColumn == TrackModel::SortColumnId::Invalid &&
-                    sortColumnIndex < kMaxProbeIndex) {
+                    sortColumnIndex < columnCount) {
                 sortColumnIndex++;
                 sortColumn = trackModel->sortColumnIdFromColumnIndex(sortColumnIndex);
             }
-            DEBUG_ASSERT(sortColumn != TrackModel::SortColumnId::Invalid);
         }
 
         m_pSortColumn->set(static_cast<double>(sortColumn));

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -161,8 +161,8 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel* model) {
         return;
     }
 
-    //saving current vertical bar position
-    //using address of track model as key
+    // saving current vertical bar position
+    // using address of track model as key
     saveVScrollBarPos(getTrackModel());
 
     setVisible(false);
@@ -273,9 +273,9 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel* model) {
             // If the TrackModel has an invalid or internal column as its default
             // sort, find the first valid sort column and sort by that.
             int sortColumnIndex = -1;
-            constexpr int kMaxPobeIndex = 10; // just to avoid an endless while loop
+            constexpr int kMaxProbeIndex = 10; // just to avoid an endless while loop
             while (sortColumn == TrackModel::SortColumnId::Invalid &&
-                    sortColumnIndex < kMaxPobeIndex) {
+                    sortColumnIndex < kMaxProbeIndex) {
                 sortColumnIndex++;
                 sortColumn = trackModel->sortColumnIdFromColumnIndex(sortColumnIndex);
             }

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -150,24 +150,20 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel* model) {
         return;
     }
 
-    TrackModel* newModel = nullptr;
-
-    /* If the model has not changed
-     * there's no need to exchange the headers
-     * this will cause a small GUI freeze
-     */
+    // If the model has not changed
+    // there's no need to exchange the headers
+    // this will cause a small GUI freeze
     if (getTrackModel() == trackModel) {
         // Re-sort the table even if the track model is the same. This triggers
         // a select() if the table is dirty.
         doSortByColumn(horizontalHeader()->sortIndicatorSection(),
                 horizontalHeader()->sortIndicatorOrder());
         return;
-    } else {
-        newModel = trackModel;
-        saveVScrollBarPos(getTrackModel());
-        //saving current vertical bar position
-        //using address of track model as key
     }
+
+    //saving current vertical bar position
+    //using address of track model as key
+    saveVScrollBarPos(getTrackModel());
 
     setVisible(false);
 
@@ -313,7 +309,7 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel* model) {
 
     setVisible(true);
 
-    restoreVScrollBarPos(newModel);
+    restoreVScrollBarPos(trackModel);
     // restoring scrollBar position using model pointer as key
     // scrollbar positions with respect to different models are backed by map
     initTrackMenu();

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -270,14 +270,16 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel* model) {
             sortColumn = trackModel->sortColumnIdFromColumnIndex(trackModel->defaultSortColumn());
             sortOrder = trackModel->defaultSortOrder();
 
-            // If the TrackModel has an invalid or internal column as its default
-            // sort, find the first valid sort column and sort by that.
-            int sortColumnIndex = -1;
-            const int columnCount = model->columnCount(); // just to avoid an endless while loop
-            while (sortColumn == TrackModel::SortColumnId::Invalid &&
-                    sortColumnIndex < columnCount) {
-                sortColumnIndex++;
-                sortColumn = trackModel->sortColumnIdFromColumnIndex(sortColumnIndex);
+            if (sortColumn == TrackModel::SortColumnId::Invalid) {
+                // If the TrackModel has an invalid or internal column as its default
+                // sort, find the first valid sort column and sort by that.
+                const int columnCount = model->columnCount(); // just to avoid an endless while loop
+                for (int sortColumnIndex = 0; sortColumnIndex < columnCount; sortColumnIndex++) {
+                    sortColumn = trackModel->sortColumnIdFromColumnIndex(sortColumnIndex);
+                    if (sortColumn != TrackModel::SortColumnId::Invalid) {
+                        break;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
The issue was an invalid stored sort column, that prevents the initial select() call.
Now it falls back to either a default or the first column. 
  