### PR TITLE
QML: Add support for dropping tracks on Decks

### DIFF
--- a/res/skins/QMLDemo/Deck.qml
+++ b/res/skins/QMLDemo/Deck.qml
@@ -11,6 +11,7 @@ Item {
 
     property string group // required
     property bool minimized: false
+    property var deckPlayer: Mixxx.PlayerManager.getPlayer(group)
 
     Skin.DeckInfoBar {
         id: infoBar
@@ -367,6 +368,17 @@ Item {
             fadeTarget: buttonBar
         }
 
+    }
+
+    DropArea {
+        anchors.fill: parent
+        onDropped: {
+            if (drop.hasUrls) {
+                let url = drop.urls[0];
+                console.log("Dropped URL '" + url + "' on deck " + root.group);
+                root.deckPlayer.loadTrackFromLocationUrl(url);
+            }
+        }
     }
 
 }

--- a/src/skin/qml/qmlplayermanagerproxy.cpp
+++ b/src/skin/qml/qmlplayermanagerproxy.cpp
@@ -12,6 +12,10 @@ namespace qml {
 QmlPlayerManagerProxy::QmlPlayerManagerProxy(
         std::shared_ptr<PlayerManager> pPlayerManager, QObject* parent)
         : QObject(parent), m_pPlayerManager(pPlayerManager) {
+    connect(this,
+            &QmlPlayerManagerProxy::loadLocationToPlayer,
+            m_pPlayerManager.get(),
+            &PlayerManager::loadLocationToPlayer);
 }
 
 QObject* QmlPlayerManagerProxy::getPlayer(const QString& group) {
@@ -25,6 +29,12 @@ QObject* QmlPlayerManagerProxy::getPlayer(const QString& group) {
     // the corresponding JS object is garbage collected.
     QmlPlayerProxy* pPlayerProxy = new QmlPlayerProxy(pPlayer);
     QQmlEngine::setObjectOwnership(pPlayerProxy, QQmlEngine::JavaScriptOwnership);
+    connect(pPlayerProxy,
+            &QmlPlayerProxy::loadTrackFromLocationRequested,
+            this,
+            [this, group](const QString& trackLocation) {
+                emit loadLocationToPlayer(trackLocation, group);
+            });
     return pPlayerProxy;
 }
 

--- a/src/skin/qml/qmlplayermanagerproxy.h
+++ b/src/skin/qml/qmlplayermanagerproxy.h
@@ -17,6 +17,9 @@ class QmlPlayerManagerProxy : public QObject {
 
     Q_INVOKABLE QObject* getPlayer(const QString& deck);
 
+  signals:
+    void loadLocationToPlayer(const QString& location, const QString& group);
+
   private:
     const std::shared_ptr<PlayerManager> m_pPlayerManager;
 };

--- a/src/skin/qml/qmlplayerproxy.cpp
+++ b/src/skin/qml/qmlplayerproxy.cpp
@@ -40,6 +40,10 @@ QmlPlayerProxy::QmlPlayerProxy(BaseTrackPlayer* pTrackPlayer, QObject* parent)
     connect(this, &QmlPlayerProxy::trackChanged, this, &QmlPlayerProxy::slotTrackChanged);
 }
 
+void QmlPlayerProxy::loadTrackFromLocation(const QString& trackLocation) {
+    emit loadTrackFromLocationRequested(trackLocation);
+}
+
 void QmlPlayerProxy::slotTrackLoaded(TrackPointer pTrack) {
     m_pCurrentTrack = pTrack;
     if (pTrack != nullptr) {

--- a/src/skin/qml/qmlplayerproxy.cpp
+++ b/src/skin/qml/qmlplayerproxy.cpp
@@ -44,6 +44,14 @@ void QmlPlayerProxy::loadTrackFromLocation(const QString& trackLocation) {
     emit loadTrackFromLocationRequested(trackLocation);
 }
 
+void QmlPlayerProxy::loadTrackFromLocationUrl(const QUrl& trackLocationUrl) {
+    if (trackLocationUrl.isLocalFile()) {
+        loadTrackFromLocation(trackLocationUrl.toLocalFile());
+    } else {
+        qWarning() << "QmlPlayerProxy: URL" << trackLocationUrl << "is not a local file!";
+    }
+}
+
 void QmlPlayerProxy::slotTrackLoaded(TrackPointer pTrack) {
     m_pCurrentTrack = pTrack;
     if (pTrack != nullptr) {

--- a/src/skin/qml/qmlplayerproxy.h
+++ b/src/skin/qml/qmlplayerproxy.h
@@ -54,6 +54,8 @@ class QmlPlayerProxy : public QObject {
         return m_pTrackPlayer;
     }
 
+    Q_INVOKABLE void loadTrackFromLocation(const QString& trackLocation);
+
   public slots:
     void slotTrackLoaded(TrackPointer pTrack);
     void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
@@ -93,6 +95,8 @@ class QmlPlayerProxy : public QObject {
     void keyTextChanged();
     void colorChanged();
     void coverArtUrlChanged();
+
+    void loadTrackFromLocationRequested(const QString& trackLocation);
 
   private:
     QPointer<BaseTrackPlayer> m_pTrackPlayer;

--- a/src/skin/qml/qmlplayerproxy.h
+++ b/src/skin/qml/qmlplayerproxy.h
@@ -55,6 +55,7 @@ class QmlPlayerProxy : public QObject {
     }
 
     Q_INVOKABLE void loadTrackFromLocation(const QString& trackLocation);
+    Q_INVOKABLE void loadTrackFromLocationUrl(const QUrl& trackLocationUrl);
 
   public slots:
     void slotTrackLoaded(TrackPointer pTrack);


### PR DESCRIPTION
This allows you to open a file manager and drag-and-drop a file onto a deck. Tested with nautilus.