### PR TITLE
Move code from Track to TrackDAO / Fix DB mapping

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -562,7 +562,7 @@ void bindTrackLibraryValues(
             trackMetadata.getStreamInfo().getDuration().toDoubleSeconds());
 
     pTrackLibraryQuery->bindValue(":header_parsed",
-            track.isSourceSynchronized() ? 1 : 0);
+            TrackDAO::getTrackHeaderParsedInternal(track) ? 1 : 0);
     const QDateTime sourceSynchronizedAt =
             track.getSourceSynchronizedAt();
     if (sourceSynchronizedAt.isValid()) {
@@ -2353,4 +2353,9 @@ void TrackDAO::setTrackGenreInternal(Track* pTrack, const QString& genre) {
 void TrackDAO::setTrackHeaderParsedInternal(Track* pTrack, bool headerParsed) {
     DEBUG_ASSERT(pTrack);
     pTrack->setHeaderParsedFromTrackDAO(headerParsed);
+}
+
+//static
+bool TrackDAO::getTrackHeaderParsedInternal(const mixxx::TrackRecord& trackRecord) {
+    return trackRecord.m_headerParsed;
 }

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1193,7 +1193,7 @@ bool setTrackFiletype(const QSqlRecord& record, const int column, Track* pTrack)
 }
 
 bool setTrackHeaderParsed(const QSqlRecord& record, const int column, Track* pTrack) {
-    pTrack->setHeaderParsedFromTrackDAO(record.value(column).toBool());
+    TrackDAO::setTrackHeaderParsedInternal(pTrack, record.value(column).toBool());
     return false;
 }
 
@@ -2347,4 +2347,10 @@ bool TrackDAO::updatePlayCounterFromPlayedHistory(
 void TrackDAO::setTrackGenreInternal(Track* pTrack, const QString& genre) {
     DEBUG_ASSERT(pTrack);
     pTrack->setGenreFromTrackDAO(genre);
+}
+
+//static
+void TrackDAO::setTrackHeaderParsedInternal(Track* pTrack, bool headerParsed) {
+    DEBUG_ASSERT(pTrack);
+    pTrack->setHeaderParsedFromTrackDAO(headerParsed);
 }

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -81,11 +81,20 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     bool updatePlayCounterFromPlayedHistory(
             const QSet<TrackId>& trackIds) const;
 
-    /// Ugly workaround, don't use!!!
+    /// Don't use even if public!!! Ugly workaround for C++ visibility restrictions.
+    /// This method is invoked by a free function that needs to access
+    /// a private Track member that only TrackDAO is allowed to access
+    /// as a friend.
     static void setTrackGenreInternal(Track* pTrack, const QString& genre);
-    /// Ugly workaround, don't use!!!
+    /// Don't use even if public!!! Ugly workaround for C++ visibility restrictions.
+    /// This method is invoked by a free function that needs to access
+    /// a private TrackRecord member that only TrackDAO is allowed to
+    /// access as a friend.
     static void setTrackHeaderParsedInternal(Track* pTrack, bool headerParsed);
-    /// Ugly workaround, don't use!!!
+    /// Don't use even if public!!! Ugly workaround for C++ visibility restrictions.
+    /// This method is invoked by a free function that needs to access
+    /// private TrackRecord member that only TrackDAO is allowed to
+    /// access as a friend.
     static bool getTrackHeaderParsedInternal(const mixxx::TrackRecord& trackRecord);
 
   signals:

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -24,6 +24,7 @@ class LibraryHashDAO;
 namespace mixxx {
 
 class FileInfo;
+class TrackRecord;
 
 } // namespace mixxx
 
@@ -84,6 +85,8 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     static void setTrackGenreInternal(Track* pTrack, const QString& genre);
     /// Ugly workaround, don't use!!!
     static void setTrackHeaderParsedInternal(Track* pTrack, bool headerParsed);
+    /// Ugly workaround, don't use!!!
+    static bool getTrackHeaderParsedInternal(const mixxx::TrackRecord& trackRecord);
 
   signals:
     // Forwarded from Track object

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -82,6 +82,8 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
 
     /// Ugly workaround, don't use!!!
     static void setTrackGenreInternal(Track* pTrack, const QString& genre);
+    /// Ugly workaround, don't use!!!
+    static void setTrackHeaderParsedInternal(Track* pTrack, bool headerParsed);
 
   signals:
     // Forwarded from Track object

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -158,13 +158,6 @@ class Track : public QObject {
     // Indicates if the metadata has been parsed from file tags.
     bool isSourceSynchronized() const;
 
-    void setHeaderParsedFromTrackDAO(bool headerParsed) {
-        // Always operating on a newly created, exclusive instance! No need
-        // to lock the mutex.
-        DEBUG_ASSERT(!m_record.m_headerParsed);
-        m_record.m_headerParsed = headerParsed;
-    }
-
     // The date/time of the last import or export of metadata
     void setSourceSynchronizedAt(const QDateTime& sourceSynchronizedAt);
     QDateTime getSourceSynchronizedAt() const;
@@ -582,6 +575,12 @@ class Track : public QObject {
     mixxx::CueInfoImporterPointer m_pCueInfoImporterPending;
 
     friend class TrackDAO;
+    void setHeaderParsedFromTrackDAO(bool headerParsed) {
+        // Always operating on a newly created, exclusive instance! No need
+        // to lock the mutex.
+        DEBUG_ASSERT(!m_record.m_headerParsed);
+        m_record.m_headerParsed = headerParsed;
+    }
     /// Set the genre text WITHOUT updating the corresponding custom tags.
     ///
     /// TODO: Remove and populate TrackRecord from the database instead.

--- a/src/track/trackrecord.h
+++ b/src/track/trackrecord.h
@@ -10,6 +10,8 @@
 #include "track/trackmetadata.h"
 #include "util/color/rgbcolor.h"
 
+// Forward declaration for accessing m_headerParsed
+class TrackDAO;
 
 namespace mixxx {
 
@@ -173,6 +175,7 @@ class TrackRecord final {
     //    Stale metadata should be re-imported depending on the other flags.
     std::optional<audio::StreamInfo> m_streamInfoFromSource;
 
+    friend class ::TrackDAO;
     bool m_headerParsed; // deprecated, replaced by sourceSynchronizedAt
 
     /// Equality comparison


### PR DESCRIPTION
A cleanup PR before introducing a new file tag synchronization feature:

- `Track`: Make `setHeaderParsedFromTrackDAO()` private by moving the ugly workarounds as public methods into `TrackDAO`, which is used by less code and where it does not matter so much.
- `TrackDAO`: Fix writing of the `header_parsed` column by populating it directly from the corresponding (deprecated) property. This was not a bug, just a conceptual issue. The effect is identical.