### PR TITLE
constexpr DEBUG_ASSERT

### DIFF
--- a/src/util/assert.h
+++ b/src/util/assert.h
@@ -2,26 +2,23 @@
 
 #include <QtDebug>
 
-
 static constexpr const char* kDebugAssertPrefix = "DEBUG ASSERT";
 
-inline void mixxx_noop(void) {}
-
+#ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
 inline void mixxx_debug_assert(const char* assertion, const char* file, int line, const char* function) {
     qCritical("%s: \"%s\" in function %s at %s:%d", kDebugAssertPrefix, assertion, function, file, line);
 }
-
-inline bool mixxx_maybe_debug_assert_return_true(const char* assertion, const char* file, int line, const char* function) {
-#ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
-    mixxx_debug_assert(assertion, file, line, function);
-#else
-    Q_UNUSED(assertion);
-    Q_UNUSED(file);
-    Q_UNUSED(line);
-    Q_UNUSED(function);
 #endif
+
+#ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
+inline bool mixxx_maybe_debug_assert_return_true(const char* assertion,
+        const char* file,
+        int line,
+        const char* function) {
+    mixxx_debug_assert(assertion, file, line, function);
     return true;
 }
+#endif
 
 inline void mixxx_release_assert(const char* assertion, const char* file, int line, const char* function) {
     qFatal("ASSERT: \"%s\" in function %s at %s:%d", assertion, function, file, line);
@@ -40,7 +37,10 @@ inline void mixxx_release_assert(const char* assertion, const char* file, int li
 /// very hard before using this -- this should only be for the most dire of
 /// situations where we know Mixxx cannot take any action without potentially
 /// corrupting user data. Handle errors gracefully whenever possible.
-#define RELEASE_ASSERT(cond) ((!(cond)) ? mixxx_release_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION) : mixxx_noop())
+#define RELEASE_ASSERT(cond)                                              \
+    if (Q_UNLIKELY(!(cond))) {                                            \
+        mixxx_release_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION); \
+    }
 
 // Checks that cond is true in debug builds. If cond is false then prints a
 // warning message to the console. If Mixxx is built with
@@ -52,11 +52,20 @@ inline void mixxx_release_assert(const char* assertion, const char* file, int li
 //
 // In release builds, doSomething() is never called!
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
-#define DEBUG_ASSERT(cond) ((!(cond)) ? mixxx_debug_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION) : mixxx_noop())
+#define DEBUG_ASSERT(cond)                                              \
+    if (Q_UNLIKELY(!(cond))) {                                          \
+        mixxx_debug_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION); \
+    }
 #else
 #define DEBUG_ASSERT(cond)
 #endif
 
 /// Same as DEBUG_ASSERT, but if MIXXX_DEBUG_ASSERTIONS_FATAL is disabled run the specified fallback function.
 /// In most cases you should probably use this rather than DEBUG_ASSERT. Only use DEBUG_ASSERT if there is no appropriate fallback.
-#define VERIFY_OR_DEBUG_ASSERT(cond) if ((!(cond)) && mixxx_maybe_debug_assert_return_true(#cond, __FILE__, __LINE__, ASSERT_FUNCTION))
+#ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
+#define VERIFY_OR_DEBUG_ASSERT(cond) \
+    if (Q_UNLIKELY(!(cond)) &&       \
+            mixxx_maybe_debug_assert_return_true(#cond, __FILE__, __LINE__, ASSERT_FUNCTION))
+#else
+#define VERIFY_OR_DEBUG_ASSERT(cond) if (Q_UNLIKELY(!(cond)))
+#endif

--- a/src/util/assert.h
+++ b/src/util/assert.h
@@ -38,7 +38,7 @@ inline void mixxx_release_assert(const char* assertion, const char* file, int li
 /// situations where we know Mixxx cannot take any action without potentially
 /// corrupting user data. Handle errors gracefully whenever possible.
 #define RELEASE_ASSERT(cond)                                              \
-    if (Q_UNLIKELY(!(cond))) {                                            \
+    if (Q_UNLIKELY(!static_cast<bool>(cond))) {                           \
         mixxx_release_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION); \
     }
 
@@ -53,7 +53,7 @@ inline void mixxx_release_assert(const char* assertion, const char* file, int li
 // In release builds, doSomething() is never called!
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
 #define DEBUG_ASSERT(cond)                                              \
-    if (Q_UNLIKELY(!(cond))) {                                          \
+    if (Q_UNLIKELY(!static_cast<bool>(cond))) {                         \
         mixxx_debug_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION); \
     }
 #else
@@ -63,9 +63,9 @@ inline void mixxx_release_assert(const char* assertion, const char* file, int li
 /// Same as DEBUG_ASSERT, but if MIXXX_DEBUG_ASSERTIONS_FATAL is disabled run the specified fallback function.
 /// In most cases you should probably use this rather than DEBUG_ASSERT. Only use DEBUG_ASSERT if there is no appropriate fallback.
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
-#define VERIFY_OR_DEBUG_ASSERT(cond) \
-    if (Q_UNLIKELY(!(cond)) &&       \
+#define VERIFY_OR_DEBUG_ASSERT(cond)            \
+    if (Q_UNLIKELY(!static_cast<bool>(cond)) && \
             mixxx_maybe_debug_assert_return_true(#cond, __FILE__, __LINE__, ASSERT_FUNCTION))
 #else
-#define VERIFY_OR_DEBUG_ASSERT(cond) if (Q_UNLIKELY(!(cond)))
+#define VERIFY_OR_DEBUG_ASSERT(cond) if (Q_UNLIKELY(!static_cast<bool>(cond)))
 #endif

--- a/src/util/assert.h
+++ b/src/util/assert.h
@@ -11,7 +11,7 @@ inline void mixxx_debug_assert(const char* assertion, const char* file, int line
 #endif
 
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
-inline bool mixxx_maybe_debug_assert_return_true(const char* assertion,
+inline bool mixxx_debug_assert_return_true(const char* assertion,
         const char* file,
         int line,
         const char* function) {
@@ -65,7 +65,7 @@ inline void mixxx_release_assert(const char* assertion, const char* file, int li
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
 #define VERIFY_OR_DEBUG_ASSERT(cond)            \
     if (Q_UNLIKELY(!static_cast<bool>(cond)) && \
-            mixxx_maybe_debug_assert_return_true(#cond, __FILE__, __LINE__, ASSERT_FUNCTION))
+            mixxx_debug_assert_return_true(#cond, __FILE__, __LINE__, ASSERT_FUNCTION))
 #else
 #define VERIFY_OR_DEBUG_ASSERT(cond) if (Q_UNLIKELY(!static_cast<bool>(cond)))
 #endif


### PR DESCRIPTION
Replace the unused conditional assignment by plain if() to make our asserts usable in contsexpr

In case the assertion failed the compiler is already complaining that the assertion is no longer const, because QCritical is not const.


