### PR TITLE
Changed beatloop_activate button behaviour to match lp1876003

### DIFF
--- a/res/skins/Deere/deck_looping_controls.xml
+++ b/res/skins/Deere/deck_looping_controls.xml
@@ -25,7 +25,7 @@
           <!-- Workaround for layout spacing -->
           <WidgetGroup><Size>1f,0min</Size></WidgetGroup>
 
-          <Template src="skin:left_right_2state_button.xml">
+          <Template src="skin:left_right_display_2state_button.xml">
             <SetVariable name="TooltipId">beatloop_activate</SetVariable>
             <SetVariable name="ObjectName">BeatloopActivate</SetVariable>
             <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -39,6 +39,7 @@
             <SetVariable name="state_1_unpressed">icon/ic_beatloop_activate_48px.svg</SetVariable>
             <SetVariable name="left_connection_control"><Variable name="group"/>,beatloop_activate</SetVariable>
             <SetVariable name="right_connection_control"><Variable name="group"/>,beatlooproll_activate</SetVariable>
+            <SetVariable name="display_connection_control"><Variable name="group"/>,loop_enabled</SetVariable>
           </Template>
 
         </Children>
@@ -84,7 +85,7 @@
           <!-- Workaround for layout spacing -->
           <WidgetGroup><Size>5f,0min</Size></WidgetGroup>
 
-          <Template src="skin:left_right_display_2state_button.xml">
+          <Template src="skin:left_right_2state_button.xml">
             <SetVariable name="TooltipId">reloop_toggle</SetVariable>
             <SetVariable name="ObjectName">Reloop</SetVariable>
             <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -98,7 +99,6 @@
             <SetVariable name="state_1_unpressed">icon/ic_loop_48px.svg</SetVariable>
             <SetVariable name="left_connection_control"><Variable name="group"/>,reloop_toggle</SetVariable>
             <SetVariable name="right_connection_control"><Variable name="group"/>,reloop_andstop</SetVariable>
-            <SetVariable name="display_connection_control"><Variable name="group"/>,loop_enabled</SetVariable>
           </Template>
 
         </Children>

--- a/res/skins/LateNight/decks/row_5_transportLoopJump.xml
+++ b/res/skins/LateNight/decks/row_5_transportLoopJump.xml
@@ -237,12 +237,13 @@
                 <Layout>horizontal</Layout>
                 <SizePolicy>min,max</SizePolicy>
                 <Children>
-                  <Template src="skin:/controls/button_2state_right.xml">
+                  <Template src="skin:/controls/button_2state_right_display.xml">
                     <SetVariable name="TooltipId">beatloop_activate</SetVariable>
                     <SetVariable name="ObjectName">LoopActivate</SetVariable>
                     <SetVariable name="Size">26f,26f</SetVariable>
                     <SetVariable name="ConfigKey"><Variable name="Group"/>,beatloop_activate</SetVariable>
                     <SetVariable name="ConfigKeyRight"><Variable name="Group"/>,beatlooproll_activate</SetVariable>
+                    <SetVariable name="ConfigKeyDisp"><Variable name="Group"/>,loop_enabled</SetVariable>
                   </Template>
 
                   <BeatSpinBox>
@@ -266,13 +267,12 @@
                 <Layout>horizontal</Layout>
                 <SizePolicy>min,max</SizePolicy>
                 <Children>
-                  <Template src="skin:/controls/button_2state_right_display.xml">
+                  <Template src="skin:/controls/button_2state_right.xml">
                     <SetVariable name="TooltipId">reloop_toggle</SetVariable>
                     <SetVariable name="ObjectName">Reloop</SetVariable>
                     <SetVariable name="Size">26f,26f</SetVariable>
                     <SetVariable name="ConfigKey"><Variable name="Group"/>,reloop_toggle</SetVariable>
                     <SetVariable name="ConfigKeyRight"><Variable name="Group"/>,reloop_andstop</SetVariable>
-                    <SetVariable name="ConfigKeyDisp"><Variable name="Group"/>,loop_enabled</SetVariable>
                   </Template>
 
                   <Template src="skin:/controls/button_1state_right.xml">

--- a/res/skins/Shade/deck_transport.xml
+++ b/res/skins/Shade/deck_transport.xml
@@ -351,6 +351,10 @@
           <ConfigKey>[Channel<Variable name="channum"/>],beatloop_4_enabled</ConfigKey>
           <ConnectValueFromWidget>false</ConnectValueFromWidget>
         </Connection>
+        <Connection>
+          <ConfigKey>[Channel<Variable name="channum"/>],loop_enabled</ConfigKey>
+          <ConnectValueFromWidget>false</ConnectValueFromWidget>
+        </Connection>
       </PushButton>
       <PushButton>
         <TooltipId>reloop_toggle</TooltipId>
@@ -378,10 +382,6 @@
           <EmitOnPressAndRelease>true</EmitOnPressAndRelease>
           <ButtonState>RightButton</ButtonState>
           <ConnectValueToWidget>false</ConnectValueToWidget>
-        </Connection>
-        <Connection>
-          <ConfigKey>[Channel<Variable name="channum"/>],loop_enabled</ConfigKey>
-          <ConnectValueFromWidget>false</ConnectValueFromWidget>
         </Connection>
       </PushButton>
 

--- a/res/skins/Shade/looping.xml
+++ b/res/skins/Shade/looping.xml
@@ -160,10 +160,6 @@
               <ButtonState>RightButton</ButtonState>
               <ConnectValueToWidget>false</ConnectValueToWidget>
             </Connection>
-            <Connection>
-              <ConfigKey>[Channel<Variable name="channum"/>],loop_enabled</ConfigKey>
-              <ConnectValueFromWidget>false</ConnectValueFromWidget>
-            </Connection>
           </PushButton>
 
           <PushButton>

--- a/res/skins/Tango/decks/loop_controls.xml
+++ b/res/skins/Tango/decks/loop_controls.xml
@@ -21,7 +21,7 @@ Variables:
 
           <WidgetGroup><Size>3f,1min</Size></WidgetGroup>
 
-          <Template src="skin:../Tango/controls/button_2state_right.xml">
+          <Template src="skin:../Tango/controls/button_2state_right_display.xml">
             <SetVariable name="TooltipId">beatloop_activate</SetVariable>
             <SetVariable name="ObjectName">LoopActivateButton</SetVariable>
             <SetVariable name="Size">30f,22f</SetVariable>
@@ -29,6 +29,7 @@ Variables:
             <SetVariable name="state_1_icon">loop_on.svg</SetVariable>
             <SetVariable name="ConfigKey"><Variable name="group"/>,beatloop_activate</SetVariable>
             <SetVariable name="ConfigKeyRight"><Variable name="group"/>,beatlooproll_activate</SetVariable>
+            <SetVariable name="ConfigKeyDisp"><Variable name="group"/>,loop_enabled</SetVariable>
           </Template>
 
           <WidgetGroup><Size>2f,1min</Size></WidgetGroup>
@@ -52,7 +53,7 @@ Variables:
             <Layout>horizontal</Layout>
             <SizePolicy>f,min</SizePolicy>
             <Children>
-              <Template src="skin:../Tango/controls/button_2state_right_display.xml">
+              <Template src="skin:../Tango/controls/button_2state_right.xml">
                 <SetVariable name="TooltipId">reloop_toggle</SetVariable>
                 <SetVariable name="ObjectName">ReloopButton</SetVariable>
                 <SetVariable name="Size">22f,22f</SetVariable>
@@ -60,7 +61,6 @@ Variables:
                 <SetVariable name="state_1_icon">reloop_on.svg</SetVariable>
                 <SetVariable name="ConfigKey"><Variable name="group"/>,reloop_toggle</SetVariable>
                 <SetVariable name="ConfigKeyRight"><Variable name="group"/>,reloop_andstop</SetVariable>
-                <SetVariable name="ConfigKeyDisp"><Variable name="group"/>,loop_enabled</SetVariable>
               </Template>
 
               <WidgetGroup><Size>1f,1min</Size></WidgetGroup>

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -1161,7 +1161,13 @@ void LoopingControl::slotBeatLoopSizeChangeRequest(double beats) {
 
 void LoopingControl::slotBeatLoopToggle(double pressed) {
     if (pressed > 0) {
-        slotBeatLoop(m_pCOBeatLoopSize->get());
+        if (m_bLoopingEnabled) {
+            // Deactivate the loop if we're already looping
+            setLoopingEnabled(false);
+        } else {
+            // Create a loop at current position
+            slotBeatLoop(m_pCOBeatLoopSize->get());
+        }
     }
 }
 

--- a/src/test/looping_control_test.cpp
+++ b/src/test/looping_control_test.cpp
@@ -638,8 +638,8 @@ TEST_F(LoopingControlTest, BeatLoopSize_SetAndToggle) {
 
     m_pButtonBeatLoopActivate->set(1.0);
     m_pButtonBeatLoopActivate->set(0.0);
-    EXPECT_TRUE(m_pLoopEnabled->toBool());
-    EXPECT_TRUE(m_pBeatLoop2Enabled->toBool());
+    EXPECT_FALSE(m_pLoopEnabled->toBool());
+    EXPECT_FALSE(m_pBeatLoop2Enabled->toBool());
 }
 
 TEST_F(LoopingControlTest, BeatLoopSize_SetWithoutTrackLoaded) {
@@ -684,8 +684,8 @@ TEST_F(LoopingControlTest, BeatLoopSize_IsSetByNumberedControl) {
 
     m_pButtonBeatLoopActivate->set(1.0);
     m_pButtonBeatLoopActivate->set(0.0);
-    EXPECT_TRUE(m_pBeatLoop2Enabled->toBool());
-    EXPECT_TRUE(m_pLoopEnabled->toBool());
+    EXPECT_FALSE(m_pBeatLoop2Enabled->toBool());
+    EXPECT_FALSE(m_pLoopEnabled->toBool());
     EXPECT_EQ(2.0, m_pBeatLoopSize->get());
 }
 


### PR DESCRIPTION
Changed beatloop_activate behaviour to:

- if a loop is active, deactivate it
- if no loop is active, activate a beatloop at the current playback position

As discussed in https://bugs.launchpad.net/mixxx/+bug/1876003