### PR TITLE
Skins: fix remaining 'font leaks'

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -829,11 +829,11 @@ WLibrary QLabel,
 WLibrary QRadioButton {
   font-family: "Open Sans";
   font-style: normal;
+  font-weight: normal;
 }
 
-WWidget,
-WLibrary QLabel,
-WLibrary QPushButton {
+WLabel, WLibrary QLabel,
+WPushButton, WLibrary QPushButton {
   font-size: 12px;
   font-weight: bold;
   text-transform: uppercase;
@@ -1570,8 +1570,6 @@ WPushButton {
     border: 1px solid #4B4B4B;
     border-radius: 2px;
     outline: none;
-    font-size: 12px;
-    font-weight: bold;
 }
 
 WPushButton:hover,
@@ -1643,10 +1641,6 @@ WPushButton#PreviewIndicator[value="0"] {
     background-color: #5F5F5F;
     border: 3px solid #0080BE;
     border-radius: 3px;
-}
-
-WRecordingDuration {
-  font-weight: bold;
 }
 
 /* The effect unit mix mode button toggles between

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -248,7 +248,7 @@ WTrackTableView {
   border: 1px solid #FF6600;
 }
 
-QTextBrowser {
+#LibraryContainer QTextBrowser {
   padding-left: 5px;
 }
 
@@ -807,26 +807,32 @@ WOverview #PassthroughLabel,
 /* all context menus */
 #MainMenu, #MainMenu QMenu,
 WLibrarySidebar QMenu,
+WLibrary QHeaderView,
 WLibrary QHeaderView QMenu,
-QTextBrowser QMenu,
+WLibrary QHeaderView::section,
+#LibraryContainer QTextBrowser,
+#LibraryContainer QTextBrowser QMenu,
 QLineEdit QMenu,
 WCueMenuPopup,
 WCueMenuPopup QLabel,
+WCueMenuPopup QLineEdit,
 WCoverArtMenu,
 WTrackMenu,
 WTrackMenu QMenu,
+WTrackMenu QMenu QCheckBox,
 WOverview /* Hotcue labels in the overview */,
 WEffect,
 WEffectSelector,
 WEffectSelector QAbstractScrollArea,
 #fadeModeCombobox,
-#fadeModeCombobox QAbstractScrollArea
+#fadeModeCombobox QAbstractScrollArea,
 #LibraryContainer QPushButton,
 #LibraryContainer QLabel,
 #LibraryContainer QRadioButton,
 #LibraryContainer QHeaderView,
 #LibraryContainer QHeaderView::item {
   font-family: "Open Sans";
+  font-style: normal;
 }
 
 WWidget,
@@ -1900,7 +1906,7 @@ QToolTip,
 #MainMenu QMenu,
 WLibrarySidebar QMenu,
 WLibrary QHeaderView QMenu,
-QTextBrowser QMenu,
+#LibraryContainer QTextBrowser QMenu,
 WTrackMenu,
 WTrackMenu QMenu,
 QLineEdit QMenu,
@@ -1926,8 +1932,8 @@ WLibrarySidebar QMenu,
 WLibrarySidebar QMenu::item,
 WLibrary QHeaderView QMenu,
 WLibrary QHeaderView QMenu::item,
-QTextBrowser QMenu,
-QTextBrowser QMenu::item,
+#LibraryContainer QTextBrowser QMenu,
+#LibraryContainer QTextBrowser QMenu::item,
 WTrackMenu,
 WTrackMenu::item,
 WTrackMenu QMenu,
@@ -1949,7 +1955,7 @@ WEffectSelector QAbstractScrollArea,
 QToolTip,
 WLibrarySidebar QMenu,
 WLibrary QHeaderView QMenu,
-QTextBrowser QMenu,
+#LibraryContainer QTextBrowser QMenu,
 WTrackMenu,
 WTrackMenu QMenu,
 QLineEdit QMenu,
@@ -1973,7 +1979,7 @@ WEffectSelector QAbstractScrollArea,
   WLibrarySidebar QMenu::indicator:unchecked:selected,
   WLibrary QHeaderView QMenu::item:selected,
   WLibrary QHeaderView QMenu::indicator:unchecked:selected,
-  QTextBrowser QMenu::item:selected,
+  #LibraryContainer QTextBrowser QMenu::item:selected,
   WTrackMenu::item:selected,
   WTrackMenu QMenu::item:selected,
   WTrackMenu QMenu QCheckBox:selected,
@@ -2157,13 +2163,13 @@ WTrackMenu QMenu::item,
 QLineEdit QMenu::item,
 WCoverArtMenu::item,
 /* for the sake of completeness: html root view of Crates, Rec etc. */
-QTextBrowser QMenu::item {
+#LibraryContainer QTextBrowser QMenu::item {
   padding: 5px 12px 5px 12px;
 }
 
 /* Icons in those menus (copy, paste, cut, delete) */
 QLineEdit QMenu::icon,
-QTextBrowser QMenu::icon,
+#LibraryContainer QTextBrowser QMenu::icon,
 /* - checkbox in Crate name context menu
     "[ ] Auto DJ Track Source" */
 WLibrarySidebar QMenu::indicator,

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -202,9 +202,9 @@
  *******************************************************************************/
 
 /* sidebar, as well as root items for playlists, crates, and history */
-#LibraryContainer QTextBrowser,
-#LibraryContainer QTableView,
-#LibraryContainer QTreeView {
+WLibraryTextBrowser,
+WTrackTableView,
+WLibrarySidebar {
   color: #d2d2d2;
   border: 1px solid #1A1A1A;
   background-color: #1F1F1F;
@@ -219,20 +219,17 @@
 }
 
 /* Selected rows in Tree and Tracks table */
-#LibraryContainer QTableView::item:selected,
-#LibraryContainer QTreeView::item:selected,
+WTrackTableView::item:selected,
+WLibrarySidebar::item:selected,
 #LibraryBPMButton::item:selected {
   color: #D6D6D6;
   background-color: #006596;
 }
-#LibraryContainer QTreeView::item:focus {
-  outline: none;
-}
 /* Use the native focus decoration */
 /* This is for all cells including Played and Location */
-#LibraryContainer QTableView,
+WTrackTableView,
 /* This is for the BPM cell */
-#LibraryContainer QTableView QCheckBox:focus {
+WTrackTableView QCheckBox:focus {
   outline: 1px solid #D6D6D6;
 }
 /* This uses a custom qproperty to set the focus border
@@ -242,13 +239,13 @@ WTrackTableView {
   qproperty-focusBorderColor: #D6D6D6;
 }
 
-#LibraryContainer QTableView:focus,
-#LibraryContainer QTreeView:focus,
-#LibraryContainer QTextBrowser:focus {
+WTrackTableView:focus,
+WLibrarySidebar:focus,
+WLibraryTextBrowser:focus {
   border: 1px solid #FF6600;
 }
 
-#LibraryContainer QTextBrowser {
+WLibraryTextBrowser {
   padding-left: 5px;
 }
 
@@ -268,11 +265,11 @@ WLibrary QLineEdit,
 
 
 /* checkbox in library "Played" column */
-#LibraryContainer QTableView::indicator:checked {
+WTrackTableView::indicator:checked {
   image: url(skin:/../Deere/icon/ic_library_checkmark.svg);
   border: 1px solid #ff6600;
 }
-#LibraryContainer QTableView::indicator:unchecked {
+WTrackTableView::indicator:unchecked {
   border: 1px solid rgba(151,151,151,128);
 }
 
@@ -334,14 +331,14 @@ QPushButton#LibraryPreviewButton:checked:hover {
 }
 
 /* library header row */
-#LibraryContainer QHeaderView {
+WTrackTableViewHeader {
   /* Don't set a font size to pick up the system font size. */
   color: #d2d2d2;
   background-color: #1A1A1A;
   border-bottom: 1px solid #141414;
 }
 
-#LibraryContainer QHeaderView::section {
+WTrackTableViewHeader::section {
   height: 1.1em;
   font-weight: bold;
   padding: 2px;
@@ -352,16 +349,16 @@ QPushButton#LibraryPreviewButton:checked:hover {
   border-right: 1px solid #141414;
 }
 
-#LibraryContainer QHeaderView::up-arrow,
-#LibraryContainer QHeaderView::down-arrow {
+WTrackTableViewHeader::up-arrow,
+WTrackTableViewHeader::down-arrow {
   background-color: rgba(26,26,26,220);
   padding: 0px;
 }
-#LibraryContainer QHeaderView::up-arrow {
+WTrackTableViewHeader::up-arrow {
   image: url(skin:/../Deere/image/style_sort_up.svg);
 }
 
-#LibraryContainer QHeaderView::down-arrow {
+WTrackTableViewHeader::down-arrow {
   image: url(skin:/../Deere/image/style_sort_down.svg);
 }
 
@@ -412,8 +409,8 @@ WSearchLineEdit {
   qproperty-layoutSpacing: 0;
 }
 
-#LibraryContainer QTreeView,
-#LibraryContainer QTreeView::item:focus {
+WLibrarySidebar,
+WLibrarySidebar::item:focus {
   outline: none;
 /* Spacing between treeview and preview deck/search bar */
   margin: 0px;
@@ -424,21 +421,21 @@ WSearchLineEdit {
 }
 
 /* triangle for closed/opened branches in treeview */
-#LibraryContainer QTreeView::branch:has-children:!has-siblings:closed,
-#LibraryContainer QTreeView::branch:closed:has-children:has-siblings {
+WLibrarySidebar::branch:has-children:!has-siblings:closed,
+WLibrarySidebar::branch:closed:has-children:has-siblings {
   border-image: none; image: url(skin:/../Deere/image/style_branch_closed.png);
 }
 
-#LibraryContainer QTreeView::branch:open:has-children:!has-siblings,
-#LibraryContainer QTreeView::branch:open:has-children:has-siblings {
+WLibrarySidebar::branch:open:has-children:!has-siblings,
+WLibrarySidebar::branch:open:has-children:has-siblings {
   border-image: none; image: url(skin:/../Deere/image/style_branch_open.png);
 }
 
 /* space left of selected child item */
-#LibraryContainer QTreeView::branch:!has-children:!has-siblings:closed:selected,
-#LibraryContainer QTreeView::branch:closed:!has-children:has-siblings:selected,
-#LibraryContainer QTreeView::branch:open:!has-children:!has-siblings:selected,
-#LibraryContainer QTreeView::branch:open:!has-children:has-siblings:selected {
+WLibrarySidebar::branch:!has-children:!has-siblings:closed:selected,
+WLibrarySidebar::branch:closed:!has-children:has-siblings:selected,
+WLibrarySidebar::branch:open:!has-children:!has-siblings:selected,
+WLibrarySidebar::branch:open:!has-children:has-siblings:selected {
   border-image: none;
   background-color: #1F1F1F;
 }
@@ -806,12 +803,13 @@ WBeatSpinBox,
 WOverview #PassthroughLabel,
 /* all context menus */
 #MainMenu, #MainMenu QMenu,
+WLibrarySidebar,
 WLibrarySidebar QMenu,
-WLibrary QHeaderView,
-WLibrary QHeaderView QMenu,
-WLibrary QHeaderView::section,
-#LibraryContainer QTextBrowser,
-#LibraryContainer QTextBrowser QMenu,
+WTrackTableViewHeader,
+WTrackTableViewHeader QMenu,
+WTrackTableViewHeader::section,
+WLibraryTextBrowser,
+WLibraryTextBrowser QMenu,
 QLineEdit QMenu,
 WCueMenuPopup,
 WCueMenuPopup QLabel,
@@ -826,11 +824,9 @@ WEffectSelector,
 WEffectSelector QAbstractScrollArea,
 #fadeModeCombobox,
 #fadeModeCombobox QAbstractScrollArea,
-#LibraryContainer QPushButton,
-#LibraryContainer QLabel,
-#LibraryContainer QRadioButton,
-#LibraryContainer QHeaderView,
-#LibraryContainer QHeaderView::item {
+WLibrary QPushButton,
+WLibrary QLabel,
+WLibrary QRadioButton {
   font-family: "Open Sans";
   font-style: normal;
 }
@@ -1905,8 +1901,8 @@ do not highlight either state. */
 QToolTip,
 #MainMenu QMenu,
 WLibrarySidebar QMenu,
-WLibrary QHeaderView QMenu,
-#LibraryContainer QTextBrowser QMenu,
+WTrackTableViewHeader QMenu,
+WLibraryTextBrowser QMenu,
 WTrackMenu,
 WTrackMenu QMenu,
 QLineEdit QMenu,
@@ -1930,10 +1926,10 @@ QToolTip,
 #ToolBar,
 WLibrarySidebar QMenu,
 WLibrarySidebar QMenu::item,
-WLibrary QHeaderView QMenu,
-WLibrary QHeaderView QMenu::item,
-#LibraryContainer QTextBrowser QMenu,
-#LibraryContainer QTextBrowser QMenu::item,
+WTrackTableViewHeader QMenu,
+WTrackTableViewHeader QMenu::item,
+WLibraryTextBrowser QMenu,
+WLibraryTextBrowser QMenu::item,
 WTrackMenu,
 WTrackMenu::item,
 WTrackMenu QMenu,
@@ -1954,8 +1950,8 @@ WEffectSelector QAbstractScrollArea,
 }
 QToolTip,
 WLibrarySidebar QMenu,
-WLibrary QHeaderView QMenu,
-#LibraryContainer QTextBrowser QMenu,
+WTrackTableViewHeader QMenu,
+WLibraryTextBrowser QMenu,
 WTrackMenu,
 WTrackMenu QMenu,
 QLineEdit QMenu,
@@ -1977,9 +1973,9 @@ WEffectSelector QAbstractScrollArea,
   #MainMenu QMenu::indicator:unchecked:selected,
   WLibrarySidebar QMenu::item:selected,
   WLibrarySidebar QMenu::indicator:unchecked:selected,
-  WLibrary QHeaderView QMenu::item:selected,
-  WLibrary QHeaderView QMenu::indicator:unchecked:selected,
-  #LibraryContainer QTextBrowser QMenu::item:selected,
+  WTrackTableViewHeader QMenu::item:selected,
+  WTrackTableViewHeader QMenu::indicator:unchecked:selected,
+  WLibraryTextBrowser QMenu::item:selected,
   WTrackMenu::item:selected,
   WTrackMenu QMenu::item:selected,
   WTrackMenu QMenu QCheckBox:selected,
@@ -2136,7 +2132,7 @@ QLineEdit QMenu::separator {
 }
 #MainMenu QMenu::separator,
 WLibrarySidebar QMenu::separator,
-WLibrary QHeaderView QMenu::separator,
+WTrackTableViewHeader QMenu::separator,
 WTrackMenu::separator,
 WTrackMenu QMenu::separator,
 QLineEdit QMenu::separator {
@@ -2145,7 +2141,7 @@ QLineEdit QMenu::separator {
 
 /* All menus that have at least one item with a checkbox*/
 WLibrarySidebar QMenu::item,
-WLibrary QHeaderView QMenu::item,
+WTrackTableViewHeader QMenu::item,
 #CratesMenu::item {
 /* padding-right reserves space for the submenu expand arrow
   padding-left should be bigger than the menu icon width +
@@ -2163,18 +2159,18 @@ WTrackMenu QMenu::item,
 QLineEdit QMenu::item,
 WCoverArtMenu::item,
 /* for the sake of completeness: html root view of Crates, Rec etc. */
-#LibraryContainer QTextBrowser QMenu::item {
+WLibraryTextBrowser QMenu::item {
   padding: 5px 12px 5px 12px;
 }
 
 /* Icons in those menus (copy, paste, cut, delete) */
 QLineEdit QMenu::icon,
-#LibraryContainer QTextBrowser QMenu::icon,
+WLibraryTextBrowser QMenu::icon,
 /* - checkbox in Crate name context menu
     "[ ] Auto DJ Track Source" */
 WLibrarySidebar QMenu::indicator,
 /* Column checkboxes in the table header menu */
-WLibrary QHeaderView QMenu::indicator {
+WTrackTableViewHeader QMenu::indicator {
   /* Qt 5.12.8: negative margin-right increases the overall item width but has no effect
                 on the indicator itself.
                 positive margin-right pushes icon to the right...
@@ -2189,7 +2185,7 @@ WTrackMenu QMenu QCheckBox {
 }
 
 WLibrarySidebar QMenu::indicator,
-WLibrary QHeaderView QMenu::indicator,
+WTrackTableViewHeader QMenu::indicator,
 WTrackMenu QMenu QCheckBox::indicator {
   width: 13px;
   height: 13px;
@@ -2209,7 +2205,7 @@ WLibrary QTableView::indicator {
 
 QLineEdit QMenu::icon:selected,
 WLibrarySidebar QMenu::indicator:selected,
-WLibrary QHeaderView QMenu::indicator:selected,
+WTrackTableViewHeader QMenu::indicator:selected,
 WTrackMenu QMenu QCheckBox::indicator:selected {
   border: 1px solid #999;
 }
@@ -2233,7 +2229,7 @@ WLibrary QTableView::indicator:checked,
 WTrackMenu QMenu QCheckBox::indicator:checked {
   image: url(skin:/../Deere/icon/ic_library_checkmark_orange.svg);
 }
-WLibrary QHeaderView QMenu::indicator:checked,
+WTrackTableViewHeader QMenu::indicator:checked,
 WEffectSelector::indicator:checked,
 #fadeModeCombobox::indicator:checked {
   image: url(skin:/../Deere/icon/ic_library_checkmark_blue.svg);
@@ -2269,8 +2265,8 @@ WTrackMenu QMenu::right-arrow {
   selected, unchecked items would have a checkmark */
 WLibrarySidebar QMenu::indicator:unchecked,
 WLibrarySidebar QMenu::indicator:unchecked:selected,
-WLibrary QHeaderView QMenu::indicator:unchecked,
-WLibrary QHeaderView QMenu::indicator:unchecked:selected,
+WTrackTableViewHeader QMenu::indicator:unchecked,
+WTrackTableViewHeader QMenu::indicator:unchecked:selected,
 WLibrary QTableView::indicator:unchecked,
 WLibrary QTableView::indicator:unchecked:selected,
 WEffectSelector::indicator:unchecked,

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -24,12 +24,12 @@ WEffectSelector,
 WEffectSelector QAbstractScrollArea,
 #fadeModeCombobox,
 #fadeModeCombobox QAbstractScrollArea,
-#LibraryContainer QTextBrowser,
-#LibraryContainer QPushButton,
-#LibraryContainer QLabel,
-#LibraryContainer QRadioButton,
-#LibraryContainer QHeaderView,
-#LibraryContainer QHeaderView::section {
+WLibraryTextBrowser,
+WLibrary QPushButton,
+WLibrary QLabel,
+WLibrary QRadioButton,
+WTrackTableViewHeader,
+WTrackTableViewHeader::section {
   /* On Linux all weight variants of Open Sans are identified
   as "Open Sans".
   On Windows however, the semi-bold variant is identified as
@@ -86,7 +86,7 @@ WOverview #PassthroughLabel {
 QToolTip,
 WLibrarySidebar QMenu,
 WLibrary QHeaderView QMenu,
-#LibraryContainer QTextBrowser QMenu,
+WLibraryTextBrowser QMenu,
 WTrackMenu,
 WTrackMenu QMenu,
 WTrackMenu QMenu QCheckBox,
@@ -181,7 +181,7 @@ WEffectSelector::item:selected,
 }
 
 WLibrarySidebar QMenu::separator,
-#LibraryContainer QTextBrowser QMenu::separator,
+WLibraryTextBrowser QMenu::separator,
 WTrackMenu::separator,
 WTrackMenu QMenu::separator,
 QLineEdit QMenu::separator {
@@ -209,13 +209,13 @@ WTrackMenu QMenu::item,
 QLineEdit QMenu::item,
 WCoverArtMenu::item,
 /* for the sake of completeness: html root view of Crates, Rec etc. */
-#LibraryContainer QTextBrowser QMenu::item {
+WLibraryTextBrowser QMenu::item {
   padding: 5px 12px 5px 12px;
 }
 
 /* Icons in those menus (copy, paste, cut, delete) */
 QLineEdit QMenu::icon,
-#LibraryContainer QTextBrowser QMenu::icon,
+WLibraryTextBrowser QMenu::icon,
 /* - checkbox in Crate name context menu
     "[ ] Auto DJ Track Source" */
 WLibrarySidebar QMenu::indicator,
@@ -236,7 +236,7 @@ WTrackMenu QMenu QCheckBox {
 
   WTrackMenu::right-arrow,
   WTrackMenu QMenu::right-arrow,
-  #LibraryContainer QTableView::indicator {
+  WTrackTableView::indicator {
     width: 10px;
     height: 10px;
   }
@@ -360,17 +360,17 @@ WRecordingDuration {
 }
 
 
-#LibraryContainer QHeaderView::item {
+WTrackTableViewHeader::item {
   /* Don't set a font size to pick up the system font size. */
   border-bottom: 1px solid #000;
   }
-  #LibraryContainer QHeaderView::section {
+  WTrackTableViewHeader::section {
     height: 1.1em;
     border: 0px;
     padding: 2px;
   }
-  #LibraryContainer QHeaderView::up-arrow,
-  #LibraryContainer QHeaderView::down-arrow {
+  WTrackTableViewHeader::up-arrow,
+  WTrackTableViewHeader::down-arrow {
     width: 0.8em;
     padding: 0px 3px;
     }
@@ -909,7 +909,7 @@ QLabel#labelRecStatistics {
   margin: 3px 0px 3px 0px;
 }
 
-#LibraryContainer QTreeView {
+WLibrarySidebar {
   show-decoration-selected: 0;
 }
 /************** Library *******************************************************/

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -17,12 +17,14 @@ WBeatSpinBox,
 WOverview #PassthroughLabel,
 WCueMenuPopup,
 WCueMenuPopup QLabel,
+WCueMenuPopup QLineEdit,
 WOverview, /* Hotcue labels in the overview */
 WEffect,
 WEffectSelector,
 WEffectSelector QAbstractScrollArea,
 #fadeModeCombobox,
 #fadeModeCombobox QAbstractScrollArea,
+#LibraryContainer QTextBrowser,
 #LibraryContainer QPushButton,
 #LibraryContainer QLabel,
 #LibraryContainer QRadioButton,
@@ -84,13 +86,17 @@ WOverview #PassthroughLabel {
 QToolTip,
 WLibrarySidebar QMenu,
 WLibrary QHeaderView QMenu,
+#LibraryContainer QTextBrowser QMenu,
 WTrackMenu,
+WTrackMenu QMenu,
+WTrackMenu QMenu QCheckBox,
 QLineEdit QMenu,
 WCoverArtMenu,
 QLabel#labelRecPrefix,
 QLabel#labelRecStatistics {
   font-family: "Open Sans";
   font-weight: normal;
+  font-style: normal;
 }
 
 /* It is difficult to achieve identical styles WMainMenuBar #MainMenu
@@ -175,6 +181,7 @@ WEffectSelector::item:selected,
 }
 
 WLibrarySidebar QMenu::separator,
+#LibraryContainer QTextBrowser QMenu::separator,
 WTrackMenu::separator,
 WTrackMenu QMenu::separator,
 QLineEdit QMenu::separator {
@@ -202,13 +209,13 @@ WTrackMenu QMenu::item,
 QLineEdit QMenu::item,
 WCoverArtMenu::item,
 /* for the sake of completeness: html root view of Crates, Rec etc. */
-QTextBrowser QMenu::item {
+#LibraryContainer QTextBrowser QMenu::item {
   padding: 5px 12px 5px 12px;
 }
 
 /* Icons in those menus (copy, paste, cut, delete) */
 QLineEdit QMenu::icon,
-QTextBrowser QMenu::icon,
+#LibraryContainer QTextBrowser QMenu::icon,
 /* - checkbox in Crate name context menu
     "[ ] Auto DJ Track Source" */
 WLibrarySidebar QMenu::indicator,

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -1077,16 +1077,16 @@ WEffectSelector QAbstractScrollArea,
 WSearchLineEdit,
 #LibraryBPMSpinBox,
 #LibraryBPMButton::item,
-#LibraryContainer QTableView,
-#LibraryContainer QTableView::indicator,
-#LibraryContainer QTextBrowser,
-#LibraryContainer QTreeView,
+WTrackTableView,
+WTrackTableView::indicator,
+WLibraryTextBrowser,
+WLibrarySidebar,
 #LibraryFeatureControls QLabel,
 #LibraryFeatureControls QRadioButton,
 QToolTip,
 WLibrarySidebar QMenu,
-WLibrary QHeaderView QMenu,
-QTextBrowser QMenu,
+WTrackTableViewHeader QMenu,
+WLibraryTextBrowser QMenu,
 WTrackMenu,
 WTrackMenu QMenu,
 WTrackMenu QMenu QCheckBox,
@@ -1985,9 +1985,9 @@ WLibrary,
   border-top-left-radius: 0px;
 }
 
-#LibraryContainer QTableView,
-#LibraryContainer QTextBrowser,
-#LibraryContainer QTreeView {
+WTrackTableView,
+WLibraryTextBrowser,
+WLibrarySidebar {
   border-top: 1px solid #0a0a0a;
   border-right: 1px solid qlineargradient(x1:0, y1:0, x2:0, y2:1,
     stop:0 #333,
@@ -2004,28 +2004,25 @@ WLibrary,
   /* background of Color delegate in selected row */
   selection-background-color: #5e4507;
 }
-#LibraryContainer QTableView:focus,
-#LibraryContainer QTreeView:focus,
-#LibraryContainer QTextBrowser:focus {
+WTrackTableView:focus,
+WLibrarySidebar:focus,
+WLibraryTextBrowser:focus {
   border: 1px solid #d09300;
 }
 
 /* Selected rows in Tree and Tracks table */
-#LibraryContainer QTreeView::item:selected,
-#LibraryContainer QTableView::item:selected,
+WLibrarySidebar::item:selected,
+WTrackTableView::item:selected,
 #LibraryBPMButton::item:selected {
   color: #fff;
   background-color: #5e4507;
 }
-#LibraryContainer QTreeView::item:focus {
-  outline: none;
-}
 
 /* Use the native focus decoration */
 /* This is for all cells including Played and Location */
-#LibraryContainer QTableView,
+WTrackTableView,
 /* This is for the BPM cell */
-#LibraryContainer QTableView QCheckBox:focus {
+WTrackTableView QCheckBox:focus {
   outline: 1px solid #fff;
 }
 /* This uses a custom qproperty to set the focus border
@@ -2035,11 +2032,11 @@ WTrackTableView {
   qproperty-focusBorderColor: #fff;
 }
 
-#LibraryContainer QTreeView {
+WLibrarySidebar {
   show-decoration-selected: 0;
 }
-#LibraryContainer QTreeView,
-#LibraryContainer QTreeView::item:focus {
+WLibrarySidebar,
+WLibrarySidebar::item:focus {
   outline: none;
 }
 
@@ -2103,24 +2100,24 @@ WCueMenuPopup QPushButton:focus {
 
 /*********** table header styles *********************************/
 
-#LibraryContainer QHeaderView {
+WTrackTableViewHeader {
   color: #bbb;
   border-bottom: 1px solid #000;
   }
-  #LibraryContainer QHeaderView,
-  #LibraryContainer QHeaderView::section,
-  #LibraryContainer QHeaderView::up-arrow,
-  #LibraryContainer QHeaderView::down-arrow {
+  WTrackTableViewHeader,
+  WTrackTableViewHeader::section,
+  WTrackTableViewHeader::up-arrow,
+  WTrackTableViewHeader::down-arrow {
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
       stop:0 #222,
       stop:1 #111);
   }
-  #LibraryContainer QHeaderView::section {
+  WTrackTableViewHeader::section {
     border-right: 1px solid #000;
     border-bottom: 1px solid #000;
   }
-  #LibraryContainer QHeaderView::up-arrow,
-  #LibraryContainer QHeaderView::down-arrow {
+  WTrackTableViewHeader::up-arrow,
+  WTrackTableViewHeader::down-arrow {
     border-right: 1px solid #000;
     /* gradient colors should match those of QHeaderView gradient,
       with a little transparency added to not cut off the header label */
@@ -2128,10 +2125,10 @@ WCueMenuPopup QPushButton:focus {
       stop:0 rgba(34,34,34,190),
       stop:1 rgba(17,17,17,190));
     }
-    #LibraryContainer QHeaderView::up-arrow {
+    WTrackTableViewHeader::up-arrow {
       image: url(skin:/classic/buttons/btn__lib_sort_up.svg);
       }
-    #LibraryContainer QHeaderView::down-arrow {
+    WTrackTableViewHeader::down-arrow {
       image: url(skin:/classic/buttons/btn__lib_sort_down.svg);
     }
 
@@ -2164,7 +2161,7 @@ WEffectSelector QAbstractScrollArea QScrollBar {
     background-color: #000;
   }
   /* catch scroll bar of focused treeview like this:
-  #LibraryContainer QTreeView:focus QScrollBar:vertical {
+  WLibrarySidebar:focus QScrollBar:vertical {
   }*/
 #LibraryContainer QScrollBar::handle:horizontal,
 WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal {
@@ -2289,37 +2286,38 @@ WLibrary QRadioButton::indicator:unchecked {
 
 /* triangle for closed/opened branches in treeview */
 /* closed */
-#LibraryContainer QTreeView::branch:closed:has-children:!has-siblings:!selected,
-#LibraryContainer QTreeView::branch:closed:has-children:has-siblings:!selected {
+WLibrarySidebar::branch:closed:has-children:!has-siblings:!selected,
+WLibrarySidebar::branch:closed:has-children:has-siblings:!selected {
 /*  Suppresses that selected sidebar items branch indicator shows wrong color when out of focus ; lp:880588 */
   border-image: none;
+  /* TODO try if oversized icon would be upscaled */
   image: url(skin:/classic/style/library_branch_closed_grey.png);
   }
   /* closed, selected */
-  #LibraryContainer QTreeView::branch:closed:has-children:!has-siblings:selected,
-  #LibraryContainer QTreeView::branch:closed:has-children:has-siblings:selected {
+  WLibrarySidebar::branch:closed:has-children:!has-siblings:selected,
+  WLibrarySidebar::branch:closed:has-children:has-siblings:selected {
     border-image: none;
     image: url(skin:/classic/style/library_branch_closed_selected_white.png);
     background-color: #5e4507;
   }
 /* open */
-#LibraryContainer QTreeView::branch:open:has-children:!has-siblings,
-#LibraryContainer QTreeView::branch:open:has-children:has-siblings {
+WLibrarySidebar::branch:open:has-children:!has-siblings,
+WLibrarySidebar::branch:open:has-children:has-siblings {
   border-image: none;
   image: url(skin:/classic/style/library_branch_open_grey.png);
   }
   /* open, selected */
-  #LibraryContainer QTreeView::branch:open:has-children:!has-siblings:selected,
-  #LibraryContainer QTreeView::branch:open:has-children:has-siblings:selected {
+  WLibrarySidebar::branch:open:has-children:!has-siblings:selected,
+  WLibrarySidebar::branch:open:has-children:has-siblings:selected {
     border-image: none;
     image: url(skin:/classic/style/library_branch_open_selected_white.png);
     background-color: #5e4507;
     }
   /* space left of selected child item */
-  #LibraryContainer QTreeView::branch:closed:!has-children:!has-siblings:selected,
-  #LibraryContainer QTreeView::branch:closed:!has-children:has-siblings:selected,
-  #LibraryContainer QTreeView::branch:open:!has-children:!has-siblings:selected,
-  #LibraryContainer QTreeView::branch:open:!has-children:has-siblings:selected {
+  WLibrarySidebar::branch:closed:!has-children:!has-siblings:selected,
+  WLibrarySidebar::branch:closed:!has-children:has-siblings:selected,
+  WLibrarySidebar::branch:open:!has-children:!has-siblings:selected,
+  WLibrarySidebar::branch:open:!has-children:has-siblings:selected {
     border-image: none;
     background-color: #0f0f0f;
   }
@@ -2331,8 +2329,8 @@ WLibrary QRadioButton::indicator:unchecked {
 *************** QSpinBox, QMenu, QToolTip *************************************/
 QToolTip,
 WLibrarySidebar QMenu,
-WLibrary QHeaderView QMenu,
-QTextBrowser QMenu,
+WTrackTableViewHeader QMenu,
+WLibraryTextBrowser QMenu,
 WTrackMenu,
 WTrackMenu QMenu,
 WEffectSelector QAbstractScrollArea,
@@ -2360,10 +2358,10 @@ QToolTip,
 #MainMenu QMenu QCheckBox,
 WLibrarySidebar QMenu,
 WLibrarySidebar QMenu::item,
-WLibrary QHeaderView QMenu,
-WLibrary QHeaderView QMenu::item,
-QTextBrowser QMenu,
-QTextBrowser QMenu::item,
+WTrackTableViewHeader QMenu,
+WTrackTableViewHeader QMenu::item,
+WLibraryTextBrowser QMenu,
+WLibraryTextBrowser QMenu::item,
 WTrackMenu,
 WTrackMenu::item,
 WTrackMenu QMenu,
@@ -2393,7 +2391,7 @@ WEffectSelector, #fadeModeCombobox {
 /* ::indicator:!checked won't work. use 'unchecked' */
 #MainMenu QMenu::indicator:unchecked:selected,
 WLibrarySidebar QMenu::item:selected,
-WLibrary QHeaderView QMenu::item:selected,
+WTrackTableViewHeader QMenu::item:selected,
 WTrackMenu::item:selected,
 WTrackMenu QMenu::item:selected,
 WTrackMenu QMenu QCheckBox:selected,
@@ -2440,7 +2438,7 @@ QLineEdit QMenu::item:disabled {
   }
 
   WLibrarySidebar QMenu::indicator:checked,
-  WLibrary QHeaderView QMenu::indicator:checked,
+  WTrackTableViewHeader QMenu::indicator:checked,
   WLibrary QTableView::indicator:checked,
   WTrackMenu QMenu QCheckBox::indicator:checked,
   WEffectSelector::indicator:checked,
@@ -2480,21 +2478,21 @@ QLineEdit QMenu::item:disabled {
 
 /* This is the only way to select the 'Played' checkbox.
   Note that this also selects the BPM lock. */
-#LibraryContainer QTableView::indicator {
+WTrackTableView::indicator {
   /* border is added to size defined in style.qss */
   border: 1px solid transparent;
   margin: 0px;
   padding: 0px;
   }
-  #LibraryContainer QTableView::indicator:checked {
+  WTrackTableView::indicator:checked {
     border: 1px solid #ff6600;
     }
-  #LibraryContainer QTableView::indicator:unchecked {
+  WTrackTableView::indicator:unchecked {
     border: 1px solid rgba(151,151,151,128);
     }
   #MainMenu QMenu::separator,
   WLibrarySidebar QMenu::separator,
-  WLibrary QHeaderView QMenu::separator,
+  WTrackTableViewHeader QMenu::separator,
   WTrackMenu::separator,
   WTrackMenu QMenu::separator,
   QLineEdit QMenu::separator,
@@ -2507,8 +2505,8 @@ QLineEdit QMenu::item:disabled {
   selected, unchecked items would have a checkmark */
 WLibrarySidebar QMenu::indicator:unchecked,
 WLibrarySidebar QMenu::indicator:unchecked:selected,
-WLibrary QHeaderView QMenu::indicator:unchecked,
-WLibrary QHeaderView QMenu::indicator:unchecked:selected,
+WTrackTableViewHeader QMenu::indicator:unchecked,
+WTrackTableViewHeader QMenu::indicator:unchecked:selected,
 WLibrary QTableView::indicator:unchecked,
 WLibrary QTableView::indicator:unchecked:selected,
 WEffectSelector::indicator:unchecked,

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -175,16 +175,16 @@ WCueMenuPopup #CueLabelEdit {
   border-right: 1px solid #252525;
   background-color: #19191a;
   }
-#LibraryContainer QTableView,
-#LibraryContainer QTextBrowser,
-#LibraryContainer QTreeView,
+WTrackTableView,
+WLibraryTextBrowser,
+WLibrarySidebar,
 WSearchLineEdit {
   border-top: 1px solid #000;
   border-left: 1px solid #000;
   border-bottom: 1px solid #1e1e1e;
   border-right: 1px solid #222;
   }
-  #LibraryContainer QTextBrowser {
+  WLibraryTextBrowser {
     margin-top: 1px;
     padding: 5px 0px 0px 8px;
     border-top: 1px solid #212123;
@@ -1203,18 +1203,18 @@ WSearchLineEdit, WTime,
 #PreviewDeckTextBox, #PreviewTitle, #PreviewBPM,
 #LibraryBPMSpinBox,
 #LibraryBPMButton::item,
-#LibraryContainer QTableView,
-#LibraryContainer QTableView::indicator,
-#LibraryContainer QTextBrowser,
-#LibraryContainer QTreeView,
+WTrackTableView,
+WTrackTableView::indicator,
+WLibraryTextBrowser,
+WLibrarySidebar,
 #LibraryFeatureControls QLabel,
 #LibraryFeatureControls QPushButton,
 #LibraryFeatureControls QRadioButton,
 /* Tooltip and menus */
 QToolTip,
 WLibrarySidebar QMenu,
-WLibrary QHeaderView QMenu,
-QTextBrowser QMenu,
+WTrackTableViewHeader QMenu,
+WLibraryTextBrowser QMenu,
 WTrackMenu,
 WTrackMenu QMenu,
 WTrackMenu QMenu QCheckBox,
@@ -1249,7 +1249,7 @@ WEffectSelector:!editable:on,
 }
   /* dim² ivory */
   #SamplerBpm, #SamplerBpmMini,
-  #LibraryContainer QHeaderView {
+  WTrackTableViewHeader {
     color: #766b65;
   }
 
@@ -1470,17 +1470,17 @@ WEffectSelector:!editable,
     border-image: url(skin:/palemoon/buttons/btn_embedded_library_active.svg) 2 2 2 2;
   }
 
-  #LibraryContainer QHeaderView {
+  WTrackTableViewHeader {
     border-bottom-right-radius: 1px solid #000;
     outline: none;
   }
-  #LibraryContainer QHeaderView::section {
+  WTrackTableViewHeader::section {
     outline: none;
     border-width: 1px 2px 1px 1px;
     border-image: url(skin:/palemoon/buttons/btn_embedded_library_header.svg) 1 2 1 1;
   }
-  #LibraryContainer QHeaderView::up-arrow,
-  #LibraryContainer QHeaderView::down-arrow {
+  WTrackTableViewHeader::up-arrow,
+  WTrackTableViewHeader::down-arrow {
     outline: none;
     /* ToDo: restore image
     border-width: 1px 2px 1px 0px;
@@ -1577,8 +1577,8 @@ WBeatSpinBox::down-button {
   WBeatSpinBox::down-button,
   WPushButton#LoopActivate[displayValue="0"], /* in compact deck */
   WPushButton#FxParameterButton[displayValue="0"],
-  #LibraryContainer QHeaderView,
-  #LibraryContainer QHeaderView::section {
+  WTrackTableViewHeader,
+  WTrackTableViewHeader::section {
     background-color: #171719;
   }
   /* even buttons in 2nd level containers */
@@ -2439,9 +2439,9 @@ WColorPicker QPushButton[checked="true"] {
 
 /************** Library *********************************************/
 
-#LibraryContainer QTableView,
-#LibraryContainer QTextBrowser,
-#LibraryContainer QTreeView,
+WTrackTableView,
+WLibraryTextBrowser,
+WLibrarySidebar,
 #SkinSettings,
 WSearchLineEdit,
 WLibrary QLineEdit,
@@ -2450,9 +2450,9 @@ WLibrary QLineEdit,
   background-color: #0f0f0f;
 }
 
-#LibraryContainer QTableView,
-#LibraryContainer QTextBrowser,
-#LibraryContainer QTreeView {
+WTrackTableView,
+WLibraryTextBrowser,
+WLibrarySidebar {
   alternate-background-color: #0a0a0a;
 /* In selected library rows this sets the color of
   * shapes in star rating delegate
@@ -2463,32 +2463,32 @@ WLibrary QLineEdit,
   selection-background-color: #2c454f;
 }
 /* Selected rows in Tree and Tracks table */
-#LibraryContainer QTreeView::item:selected,
-#LibraryContainer QTableView::item:selected,
+WLibrarySidebar::item:selected,
+WTrackTableView::item:selected,
 #LibraryBPMButton::item:selected {
   color: #fff;
   background-color: #2c454f;
 }
-#LibraryContainer QTreeView,
-#LibraryContainer QTreeView::item:focus {
+WLibrarySidebar,
+WLibrarySidebar::item:focus {
   outline: none;
 }
 
-#LibraryContainer QTableView:focus,
-#LibraryContainer QTreeView:focus,
-#LibraryContainer QTextBrowser:focus {
+WTrackTableView:focus,
+WLibrarySidebar:focus,
+WLibraryTextBrowser:focus {
   border: 1px solid #257b82;
 }
 
-#LibraryContainer QTreeView {
+WLibrarySidebar {
   show-decoration-selected: 0;
 }
 
 /* Use the native focus decoration */
 /* This is for all cells including Played and Location */
-#LibraryContainer QTableView,
+WTrackTableView,
 /* This is for the BPM cell */
-#LibraryContainer QTableView QCheckBox:focus {
+WTrackTableView QCheckBox:focus {
   outline: 1px solid #fff;
 }
 /* This uses a custom qproperty to set the focus border
@@ -2563,15 +2563,15 @@ WLibrary QLineEdit,
 
 /*********** table header styles *********************************/
 
-#LibraryContainer QHeaderView {
+WTrackTableViewHeader {
   }
-  #LibraryContainer QHeaderView::section {
+  WTrackTableViewHeader::section {
     padding: 2px 1px 0px 3px;
     }
-    #LibraryContainer QHeaderView::up-arrow {
+    WTrackTableViewHeader::up-arrow {
       image: url(skin:/palemoon/buttons/btn__lib_sort_up.svg);
     }
-    #LibraryContainer QHeaderView::down-arrow {
+    WTrackTableViewHeader::down-arrow {
       image: url(skin:/palemoon/buttons/btn__lib_sort_down.svg);
     }
 
@@ -2608,7 +2608,7 @@ WEffectSelector QAbstractScrollArea QScrollBar {
     border-top: 1px solid #212123;
   }
   /* catch scroll bar of focused treeview like this:
-  #LibraryContainer QTreeView:focus QScrollBar:vertical {
+  WLibrarySidebar:focus QScrollBar:vertical {
   }*/
   #LibraryContainer QScrollBar::handle:horizontal,
   WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal {
@@ -2747,43 +2747,43 @@ WLibrary QRadioButton::indicator:unchecked {
     margin: 4px 5px 5px 1px;
   }
 
-#LibraryContainer QTreeView {
+WLibrarySidebar {
   show-decoration-selected: 0;
 }
 /* triangle for closed/opened branches in treeview */
 /* closed */
-#LibraryContainer QTreeView::branch:closed:has-children:!has-siblings:!selected,
-#LibraryContainer QTreeView::branch:closed:has-children:has-siblings:!selected {
+WLibrarySidebar::branch:closed:has-children:!has-siblings:!selected,
+WLibrarySidebar::branch:closed:has-children:has-siblings:!selected {
 /* Suppresses that selected sidebar items branch indicator shows wrong color when
     out of focus ; lp:880588 */
   border-image: none;
   image: url(skin:/palemoon/style/library_branch_closed_grey.png);
   }
   /* closed, selected */
-  #LibraryContainer QTreeView::branch:closed:has-children:!has-siblings:selected,
-  #LibraryContainer QTreeView::branch:closed:has-children:has-siblings:selected {
+  WLibrarySidebar::branch:closed:has-children:!has-siblings:selected,
+  WLibrarySidebar::branch:closed:has-children:has-siblings:selected {
     border-image: none;
     image: url(skin:/palemoon/style/library_branch_closed_selected_white.png);
     background-color: #2c454f;
   }
 /* open */
-#LibraryContainer QTreeView::branch:open:has-children:!has-siblings,
-#LibraryContainer QTreeView::branch:open:has-children:has-siblings {
+WLibrarySidebar::branch:open:has-children:!has-siblings,
+WLibrarySidebar::branch:open:has-children:has-siblings {
   border-image: none;
   image: url(skin:/palemoon/style/library_branch_open_grey.png);
   }
   /* open, selected */
-  #LibraryContainer QTreeView::branch:open:has-children:!has-siblings:selected,
-  #LibraryContainer QTreeView::branch:open:has-children:has-siblings:selected {
+  WLibrarySidebar::branch:open:has-children:!has-siblings:selected,
+  WLibrarySidebar::branch:open:has-children:has-siblings:selected {
     border-image: none;
     image: url(skin:/palemoon/style/library_branch_open_selected_white.png);
     background-color: #2c454f;
     }
   /* space left of selected child item */
-  #LibraryContainer QTreeView::branch:closed:!has-children:!has-siblings:selected,
-  #LibraryContainer QTreeView::branch:closed:!has-children:has-siblings:selected,
-  #LibraryContainer QTreeView::branch:open:!has-children:!has-siblings:selected,
-  #LibraryContainer QTreeView::branch:open:!has-children:has-siblings:selected {
+  WLibrarySidebar::branch:closed:!has-children:!has-siblings:selected,
+  WLibrarySidebar::branch:closed:!has-children:has-siblings:selected,
+  WLibrarySidebar::branch:open:!has-children:!has-siblings:selected,
+  WLibrarySidebar::branch:open:!has-children:has-siblings:selected {
     border-image: none;
     background-color: #0f0f0f;
   }
@@ -2795,8 +2795,8 @@ WLibrary QRadioButton::indicator:unchecked {
 *************** QSpinBox, QMenu, QToolTip *************************************/
 QToolTip,
 WLibrarySidebar QMenu,
-WLibrary QHeaderView QMenu,
-QTextBrowser QMenu,
+WTrackTableViewHeader QMenu,
+WLibraryTextBrowser QMenu,
 WTrackMenu,
 WTrackMenu QMenu,
 QLineEdit QMenu,
@@ -2822,10 +2822,10 @@ QToolTip,
 #MainMenu QMenu QCheckBox,
 WLibrarySidebar QMenu,
 WLibrarySidebar QMenu::item,
-WLibrary QHeaderView QMenu,
-WLibrary QHeaderView QMenu::item,
-QTextBrowser QMenu,
-QTextBrowser QMenu::item,
+WTrackTableViewHeader QMenu,
+WTrackTableViewHeader QMenu::item,
+WLibraryTextBrowser QMenu,
+WLibraryTextBrowser QMenu::item,
 WTrackMenu,
 WTrackMenu::item,
 WTrackMenu QMenu,
@@ -2852,7 +2852,7 @@ WEffectSelector::item,
 /* ::indicator:!checked won't work. use 'unchecked' */
 #MainMenu QMenu::indicator:unchecked:selected,
 WLibrarySidebar QMenu::item:selected,
-WLibrary QHeaderView QMenu::item:selected,
+WTrackTableViewHeader QMenu::item:selected,
 WTrackMenu::item:selected,
 WTrackMenu QMenu::item:selected,
 WTrackMenu QMenu QCheckBox:selected,
@@ -2897,7 +2897,7 @@ QLineEdit QMenu::item:disabled {
 }
 
   #MainMenu QMenu::separator,
-  #LibraryContainer QMenu::separator,
+  WLibrarySidebar QMenu::separator,
   WTrackMenu::separator,
   WTrackMenu QMenu::separator,
   QLineEdit QMenu::separator,
@@ -2927,7 +2927,7 @@ QLineEdit QMenu::item:disabled {
     }
 
   WLibrarySidebar QMenu::indicator:checked,
-  WLibrary QHeaderView QMenu::indicator:checked,
+  WTrackTableViewHeader QMenu::indicator:checked,
   WLibrary QTableView::indicator:checked,
   WTrackMenu QMenu QCheckBox::indicator:checked,
   WEffectSelector::indicator:checked,
@@ -2965,8 +2965,8 @@ QLineEdit QMenu::item:disabled {
   selected, unchecked items would have a checkmark */
 WLibrarySidebar QMenu::indicator:unchecked,
 WLibrarySidebar QMenu::indicator:unchecked:selected,
-WLibrary QHeaderView QMenu::indicator:unchecked,
-WLibrary QHeaderView QMenu::indicator:unchecked:selected,
+WTrackTableViewHeader QMenu::indicator:unchecked,
+WTrackTableViewHeader QMenu::indicator:unchecked:selected,
 WLibrary QTableView::indicator:unchecked,
 WLibrary QTableView::indicator:unchecked:selected,
 WEffectSelector::indicator:unchecked,

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -27,11 +27,11 @@ QSpinBox,
 WBeatSpinBox,
 QToolTip,
 WOverview #PassthroughLabel,
-WLibrary QHeaderView,
-WLibrary QHeaderView QMenu,
+WTrackTableViewHeader,
+WTrackTableViewHeader QMenu,
 WLibrarySidebar QMenu,
-#LibraryContainer QTextBrowser,
-#LibraryContainer QTextBrowser QMenu,
+WLibraryTextBrowser,
+WLibraryTextBrowser QMenu,
 QLineEdit QMenu,
 WCueMenuPopup,
 WCueMenuPopup QMenu,
@@ -110,9 +110,9 @@ WBeatSpinBox::down-button {
 QToolTip,
 WLibrarySidebar QMenu,
 WLibrarySidebar QMenu::item,
-WLibrary QHeaderView QMenu,
-WLibrary QHeaderView QMenu::item,
-#LibraryContainer QTextBrowser QMenu,
+WTrackTableViewHeader QMenu,
+WTrackTableViewHeader QMenu::item,
+WLibraryTextBrowser QMenu,
 WTrackMenu,
 WTrackMenu::item,
 WTrackMenu QMenu,
@@ -160,8 +160,8 @@ WBeatSpinBox,
 #MainMenu QMenu::indicator:unchecked:selected,
 WLibrarySidebar QMenu::item:selected,
 WLibrarySidebar QMenu::indicator:unchecked:selected,
-WLibrary QHeaderView QMenu::item:selected,
-WLibrary QHeaderView QMenu::indicator:unchecked:selected,
+WTrackTableViewHeader QMenu::item:selected,
+WTrackTableViewHeader QMenu::indicator:unchecked:selected,
 WLibraryTextBrowser QMenu::item:selected,
 WTrackMenu::item:selected,
 WTrackMenu QMenu::item:selected,
@@ -358,7 +358,7 @@ WEffectSelector QAbstractScrollArea,
   /* checked checkbox */
   /* checkbox in Crate name context menu: "[ ] Auto DJ Track Source"  */
   WLibrarySidebar QMenu::indicator:checked,
-  WLibrary QHeaderView QMenu::indicator:checked,
+  WTrackTableViewHeader QMenu::indicator:checked,
   WTrackMenu QMenu QCheckBox::indicator:checked,
   WEffectSelector::indicator:checked,
   #fadeModeCombobox::indicator:checked {
@@ -377,7 +377,7 @@ WEffectSelector QAbstractScrollArea,
   }
   /* unchecked menu checkbox */
   WLibrarySidebar QMenu::indicator:unchecked,
-  WLibrary QHeaderView QMenu::indicator:unchecked,
+  WTrackTableViewHeader QMenu::indicator:unchecked,
   WTrackMenu QMenu QCheckBox::indicator:enabled:unchecked {
     border-color: #1a2025;
     /* remove OS focus indicator */
@@ -397,7 +397,7 @@ WEffectSelector QAbstractScrollArea,
 
 /* All menus that have at least one item with a checkbox*/
 WLibrarySidebar QMenu::item,
-WLibrary QHeaderView QMenu::item,
+WTrackTableViewHeader QMenu::item,
 #CratesMenu::item {
 /* padding-right reserves space for the submenu expand arrow
   padding-left should be bigger than the menu icon width +
@@ -426,7 +426,7 @@ WLibraryTextBrowser QMenu::icon,
     "[ ] Auto DJ Track Source" */
 WLibrarySidebar QMenu::indicator,
 /* Column checkboxes in the table header menu */
-WLibrary QHeaderView QMenu::indicator {
+WTrackTableViewHeader QMenu::indicator {
   /* Qt 5.12.8: negative margin-right increases the overall item width but has no effect
                 on the indicator itself.
                 positive margin-right pushes icon to the right...
@@ -441,7 +441,7 @@ WTrackMenu QMenu QCheckBox {
 }
 
 WLibrarySidebar QMenu::separator,
-WLibrary QHeaderView QMenu::separator,
+WTrackTableViewHeader QMenu::separator,
 WTrackMenu::separator,
 WTrackMenu QMenu::separator,
 QLineEdit QMenu::separator {
@@ -450,7 +450,7 @@ QLineEdit QMenu::separator {
   }
   #MainMenu QMenu::separator,
   WLibrarySidebar QMenu::separator,
-  WLibrary QHeaderView QMenu::separator,
+  WTrackTableViewHeader QMenu::separator,
   WTrackMenu::separator,
   WTrackMenu QMenu::separator,
   QLineEdit QMenu::separator {
@@ -458,7 +458,7 @@ QLineEdit QMenu::separator {
   }
 
   WLibrarySidebar QMenu::indicator,
-  WLibrary QHeaderView QMenu::indicator,
+  WTrackTableViewHeader QMenu::indicator,
   WTrackMenu QMenu QCheckBox::indicator {
     width: 13px;
     height: 13px;
@@ -530,9 +530,9 @@ WLibrary WColorPicker QPushButton {
 ################### most of it was LateNight & Deere & Tango ###
 ############ added styling for AutoDJ & Recording etc ###### */
 
-#LibraryContainer QTableView,
-#LibraryContainer QTextBrowser,
-#LibraryContainer QTreeView {
+WTrackTableView,
+WLibraryTextBrowser,
+WLibrarySidebar {
   border: 1px solid #585858;
   font-weight: normal;
   color: #9e9e9e;
@@ -545,27 +545,27 @@ WLibrary WColorPicker QPushButton {
   selection-background-color: #656d75;
 }
 
-#LibraryContainer QTextBrowser {
+WLibraryTextBrowser {
   padding-left: 10px;
 }
 
-#LibraryContainer QTableView::item:selected,
-#LibraryContainer QTreeView::item:selected,
-#LibraryContainer QTreeView::branch:selected,
+WTrackTableView::item:selected,
+WLibrarySidebar::item:selected,
+WLibrarySidebar::branch:selected,
 #LibraryBPMButton::item:selected {
   color: #000;
   background-color: #656d75;
 }
-#LibraryContainer QTreeView,
-#LibraryContainer QTreeView::item:focus {
+WLibrarySidebar,
+WLibrarySidebar::item:focus {
   outline: none;
 }
 
 /* Use the native focus decoration */
 /* This is for all cells including Played and Location */
-#LibraryContainer QTableView,
+WTrackTableView,
 /* This is for the BPM cell */
-#LibraryContainer QTableView QCheckBox:focus {
+WTrackTableView QCheckBox:focus {
   outline: 1px solid #c9c9c9;
 }
 /* This uses a custom qproperty to set the focus border
@@ -642,7 +642,7 @@ WTrackTableView {
 
 
   /* checkbox in library "Played" column */
-  WLibrary QTableView::indicator {
+  WTrackTableView::indicator {
     width: 10px;
     height: 10px;
     margin: 0px;
@@ -650,11 +650,11 @@ WTrackTableView {
     color: #cfcfcf;
     border: 1px solid transparent;
     }
-    WLibrary QTableView::indicator:checked {
+    WTrackTableView::indicator:checked {
       image: url(skin:/btn/btn_lib_checkmark.svg) no-repeat center center;
       border: 1px solid #ff6600;
     }
-    WLibrary QTableView::indicator:unchecked {
+    WTrackTableView::indicator:unchecked {
       border: 1px solid rgba(151,151,151,128);
     }
 
@@ -662,10 +662,10 @@ WTrackTableView {
   selected, unchecked items would have a checkmark */
 WLibrarySidebar QMenu::indicator:unchecked,
 WLibrarySidebar QMenu::indicator:unchecked:selected,
-WLibrary QHeaderView QMenu::indicator:unchecked,
-WLibrary QHeaderView QMenu::indicator:unchecked:selected,
-WLibrary QTableView::indicator:unchecked,
-WLibrary QTableView::indicator:unchecked:selected,
+WTrackTableViewHeader QMenu::indicator:unchecked,
+WTrackTableViewHeader QMenu::indicator:unchecked:selected,
+WTrackTableView::indicator:unchecked,
+WTrackTableView::indicator:unchecked:selected,
 WEffectSelector::indicator:unchecked,
 WEffectSelector::indicator:unchecked:selected,
 #fadeModeCombobox::indicator:unchecked,
@@ -695,7 +695,7 @@ WSearchLineEdit {
   /* Clear button: see /skins/default.qss */
 
 
-#LibraryContainer QTreeView {
+WLibrarySidebar {
   min-height: 90px;
   min-width: 90px;
   show-decoration-selected: 0;
@@ -703,44 +703,44 @@ WSearchLineEdit {
   Defined by SearchBox	*/
   margin: 0px;
   }
-  #LibraryContainer QTableView:focus,
-  #LibraryContainer QTreeView:focus,
+  WTrackTableView:focus,
+  WLibrarySidebar:focus,
   #LibraryContainer WLibraryTextBrowser:focus {
     border-color: #ff6600;
   }
 
 /*  Closed branch of tree 	*/
-#LibraryContainer QTreeView::branch:has-children:!has-siblings:closed,
-#LibraryContainer QTreeView::branch:closed:has-children:has-siblings {
+WLibrarySidebar::branch:has-children:!has-siblings:closed,
+WLibrarySidebar::branch:closed:has-children:has-siblings {
   image: url(skin:/style/style_branch_closed.png);
   }
-  #LibraryContainer QTreeView::branch:has-children:!has-siblings:closed:selected,
-  #LibraryContainer QTreeView::branch:closed:has-children:has-siblings:selected {
+  WLibrarySidebar::branch:has-children:!has-siblings:closed:selected,
+  WLibrarySidebar::branch:closed:has-children:has-siblings:selected {
     image: url(skin:/style/style_branch_closed_selected.png);
   }
 
 /*  Open branch of tree 	*/
-#LibraryContainer QTreeView::branch:open:has-children:!has-siblings,
-#LibraryContainer QTreeView::branch:open:has-children:has-siblings {
+WLibrarySidebar::branch:open:has-children:!has-siblings,
+WLibrarySidebar::branch:open:has-children:has-siblings {
   image: url(skin:/style/style_branch_open.png);
   }
-  #LibraryContainer QTreeView::branch:open:has-children:!has-siblings:selected,
-  #LibraryContainer QTreeView::branch:open:has-children:has-siblings:selected {
+  WLibrarySidebar::branch:open:has-children:!has-siblings:selected,
+  WLibrarySidebar::branch:open:has-children:has-siblings:selected {
     border-image: none;
     image: url(skin:/style/style_branch_open_selected.png);
   }
   /* space left of selected child item */
-  #LibraryContainer QTreeView::branch:!has-children:!has-siblings:closed:selected,
-  #LibraryContainer QTreeView::branch:closed:!has-children:has-siblings:selected,
-  #LibraryContainer QTreeView::branch:open:!has-children:!has-siblings:selected,
-  #LibraryContainer QTreeView::branch:open:!has-children:has-siblings:selected {
+  WLibrarySidebar::branch:!has-children:!has-siblings:closed:selected,
+  WLibrarySidebar::branch:closed:!has-children:has-siblings:selected,
+  WLibrarySidebar::branch:open:!has-children:!has-siblings:selected,
+  WLibrarySidebar::branch:open:!has-children:has-siblings:selected {
     border-image: none;
     background-color: #0f0f0f;
   }
 
 
-WLibrary QHeaderView,
-WLibrary QHeaderView::section,
+WTrackTableViewHeader,
+WTrackTableViewHeader::section,
 #LibraryContainer QScrollBar:horizontal,
 #LibraryContainer QScrollBar:vertical,
 WEffectSelector QAbstractScrollArea QScrollBar:horizontal,
@@ -749,7 +749,7 @@ WEffectSelector QAbstractScrollArea QScrollBar:vertical,
 #fadeModeCombobox QAbstractScrollArea QScrollBar:vertical {
   background-color: #626f87;
 }
-WLibrary QHeaderView {
+WTrackTableViewHeader {
   /* Don't set a font size to pick up the system font size. */
   font-weight: bold;
   color: #000;
@@ -757,7 +757,7 @@ WLibrary QHeaderView {
   border-bottom: 1px solid #0f0f0f;
 }
 /*	Library header 'buttons'	*/
-WLibrary QHeaderView::section {
+WTrackTableViewHeader::section {
   height: 1.1em;
   padding: 2px 1px 2px 2px;
   /*	set right border so that first column header
@@ -767,17 +767,17 @@ WLibrary QHeaderView::section {
   border-radius: 0px;
 }
 
-WLibrary QHeaderView::up-arrow,
-WLibrary QHeaderView::down-arrow {
+WTrackTableViewHeader::up-arrow,
+WTrackTableViewHeader::down-arrow {
   width: 12px;
   padding-right: 2px;
   margin-right: 1px;
   background-color: rgba(98,111,135,255);
   }
-  WLibrary QHeaderView::up-arrow {
+  WTrackTableViewHeader::up-arrow {
     image: url(skin:/btn/btn_lib_sort_up_black.png)
   }
-  WLibrary QHeaderView::down-arrow {
+  WTrackTableViewHeader::down-arrow {
     image: url(skin:/btn/btn_lib_sort_down_black.png)
   }
 

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -16,7 +16,7 @@
 #Mixxx, WWidget,
 WEffect,
 WKey,
-WLabel, WLibrary QLabel,
+WLabel, QLabel,
 WNumber, WNumberPos,
 WPushButton, WLibrary QPushButton, WLibrary QRadioButton,
 WRecordingDuration,
@@ -30,13 +30,15 @@ WOverview #PassthroughLabel,
 WLibrary QHeaderView,
 WLibrary QHeaderView QMenu,
 WLibrarySidebar QMenu,
-QTextBrowser QMenu,
+#LibraryContainer QTextBrowser,
+#LibraryContainer QTextBrowser QMenu,
 QLineEdit QMenu,
 WCueMenuPopup,
 WCueMenuPopup QMenu,
 WCoverArtMenu,
 WTrackMenu,
 WTrackMenu QMenu,
+WTrackMenu QMenu QCheckBox,
 WOverview /* Hotcue labels in the overview */,
 QComboBox,
 WEffectSelector,
@@ -44,6 +46,8 @@ WEffectSelector QAbstractScrollArea,
 #fadeModeCombobox,
 #fadeModeCombobox QAbstractScrollArea {
   font-family: "Open Sans";
+  font-weight: normal;
+  font-style: normal;
 }
 
 /* Passthrough label on overview waveform */
@@ -108,8 +112,7 @@ WLibrarySidebar QMenu,
 WLibrarySidebar QMenu::item,
 WLibrary QHeaderView QMenu,
 WLibrary QHeaderView QMenu::item,
-QTextBrowser QMenu,
-QTextBrowser QMenu::item,
+#LibraryContainer QTextBrowser QMenu,
 WTrackMenu,
 WTrackMenu::item,
 WTrackMenu QMenu,
@@ -159,7 +162,7 @@ WLibrarySidebar QMenu::item:selected,
 WLibrarySidebar QMenu::indicator:unchecked:selected,
 WLibrary QHeaderView QMenu::item:selected,
 WLibrary QHeaderView QMenu::indicator:unchecked:selected,
-QTextBrowser QMenu::item:selected,
+WLibraryTextBrowser QMenu::item:selected,
 WTrackMenu::item:selected,
 WTrackMenu QMenu::item:selected,
 WTrackMenu QMenu QCheckBox:selected,
@@ -412,13 +415,13 @@ WTrackMenu QMenu::item,
 QLineEdit QMenu::item,
 WCoverArtMenu::item,
 /* for the sake of completeness: html root view of Crates, Rec etc. */
-QTextBrowser QMenu::item {
+WLibraryTextBrowser QMenu::item {
   padding: 5px 12px 5px 12px;
 }
 
 /* Icons in those menus (copy, paste, cut, delete) */
 QLineEdit QMenu::icon,
-QTextBrowser QMenu::icon,
+WLibraryTextBrowser QMenu::icon,
 /* - checkbox in Crate name context menu
     "[ ] Auto DJ Track Source" */
 WLibrarySidebar QMenu::indicator,
@@ -542,7 +545,7 @@ WLibrary WColorPicker QPushButton {
   selection-background-color: #656d75;
 }
 
-QTextBrowser {
+#LibraryContainer QTextBrowser {
   padding-left: 10px;
 }
 
@@ -702,7 +705,7 @@ WSearchLineEdit {
   }
   #LibraryContainer QTableView:focus,
   #LibraryContainer QTreeView:focus,
-  #LibraryContainer QTextBrowser:focus {
+  #LibraryContainer WLibraryTextBrowser:focus {
     border-color: #ff6600;
   }
 

--- a/res/skins/Shade/style_dark.qss
+++ b/res/skins/Shade/style_dark.qss
@@ -5,10 +5,10 @@
 QToolTip,
 WLibrarySidebar QMenu,
 WLibrarySidebar QMenu::item,
-WLibrary QHeaderView QMenu,
-WLibrary QHeaderView QMenu::item,
-QTextBrowser QMenu,
-QTextBrowser QMenu::item,
+WTrackTableViewHeader QMenu,
+WTrackTableViewHeader QMenu::item,
+WLibraryTextBrowser QMenu,
+WLibraryTextBrowser QMenu::item,
 WTrackMenu,
 WTrackMenu::item,
 WTrackMenu QMenu,
@@ -52,9 +52,9 @@ WEffectSelector::indicator:unchecked,
 #MainMenu QMenu::indicator:unchecked:selected,
 WLibrarySidebar QMenu::item:selected,
 WLibrarySidebar QMenu::indicator:unchecked:selected,
-WLibrary QHeaderView QMenu::item:selected,
-WLibrary QHeaderView QMenu::indicator:unchecked:selected,
-QTextBrowser QMenu::item:selected,
+WTrackTableViewHeader QMenu::item:selected,
+WTrackTableViewHeader QMenu::indicator:unchecked:selected,
+WLibraryTextBrowser QMenu::item:selected,
 WTrackMenu::item:selected,
 WTrackMenu QMenu::item:selected,
 WTrackMenu QMenu QCheckBox:selected,
@@ -80,7 +80,7 @@ WEffectSelector::indicator:unchecked:selected,
 
   #MainMenu QMenu::separator,
   WLibrarySidebar QMenu::separator,
-  WLibrary QHeaderView QMenu::separator,
+  WTrackTableViewHeader QMenu::separator,
   WTrackMenu::separator,
   WTrackMenu QMenu::separator,
   QLineEdit QMenu::separator {
@@ -89,7 +89,7 @@ WEffectSelector::indicator:unchecked:selected,
   /* checked checkbox */
   /* checkbox in Crate name context menu: "[ ] Auto DJ Track Source"  */
   WLibrarySidebar QMenu::indicator:checked,
-  WLibrary QHeaderView QMenu::indicator:checked,
+  WTrackTableViewHeader QMenu::indicator:checked,
   WTrackMenu QMenu QCheckBox::indicator:checked,
   WEffectSelector::indicator:checked,
   #fadeModeCombobox::indicator:checked {
@@ -143,16 +143,16 @@ WOverview #PassthroughLabel {
 }
 
 
-#LibraryContainer QTableView,
-#LibraryContainer QTreeView {
+WTrackTableView,
+WLibrarySidebar {
   /* background of Color delegate in selected row */
   selection-background-color: #666;
   /*outline: 1px solid yellow;*/
 }
 
-#LibraryContainer QTableView:focus,
-#LibraryContainer QTreeView:focus,
-#LibraryContainer QTextBrowser:focus {
+WTrackTableView:focus,
+WLibrarySidebar:focus,
+WLibraryTextBrowser:focus {
   border-color: #78C70B;
 }
 
@@ -163,23 +163,23 @@ WSearchLineEdit QToolButton:focus {
   image: url(skin:/btn/btn_lib_clear_search_focus_green.svg);
 }
 
-#LibraryContainer QTreeView::item:selected,
-#LibraryContainer QTableView::item:selected,
-#LibraryContainer QTreeView::branch:selected,
+WLibrarySidebar::item:selected,
+WTrackTableView::item:selected,
+WLibrarySidebar::branch:selected,
 #LibraryBPMButton::item:selected {
   color: #000;
   selection-color: #000;
   background-color: #666;
 }
-#LibraryContainer QTreeView,
-#LibraryContainer QTreeView::item:focus {
+WLibrarySidebar,
+WLibrarySidebar::item:focus {
   outline: none;
 }
 /* Use the native focus decoration */
 /* This is for all cells including Played and Location */
-#LibraryContainer QTableView,
+WTrackTableView,
 /* This is for the BPM cell */
-#LibraryContainer QTableView QCheckBox:focus {
+WTrackTableView QCheckBox:focus {
   outline: 1px solid #ccc;
 }
 /* This uses a custom qproperty to set the focus border
@@ -207,7 +207,7 @@ WTrackTableView {
   }
 
 /* checkbox in library "Played" column */
-#LibraryContainer QTableView::indicator:unchecked:selected {
+WTrackTableView::indicator:unchecked:selected {
   background: none;
   color: #cfcfcf;
   border: 1px solid #000;
@@ -223,8 +223,8 @@ WEffectSelector QAbstractScrollArea QScrollBar::sub-page,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::sub-page {
   background-color: #000;
 }
-#LibraryContainer QHeaderView,
-#LibraryContainer QHeaderView::section,
+WTrackTableViewHeader,
+WTrackTableViewHeader::section,
 #LibraryContainer QScrollBar::handle:vertical,
 #LibraryContainer QScrollBar::handle:horizontal,
 WEffectSelector QAbstractScrollArea QScrollBar::handle:vertical,
@@ -234,14 +234,14 @@ WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal,
   background: #3f3041;
   color: #999;
 }
-#LibraryContainer QHeaderView::up-arrow,
-#LibraryContainer QHeaderView::down-arrow {
+WTrackTableViewHeader::up-arrow,
+WTrackTableViewHeader::down-arrow {
   background-color: rgba(63,48,65,200);
   }
-  #LibraryContainer QHeaderView::up-arrow {
+  WTrackTableViewHeader::up-arrow {
     image: url(skin:/btn/btn_lib_sort_up_green.png)
   }
-  #LibraryContainer QHeaderView::down-arrow {
+  WTrackTableViewHeader::down-arrow {
     image: url(skin:/btn/btn_lib_sort_down_green.png)
   }
 #LibraryFeatureControls QPushButton:enabled {

--- a/res/skins/Shade/style_summer_sunset.qss
+++ b/res/skins/Shade/style_summer_sunset.qss
@@ -5,8 +5,8 @@
 QToolTip,
 WLibrarySidebar QMenu,
 WLibrarySidebar QMenu::item,
-WLibrary QHeaderView QMenu,
-WLibrary QHeaderView QMenu::item,
+WTrackTableViewHeader QMenu,
+WTrackTableViewHeader QMenu::item,
 QTextBrowser QMenu,
 QTextBrowser QMenu::item,
 WTrackMenu,
@@ -46,7 +46,7 @@ WBeatSpinBox,
 }
   #MainMenu QMenu::separator
   WLibrarySidebar QMenu::separator,
-  WLibrary QHeaderView QMenu::separator,
+  WTrackTableViewHeader QMenu::separator,
   WTrackMenu::separator,
   WTrackMenu QMenu::separator,
   QLineEdit QMenu::separator {
@@ -60,8 +60,8 @@ WBeatSpinBox,
 #MainMenu QMenu::indicator:unchecked:selected,
 WLibrarySidebar QMenu::item:selected,
 WLibrarySidebar QMenu::indicator:unchecked:selected,
-WLibrary QHeaderView QMenu::item:selected,
-WLibrary QHeaderView QMenu::indicator:unchecked:selected,
+WTrackTableViewHeader QMenu::item:selected,
+WTrackTableViewHeader QMenu::indicator:unchecked:selected,
 QTextBrowser QMenu::item:selected,
 WTrackMenu::item:selected,
 WTrackMenu QMenu::item:selected,
@@ -87,7 +87,7 @@ WEffectSelector::indicator:unchecked:selected,
   }
   /* unchecked menu checkbox */
   WLibrarySidebar QMenu::indicator:unchecked,
-  WLibrary QHeaderView QMenu::indicator:unchecked,
+  WTrackTableViewHeader QMenu::indicator:unchecked,
   WTrackMenu QMenu QCheckBox::indicator:enabled:unchecked {
     border-color: #222;
   }
@@ -95,7 +95,7 @@ WEffectSelector::indicator:unchecked:selected,
   /* checked checkbox */
   /* checkbox in Crate name context menu: "[ ] Auto DJ Track Source"  */
   WLibrarySidebar QMenu::indicator:checked,
-  WLibrary QHeaderView QMenu::indicator:checked,
+  WTrackTableViewHeader QMenu::indicator:checked,
   WTrackMenu QMenu QCheckBox::indicator:checked,
   WEffectSelector::indicator:checked,
   #fadeModeCombobox::indicator:checked {
@@ -140,9 +140,9 @@ WOverview #PassthroughLabel {
   color: #FF9900;
 }
 
-#LibraryContainer QTableView:focus,
-#LibraryContainer QTreeView:focus,
-#LibraryContainer QTextBrowser:focus,
+WTrackTableView:focus,
+WLibrarySidebar:focus,
+WLibraryTextBrowser:focus,
 WSearchLineEdit:focus {
   border-color: #78C70B;
 }

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -31,12 +31,14 @@ WEffect,
 WEffectSelector,
 WEffectSelector QAbstractScrollArea,
 #fadeModeCombobox,
-#fadeModeCombobox QAbstractScrollArea
+#fadeModeCombobox QAbstractScrollArea,
+#LibraryContainer QTextBrowser,
 #LibraryContainer QPushButton,
 #LibraryContainer QLabel,
 #LibraryContainer QRadioButton {
   font-family: Ubuntu;
   font-weight: normal;
+  font-style: normal;
 }
 /* Unfortunately, the proportional line height of the Ubuntu font
   is not as tall as Open Sans. For single-line buttons this doesn't
@@ -48,10 +50,11 @@ QToolTip,
 WCueMenuPopup QLabel,
 WTrackMenu,
 WTrackMenu QMenu,
+WTrackMenu QMenu QCheckBox,
 QLineEdit QMenu,
 WCoverArtMenu,
 WLibrarySidebar QMenu,
-QTextBrowser QMenu,
+#LibraryContainer QTextBrowser QMenu,
 WOverview, /* Hotcue labels in the overview */
 WEffectSelector,
 WEffectSelector QAbstractScrollArea,
@@ -60,6 +63,8 @@ WEffectSelector QAbstractScrollArea,
 /* With 'Ubuntu' font the header section titles would always be top-aligned... */
 WLibrary QHeaderView::section {
   font-family: "Open Sans";
+  font-weight: normal;
+  font-style: normal;
 }
 
 WPushButton {
@@ -2200,13 +2205,13 @@ WTrackMenu QMenu::item,
 QLineEdit QMenu::item,
 WCoverArtMenu::item,
 /* for the sake of completeness: html root view of Crates, Rec etc. */
-QTextBrowser QMenu::item {
+WLibraryTextBrowser QMenu::item {
   padding: 5px 12px 5px 12px;
 }
 
 /* Icons in those menus (copy, paste, cut, delete) */
 QLineEdit QMenu::icon,
-QTextBrowser QMenu::icon,
+WLibraryTextBrowser QMenu::icon,
 /* - checkbox in Crate name context menu
     "[ ] Auto DJ Track Source" */
 WLibrarySidebar QMenu::indicator,
@@ -2241,8 +2246,8 @@ WLibrarySidebar QMenu,
 WLibrarySidebar QMenu::item,
 WLibrary QHeaderView QMenu,
 WLibrary QHeaderView QMenu::item,
-QTextBrowser QMenu,
-QTextBrowser QMenu::item,
+WLibraryTextBrowser QMenu,
+WLibraryTextBrowser QMenu::item,
 WTrackMenu,
 WTrackMenu::item,
 WTrackMenu QMenu,
@@ -2664,7 +2669,7 @@ WTrackTableView {
         image: url(skin:/../Tango/graphics/library_sort_up.svg);
       }
 
-QTextBrowser {
+#LibraryContainer QTextBrowser {
   padding-left: 5px;
 }
 

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -32,10 +32,10 @@ WEffectSelector,
 WEffectSelector QAbstractScrollArea,
 #fadeModeCombobox,
 #fadeModeCombobox QAbstractScrollArea,
-#LibraryContainer QTextBrowser,
-#LibraryContainer QPushButton,
-#LibraryContainer QLabel,
-#LibraryContainer QRadioButton {
+WLibraryTextBrowser,
+WLibrary QPushButton,
+WLibrary QLabel,
+WLibrary QRadioButton {
   font-family: Ubuntu;
   font-weight: normal;
   font-style: normal;
@@ -54,14 +54,14 @@ WTrackMenu QMenu QCheckBox,
 QLineEdit QMenu,
 WCoverArtMenu,
 WLibrarySidebar QMenu,
-#LibraryContainer QTextBrowser QMenu,
+WLibraryTextBrowser QMenu,
 WOverview, /* Hotcue labels in the overview */
 WEffectSelector,
 WEffectSelector QAbstractScrollArea,
 #fadeModeCombobox,
 #fadeModeCombobox QAbstractScrollArea,
 /* With 'Ubuntu' font the header section titles would always be top-aligned... */
-WLibrary QHeaderView::section {
+WTrackTableViewHeader::section {
   font-family: "Open Sans";
   font-weight: normal;
   font-style: normal;
@@ -73,9 +73,9 @@ WPushButton {
 }
 
 WPushButton,
-#LibraryContainer QPushButton,
-#LibraryContainer QLabel,
-#LibraryContainer QRadioButton {
+WLibrary QPushButton,
+WLibrary QLabel,
+WLibrary QRadioButton {
   font-size: 12px/12px;
 }
 
@@ -2187,7 +2187,7 @@ WEffectSelector::indicator:unchecked,
 
 /* All menus that have at least one item with a checkbox*/
 WLibrarySidebar QMenu::item,
-WLibrary QHeaderView QMenu::item,
+WTrackTableViewHeader QMenu::item,
 #CratesMenu::item {
 /* padding-right reserves space for the submenu expand arrow
   padding-left should be bigger than the menu icon width +
@@ -2216,7 +2216,7 @@ WLibraryTextBrowser QMenu::icon,
     "[ ] Auto DJ Track Source" */
 WLibrarySidebar QMenu::indicator,
 /* Column checkboxes in the table header menu */
-WLibrary QHeaderView QMenu::indicator {
+WTrackTableViewHeader QMenu::indicator {
   /* Qt 5.12.8: negative margin-right increases the overall item width but has no effect
                 on the indicator itself.
                 positive margin-right pushes icon to the right...
@@ -2244,8 +2244,8 @@ QToolTip,
 #MainMenu QMenu QCheckBox,
 WLibrarySidebar QMenu,
 WLibrarySidebar QMenu::item,
-WLibrary QHeaderView QMenu,
-WLibrary QHeaderView QMenu::item,
+WTrackTableViewHeader QMenu,
+WTrackTableViewHeader QMenu::item,
 WLibraryTextBrowser QMenu,
 WLibraryTextBrowser QMenu::item,
 WTrackMenu,
@@ -2272,7 +2272,7 @@ WEffectSelector, WEffectSelector QAbstractScrollArea,
 QToolTip,
 WCueMenuPopup,
 WLibrarySidebar QMenu,
-WLibrary QHeaderView QMenu,
+WTrackTableViewHeader QMenu,
 QLineEdit QMenu,
 WCoverArtMenu,
 WTrackMenu,
@@ -2300,7 +2300,7 @@ WEffectSelector QAbstractScrollArea,
 /* ::indicator:!checked won't work. use 'unchecked' */
 #MainMenu QMenu::indicator:unchecked:selected,
 WLibrarySidebar QMenu::item:selected,
-WLibrary QHeaderView QMenu::item:selected,
+WTrackTableViewHeader QMenu::item:selected,
 WTrackMenu::item:selected,
 WTrackMenu QMenu::item:selected,
 WTrackMenu QMenu QCheckBox:selected,
@@ -2328,7 +2328,7 @@ QLineEdit QMenu::item:disabled {
 }
 
 WLibrarySidebar QMenu::separator,
-WLibrary QHeaderView QMenu::separator,
+WTrackTableViewHeader QMenu::separator,
 WTrackMenu::separator,
 WTrackMenu QMenu::separator,
 QLineEdit QMenu::separator {
@@ -2337,7 +2337,7 @@ QLineEdit QMenu::separator {
   }
   #MainMenu QMenu::separator,
   WLibrarySidebar QMenu::separator,
-  WLibrary QHeaderView QMenu::separator,
+  WTrackTableViewHeader QMenu::separator,
   WTrackMenu::separator,
   WTrackMenu QMenu::separator,
   QLineEdit QMenu::separator {
@@ -2361,16 +2361,16 @@ WTrackMenu QMenu::right-arrow {
     image: url(skin:/../Tango/buttons/btn_arrow_right_hover.svg);
   }
 
-  WLibrary QHeaderView QMenu::indicator {
+  WTrackTableViewHeader QMenu::indicator {
     width: 10px;
     height: 10px;
     }
-    WLibrary QHeaderView QMenu::indicator:checked {
+    WTrackTableViewHeader QMenu::indicator:checked {
       image: url(skin:/../Tango/buttons/btn_lib_checkmark_white.svg);
     }
 
 WLibrarySidebar QMenu::indicator,
-WLibrary QHeaderView QMenu::indicator,
+WTrackTableViewHeader QMenu::indicator,
 WTrackMenu QMenu QCheckBox::indicator {
   width: 13px;
   height: 13px;
@@ -2379,7 +2379,7 @@ WTrackMenu QMenu QCheckBox::indicator {
   border-radius: 1px;
   }
   WLibrarySidebar QMenu::indicator:checked,
-  WLibrary QHeaderView QMenu::indicator:checked,
+  WTrackTableViewHeader QMenu::indicator:checked,
   WTrackMenu QMenu QCheckBox::indicator:checked {
     image: url(skin:/../Tango/buttons/btn_lib_checkmark.svg);
     border: 1px solid #111;
@@ -2507,11 +2507,11 @@ WTrackMenu QMenu QCheckBox::indicator {
       image: url(skin:/../Tango/buttons/btn_lib_mini_hover.svg) no-repeat center top;
     }
 
-#LibraryContainer QTableView,
-#LibraryContainer QTextBrowser,
-#LibraryContainer QTreeView {
+WTrackTableView,
+WLibraryTextBrowser,
+WLibrarySidebar {
   border: 2px solid #585858;
-  font-weight: normal;
+  /* font-weight: normal; */
   color: #9e9e9e;
   background-color: #0f0f0f;
   alternate-background-color: #1a1a1a;
@@ -2525,21 +2525,21 @@ WTrackMenu QMenu QCheckBox::indicator {
 }
 
 /* selected table row */
-#LibraryContainer QTableView::item:selected,
+WTrackTableView::item:selected,
 #LibraryBPMButton::item:selected {
   color: #fff;
   background-color: #555;
 }
-#LibraryContainer QTreeView,
-#LibraryContainer QTreeView::item:focus {
+WLibrarySidebar,
+WLibrarySidebar::item:focus {
   outline: none;
 }
 
 /* Use the native focus decoration */
 /* This is for all cells including Played and Location */
-#LibraryContainer QTableView,
+WTrackTableView,
 /* This is for the BPM cell */
-#LibraryContainer QTableView QCheckBox:focus {
+WTrackTableView QCheckBox:focus {
     outline: 1px solid #fff;
 }
 /* This uses a custom qproperty to set the focus border
@@ -2559,7 +2559,7 @@ WTrackTableView {
     border: 1px solid #555;
   }
 
-#LibraryContainer QTreeView {
+WLibrarySidebar {
   min-height: 90px;
   min-width: 90px;
   border-width: 1px 1px 1px 0px;
@@ -2570,10 +2570,10 @@ WTrackTableView {
   Shift WSearchLineEdit instead */
   margin: 0px;
   }
-  #LibraryContainer QTableView:focus,
-  #LibraryContainer QTreeView:focus,
-  #LibraryContainer QTableView:focus,
-  #LibraryContainer WSearchLineEdit:focus {
+  WTrackTableView:focus,
+  WLibrarySidebar:focus,
+  WTrackTableView:focus,
+  WSearchLineEdit:focus {
   /* New Library navigation COs only work if TreeView or TableView have focus.
     Clicking on buttons, sliders and visuals elsewhere removes focus from Library.
     In conjunction with [Library],MoveFocusBackward/..Forward, some highlight
@@ -2582,56 +2582,56 @@ WTrackTableView {
   }
 
 /*  Closed branch icon in tree */
-#LibraryContainer QTreeView::branch:has-children:!has-siblings:closed,
-#LibraryContainer QTreeView::branch:closed:has-children:has-siblings {
+WLibrarySidebar::branch:has-children:!has-siblings:closed,
+WLibrarySidebar::branch:closed:has-children:has-siblings {
   image: url(skin:/../Tango/graphics/branch_closed.png);
   }
-  #LibraryContainer QTreeView::branch:has-children:!has-siblings:closed:selected,
-  #LibraryContainer QTreeView::branch:closed:has-children:has-siblings:selected {
+  WLibrarySidebar::branch:has-children:!has-siblings:closed:selected,
+  WLibrarySidebar::branch:closed:has-children:has-siblings:selected {
     background-color: #333;
   }
 
 /*  Open branch icon in tree */
-#LibraryContainer QTreeView::branch:open:has-children:!has-siblings,
-#LibraryContainer QTreeView::branch:open:has-children:has-siblings {
+WLibrarySidebar::branch:open:has-children:!has-siblings,
+WLibrarySidebar::branch:open:has-children:has-siblings {
   image: url(skin:/../Tango/graphics/branch_open.png);
   }
-  #LibraryContainer QTreeView::branch:open:has-children:!has-siblings:selected,
-  #LibraryContainer QTreeView::branch:open:has-children:has-siblings:selected {
+  WLibrarySidebar::branch:open:has-children:!has-siblings:selected,
+  WLibrarySidebar::branch:open:has-children:has-siblings:selected {
     border-image: none;
     background-color: #333;
   }
 /* Text label of branch item */
-#LibraryContainer QTreeView::item:selected {
+WLibrarySidebar::item:selected {
   border-image: none;
   background-image: none;
   background-color: #333;
   color: #d2d2d2;
   }
   /* space left of selected child item */
-  #LibraryContainer QTreeView::branch:!has-children:!has-siblings:closed:selected,
-  #LibraryContainer QTreeView::branch:closed:!has-children:has-siblings:selected,
-  #LibraryContainer QTreeView::branch:open:!has-children:!has-siblings:selected,
-  #LibraryContainer QTreeView::branch:open:!has-children:has-siblings:selected {
+  WLibrarySidebar::branch:!has-children:!has-siblings:closed:selected,
+  WLibrarySidebar::branch:closed:!has-children:has-siblings:selected,
+  WLibrarySidebar::branch:open:!has-children:!has-siblings:selected,
+  WLibrarySidebar::branch:open:!has-children:has-siblings:selected {
     border-image: none;
     background-color: #0f0f0f;
   }
 
-#LibraryContainer QTreeView::item:!selected {
+WLibrarySidebar::item:!selected {
   border-image: none;
   background-image: none;
   background-color: #0f0f0f;
   color: #999;
   }
 
-#LibraryContainer QHeaderView {
+WTrackTableViewHeader {
   /* Don't set a font size to pick up the system font size. */
   font-weight: bold;
   color: #CFCFCF;
   background-color: #1e1e1e;
   }
   /*  Library header 'buttons'  */
-  #LibraryContainer QHeaderView::section {
+  WTrackTableViewHeader::section {
     height: 1.1em;
     padding: 0px 2px;
     /*  use 'border-right' so that for the header of the leftmost column
@@ -2640,36 +2640,36 @@ WTrackTableView {
     background-color: #333;
     border-radius: 0px;
     }
-  #LibraryContainer QHeaderView::section:hover {
+  WTrackTableViewHeader::section:hover {
     background-color: #585858;
     border-radius: 0px;
   }
 
-  #LibraryContainer QHeaderView::up-arrow,
-  #LibraryContainer QHeaderView::down-arrow {
+  WTrackTableViewHeader::up-arrow,
+  WTrackTableViewHeader::down-arrow {
     width: 12px;
     padding-right: 2px;
     border-right: 1px solid #585858;
     background-color: rgba(51,51,51,200);
     }
-    #LibraryContainer QHeaderView::up-arrow:hover,
-    #LibraryContainer QHeaderView::down-arrow:hover {
+    WTrackTableViewHeader::up-arrow:hover,
+    WTrackTableViewHeader::down-arrow:hover {
       background-color: rgba(88,88,88,200);
     }
-    #LibraryContainer QHeaderView::up-arrow {
+    WTrackTableViewHeader::up-arrow {
       image: url(skin:/../Tango/graphics/library_sort_up.svg);
       }
-      #LibraryContainer QHeaderView::up-arrow:hover {
+      WTrackTableViewHeader::up-arrow:hover {
         image: url(skin:/../Tango/graphics/library_sort_down.svg);
       }
-    #LibraryContainer QHeaderView::down-arrow {
+    WTrackTableViewHeader::down-arrow {
       image: url(skin:/../Tango/graphics/library_sort_down.svg);
       }
-      #LibraryContainer QHeaderView::down-arrow:hover {
+      WTrackTableViewHeader::down-arrow:hover {
         image: url(skin:/../Tango/graphics/library_sort_up.svg);
       }
 
-#LibraryContainer QTextBrowser {
+WLibraryTextBrowser {
   padding-left: 5px;
 }
 
@@ -2993,7 +2993,7 @@ QPushButton#pushButtonRepeatPlaylist:!checked {
     }*/
 
   /* checkbox in library "Played" column */
-  #LibraryContainer QTableView::indicator {
+  WTrackTableView::indicator {
     width: 10px;
     height: 10px;
     margin: 0px;
@@ -3002,13 +3002,13 @@ QPushButton#pushButtonRepeatPlaylist:!checked {
     /* border is added to size defined above */
     border: 1px solid rgba(151,151,151,128);
     }
-  #LibraryContainer QTableView::indicator:hover {
+  WTrackTableView::indicator:hover {
       border: 1px solid #888;
     }
-  #LibraryContainer QTableView::indicator:checked {
+  WTrackTableView::indicator:checked {
     image: url(skin:/../Tango/buttons/btn_lib_checkmark.svg);
     }
-  #LibraryContainer QTableView::indicator:unchecked {
+  WTrackTableView::indicator:unchecked {
     background: none;
     }
 
@@ -3068,8 +3068,8 @@ WLibrary QRadioButton::indicator:unchecked {
   selected, unchecked items would have a checkmark */
 WLibrarySidebar QMenu::indicator:unchecked,
 WLibrarySidebar QMenu::indicator:unchecked:selected,
-WLibrary QHeaderView QMenu::indicator:unchecked,
-WLibrary QHeaderView QMenu::indicator:unchecked:selected,
+WTrackTableViewHeader QMenu::indicator:unchecked,
+WTrackTableViewHeader QMenu::indicator:unchecked:selected,
 WLibrary QTableView::indicator:unchecked,
 WLibrary QTableView::indicator:unchecked:selected,
 WEffectSelector::indicator:unchecked,


### PR DESCRIPTION
now all widget fonts should be determined by skin stylesheets, i.e. impossible to override by OS settings.

For example when you choose a huge, italic serif type in OS font settings or with Qt5 Settings there should be no spot in Mixxx that is bigger than expected, _italic_ or not the skin font.

Exceptions:
* table header font **size**, though all characters should be visible (not cut off) and the header height should be about 10% taller than the font
* context menu font **size**
* main menu bar font, size and style