### PR TITLE
Start to untangle CoreServices/MixxxMainWindow initialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1536,6 +1536,7 @@ add_executable(mixxx-test
   src/test/controller_mapping_validation_test.cpp
   src/test/controllerscriptenginelegacy_test.cpp
   src/test/controlobjecttest.cpp
+  src/test/coreservicestest.cpp
   src/test/coverartcache_test.cpp
   src/test/coverartutils_test.cpp
   src/test/cratestorage_test.cpp

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -106,6 +106,8 @@ namespace mixxx {
 CoreServices::CoreServices(const CmdlineArgs& args)
         : m_runtime_timer(QLatin1String("CoreServices::runtime")),
           m_cmdlineArgs(args) {
+    initializeSettings();
+    initializeKeyboard();
 }
 
 CoreServices::~CoreServices() = default;

--- a/src/coreservices.h
+++ b/src/coreservices.h
@@ -40,7 +40,6 @@ class CoreServices : public QObject {
     CoreServices(const CmdlineArgs& args);
     ~CoreServices();
 
-    void initializeScreensaverManager();
     void initialize(QApplication* pApp);
     void shutdown();
 

--- a/src/coreservices.h
+++ b/src/coreservices.h
@@ -40,9 +40,6 @@ class CoreServices : public QObject {
     CoreServices(const CmdlineArgs& args);
     ~CoreServices();
 
-    void initializeSettings();
-    // FIXME: should be private, but WMainMenuBar needs it initialized early
-    void initializeKeyboard();
     void initializeScreensaverManager();
     void initialize(QApplication* pApp);
     void shutdown();
@@ -121,6 +118,8 @@ class CoreServices : public QObject {
 
   private:
     bool initializeDatabase();
+    void initializeKeyboard();
+    void initializeSettings();
 
     std::shared_ptr<SettingsManager> m_pSettingsManager;
     std::shared_ptr<mixxx::ControlIndicatorTimer> m_pControlIndicatorTimer;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,8 +23,20 @@ constexpr int kFatalErrorOnStartupExitCode = 1;
 constexpr int kParseCmdlineArgsErrorExitCode = 2;
 
 int runMixxx(MixxxApplication* app, const CmdlineArgs& args) {
-    auto coreServices = std::make_shared<mixxx::CoreServices>(args);
-    MixxxMainWindow mainWindow(app, coreServices);
+    const auto pCoreServices = std::make_shared<mixxx::CoreServices>(args);
+    pCoreServices->initializeSettings();
+    pCoreServices->initializeKeyboard();
+
+    MixxxMainWindow mainWindow(app, pCoreServices);
+    app->installEventFilter(&mainWindow);
+
+    QObject::connect(pCoreServices.get(),
+            &mixxx::CoreServices::initializationProgressUpdate,
+            &mainWindow,
+            &MixxxMainWindow::initializationProgressUpdate);
+    pCoreServices->initialize(app);
+    mainWindow.initialize();
+
     // If startup produced a fatal error, then don't even start the
     // Qt event loop.
     if (ErrorDialogHandler::instance()->checkError()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,8 +24,6 @@ constexpr int kParseCmdlineArgsErrorExitCode = 2;
 
 int runMixxx(MixxxApplication* app, const CmdlineArgs& args) {
     const auto pCoreServices = std::make_shared<mixxx::CoreServices>(args);
-    pCoreServices->initializeSettings();
-    pCoreServices->initializeKeyboard();
 
     MixxxMainWindow mainWindow(app, pCoreServices);
     app->installEventFilter(&mainWindow);

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -105,8 +105,6 @@ MixxxMainWindow::MixxxMainWindow(
           m_toolTipsCfg(mixxx::TooltipsPreference::TOOLTIPS_ON) {
     DEBUG_ASSERT(pApp);
     DEBUG_ASSERT(pCoreServices);
-    m_pCoreServices->initializeSettings();
-    m_pCoreServices->initializeKeyboard();
     // These depend on the settings
     createMenuBar();
     m_pMenuBar->hide();
@@ -124,15 +122,9 @@ MixxxMainWindow::MixxxMainWindow(
 
     m_pGuiTick = new GuiTick();
     m_pVisualsManager = new VisualsManager();
+}
 
-    connect(
-            m_pCoreServices.get(),
-            &mixxx::CoreServices::initializationProgressUpdate,
-            this,
-            &MixxxMainWindow::initializationProgressUpdate);
-
-    m_pCoreServices->initialize(pApp);
-
+void MixxxMainWindow::initialize() {
     m_pCoreServices->getControlIndicatorTimer()->setLegacyVsyncEnabled(true);
 
     UserSettingsPointer pConfig = m_pCoreServices->getSettings();
@@ -168,6 +160,8 @@ MixxxMainWindow::MixxxMainWindow(
 
     initializationProgressUpdate(65, tr("skin"));
 
+    // Install an event filter to catch certain QT events, such as tooltips.
+    // This allows us to turn off tooltips.
     installEventFilter(m_pCoreServices->getKeyboardEventFilter().get());
 
     DEBUG_ASSERT(m_pCoreServices->getPlayerManager());
@@ -273,11 +267,6 @@ MixxxMainWindow::MixxxMainWindow(
     if (!CmdlineArgs::Instance().getSafeMode()) {
         checkDirectRendering();
     }
-
-    // Install an event filter to catch certain QT events, such as tooltips.
-    // This allows us to turn off tooltips.
-    pApp->installEventFilter(this); // The eventfilter is located in this
-                                    // Mixxx class as a callback.
 
     // Try open player device If that fails, the preference panel is opened.
     bool retryClicked;

--- a/src/mixxxmainwindow.h
+++ b/src/mixxxmainwindow.h
@@ -50,6 +50,8 @@ class MixxxMainWindow : public QMainWindow {
     MixxxMainWindow(QApplication* app, std::shared_ptr<mixxx::CoreServices> pCoreServices);
     ~MixxxMainWindow() override;
 
+    /// Initialize main window after creation. Should only be called once.
+    void initialize();
     /// creates the menu_bar and inserts the file Menu
     void createMenuBar();
     void connectMenuBar();
@@ -82,6 +84,8 @@ class MixxxMainWindow : public QMainWindow {
     void slotNoDeckPassthroughInputConfigured();
     void slotNoVinylControlInputConfigured();
 
+    void initializationProgressUpdate(int progress, const QString& serviceName);
+
   private slots:
     void slotTooltipModeChanged(mixxx::TooltipsPreference tt);
 
@@ -96,9 +100,6 @@ class MixxxMainWindow : public QMainWindow {
     /// Event filter to block certain events (eg. tooltips if tooltips are disabled)
     bool eventFilter(QObject *obj, QEvent *event) override;
     void closeEvent(QCloseEvent *event) override;
-
-  private slots:
-    void initializationProgressUpdate(int progress, const QString& serviceName);
 
   private:
     void initializeWindow();

--- a/src/test/coreservicestest.cpp
+++ b/src/test/coreservicestest.cpp
@@ -1,0 +1,34 @@
+#include <gtest/gtest.h>
+
+#include "coreservices.h"
+#include "test/mixxxtest.h"
+#include "util/cmdlineargs.h"
+
+class CoreServicesTest : public MixxxTest {
+};
+
+// This test is disabled because it fails on CI for some unknown reason.
+TEST_F(CoreServicesTest, DISABLED_TestInitialization) {
+    // Initialize the app
+    const int argc = 1;
+    CmdlineArgs cmdlineArgs;
+    char progName[] = "mixxxtest";
+    char safeMode[] = "--safe-mode";
+    char* argv[] = {progName, safeMode};
+    cmdlineArgs.parse(argc, argv);
+
+    const auto pCoreServices = std::make_unique<mixxx::CoreServices>(cmdlineArgs);
+    pCoreServices->initializeSettings();
+    pCoreServices->initializeKeyboard();
+    pCoreServices->initialize(application());
+
+    EXPECT_NE(pCoreServices->getControllerManager(), nullptr);
+    EXPECT_NE(pCoreServices->getEffectsManager(), nullptr);
+    EXPECT_NE(pCoreServices->getLV2Backend(), nullptr);
+    EXPECT_NE(pCoreServices->getLibrary(), nullptr);
+    EXPECT_NE(pCoreServices->getPlayerManager(), nullptr);
+    EXPECT_NE(pCoreServices->getScreensaverManager(), nullptr);
+    EXPECT_NE(pCoreServices->getSettingsManager(), nullptr);
+    EXPECT_NE(pCoreServices->getSoundManager(), nullptr);
+    EXPECT_NE(pCoreServices->getVinylControlManager(), nullptr);
+}

--- a/src/test/coreservicestest.cpp
+++ b/src/test/coreservicestest.cpp
@@ -18,8 +18,6 @@ TEST_F(CoreServicesTest, DISABLED_TestInitialization) {
     cmdlineArgs.parse(argc, argv);
 
     const auto pCoreServices = std::make_unique<mixxx::CoreServices>(cmdlineArgs);
-    pCoreServices->initializeSettings();
-    pCoreServices->initializeKeyboard();
     pCoreServices->initialize(application());
 
     EXPECT_NE(pCoreServices->getControllerManager(), nullptr);


### PR DESCRIPTION
Based on #4109. This moves some required stuff like `GuiTick`/`VisualsManager` into `CoreServices` (without them, CoreServices initialization will fail with a debug assertion). It also moves the call to `CoreServices::initialize` out of `MixxxMainWindow`, because even without a `MixxxMainWindow` the `CoreServices` should be initialized (this will be necessary when we to a pure QML interface instead of embedding the QML UI inside a `QQuickWidget`.)

This is not yet complete, for example the sound setup (`setupDevices()`) should also happen in `main`, but this requires moving the preferences out of MixxxMainWindow, too. Unfortunately, these depend on `WaveformWidgetFactory` which is not needed for QML. Hence, this will need some more refacoring in later PRs.