### PR TITLE
Update query planner statistics of database after library scan finished

### DIFF
--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -68,9 +68,9 @@ void cleanUpDatabase(const QSqlDatabase& database) {
 
 /// Update statistics for the query planner
 /// See also: https://www.sqlite.org/lang_analyze.html
-void analyzeAndOptimizeDatabase(const QSqlDatabase& database) {
+void updateQueryPlannerStatisticsForDatabase(const QSqlDatabase& database) {
     kLogger.info()
-            << "Analyzing and optimizing database...";
+            << "Updating query planner statistics for database...";
     PerformanceTimer timer;
     timer.start();
     const auto sqlStmt = QStringLiteral("ANALYZE");
@@ -78,11 +78,11 @@ void analyzeAndOptimizeDatabase(const QSqlDatabase& database) {
     const auto numRows = execRowCountQuery(query);
     VERIFY_OR_DEBUG_ASSERT(numRows >= 0) {
         kLogger.warning()
-                << "Failed to analyze and optimize database";
+                << "Failed to update query planner statistics for database";
     }
     else {
         kLogger.info()
-                << "Finished database analysis and optimization:"
+                << "Finished updating query planner statistics for database:"
                 << timer.elapsed().debugMillisWithUnit();
     }
 }
@@ -408,7 +408,7 @@ void LibraryScanner::slotFinishUnhashedScan() {
 
     if (!m_scannerGlobal->shouldCancel() && bScanFinishedCleanly) {
         const auto dbConnection = mixxx::DbConnectionPooled(m_pDbConnectionPool);
-        analyzeAndOptimizeDatabase(dbConnection);
+        updateQueryPlannerStatisticsForDatabase(dbConnection);
     }
 
     if (!m_scannerGlobal->shouldCancel() && bScanFinishedCleanly) {

--- a/tools/mixxxdb_cleanup.sql
+++ b/tools/mixxxdb_cleanup.sql
@@ -79,6 +79,10 @@ DELETE FROM track_analysis WHERE track_id NOT IN (SELECT id FROM track_locations
 -- Post-cleanup maintenance                                          --
 -----------------------------------------------------------------------
 
-VACUUM;
+-- Update statistics for the query planner
+-- https://www.sqlite.org/lang_analyze.html
+ANALYZE;
 
-PRAGMA optimize;
+-- Rebuild the entire database file
+-- https://www.sqlite.org/lang_vacuum.html
+VACUUM;

--- a/tools/mixxxdb_cleanup.sql
+++ b/tools/mixxxdb_cleanup.sql
@@ -79,10 +79,13 @@ DELETE FROM track_analysis WHERE track_id NOT IN (SELECT id FROM track_locations
 -- Post-cleanup maintenance                                          --
 -----------------------------------------------------------------------
 
--- Update statistics for the query planner
--- https://www.sqlite.org/lang_analyze.html
-ANALYZE;
-
 -- Rebuild the entire database file
 -- https://www.sqlite.org/lang_vacuum.html
 VACUUM;
+
+-- According to Richard Hipp himself executing VACUUM before ANALYZE is the
+-- recommended order: https://sqlite.org/forum/forumpost/62fb63a29c5f7810?t=h
+
+-- Update statistics for the query planner
+-- https://www.sqlite.org/lang_analyze.html
+ANALYZE;


### PR DESCRIPTION
This operation turned out to be crucial for achieving an acceptable performance after a mass import into aoide. Otherwise some queries took 30-90s on a large library or just stalled at 100% CPU! Though the issue might not affect Mixxx which uses a simpler schema that requires less JOINs.

The operation typically finishes after ~5-10 sec.