### PR TITLE
LoopingControl: Handle invalid start position properly (lp1942715)

### DIFF
--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -959,19 +959,17 @@ void LoopingControl::slotLoopStartPos(double positionSamples) {
     if (!position.isValid()) {
         emit loopReset();
         setLoopingEnabled(false);
+    } else if (loopInfo.endPosition.isValid() && loopInfo.endPosition <= position) {
+        emit loopReset();
+        loopInfo.endPosition = mixxx::audio::kInvalidFramePos;
+        m_pCOLoopEndPosition->set(kNoTrigger);
+        setLoopingEnabled(false);
     }
 
     loopInfo.seekMode = LoopSeekMode::MovedOut;
     loopInfo.startPosition = position;
     m_pCOLoopStartPosition->set(position.toEngineSamplePosMaybeInvalid());
 
-    if (loopInfo.startPosition.isValid() && loopInfo.endPosition.isValid() &&
-            loopInfo.endPosition <= loopInfo.startPosition) {
-        emit loopReset();
-        loopInfo.endPosition = mixxx::audio::kInvalidFramePos;
-        m_pCOLoopEndPosition->set(kNoTrigger);
-        setLoopingEnabled(false);
-    }
     m_loopInfo.setValue(loopInfo);
 }
 

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -946,30 +946,35 @@ void LoopingControl::slotReloopAndStop(double pressed) {
 
 void LoopingControl::slotLoopStartPos(double positionSamples) {
     // This slot is called before trackLoaded() for a new Track
-    const auto position = mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(positionSamples);
 
     LoopInfo loopInfo = m_loopInfo.getValue();
-    if (loopInfo.startPosition == position) {
-        //nothing to do
-        return;
+
+    {
+        const auto position =
+                mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
+                        positionSamples);
+        if (loopInfo.startPosition == position) {
+            // Nothing to do
+            return;
+        }
+        loopInfo.startPosition = position;
     }
+
+    loopInfo.seekMode = LoopSeekMode::MovedOut;
 
     clearActiveBeatLoop();
 
-    if (!position.isValid()) {
+    if (!loopInfo.startPosition.isValid()) {
         emit loopReset();
         setLoopingEnabled(false);
-    } else if (loopInfo.endPosition.isValid() && loopInfo.endPosition <= position) {
+    } else if (loopInfo.endPosition.isValid() && loopInfo.endPosition <= loopInfo.startPosition) {
         emit loopReset();
         loopInfo.endPosition = mixxx::audio::kInvalidFramePos;
         m_pCOLoopEndPosition->set(kNoTrigger);
         setLoopingEnabled(false);
     }
 
-    loopInfo.seekMode = LoopSeekMode::MovedOut;
-    loopInfo.startPosition = position;
-    m_pCOLoopStartPosition->set(position.toEngineSamplePosMaybeInvalid());
-
+    m_pCOLoopStartPosition->set(loopInfo.startPosition.toEngineSamplePosMaybeInvalid());
     m_loopInfo.setValue(loopInfo);
 }
 

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -965,7 +965,8 @@ void LoopingControl::slotLoopStartPos(double positionSamples) {
     loopInfo.startPosition = position;
     m_pCOLoopStartPosition->set(position.toEngineSamplePosMaybeInvalid());
 
-    if (loopInfo.endPosition.isValid() && loopInfo.endPosition <= loopInfo.startPosition) {
+    if (loopInfo.startPosition.isValid() && loopInfo.endPosition.isValid() &&
+            loopInfo.endPosition <= loopInfo.startPosition) {
         emit loopReset();
         loopInfo.endPosition = mixxx::audio::kInvalidFramePos;
         m_pCOLoopEndPosition->set(kNoTrigger);


### PR DESCRIPTION
An invalid start position resets the loop anyway.

See this for details: https://bugs.launchpad.net/mixxx/+bug/1942715