### PR TITLE
BeatFactory: Round beatgrid frame positions in makePreferredBeats()

### DIFF
--- a/src/track/beatfactory.cpp
+++ b/src/track/beatfactory.cpp
@@ -80,7 +80,7 @@ mixxx::BeatsPointer BeatFactory::makePreferredBeats(
                 constantRegions, sampleRate, &firstBeat);
         firstBeat = BeatUtils::adjustPhase(firstBeat, constBPM, sampleRate, beats);
         auto pGrid = mixxx::BeatGrid::makeBeatGrid(
-                sampleRate, constBPM, firstBeat, subVersion);
+                sampleRate, constBPM, firstBeat.toNearestFrameBoundary(), subVersion);
         return pGrid;
     } else if (version == BEAT_MAP_VERSION) {
         QVector<mixxx::audio::FramePos> ironedBeats = BeatUtils::getBeats(constantRegions);


### PR DESCRIPTION
Due to our internal beatgrid storage format, fractional beat positions
are not allowed.

Fixes https://github.com/mixxxdj/mixxx/pull/4258/files#r702285221.

Alternative to #4261.