### PR TITLE
Allow None buildtype

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,8 @@ if(NOT CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Choose the type of build." FORCE)
     # Set the possible values of build type for cmake-gui
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "RelWithDebInfo")
+  elseif(CMAKE_BUILD_TYPE MATCHES "^(None)$")
+    message(WARNING "Building with custom compiler flags is discouraged and can cause unexpected problems.")
   elseif(NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release|RelWithDebInfo)$")
     message(FATAL_ERROR "CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} is not supported, use one of Debug, Release or RelWithDebInfo.")
   endif()


### PR DESCRIPTION
Some distributions, in my case Alpine Linux, require building CMake packages with the
"None" buildtype as this makes packages use compiler flags required by
the distribution.

See a discussion with the Arch Linux maintainer:
https://github.com/archlinux/svntogit-community/commit/da37cf256156dead98e5a62219ab4006167986f9#r53047679

And with one of the Alpine Linux packagers:
https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/23363#note_168960