### PR TITLE
Fix inverted scroll wheel waveform zoom direction

### DIFF
--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -175,12 +175,12 @@ void WWaveformViewer::mouseReleaseEvent(QMouseEvent* /*event*/) {
     setCursor(Qt::ArrowCursor);
 }
 
-void WWaveformViewer::wheelEvent(QWheelEvent *event) {
+void WWaveformViewer::wheelEvent(QWheelEvent* event) {
     if (m_waveformWidget) {
         if (event->angleDelta().y() > 0) {
-            onZoomChange(m_waveformWidget->getZoomFactor() * 1.05);
-        } else {
             onZoomChange(m_waveformWidget->getZoomFactor() / 1.05);
+        } else {
+            onZoomChange(m_waveformWidget->getZoomFactor() * 1.05);
         }
     }
 }


### PR DESCRIPTION
Fixes bug [#1876005](https://bugs.launchpad.net/mixxx/+bug/1876005)

The feature to zoom the waveform using the scroll wheel was inverted, when compared to standard behaviour from each OS. This fixes the reported bug.
Due to it having stayed that way for quite a while, some people might actually already be used to the way it is now, so I also added a preference to keep it inverted.

![image](https://user-images.githubusercontent.com/32823411/129107639-b06461fd-7f2e-42de-9f1a-4d04eb85c38d.png)

