### PR TITLE
[DDJ 200] Get knobs/sliders position at init

### DIFF
--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -59,7 +59,7 @@ DDJ200.init = function() {
     engine.beginTimer(500, function() {
         engine.setValue("[Library]", "MoveFocus", 1);
     }, true);
-    
+
     // query the controller for current control positions on startup
     midi.sendSysexMsg([0xF0, 0x00, 0x40, 0x05, 0x00, 0x00, 0x02, 0x0a, 0x00, 0x03, 0x01, 0xf7], 12);
 };

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -59,6 +59,9 @@ DDJ200.init = function() {
     engine.beginTimer(500, function() {
         engine.setValue("[Library]", "MoveFocus", 1);
     }, true);
+    
+    // query the controller for current control positions on startup
+    midi.sendSysexMsg([0xF0, 0x00, 0x40, 0x05, 0x00, 0x00, 0x02, 0x0a, 0x00, 0x03, 0x01, 0xf7], 12);
 };
 
 DDJ200.shutdown = function() {


### PR DESCRIPTION
This change add a line based on DDJ 400 mapping with a little of reverse engineering in my DDJ 200 controller to start mixxx with all knobs and sliders at same position as the controller.

I intercepted messages between rekordbox and my DJJ 200 with wireshark to find some command similar to the command I found at DDJ 400 mapping and found this. It's not documented in DDJ 200 midi manual but works like a charm.