### PR TITLE
Traktor S3: Disable scratch when switching decks to prevent locked scratch issue

### DIFF
--- a/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
@@ -165,6 +165,7 @@ TraktorS3.Deck = function(controller, deckNumber, group) {
     this.deckNumber = deckNumber;
     this.group = group;
     this.activeChannel = "[Channel" + deckNumber + "]";
+    this.previousActiveChannel = undefined;
     // When true, touching the wheel enables scratch mode.  When off, touching the wheel
     // has no special effect
     this.jogToggled = TraktorS3.JogDefaultOn;
@@ -200,6 +201,7 @@ TraktorS3.Deck.prototype.activateChannel = function(channel) {
         HIDDebug("Programming ERROR: tried to activate a channel with a deck that is not its parent");
         return;
     }
+    this.previousActiveChannel = this.activeChannel;
     this.activeChannel = channel.group;
     engine.softTakeoverIgnoreNextValue(this.activeChannel, "rate");
     this.controller.lightDeck(this.activeChannel);
@@ -1791,15 +1793,15 @@ TraktorS3.Controller.prototype.deckSwitchHandler = function(field) {
         return;
     }
 
-    var isScratching = engine.getValue(this.activeChannel, "scratch2_enable");
-    if (isScratching) {
-        engine.setValue(this.activeChannel, "scratch2", 0.0);
-        engine.setValue(this.activeChannel, "scratch2_enable", false);
-    }
-
     var channel = this.Channels[field.group];
     var deck = channel.parentDeck;
     deck.activateChannel(channel);
+
+    var isScratching = engine.getValue(deck.previousActiveChannel, "scratch2_enable");
+    if (isScratching) {
+        engine.setValue(deck.previousActiveChannel, "scratch2", 0.0);
+        engine.setValue(deck.previousActiveChannel, "scratch2_enable", false);
+    }
 };
 
 TraktorS3.Controller.prototype.extModeHandler = function(field) {

--- a/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
@@ -165,7 +165,6 @@ TraktorS3.Deck = function(controller, deckNumber, group) {
     this.deckNumber = deckNumber;
     this.group = group;
     this.activeChannel = "[Channel" + deckNumber + "]";
-    this.previousActiveChannel = undefined;
     // When true, touching the wheel enables scratch mode.  When off, touching the wheel
     // has no special effect
     this.jogToggled = TraktorS3.JogDefaultOn;
@@ -201,7 +200,6 @@ TraktorS3.Deck.prototype.activateChannel = function(channel) {
         HIDDebug("Programming ERROR: tried to activate a channel with a deck that is not its parent");
         return;
     }
-    this.previousActiveChannel = this.activeChannel;
     this.activeChannel = channel.group;
     engine.softTakeoverIgnoreNextValue(this.activeChannel, "rate");
     this.controller.lightDeck(this.activeChannel);
@@ -1795,13 +1793,14 @@ TraktorS3.Controller.prototype.deckSwitchHandler = function(field) {
 
     var channel = this.Channels[field.group];
     var deck = channel.parentDeck;
-    deck.activateChannel(channel);
 
-    var isScratching = engine.getValue(deck.previousActiveChannel, "scratch2_enable");
+    var isScratching = engine.getValue(deck.activeChannel, "scratch2_enable");
     if (isScratching) {
-        engine.setValue(deck.previousActiveChannel, "scratch2", 0.0);
-        engine.setValue(deck.previousActiveChannel, "scratch2_enable", false);
+        engine.setValue(deck.activeChannel, "scratch2", 0.0);
+        engine.setValue(deck.activeChannel, "scratch2_enable", false);
     }
+
+    deck.activateChannel(channel);
 };
 
 TraktorS3.Controller.prototype.extModeHandler = function(field) {

--- a/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
@@ -1791,6 +1791,12 @@ TraktorS3.Controller.prototype.deckSwitchHandler = function(field) {
         return;
     }
 
+    var isScratching = engine.getValue(this.activeChannel, "scratch2_enable");
+    if (isScratching) {
+        engine.setValue(this.activeChannel, "scratch2", 0.0);
+        engine.setValue(this.activeChannel, "scratch2_enable", false);
+    }
+
     var channel = this.Channels[field.group];
     var deck = channel.parentDeck;
     deck.activateChannel(channel);


### PR DESCRIPTION
Hi there,

I have been using the Traktor S3 controller mappings and have come across this sneaky bug. Steps to reproduce below:

1. Start any song you like and perform a spin in whichever direction you feel like
2. quickly swap decks and you will find the previous deck is kept in scratch mode

This happens due to ```TraktorS3.Deck.prototype.checkJogInertia``` function using ```this.activeChannel``` which is now different than the previous active channel. Traktor DJ Pro works the same way as in if you perform a spin in any direction and swap decks it interrupts the current spinning deck. 

Thanks Mixxx Dev for building such an amazing software!!!!

Thanks,
Eva