### PR TITLE
Improve Hercules inpulse 300 mappings

### DIFF
--- a/res/controllers/Hercules_DJControl_Inpulse_300.midi.xml
+++ b/res/controllers/Hercules_DJControl_Inpulse_300.midi.xml
@@ -1683,6 +1683,19 @@
 				</options>
 			</control>
 
+			<!-- CC's MIDI Channel 4 (0xB3 Browser encoder SHIFT mode either one)-->
+			<!--Browser encoder-->
+			<control>
+				<group>[Library]</group>
+				<key>MoveHorizontal</key>
+				<description>Move Horizontal (Browser Knob)</description>
+				<status>0xB3</status>
+				<midino>0x01</midino>
+				<options>
+					<selectknob />
+				</options>
+			</control>
+
 			<!-- CC's MIDI Channel 2 (0xB1 Deck A - Standard mode)-->
 
 			<!-- Volume-->
@@ -1961,7 +1974,7 @@
 				</options>
 			</control>
 
-			<!-- CC's MIDI Channel 5 (0xB4  Deck B - SHIFT mode)-->
+			<!-- CC's MIDI Channel 5 (0xB4  Deck A - SHIFT mode)-->
 			<!--Jog wheel-->
 			<control>
 				<group>[Channel1]</group>

--- a/res/controllers/Hercules_DJControl_Inpulse_300.midi.xml
+++ b/res/controllers/Hercules_DJControl_Inpulse_300.midi.xml
@@ -710,11 +710,52 @@
 				</options>
 			</control>
 			<control>
+				<group>[EffectRack1_EffectUnit1_Effect1]</group>
+				<key>next_effect</key>
+				<description>FX Unit 1 - Slot 1 next effect</description>
+				<status>0x96</status>
+				<midino>0x54</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit1_Effect2]</group>
+				<key>next_effect</key>
+				<description>FX Unit 1 - Slot 2 next effect</description>
+				<status>0x96</status>
+				<midino>0x55</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit1_Effect3]</group>
+				<key>next_effect</key>
+				<description>FX Unit 1 - Slot 3 next effect</description>
+				<status>0x96</status>
+				<midino>0x56</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit2]</group>
+				<key>group_[Channel1]_enable</key>
+				<description>FX Unit 2 On/Off - Deck A</description>
+				<status>0x96</status>
+				<midino>0x57</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<!--FX Pads (SHIFT mode) 0x58-0x5F -->
+			<control>
 				<group>[EffectRack1_EffectUnit3_Effect1]</group>
 				<key>enabled</key>
 				<description>FX Unit 3 - Slot 1 On/Off</description>
 				<status>0x96</status>
-				<midino>0x54</midino>
+				<midino>0x58</midino>
 				<options>
 					<normal />
 				</options>
@@ -724,7 +765,7 @@
 				<key>enabled</key>
 				<description>FX Unit 3 - Slot 2 On/Off</description>
 				<status>0x96</status>
-				<midino>0x55</midino>
+				<midino>0x59</midino>
 				<options>
 					<normal />
 				</options>
@@ -734,7 +775,7 @@
 				<key>enabled</key>
 				<description>FX Unit 3 - Slot 3 On/Off</description>
 				<status>0x96</status>
-				<midino>0x56</midino>
+				<midino>0x5A</midino>
 				<options>
 					<normal />
 				</options>
@@ -744,47 +785,6 @@
 				<key>group_[Channel1]_enable</key>
 				<description>FX Unit 3 On/Off - Deck A</description>
 				<status>0x96</status>
-				<midino>0x57</midino>
-				<options>
-					<normal />
-				</options>
-			</control>
-			<!--FX Pads (SHIFT mode) 0x58-0x5F -->
-			<control>
-				<group>[EffectRack1_EffectUnit1_Effect1]</group>
-				<key>enabled</key>
-				<description>FX Unit 1 - Slot 1 On/Off</description>
-				<status>0x96</status>
-				<midino>0x58</midino>
-				<options>
-					<normal />
-				</options>
-			</control>
-			<control>
-				<group>[EffectRack1_EffectUnit1_Effect2]</group>
-				<key>enabled</key>
-				<description>FX Unit 1 - Slot 2 On/Off</description>
-				<status>0x96</status>
-				<midino>0x59</midino>
-				<options>
-					<normal />
-				</options>
-			</control>
-			<control>
-				<group>[EffectRack1_EffectUnit1_Effect3]</group>
-				<key>enabled</key>
-				<description>FX Unit 1 - Slot 3 On/Off</description>
-				<status>0x96</status>
-				<midino>0x5A</midino>
-				<options>
-					<normal />
-				</options>
-			</control>
-			<control>
-				<group>[EffectRack1_EffectUnit1]</group>
-				<key>group_[Channel2]_enable</key>
-				<description>FX Unit 1 On/Off - Deck B</description>
-				<status>0x96</status>
 				<midino>0x5B</midino>
 				<options>
 					<normal />
@@ -792,8 +792,8 @@
 			</control>
 			<control>
 				<group>[EffectRack1_EffectUnit3_Effect1]</group>
-				<key>enabled</key>
-				<description>FX Unit 3 - Slot 1 On/Off</description>
+				<key>next_effect</key>
+				<description>FX Unit 3 - Slot 1 next effect</description>
 				<status>0x96</status>
 				<midino>0x5C</midino>
 				<options>
@@ -802,8 +802,8 @@
 			</control>
 			<control>
 				<group>[EffectRack1_EffectUnit3_Effect2]</group>
-				<key>enabled</key>
-				<description>FX Unit 3 - Slot 2 On/Off</description>
+				<key>next_effect</key>
+				<description>FX Unit 3 - Slot 2 next effect</description>
 				<status>0x96</status>
 				<midino>0x5D</midino>
 				<options>
@@ -812,8 +812,8 @@
 			</control>
 			<control>
 				<group>[EffectRack1_EffectUnit3_Effect3]</group>
-				<key>enabled</key>
-				<description>FX Unit 3 - Slot 3 On/Off</description>
+				<key>next_effect</key>
+				<description>FX Unit 3 - Slot 3 next effect</description>
 				<status>0x96</status>
 				<midino>0x5E</midino>
 				<options>
@@ -821,9 +821,9 @@
 				</options>
 			</control>
 			<control>
-				<group>[EffectRack1_EffectUnit3]</group>
-				<key>group_[Channel2]_enable</key>
-				<description>FX Unit 3 On/Off - Deck B</description>
+				<group>[EffectRack1_EffectUnit4]</group>
+				<key>group_[Channel1]_enable</key>
+				<description>FX Unit 4 On/Off - Deck A</description>
 				<status>0x96</status>
 				<midino>0x5F</midino>
 				<options>
@@ -1277,9 +1277,9 @@
 				</options>
 			</control>
 			<control>
-				<group>[EffectRack1_EffectUnit2]</group>
+				<group>[EffectRack1_EffectUnit1]</group>
 				<key>group_[Channel2]_enable</key>
-				<description>FX Unit 2 On/Off - Deck B</description>
+				<description>FX Unit 1 On/Off - Deck B</description>
 				<status>0x97</status>
 				<midino>0x53</midino>
 				<options>
@@ -1287,9 +1287,9 @@
 				</options>
 			</control>
 			<control>
-				<group>[EffectRack1_EffectUnit4_Effect1]</group>
-				<key>enabled</key>
-				<description>FX Unit 4 - Slot 1 On/Off</description>
+				<group>[EffectRack1_EffectUnit2_Effect1]</group>
+				<key>next_effect</key>
+				<description>FX Unit 2 - Slot 1 next effect</description>
 				<status>0x97</status>
 				<midino>0x54</midino>
 				<options>
@@ -1297,9 +1297,9 @@
 				</options>
 			</control>
 			<control>
-				<group>[EffectRack1_EffectUnit4_Effect2]</group>
-				<key>enabled</key>
-				<description>FX Unit 4 - Slot 2 On/Off</description>
+				<group>[EffectRack1_EffectUnit2_Effect2]</group>
+				<key>next_effect</key>
+				<description>FX Unit 2 - Slot 2 next effect</description>
 				<status>0x97</status>
 				<midino>0x55</midino>
 				<options>
@@ -1307,9 +1307,9 @@
 				</options>
 			</control>
 			<control>
-				<group>[EffectRack1_EffectUnit4_Effect3]</group>
-				<key>enabled</key>
-				<description>FX Unit 4 - Slot 3 On/Off</description>
+				<group>[EffectRack1_EffectUnit2_Effect3]</group>
+				<key>next_effect</key>
+				<description>FX Unit 2 - Slot 3 next effect</description>
 				<status>0x97</status>
 				<midino>0x56</midino>
 				<options>
@@ -1317,9 +1317,9 @@
 				</options>
 			</control>
 			<control>
-				<group>[EffectRack1_EffectUnit4]</group>
+				<group>[EffectRack1_EffectUnit2]</group>
 				<key>group_[Channel2]_enable</key>
-				<description>FX Unit 4 On/Off - Deck A</description>
+				<description>FX Unit 2 On/Off - Deck B</description>
 				<status>0x97</status>
 				<midino>0x57</midino>
 				<options>
@@ -1328,51 +1328,11 @@
 			</control>
 			<!--FX Pads (SHIFT mode) 0x58-0x5F -->
 			<control>
-				<group>[EffectRack1_EffectUnit2_Effect1]</group>
-				<key>enabled</key>
-				<description>FX Unit 2 - Slot 1 On/Off</description>
-				<status>0x97</status>
-				<midino>0x58</midino>
-				<options>
-					<normal />
-				</options>
-			</control>
-			<control>
-				<group>[EffectRack1_EffectUnit2_Effect2]</group>
-				<key>enabled</key>
-				<description>FX Unit 2 - Slot 2 On/Off</description>
-				<status>0x97</status>
-				<midino>0x59</midino>
-				<options>
-					<normal />
-				</options>
-			</control>
-			<control>
-				<group>[EffectRack1_EffectUnit2_Effect3]</group>
-				<key>enabled</key>
-				<description>FX Unit 2 - Slot 3 On/Off</description>
-				<status>0x97</status>
-				<midino>0x5A</midino>
-				<options>
-					<normal />
-				</options>
-			</control>
-			<control>
-				<group>[EffectRack1_EffectUnit2]</group>
-				<key>group_[Channel1]_enable</key>
-				<description>FX Unit 2 On/Off - Deck A</description>
-				<status>0x97</status>
-				<midino>0x5B</midino>
-				<options>
-					<normal />
-				</options>
-			</control>
-			<control>
 				<group>[EffectRack1_EffectUnit4_Effect1]</group>
 				<key>enabled</key>
 				<description>FX Unit 4 - Slot 1 On/Off</description>
 				<status>0x97</status>
-				<midino>0x5C</midino>
+				<midino>0x58</midino>
 				<options>
 					<normal />
 				</options>
@@ -1382,7 +1342,7 @@
 				<key>enabled</key>
 				<description>FX Unit 4 - Slot 2 On/Off</description>
 				<status>0x97</status>
-				<midino>0x5D</midino>
+				<midino>0x59</midino>
 				<options>
 					<normal />
 				</options>
@@ -1392,6 +1352,46 @@
 				<key>enabled</key>
 				<description>FX Unit 4 - Slot 3 On/Off</description>
 				<status>0x97</status>
+				<midino>0x5A</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit3]</group>
+				<key>group_[Channel2]_enable</key>
+				<description>FX Unit 3 On/Off - Deck B</description>
+				<status>0x97</status>
+				<midino>0x5B</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit4_Effect1]</group>
+				<key>next_effect</key>
+				<description>FX Unit 4 - Slot 1 next effect</description>
+				<status>0x97</status>
+				<midino>0x5C</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit4_Effect2]</group>
+				<key>next_effect</key>
+				<description>FX Unit 4 - Slot 2 next effect</description>
+				<status>0x97</status>
+				<midino>0x5D</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit4_Effect3]</group>
+				<key>next_effect</key>
+				<description>FX Unit 4 - Slot 3 next effect</description>
+				<status>0x97</status>
 				<midino>0x5E</midino>
 				<options>
 					<normal />
@@ -1399,8 +1399,8 @@
 			</control>
 			<control>
 				<group>[EffectRack1_EffectUnit4]</group>
-				<key>group_[Channel1]_enable</key>
-				<description>FX Unit 4 On/Off - Deck A</description>
+				<key>group_[Channel2]_enable</key>
+				<description>FX Unit 4 On/Off - Deck B</description>
 				<status>0x97</status>
 				<midino>0x5F</midino>
 				<options>
@@ -2773,13 +2773,53 @@
 				<on>0x7f</on>
 			</output>
 			<output>
+				<group>[EffectRack1_EffectUnit1_Effect1]</group>
+				<key>next_effect</key>
+				<description>FX1 Effect 1 next effect</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x96</status>
+				<midino>0x54</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit1_Effect2]</group>
+				<key>next_effect</key>
+				<description>FX1 Effect 2 next effect</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x96</status>
+				<midino>0x55</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit1_Effect3]</group>
+				<key>next_effect</key>
+				<description>FX1 Effect 1 next effect</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x96</status>
+				<midino>0x56</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit1]</group>
+				<key>group_[Channel1]_enable</key>
+				<description>FX2 is active on Deck A</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x96</status>
+				<midino>0x57</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
 				<group>[EffectRack1_EffectUnit3_Effect1]</group>
 				<key>enabled</key>
 				<description>FX3 Effect 1 activate</description>
 				<minimum>0.5</minimum>
 				<maximum>1</maximum>
 				<status>0x96</status>
-				<midino>0x54</midino>
+				<midino>0x58</midino>
 				<on>0x7f</on>
 			</output>
 			<output>
@@ -2789,7 +2829,7 @@
 				<minimum>0.5</minimum>
 				<maximum>1</maximum>
 				<status>0x96</status>
-				<midino>0x55</midino>
+				<midino>0x59</midino>
 				<on>0x7f</on>
 			</output>
 			<output>
@@ -2799,7 +2839,7 @@
 				<minimum>0.5</minimum>
 				<maximum>1</maximum>
 				<status>0x96</status>
-				<midino>0x56</midino>
+				<midino>0x5A</midino>
 				<on>0x7f</on>
 			</output>
 			<output>
@@ -2809,53 +2849,13 @@
 				<minimum>0.5</minimum>
 				<maximum>1</maximum>
 				<status>0x96</status>
-				<midino>0x57</midino>
-				<on>0x7f</on>
-			</output>
-			<output>
-				<group>[EffectRack1_EffectUnit1_Effect1]</group>
-				<key>enabled</key>
-				<description>FX1 Effect 1 activate</description>
-				<minimum>0.5</minimum>
-				<maximum>1</maximum>
-				<status>0x96</status>
-				<midino>0x58</midino>
-				<on>0x7f</on>
-			</output>
-			<output>
-				<group>[EffectRack1_EffectUnit1_Effect2]</group>
-				<key>enabled</key>
-				<description>FX1 Effect 2 activate</description>
-				<minimum>0.5</minimum>
-				<maximum>1</maximum>
-				<status>0x96</status>
-				<midino>0x59</midino>
-				<on>0x7f</on>
-			</output>
-			<output>
-				<group>[EffectRack1_EffectUnit1_Effect3]</group>
-				<key>enabled</key>
-				<description>FX1 Effect 3 activate</description>
-				<minimum>0.5</minimum>
-				<maximum>1</maximum>
-				<status>0x96</status>
-				<midino>0x5A</midino>
-				<on>0x7f</on>
-			</output>
-			<output>
-				<group>[EffectRack1_EffectUnit1]</group>
-				<key>group_[Channel2]_enable</key>
-				<description>FX1 is active on Deck B</description>
-				<minimum>0.5</minimum>
-				<maximum>1</maximum>
-				<status>0x96</status>
 				<midino>0x5B</midino>
 				<on>0x7f</on>
 			</output>
 			<output>
 				<group>[EffectRack1_EffectUnit3_Effect1]</group>
-				<key>enabled</key>
-				<description>FX3 Effect 1 activate</description>
+				<key>next_effect</key>
+				<description>FX3 Effect 1 next effect</description>
 				<minimum>0.5</minimum>
 				<maximum>1</maximum>
 				<status>0x96</status>
@@ -2864,8 +2864,8 @@
 			</output>
 			<output>
 				<group>[EffectRack1_EffectUnit3_Effect2]</group>
-				<key>enabled</key>
-				<description>FX3 Effect 2 activate</description>
+				<key>next_effect</key>
+				<description>FX3 Effect 2 next effect</description>
 				<minimum>0.5</minimum>
 				<maximum>1</maximum>
 				<status>0x96</status>
@@ -2874,8 +2874,8 @@
 			</output>
 			<output>
 				<group>[EffectRack1_EffectUnit3_Effect3]</group>
-				<key>enabled</key>
-				<description>FX3 Effect 3 activate</description>
+				<key>next_effect</key>
+				<description>FX3 Effect 3 next_effect</description>
 				<minimum>0.5</minimum>
 				<maximum>1</maximum>
 				<status>0x96</status>
@@ -2883,9 +2883,9 @@
 				<on>0x7f</on>
 			</output>
 			<output>
-				<group>[EffectRack1_EffectUnit3]</group>
+				<group>[EffectRack1_EffectUnit4]</group>
 				<key>group_[Channel1]_enable</key>
-				<description>FX3 is active on Deck B</description>
+				<description>FX4 is active on Deck A</description>
 				<minimum>0.5</minimum>
 				<maximum>1</maximum>
 				<status>0x96</status>
@@ -2924,13 +2924,53 @@
 				<on>0x7f</on>
 			</output>
 			<output>
+				<group>[EffectRack1_EffectUnit1]</group>
+				<key>group_[Channel2]_enable</key>
+				<description>FX1 is active on Deck B</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x97</status>
+				<midino>0x53</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit2_Effect1]</group>
+				<key>next_effect</key>
+				<description>FX2 Effect 1 next effect</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x97</status>
+				<midino>0x54</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit2_Effect2]</group>
+				<key>next_effect</key>
+				<description>FX2 Effect 2 next effect</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x97</status>
+				<midino>0x55</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit2_Effect3]</group>
+				<key>next_effect</key>
+				<description>FX2 Effect 3 next effect</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x97</status>
+				<midino>0x56</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
 				<group>[EffectRack1_EffectUnit2]</group>
 				<key>group_[Channel2]_enable</key>
 				<description>FX2 is active on Deck B</description>
 				<minimum>0.5</minimum>
 				<maximum>1</maximum>
 				<status>0x97</status>
-				<midino>0x53</midino>
+				<midino>0x57</midino>
 				<on>0x7f</on>
 			</output>
 			<output>
@@ -2940,7 +2980,7 @@
 				<minimum>0.5</minimum>
 				<maximum>1</maximum>
 				<status>0x97</status>
-				<midino>0x54</midino>
+				<midino>0x58</midino>
 				<on>0x7f</on>
 			</output>
 			<output>
@@ -2950,7 +2990,7 @@
 				<minimum>0.5</minimum>
 				<maximum>1</maximum>
 				<status>0x97</status>
-				<midino>0x55</midino>
+				<midino>0x59</midino>
 				<on>0x7f</on>
 			</output>
 			<output>
@@ -2960,53 +3000,13 @@
 				<minimum>0.5</minimum>
 				<maximum>1</maximum>
 				<status>0x97</status>
-				<midino>0x56</midino>
-				<on>0x7f</on>
-			</output>
-			<output>
-				<group>[EffectRack1_EffectUnit4]</group>
-				<key>group_[Channel2]_enable</key>
-				<description>FX4 is active on Deck B</description>
-				<minimum>0.5</minimum>
-				<maximum>1</maximum>
-				<status>0x97</status>
-				<midino>0x57</midino>
-				<on>0x7f</on>
-			</output>
-			<output>
-				<group>[EffectRack1_EffectUnit2_Effect1]</group>
-				<key>enabled</key>
-				<description>FX2 Effect 1 activate</description>
-				<minimum>0.5</minimum>
-				<maximum>1</maximum>
-				<status>0x97</status>
-				<midino>0x58</midino>
-				<on>0x7f</on>
-			</output>
-			<output>
-				<group>[EffectRack1_EffectUnit2_Effect2]</group>
-				<key>enabled</key>
-				<description>FX2 Effect 2 activate</description>
-				<minimum>0.5</minimum>
-				<maximum>1</maximum>
-				<status>0x97</status>
-				<midino>0x59</midino>
-				<on>0x7f</on>
-			</output>
-			<output>
-				<group>[EffectRack1_EffectUnit2_Effect3]</group>
-				<key>enabled</key>
-				<description>FX2 Effect 3 activate</description>
-				<minimum>0.5</minimum>
-				<maximum>1</maximum>
-				<status>0x97</status>
 				<midino>0x5A</midino>
 				<on>0x7f</on>
 			</output>
 			<output>
-				<group>[EffectRack1_EffectUnit2]</group>
-				<key>group_[Channel1]_enable</key>
-				<description>FX2 is active on Deck A</description>
+				<group>[EffectRack1_EffectUnit3]</group>
+				<key>group_[Channel2]_enable</key>
+				<description>FX3 is active on Deck A</description>
 				<minimum>0.5</minimum>
 				<maximum>1</maximum>
 				<status>0x97</status>
@@ -3015,8 +3015,8 @@
 			</output>
 			<output>
 				<group>[EffectRack1_EffectUnit4_Effect1]</group>
-				<key>enabled</key>
-				<description>FX4 Effect 1 activate</description>
+				<key>next_effect</key>
+				<description>FX4 Effect 1 next effect</description>
 				<minimum>0.5</minimum>
 				<maximum>1</maximum>
 				<status>0x97</status>
@@ -3025,7 +3025,7 @@
 			</output>
 			<output>
 				<group>[EffectRack1_EffectUnit4_Effect2]</group>
-				<key>enabled</key>
+				<key>next_effect</key>
 				<description>FX4 Effect 2 activate</description>
 				<minimum>0.5</minimum>
 				<maximum>1</maximum>
@@ -3035,8 +3035,8 @@
 			</output>
 			<output>
 				<group>[EffectRack1_EffectUnit4_Effect3]</group>
-				<key>enabled</key>
-				<description>FX4 Effect 3 activate</description>
+				<key>next_effect</key>
+				<description>FX4 Effect 3 next effect</description>
 				<minimum>0.5</minimum>
 				<maximum>1</maximum>
 				<status>0x97</status>
@@ -3045,8 +3045,8 @@
 			</output>
 			<output>
 				<group>[EffectRack1_EffectUnit4]</group>
-				<key>group_[Channel1]_enable</key>
-				<description>FX4 is active on Deck A</description>
+				<key>group_[Channel2]_enable</key>
+				<description>FX4 is active on Deck B</description>
 				<minimum>0.5</minimum>
 				<maximum>1</maximum>
 				<status>0x97</status>

--- a/res/controllers/Hercules_DJControl_Inpulse_300.midi.xml
+++ b/res/controllers/Hercules_DJControl_Inpulse_300.midi.xml
@@ -884,7 +884,7 @@
 			<control>
 				<group>[Channel1]</group>
 				<key>beatlooproll_4_activate</key>
-				<description>Loop 2 Beat (Pad 6)</description>
+				<description>Loop 4 Beat (Pad 6)</description>
 				<status>0x96</status>
 				<midino>0x15</midino>
 				<options>
@@ -904,7 +904,7 @@
 			<control>
 				<group>[Channel1]</group>
 				<key>beatlooproll_16_activate</key>
-				<description>Loop 2 Beat (Pad 8)</description>
+				<description>Loop 16 Beat (Pad 8)</description>
 				<status>0x96</status>
 				<midino>0x17</midino>
 				<options>
@@ -1461,7 +1461,7 @@
 			<control>
 				<group>[Channel2]</group>
 				<key>beatlooproll_4_activate</key>
-				<description>Loop 2 Beat (Pad 6)</description>
+				<description>Loop 4 Beat (Pad 6)</description>
 				<status>0x97</status>
 				<midino>0x15</midino>
 				<options>
@@ -1481,7 +1481,7 @@
 			<control>
 				<group>[Channel2]</group>
 				<key>beatlooproll_16_activate</key>
-				<description>Loop 2 Beat (Pad 8)</description>
+				<description>Loop 16 Beat (Pad 8)</description>
 				<status>0x97</status>
 				<midino>0x17</midino>
 				<options>
@@ -1490,7 +1490,7 @@
 			</control>
 			<!--Sampler-->
 			<control>
-				<group>[Sampler1]</group>
+				<group>[Sampler9]</group>
 				<key>cue_gotoandplay</key>
 				<description>PAD 1</description>
 				<status>0x97</status>
@@ -1500,7 +1500,7 @@
 				</options>
 			</control>
 			<control>
-				<group>[Sampler2]</group>
+				<group>[Sampler10]</group>
 				<key>cue_gotoandplay</key>
 				<description>PAD 2</description>
 				<status>0x97</status>
@@ -1510,7 +1510,7 @@
 				</options>
 			</control>
 			<control>
-				<group>[Sampler3]</group>
+				<group>[Sampler11]</group>
 				<key>cue_gotoandplay</key>
 				<description>PAD 3</description>
 				<status>0x97</status>
@@ -1520,7 +1520,7 @@
 				</options>
 			</control>
 			<control>
-				<group>[Sampler4]</group>
+				<group>[Sampler12]</group>
 				<key>cue_gotoandplay</key>
 				<description>PAD 1</description>
 				<status>0x97</status>
@@ -1530,7 +1530,7 @@
 				</options>
 			</control>
 			<control>
-				<group>[Sampler5]</group>
+				<group>[Sampler13]</group>
 				<key>cue_gotoandplay</key>
 				<description>PAD 5</description>
 				<status>0x97</status>
@@ -1540,7 +1540,7 @@
 				</options>
 			</control>
 			<control>
-				<group>[Sampler6]</group>
+				<group>[Sampler14]</group>
 				<key>cue_gotoandplay</key>
 				<description>PAD 6</description>
 				<status>0x97</status>
@@ -1550,7 +1550,7 @@
 				</options>
 			</control>
 			<control>
-				<group>[Sampler7]</group>
+				<group>[Sampler15]</group>
 				<key>cue_gotoandplay</key>
 				<description>PAD 7</description>
 				<status>0x97</status>
@@ -1560,7 +1560,7 @@
 				</options>
 			</control>
 			<control>
-				<group>[Sampler8]</group>
+				<group>[Sampler16]</group>
 				<key>cue_gotoandplay</key>
 				<description>PAD 8</description>
 				<status>0x97</status>
@@ -3064,7 +3064,7 @@
 				<minimum>0.5</minimum>
 			</output>
 			<output>
-				<group>[Sampler1]</group>
+				<group>[Sampler9]</group>
 				<key>play_indicator</key>
 				<description>(Pad 1 DECK B)</description>
 				<status>0x97</status>
@@ -3082,7 +3082,7 @@
 				<minimum>0.5</minimum>
 			</output>
 			<output>
-				<group>[Sampler2]</group>
+				<group>[Sampler10]</group>
 				<key>play_indicator</key>
 				<description>(Pad 2 DECK B)</description>
 				<status>0x97</status>
@@ -3100,7 +3100,7 @@
 				<minimum>0.5</minimum>
 			</output>
 			<output>
-				<group>[Sampler3]</group>
+				<group>[Sampler11]</group>
 				<key>play_indicator</key>
 				<description>(Pad 3 DECK B)</description>
 				<status>0x97</status>
@@ -3118,7 +3118,7 @@
 				<minimum>0.5</minimum>
 			</output>
 			<output>
-				<group>[Sampler4]</group>
+				<group>[Sampler12]</group>
 				<key>play_indicator</key>
 				<description>(Pad 4 DECK B)</description>
 				<status>0x97</status>
@@ -3136,7 +3136,7 @@
 				<minimum>0.5</minimum>
 			</output>
 			<output>
-				<group>[Sampler5]</group>
+				<group>[Sampler13]</group>
 				<key>play_indicator</key>
 				<description>(Pad 5 DECK B)</description>
 				<status>0x97</status>
@@ -3154,7 +3154,7 @@
 				<minimum>0.5</minimum>
 			</output>
 			<output>
-				<group>[Sampler6]</group>
+				<group>[Sampler14]</group>
 				<key>play_indicator</key>
 				<description>(Pad 6 DECK B)</description>
 				<status>0x97</status>
@@ -3172,7 +3172,7 @@
 				<minimum>0.5</minimum>
 			</output>
 			<output>
-				<group>[Sampler7]</group>
+				<group>[Sampler15]</group>
 				<key>play_indicator</key>
 				<description>(Pad 7 DECK B)</description>
 				<status>0x97</status>
@@ -3190,7 +3190,7 @@
 				<minimum>0.5</minimum>
 			</output>
 			<output>
-				<group>[Sampler8]</group>
+				<group>[Sampler16]</group>
 				<key>play_indicator</key>
 				<description>(Pad 4 DECK B)</description>
 				<status>0x97</status>

--- a/res/controllers/Hercules_DJControl_Inpulse_300.midi.xml
+++ b/res/controllers/Hercules_DJControl_Inpulse_300.midi.xml
@@ -648,6 +648,168 @@
 					<normal />
 				</options>
 			</control>
+			<!--FX Pads -->
+			<control>
+				<group>[EffectRack1_EffectUnit1_Effect1]</group>
+				<key>enabled</key>
+				<description>FX Unit 1 - Slot 1 On/Off</description>
+				<status>0x96</status>
+				<midino>0x50</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit1_Effect2]</group>
+				<key>enabled</key>
+				<description>FX Unit 1 - Slot 2 On/Off</description>
+				<status>0x96</status>
+				<midino>0x51</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit1_Effect3]</group>
+				<key>enabled</key>
+				<description>FX Unit 1 - Slot 3 On/Off</description>
+				<status>0x96</status>
+				<midino>0x52</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit1]</group>
+				<key>group_[Channel1]_enable</key>
+				<description>FX Unit 1 On/Off - Deck A</description>
+				<status>0x96</status>
+				<midino>0x53</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit3_Effect1]</group>
+				<key>enabled</key>
+				<description>FX Unit 3 - Slot 1 On/Off</description>
+				<status>0x96</status>
+				<midino>0x54</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit3_Effect2]</group>
+				<key>enabled</key>
+				<description>FX Unit 3 - Slot 2 On/Off</description>
+				<status>0x96</status>
+				<midino>0x55</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit3_Effect3]</group>
+				<key>enabled</key>
+				<description>FX Unit 3 - Slot 3 On/Off</description>
+				<status>0x96</status>
+				<midino>0x56</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit3]</group>
+				<key>group_[Channel1]_enable</key>
+				<description>FX Unit 3 On/Off - Deck A</description>
+				<status>0x96</status>
+				<midino>0x57</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<!--FX Pads (SHIFT mode) 0x58-0x5F -->
+			<control>
+				<group>[EffectRack1_EffectUnit1_Effect1]</group>
+				<key>enabled</key>
+				<description>FX Unit 1 - Slot 1 On/Off</description>
+				<status>0x96</status>
+				<midino>0x58</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit1_Effect2]</group>
+				<key>enabled</key>
+				<description>FX Unit 1 - Slot 2 On/Off</description>
+				<status>0x96</status>
+				<midino>0x59</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit1_Effect3]</group>
+				<key>enabled</key>
+				<description>FX Unit 1 - Slot 3 On/Off</description>
+				<status>0x96</status>
+				<midino>0x5A</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit1]</group>
+				<key>group_[Channel2]_enable</key>
+				<description>FX Unit 1 On/Off - Deck B</description>
+				<status>0x96</status>
+				<midino>0x5B</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit3_Effect1]</group>
+				<key>enabled</key>
+				<description>FX Unit 3 - Slot 1 On/Off</description>
+				<status>0x96</status>
+				<midino>0x5C</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit3_Effect2]</group>
+				<key>enabled</key>
+				<description>FX Unit 3 - Slot 2 On/Off</description>
+				<status>0x96</status>
+				<midino>0x5D</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit3_Effect3]</group>
+				<key>enabled</key>
+				<description>FX Unit 3 - Slot 3 On/Off</description>
+				<status>0x96</status>
+				<midino>0x5E</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit3]</group>
+				<key>group_[Channel2]_enable</key>
+				<description>FX Unit 3 On/Off - Deck B</description>
+				<status>0x96</status>
+				<midino>0x5F</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
 			<!--Roll-->
 			<control>
 				<group>[Channel1]</group>
@@ -1059,6 +1221,168 @@
 				<description>PAD 8</description>
 				<status>0x97</status>
 				<midino>0x0F</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<!--FX Pads -->
+			<control>
+				<group>[EffectRack1_EffectUnit2_Effect1]</group>
+				<key>enabled</key>
+				<description>FX Unit 2 - Slot 1 On/Off</description>
+				<status>0x97</status>
+				<midino>0x50</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit2_Effect2]</group>
+				<key>enabled</key>
+				<description>FX Unit 2 - Slot 2 On/Off</description>
+				<status>0x97</status>
+				<midino>0x51</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit2_Effect3]</group>
+				<key>enabled</key>
+				<description>FX Unit 2 - Slot 3 On/Off</description>
+				<status>0x97</status>
+				<midino>0x52</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit2]</group>
+				<key>group_[Channel2]_enable</key>
+				<description>FX Unit 2 On/Off - Deck B</description>
+				<status>0x97</status>
+				<midino>0x53</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit4_Effect1]</group>
+				<key>enabled</key>
+				<description>FX Unit 4 - Slot 1 On/Off</description>
+				<status>0x97</status>
+				<midino>0x54</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit4_Effect2]</group>
+				<key>enabled</key>
+				<description>FX Unit 4 - Slot 2 On/Off</description>
+				<status>0x97</status>
+				<midino>0x55</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit4_Effect3]</group>
+				<key>enabled</key>
+				<description>FX Unit 4 - Slot 3 On/Off</description>
+				<status>0x97</status>
+				<midino>0x56</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit4]</group>
+				<key>group_[Channel2]_enable</key>
+				<description>FX Unit 4 On/Off - Deck A</description>
+				<status>0x97</status>
+				<midino>0x57</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<!--FX Pads (SHIFT mode) 0x58-0x5F -->
+			<control>
+				<group>[EffectRack1_EffectUnit2_Effect1]</group>
+				<key>enabled</key>
+				<description>FX Unit 2 - Slot 1 On/Off</description>
+				<status>0x97</status>
+				<midino>0x58</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit2_Effect2]</group>
+				<key>enabled</key>
+				<description>FX Unit 2 - Slot 2 On/Off</description>
+				<status>0x97</status>
+				<midino>0x59</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit2_Effect3]</group>
+				<key>enabled</key>
+				<description>FX Unit 2 - Slot 3 On/Off</description>
+				<status>0x97</status>
+				<midino>0x5A</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit2]</group>
+				<key>group_[Channel1]_enable</key>
+				<description>FX Unit 2 On/Off - Deck A</description>
+				<status>0x97</status>
+				<midino>0x5B</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit4_Effect1]</group>
+				<key>enabled</key>
+				<description>FX Unit 4 - Slot 1 On/Off</description>
+				<status>0x97</status>
+				<midino>0x5C</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit4_Effect2]</group>
+				<key>enabled</key>
+				<description>FX Unit 4 - Slot 2 On/Off</description>
+				<status>0x97</status>
+				<midino>0x5D</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit4_Effect3]</group>
+				<key>enabled</key>
+				<description>FX Unit 4 - Slot 3 On/Off</description>
+				<status>0x97</status>
+				<midino>0x5E</midino>
+				<options>
+					<normal />
+				</options>
+			</control>
+			<control>
+				<group>[EffectRack1_EffectUnit4]</group>
+				<key>group_[Channel1]_enable</key>
+				<description>FX Unit 4 On/Off - Deck A</description>
+				<status>0x97</status>
+				<midino>0x5F</midino>
 				<options>
 					<normal />
 				</options>
@@ -2374,6 +2698,328 @@
 				<on>0x7F</on>
 				<minimum>0.5</minimum>
 			</output>
+			<!--LED FX Channel1 -->
+			<output>
+				<group>[EffectRack1_EffectUnit1_Effect1]</group>
+				<key>enabled</key>
+				<description>FX1 Effect 1 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x96</status>
+				<midino>0x50</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit1_Effect2]</group>
+				<key>enabled</key>
+				<description>FX1 Effect 2 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x96</status>
+				<midino>0x51</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit1_Effect3]</group>
+				<key>enabled</key>
+				<description>FX1 Effect 3 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x96</status>
+				<midino>0x52</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit1]</group>
+				<key>group_[Channel1]_enable</key>
+				<description>FX1 is active on Deck A</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x96</status>
+				<midino>0x53</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit3_Effect1]</group>
+				<key>enabled</key>
+				<description>FX3 Effect 1 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x96</status>
+				<midino>0x54</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit3_Effect2]</group>
+				<key>enabled</key>
+				<description>FX3 Effect 2 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x96</status>
+				<midino>0x55</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit3_Effect3]</group>
+				<key>enabled</key>
+				<description>FX3 Effect 3 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x96</status>
+				<midino>0x56</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit3]</group>
+				<key>group_[Channel1]_enable</key>
+				<description>FX3 is active on Deck A</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x96</status>
+				<midino>0x57</midino>
+				<on>0x7f</on>
+			</output>	
+			<output>
+				<group>[EffectRack1_EffectUnit1_Effect1]</group>
+				<key>enabled</key>
+				<description>FX1 Effect 1 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x96</status>
+				<midino>0x58</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit1_Effect2]</group>
+				<key>enabled</key>
+				<description>FX1 Effect 2 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x96</status>
+				<midino>0x59</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit1_Effect3]</group>
+				<key>enabled</key>
+				<description>FX1 Effect 3 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x96</status>
+				<midino>0x5A</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit1]</group>
+				<key>group_[Channel2]_enable</key>
+				<description>FX1 is active on Deck B</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x96</status>
+				<midino>0x5B</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit3_Effect1]</group>
+				<key>enabled</key>
+				<description>FX3 Effect 1 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x96</status>
+				<midino>0x5C</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit3_Effect2]</group>
+				<key>enabled</key>
+				<description>FX3 Effect 2 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x96</status>
+				<midino>0x5D</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit3_Effect3]</group>
+				<key>enabled</key>
+				<description>FX3 Effect 3 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x96</status>
+				<midino>0x5E</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit3]</group>
+				<key>group_[Channel1]_enable</key>
+				<description>FX3 is active on Deck B</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x96</status>
+				<midino>0x5F</midino>
+				<on>0x7f</on>
+			</output>	
+			<!--LED FX Channel2 -->
+			<output>
+				<group>[EffectRack1_EffectUnit2_Effect1]</group>
+				<key>enabled</key>
+				<description>FX2 Effect 1 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x97</status>
+				<midino>0x50</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit2_Effect2]</group>
+				<key>enabled</key>
+				<description>FX2 Effect 2 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x97</status>
+				<midino>0x51</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit2_Effect3]</group>
+				<key>enabled</key>
+				<description>FX2 Effect 3 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x97</status>
+				<midino>0x52</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit2]</group>
+				<key>group_[Channel2]_enable</key>
+				<description>FX2 is active on Deck B</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x97</status>
+				<midino>0x53</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit4_Effect1]</group>
+				<key>enabled</key>
+				<description>FX4 Effect 1 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x97</status>
+				<midino>0x54</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit4_Effect2]</group>
+				<key>enabled</key>
+				<description>FX4 Effect 2 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x97</status>
+				<midino>0x55</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit4_Effect3]</group>
+				<key>enabled</key>
+				<description>FX4 Effect 3 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x97</status>
+				<midino>0x56</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit4]</group>
+				<key>group_[Channel2]_enable</key>
+				<description>FX4 is active on Deck B</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x97</status>
+				<midino>0x57</midino>
+				<on>0x7f</on>
+			</output>	
+			<output>
+				<group>[EffectRack1_EffectUnit2_Effect1]</group>
+				<key>enabled</key>
+				<description>FX2 Effect 1 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x97</status>
+				<midino>0x58</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit2_Effect2]</group>
+				<key>enabled</key>
+				<description>FX2 Effect 2 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x97</status>
+				<midino>0x59</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit2_Effect3]</group>
+				<key>enabled</key>
+				<description>FX2 Effect 3 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x97</status>
+				<midino>0x5A</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit2]</group>
+				<key>group_[Channel1]_enable</key>
+				<description>FX2 is active on Deck A</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x97</status>
+				<midino>0x5B</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit4_Effect1]</group>
+				<key>enabled</key>
+				<description>FX4 Effect 1 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x97</status>
+				<midino>0x5C</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit4_Effect2]</group>
+				<key>enabled</key>
+				<description>FX4 Effect 2 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x97</status>
+				<midino>0x5D</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit4_Effect3]</group>
+				<key>enabled</key>
+				<description>FX4 Effect 3 activate</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x97</status>
+				<midino>0x5E</midino>
+				<on>0x7f</on>
+			</output>
+			<output>
+				<group>[EffectRack1_EffectUnit4]</group>
+				<key>group_[Channel1]_enable</key>
+				<description>FX4 is active on Deck A</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x97</status>
+				<midino>0x5F</midino>
+				<on>0x7f</on>
+			</output>		
 			<!--LED SAMPLE-->
 			<output>
 				<group>[Sampler1]</group>

--- a/res/controllers/Hercules_DJControl_Inpulse_300.midi.xml
+++ b/res/controllers/Hercules_DJControl_Inpulse_300.midi.xml
@@ -117,7 +117,7 @@
 				<options>
 					<normal />
 				</options>
-			</control>		
+			</control>
 			<control>
 				<group>[Channel1]</group>
 				<key>keylock</key>
@@ -265,7 +265,7 @@
 				<options>
 					<normal />
 				</options>
-			</control>		
+			</control>
 			<control>
 				<group>[Channel2]</group>
 				<key>keylock</key>
@@ -2820,7 +2820,7 @@
 				<status>0x96</status>
 				<midino>0x57</midino>
 				<on>0x7f</on>
-			</output>	
+			</output>
 			<output>
 				<group>[EffectRack1_EffectUnit1_Effect1]</group>
 				<key>enabled</key>
@@ -2900,7 +2900,7 @@
 				<status>0x96</status>
 				<midino>0x5F</midino>
 				<on>0x7f</on>
-			</output>	
+			</output>
 			<!--LED FX Channel2 -->
 			<output>
 				<group>[EffectRack1_EffectUnit2_Effect1]</group>
@@ -2981,7 +2981,7 @@
 				<status>0x97</status>
 				<midino>0x57</midino>
 				<on>0x7f</on>
-			</output>	
+			</output>
 			<output>
 				<group>[EffectRack1_EffectUnit2_Effect1]</group>
 				<key>enabled</key>
@@ -3061,7 +3061,7 @@
 				<status>0x97</status>
 				<midino>0x5F</midino>
 				<on>0x7f</on>
-			</output>		
+			</output>
 			<!--LED SAMPLE-->
 			<output>
 				<group>[Sampler1]</group>

--- a/res/controllers/Hercules_DJControl_Inpulse_300.midi.xml
+++ b/res/controllers/Hercules_DJControl_Inpulse_300.midi.xml
@@ -110,9 +110,19 @@
 			<!--Q A-->
 			<control>
 				<group>[Channel1]</group>
-				<key>keylock</key>
+				<key>quantize</key>
 				<description>Q button</description>
 				<status>0x91</status>
+				<midino>0x02</midino>
+				<options>
+					<normal />
+				</options>
+			</control>		
+			<control>
+				<group>[Channel1]</group>
+				<key>keylock</key>
+				<description>Shift + Q button</description>
+				<status>0x94</status>
 				<midino>0x02</midino>
 				<options>
 					<normal />
@@ -248,9 +258,19 @@
 			<!--Q B-->
 			<control>
 				<group>[Channel2]</group>
-				<key>keylock</key>
+				<key>quantize</key>
 				<description>Q button</description>
 				<status>0x92</status>
+				<midino>0x02</midino>
+				<options>
+					<normal />
+				</options>
+			</control>		
+			<control>
+				<group>[Channel2]</group>
+				<key>keylock</key>
+				<description>Shift + Q button</description>
+				<status>0x95</status>
 				<midino>0x02</midino>
 				<options>
 					<normal />
@@ -2039,11 +2059,22 @@
 			</output>
 			<output>
 				<group>[Channel1]</group>
-				<key>keylock</key>
+				<key>quantize</key>
 				<description>Q button Deck A</description>
 				<minimum>0.5</minimum>
 				<maximum>1</maximum>
 				<status>0x91</status>
+				<midino>0x02</midino>
+				<on>0x7f</on>
+				<off>0x0</off>
+			</output>
+			<output>
+				<group>[Channel1]</group>
+				<key>keylock</key>
+				<description>Q button Deck A(SHIFT mode)</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x94</status>
 				<midino>0x02</midino>
 				<on>0x7f</on>
 				<off>0x0</off>
@@ -2105,11 +2136,22 @@
 			</output>
 			<output>
 				<group>[Channel2]</group>
-				<key>keylock</key>
+				<key>quantize</key>
 				<description>Q button Deck B</description>
 				<minimum>0.5</minimum>
 				<maximum>1</maximum>
 				<status>0x92</status>
+				<midino>0x02</midino>
+				<on>0x7f</on>
+				<off>0x0</off>
+			</output>
+			<output>
+				<group>[Channel2]</group>
+				<key>keylock</key>
+				<description>Q button Deck B(SHIFT mode)</description>
+				<minimum>0.5</minimum>
+				<maximum>1</maximum>
+				<status>0x95</status>
 				<midino>0x02</midino>
 				<on>0x7f</on>
 				<off>0x0</off>

--- a/res/controllers/Hercules_DJControl_Inpulse_300.midi.xml
+++ b/res/controllers/Hercules_DJControl_Inpulse_300.midi.xml
@@ -120,7 +120,7 @@
 			</control>
 			<control>
 				<group>[Channel1]</group>
-				<key>keylock</key>
+				<key>beats_translate_curpos</key>
 				<description>Shift + Q button</description>
 				<status>0x94</status>
 				<midino>0x02</midino>
@@ -268,7 +268,7 @@
 			</control>
 			<control>
 				<group>[Channel2]</group>
-				<key>keylock</key>
+				<key>beats_translate_curpos</key>
 				<description>Shift + Q button</description>
 				<status>0x95</status>
 				<midino>0x02</midino>
@@ -2069,17 +2069,6 @@
 				<off>0x0</off>
 			</output>
 			<output>
-				<group>[Channel1]</group>
-				<key>keylock</key>
-				<description>Q button Deck A(SHIFT mode)</description>
-				<minimum>0.5</minimum>
-				<maximum>1</maximum>
-				<status>0x94</status>
-				<midino>0x02</midino>
-				<on>0x7f</on>
-				<off>0x0</off>
-			</output>
-			<output>
 				<group>[Channel2]</group>
 				<key>play_indicator</key>
 				<description>PLAY LED Deck B</description>
@@ -2141,17 +2130,6 @@
 				<minimum>0.5</minimum>
 				<maximum>1</maximum>
 				<status>0x92</status>
-				<midino>0x02</midino>
-				<on>0x7f</on>
-				<off>0x0</off>
-			</output>
-			<output>
-				<group>[Channel2]</group>
-				<key>keylock</key>
-				<description>Q button Deck B(SHIFT mode)</description>
-				<minimum>0.5</minimum>
-				<maximum>1</maximum>
-				<status>0x95</status>
 				<midino>0x02</midino>
 				<on>0x7f</on>
 				<off>0x0</off>


### PR DESCRIPTION
Hi, I've bought myself my first DJ Controller. 
My friend has an Inpulse 200 and I've noticed that he already has some effects mapped on his smaller controller. So I've done some digging and came up with some improvements for Inpulse 300.

- I've mapped FX keys inspired by _Inpulse 300_  original mappings.
  - Pads 1 - 3 pads turn on `EffectN`
  - Pads 5 - 7 cycle to next effect.
  - Pad 4 toggles FX1 on that deck.
  - Pad 8 toggles FX2 on that deck.
  - In `SHIFT` mode pads control FX3 Effect units on deck A and FX4 units on deck B.
  - Enabled LED mappings to show the active status of independently mapped pads.
- I've switched `keylock` for `quantize` as the controller has a `Q` label on that place.
- Fixed `SHIFT` + `Q` to `beats_translate_curpos`
- Enhanced Sampler Pads to enable to control 16 sample banks
- Enable browser knob to `MoveHorizontal` when in `SHIFT` mode

Updated manual documentation: https://github.com/mixxxdj/manual/pull/425#pullrequestreview-741821849


I've been using mixxx just for a month so please let me know if I could do more improvements.