### PR TITLE
ControllerScriptEngineBase: install console extension

### DIFF
--- a/src/controllers/scripting/controllerscriptenginebase.cpp
+++ b/src/controllers/scripting/controllerscriptenginebase.cpp
@@ -25,6 +25,8 @@ bool ControllerScriptEngineBase::initialize() {
     // Create the Script Engine
     m_pJSEngine = std::make_shared<QJSEngine>(this);
 
+    m_pJSEngine->installExtensions(QJSEngine::ConsoleExtension);
+
     QJSValue engineGlobalObject = m_pJSEngine->globalObject();
 
     QJSValue mapper = m_pJSEngine->newQMetaObject(

--- a/src/controllers/scripting/controllerscriptmoduleengine.cpp
+++ b/src/controllers/scripting/controllerscriptmoduleengine.cpp
@@ -16,7 +16,6 @@ ControllerScriptModuleEngine::~ControllerScriptModuleEngine() {
 
 bool ControllerScriptModuleEngine::initialize() {
     ControllerScriptEngineBase::initialize();
-    m_pJSEngine->installExtensions(QJSEngine::ConsoleExtension);
     // TODO: Add new ControlObject JS API to scripting environment.
 
     QJSValue mod =


### PR DESCRIPTION
This allows new scripts to use `console.*` functions which for example
enables easier debugging using Qt's debugging and logging tools.
See https://doc.qt.io/qt-5/qtquick-debugging.html#console-api for more information
on the console extension api.

I already suggested this while reviewing another PR: https://github.com/mixxxdj/mixxx/pull/4171#discussion_r681067426