### PR TITLE
BeatsPointer: Use std::shared_ptr instead of QSharedPointer

### DIFF
--- a/src/engine/controls/quantizecontrol.cpp
+++ b/src/engine/controls/quantizecontrol.cpp
@@ -38,7 +38,7 @@ void QuantizeControl::trackLoaded(TrackPointer pNewTrack) {
         lookupBeatPositions(mixxx::audio::kStartFramePos);
         updateClosestBeat(mixxx::audio::kStartFramePos);
     } else {
-        m_pBeats.clear();
+        m_pBeats.reset();
         m_pCOPrevBeat->set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
         m_pCONextBeat->set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
         m_pCOClosestBeat->set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -593,7 +593,7 @@ void bindTrackLibraryValues(
     QString beatsSubVersion;
     // Fall back on cached BPM
     mixxx::Bpm bpm = trackInfo.getBpm();
-    if (!pBeats.isNull()) {
+    if (pBeats) {
         beatsBlob = pBeats->toByteArray();
         beatsVersion = pBeats->getVersion();
         beatsSubVersion = pBeats->getSubVersion();

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -513,7 +513,7 @@ void DlgTrackInfo::clear() {
 
     resetTrackRecord();
 
-    m_pBeatsClone.clear();
+    m_pBeatsClone.reset();
     updateSpinBpmFromBeats();
 
     txtLocation->setText("");
@@ -550,7 +550,7 @@ void DlgTrackInfo::slotBpmThreeHalves() {
 }
 
 void DlgTrackInfo::slotBpmClear() {
-    m_pBeatsClone.clear();
+    m_pBeatsClone.reset();
     updateSpinBpmFromBeats();
 
     bpmConst->setChecked(true);
@@ -576,7 +576,7 @@ void DlgTrackInfo::slotBpmConstChanged(int state) {
                     bpm,
                     cuePosition);
         } else {
-            m_pBeatsClone.clear();
+            m_pBeatsClone.reset();
         }
         spinBpm->setEnabled(true);
         bpmTap->setEnabled(true);
@@ -604,7 +604,7 @@ void DlgTrackInfo::slotBpmTap(double averageLength, int numSamples) {
 void DlgTrackInfo::slotSpinBpmValueChanged(double value) {
     const auto bpm = mixxx::Bpm(value);
     if (!bpm.isValid()) {
-        m_pBeatsClone.clear();
+        m_pBeatsClone.reset();
         return;
     }
 

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -156,7 +156,7 @@ TEST(BeatGridTest, FromMetadata) {
     EXPECT_DOUBLE_EQ(pTrack->getBpm(), mixxx::Bpm::kValueUndefined);
 
     pBeats = pTrack->getBeats();
-    EXPECT_EQ(pBeats.isNull(), true);
+    EXPECT_EQ(nullptr, pBeats);
 }
 
 }  // namespace

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -2,8 +2,8 @@
 
 #include <QByteArray>
 #include <QList>
-#include <QSharedPointer>
 #include <QString>
+#include <memory>
 
 #include "audio/frame.h"
 #include "audio/types.h"
@@ -14,7 +14,7 @@
 namespace mixxx {
 
 class Beats;
-typedef QSharedPointer<Beats> BeatsPointer;
+typedef std::shared_ptr<Beats> BeatsPointer;
 
 class BeatIterator {
   public:


### PR DESCRIPTION
BeatGrid/BeatMap don't inherit from QObject, so we can simply use
std::shared_ptr.