### PR TITLE
lp1933001: Preserve phase of decoded FLAC samples

### DIFF
--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -399,10 +399,11 @@ namespace {
 // https://bugs.launchpad.net/mixxx/+bug/1769717
 // https://hydrogenaud.io/index.php/topic,61792.msg559045.html#msg559045
 
-// We will shift decoded samples left by (32 - m_bitsPerSample) to
-// get rid of the garbage in the most significant bits before scaling
-// to the range [-CSAMPLE_PEAK, CSAMPLE_PEAK - epsilon] with
-// epsilon = 1 / 2 ^ bitsPerSample.
+// We multiply the decoded samples by 2 ^ (32 - m_bitsPerSample) to
+// get rid of the garbage in the most significant bits which get shifted
+// out to the left. The resulting, upscaled integer value is then scaled
+// down to the floating point range [-CSAMPLE_PEAK, CSAMPLE_PEAK - epsilon]
+// with epsilon = 1 / 2 ^ bitsPerSample.
 //
 // We have to negate the nominator to compensate for the negative denominator!
 // Otherwise the phase would be inverted: https://bugs.launchpad.net/mixxx/+bug/1933001

--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -412,8 +412,8 @@ constexpr CSAMPLE kSampleUnshiftFactor = -CSAMPLE_PEAK /
 inline CSAMPLE convertDecodedSample(FLAC__int32 decodedSample, int bitsPerSample) {
     static_assert(std::numeric_limits<FLAC__int32>::is_signed);
     static_assert(kSampleUnshiftFactor > CSAMPLE_ZERO, "preserve phase of decoded signal");
-    const auto leftShift = (std::numeric_limits<FLAC__int32>::digits + 1) - bitsPerSample;
-    const auto shiftedSample = decodedSample << leftShift;
+    const auto shiftLeft = (std::numeric_limits<FLAC__int32>::digits + 1) - bitsPerSample;
+    const auto shiftedSample = decodedSample << shiftLeft;
     return shiftedSample * kSampleUnshiftFactor;
 }
 

--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -416,7 +416,7 @@ inline CSAMPLE convertDecodedSample(FLAC__int32 decodedSample, int bitsPerSample
     // Multiples by 2 ^ (32 - bitsPerSample)
     const auto upscaleShift = (std::numeric_limits<FLAC__int32>::digits + 1) - bitsPerSample;
     const auto upscaledSample = decodedSample << upscaleShift;
-    // shiftedSample is now a 32-bit signed integer that needs to scaled
+    // upscaledSample is now a 32-bit signed integer that needs to scaled
     // to the range [-CSAMPLE_PEAK, CSAMPLE_PEAK - epsilon]
     return upscaledSample * kSampleScaleFactor;
 }

--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -403,12 +403,18 @@ namespace {
 // get rid of the garbage in the most significant bits before scaling
 // to the range [-CSAMPLE_PEAK, CSAMPLE_PEAK - epsilon] with
 // epsilon = 1 / 2 ^ bitsPerSample.
-constexpr CSAMPLE kSampleScaleFactor = CSAMPLE_PEAK /
+//
+// We have to negate the nominator to compensate for the negative denominator!
+// Otherwise the phase would be inverted: https://bugs.launchpad.net/mixxx/+bug/1933001
+constexpr CSAMPLE kSampleUnshiftFactor = -CSAMPLE_PEAK /
         (static_cast<FLAC__int32>(1) << std::numeric_limits<FLAC__int32>::digits);
 
 inline CSAMPLE convertDecodedSample(FLAC__int32 decodedSample, int bitsPerSample) {
-    DEBUG_ASSERT(std::numeric_limits<FLAC__int32>::is_signed);
-    return (decodedSample << ((std::numeric_limits<FLAC__int32>::digits + 1) - bitsPerSample)) * kSampleScaleFactor;
+    static_assert(std::numeric_limits<FLAC__int32>::is_signed);
+    static_assert(kSampleUnshiftFactor > CSAMPLE_ZERO, "preserve phase of decoded signal");
+    const auto leftShift = (std::numeric_limits<FLAC__int32>::digits + 1) - bitsPerSample;
+    const auto shiftedSample = decodedSample << leftShift;
+    return shiftedSample * kSampleUnshiftFactor;
 }
 
 } // anonymous namespace


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1933001

Caused by a wrong sign of the scale factor. The denominator is negative and not positive as assumed.

- Negated nominator of the constant factor
- Improved readability of the code