### PR TITLE
LateNight: fix scaling of icons still using background-image

### DIFF
--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -245,7 +245,7 @@ WSearchLineEdit,
     min-width: 1px;
     max-width: 1px;
     margin: 2px 1px;
-    background: url(skin:/classic/style/fx_separator.svg) no-repeat center center;
+    image: url(skin:/classic/style/fx_separator.svg) no-repeat center center;
   }
   #FxSlotSeparatorH {
     min-height: 2px;

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -324,7 +324,7 @@ WSearchLineEdit {
 
   #FxFlowIndicatorCollapsed {
     margin: 0px 0px 0px 0px;
-    background-image: url(skin:/palemoon/style/fx_flow_horizontal.svg) no-repeat center center;
+    image: url(skin:/palemoon/style/fx_flow_horizontal.svg) no-repeat center center;
   }
   #ToolbarSeparator {
     margin: 0px 5px;
@@ -2131,21 +2131,15 @@ WPushButton#PlayDeck[value="0"] {
     image: url(skin:/palemoon/buttons/btn__split_active.svg) no-repeat center center;
   }
 
-#FxExpand,
-#SamplerExpand,
-#LibExpand {
-  background-repeat: no-repeat;
-  background-position: center center;
-}
 #FxExpand[value="0"],
 #SamplerExpand[value="0"],
 #LibExpand[value="0"] {
-  background: url(skin:/palemoon/buttons/btn__expand_dim.svg) no-repeat center center;
+  image: url(skin:/palemoon/buttons/btn__expand_dim.svg) no-repeat center center;
   }
   #FxExpand[value="1"],
   #SamplerExpand[value="1"],
   #LibExpand[value="1"] {
-    background: url(skin:/palemoon/buttons/btn__collapse_dim.svg) no-repeat center center;
+    image: url(skin:/palemoon/buttons/btn__collapse_dim.svg) no-repeat center center;
   }
 
 #MixModeButton[value="0"] {
@@ -2718,11 +2712,11 @@ WLibrary QLabel, WLibrary QRadioButton {
 }
 
 WLibrary QRadioButton::indicator:checked {
-  background: url(skin:/palemoon/buttons/btn__lib_radio_button_on_blue.svg) center center;
+  image: url(skin:/palemoon/buttons/btn__lib_radio_button_on_blue.svg) center center;
 }
 
 WLibrary QRadioButton::indicator:unchecked {
-  background: url(skin:/palemoon/buttons/btn__lib_radio_button_off.svg) center center;
+  image: url(skin:/palemoon/buttons/btn__lib_radio_button_off.svg) center center;
 }
 
 /* Library feature pushbuttons


### PR DESCRIPTION
@Swiftb0y Please check the mini/maxi toggles of Fx, Samplers and the library.

There are still a few icons using background-image (thus looking pixelated when scaled up) but fixing those, too, would require more work. Reason: **a** `image` always scales the icon to fill the available area, while **b** `background-image` uses the image at original size and respects `background-position` but scales the rendered pixmap (not the vector source) when scaling Mixxx.
: \

Good enough now : )