### PR TITLE
Obsolete Ubuntu Bionic 18.04

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -31,15 +31,14 @@ SpacesBeforeTrailingComments: 1
 # StatementMacros don't require a trailing semicolon.
 # Trailing semicolons should be omitted after these macros
 # when compiling with -Wpedantic to avoid warnings.
-# TODO: Enable if Clang 8 is available, Ubuntu 18.04 uses Clang 6
-#StatementMacros:
-#  - Q_DECLARE_FLAGS
-#  - Q_DECLARE_METATYPE
-#  - Q_DECLARE_OPERATORS_FOR_FLAGS
-#  - Q_OBJECT
-#  - Q_PROPERTY
-#  - Q_UNUSED
-#  - QT_REQUIRE_VERSION
+StatementMacros:
+  - Q_DECLARE_FLAGS
+  - Q_DECLARE_METATYPE
+  - Q_DECLARE_OPERATORS_FOR_FLAGS
+  - Q_OBJECT
+  - Q_PROPERTY
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
 ---
 Language: JavaScript
 # Don't format .js files yet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,11 +157,11 @@ jobs:
       # Possibly related: actions/checkout#290
       run: git fetch origin --force --tags
 
-    - name: "[macOS/Ubuntu 18.04] Set up cmake"
+    - name: "[macOS] Set up cmake"
       uses: jwlawson/actions-setup-cmake@v1.4
       # Ubuntu 20.04 should use the CMake version from the repos, and Visual
       # Studio on Windows comes with its own CMake version anyway.
-      if: runner.os == 'macOS' || matrix.os == 'ubuntu-18.04'
+      if: runner.os == 'macOS'
       with:
         # This should always match the mininum required version in
         # our CMakeLists.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,7 @@ jobs:
       run: git fetch origin --force --tags
 
     - name: "[macOS] Set up cmake"
-      uses: jwlawson/actions-setup-cmake@v1.4
+      uses: jwlawson/actions-setup-cmake@v1.9
       # Ubuntu 20.04 should use the CMake version from the repos, and Visual
       # Studio on Windows comes with its own CMake version anyway.
       if: runner.os == 'macOS'

--- a/src/encoder/encoderfdkaac.cpp
+++ b/src/encoder/encoderfdkaac.cpp
@@ -77,7 +77,7 @@ EncoderFdkAac::EncoderFdkAac(EncoderCallback* pCallback)
 #endif
     libnames << QStringLiteral("fdk-aac");
     // Although the line above should suffice, detection of the fdk-aac library
-    // does not work on Ubuntu 18.04 LTS and Ubuntu 20.04 LTS:
+    // does not work on Ubuntu 20.04 LTS:
     //
     //     $ dpkg -L libfdk-aac1 | grep so
     //     /usr/lib/x86_64-linux-gnu/libfdk-aac.so.1.0.0

--- a/src/encoder/encodersndfileflac.cpp
+++ b/src/encoder/encodersndfileflac.cpp
@@ -85,7 +85,7 @@ void EncoderSndfileFlac::initStream() {
 #endif //SFC_SUPPORTS_SET_COMPRESSION_LEVEL
 
     // Version 1.0.28 suffers broken clamping https://bugs.launchpad.net/mixxx/+bug/1915298
-    // We receive "libsndfile-1.0.28" on Ubuntu Bionic 18.04 LTS/Focal 20.04 LTS/Grovy 20.10
+    // We receive "libsndfile-1.0.28" on Ubuntu Focal 20.04 LTS/Grovy 20.10
     // Older versions are not expected. All newer version have a working internal clamping
     const char* sf_version = sf_version_string();
     if (strstr(sf_version, "-1.0.28") != nullptr) {

--- a/src/widget/whotcuebutton.cpp
+++ b/src/widget/whotcuebutton.cpp
@@ -175,11 +175,7 @@ void WHotcueButton::slotColorChanged(double color) {
 }
 
 void WHotcueButton::slotTypeChanged(double type) {
-    // If the cast is put directly into the switch case, this seems to trigger
-    // a false positive warning on gcc 7.5.0 on Ubuntu 18.04.4 Bionic, so we cast
-    // it to int first and save to a local const variable.
-    const mixxx::CueType cueType = static_cast<mixxx::CueType>(static_cast<int>(type));
-    switch (cueType) {
+    switch (static_cast<mixxx::CueType>(static_cast<int>(type))) {
     case mixxx::CueType::Invalid:
         m_type = QLatin1String("");
         break;


### PR DESCRIPTION
- Update comments
- Update clang format settings
- Remove obsolete workaround
- Remove obsolete references in CI build
- Upgrade actions-setup-cmake in CI build

TODO:
- Update PPA build