### PR TITLE
Promote many simple const variables to constexpr

### DIFF
--- a/src/analyzer/analyzerebur128.cpp
+++ b/src/analyzer/analyzerebur128.cpp
@@ -8,7 +8,7 @@
 #include "util/timer.h"
 
 namespace {
-const double kReplayGain2ReferenceLUFS = -18;
+constexpr double kReplayGain2ReferenceLUFS = -18;
 } // anonymous namespace
 
 AnalyzerEbur128::AnalyzerEbur128(UserSettingsPointer pConfig)

--- a/src/analyzer/analyzerwaveform.cpp
+++ b/src/analyzer/analyzerwaveform.cpp
@@ -54,9 +54,9 @@ bool AnalyzerWaveform::initialize(TrackPointer tio,
     createFilters(sampleRate);
 
     //TODO (vrince) Do we want to expose this as settings or whatever ?
-    const int mainWaveformSampleRate = 441;
+    constexpr int mainWaveformSampleRate = 441;
     // two visual sample per pixel in full width overview in full hd
-    const int summaryWaveformSamples = 2 * 1920;
+    constexpr int summaryWaveformSamples = 2 * 1920;
 
     m_waveform = WaveformPointer(new Waveform(
             sampleRate, totalSamples, mainWaveformSampleRate, -1));

--- a/src/controllers/controllerinputmappingtablemodel.cpp
+++ b/src/controllers/controllerinputmappingtablemodel.cpp
@@ -160,7 +160,7 @@ int ControllerInputMappingTableModel::columnCount(const QModelIndex& parent) con
         return 0;
     }
     // Control and description.
-    const int kBaseColumns = 2;
+    constexpr int kBaseColumns = 2;
     if (m_pMidiMapping != nullptr) {
         // Channel, Opcode, Control, Options
         return kBaseColumns + 4;

--- a/src/controllers/controlleroutputmappingtablemodel.cpp
+++ b/src/controllers/controlleroutputmappingtablemodel.cpp
@@ -127,7 +127,7 @@ int ControllerOutputMappingTableModel::columnCount(const QModelIndex& parent) co
         return 0;
     }
     // Control and description
-    const int kBaseColumns = 2;
+    constexpr int kBaseColumns = 2;
     if (m_pMidiMapping != nullptr) {
         // Channel, Opcode, Control, On, Off, Min, Max
         return kBaseColumns + 7;

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -107,7 +107,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
         // TODO: Although there is a mode with 4-band EQs, it's not feasible
         // right now to add support for learning both it and regular 3-band eqs.
         // Since 3-band is by far the most common, stick with that.
-        const int kMaxEqs = 3;
+        constexpr int kMaxEqs = 3;
         QList<QString> eqNames;
         eqNames.append(tr("Low EQ"));
         eqNames.append(tr("Mid EQ"));
@@ -769,7 +769,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
 
     // When kNumEffectRacks is changed to >1 put effect unit actions into
     // separate "Effect Rack N" submenus.
-    const int kNumEffectRacks = 1;
+    constexpr int kNumEffectRacks = 1;
     for (int iRackNumber = 1; iRackNumber <= kNumEffectRacks; ++iRackNumber) {
         const QString rackGroup = StandardEffectRack::formatGroupString(
                 iRackNumber - 1);

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
@@ -11,11 +11,11 @@
 #include "util/time.h"
 
 namespace {
-const int kDecks = 16;
+constexpr int kDecks = 16;
 
 // Use 1ms for the Alpha-Beta dt. We're assuming the OS actually gives us a 1ms
 // timer.
-const int kScratchTimerMs = 1;
+constexpr int kScratchTimerMs = 1;
 const double kAlphaBetaDt = kScratchTimerMs / 1000.0;
 } // anonymous namespace
 

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -77,7 +77,7 @@ void clearHelper(std::shared_ptr<T>& ref_ptr, const char* name) {
 #if defined(Q_OS_LINUX)
 typedef Bool (*WireToErrorType)(Display*, XErrorEvent*, xError*);
 
-const int NUM_HANDLERS = 256;
+constexpr int NUM_HANDLERS = 256;
 WireToErrorType __oldHandlers[NUM_HANDLERS] = {nullptr};
 
 Bool __xErrorHandler(Display* display, XErrorEvent* event, xError* error) {

--- a/src/effects/builtin/autopaneffect.h
+++ b/src/effects/builtin/autopaneffect.h
@@ -57,7 +57,7 @@ class RampedSample {
     bool initialized;
 };
 
-static const int panMaxDelay = 3300; // allows a 30 Hz filter at 97346;
+static constexpr int panMaxDelay = 3300; // allows a 30 Hz filter at 97346;
 // static const int panMaxDelay = 50000; // high for debug;
 
 class AutoPanGroupState : public EffectState {

--- a/src/effects/builtin/balanceeffect.cpp
+++ b/src/effects/builtin/balanceeffect.cpp
@@ -3,8 +3,8 @@
 #include "util/defs.h"
 
 namespace {
-    const double kMaxCornerHz = 500;
-    const double kMinCornerHz = 16;
+constexpr double kMaxCornerHz = 500;
+constexpr double kMinCornerHz = 16;
 } // anonymous namespace
 
 // static

--- a/src/effects/builtin/filtereffect.cpp
+++ b/src/effects/builtin/filtereffect.cpp
@@ -2,8 +2,8 @@
 #include "util/math.h"
 
 namespace {
-const double kMinCorner = 13; // Hz
-const double kMaxCorner = 22050; // Hz
+constexpr double kMinCorner = 13;    // Hz
+constexpr double kMaxCorner = 22050; // Hz
 } // anonymous namespace
 
 // static

--- a/src/effects/builtin/linkwitzriley8eqeffect.cpp
+++ b/src/effects/builtin/linkwitzriley8eqeffect.cpp
@@ -3,9 +3,9 @@
 #include "effects/builtin/equalizer_util.h"
 #include "util/math.h"
 
-static const unsigned int kStartupSamplerate = 44100;
-static const unsigned int kStartupLoFreq = 246;
-static const unsigned int kStartupHiFreq = 2484;
+static constexpr unsigned int kStartupSamplerate = 44100;
+static constexpr unsigned int kStartupLoFreq = 246;
+static constexpr unsigned int kStartupHiFreq = 2484;
 
 // static
 QString LinkwitzRiley8EQEffect::getId() {

--- a/src/effects/builtin/loudnesscontoureffect.cpp
+++ b/src/effects/builtin/loudnesscontoureffect.cpp
@@ -4,12 +4,12 @@
 namespace {
 
 // The defaults are tweaked to match the TEA6320 IC
-static const double kLoPeakFreq = 20.0;
-static const double kHiShelveFreq = 3000.0;
-static const double kMaxLoGain = 30.0;
-static const double kHiShelveGainDiv = 3.0;
-static const double kLoPleakQ = 0.2;
-static const double kHiShelveQ = 0.7;
+static constexpr double kLoPeakFreq = 20.0;
+static constexpr double kHiShelveFreq = 3000.0;
+static constexpr double kMaxLoGain = 30.0;
+static constexpr double kHiShelveGainDiv = 3.0;
+static constexpr double kLoPleakQ = 0.2;
+static constexpr double kHiShelveQ = 0.7;
 
 } // anonymous namespace
 

--- a/src/effects/builtin/metronomeclick.h
+++ b/src/effects/builtin/metronomeclick.h
@@ -5,8 +5,8 @@
 // This is a new recording from a real metronome
 // it was converted from *.wav to plain text using Audacity
 
-const SINT kClickSize44100 = 1024;
-const CSAMPLE kClick44100[kClickSize44100] = {
+constexpr SINT kClickSize44100 = 1024;
+constexpr CSAMPLE kClick44100[kClickSize44100] = {
         0.03459f,
         0.09436f,
         0.13646f,
@@ -1032,8 +1032,8 @@ const CSAMPLE kClick44100[kClickSize44100] = {
         0.00039f,
         0.00139f};
 
-const unsigned int kClickSize48000 = 1116;
-const CSAMPLE kClick48000[kClickSize48000] = {
+constexpr unsigned int kClickSize48000 = 1116;
+constexpr CSAMPLE kClick48000[kClickSize48000] = {
         0.01534f,
         0.05623f,
         0.10618f,
@@ -2151,8 +2151,8 @@ const CSAMPLE kClick48000[kClickSize48000] = {
         0.00132f,
         0.00021f};
 
-const unsigned int kClickSize96000 = 2231;
-const CSAMPLE kClick96000[kClickSize96000] = {
+constexpr unsigned int kClickSize96000 = 2231;
+constexpr CSAMPLE kClick96000[kClickSize96000] = {
         0.01534f,
         0.03123f,
         0.05623f,

--- a/src/effects/builtin/moogladder4filtereffect.cpp
+++ b/src/effects/builtin/moogladder4filtereffect.cpp
@@ -1,9 +1,8 @@
 #include "effects/builtin/moogladder4filtereffect.h"
 #include "util/math.h"
 
-
-static const double kMinCorner = 0.0003; // 13 Hz @ 44100
-static const double kMaxCorner = 0.5; // 22050 Hz @ 44100
+static constexpr double kMinCorner = 0.0003; // 13 Hz @ 44100
+static constexpr double kMaxCorner = 0.5;    // 22050 Hz @ 44100
 
 // static
 QString MoogLadder4FilterEffect::getId() {

--- a/src/effects/builtin/threebandbiquadeqeffect.cpp
+++ b/src/effects/builtin/threebandbiquadeqeffect.cpp
@@ -7,17 +7,17 @@ namespace {
 
 // The defaults are tweaked to match the Xone:23 EQ
 // but allow 12 dB boost instead of just 6 dB
-static const int kStartupSamplerate = 44100;
-static const double kMinimumFrequency = 10.0;
-static const double kMaximumFrequency = kStartupSamplerate / 2;
-static const double kStartupLoFreq = 50.0;
-static const double kStartupMidFreq = 1100.0;
-static const double kStartupHiFreq = 12000.0;
-static const double kQBoost = 0.3;
-static const double kQKill = 0.9;
-static const double kQKillShelve = 0.4;
-static const double kBoostGain = 12;
-static const double kKillGain = -26;
+static constexpr int kStartupSamplerate = 44100;
+static constexpr double kMinimumFrequency = 10.0;
+static constexpr double kMaximumFrequency = kStartupSamplerate / 2;
+static constexpr double kStartupLoFreq = 50.0;
+static constexpr double kStartupMidFreq = 1100.0;
+static constexpr double kStartupHiFreq = 12000.0;
+static constexpr double kQBoost = 0.3;
+static constexpr double kQKill = 0.9;
+static constexpr double kQKillShelve = 0.4;
+static constexpr double kBoostGain = 12;
+static constexpr double kKillGain = -26;
 
 
 double getCenterFrequency(double low, double high) {

--- a/src/effects/effectchainmanager.h
+++ b/src/effects/effectchainmanager.h
@@ -63,7 +63,7 @@ class EffectChainManager : public QObject {
     // Reloads all effect to the slots to update parameter assignments
     void refeshAllRacks();
 
-    static const int kNumStandardEffectChains = 4;
+    static constexpr int kNumStandardEffectChains = 4;
 
     bool isAdoptMetaknobValueEnabled() const;
 

--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -11,7 +11,7 @@
 #include "util/xml.h"
 
 // The maximum number of effect parameters we're going to support.
-const unsigned int kDefaultMaxParameters = 16;
+constexpr unsigned int kDefaultMaxParameters = 16;
 
 EffectSlot::EffectSlot(const QString& group,
                        const unsigned int iChainNumber,

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -19,7 +19,7 @@ const QString EffectsManager::kNoEffectString = QStringLiteral("---");
 namespace {
 constexpr QChar kEffectGroupSeparator = '_';
 constexpr QChar kGroupClose = ']';
-const unsigned int kEffectMessagPipeFifoSize = 2048;
+constexpr unsigned int kEffectMessagPipeFifoSize = 2048;
 const QRegularExpression kIntRegex(QStringLiteral(".*(\\d+).*"));
 } // anonymous namespace
 

--- a/src/effects/effectxmlelements.h
+++ b/src/effects/effectxmlelements.h
@@ -1,7 +1,7 @@
 namespace EffectXml {
 // Version history:
 // 0 (Mixxx 2.1.0): initial support for saving state of effects
-const int kXmlSchemaVersion = 0;
+constexpr int kXmlSchemaVersion = 0;
 
 const QString Root("MixxxEffects");
 const QString SchemaVersion("SchemaVersion");

--- a/src/encoder/encoderfdkaac.cpp
+++ b/src/encoder/encoderfdkaac.cpp
@@ -15,7 +15,7 @@
 
 namespace {
 // recommended in encoder documentation, section 2.4.1
-const int kOutBufferBits = 6144;
+constexpr int kOutBufferBits = 6144;
 const mixxx::Logger kLogger("EncoderFdkAac");
 } // namespace
 

--- a/src/encoder/encoderfdkaac.h
+++ b/src/encoder/encoderfdkaac.h
@@ -22,9 +22,9 @@ class EncoderFdkAac : public Encoder {
     QString buttWindowsFdkAac();
 
     // libfdk-aac common AOTs
-    static const int AOT_AAC_LC = 2; // AAC-LC: Low Complexity (iTunes)
-    static const int AOT_SBR = 5;    // HE-AAC: with Spectral Band Replication
-    static const int AOT_PS = 29;    // HE-AACv2: Parametric Stereo (includes SBR)
+    static constexpr int AOT_AAC_LC = 2; // AAC-LC: Low Complexity (iTunes)
+    static constexpr int AOT_SBR = 5;    // HE-AAC: with Spectral Band Replication
+    static constexpr int AOT_PS = 29;    // HE-AACv2: Parametric Stereo (includes SBR)
 
     // libfdk-aac types and structs
     typedef signed int INT;

--- a/src/encoder/encoderfdkaacsettings.cpp
+++ b/src/encoder/encoderfdkaacsettings.cpp
@@ -4,7 +4,7 @@
 #include "util/logger.h"
 
 namespace {
-const int kDefaultQualityIndex = 6;
+constexpr int kDefaultQualityIndex = 6;
 const char* kQualityKey = "FdkAac_Quality";
 const mixxx::Logger kLogger("EncoderFdkAacSettings");
 } // namespace

--- a/src/encoder/encoderopus.cpp
+++ b/src/encoder/encoderopus.cpp
@@ -220,7 +220,7 @@ void EncoderOpus::pushHeaderPacket() {
     // - Mapping family: 1 byte
     // - Channel mapping table: ignored
     // Total: 19 bytes
-    const int frameSize = 19;
+    constexpr int frameSize = 19;
     QByteArray frame;
 
     // Magic signature (8 bytes)

--- a/src/encoder/encoderopussettings.cpp
+++ b/src/encoder/encoderopussettings.cpp
@@ -5,7 +5,7 @@
 #include "util/logger.h"
 
 namespace {
-const int kDefaultQualityIndex = 6;
+constexpr int kDefaultQualityIndex = 6;
 const char* kQualityKey = "Opus_Quality";
 const mixxx::Logger kLogger("EncoderOpusSettings");
 } // namespace

--- a/src/engine/bufferscalers/enginebufferscalelinear.h
+++ b/src/engine/bufferscalers/enginebufferscalelinear.h
@@ -4,7 +4,7 @@
 #include "engine/readaheadmanager.h"
 
 /** Number of samples to read ahead */
-const int kiLinearScaleReadAheadLength = 10240;
+constexpr int kiLinearScaleReadAheadLength = 10240;
 
 
 class EngineBufferScaleLinear : public EngineBufferScale  {

--- a/src/engine/bufferscalers/enginebufferscalerubberband.cpp
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.cpp
@@ -54,7 +54,7 @@ void EngineBufferScaleRubberBand::setScaleParameters(double base_rate,
     // References:
     // https://bugs.launchpad.net/ubuntu/+bug/1263233
     // https://bitbucket.org/breakfastquay/rubberband/issue/4/sigfpe-zero-division-with-high-time-ratios
-    const double kMinSeekSpeed = 1.0 / 128.0;
+    constexpr double kMinSeekSpeed = 1.0 / 128.0;
     double speed_abs = fabs(*pTempoRatio);
     if (speed_abs < kMinSeekSpeed) {
         // Let the caller know we ignored their speed.

--- a/src/engine/bufferscalers/enginebufferscalest.cpp
+++ b/src/engine/bufferscalers/enginebufferscalest.cpp
@@ -22,7 +22,7 @@ namespace {
 // 0.918 (upscaling 44.1 kHz to 48 kHz) will produce an additional offset of 3 Frames
 // 0.459 (upscaling 44.1 kHz to 96 kHz) will produce an additional offset of 18 Frames
 // (Rubberband does not suffer this issue)
-const SINT kSeekOffsetFrames = 519;
+constexpr SINT kSeekOffsetFrames = 519;
 
 }  // namespace
 

--- a/src/engine/cachingreader/cachingreader.cpp
+++ b/src/engine/cachingreader/cachingreader.cpp
@@ -20,7 +20,7 @@ mixxx::Logger kLogger("CachingReader");
 // This is the default hint frameCount that is adopted in case of Hint::kFrameCountForward and
 // Hint::kFrameCountBackward count is provided. It matches 23 ms @ 44.1 kHz
 // TODO() Do we suffer cache misses if we use an audio buffer of above 23 ms?
-const SINT kDefaultHintFrames = 1024;
+constexpr SINT kDefaultHintFrames = 1024;
 
 // With CachingReaderChunk::kFrames = 8192 each chunk consumes
 // 8192 frames * 2 channels/frame * 4-bytes per sample = 65 kB.
@@ -37,7 +37,7 @@ const SINT kDefaultHintFrames = 1024;
 // (kNumberOfCachedChunksInMemory = 1, 2, 3, ...) for testing purposes
 // to verify that the MRU/LRU cache works as expected. Even though
 // massive drop outs are expected to occur Mixxx should run reliably!
-const SINT kNumberOfCachedChunksInMemory = 80;
+constexpr SINT kNumberOfCachedChunksInMemory = 80;
 
 } // anonymous namespace
 

--- a/src/engine/cachingreader/cachingreaderchunk.cpp
+++ b/src/engine/cachingreader/cachingreaderchunk.cpp
@@ -13,7 +13,7 @@ namespace {
 
 mixxx::Logger kLogger("CachingReaderChunk");
 
-const SINT kInvalidChunkIndex = -1;
+constexpr SINT kInvalidChunkIndex = -1;
 
 } // anonymous namespace
 

--- a/src/engine/channelhandle.h
+++ b/src/engine/channelhandle.h
@@ -167,7 +167,7 @@ typedef std::shared_ptr<ChannelHandleFactory> ChannelHandleFactoryPointer;
 // integer value.
 template <class T>
 class ChannelHandleMap {
-    static const int kMaxExpectedGroups = 256;
+    static constexpr int kMaxExpectedGroups = 256;
     typedef QVarLengthArray<T, kMaxExpectedGroups> container_type;
   public:
     typedef typename QVarLengthArray<T, kMaxExpectedGroups>::const_iterator const_iterator;

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -514,16 +514,16 @@ double BpmControl::calcSyncAdjustment(bool userTweakingSync) {
         // Threshold above which sync is really, really bad, so much so that we
         // don't even know if we're ahead or behind.  This can occur when quantize was
         // off, but then it gets turned on.
-        const double kTrainWreckThreshold = 0.2;
-        const double kSyncAdjustmentCap = 0.05;
+        constexpr double kTrainWreckThreshold = 0.2;
+        constexpr double kSyncAdjustmentCap = 0.05;
         if (fabs(error) > kTrainWreckThreshold) {
             // Assume poor reflexes (late button push) -- speed up to catch the other track.
             adjustment = 1.0 + kSyncAdjustmentCap;
         } else if (fabs(error) > kErrorThreshold) {
             // Proportional control constant. The higher this is, the more we
             // influence sync.
-            const double kSyncAdjustmentProportional = 0.7;
-            const double kSyncDeltaCap = 0.02;
+            constexpr double kSyncAdjustmentProportional = 0.7;
+            constexpr double kSyncDeltaCap = 0.02;
 
             // TODO(owilliams): There are a lot of "1.0"s in this code -- can we eliminate them?
             const double adjust = 1.0 + (-error * kSyncAdjustmentProportional);

--- a/src/engine/controls/enginecontrol.h
+++ b/src/engine/controls/enginecontrol.h
@@ -17,7 +17,7 @@
 class EngineMaster;
 class EngineBuffer;
 
-const int kNoTrigger = -1;
+constexpr int kNoTrigger = -1;
 static_assert(
         mixxx::audio::FramePos::kLegacyInvalidEnginePosition == kNoTrigger,
         "Invalid engine position value mismatch");

--- a/src/engine/controls/keycontrol.cpp
+++ b/src/engine/controls/keycontrol.cpp
@@ -12,8 +12,8 @@
 #include "track/keyutils.h"
 
 //static const double kLockOriginalKey = 0;
-static const double kLockCurrentKey = 1;
-static const double kKeepUnlockedKey = 1;
+static constexpr double kLockCurrentKey = 1;
+static constexpr double kKeepUnlockedKey = 1;
 
 KeyControl::KeyControl(const QString& group,
         UserSettingsPointer pConfig)

--- a/src/engine/controls/ratecontrol.cpp
+++ b/src/engine/controls/ratecontrol.cpp
@@ -364,7 +364,7 @@ double RateControl::getWheelFactor() const {
 
 double RateControl::getJogFactor() const {
     // FIXME: Sensitivity should be configurable separately?
-    const double jogSensitivity = 0.1;  // Nudges during playback
+    constexpr double jogSensitivity = 0.1; // Nudges during playback
     double jogValue = m_pJog->get();
 
     // Since m_pJog is an accumulator, reset it since we've used its value.

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -399,7 +399,7 @@ void EngineMaster::process(const int iBufferSize) {
     m_sampleRate = mixxx::audio::SampleRate::fromDouble(m_pMasterSampleRate->get());
     m_iBufferSize = iBufferSize;
     // TODO: remove assumption of stereo buffer
-    const unsigned int kChannels = 2;
+    constexpr unsigned int kChannels = 2;
     const unsigned int iFrames = iBufferSize / kChannels;
 
     if (m_pEngineEffectsManager) {
@@ -825,7 +825,7 @@ void EngineMaster::addChannel(EngineChannel* pChannel) {
     pChannelInfo->m_pBuffer = SampleUtil::alloc(MAX_BUFFER_LEN);
     SampleUtil::clear(pChannelInfo->m_pBuffer, MAX_BUFFER_LEN);
     m_channels.append(pChannelInfo);
-    const GainCache gainCacheDefault = {0, false};
+    constexpr GainCache gainCacheDefault = {0, false};
     m_channelHeadphoneGainCache.append(gainCacheDefault);
     m_channelTalkoverGainCache.append(gainCacheDefault);
     m_channelMasterGainCache.append(gainCacheDefault);

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -33,7 +33,7 @@ class EngineDelay;
 
 // The number of channels to pre-allocate in various structures in the
 // engine. Prevents memory allocation in EngineMaster::addChannel.
-static const int kPreallocatedChannels = 64;
+static constexpr int kPreallocatedChannels = 64;
 
 class EngineMaster : public QObject, public AudioSource {
     Q_OBJECT

--- a/src/engine/enginepregain.cpp
+++ b/src/engine/enginepregain.cpp
@@ -95,7 +95,7 @@ void EnginePregain::process(CSAMPLE* pInOut, const int iBufferSize) {
 
         // This means that a ReplayGain value has been calculated after the
         // track has been loaded
-        const float kFadeSeconds = 1.0;
+        constexpr float kFadeSeconds = 1.0;
 
         if (m_bSmoothFade) {
             float seconds = static_cast<float>(m_timer.elapsed().toDoubleSeconds());

--- a/src/engine/filters/enginefiltermoogladder4.h
+++ b/src/engine/filters/enginefiltermoogladder4.h
@@ -73,7 +73,7 @@ class EngineFilterMoogLadderBase : public EngineObjectConstIn {
     // cutoff  in Hz
     // resonance  range 0 ... 4 (4 = self resonance)
     void setParameter(int sampleRate, float cutoff, float resonance) {
-        const float v2 = 2 + kVt;   // twice the 'thermal voltage of a transistor'
+        constexpr float v2 = 2 + kVt; // twice the 'thermal voltage of a transistor'
 
         float kfc = cutoff / sampleRate;
         float kf = kfc;
@@ -182,8 +182,7 @@ class EngineFilterMoogLadderBase : public EngineObjectConstIn {
     }
 
     inline CSAMPLE processSample(float input, struct Buffer* pB) {
-
-        const float v2 = 2 + kVt;   // twice the 'thermal voltage of a transistor'
+        constexpr float v2 = 2 + kVt; // twice the 'thermal voltage of a transistor'
 
         // cascade of 4 1st-order sections
         float x1 = input - pB->m_amf * m_kacr;

--- a/src/engine/filters/enginefilterpan.h
+++ b/src/engine/filters/enginefilterpan.h
@@ -5,7 +5,7 @@
 #include "engine/engineobject.h"
 #include "util/assert.h"
 
-static const int numChannels = 2;
+static constexpr int numChannels = 2;
 
 template<unsigned int SIZE>
 class EngineFilterPan : public EngineObjectConstIn {

--- a/src/engine/filters/enginefilterpansingle.h
+++ b/src/engine/filters/enginefilterpansingle.h
@@ -12,7 +12,7 @@
 #include "engine/engineobject.h"
 #include "util/assert.h"
 
-static const int numChannels = 2;
+static constexpr int numChannels = 2;
 
 template<unsigned int SIZE>
 class EngineFilterPanSingle {

--- a/src/engine/positionscratchcontroller.cpp
+++ b/src/engine/positionscratchcontroller.cpp
@@ -145,9 +145,9 @@ void PositionScratchController::process(double currentSample, double releaseRate
             }
 
             // Max velocity we would like to stop in a given time period.
-            const double kMaxVelocity = 100;
+            constexpr double kMaxVelocity = 100;
             // Seconds to stop a throw at the max velocity.
-            const double kTimeToStop = 1.0;
+            constexpr double kTimeToStop = 1.0;
 
             // We calculate the exponential decay constant based on the above
             // constants. Roughly we backsolve what the decay should be if we want to
@@ -239,7 +239,7 @@ void PositionScratchController::process(double currentSample, double releaseRate
 
             // The rate threshold above which disabling position scratching will enable
             // an 'inertia' mode.
-            const double kThrowThreshold = 2.5;
+            constexpr double kThrowThreshold = 2.5;
 
             if (fabs(m_dRate) > kThrowThreshold) {
                 m_bEnableInertia = true;

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -7,7 +7,7 @@
 #include "util/math.h"
 #include "util/sample.h"
 
-static const int kNumChannels = 2;
+static constexpr int kNumChannels = 2;
 
 ReadAheadManager::ReadAheadManager()
         : m_pLoopingControl(nullptr),

--- a/src/engine/sidechain/enginenetworkstream.cpp
+++ b/src/engine/sidechain/enginenetworkstream.cpp
@@ -19,7 +19,7 @@ static PgGetSystemTimeFn s_pfpgGetSystemTimeFn = NULL;
 #include "util/sample.h"
 
 namespace {
-const int kNetworkLatencyFrames = 8192; // 185 ms @ 44100 Hz
+constexpr int kNetworkLatencyFrames = 8192; // 185 ms @ 44100 Hz
 // Related chunk sizes:
 // Mp3 frames = 1152 samples
 // Ogg frames = 64 to 8192 samples.

--- a/src/engine/sidechain/enginerecord.cpp
+++ b/src/engine/sidechain/enginerecord.cpp
@@ -10,7 +10,7 @@
 #include "track/track.h"
 #include "util/event.h"
 
-const int kMetaDataLifeTimeout = 16;
+constexpr int kMetaDataLifeTimeout = 16;
 
 EngineRecord::EngineRecord(UserSettingsPointer pConfig)
         : m_pConfig(pConfig),

--- a/src/engine/sidechain/enginesidechain.cpp
+++ b/src/engine/sidechain/enginesidechain.cpp
@@ -78,7 +78,7 @@ void EngineSideChain::receiveBuffer(const AudioInput& input,
 void EngineSideChain::writeSamples(const CSAMPLE* pBuffer, int iFrames) {
     Trace sidechain("EngineSideChain::writeSamples");
     // TODO: remove assumption of stereo buffer
-    const int kChannels = 2;
+    constexpr int kChannels = 2;
     const int iSamples = iFrames * kChannels;
     int samples_written = m_sampleFifo.write(pBuffer, iSamples);
 

--- a/src/engine/sidechain/enginesidechain.h
+++ b/src/engine/sidechain/enginesidechain.h
@@ -32,7 +32,7 @@ class EngineSideChain : public QThread, public AudioDestination {
     // Thread-safe, blocking.
     void addSideChainWorker(SideChainWorker* pWorker);
 
-    static const int SIDECHAIN_BUFFER_SIZE = 65536;
+    static constexpr int SIDECHAIN_BUFFER_SIZE = 65536;
 
   private:
     void run() override;

--- a/src/engine/sidechain/shoutconnection.cpp
+++ b/src/engine/sidechain/shoutconnection.cpp
@@ -33,11 +33,11 @@
 
 namespace {
 
-const int kConnectRetries = 30;
-const int kMaxNetworkCache = 491520;  // 10 s mp3 @ 192 kbit/s
+constexpr int kConnectRetries = 30;
+constexpr int kMaxNetworkCache = 491520; // 10 s mp3 @ 192 kbit/s
 // Shoutcast default receive buffer 1048576 and autodumpsourcetime 30 s
 // http://wiki.shoutcast.com/wiki/SHOUTcast_DNAS_Server_2
-const int kMaxShoutFailures = 3;
+constexpr int kMaxShoutFailures = 3;
 
 const QRegularExpression kArtistOrTitleRegex(QStringLiteral("\\$artist|\\$title"));
 const QRegularExpression kArtistRegex(QStringLiteral("\\$artist"));

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -28,7 +28,7 @@ const QString kViewName = QStringLiteral("Auto DJ");
 } // namespace
 
 namespace {
-    const int kMaxRetrieveAttempts = 3;
+constexpr int kMaxRetrieveAttempts = 3;
 
     int findOrCrateAutoDjPlaylistId(PlaylistDAO& playlistDAO) {
         int playlistId = playlistDAO.getPlaylistIdFromName(AUTODJ_TABLE);

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -14,8 +14,8 @@
 namespace {
 const char* kTransitionPreferenceName = "Transition";
 const char* kTransitionModePreferenceName = "TransitionMode";
-const double kTransitionPreferenceDefault = 10.0;
-const double kKeepPosition = -1.0;
+constexpr double kTransitionPreferenceDefault = 10.0;
+constexpr double kKeepPosition = -1.0;
 
 static const bool sDebug = false;
 } // anonymous namespace

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -28,8 +28,8 @@ const bool sDebug = false;
 // The logic in the following code relies to a track column = 0
 // Do not change it without changing the logic
 // Column 0 is skipped when calculating the the columns of the view table
-const int kIdColumn = 0;
-const int kMaxSortColumns = 3;
+constexpr int kIdColumn = 0;
+constexpr int kMaxSortColumns = 3;
 
 // Constant for getModelSetting(name)
 const QString COLUMNS_SORTING = QStringLiteral("ColumnsSorting");

--- a/src/library/browse/browsetablemodel.h
+++ b/src/library/browse/browsetablemodel.h
@@ -8,27 +8,27 @@
 #include "library/browse/browsethread.h"
 
 //constants
-const int COLUMN_PREVIEW = 0;
-const int COLUMN_FILENAME = 1;
-const int COLUMN_ARTIST = 2;
-const int COLUMN_TITLE = 3;
-const int COLUMN_ALBUM = 4;
-const int COLUMN_TRACK_NUMBER = 5;
-const int COLUMN_YEAR = 6;
-const int COLUMN_GENRE = 7;
-const int COLUMN_COMPOSER = 8;
-const int COLUMN_COMMENT = 9;
-const int COLUMN_DURATION = 10;
-const int COLUMN_BPM = 11;
-const int COLUMN_KEY = 12;
-const int COLUMN_TYPE = 13;
-const int COLUMN_BITRATE = 14;
-const int COLUMN_NATIVELOCATION = 15;
-const int COLUMN_ALBUMARTIST = 16;
-const int COLUMN_GROUPING = 17;
-const int COLUMN_FILE_MODIFIED_TIME = 18;
-const int COLUMN_FILE_CREATION_TIME = 19;
-const int COLUMN_REPLAYGAIN = 20;
+constexpr int COLUMN_PREVIEW = 0;
+constexpr int COLUMN_FILENAME = 1;
+constexpr int COLUMN_ARTIST = 2;
+constexpr int COLUMN_TITLE = 3;
+constexpr int COLUMN_ALBUM = 4;
+constexpr int COLUMN_TRACK_NUMBER = 5;
+constexpr int COLUMN_YEAR = 6;
+constexpr int COLUMN_GENRE = 7;
+constexpr int COLUMN_COMPOSER = 8;
+constexpr int COLUMN_COMMENT = 9;
+constexpr int COLUMN_DURATION = 10;
+constexpr int COLUMN_BPM = 11;
+constexpr int COLUMN_KEY = 12;
+constexpr int COLUMN_TYPE = 13;
+constexpr int COLUMN_BITRATE = 14;
+constexpr int COLUMN_NATIVELOCATION = 15;
+constexpr int COLUMN_ALBUMARTIST = 16;
+constexpr int COLUMN_GROUPING = 17;
+constexpr int COLUMN_FILE_MODIFIED_TIME = 18;
+constexpr int COLUMN_FILE_CREATION_TIME = 19;
+constexpr int COLUMN_REPLAYGAIN = 20;
 
 class TrackCollectionManager;
 

--- a/src/library/dao/analysisdao.cpp
+++ b/src/library/dao/analysisdao.cpp
@@ -15,7 +15,7 @@ const QString AnalysisDao::s_analysisTableName = "track_analysis";
 // compression level (-1) takes the size down to about 600KB. The difference
 // between the default and 9 (the max) was only about 1-2KB for a lot of extra
 // CPU time so I think we should stick with the default. rryan 4/3/2012
-const int kCompressionLevel = -1;
+constexpr int kCompressionLevel = -1;
 
 AnalysisDao::AnalysisDao(UserSettingsPointer pConfig)
         : m_pConfig(pConfig) {

--- a/src/library/dao/autodjcratesdao.cpp
+++ b/src/library/dao/autodjcratesdao.cpp
@@ -42,12 +42,12 @@
 
 namespace {
 // Percentage of most and least played tracks to ignore [0,50)
-const int kLeastPreferredPercent = 15;
+constexpr int kLeastPreferredPercent = 15;
 
 // These consts are only used for DEBUG_ASSERTs
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
-const int kLeastPreferredPercentMin = 0;
-const int kLeastPreferredPercentMax = 50;
+constexpr int kLeastPreferredPercentMin = 0;
+constexpr int kLeastPreferredPercentMax = 50;
 #endif
 
 int bounded_rand(int highest) {

--- a/src/library/export/engineprimeexportjob.cpp
+++ b/src/library/export/engineprimeexportjob.cpp
@@ -26,9 +26,9 @@ namespace {
 
 const std::string kMixxxRootCrateName = "Mixxx";
 
-const int kMaxHotCues = 8;
+constexpr int kMaxHotCues = 8;
 
-const uint8_t kDefaultWaveformOpacity = 127;
+constexpr uint8_t kDefaultWaveformOpacity = 127;
 
 const QStringList kSupportedFileTypes = {"mp3", "flac", "ogg"};
 

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -499,7 +499,7 @@ QString parseDeviceDB(mixxx::DbConnectionPoolPtr dbConnectionPool, TreeItem* dev
     // Attempt was made to also recover HISTORY
     // playlists (which are found on removable Rekordbox devices), however
     // they didn't appear to contain valid row_ref_t structures.
-    const int totalTables = 8;
+    constexpr int totalTables = 8;
 
     rekordbox_pdb_t::page_type_t tableOrder[totalTables] = {
             rekordbox_pdb_t::PAGE_TYPE_KEYS,

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -20,7 +20,7 @@
 namespace {
 
 // TODO(rryan) make configurable
-const int kScannerThreadPoolSize = 1;
+constexpr int kScannerThreadPoolSize = 1;
 
 mixxx::Logger kLogger("LibraryScanner");
 

--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -17,7 +17,7 @@ namespace {
 // in the sidebar tree. This is essential to allow smooth scrolling through
 // a list of items with an encoder or the keyboard! A value of 300 ms has
 // been chosen as a compromise between usability and responsiveness.
-const int kPressedUntilClickedTimeoutMillis = 300;
+constexpr int kPressedUntilClickedTimeoutMillis = 300;
 
 const QHash<int, QByteArray> kRoleNames = {
         // Only roles that are useful in QML are added here.

--- a/src/library/starrating.cpp
+++ b/src/library/starrating.cpp
@@ -6,7 +6,7 @@
 #include "util/math.h"
 
 // Magic number? Explain what this factor affects and how
-const int PaintingScaleFactor = 15;
+constexpr int PaintingScaleFactor = 15;
 
 StarRating::StarRating(
         int starCount,

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -366,7 +366,7 @@ void SetlogFeature::slotPlayingTrackChanged(TrackPointer currentPlayingTrack) {
         m_recentTracks.push_front(currentPlayingTrackId);
 
         // Keep a window of 6 tracks (inspired by 2 decks, 4 samplers)
-        const int kRecentTrackWindow = 6;
+        constexpr int kRecentTrackWindow = 6;
         while (m_recentTracks.size() > kRecentTrackWindow) {
             m_recentTracks.pop_back();
         }

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -22,9 +22,9 @@
 
 namespace {
 
-const double kNoTrackColor = -1;
-const double kShiftCuesOffsetMillis = 10;
-const double kShiftCuesOffsetSmallMillis = 1;
+constexpr double kNoTrackColor = -1;
+constexpr double kShiftCuesOffsetMillis = 10;
+constexpr double kShiftCuesOffsetSmallMillis = 1;
 
 inline double trackColorToDouble(mixxx::RgbColor::optional_t color) {
     return (color ? static_cast<double>(*color) : kNoTrackColor);

--- a/src/mixer/playerinfo.cpp
+++ b/src/mixer/playerinfo.cpp
@@ -11,7 +11,7 @@
 
 namespace {
 
-const int kPlayingDeckUpdateIntervalMillis = 2000;
+constexpr int kPlayingDeckUpdateIntervalMillis = 2000;
 
 PlayerInfo* s_pPlayerInfo = nullptr;
 

--- a/src/musicbrainz/chromaprinter.cpp
+++ b/src/musicbrainz/chromaprinter.cpp
@@ -29,7 +29,7 @@ namespace
 // AcoustID only stores a fingerprint for the first two minutes of a song
 // on their server so we need only a fingerprint of the first two minutes
 // --kain88 July 2012
-const SINT kFingerprintDuration = 120; // in seconds
+    constexpr SINT kFingerprintDuration = 120; // in seconds
 
 QString calcFingerprint(
         mixxx::AudioSourceStereoProxy& audioSourceProxy,

--- a/src/network/httpstatuscode.h
+++ b/src/network/httpstatuscode.h
@@ -8,11 +8,11 @@ namespace network {
 
 typedef int HttpStatusCode;
 
-const HttpStatusCode kHttpStatusCodeInvalid = -1;
-const HttpStatusCode kHttpStatusCodeOk = 200;
-const HttpStatusCode kHttpStatusCodeCreated = 201;
-const HttpStatusCode kHttpStatusCodeAccepted = 202;
-const HttpStatusCode kHttpStatusCodeNoContent = 204;
+constexpr HttpStatusCode kHttpStatusCodeInvalid = -1;
+constexpr HttpStatusCode kHttpStatusCodeOk = 200;
+constexpr HttpStatusCode kHttpStatusCodeCreated = 201;
+constexpr HttpStatusCode kHttpStatusCodeAccepted = 202;
+constexpr HttpStatusCode kHttpStatusCodeNoContent = 204;
 
 inline bool HttpStatusCode_isInformational(
         int statusCode) {

--- a/src/preferences/broadcastsettingsmodel.cpp
+++ b/src/preferences/broadcastsettingsmodel.cpp
@@ -5,9 +5,9 @@
 #include "moc_broadcastsettingsmodel.cpp"
 
 namespace {
-const int kColumnEnabled = 0;
-const int kColumnName = 1;
-const int kColumnStatus = 2;
+constexpr int kColumnEnabled = 0;
+constexpr int kColumnName = 1;
+constexpr int kColumnStatus = 2;
 } // namespace
 
 BroadcastSettingsModel::BroadcastSettingsModel() {

--- a/src/preferences/dialog/dlgprefbroadcast.cpp
+++ b/src/preferences/dialog/dlgprefbroadcast.cpp
@@ -27,8 +27,8 @@
 
 namespace {
 const char* kSettingsGroupHeader = "Settings for %1";
-const int kColumnEnabled = 0;
-const int kColumnName = 1;
+constexpr int kColumnEnabled = 0;
+constexpr int kColumnName = 1;
 const mixxx::Logger kLogger("DlgPrefBroadcast");
 } // namespace
 

--- a/src/preferences/dialog/dlgprefcrossfader.cpp
+++ b/src/preferences/dialog/dlgprefcrossfader.cpp
@@ -127,8 +127,8 @@ void DlgPrefCrossfader::slotUpdate() {
 // has been made.
 void DlgPrefCrossfader::drawXfaderDisplay()
 {
-    const int kGrindXLines = 4;
-    const int kGrindYLines = 6;
+    constexpr int kGrindXLines = 4;
+    constexpr int kGrindYLines = 6;
 
     int sizeX = graphicsViewXfader->width();
     int sizeY = graphicsViewXfader->height();

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -24,8 +24,8 @@ const QString kDefaultEqId = BiquadFullKillEQEffect::getId();
 const QString kDefaultMainEqId = QString();
 const QString kDefaultQuickEffectId = FilterEffect::getId();
 
-const int kFrequencyUpperLimit = 20050;
-const int kFrequencyLowerLimit = 16;
+constexpr int kFrequencyUpperLimit = 20050;
+constexpr int kFrequencyLowerLimit = 16;
 
 DlgPrefEQ::DlgPrefEQ(
         QWidget* pParent,

--- a/src/preferences/dialog/dlgprefreplaygain.cpp
+++ b/src/preferences/dialog/dlgprefreplaygain.cpp
@@ -9,7 +9,7 @@ const char* kConfigKey = "[ReplayGain]";
 const char* kReplayGainBoost = "ReplayGainBoost";
 const char* kDefaultBoost = "DefaultBoost";
 const char* kReplayGainEnabled = "ReplayGainEnabled";
-const int kReplayGainReferenceLUFS = -18;
+constexpr int kReplayGainReferenceLUFS = -18;
 } // anonymous namespace
 
 DlgPrefReplayGain::DlgPrefReplayGain(QWidget* parent, UserSettingsPointer pConfig)

--- a/src/preferences/effectsettingsmodel.cpp
+++ b/src/preferences/effectsettingsmodel.cpp
@@ -3,10 +3,10 @@
 #include "moc_effectsettingsmodel.cpp"
 
 namespace {
-const int kColumnEnabled = 0;
-const int kColumnName = 1;
-const int kColumnType = 2;
-const int kNumberOfColumns = 3;
+constexpr int kColumnEnabled = 0;
+constexpr int kColumnName = 1;
+constexpr int kColumnType = 2;
+constexpr int kNumberOfColumns = 3;
 } // namespace
 
 EffectSettingsModel::EffectSettingsModel() {

--- a/src/preferences/replaygainsettings.cpp
+++ b/src/preferences/replaygainsettings.cpp
@@ -15,7 +15,7 @@ const char* kReplayGainReanalyze = "ReplayGainReanalyze";
 
 const char* kReplayGainEnabled = "ReplayGainEnabled";
 
-const int kInitialDefaultBoostDefault = -6;
+constexpr int kInitialDefaultBoostDefault = -6;
 } // anonymous namespace
 
 ReplayGainSettings::ReplayGainSettings(UserSettingsPointer pConfig)

--- a/src/skin/qml/qmlwaveformoverview.cpp
+++ b/src/skin/qml/qmlwaveformoverview.cpp
@@ -125,7 +125,7 @@ void QmlWaveformOverview::paint(QPainter* pPainter) {
         return;
     }
 
-    const int actualCompletion = 0;
+    constexpr int actualCompletion = 0;
     // Always multiple of 2
     const int waveformCompletion = pWaveform->getCompletion();
     // Test if there is some new to draw (at least of pixel width)

--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -18,7 +18,7 @@
 #include "waveform/visualplayposition.h"
 
 namespace {
-const int kNetworkLatencyFrames = 8192; // 185 ms @ 44100 Hz
+constexpr int kNetworkLatencyFrames = 8192; // 185 ms @ 44100 Hz
 // Related chunk sizes:
 // Mp3 frames = 1152 samples
 // Ogg frames = 64 to 8192 samples.

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -37,7 +37,7 @@ constexpr int kCpuUsageUpdateRate = 30; // in 1/s, fits to display frame rate
 
 // We warn only at invalid timing 3, since the first two
 // callbacks can be always wrong due to a setup/open jitter
-const int m_invalidTimeInfoWarningCount = 3;
+constexpr int m_invalidTimeInfoWarningCount = 3;
 
 int paV19Callback(const void *inputBuffer, void *outputBuffer,
                   unsigned long framesPerBuffer,

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -39,7 +39,7 @@ struct DeviceMode {
 };
 
 #ifdef __LINUX__
-const unsigned int kSleepSecondsAfterClosingDevice = 5;
+constexpr unsigned int kSleepSecondsAfterClosingDevice = 5;
 #endif
 } // anonymous namespace
 

--- a/src/sources/audiosource.cpp
+++ b/src/sources/audiosource.cpp
@@ -12,7 +12,7 @@ const Logger kLogger("AudioSource");
 // stream works.
 // NOTE(2020-05-01): A single frame is sufficient to reliably detect
 // the broken FAAD2 v2.9.1 library.
-const SINT kVerifyReadableMaxFrameCount = 1;
+constexpr SINT kVerifyReadableMaxFrameCount = 1;
 
 } // anonymous namespace
 

--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -67,7 +67,7 @@ void FLAC_error_cb(const FLAC__StreamDecoder*,
 
 // end callbacks
 
-const SINT kBitsPerSampleDefault = 0;
+constexpr SINT kBitsPerSampleDefault = 0;
 
 } // namespace
 

--- a/src/test/audiotaperpot_test.cpp
+++ b/src/test/audiotaperpot_test.cpp
@@ -11,9 +11,9 @@ class AudioTaperPotTest : public MixxxTest {};
 
 TEST_F(AudioTaperPotTest, ScaleTest) {
     {
-        const double minDB = -6;
-        const double maxDB = 6;
-        const double neutralParameter = 0.5;
+        constexpr double minDB = -6;
+        constexpr double maxDB = 6;
+        constexpr double neutralParameter = 0.5;
         ControlAudioTaperPotBehavior catpb(minDB, maxDB, neutralParameter);
         // Parameter 0 is always 0 (-Infinity)
         ASSERT_DOUBLE_EQ(0.0, catpb.parameterToValue(0));
@@ -32,9 +32,9 @@ TEST_F(AudioTaperPotTest, ScaleTest) {
     }
 
     {
-        const double minDB = 0;
-        const double maxDB = 6;
-        const double neutralParameter = 0.5;
+        constexpr double minDB = 0;
+        constexpr double maxDB = 6;
+        constexpr double neutralParameter = 0.5;
         ControlAudioTaperPotBehavior catpb(minDB, maxDB, neutralParameter);
         // Parameter 0 is always 0 (-Infinity)
         ASSERT_DOUBLE_EQ(0.0, catpb.parameterToValue(0));
@@ -53,9 +53,9 @@ TEST_F(AudioTaperPotTest, ScaleTest) {
     }
 
     {
-        const double minDB = -6;
-        const double maxDB = 0;
-        const double neutralParameter = 1;
+        constexpr double minDB = -6;
+        constexpr double maxDB = 0;
+        constexpr double neutralParameter = 1;
         ControlAudioTaperPotBehavior catpb(minDB, maxDB, neutralParameter);
         // Parameter 0 is always 0 (-Infinity)
         ASSERT_DOUBLE_EQ(0.0, catpb.parameterToValue(0));

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -56,7 +56,7 @@ TEST_F(BeatMapTest, Scale) {
     m_pTrack->trySetBpm(bpm.value());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
-    const int numBeats = 100;
+    constexpr int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<mixxx::audio::FramePos> beats =
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
@@ -87,7 +87,7 @@ TEST_F(BeatMapTest, TestNthBeat) {
     m_pTrack->trySetBpm(bpm.value());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
-    const int numBeats = 100;
+    constexpr int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<mixxx::audio::FramePos> beats =
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
@@ -133,14 +133,14 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat) {
     m_pTrack->trySetBpm(bpm.value());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
-    const int numBeats = 100;
+    constexpr int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<mixxx::audio::FramePos> beats =
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
     auto pMap = Beats::fromBeatPositions(m_pTrack->getSampleRate(), beats);
 
     // Pretend we're on the 20th beat;
-    const int curBeat = 20;
+    constexpr int curBeat = 20;
     const mixxx::audio::FramePos position = startOffsetFrames + beatLengthFrames * curBeat;
 
     // The spec dictates that a value of 0 is always invalid and returns an invalid position
@@ -176,7 +176,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
     m_pTrack->trySetBpm(bpm.value());
     mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
     const auto startOffsetFrames = mixxx::audio::FramePos(7);
-    const int numBeats = 100;
+    constexpr int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<mixxx::audio::FramePos> beats =
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
@@ -215,7 +215,7 @@ TEST_F(BeatMapTest, TestBpmAround) {
     constexpr mixxx::Bpm filebpm(60.0);
     double approx_beat_length = getBeatLengthFrames(filebpm);
     m_pTrack->trySetBpm(filebpm.value());
-    const int numBeats = 64;
+    constexpr int numBeats = 64;
 
     QVector<mixxx::audio::FramePos> beats;
     mixxx::audio::FramePos beat_pos = mixxx::audio::kStartFramePos;

--- a/src/test/bpmcontrol_test.cpp
+++ b/src/test/bpmcontrol_test.cpp
@@ -23,7 +23,7 @@ TEST_F(BpmControlTest, ShortestPercentageChange) {
 }
 
 TEST_F(BpmControlTest, BeatContext_BeatGrid) {
-    const int sampleRate = 44100;
+    constexpr int sampleRate = 44100;
 
     TrackPointer pTrack = Track::newTemporary();
     pTrack->setAudioProperties(

--- a/src/test/coreservicestest.cpp
+++ b/src/test/coreservicestest.cpp
@@ -10,7 +10,7 @@ class CoreServicesTest : public MixxxTest {
 // This test is disabled because it fails on CI for some unknown reason.
 TEST_F(CoreServicesTest, DISABLED_TestInitialization) {
     // Initialize the app
-    const int argc = 1;
+    constexpr int argc = 1;
     CmdlineArgs cmdlineArgs;
     char progName[] = "mixxxtest";
     char safeMode[] = "--safe-mode";

--- a/src/test/cratestorage_test.cpp
+++ b/src/test/cratestorage_test.cpp
@@ -12,7 +12,7 @@ class CrateStorageTest : public LibraryTest {
 };
 
 TEST_F(CrateStorageTest, persistentLifecycle) {
-    const uint kNumCrates = 10;
+    constexpr uint kNumCrates = 10;
 
     // Insert some crates
     for (auto i = kNumCrates; i > 0; --i) {

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -1985,7 +1985,7 @@ TEST_F(EngineSyncTest, HalfDoubleConsistency) {
     // half-double matching should be consistent
     mixxx::audio::FrameDiff_t beatLengthFrames = 60.0 * 44100 / 90.0;
     constexpr auto startOffsetFrames = mixxx::audio::kStartFramePos;
-    const int numBeats = 100;
+    constexpr int numBeats = 100;
     QVector<mixxx::audio::FramePos> beats1 =
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
     auto pBeats1 = mixxx::Beats::fromBeatPositions(m_pTrack1->getSampleRate(), beats1);
@@ -2277,7 +2277,7 @@ TEST_F(EngineSyncTest, UserTweakPreservedInSeek) {
     // Ensure that when we do a seek during sync lock, the user offset is maintained.
 
     // This is about 128 bpm, but results in nice round numbers of samples.
-    const double kDivisibleBpm = 44100.0 / 344.0;
+    constexpr double kDivisibleBpm = 44100.0 / 344.0;
     mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
             m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(kDivisibleBpm));
     m_pTrack1->trySetBeats(pBeats1);
@@ -2358,7 +2358,7 @@ TEST_F(EngineSyncTest, FollowerUserTweakPreservedInLeaderChange) {
     // reinitializing the leader parameters..
 
     // This is about 128 bpm, but results in nice round numbers of samples.
-    const double kDivisibleBpm = 44100.0 / 344.0;
+    constexpr double kDivisibleBpm = 44100.0 / 344.0;
     mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
             m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(kDivisibleBpm));
     m_pTrack1->trySetBeats(pBeats1);
@@ -2409,7 +2409,7 @@ TEST_F(EngineSyncTest, FollowerUserTweakPreservedInLeaderChange) {
 TEST_F(EngineSyncTest, FollowerUserTweakPreservedInSyncDisable) {
     // Ensure that when a follower disables sync, a phase seek is not performed.
     // This is about 128 bpm, but results in nice round numbers of samples.
-    const double kDivisibleBpm = 44100.0 / 344.0;
+    constexpr double kDivisibleBpm = 44100.0 / 344.0;
     mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
             m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(kDivisibleBpm));
     m_pTrack1->trySetBeats(pBeats1);
@@ -2445,7 +2445,7 @@ TEST_F(EngineSyncTest, LeaderUserTweakPreservedInLeaderChange) {
     // reinitializing the leader parameters..
 
     // This is about 128 bpm, but results in nice round numbers of samples.
-    const double kDivisibleBpm = 44100.0 / 344.0;
+    constexpr double kDivisibleBpm = 44100.0 / 344.0;
     mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
             m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(kDivisibleBpm));
     m_pTrack1->trySetBeats(pBeats1);

--- a/src/test/midicontrollertest.cpp
+++ b/src/test/midicontrollertest.cpp
@@ -433,9 +433,9 @@ TEST_F(MidiControllerTest, ReceiveMessage_ToggleCO_PushCC) {
 TEST_F(MidiControllerTest, ReceiveMessage_PotMeterCO_7BitCC) {
     ConfigKey key("[Channel1]", "playposition");
 
-    const double kMinValue = -1234.5;
-    const double kMaxValue = 678.9;
-    const double kMiddleValue = (kMinValue + kMaxValue) * 0.5;
+    constexpr double kMinValue = -1234.5;
+    constexpr double kMaxValue = 678.9;
+    constexpr double kMiddleValue = (kMinValue + kMaxValue) * 0.5;
     ControlPotmeter potmeter(key, kMinValue, kMaxValue);
 
     unsigned char channel = 0x01;
@@ -465,9 +465,9 @@ TEST_F(MidiControllerTest, ReceiveMessage_PotMeterCO_7BitCC) {
 TEST_F(MidiControllerTest, ReceiveMessage_PotMeterCO_14BitCC) {
     ConfigKey key("[Channel1]", "playposition");
 
-    const double kMinValue = -1234.5;
-    const double kMaxValue = 678.9;
-    const double kMiddleValue = (kMinValue + kMaxValue) * 0.5;
+    constexpr double kMinValue = -1234.5;
+    constexpr double kMaxValue = 678.9;
+    constexpr double kMiddleValue = (kMinValue + kMaxValue) * 0.5;
     ControlPotmeter potmeter(key, kMinValue, kMaxValue);
     potmeter.set(0);
 
@@ -559,9 +559,9 @@ TEST_F(MidiControllerTest, ReceiveMessage_PotMeterCO_14BitCC) {
 TEST_F(MidiControllerTest, ReceiveMessage_PotMeterCO_14BitPitchBend) {
     ConfigKey key("[Channel1]", "rate");
 
-    const double kMinValue = -1234.5;
-    const double kMaxValue = 678.9;
-    const double kMiddleValue = (kMinValue + kMaxValue) * 0.5;
+    constexpr double kMinValue = -1234.5;
+    constexpr double kMaxValue = 678.9;
+    constexpr double kMiddleValue = (kMinValue + kMaxValue) * 0.5;
     ControlPotmeter potmeter(key, kMinValue, kMaxValue);
     unsigned char channel = 0x01;
 

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -268,7 +268,7 @@ TEST_F(SoundSourceProxyTest, TOAL_TPE2) {
 }
 
 TEST_F(SoundSourceProxyTest, seekForwardBackward) {
-    const SINT kReadFrameCount = 10000;
+    constexpr SINT kReadFrameCount = 10000;
 
     const QStringList filePaths = getFilePaths();
     for (const auto& filePath : filePaths) {
@@ -478,7 +478,7 @@ TEST_F(SoundSourceProxyTest, skipAndRead) {
 }
 
 TEST_F(SoundSourceProxyTest, seekBoundaries) {
-    const SINT kReadFrameCount = 1000;
+    constexpr SINT kReadFrameCount = 1000;
     const QStringList filePaths = getFilePaths();
     for (const auto& filePath : filePaths) {
         ASSERT_TRUE(SoundSourceProxy::isFileNameSupported(filePath));
@@ -591,7 +591,7 @@ TEST_F(SoundSourceProxyTest, seekBoundaries) {
 }
 
 TEST_F(SoundSourceProxyTest, readBeyondEnd) {
-    const SINT kReadFrameCount = 1000;
+    constexpr SINT kReadFrameCount = 1000;
     const QStringList filePaths = getFilePaths();
     for (const auto& filePath : filePaths) {
         ASSERT_TRUE(SoundSourceProxy::isFileNameSupported(filePath));

--- a/src/track/taglib/trackmetadata_id3v2.cpp
+++ b/src/track/taglib/trackmetadata_id3v2.cpp
@@ -31,7 +31,7 @@ namespace {
 // i.e. only 3 instead of 4 characters.
 // https://en.wikipedia.org/wiki/ID3#ID3v2
 // http://id3.org/Developer%20Information
-const unsigned int kMinVersion = 3;
+constexpr unsigned int kMinVersion = 3;
 
 bool checkHeaderVersionSupported(
         const TagLib::ID3v2::Header& header) {

--- a/src/util/battery/battery.cpp
+++ b/src/util/battery/battery.cpp
@@ -16,7 +16,7 @@
 #include "util/math.h"
 
 // interval (in ms) of the timer which calls update()
-const int kiUpdateInterval = 5000;
+constexpr int kiUpdateInterval = 5000;
 
 Battery::Battery(QObject* parent)
         : QObject(parent),
@@ -44,7 +44,7 @@ Battery* Battery::getBattery(QObject* parent) {
 }
 
 void Battery::update() {
-    const double kPercentageEpsilon = 0.1;
+    constexpr double kPercentageEpsilon = 0.1;
     double lastPercentage = m_dPercentage;
     int lastMinutesLeft = m_iMinutesLeft;
     ChargingState lastChargingState = m_chargingState;

--- a/src/util/color/color.cpp
+++ b/src/util/color/color.cpp
@@ -19,9 +19,9 @@ int brightness(int red, int green, int blue) {
 // returns a lighter color, otherwise returns a darker color.
 QColor chooseContrastColor(QColor baseColor, int dimBrightThreshold) {
     // Will produce a color that is 60% brighter.
-    static const int iLighterFactor = 160;
+    static constexpr int iLighterFactor = 160;
     // We consider a hsv color dark if its value is <= 20% of max value
-    static const int iMinimumValue = 20 * 255 / 100;
+    static constexpr int iMinimumValue = 20 * 255 / 100;
 
     // Convert to Hsv to make sure the conversion only happens once.
     // QColor::darker() and QColor::lighter() internally convert from and to Hsv if the color is not already in Hsv.

--- a/src/util/db/dbfieldindex.h
+++ b/src/util/db/dbfieldindex.h
@@ -4,7 +4,7 @@
 // field indices of QSqlRecord.
 class DbFieldIndex {
 public:
-    static const int INVALID_INDEX = -1;
+    static constexpr int INVALID_INDEX = -1;
 
     // Implicit conversion from int
     DbFieldIndex(int index = INVALID_INDEX)

--- a/src/util/db/dbid.h
+++ b/src/util/db/dbid.h
@@ -107,7 +107,7 @@ public:
     }
 
 private:
-    static const value_type kInvalidValue = -1;
+  static constexpr value_type kInvalidValue = -1;
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     static const QMetaType::Type kVariantType;

--- a/src/util/defs.h
+++ b/src/util/defs.h
@@ -2,6 +2,6 @@
 
 // Maximum buffer length to each EngineObject::process call.
 //TODO: Replace this with mixxx::AudioParameters::bufferSize()
-const unsigned int MAX_BUFFER_LEN = 160000;
+constexpr unsigned int MAX_BUFFER_LEN = 160000;
 
-const int kMaxNumberOfDecks = 4;
+constexpr int kMaxNumberOfDecks = 4;

--- a/src/util/duration.cpp
+++ b/src/util/duration.cpp
@@ -11,9 +11,9 @@ namespace mixxx {
 
 namespace {
 
-static const qint64 kSecondsPerMinute = 60;
-static const qint64 kSecondsPerHour = 60 * kSecondsPerMinute;
-static const qint64 kSecondsPerDay = 24 * kSecondsPerHour;
+static constexpr qint64 kSecondsPerMinute = 60;
+static constexpr qint64 kSecondsPerHour = 60 * kSecondsPerMinute;
+static constexpr qint64 kSecondsPerDay = 24 * kSecondsPerHour;
 
 } // namespace
 

--- a/src/util/path.h
+++ b/src/util/path.h
@@ -3,7 +3,7 @@
 #ifndef PATH_MAX
 #ifndef MAX_PATH
 // http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247%28v=vs.85%29.aspx
-const int MAX_PATH = 260;
+constexpr int MAX_PATH = 260;
 #endif
 // Use POSIX name for MAX_PATH
 enum {

--- a/src/util/rlimit.cpp
+++ b/src/util/rlimit.cpp
@@ -9,7 +9,7 @@ extern "C" {
 
 // TODO(xxx) this is the result from a calculation inside PortAudio
 // We should query the value from PA or do the same calculations
-const rlim_t PA_RTPRIO = 82; // PA sets RtPrio = 82
+constexpr rlim_t PA_RTPRIO = 82; // PA sets RtPrio = 82
 
 // static
 unsigned int RLimit::getCurRtPrio() {

--- a/src/util/rotary.cpp
+++ b/src/util/rotary.cpp
@@ -2,7 +2,7 @@
 
 #include <QtDebug>
 
-const int kiRotaryFilterMaxLen = 50;
+constexpr int kiRotaryFilterMaxLen = 50;
 
 Rotary::Rotary()
     : m_iFilterPos(0),

--- a/src/util/statsmanager.cpp
+++ b/src/util/statsmanager.cpp
@@ -10,8 +10,8 @@
 #include "util/compatibility/qmutex.h"
 
 // In practice we process stats pipes about once a minute @1ms latency.
-const int kStatsPipeSize = 1 << 10;
-const int kProcessLength = kStatsPipeSize * 4 / 5;
+constexpr int kStatsPipeSize = 1 << 10;
+constexpr int kProcessLength = kStatsPipeSize * 4 / 5;
 
 // static
 bool StatsManager::s_bStatsManagerEnabled = false;

--- a/src/vinylcontrol/defs_vinylcontrol.h
+++ b/src/vinylcontrol/defs_vinylcontrol.h
@@ -3,10 +3,10 @@
 #define VINYL_PREF_KEY "[VinylControl]"
 
 const QString kVCGroup = QString("[Channel%1]");
-const int VINYL_STATUS_DISABLED = 0;
-const int VINYL_STATUS_OK = 1;
-const int VINYL_STATUS_WARNING = 2;
-const int VINYL_STATUS_ERROR = 3;
+constexpr int VINYL_STATUS_DISABLED = 0;
+constexpr int VINYL_STATUS_OK = 1;
+constexpr int VINYL_STATUS_WARNING = 2;
+constexpr int VINYL_STATUS_ERROR = 3;
 
 #define MIXXX_VINYL_FINALSCRATCH "Final Scratch (crappy)"  // Not currently used
 #define MIXXX_VINYL_MIXVIBESDVS "MixVibes DVS V2 Vinyl"
@@ -44,4 +44,4 @@ const int VINYL_STATUS_ERROR = 3;
 #define MIXXX_VINYL_SCOPE_UPDATE_LATENCY_MS 66
 #define MIXXX_VINYL_SCOPE_SIZE 100
 
-const int kMaximumVinylControlInputs = 4;
+constexpr int kMaximumVinylControlInputs = 4;

--- a/src/vinylcontrol/vinylcontrolprocessor.cpp
+++ b/src/vinylcontrol/vinylcontrolprocessor.cpp
@@ -225,7 +225,7 @@ void VinylControlProcessor::receiveBuffer(const AudioInput& input,
         return;
     }
 
-    const int kChannels = 2;
+    constexpr int kChannels = 2;
     const int nSamples = nFrames * kChannels;
     int samplesWritten = pSamplePipe->write(pBuffer, nSamples);
 

--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -21,7 +21,7 @@ constexpr int kChannels = 2;
 } // namespace
 
 // Sample threshold below which we consider there to be no signal.
-const double kMinSignal = 75.0 / SAMPLE_MAXIMUM;
+constexpr double kMinSignal = 75.0 / SAMPLE_MAXIMUM;
 
 bool VinylControlXwax::s_bLUTInitialized = false;
 QMutex VinylControlXwax::s_xwaxLUTMutex;
@@ -685,8 +685,8 @@ void VinylControlXwax::doTrackSelection(bool valid_pos, double pitch, double pos
     //track will be selected when the needle is moved back to play area
     //track selection can be cancelled by loading a track manually
 
-    const int SELECT_INTERVAL = 150;
-    const double NOPOS_SPEED = 0.50;
+    constexpr int SELECT_INTERVAL = 150;
+    constexpr double NOPOS_SPEED = 0.50;
 
     if (m_pControlTrackSelector == nullptr) {
         // this isn't done in the constructor because this object

--- a/src/waveform/renderers/waveformrendererendoftrack.h
+++ b/src/waveform/renderers/waveformrendererendoftrack.h
@@ -15,7 +15,7 @@ class ControlProxy;
 
 class WaveformRendererEndOfTrack : public WaveformRendererAbstract {
   public:
-    static const int s_maxAlpha = 125;
+    static constexpr int s_maxAlpha = 125;
     explicit WaveformRendererEndOfTrack(
             WaveformWidgetRenderer* waveformWidgetRenderer);
     virtual ~WaveformRendererEndOfTrack();

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -17,8 +17,8 @@
 #include "widget/wwidget.h"
 
 namespace {
-    const int kMaxCueLabelLength = 23;
-    } // namespace
+constexpr int kMaxCueLabelLength = 23;
+} // namespace
 
 WaveformRenderMark::WaveformRenderMark(
         WaveformWidgetRenderer* waveformWidgetRenderer) :
@@ -270,8 +270,8 @@ void WaveformRenderMark::generateMarkImage(WaveformMarkPointer pMark) {
 
     //fixed margin ...
     QRect wordRect = metrics.tightBoundingRect(label);
-    const int marginX = 1;
-    const int marginY = 1;
+    constexpr int marginX = 1;
+    constexpr int marginY = 1;
     wordRect.moveTop(marginX + 1);
     wordRect.moveLeft(marginY + 1);
     wordRect.setHeight(wordRect.height() + (wordRect.height() % 2));

--- a/src/waveform/renderers/waveformsignalcolors.cpp
+++ b/src/waveform/renderers/waveformsignalcolors.cpp
@@ -132,7 +132,7 @@ void WaveformSignalColors::fallBackFromSignalColor() {
     qreal h, s, l, a;
     m_signalColor.getHslF(&h,&s,&l,&a);
 
-    const double analogousAngle = 1.0/12.0;
+    constexpr double analogousAngle = 1.0 / 12.0;
 
     if (s < 0.1) { // gray
         const qreal sMax = 1.0 - h;

--- a/src/waveform/visualsmanager.h
+++ b/src/waveform/visualsmanager.h
@@ -12,9 +12,9 @@
 namespace {
 
 // Rate at which the playpos slider is updated
-const int kUpdateRate = 15; // updates per second
+constexpr int kUpdateRate = 15; // updates per second
 // Number of kiUpdateRates that go by before we update BPM.
-const int kSlowUpdateDivider = 4; // kUpdateRate / kSlowUpdateDivider = 3.75 updates per sec
+constexpr int kSlowUpdateDivider = 4; // kUpdateRate / kSlowUpdateDivider = 3.75 updates per sec
 
 } // anonymous namespace
 

--- a/src/waveform/waveform.cpp
+++ b/src/waveform/waveform.cpp
@@ -5,7 +5,7 @@
 
 using namespace mixxx::track;
 
-const int kNumChannels = 2;
+constexpr int kNumChannels = 2;
 
 // Return the smallest power of 2 which is greater than the desired size when
 // squared.

--- a/src/waveform/waveformmarklabel.cpp
+++ b/src/waveform/waveformmarklabel.cpp
@@ -16,7 +16,7 @@ void WaveformMarkLabel::prerender(QPointF bottomLeft,
 
     m_text = text;
     QFontMetrics fontMetrics(font);
-    const int padding = 2;
+    constexpr int padding = 2;
 
     QRectF pixmapRect;
     pixmapRect = fontMetrics.boundingRect(text);

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -10,7 +10,7 @@
 #include "moc_wlibrarysidebar.cpp"
 #include "util/dnd.h"
 
-const int expand_time = 250;
+constexpr int expand_time = 250;
 
 WLibrarySidebar::WLibrarySidebar(QWidget* parent)
         : QTreeView(parent),

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -14,7 +14,7 @@
 
 namespace {
 
-const int kMaxLoadToDeckActions = 4;
+constexpr int kMaxLoadToDeckActions = 4;
 
 QString buildWhatsThis(const QString& title, const QString& text) {
     QString preparedTitle = title;

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -1234,8 +1234,8 @@ void WOverview::resizeEvent(QResizeEvent* pEvent) {
     Q_UNUSED(pEvent);
     // Play-position potmeters range from 0 to 1 but they allow out-of-range
     // sets. This is to give VC access to the pre-roll area.
-    const double kMaxPlayposRange = 1.0;
-    const double kMinPlayposRange = 0.0;
+    constexpr double kMaxPlayposRange = 1.0;
+    constexpr double kMinPlayposRange = 0.0;
 
     // Values of zero and one in normalized space.
     const double zero = (0.0 - kMinPlayposRange) / (kMaxPlayposRange - kMinPlayposRange);

--- a/src/widget/wtime.h
+++ b/src/widget/wtime.h
@@ -28,6 +28,6 @@ class WTime: public WLabel {
     short m_iInterval;
     // m_iInterval is set to s_iSecondInterval if seconds are shown
     // otherwise, m_iInterval = s_iMinuteInterval
-    static const short s_iSecondInterval = 100;
-    static const short s_iMinuteInterval = 1000;
+    static constexpr short s_iSecondInterval = 100;
+    static constexpr short s_iMinuteInterval = 1000;
 };


### PR DESCRIPTION
As encouraged and suggested in Mixxx's Coding Guidelines:

---
**constexpr**

Use whenever possible, [...]

---
https://github.com/mixxxdj/mixxx/wiki/Coding%20Guidelines#constexpr