### PR TITLE
Beats frame refactor

### DIFF
--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -158,9 +158,7 @@ bool AnalyzerBeats::shouldAnalyze(TrackPointer pTrack) const {
         return m_bPreferencesReanalyzeImported;
     }
 
-    if (subVersion.isEmpty() &&
-            pBeats->findNextBeat(mixxx::audio::kStartFramePos) <=
-                    mixxx::audio::kStartFramePos &&
+    if (subVersion.isEmpty() && pBeats->firstBeat() <= mixxx::audio::kStartFramePos &&
             m_pluginId != mixxx::AnalyzerSoundTouchBeats::pluginInfo().id()) {
         // This happens if the beat grid was created from the metadata BPM value.
         qDebug() << "First beat is 0 for grid so analyzing track to find first beat.";

--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -158,7 +158,9 @@ bool AnalyzerBeats::shouldAnalyze(TrackPointer pTrack) const {
         return m_bPreferencesReanalyzeImported;
     }
 
-    if (subVersion.isEmpty() && pBeats->findNextBeat(0) <= 0.0 &&
+    if (subVersion.isEmpty() &&
+            pBeats->findNextBeat(mixxx::audio::kStartFramePos) <=
+                    mixxx::audio::kStartFramePos &&
             m_pluginId != mixxx::AnalyzerSoundTouchBeats::pluginInfo().id()) {
         // This happens if the beat grid was created from the metadata BPM value.
         qDebug() << "First beat is 0 for grid so analyzing track to find first beat.";

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -207,7 +207,7 @@ void BpmControl::slotTranslateBeatsEarlier(double v) {
     if (pBeats &&
             (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
         const double sampleOffset = getSampleOfTrack().rate * -0.01;
-        const mixxx::audio::FrameDiff_t frameOffset = sampleOffset / 2;
+        const mixxx::audio::FrameDiff_t frameOffset = sampleOffset / mixxx::kEngineChannelCount;
         pTrack->trySetBeats(pBeats->translate(frameOffset));
     }
 }
@@ -225,7 +225,7 @@ void BpmControl::slotTranslateBeatsLater(double v) {
             (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
         // TODO(rryan): Track::getSampleRate is possibly inaccurate!
         const double sampleOffset = getSampleOfTrack().rate * 0.01;
-        const mixxx::audio::FrameDiff_t frameOffset = sampleOffset / 2;
+        const mixxx::audio::FrameDiff_t frameOffset = sampleOffset / mixxx::kEngineChannelCount;
         pTrack->trySetBeats(pBeats->translate(frameOffset));
     }
 }
@@ -1067,7 +1067,7 @@ void BpmControl::slotBeatsTranslateMatchAlignment(double v) {
         m_dUserOffset.setValue(0.0);
 
         double sampleOffset = getPhaseOffset(getSampleOfTrack().current);
-        const mixxx::audio::FrameDiff_t frameOffset = sampleOffset / 2;
+        const mixxx::audio::FrameDiff_t frameOffset = sampleOffset / mixxx::kEngineChannelCount;
         pTrack->trySetBeats(pBeats->translate(-frameOffset));
     }
 }

--- a/src/engine/controls/clockcontrol.cpp
+++ b/src/engine/controls/clockcontrol.cpp
@@ -88,10 +88,18 @@ void ClockControl::updateIndicators(const double dRate,
     if (pBeats) {
         if ((currentSample >= m_NextBeatSamples) ||
                 (currentSample <= m_PrevBeatSamples)) {
-            pBeats->findPrevNextBeats(currentSample,
-                    &m_PrevBeatSamples,
-                    &m_NextBeatSamples,
+            mixxx::audio::FramePos prevBeatPosition;
+            mixxx::audio::FramePos nextBeatPosition;
+            pBeats->findPrevNextBeats(mixxx::audio::FramePos::fromEngineSamplePos(currentSample),
+                    &prevBeatPosition,
+                    &nextBeatPosition,
                     false); // Precise compare without tolerance needed
+            m_PrevBeatSamples = prevBeatPosition.isValid()
+                    ? prevBeatPosition.toEngineSamplePos()
+                    : -1;
+            m_NextBeatSamples = nextBeatPosition.isValid()
+                    ? nextBeatPosition.toEngineSamplePos()
+                    : -1;
         }
     } else {
         m_PrevBeatSamples = -1;

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -766,7 +766,17 @@ void CueControl::hotcueSet(HotcueControl* pControl, double value, HotcueSetMode 
             if (beatloopSize <= 0 || !pBeats) {
                 return;
             }
-            cueEndPosition = pBeats->findNBeatsFromSample(cueStartPosition, beatloopSize);
+            mixxx::audio::FramePos cueEndPositionFrames;
+            if (cueStartPosition != Cue::kNoPosition) {
+                const auto cueStartPositionFrames =
+                        mixxx::audio::FramePos::fromEngineSamplePos(
+                                cueStartPosition);
+                cueEndPositionFrames = pBeats->findNBeatsFromSample(
+                        cueStartPositionFrames, beatloopSize);
+            }
+            cueEndPosition = cueEndPositionFrames.isValid()
+                    ? cueEndPositionFrames.toEngineSamplePos()
+                    : Cue::kNoPosition;
         }
         cueType = mixxx::CueType::Loop;
         break;
@@ -1979,10 +1989,12 @@ double CueControl::quantizeCuePoint(double cuePos) {
         return cuePos;
     }
 
-    double closestBeat = pBeats->findClosestBeat(cuePos);
+    const auto cuePosition = mixxx::audio::FramePos::fromEngineSamplePos(cuePos);
+    const auto closestBeatPosition = pBeats->findClosestBeat(cuePosition);
     // The closest beat can be an unreachable  interpolated beat past the end of
     // the track.
-    if (closestBeat != -1.0 && closestBeat <= total) {
+    const double closestBeat = closestBeatPosition.toEngineSamplePos();
+    if (closestBeatPosition.isValid() && closestBeat <= total) {
         return closestBeat;
     }
 

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -771,7 +771,7 @@ void CueControl::hotcueSet(HotcueControl* pControl, double value, HotcueSetMode 
                 const auto cueStartPositionFrames =
                         mixxx::audio::FramePos::fromEngineSamplePos(
                                 cueStartPosition);
-                cueEndPositionFrames = pBeats->findNBeatsFromSample(
+                cueEndPositionFrames = pBeats->findNBeatsFromPosition(
                         cueStartPositionFrames, beatloopSize);
             }
             cueEndPosition = cueEndPositionFrames.isValid()

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -527,8 +527,8 @@ double LoopingControl::getSyncPositionInsideLoop(double dRequestedPlaypos, doubl
     return dSyncedPlayPos;
 }
 
-void LoopingControl::setBeatLoop(double startPosition, bool enabled) {
-    VERIFY_OR_DEBUG_ASSERT(startPosition != Cue::kNoPosition) {
+void LoopingControl::setBeatLoop(double startPositionSamples, bool enabled) {
+    VERIFY_OR_DEBUG_ASSERT(startPositionSamples != Cue::kNoPosition) {
         return;
     }
 
@@ -541,9 +541,12 @@ void LoopingControl::setBeatLoop(double startPosition, bool enabled) {
 
     // TODO(XXX): This is not realtime safe. See this Zulip discussion for details:
     // https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/getting.20locks.20out.20of.20Beats
-    double endPosition = pBeats->findNBeatsFromSample(startPosition, beatloopSize);
+    const auto startPosition = mixxx::audio::FramePos::fromEngineSamplePos(startPositionSamples);
+    const auto endPosition = pBeats->findNBeatsFromSample(startPosition, beatloopSize);
 
-    setLoop(startPosition, endPosition, enabled);
+    if (startPosition.isValid() && endPosition.isValid()) {
+        setLoop(startPositionSamples, endPosition.toEngineSamplePos(), enabled);
+    }
 }
 
 void LoopingControl::setLoop(double startPosition, double endPosition, bool enabled) {
@@ -615,8 +618,11 @@ void LoopingControl::setLoopInToCurrentPosition() {
     if (loopSamples.end != kNoTrigger &&
             (loopSamples.end - pos) < MINIMUM_AUDIBLE_LOOP_SIZE) {
         if (quantizedBeat != -1 && pBeats) {
-            pos = pBeats->findNthBeat(quantizedBeat, -2);
-            if (pos == -1 || (loopSamples.end - pos) < MINIMUM_AUDIBLE_LOOP_SIZE) {
+            const auto quantizedBeatPosition =
+                    mixxx::audio::FramePos::fromEngineSamplePos(quantizedBeat);
+            const auto position = pBeats->findNthBeat(quantizedBeatPosition, -2);
+            pos = position.toEngineSamplePos();
+            if (!position.isValid() || (loopSamples.end - pos) < MINIMUM_AUDIBLE_LOOP_SIZE) {
                 pos = loopSamples.end - MINIMUM_AUDIBLE_LOOP_SIZE;
             }
         } else {
@@ -640,8 +646,9 @@ void LoopingControl::setLoopInToCurrentPosition() {
     if (m_pQuantizeEnabled->toBool()
             && loopSamples.start < loopSamples.end
             && pBeats) {
-        m_pCOBeatLoopSize->setAndConfirm(
-                pBeats->numBeatsInRange(loopSamples.start, loopSamples.end));
+        const auto startPosition = mixxx::audio::FramePos::fromEngineSamplePos(loopSamples.start);
+        const auto endPosition = mixxx::audio::FramePos::fromEngineSamplePos(loopSamples.end);
+        m_pCOBeatLoopSize->setAndConfirm(pBeats->numBeatsInRange(startPosition, endPosition));
         updateBeatLoopingControls();
     } else {
         clearActiveBeatLoop();
@@ -721,8 +728,11 @@ void LoopingControl::setLoopOutToCurrentPosition() {
     //  use the smallest pre-defined beatloop instead (when possible)
     if ((pos - loopSamples.start) < MINIMUM_AUDIBLE_LOOP_SIZE) {
         if (quantizedBeat != -1 && pBeats) {
-            pos = static_cast<int>(floor(pBeats->findNthBeat(quantizedBeat, 2)));
-            if (pos == -1 || (pos - loopSamples.start) < MINIMUM_AUDIBLE_LOOP_SIZE) {
+            const auto quantizedBeatPosition =
+                    mixxx::audio::FramePos::fromEngineSamplePos(quantizedBeat);
+            const auto position = pBeats->findNthBeat(quantizedBeatPosition, 2);
+            pos = static_cast<int>(position.toLowerFrameBoundary().toEngineSamplePos());
+            if (!position.isValid() || (pos - loopSamples.start) < MINIMUM_AUDIBLE_LOOP_SIZE) {
                 pos = loopSamples.start + MINIMUM_AUDIBLE_LOOP_SIZE;
             }
         } else {
@@ -745,8 +755,9 @@ void LoopingControl::setLoopOutToCurrentPosition() {
     }
 
     if (m_pQuantizeEnabled->toBool() && pBeats) {
-        m_pCOBeatLoopSize->setAndConfirm(
-            pBeats->numBeatsInRange(loopSamples.start, loopSamples.end));
+        const auto startPosition = mixxx::audio::FramePos::fromEngineSamplePos(loopSamples.start);
+        const auto endPosition = mixxx::audio::FramePos::fromEngineSamplePos(loopSamples.end);
+        m_pCOBeatLoopSize->setAndConfirm(pBeats->numBeatsInRange(startPosition, endPosition));
         updateBeatLoopingControls();
     } else {
         clearActiveBeatLoop();
@@ -1097,8 +1108,12 @@ bool LoopingControl::currentLoopMatchesBeatloopSize() {
     LoopSamples loopSamples = m_loopSamples.getValue();
 
     // Calculate where the loop out point would be if it is a beatloop
-    double beatLoopOutPoint =
-        pBeats->findNBeatsFromSample(loopSamples.start, m_pCOBeatLoopSize->get());
+    const auto loopStartPosition = mixxx::audio::FramePos::fromEngineSamplePos(loopSamples.start);
+    const auto loopEndPosition = pBeats->findNBeatsFromSample(
+            loopStartPosition, m_pCOBeatLoopSize->get());
+    const double beatLoopOutPoint = loopEndPosition.isValid()
+            ? loopEndPosition.toEngineSamplePos()
+            : -1;
 
     return loopSamples.end > beatLoopOutPoint - 2 &&
             loopSamples.end < beatLoopOutPoint + 2;
@@ -1110,11 +1125,15 @@ double LoopingControl::findBeatloopSizeForLoop(double start, double end) const {
         return -1;
     }
 
+    const auto loopStartPosition = mixxx::audio::FramePos::fromEngineSamplePos(start);
     for (unsigned int i = 0; i < (sizeof(s_dBeatSizes) / sizeof(s_dBeatSizes[0])); ++i) {
-        double beatLoopOutPoint =
-            pBeats->findNBeatsFromSample(start, s_dBeatSizes[i]);
-        if (end > beatLoopOutPoint - 2 && end < beatLoopOutPoint + 2) {
-            return s_dBeatSizes[i];
+        const auto loopEndPosition = pBeats->findNBeatsFromSample(
+                loopStartPosition, s_dBeatSizes[i]);
+        if (loopEndPosition.isValid()) {
+            const double beatLoopOutPoint = loopEndPosition.toEngineSamplePos();
+            if (end > beatLoopOutPoint - 2 && end < beatLoopOutPoint + 2) {
+                return s_dBeatSizes[i];
+            }
         }
     }
     return -1;
@@ -1192,15 +1211,26 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable
     } else {
         // loop_in is set to the closest beat if quantize is on and the loop size is >= 1 beat.
         // The closest beat might be ahead of play position and will cause a catching loop.
-        double prevBeat;
-        double nextBeat;
-        pBeats->findPrevNextBeats(currentSample, &prevBeat, &nextBeat, true);
+        mixxx::audio::FramePos prevBeatPosition;
+        mixxx::audio::FramePos nextBeatPosition;
+        const auto currentPosition = mixxx::audio::FramePos::fromEngineSamplePos(currentSample);
+        pBeats->findPrevNextBeats(currentPosition, &prevBeatPosition, &nextBeatPosition, true);
+        const double prevBeat = prevBeatPosition.isValid()
+                ? prevBeatPosition.toEngineSamplePos()
+                : -1;
+        const double nextBeat = nextBeatPosition.isValid()
+                ? nextBeatPosition.toEngineSamplePos()
+                : -1;
 
         if (m_pQuantizeEnabled->toBool() && prevBeat != -1) {
             double beatLength = nextBeat - prevBeat;
             double loopLength = beatLength * beats;
 
-            double closestBeat = pBeats->findClosestBeat(currentSample);
+            const mixxx::audio::FramePos closestBeatPosition =
+                    pBeats->findClosestBeat(currentPosition);
+            double closestBeat = closestBeatPosition.isValid()
+                    ? closestBeatPosition.toEngineSamplePos()
+                    : -1;
             if (beats >= 1.0) {
                 newloopSamples.start = closestBeat;
             } else {
@@ -1239,7 +1269,11 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable
         }
     }
 
-    newloopSamples.end = pBeats->findNBeatsFromSample(newloopSamples.start, beats);
+    const auto newLoopStartPosition =
+            mixxx::audio::FramePos::fromEngineSamplePos(newloopSamples.start);
+    const auto newLoopEndPosition = pBeats->findNBeatsFromSample(newLoopStartPosition, beats);
+    newloopSamples.end = newLoopEndPosition.isValid() ? newLoopEndPosition.toEngineSamplePos() : -1;
+
     if (newloopSamples.start >= newloopSamples.end // happens when the call above fails
             || newloopSamples.end > samples) { // Do not allow beat loops to go beyond the end of the track
         // If a track is loaded with beatloop_size larger than
@@ -1247,8 +1281,12 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable
         // the end of the track, let beatloop_size be set to
         // a smaller size, but not get larger.
         double previousBeatloopSize = m_pCOBeatLoopSize->get();
-        double previousBeatloopOutPoint = pBeats->findNBeatsFromSample(
-                newloopSamples.start, previousBeatloopSize);
+        const mixxx::audio::FramePos previousLoopEndPosition =
+                pBeats->findNBeatsFromSample(
+                        newLoopStartPosition, previousBeatloopSize);
+        double previousBeatloopOutPoint = previousLoopEndPosition.isValid()
+                ? previousLoopEndPosition.toEngineSamplePos()
+                : -1;
         if (previousBeatloopOutPoint < newloopSamples.start
                 && beats < previousBeatloopSize) {
             m_pCOBeatLoopSize->setAndConfirm(beats);
@@ -1352,7 +1390,11 @@ void LoopingControl::slotBeatJump(double beats) {
         slotLoopMove(beats);
     } else {
         // seekExact bypasses Quantize, because a beat jump is implicit quantized
-        seekExact(pBeats->findNBeatsFromSample(currentSample, beats));
+        const auto currentPosition = mixxx::audio::FramePos::fromEngineSamplePos(currentSample);
+        const auto seekPosition = pBeats->findNBeatsFromSample(currentPosition, beats);
+        if (seekPosition.isValid()) {
+            seekExact(seekPosition.toEngineSamplePos());
+        }
     }
 }
 
@@ -1380,10 +1422,19 @@ void LoopingControl::slotLoopMove(double beats) {
 
     if (BpmControl::getBeatContext(pBeats, m_currentSample.getValue(),
                                    nullptr, nullptr, nullptr, nullptr)) {
-        double new_loop_in = pBeats->findNBeatsFromSample(loopSamples.start, beats);
-        double new_loop_out = currentLoopMatchesBeatloopSize() ?
-                pBeats->findNBeatsFromSample(new_loop_in, m_pCOBeatLoopSize->get()) :
-                pBeats->findNBeatsFromSample(loopSamples.end, beats);
+        const auto loopStartPosition =
+                mixxx::audio::FramePos::fromEngineSamplePos(loopSamples.start);
+        const auto loopEndPosition = mixxx::audio::FramePos::fromEngineSamplePos(loopSamples.end);
+        const auto newLoopStartPosition = pBeats->findNBeatsFromSample(loopStartPosition, beats);
+        const auto newLoopEndPosition = currentLoopMatchesBeatloopSize()
+                ? pBeats->findNBeatsFromSample(newLoopStartPosition, m_pCOBeatLoopSize->get())
+                : pBeats->findNBeatsFromSample(loopEndPosition, beats);
+        double new_loop_in = newLoopStartPosition.isValid()
+                ? newLoopStartPosition.toEngineSamplePos()
+                : kNoTrigger;
+        double new_loop_out = newLoopEndPosition.isValid()
+                ? newLoopEndPosition.toEngineSamplePos()
+                : kNoTrigger;
 
         // The track would stop as soon as the playhead crosses track end,
         // so we don't allow moving a loop beyond end.

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -542,7 +542,7 @@ void LoopingControl::setBeatLoop(double startPositionSamples, bool enabled) {
     // TODO(XXX): This is not realtime safe. See this Zulip discussion for details:
     // https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/getting.20locks.20out.20of.20Beats
     const auto startPosition = mixxx::audio::FramePos::fromEngineSamplePos(startPositionSamples);
-    const auto endPosition = pBeats->findNBeatsFromSample(startPosition, beatloopSize);
+    const auto endPosition = pBeats->findNBeatsFromPosition(startPosition, beatloopSize);
 
     if (startPosition.isValid() && endPosition.isValid()) {
         setLoop(startPositionSamples, endPosition.toEngineSamplePos(), enabled);
@@ -1109,7 +1109,7 @@ bool LoopingControl::currentLoopMatchesBeatloopSize() {
 
     // Calculate where the loop out point would be if it is a beatloop
     const auto loopStartPosition = mixxx::audio::FramePos::fromEngineSamplePos(loopSamples.start);
-    const auto loopEndPosition = pBeats->findNBeatsFromSample(
+    const auto loopEndPosition = pBeats->findNBeatsFromPosition(
             loopStartPosition, m_pCOBeatLoopSize->get());
     const double beatLoopOutPoint = loopEndPosition.isValid()
             ? loopEndPosition.toEngineSamplePos()
@@ -1127,7 +1127,7 @@ double LoopingControl::findBeatloopSizeForLoop(double start, double end) const {
 
     const auto loopStartPosition = mixxx::audio::FramePos::fromEngineSamplePos(start);
     for (unsigned int i = 0; i < (sizeof(s_dBeatSizes) / sizeof(s_dBeatSizes[0])); ++i) {
-        const auto loopEndPosition = pBeats->findNBeatsFromSample(
+        const auto loopEndPosition = pBeats->findNBeatsFromPosition(
                 loopStartPosition, s_dBeatSizes[i]);
         if (loopEndPosition.isValid()) {
             const double beatLoopOutPoint = loopEndPosition.toEngineSamplePos();
@@ -1271,7 +1271,7 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable
 
     const auto newLoopStartPosition =
             mixxx::audio::FramePos::fromEngineSamplePos(newloopSamples.start);
-    const auto newLoopEndPosition = pBeats->findNBeatsFromSample(newLoopStartPosition, beats);
+    const auto newLoopEndPosition = pBeats->findNBeatsFromPosition(newLoopStartPosition, beats);
     newloopSamples.end = newLoopEndPosition.isValid() ? newLoopEndPosition.toEngineSamplePos() : -1;
 
     if (newloopSamples.start >= newloopSamples.end // happens when the call above fails
@@ -1282,7 +1282,7 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable
         // a smaller size, but not get larger.
         double previousBeatloopSize = m_pCOBeatLoopSize->get();
         const mixxx::audio::FramePos previousLoopEndPosition =
-                pBeats->findNBeatsFromSample(
+                pBeats->findNBeatsFromPosition(
                         newLoopStartPosition, previousBeatloopSize);
         double previousBeatloopOutPoint = previousLoopEndPosition.isValid()
                 ? previousLoopEndPosition.toEngineSamplePos()
@@ -1391,7 +1391,7 @@ void LoopingControl::slotBeatJump(double beats) {
     } else {
         // seekExact bypasses Quantize, because a beat jump is implicit quantized
         const auto currentPosition = mixxx::audio::FramePos::fromEngineSamplePos(currentSample);
-        const auto seekPosition = pBeats->findNBeatsFromSample(currentPosition, beats);
+        const auto seekPosition = pBeats->findNBeatsFromPosition(currentPosition, beats);
         if (seekPosition.isValid()) {
             seekExact(seekPosition.toEngineSamplePos());
         }
@@ -1425,10 +1425,10 @@ void LoopingControl::slotLoopMove(double beats) {
         const auto loopStartPosition =
                 mixxx::audio::FramePos::fromEngineSamplePos(loopSamples.start);
         const auto loopEndPosition = mixxx::audio::FramePos::fromEngineSamplePos(loopSamples.end);
-        const auto newLoopStartPosition = pBeats->findNBeatsFromSample(loopStartPosition, beats);
+        const auto newLoopStartPosition = pBeats->findNBeatsFromPosition(loopStartPosition, beats);
         const auto newLoopEndPosition = currentLoopMatchesBeatloopSize()
-                ? pBeats->findNBeatsFromSample(newLoopStartPosition, m_pCOBeatLoopSize->get())
-                : pBeats->findNBeatsFromSample(loopEndPosition, beats);
+                ? pBeats->findNBeatsFromPosition(newLoopStartPosition, m_pCOBeatLoopSize->get())
+                : pBeats->findNBeatsFromPosition(loopEndPosition, beats);
         double new_loop_in = newLoopStartPosition.isValid()
                 ? newLoopStartPosition.toEngineSamplePos()
                 : kNoTrigger;

--- a/src/engine/controls/quantizecontrol.cpp
+++ b/src/engine/controls/quantizecontrol.cpp
@@ -79,10 +79,17 @@ void QuantizeControl::playPosChanged(double dNewPlaypos) {
 void QuantizeControl::lookupBeatPositions(double dCurrentSample) {
     mixxx::BeatsPointer pBeats = m_pBeats;
     if (pBeats) {
-        double prevBeat, nextBeat;
-        pBeats->findPrevNextBeats(dCurrentSample, &prevBeat, &nextBeat, true);
-        m_pCOPrevBeat->set(prevBeat);
-        m_pCONextBeat->set(nextBeat);
+        const auto position = mixxx::audio::FramePos::fromEngineSamplePos(dCurrentSample);
+        mixxx::audio::FramePos prevBeatPosition;
+        mixxx::audio::FramePos nextBeatPosition;
+        pBeats->findPrevNextBeats(position, &prevBeatPosition, &nextBeatPosition, true);
+        // FIXME: -1.0 is a valid frame position, should we set the COs to NaN?
+        m_pCOPrevBeat->set(prevBeatPosition.isValid()
+                        ? prevBeatPosition.toEngineSamplePos()
+                        : -1.0);
+        m_pCONextBeat->set(nextBeatPosition.isValid()
+                        ? nextBeatPosition.toEngineSamplePos()
+                        : -1.0);
     }
 }
 

--- a/src/library/export/engineprimeexportjob.cpp
+++ b/src/library/export/engineprimeexportjob.cpp
@@ -193,21 +193,24 @@ void exportMetadata(djinterop::database* pDatabase,
         // starts at the beginning of a bar, then move backwards towards the
         // beginning of the track in 4-beat decrements to find the first beat
         // in the track that also aligns with the start of a bar.
-        double firstBeatPlayPos = beats->findNextBeat(0);
-        double cueBeatPlayPos = beats->findClosestBeat(cuePlayPos);
+        const auto firstBeatPlayPos = beats->findNextBeat(mixxx::audio::kStartFramePos);
+        const auto cueBeatPlayPos = beats->findClosestBeat(
+                mixxx::audio::FramePos::fromEngineSamplePos(cuePlayPos));
         int numBeatsToCue = beats->numBeatsInRange(firstBeatPlayPos, cueBeatPlayPos);
-        double firstBarAlignedBeatPlayPos = beats->findNBeatsFromSample(
+        const auto firstBarAlignedBeatPlayPos = beats->findNBeatsFromSample(
                 cueBeatPlayPos, numBeatsToCue & ~0x3);
 
         // We will treat the first bar-aligned beat as beat zero.  Find the
         // number of beats from there until the end of the track in order to
         // correctly assign an index for the last beat.
-        double lastBeatPlayPos = beats->findPrevBeat(sampleOffsetToPlayPos(sampleCount));
+        const auto lastBeatPlayPos =
+                beats->findPrevBeat(mixxx::audio::FramePos::fromEngineSamplePos(
+                        sampleOffsetToPlayPos(sampleCount)));
         int numBeats = beats->numBeatsInRange(firstBarAlignedBeatPlayPos, lastBeatPlayPos);
         if (numBeats > 0) {
             std::vector<djinterop::beatgrid_marker> beatgrid{
-                    {0, playPosToSampleOffset(firstBarAlignedBeatPlayPos)},
-                    {numBeats, playPosToSampleOffset(lastBeatPlayPos)}};
+                    {0, playPosToSampleOffset(firstBarAlignedBeatPlayPos.toEngineSamplePos())},
+                    {numBeats, playPosToSampleOffset(lastBeatPlayPos.toEngineSamplePos())}};
             beatgrid = el::normalize_beatgrid(std::move(beatgrid), sampleCount);
             snapshot.default_beatgrid = beatgrid;
             snapshot.adjusted_beatgrid = beatgrid;

--- a/src/library/export/engineprimeexportjob.cpp
+++ b/src/library/export/engineprimeexportjob.cpp
@@ -193,7 +193,7 @@ void exportMetadata(djinterop::database* pDatabase,
         // starts at the beginning of a bar, then move backwards towards the
         // beginning of the track in 4-beat decrements to find the first beat
         // in the track that also aligns with the start of a bar.
-        const auto firstBeatPlayPos = beats->findNextBeat(mixxx::audio::kStartFramePos);
+        const auto firstBeatPlayPos = beats->firstBeat();
         const auto cueBeatPlayPos = beats->findClosestBeat(
                 mixxx::audio::FramePos::fromEngineSamplePos(cuePlayPos));
         int numBeatsToCue = beats->numBeatsInRange(firstBeatPlayPos, cueBeatPlayPos);

--- a/src/library/export/engineprimeexportjob.cpp
+++ b/src/library/export/engineprimeexportjob.cpp
@@ -197,7 +197,7 @@ void exportMetadata(djinterop::database* pDatabase,
         const auto cueBeatPlayPos = beats->findClosestBeat(
                 mixxx::audio::FramePos::fromEngineSamplePos(cuePlayPos));
         int numBeatsToCue = beats->numBeatsInRange(firstBeatPlayPos, cueBeatPlayPos);
-        const auto firstBarAlignedBeatPlayPos = beats->findNBeatsFromSample(
+        const auto firstBarAlignedBeatPlayPos = beats->findNBeatsFromPosition(
                 cueBeatPlayPos, numBeatsToCue & ~0x3);
 
         // We will treat the first bar-aligned beat as beat zero.  Find the

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -55,55 +55,57 @@ TEST(BeatGridTest, Scale) {
 }
 
 TEST(BeatGridTest, TestNthBeatWhenOnBeat) {
-    int sampleRate = 44100;
+    constexpr int sampleRate = 44100;
     TrackPointer pTrack = newTrack(sampleRate);
 
-    double bpm = 60.1;
-    const int kFrameSize = 2;
+    constexpr double bpm = 60.1;
     pTrack->trySetBpm(bpm);
-    double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
+    constexpr mixxx::audio::FrameDiff_t beatLengthFrames = 60.0 * sampleRate / bpm;
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
             QString(),
             mixxx::Bpm(bpm),
             mixxx::audio::kStartFramePos);
     // Pretend we're on the 20th beat;
-    double position = beatLength * 20;
+    constexpr mixxx::audio::FramePos position(beatLengthFrames * 20);
 
-    // The spec dictates that a value of 0 is always invalid and returns -1
-    EXPECT_EQ(-1, pGrid->findNthBeat(position, 0));
+    // The spec dictates that a value of 0 is always invalid and returns an invalid position
+    EXPECT_FALSE(pGrid->findNthBeat(position, 0).isValid());
 
     // findNthBeat should return exactly the current beat if we ask for 1 or
     // -1. For all other values, it should return n times the beat length.
     for (int i = 1; i < 20; ++i) {
-        EXPECT_NEAR(position + beatLength * (i - 1), pGrid->findNthBeat(position, i), kMaxBeatError);
-        EXPECT_NEAR(position + beatLength * (-i + 1), pGrid->findNthBeat(position, -i), kMaxBeatError);
+        EXPECT_NEAR((position + beatLengthFrames * (i - 1)).value(),
+                pGrid->findNthBeat(position, i).value(),
+                kMaxBeatError);
+        EXPECT_NEAR((position + beatLengthFrames * (-i + 1)).value(),
+                pGrid->findNthBeat(position, -i).value(),
+                kMaxBeatError);
     }
 
     // Also test prev/next beat calculation.
-    double prevBeat, nextBeat;
+    mixxx::audio::FramePos prevBeat, nextBeat;
     pGrid->findPrevNextBeats(position, &prevBeat, &nextBeat, true);
-    EXPECT_NEAR(position, prevBeat, kMaxBeatError);
-    EXPECT_NEAR(position + beatLength, nextBeat, kMaxBeatError);
+    EXPECT_NEAR(position.value(), prevBeat.value(), kMaxBeatError);
+    EXPECT_NEAR((position + beatLengthFrames).value(), nextBeat.value(), kMaxBeatError);
 
     // Also test prev/next beat calculation without snapping tolerance
     pGrid->findPrevNextBeats(position, &prevBeat, &nextBeat, false);
-    EXPECT_NEAR(position, prevBeat, kMaxBeatError);
-    EXPECT_NEAR(position + beatLength, nextBeat, kMaxBeatError);
+    EXPECT_NEAR(position.value(), prevBeat.value(), kMaxBeatError);
+    EXPECT_NEAR((position + beatLengthFrames).value(), nextBeat.value(), kMaxBeatError);
 
     // Both previous and next beat should return the current position.
-    EXPECT_NEAR(position, pGrid->findNextBeat(position), kMaxBeatError);
-    EXPECT_NEAR(position, pGrid->findPrevBeat(position), kMaxBeatError);
+    EXPECT_NEAR(position.value(), pGrid->findNextBeat(position).value(), kMaxBeatError);
+    EXPECT_NEAR(position.value(), pGrid->findPrevBeat(position).value(), kMaxBeatError);
 }
 
 TEST(BeatGridTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
-    int sampleRate = 44100;
+    constexpr int sampleRate = 44100;
     TrackPointer pTrack = newTrack(sampleRate);
 
-    double bpm = 60.1;
-    const int kFrameSize = 2;
+    constexpr double bpm = 60.1;
     pTrack->trySetBpm(bpm);
-    double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
+    constexpr double beatLengthFrames = 60.0 * sampleRate / bpm;
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
             QString(),
@@ -111,43 +113,46 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
             mixxx::audio::kStartFramePos);
 
     // Pretend we're just before the 20th beat.
-    const double kClosestBeat = 20 * beatLength;
-    double position = kClosestBeat - beatLength * 0.005;
+    constexpr mixxx::audio::FramePos kClosestBeat(20 * beatLengthFrames);
+    const mixxx::audio::FramePos position(kClosestBeat - beatLengthFrames * 0.005);
 
-    // The spec dictates that a value of 0 is always invalid and returns -1
-    EXPECT_EQ(-1, pGrid->findNthBeat(position, 0));
+    // The spec dictates that a value of 0 is always invalid and returns an invalid position
+    EXPECT_FALSE(pGrid->findNthBeat(position, 0).isValid());
 
     // findNthBeat should return exactly the current beat if we ask for 1 or
     // -1. For all other values, it should return n times the beat length.
     for (int i = 1; i < 20; ++i) {
-        EXPECT_NEAR(kClosestBeat + beatLength * (i - 1), pGrid->findNthBeat(position, i), kMaxBeatError);
-        EXPECT_NEAR(kClosestBeat + beatLength * (-i + 1), pGrid->findNthBeat(position, -i), kMaxBeatError);
+        EXPECT_NEAR((kClosestBeat + beatLengthFrames * (i - 1)).value(),
+                pGrid->findNthBeat(position, i).value(),
+                kMaxBeatError);
+        EXPECT_NEAR((kClosestBeat + beatLengthFrames * (-i + 1)).value(),
+                pGrid->findNthBeat(position, -i).value(),
+                kMaxBeatError);
     }
 
     // Also test prev/next beat calculation.
-    double prevBeat, nextBeat;
+    mixxx::audio::FramePos prevBeat, nextBeat;
     pGrid->findPrevNextBeats(position, &prevBeat, &nextBeat, true);
-    EXPECT_NEAR(kClosestBeat, prevBeat, kMaxBeatError);
-    EXPECT_NEAR(kClosestBeat + beatLength, nextBeat, kMaxBeatError);
+    EXPECT_NEAR(kClosestBeat.value(), prevBeat.value(), kMaxBeatError);
+    EXPECT_NEAR((kClosestBeat + beatLengthFrames).value(), nextBeat.value(), kMaxBeatError);
 
     // Also test prev/next beat calculation without snapping tolerance
     pGrid->findPrevNextBeats(position, &prevBeat, &nextBeat, false);
-    EXPECT_NEAR(kClosestBeat - beatLength, prevBeat, kMaxBeatError);
-    EXPECT_NEAR(kClosestBeat, nextBeat, kMaxBeatError);
+    EXPECT_NEAR((kClosestBeat - beatLengthFrames).value(), prevBeat.value(), kMaxBeatError);
+    EXPECT_NEAR(kClosestBeat.value(), nextBeat.value(), kMaxBeatError);
 
     // Both previous and next beat should return the closest beat.
-    EXPECT_NEAR(kClosestBeat, pGrid->findNextBeat(position), kMaxBeatError);
-    EXPECT_NEAR(kClosestBeat, pGrid->findPrevBeat(position), kMaxBeatError);
+    EXPECT_NEAR(kClosestBeat.value(), pGrid->findNextBeat(position).value(), kMaxBeatError);
+    EXPECT_NEAR(kClosestBeat.value(), pGrid->findPrevBeat(position).value(), kMaxBeatError);
 }
 
 TEST(BeatGridTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
-    int sampleRate = 44100;
+    constexpr int sampleRate = 44100;
     TrackPointer pTrack = newTrack(sampleRate);
 
-    double bpm = 60.1;
-    const int kFrameSize = 2;
+    constexpr double bpm = 60.1;
     pTrack->trySetBpm(bpm);
-    double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
+    constexpr double beatLengthFrames = 60.0 * sampleRate / bpm;
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
             QString(),
@@ -155,43 +160,46 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
             mixxx::audio::kStartFramePos);
 
     // Pretend we're just before the 20th beat.
-    const double kClosestBeat = 20 * beatLength;
-    double position = kClosestBeat + beatLength * 0.005;
+    constexpr mixxx::audio::FramePos kClosestBeat(20 * beatLengthFrames);
+    const mixxx::audio::FramePos position(kClosestBeat + beatLengthFrames * 0.005);
 
-    // The spec dictates that a value of 0 is always invalid and returns -1
-    EXPECT_EQ(-1, pGrid->findNthBeat(position, 0));
+    // The spec dictates that a value of 0 is always invalid and returns an invalid position
+    EXPECT_FALSE(pGrid->findNthBeat(position, 0).isValid());
 
     // findNthBeat should return exactly the current beat if we ask for 1 or
     // -1. For all other values, it should return n times the beat length.
     for (int i = 1; i < 20; ++i) {
-        EXPECT_NEAR(kClosestBeat + beatLength * (i - 1), pGrid->findNthBeat(position, i), kMaxBeatError);
-        EXPECT_NEAR(kClosestBeat + beatLength * (-i + 1), pGrid->findNthBeat(position, -i), kMaxBeatError);
+        EXPECT_NEAR((kClosestBeat + beatLengthFrames * (i - 1)).value(),
+                pGrid->findNthBeat(position, i).value(),
+                kMaxBeatError);
+        EXPECT_NEAR((kClosestBeat + beatLengthFrames * (-i + 1)).value(),
+                pGrid->findNthBeat(position, -i).value(),
+                kMaxBeatError);
     }
 
     // Also test prev/next beat calculation.
-    double prevBeat, nextBeat;
+    mixxx::audio::FramePos prevBeat, nextBeat;
     pGrid->findPrevNextBeats(position, &prevBeat, &nextBeat, true);
-    EXPECT_NEAR(kClosestBeat, prevBeat, kMaxBeatError);
-    EXPECT_NEAR(kClosestBeat + beatLength, nextBeat, kMaxBeatError);
+    EXPECT_NEAR(kClosestBeat.value(), prevBeat.value(), kMaxBeatError);
+    EXPECT_NEAR((kClosestBeat + beatLengthFrames).value(), nextBeat.value(), kMaxBeatError);
 
     // Also test prev/next beat calculation without snapping tolerance
     pGrid->findPrevNextBeats(position, &prevBeat, &nextBeat, false);
-    EXPECT_NEAR(kClosestBeat, prevBeat, kMaxBeatError);
-    EXPECT_NEAR(kClosestBeat + beatLength, nextBeat, kMaxBeatError);
+    EXPECT_NEAR(kClosestBeat.value(), prevBeat.value(), kMaxBeatError);
+    EXPECT_NEAR((kClosestBeat + beatLengthFrames).value(), nextBeat.value(), kMaxBeatError);
 
     // Both previous and next beat should return the closest beat.
-    EXPECT_NEAR(kClosestBeat, pGrid->findNextBeat(position), kMaxBeatError);
-    EXPECT_NEAR(kClosestBeat, pGrid->findPrevBeat(position), kMaxBeatError);
+    EXPECT_NEAR(kClosestBeat.value(), pGrid->findNextBeat(position).value(), kMaxBeatError);
+    EXPECT_NEAR(kClosestBeat.value(), pGrid->findPrevBeat(position).value(), kMaxBeatError);
 }
 
 TEST(BeatGridTest, TestNthBeatWhenNotOnBeat) {
-    int sampleRate = 44100;
+    constexpr int sampleRate = 44100;
     TrackPointer pTrack = newTrack(sampleRate);
 
-    const auto bpm = mixxx::Bpm(60.1);
-    const int kFrameSize = 2;
+    constexpr mixxx::Bpm bpm(60.1);
     pTrack->trySetBpm(bpm.value());
-    double beatLength = (60.0 * sampleRate / bpm.value()) * kFrameSize;
+    const mixxx::audio::FrameDiff_t beatLengthFrames = 60.0 * sampleRate / bpm.value();
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
             QString(),
@@ -199,30 +207,34 @@ TEST(BeatGridTest, TestNthBeatWhenNotOnBeat) {
             mixxx::audio::kStartFramePos);
 
     // Pretend we're half way between the 20th and 21st beat
-    double previousBeat = beatLength * 20.0;
-    double nextBeat = beatLength * 21.0;
-    double position = (nextBeat + previousBeat) / 2.0;
+    const mixxx::audio::FramePos previousBeat(beatLengthFrames * 20.0);
+    const mixxx::audio::FramePos nextBeat(beatLengthFrames * 21.0);
+    const mixxx::audio::FramePos position = previousBeat + (nextBeat - previousBeat) / 2.0;
 
-    // The spec dictates that a value of 0 is always invalid and returns -1
-    EXPECT_EQ(-1, pGrid->findNthBeat(position, 0));
+    // The spec dictates that a value of 0 is always invalid and returns an invalid position
+    EXPECT_FALSE(pGrid->findNthBeat(position, 0).isValid());
 
     // findNthBeat should return multiples of beats starting from the next or
     // previous beat, depending on whether N is positive or negative.
     for (int i = 1; i < 20; ++i) {
-        EXPECT_NEAR(nextBeat + beatLength*(i-1), pGrid->findNthBeat(position, i), kMaxBeatError);
-        EXPECT_NEAR(previousBeat + beatLength*(-i+1), pGrid->findNthBeat(position, -i), kMaxBeatError);
+        EXPECT_NEAR((nextBeat + beatLengthFrames * (i - 1)).value(),
+                pGrid->findNthBeat(position, i).value(),
+                kMaxBeatError);
+        EXPECT_NEAR((previousBeat + beatLengthFrames * (-i + 1)).value(),
+                pGrid->findNthBeat(position, -i).value(),
+                kMaxBeatError);
     }
 
     // Also test prev/next beat calculation
-    double foundPrevBeat, foundNextBeat;
+    mixxx::audio::FramePos foundPrevBeat, foundNextBeat;
     pGrid->findPrevNextBeats(position, &foundPrevBeat, &foundNextBeat, true);
-    EXPECT_NEAR(previousBeat, foundPrevBeat, kMaxBeatError);
-    EXPECT_NEAR(nextBeat, foundNextBeat, kMaxBeatError);
+    EXPECT_NEAR(previousBeat.value(), foundPrevBeat.value(), kMaxBeatError);
+    EXPECT_NEAR(nextBeat.value(), foundNextBeat.value(), kMaxBeatError);
 
     // Also test prev/next beat calculation without snapping tolerance
     pGrid->findPrevNextBeats(position, &foundPrevBeat, &foundNextBeat, false);
-    EXPECT_NEAR(previousBeat, foundPrevBeat, kMaxBeatError);
-    EXPECT_NEAR(nextBeat, foundNextBeat, kMaxBeatError);
+    EXPECT_NEAR(previousBeat.value(), foundPrevBeat.value(), kMaxBeatError);
+    EXPECT_NEAR(nextBeat.value(), foundNextBeat.value(), kMaxBeatError);
 }
 
 TEST(BeatGridTest, FromMetadata) {

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -27,10 +27,6 @@ class BeatMapTest : public testing::Test {
         return (60.0 * m_iSampleRate / bpm.value());
     }
 
-    double getBeatLengthSamples(mixxx::Bpm bpm) {
-        return getBeatLengthFrames(bpm) * m_iFrameSize;
-    }
-
     QVector<mixxx::audio::FramePos> createBeatVector(mixxx::audio::FramePos first_beat,
             unsigned int num_beats,
             mixxx::audio::FrameDiff_t beat_length) {
@@ -82,8 +78,6 @@ TEST_F(BeatMapTest, TestNthBeat) {
     m_pTrack->trySetBpm(bpm.value());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
-    double beatLengthSamples = getBeatLengthSamples(bpm);
-    const double startOffsetSamples = startOffsetFrames.toEngineSamplePos();
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<mixxx::audio::FramePos> beats =
@@ -91,23 +85,23 @@ TEST_F(BeatMapTest, TestNthBeat) {
     auto pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
 
     // Check edge cases
-    double firstBeat = startOffsetSamples + beatLengthSamples * 0;
-    double lastBeat = startOffsetSamples + beatLengthSamples * (numBeats - 1);
+    const mixxx::audio::FramePos firstBeat = startOffsetFrames + beatLengthFrames * 0;
+    const mixxx::audio::FramePos lastBeat = startOffsetFrames + beatLengthFrames * (numBeats - 1);
     EXPECT_EQ(lastBeat, pMap->findNthBeat(lastBeat, 1));
     EXPECT_EQ(lastBeat, pMap->findNextBeat(lastBeat));
-    EXPECT_EQ(-1, pMap->findNthBeat(lastBeat, 2));
+    EXPECT_FALSE(pMap->findNthBeat(lastBeat, 2).isValid());
     EXPECT_EQ(firstBeat, pMap->findNthBeat(firstBeat, -1));
     EXPECT_EQ(firstBeat, pMap->findPrevBeat(firstBeat));
-    EXPECT_EQ(-1, pMap->findNthBeat(firstBeat, -2));
+    EXPECT_FALSE(pMap->findNthBeat(firstBeat, -2).isValid());
 
-    double prevBeat, nextBeat;
+    mixxx::audio::FramePos prevBeat, nextBeat;
     pMap->findPrevNextBeats(lastBeat, &prevBeat, &nextBeat, true);
     EXPECT_EQ(lastBeat, prevBeat);
-    EXPECT_EQ(-1, nextBeat);
+    EXPECT_FALSE(nextBeat.isValid());
 
     pMap->findPrevNextBeats(firstBeat, &prevBeat, &nextBeat, true);
     EXPECT_EQ(firstBeat, prevBeat);
-    EXPECT_EQ(firstBeat + beatLengthSamples, nextBeat);
+    EXPECT_EQ(firstBeat + beatLengthFrames, nextBeat);
 }
 
 TEST_F(BeatMapTest, TestNthBeatWhenOnBeat) {
@@ -115,8 +109,6 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat) {
     m_pTrack->trySetBpm(bpm.value());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
-    double beatLengthSamples = getBeatLengthSamples(bpm);
-    const double startOffsetSamples = startOffsetFrames.toEngineSamplePos();
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<mixxx::audio::FramePos> beats =
@@ -125,28 +117,30 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat) {
 
     // Pretend we're on the 20th beat;
     const int curBeat = 20;
-    double position = startOffsetSamples + beatLengthSamples * curBeat;
+    const mixxx::audio::FramePos position = startOffsetFrames + beatLengthFrames * curBeat;
 
-    // The spec dictates that a value of 0 is always invalid and returns -1
-    EXPECT_EQ(-1, pMap->findNthBeat(position, 0));
+    // The spec dictates that a value of 0 is always invalid and returns an invalid position
+    EXPECT_FALSE(pMap->findNthBeat(position, 0).isValid());
 
     // findNthBeat should return exactly the current beat if we ask for 1 or
     // -1. For all other values, it should return n times the beat length.
     for (int i = 1; i < curBeat; ++i) {
-        EXPECT_DOUBLE_EQ(position + beatLengthSamples*(i-1), pMap->findNthBeat(position, i));
-        EXPECT_DOUBLE_EQ(position + beatLengthSamples*(-i+1), pMap->findNthBeat(position, -i));
+        EXPECT_DOUBLE_EQ((position + beatLengthFrames * (i - 1)).value(),
+                pMap->findNthBeat(position, i).value());
+        EXPECT_DOUBLE_EQ((position + beatLengthFrames * (-i + 1)).value(),
+                pMap->findNthBeat(position, -i).value());
     }
 
     // Also test prev/next beat calculation.
-    double prevBeat, nextBeat;
+    mixxx::audio::FramePos prevBeat, nextBeat;
     pMap->findPrevNextBeats(position, &prevBeat, &nextBeat, true);
     EXPECT_EQ(position, prevBeat);
-    EXPECT_EQ(position + beatLengthSamples, nextBeat);
+    EXPECT_EQ(position + beatLengthFrames, nextBeat);
 
     // Also test prev/next beat calculation without snapping tolerance
     pMap->findPrevNextBeats(position, &prevBeat, &nextBeat, false);
     EXPECT_EQ(position, prevBeat);
-    EXPECT_EQ(position + beatLengthSamples, nextBeat);
+    EXPECT_EQ(position + beatLengthFrames, nextBeat);
 
     // Both previous and next beat should return the current position.
     EXPECT_EQ(position, pMap->findNextBeat(position));
@@ -158,8 +152,6 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
     m_pTrack->trySetBpm(bpm.value());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
-    double beatLengthSamples = getBeatLengthSamples(bpm);
-    const double startOffsetSamples = startOffsetFrames.toEngineSamplePos();
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<mixxx::audio::FramePos> beats =
@@ -168,28 +160,30 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
 
     // Pretend we're just before the 20th beat;
     const int curBeat = 20;
-    const double kClosestBeat = startOffsetSamples + curBeat * beatLengthSamples;
-    double position = kClosestBeat - beatLengthSamples * 0.005;
+    const mixxx::audio::FramePos kClosestBeat = startOffsetFrames + curBeat * beatLengthFrames;
+    const mixxx::audio::FramePos position = kClosestBeat - beatLengthFrames * 0.005;
 
     // The spec dictates that a value of 0 is always invalid and returns -1
-    EXPECT_EQ(-1, pMap->findNthBeat(position, 0));
+    EXPECT_FALSE(pMap->findNthBeat(position, 0).isValid());
 
     // findNthBeat should return exactly the current beat if we ask for 1 or
     // -1. For all other values, it should return n times the beat length.
     for (int i = 1; i < curBeat; ++i) {
-        EXPECT_DOUBLE_EQ(kClosestBeat + beatLengthSamples*(i-1), pMap->findNthBeat(position, i));
-        EXPECT_DOUBLE_EQ(kClosestBeat + beatLengthSamples*(-i+1), pMap->findNthBeat(position, -i));
+        EXPECT_DOUBLE_EQ((kClosestBeat + beatLengthFrames * (i - 1)).value(),
+                pMap->findNthBeat(position, i).value());
+        EXPECT_DOUBLE_EQ((kClosestBeat + beatLengthFrames * (-i + 1)).value(),
+                pMap->findNthBeat(position, -i).value());
     }
 
     // Also test prev/next beat calculation
-    double prevBeat, nextBeat;
+    mixxx::audio::FramePos prevBeat, nextBeat;
     pMap->findPrevNextBeats(position, &prevBeat, &nextBeat, true);
     EXPECT_EQ(kClosestBeat, prevBeat);
-    EXPECT_EQ(kClosestBeat + beatLengthSamples, nextBeat);
+    EXPECT_EQ(kClosestBeat + beatLengthFrames, nextBeat);
 
     // Also test prev/next beat calculation without snapping tolerance
     pMap->findPrevNextBeats(position, &prevBeat, &nextBeat, false);
-    EXPECT_EQ(kClosestBeat - beatLengthSamples, prevBeat);
+    EXPECT_EQ(kClosestBeat - beatLengthFrames, prevBeat);
     EXPECT_EQ(kClosestBeat, nextBeat);
 
     // Both previous and next beat should return the closest beat.
@@ -203,8 +197,6 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
     m_pTrack->trySetBpm(bpm.value());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
-    double beatLengthSamples = getBeatLengthSamples(bpm);
-    const double startOffsetSamples = startOffsetFrames.toEngineSamplePos();
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<mixxx::audio::FramePos> beats =
@@ -213,31 +205,33 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
 
     // Pretend we're just after the 20th beat;
     const int curBeat = 20;
-    const double kClosestBeat = startOffsetSamples + curBeat * beatLengthSamples;
-    double position = kClosestBeat + beatLengthSamples * 0.005;
+    const mixxx::audio::FramePos kClosestBeat = startOffsetFrames + curBeat * beatLengthFrames;
+    const mixxx::audio::FramePos position = kClosestBeat + beatLengthFrames * 0.005;
 
     // The spec dictates that a value of 0 is always invalid and returns -1
-    EXPECT_EQ(-1, pMap->findNthBeat(position, 0));
+    EXPECT_FALSE(pMap->findNthBeat(position, 0).isValid());
 
     EXPECT_EQ(kClosestBeat, pMap->findClosestBeat(position));
 
     // findNthBeat should return exactly the current beat if we ask for 1 or
     // -1. For all other values, it should return n times the beat length.
     for (int i = 1; i < curBeat; ++i) {
-        EXPECT_DOUBLE_EQ(kClosestBeat + beatLengthSamples*(i-1), pMap->findNthBeat(position, i));
-        EXPECT_DOUBLE_EQ(kClosestBeat + beatLengthSamples*(-i+1), pMap->findNthBeat(position, -i));
+        EXPECT_DOUBLE_EQ((kClosestBeat + beatLengthFrames * (i - 1)).value(),
+                pMap->findNthBeat(position, i).value());
+        EXPECT_DOUBLE_EQ((kClosestBeat + beatLengthFrames * (-i + 1)).value(),
+                pMap->findNthBeat(position, -i).value());
     }
 
     // Also test prev/next beat calculation.
-    double prevBeat, nextBeat;
+    mixxx::audio::FramePos prevBeat, nextBeat;
     pMap->findPrevNextBeats(position, &prevBeat, &nextBeat, true);
     EXPECT_EQ(kClosestBeat, prevBeat);
-    EXPECT_EQ(kClosestBeat + beatLengthSamples, nextBeat);
+    EXPECT_EQ(kClosestBeat + beatLengthFrames, nextBeat);
 
     // Also test prev/next beat calculation without snapping tolerance
     pMap->findPrevNextBeats(position, &prevBeat, &nextBeat, false);
     EXPECT_EQ(kClosestBeat, prevBeat);
-    EXPECT_EQ(kClosestBeat + beatLengthSamples, nextBeat);
+    EXPECT_EQ(kClosestBeat + beatLengthFrames, nextBeat);
 
     // Both previous and next beat should return the closest beat.
     EXPECT_EQ(kClosestBeat, pMap->findNextBeat(position));
@@ -249,8 +243,6 @@ TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
     m_pTrack->trySetBpm(bpm.value());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
-    double beatLengthSamples = getBeatLengthSamples(bpm);
-    const double startOffsetSamples = startOffsetFrames.toEngineSamplePos();
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<mixxx::audio::FramePos> beats =
@@ -258,24 +250,24 @@ TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
     auto pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
 
     // Pretend we're half way between the 20th and 21st beat
-    double previousBeat = startOffsetSamples + beatLengthSamples * 20.0;
-    double nextBeat = startOffsetSamples + beatLengthSamples * 21.0;
-    double position = (nextBeat + previousBeat) / 2.0;
+    const mixxx::audio::FramePos previousBeat = startOffsetFrames + beatLengthFrames * 20.0;
+    const mixxx::audio::FramePos nextBeat = startOffsetFrames + beatLengthFrames * 21.0;
+    const mixxx::audio::FramePos position = previousBeat + (nextBeat - previousBeat) / 2.0;
 
     // The spec dictates that a value of 0 is always invalid and returns -1
-    EXPECT_EQ(-1, pMap->findNthBeat(position, 0));
+    EXPECT_FALSE(pMap->findNthBeat(position, 0).isValid());
 
     // findNthBeat should return multiples of beats starting from the next or
     // previous beat, depending on whether N is positive or negative.
     for (int i = 1; i < 20; ++i) {
-        EXPECT_DOUBLE_EQ(nextBeat + beatLengthSamples*(i-1),
-                         pMap->findNthBeat(position, i));
-        EXPECT_DOUBLE_EQ(previousBeat - beatLengthSamples*(i-1),
-                         pMap->findNthBeat(position, -i));
+        EXPECT_DOUBLE_EQ((nextBeat + beatLengthFrames * (i - 1)).value(),
+                pMap->findNthBeat(position, i).value());
+        EXPECT_DOUBLE_EQ((previousBeat - beatLengthFrames * (i - 1)).value(),
+                pMap->findNthBeat(position, -i).value());
     }
 
     // Also test prev/next beat calculation
-    double foundPrevBeat, foundNextBeat;
+    mixxx::audio::FramePos foundPrevBeat, foundNextBeat;
     pMap->findPrevNextBeats(position, &foundPrevBeat, &foundNextBeat, true);
     EXPECT_EQ(previousBeat, foundPrevBeat);
     EXPECT_EQ(nextBeat, foundNextBeat);
@@ -288,7 +280,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
 
 TEST_F(BeatMapTest, TestBpmAround) {
     constexpr mixxx::Bpm filebpm(60.0);
-    double approx_beat_length = getBeatLengthSamples(filebpm);
+    double approx_beat_length = getBeatLengthFrames(filebpm);
     m_pTrack->trySetBpm(filebpm.value());
     const int numBeats = 64;
 
@@ -305,21 +297,33 @@ TEST_F(BeatMapTest, TestBpmAround) {
     // The average of the first 8 beats should be different than the average
     // of the last 8 beats.
     EXPECT_DOUBLE_EQ(63.937645572318047,
-            pMap->getBpmAroundPosition(4 * approx_beat_length, 4).value());
+            pMap->getBpmAroundPosition(
+                        mixxx::audio::kStartFramePos + 4 * approx_beat_length,
+                        4)
+                    .value());
     EXPECT_DOUBLE_EQ(118.96668932698844,
-            pMap->getBpmAroundPosition(60 * approx_beat_length, 4).value());
+            pMap->getBpmAroundPosition(
+                        mixxx::audio::kStartFramePos + 60 * approx_beat_length,
+                        4)
+                    .value());
     // Also test at the beginning and end of the track
     EXPECT_DOUBLE_EQ(62.937377309576974,
-            pMap->getBpmAroundPosition(0, 4).value());
+            pMap->getBpmAroundPosition(mixxx::audio::kStartFramePos, 4).value());
     EXPECT_DOUBLE_EQ(118.96668932698844,
-            pMap->getBpmAroundPosition(65 * approx_beat_length, 4).value());
+            pMap->getBpmAroundPosition(
+                        mixxx::audio::kStartFramePos + 65 * approx_beat_length,
+                        4)
+                    .value());
 
     // Try a really, really short track
     constexpr auto startFramePos = mixxx::audio::FramePos(10);
-    beats = createBeatVector(startFramePos, 3, getBeatLengthFrames(filebpm));
+    beats = createBeatVector(startFramePos, 3, approx_beat_length);
     pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
     EXPECT_DOUBLE_EQ(filebpm.value(),
-            pMap->getBpmAroundPosition(1 * approx_beat_length, 4).value());
+            pMap->getBpmAroundPosition(
+                        mixxx::audio::kStartFramePos + 1 * approx_beat_length,
+                        4)
+                    .value());
 }
 
 }  // namespace

--- a/src/test/beatstranslatetest.cpp
+++ b/src/test/beatstranslatetest.cpp
@@ -12,16 +12,18 @@ TEST_F(BeatsTranslateTest, SimpleTranslateMatch) {
     auto grid1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), QString(), bpm, firstBeat);
     m_pTrack1->trySetBeats(grid1);
-    ASSERT_DOUBLE_EQ(firstBeat.value(), grid1->findClosestBeat(0));
+    ASSERT_DOUBLE_EQ(firstBeat.value(),
+            grid1->findClosestBeat(mixxx::audio::kStartFramePos).value());
 
     auto grid2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), QString(), bpm, firstBeat);
     m_pTrack2->trySetBeats(grid2);
-    ASSERT_DOUBLE_EQ(firstBeat.value(), grid2->findClosestBeat(0));
+    ASSERT_DOUBLE_EQ(firstBeat.value(),
+            grid2->findClosestBeat(mixxx::audio::kStartFramePos).value());
 
     // Seek deck 1 forward a bit.
-    const double delta = 2222.0;
-    m_pChannel1->getEngineBuffer()->slotControlSeekAbs(delta);
+    const double deltaFrames = 1111.0;
+    m_pChannel1->getEngineBuffer()->slotControlSeekAbs(deltaFrames * 2.0);
     ProcessBuffer();
     EXPECT_TRUE(m_pChannel1->getEngineBuffer()->getVisualPlayPos() > 0);
 
@@ -43,9 +45,9 @@ TEST_F(BeatsTranslateTest, SimpleTranslateMatch) {
     pTranslateMatchAlignment->set(1.0);
     ProcessBuffer();
 
-    // Deck 1 is +delta away from its closest beat (which is at 0).
-    // Deck 2 was left at 0. We translated grid 2 so that it is also +delta
-    // away from its closest beat, so that beat should be at -delta.
+    // Deck 1 is +deltaFrames away from its closest beat (which is at 0).
+    // Deck 2 was left at 0. We translated grid 2 so that it is also +deltaFrames
+    // away from its closest beat, so that beat should be at -deltaFrames.
     mixxx::BeatsPointer beats = m_pTrack2->getBeats();
-    ASSERT_DOUBLE_EQ(-delta, beats->findClosestBeat(0));
+    ASSERT_DOUBLE_EQ(-deltaFrames, beats->findClosestBeat(mixxx::audio::kStartFramePos).value());
 }

--- a/src/test/seratobeatgridtest.cpp
+++ b/src/test/seratobeatgridtest.cpp
@@ -157,9 +157,8 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
                 sampleRate, QString("Test"), beatPositionsFrames);
         // Check that the first section's BPM is 100
         EXPECT_EQ(pBeats->getBpmAroundPosition(
-                          signalInfo.frames2samples(
-                                  static_cast<SINT>(initialFrameOffset +
-                                          framesPerBeat * kNumBeats120BPM / 2)),
+                          mixxx::audio::FramePos(initialFrameOffset +
+                                  framesPerBeat * kNumBeats120BPM / 2),
                           1),
                 bpm);
 
@@ -196,17 +195,15 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
                 sampleRate, QString("Test"), beatPositionsFrames);
         // Check that the first section'd BPM is 100
         EXPECT_EQ(pBeats->getBpmAroundPosition(
-                          signalInfo.frames2samples(
-                                  static_cast<SINT>(initialFrameOffset +
-                                          framesPerBeat * kNumBeats120BPM / 2)),
+                          mixxx::audio::FramePos(initialFrameOffset +
+                                  framesPerBeat * kNumBeats120BPM / 2),
                           1),
                 bpm);
         // Check that the second section'd BPM is 50
         EXPECT_EQ(pBeats->getBpmAroundPosition(
-                          signalInfo.frames2samples(
-                                  static_cast<SINT>(initialFrameOffset +
-                                          framesPerBeat * kNumBeats120BPM +
-                                          framesPerBeat * kNumBeats60BPM / 2)),
+                          mixxx::audio::FramePos(initialFrameOffset +
+                                  framesPerBeat * kNumBeats120BPM +
+                                  framesPerBeat * kNumBeats60BPM / 2),
                           1),
                 bpm / 2);
 
@@ -249,25 +246,22 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
                 sampleRate, QString("Test"), beatPositionsFrames);
         // Check that the first section's BPM is 100
         EXPECT_EQ(pBeats->getBpmAroundPosition(
-                          signalInfo.frames2samples(
-                                  static_cast<SINT>(initialFrameOffset +
-                                          framesPerBeat * kNumBeats120BPM / 2)),
+                          mixxx::audio::FramePos(initialFrameOffset +
+                                  framesPerBeat * kNumBeats120BPM / 2),
                           1),
                 bpm);
         // Check that the second section's BPM is 50
         EXPECT_EQ(pBeats->getBpmAroundPosition(
-                          signalInfo.frames2samples(
-                                  static_cast<SINT>(initialFrameOffset +
-                                          framesPerBeat * kNumBeats120BPM +
-                                          framesPerBeat * kNumBeats60BPM / 2)),
+                          mixxx::audio::FramePos(initialFrameOffset +
+                                  framesPerBeat * kNumBeats120BPM +
+                                  framesPerBeat * kNumBeats60BPM / 2),
                           1),
                 bpm / 2);
         // Check that the third section's BPM is 100
         EXPECT_EQ(pBeats->getBpmAroundPosition(
-                          signalInfo.frames2samples(static_cast<SINT>(
-                                  initialFrameOffset +
+                          mixxx::audio::FramePos(initialFrameOffset +
                                   framesPerBeat * kNumBeats120BPM * 1.5 +
-                                  framesPerBeat * kNumBeats60BPM)),
+                                  framesPerBeat * kNumBeats60BPM),
                           1),
                 bpm / 2);
 

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -23,50 +23,54 @@ namespace mixxx {
 
 class BeatGridIterator : public BeatIterator {
   public:
-    BeatGridIterator(double dBeatLength, double dFirstBeat, double dEndSample)
-            : m_dBeatLength(dBeatLength),
-              m_dCurrentSample(dFirstBeat),
-              m_dEndSample(dEndSample) {
+    BeatGridIterator(audio::FrameDiff_t beatLengthFrames,
+            audio::FramePos firstBeatPosition,
+            audio::FramePos endPosition)
+            : m_beatLengthFrames(beatLengthFrames),
+              m_endPosition(endPosition),
+              m_currentPosition(firstBeatPosition) {
     }
 
     bool hasNext() const override {
-        return m_dBeatLength > 0 && m_dCurrentSample <= m_dEndSample;
+        return m_beatLengthFrames > 0 && m_currentPosition <= m_endPosition;
     }
 
-    double next() override {
-        double beat = m_dCurrentSample;
-        m_dCurrentSample += m_dBeatLength;
-        return beat;
+    audio::FramePos next() override {
+        const audio::FramePos beatPosition = m_currentPosition;
+        m_currentPosition += m_beatLengthFrames;
+        return beatPosition;
     }
 
   private:
-    double m_dBeatLength;
-    double m_dCurrentSample;
-    double m_dEndSample;
+    const audio::FrameDiff_t m_beatLengthFrames;
+    const audio::FramePos m_endPosition;
+    audio::FramePos m_currentPosition;
 };
 
 BeatGrid::BeatGrid(
         audio::SampleRate sampleRate,
         const QString& subVersion,
         const mixxx::track::io::BeatGrid& grid,
-        double beatLength)
+        audio::FrameDiff_t beatLengthFrames)
         : m_subVersion(subVersion),
           m_sampleRate(sampleRate),
           m_grid(grid),
-          m_dBeatLength(beatLength) {
+          m_beatLengthFrames(beatLengthFrames) {
     // BeatGrid should live in the same thread as the track it is associated
     // with.
 }
 
-BeatGrid::BeatGrid(const BeatGrid& other, const mixxx::track::io::BeatGrid& grid, double beatLength)
+BeatGrid::BeatGrid(const BeatGrid& other,
+        const mixxx::track::io::BeatGrid& grid,
+        audio::FrameDiff_t beatLengthFrames)
         : m_subVersion(other.m_subVersion),
           m_sampleRate(other.m_sampleRate),
           m_grid(grid),
-          m_dBeatLength(beatLength) {
+          m_beatLengthFrames(beatLengthFrames) {
 }
 
 BeatGrid::BeatGrid(const BeatGrid& other)
-        : BeatGrid(other, other.m_grid, other.m_dBeatLength) {
+        : BeatGrid(other, other.m_grid, other.m_beatLengthFrames) {
 }
 
 // static
@@ -74,9 +78,9 @@ BeatsPointer BeatGrid::makeBeatGrid(
         audio::SampleRate sampleRate,
         const QString& subVersion,
         mixxx::Bpm bpm,
-        mixxx::audio::FramePos firstBeatPos) {
+        mixxx::audio::FramePos firstBeatPosition) {
     // FIXME: Should this be a debug assertion?
-    if (!bpm.isValid()) {
+    if (!bpm.isValid() || !firstBeatPosition.isValid()) {
         return nullptr;
     }
 
@@ -84,11 +88,11 @@ BeatsPointer BeatGrid::makeBeatGrid(
 
     grid.mutable_bpm()->set_bpm(bpm.value());
     grid.mutable_first_beat()->set_frame_position(
-            static_cast<google::protobuf::int32>(firstBeatPos.value()));
+            static_cast<google::protobuf::int32>(firstBeatPosition.value()));
     // Calculate beat length as sample offsets
-    double beatLength = (60.0 * sampleRate / bpm.value()) * kFrameSize;
+    const audio::FrameDiff_t beatLengthFrames = 60.0 * sampleRate / bpm.value();
 
-    return BeatsPointer(new BeatGrid(sampleRate, subVersion, grid, beatLength));
+    return BeatsPointer(new BeatGrid(sampleRate, subVersion, grid, beatLengthFrames));
 }
 
 // static
@@ -98,8 +102,8 @@ BeatsPointer BeatGrid::makeBeatGrid(
         const QByteArray& byteArray) {
     mixxx::track::io::BeatGrid grid;
     if (grid.ParseFromArray(byteArray.constData(), byteArray.length())) {
-        double beatLength = (60.0 * sampleRate / grid.bpm().bpm()) * kFrameSize;
-        return BeatsPointer(new BeatGrid(sampleRate, subVersion, grid, beatLength));
+        const audio::FrameDiff_t beatLengthFrames = (60.0 * sampleRate / grid.bpm().bpm());
+        return BeatsPointer(new BeatGrid(sampleRate, subVersion, grid, beatLengthFrames));
     }
 
     // Legacy fallback for BeatGrid-1.0
@@ -119,8 +123,8 @@ QByteArray BeatGrid::toByteArray() const {
     return QByteArray(output.data(), static_cast<int>(output.length()));
 }
 
-double BeatGrid::firstBeatSample() const {
-    return m_grid.first_beat().frame_position() * kFrameSize;
+audio::FramePos BeatGrid::firstBeatPosition() const {
+    return audio::FramePos(m_grid.first_beat().frame_position());
 }
 
 mixxx::Bpm BeatGrid::bpm() const {
@@ -137,44 +141,50 @@ QString BeatGrid::getSubVersion() const {
 
 // internal use only
 bool BeatGrid::isValid() const {
-    return m_sampleRate.isValid() && bpm().isValid();
+    return m_sampleRate.isValid() && bpm().isValid() && firstBeatPosition().isValid();
 }
 
 // This could be implemented in the Beats Class itself.
 // If necessary, the child class can redefine it.
-double BeatGrid::findNextBeat(double dSamples) const {
-    return findNthBeat(dSamples, +1);
+audio::FramePos BeatGrid::findNextBeat(audio::FramePos position) const {
+    return findNthBeat(position, 1);
 }
 
 // This could be implemented in the Beats Class itself.
 // If necessary, the child class can redefine it.
-double BeatGrid::findPrevBeat(double dSamples) const {
-    return findNthBeat(dSamples, -1);
+audio::FramePos BeatGrid::findPrevBeat(audio::FramePos position) const {
+    return findNthBeat(position, -1);
 }
 
 // This is an internal call. This could be implemented in the Beats Class itself.
-double BeatGrid::findClosestBeat(double dSamples) const {
+audio::FramePos BeatGrid::findClosestBeat(audio::FramePos position) const {
     if (!isValid()) {
-        return -1;
+        return audio::kInvalidFramePos;
     }
-    double prevBeat;
-    double nextBeat;
-    findPrevNextBeats(dSamples, &prevBeat, &nextBeat, true);
-    if (prevBeat == -1) {
-        // If both values are -1, we correctly return -1.
-        return nextBeat;
-    } else if (nextBeat == -1) {
-        return prevBeat;
+    audio::FramePos prevBeatPosition;
+    audio::FramePos nextBeatPosition;
+    findPrevNextBeats(position, &prevBeatPosition, &nextBeatPosition, true);
+    if (!prevBeatPosition.isValid()) {
+        // If both positions are invalid, we correctly return an invalid position.
+        return nextBeatPosition;
     }
-    return (nextBeat - dSamples > dSamples - prevBeat) ? prevBeat : nextBeat;
+
+    if (!nextBeatPosition.isValid()) {
+        return prevBeatPosition;
+    }
+
+    // Both position are valid, return the closest position.
+    return (nextBeatPosition - position > position - prevBeatPosition)
+            ? prevBeatPosition
+            : nextBeatPosition;
 }
 
-double BeatGrid::findNthBeat(double dSamples, int n) const {
+audio::FramePos BeatGrid::findNthBeat(audio::FramePos position, int n) const {
     if (!isValid() || n == 0) {
-        return -1;
+        return audio::kInvalidFramePos;
     }
 
-    double beatFraction = (dSamples - firstBeatSample()) / m_dBeatLength;
+    double beatFraction = (position - firstBeatPosition()) / m_beatLengthFrames;
     double prevBeat = floor(beatFraction);
     double nextBeat = ceil(beatFraction);
 
@@ -196,38 +206,34 @@ double BeatGrid::findNthBeat(double dSamples, int n) const {
         nextBeat = prevBeat;
     }
 
-    double dClosestBeat;
+    audio::FramePos closestBeatPosition;
     if (n > 0) {
         // We're going forward, so use ceil to round up to the next multiple of
         // m_dBeatLength
-        dClosestBeat = nextBeat * m_dBeatLength + firstBeatSample();
+        closestBeatPosition = firstBeatPosition() + nextBeat * m_beatLengthFrames;
         n = n - 1;
     } else {
         // We're going backward, so use floor to round down to the next multiple
         // of m_dBeatLength
-        dClosestBeat = prevBeat * m_dBeatLength + firstBeatSample();
+        closestBeatPosition = firstBeatPosition() + prevBeat * m_beatLengthFrames;
         n = n + 1;
     }
 
-    double dResult = dClosestBeat + n * m_dBeatLength;
-    return dResult;
+    const audio::FramePos result = closestBeatPosition + n * m_beatLengthFrames;
+    return result;
 }
 
-bool BeatGrid::findPrevNextBeats(double dSamples,
-        double* dpPrevBeatSamples,
-        double* dpNextBeatSamples,
+bool BeatGrid::findPrevNextBeats(audio::FramePos position,
+        audio::FramePos* prevBeatPosition,
+        audio::FramePos* nextBeatPosition,
         bool snapToNearBeats) const {
-    double dFirstBeatSample;
-    double dBeatLength;
     if (!isValid()) {
-        *dpPrevBeatSamples = -1.0;
-        *dpNextBeatSamples = -1.0;
+        *prevBeatPosition = audio::kInvalidFramePos;
+        *nextBeatPosition = audio::kInvalidFramePos;
         return false;
     }
-    dFirstBeatSample = firstBeatSample();
-    dBeatLength = m_dBeatLength;
 
-    double beatFraction = (dSamples - dFirstBeatSample) / dBeatLength;
+    double beatFraction = (position - firstBeatPosition()) / m_beatLengthFrames;
     double prevBeat = floor(beatFraction);
     double nextBeat = ceil(beatFraction);
 
@@ -246,30 +252,33 @@ bool BeatGrid::findPrevNextBeats(double dSamples,
         // And nextBeat needs to be incremented.
         ++nextBeat;
     }
-    *dpPrevBeatSamples = prevBeat * dBeatLength + dFirstBeatSample;
-    *dpNextBeatSamples = nextBeat * dBeatLength + dFirstBeatSample;
+    *prevBeatPosition = firstBeatPosition() + prevBeat * m_beatLengthFrames;
+    *nextBeatPosition = firstBeatPosition() + nextBeat * m_beatLengthFrames;
     return true;
 }
 
-std::unique_ptr<BeatIterator> BeatGrid::findBeats(double startSample, double stopSample) const {
-    if (!isValid() || startSample > stopSample) {
+std::unique_ptr<BeatIterator> BeatGrid::findBeats(
+        audio::FramePos startPosition, audio::FramePos endPosition) const {
+    // FIXME: Should this be a VERIFY_OR_DEBUG_ASSERT?
+    if (!isValid() || !startPosition.isValid() || !endPosition.isValid() ||
+            startPosition > endPosition) {
         return std::unique_ptr<BeatIterator>();
     }
-    //qDebug() << "BeatGrid::findBeats startSample" << startSample << "stopSample"
-    //         << stopSample << "beatlength" << m_dBeatLength << "BPM" << bpm();
-    double curBeat = findNextBeat(startSample);
-    if (curBeat == -1.0) {
+    const audio::FramePos startBeatPosition = findNextBeat(startPosition);
+    if (!startBeatPosition.isValid()) {
         return std::unique_ptr<BeatIterator>();
     }
-    return std::make_unique<BeatGridIterator>(m_dBeatLength, curBeat, stopSample);
+    return std::make_unique<BeatGridIterator>(m_beatLengthFrames, startBeatPosition, endPosition);
 }
 
-bool BeatGrid::hasBeatInRange(double startSample, double stopSample) const {
-    if (!isValid() || startSample > stopSample) {
+bool BeatGrid::hasBeatInRange(audio::FramePos startPosition, audio::FramePos endPosition) const {
+    // FIXME: Should this be a VERIFY_OR_DEBUG_ASSERT?
+    if (!isValid() || !startPosition.isValid() || !endPosition.isValid() ||
+            startPosition > endPosition) {
         return false;
     }
-    double curBeat = findNextBeat(startSample);
-    if (curBeat != -1.0 && curBeat <= stopSample) {
+    const audio::FramePos currentPosition = findNextBeat(startPosition);
+    if (currentPosition.isValid() && currentPosition <= endPosition) {
         return true;
     }
     return false;
@@ -283,8 +292,8 @@ mixxx::Bpm BeatGrid::getBpm() const {
 }
 
 // Note: Also called from the engine thread
-mixxx::Bpm BeatGrid::getBpmAroundPosition(double curSample, int n) const {
-    Q_UNUSED(curSample);
+mixxx::Bpm BeatGrid::getBpmAroundPosition(audio::FramePos position, int n) const {
+    Q_UNUSED(position);
     Q_UNUSED(n);
 
     if (!isValid()) {
@@ -293,16 +302,17 @@ mixxx::Bpm BeatGrid::getBpmAroundPosition(double curSample, int n) const {
     return bpm();
 }
 
-BeatsPointer BeatGrid::translate(double dNumSamples) const {
+BeatsPointer BeatGrid::translate(audio::FrameDiff_t offset) const {
     if (!isValid()) {
         return BeatsPointer(new BeatGrid(*this));
     }
     mixxx::track::io::BeatGrid grid = m_grid;
-    double newFirstBeatFrames = (firstBeatSample() + dNumSamples) / kFrameSize;
+    const audio::FramePos newFirstBeatPosition = firstBeatPosition() + offset;
     grid.mutable_first_beat()->set_frame_position(
-            static_cast<google::protobuf::int32>(newFirstBeatFrames));
+            static_cast<google::protobuf::int32>(
+                    newFirstBeatPosition.toLowerFrameBoundary().value()));
 
-    return BeatsPointer(new BeatGrid(*this, grid, m_dBeatLength));
+    return BeatsPointer(new BeatGrid(*this, grid, m_beatLengthFrames));
 }
 
 BeatsPointer BeatGrid::scale(enum BPMScale scale) const {

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "audio/frame.h"
 #include "proto/beats.pb.h"
 #include "track/beats.h"
 
@@ -44,18 +43,19 @@ class BeatGrid final : public Beats {
     // Beat calculations
     ////////////////////////////////////////////////////////////////////////////
 
-    double findNextBeat(double dSamples) const override;
-    double findPrevBeat(double dSamples) const override;
-    bool findPrevNextBeats(double dSamples,
-            double* dpPrevBeatSamples,
-            double* dpNextBeatSamples,
+    audio::FramePos findNextBeat(audio::FramePos position) const override;
+    audio::FramePos findPrevBeat(audio::FramePos position) const override;
+    bool findPrevNextBeats(audio::FramePos position,
+            audio::FramePos* prevBeatPosition,
+            audio::FramePos* nextBeatPosition,
             bool snapToNearBeats) const override;
-    double findClosestBeat(double dSamples) const override;
-    double findNthBeat(double dSamples, int n) const override;
-    std::unique_ptr<BeatIterator> findBeats(double startSample, double stopSample) const override;
-    bool hasBeatInRange(double startSample, double stopSample) const override;
+    audio::FramePos findClosestBeat(audio::FramePos position) const override;
+    audio::FramePos findNthBeat(audio::FramePos position, int n) const override;
+    std::unique_ptr<BeatIterator> findBeats(audio::FramePos startPosition,
+            audio::FramePos endPosition) const override;
+    bool hasBeatInRange(audio::FramePos startPosition, audio::FramePos endPosition) const override;
     mixxx::Bpm getBpm() const override;
-    mixxx::Bpm getBpmAroundPosition(double curSample, int n) const override;
+    mixxx::Bpm getBpmAroundPosition(audio::FramePos position, int n) const override;
 
     audio::SampleRate getSampleRate() const override {
         return m_sampleRate;
@@ -65,7 +65,7 @@ class BeatGrid final : public Beats {
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
-    BeatsPointer translate(double dNumSamples) const override;
+    BeatsPointer translate(audio::FrameDiff_t offset) const override;
     BeatsPointer scale(enum BPMScale scale) const override;
     BeatsPointer setBpm(mixxx::Bpm bpm) override;
 
@@ -79,7 +79,7 @@ class BeatGrid final : public Beats {
     BeatGrid(const BeatGrid& other, const mixxx::track::io::BeatGrid& grid, double beatLength);
     BeatGrid(const BeatGrid& other);
 
-    double firstBeatSample() const;
+    audio::FramePos firstBeatPosition() const;
     mixxx::Bpm bpm() const;
 
     // For internal use only.
@@ -92,7 +92,7 @@ class BeatGrid final : public Beats {
     // Data storage for BeatGrid
     const mixxx::track::io::BeatGrid m_grid;
     // The length of a beat in samples
-    const double m_dBeatLength;
+    const audio::FrameDiff_t m_beatLengthFrames;
 };
 
 } // namespace mixxx

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -32,10 +32,6 @@ inline Beat beatFromFramePos(mixxx::audio::FramePos beatPosition) {
     return beat;
 }
 
-inline mixxx::audio::FrameDiff_t frameDiffFromSampleDiff(double sampleDiff) {
-    return std::floor(sampleDiff / mixxx::kEngineChannelCount);
-}
-
 bool BeatLessThan(const Beat& beat1, const Beat& beat2) {
     return beat1.frame_position() < beat2.frame_position();
 }

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include "audio/frame.h"
 #include "proto/beats.pb.h"
 #include "track/beats.h"
 
@@ -47,19 +46,20 @@ class BeatMap final : public Beats {
     // Beat calculations
     ////////////////////////////////////////////////////////////////////////////
 
-    double findNextBeat(double dSamples) const override;
-    double findPrevBeat(double dSamples) const override;
-    bool findPrevNextBeats(double dSamples,
-            double* dpPrevBeatSamples,
-            double* dpNextBeatSamples,
+    audio::FramePos findNextBeat(audio::FramePos position) const override;
+    audio::FramePos findPrevBeat(audio::FramePos position) const override;
+    bool findPrevNextBeats(audio::FramePos position,
+            audio::FramePos* prevBeatPosition,
+            audio::FramePos* nextBeatPosition,
             bool snapToNearBeats) const override;
-    double findClosestBeat(double dSamples) const override;
-    double findNthBeat(double dSamples, int n) const override;
-    std::unique_ptr<BeatIterator> findBeats(double startSample, double stopSample) const override;
-    bool hasBeatInRange(double startSample, double stopSample) const override;
+    audio::FramePos findClosestBeat(audio::FramePos position) const override;
+    audio::FramePos findNthBeat(audio::FramePos position, int n) const override;
+    std::unique_ptr<BeatIterator> findBeats(audio::FramePos startPosition,
+            audio::FramePos endPosition) const override;
+    bool hasBeatInRange(audio::FramePos startPosition, audio::FramePos endPosition) const override;
 
     mixxx::Bpm getBpm() const override;
-    mixxx::Bpm getBpmAroundPosition(double curSample, int n) const override;
+    mixxx::Bpm getBpmAroundPosition(audio::FramePos position, int n) const override;
 
     audio::SampleRate getSampleRate() const override {
         return m_sampleRate;
@@ -69,7 +69,7 @@ class BeatMap final : public Beats {
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
-    BeatsPointer translate(double dNumSamples) const override;
+    BeatsPointer translate(audio::FrameDiff_t offset) const override;
     BeatsPointer scale(enum BPMScale scale) const override;
     BeatsPointer setBpm(mixxx::Bpm bpm) override;
 

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -14,7 +14,7 @@ int Beats::numBeatsInRange(audio::FramePos startPosition, audio::FramePos endPos
     return i - 2;
 };
 
-audio::FramePos Beats::findNBeatsFromSample(audio::FramePos position, double beats) const {
+audio::FramePos Beats::findNBeatsFromPosition(audio::FramePos position, double beats) const {
     audio::FramePos prevBeatPosition;
     audio::FramePos nextBeatPosition;
 

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -5,11 +5,12 @@ namespace mixxx {
 int Beats::numBeatsInRange(audio::FramePos startPosition, audio::FramePos endPosition) const {
     audio::FramePos lastPosition = audio::kStartFramePos;
     int i = 1;
-    for (; lastPosition < endPosition; i++) {
+    while (lastPosition < endPosition) {
         lastPosition = findNthBeat(startPosition, i);
         if (!lastPosition.isValid()) {
             break;
         }
+        i++;
     }
     return i - 2;
 };

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -2,54 +2,55 @@
 
 namespace mixxx {
 
-int Beats::numBeatsInRange(double dStartSample, double dEndSample) const {
-    double dLastCountedBeat = 0.0;
-    int iBeatsCounter;
-    for (iBeatsCounter = 1; dLastCountedBeat < dEndSample; iBeatsCounter++) {
-        dLastCountedBeat = findNthBeat(dStartSample, iBeatsCounter);
-        if (dLastCountedBeat == -1) {
+int Beats::numBeatsInRange(audio::FramePos startPosition, audio::FramePos endPosition) const {
+    audio::FramePos lastPosition = audio::kStartFramePos;
+    int i = 1;
+    for (; lastPosition < endPosition; i++) {
+        lastPosition = findNthBeat(startPosition, i);
+        if (!lastPosition.isValid()) {
             break;
         }
     }
-    return iBeatsCounter - 2;
+    return i - 2;
 };
 
-double Beats::findNBeatsFromSample(double fromSample, double beats) const {
-    double nthBeat;
-    double prevBeat;
-    double nextBeat;
+audio::FramePos Beats::findNBeatsFromSample(audio::FramePos position, double beats) const {
+    audio::FramePos prevBeatPosition;
+    audio::FramePos nextBeatPosition;
 
-    if (!findPrevNextBeats(fromSample, &prevBeat, &nextBeat, true)) {
-        return fromSample;
+    if (!findPrevNextBeats(position, &prevBeatPosition, &nextBeatPosition, true)) {
+        return position;
     }
-    double fromFractionBeats = (fromSample - prevBeat) / (nextBeat - prevBeat);
-    double beatsFromPrevBeat = fromFractionBeats + beats;
+    const audio::FrameDiff_t fromFractionBeats = (position - prevBeatPosition) /
+            (nextBeatPosition - prevBeatPosition);
+    const audio::FrameDiff_t beatsFromPrevBeat = fromFractionBeats + beats;
 
-    int fullBeats = static_cast<int>(beatsFromPrevBeat);
-    double fractionBeats = beatsFromPrevBeat - fullBeats;
+    const int fullBeats = static_cast<int>(beatsFromPrevBeat);
+    const audio::FrameDiff_t fractionBeats = beatsFromPrevBeat - fullBeats;
 
     // Add the length between this beat and the fullbeats'th beat
     // to the end position
+    audio::FramePos nthBeatPosition;
     if (fullBeats > 0) {
-        nthBeat = findNthBeat(nextBeat, fullBeats);
+        nthBeatPosition = findNthBeat(nextBeatPosition, fullBeats);
     } else {
-        nthBeat = findNthBeat(prevBeat, fullBeats - 1);
+        nthBeatPosition = findNthBeat(prevBeatPosition, fullBeats - 1);
     }
 
-    if (nthBeat == -1) {
-        return fromSample;
+    if (!nthBeatPosition.isValid()) {
+        return position;
     }
 
     // Add the fraction of the beat
     if (fractionBeats != 0) {
-        nextBeat = findNthBeat(nthBeat, 2);
-        if (nextBeat == -1) {
-            return fromSample;
+        nextBeatPosition = findNthBeat(nthBeatPosition, 2);
+        if (!nextBeatPosition.isValid()) {
+            return position;
         }
-        nthBeat += (nextBeat - nthBeat) * fractionBeats;
+        nthBeatPosition += (nextBeatPosition - nthBeatPosition) * fractionBeats;
     }
 
-    return nthBeat;
+    return nthBeatPosition;
 };
 
 } // namespace mixxx

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -98,6 +98,12 @@ class Beats {
             audio::FramePos* nextBeatPosition,
             bool snapToNearBeats) const = 0;
 
+    /// Return the frame position of the first beat in the track, or an invalid
+    /// position if none exists.
+    audio::FramePos firstBeat() const {
+        return findNextBeat(mixxx::audio::kStartFramePos);
+    }
+
     /// Starting from frame position `position`, return the frame position of
     /// the closest beat in the track, or an invalid positon if none exists.
     virtual audio::FramePos findClosestBeat(audio::FramePos position) const = 0;

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -115,7 +115,7 @@ class Beats {
 
     /// Find the frame position N beats away from `position`. The number of beats may be
     /// negative and does not need to be an integer.
-    audio::FramePos findNBeatsFromSample(audio::FramePos position, double beats) const;
+    audio::FramePos findNBeatsFromPosition(audio::FramePos position, double beats) const;
 
     /// Reutns an iterator that yields frame position of every beat occurring
     /// between `startPosition` and `endPosition`. `BeatIterator` must be iterated

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -5,6 +5,7 @@
 #include <QSharedPointer>
 #include <QString>
 
+#include "audio/frame.h"
 #include "audio/types.h"
 #include "track/bpm.h"
 #include "util/memory.h"
@@ -19,7 +20,7 @@ class BeatIterator {
   public:
     virtual ~BeatIterator() = default;
     virtual bool hasNext() const = 0;
-    virtual double next() = 0;
+    virtual audio::FramePos next() = 0;
 };
 
 /// Beats is the base class for BPM and beat management classes. It provides a
@@ -77,63 +78,66 @@ class Beats {
     // TODO: We may want to implement these with common code that returns
     //       the triple of closest, next, and prev.
 
-    /// Starting from dSamples, return the sample of the next beat in the
-    /// track, or -1 if none exists. If dSamples refers to the location of a
-    /// beat, dSamples is returned.
-    virtual double findNextBeat(double dSamples) const = 0;
+    /// Starting from frame position `position`, return the frame position of
+    /// the next beat in the track, or an invalid position if none exists. If
+    /// `position` refers to the location of a beat, `position` is returned.
+    virtual audio::FramePos findNextBeat(audio::FramePos position) const = 0;
 
-    /// Starting from sample dSamples, return the sample of the previous beat
-    /// in the track, or -1 if none exists. If dSamples refers to the location
-    /// of beat, dSamples is returned.
-    virtual double findPrevBeat(double dSamples) const = 0;
+    /// Starting from frame position `position`, return the frame position of
+    /// the previous beat in the track, or an invalid position if none exists.
+    /// If `position` refers to the location of beat, `position` is returned.
+    virtual audio::FramePos findPrevBeat(audio::FramePos position) const = 0;
 
-    /// Starting from sample dSamples, fill the samples of the previous beat
-    /// and next beat.  Either can be -1 if none exists.  If dSamples refers to
-    /// the location of the beat, the first value is dSamples, and the second
-    /// value is the next beat position.  Non- -1 values are guaranteed to be
-    /// even.  Returns false if *at least one* sample is -1.  (Can return false
-    /// with one beat successfully filled)
-    virtual bool findPrevNextBeats(double dSamples,
-            double* dpPrevBeatSamples,
-            double* dpNextBeatSamples,
+    /// Starting from frame position `position`, fill the frame position of the
+    /// previous beat and next beat. Either can be invalid if none exists. If
+    /// `position` refers to the location of the beat, the first value is
+    /// `position`, and the second value is the next beat position. Returns
+    /// `false` if *at least one* position is invalid.
+    virtual bool findPrevNextBeats(audio::FramePos position,
+            audio::FramePos* prevBeatPosition,
+            audio::FramePos* nextBeatPosition,
             bool snapToNearBeats) const = 0;
 
-    /// Starting from sample dSamples, return the sample of the closest beat in
-    /// the track, or -1 if none exists.  Non- -1 values are guaranteed to be
-    /// even.
-    virtual double findClosestBeat(double dSamples) const = 0;
+    /// Starting from frame position `position`, return the frame position of
+    /// the closest beat in the track, or an invalid positon if none exists.
+    virtual audio::FramePos findClosestBeat(audio::FramePos position) const = 0;
 
-    /// Find the Nth beat from sample dSamples. Works with both positive and
-    /// negative values of n. Calling findNthBeat with n=0 is invalid. Calling
-    /// findNthBeat with n=1 or n=-1 is equivalent to calling findNextBeat and
-    /// findPrevBeat, respectively. If dSamples refers to the location of a
-    /// beat, then dSamples is returned. If no beat can be found, returns -1.
-    virtual double findNthBeat(double dSamples, int n) const = 0;
+    /// Find the Nth beat from frame position `position`. Works with both
+    /// positive and negative values of n. Calling findNthBeat with `n=0` is
+    /// invalid and always returns an invalid frame position. Calling
+    /// findNthBeat with `n=1` or `n=-1` is equivalent to calling
+    /// `findNextBeat` and `findPrevBeat`, respectively. If `position` refers
+    /// to the location of a beat, then `position` is returned. If no beat can
+    /// be found, returns an invalid frame position.
+    virtual audio::FramePos findNthBeat(audio::FramePos position, int n) const = 0;
 
-    int numBeatsInRange(double dStartSample, double dEndSample) const;
+    int numBeatsInRange(audio::FramePos startPosition, audio::FramePos endPosition) const;
 
-    /// Find the sample N beats away from dSample. The number of beats may be
+    /// Find the frame position N beats away from `position`. The number of beats may be
     /// negative and does not need to be an integer.
-    double findNBeatsFromSample(double fromSample, double beats) const;
+    audio::FramePos findNBeatsFromSample(audio::FramePos position, double beats) const;
 
-    /// Adds to pBeatsList the position in samples of every beat occurring
-    /// between startPosition and endPosition. BeatIterator must be iterated
-    /// while holding a strong references to the Beats object to ensure that
-    /// the Beats object is not deleted. Caller takes ownership of the returned
-    /// BeatIterator;
-    virtual std::unique_ptr<BeatIterator> findBeats(double startSample, double stopSample) const = 0;
+    /// Reutns an iterator that yields frame position of every beat occurring
+    /// between `startPosition` and `endPosition`. `BeatIterator` must be iterated
+    /// while holding a strong references to the `Beats` object to ensure that
+    /// the `Beats` object is not deleted. Caller takes ownership of the returned
+    /// `BeatIterator`.
+    virtual std::unique_ptr<BeatIterator> findBeats(
+            audio::FramePos startPosition,
+            audio::FramePos endPosition) const = 0;
 
-    /// Return whether or not a sample lies between startPosition and endPosition.
-    virtual bool hasBeatInRange(double startSample, double stopSample) const = 0;
+    /// Return whether or not a beat exists between `startPosition` and `endPosition`.
+    virtual bool hasBeatInRange(audio::FramePos startPosition,
+            audio::FramePos endPosition) const = 0;
 
     /// Return the average BPM over the entire track if the BPM is valid,
     /// otherwise returns -1
     virtual mixxx::Bpm getBpm() const = 0;
 
     /// Return the average BPM over the range of n*2 beats centered around
-    /// curSample.  (An n of 4 results in an averaging of 8 beats).  Invalid
-    /// BPM returns -1.
-    virtual mixxx::Bpm getBpmAroundPosition(double curSample, int n) const = 0;
+    /// frame position `position`. For example, n=4 results in an averaging of 8 beats.
+    /// The returned Bpm value may be invalid.
+    virtual mixxx::Bpm getBpmAroundPosition(audio::FramePos position, int n) const = 0;
 
     virtual audio::SampleRate getSampleRate() const = 0;
 
@@ -141,17 +145,18 @@ class Beats {
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
-    /// Translate all beats in the song by dNumSamples samples. Beats that lie
-    /// before the start of the track or after the end of the track are not
-    /// removed. Beats instance must have the capability BEATSCAP_TRANSLATE.
-    virtual BeatsPointer translate(double dNumSamples) const = 0;
+    /// Translate all beats in the song by `offset` frames. Beats that lie
+    /// before the start of the track or after the end of the track are *not*
+    /// removed. The `Beats` instance must have the capability
+    /// `BEATSCAP_TRANSLATE`.
+    virtual BeatsPointer translate(audio::FrameDiff_t offset) const = 0;
 
-    /// Scale the position of every beat in the song by dScalePercentage. Beats
-    /// class must have the capability BEATSCAP_SCALE.
+    /// Scale the position of every beat in the song by `scale`. The `Beats`
+    /// class must have the capability `BEATSCAP_SCALE`.
     virtual BeatsPointer scale(enum BPMScale scale) const = 0;
 
-    /// Adjust the beats so the global average BPM matches bpm. Beats class
-    /// must have the capability BEATSCAP_SET.
+    /// Adjust the beats so the global average BPM matches `bpm`. The `Beats`
+    /// class must have the capability `BEATSCAP_SET`.
     virtual BeatsPointer setBpm(mixxx::Bpm bpm) = 0;
 };
 

--- a/src/track/serato/beatgrid.cpp
+++ b/src/track/serato/beatgrid.cpp
@@ -437,10 +437,9 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
     // in the track, therefore we calculate the track duration in samples and
     // round up. This value might be longer than the actual track, but that's
     // okay because we want to make sure we get all beats.
-    const SINT trackDurationSamples = signalInfo.frames2samples(
-            static_cast<SINT>(signalInfo.secs2frames(
-                    std::ceil(duration.toDoubleSeconds()))));
-    auto pBeatsIterator = pBeats->findBeats(0, trackDurationSamples);
+    const auto trackEndPosition = audio::FramePos(
+            signalInfo.secs2frames(std::ceil(duration.toDoubleSeconds())));
+    auto pBeatsIterator = pBeats->findBeats(audio::kStartFramePos, trackEndPosition);
 
     // This might be null if the track doesn't contain any beats
     if (!pBeatsIterator || !pBeatsIterator->hasNext()) {
@@ -450,38 +449,37 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
         return;
     }
 
-    const double beatgridFrameOffset = signalInfo.samples2framesFractional(pBeatsIterator->next());
-    double currentBeatPositionFrames = 0;
-    double previousBeatPositionFrames = 0;
-    double previousDeltaFrames = -1;
+    const audio::FrameDiff_t beatgridFrameOffset = pBeatsIterator->next().value();
+    audio::FramePos currentBeatPositionFrames = audio::kStartFramePos;
+    audio::FramePos previousBeatPositionFrames = audio::kStartFramePos;
+    audio::FrameDiff_t previousDeltaFrames = -1;
     QList<SeratoBeatGridNonTerminalMarkerPointer> nonTerminalMarkers;
     {
         const double positionSecs = signalInfo.frames2secsFractional(
-                currentBeatPositionFrames + beatgridFrameOffset);
+                currentBeatPositionFrames.value() + beatgridFrameOffset);
         nonTerminalMarkers.append(
                 std::make_shared<SeratoBeatGridNonTerminalMarker>(
                         positionSecs - timingOffsetSecs, 0));
     }
     while (pBeatsIterator->hasNext()) {
         previousBeatPositionFrames = currentBeatPositionFrames;
-        currentBeatPositionFrames =
-                signalInfo.samples2framesFractional(pBeatsIterator->next()) -
-                beatgridFrameOffset;
+        currentBeatPositionFrames = pBeatsIterator->next() - beatgridFrameOffset;
 
         // Calculate the delta between the current beat and the previous beat.
         // If the distance is the same as the distance between the previous
         // beat and the beat before that, we can just increment
         // `beatsSinceLastMarker`. If not, we need to add a new marker.
-        const double currentDeltaFrames = currentBeatPositionFrames - previousBeatPositionFrames;
+        const audio::FrameDiff_t currentDeltaFrames =
+                currentBeatPositionFrames - previousBeatPositionFrames;
         if (previousDeltaFrames < 0) {
             previousDeltaFrames = currentDeltaFrames;
         }
 
-        const double differenceBetweenCurrentAndPreviousDelta =
+        const audio::FrameDiff_t differenceBetweenCurrentAndPreviousDelta =
                 abs(currentDeltaFrames - previousDeltaFrames);
         if (differenceBetweenCurrentAndPreviousDelta >= kEpsilon) {
             const double positionSecs = signalInfo.frames2secsFractional(
-                    previousBeatPositionFrames + beatgridFrameOffset);
+                    previousBeatPositionFrames.value() + beatgridFrameOffset);
             nonTerminalMarkers.append(
                     std::make_shared<SeratoBeatGridNonTerminalMarker>(
                             positionSecs - timingOffsetSecs, 1));
@@ -505,13 +503,11 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
     }
 
     // Finally, create the terminal marker.
-    const double currentBeatPositionFramesWithOffset =
+    const audio::FramePos currentBeatPositionFramesWithOffset =
             currentBeatPositionFrames + beatgridFrameOffset;
     const double positionSecs = signalInfo.frames2secsFractional(
-            currentBeatPositionFramesWithOffset);
-    const mixxx::Bpm bpm = pBeats->getBpmAroundPosition(
-            signalInfo.getChannelCount() * currentBeatPositionFramesWithOffset,
-            1);
+            currentBeatPositionFramesWithOffset.value());
+    const mixxx::Bpm bpm = pBeats->getBpmAroundPosition(currentBeatPositionFramesWithOffset, 1);
 
     setTerminalMarker(std::make_shared<SeratoBeatGridTerminalMarker>(
             positionSecs - timingOffsetSecs, static_cast<float>(bpm.value())));

--- a/src/waveform/renderers/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/waveformrenderbeat.cpp
@@ -57,8 +57,8 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
     //          << "lastDisplayedPosition" << lastDisplayedPosition;
 
     std::unique_ptr<mixxx::BeatIterator> it(trackBeats->findBeats(
-            firstDisplayedPosition * trackSamples,
-            lastDisplayedPosition * trackSamples));
+            mixxx::audio::FramePos::fromEngineSamplePos(firstDisplayedPosition * trackSamples),
+            mixxx::audio::FramePos::fromEngineSamplePos(lastDisplayedPosition * trackSamples)));
 
     // if no beat do not waste time saving/restoring painter
     if (!it || !it->hasNext()) {
@@ -80,7 +80,7 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
     int beatCount = 0;
 
     while (it->hasNext()) {
-        double beatPosition = it->next();
+        double beatPosition = it->next().toEngineSamplePos();
         double xBeatPoint =
                 m_waveformRenderer->transformSamplePositionInRendererWorld(beatPosition);
 


### PR DESCRIPTION
Based on #4048.

This changes the Beats object to return the FramePos type from all methods that return positions.
I tried to keep the changes in the calling code as small as possible, which admittedly makes this code quite ugly with all this back/forth conversion. But otherwise it would be much more work and the diff would be huge.

This PR makes it possible to migrate the other features to the framepos type independently later on, which is taken care of in #4061 for example.