### PR TITLE
Removed raw array pointer types for std::vector

### DIFF
--- a/src/analyzer/analyzergain.cpp
+++ b/src/analyzer/analyzergain.cpp
@@ -9,15 +9,11 @@
 
 AnalyzerGain::AnalyzerGain(UserSettingsPointer pConfig)
         : m_rgSettings(pConfig),
-          m_pLeftTempBuffer(nullptr),
-          m_pRightTempBuffer(nullptr),
           m_iBufferSize(0) {
     m_pReplayGain = new ReplayGain();
 }
 
 AnalyzerGain::~AnalyzerGain() {
-    delete[] m_pLeftTempBuffer;
-    delete[] m_pRightTempBuffer;
     delete m_pReplayGain;
 }
 
@@ -40,15 +36,16 @@ bool AnalyzerGain::processSamples(const CSAMPLE *pIn, const int iLen) {
 
     int halfLength = static_cast<int>(iLen / 2);
     if (halfLength > m_iBufferSize) {
-        delete[] m_pLeftTempBuffer;
-        delete[] m_pRightTempBuffer;
-        m_pLeftTempBuffer = new CSAMPLE[halfLength];
-        m_pRightTempBuffer = new CSAMPLE[halfLength];
+        m_pLeftTempBuffer.resize(halfLength);
+        m_pRightTempBuffer.resize(halfLength);
     }
-    SampleUtil::deinterleaveBuffer(m_pLeftTempBuffer, m_pRightTempBuffer, pIn, halfLength);
-    SampleUtil::applyGain(m_pLeftTempBuffer, 32767, halfLength);
-    SampleUtil::applyGain(m_pRightTempBuffer, 32767, halfLength);
-    return m_pReplayGain->process(m_pLeftTempBuffer, m_pRightTempBuffer, halfLength);
+    SampleUtil::deinterleaveBuffer(m_pLeftTempBuffer.data(),
+            m_pRightTempBuffer.data(),
+            pIn,
+            halfLength);
+    SampleUtil::applyGain(m_pLeftTempBuffer.data(), 32767, halfLength);
+    SampleUtil::applyGain(m_pRightTempBuffer.data(), 32767, halfLength);
+    return m_pReplayGain->process(m_pLeftTempBuffer.data(), m_pRightTempBuffer.data(), halfLength);
 }
 
 void AnalyzerGain::storeResults(TrackPointer tio) {

--- a/src/analyzer/analyzergain.h
+++ b/src/analyzer/analyzergain.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include "analyzer/analyzer.h"
 #include "preferences/replaygainsettings.h"
 
@@ -30,8 +32,8 @@ class AnalyzerGain : public Analyzer {
 
   private:
     ReplayGainSettings m_rgSettings;
-    CSAMPLE* m_pLeftTempBuffer;
-    CSAMPLE* m_pRightTempBuffer;
+    std::vector<CSAMPLE> m_pLeftTempBuffer;
+    std::vector<CSAMPLE> m_pRightTempBuffer;
     ReplayGain* m_pReplayGain;
     int m_iBufferSize;
 };

--- a/src/effects/lv2/lv2effectprocessor.cpp
+++ b/src/effects/lv2/lv2effectprocessor.cpp
@@ -9,16 +9,15 @@ LV2EffectProcessor::LV2EffectProcessor(EngineEffect* pEngineEffect,
         const LilvPlugin* plugin,
         const QList<int>& audioPortIndices,
         const QList<int>& controlPortIndices)
-        : m_pPlugin(plugin),
+        : m_inputL(MAX_BUFFER_LEN),
+          m_inputR(MAX_BUFFER_LEN),
+          m_outputL(MAX_BUFFER_LEN),
+          m_outputR(MAX_BUFFER_LEN),
+          m_params(pManifest->parameters().size()),
+          m_pPlugin(plugin),
           m_audioPortIndices(audioPortIndices),
           m_controlPortIndices(controlPortIndices),
           m_pEffectsManager(nullptr) {
-    m_inputL = new float[MAX_BUFFER_LEN];
-    m_inputR = new float[MAX_BUFFER_LEN];
-    m_outputL = new float[MAX_BUFFER_LEN];
-    m_outputR = new float[MAX_BUFFER_LEN];
-    m_params = new float[pManifest->parameters().size()];
-
     const QList<EffectManifestParameterPointer>& effectManifestParameterList =
             pManifest->parameters();
 
@@ -51,11 +50,6 @@ LV2EffectProcessor::~LV2EffectProcessor() {
     }
     m_channelStateMatrix.clear();
 
-    delete[] m_inputL;
-    delete[] m_inputR;
-    delete[] m_outputL;
-    delete[] m_outputR;
-    delete[] m_params;
 }
 
 void LV2EffectProcessor::initialize(
@@ -147,10 +141,10 @@ LV2EffectGroupState* LV2EffectProcessor::createGroupState(const mixxx::EnginePar
 
         // We assume the audio ports are in the following order:
         // input_left, input_right, output_left, output_right
-        lilv_instance_connect_port(handle, m_audioPortIndices[0], m_inputL);
-        lilv_instance_connect_port(handle, m_audioPortIndices[1], m_inputR);
-        lilv_instance_connect_port(handle, m_audioPortIndices[2], m_outputL);
-        lilv_instance_connect_port(handle, m_audioPortIndices[3], m_outputR);
+        lilv_instance_connect_port(handle, m_audioPortIndices[0], m_inputL.data());
+        lilv_instance_connect_port(handle, m_audioPortIndices[1], m_inputR.data());
+        lilv_instance_connect_port(handle, m_audioPortIndices[2], m_outputL.data());
+        lilv_instance_connect_port(handle, m_audioPortIndices[3], m_outputR.data());
 
         lilv_instance_activate(handle);
     }

--- a/src/effects/lv2/lv2effectprocessor.h
+++ b/src/effects/lv2/lv2effectprocessor.h
@@ -2,6 +2,8 @@
 
 #include <lilv/lilv.h>
 
+#include <vector>
+
 #include "effects/defs.h"
 #include "effects/effectmanifest.h"
 #include "effects/effectprocessor.h"
@@ -56,11 +58,11 @@ class LV2EffectProcessor : public EffectProcessor {
     LV2EffectGroupState* createGroupState(const mixxx::EngineParameters& bufferParameters);
 
     QList<EngineEffectParameter*> m_parameters;
-    float* m_inputL;
-    float* m_inputR;
-    float* m_outputL;
-    float* m_outputR;
-    float* m_params;
+    std::vector<CSAMPLE> m_inputL;
+    std::vector<CSAMPLE> m_inputR;
+    std::vector<CSAMPLE> m_outputL;
+    std::vector<CSAMPLE> m_outputR;
+    std::vector<CSAMPLE> m_params;
     const LilvPlugin* m_pPlugin;
     const QList<int> m_audioPortIndices;
     const QList<int> m_controlPortIndices;

--- a/src/effects/lv2/lv2manifest.cpp
+++ b/src/effects/lv2/lv2manifest.cpp
@@ -4,10 +4,15 @@
 #include "util/fpclassify.h"
 
 LV2Manifest::LV2Manifest(const LilvPlugin* plug,
-                         QHash<QString, LilvNode*>& properties)
+        QHash<QString, LilvNode*>& properties)
         : m_pEffectManifest(new EffectManifest()),
-          m_status(AVAILABLE) {
+          m_minimum(lilv_plugin_get_num_ports(plug)),
 
+          m_maximum(lilv_plugin_get_num_ports(plug)),
+
+          m_default(lilv_plugin_get_num_ports(plug)),
+
+          m_status(AVAILABLE) {
     m_pLV2plugin = plug;
 
     // Get and set the ID
@@ -25,11 +30,8 @@ LV2Manifest::LV2Manifest(const LilvPlugin* plug,
     lilv_node_free(info);
 
     int numPorts = lilv_plugin_get_num_ports(plug);
-    m_minimum = new float[numPorts];
-    m_maximum = new float[numPorts];
-    m_default = new float[numPorts];
-    lilv_plugin_get_port_ranges_float(m_pLV2plugin, m_minimum, m_maximum,
-                                      m_default);
+    lilv_plugin_get_port_ranges_float(
+            m_pLV2plugin, m_minimum.data(), m_maximum.data(), m_default.data());
 
     // Counters to determine the type of the plug in
     int inputPorts = 0;
@@ -150,12 +152,6 @@ LV2Manifest::LV2Manifest(const LilvPlugin* plug,
         m_status = HAS_REQUIRED_FEATURES;
     }
     lilv_nodes_free(features);
-}
-
-LV2Manifest::~LV2Manifest() {
-    delete[] m_minimum;
-    delete[] m_maximum;
-    delete[] m_default;
 }
 
 EffectManifestPointer LV2Manifest::getEffectManifest() const {

--- a/src/effects/lv2/lv2manifest.h
+++ b/src/effects/lv2/lv2manifest.h
@@ -2,6 +2,8 @@
 
 #include <lilv/lilv.h>
 
+#include <vector>
+
 #include "effects/defs.h"
 #include "effects/effectmanifest.h"
 
@@ -14,7 +16,6 @@ class LV2Manifest {
     };
 
     LV2Manifest(const LilvPlugin* plug, QHash<QString, LilvNode*>& properties);
-    ~LV2Manifest();
     EffectManifestPointer getEffectManifest() const;
     QList<int> getAudioPortIndices();
     QList<int> getControlPortIndices();
@@ -38,8 +39,8 @@ class LV2Manifest {
     QList<int> controlPortIndices;
 
     // Arrays used for storing minimum, maximum and default parameter values
-    float* m_minimum;
-    float* m_maximum;
-    float* m_default;
+    std::vector<float> m_minimum;
+    std::vector<float> m_maximum;
+    std::vector<float> m_default;
     Status m_status;
 };

--- a/src/encoder/encoderfdkaac.cpp
+++ b/src/encoder/encoderfdkaac.cpp
@@ -31,10 +31,8 @@ EncoderFdkAac::EncoderFdkAac(EncoderCallback* pCallback)
           m_pCallback(pCallback),
           m_pLibrary(nullptr),
           m_pInputFifo(nullptr),
-          m_pFifoChunkBuffer(nullptr),
           m_readRequired(0),
           m_aacEnc(),
-          m_pAacDataBuffer(nullptr),
           m_aacInfo(),
           m_hasSbr(false) {
     // Load the shared library
@@ -164,8 +162,6 @@ EncoderFdkAac::~EncoderFdkAac() {
         kLogger.debug() << "Unloaded libfdk-aac";
     }
 
-    delete[] m_pAacDataBuffer;
-    delete[] m_pFifoChunkBuffer;
     delete m_pInputFifo;
 }
 
@@ -283,11 +279,7 @@ int EncoderFdkAac::initEncoder(mixxx::audio::SampleRate sampleRate, QString* pUs
     // This initializes the encoder handle but not the encoder itself.
     // Actual encoder init is done below.
     aacEncOpen(&m_aacEnc, 0, m_channels);
-    VERIFY_OR_DEBUG_ASSERT(!m_pAacDataBuffer) {
-        delete[] m_pAacDataBuffer;
-        m_pAacDataBuffer = nullptr;
-    }
-    m_pAacDataBuffer = new unsigned char[kOutBufferBits * m_channels]();
+    m_pAacDataBuffer.resize(kOutBufferBits * m_channels);
 
     // AAC Object Type: specifies "mode": AAC-LC, HE-AAC, HE-AACv2, DAB AAC, etc...
     if (aacEncoder_SetParam(m_aacEnc, AACENC_AOT, m_aacAot) != AACENC_OK) {
@@ -355,11 +347,7 @@ int EncoderFdkAac::initEncoder(mixxx::audio::SampleRate sampleRate, QString* pUs
     }
     m_pInputFifo = new FIFO<SAMPLE>(EngineSideChain::SIDECHAIN_BUFFER_SIZE * 2);
 
-    VERIFY_OR_DEBUG_ASSERT(!m_pFifoChunkBuffer) {
-        delete[] m_pFifoChunkBuffer;
-        m_pFifoChunkBuffer = nullptr;
-    }
-    m_pFifoChunkBuffer = new SAMPLE[m_readRequired * sizeof(SAMPLE)]();
+    m_pFifoChunkBuffer.resize(m_readRequired * sizeof(SAMPLE));
     return 0;
 }
 
@@ -394,12 +382,12 @@ void EncoderFdkAac::encodeBuffer(const CSAMPLE* samples, const int sampleCount) 
 }
 
 void EncoderFdkAac::processFIFO() {
-    if (!m_pInputFifo || !m_pFifoChunkBuffer) {
+    if (!m_pInputFifo || m_pFifoChunkBuffer.empty()) {
         return;
     }
 
     while (m_pInputFifo->readAvailable() >= m_readRequired) {
-        m_pInputFifo->read(m_pFifoChunkBuffer, m_readRequired);
+        m_pInputFifo->read(m_pFifoChunkBuffer.data(), m_readRequired);
 
         // fdk-aac only accept pointers for most buffer settings.
         // Declare settings here and point to them below.
@@ -414,7 +402,8 @@ void EncoderFdkAac::processFIFO() {
         // Input Buffer
         AACENC_BufDesc inputBuf;
         inputBuf.numBufs = 1;
-        inputBuf.bufs = (void**)&m_pFifoChunkBuffer;
+        void* chunkBuffer[] = {m_pFifoChunkBuffer.data()};
+        inputBuf.bufs = chunkBuffer;
         inputBuf.bufSizes = &inDataSize;
         inputBuf.bufElSizes = &inSampleSize;
         inputBuf.bufferIdentifiers = &inDataDescription;
@@ -426,7 +415,8 @@ void EncoderFdkAac::processFIFO() {
         // Output (result) Buffer
         AACENC_BufDesc outputBuf;
         outputBuf.numBufs = 1;
-        outputBuf.bufs = (void**)&m_pAacDataBuffer;
+        void* dataBuffer[] = {m_pAacDataBuffer.data()};
+        outputBuf.bufs = dataBuffer;
         outputBuf.bufSizes = &outDataSize;
         outputBuf.bufElSizes = &outElemSize;
         outputBuf.bufferIdentifiers = &outDataDescription;
@@ -445,7 +435,7 @@ void EncoderFdkAac::processFIFO() {
             kLogger.warning() << "encoder ignored" << sampleDiff << "samples!";
         }
 
-        m_pCallback->write(nullptr, m_pAacDataBuffer, 0, outputDesc.numOutBytes);
+        m_pCallback->write(nullptr, m_pAacDataBuffer.data(), 0, outputDesc.numOutBytes);
     }
 }
 

--- a/src/encoder/encoderfdkaac.h
+++ b/src/encoder/encoderfdkaac.h
@@ -3,6 +3,7 @@
 #include <QLibrary>
 #include <QString>
 #include <memory>
+#include <vector>
 
 #include "encoder/encoder.h"
 #include "util/fifo.h"
@@ -205,10 +206,10 @@ class EncoderFdkAac : public Encoder {
     EncoderCallback* m_pCallback;
     std::unique_ptr<QLibrary> m_pLibrary;
     FIFO<SAMPLE>* m_pInputFifo;
-    SAMPLE* m_pFifoChunkBuffer;
+    std::vector<SAMPLE> m_pFifoChunkBuffer;
     int m_readRequired;
     HANDLE_AACENCODER m_aacEnc;
-    unsigned char* m_pAacDataBuffer;
+    std::vector<unsigned char> m_pAacDataBuffer;
     AACENC_InfoStruct m_aacInfo;
     bool m_hasSbr;
 };

--- a/src/test/analyzersilence_test.cpp
+++ b/src/test/analyzersilence_test.cpp
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+#include <vector>
+
 #include "engine/engine.h"
 #include "test/mixxxtest.h"
 #include "track/track.h"
@@ -27,16 +29,15 @@ class AnalyzerSilenceTest : public MixxxTest {
                 mixxx::Duration::fromSeconds(kTrackLengthFrames / 44100.0));
 
         nTrackSampleDataLength = kChannelCount * kTrackLengthFrames;
-        pTrackSampleData = new CSAMPLE[nTrackSampleDataLength];
+        pTrackSampleData.resize(nTrackSampleDataLength);
     }
 
     void TearDown() override {
-        delete[] pTrackSampleData;
     }
 
     void analyzeTrack() {
         analyzerSilence.initialize(pTrack, pTrack->getSampleRate(), nTrackSampleDataLength);
-        analyzerSilence.processSamples(pTrackSampleData, nTrackSampleDataLength);
+        analyzerSilence.processSamples(pTrackSampleData.data(), nTrackSampleDataLength);
         analyzerSilence.storeResults(pTrack);
         analyzerSilence.cleanup();
     }
@@ -44,7 +45,7 @@ class AnalyzerSilenceTest : public MixxxTest {
   protected:
     AnalyzerSilence analyzerSilence;
     TrackPointer pTrack;
-    CSAMPLE* pTrackSampleData;
+    std::vector<CSAMPLE> pTrackSampleData;
     int nTrackSampleDataLength; // in samples
 };
 

--- a/src/test/sampleutiltest.cpp
+++ b/src/test/sampleutiltest.cpp
@@ -1,9 +1,10 @@
 #include <benchmark/benchmark.h>
 #include <gtest/gtest.h>
 
-#include <QtDebug>
 #include <QList>
 #include <QPair>
+#include <QtDebug>
+#include <vector>
 
 #include "util/sample.h"
 #include "util/timer.h"
@@ -260,12 +261,12 @@ TEST_F(SampleUtilTest, convertS16ToFloat32) {
     for (int i = 0; i < buffers.size(); ++i) {
         CSAMPLE* buffer = buffers[i];
         int size = sizes[i];
-        SAMPLE* s16 = new SAMPLE[size];
+        auto s16 = std::vector<SAMPLE>(size);
         FillBuffer(buffer, 1.0f, size);
         for (int j = 0; j < size; ++j) {
             s16[j] = SAMPLE_MAXIMUM;
         }
-        SampleUtil::convertS16ToFloat32(buffer, s16, size);
+        SampleUtil::convertS16ToFloat32(buffer, s16.data(), size);
         for (int j = 0; j < size; ++j) {
             EXPECT_FLOAT_EQ(expectedMax, buffer[j]);
         }
@@ -273,7 +274,7 @@ TEST_F(SampleUtilTest, convertS16ToFloat32) {
         for (int j = 0; j < size; ++j) {
             s16[j] = 0;
         }
-        SampleUtil::convertS16ToFloat32(buffer, s16, size);
+        SampleUtil::convertS16ToFloat32(buffer, s16.data(), size);
         for (int j = 0; j < size; ++j) {
             EXPECT_FLOAT_EQ(0.0f, buffer[j]);
         }
@@ -281,11 +282,10 @@ TEST_F(SampleUtilTest, convertS16ToFloat32) {
         for (int j = 0; j < size; ++j) {
             s16[j] = SAMPLE_MINIMUM;
         }
-        SampleUtil::convertS16ToFloat32(buffer, s16, size);
+        SampleUtil::convertS16ToFloat32(buffer, s16.data(), size);
         for (int j = 0; j < size; ++j) {
             EXPECT_FLOAT_EQ(-1.0f, buffer[j]);
         }
-        delete [] s16;
     }
 }
 

--- a/src/util/circularbuffer.h
+++ b/src/util/circularbuffer.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <stdlib.h>
+#include <cstdlib>
+#include <vector>
 
 // CircularBuffer is a basic implementation of a constant-length circular
 // buffer.
@@ -14,17 +15,14 @@ class CircularBuffer {
   public:
     CircularBuffer(unsigned int iLength)
             : m_iLength(iLength),
-              m_pBuffer(new T[m_iLength]),
+              m_pBuffer(m_iLength),
               m_iWritePos(0),
               m_iReadPos(0) {
         // No need to clear the buffer because we consider it to be empty right
         // now.
     }
 
-    virtual ~CircularBuffer() {
-        delete [] m_pBuffer;
-        m_pBuffer = NULL;
-    }
+    virtual ~CircularBuffer() = default;
 
     // Returns true if the buffer is full
     inline bool isFull() const {
@@ -50,7 +48,7 @@ class CircularBuffer {
     // items written, which could be less than numItems if the buffer becomes
     // full.
     unsigned int write(const T* pBuffer, const unsigned int numItems) {
-        if (m_pBuffer == NULL)
+        if (m_pBuffer.empty())
             return 0;
 
         unsigned int itemsWritten = 0;
@@ -64,7 +62,7 @@ class CircularBuffer {
     // Read itemsToRead into pBuffer. Returns the total number of items read,
     // which may be less than itemsToRead if the buffer becomes empty.
     unsigned int read(T* pBuffer, const unsigned int itemsToRead) {
-        if (m_pBuffer == NULL)
+        if (m_pBuffer.empty())
             return 0;
 
         unsigned int itemsRead = 0;
@@ -76,7 +74,7 @@ class CircularBuffer {
     }
 
     unsigned int skip(const unsigned int itemsToRead) {
-        if (m_pBuffer == NULL)
+        if (m_pBuffer.empty())
             return 0;
         unsigned int itemsRead = 0;
         while (!isEmpty() && itemsRead < itemsToRead) {
@@ -88,7 +86,7 @@ class CircularBuffer {
 
   private:
     const unsigned int m_iLength;
-    T* m_pBuffer;
+    std::vector<T> m_pBuffer;
     unsigned int m_iWritePos;
     unsigned int m_iReadPos;
 };

--- a/src/util/fifo.h
+++ b/src/util/fifo.h
@@ -9,18 +9,16 @@ template <class DataType>
 class FIFO {
   public:
     explicit FIFO(int size)
-            : m_data(NULL) {
+            : m_data(roundUpToPowerOf2(size)) {
         size = roundUpToPowerOf2(size);
         // If we can't represent the next higher power of 2 then bail.
         if (size < 0) {
             return;
         }
-        m_data = new DataType[size];
         PaUtil_InitializeRingBuffer(
-                &m_ringBuffer, sizeof(DataType), size, m_data);
+                &m_ringBuffer, sizeof(DataType), m_data.size(), m_data.data());
     }
     virtual ~FIFO() {
-        delete [] m_data;
     }
     int readAvailable() const {
         return PaUtil_GetRingBufferReadAvailable(&m_ringBuffer);
@@ -64,7 +62,7 @@ class FIFO {
     }
 
   private:
-    DataType* m_data;
+    std::vector<DataType> m_data;
     PaUtilRingBuffer m_ringBuffer;
     DISALLOW_COPY_AND_ASSIGN(FIFO<DataType>);
 };

--- a/src/util/rotary.cpp
+++ b/src/util/rotary.cpp
@@ -5,19 +5,15 @@
 constexpr int kiRotaryFilterMaxLen = 50;
 
 Rotary::Rotary()
-    : m_iFilterPos(0),
-      m_dCalibration(1.0),
-      m_dLastValue(0.0),
-      m_iCalibrationCount(0) {
-    m_iFilterLength = kiRotaryFilterMaxLen;
-    m_pFilter = new double[m_iFilterLength];
+        : m_iFilterLength(kiRotaryFilterMaxLen),
+          m_iFilterPos(0),
+          m_pFilter(m_iFilterLength),
+          m_dCalibration(1.0),
+          m_dLastValue(0.0),
+          m_iCalibrationCount(0) {
     for (int i = 0; i < m_iFilterLength; ++i) {
         m_pFilter[i] = 0.;
     }
-}
-
-Rotary::~Rotary() {
-    delete [] m_pFilter;
 }
 
 /* Note: There's probably a bug in this function (or this class) somewhere.

--- a/src/util/rotary.h
+++ b/src/util/rotary.h
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <vector>
+
 class Rotary {
   public:
     Rotary();
-    ~Rotary();
 
     // Start calibration measurement
     void calibrateStart();
@@ -30,7 +31,7 @@ class Rotary {
     // Update position in filter
     int m_iFilterPos;
     // Pointer to rotary filter buffer
-    double *m_pFilter;
+    std::vector<double> m_pFilter;
     // Calibration value
     double m_dCalibration;
     // Last value

--- a/src/vinylcontrol/vinylcontrolsignalwidget.cpp
+++ b/src/vinylcontrol/vinylcontrolsignalwidget.cpp
@@ -1,5 +1,7 @@
 #include "vinylcontrol/vinylcontrolsignalwidget.h"
 
+#include <algorithm>
+
 #include "moc_vinylcontrolsignalwidget.cpp"
 
 VinylControlSignalWidget::VinylControlSignalWidget()
@@ -7,7 +9,6 @@ VinylControlSignalWidget::VinylControlSignalWidget()
           m_iVinylInput(-1),
           m_iSize(MIXXX_VINYL_SCOPE_SIZE),
           m_qImage(),
-          m_imageData(nullptr),
           m_iAngle(0),
           m_fSignalQuality(0.0f),
           m_bVinylActive(false) {
@@ -18,8 +19,8 @@ void VinylControlSignalWidget::setSize(int size) {
     setSizePolicy(QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed));
     setMinimumSize(size, size);
     setMaximumSize(size, size);
-    m_imageData = new uchar[size * size * 4];
-    m_qImage = QImage(m_imageData, size, size, 0, QImage::Format_ARGB32);
+    m_imageData.resize(size * size * 4);
+    m_qImage = QImage(m_imageData.data(), size, size, 0, QImage::Format_ARGB32);
 }
 
 void VinylControlSignalWidget::setVinylInput(int input) {
@@ -27,7 +28,6 @@ void VinylControlSignalWidget::setVinylInput(int input) {
 }
 
 VinylControlSignalWidget::~VinylControlSignalWidget() {
-    delete [] m_imageData;
 }
 
 void VinylControlSignalWidget::setVinylActive(bool active)
@@ -57,7 +57,7 @@ void VinylControlSignalWidget::onVinylSignalQualityUpdate(const VinylSignalQuali
     qual_color.setHsv((int)(120.0 * m_fSignalQuality), 255, 255);
     qual_color.getRgb(&r, &g, &b);
 
-    if (m_imageData == nullptr) {
+    if (m_imageData.empty()) {
         return;
     }
 
@@ -76,9 +76,7 @@ void VinylControlSignalWidget::onVinylSignalQualityUpdate(const VinylSignalQuali
 
 void VinylControlSignalWidget::resetWidget()
 {
-    if (m_imageData != nullptr) {
-        memset(m_imageData, 0, sizeof(uchar) * m_iSize * m_iSize * 4);
-    }
+    std::fill(std::begin(m_imageData), std::end(m_imageData), 0);
 }
 
 void VinylControlSignalWidget::paintEvent(QPaintEvent* event) {

--- a/src/vinylcontrol/vinylcontrolsignalwidget.h
+++ b/src/vinylcontrol/vinylcontrolsignalwidget.h
@@ -12,6 +12,7 @@
 #include <QPainter>
 #include <QTimerEvent>
 #include <QWidget>
+#include <vector>
 
 #include "vinylcontrol/vinylsignalquality.h"
 
@@ -36,7 +37,7 @@ class VinylControlSignalWidget : public QWidget, public VinylSignalQualityListen
     int m_iSize;
 
     QImage m_qImage;
-    unsigned char * m_imageData;
+    std::vector<uchar> m_imageData;
     int m_iAngle;
     float m_fSignalQuality;
     bool m_bVinylActive;

--- a/src/vinylcontrol/vinylcontrolxwax.h
+++ b/src/vinylcontrol/vinylcontrolxwax.h
@@ -1,11 +1,12 @@
 #pragma once
 
 #include <QTime>
+#include <vector>
 
 #include "soundio/soundmanagerutil.h"
-#include "vinylcontrol/vinylcontrol.h"
-#include "vinylcontrol/steadypitch.h"
 #include "util/types.h"
+#include "vinylcontrol/steadypitch.h"
+#include "vinylcontrol/vinylcontrol.h"
 
 #ifdef _MSC_VER
 #include "timecoder.h"
@@ -53,7 +54,7 @@ class VinylControlXwax : public VinylControl {
     double m_dVinylPositionOld;
 
     // Scratch buffer for CSAMPLE -> short conversions.
-    short* m_pWorkBuffer;
+    std::vector<short> m_pWorkBuffer;
     size_t m_workBufferSize;
 
     // Signal quality ring buffer.
@@ -91,7 +92,7 @@ class VinylControlXwax : public VinylControl {
     // The pitch ring buffer.
     // TODO(XXX): Replace with CircularBuffer instead of handling the ring logic
     // in VinylControlXwax.
-    double* m_pPitchRing;
+    std::vector<double> m_pPitchRing;
     // How large the pitch ring buffer is.
     int m_iPitchRingSize;
     // Our current position in the pitch ring buffer.


### PR DESCRIPTION
The changeset's style tries to match like-for-like the current code(base). 

Note: [m_pFifoChunkBuffer](https://github.com/mixxxdj/mixxx/pull/4341/files#diff-7a464d8e6a6ae6ae2eb310a2e36ac70fc56b4a2b3b7f6b5b726fc511877f0029L350-R346) was actually an array pointer; was [not deleted safely](https://github.com/mixxxdj/mixxx/pull/4341/files#diff-7a464d8e6a6ae6ae2eb310a2e36ac70fc56b4a2b3b7f6b5b726fc511877f0029L167-L168). Refactor fixes memory leak.

---

An exception was made for [pBuffer in util/sample.cpp](https://github.com/mixxxdj/mixxx/blob/21420a8be90df60b44926ca0860d373f4b39c222/src/util/sample.cpp#L92). Refactoring will be done later.
