### PR TITLE
DB: Fix 0/NULL issues when reading source_synchronized_ms

### DIFF
--- a/res/schema.xml
+++ b/res/schema.xml
@@ -566,4 +566,12 @@ reapplying those migrations.
       ALTER TABLE library ADD COLUMN source_synchronized_ms INTEGER DEFAULT NULL;
     </sql>
   </revision>
+  <revision version="38" min_compatible="3">
+    <description>
+      Fix 0/NULL issue after upgrade to schema version 37.
+    </description>
+    <sql>
+      UPDATE library SET source_synchronized_ms=NULL WHERE source_synchronized_ms=0;
+    </sql>
+  </revision>
 </schema>

--- a/src/database/mixxxdb.cpp
+++ b/src/database/mixxxdb.cpp
@@ -12,7 +12,7 @@
 const QString MixxxDb::kDefaultSchemaFile(":/schema.xml");
 
 //static
-const int MixxxDb::kRequiredSchemaVersion = 37;
+const int MixxxDb::kRequiredSchemaVersion = 38;
 
 namespace {
 

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1209,7 +1209,10 @@ bool setTrackHeaderParsed(const QSqlRecord& record, const int column, TrackPoint
 bool setTrackSourceSynchronizedAt(const QSqlRecord& record, const int column, TrackPointer pTrack) {
     QDateTime sourceSynchronizedAt;
     const QVariant value = record.value(column);
-    if (value.isValid() && value.canConvert<quint64>()) {
+    // Observation (Qt 5.15): QVariant::isValid() may return true even
+    // if the column value is NULL and then converts to 0 (zero). This
+    // is NOT desired and therefore we MUST USE QVariant::isNull() instead!
+    if (!value.isNull() && value.canConvert<quint64>()) {
         const quint64 msecsSinceEpoch = qvariant_cast<quint64>(value);
         sourceSynchronizedAt.setTimeSpec(Qt::UTC);
         sourceSynchronizedAt.setMSecsSinceEpoch(msecsSinceEpoch);

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1213,6 +1213,7 @@ bool setTrackSourceSynchronizedAt(const QSqlRecord& record, const int column, Tr
     // if the column value is NULL and then converts to 0 (zero). This
     // is NOT desired and therefore we MUST USE QVariant::isNull() instead!
     if (!value.isNull() && value.canConvert<quint64>()) {
+        DEBUG_ASSERT(value.isValid());
         const quint64 msecsSinceEpoch = qvariant_cast<quint64>(value);
         sourceSynchronizedAt.setTimeSpec(Qt::UTC);
         sourceSynchronizedAt.setMSecsSinceEpoch(msecsSinceEpoch);

--- a/src/library/export/engineprimeexportjob.cpp
+++ b/src/library/export/engineprimeexportjob.cpp
@@ -151,8 +151,12 @@ void exportMetadata(djinterop::database* pDatabase,
     snapshot.comment = pTrack->getComment().toStdString();
     snapshot.composer = pTrack->getComposer().toStdString();
     snapshot.key = toDjinteropKey(pTrack->getKey());
-    int64_t lastModifiedMillisSinceEpoch =
-            pTrack->getFileInfo().lastModified().toMSecsSinceEpoch();
+    int64_t lastModifiedMillisSinceEpoch = 0;
+    const QDateTime fileLastModified = pTrack->getFileInfo().lastModified();
+    if (fileLastModified.isValid()) {
+        // Only defined if valid
+        lastModifiedMillisSinceEpoch = fileLastModified.toMSecsSinceEpoch();
+    }
     std::chrono::system_clock::time_point lastModifiedAt{
             std::chrono::milliseconds{lastModifiedMillisSinceEpoch}};
     snapshot.last_modified_at = lastModifiedAt;

--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -76,7 +76,14 @@ class AiffFile : public TagLib::RIFF::AIFF::File {
 };
 
 inline QDateTime getSourceSynchronizedAt(const QFileInfo& fileInfo) {
-    return fileInfo.lastModified().toUTC();
+    const QDateTime lastModifiedUtc = fileInfo.lastModified().toUTC();
+    // Ignore bogus values like 1970-01-01T00:00:00.000 UTC
+    // that are obviously incorrect and don't provide any
+    // information.
+    if (lastModifiedUtc.toMSecsSinceEpoch() == 0) {
+        return QDateTime{};
+    }
+    return lastModifiedUtc;
 }
 
 } // anonymous namespace

--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -80,7 +80,9 @@ inline QDateTime getSourceSynchronizedAt(const QFileInfo& fileInfo) {
     // Ignore bogus values like 1970-01-01T00:00:00.000 UTC
     // that are obviously incorrect and don't provide any
     // information.
-    if (lastModifiedUtc.toMSecsSinceEpoch() == 0) {
+    if (lastModifiedUtc.isValid() &&
+            // Only defined if valid
+            lastModifiedUtc.toMSecsSinceEpoch() == 0) {
         return QDateTime{};
     }
     return lastModifiedUtc;

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -118,6 +118,14 @@ bool TrackRecord::updateSourceSynchronizedAt(
     if (getSourceSynchronizedAt() == sourceSynchronizedAt) {
         return false; // unchanged
     }
+    if (getSourceSynchronizedAt().isValid() &&
+            getSourceSynchronizedAt() >= sourceSynchronizedAt) {
+        kLogger.warning()
+                << "Backdating source synchronization time from"
+                << getSourceSynchronizedAt()
+                << "to"
+                << sourceSynchronizedAt;
+    }
     setSourceSynchronizedAt(sourceSynchronizedAt);
     m_headerParsed = sourceSynchronizedAt.isValid();
     DEBUG_ASSERT(isSourceSynchronized());

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -119,7 +119,7 @@ bool TrackRecord::updateSourceSynchronizedAt(
         return false; // unchanged
     }
     if (getSourceSynchronizedAt().isValid() &&
-            getSourceSynchronizedAt() >= sourceSynchronizedAt) {
+            getSourceSynchronizedAt() > sourceSynchronizedAt) {
         kLogger.warning()
                 << "Backdating source synchronization time from"
                 << getSourceSynchronizedAt()


### PR DESCRIPTION
Unfortunately I noticed a very strange behavior of Qt when reading a *nullable* integer database column that contains NULL:

```
// Observation (Qt 5.15): QVariant::isValid() may return true even
// if the column value is NULL and then converts to 0 (zero). This
// is NOT desired and therefore we MUST USE QVariant::isNull() instead!
```

As a consequence the column `library.source_synchronized_ms` now contains 0 (= zero) instead of NULL for some tracks after they have been loaded and saved at least once after the migration.

Do we need a formal DB schema update to fix this issue? This would probably be the safe solution.

The first commit is just a minor logging improvement to detect inconsistencies between the library and external files.