### PR TITLE
Link time asserts

### DIFF
--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -110,7 +110,7 @@ bool AnalyzerBeats::initialize(const AnalyzerTrack& track,
         } else {
             // This must not happen, because we have already verified above
             // that the PlugInId is valid
-            DEBUG_ASSERT(false);
+            DEBUG_ASSERT_UNREACHABLE(false);
         }
 
         if (m_pPlugin) {

--- a/src/analyzer/analyzerkey.cpp
+++ b/src/analyzer/analyzerkey.cpp
@@ -105,7 +105,7 @@ bool AnalyzerKey::initialize(const AnalyzerTrack& track,
         } else {
             // This must not happen, because we have already verified above
             // that the PlugInId is valid
-            DEBUG_ASSERT(false);
+            DEBUG_ASSERT_UNREACHABLE(false);
         }
 
         if (m_pPlugin) {

--- a/src/analyzer/plugins/analyzerqueenmarykey.cpp
+++ b/src/analyzer/plugins/analyzerqueenmarykey.cpp
@@ -62,7 +62,7 @@ bool AnalyzerQueenMaryKey::initialize(mixxx::audio::SampleRate sampleRate) {
 
                 if (!ChromaticKey_IsValid(iKey)) {
                     qWarning() << "No valid key detected in analyzed window:" << iKey;
-                    DEBUG_ASSERT(!"iKey is invalid");
+                    DEBUG_ASSERT_UNREACHABLE(!"iKey is invalid");
                     return false;
                 }
                 const auto key = static_cast<ChromaticKey>(iKey);

--- a/src/analyzer/trackanalysisscheduler.cpp
+++ b/src/analyzer/trackanalysisscheduler.cpp
@@ -231,7 +231,7 @@ void TrackAnalysisScheduler::onWorkerThreadProgress(
         DEBUG_ASSERT(!worker);
         break;
     default:
-        DEBUG_ASSERT(!"Unhandled signal from worker thread");
+        DEBUG_ASSERT_UNREACHABLE(!"Unhandled signal from worker thread");
     }
     emitProgressOrFinished();
 }

--- a/src/audio/types.cpp
+++ b/src/audio/types.cpp
@@ -13,7 +13,7 @@ QDebug operator<<(QDebug dbg, ChannelLayout arg) {
     case ChannelLayout::Stereo:
         return dbg << "Stereo";
     }
-    DEBUG_ASSERT(!"unreachable code");
+    DEBUG_ASSERT_UNREACHABLE(!"unreachable code");
     return dbg;
 }
 

--- a/src/controllers/scripting/colormapper.cpp
+++ b/src/controllers/scripting/colormapper.cpp
@@ -70,7 +70,7 @@ QRgb ColorMapper::getNearestColor(QRgb desiredColor) {
     }
 
     DEBUG_ASSERT(m_availableColors.isEmpty());
-    DEBUG_ASSERT(!"Unreachable: No matching color found");
+    DEBUG_ASSERT_UNREACHABLE(!"Unreachable: No matching color found");
     return desiredColor;
 }
 

--- a/src/database/mixxxdb.cpp
+++ b/src/database/mixxxdb.cpp
@@ -116,6 +116,6 @@ bool MixxxDb::initDatabaseSchema(
         return false; // abort
     }
     // Suppress compiler warning
-    DEBUG_ASSERT(!"unhandled switch/case");
+    DEBUG_ASSERT_UNREACHABLE(!"unhandled switch/case");
     return false;
 }

--- a/src/database/schemamanager.cpp
+++ b/src/database/schemamanager.cpp
@@ -42,7 +42,7 @@ std::optional<int> readSchemaVersion(
         return std::nullopt;
     }
 
-    VERIFY_OR_DEBUG_ASSERT((schemaVersion >= INITIAL_VERSION)) {
+    VERIFY_OR_DEBUG_ASSERT(schemaVersion >= INITIAL_VERSION) {
         kLogger.critical()
                 << "Invalid database schema version"
                 << settingsValue;

--- a/src/database/schemamanager.cpp
+++ b/src/database/schemamanager.cpp
@@ -35,12 +35,20 @@ std::optional<int> readSchemaVersion(
     }
     bool ok = false;
     int schemaVersion = settingsValue.toInt(&ok);
-    VERIFY_OR_DEBUG_ASSERT(ok && (schemaVersion >= INITIAL_VERSION)) {
+    VERIFY_OR_DEBUG_ASSERT(ok) {
         kLogger.critical()
                 << "Invalid database schema version"
                 << settingsValue;
         return std::nullopt;
     }
+
+    VERIFY_OR_DEBUG_ASSERT((schemaVersion >= INITIAL_VERSION)) {
+        kLogger.critical()
+                << "Invalid database schema version"
+                << settingsValue;
+        return std::nullopt;
+    }
+
     return schemaVersion;
 }
 

--- a/src/effects/backends/effectprocessor.h
+++ b/src/effects/backends/effectprocessor.h
@@ -206,7 +206,6 @@ class EffectProcessorImpl : public EffectProcessor {
             }
         }
 
-        DEBUG_ASSERT(requiredVectorSize > 0);
         auto& outputChannelStates = m_channelStateMatrix[inputChannel];
         DEBUG_ASSERT(outputChannelStates.size() == 0);
         outputChannelStates.reserve(requiredVectorSize);

--- a/src/encoder/encoder.cpp
+++ b/src/encoder/encoder.cpp
@@ -123,7 +123,7 @@ EncoderPointer EncoderFactory::createEncoder(
     } else {
         qWarning() << "Unsupported format requested! "
                 << QString(pSettings ? pSettings->getFormat() : QString("NULL"));
-        DEBUG_ASSERT(false);
+        DEBUG_ASSERT_UNREACHABLE(false);
         pEncoder = std::make_shared<EncoderWave>(pCallback);
     }
     return pEncoder;
@@ -151,7 +151,7 @@ EncoderRecordingSettingsPointer EncoderFactory::getEncoderRecordingSettings(Enco
         return std::make_shared<EncoderFdkAacSettings>(pConfig, format.internalName);
     } else {
         qWarning() << "Unsupported format requested! " << format.internalName;
-        DEBUG_ASSERT(false);
+        DEBUG_ASSERT_UNREACHABLE(false);
         return std::make_shared<EncoderWaveSettings>(pConfig, ENCODING_WAVE);
     }
 }

--- a/src/encoder/encoderrecordingsettings.h
+++ b/src/encoder/encoderrecordingsettings.h
@@ -19,13 +19,13 @@ class EncoderRecordingSettings : public EncoderSettings {
 
     virtual void setQualityByIndex(int qualityIndex) {
         Q_UNUSED(qualityIndex);
-        DEBUG_ASSERT(!"unimplemented");
+        DEBUG_ASSERT_UNREACHABLE(!"unimplemented");
     }
 
     // Sets the compression level
     void setCompression(int compression) override {
         Q_UNUSED(compression);
-        DEBUG_ASSERT(!"unimplemented");
+        DEBUG_ASSERT_UNREACHABLE(!"unimplemented");
     }
 
     // Selects the option by its index. If it is a single-element option,
@@ -33,7 +33,7 @@ class EncoderRecordingSettings : public EncoderSettings {
     virtual void setGroupOption(const QString& groupCode, int optionIndex) {
         Q_UNUSED(groupCode);
         Q_UNUSED(optionIndex);
-        DEBUG_ASSERT(!"unimplemented");
+        DEBUG_ASSERT_UNREACHABLE(!"unimplemented");
     }
 
     // Override getChannelMode to read from recording preferences but making it

--- a/src/encoder/encodersndfileflac.cpp
+++ b/src/encoder/encodersndfileflac.cpp
@@ -26,7 +26,7 @@ void convertFloat32ToIntFormat(int* pDest, const CSAMPLE* pSrc, SINT numSamples,
                     static_cast<CSAMPLE>(static_cast<int>(INT_MAX & 0xFFFFFF00))));
         }
     } else {
-        DEBUG_ASSERT(!"Not implemented");
+        DEBUG_ASSERT_UNREACHABLE(!"Not implemented");
     }
 }
 

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -697,7 +697,7 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
         break;
     }
     default:
-        DEBUG_ASSERT(!"Unknown enum value");
+        DEBUG_ASSERT_UNREACHABLE(!"Unknown enum value");
         break;
     }
     seekOnLoad(mixxx::audio::kStartFramePos);
@@ -1029,7 +1029,7 @@ void CueControl::hotcueSet(HotcueControl* pControl, double value, HotcueSetMode 
         break;
     }
     default:
-        DEBUG_ASSERT(!"Invalid HotcueSetMode");
+        DEBUG_ASSERT_UNREACHABLE(!"Invalid HotcueSetMode");
         return;
     }
 
@@ -1267,7 +1267,7 @@ void CueControl::hotcueActivate(HotcueControl* pControl, double value, HotcueSet
                     }
                     break;
                 default:
-                    DEBUG_ASSERT(!"Invalid CueType!");
+                    DEBUG_ASSERT_UNREACHABLE(!"Invalid CueType!");
                 }
             } else {
                 // pressed during pause or preview

--- a/src/engine/effects/engineeffectsdelay.h
+++ b/src/engine/effects/engineeffectsdelay.h
@@ -42,10 +42,12 @@ class EngineEffectsDelay final : public EngineObject {
     /// a zero delay. When is the delay set, the EngineEffectsDelay::process
     /// method works with this set delay value until the value is changed.
     void setDelayFrames(SINT delayFrames) {
-        VERIFY_OR_DEBUG_ASSERT(delayFrames >= 0) {
+        if (delayFrames < 0) {
+            DEBUG_ASSERT_UNREACHABLE(false);
             delayFrames = 0;
         }
-        VERIFY_OR_DEBUG_ASSERT(delayFrames <= kMaxDelayFrames) {
+        if (delayFrames > kMaxDelayFrames) {
+            DEBUG_ASSERT_UNREACHABLE(false);
             delayFrames = kMaxDelayFrames;
         }
 

--- a/src/engine/effects/engineeffectsmanager.cpp
+++ b/src/engine/effects/engineeffectsmanager.cpp
@@ -38,7 +38,7 @@ void EngineEffectsManager::onCallbackStart() {
                 }
             }
 
-            VERIFY_OR_DEBUG_ASSERT(chainExists) {
+            RUNTIME_VERIFY_OR_DEBUG_ASSERT(chainExists) {
                 response.success = false;
                 response.status = EffectsResponse::NO_SUCH_CHAIN;
                 break;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1392,7 +1392,7 @@ void EngineBuffer::processSeek(bool paused) {
             position = pOtherChannel->getEngineBuffer()->getExactPlayPos();
         } break;
         default:
-            DEBUG_ASSERT(!"Unhandled seek request type");
+            DEBUG_ASSERT_UNREACHABLE(!"Unhandled seek request type");
             m_queuedSeek.setValue(kNoQueuedSeek);
             return;
     }

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -634,7 +634,7 @@ QVariant BaseTrackTableModel::roleValue(
             double durationInSeconds;
             if (rawValue.canConvert<mixxx::Duration>()) {
                 const auto duration = rawValue.value<mixxx::Duration>();
-                VERIFY_OR_DEBUG_ASSERT(duration >= mixxx::Duration::empty()) {
+                RUNTIME_VERIFY_OR_DEBUG_ASSERT(duration >= mixxx::Duration::empty()) {
                     return QVariant();
                 }
                 durationInSeconds = duration.toDoubleSeconds();
@@ -644,7 +644,7 @@ QVariant BaseTrackTableModel::roleValue(
                 }
                 bool ok;
                 durationInSeconds = rawValue.toDouble(&ok);
-                VERIFY_OR_DEBUG_ASSERT(ok && durationInSeconds >= 0) {
+                RUNTIME_VERIFY_OR_DEBUG_ASSERT(ok && durationInSeconds >= 0) {
                     return QVariant();
                 }
             }
@@ -661,7 +661,7 @@ QVariant BaseTrackTableModel::roleValue(
             }
             bool ok;
             const auto starCount = rawValue.toInt(&ok);
-            VERIFY_OR_DEBUG_ASSERT(ok && starCount >= StarRating::kMinStarCount) {
+            RUNTIME_VERIFY_OR_DEBUG_ASSERT(ok && starCount >= StarRating::kMinStarCount) {
                 return QVariant();
             }
             return QVariant::fromValue(StarRating(starCount));
@@ -675,7 +675,7 @@ QVariant BaseTrackTableModel::roleValue(
             }
             bool ok;
             const auto timesPlayed = rawValue.toInt(&ok);
-            VERIFY_OR_DEBUG_ASSERT(ok && timesPlayed >= 0) {
+            RUNTIME_VERIFY_OR_DEBUG_ASSERT(ok && timesPlayed >= 0) {
                 return QVariant();
             }
             return QString::number(timesPlayed);
@@ -1137,7 +1137,7 @@ void BaseTrackTableModel::slotRefreshOverviewRows(const QList<int>& rows) {
         return;
     }
     const int column = fieldIndex(LIBRARYTABLE_WAVESUMMARYHEX);
-    VERIFY_OR_DEBUG_ASSERT(column >= 0) {
+    RUNTIME_VERIFY_OR_DEBUG_ASSERT(column >= 0) {
         return;
     }
     emitDataChangedForMultipleRowsInColumn(rows, column);

--- a/src/library/coverart.cpp
+++ b/src/library/coverart.cpp
@@ -167,7 +167,7 @@ CoverInfo::LoadedImage CoverInfo::loadImage(TrackPointer pTrack) const {
     } else if (type == CoverInfo::NONE) {
         loadedImage.result = LoadedImage::Result::NoImage;
     } else {
-        DEBUG_ASSERT(!"unhandled CoverInfo::Type");
+        DEBUG_ASSERT_UNREACHABLE(!"unhandled CoverInfo::Type");
     }
     return loadedImage;
 }
@@ -210,7 +210,7 @@ QDebug operator<<(QDebug dbg, const CoverInfo::LoadedImage::Result& result) {
     case CoverInfo::LoadedImage::Result::ErrorUnknown:
         return dbg << "ErrorUnknown";
     }
-    DEBUG_ASSERT(!"unreachable");
+    DEBUG_ASSERT_UNREACHABLE(!"unreachable");
     return dbg;
 }
 

--- a/src/library/dao/autodjcratesdao.cpp
+++ b/src/library/dao/autodjcratesdao.cpp
@@ -565,7 +565,7 @@ TrackId AutoDJCratesDAO::getRandomTrackId() {
         AUTODJACTIVETRACKS_TABLE);
     if (!oQuery.exec()) {
         LOG_FAILED_QUERY(oQuery);
-        DEBUG_ASSERT(!"failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"failed query");
         return TrackId();
     }
     int iUnplayedTracks = 0;
@@ -649,7 +649,7 @@ TrackId AutoDJCratesDAO::getRandomTrackId() {
     oQuery.bindValue (":active", iActiveTracks);
     if (!oQuery.exec()) {
         LOG_FAILED_QUERY(oQuery);
-        DEBUG_ASSERT(!"failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"failed query");
         return TrackId();
     }
     if (oQuery.next()) {
@@ -680,7 +680,7 @@ TrackId AutoDJCratesDAO::getRandomTrackIdFromAutoDj(int percentActive) {
         " WHERE " AUTODJCRATESTABLE_AUTODJREFS " > 0" );
     if (!oQuery.exec()) {
         LOG_FAILED_QUERY(oQuery);
-        DEBUG_ASSERT(!"failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"failed query");
         return TrackId();
     }
     VERIFY_OR_DEBUG_ASSERT(oQuery.next()) {
@@ -720,7 +720,7 @@ TrackId AutoDJCratesDAO::getRandomTrackIdFromAutoDj(int percentActive) {
     oQuery.bindValue (":active", iActiveTracks);
     if (!oQuery.exec()) {
         LOG_FAILED_QUERY(oQuery);
-        DEBUG_ASSERT(!"failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"failed query");
         return TrackId();
     }
     if (oQuery.next()) {
@@ -1185,7 +1185,7 @@ TrackId AutoDJCratesDAO::getRandomTrackIdFromLibrary(int iPlaylistId) {
     oQuery.bindValue(":id",iPlaylistId);
     if (!oQuery.exec()) {
         LOG_FAILED_QUERY(oQuery);
-        DEBUG_ASSERT(!"failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"failed query");
         return TrackId();
     }
     int iTotalTracks = 0;
@@ -1249,7 +1249,7 @@ TrackId AutoDJCratesDAO::getRandomTrackIdFromLibrary(int iPlaylistId) {
     oQuery.bindValue(":offset", offset);
     if (!oQuery.exec()) {
         LOG_FAILED_QUERY(oQuery);
-        DEBUG_ASSERT(!"failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"failed query");
         return TrackId();
     }
     if (oQuery.next()) {

--- a/src/library/dao/autodjcratesdao.cpp
+++ b/src/library/dao/autodjcratesdao.cpp
@@ -656,7 +656,7 @@ TrackId AutoDJCratesDAO::getRandomTrackId() {
         // Give our caller the randomly-selected track.
         return TrackId(oQuery.value(0));
     } else {
-        DEBUG_ASSERT(false); // We should have exit earlier
+        DEBUG_ASSERT_UNREACHABLE(false); // We should have exit earlier
         qDebug() << "No random track available for Auto DJ";
         return TrackId();
     }
@@ -727,7 +727,7 @@ TrackId AutoDJCratesDAO::getRandomTrackIdFromAutoDj(int percentActive) {
         // Give our caller the randomly-selected track.
         return TrackId(oQuery.value(0));
     } else {
-        DEBUG_ASSERT(false); // We should have exit earlier
+        DEBUG_ASSERT_UNREACHABLE(false); // We should have exit earlier
         qDebug() << "No random track available for Auto DJ";
         return TrackId();
     }

--- a/src/library/dao/cuedao.cpp
+++ b/src/library/dao/cuedao.cpp
@@ -89,7 +89,7 @@ QList<CuePointer> CueDAO::getCuesForTrack(TrackId trackId) const {
         kLogger.warning()
                 << "Failed to load cues of track"
                 << trackId;
-        DEBUG_ASSERT(!"failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"failed query");
         return cues;
     }
     QMap<int, CuePointer> hotCuesByNumber;
@@ -234,7 +234,7 @@ void CueDAO::saveTrackCues(
         kLogger.warning()
                 << "Failed to delete orphaned cues of track"
                 << trackId;
-        DEBUG_ASSERT(!"failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"failed query");
         return;
     }
     if (query.numRowsAffected() > 0) {

--- a/src/library/dao/directorydao.cpp
+++ b/src/library/dao/directorydao.cpp
@@ -134,7 +134,7 @@ DirectoryDAO::AddResult DirectoryDAO::addDirectory(
             kLogger.warning()
                     << "Failed to remove obsolete child directory"
                     << oldDir.location();
-            DEBUG_ASSERT(!"removeDirectory failed");
+            DEBUG_ASSERT_UNREACHABLE(!"removeDirectory failed");
             continue;
         }
     }

--- a/src/library/dao/settingsdao.cpp
+++ b/src/library/dao/settingsdao.cpp
@@ -75,7 +75,7 @@ bool SettingsDAO::setValue(const QString& name, const QVariant& value) const {
         kLogger.warning()
                 << "Failed to set" << name << "=" << value
                 << query.lastError();
-        DEBUG_ASSERT(!"Failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"Failed query");
         return false;
     }
     return true;

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -56,7 +56,7 @@ void markTrackLocationsAsDeleted(const QSqlDatabase& database, const QString& di
     if (!query.exec()) {
         LOG_FAILED_QUERY(query)
                 << "Couldn't mark tracks in" << directory << "as deleted.";
-        DEBUG_ASSERT(!"Failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"Failed query");
     }
 }
 
@@ -164,7 +164,7 @@ TrackId TrackDAO::getTrackIdByLocation(const QString& location) const {
     query.bindValue(":location", location);
     if (!query.exec()) {
         LOG_FAILED_QUERY(query);
-        DEBUG_ASSERT(!"Failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"Failed query");
         return {};
     }
     if (!query.next()) {
@@ -215,7 +215,7 @@ QList<TrackId> TrackDAO::resolveTrackIds(
             "(location varchar (512))");
     if (!query.exec()) {
         LOG_FAILED_QUERY(query);
-        DEBUG_ASSERT(!"Failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"Failed query");
         return trackIds;
     }
 
@@ -225,7 +225,7 @@ QList<TrackId> TrackDAO::resolveTrackIds(
             "VALUES " + pathList.join(','));
     if (!query.exec()) {
         LOG_FAILED_QUERY(query);
-        DEBUG_ASSERT(!"Failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"Failed query");
     }
 
     if (flags & ResolveTrackIdFlag::AddMissing) {
@@ -239,7 +239,7 @@ QList<TrackId> TrackDAO::resolveTrackIds(
                 "WHERE playlist_import.location = track_locations.location)");
         if (!query.exec()) {
             LOG_FAILED_QUERY(query);
-            DEBUG_ASSERT(!"Failed query");
+            DEBUG_ASSERT_UNREACHABLE(!"Failed query");
         }
         const int locationColumn = query.record().indexOf(LIBRARYTABLE_LOCATION);
         while (query.next()) {
@@ -287,7 +287,7 @@ QList<TrackId> TrackDAO::resolveTrackIds(
     query.prepare("DROP TABLE IF EXISTS playlist_import");
     if (!query.exec()) {
         LOG_FAILED_QUERY(query);
-        DEBUG_ASSERT(!"Failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"Failed query");
     }
 
     return trackIds;
@@ -342,7 +342,7 @@ QString TrackDAO::getTrackLocation(TrackId trackId) const {
     query.bindValue(":id", trackId.toVariant());
     if (!query.exec()) {
         LOG_FAILED_QUERY(query);
-        DEBUG_ASSERT(!"Failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"Failed query");
         return "";
     }
     const int locationColumn = query.record().indexOf(LIBRARYTABLE_LOCATION);
@@ -723,7 +723,7 @@ bool insertTrackLibrary(
         LOG_FAILED_QUERY(*pTrackLibraryInsert)
                 << "Failed to insert new track into library:"
                 << fileInfo;
-        DEBUG_ASSERT(!"Failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"Failed query");
         return false;
     }
     return true;
@@ -1044,7 +1044,7 @@ QList<TrackRef> TrackDAO::getAllTrackRefs(const QDir& rootDir) const {
     query.bindValue(":locationPathPrefix", locationPathPrefix);
     if (!query.exec()) {
         LOG_FAILED_QUERY(query) << "could not get tracks within directory:" << locationPathPrefix;
-        DEBUG_ASSERT(!"Failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"Failed query");
     }
 
     QList<TrackRef> trackRefs;
@@ -1476,7 +1476,7 @@ TrackPointer TrackDAO::getTrackById(TrackId trackId) const {
         if (!query.exec()) {
             LOG_FAILED_QUERY(query)
                     << QString("getTrack(%1)").arg(trackId.toString());
-            DEBUG_ASSERT(!"Failed query");
+            DEBUG_ASSERT_UNREACHABLE(!"Failed query");
             return nullptr;
         }
 
@@ -1560,7 +1560,7 @@ TrackPointer TrackDAO::getTrackById(TrackId trackId) const {
         int recordCount = queryRecord.count();
         if (recordCount != columnsCount) {
             recordCount = math_min(recordCount, columnsCount);
-            DEBUG_ASSERT(!"Failed query");
+            DEBUG_ASSERT_UNREACHABLE(!"Failed query");
         }
         for (int i = 0; i < recordCount; ++i) {
             TrackPopulatorFn populator = columns[i].populator;
@@ -1753,7 +1753,7 @@ bool TrackDAO::updateTrack(const Track& track) const {
 
     if (!query.exec()) {
         LOG_FAILED_QUERY(query);
-        DEBUG_ASSERT(!"Failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"Failed query");
         return false;
     }
 
@@ -1812,7 +1812,7 @@ void TrackDAO::invalidateTrackLocationsInLibrary() const {
     if (!query.exec()) {
         LOG_FAILED_QUERY(query)
                 << "Couldn't mark tracks in library as needing verification.";
-        DEBUG_ASSERT(!"Failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"Failed query");
     }
 }
 
@@ -1828,7 +1828,7 @@ void TrackDAO::markTrackLocationsAsVerified(const QStringList& locations) const 
     if (!query.exec()) {
         LOG_FAILED_QUERY(query)
                 << "Couldn't mark track locations as verified.";
-        DEBUG_ASSERT(!"Failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"Failed query");
     }
 }
 
@@ -1845,7 +1845,7 @@ void TrackDAO::markTracksInDirectoriesAsVerified(const QStringList& directories)
     if (!query.exec()) {
         LOG_FAILED_QUERY(query)
                 << "Couldn't mark tracks in" << directories.size() << "directories as verified.";
-        DEBUG_ASSERT(!"Failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"Failed query");
     }
 }
 
@@ -1859,7 +1859,7 @@ void TrackDAO::markUnverifiedTracksAsDeleted() {
     QSet<TrackId> trackIds;
     if (!query.exec()) {
         LOG_FAILED_QUERY(query) << "Couldn't find unverified tracks";
-        DEBUG_ASSERT(!"Failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"Failed query");
     }
     while (query.next()) {
         trackIds.insert(TrackId(query.value(query.record().indexOf(LIBRARYTABLE_MIXXXDELETED))));
@@ -1871,7 +1871,7 @@ void TrackDAO::markUnverifiedTracksAsDeleted() {
     if (!query.exec()) {
         LOG_FAILED_QUERY(query)
                 << "Couldn't mark unverified tracks as deleted.";
-        DEBUG_ASSERT(!"Failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"Failed query");
     }
 }
 
@@ -1941,7 +1941,7 @@ bool TrackDAO::detectMovedTracks(
                     .arg(TRACK_ID, LOCATION_ID));
     if (!oldTrackQuery.exec()) {
         LOG_FAILED_QUERY(oldTrackQuery);
-        DEBUG_ASSERT(!"Failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"Failed query");
         return false;
     }
     QSqlRecord oldTrackQueryRecord = oldTrackQuery.record();
@@ -1970,7 +1970,7 @@ bool TrackDAO::detectMovedTracks(
         newTrackQuery.bindValue(":duration", duration);
         if (!newTrackQuery.exec()) {
             LOG_FAILED_QUERY(newTrackQuery);
-            DEBUG_ASSERT(!"Failed query");
+            DEBUG_ASSERT_UNREACHABLE(!"Failed query");
             continue;
         }
         const auto newTrackIdColumn = newTrackQuery.record().indexOf(TRACK_ID);
@@ -2049,7 +2049,7 @@ bool TrackDAO::detectMovedTracks(
                 LOG_FAILED_QUERY(query);
                 // Last chance to skip this entry, i.e. nothing has been
                 // deleted or updated yet!
-                DEBUG_ASSERT(!"Failed query");
+                DEBUG_ASSERT_UNREACHABLE(!"Failed query");
                 continue;
             }
         }
@@ -2064,7 +2064,7 @@ bool TrackDAO::detectMovedTracks(
             query.bindValue(":oldid", relocatedTrack.updatedTrackRef().getId().toVariant());
             if (!query.exec()) {
                 LOG_FAILED_QUERY(query);
-                DEBUG_ASSERT(!"Failed query");
+                DEBUG_ASSERT_UNREACHABLE(!"Failed query");
             }
         }
 
@@ -2075,7 +2075,7 @@ bool TrackDAO::detectMovedTracks(
             query.bindValue(":id", oldTrackLocationId.toVariant());
             if (!query.exec()) {
                 LOG_FAILED_QUERY(query);
-                DEBUG_ASSERT(!"Failed query");
+                DEBUG_ASSERT_UNREACHABLE(!"Failed query");
             }
         }
 
@@ -2098,7 +2098,7 @@ void TrackDAO::hideAllTracks(const QDir& rootDir) const {
     query.bindValue(":locationPathPrefix", locationPathPrefix);
     if (!query.exec()) {
         LOG_FAILED_QUERY(query) << "could not get tracks within directory:" << rootDir;
-        DEBUG_ASSERT(!"Failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"Failed query");
     }
 
     QStringList trackIds;
@@ -2111,7 +2111,7 @@ void TrackDAO::hideAllTracks(const QDir& rootDir) const {
                           "WHERE id in (%1)").arg(trackIds.join(",")));
     if (!query.exec()) {
         LOG_FAILED_QUERY(query);
-        DEBUG_ASSERT(!"Failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"Failed query");
     }
 }
 
@@ -2134,7 +2134,7 @@ bool TrackDAO::verifyRemainingTracks(
             "WHERE needs_verification = 1");
     if (!query.exec()) {
         LOG_FAILED_QUERY(query);
-        DEBUG_ASSERT(!"Failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"Failed query");
         return false;
     }
 
@@ -2223,7 +2223,7 @@ void TrackDAO::detectCoverArtForTracksWithoutCover(volatile const bool* pCancel,
     if (!query.exec()) {
         LOG_FAILED_QUERY(query)
                 << "failed looking for tracks with unknown cover art";
-        DEBUG_ASSERT(!"Failed query");
+        DEBUG_ASSERT_UNREACHABLE(!"Failed query");
         return;
     }
 
@@ -2246,7 +2246,7 @@ void TrackDAO::detectCoverArtForTracksWithoutCover(volatile const bool* pCancel,
         if (source == CoverInfo::USER_SELECTED) {
             kLogger.warning() << "PROGRAMMING ERROR! detectCoverArtForTracksWithoutCover()"
                               << "got a USER_SELECTED track. Skipping.";
-            DEBUG_ASSERT(!"Failed query");
+            DEBUG_ASSERT_UNREACHABLE(!"Failed query");
             continue;
         }
         tracksWithoutCover.append(track);

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -683,7 +683,7 @@ bool Library::requestRemoveDir(const QString& dir, LibraryRemovalType removalTyp
         m_pTrackCollectionManager->purgeAllTracks(dir);
         break;
     default:
-        DEBUG_ASSERT(!"unreachable");
+        DEBUG_ASSERT_UNREACHABLE(!"unreachable");
     }
 
     return true;

--- a/src/library/proxytrackmodel.cpp
+++ b/src/library/proxytrackmodel.cpp
@@ -13,7 +13,7 @@ ProxyTrackModel::ProxyTrackModel(QAbstractItemModel* pTrackModel,
           m_pTrackModel(dynamic_cast<TrackModel*>(pTrackModel)),
           m_currentSearch(""),
           m_bHandleSearches(bHandleSearches) {
-    X_VERIFY_OR_DEBUG_ASSERT(m_pTrackModel && pTrackModel) {
+    VERIFY_OR_DEBUG_ASSERT(m_pTrackModel) {
         return;
     }
     setSourceModel(pTrackModel);

--- a/src/library/proxytrackmodel.cpp
+++ b/src/library/proxytrackmodel.cpp
@@ -13,7 +13,7 @@ ProxyTrackModel::ProxyTrackModel(QAbstractItemModel* pTrackModel,
           m_pTrackModel(dynamic_cast<TrackModel*>(pTrackModel)),
           m_currentSearch(""),
           m_bHandleSearches(bHandleSearches) {
-    VERIFY_OR_DEBUG_ASSERT(m_pTrackModel && pTrackModel) {
+    X_VERIFY_OR_DEBUG_ASSERT(m_pTrackModel && pTrackModel) {
         return;
     }
     setSourceModel(pTrackModel);

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -723,7 +723,7 @@ bool LibraryScanner::changeScannerState(ScannerState newState) {
         m_state = IDLE;
         return true;
     default:
-        DEBUG_ASSERT(false);
+        DEBUG_ASSERT_UNREACHABLE(false);
         return false;
     }
 }

--- a/src/library/trackprocessing.cpp
+++ b/src/library/trackprocessing.cpp
@@ -113,7 +113,7 @@ ModalTrackBatchOperationProcessor::doProcessNextTrack(
     case Mode::ApplyAndSave:
         return ProcessNextTrackResult::SaveTrackAndContinueProcessing;
     }
-    DEBUG_ASSERT(!"unreachable");
+    DEBUG_ASSERT_UNREACHABLE(!"unreachable");
     return ProcessNextTrackResult::AbortProcessing;
 }
 

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -1450,7 +1450,7 @@ bool MixxxMainWindow::eventFilter(QObject* obj, QEvent* event) {
         case mixxx::preferences::Tooltips::Off:
             return true;
         default:
-            DEBUG_ASSERT(!"m_toolTipsCfg value unknown");
+            DEBUG_ASSERT_UNREACHABLE(!"m_toolTipsCfg value unknown");
             return true;
         }
     } else if (event->type() == QEvent::WindowStateChange) {

--- a/src/network/jsonwebtask.cpp
+++ b/src/network/jsonwebtask.cpp
@@ -203,7 +203,7 @@ QNetworkReply* JsonWebTask::sendNetworkRequest(
                 QNetworkRequest(url));
     }
     }
-    DEBUG_ASSERT(!"unreachable");
+    DEBUG_ASSERT_UNREACHABLE(!"unreachable");
     return nullptr;
 }
 

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -2561,7 +2561,7 @@ void LegacySkinParser::setupConnections(const QDomNode& node, WBaseWidget* pWidg
                 break;
             default:
                 // can't happen. Nothing else is returned by parseButtonState();
-                DEBUG_ASSERT(false);
+                DEBUG_ASSERT_UNREACHABLE(false);
                 break;
             }
 

--- a/src/soundio/soundmanagerutil.h
+++ b/src/soundio/soundmanagerutil.h
@@ -289,7 +289,7 @@ inline bool operator!=(
 
 /// There is not really a use case for this, but it is required for QMetaType::registerComparators.
 inline bool operator<(const SoundDeviceId& lhs, const SoundDeviceId& rhs) {
-    DEBUG_ASSERT(!"should never be invoked");
+    DEBUG_ASSERT_UNREACHABLE(!"should never be invoked");
     return lhs.portAudioIndex < rhs.portAudioIndex;
 }
 

--- a/src/sources/audiosource.h
+++ b/src/sources/audiosource.h
@@ -431,7 +431,7 @@ inline QDebug operator<<(QDebug dbg, AudioSource::OpenMode openMode) {
     case AudioSource::OpenMode::Permissive:
         return dbg << "Permissive";
     default:
-        DEBUG_ASSERT(!"Unknown OpenMode");
+        DEBUG_ASSERT_UNREACHABLE(!"Unknown OpenMode");
         return dbg << "Unknown";
     }
 }
@@ -445,7 +445,7 @@ inline QDebug operator<<(QDebug dbg, AudioSource::OpenResult openResult) {
     case AudioSource::OpenResult::Failed:
         return dbg << "Failed";
     default:
-        DEBUG_ASSERT(!"Unknown OpenResult");
+        DEBUG_ASSERT_UNREACHABLE(!"Unknown OpenResult");
         return dbg << "Unknown";
     }
 }

--- a/src/sources/soundsourceprovider.cpp
+++ b/src/sources/soundsourceprovider.cpp
@@ -15,7 +15,7 @@ QDebug operator<<(QDebug dbg, SoundSourceProviderPriority arg) {
     case SoundSourceProviderPriority::Highest:
         return dbg << static_cast<int>(arg) << "(highest)";
     default:
-        DEBUG_ASSERT(!"unexpected SoundSourceProviderPriority");
+        DEBUG_ASSERT_UNREACHABLE(!"unexpected SoundSourceProviderPriority");
         return dbg;
     }
 }

--- a/src/test/engineeffectsdelay_test.cpp
+++ b/src/test/engineeffectsdelay_test.cpp
@@ -51,9 +51,7 @@ TEST_F(EngineEffectsDelayTest, NegativeDelayValue) {
 
     EXPECT_DEATH({
         // Set negative delay value.
-        m_effectsDelay.setDelayFrames(-1);
-    },
-            "delayFrames >= 0");
+        m_effectsDelay.setDelayFrames(-1); }, "false");
 #else
     const SINT numSamples = 4;
 
@@ -81,9 +79,7 @@ TEST_F(EngineEffectsDelayTest, DelayGreaterThanDelayBufferSize) {
 
     EXPECT_DEATH({
         // Set delay greater than the size of the delay buffer.
-        m_effectsDelay.setDelayFrames(numDelayFrames);
-    },
-            "delayFrames <= kMaxDelayFrames");
+        m_effectsDelay.setDelayFrames(numDelayFrames); }, "false");
 #else
     const SINT numSamples = 4;
 

--- a/src/track/cueinfo.cpp
+++ b/src/track/cueinfo.cpp
@@ -26,7 +26,7 @@ void assertEndPosition(
         break;
     case CueType::Beat: // unused
     default:
-        DEBUG_ASSERT(!"Unknown Loop Type");
+        DEBUG_ASSERT_UNREACHABLE(!"Unknown Loop Type");
     }
 }
 

--- a/src/track/serato/beatgrid.cpp
+++ b/src/track/serato/beatgrid.cpp
@@ -374,7 +374,7 @@ QByteArray SeratoBeatGrid::dump(taglib::FileType fileType) const {
     case taglib::FileType::FLAC:
         return dumpBase64Encoded();
     default:
-        DEBUG_ASSERT(false);
+        DEBUG_ASSERT_UNREACHABLE(false);
         return {};
     }
 }

--- a/src/track/serato/markers.cpp
+++ b/src/track/serato/markers.cpp
@@ -557,7 +557,7 @@ QByteArray SeratoMarkers::dump(taglib::FileType fileType) const {
     case taglib::FileType::MP4:
         return dumpMP4();
     default:
-        DEBUG_ASSERT(false);
+        DEBUG_ASSERT_UNREACHABLE(false);
         return {};
     }
 }
@@ -726,7 +726,7 @@ void SeratoMarkers::setCues(const QList<CueInfo>& cueInfos) {
             loopMap.insert(hotcueIndex, cueInfo);
             break;
         default:
-            DEBUG_ASSERT(!"Invalid cue type");
+            DEBUG_ASSERT_UNREACHABLE(!"Invalid cue type");
             continue;
         }
     }

--- a/src/track/serato/markers2.cpp
+++ b/src/track/serato/markers2.cpp
@@ -514,7 +514,7 @@ QByteArray SeratoMarkers2::dump(taglib::FileType fileType) const {
     case taglib::FileType::OggVorbis:
         return dumpCommon();
     default:
-        DEBUG_ASSERT(false);
+        DEBUG_ASSERT_UNREACHABLE(false);
         return {};
     }
 }
@@ -688,7 +688,7 @@ void SeratoMarkers2::setCues(const QList<CueInfo>& cueInfos) {
             loopMap.insert(hotcueIndex, cueInfo);
             break;
         default:
-            DEBUG_ASSERT(!"Invalid cue type");
+            DEBUG_ASSERT_UNREACHABLE(!"Invalid cue type");
             continue;
         }
     }

--- a/src/track/serato/tags.cpp
+++ b/src/track/serato/tags.cpp
@@ -127,7 +127,7 @@ double SeratoTags::guessTimingOffsetMillis(
 #endif
 #if defined(__FFMPEG__)
         if (primaryDecoderName == mixxx::SoundSourceProviderFFmpeg::kDisplayName) {
-            DEBUG_ASSERT(!usingMadOrFFmpeg);
+            DEBUG_ASSERT_UNREACHABLE(!usingMadOrFFmpeg);
             usingMadOrFFmpeg = true;
         }
 #endif

--- a/src/track/serato/tags.cpp
+++ b/src/track/serato/tags.cpp
@@ -323,7 +323,7 @@ void SeratoTags::setCueInfos(const QList<CueInfo>& cueInfos, double timingOffset
         case CueType::Loop:
             if (!cueInfoSeratoAdjusted.getEndPositionMillis().has_value()) {
                 qWarning() << "Loop Cue" << hotcueIndex << "has no end position";
-                DEBUG_ASSERT(false);
+                DEBUG_ASSERT_UNREACHABLE(false);
                 continue;
             }
             hotcueIndex -= kLoopImportIndexOffset;

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1876,7 +1876,7 @@ ExportTrackMetadataResult Track::exportMetadata(
                 << getLocation();
         return ExportTrackMetadataResult::Failed;
     }
-    DEBUG_ASSERT(!"unhandled case in switch statement");
+    DEBUG_ASSERT_UNREACHABLE(!"unhandled case in switch statement");
     return ExportTrackMetadataResult::Skipped;
 }
 

--- a/src/util/assert.h
+++ b/src/util/assert.h
@@ -106,6 +106,9 @@ extern void link_assert_failed(void);
     } while (0)
 #endif
 
+/// Same as DEBUG_ASSERT, but without the linker assertion
+/// This can be used where the compiler duplicates the DEBUG_ASSERT statement
+/// leading to an unconditional link_assert_failed() call
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
 #define X_DEBUG_ASSERT(cond)                                                \
     do                                                                      \

--- a/src/util/assert.h
+++ b/src/util/assert.h
@@ -160,8 +160,12 @@ extern void link_assert_failed(void);
 /// rather than DEBUG_ASSERT. Only use DEBUG_ASSERT if there is no appropriate
 /// fallback.
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
-#define DEBUG_ASSERT_UNREACHABLE(cond) \
-    mixxx_debug_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION)
+#define DEBUG_ASSERT_UNREACHABLE(cond)                                  \
+    do {                                                                \
+        mixxx_debug_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION); \
+    } while (0)
 #else
-#define DEBUG_ASSERT_UNREACHABLE(cond)
+#define DEBUG_ASSERT_UNREACHABLE(cond) \
+    do {                               \
+    } while (0)
 #endif

--- a/src/util/assert.h
+++ b/src/util/assert.h
@@ -36,6 +36,8 @@ inline void mixxx_release_assert(const char* assertion, const char* file, int li
 #ifdef MIXXX_LINK_ASSERTIONS_ENABLED
 /// This function is intentionally not defined to produce a linker error
 /// when the invocation is not dead code and optimized out
+/// NOTE: It might happen in rare cases that the compiler splits up the DEBUG_ASSERT
+/// leading to false positives. Than use RUNTIME_DEBUG_ASSERT instead.
 extern void link_assert_failed(void);
 // Note void link_assert_failed(void) = delete; does not work, because
 // it is evaluated before optimizing

--- a/src/util/assert.h
+++ b/src/util/assert.h
@@ -5,10 +5,10 @@
 #ifdef __OPTIMIZE__
 #ifdef __has_builtin
 #if __has_builtin(__builtin_constant_p)
-#define HAS_BUILDIN_CONSTANT_P
+#define MIXXX_LINK_ASSERTIONS_ENABLED
 #endif
 #elif __GNUC__ < 10
-#define HAS_BUILDIN_CONSTANT_P
+#define MIXXX_LINK_ASSERTIONS_ENABLED
 #endif
 #endif
 
@@ -33,11 +33,13 @@ inline void mixxx_release_assert(const char* assertion, const char* file, int li
     qFatal("ASSERT: \"%s\" in function %s at %s:%d", assertion, function, file, line);
 }
 
+#ifdef MIXXX_LINK_ASSERTIONS_ENABLED
 /// This function is intentionally not defined to produce a linker error
 /// when the invocation is not dead code and optimized out
 extern void link_assert_failed(void);
 // Note void link_assert_failed(void) = delete; does not work, because
 // it is evaluated before optimizing
+#endif
 
 // These macros provide the demangled function name (including helpful template
 // type information) and are supported on every version of GCC, Clang, and MSVC
@@ -125,7 +127,7 @@ extern void link_assert_failed(void);
 ///
 /// Note that the check and fallback will be included in release builds.
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
-#ifdef HAS_BUILDIN_CONSTANT_P
+#ifdef MIXXX_LINK_ASSERTIONS_ENABLED
 #define VERIFY_OR_DEBUG_ASSERT(cond)                                          \
     if (Q_UNLIKELY(__builtin_constant_p(cond) && !static_cast<bool>(cond))) { \
         link_assert_failed();                                                 \

--- a/src/util/assert.h
+++ b/src/util/assert.h
@@ -112,14 +112,14 @@ extern void link_assert_failed(void);
 /// This can be used where the compiler duplicates the DEBUG_ASSERT statement
 /// leading to an unconditional link_assert_failed() call
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
-#define X_DEBUG_ASSERT(cond)                                                \
+#define RUNTIME_DEBUG_ASSERT(cond)                                          \
     do                                                                      \
         if (Q_UNLIKELY(!static_cast<bool>(cond))) {                         \
             mixxx_debug_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION); \
         }                                                                   \
     while (0)
 #else
-#define X_DEBUG_ASSERT(cond)
+#define RUNTIME_DEBUG_ASSERT(cond)
 #endif
 
 /// Same as DEBUG_ASSERT, but if MIXXX_DEBUG_ASSERTIONS_FATAL is disabled run
@@ -148,11 +148,11 @@ extern void link_assert_failed(void);
 #endif
 
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
-#define X_VERIFY_OR_DEBUG_ASSERT(cond)          \
+#define RUNTIME_VERIFY_OR_DEBUG_ASSERT(cond)    \
     if (Q_UNLIKELY(!static_cast<bool>(cond)) && \
             mixxx_debug_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION))
 #else
-#define X_VERIFY_OR_DEBUG_ASSERT(cond) if (Q_UNLIKELY(!static_cast<bool>(cond)))
+#define RUNTIME_VERIFY_OR_DEBUG_ASSERT(cond) if (Q_UNLIKELY(!static_cast<bool>(cond)))
 #endif
 
 /// Same as DEBUG_ASSERT, but if MIXXX_DEBUG_ASSERTIONS_FATAL is disabled run

--- a/src/util/assert.h
+++ b/src/util/assert.h
@@ -2,20 +2,29 @@
 
 #include <QtDebug>
 
+#ifdef __OPTIMIZE__
+#ifdef __has_builtin
+#if __has_builtin(__builtin_constant_p)
+#define HAS_BUILDIN_CONSTANT_P
+#endif
+#elif __GNUC__ < 10
+#define HAS_BUILDIN_CONSTANT_P
+#endif
+#endif
+
 static constexpr const char* kDebugAssertPrefix = "DEBUG ASSERT";
 
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
-inline void mixxx_debug_assert(const char* assertion, const char* file, int line, const char* function) {
-    qCritical("%s: \"%s\" in function %s at %s:%d", kDebugAssertPrefix, assertion, function, file, line);
-}
-#endif
-
-#ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
-inline bool mixxx_debug_assert_return_true(const char* assertion,
+inline bool mixxx_debug_assert(const char* assertion,
         const char* file,
         int line,
         const char* function) {
-    mixxx_debug_assert(assertion, file, line, function);
+    qCritical("%s: \"%s\" in function %s at %s:%d",
+            kDebugAssertPrefix,
+            assertion,
+            function,
+            file,
+            line);
     return true;
 }
 #endif
@@ -23,6 +32,12 @@ inline bool mixxx_debug_assert_return_true(const char* assertion,
 inline void mixxx_release_assert(const char* assertion, const char* file, int line, const char* function) {
     qFatal("ASSERT: \"%s\" in function %s at %s:%d", assertion, function, file, line);
 }
+
+/// This function is intentionally not defined to produce a linker error
+/// when the invocation is not dead code and optimized out
+extern void link_assert_failed(void);
+// Note void link_assert_failed(void) = delete; does not work, because
+// it is evaluated before optimizing
 
 // These macros provide the demangled function name (including helpful template
 // type information) and are supported on every version of GCC, Clang, and MSVC
@@ -37,12 +52,24 @@ inline void mixxx_release_assert(const char* assertion, const char* file, int li
 /// very hard before using this -- this should only be for the most dire of
 /// situations where we know Mixxx cannot take any action without potentially
 /// corrupting user data. Handle errors gracefully whenever possible.
+
+#ifdef HAS_BUILDIN_CONSTANT_P
+#define RELEASE_ASSERT(cond)                                                      \
+    do                                                                            \
+        if (Q_UNLIKELY(__builtin_constant_p(cond) && !static_cast<bool>(cond))) { \
+            link_assert_failed();                                                 \
+        } else if (Q_UNLIKELY(!static_cast<bool>(cond))) {                        \
+            mixxx_release_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION);     \
+        }                                                                         \
+    while (0)
+#else
 #define RELEASE_ASSERT(cond)                                                  \
     do                                                                        \
         if (!static_cast<bool>(cond)) [[unlikely]] {                          \
             mixxx_release_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION); \
         }                                                                     \
     while (0)
+#endif
 
 /// Checks that cond is true in debug builds. If cond is false then prints a
 /// warning message to the console. If Mixxx is built with
@@ -54,16 +81,38 @@ inline void mixxx_release_assert(const char* assertion, const char* file, int li
 ///
 /// In release builds, doSomething() is never called!
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
+#ifdef HAS_BUILDIN_CONSTANT_P
+#define DEBUG_ASSERT(cond)                                                        \
+    do                                                                            \
+        if (Q_UNLIKELY(__builtin_constant_p(cond) && !static_cast<bool>(cond))) { \
+            link_assert_failed();                                                 \
+        } else if (Q_UNLIKELY(!static_cast<bool>(cond))) {                        \
+            mixxx_debug_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION);       \
+        }                                                                         \
+    while (0)
+#else
 #define DEBUG_ASSERT(cond)                                                  \
     do                                                                      \
         if (!static_cast<bool>(cond)) [[unlikely]] {                        \
             mixxx_debug_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION); \
         }                                                                   \
     while (0)
+#endif
 #else
 #define DEBUG_ASSERT(cond) \
     do {                   \
     } while (0)
+#endif
+
+#ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
+#define X_DEBUG_ASSERT(cond)                                                \
+    do                                                                      \
+        if (Q_UNLIKELY(!static_cast<bool>(cond))) {                         \
+            mixxx_debug_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION); \
+        }                                                                   \
+    while (0)
+#else
+#define X_DEBUG_ASSERT(cond)
 #endif
 
 /// Same as DEBUG_ASSERT, but if MIXXX_DEBUG_ASSERTIONS_FATAL is disabled run
@@ -76,9 +125,36 @@ inline void mixxx_release_assert(const char* assertion, const char* file, int li
 ///
 /// Note that the check and fallback will be included in release builds.
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
+#ifdef HAS_BUILDIN_CONSTANT_P
+#define VERIFY_OR_DEBUG_ASSERT(cond)                                          \
+    if (Q_UNLIKELY(__builtin_constant_p(cond) && !static_cast<bool>(cond))) { \
+        link_assert_failed();                                                 \
+    } else if (Q_UNLIKELY(!static_cast<bool>(cond)) &&                        \
+            mixxx_debug_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION))
+#else
 #define VERIFY_OR_DEBUG_ASSERT(cond)            \
     if (Q_UNLIKELY(!static_cast<bool>(cond)) && \
-            mixxx_debug_assert_return_true(#cond, __FILE__, __LINE__, ASSERT_FUNCTION))
+            mixxx_debug_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION))
+#endif
 #else
 #define VERIFY_OR_DEBUG_ASSERT(cond) if (!static_cast<bool>(cond)) [[unlikely]]
+#endif
+
+#ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
+#define X_VERIFY_OR_DEBUG_ASSERT(cond)          \
+    if (Q_UNLIKELY(!static_cast<bool>(cond)) && \
+            mixxx_debug_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION))
+#else
+#define X_VERIFY_OR_DEBUG_ASSERT(cond) if (Q_UNLIKELY(!static_cast<bool>(cond)))
+#endif
+
+/// Same as DEBUG_ASSERT, but if MIXXX_DEBUG_ASSERTIONS_FATAL is disabled run
+/// the specified fallback function. In most cases you should probably use this
+/// rather than DEBUG_ASSERT. Only use DEBUG_ASSERT if there is no appropriate
+/// fallback.
+#ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
+#define DEBUG_ASSERT_UNREACHABLE(cond) \
+    mixxx_debug_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION)
+#else
+#define DEBUG_ASSERT_UNREACHABLE(cond)
 #endif

--- a/src/util/indexrange.cpp
+++ b/src/util/indexrange.cpp
@@ -47,7 +47,7 @@ bool IndexRange::isSubrangeOf(IndexRange outerIndexRange) const {
             return (outerIndexRange.start() <= start() &&
                     outerIndexRange.end() >= end());
         }
-        DEBUG_ASSERT(!"Cannot compare ranges with different orientations");
+        DEBUG_ASSERT_UNREACHABLE(!"Cannot compare ranges with different orientations");
         return false;
     }
 
@@ -56,7 +56,7 @@ bool IndexRange::isSubrangeOf(IndexRange outerIndexRange) const {
                 outerIndexRange.end() <= end());
     }
 
-    DEBUG_ASSERT(!"Cannot compare ranges with different orientations");
+    DEBUG_ASSERT_UNREACHABLE(!"Cannot compare ranges with different orientations");
     return false;
 }
 
@@ -69,7 +69,7 @@ std::optional<IndexRange> intersect2(IndexRange lhs, IndexRange rhs) {
                 return IndexRange::between(start, end);
             }
         } else {
-            DEBUG_ASSERT(!"Cannot intersect index ranges with different orientations");
+            DEBUG_ASSERT_UNREACHABLE(!"Cannot intersect index ranges with different orientations");
             return std::nullopt;
         }
     } else if (lhs.start() > lhs.end()) {
@@ -80,7 +80,7 @@ std::optional<IndexRange> intersect2(IndexRange lhs, IndexRange rhs) {
                 return IndexRange::between(start, end);
             }
         } else {
-            DEBUG_ASSERT(!"Cannot intersect index ranges with different orientations");
+            DEBUG_ASSERT_UNREACHABLE(!"Cannot intersect index ranges with different orientations");
             return std::nullopt;
         }
     } else {

--- a/src/util/math.h
+++ b/src/util/math.h
@@ -24,7 +24,7 @@ template<typename T>
 constexpr T math_clamp(T value, T min, T max) {
     // DEBUG_ASSERT compiles out in release builds so it does not affect
     // vectorization or pipelining of clamping in tight loops.
-    DEBUG_ASSERT(min <= max);
+    RUNTIME_DEBUG_ASSERT(min <= max);
     return std::clamp(value, min, max);
 }
 

--- a/src/util/samplebuffer.h
+++ b/src/util/samplebuffer.h
@@ -71,14 +71,14 @@ class SampleBuffer final {
         return m_data;
     }
     CSAMPLE* data(SINT offset) noexcept {
-        DEBUG_ASSERT((m_data != nullptr) || (offset == 0));
+        RUNTIME_DEBUG_ASSERT((m_data != nullptr) || (offset == 0));
         DEBUG_ASSERT(0 <= offset);
         // >=: allow access to one element behind allocated memory
         DEBUG_ASSERT(m_size >= offset);
         return m_data + offset;
     }
     const CSAMPLE* data(SINT offset) const noexcept {
-        DEBUG_ASSERT((m_data != nullptr) || (offset == 0));
+        RUNTIME_DEBUG_ASSERT((m_data != nullptr) || (offset == 0));
         DEBUG_ASSERT(0 <= offset);
         // >=: allow access to one element behind allocated memory
         DEBUG_ASSERT(m_size >= offset);

--- a/src/widget/whotcuebutton.cpp
+++ b/src/widget/whotcuebutton.cpp
@@ -335,7 +335,7 @@ void WHotcueButton::slotTypeChanged(double type) {
         m_type = QStringLiteral("n60dbsound");
         break;
     default:
-        DEBUG_ASSERT(!"Unknown cue type!");
+        DEBUG_ASSERT_UNREACHABLE(!"Unknown cue type!");
         m_type = QLatin1String("");
     }
     restyleAndRepaint();

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -3030,7 +3030,7 @@ bool WTrackMenu::featureIsEnabled(Feature flag) const {
     case Feature::SelectInLibrary:
         return m_pTrack != nullptr;
     default:
-        DEBUG_ASSERT(!"unreachable");
+        DEBUG_ASSERT_UNREACHABLE(!"unreachable");
         return false;
     }
 }

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1510,7 +1510,7 @@ void WTrackTableView::loadSelectedTrackToGroup(const QString& group,
 
 QList<TrackId> WTrackTableView::getSelectedTrackIds() const {
     TrackModel* pTrackModel = getTrackModel();
-    VERIFY_OR_DEBUG_ASSERT(pTrackModel != nullptr) {
+    RUNTIME_VERIFY_OR_DEBUG_ASSERT(pTrackModel != nullptr) {
         qWarning() << "No track model available";
         return {};
     }
@@ -1534,7 +1534,7 @@ QList<TrackId> WTrackTableView::getSelectedTrackIds() const {
 
 TrackId WTrackTableView::getCurrentTrackId() const {
     TrackModel* pTrackModel = getTrackModel();
-    VERIFY_OR_DEBUG_ASSERT(pTrackModel != nullptr) {
+    RUNTIME_VERIFY_OR_DEBUG_ASSERT(pTrackModel != nullptr) {
         qWarning() << "No track model available";
         return {};
     }
@@ -1558,7 +1558,7 @@ bool WTrackTableView::isTrackInCurrentView(const TrackId& trackId) {
     }
     //qDebug() << "WTrackTableView::isTrackInCurrentView" << trackId;
     TrackModel* pTrackModel = getTrackModel();
-    VERIFY_OR_DEBUG_ASSERT(pTrackModel != nullptr) {
+    RUNTIME_VERIFY_OR_DEBUG_ASSERT(pTrackModel != nullptr) {
         qWarning() << "No track model";
         return false;
     }
@@ -1569,7 +1569,7 @@ bool WTrackTableView::isTrackInCurrentView(const TrackId& trackId) {
 
 void WTrackTableView::setSelectedTracks(const QList<TrackId>& trackIds) {
     TrackModel* pTrackModel = getTrackModel();
-    VERIFY_OR_DEBUG_ASSERT(pTrackModel != nullptr) {
+    RUNTIME_VERIFY_OR_DEBUG_ASSERT(pTrackModel != nullptr) {
         qWarning() << "No track model";
         return;
     }

--- a/src/widget/wwidget.cpp
+++ b/src/widget/wwidget.cpp
@@ -89,7 +89,7 @@ bool WWidget::event(QEvent* e) {
                 eventType = QEvent::MouseButtonRelease;
                 break;
             default:
-                DEBUG_ASSERT(false);
+                DEBUG_ASSERT_UNREACHABLE(false);
                 break;
             }
 


### PR DESCRIPTION
Finding a way to improve debug asserts in const expressions I have developed this PR as a drive by. 

This extends our debug asserts to fail linking if the likely good branch is optimized away and not reachable. 

This utilizes the __builtin_constant_p() build in function available on gcc and clang.

Unfortunately it does not work in case the DEBUG_ASSERT() statement is duplicated into two branches during optimization. 
For these case I have added the old version as  RUNTIME_DEBUG_ASSERT() 

Things like DEBUG_ASSERT(false) do no longer work, because they have no good branch and will fail. 
For this purpose I have added DEBUG_ASSERT_UNREACHABLE(false)

The good thing is that this works without all constexpr keywords and uses the feature the compiler uses anyway in O3. 
The bad thing is that it relies on the compiler optimization.  

What do you think about it?

