### PR TITLE
Waveforms preferences: sort waveform types combobox alphabetically

### DIFF
--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -24,11 +24,15 @@ DlgPrefWaveform::DlgPrefWaveform(QWidget* pParent, MixxxMainWindow* pMixxx,
 
     // Populate waveform options.
     WaveformWidgetFactory* factory = WaveformWidgetFactory::instance();
+    // We assume that the original type list order remains constant.
+    // We will use the type index later on to set waveform types and to
+    // update the combobox.
     QVector<WaveformWidgetAbstractHandle> handles = factory->getAvailableTypes();
     for (int i = 0; i < handles.size(); ++i) {
-        waveformTypeComboBox->addItem(handles[i].getDisplayName(),
-                                      handles[i].getType());
+        waveformTypeComboBox->addItem(handles[i].getDisplayName(), i);
     }
+    // Sort the combobox items alphabetically
+    waveformTypeComboBox->model()->sort(0);
 
     // Populate zoom options.
     for (int i = static_cast<int>(WaveformWidgetRenderer::s_waveformMinZoom);
@@ -141,8 +145,8 @@ void DlgPrefWaveform::slotUpdate() {
         openGlStatusIcon->setText(tr("OpenGL not available") + ": " + factory->getOpenGLVersion());
     }
 
-    WaveformWidgetType::Type currentType = factory->getType();
-    int currentIndex = waveformTypeComboBox->findData(currentType);
+    // The combobox holds a list of [handle name, handle index]
+    int currentIndex = waveformTypeComboBox->findData(factory->getHandleIndex());
     if (currentIndex != -1 && waveformTypeComboBox->currentIndex() != currentIndex) {
         waveformTypeComboBox->setCurrentIndex(currentIndex);
     }
@@ -244,7 +248,8 @@ void DlgPrefWaveform::slotSetWaveformType(int index) {
     if (index < 0) {
         return;
     }
-    WaveformWidgetFactory::instance()->setWidgetTypeFromHandle(index);
+    int handleIndex = waveformTypeComboBox->itemData(index).toInt();
+    WaveformWidgetFactory::instance()->setWidgetTypeFromHandle(handleIndex);
 }
 
 void DlgPrefWaveform::slotSetWaveformOverviewType(int index) {

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -195,10 +195,10 @@ void DlgPrefWaveform::slotApply() {
 void DlgPrefWaveform::slotResetToDefaults() {
     WaveformWidgetFactory* factory = WaveformWidgetFactory::instance();
 
-    // Get the default we ought to use based on whether the user has OpenGL or
-    // not.
-    WaveformWidgetType::Type defaultType = factory->autoChooseWidgetType();
-    int defaultIndex = waveformTypeComboBox->findData(defaultType);
+    // Get the default we ought to use based on whether the user has OpenGL or not.
+    // Select the combobox index that holds the default handle's index in data column.
+    int defaultIndex = waveformTypeComboBox->findData(
+            factory->findHandleIndexFromType(factory->autoChooseWidgetType()));
     if (defaultIndex != -1 && waveformTypeComboBox->currentIndex() != defaultIndex) {
         waveformTypeComboBox->setCurrentIndex(defaultIndex);
     }

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -95,6 +95,7 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     int getHandleIndex() {
         return findHandleIndexFromType(m_type);
     }
+    int findHandleIndexFromType(WaveformWidgetType::Type type);
 
   protected:
     bool setWidgetType(
@@ -159,7 +160,6 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     int findIndexOf(WWaveformViewer* viewer) const;
 
     WaveformWidgetType::Type findTypeFromHandleIndex(int index);
-    int findHandleIndexFromType(WaveformWidgetType::Type type);
 
     //All type of available widgets
 

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -92,6 +92,9 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     /// dialog.
     bool setWidgetTypeFromHandle(int handleIndex, bool force = false);
     WaveformWidgetType::Type getType() const { return m_type;}
+    int getHandleIndex() {
+        return findHandleIndexFromType(m_type);
+    }
 
   protected:
     bool setWidgetType(

--- a/src/waveform/widgets/waveformwidgettype.h
+++ b/src/waveform/widgets/waveformwidgettype.h
@@ -6,21 +6,21 @@ class WaveformWidgetType {
         // The order must not be changed because the waveforms are referenced
         // from the sorted preferences by a number.
         EmptyWaveform = 0,
-        SoftwareSimpleWaveform,  //TODO
-        SoftwareWaveform,        // Filtered
-        QtSimpleWaveform,        // Simple Qt
-        QtWaveform,              // Filtered Qt
-        GLSimpleWaveform,        // Simple GL
-        GLFilteredWaveform,      // Filtered GL
-        GLSLFilteredWaveform,    // Filtered GLSL
-        HSVWaveform,             // HSV
-        GLVSyncTest,             // VSync GL
-        RGBWaveform,             // RGB
-        GLRGBWaveform,           // RGB GL
-        GLSLRGBWaveform,         // RGB GLSL
-        QtVSyncTest,             // VSync Qt
-        QtHSVWaveform,           // HSV Qt
-        QtRGBWaveform,           // RGB Qt
-        Count_WaveformwidgetType // Also used as invalid value
+        SoftwareSimpleWaveform,  // 1  TODO
+        SoftwareWaveform,        // 2  Filtered
+        QtSimpleWaveform,        // 3  Simple Qt
+        QtWaveform,              // 4  Filtered Qt
+        GLSimpleWaveform,        // 5  Simple GL
+        GLFilteredWaveform,      // 6  Filtered GL
+        GLSLFilteredWaveform,    // 7  Filtered GLSL
+        HSVWaveform,             // 8  HSV
+        GLVSyncTest,             // 9  VSync GL
+        RGBWaveform,             // 10 RGB
+        GLRGBWaveform,           // 11 RGB GL
+        GLSLRGBWaveform,         // 12 RGB GLSL
+        QtVSyncTest,             // 13 VSync Qt
+        QtHSVWaveform,           // 14 HSV Qt
+        QtRGBWaveform,           // 15 RGB Qt
+        Count_WaveformwidgetType // 16 Also used as invalid value
     };
 };


### PR DESCRIPTION
sorting is done only in DlgPrefWaveform when reading/writing to/from the combobox to avoid the effort doing similiar in waveformwidgetfactory, see https://github.com/mixxxdj/mixxx/pull/3979
user config is respected and not affected.

before
![image](https://user-images.githubusercontent.com/5934199/121758274-0bf69200-cb21-11eb-8619-a36e75756a14.png)


this PR
![image](https://user-images.githubusercontent.com/5934199/121758189-b5895380-cb20-11eb-8a8a-b64b37123e08.png)
