### PR TITLE
Crossfade when crossing pitch 1.0 at non 1.0 speed

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -895,6 +895,19 @@ void EngineBuffer::processTrackLocked(
             readToCrossfadeBuffer(iBufferSize);
             // Clear the scaler information
             m_pScale->clear();
+        } else if (m_pScale != m_pScaleVinyl &&
+                speed != 1.0 &&
+                ((pitchRatio >= 1 && m_pitch_old < 1) ||
+                        (pitchRatio <= 1 && m_pitch_old > 1) ||
+                        (pitchRatio != 1 && m_pitch_old == 1 && m_pScale == m_pScaleST))) {
+            // https://bugs.launchpad.net/mixxx/+bug/1933756
+            // Crossing pitch ratio of 1.0 with speed != 1.0
+            // produces a crackling sound with Rubberband and Soundtouch.
+            // Soundtouch also crackles when moving away from 1.0.
+            // With soundtouch there is still a minor crackling left with
+            // buffer sizes <= 23 ms.
+            readToCrossfadeBuffer(iBufferSize);
+            m_pScale->clear();
         }
 
         m_baserate_old = baserate;


### PR DESCRIPTION
This removes a crackling sound with a 440 Hz sine tone.
Fixes https://bugs.launchpad.net/mixxx/+bug/1933756