### PR TITLE
ControllerScriptEngineBase: only shutdown controller engine if it exists

### DIFF
--- a/src/controllers/scripting/controllerscriptenginebase.cpp
+++ b/src/controllers/scripting/controllerscriptenginebase.cpp
@@ -55,7 +55,10 @@ void ControllerScriptEngineBase::shutdown() {
 }
 
 void ControllerScriptEngineBase::reload() {
-    shutdown();
+    // JSEngine needs to exist for it to be shutdown
+    if (m_pJSEngine) {
+        shutdown();
+    }
     initialize();
 }
 


### PR DESCRIPTION
When loading a faulty controller script, the engine might gets destroyed
when no script is using it. So when reloading when the file changes,
trying to shutdown an engine that doesn't exist triggers a debug assert
or crashes mixxx. So in that case, skip the shutdown procedure and just
re-initialize it instead.