### PR TITLE
lp1933853 Rekordbox: Handle exception when parsing corrupt .pdb files

### DIFF
--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -1532,7 +1532,13 @@ void RekordboxFeature::onTracksFound() {
     qDebug() << "onTracksFound";
     m_childModel.triggerRepaint();
 
-    QString devicePlaylist = m_tracksFuture.result();
+    QString devicePlaylist;
+    try {
+        devicePlaylist = m_tracksFuture.result();
+    } catch (const std::exception& e) {
+        qWarning() << "Failed to load Rekordbox database:" << e.what();
+        return;
+    }
 
     qDebug() << "Show Rekordbox Device Playlist: " << devicePlaylist;
 


### PR DESCRIPTION
Though std::exception::what() doesn't return a meaningful message.

warning [Main] Failed to load Rekordbox database: std::exception