### PR TITLE
CmdlineArgs: enforce parsing through App instance

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,11 +64,6 @@ int main(int argc, char * argv[]) {
     QCoreApplication::setApplicationName(VersionStore::applicationName());
     QCoreApplication::setApplicationVersion(VersionStore::version());
 
-    // Construct a list of strings based on the command line arguments
-    CmdlineArgs& args = CmdlineArgs::Instance();
-    if (!args.parse(argc, argv)) {
-        return kParseCmdlineArgsErrorExitCode;
-    }
 
     // If you change this here, you also need to change it in
     // ErrorDialogHandler::errorDialog(). TODO(XXX): Remove this hack.
@@ -87,6 +82,12 @@ int main(int argc, char * argv[]) {
 #endif
 
     MixxxApplication app(argc, argv);
+
+    // Construct a list of strings based on the command line arguments
+    CmdlineArgs& args = CmdlineArgs::Instance();
+    if (!args.process(app)) {
+        return kParseCmdlineArgsErrorExitCode;
+    }
 
 #ifdef __APPLE__
     QDir dir(QApplication::applicationDirPath());

--- a/src/test/mixxxtest.cpp
+++ b/src/test/mixxxtest.cpp
@@ -22,8 +22,11 @@ QString makeTestConfigFile(const QString& path) {
 QScopedPointer<MixxxApplication> MixxxTest::s_pApplication;
 
 MixxxTest::ApplicationScope::ApplicationScope(int& argc, char** argv) {
+    DEBUG_ASSERT(s_pApplication.isNull());
+    MixxxApplication* app = new MixxxApplication(argc, argv);
+
     CmdlineArgs args;
-    const bool argsParsed = args.parse(argc, argv);
+    const bool argsParsed = args.process(*app);
     Q_UNUSED(argsParsed);
     DEBUG_ASSERT(argsParsed);
 
@@ -42,8 +45,7 @@ MixxxTest::ApplicationScope::ApplicationScope(int& argc, char** argv) {
     // due to timing issues.
     disableConcurrentGuessingOfTrackCoverInfoDuringTests();
 
-    DEBUG_ASSERT(s_pApplication.isNull());
-    s_pApplication.reset(new MixxxApplication(argc, argv));
+    s_pApplication.reset(app);
 }
 
 MixxxTest::ApplicationScope::~ApplicationScope() {

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -63,13 +63,7 @@ bool parseLogLevel(
 }
 } // namespace
 
-bool CmdlineArgs::parse(int& argc, char** argv) {
-    QStringList arguments;
-    arguments.reserve(argc);
-    for (int a = 0; a < argc; ++a) {
-        arguments << QString::fromLocal8Bit(argv[a]);
-    }
-
+bool CmdlineArgs::process(const QCoreApplication& app) {
     QCommandLineParser parser;
     parser.setApplicationDescription(QCoreApplication::translate("main",
             "Mixxx is an open source DJ software. For more information, "
@@ -184,19 +178,13 @@ bool CmdlineArgs::parse(int& argc, char** argv) {
                     "you specify will be loaded into the next virtual deck."));
 
     // process all arguments
-    if (!parser.parse(arguments)) {
-        qWarning() << parser.errorText();
-    }
+    parser.process(app);
 
     if (parser.isSet(helpOption)
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
             || parser.isSet(QStringLiteral("help-all"))
 #endif
     ) {
-        // we need to call process here with an initialized QCoreApplication
-        // otherwise there is no way to print the help-all information
-        QCoreApplication coreApp(argc, argv);
-        parser.process(arguments);
         return false;
     }
     if (parser.isSet(versionOption)) {

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -21,7 +21,7 @@ class CmdlineArgs final {
         return cla;
     }
 
-    bool parse(int& argc, char** argv);
+    bool process(const QCoreApplication& app);
 
     const QList<QString>& getMusicFiles() const { return m_musicFiles; }
     bool getStartInFullscreen() const { return m_startInFullscreen; }


### PR DESCRIPTION
If arguments are parsed directly without filtering through
a QCoreApplication instance, Qt built-in arguments are not
recognized by the parser. Processing the arguments through an
application instance filters the Qt internal arguments out
before parsing.
See https://doc.qt.io/qt-5/qapplication.html#QApplication