### PR TITLE
do not allow using keyboards and mice as HID controllers

### DIFF
--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -151,10 +151,8 @@ void HidController::guessDeviceCategory() {
     if (hid_interface_number==-1) {
         if (hid_usage_page==0x1) {
             switch (hid_usage) {
-                case 0x2: info = tr("Generic HID Mouse"); break;
                 case 0x4: info = tr("Generic HID Joystick"); break;
                 case 0x5: info = tr("Generic HID Gamepad"); break;
-                case 0x6: info = tr("Generic HID Keyboard"); break;
                 case 0x8: info = tr("Generic HID Multiaxis Controller"); break;
                 default: info = tr("Unknown HID Desktop Device") +
                     QStringLiteral(" 0x") + QString::number(hid_usage_page, 16) +

--- a/src/controllers/hid/hiddenylist.h
+++ b/src/controllers/hid/hiddenylist.h
@@ -15,3 +15,8 @@ hid_denylist_t hid_denylisted[] = {
         {0x1157, 0x300, 0x1, 0x2, -1},   // EKS Otus mouse pad (OS/X,windows)
         {0x1157, 0x300, 0x0, 0x0, 0x3},  // EKS Otus mouse pad (linux)
 };
+
+constexpr unsigned short kGenericDesktopUsagePage = 0x01;
+
+constexpr unsigned short kGenericDesktopMouseUsage = 0x02;
+constexpr unsigned short kGenericDesktopKeyboardUsage = 0x06;

--- a/src/controllers/hid/hidenumerator.cpp
+++ b/src/controllers/hid/hidenumerator.cpp
@@ -8,6 +8,16 @@
 namespace {
 
 bool recognizeDevice(const hid_device_info& device_info) {
+    // Skip mice and keyboards. Users can accidentally disable their mouse
+    // and/or keyboard by enabling them as HID controllers in Mixxx.
+    // https://bugs.launchpad.net/mixxx/+bug/1940599
+    if (device_info.usage_page == kGenericDesktopUsagePage &&
+            (device_info.usage == kGenericDesktopMouseUsage ||
+                    device_info.usage == kGenericDesktopKeyboardUsage)) {
+        return false;
+    }
+
+    // Exclude specific devices from the denylist.
     bool interface_number_valid = device_info.interface_number != -1;
     const int denylist_len = sizeof(hid_denylisted) / sizeof(hid_denylisted[0]);
     for (int bl_index = 0; bl_index < denylist_len; bl_index++) {


### PR DESCRIPTION
Enabling a keyboard or mouse as an HID controller makes it stop
working as a keyboard or mouse.