### PR TITLE
Update controller mapping for Behringer DDM4000 mixer

### DIFF
--- a/res/controllers/Behringer-DDM4000-scripts.js
+++ b/res/controllers/Behringer-DDM4000-scripts.js
@@ -259,6 +259,8 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                         midi: { // eslint-disable-next-line key-spacing
                             parameterKnobs:   {1: [cc,   0x06], 2: [cc,   0x05], 3: [cc,   0x04]},
                             parameterButtons: {1: [note, 0x02], 2: [note, 0x01], 3: [note, 0x00]},
+                            enabled: null,
+                            super1: null,
                         },
                         output: {
                             parameterButtons: {1: [cc,   0x3D], 2: [cc,   0x3B], 3: [cc,   0x39]}, // Amber
@@ -289,6 +291,8 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                         midi: { // eslint-disable-next-line key-spacing
                             parameterKnobs:   {1: [cc,   0x0A], 2: [cc,   0x09], 3: [cc,   0x08]},
                             parameterButtons: {1: [note, 0x06], 2: [note, 0x05], 3: [note, 0x04]},
+                            enabled: null,
+                            super1: null,
                         },
                         output: {
                             parameterButtons: {1: [cc,   0x47], 2: [cc,   0x45], 3: [cc,   0x43]}, // Amber
@@ -319,6 +323,8 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                         midi: { // eslint-disable-next-line key-spacing
                             parameterKnobs:   {1: [cc,   0x0E], 2: [cc,   0x0D], 3: [cc,   0x0C]},
                             parameterButtons: {1: [note, 0x0A], 2: [note, 0x09], 3: [note, 0x08]},
+                            enabled: null,
+                            super1: null,
                         },
                         output: {
                             parameterButtons: {1: [cc,   0x51], 2: [cc,   0x4F], 3: [cc,   0x4D]}, // Amber
@@ -349,6 +355,8 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                         midi: { // eslint-disable-next-line key-spacing
                             parameterKnobs:   {1: [cc,   0x12], 2: [cc,   0x11], 3: [cc,   0x10]},
                             parameterButtons: {1: [note, 0x0E], 2: [note, 0x0D], 3: [note, 0x0C]},
+                            enabled: null,
+                            super1: null,
                         },
                         output: {
                             parameterButtons: {1: [cc,   0x5B], 2: [cc,   0x59], 3: [cc,   0x57]}, // Amber
@@ -468,7 +476,7 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                         {options: {midi: [note, 0x79], key: null, sendShifted: true}}, // Sampler: Select
                         { // Sampler: CF Assign
                             type: e.EnumToggleButton,
-                            options: {midi: [note, 0x7A],  inKey: "orientation", values: [center, left, right]},
+                            options: {midi: [note, 0x7A], inKey: "orientation", values: [center, left, right]},
                         },
                         {type: CrossfaderAssignLED, options: {midi: [cc, 0x7A], onValue: left}}, // Sampler: CF Assign A
                         {type: CrossfaderAssignLED, options: {midi: [cc, 0x7B], onValue: right}}, // Sampler: CF Assign B

--- a/res/controllers/Behringer-DDM4000-scripts.js
+++ b/res/controllers/Behringer-DDM4000-scripts.js
@@ -10,6 +10,7 @@ var DDM4000 = new behringer.extension.GenericMidiController({
 
         var DEFAULT_LONGPRESS_DURATION = 500;
         var DEFAULT_BLINK_DURATION = 425;
+        var THROTTLE_DELAY = 40;
 
         /* Shortcut variables */
         var c    = components;
@@ -201,6 +202,7 @@ var DDM4000 = new behringer.extension.GenericMidiController({
             var ModeButton = function(options) {
                 options = options || {};
                 options.key = options.key || "mode";
+                options.longPressTimeout = options.longPressTimeout || DEFAULT_LONGPRESS_DURATION;
                 e.LongPressButton.call(this, options);
             };
             ModeButton.prototype = e.deriveFrom(e.LongPressButton, {
@@ -219,13 +221,12 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                     midi.sendShortMsg(cc, this.midi[1] + 1, this.outValueScale(value));
                 },
             });
-            this.modeButton = new ModeButton(
-                {midi: bankOptions.mode, group: bankOptions.group, longPressTimeout: DEFAULT_LONGPRESS_DURATION});
+            this.modeButton = new ModeButton({midi: bankOptions.mode, group: bankOptions.group});
         };
         SamplerBank.prototype = e.deriveFrom(c.ComponentContainer);
 
         return {
-            throttleDelay: 40,
+            throttleDelay: THROTTLE_DELAY,
             init: function() {
 
                 /*
@@ -391,6 +392,12 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                 { // Crossfader
                     defaultDefinition: {type: c.Button, options: {group: "[Master]"}},
                     components: [
+                        { // Crossfader: On
+                            type: CrossfaderUnit, options: {
+                                crossfader: {midi: [cc, 0x15]},
+                                button: {group: "[Skin]", midi: [note, 0x1F], sendShifted: true},
+                            },
+                        },
                         {options: {midi: [note, 0x17],    key: null, sendShifted: true}}, // Crossfader: A Full Freq
                         {options: {midi: [note, 0x18],    key: null, sendShifted: true}}, // Crossfader: A High
                         {options: {midi: [note, 0x19],    key: null, sendShifted: true}}, // Crossfader: A Mid
@@ -399,13 +406,6 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                         {options: {midi: [note, 0x1C],    key: null, sendShifted: true}}, // Crossfader: B High
                         {options: {midi: [note, 0x1D],    key: null, sendShifted: true}}, // Crossfader: B Mid
                         {options: {midi: [note, 0x1E],    key: null, sendShifted: true}}, // Crossfader: B Low
-                        { // Crossfader: On
-                            type: CrossfaderUnit,
-                            options: {
-                                button: {group: "[Skin]", midi: [note, 0x1F], sendShifted: true},
-                                crossfader: {midi: [cc, 0x15]}
-                            },
-                        },
                         {options: {midi: [note, 0x2A],    key: null, sendShifted: true}}, // Crossfader: Bounce to MIDI Clock
                         {options: {midi: [note, 0x2B],  inKey: null}}, // Crossfader: Beat (Left)
                         {options: {midi: [note, 0x2C],  inKey: null}}, // Crossfader: Beat (Right)

--- a/res/controllers/Behringer-DDM4000-scripts.js
+++ b/res/controllers/Behringer-DDM4000-scripts.js
@@ -225,6 +225,7 @@ var DDM4000 = new behringer.extension.GenericMidiController({
         SamplerBank.prototype = e.deriveFrom(c.ComponentContainer);
 
         return {
+            throttleDelay: 40,
             init: function() {
 
                 /*

--- a/res/controllers/Behringer-DDM4000-scripts.js
+++ b/res/controllers/Behringer-DDM4000-scripts.js
@@ -251,9 +251,9 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                                 midi: [note, 0x3F], key: "pfl", type: toggle, sendShifted: true
                             }
                         },
-                        {type: c.Button, options: {midi: [note, 0x03],  inKey: ""}}, // Mode
-                        {type: c.Button, options: {midi: [cc,   0x38], outKey: ""}}, // Mode: Multi
-                        {type: c.Button, options: {midi: [cc,   0x37], outKey: ""}}, // Mode: Single
+                        {type: c.Button, options: {midi: [note, 0x03],  inKey: null}}, // Mode
+                        {type: c.Button, options: {midi: [cc,   0x38], outKey: null}}, // Mode: Multi
+                        {type: c.Button, options: {midi: [cc,   0x37], outKey: null}}, // Mode: Single
                     ],
                     equalizerUnit: { //        P3 / Low,        P2 / Mid,        P1 / High
                         midi: { // eslint-disable-next-line key-spacing
@@ -281,9 +281,9 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                                 midi: [note, 0x49], key: "pfl", type: toggle, sendShifted: true
                             }
                         },
-                        {type: c.Button, options: {midi: [note, 0x07],  inKey: ""}}, // Mode
-                        {type: c.Button, options: {midi: [cc,   0x42], outKey: ""}}, // Mode: Multi
-                        {type: c.Button, options: {midi: [cc,   0x41], outKey: ""}}, // Mode: Single
+                        {type: c.Button, options: {midi: [note, 0x07],  inKey: null}}, // Mode
+                        {type: c.Button, options: {midi: [cc,   0x42], outKey: null}}, // Mode: Multi
+                        {type: c.Button, options: {midi: [cc,   0x41], outKey: null}}, // Mode: Single
                     ],
                     equalizerUnit: { //        P3 / Low,        P2 / Mid,        P1 / High
                         midi: { // eslint-disable-next-line key-spacing
@@ -311,9 +311,9 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                                 midi: [note, 0x53], key: "pfl", type: toggle, sendShifted: true
                             }
                         },
-                        {type: c.Button, options: {midi: [note, 0x0B],  inKey: ""}}, // Mode
-                        {type: c.Button, options: {midi: [cc,   0x4C], outKey: ""}}, // Mode: Multi
-                        {type: c.Button, options: {midi: [cc,   0x4B], outKey: ""}}, // Mode: Single
+                        {type: c.Button, options: {midi: [note, 0x0B],  inKey: null}}, // Mode
+                        {type: c.Button, options: {midi: [cc,   0x4C], outKey: null}}, // Mode: Multi
+                        {type: c.Button, options: {midi: [cc,   0x4B], outKey: null}}, // Mode: Single
                     ],
                     equalizerUnit: { //        P3 / Low,        P2 / Mid,        P1 / High
                         midi: { // eslint-disable-next-line key-spacing
@@ -341,9 +341,9 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                                 midi: [note, 0x5D], key: "pfl", type: toggle, sendShifted: true
                             }
                         },
-                        {type: c.Button, options: {midi: [note, 0x0F],  inKey: ""}}, // Mode
-                        {type: c.Button, options: {midi: [cc,   0x56], outKey: ""}}, // Mode: Multi
-                        {type: c.Button, options: {midi: [cc,   0x55], outKey: ""}}, // Mode: Single
+                        {type: c.Button, options: {midi: [note, 0x0F],  inKey: null}}, // Mode
+                        {type: c.Button, options: {midi: [cc,   0x56], outKey: null}}, // Mode: Multi
+                        {type: c.Button, options: {midi: [cc,   0x55], outKey: null}}, // Mode: Single
                     ],
                     equalizerUnit: { //        P3 / Low,        P2 / Mid,        P1 / High
                         midi: { // eslint-disable-next-line key-spacing
@@ -361,14 +361,14 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                 { // Microphone
                     defaultDefinition: {type: c.Button, options: {group: "[Microphone]"}},
                     components: [
-                        {options: {midi: [cc,   0x02], inKey: ""}, type: c.Pot}, // Mic: EQ Low
-                        {options: {midi: [cc,   0x01], inKey: ""}, type: c.Pot}, // Mic: EQ Mid
-                        {options: {midi: [cc,   0x00], inKey: ""}, type: c.Pot}, // Mic: EQ High
-                        {options: {midi: [note, 0x31], key: "", sendShifted: true}}, // Mic: Setup
-                        {options: {midi: [note, 0x32], key: "", sendShifted: true}}, // Mic: XMC On
-                        {options: {midi: [note, 0x33], key: "", sendShifted: true}}, // Mic: FX On
+                        {options: {midi: [cc,   0x02], inKey: null}, type: c.Pot}, // Mic: EQ Low
+                        {options: {midi: [cc,   0x01], inKey: null}, type: c.Pot}, // Mic: EQ Mid
+                        {options: {midi: [cc,   0x00], inKey: null}, type: c.Pot}, // Mic: EQ High
+                        {options: {midi: [note, 0x31], key: null, sendShifted: true}}, // Mic: Setup
+                        {options: {midi: [note, 0x32], key: null, sendShifted: true}}, // Mic: XMC On
+                        {options: {midi: [note, 0x33], key: null, sendShifted: true}}, // Mic: FX On
                         {options: {midi: [note, 0x34], key: "talkover", sendShifted: true}}, // Mic: Talk On
-                        {options: {midi: [note, 0x35], key: "", sendShifted: true}}, // Mic: On/Off
+                        {options: {midi: [note, 0x35], key: null, sendShifted: true}}, // Mic: On/Off
                     ]
                 },
                 { // Crossfader
@@ -382,14 +382,14 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                 { // Crossfader
                     defaultDefinition: {type: c.Button, options: {group: "[Master]"}},
                     components: [
-                        {options: {midi: [note, 0x17],    key: "", sendShifted: true}}, // Crossfader: A Full Freq
-                        {options: {midi: [note, 0x18],    key: "", sendShifted: true}}, // Crossfader: A High
-                        {options: {midi: [note, 0x19],    key: "", sendShifted: true}}, // Crossfader: A Mid
-                        {options: {midi: [note, 0x1A],    key: "", sendShifted: true}}, // Crossfader: A Low
-                        {options: {midi: [note, 0x1B],    key: "", sendShifted: true}}, // Crossfader: B Full Freq
-                        {options: {midi: [note, 0x1C],    key: "", sendShifted: true}}, // Crossfader: B High
-                        {options: {midi: [note, 0x1D],    key: "", sendShifted: true}}, // Crossfader: B Mid
-                        {options: {midi: [note, 0x1E],    key: "", sendShifted: true}}, // Crossfader: B Low
+                        {options: {midi: [note, 0x17],    key: null, sendShifted: true}}, // Crossfader: A Full Freq
+                        {options: {midi: [note, 0x18],    key: null, sendShifted: true}}, // Crossfader: A High
+                        {options: {midi: [note, 0x19],    key: null, sendShifted: true}}, // Crossfader: A Mid
+                        {options: {midi: [note, 0x1A],    key: null, sendShifted: true}}, // Crossfader: A Low
+                        {options: {midi: [note, 0x1B],    key: null, sendShifted: true}}, // Crossfader: B Full Freq
+                        {options: {midi: [note, 0x1C],    key: null, sendShifted: true}}, // Crossfader: B High
+                        {options: {midi: [note, 0x1D],    key: null, sendShifted: true}}, // Crossfader: B Mid
+                        {options: {midi: [note, 0x1E],    key: null, sendShifted: true}}, // Crossfader: B Low
                         { // Crossfader: On
                             type: CrossfaderUnit,
                             options: {
@@ -397,29 +397,29 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                                 crossfader: {midi: [cc, 0x15]}
                             },
                         },
-                        {options: {midi: [note, 0x2A],    key: "", sendShifted: true}}, // Crossfader: Bounce to MIDI Clock
-                        {options: {midi: [note, 0x2B],  inKey: ""}}, // Crossfader: Beat (Left)
-                        {options: {midi: [note, 0x2C],  inKey: ""}}, // Crossfader: Beat (Right)
-                        {options: {midi: [cc,   0x2B], outKey: ""}}, // Crossfader: Beat 1
-                        {options: {midi: [cc,   0x2C], outKey: ""}}, // Crossfader: Beat 2
-                        {options: {midi: [cc,   0x2D], outKey: ""}}, // Crossfader: Beat 4
-                        {options: {midi: [cc,   0x2E], outKey: ""}}, // Crossfader: Beat 8
-                        {options: {midi: [cc,   0x2F], outKey: ""}}, // Crossfader: Beat 16
+                        {options: {midi: [note, 0x2A],    key: null, sendShifted: true}}, // Crossfader: Bounce to MIDI Clock
+                        {options: {midi: [note, 0x2B],  inKey: null}}, // Crossfader: Beat (Left)
+                        {options: {midi: [note, 0x2C],  inKey: null}}, // Crossfader: Beat (Right)
+                        {options: {midi: [cc,   0x2B], outKey: null}}, // Crossfader: Beat 1
+                        {options: {midi: [cc,   0x2C], outKey: null}}, // Crossfader: Beat 2
+                        {options: {midi: [cc,   0x2D], outKey: null}}, // Crossfader: Beat 4
+                        {options: {midi: [cc,   0x2E], outKey: null}}, // Crossfader: Beat 8
+                        {options: {midi: [cc,   0x2F], outKey: null}}, // Crossfader: Beat 16
                     ]
                 },
                 { // Sampler
                     defaultDefinition: {type: c.Button, options: {group: "[Sampler1]"}},
                     components: [
                         {options: {midi: [cc,   0x03],  inKey: "volume"}, type: c.Pot}, // Sampler: Volume/Mix
-                        {options: {midi: [note, 0x5F],    key: "", sendShifted: true}}, // Sampler: Insert
-                        {options: {midi: [note, 0x60],  inKey: ""}}, // Sampler: REC Source (Right)
-                        {options: {midi: [note, 0x61],  inKey: ""}}, // Sampler: REC Source (Left)
-                        {options: {midi: [cc,   0x60], outKey: ""}}, // Sampler: REC Source 1
-                        {options: {midi: [cc,   0x61], outKey: ""}}, // Sampler: REC Source 2
-                        {options: {midi: [cc,   0x62], outKey: ""}}, // Sampler: REC Source 3
-                        {options: {midi: [cc,   0x63], outKey: ""}}, // Sampler: REC Source 4
-                        {options: {midi: [cc,   0x64], outKey: ""}}, // Sampler: REC Source Microphone
-                        {options: {midi: [cc,   0x65], outKey: ""}}, // Sampler: REC Source Master
+                        {options: {midi: [note, 0x5F],    key: null, sendShifted: true}}, // Sampler: Insert
+                        {options: {midi: [note, 0x60],  inKey: null}}, // Sampler: REC Source (Right)
+                        {options: {midi: [note, 0x61],  inKey: null}}, // Sampler: REC Source (Left)
+                        {options: {midi: [cc,   0x60], outKey: null}}, // Sampler: REC Source 1
+                        {options: {midi: [cc,   0x61], outKey: null}}, // Sampler: REC Source 2
+                        {options: {midi: [cc,   0x62], outKey: null}}, // Sampler: REC Source 3
+                        {options: {midi: [cc,   0x63], outKey: null}}, // Sampler: REC Source 4
+                        {options: {midi: [cc,   0x64], outKey: null}}, // Sampler: REC Source Microphone
+                        {options: {midi: [cc,   0x65], outKey: null}}, // Sampler: REC Source Master
                         {options: {midi: [note, 0x66],    key: "pfl", sendShifted: true}}, // Sampler: PFL
                         {options: {midi: [note, 0x67],  inKey: "beatloop_size", values: [1, 2, 4, 8, 16, 256]}, type: e.EnumToggleButton}, // Sampler: Sample Length (Right)
                         {options: {midi: [note, 0x68],  inKey: "beatloop_size", values: [256, 16, 8, 4, 2, 1]}, type: e.EnumToggleButton}, // Sampler: Sample Length (Left)
@@ -429,8 +429,8 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                         {options: {midi: [cc,   0x6A], outKey: "beatloop_size", onValue: 8},   type: e.CustomButton}, // Sampler: Sample Length 8
                         {options: {midi: [cc,   0x6B], outKey: "beatloop_size", onValue: 16},  type: e.CustomButton}, // Sampler: Sample Length 16
                         {options: {midi: [cc,   0x6C], outKey: "beatloop_size", onValue: 256}, type: e.CustomButton}, // Sampler: Sample Length ∞
-                        {options: {midi: [note, 0x6D],    key: "", sendShifted: true}}, // Sampler: Record / In
-                        {options: {midi: [note, 0x6C],  inKey: ""}}, // Sampler: Bank Assign
+                        {options: {midi: [note, 0x6D],    key: null, sendShifted: true}}, // Sampler: Record / In
+                        {options: {midi: [note, 0x6C],  inKey: null}}, // Sampler: Bank Assign
                         { // Sampler Bank 1
                             type: SamplerBank,
                             options: {
@@ -465,14 +465,14 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                                 blinkDuration: DEFAULT_BLINK_DURATION,
                             }
                         },
-                        {options: {midi: [note, 0x79],    key: "", sendShifted: true}}, // Sampler: Select
+                        {options: {midi: [note, 0x79], key: null, sendShifted: true}}, // Sampler: Select
                         { // Sampler: CF Assign
                             type: e.EnumToggleButton,
                             options: {midi: [note, 0x7A],  inKey: "orientation", values: [center, left, right]},
                         },
                         {type: CrossfaderAssignLED, options: {midi: [cc, 0x7A], onValue: left}}, // Sampler: CF Assign A
                         {type: CrossfaderAssignLED, options: {midi: [cc, 0x7B], onValue: right}}, // Sampler: CF Assign B
-                        {options: {midi: [note, 0x7C],    key: "", sendShifted: true}}, // Sampler: CF Start
+                        {options: {midi: [note, 0x7C], key: null, sendShifted: true}}, // Sampler: CF Start
                     ]
                 }
             ],

--- a/res/controllers/Behringer-Extension-scripts.js
+++ b/res/controllers/Behringer-Extension-scripts.js
@@ -558,7 +558,7 @@
      * `sizeControl` being preferred.
      *
      * @constructor
-     * @extends {components.Encoder}
+     * @extends {DirectionEncoder}
      * @param {object} options Options object
      * @param {number} options.size (optional) Size given in number of beats; default: 0.5
      * @param {string} options.sizeControl (optional) Name of a control that contains `size`

--- a/res/controllers/Behringer-Extension-scripts.js
+++ b/res/controllers/Behringer-Extension-scripts.js
@@ -55,14 +55,18 @@
      * @private
      */
     var stringifyComponent = function(component) {
-        if (component === undefined) {
+        if (!component) {
             return;
         }
-        var id = findComponentId(component.midi);
-        if (id !== undefined) {
-            var key = component.inKey || component.outKey;
-            return "(" + id + ": " + component.group + "," + key + ")";
+        var key = component.inKey || component.outKey;
+        var value = component.group + "," + key;
+        if (component.midi) {
+            var id = findComponentId(component.midi);
+            if (id !== undefined) {
+                value = id + ": " + value;
+            }
         }
+        return "(" + value + ")";
     };
 
     /**
@@ -759,6 +763,11 @@
                 log.error("Missing component");
                 return;
             }
+            if (!component.midi) {
+                log.debug(containerName + ": ignore "
+                    + stringifyComponent(component) + " without MIDI address");
+                return;
+            }
             var id = findComponentId(component.midi);
             if (!Object.prototype.hasOwnProperty.call(this.containers, containerName)) {
                 this.createContainer(containerName);
@@ -1254,7 +1263,7 @@
          * @private
          */
         processMidiAddresses: function(definition, implementation, action) {
-            if (Array.isArray(definition)) {
+            if (Array.isArray(definition) || !definition) {
                 action.call(this, definition, implementation);
             } else if (typeof definition === "object") {
                 Object.keys(definition).forEach(function(name) {

--- a/res/controllers/Behringer-Extension-scripts.js
+++ b/res/controllers/Behringer-Extension-scripts.js
@@ -1118,9 +1118,9 @@
             }
 
             /*
-            * Contains all decks and effect units so that a (un)shift operation
-            * is delegated to the decks, effect units and their children.
-            */
+             * Contains all decks and effect units so that a (un)shift operation
+             * is delegated to the decks, effect units and their children.
+             */
             this.componentContainers = [];
 
             this.layerManager = this.createLayerManager(

--- a/res/controllers/Behringer-Extension-scripts.js
+++ b/res/controllers/Behringer-Extension-scripts.js
@@ -116,6 +116,27 @@
     };
 
     /**
+     * A component that uses the parameter instead of the value as output.
+     *
+     * @constructor
+     * @extends {components.Component}
+     * @param {object} options Options object
+     * @public
+     */
+    var ParameterComponent = function(options) {
+        components.Component.call(this, options);
+    };
+    ParameterComponent.prototype = deriveFrom(components.Component, {
+        outValueScale: function(_value) {
+            /*
+             * We ignore the argument and use the parameter (0..1) instead because value scale is
+             * arbitrary and thus cannot be mapped to MIDI values (0..127) properly.
+             */
+            return convertToMidiValue.call(this, this.outGetParameter());
+        },
+    });
+
+    /**
      * A button to toggle un-/shift on a target component.
      *
      * @constructor
@@ -647,16 +668,9 @@
         }
         this.source = options.source;
         this.sync();
-        components.Component.call(this, options);
+        ParameterComponent.call(this, options);
     };
-    Publisher.prototype = deriveFrom(components.Component, {
-        outValueScale: function(_value) {
-            /*
-             * We ignore the argument and use the parameter (0..1) instead because value scale is
-             * arbitrary and thus cannot be mapped to MIDI values (0..127) properly.
-             */
-            return convertToMidiValue.call(this, this.outGetParameter());
-        },
+    Publisher.prototype = deriveFrom(ParameterComponent, {
         sync: function() {
             this.midi = this.source.midi;
             this.group = this.source.group;
@@ -1517,6 +1531,7 @@
 
     var exports = {};
     exports.deriveFrom = deriveFrom;
+    exports.ParameterComponent = ParameterComponent;
     exports.ShiftButton = ShiftButton;
     exports.Trigger = Trigger;
     exports.CustomButton = CustomButton;

--- a/res/controllers/Behringer-Extension-scripts.js
+++ b/res/controllers/Behringer-Extension-scripts.js
@@ -222,7 +222,7 @@
      * Use `start(action)` to start and `reset()` to reset.
      *
      * @constructor
-     * @param {number} options.timeout Duration between start and action
+     * @param {number} options.timeout Duration between start and action (in ms)
      * @param {boolean} options.oneShot If `true`, the action is run once;
      *                          otherwise, it is run periodically until the timer is reset.
      * @param {function} options.action Function that is executed whenever the timer expires

--- a/res/controllers/Behringer-Extension-scripts.js
+++ b/res/controllers/Behringer-Extension-scripts.js
@@ -1136,7 +1136,7 @@
      *     |        |            component.
      *     |        +- output: Additional output definitions (optional).
      *     |                   The structure of this object is the same as the structure of
-     *     |                   `components`. Every value change of a component contained in `output`
+     *     |                   `midi`. Every value change of a component contained in `output`
      *     |                   causes a MIDI message to be sent to the hardware controller, using
      *     |                   the configured address instead of the component's `midi` property.
      *     |                   This option is independent of the `feedback` option.

--- a/res/controllers/Behringer-Extension-scripts.js
+++ b/res/controllers/Behringer-Extension-scripts.js
@@ -1325,14 +1325,9 @@
         createDeck: function(deckDefinition, componentStorage) {
             var deck = new components.Deck(deckDefinition.deckNumbers);
             deckDefinition.components.forEach(function(componentDefinition, index) {
-                if (componentDefinition && componentDefinition.type) {
-                    var options = _.merge({group: deck.currentDeck}, componentDefinition.options);
-                    deck[index] = new componentDefinition.type(options);
-                } else {
-                    log.error("Skipping component without type on Deck of " + deck.currentDeck
-                        + ": " + stringifyObject(componentDefinition));
-                    deck[index] = null;
-                }
+                var options = _.merge({group: deck.currentDeck}, componentDefinition.options);
+                var definition = _.merge(componentDefinition, {options: options});
+                deck[index] = this.createComponent(definition);
             }, this);
             if (deckDefinition.equalizerUnit) {
                 deck.equalizerUnit = this.setupMidi(


### PR DESCRIPTION
This PR contains
* A fix for a bug that prevents the mixer to be completely initialized on startup
* Proper handling of mapping definitions with missing (falsy) MIDI address
* Consistent use of `null` instead of empty strings for intentionally missing values
* A `ParameterComponent` that is able to send correct output values for effect parameters
* Soft-takeover support for the `EnumEncoder` component
* Removal of redundant code
* Documentation fixes

The bug was really annoying and hard to detect: on startup, only a part of the mixer LEDs had the correct state. Some were on, but others were off unexpectedly. After a few hours of debugging, it turned out that the problem is the processing speed of the hardware mixer. When too many MIDI messages arrive in a short time, only a part of them is processed. My solution is a configurable throttling logic that delays component initialization. Users may disable the throttling or change the delay. 

The `ParameterComponent` is required to send proper output values for effect parameters. Some of them have unusual values ranges, e.g. flanger speed `[32..0,5]` in a non-linear manner. The `output()` function of the `Encoder` component is not prepared for this, it just multiplies this value with 127 and sends the result to the controller. The `ParameterComponent` uses the parameter (range: `[0..1]`) instead of the value, so the MIDI value is correct.
