### PR TITLE
Qickfix: Move Sandbox::checkSandboxed()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,13 +76,6 @@ int main(int argc, char * argv[]) {
     // the main thread. Bug #1748636.
     ErrorDialogHandler::instance();
 
-#ifdef __APPLE__
-    Sandbox::checkSandboxed();
-    if (!args.getSettingsPathSet()) {
-        args.setSettingsPath(Sandbox::migrateOldSettings());
-    }
-#endif
-
     MixxxApplication app(argc, argv);
 
 #ifdef __APPLE__

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,6 +76,10 @@ int main(int argc, char * argv[]) {
     // the main thread. Bug #1748636.
     ErrorDialogHandler::instance();
 
+#ifdef __APPLE__
+    Sandbox::checkSandboxed();
+#endif
+
     MixxxApplication app(argc, argv);
 
 #ifdef __APPLE__

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -175,6 +175,8 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
     // TODO: This place it is to late to provide the same settings path to all components
     // and to early to log errors and give user advises in their system language
     // Solution: Init Mixxx with default, copy preferences and restart.
+    // Calling this from main.cpp before QApplication is initialized will crash mixxx
+    // due to possible QMesssagebox calls inside migrateOldSettings()
     if (!args.getSettingsPathSet()) {
         CmdlineArgs::Instance().setSettingsPath(Sandbox::migrateOldSettings());
     }

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -171,6 +171,13 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
     m_runtime_timer.start();
     mixxx::Time::start();
 
+#ifdef __APPLE__
+    Sandbox::checkSandboxed();
+    if (!args.getSettingsPathSet()) {
+        CmdlineArgs::Instance().setSettingsPath(Sandbox::migrateOldSettings());
+    }
+#endif
+
     QString settingsPath = args.getSettingsPath();
 
     mixxx::LogFlags logFlags = mixxx::LogFlag::LogToFile;

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -172,7 +172,6 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
     mixxx::Time::start();
 
 #ifdef __APPLE__
-    Sandbox::checkSandboxed();
     // TODO: This place it is to late to provide the same settings path to all components
     // and to early to log errors and give user advises in their system language
     // Solution: Init Mixxx with default, copy preferences and restart.

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -172,11 +172,12 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
     mixxx::Time::start();
 
 #ifdef __APPLE__
-    // TODO: This place it is to late to provide the same settings path to all components
-    // and to early to log errors and give user advises in their system language
-    // Solution: Init Mixxx with default, copy preferences and restart.
-    // Calling this from main.cpp before QApplication is initialized will crash mixxx
-    // due to possible QMesssagebox calls inside migrateOldSettings()
+    // TODO: At this point it is too late to provide the same settings path to all components
+    // and too early to log errors and give users advises in their system language.
+    // Calling this from main.cpp before the QApplication is initialized may cause a crash
+    // due to potential QMessageBox invocations within migrateOldSettings().
+    // Solution: Start Mixxx with default settings, migrate the preferences, and then restart
+    // immediately.
     if (!args.getSettingsPathSet()) {
         CmdlineArgs::Instance().setSettingsPath(Sandbox::migrateOldSettings());
     }

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -173,6 +173,9 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
 
 #ifdef __APPLE__
     Sandbox::checkSandboxed();
+    // TODO: This place it is to late to provide the same settings path to all components
+    // and to early to log errors and give user advises in their system language
+    // Solution: Init Mixxx with default, copy preferences and restart.
     if (!args.getSettingsPathSet()) {
         CmdlineArgs::Instance().setSettingsPath(Sandbox::migrateOldSettings());
     }


### PR DESCRIPTION
Move Sandbox::checkSandboxed() back to MixxxMainWindow fixing a crash introduced by #3956

This is a band aid. That reintroduces the issue of settings path access before checking the sandbox will be fixed in a follow up PR