### PR TITLE
test: Only register SoundSourceProviders when actually necessary

### DIFF
--- a/src/test/librarytest.h
+++ b/src/test/librarytest.h
@@ -7,10 +7,11 @@
 #include "library/trackcollection.h"
 #include "library/trackcollectionmanager.h"
 #include "test/mixxxdbtest.h"
+#include "test/soundsourceproviderregistration.h"
 #include "util/db/dbconnectionpooled.h"
 #include "util/db/dbconnectionpooler.h"
 
-class LibraryTest : public MixxxDbTest {
+class LibraryTest : public MixxxDbTest, SoundSourceProviderRegistration {
   protected:
     LibraryTest();
     ~LibraryTest() override = default;

--- a/src/test/mixxxtest.cpp
+++ b/src/test/mixxxtest.cpp
@@ -4,7 +4,6 @@
 
 #include "control/control.h"
 #include "library/coverartutils.h"
-#include "sources/soundsourceproxy.h"
 #include "util/cmdlineargs.h"
 #include "util/logging.h"
 
@@ -45,11 +44,6 @@ MixxxTest::ApplicationScope::ApplicationScope(int& argc, char** argv) {
 
     DEBUG_ASSERT(s_pApplication.isNull());
     s_pApplication.reset(new MixxxApplication(argc, argv));
-
-    const bool providersRegistered =
-            SoundSourceProxy::registerProviders();
-    Q_UNUSED(providersRegistered);
-    DEBUG_ASSERT(providersRegistered);
 }
 
 MixxxTest::ApplicationScope::~ApplicationScope() {

--- a/src/test/signalpathtest.h
+++ b/src/test/signalpathtest.h
@@ -21,6 +21,7 @@
 #include "mixer/sampler.h"
 #include "preferences/usersettings.h"
 #include "test/mixxxtest.h"
+#include "test/soundsourceproviderregistration.h"
 #include "track/track.h"
 #include "util/defs.h"
 #include "util/memory.h"
@@ -55,7 +56,7 @@ class TestEngineMaster : public EngineMaster {
     }
 };
 
-class BaseSignalPathTest : public MixxxTest {
+class BaseSignalPathTest : public MixxxTest, SoundSourceProviderRegistration {
   protected:
     BaseSignalPathTest() {
         m_pGuiTick = std::make_unique<GuiTick>();

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -4,6 +4,7 @@
 #include "sources/audiosourcestereoproxy.h"
 #include "sources/soundsourceproxy.h"
 #include "test/mixxxtest.h"
+#include "test/soundsourceproviderregistration.h"
 #include "track/track.h"
 #include "track/trackmetadata.h"
 #include "util/samplebuffer.h"
@@ -35,7 +36,7 @@ const CSAMPLE kMaxDecodingError = 0.01f;
 
 } // anonymous namespace
 
-class SoundSourceProxyTest : public MixxxTest {
+class SoundSourceProxyTest : public MixxxTest, SoundSourceProviderRegistration {
   protected:
     static QStringList getFileNameSuffixes() {
         QStringList availableFileNameSuffixes;

--- a/src/test/soundsourceproviderregistration.h
+++ b/src/test/soundsourceproviderregistration.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "sources/soundsourceproxy.h"
+
+/// This class can be used as a mixin for or a member of test classes that
+/// require accessing SoundSources.
+class SoundSourceProviderRegistration {
+  protected:
+    SoundSourceProviderRegistration() {
+        const bool providersRegistered =
+                SoundSourceProxy::registerProviders();
+        Q_UNUSED(providersRegistered);
+        DEBUG_ASSERT(providersRegistered);
+    }
+};

--- a/src/test/trackupdate_test.cpp
+++ b/src/test/trackupdate_test.cpp
@@ -3,6 +3,7 @@
 #include "library/coverart.h"
 #include "sources/soundsourceproxy.h"
 #include "test/mixxxtest.h"
+#include "test/soundsourceproviderregistration.h"
 #include "track/track.h"
 
 namespace {
@@ -12,7 +13,7 @@ const QDir kTestDir(QDir::current().absoluteFilePath("src/test/id3-test-data"));
 } // anonymous namespace
 
 // Test for updating track metadata and cover art from files.
-class TrackUpdateTest: public MixxxTest {
+class TrackUpdateTest : public MixxxTest, SoundSourceProviderRegistration {
   protected:
     static bool hasTrackMetadata(const TrackPointer& pTrack) {
         return !pTrack->getArtist().isEmpty();


### PR DESCRIPTION
This allows tests to inherit from MixxxTest and still register
SoundSourceProviders themselves, e.g. by instantiating CoreServices.
It also reduces log spam caused by the sound source provider
registration.