### PR TITLE
Fix conditional compilation for aarch64

### DIFF
--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -437,7 +437,7 @@ void SoundDeviceNetwork::callbackProcessClkRef() {
         }
 #endif
 
-#ifdef aarch64
+#if defined(__aarch64__)
         // Flush-to-zero on aarch64 is controlled by the Floating-point Control Register
         // Load the register into our variable.
         int savedFPCR;

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -905,7 +905,7 @@ int SoundDevicePortAudio::callbackProcessClkRef(
 #endif
 #endif
 
-#ifdef aarch64
+#if defined(__aarch64__)
         // Flush-to-zero on aarch64 is controlled by the Floating-point Control Register
         // Load the register into our variable.
         int savedFPCR;


### PR DESCRIPTION
As discussed on [Zulip](https://mixxx.zulipchat.com/#narrow/stream/247620-development-help/topic/M1.20Build.20--.20no.20main.20waveform.20display).

CHANGELOG: "Fix performance issue on AArch64 by enabling flush-to-zero for floating-point arithmetic"