### PR TITLE
Waveforms on macOS fixup: also exclude simple renderers from enum list

### DIFF
--- a/src/waveform/widgets/waveformwidgettype.h
+++ b/src/waveform/widgets/waveformwidgettype.h
@@ -6,16 +6,26 @@ class WaveformWidgetType {
         // The order must not be changed because the waveforms are referenced
         // from the sorted preferences by a number.
         EmptyWaveform = 0,
-        SoftwareSimpleWaveform,  //TODO
-        SoftwareWaveform,        // Filtered
-        QtSimpleWaveform,        // Simple Qt
-        QtWaveform,              // Filtered Qt
-        GLSimpleWaveform,        // Simple GL
-        GLFilteredWaveform,      // Filtered GL
-        GLSLFilteredWaveform,    // Filtered GLSL
-        HSVWaveform,             // HSV
-        GLVSyncTest,             // VSync GL
-        RGBWaveform,             // RGB
+        SoftwareSimpleWaveform, //TODO
+#ifndef __APPLE__
+        // Don't offer the simple renderers on macOS, they do not work with skins
+        // that load GL widgets (spinnies, waveforms) in singletons.
+        // Also excluded in enum WaveformWidgetType
+        // https://bugs.launchpad.net/bugs/1928772
+        SoftwareWaveform, // Filtered
+#endif
+        QtSimpleWaveform,     // Simple Qt
+        QtWaveform,           // Filtered Qt
+        GLSimpleWaveform,     // Simple GL
+        GLFilteredWaveform,   // Filtered GL
+        GLSLFilteredWaveform, // Filtered GLSL
+#ifndef __APPLE__
+        HSVWaveform, // HSV
+#endif
+        GLVSyncTest, // VSync GL
+#ifndef __APPLE__
+        RGBWaveform, // RGB
+#endif
         GLRGBWaveform,           // RGB GL
         GLSLRGBWaveform,         // RGB GLSL
         QtVSyncTest,             // VSync Qt


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1931777
regression from https://github.com/mixxxdj/mixxx/pull/3979