### PR TITLE
add [Library],clear_search

### DIFF
--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -742,6 +742,13 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             libraryMenu,
             false,
             m_libraryStr);
+    addControl("[Library]",
+            "clear_search",
+            tr("Clear search"),
+            tr("Clears the search query"),
+            libraryMenu,
+            false,
+            m_libraryStr);
 
     libraryMenu->addSeparator();
     addControl("[Recording]", "toggle_recording",

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -213,13 +213,9 @@ LibraryControl::LibraryControl(Library* pLibrary)
             this,
             &LibraryControl::slotTrackColorNext);
 
-    // Control to navigate between widgets (tab/shit+tab button)
+    // Controls to select saved searchbox queries and to clear the searchbox
     m_pSelectHistoryNext = std::make_unique<ControlPushButton>(
             ConfigKey("[Library]", "search_history_next"));
-    m_pSelectHistoryPrev = std::make_unique<ControlPushButton>(
-            ConfigKey("[Library]", "search_history_prev"));
-    m_pSelectHistorySelect = std::make_unique<ControlEncoder>(
-            ConfigKey("[Library]", "search_history_selector"), false);
     connect(m_pSelectHistoryNext.get(),
             &ControlPushButton::valueChanged,
             this,
@@ -227,10 +223,12 @@ LibraryControl::LibraryControl(Library* pLibrary)
                 VERIFY_OR_DEBUG_ASSERT(m_pSearchbox) {
                     return;
                 }
-                if (value >= 1.0) {
+                if (value > 0.0) {
                     m_pSearchbox->slotMoveSelectedHistory(1);
                 }
             });
+    m_pSelectHistoryPrev = std::make_unique<ControlPushButton>(
+            ConfigKey("[Library]", "search_history_prev"));
     connect(m_pSelectHistoryPrev.get(),
             &ControlPushButton::valueChanged,
             this,
@@ -238,10 +236,12 @@ LibraryControl::LibraryControl(Library* pLibrary)
                 VERIFY_OR_DEBUG_ASSERT(m_pSearchbox) {
                     return;
                 }
-                if (value >= 1.0) {
+                if (value > 0.0) {
                     m_pSearchbox->slotMoveSelectedHistory(-1);
                 }
             });
+    m_pSelectHistorySelect = std::make_unique<ControlEncoder>(
+            ConfigKey("[Library]", "search_history_selector"), false);
     connect(m_pSelectHistorySelect.get(),
             &ControlEncoder::valueChanged,
             this,
@@ -249,8 +249,22 @@ LibraryControl::LibraryControl(Library* pLibrary)
                 VERIFY_OR_DEBUG_ASSERT(m_pSearchbox) {
                     return;
                 }
-                if (steps >= 1.0 || steps <= -1.0) {
+                int iSteps = static_cast<int>(steps);
+                if (iSteps) {
                     m_pSearchbox->slotMoveSelectedHistory(static_cast<int>(steps));
+                }
+            });
+    m_pClearSearch = std::make_unique<ControlPushButton>(
+            ConfigKey("[Library]", "clear_search"));
+    connect(m_pClearSearch.get(),
+            &ControlPushButton::valueChanged,
+            this,
+            [this](double value) {
+                VERIFY_OR_DEBUG_ASSERT(m_pSearchbox) {
+                    return;
+                }
+                if (value > 0.0) {
+                    m_pSearchbox->slotClearSearch();
                 }
             });
 

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -147,6 +147,7 @@ class LibraryControl : public QObject {
     std::unique_ptr<ControlPushButton> m_pSelectHistoryNext;
     std::unique_ptr<ControlPushButton> m_pSelectHistoryPrev;
     std::unique_ptr<ControlEncoder> m_pSelectHistorySelect;
+    std::unique_ptr<ControlPushButton> m_pClearSearch;
 
     // Font sizes
     std::unique_ptr<ControlPushButton> m_pFontSizeIncrement;

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -430,7 +430,8 @@ void WSearchLineEdit::slotSaveSearch() {
 
 void WSearchLineEdit::slotMoveSelectedHistory(int steps) {
     int nIndex = currentIndex() + steps;
-    // we wrap around to the last entry on backwards direction
+    // at the top we manually wrap around to the last entry.
+    // at the bottom wrap-around happens automatically due to invalid nIndex.
     if (nIndex < -1) {
         nIndex = count() - 1;
     }


### PR DESCRIPTION
(noticed when adding the controls documentation to the manual)

add `[Library],clear_search` to complete the searchbox controls set.
the search can also be cleared by scrolling to the top, but that easily overshots and wraps around.
Also a direct control is simpler than scroling through a list (for the same reason I argue the Clear button should be focusable by `MoveFocus`)