### PR TITLE
Clamped pitch and pitch_adjust to fix segmentation fault

### DIFF
--- a/src/engine/controls/keycontrol.cpp
+++ b/src/engine/controls/keycontrol.cpp
@@ -24,8 +24,8 @@ KeyControl::KeyControl(const QString& group,
     m_pitchRateInfo.keylock = false;
 
     // pitch is the distance to the original pitch in semitones
-    // knob in semitones; 9.4 ct per midi step allowOutOfBounds = true;
-    m_pPitch = new ControlPotmeter(ConfigKey(group, "pitch"), -6.0, 6.0, true);
+    // knob in semitones; 9.4 ct per midi step allowOutOfBounds = false;
+    m_pPitch = new ControlPotmeter(ConfigKey(group, "pitch"), -30.0, 30, false);
     // Coarse adjust by full semitone steps.
     m_pPitch->setStepCount(12);
     // Fine adjust with semitone / 10 = 10 ct;.
@@ -36,8 +36,8 @@ KeyControl::KeyControl(const QString& group,
 
     // pitch_adjust is the distance to the linear pitch in semitones
     // set by the speed slider or to the locked key.
-    // pitch_adjust knob in semitones; 4.7 ct per midi step; allowOutOfBounds = true;
-    m_pPitchAdjust = new ControlPotmeter(ConfigKey(group, "pitch_adjust"), -3.0, 3.0, true);
+    // pitch_adjust knob in semitones; 4.7 ct per midi step; allowOutOfBounds = false;
+    m_pPitchAdjust = new ControlPotmeter(ConfigKey(group, "pitch_adjust"), -15.0, 15.0, false);
     // Coarse adjust by full semitone steps.
     m_pPitchAdjust->setStepCount(6);
     // Fine adjust with semitone / 10 = 10 ct;.


### PR DESCRIPTION
A brute fix to [lp1684845](https://bugs.launchpad.net/mixxx/+bug/1684845).

* increased control ranges:
  * `pitch`: -30 to +30
  * `pitch_adjust`: -15 to +15
* set `allowOutOfBounds` to *false* on both of them so the value doesn't get to high nor too low, as it causes Mixxx to crash.