### PR TITLE
Beats: Remove unnecessary capabilities

### DIFF
--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -204,8 +204,7 @@ void BpmControl::slotTranslateBeatsEarlier(double v) {
         return;
     }
     const mixxx::BeatsPointer pBeats = pTrack->getBeats();
-    if (pBeats &&
-            (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
+    if (pBeats) {
         const double sampleOffset = getSampleOfTrack().rate * -0.01;
         const mixxx::audio::FrameDiff_t frameOffset = sampleOffset / mixxx::kEngineChannelCount;
         pTrack->trySetBeats(pBeats->translate(frameOffset));
@@ -221,8 +220,7 @@ void BpmControl::slotTranslateBeatsLater(double v) {
         return;
     }
     const mixxx::BeatsPointer pBeats = pTrack->getBeats();
-    if (pBeats &&
-            (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
+    if (pBeats) {
         // TODO(rryan): Track::getSampleRate is possibly inaccurate!
         const double sampleOffset = getSampleOfTrack().rate * 0.01;
         const mixxx::audio::FrameDiff_t frameOffset = sampleOffset / mixxx::kEngineChannelCount;
@@ -1043,7 +1041,7 @@ void BpmControl::slotBeatsTranslate(double v) {
         return;
     }
     const mixxx::BeatsPointer pBeats = pTrack->getBeats();
-    if (pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
+    if (pBeats) {
         const auto currentPosition =
                 mixxx::audio::FramePos::fromEngineSamplePos(
                         getSampleOfTrack().current)
@@ -1063,7 +1061,7 @@ void BpmControl::slotBeatsTranslateMatchAlignment(double v) {
         return;
     }
     const mixxx::BeatsPointer pBeats = pTrack->getBeats();
-    if (pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_TRANSLATE)) {
+    if (pBeats) {
         // Must reset the user offset *before* calling getPhaseOffset(),
         // otherwise it will always return 0 if master sync is active.
         m_dUserOffset.setValue(0.0);

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -32,7 +32,7 @@ class BeatGrid final : public Beats {
     // comments in beats.h
 
     Beats::CapabilitiesFlags getCapabilities() const override {
-        return BEATSCAP_TRANSLATE | BEATSCAP_SCALE | BEATSCAP_SETBPM;
+        return BEATSCAP_SETBPM;
     }
 
     QByteArray toByteArray() const override;

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -34,8 +34,7 @@ class BeatMap final : public Beats {
             const QVector<mixxx::audio::FramePos>& beats);
 
     Beats::CapabilitiesFlags getCapabilities() const override {
-        return BEATSCAP_TRANSLATE | BEATSCAP_SCALE | BEATSCAP_ADDREMOVE |
-                BEATSCAP_MOVEBEAT;
+        return BEATSCAP_NONE;
     }
 
     QByteArray toByteArray() const override;

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -31,17 +31,9 @@ class Beats {
     virtual ~Beats() = default;
 
     enum Capabilities {
-        BEATSCAP_NONE = 0x0000,
-        /// Add or remove a single beat
-        BEATSCAP_ADDREMOVE = 0x0001,
-        /// Move all beat markers earlier or later
-        BEATSCAP_TRANSLATE = 0x0002,
-        /// Scale beat distance by a fixed ratio
-        BEATSCAP_SCALE = 0x0004,
-        /// Move a single Beat
-        BEATSCAP_MOVEBEAT = 0x0008,
+        BEATSCAP_NONE = 0,
         /// Set new bpm, beat grid only
-        BEATSCAP_SETBPM = 0x0010
+        BEATSCAP_SETBPM = 1
     };
     /// Allows us to do ORing
     typedef int CapabilitiesFlags;
@@ -153,12 +145,10 @@ class Beats {
 
     /// Translate all beats in the song by `offset` frames. Beats that lie
     /// before the start of the track or after the end of the track are *not*
-    /// removed. The `Beats` instance must have the capability
-    /// `BEATSCAP_TRANSLATE`.
+    /// removed.
     virtual BeatsPointer translate(audio::FrameDiff_t offset) const = 0;
 
-    /// Scale the position of every beat in the song by `scale`. The `Beats`
-    /// class must have the capability `BEATSCAP_SCALE`.
+    /// Scale the position of every beat in the song by `scale`.
     virtual BeatsPointer scale(BpmScale scale) const = 0;
 
     /// Adjust the beats so the global average BPM matches `bpm`. The `Beats`


### PR DESCRIPTION
We currently have two beats implementations (`BeatGrid` and `BeatMap`)
and both support scaling and translating. Hence, it's unnecessary to
maintain these flags. In fact, the `BEATSCAP_SCALE` capability wasn't
even checked in the calling code but nobody noticed because both support
it anyway.

The `BEATSCAP_ADDREMOVE` and `BEATSCAP_MOVEBEAT` capabilities are only
supported by the `BeatMap`, but we don't have any code that makes use of
them. Therefore, these can be removed as well