### PR TITLE
skin preview: consider devicePixelRatio when scaling

### DIFF
--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -59,18 +59,20 @@ bool skinFitsScreenSize(
 
 } // namespace
 
-DlgPrefInterface::DlgPrefInterface(QWidget * parent, MixxxMainWindow * mixxx,
-                                 SkinLoader* pSkinLoader,
-                                 UserSettingsPointer pConfig)
-        :  DlgPreferencePage(parent),
-           m_pConfig(pConfig),
-           m_mixxx(mixxx),
-           m_pSkinLoader(pSkinLoader),
-           m_dScaleFactorAuto(1.0),
-           m_bUseAutoScaleFactor(false),
-           m_dScaleFactor(1.0),
-           m_bStartWithFullScreen(false),
-           m_bRebootMixxxView(false) {
+DlgPrefInterface::DlgPrefInterface(QWidget* parent,
+        MixxxMainWindow* mixxx,
+        SkinLoader* pSkinLoader,
+        UserSettingsPointer pConfig)
+        : DlgPreferencePage(parent),
+          m_pConfig(pConfig),
+          m_mixxx(mixxx),
+          m_pSkinLoader(pSkinLoader),
+          m_dScaleFactorAuto(1.0),
+          m_bUseAutoScaleFactor(false),
+          m_dScaleFactor(1.0),
+          m_dDevicePixelRatio(1.0),
+          m_bStartWithFullScreen(false),
+          m_bRebootMixxxView(false) {
     setupUi(this);
 
     // Locale setting
@@ -150,6 +152,8 @@ DlgPrefInterface::DlgPrefInterface(QWidget * parent, MixxxMainWindow * mixxx,
         skins.append(dir.entryInfoList());
     }
 
+    m_dDevicePixelRatio = getDevicePixelRatioF(this);
+
     QString configuredSkinPath = m_pSkinLoader->getConfiguredSkinPath();
     int index = 0;
     const auto* const pScreen = getScreen();
@@ -161,7 +165,9 @@ DlgPrefInterface::DlgPrefInterface(QWidget * parent, MixxxMainWindow * mixxx,
             ComboBoxSkinconf->setCurrentIndex(index);
             // schemes must be updated here to populate the drop-down box and set m_colorScheme
             slotUpdateSchemes();
-            skinPreviewLabel->setPixmap(m_pSkinLoader->getSkinPreview(m_skin, m_colorScheme));
+            skinPreviewLabel->setPixmap(m_pSkinLoader->getSkinPreview(m_skin,
+                    m_colorScheme,
+                    m_dDevicePixelRatio));
             if (skinFitsScreenSize(*pScreen, configuredSkinPath)) {
                 warningLabel->hide();
             } else {
@@ -373,7 +379,9 @@ void DlgPrefInterface::slotSetScheme(int) {
         m_colorScheme = newScheme;
         m_bRebootMixxxView = true;
     }
-    skinPreviewLabel->setPixmap(m_pSkinLoader->getSkinPreview(m_skin, m_colorScheme));
+    skinPreviewLabel->setPixmap(m_pSkinLoader->getSkinPreview(m_skin,
+            m_colorScheme,
+            m_dDevicePixelRatio));
 }
 
 void DlgPrefInterface::slotSetSkinDescription(const QString& skin) {
@@ -404,7 +412,9 @@ void DlgPrefInterface::slotSetSkin(int) {
         slotSetSkinDescription(m_skin);
     }
 
-    skinPreviewLabel->setPixmap(m_pSkinLoader->getSkinPreview(newSkin, m_colorScheme));
+    skinPreviewLabel->setPixmap(m_pSkinLoader->getSkinPreview(newSkin,
+            m_colorScheme,
+            m_dDevicePixelRatio));
 }
 
 void DlgPrefInterface::slotApply() {

--- a/src/preferences/dialog/dlgprefinterface.h
+++ b/src/preferences/dialog/dlgprefinterface.h
@@ -59,6 +59,7 @@ class DlgPrefInterface : public DlgPreferencePage, public Ui::DlgPrefControlsDlg
     double m_dScaleFactorAuto;
     bool m_bUseAutoScaleFactor;
     double m_dScaleFactor;
+    double m_dDevicePixelRatio;
     bool m_bStartWithFullScreen;
     mixxx::ScreenSaverPreference m_screensaverMode;
 

--- a/src/skin/skinloader.cpp
+++ b/src/skin/skinloader.cpp
@@ -60,7 +60,9 @@ QString SkinLoader::getSkinPath(const QString& skinName) const {
     return QString();
 }
 
-QPixmap SkinLoader::getSkinPreview(const QString& skinName, const QString& schemeName) const {
+QPixmap SkinLoader::getSkinPreview(const QString& skinName,
+        const QString& schemeName,
+        const double devicePixelRatio) const {
     QPixmap preview;
     if (!schemeName.isEmpty()) {
         QString schemeNameUnformatted = schemeName;
@@ -72,7 +74,10 @@ QPixmap SkinLoader::getSkinPreview(const QString& skinName, const QString& schem
     if (preview.isNull()) {
         preview.load(":/images/skin_preview_placeholder.png");
     }
-    preview = preview.scaled(QSize(640, 360), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    preview = preview.scaled(QSize(640, 360) * devicePixelRatio,
+            Qt::KeepAspectRatio,
+            Qt::SmoothTransformation);
+    preview.setDevicePixelRatio(devicePixelRatio);
     return preview;
 }
 

--- a/src/skin/skinloader.h
+++ b/src/skin/skinloader.h
@@ -35,7 +35,9 @@ class SkinLoader {
     LaunchImage* loadLaunchImage(QWidget* pParent);
 
     QString getSkinPath(const QString& skinName) const;
-    QPixmap getSkinPreview(const QString& skinName, const QString& schemeName) const;
+    QPixmap getSkinPreview(const QString& skinName,
+            const QString& schemeName,
+            const double devicePixelRatio) const;
     QString getConfiguredSkinPath() const;
     QString getDefaultSkinName() const;
     QList<QDir> getSkinSearchPaths() const;


### PR DESCRIPTION
follow-up for #3926 
fixes blurry preview images.

before
![image](https://user-images.githubusercontent.com/5934199/120730987-f2cb6100-c4e2-11eb-8991-9007b67657dd.png)

this PR (not ethat you can now read the library : ) try with `QT_SCALE_FACTORS=3` for full effect
![preview_after](https://user-images.githubusercontent.com/5934199/120730932-d9c2b000-c4e2-11eb-9f72-2b00adab9e37.png)
