### PR TITLE
Add tool tips to sidebar tree items

### DIFF
--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -9,6 +9,7 @@
 #include "library/treeitem.h"
 #include "moc_sidebarmodel.cpp"
 #include "util/assert.h"
+#include "util/cmdlineargs.h"
 
 namespace {
 
@@ -258,10 +259,14 @@ QVariant SidebarModel::data(const QModelIndex& index, int role) const {
             if (pTreeItem->getData().toString() == QUICK_LINK_NODE) {
                 return pTreeItem->getLabel();
             } else {
-                if (pTreeItem->getToolTip().isEmpty()) {
+                if (!pTreeItem->getToolTip().isEmpty()) {
+                    return pTreeItem->getToolTip();
+                } else if (CmdlineArgs::Instance().getDeveloper()) {
+                    // Display the internal data only for debugging
                     return pTreeItem->getData();
                 } else {
-                    return pTreeItem->getToolTip();
+                    // No tool tip
+                    return {};
                 }
             }
         }

--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -257,8 +257,13 @@ QVariant SidebarModel::data(const QModelIndex& index, int role) const {
             // If it's the "Quick Links" node, display it's name
             if (pTreeItem->getData().toString() == QUICK_LINK_NODE) {
                 return pTreeItem->getLabel();
+            } else {
+                if (pTreeItem->getToolTip().isEmpty()) {
+                    return pTreeItem->getData();
+                } else {
+                    return pTreeItem->getToolTip();
+                }
             }
-            return pTreeItem->getData();
         }
         case Qt::FontRole: {
             QFont font;

--- a/src/library/treeitem.h
+++ b/src/library/treeitem.h
@@ -108,6 +108,13 @@ class TreeItem final {
         return m_label;
     }
 
+    void setToolTip(const QString& toolTip) {
+        m_toolTip = toolTip;
+    }
+    const QString& getToolTip() const {
+        return m_toolTip;
+    }
+
     void setData(const QVariant& data) {
         m_data = data;
     }
@@ -147,6 +154,7 @@ class TreeItem final {
     QList<TreeItem*> m_children; // owned child items
 
     QString m_label;
+    QString m_toolTip;
     QVariant m_data;
     QIcon m_icon;
     bool m_bold;

--- a/src/library/treeitemmodel.cpp
+++ b/src/library/treeitemmodel.cpp
@@ -52,6 +52,8 @@ QVariant TreeItemModel::data(const QModelIndex &index, int role) const {
     switch (role) {
     case Qt::DisplayRole:
         return item->getLabel();
+    case Qt::ToolTipRole:
+        return item->getToolTip();
     case kDataRole:
         return item->getData();
     case kBoldRole:
@@ -73,6 +75,9 @@ bool TreeItemModel::setData(const QModelIndex &a_rIndex,
     switch (a_iRole) {
     case Qt::DisplayRole:
         pItem->setLabel(a_rValue.toString());
+        break;
+    case Qt::ToolTipRole:
+        pItem->setToolTip(a_rValue.toString());
         break;
     case kDataRole:
         pItem->setData(a_rValue);


### PR DESCRIPTION
A byproduct from the aoide branch, simple and straightforward.

Could be added even though we will migrate to QML.