### PR TITLE
SidebarModel: Add basic support for icon names

### DIFF
--- a/src/library/analysisfeature.cpp
+++ b/src/library/analysisfeature.cpp
@@ -48,12 +48,11 @@ AnalyzerModeFlags getAnalyzerModeFlags(
 AnalysisFeature::AnalysisFeature(
         Library* pLibrary,
         UserSettingsPointer pConfig)
-        : LibraryFeature(pLibrary, pConfig),
-        m_baseTitle(tr("Analyze")),
-        m_icon(":/images/library/ic_library_prepare.svg"),
-        m_pTrackAnalysisScheduler(TrackAnalysisScheduler::NullPointer()),
-        m_pAnalysisView(nullptr),
-        m_title(m_baseTitle) {
+        : LibraryFeature(pLibrary, pConfig, QStringLiteral("prepare")),
+          m_baseTitle(tr("Analyze")),
+          m_pTrackAnalysisScheduler(TrackAnalysisScheduler::NullPointer()),
+          m_pAnalysisView(nullptr),
+          m_title(m_baseTitle) {
 }
 
 void AnalysisFeature::resetTitle() {

--- a/src/library/analysisfeature.h
+++ b/src/library/analysisfeature.h
@@ -26,10 +26,6 @@ class AnalysisFeature : public LibraryFeature {
         return m_title;
     }
 
-    QIcon getIcon() override {
-        return m_icon;
-    }
-
     bool dropAccept(const QList<QUrl>& urls, QObject* pSource) override;
     bool dragMoveAccept(const QUrl& url) override;
     void bindLibraryWidget(WLibrary* libraryWidget,
@@ -64,7 +60,6 @@ class AnalysisFeature : public LibraryFeature {
     void setTitleProgress(int currentTrackNumber, int totalTracksCount);
 
     const QString m_baseTitle;
-    const QIcon m_icon;
 
     TrackAnalysisScheduler::Pointer m_pTrackAnalysisScheduler;
 

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -48,14 +48,13 @@ namespace {
 AutoDJFeature::AutoDJFeature(Library* pLibrary,
         UserSettingsPointer pConfig,
         PlayerManagerInterface* pPlayerManager)
-        : LibraryFeature(pLibrary, pConfig),
+        : LibraryFeature(pLibrary, pConfig, QStringLiteral("autodj")),
           m_pTrackCollection(pLibrary->trackCollectionManager()->internalCollection()),
           m_playlistDao(m_pTrackCollection->getPlaylistDAO()),
           m_iAutoDJPlaylistId(findOrCrateAutoDjPlaylistId(m_playlistDao)),
           m_pAutoDJProcessor(nullptr),
           m_pAutoDJView(nullptr),
-          m_autoDjCratesDao(m_iAutoDJPlaylistId, pLibrary->trackCollectionManager(), m_pConfig),
-          m_icon(":/images/library/ic_library_autodj.svg") {
+          m_autoDjCratesDao(m_iAutoDJPlaylistId, pLibrary->trackCollectionManager(), m_pConfig) {
     qRegisterMetaType<AutoDJProcessor::AutoDJState>("AutoDJState");
     m_pAutoDJProcessor = new AutoDJProcessor(this,
             m_pConfig,
@@ -108,10 +107,6 @@ AutoDJFeature::~AutoDJFeature() {
 
 QVariant AutoDJFeature::title() {
     return tr("Auto DJ");
-}
-
-QIcon AutoDJFeature::getIcon() {
-    return m_icon;
 }
 
 void AutoDJFeature::bindLibraryWidget(

--- a/src/library/autodj/autodjfeature.h
+++ b/src/library/autodj/autodjfeature.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <QAction>
-#include <QIcon>
 #include <QList>
 #include <QModelIndex>
 #include <QObject>
@@ -34,7 +33,6 @@ class AutoDJFeature : public LibraryFeature {
     virtual ~AutoDJFeature();
 
     QVariant title() override;
-    QIcon getIcon() override;
 
     bool dropAccept(const QList<QUrl>& urls, QObject* pSource) override;
     bool dragMoveAccept(const QUrl& url) override;
@@ -83,7 +81,6 @@ class AutoDJFeature : public LibraryFeature {
     // auto-DJ list.
     QAction *m_pRemoveCrateFromAutoDj;
 
-    QIcon m_icon;
     QPointer<WLibrarySidebar> m_pSidebarWidget;
 
   private slots:

--- a/src/library/banshee/bansheefeature.cpp
+++ b/src/library/banshee/bansheefeature.cpp
@@ -17,9 +17,8 @@ const QString BansheeFeature::BANSHEE_MOUNT_KEY = "mixxx.BansheeFeature.mount";
 QString BansheeFeature::m_databaseFile;
 
 BansheeFeature::BansheeFeature(Library* pLibrary, UserSettingsPointer pConfig)
-        : BaseExternalLibraryFeature(pLibrary, pConfig),
-          m_cancelImport(false),
-          m_icon(":/images/library/ic_library_banshee.svg") {
+        : BaseExternalLibraryFeature(pLibrary, pConfig, QStringLiteral("banshee")),
+          m_cancelImport(false) {
     Q_UNUSED(pConfig);
     m_pBansheePlaylistModel = new BansheePlaylistModel(
             this, m_pLibrary->trackCollectionManager(), &m_connection);
@@ -56,10 +55,6 @@ void BansheeFeature::prepareDbPath(UserSettingsPointer pConfig) {
 
 QVariant BansheeFeature::title() {
     return m_title;
-}
-
-QIcon BansheeFeature::getIcon() {
-    return m_icon;
 }
 
 void BansheeFeature::activate() {

--- a/src/library/banshee/bansheefeature.h
+++ b/src/library/banshee/bansheefeature.h
@@ -24,7 +24,6 @@ class BansheeFeature : public BaseExternalLibraryFeature {
     static void prepareDbPath(UserSettingsPointer pConfig);
 
     virtual QVariant title();
-    virtual QIcon getIcon();
 
     virtual TreeItemModel* getChildModel();
 
@@ -50,7 +49,6 @@ class BansheeFeature : public BaseExternalLibraryFeature {
     QFuture<TreeItem*> m_future;
     QString m_title;
     bool m_cancelImport;
-    QIcon m_icon;
 
     static QString m_databaseFile;
 

--- a/src/library/baseexternallibraryfeature.cpp
+++ b/src/library/baseexternallibraryfeature.cpp
@@ -18,8 +18,9 @@ const mixxx::Logger kLogger("BaseExternalLibraryFeature");
 
 BaseExternalLibraryFeature::BaseExternalLibraryFeature(
         Library* pLibrary,
-        UserSettingsPointer pConfig)
-        : LibraryFeature(pLibrary, pConfig),
+        UserSettingsPointer pConfig,
+        const QString& iconName)
+        : LibraryFeature(pLibrary, pConfig, iconName),
           m_pTrackCollection(pLibrary->trackCollectionManager()->internalCollection()) {
     m_pAddToAutoDJAction = make_parented<QAction>(tr("Add to Auto DJ Queue (bottom)"), this);
     connect(m_pAddToAutoDJAction,

--- a/src/library/baseexternallibraryfeature.h
+++ b/src/library/baseexternallibraryfeature.h
@@ -16,7 +16,8 @@ class BaseExternalLibraryFeature : public LibraryFeature {
   public:
     BaseExternalLibraryFeature(
             Library* pLibrary,
-            UserSettingsPointer pConfig);
+            UserSettingsPointer pConfig,
+            const QString& iconName);
     ~BaseExternalLibraryFeature() override = default;
 
   public slots:

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -31,12 +31,11 @@ BrowseFeature::BrowseFeature(
         Library* pLibrary,
         UserSettingsPointer pConfig,
         RecordingManager* pRecordingManager)
-        : LibraryFeature(pLibrary, pConfig),
+        : LibraryFeature(pLibrary, pConfig, QString("computer")),
           m_pTrackCollection(pLibrary->trackCollectionManager()->internalCollection()),
           m_browseModel(this, pLibrary->trackCollectionManager(), pRecordingManager),
           m_proxyModel(&m_browseModel),
-          m_pLastRightClickedItem(nullptr),
-          m_icon(":/images/library/ic_library_computer.svg") {
+          m_pLastRightClickedItem(nullptr) {
     connect(this,
             &BrowseFeature::requestAddDir,
             pLibrary,
@@ -211,10 +210,6 @@ void BrowseFeature::slotRemoveQuickLink() {
 
     m_quickLinkList.removeAt(index);
     saveQuickLinks();
-}
-
-QIcon BrowseFeature::getIcon() {
-    return m_icon;
 }
 
 TreeItemModel* BrowseFeature::getChildModel() {

--- a/src/library/browse/browsefeature.h
+++ b/src/library/browse/browsefeature.h
@@ -33,19 +33,19 @@ class BrowseFeature : public LibraryFeature {
     QVariant title() override;
 
     void bindLibraryWidget(WLibrary* libraryWidget,
-                    KeyboardEventFilter* keyboard);
-    void bindSidebarWidget(WLibrarySidebar* pSidebarWidget);
+            KeyboardEventFilter* keyboard) override;
+    void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
 
-    TreeItemModel* getChildModel();
+    TreeItemModel* getChildModel() override;
 
   public slots:
     void slotAddQuickLink();
     void slotRemoveQuickLink();
     void slotAddToLibrary();
-    void activate();
-    void activateChild(const QModelIndex& index);
-    void onRightClickChild(const QPoint& globalPos, const QModelIndex& index);
-    void onLazyChildExpandation(const QModelIndex& index);
+    void activate() override;
+    void activateChild(const QModelIndex& index) override;
+    void onRightClickChild(const QPoint& globalPos, const QModelIndex& index) override;
+    void onLazyChildExpandation(const QModelIndex& index) override;
     void slotLibraryScanStarted();
     void slotLibraryScanFinished();
 

--- a/src/library/browse/browsefeature.h
+++ b/src/library/browse/browsefeature.h
@@ -30,8 +30,7 @@ class BrowseFeature : public LibraryFeature {
             RecordingManager* pRecordingManager);
     virtual ~BrowseFeature();
 
-    QVariant title();
-    QIcon getIcon();
+    QVariant title() override;
 
     void bindLibraryWidget(WLibrary* libraryWidget,
                     KeyboardEventFilter* keyboard);
@@ -73,6 +72,5 @@ class BrowseFeature : public LibraryFeature {
     TreeItem* m_pLastRightClickedItem;
     TreeItem* m_pQuickLinkItem;
     QStringList m_quickLinkList;
-    QIcon m_icon;
     QPointer<WLibrarySidebar> m_pSidebarWidget;
 };

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -63,9 +63,8 @@ QString localhost_token() {
 } // anonymous namespace
 
 ITunesFeature::ITunesFeature(Library* pLibrary, UserSettingsPointer pConfig)
-        : BaseExternalLibraryFeature(pLibrary, pConfig),
-          m_cancelImport(false),
-          m_icon(":/images/library/ic_library_itunes.svg") {
+        : BaseExternalLibraryFeature(pLibrary, pConfig, QStringLiteral("itunes")),
+          m_cancelImport(false) {
     QString tableName = "itunes_library";
     QString idColumn = "id";
     QStringList columns;
@@ -150,10 +149,6 @@ bool ITunesFeature::isSupported() {
 
 QVariant ITunesFeature::title() {
     return m_title;
-}
-
-QIcon ITunesFeature::getIcon() {
-    return m_icon;
 }
 
 void ITunesFeature::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {

--- a/src/library/itunes/itunesfeature.h
+++ b/src/library/itunes/itunesfeature.h
@@ -24,7 +24,6 @@ class ITunesFeature : public BaseExternalLibraryFeature {
     static bool isSupported();
 
     QVariant title() override;
-    QIcon getIcon() override;
     void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
 
     TreeItemModel* getChildModel() override;
@@ -69,5 +68,4 @@ class ITunesFeature : public BaseExternalLibraryFeature {
 
     QSharedPointer<BaseTrackCache> m_trackSource;
     QPointer<WLibrarySidebar> m_pSidebarWidget;
-    QIcon m_icon;
 };

--- a/src/library/libraryfeature.cpp
+++ b/src/library/libraryfeature.cpp
@@ -15,15 +15,21 @@
 namespace {
 
 const mixxx::Logger kLogger("LibraryFeature");
+const QString kIconPath = QStringLiteral(":/images/library/ic_library_%1.svg");
 
 } // anonymous namespace
 
 LibraryFeature::LibraryFeature(
         Library* pLibrary,
-        UserSettingsPointer pConfig)
+        UserSettingsPointer pConfig,
+        const QString& iconName)
         : QObject(pLibrary),
           m_pLibrary(pLibrary),
-          m_pConfig(pConfig) {
+          m_pConfig(pConfig),
+          m_iconName(iconName) {
+    if (!m_iconName.isEmpty()) {
+        m_icon = QIcon(kIconPath.arg(m_iconName));
+    }
 }
 
 QStringList LibraryFeature::getPlaylistFiles(QFileDialog::FileMode mode) const {

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -29,11 +29,25 @@ class LibraryFeature : public QObject {
   public:
     LibraryFeature(
             Library* pLibrary,
-            UserSettingsPointer pConfig);
+            UserSettingsPointer pConfig,
+            const QString& iconName);
     ~LibraryFeature() override = default;
 
     virtual QVariant title() = 0;
-    virtual QIcon getIcon() = 0;
+
+    /// Returns the icon name.
+    ///
+    /// This is useful for QML skins that need to build a URL anyway and may use their own icon theme.
+    QString iconName() const {
+        return m_iconName;
+    }
+
+    /// Returns the icon.
+    ///
+    /// This is used by legacy QWidget skins that display a QIcon directly.
+    QIcon icon() const {
+        return m_icon;
+    }
 
     virtual bool dropAccept(const QList<QUrl>& urls, QObject* pSource) {
         Q_UNUSED(urls);
@@ -134,4 +148,7 @@ class LibraryFeature : public QObject {
 
   private:
     QStringList getPlaylistFiles(QFileDialog::FileMode mode) const;
+
+    QString m_iconName;
+    QIcon m_icon;
 };

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -69,10 +69,9 @@ const QStringList DEFAULT_COLUMNS = {
 
 MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
         UserSettingsPointer pConfig)
-        : LibraryFeature(pLibrary, pConfig),
+        : LibraryFeature(pLibrary, pConfig, QStringLiteral("tracks")),
           kMissingTitle(tr("Missing Tracks")),
           kHiddenTitle(tr("Hidden Tracks")),
-          m_icon(":/images/library/ic_library_tracks.svg"),
           m_pTrackCollection(pLibrary->trackCollectionManager()->internalCollection()),
           m_pLibraryTableModel(nullptr),
           m_pMissingView(nullptr),
@@ -142,10 +141,6 @@ void MixxxLibraryFeature::bindLibraryWidget(WLibrary* pLibraryWidget,
 
 QVariant MixxxLibraryFeature::title() {
     return tr("Tracks");
-}
-
-QIcon MixxxLibraryFeature::getIcon() {
-    return m_icon;
 }
 
 TreeItemModel* MixxxLibraryFeature::getChildModel() {

--- a/src/library/mixxxlibraryfeature.h
+++ b/src/library/mixxxlibraryfeature.h
@@ -34,7 +34,6 @@ class MixxxLibraryFeature final : public LibraryFeature {
     ~MixxxLibraryFeature() override = default;
 
     QVariant title() override;
-    QIcon getIcon() override;
     bool dropAccept(const QList<QUrl>& urls, QObject* pSource) override;
     bool dragMoveAccept(const QUrl& url) override;
     TreeItemModel* getChildModel() override;
@@ -67,7 +66,6 @@ class MixxxLibraryFeature final : public LibraryFeature {
   private:
     const QString kMissingTitle;
     const QString kHiddenTitle;
-    const QIcon m_icon;
     TrackCollection* const m_pTrackCollection;
 
     QSharedPointer<BaseTrackCache> m_pBaseTrackCache;

--- a/src/library/recording/recordingfeature.cpp
+++ b/src/library/recording/recordingfeature.cpp
@@ -16,19 +16,14 @@ const QString kViewName = QStringLiteral("Recording");
 } // anonymous namespace
 
 RecordingFeature::RecordingFeature(Library* pLibrary,
-                                   UserSettingsPointer pConfig,
-                                   RecordingManager* pRecordingManager)
-        : LibraryFeature(pLibrary, pConfig),
-          m_pRecordingManager(pRecordingManager),
-          m_icon(":/images/library/ic_library_recordings.svg") {
+        UserSettingsPointer pConfig,
+        RecordingManager* pRecordingManager)
+        : LibraryFeature(pLibrary, pConfig, QStringLiteral("recordings")),
+          m_pRecordingManager(pRecordingManager) {
 }
 
 QVariant RecordingFeature::title() {
     return QVariant(tr("Recordings"));
-}
-
-QIcon RecordingFeature::getIcon() {
-    return m_icon;
 }
 
 TreeItemModel* RecordingFeature::getChildModel() {

--- a/src/library/recording/recordingfeature.h
+++ b/src/library/recording/recordingfeature.h
@@ -20,7 +20,6 @@ class RecordingFeature final : public LibraryFeature {
     ~RecordingFeature() override = default;
 
     QVariant title() override;
-    QIcon getIcon() override;
 
     void bindLibraryWidget(WLibrary* libraryWidget,
                     KeyboardEventFilter* keyboard) override;
@@ -37,7 +36,6 @@ class RecordingFeature final : public LibraryFeature {
 
   private:
     RecordingManager* const m_pRecordingManager;
-    const QIcon m_icon;
 
     FolderTreeModel m_childModel;
 };

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -1325,8 +1325,7 @@ bool RekordboxPlaylistModel::isColumnInternal(int column) {
 RekordboxFeature::RekordboxFeature(
         Library* pLibrary,
         UserSettingsPointer pConfig)
-        : BaseExternalLibraryFeature(pLibrary, pConfig),
-          m_icon(":/images/library/ic_library_rekordbox.svg") {
+        : BaseExternalLibraryFeature(pLibrary, pConfig, QStringLiteral("rekordbox")) {
     QString tableName = kRekordboxLibraryTable;
     QString idColumn = LIBRARYTABLE_ID;
     QStringList columns;
@@ -1436,10 +1435,6 @@ BaseSqlTableModel* RekordboxFeature::getPlaylistModelForPlaylist(const QString& 
 
 QVariant RekordboxFeature::title() {
     return m_title;
-}
-
-QIcon RekordboxFeature::getIcon() {
-    return m_icon;
 }
 
 bool RekordboxFeature::isSupported() {

--- a/src/library/rekordbox/rekordboxfeature.h
+++ b/src/library/rekordbox/rekordboxfeature.h
@@ -59,7 +59,6 @@ class RekordboxFeature : public BaseExternalLibraryFeature {
     ~RekordboxFeature() override;
 
     QVariant title() override;
-    QIcon getIcon() override;
     static bool isSupported();
     void bindLibraryWidget(WLibrary* libraryWidget,
             KeyboardEventFilter* keyboard) override;
@@ -90,5 +89,4 @@ class RekordboxFeature : public BaseExternalLibraryFeature {
     QString m_title;
 
     QSharedPointer<BaseTrackCache> m_trackSource;
-    QIcon m_icon;
 };

--- a/src/library/rhythmbox/rhythmboxfeature.cpp
+++ b/src/library/rhythmbox/rhythmboxfeature.cpp
@@ -15,9 +15,8 @@
 #include "moc_rhythmboxfeature.cpp"
 
 RhythmboxFeature::RhythmboxFeature(Library* pLibrary, UserSettingsPointer pConfig)
-        : BaseExternalLibraryFeature(pLibrary, pConfig),
-          m_cancelImport(false),
-          m_icon(":/images/library/ic_library_rhythmbox.svg") {
+        : BaseExternalLibraryFeature(pLibrary, pConfig, QStringLiteral("rhythmbox")),
+          m_cancelImport(false) {
     QString tableName = "rhythmbox_library";
     QString idColumn = "id";
     QStringList columns;
@@ -106,10 +105,6 @@ bool RhythmboxFeature::isSupported() {
 
 QVariant RhythmboxFeature::title() {
     return m_title;
-}
-
-QIcon RhythmboxFeature::getIcon() {
-    return m_icon;
 }
 
 TreeItemModel* RhythmboxFeature::getChildModel() {

--- a/src/library/rhythmbox/rhythmboxfeature.h
+++ b/src/library/rhythmbox/rhythmboxfeature.h
@@ -22,7 +22,6 @@ class RhythmboxFeature : public BaseExternalLibraryFeature {
     static bool isSupported();
 
     QVariant title();
-    QIcon getIcon();
 
     TreeItemModel* getChildModel();
     // processes the music collection
@@ -58,5 +57,4 @@ class RhythmboxFeature : public BaseExternalLibraryFeature {
     bool m_cancelImport;
 
     QSharedPointer<BaseTrackCache>  m_trackSource;
-    QIcon m_icon;
 };

--- a/src/library/serato/seratofeature.cpp
+++ b/src/library/serato/seratofeature.cpp
@@ -846,8 +846,7 @@ bool dropTable(QSqlDatabase& database, const QString& tableName) {
 SeratoFeature::SeratoFeature(
         Library* pLibrary,
         UserSettingsPointer pConfig)
-        : BaseExternalLibraryFeature(pLibrary, pConfig),
-          m_icon(":/images/library/ic_library_serato.svg") {
+        : BaseExternalLibraryFeature(pLibrary, pConfig, QStringLiteral("serato")) {
     QStringList columns;
     columns << LIBRARYTABLE_ID
             << LIBRARYTABLE_TITLE
@@ -957,10 +956,6 @@ BaseSqlTableModel* SeratoFeature::getPlaylistModelForPlaylist(const QString& pla
 
 QVariant SeratoFeature::title() {
     return m_title;
-}
-
-QIcon SeratoFeature::getIcon() {
-    return m_icon;
 }
 
 bool SeratoFeature::isSupported() {

--- a/src/library/serato/seratofeature.h
+++ b/src/library/serato/seratofeature.h
@@ -29,7 +29,6 @@ class SeratoFeature : public BaseExternalLibraryFeature {
     ~SeratoFeature() override;
 
     QVariant title() override;
-    QIcon getIcon() override;
     static bool isSupported();
     void bindLibraryWidget(WLibrary* libraryWidget,
             KeyboardEventFilter* keyboard) override;
@@ -60,5 +59,4 @@ class SeratoFeature : public BaseExternalLibraryFeature {
     QString m_title;
 
     QSharedPointer<BaseTrackCache> m_trackSource;
-    QIcon m_icon;
 };

--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -229,7 +229,9 @@ QVariant SidebarModel::data(const QModelIndex& index, int role) const {
         if (role == Qt::DisplayRole) {
             return m_sFeatures[index.row()]->title();
         } else if (role == Qt::DecorationRole) {
-            return m_sFeatures[index.row()]->getIcon();
+            return m_sFeatures[index.row()]->icon();
+        } else if (role == SidebarModel::IconNameRole) {
+            return m_sFeatures[index.row()]->iconName();
         }
     }
 
@@ -246,15 +248,17 @@ QVariant SidebarModel::data(const QModelIndex& index, int role) const {
                 } else {
                     return pTreeItem->getData();
                 }
-            } else if (role == TreeItemModel::kDataRole) {
-                // We use Qt::UserRole to ask for the datapath.
-                return pTreeItem->getData();
             } else if (role == Qt::FontRole) {
                 QFont font;
                 font.setBold(pTreeItem->isBold());
                 return font;
             } else if (role == Qt::DecorationRole) {
                 return pTreeItem->getIcon();
+            } else if (role == SidebarModel::DataRole) {
+                return pTreeItem->getData();
+            } else if (role == SidebarModel::IconNameRole) {
+                // TODO: Add support for icon names in tree items
+                return QString();
             }
         }
     }

--- a/src/library/sidebarmodel.h
+++ b/src/library/sidebarmodel.h
@@ -15,6 +15,12 @@ class SidebarModel : public QAbstractItemModel {
     // for parented_ptr
     using QObject::parent;
 
+    enum Roles {
+        IconNameRole = Qt::UserRole + 1,
+        DataRole,
+    };
+    Q_ENUM(Roles);
+
     explicit SidebarModel(
             QObject* parent = nullptr);
     ~SidebarModel() override = default;

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -31,8 +31,9 @@ constexpr QChar kUnsafeFilenameReplacement = '-';
 BasePlaylistFeature::BasePlaylistFeature(Library* pLibrary,
         UserSettingsPointer pConfig,
         PlaylistTableModel* pModel,
-        const QString& rootViewName)
-        : BaseTrackSetFeature(pLibrary, pConfig, rootViewName),
+        const QString& rootViewName,
+        const QString& iconName)
+        : BaseTrackSetFeature(pLibrary, pConfig, rootViewName, iconName),
           m_playlistDao(pLibrary->trackCollectionManager()
                                 ->internalCollection()
                                 ->getPlaylistDAO()),

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -30,7 +30,8 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     BasePlaylistFeature(Library* pLibrary,
             UserSettingsPointer pConfig,
             PlaylistTableModel* pModel,
-            const QString& rootViewName);
+            const QString& rootViewName,
+            const QString& iconName);
     ~BasePlaylistFeature() override = default;
 
     TreeItemModel* getChildModel() override;

--- a/src/library/trackset/basetracksetfeature.cpp
+++ b/src/library/trackset/basetracksetfeature.cpp
@@ -5,8 +5,9 @@
 BaseTrackSetFeature::BaseTrackSetFeature(
         Library* pLibrary,
         UserSettingsPointer pConfig,
-        const QString& rootViewName)
-        : LibraryFeature(pLibrary, pConfig),
+        const QString& rootViewName,
+        const QString& iconName)
+        : LibraryFeature(pLibrary, pConfig, iconName),
           m_rootViewName(rootViewName) {
 }
 

--- a/src/library/trackset/basetracksetfeature.h
+++ b/src/library/trackset/basetracksetfeature.h
@@ -8,7 +8,8 @@ class BaseTrackSetFeature : public LibraryFeature {
   public:
     BaseTrackSetFeature(Library* pLibrary,
             UserSettingsPointer pConfig,
-            const QString& rootViewName);
+            const QString& rootViewName,
+            const QString& iconName);
 
   signals:
     void analyzeTracks(const QList<TrackId>&);

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -41,8 +41,7 @@ QString formatLabel(
 
 CrateFeature::CrateFeature(Library* pLibrary,
         UserSettingsPointer pConfig)
-        : BaseTrackSetFeature(pLibrary, pConfig, "CRATEHOME"),
-          m_cratesIcon(":/images/library/ic_library_crates.svg"),
+        : BaseTrackSetFeature(pLibrary, pConfig, "CRATEHOME", QStringLiteral("crates")),
           m_lockedCrateIcon(":/images/library/ic_library_locked_tracklist.svg"),
           m_pTrackCollection(pLibrary->trackCollectionManager()->internalCollection()),
           m_crateTableModel(this, pLibrary->trackCollectionManager()) {
@@ -172,10 +171,6 @@ void CrateFeature::connectTrackCollection() {
 
 QVariant CrateFeature::title() {
     return tr("Crates");
-}
-
-QIcon CrateFeature::getIcon() {
-    return m_cratesIcon;
 }
 
 QString CrateFeature::formatRootViewHtml() const {

--- a/src/library/trackset/crate/cratefeature.h
+++ b/src/library/trackset/crate/cratefeature.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <QAction>
-#include <QIcon>
 #include <QList>
 #include <QModelIndex>
 #include <QPoint>
@@ -30,7 +29,6 @@ class CrateFeature : public BaseTrackSetFeature {
     ~CrateFeature() override = default;
 
     QVariant title() override;
-    QIcon getIcon() override;
 
     bool dropAcceptChild(const QModelIndex& index,
             const QList<QUrl>& urls,
@@ -98,7 +96,6 @@ class CrateFeature : public BaseTrackSetFeature {
 
     QString formatRootViewHtml() const;
 
-    const QIcon m_cratesIcon;
     const QIcon m_lockedCrateIcon;
 
     TrackCollection* const m_pTrackCollection;

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -42,8 +42,8 @@ PlaylistFeature::PlaylistFeature(Library* pLibrary, UserSettingsPointer pConfig)
                   new PlaylistTableModel(nullptr,
                           pLibrary->trackCollectionManager(),
                           "mixxx.db.model.playlist"),
-                  QStringLiteral("PLAYLISTHOME")),
-          m_icon(QStringLiteral(":/images/library/ic_library_playlist.svg")) {
+                  QStringLiteral("PLAYLISTHOME"),
+                  QStringLiteral("playlist")) {
     // construct child model
     std::unique_ptr<TreeItem> pRootItem = TreeItem::newRoot(this);
     m_childModel.setRootItem(std::move(pRootItem));
@@ -52,10 +52,6 @@ PlaylistFeature::PlaylistFeature(Library* pLibrary, UserSettingsPointer pConfig)
 
 QVariant PlaylistFeature::title() {
     return tr("Playlists");
-}
-
-QIcon PlaylistFeature::getIcon() {
-    return m_icon;
 }
 
 void PlaylistFeature::onRightClick(const QPoint& globalPos) {

--- a/src/library/trackset/playlistfeature.h
+++ b/src/library/trackset/playlistfeature.h
@@ -25,7 +25,6 @@ class PlaylistFeature : public BasePlaylistFeature {
     ~PlaylistFeature() override = default;
 
     QVariant title() override;
-    QIcon getIcon() override;
 
     bool dropAcceptChild(const QModelIndex& index,
             const QList<QUrl>& urls,
@@ -49,5 +48,4 @@ class PlaylistFeature : public BasePlaylistFeature {
 
   private:
     QString getRootViewHtml() const override;
-    const QIcon m_icon;
 };

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -35,9 +35,9 @@ SetlogFeature::SetlogFeature(
                           pLibrary->trackCollectionManager(),
                           "mixxx.db.model.setlog",
                           /*keep deleted tracks*/ true),
-                  QStringLiteral("SETLOGHOME")),
-          m_playlistId(kInvalidPlaylistId),
-          m_icon(QStringLiteral(":/images/library/ic_library_history.svg")) {
+                  QStringLiteral("SETLOGHOME"),
+                  QStringLiteral("history")),
+          m_playlistId(kInvalidPlaylistId) {
     // clear old empty entries
     ScopedTransaction transaction(pLibrary->trackCollectionManager()
                                           ->internalCollection()
@@ -77,10 +77,6 @@ SetlogFeature::~SetlogFeature() {
 
 QVariant SetlogFeature::title() {
     return tr("History");
-}
-
-QIcon SetlogFeature::getIcon() {
-    return m_icon;
 }
 
 void SetlogFeature::bindLibraryWidget(

--- a/src/library/trackset/setlogfeature.h
+++ b/src/library/trackset/setlogfeature.h
@@ -16,7 +16,6 @@ class SetlogFeature : public BasePlaylistFeature {
     virtual ~SetlogFeature();
 
     QVariant title() override;
-    QIcon getIcon() override;
 
     void bindLibraryWidget(WLibrary* libraryWidget,
             KeyboardEventFilter* keyboard) override;
@@ -49,5 +48,4 @@ class SetlogFeature : public BasePlaylistFeature {
     QAction* m_pStartNewPlaylist;
     int m_playlistId;
     QPointer<WLibrary> m_libraryWidget;
-    const QIcon m_icon;
 };

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -64,9 +64,8 @@ bool TraktorPlaylistModel::isColumnHiddenByDefault(int column) {
 }
 
 TraktorFeature::TraktorFeature(Library* pLibrary, UserSettingsPointer pConfig)
-        : BaseExternalLibraryFeature(pLibrary, pConfig),
-          m_cancelImport(false),
-          m_icon(":/images/library/ic_library_traktor.svg") {
+        : BaseExternalLibraryFeature(pLibrary, pConfig, QStringLiteral("traktor")),
+          m_cancelImport(false) {
     QString tableName = "traktor_library";
     QString idColumn = "id";
     QStringList columns;
@@ -141,10 +140,6 @@ BaseSqlTableModel* TraktorFeature::getPlaylistModelForPlaylist(const QString& pl
 
 QVariant TraktorFeature::title() {
     return m_title;
-}
-
-QIcon TraktorFeature::getIcon() {
-    return m_icon;
 }
 
 bool TraktorFeature::isSupported() {

--- a/src/library/traktor/traktorfeature.h
+++ b/src/library/traktor/traktorfeature.h
@@ -35,7 +35,6 @@ class TraktorFeature : public BaseExternalLibraryFeature {
     virtual ~TraktorFeature();
 
     QVariant title() override;
-    QIcon getIcon() override;
     static bool isSupported();
 
     TreeItemModel* getChildModel() override;
@@ -74,5 +73,4 @@ class TraktorFeature : public BaseExternalLibraryFeature {
     QString m_title;
 
     QSharedPointer<BaseTrackCache> m_trackSource;
-    QIcon m_icon;
 };


### PR DESCRIPTION
QML can't deal with `QIcon` objects. Instead, it uses icon urls. We could convert the qrc icon path to a `qrc://` url, but that would maintain the current limitation that the library icons can't be customized. Therefore, this only uses icon "names" and the QML part can build the icon url itself (potentially using custom icons).