### PR TITLE
Update Windows build environment 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,9 @@ endif()
 # Set a default build type if none was specified
 # See https://blog.kitware.com/cmake-and-the-default-build-type/ for details.
 set(default_build_type "RelWithDebInfo")
-if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+if(EXISTS "${CMAKE_SOURCE_DIR}/.git" AND NOT WIN32)
+  # On Windows, Debug builds are linked to unoptimized libs
+  # generating unusable slow Mixxx builds.
   set(default_build_type "Debug")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,9 +41,7 @@ endif()
 # Set a default build type if none was specified
 # See https://blog.kitware.com/cmake-and-the-default-build-type/ for details.
 set(default_build_type "RelWithDebInfo")
-if(EXISTS "${CMAKE_SOURCE_DIR}/.git" AND NOT WIN32)
-  # Debug builds are broken on Windows due to CMake/vcpkg linking issues.
-  # As a workaround, we just default to RelWithDebInfo on Windows.
+if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
   set(default_build_type "Debug")
 endif()
 

--- a/packaging/windows/build_environment
+++ b/packaging/windows/build_environment
@@ -1,1 +1,1 @@
-mixxx-dependencies-2.3-x64-windows-3d70970e752542db9901e4aa2656f215699dc102
+mixxx-deps-2.3-x64-windows-049b5ad


### PR DESCRIPTION
and remove workaround for broken debug builds