### PR TITLE
sidebar: Left key jumps to parent and activates it

### DIFF
--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -205,6 +205,26 @@ void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
     //    // encoder click via "GoToItem"
     //    qDebug() << "GoToItem";
     //    TODO(xxx) decide what todo here instead of in librarycontrol
+    } else if (event->key() == Qt::Key_Left) {
+        auto selModel = selectionModel();
+        QModelIndexList selectedRows = selModel->selectedRows();
+        if (selectedRows.isEmpty()) {
+            return;
+        }
+        // If an expanded item is selected let QTreeView collapse it
+        QModelIndex selIndex = selectedRows.first();
+        DEBUG_ASSERT(selIndex.isValid());
+        if (isExpanded(selIndex)) {
+            QTreeView::keyPressEvent(event);
+            return;
+        }
+        // Else jump to its parent and activate it
+        QModelIndex parentIndex = selIndex.parent();
+        if (parentIndex.isValid()) {
+            selectIndex(parentIndex);
+            emit pressed(parentIndex);
+        }
+        return;
     }
 
     // Fall through to default handler.


### PR DESCRIPTION
This is supposed to facilitate the treeview navigation a bit:
If a collapsed child item is selected `Left` now selects & activates the parent item.

I'm used to it from apps (Thunar and Thunderbird) and I find this very handy, e.g. when you're somewhere in the middle of a long crates list and want to jump to another root item (using PageUp/Down and Up/Down afterwards is cumbersome)