### PR TITLE
Fix preference option for re-analyzing beatgrids imported from other software

### DIFF
--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -81,6 +81,7 @@ bool AnalyzerBeats::initialize(TrackPointer pTrack, int sampleRate, int totalSam
              << "\nPlugin:" << m_pluginId
              << "\nFixed tempo assumption:" << m_bPreferencesFixedTempo
              << "\nRe-analyze when settings change:" << m_bPreferencesReanalyzeOldBpm
+             << "\nRe-analyze imported from other software:" << m_bPreferencesReanalyzeImported
              << "\nFast analysis:" << m_bPreferencesFastAnalysis;
 
     m_sampleRate = sampleRate;

--- a/src/preferences/beatdetectionsettings.h
+++ b/src/preferences/beatdetectionsettings.h
@@ -31,7 +31,11 @@ class BeatDetectionSettings {
     DEFINE_PREFERENCE_HELPERS(ReanalyzeWhenSettingsChange, bool,
                               BPM_CONFIG_KEY, BPM_REANALYZE_WHEN_SETTINGS_CHANGE, false);
 
-    DEFINE_PREFERENCE_HELPERS(ReanalyzeImported, bool, BPM_CONFIG_KEY, BPM_REANALYZE_WHEN_SETTINGS_CHANGE, false);
+    DEFINE_PREFERENCE_HELPERS(ReanalyzeImported,
+            bool,
+            BPM_CONFIG_KEY,
+            BPM_REANALYZE_IMPORTED,
+            false);
 
     DEFINE_PREFERENCE_HELPERS(FastAnalysis, bool,
                               BPM_CONFIG_KEY, BPM_FAST_ANALYSIS_ENABLED, false);

--- a/src/preferences/dialog/dlgprefbeats.cpp
+++ b/src/preferences/dialog/dlgprefbeats.cpp
@@ -61,6 +61,7 @@ void DlgPrefBeats::loadSettings() {
     m_bAnalyzerEnabled = m_bpmSettings.getBpmDetectionEnabled();
     m_bFixedTempoEnabled = m_bpmSettings.getFixedTempoAssumption();
     m_bReanalyze =  m_bpmSettings.getReanalyzeWhenSettingsChange();
+    m_bReanalyzeImported = m_bpmSettings.getReanalyzeImported();
     m_bFastAnalysisEnabled = m_bpmSettings.getFastAnalysis();
 
     slotUpdate();
@@ -74,6 +75,7 @@ void DlgPrefBeats::slotResetToDefaults() {
     m_bFixedTempoEnabled = m_bpmSettings.getFixedTempoAssumptionDefault();
     m_bFastAnalysisEnabled = m_bpmSettings.getFastAnalysisDefault();
     m_bReanalyze = m_bpmSettings.getReanalyzeWhenSettingsChangeDefault();
+    m_bReanalyzeImported = m_bpmSettings.getReanalyzeImportedDefault();
 
     slotUpdate();
 }


### PR DESCRIPTION
I noticed a minor issue in the Beat Detection preferences, so I decided to fix it.

Steps to reproduce:
1. Open Mixxx 2.3
2. In the Beat Detection preferences, check the option "Re-analyze beatgrids imported from other DJ software"
3. Restart Mixxx
4. Notice that that option in the preferences is unchecked
