### PR TITLE
Behringer extension scripts: fix backwards beatloop

### DIFF
--- a/res/controllers/Behringer-Extension-scripts.js
+++ b/res/controllers/Behringer-Extension-scripts.js
@@ -478,8 +478,8 @@
                 var loopSize = engine.getValue(group, "beatloop_size");
                 var beatjumpSize = engine.getValue(group, "beatjump_size");
                 engine.setValue(group, "beatjump_size", loopSize);
-                script.triggerControl(group, "beatloop_activate");
                 script.triggerControl(group, "beatjump_backward");
+                script.triggerControl(group, "beatloop_activate");
                 engine.setValue(group, "beatjump_size", beatjumpSize);
             } else {
                 script.triggerControl(group, "reloop_toggle");


### PR DESCRIPTION
The Behringer extension scripts contain a button that starts a beatloop _ending_ at the current play position. The implementation has a bug that is fixed by this PR.

**Bug description**
Suppose that the current play position is t, the beatloop size is 4 beats and the backloop button is pressed.
Desired behaviour: play position is t-4, the loop starts at t-4 and ends at t.
Actual behaviour: play position is t-4, the loop starts at t and ends at t+4.
