### PR TITLE
Cue Frame Refactoring

### DIFF
--- a/src/analyzer/analyzersilence.cpp
+++ b/src/analyzer/analyzersilence.cpp
@@ -15,7 +15,7 @@ bool shouldAnalyze(TrackPointer pTrack) {
     CuePointer pOutroCue = pTrack->findCueByType(mixxx::CueType::Outro);
     CuePointer pAudibleSound = pTrack->findCueByType(mixxx::CueType::AudibleSound);
 
-    if (!pIntroCue || !pOutroCue || !pAudibleSound || pAudibleSound->getLength() <= 0) {
+    if (!pIntroCue || !pOutroCue || !pAudibleSound || pAudibleSound->getLengthFrames() <= 0) {
         return true;
     }
     return false;

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -484,7 +484,7 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
                 pNewTrack->findCueByType(mixxx::CueType::AudibleSound);
         double audibleSoundPosition = Cue::kNoPosition;
         if (pAudibleSound) {
-            audibleSoundPosition = pAudibleSound->getPosition();
+            audibleSoundPosition = pAudibleSound->getPosition().toEngineSamplePosMaybeInvalid();
         }
         if (audibleSoundPosition != Cue::kNoPosition) {
             seekOnLoad(audibleSoundPosition);
@@ -581,8 +581,8 @@ void CueControl::loadCuesFromTrack() {
             } else {
                 // If the old hotcue is the same, then we only need to update
                 Cue::StartAndEndPositions pos = pCue->getStartAndEndPosition();
-                pControl->setPosition(pos.startPosition);
-                pControl->setEndPosition(pos.endPosition);
+                pControl->setPosition(pos.startPosition.toEngineSamplePosMaybeInvalid());
+                pControl->setEndPosition(pos.endPosition.toEngineSamplePosMaybeInvalid());
                 pControl->setColor(pCue->getColor());
                 pControl->setType(pCue->getType());
             }
@@ -604,8 +604,8 @@ void CueControl::loadCuesFromTrack() {
     }
 
     if (pIntroCue) {
-        double startPosition = pIntroCue->getPosition();
-        double endPosition = pIntroCue->getEndPosition();
+        double startPosition = pIntroCue->getPosition().toEngineSamplePosMaybeInvalid();
+        double endPosition = pIntroCue->getEndPosition().toEngineSamplePosMaybeInvalid();
 
         m_pIntroStartPosition->set(quantizeCuePoint(startPosition));
         m_pIntroStartEnabled->forceSet(
@@ -621,8 +621,8 @@ void CueControl::loadCuesFromTrack() {
     }
 
     if (pOutroCue) {
-        double startPosition = pOutroCue->getPosition();
-        double endPosition = pOutroCue->getEndPosition();
+        double startPosition = pOutroCue->getPosition().toEngineSamplePosMaybeInvalid();
+        double endPosition = pOutroCue->getEndPosition().toEngineSamplePosMaybeInvalid();
 
         m_pOutroStartPosition->set(quantizeCuePoint(startPosition));
         m_pOutroStartEnabled->forceSet(
@@ -642,7 +642,7 @@ void CueControl::loadCuesFromTrack() {
     // The mixxx::CueType::MainCue from getCuePoints() has the priority
     CuePosition mainCuePoint;
     if (pMainCue) {
-        double position = pMainCue->getPosition();
+        double position = pMainCue->getPosition().toEngineSamplePosMaybeInvalid();
         mainCuePoint.setPosition(position);
         // adjust the track cue accordingly
         m_pLoadedTrack->setCuePoint(mainCuePoint);
@@ -899,7 +899,7 @@ void CueControl::hotcueGotoAndLoop(HotcueControl* pControl, double value) {
         return;
     }
 
-    double startPosition = pCue->getPosition();
+    double startPosition = pCue->getPosition().toEngineSamplePosMaybeInvalid();
     if (startPosition == Cue::kNoPosition) {
         return;
     }
@@ -933,10 +933,10 @@ void CueControl::hotcueCueLoop(HotcueControl* pControl, double value) {
 
     CuePointer pCue = pControl->getCue();
 
-    if (!pCue || pCue->getPosition() == Cue::kNoPosition) {
+    if (!pCue || !pCue->getPosition().isValid()) {
         hotcueSet(pControl, value, HotcueSetMode::Cue);
         pCue = pControl->getCue();
-        VERIFY_OR_DEBUG_ASSERT(pCue && pCue->getPosition() != Cue::kNoPosition) {
+        VERIFY_OR_DEBUG_ASSERT(pCue && pCue->getPosition().isValid()) {
             return;
         }
     }
@@ -951,7 +951,9 @@ void CueControl::hotcueCueLoop(HotcueControl* pControl, double value) {
         } else {
             bool loopActive = pControl->getStatus() == HotcueControl::Status::Active;
             Cue::StartAndEndPositions pos = pCue->getStartAndEndPosition();
-            setLoop(pos.startPosition, pos.endPosition, !loopActive);
+            setLoop(pos.startPosition.toEngineSamplePosMaybeInvalid(),
+                    pos.endPosition.toEngineSamplePosMaybeInvalid(),
+                    !loopActive);
         }
     } break;
     case mixxx::CueType::HotCue: {
@@ -959,7 +961,7 @@ void CueControl::hotcueCueLoop(HotcueControl* pControl, double value) {
         // create a beatloop starting at the hotcue position. This is useful for
         // mapping the CUE LOOP mode labeled on some controllers.
         setCurrentSavedLoopControlAndActivate(nullptr);
-        double startPosition = pCue->getPosition();
+        double startPosition = pCue->getPosition().toEngineSamplePosMaybeInvalid();
         bool loopActive = m_pLoopEnabled->toBool() &&
                 (startPosition == m_pLoopStartPosition->get());
         setBeatLoop(startPosition, !loopActive);
@@ -978,7 +980,7 @@ void CueControl::hotcueActivate(HotcueControl* pControl, double value, HotcueSet
     CuePointer pCue = pControl->getCue();
     if (value > 0) {
         // pressed
-        if (pCue && pCue->getPosition() != Cue::kNoPosition &&
+        if (pCue && pCue->getPosition().isValid() &&
                 pCue->getType() != mixxx::CueType::Invalid) {
             if (m_pPlay->toBool() && m_currentlyPreviewingIndex == Cue::kNoHotCue) {
                 // playing by Play button
@@ -993,7 +995,10 @@ void CueControl::hotcueActivate(HotcueControl* pControl, double value, HotcueSet
                         bool loopActive = pControl->getStatus() ==
                                 HotcueControl::Status::Active;
                         Cue::StartAndEndPositions pos = pCue->getStartAndEndPosition();
-                        setLoop(pos.startPosition, pos.endPosition, !loopActive);
+                        setLoop(pos.startPosition
+                                        .toEngineSamplePosMaybeInvalid(),
+                                pos.endPosition.toEngineSamplePosMaybeInvalid(),
+                                !loopActive);
                     }
                     break;
                 default:
@@ -1096,7 +1101,9 @@ void CueControl::hotcuePositionChanged(
         if (newPosition == Cue::kNoPosition) {
             detachCue(pControl);
         } else if (newPosition > 0 && newPosition < m_pTrackSamples->get()) {
-            if (pCue->getType() == mixxx::CueType::Loop && newPosition >= pCue->getEndPosition()) {
+            if (pCue->getType() == mixxx::CueType::Loop &&
+                    newPosition >= pCue->getEndPosition()
+                                           .toEngineSamplePosMaybeInvalid()) {
                 return;
             }
             pCue->setStartPosition(newPosition);
@@ -1115,7 +1122,7 @@ void CueControl::hotcueEndPositionChanged(
             pCue->setType(mixxx::CueType::HotCue);
             pCue->setEndPosition(Cue::kNoPosition);
         } else {
-            if (newEndPosition > pCue->getPosition()) {
+            if (newEndPosition > pCue->getPosition().toEngineSamplePosMaybeInvalid()) {
                 pCue->setEndPosition(newEndPosition);
             }
         }
@@ -2092,12 +2099,14 @@ void CueControl::setCurrentSavedLoopControlAndActivate(HotcueControl* pControl) 
 
     VERIFY_OR_DEBUG_ASSERT(
             type == mixxx::CueType::Loop &&
-            pos.endPosition != Cue::kNoPosition) {
+            pos.endPosition.isValid()) {
         return;
     }
 
     // Set new control as active
-    setLoop(pos.startPosition, pos.endPosition, true);
+    setLoop(pos.startPosition.toEngineSamplePosMaybeInvalid(),
+            pos.endPosition.toEngineSamplePosMaybeInvalid(),
+            true);
     pControl->setStatus(HotcueControl::Status::Active);
     m_pCurrentSavedLoopControl.storeRelease(pControl);
 }
@@ -2113,14 +2122,14 @@ void CueControl::slotLoopEnabledChanged(bool enabled) {
     }
 
     DEBUG_ASSERT(pSavedLoopControl->getStatus() != HotcueControl::Status::Empty);
-    DEBUG_ASSERT(
-            pSavedLoopControl->getCue() &&
+    DEBUG_ASSERT(pSavedLoopControl->getCue() &&
             pSavedLoopControl->getCue()->getPosition() ==
-                    m_pLoopStartPosition->get());
-    DEBUG_ASSERT(
-            pSavedLoopControl->getCue() &&
+                    mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
+                            m_pLoopStartPosition->get()));
+    DEBUG_ASSERT(pSavedLoopControl->getCue() &&
             pSavedLoopControl->getCue()->getEndPosition() ==
-                    m_pLoopEndPosition->get());
+                    mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
+                            m_pLoopEndPosition->get()));
 
     if (enabled) {
         pSavedLoopControl->setStatus(HotcueControl::Status::Active);
@@ -2421,8 +2430,8 @@ double HotcueControl::getEndPosition() const {
 void HotcueControl::setCue(const CuePointer& pCue) {
     DEBUG_ASSERT(!m_pCue);
     Cue::StartAndEndPositions pos = pCue->getStartAndEndPosition();
-    setPosition(pos.startPosition);
-    setEndPosition(pos.endPosition);
+    setPosition(pos.startPosition.toEngineSamplePosMaybeInvalid());
+    setEndPosition(pos.endPosition.toEngineSamplePosMaybeInvalid());
     setColor(pCue->getColor());
     setStatus((pCue->getType() == mixxx::CueType::Invalid)
                     ? HotcueControl::Status::Empty

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -112,7 +112,7 @@ class HotcueControl : public QObject {
     /// for the case the cue is deleted during preview.
     void cachePreviewingStartState() {
         if (m_pCue) {
-            m_previewingPosition.setValue(m_pCue->getPosition());
+            m_previewingPosition.setValue(m_pCue->getPosition().toEngineSamplePosMaybeInvalid());
             m_previewingType.setValue(m_pCue->getType());
         } else {
             m_previewingType.setValue(mixxx::CueType::Invalid);

--- a/src/engine/controls/enginecontrol.h
+++ b/src/engine/controls/enginecontrol.h
@@ -5,6 +5,7 @@
 #include <QList>
 #include <QObject>
 
+#include "audio/frame.h"
 #include "control/controlvalue.h"
 #include "engine/cachingreader/cachingreader.h"
 #include "engine/effects/groupfeaturestate.h"
@@ -17,6 +18,9 @@ class EngineMaster;
 class EngineBuffer;
 
 const int kNoTrigger = -1;
+static_assert(
+        mixxx::audio::FramePos::kLegacyInvalidEnginePosition == kNoTrigger,
+        "Invalid engine position value mismatch");
 
 /**
  * EngineControl is an abstract base class for objects which implement

--- a/src/engine/controls/vinylcontrolcontrol.cpp
+++ b/src/engine/controls/vinylcontrolcontrol.cpp
@@ -127,7 +127,7 @@ void VinylControlControl::slotControlVinylSeek(double fractionalPos) {
                 continue;
             }
 
-            double cue_position = pCue->getPosition();
+            double cue_position = pCue->getPosition().toEngineSamplePosMaybeInvalid();
             // pick cues closest to new_playpos
             if ((nearest_playpos == -1) ||
                 (fabs(new_playpos - cue_position) < shortest_distance)) {

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1104,7 +1104,7 @@ double AutoDJProcessor::getFirstSoundSecond(DeckAttributes* pDeck) {
 
     CuePointer pFromTrackAudibleSound = pTrack->findCueByType(mixxx::CueType::AudibleSound);
     if (pFromTrackAudibleSound) {
-        double firstSound = pFromTrackAudibleSound->getPosition();
+        double firstSound = pFromTrackAudibleSound->getPosition().toEngineSamplePosMaybeInvalid();
         if (firstSound > 0.0) {
             return samplePositionToSeconds(firstSound, pDeck);
         }
@@ -1121,8 +1121,9 @@ double AutoDJProcessor::getLastSoundSecond(DeckAttributes* pDeck) {
     CuePointer pFromTrackAudibleSound = pTrack->findCueByType(mixxx::CueType::AudibleSound);
     if (pFromTrackAudibleSound) {
         Cue::StartAndEndPositions pos = pFromTrackAudibleSound->getStartAndEndPosition();
-        if (pos.endPosition > 0 && (pos.endPosition - pos.startPosition) > 0) {
-            return samplePositionToSeconds(pos.endPosition, pDeck);
+        if (pos.endPosition > mixxx::audio::kStartFramePos &&
+                (pos.endPosition - pos.startPosition) > 0) {
+            return samplePositionToSeconds(pos.endPosition.toEngineSamplePosMaybeInvalid(), pDeck);
         }
     }
     return getEndSecond(pDeck);

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -536,7 +536,8 @@ void bindTrackLibraryValues(
     pTrackLibraryQuery->bindValue(":comment", trackInfo.getComment());
     pTrackLibraryQuery->bindValue(":url", track.getUrl());
     pTrackLibraryQuery->bindValue(":rating", track.getRating());
-    pTrackLibraryQuery->bindValue(":cuepoint", track.getCuePoint().getPosition());
+    pTrackLibraryQuery->bindValue(":cuepoint",
+            track.getMainCuePosition().toEngineSamplePosMaybeInvalid());
     pTrackLibraryQuery->bindValue(":bpm_lock", track.getBpmLocked() ? 1 : 0);
     pTrackLibraryQuery->bindValue(":replaygain", trackInfo.getReplayGain().getRatio());
     pTrackLibraryQuery->bindValue(":replaygain_peak", trackInfo.getReplayGain().getPeak());
@@ -1145,7 +1146,8 @@ bool setTrackRating(const QSqlRecord& record, const int column,
 
 bool setTrackCuePoint(const QSqlRecord& record, const int column,
                       TrackPointer pTrack) {
-    pTrack->setCuePoint(CuePosition(record.value(column).toDouble()));
+    pTrack->setMainCuePosition(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
+            record.value(column).toDouble()));
     return false;
 }
 

--- a/src/library/export/engineprimeexportjob.cpp
+++ b/src/library/export/engineprimeexportjob.cpp
@@ -248,7 +248,7 @@ void exportMetadata(djinterop::database* pDatabase,
 
         djinterop::hot_cue hotCue{};
         hotCue.label = label.toStdString();
-        hotCue.sample_offset = playPosToSampleOffset(pCue->getPosition());
+        hotCue.sample_offset = playPosToSampleOffset(pCue->getPosition().toEngineSamplePos());
 
         auto color = mixxx::RgbColor::toQColor(pCue->getColor());
         hotCue.color = djinterop::pad_color{

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -265,8 +265,8 @@ void BaseTrackPlayerImpl::loadTrack(TrackPointer pTrack) {
         }
 
         if (pLoopCue) {
-            double loopStart = pLoopCue->getPosition();
-            double loopEnd = loopStart + pLoopCue->getLength();
+            double loopStart = pLoopCue->getPosition().toEngineSamplePosMaybeInvalid();
+            double loopEnd = loopStart + (pLoopCue->getLengthFrames() * mixxx::kEngineChannelCount);
             if (loopStart != kNoTrigger && loopEnd != kNoTrigger && loopStart <= loopEnd) {
                 m_pLoopInPoint->set(loopStart);
                 m_pLoopOutPoint->set(loopEnd);

--- a/src/test/analyzersilence_test.cpp
+++ b/src/test/analyzersilence_test.cpp
@@ -60,12 +60,12 @@ TEST_F(AnalyzerSilenceTest, SilenceTrack) {
     EXPECT_DOUBLE_EQ(0.0, cue.getPosition());
 
     CuePointer pIntroCue = pTrack->findCueByType(mixxx::CueType::Intro);
-    EXPECT_DOUBLE_EQ(0.0, pIntroCue->getPosition());
-    EXPECT_DOUBLE_EQ(0.0, pIntroCue->getLength());
+    EXPECT_EQ(mixxx::audio::kStartFramePos, pIntroCue->getPosition());
+    EXPECT_DOUBLE_EQ(0.0, pIntroCue->getLengthFrames() * kChannelCount);
 
     CuePointer pOutroCue = pTrack->findCueByType(mixxx::CueType::Outro);
-    EXPECT_DOUBLE_EQ(Cue::kNoPosition, pOutroCue->getPosition());
-    EXPECT_DOUBLE_EQ(nTrackSampleDataLength, pOutroCue->getLength());
+    EXPECT_EQ(mixxx::audio::kInvalidFramePos, pOutroCue->getPosition());
+    EXPECT_DOUBLE_EQ(nTrackSampleDataLength, pOutroCue->getLengthFrames() * kChannelCount);
 }
 
 TEST_F(AnalyzerSilenceTest, EndToEndToneTrack) {
@@ -81,12 +81,12 @@ TEST_F(AnalyzerSilenceTest, EndToEndToneTrack) {
     EXPECT_DOUBLE_EQ(0.0, cue.getPosition());
 
     CuePointer pIntroCue = pTrack->findCueByType(mixxx::CueType::Intro);
-    EXPECT_DOUBLE_EQ(0.0, pIntroCue->getPosition());
-    EXPECT_DOUBLE_EQ(0.0, pIntroCue->getLength());
+    EXPECT_EQ(mixxx::audio::kStartFramePos, pIntroCue->getPosition());
+    EXPECT_DOUBLE_EQ(0.0, pIntroCue->getLengthFrames() * kChannelCount);
 
     CuePointer pOutroCue = pTrack->findCueByType(mixxx::CueType::Outro);
-    EXPECT_DOUBLE_EQ(Cue::kNoPosition, pOutroCue->getPosition());
-    EXPECT_DOUBLE_EQ(nTrackSampleDataLength, pOutroCue->getLength());
+    EXPECT_EQ(mixxx::audio::kInvalidFramePos, pOutroCue->getPosition());
+    EXPECT_DOUBLE_EQ(nTrackSampleDataLength, pOutroCue->getLengthFrames() * kChannelCount);
 }
 
 TEST_F(AnalyzerSilenceTest, ToneTrackWithSilence) {
@@ -112,12 +112,12 @@ TEST_F(AnalyzerSilenceTest, ToneTrackWithSilence) {
     EXPECT_DOUBLE_EQ(nTrackSampleDataLength / 4, cue.getPosition());
 
     CuePointer pIntroCue = pTrack->findCueByType(mixxx::CueType::Intro);
-    EXPECT_DOUBLE_EQ(nTrackSampleDataLength / 4, pIntroCue->getPosition());
-    EXPECT_DOUBLE_EQ(0.0, pIntroCue->getLength());
+    EXPECT_DOUBLE_EQ(nTrackSampleDataLength / 4, pIntroCue->getPosition().toEngineSamplePos());
+    EXPECT_DOUBLE_EQ(0.0, pIntroCue->getLengthFrames() * kChannelCount);
 
     CuePointer pOutroCue = pTrack->findCueByType(mixxx::CueType::Outro);
-    EXPECT_DOUBLE_EQ(Cue::kNoPosition, pOutroCue->getPosition());
-    EXPECT_DOUBLE_EQ(3 * nTrackSampleDataLength / 4, pOutroCue->getLength());
+    EXPECT_EQ(mixxx::audio::kInvalidFramePos, pOutroCue->getPosition());
+    EXPECT_DOUBLE_EQ(3 * nTrackSampleDataLength / 4, pOutroCue->getLengthFrames() * kChannelCount);
 }
 
 TEST_F(AnalyzerSilenceTest, ToneTrackWithSilenceInTheMiddle) {
@@ -155,12 +155,12 @@ TEST_F(AnalyzerSilenceTest, ToneTrackWithSilenceInTheMiddle) {
     EXPECT_DOUBLE_EQ(oneFifthOfTrackLength, cue.getPosition());
 
     CuePointer pIntroCue = pTrack->findCueByType(mixxx::CueType::Intro);
-    EXPECT_DOUBLE_EQ(oneFifthOfTrackLength, pIntroCue->getPosition());
-    EXPECT_DOUBLE_EQ(0.0, pIntroCue->getLength());
+    EXPECT_DOUBLE_EQ(oneFifthOfTrackLength, pIntroCue->getPosition().toEngineSamplePos());
+    EXPECT_DOUBLE_EQ(0.0, pIntroCue->getLengthFrames() * kChannelCount);
 
     CuePointer pOutroCue = pTrack->findCueByType(mixxx::CueType::Outro);
-    EXPECT_DOUBLE_EQ(Cue::kNoPosition, pOutroCue->getPosition());
-    EXPECT_DOUBLE_EQ(4 * oneFifthOfTrackLength, pOutroCue->getLength());
+    EXPECT_EQ(mixxx::audio::kInvalidFramePos, pOutroCue->getPosition());
+    EXPECT_DOUBLE_EQ(4 * oneFifthOfTrackLength, pOutroCue->getLengthFrames() * kChannelCount);
 }
 
 TEST_F(AnalyzerSilenceTest, RespectUserEdits) {
@@ -199,11 +199,11 @@ TEST_F(AnalyzerSilenceTest, RespectUserEdits) {
     CuePosition cue = pTrack->getCuePoint();
     EXPECT_DOUBLE_EQ(kManualCuePosition, cue.getPosition());
 
-    EXPECT_DOUBLE_EQ(kManualIntroPosition, pIntroCue->getPosition());
-    EXPECT_DOUBLE_EQ(0.0, pIntroCue->getLength());
+    EXPECT_DOUBLE_EQ(kManualIntroPosition, pIntroCue->getPosition().toEngineSamplePos());
+    EXPECT_DOUBLE_EQ(0.0, pIntroCue->getLengthFrames() * kChannelCount);
 
-    EXPECT_DOUBLE_EQ(Cue::kNoPosition, pOutroCue->getPosition());
-    EXPECT_DOUBLE_EQ(kManualOutroPosition, pOutroCue->getLength());
+    EXPECT_EQ(mixxx::audio::kInvalidFramePos, pOutroCue->getPosition());
+    EXPECT_DOUBLE_EQ(kManualOutroPosition, pOutroCue->getLengthFrames() * kChannelCount);
 }
 
 } // namespace

--- a/src/test/cue_test.cpp
+++ b/src/test/cue_test.cpp
@@ -12,8 +12,8 @@ TEST(CueTest, NewCueIsDirty) {
     const auto cue = Cue(
             mixxx::CueType::HotCue,
             1,
-            0.0,
-            Cue::kNoPosition);
+            mixxx::audio::kStartFramePos,
+            mixxx::audio::kInvalidFramePos);
     EXPECT_TRUE(cue.isDirty());
 }
 

--- a/src/test/cuecontrol_test.cpp
+++ b/src/test/cuecontrol_test.cpp
@@ -398,8 +398,8 @@ TEST_F(CueControlTest, IntroCue_SetStartEnd_ClearStartEnd) {
     CuePointer pCue = pTrack->findCueByType(mixxx::CueType::Intro);
     EXPECT_NE(nullptr, pCue);
     if (pCue != nullptr) {
-        EXPECT_DOUBLE_EQ(100.0, pCue->getPosition());
-        EXPECT_DOUBLE_EQ(0.0, pCue->getLength());
+        EXPECT_DOUBLE_EQ(100.0, pCue->getPosition().toEngineSamplePos());
+        EXPECT_DOUBLE_EQ(0.0, pCue->getLengthFrames() * mixxx::kEngineChannelCount);
     }
 
     // Set intro end cue
@@ -414,8 +414,8 @@ TEST_F(CueControlTest, IntroCue_SetStartEnd_ClearStartEnd) {
     pCue = pTrack->findCueByType(mixxx::CueType::Intro);
     EXPECT_NE(nullptr, pCue);
     if (pCue != nullptr) {
-        EXPECT_DOUBLE_EQ(100.0, pCue->getPosition());
-        EXPECT_DOUBLE_EQ(400.0, pCue->getLength());
+        EXPECT_DOUBLE_EQ(100.0, pCue->getPosition().toEngineSamplePos());
+        EXPECT_DOUBLE_EQ(400.0, pCue->getLengthFrames() * mixxx::kEngineChannelCount);
     }
 
     // Clear intro start cue
@@ -429,8 +429,8 @@ TEST_F(CueControlTest, IntroCue_SetStartEnd_ClearStartEnd) {
     pCue = pTrack->findCueByType(mixxx::CueType::Intro);
     EXPECT_NE(nullptr, pCue);
     if (pCue != nullptr) {
-        EXPECT_DOUBLE_EQ(Cue::kNoPosition, pCue->getPosition());
-        EXPECT_DOUBLE_EQ(500.0, pCue->getLength());
+        EXPECT_EQ(mixxx::audio::kInvalidFramePos, pCue->getPosition());
+        EXPECT_DOUBLE_EQ(500.0, pCue->getLengthFrames() * mixxx::kEngineChannelCount);
     }
 
     // Clear intro end cue
@@ -459,8 +459,8 @@ TEST_F(CueControlTest, OutroCue_SetStartEnd_ClearStartEnd) {
     CuePointer pCue = pTrack->findCueByType(mixxx::CueType::Outro);
     EXPECT_NE(nullptr, pCue);
     if (pCue != nullptr) {
-        EXPECT_DOUBLE_EQ(750.0, pCue->getPosition());
-        EXPECT_DOUBLE_EQ(0.0, pCue->getLength());
+        EXPECT_DOUBLE_EQ(750.0, pCue->getPosition().toEngineSamplePos());
+        EXPECT_DOUBLE_EQ(0.0, pCue->getLengthFrames() * mixxx::kEngineChannelCount);
     }
 
     // Set outro end cue
@@ -475,8 +475,8 @@ TEST_F(CueControlTest, OutroCue_SetStartEnd_ClearStartEnd) {
     pCue = pTrack->findCueByType(mixxx::CueType::Outro);
     EXPECT_NE(nullptr, pCue);
     if (pCue != nullptr) {
-        EXPECT_DOUBLE_EQ(750.0, pCue->getPosition());
-        EXPECT_DOUBLE_EQ(250.0, pCue->getLength());
+        EXPECT_DOUBLE_EQ(750.0, pCue->getPosition().toEngineSamplePos());
+        EXPECT_DOUBLE_EQ(250.0, pCue->getLengthFrames() * mixxx::kEngineChannelCount);
     }
 
     // Clear outro start cue
@@ -490,8 +490,8 @@ TEST_F(CueControlTest, OutroCue_SetStartEnd_ClearStartEnd) {
     pCue = pTrack->findCueByType(mixxx::CueType::Outro);
     EXPECT_NE(nullptr, pCue);
     if (pCue != nullptr) {
-        EXPECT_DOUBLE_EQ(Cue::kNoPosition, pCue->getPosition());
-        EXPECT_DOUBLE_EQ(1000.0, pCue->getLength());
+        EXPECT_EQ(mixxx::audio::kInvalidFramePos, pCue->getPosition());
+        EXPECT_DOUBLE_EQ(1000.0, pCue->getLengthFrames() * mixxx::kEngineChannelCount);
     }
 
     // Clear outro end cue

--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -36,7 +36,6 @@ inline mixxx::audio::FramePos positionMillisToFrames(
         return mixxx::audio::kInvalidFramePos;
     }
 
-    // Try to avoid rounding errors
     return mixxx::audio::FramePos((*positionMillis * sampleRate) / 1000);
 }
 } // namespace

--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -3,6 +3,7 @@
 #include <QMutexLocker>
 #include <QtDebug>
 
+#include "audio/frame.h"
 #include "engine/engine.h"
 #include "moc_cue.cpp"
 #include "util/assert.h"
@@ -11,30 +12,32 @@
 
 namespace {
 
-inline std::optional<double> positionSamplesToMillis(
-        double positionSamples,
+inline std::optional<double> positionFramesToMillis(
+        mixxx::audio::FramePos position,
         mixxx::audio::SampleRate sampleRate) {
     VERIFY_OR_DEBUG_ASSERT(sampleRate.isValid()) {
         return std::nullopt;
     }
-    if (positionSamples == Cue::kNoPosition) {
+    if (!position.isValid()) {
         return std::nullopt;
     }
     // Try to avoid rounding errors
-    return (positionSamples * 1000) / (sampleRate * mixxx::kEngineChannelCount);
+    return (position.value() * 1000) / sampleRate;
 }
 
-inline double positionMillisToSamples(
+inline mixxx::audio::FramePos positionMillisToFrames(
         std::optional<double> positionMillis,
         mixxx::audio::SampleRate sampleRate) {
     VERIFY_OR_DEBUG_ASSERT(sampleRate.isValid()) {
-        return Cue::kNoPosition;
+        return mixxx::audio::kInvalidFramePos;
     }
+
     if (!positionMillis) {
-        return Cue::kNoPosition;
+        return mixxx::audio::kInvalidFramePos;
     }
+
     // Try to avoid rounding errors
-    return (*positionMillis * sampleRate * mixxx::kEngineChannelCount) / 1000;
+    return mixxx::audio::FramePos((*positionMillis * sampleRate) / 1000);
 }
 } // namespace
 
@@ -48,27 +51,25 @@ void CuePointer::deleteLater(Cue* pCue) {
 Cue::Cue(
         DbId id,
         mixxx::CueType type,
-        double position,
-        double length,
+        mixxx::audio::FramePos position,
+        mixxx::audio::FrameDiff_t length,
         int hotCue,
         const QString& label,
         mixxx::RgbColor color)
         : m_bDirty(false), // clear flag after loading from database
           m_dbId(id),
           m_type(type),
-          m_sampleStartPosition(position),
+          m_startPosition(position),
           m_iHotCue(hotCue),
           m_label(label),
           m_color(color) {
     DEBUG_ASSERT(m_dbId.isValid());
     if (length != 0) {
-        if (position != Cue::kNoPosition) {
-            m_sampleEndPosition = position + length;
+        if (position.isValid()) {
+            m_endPosition = position + length;
         } else {
-            m_sampleEndPosition = length;
+            m_endPosition = mixxx::audio::kStartFramePos + length;
         }
-    } else {
-        m_sampleEndPosition = Cue::kNoPosition;
     }
 }
 
@@ -78,12 +79,12 @@ Cue::Cue(
         bool setDirty)
         : m_bDirty(setDirty),
           m_type(cueInfo.getType()),
-          m_sampleStartPosition(
-                  positionMillisToSamples(
+          m_startPosition(
+                  positionMillisToFrames(
                           cueInfo.getStartPositionMillis(),
                           sampleRate)),
-          m_sampleEndPosition(
-                  positionMillisToSamples(
+          m_endPosition(
+                  positionMillisToFrames(
                           cueInfo.getEndPositionMillis(),
                           sampleRate)),
           m_iHotCue(cueInfo.getHotCueIndex() ? *cueInfo.getHotCueIndex() : kNoHotCue),
@@ -96,12 +97,12 @@ Cue::Cue(
 Cue::Cue(
         mixxx::CueType type,
         int hotCueIndex,
-        double sampleStartPosition,
-        double sampleEndPosition)
+        mixxx::audio::FramePos startPosition,
+        mixxx::audio::FramePos endPosition)
         : m_bDirty(true), // not yet in database, needs to be saved
           m_type(type),
-          m_sampleStartPosition(sampleStartPosition),
-          m_sampleEndPosition(sampleEndPosition),
+          m_startPosition(startPosition),
+          m_endPosition(endPosition),
           m_iHotCue(hotCueIndex),
           m_color(mixxx::PredefinedColorPalettes::kDefaultCueColor) {
     DEBUG_ASSERT(!m_dbId.isValid());
@@ -112,8 +113,8 @@ mixxx::CueInfo Cue::getCueInfo(
     QMutexLocker lock(&m_mutex);
     return mixxx::CueInfo(
             m_type,
-            positionSamplesToMillis(m_sampleStartPosition, sampleRate),
-            positionSamplesToMillis(m_sampleEndPosition, sampleRate),
+            positionFramesToMillis(m_startPosition, sampleRate),
+            positionFramesToMillis(m_endPosition, sampleRate),
             m_iHotCue == kNoHotCue ? std::nullopt : std::make_optional(m_iHotCue),
             m_label,
             m_color);
@@ -151,43 +152,43 @@ void Cue::setType(mixxx::CueType type) {
     emit updated();
 }
 
-double Cue::getPosition() const {
+mixxx::audio::FramePos Cue::getPosition() const {
     QMutexLocker lock(&m_mutex);
-    return m_sampleStartPosition;
+    return m_startPosition;
 }
 
-void Cue::setStartPosition(double samplePosition) {
+void Cue::setStartPosition(mixxx::audio::FramePos position) {
     QMutexLocker lock(&m_mutex);
-    if (m_sampleStartPosition == samplePosition) {
+    if (m_startPosition == position) {
         return;
     }
-    m_sampleStartPosition = samplePosition;
+    m_startPosition = position;
     m_bDirty = true;
     lock.unlock();
     emit updated();
 }
 
-void Cue::setEndPosition(double samplePosition) {
+void Cue::setEndPosition(mixxx::audio::FramePos position) {
     QMutexLocker lock(&m_mutex);
-    if (m_sampleEndPosition == samplePosition) {
+    if (m_endPosition == position) {
         return;
     }
-    m_sampleEndPosition = samplePosition;
+    m_endPosition = position;
     m_bDirty = true;
     lock.unlock();
     emit updated();
 }
 
 void Cue::setStartAndEndPosition(
-        double sampleStartPosition,
-        double sampleEndPosition) {
+        mixxx::audio::FramePos startPosition,
+        mixxx::audio::FramePos endPosition) {
     QMutexLocker lock(&m_mutex);
-    if (m_sampleStartPosition == sampleStartPosition &&
-            m_sampleEndPosition == sampleEndPosition) {
+    if (m_startPosition == startPosition &&
+            m_endPosition == endPosition) {
         return;
     }
-    m_sampleStartPosition = sampleStartPosition;
-    m_sampleEndPosition = sampleEndPosition;
+    m_startPosition = startPosition;
+    m_endPosition = endPosition;
     m_bDirty = true;
     lock.unlock();
     emit updated();
@@ -195,31 +196,31 @@ void Cue::setStartAndEndPosition(
 
 Cue::StartAndEndPositions Cue::getStartAndEndPosition() const {
     QMutexLocker lock(&m_mutex);
-    return {m_sampleStartPosition, m_sampleEndPosition};
+    return {m_startPosition, m_endPosition};
 }
 
-void Cue::shiftPositionFrames(double frameOffset) {
+void Cue::shiftPositionFrames(mixxx::audio::FrameDiff_t frameOffset) {
     QMutexLocker lock(&m_mutex);
-    if (m_sampleStartPosition != kNoPosition) {
-        m_sampleStartPosition += frameOffset * mixxx::kEngineChannelCount;
+    if (m_startPosition.isValid()) {
+        m_startPosition += frameOffset;
     }
-    if (m_sampleEndPosition != kNoPosition) {
-        m_sampleEndPosition += frameOffset * mixxx::kEngineChannelCount;
+    if (m_endPosition.isValid()) {
+        m_endPosition += frameOffset;
     }
     m_bDirty = true;
     lock.unlock();
     emit updated();
 }
 
-double Cue::getLength() const {
+mixxx::audio::FrameDiff_t Cue::getLengthFrames() const {
     QMutexLocker lock(&m_mutex);
-    if (m_sampleEndPosition == Cue::kNoPosition) {
+    if (!m_endPosition.isValid()) {
         return 0;
     }
-    if (m_sampleStartPosition == Cue::kNoPosition) {
-        return m_sampleEndPosition;
+    if (!m_startPosition.isValid()) {
+        return m_endPosition.value();
     }
-    return m_sampleEndPosition - m_sampleStartPosition;
+    return m_endPosition - m_startPosition;
 }
 
 int Cue::getHotCue() const {
@@ -269,9 +270,9 @@ void Cue::setDirty(bool dirty) {
     m_bDirty = dirty;
 }
 
-double Cue::getEndPosition() const {
+mixxx::audio::FramePos Cue::getEndPosition() const {
     QMutexLocker lock(&m_mutex);
-    return m_sampleEndPosition;
+    return m_endPosition;
 }
 
 bool operator==(const CuePosition& lhs, const CuePosition& rhs) {

--- a/src/track/cue.h
+++ b/src/track/cue.h
@@ -69,19 +69,11 @@ class Cue : public QObject {
     mixxx::audio::FramePos getPosition() const;
     void setStartPosition(mixxx::audio::FramePos position);
     void setStartPosition(double samplePosition) {
-        mixxx::audio::FramePos position;
-        if (samplePosition != Cue::kNoPosition) {
-            position = mixxx::audio::FramePos::fromEngineSamplePos(samplePosition);
-        }
-        setStartPosition(position);
+        setStartPosition(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(samplePosition));
     }
     void setEndPosition(mixxx::audio::FramePos position);
     void setEndPosition(double samplePosition) {
-        mixxx::audio::FramePos position;
-        if (samplePosition != Cue::kNoPosition) {
-            position = mixxx::audio::FramePos::fromEngineSamplePos(samplePosition);
-        }
-        setEndPosition(position);
+        setEndPosition(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(samplePosition));
     }
     void setStartAndEndPosition(
             mixxx::audio::FramePos startPosition,
@@ -89,14 +81,12 @@ class Cue : public QObject {
     void setStartAndEndPosition(
             double sampleStartPosition,
             double sampleEndPosition) {
-        mixxx::audio::FramePos startPosition;
-        mixxx::audio::FramePos endPosition;
-        if (sampleStartPosition != Cue::kNoPosition) {
-            startPosition = mixxx::audio::FramePos::fromEngineSamplePos(sampleStartPosition);
-        }
-        if (sampleEndPosition != Cue::kNoPosition) {
-            endPosition = mixxx::audio::FramePos::fromEngineSamplePos(sampleEndPosition);
-        }
+        const auto startPosition =
+                mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
+                        sampleStartPosition);
+        const auto endPosition =
+                mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
+                        sampleEndPosition);
         setStartAndEndPosition(startPosition, endPosition);
     }
     void shiftPositionFrames(mixxx::audio::FrameDiff_t frameOffset);

--- a/src/track/cue.h
+++ b/src/track/cue.h
@@ -29,8 +29,8 @@ class Cue : public QObject {
             "Conflicting definitions of invalid and first hot cue index");
 
     struct StartAndEndPositions {
-        double startPosition;
-        double endPosition;
+        mixxx::audio::FramePos startPosition;
+        mixxx::audio::FramePos endPosition;
     };
 
     Cue() = delete;
@@ -45,8 +45,8 @@ class Cue : public QObject {
     Cue(
             DbId id,
             mixxx::CueType type,
-            double position,
-            double length,
+            mixxx::audio::FramePos position,
+            mixxx::audio::FrameDiff_t length,
             int hotCue,
             const QString& label,
             mixxx::RgbColor color);
@@ -55,8 +55,8 @@ class Cue : public QObject {
     Cue(
             mixxx::CueType type,
             int hotCueIndex,
-            double sampleStartPosition,
-            double sampleEndPosition);
+            mixxx::audio::FramePos startPosition,
+            mixxx::audio::FramePos endPosition);
 
     ~Cue() override = default;
 
@@ -66,17 +66,42 @@ class Cue : public QObject {
     mixxx::CueType getType() const;
     void setType(mixxx::CueType type);
 
-    double getPosition() const;
-    void setStartPosition(
-            double samplePosition);
-    void setEndPosition(
-            double samplePosition);
+    mixxx::audio::FramePos getPosition() const;
+    void setStartPosition(mixxx::audio::FramePos position);
+    void setStartPosition(double samplePosition) {
+        mixxx::audio::FramePos position;
+        if (samplePosition != Cue::kNoPosition) {
+            position = mixxx::audio::FramePos::fromEngineSamplePos(samplePosition);
+        }
+        setStartPosition(position);
+    }
+    void setEndPosition(mixxx::audio::FramePos position);
+    void setEndPosition(double samplePosition) {
+        mixxx::audio::FramePos position;
+        if (samplePosition != Cue::kNoPosition) {
+            position = mixxx::audio::FramePos::fromEngineSamplePos(samplePosition);
+        }
+        setEndPosition(position);
+    }
+    void setStartAndEndPosition(
+            mixxx::audio::FramePos startPosition,
+            mixxx::audio::FramePos endPosition);
     void setStartAndEndPosition(
             double sampleStartPosition,
-            double sampleEndPosition);
-    void shiftPositionFrames(double frameOffset);
+            double sampleEndPosition) {
+        mixxx::audio::FramePos startPosition;
+        mixxx::audio::FramePos endPosition;
+        if (sampleStartPosition != Cue::kNoPosition) {
+            startPosition = mixxx::audio::FramePos::fromEngineSamplePos(sampleStartPosition);
+        }
+        if (sampleEndPosition != Cue::kNoPosition) {
+            endPosition = mixxx::audio::FramePos::fromEngineSamplePos(sampleEndPosition);
+        }
+        setStartAndEndPosition(startPosition, endPosition);
+    }
+    void shiftPositionFrames(mixxx::audio::FrameDiff_t frameOffset);
 
-    double getLength() const;
+    mixxx::audio::FrameDiff_t getLengthFrames() const;
 
     int getHotCue() const;
 
@@ -86,7 +111,7 @@ class Cue : public QObject {
     mixxx::RgbColor getColor() const;
     void setColor(mixxx::RgbColor color);
 
-    double getEndPosition() const;
+    mixxx::audio::FramePos getEndPosition() const;
 
     StartAndEndPositions getStartAndEndPosition() const;
 
@@ -106,8 +131,8 @@ class Cue : public QObject {
     bool m_bDirty;
     DbId m_dbId;
     mixxx::CueType m_type;
-    double m_sampleStartPosition;
-    double m_sampleEndPosition;
+    mixxx::audio::FramePos m_startPosition;
+    mixxx::audio::FramePos m_endPosition;
     const int m_iHotCue;
     QString m_label;
     mixxx::RgbColor m_color;

--- a/src/track/cue.h
+++ b/src/track/cue.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <type_traits> // static_assert
 
+#include "audio/frame.h"
 #include "audio/types.h"
 #include "track/cueinfo.h"
 #include "util/color/rgbcolor.h"
@@ -114,6 +115,10 @@ class Cue : public QObject {
     friend class Track;
     friend class CueDAO;
 };
+
+static_assert(mixxx::audio::FramePos::kLegacyInvalidEnginePosition ==
+                Cue::kNoPosition,
+        "Invalid engine position value mismatch");
 
 class CuePointer : public std::shared_ptr<Cue> {
   public:

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -880,8 +880,8 @@ void Track::setCuePoint(CuePosition cue) {
             pLoadCue = CuePointer(new Cue(
                     mixxx::CueType::MainCue,
                     Cue::kNoHotCue,
-                    position,
-                    Cue::kNoPosition));
+                    mixxx::audio::FramePos::fromEngineSamplePos(position),
+                    mixxx::audio::kInvalidFramePos));
             // While this method could be called from any thread,
             // associated Cue objects should always live on the
             // same thread as their host, namely this->thread().
@@ -937,8 +937,8 @@ CuePointer Track::createAndAddCue(
     CuePointer pCue(new Cue(
             type,
             hotCueIndex,
-            sampleStartPosition,
-            sampleEndPosition));
+            mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(sampleStartPosition),
+            mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(sampleEndPosition)));
     // While this method could be called from any thread,
     // associated Cue objects should always live on the
     // same thread as their host, namely this->thread().
@@ -1187,7 +1187,7 @@ bool Track::setCuePointsWhileLocked(const QList<CuePointer>& cuePoints) {
                 this,
                 &Track::slotCueUpdated);
         if (pCue->getType() == mixxx::CueType::MainCue) {
-            m_record.setCuePoint(CuePosition(pCue->getPosition()));
+            m_record.setCuePoint(CuePosition(pCue->getPosition().toEngineSamplePosMaybeInvalid()));
         }
     }
     return true;

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -262,12 +262,24 @@ class Track : public QObject {
     ConstWaveformPointer getWaveformSummary() const;
     void setWaveformSummary(ConstWaveformPointer pWaveform);
 
-    // Get the track's main cue point
-    CuePosition getCuePoint() const;
+    /// Get the track's main cue point
+    mixxx::audio::FramePos getMainCuePosition() const;
+    CuePosition getCuePoint() const {
+        const auto position = getMainCuePosition();
+        if (!position.isValid()) {
+            return {};
+        }
+        return {position.toEngineSamplePos()};
+    };
     // Set the track's main cue point
-    void setCuePoint(CuePosition cue);
+    void setMainCuePosition(mixxx::audio::FramePos position);
+    void setCuePoint(CuePosition position) {
+        setMainCuePosition(
+                mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
+                        position.getPosition()));
+    }
     /// Shift all cues by a constant offset
-    void shiftCuePositionsMillis(double milliseconds);
+    void shiftCuePositionsMillis(mixxx::audio::FrameDiff_t milliseconds);
     // Call when analysis is done.
     void analysisFinished();
 
@@ -275,8 +287,20 @@ class Track : public QObject {
     CuePointer createAndAddCue(
             mixxx::CueType type,
             int hotCueIndex,
-            double sampleStartPosition,
-            double sampleEndPosition);
+            mixxx::audio::FramePos startPosition,
+            mixxx::audio::FramePos endPosition);
+    CuePointer createAndAddCue(
+            mixxx::CueType type,
+            int hotCueIndex,
+            double startPositionSamples,
+            double endPositionSamples) {
+        return createAndAddCue(type,
+                hotCueIndex,
+                mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
+                        startPositionSamples),
+                mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
+                        endPositionSamples));
+    }
     CuePointer findCueByType(mixxx::CueType type) const; // NOTE: Cannot be used for hotcues.
     CuePointer findCueById(DbId id) const;
     void removeCue(const CuePointer& pCue);

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -265,11 +265,7 @@ class Track : public QObject {
     /// Get the track's main cue point
     mixxx::audio::FramePos getMainCuePosition() const;
     CuePosition getCuePoint() const {
-        const auto position = getMainCuePosition();
-        if (!position.isValid()) {
-            return {};
-        }
-        return {position.toEngineSamplePos()};
+        return getMainCuePosition().toEngineSamplePosMaybeInvalid();
     };
     // Set the track's main cue point
     void setMainCuePosition(mixxx::audio::FramePos position);

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -15,6 +15,7 @@ const Logger kLogger("TrackRecord");
 
 TrackRecord::TrackRecord(TrackId id)
         : m_id(std::move(id)),
+          m_mainCuePosition(mixxx::audio::kStartFramePos),
           m_rating(0),
           m_bpmLocked(false),
           m_headerParsed(false) {
@@ -321,7 +322,7 @@ bool operator==(const TrackRecord& lhs, const TrackRecord& rhs) {
             lhs.getUrl() == rhs.getUrl() &&
             lhs.getPlayCounter() == rhs.getPlayCounter() &&
             lhs.getColor() == rhs.getColor() &&
-            lhs.getCuePoint() == rhs.getCuePoint() &&
+            lhs.getMainCuePosition() == rhs.getMainCuePosition() &&
             lhs.getBpmLocked() == rhs.getBpmLocked() &&
             lhs.getKeys() == rhs.getKeys() &&
             lhs.getRating() == rhs.getRating() &&

--- a/src/track/trackrecord.h
+++ b/src/track/trackrecord.h
@@ -52,7 +52,7 @@ class TrackRecord final {
     MIXXX_DECL_PROPERTY(QString, url, Url)
     MIXXX_DECL_PROPERTY(PlayCounter, playCounter, PlayCounter)
     MIXXX_DECL_PROPERTY(RgbColor::optional_t, color, Color)
-    MIXXX_DECL_PROPERTY(CuePosition, cuePoint, CuePoint)
+    MIXXX_DECL_PROPERTY(mixxx::audio::FramePos, mainCuePosition, MainCuePosition)
     MIXXX_DECL_PROPERTY(int, rating, Rating)
     MIXXX_DECL_PROPERTY(bool, bpmLocked, BpmLocked)
 

--- a/src/widget/wcuemenupopup.cpp
+++ b/src/widget/wcuemenupopup.cpp
@@ -83,13 +83,11 @@ void WCueMenuPopup::setTrackAndCue(TrackPointer pTrack, const CuePointer& pCue) 
 
         QString positionText = "";
         Cue::StartAndEndPositions pos = m_pCue->getStartAndEndPosition();
-        if (pos.startPosition != Cue::kNoPosition) {
-            double startPositionSeconds = pos.startPosition /
-                    m_pTrack->getSampleRate() / mixxx::kEngineChannelCount;
+        if (pos.startPosition.isValid()) {
+            double startPositionSeconds = pos.startPosition.value() / m_pTrack->getSampleRate();
             positionText = mixxx::Duration::formatTime(startPositionSeconds, mixxx::Duration::Precision::CENTISECONDS);
-            if (pos.endPosition != Cue::kNoPosition) {
-                double endPositionSeconds = pos.endPosition /
-                        m_pTrack->getSampleRate() / mixxx::kEngineChannelCount;
+            if (pos.endPosition.isValid()) {
+                double endPositionSeconds = pos.endPosition.value() / m_pTrack->getSampleRate();
                 positionText = QString("%1 - %2").arg(
                     positionText,
                     mixxx::Duration::formatTime(endPositionSeconds, mixxx::Duration::Precision::CENTISECONDS)


### PR DESCRIPTION
This duplicates the Cue related methods in order to support Frame positions. This allows migrating the individual parts of the code individually instead of all at once. The original sample-based methods will be removed in #4061.