### PR TITLE
Sync Lock: Perform updateAudible work in process call

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1018,6 +1018,8 @@ void EngineBuffer::processTrackLocked(
         }
     }
 
+    m_pSyncControl->updateAudible();
+
     // Give the Reader hints as to which chunks of the current song we
     // really care about. It will try very hard to keep these in memory
     hintReader(rate);
@@ -1217,14 +1219,15 @@ void EngineBuffer::processSeek(bool paused) {
 void EngineBuffer::postProcess(const int iBufferSize) {
     // The order of events here is very delicate.  It's necessary to update
     // some values before others, because the later updates may require
-    // values from the first update.
+    // values from the first update. Do not make calls here that could affect
+    // which Syncable is leader or could cause Syncables to try to match
+    // beat distances. During these calls those values are inconsistent.
     if (kLogger.traceEnabled()) {
         kLogger.trace() << getGroup() << "EngineBuffer::postProcess";
     }
     double local_bpm = m_pBpmControl->updateLocalBpm();
     double beat_distance = m_pBpmControl->updateBeatDistance();
     m_pSyncControl->setLocalBpm(local_bpm);
-    m_pSyncControl->updateAudible();
     SyncMode mode = m_pSyncControl->getSyncMode();
     if (isMaster(mode)) {
         m_pEngineSync->notifyBeatDistanceChanged(m_pSyncControl, beat_distance);

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1018,8 +1018,6 @@ void EngineBuffer::processTrackLocked(
         }
     }
 
-    m_pSyncControl->updateAudible();
-
     // Give the Reader hints as to which chunks of the current song we
     // really care about. It will try very hard to keep these in memory
     hintReader(rate);
@@ -1091,6 +1089,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
         // for postProcess so we can broadcast this update to followers.
         m_pSyncControl->reportPlayerSpeed(m_speed_old, m_scratching_old);
     }
+    m_pSyncControl->updateAudible();
 
     m_iLastBufferSize = iBufferSize;
     m_bCrossfadeReady = false;


### PR DESCRIPTION
Beat distance values are inconsistent during postprocess, so no work should be done in that function that might affect sync state between syncables.

This fixes audio artifacts when two tracks have sync and quantize on and you move the faders up and down during playback.