### PR TITLE
Library sidebar: also activate items on PageUp/Down events

### DIFF
--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -186,15 +186,18 @@ void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
     if (event->key() == Qt::Key_Return) {
         toggleSelectedItem();
         return;
-    } else if (event->key() == Qt::Key_Down || event->key() == Qt::Key_Up) {
+    } else if (event->key() == Qt::Key_Down ||
+            event->key() == Qt::Key_Up ||
+            event->key() == Qt::Key_PageDown ||
+            event->key() == Qt::Key_PageUp ||
+            event->key() == Qt::Key_End ||
+            event->key() == Qt::Key_Home) {
         // Let the tree view move up and down for us.
         QTreeView::keyPressEvent(event);
-
         // But force the index to be activated/clicked after the selection
         // changes. (Saves you from having to push "enter" after changing the
         // selection.)
-        QModelIndexList selectedIndices = this->selectionModel()->selectedRows();
-
+        QModelIndexList selectedIndices = selectionModel()->selectedRows();
         //Note: have to get the selected indices _after_ QTreeView::keyPressEvent()
         if (selectedIndices.size() > 0) {
             QModelIndex index = selectedIndices.at(0);


### PR DESCRIPTION
Activate sidebar items also on PageUp / PageDown / Home / End events = update the table view
Affects keyboard and `[Library],Scroll..` commands.

Previously those keys would move the sidebar selection as expected but the new item wasn't actually activated.
The table view didn't change, may even stay empty, which does cause panic in case you scroll up to Tracks ; )