### PR TITLE
add halve/double controls for beatjump size

### DIFF
--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -166,6 +166,18 @@ LoopingControl::LoopingControl(const QString& group,
             this, &LoopingControl::slotBeatJump, Qt::DirectConnection);
     m_pCOBeatJumpSize = new ControlObject(ConfigKey(group, "beatjump_size"),
                                           true, false, false, 4.0);
+
+    m_pCOBeatJumpSizeHalve = new ControlPushButton(ConfigKey(group, "beatjump_size_halve"));
+    connect(m_pCOBeatJumpSizeHalve,
+            &ControlObject::valueChanged,
+            this,
+            &LoopingControl::slotBeatJumpSizeHalve);
+    m_pCOBeatJumpSizeDouble = new ControlPushButton(ConfigKey(group, "beatjump_size_double"));
+    connect(m_pCOBeatJumpSizeDouble,
+            &ControlObject::valueChanged,
+            this,
+            &LoopingControl::slotBeatJumpSizeDouble);
+
     m_pCOBeatJumpForward = new ControlPushButton(ConfigKey(group, "beatjump_forward"));
     connect(m_pCOBeatJumpForward, &ControlObject::valueChanged,
             this, &LoopingControl::slotBeatJumpForward);
@@ -211,6 +223,7 @@ LoopingControl::LoopingControl(const QString& group,
 }
 
 LoopingControl::~LoopingControl() {
+    // TODO Use unique_ptr to manage lifetime
     delete m_pLoopOutButton;
     delete m_pLoopOutGotoButton;
     delete m_pLoopInButton;
@@ -236,6 +249,8 @@ LoopingControl::~LoopingControl() {
 
     delete m_pCOBeatJump;
     delete m_pCOBeatJumpSize;
+    delete m_pCOBeatJumpSizeHalve;
+    delete m_pCOBeatJumpSizeDouble;
     delete m_pCOBeatJumpForward;
     delete m_pCOBeatJumpBackward;
     while (!m_beatJumps.isEmpty()) {
@@ -1431,14 +1446,26 @@ void LoopingControl::slotBeatJump(double beats) {
     }
 }
 
+void LoopingControl::slotBeatJumpSizeHalve(double pressed) {
+    if (pressed > 0) {
+        m_pCOBeatJumpSize->set(m_pCOBeatJumpSize->get() / 2);
+    }
+}
+
+void LoopingControl::slotBeatJumpSizeDouble(double pressed) {
+    if (pressed > 0) {
+        m_pCOBeatJumpSize->set(m_pCOBeatJumpSize->get() * 2);
+    }
+}
+
 void LoopingControl::slotBeatJumpForward(double pressed) {
-    if (pressed != 0) {
+    if (pressed > 0) {
         slotBeatJump(m_pCOBeatJumpSize->get());
     }
 }
 
 void LoopingControl::slotBeatJumpBackward(double pressed) {
-    if (pressed != 0) {
+    if (pressed > 0) {
         slotBeatJump(-1.0 * m_pCOBeatJumpSize->get());
     }
 }

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -87,6 +87,8 @@ class LoopingControl : public EngineControl {
 
     // Jump forward or backward by beats.
     void slotBeatJump(double beats);
+    void slotBeatJumpSizeHalve(double pressed);
+    void slotBeatJumpSizeDouble(double pressed);
     void slotBeatJumpForward(double pressed);
     void slotBeatJumpBackward(double pressed);
 
@@ -180,6 +182,8 @@ class LoopingControl : public EngineControl {
 
     ControlObject* m_pCOBeatJump;
     ControlObject* m_pCOBeatJumpSize;
+    ControlPushButton* m_pCOBeatJumpSizeHalve;
+    ControlPushButton* m_pCOBeatJumpSizeDouble;
     ControlPushButton* m_pCOBeatJumpForward;
     ControlPushButton* m_pCOBeatJumpBackward;
     QList<BeatJumpControl*> m_beatJumps;


### PR DESCRIPTION
Allows to change the beatjump size with keyboards.
`beatjump_size_halve`
`beatjump_size_double`

quick fix for a forum request.
https://mixxx.discourse.group/t/maintening-a-key-pressed-doesnt-have-any-effect/22977