### PR TITLE
Fuzzy beats fix.

### DIFF
--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -666,7 +666,7 @@ mixxx::audio::FramePos BpmControl::getNearestPositionInPhase(
             mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
                     m_pNextBeat->get());
     mixxx::audio::FrameDiff_t thisBeatLengthFrames;
-    if (thisPrevBeatPosition.isValid() || thisNextBeatPosition.isValid() ||
+    if (!thisPrevBeatPosition.isValid() || !thisNextBeatPosition.isValid() ||
             thisPosition > thisNextBeatPosition ||
             thisPosition < thisPrevBeatPosition) {
         if (kLogger.traceEnabled()) {
@@ -863,10 +863,9 @@ mixxx::audio::FramePos BpmControl::getBeatMatchPosition(
     mixxx::audio::FrameDiff_t thisBeatLengthFrames;
 
     // Look up the next beat and beat length for the new position
-    if (!thisNextBeatPosition.isValid() ||
+    if (!thisNextBeatPosition.isValid() || !thisPrevBeatPosition.isValid() ||
             thisPosition > thisNextBeatPosition ||
-            (thisPrevBeatPosition.isValid() &&
-                    thisPosition < thisPrevBeatPosition)) {
+            thisPosition < thisPrevBeatPosition) {
         if (kLogger.traceEnabled()) {
             kLogger.trace() << "BpmControl::getBeatMatchPosition out of date"
                             << thisPrevBeatPosition << thisPosition << thisNextBeatPosition;

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -1228,7 +1228,6 @@ mixxx::audio::FramePos LoopingControl::findQuantizedBeatloopStart(
 
     const mixxx::audio::FrameDiff_t beatLength = nextBeatPosition - prevBeatPosition;
     double loopLength = beatLength * beats;
-    mixxx::audio::FramePos startPosition;
     if (beats >= 1.0) {
         const mixxx::audio::FramePos closestBeatPosition =
                 (nextBeatPosition - currentPosition >

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -1235,39 +1235,27 @@ mixxx::audio::FramePos LoopingControl::findQuantizedBeatloopStart(
                         currentPosition - prevBeatPosition)
                 ? prevBeatPosition
                 : nextBeatPosition;
-        startPosition = closestBeatPosition;
-    } else {
-        // In case of beat length less then 1 beat:
-        // (| - beats, ^ - current track's position):
-        //
-        // ...|...................^........|...
-        //
-        // If we press 1/2 beatloop we want loop from 50% to 100%,
-        // If I press 1/4 beatloop, we want loop from 50% to 75% etc
-        const mixxx::audio::FrameDiff_t framesSinceLastBeat =
-                currentPosition - prevBeatPosition;
-        // find the previous beat fraction and check if the current position is closer to this or the next one
-        // place the new loop start to the closer one
-        const mixxx::audio::FramePos previousFractionBeatPosition =
-                prevBeatPosition + floor(framesSinceLastBeat / loopLength) * loopLength;
-        double framesSinceLastFractionBeatPosition = currentPosition - previousFractionBeatPosition;
-        if (framesSinceLastFractionBeatPosition <= (loopLength / 2.0)) {
-            startPosition = previousFractionBeatPosition;
-        } else {
-            startPosition = previousFractionBeatPosition + loopLength;
-        }
-    }
-    // If running reverse, move the loop one loop size to the left.
-    // Thus, the loops end will be closest to the current position
-    bool reverse = false;
-    if (m_pRateControl != nullptr) {
-        reverse = m_pRateControl->isReverseButtonPressed();
-    }
-    if (reverse) {
-        startPosition -= loopLength;
+        return closestBeatPosition;
     }
 
-    return startPosition;
+    // In case of beat length less then 1 beat:
+    // (| - beats, ^ - current track's position):
+    //
+    // ...|...................^........|...
+    //
+    // If we press 1/2 beatloop we want loop from 50% to 100%,
+    // If I press 1/4 beatloop, we want loop from 50% to 75% etc
+    const mixxx::audio::FrameDiff_t framesSinceLastBeat =
+            currentPosition - prevBeatPosition;
+    // find the previous beat fraction and check if the current position is closer to this or the next one
+    // place the new loop start to the closer one
+    const mixxx::audio::FramePos previousFractionBeatPosition =
+            prevBeatPosition + floor(framesSinceLastBeat / loopLength) * loopLength;
+    double framesSinceLastFractionBeatPosition = currentPosition - previousFractionBeatPosition;
+    if (framesSinceLastFractionBeatPosition <= (loopLength / 2.0)) {
+        return previousFractionBeatPosition;
+    }
+    return previousFractionBeatPosition + loopLength;
 }
 
 void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable) {
@@ -1311,7 +1299,7 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable
             mixxx::audio::kInvalidFramePos,
             LoopSeekMode::MovedOut};
     LoopInfo loopInfo = m_loopInfo.getValue();
-    const auto currentPosition = m_currentPosition.getValue();
+    mixxx::audio::FramePos currentPosition = m_currentPosition.getValue();
 
     // Start from the current position/closest beat and
     // create the loop around X beats from there.
@@ -1321,12 +1309,24 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable
         } else {
             newloopInfo.startPosition = currentPosition;
         }
-    } else if (!m_pQuantizeEnabled->toBool()) {
-        newloopInfo.startPosition = currentPosition;
     } else {
-        // loop_in is set to the closest beat if quantize is on and the loop size is >= 1 beat.
-        // The closest beat might be ahead of play position and will cause a catching loop.
-        newloopInfo.startPosition = findQuantizedBeatloopStart(pBeats, currentPosition, beats);
+        // If running reverse, move the loop one loop size to the left.
+        // Thus, the loops end will be closest to the current position
+        bool reverse = false;
+        if (m_pRateControl != nullptr) {
+            reverse = m_pRateControl->isReverseButtonPressed();
+        }
+        if (reverse) {
+            currentPosition = pBeats->findNBeatsFromPosition(currentPosition, -beats);
+        }
+
+        if (!m_pQuantizeEnabled->toBool()) {
+            newloopInfo.startPosition = currentPosition;
+        } else {
+            // loop_in is set to the closest beat if quantize is on and the loop size is >= 1 beat.
+            // The closest beat might be ahead of play position and will cause a catching loop.
+            newloopInfo.startPosition = findQuantizedBeatloopStart(pBeats, currentPosition, beats);
+        }
     }
 
     newloopInfo.endPosition = pBeats->findNBeatsFromPosition(newloopInfo.startPosition, beats);

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -134,6 +134,10 @@ class LoopingControl : public EngineControl {
             mixxx::audio::FramePos oldLoopInPosition,
             mixxx::audio::FramePos newLoopInPosition,
             mixxx::audio::FramePos newLoopOutPosition);
+    mixxx::audio::FramePos findQuantizedBeatloopStart(
+            const mixxx::BeatsPointer& pBeats,
+            mixxx::audio::FramePos currentPosition,
+            double beats) const;
 
     ControlPushButton* m_pCOBeatLoopActivate;
     ControlPushButton* m_pCOBeatLoopRollActivate;

--- a/src/engine/controls/quantizecontrol.cpp
+++ b/src/engine/controls/quantizecontrol.cpp
@@ -55,8 +55,13 @@ void QuantizeControl::trackBeatsUpdated(mixxx::BeatsPointer pBeats) {
 void QuantizeControl::setFrameInfo(mixxx::audio::FramePos currentPosition,
         mixxx::audio::FramePos trackEndPosition,
         mixxx::audio::SampleRate sampleRate) {
-    EngineControl::setFrameInfo(currentPosition, trackEndPosition, sampleRate);
-    playPosChanged(currentPosition);
+    FrameInfo frameInf = frameInfo();
+    if (frameInf.currentPosition != currentPosition ||
+            frameInf.trackEndPosition != trackEndPosition ||
+            frameInf.sampleRate != sampleRate) {
+        EngineControl::setFrameInfo(currentPosition, trackEndPosition, sampleRate);
+        playPosChanged(currentPosition);
+    }
 }
 
 void QuantizeControl::playPosChanged(mixxx::audio::FramePos position) {

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -164,25 +164,17 @@ audio::FramePos BeatGrid::findNthBeat(audio::FramePos position, int n) const {
     if (!isValid() || n == 0) {
         return audio::kInvalidFramePos;
     }
-
-    const double beatFraction = (position - firstBeatPosition()) / m_beatLengthFrames;
-    const double prevBeat = floor(beatFraction);
-    const double nextBeat = ceil(beatFraction);
-
-    audio::FramePos closestBeatPosition;
+    double startBeat = (position - firstBeatPosition()) / m_beatLengthFrames;
     if (n > 0) {
-        // We're going forward, so use ceil to round up to the next multiple of
-        // m_dBeatLength
-        closestBeatPosition = firstBeatPosition() + nextBeat * m_beatLengthFrames;
+        // We're going forward, so use ceil to round up to the next beat.
+        startBeat = ceil(startBeat);
         n = n - 1;
     } else {
-        // We're going backward, so use floor to round down to the next multiple
-        // of m_dBeatLength
-        closestBeatPosition = firstBeatPosition() + prevBeat * m_beatLengthFrames;
+        // We're going backward, so use floor to round down to the previous beat.
+        startBeat = floor(startBeat);
         n = n + 1;
     }
-
-    const audio::FramePos result = closestBeatPosition + n * m_beatLengthFrames;
+    const audio::FramePos result = firstBeatPosition() + (startBeat + n) * m_beatLengthFrames;
     return result;
 }
 

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -186,6 +186,13 @@ audio::FramePos BeatGrid::findNthBeat(audio::FramePos position, int n) const {
     return result;
 }
 
+audio::FramePos BeatGrid::findNBeatsFromPosition(audio::FramePos position, double beats) const {
+    if (!isValid() && position.isValid()) {
+        return audio::kInvalidFramePos;
+    }
+    return position + beats * m_beatLengthFrames;
+};
+
 bool BeatGrid::findPrevNextBeats(audio::FramePos position,
         audio::FramePos* prevBeatPosition,
         audio::FramePos* nextBeatPosition,

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -186,12 +186,12 @@ audio::FramePos BeatGrid::findNBeatsFromPosition(audio::FramePos position, doubl
 };
 
 bool BeatGrid::findPrevNextBeats(audio::FramePos position,
-        audio::FramePos* prevBeatPosition,
-        audio::FramePos* nextBeatPosition,
+        audio::FramePos* pPrevBeatPosition,
+        audio::FramePos* pNextBeatPosition,
         bool snapToNearBeats) const {
     if (!isValid()) {
-        *prevBeatPosition = audio::kInvalidFramePos;
-        *nextBeatPosition = audio::kInvalidFramePos;
+        *pPrevBeatPosition = audio::kInvalidFramePos;
+        *pNextBeatPosition = audio::kInvalidFramePos;
         return false;
     }
 
@@ -214,8 +214,8 @@ bool BeatGrid::findPrevNextBeats(audio::FramePos position,
         // And nextBeat needs to be incremented.
         ++nextBeat;
     }
-    *prevBeatPosition = firstBeatPosition() + prevBeat * m_beatLengthFrames;
-    *nextBeatPosition = firstBeatPosition() + nextBeat * m_beatLengthFrames;
+    *pPrevBeatPosition = firstBeatPosition() + prevBeat * m_beatLengthFrames;
+    *pNextBeatPosition = firstBeatPosition() + nextBeat * m_beatLengthFrames;
     return true;
 }
 

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -164,17 +164,17 @@ audio::FramePos BeatGrid::findNthBeat(audio::FramePos position, int n) const {
     if (!isValid() || n == 0) {
         return audio::kInvalidFramePos;
     }
-    double startBeat = (position - firstBeatPosition()) / m_beatLengthFrames;
+    double fromBeatIndex = (position - firstBeatPosition()) / m_beatLengthFrames;
     if (n > 0) {
         // We're going forward, so use ceil to round up to the next beat.
-        startBeat = ceil(startBeat);
+        fromBeatIndex = ceil(fromBeatIndex);
         n = n - 1;
     } else {
         // We're going backward, so use floor to round down to the previous beat.
-        startBeat = floor(startBeat);
+        fromBeatIndex = floor(fromBeatIndex);
         n = n + 1;
     }
-    const audio::FramePos result = firstBeatPosition() + (startBeat + n) * m_beatLengthFrames;
+    const audio::FramePos result = firstBeatPosition() + (fromBeatIndex + n) * m_beatLengthFrames;
     return result;
 }
 

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -47,8 +47,8 @@ class BeatGrid final : public Beats {
             audio::FramePos position,
             double beats) const override;
     bool findPrevNextBeats(audio::FramePos position,
-            audio::FramePos* prevBeatPosition,
-            audio::FramePos* nextBeatPosition,
+            audio::FramePos* pPrevBeatPosition,
+            audio::FramePos* pNextBeatPosition,
             bool snapToNearBeats) const override;
     audio::FramePos findNthBeat(audio::FramePos position, int n) const override;
     std::unique_ptr<BeatIterator> findBeats(audio::FramePos startPosition,

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -43,6 +43,9 @@ class BeatGrid final : public Beats {
     // Beat calculations
     ////////////////////////////////////////////////////////////////////////////
 
+    audio::FramePos findNBeatsFromPosition(
+            audio::FramePos position,
+            double beats) const override;
     bool findPrevNextBeats(audio::FramePos position,
             audio::FramePos* prevBeatPosition,
             audio::FramePos* nextBeatPosition,

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -353,7 +353,7 @@ audio::FramePos BeatMap::findNBeatsFromPosition(audio::FramePos position, double
     audio::FramePos prevBeatPosition;
     audio::FramePos nextBeatPosition;
 
-    if (!findPrevNextBeats(position, &prevBeatPosition, &nextBeatPosition, true)) {
+    if (!findPrevNextBeats(position, &prevBeatPosition, &nextBeatPosition, false)) {
         return position;
     }
     const audio::FrameDiff_t fromFractionBeats = (position - prevBeatPosition) /

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -398,75 +398,36 @@ bool BeatMap::findPrevNextBeats(audio::FramePos position,
         return false;
     }
 
-    Beat beat = beatFromFramePos(position.toNearestFrameBoundary());
-
-    // it points at the first occurrence of beat or the next largest beat
-    BeatList::const_iterator it =
-            std::lower_bound(m_beats.constBegin(), m_beats.constEnd(), beat, beatLessThan);
-
-    // If the position is within 1/10th of a second of the next or previous
-    // beat, pretend we are on that beat.
-    const double kFrameEpsilon = 0.1 * m_sampleRate;
-
-    // Back-up by one.
-    if (it != m_beats.begin()) {
-        --it;
+    double kFrameEpsilon = 0.0;
+    if (snapToNearBeats) {
+        // If the position is within 1/10th of a second of the next or previous
+        // beat, pretend we are on that beat.
+        kFrameEpsilon = 0.1 * m_sampleRate;
     }
 
-    // Scan forward to find whether we are on a beat.
-    BeatList::const_iterator on_beat = m_beats.constEnd();
-    BeatList::const_iterator previous_beat = m_beats.constEnd();
-    BeatList::const_iterator next_beat = m_beats.constEnd();
+    BeatList::const_iterator it = m_beats.constBegin();
     for (; it != m_beats.end(); ++it) {
-        qint32 delta = it->frame_position() - beat.frame_position();
-
-        if ((!snapToNearBeats && (delta == 0)) ||
-                (snapToNearBeats && (abs(delta) < kFrameEpsilon))) {
-            // We are "on" this beat.
-            on_beat = it;
+        audio::FramePos beatPos(it->frame_position());
+        if (beatPos.value() > position.value() + kFrameEpsilon) {
+            *nextBeatPosition = beatPos;
             break;
         }
-
-        if (delta < 0) {
-            // If we are not on the beat and delta < 0 then this beat comes
-            // before our current position.
-            previous_beat = it;
-        } else {
-            // If we are past the beat and we aren't on it then this beat comes
-            // after our current position.
-            next_beat = it;
-            // Stop because we have everything we need now.
-            break;
-        }
+        *prevBeatPosition = beatPos;
     }
 
-    // If we are within epsilon samples of a beat then the immediately next and
-    // previous beats are the beat we are on.
-    if (on_beat != m_beats.end()) {
-        previous_beat = on_beat;
-        next_beat = on_beat + 1;
-    }
-
-    for (; next_beat != m_beats.end(); ++next_beat) {
-        if (!next_beat->enabled()) {
-            continue;
-        }
-        *nextBeatPosition = mixxx::audio::FramePos(next_beat->frame_position());
-        break;
-    }
-    if (previous_beat != m_beats.end()) {
-        for (; true; --previous_beat) {
-            if (previous_beat->enabled()) {
-                *prevBeatPosition = mixxx::audio::FramePos(previous_beat->frame_position());
-                break;
-            }
-
-            // Don't step before the start of the list.
-            if (previous_beat == m_beats.begin()) {
-                break;
+    if (!prevBeatPosition->isValid() && it != m_beats.end()) {
+        // we have no previous beat, assume a beat with the same length as the fist
+        ++it;
+        if (it != m_beats.end()) {
+            audio::FramePos afterNextBeatPos(it->frame_position());
+            audio::FramePos prevBeat = *nextBeatPosition - (afterNextBeatPos - *nextBeatPosition);
+            if (prevBeat.value() <= position.value() - kFrameEpsilon) {
+                *prevBeatPosition = prevBeat;
             }
         }
     }
+
+    //qDebug() << "findPrevNextBeats()" << *prevBeatPosition << *nextBeatPosition;
     return prevBeatPosition->isValid() && nextBeatPosition->isValid();
 }
 

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -349,6 +349,45 @@ audio::FramePos BeatMap::findNthBeat(audio::FramePos position, int n) const {
     return foundBeatPosition;
 }
 
+audio::FramePos BeatMap::findNBeatsFromPosition(audio::FramePos position, double beats) const {
+    audio::FramePos prevBeatPosition;
+    audio::FramePos nextBeatPosition;
+
+    if (!findPrevNextBeats(position, &prevBeatPosition, &nextBeatPosition, true)) {
+        return position;
+    }
+    const audio::FrameDiff_t fromFractionBeats = (position - prevBeatPosition) /
+            (nextBeatPosition - prevBeatPosition);
+    const audio::FrameDiff_t beatsFromPrevBeat = fromFractionBeats + beats;
+
+    const int fullBeats = static_cast<int>(beatsFromPrevBeat);
+    const audio::FrameDiff_t fractionBeats = beatsFromPrevBeat - fullBeats;
+
+    // Add the length between this beat and the fullbeats'th beat
+    // to the end position
+    audio::FramePos nthBeatPosition;
+    if (fullBeats > 0) {
+        nthBeatPosition = findNthBeat(nextBeatPosition, fullBeats);
+    } else {
+        nthBeatPosition = findNthBeat(prevBeatPosition, fullBeats - 1);
+    }
+
+    if (!nthBeatPosition.isValid()) {
+        return position;
+    }
+
+    // Add the fraction of the beat
+    if (fractionBeats != 0) {
+        nextBeatPosition = findNthBeat(nthBeatPosition, 2);
+        if (!nextBeatPosition.isValid()) {
+            return position;
+        }
+        nthBeatPosition += (nextBeatPosition - nthBeatPosition) * fractionBeats;
+    }
+
+    return nthBeatPosition;
+};
+
 bool BeatMap::findPrevNextBeats(audio::FramePos position,
         audio::FramePos* prevBeatPosition,
         audio::FramePos* nextBeatPosition,

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -389,11 +389,11 @@ audio::FramePos BeatMap::findNBeatsFromPosition(audio::FramePos position, double
 };
 
 bool BeatMap::findPrevNextBeats(audio::FramePos position,
-        audio::FramePos* prevBeatPosition,
-        audio::FramePos* nextBeatPosition,
+        audio::FramePos* pPrevBeatPosition,
+        audio::FramePos* pNextBeatPosition,
         bool snapToNearBeats) const {
-    *prevBeatPosition = audio::kInvalidFramePos;
-    *nextBeatPosition = audio::kInvalidFramePos;
+    *pPrevBeatPosition = audio::kInvalidFramePos;
+    *pNextBeatPosition = audio::kInvalidFramePos;
     if (!isValid() || !position.isValid()) {
         return false;
     }
@@ -409,26 +409,26 @@ bool BeatMap::findPrevNextBeats(audio::FramePos position,
     for (; it != m_beats.end(); ++it) {
         audio::FramePos beatPos(it->frame_position());
         if (beatPos.value() > position.value() + kFrameEpsilon) {
-            *nextBeatPosition = beatPos;
+            *pNextBeatPosition = beatPos;
             break;
         }
-        *prevBeatPosition = beatPos;
+        *pPrevBeatPosition = beatPos;
     }
 
-    if (!prevBeatPosition->isValid() && it != m_beats.end()) {
+    if (!pPrevBeatPosition->isValid() && it != m_beats.end()) {
         // we have no previous beat, assume a beat with the same length as the fist
         ++it;
         if (it != m_beats.end()) {
             audio::FramePos afterNextBeatPos(it->frame_position());
-            audio::FramePos prevBeat = *nextBeatPosition - (afterNextBeatPos - *nextBeatPosition);
+            audio::FramePos prevBeat = *pNextBeatPosition - (afterNextBeatPos - *pNextBeatPosition);
             if (prevBeat.value() <= position.value() - kFrameEpsilon) {
-                *prevBeatPosition = prevBeat;
+                *pPrevBeatPosition = prevBeat;
             }
         }
     }
 
-    //qDebug() << "findPrevNextBeats()" << *prevBeatPosition << *nextBeatPosition;
-    return prevBeatPosition->isValid() && nextBeatPosition->isValid();
+    //qDebug() << "findPrevNextBeats()" << *pPrevBeatPosition << *pNextBeatPosition;
+    return pPrevBeatPosition->isValid() && pNextBeatPosition->isValid();
 }
 
 std::unique_ptr<BeatIterator> BeatMap::findBeats(

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -48,8 +48,8 @@ class BeatMap final : public Beats {
             audio::FramePos position,
             double beats) const override;
     bool findPrevNextBeats(audio::FramePos position,
-            audio::FramePos* prevBeatPosition,
-            audio::FramePos* nextBeatPosition,
+            audio::FramePos* pPrevBeatPosition,
+            audio::FramePos* pNextBeatPosition,
             bool snapToNearBeats) const override;
     audio::FramePos findNthBeat(audio::FramePos position, int n) const override;
     std::unique_ptr<BeatIterator> findBeats(audio::FramePos startPosition,

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -44,6 +44,9 @@ class BeatMap final : public Beats {
     // Beat calculations
     ////////////////////////////////////////////////////////////////////////////
 
+    audio::FramePos findNBeatsFromPosition(
+            audio::FramePos position,
+            double beats) const override;
     bool findPrevNextBeats(audio::FramePos position,
             audio::FramePos* prevBeatPosition,
             audio::FramePos* nextBeatPosition,

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -49,7 +49,22 @@ BeatsPointer Beats::fromBeatPositions(
     return BeatMap::makeBeatMap(sampleRate, subVersion, beatPositions);
 }
 
+audio::FramePos Beats::snapPosToNearBeat(audio::FramePos position) const {
+    audio::FramePos prevBeatPosition;
+    audio::FramePos nextBeatPosition;
+    findPrevNextBeats(position, &prevBeatPosition, &nextBeatPosition, true);
+    if (prevBeatPosition.isValid() && position < prevBeatPosition) {
+        // Snap to beat
+        return prevBeatPosition;
+    } else if (nextBeatPosition.isValid() && position > nextBeatPosition) {
+        // Snap to beat
+        return nextBeatPosition;
+    }
+    return position;
+}
+
 int Beats::numBeatsInRange(audio::FramePos startPosition, audio::FramePos endPosition) const {
+    startPosition = snapPosToNearBeat(startPosition);
     audio::FramePos lastPosition = audio::kStartFramePos;
     int i = 1;
     while (lastPosition < endPosition) {

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -76,7 +76,7 @@ audio::FramePos Beats::findClosestBeat(audio::FramePos position) const {
     }
     audio::FramePos prevBeatPosition;
     audio::FramePos nextBeatPosition;
-    findPrevNextBeats(position, &prevBeatPosition, &nextBeatPosition, true);
+    findPrevNextBeats(position, &prevBeatPosition, &nextBeatPosition, false);
     if (!prevBeatPosition.isValid()) {
         // If both positions are invalid, we correctly return an invalid position.
         return nextBeatPosition;

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -92,43 +92,4 @@ audio::FramePos Beats::findClosestBeat(audio::FramePos position) const {
             : nextBeatPosition;
 }
 
-audio::FramePos Beats::findNBeatsFromPosition(audio::FramePos position, double beats) const {
-    audio::FramePos prevBeatPosition;
-    audio::FramePos nextBeatPosition;
-
-    if (!findPrevNextBeats(position, &prevBeatPosition, &nextBeatPosition, true)) {
-        return position;
-    }
-    const audio::FrameDiff_t fromFractionBeats = (position - prevBeatPosition) /
-            (nextBeatPosition - prevBeatPosition);
-    const audio::FrameDiff_t beatsFromPrevBeat = fromFractionBeats + beats;
-
-    const int fullBeats = static_cast<int>(beatsFromPrevBeat);
-    const audio::FrameDiff_t fractionBeats = beatsFromPrevBeat - fullBeats;
-
-    // Add the length between this beat and the fullbeats'th beat
-    // to the end position
-    audio::FramePos nthBeatPosition;
-    if (fullBeats > 0) {
-        nthBeatPosition = findNthBeat(nextBeatPosition, fullBeats);
-    } else {
-        nthBeatPosition = findNthBeat(prevBeatPosition, fullBeats - 1);
-    }
-
-    if (!nthBeatPosition.isValid()) {
-        return position;
-    }
-
-    // Add the fraction of the beat
-    if (fractionBeats != 0) {
-        nextBeatPosition = findNthBeat(nthBeatPosition, 2);
-        if (!nextBeatPosition.isValid()) {
-            return position;
-        }
-        nthBeatPosition += (nextBeatPosition - nthBeatPosition) * fractionBeats;
-    }
-
-    return nthBeatPosition;
-};
-
 } // namespace mixxx

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -130,6 +130,12 @@ class Beats : private std::enable_shared_from_this<Beats> {
     /// be found, returns an invalid frame position.
     virtual audio::FramePos findNthBeat(audio::FramePos position, int n) const = 0;
 
+    /// This function snaps the position to a beat if near.
+    /// This is used for beat loops, where start and end positions might be slightly off
+    /// due to rounding or quantizations by the engine buffer.
+    /// It makes use of virtual findPrevNextBeats() as a single instance for snapping.
+    audio::FramePos snapPosToNearBeat(audio::FramePos position) const;
+
     int numBeatsInRange(audio::FramePos startPosition, audio::FramePos endPosition) const;
 
     /// Find the frame position N beats away from `position`. The number of beats may be

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -133,8 +133,10 @@ class Beats : private std::enable_shared_from_this<Beats> {
     int numBeatsInRange(audio::FramePos startPosition, audio::FramePos endPosition) const;
 
     /// Find the frame position N beats away from `position`. The number of beats may be
-    /// negative and does not need to be an integer.
-    audio::FramePos findNBeatsFromPosition(audio::FramePos position, double beats) const;
+    /// negative and does not need to be an integer. In this case the returned position will
+    /// be between two beats as well at the same fraction.
+    virtual audio::FramePos findNBeatsFromPosition(
+            audio::FramePos position, double beats) const = 0;
 
     /// Reutns an iterator that yields frame position of every beat occurring
     /// between `startPosition` and `endPosition`. `BeatIterator` must be iterated

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -107,8 +107,8 @@ class Beats : private std::enable_shared_from_this<Beats> {
     /// `position`, and the second value is the next beat position. Returns
     /// `false` if *at least one* position is invalid.
     virtual bool findPrevNextBeats(audio::FramePos position,
-            audio::FramePos* prevBeatPosition,
-            audio::FramePos* nextBeatPosition,
+            audio::FramePos* pPrevBeatPosition,
+            audio::FramePos* pNextBeatPosition,
             bool snapToNearBeats) const = 0;
 
     /// Return the frame position of the first beat in the track, or an invalid


### PR DESCRIPTION
I have reviewed all edge case for the beat snapping algorithm and adjusted it as it makes most sense. 
Normally the functions should not snap to a beat. In most cases this creates exceptional code paths which are hard to maintain, because snapping of an inner function is not expected when reading the code. 

We have two exceptions where snapping is still applied: 
* The "beat_next" "beat_prev" COs used for caching the result of findPrevNextBeats(), along with some grown code build on it. I don't want to touch it to limit the risk of more regressions 
* The looping code. Here we have some odd situations related to the quantitation done by one audio buffer cycle. In case of beatloops, we need to be sure that the loop is still considered between two beats even if it overshoots slightly due to an audio buffer.   

The additional double rounding issue of the BeatGrid code should be fixed now. 

I am unsure about the BeatGridIterator it is implemented by repeated `m_currentPosition += m_beatLengthFrames`. I am unsure if it is exactly the same if we use `n * m_beatLengthFrames`. I am afraid not. Does anyone know? 
Luckily it is  only used for visual beats. 

This should make https://github.com/mixxxdj/mixxx/pull/4334 obsolete and fix https://bugs.launchpad.net/mixxx/+bug/1945238


 