### PR TITLE
BeatFactory: Remove makeBeatGrid function

### DIFF
--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -10,6 +10,7 @@
 #include "analyzer/plugins/analyzersoundtouchbeats.h"
 #include "library/rekordbox/rekordboxconstants.h"
 #include "track/beatfactory.h"
+#include "track/beatgrid.h"
 #include "track/beatmap.h"
 #include "track/beatutils.h"
 #include "track/track.h"
@@ -234,7 +235,7 @@ void AnalyzerBeats::storeResults(TrackPointer pTrack) {
     } else {
         mixxx::Bpm bpm = m_pPlugin->getBpm();
         qDebug() << "AnalyzerBeats plugin detected constant BPM: " << bpm;
-        pBeats = BeatFactory::makeBeatGrid(m_sampleRate, bpm, mixxx::audio::kStartFramePos);
+        pBeats = mixxx::BeatGrid::makeBeatGrid(m_sampleRate, bpm, mixxx::audio::kStartFramePos);
     }
 
     pTrack->trySetBeats(pBeats);

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -27,7 +27,6 @@
 #include "engine/sync/synccontrol.h"
 #include "moc_enginebuffer.cpp"
 #include "preferences/usersettings.h"
-#include "track/beatfactory.h"
 #include "track/keyutils.h"
 #include "track/track.h"
 #include "util/assert.h"

--- a/src/library/banshee/bansheeplaylistmodel.cpp
+++ b/src/library/banshee/bansheeplaylistmodel.cpp
@@ -9,7 +9,6 @@
 #include "library/trackcollectionmanager.h"
 #include "mixer/playermanager.h"
 #include "moc_bansheeplaylistmodel.cpp"
-#include "track/beatfactory.h"
 #include "track/beats.h"
 #include "track/track.h"
 

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -24,7 +24,7 @@
 #include "library/trackset/crate/cratestorage.h"
 #include "moc_trackdao.cpp"
 #include "sources/soundsourceproxy.h"
-#include "track/beatfactory.h"
+#include "track/beatgrid.h"
 #include "track/beats.h"
 #include "track/globaltrackcache.h"
 #include "track/keyfactory.h"
@@ -1243,11 +1243,13 @@ bool setTrackBeats(const QSqlRecord& record, const int column, Track* pTrack) {
         } else {
             pTrack->trySetBeats(pBeats);
         }
-    } else {
+    } else if (bpm.isValid()) {
         // Load a temporary beat grid without offset that will be replaced by the analyzer.
-        const auto pBeats = BeatFactory::makeBeatGrid(
-                pTrack->getSampleRate(), bpm, mixxx::audio::kStartFramePos);
+        const auto pBeats = mixxx::BeatGrid::makeBeatGrid(
+                pTrack->getSampleRate(), QString(), bpm, mixxx::audio::kStartFramePos);
         pTrack->trySetBeats(pBeats);
+    } else {
+        pTrack->trySetBeats(nullptr);
     }
     return false;
 }

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1246,7 +1246,7 @@ bool setTrackBeats(const QSqlRecord& record, const int column, Track* pTrack) {
     } else if (bpm.isValid()) {
         // Load a temporary beat grid without offset that will be replaced by the analyzer.
         const auto pBeats = mixxx::BeatGrid::makeBeatGrid(
-                pTrack->getSampleRate(), QString(), bpm, mixxx::audio::kStartFramePos);
+                pTrack->getSampleRate(), bpm, mixxx::audio::kStartFramePos);
         pTrack->trySetBeats(pBeats);
     } else {
         pTrack->trySetBeats(nullptr);

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -13,7 +13,7 @@
 #include "moc_dlgtrackinfo.cpp"
 #include "preferences/colorpalettesettings.h"
 #include "sources/soundsourceproxy.h"
-#include "track/beatfactory.h"
+#include "track/beatgrid.h"
 #include "track/beatutils.h"
 #include "track/keyfactory.h"
 #include "track/keyutils.h"
@@ -571,10 +571,10 @@ void DlgTrackInfo::slotBpmConstChanged(int state) {
             // The cue point should be set on a beat, so this seems
             // to be a good alternative
             const mixxx::audio::FramePos cuePosition = m_pLoadedTrack->getMainCuePosition();
-            m_pBeatsClone =
-                    BeatFactory::makeBeatGrid(m_pLoadedTrack->getSampleRate(),
-                            bpm,
-                            cuePosition);
+            m_pBeatsClone = mixxx::BeatGrid::makeBeatGrid(
+                    m_pLoadedTrack->getSampleRate(),
+                    bpm,
+                    cuePosition);
         } else {
             m_pBeatsClone.clear();
         }
@@ -610,7 +610,7 @@ void DlgTrackInfo::slotSpinBpmValueChanged(double value) {
 
     if (!m_pBeatsClone) {
         const mixxx::audio::FramePos cuePosition = m_pLoadedTrack->getMainCuePosition();
-        m_pBeatsClone = BeatFactory::makeBeatGrid(
+        m_pBeatsClone = mixxx::BeatGrid::makeBeatGrid(
                 m_pLoadedTrack->getSampleRate(),
                 bpm,
                 cuePosition);

--- a/src/library/serato/seratofeature.cpp
+++ b/src/library/serato/seratofeature.cpp
@@ -13,7 +13,6 @@
 #include "library/trackcollectionmanager.h"
 #include "library/treeitem.h"
 #include "moc_seratofeature.cpp"
-#include "track/beatfactory.h"
 #include "track/cue.h"
 #include "track/keyfactory.h"
 #include "util/assert.h"

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -30,7 +30,6 @@ TEST(BeatGridTest, Scale) {
     pTrack->trySetBpm(bpm.value());
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
-            QString(),
             mixxx::Bpm(bpm),
             mixxx::audio::kStartFramePos);
 
@@ -63,7 +62,6 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat) {
     constexpr mixxx::audio::FrameDiff_t beatLengthFrames = 60.0 * sampleRate / bpm;
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
-            QString(),
             mixxx::Bpm(bpm),
             mixxx::audio::kStartFramePos);
     // Pretend we're on the 20th beat;
@@ -108,7 +106,6 @@ TEST(BeatGridTest, TestNthBeatWhenNotOnBeat) {
     const mixxx::audio::FrameDiff_t beatLengthFrames = 60.0 * sampleRate / bpm.value();
 
     auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
-            QString(),
             bpm,
             mixxx::audio::kStartFramePos);
 

--- a/src/test/beatstranslatetest.cpp
+++ b/src/test/beatstranslatetest.cpp
@@ -10,13 +10,13 @@ TEST_F(BeatsTranslateTest, SimpleTranslateMatch) {
     const auto bpm = mixxx::Bpm(60.0);
     constexpr auto firstBeat = mixxx::audio::kStartFramePos;
     auto grid1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), QString(), bpm, firstBeat);
+            m_pTrack1->getSampleRate(), bpm, firstBeat);
     m_pTrack1->trySetBeats(grid1);
     ASSERT_DOUBLE_EQ(firstBeat.value(),
             grid1->findClosestBeat(mixxx::audio::kStartFramePos).value());
 
     auto grid2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), QString(), bpm, firstBeat);
+            m_pTrack2->getSampleRate(), bpm, firstBeat);
     m_pTrack2->trySetBeats(grid2);
     ASSERT_DOUBLE_EQ(firstBeat.value(),
             grid2->findClosestBeat(mixxx::audio::kStartFramePos).value());

--- a/src/test/bpmcontrol_test.cpp
+++ b/src/test/bpmcontrol_test.cpp
@@ -7,7 +7,6 @@
 #include "control/controlobject.h"
 #include "control/controlpushbutton.h"
 #include "engine/controls/bpmcontrol.h"
-#include "track/beatfactory.h"
 #include "track/beatgrid.h"
 #include "track/beatmap.h"
 #include "track/track.h"
@@ -36,7 +35,7 @@ TEST_F(BpmControlTest, BeatContext_BeatGrid) {
     const auto bpm = mixxx::Bpm(60.0);
     const mixxx::audio::FrameDiff_t expectedBeatLengthFrames = (60.0 * sampleRate / bpm.value());
 
-    const mixxx::BeatsPointer pBeats = BeatFactory::makeBeatGrid(
+    const mixxx::BeatsPointer pBeats = mixxx::BeatGrid::makeBeatGrid(
             pTrack->getSampleRate(), bpm, mixxx::audio::kStartFramePos);
 
     // On a beat.

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -1451,9 +1451,7 @@ TEST_F(EngineSyncTest, ExplicitLeaderPostProcessed) {
 TEST_F(EngineSyncTest, ZeroBPMRateAdjustIgnored) {
     // If a track isn't loaded (0 bpm), but the deck has sync enabled,
     // don't pay attention to rate changes.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(0), mixxx::audio::kStartFramePos);
-    m_pTrack1->trySetBeats(pBeats1);
+    m_pTrack1->trySetBeats(nullptr);
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     pButtonSyncEnabled1->set(1.0);
@@ -2514,9 +2512,7 @@ TEST_F(EngineSyncTest, ZeroBpmNaturalRate) {
     // If a track has a zero bpm and a bad beatgrid, make sure the rate
     // doesn't end up something crazy when sync is enabled..
     // Maybe the beatgrid ended up at zero also.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(0.0), mixxx::audio::kStartFramePos);
-    m_pTrack1->trySetBeats(pBeats1);
+    m_pTrack1->trySetBeats(nullptr);
 
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     pButtonSyncEnabled1->set(1.0);

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -10,7 +10,7 @@
 #include "preferences/usersettings.h"
 #include "test/mixxxtest.h"
 #include "test/mockedenginebackendtest.h"
-#include "track/beatfactory.h"
+#include "track/beatgrid.h"
 #include "track/beatmap.h"
 #include "util/memory.h"
 
@@ -244,10 +244,10 @@ TEST_F(EngineSyncTest, SetLeaderSuccess) {
 TEST_F(EngineSyncTest, ExplicitLeaderPersists) {
     // If we set an explicit leader, enabling sync or pressing play on other decks
     // doesn't cause the leader to move around.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(124), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -278,13 +278,13 @@ TEST_F(EngineSyncTest, ExplicitLeaderPersists) {
 
 TEST_F(EngineSyncTest, SetLeaderWhilePlaying) {
     // Make sure we don't get two leader lights if we change leaders while playing.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(124), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
-    mixxx::BeatsPointer pBeats3 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats3 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack3->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
     m_pTrack3->trySetBeats(pBeats3);
 
@@ -315,7 +315,7 @@ TEST_F(EngineSyncTest, SetLeaderWhilePlaying) {
 
 TEST_F(EngineSyncTest, SetEnabledBecomesLeader) {
     // If we set the first channel with a valid tempo to follower, it should be leader.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(80), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     auto pButtonLeaderSync1 =
@@ -342,11 +342,11 @@ TEST_F(EngineSyncTest, DisableInternalLeaderWhilePlaying) {
     EXPECT_TRUE(isExplicitLeader(m_sInternalClockGroup));
 
     // Make sure both decks are playing.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(80), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(80), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup2, "play"))->set(1.0);
@@ -363,14 +363,14 @@ TEST_F(EngineSyncTest, DisableInternalLeaderWhilePlaying) {
 
 TEST_F(EngineSyncTest, DisableSyncOnLeader) {
     // Channel 1 follower, channel 2 leader.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     auto pButtonSyncMode1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     pButtonSyncMode1->set(static_cast<double>(SyncMode::Follower));
 
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     // Set deck two to explicit leader.
@@ -409,7 +409,7 @@ TEST_F(EngineSyncTest, InternalLeaderSetFollowerSliderMoves) {
     pButtonLeaderSyncInternal->set(1);
 
     // Set the file bpm of channel 1 to 80 bpm.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(80), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
 
@@ -428,7 +428,7 @@ TEST_F(EngineSyncTest, AnySyncDeckSliderStays) {
     // If there exists a sync deck, even if it's not playing, don't change the
     // leader BPM if a new deck enables sync.
 
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(80), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     auto pButtonSyncEnabled1 =
@@ -440,7 +440,7 @@ TEST_F(EngineSyncTest, AnySyncDeckSliderStays) {
             ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))
                     ->get());
 
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     auto pButtonSyncEnabled2 =
@@ -465,12 +465,12 @@ TEST_F(EngineSyncTest, InternalClockFollowsFirstPlayingDeck) {
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
 
     // Set up decks so they can be playing, and start deck 1.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
@@ -537,11 +537,11 @@ TEST_F(EngineSyncTest, SetExplicitLeaderByLights) {
             std::make_unique<ControlProxy>(m_sGroup2, "sync_leader");
 
     // Set the file bpm of channel 1 to 160bpm.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     // Set the file bpm of channel 2 to 150bpm.
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(150), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -620,7 +620,7 @@ TEST_F(EngineSyncTest, RateChangeTest) {
     ProcessBuffer();
 
     // Set the file bpm of channel 1 to 160bpm.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     EXPECT_DOUBLE_EQ(
@@ -640,7 +640,7 @@ TEST_F(EngineSyncTest, RateChangeTest) {
             192.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     EXPECT_DOUBLE_EQ(
@@ -663,14 +663,14 @@ TEST_F(EngineSyncTest, RateChangeTestWeirdOrder) {
     ProcessBuffer();
 
     // Set the file bpm of channel 1 to 160bpm.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -689,14 +689,14 @@ TEST_F(EngineSyncTest, RateChangeTestWeirdOrder) {
 
 TEST_F(EngineSyncTest, RateChangeTestOrder3) {
     // Set the file bpm of channel 1 to 160bpm.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sGroup1, "file_bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     EXPECT_DOUBLE_EQ(
@@ -737,12 +737,12 @@ TEST_F(EngineSyncTest, FollowerRateChange) {
     ProcessBuffer();
 
     // Set the file bpm of channel 1 to 160bpm.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
 
     // Set the file bpm of channel 2 to 120bpm.
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -785,14 +785,14 @@ TEST_F(EngineSyncTest, InternalRateChangeTest) {
     EXPECT_TRUE(isFollower(m_sGroup2));
 
     // Set the file bpm of channel 1 to 160bpm.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     EXPECT_DOUBLE_EQ(160.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "file_bpm"))->get());
 
     // Set the file bpm of channel 2 to 120bpm.
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     EXPECT_DOUBLE_EQ(120.0,
@@ -839,10 +839,10 @@ TEST_F(EngineSyncTest, InternalRateChangeTest) {
 
 TEST_F(EngineSyncTest, LeaderStopSliderCheck) {
     // If the leader is playing, and stop is pushed, the sliders should stay the same.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -885,7 +885,7 @@ TEST_F(EngineSyncTest, EnableOneDeckInitsLeader) {
     ProcessBuffer();
 
     // Set up the deck to play.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
@@ -913,7 +913,7 @@ TEST_F(EngineSyncTest, EnableOneDeckInitsLeader) {
                     ConfigKey(m_sInternalClockGroup, "beat_distance")));
 
     // Enable second deck, bpm and beat distance should still match original setting.
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(140), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))
@@ -942,10 +942,10 @@ TEST_F(EngineSyncTest, MomentarySyncAlgorithmTwo) {
     m_pConfig->set(ConfigKey("[BPM]", "sync_lock_algorithm"),
             ConfigValue(EngineSync::PREFER_LOCK_BPM));
 
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -964,7 +964,7 @@ TEST_F(EngineSyncTest, MomentarySyncAlgorithmTwo) {
 TEST_F(EngineSyncTest, EnableOneDeckInitializesLeader) {
     // Enabling sync on a deck causes it to be leader, and sets bpm and clock.
     // Set the deck to play.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
@@ -1155,7 +1155,7 @@ TEST_F(EngineSyncTest, EnableOneDeckSliderUpdates) {
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
 
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
@@ -1183,12 +1183,12 @@ TEST_F(EngineSyncTest, SyncToNonSyncDeck) {
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
 
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     ProcessBuffer();
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))
@@ -1271,12 +1271,12 @@ TEST_F(EngineSyncTest, MomentarySyncDependsOnPlayingStates) {
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
 
     // Set up decks so they can be playing, and start deck 1.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
@@ -1347,7 +1347,7 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     auto pButtonEject1 = std::make_unique<ControlProxy>(m_sGroup1, "eject");
 
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     pButtonSyncEnabled1->set(1.0);
@@ -1373,7 +1373,7 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
     m_pMixerDeck1->loadFakeTrack(false, 128.0);
     EXPECT_DOUBLE_EQ(128.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(135), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     pButtonSyncEnabled2->set(1.0);
@@ -1394,7 +1394,7 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
 
 TEST_F(EngineSyncTest, FileBpmChangesDontAffectLeader) {
     // If filebpm changes, don't treat it like a rate change unless it's the leader.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     auto pButtonSyncEnabled1 =
@@ -1402,7 +1402,7 @@ TEST_F(EngineSyncTest, FileBpmChangesDontAffectLeader) {
     pButtonSyncEnabled1->set(1.0);
     ProcessBuffer();
 
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     auto pButtonSyncEnabled2 =
@@ -1414,7 +1414,7 @@ TEST_F(EngineSyncTest, FileBpmChangesDontAffectLeader) {
     EXPECT_TRUE(isFollower(m_sGroup2));
 
     // Update the leader's beats -- update the internal clock
-    pBeats1 = BeatFactory::makeBeatGrid(
+    pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     EXPECT_DOUBLE_EQ(
@@ -1423,7 +1423,7 @@ TEST_F(EngineSyncTest, FileBpmChangesDontAffectLeader) {
     EXPECT_TRUE(isSoftLeader(m_sGroup1));
 
     // Update follower beats -- don't update internal clock.
-    pBeats2 = BeatFactory::makeBeatGrid(
+    pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(140), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     EXPECT_DOUBLE_EQ(
@@ -1436,7 +1436,7 @@ TEST_F(EngineSyncTest, ExplicitLeaderPostProcessed) {
     auto pButtonLeaderSync1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     pButtonLeaderSync1->set(static_cast<double>(SyncMode::LeaderExplicit));
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     ProcessBuffer();
@@ -1459,7 +1459,7 @@ TEST_F(EngineSyncTest, ZeroBPMRateAdjustIgnored) {
             ->set(getRateSliderValue(1.0));
     ProcessBuffer();
 
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     auto pButtonSyncEnabled2 =
@@ -1498,7 +1498,7 @@ TEST_F(EngineSyncTest, BeatDistanceBeforeStart) {
     // If the start position is before zero, we should still initialize the beat distance
     // correctly.  Unfortunately, this currently doesn't work.
 
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
@@ -1516,10 +1516,10 @@ TEST_F(EngineSyncTest, BeatDistanceBeforeStart) {
 TEST_F(EngineSyncTest, ZeroLatencyRateChangeNoQuant) {
     // Confirm that a rate change in an explicit leader is instantly communicated
     // to followers.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -1566,10 +1566,10 @@ TEST_F(EngineSyncTest, ZeroLatencyRateChangeNoQuant) {
 TEST_F(EngineSyncTest, ZeroLatencyRateChangeQuant) {
     // Confirm that a rate change in an explicit leader is instantly communicated
     // to followers.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -1621,10 +1621,10 @@ TEST_F(EngineSyncTest, ZeroLatencyRateChangeQuant) {
 TEST_F(EngineSyncTest, ZeroLatencyRateDiffQuant) {
     // Confirm that a rate change in an explicit leader is instantly communicated
     // to followers.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -1677,10 +1677,10 @@ TEST_F(EngineSyncTest, ZeroLatencyRateDiffQuant) {
 // need to check. The Sync feature is unfortunately brittle.
 // This test exercises https://bugs.launchpad.net/mixxx/+bug/1884324
 TEST_F(EngineSyncTest, ActivatingSyncDoesNotCauseDrifting) {
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(150), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(150), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -1723,10 +1723,10 @@ TEST_F(EngineSyncTest, ActivatingSyncDoesNotCauseDrifting) {
 }
 
 TEST_F(EngineSyncTest, HalfDoubleBpmTest) {
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(70), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(140), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -1822,10 +1822,10 @@ TEST_F(EngineSyncTest, HalfDoubleBpmTest) {
 TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
     // If a deck plays that had its multiplier set, we need to reset the
     // internal clock.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(80), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(175), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
@@ -1947,10 +1947,10 @@ TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
 
 TEST_F(EngineSyncTest, HalfDoubleInternalClockTest) {
     // If we set the file_bpm CO's directly, the correct signals aren't fired.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(70), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(140), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -2024,10 +2024,10 @@ TEST_F(EngineSyncTest, HalfDoubleEachOther) {
     // Confirm that repeated sync with both decks leads to the same
     // Half/Double decision.
     // This test demonstrates https://bugs.launchpad.net/mixxx/+bug/1921962
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(144), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(105), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -2053,7 +2053,7 @@ TEST_F(EngineSyncTest, HalfDoubleEachOther) {
     // 105 / 75 = 1.40
     // expect 75 BPM
 
-    mixxx::BeatsPointer pBeats1b = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1b = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(150), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1b);
 
@@ -2075,7 +2075,7 @@ TEST_F(EngineSyncTest, HalfDoubleEachOther) {
 
 TEST_F(EngineSyncTest, SetFileBpmUpdatesLocalBpm) {
     ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->set(0.2);
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     EXPECT_EQ(
@@ -2088,7 +2088,7 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
 
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
@@ -2096,7 +2096,7 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     ControlObject::set(ConfigKey(m_sGroup2, "rate_ratio"), 1.0);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -2180,7 +2180,7 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
             std::make_unique<ControlProxy>(m_sGroup3, "sync_enabled");
     ControlObject::set(ConfigKey(m_sGroup3, "beat_distance"), 0.6);
     ControlObject::set(ConfigKey(m_sGroup2, "rate_ratio"), 1.0);
-    mixxx::BeatsPointer pBeats3 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats3 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack3->getSampleRate(), mixxx::Bpm(140), mixxx::audio::kStartFramePos);
     m_pTrack3->trySetBeats(pBeats3);
     // This will sync to the first deck here and not the second (lp1784185)
@@ -2226,10 +2226,10 @@ TEST_F(EngineSyncTest, UserTweakBeatDistance) {
     // If a deck has a user tweak, and another deck stops such that the first
     // is used to reseed the leader beat distance, make sure the user offset
     // is reset.
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -2279,10 +2279,10 @@ TEST_F(EngineSyncTest, UserTweakPreservedInSeek) {
 
     // This is about 128 bpm, but results in nice round numbers of samples.
     const double kDivisibleBpm = 44100.0 / 344.0;
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(kDivisibleBpm), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -2360,10 +2360,10 @@ TEST_F(EngineSyncTest, FollowerUserTweakPreservedInLeaderChange) {
 
     // This is about 128 bpm, but results in nice round numbers of samples.
     const double kDivisibleBpm = 44100.0 / 344.0;
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(kDivisibleBpm), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -2411,10 +2411,10 @@ TEST_F(EngineSyncTest, FollowerUserTweakPreservedInSyncDisable) {
     // Ensure that when a follower disables sync, a phase seek is not performed.
     // This is about 128 bpm, but results in nice round numbers of samples.
     const double kDivisibleBpm = 44100.0 / 344.0;
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(kDivisibleBpm), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -2447,10 +2447,10 @@ TEST_F(EngineSyncTest, LeaderUserTweakPreservedInLeaderChange) {
 
     // This is about 128 bpm, but results in nice round numbers of samples.
     const double kDivisibleBpm = 44100.0 / 344.0;
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(kDivisibleBpm), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -2496,7 +2496,7 @@ TEST_F(EngineSyncTest, LeaderUserTweakPreservedInLeaderChange) {
 }
 
 TEST_F(EngineSyncTest, LeaderBpmNeverZero) {
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
 
@@ -2530,12 +2530,12 @@ TEST_F(EngineSyncTest, QuantizeImpliesSyncPhase) {
     auto pButtonBeatsync1 = std::make_unique<ControlProxy>(m_sGroup1, "beatsync");
     auto pButtonBeatsyncPhase1 = std::make_unique<ControlProxy>(m_sGroup1, "beatsync_phase");
 
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
 
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -2628,7 +2628,7 @@ TEST_F(EngineSyncTest, QuantizeImpliesSyncPhase) {
 TEST_F(EngineSyncTest, SeekStayInPhase) {
     ControlObject::set(ConfigKey(m_sGroup1, "quantize"), 1.0);
 
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
 
@@ -2651,7 +2651,7 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 0.0);
     ProcessBuffer();
 
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -2674,7 +2674,7 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
 
 TEST_F(EngineSyncTest, SyncWithoutBeatgrid) {
     // this tests bug lp1783020, notresetting rate when other deck has no beatgrid
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     m_pTrack2->trySetBeats(mixxx::BeatsPointer());
@@ -2693,12 +2693,12 @@ TEST_F(EngineSyncTest, SyncWithoutBeatgrid) {
 }
 
 TEST_F(EngineSyncTest, QuantizeHotCueActivate) {
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
 
     auto pHotCue2Activate = std::make_unique<ControlProxy>(m_sGroup2, "hotcue_1_activate");
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
 
     m_pTrack2->trySetBeats(pBeats2);
@@ -2760,7 +2760,7 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
     auto pButtonSyncEnabled2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
 
     // set beatgrid for deck 1
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
     pButtonSyncEnabled1->set(1.0);
@@ -2794,7 +2794,7 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
     EXPECT_TRUE(isFollower(m_sGroup2));
 
     // Load a new beatgrid during playing, this happens when the analyser is finished.
-    mixxx::BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(140), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -2819,7 +2819,7 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
     EXPECT_TRUE(isSoftLeader(m_sGroup2));
 
     // Load a new beatgrid again, this happens when the user adjusts the beatgrid
-    mixxx::BeatsPointer pBeats2n = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats2n = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack2->getSampleRate(), mixxx::Bpm(75), mixxx::audio::kStartFramePos);
     m_pTrack2->trySetBeats(pBeats2n);
 
@@ -2835,7 +2835,7 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
 
 TEST_F(EngineSyncTest, BeatMapQuantizePlay) {
     // This test demonstates https://bugs.launchpad.net/mixxx/+bug/1874918
-    mixxx::BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(
+    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
             m_pTrack1->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
     m_pTrack1->trySetBeats(pBeats1);
 

--- a/src/test/seratobeatgridtest.cpp
+++ b/src/test/seratobeatgridtest.cpp
@@ -117,7 +117,7 @@ TEST_F(SeratoBeatGridTest, SerializeBeatgrid) {
     const auto sampleRate = mixxx::audio::SampleRate(44100);
     EXPECT_EQ(sampleRate.isValid(), true);
     const auto pBeats = mixxx::BeatGrid::makeBeatGrid(
-            sampleRate, QString("Test"), bpm, mixxx::audio::kStartFramePos);
+            sampleRate, bpm, mixxx::audio::kStartFramePos);
     const auto signalInfo = mixxx::audio::SignalInfo(mixxx::audio::ChannelCount(2), sampleRate);
     const auto duration = mixxx::Duration::fromSeconds<int>(300);
 

--- a/src/track/beatfactory.cpp
+++ b/src/track/beatfactory.cpp
@@ -12,15 +12,6 @@ const QString kRoundingVersion = QStringLiteral("V4");
 
 } // namespace
 
-mixxx::BeatsPointer BeatFactory::makeBeatGrid(
-        mixxx::audio::SampleRate sampleRate,
-        mixxx::Bpm bpm,
-        mixxx::audio::FramePos firstBeatFramePos) {
-    DEBUG_ASSERT(firstBeatFramePos.isValid());
-    DEBUG_ASSERT(!firstBeatFramePos.isFractional());
-    return mixxx::BeatGrid::makeBeatGrid(sampleRate, QString(), bpm, firstBeatFramePos);
-}
-
 // static
 QString BeatFactory::getPreferredVersion(bool fixedTempo) {
     if (fixedTempo) {
@@ -89,7 +80,7 @@ mixxx::BeatsPointer BeatFactory::makePreferredBeats(
                 constantRegions, sampleRate, &firstBeat);
         firstBeat = BeatUtils::adjustPhase(firstBeat, constBPM, sampleRate, beats);
         auto pGrid = mixxx::BeatGrid::makeBeatGrid(
-                sampleRate, subVersion, constBPM, firstBeat);
+                sampleRate, constBPM, firstBeat, subVersion);
         return pGrid;
     } else if (version == BEAT_MAP_VERSION) {
         QVector<mixxx::audio::FramePos> ironedBeats = BeatUtils::getBeats(constantRegions);

--- a/src/track/beatfactory.h
+++ b/src/track/beatfactory.h
@@ -11,11 +11,6 @@ class Track;
 
 class BeatFactory {
   public:
-    static mixxx::BeatsPointer makeBeatGrid(
-            mixxx::audio::SampleRate sampleRate,
-            mixxx::Bpm bpm,
-            mixxx::audio::FramePos firstBeatFramePos);
-
     static QString getPreferredVersion(bool fixedTempo);
 
     static QString getPreferredSubVersion(

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -75,9 +75,9 @@ BeatGrid::BeatGrid(const BeatGrid& other)
 // static
 BeatsPointer BeatGrid::makeBeatGrid(
         audio::SampleRate sampleRate,
-        const QString& subVersion,
         mixxx::Bpm bpm,
-        mixxx::audio::FramePos firstBeatPosition) {
+        mixxx::audio::FramePos firstBeatPosition,
+        const QString& subVersion) {
     VERIFY_OR_DEBUG_ASSERT(bpm.isValid() && firstBeatPosition.isValid() &&
             !firstBeatPosition.isFractional()) {
         return nullptr;
@@ -113,7 +113,7 @@ BeatsPointer BeatGrid::fromByteArray(
     const auto firstBeat = mixxx::audio::FramePos(blob->firstBeat);
     const auto bpm = mixxx::Bpm(blob->bpm);
 
-    return makeBeatGrid(sampleRate, subVersion, bpm, firstBeat);
+    return makeBeatGrid(sampleRate, bpm, firstBeat, subVersion);
 }
 
 QByteArray BeatGrid::toByteArray() const {

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -78,8 +78,8 @@ BeatsPointer BeatGrid::makeBeatGrid(
         const QString& subVersion,
         mixxx::Bpm bpm,
         mixxx::audio::FramePos firstBeatPosition) {
-    // FIXME: Should this be a debug assertion?
-    if (!bpm.isValid() || !firstBeatPosition.isValid()) {
+    VERIFY_OR_DEBUG_ASSERT(bpm.isValid() && firstBeatPosition.isValid() &&
+            !firstBeatPosition.isFractional()) {
         return nullptr;
     }
 

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -19,9 +19,9 @@ class BeatGrid final : public Beats {
 
     static BeatsPointer makeBeatGrid(
             audio::SampleRate sampleRate,
-            const QString& subVersion,
             mixxx::Bpm bpm,
-            mixxx::audio::FramePos firstBeatPos);
+            mixxx::audio::FramePos firstBeatPos,
+            const QString& subVersion = QString());
 
     static BeatsPointer fromByteArray(
             audio::SampleRate sampleRate,

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -12,7 +12,7 @@
 #include <QtGlobal>
 #include <algorithm>
 
-#include "track/beatfactory.h"
+#include "track/beatgrid.h"
 #include "track/beatutils.h"
 #include "track/track.h"
 #include "util/math.h"
@@ -605,7 +605,7 @@ BeatsPointer BeatMap::setBpm(mixxx::Bpm bpm) {
     const auto firstBeatPosition = mixxx::audio::FramePos(m_beats.first().frame_position());
     DEBUG_ASSERT(firstBeatPosition.isValid());
 
-    return BeatFactory::makeBeatGrid(m_sampleRate, bpm, firstBeatPosition);
+    return mixxx::BeatGrid::makeBeatGrid(m_sampleRate, bpm, firstBeatPosition);
 }
 
 } // namespace mixxx

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -7,7 +7,7 @@
 #include "library/library_prefs.h"
 #include "moc_track.cpp"
 #include "sources/metadatasource.h"
-#include "track/beatfactory.h"
+#include "track/beatgrid.h"
 #include "track/beatmap.h"
 #include "track/trackref.h"
 #include "util/assert.h"
@@ -355,7 +355,7 @@ bool Track::trySetBpmWhileLocked(mixxx::Bpm bpm) {
         if (!cuePosition.isValid()) {
             cuePosition = mixxx::audio::kStartFramePos;
         }
-        auto pBeats = BeatFactory::makeBeatGrid(getSampleRate(),
+        auto pBeats = mixxx::BeatGrid::makeBeatGrid(getSampleRate(),
                 bpm,
                 cuePosition);
         return trySetBeatsWhileLocked(std::move(pBeats));


### PR DESCRIPTION
That function and just calls `BeatGrid::makeBeatGrid` internally. This is useless indirection.