### PR TITLE
Fix race condition in ReplayGain test

### DIFF
--- a/src/test/replaygaintest.cpp
+++ b/src/test/replaygaintest.cpp
@@ -160,13 +160,18 @@ TEST_F(ReplayGainTest, NormalizePeak) {
 class AdjustReplayGainTest : public MockedEngineBackendTest {};
 
 TEST_F(AdjustReplayGainTest, AdjustReplayGainUpdatesPregain) {
+    const QString kTrackLocationTest = QDir::currentPath() + "/src/test/sine-30.wav";
+    TrackPointer pTrack(Track::newTemporary(kTrackLocationTest));
+
+    // Load the same track in decks 1 and 2 so we can see that the pregain is adjusted on both
+    // decks.
+    loadTrack(m_pMixerDeck1, pTrack);
+    loadTrack(m_pMixerDeck2, pTrack);
+
     // Initialize fake track replaygain so it's not zero.
     mixxx::ReplayGain replayGain;
     replayGain.setRatio(1.0);
-    m_pTrack1->setReplayGain(replayGain);
-    // Load the same track in decks 1 and 2 so we can see that the pregain is adjusted on both
-    // decks.
-    m_pMixerDeck2->slotLoadTrack(m_pTrack1, false);
+    pTrack->setReplayGain(replayGain);
     // Because of this artificial process we have to manually set the replaygain CO for the second
     // deck.
     m_pMixerDeck2->slotSetReplayGain(replayGain);
@@ -183,7 +188,7 @@ TEST_F(AdjustReplayGainTest, AdjustReplayGainUpdatesPregain) {
             .005);
     EXPECT_DOUBLE_EQ(1.2, ControlObject::getControl(ConfigKey(m_sGroup1, "replaygain"))->get());
     EXPECT_DOUBLE_EQ(1.2, ControlObject::getControl(ConfigKey(m_sGroup2, "replaygain"))->get());
-    EXPECT_DOUBLE_EQ(1.2, m_pTrack1->getReplayGain().getRatio());
+    EXPECT_DOUBLE_EQ(1.2, pTrack->getReplayGain().getRatio());
 }
 
 } // anonymous namespace


### PR DESCRIPTION
This test caused a race because it called slotLoadTrack instead of loadTrack, so it did not wait for the track to actually load. The test was quitting before the caching reader had a chance to finish setting up, so when the test was getting torn down there was a chance that the reader would try to access the objects while they were being destructed.
    
Because the test infrastructure has its own destruction code, it's not clear if this crash could occur in regular code.
    
Fixes https://bugs.launchpad.net/mixxx/+bug/1940589

