### PR TITLE
lp1934785 SoundSourceFFmpeg: Ignore inaudible samples before start of stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Fix performance issue on AArch64 by enabling flush-to-zero for floating-point arithmetic [#4144](https://github.com/mixxxdj/mixxx/pull/4144)
 * Fix custom key notation not restored correctly after restart [#4136](https://github.com/mixxxdj/mixxx/pull/4136)
 * Traktor S3: Disable scratch when switching decks to prevent locked scratch issue [#4073](https://github.com/mixxxdj/mixxx/pull/4073)
+* FFmpeg: Ignore inaudible samples before start of stream [#4245](https://github.com/mixxxdj/mixxx/pull/4245)
 
 ### Packaging
 

--- a/src/sources/readaheadframebuffer.cpp
+++ b/src/sources/readaheadframebuffer.cpp
@@ -3,8 +3,15 @@
 #include "util/logger.h"
 #include "util/sample.h"
 
+// Override or set to `true` to enable verbose debug logging.
 #if !defined(VERBOSE_DEBUG_LOG)
 #define VERBOSE_DEBUG_LOG false
+#endif
+
+// Override or set to `true` to break with a debug assertion
+// if an overlap or gap in the audio stream has been detected.
+#if !defined(DEBUG_ASSERT_ON_DISCONTINUITIES)
+#define DEBUG_ASSERT_ON_DISCONTINUITIES false
 #endif
 
 namespace mixxx {
@@ -135,6 +142,9 @@ ReadableSampleFrames ReadAheadFrameBuffer::fillBuffer(
                 << bufferedRange()
                 << "and input buffer"
                 << inputRange;
+#if DEBUG_ASSERT_ON_DISCONTINUITIES
+        DEBUG_ASSERT(!"Unexpected gap");
+#endif
         switch (discontinuityGapMode) {
         case DiscontinuityGapMode::Skip:
             reset(inputRange.start());
@@ -314,6 +324,9 @@ WritableSampleFrames ReadAheadFrameBuffer::consumeAndFillBuffer(
                     << outputRange
                     << "with input buffer"
                     << inputRange;
+#if DEBUG_ASSERT_ON_DISCONTINUITIES
+            DEBUG_ASSERT(!"Unexpected overlap");
+#endif
             switch (discontinuityOverlapMode) {
             case DiscontinuityOverlapMode::Ignore:
                 break;
@@ -345,6 +358,9 @@ WritableSampleFrames ReadAheadFrameBuffer::consumeAndFillBuffer(
                     << bufferedRange()
                     << "with input buffer"
                     << inputRange;
+#if DEBUG_ASSERT_ON_DISCONTINUITIES
+            DEBUG_ASSERT(!"Unexpected overlap");
+#endif
             switch (discontinuityOverlapMode) {
             case DiscontinuityOverlapMode::Ignore:
                 break;
@@ -397,6 +413,9 @@ WritableSampleFrames ReadAheadFrameBuffer::consumeAndFillBuffer(
                         << outputRange
                         << "and input buffer"
                         << inputRange;
+#if DEBUG_ASSERT_ON_DISCONTINUITIES
+                DEBUG_ASSERT(!"Unexpected gap");
+#endif
                 switch (discontinuityGapMode) {
                 case DiscontinuityGapMode::Skip:
                     break;

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -1225,6 +1225,11 @@ ReadableSampleFrames SoundSourceFFmpeg::readSampleFramesClamped(
             // Housekeeping before next decoding iteration
             av_frame_unref(m_pavDecodedFrame);
             av_frame_unref(m_pavResampledFrame);
+
+            // The first loop condition (see below) should always be true
+            // and has only been added to prevent infinite looping in case
+            // of unexpected result values.
+            DEBUG_ASSERT(avcodec_receive_frame_result == 0);
         } while (avcodec_receive_frame_result == 0 &&
                 m_frameBuffer.isValid());
     }

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -60,7 +60,7 @@ constexpr int64_t kavStreamDecoderFrameDelayAAC = 2112;
 // Use 0-based sample frame indexing
 constexpr SINT kMinFrameIndex = 0;
 
-constexpr SINT kSamplesPerMP3Frame = 1152;
+constexpr SINT kMaxSamplesPerMP3Frame = 1152;
 
 const Logger kLogger("SoundSourceFFmpeg");
 
@@ -106,7 +106,7 @@ inline int64_t getStreamStartTime(const AVStream& avStream) {
             // using the default start time.
             // Not all M4A files encode the start_time correctly, e.g.
             // the test file cover-test-itunes-12.7.0-aac.m4a has a valid
-            // start_time of 0. Unfortunately, this special case is cannot
+            // start_time of 0. Unfortunately, this special case cannot be
             // detected and compensated.
             start_time = math_max(kavStreamDefaultStartTime, kavStreamDecoderFrameDelayAAC);
             break;
@@ -185,7 +185,7 @@ SINT getStreamSeekPrerollFrameCount(const AVStream& avStream) {
         // slight deviations from the exact signal!
         DEBUG_ASSERT(avStream.codecpar->channels <= 2);
         const SINT mp3SeekPrerollFrameCount =
-                9 * (kSamplesPerMP3Frame / avStream.codecpar->channels);
+                9 * (kMaxSamplesPerMP3Frame / avStream.codecpar->channels);
         return math_max(mp3SeekPrerollFrameCount, defaultSeekPrerollFrameCount);
     }
     case AV_CODEC_ID_AAC:

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -1052,6 +1052,13 @@ ReadableSampleFrames SoundSourceFFmpeg::readSampleFramesClamped(
 #if VERBOSE_DEBUG_LOG
                 avTrace("Received decoded frame", *m_pavDecodedFrame);
 #endif
+                VERIFY_OR_DEBUG_ASSERT(
+                        (m_pavDecodedFrame->flags &
+                                (AV_FRAME_FLAG_CORRUPT |
+                                        AV_FRAME_FLAG_DISCARD)) == 0) {
+                    av_frame_unref(m_pavDecodedFrame);
+                    continue;
+                }
                 const auto decodedFrameCount = m_pavDecodedFrame->nb_samples;
                 DEBUG_ASSERT(decodedFrameCount > 0);
                 auto streamFrameIndex =


### PR DESCRIPTION
The documentation of FFmpeg is lacking. This is defined nowhere and I also didn't find any examples that handle this case.

Reporting of inaudible samples might have been introduced by FFmpeg 4.4, either deliberately or accidentally. That's probably the reason why we didn't notice any issues with earlier versions.

Fixes https://bugs.launchpad.net/mixxx/+bug/1934785