### PR TITLE
Add FIXMEs for use of bpm.value() without checking

### DIFF
--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -174,6 +174,7 @@ void BpmControl::adjustBeatsBpm(double deltaBpm) {
     const mixxx::BeatsPointer pBeats = pTrack->getBeats();
     if (pBeats && (pBeats->getCapabilities() & mixxx::Beats::BEATSCAP_SETBPM)) {
         mixxx::Bpm bpm = pBeats->getBpm();
+        // FIXME: calling bpm.value() without checking bpm.isValid()
         const auto centerBpm = mixxx::Bpm(math_max(kBpmAdjustMin, bpm.value() + deltaBpm));
         mixxx::Bpm adjustedBpm = BeatUtils::roundBpmWithinRange(
                 centerBpm - kBpmAdjustStep / 2, centerBpm, centerBpm + kBpmAdjustStep / 2);

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -511,6 +511,7 @@ void SyncControl::reportPlayerSpeed(double speed, bool scratching) {
 double SyncControl::fileBpm() const {
     mixxx::BeatsPointer pBeats = m_pBeats;
     if (pBeats) {
+        // FIXME: calling bpm.value() without checking bpm.isValid()
         return pBeats->getBpm().value();
     }
     return mixxx::Bpm::kValueUndefined;

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -782,6 +782,7 @@ QVariant BaseTrackTableModel::roleValue(
         case ColumnCache::COLUMN_LIBRARYTABLE_BPM: {
             bool ok;
             const auto bpmValue = rawValue.toDouble(&ok);
+            // FIXME: calling bpm.value() without checking bpm.isValid()
             return ok ? bpmValue : mixxx::Bpm().value();
         }
         case ColumnCache::COLUMN_LIBRARYTABLE_TIMESPLAYED:

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -369,6 +369,7 @@ void DlgTrackInfo::updateTrackMetadataFields() {
 void DlgTrackInfo::reloadTrackBeats(const Track& track) {
     m_pBeatsClone = track.getBeats();
     if (m_pBeatsClone) {
+        // FIXME: calling bpm.value() without checking bpm.isValid()
         spinBpm->setValue(m_pBeatsClone->getBpm().value());
     } else {
         spinBpm->setValue(0.0);
@@ -521,6 +522,7 @@ void DlgTrackInfo::slotBpmDouble() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::BpmScale::Double);
     // read back the actual value
     mixxx::Bpm newValue = m_pBeatsClone->getBpm();
+    // FIXME: calling bpm.value() without checking bpm.isValid()
     spinBpm->setValue(newValue.value());
 }
 
@@ -528,6 +530,7 @@ void DlgTrackInfo::slotBpmHalve() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::BpmScale::Halve);
     // read back the actual value
     const mixxx::Bpm newValue = m_pBeatsClone->getBpm();
+    // FIXME: calling bpm.value() without checking bpm.isValid()
     spinBpm->setValue(newValue.value());
 }
 
@@ -535,6 +538,7 @@ void DlgTrackInfo::slotBpmTwoThirds() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::BpmScale::TwoThirds);
     // read back the actual value
     const mixxx::Bpm newValue = m_pBeatsClone->getBpm();
+    // FIXME: calling bpm.value() without checking bpm.isValid()
     spinBpm->setValue(newValue.value());
 }
 
@@ -542,6 +546,7 @@ void DlgTrackInfo::slotBpmThreeFourth() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::BpmScale::ThreeFourths);
     // read back the actual value
     const mixxx::Bpm newValue = m_pBeatsClone->getBpm();
+    // FIXME: calling bpm.value() without checking bpm.isValid()
     spinBpm->setValue(newValue.value());
 }
 
@@ -549,6 +554,7 @@ void DlgTrackInfo::slotBpmFourThirds() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::BpmScale::FourThirds);
     // read back the actual value
     const mixxx::Bpm newValue = m_pBeatsClone->getBpm();
+    // FIXME: calling bpm.value() without checking bpm.isValid()
     spinBpm->setValue(newValue.value());
 }
 
@@ -556,6 +562,7 @@ void DlgTrackInfo::slotBpmThreeHalves() {
     m_pBeatsClone = m_pBeatsClone->scale(mixxx::Beats::BpmScale::ThreeHalves);
     // read back the actual value
     const mixxx::Bpm newValue = m_pBeatsClone->getBpm();
+    // FIXME: calling bpm.value() without checking bpm.isValid()
     spinBpm->setValue(newValue.value());
 }
 

--- a/src/track/beatutils.cpp
+++ b/src/track/beatutils.cpp
@@ -325,6 +325,7 @@ mixxx::Bpm BeatUtils::makeConstBpm(
 mixxx::Bpm BeatUtils::roundBpmWithinRange(
         mixxx::Bpm minBpm, mixxx::Bpm centerBpm, mixxx::Bpm maxBpm) {
     // First try to snap to a full integer BPM
+    // FIXME: calling bpm.value() without checking bpm.isValid()
     auto snapBpm = mixxx::Bpm(round(centerBpm.value()));
     if (snapBpm > minBpm && snapBpm < maxBpm) {
         // Success
@@ -387,6 +388,7 @@ mixxx::audio::FramePos BeatUtils::adjustPhase(
         mixxx::Bpm bpm,
         mixxx::audio::SampleRate sampleRate,
         const QVector<mixxx::audio::FramePos>& beats) {
+    // FIXME: calling bpm.value() without checking bpm.isValid()
     const double beatLength = 60 * sampleRate / bpm.value();
     const mixxx::audio::FramePos startOffset =
             mixxx::audio::FramePos(fmod(firstBeat.value(), beatLength));

--- a/src/track/serato/beatgrid.cpp
+++ b/src/track/serato/beatgrid.cpp
@@ -509,6 +509,7 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
             currentBeatPositionFramesWithOffset.value());
     const mixxx::Bpm bpm = pBeats->getBpmAroundPosition(currentBeatPositionFramesWithOffset, 1);
 
+    // FIXME: calling bpm.value() without checking bpm.isValid()
     setTerminalMarker(std::make_shared<SeratoBeatGridTerminalMarker>(
             positionSecs - timingOffsetSecs, static_cast<float>(bpm.value())));
     setNonTerminalMarkers(nonTerminalMarkers);


### PR DESCRIPTION
This PR does two things:

* Makes the Engine Prime export more resilient to any occasion where cue points or the beat grid are not properly set up for a given track - this led to assertion violations during a whole-library export.
* Marks with `FIXME` statements any instances in the code where I could see a call to `Bpm::value()` without an appropriate check or assertion on `Bpm::isValid()` first.

With regard to the FIXMEs, it may be the case that some parts of the code I highlighted in this PR are actually safe - but the point of this PR is simply to highlight where any such safety doesn't seem immediately "obvious".

Happy to review any of the FIXMEs (i.e. remove or fix them if trivial!) before this PR is approved.