### PR TITLE
Logging: Suppress expected and harmless schema migration errors

### DIFF
--- a/src/database/schemamanager.cpp
+++ b/src/database/schemamanager.cpp
@@ -238,9 +238,7 @@ SchemaManager::Result SchemaManager::upgradeToSchemaVersion(
             FwdSqlQuery query(m_settingsDao.database(), statement);
             result = query.isPrepared() && query.execPrepared();
             if (!result &&
-                    query.hasError() &&
-                    query.lastError().databaseText().startsWith(
-                            QStringLiteral("duplicate column name: "))) {
+                    query.hasDuplicateColumnNameError()) {
                 // New columns may have already been added during a previous
                 // migration to a different (= preceding) schema version. This
                 // is a very common situation during development when switching
@@ -249,10 +247,10 @@ SchemaManager::Result SchemaManager::upgradeToSchemaVersion(
                 // handle those errors here after they occurred.
                 // If the remaining migration finishes without other errors this
                 // is probably ok.
-                kLogger.warning()
-                        << "Ignoring failed statement"
+                kLogger.info()
+                        << "Safely ignoring failed statement"
                         << statement
-                        << "and continuing with schema migration";
+                        << "while re-applying a schema migration";
                 result = true;
             }
         }

--- a/src/util/db/fwdsqlquery.cpp
+++ b/src/util/db/fwdsqlquery.cpp
@@ -39,12 +39,29 @@ FwdSqlQuery::FwdSqlQuery(
           m_prepared(prepareQuery(*this, statement)) {
     if (!m_prepared) {
         DEBUG_ASSERT(!database.isOpen() || hasError());
-        kLogger.critical()
-                << "Failed to prepare"
-                << statement
-                << ":"
-                << lastError();
+        if (hasDuplicateColumnNameError()) {
+            // Special case: Errors caused by re-adding a column when
+            // re-appliying a schema migration are expected and we
+            // should not report them as an error.
+            kLogger.debug()
+                    << "Failed to prepare schema migration statement"
+                    << statement
+                    << ":"
+                    << lastError();
+        } else {
+            kLogger.critical()
+                    << "Failed to prepare statement"
+                    << statement
+                    << ":"
+                    << lastError();
+        }
     }
+}
+
+bool FwdSqlQuery::hasDuplicateColumnNameError() const {
+    return hasError() &&
+            lastError().databaseText().startsWith(
+                    QStringLiteral("duplicate column name: "));
 }
 
 bool FwdSqlQuery::execPrepared() {

--- a/src/util/db/fwdsqlquery.h
+++ b/src/util/db/fwdsqlquery.h
@@ -49,6 +49,7 @@ class FwdSqlQuery : protected QSqlQuery {
         return lastError().isValid() &&
                 (lastError().type() != QSqlError::NoError);
     }
+    bool hasDuplicateColumnNameError() const;
     QSqlError lastError() const {
         return QSqlQuery::lastError();
     }


### PR DESCRIPTION
https://mixxx.zulipchat.com/#narrow/stream/247620-development-help/topic/Library.20warnings

Here's the fix, an ugly hack. But I am not willing to explain this over and over again ;)