### PR TITLE
CMake: fix detection of SoundTouch pkgconfig file and version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2178,7 +2178,7 @@ endif()
 
 # SoundTouch
 find_package(SoundTouch)
-default_option(SoundTouch_STATIC "Link libSoundTouch statically" "NOT SoundTouch_FOUND")
+default_option(SoundTouch_STATIC "Link libSoundTouch statically" "NOT SoundTouch_FOUND OR SoundTouch_VERSION VERSION_LESS 2.1.2")
 if(SoundTouch_STATIC)
   message(STATUS "Preparing internal libSoundTouch")
   add_library(SoundTouch STATIC EXCLUDE_FROM_ALL

--- a/cmake/modules/FindSoundTouch.cmake
+++ b/cmake/modules/FindSoundTouch.cmake
@@ -45,7 +45,7 @@ The following cache variables may also be set:
 
 find_package(PkgConfig QUIET)
 if(PkgConfig_FOUND)
-  pkg_check_modules(PC_SoundTouch QUIET soundtouch>=2.1.2)
+  pkg_check_modules(PC_SoundTouch QUIET soundtouch)
 endif()
 
 find_path(SoundTouch_INCLUDE_DIR
@@ -61,12 +61,22 @@ find_library(SoundTouch_LIBRARY
 )
 mark_as_advanced(SoundTouch_LIBRARY)
 
+# Version detection
+if(DEFINED PC_SoundTouch_VERSION)
+  set(SoundTouch_VERSION "${PC_SoundTouch_VERSION}")
+else()
+  if(EXISTS "${SoundTouch_INCLUDE_DIR}/soundtouch/SoundTouch.h")
+    file(READ "${SoundTouch_INCLUDE_DIR}/soundtouch/SoundTouch.h" SoundTouch_H_CONTENTS)
+    string(REGEX MATCH "#define SOUNDTOUCH_VERSION[ \t]+\"([0-9]+\.[0-9]+\.[0-9]+)\"" _dummy "${SoundTouch_H_CONTENTS}")
+    set(SoundTouch_VERSION "${CMAKE_MATCH_1}")
+  endif()
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   SoundTouch
-  DEFAULT_MSG
-  SoundTouch_LIBRARY
-  SoundTouch_INCLUDE_DIR
+  REQUIRED_VARS SoundTouch_LIBRARY SoundTouch_INCLUDE_DIR
+  VERSION_VAR SoundTouch_VERSION
 )
 
 if(SoundTouch_FOUND)

--- a/cmake/modules/FindSoundTouch.cmake
+++ b/cmake/modules/FindSoundTouch.cmake
@@ -45,7 +45,7 @@ The following cache variables may also be set:
 
 find_package(PkgConfig QUIET)
 if(PkgConfig_FOUND)
-  pkg_check_modules(PC_SoundTouch QUIET SoundTouch>=2.1.1)
+  pkg_check_modules(PC_SoundTouch QUIET soundtouch>=2.1.2)
 endif()
 
 find_path(SoundTouch_INCLUDE_DIR


### PR DESCRIPTION
I noticed this bug after copying this module to Tenacity.