### PR TITLE
Add midiThrough argument

### DIFF
--- a/src/controllers/midi/portmidienumerator.cpp
+++ b/src/controllers/midi/portmidienumerator.cpp
@@ -16,6 +16,7 @@ bool recognizeDevice(const PmDeviceInfo& deviceInfo) {
     // In developer mode we show the MIDI Through Port, otherwise ignore it
     // since it routinely causes trouble.
     return CmdlineArgs::Instance().getDeveloper() ||
+           CmdlineArgs::Instance().getMidiThrough() ||
             !QLatin1String(deviceInfo.name)
                      .startsWith(kMidiThroughPortPrefix, Qt::CaseInsensitive);
 }

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -24,6 +24,7 @@ CmdlineArgs::CmdlineArgs()
           m_debugAssertBreak(false),
           m_settingsPathSet(false),
           m_useColors(false),
+          m_midiThrough(false),
           m_logLevel(mixxx::kLogLevelDefault),
           m_logFlushLevel(mixxx::kLogFlushLevelDefault),
 // We are not ready to switch to XDG folders under Linux, so keeping $HOME/.mixxx as preferences folder. see lp:1463273
@@ -172,6 +173,12 @@ bool CmdlineArgs::parse(int argc, char** argv) {
             QStringLiteral("auto"));
     parser.addOption(color);
 
+    const QCommandLineOption midiThrough(QStringLiteral("midiThrough"),
+            QCoreApplication::translate("CmdlineArgs",
+                    "Enables MIDI Through mode.  Shows MIDI through ports in "
+                    "Preferences/Controllers."));
+    parser.addOption(midiThrough);
+
     const QCommandLineOption logLevel(QStringLiteral("log-level"),
             QCoreApplication::translate("CmdlineArgs",
                     "Sets the verbosity of command line logging.\n"
@@ -275,6 +282,7 @@ bool CmdlineArgs::parse(int argc, char** argv) {
     m_developer = parser.isSet(developer);
     m_safeMode = parser.isSet(safeMode) || parser.isSet(safeModeDeprecated);
     m_debugAssertBreak = parser.isSet(debugAssertBreak) || parser.isSet(debugAssertBreakDeprecated);
+    m_midiThrough = parser.isSet(midiThrough);
 
     m_musicFiles = parser.positionalArguments();
 

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -33,6 +33,7 @@ class CmdlineArgs final {
     }
     bool getDebugAssertBreak() const { return m_debugAssertBreak; }
     bool getSettingsPathSet() const { return m_settingsPathSet; }
+    bool getMidiThrough() const {return m_midiThrough; }
     mixxx::LogLevel getLogLevel() const { return m_logLevel; }
     mixxx::LogLevel getLogFlushLevel() const { return m_logFlushLevel; }
     bool getTimelineEnabled() const { return !m_timelinePath.isEmpty(); }
@@ -53,6 +54,7 @@ class CmdlineArgs final {
     bool m_debugAssertBreak;
     bool m_settingsPathSet; // has --settingsPath been set on command line ?
     bool m_useColors;       // should colors be used
+    bool m_midiThrough;
     mixxx::LogLevel m_logLevel; // Level of stderr logging message verbosity
     mixxx::LogLevel m_logFlushLevel; // Level of mixx.log file flushing
     QString m_locale;

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -33,7 +33,7 @@ class CmdlineArgs final {
     }
     bool getDebugAssertBreak() const { return m_debugAssertBreak; }
     bool getSettingsPathSet() const { return m_settingsPathSet; }
-    bool getMidiThrough() const {return m_midiThrough; }
+    bool getMidiThrough() const { return m_midiThrough; }
     mixxx::LogLevel getLogLevel() const { return m_logLevel; }
     mixxx::LogLevel getLogFlushLevel() const { return m_logFlushLevel; }
     bool getTimelineEnabled() const { return !m_timelinePath.isEmpty(); }


### PR DESCRIPTION
Adds a `--midiThrough` argument to enable the display of Midi Through ports in Preferences/Controllers.
Is the first proposed step to resolve #8356