### PR TITLE
Fix bad phase seek when starting from preroll.

### DIFF
--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -812,9 +812,11 @@ double BpmControl::getBeatMatchPosition(
     }
     if (playing) {
         if (!pOtherEngineBuffer || pOtherEngineBuffer->getSpeed() == 0.0) {
-            // "this" track is playing, or just starting
-            // only match phase if the sync target is playing as well
-            // else use the previous phase of "this" track before the seek
+            // "this" track is playing, or just starting.
+            // Only match phase if the sync target is playing as well,
+            // otherwise use the previous phase of "this" track before the seek.
+            // This occurs when the DJ does a quantized seek -- we preserve
+            // the exact beat distance.
             pOtherEngineBuffer = getEngineBuffer();
         }
     } else if (!pOtherEngineBuffer) {

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1353,14 +1353,10 @@ void EngineBuffer::slotEjectTrack(double v) {
 }
 
 double EngineBuffer::getExactPlayPos() {
-    double visualPlayPos = getVisualPlayPos();
-    if (visualPlayPos > 0) {
-        return getVisualPlayPos() * getTrackSamples();
-    } else {
-        // Track was just loaded and the first buffer was not processed yet.
-        // assume it is at 0:00
+    if (!m_visualPlayPos->isValid()) {
         return 0.0;
     }
+    return m_visualPlayPos->getEnginePlayPos() * getTrackSamples();
 }
 
 double EngineBuffer::getVisualPlayPos() {

--- a/src/waveform/visualplayposition.h
+++ b/src/waveform/visualplayposition.h
@@ -60,6 +60,9 @@ class VisualPlayPosition : public QObject {
     static void setCallbackEntryToDacSecs(double secs, const PerformanceTimer& time);
 
     void setInvalid() { m_valid = false; };
+    bool isValid() const {
+        return m_valid;
+    }
 
   private slots:
     void slotAudioBufferSizeChanged(double sizeMs);


### PR DESCRIPTION
We were interpreting all <0 playposition as "invalid", which is not correct.
fixes https://bugs.launchpad.net/mixxx/+bug/1930143