### PR TITLE
Update to libdjinterop 0.16.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1797,8 +1797,8 @@ if(ENGINEPRIME)
     # External project sources must be downloaded as an archive into DOWNLOAD_DIR
     # from an URL to keep offline builds like for Fedora/RPM Fusion working!
     ExternalProject_Add(libdjinterop
-      URL "https://github.com/xsco/libdjinterop/archive/0.15.2.tar.gz"
-      URL_HASH SHA256=66f64c0b38a53936ba1b471524905e35afd605bc05d29e7aa6fa7ea0005c7d54
+      URL "https://github.com/xsco/libdjinterop/archive/0.16.0.tar.gz"
+      URL_HASH SHA256=c998831fe4d3cc80c5c031491204244c9ed0c61575dd529260304b95d79db588
       DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/download/libdjinterop"
       INSTALL_DIR ${DJINTEROP_INSTALL_DIR}
       LIST_SEPARATOR "|"

--- a/src/library/export/engineprimeexportjob.cpp
+++ b/src/library/export/engineprimeexportjob.cpp
@@ -150,8 +150,10 @@ void exportMetadata(djinterop::database* pDatabase,
     std::chrono::system_clock::time_point lastModifiedAt{
             std::chrono::milliseconds{lastModifiedMillisSinceEpoch}};
     snapshot.last_modified_at = lastModifiedAt;
+    snapshot.last_accessed_at = lastModifiedAt;
     snapshot.bitrate = pTrack->getBitrate();
     snapshot.rating = pTrack->getRating() * 20; // note rating is in range 0-100
+    snapshot.file_bytes = pTrack->getFileInfo().sizeInBytes();
 
     // Frames used interchangeably with "samples" here.
     const auto frameCount = static_cast<int64_t>(pTrack->getDuration() * pTrack->getSampleRate());
@@ -168,9 +170,9 @@ void exportMetadata(djinterop::database* pDatabase,
 
     // Set main cue-point.
     mixxx::audio::FramePos cuePlayPos = pTrack->getMainCuePosition();
-    // FIXME: What if the cuePlayPos is invalid?
-    snapshot.default_main_cue = cuePlayPos.value();
-    snapshot.adjusted_main_cue = cuePlayPos.value();
+    const auto cuePlayPosValue = cuePlayPos.isValid() ? cuePlayPos.value() : 0;
+    snapshot.default_main_cue = cuePlayPosValue;
+    snapshot.adjusted_main_cue = cuePlayPosValue;
 
     // Fill in beat grid.  For now, assume a constant average BPM across
     // the whole track.  Note that points in the track are specified as


### PR DESCRIPTION
Update to use libdjinterop 0.16.0

* Provides support for Denon firmware 1.6.x (current latest version)
* Populates a few fields that were not previously set
* Addresses a FIXME left in recent PR https://github.com/mixxxdj/mixxx/pull/4077

After this PR is merged, the [0.16.0 Ubuntu packages of libdjinterop](https://launchpad.net/~xsco/+archive/ubuntu/djinterop/+packages) ought to be copied into the Mixxx PPA, in order for Ubuntu builds to work with the newer code.