### PR TITLE
Fix usage of  sqlite3_create_function()

### DIFF
--- a/src/util/db/dbconnection.cpp
+++ b/src/util/db/dbconnection.cpp
@@ -280,7 +280,7 @@ bool initDatabase(const QSqlDatabase& database, StringCollator* pCollator) {
             handle,
             "like",
             2,
-            SQLITE_UTF8,
+            SQLITE_UTF8 | SQLITE_DETERMINISTIC,
             nullptr,
             sqliteLikeUtf8,
             nullptr,
@@ -295,7 +295,7 @@ bool initDatabase(const QSqlDatabase& database, StringCollator* pCollator) {
             handle,
             "like",
             3, // 3rd arg = ESCAPE
-            SQLITE_UTF8,
+            SQLITE_UTF8 | SQLITE_DETERMINISTIC,
             nullptr,
             sqliteLikeUtf8,
             nullptr,

--- a/src/util/db/dbconnection.cpp
+++ b/src/util/db/dbconnection.cpp
@@ -195,9 +195,9 @@ const char kLexicographicalCollationFunc[] = "mixxxLexicographicalCollationFunc"
 // The SQL statement 'A LIKE B' is implemented as 'like(B, A)', and if there is
 // an escape character, say E, it is implemented as 'like(B, A, E)'
 //static
-void sqliteLike(sqlite3_context *context,
-                                int aArgc,
-                                sqlite3_value **aArgv) {
+void sqliteLikeUtf8(sqlite3_context* context,
+        int aArgc,
+        sqlite3_value** aArgv) {
     VERIFY_OR_DEBUG_ASSERT(aArgc == 2 || aArgc == 3) {
         return;
     }
@@ -277,13 +277,14 @@ bool initDatabase(const QSqlDatabase& database, StringCollator* pCollator) {
     }
 
     result = sqlite3_create_function(
-                    handle,
-                    "like",
-                    2,
-                    SQLITE_ANY,
-                    nullptr,
-                    sqliteLike,
-                    nullptr, nullptr);
+            handle,
+            "like",
+            2,
+            SQLITE_UTF8,
+            nullptr,
+            sqliteLikeUtf8,
+            nullptr,
+            nullptr);
     VERIFY_OR_DEBUG_ASSERT(result == SQLITE_OK) {
         kLogger.warning()
                 << "Failed to install custom 2-arg LIKE function for SQLite3:"
@@ -291,13 +292,14 @@ bool initDatabase(const QSqlDatabase& database, StringCollator* pCollator) {
     }
 
     result = sqlite3_create_function(
-                    handle,
-                    "like",
-                    3,
-                    SQLITE_UTF8, // No conversion, Data is stored as UTF8
-                    nullptr,
-                    sqliteLike,
-                    nullptr, nullptr);
+            handle,
+            "like",
+            3, // 3rd arg = ESCAPE
+            SQLITE_UTF8,
+            nullptr,
+            sqliteLikeUtf8,
+            nullptr,
+            nullptr);
     VERIFY_OR_DEBUG_ASSERT(result == SQLITE_OK) {
         kLogger.warning()
                 << "Failed to install custom 3-arg LIKE function for SQLite3:"


### PR DESCRIPTION
Didn't cause any bugs, because strings are internally stored as UTF-8. The new function name `sqliteLikeUtf8()` now explicitly documents our assumptions.

We also missed a performance optimization hint.