### PR TITLE
metainfo.xml: Add missing release timestamp attribute

### DIFF
--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -98,7 +98,7 @@
   Do not edit it manually.
   -->
   <releases>
-    <release version="2.3.1" date="2021-09-29" type="stable">
+    <release version="2.3.1" type="stable" date="2021-09-29" timestamp="1632873600">
       <description>
  <ul>
   <li>
@@ -306,7 +306,7 @@
  </ul>
 </description>
     </release>
-    <release version="2.3.0" date="2021-06-28" type="stable">
+    <release version="2.3.0" type="stable" date="2021-06-28" timestamp="1624838400">
       <description>
  <p>
   Hotcues
@@ -863,7 +863,7 @@
  </ul>
 </description>
     </release>
-    <release version="2.2.4" date="2020-06-27" type="stable">
+    <release version="2.2.4" type="stable" date="2020-06-27" timestamp="1593216000">
       <description>
  <ul>
   <li>
@@ -954,7 +954,7 @@
  </ul>
 </description>
     </release>
-    <release version="2.2.3" date="2019-11-24" type="stable">
+    <release version="2.2.3" type="stable" date="2019-11-24" timestamp="1574553600">
       <description>
  <ul>
   <li>
@@ -1038,7 +1038,7 @@
  </ul>
 </description>
     </release>
-    <release version="2.2.2" date="2019-08-10" type="stable">
+    <release version="2.2.2" type="stable" date="2019-08-10" timestamp="1565395200">
       <description>
  <ul>
   <li>
@@ -1113,7 +1113,7 @@
  </ul>
 </description>
     </release>
-    <release version="2.2.1" date="2019-04-22" type="stable">
+    <release version="2.2.1" type="stable" date="2019-04-22" timestamp="1555891200">
       <description>
  <ul>
   <li>
@@ -1147,7 +1147,7 @@
  </ul>
 </description>
     </release>
-    <release version="2.2.0" date="2018-12-17" type="stable">
+    <release version="2.2.0" type="stable" date="2018-12-17" timestamp="1545004800">
       <description>
  <p>
   General
@@ -1226,7 +1226,7 @@
  </ul>
 </description>
     </release>
-    <release version="2.1.8" date="2019-04-07" type="stable">
+    <release version="2.1.8" type="stable" date="2019-04-07" timestamp="1554595200">
       <description>
  <ul>
   <li>
@@ -1252,7 +1252,7 @@
  </ul>
 </description>
     </release>
-    <release version="2.1.7" date="2019-01-15" type="stable">
+    <release version="2.1.7" type="stable" date="2019-01-15" timestamp="1547510400">
       <description>
  <ul>
   <li>
@@ -1278,7 +1278,7 @@
  </ul>
 </description>
     </release>
-    <release version="2.1.6" date="2018-12-23" type="stable">
+    <release version="2.1.6" type="stable" date="2018-12-23" timestamp="1545523200">
       <description>
  <ul>
   <li>
@@ -1356,7 +1356,7 @@
  </ul>
 </description>
     </release>
-    <release version="2.1.5" date="2018-10-28" type="stable">
+    <release version="2.1.5" type="stable" date="2018-10-28" timestamp="1540684800">
       <description>
  <ul>
   <li>
@@ -1398,7 +1398,7 @@
  </ul>
 </description>
     </release>
-    <release version="2.1.4" date="2018-08-29" type="stable">
+    <release version="2.1.4" type="stable" date="2018-08-29" timestamp="1535500800">
       <description>
  <p>
   Fix track selection not getting shown in the track
@@ -1410,7 +1410,7 @@ each build.
  </p>
 </description>
     </release>
-    <release version="2.1.3" date="2018-08-20" type="stable">
+    <release version="2.1.3" type="stable" date="2018-08-20" timestamp="1534723200">
       <description>
  <p>
   Fix a severe performance regression on Windows:
@@ -1418,7 +1418,7 @@ each build.
  </p>
 </description>
     </release>
-    <release version="2.1.2" date="2018-08-10" type="stable">
+    <release version="2.1.2" type="stable" date="2018-08-10" timestamp="1533859200">
       <description>
  <p>
   Yet another bugfix release of Mixxx 2.1.
@@ -1473,7 +1473,7 @@ Here is a quick summary of what is new in Mixxx 2.1.2:
  </ul>
 </description>
     </release>
-    <release version="2.1.1" date="2018-06-13" type="stable">
+    <release version="2.1.1" type="stable" date="2018-06-13" timestamp="1528848000">
       <description>
  <p>
   After two months it is time to do a bugfix release of Mixxx 2.1.
@@ -1544,7 +1544,7 @@ Here is a quick summary of what is new in Mixxx 2.1.1:
  </ul>
 </description>
     </release>
-    <release version="2.1.0" date="2018-04-15" type="stable">
+    <release version="2.1.0" type="stable" date="2018-04-15" timestamp="1523750400">
       <description>
  <p>
   After two years of hard work, we are pleased to announce Mixxx 2.1. We
@@ -1796,7 +1796,7 @@ tips on getting started contributing code to Mixxx.
  </p>
 </description>
     </release>
-    <release version="2.0.0" date="2015-12-31" type="stable">
+    <release version="2.0.0" type="stable" date="2015-12-31" timestamp="1451520000">
       <description>
  <ul>
   <li>

--- a/tools/update_metainfo.py
+++ b/tools/update_metainfo.py
@@ -23,12 +23,15 @@ def parse_changelog(content):
             "version": matchobj.group("number"),
         }
         try:
-            attrib["date"] = datetime.datetime.strptime(
+            release_date = datetime.datetime.strptime(
                 matchobj.group("date"), " (%Y-%m-%d)"
-            ).strftime("%Y-%m-%d")
-            attrib["type"] = "stable"
+            ).replace(tzinfo=datetime.timezone.utc)
         except ValueError:
             attrib["type"] = "development"
+        else:
+            attrib["type"] = "stable"
+            attrib["date"] = release_date.strftime("%Y-%m-%d")
+            attrib["timestamp"] = "{:.0f}".format(release_date.timestamp())
 
         soup = bs4.BeautifulSoup(
             markdown.markdown(description_md), "html.parser"


### PR DESCRIPTION
Before, we only added the `date` attribute. The `timestamp` doesn't
carry any additional information, but it's required for flatpak:

https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/Flatpak.20build/near/255671054