### PR TITLE
SyncLock: Do not seek phase when audible status changes

### DIFF
--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -254,8 +254,6 @@ void EngineSync::notifyPlayingAudible(Syncable* pSyncable, bool playingAudible) 
         activateMaster(newMaster, false);
         setMasterParams(newMaster, newMaster->getBeatDistance(), newMaster->getBaseBpm(), newMaster->getBpm());
     }
-
-    pSyncable->requestSync();
 }
 
 void EngineSync::notifyScratching(Syncable* pSyncable, bool scratching) {


### PR DESCRIPTION
backport of https://github.com/mixxxdj/mixxx/pull/4155 -- the other issue fixed in that PR does not affect 2.3

https://mixxx.discourse.group/t/vestax-tr-1-weird-behaviour-quantizing-drops-tempo/22715/7
Do not seek phase when audible status changes

(the syncrequest is totally unnecessary, enginebuffer already puts in a sync request when the user hits Play)