### PR TITLE
Add Beats::fromByteArray() static method

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1235,7 +1235,7 @@ bool setTrackBeats(const QSqlRecord& record, const int column, Track* pTrack) {
     QString beatsSubVersion = record.value(column + 2).toString();
     QByteArray beatsBlob = record.value(column + 3).toByteArray();
     bool bpmLocked = record.value(column + 4).toBool();
-    const mixxx::BeatsPointer pBeats = BeatFactory::loadBeatsFromByteArray(
+    const mixxx::BeatsPointer pBeats = mixxx::Beats::fromByteArray(
             pTrack->getSampleRate(), beatsVersion, beatsSubVersion, beatsBlob);
     if (pBeats) {
         if (bpmLocked) {

--- a/src/track/beatfactory.cpp
+++ b/src/track/beatfactory.cpp
@@ -19,11 +19,11 @@ mixxx::BeatsPointer BeatFactory::loadBeatsFromByteArray(
         const QByteArray& beatsSerialized) {
     if (beatsVersion == BEAT_GRID_1_VERSION ||
         beatsVersion == BEAT_GRID_2_VERSION) {
-        auto pGrid = mixxx::BeatGrid::makeBeatGrid(sampleRate, beatsSubVersion, beatsSerialized);
+        auto pGrid = mixxx::BeatGrid::fromByteArray(sampleRate, beatsSubVersion, beatsSerialized);
         qDebug() << "Successfully deserialized BeatGrid";
         return pGrid;
     } else if (beatsVersion == BEAT_MAP_VERSION) {
-        auto pMap = mixxx::BeatMap::makeBeatMap(sampleRate, beatsSubVersion, beatsSerialized);
+        auto pMap = mixxx::BeatMap::fromByteArray(sampleRate, beatsSubVersion, beatsSerialized);
         qDebug() << "Successfully deserialized BeatMap";
         return pMap;
     }

--- a/src/track/beatfactory.cpp
+++ b/src/track/beatfactory.cpp
@@ -12,25 +12,6 @@ const QString kRoundingVersion = QStringLiteral("V4");
 
 } // namespace
 
-mixxx::BeatsPointer BeatFactory::loadBeatsFromByteArray(
-        mixxx::audio::SampleRate sampleRate,
-        const QString& beatsVersion,
-        const QString& beatsSubVersion,
-        const QByteArray& beatsSerialized) {
-    if (beatsVersion == BEAT_GRID_1_VERSION ||
-        beatsVersion == BEAT_GRID_2_VERSION) {
-        auto pGrid = mixxx::BeatGrid::fromByteArray(sampleRate, beatsSubVersion, beatsSerialized);
-        qDebug() << "Successfully deserialized BeatGrid";
-        return pGrid;
-    } else if (beatsVersion == BEAT_MAP_VERSION) {
-        auto pMap = mixxx::BeatMap::fromByteArray(sampleRate, beatsSubVersion, beatsSerialized);
-        qDebug() << "Successfully deserialized BeatMap";
-        return pMap;
-    }
-    qDebug() << "BeatFactory::loadBeatsFromByteArray could not parse serialized beats.";
-    return mixxx::BeatsPointer();
-}
-
 mixxx::BeatsPointer BeatFactory::makeBeatGrid(
         mixxx::audio::SampleRate sampleRate,
         mixxx::Bpm bpm,

--- a/src/track/beatfactory.h
+++ b/src/track/beatfactory.h
@@ -11,11 +11,6 @@ class Track;
 
 class BeatFactory {
   public:
-    static mixxx::BeatsPointer loadBeatsFromByteArray(
-            mixxx::audio::SampleRate sampleRate,
-            const QString& beatsVersion,
-            const QString& beatsSubVersion,
-            const QByteArray& beatsSerialized);
     static mixxx::BeatsPointer makeBeatGrid(
             mixxx::audio::SampleRate sampleRate,
             mixxx::Bpm bpm,

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -95,7 +95,7 @@ BeatsPointer BeatGrid::makeBeatGrid(
 }
 
 // static
-BeatsPointer BeatGrid::makeBeatGrid(
+BeatsPointer BeatGrid::fromByteArray(
         audio::SampleRate sampleRate,
         const QString& subVersion,
         const QByteArray& byteArray) {

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -23,7 +23,7 @@ class BeatGrid final : public Beats {
             mixxx::Bpm bpm,
             mixxx::audio::FramePos firstBeatPos);
 
-    static BeatsPointer makeBeatGrid(
+    static BeatsPointer fromByteArray(
             audio::SampleRate sampleRate,
             const QString& subVersion,
             const QByteArray& byteArray);

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -202,7 +202,7 @@ BeatMap::BeatMap(const BeatMap& other)
 }
 
 // static
-BeatsPointer BeatMap::makeBeatMap(
+BeatsPointer BeatMap::fromByteArray(
         audio::SampleRate sampleRate,
         const QString& subVersion,
         const QByteArray& byteArray) {

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -23,7 +23,7 @@ class BeatMap final : public Beats {
 
     ~BeatMap() override = default;
 
-    static BeatsPointer makeBeatMap(
+    static BeatsPointer fromByteArray(
             audio::SampleRate sampleRate,
             const QString& subVersion,
             const QByteArray& byteArray);

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -1,6 +1,36 @@
 #include "track/beats.h"
 
+#include "track/beatgrid.h"
+#include "track/beatmap.h"
+
 namespace mixxx {
+
+// static
+mixxx::BeatsPointer Beats::fromByteArray(
+        mixxx::audio::SampleRate sampleRate,
+        const QString& beatsVersion,
+        const QString& beatsSubVersion,
+        const QByteArray& beatsSerialized) {
+    mixxx::BeatsPointer pBeats = nullptr;
+    if (beatsVersion == BEAT_GRID_1_VERSION || beatsVersion == BEAT_GRID_2_VERSION) {
+        pBeats = mixxx::BeatGrid::fromByteArray(sampleRate, beatsSubVersion, beatsSerialized);
+    } else if (beatsVersion == BEAT_MAP_VERSION) {
+        pBeats = mixxx::BeatMap::fromByteArray(sampleRate, beatsSubVersion, beatsSerialized);
+    } else {
+        qWarning().nospace() << "Failed to deserialize Beats (" << beatsVersion
+                             << "): Invalid beats version";
+        return nullptr;
+    }
+
+    if (!pBeats) {
+        qWarning().nospace() << "Failed to deserialize Beats (" << beatsVersion
+                             << "): Parsing failed";
+        return nullptr;
+    }
+
+    qDebug().nospace() << "Successfully deserialized Beats (" << beatsVersion << ")";
+    return pBeats;
+}
 
 int Beats::numBeatsInRange(audio::FramePos startPosition, audio::FramePos endPosition) const {
     audio::FramePos lastPosition = audio::kStartFramePos;

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -30,6 +30,12 @@ class Beats {
   public:
     virtual ~Beats() = default;
 
+    static mixxx::BeatsPointer fromByteArray(
+            mixxx::audio::SampleRate sampleRate,
+            const QString& beatsVersion,
+            const QString& beatsSubVersion,
+            const QByteArray& beatsSerialized);
+
     enum class BpmScale {
         Double,
         Halve,


### PR DESCRIPTION
Make beats serialization/deserialization symmetric (there already is `toByteArray()`).