### PR TITLE
Bump PPA version to 2.4.0~alpha2

### DIFF
--- a/packaging/CPackDebUploadPPA.cmake
+++ b/packaging/CPackDebUploadPPA.cmake
@@ -43,10 +43,12 @@ if(NOT CPACK_DEBIAN_GPG_RET EQUAL "0")
 endif()
 
 # hack to advance the version from the legacy version like this:
-# dpkg --compare-versions 2.4.0~alpha~pre1~git7859  lt 2.4.0~alpha1~5463~gf2da9e619d && echo true
-# dpkg --compare-versions 2.4.0~alpha1~5463~gf2da9e619d lt 2.4.0 && echo true
+# dpkg --compare-versions 2.4.0~alpha~pre1~git7859  lt 2.4.0~alpha2~5463~gf2da9e619d && echo true
+# and from changing to --first-parent
+# dpkg --compare-versions 2.4.0~alpha1~6372~g0244af2e04-1~impish lt 2.4.0~alpha2~805~g4f13bc1d5d-1~impish && echo true
+# dpkg --compare-versions 2.4.0~alpha2~5463~gf2da9e619d lt 2.4.0 && echo true
 if(DEB_UPLOAD_PPA MATCHES "nightlies")
-  string(REPLACE "2.4~alpha~" "2.4.0~alpha1~" CPACK_DEBIAN_PACKAGE_VERSION "${CPACK_DEBIAN_PACKAGE_VERSION}")
+  string(REPLACE "2.4~alpha~" "2.4.0~alpha2~" CPACK_DEBIAN_PACKAGE_VERSION "${CPACK_DEBIAN_PACKAGE_VERSION}")
 endif()
 
 message(NOTICE "Creating mixxx_${CPACK_DEBIAN_PACKAGE_VERSION}.orig.tar.gz")


### PR DESCRIPTION
This is required because we have added --first-parent to our git describe
call which has lowers the count since last tag to 805 from 6372

This should now update our PPA alpha users again.

```
dpkg --compare-versions 2.4.0~alpha1~6372~g0244af2e04-1~impish lt 2.4.0~alpha2~805~g4f13bc1d5d-1~impish && echo true
true
```
