### PR TITLE
Enable export of hot cue colours to EnginePrime

### DIFF
--- a/src/library/export/engineprimeexportjob.cpp
+++ b/src/library/export/engineprimeexportjob.cpp
@@ -242,7 +242,14 @@ void exportMetadata(djinterop::database* pDatabase,
         djinterop::hot_cue hotCue{};
         hotCue.label = label.toStdString();
         hotCue.sample_offset = playPosToSampleOffset(pCue->getPosition());
-        hotCue.color = el::standard_pad_colors::pads[hotCueIndex];
+
+        auto color = mixxx::RgbColor::toQColor(pCue->getColor());
+        hotCue.color = djinterop::pad_color{
+                static_cast<uint_least8_t>(color.red()),
+                static_cast<uint_least8_t>(color.green()),
+                static_cast<uint_least8_t>(color.blue()),
+                255};
+
         snapshot.hot_cues[hotCueIndex] = hotCue;
     }
 


### PR DESCRIPTION
Enables export of hot cue colours to Engine Prime.  Previously, only the standard Denon colour palette was used.

Basic experimental testing performed successfully on SC5000 hardware.