### PR TITLE
ControlDoublePrivate: log warning before assert fails.

### DIFF
--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -148,11 +148,12 @@ QSharedPointer<ControlDoublePrivate> ControlDoublePrivate::getControl(
             auto pControl = it.value().lock();
             if (pControl) {
                 // Control object already exists
-                VERIFY_OR_DEBUG_ASSERT(!pCreatorCO) {
+                if (pCreatorCO) {
                     qWarning()
                             << "ControlObject"
                             << key.group << key.item
                             << "already created";
+                    DEBUG_ASSERT(false);
                     return nullptr;
                 }
                 return pControl;
@@ -311,8 +312,9 @@ double ControlDoublePrivate::getParameterForValue(double value) const {
 
 double ControlDoublePrivate::getParameterForMidi(double midiParam) const {
     QSharedPointer<ControlNumericBehavior> pBehavior = m_pBehavior;
-    VERIFY_OR_DEBUG_ASSERT(pBehavior) {
+    if (!pBehavior) {
         qWarning() << "Cannot set" << m_key << "by Midi";
+        DEBUG_ASSERT(false);
         return 0;
     }
     return pBehavior->midiToParameter(midiParam);
@@ -320,8 +322,9 @@ double ControlDoublePrivate::getParameterForMidi(double midiParam) const {
 
 void ControlDoublePrivate::setValueFromMidi(MidiOpCode opcode, double midiParam) {
     QSharedPointer<ControlNumericBehavior> pBehavior = m_pBehavior;
-    VERIFY_OR_DEBUG_ASSERT(pBehavior) {
+    if (!pBehavior) {
         qWarning() << "Cannot set" << m_key << "by Midi";
+        DEBUG_ASSERT(false);
         return;
     }
     pBehavior->setValueFromMidi(opcode, midiParam, this);
@@ -329,8 +332,9 @@ void ControlDoublePrivate::setValueFromMidi(MidiOpCode opcode, double midiParam)
 
 double ControlDoublePrivate::getMidiParameter() const {
     QSharedPointer<ControlNumericBehavior> pBehavior = m_pBehavior;
-    VERIFY_OR_DEBUG_ASSERT(pBehavior) {
+    if (!pBehavior) {
         qWarning() << "Cannot get" << m_key << "by Midi";
+        DEBUG_ASSERT(false);
         return 0;
     }
     return pBehavior->valueToMidiParameter(get());

--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -153,7 +153,7 @@ QSharedPointer<ControlDoublePrivate> ControlDoublePrivate::getControl(
                             << "ControlObject"
                             << key.group << key.item
                             << "already created";
-                    DEBUG_ASSERT(false);
+                    DEBUG_ASSERT(!"pCreatorCO != nullptr, ControlObject already created");
                     return nullptr;
                 }
                 return pControl;
@@ -313,8 +313,8 @@ double ControlDoublePrivate::getParameterForValue(double value) const {
 double ControlDoublePrivate::getParameterForMidi(double midiParam) const {
     QSharedPointer<ControlNumericBehavior> pBehavior = m_pBehavior;
     if (!pBehavior) {
-        qWarning() << "Cannot set" << m_key << "by Midi";
-        DEBUG_ASSERT(false);
+        qWarning() << "Cannot get" << m_key << "for Midi";
+        DEBUG_ASSERT(!"pBehavior == nullptr, getParameterForMidi is returning 0");
         return 0;
     }
     return pBehavior->midiToParameter(midiParam);
@@ -323,8 +323,8 @@ double ControlDoublePrivate::getParameterForMidi(double midiParam) const {
 void ControlDoublePrivate::setValueFromMidi(MidiOpCode opcode, double midiParam) {
     QSharedPointer<ControlNumericBehavior> pBehavior = m_pBehavior;
     if (!pBehavior) {
-        qWarning() << "Cannot set" << m_key << "by Midi";
-        DEBUG_ASSERT(false);
+        qWarning() << "Cannot set" << m_key << "from Midi";
+        DEBUG_ASSERT(!"pBehavior == nullptr, abort setValueFromMidi()");
         return;
     }
     pBehavior->setValueFromMidi(opcode, midiParam, this);
@@ -333,8 +333,8 @@ void ControlDoublePrivate::setValueFromMidi(MidiOpCode opcode, double midiParam)
 double ControlDoublePrivate::getMidiParameter() const {
     QSharedPointer<ControlNumericBehavior> pBehavior = m_pBehavior;
     if (!pBehavior) {
-        qWarning() << "Cannot get" << m_key << "by Midi";
-        DEBUG_ASSERT(false);
+        qWarning() << "Cannot get" << m_key << "as Midi";
+        DEBUG_ASSERT(!"pBehavior == nullptr, getMidiParameter() is returning 0");
         return 0;
     }
     return pBehavior->valueToMidiParameter(get());


### PR DESCRIPTION
Make sure the warning is printed before the assertion kills mixxx.
This should help to debug issues discussed here: 

https://mixxx.zulipchat.com/#narrow/stream/247620-development-help/topic/qDebug.20messages.20with.20DEBUG_ASSERTIONS_FATAL