### PR TITLE
Beats: Refactor getBpm() into getBpmInRange(startPos, endPos)

### DIFF
--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -233,7 +233,7 @@ void AnalyzerBeats::storeResults(TrackPointer pTrack) {
                 m_bPreferencesFixedTempo,
                 m_sampleRate);
         qDebug() << "AnalyzerBeats plugin detected" << beats.size()
-                 << "beats. Average BPM:"
+                 << "beats. Predominant BPM:"
                  << (pBeats ? pBeats->getBpmInRange(
                                       mixxx::audio::kStartFramePos,
                                       mixxx::audio::FramePos{

--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -145,7 +145,10 @@ bool AnalyzerBeats::shouldAnalyze(TrackPointer pTrack) const {
     if (!pBeats) {
         return true;
     }
-    if (!pBeats->getBpm().isValid()) {
+    if (!pBeats->getBpmInRange(mixxx::audio::kStartFramePos,
+                       mixxx::audio::FramePos{
+                               pTrack->getDuration() * pBeats->getSampleRate()})
+                    .isValid()) {
         // Tracks with an invalid bpm <= 0 should be re-analyzed,
         // independent of the preference settings. We expect that
         // all tracks have a bpm > 0 when analyzed. Users that want
@@ -230,7 +233,13 @@ void AnalyzerBeats::storeResults(TrackPointer pTrack) {
                 m_bPreferencesFixedTempo,
                 m_sampleRate);
         qDebug() << "AnalyzerBeats plugin detected" << beats.size()
-                 << "beats. Average BPM:" << (pBeats ? pBeats->getBpm() : mixxx::Bpm());
+                 << "beats. Average BPM:"
+                 << (pBeats ? pBeats->getBpmInRange(
+                                      mixxx::audio::kStartFramePos,
+                                      mixxx::audio::FramePos{
+                                              pTrack->getDuration() *
+                                              pBeats->getSampleRate()})
+                            : mixxx::Bpm());
     } else {
         mixxx::Bpm bpm = m_pPlugin->getBpm();
         qDebug() << "AnalyzerBeats plugin detected constant BPM: " << bpm;

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -622,7 +622,7 @@ void SyncControl::reportPlayerSpeed(double speed, bool scratching) {
 mixxx::Bpm SyncControl::fileBpm() const {
     mixxx::BeatsPointer pBeats = m_pBeats;
     if (pBeats) {
-        return pBeats->getBpm();
+        return pBeats->getBpmInRange(mixxx::audio::kStartFramePos, frameInfo().trackEndPosition);
     }
     return {};
 }

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -594,7 +594,10 @@ void bindTrackLibraryValues(
         beatsBlob = pBeats->toByteArray();
         beatsVersion = pBeats->getVersion();
         beatsSubVersion = pBeats->getSubVersion();
-        bpm = pBeats->getBpm();
+        const auto trackEndPosition = mixxx::audio::FramePos{
+                trackMetadata.getStreamInfo().getDuration().toDoubleSeconds() *
+                pBeats->getSampleRate()};
+        bpm = pBeats->getBpmInRange(mixxx::audio::kStartFramePos, trackEndPosition);
     }
     const double bpmValue = bpm.isValid() ? bpm.value() : mixxx::Bpm::kValueUndefined;
     pTrackLibraryQuery->bindValue(":bpm", bpmValue);

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -32,25 +32,40 @@ TEST(BeatGridTest, Scale) {
     auto pGrid = Beats::fromConstTempo(pTrack->getSampleRate(),
             mixxx::audio::kStartFramePos,
             mixxx::Bpm(bpm));
+    const auto trackEndPosition = audio::FramePos{pTrack->getDuration() * pGrid->getSampleRate()};
 
-    EXPECT_DOUBLE_EQ(bpm.value(), pGrid->getBpm().value());
+    EXPECT_DOUBLE_EQ(bpm.value(),
+            pGrid->getBpmInRange(audio::kStartFramePos, trackEndPosition)
+                    .value());
     pGrid = *pGrid->tryScale(Beats::BpmScale::Double);
-    EXPECT_DOUBLE_EQ(2 * bpm.value(), pGrid->getBpm().value());
+    EXPECT_DOUBLE_EQ(2 * bpm.value(),
+            pGrid->getBpmInRange(audio::kStartFramePos, trackEndPosition)
+                    .value());
 
     pGrid = *pGrid->tryScale(Beats::BpmScale::Halve);
-    EXPECT_DOUBLE_EQ(bpm.value(), pGrid->getBpm().value());
+    EXPECT_DOUBLE_EQ(bpm.value(),
+            pGrid->getBpmInRange(audio::kStartFramePos, trackEndPosition)
+                    .value());
 
     pGrid = *pGrid->tryScale(Beats::BpmScale::TwoThirds);
-    EXPECT_DOUBLE_EQ(bpm.value() * 2 / 3, pGrid->getBpm().value());
+    EXPECT_DOUBLE_EQ(bpm.value() * 2 / 3,
+            pGrid->getBpmInRange(audio::kStartFramePos, trackEndPosition)
+                    .value());
 
     pGrid = *pGrid->tryScale(Beats::BpmScale::ThreeHalves);
-    EXPECT_DOUBLE_EQ(bpm.value(), pGrid->getBpm().value());
+    EXPECT_DOUBLE_EQ(bpm.value(),
+            pGrid->getBpmInRange(audio::kStartFramePos, trackEndPosition)
+                    .value());
 
     pGrid = *pGrid->tryScale(Beats::BpmScale::ThreeFourths);
-    EXPECT_DOUBLE_EQ(bpm.value() * 3 / 4, pGrid->getBpm().value());
+    EXPECT_DOUBLE_EQ(bpm.value() * 3 / 4,
+            pGrid->getBpmInRange(audio::kStartFramePos, trackEndPosition)
+                    .value());
 
     pGrid = *pGrid->tryScale(Beats::BpmScale::FourThirds);
-    EXPECT_DOUBLE_EQ(bpm.value(), pGrid->getBpm().value());
+    EXPECT_DOUBLE_EQ(bpm.value(),
+            pGrid->getBpmInRange(audio::kStartFramePos, trackEndPosition)
+                    .value());
 }
 
 TEST(BeatGridTest, TestNthBeatWhenOnBeat) {
@@ -149,7 +164,11 @@ TEST(BeatGridTest, FromMetadata) {
     EXPECT_DOUBLE_EQ(pTrack->getBpm(), bpm.value());
 
     auto pBeats = pTrack->getBeats();
-    EXPECT_DOUBLE_EQ(pBeats->getBpm().value(), bpm.value());
+    const auto trackEndPosition = audio::FramePos{pTrack->getDuration() * pBeats->getSampleRate()};
+    EXPECT_DOUBLE_EQ(
+            pBeats->getBpmInRange(audio::kStartFramePos, trackEndPosition)
+                    .value(),
+            bpm.value());
 
     // Invalid bpm resets the bpm
     ASSERT_TRUE(pTrack->trySetBpm(-60.1));

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -61,25 +61,40 @@ TEST_F(BeatMapTest, Scale) {
     QVector<mixxx::audio::FramePos> beats =
             createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
     auto pMap = Beats::fromBeatPositions(m_pTrack->getSampleRate(), beats);
+    const auto trackEndPosition = audio::FramePos{m_pTrack->getDuration() * pMap->getSampleRate()};
 
-    EXPECT_DOUBLE_EQ(bpm.value(), pMap->getBpm().value());
+    EXPECT_DOUBLE_EQ(bpm.value(),
+            pMap->getBpmInRange(audio::kStartFramePos, trackEndPosition)
+                    .value());
     pMap = *pMap->tryScale(Beats::BpmScale::Double);
-    EXPECT_DOUBLE_EQ(2 * bpm.value(), pMap->getBpm().value());
+    EXPECT_DOUBLE_EQ(2 * bpm.value(),
+            pMap->getBpmInRange(audio::kStartFramePos, trackEndPosition)
+                    .value());
 
     pMap = *pMap->tryScale(Beats::BpmScale::Halve);
-    EXPECT_DOUBLE_EQ(bpm.value(), pMap->getBpm().value());
+    EXPECT_DOUBLE_EQ(bpm.value(),
+            pMap->getBpmInRange(audio::kStartFramePos, trackEndPosition)
+                    .value());
 
     pMap = *pMap->tryScale(Beats::BpmScale::TwoThirds);
-    EXPECT_DOUBLE_EQ(bpm.value() * 2 / 3, pMap->getBpm().value());
+    EXPECT_DOUBLE_EQ(bpm.value() * 2 / 3,
+            pMap->getBpmInRange(audio::kStartFramePos, trackEndPosition)
+                    .value());
 
     pMap = *pMap->tryScale(Beats::BpmScale::ThreeHalves);
-    EXPECT_DOUBLE_EQ(bpm.value(), pMap->getBpm().value());
+    EXPECT_DOUBLE_EQ(bpm.value(),
+            pMap->getBpmInRange(audio::kStartFramePos, trackEndPosition)
+                    .value());
 
     pMap = *pMap->tryScale(Beats::BpmScale::ThreeFourths);
-    EXPECT_DOUBLE_EQ(bpm.value() * 3 / 4, pMap->getBpm().value());
+    EXPECT_DOUBLE_EQ(bpm.value() * 3 / 4,
+            pMap->getBpmInRange(audio::kStartFramePos, trackEndPosition)
+                    .value());
 
     pMap = *pMap->tryScale(Beats::BpmScale::FourThirds);
-    EXPECT_DOUBLE_EQ(bpm.value(), pMap->getBpm().value());
+    EXPECT_DOUBLE_EQ(bpm.value(),
+            pMap->getBpmInRange(audio::kStartFramePos, trackEndPosition)
+                    .value());
 }
 
 TEST_F(BeatMapTest, TestNthBeat) {

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -247,7 +247,11 @@ bool BeatGrid::hasBeatInRange(audio::FramePos startPosition, audio::FramePos end
     return false;
 }
 
-mixxx::Bpm BeatGrid::getBpm() const {
+mixxx::Bpm BeatGrid::getBpmInRange(
+        audio::FramePos startPosition, audio::FramePos endPosition) const {
+    Q_UNUSED(startPosition);
+    Q_UNUSED(endPosition);
+
     if (!isValid()) {
         return {};
     }
@@ -258,7 +262,11 @@ mixxx::Bpm BeatGrid::getBpm() const {
 mixxx::Bpm BeatGrid::getBpmAroundPosition(audio::FramePos position, int n) const {
     Q_UNUSED(position);
     Q_UNUSED(n);
-    return getBpm();
+
+    if (!isValid()) {
+        return {};
+    }
+    return bpm();
 }
 
 std::optional<BeatsPointer> BeatGrid::tryTranslate(audio::FrameDiff_t offset) const {

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -51,7 +51,8 @@ class BeatGrid final : public Beats {
     std::unique_ptr<BeatIterator> findBeats(audio::FramePos startPosition,
             audio::FramePos endPosition) const override;
     bool hasBeatInRange(audio::FramePos startPosition, audio::FramePos endPosition) const override;
-    mixxx::Bpm getBpm() const override;
+    mixxx::Bpm getBpmInRange(audio::FramePos startPosition,
+            audio::FramePos endPosition) const override;
     mixxx::Bpm getBpmAroundPosition(audio::FramePos position, int n) const override;
 
     audio::SampleRate getSampleRate() const override {

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -53,7 +53,8 @@ class BeatMap final : public Beats {
             audio::FramePos endPosition) const override;
     bool hasBeatInRange(audio::FramePos startPosition, audio::FramePos endPosition) const override;
 
-    mixxx::Bpm getBpm() const override;
+    mixxx::Bpm getBpmInRange(audio::FramePos startPosition,
+            audio::FramePos endPosition) const override;
     mixxx::Bpm getBpmAroundPosition(audio::FramePos position, int n) const override;
 
     audio::SampleRate getSampleRate() const override {
@@ -76,14 +77,12 @@ class BeatMap final : public Beats {
             MakeSharedTag,
             audio::SampleRate sampleRate,
             const QString& subVersion,
-            BeatList beats,
-            mixxx::Bpm nominalBpm);
+            BeatList beats);
     // Constructor to update the beat map
     BeatMap(
             MakeSharedTag,
             const BeatMap& other,
-            BeatList beats,
-            mixxx::Bpm nominalBpm);
+            BeatList beats);
     BeatMap(
             MakeSharedTag,
             const BeatMap& other);
@@ -93,7 +92,6 @@ class BeatMap final : public Beats {
 
     const QString m_subVersion;
     const audio::SampleRate m_sampleRate;
-    const mixxx::Bpm m_nominalBpm;
     const BeatList m_beats;
 };
 

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -150,9 +150,10 @@ class Beats : private std::enable_shared_from_this<Beats> {
     virtual bool hasBeatInRange(audio::FramePos startPosition,
             audio::FramePos endPosition) const = 0;
 
-    /// Return the average BPM over the entire track if the BPM is valid,
-    /// otherwise returns an invalid bpm value.
-    virtual mixxx::Bpm getBpm() const = 0;
+    /// Return the average BPM between `startPosition` and `endPosition` if the BPM is valid,
+    /// otherwise returns an invalid BPM value.
+    virtual mixxx::Bpm getBpmInRange(audio::FramePos startPosition,
+            audio::FramePos endPosition) const = 0;
 
     /// Return the average BPM over the range of n*2 beats centered around
     /// frame position `position`. For example, n=4 results in an averaging of 8 beats.

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -155,7 +155,7 @@ class Beats : private std::enable_shared_from_this<Beats> {
     virtual mixxx::Bpm getBpmInRange(audio::FramePos startPosition,
             audio::FramePos endPosition) const = 0;
 
-    /// Return the average BPM over the range of n*2 beats centered around
+    /// Return the arithmetic average BPM over the range of n*2 beats centered around
     /// frame position `position`. For example, n=4 results in an averaging of 8 beats.
     /// The returned Bpm value may be invalid.
     virtual mixxx::Bpm getBpmAroundPosition(audio::FramePos position, int n) const = 0;

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -150,8 +150,8 @@ class Beats : private std::enable_shared_from_this<Beats> {
     virtual bool hasBeatInRange(audio::FramePos startPosition,
             audio::FramePos endPosition) const = 0;
 
-    /// Return the average BPM between `startPosition` and `endPosition` if the BPM is valid,
-    /// otherwise returns an invalid BPM value.
+    /// Return the predominant BPM value between `startPosition` and `endPosition`
+    /// if the BPM is valid, otherwise returns an invalid BPM value.
     virtual mixxx::Bpm getBpmInRange(audio::FramePos startPosition,
             audio::FramePos endPosition) const = 0;
 

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -49,8 +49,13 @@ inline bool compareAndSet(T* pField, T&& value) {
 }
 
 inline mixxx::Bpm getBeatsPointerBpm(
-        const mixxx::BeatsPointer& pBeats) {
-    return pBeats ? mixxx::Bpm{pBeats->getBpm()} : mixxx::Bpm{};
+        const mixxx::BeatsPointer& pBeats, double durationSecs) {
+    if (!pBeats) {
+        return mixxx::Bpm{};
+    }
+
+    const auto trackEndPosition = mixxx::audio::FramePos{durationSecs * pBeats->getSampleRate()};
+    return pBeats->getBpmInRange(mixxx::audio::kStartFramePos, trackEndPosition);
 }
 
 } // anonymous namespace
@@ -166,7 +171,10 @@ void Track::replaceMetadataFromSource(
         // Need to set BPM after sample rate since beat grid creation depends on
         // knowing the sample rate. Bug #1020438.
         auto beatsAndBpmModified = false;
-        if (importedBpm.isValid() && (!m_pBeats || !m_pBeats->getBpm().isValid())) {
+        if (importedBpm.isValid() &&
+                (!m_pBeats ||
+                        !getBeatsPointerBpm(m_pBeats, getDuration())
+                                 .isValid())) {
             // Only use the imported BPM if the current beat grid is either
             // missing or not valid! The BPM value in the metadata might be
             // imprecise (normalized or rounded), e.g. ID3v2 only supports
@@ -338,7 +346,8 @@ void Track::adjustReplayGainFromPregain(double gain) {
 
 mixxx::Bpm Track::getBpmWhileLocked() const {
     // BPM values must be synchronized at all times!
-    DEBUG_ASSERT(m_record.getMetadata().getTrackInfo().getBpm() == getBeatsPointerBpm(m_pBeats));
+    DEBUG_ASSERT(m_record.getMetadata().getTrackInfo().getBpm() ==
+            getBeatsPointerBpm(m_pBeats, getDuration()));
     return m_record.getMetadata().getTrackInfo().getBpm();
 }
 
@@ -357,7 +366,7 @@ bool Track::trySetBpmWhileLocked(mixxx::Bpm bpm) {
                 cuePosition,
                 bpm);
         return trySetBeatsWhileLocked(std::move(pBeats));
-    } else if (m_pBeats->getBpm() != bpm) {
+    } else if (getBeatsPointerBpm(m_pBeats, getDuration()) != bpm) {
         // Continue with the regular cases
         const auto newBeats = m_pBeats->trySetBpm(bpm);
         if (newBeats) {
@@ -401,7 +410,7 @@ bool Track::setBeatsWhileLocked(mixxx::BeatsPointer pBeats) {
         return false;
     }
     m_pBeats = std::move(pBeats);
-    m_record.refMetadata().refTrackInfo().setBpm(getBeatsPointerBpm(m_pBeats));
+    m_record.refMetadata().refTrackInfo().setBpm(getBeatsPointerBpm(m_pBeats, getDuration()));
     return true;
 }
 


### PR DESCRIPTION
This lays some groundwork for a future, sparse representation of beats
in a track.

At the moment, we have two kinds of beats implementations:

1. The `BeatMap` representation is simply a list of every single beat
   position in a track. Hence, changing tempos are supported, but memory
   intensive to work with.
2. The `BeatGrid` representation is actually sparse (only stores the
   offset and bpm instead of actual beat positions), but only supports a
   single constant tempo.

Both are not sufficient. A future implementation should be both sparse
and support multiple tempos per track. To make this possible, we need to
know the track duration for calculating the average BPM of a track.

There are two ways to handle this: We could either store the track
duration in a beats object, or we change the `getBpm()` method signature
to require passing the position range of the track that we want to know
the BPM for.

This commit implements the latter solution, because it's fully
backwards-compatible and - in contrast to the former - can be
implemented *without* modifying the protobuf format of the `BeatGrid`
class (which currently doesn't store the track end position).

Related Zulip discussion:
https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/beat.20grid.20revamp.20re.3A.20pr.20.232961/near/251702242