### PR TITLE
set continue-on-error: true for coveralls.io upload

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -132,6 +132,7 @@ jobs:
       working-directory: build
     - name: "Upload Coverage Report to coveralls.io"
       if: matrix.name == 'coverage'
+      continue-on-error: true
       uses: coverallsapp/github-action@master
       with:
         flag-name: ubuntu-20.04


### PR DESCRIPTION
All other checks shall be continued if the coveralls.io upload fails because of server maintenance