### PR TITLE
Fix reimport of track metadata

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -668,7 +668,11 @@ void DlgTrackInfo::slotImportMetadataFromFile() {
     // losing existing metadata or to lose the beat grid by replacing
     // it with a default grid created from an imprecise BPM.
     // See also: https://bugs.launchpad.net/mixxx/+bug/1929311
-    mixxx::TrackMetadata trackMetadata = m_pLoadedTrack->getMetadata();
+    // In additiona we need to preserve all other track properties
+    // that are stored in TrackRecord, which serves as the underlying
+    // model for this dialog.
+    mixxx::TrackRecord trackRecord = m_pLoadedTrack->getRecord();
+    mixxx::TrackMetadata trackMetadata = trackRecord.getMetadata();
     QImage coverImage;
     const auto [importResult, metadataSynchronized] =
             SoundSourceProxy(m_pLoadedTrack)
@@ -682,7 +686,6 @@ void DlgTrackInfo::slotImportMetadataFromFile() {
             fileAccess.info(),
             trackMetadata.getAlbumInfo().getTitle(),
             coverImage);
-    mixxx::TrackRecord trackRecord;
     trackRecord.replaceMetadataFromSource(
             std::move(trackMetadata),
             metadataSynchronized);

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -110,6 +110,11 @@ bool copyIfNotEmpty(
 bool TrackRecord::replaceMetadataFromSource(
         TrackMetadata&& importedMetadata,
         const QDateTime& metadataSynchronized) {
+    if (m_streamInfoFromSource) {
+        // Preserve precise stream info if available, i.e. discard the
+        // audio properties that are also stored as track metadata.
+        importedMetadata.updateStreamInfoFromSource(*m_streamInfoFromSource);
+    }
     bool modified = false;
     if (getMetadata() != importedMetadata) {
         setMetadata(std::move(importedMetadata));


### PR DESCRIPTION
The first commit fixes a bug reported here: https://github.com/mixxxdj/mixxx/pull/3978#issuecomment-860478706

We need to preserve the extended metadata stored in `TrackRecord`, and not only `TrackMetadata`.

@Holzhaus I also noticed that audio stream properties as reported by the sound source get out-of-sync when re-importing track metadata for a currently loaded track. Fixed by the 2nd commit.