### PR TITLE
explicitly convert QStrings to QFileInfos

### DIFF
--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -519,7 +519,7 @@ void DlgPrefController::slotApply() {
 
     QString mappingPath = mappingPathFromIndex(m_ui.comboBoxMapping->currentIndex());
     m_pMapping = LegacyControllerMappingFileHandler::loadMapping(
-            mappingPath, QDir(resourceMappingsPath(m_pConfig)));
+            QFileInfo(mappingPath), QDir(resourceMappingsPath(m_pConfig)));
 
     // Load the resulting mapping (which has been mutated by the input/output
     // table models). The controller clones the mapping so we aren't touching
@@ -581,7 +581,7 @@ void DlgPrefController::slotMappingSelected(int chosenIndex) {
 
     std::shared_ptr<LegacyControllerMapping> pMapping =
             LegacyControllerMappingFileHandler::loadMapping(
-                    mappingPath, QDir(resourceMappingsPath(m_pConfig)));
+                    QFileInfo(mappingPath), QDir(resourceMappingsPath(m_pConfig)));
 
     if (pMapping) {
         DEBUG_ASSERT(!pMapping->isDirty());


### PR DESCRIPTION
required by Qt6
```
../src/controllers/dlgprefcontroller.cpp: In member function ‘virtual void DlgPrefController::slotApply()’:
../src/controllers/dlgprefcontroller.cpp:522:13: error: cannot convert ‘QString’ to ‘const QFileInfo&’
  522 |             mappingPath, QDir(resourceMappingsPath(m_pConfig)));
      |             ^~~~~~~~~~~
      |             |
      |             QString
In file included from ../src/controllers/hid/legacyhidcontrollermappingfilehandler.h:3,
                 from ../src/controllers/hid/legacyhidcontrollermapping.h:3,
                 from ../src/controllers/controllermappingtablemodel.h:10,
                 from ../src/controllers/controllerinputmappingtablemodel.h:8,
                 from ../src/controllers/dlgprefcontroller.h:7,
                 from ../src/controllers/dlgprefcontroller.cpp:1:
../src/controllers/legacycontrollermappingfilehandler.h:17:82: note:   initializing argument 1 of ‘static std::shared_ptr<LegacyControllerMapping> LegacyControllerMappingFileHandler::loadMapping(const QFileInfo&, const QDir&)’
   17 |     static std::shared_ptr<LegacyControllerMapping> loadMapping(const QFileInfo& mappingFile,
      |                                                                 ~~~~~~~~~~~~~~~~~^~~~~~~~~~~
../src/controllers/dlgprefcontroller.cpp: In member function ‘void DlgPrefController::slotMappingSelected(int)’:
../src/controllers/dlgprefcontroller.cpp:584:21: error: cannot convert ‘QString’ to ‘const QFileInfo&’
  584 |                     mappingPath, QDir(resourceMappingsPath(m_pConfig)));
      |                     ^~~~~~~~~~~
      |                     |
      |                     QString
In file included from ../src/controllers/hid/legacyhidcontrollermappingfilehandler.h:3,
                 from ../src/controllers/hid/legacyhidcontrollermapping.h:3,
                 from ../src/controllers/controllermappingtablemodel.h:10,
                 from ../src/controllers/controllerinputmappingtablemodel.h:8,
                 from ../src/controllers/dlgprefcontroller.h:7,
                 from ../src/controllers/dlgprefcontroller.cpp:1:
../src/controllers/legacycontrollermappingfilehandler.h:17:82: note:   initializing argument 1 of ‘static std::shared_ptr<LegacyControllerMapping> LegacyControllerMappingFileHandler::loadMapping(const QFileInfo&, const QDir&)’
   17 |     static std::shared_ptr<LegacyControllerMapping> loadMapping(const QFileInfo& mappingFile,
      |                                                                 ~~~~~~~~~~~~~~~~~^~~~~~~~~~~
```