### PR TITLE
cmake default_option() parentheses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2271,13 +2271,7 @@ find_package(MP4)
 find_package(MP4v2)
 # It is enabled by default on Linux only, because other targets have other
 # solutions. It requires MP4 or MP4v2.
-# Note, we use if() here, because the following line does not work with cmake 3.16.3
-# default_option(FAAD "FAAD AAC audio file decoder support" "UNIX;NOT APPLE;(MP4_FOUND OR MP4v2_FOUND)")
-if (UNIX AND NOT APPLE AND (MP4_FOUND OR MP4v2_FOUND))
-  option(FAAD "FAAD AAC audio file decoder support" ON)
-else()
-  option(FAAD "FAAD AAC audio file decoder support" OFF)
-endif()
+default_option(FAAD "FAAD AAC audio file decoder support" "UNIX;NOT APPLE;MP4_FOUND OR MP4v2_FOUND")
 if(FAAD)
   if(NOT MP4_FOUND AND NOT MP4v2_FOUND)
     message(FATAL_ERROR "FAAD AAC audio support requires libmp4 or libmp4v2 with development headers.")

--- a/cmake/modules/DefaultOption.cmake
+++ b/cmake/modules/DefaultOption.cmake
@@ -33,7 +33,10 @@ set a default and the value may be overridden by the user.
 macro(DEFAULT_OPTION option doc depends)
   set(${option}_DEFAULT_ON 1)
   foreach(d ${depends})
-    string(REGEX REPLACE " +" ";" DEFAULT_OPTION_DEP "${d}")
+    # if() takes the condition as a list of arguments. Parentheses need to be separated as well.
+    string(REPLACE "(" " ( " DEFAULT_OPTION_DEP "${d}")
+    string(REPLACE ")" " ) " DEFAULT_OPTION_DEP "${DEFAULT_OPTION_DEP}")
+    string(REGEX REPLACE " +" ";" DEFAULT_OPTION_DEP "${DEFAULT_OPTION_DEP}")
     if(${DEFAULT_OPTION_DEP})
     else()
       set(${option}_DEFAULT_ON 0)


### PR DESCRIPTION
I have found some time to dig down the latest cmake issue. It turns out that it is an issue in our own module, but the parentheses are not required anyway. 
This PR fixes both. 

The original cmake_dependent_option() also suffers the issue, I have reported a bug and issued a PR with the fix:
https://gitlab.kitware.com/cmake/cmake/-/issues/22303