### PR TITLE
Reordered Musicbrainz tags as suggested in lp1924620 +  lp1899350

### DIFF
--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -41,9 +41,7 @@ QStringList trackReleaseColumnValues(
             << trackRelease.albumTitle
             << trackRelease.date
             << trackNumberAndTotal
-            << trackRelease.albumArtist
-
-            ;
+            << trackRelease.albumArtist;
     return columnValues;
 }
 

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -19,12 +19,12 @@ QStringList trackColumnValues(
     QStringList columnValues;
     columnValues.reserve(6);
     columnValues
-            << trackMetadata.getTrackInfo().getYear()
-            << trackMetadata.getAlbumInfo().getTitle()
-            << trackMetadata.getAlbumInfo().getArtist()
-            << trackNumberAndTotal
             << trackMetadata.getTrackInfo().getTitle()
-            << trackMetadata.getTrackInfo().getArtist();
+            << trackMetadata.getTrackInfo().getArtist()
+            << trackMetadata.getAlbumInfo().getTitle()
+            << trackMetadata.getTrackInfo().getYear()
+            << trackNumberAndTotal
+            << trackMetadata.getAlbumInfo().getArtist();
     return columnValues;
 }
 
@@ -36,12 +36,14 @@ QStringList trackReleaseColumnValues(
     QStringList columnValues;
     columnValues.reserve(6);
     columnValues
-            << trackRelease.date
-            << trackRelease.albumTitle
-            << trackRelease.albumArtist
-            << trackNumberAndTotal
             << trackRelease.title
-            << trackRelease.artist;
+            << trackRelease.artist
+            << trackRelease.albumTitle
+            << trackRelease.date
+            << trackNumberAndTotal
+            << trackRelease.albumArtist
+
+            ;
     return columnValues;
 }
 
@@ -86,12 +88,12 @@ void DlgTagFetcher::init() {
     connect(&m_tagFetcher, &TagFetcher::networkError, this, &DlgTagFetcher::slotNetworkResult);
 
     // Resize columns, this can't be set in the ui file
-    results->setColumnWidth(0, 50);  // Year column
-    results->setColumnWidth(1, 160); // Album column
-    results->setColumnWidth(2, 160); // Album artist column
-    results->setColumnWidth(3, 50);  // Track (numbers) column
-    results->setColumnWidth(4, 160); // Title column
-    results->setColumnWidth(5, 160); // Artist column
+    results->setColumnWidth(0, 160); // Title column
+    results->setColumnWidth(1, 160); // Artist column
+    results->setColumnWidth(2, 160); // Album column
+    results->setColumnWidth(3, 50);  // Year column
+    results->setColumnWidth(4, 50);  // Track (numbers) column
+    results->setColumnWidth(5, 160); // Album artist column
 }
 
 void DlgTagFetcher::slotNext() {

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -53,7 +53,7 @@ void addTrack(
         QTreeWidget* parent) {
     QTreeWidgetItem* item = new QTreeWidgetItem(parent, trackRow);
     item->setData(0, Qt::UserRole, resultIndex);
-    item->setData(0, Qt::TextAlignmentRole, Qt::AlignRight);
+    item->setData(0, Qt::TextAlignmentRole, Qt::AlignLeft);
 }
 
 } // anonymous namespace
@@ -308,6 +308,8 @@ void DlgTagFetcher::updateStack() {
             ++trackIndex;
         }
     }
+
+    results->header()->resizeSections(QHeaderView::ResizeToContents);
 
     // Find the item that was selected last time
     for (int i = 0; i < results->model()->rowCount(); ++i) {

--- a/src/library/dlgtagfetcher.ui
+++ b/src/library/dlgtagfetcher.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QStackedWidget" name="stack">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="results_page">
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -47,7 +47,12 @@
          </attribute>
          <column>
           <property name="text">
-           <string>Year</string>
+           <string>Title</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Artist</string>
           </property>
          </column>
          <column>
@@ -57,7 +62,7 @@
          </column>
          <column>
           <property name="text">
-           <string>Album Artist</string>
+           <string>Year</string>
           </property>
          </column>
          <column>
@@ -67,12 +72,7 @@
          </column>
          <column>
           <property name="text">
-           <string>Title</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>Artist</string>
+           <string>Album Artist</string>
           </property>
          </column>
         </widget>

--- a/src/library/dlgtagfetcher.ui
+++ b/src/library/dlgtagfetcher.ui
@@ -45,6 +45,9 @@
          <attribute name="headerMinimumSectionSize">
           <number>50</number>
          </attribute>
+         <attribute name="headerStretchLastSection">
+          <bool>false</bool>
+         </attribute>
          <column>
           <property name="text">
            <string>Title</string>


### PR DESCRIPTION
["Musikbrainz: Wrong column order in result window"](https://bugs.launchpad.net/mixxx/+bug/1924620)
["wierd column order in Musicbraiz result dialog"](https://bugs.launchpad.net/mixxx/+bug/1899350)

Before:

![musicbrainz-before](https://user-images.githubusercontent.com/83535479/122227161-f08bde00-ceb6-11eb-8df7-68094ab7d3e8.png)

After:

![musicbrainz-after](https://user-images.githubusercontent.com/83535479/122226884-aa367f00-ceb6-11eb-8fd7-7b16a4a54c72.png)


Todo:

- Find out where the colons in 'Artist' and 'Album' stem from and get rid of them
- Optional: Modify column sizes for a better look, or, if possible, resize them after the import from Musicbrainz to make them fit to the text

Open questions:

-  Do I need to also change the column order in  `dlgtagfetcher.ui` - item `<widget class="QTreeWidget" name="submit_tree">`?
- Is `dlgtagfetcher` used for something else than Musicbrainz so that my changes may break stuff elsewhere?
