### PR TITLE
DbId: More restrictive handling of invalid values

### DIFF
--- a/src/test/dbidtest.cpp
+++ b/src/test/dbidtest.cpp
@@ -14,7 +14,7 @@ static_assert(DbId::kMinValue != kSomeValidValue);
 constexpr DbId::value_type kSomeInvalidValue = -123;
 static_assert(DbId::kInvalidValue != kSomeInvalidValue);
 
-constexpr DbId kSomeInvalidId = DbId{DbId::NoAssert{}, kSomeInvalidValue};
+constexpr DbId kSomeInvalidId = DbId::fromValueUnchecked(kSomeInvalidValue);
 
 TEST_F(DbIdTest, fromInvalidValue) {
     EXPECT_FALSE(DbId{}.isValid());

--- a/src/test/dbidtest.cpp
+++ b/src/test/dbidtest.cpp
@@ -27,10 +27,10 @@ TEST_F(DbIdTest, fromValidValue) {
 }
 
 TEST_F(DbIdTest, toValue) {
-    EXPECT_EQ(DbId::kInvalidValue, DbId{}.valueNoAssert());
+    EXPECT_EQ(DbId::kInvalidValue, DbId{}.valueMaybeInvalid());
     EXPECT_EQ(DbId::kMinValue, DbId{DbId::kMinValue}.value());
     EXPECT_EQ(kSomeValidValue, DbId{kSomeValidValue}.value());
-    EXPECT_EQ(kSomeInvalidValue, kSomeInvalidId.valueNoAssert());
+    EXPECT_EQ(kSomeInvalidValue, kSomeInvalidId.valueMaybeInvalid());
 }
 
 TEST_F(DbIdTest, fromInvalidVariant) {

--- a/src/util/db/dbid.cpp
+++ b/src/util/db/dbid.cpp
@@ -1,24 +1,30 @@
 #include "util/db/dbid.h"
 
+namespace {
+/// The variant type has to be obtained from a valid value,
+/// because invalid values are mapped to QVariant::Invalid!
+const QVariant::Type kVariantType = DbId{DbId::kMinValue}.toVariant().type();
+} // namespace
 
 //static
-const QVariant::Type DbId::kVariantType = DbId().toVariant().type();
-
-//static
-DbId::value_type DbId::valueOf(QVariant /*pass-by-value*/ variant) {
+DbId::value_type DbId::valueOf(QVariant variant) {
     // The parameter "variant" is passed by value since we need to use
     // the in place QVariant::convert(). Due to Qt's implicit sharing
     // the value is only copied if the type is different. The redundant
     // conversion inside value() is bypassed since the type already
     // matches. We cannot use value(), only because it returns the
     // valid id 0 in case of conversion errors.
+    if (variant.isNull()) {
+        return kInvalidValue;
+    }
+    DEBUG_ASSERT(kVariantType != QVariant::Invalid);
     if (variant.convert(kVariantType)) {
-        value_type value = variant.value<value_type>();
+        const auto value = variant.value<value_type>();
         if (isValidValue(value)) {
             return value;
         }
     }
     qCritical() << "Invalid database identifier value:"
-            << variant;
+                << variant;
     return kInvalidValue;
 }

--- a/src/util/db/dbid.h
+++ b/src/util/db/dbid.h
@@ -56,7 +56,7 @@ class DbId {
         return isValidValue(m_value);
     }
 
-    constexpr value_type valueNoAssert() const {
+    constexpr value_type valueMaybeInvalid() const {
         return m_value;
     }
     value_type value() const {
@@ -97,11 +97,11 @@ class DbId {
 };
 
 inline constexpr bool operator==(const DbId& lhs, const DbId& rhs) {
-    return lhs.valueNoAssert() == rhs.valueNoAssert();
+    return lhs.valueMaybeInvalid() == rhs.valueMaybeInvalid();
 }
 
 inline constexpr bool operator!=(const DbId& lhs, const DbId& rhs) {
-    return lhs.valueNoAssert() != rhs.valueNoAssert();
+    return lhs.valueMaybeInvalid() != rhs.valueMaybeInvalid();
 }
 
 inline bool operator<(const DbId& lhs, const DbId& rhs) {
@@ -121,17 +121,17 @@ inline bool operator>=(const DbId& lhs, const DbId& rhs) {
 }
 
 inline std::ostream& operator<<(std::ostream& os, const DbId& dbId) {
-    return os << dbId.valueNoAssert();
+    return os << dbId.valueMaybeInvalid();
 }
 
 inline QDebug operator<<(QDebug debug, const DbId& dbId) {
-    return debug << dbId.valueNoAssert();
+    return debug << dbId.valueMaybeInvalid();
 }
 
 inline uint qHash(
         const DbId& dbId,
         uint seed = 0) {
-    return qHash(dbId.valueNoAssert(), seed);
+    return qHash(dbId.valueMaybeInvalid(), seed);
 }
 
 Q_DECLARE_TYPEINFO(DbId, Q_MOVABLE_TYPE);

--- a/src/util/db/dbid.h
+++ b/src/util/db/dbid.h
@@ -50,7 +50,7 @@ class DbId {
     /// Creates an instance from the provided inner value. The value
     /// might be either valid or invalid. Triggers a debug assertion
     /// if an invalid value doesn't equal the predefined constant.
-    explicit DbId(value_type value)
+    explicit constexpr DbId(value_type value)
             : DbId(NoAssert{}, value) {
         DEBUG_ASSERT(isValid() || m_value == kInvalidValue);
     }
@@ -80,7 +80,7 @@ class DbId {
     ///
     /// Returns the inner value. Triggers a debug assertion when
     /// invoked on invalid instances.
-    value_type value() const {
+    constexpr value_type value() const {
         DEBUG_ASSERT(isValid());
         return m_value;
     }
@@ -89,7 +89,7 @@ class DbId {
     ///
     /// Returns the inner value. Triggers a debug assertion when
     /// invoked on invalid instances.
-    operator value_type() const {
+    constexpr operator value_type() const {
         return value();
     }
 

--- a/src/util/db/dbid.h
+++ b/src/util/db/dbid.h
@@ -35,14 +35,16 @@ class DbId {
         return value >= kMinValue;
     }
 
-
+    /// Create an invalid instance
     constexpr DbId()
             : m_value(kInvalidValue) {
     }
+    /// Try to convert from a QVariant
+    ///
+    /// If the conversion fails an invalid instance as fallback.
     explicit DbId(QVariant variant)
             : DbId(NoAssert{}, valueOf(std::move(variant))) {
     }
-
     /// Explicit checked conversion from inner value
     ///
     /// Creates an instance from the provided inner value. The value
@@ -57,6 +59,8 @@ class DbId {
     ///
     /// Creates an instance with the provided inner value without
     /// any consistency checks that could trigger an assertion.
+    ///
+    /// Use consciously, e.g. for testing.
     static constexpr DbId fromValueUnchecked(value_type value) {
         return DbId(NoAssert{}, value);
     }

--- a/src/util/db/dbid.h
+++ b/src/util/db/dbid.h
@@ -1,126 +1,138 @@
 #pragma once
 
-
+#include <QString>
+#include <QVariant>
+#include <QtDebug>
 #include <functional>
 #include <ostream>
 #include <utility>
 
-#include <QString>
-#include <QVariant>
-#include <QtDebug>
-
 #include "util/assert.h"
 
-
-// Base class for ID values of objects that are stored in the database.
+/// Base class for ID values of objects that are stored in the database.
 //
-// Implicit conversion from/to the native value type has been disabled
-// on purpose in favor of explicit conversion. The internal value type
-// is also hidden as an implementation detail.
+/// Implicit conversion from/to the native value type has been disabled
+/// on purpose in favor of explicit conversion. The internal value type
+/// is also hidden as an implementation detail.
 //
-// Although used as a base class this class has a non-virtual destructor,
-// because destruction is trivial and for maximum efficiency! Derived
-// classes may add additional behavior (= member functions), but should
-// not add any additional state (= member variables). Inheritance is
-// only needed for type-safety.
+/// Although used as a base class this class has a non-virtual destructor,
+/// because destruction is trivial and for maximum efficiency! Derived
+/// classes may add additional behavior (= member functions), but should
+/// not add any additional state (= member variables). Inheritance is
+/// only needed for type-safety.
 class DbId {
-protected:
-public:
-    // Alias for the corresponding native type. It keeps the
-    // implementation of this class flexible if we ever gonna
-    // need to change it from 'int' to 'long' or any other type.
+  public:
+    /// Alias for the corresponding native type. It keeps the
+    /// implementation of this class flexible if we ever gonna
+    /// need to change it from 'int' to 'long' or any other type.
     typedef int value_type;
 
-    DbId()
-        : m_value(kInvalidValue) {
-        DEBUG_ASSERT(!isValid());
-    }
-    explicit DbId(value_type value)
-        : m_value(value) {
-        DEBUG_ASSERT(isValid() || (kInvalidValue == m_value));
-    }
-    explicit DbId(QVariant variant)
-        : DbId(valueOf(std::move(variant))) {
+    static constexpr value_type kInvalidValue = -1;
+    static constexpr value_type kMinValue = 0;
+
+    static constexpr bool isValidValue(value_type value) {
+        static_assert(kInvalidValue < kMinValue);
+        return value >= kMinValue;
     }
 
-    bool isValid() const {
+    /// Type tag for overloaded constructor that doesn't assert
+    struct NoAssert {};
+
+    constexpr DbId()
+            : m_value(kInvalidValue) {
+    }
+    constexpr DbId(NoAssert, value_type value)
+            : m_value(value) {
+    }
+    explicit DbId(value_type value)
+            : DbId(NoAssert{}, value) {
+        DEBUG_ASSERT(isValid() || m_value == kInvalidValue);
+    }
+    explicit DbId(QVariant variant)
+            : DbId(NoAssert{}, valueOf(std::move(variant))) {
+    }
+
+    constexpr bool isValid() const {
         return isValidValue(m_value);
     }
 
-    value_type value() const {
+    constexpr value_type valueNoAssert() const {
         return m_value;
+    }
+    value_type value() const {
+        DEBUG_ASSERT(isValid());
+        return m_value;
+    }
+    operator value_type() const {
+        return value();
     }
 
     std::size_t hash() const {
         return std::hash<value_type>()(m_value);
     }
 
-    typedef std::function<std::size_t (const DbId& dbid)> hash_fun_t;
+    typedef std::function<std::size_t(const DbId& dbid)> hash_fun_t;
     static std::size_t hash_fun(const DbId& dbid) {
         return dbid.hash();
     }
 
-    // This function should be used for value binding in DB queries
-    // with bindValue().
+    /// Convert into QVariant
+    ///
+    /// This function is used for value binding in DB queries with bindValue().
     QVariant toVariant() const {
-        return QVariant(m_value);
+        return isValid() ? QVariant{m_value} : QVariant{};
     }
 
+    /// Convert into QString
+    ///
+    /// This function is used for formatting comma-separated lists of ids in DB queries.
     QString toString() const {
-        return QString::number(m_value);
+        return isValid() ? QString::number(m_value) : QString{};
     }
 
-    friend bool operator==(const DbId& lhs, const DbId& rhs) {
-        return lhs.m_value == rhs.m_value;
-    }
-
-    friend bool operator!=(const DbId& lhs, const DbId& rhs) {
-        return lhs.m_value != rhs.m_value;
-    }
-
-    friend bool operator<(const DbId& lhs, const DbId& rhs) {
-        return lhs.m_value < rhs.m_value;
-    }
-
-    friend bool operator>(const DbId& lhs, const DbId& rhs) {
-        return lhs.m_value > rhs.m_value;
-    }
-
-    friend bool operator<=(const DbId& lhs, const DbId& rhs) {
-        return lhs.m_value <= rhs.m_value;
-    }
-
-    friend bool operator>=(const DbId& lhs, const DbId& rhs) {
-        return lhs.m_value >= rhs.m_value;
-    }
-
-    friend std::ostream& operator<<(std::ostream& os, const DbId& dbId) {
-        return os << dbId.m_value;
-    }
-
-    friend QDebug operator<<(QDebug debug, const DbId& dbId) {
-        return debug << dbId.m_value;
-    }
-
-    friend uint qHash(
-            const DbId& dbId,
-            uint seed = 0) {
-        return qHash(dbId.m_value, seed);
-    }
-
-private:
-    static const value_type kInvalidValue = -1;
-
-    static const QVariant::Type kVariantType;
-
-    static bool isValidValue(value_type value) {
-        return 0 <= value;
-    }
-
-    static value_type valueOf(QVariant /*pass-by-value*/ variant);
+  private:
+    static value_type valueOf(QVariant variant);
 
     value_type m_value;
 };
+
+inline constexpr bool operator==(const DbId& lhs, const DbId& rhs) {
+    return lhs.valueNoAssert() == rhs.valueNoAssert();
+}
+
+inline constexpr bool operator!=(const DbId& lhs, const DbId& rhs) {
+    return lhs.valueNoAssert() != rhs.valueNoAssert();
+}
+
+inline bool operator<(const DbId& lhs, const DbId& rhs) {
+    return lhs.value() < rhs.value();
+}
+
+inline bool operator>(const DbId& lhs, const DbId& rhs) {
+    return lhs.value() > rhs.value();
+}
+
+inline bool operator<=(const DbId& lhs, const DbId& rhs) {
+    return lhs.value() <= rhs.value();
+}
+
+inline bool operator>=(const DbId& lhs, const DbId& rhs) {
+    return lhs.value() >= rhs.value();
+}
+
+inline std::ostream& operator<<(std::ostream& os, const DbId& dbId) {
+    return os << dbId.valueNoAssert();
+}
+
+inline QDebug operator<<(QDebug debug, const DbId& dbId) {
+    return debug << dbId.valueNoAssert();
+}
+
+inline uint qHash(
+        const DbId& dbId,
+        uint seed = 0) {
+    return qHash(dbId.valueNoAssert(), seed);
+}
 
 Q_DECLARE_TYPEINFO(DbId, Q_MOVABLE_TYPE);
 Q_DECLARE_METATYPE(DbId)


### PR DESCRIPTION
- Only permit creation from a single, well-defined invalid value
- Do not leak any invalid values
- Declare more functions as `constexpr`
- Move obsolete `friend` functions into outer scope
- Add more tests