### PR TITLE
blink overview waveform in end-of-track range

### DIFF
--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -562,6 +562,7 @@ void WaveformWidgetFactory::setEndOfTrackWarningTime(int endTime) {
     if (m_config) {
         m_config->setValue(kEndOfTrackWarningKey, m_endOfTrackWarningTime);
     }
+    emit endOfTrackTimeChanged(endTime);
 }
 
 bool WaveformWidgetFactory::setWidgetType(WaveformWidgetType::Type type) {

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -238,6 +238,7 @@ class WaveformWidgetFactory : public QObject,
     void swapSpinnies();
     void renderVuMeters(VSyncThread*);
     void swapVuMeters();
+    void endOfTrackTimeChanged(int time);
 
     void overviewScalingChanged();
     void visualGainChanged(double allChannelGain, double lowGain, double midGain, double highGain);

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -1533,8 +1533,16 @@ double WOverview::samplePositionToSeconds(double sample) {
     }
 
     double trackTime = sample /
+<<<<<<< HEAD
             (m_trackSampleRateControl.get() * mixxx::kEngineChannelOutputCount);
     return trackTime / rate;
+||||||| parent of 34842c5d70 (WOverview: make ControlProxies parented_ptr, use PollingControlProxy)
+            (m_trackSampleRateControl->get() * mixxx::kEngineChannelOutputCount);
+    return trackTime / m_pRateRatioControl->get();
+=======
+            (m_trackSampleRateControl.get() * mixxx::kEngineChannelOutputCount);
+    return trackTime / m_pRateRatioControl->get();
+>>>>>>> 34842c5d70 (WOverview: make ControlProxies parented_ptr, use PollingControlProxy)
 }
 
 void WOverview::resizeEvent(QResizeEvent* pEvent) {

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -5,6 +5,8 @@
 #include <QPixmap>
 
 #include "analyzer/analyzerprogress.h"
+#include "control/pollingcontrolproxy.h"
+#include "skin/legacy/skincontext.h"
 #include "track/track_decl.h"
 #include "track/trackid.h"
 #include "util/parented_ptr.h"

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -66,6 +66,7 @@ class WOverview : public WWidget, public TrackDropTarget {
     void onPassthroughChange(double v);
     void onEndOfTrackBlinkTimerChange(double v);
     void receiveCuesUpdated();
+    void setEndOfTrackTime(int time);
 
     void slotWaveformSummaryUpdated();
     void slotCueMenuPopupAboutToHide();

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -161,9 +161,9 @@ class WOverview : public WWidget, public TrackDropTarget {
     int m_iPosSeconds;
     // True if pick-up is dragged. Only used when m_bEventWhileDrag is false
     bool m_bLeftClickDragging;
-    // Internal storage of slider position in pixels
-    int m_iPickupPos;
     // position of the overlay shadow
+    int m_iPickupPos;
+    // Internal storage of slider position in pixels
     int m_iPlayPos;
     bool m_bTimeRulerActive;
     Qt::Orientation m_orientation;

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -64,6 +64,7 @@ class WOverview : public WWidget, public TrackDropTarget {
     void onMarkRangeChange(double v);
     void onRateRatioChange(double v);
     void onPassthroughChange(double v);
+    void onEndOfTrackBlinkTimerChange(double v);
     void receiveCuesUpdated();
 
     void slotWaveformSummaryUpdated();
@@ -155,6 +156,7 @@ class WOverview : public WWidget, public TrackDropTarget {
     float m_diffGain;
     qreal m_devicePixelRatio;
     bool m_endOfTrack;
+    bool m_drawEndOfTrack;
     bool m_bPassthroughEnabled;
 
     parented_ptr<WCueMenuPopup> m_pCueMenuPopup;
@@ -167,6 +169,7 @@ class WOverview : public WWidget, public TrackDropTarget {
     int m_iPickupPos;
     // Internal storage of slider position in pixels
     int m_iPlayPos;
+    int m_endOfTrackWarningTime;
     bool m_bTimeRulerActive;
     Qt::Orientation m_orientation;
     int m_dragMarginH;
@@ -195,6 +198,8 @@ class WOverview : public WWidget, public TrackDropTarget {
     PollingControlProxy m_trackSampleRateControl;
     PollingControlProxy m_trackSamplesControl;
     PollingControlProxy m_playpositionControl;
+    PollingControlProxy m_pTimeRemainingControl;
+    parented_ptr<ControlProxy> m_pEndOfTrackBlinkTimer;
     parented_ptr<ControlProxy> m_pPassthroughControl;
     parented_ptr<ControlProxy> m_pTypeControl;
     parented_ptr<ControlProxy> m_pMinuteMarkersControl;


### PR DESCRIPTION
fixes #9648

- [x] add end-of-track blinking to overview
- [ ] remove blinking from waveform, adjust preferences accordingly

As of now the **e**nd-**o**f-**t**rack blinking is exactly that: on/off
The eot background is always drawn as before, the frame blinks.
Please test how this works for you.

I'll try to implement some kind of fading (fade out), maybe other modes as well.

Code is not polished yet, I'll ring the bell when it is.
Though I appreciate reviews of the general approach.