### PR TITLE
Use mixxx::Bpm for remaining beats methods (Pt. 3)

### DIFF
--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -143,7 +143,7 @@ bool AnalyzerBeats::shouldAnalyze(TrackPointer pTrack) const {
     if (!pBeats) {
         return true;
     }
-    if (!pBeats->getBpm().hasValue()) {
+    if (!pBeats->getBpm().isValid()) {
         // Tracks with an invalid bpm <= 0 should be re-analyzed,
         // independent of the preference settings. We expect that
         // all tracks have a bpm > 0 when analyzed. Users that want

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -174,7 +174,7 @@ void BpmControl::adjustBeatsBpm(double deltaBpm) {
     const mixxx::BeatsPointer pBeats = pTrack->getBeats();
     if (pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM)) {
         mixxx::Bpm bpm = pBeats->getBpm();
-        const auto centerBpm = mixxx::Bpm(math_max(kBpmAdjustMin, bpm.getValue() + deltaBpm));
+        const auto centerBpm = mixxx::Bpm(math_max(kBpmAdjustMin, bpm.value() + deltaBpm));
         mixxx::Bpm adjustedBpm = BeatUtils::roundBpmWithinRange(
                 centerBpm - kBpmAdjustStep / 2, centerBpm, centerBpm + kBpmAdjustStep / 2);
         pTrack->trySetBeats(pBeats->setBpm(adjustedBpm));
@@ -1071,7 +1071,7 @@ mixxx::Bpm BpmControl::updateLocalBpm() {
     if (pBeats) {
         localBpm = pBeats->getBpmAroundPosition(
                 getSampleOfTrack().current, kLocalBpmSpan);
-        if (!localBpm.hasValue()) {
+        if (!localBpm.isValid()) {
             localBpm = pBeats->getBpm();
         }
     }
@@ -1081,8 +1081,8 @@ mixxx::Bpm BpmControl::updateLocalBpm() {
         }
         // FIXME: Should this really update the engine bpm if it's invalid?
         double localBpmValue = mixxx::Bpm::kValueUndefined;
-        if (localBpm.hasValue()) {
-            localBpmValue = localBpm.getValue();
+        if (localBpm.isValid()) {
+            localBpmValue = localBpm.value();
         }
         m_pLocalBpm->set(localBpmValue);
         slotUpdateEngineBpm();

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1299,8 +1299,8 @@ void EngineBuffer::postProcess(const int iBufferSize) {
     double beatDistance = m_pBpmControl->updateBeatDistance();
     // FIXME: Double check if calling setLocalBpm with an invalid value is correct and intended.
     double localBpmValue = mixxx::Bpm::kValueUndefined;
-    if (localBpm.hasValue()) {
-        localBpmValue = localBpm.getValue();
+    if (localBpm.isValid()) {
+        localBpmValue = localBpm.value();
     }
     m_pSyncControl->setLocalBpm(localBpmValue);
     m_pSyncControl->updateAudible();

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -516,7 +516,7 @@ void SyncControl::notifySeek(double dNewPlaypos) {
 double SyncControl::fileBpm() const {
     mixxx::BeatsPointer pBeats = m_pBeats;
     if (pBeats) {
-        return pBeats->getBpm().getValue();
+        return pBeats->getBpm().value();
     }
     return mixxx::Bpm::kValueUndefined;
 }

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -664,11 +664,11 @@ QVariant BaseTrackTableModel::roleValue(
                     bpm = mixxx::Bpm(bpmValue);
                 }
             }
-            if (bpm.hasValue()) {
+            if (bpm.isValid()) {
                 if (role == Qt::ToolTipRole || role == kDataExportRole) {
-                    return QString::number(bpm.getValue(), 'f', 4);
+                    return QString::number(bpm.value(), 'f', 4);
                 } else {
-                    return QString::number(bpm.getValue(), 'f', 1);
+                    return QString::number(bpm.value(), 'f', 1);
                 }
             } else {
                 return QChar('-');
@@ -782,7 +782,7 @@ QVariant BaseTrackTableModel::roleValue(
         case ColumnCache::COLUMN_LIBRARYTABLE_BPM: {
             bool ok;
             const auto bpmValue = rawValue.toDouble(&ok);
-            return ok ? bpmValue : mixxx::Bpm().getValue();
+            return ok ? bpmValue : mixxx::Bpm().value();
         }
         case ColumnCache::COLUMN_LIBRARYTABLE_TIMESPLAYED:
             return index.sibling(

--- a/src/library/browse/browsethread.cpp
+++ b/src/library/browse/browsethread.cpp
@@ -227,9 +227,7 @@ void BrowseThread::populateModel() {
             item = new QStandardItem(trackMetadata.getTrackInfo().getBpmText());
             item->setToolTip(item->text());
             const mixxx::Bpm bpm = trackMetadata.getTrackInfo().getBpm();
-            item->setData(bpm.hasValue() ? bpm.getValue()
-                                         : mixxx::Bpm::kValueUndefined,
-                    Qt::UserRole);
+            item->setData(bpm.isValid() ? bpm.value() : mixxx::Bpm::kValueUndefined, Qt::UserRole);
             row_data.insert(COLUMN_BPM, item);
 
             item = new QStandardItem(trackMetadata.getTrackInfo().getKey());

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -588,7 +588,7 @@ void bindTrackLibraryValues(
         beatsSubVersion = pBeats->getSubVersion();
         bpm = pBeats->getBpm();
     }
-    const double bpmValue = bpm.hasValue() ? bpm.getValue() : mixxx::Bpm::kValueUndefined;
+    const double bpmValue = bpm.isValid() ? bpm.value() : mixxx::Bpm::kValueUndefined;
     pTrackLibraryQuery->bindValue(":bpm", bpmValue);
     pTrackLibraryQuery->bindValue(":beats_version", beatsVersion);
     pTrackLibraryQuery->bindValue(":beats_sub_version", beatsSubVersion);

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -369,7 +369,7 @@ void DlgTrackInfo::updateTrackMetadataFields() {
 void DlgTrackInfo::reloadTrackBeats(const Track& track) {
     m_pBeatsClone = track.getBeats();
     if (m_pBeatsClone) {
-        spinBpm->setValue(m_pBeatsClone->getBpm().getValue());
+        spinBpm->setValue(m_pBeatsClone->getBpm().value());
     } else {
         spinBpm->setValue(0.0);
     }
@@ -521,42 +521,42 @@ void DlgTrackInfo::slotBpmDouble() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::DOUBLE);
     // read back the actual value
     mixxx::Bpm newValue = m_pBeatsClone->getBpm();
-    spinBpm->setValue(newValue.getValue());
+    spinBpm->setValue(newValue.value());
 }
 
 void DlgTrackInfo::slotBpmHalve() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::HALVE);
     // read back the actual value
     const mixxx::Bpm newValue = m_pBeatsClone->getBpm();
-    spinBpm->setValue(newValue.getValue());
+    spinBpm->setValue(newValue.value());
 }
 
 void DlgTrackInfo::slotBpmTwoThirds() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::TWOTHIRDS);
     // read back the actual value
     const mixxx::Bpm newValue = m_pBeatsClone->getBpm();
-    spinBpm->setValue(newValue.getValue());
+    spinBpm->setValue(newValue.value());
 }
 
 void DlgTrackInfo::slotBpmThreeFourth() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::THREEFOURTHS);
     // read back the actual value
     const mixxx::Bpm newValue = m_pBeatsClone->getBpm();
-    spinBpm->setValue(newValue.getValue());
+    spinBpm->setValue(newValue.value());
 }
 
 void DlgTrackInfo::slotBpmFourThirds() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::FOURTHIRDS);
     // read back the actual value
     const mixxx::Bpm newValue = m_pBeatsClone->getBpm();
-    spinBpm->setValue(newValue.getValue());
+    spinBpm->setValue(newValue.value());
 }
 
 void DlgTrackInfo::slotBpmThreeHalves() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::THREEHALVES);
     // read back the actual value
     const mixxx::Bpm newValue = m_pBeatsClone->getBpm();
-    spinBpm->setValue(newValue.getValue());
+    spinBpm->setValue(newValue.value());
 }
 
 void DlgTrackInfo::slotBpmClear() {
@@ -607,13 +607,13 @@ void DlgTrackInfo::slotBpmTap(double averageLength, int numSamples) {
             averageBpm + kBpmTabRounding);
     if (averageBpm != m_lastTapedBpm) {
         m_lastTapedBpm = averageBpm;
-        spinBpm->setValue(averageBpm.getValue());
+        spinBpm->setValue(averageBpm.value());
     }
 }
 
 void DlgTrackInfo::slotSpinBpmValueChanged(double value) {
     const auto bpm = mixxx::Bpm(value);
-    if (!bpm.hasValue()) {
+    if (!bpm.isValid()) {
         m_pBeatsClone.clear();
         return;
     }
@@ -637,7 +637,7 @@ void DlgTrackInfo::slotSpinBpmValueChanged(double value) {
 
     // read back the actual value
     const mixxx::Bpm newValue = m_pBeatsClone->getBpm();
-    spinBpm->setValue(newValue.getValue());
+    spinBpm->setValue(newValue.value());
 }
 
 mixxx::UpdateResult DlgTrackInfo::updateKeyText() {

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -27,31 +27,31 @@ TEST(BeatGridTest, Scale) {
     TrackPointer pTrack = newTrack(sampleRate);
 
     constexpr mixxx::Bpm bpm(60.0);
-    pTrack->trySetBpm(bpm.getValue());
+    pTrack->trySetBpm(bpm.value());
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
             QString(),
             mixxx::Bpm(bpm),
             mixxx::audio::kStartFramePos);
 
-    EXPECT_DOUBLE_EQ(bpm.getValue(), pGrid->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value(), pGrid->getBpm().value());
     pGrid = pGrid->scale(Beats::DOUBLE);
-    EXPECT_DOUBLE_EQ(2 * bpm.getValue(), pGrid->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(2 * bpm.value(), pGrid->getBpm().value());
 
     pGrid = pGrid->scale(Beats::HALVE);
-    EXPECT_DOUBLE_EQ(bpm.getValue(), pGrid->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value(), pGrid->getBpm().value());
 
     pGrid = pGrid->scale(Beats::TWOTHIRDS);
-    EXPECT_DOUBLE_EQ(bpm.getValue() * 2 / 3, pGrid->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value() * 2 / 3, pGrid->getBpm().value());
 
     pGrid = pGrid->scale(Beats::THREEHALVES);
-    EXPECT_DOUBLE_EQ(bpm.getValue(), pGrid->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value(), pGrid->getBpm().value());
 
     pGrid = pGrid->scale(Beats::THREEFOURTHS);
-    EXPECT_DOUBLE_EQ(bpm.getValue() * 3 / 4, pGrid->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value() * 3 / 4, pGrid->getBpm().value());
 
     pGrid = pGrid->scale(Beats::FOURTHIRDS);
-    EXPECT_DOUBLE_EQ(bpm.getValue(), pGrid->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value(), pGrid->getBpm().value());
 }
 
 TEST(BeatGridTest, TestNthBeatWhenOnBeat) {
@@ -190,8 +190,8 @@ TEST(BeatGridTest, TestNthBeatWhenNotOnBeat) {
 
     const auto bpm = mixxx::Bpm(60.1);
     const int kFrameSize = 2;
-    pTrack->trySetBpm(bpm.getValue());
-    double beatLength = (60.0 * sampleRate / bpm.getValue()) * kFrameSize;
+    pTrack->trySetBpm(bpm.value());
+    double beatLength = (60.0 * sampleRate / bpm.value()) * kFrameSize;
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
             QString(),
@@ -230,11 +230,11 @@ TEST(BeatGridTest, FromMetadata) {
     TrackPointer pTrack = newTrack(sampleRate);
 
     constexpr mixxx::Bpm bpm(60.1);
-    ASSERT_TRUE(pTrack->trySetBpm(bpm.getValue()));
-    EXPECT_DOUBLE_EQ(pTrack->getBpm(), bpm.getValue());
+    ASSERT_TRUE(pTrack->trySetBpm(bpm.value()));
+    EXPECT_DOUBLE_EQ(pTrack->getBpm(), bpm.value());
 
     auto pBeats = pTrack->getBeats();
-    EXPECT_DOUBLE_EQ(pBeats->getBpm().getValue(), bpm.getValue());
+    EXPECT_DOUBLE_EQ(pBeats->getBpm().value(), bpm.value());
 
     // Invalid bpm resets the bpm
     ASSERT_TRUE(pTrack->trySetBpm(-60.1));

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -24,7 +24,7 @@ class BeatMapTest : public testing::Test {
     }
 
     mixxx::audio::FrameDiff_t getBeatLengthFrames(mixxx::Bpm bpm) {
-        return (60.0 * m_iSampleRate / bpm.getValue());
+        return (60.0 * m_iSampleRate / bpm.value());
     }
 
     double getBeatLengthSamples(mixxx::Bpm bpm) {
@@ -48,7 +48,7 @@ class BeatMapTest : public testing::Test {
 
 TEST_F(BeatMapTest, Scale) {
     constexpr mixxx::Bpm bpm(60.0);
-    m_pTrack->trySetBpm(bpm.getValue());
+    m_pTrack->trySetBpm(bpm.value());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
     const int numBeats = 100;
@@ -57,29 +57,29 @@ TEST_F(BeatMapTest, Scale) {
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
     auto pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
 
-    EXPECT_DOUBLE_EQ(bpm.getValue(), pMap->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value(), pMap->getBpm().value());
     pMap = pMap->scale(Beats::DOUBLE);
-    EXPECT_DOUBLE_EQ(2 * bpm.getValue(), pMap->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(2 * bpm.value(), pMap->getBpm().value());
 
     pMap = pMap->scale(Beats::HALVE);
-    EXPECT_DOUBLE_EQ(bpm.getValue(), pMap->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value(), pMap->getBpm().value());
 
     pMap = pMap->scale(Beats::TWOTHIRDS);
-    EXPECT_DOUBLE_EQ(bpm.getValue() * 2 / 3, pMap->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value() * 2 / 3, pMap->getBpm().value());
 
     pMap = pMap->scale(Beats::THREEHALVES);
-    EXPECT_DOUBLE_EQ(bpm.getValue(), pMap->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value(), pMap->getBpm().value());
 
     pMap = pMap->scale(Beats::THREEFOURTHS);
-    EXPECT_DOUBLE_EQ(bpm.getValue() * 3 / 4, pMap->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value() * 3 / 4, pMap->getBpm().value());
 
     pMap = pMap->scale(Beats::FOURTHIRDS);
-    EXPECT_DOUBLE_EQ(bpm.getValue(), pMap->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value(), pMap->getBpm().value());
 }
 
 TEST_F(BeatMapTest, TestNthBeat) {
     constexpr mixxx::Bpm bpm(60.0);
-    m_pTrack->trySetBpm(bpm.getValue());
+    m_pTrack->trySetBpm(bpm.value());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -112,7 +112,7 @@ TEST_F(BeatMapTest, TestNthBeat) {
 
 TEST_F(BeatMapTest, TestNthBeatWhenOnBeat) {
     constexpr mixxx::Bpm bpm(60.0);
-    m_pTrack->trySetBpm(bpm.getValue());
+    m_pTrack->trySetBpm(bpm.value());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -155,7 +155,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat) {
 
 TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
     constexpr mixxx::Bpm bpm(60.0);
-    m_pTrack->trySetBpm(bpm.getValue());
+    m_pTrack->trySetBpm(bpm.value());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -200,7 +200,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
 
 TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
     constexpr mixxx::Bpm bpm(60.0);
-    m_pTrack->trySetBpm(bpm.getValue());
+    m_pTrack->trySetBpm(bpm.value());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -246,7 +246,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
 
 TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
     constexpr mixxx::Bpm bpm(60.0);
-    m_pTrack->trySetBpm(bpm.getValue());
+    m_pTrack->trySetBpm(bpm.value());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -289,7 +289,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
 TEST_F(BeatMapTest, TestBpmAround) {
     constexpr mixxx::Bpm filebpm(60.0);
     double approx_beat_length = getBeatLengthSamples(filebpm);
-    m_pTrack->trySetBpm(filebpm.getValue());
+    m_pTrack->trySetBpm(filebpm.value());
     const int numBeats = 64;
 
     QVector<mixxx::audio::FramePos> beats;
@@ -305,21 +305,21 @@ TEST_F(BeatMapTest, TestBpmAround) {
     // The average of the first 8 beats should be different than the average
     // of the last 8 beats.
     EXPECT_DOUBLE_EQ(63.937645572318047,
-            pMap->getBpmAroundPosition(4 * approx_beat_length, 4).getValue());
+            pMap->getBpmAroundPosition(4 * approx_beat_length, 4).value());
     EXPECT_DOUBLE_EQ(118.96668932698844,
-            pMap->getBpmAroundPosition(60 * approx_beat_length, 4).getValue());
+            pMap->getBpmAroundPosition(60 * approx_beat_length, 4).value());
     // Also test at the beginning and end of the track
     EXPECT_DOUBLE_EQ(62.937377309576974,
-            pMap->getBpmAroundPosition(0, 4).getValue());
+            pMap->getBpmAroundPosition(0, 4).value());
     EXPECT_DOUBLE_EQ(118.96668932698844,
-            pMap->getBpmAroundPosition(65 * approx_beat_length, 4).getValue());
+            pMap->getBpmAroundPosition(65 * approx_beat_length, 4).value());
 
     // Try a really, really short track
     constexpr auto startFramePos = mixxx::audio::FramePos(10);
     beats = createBeatVector(startFramePos, 3, getBeatLengthFrames(filebpm));
     pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
-    EXPECT_DOUBLE_EQ(filebpm.getValue(),
-            pMap->getBpmAroundPosition(1 * approx_beat_length, 4).getValue());
+    EXPECT_DOUBLE_EQ(filebpm.value(),
+            pMap->getBpmAroundPosition(1 * approx_beat_length, 4).value());
 }
 
 }  // namespace

--- a/src/test/beatstranslatetest.cpp
+++ b/src/test/beatstranslatetest.cpp
@@ -33,8 +33,8 @@ TEST_F(BeatsTranslateTest, SimpleTranslateMatch) {
     // doesn't get set naturally, but this will do for now.
     auto pBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "bpm");
     auto pBpm2 = std::make_unique<ControlProxy>(m_sGroup1, "bpm");
-    pBpm1->set(bpm.getValue());
-    pBpm2->set(bpm.getValue());
+    pBpm1->set(bpm.value());
+    pBpm2->set(bpm.value());
     ProcessBuffer();
 
     // Push the button on deck 2.

--- a/src/test/bpmcontrol_test.cpp
+++ b/src/test/bpmcontrol_test.cpp
@@ -35,7 +35,7 @@ TEST_F(BpmControlTest, BeatContext_BeatGrid) {
 
     const auto bpm = mixxx::Bpm(60.0);
     const int kFrameSize = 2;
-    const double expectedBeatLength = (60.0 * sampleRate / bpm.getValue()) * kFrameSize;
+    const double expectedBeatLength = (60.0 * sampleRate / bpm.value()) * kFrameSize;
 
     const mixxx::BeatsPointer pBeats = BeatFactory::makeBeatGrid(
             pTrack->getSampleRate(), bpm, mixxx::audio::kStartFramePos);

--- a/src/test/metadatatest.cpp
+++ b/src/test/metadatatest.cpp
@@ -48,7 +48,7 @@ class MetadataTest : public testing::Test {
         mixxx::TrackMetadata trackMetadata;
         mixxx::taglib::id3v2::importTrackMetadataFromTag(&trackMetadata, tag);
 
-        EXPECT_DOUBLE_EQ(expectedValue, trackMetadata.getTrackInfo().getBpm().getValue());
+        EXPECT_DOUBLE_EQ(expectedValue, trackMetadata.getTrackInfo().getBpm().value());
     }
 };
 

--- a/src/test/seratobeatgridtest.cpp
+++ b/src/test/seratobeatgridtest.cpp
@@ -126,7 +126,7 @@ TEST_F(SeratoBeatGridTest, SerializeBeatgrid) {
     seratoBeatGrid.setBeats(pBeats, signalInfo, duration, 0);
     EXPECT_EQ(seratoBeatGrid.nonTerminalMarkers().size(), 0);
     EXPECT_NE(seratoBeatGrid.terminalMarker(), nullptr);
-    EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm.getValue()));
+    EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm.value()));
 }
 
 TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
@@ -137,7 +137,7 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
     const auto signalInfo = mixxx::audio::SignalInfo(mixxx::audio::ChannelCount(2), sampleRate);
     const auto duration = mixxx::Duration::fromSeconds<int>(300);
     const mixxx::audio::FrameDiff_t framesPerMinute = signalInfo.getSampleRate() * 60;
-    const mixxx::audio::FrameDiff_t framesPerBeat = framesPerMinute / bpm.getValue();
+    const mixxx::audio::FrameDiff_t framesPerBeat = framesPerMinute / bpm.value();
     const mixxx::audio::FrameDiff_t initialFrameOffset = framesPerBeat / 2;
 
     QVector<mixxx::audio::FramePos> beatPositionsFrames;
@@ -167,7 +167,7 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
         seratoBeatGrid.setBeats(pBeats, signalInfo, duration, timingOffsetMillis);
         EXPECT_EQ(seratoBeatGrid.nonTerminalMarkers().size(), 0);
         EXPECT_NE(seratoBeatGrid.terminalMarker(), nullptr);
-        EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm.getValue()));
+        EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm.value()));
 
         // Check if the beats can be re-imported losslessly
         mixxx::SeratoBeatsImporter beatsImporter(
@@ -218,7 +218,7 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
                 kNumBeats60BPM - 1);
         EXPECT_NE(seratoBeatGrid.terminalMarker(), nullptr);
         EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(),
-                static_cast<float>(bpm.getValue() / 2));
+                static_cast<float>(bpm.value() / 2));
 
         // Check if the beats can be re-imported losslessly
         mixxx::SeratoBeatsImporter beatsImporter(
@@ -278,7 +278,7 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
         ASSERT_EQ(seratoBeatGrid.nonTerminalMarkers()[1]->beatsTillNextMarker(), kNumBeats60BPM);
         ASSERT_EQ(seratoBeatGrid.nonTerminalMarkers()[2]->beatsTillNextMarker(), kNumBeats60BPM);
         EXPECT_NE(seratoBeatGrid.terminalMarker(), nullptr);
-        EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm.getValue()));
+        EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm.value()));
 
         // Check if the beats can be re-imported losslessly
         mixxx::SeratoBeatsImporter beatsImporter(

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -76,17 +76,17 @@ BeatsPointer BeatGrid::makeBeatGrid(
         mixxx::Bpm bpm,
         mixxx::audio::FramePos firstBeatPos) {
     // FIXME: Should this be a debug assertion?
-    if (!bpm.hasValue()) {
+    if (!bpm.isValid()) {
         return nullptr;
     }
 
     mixxx::track::io::BeatGrid grid;
 
-    grid.mutable_bpm()->set_bpm(bpm.getValue());
+    grid.mutable_bpm()->set_bpm(bpm.value());
     grid.mutable_first_beat()->set_frame_position(
             static_cast<google::protobuf::int32>(firstBeatPos.value()));
     // Calculate beat length as sample offsets
-    double beatLength = (60.0 * sampleRate / bpm.getValue()) * kFrameSize;
+    double beatLength = (60.0 * sampleRate / bpm.value()) * kFrameSize;
 
     return BeatsPointer(new BeatGrid(sampleRate, subVersion, grid, beatLength));
 }
@@ -137,7 +137,7 @@ QString BeatGrid::getSubVersion() const {
 
 // internal use only
 bool BeatGrid::isValid() const {
-    return m_sampleRate.isValid() && bpm().hasValue();
+    return m_sampleRate.isValid() && bpm().isValid();
 }
 
 // This could be implemented in the Beats Class itself.
@@ -333,23 +333,23 @@ BeatsPointer BeatGrid::scale(enum BPMScale scale) const {
         return BeatsPointer(new BeatGrid(*this));
     }
 
-    if (!bpm.hasValue()) {
+    if (!bpm.isValid()) {
         return BeatsPointer(new BeatGrid(*this));
     }
 
     bpm = BeatUtils::roundBpmWithinRange(bpm - kBpmScaleRounding, bpm, bpm + kBpmScaleRounding);
-    grid.mutable_bpm()->set_bpm(bpm.getValue());
-    double beatLength = (60.0 * m_sampleRate / bpm.getValue()) * kFrameSize;
+    grid.mutable_bpm()->set_bpm(bpm.value());
+    double beatLength = (60.0 * m_sampleRate / bpm.value()) * kFrameSize;
     return BeatsPointer(new BeatGrid(*this, grid, beatLength));
 }
 
 BeatsPointer BeatGrid::setBpm(mixxx::Bpm bpm) {
-    VERIFY_OR_DEBUG_ASSERT(bpm.hasValue()) {
+    VERIFY_OR_DEBUG_ASSERT(bpm.isValid()) {
         return nullptr;
     }
     mixxx::track::io::BeatGrid grid = m_grid;
-    grid.mutable_bpm()->set_bpm(bpm.getValue());
-    double beatLength = (60.0 * m_sampleRate / bpm.getValue()) * kFrameSize;
+    grid.mutable_bpm()->set_bpm(bpm.value());
+    double beatLength = (60.0 * m_sampleRate / bpm.value()) * kFrameSize;
     return BeatsPointer(new BeatGrid(*this, grid, beatLength));
 }
 

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -22,22 +22,28 @@ class BeatIterator {
     virtual double next() = 0;
 };
 
-// Beats is the base class for BPM and beat management classes. It
-// provides a specification of all methods a beat-manager class must provide, as
-// well as a capability model for representing optional features.
+/// Beats is the base class for BPM and beat management classes. It provides a
+/// specification of all methods a beat-manager class must provide, as well as
+/// a capability model for representing optional features.
 class Beats {
   public:
     virtual ~Beats() = default;
 
     enum Capabilities {
-        BEATSCAP_NONE          = 0x0000,
-        BEATSCAP_ADDREMOVE     = 0x0001, // Add or remove a single beat
-        BEATSCAP_TRANSLATE     = 0x0002, // Move all beat markers earlier or later
-        BEATSCAP_SCALE         = 0x0004, // Scale beat distance by a fixed ratio
-        BEATSCAP_MOVEBEAT      = 0x0008, // Move a single Beat
-        BEATSCAP_SETBPM        = 0x0010  // Set new bpm, beat grid only
+        BEATSCAP_NONE = 0x0000,
+        /// Add or remove a single beat
+        BEATSCAP_ADDREMOVE = 0x0001,
+        /// Move all beat markers earlier or later
+        BEATSCAP_TRANSLATE = 0x0002,
+        /// Scale beat distance by a fixed ratio
+        BEATSCAP_SCALE = 0x0004,
+        /// Move a single Beat
+        BEATSCAP_MOVEBEAT = 0x0008,
+        /// Set new bpm, beat grid only
+        BEATSCAP_SETBPM = 0x0010
     };
-    typedef int CapabilitiesFlags; // Allows us to do ORing
+    /// Allows us to do ORing
+    typedef int CapabilitiesFlags;
 
     enum BPMScale {
         DOUBLE,
@@ -48,17 +54,18 @@ class Beats {
         THREEHALVES,
     };
 
+    /// Retrieve the capabilities supported by the beats implementation.
     virtual Beats::CapabilitiesFlags getCapabilities() const = 0;
 
-    // Serialization
+    /// Serialize beats to QByteArray.
     virtual QByteArray toByteArray() const = 0;
 
-    // A string representing the version of the beat-processing code that
-    // produced this Beats instance. Used by BeatsFactory for associating a
-    // given serialization with the version that produced it.
+    /// A string representing the version of the beat-processing code that
+    /// produced this Beats instance. Used by BeatsFactory for associating a
+    /// given serialization with the version that produced it.
     virtual QString getVersion() const = 0;
-    // A sub-version can be used to represent the preferences used to generate
-    // the beats object.
+    /// A sub-version can be used to represent the preferences used to generate
+    /// the beats object.
     virtual QString getSubVersion() const = 0;
 
     ////////////////////////////////////////////////////////////////////////////
@@ -70,62 +77,62 @@ class Beats {
     // TODO: We may want to implement these with common code that returns
     //       the triple of closest, next, and prev.
 
-    // Starting from sample dSamples, return the sample of the next beat in the
-    // track, or -1 if none exists. If dSamples refers to the location of a
-    // beat, dSamples is returned.
+    /// Starting from dSamples, return the sample of the next beat in the
+    /// track, or -1 if none exists. If dSamples refers to the location of a
+    /// beat, dSamples is returned.
     virtual double findNextBeat(double dSamples) const = 0;
 
-    // Starting from sample dSamples, return the sample of the previous beat in
-    // the track, or -1 if none exists. If dSamples refers to the location of
-    // beat, dSamples is returned.
+    /// Starting from sample dSamples, return the sample of the previous beat
+    /// in the track, or -1 if none exists. If dSamples refers to the location
+    /// of beat, dSamples is returned.
     virtual double findPrevBeat(double dSamples) const = 0;
 
-    // Starting from sample dSamples, fill the samples of the previous beat
-    // and next beat.  Either can be -1 if none exists.  If dSamples refers
-    // to the location of the beat, the first value is dSamples, and the second
-    // value is the next beat position.  Non- -1 values are guaranteed to be
-    // even.  Returns false if *at least one* sample is -1.  (Can return false
-    // with one beat successfully filled)
+    /// Starting from sample dSamples, fill the samples of the previous beat
+    /// and next beat.  Either can be -1 if none exists.  If dSamples refers to
+    /// the location of the beat, the first value is dSamples, and the second
+    /// value is the next beat position.  Non- -1 values are guaranteed to be
+    /// even.  Returns false if *at least one* sample is -1.  (Can return false
+    /// with one beat successfully filled)
     virtual bool findPrevNextBeats(double dSamples,
             double* dpPrevBeatSamples,
             double* dpNextBeatSamples,
             bool snapToNearBeats) const = 0;
 
-    // Starting from sample dSamples, return the sample of the closest beat in
-    // the track, or -1 if none exists.  Non- -1 values are guaranteed to be
-    // even.
+    /// Starting from sample dSamples, return the sample of the closest beat in
+    /// the track, or -1 if none exists.  Non- -1 values are guaranteed to be
+    /// even.
     virtual double findClosestBeat(double dSamples) const = 0;
 
-    // Find the Nth beat from sample dSamples. Works with both positive and
-    // negative values of n. Calling findNthBeat with n=0 is invalid. Calling
-    // findNthBeat with n=1 or n=-1 is equivalent to calling findNextBeat and
-    // findPrevBeat, respectively. If dSamples refers to the location of a beat,
-    // then dSamples is returned. If no beat can be found, returns -1.
+    /// Find the Nth beat from sample dSamples. Works with both positive and
+    /// negative values of n. Calling findNthBeat with n=0 is invalid. Calling
+    /// findNthBeat with n=1 or n=-1 is equivalent to calling findNextBeat and
+    /// findPrevBeat, respectively. If dSamples refers to the location of a
+    /// beat, then dSamples is returned. If no beat can be found, returns -1.
     virtual double findNthBeat(double dSamples, int n) const = 0;
 
     int numBeatsInRange(double dStartSample, double dEndSample) const;
 
-    // Find the sample N beats away from dSample. The number of beats may be
-    // negative and does not need to be an integer.
+    /// Find the sample N beats away from dSample. The number of beats may be
+    /// negative and does not need to be an integer.
     double findNBeatsFromSample(double fromSample, double beats) const;
 
-
-    // Adds to pBeatsList the position in samples of every beat occurring between
-    // startPosition and endPosition. BeatIterator must be iterated while
-    // holding a strong references to the Beats object to ensure that the Beats
-    // object is not deleted. Caller takes ownership of the returned BeatIterator;
+    /// Adds to pBeatsList the position in samples of every beat occurring
+    /// between startPosition and endPosition. BeatIterator must be iterated
+    /// while holding a strong references to the Beats object to ensure that
+    /// the Beats object is not deleted. Caller takes ownership of the returned
+    /// BeatIterator;
     virtual std::unique_ptr<BeatIterator> findBeats(double startSample, double stopSample) const = 0;
 
-    // Return whether or not a sample lies between startPosition and endPosition
+    /// Return whether or not a sample lies between startPosition and endPosition.
     virtual bool hasBeatInRange(double startSample, double stopSample) const = 0;
 
-    // Return the average BPM over the entire track if the BPM is
-    // valid, otherwise returns -1
+    /// Return the average BPM over the entire track if the BPM is valid,
+    /// otherwise returns -1
     virtual mixxx::Bpm getBpm() const = 0;
 
-    // Return the average BPM over the range of n*2 beats centered around
-    // curSample.  (An n of 4 results in an averaging of 8 beats).  Invalid
-    // BPM returns -1.
+    /// Return the average BPM over the range of n*2 beats centered around
+    /// curSample.  (An n of 4 results in an averaging of 8 beats).  Invalid
+    /// BPM returns -1.
     virtual mixxx::Bpm getBpmAroundPosition(double curSample, int n) const = 0;
 
     virtual audio::SampleRate getSampleRate() const = 0;
@@ -134,17 +141,17 @@ class Beats {
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
-    // Translate all beats in the song by dNumSamples samples. Beats that lie
-    // before the start of the track or after the end of the track are not
-    // removed. Beats instance must have the capability BEATSCAP_TRANSLATE.
+    /// Translate all beats in the song by dNumSamples samples. Beats that lie
+    /// before the start of the track or after the end of the track are not
+    /// removed. Beats instance must have the capability BEATSCAP_TRANSLATE.
     virtual BeatsPointer translate(double dNumSamples) const = 0;
 
-    // Scale the position of every beat in the song by dScalePercentage. Beats
-    // class must have the capability BEATSCAP_SCALE.
+    /// Scale the position of every beat in the song by dScalePercentage. Beats
+    /// class must have the capability BEATSCAP_SCALE.
     virtual BeatsPointer scale(enum BPMScale scale) const = 0;
 
-    // Adjust the beats so the global average BPM matches bpm. Beats class must
-    // have the capability BEATSCAP_SET.
+    /// Adjust the beats so the global average BPM matches bpm. Beats class
+    /// must have the capability BEATSCAP_SET.
     virtual BeatsPointer setBpm(mixxx::Bpm bpm) = 0;
 };
 

--- a/src/track/beatutils.cpp
+++ b/src/track/beatutils.cpp
@@ -313,7 +313,7 @@ mixxx::Bpm BeatUtils::makeConstBpm(
         // bpm adjustments are made.
         // This is a temporary fix, ideally the anchor point for the BPM grid should
         // be the first proper downbeat, or perhaps the CUE point.
-        const double roundedBeatLength = 60.0 * sampleRate / roundBpm.getValue();
+        const double roundedBeatLength = 60.0 * sampleRate / roundBpm.value();
         *pFirstBeat = mixxx::audio::FramePos(
                 fmod(constantRegions[startRegionIndex].firstBeat.value(),
                         roundedBeatLength));
@@ -325,7 +325,7 @@ mixxx::Bpm BeatUtils::makeConstBpm(
 mixxx::Bpm BeatUtils::roundBpmWithinRange(
         mixxx::Bpm minBpm, mixxx::Bpm centerBpm, mixxx::Bpm maxBpm) {
     // First try to snap to a full integer BPM
-    auto snapBpm = mixxx::Bpm(round(centerBpm.getValue()));
+    auto snapBpm = mixxx::Bpm(round(centerBpm.value()));
     if (snapBpm > minBpm && snapBpm < maxBpm) {
         // Success
         return snapBpm;
@@ -339,20 +339,20 @@ mixxx::Bpm BeatUtils::roundBpmWithinRange(
         if (centerBpm < mixxx::Bpm(85.0)) {
             // this cane be actually up to 175 BPM
             // allow halve BPM values
-            return mixxx::Bpm(round(centerBpm.getValue() * 2) / 2);
+            return mixxx::Bpm(round(centerBpm.value() * 2) / 2);
         } else if (centerBpm > mixxx::Bpm(127.0)) {
             // optimize for 2/3 going down to 85
-            return mixxx::Bpm(round(centerBpm.getValue() / 3 * 2) * 3 / 2);
+            return mixxx::Bpm(round(centerBpm.value() / 3 * 2) * 3 / 2);
         }
     }
 
     if (roundBpmWidth > 1.0 / 12) {
         // this covers all sorts of 1/2 2/3 and 3/4 multiplier
-        return mixxx::Bpm(round(centerBpm.getValue() * 12) / 12);
+        return mixxx::Bpm(round(centerBpm.value() * 12) / 12);
     } else {
         // We are here if we have more that ~75 beats and ~30 s
         // try to snap to a 1/12 Bpm
-        snapBpm = mixxx::Bpm(round(centerBpm.getValue() * 12) / 12);
+        snapBpm = mixxx::Bpm(round(centerBpm.value() * 12) / 12);
         if (snapBpm > minBpm && snapBpm < maxBpm) {
             // Success
             return snapBpm;
@@ -387,7 +387,7 @@ mixxx::audio::FramePos BeatUtils::adjustPhase(
         mixxx::Bpm bpm,
         mixxx::audio::SampleRate sampleRate,
         const QVector<mixxx::audio::FramePos>& beats) {
-    const double beatLength = 60 * sampleRate / bpm.getValue();
+    const double beatLength = 60 * sampleRate / bpm.value();
     const mixxx::audio::FramePos startOffset =
             mixxx::audio::FramePos(fmod(firstBeat.value(), beatLength));
     mixxx::audio::FrameDiff_t offsetAdjust = 0;

--- a/src/track/bpm.h
+++ b/src/track/bpm.h
@@ -41,11 +41,11 @@ public:
         return util_isfinite(value) && kValueMin < value;
     }
 
-    bool hasValue() const {
+    bool isValid() const {
         return isValidValue(m_value);
     }
-    double getValue() const {
-        VERIFY_OR_DEBUG_ASSERT(hasValue()) {
+    double value() const {
+        VERIFY_OR_DEBUG_ASSERT(isValid()) {
             return kValueUndefined;
         }
         return m_value;
@@ -72,12 +72,12 @@ public:
     bool compareEq(
             const Bpm& bpm,
             Comparison cmp = Comparison::Default) const {
-        if (!hasValue() && !bpm.hasValue()) {
+        if (!isValid() && !bpm.isValid()) {
             // Both values are invalid and thus equal.
             return true;
         }
 
-        if (hasValue() != bpm.hasValue()) {
+        if (isValid() != bpm.isValid()) {
             // One value is valid, one is not.
             return false;
         }
@@ -85,12 +85,12 @@ public:
         // At this point both values are valid
         switch (cmp) {
         case Comparison::Integer:
-            return Bpm::valueToInteger(getValue()) == Bpm::valueToInteger(bpm.getValue());
+            return Bpm::valueToInteger(value()) == Bpm::valueToInteger(bpm.value());
         case Comparison::String:
-            return Bpm::valueToString(getValue()) == Bpm::valueToString(bpm.getValue());
+            return Bpm::valueToString(value()) == Bpm::valueToString(bpm.value());
         case Comparison::Default:
         default:
-            return getValue() == bpm.getValue();
+            return value() == bpm.value();
         }
     }
 
@@ -99,25 +99,25 @@ public:
     }
 
     Bpm& operator+=(double increment) {
-        DEBUG_ASSERT(hasValue());
+        DEBUG_ASSERT(isValid());
         m_value += increment;
         return *this;
     }
 
     Bpm& operator-=(double decrement) {
-        DEBUG_ASSERT(hasValue());
+        DEBUG_ASSERT(isValid());
         m_value -= decrement;
         return *this;
     }
 
     Bpm& operator*=(double multiple) {
-        DEBUG_ASSERT(hasValue());
+        DEBUG_ASSERT(isValid());
         m_value *= multiple;
         return *this;
     }
 
     Bpm& operator/=(double divisor) {
-        DEBUG_ASSERT(hasValue());
+        DEBUG_ASSERT(isValid());
         m_value /= divisor;
         return *this;
     }
@@ -128,35 +128,35 @@ private:
 
 /// Bpm can be added to a double
 inline Bpm operator+(Bpm bpm, double bpmDiff) {
-    return Bpm(bpm.getValue() + bpmDiff);
+    return Bpm(bpm.value() + bpmDiff);
 }
 
 /// Bpm can be subtracted from a double
 inline Bpm operator-(Bpm bpm, double bpmDiff) {
-    return Bpm(bpm.getValue() - bpmDiff);
+    return Bpm(bpm.value() - bpmDiff);
 }
 
 /// Two Bpm values can be subtracted to get a double
 inline double operator-(Bpm bpm1, Bpm bpm2) {
-    return bpm1.getValue() - bpm2.getValue();
+    return bpm1.value() - bpm2.value();
 }
 
 // Adding two Bpm is not allowed, because it makes no sense semantically.
 
 /// Bpm can be multiplied or divided by a double
 inline Bpm operator*(Bpm bpm, double multiple) {
-    return Bpm(bpm.getValue() * multiple);
+    return Bpm(bpm.value() * multiple);
 }
 
 inline Bpm operator/(Bpm bpm, double divisor) {
-    return Bpm(bpm.getValue() / divisor);
+    return Bpm(bpm.value() / divisor);
 }
 
 inline bool operator==(Bpm bpm1, Bpm bpm2) {
-    if (!bpm1.hasValue() && !bpm2.hasValue()) {
+    if (!bpm1.isValid() && !bpm2.isValid()) {
         return true;
     }
-    return bpm1.hasValue() && bpm2.hasValue() && bpm1.getValue() == bpm2.getValue();
+    return bpm1.isValid() && bpm2.isValid() && bpm1.value() == bpm2.value();
 }
 
 inline bool operator!=(Bpm bpm1, Bpm bpm2) {
@@ -164,7 +164,7 @@ inline bool operator!=(Bpm bpm1, Bpm bpm2) {
 }
 
 inline bool operator<(Bpm bpm1, Bpm bpm2) {
-    return bpm1.getValue() < bpm2.getValue();
+    return bpm1.value() < bpm2.value();
 }
 
 inline bool operator<=(Bpm bpm1, Bpm bpm2) {
@@ -180,8 +180,8 @@ inline bool operator>=(Bpm bpm1, Bpm bpm2) {
 }
 
 inline QDebug operator<<(QDebug dbg, Bpm arg) {
-    if (arg.hasValue()) {
-        dbg.nospace() << "Bpm(" << arg.getValue() << ")";
+    if (arg.isValid()) {
+        dbg.nospace() << "Bpm(" << arg.value() << ")";
     } else {
         dbg << "Bpm(Invalid)";
     }

--- a/src/track/serato/beatgrid.cpp
+++ b/src/track/serato/beatgrid.cpp
@@ -514,7 +514,7 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
             1);
 
     setTerminalMarker(std::make_shared<SeratoBeatGridTerminalMarker>(
-            positionSecs - timingOffsetSecs, static_cast<float>(bpm.getValue())));
+            positionSecs - timingOffsetSecs, static_cast<float>(bpm.value())));
     setNonTerminalMarkers(nonTerminalMarkers);
 }
 

--- a/src/track/taglib/trackmetadata_common.h
+++ b/src/track/taglib/trackmetadata_common.h
@@ -72,7 +72,7 @@ inline TagLib::String uuidToTString(
 inline QString formatBpm(
         const TrackMetadata& trackMetadata) {
     return Bpm::valueToString(
-            trackMetadata.getTrackInfo().getBpm().getValue());
+            trackMetadata.getTrackInfo().getBpm().value());
 }
 
 bool parseBpm(

--- a/src/track/taglib/trackmetadata_id3v2.cpp
+++ b/src/track/taglib/trackmetadata_id3v2.cpp
@@ -561,12 +561,12 @@ inline QImage loadImageFromPictureFrame(
 
 inline QString formatBpmInteger(
         const TrackMetadata& trackMetadata) {
-    if (!trackMetadata.getTrackInfo().getBpm().hasValue()) {
+    if (!trackMetadata.getTrackInfo().getBpm().isValid()) {
         return QString();
     }
     return QString::number(
             Bpm::valueToInteger(
-                    trackMetadata.getTrackInfo().getBpm().getValue()));
+                    trackMetadata.getTrackInfo().getBpm().value()));
 }
 
 } // anonymous namespace
@@ -795,7 +795,7 @@ void importTrackMetadataFromTag(
     if (!bpmFrames.isEmpty()) {
         parseBpm(pTrackMetadata,
                 firstNonEmptyFrameToQString(bpmFrames));
-        double bpmValue = pTrackMetadata->getTrackInfo().getBpm().getValue();
+        double bpmValue = pTrackMetadata->getTrackInfo().getBpm().value();
         // Some software use (or used) to write decimated values without comma,
         // so the number reads as 1352 or 14525 when it is 135.2 or 145.25
         if (bpmValue < Bpm::kValueMin || bpmValue > 1000 * Bpm::kValueMax) {

--- a/src/track/taglib/trackmetadata_mp4.cpp
+++ b/src/track/taglib/trackmetadata_mp4.cpp
@@ -381,10 +381,10 @@ bool exportTrackMetadataIntoTag(
     writeAtom(pTag, "\251grp", toTString(trackMetadata.getTrackInfo().getGrouping()));
 
     // Write both BPM fields (just in case)
-    if (trackMetadata.getTrackInfo().getBpm().hasValue()) {
+    if (trackMetadata.getTrackInfo().getBpm().isValid()) {
         // 16-bit integer value
         const int tmpoValue =
-                Bpm::valueToInteger(trackMetadata.getTrackInfo().getBpm().getValue());
+                Bpm::valueToInteger(trackMetadata.getTrackInfo().getBpm().value());
         pTag->setItem("tmpo", tmpoValue);
     } else {
         pTag->removeItem("tmpo");

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -171,12 +171,12 @@ void Track::replaceMetadataFromSource(
         // Need to set BPM after sample rate since beat grid creation depends on
         // knowing the sample rate. Bug #1020438.
         auto beatsAndBpmModified = false;
-        if (importedBpm.hasValue() && (!m_pBeats || !m_pBeats->getBpm().hasValue())) {
+        if (importedBpm.isValid() && (!m_pBeats || !m_pBeats->getBpm().isValid())) {
             // Only use the imported BPM if the current beat grid is either
             // missing or not valid! The BPM value in the metadata might be
             // imprecise (normalized or rounded), e.g. ID3v2 only supports
             // integer values.
-            beatsAndBpmModified = trySetBpmWhileLocked(importedBpm.getValue());
+            beatsAndBpmModified = trySetBpmWhileLocked(importedBpm.value());
         }
         modified |= beatsAndBpmModified;
 
@@ -288,7 +288,7 @@ bool Track::replaceRecord(
     } else {
         // Setting the bpm manually may in turn update the beat grid
         bpmUpdatedFlag = trySetBpmWhileLocked(
-                newRecord.getMetadata().getTrackInfo().getBpm().getValue());
+                newRecord.getMetadata().getTrackInfo().getBpm().value());
     }
     // The bpm in m_record has already been updated. Read it and copy it into
     // the new record to ensure it will be consistent with the new beat grid.
@@ -339,7 +339,7 @@ mixxx::Bpm Track::getBpmWhileLocked() const {
 
 bool Track::trySetBpmWhileLocked(double bpmValue) {
     const auto bpm = mixxx::Bpm(bpmValue);
-    if (!bpm.hasValue()) {
+    if (!bpm.isValid()) {
         // If the user sets the BPM to an invalid value, we assume
         // they want to clear the beatgrid.
         return trySetBeatsWhileLocked(nullptr);
@@ -364,7 +364,7 @@ bool Track::trySetBpmWhileLocked(double bpmValue) {
 double Track::getBpm() const {
     const QMutexLocker lock(&m_qMutex);
     const mixxx::Bpm bpm = getBpmWhileLocked();
-    return bpm.hasValue() ? bpm.getValue() : mixxx::Bpm::kValueUndefined;
+    return bpm.isValid() ? bpm.value() : mixxx::Bpm::kValueUndefined;
 }
 
 bool Track::trySetBpm(double bpmValue) {


### PR DESCRIPTION
Based on #4045.

This just renames some methods of the `mixxx::Bpm` class to make them clearer and consistent with the `mixxx::audio::FramePos` class and improves the comments in the `Beats` class.