### PR TITLE
QML: Add support for deck cloning

### DIFF
--- a/res/skins/QMLDemo/Deck.qml
+++ b/res/skins/QMLDemo/Deck.qml
@@ -13,6 +13,20 @@ Item {
     property bool minimized: false
     property var deckPlayer: Mixxx.PlayerManager.getPlayer(group)
 
+    Drag.active: dragArea.drag.active
+    Drag.dragType: Drag.Automatic
+    Drag.supportedActions: Qt.CopyAction
+    Drag.mimeData: {
+        "mixxx/player": this.group
+    }
+
+    MouseArea {
+        id: dragArea
+
+        anchors.fill: root
+        drag.target: root
+    }
+
     Skin.SectionBackground {
         anchors.fill: parent
     }

--- a/res/skins/QMLDemo/Deck.qml
+++ b/res/skins/QMLDemo/Deck.qml
@@ -17,7 +17,14 @@ Item {
     Drag.dragType: Drag.Automatic
     Drag.supportedActions: Qt.CopyAction
     Drag.mimeData: {
-        "mixxx/player": this.group
+        let data = {
+            "mixxx/player": group
+        };
+        const trackLocationUrl = deckPlayer.trackLocationUrl;
+        if (trackLocationUrl)
+            data["text/uri-list"] = trackLocationUrl;
+
+        return data;
     }
 
     MouseArea {

--- a/res/skins/QMLDemo/Mixxx/PlayerDropArea.qml
+++ b/res/skins/QMLDemo/Mixxx/PlayerDropArea.qml
@@ -7,6 +7,16 @@ DropArea {
     property var player: Mixxx.PlayerManager.getPlayer(group)
 
     onDropped: {
+        if (drop.formats.includes("mixxx/player")) {
+            const sourceGroup = drop.getDataAsString("mixxx/player");
+            // Prevent dropping a deck onto itself
+            if (sourceGroup != this.group)
+                return ;
+
+            console.log("Drag from group " + sourceGroup);
+            player.cloneFromGroup(sourceGroup);
+            return ;
+        }
         if (drop.hasUrls) {
             let url = drop.urls[0];
             console.log("Dropped URL '" + url + "' on deck " + group);

--- a/res/skins/QMLDemo/Sampler.qml
+++ b/res/skins/QMLDemo/Sampler.qml
@@ -21,6 +21,19 @@ Rectangle {
         return Qt.darker(root.deckPlayer.color, 2);
     }
     implicitHeight: gainKnob.height + 10
+    Drag.active: dragArea.drag.active
+    Drag.dragType: Drag.Automatic
+    Drag.supportedActions: Qt.CopyAction
+    Drag.mimeData: {
+        "mixxx/player": this.group
+    }
+
+    MouseArea {
+        id: dragArea
+
+        anchors.fill: root
+        drag.target: root
+    }
 
     Skin.SectionBackground {
         anchors.fill: parent

--- a/res/skins/QMLDemo/Sampler.qml
+++ b/res/skins/QMLDemo/Sampler.qml
@@ -25,7 +25,14 @@ Rectangle {
     Drag.dragType: Drag.Automatic
     Drag.supportedActions: Qt.CopyAction
     Drag.mimeData: {
-        "mixxx/player": this.group
+        let data = {
+            "mixxx/player": group
+        };
+        const trackLocationUrl = deckPlayer.trackLocationUrl;
+        if (trackLocationUrl)
+            data["text/uri-list"] = trackLocationUrl;
+
+        return data;
     }
 
     MouseArea {

--- a/src/skin/qml/qmlplayermanagerproxy.cpp
+++ b/src/skin/qml/qmlplayermanagerproxy.cpp
@@ -35,6 +35,12 @@ QObject* QmlPlayerManagerProxy::getPlayer(const QString& group) {
             [this, group](const QString& trackLocation) {
                 emit loadLocationToPlayer(trackLocation, group);
             });
+    connect(pPlayerProxy,
+            &QmlPlayerProxy::cloneFromGroup,
+            this,
+            [this, group](const QString& sourceGroup) {
+                m_pPlayerManager->slotCloneDeck(sourceGroup, group);
+            });
     return pPlayerProxy;
 }
 

--- a/src/skin/qml/qmlplayerproxy.cpp
+++ b/src/skin/qml/qmlplayerproxy.cpp
@@ -139,6 +139,7 @@ void QmlPlayerProxy::slotTrackChanged() {
     emit keyTextChanged();
     emit colorChanged();
     emit coverArtUrlChanged();
+    emit trackLocationUrlChanged();
 }
 
 PROPERTY_IMPL(QString, artist, getArtist, setArtist)
@@ -178,6 +179,15 @@ QUrl QmlPlayerProxy::getCoverArtUrl() const {
 
     const CoverInfo coverInfo = pTrack->getCoverInfoWithLocation();
     return AsyncImageProvider::trackLocationToCoverArtUrl(coverInfo.trackLocation);
+}
+
+QUrl QmlPlayerProxy::getTrackLocationUrl() const {
+    const TrackPointer pTrack = m_pCurrentTrack;
+    if (pTrack == nullptr) {
+        return QUrl();
+    }
+
+    return QUrl::fromLocalFile(pTrack->getLocation());
 }
 
 } // namespace qml

--- a/src/skin/qml/qmlplayerproxy.h
+++ b/src/skin/qml/qmlplayerproxy.h
@@ -29,6 +29,7 @@ class QmlPlayerProxy : public QObject {
     Q_PROPERTY(QString keyText READ getKeyText WRITE setKeyText NOTIFY keyTextChanged)
     Q_PROPERTY(QColor color READ getColor WRITE setColor NOTIFY colorChanged)
     Q_PROPERTY(QUrl coverArtUrl READ getCoverArtUrl NOTIFY coverArtUrlChanged)
+    Q_PROPERTY(QUrl trackLocationUrl READ getTrackLocationUrl NOTIFY trackLocationUrlChanged)
 
   public:
     explicit QmlPlayerProxy(BaseTrackPlayer* pTrackPlayer, QObject* parent = nullptr);
@@ -48,6 +49,7 @@ class QmlPlayerProxy : public QObject {
     QString getKeyText() const;
     QColor getColor() const;
     QUrl getCoverArtUrl() const;
+    QUrl getTrackLocationUrl() const;
 
     /// Needed for interacting with the raw track player object.
     BaseTrackPlayer* internalTrackPlayer() const {
@@ -97,6 +99,7 @@ class QmlPlayerProxy : public QObject {
     void keyTextChanged();
     void colorChanged();
     void coverArtUrlChanged();
+    void trackLocationUrlChanged();
 
     void loadTrackFromLocationRequested(const QString& trackLocation);
 

--- a/src/skin/qml/qmlplayerproxy.h
+++ b/src/skin/qml/qmlplayerproxy.h
@@ -81,6 +81,7 @@ class QmlPlayerProxy : public QObject {
     void trackLoaded();
     void trackUnloaded();
     void trackChanged();
+    void cloneFromGroup(const QString& group);
 
     void albumChanged();
     void titleChanged();


### PR DESCRIPTION
This makes it possible to clone decks via drag and drop. 