### PR TITLE
Release candidate 2.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 
 project(mixxx VERSION 2.3.0)
 # Work around missing version suffixes support https://gitlab.kitware.com/cmake/cmake/-/issues/16716
-set(MIXXX_VERSION_PRERELEASE "beta") # set to "alpha-pre" "beta" or ""
+set(MIXXX_VERSION_PRERELEASE "") # set to "alpha-pre" "beta" or ""
 
 set(CMAKE_PROJECT_HOMEPAGE_URL "https://www.mixxx.org")
 set(CMAKE_PROJECT_DESCRIPTION "Mixxx is Free DJ software that gives you everything you need to perform live mixes.")


### PR DESCRIPTION
This removes the beta suffix from the Version creating a release candidate. 

After merging, we need to to a smoke test with all binaries.

More steps can be found here: 
https://github.com/mixxxdj/mixxx/wiki/Release-Checklist-2.3.0 

