### PR TITLE
ColorMapper: add missing #include <QVariant>

### DIFF
--- a/src/controllers/scripting/colormapper.cpp
+++ b/src/controllers/scripting/colormapper.cpp
@@ -1,5 +1,6 @@
 #include "controllers/scripting/colormapper.h"
 
+#include <QVariant>
 #include <cmath>
 #include <cstdint>
 


### PR DESCRIPTION
This is needed in Qt6.