### PR TITLE
SeratoFeature: Use default duration of 0 instead of -1

### DIFF
--- a/src/library/serato/seratofeature.cpp
+++ b/src/library/serato/seratofeature.cpp
@@ -71,7 +71,7 @@ struct serato_track_t {
     QString grouping;
     QString label;
     int year = -1;
-    int duration = -1;
+    int duration = 0;
     QString bitrate;
     QString samplerate;
     double bpm = -1.0;


### PR DESCRIPTION
This fixes the following debug assertion that may be triggered if no
duration is specified in the Serato database:

    DEBUG ASSERT: "ok && durationInSeconds >= 0" in function QVariant BaseTrackTableModel::roleValue(const QModelIndex&, QVariant&&, int) const at /home/jan/Projects/mixxx/src/library/basetracktablemodel.cpp:580