### PR TITLE
Sidebar item selection fix

### DIFF
--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -179,17 +179,9 @@ void BasePlaylistFeature::activateChild(const QModelIndex& index) {
     if (playlistId == kInvalidPlaylistId) {
         return;
     }
-
     m_pPlaylistTableModel->setTableModel(playlistId);
     emit showTrackModel(m_pPlaylistTableModel);
     emit enableCoverArtDisplay(true);
-    // Update selection
-    emit featureSelect(this, m_lastRightClickedIndex);
-
-    if (!m_pSidebarWidget) {
-        return;
-    }
-    m_pSidebarWidget->selectChildIndex(index);
 }
 
 void BasePlaylistFeature::activatePlaylist(int playlistId) {
@@ -201,7 +193,6 @@ void BasePlaylistFeature::activatePlaylist(int playlistId) {
     if (!index.isValid()) {
         return;
     }
-
     m_lastRightClickedIndex = index;
     m_pPlaylistTableModel->setTableModel(playlistId);
     emit showTrackModel(m_pPlaylistTableModel);

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -185,11 +185,11 @@ void BasePlaylistFeature::activateChild(const QModelIndex& index) {
 }
 
 void BasePlaylistFeature::activatePlaylist(int playlistId) {
-    // qDebug() << "BasePlaylistFeature::activatePlaylist()" << playlistId;
     VERIFY_OR_DEBUG_ASSERT(playlistId != kInvalidPlaylistId) {
         return;
     }
     QModelIndex index = indexFromPlaylistId(playlistId);
+    //qDebug() << "BasePlaylistFeature::activatePlaylist()" << playlistId << index;
     VERIFY_OR_DEBUG_ASSERT(index.isValid()) {
         return;
     }

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -176,7 +176,7 @@ void BasePlaylistFeature::selectPlaylistInSidebar(int playlistId, bool select) {
 void BasePlaylistFeature::activateChild(const QModelIndex& index) {
     //qDebug() << "BasePlaylistFeature::activateChild()" << index;
     int playlistId = playlistIdFromIndex(index);
-    if (playlistId == kInvalidPlaylistId) {
+    VERIFY_OR_DEBUG_ASSERT(playlistId != kInvalidPlaylistId) {
         return;
     }
     m_pPlaylistTableModel->setTableModel(playlistId);
@@ -186,11 +186,11 @@ void BasePlaylistFeature::activateChild(const QModelIndex& index) {
 
 void BasePlaylistFeature::activatePlaylist(int playlistId) {
     // qDebug() << "BasePlaylistFeature::activatePlaylist()" << playlistId;
-    if (playlistId == kInvalidPlaylistId) {
+    VERIFY_OR_DEBUG_ASSERT(playlistId != kInvalidPlaylistId) {
         return;
     }
     QModelIndex index = indexFromPlaylistId(playlistId);
-    if (!index.isValid()) {
+    VERIFY_OR_DEBUG_ASSERT(index.isValid()) {
         return;
     }
     m_lastRightClickedIndex = index;

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -279,6 +279,7 @@ TreeItemModel* CrateFeature::sidebarModel() const {
 }
 
 void CrateFeature::activateChild(const QModelIndex& index) {
+    //qDebug() << "CrateFeature::activateChild()" << index;
     CrateId crateId(crateIdFromIndex(index));
     VERIFY_OR_DEBUG_ASSERT(crateId.isValid()) {
         return;

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -395,6 +395,8 @@ void CrateFeature::slotDeleteCrate() {
             qWarning() << "Refusing to delete locked crate" << crate;
             return;
         }
+        // TODO Store sibling index to restore selection after crate was deleted
+        // to avoid scroll position reset (to Crate root item)
         if (m_pTrackCollection->deleteCrate(crate.getId())) {
             qDebug() << "Deleted crate" << crate;
             return;

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -395,9 +395,11 @@ void CrateFeature::slotDeleteCrate() {
             qWarning() << "Refusing to delete locked crate" << crate;
             return;
         }
-        // TODO Store sibling index to restore selection after crate was deleted
-        // to avoid scroll position reset (to Crate root item)
-        if (m_pTrackCollection->deleteCrate(crate.getId())) {
+        CrateId crateId = crate.getId();
+        // Store sibling id to restore selection after crate was deleted
+        // to avoid the scroll position being reset to Crate root item.
+        storePrevSiblingCrateId(crateId);
+        if (m_pTrackCollection->deleteCrate(crateId)) {
             qDebug() << "Deleted crate" << crate;
             return;
         }
@@ -768,16 +770,34 @@ void CrateFeature::slotExportTrackFiles() {
     track_export.exportTracks();
 }
 
+void CrateFeature::storePrevSiblingCrateId(CrateId crateId) {
+    QModelIndex actIndex = indexFromCrateId(crateId);
+    for (int i = (actIndex.row() + 1); i >= (actIndex.row() - 1); i -= 2) {
+        QModelIndex newIndex = actIndex.sibling(i, actIndex.column());
+        if (newIndex.isValid()) {
+            TreeItem* pTreeItem = m_pSidebarModel->getItem(newIndex);
+            DEBUG_ASSERT(pTreeItem != nullptr);
+            if (!pTreeItem->hasChildren()) {
+                m_prevSiblingCrate = crateIdFromIndex(newIndex);
+            }
+        }
+    }
+}
+
 void CrateFeature::slotCrateTableChanged(CrateId crateId) {
     if (m_lastRightClickedIndex.isValid() &&
             (crateIdFromIndex(m_lastRightClickedIndex) == crateId)) {
-        // Preserve crate selection
+        // Try to restore previous selection
         m_lastRightClickedIndex = rebuildChildModel(crateId);
         if (m_lastRightClickedIndex.isValid()) {
+            // Select last active crate
             activateCrate(crateId);
+        } else if (m_prevSiblingCrate.isValid()) {
+            // Select neighbour of deleted crate
+            activateCrate(m_prevSiblingCrate);
         }
     } else {
-        // Discard crate selection
+        // No valid selection to restore
         rebuildChildModel();
     }
 }

--- a/src/library/trackset/crate/cratefeature.h
+++ b/src/library/trackset/crate/cratefeature.h
@@ -102,6 +102,11 @@ class CrateFeature : public BaseTrackSetFeature {
 
     CrateTableModel m_crateTableModel;
 
+    // Stores the id of a crate in the sidebar that is adjacent to the crate(crateId).
+    void storePrevSiblingCrateId(CrateId crateId);
+    // Can be used to restore a similiar selection after the sidebar model was rebuilt.
+    CrateId m_prevSiblingCrate;
+
     QModelIndex m_lastRightClickedIndex;
     TrackPointer m_pSelectedTrack;
 

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -212,15 +212,20 @@ void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
 }
 
 void WLibrarySidebar::selectIndex(const QModelIndex& index) {
+    //qDebug() << "WLibrarySidebar::selectIndex" << index;
+    if (!index.isValid()) {
+        return;
+    }
     auto* pModel = new QItemSelectionModel(model());
     pModel->select(index, QItemSelectionModel::Select);
     if (selectionModel()) {
         selectionModel()->deleteLater();
     }
-    setSelectionModel(pModel);
     if (index.parent().isValid()) {
         expand(index.parent());
     }
+    setSelectionModel(pModel);
+    setCurrentIndex(index);
     scrollTo(index);
 }
 
@@ -232,6 +237,9 @@ void WLibrarySidebar::selectChildIndex(const QModelIndex& index, bool selectItem
         return;
     }
     QModelIndex translated = sidebarModel->translateChildIndex(index);
+    if (!translated.isValid()) {
+        return;
+    }
 
     if (selectItem) {
         auto* pModel = new QItemSelectionModel(sidebarModel);
@@ -240,6 +248,7 @@ void WLibrarySidebar::selectChildIndex(const QModelIndex& index, bool selectItem
             selectionModel()->deleteLater();
         }
         setSelectionModel(pModel);
+        setCurrentIndex(translated);
     }
 
     QModelIndex parentIndex = translated.parent();


### PR DESCRIPTION
Fixes some issues when navigating the sidebar with Up/Down keys, `[Library],Move...`, `[Playlist],Select...` controls (emulated key presses)

**part1**
fixes https://bugs.launchpad.net/mixxx/+bug/1939082

Keys can NOT select the pevious/next playlist (Playlists, History) but make the selection jump to Tracks (and sometimes apply the key press after that).

Looks like #2996 added the redundant and failing code (git bisect points to a8a93f02e44751d42e9673d622dcd0233c024feb), ~~though I didn't trace what exactly causes the fail~~ (redundant sidebar item activation with invalid index) 

En passant I added some debug assertions.

**part 2**
After creating a playlist/crate Up/Down keys would make the selection jump to the Tracks.
Fixed by adding `setCurrentIndex()` to  `WLibrarySidebar::selectIndex` and `WLibrarySidebar::selectChildIndex`.
**edit** also prevents the jump when moving away from active external features' root item (Serato, Rekordbox ...)

**part 3**
Remove a crate and the selection jumps to the Crates root item.
Fix: Like with playlists, before deleting a crate, store its neighbour's Id to somewhat restore the selection afterwards, or rather scroll position.