### PR TITLE
Revert "BeatGrid: Remove fuzzy behavior from findNthBeat"

### DIFF
--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -97,6 +97,98 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat) {
     EXPECT_NEAR(position.value(), pGrid->findPrevBeat(position).value(), kMaxBeatError);
 }
 
+TEST(BeatGridTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
+    constexpr int sampleRate = 44100;
+    TrackPointer pTrack = newTrack(sampleRate);
+
+    constexpr double bpm = 60.1;
+    pTrack->trySetBpm(bpm);
+    constexpr double beatLengthFrames = 60.0 * sampleRate / bpm;
+
+    auto pGrid = Beats::fromConstTempo(pTrack->getSampleRate(),
+            mixxx::audio::kStartFramePos,
+            mixxx::Bpm(bpm));
+
+    // Pretend we're just before the 20th beat.
+    constexpr mixxx::audio::FramePos kClosestBeat(20 * beatLengthFrames);
+    const mixxx::audio::FramePos position(kClosestBeat - beatLengthFrames * 0.005);
+
+    // The spec dictates that a value of 0 is always invalid and returns an invalid position
+    EXPECT_FALSE(pGrid->findNthBeat(position, 0).isValid());
+
+    // findNthBeat should return exactly the current beat if we ask for 1 or
+    // -1. For all other values, it should return n times the beat length.
+    for (int i = 1; i < 20; ++i) {
+        EXPECT_NEAR((kClosestBeat + beatLengthFrames * (i - 1)).value(),
+                pGrid->findNthBeat(position, i).value(),
+                kMaxBeatError);
+        EXPECT_NEAR((kClosestBeat + beatLengthFrames * (-i + 1)).value(),
+                pGrid->findNthBeat(position, -i).value(),
+                kMaxBeatError);
+    }
+
+    // Also test prev/next beat calculation.
+    mixxx::audio::FramePos prevBeat, nextBeat;
+    pGrid->findPrevNextBeats(position, &prevBeat, &nextBeat, true);
+    EXPECT_NEAR(kClosestBeat.value(), prevBeat.value(), kMaxBeatError);
+    EXPECT_NEAR((kClosestBeat + beatLengthFrames).value(), nextBeat.value(), kMaxBeatError);
+
+    // Also test prev/next beat calculation without snapping tolerance
+    pGrid->findPrevNextBeats(position, &prevBeat, &nextBeat, false);
+    EXPECT_NEAR((kClosestBeat - beatLengthFrames).value(), prevBeat.value(), kMaxBeatError);
+    EXPECT_NEAR(kClosestBeat.value(), nextBeat.value(), kMaxBeatError);
+
+    // Both previous and next beat should return the closest beat.
+    EXPECT_NEAR(kClosestBeat.value(), pGrid->findNextBeat(position).value(), kMaxBeatError);
+    EXPECT_NEAR(kClosestBeat.value(), pGrid->findPrevBeat(position).value(), kMaxBeatError);
+}
+
+TEST(BeatGridTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
+    constexpr int sampleRate = 44100;
+    TrackPointer pTrack = newTrack(sampleRate);
+
+    constexpr double bpm = 60.1;
+    pTrack->trySetBpm(bpm);
+    constexpr double beatLengthFrames = 60.0 * sampleRate / bpm;
+
+    auto pGrid = Beats::fromConstTempo(pTrack->getSampleRate(),
+            mixxx::audio::kStartFramePos,
+            mixxx::Bpm(bpm));
+
+    // Pretend we're just before the 20th beat.
+    constexpr mixxx::audio::FramePos kClosestBeat(20 * beatLengthFrames);
+    const mixxx::audio::FramePos position(kClosestBeat + beatLengthFrames * 0.005);
+
+    // The spec dictates that a value of 0 is always invalid and returns an invalid position
+    EXPECT_FALSE(pGrid->findNthBeat(position, 0).isValid());
+
+    // findNthBeat should return exactly the current beat if we ask for 1 or
+    // -1. For all other values, it should return n times the beat length.
+    for (int i = 1; i < 20; ++i) {
+        EXPECT_NEAR((kClosestBeat + beatLengthFrames * (i - 1)).value(),
+                pGrid->findNthBeat(position, i).value(),
+                kMaxBeatError);
+        EXPECT_NEAR((kClosestBeat + beatLengthFrames * (-i + 1)).value(),
+                pGrid->findNthBeat(position, -i).value(),
+                kMaxBeatError);
+    }
+
+    // Also test prev/next beat calculation.
+    mixxx::audio::FramePos prevBeat, nextBeat;
+    pGrid->findPrevNextBeats(position, &prevBeat, &nextBeat, true);
+    EXPECT_NEAR(kClosestBeat.value(), prevBeat.value(), kMaxBeatError);
+    EXPECT_NEAR((kClosestBeat + beatLengthFrames).value(), nextBeat.value(), kMaxBeatError);
+
+    // Also test prev/next beat calculation without snapping tolerance
+    pGrid->findPrevNextBeats(position, &prevBeat, &nextBeat, false);
+    EXPECT_NEAR(kClosestBeat.value(), prevBeat.value(), kMaxBeatError);
+    EXPECT_NEAR((kClosestBeat + beatLengthFrames).value(), nextBeat.value(), kMaxBeatError);
+
+    // Both previous and next beat should return the closest beat.
+    EXPECT_NEAR(kClosestBeat.value(), pGrid->findNextBeat(position).value(), kMaxBeatError);
+    EXPECT_NEAR(kClosestBeat.value(), pGrid->findPrevBeat(position).value(), kMaxBeatError);
+}
+
 TEST(BeatGridTest, TestNthBeatWhenNotOnBeat) {
     constexpr int sampleRate = 44100;
     TrackPointer pTrack = newTrack(sampleRate);

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -147,9 +147,27 @@ audio::FramePos BeatGrid::findNthBeat(audio::FramePos position, int n) const {
         return audio::kInvalidFramePos;
     }
 
-    const double beatFraction = (position - firstBeatPosition()) / m_beatLengthFrames;
-    const double prevBeat = floor(beatFraction);
-    const double nextBeat = ceil(beatFraction);
+    double beatFraction = (position - firstBeatPosition()) / m_beatLengthFrames;
+    double prevBeat = floor(beatFraction);
+    double nextBeat = ceil(beatFraction);
+
+    // If the position is within 1/100th of the next or previous beat, treat it
+    // as if it is that beat.
+    const double kEpsilon = .01;
+
+    if (fabs(nextBeat - beatFraction) < kEpsilon) {
+        // If we are going to pretend we were actually on nextBeat then prevBeat
+        // needs to be re-calculated. Since it is floor(beatFraction), that's
+        // the same as nextBeat.  We only use prevBeat so no need to increment
+        // nextBeat.
+        prevBeat = nextBeat;
+    } else if (fabs(prevBeat - beatFraction) < kEpsilon) {
+        // If we are going to pretend we were actually on prevBeat then nextBeat
+        // needs to be re-calculated. Since it is ceil(beatFraction), that's
+        // the same as prevBeat.  We will only use nextBeat so no need to
+        // decrement prevBeat.
+        nextBeat = prevBeat;
+    }
 
     audio::FramePos closestBeatPosition;
     if (n > 0) {


### PR DESCRIPTION
This reverts commit 95f7d36647a6df05c413d5f37f1ce878653a3ce0.

Due to floating point inaccuracy, it's not a good idea to blindly round beat positions without some amount of fuzz.  The reverted change caused https://bugs.launchpad.net/mixxx/+bug/1945238