### PR TITLE
CMake: fix detection of hidapi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2605,9 +2605,8 @@ find_package(LibUSB)
 # USB HID controller support
 option(HID "USB HID controller support" ON)
 if(HID)
-  find_package(hidapi)
-  # hidapi_VERSION is only available starting with 0.10.0
-  if(NOT hidapi_FOUND OR NOT hidapi_VERSION OR hidapi_VERSION VERSION_LESS 0.10.1)
+  find_package(hidapi 0.10.1)
+  if(NOT hidapi_FOUND)
     message(STATUS "Linking internal libhidapi statically")
     add_library(mixxx-hidapi STATIC EXCLUDE_FROM_ALL)
     target_include_directories(mixxx-hidapi SYSTEM PUBLIC lib/hidapi/hidapi)

--- a/cmake/modules/Findhidapi.cmake
+++ b/cmake/modules/Findhidapi.cmake
@@ -62,14 +62,6 @@ find_library(hidapi_LIBRARY
 )
 mark_as_advanced(hidapi_LIBRARY)
 
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(
-  hidapi
-  DEFAULT_MSG
-  hidapi_LIBRARY
-  hidapi_INCLUDE_DIR
-)
-
 # Version detection
 if (EXISTS "${hidapi_INCLUDE_DIR}/hidapi.h")
     file(READ "${hidapi_INCLUDE_DIR}/hidapi.h" hidapi_H_CONTENTS)
@@ -80,10 +72,22 @@ if (EXISTS "${hidapi_INCLUDE_DIR}/hidapi.h")
     string(REGEX MATCH "#define HID_API_VERSION_PATCH ([0-9]+)" _dummy "${hidapi_H_CONTENTS}")
     set(hidapi_VERSION_PATCH "${CMAKE_MATCH_1}")
     # hidapi_VERSION is only available starting with 0.10.0
-    if (hidapi_VERSION_MAJOR AND hidapi_VERSION_MINOR AND hidapi_VERSION_PATCH)
+    # Simply using if(NOT) does not work because 0 is a valid value, so compare to empty string.
+    if (NOT hidapi_VERSION_MAJOR STREQUAL "" AND
+        NOT hidapi_VERSION_MINOR STREQUAL "" AND
+        NOT hidapi_VERSION_PATCH STREQUAL "")
       set(hidapi_VERSION "${hidapi_VERSION_MAJOR}.${hidapi_VERSION_MINOR}.${hidapi_VERSION_PATCH}")
     endif()
-endif ()
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  hidapi
+  DEFAULT_MSG
+  hidapi_LIBRARY
+  hidapi_INCLUDE_DIR
+  hidapi_VERSION
+)
 
 if(hidapi_FOUND)
   set(hidapi_LIBRARIES "${hidapi_LIBRARY}")


### PR DESCRIPTION
Mixxx was building its vendored copy of hidapi even when the system had hidapi 0.10.1.