### PR TITLE
CMake: fix linking protobuf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2074,10 +2074,6 @@ target_include_directories(mixxx-lib SYSTEM PUBLIC ${PortMidi_INCLUDE_DIRS})
 target_link_libraries(mixxx-lib PRIVATE ${PortMidi_LIBRARIES})
 
 # Protobuf
-if(NOT BUILD_SHARED_LIBS)
-  set(Protobuf_USE_STATIC_LIBS ON)
-  mark_as_advanced(Protobuf_USE_STATIC_LIBS)
-endif()
 add_subdirectory(src/proto)
 target_link_libraries(mixxx-lib PRIVATE mixxx-proto)
 

--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -1,6 +1,19 @@
 # Protobuf
-find_package(Protobuf)
+find_package(Protobuf REQUIRED)
+
 add_library(mixxx-proto OBJECT)
+
+include(IsStaticLibrary)
+if(TARGET protobuf::libprotobuf-lite)
+    target_link_libraries(mixxx-proto PRIVATE protobuf::libprotobuf-lite)
+    is_static_library(Protobuf_USE_STATIC_LIBS protobuf::libprotobuf-lite)
+elseif(TARGET protobuf::libprotobuf)
+    target_link_libraries(mixxx-proto PRIVATE protobuf::libprotobuf)
+    is_static_library(Protobuf_USE_STATIC_LIBS protobuf::libprotobuf)
+else()
+    message(FATAL_ERROR "Protobuf or Protobuf-lite libraries are required to compile Mixxx.")
+endif()
+
 protobuf_generate(
   LANGUAGE cpp
   TARGET mixxx-proto
@@ -11,11 +24,3 @@ protobuf_generate(
     skin.proto
     waveform.proto
 )
-
-if(TARGET protobuf::libprotobuf-lite)
-    target_link_libraries(mixxx-proto PRIVATE protobuf::libprotobuf-lite)
-elseif(TARGET protobuf::libprotobuf)
-    target_link_libraries(mixxx-proto PRIVATE protobuf::libprotobuf)
-else()
-    message(FATAL_ERROR "Protobuf or Protobuf-lite libraries are required to compile Mixxx.")
-endif()


### PR DESCRIPTION
This was broken by the refactoring for building with static
libraries (c21aec26eb0a9efa355e44579eebb2bea4ff1034 #4163):
https://github.com/mixxxdj/mixxx/pull/4163#discussion_r684395927
https://mixxx.zulipchat.com/#narrow/stream/247620-development-help/topic/cmake.20fails.20with.20Could.20NOT.20find.20Protobuf