### PR TITLE
Advance beat analysis version to V4

### DIFF
--- a/src/track/beatfactory.cpp
+++ b/src/track/beatfactory.cpp
@@ -8,7 +8,7 @@
 
 namespace {
 
-const QString kRoundingVersion = QStringLiteral("V3");
+const QString kRoundingVersion = QStringLiteral("V4");
 
 } // namespace
 


### PR DESCRIPTION
... because of the moved first beat in const beat grits introduced in #3965