### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,7 @@ repos:
     language: python
     files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|m|mm|proto|vert)$
 - repo: https://github.com/psf/black
-  rev: 21.7b0
+  rev: 21.9b0
   hooks:
   - id: black
     files: ^tools/.*$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,7 +96,7 @@ repos:
   hooks:
   - id: shellcheck
 - repo: https://github.com/DavidAnson/markdownlint-cli2
-  rev: v0.2.0
+  rev: v0.3.1
   hooks:
   - id: markdownlint-cli2
 - repo: local

--- a/res/controllers/novation-launchpad/README.md
+++ b/res/controllers/novation-launchpad/README.md
@@ -87,9 +87,8 @@ To select a single channel, simply press the button corresponding to the
 channel. This will remove all existing selections, and find the largest default
 preset that can be fit on the main grid.
 
-Presets come in 3 different sizes: *short* (4x4), *tall* (4x8) and *grande*
-(8x8)[1]. Multiple presets can have the same size, but only one preset
-can be default per size.
+Presets come in 3 different sizes: *short* (4x4), *tall* (4x8) and *grande* (8x8)(1).
+Multiple presets can have the same size, but only one preset can be default per size.
 
 To select multiple channels to be laid out, press the corresponding buttons
 in a *chord*. This way you can select to 4 channels.


### PR DESCRIPTION
Two minor updates and a manual edit to prevent reformatting due to a false positive.

### How to test

Run the following command:

```
SKIP=clang-format,eslint,end-of-file-fixer,trailing-whitespace \
pre-commit run --all-files
```

Expected result: No changes