### PR TITLE
Check if HAVE_XSCREENSAVER_SUSPEND is defined befor using the value

### DIFF
--- a/src/util/screensaver.cpp
+++ b/src/util/screensaver.cpp
@@ -26,11 +26,11 @@ https://github.com/awjackson/bsnes-classic/blob/038e2e051ffc8abe7c56a3bf27e3016c
 #  include <windows.h>
 #elif defined(Q_OS_LINUX)
 #  include <QtDBus>
-#elif HAVE_XSCREENSAVER_SUSPEND
+#elif defined(HAVE_XSCREENSAVER_SUSPEND) && HAVE_XSCREENSAVER_SUSPEND
 #  include <X11/extensions/scrnsaver.h>
 #endif // Q_OS_WIN
 
-#if defined(Q_OS_LINUX) || HAVE_XSCREENSAVER_SUSPEND
+#if defined(Q_OS_LINUX) || (defined(HAVE_XSCREENSAVER_SUSPEND) && HAVE_XSCREENSAVER_SUSPEND)
 #  define None XNone
 #  define Window XWindow
 #  include <X11/Xlib.h>


### PR DESCRIPTION
This fixes the following warning when building with MacOs:
```
2021-07-18T18:01:48.7733180Z ##[warning]/Users/runner/work/mixxx/mixxx/src/util/screensaver.cpp:33:28: warning: 'HAVE_XSCREENSAVER_SUSPEND' is not defined, evaluates to 0 [-Wundef]
2021-07-18T18:01:48.7791160Z #if defined(Q_OS_LINUX) || HAVE_XSCREENSAVER_SUSPEND
```