### PR TITLE
Fix: Reset main window title when all decks stop playing

### DIFF
--- a/src/mixer/playerinfo.cpp
+++ b/src/mixer/playerinfo.cpp
@@ -171,10 +171,7 @@ void PlayerInfo::updateCurrentPlayingDeck() {
         // Note: When starting Auto-DJ "play" might be processed before a new
         // is track is fully loaded. currentPlayingTrackChanged() is then emitted
         // after setTrackInfo().
-        TrackPointer pTrack = getCurrentPlayingTrack();
-        if (pTrack) {
-            emit currentPlayingTrackChanged(pTrack);
-        }
+        emit currentPlayingTrackChanged(getCurrentPlayingTrack());
     }
 }
 


### PR DESCRIPTION
There is a minor UI issue affecting both 2.3 and main.

Steps to reproduce:

1. Start playing a track in Mixxx
2. Observe that main window title has updated to "Track title | Mixxx"
3. Stop the track or let it finish playing
4. Observe that main window title didn't reset to "Mixxx"

This behavior was introduced in 37c41e5daf19dcac0b148a5d02792f4c15c81078.
