### PR TITLE
do not assume PortAudio on Linux was built with ALSA backend

### DIFF
--- a/cmake/modules/FindPortAudio.cmake
+++ b/cmake/modules/FindPortAudio.cmake
@@ -54,6 +54,12 @@ find_path(PortAudio_INCLUDE_DIR
   DOC "PortAudio include directory")
 mark_as_advanced(PortAudio_INCLUDE_DIR)
 
+# Temporary hack until https://github.com/PortAudio/portaudio/pull/635 is released.
+find_path(PortAudio_ALSA_H
+  NAMES pa_linux_alsa.h
+  PATHS ${PC_PortAudio_INCLUDE_DIRS})
+mark_as_advanced(PortAudio_ALSA_H)
+
 find_library(PortAudio_LIBRARY
   NAMES portaudio
   PATHS ${PC_PortAudio_LIBRARY_DIRS}
@@ -78,5 +84,8 @@ if(PortAudio_FOUND)
         INTERFACE_COMPILE_OPTIONS "${PC_PortAudio_CFLAGS_OTHER}"
         INTERFACE_INCLUDE_DIRECTORIES "${PortAudio_INCLUDE_DIR}"
     )
+    if(PortAudio_ALSA_H)
+      target_compile_definitions(PortAudio::PortAudio INTERFACE PA_USE_ALSA)
+    endif()
   endif()
 endif()

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -20,7 +20,7 @@
 #include "vinylcontrol/defs_vinylcontrol.h"
 #include "waveform/visualplayposition.h"
 
-#ifdef __LINUX__
+#ifdef PA_USE_ALSA
 // for PaAlsa_EnableRealtimeScheduling
 #include <pa_linux_alsa.h>
 #endif
@@ -333,8 +333,7 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
         qDebug() << "Opened PortAudio stream successfully... starting";
     }
 
-
-#ifdef __LINUX__
+#ifdef PA_USE_ALSA
     if (m_deviceTypeId == paALSA) {
         qInfo() << "Enabling ALSA real-time scheduling";
         PaAlsa_EnableRealtimeScheduling(pStream, 1);


### PR DESCRIPTION
hack around a PipeWire bug:
https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/1547