### PR TITLE
Skins, waveforms: remove I-beam from in/outro markers to equalize marker size

### DIFF
--- a/res/skins/Deere/deck_waveform.xml
+++ b/res/skins/Deere/deck_waveform.xml
@@ -84,7 +84,7 @@
           <Control>intro_start_position</Control>
           <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
           <Text>&#9698;</Text>
-          <Align>bottom</Align>
+          <Align>bottom|right</Align>
           <Color>#0000FF</Color>
           <TextColor>#FFFFFF</TextColor>
         </Mark>
@@ -92,7 +92,7 @@
           <Control>intro_end_position</Control>
           <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
           <Text>&#9698;</Text>
-          <Align>bottom</Align>
+          <Align>bottom|left</Align>
           <Color>#0000FF</Color>
           <TextColor>#FFFFFF</TextColor>
         </Mark>
@@ -108,7 +108,7 @@
           <Control>outro_start_position</Control>
           <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
           <Text>&#9699;</Text>
-          <Align>bottom</Align>
+          <Align>bottom|right</Align>
           <Color>#0000FF</Color>
           <TextColor>#FFFFFF</TextColor>
         </Mark>
@@ -116,7 +116,7 @@
           <Control>outro_end_position</Control>
           <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
           <Text>&#9699;</Text>
-          <Align>bottom</Align>
+          <Align>bottom|left</Align>
           <Color>#0000FF</Color>
           <TextColor>#FFFFFF</TextColor>
         </Mark>

--- a/res/skins/Deere/deck_waveform.xml
+++ b/res/skins/Deere/deck_waveform.xml
@@ -83,7 +83,7 @@
         <Mark>
           <Control>intro_start_position</Control>
           <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-          <Text>|&#9698;</Text>
+          <Text>&#9698;</Text>
           <Align>bottom</Align>
           <Color>#0000FF</Color>
           <TextColor>#FFFFFF</TextColor>
@@ -91,7 +91,7 @@
         <Mark>
           <Control>intro_end_position</Control>
           <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-          <Text>&#9698;|</Text>
+          <Text>&#9698;</Text>
           <Align>bottom</Align>
           <Color>#0000FF</Color>
           <TextColor>#FFFFFF</TextColor>
@@ -107,7 +107,7 @@
         <Mark>
           <Control>outro_start_position</Control>
           <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-          <Text>|&#9699;</Text>
+          <Text>&#9699;</Text>
           <Align>bottom</Align>
           <Color>#0000FF</Color>
           <TextColor>#FFFFFF</TextColor>
@@ -115,7 +115,7 @@
         <Mark>
           <Control>outro_end_position</Control>
           <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-          <Text>&#9699;|</Text>
+          <Text>&#9699;</Text>
           <Align>bottom</Align>
           <Color>#0000FF</Color>
           <TextColor>#FFFFFF</TextColor>

--- a/res/skins/Shade/waveform.xml
+++ b/res/skins/Shade/waveform.xml
@@ -59,35 +59,35 @@
       <Color>#0000FF</Color>
       <Opacity>0.1</Opacity>
     </MarkRange>
+    <Mark>
+      <Control>intro_start_position</Control>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <Text>&#9698;</Text>
+      <Align>bottom|right</Align>
+      <Color>#0000FF</Color>
+      <TextColor>#FFFFFF</TextColor>
+    </Mark>
+    <Mark>
+      <Control>intro_end_position</Control>
+      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
+      <Text>&#9698;</Text>
+      <Align>bottom|left</Align>
+      <Color>#0000FF</Color>
+      <TextColor>#FFFFFF</TextColor>
+    </Mark>
+    <!-- Outro -->
     <MarkRange>
       <StartControl>outro_start_position</StartControl>
       <EndControl>outro_end_position</EndControl>
       <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
       <Color>#0000FF</Color>
-    </MarkRange>
-    <Mark>
-      <Control>intro_start_position</Control>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-      <Text>&#9698;</Text>
-      <Align>bottom</Align>
-      <Color>#0000FF</Color>
-      <TextColor>#FFFFFF</TextColor>
-    </Mark>
-    <!-- Outro -->
-    <Mark>
-      <Control>intro_end_position</Control>
-      <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-      <Text>&#9698;</Text>
-      <Align>bottom</Align>
-      <Color>#0000FF</Color>
       <Opacity>0.1</Opacity>
-      <TextColor>#FFFFFF</TextColor>
-    </Mark>
+    </MarkRange>
     <Mark>
       <Control>outro_start_position</Control>
       <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
       <Text>&#9699;</Text>
-      <Align>bottom</Align>
+      <Align>bottom|right</Align>
       <Color>#0000FF</Color>
       <TextColor>#FFFFFF</TextColor>
     </Mark>
@@ -95,7 +95,7 @@
       <Control>outro_end_position</Control>
       <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
       <Text>&#9699;</Text>
-      <Align>bottom</Align>
+      <Align>bottom|left</Align>
       <Color>#0000FF</Color>
       <TextColor>#FFFFFF</TextColor>
     </Mark>

--- a/res/skins/Shade/waveform.xml
+++ b/res/skins/Shade/waveform.xml
@@ -68,7 +68,7 @@
     <Mark>
       <Control>intro_start_position</Control>
       <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-      <Text>|&#9698;</Text>
+      <Text>&#9698;</Text>
       <Align>bottom</Align>
       <Color>#0000FF</Color>
       <TextColor>#FFFFFF</TextColor>
@@ -77,7 +77,7 @@
     <Mark>
       <Control>intro_end_position</Control>
       <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-      <Text>&#9698;|</Text>
+      <Text>&#9698;</Text>
       <Align>bottom</Align>
       <Color>#0000FF</Color>
       <Opacity>0.1</Opacity>
@@ -86,7 +86,7 @@
     <Mark>
       <Control>outro_start_position</Control>
       <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-      <Text>|&#9699;</Text>
+      <Text>&#9699;</Text>
       <Align>bottom</Align>
       <Color>#0000FF</Color>
       <TextColor>#FFFFFF</TextColor>
@@ -94,7 +94,7 @@
     <Mark>
       <Control>outro_end_position</Control>
       <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-      <Text>&#9699;|</Text>
+      <Text>&#9699;</Text>
       <Align>bottom</Align>
       <Color>#0000FF</Color>
       <TextColor>#FFFFFF</TextColor>

--- a/res/skins/Tango/waveform.xml
+++ b/res/skins/Tango/waveform.xml
@@ -77,7 +77,7 @@ Variables:
           <Control>intro_start_position</Control>
           <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
           <Text>&#9698;</Text>
-          <Align>bottom</Align>
+          <Align>bottom|right</Align>
           <Color>#0000FF</Color>
           <TextColor>#FFFFFF</TextColor>
         </Mark>
@@ -85,7 +85,7 @@ Variables:
           <Control>intro_end_position</Control>
           <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
           <Text>&#9698;</Text>
-          <Align>bottom</Align>
+          <Align>bottom|left</Align>
           <Color>#0000FF</Color>
           <TextColor>#FFFFFF</TextColor>
         </Mark>
@@ -100,7 +100,7 @@ Variables:
           <Control>outro_start_position</Control>
           <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
           <Text>&#9699;</Text>
-          <Align>bottom</Align>
+          <Align>bottom|right</Align>
           <Color>#0000FF</Color>
           <TextColor>#FFFFFF</TextColor>
         </Mark>
@@ -108,7 +108,7 @@ Variables:
           <Control>outro_end_position</Control>
           <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
           <Text>&#9699;</Text>
-          <Align>bottom</Align>
+          <Align>bottom|left</Align>
           <Color>#0000FF</Color>
           <TextColor>#FFFFFF</TextColor>
         </Mark>

--- a/res/skins/Tango/waveform.xml
+++ b/res/skins/Tango/waveform.xml
@@ -76,7 +76,7 @@ Variables:
         <Mark>
           <Control>intro_start_position</Control>
           <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-          <Text>|&#9698;</Text>
+          <Text>&#9698;</Text>
           <Align>bottom</Align>
           <Color>#0000FF</Color>
           <TextColor>#FFFFFF</TextColor>
@@ -84,7 +84,7 @@ Variables:
         <Mark>
           <Control>intro_end_position</Control>
           <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-          <Text>&#9698;|</Text>
+          <Text>&#9698;</Text>
           <Align>bottom</Align>
           <Color>#0000FF</Color>
           <TextColor>#FFFFFF</TextColor>
@@ -99,7 +99,7 @@ Variables:
         <Mark>
           <Control>outro_start_position</Control>
           <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-          <Text>|&#9699;</Text>
+          <Text>&#9699;</Text>
           <Align>bottom</Align>
           <Color>#0000FF</Color>
           <TextColor>#FFFFFF</TextColor>
@@ -107,7 +107,7 @@ Variables:
         <Mark>
           <Control>outro_end_position</Control>
           <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-          <Text>&#9699;|</Text>
+          <Text>&#9699;</Text>
           <Align>bottom</Align>
           <Color>#0000FF</Color>
           <TextColor>#FFFFFF</TextColor>


### PR DESCRIPTION
![Screenshot_2021-06-13_17-11-02](https://user-images.githubusercontent.com/5934199/121813073-d067df00-cc6a-11eb-8b98-46b129b4d035.png)
![Screenshot_2021-06-13_17-11-07](https://user-images.githubusercontent.com/5934199/121813075-d1007580-cc6a-11eb-97a4-01ada14ac6e9.png)
![Screenshot_2021-06-13_17-11-13](https://user-images.githubusercontent.com/5934199/121813076-d1007580-cc6a-11eb-92e3-d0757217072e.png)
![Screenshot_2021-06-13_17-11-20](https://user-images.githubusercontent.com/5934199/121813078-d1990c00-cc6a-11eb-9355-0588c959a659.png)