### PR TITLE
Sandbox Dialog Fixes

### DIFF
--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -188,8 +188,7 @@ Library::Library(
     // sandboxing then we will need them to give us permission.
     qDebug() << "Checking for access to user's library directories:";
     foreach (QString directoryPath, getDirs()) {
-        QFileInfo directory(directoryPath);
-        bool hasAccess = Sandbox::askForAccess(directory.canonicalFilePath());
+        bool hasAccess = Sandbox::askForAccess(directoryPath);
         qDebug() << "Checking for access to" << directoryPath << ":" << hasAccess;
     }
 

--- a/src/util/sandbox.cpp
+++ b/src/util/sandbox.cpp
@@ -63,25 +63,22 @@ void Sandbox::shutdown() {
 }
 
 // static
-bool Sandbox::askForAccess(const QString& canonicalPath) {
+bool Sandbox::askForAccess(const QString& path) {
     if (sDebug) {
-        qDebug() << "Sandbox::askForAccess" << canonicalPath;
+        qDebug() << "Sandbox::askForAccess" << path;
     }
     if (!enabled()) {
         // Pretend we have access.
         return true;
     }
 
-    QFileInfo info(canonicalPath);
+    QFileInfo info(path);
     // We always want read/write access because we wouldn't want to have to
     // re-ask for access in the future if we need to write.
     if (canAccessFile(info)) {
         return true;
     }
 
-    if (sDebug) {
-        qDebug() << "Sandbox: Requesting user access to" << canonicalPath;
-    }
     QString title = QObject::tr("Mixxx Needs Access to: %1")
             .arg(info.fileName());
 
@@ -98,20 +95,20 @@ bool Sandbox::askForAccess(const QString& canonicalPath) {
                     "the file picker. "
                     "We're sorry for this inconvenience.\n\n"
                     "To abort this action, press Cancel on the file dialog.")
-                    .arg(canonicalPath, info.fileName()));
+                    .arg(path, info.fileName()));
 
     QString result;
     QFileInfo resultInfo;
     while (true) {
         if (info.isFile()) {
-            result = QFileDialog::getOpenFileName(nullptr, title, canonicalPath);
+            result = QFileDialog::getOpenFileName(nullptr, title, path);
         } else if (info.isDir()) {
-            result = QFileDialog::getExistingDirectory(nullptr, title, canonicalPath);
+            result = QFileDialog::getExistingDirectory(nullptr, title, path);
         }
 
         if (result.isNull()) {
             if (sDebug) {
-                qDebug() << "Sandbox: User rejected access to" << canonicalPath;
+                qDebug() << "Sandbox: User rejected access to" << path;
             }
             return false;
         }

--- a/src/util/sandbox.cpp
+++ b/src/util/sandbox.cpp
@@ -87,7 +87,7 @@ bool Sandbox::askForAccess(const QString& path) {
     QString title = QObject::tr("Mixxx Needs Access to: %1")
             .arg(info.fileName());
 
-    QMessageBox::question(nullptr,
+    QMessageBox::information(nullptr,
             title,
             QObject::tr(
                     "Due to Mac Sandboxing, we need your permission to access "
@@ -129,7 +129,7 @@ bool Sandbox::askForAccess(const QString& path) {
         if (sDebug) {
             qDebug() << "User selected the wrong file.";
         }
-        QMessageBox::question(
+        QMessageBox::information(
                 nullptr, title, QObject::tr("You selected the wrong file. To grant Mixxx access, "
                                             "please select the file '%1'. If you do not want to "
                                             "continue, press Cancel.")

--- a/src/util/sandbox.cpp
+++ b/src/util/sandbox.cpp
@@ -74,7 +74,7 @@ bool Sandbox::askForAccess(const QString& path) {
 
     QFileInfo info(path);
     if (info.exists()) {
-        // we cannot grand access to a not existing file
+        // We cannot grant access to a not existing file
         return false;
     }
 

--- a/src/util/sandbox.cpp
+++ b/src/util/sandbox.cpp
@@ -73,6 +73,11 @@ bool Sandbox::askForAccess(const QString& path) {
     }
 
     QFileInfo info(path);
+    if (info.exists()) {
+        // we cannot grand access to a not existing file
+        return false;
+    }
+
     // We always want read/write access because we wouldn't want to have to
     // re-ask for access in the future if we need to write.
     if (canAccessFile(info)) {

--- a/src/util/sandbox.h
+++ b/src/util/sandbox.h
@@ -42,7 +42,7 @@ class Sandbox {
     }
 
     // Prompt the user to give us access to the path with an open-file dialog.
-    static bool askForAccess(const QString& canonicalPath);
+    static bool askForAccess(const QString& path);
 
     static bool canAccessFile(const QFileInfo& file) {
         SecurityTokenPointer pToken = openSecurityToken(file, true);


### PR DESCRIPTION
If the library folder no longer exists, the canonical path cannot be calculated and is empty. 
This leads to an empty Sandbox dialog which is confusing. 

This also fixes the wrong buttons. 
The suggested String changes need to be done in 2.4 to not risk untranslated strings. 

https://bugs.launchpad.net/mixxx/+bug/1921541


