### PR TITLE
QML: Expose library track table as a listmodel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -774,6 +774,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/skin/qml/qmleffectmanifestparametersmodel.cpp
   src/skin/qml/qmleffectsmanagerproxy.cpp
   src/skin/qml/qmleffectslotproxy.cpp
+  src/skin/qml/qmllibraryproxy.cpp
   src/skin/qml/qmlplayermanagerproxy.cpp
   src/skin/qml/qmlplayerproxy.cpp
   src/skin/qml/qmlskin.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -775,6 +775,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/skin/qml/qmleffectsmanagerproxy.cpp
   src/skin/qml/qmleffectslotproxy.cpp
   src/skin/qml/qmllibraryproxy.cpp
+  src/skin/qml/qmllibrarytracklistmodel.cpp
   src/skin/qml/qmlplayermanagerproxy.cpp
   src/skin/qml/qmlplayerproxy.cpp
   src/skin/qml/qmlskin.cpp

--- a/res/skins/QMLDemo/Library.qml
+++ b/res/skins/QMLDemo/Library.qml
@@ -1,7 +1,6 @@
 import "." as Skin
-import Qt.labs.qmlmodels 1.0
+import Mixxx 0.1 as Mixxx
 import QtQuick 2.12
-import QtQuick.Controls 1.4
 import "Theme"
 
 Item {
@@ -9,12 +8,49 @@ Item {
         color: Theme.deckBackgroundColor
         anchors.fill: parent
 
-        Text {
-            text: "Library Placeholder"
-            font.family: Theme.fontFamily
-            font.pixelSize: Theme.textFontPixelSize
-            color: Theme.deckTextColor
-            anchors.centerIn: parent
+        ListView {
+            anchors.fill: parent
+            anchors.margins: 10
+            clip: true
+            model: Mixxx.Library.model
+
+            delegate: Item {
+                id: itemDelegate
+
+                implicitWidth: 300
+                implicitHeight: 30
+
+                Text {
+                    anchors.fill: parent
+                    text: artist + " - " + title
+                    color: Theme.deckTextColor
+                }
+
+                Image {
+                    id: dragItem
+
+                    Drag.active: dragArea.drag.active
+                    Drag.dragType: Drag.Automatic
+                    Drag.supportedActions: Qt.CopyAction
+                    Drag.mimeData: {
+                        "text/uri-list": fileUrl,
+                        "text/plain": fileUrl
+                    }
+                    anchors.fill: parent
+                }
+
+                MouseArea {
+                    id: dragArea
+
+                    anchors.fill: parent
+                    drag.target: dragItem
+                    onPressed: parent.grabToImage(function(result) {
+                        dragItem.Drag.imageSource = result.url;
+                    })
+                }
+
+            }
+
         }
 
     }

--- a/res/skins/QMLDemo/Library.qml
+++ b/res/skins/QMLDemo/Library.qml
@@ -44,7 +44,7 @@ Item {
 
                     anchors.fill: parent
                     drag.target: dragItem
-                    onPressed: parent.grabToImage(function(result) {
+                    onPressed: parent.grabToImage((result) => {
                         dragItem.Drag.imageSource = result.url;
                     })
                 }

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -606,3 +606,11 @@ std::unique_ptr<mixxx::LibraryExporter> Library::makeLibraryExporter(
             parent, m_pConfig, m_pTrackCollectionManager);
 }
 #endif
+
+LibraryTableModel* Library::trackTableModel() const {
+    VERIFY_OR_DEBUG_ASSERT(m_pMixxxLibraryFeature) {
+        return nullptr;
+    }
+
+    return m_pMixxxLibraryFeature->trackTableModel();
+}

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -73,6 +73,9 @@ class Library: public QObject {
 
     void addFeature(LibraryFeature* feature);
 
+    /// Needed for exposing models to QML
+    LibraryTableModel* trackTableModel() const;
+
     int getTrackTableRowHeight() const {
         return m_iTrackTableRowHeight;
     }

--- a/src/library/mixxxlibraryfeature.h
+++ b/src/library/mixxxlibraryfeature.h
@@ -47,6 +47,10 @@ class MixxxLibraryFeature final : public LibraryFeature {
         return true;
     }
 
+    LibraryTableModel* trackTableModel() const {
+        return m_pLibraryTableModel;
+    }
+
     void searchAndActivate(const QString& query);
 
   public slots:

--- a/src/skin/qml/qmllibraryproxy.cpp
+++ b/src/skin/qml/qmllibraryproxy.cpp
@@ -1,0 +1,22 @@
+#include "skin/qml/qmllibraryproxy.h"
+
+#include <QAbstractItemModel>
+
+#include "library/library.h"
+
+namespace mixxx {
+namespace skin {
+namespace qml {
+
+QmlLibraryProxy::QmlLibraryProxy(Library* pLibrary, QObject* parent)
+        : QObject(parent), m_pLibrary(pLibrary) {
+}
+
+QAbstractItemModel* QmlLibraryProxy::model() {
+    // TODO
+    return nullptr;
+}
+
+} // namespace qml
+} // namespace skin
+} // namespace mixxx

--- a/src/skin/qml/qmllibraryproxy.cpp
+++ b/src/skin/qml/qmllibraryproxy.cpp
@@ -3,18 +3,21 @@
 #include <QAbstractItemModel>
 
 #include "library/library.h"
+#include "skin/qml/qmllibrarytracklistmodel.h"
 
 namespace mixxx {
 namespace skin {
 namespace qml {
 
 QmlLibraryProxy::QmlLibraryProxy(Library* pLibrary, QObject* parent)
-        : QObject(parent), m_pLibrary(pLibrary) {
+        : QObject(parent),
+          m_pLibrary(pLibrary),
+          m_pModel(
+                  new QmlLibraryTrackListModel(m_pLibrary->trackTableModel())) {
 }
 
-QAbstractItemModel* QmlLibraryProxy::model() {
-    // TODO
-    return nullptr;
+QmlLibraryProxy::~QmlLibraryProxy() {
+    delete m_pModel;
 }
 
 } // namespace qml

--- a/src/skin/qml/qmllibraryproxy.cpp
+++ b/src/skin/qml/qmllibraryproxy.cpp
@@ -3,21 +3,15 @@
 #include <QAbstractItemModel>
 
 #include "library/library.h"
-#include "skin/qml/qmllibrarytracklistmodel.h"
 
 namespace mixxx {
 namespace skin {
 namespace qml {
 
-QmlLibraryProxy::QmlLibraryProxy(Library* pLibrary, QObject* parent)
+QmlLibraryProxy::QmlLibraryProxy(std::shared_ptr<Library> pLibrary, QObject* parent)
         : QObject(parent),
           m_pLibrary(pLibrary),
-          m_pModel(
-                  new QmlLibraryTrackListModel(m_pLibrary->trackTableModel())) {
-}
-
-QmlLibraryProxy::~QmlLibraryProxy() {
-    delete m_pModel;
+          m_pModel(make_parented<QmlLibraryTrackListModel>(m_pLibrary->trackTableModel(), this)) {
 }
 
 } // namespace qml

--- a/src/skin/qml/qmllibraryproxy.h
+++ b/src/skin/qml/qmllibraryproxy.h
@@ -1,5 +1,9 @@
 #pragma once
 #include <QObject>
+#include <memory>
+
+#include "skin/qml/qmllibrarytracklistmodel.h"
+#include "util/parented_ptr.h"
 
 class Library;
 
@@ -14,12 +18,11 @@ class QmlLibraryProxy : public QObject {
     Q_PROPERTY(mixxx::skin::qml::QmlLibraryTrackListModel* model MEMBER m_pModel CONSTANT)
 
   public:
-    explicit QmlLibraryProxy(Library* pLibrary, QObject* parent = nullptr);
-    ~QmlLibraryProxy();
+    explicit QmlLibraryProxy(std::shared_ptr<Library> pLibrary, QObject* parent = nullptr);
 
   private:
-    Library* m_pLibrary;
-    QmlLibraryTrackListModel* m_pModel;
+    std::shared_ptr<Library> m_pLibrary;
+    parented_ptr<QmlLibraryTrackListModel> m_pModel;
 };
 
 } // namespace qml

--- a/src/skin/qml/qmllibraryproxy.h
+++ b/src/skin/qml/qmllibraryproxy.h
@@ -1,0 +1,23 @@
+#pragma once
+#include <QObject>
+
+class Library;
+
+namespace mixxx {
+namespace skin {
+namespace qml {
+
+class QmlLibraryProxy : public QObject {
+    Q_OBJECT
+  public:
+    explicit QmlLibraryProxy(Library* pLibrary, QObject* parent = nullptr);
+
+    Q_INVOKABLE QAbstractItemModel* model();
+
+  private:
+    Library* m_pLibrary;
+};
+
+} // namespace qml
+} // namespace skin
+} // namespace mixxx

--- a/src/skin/qml/qmllibraryproxy.h
+++ b/src/skin/qml/qmllibraryproxy.h
@@ -7,15 +7,19 @@ namespace mixxx {
 namespace skin {
 namespace qml {
 
+class QmlLibraryTrackListModel;
+
 class QmlLibraryProxy : public QObject {
     Q_OBJECT
+    Q_PROPERTY(mixxx::skin::qml::QmlLibraryTrackListModel* model MEMBER m_pModel CONSTANT)
+
   public:
     explicit QmlLibraryProxy(Library* pLibrary, QObject* parent = nullptr);
-
-    Q_INVOKABLE QAbstractItemModel* model();
+    ~QmlLibraryProxy();
 
   private:
     Library* m_pLibrary;
+    QmlLibraryTrackListModel* m_pModel;
 };
 
 } // namespace qml

--- a/src/skin/qml/qmllibrarytracklistmodel.cpp
+++ b/src/skin/qml/qmllibrarytracklistmodel.cpp
@@ -1,0 +1,85 @@
+#include "skin/qml/qmllibrarytracklistmodel.h"
+
+namespace mixxx {
+namespace skin {
+namespace qml {
+namespace {
+const QHash<int, QByteArray> kRoleNames = {
+        {QmlLibraryTrackListModel::TitleRole, "title"},
+        {QmlLibraryTrackListModel::ArtistRole, "artist"},
+        {QmlLibraryTrackListModel::AlbumRole, "album"},
+        {QmlLibraryTrackListModel::AlbumArtistRole, "albumArtist"},
+        {QmlLibraryTrackListModel::FileUrlRole, "fileUrl"},
+};
+}
+
+QVariant QmlLibraryTrackListModel::data(const QModelIndex& proxyIndex, int role) const {
+    if (!proxyIndex.isValid()) {
+        return QVariant();
+    }
+
+    VERIFY_OR_DEBUG_ASSERT(checkIndex(proxyIndex)) {
+        return QVariant();
+    }
+
+    const auto pSourceModel = static_cast<LibraryTableModel*>(sourceModel());
+    VERIFY_OR_DEBUG_ASSERT(pSourceModel) {
+        return QVariant();
+    }
+
+    if (proxyIndex.column() > 0) {
+        return QVariant();
+    }
+
+    int column = -1;
+    switch (role) {
+    case TitleRole:
+        column = pSourceModel->fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TITLE);
+        break;
+    case ArtistRole:
+        column = pSourceModel->fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ARTIST);
+        break;
+    case AlbumRole:
+        column = pSourceModel->fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ALBUM);
+        break;
+    case AlbumArtistRole:
+        column = pSourceModel->fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ALBUMARTIST);
+        break;
+    case FileUrlRole: {
+        column = pSourceModel->fieldIndex(ColumnCache::COLUMN_TRACKLOCATIONSTABLE_LOCATION);
+        const QString location = QIdentityProxyModel::data(
+                proxyIndex.siblingAtColumn(column), Qt::DisplayRole)
+                                         .toString();
+        if (location.isEmpty()) {
+            return QVariant();
+        }
+        return QUrl::fromLocalFile(location);
+    }
+    default:
+        break;
+    }
+
+    if (column < 0) {
+        return QVariant();
+    }
+
+    return QIdentityProxyModel::data(proxyIndex.siblingAtColumn(column), Qt::DisplayRole);
+}
+
+int QmlLibraryTrackListModel::columnCount(const QModelIndex& parent) const {
+    // This is a list model, i.e. entries without a parent have exactly one column.
+    if (!parent.isValid()) {
+        return 1;
+    }
+
+    // This is not a tree, so all indices with a parent don't have any columns.
+    return 0;
+}
+
+QHash<int, QByteArray> QmlLibraryTrackListModel::roleNames() const {
+    return kRoleNames;
+}
+
+} // namespace qml
+} // namespace skin
+} // namespace mixxx

--- a/src/skin/qml/qmllibrarytracklistmodel.cpp
+++ b/src/skin/qml/qmllibrarytracklistmodel.cpp
@@ -67,13 +67,13 @@ QVariant QmlLibraryTrackListModel::data(const QModelIndex& proxyIndex, int role)
 }
 
 int QmlLibraryTrackListModel::columnCount(const QModelIndex& parent) const {
-    // This is a list model, i.e. entries without a parent have exactly one column.
-    if (!parent.isValid()) {
-        return 1;
+    // This is a list model, i.e. no entries have a parent.
+    VERIFY_OR_DEBUG_ASSERT(!parent.isValid()) {
+        return 0;
     }
 
-    // This is not a tree, so all indices with a parent don't have any columns.
-    return 0;
+    // There is exactly one column. All data is exposed as roles.
+    return 1;
 }
 
 QHash<int, QByteArray> QmlLibraryTrackListModel::roleNames() const {

--- a/src/skin/qml/qmllibrarytracklistmodel.cpp
+++ b/src/skin/qml/qmllibrarytracklistmodel.cpp
@@ -1,5 +1,7 @@
 #include "skin/qml/qmllibrarytracklistmodel.h"
 
+#include "library/librarytablemodel.h"
+
 namespace mixxx {
 namespace skin {
 namespace qml {
@@ -11,6 +13,12 @@ const QHash<int, QByteArray> kRoleNames = {
         {QmlLibraryTrackListModel::AlbumArtistRole, "albumArtist"},
         {QmlLibraryTrackListModel::FileUrlRole, "fileUrl"},
 };
+}
+
+QmlLibraryTrackListModel::QmlLibraryTrackListModel(LibraryTableModel* pModel, QObject* pParent)
+        : QIdentityProxyModel(pParent) {
+    pModel->select();
+    setSourceModel(pModel);
 }
 
 QVariant QmlLibraryTrackListModel::data(const QModelIndex& proxyIndex, int role) const {

--- a/src/skin/qml/qmllibrarytracklistmodel.cpp
+++ b/src/skin/qml/qmllibrarytracklistmodel.cpp
@@ -15,20 +15,20 @@ const QHash<int, QByteArray> kRoleNames = {
 
 QVariant QmlLibraryTrackListModel::data(const QModelIndex& proxyIndex, int role) const {
     if (!proxyIndex.isValid()) {
-        return QVariant();
+        return {};
     }
 
     VERIFY_OR_DEBUG_ASSERT(checkIndex(proxyIndex)) {
-        return QVariant();
+        return {};
     }
 
     const auto pSourceModel = static_cast<LibraryTableModel*>(sourceModel());
     VERIFY_OR_DEBUG_ASSERT(pSourceModel) {
-        return QVariant();
+        return {};
     }
 
     if (proxyIndex.column() > 0) {
-        return QVariant();
+        return {};
     }
 
     int column = -1;
@@ -51,7 +51,7 @@ QVariant QmlLibraryTrackListModel::data(const QModelIndex& proxyIndex, int role)
                 proxyIndex.siblingAtColumn(column), Qt::DisplayRole)
                                          .toString();
         if (location.isEmpty()) {
-            return QVariant();
+            return {};
         }
         return QUrl::fromLocalFile(location);
     }
@@ -60,7 +60,7 @@ QVariant QmlLibraryTrackListModel::data(const QModelIndex& proxyIndex, int role)
     }
 
     if (column < 0) {
-        return QVariant();
+        return {};
     }
 
     return QIdentityProxyModel::data(proxyIndex.siblingAtColumn(column), Qt::DisplayRole);

--- a/src/skin/qml/qmllibrarytracklistmodel.h
+++ b/src/skin/qml/qmllibrarytracklistmodel.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <QIdentityProxyModel>
+
+#include "library/librarytablemodel.h"
+
+namespace mixxx {
+namespace skin {
+namespace qml {
+
+class QmlLibraryTrackListModel : public QIdentityProxyModel {
+  public:
+    enum Roles {
+        TitleRole = Qt::UserRole,
+        ArtistRole,
+        AlbumRole,
+        AlbumArtistRole,
+        FileUrlRole,
+    };
+    Q_ENUM(Roles);
+
+    QmlLibraryTrackListModel(LibraryTableModel* pModel, QObject* pParent = nullptr)
+            : QIdentityProxyModel(pParent) {
+        pModel->select();
+        setSourceModel(pModel);
+    }
+    ~QmlLibraryTrackListModel() = default;
+
+    QVariant data(const QModelIndex& index, int role) const override;
+    int columnCount(const QModelIndex& index = QModelIndex()) const override;
+    QHash<int, QByteArray> roleNames() const override;
+};
+
+} // namespace qml
+} // namespace skin
+} // namespace mixxx
+
+Q_DECLARE_METATYPE(mixxx::skin::qml::QmlLibraryTrackListModel*)

--- a/src/skin/qml/qmllibrarytracklistmodel.h
+++ b/src/skin/qml/qmllibrarytracklistmodel.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <QIdentityProxyModel>
 
-#include "library/librarytablemodel.h"
+class LibraryTableModel;
 
 namespace mixxx {
 namespace skin {
@@ -18,11 +18,7 @@ class QmlLibraryTrackListModel : public QIdentityProxyModel {
     };
     Q_ENUM(Roles);
 
-    QmlLibraryTrackListModel(LibraryTableModel* pModel, QObject* pParent = nullptr)
-            : QIdentityProxyModel(pParent) {
-        pModel->select();
-        setSourceModel(pModel);
-    }
+    QmlLibraryTrackListModel(LibraryTableModel* pModel, QObject* pParent = nullptr);
     ~QmlLibraryTrackListModel() = default;
 
     QVariant data(const QModelIndex& index, int role) const override;

--- a/src/skin/qml/qmlskin.cpp
+++ b/src/skin/qml/qmlskin.cpp
@@ -222,7 +222,7 @@ QWidget* QmlSkin::loadSkin(QWidget* pParent,
                         Q_UNUSED(pScriptEngine);
 
                         QmlLibraryProxy* pLibraryProxy = new QmlLibraryProxy(
-                                pCoreServices->getLibrary().get(),
+                                pCoreServices->getLibrary(),
                                 pEngine);
                         return pLibraryProxy;
                     }));

--- a/src/skin/qml/qmlskin.cpp
+++ b/src/skin/qml/qmlskin.cpp
@@ -134,6 +134,15 @@ QWidget* QmlSkin::loadSkin(QWidget* pParent,
     qmlRegisterType<QmlControlProxy>("Mixxx", 0, 1, "ControlProxy");
     qmlRegisterType<QmlWaveformOverview>("Mixxx", 0, 1, "WaveformOverview");
 
+    // Any uncreateable non-singleton types registered here require arguments
+    // that we don't want to expose to QML directly. Instead, they can be
+    // retrieved by member properties or methods from the singleton types.
+    //
+    // The alternative would be to register their *arguments* in the QML
+    // system, which would improve nothing, or we had to expose them as
+    // singletons to that they can be accessed by components instantiated by
+    // QML, which would also be suboptimal.
+
     qmlRegisterSingletonType<QmlEffectsManagerProxy>("Mixxx",
             0,
             1,

--- a/src/skin/qml/qmlskin.cpp
+++ b/src/skin/qml/qmlskin.cpp
@@ -12,6 +12,7 @@
 #include "skin/qml/qmleffectslotproxy.h"
 #include "skin/qml/qmleffectsmanagerproxy.h"
 #include "skin/qml/qmllibraryproxy.h"
+#include "skin/qml/qmllibrarytracklistmodel.h"
 #include "skin/qml/qmlplayermanagerproxy.h"
 #include "skin/qml/qmlplayerproxy.h"
 #include "skin/qml/qmlvisibleeffectsmodel.h"
@@ -205,6 +206,12 @@ QWidget* QmlSkin::loadSkin(QWidget* pParent,
                         return pConfigProxy;
                     }));
 
+    qmlRegisterUncreatableType<QmlLibraryTrackListModel>("Mixxx",
+            0,
+            1,
+            "LibraryTrackListModel",
+            "LibraryTrackListModel objects can't be created directly, "
+            "please use Mixxx.Library.model");
     qmlRegisterSingletonType<QmlLibraryProxy>("Mixxx",
             0,
             1,

--- a/src/skin/qml/qmlskin.cpp
+++ b/src/skin/qml/qmlskin.cpp
@@ -11,6 +11,7 @@
 #include "skin/qml/qmleffectmanifestparametersmodel.h"
 #include "skin/qml/qmleffectslotproxy.h"
 #include "skin/qml/qmleffectsmanagerproxy.h"
+#include "skin/qml/qmllibraryproxy.h"
 #include "skin/qml/qmlplayermanagerproxy.h"
 #include "skin/qml/qmlplayerproxy.h"
 #include "skin/qml/qmlvisibleeffectsmodel.h"
@@ -202,6 +203,21 @@ QWidget* QmlSkin::loadSkin(QWidget* pParent,
                                         pConfig,
                                         pEngine);
                         return pConfigProxy;
+                    }));
+
+    qmlRegisterSingletonType<QmlLibraryProxy>("Mixxx",
+            0,
+            1,
+            "Library",
+            lambda_to_singleton_type_factory_ptr(
+                    [pCoreServices](QQmlEngine* pEngine,
+                            QJSEngine* pScriptEngine) -> QObject* {
+                        Q_UNUSED(pScriptEngine);
+
+                        QmlLibraryProxy* pLibraryProxy = new QmlLibraryProxy(
+                                pCoreServices->getLibrary().get(),
+                                pEngine);
+                        return pLibraryProxy;
                     }));
 
     QQuickWidget* pWidget = new QQuickWidget(pParent);


### PR DESCRIPTION
This is a first implementation to make the library usable in QML.

Actually I'm unsure if using a listmodel works for QML after all. For example, I don't really know how to implement multiple columns that may even be reorderable. But it works fine for testing and as an initial implementation.

After we did some testing we may have to go with a tablemodel after all. This should not block this PR though.