### PR TITLE
lp1935703: Use nearest frame boundary in lookupBeatPositions()

### DIFF
--- a/src/audio/frame.h
+++ b/src/audio/frame.h
@@ -109,6 +109,12 @@ class FramePos final {
         return FramePos(std::floor(value()));
     }
 
+    /// Return position rounded to the next upper full frame position, without
+    /// the fractional part.
+    [[nodiscard]] FramePos toUpperFrameBoundary() const {
+        return FramePos(std::ceil(value()));
+    }
+
     /// Return position rounded to the nearest full frame position, without
     /// the fractional part.
     [[nodiscard]] FramePos toNearestFrameBoundary() const {

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -10,7 +10,7 @@ using namespace mixxx;
 
 namespace {
 
-int countBeatsInIterator(std::unique_ptr<BeatIterator> pIterator) {
+int countRemainingBeats(std::unique_ptr<BeatIterator> pIterator) {
     int numBeatsFound = 0;
     while (pIterator->hasNext()) {
         pIterator->next();
@@ -351,34 +351,34 @@ TEST_F(BeatMapTest, FindBeatsWithFractionalPos) {
 
     // All beats are in range
     auto it = pMap->findBeats(mixxx::audio::kStartFramePos, lastBeatPos);
-    int numBeatsFound = countBeatsInIterator(std::move(it));
+    int numBeatsFound = countRemainingBeats(std::move(it));
     EXPECT_EQ(numBeats, numBeatsFound);
 
     // Only half the beats are in range
     const auto halfBeatsPosition = mixxx::audio::kStartFramePos +
             beatLengthFrames * ((numBeats / 2) - 1);
     it = pMap->findBeats(mixxx::audio::kStartFramePos, halfBeatsPosition);
-    numBeatsFound = countBeatsInIterator(std::move(it));
+    numBeatsFound = countRemainingBeats(std::move(it));
     EXPECT_EQ(numBeats / 2, numBeatsFound);
 
     // First beat is not in range
     it = pMap->findBeats(mixxx::audio::kStartFramePos + 0.5, lastBeatPos + 0.5);
-    numBeatsFound = countBeatsInIterator(std::move(it));
+    numBeatsFound = countRemainingBeats(std::move(it));
     EXPECT_EQ(numBeats - 1, numBeatsFound);
 
     // Last beat is not in range
     it = pMap->findBeats(mixxx::audio::kStartFramePos - 0.5, lastBeatPos - 0.5);
-    numBeatsFound = countBeatsInIterator(std::move(it));
+    numBeatsFound = countRemainingBeats(std::move(it));
     EXPECT_EQ(numBeats - 1, numBeatsFound);
 
     // All beats are in range
     it = pMap->findBeats(mixxx::audio::kStartFramePos - 0.5, lastBeatPos + 0.5);
-    numBeatsFound = countBeatsInIterator(std::move(it));
+    numBeatsFound = countRemainingBeats(std::move(it));
     EXPECT_EQ(numBeats, numBeatsFound);
 
     // First and last beats in range
     it = pMap->findBeats(mixxx::audio::kStartFramePos + 0.5, lastBeatPos - 0.5);
-    numBeatsFound = countBeatsInIterator(std::move(it));
+    numBeatsFound = countRemainingBeats(std::move(it));
     EXPECT_EQ(numBeats - 2, numBeatsFound);
 }
 

--- a/src/test/frametest.cpp
+++ b/src/test/frametest.cpp
@@ -78,3 +78,31 @@ TEST_F(FrameTest, LowerFrameBoundary) {
     EXPECT_EQ(mixxx::audio::FramePos(-101), mixxx::audio::FramePos(-100.1).toLowerFrameBoundary());
     EXPECT_EQ(mixxx::audio::FramePos(-101), mixxx::audio::FramePos(-100.9).toLowerFrameBoundary());
 }
+
+TEST_F(FrameTest, UpperFrameBoundary) {
+    EXPECT_EQ(mixxx::audio::FramePos(0), mixxx::audio::FramePos(0).toUpperFrameBoundary());
+    EXPECT_EQ(mixxx::audio::FramePos(1), mixxx::audio::FramePos(0.5).toUpperFrameBoundary());
+    EXPECT_EQ(mixxx::audio::FramePos(1), mixxx::audio::FramePos(0.9).toUpperFrameBoundary());
+    EXPECT_EQ(mixxx::audio::FramePos(100), mixxx::audio::FramePos(100).toUpperFrameBoundary());
+    EXPECT_EQ(mixxx::audio::FramePos(101), mixxx::audio::FramePos(100.1).toUpperFrameBoundary());
+    EXPECT_EQ(mixxx::audio::FramePos(101), mixxx::audio::FramePos(100.9).toUpperFrameBoundary());
+    EXPECT_EQ(mixxx::audio::FramePos(-99), mixxx::audio::FramePos(-99.9).toUpperFrameBoundary());
+    EXPECT_EQ(mixxx::audio::FramePos(-99), mixxx::audio::FramePos(-99.1).toUpperFrameBoundary());
+    EXPECT_EQ(mixxx::audio::FramePos(-100), mixxx::audio::FramePos(-100.1).toUpperFrameBoundary());
+    EXPECT_EQ(mixxx::audio::FramePos(-100), mixxx::audio::FramePos(-100.9).toUpperFrameBoundary());
+}
+
+TEST_F(FrameTest, NearestFrameBoundary) {
+    EXPECT_EQ(mixxx::audio::FramePos(0), mixxx::audio::FramePos(0).toNearestFrameBoundary());
+    EXPECT_EQ(mixxx::audio::FramePos(1), mixxx::audio::FramePos(0.5).toNearestFrameBoundary());
+    EXPECT_EQ(mixxx::audio::FramePos(1), mixxx::audio::FramePos(0.9).toNearestFrameBoundary());
+    EXPECT_EQ(mixxx::audio::FramePos(100), mixxx::audio::FramePos(100).toNearestFrameBoundary());
+    EXPECT_EQ(mixxx::audio::FramePos(100), mixxx::audio::FramePos(100.1).toNearestFrameBoundary());
+    EXPECT_EQ(mixxx::audio::FramePos(101), mixxx::audio::FramePos(100.9).toNearestFrameBoundary());
+    EXPECT_EQ(mixxx::audio::FramePos(-100), mixxx::audio::FramePos(-99.9).toNearestFrameBoundary());
+    EXPECT_EQ(mixxx::audio::FramePos(-99), mixxx::audio::FramePos(-99.1).toNearestFrameBoundary());
+    EXPECT_EQ(mixxx::audio::FramePos(-100),
+            mixxx::audio::FramePos(-100.1).toNearestFrameBoundary());
+    EXPECT_EQ(mixxx::audio::FramePos(-101),
+            mixxx::audio::FramePos(-100.9).toNearestFrameBoundary());
+}

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -32,7 +32,7 @@ inline Beat beatFromFramePos(mixxx::audio::FramePos beatPosition) {
     return beat;
 }
 
-bool beatLessThan(const Beat& beat1, const Beat& beat2) {
+inline bool beatLessThan(const Beat& beat1, const Beat& beat2) {
     return beat1.frame_position() < beat2.frame_position();
 }
 

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -32,7 +32,7 @@ inline Beat beatFromFramePos(mixxx::audio::FramePos beatPosition) {
     return beat;
 }
 
-bool BeatLessThan(const Beat& beat1, const Beat& beat2) {
+bool beatLessThan(const Beat& beat1, const Beat& beat2) {
     return beat1.frame_position() < beat2.frame_position();
 }
 
@@ -319,7 +319,7 @@ audio::FramePos BeatMap::findNthBeat(audio::FramePos position, int n) const {
 
     // it points at the first occurrence of beat or the next largest beat
     BeatList::const_iterator it =
-            std::lower_bound(m_beats.constBegin(), m_beats.constEnd(), beat, BeatLessThan);
+            std::lower_bound(m_beats.constBegin(), m_beats.constEnd(), beat, beatLessThan);
 
     // If the position is within 1/10th of a second of the next or previous
     // beat, pretend we are on that beat.
@@ -405,7 +405,7 @@ bool BeatMap::findPrevNextBeats(audio::FramePos position,
 
     // it points at the first occurrence of beat or the next largest beat
     BeatList::const_iterator it =
-            std::lower_bound(m_beats.constBegin(), m_beats.constEnd(), beat, BeatLessThan);
+            std::lower_bound(m_beats.constBegin(), m_beats.constEnd(), beat, beatLessThan);
 
     // If the position is within 1/10th of a second of the next or previous
     // beat, pretend we are on that beat.
@@ -485,11 +485,10 @@ std::unique_ptr<BeatIterator> BeatMap::findBeats(
     Beat endBeat = beatFromFramePos(endPosition.toLowerFrameBoundary());
 
     BeatList::const_iterator curBeat =
-            std::lower_bound(m_beats.constBegin(), m_beats.constEnd(),
-                        startBeat, BeatLessThan);
+            std::lower_bound(m_beats.constBegin(), m_beats.constEnd(), startBeat, beatLessThan);
 
     BeatList::const_iterator lastBeat =
-            std::upper_bound(m_beats.constBegin(), m_beats.constEnd(), endBeat, BeatLessThan);
+            std::upper_bound(m_beats.constBegin(), m_beats.constEnd(), endBeat, beatLessThan);
 
     if (curBeat >= lastBeat) {
         return std::unique_ptr<BeatIterator>();

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -503,6 +503,12 @@ bool BeatMap::hasBeatInRange(audio::FramePos startPosition, audio::FramePos endP
         return false;
     }
     audio::FramePos beatPosition = findNextBeat(startPosition.toUpperFrameBoundary());
+
+    // FIXME: The following assertion should always hold true, but it doesn't,
+    // because the position matching in findNthBeat() is fuzzy. This should be
+    // resolved, and moved to the calling code, to only use fuzzy matches when
+    // actually desired.
+    // DEBUG_ASSERT(beatPosition >= startPosition.toUpperFrameBoundary());
     if (beatPosition.isValid() && beatPosition <= endPosition.toLowerFrameBoundary()) {
         return true;
     }

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -508,7 +508,7 @@ bool BeatMap::hasBeatInRange(audio::FramePos startPosition, audio::FramePos endP
     // because the position matching in findNthBeat() is fuzzy. This should be
     // resolved, and moved to the calling code, to only use fuzzy matches when
     // actually desired.
-    // DEBUG_ASSERT(beatPosition >= startPosition.toUpperFrameBoundary());
+    // DEBUG_ASSERT(!beatPosition.isValid() || beatPosition >= startPosition.toUpperFrameBoundary());
     if (beatPosition.isValid() && beatPosition <= endPosition.toLowerFrameBoundary()) {
         return true;
     }

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -503,8 +503,8 @@ bool BeatMap::hasBeatInRange(audio::FramePos startPosition, audio::FramePos endP
             startPosition > endPosition) {
         return false;
     }
-    audio::FramePos beatPosition = findNextBeat(startPosition);
-    if (beatPosition <= endPosition) {
+    audio::FramePos beatPosition = findNextBeat(startPosition.toUpperFrameBoundary());
+    if (beatPosition.isValid() && beatPosition <= endPosition.toLowerFrameBoundary()) {
         return true;
     }
     return false;

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -481,6 +481,11 @@ std::unique_ptr<BeatIterator> BeatMap::findBeats(
         return std::unique_ptr<BeatIterator>();
     }
 
+    // Beats can only appear a full frame positions. If the start position is
+    // fractional, it needs to be rounded up to avoid finding a beat that
+    // appears *before* the requested start position. For the end position, the
+    // opposite applies, i.e. we need to round down to avoid finding a beat
+    // *after* the requested end position.
     Beat startBeat = beatFromFramePos(startPosition.toUpperFrameBoundary());
     Beat endBeat = beatFromFramePos(endPosition.toLowerFrameBoundary());
 

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -315,7 +315,7 @@ audio::FramePos BeatMap::findNthBeat(audio::FramePos position, int n) const {
         return audio::kInvalidFramePos;
     }
 
-    Beat beat = beatFromFramePos(position);
+    Beat beat = beatFromFramePos(position.toNearestFrameBoundary());
 
     // it points at the first occurrence of beat or the next largest beat
     BeatList::const_iterator it =
@@ -401,7 +401,7 @@ bool BeatMap::findPrevNextBeats(audio::FramePos position,
         return false;
     }
 
-    Beat beat = beatFromFramePos(position);
+    Beat beat = beatFromFramePos(position.toNearestFrameBoundary());
 
     // it points at the first occurrence of beat or the next largest beat
     BeatList::const_iterator it =
@@ -481,8 +481,8 @@ std::unique_ptr<BeatIterator> BeatMap::findBeats(
         return std::unique_ptr<BeatIterator>();
     }
 
-    Beat startBeat = beatFromFramePos(startPosition);
-    Beat endBeat = beatFromFramePos(endPosition);
+    Beat startBeat = beatFromFramePos(startPosition.toUpperFrameBoundary());
+    Beat endBeat = beatFromFramePos(endPosition.toLowerFrameBoundary());
 
     BeatList::const_iterator curBeat =
             std::lower_bound(m_beats.constBegin(), m_beats.constEnd(),


### PR DESCRIPTION
Beat searches using fractional positions should be allowed, only saving
fractional positions should cause a debug assertion. This should fix the
issue reported here: https://bugs.launchpad.net/mixxx/+bug/1935703/comments/6