### PR TITLE
Waveform: always use pixel size and 'Open Sans' for text markers

### DIFF
--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -184,15 +184,22 @@ void WaveformRenderMark::generateMarkImage(WaveformMarkPointer pMark) {
         }
     }
 
-    QFont font; // Uses the application default, if not set per skin
+    // This alone would pick the OS default font, or that set by Qt5 Settings (qt5ct)
+    // respectively. This would mostly not be notable since contemporary OS and distros
+    // use a proven sans-serif anyway. Though, some user fonts may be lacking glyphs
+    // we use for the intro/outro markers for example.
+    QFont font;
+    // So, let's just use Open Sans which is used by all official skins to achieve
+    // a consistent skin design.
+    font.setFamily("Open Sans");
     // Use a pixel size like everywhere else in Mixxx, which can be scaled well
     // in general.
     // Point sizes would work if only explicit Qt scaling QT_SCALE_FACTORS is used,
     // though as soon as other OS-based font and app scaling mechanics join the
     // party the resulting font size is hard to predict (affects all supported OS).
     font.setPixelSize(13);
-    font.setStretch(100);
-    font.setWeight(75);
+    font.setWeight(75); // bold
+    font.setItalic(false);
 
     QFontMetrics metrics(font);
 

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -185,7 +185,12 @@ void WaveformRenderMark::generateMarkImage(WaveformMarkPointer pMark) {
     }
 
     QFont font; // Uses the application default, if not set per skin
-    font.setPointSizeF(10 * devicePixelRatio);
+    // Use a pixel size like everywhere else in Mixxx, which can be scaled well
+    // in general.
+    // Point sizes would work if only explicit Qt scaling QT_SCALE_FACTORS is used,
+    // though as soon as other OS-based font and app scaling mechanics join the
+    // party the resulting font size is hard to predict (affects all supported OS).
+    font.setPixelSize(13);
     font.setStretch(100);
     font.setWeight(75);
 


### PR DESCRIPTION
Waveform text markers now
* use fixed pixel size matching sizes used in skins (and the previous 10 point)
* always use Open Sans

Please test on
* Windows
* macOS
* various Linux distros/DEs

Try different combinations of font scaling, general app scaling (if available, "Make everything Bigger" on Win10 : ) and `export QT_SCALE_FACTORS=...` (see [Troubleshooting](https://github.com/mixxxdj/mixxx/wiki/troubleshooting#graphical-user-interface-gui-is-too-big-or-too-small)). Also use fractional scaling if available.
Then, check if the waveform text markers are **always** sized 'pleasantly' like in the below screenshots.
Please test at 100% with current 2.3beta first and report if the font size differs noteworthy.
![image](https://user-images.githubusercontent.com/5934199/120907529-85ded500-c662-11eb-8cc1-9021e4e6f35c.png)
![image](https://user-images.githubusercontent.com/5934199/120907516-6e9fe780-c662-11eb-9406-2cf8fda9394c.png)
![image](https://user-images.githubusercontent.com/5934199/120907537-9db65900-c662-11eb-9c32-dcbb639d5b10.png)
![image](https://user-images.githubusercontent.com/5934199/120907544-ad35a200-c662-11eb-8c98-8c81039b83e3.png)

