### PR TITLE
Library: resize the Played checkbox and BPM lock with the library font

### DIFF
--- a/res/skins/Deere/icon/ic_library_checkbox.svg
+++ b/res/skins/Deere/icon/ic_library_checkbox.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3.2837546" y="5.0633898" width="0" height="0" rx="10" ry="10" fill="#9a6900" opacity=".7" style="paint-order:markers fill stroke"/>
+  <rect x=".50632912" y=".50632912" width="18.987" height="18.987341" stroke="#585858" stroke-linecap="square" stroke-width="1.01266" style="paint-order:markers fill stroke"/>
+</svg>

--- a/res/skins/Deere/icon/ic_library_checkbox_checked.svg
+++ b/res/skins/Deere/icon/ic_library_checkbox_checked.svg
@@ -1,0 +1,9 @@
+<svg width="20" height="20" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <rect x=".50632912" y=".50632912" width="18.987" height="18.987341" stroke="#f60" stroke-linecap="square" stroke-width="1.01266" style="paint-order:markers fill stroke"/>
+  <g transform="matrix(1.8 0 0 1.8 .99999986 -38.6)">
+    <g transform="matrix(.4151 0 0 .4151 -1.6604 19.547)">
+      <path d="m8.8184 20.364 4.8181 4.8181 9.6363-14.454" fill="none" stroke="#f60" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.8181"/>
+    </g>
+  </g>
+  <rect x="3.2837546" y="5.0633898" width="0" height="0" rx="10" ry="10" fill="#9a6900" opacity=".7" style="paint-order:markers fill stroke"/>
+</svg>

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -264,12 +264,11 @@ WLibrary QLineEdit,
 }
 
 /* checkbox in library "Played" column */
-WTrackTableView::indicator:checked {
-  image: url(skin:/../Deere/icon/ic_library_checkmark.svg);
-  border: 1px solid #ff6600;
-}
 WTrackTableView::indicator:unchecked {
-  border: 1px solid rgba(151,151,151,128);
+  image: url(skin:/../Deere/icon/ic_library_checkbox.svg);
+}
+WTrackTableView::indicator:checked {
+  image: url(skin:/../Deere/icon/ic_library_checkbox_checked.svg);
 }
 
 /* focused BPM cell in the library "BPM" column */
@@ -2122,7 +2121,6 @@ WTrackMenu QMenu QCheckBox::indicator:disabled {
   background-color: #333;
 }
 WLibrarySidebar QMenu::indicator:checked,
-WTrackTableView::indicator:checked,
 WTrackMenu QMenu QCheckBox::indicator:checked {
   image: url(skin:/../Deere/icon/ic_library_checkmark_orange.svg);
 }
@@ -2158,8 +2156,6 @@ WLibrarySidebar QMenu::indicator:unchecked,
 WLibrarySidebar QMenu::indicator:unchecked:selected,
 WTrackTableViewHeader QMenu::indicator:unchecked,
 WTrackTableViewHeader QMenu::indicator:unchecked:selected,
-WTrackTableView::indicator:unchecked,
-WTrackTableView::indicator:unchecked:selected,
 WEffectSelector::indicator:unchecked,
 WEffectSelector::indicator:unchecked:selected,
 #fadeModeCombobox::indicator:unchecked,

--- a/res/skins/LateNight/classic/buttons/btn__lib_checkbox.svg
+++ b/res/skins/LateNight/classic/buttons/btn__lib_checkbox.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <rect x=".5" y=".5" width="19" height="19" rx="1.0000001" ry="1.0000001" stroke="#4d4d4d" stroke-linecap="square" stroke-linejoin="round" style="paint-order:markers fill stroke"/>
+</svg>

--- a/res/skins/LateNight/classic/buttons/btn__lib_checkbox_checked.svg
+++ b/res/skins/LateNight/classic/buttons/btn__lib_checkbox_checked.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <rect x=".5" y=".5" width="19" height="19" stroke="#f60" stroke-linecap="square" style="paint-order:markers fill stroke"/>
+  <path d="m4.3659 11.878 3.7560375 3.75605 7.5121625-11.2679" fill="none" stroke="#f60" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.3412"/>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__lib_checkbox.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__lib_checkbox.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <rect x=".5" y=".5" width="19" height="19" rx="1" ry="1" stroke="#3b3b3b" stroke-linecap="square" stroke-linejoin="round" style="paint-order:markers fill stroke"/>
+</svg>

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -134,7 +134,8 @@ WEffectSelector QAbstractScrollArea {
     margin: 2px;
   }
   WEffectSelector::down-arrow,
-  #fadeModeCombobox::down-arrow {
+  #fadeModeCombobox::down-arrow,
+  WTrackTableView::indicator {
     border: 0;
     padding: 0;
     margin: 0;

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -2438,8 +2438,6 @@ QLineEdit QMenu::item:disabled {
   }
 
   WLibrarySidebar QMenu::indicator:checked,
-  WTrackTableViewHeader QMenu::indicator:checked,
-  WTrackTableView::indicator:checked,
   WTrackMenu QMenu QCheckBox::indicator:checked,
   WEffectSelector::indicator:checked,
   #fadeModeCombobox::indicator:checked {
@@ -2478,18 +2476,13 @@ QLineEdit QMenu::item:disabled {
 
 /* This is the only way to select the 'Played' checkbox.
   Note that this also selects the BPM lock. */
-WTrackTableView::indicator {
-  /* border is added to size defined in style.qss */
-  border: 1px solid transparent;
-  margin: 0px;
-  padding: 0px;
-  }
   WTrackTableView::indicator:checked {
-    border: 1px solid #ff6600;
+    image: url(skin:/classic/buttons/btn__lib_checkbox_checked.svg);
     }
   WTrackTableView::indicator:unchecked {
-    border: 1px solid rgba(151,151,151,128);
+    image: url(skin:/classic/buttons/btn__lib_checkbox.svg);
     }
+
   #MainMenu QMenu::separator,
   WLibrarySidebar QMenu::separator,
   WTrackTableViewHeader QMenu::separator,
@@ -2508,8 +2501,6 @@ WLibrarySidebar QMenu::indicator:unchecked,
 WLibrarySidebar QMenu::indicator:unchecked:selected,
 WTrackTableViewHeader QMenu::indicator:unchecked,
 WTrackTableViewHeader QMenu::indicator:unchecked:selected,
-WTrackTableView::indicator:unchecked,
-WTrackTableView::indicator:unchecked:selected,
 WEffectSelector::indicator:unchecked,
 WEffectSelector::indicator:unchecked:selected,
 #fadeModeCombobox::indicator:unchecked,

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -2496,18 +2496,6 @@ WTrackTableView {
   qproperty-focusBorderColor: #fff;
 }
 
-/* This is the only way to select the 'Played' checkbox.
-  Note that this also selects the BPM lock. */
-WTrackTableView::indicator {
-  /* border is added to configured size */
-  border: 1px solid transparent;
-  margin: 0px;
-  padding: 0px;
-  }
-  WTrackTableView::indicator:unchecked {
-    border: 1px solid rgba(151,151,151,128);
-  }
-
 /* Table cell in edit mode */
 WLibrary QLineEdit,
 #LibraryBPMSpinBox {
@@ -2922,12 +2910,15 @@ QLineEdit QMenu::item:disabled {
       image: url(skin:/palemoon/buttons/btn__menu_checkbox.svg);
     }
 
+  /* This is the only way to select the 'Played' checkbox.
+    Note that this also selects the BPM lock, so style that afterwards. */
+  WTrackTableView::indicator:unchecked {
+    image: url(skin:/palemoon/buttons/btn__lib_checkbox.svg);
+  }
   WLibrarySidebar QMenu::indicator:checked,
   WTrackTableViewHeader QMenu::indicator:checked,
   WTrackTableView::indicator:checked,
-  WTrackMenu QMenu QCheckBox::indicator:checked,
-  WEffectSelector::indicator:checked,
-  #fadeModeCombobox::indicator:checked {
+  WTrackMenu QMenu QCheckBox::indicator:checked {
     image: url(skin:/palemoon/buttons/btn__lib_checkmark_blue.svg);
   }
   WEffectSelector::indicator:checked,
@@ -2963,8 +2954,6 @@ WLibrarySidebar QMenu::indicator:unchecked,
 WLibrarySidebar QMenu::indicator:unchecked:selected,
 WTrackTableViewHeader QMenu::indicator:unchecked,
 WTrackTableViewHeader QMenu::indicator:unchecked:selected,
-WTrackTableView::indicator:unchecked,
-WTrackTableView::indicator:unchecked:selected,
 WEffectSelector::indicator:unchecked,
 WEffectSelector::indicator:unchecked:selected,
 #fadeModeCombobox::indicator:unchecked,

--- a/res/skins/Shade/btn/btn_lib_checkbox.svg
+++ b/res/skins/Shade/btn/btn_lib_checkbox.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3.2837546" y="5.0633898" width="0" height="0" rx="10" ry="10" fill="#9a6900" opacity=".7" style="paint-order:markers fill stroke"/>
+  <rect x=".50632912" y=".50632912" width="18.987" height="18.987341" stroke="#585858" stroke-linecap="square" stroke-width="1.01266" style="paint-order:markers fill stroke"/>
+</svg>

--- a/res/skins/Shade/btn/btn_lib_checkbox_checked.svg
+++ b/res/skins/Shade/btn/btn_lib_checkbox_checked.svg
@@ -1,0 +1,9 @@
+<svg width="20" height="20" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <rect x=".50632912" y=".50632912" width="18.987" height="18.987341" stroke="#f60" stroke-linecap="square" stroke-width="1.01266" style="paint-order:markers fill stroke"/>
+  <g transform="matrix(1.8 0 0 1.8 .99999986 -38.6)">
+    <g transform="matrix(.4151 0 0 .4151 -1.6604 19.547)">
+      <path d="m8.8184 20.364 4.8181 4.8181 9.6363-14.454" fill="none" stroke="#f60" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.8181"/>
+    </g>
+  </g>
+  <rect x="3.2837546" y="5.0633898" width="0" height="0" rx="10" ry="10" fill="#9a6900" opacity=".7" style="paint-order:markers fill stroke"/>
+</svg>

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -549,15 +549,13 @@ WTrackTableView {
   WTrackTableView::indicator {
     margin: 0px;
     padding: 0px;
-    color: #cfcfcf;
-    border: 1px solid transparent;
+    border: 0px;
     }
-    WTrackTableView::indicator:checked {
-      image: url(skin:/btn/btn_lib_checkmark.svg) no-repeat center center;
-      border: 1px solid #ff6600;
+  WTrackTableView::indicator:unchecked {
+    image: url(skin:/btn/btn_lib_checkbox.svg);
     }
-    WTrackTableView::indicator:unchecked {
-      border: 1px solid rgba(151,151,151,128);
+  WTrackTableView::indicator:checked {
+    image: url(skin:/btn/btn_lib_checkbox_checked.svg);
     }
 
 /* explicitly remove icons from unchecked items otherwise
@@ -566,8 +564,6 @@ WLibrarySidebar QMenu::indicator:unchecked,
 WLibrarySidebar QMenu::indicator:unchecked:selected,
 WTrackTableViewHeader QMenu::indicator:unchecked,
 WTrackTableViewHeader QMenu::indicator:unchecked:selected,
-WTrackTableView::indicator:unchecked,
-WTrackTableView::indicator:unchecked:selected,
 WEffectSelector::indicator:unchecked,
 WEffectSelector::indicator:unchecked:selected,
 #fadeModeCombobox::indicator:unchecked,

--- a/res/skins/Tango/buttons/btn_lib_checkbox.svg
+++ b/res/skins/Tango/buttons/btn_lib_checkbox.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <rect x=".50632912" y=".50632912" width="18.987" height="18.987341" stroke="#585858" stroke-linecap="square" stroke-width="1.01266" style="paint-order:markers fill stroke"/>
+  <rect x="3.2837546" y="5.0633898" width="0" height="0" rx="10" ry="10" fill="#9a6900" opacity=".7" style="paint-order:markers fill stroke"/>
+</svg>

--- a/res/skins/Tango/buttons/btn_lib_checkbox_checked.svg
+++ b/res/skins/Tango/buttons/btn_lib_checkbox_checked.svg
@@ -1,0 +1,9 @@
+<svg width="20" height="20" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <rect x=".50632912" y=".50632912" width="18.987" height="18.987341" stroke="#585858" stroke-linecap="square" stroke-width="1.01266" style="paint-order:markers fill stroke"/>
+  <g transform="matrix(1.8 0 0 1.8 .99999986 -38.6)">
+    <g transform="matrix(.4151 0 0 .4151 -1.6604 19.547)">
+      <path d="m8.8184 20.364 4.8181 4.8181 9.6363-14.454" fill="none" stroke="#f60" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.8181"/>
+    </g>
+  </g>
+  <rect x="3.2837546" y="5.0633898" width="0" height="0" rx="10" ry="10" fill="#9a6900" opacity=".7" style="paint-order:markers fill stroke"/>
+</svg>

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -2902,21 +2902,11 @@ QPushButton#pushButtonRepeatPlaylist:!checked {
     }*/
 
   /* checkbox in library "Played" column */
-  WTrackTableView::indicator {
-    margin: 0px;
-    padding: 0px;
-    color: #cfcfcf;
-    /* border is added to size defined above */
-    border: 1px solid rgba(151,151,151,128);
-    }
-  WTrackTableView::indicator:hover {
-      border: 1px solid #888;
-    }
   WTrackTableView::indicator:checked {
-    image: url(skin:/../Tango/buttons/btn_lib_checkmark.svg);
+    image: url(skin:/../Tango/buttons/btn_lib_checkbox_checked.svg);
     }
   WTrackTableView::indicator:unchecked {
-    background: none;
+    image: url(skin:/../Tango/buttons/btn_lib_checkbox.svg);
     }
 
 WLibrary QSpinBox {
@@ -2977,8 +2967,6 @@ WLibrarySidebar QMenu::indicator:unchecked,
 WLibrarySidebar QMenu::indicator:unchecked:selected,
 WTrackTableViewHeader QMenu::indicator:unchecked,
 WTrackTableViewHeader QMenu::indicator:unchecked:selected,
-WTrackTableView::indicator:unchecked,
-WTrackTableView::indicator:unchecked:selected,
 WEffectSelector::indicator:unchecked,
 WEffectSelector::indicator:unchecked:selected,
 #fadeModeCombobox::indicator:unchecked,

--- a/res/skins/default.qss
+++ b/res/skins/default.qss
@@ -11,13 +11,12 @@
   image: url(:/images/library/ic_library_preview_play.svg);
 }
 
-/* These library table indicators are scaled with the library font:
-checkbox next to the 'Played' counter */
+/* 'Played' checkbox */
 WTrackTableView::indicator,
 /* BPM lock icon */
 #LibraryBPMButton::indicator {
-  width: 0.5em;
-  height: 0.5em;
+  /* The indicator size is dynamically adjusted in c++ to match the size
+  of the library font: width/height = 0.7em*/
 }
 /* Style the library BPM Button with a default image */
 QPushButton#LibraryBPMButton {

--- a/src/widget/wlibrarytableview.cpp
+++ b/src/widget/wlibrarytableview.cpp
@@ -134,6 +134,17 @@ void WLibraryTableView::setTrackTableFont(const QFont& font) {
     setFont(font);
     QFontMetrics metrics(font);
     verticalHeader()->setMinimumSectionSize(metrics.height());
+    // Resize the 'Played' checkbox and the BPM lock icon.
+    // Note: this works well for library font sizes up to ~200% of the original
+    // system font's size (that set with Qt5 Settings respectively). Above that,
+    // the indicators start to overlap the item text because the painter rectangle
+    // is not resized (also depending on the system font size).
+    setStyleSheet(QStringLiteral(
+            "WTrackTableView::indicator,"
+            "#LibraryBPMButton::indicator {"
+            "height: %1px;"
+            "width: %1px;}")
+                          .arg(metrics.height() * 0.7));
 }
 
 void WLibraryTableView::setTrackTableRowHeight(int rowHeight) {


### PR DESCRIPTION
This should resize the 'Played' checkbox and the BPM lock icon to match the library font.
(another snippet to fix https://bugs.launchpad.net/mixxx/+bug/1736001)
This works well for library font sizes up to 200% of the original system font's size. Above that, the indicators start to overlap the item text because the painter rectangle is not resized (also depending on the system font size).

Admittedly this can be considered a stupid hack, but I have not found a more efficient way, and the solution should be fine for now.
For the BPM delegate this _could_ be done in [paintItem()](https://github.com/mixxxdj/mixxx/blob/b5a8dcd661f0a039b3da33dfca6257c696115f12/src/library/bpmdelegate.cpp#L59) by resizing the painter rectangle, but I didn't find a way to access the Played indicator like that.

System 11pt (Qt5 Settings 11pt), library 22pt
This PR
![image](https://user-images.githubusercontent.com/5934199/124336253-991b8c80-db9d-11eb-918f-531186b51792.png)

2.3
![image](https://user-images.githubusercontent.com/5934199/124336379-20690000-db9e-11eb-90d4-3383f5cc4306.png)