### PR TITLE
[WiP] Re-enable codespell hook

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,4 +1,7 @@
-Crate
 crate
-InOut
+inout
 copyable
+technics
+doubleclick
+pevent
+preverse

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+ignore-words = .codespellignore

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ default_language_version:
   python: python3
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.3.0
+  rev: v4.0.1
   hooks:
   - id: fix-byte-order-marker
     exclude: ^.*(\.cbproj|\.groupproj|\.props|\.sln|\.vcxproj|\.vcxproj.filters)$
@@ -67,14 +67,14 @@ repos:
     - manual
   - id: no-commit-to-branch
 - repo: https://github.com/codespell-project/codespell
-  rev: v1.17.1
+  rev: v2.1.0
   hooks:
   - id: codespell
     # ignore-regex is substituted by ' '
     entry: tools/codespell.py --ignore-file .codespellignore --ignore-regex "\\W(?:m_p*(?=[A-Z])|m_(?=\\w)|pp*(?=[A-Z])|k(?=[A-Z])|s_(?=\\w))" --files
     exclude: ^(\.codespellignore|src/dialog/dlgabout\.cpp|.*\.(?:pot?|ts|wxl))$
 - repo: https://github.com/pre-commit/mirrors-eslint
-  rev: v7.12.1
+  rev: v7.32.0
   hooks:
   - id: eslint
     args: [--fix, --report-unused-disable-directives]
@@ -94,18 +94,18 @@ repos:
     language: python
     files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|m|mm|proto|vert)$
 - repo: https://github.com/psf/black
-  rev: 20.8b1
+  rev: 21.7b0
   hooks:
   - id: black
     files: ^tools/.*$
 - repo: https://gitlab.com/pycqa/flake8
-  rev: '3.8.4'
+  rev: '3.9.2'
   hooks:
   - id: flake8
     files: ^tools/.*$
     types: [text, python]
 - repo: https://github.com/shellcheck-py/shellcheck-py
-  rev: v0.7.1.1
+  rev: v0.7.2.1
   hooks:
   - id: shellcheck
 - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,9 +70,7 @@ repos:
   rev: v2.1.0
   hooks:
   - id: codespell
-    # ignore-regex is substituted by ' '
-    entry: tools/codespell.py --ignore-file .codespellignore --ignore-regex "\\W(?:m_p*(?=[A-Z])|m_(?=\\w)|pp*(?=[A-Z])|k(?=[A-Z])|s_(?=\\w))" --files
-    exclude: ^(\.codespellignore|src/dialog/dlgabout\.cpp|.*\.(?:pot?|ts|wxl))$
+    exclude: ^(src/dialog/dlgabout\.cpp|packaging/wix/LICENSE.rtf|.*\.(?:pot?|ts|wxl))$
 - repo: https://github.com/pre-commit/mirrors-eslint
   rev: v7.32.0
   hooks:


### PR DESCRIPTION
TODO:
- [ ] Merge #4192
- [ ] Fix spelling errors

- The codespell hook didn't work
- The ignore-regex option didn't work
- The spelling in .codespellignore has to match that in [dictionary.txt](https://github.com/codespell-project/codespell/blob/master/codespell_lib/data/dictionary.txt) if the word already appears there, i.e. we have to explicitly use lowercase instead of the desired case. Everything in dictionary.txt is lowercase, even though all other words in .codespellignore are supposed to be case-sensitive. If new exceptions are added to dictionary.txt the contents of .codespellignore will be ignored if not written in lowercase :exploding_head: Who designs such a bullshit algorithm???