### PR TITLE
resolve ambiguous overload of QJSValue constructor

### DIFF
--- a/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
@@ -175,7 +175,7 @@ bool ControllerScriptEngineLegacy::handleIncomingData(const QByteArray& data) {
 
     QJSValueList args;
     args << m_pJSEngine->toScriptValue(data);
-    args << QJSValue(data.size());
+    args << QJSValue(static_cast<uint>(data.size()));
 
     for (const QJSValue& function : std::as_const(m_incomingDataFunctions)) {
         ControllerScriptEngineBase::executeFunction(function, args);


### PR DESCRIPTION
required by Qt6
```
../src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp: In member function ‘bool ControllerScriptEngineLegacy::handleIncomingData(const QByteArray&)’:
../src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp:178:33: error: call of overloaded ‘QJSValue(qsizetype)’ is ambiguous
  178 |     args << QJSValue(data.size());
      |                                 ^
In file included from /usr/include/qt6/QtQml/qjsengine.h:48,
                 from /usr/include/qt6/QtQml/QJSEngine:1,
                 from ../src/controllers/scripting/legacy/controllerscriptenginelegacy.h:4,
                 from ../src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp:1:
/usr/include/qt6/QtQml/qjsvalue.h:113:14: note: candidate: ‘QJSValue::QJSValue(QJSPrimitiveValue&&)’
  113 |     explicit QJSValue(QJSPrimitiveValue &&value);
      |              ^~~~~~~~
/usr/include/qt6/QtQml/qjsvalue.h:104:5: note: candidate: ‘QJSValue::QJSValue(double)’
  104 |     QJSValue(double value);
      |     ^~~~~~~~
/usr/include/qt6/QtQml/qjsvalue.h:103:5: note: candidate: ‘QJSValue::QJSValue(uint)’
  103 |     QJSValue(uint value);
      |     ^~~~~~~~
/usr/include/qt6/QtQml/qjsvalue.h:102:5: note: candidate: ‘QJSValue::QJSValue(int)’
  102 |     QJSValue(int value);
      |     ^~~~~~~~
/usr/include/qt6/QtQml/qjsvalue.h:101:5: note: candidate: ‘QJSValue::QJSValue(bool)’
  101 |     QJSValue(bool value);
      |     ^~~~~~~~
/usr/include/qt6/QtQml/qjsvalue.h:96:12: note: candidate: ‘QJSValue::QJSValue(QJSValue&&)’
   96 |     inline QJSValue(QJSValue && other) : d(other.d) { other.d = 0; }
      |            ^~~~~~~~
/usr/include/qt6/QtQml/qjsvalue.h:93:5: note: candidate: ‘QJSValue::QJSValue(const QJSValue&)’
   93 |     QJSValue(const QJSValue &other);
      |     ^~~~~~~~
```