### PR TITLE
Basic QML Sidebar placeholder

### DIFF
--- a/res/skins/QMLDemo/Library.qml
+++ b/res/skins/QMLDemo/Library.qml
@@ -1,6 +1,7 @@
 import "." as Skin
 import Mixxx 0.1 as Mixxx
 import QtQuick 2.12
+import QtQuick.Controls 1.4
 import "Theme"
 
 Item {
@@ -8,8 +9,40 @@ Item {
         color: Theme.deckBackgroundColor
         anchors.fill: parent
 
+        TreeView {
+            id: sidebar
+
+            anchors.top: parent.top
+            anchors.left: parent.left
+            anchors.bottom: parent.bottom
+            anchors.margins: 10
+            width: 250
+            model: Mixxx.Library.getSidebarModel()
+
+            TableViewColumn {
+                title: "Icon"
+                role: "iconName"
+                width: 50
+
+                delegate: Image {
+                    fillMode: Image.PreserveAspectFit
+                    source: styleData.value ? "qrc:///images/library/ic_library_" + styleData.value + ".svg" : ""
+                }
+
+            }
+
+            TableViewColumn {
+                title: "Title"
+                role: "display"
+            }
+
+        }
+
         ListView {
-            anchors.fill: parent
+            anchors.top: parent.top
+            anchors.left: sidebar.right
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
             anchors.margins: 10
             clip: true
             model: Mixxx.Library.model

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -76,6 +76,11 @@ class Library: public QObject {
     /// Needed for exposing models to QML
     LibraryTableModel* trackTableModel() const;
 
+    /// Needed for exposing sidebar to QML
+    SidebarModel* sidebarModel() const {
+        return m_pSidebarModel.get();
+    }
+
     int getTrackTableRowHeight() const {
         return m_iTrackTableRowHeight;
     }

--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -18,6 +18,13 @@ namespace {
 // been chosen as a compromise between usability and responsiveness.
 const int kPressedUntilClickedTimeoutMillis = 300;
 
+const QHash<int, QByteArray> kRoleNames = {
+        // Only roles that are useful in QML are added here.
+        {Qt::DisplayRole, "display"},
+        {Qt::ToolTipRole, "tooltip"},
+        {SidebarModel::IconNameRole, "iconName"},
+};
+
 } // anonymous namespace
 
 SidebarModel::SidebarModel(
@@ -268,6 +275,10 @@ QVariant SidebarModel::data(const QModelIndex& index, int role) const {
             return QVariant();
         }
     }
+}
+
+QHash<int, QByteArray> SidebarModel::roleNames() const {
+    return kRoleNames;
 }
 
 void SidebarModel::startPressedUntilClickedTimer(const QModelIndex& pressedIndex) {

--- a/src/library/sidebarmodel.h
+++ b/src/library/sidebarmodel.h
@@ -38,6 +38,7 @@ class SidebarModel : public QAbstractItemModel {
     int columnCount(const QModelIndex& parent = QModelIndex()) const override;
     QVariant data(const QModelIndex& index,
                   int role = Qt::DisplayRole) const override;
+    QHash<int, QByteArray> roleNames() const override;
     bool dropAccept(const QModelIndex& index, const QList<QUrl>& urls, QObject* pSource);
     bool dragMoveAccept(const QModelIndex& index, const QUrl& url);
     bool hasChildren(const QModelIndex& parent = QModelIndex()) const override;

--- a/src/skin/qml/qmllibraryproxy.cpp
+++ b/src/skin/qml/qmllibraryproxy.cpp
@@ -3,6 +3,7 @@
 #include <QAbstractItemModel>
 
 #include "library/library.h"
+#include "library/sidebarmodel.h"
 
 namespace mixxx {
 namespace skin {
@@ -12,6 +13,10 @@ QmlLibraryProxy::QmlLibraryProxy(std::shared_ptr<Library> pLibrary, QObject* par
         : QObject(parent),
           m_pLibrary(pLibrary),
           m_pModel(make_parented<QmlLibraryTrackListModel>(m_pLibrary->trackTableModel(), this)) {
+}
+
+QAbstractItemModel* QmlLibraryProxy::getSidebarModel() {
+    return m_pLibrary->sidebarModel();
 }
 
 } // namespace qml

--- a/src/skin/qml/qmllibraryproxy.h
+++ b/src/skin/qml/qmllibraryproxy.h
@@ -6,6 +6,9 @@
 #include "util/parented_ptr.h"
 
 class Library;
+class SidebarModel;
+
+QT_FORWARD_DECLARE_CLASS(QAbstractItemModel);
 
 namespace mixxx {
 namespace skin {
@@ -19,6 +22,8 @@ class QmlLibraryProxy : public QObject {
 
   public:
     explicit QmlLibraryProxy(std::shared_ptr<Library> pLibrary, QObject* parent = nullptr);
+
+    Q_INVOKABLE QAbstractItemModel* getSidebarModel();
 
   private:
     std::shared_ptr<Library> m_pLibrary;


### PR DESCRIPTION
Follow-up to #4034.

This now exposes the SidebarModel to QML and adds an actual treeview to the QML skin.
Top level items are displayed, including icons.

For now, those items are not clickable (nothing happens) and the lazy loading mechanic (e.g. browse feature) is not working. For stuff like that to work, some more serious refactoring is needed. The same goes for child item icons.

Unfortunately, Qt Quick Control 2 does not provide a TreeView (they made that a [premium feature](https://marketplace.qt.io/products/treeview)), so this still uses the old Qt Quick Controls 1 TreeView component. We may evaluate [existing solutions](https://github.com/diracsbracket/qmltreeview2) or [roll our own](https://www.qtdeveloperdays.com/sites/default/files/north-america/QtQuickTreeView.pdf) in the future.