### PR TITLE
WTrackMenu: add and display hotkeys

### DIFF
--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -337,6 +337,7 @@ void Library::bindLibraryWidget(
             pLibraryWidget->getTrackTableBackgroundColorOpacity(),
             true);
     pTrackTableView->installEventFilter(pKeyboard);
+    pTrackTableView->setKeyboardConfig(pKeyboard->getKeyboardConfig());
     connect(this,
             &Library::showTrackModel,
             pTrackTableView,

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -40,12 +40,14 @@
 WTrackMenu::WTrackMenu(
         QWidget* parent,
         UserSettingsPointer pConfig,
+        const ConfigObject<ConfigValueKbd>* pKbdConfig,
         Library* pLibrary,
         Features flags,
         TrackModel* trackModel)
         : QMenu(parent),
           m_pTrackModel(trackModel),
           m_pConfig(pConfig),
+          m_pKbdConfig(pKbdConfig),
           m_pLibrary(pLibrary),
           m_bPlaylistMenuLoaded(false),
           m_bCrateMenuLoaded(false),

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -8,6 +8,7 @@
 #include "library/coverart.h"
 #include "library/dao/playlistdao.h"
 #include "library/trackprocessing.h"
+#include "preferences/configobject.h"
 #include "preferences/usersettings.h"
 #include "track/beats.h"
 #include "track/trackref.h"
@@ -57,6 +58,7 @@ class WTrackMenu : public QMenu {
 
     WTrackMenu(QWidget* parent,
             UserSettingsPointer pConfig,
+            const ConfigObject<ConfigValueKbd>* pKbdConfig,
             Library* pLibrary,
             Features flags = Feature::All,
             TrackModel* trackModel = nullptr);
@@ -273,6 +275,7 @@ class WTrackMenu : public QMenu {
     QAction* m_pClearAllMetadataAction{};
 
     const UserSettingsPointer m_pConfig;
+    const ConfigObject<ConfigValueKbd>* m_pKbdConfig;
     Library* const m_pLibrary;
 
     std::unique_ptr<DlgTrackInfo> m_pDlgTrackInfo;

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -32,7 +32,7 @@ WTrackProperty::WTrackProperty(
           m_group(group),
           m_pConfig(pConfig),
           m_pTrackMenu(make_parented<WTrackMenu>(
-                  this, pConfig, pLibrary, kTrackMenuFeatures)) {
+                  this, pConfig, nullptr, pLibrary, kTrackMenuFeatures)) {
     setAcceptDrops(true);
 }
 

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -756,6 +756,14 @@ TrackModel* WTrackTableView::getTrackModel() const {
 
 void WTrackTableView::keyPressEvent(QKeyEvent* event) {
     if (event->key() == Qt::Key_Return) {
+        // Ctrl+Enter opens track properties dialog
+        if (event->modifiers() & Qt::ControlModifier) {
+            QModelIndexList indices = selectionModel()->selectedRows();
+            if (indices.length() == 1) {
+                m_pTrackMenu->loadTrackModelIndices(indices);
+                m_pTrackMenu->slotShowDlgTrackInfo();
+            }
+        }
         // It is not a good idea if 'key_return'
         // causes a track to load since we allow in-line editing
         // of table items in general

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -53,6 +53,7 @@ WTrackTableView::WTrackTableView(QWidget* parent,
                   pConfig,
                   kVScrollBarPosConfigKey),
           m_pConfig(pConfig),
+          m_pKbdConfig(nullptr),
           m_pLibrary(pLibrary),
           m_backgroundColorOpacity(backgroundColorOpacity),
           m_pFocusBorderColor(kDefaultFocusBorderColor),
@@ -331,6 +332,10 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel* model) {
     initTrackMenu();
 }
 
+void WTrackTableView::setKeyboardConfig(const ConfigObject<ConfigValueKbd>* kbdConfig) {
+    m_pKbdConfig = kbdConfig;
+}
+
 void WTrackTableView::initTrackMenu() {
     auto* trackModel = getTrackModel();
     DEBUG_ASSERT(trackModel);
@@ -341,6 +346,7 @@ void WTrackTableView::initTrackMenu() {
 
     m_pTrackMenu = make_parented<WTrackMenu>(this,
             m_pConfig,
+            m_pKbdConfig,
             m_pLibrary,
             WTrackMenu::Feature::All,
             trackModel);

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -54,6 +54,7 @@ class WTrackTableView : public WLibraryTableView {
 
   public slots:
     void loadTrackModel(QAbstractItemModel* model);
+    void setKeyboardConfig(const ConfigObject<ConfigValueKbd>* kbdConfig);
     void slotMouseDoubleClicked(const QModelIndex &);
     void slotUnhide();
     void slotPurge();
@@ -94,6 +95,7 @@ class WTrackTableView : public WLibraryTableView {
     void initTrackMenu();
 
     const UserSettingsPointer m_pConfig;
+    const ConfigObject<ConfigValueKbd>* m_pKbdConfig;
     Library* const m_pLibrary;
 
     // Context menu container

--- a/src/widget/wtracktext.cpp
+++ b/src/widget/wtracktext.cpp
@@ -31,7 +31,7 @@ WTrackText::WTrackText(QWidget* pParent,
           m_group(group),
           m_pConfig(pConfig),
           m_pTrackMenu(make_parented<WTrackMenu>(
-                  this, pConfig, pLibrary, kTrackMenuFeatures)) {
+                  this, pConfig, nullptr, pLibrary, kTrackMenuFeatures)) {
     setAcceptDrops(true);
 }
 

--- a/src/widget/wtrackwidgetgroup.cpp
+++ b/src/widget/wtrackwidgetgroup.cpp
@@ -37,7 +37,7 @@ WTrackWidgetGroup::WTrackWidgetGroup(QWidget* pParent,
           m_pConfig(pConfig),
           m_trackColorAlpha(kDefaultTrackColorAlpha),
           m_pTrackMenu(make_parented<WTrackMenu>(
-                  this, pConfig, pLibrary, kTrackMenuFeatures)) {
+                  this, pConfig, nullptr, pLibrary, kTrackMenuFeatures)) {
     setAcceptDrops(true);
 }
 


### PR DESCRIPTION
based on #4347

allows to set keyboard shortcuts in the track menu and display the keys