### PR TITLE
Fix wrong base tag used for deployment and displayed in About dialog

### DIFF
--- a/cmake/modules/GitInfo.cmake
+++ b/cmake/modules/GitInfo.cmake
@@ -1,7 +1,7 @@
 # Get the current commit ref
 if(NOT GIT_DESCRIBE)
   execute_process(
-    COMMAND git describe --tags --always --dirty=-modified
+    COMMAND git describe --tags --always --first-parent --dirty=-modified
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     OUTPUT_VARIABLE GIT_DESCRIBE
     OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -68,7 +68,13 @@ def git_info(info, path="."):
     elif info == "describe":
         # A dirty git state should only be possible on local builds, but since
         # this script may be used locally we'll add it here.
-        cmd = ("git", "describe", "--always", "--dirty=-modified")
+        cmd = (
+            "git",
+            "describe",
+            "--always",
+            "--first-parent",
+            "--dirty=-modified",
+        )
     else:
         raise ValueError("Invalid git info type!")
 


### PR DESCRIPTION
By default, `git describe` shows the number of commits from the latest
tag in the git history. In our case we don't want that, because this can
cause problems:

            2.4-alpha              Expected: 2.4-alpha-N-abcdef123
    main ---+X---------------+---> Actual: 2.3.0-M-abcdef456
             \              /
              X------------X--->
             2.3-beta     2.3.0

Hence, we need to add the `--first-parent` flag to git describe, so that
it only follows the first parent of a merge and does not pull in tags
from another branch.

Fixes mixxxdj/website#248.

See the issue for details: https://github.com/mixxxdj/website/issues/248