### PR TITLE
prohibit WWaveformViewer getting focused

### DIFF
--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -43,6 +43,7 @@ WWaveformViewer::WWaveformViewer(
     m_pPlayEnabled = new ControlProxy(group, "play", this, ControlFlag::NoAssertIfMissing);
 
     setAttribute(Qt::WA_OpaquePaintEvent);
+    setFocusPolicy(Qt::NoFocus);
 }
 
 WWaveformViewer::~WWaveformViewer() {


### PR DESCRIPTION
so the currently focused widget stays focused, which is crucial for toggling maximize_library
with <Spacebar> when any of the library widgets has focus.

backport of #4128