### PR TITLE
Skins: append / when setting skin base path

### DIFF
--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -410,7 +410,7 @@ QWidget* LegacySkinParser::parseSkin(const QString& skinPath, QWidget* pParent) 
 
 LaunchImage* LegacySkinParser::parseLaunchImage(const QString& skinPath, QWidget* pParent) {
     m_pContext = std::make_unique<SkinContext>(m_pConfig, skinPath + "/skin.xml");
-    m_pContext->setSkinBasePath(skinPath + "/");
+    m_pContext->setSkinBasePath(skinPath);
 
     QDomElement skinDocument = openSkin(skinPath);
     if (skinDocument.isNull()) {
@@ -2308,7 +2308,5 @@ QString LegacySkinParser::stylesheetAbsIconPaths(QString& style) {
     // <Style> nodes) with absolute file paths.
     // TODO Can be removed/disabled as soon as all target distros have the fixed
     // package in their repo.
-    // Note: It's safe to use the base path after parseSkin() has updated it
-    // (parseLaunchImage() appends "/" earlier)
     return style.replace("url(skin:", "url(" + m_pContext->getSkinBasePath());
 }

--- a/src/skin/legacy/skincontext.h
+++ b/src/skin/legacy/skincontext.h
@@ -55,7 +55,7 @@ class SkinContext {
     void setSkinBasePath(const QString& skinBasePath) {
         QStringList skinPaths(skinBasePath);
         QDir::setSearchPaths("skin", skinPaths);
-        m_skinBasePath = skinBasePath;
+        m_skinBasePath = skinBasePath + "/";
     }
 
     // Sets the base path used by getSkinPath.


### PR DESCRIPTION
This ensures stylesheet icon urls without leading / are transformed to correct paths.

Regression from #3877, noticed with DarkMetal https://mixxx.discourse.group/t/crates-playlists-history-etc-vanish-from-dark-metal/22704/ : the user assumed the library was broken because the sidebar expand arrow icons were missing...

So my hasty conclusion was wrong
https://github.com/mixxxdj/mixxx/blob/1557ef252b1c9c7771e74379a872e8a67956688c/src/skin/legacy/legacyskinparser.cpp#L2311-L2313
because the skin base path is also set by LegacySkinParser::parseSkin() without trailing /

Appending the / will result in // but this is filtered by Qt later on (_assuming_ since leading / are used for the LateNight launch image and that works on all platforms)

## Proposed Changelog entry

    - Fix support for relative paths in the skin system which caused missing images in third-party skins. #4151