### PR TITLE
DirectoryDAO: Fix file path matching when relocating directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1117,7 +1117,7 @@ endif()
 
 
 if(WIN32)
-  target_compile_definitions(mixxx-lib PRIVATE __WINDOWS__)
+  target_compile_definitions(mixxx-lib PUBLIC __WINDOWS__)
 
   # Helps prevent duplicate symbols
   target_compile_definitions(mixxx-lib PUBLIC _ATL_MIN_CRT)

--- a/src/library/dao/directorydao.cpp
+++ b/src/library/dao/directorydao.cpp
@@ -6,7 +6,6 @@
 #include "library/queryutil.h"
 #include "util/db/sqllikewildcardescaper.h"
 #include "util/db/sqllikewildcards.h"
-#include "util/db/sqlstringformatter.h"
 
 namespace {
 
@@ -111,10 +110,9 @@ QList<RelocatedTrack> DirectoryDAO::relocateDirectory(
             "SELECT library.id,track_locations.id,track_locations.location "
             "FROM library INNER JOIN track_locations ON "
             "track_locations.id=library.location WHERE "
-            "track_locations.location LIKE %1 ESCAPE '%2'")
-                          .arg(SqlStringFormatter::format(
-                                       m_database, startsWithOldFolder),
-                                  kSqlLikeMatchAll));
+            "track_locations.location LIKE :startsWithOldFolder ESCAPE :escape"));
+    query.bindValue(":startsWithOldFolder", startsWithOldFolder);
+    query.bindValue(":escape", kSqlLikeMatchAll);
     if (!query.exec()) {
         LOG_FAILED_QUERY(query) << "could not relocate path of tracks";
         return {};

--- a/src/library/dao/directorydao.h
+++ b/src/library/dao/directorydao.h
@@ -24,6 +24,6 @@ class DirectoryDAO : public DAO {
     int removeDirectory(const QString& dir) const;
 
     QList<RelocatedTrack> relocateDirectory(
-            const QString& oldFolder,
-            const QString& newFolder) const;
+            const QString& oldDirectory,
+            const QString& newDirectory) const;
 };

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1770,14 +1770,19 @@ void TrackDAO::hideAllTracks(const QDir& rootDir) const {
     // Capture entries that start with the directory prefix dir.
     // dir needs to end in a slash otherwise we might match other
     // directories.
-    QString likeClause = SqlLikeWildcardEscaper::apply(rootDir.absolutePath() + "/", kSqlLikeMatchAll) + kSqlLikeMatchAll;
+    const QString rootDirPath = rootDir.absolutePath();
+    DEBUG_ASSERT(!rootDirPath.endsWith('/'));
+    const QString likeClause =
+            SqlLikeWildcardEscaper::apply(rootDirPath + '/', kSqlLikeMatchAll) +
+            kSqlLikeMatchAll;
 
     QSqlQuery query(m_database);
-    query.prepare(QString("SELECT library.id FROM library INNER JOIN track_locations "
-                          "ON library.location = track_locations.id "
-                          "WHERE track_locations.location LIKE %1 ESCAPE '%2'")
-                  .arg(SqlStringFormatter::format(m_database, likeClause), kSqlLikeMatchAll));
-
+    query.prepare(QStringLiteral(
+            "SELECT library.id FROM library INNER JOIN track_locations "
+            "ON library.location = track_locations.id "
+            "WHERE track_locations.location LIKE :likeClause ESCAPE :escape"));
+    query.bindValue(":likeClause", likeClause);
+    query.bindValue(":escape", kSqlLikeMatchAll);
     VERIFY_OR_DEBUG_ASSERT(query.exec()) {
         LOG_FAILED_QUERY(query) << "could not get tracks within directory:" << rootDir;
     }


### PR DESCRIPTION
CHANGELOG: Fix relocation of directories with special/reserved characters in path name

- Properly escape and quote file path strings in SQL query
- Use case-sensitive file path matching
- Do not modify passed arguments in DAO, only verify the assumptions by using assertions
- Extend relocateDirectory test