### PR TITLE
QmlEffectsManagerProxy: fully define QmlVisibleEffectsModel

### DIFF
--- a/src/skin/qml/qmleffectsmanagerproxy.h
+++ b/src/skin/qml/qmleffectsmanagerproxy.h
@@ -2,12 +2,12 @@
 #include <QObject>
 
 #include "effects/effectsmanager.h"
+#include "skin/qml/qmlvisibleeffectsmodel.h"
 
 namespace mixxx {
 namespace skin {
 namespace qml {
 
-class QmlVisibleEffectsModel;
 class QmlEffectSlotProxy;
 
 class QmlEffectsManagerProxy : public QObject {


### PR DESCRIPTION
This is required in Qt6:
```
In file included from /usr/include/qt6/QtCore/qobject.h:54,
                 from /usr/include/qt6/QtWidgets/qwidget.h:45,
                 from /usr/include/qt6/QtWidgets/qdialog.h:44,
                 from /usr/include/qt6/QtWidgets/QDialog:1,
                 from mixxx-lib_autogen/LOXWS6PXLU/../../../src/dialog/dlgkeywheel.h:4,
                 from mixxx-lib_autogen/LOXWS6PXLU/moc_dlgkeywheel.cpp:10,
                 from mixxx-lib_autogen/mocs_compilation.cpp:2:
/usr/include/qt6/QtCore/qmetatype.h: In instantiation of ‘struct QtPrivate::IsPointerToTypeDerivedFromQObject<mixxx::skin::qml::QmlVisibleEffectsModel*>’:
/usr/include/qt6/QtCore/qmetatype.h:1096:63:   required from ‘struct QtPrivate::QMetaTypeTypeFlags<mixxx::skin::qml::QmlVisibleEffectsModel*>’
/usr/include/qt6/QtCore/qmetatype.h:2257:44:   required from ‘constexpr const QtPrivate::QMetaTypeInterface QtPrivate::QMetaTypeInterfaceWrapper<mixxx::skin::qml::QmlVisibleEffectsModel*>::metaType’
/usr/include/qt6/QtCore/qmetatype.h:2380:16:   required from ‘constexpr const QtPrivate::QMetaTypeInterface* QtPrivate::qTryMetaTypeInterfaceForType() [with Unique = qt_meta_stringdata_mixxx__skin__qml__QmlEffectsManagerProxy_t; TypeCompletePair = QtPrivate::TypeAndForceComplete<mixxx::skin::qml::QmlVisibleEffectsModel*, std::integral_constant<bool, true> >]’
/usr/include/qt6/QtCore/qmetatype.h:2424:55:   required from ‘constexpr const QtPrivate::QMetaTypeInterface* const qt_incomplete_metaTypeArray [5]<qt_meta_stringdata_mixxx__skin__qml__QmlEffectsManagerProxy_t, QtPrivate::TypeAndForceComplete<mixxx::skin::qml::QmlVisibleEffectsModel*, std::integral_constant<bool, true> >, QtPrivate::TypeAndForceComplete<mixxx::skin::qml::QmlEffectSlotProxy*, std::integral_constant<bool, false> >, QtPrivate::TypeAndForceComplete<int, std::integral_constant<bool, false> >, QtPrivate::TypeAndForceComplete<int, std::integral_constant<bool, false> >, QtPrivate::TypeAndForceComplete<int, std::integral_constant<bool, false> > >’
mixxx-lib_autogen/PXXERMKKWZ/moc_qmleffectsmanagerproxy.cpp:109:1:   required from here
/usr/include/qt6/QtCore/qmetatype.h:778:23: error: invalid application of ‘sizeof’ to incomplete type ‘mixxx::skin::qml::QmlVisibleEffectsModel’
  778 |         static_assert(sizeof(T), "Type argument of Q_PROPERTY or Q_DECLARE_METATYPE(T*) must be fully defined");
      |                       ^~~~~~~~~
```