### PR TITLE
Make sure args.getSettingsPath() returns the correct directory

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,8 +84,14 @@ int main(int argc, char * argv[]) {
     // the main thread. Bug #1748636.
     ErrorDialogHandler::instance();
 
-    MixxxApplication app(argc, argv);
+#ifdef __APPLE__
+    Sandbox::checkSandboxed();
+    if (!args.getSettingsPathSet()) {
+        args.setSettingsPath(Sandbox::migrateOldSettings());
+    }
+#endif
 
+    MixxxApplication app(argc, argv);
 
 #ifdef __APPLE__
     QDir dir(QApplication::applicationDirPath());

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -172,12 +172,6 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
     mixxx::Time::start();
 
     QString settingsPath = args.getSettingsPath();
-#ifdef __APPLE__
-    Sandbox::checkSandboxed();
-    if (!args.getSettingsPathSet()) {
-        settingsPath = Sandbox::migrateOldSettings();
-    }
-#endif
 
     mixxx::LogFlags logFlags = mixxx::LogFlag::LogToFile;
     if (args.getDebugAssertBreak()) {

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -55,7 +55,7 @@ bool CmdlineArgs::Parse(int &argc, char **argv) {
             if (!m_settingsPath.endsWith("/")) {
                 m_settingsPath.append("/");
             }
-            m_settingsPathSet=true;
+            m_settingsPathSet = true;
         } else if (argv[i] == QString("--resourcePath") && i+1 < argc) {
             m_resourcePath = QString::fromLocal8Bit(argv[i+1]);
             i++;

--- a/src/util/sandbox.cpp
+++ b/src/util/sandbox.cpp
@@ -366,6 +366,7 @@ SecurityTokenPointer Sandbox::openTokenFromBookmark(const QString& canonicalPath
     return SecurityTokenPointer();
 }
 
+#ifdef __APPLE__
 QString Sandbox::migrateOldSettings() {
     // QStandardPaths::DataLocation returns a different location depending on whether the build
     // is signed (and therefore sandboxed with the hardened runtime), so use the absolute path
@@ -438,7 +439,6 @@ QString Sandbox::migrateOldSettings() {
         return sandboxedPath;
     }
 
-#ifdef __APPLE__
     CFURLRef url = CFURLCreateWithFileSystemPath(
             kCFAllocatorDefault, QStringToCFString(legacySettingsPath), kCFURLPOSIXPathStyle, true);
     if (url) {
@@ -498,9 +498,9 @@ QString Sandbox::migrateOldSettings() {
             }
         }
     }
-#endif
     return sandboxedPath;
 }
+#endif
 
 #ifdef __APPLE__
 SandboxSecurityToken::SandboxSecurityToken(const QString& path, CFURLRef url)

--- a/src/util/sandbox.h
+++ b/src/util/sandbox.h
@@ -32,7 +32,9 @@ class Sandbox {
     static void setPermissionsFilePath(const QString& permissionsFile);
     static void shutdown();
 
+#ifdef __APPLE__
     static QString migrateOldSettings();
+#endif
 
     // Returns true if we are in a sandbox.
     static bool enabled() {


### PR DESCRIPTION
This makes sure that getSettingsPath() always return the right directory. 
This is done by writing it back using args.getSettingsPathSet() when it was changed by sandboxing. 
I have also moved the code into main, to make sure that CmdlineArgs::Instance()->getSettingsPath() can be used unconditionally. 