### PR TITLE
Behringer BCR2000: fix mapping of effect assignment buttons

### DIFF
--- a/res/controllers/Behringer-BCR2000-scripts.js
+++ b/res/controllers/Behringer-BCR2000-scripts.js
@@ -89,7 +89,7 @@ var BCR2000 = new behringer.extension.GenericMidiController({
                     },
                     {
                         type: c.EffectAssignmentButton, options: {
-                            midi: [cc, p.buttonBox[1]],
+                            midi: [cc, p.buttonBox[2]],
                             effectUnit: 2,
                             type: c.Button.prototype.types.push
                         }
@@ -177,7 +177,7 @@ var BCR2000 = new behringer.extension.GenericMidiController({
                     },
                     {
                         type: c.EffectAssignmentButton, options: {
-                            midi: [cc, p.buttonBox[2]],
+                            midi: [cc, p.buttonBox[1]],
                             effectUnit: 1,
                             type: c.Button.prototype.types.push
                         }


### PR DESCRIPTION
The effect assignment buttons were swapped accidentally:
* Top right button should be deck 2, effect unit 1
* Bottom left button should be deck 1, effect unit 2

The [documentation](https://manual.mixxx.org/2.3/en/hardware/controllers/behringer_bcr2000.html) is correct.