### PR TITLE
Linux: Remove obsolete X11 code from Qt 4

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,10 +15,6 @@
 #include "util/logging.h"
 #include "util/versionstore.h"
 
-#ifdef Q_OS_LINUX
-#include <X11/Xlib.h>
-#endif
-
 namespace {
 
 // Exit codes
@@ -45,10 +41,6 @@ int runMixxx(MixxxApplication* app, const CmdlineArgs& args) {
 
 int main(int argc, char * argv[]) {
     Console console;
-
-#ifdef Q_OS_LINUX
-    XInitThreads();
-#endif
 
     // These need to be set early on (not sure how early) in order to trigger
     // logic in the OS X appstore support patch from QTBUG-16549.


### PR DESCRIPTION
This should have been accomplished by using Qt::AA_X11InitThreads, which became obsolete with Qt5.