### PR TITLE
Replace trackLoaded and trackUnloaded with a common Track changed signal

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -109,9 +109,9 @@ BaseTrackTableModel::BaseTrackTableModel(
             this,
             &BaseTrackTableModel::slotRefreshAllRows);
     connect(&PlayerInfo::instance(),
-            &PlayerInfo::trackLoaded,
+            &PlayerInfo::trackChanged,
             this,
-            &BaseTrackTableModel::slotTrackLoaded);
+            &BaseTrackTableModel::slotTrackChanged);
 }
 
 void BaseTrackTableModel::initTableColumnsAndHeaderProperties(
@@ -912,9 +912,11 @@ QMimeData* BaseTrackTableModel::mimeData(
     }
 }
 
-void BaseTrackTableModel::slotTrackLoaded(
+void BaseTrackTableModel::slotTrackChanged(
         const QString& group,
-        TrackPointer pTrack) {
+        TrackPointer pNewTrack,
+        TrackPointer pOldTrack) {
+    Q_UNUSED(pOldTrack);
     if (group == m_previewDeckGroup) {
         // If there was a previously loaded track, refresh its rows so the
         // preview state will update.
@@ -928,7 +930,7 @@ void BaseTrackTableModel::slotTrackLoaded(
                 emit dataChanged(topLeft, bottomRight);
             }
         }
-        m_previewDeckTrackId = doGetTrackId(pTrack);
+        m_previewDeckTrackId = doGetTrackId(pNewTrack);
     }
 }
 

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -220,9 +220,10 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     }
 
   private slots:
-    void slotTrackLoaded(
+    void slotTrackChanged(
             const QString& group,
-            TrackPointer pTrack);
+            TrackPointer pNewTrack,
+            TrackPointer pOldTrack);
 
     void slotRefreshCoverRows(
             const QList<int>& rows);

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -154,10 +154,12 @@ BrowseTableModel::BrowseTableModel(QObject* parent,
             Qt::QueuedConnection);
 
     connect(&PlayerInfo::instance(),
-            &PlayerInfo::trackLoaded,
+            &PlayerInfo::trackChanged,
             this,
-            &BrowseTableModel::trackLoaded);
-    trackLoaded(m_previewDeckGroup, PlayerInfo::instance().getTrackInfo(m_previewDeckGroup));
+            &BrowseTableModel::trackChanged);
+    trackChanged(m_previewDeckGroup,
+            PlayerInfo::instance().getTrackInfo(m_previewDeckGroup),
+            TrackPointer());
 }
 
 BrowseTableModel::~BrowseTableModel() {
@@ -437,7 +439,9 @@ bool BrowseTableModel::setData(
     return true;
 }
 
-void BrowseTableModel::trackLoaded(const QString& group, TrackPointer pTrack) {
+void BrowseTableModel::trackChanged(
+        const QString& group, TrackPointer pNewTrack, TrackPointer pOldTrack) {
+    Q_UNUSED(pOldTrack);
     if (group == m_previewDeckGroup) {
         for (int row = 0; row < rowCount(); ++row) {
             QModelIndex i = index(row, COLUMN_PREVIEW);
@@ -446,8 +450,8 @@ void BrowseTableModel::trackLoaded(const QString& group, TrackPointer pTrack) {
                 item->setText("0");
             }
         }
-        if (pTrack) {
-            QString trackLocation = pTrack->getLocation();
+        if (pNewTrack) {
+            QString trackLocation = pNewTrack->getLocation();
             for (int row = 0; row < rowCount(); ++row) {
                 QModelIndex i = index(row, COLUMN_PREVIEW);
                 QString location = getTrackLocation(i);

--- a/src/library/browse/browsetablemodel.h
+++ b/src/library/browse/browsetablemodel.h
@@ -76,7 +76,7 @@ class BrowseTableModel final : public QStandardItemModel, public virtual TrackMo
   public slots:
     void slotClear(BrowseTableModel*);
     void slotInsert(const QList< QList<QStandardItem*> >&, BrowseTableModel*);
-    void trackLoaded(const QString& group, TrackPointer pTrack);
+    void trackChanged(const QString& group, TrackPointer pNewTrack, TrackPointer pOldTrack);
 
   private:
     void addSearchColumn(int index);

--- a/src/library/dao/autodjcratesdao.cpp
+++ b/src/library/dao/autodjcratesdao.cpp
@@ -263,13 +263,9 @@ void AutoDJCratesDAO::createAndConnectAutoDjCratesDatabase() {
     // These count as auto-DJ references, i.e. prevent the track from being
     // selected randomly.
     connect(&PlayerInfo::instance(),
-            &PlayerInfo::trackLoaded,
+            &PlayerInfo::trackChanged,
             this,
-            &AutoDJCratesDAO::slotPlayerInfoTrackLoaded);
-    connect(&PlayerInfo::instance(),
-            &PlayerInfo::trackUnloaded,
-            this,
-            &AutoDJCratesDAO::slotPlayerInfoTrackUnloaded);
+            &AutoDJCratesDAO::slotPlayerInfoTrackChanged);
 
     // Remember that the auto-DJ-crates database has been created.
     m_bAutoDjCratesDbCreated = true;
@@ -1074,8 +1070,14 @@ void AutoDJCratesDAO::slotPlaylistTrackRemoved(int playlistId,
     }
 }
 
+void AutoDJCratesDAO::slotPlayerInfoTrackChanged(
+        const QString& group, TrackPointer pNewTrack, TrackPointer pOldTrack) {
+    playerInfoTrackUnloaded(group, pOldTrack);
+    playerInfoTrackLoaded(group, pNewTrack);
+}
+
 // Signaled by the PlayerInfo singleton when a track is loaded to a deck.
-void AutoDJCratesDAO::slotPlayerInfoTrackLoaded(const QString& a_strGroup,
+void AutoDJCratesDAO::playerInfoTrackLoaded(const QString& a_strGroup,
         TrackPointer a_pTrack) {
     // This gets called with a null track during an unload.  Filter that out.
     if (a_pTrack == nullptr) {
@@ -1106,7 +1108,7 @@ void AutoDJCratesDAO::slotPlayerInfoTrackLoaded(const QString& a_strGroup,
 }
 
 // Signaled by the PlayerInfo singleton when a track is unloaded from a deck.
-void AutoDJCratesDAO::slotPlayerInfoTrackUnloaded(const QString& group,
+void AutoDJCratesDAO::playerInfoTrackUnloaded(const QString& group,
         TrackPointer pTrack) {
     // This counts as an auto-DJ reference.  The idea is to prevent tracks that
     // are loaded into a deck from being randomly chosen.

--- a/src/library/dao/autodjcratesdao.h
+++ b/src/library/dao/autodjcratesdao.h
@@ -92,10 +92,13 @@ class AutoDJCratesDAO : public QObject {
 
     // Signaled by the PlayerInfo singleton when a track is loaded to, or
     // unloaded from, a deck.
-    void slotPlayerInfoTrackLoaded(const QString& group, TrackPointer pTrack);
-    void slotPlayerInfoTrackUnloaded(const QString& group, TrackPointer pTrack);
+    void slotPlayerInfoTrackChanged(const QString& group,
+            TrackPointer pNewTrack,
+            TrackPointer pOldTrack);
 
   private:
+    void playerInfoTrackLoaded(const QString& group, TrackPointer pTrack);
+    void playerInfoTrackUnloaded(const QString& group, TrackPointer pTrack);
     void updateAutoDjCrate(CrateId crateId);
     void deleteAutoDjCrate(CrateId crateId);
 

--- a/src/mixer/playerinfo.cpp
+++ b/src/mixer/playerinfo.cpp
@@ -63,12 +63,9 @@ void PlayerInfo::setTrackInfo(const QString& group, const TrackPointer& pTrack) 
         pOld = m_loadedTrackMap.value(group);
         m_loadedTrackMap.insert(group, pTrack);
     }
-    if (pOld) {
-        emit trackUnloaded(group, pOld);
-    }
-    if (pTrack) {
-        emit trackLoaded(group, pTrack);
+    emit trackChanged(group, pTrack, pOld);
 
+    if (pTrack) {
         updateCurrentPlayingDeck();
 
         int playingDeck = m_currentlyPlayingDeck;

--- a/src/mixer/playerinfo.h
+++ b/src/mixer/playerinfo.h
@@ -27,8 +27,7 @@ class PlayerInfo : public QObject {
   signals:
     void currentPlayingDeckChanged(int deck);
     void currentPlayingTrackChanged(TrackPointer pTrack);
-    void trackLoaded(const QString& group, TrackPointer pTrack);
-    void trackUnloaded(const QString& group, TrackPointer pTrack);
+    void trackChanged(const QString& group, TrackPointer pNewTrack, TrackPointer pOldTrack);
 
   private:
     class DeckControls {


### PR DESCRIPTION
This continues https://github.com/mixxxdj/mixxx/pull/4041 with the suggested common signal. 

The pointed out issue with BpmControl is non, because it listens to the caching reader signals directly. 
As far as I have tested there was also no issue with the original code. 

However this version is less error prone and should save a few CPU cycles.  