### PR TITLE
DlgTrackInfo: Fix SIGSEGV after debug assertion

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -616,12 +616,13 @@ void DlgTrackInfo::slotSpinBpmValueChanged(double value) {
                 bpm);
     }
 
-    const mixxx::Bpm oldValue = m_pBeatsClone->getBpm();
-    if (oldValue == bpm) {
-        return;
+    if (m_pBeatsClone) {
+        const mixxx::Bpm oldValue = m_pBeatsClone->getBpm();
+        if (oldValue == bpm) {
+            return;
+        }
+        m_pBeatsClone = m_pBeatsClone->setBpm(bpm);
     }
-
-    m_pBeatsClone = m_pBeatsClone->setBpm(bpm);
 
     updateSpinBpmFromBeats();
 }

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -609,7 +609,11 @@ void DlgTrackInfo::slotSpinBpmValueChanged(double value) {
     }
 
     if (!m_pBeatsClone) {
-        const mixxx::audio::FramePos cuePosition = m_pLoadedTrack->getMainCuePosition();
+        mixxx::audio::FramePos cuePosition = m_pLoadedTrack->getMainCuePosition();
+        // This should never happen, but we cannot be sure
+        VERIFY_OR_DEBUG_ASSERT(cuePosition.isValid()) {
+            cuePosition = mixxx::audio::kStartFramePos;
+        }
         m_pBeatsClone = mixxx::Beats::fromConstTempo(
                 m_pLoadedTrack->getSampleRate(),
                 cuePosition,

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -560,30 +560,14 @@ void DlgTrackInfo::slotBpmClear() {
 }
 
 void DlgTrackInfo::slotBpmConstChanged(int state) {
-    if (state != Qt::Unchecked) {
-        // const beatgrid requested
-        const auto bpm = mixxx::Bpm(spinBpm->value());
-        if (bpm.isValid()) {
-            // Since the user is not satisfied with the beat map,
-            // it is hard to predict a fitting beat. We know that we
-            // cannot use the first beat, since it is out of sync in
-            // almost all cases.
-            // The cue point should be set on a beat, so this seems
-            // to be a good alternative
-            const mixxx::audio::FramePos cuePosition = m_pLoadedTrack->getMainCuePosition();
-            m_pBeatsClone = mixxx::Beats::fromConstTempo(
-                    m_pLoadedTrack->getSampleRate(),
-                    cuePosition,
-                    bpm);
-        } else {
-            m_pBeatsClone.reset();
-        }
-        spinBpm->setEnabled(true);
-        bpmTap->setEnabled(true);
-    } else {
+    if (state == Qt::Unchecked) {
         // try to reload BeatMap from the Track
         reloadTrackBeats(*m_pLoadedTrack);
+        return;
     }
+    spinBpm->setEnabled(true);
+    bpmTap->setEnabled(true);
+    slotSpinBpmValueChanged(spinBpm->value());
 }
 
 void DlgTrackInfo::slotBpmTap(double averageLength, int numSamples) {

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -616,7 +616,8 @@ void DlgTrackInfo::slotSpinBpmValueChanged(double value) {
         }
         m_pBeatsClone = mixxx::Beats::fromConstTempo(
                 m_pLoadedTrack->getSampleRate(),
-                cuePosition,
+                // Cue positions might be fractional, i.e. not on frame boundaries!
+                cuePosition.toNearestFrameBoundary(),
                 bpm);
     }
 

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -20,7 +20,7 @@ class BeatGrid final : public Beats {
     static BeatsPointer makeBeatGrid(
             audio::SampleRate sampleRate,
             mixxx::Bpm bpm,
-            mixxx::audio::FramePos firstBeatPos,
+            mixxx::audio::FramePos firstBeatPositionOnFrameBoundary,
             const QString& subVersion = QString());
 
     static BeatsPointer fromByteArray(


### PR DESCRIPTION
TODO:
- [x] Fix update of BPM spin box (by reverting the last commit that reordered updates)

Occurred in DlgTrackInfo::slotSpinBpmValueChanged():

```
critical [Main] DEBUG ASSERT: "bpm.isValid() && firstBeatPosition.isValid() && !firstBeatPosition.isFractional()" in function static mixxx::BeatsPointer mixxx::BeatGrid::makeBeatGrid(mixxx::audio::SampleRate, mixxx::Bpm, mixxx::audio::FramePos, const QString&) at ../src/track/beatgrid.cpp:80

#6  mixxx::BeatGrid::makeBeatGrid(mixxx::audio::SampleRate, mixxx::Bpm, mixxx::audio::FramePos, QString const&) (sampleRate=..., bpm=..., firstBeatPosition=..., subVersion=...)
    at ../src/track/beatgrid.cpp:80
#7  0x0000000000b4de16 in mixxx::Beats::fromConstTempo(mixxx::audio::SampleRate, mixxx::audio::FramePos, mixxx::Bpm, QString const&) (sampleRate=..., position=..., 
    position@entry=..., bpm=..., bpm@entry=..., subVersion=...) at ../src/track/beats.cpp:41
#8  0x0000000000e0ad70 in DlgTrackInfo::slotBpmConstChanged(int) (this=0x30e9b060, state=<optimized out>) at ../src/library/dlgtrackinfo.cpp:679
#9  0x00007ffff378b3a9 in void doActivate<false>(QObject*, int, void**) () at /lib64/libQt5Core.so.5
#10 0x00007ffff67ef292 in QCheckBox::stateChanged(int) () at /lib64/libQt5Widgets.so.5
#11 0x00007ffff67e0275 in QAbstractButton::setChecked(bool) () at /lib64/libQt5Widgets.so.5
#12 0x0000000000e0a950 in DlgTrackInfo::reloadTrackBeats(Track const&) (this=0x30e9b060, track=...) at ../src/library/dlgtrackinfo.cpp:475
#13 0x0000000000e0ce86 in DlgTrackInfo::updateFromTrack(Track const&) (this=0x30e9b060, track=...) at ../src/library/dlgtrackinfo.cpp:396
#14 0x0000000000e0d7f7 in DlgTrackInfo::loadTrackInternal(std::shared_ptr<Track> const&) (this=0x30e9b060, pTrack=std::shared_ptr<Track> (use count 4, weak count 1) = {...})
    at /usr/include/c++/11/bits/shared_ptr_base.h:1295
#15 0x0000000000e0d9af in DlgTrackInfo::loadTrack(QModelIndex const&) (this=0x30e9b060, index=...) at ../src/library/dlgtrackinfo.cpp:523
#16 0x0000000000c03c26 in WTrackMenu::slotShowDlgTrackInfo() (this=0x2dfeab70) at /usr/include/qt5/QtCore/qlist.h:151

critical [Main] DEBUG ASSERT: "bpm.isValid() && firstBeatPosition.isValid() && !firstBeatPosition.isFractional()" in function static mixxx::BeatsPointer mixxx::BeatGrid::makeBeatGrid(mixxx::audio::SampleRate, mixxx::Bpm, mixxx::audio::FramePos, const QString&) at ../src/track/beatgrid.cpp:80

Thread 1 "mixxx" received signal SIGINT, Interrupt.
0x00007ffff30a48b2 in raise () from /lib64/libpthread.so.0
(gdb) c
Continuing.

Thread 1 "mixxx" received signal SIGSEGV, Segmentation fault.
DlgTrackInfo::slotSpinBpmValueChanged (this=0x30e9b060, value=124.68554415) at /usr/include/c++/11/bits/shared_ptr_base.h:1295
```

~~I am not able to reproduce the error and cannot tell why it occurred.~~ Select a track with a fractional cue point (i.e. not on frame boundary) and open the properties dialog.