### PR TITLE
Command line help fix

### DIFF
--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -75,19 +75,23 @@ bool CmdlineArgs::parse(int argc, char** argv) {
     }
 
     QCommandLineParser parser;
-    parser.setApplicationDescription(QCoreApplication::translate("CmdlineArgs",
-            "Mixxx is an open source DJ software. For more information, "
-            "see " MIXXX_MANUAL_COMMANDLINEOPTIONS_URL
-            "\n."
-            "CamelCase arguments are deprecated and will be removed in 2.5"));
     parser.setSingleDashWordOptionMode(QCommandLineParser::ParseAsLongOptions);
 
+    parser.setApplicationDescription(
+            QCoreApplication::translate("CmdlineArgs",
+                    "Mixxx is an open source DJ software. For more "
+                    "information, see: ") +
+            MIXXX_MANUAL_COMMANDLINEOPTIONS_URL);
+
     // add options
-    const QCommandLineOption fullscreen(QStringList() << "f"
-                                                      << "full-screen"
-                                                      << "fullScreen",
-            QCoreApplication::translate("CmdlineArgs", "Starts Mixxx in full-screen mode"));
-    parser.addOption(fullscreen);
+    const QCommandLineOption fullScreen(
+            QStringList({QStringLiteral("f"), QStringLiteral("full-screen")}),
+            QCoreApplication::translate(
+                    "CmdlineArgs", "Starts Mixxx in full-screen mode"));
+    QCommandLineOption fullScreenDeprecated(QStringLiteral("fullScreen"));
+    fullScreenDeprecated.setFlags(QCommandLineOption::HiddenFromHelp);
+    parser.addOption(fullScreen);
+    parser.addOption(fullScreenDeprecated);
 
     const QCommandLineOption locale(QStringLiteral("locale"),
             QCoreApplication::translate("CmdlineArgs",
@@ -96,37 +100,50 @@ bool CmdlineArgs::parse(int argc, char** argv) {
     parser.addOption(locale);
 
     // An option with a value
-    const QCommandLineOption settingsPath(QStringList() << "settings-path"
-                                                        << "settingsPath",
+    const QCommandLineOption settingsPath(QStringLiteral("settings-path"),
             QCoreApplication::translate("CmdlineArgs",
                     "Top-level directory where Mixxx should look for settings. "
                     "Default is:") +
-                    getSettingsPath().toLocal8Bit().constData(),
+                    getSettingsPath(),
+            QStringLiteral("path"));
+    QCommandLineOption settingsPathDeprecated(
             QStringLiteral("settingsPath"));
+    settingsPathDeprecated.setFlags(QCommandLineOption::HiddenFromHelp);
     parser.addOption(settingsPath);
+    parser.addOption(settingsPathDeprecated);
 
-    QCommandLineOption resourcePath(QStringList() << "resource-path"
-                                                  << "resourcePath",
+    QCommandLineOption resourcePath(QStringLiteral("resource-path"),
             QCoreApplication::translate("CmdlineArgs",
                     "Top-level directory where Mixxx should look for its "
                     "resource files such as MIDI mappings, overriding the "
                     "default installation location."),
+            QStringLiteral("path"));
+    QCommandLineOption resourcePathDeprecated(
             QStringLiteral("resourcePath"));
+    resourcePathDeprecated.setFlags(QCommandLineOption::HiddenFromHelp);
     parser.addOption(resourcePath);
+    parser.addOption(resourcePathDeprecated);
 
-    const QCommandLineOption timelinePath(QStringList() << "timeline-path"
-                                                        << "timelinePath",
-            QCoreApplication::translate("CmdlineArgs", "Path the timeline is written to"));
+    const QCommandLineOption timelinePath(QStringLiteral("timeline-path"),
+            QCoreApplication::translate("CmdlineArgs",
+                    "Path the debug statistics time line is written to"),
+            QStringLiteral("path"));
+    QCommandLineOption timelinePathDeprecated(
+            QStringLiteral("timelinePath"), timelinePath.description());
+    timelinePathDeprecated.setFlags(QCommandLineOption::HiddenFromHelp);
     parser.addOption(timelinePath);
+    parser.addOption(timelinePathDeprecated);
 
-    const QCommandLineOption controllerDebug(QStringList() << "controller-debug"
-                                                           << "controllerDebug"
-                                                           << "midi-debug"
-                                                           << "midiDebug",
+    const QCommandLineOption controllerDebug(QStringLiteral("controller-debug"),
             QCoreApplication::translate("CmdlineArgs",
                     "Causes Mixxx to display/log all of the controller data it "
                     "receives and script functions it loads"));
+    QCommandLineOption controllerDebugDeprecated(
+            QStringList({QStringLiteral("controllerDebug"),
+                    QStringLiteral("midiDebug")}));
+    controllerDebugDeprecated.setFlags(QCommandLineOption::HiddenFromHelp);
     parser.addOption(controllerDebug);
+    parser.addOption(controllerDebugDeprecated);
 
     const QCommandLineOption developer(QStringLiteral("developer"),
             QCoreApplication::translate("CmdlineArgs",
@@ -134,13 +151,15 @@ bool CmdlineArgs::parse(int argc, char** argv) {
                     "performance, and a Developer tools menu."));
     parser.addOption(developer);
 
-    const QCommandLineOption safeMode(QStringList() << "safe-mode"
-                                                    << "safeMode",
+    const QCommandLineOption safeMode(QStringLiteral("safe-mode"),
             QCoreApplication::translate("CmdlineArgs",
                     "Enables safe-mode. Disables OpenGL waveforms, and "
                     "spinning vinyl widgets. Try this option if Mixxx is "
                     "crashing on startup."));
+    QCommandLineOption safeModeDeprecated(QStringLiteral("safeMode"), safeMode.description());
+    safeModeDeprecated.setFlags(QCommandLineOption::HiddenFromHelp);
     parser.addOption(safeMode);
+    parser.addOption(safeModeDeprecated);
 
     const QCommandLineOption color(QStringLiteral("color"),
             QCoreApplication::translate("CmdlineArgs",
@@ -149,8 +168,7 @@ bool CmdlineArgs::parse(int argc, char** argv) {
             QStringLiteral("auto"));
     parser.addOption(color);
 
-    const QCommandLineOption logLevel(QStringList() << "log-level"
-                                                    << "logLevel",
+    const QCommandLineOption logLevel(QStringLiteral("log-level"),
             QCoreApplication::translate("CmdlineArgs",
                     "Sets the verbosity of command line logging.\n"
                     "critical - Critical/Fatal only\n"
@@ -158,26 +176,33 @@ bool CmdlineArgs::parse(int argc, char** argv) {
                     "info     - Above + Informational messages\n"
                     "debug    - Above + Debug/Developer messages\n"
                     "trace    - Above + Profiling messages"),
-            QStringLiteral("logLevel"));
+            QStringLiteral("level"));
+    QCommandLineOption logLevelDeprecated(QStringLiteral("logLevel"), logLevel.description());
+    logLevelDeprecated.setFlags(QCommandLineOption::HiddenFromHelp);
     parser.addOption(logLevel);
+    parser.addOption(logLevelDeprecated);
 
-    const QCommandLineOption logFlushLevel(QStringList() << "log-flush-level"
-                                                         << "logFlushLevel",
+    const QCommandLineOption logFlushLevel(QStringLiteral("log-flush-level"),
             QCoreApplication::translate("CmdlineArgs",
                     "Sets the the logging level at which the log buffer is "
-                    "flushed to mixxx.log. LEVEL is one of the values defined "
-                    "at --logLevel above."),
-            QStringLiteral("logFlushLevel"));
+                    "flushed to mixxx.log. <level> is one of the values defined "
+                    "at --log-level above."),
+            QStringLiteral("level"));
+    QCommandLineOption logFlushLevelDeprecated(
+            QStringLiteral("logFlushLevel"), logLevel.description());
+    logFlushLevelDeprecated.setFlags(QCommandLineOption::HiddenFromHelp);
     parser.addOption(logFlushLevel);
+    parser.addOption(logFlushLevelDeprecated);
 
-#ifdef MIXXX_BUILD_DEBUG
-    QCommandLineOption debugAssertBreak(QStringList() << "debug-assert-break"
-                                                      << "debugAssertBreak",
+    QCommandLineOption debugAssertBreak(QStringLiteral("debug-assert-break"),
             QCoreApplication::translate("CmdlineArgs",
                     "Breaks (SIGINT) Mixxx, if a DEBUG_ASSERT evaluates to "
                     "false. Under a debugger you can continue afterwards."));
+    QCommandLineOption debugAssertBreakDeprecated(
+            QStringLiteral("debugAssertBreak"), debugAssertBreak.description());
+    debugAssertBreakDeprecated.setFlags(QCommandLineOption::HiddenFromHelp);
     parser.addOption(debugAssertBreak);
-#endif
+    parser.addOption(debugAssertBreakDeprecated);
 
     const QCommandLineOption helpOption = parser.addHelpOption();
     const QCommandLineOption versionOption = parser.addVersionOption();
@@ -208,7 +233,7 @@ bool CmdlineArgs::parse(int argc, char** argv) {
         return false;
     }
 
-    m_startInFullscreen = parser.isSet(fullscreen);
+    m_startInFullscreen = parser.isSet(fullScreen);
 
     if (parser.isSet(locale)) {
         m_locale = parser.value(locale);
@@ -220,29 +245,42 @@ bool CmdlineArgs::parse(int argc, char** argv) {
             m_settingsPath.append("/");
         }
         m_settingsPathSet = true;
+    } else if (parser.isSet(settingsPathDeprecated)) {
+        m_settingsPath = parser.value(settingsPathDeprecated);
+        if (!m_settingsPath.endsWith("/")) {
+            m_settingsPath.append("/");
+        }
+        m_settingsPathSet = true;
     }
 
     if (parser.isSet(resourcePath)) {
         m_resourcePath = parser.value(resourcePath);
+    } else if (parser.isSet(resourcePathDeprecated)) {
+        m_resourcePath = parser.value(resourcePathDeprecated);
     }
 
     if (parser.isSet(timelinePath)) {
         m_timelinePath = parser.value(timelinePath);
+    } else if (parser.isSet(timelinePathDeprecated)) {
+        m_timelinePath = parser.value(timelinePathDeprecated);
     }
 
-    m_midiDebug = parser.isSet(controllerDebug);
+    m_midiDebug = parser.isSet(controllerDebug) || parser.isSet(controllerDebugDeprecated);
     m_developer = parser.isSet(developer);
-    m_safeMode = parser.isSet(safeMode);
-
-#ifdef MIXXX_BUILD_DEBUG
-    m_debugAssertBreak = parser.isSet(debugAssertBreak);
-#endif
+    m_safeMode = parser.isSet(safeMode) || parser.isSet(safeModeDeprecated);
+    m_debugAssertBreak = parser.isSet(debugAssertBreak) || parser.isSet(debugAssertBreakDeprecated);
 
     m_musicFiles = parser.positionalArguments();
 
     if (parser.isSet(logLevel)) {
         if (!parseLogLevel(parser.value(logLevel), &m_logLevel)) {
             fputs("\nlog-level wasn't 'trace', 'debug', 'info', 'warning', or 'critical'!\n"
+                  "Mixxx will only print warnings and critical messages to the console.\n",
+                    stdout);
+        }
+    } else if (parser.isSet(logLevelDeprecated)) {
+        if (!parseLogLevel(parser.value(logLevelDeprecated), &m_logLevel)) {
+            fputs("\nlogLevel wasn't 'trace', 'debug', 'info', 'warning', or 'critical'!\n"
                   "Mixxx will only print warnings and critical messages to the console.\n",
                     stdout);
         }
@@ -255,6 +293,12 @@ bool CmdlineArgs::parse(int argc, char** argv) {
     if (parser.isSet(logFlushLevel)) {
         if (!parseLogLevel(parser.value(logFlushLevel), &m_logFlushLevel)) {
             fputs("\nlog-flush-level wasn't 'trace', 'debug', 'info', 'warning', or 'critical'!\n"
+                  "Mixxx will only flush output after a critical message.\n",
+                    stdout);
+        }
+    } else if (parser.isSet(logFlushLevelDeprecated)) {
+        if (!parseLogLevel(parser.value(logFlushLevelDeprecated), &m_logFlushLevel)) {
+            fputs("\nlogFlushLevel wasn't 'trace', 'debug', 'info', 'warning', or 'critical'!\n"
                   "Mixxx will only flush output after a critical message.\n",
                     stdout);
         }
@@ -281,7 +325,7 @@ bool CmdlineArgs::parse(int argc, char** argv) {
     } else if (parser.value(color).compare(QLatin1String("never"), Qt::CaseInsensitive) == 0) {
         m_useColors = false;
     } else {
-        qWarning() << "Unknown setting for color, ignoring";
+        fputs("Unknown argument for for color.\n", stdout);
     }
 
     return true;

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -75,7 +75,7 @@ bool CmdlineArgs::parse(int argc, char** argv) {
     }
 
     QCommandLineParser parser;
-    parser.setApplicationDescription(QCoreApplication::translate("main",
+    parser.setApplicationDescription(QCoreApplication::translate("CmdlineArgs",
             "Mixxx is an open source DJ software. For more information, "
             "see " MIXXX_MANUAL_COMMANDLINEOPTIONS_URL
             "\n."
@@ -86,11 +86,11 @@ bool CmdlineArgs::parse(int argc, char** argv) {
     const QCommandLineOption fullscreen(QStringList() << "f"
                                                       << "full-screen"
                                                       << "fullScreen",
-            QCoreApplication::translate("main", "Starts Mixxx in full-screen mode"));
+            QCoreApplication::translate("CmdlineArgs", "Starts Mixxx in full-screen mode"));
     parser.addOption(fullscreen);
 
     const QCommandLineOption locale(QStringLiteral("locale"),
-            QCoreApplication::translate("main",
+            QCoreApplication::translate("CmdlineArgs",
                     "Use a custom locale for loading translations. (e.g "
                     "'fr')"));
     parser.addOption(locale);
@@ -98,7 +98,7 @@ bool CmdlineArgs::parse(int argc, char** argv) {
     // An option with a value
     const QCommandLineOption settingsPath(QStringList() << "settings-path"
                                                         << "settingsPath",
-            QCoreApplication::translate("main",
+            QCoreApplication::translate("CmdlineArgs",
                     "Top-level directory where Mixxx should look for settings. "
                     "Default is:") +
                     getSettingsPath().toLocal8Bit().constData(),
@@ -107,7 +107,7 @@ bool CmdlineArgs::parse(int argc, char** argv) {
 
     QCommandLineOption resourcePath(QStringList() << "resource-path"
                                                   << "resourcePath",
-            QCoreApplication::translate("main",
+            QCoreApplication::translate("CmdlineArgs",
                     "Top-level directory where Mixxx should look for its "
                     "resource files such as MIDI mappings, overriding the "
                     "default installation location."),
@@ -116,34 +116,34 @@ bool CmdlineArgs::parse(int argc, char** argv) {
 
     const QCommandLineOption timelinePath(QStringList() << "timeline-path"
                                                         << "timelinePath",
-            QCoreApplication::translate("main", "Path the timeline is written to"));
+            QCoreApplication::translate("CmdlineArgs", "Path the timeline is written to"));
     parser.addOption(timelinePath);
 
     const QCommandLineOption controllerDebug(QStringList() << "controller-debug"
                                                            << "controllerDebug"
                                                            << "midi-debug"
                                                            << "midiDebug",
-            QCoreApplication::translate("main",
+            QCoreApplication::translate("CmdlineArgs",
                     "Causes Mixxx to display/log all of the controller data it "
                     "receives and script functions it loads"));
     parser.addOption(controllerDebug);
 
     const QCommandLineOption developer(QStringLiteral("developer"),
-            QCoreApplication::translate("main",
+            QCoreApplication::translate("CmdlineArgs",
                     "Enables developer-mode. Includes extra log info, stats on "
                     "performance, and a Developer tools menu."));
     parser.addOption(developer);
 
     const QCommandLineOption safeMode(QStringList() << "safe-mode"
                                                     << "safeMode",
-            QCoreApplication::translate("main",
+            QCoreApplication::translate("CmdlineArgs",
                     "Enables safe-mode. Disables OpenGL waveforms, and "
                     "spinning vinyl widgets. Try this option if Mixxx is "
                     "crashing on startup."));
     parser.addOption(safeMode);
 
     const QCommandLineOption color(QStringLiteral("color"),
-            QCoreApplication::translate("main",
+            QCoreApplication::translate("CmdlineArgs",
                     "[auto|always|never] Use colors on the console output."),
             QStringLiteral("color"),
             QStringLiteral("auto"));
@@ -151,7 +151,7 @@ bool CmdlineArgs::parse(int argc, char** argv) {
 
     const QCommandLineOption logLevel(QStringList() << "log-level"
                                                     << "logLevel",
-            QCoreApplication::translate("main",
+            QCoreApplication::translate("CmdlineArgs",
                     "Sets the verbosity of command line logging.\n"
                     "critical - Critical/Fatal only\n"
                     "warning  - Above + Warnings\n"
@@ -163,7 +163,7 @@ bool CmdlineArgs::parse(int argc, char** argv) {
 
     const QCommandLineOption logFlushLevel(QStringList() << "log-flush-level"
                                                          << "logFlushLevel",
-            QCoreApplication::translate("main",
+            QCoreApplication::translate("CmdlineArgs",
                     "Sets the the logging level at which the log buffer is "
                     "flushed to mixxx.log. LEVEL is one of the values defined "
                     "at --logLevel above."),
@@ -173,7 +173,7 @@ bool CmdlineArgs::parse(int argc, char** argv) {
 #ifdef MIXXX_BUILD_DEBUG
     QCommandLineOption debugAssertBreak(QStringList() << "debug-assert-break"
                                                       << "debugAssertBreak",
-            QCoreApplication::translate("main",
+            QCoreApplication::translate("CmdlineArgs",
                     "Breaks (SIGINT) Mixxx, if a DEBUG_ASSERT evaluates to "
                     "false. Under a debugger you can continue afterwards."));
     parser.addOption(debugAssertBreak);
@@ -183,7 +183,7 @@ bool CmdlineArgs::parse(int argc, char** argv) {
     const QCommandLineOption versionOption = parser.addVersionOption();
 
     parser.addPositionalArgument(QStringLiteral("file"),
-            QCoreApplication::translate("main",
+            QCoreApplication::translate("CmdlineArgs",
                     "Load the specified music file(s) at start-up. Each file "
                     "you specify will be loaded into the next virtual deck."));
 

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -63,7 +63,11 @@ bool parseLogLevel(
 }
 } // namespace
 
-bool CmdlineArgs::parse(int& argc, char** argv) {
+bool CmdlineArgs::parse(int argc, char** argv) {
+    if (argc == 1) {
+        // We have got the binary name only, noting to do
+        return true;
+    }
     QStringList arguments;
     arguments.reserve(argc);
     for (int a = 0; a < argc; ++a) {

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -65,7 +65,7 @@ bool parseLogLevel(
 
 bool CmdlineArgs::parse(int argc, char** argv) {
     if (argc == 1) {
-        // We have got the binary name only, noting to do
+        // Mixxx was run with the binary name only, nothing to do
         return true;
     }
     QStringList arguments;

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -21,7 +21,7 @@ class CmdlineArgs final {
         return cla;
     }
 
-    bool parse(int& argc, char** argv);
+    bool parse(int argc, char** argv);
 
     const QList<QString>& getMusicFiles() const { return m_musicFiles; }
     bool getStartInFullscreen() const { return m_startInFullscreen; }


### PR DESCRIPTION
This fixes the command line output: 

Now:
```
Usage: ./mixxx [options] file
Mixxx is an open source DJ software. For more information, see: https://manual.mixxx.org/2.4/chapters/appendix/commandline_dev_tools.html

Options:
  -f, --full-screen          Starts Mixxx in full-screen mode
  --locale                   Use a custom locale for loading translations. (e.g
                             'fr')
  --settings-path <path>     Top-level directory where Mixxx should look for
                             settings. Default is:/home/sperry/.mixxx/
  --resource-path <path>     Top-level directory where Mixxx should look for
                             its resource files such as MIDI mappings,
                             overriding the default installation location.
  --timeline-path <path>     Path the debug statistics time line is written to
  --controller-debug         Causes Mixxx to display/log all of the controller
                             data it receives and script functions it loads
  --developer                Enables developer-mode. Includes extra log info,
                             stats on performance, and a Developer tools menu.
  --safe-mode                Enables safe-mode. Disables OpenGL waveforms, and
                             spinning vinyl widgets. Try this option if Mixxx is
                             crashing on startup.
  --color <color>            [auto|always|never] Use colors on the console
                             output.
  --log-level <level>        Sets the verbosity of command line logging.
                             critical - Critical/Fatal only
                             warning  - Above + Warnings
                             info     - Above + Informational messages
                             debug    - Above + Debug/Developer messages
                             trace    - Above + Profiling messages
  --log-flush-level <level>  Sets the the logging level at which the log buffer
                             is flushed to mixxx.log. <level> is one of the
                             values defined at --log-level above.
  --debug-assert-break       Breaks (SIGINT) Mixxx, if a DEBUG_ASSERT evaluates
                             to false. Under a debugger you can continue
                             afterwards.
  -h, --help                 Displays this help.
  -v, --version              Displays version information.

Arguments:
  file                       Load the specified music file(s) at start-up. Each
                             file you specify will be loaded into the next
                             virtual deck.
```
Before:
```
Usage: ./mixxx [options] file
Mixxx is an open source DJ software. For more information, see https://manual.mixxx.org/2.4/chapters/appendix/commandline_dev_tools.html
.CamelCase arguments are deprecated and will be removed in 2.5

Options:
  -f, --full-screen, --fullScreen                                   Starts
                                                                    Mixxx in
                                                                    full-screen
                                                                    mode
  --locale                                                          Use a
                                                                    custom
                                                                    locale for
                                                                    loading
                                                                    translations
                                                                    . (e.g 'fr')
  --settings-path, --settingsPath <settingsPath>                    Top-level
                                                                    directory
                                                                    where Mixxx
                                                                    should look
                                                                    for
                                                                    settings.
                                                                    Default
                                                                    is:/home/spe
                                                                    rry/.mixxx/
  --resource-path, --resourcePath <resourcePath>                    Top-level
                                                                    directory
                                                                    where Mixxx
                                                                    should look
                                                                    for its
                                                                    resource
                                                                    files such
                                                                    as MIDI
                                                                    mappings,
                                                                    overriding
                                                                    the default
                                                                    installation
                                                                    location.
  --timeline-path, --timelinePath                                   Path the
                                                                    timeline is
                                                                    written to
  --controller-debug, --controllerDebug, --midi-debug, --midiDebug  Causes
                                                                    Mixxx to
                                                                    display/log
                                                                    all of the
                                                                    controller
                                                                    data it
                                                                    receives and
                                                                    script
                                                                    functions it
                                                                    loads
  --developer                                                       Enables
                                                                    developer-mo
                                                                    de. Includes
                                                                    extra log
                                                                    info, stats
                                                                    on
                                                                    performance,
                                                                    and a
                                                                    Developer
                                                                    tools menu.
  --safe-mode, --safeMode                                           Enables
                                                                    safe-mode.
                                                                    Disables
                                                                    OpenGL
                                                                    waveforms,
                                                                    and spinning
                                                                    vinyl
                                                                    widgets. Try
                                                                    this option
                                                                    if Mixxx is
                                                                    crashing on
                                                                    startup.
  --color <color>                                                   [auto|alway
                                                                    s|never] Use
                                                                    colors on
                                                                    the console
                                                                    output.
  --log-level, --logLevel <logLevel>                                Sets the
                                                                    verbosity of
                                                                    command line
                                                                    logging.
                                                                    critical -
                                                                    Critical/Fat
                                                                    al only
                                                                    warning  -
                                                                    Above +
                                                                    Warnings
                                                                    info     -
                                                                    Above +
                                                                    Informationa
                                                                    l messages
                                                                    debug    -
                                                                    Above +
                                                                    Debug/Develo
                                                                    per messages
                                                                    trace    -
                                                                    Above +
                                                                    Profiling
                                                                    messages
  --log-flush-level, --logFlushLevel <logFlushLevel>                Sets the
                                                                    the logging
                                                                    level at
                                                                    which the
                                                                    log buffer
                                                                    is flushed
                                                                    to
                                                                    mixxx.log.
                                                                    LEVEL is one
                                                                    of the
                                                                    values
                                                                    defined at
                                                                    --logLevel
                                                                    above.
  --debug-assert-break, --debugAssertBreak                          Breaks
                                                                    (SIGINT)
                                                                    Mixxx, if a
                                                                    DEBUG_ASSERT
                                                                    evaluates to
                                                                    false. Under
                                                                    a debugger
                                                                    you can
                                                                    continue
                                                                    afterwards.
  -h, --help                                                        Displays
                                                                    this help.
  -v, --version                                                     Displays
                                                                    version
                                                                    information.

Arguments:
  file                                                              Load the
                                                                    specified
                                                                    music
                                                                    file(s) at
                                                                    start-up.
                                                                    Each file
                                                                    you specify
                                                                    will be
                                                                    loaded into
                                                                    the next
                                                                    virtual
                                                                    deck.
```

