### PR TITLE
SoundSourceMP3: Log recoverable errors as info instead of warning

### DIFF
--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -147,8 +147,11 @@ bool decodeFrameHeader(
                     return false;
                 }
             }
-            kLogger.warning() << "Recoverable MP3 header decoding error:"
-                              << mad_stream_errorstr(pMadStream);
+            // These recoverable errors occur for many MP3 files and might
+            // worry users when logged as a warning. The issue will become
+            // obsolete once we switched to FFmpeg for MP3 decoding.
+            kLogger.info() << "Recoverable MP3 header decoding error:"
+                           << mad_stream_errorstr(pMadStream);
             logFrameHeader(kLogger.warning(), *pMadHeader);
             return false;
         }


### PR DESCRIPTION
https://mixxx.discourse.group/t/how-to-relate-analyzer-warnings-to-the-files-which-caused-them-and-how-to-fix/23212