### PR TITLE
Auto DJ skip fix lp1941989

### DIFF
--- a/src/engine/cachingreader/cachingreader.cpp
+++ b/src/engine/cachingreader/cachingreader.cpp
@@ -222,6 +222,7 @@ void CachingReader::newTrack(TrackPointer pTrack) {
     m_worker.newTrack(std::move(pTrack));
 }
 
+// Called from the engine thread
 void CachingReader::process() {
     ReaderStatusUpdate update;
     while (m_readerStatusUpdateFIFO.read(&update, 1) == 1) {

--- a/src/engine/cachingreader/cachingreaderworker.h
+++ b/src/engine/cachingreader/cachingreaderworker.h
@@ -131,6 +131,10 @@ class CachingReaderWorker : public EngineWorker {
     QAtomicInt m_newTrackAvailable;
     TrackPointer m_pNewTrack;
 
+    /// call to be prepare for new tracks 
+    /// Make sure engine has been stopped before
+    void cleanUpOldTrack();
+
     /// Internal method to unload a track.
     /// does not emit signals
     void ejectTrack();

--- a/src/engine/cachingreader/cachingreaderworker.h
+++ b/src/engine/cachingreader/cachingreaderworker.h
@@ -131,7 +131,11 @@ class CachingReaderWorker : public EngineWorker {
     QAtomicInt m_newTrackAvailable;
     TrackPointer m_pNewTrack;
 
-    // Internal method to load a track. Emits trackLoaded when finished.
+    /// Internal method to unload a track.
+    /// does not emit signals
+    void ejectTrack();
+
+    /// Internal method to load a track. Emits trackLoaded when finished.
     void loadTrack(const TrackPointer& pTrack);
 
     ReaderStatusUpdate processReadRequest(

--- a/src/engine/cachingreader/cachingreaderworker.h
+++ b/src/engine/cachingreader/cachingreaderworker.h
@@ -128,7 +128,7 @@ class CachingReaderWorker : public EngineWorker {
     // Queue of Tracks to load, and the corresponding lock. Must acquire the
     // lock to touch.
     QMutex m_newTrackMutex;
-    bool m_newTrackAvailable;
+    QAtomicInt m_newTrackAvailable;
     TrackPointer m_pNewTrack;
 
     // Internal method to load a track. Emits trackLoaded when finished.

--- a/src/engine/cachingreader/cachingreaderworker.h
+++ b/src/engine/cachingreader/cachingreaderworker.h
@@ -131,13 +131,15 @@ class CachingReaderWorker : public EngineWorker {
     QAtomicInt m_newTrackAvailable;
     TrackPointer m_pNewTrack;
 
-    /// call to be prepare for new tracks 
+    void discardAllPendingRequests();
+
+    /// call to be prepare for new tracks
     /// Make sure engine has been stopped before
-    void cleanUpOldTrack();
+    void closeAudioSource();
 
     /// Internal method to unload a track.
     /// does not emit signals
-    void ejectTrack();
+    void unloadTrack();
 
     /// Internal method to load a track. Emits trackLoaded when finished.
     void loadTrack(const TrackPointer& pTrack);

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -90,7 +90,6 @@ EngineBuffer::EngineBuffer(const QString& group,
           m_iSeekPhaseQueued(0),
           m_iEnableSyncQueued(SYNC_REQUEST_NONE),
           m_iSyncModeQueued(SYNC_INVALID),
-          m_iTrackLoading(0),
           m_bPlayAfterLoading(false),
           m_iSampleRate(0),
           m_pCrossfadeBuffer(SampleUtil::alloc(MAX_BUFFER_LEN)),
@@ -1050,7 +1049,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
     m_pScaleST->setSampleRate(sampleRate);
     m_pScaleRB->setSampleRate(sampleRate);
 
-    bool bTrackLoading = atomicLoadRelaxed(m_iTrackLoading) != 0;
+    bool bTrackLoading = atomicLoadAcquire(m_iTrackLoading) != 0;
     if (!bTrackLoading && m_pause.tryLock()) {
         processTrackLocked(pOutput, iBufferSize, m_iSampleRate);
         // release the pauselock

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1049,7 +1049,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
     m_pScaleST->setSampleRate(sampleRate);
     m_pScaleRB->setSampleRate(sampleRate);
 
-    bool bTrackLoading = atomicLoadAcquire(m_iTrackLoading) != 0;
+    bool bTrackLoading = m_iTrackLoading.loadAcquire() != 0;
     if (!bTrackLoading && m_pause.tryLock()) {
         processTrackLocked(pOutput, iBufferSize, m_iSampleRate);
         // release the pauselock

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -724,6 +724,7 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
             // loaded into the otherDeck
             thisDeck->fadeBeginPos = 1.0;
             thisDeck->fadeEndPos = 1.0;
+            otherDeck->isFromDeck = false;
             // Load the next track to otherDeck.
             loadNextTrackFromQueue(*otherDeck);
             emitAutoDJStateChanged(m_eState);


### PR DESCRIPTION
This should fix https://bugs.launchpad.net/mixxx/+bug/1941989 where tracks are skipped in AutoDJ. 

This is hard to test, because skipping happens only under rare conditions. I was able to reproduce it unreliable with the "Full Track Mode" and a slow spinning USB HDD. With this PR I cannot reproduce it anymore. 

The fix is implemented in two places: 
* Fix the symptom: Remove isFromDeck flag before loading a new track, to avoid doing transition twice.
* The guessed Root case: The engine was able to request new chunks of an already replaced track.  

