### PR TITLE
updates for the "Korg Kaoss DJ" controller script

### DIFF
--- a/res/controllers/Korg-KAOSS-DJ-scripts.js
+++ b/res/controllers/Korg-KAOSS-DJ-scripts.js
@@ -202,6 +202,22 @@ KAOSSDJ.controllerFxTouchUp = function(channel, control, value, status, group) {
     engine.setValue('[EffectRack1_EffectUnit'+deck.deckNumber +']', 'super1', 0);
 };
 
+// use loop-button to deactivate an active loop or initialize a beatloop at the current playback position
+KAOSSDJ.toggle_loop = function(channel, control, value, status, group) {
+	var deck = KAOSSDJ.getDeckByChannel(channel);
+	var loop_enabled = engine.getValue(deck.group, "loop_enabled");
+
+	if(value === ON) {
+		if(loop_enabled) {
+			engine.setValue(deck.group, "reloop_exit", true)
+			engine.setValue(deck.group, "beatloop_activate", false)
+		} else {
+			engine.setValue(deck.group, "beatloop_activate", true)
+		}
+	}
+};
+
+
 // <LOAD A/B>           : load track
 // <SHIFT> + <LOAD A/B> : open/close folder in file-browser
 KAOSSDJ.load_callback = function(channel, control, value, status, group) {

--- a/res/controllers/Korg-KAOSS-DJ-scripts.js
+++ b/res/controllers/Korg-KAOSS-DJ-scripts.js
@@ -315,3 +315,21 @@ KAOSSDJ.tap_button_callback = function(channel, control, value, status, group) {
 	};
 };
 
+// <SHIFT> + <TOUCHPAD X> : control super knob of QuickEffectRack for deck 1
+KAOSSDJ.controllerFxTouchMoveVertical_shift = function(channel, control, value, status, group) {
+    var deck = KAOSSDJ.decks[0];
+    if (deck.fx) {
+        var val = script.absoluteLin(value, 0, 1, 0, 127)
+        engine.setValue('[QuickEffectRack1_' + deck.group + ']', 'super1', val);
+    }
+};
+
+// <SHIFT> + <TOUCHPAD Y> : control super knob of QuickEffectRack for deck 2
+KAOSSDJ.controllerFxTouchMoveHorizontal_shift = function(channel, control, value, status, group) {
+    var deck = KAOSSDJ.decks[1];
+    if (deck.fx) {
+        var val = script.absoluteLin(value, 0, 1, 0, 127)
+        engine.setValue('[QuickEffectRack1_' + deck.group + ']', 'super1', val);
+    }
+};
+

--- a/res/controllers/Korg-KAOSS-DJ-scripts.js
+++ b/res/controllers/Korg-KAOSS-DJ-scripts.js
@@ -7,29 +7,29 @@ var ON = 0x7F,
     UP = 0x01,
     DOWN = 0x7F;
 var ledChannel = {
-    'btnsL': 0x97,
-    'btnsR': 0x98,
-    'knobsL': 0xB7,
-    'knobsR': 0xB8,
-    'master': 0xB6
+    "btnsL": 0x97,
+    "btnsR": 0x98,
+    "knobsL": 0xB7,
+    "knobsR": 0xB8,
+    "master": 0xB6
 };
 var led = {
-    'cue': 0x1E,
-    'sync': 0x1D,
-    'play': 0x1B,
-    'headphones': 0x19,
-    'fx': 0x18, // warning: led is owned by controller
-    'stripL': 0x15,
-    'stripM': 0x16,
-    'stripR': 0x17,
-    'loopStripL': 0x0F,
-    'loopStripM': 0x10,
-    'loopStripR': 0x11,
+    "cue": 0x1E,
+    "sync": 0x1D,
+    "play": 0x1B,
+    "headphones": 0x19,
+    "fx": 0x18, // warning: led is owned by controller
+    "stripL": 0x15,
+    "stripM": 0x16,
+    "stripR": 0x17,
+    "loopStripL": 0x0F,
+    "loopStripM": 0x10,
+    "loopStripR": 0x11,
 };
 
 // shift button state variables
-var shift_left_pressed = false
-var shift_right_pressed = false
+var shiftLeftPressed = false;
+var shiftRightPressed = false;
 
 // initialise decks
 KAOSSDJ.deck = function(deckNumber) {
@@ -49,10 +49,10 @@ for (var i = 0; i < 4; i++) { // TODO: currently only 2 decks supported. is 4 po
 KAOSSDJ.init = function(id, debugging) {
     // turn on main led channels
     var ledChannels = [
-        ledChannel['knobsL'],
-        ledChannel['knobsR'],
-        ledChannel['master']
-    ]
+        ledChannel.knobsL,
+        ledChannel.knobsR,
+        ledChannel.master
+    ];
     for (var led = 0x00; led <= 0xFF; led++) {
         for (var i = 0; i < ledChannels.length; i++) {
             midi.sendShortMsg(ledChannels[i], led, ON);
@@ -77,7 +77,7 @@ KAOSSDJ.shutdown = function(id, debugging) {
 // ==== helper ====
 
 KAOSSDJ.getDeckIndexFromChannel = function(channel) {
-    return channel - 7
+    return channel - 7;
 };
 
 KAOSSDJ.getDeckByChannel = function(channel) {
@@ -97,10 +97,10 @@ KAOSSDJ.wheelTouch = function(channel, control, value, status, group) {
     var beta = alpha / 32;
     var deck = KAOSSDJ.getDeckByChannel(channel);
     var deckNumber = deck.deckNumber;
-    var deck_playing = engine.getValue('[Channel' + deckNumber + ']', 'play_indicator');
+    var deckPlaying = engine.getValue("[Channel" + deckNumber + "]", "play_indicator");
 
     // If in scratch mode or not playing enable vinyl-like control
-    if (deck.jogWheelsInScratchMode || !deck_playing ) {
+    if (deck.jogWheelsInScratchMode || !deckPlaying) {
         if (value === ON) {
             // Enable scratching on touch
             engine.scratchEnable(deckNumber, 128, 33 + 1 / 3, alpha, beta);
@@ -123,7 +123,7 @@ KAOSSDJ.wheelTurn = function(channel, control, value, status, group) {
     if (engine.isScratching(deckNumber)) {
         engine.scratchTick(deckNumber, newValue);
     } else {
-        engine.setValue('[Channel' + deckNumber + ']', 'jog', newValue); // Pitch bend
+        engine.setValue("[Channel" + deckNumber + "]", "jog", newValue); // Pitch bend
     }
 };
 
@@ -141,10 +141,10 @@ KAOSSDJ.wheelTurnShift = function(channel, control, value, status, group) {
         engine.scratchTick(deck.deckNumber, newValue);
     } else {
         // Move beatgrid
-        if(value === UP){
-            engine.setValue(deck.group, 'beats_translate_later', true);
-        } else if (value === DOWN){
-            engine.setValue(deck.group, 'beats_translate_earlier', true);
+        if (value === UP) {
+            engine.setValue(deck.group, "beats_translate_later", true);
+        } else if (value === DOWN) {
+            engine.setValue(deck.group, "beats_translate_earlier", true);
         }
     }
 };
@@ -152,184 +152,181 @@ KAOSSDJ.wheelTurnShift = function(channel, control, value, status, group) {
 KAOSSDJ.scratchMode = function(channel, control, value, status, group) {
     if (value === ON) {
         // Turn scratch mode on jogwheel (LED is red)
-        KAOSSDJ.updateDeckByChannel(channel, 'jogWheelsInScratchMode', true);
+        KAOSSDJ.updateDeckByChannel(channel, "jogWheelsInScratchMode", true);
     } else if (value === OFF) {
         // Turn scratch mode on jogwheel (LED is off)
-        KAOSSDJ.updateDeckByChannel(channel, 'jogWheelsInScratchMode', false);
+        KAOSSDJ.updateDeckByChannel(channel, "jogWheelsInScratchMode", false);
     }
 };
 
 KAOSSDJ.leftFxSwitch = function(channel, control, value, status, group) {
     var deck = KAOSSDJ.getDeckByChannel(channel);
-    if(value === ON) {
-        KAOSSDJ.updateDeckByChannel(channel, 'fx', true);
+    if (value === ON) {
+        KAOSSDJ.updateDeckByChannel(channel, "fx", true);
     } else {
-        KAOSSDJ.updateDeckByChannel(channel, 'fx', false);
+        KAOSSDJ.updateDeckByChannel(channel, "fx", false);
     }
 };
 
 KAOSSDJ.rightFxSwitch = function(channel, control, value, status, group) {
-    if(value === ON) {
-        KAOSSDJ.updateDeckByChannel(channel, 'fx', true);
+    if (value === ON) {
+        KAOSSDJ.updateDeckByChannel(channel, "fx", true);
     } else {
-        KAOSSDJ.updateDeckByChannel(channel, 'fx', false);
+        KAOSSDJ.updateDeckByChannel(channel, "fx", false);
     }
 };
 
 KAOSSDJ.controllerFxTouchMoveVertical = function(channel, control, value, status, group) {
     var decks = KAOSSDJ.decks;
-    for(key in decks) {
+    for (key in decks) {
         var deck = decks[key];
-        if(deck.fx) {
-            engine.setValue('[EffectRack1_EffectUnit'+deck.deckNumber +']', 'mix', value / 127);
+        if (deck.fx) {
+            engine.setValue("[EffectRack1_EffectUnit"+deck.deckNumber +"]", "mix", value / 127);
         }
     }
 };
 
 KAOSSDJ.controllerFxTouchMoveHorizontal = function(channel, control, value, status, group) {
     var decks = KAOSSDJ.decks;
-    for(key in decks) {
+    for (key in decks) {
         var deck = decks[key];
-        if(deck.fx) {
-            engine.setValue('[EffectRack1_EffectUnit'+deck.deckNumber +']', 'super1', value / 127);
+        if (deck.fx) {
+            engine.setValue("[EffectRack1_EffectUnit"+deck.deckNumber +"]", "super1", value / 127);
         }
     }
 };
 
 KAOSSDJ.controllerFxTouchUp = function(channel, control, value, status, group) {
     var deck = KAOSSDJ.getDeckByChannel(channel);
-    engine.setValue('[EffectRack1_EffectUnit'+deck.deckNumber +']', 'mix', 0);
-    engine.setValue('[EffectRack1_EffectUnit'+deck.deckNumber +']', 'super1', 0);
+    engine.setValue("[EffectRack1_EffectUnit"+deck.deckNumber +"]", "mix", 0);
+    engine.setValue("[EffectRack1_EffectUnit"+deck.deckNumber +"]", "super1", 0);
 };
 
 // use loop-button to deactivate an active loop or initialize a beatloop at the current playback position
-KAOSSDJ.toggle_loop = function(channel, control, value, status, group) {
-	var deck = KAOSSDJ.getDeckByChannel(channel);
-	var loop_enabled = engine.getValue(deck.group, "loop_enabled");
+KAOSSDJ.toggleLoop = function(channel, control, value, status, group) {
+    var deck = KAOSSDJ.getDeckByChannel(channel);
+    var loopEnabled = engine.getValue(deck.group, "loopEnabled");
 
-	if(value === ON) {
-		if(loop_enabled) {
-			engine.setValue(deck.group, "reloop_exit", true)
-			engine.setValue(deck.group, "beatloop_activate", false)
-		} else {
-			engine.setValue(deck.group, "beatloop_activate", true)
-		}
-	}
+    if (value === ON) {
+        if (loopEnabled) {
+            engine.setValue(deck.group, "reloop_exit", true);
+            engine.setValue(deck.group, "beatloop_activate", false);
+        } else {
+            engine.setValue(deck.group, "beatloop_activate", true);
+        }
+    }
 };
 
 
 // <LOAD A/B>           : load track
 // <SHIFT> + <LOAD A/B> : open/close folder in file-browser
-KAOSSDJ.load_callback = function(channel, control, value, status, group) {
-	var deck = KAOSSDJ.getDeckByChannel(channel);
-	if(value === ON) {
-        if ((shift_left_pressed) || (shift_right_pressed)) {
-			if (deck.deckNumber == 1) {
-				engine.setValue("[Library]", "MoveLeft", true)
-			} else {
-				engine.setValue("[Library]", "MoveRight", true)
-			}
-		} else {
-			engine.setValue(deck.group, "LoadSelectedTrack", true)
-		}
-	}
+KAOSSDJ.loadCallback = function(channel, control, value, status, group) {
+    var deck = KAOSSDJ.getDeckByChannel(channel);
+    if (value === ON) {
+        if ((shiftLeftPressed) || (shiftRightPressed)) {
+            if (deck.deckNumber == 1) {
+                engine.setValue("[Library]", "MoveLeft", true);
+            } else {
+                engine.setValue("[Library]", "MoveRight", true);
+            }
+        } else {
+            engine.setValue(deck.group, "LoadSelectedTrack", true);
+        }
+    }
 };
 
-KAOSSDJ.shift_left_callback = function(channel, control, value, status, group) {
-	if(value === ON) {
-		// if (shift_right_pressed == true) {
-		// 	TODO add functionality if <RIGHT SHIFT> is active while <LEFT SHIFT> is pressed?
-		// }
-		shift_left_pressed = true
-	} else
-		shift_left_pressed = false
+KAOSSDJ.shiftLeftCallback = function(channel, control, value, status, group) {
+    if (value === ON) {
+        // if (shiftRightPressed == true) {
+        // 	TODO add functionality if <RIGHT SHIFT> is active while <LEFT SHIFT> is pressed?
+        // }
+        shiftLeftPressed = true;
+    } else { shiftLeftPressed = false; }
 };
 
-KAOSSDJ.shift_right_callback = function(channel, control, value, status, group) {
-	if(value === ON) {
-		// if (shift_left_pressed == true) {
-		// 	TODO add functionality if <LEFT SHIFT> is active while <RIGHT SHIFT> is pressed?
-		// }
-        shift_right_pressed = true
-	} else
-		shift_right_pressed = false
+KAOSSDJ.shiftRightCallback = function(channel, control, value, status, group) {
+    if (value === ON) {
+        // if (shiftLeftPressed == true) {
+        // 	TODO add functionality if <LEFT SHIFT> is active while <RIGHT SHIFT> is pressed?
+        // }
+        shiftRightPressed = true;
+    } else { shiftRightPressed = false; }
 };
 
-KAOSSDJ.change_focus = function(channel, control, value, status, group) {
-	if(value === ON) {
+KAOSSDJ.changeFocus = function(channel, control, value, status, group) {
+    if (value === ON) {
         // toggle focus between Playlist and File-Browser
         engine.setValue("[Library]", "MoveFocusForward", true);
-	}
+    }
 };
 
 // <browseKnob>           : browse library up & down
 // <SHIFT> + <browseKnob> : toggle focus between Playlist and File-Browser
 KAOSSDJ.browseKnob = function(channel, control, value, status, group) {
     var nval = (value > 0x40 ? value - 0x80 : value);
-	if (value > 0x40) {
-		if ((shift_left_pressed) || (shift_right_pressed)) {
-			engine.setValue("[Library]", "MoveFocusForward", true);
-		} else {
-			engine.setValue("[Library]", "MoveUp", true);
-		}
-	} else {
-		if ((shift_left_pressed) || (shift_right_pressed)) {
-			engine.setValue("[Library]", "MoveFocusBackward", true);
-		} else {
-			engine.setValue("[Library]", "MoveDown", true);
-		}
-	};
+    if (value > 0x40) {
+        if ((shiftLeftPressed) || (shiftRightPressed)) {
+            engine.setValue("[Library]", "MoveFocusForward", true);
+        } else {
+            engine.setValue("[Library]", "MoveUp", true);
+        }
+    } else {
+        if ((shiftLeftPressed) || (shiftRightPressed)) {
+            engine.setValue("[Library]", "MoveFocusBackward", true);
+        } else {
+            engine.setValue("[Library]", "MoveDown", true);
+        }
+    }
 };
 
 // <TAP>                : open folder
 // <TAP> + <TAP>        : double-tap to close folder
 // <SHIFT LEFT> + <TAP> : tap bpm of LEFT track
 // <SHIFT RIGHT> + <TAP> : tap bpm of RIGHT track
-var double_tap_time;
-KAOSSDJ.tap_button_callback = function(channel, control, value, status, group) {
+var doubleTapTime;
+KAOSSDJ.tapButtonCallback = function(channel, control, value, status, group) {
     var now = new Date().getTime();
-    var timesince = now - double_tap_time;
+    var timesince = now - doubleTapTime;
 
-	/* shift tab to move focus view */
-	if ((value === ON) && ((shift_left_pressed))) {
-		// engine.setValue("[Library]", "MoveFocusForward", true);
-		engine.setValue("[Channel1]", "bpm_tap", true);
-		return
-	}
-	if ((value === ON) && ((shift_right_pressed))) {
-		// engine.setValue("[Library]", "MoveFocusForward", true);
-		engine.setValue("[Channel2]", "bpm_tap", true);
-		return
-	}
+    /* shift tab to move focus view */
+    if ((value === ON) && ((shiftLeftPressed))) {
+        // engine.setValue("[Library]", "MoveFocusForward", true);
+        engine.setValue("[Channel1]", "bpm_tap", true);
+        return;
+    }
+    if ((value === ON) && ((shiftRightPressed))) {
+        // engine.setValue("[Library]", "MoveFocusForward", true);
+        engine.setValue("[Channel2]", "bpm_tap", true);
+        return;
+    }
 
-	/* tap to open folder, double-tap to close folder (twice to undo first tap)*/
-	if (value === ON) {
-		if((timesince < 600) && (timesince > 0)){
-			engine.setValue("[Library]", "MoveLeft", true);
-			engine.setValue("[Library]", "MoveLeft", true);
-		} else {
-			engine.setValue("[Library]", "MoveRight", true);
-		};
+    /* tap to open folder, double-tap to close folder (twice to undo first tap)*/
+    if (value === ON) {
+        if ((timesince < 600) && (timesince > 0)) {
+            engine.setValue("[Library]", "MoveLeft", true);
+            engine.setValue("[Library]", "MoveLeft", true);
+        } else {
+            engine.setValue("[Library]", "MoveRight", true);
+        }
 
-	   double_tap_time = new Date().getTime();
-	};
+	   doubleTapTime = new Date().getTime();
+    }
 };
 
 // <SHIFT> + <TOUCHPAD X> : control super knob of QuickEffectRack for deck 1
-KAOSSDJ.controllerFxTouchMoveVertical_shift = function(channel, control, value, status, group) {
+KAOSSDJ.controllerFxTouchMoveVerticalShift = function(channel, control, value, status, group) {
     var deck = KAOSSDJ.decks[0];
     if (deck.fx) {
-        var val = script.absoluteLin(value, 0, 1, 0, 127)
-        engine.setValue('[QuickEffectRack1_' + deck.group + ']', 'super1', val);
+        var val = script.absoluteLin(value, 0, 1, 0, 127);
+        engine.setValue("[QuickEffectRack1_" + deck.group + "]", "super1", val);
     }
 };
 
 // <SHIFT> + <TOUCHPAD Y> : control super knob of QuickEffectRack for deck 2
-KAOSSDJ.controllerFxTouchMoveHorizontal_shift = function(channel, control, value, status, group) {
+KAOSSDJ.controllerFxTouchMoveHorizontalShift = function(channel, control, value, status, group) {
     var deck = KAOSSDJ.decks[1];
     if (deck.fx) {
-        var val = script.absoluteLin(value, 0, 1, 0, 127)
-        engine.setValue('[QuickEffectRack1_' + deck.group + ']', 'super1', val);
+        var val = script.absoluteLin(value, 0, 1, 0, 127);
+        engine.setValue("[QuickEffectRack1_" + deck.group + "]", "super1", val);
     }
 };
-

--- a/res/controllers/Korg-KAOSS-DJ-scripts.js
+++ b/res/controllers/Korg-KAOSS-DJ-scripts.js
@@ -68,7 +68,7 @@ KAOSSDJ.init = function(id, debugging) {
 KAOSSDJ.shutdown = function(id, debugging) {
     // turn off all LEDs
     for (var led = 0x00; led <= 0xFF; led++) {
-        for (key in ledChannel) {
+        for (var key in ledChannel) {
             midi.sendShortMsg(ledChannel[key], led, OFF);
         }
     }
@@ -178,7 +178,7 @@ KAOSSDJ.rightFxSwitch = function(channel, control, value, status, group) {
 
 KAOSSDJ.controllerFxTouchMoveVertical = function(channel, control, value, status, group) {
     var decks = KAOSSDJ.decks;
-    for (key in decks) {
+    for (var key in decks) {
         var deck = decks[key];
         if (deck.fx) {
             engine.setValue("[EffectRack1_EffectUnit"+deck.deckNumber +"]", "mix", value / 127);
@@ -188,7 +188,7 @@ KAOSSDJ.controllerFxTouchMoveVertical = function(channel, control, value, status
 
 KAOSSDJ.controllerFxTouchMoveHorizontal = function(channel, control, value, status, group) {
     var decks = KAOSSDJ.decks;
-    for (key in decks) {
+    for (var key in decks) {
         var deck = decks[key];
         if (deck.fx) {
             engine.setValue("[EffectRack1_EffectUnit"+deck.deckNumber +"]", "super1", value / 127);

--- a/res/controllers/Korg-KAOSS-DJ-scripts.js
+++ b/res/controllers/Korg-KAOSS-DJ-scripts.js
@@ -205,7 +205,7 @@ KAOSSDJ.controllerFxTouchUp = function(channel, _control, _value, _status, _grou
 // use loop-button to deactivate an active loop or initialize a beatloop at the current playback position
 KAOSSDJ.toggleLoop = function(channel, _control, value, _status, _group) {
     var deck = KAOSSDJ.getDeckByChannel(channel);
-    var loopEnabled = engine.getValue(deck.group, "loopEnabled");
+    var loopEnabled = engine.getValue(deck.group, "loop_enabled");
 
     if (value === ON) {
         if (loopEnabled) {

--- a/res/controllers/Korg-KAOSS-DJ-scripts.js
+++ b/res/controllers/Korg-KAOSS-DJ-scripts.js
@@ -13,19 +13,20 @@ var ledChannel = {
     "knobsR": 0xB8,
     "master": 0xB6
 };
-var led = {
-    "cue": 0x1E,
-    "sync": 0x1D,
-    "play": 0x1B,
-    "headphones": 0x19,
-    "fx": 0x18, // warning: led is owned by controller
-    "stripL": 0x15,
-    "stripM": 0x16,
-    "stripR": 0x17,
-    "loopStripL": 0x0F,
-    "loopStripM": 0x10,
-    "loopStripR": 0x11,
-};
+
+// var led = {
+//     "cue": 0x1E,
+//     "sync": 0x1D,
+//     "play": 0x1B,
+//     "headphones": 0x19,
+//     "fx": 0x18, // warning: led is owned by controller
+//     "stripL": 0x15,
+//     "stripM": 0x16,
+//     "stripR": 0x17,
+//     "loopStripL": 0x0F,
+//     "loopStripM": 0x10,
+//     "loopStripR": 0x11,
+// };
 
 // shift button state variables
 var shiftLeftPressed = false;
@@ -46,7 +47,7 @@ for (var i = 0; i < 4; i++) { // TODO: currently only 2 decks supported. is 4 po
 
 // ==== lifecycle ====
 
-KAOSSDJ.init = function(id, debugging) {
+KAOSSDJ.init = function(_id, _debugging) {
     // turn on main led channels
     var ledChannels = [
         ledChannel.knobsL,
@@ -65,7 +66,7 @@ KAOSSDJ.init = function(id, debugging) {
     midi.sendSysexMsg(ControllerStatusSysex, ControllerStatusSysex.length);
 };
 
-KAOSSDJ.shutdown = function(id, debugging) {
+KAOSSDJ.shutdown = function(_id, _debugging) {
     // turn off all LEDs
     for (var led = 0x00; led <= 0xFF; led++) {
         for (var key in ledChannel) {
@@ -92,7 +93,7 @@ KAOSSDJ.updateDeckByChannel = function(channel, key, value) {
 
 // ==== mapped functions ====
 
-KAOSSDJ.wheelTouch = function(channel, control, value, status, group) {
+KAOSSDJ.wheelTouch = function(channel, _control, value, _status, _group) {
     var alpha = 1.0 / 8;
     var beta = alpha / 32;
     var deck = KAOSSDJ.getDeckByChannel(channel);
@@ -111,7 +112,7 @@ KAOSSDJ.wheelTouch = function(channel, control, value, status, group) {
     }
 };
 
-KAOSSDJ.wheelTurn = function(channel, control, value, status, group) {
+KAOSSDJ.wheelTurn = function(channel, _control, value, _status, _group) {
     var deck = KAOSSDJ.getDeckByChannel(channel);
     var deckNumber = deck.deckNumber;
     var newValue = 0;
@@ -127,7 +128,7 @@ KAOSSDJ.wheelTurn = function(channel, control, value, status, group) {
     }
 };
 
-KAOSSDJ.wheelTurnShift = function(channel, control, value, status, group) {
+KAOSSDJ.wheelTurnShift = function(channel, _control, value, _status, _group) {
     var deck = KAOSSDJ.getDeckByChannel(channel);
     if (deck.jogWheelsInScratchMode) {
         // Fast scratch
@@ -149,7 +150,7 @@ KAOSSDJ.wheelTurnShift = function(channel, control, value, status, group) {
     }
 };
 
-KAOSSDJ.scratchMode = function(channel, control, value, status, group) {
+KAOSSDJ.scratchMode = function(channel, _control, value, _status, _group) {
     if (value === ON) {
         // Turn scratch mode on jogwheel (LED is red)
         KAOSSDJ.updateDeckByChannel(channel, "jogWheelsInScratchMode", true);
@@ -159,8 +160,7 @@ KAOSSDJ.scratchMode = function(channel, control, value, status, group) {
     }
 };
 
-KAOSSDJ.leftFxSwitch = function(channel, control, value, status, group) {
-    var deck = KAOSSDJ.getDeckByChannel(channel);
+KAOSSDJ.leftFxSwitch = function(channel, _control, value, _status, _group) {
     if (value === ON) {
         KAOSSDJ.updateDeckByChannel(channel, "fx", true);
     } else {
@@ -168,7 +168,7 @@ KAOSSDJ.leftFxSwitch = function(channel, control, value, status, group) {
     }
 };
 
-KAOSSDJ.rightFxSwitch = function(channel, control, value, status, group) {
+KAOSSDJ.rightFxSwitch = function(channel, _control, value, _status, _group) {
     if (value === ON) {
         KAOSSDJ.updateDeckByChannel(channel, "fx", true);
     } else {
@@ -176,7 +176,7 @@ KAOSSDJ.rightFxSwitch = function(channel, control, value, status, group) {
     }
 };
 
-KAOSSDJ.controllerFxTouchMoveVertical = function(channel, control, value, status, group) {
+KAOSSDJ.controllerFxTouchMoveVertical = function(_channel, _control, value, _status, _group) {
     var decks = KAOSSDJ.decks;
     for (var key in decks) {
         var deck = decks[key];
@@ -186,7 +186,7 @@ KAOSSDJ.controllerFxTouchMoveVertical = function(channel, control, value, status
     }
 };
 
-KAOSSDJ.controllerFxTouchMoveHorizontal = function(channel, control, value, status, group) {
+KAOSSDJ.controllerFxTouchMoveHorizontal = function(_channel, _control, value, _status, _group) {
     var decks = KAOSSDJ.decks;
     for (var key in decks) {
         var deck = decks[key];
@@ -196,14 +196,14 @@ KAOSSDJ.controllerFxTouchMoveHorizontal = function(channel, control, value, stat
     }
 };
 
-KAOSSDJ.controllerFxTouchUp = function(channel, control, value, status, group) {
+KAOSSDJ.controllerFxTouchUp = function(channel, _control, _value, _status, _group) {
     var deck = KAOSSDJ.getDeckByChannel(channel);
     engine.setValue("[EffectRack1_EffectUnit"+deck.deckNumber +"]", "mix", 0);
     engine.setValue("[EffectRack1_EffectUnit"+deck.deckNumber +"]", "super1", 0);
 };
 
 // use loop-button to deactivate an active loop or initialize a beatloop at the current playback position
-KAOSSDJ.toggleLoop = function(channel, control, value, status, group) {
+KAOSSDJ.toggleLoop = function(channel, _control, value, _status, _group) {
     var deck = KAOSSDJ.getDeckByChannel(channel);
     var loopEnabled = engine.getValue(deck.group, "loopEnabled");
 
@@ -220,7 +220,7 @@ KAOSSDJ.toggleLoop = function(channel, control, value, status, group) {
 
 // <LOAD A/B>           : load track
 // <SHIFT> + <LOAD A/B> : open/close folder in file-browser
-KAOSSDJ.loadCallback = function(channel, control, value, status, group) {
+KAOSSDJ.loadCallback = function(channel, _control, value, _status, _group) {
     var deck = KAOSSDJ.getDeckByChannel(channel);
     if (value === ON) {
         if ((shiftLeftPressed) || (shiftRightPressed)) {
@@ -235,7 +235,7 @@ KAOSSDJ.loadCallback = function(channel, control, value, status, group) {
     }
 };
 
-KAOSSDJ.shiftLeftCallback = function(channel, control, value, status, group) {
+KAOSSDJ.shiftLeftCallback = function(_channel, _control, value, _status, _group) {
     if (value === ON) {
         // if (shiftRightPressed == true) {
         // 	TODO add functionality if <RIGHT SHIFT> is active while <LEFT SHIFT> is pressed?
@@ -244,7 +244,7 @@ KAOSSDJ.shiftLeftCallback = function(channel, control, value, status, group) {
     } else { shiftLeftPressed = false; }
 };
 
-KAOSSDJ.shiftRightCallback = function(channel, control, value, status, group) {
+KAOSSDJ.shiftRightCallback = function(_channel, _control, value, _status, _group) {
     if (value === ON) {
         // if (shiftLeftPressed == true) {
         // 	TODO add functionality if <LEFT SHIFT> is active while <RIGHT SHIFT> is pressed?
@@ -253,7 +253,7 @@ KAOSSDJ.shiftRightCallback = function(channel, control, value, status, group) {
     } else { shiftRightPressed = false; }
 };
 
-KAOSSDJ.changeFocus = function(channel, control, value, status, group) {
+KAOSSDJ.changeFocus = function(_channel, _control, value, _status, _group) {
     if (value === ON) {
         // toggle focus between Playlist and File-Browser
         engine.setValue("[Library]", "MoveFocusForward", true);
@@ -262,8 +262,7 @@ KAOSSDJ.changeFocus = function(channel, control, value, status, group) {
 
 // <browseKnob>           : browse library up & down
 // <SHIFT> + <browseKnob> : toggle focus between Playlist and File-Browser
-KAOSSDJ.browseKnob = function(channel, control, value, status, group) {
-    var nval = (value > 0x40 ? value - 0x80 : value);
+KAOSSDJ.browseKnob = function(_channel, _control, value, _status, _group) {
     if (value > 0x40) {
         if ((shiftLeftPressed) || (shiftRightPressed)) {
             engine.setValue("[Library]", "MoveFocusForward", true);
@@ -284,7 +283,7 @@ KAOSSDJ.browseKnob = function(channel, control, value, status, group) {
 // <SHIFT LEFT> + <TAP> : tap bpm of LEFT track
 // <SHIFT RIGHT> + <TAP> : tap bpm of RIGHT track
 var doubleTapTime;
-KAOSSDJ.tapButtonCallback = function(channel, control, value, status, group) {
+KAOSSDJ.tapButtonCallback = function(_channel, _control, value, _status, _group) {
     var now = new Date().getTime();
     var timesince = now - doubleTapTime;
 
@@ -314,7 +313,7 @@ KAOSSDJ.tapButtonCallback = function(channel, control, value, status, group) {
 };
 
 // <SHIFT> + <TOUCHPAD X> : control super knob of QuickEffectRack for deck 1
-KAOSSDJ.controllerFxTouchMoveVerticalShift = function(channel, control, value, status, group) {
+KAOSSDJ.controllerFxTouchMoveVerticalShift = function(_channel, _control, value, _status, _group) {
     var deck = KAOSSDJ.decks[0];
     if (deck.fx) {
         var val = script.absoluteLin(value, 0, 1, 0, 127);
@@ -323,7 +322,7 @@ KAOSSDJ.controllerFxTouchMoveVerticalShift = function(channel, control, value, s
 };
 
 // <SHIFT> + <TOUCHPAD Y> : control super knob of QuickEffectRack for deck 2
-KAOSSDJ.controllerFxTouchMoveHorizontalShift = function(channel, control, value, status, group) {
+KAOSSDJ.controllerFxTouchMoveHorizontalShift = function(_channel, _control, value, _status, _group) {
     var deck = KAOSSDJ.decks[1];
     if (deck.fx) {
         var val = script.absoluteLin(value, 0, 1, 0, 127);

--- a/res/controllers/Korg-KAOSS-DJ-scripts.js
+++ b/res/controllers/Korg-KAOSS-DJ-scripts.js
@@ -224,7 +224,7 @@ KAOSSDJ.loadCallback = function(channel, control, value, status, group) {
     var deck = KAOSSDJ.getDeckByChannel(channel);
     if (value === ON) {
         if ((shiftLeftPressed) || (shiftRightPressed)) {
-            if (deck.deckNumber == 1) {
+            if (deck.deckNumber === 1) {
                 engine.setValue("[Library]", "MoveLeft", true);
             } else {
                 engine.setValue("[Library]", "MoveRight", true);
@@ -309,7 +309,7 @@ KAOSSDJ.tapButtonCallback = function(channel, control, value, status, group) {
             engine.setValue("[Library]", "MoveRight", true);
         }
 
-	   doubleTapTime = new Date().getTime();
+        doubleTapTime = new Date().getTime();
     }
 };
 

--- a/res/controllers/Korg-KAOSS-DJ.midi.xml
+++ b/res/controllers/Korg-KAOSS-DJ.midi.xml
@@ -13,7 +13,7 @@
         <controls>
             <control>
                 <group>[Channel1]</group>
-                <key>KAOSSDJ.change_focus</key>
+                <key>KAOSSDJ.changeFocus</key>
                 <description>Change focus between library and playlist</description>
                 <status>0x96</status>
                 <midino>0x07</midino>
@@ -23,7 +23,7 @@
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>KAOSSDJ.tap_button_callback</key>
+                <key>KAOSSDJ.tapButtonCallback</key>
                 <status>0x96</status>
                 <midino>0x0B</midino>
                 <options>
@@ -52,7 +52,7 @@
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>KAOSSDJ.load_callback</key>
+                <key>KAOSSDJ.loadCallback</key>
                 <description>Load into Deck 1</description>
                 <status>0x97</status>
                 <midino>0x0E</midino>
@@ -62,7 +62,7 @@
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>KAOSSDJ.load_callback</key>
+                <key>KAOSSDJ.loadCallback</key>
                 <description>Load into Deck 2</description>
                 <status>0x98</status>
                 <midino>0x0E</midino>
@@ -132,7 +132,7 @@
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>KAOSSDJ.toggle_loop</key>
+                <key>KAOSSDJ.toggleLoop</key>
                 <description>MIDI Learned from 2 messages.</description>
                 <status>0x97</status>
                 <midino>0x10</midino>
@@ -152,7 +152,7 @@
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>KAOSSDJ.toggle_loop</key>
+                <key>KAOSSDJ.toggleLoop</key>
                 <description>MIDI Learned from 2 messages.</description>
                 <status>0x98</status>
                 <midino>0x10</midino>
@@ -192,7 +192,7 @@
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>KAOSSDJ.controllerFxTouchMoveVertical_shift</key>
+                <key>KAOSSDJ.controllerFxTouchMoveVerticalShift</key>
                 <status>0xB6</status>
                 <midino>0x11</midino>
                 <options>
@@ -221,7 +221,7 @@
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>KAOSSDJ.controllerFxTouchMoveHorizontal_shift</key>
+                <key>KAOSSDJ.controllerFxTouchMoveHorizontalShift</key>
                 <status>0xB6</status>
                 <midino>0x12</midino>
                 <options>
@@ -420,7 +420,7 @@
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>KAOSSDJ.shift_left_callback</key>
+                <key>KAOSSDJ.shiftLeftCallback</key>
                 <description>Right shift button</description>
                 <status>0x97</status>
                 <midino>0x1A</midino>
@@ -430,7 +430,7 @@
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>KAOSSDJ.shift_right_callback</key>
+                <key>KAOSSDJ.shiftRightCallback</key>
                 <description>Left shift button</description>
                 <status>0x98</status>
                 <midino>0x1A</midino>

--- a/res/controllers/Korg-KAOSS-DJ.midi.xml
+++ b/res/controllers/Korg-KAOSS-DJ.midi.xml
@@ -1,373 +1,31 @@
 <?xml version='1.0' encoding='utf-8'?>
-<MixxxControllerPreset mixxxVersion="2.0.0" schemaVersion="1">
+<MixxxControllerPreset schemaVersion="1" mixxxVersion="2.0.0">
     <info>
         <name>Korg KAOSS DJ</name>
-        <author>Seb Dooris, Fayaaz Ahmed, Lee Arromba</author>
+        <author>Seb Dooris, Fayaaz Ahmed, Lee Arromba, Raphael Quast</author>
         <description>Controller mapping for the Korg KAOSS DJ Controller.</description>
         <forums>https://www.mixxx.org/forums/viewtopic.php?f=7&amp;t=8479</forums>
-        <manual>korg_kaoss_dj</manual>
     </info>
     <controller id="KAOSS">
         <scriptfiles>
-            <file functionprefix="KAOSSDJ" filename="Korg-KAOSS-DJ-scripts.js"/>
+            <file filename="Korg-KAOSS-DJ-scripts.js" functionprefix="KAOSSDJ"/>
         </scriptfiles>
         <controls>
             <control>
                 <group>[Channel1]</group>
-                <key>sync_enabled</key>
-                <description>Left Sync</description>
-                <status>0x97</status>
-                <midino>0x1D</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>KAOSSDJ.wheelTurn</key>
-                <description>Left Jog Wheel Turn Scratch</description>
-                <status>0xB7</status>
-                <midino>0x10</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>play</key>
-                <description>Right Play</description>
-                <status>0x98</status>
-                <midino>0x1B</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>play</key>
-                <description>Left Play</description>
-                <status>0x97</status>
-                <midino>0x1B</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Playlist]</group>
-                <key>KAOSSDJ.browseKnob</key>
-                <description>Library Browse</description>
-                <status>0xB6</status>
-                <midino>0x1E</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>LoadSelectedTrack</key>
-                <description>Load into Deck 2</description>
-                <status>0x98</status>
-                <midino>0x0E</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>KAOSSDJ.rightFxSwitch</key>
-                <description>Right Fx switch</description>
-                <status>0x98</status>
-                <midino>0x18</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>LoadSelectedTrack</key>
-                <description>Load into Deck 1</description>
-                <status>0x97</status>
-                <midino>0x0E</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>KAOSSDJ.leftFxSwitch</key>
-                <description>Left Fx switch</description>
-                <status>0x97</status>
-                <midino>0x18</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>loop_halve</key>
-                <description>MIDI Learned from 6 messages.</description>
-                <status>0x98</status>
-                <midino>0x0F</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>pfl</key>
-                <description>Right Headphones Button</description>
-                <status>0x98</status>
-                <midino>0x19</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>loop_halve</key>
-                <description>MIDI Learned from 2 messages.</description>
-                <status>0x97</status>
-                <midino>0x0F</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[EqualizerRack1_[Channel2]_Effect1]</group>
-                <key>parameter2</key>
-                <description>Right Equaliser Mid</description>
-                <status>0xB8</status>
-                <midino>0x1C</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>pfl</key>
-                <description>Left Headphones Button</description>
-                <status>0x97</status>
-                <midino>0x19</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-                <key>parameter2</key>
-                <description>Left Equaliser Mid</description>
-                <status>0xB7</status>
-                <midino>0x1C</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[EqualizerRack1_[Channel2]_Effect1]</group>
-                <key>parameter1</key>
-                <description>Right Equaliser Low</description>
-                <status>0xB8</status>
-                <midino>0x1D</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-                <key>parameter1</key>
-                <description>Left Equaliser Low</description>
-                <status>0xB7</status>
-                <midino>0x1D</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>pregain</key>
-                <description>Right Gain</description>
-                <status>0xB8</status>
-                <midino>0x1A</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>pregain</key>
-                <description>Right Gain</description>
-                <status>0xB8</status>
-                <midino>0x1A</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Sampler3]</group>
-                <key>cue_gotoandplay</key>
-                <description>Sampler 3 Play</description>
+                <key>KAOSSDJ.change_focus</key>
+                <description>Change focus between library and playlist</description>
                 <status>0x96</status>
-                <midino>0x4C</midino>
+                <midino>0x07</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>pregain</key>
-                <description>Left Gain</description>
-                <status>0xB7</status>
-                <midino>0x1A</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[EqualizerRack1_[Channel2]_Effect1]</group>
-                <key>parameter3</key>
-                <description>Right Equaliser High</description>
-                <status>0xB8</status>
-                <midino>0x1B</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Sampler4]</group>
-                <key>cue_gotoandplay</key>
-                <description>Sampler 4 Play</description>
+                <key>KAOSSDJ.tap_button_callback</key>
                 <status>0x96</status>
-                <midino>0x4D</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-                <key>parameter3</key>
-                <description>Left Equaliser High</description>
-                <status>0xB7</status>
-                <midino>0x1B</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>KAOSSDJ.wheelTurn</key>
-                <description>Right Jog Wheel Turn</description>
-                <status>0xB8</status>
-                <midino>0x0E</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>volume</key>
-                <description>MIDI Learned from 238 messages.</description>
-                <status>0xB8</status>
-                <midino>0x18</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Sampler1]</group>
-                <key>cue_gotoandplay</key>
-                <description>Sampler 1 Play</description>
-                <status>0x96</status>
-                <midino>0x4A</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>KAOSSDJ.wheelTurn</key>
-                <description>Left Jog Wheel Turn</description>
-                <status>0xB7</status>
-                <midino>0x0E</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>volume</key>
-                <description>MIDI Learned from 150 messages.</description>
-                <status>0xB7</status>
-                <midino>0x18</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>KAOSSDJ.wheelTurnShift</key>
-                <description>Right Jog Wheel Turn Shift</description>
-                <status>0xB8</status>
-                <midino>0x0F</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>rate</key>
-                <description>Right Pitch Bend</description>
-                <status>0xB8</status>
-                <midino>0x19</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Sampler2]</group>
-                <key>cue_gotoandplay</key>
-                <description>Sampler 2 Play</description>
-                <status>0x96</status>
-                <midino>0x4B</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>KAOSSDJ.wheelTurnShift</key>
-                <description>Left Jog Wheel Turn Shift</description>
-                <status>0xB7</status>
-                <midino>0x0F</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>rate</key>
-                <description>Left Pitch Bend</description>
-                <status>0xB7</status>
-                <midino>0x19</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>KAOSSDJ.scratchMode</key>
-                <description>Scratch mode button</description>
-                <status>0x98</status>
-                <midino>0x16</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>KAOSSDJ.controllerFxTouchMoveVertical</key>
-                <description>Fx Control</description>
-                <status>0xB8</status>
-                <midino>0x0D</midino>
+                <midino>0x0B</midino>
                 <options>
                     <script-binding/>
                 </options>
@@ -384,190 +42,140 @@
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>KAOSSDJ.controllerFxTouchUp</key>
+                <key>KAOSSDJ.controllerFxTouchMoveVertical</key>
                 <description>Fx Control</description>
-                <status>0x97</status>
-                <midino>0x20</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>KAOSSDJ.controllerFxTouchUp</key>
-                <description>Fx Control</description>
-                <status>0x98</status>
-                <midino>0x20</midino>
+                <status>0xB8</status>
+                <midino>0x0D</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>KAOSSDJ.scratchMode</key>
-                <description>Scratch mode button</description>
+                <key>KAOSSDJ.load_callback</key>
+                <description>Load into Deck 1</description>
                 <status>0x97</status>
-                <midino>0x16</midino>
+                <midino>0x0E</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>rate_temp_up</key>
-                <description>Nudge (pitch+)</description>
+                <key>KAOSSDJ.load_callback</key>
+                <description>Load into Deck 2</description>
                 <status>0x98</status>
-                <midino>0x17</midino>
+                <midino>0x0E</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>rate_temp_up</key>
-                <description>Nudge (pitch +)</description>
-                <status>0x97</status>
-                <midino>0x17</midino>
+                <key>KAOSSDJ.wheelTurn</key>
+                <description>Left Jog Wheel Turn</description>
+                <status>0xB7</status>
+                <midino>0x0E</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>hotcue_3_activate</key>
-                <description>Right HotCue 3</description>
-                <status>0x98</status>
-                <midino>0x14</midino>
+                <key>KAOSSDJ.wheelTurn</key>
+                <description>Right Jog Wheel Turn</description>
+                <status>0xB8</status>
+                <midino>0x0E</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>hotcue_3_activate</key>
-                <description>Left HotCue 3</description>
-                <status>0x97</status>
-                <midino>0x14</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>rate_temp_down</key>
-                <description>Nudge (pitch-)</description>
-                <status>0x98</status>
-                <midino>0x15</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>rate_temp_down</key>
-                <description>Nudge (pitch -)</description>
-                <status>0x97</status>
-                <midino>0x15</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>hotcue_1_activate</key>
-                <description>Right HotCue 1</description>
-                <status>0x98</status>
-                <midino>0x12</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>hotcue_1_activate</key>
-                <description>Left HotCue 1</description>
-                <status>0x97</status>
-                <midino>0x12</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>hotcue_2_activate</key>
-                <description>Right HotCue 2</description>
-                <status>0x98</status>
-                <midino>0x13</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>hotcue_2_activate</key>
-                <description>Left HotCue 2</description>
-                <status>0x97</status>
-                <midino>0x13</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>hotcue_2_clear</key>
-                <description>Right HotCue 2 clear</description>
-                <status>0x98</status>
-                <midino>0x2C</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>reloop_exit</key>
+                <key>loop_halve</key>
                 <description>MIDI Learned from 2 messages.</description>
-                <status>0x98</status>
-                <midino>0x10</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>hotcue_2_clear</key>
-                <description>Left HotCue 2 clear</description>
                 <status>0x97</status>
-                <midino>0x2C</midino>
+                <midino>0x0F</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>loop_halve</key>
+                <description>MIDI Learned from 6 messages.</description>
+                <status>0x98</status>
+                <midino>0x0F</midino>
                 <options>
                     <normal/>
                 </options>
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>reloop_exit</key>
+                <key>KAOSSDJ.wheelTurnShift</key>
+                <description>Left Jog Wheel Turn Shift</description>
+                <status>0xB7</status>
+                <midino>0x0F</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>KAOSSDJ.wheelTurnShift</key>
+                <description>Right Jog Wheel Turn Shift</description>
+                <status>0xB8</status>
+                <midino>0x0F</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>KAOSSDJ.toggle_loop</key>
                 <description>MIDI Learned from 2 messages.</description>
                 <status>0x97</status>
                 <midino>0x10</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>KAOSSDJ.wheelTurn</key>
+                <description>Left Jog Wheel Turn Scratch</description>
+                <status>0x97</status>
+                <midino>0x10</midino>
+                <options>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>hotcue_3_clear</key>
-                <description>Right HotCue 3 clear</description>
+                <key>KAOSSDJ.toggle_loop</key>
+                <description>MIDI Learned from 2 messages.</description>
                 <status>0x98</status>
-                <midino>0x2D</midino>
+                <midino>0x10</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
-                <group>[Master]</group>
-                <key>crossfader</key>
-                <description>X-Fader</description>
-                <status>0xB6</status>
-                <midino>0x17</midino>
+                <group>[Channel2]</group>
+                <key>KAOSSDJ.wheelTurn</key>
+                <description>Right Jog Wheel Turn SCRATCH</description>
+                <status>0xB8</status>
+                <midino>0x10</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>loop_double</key>
+                <description>MIDI Learned from 4 messages.</description>
+                <status>0x97</status>
+                <midino>0x11</midino>
                 <options>
                     <normal/>
                 </options>
@@ -584,70 +192,378 @@
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>hotcue_3_clear</key>
-                <description>Left HotCue 3 clear</description>
-                <status>0x97</status>
-                <midino>0x2D</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>loop_double</key>
-                <description>MIDI Learned from 4 messages.</description>
-                <status>0x97</status>
+                <key>KAOSSDJ.controllerFxTouchMoveVertical_shift</key>
+                <status>0xB6</status>
                 <midino>0x11</midino>
                 <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>loop_out</key>
-                <description>Right Loop out</description>
-                <status>0x98</status>
-                <midino>0x2A</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>playposition</key>
-                <description>Track Seek</description>
-                <status>0xB8</status>
-                <midino>0x21</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>cue_default</key>
-                <description>Right CUE</description>
-                <status>0x98</status>
-                <midino>0x1E</midino>
-                <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>loop_out</key>
-                <description>Left Loop out</description>
+                <key>hotcue_1_activate</key>
+                <description>Left HotCue 1</description>
                 <status>0x97</status>
-                <midino>0x2A</midino>
+                <midino>0x12</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>hotcue_1_activate</key>
+                <description>Right HotCue 1</description>
+                <status>0x98</status>
+                <midino>0x12</midino>
                 <options>
                     <normal/>
                 </options>
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>playposition</key>
-                <description>Track Seek</description>
+                <key>KAOSSDJ.controllerFxTouchMoveHorizontal_shift</key>
+                <status>0xB6</status>
+                <midino>0x12</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>hotcue_2_activate</key>
+                <description>Left HotCue 2</description>
+                <status>0x97</status>
+                <midino>0x13</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>hotcue_2_activate</key>
+                <description>Right HotCue 2</description>
+                <status>0x98</status>
+                <midino>0x13</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>hotcue_3_activate</key>
+                <description>Left HotCue 3</description>
+                <status>0x97</status>
+                <midino>0x14</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>hotcue_3_activate</key>
+                <description>Right HotCue 3</description>
+                <status>0x98</status>
+                <midino>0x14</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>rate_temp_down</key>
+                <description>Nudge (pitch -)</description>
+                <status>0x97</status>
+                <midino>0x15</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>rate_temp_down</key>
+                <description>Nudge (pitch-)</description>
+                <status>0x98</status>
+                <midino>0x15</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>KAOSSDJ.scratchMode</key>
+                <description>Scratch mode button</description>
+                <status>0x97</status>
+                <midino>0x16</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>KAOSSDJ.scratchMode</key>
+                <description>Scratch mode button</description>
+                <status>0x98</status>
+                <midino>0x16</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>rate_temp_up</key>
+                <description>Nudge (pitch +)</description>
+                <status>0x97</status>
+                <midino>0x17</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>rate_temp_up</key>
+                <description>Nudge (pitch+)</description>
+                <status>0x98</status>
+                <midino>0x17</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Master]</group>
+                <key>crossfader</key>
+                <description>X-Fader</description>
+                <status>0xB6</status>
+                <midino>0x17</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>KAOSSDJ.leftFxSwitch</key>
+                <description>Left Fx switch</description>
+                <status>0x97</status>
+                <midino>0x18</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>KAOSSDJ.rightFxSwitch</key>
+                <description>Right Fx switch</description>
+                <status>0x98</status>
+                <midino>0x18</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>volume</key>
+                <description>MIDI Learned from 150 messages.</description>
                 <status>0xB7</status>
-                <midino>0x21</midino>
+                <midino>0x18</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>volume</key>
+                <description>MIDI Learned from 238 messages.</description>
+                <status>0xB8</status>
+                <midino>0x18</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>pfl</key>
+                <description>Left Headphones Button</description>
+                <status>0x97</status>
+                <midino>0x19</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>pfl</key>
+                <description>Right Headphones Button</description>
+                <status>0x98</status>
+                <midino>0x19</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>rate</key>
+                <description>Left Pitch Bend</description>
+                <status>0xB7</status>
+                <midino>0x19</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>rate</key>
+                <description>Right Pitch Bend</description>
+                <status>0xB8</status>
+                <midino>0x19</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>KAOSSDJ.shift_left_callback</key>
+                <description>Right shift button</description>
+                <status>0x97</status>
+                <midino>0x1A</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>KAOSSDJ.shift_right_callback</key>
+                <description>Left shift button</description>
+                <status>0x98</status>
+                <midino>0x1A</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>pregain</key>
+                <description>Left Gain</description>
+                <status>0xB7</status>
+                <midino>0x1A</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>pregain</key>
+                <description>Right Gain</description>
+                <status>0xB8</status>
+                <midino>0x1A</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>pregain</key>
+                <description>Right Gain</description>
+                <status>0xB8</status>
+                <midino>0x1A</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>play</key>
+                <description>Left Play</description>
+                <status>0x97</status>
+                <midino>0x1B</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>play</key>
+                <description>Right Play</description>
+                <status>0x98</status>
+                <midino>0x1B</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+                <key>parameter3</key>
+                <description>Left Equaliser High</description>
+                <status>0xB7</status>
+                <midino>0x1B</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+                <key>parameter3</key>
+                <description>Right Equaliser High</description>
+                <status>0xB8</status>
+                <midino>0x1B</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+                <key>parameter2</key>
+                <description>Left Equaliser Mid</description>
+                <status>0xB7</status>
+                <midino>0x1C</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+                <key>parameter2</key>
+                <description>Right Equaliser Mid</description>
+                <status>0xB8</status>
+                <midino>0x1C</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>sync_enabled</key>
+                <description>Left Sync</description>
+                <status>0x97</status>
+                <midino>0x1D</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>sync_enabled</key>
+                <description>Right Sync</description>
+                <status>0x98</status>
+                <midino>0x1D</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+                <key>parameter1</key>
+                <description>Left Equaliser Low</description>
+                <status>0xB7</status>
+                <midino>0x1D</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+                <key>parameter1</key>
+                <description>Right Equaliser Low</description>
+                <status>0xB8</status>
+                <midino>0x1D</midino>
                 <options>
                     <normal/>
                 </options>
@@ -664,32 +580,22 @@
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>hotcue_1_clear</key>
-                <description>Right HotCue 1 clear</description>
+                <key>cue_default</key>
+                <description>Right CUE</description>
                 <status>0x98</status>
-                <midino>0x2B</midino>
+                <midino>0x1E</midino>
                 <options>
                     <normal/>
                 </options>
             </control>
             <control>
-                <group>[Channel2]</group>
-                <key>KAOSSDJ.wheelTouch</key>
-                <description>Right Jog Wheel Touch</description>
-                <status>0x98</status>
-                <midino>0x1F</midino>
+                <group>[Playlist]</group>
+                <key>KAOSSDJ.browseKnob</key>
+                <description>Library Browse</description>
+                <status>0xB6</status>
+                <midino>0x1E</midino>
                 <options>
                     <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>hotcue_1_clear</key>
-                <description>Left HotCue 1 clear</description>
-                <status>0x97</status>
-                <midino>0x2B</midino>
-                <options>
-                    <normal/>
                 </options>
             </control>
             <control>
@@ -704,10 +610,60 @@
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>loop_in</key>
-                <description>Right Loop in</description>
+                <key>KAOSSDJ.wheelTouch</key>
+                <description>Right Jog Wheel Touch</description>
                 <status>0x98</status>
-                <midino>0x28</midino>
+                <midino>0x1F</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>KAOSSDJ.MoveFocus</key>
+                <description>fx knob</description>
+                <status>0xB6</status>
+                <midino>0x1F</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>KAOSSDJ.controllerFxTouchUp</key>
+                <description>Fx Control</description>
+                <status>0x97</status>
+                <midino>0x20</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>KAOSSDJ.controllerFxTouchUp</key>
+                <description>Fx Control</description>
+                <status>0x98</status>
+                <midino>0x20</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>playposition</key>
+                <description>Track Seek</description>
+                <status>0xB7</status>
+                <midino>0x21</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>playposition</key>
+                <description>Track Seek</description>
+                <status>0xB8</status>
+                <midino>0x21</midino>
                 <options>
                     <normal/>
                 </options>
@@ -724,27 +680,17 @@
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>beatloop_activate</key>
-                <description>MIDI Learned from 4 messages.</description>
+                <key>loop_in</key>
+                <description>Right Loop in</description>
                 <status>0x98</status>
-                <midino>0x29</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>sync_enabled</key>
-                <description>Right Sync</description>
-                <status>0x98</status>
-                <midino>0x1D</midino>
+                <midino>0x28</midino>
                 <options>
                     <normal/>
                 </options>
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>beatloop_activate</key>
+                <key>reloop_toggle</key>
                 <description>MIDI Learned from 2 messages.</description>
                 <status>0x97</status>
                 <midino>0x29</midino>
@@ -754,72 +700,138 @@
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>KAOSSDJ.wheelTurn</key>
-                <description>Right Jog Wheel Turn SCRATCH</description>
-                <status>0xB8</status>
-                <midino>0x10</midino>
+                <key>reloop_toggle</key>
+                <description>MIDI Learned from 4 messages.</description>
+                <status>0x98</status>
+                <midino>0x29</midino>
                 <options>
-                    <script-binding/>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>loop_out</key>
+                <description>Left Loop out</description>
+                <status>0x97</status>
+                <midino>0x2A</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>loop_out</key>
+                <description>Right Loop out</description>
+                <status>0x98</status>
+                <midino>0x2A</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>hotcue_1_clear</key>
+                <description>Left HotCue 1 clear</description>
+                <status>0x97</status>
+                <midino>0x2B</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>hotcue_1_clear</key>
+                <description>Right HotCue 1 clear</description>
+                <status>0x98</status>
+                <midino>0x2B</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>hotcue_2_clear</key>
+                <description>Left HotCue 2 clear</description>
+                <status>0x97</status>
+                <midino>0x2C</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>hotcue_2_clear</key>
+                <description>Right HotCue 2 clear</description>
+                <status>0x98</status>
+                <midino>0x2C</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>hotcue_3_clear</key>
+                <description>Left HotCue 3 clear</description>
+                <status>0x97</status>
+                <midino>0x2D</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>hotcue_3_clear</key>
+                <description>Right HotCue 3 clear</description>
+                <status>0x98</status>
+                <midino>0x2D</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Sampler1]</group>
+                <key>cue_gotoandplay</key>
+                <description>Sampler 1 Play</description>
+                <status>0x96</status>
+                <midino>0x4A</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Sampler2]</group>
+                <key>cue_gotoandplay</key>
+                <description>Sampler 2 Play</description>
+                <status>0x96</status>
+                <midino>0x4B</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Sampler3]</group>
+                <key>cue_gotoandplay</key>
+                <description>Sampler 3 Play</description>
+                <status>0x96</status>
+                <midino>0x4C</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Sampler4]</group>
+                <key>cue_gotoandplay</key>
+                <description>Sampler 4 Play</description>
+                <status>0x96</status>
+                <midino>0x4D</midino>
+                <options>
+                    <normal/>
                 </options>
             </control>
         </controls>
         <outputs>
             <output>
                 <group>[Channel1]</group>
-                <key>loop_enabled</key>
-                <status>0x97</status>
-                <midino>0x10</midino>
-                <on>0x00</on>
-                <off>0x7F</off>
-                <maximum>0</maximum>
-            </output>
-            <output>
-                <group>[Channel2]</group>
-                <key>hotcue_3_enabled</key>
-                <status>0x98</status>
-                <midino>0x14</midino>
-                <on>0x00</on>
-                <off>0x7F</off>
-                <maximum>0</maximum>
-            </output>
-            <output>
-                <group>[Channel1]</group>
-                <key>play_indicator</key>
-                <status>0x97</status>
-                <midino>0x1B</midino>
-                <on>0x00</on>
-                <off>0x7F</off>
-                <maximum>0</maximum>
-            </output>
-            <output>
-                <group>[Channel2]</group>
-                <key>sync_enabled</key>
-                <status>0x98</status>
-                <midino>0x1D</midino>
-                <on>0x00</on>
-                <off>0x7F</off>
-                <maximum>0</maximum>
-            </output>
-            <output>
-                <group>[Channel1]</group>
-                <key>sync_enabled</key>
-                <status>0x97</status>
-                <midino>0x1D</midino>
-                <on>0x00</on>
-                <off>0x7F</off>
-                <maximum>0</maximum>
-            </output>
-            <output>
-                <group>[Channel2]</group>
-                <key>loop_enabled</key>
-                <status>0x98</status>
-                <midino>0x10</midino>
-                <on>0x00</on>
-                <off>0x7F</off>
-                <maximum>0</maximum>
-            </output>
-            <output>
-                <group>[Channel1]</group>
                 <key>cue_indicator</key>
                 <status>0x97</status>
                 <midino>0x1E</midino>
@@ -829,18 +841,18 @@
             </output>
             <output>
                 <group>[Channel1]</group>
-                <key>pfl</key>
+                <key>hotcue_1_enabled</key>
                 <status>0x97</status>
-                <midino>0x19</midino>
+                <midino>0x12</midino>
                 <on>0x00</on>
                 <off>0x7F</off>
                 <maximum>0</maximum>
             </output>
             <output>
-                <group>[Channel2]</group>
-                <key>pfl</key>
-                <status>0x98</status>
-                <midino>0x19</midino>
+                <group>[Channel1]</group>
+                <key>hotcue_2_enabled</key>
+                <status>0x97</status>
+                <midino>0x13</midino>
                 <on>0x00</on>
                 <off>0x7F</off>
                 <maximum>0</maximum>
@@ -855,9 +867,27 @@
                 <maximum>0</maximum>
             </output>
             <output>
-                <group>[Channel2]</group>
+                <group>[Channel1]</group>
+                <key>loop_enabled</key>
+                <status>0x97</status>
+                <midino>0x10</midino>
+                <on>0x00</on>
+                <off>0x7F</off>
+                <maximum>0</maximum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>pfl</key>
+                <status>0x97</status>
+                <midino>0x19</midino>
+                <on>0x00</on>
+                <off>0x7F</off>
+                <maximum>0</maximum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
                 <key>play_indicator</key>
-                <status>0x98</status>
+                <status>0x97</status>
                 <midino>0x1B</midino>
                 <on>0x00</on>
                 <off>0x7F</off>
@@ -865,9 +895,18 @@
             </output>
             <output>
                 <group>[Channel1]</group>
-                <key>hotcue_1_enabled</key>
+                <key>sync_enabled</key>
                 <status>0x97</status>
-                <midino>0x12</midino>
+                <midino>0x1D</midino>
+                <on>0x00</on>
+                <off>0x7F</off>
+                <maximum>0</maximum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>cue_indicator</key>
+                <status>0x98</status>
+                <midino>0x1E</midino>
                 <on>0x00</on>
                 <off>0x7F</off>
                 <maximum>0</maximum>
@@ -891,19 +930,46 @@
                 <maximum>0</maximum>
             </output>
             <output>
-                <group>[Channel1]</group>
-                <key>hotcue_2_enabled</key>
-                <status>0x97</status>
-                <midino>0x13</midino>
+                <group>[Channel2]</group>
+                <key>hotcue_3_enabled</key>
+                <status>0x98</status>
+                <midino>0x14</midino>
                 <on>0x00</on>
                 <off>0x7F</off>
                 <maximum>0</maximum>
             </output>
             <output>
                 <group>[Channel2]</group>
-                <key>cue_indicator</key>
+                <key>loop_enabled</key>
                 <status>0x98</status>
-                <midino>0x1E</midino>
+                <midino>0x10</midino>
+                <on>0x00</on>
+                <off>0x7F</off>
+                <maximum>0</maximum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>pfl</key>
+                <status>0x98</status>
+                <midino>0x19</midino>
+                <on>0x00</on>
+                <off>0x7F</off>
+                <maximum>0</maximum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>play_indicator</key>
+                <status>0x98</status>
+                <midino>0x1B</midino>
+                <on>0x00</on>
+                <off>0x7F</off>
+                <maximum>0</maximum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>sync_enabled</key>
+                <status>0x98</status>
+                <midino>0x1D</midino>
                 <on>0x00</on>
                 <off>0x7F</off>
                 <maximum>0</maximum>


### PR DESCRIPTION
### New assignments:

|||
|--------------|-----------|
| `browser Knob` | browse library or playlist up & down (same as before) |
| `shift` + `browser Knob` | toggle focus between Playlist and File-Browser |

|||
|--------------|-----------|
| `tap`     |  open folder       |  
| 2 x `tap`     |  close folder       |  
| `(left) shift` + `tap`|  tap bpm of left track | 
| `(right) shift` + `tap`|  tap bpm of right track | 

|||
|--------------|-----------|
| `load A / B` | load track to deck 1 / 2 (same as before) |
| `shift` + `load A / B` | open / close folder in file-browser|   

|||
|--------------|-----------|
| `shift` + `touchpad X` | control super knob of QuickEffectRack for deck 1|   
| `shift` + `touchpad Y` | control super knob of QuickEffectRack for deck 2 |   

### changed assignments
- the loop-on button now works as follows:
   - if a loop is active, it deactivates the loop (same as before)
   - if no loop is active, a new beatloop is created at the current playback position  
    (before a re-loop of the deactivated loop was triggered)


### doc-updates:
https://github.com/mixxxdj/manual/pull/430
