### PR TITLE
SoundSourceM4A: Fix armv7hl build on gcc 11.1 

### DIFF
--- a/src/sources/soundsourcem4a.cpp
+++ b/src/sources/soundsourcem4a.cpp
@@ -761,15 +761,15 @@ ReadableSampleFrames SoundSourceM4A::readSampleFramesClamped(
             // Verify the decoded sample data for consistency
             const auto channelCount = mixxx::audio::ChannelCount(decFrameInfo.channels);
             VERIFY_OR_DEBUG_ASSERT(getSignalInfo().getChannelCount() == channelCount) {
-                kLogger.critical() << "Corrupt or unsupported AAC file:"
-                                   << "Unexpected number of channels"
-                                   << channelCount << "<>"
-                                   << getSignalInfo().getChannelCount();
+                kLogger.warning() << "Corrupt or unsupported AAC file:"
+                                  << "Unexpected number of channels"
+                                  << channelCount << "<>"
+                                  << getSignalInfo().getChannelCount();
                 break; // abort
             }
             const auto sampleRate = mixxx::audio::SampleRate(decFrameInfo.samplerate);
             VERIFY_OR_DEBUG_ASSERT(getSignalInfo().getSampleRate() == sampleRate) {
-                kLogger.critical()
+                kLogger.warning()
                         << "Corrupt or unsupported AAC file:"
                         << "Unexpected sample rate" << sampleRate
                         << "<>" << getSignalInfo().getSampleRate();

--- a/src/sources/soundsourcem4a.cpp
+++ b/src/sources/soundsourcem4a.cpp
@@ -759,19 +759,19 @@ ReadableSampleFrames SoundSourceM4A::readSampleFramesClamped(
                     pDecodeBuffer); // verify the in/out parameter
 
             // Verify the decoded sample data for consistency
-            VERIFY_OR_DEBUG_ASSERT(getSignalInfo().getChannelCount() ==
-                    decFrameInfo.channels) {
+            const auto channelCount = mixxx::audio::ChannelCount(decFrameInfo.channels);
+            VERIFY_OR_DEBUG_ASSERT(getSignalInfo().getChannelCount() == channelCount) {
                 kLogger.critical() << "Corrupt or unsupported AAC file:"
                                    << "Unexpected number of channels"
-                                   << decFrameInfo.channels << "<>"
+                                   << channelCount << "<>"
                                    << getSignalInfo().getChannelCount();
                 break; // abort
             }
-            VERIFY_OR_DEBUG_ASSERT(getSignalInfo().getSampleRate() ==
-                    SINT(decFrameInfo.samplerate)) {
+            const auto sampleRate = mixxx::audio::SampleRate(decFrameInfo.samplerate);
+            VERIFY_OR_DEBUG_ASSERT(getSignalInfo().getSampleRate() == sampleRate) {
                 kLogger.critical()
                         << "Corrupt or unsupported AAC file:"
-                        << "Unexpected sample rate" << decFrameInfo.samplerate
+                        << "Unexpected sample rate" << sampleRate
                         << "<>" << getSignalInfo().getSampleRate();
                 break; // abort
             }


### PR DESCRIPTION
Next build error: https://koji.rpmfusion.org/kojifiles/work/tasks/9223/489223/build.log

```
-Werror -fPIC -pthread -std=gnu++17 -MD -MT CMakeFiles/mixxx-lib.dir/src/sources/soundsourcem4a.cpp.o -MF CMakeFiles/mixxx-lib.dir/src/sources/soundsourcem4a.cpp.o.d -o CMakeFiles/mixxx-lib.dir/src/sources/soundsourcem4a.cpp.o -c ../src/sources/soundsourcem4a.cpp
In file included from ../src/audio/types.h:7,
                 from ../src/audio/signalinfo.h:3,
                 from ../src/audio/streaminfo.h:3,
                 from ../src/sources/audiosource.h:3,
                 from ../src/sources/soundsource.h:5,
                 from ../src/sources/soundsourcem4a.h:3,
                 from ../src/sources/soundsourcem4a.cpp:1:
../src/sources/soundsourcem4a.cpp: In member function 'virtual mixxx::ReadableSampleFrames mixxx::SoundSourceM4A::readSampleFramesClamped(const mixxx::WritableSampleFrames&)':
../src/sources/soundsourcem4a.cpp:770:68: error: comparison of integer expressions of different signedness: 'mixxx::audio::SampleRate::value_t' {aka 'unsigned int'} and 'SINT' {aka 'int'} [-Werror=sign-compare]
  770 |             VERIFY_OR_DEBUG_ASSERT(getSignalInfo().getSampleRate() ==
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
  771 |                     SINT(decFrameInfo.samplerate)) {
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                   
../src/util/assert.h:62:45: note: in definition of macro 'VERIFY_OR_DEBUG_ASSERT'
   62 | #define VERIFY_OR_DEBUG_ASSERT(cond) if ((!(cond)) && mixxx_maybe_debug_assert_return_true(#cond, __FILE__, __LINE__, ASSERT_FUNCTION))
      |                                             ^~~~
cc1plus: all warnings being treated as errors
```

