### PR TITLE
EngineMaster: Use mixxx::audio::SampleRate

### DIFF
--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -3,15 +3,16 @@
 #include <QObject>
 #include <QVarLengthArray>
 
-#include "preferences/usersettings.h"
+#include "audio/types.h"
 #include "control/controlobject.h"
 #include "control/controlpushbutton.h"
-#include "engine/engineobject.h"
-#include "engine/channels/enginechannel.h"
 #include "engine/channelhandle.h"
+#include "engine/channels/enginechannel.h"
+#include "engine/engineobject.h"
+#include "preferences/usersettings.h"
+#include "recording/recordingmanager.h"
 #include "soundio/soundmanager.h"
 #include "soundio/soundmanagerutil.h"
-#include "recording/recordingmanager.h"
 
 class EngineWorkerScheduler;
 class EngineBuffer;
@@ -283,7 +284,7 @@ class EngineMaster : public QObject, public AudioSource {
     QVarLengthArray<ChannelInfo*, kPreallocatedChannels> m_activeHeadphoneChannels;
     QVarLengthArray<ChannelInfo*, kPreallocatedChannels> m_activeTalkoverChannels;
 
-    unsigned int m_iSampleRate;
+    mixxx::audio::SampleRate m_sampleRate;
     unsigned int m_iBufferSize;
 
     // Mixing buffers for each output.

--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -527,11 +527,11 @@ void EngineSync::addSyncableDeck(Syncable* pSyncable) {
     m_syncables.append(pSyncable);
 }
 
-void EngineSync::onCallbackStart(int sampleRate, int bufferSize) {
+void EngineSync::onCallbackStart(mixxx::audio::SampleRate sampleRate, int bufferSize) {
     m_pInternalClock->onCallbackStart(sampleRate, bufferSize);
 }
 
-void EngineSync::onCallbackEnd(int sampleRate, int bufferSize) {
+void EngineSync::onCallbackEnd(mixxx::audio::SampleRate sampleRate, int bufferSize) {
     m_pInternalClock->onCallbackEnd(sampleRate, bufferSize);
 }
 

--- a/src/engine/sync/enginesync.h
+++ b/src/engine/sync/enginesync.h
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest_prod.h>
 
+#include "audio/types.h"
 #include "engine/sync/syncable.h"
 #include "preferences/usersettings.h"
 
@@ -57,8 +58,8 @@ class EngineSync : public SyncableListener {
 
     void addSyncableDeck(Syncable* pSyncable);
     EngineChannel* getLeader() const;
-    void onCallbackStart(int sampleRate, int bufferSize);
-    void onCallbackEnd(int sampleRate, int bufferSize);
+    void onCallbackStart(mixxx::audio::SampleRate sampleRate, int bufferSize);
+    void onCallbackEnd(mixxx::audio::SampleRate sampleRate, int bufferSize);
 
   private:
     /// Iterate over decks, and based on sync and play status, pick a new Leader.

--- a/src/engine/sync/internalclock.h
+++ b/src/engine/sync/internalclock.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <QObject>
-#include <QString>
 #include <QScopedPointer>
+#include <QString>
 
+#include "audio/types.h"
 #include "engine/sync/clock.h"
 #include "engine/sync/syncable.h"
 
@@ -57,8 +58,8 @@ class InternalClock : public QObject, public Clock, public Syncable {
     void updateInstantaneousBpm(mixxx::Bpm bpm) override;
     void reinitLeaderParams(double beatDistance, mixxx::Bpm baseBpm, mixxx::Bpm bpm) override;
 
-    void onCallbackStart(int sampleRate, int bufferSize);
-    void onCallbackEnd(int sampleRate, int bufferSize);
+    void onCallbackStart(mixxx::audio::SampleRate sampleRate, int bufferSize);
+    void onCallbackEnd(mixxx::audio::SampleRate sampleRate, int bufferSize);
 
   private slots:
     void slotBpmChanged(double bpm);
@@ -66,7 +67,7 @@ class InternalClock : public QObject, public Clock, public Syncable {
     void slotSyncLeaderEnabledChangeRequest(double state);
 
   private:
-    void updateBeatLength(int sampleRate, mixxx::Bpm bpm);
+    void updateBeatLength(mixxx::audio::SampleRate sampleRate, mixxx::Bpm bpm);
 
     const QString m_group;
     SyncableListener* m_pEngineSync;
@@ -75,7 +76,7 @@ class InternalClock : public QObject, public Clock, public Syncable {
     QScopedPointer<ControlPushButton> m_pSyncLeaderEnabled;
     SyncMode m_mode;
 
-    int m_iOldSampleRate;
+    mixxx::audio::SampleRate m_oldSampleRate;
     mixxx::Bpm m_oldBpm;
 
     // This is the BPM value at unity adopted when sync is enabled.


### PR DESCRIPTION
Use `mixxx::audio::SampleRate` instead of `int` in the `EngineMaster`,
`EngineSync` and `InternalClock` code.

The type was not applied to the channel mixer and effects code to reduce
potential merge conflicts with #1966 and #2618.

Based on PR #4071.