### PR TITLE
pre-commit: Fix detection of renamed files

### DIFF
--- a/tools/clang_format.py
+++ b/tools/clang_format.py
@@ -21,7 +21,7 @@ BREAK_BEFORE = 80
 
 def get_clang_format_config_with_columnlimit(rootdir, limit):
     """Create a temporary config with ColumnLimit set to 80."""
-    cpp_file = os.path.join(rootdir, "src/mixxx.cpp")
+    cpp_file = os.path.join(rootdir, "src/main.cpp")
     proc = subprocess.run(
         ["clang-format", "--dump-config", cpp_file],
         capture_output=True,

--- a/tools/githelper.py
+++ b/tools/githelper.py
@@ -24,6 +24,40 @@ def get_toplevel_path() -> str:
     return subprocess.check_output(cmd, text=True).strip()
 
 
+def get_moved_files(
+    changeset, include_files=None
+) -> typing.Iterable[typing.Tuple[str, str]]:
+    """
+    Inspect `git diff` output to find moved/renamed files.
+
+    Yields tuples in the form (old_file, new_file).
+
+    If include_files is set, this only yields results where at least one of the
+    two file names is in the list of file names to include.
+    """
+
+    logger = logging.getLogger(__name__)
+
+    cmd = ["git", "diff", "--raw", "-z", changeset]
+    logger.debug("Executing: %r", cmd)
+    proc = subprocess.run(cmd, capture_output=True)
+    proc.check_returncode()
+    diff_output = proc.stdout.decode(errors="replace")
+    for line in diff_output.lstrip(":").split(":"):
+        change, _, files = line.partition("\0")
+        _, _, changetype = change.rpartition(" ")
+        if changetype.startswith("R"):
+            # A file was renamed
+            old_file, sep, new_file = files.rstrip("\0").partition("\0")
+            assert sep == "\0"
+
+            move = (old_file, new_file)
+            if include_files and not any(x in include_files for x in move):
+                continue
+
+            yield move
+
+
 def get_changed_lines(
     from_ref=None, to_ref=None, filter_lines=None, include_files=None
 ) -> typing.Iterable[Line]:
@@ -48,16 +82,31 @@ def get_changed_lines(
         # repository). Therefore we need to filter our all files outside of the
         # current repository before passing them to git diff.
         toplevel_path = get_toplevel_path()
-        include_files_filtered = [
+        include_files = {
             path
             for path in include_files
             if os.path.commonprefix((os.path.abspath(path), toplevel_path))
             == toplevel_path
-        ]
-        if not include_files_filtered:
+        }
+        if not include_files:
             # No files to check
             return
-        cmd.extend(["--", *include_files_filtered])
+
+        # If files were moved, it's possible that only the new filename is in
+        # the list of included files. For example, this is the case when the
+        # script is used by pre-commit. When calling `git diff` after a rename
+        # with a path argument where only the new file is listed, git treats
+        # the file as newly added and the whole file shows up as added lines.
+        #
+        # This leads to false positives because the lines were not actually
+        # changed. Hence, we check if any of the files were renamed, and make
+        # sure that both the old and new filename is included in the initial
+        # `git diff` call.
+        moved_files = get_moved_files(changeset, include_files=include_files)
+        include_files_with_moved = include_files.union(
+            itertools.chain.from_iterable(moved_files)
+        )
+        cmd.extend(["--", *include_files_with_moved])
     logger.debug("Executing: %r", cmd)
     proc = subprocess.run(cmd, capture_output=True)
     proc.check_returncode()
@@ -115,6 +164,8 @@ def get_changed_lines(
             )
 
             if filter_lines is None or filter_lines(lineobj):
+                if include_files and lineobj.sourcefile not in include_files:
+                    continue
                 yield lineobj
 
         # If we reach this part, the line does not contain a diff filename or a

--- a/tools/githelper.py
+++ b/tools/githelper.py
@@ -57,7 +57,7 @@ def get_changed_lines(
         if not include_files_filtered:
             # No files to check
             return
-        cmd.extend(["--", *include_files])
+        cmd.extend(["--", *include_files_filtered])
     logger.debug("Executing: %r", cmd)
     proc = subprocess.run(cmd, capture_output=True)
     proc.check_returncode()

--- a/tools/githelper.py
+++ b/tools/githelper.py
@@ -27,7 +27,7 @@ def get_toplevel_path() -> str:
 def get_changed_lines(
     from_ref=None, to_ref=None, filter_lines=None, include_files=None
 ) -> typing.Iterable[Line]:
-    """Inspect `git diff-index` output, yields changed lines."""
+    """Inspect `git diff` output, yields changed lines."""
 
     logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Renaming existing files currently leads to mass reformattings of the whole file. This fixes the issue.