### PR TITLE
fix app/window icons

### DIFF
--- a/src/defs_urls.h
+++ b/src/defs_urls.h
@@ -10,6 +10,7 @@
 
 // Icons used for the main window and dialogs
 #define MIXXX_ICON_PATH ":/images/icons/scalable/apps/mixxx.svg"
+#define MIXXX_LOGO_PATH ":/images/mixxx_logo.svg"
 
 #define MIXXX_WEBSITE_URL       "https://www.mixxx.org"
 #define MIXXX_WEBSITE_SHORT_URL "www.mixxx.org"

--- a/src/defs_urls.h
+++ b/src/defs_urls.h
@@ -8,6 +8,9 @@
     TO_STR(major)                    \
     "." TO_STR(minor)
 
+// Icons used for the main window and dialogs
+#define MIXXX_ICON_PATH ":/images/icons/scalable/apps/mixxx.svg"
+
 #define MIXXX_WEBSITE_URL       "https://www.mixxx.org"
 #define MIXXX_WEBSITE_SHORT_URL "www.mixxx.org"
 #define MIXXX_SUPPORT_URL       "https://www.mixxx.org/support/"

--- a/src/dialog/dlgabout.cpp
+++ b/src/dialog/dlgabout.cpp
@@ -9,11 +9,14 @@
 #include "util/color/color.h"
 #include "util/versionstore.h"
 
-DlgAbout::DlgAbout(QWidget* parent) : QDialog(parent), Ui::DlgAboutDlg() {
+DlgAbout::DlgAbout()
+        : QDialog(nullptr),
+          Ui::DlgAboutDlg() {
     setupUi(this);
+    setWindowIcon(QIcon(MIXXX_ICON_PATH));
 
-    mixxx_icon->load(QString(":/images/icons/scalable/apps/mixxx.svg"));
-    mixxx_logo->load(QString(":/images/mixxx_logo.svg"));
+    mixxx_icon->load(QString(MIXXX_ICON_PATH));
+    mixxx_logo->load(QString(MIXXX_LOGO_PATH));
 
     version_label->setText(VersionStore::applicationName() +
             QStringLiteral(" ") + VersionStore::version());

--- a/src/dialog/dlgabout.h
+++ b/src/dialog/dlgabout.h
@@ -8,5 +8,5 @@
 class DlgAbout : public QDialog, public Ui::DlgAboutDlg {
     Q_OBJECT
   public:
-    DlgAbout(QWidget* parent);
+    DlgAbout();
 };

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -3,6 +3,7 @@
 #include <QTreeWidget>
 #include <QtDebug>
 
+#include "defs_urls.h"
 #include "moc_dlgtagfetcher.cpp"
 #include "track/track.h"
 #include "track/tracknumbers.h"
@@ -69,6 +70,7 @@ DlgTagFetcher::DlgTagFetcher(
 
 void DlgTagFetcher::init() {
     setupUi(this);
+    setWindowIcon(QIcon(MIXXX_ICON_PATH));
 
     if (m_pTrackModel) {
         connect(btnPrev, &QPushButton::clicked, this, &DlgTagFetcher::slotPrev);

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -4,6 +4,7 @@
 #include <QStringBuilder>
 #include <QtDebug>
 
+#include "defs_urls.h"
 #include "library/coverartcache.h"
 #include "library/coverartutils.h"
 #include "library/dlgtagfetcher.h"
@@ -54,6 +55,7 @@ DlgTrackInfo::~DlgTrackInfo() {
 
 void DlgTrackInfo::init() {
     setupUi(this);
+    setWindowIcon(QIcon(MIXXX_ICON_PATH));
 
     coverLayout->setAlignment(Qt::AlignRight | Qt::AlignTop);
     coverLayout->setSpacing(0);

--- a/src/library/scanner/libraryscannerdlg.cpp
+++ b/src/library/scanner/libraryscannerdlg.cpp
@@ -5,12 +5,13 @@
 #include <QVBoxLayout>
 #include <QtDebug>
 
+#include "defs_urls.h"
 #include "moc_libraryscannerdlg.cpp"
 
 LibraryScannerDlg::LibraryScannerDlg(QWidget* parent, Qt::WindowFlags f)
         : QWidget(parent, f),
           m_bCancelled(false) {
-    setWindowIcon(QIcon(":/images/icons/scalable/apps/mixxx.svg"));
+    setWindowIcon(QIcon(MIXXX_ICON_PATH));
 
     QVBoxLayout* pLayout = new QVBoxLayout(this);
 

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -1520,7 +1520,7 @@ void MixxxMainWindow::slotChangedPlayingDeck(int deck) {
 }
 
 void MixxxMainWindow::slotHelpAbout() {
-    DlgAbout* about = new DlgAbout(this);
+    DlgAbout* about = new DlgAbout;
     about->show();
 }
 

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -527,7 +527,7 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
             m_pEffectsManager,
             m_pSettingsManager.get(),
             m_pLibrary);
-    m_pPrefDlg->setWindowIcon(QIcon(":/images/icons/mixxx.svg"));
+    m_pPrefDlg->setWindowIcon(QIcon(MIXXX_ICON_PATH));
     m_pPrefDlg->setHidden(true);
 
     launchProgress(60);
@@ -950,7 +950,7 @@ void MixxxMainWindow::initializeWindow() {
     restoreState(QByteArray::fromBase64(m_pSettingsManager->settings()->getValueString(
         ConfigKey("[MainWindow]", "state")).toUtf8()));
 
-    setWindowIcon(QIcon(":/images/icons/mixxx.svg"));
+    setWindowIcon(QIcon(MIXXX_ICON_PATH));
     slotUpdateWindowTitle(TrackPointer());
 }
 

--- a/src/preferences/upgrade.cpp
+++ b/src/preferences/upgrade.cpp
@@ -9,6 +9,7 @@
 #include "config.h"
 #include "controllers/defs_controllers.h"
 #include "database/mixxxdb.h"
+#include "defs_urls.h"
 #include "library/library_preferences.h"
 #include "library/trackcollection.h"
 #include "preferences/beatdetectionsettings.h"
@@ -450,7 +451,7 @@ UserSettingsPointer Upgrade::versionUpgrade(const QString& settingsPath) {
 
 bool Upgrade::askReScanLibrary() {
     QMessageBox msgBox;
-    msgBox.setIconPixmap(QPixmap(":/images/icons/scalable/apps/mixxx.svg"));
+    msgBox.setIconPixmap(QPixmap(MIXXX_ICON_PATH));
     msgBox.setWindowTitle(QMessageBox::tr("Upgrading Mixxx"));
     msgBox.setText(QMessageBox::tr("Mixxx now supports displaying cover art.\n"
                       "Do you want to scan your library for cover files now?"));
@@ -482,7 +483,7 @@ bool Upgrade::askReanalyzeBeats() {
     QString generateNew = QMessageBox::tr("Generate New Beatgrids");
 
     QMessageBox msgBox;
-    msgBox.setIconPixmap(QPixmap(":/images/icons/mixxx.svg"));
+    msgBox.setIconPixmap(QPixmap(MIXXX_ICON_PATH));
     msgBox.setWindowTitle(windowTitle);
     msgBox.setText(QString("<html><h2>%1</h2><p>%2</p><p>%3</p><p>%4</p></html>")
                    .arg(mainHeading, paragraph1, paragraph2, paragraph3));


### PR DESCRIPTION
* fix regression introduced by 564df770565496172e81eb450f51b2d0dd5e3ee9, all dialogs (except warnings) now use the Mixxx icon
(not 100% sure I caught all, and I didn't figure why the icon is implicitely inherited, for example by the _Replace Hotcue Color_ dialog)
* make About dialog reachable via Alt+Tab by _not_ parenting it to MixxxMainWindow
(this was a bit annoying until now, i.e. when trying to jump back and forth between About Mixxx and web browser to report bugs)