### PR TITLE
Check if file is writable before making a copy for writing

### DIFF
--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -630,6 +630,14 @@ class SafelyWritableFile final {
         // See also: https://bugs.launchpad.net/mixxx/+bug/1815305
         DEBUG_ASSERT(m_origFileName.isNull());
         DEBUG_ASSERT(m_tempFileName.isNull());
+        if (!QFileInfo(origFileName).isWritable()) {
+            kLogger.warning()
+                    << "Failed to prepare file for writing:"
+                    << origFileName
+                    << "is not writable.";
+            // Abort constructor
+            return;
+        }
         if (useTemporaryFile) {
             QString tempFileName = origFileName + kSafelyWritableTempFileSuffix;
             QFile origFile(origFileName);


### PR DESCRIPTION
This fixes some follow up errors when exporting metadata to a read-only file leading to unclear warnings.

Now: 
```
warning [Main] MetadataSourceTagLib - Failed to prepare file before writing: "/home/daniel/Musik/Nathan Evans - Wellerman.mp3" is not writable.
warning [Main] MetadataSourceTagLib - Unable to export track metadata into file "/home/daniel/Musik/Nathan Evans - Wellerman.mp3" - Please check file permissions and storage space
warning [Main] Track - Failed to export track metadata: "/home/sperry/Musik/Nathan Evans -  Wellerman.mp3"
```

before:
```
Warning [Main] MetadataSourceTagLib - Failed to save tags of file "/home/daniel/Musik/Nathan Evans - Wellerman.mp3"
Warning [Main] Track - Failed to export track metadata: "/home/daniel/Musik/Nathan Evans - Wellerman.mp3"
```