### PR TITLE
Fix type detection of AIFF files

### DIFF
--- a/res/schema.xml
+++ b/res/schema.xml
@@ -574,4 +574,12 @@ reapplying those migrations.
       UPDATE library SET source_synchronized_ms=NULL WHERE source_synchronized_ms=0;
     </sql>
   </revision>
+  <revision version="39" min_compatible="3">
+    <description>
+      Replace file type "aif" with "aiff".
+    </description>
+    <sql>
+      UPDATE library SET filetype='aiff' WHERE filetype='aif';
+    </sql>
+  </revision>
 </schema>

--- a/src/database/mixxxdb.cpp
+++ b/src/database/mixxxdb.cpp
@@ -12,7 +12,7 @@
 const QString MixxxDb::kDefaultSchemaFile(":/schema.xml");
 
 //static
-const int MixxxDb::kRequiredSchemaVersion = 38;
+const int MixxxDb::kRequiredSchemaVersion = 39;
 
 namespace {
 

--- a/src/sources/soundsource.cpp
+++ b/src/sources/soundsource.cpp
@@ -28,6 +28,10 @@ inline QString fileTypeFromSuffix(const QString& suffix) {
         // of an empty string which might either be null or "".
         return QString{};
     }
+    // Map shortened suffix "aif" to "aiff" for disambiguation
+    if (fileType == QStringLiteral("aif")) {
+        return QStringLiteral("aiff");
+    }
     return fileType;
 }
 

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -752,12 +752,33 @@ TEST_F(SoundSourceProxyTest, getTypeFromFile) {
 }
 
 TEST_F(SoundSourceProxyTest, getTypeFromMissingFile) {
+    // Also verify that the shortened suffix ".aif" (case-insensitive) is
+    // mapped to file type "aiff", independent of whether the file exists or not!
     const QFileInfo missingFileWithUppercaseSuffixAndLeadingTrailingWhitespaceSuffix =
-            kTestDir.absoluteFilePath(QStringLiteral("missing_file. AIFF "));
+            kTestDir.absoluteFilePath(QStringLiteral("missing_file. AIF "));
 
     ASSERT_FALSE(missingFileWithUppercaseSuffixAndLeadingTrailingWhitespaceSuffix.exists());
 
     EXPECT_STREQ(qPrintable("aiff"),
             qPrintable(mixxx::SoundSource::getTypeFromFile(
                     missingFileWithUppercaseSuffixAndLeadingTrailingWhitespaceSuffix)));
+}
+
+TEST_F(SoundSourceProxyTest, getTypeFromAiffFile) {
+    const QString aiffFilePath =
+            kTestDir.absoluteFilePath(QStringLiteral("cover-test.aiff"));
+
+    ASSERT_TRUE(QFileInfo::exists(aiffFilePath));
+    ASSERT_STREQ(qPrintable("aiff"),
+            qPrintable(mixxx::SoundSource::getTypeFromFile(
+                    aiffFilePath)));
+
+    const QString aiffFilePathWithShortenedSuffix =
+            mixxxtest::generateTemporaryFileName(QStringLiteral("cover-test.aif"));
+    mixxxtest::copyFile(aiffFilePath, aiffFilePathWithShortenedSuffix);
+    ASSERT_TRUE(QFileInfo::exists(aiffFilePathWithShortenedSuffix));
+
+    EXPECT_STREQ(qPrintable("aiff"),
+            qPrintable(mixxx::SoundSource::getTypeFromFile(
+                    aiffFilePathWithShortenedSuffix)));
 }


### PR DESCRIPTION
Another follow-up of #4356. The file type mapping of AIFF files was already inconsistent before.

- Consistently map to file type "aiff", even if the file suffix is ".aif"
- Fix existing database entries