### PR TITLE
Beats: Move identical method implementations from BeatGrid/BeatMap

### DIFF
--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -143,41 +143,6 @@ bool BeatGrid::isValid() const {
     return m_sampleRate.isValid() && bpm().isValid() && firstBeatPosition().isValid();
 }
 
-// This could be implemented in the Beats Class itself.
-// If necessary, the child class can redefine it.
-audio::FramePos BeatGrid::findNextBeat(audio::FramePos position) const {
-    return findNthBeat(position, 1);
-}
-
-// This could be implemented in the Beats Class itself.
-// If necessary, the child class can redefine it.
-audio::FramePos BeatGrid::findPrevBeat(audio::FramePos position) const {
-    return findNthBeat(position, -1);
-}
-
-// This is an internal call. This could be implemented in the Beats Class itself.
-audio::FramePos BeatGrid::findClosestBeat(audio::FramePos position) const {
-    if (!isValid()) {
-        return audio::kInvalidFramePos;
-    }
-    audio::FramePos prevBeatPosition;
-    audio::FramePos nextBeatPosition;
-    findPrevNextBeats(position, &prevBeatPosition, &nextBeatPosition, true);
-    if (!prevBeatPosition.isValid()) {
-        // If both positions are invalid, we correctly return an invalid position.
-        return nextBeatPosition;
-    }
-
-    if (!nextBeatPosition.isValid()) {
-        return prevBeatPosition;
-    }
-
-    // Both position are valid, return the closest position.
-    return (nextBeatPosition - position > position - prevBeatPosition)
-            ? prevBeatPosition
-            : nextBeatPosition;
-}
-
 audio::FramePos BeatGrid::findNthBeat(audio::FramePos position, int n) const {
     if (!isValid() || n == 0) {
         return audio::kInvalidFramePos;

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -79,7 +79,6 @@ class BeatGrid final : public Beats {
     audio::FramePos firstBeatPosition() const;
     mixxx::Bpm bpm() const;
 
-    // For internal use only.
     bool isValid() const override;
 
     // The sub-version of this beatgrid.

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -43,13 +43,10 @@ class BeatGrid final : public Beats {
     // Beat calculations
     ////////////////////////////////////////////////////////////////////////////
 
-    audio::FramePos findNextBeat(audio::FramePos position) const override;
-    audio::FramePos findPrevBeat(audio::FramePos position) const override;
     bool findPrevNextBeats(audio::FramePos position,
             audio::FramePos* prevBeatPosition,
             audio::FramePos* nextBeatPosition,
             bool snapToNearBeats) const override;
-    audio::FramePos findClosestBeat(audio::FramePos position) const override;
     audio::FramePos findNthBeat(audio::FramePos position, int n) const override;
     std::unique_ptr<BeatIterator> findBeats(audio::FramePos startPosition,
             audio::FramePos endPosition) const override;
@@ -83,7 +80,7 @@ class BeatGrid final : public Beats {
     mixxx::Bpm bpm() const;
 
     // For internal use only.
-    bool isValid() const;
+    bool isValid() const override;
 
     // The sub-version of this beatgrid.
     const QString m_subVersion;

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -281,36 +281,6 @@ bool BeatMap::isValid() const {
     return m_sampleRate.isValid() && m_beats.size() >= kMinNumberOfBeats;
 }
 
-audio::FramePos BeatMap::findNextBeat(audio::FramePos position) const {
-    return findNthBeat(position, 1);
-}
-
-audio::FramePos BeatMap::findPrevBeat(audio::FramePos position) const {
-    return findNthBeat(position, -1);
-}
-
-audio::FramePos BeatMap::findClosestBeat(audio::FramePos position) const {
-    if (!isValid()) {
-        return audio::kInvalidFramePos;
-    }
-    audio::FramePos prevBeatPosition;
-    audio::FramePos nextBeatPosition;
-    findPrevNextBeats(position, &prevBeatPosition, &nextBeatPosition, true);
-    if (!prevBeatPosition.isValid()) {
-        // If both positions are invalid, we correctly return an invalid position.
-        return nextBeatPosition;
-    }
-
-    if (!nextBeatPosition.isValid()) {
-        return prevBeatPosition;
-    }
-
-    // Both position are valid, return the closest position.
-    return (nextBeatPosition - position > position - prevBeatPosition)
-            ? prevBeatPosition
-            : nextBeatPosition;
-}
-
 audio::FramePos BeatMap::findNthBeat(audio::FramePos position, int n) const {
     if (!isValid() || n == 0) {
         return audio::kInvalidFramePos;

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -45,13 +45,10 @@ class BeatMap final : public Beats {
     // Beat calculations
     ////////////////////////////////////////////////////////////////////////////
 
-    audio::FramePos findNextBeat(audio::FramePos position) const override;
-    audio::FramePos findPrevBeat(audio::FramePos position) const override;
     bool findPrevNextBeats(audio::FramePos position,
             audio::FramePos* prevBeatPosition,
             audio::FramePos* nextBeatPosition,
             bool snapToNearBeats) const override;
-    audio::FramePos findClosestBeat(audio::FramePos position) const override;
     audio::FramePos findNthBeat(audio::FramePos position, int n) const override;
     std::unique_ptr<BeatIterator> findBeats(audio::FramePos startPosition,
             audio::FramePos endPosition) const override;
@@ -82,7 +79,7 @@ class BeatMap final : public Beats {
     BeatMap(const BeatMap& other);
 
     // For internal use only.
-    bool isValid() const;
+    bool isValid() const override;
 
     const QString m_subVersion;
     const audio::SampleRate m_sampleRate;

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -78,7 +78,6 @@ class BeatMap final : public Beats {
     BeatMap(const BeatMap& other, BeatList beats, mixxx::Bpm nominalBpm);
     BeatMap(const BeatMap& other);
 
-    // For internal use only.
     bool isValid() const override;
 
     const QString m_subVersion;

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -45,6 +45,36 @@ int Beats::numBeatsInRange(audio::FramePos startPosition, audio::FramePos endPos
     return i - 2;
 };
 
+audio::FramePos Beats::findNextBeat(audio::FramePos position) const {
+    return findNthBeat(position, 1);
+}
+
+audio::FramePos Beats::findPrevBeat(audio::FramePos position) const {
+    return findNthBeat(position, -1);
+}
+
+audio::FramePos Beats::findClosestBeat(audio::FramePos position) const {
+    if (!isValid()) {
+        return audio::kInvalidFramePos;
+    }
+    audio::FramePos prevBeatPosition;
+    audio::FramePos nextBeatPosition;
+    findPrevNextBeats(position, &prevBeatPosition, &nextBeatPosition, true);
+    if (!prevBeatPosition.isValid()) {
+        // If both positions are invalid, we correctly return an invalid position.
+        return nextBeatPosition;
+    }
+
+    if (!nextBeatPosition.isValid()) {
+        return prevBeatPosition;
+    }
+
+    // Both position are valid, return the closest position.
+    return (nextBeatPosition - position > position - prevBeatPosition)
+            ? prevBeatPosition
+            : nextBeatPosition;
+}
+
 audio::FramePos Beats::findNBeatsFromPosition(audio::FramePos position, double beats) const {
     audio::FramePos prevBeatPosition;
     audio::FramePos nextBeatPosition;

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -157,7 +157,6 @@ class Beats {
     virtual BeatsPointer setBpm(mixxx::Bpm bpm) = 0;
 
   protected:
-    /// For internal use only.
     virtual bool isValid() const = 0;
 };
 

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -75,12 +75,12 @@ class Beats {
     /// Starting from frame position `position`, return the frame position of
     /// the next beat in the track, or an invalid position if none exists. If
     /// `position` refers to the location of a beat, `position` is returned.
-    virtual audio::FramePos findNextBeat(audio::FramePos position) const = 0;
+    audio::FramePos findNextBeat(audio::FramePos position) const;
 
     /// Starting from frame position `position`, return the frame position of
     /// the previous beat in the track, or an invalid position if none exists.
     /// If `position` refers to the location of beat, `position` is returned.
-    virtual audio::FramePos findPrevBeat(audio::FramePos position) const = 0;
+    audio::FramePos findPrevBeat(audio::FramePos position) const;
 
     /// Starting from frame position `position`, fill the frame position of the
     /// previous beat and next beat. Either can be invalid if none exists. If
@@ -100,7 +100,7 @@ class Beats {
 
     /// Starting from frame position `position`, return the frame position of
     /// the closest beat in the track, or an invalid position if none exists.
-    virtual audio::FramePos findClosestBeat(audio::FramePos position) const = 0;
+    audio::FramePos findClosestBeat(audio::FramePos position) const;
 
     /// Find the Nth beat from frame position `position`. Works with both
     /// positive and negative values of n. Calling findNthBeat with `n=0` is
@@ -155,6 +155,10 @@ class Beats {
 
     /// Adjust the beats so the global average BPM matches `bpm`.
     virtual BeatsPointer setBpm(mixxx::Bpm bpm) = 0;
+
+  protected:
+    /// For internal use only.
+    virtual bool isValid() const = 0;
 };
 
 } // namespace mixxx


### PR DESCRIPTION
This is a first step toward merging the beatgrid/beatmap classes into a
single class.