### PR TITLE
Add ControlFramePos(Proxy) classes and use them in CueControl/LoopingControl/QuantizeControl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,6 +437,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/control/controlbehavior.cpp
   src/control/controleffectknob.cpp
   src/control/controlencoder.cpp
+  src/control/controlframepos.cpp
   src/control/controlindicator.cpp
   src/control/controlindicatortimer.cpp
   src/control/controllinpotmeter.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,6 +438,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/control/controleffectknob.cpp
   src/control/controlencoder.cpp
   src/control/controlframepos.cpp
+  src/control/controlframeposproxy.cpp
   src/control/controlindicator.cpp
   src/control/controlindicatortimer.cpp
   src/control/controllinpotmeter.cpp

--- a/src/control/controlframepos.cpp
+++ b/src/control/controlframepos.cpp
@@ -1,0 +1,19 @@
+#include "control/controlframepos.h"
+
+#include "moc_controlframepos.cpp"
+
+ControlFramePos::ControlFramePos(const ConfigKey& key, mixxx::audio::FramePos defaultPosition)
+        : ControlObject(key) {
+    setDefaultPosition(defaultPosition);
+    reset();
+    connect(this,
+            &ControlFramePos::valueChanged,
+            this,
+            &ControlFramePos::slotValueChanged,
+            Qt::DirectConnection);
+}
+
+void ControlFramePos::slotValueChanged(double value) {
+    const auto position = mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(value);
+    emit positionChanged(position);
+}

--- a/src/control/controlframepos.h
+++ b/src/control/controlframepos.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "audio/frame.h"
+#include "control/controlobject.h"
+
+/// Special kind of `ControlObject` that is used for storing frame positions.
+//
+/// Although it exposes a `mixxx::audio::FramePos`-based API, the underlying
+/// control value uses sample positions for backwards compatibility. This might
+/// change in the future.
+class ControlFramePos : public ControlObject {
+    Q_OBJECT
+  public:
+    /// Creates a new ControlFramePos with the given default position.
+    ControlFramePos(const ConfigKey& key, mixxx::audio::FramePos defaultPosition);
+
+    /// Creates a new ControlFramePos. The default position is invalid.
+    ControlFramePos(const ConfigKey& key)
+            : ControlFramePos(key, mixxx::audio::kInvalidFramePos){};
+
+    /// Set the default position that is used when calling `reset()`.
+    void setDefaultPosition(mixxx::audio::FramePos position) {
+        ControlObject::setDefaultValue(position.toEngineSamplePosMaybeInvalid());
+    }
+
+    /// Returns the default position (i.e. the position that the control object
+    /// is set to when calling `reset()`).
+    mixxx::audio::FramePos defaultPosition() const {
+        return mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
+                ControlObject::defaultValue());
+    }
+
+    /// Returns the `mixxx:audio::FramePos` interpretation of the ControlObject.
+    mixxx::audio::FramePos toFramePos() const {
+        return mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(ControlObject::get());
+    }
+
+    /// Set the ControlObject from a `mixxx::audio::FramePos`.
+    void set(mixxx::audio::FramePos position) {
+        ControlObject::set(position.toEngineSamplePosMaybeInvalid());
+    }
+
+    /// Set the ControlObject from a `mixxx::audio::FramePos`.
+    void setAndConfirm(mixxx::audio::FramePos position) {
+        ControlObject::setAndConfirm(position.toEngineSamplePosMaybeInvalid());
+    }
+
+  signals:
+    /// Emitted whenever the `valueChanged` signal is emitted. Connect to this
+    /// signal when you want to receive the `mixxx::audio::FramePos` instead of
+    /// the double sample position.
+    void positionChanged(mixxx::audio::FramePos position);
+
+  private slots:
+    /// Invoked by the `valueChanged` signal. Converts the new value to a
+    /// `mixxx::audio::FramePos` and emit the `positionChanged` signal.
+    void slotValueChanged(double value);
+};

--- a/src/control/controlframeposproxy.cpp
+++ b/src/control/controlframeposproxy.cpp
@@ -1,0 +1,16 @@
+#include "control/controlframepos.h"
+#include "moc_controlframeposproxy.cpp"
+
+ControlFramePosProxy::ControlFramePosProxy(const ConfigKey& key, QObject* pParent)
+        : ControlProxy(key, pParent) {
+    connect(this,
+            &ControlFramePosProxy::valueChanged,
+            this,
+            &ControlFramePosProxy::slotValueChanged,
+            Qt::DirectConnection);
+}
+
+void ControlFramePosProxy::slotValueChanged(double value) {
+    const auto position = mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(value);
+    emit positionChanged(position);
+}

--- a/src/control/controlframeposproxy.h
+++ b/src/control/controlframeposproxy.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "audio/frame.h"
+#include "control/controlproxy.h"
+
+/// Special kind of `ControlProxy` that is used for storing frame positions.
+//
+/// Although it exposes a `mixxx::audio::FramePos`-based API, the underlying
+/// control value uses sample positions for backwards compatibility. This might
+/// change in the future.
+class ControlFramePosProxy : public ControlProxy {
+    Q_OBJECT
+  public:
+    /// Creates a new ControlFramePos with the given default position.
+    ControlFramePosProxy(const ConfigKey& key, QObject* pParent = nullptr);
+
+    /// Returns the `mixxx:audio::FramePos` interpretation of the ControlProxy.
+    mixxx::audio::FramePos toFramePos() const {
+        return mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(ControlProxy::get());
+    }
+
+    /// Set the ControlProxy from a `mixxx::audio::FramePos`.
+    void set(mixxx::audio::FramePos position) {
+        ControlProxy::set(position.toEngineSamplePosMaybeInvalid());
+    }
+
+  signals:
+    /// Emitted whenever the `valueChanged` signal is emitted. Connect to this
+    /// signal when you want to receive the `mixxx::audio::FramePos` instead of
+    /// the double sample position.
+    void positionChanged(mixxx::audio::FramePos position);
+
+  private slots:
+    /// Invoked by the `valueChanged` signal. Converts the new value to a
+    /// `mixxx::audio::FramePos` and emit the `positionChanged` signal.
+    void slotValueChanged(double value);
+};

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -10,6 +10,7 @@
 #include "util/tapfilter.h"
 
 class ControlObject;
+class ControlFramePosProxy;
 class ControlLinPotmeter;
 class ControlPushButton;
 class EngineBuffer;
@@ -129,13 +130,13 @@ class BpmControl : public EngineControl {
     ControlObject* m_pQuantize;
 
     // ControlObjects that come from QuantizeControl
-    QScopedPointer<ControlProxy> m_pNextBeat;
-    QScopedPointer<ControlProxy> m_pPrevBeat;
+    std::unique_ptr<ControlFramePosProxy> m_pNextBeatPosition;
+    std::unique_ptr<ControlFramePosProxy> m_pPrevBeatPosition;
 
     // ControlObjects that come from LoopingControl
     ControlProxy* m_pLoopEnabled;
-    ControlProxy* m_pLoopStartPosition;
-    ControlProxy* m_pLoopEndPosition;
+    std::unique_ptr<ControlFramePosProxy> m_pLoopStartPosition;
+    std::unique_ptr<ControlFramePosProxy> m_pLoopEndPosition;
 
     // The average bpm around the current playposition;
     ControlObject* m_pLocalBpm;

--- a/src/engine/controls/clockcontrol.cpp
+++ b/src/engine/controls/clockcontrol.cpp
@@ -1,5 +1,6 @@
 #include "engine/controls/clockcontrol.h"
 
+#include "control/controlframeposproxy.h"
 #include "control/controlobject.h"
 #include "control/controlproxy.h"
 #include "engine/controls/enginecontrol.h"
@@ -17,10 +18,14 @@ constexpr double kSignificiantRateThreshold =
 
 ClockControl::ClockControl(const QString& group, UserSettingsPointer pConfig)
         : EngineControl(group, pConfig),
-          m_pCOBeatActive(std::make_unique<ControlObject>(ConfigKey(group, "beat_active"))),
-          m_pLoopEnabled(std::make_unique<ControlProxy>(group, "loop_enabled", this)),
-          m_pLoopStartPosition(std::make_unique<ControlProxy>(group, "loop_start_position", this)),
-          m_pLoopEndPosition(std::make_unique<ControlProxy>(group, "loop_end_position", this)),
+          m_pCOBeatActive(std::make_unique<ControlObject>(
+                  ConfigKey(group, "beat_active"))),
+          m_pLoopEnabled(
+                  std::make_unique<ControlProxy>(group, "loop_enabled", this)),
+          m_pLoopStartPosition(std::make_unique<ControlFramePosProxy>(
+                  ConfigKey(group, "loop_start_position"))),
+          m_pLoopEndPosition(std::make_unique<ControlFramePosProxy>(
+                  ConfigKey(group, "loop_end_position"))),
           m_lastPlayDirectionWasForwards(true),
           m_lastEvaluatedPosition(mixxx::audio::kStartFramePos),
           m_prevBeatPosition(mixxx::audio::kStartFramePos),
@@ -92,12 +97,8 @@ void ClockControl::updateIndicators(const double dRate,
 
     // Loops need special handling
     if (m_pLoopEnabled->toBool()) {
-        const auto loopStartPosition =
-                mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                        m_pLoopStartPosition->get());
-        const auto loopEndPosition =
-                mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                        m_pLoopEndPosition->get());
+        const auto loopStartPosition = m_pLoopStartPosition->toFramePos();
+        const auto loopEndPosition = m_pLoopEndPosition->toFramePos();
 
         if (m_prevBeatPosition.isValid() && m_nextBeatPosition.isValid() &&
                 loopStartPosition.isValid() && loopEndPosition.isValid() &&

--- a/src/engine/controls/clockcontrol.h
+++ b/src/engine/controls/clockcontrol.h
@@ -9,6 +9,7 @@
 #include "track/track_decl.h"
 
 class ControlProxy;
+class ControlFramePosProxy;
 class ControlObject;
 
 class ClockControl: public EngineControl {
@@ -31,8 +32,8 @@ class ClockControl: public EngineControl {
 
     // ControlObjects that come from LoopingControl
     std::unique_ptr<ControlProxy> m_pLoopEnabled;
-    std::unique_ptr<ControlProxy> m_pLoopStartPosition;
-    std::unique_ptr<ControlProxy> m_pLoopEndPosition;
+    std::unique_ptr<ControlFramePosProxy> m_pLoopStartPosition;
+    std::unique_ptr<ControlFramePosProxy> m_pLoopEndPosition;
 
     // True is forward direction, False is reverse
     bool m_lastPlayDirectionWasForwards;

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -430,13 +430,13 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
 
         m_pCueIndicator->setBlinkValue(ControlIndicator::OFF);
         m_pCuePoint->reset();
-        m_pIntroStartPosition->set(mixxx::audio::kInvalidFramePos);
+        m_pIntroStartPosition->reset();
         m_pIntroStartEnabled->forceSet(0.0);
-        m_pIntroEndPosition->set(mixxx::audio::kInvalidFramePos);
+        m_pIntroEndPosition->reset();
         m_pIntroEndEnabled->forceSet(0.0);
-        m_pOutroStartPosition->set(mixxx::audio::kInvalidFramePos);
+        m_pOutroStartPosition->reset();
         m_pOutroStartEnabled->forceSet(0.0);
-        m_pOutroEndPosition->set(mixxx::audio::kInvalidFramePos);
+        m_pOutroEndPosition->reset();
         m_pOutroEndEnabled->forceSet(0.0);
         setHotcueFocusIndex(Cue::kNoHotCue);
         m_pLoadedTrack.reset();
@@ -612,9 +612,9 @@ void CueControl::loadCuesFromTrack() {
         m_pIntroEndPosition->set(endPosition);
         m_pIntroEndEnabled->forceSet(endPosition.isValid());
     } else {
-        m_pIntroStartPosition->set(mixxx::audio::kInvalidFramePos);
+        m_pIntroStartPosition->reset();
         m_pIntroStartEnabled->forceSet(0.0);
-        m_pIntroEndPosition->set(mixxx::audio::kInvalidFramePos);
+        m_pIntroEndPosition->reset();
         m_pIntroEndEnabled->forceSet(0.0);
     }
 
@@ -627,9 +627,9 @@ void CueControl::loadCuesFromTrack() {
         m_pOutroEndPosition->set(endPosition);
         m_pOutroEndEnabled->forceSet(endPosition.isValid());
     } else {
-        m_pOutroStartPosition->set(mixxx::audio::kInvalidFramePos);
+        m_pOutroStartPosition->reset();
         m_pOutroStartEnabled->forceSet(0.0);
-        m_pOutroEndPosition->set(mixxx::audio::kInvalidFramePos);
+        m_pOutroEndPosition->reset();
         m_pOutroEndEnabled->forceSet(0.0);
     }
 

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -5,6 +5,7 @@
 #include <QList>
 #include <QMutex>
 
+#include "control/controlframeposproxy.h"
 #include "control/controlproxy.h"
 #include "engine/controls/enginecontrol.h"
 #include "preferences/colorpalettesettings.h"
@@ -17,6 +18,7 @@
 
 class ControlObject;
 class ControlFramePos;
+class ControlFramePosProxy;
 class ControlPushButton;
 class ControlIndicator;
 
@@ -284,9 +286,9 @@ class CueControl : public EngineControl {
     ControlObject* m_pPlay;
     ControlObject* m_pStopButton;
     ControlObject* m_pQuantizeEnabled;
-    ControlObject* m_pClosestBeat;
-    parented_ptr<ControlProxy> m_pLoopStartPosition;
-    parented_ptr<ControlProxy> m_pLoopEndPosition;
+    std::unique_ptr<ControlFramePosProxy> m_pClosestBeatPosition;
+    parented_ptr<ControlFramePosProxy> m_pLoopStartPosition;
+    parented_ptr<ControlFramePosProxy> m_pLoopEndPosition;
     parented_ptr<ControlProxy> m_pLoopEnabled;
     parented_ptr<ControlProxy> m_pBeatLoopActivate;
     parented_ptr<ControlProxy> m_pBeatLoopSize;
@@ -296,7 +298,7 @@ class CueControl : public EngineControl {
     const int m_iNumHotCues;
     QList<HotcueControl*> m_hotcueControls;
 
-    ControlObject* m_pTrackSamples;
+    std::unique_ptr<ControlFramePosProxy> m_pTrackEndPosition;
     ControlFramePos* m_pCuePoint;
     ControlObject* m_pCueMode;
     ControlPushButton* m_pCueSet;

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -16,6 +16,7 @@
 #define NUM_HOT_CUES 37
 
 class ControlObject;
+class ControlFramePos;
 class ControlPushButton;
 class ControlIndicator;
 
@@ -134,8 +135,8 @@ class HotcueControl : public QObject {
     void slotHotcueActivateLoop(double v);
     void slotHotcueActivatePreview(double v);
     void slotHotcueClear(double v);
-    void slotHotcueEndPositionChanged(double newPosition);
-    void slotHotcuePositionChanged(double newPosition);
+    void slotHotcueEndPositionChanged(mixxx::audio::FramePos newPosition);
+    void slotHotcuePositionChanged(mixxx::audio::FramePos newPosition);
     void slotHotcueColorChangeRequest(double newColor);
     void slotHotcueColorChanged(double newColor);
 
@@ -149,8 +150,8 @@ class HotcueControl : public QObject {
     void hotcueActivate(HotcueControl* pHotcue, double v, HotcueSetMode mode);
     void hotcueActivatePreview(HotcueControl* pHotcue, double v);
     void hotcueClear(HotcueControl* pHotcue, double v);
-    void hotcuePositionChanged(HotcueControl* pHotcue, double newPosition);
-    void hotcueEndPositionChanged(HotcueControl* pHotcue, double newEndPosition);
+    void hotcuePositionChanged(HotcueControl* pHotcue, mixxx::audio::FramePos newPosition);
+    void hotcueEndPositionChanged(HotcueControl* pHotcue, mixxx::audio::FramePos newEndPosition);
     void hotcueColorChanged(HotcueControl* pHotcue, double newColor);
     void hotcuePlay(double v);
 
@@ -162,8 +163,8 @@ class HotcueControl : public QObject {
     CuePointer m_pCue;
 
     // Hotcue state controls
-    std::unique_ptr<ControlObject> m_hotcuePosition;
-    std::unique_ptr<ControlObject> m_hotcueEndPosition;
+    std::unique_ptr<ControlFramePos> m_hotcuePosition;
+    std::unique_ptr<ControlFramePos> m_hotcueEndPosition;
     std::unique_ptr<ControlObject> m_pHotcueStatus;
     std::unique_ptr<ControlObject> m_hotcueType;
     std::unique_ptr<ControlObject> m_hotcueColor;
@@ -225,8 +226,8 @@ class CueControl : public EngineControl {
     void hotcueActivatePreview(HotcueControl* pControl, double v);
     void updateCurrentlyPreviewingIndex(int hotcueIndex);
     void hotcueClear(HotcueControl* pControl, double v);
-    void hotcuePositionChanged(HotcueControl* pControl, double newPosition);
-    void hotcueEndPositionChanged(HotcueControl* pControl, double newEndPosition);
+    void hotcuePositionChanged(HotcueControl* pControl, mixxx::audio::FramePos newPosition);
+    void hotcueEndPositionChanged(HotcueControl* pControl, mixxx::audio::FramePos newEndPosition);
 
     void hotcueFocusColorNext(double v);
     void hotcueFocusColorPrev(double v);
@@ -296,7 +297,7 @@ class CueControl : public EngineControl {
     QList<HotcueControl*> m_hotcueControls;
 
     ControlObject* m_pTrackSamples;
-    ControlObject* m_pCuePoint;
+    ControlFramePos* m_pCuePoint;
     ControlObject* m_pCueMode;
     ControlPushButton* m_pCueSet;
     ControlPushButton* m_pCueClear;
@@ -312,25 +313,25 @@ class CueControl : public EngineControl {
     ControlPushButton* m_pCueGotoAndStop;
     ControlPushButton* m_pCuePreview;
 
-    ControlObject* m_pIntroStartPosition;
+    ControlFramePos* m_pIntroStartPosition;
     ControlObject* m_pIntroStartEnabled;
     ControlPushButton* m_pIntroStartSet;
     ControlPushButton* m_pIntroStartClear;
     ControlPushButton* m_pIntroStartActivate;
 
-    ControlObject* m_pIntroEndPosition;
+    ControlFramePos* m_pIntroEndPosition;
     ControlObject* m_pIntroEndEnabled;
     ControlPushButton* m_pIntroEndSet;
     ControlPushButton* m_pIntroEndClear;
     ControlPushButton* m_pIntroEndActivate;
 
-    ControlObject* m_pOutroStartPosition;
+    ControlFramePos* m_pOutroStartPosition;
     ControlObject* m_pOutroStartEnabled;
     ControlPushButton* m_pOutroStartSet;
     ControlPushButton* m_pOutroStartClear;
     ControlPushButton* m_pOutroStartActivate;
 
-    ControlObject* m_pOutroEndPosition;
+    ControlFramePos* m_pOutroEndPosition;
     ControlObject* m_pOutroEndEnabled;
     ControlPushButton* m_pOutroEndSet;
     ControlPushButton* m_pOutroEndClear;

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -12,6 +12,7 @@
 #include "track/track_decl.h"
 
 class ControlFramePos;
+class ControlFramePosProxy;
 class ControlPushButton;
 class ControlObject;
 
@@ -165,10 +166,10 @@ class LoopingControl : public EngineControl {
     LoopInfo m_oldLoopInfo;
     ControlValueAtomic<mixxx::audio::FramePos> m_currentPosition;
     ControlObject* m_pQuantizeEnabled;
-    ControlObject* m_pNextBeat;
-    ControlObject* m_pPreviousBeat;
-    ControlObject* m_pClosestBeat;
-    ControlObject* m_pTrackSamples;
+    std::unique_ptr<ControlFramePosProxy> m_pNextBeatPosition;
+    std::unique_ptr<ControlFramePosProxy> m_pPreviousBeatPosition;
+    std::unique_ptr<ControlFramePosProxy> m_pClosestBeatPosition;
+    std::unique_ptr<ControlFramePosProxy> m_pTrackEndPosition;
     QAtomicPointer<BeatLoopingControl> m_pActiveBeatLoop;
 
     // Base BeatLoop Control Object.

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -11,6 +11,7 @@
 #include "track/cue.h"
 #include "track/track_decl.h"
 
+class ControlFramePos;
 class ControlPushButton;
 class ControlObject;
 
@@ -71,8 +72,8 @@ class LoopingControl : public EngineControl {
     void slotLoopExit(double);
     void slotReloopToggle(double);
     void slotReloopAndStop(double);
-    void slotLoopStartPos(double);
-    void slotLoopEndPos(double);
+    void slotLoopStartPositionChanged(mixxx::audio::FramePos);
+    void slotLoopEndPositionChanged(mixxx::audio::FramePos);
 
     // Generate a loop of 'beats' length. It can also do fractions for a
     // beatslicing effect.
@@ -135,8 +136,8 @@ class LoopingControl : public EngineControl {
 
     ControlPushButton* m_pCOBeatLoopActivate;
     ControlPushButton* m_pCOBeatLoopRollActivate;
-    ControlObject* m_pCOLoopStartPosition;
-    ControlObject* m_pCOLoopEndPosition;
+    ControlFramePos* m_pCOLoopStartPosition;
+    ControlFramePos* m_pCOLoopEndPosition;
     ControlObject* m_pCOLoopEnabled;
     ControlPushButton* m_pLoopInButton;
     ControlPushButton* m_pLoopInGotoButton;

--- a/src/engine/controls/quantizecontrol.cpp
+++ b/src/engine/controls/quantizecontrol.cpp
@@ -33,9 +33,9 @@ void QuantizeControl::trackLoaded(TrackPointer pNewTrack) {
         updateClosestBeat(mixxx::audio::kStartFramePos);
     } else {
         m_pBeats.clear();
-        m_pCOPrevBeat->set(mixxx::audio::kInvalidFramePos);
-        m_pCONextBeat->set(mixxx::audio::kInvalidFramePos);
-        m_pCOClosestBeat->set(mixxx::audio::kInvalidFramePos);
+        m_pCOPrevBeat->reset();
+        m_pCONextBeat->reset();
+        m_pCOClosestBeat->reset();
     }
 }
 

--- a/src/engine/controls/quantizecontrol.cpp
+++ b/src/engine/controls/quantizecontrol.cpp
@@ -2,7 +2,7 @@
 
 #include <QtDebug>
 
-#include "control/controlobject.h"
+#include "control/controlframepos.h"
 #include "control/controlpushbutton.h"
 #include "engine/controls/enginecontrol.h"
 #include "moc_quantizecontrol.cpp"
@@ -15,19 +15,13 @@ QuantizeControl::QuantizeControl(const QString& group,
     // Turn quantize OFF by default. See Bug #898213
     m_pCOQuantizeEnabled = new ControlPushButton(ConfigKey(group, "quantize"), true);
     m_pCOQuantizeEnabled->setButtonMode(ControlPushButton::TOGGLE);
-    m_pCONextBeat = new ControlObject(ConfigKey(group, "beat_next"));
-    m_pCONextBeat->set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
-    m_pCOPrevBeat = new ControlObject(ConfigKey(group, "beat_prev"));
-    m_pCOPrevBeat->set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
-    m_pCOClosestBeat = new ControlObject(ConfigKey(group, "beat_closest"));
-    m_pCOClosestBeat->set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
+    m_pCONextBeat = std::make_unique<ControlFramePos>(ConfigKey(group, "beat_next"));
+    m_pCOPrevBeat = std::make_unique<ControlFramePos>(ConfigKey(group, "beat_prev"));
+    m_pCOClosestBeat = std::make_unique<ControlFramePos>(ConfigKey(group, "beat_closest"));
 }
 
 QuantizeControl::~QuantizeControl() {
     delete m_pCOQuantizeEnabled;
-    delete m_pCONextBeat;
-    delete m_pCOPrevBeat;
-    delete m_pCOClosestBeat;
 }
 
 void QuantizeControl::trackLoaded(TrackPointer pNewTrack) {
@@ -39,9 +33,9 @@ void QuantizeControl::trackLoaded(TrackPointer pNewTrack) {
         updateClosestBeat(mixxx::audio::kStartFramePos);
     } else {
         m_pBeats.clear();
-        m_pCOPrevBeat->set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
-        m_pCONextBeat->set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
-        m_pCOClosestBeat->set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
+        m_pCOPrevBeat->set(mixxx::audio::kInvalidFramePos);
+        m_pCONextBeat->set(mixxx::audio::kInvalidFramePos);
+        m_pCOClosestBeat->set(mixxx::audio::kInvalidFramePos);
     }
 }
 
@@ -66,12 +60,8 @@ void QuantizeControl::playPosChanged(mixxx::audio::FramePos position) {
     // do so.
     // NOTE: This bypasses the epsilon calculation, but is there a way
     //       that could actually cause a problem?
-    const auto prevBeatPosition =
-            mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                    m_pCOPrevBeat->get());
-    const auto nextBeatPosition =
-            mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                    m_pCONextBeat->get());
+    const auto prevBeatPosition = m_pCOPrevBeat->toFramePos();
+    const auto nextBeatPosition = m_pCONextBeat->toFramePos();
     if (!prevBeatPosition.isValid() || position < prevBeatPosition ||
             !nextBeatPosition.isValid() || position > nextBeatPosition) {
         lookupBeatPositions(position);
@@ -86,9 +76,8 @@ void QuantizeControl::lookupBeatPositions(mixxx::audio::FramePos position) {
         mixxx::audio::FramePos prevBeatPosition;
         mixxx::audio::FramePos nextBeatPosition;
         pBeats->findPrevNextBeats(position, &prevBeatPosition, &nextBeatPosition, true);
-        // FIXME: -1.0 is a valid frame position, should we set the COs to NaN?
-        m_pCOPrevBeat->set(prevBeatPosition.toEngineSamplePosMaybeInvalid());
-        m_pCONextBeat->set(nextBeatPosition.toEngineSamplePosMaybeInvalid());
+        m_pCOPrevBeat->set(prevBeatPosition);
+        m_pCONextBeat->set(nextBeatPosition);
     }
 }
 
@@ -97,34 +86,28 @@ void QuantizeControl::updateClosestBeat(mixxx::audio::FramePos position) {
     if (!m_pBeats) {
         return;
     }
-    const auto prevBeatPosition =
-            mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                    m_pCOPrevBeat->get());
-    const auto nextBeatPosition =
-            mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                    m_pCONextBeat->get());
+    const auto prevBeatPosition = m_pCOPrevBeat->toFramePos();
+    const auto nextBeatPosition = m_pCONextBeat->toFramePos();
 
     // Calculate closest beat by hand since we want the beat locations themselves
     // and duplicating the work by calling the standard API would double
     // the number of mutex locks.
     if (!prevBeatPosition.isValid()) {
         if (nextBeatPosition.isValid()) {
-            m_pCOClosestBeat->set(nextBeatPosition.toEngineSamplePos());
+            m_pCOClosestBeat->set(nextBeatPosition);
         } else {
             // Likely no beat information -- can't set closest beat value.
         }
     } else if (!nextBeatPosition.isValid()) {
-        m_pCOClosestBeat->set(prevBeatPosition.toEngineSamplePos());
+        m_pCOClosestBeat->set(prevBeatPosition);
     } else {
         const mixxx::audio::FramePos currentClosestBeatPosition =
                 (nextBeatPosition - position > position - prevBeatPosition)
                 ? prevBeatPosition
                 : nextBeatPosition;
-        const auto closestBeatPosition =
-                mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                        m_pCOClosestBeat->get());
+        const auto closestBeatPosition = m_pCOClosestBeat->toFramePos();
         if (closestBeatPosition != currentClosestBeatPosition) {
-            m_pCOClosestBeat->set(currentClosestBeatPosition.toEngineSamplePos());
+            m_pCOClosestBeat->set(currentClosestBeatPosition);
         }
     }
 }

--- a/src/engine/controls/quantizecontrol.h
+++ b/src/engine/controls/quantizecontrol.h
@@ -8,6 +8,7 @@
 #include "track/track_decl.h"
 
 class ControlObject;
+class ControlFramePos;
 class ControlPushButton;
 
 class QuantizeControl : public EngineControl {
@@ -31,9 +32,9 @@ class QuantizeControl : public EngineControl {
     void playPosChanged(mixxx::audio::FramePos position);
 
     ControlPushButton* m_pCOQuantizeEnabled;
-    ControlObject* m_pCONextBeat;
-    ControlObject* m_pCOPrevBeat;
-    ControlObject* m_pCOClosestBeat;
+    std::unique_ptr<ControlFramePos> m_pCONextBeat;
+    std::unique_ptr<ControlFramePos> m_pCOPrevBeat;
+    std::unique_ptr<ControlFramePos> m_pCOClosestBeat;
 
     // m_pBeats is written from an engine worker thread
     mixxx::BeatsPointer m_pBeats;

--- a/src/test/cuecontrol_test.cpp
+++ b/src/test/cuecontrol_test.cpp
@@ -6,24 +6,34 @@ class CueControlTest : public BaseSignalPathTest {
     void SetUp() override {
         BaseSignalPathTest::SetUp();
 
-        m_pQuantizeEnabled = std::make_unique<ControlProxy>(m_sGroup1, "quantize");
-        m_pCuePoint = std::make_unique<ControlProxy>(m_sGroup1, "cue_point");
-        m_pIntroStartPosition = std::make_unique<ControlProxy>(m_sGroup1, "intro_start_position");
-        m_pIntroStartEnabled = std::make_unique<ControlProxy>(m_sGroup1, "intro_start_enabled");
-        m_pIntroStartSet = std::make_unique<ControlProxy>(m_sGroup1, "intro_start_set");
-        m_pIntroStartClear = std::make_unique<ControlProxy>(m_sGroup1, "intro_start_clear");
-        m_pIntroEndPosition = std::make_unique<ControlProxy>(m_sGroup1, "intro_end_position");
-        m_pIntroEndEnabled = std::make_unique<ControlProxy>(m_sGroup1, "intro_end_enabled");
-        m_pIntroEndSet = std::make_unique<ControlProxy>(m_sGroup1, "intro_end_set");
-        m_pIntroEndClear = std::make_unique<ControlProxy>(m_sGroup1, "intro_end_clear");
-        m_pOutroStartPosition = std::make_unique<ControlProxy>(m_sGroup1, "outro_start_position");
-        m_pOutroStartEnabled = std::make_unique<ControlProxy>(m_sGroup1, "outro_start_enabled");
-        m_pOutroStartSet = std::make_unique<ControlProxy>(m_sGroup1, "outro_start_set");
-        m_pOutroStartClear = std::make_unique<ControlProxy>(m_sGroup1, "outro_start_clear");
-        m_pOutroEndPosition = std::make_unique<ControlProxy>(m_sGroup1, "outro_end_position");
-        m_pOutroEndEnabled = std::make_unique<ControlProxy>(m_sGroup1, "outro_end_enabled");
-        m_pOutroEndSet = std::make_unique<ControlProxy>(m_sGroup1, "outro_end_set");
-        m_pOutroEndClear = std::make_unique<ControlProxy>(m_sGroup1, "outro_end_clear");
+        m_pQuantizeEnabled = std::make_unique<ControlProxy>(ConfigKey(m_sGroup1, "quantize"));
+        m_pCuePoint = std::make_unique<ControlFramePosProxy>(ConfigKey(m_sGroup1, "cue_point"));
+        m_pIntroStartPosition = std::make_unique<ControlFramePosProxy>(
+                ConfigKey(m_sGroup1, "intro_start_position"));
+        m_pIntroStartEnabled = std::make_unique<ControlProxy>(
+                ConfigKey(m_sGroup1, "intro_start_enabled"));
+        m_pIntroStartSet = std::make_unique<ControlProxy>(ConfigKey(m_sGroup1, "intro_start_set"));
+        m_pIntroStartClear = std::make_unique<ControlProxy>(
+                ConfigKey(m_sGroup1, "intro_start_clear"));
+        m_pIntroEndPosition = std::make_unique<ControlFramePosProxy>(
+                ConfigKey(m_sGroup1, "intro_end_position"));
+        m_pIntroEndEnabled = std::make_unique<ControlProxy>(
+                ConfigKey(m_sGroup1, "intro_end_enabled"));
+        m_pIntroEndSet = std::make_unique<ControlProxy>(ConfigKey(m_sGroup1, "intro_end_set"));
+        m_pIntroEndClear = std::make_unique<ControlProxy>(ConfigKey(m_sGroup1, "intro_end_clear"));
+        m_pOutroStartPosition = std::make_unique<ControlFramePosProxy>(
+                ConfigKey(m_sGroup1, "outro_start_position"));
+        m_pOutroStartEnabled = std::make_unique<ControlProxy>(
+                ConfigKey(m_sGroup1, "outro_start_enabled"));
+        m_pOutroStartSet = std::make_unique<ControlProxy>(ConfigKey(m_sGroup1, "outro_start_set"));
+        m_pOutroStartClear = std::make_unique<ControlProxy>(
+                ConfigKey(m_sGroup1, "outro_start_clear"));
+        m_pOutroEndPosition = std::make_unique<ControlFramePosProxy>(
+                ConfigKey(m_sGroup1, "outro_end_position"));
+        m_pOutroEndEnabled = std::make_unique<ControlProxy>(
+                ConfigKey(m_sGroup1, "outro_end_enabled"));
+        m_pOutroEndSet = std::make_unique<ControlProxy>(ConfigKey(m_sGroup1, "outro_end_set"));
+        m_pOutroEndClear = std::make_unique<ControlProxy>(ConfigKey(m_sGroup1, "outro_end_clear"));
     }
 
     TrackPointer createTestTrack() const {
@@ -61,20 +71,20 @@ class CueControlTest : public BaseSignalPathTest {
     }
 
     std::unique_ptr<ControlProxy> m_pQuantizeEnabled;
-    std::unique_ptr<ControlProxy> m_pCuePoint;
-    std::unique_ptr<ControlProxy> m_pIntroStartPosition;
+    std::unique_ptr<ControlFramePosProxy> m_pCuePoint;
+    std::unique_ptr<ControlFramePosProxy> m_pIntroStartPosition;
     std::unique_ptr<ControlProxy> m_pIntroStartEnabled;
     std::unique_ptr<ControlProxy> m_pIntroStartSet;
     std::unique_ptr<ControlProxy> m_pIntroStartClear;
-    std::unique_ptr<ControlProxy> m_pIntroEndPosition;
+    std::unique_ptr<ControlFramePosProxy> m_pIntroEndPosition;
     std::unique_ptr<ControlProxy> m_pIntroEndEnabled;
     std::unique_ptr<ControlProxy> m_pIntroEndSet;
     std::unique_ptr<ControlProxy> m_pIntroEndClear;
-    std::unique_ptr<ControlProxy> m_pOutroStartPosition;
+    std::unique_ptr<ControlFramePosProxy> m_pOutroStartPosition;
     std::unique_ptr<ControlProxy> m_pOutroStartEnabled;
     std::unique_ptr<ControlProxy> m_pOutroStartSet;
     std::unique_ptr<ControlProxy> m_pOutroStartClear;
-    std::unique_ptr<ControlProxy> m_pOutroEndPosition;
+    std::unique_ptr<ControlFramePosProxy> m_pOutroEndPosition;
     std::unique_ptr<ControlProxy> m_pOutroEndEnabled;
     std::unique_ptr<ControlProxy> m_pOutroEndSet;
     std::unique_ptr<ControlProxy> m_pOutroEndClear;
@@ -102,11 +112,11 @@ TEST_F(CueControlTest, LoadUnloadTrack) {
 
     loadTrack(pTrack);
 
-    EXPECT_FRAMEPOS_EQ_CONTROL(kCuePosition, m_pCuePoint);
-    EXPECT_FRAMEPOS_EQ_CONTROL(kIntroStartPosition, m_pIntroStartPosition);
-    EXPECT_FRAMEPOS_EQ_CONTROL(kIntroEndPosition, m_pIntroEndPosition);
-    EXPECT_FRAMEPOS_EQ_CONTROL(kOutroStartPosition, m_pOutroStartPosition);
-    EXPECT_FRAMEPOS_EQ_CONTROL(kOutroEndPosition, m_pOutroEndPosition);
+    EXPECT_FRAMEPOS_EQ(kCuePosition, m_pCuePoint->toFramePos());
+    EXPECT_FRAMEPOS_EQ(kIntroStartPosition, m_pIntroStartPosition->toFramePos());
+    EXPECT_FRAMEPOS_EQ(kIntroEndPosition, m_pIntroEndPosition->toFramePos());
+    EXPECT_FRAMEPOS_EQ(kOutroStartPosition, m_pOutroStartPosition->toFramePos());
+    EXPECT_FRAMEPOS_EQ(kOutroEndPosition, m_pOutroEndPosition->toFramePos());
     EXPECT_TRUE(m_pIntroStartEnabled->toBool());
     EXPECT_TRUE(m_pIntroEndEnabled->toBool());
     EXPECT_TRUE(m_pOutroStartEnabled->toBool());
@@ -114,11 +124,11 @@ TEST_F(CueControlTest, LoadUnloadTrack) {
 
     unloadTrack();
 
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kInvalidFramePos, m_pCuePoint);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kInvalidFramePos, m_pIntroStartPosition);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kInvalidFramePos, m_pIntroEndPosition);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kInvalidFramePos, m_pOutroStartPosition);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kInvalidFramePos, m_pOutroEndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kInvalidFramePos, m_pCuePoint->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kInvalidFramePos, m_pIntroStartPosition->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kInvalidFramePos, m_pIntroEndPosition->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kInvalidFramePos, m_pOutroStartPosition->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kInvalidFramePos, m_pOutroEndPosition->toFramePos());
     EXPECT_FALSE(m_pIntroStartEnabled->toBool());
     EXPECT_FALSE(m_pIntroEndEnabled->toBool());
     EXPECT_FALSE(m_pOutroStartEnabled->toBool());
@@ -144,11 +154,11 @@ TEST_F(CueControlTest, LoadTrackWithDetectedCues) {
 
     loadTrack(pTrack);
 
-    EXPECT_FRAMEPOS_EQ_CONTROL(kCuePosition, m_pCuePoint);
-    EXPECT_FRAMEPOS_EQ_CONTROL(kCuePosition, m_pIntroStartPosition);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kInvalidFramePos, m_pIntroEndPosition);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kInvalidFramePos, m_pOutroStartPosition);
-    EXPECT_FRAMEPOS_EQ_CONTROL(kOutroEndPosition, m_pOutroEndPosition);
+    EXPECT_FRAMEPOS_EQ(kCuePosition, m_pCuePoint->toFramePos());
+    EXPECT_FRAMEPOS_EQ(kCuePosition, m_pIntroStartPosition->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kInvalidFramePos, m_pIntroEndPosition->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kInvalidFramePos, m_pOutroStartPosition->toFramePos());
+    EXPECT_FRAMEPOS_EQ(kOutroEndPosition, m_pOutroEndPosition->toFramePos());
     EXPECT_TRUE(m_pIntroStartEnabled->toBool());
     EXPECT_FALSE(m_pIntroEndEnabled->toBool());
     EXPECT_FALSE(m_pOutroStartEnabled->toBool());
@@ -173,11 +183,11 @@ TEST_F(CueControlTest, LoadTrackWithIntroEndAndOutroStart) {
 
     loadTrack(pTrack);
 
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pCuePoint);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kInvalidFramePos, m_pIntroStartPosition);
-    EXPECT_FRAMEPOS_EQ_CONTROL(kIntroEndPosition, m_pIntroEndPosition);
-    EXPECT_FRAMEPOS_EQ_CONTROL(kOutroStartPosition, m_pOutroStartPosition);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kInvalidFramePos, m_pOutroEndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pCuePoint->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kInvalidFramePos, m_pIntroStartPosition->toFramePos());
+    EXPECT_FRAMEPOS_EQ(kIntroEndPosition, m_pIntroEndPosition->toFramePos());
+    EXPECT_FRAMEPOS_EQ(kOutroStartPosition, m_pOutroStartPosition->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kInvalidFramePos, m_pOutroEndPosition->toFramePos());
     EXPECT_FALSE(m_pIntroStartEnabled->toBool());
     EXPECT_TRUE(m_pIntroEndEnabled->toBool());
     EXPECT_TRUE(m_pOutroStartEnabled->toBool());
@@ -219,11 +229,11 @@ TEST_F(CueControlTest, LoadAutodetectedCues_QuantizeEnabled) {
 
     loadTrack(pTrack);
 
-    EXPECT_FRAMEPOS_EQ_CONTROL(kQuantizedIntroStartPosition, m_pCuePoint);
-    EXPECT_FRAMEPOS_EQ_CONTROL(kQuantizedIntroStartPosition, m_pIntroStartPosition);
-    EXPECT_FRAMEPOS_EQ_CONTROL(kQuantizedIntroEndPosition, m_pIntroEndPosition);
-    EXPECT_FRAMEPOS_EQ_CONTROL(kQuantizedOutroStartPosition, m_pOutroStartPosition);
-    EXPECT_FRAMEPOS_EQ_CONTROL(kQuantizedOutroEndPosition, m_pOutroEndPosition);
+    EXPECT_FRAMEPOS_EQ(kQuantizedIntroStartPosition, m_pCuePoint->toFramePos());
+    EXPECT_FRAMEPOS_EQ(kQuantizedIntroStartPosition, m_pIntroStartPosition->toFramePos());
+    EXPECT_FRAMEPOS_EQ(kQuantizedIntroEndPosition, m_pIntroEndPosition->toFramePos());
+    EXPECT_FRAMEPOS_EQ(kQuantizedOutroStartPosition, m_pOutroStartPosition->toFramePos());
+    EXPECT_FRAMEPOS_EQ(kQuantizedOutroEndPosition, m_pOutroEndPosition->toFramePos());
 }
 
 TEST_F(CueControlTest, LoadAutodetectedCues_QuantizeEnabledNoBeats) {
@@ -249,11 +259,11 @@ TEST_F(CueControlTest, LoadAutodetectedCues_QuantizeEnabledNoBeats) {
 
     loadTrack(pTrack);
 
-    EXPECT_FRAMEPOS_EQ_CONTROL(kCuePosition, m_pCuePoint);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(250.0), m_pIntroStartPosition);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(400.0), m_pIntroEndPosition);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(550.0), m_pOutroStartPosition);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(800.0), m_pOutroEndPosition);
+    EXPECT_FRAMEPOS_EQ(kCuePosition, m_pCuePoint->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(250.0), m_pIntroStartPosition->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(400.0), m_pIntroEndPosition->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(550.0), m_pOutroStartPosition->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(800.0), m_pOutroEndPosition->toFramePos());
 }
 
 TEST_F(CueControlTest, LoadAutodetectedCues_QuantizeDisabled) {
@@ -278,11 +288,11 @@ TEST_F(CueControlTest, LoadAutodetectedCues_QuantizeDisabled) {
 
     loadTrack(pTrack);
 
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(240.0), m_pCuePoint);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(210.0), m_pIntroStartPosition);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(330.0), m_pIntroEndPosition);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(770.0), m_pOutroStartPosition);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(990.0), m_pOutroEndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(240.0), m_pCuePoint->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(210.0), m_pIntroStartPosition->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(330.0), m_pIntroEndPosition->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(770.0), m_pOutroStartPosition->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(990.0), m_pOutroEndPosition->toFramePos());
 }
 
 TEST_F(CueControlTest, SeekOnLoadDefault) {
@@ -296,7 +306,7 @@ TEST_F(CueControlTest, SeekOnLoadDefault) {
 
     loadTrack(pTrack);
 
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(250.0), m_pIntroStartPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(250.0), m_pIntroStartPosition->toFramePos());
     EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(250.0), getCurrentFramePos());
 }
 
@@ -307,7 +317,7 @@ TEST_F(CueControlTest, SeekOnLoadMainCue) {
     loadTrack(pTrack);
 
     // We expect a cue point at the very beginning
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pCuePoint);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pCuePoint->toFramePos());
     EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, getCurrentFramePos());
 
     // Move cue like silence analysis does and check if track is following it
@@ -315,7 +325,7 @@ TEST_F(CueControlTest, SeekOnLoadMainCue) {
     pTrack->analysisFinished();
     ProcessBuffer();
 
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(200.0), m_pCuePoint);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(200.0), m_pCuePoint->toFramePos());
     EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(200.0), getCurrentFramePos());
 }
 
@@ -329,7 +339,7 @@ TEST_F(CueControlTest, DontSeekOnLoadMainCue) {
     // track has been manual seeked before.
     loadTrack(pTrack);
 
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(100.0), m_pCuePoint);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(100.0), m_pCuePoint->toFramePos());
     EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(100.0), getCurrentFramePos());
 
     // Manually seek  the track
@@ -340,7 +350,7 @@ TEST_F(CueControlTest, DontSeekOnLoadMainCue) {
     pTrack->analysisFinished();
     ProcessBuffer();
 
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(400.0), m_pCuePoint);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(400.0), m_pCuePoint->toFramePos());
     EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(200.0), getCurrentFramePos());
 }
 
@@ -352,7 +362,7 @@ TEST_F(CueControlTest, SeekOnLoadDefault_CueInPreroll) {
 
     loadTrack(pTrack);
 
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(-100.0), m_pCuePoint);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(-100.0), m_pCuePoint->toFramePos());
     EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(-100.0), getCurrentFramePos());
 
     // Move cue like silence analysis does and check if track is following it
@@ -360,7 +370,7 @@ TEST_F(CueControlTest, SeekOnLoadDefault_CueInPreroll) {
     pTrack->analysisFinished();
     ProcessBuffer();
 
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(-200.0), m_pCuePoint);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(-200.0), m_pCuePoint->toFramePos());
     EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(-200.0), getCurrentFramePos());
 }
 
@@ -379,13 +389,13 @@ TEST_F(CueControlTest, FollowCueOnQuantize) {
 
     loadTrack(pTrack);
 
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePos, m_pCuePoint);
+    EXPECT_FRAMEPOS_EQ(cuePos, m_pCuePoint->toFramePos());
     EXPECT_FRAMEPOS_EQ(cuePos, getCurrentFramePos());
 
     // enable quantization and expect current position to follow
     m_pQuantizeEnabled->set(1);
     ProcessBuffer();
-    EXPECT_FRAMEPOS_EQ_CONTROL(quantizedCuePos, m_pCuePoint);
+    EXPECT_FRAMEPOS_EQ(quantizedCuePos, m_pCuePoint->toFramePos());
     EXPECT_FRAMEPOS_EQ(quantizedCuePos, getCurrentFramePos());
 
     // move current position to track start
@@ -398,7 +408,7 @@ TEST_F(CueControlTest, FollowCueOnQuantize) {
     // enable quantization again and expect play position to stay at track start
     m_pQuantizeEnabled->set(1);
     ProcessBuffer();
-    EXPECT_FRAMEPOS_EQ_CONTROL(quantizedCuePos, m_pCuePoint);
+    EXPECT_FRAMEPOS_EQ(quantizedCuePos, m_pCuePoint->toFramePos());
     EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, getCurrentFramePos());
 }
 
@@ -409,9 +419,9 @@ TEST_F(CueControlTest, IntroCue_SetStartEnd_ClearStartEnd) {
     setCurrentFramePos(mixxx::audio::FramePos(100.0));
     m_pIntroStartSet->set(1);
     m_pIntroStartSet->set(0);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(100.0), m_pIntroStartPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(100.0), m_pIntroStartPosition->toFramePos());
     EXPECT_TRUE(m_pIntroStartEnabled->toBool());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kInvalidFramePos, m_pIntroEndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kInvalidFramePos, m_pIntroEndPosition->toFramePos());
     EXPECT_FALSE(m_pIntroEndEnabled->toBool());
 
     CuePointer pCue = pTrack->findCueByType(mixxx::CueType::Intro);
@@ -425,9 +435,9 @@ TEST_F(CueControlTest, IntroCue_SetStartEnd_ClearStartEnd) {
     setCurrentFramePos(mixxx::audio::FramePos(500.0));
     m_pIntroEndSet->set(1);
     m_pIntroEndSet->set(0);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(100.0), m_pIntroStartPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(100.0), m_pIntroStartPosition->toFramePos());
     EXPECT_TRUE(m_pIntroStartEnabled->toBool());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(500.0), m_pIntroEndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(500.0), m_pIntroEndPosition->toFramePos());
     EXPECT_TRUE(m_pIntroEndEnabled->toBool());
 
     pCue = pTrack->findCueByType(mixxx::CueType::Intro);
@@ -440,9 +450,9 @@ TEST_F(CueControlTest, IntroCue_SetStartEnd_ClearStartEnd) {
     // Clear intro start cue
     m_pIntroStartClear->set(1);
     m_pIntroStartClear->set(0);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kInvalidFramePos, m_pIntroStartPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kInvalidFramePos, m_pIntroStartPosition->toFramePos());
     EXPECT_FALSE(m_pIntroStartEnabled->toBool());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(500.0), m_pIntroEndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(500.0), m_pIntroEndPosition->toFramePos());
     EXPECT_TRUE(m_pIntroEndEnabled->toBool());
 
     pCue = pTrack->findCueByType(mixxx::CueType::Intro);
@@ -455,9 +465,9 @@ TEST_F(CueControlTest, IntroCue_SetStartEnd_ClearStartEnd) {
     // Clear intro end cue
     m_pIntroEndClear->set(1);
     m_pIntroEndClear->set(0);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kInvalidFramePos, m_pIntroStartPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kInvalidFramePos, m_pIntroStartPosition->toFramePos());
     EXPECT_FALSE(m_pIntroStartEnabled->toBool());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kInvalidFramePos, m_pIntroEndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kInvalidFramePos, m_pIntroEndPosition->toFramePos());
     EXPECT_FALSE(m_pIntroEndEnabled->toBool());
 
     EXPECT_EQ(nullptr, pTrack->findCueByType(mixxx::CueType::Intro));
@@ -470,9 +480,9 @@ TEST_F(CueControlTest, OutroCue_SetStartEnd_ClearStartEnd) {
     setCurrentFramePos(mixxx::audio::FramePos(750.0));
     m_pOutroStartSet->set(1);
     m_pOutroStartSet->set(0);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(750.0), m_pOutroStartPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(750.0), m_pOutroStartPosition->toFramePos());
     EXPECT_TRUE(m_pOutroStartEnabled->toBool());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kInvalidFramePos, m_pOutroEndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kInvalidFramePos, m_pOutroEndPosition->toFramePos());
     EXPECT_FALSE(m_pOutroEndEnabled->toBool());
 
     CuePointer pCue = pTrack->findCueByType(mixxx::CueType::Outro);
@@ -486,9 +496,9 @@ TEST_F(CueControlTest, OutroCue_SetStartEnd_ClearStartEnd) {
     setCurrentFramePos(mixxx::audio::FramePos(1000.0));
     m_pOutroEndSet->set(1);
     m_pOutroEndSet->set(0);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(750.0), m_pOutroStartPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(750.0), m_pOutroStartPosition->toFramePos());
     EXPECT_TRUE(m_pOutroStartEnabled->toBool());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(1000.0), m_pOutroEndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(1000.0), m_pOutroEndPosition->toFramePos());
     EXPECT_TRUE(m_pOutroEndEnabled->toBool());
 
     pCue = pTrack->findCueByType(mixxx::CueType::Outro);
@@ -501,9 +511,9 @@ TEST_F(CueControlTest, OutroCue_SetStartEnd_ClearStartEnd) {
     // Clear outro start cue
     m_pOutroStartClear->set(1);
     m_pOutroStartClear->set(0);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kInvalidFramePos, m_pOutroStartPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kInvalidFramePos, m_pOutroStartPosition->toFramePos());
     EXPECT_FALSE(m_pOutroStartEnabled->toBool());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(1000.0), m_pOutroEndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos(1000.0), m_pOutroEndPosition->toFramePos());
     EXPECT_TRUE(m_pOutroEndEnabled->toBool());
 
     pCue = pTrack->findCueByType(mixxx::CueType::Outro);
@@ -516,9 +526,9 @@ TEST_F(CueControlTest, OutroCue_SetStartEnd_ClearStartEnd) {
     // Clear outro end cue
     m_pOutroEndClear->set(1);
     m_pOutroEndClear->set(0);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kInvalidFramePos, m_pOutroStartPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kInvalidFramePos, m_pOutroStartPosition->toFramePos());
     EXPECT_FALSE(m_pOutroStartEnabled->toBool());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kInvalidFramePos, m_pOutroEndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kInvalidFramePos, m_pOutroEndPosition->toFramePos());
     EXPECT_FALSE(m_pOutroEndEnabled->toBool());
 
     EXPECT_EQ(nullptr, pTrack->findCueByType(mixxx::CueType::Outro));

--- a/src/test/hotcuecontrol_test.cpp
+++ b/src/test/hotcuecontrol_test.cpp
@@ -13,30 +13,43 @@ class HotcueControlTest : public BaseSignalPathTest {
     void SetUp() override {
         BaseSignalPathTest::SetUp();
 
-        m_pPlay = std::make_unique<ControlProxy>(m_sGroup1, "play");
-        m_pBeatloopActivate = std::make_unique<ControlProxy>(m_sGroup1, "beatloop_activate");
-        m_pBeatloopSize = std::make_unique<ControlProxy>(m_sGroup1, "beatloop_size");
-        m_pLoopStartPosition = std::make_unique<ControlProxy>(m_sGroup1, "loop_start_position");
-        m_pLoopEndPosition = std::make_unique<ControlProxy>(m_sGroup1, "loop_end_position");
-        m_pLoopEnabled = std::make_unique<ControlProxy>(m_sGroup1, "loop_enabled");
-        m_pLoopDouble = std::make_unique<ControlProxy>(m_sGroup1, "loop_double");
-        m_pLoopHalve = std::make_unique<ControlProxy>(m_sGroup1, "loop_halve");
-        m_pLoopMove = std::make_unique<ControlProxy>(m_sGroup1, "loop_move");
-        m_pHotcue1Activate = std::make_unique<ControlProxy>(m_sGroup1, "hotcue_1_activate");
-        m_pHotcue1ActivateCue = std::make_unique<ControlProxy>(m_sGroup1, "hotcue_1_activatecue");
-        m_pHotcue1ActivateLoop = std::make_unique<ControlProxy>(m_sGroup1, "hotcue_1_activateloop");
-        m_pHotcue1Set = std::make_unique<ControlProxy>(m_sGroup1, "hotcue_1_set");
-        m_pHotcue1SetCue = std::make_unique<ControlProxy>(m_sGroup1, "hotcue_1_setcue");
-        m_pHotcue1SetLoop = std::make_unique<ControlProxy>(m_sGroup1, "hotcue_1_setloop");
-        m_pHotcue1Goto = std::make_unique<ControlProxy>(m_sGroup1, "hotcue_1_goto");
-        m_pHotcue1GotoAndPlay = std::make_unique<ControlProxy>(m_sGroup1, "hotcue_1_gotoandplay");
-        m_pHotcue1GotoAndLoop = std::make_unique<ControlProxy>(m_sGroup1, "hotcue_1_gotoandloop");
-        m_pHotcue1CueLoop = std::make_unique<ControlProxy>(m_sGroup1, "hotcue_1_cueloop");
-        m_pHotcue1Position = std::make_unique<ControlProxy>(m_sGroup1, "hotcue_1_position");
-        m_pHotcue1EndPosition = std::make_unique<ControlProxy>(m_sGroup1, "hotcue_1_endposition");
-        m_pHotcue1Enabled = std::make_unique<ControlProxy>(m_sGroup1, "hotcue_1_enabled");
-        m_pHotcue1Clear = std::make_unique<ControlProxy>(m_sGroup1, "hotcue_1_clear");
-        m_pQuantizeEnabled = std::make_unique<ControlProxy>(m_sGroup1, "quantize");
+        m_pPlay = std::make_unique<ControlProxy>(ConfigKey(m_sGroup1, "play"));
+        m_pBeatloopActivate = std::make_unique<ControlFramePosProxy>(
+                ConfigKey(m_sGroup1, "beatloop_activate"));
+        m_pBeatloopSize = std::make_unique<ControlProxy>(ConfigKey(m_sGroup1, "beatloop_size"));
+        m_pLoopStartPosition = std::make_unique<ControlFramePosProxy>(
+                ConfigKey(m_sGroup1, "loop_start_position"));
+        m_pLoopEndPosition = std::make_unique<ControlFramePosProxy>(
+                ConfigKey(m_sGroup1, "loop_end_position"));
+        m_pLoopEnabled = std::make_unique<ControlProxy>(ConfigKey(m_sGroup1, "loop_enabled"));
+        m_pLoopDouble = std::make_unique<ControlProxy>(ConfigKey(m_sGroup1, "loop_double"));
+        m_pLoopHalve = std::make_unique<ControlProxy>(ConfigKey(m_sGroup1, "loop_halve"));
+        m_pLoopMove = std::make_unique<ControlProxy>(ConfigKey(m_sGroup1, "loop_move"));
+        m_pHotcue1Activate = std::make_unique<ControlProxy>(
+                ConfigKey(m_sGroup1, "hotcue_1_activate"));
+        m_pHotcue1ActivateCue = std::make_unique<ControlProxy>(
+                ConfigKey(m_sGroup1, "hotcue_1_activatecue"));
+        m_pHotcue1ActivateLoop = std::make_unique<ControlProxy>(
+                ConfigKey(m_sGroup1, "hotcue_1_activateloop"));
+        m_pHotcue1Set = std::make_unique<ControlProxy>(ConfigKey(m_sGroup1, "hotcue_1_set"));
+        m_pHotcue1SetCue = std::make_unique<ControlProxy>(ConfigKey(m_sGroup1, "hotcue_1_setcue"));
+        m_pHotcue1SetLoop = std::make_unique<ControlProxy>(
+                ConfigKey(m_sGroup1, "hotcue_1_setloop"));
+        m_pHotcue1Goto = std::make_unique<ControlProxy>(ConfigKey(m_sGroup1, "hotcue_1_goto"));
+        m_pHotcue1GotoAndPlay = std::make_unique<ControlProxy>(
+                ConfigKey(m_sGroup1, "hotcue_1_gotoandplay"));
+        m_pHotcue1GotoAndLoop = std::make_unique<ControlProxy>(
+                ConfigKey(m_sGroup1, "hotcue_1_gotoandloop"));
+        m_pHotcue1CueLoop = std::make_unique<ControlProxy>(
+                ConfigKey(m_sGroup1, "hotcue_1_cueloop"));
+        m_pHotcue1Position = std::make_unique<ControlFramePosProxy>(
+                ConfigKey(m_sGroup1, "hotcue_1_position"));
+        m_pHotcue1EndPosition = std::make_unique<ControlFramePosProxy>(
+                ConfigKey(m_sGroup1, "hotcue_1_endposition"));
+        m_pHotcue1Enabled = std::make_unique<ControlProxy>(
+                ConfigKey(m_sGroup1, "hotcue_1_enabled"));
+        m_pHotcue1Clear = std::make_unique<ControlProxy>(ConfigKey(m_sGroup1, "hotcue_1_clear"));
+        m_pQuantizeEnabled = std::make_unique<ControlProxy>(ConfigKey(m_sGroup1, "quantize"));
     }
 
     TrackPointer createTestTrack() const {
@@ -90,8 +103,8 @@ class HotcueControlTest : public BaseSignalPathTest {
     std::unique_ptr<ControlProxy> m_pPlay;
     std::unique_ptr<ControlProxy> m_pBeatloopActivate;
     std::unique_ptr<ControlProxy> m_pBeatloopSize;
-    std::unique_ptr<ControlProxy> m_pLoopStartPosition;
-    std::unique_ptr<ControlProxy> m_pLoopEndPosition;
+    std::unique_ptr<ControlFramePosProxy> m_pLoopStartPosition;
+    std::unique_ptr<ControlFramePosProxy> m_pLoopEndPosition;
     std::unique_ptr<ControlProxy> m_pLoopEnabled;
     std::unique_ptr<ControlProxy> m_pLoopDouble;
     std::unique_ptr<ControlProxy> m_pLoopHalve;
@@ -106,8 +119,8 @@ class HotcueControlTest : public BaseSignalPathTest {
     std::unique_ptr<ControlProxy> m_pHotcue1GotoAndPlay;
     std::unique_ptr<ControlProxy> m_pHotcue1GotoAndLoop;
     std::unique_ptr<ControlProxy> m_pHotcue1CueLoop;
-    std::unique_ptr<ControlProxy> m_pHotcue1Position;
-    std::unique_ptr<ControlProxy> m_pHotcue1EndPosition;
+    std::unique_ptr<ControlFramePosProxy> m_pHotcue1Position;
+    std::unique_ptr<ControlFramePosProxy> m_pHotcue1EndPosition;
     std::unique_ptr<ControlProxy> m_pHotcue1Enabled;
     std::unique_ptr<ControlProxy> m_pHotcue1Clear;
     std::unique_ptr<ControlProxy> m_pQuantizeEnabled;
@@ -117,22 +130,14 @@ TEST_F(HotcueControlTest, DefautltControlValues) {
     TrackPointer pTrack = createTestTrack();
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     loadTrack(pTrack);
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 }
 
 TEST_F(HotcueControlTest, NoTrackLoaded) {
@@ -141,62 +146,38 @@ TEST_F(HotcueControlTest, NoTrackLoaded) {
     m_pHotcue1Set->set(1);
     m_pHotcue1Set->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     m_pHotcue1SetCue->set(1);
     m_pHotcue1SetCue->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     m_pHotcue1SetLoop->set(1);
     m_pHotcue1SetLoop->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     m_pHotcue1Activate->set(1);
     m_pHotcue1Activate->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     m_pHotcue1ActivateCue->set(1);
     m_pHotcue1ActivateCue->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     m_pHotcue1ActivateLoop->set(1);
     m_pHotcue1ActivateLoop->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 }
 
 TEST_F(HotcueControlTest, SetCueAuto) {
@@ -205,12 +186,8 @@ TEST_F(HotcueControlTest, SetCueAuto) {
     constexpr mixxx::audio::FramePos cuePosition(100);
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     m_pQuantizeEnabled->set(0);
     setCurrentFramePosition(cuePosition);
@@ -219,22 +196,16 @@ TEST_F(HotcueControlTest, SetCueAuto) {
     m_pHotcue1Set->set(1);
     m_pHotcue1Set->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition, m_pHotcue1Position);
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FRAMEPOS_EQ(cuePosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 }
 
 TEST_F(HotcueControlTest, SetCueManual) {
     createAndLoadFakeTrack();
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     constexpr mixxx::audio::FramePos hotcuePosition(100);
 
@@ -244,22 +215,16 @@ TEST_F(HotcueControlTest, SetCueManual) {
     m_pHotcue1SetCue->set(1);
     m_pHotcue1SetCue->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(hotcuePosition, m_pHotcue1Position);
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FRAMEPOS_EQ(hotcuePosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 }
 
 TEST_F(HotcueControlTest, SetLoopAuto) {
     createAndLoadFakeTrack();
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     constexpr mixxx::audio::FramePos loopStartPosition(100);
     constexpr mixxx::audio::FramePos loopEndPosition(200);
@@ -268,20 +233,16 @@ TEST_F(HotcueControlTest, SetLoopAuto) {
     m_pHotcue1Set->set(1);
     m_pHotcue1Set->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopEndPosition, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(loopStartPosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(loopEndPosition, m_pHotcue1EndPosition->toFramePos());
 }
 
 TEST_F(HotcueControlTest, SetLoopManualWithLoop) {
     createAndLoadFakeTrack();
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     constexpr mixxx::audio::FramePos loopStartPosition(100);
     constexpr mixxx::audio::FramePos loopEndPosition(200);
@@ -290,8 +251,8 @@ TEST_F(HotcueControlTest, SetLoopManualWithLoop) {
     m_pHotcue1SetLoop->set(1);
     m_pHotcue1SetLoop->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopEndPosition, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(loopStartPosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(loopEndPosition, m_pHotcue1EndPosition->toFramePos());
 }
 
 TEST_F(HotcueControlTest, SetLoopManualWithoutLoop) {
@@ -308,42 +269,30 @@ TEST_F(HotcueControlTest, SetLoopManualWithoutLoop) {
     ProcessBuffer();
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     m_pHotcue1SetLoop->set(1);
     m_pHotcue1SetLoop->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
     EXPECT_FRAMEPOS_EQ(loopStartPosition, currentFramePosition());
-    EXPECT_FRAMEPOS_EQ_CONTROL(currentFramePosition(), m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(currentFramePosition() + beatloopLengthFrames,
-            m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(currentFramePosition(), m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(currentFramePosition() + beatloopLengthFrames,
+            m_pHotcue1EndPosition->toFramePos());
 }
 
 TEST_F(HotcueControlTest, SetLoopManualWithoutLoopOrBeats) {
     createAndLoadFakeTrack();
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     m_pHotcue1SetLoop->set(1);
     m_pHotcue1SetLoop->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 }
 
 TEST_F(HotcueControlTest, CueGoto) {
@@ -351,12 +300,8 @@ TEST_F(HotcueControlTest, CueGoto) {
     TrackPointer pTrack = loadTestTrackWithBpm(120.0);
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     const auto cuePosition = mixxx::audio::FramePos(8 * getBeatLengthFrames(pTrack));
 
@@ -368,10 +313,8 @@ TEST_F(HotcueControlTest, CueGoto) {
     m_pHotcue1SetCue->set(1);
     m_pHotcue1SetCue->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition, m_pHotcue1Position);
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FRAMEPOS_EQ(cuePosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     // Seek to start of track
     setCurrentFramePosition(mixxx::audio::kStartFramePos);
@@ -384,10 +327,8 @@ TEST_F(HotcueControlTest, CueGoto) {
     EXPECT_FRAMEPOS_EQ(cuePosition, currentFramePosition());
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition, m_pHotcue1Position);
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FRAMEPOS_EQ(cuePosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
     EXPECT_DOUBLE_EQ(0.0, m_pLoopEnabled->get());
 }
 
@@ -396,12 +337,8 @@ TEST_F(HotcueControlTest, CueGotoAndPlay) {
     TrackPointer pTrack = loadTestTrackWithBpm(120.0);
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     const auto cuePosition = mixxx::audio::FramePos(8 * getBeatLengthFrames(pTrack));
 
@@ -413,10 +350,8 @@ TEST_F(HotcueControlTest, CueGotoAndPlay) {
     m_pHotcue1SetCue->set(1);
     m_pHotcue1SetCue->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition, m_pHotcue1Position);
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FRAMEPOS_EQ(cuePosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     // Seek to start of track
     setCurrentFramePosition(mixxx::audio::kStartFramePos);
@@ -429,10 +364,8 @@ TEST_F(HotcueControlTest, CueGotoAndPlay) {
     EXPECT_LE(cuePosition, currentFramePosition());
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition, m_pHotcue1Position);
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FRAMEPOS_EQ(cuePosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
     EXPECT_DOUBLE_EQ(0.0, m_pLoopEnabled->get());
 }
 
@@ -441,12 +374,8 @@ TEST_F(HotcueControlTest, CueGotoAndLoop) {
     TrackPointer pTrack = loadTestTrackWithBpm(120.0);
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     const mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(pTrack);
     const auto cuePosition = mixxx::audio::FramePos(8 * beatLengthFrames);
@@ -461,10 +390,8 @@ TEST_F(HotcueControlTest, CueGotoAndLoop) {
     m_pHotcue1SetCue->set(1);
     m_pHotcue1SetCue->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition, m_pHotcue1Position);
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FRAMEPOS_EQ(cuePosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     // Seek to start of track
     setCurrentFramePosition(mixxx::audio::kStartFramePos);
@@ -477,14 +404,12 @@ TEST_F(HotcueControlTest, CueGotoAndLoop) {
     EXPECT_LE(cuePosition, currentFramePosition());
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition, m_pHotcue1Position);
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FRAMEPOS_EQ(cuePosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     EXPECT_DOUBLE_EQ(1.0, m_pLoopEnabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition, m_pLoopStartPosition);
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition + beatloopLengthFrames, m_pLoopEndPosition);
+    EXPECT_FRAMEPOS_EQ(cuePosition, m_pLoopStartPosition->toFramePos());
+    EXPECT_FRAMEPOS_EQ(cuePosition + beatloopLengthFrames, m_pLoopEndPosition->toFramePos());
 }
 
 TEST_F(HotcueControlTest, SavedLoopGoto) {
@@ -497,12 +422,8 @@ TEST_F(HotcueControlTest, SavedLoopGoto) {
     const auto cuePosition = mixxx::audio::FramePos(8 * beatLengthFrames);
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     // Seek to cue Position (8th beat)
     setCurrentFramePosition(cuePosition);
@@ -518,8 +439,8 @@ TEST_F(HotcueControlTest, SavedLoopGoto) {
 
     // Save loop to hotcue slot 1
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition + loopLengthFrames, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(cuePosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(cuePosition + loopLengthFrames, m_pHotcue1EndPosition->toFramePos());
 
     // Disable loop
     m_pLoopEnabled->set(0);
@@ -537,8 +458,8 @@ TEST_F(HotcueControlTest, SavedLoopGoto) {
     EXPECT_FRAMEPOS_EQ(cuePosition, currentFramePosition());
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition + loopLengthFrames, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(cuePosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(cuePosition + loopLengthFrames, m_pHotcue1EndPosition->toFramePos());
     EXPECT_DOUBLE_EQ(0.0, m_pLoopEnabled->get());
 }
 
@@ -552,12 +473,8 @@ TEST_F(HotcueControlTest, SavedLoopGotoAndPlay) {
     const auto cuePosition = mixxx::audio::FramePos(8 * beatLengthFrames);
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     // Seek to cue Position (8th beat)
     setCurrentFramePosition(cuePosition);
@@ -573,8 +490,8 @@ TEST_F(HotcueControlTest, SavedLoopGotoAndPlay) {
 
     // Save loop to hotcue slot 1
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition + loopLengthFrames, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(cuePosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(cuePosition + loopLengthFrames, m_pHotcue1EndPosition->toFramePos());
 
     // Disable loop
     m_pLoopEnabled->set(0);
@@ -592,8 +509,8 @@ TEST_F(HotcueControlTest, SavedLoopGotoAndPlay) {
     EXPECT_LE(cuePosition, currentFramePosition());
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition + loopLengthFrames, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(cuePosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(cuePosition + loopLengthFrames, m_pHotcue1EndPosition->toFramePos());
     EXPECT_DOUBLE_EQ(0.0, m_pLoopEnabled->get());
 }
 
@@ -607,12 +524,8 @@ TEST_F(HotcueControlTest, SavedLoopGotoAndLoop) {
     const auto cuePosition = mixxx::audio::FramePos(8 * beatLengthFrames);
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     // Seek to cue Position (8th beat)
     setCurrentFramePosition(cuePosition);
@@ -628,8 +541,8 @@ TEST_F(HotcueControlTest, SavedLoopGotoAndLoop) {
 
     // Save loop to hotcue slot 1
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition + loopLengthFrames, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(cuePosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(cuePosition + loopLengthFrames, m_pHotcue1EndPosition->toFramePos());
 
     // Disable loop
     m_pLoopEnabled->set(0);
@@ -647,23 +560,19 @@ TEST_F(HotcueControlTest, SavedLoopGotoAndLoop) {
     EXPECT_LE(cuePosition, currentFramePosition());
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition + loopLengthFrames, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(cuePosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(cuePosition + loopLengthFrames, m_pHotcue1EndPosition->toFramePos());
     EXPECT_DOUBLE_EQ(1.0, m_pLoopEnabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition, m_pLoopStartPosition);
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition + loopLengthFrames, m_pLoopEndPosition);
+    EXPECT_FRAMEPOS_EQ(cuePosition, m_pLoopStartPosition->toFramePos());
+    EXPECT_FRAMEPOS_EQ(cuePosition + loopLengthFrames, m_pLoopEndPosition->toFramePos());
 }
 
 TEST_F(HotcueControlTest, SavedLoopStatus) {
     createAndLoadFakeTrack();
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     constexpr auto loopStartPositon = mixxx::audio::FramePos(100);
     constexpr auto loopEndPosition = mixxx::audio::FramePos(200);
@@ -674,36 +583,32 @@ TEST_F(HotcueControlTest, SavedLoopStatus) {
     m_pHotcue1SetLoop->set(0);
     EXPECT_DOUBLE_EQ(1.0, m_pLoopEnabled->get());
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPositon, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopEndPosition, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(loopStartPositon, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(loopEndPosition, m_pHotcue1EndPosition->toFramePos());
 
     // Disable Loop
     m_pLoopEnabled->set(0);
 
     EXPECT_DOUBLE_EQ(0.0, m_pLoopEnabled->get());
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPositon, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopEndPosition, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(loopStartPositon, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(loopEndPosition, m_pHotcue1EndPosition->toFramePos());
 
     // Re-Enable Loop
     m_pLoopEnabled->set(1);
 
     EXPECT_DOUBLE_EQ(1.0, m_pLoopEnabled->get());
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPositon, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopEndPosition, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(loopStartPositon, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(loopEndPosition, m_pHotcue1EndPosition->toFramePos());
 
     m_pHotcue1Clear->set(1);
     m_pHotcue1Clear->set(0);
 
     EXPECT_DOUBLE_EQ(1.0, m_pLoopEnabled->get());
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 }
 
 TEST_F(HotcueControlTest, SavedLoopScale) {
@@ -715,12 +620,8 @@ TEST_F(HotcueControlTest, SavedLoopScale) {
     const mixxx::audio::FrameDiff_t loopLengthFrames = m_pBeatloopSize->get() * beatLengthFrames;
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     // Set a beatloop (4 beats)
     m_pBeatloopActivate->set(1);
@@ -732,32 +633,30 @@ TEST_F(HotcueControlTest, SavedLoopScale) {
     m_pHotcue1SetLoop->set(1);
     m_pHotcue1SetLoop->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos + loopLengthFrames,
-            m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos + loopLengthFrames,
+            m_pHotcue1EndPosition->toFramePos());
 
     // Double loop size (4 => 8 beats)
     m_pLoopDouble->set(1);
     m_pLoopDouble->set(0);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(
-            mixxx::audio::kStartFramePos + 2 * loopLengthFrames,
-            m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos + 2 * loopLengthFrames,
+            m_pHotcue1EndPosition->toFramePos());
 
     // Halve loop size (8 => 4 beats)
     m_pLoopHalve->set(1);
     m_pLoopHalve->set(0);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos + loopLengthFrames,
-            m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos + loopLengthFrames,
+            m_pHotcue1EndPosition->toFramePos());
 
     // Halve loop size (4 => 2 beats)
     m_pLoopHalve->set(1);
     m_pLoopHalve->set(0);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(
-            mixxx::audio::kStartFramePos + loopLengthFrames / 2,
-            m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos + loopLengthFrames / 2,
+            m_pHotcue1EndPosition->toFramePos());
 
     m_pPlay->set(0);
 }
@@ -772,12 +671,8 @@ TEST_F(HotcueControlTest, SavedLoopMove) {
     const mixxx::audio::FrameDiff_t loopLengthFrames = loopSize * beatLengthFrames;
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     // Set a beatloop at position 0
     m_pBeatloopActivate->set(1);
@@ -789,33 +684,34 @@ TEST_F(HotcueControlTest, SavedLoopMove) {
     m_pHotcue1SetLoop->set(0);
     ProcessBuffer();
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos + loopLengthFrames,
-            m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos + loopLengthFrames,
+            m_pHotcue1EndPosition->toFramePos());
 
     // Move loop right (0 => 4 beats)
     m_pLoopMove->set(loopSize);
     ProcessBuffer();
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos + loopLengthFrames, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(
-            mixxx::audio::kStartFramePos + 2 * loopLengthFrames,
-            m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos + loopLengthFrames,
+            m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos + 2 * loopLengthFrames,
+            m_pHotcue1EndPosition->toFramePos());
 
     // Move loop left (4 => 0 beats)
     m_pLoopMove->set(-loopSize);
     ProcessBuffer();
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos + loopLengthFrames,
-            m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos + loopLengthFrames,
+            m_pHotcue1EndPosition->toFramePos());
 
     // Move loop left (0 => -4 beats)
     m_pLoopMove->set(-loopSize);
     ProcessBuffer();
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos - loopLengthFrames, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos - loopLengthFrames,
+            m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1EndPosition->toFramePos());
 
     m_pPlay->set(0);
 }
@@ -829,12 +725,8 @@ TEST_F(HotcueControlTest, SavedLoopNoScaleIfDisabled) {
     const mixxx::audio::FrameDiff_t loopLengthFrames = m_pBeatloopSize->get() * beatLengthFrames;
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     // Set a beatloop (4 beats)
     m_pBeatloopActivate->set(1);
@@ -846,9 +738,9 @@ TEST_F(HotcueControlTest, SavedLoopNoScaleIfDisabled) {
     m_pHotcue1SetLoop->set(1);
     m_pHotcue1SetLoop->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos + loopLengthFrames,
-            m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos + loopLengthFrames,
+            m_pHotcue1EndPosition->toFramePos());
 
     // Disable loop
     m_pLoopEnabled->set(0);
@@ -857,23 +749,23 @@ TEST_F(HotcueControlTest, SavedLoopNoScaleIfDisabled) {
     // Double loop size (4 => 8 beats) while saved loop is disabled
     m_pLoopDouble->set(1);
     m_pLoopDouble->set(0);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos + loopLengthFrames,
-            m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos + loopLengthFrames,
+            m_pHotcue1EndPosition->toFramePos());
 
     // Halve loop size (8 => 4 beats) while saved loop is disabled
     m_pLoopHalve->set(1);
     m_pLoopHalve->set(0);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos + loopLengthFrames,
-            m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos + loopLengthFrames,
+            m_pHotcue1EndPosition->toFramePos());
 
     // Halve loop size (4 => 2 beats) while saved loop is disabled
     m_pLoopHalve->set(1);
     m_pLoopHalve->set(0);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos + loopLengthFrames,
-            m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos + loopLengthFrames,
+            m_pHotcue1EndPosition->toFramePos());
 
     m_pPlay->set(0);
 }
@@ -888,12 +780,8 @@ TEST_F(HotcueControlTest, SavedLoopNoMoveIfDisabled) {
     const mixxx::audio::FrameDiff_t loopLengthFrames = loopSize * beatLengthFrames;
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     // Set a beatloop at position 0
     m_pBeatloopActivate->set(1);
@@ -904,9 +792,9 @@ TEST_F(HotcueControlTest, SavedLoopNoMoveIfDisabled) {
     m_pHotcue1SetLoop->set(1);
     m_pHotcue1SetLoop->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos + loopLengthFrames,
-            m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos + loopLengthFrames,
+            m_pHotcue1EndPosition->toFramePos());
 
     // Disable Loop
     m_pLoopEnabled->set(0);
@@ -915,21 +803,21 @@ TEST_F(HotcueControlTest, SavedLoopNoMoveIfDisabled) {
 
     // Move loop right (0 => 4 beats) while saved loop is disabled
     m_pLoopMove->set(loopSize);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos + loopLengthFrames,
-            m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos + loopLengthFrames,
+            m_pHotcue1EndPosition->toFramePos());
 
     // Move loop left (4 => 0 beats) while saved loop is disabled
     m_pLoopMove->set(-loopSize);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos + loopLengthFrames,
-            m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos + loopLengthFrames,
+            m_pHotcue1EndPosition->toFramePos());
 
     // Move loop left (0 => -4 beats) while saved loop is disabled
     m_pLoopMove->set(-loopSize);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos + loopLengthFrames,
-            m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos + loopLengthFrames,
+            m_pHotcue1EndPosition->toFramePos());
 
     m_pPlay->set(0);
 }
@@ -943,12 +831,8 @@ TEST_F(HotcueControlTest, SavedLoopReset) {
     const mixxx::audio::FrameDiff_t loopLengthFrames = m_pBeatloopSize->get() * beatLengthFrames;
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     // Set a beatloop
     m_pBeatloopActivate->set(1);
@@ -959,9 +843,9 @@ TEST_F(HotcueControlTest, SavedLoopReset) {
     m_pHotcue1SetLoop->set(1);
     m_pHotcue1SetLoop->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos + loopLengthFrames,
-            m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos + loopLengthFrames,
+            m_pHotcue1EndPosition->toFramePos());
 
     const auto loopEndPosition = mixxx::audio::kStartFramePos + loopLengthFrames;
 
@@ -973,20 +857,16 @@ TEST_F(HotcueControlTest, SavedLoopReset) {
 
     // Check if setting the new beatloop disabled the current saved loop
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopEndPosition, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(loopEndPosition, m_pHotcue1EndPosition->toFramePos());
 }
 
 TEST_F(HotcueControlTest, SavedLoopCueLoopWithExistingLoop) {
     createAndLoadFakeTrack();
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     constexpr auto loopStartPosition = mixxx::audio::FramePos(100);
     constexpr auto loopEndPosition = mixxx::audio::FramePos(200);
@@ -997,8 +877,8 @@ TEST_F(HotcueControlTest, SavedLoopCueLoopWithExistingLoop) {
     m_pHotcue1SetLoop->set(0);
     EXPECT_DOUBLE_EQ(1.0, m_pLoopEnabled->get());
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopEndPosition, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(loopStartPosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(loopEndPosition, m_pHotcue1EndPosition->toFramePos());
 
     // Disable Loop
     m_pHotcue1CueLoop->set(1);
@@ -1006,8 +886,8 @@ TEST_F(HotcueControlTest, SavedLoopCueLoopWithExistingLoop) {
 
     EXPECT_DOUBLE_EQ(0.0, m_pLoopEnabled->get());
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopEndPosition, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(loopStartPosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(loopEndPosition, m_pHotcue1EndPosition->toFramePos());
 
     // Re-Enable Loop
     m_pHotcue1CueLoop->set(1);
@@ -1015,8 +895,8 @@ TEST_F(HotcueControlTest, SavedLoopCueLoopWithExistingLoop) {
 
     EXPECT_DOUBLE_EQ(1.0, m_pLoopEnabled->get());
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopEndPosition, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(loopStartPosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(loopEndPosition, m_pHotcue1EndPosition->toFramePos());
 }
 
 TEST_F(HotcueControlTest, CueLoopWithoutHotcueSetsHotcue) {
@@ -1024,21 +904,15 @@ TEST_F(HotcueControlTest, CueLoopWithoutHotcueSetsHotcue) {
     TrackPointer pTrack = loadTestTrackWithBpm(120.0);
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     m_pHotcue1CueLoop->set(1);
     m_pHotcue1CueLoop->set(0);
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
     EXPECT_TRUE(m_pLoopEnabled->toBool());
 }
 
@@ -1050,7 +924,7 @@ TEST_F(HotcueControlTest, CueLoopWithSavedLoopToggles) {
     m_pHotcue1SetLoop->set(0);
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
     EXPECT_NE(Cue::kNoPosition, m_pHotcue1EndPosition->get());
     EXPECT_TRUE(m_pLoopEnabled->toBool());
 
@@ -1058,7 +932,7 @@ TEST_F(HotcueControlTest, CueLoopWithSavedLoopToggles) {
     m_pHotcue1CueLoop->set(0);
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
     EXPECT_NE(Cue::kNoPosition, m_pHotcue1EndPosition->get());
     EXPECT_FALSE(m_pLoopEnabled->toBool());
 
@@ -1066,7 +940,7 @@ TEST_F(HotcueControlTest, CueLoopWithSavedLoopToggles) {
     m_pHotcue1CueLoop->set(0);
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
     EXPECT_NE(Cue::kNoPosition, m_pHotcue1EndPosition->get());
     EXPECT_TRUE(m_pLoopEnabled->toBool());
 }
@@ -1075,21 +949,15 @@ TEST_F(HotcueControlTest, CueLoopWithoutLoopOrBeats) {
     createAndLoadFakeTrack();
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     m_pHotcue1CueLoop->set(1);
     m_pHotcue1CueLoop->set(0);
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
     EXPECT_FALSE(m_pLoopEnabled->toBool());
 }
 
@@ -1105,12 +973,8 @@ TEST_F(HotcueControlTest, SavedLoopToggleDoesNotSeek) {
     const auto loopStartPosition = mixxx::audio::FramePos(8 * beatLengthFrames);
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     // Seek to loop start position
     setCurrentFramePosition(loopStartPosition);
@@ -1126,8 +990,8 @@ TEST_F(HotcueControlTest, SavedLoopToggleDoesNotSeek) {
     m_pHotcue1SetLoop->set(1);
     m_pHotcue1SetLoop->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition + loopLengthFrames, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(loopStartPosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(loopStartPosition + loopLengthFrames, m_pHotcue1EndPosition->toFramePos());
 
     // Seek to start of track
     setCurrentFramePosition(beforeLoopPosition);
@@ -1135,16 +999,16 @@ TEST_F(HotcueControlTest, SavedLoopToggleDoesNotSeek) {
 
     // Check that the previous seek disabled the loop
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition + loopLengthFrames, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(loopStartPosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(loopStartPosition + loopLengthFrames, m_pHotcue1EndPosition->toFramePos());
 
     // Re-Enable loop
     m_pHotcue1Activate->set(1);
     m_pHotcue1Activate->set(0);
     ProcessBuffer();
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition + loopLengthFrames, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(loopStartPosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(loopStartPosition + loopLengthFrames, m_pHotcue1EndPosition->toFramePos());
 
     // Check that re-enabling loop didn't seek
     EXPECT_NEAR(beforeLoopPosition.value(), currentFramePosition().value(), 1024);
@@ -1154,8 +1018,8 @@ TEST_F(HotcueControlTest, SavedLoopToggleDoesNotSeek) {
     m_pHotcue1Activate->set(0);
     ProcessBuffer();
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition + loopLengthFrames, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(loopStartPosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(loopStartPosition + loopLengthFrames, m_pHotcue1EndPosition->toFramePos());
 }
 
 TEST_F(HotcueControlTest, SavedLoopActivate) {
@@ -1171,12 +1035,8 @@ TEST_F(HotcueControlTest, SavedLoopActivate) {
     const auto afterLoopPosition = mixxx::audio::FramePos(16 * beatLengthFrames);
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     // Seek to loop start position
     setCurrentFramePosition(loopStartPosition);
@@ -1192,8 +1052,8 @@ TEST_F(HotcueControlTest, SavedLoopActivate) {
     m_pHotcue1Activate->set(1);
     m_pHotcue1Activate->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition + loopLengthFrames, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(loopStartPosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(loopStartPosition + loopLengthFrames, m_pHotcue1EndPosition->toFramePos());
 
     // Seek to start of track
     setCurrentFramePosition(beforeLoopPosition);
@@ -1202,16 +1062,16 @@ TEST_F(HotcueControlTest, SavedLoopActivate) {
 
     // Check that the previous seek disabled the loop
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition + loopLengthFrames, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(loopStartPosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(loopStartPosition + loopLengthFrames, m_pHotcue1EndPosition->toFramePos());
 
     // Activate saved loop (does not imply seeking to loop start)
     m_pHotcue1Activate->set(1);
     m_pHotcue1Activate->set(0);
     ProcessBuffer();
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition + loopLengthFrames, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(loopStartPosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(loopStartPosition + loopLengthFrames, m_pHotcue1EndPosition->toFramePos());
     EXPECT_NEAR(positionBeforeActivate.value(), currentFramePosition().value(), 1000);
 
     // Seek to position after saved loop
@@ -1220,8 +1080,8 @@ TEST_F(HotcueControlTest, SavedLoopActivate) {
 
     // Check that the previous seek disabled the loop
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition + loopLengthFrames, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(loopStartPosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(loopStartPosition + loopLengthFrames, m_pHotcue1EndPosition->toFramePos());
 
     positionBeforeActivate = currentFramePosition();
 
@@ -1231,8 +1091,8 @@ TEST_F(HotcueControlTest, SavedLoopActivate) {
     m_pHotcue1Activate->set(0);
     ProcessBuffer();
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition + loopLengthFrames, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(loopStartPosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(loopStartPosition + loopLengthFrames, m_pHotcue1EndPosition->toFramePos());
     EXPECT_NEAR(loopStartPosition.value(), currentFramePosition().value(), 1000);
 }
 
@@ -1247,12 +1107,8 @@ TEST_F(HotcueControlTest, SavedLoopActivateWhilePlayingTogglesLoop) {
     const auto loopEndPosition = loopStartPosition + loopLengthFrames;
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     // Set a beatloop
     setCurrentFramePosition(loopStartPosition);
@@ -1268,8 +1124,8 @@ TEST_F(HotcueControlTest, SavedLoopActivateWhilePlayingTogglesLoop) {
     m_pHotcue1Activate->set(1);
     m_pHotcue1Activate->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopEndPosition, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(loopStartPosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(loopEndPosition, m_pHotcue1EndPosition->toFramePos());
     EXPECT_DOUBLE_EQ(1.0, m_pLoopEnabled->get());
     EXPECT_DOUBLE_EQ(m_pHotcue1Position->get(), m_pLoopStartPosition->get());
     EXPECT_DOUBLE_EQ(m_pHotcue1EndPosition->get(), m_pLoopEndPosition->get());
@@ -1295,12 +1151,8 @@ TEST_F(HotcueControlTest, SavedLoopBeatLoopSizeRestore) {
     const mixxx::audio::FrameDiff_t loopLengthFrames = m_pBeatloopSize->get() * beatLengthFrames;
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     // Set a beatloop
     m_pBeatloopActivate->set(1);
@@ -1312,16 +1164,16 @@ TEST_F(HotcueControlTest, SavedLoopBeatLoopSizeRestore) {
     m_pHotcue1ActivateLoop->set(1);
     m_pHotcue1ActivateLoop->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos + loopLengthFrames,
-            m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos + loopLengthFrames,
+            m_pHotcue1EndPosition->toFramePos());
 
     // Disable loop
     m_pLoopEnabled->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos + loopLengthFrames,
-            m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos + loopLengthFrames,
+            m_pHotcue1EndPosition->toFramePos());
 
     // Set new beatloop size
     m_pBeatloopSize->set(savedLoopSize / 2);
@@ -1330,9 +1182,9 @@ TEST_F(HotcueControlTest, SavedLoopBeatLoopSizeRestore) {
     m_pHotcue1ActivateLoop->set(1);
     m_pHotcue1ActivateLoop->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos + loopLengthFrames,
-            m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos + loopLengthFrames,
+            m_pHotcue1EndPosition->toFramePos());
 
     // Check that saved loop's beatloop size has been restored
     EXPECT_DOUBLE_EQ(savedLoopSize, m_pBeatloopSize->get());
@@ -1351,12 +1203,8 @@ TEST_F(HotcueControlTest, SavedLoopBeatLoopSizeRestoreDoesNotJump) {
     const auto afterLoopPosition = mixxx::audio::FramePos(beatLengthFrames);
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     // Seek to cue Position (8th beat)
     setCurrentFramePosition(cuePosition);
@@ -1371,8 +1219,8 @@ TEST_F(HotcueControlTest, SavedLoopBeatLoopSizeRestoreDoesNotJump) {
     m_pHotcue1SetLoop->set(1);
     m_pHotcue1SetLoop->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition + loopLengthFrames, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(cuePosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(cuePosition + loopLengthFrames, m_pHotcue1EndPosition->toFramePos());
 
     m_pPlay->set(1);
 
@@ -1381,8 +1229,8 @@ TEST_F(HotcueControlTest, SavedLoopBeatLoopSizeRestoreDoesNotJump) {
     // Disable loop
     m_pLoopEnabled->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition + loopLengthFrames, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(cuePosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(cuePosition + loopLengthFrames, m_pHotcue1EndPosition->toFramePos());
 
     // Set new beatloop size
     m_pBeatloopSize->set(m_pBeatloopSize->get() / 2);
@@ -1394,8 +1242,8 @@ TEST_F(HotcueControlTest, SavedLoopBeatLoopSizeRestoreDoesNotJump) {
     m_pHotcue1Activate->set(1);
     m_pHotcue1Activate->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition + loopLengthFrames, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(cuePosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(cuePosition + loopLengthFrames, m_pHotcue1EndPosition->toFramePos());
 
     // Check that saved loop's beatloop size has been restored
     EXPECT_DOUBLE_EQ(savedLoopSize, m_pBeatloopSize->get());
@@ -1408,8 +1256,8 @@ TEST_F(HotcueControlTest, SavedLoopBeatLoopSizeRestoreDoesNotJump) {
     // Disable loop
     m_pLoopEnabled->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition + loopLengthFrames, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(cuePosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(cuePosition + loopLengthFrames, m_pHotcue1EndPosition->toFramePos());
 
     // Set new beatloop size
     m_pBeatloopSize->set(m_pBeatloopSize->get() / 2);
@@ -1421,8 +1269,8 @@ TEST_F(HotcueControlTest, SavedLoopBeatLoopSizeRestoreDoesNotJump) {
     m_pHotcue1Activate->set(1);
     m_pHotcue1Activate->set(0);
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(cuePosition + loopLengthFrames, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(cuePosition, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(cuePosition + loopLengthFrames, m_pHotcue1EndPosition->toFramePos());
 
     // Check that saved loop's beatloop size has been restored
     EXPECT_DOUBLE_EQ(savedLoopSize, m_pBeatloopSize->get());
@@ -1437,12 +1285,8 @@ TEST_F(HotcueControlTest, SavedLoopUnloadTrackWhileActive) {
     loadTestTrackWithBpm(120.0);
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     // Set a beatloop
     m_pBeatloopActivate->set(1);
@@ -1464,12 +1308,8 @@ TEST_F(HotcueControlTest, SavedLoopUnloadTrackWhileActive) {
     ProcessBuffer();
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 }
 
 TEST_F(HotcueControlTest, SavedLoopUseLoopInOutWhileActive) {
@@ -1480,12 +1320,8 @@ TEST_F(HotcueControlTest, SavedLoopUseLoopInOutWhileActive) {
     loadTestTrackWithBpm(120.0);
 
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty), m_pHotcue1Enabled->get());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                         .isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                         .isValid());
+    EXPECT_FALSE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_FALSE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     // Set a beatloop
     m_pBeatloopActivate->set(1);
@@ -1497,12 +1333,8 @@ TEST_F(HotcueControlTest, SavedLoopUseLoopInOutWhileActive) {
     m_pHotcue1SetLoop->set(0);
     ProcessBuffer();
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_TRUE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1Position->get())
-                        .isValid());
-    EXPECT_TRUE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-            m_pHotcue1EndPosition->get())
-                        .isValid());
+    EXPECT_TRUE(m_pHotcue1Position->toFramePos().isValid());
+    EXPECT_TRUE(m_pHotcue1EndPosition->toFramePos().isValid());
 
     constexpr auto loopEndPosition = mixxx::audio::FramePos(1000);
 
@@ -1519,6 +1351,6 @@ TEST_F(HotcueControlTest, SavedLoopUseLoopInOutWhileActive) {
 
     ProcessBuffer();
     EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Active), m_pHotcue1Enabled->get());
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kStartFramePos, m_pHotcue1Position);
-    EXPECT_FRAMEPOS_EQ_CONTROL(loopEndPosition, m_pHotcue1EndPosition);
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, m_pHotcue1Position->toFramePos());
+    EXPECT_FRAMEPOS_EQ(loopEndPosition, m_pHotcue1EndPosition->toFramePos());
 }

--- a/src/test/looping_control_test.cpp
+++ b/src/test/looping_control_test.cpp
@@ -300,7 +300,7 @@ TEST_F(LoopingControlTest, LoopInOutButtons_QuantizeEnabled) {
     EXPECT_FRAMEPOS_EQ(kTrackEndPosition * m_pPlayPosition->get(),
             mixxx::audio::FramePos{(44100 * 4) + 250});
 
-    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos{2}, m_pBeatLoopSize);
+    EXPECT_EQ(4, m_pBeatLoopSize->get());
     EXPECT_TRUE(m_pBeatLoop4Enabled->toBool());
 
     // Check that beatloop_4_enabled is reset to 0 when changing the loop size.

--- a/src/test/signalpathtest.h
+++ b/src/test/signalpathtest.h
@@ -38,14 +38,6 @@ using ::testing::_;
         EXPECT_DOUBLE_EQ((pos1).value(), (pos2).value()); \
     }
 
-#define EXPECT_FRAMEPOS_EQ_CONTROL(position, control)                    \
-    {                                                                    \
-        const auto controlPos =                                          \
-                mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid( \
-                        control->get());                                 \
-        EXPECT_FRAMEPOS_EQ(position, controlPos);                        \
-    }
-
 // Subclass of EngineMaster that provides access to the master buffer object
 // for comparison.
 class TestEngineMaster : public EngineMaster {


### PR DESCRIPTION
This gets rid of the remaining sample<->frame position conversions in the engine.

Related Zulip Discussion: https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/Typed.20Controls.2FControlProxies