### PR TITLE
SoundSourceFFmpeg + ReadAheadFrameBuffer: Debugging options

### DIFF
--- a/src/sources/readaheadframebuffer.cpp
+++ b/src/sources/readaheadframebuffer.cpp
@@ -3,8 +3,15 @@
 #include "util/logger.h"
 #include "util/sample.h"
 
+// Override or set to `true` to enable verbose debug logging.
 #if !defined(VERBOSE_DEBUG_LOG)
 #define VERBOSE_DEBUG_LOG false
+#endif
+
+// Override or set to `true` to break with a debug assertion
+// if an overlap or gap in the audio stream has been detected.
+#if !defined(DEBUG_ASSERT_ON_DISCONTINUITIES)
+#define DEBUG_ASSERT_ON_DISCONTINUITIES false
 #endif
 
 namespace mixxx {
@@ -135,6 +142,9 @@ ReadableSampleFrames ReadAheadFrameBuffer::fillBuffer(
                 << bufferedRange()
                 << "and input buffer"
                 << inputRange;
+#if DEBUG_ASSERT_ON_DISCONTINUITIES
+        DEBUG_ASSERT(!"Unexpected gap");
+#endif
         switch (discontinuityGapMode) {
         case DiscontinuityGapMode::Skip:
             reset(inputRange.start());
@@ -314,6 +324,9 @@ WritableSampleFrames ReadAheadFrameBuffer::consumeAndFillBuffer(
                     << outputRange
                     << "with input buffer"
                     << inputRange;
+#if DEBUG_ASSERT_ON_DISCONTINUITIES
+            DEBUG_ASSERT(!"Unexpected overlap");
+#endif
             switch (discontinuityOverlapMode) {
             case DiscontinuityOverlapMode::Ignore:
                 break;
@@ -345,6 +358,9 @@ WritableSampleFrames ReadAheadFrameBuffer::consumeAndFillBuffer(
                     << bufferedRange()
                     << "with input buffer"
                     << inputRange;
+#if DEBUG_ASSERT_ON_DISCONTINUITIES
+            DEBUG_ASSERT(!"Unexpected overlap");
+#endif
             switch (discontinuityOverlapMode) {
             case DiscontinuityOverlapMode::Ignore:
                 break;
@@ -397,6 +413,9 @@ WritableSampleFrames ReadAheadFrameBuffer::consumeAndFillBuffer(
                         << outputRange
                         << "and input buffer"
                         << inputRange;
+#if DEBUG_ASSERT_ON_DISCONTINUITIES
+                DEBUG_ASSERT(!"Unexpected gap");
+#endif
                 switch (discontinuityGapMode) {
                 case DiscontinuityGapMode::Skip:
                     break;

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -60,7 +60,7 @@ constexpr int64_t kavStreamDecoderFrameDelayAAC = 2112;
 // Use 0-based sample frame indexing
 constexpr SINT kMinFrameIndex = 0;
 
-constexpr SINT kSamplesPerMP3Frame = 1152;
+constexpr SINT kMaxSamplesPerMP3Frame = 1152;
 
 const Logger kLogger("SoundSourceFFmpeg");
 
@@ -106,7 +106,7 @@ inline int64_t getStreamStartTime(const AVStream& avStream) {
             // using the default start time.
             // Not all M4A files encode the start_time correctly, e.g.
             // the test file cover-test-itunes-12.7.0-aac.m4a has a valid
-            // start_time of 0. Unfortunately, this special case is cannot
+            // start_time of 0. Unfortunately, this special case cannot be
             // detected and compensated.
             start_time = math_max(kavStreamDefaultStartTime, kavStreamDecoderFrameDelayAAC);
             break;
@@ -185,7 +185,7 @@ SINT getStreamSeekPrerollFrameCount(const AVStream& avStream) {
         // slight deviations from the exact signal!
         DEBUG_ASSERT(avStream.codecpar->channels <= 2);
         const SINT mp3SeekPrerollFrameCount =
-                9 * (kSamplesPerMP3Frame / avStream.codecpar->channels);
+                9 * (kMaxSamplesPerMP3Frame / avStream.codecpar->channels);
         return math_max(mp3SeekPrerollFrameCount, defaultSeekPrerollFrameCount);
     }
     case AV_CODEC_ID_AAC:


### PR DESCRIPTION
Minor changes and extensions that will help to analyze https://bugs.launchpad.net/mixxx/+bug/1934785.