### PR TITLE
BeatsImporter: Return Beats object instead of frame position vector

### DIFF
--- a/src/test/seratobeatgridtest.cpp
+++ b/src/test/seratobeatgridtest.cpp
@@ -170,14 +170,19 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
         mixxx::SeratoBeatsImporter beatsImporter(
                 seratoBeatGrid.nonTerminalMarkers(),
                 seratoBeatGrid.terminalMarker());
-        const QVector<mixxx::audio::FramePos> importedBeatPositionsFrames =
-                beatsImporter.importBeatsAndApplyTimingOffset(timingOffsetMillis, signalInfo);
-        ASSERT_EQ(beatPositionsFrames.size(), importedBeatPositionsFrames.size());
+        const auto pImportedBeats =
+                beatsImporter.importBeatsAndApplyTimingOffset(
+                        timingOffsetMillis, signalInfo);
+        auto pBeatsIterator =
+                pImportedBeats->findBeats(beatPositionsFrames.first() - 1000,
+                        beatPositionsFrames.last() + 1000);
         for (int i = 0; i < beatPositionsFrames.size(); i++) {
+            const auto importedPosition = pBeatsIterator->next();
             EXPECT_NEAR(beatPositionsFrames[i].value(),
-                    importedBeatPositionsFrames[i].value(),
+                    importedPosition.value(),
                     kEpsilon);
         }
+        ASSERT_FALSE(pBeatsIterator->hasNext());
     }
 
     constexpr int kNumBeats60BPM = 4;
@@ -218,14 +223,19 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
         mixxx::SeratoBeatsImporter beatsImporter(
                 seratoBeatGrid.nonTerminalMarkers(),
                 seratoBeatGrid.terminalMarker());
-        const QVector<mixxx::audio::FramePos> importedBeatPositionsFrames =
-                beatsImporter.importBeatsAndApplyTimingOffset(timingOffsetMillis, signalInfo);
-        ASSERT_EQ(beatPositionsFrames.size(), importedBeatPositionsFrames.size());
+        const auto pImportedBeats =
+                beatsImporter.importBeatsAndApplyTimingOffset(
+                        timingOffsetMillis, signalInfo);
+        auto pBeatsIterator =
+                pImportedBeats->findBeats(beatPositionsFrames.first() - 1000,
+                        beatPositionsFrames.last() + 1000);
         for (int i = 0; i < beatPositionsFrames.size(); i++) {
+            const auto importedPosition = pBeatsIterator->next();
             EXPECT_NEAR(beatPositionsFrames[i].value(),
-                    importedBeatPositionsFrames[i].value(),
+                    importedPosition.value(),
                     kEpsilon);
         }
+        ASSERT_FALSE(pBeatsIterator->hasNext());
     }
 
     qInfo() << "Step 3: Add" << kNumBeats120BPM << "beats at 100 bpm to the beatgrid";
@@ -274,14 +284,19 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
         mixxx::SeratoBeatsImporter beatsImporter(
                 seratoBeatGrid.nonTerminalMarkers(),
                 seratoBeatGrid.terminalMarker());
-        const QVector<mixxx::audio::FramePos> importedBeatPositionsFrames =
-                beatsImporter.importBeatsAndApplyTimingOffset(timingOffsetMillis, signalInfo);
-        ASSERT_EQ(beatPositionsFrames.size(), importedBeatPositionsFrames.size());
+        const auto pImportedBeats =
+                beatsImporter.importBeatsAndApplyTimingOffset(
+                        timingOffsetMillis, signalInfo);
+        auto pBeatsIterator =
+                pImportedBeats->findBeats(beatPositionsFrames.first() - 1000,
+                        beatPositionsFrames.last() + 1000);
         for (int i = 0; i < beatPositionsFrames.size(); i++) {
+            const auto importedPosition = pBeatsIterator->next();
             EXPECT_NEAR(beatPositionsFrames[i].value(),
-                    importedBeatPositionsFrames[i].value(),
+                    importedPosition.value(),
                     kEpsilon);
         }
+        ASSERT_FALSE(pBeatsIterator->hasNext());
     }
 }
 

--- a/src/track/beatsimporter.h
+++ b/src/track/beatsimporter.h
@@ -5,6 +5,7 @@
 
 #include "audio/frame.h"
 #include "audio/streaminfo.h"
+#include "track/beats.h"
 
 namespace mixxx {
 
@@ -16,9 +17,8 @@ class BeatsImporter {
 
     virtual bool isEmpty() const = 0;
 
-    /// Determines the timing offset and returns a Vector of frame positions
-    /// to use as input for the BeatMap constructor
-    virtual QVector<mixxx::audio::FramePos> importBeatsAndApplyTimingOffset(
+    /// Determines the timing offset and returns a Beats object.
+    virtual BeatsPointer importBeatsAndApplyTimingOffset(
             const QString& filePath, const audio::StreamInfo& streamInfo) = 0;
 };
 

--- a/src/track/serato/beatsimporter.h
+++ b/src/track/serato/beatsimporter.h
@@ -4,6 +4,7 @@
 
 #include <QList>
 
+#include "track/beats.h"
 #include "track/beatsimporter.h"
 #include "track/serato/beatgrid.h"
 
@@ -18,14 +19,14 @@ class SeratoBeatsImporter : public BeatsImporter {
     ~SeratoBeatsImporter() override = default;
 
     bool isEmpty() const override;
-    QVector<mixxx::audio::FramePos> importBeatsAndApplyTimingOffset(
+    BeatsPointer importBeatsAndApplyTimingOffset(
             const QString& filePath,
             const audio::StreamInfo& streamInfo) override;
 
   private:
     FRIEND_TEST(SeratoBeatGridTest, SerializeBeatMap);
 
-    QVector<mixxx::audio::FramePos> importBeatsAndApplyTimingOffset(
+    BeatsPointer importBeatsAndApplyTimingOffset(
             double timingOffsetMillis, const audio::SignalInfo& signalInfo);
 
     QList<SeratoBeatGridNonTerminalMarkerPointer> m_nonTerminalMarkers;

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1081,10 +1081,9 @@ bool Track::importPendingBeatsWhileLocked() {
     // The sample rate is supposed to be consistent
     DEBUG_ASSERT(m_record.getStreamInfoFromSource()->getSignalInfo().getSampleRate() ==
             m_record.getMetadata().getStreamInfo().getSignalInfo().getSampleRate());
-    const auto pBeats = mixxx::Beats::fromBeatPositions(
-            m_record.getStreamInfoFromSource()->getSignalInfo().getSampleRate(),
+    const auto pBeats =
             m_pBeatsImporterPending->importBeatsAndApplyTimingOffset(
-                    getLocation(), *m_record.getStreamInfoFromSource()));
+                    getLocation(), *m_record.getStreamInfoFromSource());
     DEBUG_ASSERT(m_pBeatsImporterPending->isEmpty());
     m_pBeatsImporterPending.reset();
     return setBeatsWhileLocked(pBeats);


### PR DESCRIPTION
This makes the BeatsImporter return an actual Beats object instead of a
vector of frame positions. The main reason for this change is that it
will avoid the unnecessary intermediate step of converting to/from raw
frame positions when the new beats implementation is ready.

Additionally, this prevents wrong usage by making it impossible to
passing a `SignalInfo` to import method and then use a different sample
rate for creating the beats object (which would invalidate all
positions).

Theoretically, this also allows to return a `BeatGrid` instead of a
`BeatMap`, although we don't make use of this possibility and the
distinction hopefully becomes obsolete soon anyway.