### PR TITLE
Add wavpack and udev to the debian build requiremnts

### DIFF
--- a/packaging/debian/control.in
+++ b/packaging/debian/control.in
@@ -56,6 +56,7 @@ Build-Depends: debhelper (>= 11),
                libmp3lame-dev,
                libebur128-dev,
                libwavpack-dev,
+               libudev-dev,
 # Note: libdjinterop is available within the Mixxx PPA
                libdjinterop-dev,
 # for running mixxx-test

--- a/packaging/debian/control.in
+++ b/packaging/debian/control.in
@@ -55,6 +55,7 @@ Build-Depends: debhelper (>= 11),
                libmodplug-dev,
                libmp3lame-dev,
                libebur128-dev,
+               libwavpack-dev,
 # Note: libdjinterop is available within the Mixxx PPA
                libdjinterop-dev,
 # for running mixxx-test


### PR DESCRIPTION
We have added them to the debian_buildenv.sh but not to the control.in 

Maybe we could implement a solution that reads the dependencies from the control file. This this is currently not possible because it is incomplete, and depends on cmake. Chicken or egg problem.