### PR TITLE
mixxxlibraryfeature: remove wrong ENGINE_PRIME ifdef

### DIFF
--- a/src/library/mixxxlibraryfeature.h
+++ b/src/library/mixxxlibraryfeature.h
@@ -16,9 +16,7 @@
 #include "library/libraryfeature.h"
 #include "library/treeitemmodel.h"
 #include "preferences/usersettings.h"
-#ifdef __ENGINEPRIME__
 #include "util/parented_ptr.h"
-#endif
 
 class DlgHidden;
 class DlgMissing;


### PR DESCRIPTION
otherwise build fails with `ENGINEPRIME=OFF`