### PR TITLE
Follow-up: Library prefs

### DIFF
--- a/src/dialog/dlgkeywheel.cpp
+++ b/src/dialog/dlgkeywheel.cpp
@@ -6,6 +6,7 @@
 #include <QSvgRenderer>
 
 #include "control/controlobject.h"
+#include "library/library_prefs.h"
 
 using namespace mixxx::track::io::key;
 
@@ -46,7 +47,7 @@ DlgKeywheel::DlgKeywheel(QWidget* parent, const UserSettingsPointer& pConfig)
 
     // load the user configured setting as default
     const int notation = static_cast<int>(ControlObject::get(
-            ConfigKey("[Library]", "key_notation")));
+            mixxx::library::prefs::kKeyNotationConfigKey));
     m_notation = static_cast<KeyUtils::KeyNotation>(notation);
     // Display the current or next valid notation
     switchNotation(0);

--- a/src/library/columncache.cpp
+++ b/src/library/columncache.cpp
@@ -2,6 +2,7 @@
 
 #include "library/dao/playlistdao.h"
 #include "library/dao/trackschema.h"
+#include "library/library_prefs.h"
 #include "moc_columncache.cpp"
 #include "util/db/dbconnection.h"
 
@@ -15,7 +16,7 @@ const QString kSortNoCaseLex = mixxx::DbConnection::collateLexicographically(
 } // namespace
 
 ColumnCache::ColumnCache(const QStringList& columns) {
-    m_pKeyNotationCP = new ControlProxy("[Library]", "key_notation", this);
+    m_pKeyNotationCP = new ControlProxy(mixxx::library::prefs::kKeyNotationConfigKey, this);
     m_pKeyNotationCP->connectValueChanged(this, &ColumnCache::slotSetKeySortOrder);
 
     // ColumnCache is initialized before the preferences, so slotSetKeySortOrder is called

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -80,7 +80,8 @@ Library::Library(
           m_pAnalysisFeature(nullptr) {
     qRegisterMetaType<LibraryRemovalType>("LibraryRemovalType");
 
-    m_pKeyNotation.reset(new ControlObject(ConfigKey(kConfigGroup, "key_notation")));
+    m_pKeyNotation.reset(
+            new ControlObject(mixxx::library::prefs::kKeyNotationConfigKey));
 
     connect(m_pTrackCollectionManager,
             &TrackCollectionManager::libraryScanFinished,

--- a/src/library/library_prefs.cpp
+++ b/src/library/library_prefs.cpp
@@ -32,3 +32,8 @@ const ConfigKey mixxx::library::prefs::kSyncTrackMetadataExportConfigKey =
         ConfigKey{
                 mixxx::library::prefs::kConfigGroup,
                 QStringLiteral("SyncTrackMetadataExport")};
+
+const ConfigKey mixxx::library::prefs::kSeratoMetadataExportConfigKey =
+        ConfigKey{
+                mixxx::library::prefs::kConfigGroup,
+                QStringLiteral("SeratoMetadataExport")};

--- a/src/library/library_prefs.cpp
+++ b/src/library/library_prefs.cpp
@@ -6,24 +6,24 @@
 // reliably at compile time.
 
 const ConfigKey mixxx::library::prefs::kLegacyDirectoryConfigKey =
-        ConfigKey(
+        ConfigKey{
                 QStringLiteral("[Playlist]"),
-                QStringLiteral("Directory"));
+                QStringLiteral("Directory")};
 
 const QString mixxx::library::prefs::kConfigGroup =
         QStringLiteral("[Library]");
 
 const ConfigKey mixxx::library::prefs::kEditMetadataSelectedClickConfigKey =
-        ConfigKey(
+        ConfigKey{
                 mixxx::library::prefs::kConfigGroup,
-                "EditMetadataSelectedClick");
+                QStringLiteral("EditMetadataSelectedClick")};
 
 const ConfigKey mixxx::library::prefs::kSearchDebouncingTimeoutMillisConfigKey =
-        ConfigKey(
+        ConfigKey{
                 mixxx::library::prefs::kConfigGroup,
-                QStringLiteral("SearchDebouncingTimeoutMillis"));
+                QStringLiteral("SearchDebouncingTimeoutMillis")};
 
 const ConfigKey mixxx::library::prefs::kSyncTrackMetadataExportConfigKey =
-        ConfigKey(
+        ConfigKey{
                 mixxx::library::prefs::kConfigGroup,
-                QStringLiteral("SyncTrackMetadataExport"));
+                QStringLiteral("SyncTrackMetadataExport")};

--- a/src/library/library_prefs.cpp
+++ b/src/library/library_prefs.cpp
@@ -13,6 +13,11 @@ const ConfigKey mixxx::library::prefs::kLegacyDirectoryConfigKey =
 const QString mixxx::library::prefs::kConfigGroup =
         QStringLiteral("[Library]");
 
+const ConfigKey mixxx::library::prefs::kKeyNotationConfigKey =
+        ConfigKey{
+                mixxx::library::prefs::kConfigGroup,
+                QStringLiteral("key_notation")};
+
 const ConfigKey mixxx::library::prefs::kEditMetadataSelectedClickConfigKey =
         ConfigKey{
                 mixxx::library::prefs::kConfigGroup,

--- a/src/library/library_prefs.h
+++ b/src/library/library_prefs.h
@@ -22,6 +22,8 @@ const bool kEditMetadataSelectedClickDefault = false;
 
 extern const ConfigKey kSyncTrackMetadataExportConfigKey;
 
+extern const ConfigKey kSeratoMetadataExportConfigKey;
+
 } // namespace prefs
 
 } // namespace library

--- a/src/library/library_prefs.h
+++ b/src/library/library_prefs.h
@@ -12,6 +12,8 @@ extern const ConfigKey kLegacyDirectoryConfigKey;
 
 extern const QString kConfigGroup;
 
+extern const ConfigKey kKeyNotationConfigKey;
+
 extern const ConfigKey kSearchDebouncingTimeoutMillisConfigKey;
 
 extern const ConfigKey kEditMetadataSelectedClickConfigKey;

--- a/src/preferences/dialog/dlgprefkey.cpp
+++ b/src/preferences/dialog/dlgprefkey.cpp
@@ -5,6 +5,7 @@
 
 #include "analyzer/analyzerkey.h"
 #include "control/controlproxy.h"
+#include "library/library_prefs.h"
 #include "moc_dlgprefkey.cpp"
 #include "util/compatibility.h"
 #include "util/xml.h"
@@ -48,7 +49,7 @@ DlgPrefKey::DlgPrefKey(QWidget* parent, UserSettingsPointer pConfig)
         plugincombo->addItem(info.name(), info.id());
     }
 
-    m_pKeyNotation = new ControlProxy(ConfigKey("[Library]", "key_notation"), this);
+    m_pKeyNotation = new ControlProxy(mixxx::library::prefs::kKeyNotationConfigKey, this);
 
     loadSettings();
 

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -199,8 +199,8 @@ void DlgPrefLibrary::slotUpdate() {
             ConfigKey("[Library]","RescanOnStartup"), false));
     checkBox_SyncTrackMetadataExport->setChecked(
             m_pConfig->getValue(kSyncTrackMetadataExportConfigKey, false));
-    checkBox_SeratoMetadataExport->setChecked(m_pConfig->getValue(
-            ConfigKey("[Library]", "SeratoMetadataExport"), false));
+    checkBox_SeratoMetadataExport->setChecked(
+            m_pConfig->getValue(kSeratoMetadataExportConfigKey, false));
     checkBox_use_relative_path->setChecked(m_pConfig->getValue(
             ConfigKey("[Library]","UseRelativePathOnExport"), false));
     checkBox_show_rhythmbox->setChecked(m_pConfig->getValue(
@@ -367,8 +367,9 @@ void DlgPrefLibrary::slotApply() {
     m_pConfig->set(
             kSyncTrackMetadataExportConfigKey,
             ConfigValue{checkBox_SyncTrackMetadataExport->isChecked()});
-    m_pConfig->set(ConfigKey("[Library]", "SeratoMetadataExport"),
-            ConfigValue(static_cast<int>(checkBox_SeratoMetadataExport->isChecked())));
+    m_pConfig->set(
+            kSeratoMetadataExportConfigKey,
+            ConfigValue{checkBox_SeratoMetadataExport->isChecked()});
     m_pConfig->set(ConfigKey("[Library]","UseRelativePathOnExport"),
                 ConfigValue((int)checkBox_use_relative_path->isChecked()));
     m_pConfig->set(ConfigKey("[Library]","ShowRhythmboxLibrary"),

--- a/src/test/librarytest.cpp
+++ b/src/test/librarytest.cpp
@@ -1,5 +1,6 @@
 #include "test/librarytest.h"
 
+#include "library/library_prefs.h"
 #include "track/track.h"
 
 namespace {
@@ -31,7 +32,7 @@ std::unique_ptr<TrackCollectionManager> newTrackCollectionManager(
 LibraryTest::LibraryTest()
         : MixxxDbTest(kInMemoryDbConnection),
           m_pTrackCollectionManager(newTrackCollectionManager(config(), dbConnectionPooler())),
-          m_keyNotationCO(ConfigKey("[Library]", "key_notation")) {
+          m_keyNotationCO(mixxx::library::prefs::kKeyNotationConfigKey) {
 }
 
 TrackPointer LibraryTest::getOrAddTrackByLocation(

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -4,6 +4,7 @@
 #include <atomic>
 
 #include "engine/engine.h"
+#include "library/library_prefs.h"
 #include "moc_track.cpp"
 #include "sources/metadatasource.h"
 #include "track/beatfactory.h"
@@ -18,7 +19,6 @@ namespace {
 const mixxx::Logger kLogger("Track");
 
 constexpr bool kLogStats = false;
-const ConfigKey kConfigKeySeratoMetadataExport("[Library]", "SeratoMetadataExport");
 
 // Count the number of currently existing instances for detecting
 // memory leaks.
@@ -1457,7 +1457,7 @@ ExportTrackMetadataResult Track::exportMetadata(
         return ExportTrackMetadataResult::Skipped;
     }
 
-    if (pConfig->getValue<bool>(kConfigKeySeratoMetadataExport)) {
+    if (pConfig->getValue<bool>(mixxx::library::prefs::kSeratoMetadataExportConfigKey)) {
         const auto streamInfo = m_record.getStreamInfoFromSource();
         VERIFY_OR_DEBUG_ASSERT(streamInfo &&
                 streamInfo->getSignalInfo().isValid() &&

--- a/src/widget/wkey.cpp
+++ b/src/widget/wkey.cpp
@@ -1,5 +1,6 @@
 #include "widget/wkey.h"
 
+#include "library/library_prefs.h"
 #include "moc_wkey.cpp"
 #include "track/keys.h"
 #include "track/keyutils.h"
@@ -7,7 +8,7 @@
 WKey::WKey(const QString& group, QWidget* pParent)
         : WLabel(pParent),
           m_dOldValue(0),
-          m_keyNotation("[Library]", "key_notation", this),
+          m_keyNotation(mixxx::library::prefs::kKeyNotationConfigKey, this),
           m_engineKeyDistance(group,
                   "visual_key_distance",
                   this,

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -27,10 +27,21 @@
 
 namespace {
 
-const ConfigKey kConfigKeyAllowTrackLoadToPlayingDeck("[Controls]", "AllowTrackLoadToPlayingDeck");
+// ConfigValue key for QTable vertical scrollbar position
+const ConfigKey kVScrollBarPosConfigKey{
+        // mixxx::library::prefs::kConfigGroup is defined in another
+        // unit of compilation and cannot be reused here!
+        QStringLiteral("[Library]"),
+        QStringLiteral("VScrollBarPos")};
+
+const ConfigKey kConfigKeyAllowTrackLoadToPlayingDeck{
+        QStringLiteral("[Controls]"),
+        QStringLiteral("AllowTrackLoadToPlayingDeck")};
+
 // Default color for the focus border of TableItemDelegates
 const QColor kDefaultFocusBorderColor = Qt::white;
-} // namespace
+
+} // anonymous namespace
 
 WTrackTableView::WTrackTableView(QWidget* parent,
         UserSettingsPointer pConfig,
@@ -39,8 +50,7 @@ WTrackTableView::WTrackTableView(QWidget* parent,
         bool sorting)
         : WLibraryTableView(parent,
                   pConfig,
-                  ConfigKey(LIBRARY_CONFIGVALUE,
-                          WTRACKTABLEVIEW_VSCROLLBARPOS_KEY)),
+                  kVScrollBarPosConfigKey),
           m_pConfig(pConfig),
           m_pLibrary(pLibrary),
           m_backgroundColorOpacity(backgroundColorOpacity),

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -9,6 +9,7 @@
 #include "control/controlobject.h"
 #include "library/dao/trackschema.h"
 #include "library/library.h"
+#include "library/library_prefs.h"
 #include "library/librarytablemodel.h"
 #include "library/trackcollection.h"
 #include "library/trackcollectionmanager.h"
@@ -64,7 +65,7 @@ WTrackTableView::WTrackTableView(QWidget* parent,
     m_pCOTGuiTick = new ControlProxy("[Master]", "guiTick50ms", this);
     m_pCOTGuiTick->connectValueChanged(this, &WTrackTableView::slotGuiTick50ms);
 
-    m_pKeyNotation = new ControlProxy("[Library]", "key_notation", this);
+    m_pKeyNotation = new ControlProxy(mixxx::library::prefs::kKeyNotationConfigKey, this);
     m_pKeyNotation->connectValueChanged(this, &WTrackTableView::keyNotationChanged);
 
     m_pSortColumn = new ControlProxy("[Library]", "sort_column", this);

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -18,9 +18,6 @@ class ExternalTrackCollection;
 class Library;
 class WTrackMenu;
 
-const QString WTRACKTABLEVIEW_VSCROLLBARPOS_KEY = "VScrollBarPos"; /** ConfigValue key for QTable vertical scrollbar position */
-const QString LIBRARY_CONFIGVALUE = "[Library]"; /** ConfigValue "value" (wtf) for library stuff */
-
 class WTrackTableView : public WLibraryTableView {
     Q_OBJECT
   public:


### PR DESCRIPTION
Some trivial changes and cleanup.

Unfortunately, the "[Library]" config group is used for all kinds of settings, not only those that belong to the `Library` class.