### PR TITLE
lp1445885: Detect MIME type and deduce expected file extension and type

### DIFF
--- a/src/sources/soundsource.h
+++ b/src/sources/soundsource.h
@@ -1,10 +1,9 @@
 #pragma once
 
-#include <QDebug>
+#include <QFileInfo>
 
 #include "sources/audiosource.h"
 #include "sources/metadatasourcetaglib.h"
-
 #include "util/assert.h"
 
 namespace mixxx {
@@ -15,8 +14,17 @@ class SoundSource
         : public AudioSource,
           public MetadataSourceTagLib {
   public:
-    static QString getFileExtensionFromUrl(const QUrl& url);
+    /// Determine the type from an URL.
+    ///
+    /// Only local file URLs are supported.
+    static QString getTypeFromUrl(const QUrl& url);
 
+    /// Determine the type from a (local) file.
+    static QString getTypeFromFile(const QFileInfo& fileInfo);
+
+    /// The type of the source.
+    ///
+    /// The type equals the preferred suffix of the content's MIME type.
     QString getType() const {
         return m_type;
     }
@@ -25,7 +33,7 @@ class SoundSource
     // If no type is provided the file extension of the file referred
     // by the URL will be used as the type of the SoundSource.
     explicit SoundSource(const QUrl& url)
-            : SoundSource(url, getFileExtensionFromUrl(url)) {
+            : SoundSource(url, getTypeFromUrl(url)) {
     }
     SoundSource(const QUrl& url, const QString& type);
 

--- a/src/sources/soundsourcemodplug.cpp
+++ b/src/sources/soundsourcemodplug.cpp
@@ -32,20 +32,20 @@ const QStringList kSupportedFileExtensions = {
 constexpr SINT kChunkSizeInBytes = SINT(1) << 19;
 
 QString getModPlugTypeFromUrl(const QUrl& url) {
-    const QString fileExtension(SoundSource::getFileExtensionFromUrl(url));
-    if (fileExtension == "mod") {
+    const QString fileType = SoundSource::getTypeFromUrl(url);
+    if (fileType == "mod") {
         return "Protracker";
-    } else if (fileExtension == "med") {
+    } else if (fileType == "med") {
         return "OctaMed";
-    } else if (fileExtension == "okt") {
+    } else if (fileType == "okt") {
         return "Oktalyzer";
-    } else if (fileExtension == "s3m") {
+    } else if (fileType == "s3m") {
         return "Scream Tracker 3";
-    } else if (fileExtension == "stm") {
+    } else if (fileType == "stm") {
         return "Scream Tracker";
-    } else if (fileExtension == "xm") {
+    } else if (fileType == "xm") {
         return "FastTracker2";
-    } else if (fileExtension == "it") {
+    } else if (fileType == "it") {
         return "Impulse Tracker";
     } else {
         return "Module";

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -288,9 +288,9 @@ SoundSourceProxy::allProviderRegistrationsForUrl(
         // silently ignore empty URLs
         return {};
     }
-    const QString fileExtension =
-            mixxx::SoundSource::getFileExtensionFromUrl(url);
-    if (fileExtension.isEmpty()) {
+    const QString fileType =
+            mixxx::SoundSource::getTypeFromUrl(url);
+    if (fileType.isEmpty()) {
         kLogger.warning()
                 << "Unknown file type:"
                 << url.toString();
@@ -298,7 +298,7 @@ SoundSourceProxy::allProviderRegistrationsForUrl(
     }
     const auto providerRegistrations =
             allProviderRegistrationsForFileExtension(
-                    fileExtension);
+                    fileType);
     if (providerRegistrations.isEmpty()) {
         kLogger.warning()
                 << "Unsupported file type:"

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -708,3 +708,30 @@ TEST_F(SoundSourceProxyTest, regressionTestCachingReaderChunkJumpForward) {
         }
     }
 }
+
+TEST_F(SoundSourceProxyTest, getTypeFromFile) {
+    // Generate file names for the temporary file
+    const QString filePathWithoutSuffix =
+            mixxxtest::generateTemporaryFileName("file_with_no_file_suffix");
+    const QString filePathWithUnknownSuffix =
+            mixxxtest::generateTemporaryFileName("file_with.unknown_suffix");
+    const QString filePathWithWrongSuffix =
+            mixxxtest::generateTemporaryFileName("file_with_wrong_suffix.wav");
+
+    // Create the temporary files by copying an existing file
+    const QString validFilePath = kTestDir.absoluteFilePath(QStringLiteral("empty.mp3"));
+    mixxxtest::copyFile(validFilePath, filePathWithoutSuffix);
+    mixxxtest::copyFile(validFilePath, filePathWithUnknownSuffix);
+    mixxxtest::copyFile(validFilePath, filePathWithWrongSuffix);
+
+    ASSERT_STREQ(qPrintable("mp3"), qPrintable(mixxx::SoundSource::getTypeFromFile(validFilePath)));
+    EXPECT_STREQ(qPrintable("mp3"),
+            qPrintable(mixxx::SoundSource::getTypeFromFile(
+                    filePathWithoutSuffix)));
+    EXPECT_STREQ(qPrintable("mp3"),
+            qPrintable(mixxx::SoundSource::getTypeFromFile(
+                    filePathWithUnknownSuffix)));
+    EXPECT_STREQ(qPrintable("mp3"),
+            qPrintable(mixxx::SoundSource::getTypeFromFile(
+                    filePathWithWrongSuffix)));
+}

--- a/src/track/serato/tags.cpp
+++ b/src/track/serato/tags.cpp
@@ -21,7 +21,7 @@ namespace {
 
 QString getPrimaryDecoderNameForFilePath(const QString& filePath) {
     const QString fileExtension =
-            mixxx::SoundSource::getFileExtensionFromUrl(QUrl::fromLocalFile(filePath));
+            mixxx::SoundSource::getTypeFromFile(filePath);
     const mixxx::SoundSourceProviderPointer pPrimaryProvider =
             SoundSourceProxy::getPrimaryProviderForFileExtension(fileExtension);
     if (pPrimaryProvider) {


### PR DESCRIPTION
Checking only the actual file extension is not sufficient.

Fixes: https://bugs.launchpad.net/mixxx/+bug/1445885