### PR TITLE
Preferences > Decks: fix activation of rate change controls

### DIFF
--- a/src/engine/controls/ratecontrol.cpp
+++ b/src/engine/controls/ratecontrol.cpp
@@ -535,26 +535,24 @@ void RateControl::processTempRate(const int bufferSamples) {
                 }
             }
         } else if (m_eRateRampMode == RampMode::Linear) {
-            if (rampDirection != RampDirection::None) {
-                if (!m_bTempStarted) {
-                    m_bTempStarted = true;
-                    double latrate = ((double)bufferSamples / (double)m_pSampleRate->get());
-                    m_dRateTempRampChange = (latrate / ((double)m_iRateRampSensitivity / 100.));
-                }
+            if (!m_bTempStarted) {
+                m_bTempStarted = true;
+                double latrate = ((double)bufferSamples / (double)m_pSampleRate->get());
+                m_dRateTempRampChange = (latrate / ((double)m_iRateRampSensitivity / 100.));
+            }
 
-                switch (rampDirection) {
-                case RampDirection::Up:
-                case RampDirection::UpSmall:
-                    addRateTemp(m_dRateTempRampChange * m_pRateRange->get());
-                    break;
-                case RampDirection::Down:
-                case RampDirection::DownSmall:
-                    subRateTemp(m_dRateTempRampChange * m_pRateRange->get());
-                    break;
-                case RampDirection::None:
-                default:
-                    DEBUG_ASSERT(false);
-                }
+            switch (rampDirection) {
+            case RampDirection::Up:
+            case RampDirection::UpSmall:
+                addRateTemp(m_dRateTempRampChange * m_pRateRange->get());
+                break;
+            case RampDirection::Down:
+            case RampDirection::DownSmall:
+                subRateTemp(m_dRateTempRampChange * m_pRateRange->get());
+                break;
+            case RampDirection::None:
+            default:
+                DEBUG_ASSERT(false);
             }
         }
     } else if (m_bTempStarted) {

--- a/src/engine/controls/ratecontrol.cpp
+++ b/src/engine/controls/ratecontrol.cpp
@@ -537,8 +537,8 @@ void RateControl::processTempRate(const int bufferSamples) {
         } else if (m_eRateRampMode == RampMode::Linear) {
             if (!m_bTempStarted) {
                 m_bTempStarted = true;
-                double latrate = ((double)bufferSamples / (double)m_pSampleRate->get());
-                m_dRateTempRampChange = (latrate / ((double)m_iRateRampSensitivity / 100.));
+                double latrate = bufferSamples / m_pSampleRate->get();
+                m_dRateTempRampChange = latrate / (m_iRateRampSensitivity / 100.0);
             }
 
             switch (rampDirection) {

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -342,22 +342,8 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent,
                     MIXXX_MANUAL_CUE_MODES_URL));
 
     //
-    // Ramping Temporary Rate Change configuration
+    // Speed / Pitch reset configuration
     //
-
-    // Set Ramp Rate On or Off
-    connect(radioButtonRateRampModeLinear,
-            &QRadioButton::toggled,
-            this,
-            &DlgPrefDeck::slotRateRampingModeLinearButton);
-    m_bRateRamping = static_cast<RateControl::RampMode>(
-        m_pConfig->getValue(ConfigKey("[Controls]", "RateRamp"),
-                            static_cast<int>(kDefaultRampingMode)));
-    if (m_bRateRamping == RateControl::RampMode::Linear) {
-        radioButtonRateRampModeLinear->setChecked(true);
-    } else {
-        radioButtonRateRampModeStepping->setChecked(true);
-    }
 
     // Update "reset speed" and "reset pitch" check boxes
     // TODO: All defaults should only be set in slotResetToDefaults.
@@ -376,6 +362,10 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent,
     connect(checkBoxResetSpeed, &QCheckBox::toggled, this, &DlgPrefDeck::slotUpdateSpeedAutoReset);
     connect(checkBoxResetPitch, &QCheckBox::toggled, this, &DlgPrefDeck::slotUpdatePitchAutoReset);
 
+    //
+    // Ramping Temporary Rate Change configuration
+    //
+
     connect(SliderRateRampSensitivity,
             QOverload<int>::of(&QAbstractSlider::valueChanged),
             SpinBoxRateRampSensitivity,
@@ -384,6 +374,7 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent,
             QOverload<int>::of(&QSpinBox::valueChanged),
             SliderRateRampSensitivity,
             QOverload<int>::of(&QAbstractSlider::setValue));
+    // Enable/disable permanent rate spinboxes when smooth ramping is selected
     connect(radioButtonRateRampModeLinear,
             &QRadioButton::toggled,
             labelSpeedRampSensitivity,
@@ -396,6 +387,7 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent,
             &QRadioButton::toggled,
             SpinBoxRateRampSensitivity,
             &QWidget::setEnabled);
+    // Enable/disable temporary rate spinboxes when abrupt ramping is selected
     connect(radioButtonRateRampModeStepping,
             &QRadioButton::toggled,
             labelSpeedTemporary,
@@ -408,6 +400,19 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent,
             &QRadioButton::toggled,
             spinBoxTemporaryRateFine,
             &QWidget::setEnabled);
+    // Set Ramp Rate On or Off
+    connect(radioButtonRateRampModeLinear,
+            &QRadioButton::toggled,
+            this,
+            &DlgPrefDeck::slotRateRampingModeLinearButton);
+    m_bRateRamping = static_cast<RateControl::RampMode>(
+            m_pConfig->getValue(ConfigKey("[Controls]", "RateRamp"),
+                    static_cast<int>(kDefaultRampingMode)));
+    if (m_bRateRamping == RateControl::RampMode::Linear) {
+        radioButtonRateRampModeLinear->setChecked(true);
+    } else {
+        radioButtonRateRampModeStepping->setChecked(true);
+    }
 
     slotUpdate();
 }
@@ -478,6 +483,12 @@ void DlgPrefDeck::slotUpdate() {
     } else if (reset == BaseTrackPlayer::RESET_NONE) {
         checkBoxResetPitch->setChecked(false);
         checkBoxResetSpeed->setChecked(false);
+    }
+
+    if (m_bRateRamping == RateControl::RampMode::Linear) {
+        radioButtonRateRampModeLinear->setChecked(true);
+    } else {
+        radioButtonRateRampModeStepping->setChecked(true);
     }
 
     SliderRateRampSensitivity->setValue(

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -284,53 +284,6 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent,
     }
 
     //
-    // Rate buttons configuration
-    //
-    connect(spinBoxTemporaryRateCoarse,
-            QOverload<double>::of(&QDoubleSpinBox::valueChanged),
-            this,
-            &DlgPrefDeck::slotRateTempCoarseSpinbox);
-    connect(spinBoxTemporaryRateFine,
-            QOverload<double>::of(&QDoubleSpinBox::valueChanged),
-            this,
-            &DlgPrefDeck::slotRateTempFineSpinbox);
-    connect(spinBoxPermanentRateCoarse,
-            QOverload<double>::of(&QDoubleSpinBox::valueChanged),
-            this,
-            &DlgPrefDeck::slotRatePermCoarseSpinbox);
-    connect(spinBoxPermanentRateFine,
-            QOverload<double>::of(&QDoubleSpinBox::valueChanged),
-            this,
-            &DlgPrefDeck::slotRatePermFineSpinbox);
-
-    m_dRateTempCoarse = m_pConfig->getValue(ConfigKey("[Controls]", "RateTempLeft"),
-            kDefaultTemporaryRateChangeCoarse);
-    m_dRateTempFine = m_pConfig->getValue(ConfigKey("[Controls]", "RateTempRight"),
-            kDefaultTemporaryRateChangeFine);
-    m_dRatePermCoarse = m_pConfig->getValue(ConfigKey("[Controls]", "RatePermLeft"),
-            kDefaultPermanentRateChangeCoarse);
-    m_dRatePermFine = m_pConfig->getValue(ConfigKey("[Controls]", "RatePermRight"),
-            kDefaultPermanentRateChangeFine);
-
-    spinBoxTemporaryRateCoarse->setValue(m_dRateTempCoarse);
-    spinBoxTemporaryRateFine->setValue(m_dRateTempFine);
-    spinBoxPermanentRateCoarse->setValue(m_dRatePermCoarse);
-    spinBoxPermanentRateFine->setValue(m_dRatePermFine);
-
-    RateControl::setTemporaryRateChangeCoarseAmount(m_dRateTempCoarse);
-    RateControl::setTemporaryRateChangeFineAmount(m_dRateTempFine);
-    RateControl::setPermanentRateChangeCoarseAmount(m_dRatePermCoarse);
-    RateControl::setPermanentRateChangeFineAmount(m_dRatePermFine);
-
-    // Rate Ramp Sensitivity
-    m_iRateRampSensitivity = m_pConfig->getValue(ConfigKey("[Controls]", "RateRampSensitivity"), kDefaultRateRampSensitivity);
-    SliderRateRampSensitivity->setValue(m_iRateRampSensitivity);
-    connect(SliderRateRampSensitivity,
-            &QSlider::valueChanged,
-            this,
-            &DlgPrefDeck::slotRateRampSensitivitySlider);
-
-    //
     // Cue Mode
     //
 
@@ -366,6 +319,7 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent,
     // Ramping Temporary Rate Change configuration
     //
 
+    // Rate Ramp Sensitivity slider & spinbox
     connect(SliderRateRampSensitivity,
             QOverload<int>::of(&QAbstractSlider::valueChanged),
             SpinBoxRateRampSensitivity,
@@ -374,6 +328,16 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent,
             QOverload<int>::of(&QSpinBox::valueChanged),
             SliderRateRampSensitivity,
             QOverload<int>::of(&QAbstractSlider::setValue));
+
+    m_iRateRampSensitivity =
+            m_pConfig->getValue(ConfigKey("[Controls]", "RateRampSensitivity"),
+                    kDefaultRateRampSensitivity);
+    SliderRateRampSensitivity->setValue(m_iRateRampSensitivity);
+    connect(SliderRateRampSensitivity,
+            &QSlider::valueChanged,
+            this,
+            &DlgPrefDeck::slotRateRampSensitivitySlider);
+
     // Enable/disable permanent rate spinboxes when smooth ramping is selected
     connect(radioButtonRateRampModeLinear,
             &QRadioButton::toggled,
@@ -413,6 +377,43 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent,
     } else {
         radioButtonRateRampModeStepping->setChecked(true);
     }
+
+    // Rate buttons configuration
+    connect(spinBoxTemporaryRateCoarse,
+            QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+            this,
+            &DlgPrefDeck::slotRateTempCoarseSpinbox);
+    connect(spinBoxTemporaryRateFine,
+            QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+            this,
+            &DlgPrefDeck::slotRateTempFineSpinbox);
+    connect(spinBoxPermanentRateCoarse,
+            QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+            this,
+            &DlgPrefDeck::slotRatePermCoarseSpinbox);
+    connect(spinBoxPermanentRateFine,
+            QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+            this,
+            &DlgPrefDeck::slotRatePermFineSpinbox);
+
+    m_dRateTempCoarse = m_pConfig->getValue(ConfigKey("[Controls]", "RateTempLeft"),
+            kDefaultTemporaryRateChangeCoarse);
+    m_dRateTempFine = m_pConfig->getValue(ConfigKey("[Controls]", "RateTempRight"),
+            kDefaultTemporaryRateChangeFine);
+    m_dRatePermCoarse = m_pConfig->getValue(ConfigKey("[Controls]", "RatePermLeft"),
+            kDefaultPermanentRateChangeCoarse);
+    m_dRatePermFine = m_pConfig->getValue(ConfigKey("[Controls]", "RatePermRight"),
+            kDefaultPermanentRateChangeFine);
+
+    spinBoxTemporaryRateCoarse->setValue(m_dRateTempCoarse);
+    spinBoxTemporaryRateFine->setValue(m_dRateTempFine);
+    spinBoxPermanentRateCoarse->setValue(m_dRatePermCoarse);
+    spinBoxPermanentRateFine->setValue(m_dRatePermFine);
+
+    RateControl::setTemporaryRateChangeCoarseAmount(m_dRateTempCoarse);
+    RateControl::setTemporaryRateChangeFineAmount(m_dRateTempFine);
+    RateControl::setPermanentRateChangeCoarseAmount(m_dRatePermCoarse);
+    RateControl::setPermanentRateChangeFineAmount(m_dRatePermFine);
 
     slotUpdate();
 }

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -439,32 +439,32 @@ void DlgPrefDeck::slotUpdate() {
     checkBoxCloneDeckOnLoadDoubleTap->setChecked(m_pConfig->getValue(
             ConfigKey("[Controls]", "CloneDeckOnLoadDoubleTap"), true));
 
-    double deck1RateRange = m_rateRangeControls[0]->get();
-    int index = ComboBoxRateRange->findData(static_cast<int>(deck1RateRange * 100.0));
+    double rateRange = m_rateRangeControls[0]->get();
+    int index = ComboBoxRateRange->findData(static_cast<int>(rateRange * 100.0));
     if (index == -1) {
-        ComboBoxRateRange->addItem(QString::number(deck1RateRange * 100.).append("%"),
-                                   deck1RateRange * 100.);
+        ComboBoxRateRange->addItem(QString::number(rateRange * 100.).append("%"),
+                rateRange * 100.);
     }
     ComboBoxRateRange->setCurrentIndex(index);
 
-    double deck1RateDirection = m_rateDirectionControls[0]->get();
-    checkBoxInvertSpeedSlider->setChecked(deck1RateDirection == kRateDirectionInverted);
+    double rateDirection = m_rateDirectionControls[0]->get();
+    checkBoxInvertSpeedSlider->setChecked(rateDirection == kRateDirectionInverted);
 
-    double deck1CueMode = m_cueControls[0]->get();
-    index = ComboBoxCueMode->findData(static_cast<int>(deck1CueMode));
+    double cueMode = m_cueControls[0]->get();
+    index = ComboBoxCueMode->findData(static_cast<int>(cueMode));
     ComboBoxCueMode->setCurrentIndex(index);
 
-    KeylockMode deck1KeylockMode =
-        static_cast<KeylockMode>(static_cast<int>(m_keylockModeControls[0]->get()));
-    if (deck1KeylockMode == KeylockMode::LockCurrentKey) {
+    KeylockMode keylockMode =
+            static_cast<KeylockMode>(static_cast<int>(m_keylockModeControls[0]->get()));
+    if (keylockMode == KeylockMode::LockCurrentKey) {
         radioButtonCurrentKey->setChecked(true);
     } else {
         radioButtonOriginalKey->setChecked(true);
     }
 
-    KeyunlockMode deck1KeyunlockMode =
-        static_cast<KeyunlockMode>(static_cast<int>(m_keyunlockModeControls[0]->get()));
-    if (deck1KeyunlockMode == KeyunlockMode::KeepLockedKey) {
+    KeyunlockMode keyunlockMode =
+            static_cast<KeyunlockMode>(static_cast<int>(m_keyunlockModeControls[0]->get()));
+    if (keyunlockMode == KeyunlockMode::KeepLockedKey) {
         radioButtonKeepUnlockedKey->setChecked(true);
     } else {
         radioButtonResetUnlockedKey->setChecked(true);

--- a/src/preferences/dialog/dlgprefdeckdlg.ui
+++ b/src/preferences/dialog/dlgprefdeckdlg.ui
@@ -207,7 +207,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
      <layout class="QGridLayout" name="gridLayout_7">
       <item row="0" column="0">
        <layout class="QGridLayout" name="GridLayoutSpeedOptions">
-        <item row="7" column="1">
+        <item row="9" column="2">
          <widget class="QDoubleSpinBox" name="spinBoxPermanentRateCoarse">
           <property name="toolTip">
            <string>Permanent rate change when left-clicking</string>
@@ -235,7 +235,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="8" column="1">
+        <item row="9" column="1">
          <widget class="QDoubleSpinBox" name="spinBoxPermanentRateFine">
           <property name="toolTip">
            <string>Permanent rate change when right-clicking</string>
@@ -283,7 +283,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </attribute>
          </widget>
         </item>
-        <item row="8" column="2">
+        <item row="8" column="1">
          <widget class="QDoubleSpinBox" name="spinBoxTemporaryRateFine">
           <property name="enabled">
            <bool>false</bool>
@@ -314,7 +314,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="6" column="1">
+        <item row="9" column="0">
          <widget class="QLabel" name="labelSpeedPermanent">
           <property name="text">
            <string>Permanent</string>
@@ -324,7 +324,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="5" column="1" colspan="2">
+        <item row="6" column="1" colspan="2">
          <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
            <widget class="QSlider" name="SliderRateRampSensitivity">
@@ -372,7 +372,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </item>
          </layout>
         </item>
-        <item row="6" column="2">
+        <item row="8" column="0">
          <widget class="QLabel" name="labelSpeedTemporary">
           <property name="enabled">
            <bool>false</bool>
@@ -395,7 +395,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="5" column="0">
+        <item row="6" column="0">
          <widget class="QLabel" name="labelSpeedRampSensitivity">
           <property name="enabled">
            <bool>false</bool>
@@ -408,7 +408,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
+        <item row="5" column="0">
          <widget class="QLabel" name="labelSpeedBendBehavior">
           <property name="text">
            <string>Pitch bend behavior</string>
@@ -428,7 +428,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </attribute>
          </widget>
         </item>
-        <item row="7" column="2">
+        <item row="8" column="2">
          <widget class="QDoubleSpinBox" name="spinBoxTemporaryRateCoarse">
           <property name="enabled">
            <bool>false</bool>
@@ -473,14 +473,14 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="6" column="0">
+        <item row="7" column="0">
          <widget class="QLabel" name="labelSpeedAdjustment">
           <property name="text">
            <string>Adjustment buttons:</string>
           </property>
          </widget>
         </item>
-        <item row="7" column="0">
+        <item row="7" column="2">
          <widget class="QLabel" name="labelSpeedCoarse">
           <property name="enabled">
            <bool>true</bool>
@@ -495,7 +495,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
            <string>Coarse</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <set>Qt::AlignCenter</set>
           </property>
           <property name="wordWrap">
            <bool>false</bool>
@@ -505,7 +505,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="8" column="0">
+        <item row="7" column="1">
          <widget class="QLabel" name="labelSpeedFine">
           <property name="enabled">
            <bool>true</bool>
@@ -520,7 +520,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
            <string>Fine</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <set>Qt::AlignCenter</set>
           </property>
           <property name="wordWrap">
            <bool>false</bool>
@@ -569,7 +569,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="2">
+        <item row="5" column="2">
          <widget class="QRadioButton" name="radioButtonRateRampModeStepping">
           <property name="text">
            <string>Abrupt jump</string>
@@ -579,7 +579,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </attribute>
          </widget>
         </item>
-        <item row="4" column="1">
+        <item row="5" column="1">
          <widget class="QRadioButton" name="radioButtonRateRampModeLinear">
           <property name="toolTip">
            <string>Smoothly adjusts deck speed when temporary change buttons are held down</string>
@@ -619,13 +619,26 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </attribute>
          </widget>
         </item>
+        <item row="4" column="0">
+         <spacer name="verticalSpacer1">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>15</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
        </layout>
       </item>
      </layout>
     </widget>
    </item>
    <item row="2" column="0">
-    <spacer name="verticalSpacer">
+    <spacer name="verticalSpacer2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1931638
can't tell the reason for this change with git blame.
both the fine & coarse controls are available and working regardless of the pitchbend mode, so they should be configurable, too.