### PR TITLE
SetLogFeature: Reset pointer when WLibrary is destroyed

### DIFF
--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -92,6 +92,9 @@ void SetlogFeature::bindLibraryWidget(
             this,
             &SetlogFeature::slotPlayingTrackChanged);
     m_libraryWidget = libraryWidget;
+    connect(m_libraryWidget, &WLibrary::destroyed, [this] {
+        m_libraryWidget = nullptr;
+    });
 }
 
 void SetlogFeature::onRightClick(const QPoint& globalPos) {
@@ -397,17 +400,23 @@ void SetlogFeature::slotPlayingTrackChanged(TrackPointer currentPlayingTrack) {
     if (m_pPlaylistTableModel->getPlaylist() == m_playlistId) {
         // View needs a refresh
 
-        WTrackTableView* view = dynamic_cast<WTrackTableView*>(
-                m_libraryWidget->getActiveView());
-        if (view != nullptr) {
-            // We have a active view on the history. The user may have some
-            // important active selection. For example putting track into crates
-            // while the song changes trough autodj. The selection is then lost
-            // and dataloss occurs
-            const QList<TrackId> trackIds = view->getSelectedTrackIds();
-            m_pPlaylistTableModel->appendTrack(currentPlayingTrackId);
-            view->setSelectedTracks(trackIds);
-        } else {
+        bool hasActiveView = false;
+        if (m_libraryWidget) {
+            WTrackTableView* view = dynamic_cast<WTrackTableView*>(
+                    m_libraryWidget->getActiveView());
+            if (view != nullptr) {
+                // We have a active view on the history. The user may have some
+                // important active selection. For example putting track into crates
+                // while the song changes trough autodj. The selection is then lost
+                // and dataloss occurs
+                hasActiveView = true;
+                const QList<TrackId> trackIds = view->getSelectedTrackIds();
+                m_pPlaylistTableModel->appendTrack(currentPlayingTrackId);
+                view->setSelectedTracks(trackIds);
+            }
+        }
+
+        if (!hasActiveView) {
             m_pPlaylistTableModel->appendTrack(currentPlayingTrackId);
         }
     } else {

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -91,10 +91,7 @@ void SetlogFeature::bindLibraryWidget(
             &PlayerInfo::currentPlayingTrackChanged,
             this,
             &SetlogFeature::slotPlayingTrackChanged);
-    m_libraryWidget = libraryWidget;
-    connect(m_libraryWidget, &WLibrary::destroyed, [this] {
-        m_libraryWidget = nullptr;
-    });
+    m_libraryWidget = QPointer(libraryWidget);
 }
 
 void SetlogFeature::onRightClick(const QPoint& globalPos) {

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -37,7 +37,6 @@ SetlogFeature::SetlogFeature(
                           /*keep deleted tracks*/ true),
                   QStringLiteral("SETLOGHOME")),
           m_playlistId(kInvalidPlaylistId),
-          m_libraryWidget(nullptr),
           m_icon(QStringLiteral(":/images/library/ic_library_history.svg")) {
     // clear old empty entries
     ScopedTransaction transaction(pLibrary->trackCollectionManager()

--- a/src/library/trackset/setlogfeature.h
+++ b/src/library/trackset/setlogfeature.h
@@ -48,6 +48,6 @@ class SetlogFeature : public BasePlaylistFeature {
     QAction* m_pJoinWithPreviousAction;
     QAction* m_pStartNewPlaylist;
     int m_playlistId;
-    WLibrary* m_libraryWidget;
+    QPointer<WLibrary> m_libraryWidget;
     const QIcon m_icon;
 };


### PR DESCRIPTION
This fixes a crash when loading a legacy skin first, then switching to a
QML skin and playing a deck.