### PR TITLE
Bpm: Add a beatLength() method that returns a duration

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -30,10 +30,9 @@ namespace {
 
 constexpr double kBpmTabRounding = 1 / 12.0;
 constexpr int kFilterLength = 80;
-constexpr int kMinBpm = 30;
+constexpr auto kMinBpm = mixxx::Bpm(30.0);
 // Maximum allowed interval between beats (calculated from kMinBpm).
-const mixxx::Duration kMaxInterval = mixxx::Duration::fromMillis(
-        static_cast<qint64>(1000.0 * (60.0 / kMinBpm)));
+const mixxx::Duration kMaxInterval = kMinBpm.beatLength();
 
 } // namespace
 

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -55,19 +55,20 @@ TEST(BeatGridTest, Scale) {
 }
 
 TEST(BeatGridTest, TestNthBeatWhenOnBeat) {
-    constexpr int sampleRate = 44100;
+    constexpr auto sampleRate = mixxx::audio::SampleRate(44100);
     TrackPointer pTrack = newTrack(sampleRate);
 
-    constexpr double bpm = 60.1;
-    pTrack->trySetBpm(bpm);
-    constexpr mixxx::audio::FrameDiff_t beatLengthFrames = 60.0 * sampleRate / bpm;
+    constexpr auto bpm = mixxx::Bpm(60.1);
+    pTrack->trySetBpm(bpm.value());
+    const mixxx::audio::FrameDiff_t beatLengthFrames =
+            bpm.beatLength().toDoubleSeconds() * sampleRate;
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
             QString(),
             mixxx::Bpm(bpm),
             mixxx::audio::kStartFramePos);
     // Pretend we're on the 20th beat;
-    constexpr mixxx::audio::FramePos position(beatLengthFrames * 20);
+    const mixxx::audio::FramePos position(beatLengthFrames * 20);
 
     // The spec dictates that a value of 0 is always invalid and returns an invalid position
     EXPECT_FALSE(pGrid->findNthBeat(position, 0).isValid());
@@ -100,12 +101,13 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat) {
 }
 
 TEST(BeatGridTest, TestNthBeatWhenNotOnBeat) {
-    constexpr int sampleRate = 44100;
+    constexpr auto sampleRate = mixxx::audio::SampleRate(44100);
     TrackPointer pTrack = newTrack(sampleRate);
 
     constexpr mixxx::Bpm bpm(60.1);
     pTrack->trySetBpm(bpm.value());
-    const mixxx::audio::FrameDiff_t beatLengthFrames = 60.0 * sampleRate / bpm.value();
+    const mixxx::audio::FrameDiff_t beatLengthFrames =
+            bpm.beatLength().toDoubleSeconds() * sampleRate;
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
             QString(),

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -60,8 +60,7 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat) {
 
     constexpr auto bpm = mixxx::Bpm(60.1);
     pTrack->trySetBpm(bpm.value());
-    const mixxx::audio::FrameDiff_t beatLengthFrames =
-            bpm.beatLength().toDoubleSeconds() * sampleRate;
+    const mixxx::audio::FrameDiff_t beatLengthFrames = bpm.beatLength().toFrames(sampleRate);
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
             QString(),
@@ -106,8 +105,7 @@ TEST(BeatGridTest, TestNthBeatWhenNotOnBeat) {
 
     constexpr mixxx::Bpm bpm(60.1);
     pTrack->trySetBpm(bpm.value());
-    const mixxx::audio::FrameDiff_t beatLengthFrames =
-            bpm.beatLength().toDoubleSeconds() * sampleRate;
+    const mixxx::audio::FrameDiff_t beatLengthFrames = bpm.beatLength().toFrames(sampleRate);
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
             QString(),

--- a/src/test/bpmcontrol_test.cpp
+++ b/src/test/bpmcontrol_test.cpp
@@ -33,9 +33,10 @@ TEST_F(BpmControlTest, BeatContext_BeatGrid) {
             mixxx::audio::Bitrate(),
             mixxx::Duration::fromSeconds(180));
 
-    const auto bpm = mixxx::Bpm(60.0);
+    constexpr auto bpm = mixxx::Bpm(60.0);
     const int kFrameSize = 2;
-    const double expectedBeatLength = (60.0 * sampleRate / bpm.value()) * kFrameSize;
+    const double expectedBeatLengthSamples =
+            bpm.beatLength().toDoubleSeconds() * sampleRate * kFrameSize;
 
     const mixxx::BeatsPointer pBeats = BeatFactory::makeBeatGrid(
             pTrack->getSampleRate(), bpm, mixxx::audio::kStartFramePos);
@@ -46,6 +47,6 @@ TEST_F(BpmControlTest, BeatContext_BeatGrid) {
                                            &beatLength, &beatPercentage));
     EXPECT_DOUBLE_EQ(0.0, prevBeat);
     EXPECT_DOUBLE_EQ(beatLength, nextBeat);
-    EXPECT_DOUBLE_EQ(expectedBeatLength, beatLength);
+    EXPECT_DOUBLE_EQ(expectedBeatLengthSamples, beatLength);
     EXPECT_DOUBLE_EQ(0.0, beatPercentage);
 }

--- a/src/test/bpmcontrol_test.cpp
+++ b/src/test/bpmcontrol_test.cpp
@@ -24,19 +24,18 @@ TEST_F(BpmControlTest, ShortestPercentageChange) {
 }
 
 TEST_F(BpmControlTest, BeatContext_BeatGrid) {
-    const int sampleRate = 44100;
+    constexpr auto sampleRate = mixxx::audio::SampleRate(44100);
 
     TrackPointer pTrack = Track::newTemporary();
     pTrack->setAudioProperties(
             mixxx::audio::ChannelCount(2),
-            mixxx::audio::SampleRate(sampleRate),
+            sampleRate,
             mixxx::audio::Bitrate(),
             mixxx::Duration::fromSeconds(180));
 
     constexpr auto bpm = mixxx::Bpm(60.0);
     const int kFrameSize = 2;
-    const double expectedBeatLengthSamples =
-            bpm.beatLength().toDoubleSeconds() * sampleRate * kFrameSize;
+    const double expectedBeatLengthSamples = bpm.beatLength().toFrames(sampleRate) * kFrameSize;
 
     const mixxx::BeatsPointer pBeats = BeatFactory::makeBeatGrid(
             pTrack->getSampleRate(), bpm, mixxx::audio::kStartFramePos);

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -1988,8 +1988,7 @@ TEST_F(EngineSyncTest, HalfDoubleConsistency) {
     // half-double matching should be consistent
     constexpr auto sampleRate = mixxx::audio::SampleRate(44100);
 
-    mixxx::audio::FrameDiff_t beatLengthFrames =
-            mixxx::Bpm(90.0).beatLength().toDoubleSeconds() * sampleRate;
+    mixxx::audio::FrameDiff_t beatLengthFrames = mixxx::Bpm(90.0).beatLength().toFrames(sampleRate);
     constexpr auto startOffsetFrames = mixxx::audio::kStartFramePos;
     const int numBeats = 100;
     QVector<mixxx::audio::FramePos> beats1 =
@@ -1997,7 +1996,7 @@ TEST_F(EngineSyncTest, HalfDoubleConsistency) {
     auto pBeats1 = mixxx::BeatMap::makeBeatMap(m_pTrack1->getSampleRate(), QString(), beats1);
     m_pTrack1->trySetBeats(pBeats1);
 
-    beatLengthFrames = mixxx::Bpm(145.0).beatLength().toDoubleSeconds() * sampleRate;
+    beatLengthFrames = mixxx::Bpm(145.0).beatLength().toFrames(sampleRate);
     QVector<mixxx::audio::FramePos> beats2 =
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
     auto pBeats2 = mixxx::BeatMap::makeBeatMap(m_pTrack2->getSampleRate(), QString(), beats2);

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -1986,7 +1986,10 @@ QVector<mixxx::audio::FramePos> createBeatVector(
 
 TEST_F(EngineSyncTest, HalfDoubleConsistency) {
     // half-double matching should be consistent
-    mixxx::audio::FrameDiff_t beatLengthFrames = 60.0 * 44100 / 90.0;
+    constexpr auto sampleRate = mixxx::audio::SampleRate(44100);
+
+    mixxx::audio::FrameDiff_t beatLengthFrames =
+            mixxx::Bpm(90.0).beatLength().toDoubleSeconds() * sampleRate;
     constexpr auto startOffsetFrames = mixxx::audio::kStartFramePos;
     const int numBeats = 100;
     QVector<mixxx::audio::FramePos> beats1 =
@@ -1994,7 +1997,7 @@ TEST_F(EngineSyncTest, HalfDoubleConsistency) {
     auto pBeats1 = mixxx::BeatMap::makeBeatMap(m_pTrack1->getSampleRate(), QString(), beats1);
     m_pTrack1->trySetBeats(pBeats1);
 
-    beatLengthFrames = 60.0 * 44100 / 145.0;
+    beatLengthFrames = mixxx::Bpm(145.0).beatLength().toDoubleSeconds() * sampleRate;
     QVector<mixxx::audio::FramePos> beats2 =
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
     auto pBeats2 = mixxx::BeatMap::makeBeatMap(m_pTrack2->getSampleRate(), QString(), beats2);

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -89,7 +89,7 @@ BeatsPointer BeatGrid::makeBeatGrid(
     grid.mutable_first_beat()->set_frame_position(
             static_cast<google::protobuf::int32>(firstBeatPosition.value()));
     // Calculate beat length as sample offsets
-    const audio::FrameDiff_t beatLengthFrames = 60.0 * sampleRate / bpm.value();
+    const audio::FrameDiff_t beatLengthFrames = bpm.beatLength().toDoubleSeconds() * sampleRate;
 
     return BeatsPointer(new BeatGrid(sampleRate, subVersion, grid, beatLengthFrames));
 }
@@ -330,7 +330,8 @@ BeatsPointer BeatGrid::scale(BpmScale scale) const {
 
     bpm = BeatUtils::roundBpmWithinRange(bpm - kBpmScaleRounding, bpm, bpm + kBpmScaleRounding);
     grid.mutable_bpm()->set_bpm(bpm.value());
-    const mixxx::audio::FrameDiff_t beatLengthFrames = (60.0 * m_sampleRate / bpm.value());
+    const mixxx::audio::FrameDiff_t beatLengthFrames =
+            bpm.beatLength().toDoubleSeconds() * m_sampleRate;
     return BeatsPointer(new BeatGrid(*this, grid, beatLengthFrames));
 }
 
@@ -340,7 +341,8 @@ BeatsPointer BeatGrid::setBpm(mixxx::Bpm bpm) {
     }
     mixxx::track::io::BeatGrid grid = m_grid;
     grid.mutable_bpm()->set_bpm(bpm.value());
-    const mixxx::audio::FrameDiff_t beatLengthFrames = (60.0 * m_sampleRate / bpm.value());
+    const mixxx::audio::FrameDiff_t beatLengthFrames =
+            bpm.beatLength().toDoubleSeconds() * m_sampleRate;
     return BeatsPointer(new BeatGrid(*this, grid, beatLengthFrames));
 }
 

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -89,7 +89,7 @@ BeatsPointer BeatGrid::makeBeatGrid(
     grid.mutable_first_beat()->set_frame_position(
             static_cast<google::protobuf::int32>(firstBeatPosition.value()));
     // Calculate beat length as sample offsets
-    const audio::FrameDiff_t beatLengthFrames = bpm.beatLength().toDoubleSeconds() * sampleRate;
+    const audio::FrameDiff_t beatLengthFrames = bpm.beatLength().toFrames(sampleRate);
 
     return BeatsPointer(new BeatGrid(sampleRate, subVersion, grid, beatLengthFrames));
 }
@@ -330,8 +330,7 @@ BeatsPointer BeatGrid::scale(BpmScale scale) const {
 
     bpm = BeatUtils::roundBpmWithinRange(bpm - kBpmScaleRounding, bpm, bpm + kBpmScaleRounding);
     grid.mutable_bpm()->set_bpm(bpm.value());
-    const mixxx::audio::FrameDiff_t beatLengthFrames =
-            bpm.beatLength().toDoubleSeconds() * m_sampleRate;
+    const mixxx::audio::FrameDiff_t beatLengthFrames = bpm.beatLength().toFrames(m_sampleRate);
     return BeatsPointer(new BeatGrid(*this, grid, beatLengthFrames));
 }
 
@@ -341,8 +340,7 @@ BeatsPointer BeatGrid::setBpm(mixxx::Bpm bpm) {
     }
     mixxx::track::io::BeatGrid grid = m_grid;
     grid.mutable_bpm()->set_bpm(bpm.value());
-    const mixxx::audio::FrameDiff_t beatLengthFrames =
-            bpm.beatLength().toDoubleSeconds() * m_sampleRate;
+    const mixxx::audio::FrameDiff_t beatLengthFrames = bpm.beatLength().toFrames(m_sampleRate);
     return BeatsPointer(new BeatGrid(*this, grid, beatLengthFrames));
 }
 

--- a/src/track/beatutils.cpp
+++ b/src/track/beatutils.cpp
@@ -313,7 +313,7 @@ mixxx::Bpm BeatUtils::makeConstBpm(
         // bpm adjustments are made.
         // This is a temporary fix, ideally the anchor point for the BPM grid should
         // be the first proper downbeat, or perhaps the CUE point.
-        const double roundedBeatLength = 60.0 * sampleRate / roundBpm.value();
+        const double roundedBeatLength = roundBpm.beatLength().toDoubleSeconds() * sampleRate;
         *pFirstBeat = mixxx::audio::FramePos(
                 fmod(constantRegions[startRegionIndex].firstBeat.value(),
                         roundedBeatLength));
@@ -387,15 +387,16 @@ mixxx::audio::FramePos BeatUtils::adjustPhase(
         mixxx::Bpm bpm,
         mixxx::audio::SampleRate sampleRate,
         const QVector<mixxx::audio::FramePos>& beats) {
-    const double beatLength = 60 * sampleRate / bpm.value();
+    const mixxx::audio::FrameDiff_t beatLengthFrames =
+            bpm.beatLength().toDoubleSeconds() * sampleRate;
     const mixxx::audio::FramePos startOffset =
-            mixxx::audio::FramePos(fmod(firstBeat.value(), beatLength));
+            mixxx::audio::FramePos(fmod(firstBeat.value(), beatLengthFrames));
     mixxx::audio::FrameDiff_t offsetAdjust = 0;
     double offsetAdjustCount = 0;
     for (const auto& beat : beats) {
-        mixxx::audio::FrameDiff_t offset = fmod(beat - startOffset, beatLength);
-        if (offset > beatLength / 2) {
-            offset -= beatLength;
+        mixxx::audio::FrameDiff_t offset = fmod(beat - startOffset, beatLengthFrames);
+        if (offset > beatLengthFrames / 2) {
+            offset -= beatLengthFrames;
         }
         if (abs(offset) < (kMaxSecsPhaseError * sampleRate)) {
             offsetAdjust += offset;

--- a/src/track/beatutils.cpp
+++ b/src/track/beatutils.cpp
@@ -313,7 +313,7 @@ mixxx::Bpm BeatUtils::makeConstBpm(
         // bpm adjustments are made.
         // This is a temporary fix, ideally the anchor point for the BPM grid should
         // be the first proper downbeat, or perhaps the CUE point.
-        const double roundedBeatLength = roundBpm.beatLength().toDoubleSeconds() * sampleRate;
+        const double roundedBeatLength = roundBpm.beatLength().toFrames(sampleRate);
         *pFirstBeat = mixxx::audio::FramePos(
                 fmod(constantRegions[startRegionIndex].firstBeat.value(),
                         roundedBeatLength));
@@ -387,8 +387,7 @@ mixxx::audio::FramePos BeatUtils::adjustPhase(
         mixxx::Bpm bpm,
         mixxx::audio::SampleRate sampleRate,
         const QVector<mixxx::audio::FramePos>& beats) {
-    const mixxx::audio::FrameDiff_t beatLengthFrames =
-            bpm.beatLength().toDoubleSeconds() * sampleRate;
+    const mixxx::audio::FrameDiff_t beatLengthFrames = bpm.beatLength().toFrames(sampleRate);
     const mixxx::audio::FramePos startOffset =
             mixxx::audio::FramePos(fmod(firstBeat.value(), beatLengthFrames));
     mixxx::audio::FrameDiff_t offsetAdjust = 0;

--- a/src/track/bpm.h
+++ b/src/track/bpm.h
@@ -2,6 +2,7 @@
 
 #include <QtDebug>
 
+#include "util/duration.h"
 #include "util/fpclassify.h"
 #include "util/math.h"
 
@@ -96,6 +97,11 @@ public:
 
     QString displayText() const {
         return displayValueText(m_value);
+    }
+
+    /// Get the duration between two beats for this BPM.
+    mixxx::Duration beatLength() const {
+        return mixxx::Duration::fromSeconds(60.0 / value());
     }
 
     Bpm& operator+=(double increment) {

--- a/src/util/duration.h
+++ b/src/util/duration.h
@@ -2,10 +2,11 @@
 
 #include <QMetaType>
 #include <QString>
+#include <QTextStreamFunction>
 #include <QtDebug>
 #include <QtGlobal>
-#include <QTextStreamFunction>
 
+#include "audio/types.h"
 #include "util/assert.h"
 
 namespace mixxx {
@@ -60,6 +61,11 @@ class DurationBase {
     // Returns the duration as an integer number of nanoseconds.
     constexpr double toDoubleNanos() const {
         return m_durationNanos;
+    }
+
+    // Returns the duration as an integer number of nanoseconds.
+    constexpr double toFrames(mixxx::audio::SampleRate sampleRate) const {
+        return toDoubleSeconds() * sampleRate;
     }
 
     enum class Precision {

--- a/src/util/duration.h
+++ b/src/util/duration.h
@@ -23,43 +23,43 @@ class DurationBase {
 
     // Returns the duration as an integer number of seconds (rounded-down).
     constexpr qint64 toIntegerSeconds() const {
-        return m_durationNanos / kNanosPerSecond;
+        return static_cast<qint64>(toDoubleSeconds());
     }
 
     // Returns the duration as a floating point number of seconds.
     constexpr double toDoubleSeconds() const {
-        return static_cast<double>(m_durationNanos) / kNanosPerSecond;
+        return m_durationNanos / kNanosPerSecond;
     }
 
     // Returns the duration as an integer number of milliseconds (rounded-down).
     constexpr qint64 toIntegerMillis() const {
-        return m_durationNanos / kNanosPerMilli;
+        return static_cast<qint64>(toDoubleMillis());
     }
 
     // Returns the duration as a floating point number of milliseconds.
     constexpr double toDoubleMillis() const {
-        return static_cast<double>(m_durationNanos) / kNanosPerMilli;
+        return m_durationNanos / kNanosPerMilli;
     }
 
     // Returns the duration as an integer number of microseconds (rounded-down).
     constexpr qint64 toIntegerMicros() const {
-        return m_durationNanos / kNanosPerMicro;
+        return static_cast<qint64>(toDoubleMicros());
     }
 
     // Returns the duration as a floating point number of microseconds.
     constexpr double toDoubleMicros() const {
-        return static_cast<double>(m_durationNanos) / kNanosPerMicro;
+        return m_durationNanos / kNanosPerMicro;
     }
 
     // Returns the duration as an integer number of nanoseconds. The duration is
     // represented internally as nanoseconds so no rounding occurs.
     constexpr qint64 toIntegerNanos() const {
-        return m_durationNanos;
+        return static_cast<qint64>(toDoubleNanos());
     }
 
     // Returns the duration as an integer number of nanoseconds.
     constexpr double toDoubleNanos() const {
-        return static_cast<double>(m_durationNanos);
+        return m_durationNanos;
     }
 
     enum class Precision {
@@ -84,22 +84,22 @@ class DurationBase {
             double dSeconds,
             Precision precision = Precision::SECONDS);
 
-    static constexpr qint64 kMillisPerSecond = 1000;
-    static constexpr qint64 kMicrosPerSecond = kMillisPerSecond * 1000;
-    static constexpr qint64 kNanosPerSecond  = kMicrosPerSecond * 1000;
-    static constexpr qint64 kNanosPerMilli   = kNanosPerSecond / 1000;
-    static constexpr qint64 kNanosPerMicro   = kNanosPerMilli / 1000;
+    static constexpr double kMillisPerSecond = 1000;
+    static constexpr double kMicrosPerSecond = kMillisPerSecond * 1000;
+    static constexpr double kNanosPerSecond = kMicrosPerSecond * 1000;
+    static constexpr double kNanosPerMilli = kNanosPerSecond / 1000;
+    static constexpr double kNanosPerMicro = kNanosPerMilli / 1000;
     static const QString kInvalidDurationString;
     static QChar kKiloGroupSeparator;
     static QChar kHectoGroupSeparator;
     static QChar kDecimalSeparator;
 
   protected:
-    explicit constexpr DurationBase(qint64 durationNanos)
-        : m_durationNanos(durationNanos) {
+    explicit constexpr DurationBase(double durationNanos)
+            : m_durationNanos(durationNanos) {
     }
 
-    qint64 m_durationNanos;
+    double m_durationNanos;
 };
 
 class DurationDebug : public DurationBase {
@@ -136,21 +136,21 @@ class Duration : public DurationBase {
     // Returns a Duration object representing a duration of 'seconds'.
     template<typename T>
     static constexpr Duration fromSeconds(T seconds) {
-        return Duration(static_cast<qint64>(seconds * kNanosPerSecond));
+        return Duration(static_cast<double>(seconds * kNanosPerSecond));
     }
 
     // Returns a Duration object representing a duration of 'millis'.
-    static constexpr Duration fromMillis(qint64 millis) {
+    static constexpr Duration fromMillis(double millis) {
         return Duration(millis * kNanosPerMilli);
     }
 
     // Returns a Duration object representing a duration of 'micros'.
-    static constexpr Duration fromMicros(qint64 micros) {
+    static constexpr Duration fromMicros(double micros) {
         return Duration(micros * kNanosPerMicro);
     }
 
     // Returns a Duration object representing a duration of 'nanos'.
-    static constexpr Duration fromNanos(qint64 nanos) {
+    static constexpr Duration fromNanos(double nanos) {
         return Duration(nanos);
     }
 
@@ -264,7 +264,7 @@ class Duration : public DurationBase {
     }
 
   private:
-    explicit constexpr Duration(qint64 durationNanos)
+    explicit constexpr Duration(double durationNanos)
             : DurationBase(durationNanos) {
     }
 };


### PR DESCRIPTION
I think semantically this makes sense and would look nicer in code. Right now, the `Bpm::beatLength()` method returns a `mixxx::Duration`. I also added a method `Duration::toFrames(SampleRate)` to make the code even easier to read.

The `mixxx::Duration` class uses a 64 bit integer for storing full nanoseconds. Does this precision suffice? I don't know. Some tests fail due to this loss of precision, because they hardcode a lot of decimal points. Please let me know if we should we change the tests, not use `mixxx::Duration`, or just not make this change at all? 

Related Zulip Discussion: https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/Semantic.20type.20refactoring/near/246427762