### PR TITLE
Add support for test coverage information

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -19,9 +19,6 @@ jobs:
       uses: actions/checkout@v2
     - name: Install build dependencies
       run: tools/debian_buildenv.sh setup
-    - name: "Install cpp-coveralls"
-      if: matrix.name == 'coverage'
-      run: pip install cpp-coveralls
     - name: Create build directory
       run: mkdir build
     - name: Configure (clazy)
@@ -122,7 +119,21 @@ jobs:
         CTEST_OUTPUT_ON_FAILURE: 1
     - name: "Generate Coverage Report"
       if: matrix.name == 'coverage'
-      run: coveralls --root .. --exclude lib --exclude src/test --exclude build --gcov-options '\-lp'
+      run: >-
+        lcov
+        --capture
+        --directory .
+        --base-directory ..
+        --include "${PWD%/*}/src/*"
+        --exclude "${PWD%/*}/src/test/*"
+        --exclude "${PWD%/*}/build/*"
+        --exclude "${PWD%/*}/lib/*"
+        --output-file lcov.info
       working-directory: build
-      env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+    - name: "Upload Coverage Report to coveralls.io"
+      if: matrix.name == 'coverage'
+      uses: coverallsapp/github-action@master
+      with:
+        flag-name: ubuntu-20.04
+        path-to-lcov: build/lcov.info
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -11,6 +11,7 @@ jobs:
         include:
           - name: clazy
           - name: clang-tidy
+          - name: coverage
     runs-on: ubuntu-20.04
     name: ${{ matrix.name }}
     steps:
@@ -18,6 +19,9 @@ jobs:
       uses: actions/checkout@v2
     - name: Install build dependencies
       run: tools/debian_buildenv.sh setup
+    - name: "Install cpp-coveralls"
+      if: matrix.name == 'coverage'
+      run: pip install cpp-coveralls
     - name: Create build directory
       run: mkdir build
     - name: Configure (clazy)
@@ -71,6 +75,31 @@ jobs:
           -DWAVPACK=ON \
           ..
       working-directory: build
+    - name: Configure (coverage)
+      if: matrix.name == 'coverage'
+      run: |
+        cmake \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DOPTIMIZE=off \
+          -DCOVERAGE=ON \
+          -DWARNINGS_FATAL=OFF \
+          -DDEBUG_ASSERTIONS_FATAL=OFF \
+          -DBATTERY=ON \
+          -DBROADCAST=ON \
+          -DBULK=ON \
+          -DHID=ON \
+          -DLILV=ON \
+          -DOPUS=ON \
+          -DQTKEYCHAIN=ON \
+          -DVINYLCONTROL=ON \
+          -DFFMPEG=ON \
+          -DKEYFINDER=ON \
+          -DLOCALECOMPARE=ON \
+          -DMAD=ON \
+          -DMODPLUG=ON \
+          -DWAVPACK=ON \
+          ..
+      working-directory: build
     - name: Set up problem matcher
       uses: ammaraskar/gcc-problem-matcher@master
     - name: Build
@@ -80,3 +109,20 @@ jobs:
       env:
         CLAZY_CHECKS: level2,no-rule-of-two-soft,no-non-pod-global-static,no-qproperty-without-notify,no-wrong-qevent-cast,no-qstring-allocations,no-function-args-by-value,no-copyable-polymorphic,no-ctor-missing-parent-argument,no-missing-qobject-macro,no-rule-of-three,no-returning-void-expression,no-missing-typeinfo,no-base-class-event
         CLAZY_IGNORE_DIRS: lib/.*
+    - name: "Test"
+      if: matrix.name == 'coverage'
+      run: ctest --timeout 45
+      working-directory: build
+      env:
+        # Render analyzer waveform tests to an offscreen buffer
+        QT_QPA_PLATFORM: ${{ matrix.qt_qpa_platform }}
+        GTEST_COLOR: 1
+        # Only use single thread to prevent *.gcna files from overwriting each other
+        CTEST_PARALLEL_LEVEL: 1
+        CTEST_OUTPUT_ON_FAILURE: 1
+    - name: "Generate Coverage Report"
+      if: matrix.name == 'coverage'
+      run: coveralls --root .. --exclude lib --exclude src/test --exclude build --gcov-options '\-lp'
+      working-directory: build
+      env:
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,16 @@ if(NOT BUILD_LOW_MEMORY)
   add_compile_options(-pipe)
 endif()
 
+# Coverage
+#
+# This is only available with GCC, therefore this option is forcibly set to OFF
+# for all other compilers.
+cmake_dependent_option(COVERAGE "Coverage (i.e. gcov) support" OFF "GNU_GCC" OFF)
+if(COVERAGE)
+  add_compile_options(--coverage -fprofile-arcs -ftest-coverage)
+  add_link_options(--coverage -fprofile-arcs -ftest-coverage)
+endif()
+
 # Profiling
 #
 # This is only available on Linux, therefore this option is forcibly set to OFF

--- a/tools/debian_buildenv.sh
+++ b/tools/debian_buildenv.sh
@@ -47,6 +47,7 @@ case "$1" in
             fonts-open-sans \
             fonts-ubuntu \
             g++ \
+            lcov \
             libchromaprint-dev \
             libdistro-info-perl \
             libebur128-dev \


### PR DESCRIPTION
Add support for determining test coverage and adds support for coveralls.io.

I ran this on my own fork, here's the result: https://coveralls.io/builds/41212778

Resolves #3149.