### PR TITLE
[RFC] Bpm: Prohibit potentially undesired operations with invalid values

### DIFF
--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -143,7 +143,7 @@ bool AnalyzerBeats::shouldAnalyze(TrackPointer pTrack) const {
     if (!pBeats) {
         return true;
     }
-    if (!mixxx::Bpm::isValidValue(pBeats->getBpm())) {
+    if (!pBeats->getBpm().hasValue()) {
         // Tracks with an invalid bpm <= 0 should be re-analyzed,
         // independent of the preference settings. We expect that
         // all tracks have a bpm > 0 when analyzed. Users that want
@@ -228,7 +228,7 @@ void AnalyzerBeats::storeResults(TrackPointer pTrack) {
                 m_bPreferencesFixedTempo,
                 m_sampleRate);
         qDebug() << "AnalyzerBeats plugin detected" << beats.size()
-                 << "beats. Average BPM:" << (pBeats ? pBeats->getBpm() : 0.0);
+                 << "beats. Average BPM:" << (pBeats ? pBeats->getBpm() : mixxx::Bpm());
     } else {
         mixxx::Bpm bpm = m_pPlugin->getBpm();
         qDebug() << "AnalyzerBeats plugin detected constant BPM: " << bpm;

--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -143,7 +143,7 @@ bool AnalyzerBeats::shouldAnalyze(TrackPointer pTrack) const {
     if (!pBeats) {
         return true;
     }
-    if (!pBeats->getBpm().hasValue()) {
+    if (!pBeats->getBpm().isValid()) {
         // Tracks with an invalid bpm <= 0 should be re-analyzed,
         // independent of the preference settings. We expect that
         // all tracks have a bpm > 0 when analyzed. Users that want

--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -230,7 +230,7 @@ void AnalyzerBeats::storeResults(TrackPointer pTrack) {
         qDebug() << "AnalyzerBeats plugin detected" << beats.size()
                  << "beats. Average BPM:" << (pBeats ? pBeats->getBpm() : 0.0);
     } else {
-        float bpm = m_pPlugin->getBpm();
+        mixxx::Bpm bpm = m_pPlugin->getBpm();
         qDebug() << "AnalyzerBeats plugin detected constant BPM: " << bpm;
         pBeats = BeatFactory::makeBeatGrid(m_sampleRate, bpm, mixxx::audio::kStartFramePos);
     }

--- a/src/analyzer/plugins/analyzerplugin.h
+++ b/src/analyzer/plugins/analyzerplugin.h
@@ -4,6 +4,7 @@
 
 #include "audio/frame.h"
 #include "track/beats.h"
+#include "track/bpm.h"
 #include "track/keys.h"
 #include "util/types.h"
 
@@ -69,8 +70,8 @@ class AnalyzerBeatsPlugin : public AnalyzerPlugin {
     ~AnalyzerBeatsPlugin() override = default;
 
     virtual bool supportsBeatTracking() const = 0;
-    virtual float getBpm() const {
-        return 0.0f;
+    virtual mixxx::Bpm getBpm() const {
+        return mixxx::Bpm();
     }
     virtual QVector<mixxx::audio::FramePos> getBeats() const {
         return {};

--- a/src/analyzer/plugins/analyzersoundtouchbeats.cpp
+++ b/src/analyzer/plugins/analyzersoundtouchbeats.cpp
@@ -8,15 +8,14 @@
 namespace mixxx {
 
 AnalyzerSoundTouchBeats::AnalyzerSoundTouchBeats()
-        : m_downmixBuffer(kAnalysisFramesPerChunk), // mono, i.e. 1 sample per frame
-          m_fResultBpm(0.0f) {
+        : m_downmixBuffer(kAnalysisFramesPerChunk) {
 }
 
 AnalyzerSoundTouchBeats::~AnalyzerSoundTouchBeats() {
 }
 
 bool AnalyzerSoundTouchBeats::initialize(int samplerate) {
-    m_fResultBpm = 0.0f;
+    m_resultBpm = mixxx::Bpm();
     m_pSoundTouch = std::make_unique<soundtouch::BPMDetect>(2, samplerate);
     return true;
 }
@@ -42,7 +41,7 @@ bool AnalyzerSoundTouchBeats::finalize() {
     if (!m_pSoundTouch) {
         return false;
     }
-    m_fResultBpm = m_pSoundTouch->getBpm();
+    m_resultBpm = mixxx::Bpm(m_pSoundTouch->getBpm());
     m_pSoundTouch.reset();
     return true;
 }

--- a/src/analyzer/plugins/analyzersoundtouchbeats.h
+++ b/src/analyzer/plugins/analyzersoundtouchbeats.h
@@ -37,14 +37,15 @@ class AnalyzerSoundTouchBeats : public AnalyzerBeatsPlugin {
         return false;
     }
 
-    float getBpm() const override {
-        return m_fResultBpm;
+    mixxx::Bpm getBpm() const override {
+        return m_resultBpm;
     }
 
   private:
     std::unique_ptr<soundtouch::BPMDetect> m_pSoundTouch;
+    /// mono, i.e. 1 sample per frame
     SampleBuffer m_downmixBuffer;
-    float m_fResultBpm;
+    mixxx::Bpm m_resultBpm;
 };
 
 } // namespace mixxx

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -174,10 +174,10 @@ void BpmControl::adjustBeatsBpm(double deltaBpm) {
     const mixxx::BeatsPointer pBeats = pTrack->getBeats();
     if (pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM)) {
         double bpm = pBeats->getBpm();
-        double centerBpm = math_max(kBpmAdjustMin, bpm + deltaBpm);
-        double adjustedBpm = BeatUtils::roundBpmWithinRange(
+        const auto centerBpm = mixxx::Bpm(math_max(kBpmAdjustMin, bpm + deltaBpm));
+        mixxx::Bpm adjustedBpm = BeatUtils::roundBpmWithinRange(
                 centerBpm - kBpmAdjustStep / 2, centerBpm, centerBpm + kBpmAdjustStep / 2);
-        pTrack->trySetBeats(pBeats->setBpm(adjustedBpm));
+        pTrack->trySetBeats(pBeats->setBpm(adjustedBpm.getValue()));
     }
 }
 
@@ -257,11 +257,11 @@ void BpmControl::slotTapFilter(double averageLength, int numSamples) {
 
     // (60 seconds per minute) * (1000 milliseconds per second) / (X millis per
     // beat) = Y beats/minute
-    double averageBpm = 60.0 * 1000.0 / averageLength / rateRatio;
+    auto averageBpm = mixxx::Bpm(60.0 * 1000.0 / averageLength / rateRatio);
     averageBpm = BeatUtils::roundBpmWithinRange(averageBpm - kBpmTabRounding,
             averageBpm,
             averageBpm + kBpmTabRounding);
-    pTrack->trySetBeats(pBeats->setBpm(averageBpm));
+    pTrack->trySetBeats(pBeats->setBpm(averageBpm.getValue()));
 }
 
 void BpmControl::slotControlBeatSyncPhase(double value) {

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -174,7 +174,7 @@ void BpmControl::adjustBeatsBpm(double deltaBpm) {
     const mixxx::BeatsPointer pBeats = pTrack->getBeats();
     if (pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM)) {
         mixxx::Bpm bpm = pBeats->getBpm();
-        const auto centerBpm = mixxx::Bpm(math_max(kBpmAdjustMin, bpm.getValue() + deltaBpm));
+        const auto centerBpm = mixxx::Bpm(math_max(kBpmAdjustMin, bpm.value() + deltaBpm));
         mixxx::Bpm adjustedBpm = BeatUtils::roundBpmWithinRange(
                 centerBpm - kBpmAdjustStep / 2, centerBpm, centerBpm + kBpmAdjustStep / 2);
         pTrack->trySetBeats(pBeats->setBpm(adjustedBpm));
@@ -1071,7 +1071,7 @@ mixxx::Bpm BpmControl::updateLocalBpm() {
     if (pBeats) {
         localBpm = pBeats->getBpmAroundPosition(
                 getSampleOfTrack().current, kLocalBpmSpan);
-        if (!localBpm.hasValue()) {
+        if (!localBpm.isValid()) {
             localBpm = pBeats->getBpm();
         }
     }
@@ -1079,7 +1079,7 @@ mixxx::Bpm BpmControl::updateLocalBpm() {
         if (kLogger.traceEnabled()) {
             kLogger.trace() << getGroup() << "BpmControl::updateLocalBpm" << localBpm;
         }
-        m_pLocalBpm->set(localBpm.getValue());
+        m_pLocalBpm->set(localBpm.value());
         slotUpdateEngineBpm();
     }
     return localBpm;

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -49,7 +49,7 @@ class BpmControl : public EngineControl {
     void setTargetBeatDistance(double beatDistance);
     void updateInstantaneousBpm(double instantaneousBpm);
     void resetSyncAdjustment();
-    double updateLocalBpm();
+    mixxx::Bpm updateLocalBpm();
     /// updateBeatDistance is adjusted to include the user offset so
     /// it's transparent to other decks.
     double updateBeatDistance();

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1295,9 +1295,9 @@ void EngineBuffer::postProcess(const int iBufferSize) {
     if (kLogger.traceEnabled()) {
         kLogger.trace() << getGroup() << "EngineBuffer::postProcess";
     }
-    double localBpm = m_pBpmControl->updateLocalBpm();
+    const mixxx::Bpm localBpm = m_pBpmControl->updateLocalBpm();
     double beatDistance = m_pBpmControl->updateBeatDistance();
-    m_pSyncControl->setLocalBpm(localBpm);
+    m_pSyncControl->setLocalBpm(localBpm.getValue());
     m_pSyncControl->updateAudible();
     SyncMode mode = m_pSyncControl->getSyncMode();
     if (isMaster(mode)) {

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1297,7 +1297,7 @@ void EngineBuffer::postProcess(const int iBufferSize) {
     }
     const mixxx::Bpm localBpm = m_pBpmControl->updateLocalBpm();
     double beatDistance = m_pBpmControl->updateBeatDistance();
-    m_pSyncControl->setLocalBpm(localBpm.getValue());
+    m_pSyncControl->setLocalBpm(localBpm.value());
     m_pSyncControl->updateAudible();
     SyncMode mode = m_pSyncControl->getSyncMode();
     if (isMaster(mode)) {

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1297,7 +1297,10 @@ void EngineBuffer::postProcess(const int iBufferSize) {
     }
     const mixxx::Bpm localBpm = m_pBpmControl->updateLocalBpm();
     double beatDistance = m_pBpmControl->updateBeatDistance();
-    m_pSyncControl->setLocalBpm(localBpm.value());
+    // FIXME: Verify what should happend if the bpm is invalid
+    m_pSyncControl->setLocalBpm(localBpm.isValid()
+                    ? localBpm.value()
+                    : mixxx::Bpm::kValueUndefined);
     m_pSyncControl->updateAudible();
     SyncMode mode = m_pSyncControl->getSyncMode();
     if (isMaster(mode)) {

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -516,7 +516,7 @@ void SyncControl::notifySeek(double dNewPlaypos) {
 double SyncControl::fileBpm() const {
     mixxx::BeatsPointer pBeats = m_pBeats;
     if (pBeats) {
-        return pBeats->getBpm();
+        return pBeats->getBpm().getValue();
     }
     return 0.0;
 }

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -516,7 +516,7 @@ void SyncControl::notifySeek(double dNewPlaypos) {
 double SyncControl::fileBpm() const {
     mixxx::BeatsPointer pBeats = m_pBeats;
     if (pBeats) {
-        return pBeats->getBpm().getValue();
+        return pBeats->getBpm().value();
     }
     return 0.0;
 }

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -664,11 +664,11 @@ QVariant BaseTrackTableModel::roleValue(
                     bpm = mixxx::Bpm(bpmValue);
                 }
             }
-            if (bpm.hasValue()) {
+            if (bpm.isValid()) {
                 if (role == Qt::ToolTipRole || role == kDataExportRole) {
-                    return QString::number(bpm.getValue(), 'f', 4);
+                    return QString::number(bpm.value(), 'f', 4);
                 } else {
-                    return QString::number(bpm.getValue(), 'f', 1);
+                    return QString::number(bpm.value(), 'f', 1);
                 }
             } else {
                 return QChar('-');
@@ -782,7 +782,7 @@ QVariant BaseTrackTableModel::roleValue(
         case ColumnCache::COLUMN_LIBRARYTABLE_BPM: {
             bool ok;
             const auto bpmValue = rawValue.toDouble(&ok);
-            return ok ? bpmValue : mixxx::Bpm().getValue();
+            return ok ? bpmValue : mixxx::Bpm().value();
         }
         case ColumnCache::COLUMN_LIBRARYTABLE_TIMESPLAYED:
             return index.sibling(

--- a/src/library/browse/browsethread.cpp
+++ b/src/library/browse/browsethread.cpp
@@ -226,7 +226,7 @@ void BrowseThread::populateModel() {
 
             item = new QStandardItem(trackMetadata.getTrackInfo().getBpmText());
             item->setToolTip(item->text());
-            item->setData(trackMetadata.getTrackInfo().getBpm().getValue(), Qt::UserRole);
+            item->setData(trackMetadata.getTrackInfo().getBpm().value(), Qt::UserRole);
             row_data.insert(COLUMN_BPM, item);
 
             item = new QStandardItem(trackMetadata.getTrackInfo().getKey());

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -581,14 +581,14 @@ void bindTrackLibraryValues(
     QString beatsVersion;
     QString beatsSubVersion;
     // Fall back on cached BPM
-    double dBpm = trackInfo.getBpm().getValue();
+    mixxx::Bpm bpm = trackInfo.getBpm();
     if (!pBeats.isNull()) {
         beatsBlob = pBeats->toByteArray();
         beatsVersion = pBeats->getVersion();
         beatsSubVersion = pBeats->getSubVersion();
-        dBpm = pBeats->getBpm();
+        bpm = pBeats->getBpm();
     }
-    pTrackLibraryQuery->bindValue(":bpm", dBpm);
+    pTrackLibraryQuery->bindValue(":bpm", bpm.getValue());
     pTrackLibraryQuery->bindValue(":beats_version", beatsVersion);
     pTrackLibraryQuery->bindValue(":beats_sub_version", beatsSubVersion);
     pTrackLibraryQuery->bindValue(":beats", beatsBlob);

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1240,7 +1240,7 @@ bool setTrackAudioProperties(
 
 bool setTrackBeats(const QSqlRecord& record, const int column,
                    TrackPointer pTrack) {
-    double bpm = record.value(column).toDouble();
+    const auto bpm = mixxx::Bpm(record.value(column).toDouble());
     QString beatsVersion = record.value(column + 1).toString();
     QString beatsSubVersion = record.value(column + 2).toString();
     QByteArray beatsBlob = record.value(column + 3).toByteArray();

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -588,7 +588,7 @@ void bindTrackLibraryValues(
         beatsSubVersion = pBeats->getSubVersion();
         bpm = pBeats->getBpm();
     }
-    pTrackLibraryQuery->bindValue(":bpm", bpm.getValue());
+    pTrackLibraryQuery->bindValue(":bpm", bpm.value());
     pTrackLibraryQuery->bindValue(":beats_version", beatsVersion);
     pTrackLibraryQuery->bindValue(":beats_sub_version", beatsSubVersion);
     pTrackLibraryQuery->bindValue(":beats", beatsBlob);

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -44,7 +44,6 @@ DlgTrackInfo::DlgTrackInfo(
         : QDialog(nullptr),
           m_pTrackModel(trackModel),
           m_tapFilter(this, kFilterLength, kMaxInterval),
-          m_dLastTapedBpm(-1.),
           m_pWCoverArtLabel(make_parented<WCoverArtLabel>(this)),
           m_pWStarRating(make_parented<WStarRating>(nullptr, this)) {
     init();
@@ -583,7 +582,7 @@ void DlgTrackInfo::slotBpmConstChanged(int state) {
             CuePosition cue = m_pLoadedTrack->getCuePoint();
             m_pBeatsClone =
                     BeatFactory::makeBeatGrid(m_pLoadedTrack->getSampleRate(),
-                            spinBpm->value(),
+                            mixxx::Bpm(spinBpm->value()),
                             mixxx::audio::FramePos::fromEngineSamplePos(
                                     cue.getPosition()));
         } else {
@@ -602,18 +601,19 @@ void DlgTrackInfo::slotBpmTap(double averageLength, int numSamples) {
     if (averageLength == 0) {
         return;
     }
-    double averageBpm = 60.0 * 1000.0 / averageLength;
+    auto averageBpm = mixxx::Bpm(60.0 * 1000.0 / averageLength);
     averageBpm = BeatUtils::roundBpmWithinRange(averageBpm - kBpmTabRounding,
             averageBpm,
             averageBpm + kBpmTabRounding);
-    if (averageBpm != m_dLastTapedBpm) {
-        m_dLastTapedBpm = averageBpm;
-        spinBpm->setValue(averageBpm);
+    if (averageBpm != m_lastTapedBpm) {
+        m_lastTapedBpm = averageBpm;
+        spinBpm->setValue(averageBpm.getValue());
     }
 }
 
 void DlgTrackInfo::slotSpinBpmValueChanged(double value) {
-    if (value <= 0) {
+    const auto bpm = mixxx::Bpm(value);
+    if (!bpm.hasValue()) {
         m_pBeatsClone.clear();
         return;
     }
@@ -622,17 +622,17 @@ void DlgTrackInfo::slotSpinBpmValueChanged(double value) {
         CuePosition cue = m_pLoadedTrack->getCuePoint();
         m_pBeatsClone = BeatFactory::makeBeatGrid(
                 m_pLoadedTrack->getSampleRate(),
-                value,
+                bpm,
                 mixxx::audio::FramePos::fromEngineSamplePos(cue.getPosition()));
     }
 
     double oldValue = m_pBeatsClone->getBpm();
-    if (oldValue == value) {
+    if (oldValue == bpm.getValue()) {
         return;
     }
 
     if (m_pBeatsClone->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM) {
-        m_pBeatsClone = m_pBeatsClone->setBpm(value);
+        m_pBeatsClone = m_pBeatsClone->setBpm(bpm.getValue());
     }
 
     // read back the actual value

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -369,7 +369,7 @@ void DlgTrackInfo::updateTrackMetadataFields() {
 void DlgTrackInfo::reloadTrackBeats(const Track& track) {
     m_pBeatsClone = track.getBeats();
     if (m_pBeatsClone) {
-        spinBpm->setValue(m_pBeatsClone->getBpm());
+        spinBpm->setValue(m_pBeatsClone->getBpm().getValue());
     } else {
         spinBpm->setValue(0.0);
     }
@@ -520,43 +520,43 @@ void DlgTrackInfo::clear() {
 void DlgTrackInfo::slotBpmDouble() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::DOUBLE);
     // read back the actual value
-    double newValue = m_pBeatsClone->getBpm();
-    spinBpm->setValue(newValue);
+    mixxx::Bpm newValue = m_pBeatsClone->getBpm();
+    spinBpm->setValue(newValue.getValue());
 }
 
 void DlgTrackInfo::slotBpmHalve() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::HALVE);
     // read back the actual value
-    double newValue = m_pBeatsClone->getBpm();
-    spinBpm->setValue(newValue);
+    const mixxx::Bpm newValue = m_pBeatsClone->getBpm();
+    spinBpm->setValue(newValue.getValue());
 }
 
 void DlgTrackInfo::slotBpmTwoThirds() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::TWOTHIRDS);
     // read back the actual value
-    double newValue = m_pBeatsClone->getBpm();
-    spinBpm->setValue(newValue);
+    const mixxx::Bpm newValue = m_pBeatsClone->getBpm();
+    spinBpm->setValue(newValue.getValue());
 }
 
 void DlgTrackInfo::slotBpmThreeFourth() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::THREEFOURTHS);
     // read back the actual value
-    double newValue = m_pBeatsClone->getBpm();
-    spinBpm->setValue(newValue);
+    const mixxx::Bpm newValue = m_pBeatsClone->getBpm();
+    spinBpm->setValue(newValue.getValue());
 }
 
 void DlgTrackInfo::slotBpmFourThirds() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::FOURTHIRDS);
     // read back the actual value
-    double newValue = m_pBeatsClone->getBpm();
-    spinBpm->setValue(newValue);
+    const mixxx::Bpm newValue = m_pBeatsClone->getBpm();
+    spinBpm->setValue(newValue.getValue());
 }
 
 void DlgTrackInfo::slotBpmThreeHalves() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::THREEHALVES);
     // read back the actual value
-    double newValue = m_pBeatsClone->getBpm();
-    spinBpm->setValue(newValue);
+    const mixxx::Bpm newValue = m_pBeatsClone->getBpm();
+    spinBpm->setValue(newValue.getValue());
 }
 
 void DlgTrackInfo::slotBpmClear() {
@@ -626,18 +626,18 @@ void DlgTrackInfo::slotSpinBpmValueChanged(double value) {
                 mixxx::audio::FramePos::fromEngineSamplePos(cue.getPosition()));
     }
 
-    double oldValue = m_pBeatsClone->getBpm();
-    if (oldValue == bpm.getValue()) {
+    const mixxx::Bpm oldValue = m_pBeatsClone->getBpm();
+    if (oldValue == bpm) {
         return;
     }
 
     if (m_pBeatsClone->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM) {
-        m_pBeatsClone = m_pBeatsClone->setBpm(bpm.getValue());
+        m_pBeatsClone = m_pBeatsClone->setBpm(bpm);
     }
 
     // read back the actual value
-    double newValue = m_pBeatsClone->getBpm();
-    spinBpm->setValue(newValue);
+    const mixxx::Bpm newValue = m_pBeatsClone->getBpm();
+    spinBpm->setValue(newValue.getValue());
 }
 
 mixxx::UpdateResult DlgTrackInfo::updateKeyText() {

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -369,7 +369,7 @@ void DlgTrackInfo::updateTrackMetadataFields() {
 void DlgTrackInfo::reloadTrackBeats(const Track& track) {
     m_pBeatsClone = track.getBeats();
     if (m_pBeatsClone) {
-        spinBpm->setValue(m_pBeatsClone->getBpm().getValue());
+        spinBpm->setValue(m_pBeatsClone->getBpm().value());
     } else {
         spinBpm->setValue(0.0);
     }
@@ -521,42 +521,42 @@ void DlgTrackInfo::slotBpmDouble() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::DOUBLE);
     // read back the actual value
     mixxx::Bpm newValue = m_pBeatsClone->getBpm();
-    spinBpm->setValue(newValue.getValue());
+    spinBpm->setValue(newValue.value());
 }
 
 void DlgTrackInfo::slotBpmHalve() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::HALVE);
     // read back the actual value
     const mixxx::Bpm newValue = m_pBeatsClone->getBpm();
-    spinBpm->setValue(newValue.getValue());
+    spinBpm->setValue(newValue.value());
 }
 
 void DlgTrackInfo::slotBpmTwoThirds() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::TWOTHIRDS);
     // read back the actual value
     const mixxx::Bpm newValue = m_pBeatsClone->getBpm();
-    spinBpm->setValue(newValue.getValue());
+    spinBpm->setValue(newValue.value());
 }
 
 void DlgTrackInfo::slotBpmThreeFourth() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::THREEFOURTHS);
     // read back the actual value
     const mixxx::Bpm newValue = m_pBeatsClone->getBpm();
-    spinBpm->setValue(newValue.getValue());
+    spinBpm->setValue(newValue.value());
 }
 
 void DlgTrackInfo::slotBpmFourThirds() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::FOURTHIRDS);
     // read back the actual value
     const mixxx::Bpm newValue = m_pBeatsClone->getBpm();
-    spinBpm->setValue(newValue.getValue());
+    spinBpm->setValue(newValue.value());
 }
 
 void DlgTrackInfo::slotBpmThreeHalves() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::THREEHALVES);
     // read back the actual value
     const mixxx::Bpm newValue = m_pBeatsClone->getBpm();
-    spinBpm->setValue(newValue.getValue());
+    spinBpm->setValue(newValue.value());
 }
 
 void DlgTrackInfo::slotBpmClear() {
@@ -607,13 +607,13 @@ void DlgTrackInfo::slotBpmTap(double averageLength, int numSamples) {
             averageBpm + kBpmTabRounding);
     if (averageBpm != m_lastTapedBpm) {
         m_lastTapedBpm = averageBpm;
-        spinBpm->setValue(averageBpm.getValue());
+        spinBpm->setValue(averageBpm.value());
     }
 }
 
 void DlgTrackInfo::slotSpinBpmValueChanged(double value) {
     const auto bpm = mixxx::Bpm(value);
-    if (!bpm.hasValue()) {
+    if (!bpm.isValid()) {
         m_pBeatsClone.clear();
         return;
     }
@@ -637,7 +637,7 @@ void DlgTrackInfo::slotSpinBpmValueChanged(double value) {
 
     // read back the actual value
     const mixxx::Bpm newValue = m_pBeatsClone->getBpm();
-    spinBpm->setValue(newValue.getValue());
+    spinBpm->setValue(newValue.value());
 }
 
 mixxx::UpdateResult DlgTrackInfo::updateKeyText() {

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -115,7 +115,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     bool m_trackHasBeatMap;
 
     TapFilter m_tapFilter;
-    double m_dLastTapedBpm;
+    mixxx::Bpm m_lastTapedBpm;
 
     parented_ptr<WCoverArtLabel> m_pWCoverArtLabel;
     parented_ptr<WStarRating> m_pWStarRating;

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -27,31 +27,31 @@ TEST(BeatGridTest, Scale) {
     TrackPointer pTrack = newTrack(sampleRate);
 
     constexpr mixxx::Bpm bpm(60.0);
-    pTrack->trySetBpm(bpm.getValue());
+    pTrack->trySetBpm(bpm.value());
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
             QString(),
             mixxx::Bpm(bpm),
             mixxx::audio::kStartFramePos);
 
-    EXPECT_DOUBLE_EQ(bpm.getValue(), pGrid->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value(), pGrid->getBpm().value());
     pGrid = pGrid->scale(Beats::DOUBLE);
-    EXPECT_DOUBLE_EQ(2 * bpm.getValue(), pGrid->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(2 * bpm.value(), pGrid->getBpm().value());
 
     pGrid = pGrid->scale(Beats::HALVE);
-    EXPECT_DOUBLE_EQ(bpm.getValue(), pGrid->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value(), pGrid->getBpm().value());
 
     pGrid = pGrid->scale(Beats::TWOTHIRDS);
-    EXPECT_DOUBLE_EQ(bpm.getValue() * 2 / 3, pGrid->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value() * 2 / 3, pGrid->getBpm().value());
 
     pGrid = pGrid->scale(Beats::THREEHALVES);
-    EXPECT_DOUBLE_EQ(bpm.getValue(), pGrid->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value(), pGrid->getBpm().value());
 
     pGrid = pGrid->scale(Beats::THREEFOURTHS);
-    EXPECT_DOUBLE_EQ(bpm.getValue() * 3 / 4, pGrid->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value() * 3 / 4, pGrid->getBpm().value());
 
     pGrid = pGrid->scale(Beats::FOURTHIRDS);
-    EXPECT_DOUBLE_EQ(bpm.getValue(), pGrid->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value(), pGrid->getBpm().value());
 }
 
 TEST(BeatGridTest, TestNthBeatWhenOnBeat) {
@@ -190,8 +190,8 @@ TEST(BeatGridTest, TestNthBeatWhenNotOnBeat) {
 
     const auto bpm = mixxx::Bpm(60.1);
     const int kFrameSize = 2;
-    pTrack->trySetBpm(bpm.getValue());
-    double beatLength = (60.0 * sampleRate / bpm.getValue()) * kFrameSize;
+    pTrack->trySetBpm(bpm.value());
+    double beatLength = (60.0 * sampleRate / bpm.value()) * kFrameSize;
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
             QString(),
@@ -230,11 +230,11 @@ TEST(BeatGridTest, FromMetadata) {
     TrackPointer pTrack = newTrack(sampleRate);
 
     constexpr mixxx::Bpm bpm(60.1);
-    ASSERT_TRUE(pTrack->trySetBpm(bpm.getValue()));
-    EXPECT_DOUBLE_EQ(pTrack->getBpm(), bpm.getValue());
+    ASSERT_TRUE(pTrack->trySetBpm(bpm.value()));
+    EXPECT_DOUBLE_EQ(pTrack->getBpm(), bpm.value());
 
     auto pBeats = pTrack->getBeats();
-    EXPECT_DOUBLE_EQ(pBeats->getBpm().getValue(), bpm.getValue());
+    EXPECT_DOUBLE_EQ(pBeats->getBpm().value(), bpm.value());
 
     // Invalid bpm resets the bpm
     ASSERT_TRUE(pTrack->trySetBpm(-60.1));

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -26,12 +26,12 @@ TEST(BeatGridTest, Scale) {
     int sampleRate = 44100;
     TrackPointer pTrack = newTrack(sampleRate);
 
-    double bpm = 60.0;
+    const auto bpm = 60.0;
     pTrack->trySetBpm(bpm);
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
             QString(),
-            bpm,
+            mixxx::Bpm(bpm),
             mixxx::audio::kStartFramePos);
 
     EXPECT_DOUBLE_EQ(bpm, pGrid->getBpm());
@@ -65,7 +65,7 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat) {
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
             QString(),
-            bpm,
+            mixxx::Bpm(bpm),
             mixxx::audio::kStartFramePos);
     // Pretend we're on the 20th beat;
     double position = beatLength * 20;
@@ -107,7 +107,7 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
             QString(),
-            bpm,
+            mixxx::Bpm(bpm),
             mixxx::audio::kStartFramePos);
 
     // Pretend we're just before the 20th beat.
@@ -151,7 +151,7 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
             QString(),
-            bpm,
+            mixxx::Bpm(bpm),
             mixxx::audio::kStartFramePos);
 
     // Pretend we're just before the 20th beat.
@@ -188,10 +188,10 @@ TEST(BeatGridTest, TestNthBeatWhenNotOnBeat) {
     int sampleRate = 44100;
     TrackPointer pTrack = newTrack(sampleRate);
 
-    double bpm = 60.1;
+    const auto bpm = mixxx::Bpm(60.1);
     const int kFrameSize = 2;
-    pTrack->trySetBpm(bpm);
-    double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
+    pTrack->trySetBpm(bpm.getValue());
+    double beatLength = (60.0 * sampleRate / bpm.getValue()) * kFrameSize;
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
             QString(),
@@ -229,12 +229,12 @@ TEST(BeatGridTest, FromMetadata) {
     int sampleRate = 44100;
     TrackPointer pTrack = newTrack(sampleRate);
 
-    double bpm = 60.1;
-    ASSERT_TRUE(pTrack->trySetBpm(bpm));
-    EXPECT_DOUBLE_EQ(pTrack->getBpm(), bpm);
+    const auto bpm = mixxx::Bpm(60.1);
+    ASSERT_TRUE(pTrack->trySetBpm(bpm.getValue()));
+    EXPECT_DOUBLE_EQ(pTrack->getBpm(), bpm.getValue());
 
     auto pBeats = pTrack->getBeats();
-    EXPECT_DOUBLE_EQ(pBeats->getBpm(), bpm);
+    EXPECT_DOUBLE_EQ(pBeats->getBpm(), bpm.getValue());
 
     // Invalid bpm resets the bpm
     ASSERT_TRUE(pTrack->trySetBpm(-60.1));

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -26,32 +26,32 @@ TEST(BeatGridTest, Scale) {
     int sampleRate = 44100;
     TrackPointer pTrack = newTrack(sampleRate);
 
-    const auto bpm = 60.0;
-    pTrack->trySetBpm(bpm);
+    constexpr mixxx::Bpm bpm(60.0);
+    pTrack->trySetBpm(bpm.getValue());
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
             QString(),
             mixxx::Bpm(bpm),
             mixxx::audio::kStartFramePos);
 
-    EXPECT_DOUBLE_EQ(bpm, pGrid->getBpm());
+    EXPECT_DOUBLE_EQ(bpm.getValue(), pGrid->getBpm().getValue());
     pGrid = pGrid->scale(Beats::DOUBLE);
-    EXPECT_DOUBLE_EQ(2 * bpm, pGrid->getBpm());
+    EXPECT_DOUBLE_EQ(2 * bpm.getValue(), pGrid->getBpm().getValue());
 
     pGrid = pGrid->scale(Beats::HALVE);
-    EXPECT_DOUBLE_EQ(bpm, pGrid->getBpm());
+    EXPECT_DOUBLE_EQ(bpm.getValue(), pGrid->getBpm().getValue());
 
     pGrid = pGrid->scale(Beats::TWOTHIRDS);
-    EXPECT_DOUBLE_EQ(bpm * 2 / 3, pGrid->getBpm());
+    EXPECT_DOUBLE_EQ(bpm.getValue() * 2 / 3, pGrid->getBpm().getValue());
 
     pGrid = pGrid->scale(Beats::THREEHALVES);
-    EXPECT_DOUBLE_EQ(bpm, pGrid->getBpm());
+    EXPECT_DOUBLE_EQ(bpm.getValue(), pGrid->getBpm().getValue());
 
     pGrid = pGrid->scale(Beats::THREEFOURTHS);
-    EXPECT_DOUBLE_EQ(bpm * 3 / 4, pGrid->getBpm());
+    EXPECT_DOUBLE_EQ(bpm.getValue() * 3 / 4, pGrid->getBpm().getValue());
 
     pGrid = pGrid->scale(Beats::FOURTHIRDS);
-    EXPECT_DOUBLE_EQ(bpm, pGrid->getBpm());
+    EXPECT_DOUBLE_EQ(bpm.getValue(), pGrid->getBpm().getValue());
 }
 
 TEST(BeatGridTest, TestNthBeatWhenOnBeat) {
@@ -229,12 +229,12 @@ TEST(BeatGridTest, FromMetadata) {
     int sampleRate = 44100;
     TrackPointer pTrack = newTrack(sampleRate);
 
-    const auto bpm = mixxx::Bpm(60.1);
+    constexpr mixxx::Bpm bpm(60.1);
     ASSERT_TRUE(pTrack->trySetBpm(bpm.getValue()));
     EXPECT_DOUBLE_EQ(pTrack->getBpm(), bpm.getValue());
 
     auto pBeats = pTrack->getBeats();
-    EXPECT_DOUBLE_EQ(pBeats->getBpm(), bpm.getValue());
+    EXPECT_DOUBLE_EQ(pBeats->getBpm().getValue(), bpm.getValue());
 
     // Invalid bpm resets the bpm
     ASSERT_TRUE(pTrack->trySetBpm(-60.1));

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -24,7 +24,7 @@ class BeatMapTest : public testing::Test {
     }
 
     mixxx::audio::FrameDiff_t getBeatLengthFrames(mixxx::Bpm bpm) {
-        return (60.0 * m_iSampleRate / bpm.getValue());
+        return (60.0 * m_iSampleRate / bpm.value());
     }
 
     double getBeatLengthSamples(mixxx::Bpm bpm) {
@@ -48,7 +48,7 @@ class BeatMapTest : public testing::Test {
 
 TEST_F(BeatMapTest, Scale) {
     constexpr mixxx::Bpm bpm(60.0);
-    m_pTrack->trySetBpm(bpm.getValue());
+    m_pTrack->trySetBpm(bpm.value());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
     const int numBeats = 100;
@@ -57,29 +57,29 @@ TEST_F(BeatMapTest, Scale) {
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
     auto pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
 
-    EXPECT_DOUBLE_EQ(bpm.getValue(), pMap->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value(), pMap->getBpm().value());
     pMap = pMap->scale(Beats::DOUBLE);
-    EXPECT_DOUBLE_EQ(2 * bpm.getValue(), pMap->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(2 * bpm.value(), pMap->getBpm().value());
 
     pMap = pMap->scale(Beats::HALVE);
-    EXPECT_DOUBLE_EQ(bpm.getValue(), pMap->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value(), pMap->getBpm().value());
 
     pMap = pMap->scale(Beats::TWOTHIRDS);
-    EXPECT_DOUBLE_EQ(bpm.getValue() * 2 / 3, pMap->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value() * 2 / 3, pMap->getBpm().value());
 
     pMap = pMap->scale(Beats::THREEHALVES);
-    EXPECT_DOUBLE_EQ(bpm.getValue(), pMap->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value(), pMap->getBpm().value());
 
     pMap = pMap->scale(Beats::THREEFOURTHS);
-    EXPECT_DOUBLE_EQ(bpm.getValue() * 3 / 4, pMap->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value() * 3 / 4, pMap->getBpm().value());
 
     pMap = pMap->scale(Beats::FOURTHIRDS);
-    EXPECT_DOUBLE_EQ(bpm.getValue(), pMap->getBpm().getValue());
+    EXPECT_DOUBLE_EQ(bpm.value(), pMap->getBpm().value());
 }
 
 TEST_F(BeatMapTest, TestNthBeat) {
     constexpr mixxx::Bpm bpm(60.0);
-    m_pTrack->trySetBpm(bpm.getValue());
+    m_pTrack->trySetBpm(bpm.value());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -112,7 +112,7 @@ TEST_F(BeatMapTest, TestNthBeat) {
 
 TEST_F(BeatMapTest, TestNthBeatWhenOnBeat) {
     constexpr mixxx::Bpm bpm(60.0);
-    m_pTrack->trySetBpm(bpm.getValue());
+    m_pTrack->trySetBpm(bpm.value());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -155,7 +155,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat) {
 
 TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
     constexpr mixxx::Bpm bpm(60.0);
-    m_pTrack->trySetBpm(bpm.getValue());
+    m_pTrack->trySetBpm(bpm.value());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -200,7 +200,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
 
 TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
     constexpr mixxx::Bpm bpm(60.0);
-    m_pTrack->trySetBpm(bpm.getValue());
+    m_pTrack->trySetBpm(bpm.value());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -246,7 +246,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
 
 TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
     constexpr mixxx::Bpm bpm(60.0);
-    m_pTrack->trySetBpm(bpm.getValue());
+    m_pTrack->trySetBpm(bpm.value());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -289,7 +289,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
 TEST_F(BeatMapTest, TestBpmAround) {
     constexpr mixxx::Bpm filebpm(60.0);
     double approx_beat_length = getBeatLengthSamples(filebpm);
-    m_pTrack->trySetBpm(filebpm.getValue());
+    m_pTrack->trySetBpm(filebpm.value());
     const int numBeats = 64;
 
     QVector<mixxx::audio::FramePos> beats;
@@ -305,21 +305,21 @@ TEST_F(BeatMapTest, TestBpmAround) {
     // The average of the first 8 beats should be different than the average
     // of the last 8 beats.
     EXPECT_DOUBLE_EQ(63.937645572318047,
-            pMap->getBpmAroundPosition(4 * approx_beat_length, 4).getValue());
+            pMap->getBpmAroundPosition(4 * approx_beat_length, 4).value());
     EXPECT_DOUBLE_EQ(118.96668932698844,
-            pMap->getBpmAroundPosition(60 * approx_beat_length, 4).getValue());
+            pMap->getBpmAroundPosition(60 * approx_beat_length, 4).value());
     // Also test at the beginning and end of the track
     EXPECT_DOUBLE_EQ(62.937377309576974,
-            pMap->getBpmAroundPosition(0, 4).getValue());
+            pMap->getBpmAroundPosition(0, 4).value());
     EXPECT_DOUBLE_EQ(118.96668932698844,
-            pMap->getBpmAroundPosition(65 * approx_beat_length, 4).getValue());
+            pMap->getBpmAroundPosition(65 * approx_beat_length, 4).value());
 
     // Try a really, really short track
     constexpr auto startFramePos = mixxx::audio::FramePos(10);
     beats = createBeatVector(startFramePos, 3, getBeatLengthFrames(filebpm));
     pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
-    EXPECT_DOUBLE_EQ(filebpm.getValue(),
-            pMap->getBpmAroundPosition(1 * approx_beat_length, 4).getValue());
+    EXPECT_DOUBLE_EQ(filebpm.value(),
+            pMap->getBpmAroundPosition(1 * approx_beat_length, 4).value());
 }
 
 }  // namespace

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -23,11 +23,11 @@ class BeatMapTest : public testing::Test {
                 mixxx::Duration::fromSeconds(180));
     }
 
-    mixxx::audio::FrameDiff_t getBeatLengthFrames(double bpm) {
-        return (60.0 * m_iSampleRate / bpm);
+    mixxx::audio::FrameDiff_t getBeatLengthFrames(mixxx::Bpm bpm) {
+        return (60.0 * m_iSampleRate / bpm.getValue());
     }
 
-    double getBeatLengthSamples(double bpm) {
+    double getBeatLengthSamples(mixxx::Bpm bpm) {
         return getBeatLengthFrames(bpm) * m_iFrameSize;
     }
 
@@ -47,8 +47,8 @@ class BeatMapTest : public testing::Test {
 };
 
 TEST_F(BeatMapTest, Scale) {
-    const double bpm = 60.0;
-    m_pTrack->trySetBpm(bpm);
+    constexpr mixxx::Bpm bpm(60.0);
+    m_pTrack->trySetBpm(bpm.getValue());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
     const int numBeats = 100;
@@ -57,29 +57,29 @@ TEST_F(BeatMapTest, Scale) {
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
     auto pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
 
-    EXPECT_DOUBLE_EQ(bpm, pMap->getBpm());
+    EXPECT_DOUBLE_EQ(bpm.getValue(), pMap->getBpm().getValue());
     pMap = pMap->scale(Beats::DOUBLE);
-    EXPECT_DOUBLE_EQ(2 * bpm, pMap->getBpm());
+    EXPECT_DOUBLE_EQ(2 * bpm.getValue(), pMap->getBpm().getValue());
 
     pMap = pMap->scale(Beats::HALVE);
-    EXPECT_DOUBLE_EQ(bpm, pMap->getBpm());
+    EXPECT_DOUBLE_EQ(bpm.getValue(), pMap->getBpm().getValue());
 
     pMap = pMap->scale(Beats::TWOTHIRDS);
-    EXPECT_DOUBLE_EQ(bpm * 2 / 3, pMap->getBpm());
+    EXPECT_DOUBLE_EQ(bpm.getValue() * 2 / 3, pMap->getBpm().getValue());
 
     pMap = pMap->scale(Beats::THREEHALVES);
-    EXPECT_DOUBLE_EQ(bpm, pMap->getBpm());
+    EXPECT_DOUBLE_EQ(bpm.getValue(), pMap->getBpm().getValue());
 
     pMap = pMap->scale(Beats::THREEFOURTHS);
-    EXPECT_DOUBLE_EQ(bpm * 3 / 4, pMap->getBpm());
+    EXPECT_DOUBLE_EQ(bpm.getValue() * 3 / 4, pMap->getBpm().getValue());
 
     pMap = pMap->scale(Beats::FOURTHIRDS);
-    EXPECT_DOUBLE_EQ(bpm, pMap->getBpm());
+    EXPECT_DOUBLE_EQ(bpm.getValue(), pMap->getBpm().getValue());
 }
 
 TEST_F(BeatMapTest, TestNthBeat) {
-    const double bpm = 60.0;
-    m_pTrack->trySetBpm(bpm);
+    constexpr mixxx::Bpm bpm(60.0);
+    m_pTrack->trySetBpm(bpm.getValue());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -111,8 +111,8 @@ TEST_F(BeatMapTest, TestNthBeat) {
 }
 
 TEST_F(BeatMapTest, TestNthBeatWhenOnBeat) {
-    const double bpm = 60.0;
-    m_pTrack->trySetBpm(bpm);
+    constexpr mixxx::Bpm bpm(60.0);
+    m_pTrack->trySetBpm(bpm.getValue());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -154,8 +154,8 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat) {
 }
 
 TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
-    const double bpm = 60.0;
-    m_pTrack->trySetBpm(bpm);
+    constexpr mixxx::Bpm bpm(60.0);
+    m_pTrack->trySetBpm(bpm.getValue());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -199,8 +199,8 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
 }
 
 TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
-    const double bpm = 60.0;
-    m_pTrack->trySetBpm(bpm);
+    constexpr mixxx::Bpm bpm(60.0);
+    m_pTrack->trySetBpm(bpm.getValue());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -245,8 +245,8 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
 }
 
 TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
-    const double bpm = 60.0;
-    m_pTrack->trySetBpm(bpm);
+    constexpr mixxx::Bpm bpm(60.0);
+    m_pTrack->trySetBpm(bpm.getValue());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
     double beatLengthSamples = getBeatLengthSamples(bpm);
@@ -287,15 +287,15 @@ TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
 }
 
 TEST_F(BeatMapTest, TestBpmAround) {
-    const double filebpm = 60.0;
+    constexpr mixxx::Bpm filebpm(60.0);
     double approx_beat_length = getBeatLengthSamples(filebpm);
-    m_pTrack->trySetBpm(filebpm);
+    m_pTrack->trySetBpm(filebpm.getValue());
     const int numBeats = 64;
 
     QVector<mixxx::audio::FramePos> beats;
     mixxx::audio::FramePos beat_pos = mixxx::audio::kStartFramePos;
-    for (unsigned int i = 0, bpm=60; i < numBeats; ++i, ++bpm) {
-        const mixxx::audio::FrameDiff_t beat_length = getBeatLengthFrames(bpm);
+    for (unsigned int i = 0, bpmValue = 60; i < numBeats; ++i, ++bpmValue) {
+        const mixxx::audio::FrameDiff_t beat_length = getBeatLengthFrames(mixxx::Bpm(bpmValue));
         beats.append(beat_pos);
         beat_pos += beat_length;
     }
@@ -305,20 +305,21 @@ TEST_F(BeatMapTest, TestBpmAround) {
     // The average of the first 8 beats should be different than the average
     // of the last 8 beats.
     EXPECT_DOUBLE_EQ(63.937645572318047,
-            pMap->getBpmAroundPosition(4 * approx_beat_length, 4));
+            pMap->getBpmAroundPosition(4 * approx_beat_length, 4).getValue());
     EXPECT_DOUBLE_EQ(118.96668932698844,
-            pMap->getBpmAroundPosition(60 * approx_beat_length, 4));
+            pMap->getBpmAroundPosition(60 * approx_beat_length, 4).getValue());
     // Also test at the beginning and end of the track
     EXPECT_DOUBLE_EQ(62.937377309576974,
-            pMap->getBpmAroundPosition(0, 4));
+            pMap->getBpmAroundPosition(0, 4).getValue());
     EXPECT_DOUBLE_EQ(118.96668932698844,
-            pMap->getBpmAroundPosition(65 * approx_beat_length, 4));
+            pMap->getBpmAroundPosition(65 * approx_beat_length, 4).getValue());
 
     // Try a really, really short track
     constexpr auto startFramePos = mixxx::audio::FramePos(10);
     beats = createBeatVector(startFramePos, 3, getBeatLengthFrames(filebpm));
     pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
-    EXPECT_DOUBLE_EQ(filebpm, pMap->getBpmAroundPosition(1 * approx_beat_length, 4));
+    EXPECT_DOUBLE_EQ(filebpm.getValue(),
+            pMap->getBpmAroundPosition(1 * approx_beat_length, 4).getValue());
 }
 
 }  // namespace

--- a/src/test/beatstranslatetest.cpp
+++ b/src/test/beatstranslatetest.cpp
@@ -7,7 +7,7 @@ class BeatsTranslateTest : public MockedEngineBackendTest {
 
 TEST_F(BeatsTranslateTest, SimpleTranslateMatch) {
     // Set up BeatGrids for decks 1 and 2.
-    const double bpm = 60.0;
+    const auto bpm = mixxx::Bpm(60.0);
     constexpr auto firstBeat = mixxx::audio::kStartFramePos;
     auto grid1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), QString(), bpm, firstBeat);
@@ -33,8 +33,8 @@ TEST_F(BeatsTranslateTest, SimpleTranslateMatch) {
     // doesn't get set naturally, but this will do for now.
     auto pBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "bpm");
     auto pBpm2 = std::make_unique<ControlProxy>(m_sGroup1, "bpm");
-    pBpm1->set(bpm);
-    pBpm2->set(bpm);
+    pBpm1->set(bpm.getValue());
+    pBpm2->set(bpm.getValue());
     ProcessBuffer();
 
     // Push the button on deck 2.

--- a/src/test/beatstranslatetest.cpp
+++ b/src/test/beatstranslatetest.cpp
@@ -33,8 +33,8 @@ TEST_F(BeatsTranslateTest, SimpleTranslateMatch) {
     // doesn't get set naturally, but this will do for now.
     auto pBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "bpm");
     auto pBpm2 = std::make_unique<ControlProxy>(m_sGroup1, "bpm");
-    pBpm1->set(bpm.getValue());
-    pBpm2->set(bpm.getValue());
+    pBpm1->set(bpm.value());
+    pBpm2->set(bpm.value());
     ProcessBuffer();
 
     // Push the button on deck 2.

--- a/src/test/bpmcontrol_test.cpp
+++ b/src/test/bpmcontrol_test.cpp
@@ -33,9 +33,9 @@ TEST_F(BpmControlTest, BeatContext_BeatGrid) {
             mixxx::audio::Bitrate(),
             mixxx::Duration::fromSeconds(180));
 
-    const double bpm = 60.0;
+    const auto bpm = mixxx::Bpm(60.0);
     const int kFrameSize = 2;
-    const double expectedBeatLength = (60.0 * sampleRate / bpm) * kFrameSize;
+    const double expectedBeatLength = (60.0 * sampleRate / bpm.getValue()) * kFrameSize;
 
     const mixxx::BeatsPointer pBeats = BeatFactory::makeBeatGrid(
             pTrack->getSampleRate(), bpm, mixxx::audio::kStartFramePos);

--- a/src/test/bpmcontrol_test.cpp
+++ b/src/test/bpmcontrol_test.cpp
@@ -35,7 +35,7 @@ TEST_F(BpmControlTest, BeatContext_BeatGrid) {
 
     const auto bpm = mixxx::Bpm(60.0);
     const int kFrameSize = 2;
-    const double expectedBeatLength = (60.0 * sampleRate / bpm.getValue()) * kFrameSize;
+    const double expectedBeatLength = (60.0 * sampleRate / bpm.value()) * kFrameSize;
 
     const mixxx::BeatsPointer pBeats = BeatFactory::makeBeatGrid(
             pTrack->getSampleRate(), bpm, mixxx::audio::kStartFramePos);

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -245,10 +245,10 @@ TEST_F(EngineSyncTest, ExplicitMasterPersists) {
     // If we set an explicit master, enabling sync or pressing play on other decks
     // doesn't cause the master to move around.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 120, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 124, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(124), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
     auto pButtonMasterSync1 =
@@ -279,13 +279,13 @@ TEST_F(EngineSyncTest, ExplicitMasterPersists) {
 TEST_F(EngineSyncTest, SetMasterWhilePlaying) {
     // Make sure we don't get two master lights if we change masters while playing.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 120, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 124, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(124), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     mixxx::BeatsPointer pBeats3 = BeatFactory::makeBeatGrid(
-            m_pTrack3->getSampleRate(), 128, mixxx::audio::kStartFramePos);
+            m_pTrack3->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
     m_pTrack3->trySetBeats(pBeats3);
 
     auto pButtonMasterSync1 =
@@ -316,7 +316,7 @@ TEST_F(EngineSyncTest, SetMasterWhilePlaying) {
 TEST_F(EngineSyncTest, SetEnabledBecomesMaster) {
     // If we set the first channel with a valid tempo to follower, it should be master.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 80, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(80), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     auto pButtonMasterSync1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
@@ -343,11 +343,11 @@ TEST_F(EngineSyncTest, DisableInternalMasterWhilePlaying) {
 
     // Make sure both decks are playing.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 80, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(80), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 80, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(80), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup2, "play"))->set(1.0);
     ProcessBuffer();
@@ -364,14 +364,14 @@ TEST_F(EngineSyncTest, DisableInternalMasterWhilePlaying) {
 TEST_F(EngineSyncTest, DisableSyncOnMaster) {
     // Channel 1 follower, channel 2 master.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 130, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     auto pButtonSyncMode1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     pButtonSyncMode1->slotSet(SYNC_FOLLOWER);
 
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 130, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     // Set deck two to explicit master.
     auto pButtonSyncMaster2 =
@@ -410,7 +410,7 @@ TEST_F(EngineSyncTest, InternalMasterSetFollowerSliderMoves) {
 
     // Set the file bpm of channel 1 to 80 bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 80, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(80), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
 
     auto pButtonMasterSync1 =
@@ -429,7 +429,7 @@ TEST_F(EngineSyncTest, AnySyncDeckSliderStays) {
     // master BPM if a new deck enables sync.
 
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 80, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(80), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
@@ -441,7 +441,7 @@ TEST_F(EngineSyncTest, AnySyncDeckSliderStays) {
                     ->get());
 
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 100, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
@@ -466,12 +466,12 @@ TEST_F(EngineSyncTest, InternalClockFollowsFirstPlayingDeck) {
 
     // Set up decks so they can be playing, and start deck 1.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 100, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 130, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup2, "play"), 0.0);
@@ -538,11 +538,11 @@ TEST_F(EngineSyncTest, SetExplicitMasterByLights) {
 
     // Set the file bpm of channel 1 to 160bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 160, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     // Set the file bpm of channel 2 to 150bpm.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 150, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(150), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
@@ -621,7 +621,7 @@ TEST_F(EngineSyncTest, RateChangeTest) {
 
     // Set the file bpm of channel 1 to 160bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 160, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sGroup1, "file_bpm")));
@@ -641,7 +641,7 @@ TEST_F(EngineSyncTest, RateChangeTest) {
 
     // Set the file bpm of channel 2 to 120bpm.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 120, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     EXPECT_DOUBLE_EQ(
             120.0, ControlObject::get(ConfigKey(m_sGroup2, "file_bpm")));
@@ -664,14 +664,14 @@ TEST_F(EngineSyncTest, RateChangeTestWeirdOrder) {
 
     // Set the file bpm of channel 1 to 160bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 160, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 120, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
     // Set the rate slider of channel 1 to 1.2.
@@ -690,14 +690,14 @@ TEST_F(EngineSyncTest, RateChangeTestWeirdOrder) {
 TEST_F(EngineSyncTest, RateChangeTestOrder3) {
     // Set the file bpm of channel 1 to 160bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 160, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sGroup1, "file_bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 120, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     EXPECT_DOUBLE_EQ(
             120.0, ControlObject::get(ConfigKey(m_sGroup2, "file_bpm")));
@@ -738,12 +738,12 @@ TEST_F(EngineSyncTest, FollowerRateChange) {
 
     // Set the file bpm of channel 1 to 160bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 160, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
 
     // Set the file bpm of channel 2 to 120bpm.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 120, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
     // Set the rate slider of channel 1 to 1.2.
@@ -786,14 +786,14 @@ TEST_F(EngineSyncTest, InternalRateChangeTest) {
 
     // Set the file bpm of channel 1 to 160bpm.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 160, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     EXPECT_DOUBLE_EQ(160.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "file_bpm"))->get());
 
     // Set the file bpm of channel 2 to 120bpm.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 120, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     EXPECT_DOUBLE_EQ(120.0,
             ControlObject::getControl(ConfigKey(m_sGroup2, "file_bpm"))->get());
@@ -840,10 +840,10 @@ TEST_F(EngineSyncTest, InternalRateChangeTest) {
 TEST_F(EngineSyncTest, MasterStopSliderCheck) {
     // If the master is playing, and stop is pushed, the sliders should stay the same.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 120, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 128, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
     auto pButtonMasterSync1 =
@@ -886,7 +886,7 @@ TEST_F(EngineSyncTest, EnableOneDeckInitsMaster) {
 
     // Set up the deck to play.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 130, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
             ->set(getRateSliderValue(1.0));
@@ -914,7 +914,7 @@ TEST_F(EngineSyncTest, EnableOneDeckInitsMaster) {
 
     // Enable second deck, bpm and beat distance should still match original setting.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 140, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(140), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))
             ->set(getRateSliderValue(1.0));
@@ -943,10 +943,10 @@ TEST_F(EngineSyncTest, MomentarySyncAlgorithmTwo) {
             ConfigValue(EngineSync::PREFER_LOCK_BPM));
 
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 120, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 128, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup2, "play"))->set(1.0);
@@ -965,7 +965,7 @@ TEST_F(EngineSyncTest, EnableOneDeckInitializesMaster) {
     // Enabling sync on a deck causes it to be master, and sets bpm and clock.
     // Set the deck to play.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 130, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
             ->set(getRateSliderValue(1.0));
@@ -1156,7 +1156,7 @@ TEST_F(EngineSyncTest, EnableOneDeckSliderUpdates) {
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
 
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 130, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
             ->set(getRateSliderValue(1.0));
@@ -1184,12 +1184,12 @@ TEST_F(EngineSyncTest, SyncToNonSyncDeck) {
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
 
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 130, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     ProcessBuffer();
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 100, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))
             ->set(getRateSliderValue(1.0));
@@ -1270,12 +1270,12 @@ TEST_F(EngineSyncTest, MomentarySyncDependsOnPlayingStates) {
 
     // Set up decks so they can be playing, and start deck 1.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 100, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 130, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup2, "play"), 1.0);
@@ -1346,7 +1346,7 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
     auto pButtonEject1 = std::make_unique<ControlProxy>(m_sGroup1, "eject");
 
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 120, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     pButtonSyncEnabled1->set(1.0);
     ProcessBuffer();
@@ -1372,7 +1372,7 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
     EXPECT_DOUBLE_EQ(128.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 135, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(135), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     pButtonSyncEnabled2->set(1.0);
     ProcessBuffer();
@@ -1393,7 +1393,7 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
 TEST_F(EngineSyncTest, FileBpmChangesDontAffectMaster) {
     // If filebpm changes, don't treat it like a rate change unless it's the master.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 100, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
@@ -1401,7 +1401,7 @@ TEST_F(EngineSyncTest, FileBpmChangesDontAffectMaster) {
     ProcessBuffer();
 
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 120, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
@@ -1413,7 +1413,7 @@ TEST_F(EngineSyncTest, FileBpmChangesDontAffectMaster) {
 
     // Update the master's beats -- update the internal clock
     pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 160, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
@@ -1422,7 +1422,7 @@ TEST_F(EngineSyncTest, FileBpmChangesDontAffectMaster) {
 
     // Update follower beats -- don't update internal clock.
     pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 140, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(140), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
@@ -1435,7 +1435,7 @@ TEST_F(EngineSyncTest, ExplicitMasterPostProcessed) {
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     pButtonMasterSync1->slotSet(SYNC_MASTER_EXPLICIT);
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 160, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     ProcessBuffer();
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
@@ -1450,7 +1450,7 @@ TEST_F(EngineSyncTest, ZeroBPMRateAdjustIgnored) {
     // If a track isn't loaded (0 bpm), but the deck has sync enabled,
     // don't pay attention to rate changes.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 0, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(0), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
@@ -1460,7 +1460,7 @@ TEST_F(EngineSyncTest, ZeroBPMRateAdjustIgnored) {
     ProcessBuffer();
 
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 120, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
@@ -1499,7 +1499,7 @@ TEST_F(EngineSyncTest, DISABLED_BeatDistanceBeforeStart) {
     // correctly.  Unfortunately, this currently doesn't work.
 
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 128, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::set(ConfigKey(m_sGroup1, "playposition"), -.05);
     ControlObject::getControl(ConfigKey(m_sGroup1, "sync_mode"))
@@ -1516,10 +1516,10 @@ TEST_F(EngineSyncTest, ZeroLatencyRateChangeNoQuant) {
     // Confirm that a rate change in an explicit master is instantly communicated
     // to followers.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 128, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 160, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
     // Make Channel2 master to weed out any channel ordering issues.
@@ -1566,10 +1566,10 @@ TEST_F(EngineSyncTest, ZeroLatencyRateChangeQuant) {
     // Confirm that a rate change in an explicit master is instantly communicated
     // to followers.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 128, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 160, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
@@ -1621,10 +1621,10 @@ TEST_F(EngineSyncTest, ZeroLatencyRateDiffQuant) {
     // Confirm that a rate change in an explicit master is instantly communicated
     // to followers.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 128, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 160, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup2, "quantize"))->set(1.0);
@@ -1677,10 +1677,10 @@ TEST_F(EngineSyncTest, ZeroLatencyRateDiffQuant) {
 // This test exercises https://bugs.launchpad.net/mixxx/+bug/1884324
 TEST_F(EngineSyncTest, ActivatingSyncDoesNotCauseDrifting) {
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 150, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(150), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 150, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(150), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(0.0);
@@ -1723,10 +1723,10 @@ TEST_F(EngineSyncTest, ActivatingSyncDoesNotCauseDrifting) {
 
 TEST_F(EngineSyncTest, HalfDoubleBpmTest) {
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 70, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(70), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 140, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(140), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
     // Mixxx will choose the first playing deck to be master.  Let's start deck 2 first.
@@ -1822,10 +1822,10 @@ TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
     // If a deck plays that had its multiplier set, we need to reset the
     // internal clock.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 80, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(80), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 175, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(175), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
             ->set(getRateSliderValue(1.0));
@@ -1947,10 +1947,10 @@ TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
 TEST_F(EngineSyncTest, HalfDoubleInternalClockTest) {
     // If we set the file_bpm CO's directly, the correct signals aren't fired.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 70, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(70), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 140, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(140), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
@@ -2024,10 +2024,10 @@ TEST_F(EngineSyncTest, HalfDoubleEachOther) {
     // Half/Double decision.
     // This test demonstrates https://bugs.launchpad.net/mixxx/+bug/1921962
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 144, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(144), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 105, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(105), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
     // Threshold 1.414 sqrt(2);
@@ -2053,7 +2053,7 @@ TEST_F(EngineSyncTest, HalfDoubleEachOther) {
     // expect 75 BPM
 
     mixxx::BeatsPointer pBeats1b = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 150, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(150), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1b);
 
     EXPECT_DOUBLE_EQ(150.0,
@@ -2075,7 +2075,7 @@ TEST_F(EngineSyncTest, HalfDoubleEachOther) {
 TEST_F(EngineSyncTest, SetFileBpmUpdatesLocalBpm) {
     ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->set(0.2);
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 130, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     EXPECT_EQ(
             130.0, m_pEngineSync->getSyncableForGroup(m_sGroup1)->getBaseBpm());
@@ -2088,7 +2088,7 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 130, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
 
@@ -2096,7 +2096,7 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     ControlObject::set(ConfigKey(m_sGroup2, "rate_ratio"), 1.0);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 100, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
     // Set the sync deck playing with nothing else active.
@@ -2180,7 +2180,7 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
     ControlObject::set(ConfigKey(m_sGroup3, "beat_distance"), 0.6);
     ControlObject::set(ConfigKey(m_sGroup2, "rate_ratio"), 1.0);
     mixxx::BeatsPointer pBeats3 = BeatFactory::makeBeatGrid(
-            m_pTrack3->getSampleRate(), 140, mixxx::audio::kStartFramePos);
+            m_pTrack3->getSampleRate(), mixxx::Bpm(140), mixxx::audio::kStartFramePos);
     m_pTrack3->trySetBeats(pBeats3);
     // This will sync to the first deck here and not the second (lp1784185)
     pButtonSyncEnabled3->set(1.0);
@@ -2226,10 +2226,10 @@ TEST_F(EngineSyncTest, UserTweakBeatDistance) {
     // is used to reseed the master beat distance, make sure the user offset
     // is reset.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 128, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 128, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
@@ -2281,10 +2281,10 @@ TEST_F(EngineSyncTest, UserTweakPreservedInSeek) {
     // This is about 128 bpm, but results in nice round numbers of samples.
     const double kDivisibleBpm = 44100.0 / 344.0;
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), kDivisibleBpm, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(kDivisibleBpm), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 130, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup2, "sync_enabled"))->set(1);
@@ -2362,10 +2362,10 @@ TEST_F(EngineSyncTest, FollowerUserTweakPreservedInMasterChange) {
     // This is about 128 bpm, but results in nice round numbers of samples.
     const double kDivisibleBpm = 44100.0 / 344.0;
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), kDivisibleBpm, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(kDivisibleBpm), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 130, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "sync_master"))->set(1);
@@ -2415,10 +2415,10 @@ TEST_F(EngineSyncTest, MasterUserTweakPreservedInMasterChange) {
     // This is about 128 bpm, but results in nice round numbers of samples.
     const double kDivisibleBpm = 44100.0 / 344.0;
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), kDivisibleBpm, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(kDivisibleBpm), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 130, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "sync_master"))->set(1);
@@ -2464,7 +2464,7 @@ TEST_F(EngineSyncTest, MasterUserTweakPreservedInMasterChange) {
 
 TEST_F(EngineSyncTest, MasterBpmNeverZero) {
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 128, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
 
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
@@ -2480,7 +2480,7 @@ TEST_F(EngineSyncTest, ZeroBpmNaturalRate) {
     // doesn't end up something crazy when sync is enabled..
     // Maybe the beatgrid ended up at zero also.
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 0.0, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(0.0), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
 
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
@@ -2500,12 +2500,12 @@ TEST_F(EngineSyncTest, QuantizeImpliesSyncPhase) {
     auto pButtonBeatsyncPhase1 = std::make_unique<ControlProxy>(m_sGroup1, "beatsync_phase");
 
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 130, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
 
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 100, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
     ProcessBuffer();
@@ -2598,7 +2598,7 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
     ControlObject::set(ConfigKey(m_sGroup1, "quantize"), 1.0);
 
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 130, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
@@ -2621,7 +2621,7 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
     ProcessBuffer();
 
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 130, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
@@ -2644,7 +2644,7 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
 TEST_F(EngineSyncTest, SyncWithoutBeatgrid) {
     // this tests bug lp1783020, notresetting rate when other deck has no beatgrid
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 128, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     m_pTrack2->trySetBeats(mixxx::BeatsPointer());
 
@@ -2663,12 +2663,12 @@ TEST_F(EngineSyncTest, SyncWithoutBeatgrid) {
 
 TEST_F(EngineSyncTest, QuantizeHotCueActivate) {
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 130, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
 
     auto pHotCue2Activate = std::make_unique<ControlProxy>(m_sGroup2, "hotcue_1_activate");
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 100, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
 
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -2730,7 +2730,7 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
 
     // set beatgrid for deck 1
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 130, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     pButtonSyncEnabled1->set(1.0);
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
@@ -2764,7 +2764,7 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
 
     // Load a new beatgrid during playing, this happens when the analyser is finished.
     mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 140, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(140), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
     ProcessBuffer();
@@ -2789,7 +2789,7 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
 
     // Load a new beatgrid again, this happens when the user adjusts the beatgrid
     mixxx::BeatsPointer pBeats2n = BeatFactory::makeBeatGrid(
-            m_pTrack2->getSampleRate(), 75, mixxx::audio::kStartFramePos);
+            m_pTrack2->getSampleRate(), mixxx::Bpm(75), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2n);
 
     ProcessBuffer();
@@ -2805,7 +2805,7 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
 TEST_F(EngineSyncTest, BeatMapQuantizePlay) {
     // This test demonstates https://bugs.launchpad.net/mixxx/+bug/1874918
     mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), 120, mixxx::audio::kStartFramePos);
+            m_pTrack1->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
 
     constexpr auto kSampleRate = mixxx::audio::SampleRate(44100);

--- a/src/test/metadatatest.cpp
+++ b/src/test/metadatatest.cpp
@@ -48,7 +48,7 @@ class MetadataTest : public testing::Test {
         mixxx::TrackMetadata trackMetadata;
         mixxx::taglib::id3v2::importTrackMetadataFromTag(&trackMetadata, tag);
 
-        EXPECT_DOUBLE_EQ(expectedValue, trackMetadata.getTrackInfo().getBpm().getValue());
+        EXPECT_DOUBLE_EQ(expectedValue, trackMetadata.getTrackInfo().getBpm().value());
     }
 };
 

--- a/src/test/seratobeatgridtest.cpp
+++ b/src/test/seratobeatgridtest.cpp
@@ -126,7 +126,7 @@ TEST_F(SeratoBeatGridTest, SerializeBeatgrid) {
     seratoBeatGrid.setBeats(pBeats, signalInfo, duration, 0);
     EXPECT_EQ(seratoBeatGrid.nonTerminalMarkers().size(), 0);
     EXPECT_NE(seratoBeatGrid.terminalMarker(), nullptr);
-    EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm.getValue()));
+    EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm.value()));
 }
 
 TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
@@ -137,7 +137,7 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
     const auto signalInfo = mixxx::audio::SignalInfo(mixxx::audio::ChannelCount(2), sampleRate);
     const auto duration = mixxx::Duration::fromSeconds<int>(300);
     const mixxx::audio::FrameDiff_t framesPerMinute = signalInfo.getSampleRate() * 60;
-    const mixxx::audio::FrameDiff_t framesPerBeat = framesPerMinute / bpm.getValue();
+    const mixxx::audio::FrameDiff_t framesPerBeat = framesPerMinute / bpm.value();
     const mixxx::audio::FrameDiff_t initialFrameOffset = framesPerBeat / 2;
 
     QVector<mixxx::audio::FramePos> beatPositionsFrames;
@@ -167,7 +167,7 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
         seratoBeatGrid.setBeats(pBeats, signalInfo, duration, timingOffsetMillis);
         EXPECT_EQ(seratoBeatGrid.nonTerminalMarkers().size(), 0);
         EXPECT_NE(seratoBeatGrid.terminalMarker(), nullptr);
-        EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm.getValue()));
+        EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm.value()));
 
         // Check if the beats can be re-imported losslessly
         mixxx::SeratoBeatsImporter beatsImporter(
@@ -218,7 +218,7 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
                 kNumBeats60BPM - 1);
         EXPECT_NE(seratoBeatGrid.terminalMarker(), nullptr);
         EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(),
-                static_cast<float>(bpm.getValue() / 2));
+                static_cast<float>(bpm.value() / 2));
 
         // Check if the beats can be re-imported losslessly
         mixxx::SeratoBeatsImporter beatsImporter(
@@ -278,7 +278,7 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
         ASSERT_EQ(seratoBeatGrid.nonTerminalMarkers()[1]->beatsTillNextMarker(), kNumBeats60BPM);
         ASSERT_EQ(seratoBeatGrid.nonTerminalMarkers()[2]->beatsTillNextMarker(), kNumBeats60BPM);
         EXPECT_NE(seratoBeatGrid.terminalMarker(), nullptr);
-        EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm.getValue()));
+        EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm.value()));
 
         // Check if the beats can be re-imported losslessly
         mixxx::SeratoBeatsImporter beatsImporter(

--- a/src/test/seratobeatgridtest.cpp
+++ b/src/test/seratobeatgridtest.cpp
@@ -113,7 +113,7 @@ TEST_F(SeratoBeatGridTest, ParseEmptyDataFLAC) {
 
 TEST_F(SeratoBeatGridTest, SerializeBeatgrid) {
     // Create a const beatgrid at 120 BPM
-    const auto bpm = mixxx::Bpm(120.0);
+    constexpr mixxx::Bpm bpm(120.0);
     const auto sampleRate = mixxx::audio::SampleRate(44100);
     EXPECT_EQ(sampleRate.isValid(), true);
     const auto pBeats = mixxx::BeatGrid::makeBeatGrid(
@@ -132,12 +132,12 @@ TEST_F(SeratoBeatGridTest, SerializeBeatgrid) {
 TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
     // Create a non-const beatmap
     constexpr double timingOffsetMillis = -10;
-    constexpr int bpm = 120;
+    constexpr mixxx::Bpm bpm(120);
     const auto sampleRate = mixxx::audio::SampleRate(44100);
     const auto signalInfo = mixxx::audio::SignalInfo(mixxx::audio::ChannelCount(2), sampleRate);
     const auto duration = mixxx::Duration::fromSeconds<int>(300);
     const mixxx::audio::FrameDiff_t framesPerMinute = signalInfo.getSampleRate() * 60;
-    const mixxx::audio::FrameDiff_t framesPerBeat = framesPerMinute / bpm;
+    const mixxx::audio::FrameDiff_t framesPerBeat = framesPerMinute / bpm.getValue();
     const mixxx::audio::FrameDiff_t initialFrameOffset = framesPerBeat / 2;
 
     QVector<mixxx::audio::FramePos> beatPositionsFrames;
@@ -167,7 +167,7 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
         seratoBeatGrid.setBeats(pBeats, signalInfo, duration, timingOffsetMillis);
         EXPECT_EQ(seratoBeatGrid.nonTerminalMarkers().size(), 0);
         EXPECT_NE(seratoBeatGrid.terminalMarker(), nullptr);
-        EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm));
+        EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm.getValue()));
 
         // Check if the beats can be re-imported losslessly
         mixxx::SeratoBeatsImporter beatsImporter(
@@ -217,7 +217,8 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
         ASSERT_EQ(seratoBeatGrid.nonTerminalMarkers()[1]->beatsTillNextMarker(),
                 kNumBeats60BPM - 1);
         EXPECT_NE(seratoBeatGrid.terminalMarker(), nullptr);
-        EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm / 2));
+        EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(),
+                static_cast<float>(bpm.getValue() / 2));
 
         // Check if the beats can be re-imported losslessly
         mixxx::SeratoBeatsImporter beatsImporter(
@@ -277,7 +278,7 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
         ASSERT_EQ(seratoBeatGrid.nonTerminalMarkers()[1]->beatsTillNextMarker(), kNumBeats60BPM);
         ASSERT_EQ(seratoBeatGrid.nonTerminalMarkers()[2]->beatsTillNextMarker(), kNumBeats60BPM);
         EXPECT_NE(seratoBeatGrid.terminalMarker(), nullptr);
-        EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm));
+        EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm.getValue()));
 
         // Check if the beats can be re-imported losslessly
         mixxx::SeratoBeatsImporter beatsImporter(

--- a/src/test/seratobeatgridtest.cpp
+++ b/src/test/seratobeatgridtest.cpp
@@ -113,7 +113,7 @@ TEST_F(SeratoBeatGridTest, ParseEmptyDataFLAC) {
 
 TEST_F(SeratoBeatGridTest, SerializeBeatgrid) {
     // Create a const beatgrid at 120 BPM
-    constexpr double bpm = 120.0;
+    const auto bpm = mixxx::Bpm(120.0);
     const auto sampleRate = mixxx::audio::SampleRate(44100);
     EXPECT_EQ(sampleRate.isValid(), true);
     const auto pBeats = mixxx::BeatGrid::makeBeatGrid(
@@ -126,7 +126,7 @@ TEST_F(SeratoBeatGridTest, SerializeBeatgrid) {
     seratoBeatGrid.setBeats(pBeats, signalInfo, duration, 0);
     EXPECT_EQ(seratoBeatGrid.nonTerminalMarkers().size(), 0);
     EXPECT_NE(seratoBeatGrid.terminalMarker(), nullptr);
-    EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm));
+    EXPECT_FLOAT_EQ(seratoBeatGrid.terminalMarker()->bpm(), static_cast<float>(bpm.getValue()));
 }
 
 TEST_F(SeratoBeatGridTest, SerializeBeatMap) {

--- a/src/track/beatfactory.cpp
+++ b/src/track/beatfactory.cpp
@@ -33,9 +33,9 @@ mixxx::BeatsPointer BeatFactory::loadBeatsFromByteArray(
 
 mixxx::BeatsPointer BeatFactory::makeBeatGrid(
         mixxx::audio::SampleRate sampleRate,
-        double dBpm,
+        mixxx::Bpm bpm,
         mixxx::audio::FramePos firstBeatFramePos) {
-    return mixxx::BeatGrid::makeBeatGrid(sampleRate, QString(), dBpm, firstBeatFramePos);
+    return mixxx::BeatGrid::makeBeatGrid(sampleRate, QString(), bpm, firstBeatFramePos);
 }
 
 // static
@@ -102,7 +102,8 @@ mixxx::BeatsPointer BeatFactory::makePreferredBeats(
 
     if (version == BEAT_GRID_2_VERSION) {
         mixxx::audio::FramePos firstBeat = mixxx::audio::kStartFramePos;
-        double constBPM = BeatUtils::makeConstBpm(constantRegions, sampleRate, &firstBeat);
+        const mixxx::Bpm constBPM = BeatUtils::makeConstBpm(
+                constantRegions, sampleRate, &firstBeat);
         firstBeat = BeatUtils::adjustPhase(firstBeat, constBPM, sampleRate, beats);
         auto pGrid = mixxx::BeatGrid::makeBeatGrid(
                 sampleRate, subVersion, constBPM, firstBeat);

--- a/src/track/beatfactory.h
+++ b/src/track/beatfactory.h
@@ -5,6 +5,7 @@
 #include "audio/frame.h"
 #include "audio/types.h"
 #include "track/beats.h"
+#include "track/bpm.h"
 
 class Track;
 
@@ -17,7 +18,7 @@ class BeatFactory {
             const QByteArray& beatsSerialized);
     static mixxx::BeatsPointer makeBeatGrid(
             mixxx::audio::SampleRate sampleRate,
-            double dBpm,
+            mixxx::Bpm bpm,
             mixxx::audio::FramePos firstBeatFramePos);
 
     static QString getPreferredVersion(bool fixedTempo);

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -76,17 +76,17 @@ BeatsPointer BeatGrid::makeBeatGrid(
         mixxx::Bpm bpm,
         mixxx::audio::FramePos firstBeatPos) {
     // FIXME: Should this be a debug assertion?
-    if (!bpm.hasValue()) {
+    if (!bpm.isValid()) {
         return nullptr;
     }
 
     mixxx::track::io::BeatGrid grid;
 
-    grid.mutable_bpm()->set_bpm(bpm.getValue());
+    grid.mutable_bpm()->set_bpm(bpm.value());
     grid.mutable_first_beat()->set_frame_position(
             static_cast<google::protobuf::int32>(firstBeatPos.value()));
     // Calculate beat length as sample offsets
-    double beatLength = (60.0 * sampleRate / bpm.getValue()) * kFrameSize;
+    double beatLength = (60.0 * sampleRate / bpm.value()) * kFrameSize;
 
     return BeatsPointer(new BeatGrid(sampleRate, subVersion, grid, beatLength));
 }
@@ -137,7 +137,7 @@ QString BeatGrid::getSubVersion() const {
 
 // internal use only
 bool BeatGrid::isValid() const {
-    return m_sampleRate.isValid() && bpm().hasValue();
+    return m_sampleRate.isValid() && bpm().isValid();
 }
 
 // This could be implemented in the Beats Class itself.
@@ -333,23 +333,23 @@ BeatsPointer BeatGrid::scale(enum BPMScale scale) const {
         return BeatsPointer(new BeatGrid(*this));
     }
 
-    if (!bpm.hasValue()) {
+    if (!bpm.isValid()) {
         return BeatsPointer(new BeatGrid(*this));
     }
 
     bpm = BeatUtils::roundBpmWithinRange(bpm - kBpmScaleRounding, bpm, bpm + kBpmScaleRounding);
-    grid.mutable_bpm()->set_bpm(bpm.getValue());
-    double beatLength = (60.0 * m_sampleRate / bpm.getValue()) * kFrameSize;
+    grid.mutable_bpm()->set_bpm(bpm.value());
+    double beatLength = (60.0 * m_sampleRate / bpm.value()) * kFrameSize;
     return BeatsPointer(new BeatGrid(*this, grid, beatLength));
 }
 
 BeatsPointer BeatGrid::setBpm(mixxx::Bpm bpm) {
-    VERIFY_OR_DEBUG_ASSERT(bpm.hasValue()) {
+    VERIFY_OR_DEBUG_ASSERT(bpm.isValid()) {
         return nullptr;
     }
     mixxx::track::io::BeatGrid grid = m_grid;
-    grid.mutable_bpm()->set_bpm(bpm.getValue());
-    double beatLength = (60.0 * m_sampleRate / bpm.getValue()) * kFrameSize;
+    grid.mutable_bpm()->set_bpm(bpm.value());
+    double beatLength = (60.0 * m_sampleRate / bpm.value()) * kFrameSize;
     return BeatsPointer(new BeatGrid(*this, grid, beatLength));
 }
 

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -333,8 +333,7 @@ BeatsPointer BeatGrid::scale(enum BPMScale scale) const {
         return BeatsPointer(new BeatGrid(*this));
     }
 
-    // TODO: Check if we can remove getMaxBpm and replace it with Bpm::hasValue instead
-    if (bpm.getValue() > getMaxBpm()) {
+    if (!bpm.hasValue()) {
         return BeatsPointer(new BeatGrid(*this));
     }
 
@@ -345,9 +344,8 @@ BeatsPointer BeatGrid::scale(enum BPMScale scale) const {
 }
 
 BeatsPointer BeatGrid::setBpm(mixxx::Bpm bpm) {
-    // FIXME: Shouldn't we use mixxx::Bpm::hasValue() here?
-    if (bpm.getValue() > getMaxBpm()) {
-        bpm.setValue(getMaxBpm());
+    VERIFY_OR_DEBUG_ASSERT(bpm.hasValue()) {
+        return nullptr;
     }
     mixxx::track::io::BeatGrid grid = m_grid;
     grid.mutable_bpm()->set_bpm(bpm.getValue());

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -3,7 +3,6 @@
 #include "audio/frame.h"
 #include "proto/beats.pb.h"
 #include "track/beats.h"
-#include "track/bpm.h"
 
 #define BEAT_GRID_1_VERSION "BeatGrid-1.0"
 #define BEAT_GRID_2_VERSION "BeatGrid-2.0"
@@ -55,8 +54,8 @@ class BeatGrid final : public Beats {
     double findNthBeat(double dSamples, int n) const override;
     std::unique_ptr<BeatIterator> findBeats(double startSample, double stopSample) const override;
     bool hasBeatInRange(double startSample, double stopSample) const override;
-    double getBpm() const override;
-    double getBpmAroundPosition(double curSample, int n) const override;
+    mixxx::Bpm getBpm() const override;
+    mixxx::Bpm getBpmAroundPosition(double curSample, int n) const override;
 
     audio::SampleRate getSampleRate() const override {
         return m_sampleRate;
@@ -68,7 +67,7 @@ class BeatGrid final : public Beats {
 
     BeatsPointer translate(double dNumSamples) const override;
     BeatsPointer scale(enum BPMScale scale) const override;
-    BeatsPointer setBpm(double dBpm) override;
+    BeatsPointer setBpm(mixxx::Bpm bpm) override;
 
   private:
     BeatGrid(
@@ -81,7 +80,7 @@ class BeatGrid final : public Beats {
     BeatGrid(const BeatGrid& other);
 
     double firstBeatSample() const;
-    double bpm() const;
+    mixxx::Bpm bpm() const;
 
     // For internal use only.
     bool isValid() const;

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -3,6 +3,7 @@
 #include "audio/frame.h"
 #include "proto/beats.pb.h"
 #include "track/beats.h"
+#include "track/bpm.h"
 
 #define BEAT_GRID_1_VERSION "BeatGrid-1.0"
 #define BEAT_GRID_2_VERSION "BeatGrid-2.0"
@@ -21,7 +22,7 @@ class BeatGrid final : public Beats {
     static BeatsPointer makeBeatGrid(
             audio::SampleRate sampleRate,
             const QString& subVersion,
-            double dBpm,
+            mixxx::Bpm bpm,
             mixxx::audio::FramePos firstBeatPos);
 
     static BeatsPointer makeBeatGrid(

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -192,14 +192,14 @@ BeatMap::BeatMap(
         audio::SampleRate sampleRate,
         const QString& subVersion,
         BeatList beats,
-        double nominalBpm)
+        mixxx::Bpm nominalBpm)
         : m_subVersion(subVersion),
           m_sampleRate(sampleRate),
           m_nominalBpm(nominalBpm),
           m_beats(std::move(beats)) {
 }
 
-BeatMap::BeatMap(const BeatMap& other, BeatList beats, double nominalBpm)
+BeatMap::BeatMap(const BeatMap& other, BeatList beats, mixxx::Bpm nominalBpm)
         : m_subVersion(other.m_subVersion),
           m_sampleRate(other.m_sampleRate),
           m_nominalBpm(nominalBpm),
@@ -229,7 +229,7 @@ BeatsPointer BeatMap::makeBeatMap(
         qDebug() << "ERROR: Could not parse BeatMap from QByteArray of size"
                  << byteArray.size();
     }
-    return BeatsPointer(new BeatMap(sampleRate, subVersion, beatList, nominalBpm.getValue()));
+    return BeatsPointer(new BeatMap(sampleRate, subVersion, beatList, nominalBpm));
 }
 
 // static
@@ -261,7 +261,7 @@ BeatsPointer BeatMap::makeBeatMap(
         previousBeatPos = beatPos;
     }
     const auto nominalBpm = calculateNominalBpm(beatList, sampleRate);
-    return BeatsPointer(new BeatMap(sampleRate, subVersion, beatList, nominalBpm.getValue()));
+    return BeatsPointer(new BeatMap(sampleRate, subVersion, beatList, nominalBpm));
 }
 
 QByteArray BeatMap::toByteArray() const {
@@ -522,17 +522,17 @@ bool BeatMap::hasBeatInRange(double startSample, double stopSample) const {
     return false;
 }
 
-double BeatMap::getBpm() const {
+mixxx::Bpm BeatMap::getBpm() const {
     if (!isValid()) {
-        return mixxx::Bpm::kValueUndefined;
+        return mixxx::Bpm();
     }
     return m_nominalBpm;
 }
 
 // Note: Also called from the engine thread
-double BeatMap::getBpmAroundPosition(double curSample, int n) const {
+mixxx::Bpm BeatMap::getBpmAroundPosition(double curSample, int n) const {
     if (!isValid()) {
-        return -1;
+        return mixxx::Bpm();
     }
 
     // To make sure we are always counting n beats, iterate backward to the
@@ -564,7 +564,7 @@ double BeatMap::getBpmAroundPosition(double curSample, int n) const {
     }
 
     VERIFY_OR_DEBUG_ASSERT(lowerFrame < upperFrame) {
-        return -1;
+        return {};
     }
 
     const int kFrameEpsilon = m_sampleRate / 20;
@@ -581,8 +581,7 @@ double BeatMap::getBpmAroundPosition(double curSample, int n) const {
     }
 
     return BeatUtils::calculateAverageBpm(
-            numberOfBeats, m_sampleRate, lowerFrame, upperFrame)
-            .getValue();
+            numberOfBeats, m_sampleRate, lowerFrame, upperFrame);
 }
 
 BeatsPointer BeatMap::translate(double dNumSamples) const {
@@ -654,12 +653,12 @@ BeatsPointer BeatMap::scale(enum BPMScale scale) const {
         return BeatsPointer(new BeatMap(*this));
     }
 
-    double bpm = calculateNominalBpm(beats, m_sampleRate).getValue();
+    mixxx::Bpm bpm = calculateNominalBpm(beats, m_sampleRate);
     return BeatsPointer(new BeatMap(*this, beats, bpm));
 }
 
-BeatsPointer BeatMap::setBpm(double dBpm) {
-    Q_UNUSED(dBpm);
+BeatsPointer BeatMap::setBpm(mixxx::Bpm bpm) {
+    Q_UNUSED(bpm);
     DEBUG_ASSERT(!"BeatMap::setBpm() not implemented");
     return BeatsPointer(new BeatMap(*this));
 

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -58,8 +58,8 @@ class BeatMap final : public Beats {
     std::unique_ptr<BeatIterator> findBeats(double startSample, double stopSample) const override;
     bool hasBeatInRange(double startSample, double stopSample) const override;
 
-    double getBpm() const override;
-    double getBpmAroundPosition(double curSample, int n) const override;
+    mixxx::Bpm getBpm() const override;
+    mixxx::Bpm getBpmAroundPosition(double curSample, int n) const override;
 
     audio::SampleRate getSampleRate() const override {
         return m_sampleRate;
@@ -71,15 +71,15 @@ class BeatMap final : public Beats {
 
     BeatsPointer translate(double dNumSamples) const override;
     BeatsPointer scale(enum BPMScale scale) const override;
-    BeatsPointer setBpm(double dBpm) override;
+    BeatsPointer setBpm(mixxx::Bpm bpm) override;
 
   private:
     BeatMap(audio::SampleRate sampleRate,
             const QString& subVersion,
             BeatList beats,
-            double nominalBpm);
+            mixxx::Bpm nominalBpm);
     // Constructor to update the beat map
-    BeatMap(const BeatMap& other, BeatList beats, double nominalBpm);
+    BeatMap(const BeatMap& other, BeatList beats, mixxx::Bpm nominalBpm);
     BeatMap(const BeatMap& other);
 
     // For internal use only.
@@ -87,7 +87,7 @@ class BeatMap final : public Beats {
 
     const QString m_subVersion;
     const audio::SampleRate m_sampleRate;
-    const double m_nominalBpm;
+    const mixxx::Bpm m_nominalBpm;
     const BeatList m_beats;
 };
 

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -22,22 +22,28 @@ class BeatIterator {
     virtual double next() = 0;
 };
 
-// Beats is the base class for BPM and beat management classes. It
-// provides a specification of all methods a beat-manager class must provide, as
-// well as a capability model for representing optional features.
+/// Beats is the base class for BPM and beat management classes. It provides a
+/// specification of all methods a beat-manager class must provide, as well as
+/// a capability model for representing optional features.
 class Beats {
   public:
     virtual ~Beats() = default;
 
     enum Capabilities {
-        BEATSCAP_NONE          = 0x0000,
-        BEATSCAP_ADDREMOVE     = 0x0001, // Add or remove a single beat
-        BEATSCAP_TRANSLATE     = 0x0002, // Move all beat markers earlier or later
-        BEATSCAP_SCALE         = 0x0004, // Scale beat distance by a fixed ratio
-        BEATSCAP_MOVEBEAT      = 0x0008, // Move a single Beat
-        BEATSCAP_SETBPM        = 0x0010  // Set new bpm, beat grid only
+        BEATSCAP_NONE = 0x0000,
+        /// Add or remove a single beat
+        BEATSCAP_ADDREMOVE = 0x0001,
+        /// Move all beat markers earlier or later
+        BEATSCAP_TRANSLATE = 0x0002,
+        /// Scale beat distance by a fixed ratio
+        BEATSCAP_SCALE = 0x0004,
+        /// Move a single Beat
+        BEATSCAP_MOVEBEAT = 0x0008,
+        /// Set new bpm, beat grid only
+        BEATSCAP_SETBPM = 0x0010
     };
-    typedef int CapabilitiesFlags; // Allows us to do ORing
+    /// Allows us to do ORing
+    typedef int CapabilitiesFlags;
 
     enum BPMScale {
         DOUBLE,
@@ -48,17 +54,18 @@ class Beats {
         THREEHALVES,
     };
 
+    /// Retrieve the capabilities supported by the beats implementation.
     virtual Beats::CapabilitiesFlags getCapabilities() const = 0;
 
-    // Serialization
+    /// Serialize beats to QByteArray.
     virtual QByteArray toByteArray() const = 0;
 
-    // A string representing the version of the beat-processing code that
-    // produced this Beats instance. Used by BeatsFactory for associating a
-    // given serialization with the version that produced it.
+    /// A string representing the version of the beat-processing code that
+    /// produced this Beats instance. Used by BeatsFactory for associating a
+    /// given serialization with the version that produced it.
     virtual QString getVersion() const = 0;
-    // A sub-version can be used to represent the preferences used to generate
-    // the beats object.
+    /// A sub-version can be used to represent the preferences used to generate
+    /// the beats object.
     virtual QString getSubVersion() const = 0;
 
     ////////////////////////////////////////////////////////////////////////////
@@ -70,62 +77,62 @@ class Beats {
     // TODO: We may want to implement these with common code that returns
     //       the triple of closest, next, and prev.
 
-    // Starting from sample dSamples, return the sample of the next beat in the
-    // track, or -1 if none exists. If dSamples refers to the location of a
-    // beat, dSamples is returned.
+    /// Starting from dSamples, return the sample of the next beat in the
+    /// track, or -1 if none exists. If dSamples refers to the location of a
+    /// beat, dSamples is returned.
     virtual double findNextBeat(double dSamples) const = 0;
 
-    // Starting from sample dSamples, return the sample of the previous beat in
-    // the track, or -1 if none exists. If dSamples refers to the location of
-    // beat, dSamples is returned.
+    /// Starting from sample dSamples, return the sample of the previous beat
+    /// in the track, or -1 if none exists. If dSamples refers to the location
+    /// of beat, dSamples is returned.
     virtual double findPrevBeat(double dSamples) const = 0;
 
-    // Starting from sample dSamples, fill the samples of the previous beat
-    // and next beat.  Either can be -1 if none exists.  If dSamples refers
-    // to the location of the beat, the first value is dSamples, and the second
-    // value is the next beat position.  Non- -1 values are guaranteed to be
-    // even.  Returns false if *at least one* sample is -1.  (Can return false
-    // with one beat successfully filled)
+    /// Starting from sample dSamples, fill the samples of the previous beat
+    /// and next beat.  Either can be -1 if none exists.  If dSamples refers to
+    /// the location of the beat, the first value is dSamples, and the second
+    /// value is the next beat position.  Non- -1 values are guaranteed to be
+    /// even.  Returns false if *at least one* sample is -1.  (Can return false
+    /// with one beat successfully filled)
     virtual bool findPrevNextBeats(double dSamples,
             double* dpPrevBeatSamples,
             double* dpNextBeatSamples,
             bool snapToNearBeats) const = 0;
 
-    // Starting from sample dSamples, return the sample of the closest beat in
-    // the track, or -1 if none exists.  Non- -1 values are guaranteed to be
-    // even.
+    /// Starting from sample dSamples, return the sample of the closest beat in
+    /// the track, or -1 if none exists.  Non- -1 values are guaranteed to be
+    /// even.
     virtual double findClosestBeat(double dSamples) const = 0;
 
-    // Find the Nth beat from sample dSamples. Works with both positive and
-    // negative values of n. Calling findNthBeat with n=0 is invalid. Calling
-    // findNthBeat with n=1 or n=-1 is equivalent to calling findNextBeat and
-    // findPrevBeat, respectively. If dSamples refers to the location of a beat,
-    // then dSamples is returned. If no beat can be found, returns -1.
+    /// Find the Nth beat from sample dSamples. Works with both positive and
+    /// negative values of n. Calling findNthBeat with n=0 is invalid. Calling
+    /// findNthBeat with n=1 or n=-1 is equivalent to calling findNextBeat and
+    /// findPrevBeat, respectively. If dSamples refers to the location of a
+    /// beat, then dSamples is returned. If no beat can be found, returns -1.
     virtual double findNthBeat(double dSamples, int n) const = 0;
 
     int numBeatsInRange(double dStartSample, double dEndSample) const;
 
-    // Find the sample N beats away from dSample. The number of beats may be
-    // negative and does not need to be an integer.
+    /// Find the sample N beats away from dSample. The number of beats may be
+    /// negative and does not need to be an integer.
     double findNBeatsFromSample(double fromSample, double beats) const;
 
-
-    // Adds to pBeatsList the position in samples of every beat occurring between
-    // startPosition and endPosition. BeatIterator must be iterated while
-    // holding a strong references to the Beats object to ensure that the Beats
-    // object is not deleted. Caller takes ownership of the returned BeatIterator;
+    /// Adds to pBeatsList the position in samples of every beat occurring
+    /// between startPosition and endPosition. BeatIterator must be iterated
+    /// while holding a strong references to the Beats object to ensure that
+    /// the Beats object is not deleted. Caller takes ownership of the returned
+    /// BeatIterator;
     virtual std::unique_ptr<BeatIterator> findBeats(double startSample, double stopSample) const = 0;
 
-    // Return whether or not a sample lies between startPosition and endPosition
+    /// Return whether or not a sample lies between startPosition and endPosition.
     virtual bool hasBeatInRange(double startSample, double stopSample) const = 0;
 
-    // Return the average BPM over the entire track if the BPM is
-    // valid, otherwise returns -1
+    /// Return the average BPM over the entire track if the BPM is valid,
+    /// otherwise returns -1
     virtual mixxx::Bpm getBpm() const = 0;
 
-    // Return the average BPM over the range of n*2 beats centered around
-    // curSample.  (An n of 4 results in an averaging of 8 beats).  Invalid
-    // BPM returns -1.
+    /// Return the average BPM over the range of n*2 beats centered around
+    /// curSample.  (An n of 4 results in an averaging of 8 beats).  Invalid
+    /// BPM returns -1.
     virtual mixxx::Bpm getBpmAroundPosition(double curSample, int n) const = 0;
 
     virtual audio::SampleRate getSampleRate() const = 0;
@@ -134,17 +141,17 @@ class Beats {
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
-    // Translate all beats in the song by dNumSamples samples. Beats that lie
-    // before the start of the track or after the end of the track are not
-    // removed. Beats instance must have the capability BEATSCAP_TRANSLATE.
+    /// Translate all beats in the song by dNumSamples samples. Beats that lie
+    /// before the start of the track or after the end of the track are not
+    /// removed. Beats instance must have the capability BEATSCAP_TRANSLATE.
     virtual BeatsPointer translate(double dNumSamples) const = 0;
 
-    // Scale the position of every beat in the song by dScalePercentage. Beats
-    // class must have the capability BEATSCAP_SCALE.
+    /// Scale the position of every beat in the song by dScalePercentage. Beats
+    /// class must have the capability BEATSCAP_SCALE.
     virtual BeatsPointer scale(enum BPMScale scale) const = 0;
 
-    // Adjust the beats so the global average BPM matches bpm. Beats class must
-    // have the capability BEATSCAP_SET.
+    /// Adjust the beats so the global average BPM matches bpm. Beats class
+    /// must have the capability BEATSCAP_SET.
     virtual BeatsPointer setBpm(mixxx::Bpm bpm) = 0;
 };
 

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -6,6 +6,7 @@
 #include <QString>
 
 #include "audio/types.h"
+#include "track/bpm.h"
 #include "util/memory.h"
 #include "util/types.h"
 
@@ -124,12 +125,12 @@ class Beats {
 
     // Return the average BPM over the entire track if the BPM is
     // valid, otherwise returns -1
-    virtual double getBpm() const = 0;
+    virtual mixxx::Bpm getBpm() const = 0;
 
     // Return the average BPM over the range of n*2 beats centered around
     // curSample.  (An n of 4 results in an averaging of 8 beats).  Invalid
     // BPM returns -1.
-    virtual double getBpmAroundPosition(double curSample, int n) const = 0;
+    virtual mixxx::Bpm getBpmAroundPosition(double curSample, int n) const = 0;
 
     virtual double getMaxBpm() const {
         return kMaxBpm;
@@ -150,9 +151,9 @@ class Beats {
     // class must have the capability BEATSCAP_SCALE.
     virtual BeatsPointer scale(enum BPMScale scale) const = 0;
 
-    // Adjust the beats so the global average BPM matches dBpm. Beats class must
+    // Adjust the beats so the global average BPM matches bpm. Beats class must
     // have the capability BEATSCAP_SET.
-    virtual BeatsPointer setBpm(double dBpm) = 0;
+    virtual BeatsPointer setBpm(mixxx::Bpm bpm) = 0;
 };
 
 } // namespace mixxx

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -10,10 +10,6 @@
 #include "util/memory.h"
 #include "util/types.h"
 
-namespace {
-    double kMaxBpm = 500;
-}
-
 namespace mixxx {
 
 class Beats;
@@ -131,10 +127,6 @@ class Beats {
     // curSample.  (An n of 4 results in an averaging of 8 beats).  Invalid
     // BPM returns -1.
     virtual mixxx::Bpm getBpmAroundPosition(double curSample, int n) const = 0;
-
-    virtual double getMaxBpm() const {
-        return kMaxBpm;
-    }
 
     virtual audio::SampleRate getSampleRate() const = 0;
 

--- a/src/track/beatutils.cpp
+++ b/src/track/beatutils.cpp
@@ -313,7 +313,7 @@ mixxx::Bpm BeatUtils::makeConstBpm(
         // bpm adjustments are made.
         // This is a temporary fix, ideally the anchor point for the BPM grid should
         // be the first proper downbeat, or perhaps the CUE point.
-        const double roundedBeatLength = 60.0 * sampleRate / roundBpm.getValue();
+        const double roundedBeatLength = 60.0 * sampleRate / roundBpm.value();
         *pFirstBeat = mixxx::audio::FramePos(
                 fmod(constantRegions[startRegionIndex].firstBeat.value(),
                         roundedBeatLength));
@@ -325,7 +325,7 @@ mixxx::Bpm BeatUtils::makeConstBpm(
 mixxx::Bpm BeatUtils::roundBpmWithinRange(
         mixxx::Bpm minBpm, mixxx::Bpm centerBpm, mixxx::Bpm maxBpm) {
     // First try to snap to a full integer BPM
-    auto snapBpm = mixxx::Bpm(round(centerBpm.getValue()));
+    auto snapBpm = mixxx::Bpm(round(centerBpm.value()));
     if (snapBpm > minBpm && snapBpm < maxBpm) {
         // Success
         return snapBpm;
@@ -339,20 +339,20 @@ mixxx::Bpm BeatUtils::roundBpmWithinRange(
         if (centerBpm < mixxx::Bpm(85.0)) {
             // this cane be actually up to 175 BPM
             // allow halve BPM values
-            return mixxx::Bpm(round(centerBpm.getValue() * 2) / 2);
+            return mixxx::Bpm(round(centerBpm.value() * 2) / 2);
         } else if (centerBpm > mixxx::Bpm(127.0)) {
             // optimize for 2/3 going down to 85
-            return mixxx::Bpm(round(centerBpm.getValue() / 3 * 2) * 3 / 2);
+            return mixxx::Bpm(round(centerBpm.value() / 3 * 2) * 3 / 2);
         }
     }
 
     if (roundBpmWidth > 1.0 / 12) {
         // this covers all sorts of 1/2 2/3 and 3/4 multiplier
-        return mixxx::Bpm(round(centerBpm.getValue() * 12) / 12);
+        return mixxx::Bpm(round(centerBpm.value() * 12) / 12);
     } else {
         // We are here if we have more that ~75 beats and ~30 s
         // try to snap to a 1/12 Bpm
-        snapBpm = mixxx::Bpm(round(centerBpm.getValue() * 12) / 12);
+        snapBpm = mixxx::Bpm(round(centerBpm.value() * 12) / 12);
         if (snapBpm > minBpm && snapBpm < maxBpm) {
             // Success
             return snapBpm;
@@ -387,7 +387,7 @@ mixxx::audio::FramePos BeatUtils::adjustPhase(
         mixxx::Bpm bpm,
         mixxx::audio::SampleRate sampleRate,
         const QVector<mixxx::audio::FramePos>& beats) {
-    const double beatLength = 60 * sampleRate / bpm.getValue();
+    const double beatLength = 60 * sampleRate / bpm.value();
     const mixxx::audio::FramePos startOffset =
             mixxx::audio::FramePos(fmod(firstBeat.value(), beatLength));
     mixxx::audio::FrameDiff_t offsetAdjust = 0;

--- a/src/track/beatutils.h
+++ b/src/track/beatutils.h
@@ -4,6 +4,7 @@
 
 #include "audio/frame.h"
 #include "audio/types.h"
+#include "track/bpm.h"
 #include "util/math.h"
 
 class BeatUtils {
@@ -13,30 +14,31 @@ class BeatUtils {
         mixxx::audio::FrameDiff_t beatLength;
     };
 
-    static double calculateBpm(const QVector<mixxx::audio::FramePos>& beats,
+    static mixxx::Bpm calculateBpm(const QVector<mixxx::audio::FramePos>& beats,
             mixxx::audio::SampleRate sampleRate);
 
     static QVector<ConstRegion> retrieveConstRegions(
             const QVector<mixxx::audio::FramePos>& coarseBeats,
             mixxx::audio::SampleRate sampleRate);
 
-    static double calculateAverageBpm(int numberOfBeats,
+    static mixxx::Bpm calculateAverageBpm(int numberOfBeats,
             mixxx::audio::SampleRate sampleRate,
             mixxx::audio::FramePos lowerFrame,
             mixxx::audio::FramePos upperFrame);
 
-    static double makeConstBpm(
+    static mixxx::Bpm makeConstBpm(
             const QVector<ConstRegion>& constantRegions,
             mixxx::audio::SampleRate sampleRate,
             mixxx::audio::FramePos* pFirstBeat);
 
     static mixxx::audio::FramePos adjustPhase(
             mixxx::audio::FramePos firstBeat,
-            double bpm,
+            mixxx::Bpm bpm,
             mixxx::audio::SampleRate sampleRate,
             const QVector<mixxx::audio::FramePos>& beats);
 
     static QVector<mixxx::audio::FramePos> getBeats(const QVector<ConstRegion>& constantRegions);
 
-    static double roundBpmWithinRange(double minBpm, double centerBpm, double maxBpm);
+    static mixxx::Bpm roundBpmWithinRange(
+            mixxx::Bpm minBpm, mixxx::Bpm centerBpm, mixxx::Bpm maxBpm);
 };

--- a/src/track/bpm.h
+++ b/src/track/bpm.h
@@ -40,10 +40,10 @@ public:
         return kValueMin < value;
     }
 
-    bool hasValue() const {
+    bool isValid() const {
         return isValidValue(m_value);
     }
-    double getValue() const {
+    double value() const {
         return m_value;
     }
     void setValue(double value) {
@@ -70,12 +70,12 @@ public:
             Comparison cmp = Comparison::Default) const {
         switch (cmp) {
         case Comparison::Integer:
-            return Bpm::valueToInteger(getValue()) == Bpm::valueToInteger(bpm.getValue());
+            return Bpm::valueToInteger(value()) == Bpm::valueToInteger(bpm.value());
         case Comparison::String:
-            return Bpm::valueToString(getValue()) == Bpm::valueToString(bpm.getValue());
+            return Bpm::valueToString(value()) == Bpm::valueToString(bpm.value());
         case Comparison::Default:
         default:
-            return getValue() == bpm.getValue();
+            return value() == bpm.value();
         }
     }
 
@@ -109,56 +109,56 @@ private:
 
 /// Bpm can be added to a double
 inline Bpm operator+(Bpm bpm, double bpmDiff) {
-    return Bpm(bpm.getValue() + bpmDiff);
+    return Bpm(bpm.value() + bpmDiff);
 }
 
 /// Bpm can be subtracted from a double
 inline Bpm operator-(Bpm bpm, double bpmDiff) {
-    return Bpm(bpm.getValue() - bpmDiff);
+    return Bpm(bpm.value() - bpmDiff);
 }
 
 /// Two Bpm values can be subtracted to get a double
 inline double operator-(Bpm bpm1, Bpm bpm2) {
-    return bpm1.getValue() - bpm2.getValue();
+    return bpm1.value() - bpm2.value();
 }
 
 // Adding two Bpm is not allowed, because it makes no sense semantically.
 
 /// Bpm can be multiplied or divided by a double
 inline Bpm operator*(Bpm bpm, double multiple) {
-    return Bpm(bpm.getValue() * multiple);
+    return Bpm(bpm.value() * multiple);
 }
 
 inline Bpm operator/(Bpm bpm, double divisor) {
-    return Bpm(bpm.getValue() / divisor);
+    return Bpm(bpm.value() / divisor);
 }
 
 inline bool operator<(Bpm bpm1, Bpm bpm2) {
-    return bpm1.getValue() < bpm2.getValue();
+    return bpm1.value() < bpm2.value();
 }
 
 inline bool operator<=(Bpm bpm1, Bpm bpm2) {
-    return bpm1.getValue() <= bpm2.getValue();
+    return bpm1.value() <= bpm2.value();
 }
 
 inline bool operator>(Bpm bpm1, Bpm bpm2) {
-    return bpm1.getValue() > bpm2.getValue();
+    return bpm1.value() > bpm2.value();
 }
 
 inline bool operator>=(Bpm bpm1, Bpm bpm2) {
-    return bpm1.getValue() >= bpm2.getValue();
+    return bpm1.value() >= bpm2.value();
 }
 
 inline bool operator==(Bpm bpm1, Bpm bpm2) {
-    return bpm1.getValue() == bpm2.getValue();
+    return bpm1.value() == bpm2.value();
 }
 
 inline bool operator!=(Bpm bpm1, Bpm bpm2) {
-    return !(bpm1.getValue() == bpm2.getValue());
+    return !(bpm1.value() == bpm2.value());
 }
 
 inline QDebug operator<<(QDebug dbg, Bpm arg) {
-    dbg << arg.getValue();
+    dbg << arg.value();
     return dbg;
 }
 }

--- a/src/track/bpm.h
+++ b/src/track/bpm.h
@@ -83,25 +83,84 @@ public:
         return displayValueText(m_value);
     }
 
+    Bpm& operator+=(double increment) {
+        m_value += increment;
+        return *this;
+    }
+
+    Bpm& operator-=(double decrement) {
+        m_value -= decrement;
+        return *this;
+    }
+
+    Bpm& operator*=(double multiple) {
+        m_value *= multiple;
+        return *this;
+    }
+
+    Bpm& operator/=(double divisor) {
+        m_value /= divisor;
+        return *this;
+    }
+
 private:
     double m_value;
 };
 
-inline
-bool operator==(const Bpm& lhs, const Bpm& rhs) {
-    return lhs.compareEq(rhs);
+/// Bpm can be added to a double
+inline Bpm operator+(Bpm bpm, double bpmDiff) {
+    return Bpm(bpm.getValue() + bpmDiff);
 }
 
-inline
-bool operator!=(const Bpm& lhs, const Bpm& rhs) {
-    return !(lhs == rhs);
+/// Bpm can be subtracted from a double
+inline Bpm operator-(Bpm bpm, double bpmDiff) {
+    return Bpm(bpm.getValue() - bpmDiff);
 }
 
-inline
-QDebug operator<<(QDebug dbg, const Bpm& arg) {
-    return dbg << arg.getValue();
+/// Two Bpm values can be subtracted to get a double
+inline double operator-(Bpm bpm1, Bpm bpm2) {
+    return bpm1.getValue() - bpm2.getValue();
 }
 
+// Adding two Bpm is not allowed, because it makes no sense semantically.
+
+/// Bpm can be multiplied or divided by a double
+inline Bpm operator*(Bpm bpm, double multiple) {
+    return Bpm(bpm.getValue() * multiple);
+}
+
+inline Bpm operator/(Bpm bpm, double divisor) {
+    return Bpm(bpm.getValue() / divisor);
+}
+
+inline bool operator<(Bpm bpm1, Bpm bpm2) {
+    return bpm1.getValue() < bpm2.getValue();
+}
+
+inline bool operator<=(Bpm bpm1, Bpm bpm2) {
+    return bpm1.getValue() <= bpm2.getValue();
+}
+
+inline bool operator>(Bpm bpm1, Bpm bpm2) {
+    return bpm1.getValue() > bpm2.getValue();
+}
+
+inline bool operator>=(Bpm bpm1, Bpm bpm2) {
+    return bpm1.getValue() >= bpm2.getValue();
+}
+
+inline bool operator==(Bpm bpm1, Bpm bpm2) {
+    return bpm1.getValue() == bpm2.getValue();
+}
+
+inline bool operator!=(Bpm bpm1, Bpm bpm2) {
+    return !(bpm1.getValue() == bpm2.getValue());
+}
+
+inline QDebug operator<<(QDebug dbg, Bpm arg) {
+    dbg << arg.getValue();
+    return dbg;
+}
 }
 
 Q_DECLARE_TYPEINFO(mixxx::Bpm, Q_MOVABLE_TYPE);

--- a/src/track/bpm.h
+++ b/src/track/bpm.h
@@ -13,11 +13,11 @@ public:
     static constexpr double kValueMin = 0.0; // lower bound (exclusive)
     static constexpr double kValueMax = 300.0; // higher bound (inclusive)
 
-    Bpm()
-        : Bpm(kValueUndefined) {
+    constexpr Bpm()
+            : Bpm(kValueUndefined) {
     }
-    explicit Bpm(double value)
-        : m_value(value) {
+    explicit constexpr Bpm(double value)
+            : m_value(value) {
     }
 
     static double normalizeValue(double value);

--- a/src/track/bpm.h
+++ b/src/track/bpm.h
@@ -11,7 +11,7 @@ class Bpm final {
 public:
     static constexpr double kValueUndefined = 0.0;
     static constexpr double kValueMin = 0.0; // lower bound (exclusive)
-    static constexpr double kValueMax = 300.0; // higher bound (inclusive)
+    static constexpr double kValueMax = 500.0; // higher bound (inclusive)
 
     constexpr Bpm()
             : Bpm(kValueUndefined) {

--- a/src/track/serato/beatgrid.cpp
+++ b/src/track/serato/beatgrid.cpp
@@ -509,12 +509,12 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
             currentBeatPositionFrames + beatgridFrameOffset;
     const double positionSecs = signalInfo.frames2secsFractional(
             currentBeatPositionFramesWithOffset);
-    const double bpm = pBeats->getBpmAroundPosition(
+    const mixxx::Bpm bpm = pBeats->getBpmAroundPosition(
             signalInfo.getChannelCount() * currentBeatPositionFramesWithOffset,
             1);
 
     setTerminalMarker(std::make_shared<SeratoBeatGridTerminalMarker>(
-            positionSecs - timingOffsetSecs, bpm));
+            positionSecs - timingOffsetSecs, static_cast<float>(bpm.getValue())));
     setNonTerminalMarkers(nonTerminalMarkers);
 }
 

--- a/src/track/serato/beatgrid.cpp
+++ b/src/track/serato/beatgrid.cpp
@@ -514,7 +514,7 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
             1);
 
     setTerminalMarker(std::make_shared<SeratoBeatGridTerminalMarker>(
-            positionSecs - timingOffsetSecs, static_cast<float>(bpm.getValue())));
+            positionSecs - timingOffsetSecs, static_cast<float>(bpm.value())));
     setNonTerminalMarkers(nonTerminalMarkers);
 }
 

--- a/src/track/taglib/trackmetadata_common.h
+++ b/src/track/taglib/trackmetadata_common.h
@@ -72,7 +72,7 @@ inline TagLib::String uuidToTString(
 inline QString formatBpm(
         const TrackMetadata& trackMetadata) {
     return Bpm::valueToString(
-            trackMetadata.getTrackInfo().getBpm().getValue());
+            trackMetadata.getTrackInfo().getBpm().value());
 }
 
 bool parseBpm(

--- a/src/track/taglib/trackmetadata_id3v2.cpp
+++ b/src/track/taglib/trackmetadata_id3v2.cpp
@@ -561,12 +561,12 @@ inline QImage loadImageFromPictureFrame(
 
 inline QString formatBpmInteger(
         const TrackMetadata& trackMetadata) {
-    if (!trackMetadata.getTrackInfo().getBpm().hasValue()) {
+    if (!trackMetadata.getTrackInfo().getBpm().isValid()) {
         return QString();
     }
     return QString::number(
             Bpm::valueToInteger(
-                    trackMetadata.getTrackInfo().getBpm().getValue()));
+                    trackMetadata.getTrackInfo().getBpm().value()));
 }
 
 } // anonymous namespace
@@ -795,7 +795,7 @@ void importTrackMetadataFromTag(
     if (!bpmFrames.isEmpty()) {
         parseBpm(pTrackMetadata,
                 firstNonEmptyFrameToQString(bpmFrames));
-        double bpmValue = pTrackMetadata->getTrackInfo().getBpm().getValue();
+        double bpmValue = pTrackMetadata->getTrackInfo().getBpm().value();
         // Some software use (or used) to write decimated values without comma,
         // so the number reads as 1352 or 14525 when it is 135.2 or 145.25
         if (bpmValue < Bpm::kValueMin || bpmValue > 1000 * Bpm::kValueMax) {

--- a/src/track/taglib/trackmetadata_mp4.cpp
+++ b/src/track/taglib/trackmetadata_mp4.cpp
@@ -381,10 +381,10 @@ bool exportTrackMetadataIntoTag(
     writeAtom(pTag, "\251grp", toTString(trackMetadata.getTrackInfo().getGrouping()));
 
     // Write both BPM fields (just in case)
-    if (trackMetadata.getTrackInfo().getBpm().hasValue()) {
+    if (trackMetadata.getTrackInfo().getBpm().isValid()) {
         // 16-bit integer value
         const int tmpoValue =
-                Bpm::valueToInteger(trackMetadata.getTrackInfo().getBpm().getValue());
+                Bpm::valueToInteger(trackMetadata.getTrackInfo().getBpm().value());
         pTag->setItem("tmpo", tmpoValue);
     } else {
         pTag->removeItem("tmpo");

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -338,7 +338,8 @@ mixxx::Bpm Track::getBpmWhileLocked() const {
 }
 
 bool Track::trySetBpmWhileLocked(double bpmValue) {
-    if (!mixxx::Bpm::isValidValue(bpmValue)) {
+    const auto bpm = mixxx::Bpm(bpmValue);
+    if (!bpm.hasValue()) {
         // If the user sets the BPM to an invalid value, we assume
         // they want to clear the beatgrid.
         return trySetBeatsWhileLocked(nullptr);
@@ -346,16 +347,16 @@ bool Track::trySetBpmWhileLocked(double bpmValue) {
         // No beat grid available -> create and initialize
         double cue = m_record.getCuePoint().getPosition();
         auto pBeats = BeatFactory::makeBeatGrid(getSampleRate(),
-                bpmValue,
+                bpm,
                 mixxx::audio::FramePos::fromEngineSamplePos(cue));
         return trySetBeatsWhileLocked(std::move(pBeats));
     } else if ((m_pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM) &&
-            m_pBeats->getBpm() != bpmValue) {
+            m_pBeats->getBpm() != bpm.getValue()) {
         // Continue with the regular cases
         if (kLogger.debugEnabled()) {
             kLogger.debug() << "Updating BPM:" << getLocation();
         }
-        return trySetBeatsWhileLocked(m_pBeats->setBpm(bpmValue));
+        return trySetBeatsWhileLocked(m_pBeats->setBpm(bpm.getValue()));
     }
     return false;
 }

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -363,7 +363,11 @@ bool Track::trySetBpmWhileLocked(double bpmValue) {
 
 double Track::getBpm() const {
     const QMutexLocker lock(&m_qMutex);
-    return getBpmWhileLocked().value();
+    const auto bpm = getBpmWhileLocked();
+    if (!bpm.isValid()) {
+        return mixxx::Bpm::kValueUndefined;
+    }
+    return bpm.value();
 }
 
 bool Track::trySetBpm(double bpmValue) {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -171,12 +171,12 @@ void Track::replaceMetadataFromSource(
         // Need to set BPM after sample rate since beat grid creation depends on
         // knowing the sample rate. Bug #1020438.
         auto beatsAndBpmModified = false;
-        if (!m_pBeats || !m_pBeats->getBpm().hasValue()) {
+        if (!m_pBeats || !m_pBeats->getBpm().isValid()) {
             // Only use the imported BPM if the current beat grid is either
             // missing or not valid! The BPM value in the metadata might be
             // imprecise (normalized or rounded), e.g. ID3v2 only supports
             // integer values.
-            beatsAndBpmModified = trySetBpmWhileLocked(importedBpm.getValue());
+            beatsAndBpmModified = trySetBpmWhileLocked(importedBpm.value());
         }
         modified |= beatsAndBpmModified;
 
@@ -288,7 +288,7 @@ bool Track::replaceRecord(
     } else {
         // Setting the bpm manually may in turn update the beat grid
         bpmUpdatedFlag = trySetBpmWhileLocked(
-                newRecord.getMetadata().getTrackInfo().getBpm().getValue());
+                newRecord.getMetadata().getTrackInfo().getBpm().value());
     }
     // The bpm in m_record has already been updated. Read it and copy it into
     // the new record to ensure it will be consistent with the new beat grid.
@@ -339,7 +339,7 @@ mixxx::Bpm Track::getBpmWhileLocked() const {
 
 bool Track::trySetBpmWhileLocked(double bpmValue) {
     const auto bpm = mixxx::Bpm(bpmValue);
-    if (!bpm.hasValue()) {
+    if (!bpm.isValid()) {
         // If the user sets the BPM to an invalid value, we assume
         // they want to clear the beatgrid.
         return trySetBeatsWhileLocked(nullptr);
@@ -363,7 +363,7 @@ bool Track::trySetBpmWhileLocked(double bpmValue) {
 
 double Track::getBpm() const {
     const QMutexLocker lock(&m_qMutex);
-    return getBpmWhileLocked().getValue();
+    return getBpmWhileLocked().value();
 }
 
 bool Track::trySetBpm(double bpmValue) {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -171,7 +171,7 @@ void Track::replaceMetadataFromSource(
         // Need to set BPM after sample rate since beat grid creation depends on
         // knowing the sample rate. Bug #1020438.
         auto beatsAndBpmModified = false;
-        if (!m_pBeats || !mixxx::Bpm::isValidValue(m_pBeats->getBpm())) {
+        if (!m_pBeats || !m_pBeats->getBpm().hasValue()) {
             // Only use the imported BPM if the current beat grid is either
             // missing or not valid! The BPM value in the metadata might be
             // imprecise (normalized or rounded), e.g. ID3v2 only supports
@@ -351,12 +351,12 @@ bool Track::trySetBpmWhileLocked(double bpmValue) {
                 mixxx::audio::FramePos::fromEngineSamplePos(cue));
         return trySetBeatsWhileLocked(std::move(pBeats));
     } else if ((m_pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM) &&
-            m_pBeats->getBpm() != bpm.getValue()) {
+            m_pBeats->getBpm() != bpm) {
         // Continue with the regular cases
         if (kLogger.debugEnabled()) {
             kLogger.debug() << "Updating BPM:" << getLocation();
         }
-        return trySetBeatsWhileLocked(m_pBeats->setBpm(bpm.getValue()));
+        return trySetBeatsWhileLocked(m_pBeats->setBpm(bpm));
     }
     return false;
 }


### PR DESCRIPTION
Based on #4048.

Related zulip discussion: https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/Bpm.2FFramePos.3A.20Should.20invalid.20values.20be.20able.20to.20become.20valid.3F