### PR TITLE
pass focus to library after effect, beat size or Auto DJ transition configuration

### DIFF
--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -1,5 +1,6 @@
 #include "library/autodj/dlgautodj.h"
 
+#include <QApplication>
 #include <QMessageBox>
 
 #include "library/playlisttablemodel.h"
@@ -160,7 +161,13 @@ DlgAutoDJ::DlgAutoDJ(WLibrary* parent,
     fadeModeCombobox->setFocusPolicy(Qt::ClickFocus);
     spinBoxTransition->setFocusPolicy(Qt::ClickFocus);
     // work around QLineEdit being protected
-    spinBoxTransition->findChild<QLineEdit*>()->setFocusPolicy(Qt::ClickFocus);
+    QLineEdit* lineEditTransition(spinBoxTransition->findChild<QLineEdit*>());
+    lineEditTransition->setFocusPolicy(Qt::ClickFocus);
+    // Catch any Return keypress to pass focus to tracks table
+    connect(lineEditTransition,
+            &QLineEdit::returnPressed,
+            this,
+            &DlgAutoDJ::shiftTabKeypress);
 
     connect(spinBoxTransition,
             QOverload<int>::of(&QSpinBox::valueChanged),
@@ -178,7 +185,7 @@ DlgAutoDJ::DlgAutoDJ(WLibrary* parent,
     fadeModeCombobox->setCurrentIndex(
             fadeModeCombobox->findData(static_cast<int>(m_pAutoDJProcessor->getTransitionMode())));
     connect(fadeModeCombobox,
-            QOverload<int>::of(&QComboBox::currentIndexChanged),
+            QOverload<int>::of(&QComboBox::activated),
             this,
             &DlgAutoDJ::slotTransitionModeChanged);
 
@@ -330,9 +337,11 @@ void DlgAutoDJ::autoDJStateChanged(AutoDJProcessor::AutoDJState state) {
     }
 }
 
-void DlgAutoDJ::slotTransitionModeChanged(int comboboxIndex) {
-    m_pAutoDJProcessor->setTransitionMode(static_cast<AutoDJProcessor::TransitionMode>(
-            fadeModeCombobox->itemData(comboboxIndex).toInt()));
+void DlgAutoDJ::slotTransitionModeChanged(int newIndex) {
+    m_pAutoDJProcessor->setTransitionMode(
+            static_cast<AutoDJProcessor::TransitionMode>(
+                    fadeModeCombobox->itemData(newIndex).toInt()));
+    shiftTabKeypress();
 }
 
 void DlgAutoDJ::slotRepeatPlaylistChanged(int checkState) {
@@ -369,4 +378,13 @@ void DlgAutoDJ::updateSelectionInfo() {
 
 bool DlgAutoDJ::hasFocus() const {
     return m_pTrackTableView->hasFocus();
+}
+
+void DlgAutoDJ::shiftTabKeypress() {
+    // After selecting a mode or editing the transition time, send Shift+Tab
+    // to move focus to the next keyboard-focusable widget (tracks table in
+    // official skins) in order to immediately allow keyboard shortcuts again.
+    QKeyEvent backwardFocusKeyEvent =
+            QKeyEvent{QEvent::KeyPress, Qt::Key_Tab, Qt::ShiftModifier};
+    QApplication::sendEvent(this, &backwardFocusKeyEvent);
 }

--- a/src/library/autodj/dlgautodj.h
+++ b/src/library/autodj/dlgautodj.h
@@ -56,6 +56,7 @@ class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
     void setupActionButton(QPushButton* pButton,
             void (DlgAutoDJ::*pSlot)(bool),
             const QString& fallbackText);
+    void shiftTabKeypress();
 
     const UserSettingsPointer m_pConfig;
 

--- a/src/widget/wbeatspinbox.cpp
+++ b/src/widget/wbeatspinbox.cpp
@@ -1,5 +1,6 @@
 #include "widget/wbeatspinbox.h"
 
+#include <QApplication>
 #include <QLineEdit>
 #include <QRegularExpression>
 
@@ -293,6 +294,18 @@ bool WBeatSpinBox::event(QEvent* pEvent) {
         }
     }
     return QDoubleSpinBox::event(pEvent);
+}
+
+void WBeatSpinBox::keyPressEvent(QKeyEvent* pEvent) {
+    // Return key applies current value and sends a Shift+Tab event in order
+    // to focus a library widget. In official skins this would be the tracks table.
+    if (pEvent->key() == Qt::Key_Return) {
+        QDoubleSpinBox::keyPressEvent(pEvent);
+        QKeyEvent returnKeyEvent = QKeyEvent{QEvent::KeyPress, Qt::Key_Tab, Qt::ShiftModifier};
+        QApplication::sendEvent(this, &returnKeyEvent);
+        return;
+    }
+    return QDoubleSpinBox::keyPressEvent(pEvent);
 }
 
 bool WBeatLineEdit::event(QEvent* pEvent) {

--- a/src/widget/wbeatspinbox.h
+++ b/src/widget/wbeatspinbox.h
@@ -33,6 +33,7 @@ class WBeatSpinBox : public QDoubleSpinBox, public WBaseWidget {
 
     // for font scaling
     bool event(QEvent* pEvent) override;
+    void keyPressEvent(QKeyEvent* pEvent) override;
     double m_scaleFactor;
 };
 


### PR DESCRIPTION
Automatically re-enable keyboard shortcuts by passing focus to the tracks table (official skins) after
* picking an effect
* pressing `Enter` in a beat size spinbox
* pressing `Enter` in the Auto DJ transition time spinbox
* picking an Auto DJ transition mode

with an emulated `Shift`+`Tab` keypress.

This primarily fixes fixes rare bug [lp:1902125 effect selector can't be opened on Arch](https://bugs.launchpad.net/mixxx/+bug/1902125) (cause by `setFocusPolicy(Qt::NoFocus);

And [lp:1943325  remove focus from lineedits after pressing Enter to allow keyboard shortcuts ](https://bugs.launchpad.net/mixxx/+bug/1943325)
