### PR TITLE
Add support for editing ReplayGain values.

### DIFF
--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -706,6 +706,9 @@ bool BaseSqlTableModel::setTrackValueForColumn(
         pTrack->setComment(value.toString());
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM) == column) {
         pTrack->trySetBpm(static_cast<double>(value.toDouble()));
+    } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_REPLAYGAIN) == column) {
+        // pTrack->trySet(static_cast<double>(value.toDouble()));
+        pTrack->trySetReplayGainFromString(value.toString());
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_PLAYED) == column) {
         // Update both the played flag and the number of times played
         pTrack->updatePlayCounter(value.toBool());

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -707,8 +707,11 @@ bool BaseSqlTableModel::setTrackValueForColumn(
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM) == column) {
         pTrack->trySetBpm(static_cast<double>(value.toDouble()));
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_REPLAYGAIN) == column) {
-        // pTrack->trySet(static_cast<double>(value.toDouble()));
-        pTrack->trySetReplayGainFromString(value.toString());
+        bool valid = false;
+        double ratio = mixxx::ReplayGain::ratioFromString(value.toString(), &valid);
+        if (valid) {
+            pTrack->setReplayGainDb(ratio);
+        }
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_PLAYED) == column) {
         // Update both the played flag and the number of times played
         pTrack->updatePlayCounter(value.toBool());

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -710,7 +710,7 @@ bool BaseSqlTableModel::setTrackValueForColumn(
         bool valid = false;
         double ratio = mixxx::ReplayGain::ratioFromString(value.toString(), &valid);
         if (valid) {
-            pTrack->setReplayGainDb(ratio);
+            pTrack->setReplayGainRatio(ratio);
         }
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_PLAYED) == column) {
         // Update both the played flag and the number of times played

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -795,6 +795,21 @@ QVariant BaseTrackTableModel::roleValue(
                 return QVariant();
             }
             return QVariant::fromValue(StarRating(rawValue.toInt()));
+        case ColumnCache::COLUMN_LIBRARYTABLE_REPLAYGAIN:
+            double rgRatio;
+            if (rawValue.canConvert<mixxx::ReplayGain>()) {
+                rgRatio = rawValue.value<mixxx::ReplayGain>().getRatio();
+            } else {
+                VERIFY_OR_DEBUG_ASSERT(rawValue.canConvert<double>()) {
+                    return QVariant();
+                }
+                bool ok;
+                rgRatio = rawValue.toDouble(&ok);
+                VERIFY_OR_DEBUG_ASSERT(ok) {
+                    return QVariant();
+                }
+            }
+            return mixxx::ReplayGain::ratioToString(rgRatio);
         default:
             // Otherwise, just use the column value
             break;
@@ -878,7 +893,6 @@ Qt::ItemFlags BaseTrackTableModel::readWriteFlags(
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_DURATION) ||
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_FILETYPE) ||
             column == fieldIndex(ColumnCache::COLUMN_TRACKLOCATIONSTABLE_LOCATION) ||
-            column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_REPLAYGAIN) ||
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_SAMPLERATE)) {
         return readOnlyFlags(index);
     }

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -539,6 +539,28 @@ QVariant BaseTrackTableModel::composeCoverArtToolTipHtml(
     return html;
 }
 
+namespace {
+QVariant rawValueToReplayGainString(QVariant&& rawValue) {
+    if (rawValue.isNull()) {
+        return QVariant();
+    }
+    double rgRatio;
+    if (rawValue.canConvert<mixxx::ReplayGain>()) {
+        rgRatio = rawValue.value<mixxx::ReplayGain>().getRatio();
+    } else {
+        VERIFY_OR_DEBUG_ASSERT(rawValue.canConvert<double>()) {
+            return QVariant();
+        }
+        bool ok;
+        rgRatio = rawValue.toDouble(&ok);
+        VERIFY_OR_DEBUG_ASSERT(ok) {
+            return QVariant();
+        }
+    }
+    return mixxx::ReplayGain::ratioToString(rgRatio);
+}
+} // namespace
+
 QVariant BaseTrackTableModel::roleValue(
         const QModelIndex& index,
         QVariant&& rawValue,
@@ -741,25 +763,8 @@ QVariant BaseTrackTableModel::roleValue(
             // Render the key with the user-provided notation
             return KeyUtils::keyToString(key);
         }
-        case ColumnCache::COLUMN_LIBRARYTABLE_REPLAYGAIN: {
-            if (rawValue.isNull()) {
-                return QVariant();
-            }
-            double rgRatio;
-            if (rawValue.canConvert<mixxx::ReplayGain>()) {
-                rgRatio = rawValue.value<mixxx::ReplayGain>().getRatio();
-            } else {
-                VERIFY_OR_DEBUG_ASSERT(rawValue.canConvert<double>()) {
-                    return QVariant();
-                }
-                bool ok;
-                rgRatio = rawValue.toDouble(&ok);
-                VERIFY_OR_DEBUG_ASSERT(ok) {
-                    return QVariant();
-                }
-            }
-            return mixxx::ReplayGain::ratioToString(rgRatio);
-        }
+        case ColumnCache::COLUMN_LIBRARYTABLE_REPLAYGAIN:
+            return rawValueToReplayGainString(std::move(rawValue));
         case ColumnCache::COLUMN_LIBRARYTABLE_CHANNELS:
             // Not yet supported
             DEBUG_ASSERT(rawValue.isNull());
@@ -796,20 +801,7 @@ QVariant BaseTrackTableModel::roleValue(
             }
             return QVariant::fromValue(StarRating(rawValue.toInt()));
         case ColumnCache::COLUMN_LIBRARYTABLE_REPLAYGAIN:
-            double rgRatio;
-            if (rawValue.canConvert<mixxx::ReplayGain>()) {
-                rgRatio = rawValue.value<mixxx::ReplayGain>().getRatio();
-            } else {
-                VERIFY_OR_DEBUG_ASSERT(rawValue.canConvert<double>()) {
-                    return QVariant();
-                }
-                bool ok;
-                rgRatio = rawValue.toDouble(&ok);
-                VERIFY_OR_DEBUG_ASSERT(ok) {
-                    return QVariant();
-                }
-            }
-            return mixxx::ReplayGain::ratioToString(rgRatio);
+            return rawValueToReplayGainString(std::move(rawValue));
         default:
             // Otherwise, just use the column value
             break;

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -324,13 +324,8 @@ mixxx::ReplayGain Track::getReplayGain() const {
     return m_record.getMetadata().getTrackInfo().getReplayGain();
 }
 
-bool Track::trySetReplayGainFromString(const QString& gainStr) {
+bool Track::setReplayGainDb(double ratio) {
     QMutexLocker lock(&m_qMutex);
-    bool valid = false;
-    double ratio = mixxx::ReplayGain::ratioFromString(gainStr, &valid);
-    if (!valid) {
-        return false;
-    }
     mixxx::ReplayGain replayGain = *m_record.refMetadata().refTrackInfo().ptrReplayGain();
     replayGain.setRatio(ratio);
     if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrReplayGain(), replayGain)) {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -324,16 +324,14 @@ mixxx::ReplayGain Track::getReplayGain() const {
     return m_record.getMetadata().getTrackInfo().getReplayGain();
 }
 
-bool Track::setReplayGainRatio(double ratio) {
+void Track::setReplayGainRatio(double ratio) {
     QMutexLocker lock(&m_qMutex);
-    mixxx::ReplayGain replayGain = *m_record.refMetadata().refTrackInfo().ptrReplayGain();
-    replayGain.setRatio(ratio);
-    if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrReplayGain(), replayGain)) {
+    mixxx::ReplayGain* replayGain = m_record.refMetadata().refTrackInfo().ptrReplayGain();
+    if (ratio != replayGain->getRatio()) {
+        replayGain->setRatio(ratio);
         markDirtyAndUnlock(&lock);
-        emit replayGainUpdated(replayGain);
-        return true;
+        emit replayGainUpdated(*replayGain);
     }
-    return false;
 }
 
 void Track::setReplayGain(const mixxx::ReplayGain& replayGain) {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -8,6 +8,7 @@
 #include "sources/metadatasource.h"
 #include "track/beatfactory.h"
 #include "track/beatmap.h"
+#include "track/replaygain.h"
 #include "track/trackref.h"
 #include "util/assert.h"
 #include "util/color/color.h"
@@ -321,6 +322,23 @@ bool Track::replaceRecord(
 mixxx::ReplayGain Track::getReplayGain() const {
     QMutexLocker lock(&m_qMutex);
     return m_record.getMetadata().getTrackInfo().getReplayGain();
+}
+
+bool Track::trySetReplayGainFromString(const QString& gainStr) {
+    QMutexLocker lock(&m_qMutex);
+    bool valid = false;
+    double ratio = mixxx::ReplayGain::ratioFromString(gainStr, &valid);
+    if (!valid) {
+        return false;
+    }
+    mixxx::ReplayGain replayGain = *m_record.refMetadata().refTrackInfo().ptrReplayGain();
+    replayGain.setRatio(ratio);
+    if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrReplayGain(), replayGain)) {
+        markDirtyAndUnlock(&lock);
+        emit replayGainUpdated(replayGain);
+        return true;
+    }
+    return false;
 }
 
 void Track::setReplayGain(const mixxx::ReplayGain& replayGain) {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -324,7 +324,7 @@ mixxx::ReplayGain Track::getReplayGain() const {
     return m_record.getMetadata().getTrackInfo().getReplayGain();
 }
 
-bool Track::setReplayGainDb(double ratio) {
+bool Track::setReplayGainRatio(double ratio) {
     QMutexLocker lock(&m_qMutex);
     mixxx::ReplayGain replayGain = *m_record.refMetadata().refTrackInfo().ptrReplayGain();
     replayGain.setRatio(ratio);

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -142,9 +142,9 @@ class Track : public QObject {
     void setBpmLocked(bool bpmLocked);
     bool isBpmLocked() const;
 
-    // Try to set the ReplayGain from a db string, as done by the EditRole
-    // in the track table.
-    bool trySetReplayGainFromString(const QString& gainStr);
+    // Updates the ReplayGain ratio value, preserving the other properties of the
+    // existing ReplayGain.
+    bool setReplayGainDb(double ratio);
     // Set ReplayGain
     void setReplayGain(const mixxx::ReplayGain&);
     // Returns ReplayGain

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -142,6 +142,9 @@ class Track : public QObject {
     void setBpmLocked(bool bpmLocked);
     bool isBpmLocked() const;
 
+    // Try to set the ReplayGain from a db string, as done by the EditRole
+    // in the track table.
+    bool trySetReplayGainFromString(const QString& gainStr);
     // Set ReplayGain
     void setReplayGain(const mixxx::ReplayGain&);
     // Returns ReplayGain

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -144,7 +144,7 @@ class Track : public QObject {
 
     // Updates the ReplayGain ratio value, preserving the other properties of the
     // existing ReplayGain.
-    bool setReplayGainRatio(double ratio);
+    void setReplayGainRatio(double ratio);
     // Set ReplayGain
     void setReplayGain(const mixxx::ReplayGain&);
     // Returns ReplayGain

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -144,7 +144,7 @@ class Track : public QObject {
 
     // Updates the ReplayGain ratio value, preserving the other properties of the
     // existing ReplayGain.
-    bool setReplayGainDb(double ratio);
+    bool setReplayGainRatio(double ratio);
     // Set ReplayGain
     void setReplayGain(const mixxx::ReplayGain&);
     // Returns ReplayGain


### PR DESCRIPTION
This is another "quality of life" change.

Sometimes the replaygain value is a bit too aggressive  -- maybe it's
technically correct, but the value isn't helpful for making mixes.
Add support for editing the value using the db adjustment string as
displayed in the track table.

Tested with several problem tracks, as well as tracks without any
replaygain value. If the user wants to restore the replaygain deteced
value, they can clear the replaygain value and reanalyze.