### PR TITLE
Beats: Hide beatmap/beatgrid implementation from calling code

### DIFF
--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -11,7 +11,6 @@
 #include "library/rekordbox/rekordboxconstants.h"
 #include "track/beatfactory.h"
 #include "track/beatgrid.h"
-#include "track/beatmap.h"
 #include "track/beatutils.h"
 #include "track/track.h"
 

--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -10,7 +10,6 @@
 #include "analyzer/plugins/analyzersoundtouchbeats.h"
 #include "library/rekordbox/rekordboxconstants.h"
 #include "track/beatfactory.h"
-#include "track/beatgrid.h"
 #include "track/beatutils.h"
 #include "track/track.h"
 
@@ -234,7 +233,7 @@ void AnalyzerBeats::storeResults(TrackPointer pTrack) {
     } else {
         mixxx::Bpm bpm = m_pPlugin->getBpm();
         qDebug() << "AnalyzerBeats plugin detected constant BPM: " << bpm;
-        pBeats = mixxx::BeatGrid::makeBeatGrid(m_sampleRate, bpm, mixxx::audio::kStartFramePos);
+        pBeats = mixxx::Beats::fromConstTempo(m_sampleRate, mixxx::audio::kStartFramePos, bpm);
     }
 
     pTrack->trySetBeats(pBeats);

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -24,7 +24,6 @@
 #include "library/trackset/crate/cratestorage.h"
 #include "moc_trackdao.cpp"
 #include "sources/soundsourceproxy.h"
-#include "track/beatgrid.h"
 #include "track/beats.h"
 #include "track/globaltrackcache.h"
 #include "track/keyfactory.h"
@@ -1245,8 +1244,8 @@ bool setTrackBeats(const QSqlRecord& record, const int column, Track* pTrack) {
         }
     } else if (bpm.isValid()) {
         // Load a temporary beat grid without offset that will be replaced by the analyzer.
-        const auto pBeats = mixxx::BeatGrid::makeBeatGrid(
-                pTrack->getSampleRate(), bpm, mixxx::audio::kStartFramePos);
+        const auto pBeats = mixxx::Beats::fromConstTempo(
+                pTrack->getSampleRate(), mixxx::audio::kStartFramePos, bpm);
         pTrack->trySetBeats(pBeats);
     } else {
         pTrack->trySetBeats(nullptr);

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -14,7 +14,6 @@
 #include "moc_dlgtrackinfo.cpp"
 #include "preferences/colorpalettesettings.h"
 #include "sources/soundsourceproxy.h"
-#include "track/beatgrid.h"
 #include "track/beatutils.h"
 #include "track/keyfactory.h"
 #include "track/keyutils.h"
@@ -573,10 +572,10 @@ void DlgTrackInfo::slotBpmConstChanged(int state) {
             // The cue point should be set on a beat, so this seems
             // to be a good alternative
             const mixxx::audio::FramePos cuePosition = m_pLoadedTrack->getMainCuePosition();
-            m_pBeatsClone = mixxx::BeatGrid::makeBeatGrid(
+            m_pBeatsClone = mixxx::Beats::fromConstTempo(
                     m_pLoadedTrack->getSampleRate(),
-                    bpm,
-                    cuePosition);
+                    cuePosition,
+                    bpm);
         } else {
             m_pBeatsClone.reset();
         }
@@ -612,10 +611,10 @@ void DlgTrackInfo::slotSpinBpmValueChanged(double value) {
 
     if (!m_pBeatsClone) {
         const mixxx::audio::FramePos cuePosition = m_pLoadedTrack->getMainCuePosition();
-        m_pBeatsClone = mixxx::BeatGrid::makeBeatGrid(
+        m_pBeatsClone = mixxx::Beats::fromConstTempo(
                 m_pLoadedTrack->getSampleRate(),
-                bpm,
-                cuePosition);
+                cuePosition,
+                bpm);
     }
 
     const mixxx::Bpm oldValue = m_pBeatsClone->getBpm();

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -19,7 +19,7 @@
 #include "library/trackcollectionmanager.h"
 #include "library/treeitem.h"
 #include "moc_rekordboxfeature.cpp"
-#include "track/beatmap.h"
+#include "track/beats.h"
 #include "track/cue.h"
 #include "track/keyfactory.h"
 #include "track/track.h"
@@ -938,10 +938,10 @@ void readAnalyze(TrackPointer track,
                 beats << mixxx::audio::FramePos(sampleRateKhz * static_cast<double>(time));
             }
 
-            const auto pBeats = mixxx::BeatMap::makeBeatMap(
+            const auto pBeats = mixxx::Beats::fromBeatPositions(
                     sampleRate,
-                    mixxx::rekordboxconstants::beatsSubversion,
-                    beats);
+                    beats,
+                    mixxx::rekordboxconstants::beatsSubversion);
             track->trySetBeats(pBeats);
         } break;
         case rekordbox_anlz_t::SECTION_TAGS_CUES: {

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -2,7 +2,7 @@
 
 #include <QtDebug>
 
-#include "track/beatgrid.h"
+#include "track/beats.h"
 #include "track/track.h"
 #include "util/memory.h"
 
@@ -29,9 +29,9 @@ TEST(BeatGridTest, Scale) {
     constexpr mixxx::Bpm bpm(60.0);
     pTrack->trySetBpm(bpm.value());
 
-    auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
-            mixxx::Bpm(bpm),
-            mixxx::audio::kStartFramePos);
+    auto pGrid = Beats::fromConstTempo(pTrack->getSampleRate(),
+            mixxx::audio::kStartFramePos,
+            mixxx::Bpm(bpm));
 
     EXPECT_DOUBLE_EQ(bpm.value(), pGrid->getBpm().value());
     pGrid = pGrid->scale(Beats::BpmScale::Double);
@@ -61,9 +61,9 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat) {
     pTrack->trySetBpm(bpm);
     constexpr mixxx::audio::FrameDiff_t beatLengthFrames = 60.0 * sampleRate / bpm;
 
-    auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
-            mixxx::Bpm(bpm),
-            mixxx::audio::kStartFramePos);
+    auto pGrid = Beats::fromConstTempo(pTrack->getSampleRate(),
+            mixxx::audio::kStartFramePos,
+            mixxx::Bpm(bpm));
     // Pretend we're on the 20th beat;
     constexpr mixxx::audio::FramePos position(beatLengthFrames * 20);
 
@@ -105,9 +105,9 @@ TEST(BeatGridTest, TestNthBeatWhenNotOnBeat) {
     pTrack->trySetBpm(bpm.value());
     const mixxx::audio::FrameDiff_t beatLengthFrames = 60.0 * sampleRate / bpm.value();
 
-    auto pGrid = BeatGrid::makeBeatGrid(pTrack->getSampleRate(),
-            bpm,
-            mixxx::audio::kStartFramePos);
+    auto pGrid = Beats::fromConstTempo(pTrack->getSampleRate(),
+            mixxx::audio::kStartFramePos,
+            bpm);
 
     // Pretend we're half way between the 20th and 21st beat
     const mixxx::audio::FramePos previousBeat(beatLengthFrames * 20.0);

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -3,7 +3,7 @@
 
 #include <QtDebug>
 
-#include "track/beatmap.h"
+#include "track/beats.h"
 #include "track/track.h"
 
 using namespace mixxx;
@@ -60,7 +60,7 @@ TEST_F(BeatMapTest, Scale) {
     // Note beats must be in frames, not samples.
     QVector<mixxx::audio::FramePos> beats =
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
+    auto pMap = Beats::fromBeatPositions(m_pTrack->getSampleRate(), beats);
 
     EXPECT_DOUBLE_EQ(bpm.value(), pMap->getBpm().value());
     pMap = pMap->scale(Beats::BpmScale::Double);
@@ -91,7 +91,7 @@ TEST_F(BeatMapTest, TestNthBeat) {
     // Note beats must be in frames, not samples.
     QVector<mixxx::audio::FramePos> beats =
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
+    auto pMap = Beats::fromBeatPositions(m_pTrack->getSampleRate(), beats);
 
     // Check edge cases
     const mixxx::audio::FramePos firstBeat = startOffsetFrames + beatLengthFrames * 0;
@@ -137,7 +137,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat) {
     // Note beats must be in frames, not samples.
     QVector<mixxx::audio::FramePos> beats =
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
+    auto pMap = Beats::fromBeatPositions(m_pTrack->getSampleRate(), beats);
 
     // Pretend we're on the 20th beat;
     const int curBeat = 20;
@@ -180,7 +180,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
     // Note beats must be in frames, not samples.
     QVector<mixxx::audio::FramePos> beats =
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
+    auto pMap = Beats::fromBeatPositions(m_pTrack->getSampleRate(), beats);
 
     // Pretend we're half way between the 20th and 21st beat
     const mixxx::audio::FramePos previousBeat = startOffsetFrames + beatLengthFrames * 20.0;
@@ -225,7 +225,7 @@ TEST_F(BeatMapTest, TestBpmAround) {
         beat_pos += beat_length;
     }
 
-    auto pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
+    auto pMap = Beats::fromBeatPositions(m_pTrack->getSampleRate(), beats);
 
     // The average of the first 8 beats should be different than the average
     // of the last 8 beats.
@@ -251,7 +251,7 @@ TEST_F(BeatMapTest, TestBpmAround) {
     // Try a really, really short track
     constexpr auto startFramePos = mixxx::audio::FramePos(10);
     beats = createBeatVector(startFramePos, 3, approx_beat_length);
-    pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
+    pMap = Beats::fromBeatPositions(m_pTrack->getSampleRate(), beats);
     EXPECT_DOUBLE_EQ(filebpm.value(),
             pMap->getBpmAroundPosition(
                         mixxx::audio::kStartFramePos + 1 * approx_beat_length,
@@ -271,7 +271,7 @@ TEST_F(BeatMapTest, FindBeatsWithFractionalPos) {
     for (; beatPos <= lastBeatPos; beatPos += beatLengthFrames) {
         beats.append(beatPos);
     }
-    const auto pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
+    const auto pMap = Beats::fromBeatPositions(m_pTrack->getSampleRate(), beats);
 
     // All beats are in range
     auto it = pMap->findBeats(mixxx::audio::kStartFramePos, lastBeatPos);
@@ -318,7 +318,7 @@ TEST_F(BeatMapTest, HasBeatInRangeWithFractionalPos) {
     for (; beatPos <= lastBeatPos; beatPos += beatLengthFrames) {
         beats.append(beatPos);
     }
-    const auto pMap = BeatMap::makeBeatMap(m_pTrack->getSampleRate(), QString(), beats);
+    const auto pMap = Beats::fromBeatPositions(m_pTrack->getSampleRate(), beats);
 
     const mixxx::audio::FrameDiff_t halfBeatLengthFrames = beatLengthFrames / 2;
     EXPECT_TRUE(pMap->hasBeatInRange(mixxx::audio::kStartFramePos,

--- a/src/test/beatstranslatetest.cpp
+++ b/src/test/beatstranslatetest.cpp
@@ -1,5 +1,5 @@
 #include "test/mockedenginebackendtest.h"
-#include "track/beatgrid.h"
+#include "track/beats.h"
 #include "util/memory.h"
 
 class BeatsTranslateTest : public MockedEngineBackendTest {
@@ -9,14 +9,14 @@ TEST_F(BeatsTranslateTest, SimpleTranslateMatch) {
     // Set up BeatGrids for decks 1 and 2.
     const auto bpm = mixxx::Bpm(60.0);
     constexpr auto firstBeat = mixxx::audio::kStartFramePos;
-    auto grid1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), bpm, firstBeat);
+    auto grid1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), firstBeat, bpm);
     m_pTrack1->trySetBeats(grid1);
     ASSERT_DOUBLE_EQ(firstBeat.value(),
             grid1->findClosestBeat(mixxx::audio::kStartFramePos).value());
 
-    auto grid2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), bpm, firstBeat);
+    auto grid2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), firstBeat, bpm);
     m_pTrack2->trySetBeats(grid2);
     ASSERT_DOUBLE_EQ(firstBeat.value(),
             grid2->findClosestBeat(mixxx::audio::kStartFramePos).value());

--- a/src/test/bpmcontrol_test.cpp
+++ b/src/test/bpmcontrol_test.cpp
@@ -1,14 +1,14 @@
+#include "engine/controls/bpmcontrol.h"
+
 #include <gtest/gtest.h>
 
-#include <QtDebug>
 #include <QScopedPointer>
+#include <QtDebug>
 
-#include "mixxxtest.h"
 #include "control/controlobject.h"
 #include "control/controlpushbutton.h"
-#include "engine/controls/bpmcontrol.h"
-#include "track/beatgrid.h"
-#include "track/beatmap.h"
+#include "mixxxtest.h"
+#include "track/beats.h"
 #include "track/track.h"
 
 class BpmControlTest : public MixxxTest {
@@ -35,8 +35,8 @@ TEST_F(BpmControlTest, BeatContext_BeatGrid) {
     const auto bpm = mixxx::Bpm(60.0);
     const mixxx::audio::FrameDiff_t expectedBeatLengthFrames = (60.0 * sampleRate / bpm.value());
 
-    const mixxx::BeatsPointer pBeats = mixxx::BeatGrid::makeBeatGrid(
-            pTrack->getSampleRate(), bpm, mixxx::audio::kStartFramePos);
+    const mixxx::BeatsPointer pBeats = mixxx::Beats::fromConstTempo(
+            pTrack->getSampleRate(), mixxx::audio::kStartFramePos, bpm);
 
     // On a beat.
     mixxx::audio::FramePos prevBeatPosition;

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -11,7 +11,6 @@
 #include "test/mixxxtest.h"
 #include "test/mockedenginebackendtest.h"
 #include "track/beatgrid.h"
-#include "track/beatmap.h"
 #include "util/memory.h"
 
 namespace {
@@ -1989,13 +1988,13 @@ TEST_F(EngineSyncTest, HalfDoubleConsistency) {
     const int numBeats = 100;
     QVector<mixxx::audio::FramePos> beats1 =
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pBeats1 = mixxx::BeatMap::makeBeatMap(m_pTrack1->getSampleRate(), QString(), beats1);
+    auto pBeats1 = mixxx::Beats::fromBeatPositions(m_pTrack1->getSampleRate(), beats1);
     m_pTrack1->trySetBeats(pBeats1);
 
     beatLengthFrames = 60.0 * 44100 / 145.0;
     QVector<mixxx::audio::FramePos> beats2 =
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    auto pBeats2 = mixxx::BeatMap::makeBeatMap(m_pTrack2->getSampleRate(), QString(), beats2);
+    auto pBeats2 = mixxx::Beats::fromBeatPositions(m_pTrack2->getSampleRate(), beats2);
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
@@ -2841,8 +2840,7 @@ TEST_F(EngineSyncTest, BeatMapQuantizePlay) {
 
     constexpr auto kSampleRate = mixxx::audio::SampleRate(44100);
 
-    auto pBeats2 = mixxx::BeatMap::makeBeatMap(kSampleRate,
-            QString(),
+    auto pBeats2 = mixxx::Beats::fromBeatPositions(kSampleRate,
             // Add two beats at 120 Bpm
             QVector<mixxx::audio::FramePos>(
                     {mixxx::audio::FramePos(

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -10,7 +10,7 @@
 #include "preferences/usersettings.h"
 #include "test/mixxxtest.h"
 #include "test/mockedenginebackendtest.h"
-#include "track/beatgrid.h"
+#include "track/beats.h"
 #include "util/memory.h"
 
 namespace {
@@ -243,11 +243,11 @@ TEST_F(EngineSyncTest, SetLeaderSuccess) {
 TEST_F(EngineSyncTest, ExplicitLeaderPersists) {
     // If we set an explicit leader, enabling sync or pressing play on other decks
     // doesn't cause the leader to move around.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(120));
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(124), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(124));
     m_pTrack2->trySetBeats(pBeats2);
 
     auto pButtonLeaderSync1 =
@@ -277,14 +277,14 @@ TEST_F(EngineSyncTest, ExplicitLeaderPersists) {
 
 TEST_F(EngineSyncTest, SetLeaderWhilePlaying) {
     // Make sure we don't get two leader lights if we change leaders while playing.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(120));
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(124), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(124));
     m_pTrack2->trySetBeats(pBeats2);
-    mixxx::BeatsPointer pBeats3 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack3->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats3 = mixxx::Beats::fromConstTempo(
+            m_pTrack3->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(128));
     m_pTrack3->trySetBeats(pBeats3);
 
     auto pButtonLeaderSync1 =
@@ -314,8 +314,8 @@ TEST_F(EngineSyncTest, SetLeaderWhilePlaying) {
 
 TEST_F(EngineSyncTest, SetEnabledBecomesLeader) {
     // If we set the first channel with a valid tempo to follower, it should be leader.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(80), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(80));
     m_pTrack1->trySetBeats(pBeats1);
     auto pButtonLeaderSync1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
@@ -341,12 +341,12 @@ TEST_F(EngineSyncTest, DisableInternalLeaderWhilePlaying) {
     EXPECT_TRUE(isExplicitLeader(m_sInternalClockGroup));
 
     // Make sure both decks are playing.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(80), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(80));
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(80), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(80));
     m_pTrack2->trySetBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup2, "play"))->set(1.0);
     ProcessBuffer();
@@ -362,15 +362,15 @@ TEST_F(EngineSyncTest, DisableInternalLeaderWhilePlaying) {
 
 TEST_F(EngineSyncTest, DisableSyncOnLeader) {
     // Channel 1 follower, channel 2 leader.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(130));
     m_pTrack1->trySetBeats(pBeats1);
     auto pButtonSyncMode1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     pButtonSyncMode1->set(static_cast<double>(SyncMode::Follower));
 
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(130));
     m_pTrack2->trySetBeats(pBeats2);
     // Set deck two to explicit leader.
     auto pButtonSyncLeader2 =
@@ -408,8 +408,8 @@ TEST_F(EngineSyncTest, InternalLeaderSetFollowerSliderMoves) {
     pButtonLeaderSyncInternal->set(1);
 
     // Set the file bpm of channel 1 to 80 bpm.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(80), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(80));
     m_pTrack1->trySetBeats(pBeats1);
 
     auto pButtonLeaderSync1 =
@@ -427,8 +427,8 @@ TEST_F(EngineSyncTest, AnySyncDeckSliderStays) {
     // If there exists a sync deck, even if it's not playing, don't change the
     // leader BPM if a new deck enables sync.
 
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(80), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(80));
     m_pTrack1->trySetBeats(pBeats1);
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
@@ -439,8 +439,8 @@ TEST_F(EngineSyncTest, AnySyncDeckSliderStays) {
             ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))
                     ->get());
 
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(100));
     m_pTrack2->trySetBeats(pBeats2);
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
@@ -464,13 +464,13 @@ TEST_F(EngineSyncTest, InternalClockFollowsFirstPlayingDeck) {
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
 
     // Set up decks so they can be playing, and start deck 1.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(100));
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(130));
     m_pTrack2->trySetBeats(pBeats2);
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup2, "play"), 0.0);
@@ -536,12 +536,12 @@ TEST_F(EngineSyncTest, SetExplicitLeaderByLights) {
             std::make_unique<ControlProxy>(m_sGroup2, "sync_leader");
 
     // Set the file bpm of channel 1 to 160bpm.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(160));
     m_pTrack1->trySetBeats(pBeats1);
     // Set the file bpm of channel 2 to 150bpm.
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(150), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(150));
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
@@ -619,8 +619,8 @@ TEST_F(EngineSyncTest, RateChangeTest) {
     ProcessBuffer();
 
     // Set the file bpm of channel 1 to 160bpm.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(160));
     m_pTrack1->trySetBeats(pBeats1);
     EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sGroup1, "file_bpm")));
@@ -639,8 +639,8 @@ TEST_F(EngineSyncTest, RateChangeTest) {
             192.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(120));
     m_pTrack2->trySetBeats(pBeats2);
     EXPECT_DOUBLE_EQ(
             120.0, ControlObject::get(ConfigKey(m_sGroup2, "file_bpm")));
@@ -662,15 +662,15 @@ TEST_F(EngineSyncTest, RateChangeTestWeirdOrder) {
     ProcessBuffer();
 
     // Set the file bpm of channel 1 to 160bpm.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(160));
     m_pTrack1->trySetBeats(pBeats1);
     EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(120));
     m_pTrack2->trySetBeats(pBeats2);
 
     // Set the rate slider of channel 1 to 1.2.
@@ -688,15 +688,15 @@ TEST_F(EngineSyncTest, RateChangeTestWeirdOrder) {
 
 TEST_F(EngineSyncTest, RateChangeTestOrder3) {
     // Set the file bpm of channel 1 to 160bpm.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(160));
     m_pTrack1->trySetBeats(pBeats1);
     EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sGroup1, "file_bpm")));
 
     // Set the file bpm of channel 2 to 120bpm.
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(120));
     m_pTrack2->trySetBeats(pBeats2);
     EXPECT_DOUBLE_EQ(
             120.0, ControlObject::get(ConfigKey(m_sGroup2, "file_bpm")));
@@ -736,13 +736,13 @@ TEST_F(EngineSyncTest, FollowerRateChange) {
     ProcessBuffer();
 
     // Set the file bpm of channel 1 to 160bpm.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(160));
     m_pTrack1->trySetBeats(pBeats1);
 
     // Set the file bpm of channel 2 to 120bpm.
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(120));
     m_pTrack2->trySetBeats(pBeats2);
 
     // Set the rate slider of channel 1 to 1.2.
@@ -784,15 +784,15 @@ TEST_F(EngineSyncTest, InternalRateChangeTest) {
     EXPECT_TRUE(isFollower(m_sGroup2));
 
     // Set the file bpm of channel 1 to 160bpm.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(160));
     m_pTrack1->trySetBeats(pBeats1);
     EXPECT_DOUBLE_EQ(160.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "file_bpm"))->get());
 
     // Set the file bpm of channel 2 to 120bpm.
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(120));
     m_pTrack2->trySetBeats(pBeats2);
     EXPECT_DOUBLE_EQ(120.0,
             ControlObject::getControl(ConfigKey(m_sGroup2, "file_bpm"))->get());
@@ -838,11 +838,11 @@ TEST_F(EngineSyncTest, InternalRateChangeTest) {
 
 TEST_F(EngineSyncTest, LeaderStopSliderCheck) {
     // If the leader is playing, and stop is pushed, the sliders should stay the same.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(120));
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(128));
     m_pTrack2->trySetBeats(pBeats2);
 
     auto pButtonLeaderSync1 =
@@ -884,8 +884,8 @@ TEST_F(EngineSyncTest, EnableOneDeckInitsLeader) {
     ProcessBuffer();
 
     // Set up the deck to play.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(130));
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
             ->set(getRateSliderValue(1.0));
@@ -912,8 +912,8 @@ TEST_F(EngineSyncTest, EnableOneDeckInitsLeader) {
                     ConfigKey(m_sInternalClockGroup, "beat_distance")));
 
     // Enable second deck, bpm and beat distance should still match original setting.
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(140), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(140));
     m_pTrack2->trySetBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))
             ->set(getRateSliderValue(1.0));
@@ -941,11 +941,11 @@ TEST_F(EngineSyncTest, MomentarySyncAlgorithmTwo) {
     m_pConfig->set(ConfigKey("[BPM]", "sync_lock_algorithm"),
             ConfigValue(EngineSync::PREFER_LOCK_BPM));
 
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(120));
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(128));
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup2, "play"))->set(1.0);
@@ -963,8 +963,8 @@ TEST_F(EngineSyncTest, MomentarySyncAlgorithmTwo) {
 TEST_F(EngineSyncTest, EnableOneDeckInitializesLeader) {
     // Enabling sync on a deck causes it to be leader, and sets bpm and clock.
     // Set the deck to play.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(130));
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
             ->set(getRateSliderValue(1.0));
@@ -1154,8 +1154,8 @@ TEST_F(EngineSyncTest, EnableOneDeckSliderUpdates) {
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
 
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(130));
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
             ->set(getRateSliderValue(1.0));
@@ -1182,13 +1182,13 @@ TEST_F(EngineSyncTest, SyncToNonSyncDeck) {
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
 
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(130));
     m_pTrack1->trySetBeats(pBeats1);
     ProcessBuffer();
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(100));
     m_pTrack2->trySetBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))
             ->set(getRateSliderValue(1.0));
@@ -1270,13 +1270,13 @@ TEST_F(EngineSyncTest, MomentarySyncDependsOnPlayingStates) {
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
 
     // Set up decks so they can be playing, and start deck 1.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(100));
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(130));
     m_pTrack2->trySetBeats(pBeats2);
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
     ControlObject::set(ConfigKey(m_sGroup2, "play"), 1.0);
@@ -1346,8 +1346,8 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     auto pButtonEject1 = std::make_unique<ControlProxy>(m_sGroup1, "eject");
 
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(120));
     m_pTrack1->trySetBeats(pBeats1);
     pButtonSyncEnabled1->set(1.0);
     ProcessBuffer();
@@ -1372,8 +1372,8 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
     m_pMixerDeck1->loadFakeTrack(false, 128.0);
     EXPECT_DOUBLE_EQ(128.0,
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(135), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(135));
     m_pTrack2->trySetBeats(pBeats2);
     pButtonSyncEnabled2->set(1.0);
     ProcessBuffer();
@@ -1393,16 +1393,16 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
 
 TEST_F(EngineSyncTest, FileBpmChangesDontAffectLeader) {
     // If filebpm changes, don't treat it like a rate change unless it's the leader.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(100));
     m_pTrack1->trySetBeats(pBeats1);
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     pButtonSyncEnabled1->set(1.0);
     ProcessBuffer();
 
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(120));
     m_pTrack2->trySetBeats(pBeats2);
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
@@ -1413,8 +1413,8 @@ TEST_F(EngineSyncTest, FileBpmChangesDontAffectLeader) {
     EXPECT_TRUE(isFollower(m_sGroup2));
 
     // Update the leader's beats -- update the internal clock
-    pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
+    pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(160));
     m_pTrack1->trySetBeats(pBeats1);
     EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
@@ -1422,8 +1422,8 @@ TEST_F(EngineSyncTest, FileBpmChangesDontAffectLeader) {
     EXPECT_TRUE(isSoftLeader(m_sGroup1));
 
     // Update follower beats -- don't update internal clock.
-    pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(140), mixxx::audio::kStartFramePos);
+    pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(140));
     m_pTrack2->trySetBeats(pBeats2);
     EXPECT_DOUBLE_EQ(
             160.0, ControlObject::get(ConfigKey(m_sInternalClockGroup, "bpm")));
@@ -1435,8 +1435,8 @@ TEST_F(EngineSyncTest, ExplicitLeaderPostProcessed) {
     auto pButtonLeaderSync1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     pButtonLeaderSync1->set(static_cast<double>(SyncMode::LeaderExplicit));
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(160));
     m_pTrack1->trySetBeats(pBeats1);
     ProcessBuffer();
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
@@ -1458,8 +1458,8 @@ TEST_F(EngineSyncTest, ZeroBPMRateAdjustIgnored) {
             ->set(getRateSliderValue(1.0));
     ProcessBuffer();
 
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(120));
     m_pTrack2->trySetBeats(pBeats2);
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
@@ -1497,8 +1497,8 @@ TEST_F(EngineSyncTest, BeatDistanceBeforeStart) {
     // If the start position is before zero, we should still initialize the beat distance
     // correctly.  Unfortunately, this currently doesn't work.
 
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(128));
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
     ControlObject::set(ConfigKey(m_sGroup1, "playposition"), -.05);
@@ -1515,11 +1515,11 @@ TEST_F(EngineSyncTest, BeatDistanceBeforeStart) {
 TEST_F(EngineSyncTest, ZeroLatencyRateChangeNoQuant) {
     // Confirm that a rate change in an explicit leader is instantly communicated
     // to followers.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(128));
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(160));
     m_pTrack2->trySetBeats(pBeats2);
 
     // Make Channel2 leader to weed out any channel ordering issues.
@@ -1565,11 +1565,11 @@ TEST_F(EngineSyncTest, ZeroLatencyRateChangeNoQuant) {
 TEST_F(EngineSyncTest, ZeroLatencyRateChangeQuant) {
     // Confirm that a rate change in an explicit leader is instantly communicated
     // to followers.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(128));
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(160));
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
@@ -1620,11 +1620,11 @@ TEST_F(EngineSyncTest, ZeroLatencyRateChangeQuant) {
 TEST_F(EngineSyncTest, ZeroLatencyRateDiffQuant) {
     // Confirm that a rate change in an explicit leader is instantly communicated
     // to followers.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(128));
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(160), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(160));
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup2, "quantize"))->set(1.0);
@@ -1676,11 +1676,11 @@ TEST_F(EngineSyncTest, ZeroLatencyRateDiffQuant) {
 // need to check. The Sync feature is unfortunately brittle.
 // This test exercises https://bugs.launchpad.net/mixxx/+bug/1884324
 TEST_F(EngineSyncTest, ActivatingSyncDoesNotCauseDrifting) {
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(150), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(150));
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(150), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(150));
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(0.0);
@@ -1722,11 +1722,11 @@ TEST_F(EngineSyncTest, ActivatingSyncDoesNotCauseDrifting) {
 }
 
 TEST_F(EngineSyncTest, HalfDoubleBpmTest) {
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(70), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(70));
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(140), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(140));
     m_pTrack2->trySetBeats(pBeats2);
 
     // Mixxx will choose the first playing deck to be leader.  Let's start deck 2 first.
@@ -1821,11 +1821,11 @@ TEST_F(EngineSyncTest, HalfDoubleBpmTest) {
 TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
     // If a deck plays that had its multiplier set, we need to reset the
     // internal clock.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(80), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(80));
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(175), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(175));
     m_pTrack2->trySetBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))
             ->set(getRateSliderValue(1.0));
@@ -1946,11 +1946,11 @@ TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
 
 TEST_F(EngineSyncTest, HalfDoubleInternalClockTest) {
     // If we set the file_bpm CO's directly, the correct signals aren't fired.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(70), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(70));
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(140), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(140));
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
@@ -2023,11 +2023,11 @@ TEST_F(EngineSyncTest, HalfDoubleEachOther) {
     // Confirm that repeated sync with both decks leads to the same
     // Half/Double decision.
     // This test demonstrates https://bugs.launchpad.net/mixxx/+bug/1921962
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(144), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(144));
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(105), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(105));
     m_pTrack2->trySetBeats(pBeats2);
 
     // Threshold 1.414 sqrt(2);
@@ -2052,8 +2052,8 @@ TEST_F(EngineSyncTest, HalfDoubleEachOther) {
     // 105 / 75 = 1.40
     // expect 75 BPM
 
-    mixxx::BeatsPointer pBeats1b = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(150), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1b = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(150));
     m_pTrack1->trySetBeats(pBeats1b);
 
     EXPECT_DOUBLE_EQ(150.0,
@@ -2074,8 +2074,8 @@ TEST_F(EngineSyncTest, HalfDoubleEachOther) {
 
 TEST_F(EngineSyncTest, SetFileBpmUpdatesLocalBpm) {
     ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->set(0.2);
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(130));
     m_pTrack1->trySetBeats(pBeats1);
     EXPECT_EQ(
             mixxx::Bpm(130.0), m_pEngineSync->getSyncableForGroup(m_sGroup1)->getBaseBpm());
@@ -2087,16 +2087,16 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
 
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(130));
     m_pTrack1->trySetBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
 
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
     ControlObject::set(ConfigKey(m_sGroup2, "rate_ratio"), 1.0);
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(100));
     m_pTrack2->trySetBeats(pBeats2);
 
     // Set the sync deck playing with nothing else active.
@@ -2179,8 +2179,8 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
             std::make_unique<ControlProxy>(m_sGroup3, "sync_enabled");
     ControlObject::set(ConfigKey(m_sGroup3, "beat_distance"), 0.6);
     ControlObject::set(ConfigKey(m_sGroup2, "rate_ratio"), 1.0);
-    mixxx::BeatsPointer pBeats3 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack3->getSampleRate(), mixxx::Bpm(140), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats3 = mixxx::Beats::fromConstTempo(
+            m_pTrack3->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(140));
     m_pTrack3->trySetBeats(pBeats3);
     // This will sync to the first deck here and not the second (lp1784185)
     pButtonSyncEnabled3->set(1.0);
@@ -2225,11 +2225,11 @@ TEST_F(EngineSyncTest, UserTweakBeatDistance) {
     // If a deck has a user tweak, and another deck stops such that the first
     // is used to reseed the leader beat distance, make sure the user offset
     // is reset.
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(128));
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(128));
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
@@ -2278,11 +2278,11 @@ TEST_F(EngineSyncTest, UserTweakPreservedInSeek) {
 
     // This is about 128 bpm, but results in nice round numbers of samples.
     const double kDivisibleBpm = 44100.0 / 344.0;
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(kDivisibleBpm), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(kDivisibleBpm));
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(130));
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup2, "sync_enabled"))->set(1);
@@ -2359,11 +2359,11 @@ TEST_F(EngineSyncTest, FollowerUserTweakPreservedInLeaderChange) {
 
     // This is about 128 bpm, but results in nice round numbers of samples.
     const double kDivisibleBpm = 44100.0 / 344.0;
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(kDivisibleBpm), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(kDivisibleBpm));
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(130));
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "sync_leader"))->set(1);
@@ -2410,11 +2410,11 @@ TEST_F(EngineSyncTest, FollowerUserTweakPreservedInSyncDisable) {
     // Ensure that when a follower disables sync, a phase seek is not performed.
     // This is about 128 bpm, but results in nice round numbers of samples.
     const double kDivisibleBpm = 44100.0 / 344.0;
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(kDivisibleBpm), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(kDivisibleBpm));
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(130));
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "sync_leader"))->set(1);
@@ -2446,11 +2446,11 @@ TEST_F(EngineSyncTest, LeaderUserTweakPreservedInLeaderChange) {
 
     // This is about 128 bpm, but results in nice round numbers of samples.
     const double kDivisibleBpm = 44100.0 / 344.0;
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(kDivisibleBpm), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(kDivisibleBpm));
     m_pTrack1->trySetBeats(pBeats1);
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(130));
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "sync_leader"))->set(1);
@@ -2495,8 +2495,8 @@ TEST_F(EngineSyncTest, LeaderUserTweakPreservedInLeaderChange) {
 }
 
 TEST_F(EngineSyncTest, LeaderBpmNeverZero) {
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(128));
     m_pTrack1->trySetBeats(pBeats1);
 
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
@@ -2529,13 +2529,13 @@ TEST_F(EngineSyncTest, QuantizeImpliesSyncPhase) {
     auto pButtonBeatsync1 = std::make_unique<ControlProxy>(m_sGroup1, "beatsync");
     auto pButtonBeatsyncPhase1 = std::make_unique<ControlProxy>(m_sGroup1, "beatsync_phase");
 
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(130));
     m_pTrack1->trySetBeats(pBeats1);
 
     ControlObject::set(ConfigKey(m_sGroup2, "rate"), getRateSliderValue(1.0));
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(100));
     m_pTrack2->trySetBeats(pBeats2);
 
     ProcessBuffer();
@@ -2627,8 +2627,8 @@ TEST_F(EngineSyncTest, QuantizeImpliesSyncPhase) {
 TEST_F(EngineSyncTest, SeekStayInPhase) {
     ControlObject::set(ConfigKey(m_sGroup1, "quantize"), 1.0);
 
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(130));
     m_pTrack1->trySetBeats(pBeats1);
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
@@ -2650,8 +2650,8 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 0.0);
     ProcessBuffer();
 
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(130));
     m_pTrack2->trySetBeats(pBeats2);
 
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
@@ -2673,8 +2673,8 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
 
 TEST_F(EngineSyncTest, SyncWithoutBeatgrid) {
     // this tests bug lp1783020, notresetting rate when other deck has no beatgrid
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(128), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(128));
     m_pTrack1->trySetBeats(pBeats1);
     m_pTrack2->trySetBeats(mixxx::BeatsPointer());
 
@@ -2692,13 +2692,13 @@ TEST_F(EngineSyncTest, SyncWithoutBeatgrid) {
 }
 
 TEST_F(EngineSyncTest, QuantizeHotCueActivate) {
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(130));
     m_pTrack1->trySetBeats(pBeats1);
 
     auto pHotCue2Activate = std::make_unique<ControlProxy>(m_sGroup2, "hotcue_1_activate");
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(100), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(100));
 
     m_pTrack2->trySetBeats(pBeats2);
 
@@ -2759,8 +2759,8 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
     auto pButtonSyncEnabled2 = std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
 
     // set beatgrid for deck 1
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(130), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(130));
     m_pTrack1->trySetBeats(pBeats1);
     pButtonSyncEnabled1->set(1.0);
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
@@ -2793,8 +2793,8 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
     EXPECT_TRUE(isFollower(m_sGroup2));
 
     // Load a new beatgrid during playing, this happens when the analyser is finished.
-    mixxx::BeatsPointer pBeats2 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(140), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2 = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(140));
     m_pTrack2->trySetBeats(pBeats2);
 
     ProcessBuffer();
@@ -2818,8 +2818,8 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
     EXPECT_TRUE(isSoftLeader(m_sGroup2));
 
     // Load a new beatgrid again, this happens when the user adjusts the beatgrid
-    mixxx::BeatsPointer pBeats2n = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack2->getSampleRate(), mixxx::Bpm(75), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats2n = mixxx::Beats::fromConstTempo(
+            m_pTrack2->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(75));
     m_pTrack2->trySetBeats(pBeats2n);
 
     ProcessBuffer();
@@ -2834,8 +2834,8 @@ TEST_F(EngineSyncTest, ChangeBeatGrid) {
 
 TEST_F(EngineSyncTest, BeatMapQuantizePlay) {
     // This test demonstates https://bugs.launchpad.net/mixxx/+bug/1874918
-    mixxx::BeatsPointer pBeats1 = mixxx::BeatGrid::makeBeatGrid(
-            m_pTrack1->getSampleRate(), mixxx::Bpm(120), mixxx::audio::kStartFramePos);
+    mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
+            m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(120));
     m_pTrack1->trySetBeats(pBeats1);
 
     constexpr auto kSampleRate = mixxx::audio::SampleRate(44100);

--- a/src/test/seratobeatgridtest.cpp
+++ b/src/test/seratobeatgridtest.cpp
@@ -5,7 +5,6 @@
 #include <QDir>
 #include <QtDebug>
 
-#include "track/beatgrid.h"
 #include "track/beats.h"
 #include "track/serato/beatgrid.h"
 #include "track/serato/beatsimporter.h"
@@ -116,8 +115,8 @@ TEST_F(SeratoBeatGridTest, SerializeBeatgrid) {
     constexpr mixxx::Bpm bpm(120.0);
     const auto sampleRate = mixxx::audio::SampleRate(44100);
     EXPECT_EQ(sampleRate.isValid(), true);
-    const auto pBeats = mixxx::BeatGrid::makeBeatGrid(
-            sampleRate, bpm, mixxx::audio::kStartFramePos);
+    const auto pBeats = mixxx::Beats::fromConstTempo(
+            sampleRate, mixxx::audio::kStartFramePos, bpm);
     const auto signalInfo = mixxx::audio::SignalInfo(mixxx::audio::ChannelCount(2), sampleRate);
     const auto duration = mixxx::Duration::fromSeconds<int>(300);
 

--- a/src/test/seratobeatgridtest.cpp
+++ b/src/test/seratobeatgridtest.cpp
@@ -6,7 +6,7 @@
 #include <QtDebug>
 
 #include "track/beatgrid.h"
-#include "track/beatmap.h"
+#include "track/beats.h"
 #include "track/serato/beatgrid.h"
 #include "track/serato/beatsimporter.h"
 #include "util/memory.h"
@@ -153,8 +153,7 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
 
     // Check the const beatmap
     {
-        const auto pBeats = mixxx::BeatMap::makeBeatMap(
-                sampleRate, QString("Test"), beatPositionsFrames);
+        const auto pBeats = mixxx::Beats::fromBeatPositions(sampleRate, beatPositionsFrames);
         // Check that the first section's BPM is 100
         EXPECT_EQ(pBeats->getBpmAroundPosition(
                           mixxx::audio::FramePos(initialFrameOffset +
@@ -191,8 +190,7 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
     ASSERT_EQ(beatPositionsFrames.size(), kNumBeats120BPM + kNumBeats60BPM);
 
     {
-        const auto pBeats = mixxx::BeatMap::makeBeatMap(
-                sampleRate, QString("Test"), beatPositionsFrames);
+        const auto pBeats = mixxx::Beats::fromBeatPositions(sampleRate, beatPositionsFrames);
         // Check that the first section'd BPM is 100
         EXPECT_EQ(pBeats->getBpmAroundPosition(
                           mixxx::audio::FramePos(initialFrameOffset +
@@ -242,8 +240,7 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
     beatPositionsFrames.append(beatPositionFrames);
 
     {
-        const auto pBeats = mixxx::BeatMap::makeBeatMap(
-                sampleRate, QString("Test"), beatPositionsFrames);
+        const auto pBeats = mixxx::Beats::fromBeatPositions(sampleRate, beatPositionsFrames);
         // Check that the first section's BPM is 100
         EXPECT_EQ(pBeats->getBpmAroundPosition(
                           mixxx::audio::FramePos(initialFrameOffset +

--- a/src/track/beatfactory.cpp
+++ b/src/track/beatfactory.cpp
@@ -79,8 +79,8 @@ mixxx::BeatsPointer BeatFactory::makePreferredBeats(
         const mixxx::Bpm constBPM = BeatUtils::makeConstBpm(
                 constantRegions, sampleRate, &firstBeat);
         firstBeat = BeatUtils::adjustPhase(firstBeat, constBPM, sampleRate, beats);
-        auto pGrid = mixxx::BeatGrid::makeBeatGrid(
-                sampleRate, constBPM, firstBeat.toNearestFrameBoundary(), subVersion);
+        auto pGrid = mixxx::Beats::fromConstTempo(
+                sampleRate, firstBeat.toNearestFrameBoundary(), constBPM, subVersion);
         return pGrid;
     } else if (version == BEAT_MAP_VERSION) {
         QVector<mixxx::audio::FramePos> ironedBeats = BeatUtils::getBeats(constantRegions);

--- a/src/track/beatfactory.cpp
+++ b/src/track/beatfactory.cpp
@@ -84,7 +84,7 @@ mixxx::BeatsPointer BeatFactory::makePreferredBeats(
         return pGrid;
     } else if (version == BEAT_MAP_VERSION) {
         QVector<mixxx::audio::FramePos> ironedBeats = BeatUtils::getBeats(constantRegions);
-        auto pBeatMap = mixxx::BeatMap::makeBeatMap(sampleRate, subVersion, ironedBeats);
+        auto pBeatMap = mixxx::Beats::fromBeatPositions(sampleRate, ironedBeats, subVersion);
         return pBeatMap;
     } else {
         qDebug() << "ERROR: Could not determine what type of beatgrid to create.";

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -12,7 +12,6 @@
 #include <QtGlobal>
 #include <algorithm>
 
-#include "track/beatgrid.h"
 #include "track/beatutils.h"
 #include "track/track.h"
 #include "util/math.h"
@@ -605,7 +604,7 @@ BeatsPointer BeatMap::setBpm(mixxx::Bpm bpm) {
     const auto firstBeatPosition = mixxx::audio::FramePos(m_beats.first().frame_position());
     DEBUG_ASSERT(firstBeatPosition.isValid());
 
-    return mixxx::BeatGrid::makeBeatGrid(m_sampleRate, bpm, firstBeatPosition);
+    return fromConstTempo(m_sampleRate, firstBeatPosition, bpm);
 }
 
 } // namespace mixxx

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -32,6 +32,23 @@ mixxx::BeatsPointer Beats::fromByteArray(
     return pBeats;
 }
 
+// static
+BeatsPointer Beats::fromConstTempo(
+        audio::SampleRate sampleRate,
+        audio::FramePos position,
+        Bpm bpm,
+        const QString& subVersion) {
+    return BeatGrid::makeBeatGrid(sampleRate, bpm, position, subVersion);
+}
+
+// static
+BeatsPointer Beats::fromBeatPositions(
+        audio::SampleRate sampleRate,
+        const QVector<mixxx::audio::FramePos>& beatPositions,
+        const QString& subVersion) {
+    return BeatMap::makeBeatMap(sampleRate, subVersion, beatPositions);
+}
+
 int Beats::numBeatsInRange(audio::FramePos startPosition, audio::FramePos endPosition) const {
     audio::FramePos lastPosition = audio::kStartFramePos;
     int i = 1;

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -3,6 +3,7 @@
 #include <QByteArray>
 #include <QList>
 #include <QString>
+#include <QVector>
 #include <memory>
 
 #include "audio/frame.h"
@@ -35,6 +36,17 @@ class Beats {
             const QString& beatsVersion,
             const QString& beatsSubVersion,
             const QByteArray& beatsSerialized);
+
+    static mixxx::BeatsPointer fromConstTempo(
+            audio::SampleRate sampleRate,
+            audio::FramePos position,
+            Bpm bpm,
+            const QString& subVersion = QString());
+
+    static mixxx::BeatsPointer fromBeatPositions(
+            audio::SampleRate sampleRate,
+            const QVector<audio::FramePos>& beatPositions,
+            const QString& subVersion = QString());
 
     enum class BpmScale {
         Double,

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -7,7 +7,6 @@
 #include "library/library_prefs.h"
 #include "moc_track.cpp"
 #include "sources/metadatasource.h"
-#include "track/beatgrid.h"
 #include "track/trackref.h"
 #include "util/assert.h"
 #include "util/color/color.h"
@@ -354,9 +353,9 @@ bool Track::trySetBpmWhileLocked(mixxx::Bpm bpm) {
         if (!cuePosition.isValid()) {
             cuePosition = mixxx::audio::kStartFramePos;
         }
-        auto pBeats = mixxx::BeatGrid::makeBeatGrid(getSampleRate(),
-                bpm,
-                cuePosition);
+        auto pBeats = mixxx::Beats::fromConstTempo(getSampleRate(),
+                cuePosition,
+                bpm);
         return trySetBeatsWhileLocked(std::move(pBeats));
     } else if (m_pBeats->getBpm() != bpm) {
         // Continue with the regular cases

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -8,7 +8,6 @@
 #include "moc_track.cpp"
 #include "sources/metadatasource.h"
 #include "track/beatgrid.h"
-#include "track/beatmap.h"
 #include "track/trackref.h"
 #include "util/assert.h"
 #include "util/color/color.h"
@@ -1083,9 +1082,8 @@ bool Track::importPendingBeatsWhileLocked() {
     // The sample rate is supposed to be consistent
     DEBUG_ASSERT(m_record.getStreamInfoFromSource()->getSignalInfo().getSampleRate() ==
             m_record.getMetadata().getStreamInfo().getSignalInfo().getSampleRate());
-    const auto pBeats = mixxx::BeatMap::makeBeatMap(
+    const auto pBeats = mixxx::Beats::fromBeatPositions(
             m_record.getStreamInfoFromSource()->getSignalInfo().getSampleRate(),
-            QString(),
             m_pBeatsImporterPending->importBeatsAndApplyTimingOffset(
                     getLocation(), *m_record.getStreamInfoFromSource()));
     DEBUG_ASSERT(m_pBeatsImporterPending->isEmpty());


### PR DESCRIPTION
Another step towards merging the two beats implementations into a single one.