### PR TITLE
Denon MC7000 improvements

### DIFF
--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -563,11 +563,11 @@ MC7000.PadButtons = function(channel, control, value, status, group) {
                 if (engine.getValue("[Sampler" + i + "]", "track_loaded") === 0) {
                     engine.setValue("[Sampler" + i + "]", "LoadSelectedTrack", 1);
                 } else if (engine.getValue("[Sampler" + i + "]", "track_loaded") === 1) {
-                    // STOP PLAYING SAMPLERS ...
+                    // stop playing all other samplers ...
                     for (j = 1; j <=8; j++) {
                         engine.setValue("[Sampler" + j + "]", "cue_gotoandstop", 1);
                     }
-                    // ... BEFORE THE ACTUAL SAMPLER TO PLAY GETS STARTED
+                    // ... before the actual sampler to play gets started
                     engine.setValue("[Sampler" + i + "]", "cue_gotoandplay", 1);
                 }
             } else if (control === 0x1C + i - 1 && value >= 0x01) {
@@ -680,7 +680,7 @@ MC7000.wheelTurn = function(channel, control, value, status, group) {
     } else {
         if (MC7000.shift[deckOffset]) {
             // While Shift Button pressed -> Search through track
-            var jogSearch = 100 * adjustedSpeed;
+            var jogSearch = 100 * adjustedSpeed; // moves 100 times faster than normal jog
             engine.setValue(group, "jog", jogSearch);
         } else {
             // While Shift Button released -> Pitch Bend

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -37,7 +37,7 @@ var MC7000 = {};
 // 1) Beat LED in Slicer mode (counts every 8 beats AFTER the CUE point)
 //    only works for CONSTANT TEMPO tracks
 //    needs beat grid and CUE point set
-MC7000.experimental = true;
+MC7000.experimental = false;
 
 // Wanna have Needle Search active while playing a track ?
 // In any case Needle Search is available holding "SHIFT" down.
@@ -98,10 +98,6 @@ MC7000.needleSearchTouched = [true, true, true, true];
 
 // initial value for VINYL mode per Deck (see above for user input)
 MC7000.isVinylMode = [MC7000.VinylModeOn, MC7000.VinylModeOn, MC7000.VinylModeOn, MC7000.VinylModeOn];
-
-// used to keep track of which the rateRange of each slider.
-// value used as an index to MC7000.rateRanges
-MC7000.currentRateRangeIndex = [0, 0, 0, 0];
 
 // initialize the "factor" function for Spinback
 MC7000.factor = [];
@@ -733,13 +729,17 @@ MC7000.nextRateRange = function(midichan, control, value, status, group) {
     if (value === 0) {
         return; // don't respond to note off messages
     }
-    var deckOffset = script.deckFromGroup(group) - 1;
-    // increment currentRateRangeIndex and check for overflow
-    if (++MC7000.currentRateRangeIndex[deckOffset] ===
-      MC7000.rateRanges.length) {
-        MC7000.currentRateRangeIndex[deckOffset] = 0;
+    var currRateRange = engine.getValue(group, "rateRange");
+    engine.setValue(group, "rateRange", MC7000.getNextRateRange(currRateRange));
+};
+
+MC7000.getNextRateRange = function(currRateRange) {
+    for (var i = 0; i < MC7000.rateRanges.length; i++) {
+        if (MC7000.rateRanges[i] > currRateRange) {
+            return MC7000.rateRanges[i];
+        }
     }
-    engine.setValue(group, "rateRange", MC7000.rateRanges[MC7000.currentRateRangeIndex[deckOffset]]);
+    return MC7000.rateRanges[0];
 };
 
 // Previous Rate range toggle
@@ -747,12 +747,17 @@ MC7000.prevRateRange = function(midichan, control, value, status, group) {
     if (value === 0) {
         return; // don't respond to note off messages
     }
-    var deckOffset = script.deckFromGroup(group) - 1;
-    // decrement currentRateRangeIndex and check for underflow
-    if (--MC7000.currentRateRangeIndex[deckOffset] < 0) {
-        MC7000.currentRateRangeIndex[deckOffset] = MC7000.rateRanges.length - 1;
+    var currRateRange = engine.getValue(group, "rateRange");
+    engine.setValue(group, "rateRange", MC7000.getPrevRateRange(currRateRange));
+};
+
+MC7000.getPrevRateRange = function(currRateRange) {
+    for (var i = MC7000.rateRanges.length; i >= 0; i--) {
+        if (MC7000.rateRanges[i] < currRateRange) {
+            return MC7000.rateRanges[i];
+        }
     }
-    engine.setValue(group, "rateRange", MC7000.rateRanges[MC7000.currentRateRangeIndex[deckOffset]]);
+    return MC7000.rateRanges[MC7000.rateRanges.length - 1];
 };
 
 // Key & Waveform zoom Select

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -814,11 +814,20 @@ MC7000.stopTime = function(channel, control, value, status, group) {
 MC7000.reverse = function(channel, control, value, status, group) {
     var deckNumber = script.deckFromGroup(group);
     if (value > 0) {
-        // while the button is pressed spin back
-        engine.brake(deckNumber, true, MC7000.factor[deckNumber], - 15); // start at a rate of -15 and decrease by "factor"
+        if (engine.getValue(group, "slip_enabled"))  {
+        // backspin while button is pressed at a rate of -15 and decrease by "factor"
+            engine.brake(deckNumber, value > 0, MC7000.factor[deckNumber], - 15);
+        } else {
+            engine.brake(deckNumber, true, MC7000.factor[deckNumber], - 15);
+        }
     } else {
-        // when releasing the button the track starts softly again
-        engine.softStart(deckNumber, true, MC7000.factor[deckNumber]);
+        if (engine.getValue(group, "slip_enabled")) {
+            engine.brake(deckNumber, false); // disable brake effect
+            engine.setValue(group, "play", 1);
+            engine.setValue(group, "slip_enabled", 0);
+        } else {
+            engine.softStart(deckNumber, true, MC7000.factor[deckNumber]);
+        }
     }
 };
 

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -37,7 +37,7 @@ var MC7000 = {};
 // 1) Beat LED in Slicer mode (counts every 8 beats AFTER the CUE point)
 //    only works for CONSTANT TEMPO tracks
 //    needs beat grid and CUE point set
-MC7000.experimental = true;
+MC7000.experimental = false;
 
 // Wanna have Needle Search active while playing a track ?
 // In any case Needle Search is available holding "SHIFT" down.
@@ -86,7 +86,7 @@ MC7000.scratchParams = {
 // set to 0.5 with audio buffer set to 50ms
 // set to 1 with audio buffer set to 25ms
 // set to 3 with audio buffer set to 5ms
-MC7000.jogSensitivity = 2;
+MC7000.jogSensitivity = 1;
 
 /*/////////////////////////////////
 //      USER VARIABLES END       //

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -504,7 +504,7 @@ MC7000.PadButtons = function(channel, control, value, status, group) {
                 engine.setValue(group, "hotcue_" + i + "_activate", false);
                 if (engine.getValue(group, "slip_enabled")) {
                     engine.setValue(group, "slip_enabled", false);
-                    engine.beginTimer(250, function() {
+                    engine.beginTimer(20, function() {
                         engine.setValue(group, "slip_enabled", true);
                     }, true);
                 }
@@ -666,7 +666,7 @@ MC7000.wheelTouch = function(channel, control, value, status, group) {
             engine.scratchDisable(deckNumber);
             if (engine.getValue(group, "slip_enabled")) {
                 engine.setValue(group, "slip_enabled", false);
-                engine.beginTimer(250, function() {
+                engine.beginTimer(20, function() {
                     engine.setValue(group, "slip_enabled", true);
                 }, true);
             }
@@ -841,15 +841,18 @@ MC7000.reverse = function(channel, control, value, status, group) {
     if (value > 0) {
         if (engine.getValue(group, "slip_enabled"))  {
         // backspin while button is pressed at a rate of -15 and decrease by "factor"
-            engine.brake(deckNumber, value > 0, MC7000.factor[deckNumber], - 15);
+            engine.brake(deckNumber, value > 0, MC7000.factor[deckNumber], - 10);
         } else {
-            engine.brake(deckNumber, true, MC7000.factor[deckNumber], - 15);
+            engine.brake(deckNumber, true, MC7000.factor[deckNumber], - 10);
         }
     } else {
         if (engine.getValue(group, "slip_enabled")) {
             engine.brake(deckNumber, false); // disable brake effect
             engine.setValue(group, "play", 1);
-            engine.setValue(group, "slip_enabled", 0);
+            engine.setValue(group, "slip_enabled", false);
+            engine.beginTimer(20, function() {
+                engine.setValue(group, "slip_enabled", true);
+            }, true);
         } else {
             engine.softStart(deckNumber, true, MC7000.factor[deckNumber]);
         }
@@ -865,7 +868,7 @@ MC7000.censor = function(channel, control, value, status, group) {
         } else {
             engine.setValue(group, "reverseroll", 0);
         }
-        engine.beginTimer(250, function() {
+        engine.beginTimer(20, function() {
             engine.setValue(group, "slip_enabled", true);
         }, true);
     } else {

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -69,8 +69,8 @@ MC7000.VinylModeOn = true; // default: true
 // Scratch algorithm parameters
 MC7000.scratchParams = {
     recordSpeed: 33 + 1/3, // default: 33 + 1/3
-    alpha: (1.0/10),   // default: (1.0/10)
-    beta: (1.0/10)/32  // default: (1.0/10)/32
+    alpha: (1.0/100),   // default: (1.0/10)
+    beta: (1.0/100)/32  // default: (1.0/10)/32
 };
 
 // Sensitivity factor of the jog wheel (also depends on audio latency)

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -654,19 +654,21 @@ MC7000.wheelTouch = function(channel, control, value, status, group) {
     var deckNumber = script.deckFromGroup(group);
     var deckOffset = deckNumber - 1;
     var maxLibrary = engine.getValue("[Master]", "maximize_library");
-    if (MC7000.isVinylMode[deckOffset]) {
-        if (value === 0x7F && maxLibrary === 0) {
+    if (MC7000.isVinylMode[deckOffset] && maxLibrary === 0) {
+        if (value === 0x7F) {
             engine.scratchEnable(deckNumber, MC7000.jogWheelTicksPerRevolution,
                 MC7000.scratchParams.recordSpeed,
                 MC7000.scratchParams.alpha,
                 MC7000.scratchParams.beta);
         } else {
-            engine.scratchDisable(deckNumber);
             if (engine.getValue(group, "slip_enabled")) {
+                engine.scratchDisable(deckNumber, false); // stops scratching immediately
                 engine.setValue(group, "slip_enabled", false);
                 engine.beginTimer(50, function() {
                     engine.setValue(group, "slip_enabled", true);
                 }, true);
+            } else {
+                engine.scratchDisable(deckNumber); // continues scratching e.g. for backspin
             }
         }
     }
@@ -684,9 +686,9 @@ MC7000.wheelTurn = function(channel, control, value, status, group) {
     var deckOffset = deckNumber - 1;
     var maxLibrary = engine.getValue("[Master]", "maximize_library");
     if (maxLibrary === 1 && numTicks > 0) {
-        engine.setValue("[Library]", "MoveUp", 1);
-    } else if (maxLibrary === 1 && numTicks < 0) {
         engine.setValue("[Library]", "MoveDown", 1);
+    } else if (maxLibrary === 1 && numTicks < 0) {
+        engine.setValue("[Library]", "MoveUp", 1);
     } else if (engine.isScratching(deckNumber)) {
     // Scratch!
         engine.scratchTick(deckNumber, numTicks * MC7000.jogSensitivity);

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -653,8 +653,8 @@ MC7000.loadButton = function(channel, control, value, status, group) {
 MC7000.wheelTouch = function(channel, control, value, status, group) {
     var deckNumber = script.deckFromGroup(group);
     var deckOffset = deckNumber - 1;
-    var maxLibrary = engine.getValue("[Master]", "maximize_library");
-    if (MC7000.isVinylMode[deckOffset] && maxLibrary === 0) {
+    var libraryMaximized = engine.getValue("[Master]", "maximize_library") > 0;
+    if (MC7000.isVinylMode[deckOffset] && !libraryMaximized) {
         if (value === 0x7F) {
             engine.scratchEnable(deckNumber, MC7000.jogWheelTicksPerRevolution,
                 MC7000.scratchParams.recordSpeed,
@@ -684,10 +684,10 @@ MC7000.wheelTurn = function(channel, control, value, status, group) {
     var adjustedSpeed = numTicks * MC7000.jogSensitivity / 10;
     var deckNumber = script.deckFromGroup(group);
     var deckOffset = deckNumber - 1;
-    var maxLibrary = engine.getValue("[Master]", "maximize_library");
-    if (maxLibrary === 1 && numTicks > 0) {
+    var libraryMaximized = engine.getValue("[Master]", "maximize_library");
+    if (libraryMaximized === 1 && numTicks > 0) {
         engine.setValue("[Library]", "MoveDown", 1);
-    } else if (maxLibrary === 1 && numTicks < 0) {
+    } else if (libraryMaximized === 1 && numTicks < 0) {
         engine.setValue("[Library]", "MoveUp", 1);
     } else if (engine.isScratching(deckNumber)) {
     // Scratch!

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -504,7 +504,7 @@ MC7000.PadButtons = function(channel, control, value, status, group) {
                 engine.setValue(group, "hotcue_" + i + "_activate", false);
                 if (engine.getValue(group, "slip_enabled")) {
                     engine.setValue(group, "slip_enabled", false);
-                    engine.beginTimer(20, function() {
+                    engine.beginTimer(50, function() {
                         engine.setValue(group, "slip_enabled", true);
                     }, true);
                 }
@@ -574,11 +574,9 @@ MC7000.PadButtons = function(channel, control, value, status, group) {
                         for (j = 1; j <=8; j++) {
                             engine.setValue("[Sampler" + j + "]", "cue_gotoandstop", 1);
                         }
-                        // ... before the actual sampler to play gets started
-                        engine.setValue("[Sampler" + i + "]", "cue_gotoandplay", 1);
-                    } else {
-                        engine.setValue("[Sampler" + i + "]", "cue_gotoandplay", 1);
                     }
+                    // ... before the actual sampler to play gets started
+                    engine.setValue("[Sampler" + i + "]", "cue_gotoandplay", 1);
                 }
             } else if (control === 0x1C + i - 1 && value >= 0x01) {
                 if (engine.getValue("[Sampler" + i + "]", "play") === 1) {
@@ -666,7 +664,7 @@ MC7000.wheelTouch = function(channel, control, value, status, group) {
             engine.scratchDisable(deckNumber);
             if (engine.getValue(group, "slip_enabled")) {
                 engine.setValue(group, "slip_enabled", false);
-                engine.beginTimer(20, function() {
+                engine.beginTimer(50, function() {
                     engine.setValue(group, "slip_enabled", true);
                 }, true);
             }
@@ -839,18 +837,15 @@ MC7000.stopTime = function(channel, control, value, status, group) {
 MC7000.reverse = function(channel, control, value, status, group) {
     var deckNumber = script.deckFromGroup(group);
     if (value > 0) {
-        if (engine.getValue(group, "slip_enabled"))  {
-        // backspin while button is pressed at a rate of -15 and decrease by "factor"
-            engine.brake(deckNumber, value > 0, MC7000.factor[deckNumber], - 10);
-        } else {
-            engine.brake(deckNumber, true, MC7000.factor[deckNumber], - 10);
-        }
+        // while the button is pressed spin back
+        // start at a rate of -10 and decrease by "MC7000.factor"
+        engine.brake(deckNumber, true, MC7000.factor[deckNumber], -10);
     } else {
         if (engine.getValue(group, "slip_enabled")) {
             engine.brake(deckNumber, false); // disable brake effect
             engine.setValue(group, "play", 1);
             engine.setValue(group, "slip_enabled", false);
-            engine.beginTimer(20, function() {
+            engine.beginTimer(50, function() {
                 engine.setValue(group, "slip_enabled", true);
             }, true);
         } else {
@@ -868,7 +863,7 @@ MC7000.censor = function(channel, control, value, status, group) {
         } else {
             engine.setValue(group, "reverseroll", 0);
         }
-        engine.beginTimer(20, function() {
+        engine.beginTimer(50, function() {
             engine.setValue(group, "slip_enabled", true);
         }, true);
     } else {
@@ -972,14 +967,14 @@ MC7000.TrackPositionLEDs = function(value, group) {
             }
             // now chose which PAD LED to turn on (+8 means shifted PAD LEDs)
             if (beatCountLED === 0) {
-                midi.sendShortMsg(0x94 + deckOffset, 0x14, MC7000.padColor.hotcueon);
-                midi.sendShortMsg(0x94 + deckOffset, 0x14 + 8, MC7000.padColor.hotcueon);
+                midi.sendShortMsg(0x94 + deckOffset, 0x14, MC7000.padColor.slicerJumpFwd);
+                midi.sendShortMsg(0x94 + deckOffset, 0x14 + 8, MC7000.padColor.slicerJumpFwd);
             } else if (beatCountLED === 7) {
-                midi.sendShortMsg(0x94 + deckOffset, 0x1B, MC7000.padColor.hotcueon);
-                midi.sendShortMsg(0x94 + deckOffset, 0x1B + 8, MC7000.padColor.hotcueon);
+                midi.sendShortMsg(0x94 + deckOffset, 0x1B, MC7000.padColor.slicerJumpFwd);
+                midi.sendShortMsg(0x94 + deckOffset, 0x1B + 8, MC7000.padColor.slicerJumpFwd);
             } else if (beatCountLED > 0 && beatCountLED < 7) {
-                midi.sendShortMsg(0x94 + deckOffset, 0x14 + beatCountLED, MC7000.padColor.hotcueon);
-                midi.sendShortMsg(0x94 + deckOffset, 0x14 + 8 + beatCountLED, MC7000.padColor.hotcueon);
+                midi.sendShortMsg(0x94 + deckOffset, 0x14 + beatCountLED, MC7000.padColor.slicerJumpFwd);
+                midi.sendShortMsg(0x94 + deckOffset, 0x14 + 8 + beatCountLED, MC7000.padColor.slicerJumpFwd);
             }
         }
         MC7000.prevPadLED[deckOffset] = beatCountLED;

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -46,8 +46,13 @@ MC7000.needleSearchPlay = false; // default: false
 
 // select if the previous sampler shall stop before a new sampler starts
 // true: a running sampler will stop before the new sampler starts
-// false: all triggered samplers will play simultaniously
+// false: all triggered samplers will play simultaneously
 MC7000.prevSamplerStop = true; // default: true
+
+// Set Vinyl Mode on ("true") or off ("false") when MIXXX starts.
+// This sets the Jog Wheel touch detection / Vinyl Mode
+// and the Jog LEDs ("VINYL" on = spinny, "VINYL" off = track position).
+MC7000.VinylModeOn = true; // default: true
 
 // Possible pitchfader rate ranges given in percent.
 // can be cycled through by the RANGE buttons.
@@ -69,11 +74,6 @@ MC7000.rateRanges = [
 // use "SHIFT" + "DECK #" to toggle between both modes
 MC7000.modeSingleLED = 1; // default: 1
 
-// Set Vinyl Mode on ("true") or off ("false") when MIXXX starts.
-// This sets the Jog Wheel touch detection / Vinyl Mode
-// and the Jog LEDs ("VINYL" on = spinny, "VINYL" off = track position).
-MC7000.VinylModeOn = true; // default: true
-
 // Scratch algorithm parameters
 MC7000.scratchParams = {
     recordSpeed: 33 + 1/3, // default: 33 + 1/3
@@ -86,7 +86,6 @@ MC7000.scratchParams = {
 // set to 0.5 with audio buffer set to 50ms
 // set to 1 with audio buffer set to 25ms
 // set to 3 with audio buffer set to 5ms
-
 MC7000.jogSensitivity = 1;
 
 /*/////////////////////////////////

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -37,48 +37,48 @@ var MC7000 = {};
 // 1) Beat LED in Slicer mode (counts every 8 beats AFTER the CUE point)
 //    only works for CONSTANT TEMPO tracks
 //    needs beat grid and CUE point set
-MC7000.experimental = false; // default: false
+MC7000.experimental = true;
 
 // Wanna have Needle Search active while playing a track ?
 // In any case Needle Search is available holding "SHIFT" down.
-// can be true or false (recommended: false)
-MC7000.needleSearchPlay = false; // default: false
+// can be true or false
+MC7000.needleSearchPlay = false;
 
 // select if the previous sampler shall stop before a new sampler starts
 // true: a running sampler will stop before the new sampler starts
 // false: all triggered samplers will play simultaneously
-MC7000.prevSamplerStop = true; // default: true
+MC7000.prevSamplerStop = true;
 
 // Set Vinyl Mode on ("true") or off ("false") when MIXXX starts.
 // This sets the Jog Wheel touch detection / Vinyl Mode
 // and the Jog LEDs ("VINYL" on = spinny, "VINYL" off = track position).
-MC7000.VinylModeOn = true; // default: true
+MC7000.VinylModeOn = true;
 
 // Possible pitchfader rate ranges given in percent.
 // can be cycled through by the RANGE buttons.
 // All default values are the same as selectable in Mixxx Preferences
 MC7000.rateRanges = [
-    4/100,  // default: 4/100
-    6/100,  // default: 6/100
-    8/100,  // default: 8/100
-    10/100, // default: 10/100
-    16/100, // default: 16/100
-    24/100, // default: 24/100
-    50/100, // default: 50/100
-    90/100, // default: 90/100
+    4/100,
+    6/100,
+    8/100,
+    10/100,
+    16/100,
+    24/100,
+    50/100,
+    90/100,
 ];
 
 // Platter Ring LED mode
 // Mode 0 = Single "off" LED chase (all others "on")
 // Mode 1 = Single "on" LED chase (all others "off")
 // use "SHIFT" + "DECK #" to toggle between both modes
-MC7000.modeSingleLED = 1; // default: 1
+MC7000.modeSingleLED = 1;
 
 // Scratch algorithm parameters
 MC7000.scratchParams = {
-    recordSpeed: 33 + 1/3, // default: 33 + 1/3
-    alpha: (1.0/10),   // default: (1.0/10)
-    beta: (1.0/10)/32  // default: (1.0/10)/32
+    recordSpeed: 33 + 1/3,
+    alpha: (1.0/10),
+    beta: (1.0/10)/32
 };
 
 // Sensitivity factor of the jog wheel (also depends on audio latency)
@@ -86,7 +86,7 @@ MC7000.scratchParams = {
 // set to 0.5 with audio buffer set to 50ms
 // set to 1 with audio buffer set to 25ms
 // set to 3 with audio buffer set to 5ms
-MC7000.jogSensitivity = 1;
+MC7000.jogSensitivity = 3;
 
 /*/////////////////////////////////
 //      USER VARIABLES END       //

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -86,7 +86,7 @@ MC7000.scratchParams = {
 // set to 0.5 with audio buffer set to 50ms
 // set to 1 with audio buffer set to 25ms
 // set to 3 with audio buffer set to 5ms
-MC7000.jogSensitivity = 3;
+MC7000.jogSensitivity = 2;
 
 /*/////////////////////////////////
 //      USER VARIABLES END       //
@@ -653,8 +653,9 @@ MC7000.loadButton = function(channel, control, value, status, group) {
 MC7000.wheelTouch = function(channel, control, value, status, group) {
     var deckNumber = script.deckFromGroup(group);
     var deckOffset = deckNumber - 1;
+    var maxLibrary = engine.getValue("[Master]", "maximize_library");
     if (MC7000.isVinylMode[deckOffset]) {
-        if (value === 0x7F) {
+        if (value === 0x7F && maxLibrary === 0) {
             engine.scratchEnable(deckNumber, MC7000.jogWheelTicksPerRevolution,
                 MC7000.scratchParams.recordSpeed,
                 MC7000.scratchParams.alpha,
@@ -681,7 +682,12 @@ MC7000.wheelTurn = function(channel, control, value, status, group) {
     var adjustedSpeed = numTicks * MC7000.jogSensitivity / 10;
     var deckNumber = script.deckFromGroup(group);
     var deckOffset = deckNumber - 1;
-    if (engine.isScratching(deckNumber)) {
+    var maxLibrary = engine.getValue("[Master]", "maximize_library");
+    if (maxLibrary === 1 && numTicks > 0) {
+        engine.setValue("[Library]", "MoveUp", 1);
+    } else if (maxLibrary === 1 && numTicks < 0) {
+        engine.setValue("[Library]", "MoveDown", 1);
+    } else if (engine.isScratching(deckNumber)) {
     // Scratch!
         engine.scratchTick(deckNumber, numTicks * MC7000.jogSensitivity);
     } else {

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -1,5 +1,5 @@
 /**
- * Denon DJ MC7000 DJ controller script for Mixxx 2.3
+ * Denon DJ MC7000 DJ controller script for Mixxx 2.3.1
  *
  * Started in Dec. 2019 by OsZ
  *
@@ -37,7 +37,7 @@ var MC7000 = {};
 // 1) Beat LED in Slicer mode (counts every 8 beats AFTER the CUE point)
 //    only works for CONSTANT TEMPO tracks
 //    needs beat grid and CUE point set
-MC7000.experimental = true;
+MC7000.experimental = false;
 
 // Wanna have Needle Search active while playing a track ?
 // In any case Needle Search is available holding "SHIFT" down.
@@ -46,7 +46,7 @@ MC7000.needleSearchPlay = false;
 
 // Possible pitchfader rate ranges given in percent.
 // can be cycled through by the RANGE buttons.
-// All default values are the same as selectable in Preferences
+// All default values are the same as selectable in Mixxx Preferences
 MC7000.rateRanges = [
     4/100,  // default: 4/100
     6/100,  // default: 6/100
@@ -72,8 +72,8 @@ MC7000.VinylModeOn = true; // default: true
 // Scratch algorithm parameters
 MC7000.scratchParams = {
     recordSpeed: 33 + 1/3, // default: 33 + 1/3
-    alpha: (1.0/100),   // default: (1.0/10)
-    beta: (1.0/100)/32  // default: (1.0/10)/32
+    alpha: (1.0/10),   // default: (1.0/10)
+    beta: (1.0/10)/32  // default: (1.0/10)/32
 };
 
 // Sensitivity factor of the jog wheel (also depends on audio latency)
@@ -82,7 +82,7 @@ MC7000.scratchParams = {
 // set to 1 with audio buffer set to 25ms
 // set to 3 with audio buffer set to 5ms
 
-MC7000.jogSensitivity = 1.4;
+MC7000.jogSensitivity = 1;
 
 /*/////////////////////////////////
 //      USER VARIABLES END       //

--- a/res/controllers/Denon-MC7000.midi.xml
+++ b/res/controllers/Denon-MC7000.midi.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<MixxxControllerPreset mixxxVersion="2.3" schemaVersion="1">
+<MixxxControllerPreset mixxxVersion="2.3.1" schemaVersion="1">
     <info>
     	<name>Denon MC7000</name>
     	<author>OsZ</author>

--- a/res/controllers/Denon-MC7000.midi.xml
+++ b/res/controllers/Denon-MC7000.midi.xml
@@ -3,7 +3,7 @@
     <info>
     	<name>Denon MC7000</name>
     	<author>OsZ</author>
-    	<description>Denon MC7000 mapping. Check your Linux Kernel version to get the Audio Interface working - Details in user manual</description>
+    	<description>A professional 4-channel DJ controller featuring 2 separate audio interfaces. Please refer to the Mixxx user manual to get the audio interfaces working on Linux.</description>
     	<forums>https://mixxx.discourse.group/t/denon-mc7000-mapping/18235</forums>
     	<wiki>https://github.com/mixxxdj/mixxx/wiki/Denon-MC7000</wiki>
         <manual>denon_mc7000</manual>

--- a/res/controllers/Denon-MC7000.midi.xml
+++ b/res/controllers/Denon-MC7000.midi.xml
@@ -3,7 +3,7 @@
     <info>
     	<name>Denon MC7000</name>
     	<author>OsZ</author>
-    	<description>Denon MC7000 mapping. Check your Linux Kernel version to get the Audio Interface working - see WIKI</description>
+    	<description>Denon MC7000 mapping. Check your Linux Kernel version to get the Audio Interface working - Details in user manual</description>
     	<forums>https://mixxx.discourse.group/t/denon-mc7000-mapping/18235</forums>
     	<wiki>https://github.com/mixxxdj/mixxx/wiki/Denon-MC7000</wiki>
         <manual>denon_mc7000</manual>
@@ -939,7 +939,7 @@
                     <Script-Binding/>
                 </options>
             </control>
-			<control>
+            <control>
                 <group>[Channel1]</group>
                 <key>MC7000.wheelTouch</key>
                 <description>MIDI Learned from 759 messages.</description>


### PR DESCRIPTION
Would like to store the ideas for several small improvement that I collected from forum & zulip chats over time. No need to rush that through. 

- several SLIP mode improvements. With activated SLIP mode it will be switched off automatically and therefore jump to the original time position inside the track after:
        scratching
        after Hot Cue jump
        after backspin
- changed (simplified) jog calculations
( - changed scratch parameters  EDIT: Won't change)
- stop to play current sampler when a new one is triggered
- Rate Range change now considers start point from Mixxx preferences for changing range up and down
- Jog Wheel search through maximized library