### PR TITLE
Numark DJ2GO2 Touch: fix sampler, hotcue, beatloop buttons

### DIFF
--- a/res/controllers/Numark_DJ2GO2_Touch_scripts.js
+++ b/res/controllers/Numark_DJ2GO2_Touch_scripts.js
@@ -104,18 +104,18 @@ DJ2GO2Touch.Deck = function(deckNumbers, midiChannel) {
     for (var i = 1; i <= 4; i++) {
         this.hotcueButtons[i] = new components.HotcueButton({
             group: "[Channel" + script.deckFromGroup(this.currentDeck) + "]",
-            midi: [0x94 + midiChannel, 0x01 + i],
+            midi: [0x94 + midiChannel, 0x00 + i],
             number: i
         });
         var sampler = i + (midiChannel * DJ2GO2Touch.padsPerDeck);
         this.samplerButtons[i] = new components.SamplerButton({
             group: "[Sampler" + sampler + "]",
-            midi: [0x94 + midiChannel, 0x31 + i],
+            midi: [0x94 + midiChannel, 0x30 + i],
             number: sampler
         });
         this.beatloopButtons[i] = new components.Button({
             group: "[Channel" + script.deckFromGroup(this.currentDeck) + "]",
-            midi: [0x94 + midiChannel, 0x11 + i],
+            midi: [0x94 + midiChannel, 0x10 + i],
             number: i,
             key: "beatloop_" + Math.pow(2, i-1) + "_toggle"
         });


### PR DESCRIPTION
https://github.com/mixxxdj/mixxx/pull/4286 rebased to Mixxx 2.3.

All buttons are fixed now.