### PR TITLE
SoundSourceOpus: Fix invocation of inherited method

### DIFF
--- a/src/sources/soundsourceopus.cpp
+++ b/src/sources/soundsourceopus.cpp
@@ -98,7 +98,7 @@ SoundSourceOpus::importTrackMetadataAndCoverImage(
         TrackMetadata* pTrackMetadata,
         QImage* pCoverArt) const {
     auto const imported =
-            SoundSource::importTrackMetadataAndCoverImage(
+            MetadataSourceTagLib::importTrackMetadataAndCoverImage(
                     pTrackMetadata, pCoverArt);
     if (imported.first == ImportResult::Succeeded) {
         // Done if the default implementation in the base class


### PR DESCRIPTION
A finding while analyzing https://bugs.launchpad.net/mixxx/+bug/1940777. Not sure if this inaccuracy could cause a crash on Windows depending on the compiler version and settings.

The member function is *defined* in `MetadataSourceTagLib`, a base class of `SoundSource`.

For main this fix will soon become obsolete after #4251 has been merged.