### PR TITLE
Return Bpm from EngineBuffer and BpmControl

### DIFF
--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -25,8 +25,11 @@ class BpmControl : public EngineControl {
     BpmControl(const QString& group, UserSettingsPointer pConfig);
     ~BpmControl() override;
 
-    double getBpm() const;
-    double getLocalBpm() const { return m_pLocalBpm ? m_pLocalBpm->get() : 0.0; }
+    mixxx::Bpm getBpm() const;
+    mixxx::Bpm getLocalBpm() const {
+        return m_pLocalBpm ? mixxx::Bpm(m_pLocalBpm->get()) : mixxx::Bpm();
+    }
+
     // When in master sync mode, ratecontrol calls calcSyncedRate to figure out
     // how fast the track should play back.  The returned rate is usually just
     // the correct pitch to match bpms.  The usertweak argument represents

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -363,11 +363,11 @@ void EngineBuffer::enableIndependentPitchTempoScaling(bool bEnable,
     }
 }
 
-double EngineBuffer::getBpm() const {
+mixxx::Bpm EngineBuffer::getBpm() const {
     return m_pBpmControl->getBpm();
 }
 
-double EngineBuffer::getLocalBpm() const {
+mixxx::Bpm EngineBuffer::getLocalBpm() const {
     return m_pBpmControl->getLocalBpm();
 }
 

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -11,6 +11,7 @@
 #include "engine/engineobject.h"
 #include "engine/sync/syncable.h"
 #include "preferences/usersettings.h"
+#include "track/bpm.h"
 #include "track/track_decl.h"
 #include "util/rotary.h"
 #include "util/types.h"
@@ -97,10 +98,10 @@ class EngineBuffer : public EngineObject {
     double getSpeed() const;
     bool getScratching() const;
     bool isReverse() const;
-    // Returns current bpm value (not thread-safe)
-    double getBpm() const;
-    // Returns the BPM of the loaded track around the current position (not thread-safe)
-    double getLocalBpm() const;
+    /// Returns current bpm value (not thread-safe)
+    mixxx::Bpm getBpm() const;
+    /// Returns the BPM of the loaded track around the current position (not thread-safe)
+    mixxx::Bpm getLocalBpm() const;
     /// Sets a beatloop for the loaded track (not thread safe)
     void setBeatLoop(double startPosition, bool enabled);
     /// Sets a loop for the loaded track (not thread safe)

--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -471,7 +471,7 @@ Syncable* EngineSync::pickNonSyncSyncTarget(EngineChannel* pDontPick) const {
         // mix, and are primary decks.
         if (pChannel->isActive() && pChannel->isMasterEnabled() && pChannel->isPrimaryDeck()) {
             EngineBuffer* pBuffer = pChannel->getEngineBuffer();
-            if (pBuffer && pBuffer->getBpm() > 0) {
+            if (pBuffer && pBuffer->getBpm().isValid()) {
                 if (pBuffer->getSpeed() != 0.0) {
                     if (pSyncable->getSyncMode() != SYNC_NONE) {
                         // Second choice: first playing sync deck

--- a/src/track/bpm.h
+++ b/src/track/bpm.h
@@ -152,6 +152,11 @@ inline Bpm operator/(Bpm bpm, double divisor) {
     return Bpm(bpm.value() / divisor);
 }
 
+/// Bpm can be divided by another Bpm to get a ratio (represented as a double).
+inline double operator/(Bpm bpm, Bpm otherBpm) {
+    return bpm.value() / otherBpm.value();
+}
+
 inline bool operator==(Bpm bpm1, Bpm bpm2) {
     if (!bpm1.isValid() && !bpm2.isValid()) {
         return true;


### PR DESCRIPTION
This also fixes a potential division by zero in EngineBuffer, in case `thisLocalBpm` is invalid.