### PR TITLE
CMake: make FindPortAudio.cmake module export PortAudio::PortAudio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2041,8 +2041,7 @@ target_link_libraries(mixxx-lib PRIVATE Vorbis::vorbis Vorbis::vorbisenc Vorbis:
 
 # PortAudio
 find_package(PortAudio REQUIRED)
-target_include_directories(mixxx-lib SYSTEM PUBLIC ${PortAudio_INCLUDE_DIRS})
-target_link_libraries(mixxx-lib PRIVATE ${PortAudio_LIBRARIES})
+target_link_libraries(mixxx-lib PRIVATE PortAudio::PortAudio)
 
 # PortAudio Ring Buffer
 add_library(PortAudioRingBuffer STATIC EXCLUDE_FROM_ALL

--- a/cmake/modules/FindPortAudio.cmake
+++ b/cmake/modules/FindPortAudio.cmake
@@ -1,54 +1,82 @@
-# - Try to find Portaudio
-# Once done this will define
-#
-#  PortAudio_FOUND - system has Portaudio
-#  PortAudio_INCLUDE_DIRS - the Portaudio include directory
-#  PortAudio_LIBRARIES - Link these to use Portaudio
+# This file is part of Mixxx, Digital DJ'ing software.
+# Copyright (C) 2001-2021 Mixxx Development Team
+# Distributed under the GNU General Public Licence (GPL) version 2 or any later
+# later version. See the LICENSE file for details.
+
+#[=======================================================================[.rst:
+FindPortAudio
+--------
+
+Finds the PortAudio library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``PortAudio::PortAudio``
+  The PortAudio library
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``PortAudio_FOUND``
+  True if the system has the PortAudio library.
+``PortAudio_INCLUDE_DIRS``
+  Include directories needed to use PortAudio.
+``PortAudio_LIBRARIES``
+  Libraries needed to link to PortAudio.
+``PortAudio_DEFINITIONS``
+  Compile definitions needed to use PortAudio.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``PortAudio_INCLUDE_DIR``
+  The directory containing ``PortAudio/all.h``.
+``PortAudio_LIBRARY``
+  The path to the PortAudio library.
+
+#]=======================================================================]
 
 find_package(PkgConfig QUIET)
 if(PkgConfig_FOUND)
-  pkg_check_modules(PC_PortAudio portaudio-2.0)
+  pkg_check_modules(PC_PortAudio QUIET portaudio-2.0)
 endif()
 
-find_path(PortAudio_INCLUDE_DIRS
-  NAMES
-    portaudio.h
-  PATHS
-      /usr/local/include
-      /usr/include
-  HINTS
-    ${PC_PortAudio_INCLUDEDIR}
+find_path(PortAudio_INCLUDE_DIR
+  NAMES portaudio.h
+  PATHS ${PC_PortAudio_INCLUDE_DIRS}
+  DOC "PortAudio include directory")
+mark_as_advanced(PortAudio_INCLUDE_DIR)
+
+find_library(PortAudio_LIBRARY
+  NAMES portaudio
+  PATHS ${PC_PortAudio_LIBRARY_DIRS}
+  DOC "PortAudio library"
+)
+mark_as_advanced(PortAudio_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  PortAudio
+  DEFAULT_MSG
+  PortAudio_LIBRARY
+  PortAudio_INCLUDE_DIR
 )
 
-find_library(PortAudio_LIBRARIES
-  NAMES
-    portaudio
-  PATHS
-      /usr/local/lib
-      /usr/lib
-      /usr/lib64
-  HINTS
-    ${PC_PortAudio_LIBDIR}
-)
-
-mark_as_advanced(PortAudio_INCLUDE_DIRS PortAudio_LIBRARIES)
-
-# Found PortAudio, but it may be version 18 which is not acceptable.
-if(EXISTS ${PortAudio_INCLUDE_DIRS}/portaudio.h)
-  include(CheckCXXSourceCompiles)
-  set(CMAKE_REQUIRED_INCLUDES_SAVED ${CMAKE_REQUIRED_INCLUDES})
-  set(CMAKE_REQUIRED_INCLUDES ${PortAudio_INCLUDE_DIRS})
-  CHECK_CXX_SOURCE_COMPILES(
-    "#include <portaudio.h>\nPaDeviceIndex pa_find_device_by_name(const char *name); int main () {return 0;}"
-    PortAudio2_FOUND)
-  set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES_SAVED})
-  unset(CMAKE_REQUIRED_INCLUDES_SAVED)
-  if(PortAudio2_FOUND)
-    INCLUDE(FindPackageHandleStandardArgs)
-    FIND_PACKAGE_HANDLE_STANDARD_ARGS(PortAudio DEFAULT_MSG PortAudio_INCLUDE_DIRS PortAudio_LIBRARIES)
-  else(PortAudio2_FOUND)
-    message(STATUS
-      "  portaudio.h not compatible (requires API 2.0)")
-    set(PortAudio_FOUND FALSE)
-  endif(PortAudio2_FOUND)
+if(PortAudio_FOUND)
+  if(NOT TARGET PortAudio::PortAudio)
+    add_library(PortAudio::PortAudio UNKNOWN IMPORTED)
+    set_target_properties(PortAudio::PortAudio
+      PROPERTIES
+        IMPORTED_LOCATION "${PortAudio_LIBRARY}"
+        INTERFACE_COMPILE_OPTIONS "${PC_PortAudio_CFLAGS_OTHER}"
+        INTERFACE_INCLUDE_DIRECTORIES "${PortAudio_INCLUDE_DIR}"
+    )
+  endif()
 endif()


### PR DESCRIPTION
to match targets exported by config files
https://github.com/PortAudio/portaudio/pull/461
https://github.com/mixxxdj/vcpkg/pull/20