### PR TITLE
Only show the date in Date Added / Last Played columns

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -625,10 +625,11 @@ QVariant BaseTrackTableModel::roleValue(
             VERIFY_OR_DEBUG_ASSERT(rawValue.canConvert<QDateTime>()) {
                 return QVariant();
             }
+            QDateTime dt = mixxx::localDateTimeFromUtc(rawValue.toDateTime());
             if (role == Qt::ToolTipRole || role == kDataExportRole) {
-                return mixxx::localDateTimeFromUtc(rawValue.toDateTime());
+                return dt;
             }
-            return mixxx::localDateTimeFromUtc(rawValue.toDateTime()).date();
+            return dt.date();
         case ColumnCache::COLUMN_LIBRARYTABLE_LAST_PLAYED_AT: {
             QDateTime lastPlayedAt;
             if (rawValue.type() == QVariant::String) {
@@ -642,10 +643,11 @@ QVariant BaseTrackTableModel::roleValue(
                 return QVariant();
             }
             DEBUG_ASSERT(lastPlayedAt.timeSpec() == Qt::UTC);
+            QDateTime dt = mixxx::localDateTimeFromUtc(lastPlayedAt);
             if (role == Qt::ToolTipRole || role == kDataExportRole) {
-                return mixxx::localDateTimeFromUtc(lastPlayedAt);
+                return dt;
             }
-            return mixxx::localDateTimeFromUtc(lastPlayedAt).date();
+            return dt.date();
         }
         case ColumnCache::COLUMN_LIBRARYTABLE_BPM: {
             mixxx::Bpm bpm;

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -625,6 +625,9 @@ QVariant BaseTrackTableModel::roleValue(
             VERIFY_OR_DEBUG_ASSERT(rawValue.canConvert<QDateTime>()) {
                 return QVariant();
             }
+            if (role == Qt::ToolTipRole || role == kDataExportRole) {
+                return mixxx::localDateTimeFromUtc(rawValue.toDateTime());
+            }
             return mixxx::localDateTimeFromUtc(rawValue.toDateTime()).date();
         case ColumnCache::COLUMN_LIBRARYTABLE_LAST_PLAYED_AT: {
             QDateTime lastPlayedAt;
@@ -639,6 +642,9 @@ QVariant BaseTrackTableModel::roleValue(
                 return QVariant();
             }
             DEBUG_ASSERT(lastPlayedAt.timeSpec() == Qt::UTC);
+            if (role == Qt::ToolTipRole || role == kDataExportRole) {
+                return mixxx::localDateTimeFromUtc(lastPlayedAt);
+            }
             return mixxx::localDateTimeFromUtc(lastPlayedAt).date();
         }
         case ColumnCache::COLUMN_LIBRARYTABLE_BPM: {

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -621,7 +621,7 @@ QVariant BaseTrackTableModel::roleValue(
             return QString("(%1)").arg(timesPlayed);
         }
         case ColumnCache::COLUMN_LIBRARYTABLE_DATETIMEADDED:
-        case ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_DATETIMEADDED:
+        case ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_DATETIMEADDED: {
             VERIFY_OR_DEBUG_ASSERT(rawValue.canConvert<QDateTime>()) {
                 return QVariant();
             }
@@ -630,6 +630,7 @@ QVariant BaseTrackTableModel::roleValue(
                 return dt;
             }
             return dt.date();
+        }
         case ColumnCache::COLUMN_LIBRARYTABLE_LAST_PLAYED_AT: {
             QDateTime lastPlayedAt;
             if (rawValue.type() == QVariant::String) {

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -625,7 +625,7 @@ QVariant BaseTrackTableModel::roleValue(
             VERIFY_OR_DEBUG_ASSERT(rawValue.canConvert<QDateTime>()) {
                 return QVariant();
             }
-            return mixxx::localDateTimeFromUtc(rawValue.toDateTime());
+            return mixxx::localDateTimeFromUtc(rawValue.toDateTime()).date();
         case ColumnCache::COLUMN_LIBRARYTABLE_LAST_PLAYED_AT: {
             QDateTime lastPlayedAt;
             if (rawValue.type() == QVariant::String) {
@@ -639,7 +639,7 @@ QVariant BaseTrackTableModel::roleValue(
                 return QVariant();
             }
             DEBUG_ASSERT(lastPlayedAt.timeSpec() == Qt::UTC);
-            return mixxx::localDateTimeFromUtc(lastPlayedAt);
+            return mixxx::localDateTimeFromUtc(lastPlayedAt).date();
         }
         case ColumnCache::COLUMN_LIBRARYTABLE_BPM: {
             mixxx::Bpm bpm;


### PR DESCRIPTION
This has annoyed me for a while -- I've never wanted to know what time of day I added a track, and the column itself says "date", not "datetime".  This makes the columns much more manageable.