### PR TITLE
Library: add keyboard short to open track properties Ctrl+Enter

### DIFF
--- a/src/util/defs.h
+++ b/src/util/defs.h
@@ -5,3 +5,8 @@
 constexpr unsigned int MAX_BUFFER_LEN = 160000;
 
 constexpr int kMaxNumberOfDecks = 4;
+
+// Keyboard shortcut components for showing the Track Properties dialog and
+// for displaying the shortcut in the track context menu
+const Qt::Modifier kPropertiesShortcutModifier = Qt::CTRL;
+const Qt::Key kPropertiesShortcutKey = Qt::Key_Return;

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -26,6 +26,7 @@
 #include "preferences/colorpalettesettings.h"
 #include "sources/soundsourceproxy.h"
 #include "track/track.h"
+#include "util/defs.h"
 #include "util/desktophelper.h"
 #include "util/parented_ptr.h"
 #include "util/qt.h"
@@ -211,6 +212,13 @@ void WTrackMenu::createActions() {
 
     if (featureIsEnabled(Feature::Properties)) {
         m_pPropertiesAct = new QAction(tr("Properties"), this);
+        // This is just for having the shortcut displayed next to the action
+        // when the menu is invoked from the tracks table.
+        // The keypress is caught in WTrackTableView::keyPressEvent
+        if (m_pTrackModel) {
+            m_pPropertiesAct->setShortcut(
+                    QKeySequence(kPropertiesShortcutModifier + kPropertiesShortcutKey));
+        }
         connect(m_pPropertiesAct, &QAction::triggered, this, &WTrackMenu::slotShowDlgTrackInfo);
     }
 

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -21,6 +21,7 @@
 #include "track/track.h"
 #include "track/trackref.h"
 #include "util/assert.h"
+#include "util/defs.h"
 #include "util/dnd.h"
 #include "util/time.h"
 #include "widget/wtrackmenu.h"
@@ -757,9 +758,9 @@ TrackModel* WTrackTableView::getTrackModel() const {
 void WTrackTableView::keyPressEvent(QKeyEvent* event) {
     // Ctrl+Return opens track properties dialog.
     // Ignore it if any cell editor is open.
-    // Note: the shortcut display string needs to be set in WTrackMenu accordingly.
-    if (event->key() == Qt::Key_Return &&
-            event->modifiers() & Qt::ControlModifier &&
+    // Note: the shortcut is displayed in the track context menu
+    if (event->key() == kPropertiesShortcutKey &&
+            (event->modifiers() & kPropertiesShortcutModifier) &&
             state() != QTableView::EditingState) {
         QModelIndexList indices = selectionModel()->selectedRows();
         if (indices.length() == 1) {

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -755,14 +755,19 @@ TrackModel* WTrackTableView::getTrackModel() const {
 }
 
 void WTrackTableView::keyPressEvent(QKeyEvent* event) {
-    if (event->key() == Qt::Key_Return) {
-        // It is not a good idea if 'key_return'
-        // causes a track to load since we allow in-line editing
-        // of table items in general
-        return;
-    } else {
-        QTableView::keyPressEvent(event);
+    // Ctrl+Return opens track properties dialog.
+    // Ignore it if any cell editor is open.
+    // Note: the shortcut display string needs to be set in WTrackMenu accordingly.
+    if (event->key() == Qt::Key_Return &&
+            event->modifiers() & Qt::ControlModifier &&
+            state() != QTableView::EditingState) {
+        QModelIndexList indices = selectionModel()->selectedRows();
+        if (indices.length() == 1) {
+            m_pTrackMenu->loadTrackModelIndices(indices);
+            m_pTrackMenu->slotShowDlgTrackInfo();
+        }
     }
+    QTableView::keyPressEvent(event);
 }
 
 void WTrackTableView::loadSelectedTrack() {


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1393357

In the tracks table press `Ctrl`+`Return` to show the Track Properties dialog for the selected track.
The shortcut is displayed in the track context menu (only when invoked from the tracks table).