### PR TITLE
Preferences: Remove all references to MixxxMainWindow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -888,6 +888,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/util/sandbox.cpp
   src/util/semanticversion.cpp
   src/util/screensaver.cpp
+  src/util/screensavermanager.cpp
   src/util/sleepableqthread.cpp
   src/util/stat.cpp
   src/util/statmodel.cpp

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -30,6 +30,7 @@
 #include "util/font.h"
 #include "util/logger.h"
 #include "util/screensaver.h"
+#include "util/screensavermanager.h"
 #include "util/statsmanager.h"
 #include "util/time.h"
 #include "util/translations.h"
@@ -260,6 +261,13 @@ void CoreServices::initialize(QApplication* pApp) {
 #ifdef __VINYLCONTROL__
     m_pVCManager->init();
 #endif
+
+    // Inhibit Screensaver
+    m_pScreensaverManager = std::make_shared<ScreensaverManager>(pConfig);
+    connect(&PlayerInfo::instance(),
+            &PlayerInfo::currentPlayingDeckChanged,
+            m_pScreensaverManager.get(),
+            &ScreensaverManager::slotCurrentPlayingDeckChanged);
 
     emit initializationProgressUpdate(50, tr("library"));
     CoverArtCache::createInstance();

--- a/src/coreservices.h
+++ b/src/coreservices.h
@@ -28,6 +28,7 @@ class LV2Backend;
 namespace mixxx {
 
 class DbConnectionPool;
+class ScreensaverManager;
 
 class CoreServices : public QObject {
     Q_OBJECT
@@ -39,6 +40,7 @@ class CoreServices : public QObject {
     void initializeSettings();
     // FIXME: should be private, but WMainMenuBar needs it initialized early
     void initializeKeyboard();
+    void initializeScreensaverManager();
     void initialize(QApplication* pApp);
     void shutdown();
 
@@ -100,6 +102,10 @@ class CoreServices : public QObject {
         return m_pSettingsManager->settings();
     }
 
+    std::shared_ptr<ScreensaverManager> getScreensaverManager() const {
+        return m_pScreensaverManager;
+    }
+
   signals:
     void initializationProgressUpdate(int progress, const QString& serviceName);
 
@@ -131,6 +137,8 @@ class CoreServices : public QObject {
     std::shared_ptr<KeyboardEventFilter> m_pKeyboardEventFilter;
     std::shared_ptr<ConfigObject<ConfigValueKbd>> m_pKbdConfig;
     std::shared_ptr<ConfigObject<ConfigValueKbd>> m_pKbdConfigEmpty;
+
+    std::shared_ptr<mixxx::ScreensaverManager> m_pScreensaverManager;
 
     std::unique_ptr<ControlPushButton> m_pTouchShift;
 

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -219,7 +219,6 @@ MixxxMainWindow::MixxxMainWindow(
 
     // Initialize preference dialog
     m_pPrefDlg = new DlgPreferences(
-            this,
             m_pCoreServices->getScreensaverManager(),
             m_pSkinLoader,
             m_pCoreServices->getSoundManager(),

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -232,6 +232,10 @@ MixxxMainWindow::MixxxMainWindow(
             m_pCoreServices->getLibrary());
     m_pPrefDlg->setWindowIcon(QIcon(":/images/icons/mixxx.svg"));
     m_pPrefDlg->setHidden(true);
+    connect(m_pPrefDlg,
+            &DlgPreferences::tooltipModeChanged,
+            this,
+            &MixxxMainWindow::slotTooltipModeChanged);
 
     // Connect signals to the menubar. Should be done before emit newSkinLoaded.
     connectMenuBar();
@@ -986,10 +990,7 @@ void MixxxMainWindow::slotShowKeywheel(bool toggle) {
     }
 }
 
-void MixxxMainWindow::setToolTipsCfg(mixxx::TooltipsPreference tt) {
-    UserSettingsPointer pConfig = m_pCoreServices->getSettings();
-    pConfig->set(ConfigKey("[Controls]","Tooltips"),
-                 ConfigValue(static_cast<int>(tt)));
+void MixxxMainWindow::slotTooltipModeChanged(mixxx::TooltipsPreference tt) {
     m_toolTipsCfg = tt;
 }
 

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -236,6 +236,11 @@ MixxxMainWindow::MixxxMainWindow(
             &DlgPreferences::tooltipModeChanged,
             this,
             &MixxxMainWindow::slotTooltipModeChanged);
+    connect(m_pPrefDlg,
+            &DlgPreferences::reloadUserInterface,
+            this,
+            &MixxxMainWindow::rebootMixxxView,
+            Qt::DirectConnection);
 
     // Connect signals to the menubar. Should be done before emit newSkinLoaded.
     connectMenuBar();

--- a/src/mixxxmainwindow.h
+++ b/src/mixxxmainwindow.h
@@ -78,7 +78,6 @@ class MixxxMainWindow : public QMainWindow {
     void slotDeveloperToolsClosed();
 
     void slotUpdateWindowTitle(TrackPointer pTrack);
-    void slotChangedPlayingDeck(int deck);
 
     /// warn the user when inputs are not configured.
     void slotNoMicrophoneInputConfigured();

--- a/src/mixxxmainwindow.h
+++ b/src/mixxxmainwindow.h
@@ -56,9 +56,6 @@ class MixxxMainWindow : public QMainWindow {
     void setInhibitScreensaver(mixxx::ScreenSaverPreference inhibit);
     mixxx::ScreenSaverPreference getInhibitScreensaver();
 
-    void setToolTipsCfg(mixxx::TooltipsPreference tt);
-    inline mixxx::TooltipsPreference getToolTipsCfg() { return m_toolTipsCfg; }
-
     inline GuiTick* getGuiTick() { return m_pGuiTick; };
 
   public slots:
@@ -84,6 +81,9 @@ class MixxxMainWindow : public QMainWindow {
     void slotNoAuxiliaryInputConfigured();
     void slotNoDeckPassthroughInputConfigured();
     void slotNoVinylControlInputConfigured();
+
+  private slots:
+    void slotTooltipModeChanged(mixxx::TooltipsPreference tt);
 
   signals:
     void skinLoaded();

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -53,6 +53,7 @@
 
 DlgPreferences::DlgPreferences(
         MixxxMainWindow* mixxx,
+        std::shared_ptr<mixxx::ScreensaverManager> pScreensaverManager,
         std::shared_ptr<mixxx::skin::SkinLoader> pSkinLoader,
         std::shared_ptr<SoundManager> pSoundManager,
         std::shared_ptr<PlayerManager> pPlayerManager,
@@ -133,9 +134,13 @@ DlgPreferences::DlgPreferences(
             "ic_preferences_vinyl.svg");
 #endif // __VINYLCONTROL__
 
-    addPageWidget(PreferencesPage(
-                          new DlgPrefInterface(this, mixxx, pSkinLoader, m_pConfig),
-                          new QTreeWidgetItem(contentsTreeWidget, QTreeWidgetItem::Type)),
+    addPageWidget(PreferencesPage(new DlgPrefInterface(this,
+                                          mixxx,
+                                          pScreensaverManager,
+                                          pSkinLoader,
+                                          m_pConfig),
+                          new QTreeWidgetItem(
+                                  contentsTreeWidget, QTreeWidgetItem::Type)),
             tr("Interface"),
             "ic_preferences_interface.svg");
 

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -134,11 +134,16 @@ DlgPreferences::DlgPreferences(
             "ic_preferences_vinyl.svg");
 #endif // __VINYLCONTROL__
 
-    addPageWidget(PreferencesPage(new DlgPrefInterface(this,
-                                          mixxx,
-                                          pScreensaverManager,
-                                          pSkinLoader,
-                                          m_pConfig),
+    DlgPrefInterface* pInterfacePage = new DlgPrefInterface(this,
+            mixxx,
+            pScreensaverManager,
+            pSkinLoader,
+            m_pConfig);
+    connect(pInterfacePage,
+            &DlgPrefInterface::tooltipModeChanged,
+            this,
+            &DlgPreferences::tooltipModeChanged);
+    addPageWidget(PreferencesPage(pInterfacePage,
                           new QTreeWidgetItem(
                                   contentsTreeWidget, QTreeWidgetItem::Type)),
             tr("Interface"),

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -52,7 +52,6 @@
 #include "util/widgethelper.h"
 
 DlgPreferences::DlgPreferences(
-        MixxxMainWindow* mixxx,
         std::shared_ptr<mixxx::ScreensaverManager> pScreensaverManager,
         std::shared_ptr<mixxx::skin::SkinLoader> pSkinLoader,
         std::shared_ptr<SoundManager> pSoundManager,
@@ -135,7 +134,6 @@ DlgPreferences::DlgPreferences(
 #endif // __VINYLCONTROL__
 
     DlgPrefInterface* pInterfacePage = new DlgPrefInterface(this,
-            mixxx,
             pScreensaverManager,
             pSkinLoader,
             m_pConfig);
@@ -154,7 +152,7 @@ DlgPreferences::DlgPreferences(
             tr("Interface"),
             "ic_preferences_interface.svg");
 
-    DlgPrefWaveform* pWaveformPage = new DlgPrefWaveform(this, mixxx, m_pConfig, pLibrary);
+    DlgPrefWaveform* pWaveformPage = new DlgPrefWaveform(this, m_pConfig, pLibrary);
     addPageWidget(PreferencesPage(
                           pWaveformPage,
                           new QTreeWidgetItem(contentsTreeWidget, QTreeWidgetItem::Type)),

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -143,6 +143,11 @@ DlgPreferences::DlgPreferences(
             &DlgPrefInterface::tooltipModeChanged,
             this,
             &DlgPreferences::tooltipModeChanged);
+    connect(pInterfacePage,
+            &DlgPrefInterface::reloadUserInterface,
+            this,
+            &DlgPreferences::reloadUserInterface,
+            Qt::DirectConnection);
     addPageWidget(PreferencesPage(pInterfacePage,
                           new QTreeWidgetItem(
                                   contentsTreeWidget, QTreeWidgetItem::Type)),

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -154,11 +154,17 @@ DlgPreferences::DlgPreferences(
             tr("Interface"),
             "ic_preferences_interface.svg");
 
+    DlgPrefWaveform* pWaveformPage = new DlgPrefWaveform(this, mixxx, m_pConfig, pLibrary);
     addPageWidget(PreferencesPage(
-                          new DlgPrefWaveform(this, mixxx, m_pConfig, pLibrary),
+                          pWaveformPage,
                           new QTreeWidgetItem(contentsTreeWidget, QTreeWidgetItem::Type)),
             tr("Waveforms"),
             "ic_preferences_waveforms.svg");
+    connect(pWaveformPage,
+            &DlgPrefWaveform::reloadUserInterface,
+            this,
+            &DlgPreferences::reloadUserInterface,
+            Qt::DirectConnection);
 
     addPageWidget(PreferencesPage(
                           new DlgPrefColors(this, m_pConfig, pLibrary),

--- a/src/preferences/dialog/dlgpreferences.h
+++ b/src/preferences/dialog/dlgpreferences.h
@@ -51,6 +51,7 @@ class DlgPrefModplug;
 #endif // __MODPLUG__
 
 namespace mixxx {
+class ScreensaverManager;
 namespace skin {
 class SkinLoader;
 }
@@ -71,6 +72,7 @@ class DlgPreferences : public QDialog, public Ui::DlgPreferencesDlg {
     };
 
     DlgPreferences(MixxxMainWindow* mixxx,
+            std::shared_ptr<mixxx::ScreensaverManager> pScreensaverManager,
             std::shared_ptr<mixxx::skin::SkinLoader> pSkinLoader,
             std::shared_ptr<SoundManager> pSoundManager,
             std::shared_ptr<PlayerManager> pPlayerManager,

--- a/src/preferences/dialog/dlgpreferences.h
+++ b/src/preferences/dialog/dlgpreferences.h
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "control/controlpushbutton.h"
+#include "preferences/constants.h"
 #include "preferences/dialog/dlgpreferencepage.h"
 #include "preferences/dialog/ui_dlgpreferencesdlg.h"
 #include "preferences/settingsmanager.h"
@@ -105,6 +106,9 @@ class DlgPreferences : public QDialog, public Ui::DlgPreferencesDlg {
     void cancelPreferences();
     // Emitted if the user clicks Reset to Defaults.
     void resetToDefaults();
+
+  signals:
+    void tooltipModeChanged(mixxx::TooltipsPreference tooltipMode);
 
   protected:
     bool eventFilter(QObject*, QEvent*);

--- a/src/preferences/dialog/dlgpreferences.h
+++ b/src/preferences/dialog/dlgpreferences.h
@@ -14,7 +14,6 @@
 #include "preferences/settingsmanager.h"
 #include "preferences/usersettings.h"
 
-class MixxxMainWindow;
 class SoundManager;
 class DlgPrefSound;
 class DlgPrefLibrary;
@@ -72,7 +71,7 @@ class DlgPreferences : public QDialog, public Ui::DlgPreferencesDlg {
         QTreeWidgetItem* pTreeItem;
     };
 
-    DlgPreferences(MixxxMainWindow* mixxx,
+    DlgPreferences(
             std::shared_ptr<mixxx::ScreensaverManager> pScreensaverManager,
             std::shared_ptr<mixxx::skin::SkinLoader> pSkinLoader,
             std::shared_ptr<SoundManager> pSoundManager,

--- a/src/preferences/dialog/dlgpreferences.h
+++ b/src/preferences/dialog/dlgpreferences.h
@@ -108,6 +108,7 @@ class DlgPreferences : public QDialog, public Ui::DlgPreferencesDlg {
     void resetToDefaults();
 
   signals:
+    void reloadUserInterface();
     void tooltipModeChanged(mixxx::TooltipsPreference tooltipMode);
 
   protected:

--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -430,7 +430,7 @@ void DlgPrefInterface::slotApply() {
     }
 
     if (m_bRebootMixxxView) {
-        m_mixxx->rebootMixxxView();
+        emit reloadUserInterface();
         // Allow switching skins multiple times without closing the dialog
         m_skinNameOnUpdate = m_pSkin->name();
     }

--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -18,6 +18,7 @@
 #include "skin/skin.h"
 #include "skin/skinloader.h"
 #include "util/screensaver.h"
+#include "util/screensavermanager.h"
 #include "util/widgethelper.h"
 
 using mixxx::skin::SkinManifest;
@@ -26,11 +27,13 @@ using mixxx::skin::SkinPointer;
 DlgPrefInterface::DlgPrefInterface(
         QWidget* parent,
         MixxxMainWindow* mixxx,
+        std::shared_ptr<mixxx::ScreensaverManager> pScreensaverManager,
         std::shared_ptr<mixxx::skin::SkinLoader> pSkinLoader,
         UserSettingsPointer pConfig)
         : DlgPreferencePage(parent),
           m_pConfig(pConfig),
           m_mixxx(mixxx),
+          m_pScreensaverManager(pScreensaverManager),
           m_pSkinLoader(pSkinLoader),
           m_pSkin(pSkinLoader->getConfiguredSkin()),
           m_dScaleFactorAuto(1.0),
@@ -165,7 +168,7 @@ DlgPrefInterface::DlgPrefInterface(
     comboBoxScreensaver->addItem(tr("Prevent screensaver while playing"),
             static_cast<int>(mixxx::ScreenSaverPreference::PREVENT_ON_PLAY));
 
-    int inhibitsettings = static_cast<int>(mixxx->getInhibitScreensaver());
+    int inhibitsettings = static_cast<int>(m_pScreensaverManager->status());
     comboBoxScreensaver->setCurrentIndex(comboBoxScreensaver->findData(inhibitsettings));
 
     // Tooltip configuration
@@ -261,7 +264,7 @@ void DlgPrefInterface::slotUpdate() {
 
     loadTooltipPreferenceFromConfig();
 
-    int inhibitsettings = static_cast<int>(m_mixxx->getInhibitScreensaver());
+    int inhibitsettings = static_cast<int>(m_pScreensaverManager->status());
     comboBoxScreensaver->setCurrentIndex(comboBoxScreensaver->findData(inhibitsettings));
 }
 
@@ -413,9 +416,9 @@ void DlgPrefInterface::slotApply() {
     // screensaver mode update
     int screensaverComboBoxState = comboBoxScreensaver->itemData(
             comboBoxScreensaver->currentIndex()).toInt();
-    int screensaverConfiguredState = static_cast<int>(m_mixxx->getInhibitScreensaver());
+    int screensaverConfiguredState = static_cast<int>(m_pScreensaverManager->status());
     if (screensaverComboBoxState != screensaverConfiguredState) {
-        m_mixxx->setInhibitScreensaver(
+        m_pScreensaverManager->setStatus(
                 static_cast<mixxx::ScreenSaverPreference>(screensaverComboBoxState));
     }
 

--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -190,10 +190,9 @@ QScreen* DlgPrefInterface::getScreen() const {
     auto* pScreen =
             mixxx::widgethelper::getScreen(*this);
     if (!pScreen) {
-        // Obtain the screen from the main widget as a fallback. This
-        // is necessary if no window is available before the widget
-        // is displayed.
-        pScreen = mixxx::widgethelper::getScreen(*m_mixxx);
+        // Obtain the primary screen. This is necessary if no window is
+        // available before the widget is displayed.
+        pScreen = qGuiApp->primaryScreen();
     }
     DEBUG_ASSERT(pScreen);
     return pScreen;

--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -26,13 +26,11 @@ using mixxx::skin::SkinPointer;
 
 DlgPrefInterface::DlgPrefInterface(
         QWidget* parent,
-        MixxxMainWindow* mixxx,
         std::shared_ptr<mixxx::ScreensaverManager> pScreensaverManager,
         std::shared_ptr<mixxx::skin::SkinLoader> pSkinLoader,
         UserSettingsPointer pConfig)
         : DlgPreferencePage(parent),
           m_pConfig(pConfig),
-          m_mixxx(mixxx),
           m_pScreensaverManager(pScreensaverManager),
           m_pSkinLoader(pSkinLoader),
           m_pSkin(pSkinLoader->getConfiguredSkin()),

--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -410,7 +410,9 @@ void DlgPrefInterface::slotApply() {
     m_pConfig->set(ConfigKey("[Config]", "StartInFullscreen"),
             ConfigValue(checkBoxStartFullScreen->isChecked()));
 
-    m_mixxx->setToolTipsCfg(m_tooltipMode);
+    m_pConfig->set(ConfigKey("[Controls]", "Tooltips"),
+            ConfigValue(static_cast<int>(m_tooltipMode)));
+    emit tooltipModeChanged(m_tooltipMode);
 
     // screensaver mode update
     int screensaverComboBoxState = comboBoxScreensaver->itemData(
@@ -436,17 +438,20 @@ void DlgPrefInterface::slotApply() {
 }
 
 void DlgPrefInterface::loadTooltipPreferenceFromConfig() {
-    mixxx::TooltipsPreference configTooltips = m_mixxx->getToolTipsCfg();
-    switch (configTooltips) {
-        case mixxx::TooltipsPreference::TOOLTIPS_OFF:
-            radioButtonTooltipsOff->setChecked(true);
-            break;
-        case mixxx::TooltipsPreference::TOOLTIPS_ON:
-            radioButtonTooltipsLibraryAndSkin->setChecked(true);
-            break;
-        case mixxx::TooltipsPreference::TOOLTIPS_ONLY_IN_LIBRARY:
-            radioButtonTooltipsLibrary->setChecked(true);
-            break;
+    const auto tooltipMode = static_cast<mixxx::TooltipsPreference>(
+            m_pConfig->getValue(ConfigKey("[Controls]", "Tooltips"),
+                    static_cast<int>(mixxx::TooltipsPreference::TOOLTIPS_ON)));
+    switch (tooltipMode) {
+    case mixxx::TooltipsPreference::TOOLTIPS_OFF:
+        radioButtonTooltipsOff->setChecked(true);
+        break;
+    case mixxx::TooltipsPreference::TOOLTIPS_ONLY_IN_LIBRARY:
+        radioButtonTooltipsLibrary->setChecked(true);
+        break;
+    case mixxx::TooltipsPreference::TOOLTIPS_ON:
+    default:
+        radioButtonTooltipsLibraryAndSkin->setChecked(true);
+        break;
     }
-    m_tooltipMode = configTooltips;
+    m_tooltipMode = tooltipMode;
 }

--- a/src/preferences/dialog/dlgprefinterface.h
+++ b/src/preferences/dialog/dlgprefinterface.h
@@ -50,6 +50,9 @@ class DlgPrefInterface : public DlgPreferencePage, public Ui::DlgPrefControlsDlg
     void slotSetScaleFactor(double newValue);
     void slotSetScaleFactorAuto(bool checked);
 
+  signals:
+    void tooltipModeChanged(mixxx::TooltipsPreference tooltipMode);
+
   private:
     void notifyRebootNecessary();
     void loadTooltipPreferenceFromConfig();

--- a/src/preferences/dialog/dlgprefinterface.h
+++ b/src/preferences/dialog/dlgprefinterface.h
@@ -29,7 +29,6 @@ class DlgPrefInterface : public DlgPreferencePage, public Ui::DlgPrefControlsDlg
   public:
     DlgPrefInterface(
             QWidget* parent,
-            MixxxMainWindow* mixxx,
             std::shared_ptr<mixxx::ScreensaverManager> pScreensaverManager,
             std::shared_ptr<mixxx::skin::SkinLoader> pSkinLoader,
             UserSettingsPointer pConfig);
@@ -67,7 +66,6 @@ class DlgPrefInterface : public DlgPreferencePage, public Ui::DlgPrefControlsDlg
 
     UserSettingsPointer m_pConfig;
     ControlObject* m_pControlTrackTimeDisplay;
-    MixxxMainWindow *m_mixxx;
     std::shared_ptr<mixxx::ScreensaverManager> m_pScreensaverManager;
     std::shared_ptr<mixxx::skin::SkinLoader> m_pSkinLoader;
 

--- a/src/preferences/dialog/dlgprefinterface.h
+++ b/src/preferences/dialog/dlgprefinterface.h
@@ -18,6 +18,7 @@ class MixxxMainWindow;
 class ControlObject;
 
 namespace mixxx {
+class ScreensaverManager;
 namespace skin {
 class SkinLoader;
 }
@@ -29,6 +30,7 @@ class DlgPrefInterface : public DlgPreferencePage, public Ui::DlgPrefControlsDlg
     DlgPrefInterface(
             QWidget* parent,
             MixxxMainWindow* mixxx,
+            std::shared_ptr<mixxx::ScreensaverManager> pScreensaverManager,
             std::shared_ptr<mixxx::skin::SkinLoader> pSkinLoader,
             UserSettingsPointer pConfig);
     ~DlgPrefInterface() override = default;
@@ -62,6 +64,7 @@ class DlgPrefInterface : public DlgPreferencePage, public Ui::DlgPrefControlsDlg
     UserSettingsPointer m_pConfig;
     ControlObject* m_pControlTrackTimeDisplay;
     MixxxMainWindow *m_mixxx;
+    std::shared_ptr<mixxx::ScreensaverManager> m_pScreensaverManager;
     std::shared_ptr<mixxx::skin::SkinLoader> m_pSkinLoader;
 
     QMap<QString, mixxx::skin::SkinPointer> m_skins;

--- a/src/preferences/dialog/dlgprefinterface.h
+++ b/src/preferences/dialog/dlgprefinterface.h
@@ -51,6 +51,7 @@ class DlgPrefInterface : public DlgPreferencePage, public Ui::DlgPrefControlsDlg
     void slotSetScaleFactorAuto(bool checked);
 
   signals:
+    void reloadUserInterface();
     void tooltipModeChanged(mixxx::TooltipsPreference tooltipMode);
 
   private:

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -11,13 +11,11 @@
 
 DlgPrefWaveform::DlgPrefWaveform(
         QWidget* pParent,
-        MixxxMainWindow* pMixxx,
         UserSettingsPointer pConfig,
         std::shared_ptr<Library> pLibrary)
         : DlgPreferencePage(pParent),
           m_pConfig(pConfig),
-          m_pLibrary(pLibrary),
-          m_pMixxx(pMixxx) {
+          m_pLibrary(pLibrary) {
     setupUi(this);
 
     // Waveform overview init

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -257,7 +257,7 @@ void DlgPrefWaveform::slotSetWaveformType(int index) {
 
 void DlgPrefWaveform::slotSetWaveformOverviewType(int index) {
     m_pConfig->set(ConfigKey("[Waveform]","WaveformOverviewType"), ConfigValue(index));
-    m_pMixxx->rebootMixxxView();
+    emit reloadUserInterface();
 }
 
 void DlgPrefWaveform::slotSetDefaultZoom(int index) {

--- a/src/preferences/dialog/dlgprefwaveform.h
+++ b/src/preferences/dialog/dlgprefwaveform.h
@@ -7,7 +7,6 @@
 #include "preferences/dialog/ui_dlgprefwaveformdlg.h"
 #include "preferences/usersettings.h"
 
-class MixxxMainWindow;
 class Library;
 
 class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg {
@@ -15,7 +14,6 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
   public:
     DlgPrefWaveform(
             QWidget* pParent,
-            MixxxMainWindow* pMixxx,
             UserSettingsPointer pConfig,
             std::shared_ptr<Library> pLibrary);
     virtual ~DlgPrefWaveform();
@@ -52,5 +50,4 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
 
     UserSettingsPointer m_pConfig;
     std::shared_ptr<Library> m_pLibrary;
-    MixxxMainWindow* m_pMixxx;
 };

--- a/src/preferences/dialog/dlgprefwaveform.h
+++ b/src/preferences/dialog/dlgprefwaveform.h
@@ -42,6 +42,9 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
     void slotSetBeatGridAlpha(int alpha);
     void slotSetPlayMarkerPosition(int position);
 
+  signals:
+    void reloadUserInterface();
+
   private:
     void initWaveformControl();
     void calculateCachedWaveformDiskUsage();

--- a/src/util/screensavermanager.cpp
+++ b/src/util/screensavermanager.cpp
@@ -1,0 +1,55 @@
+#include "util/screensavermanager.h"
+
+#include "mixer/playerinfo.h"
+
+namespace mixxx {
+
+ScreensaverManager::ScreensaverManager(UserSettingsPointer pConfig, QObject* pParent)
+        : QObject(pParent), m_pConfig(pConfig) {
+    int inhibit = pConfig->getValue<int>(ConfigKey("[Config]", "InhibitScreensaver"), -1);
+    if (inhibit == -1) {
+        inhibit = static_cast<int>(mixxx::ScreenSaverPreference::PREVENT_ON);
+        pConfig->setValue<int>(ConfigKey("[Config]", "InhibitScreensaver"), inhibit);
+    }
+    m_inhibitScreensaver = static_cast<mixxx::ScreenSaverPreference>(inhibit);
+    if (m_inhibitScreensaver == mixxx::ScreenSaverPreference::PREVENT_ON) {
+        mixxx::ScreenSaverHelper::inhibit();
+    }
+}
+
+ScreensaverManager::~ScreensaverManager() {
+    if (m_inhibitScreensaver != mixxx::ScreenSaverPreference::PREVENT_OFF) {
+        mixxx::ScreenSaverHelper::uninhibit();
+    }
+}
+
+void ScreensaverManager::setStatus(mixxx::ScreenSaverPreference newInhibit) {
+    if (m_inhibitScreensaver != mixxx::ScreenSaverPreference::PREVENT_OFF) {
+        mixxx::ScreenSaverHelper::uninhibit();
+    }
+
+    if (newInhibit == mixxx::ScreenSaverPreference::PREVENT_ON) {
+        mixxx::ScreenSaverHelper::inhibit();
+    } else if (newInhibit ==
+                    mixxx::ScreenSaverPreference::PREVENT_ON_PLAY &&
+            PlayerInfo::instance().getCurrentPlayingDeck() != -1) {
+        mixxx::ScreenSaverHelper::inhibit();
+    }
+    int inhibit_int = static_cast<int>(newInhibit);
+    m_pConfig->setValue<int>(ConfigKey("[Config]", "InhibitScreensaver"), inhibit_int);
+    m_inhibitScreensaver = newInhibit;
+}
+
+void ScreensaverManager::slotCurrentPlayingDeckChanged(int deck) {
+    if (m_inhibitScreensaver != mixxx::ScreenSaverPreference::PREVENT_ON_PLAY) {
+        return;
+    }
+    if (deck == -1) {
+        // If no deck is playing, allow the screensaver to run.
+        mixxx::ScreenSaverHelper::uninhibit();
+    } else {
+        mixxx::ScreenSaverHelper::inhibit();
+    }
+}
+
+} // namespace mixxx

--- a/src/util/screensavermanager.h
+++ b/src/util/screensavermanager.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <QObject>
+
+#include "preferences/constants.h"
+#include "preferences/usersettings.h"
+#include "util/screensaver.h"
+
+namespace mixxx {
+
+class ScreensaverManager : public QObject {
+    Q_OBJECT
+  public:
+    ScreensaverManager(UserSettingsPointer pConfig, QObject* pParent = nullptr);
+    ~ScreensaverManager();
+
+    void setStatus(mixxx::ScreenSaverPreference status);
+
+    mixxx::ScreenSaverPreference status() {
+        return m_inhibitScreensaver;
+    }
+  public slots:
+    void slotCurrentPlayingDeckChanged(int deck);
+
+  private:
+    const UserSettingsPointer m_pConfig;
+    mixxx::ScreenSaverPreference m_inhibitScreensaver;
+};
+
+} // namespace mixxx


### PR DESCRIPTION
This is necessary if we want to use the preferences in QML without creating a QWidgets-based `MixxxMainWindow` instance.