### PR TITLE
Fix const beat grid first beat placement

### DIFF
--- a/src/track/beatutils.cpp
+++ b/src/track/beatutils.cpp
@@ -303,10 +303,9 @@ double BeatUtils::makeConstBpm(
         // bpm adjustments are made.
         // This is a temporary fix, ideally the anchor point for the BPM grid should
         // be the first proper downbeat, or perhaps the CUE point.
-        *pFirstBeat = constantRegions[startRegionIndex].firstBeat;
         const double roundedBeatLength = 60.0 * sampleRate / roundBpm;
-        const double beatsBeforeFirst = std::floor(*pFirstBeat / roundedBeatLength);
-        *pFirstBeat -= (roundedBeatLength * beatsBeforeFirst);
+        *pFirstBeat = fmod(constantRegions[startRegionIndex].firstBeat,
+                roundedBeatLength);
     }
     return roundBpm;
 }

--- a/src/track/beatutils.cpp
+++ b/src/track/beatutils.cpp
@@ -301,6 +301,8 @@ double BeatUtils::makeConstBpm(
         // Move the first beat as close to the start of the track as we can. This is
         // a constant beatgrid so "first beat" only affects the anchor point where
         // bpm adjustments are made.
+        // This is a temporary fix, ideally the anchor point for the BPM grid should
+        // be the first proper downbeat, or perhaps the CUE point.
         *pFirstBeat = constantRegions[startRegionIndex].firstBeat;
         const double roundedBeatLength = 60.0 * sampleRate / roundBpm;
         const double beatsBeforeFirst = std::floor(*pFirstBeat / roundedBeatLength);

--- a/src/track/beatutils.cpp
+++ b/src/track/beatutils.cpp
@@ -298,7 +298,12 @@ double BeatUtils::makeConstBpm(
     const double roundBpm = roundBpmWithinRange(minRoundBpm, centerBpm, maxRoundBpm);
 
     if (pFirstBeat) {
+        // Move the first beat as close to the start of the track as we can. This is
+        // a constant beatgrid so "first beat" only affects the anchor point where
+        // bpm adjustments are made.
         *pFirstBeat = constantRegions[startRegionIndex].firstBeat;
+        const double beatsBeforeFirst = std::floor(*pFirstBeat / longestRegionBeatLength);
+        *pFirstBeat -= (longestRegionBeatLength * beatsBeforeFirst);
     }
     return roundBpm;
 }

--- a/src/track/beatutils.cpp
+++ b/src/track/beatutils.cpp
@@ -289,9 +289,9 @@ double BeatUtils::makeConstBpm(
 
     // Create a const region region form the first beat of the first region to the last beat of the last region.
 
-    const double minRoundBpm = 60 * sampleRate / longestRegionBeatLengthMax;
-    const double maxRoundBpm = 60 * sampleRate / longestRegionBeatLengthMin;
-    const double centerBpm = 60 * sampleRate / longestRegionBeatLength;
+    const double minRoundBpm = 60.0 * sampleRate / longestRegionBeatLengthMax;
+    const double maxRoundBpm = 60.0 * sampleRate / longestRegionBeatLengthMin;
+    const double centerBpm = 60.0 * sampleRate / longestRegionBeatLength;
 
     //qDebug() << "minRoundBpm" << minRoundBpm;
     //qDebug() << "maxRoundBpm" << maxRoundBpm;
@@ -302,8 +302,9 @@ double BeatUtils::makeConstBpm(
         // a constant beatgrid so "first beat" only affects the anchor point where
         // bpm adjustments are made.
         *pFirstBeat = constantRegions[startRegionIndex].firstBeat;
-        const double beatsBeforeFirst = std::floor(*pFirstBeat / longestRegionBeatLength);
-        *pFirstBeat -= (longestRegionBeatLength * beatsBeforeFirst);
+        const double roundedBeatLength = 60.0 * sampleRate / roundBpm;
+        const double beatsBeforeFirst = std::floor(*pFirstBeat / roundedBeatLength);
+        *pFirstBeat -= (roundedBeatLength * beatsBeforeFirst);
     }
     return roundBpm;
 }


### PR DESCRIPTION
Make sure the first beat in a const beat grid is as close to the start of the track as possible.  Workaround fix for lp#1930930