### PR TITLE
CI: Trigger automatic update of manual repo if CHANGELOG.md was changed

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,27 @@
+name: Changelog
+
+on:
+  push:
+    branches:
+      - "main"
+      - "[0-9].[0-9]"
+    paths:
+      - "CHANGELOG.md"
+
+jobs:
+  trigger-changelog-update:
+    name: Trigger Changelog update on manual repository
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get current branch name
+      uses: nelonoel/branch-name@v1.0.1
+    - name: Start workflow run on manual repository
+      uses: peter-evans/repository-dispatch@v1
+      if: env.MIXXXBOT_TOKEN != null
+      with:
+        token: ${{ env.MIXXXBOT_TOKEN }}
+        repository: mixxxdj/manual
+        event-type: update-changelog
+        client-payload: '{"branch": "${{ env.BRANCH_NAME }}", "ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+      env:
+        MIXXXBOT_TOKEN: ${{ secrets.MIXXXBOT_CHANGELOG_AUTOUPDATER_PAT }}


### PR DESCRIPTION
See corresponding PR mixxxdj/manual#422 for details.

This requires a Personal Acess Token (PAT) with the `public_repo` scope
in the repository secrets (named `MANUAL_REPO_TOKEN`).