### PR TITLE
Waveforms on macOS: don't offer simple renderers (RGB, HSV, Filtered)

### DIFF
--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -765,26 +765,42 @@ void WaveformWidgetFactory::evaluateWidgets() {
         case WaveformWidgetType::SoftwareSimpleWaveform:
             continue; // //TODO(vrince):
         case WaveformWidgetType::SoftwareWaveform:
+#ifdef __APPLE__
+            // Don't offer the simple renderers on macOS, they do not work with skins
+            // that load GL widgets (spinnies, waveforms) in singletons.
+            // Also excluded in enum WaveformWidgetType
+            // https://bugs.launchpad.net/bugs/1928772
+            continue;
+#else
             widgetName = SoftwareWaveformWidget::getWaveformWidgetName();
             useOpenGl = SoftwareWaveformWidget::useOpenGl();
             useOpenGles = SoftwareWaveformWidget::useOpenGles();
             useOpenGLShaders = SoftwareWaveformWidget::useOpenGLShaders();
             developerOnly = SoftwareWaveformWidget::developerOnly();
             break;
+#endif
         case WaveformWidgetType::HSVWaveform:
+#ifdef __APPLE__
+            continue;
+#else
             widgetName = HSVWaveformWidget::getWaveformWidgetName();
             useOpenGl = HSVWaveformWidget::useOpenGl();
             useOpenGles = HSVWaveformWidget::useOpenGles();
             useOpenGLShaders = HSVWaveformWidget::useOpenGLShaders();
             developerOnly = HSVWaveformWidget::developerOnly();
             break;
+#endif
         case WaveformWidgetType::RGBWaveform:
+#ifdef __APPLE__
+            continue;
+#else
             widgetName = RGBWaveformWidget::getWaveformWidgetName();
             useOpenGl = RGBWaveformWidget::useOpenGl();
             useOpenGles = RGBWaveformWidget::useOpenGles();
             useOpenGLShaders = RGBWaveformWidget::useOpenGLShaders();
             developerOnly = RGBWaveformWidget::developerOnly();
             break;
+#endif
         case WaveformWidgetType::QtSimpleWaveform:
             widgetName = QtSimpleWaveformWidget::getWaveformWidgetName();
             useOpenGl = QtSimpleWaveformWidget::useOpenGl();

--- a/src/waveform/widgets/waveformwidgettype.h
+++ b/src/waveform/widgets/waveformwidgettype.h
@@ -6,21 +6,21 @@ class WaveformWidgetType {
         // The order must not be changed because the waveforms are referenced
         // from the sorted preferences by a number.
         EmptyWaveform = 0,
-        SoftwareSimpleWaveform, //TODO
-        SoftwareWaveform,
-        QtSimpleWaveform,
-        QtWaveform,
-        GLSimpleWaveform,
-        GLFilteredWaveform,
-        GLSLFilteredWaveform,
-        HSVWaveform,
-        GLVSyncTest,
-        RGBWaveform,
-        GLRGBWaveform,
-        GLSLRGBWaveform,
-        QtVSyncTest,
-        QtHSVWaveform,
-        QtRGBWaveform,
+        SoftwareSimpleWaveform,  //TODO
+        SoftwareWaveform,        // Filtered
+        QtSimpleWaveform,        // Simple Qt
+        QtWaveform,              // Filtered Qt
+        GLSimpleWaveform,        // Simple GL
+        GLFilteredWaveform,      // Filtered GL
+        GLSLFilteredWaveform,    // Filtered GLSL
+        HSVWaveform,             // HSV
+        GLVSyncTest,             // VSync GL
+        RGBWaveform,             // RGB
+        GLRGBWaveform,           // RGB GL
+        GLSLRGBWaveform,         // RGB GLSL
+        QtVSyncTest,             // VSync Qt
+        QtHSVWaveform,           // HSV Qt
+        QtRGBWaveform,           // RGB Qt
         Count_WaveformwidgetType // Also used as invalid value
     };
 };


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1928772
waveform not scrolling on macOS

cross-post:
"Given the fact (assumption?) that the computers running the minimum supported macOS version 10.12 are powerful enough to not require the simple renderers for performance reasons we can simply hide them on macOS -- and switch to another renderer in case a simple renderer is stored in the config after upgrading to 2.3."

Now the simple renderers are not added to the list in the preferences on macOS.
~~**Upgrade issue for macOS** users: the waveform type from the config now points to a different renderer.~~
wrong. it would switch to another renderer, though, if a simple renderer was configured before.

(OpenGL is deprecated on macOS since 10.14, but not removed, yet -- let's hope it'll stay until we have alternatives)

And, now that this is being touched anyway, I'd really like to reorder the enum list so that we have a nicely sorted list in the preferences instead of the current mess. Since this happens with a major upgrade that would be okay, wouldn't it??
![image](https://user-images.githubusercontent.com/5934199/121612478-c8d1eb80-ca5a-11eb-8707-1143053e4ddf.png)

