### PR TITLE
Pref > Library: add link to manual > settings files info

### DIFF
--- a/src/defs_urls.h
+++ b/src/defs_urls.h
@@ -65,5 +65,7 @@
     MIXXX_MANUAL_URL "/chapters/vinyl_control.html#configuring-vinyl-control"
 #define MIXXX_MANUAL_VINYL_TROUBLESHOOTING_URL \
     MIXXX_MANUAL_URL "/chapters/vinyl_control.html#troubleshooting"
+#define MIXXX_MANUAL_SETTINGS_DIRECTORY_URL \
+    MIXXX_MANUAL_URL "/chapters/appendix.html#settings-directory"
 #define MIXXX_MANUAL_FILENAME   "Mixxx-Manual.pdf"
 #define MIXXX_KBD_SHORTCUTS_FILENAME "Mixxx-Keyboard-Shortcuts.pdf"

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -11,6 +11,7 @@
 #include <QStringList>
 #include <QUrl>
 
+#include "defs_urls.h"
 #include "library/dlgtrackmetadataexport.h"
 #include "library/library.h"
 #include "library/library_prefs.h"
@@ -109,6 +110,19 @@ DlgPrefLibrary::DlgPrefLibrary(
     builtInFormatsStr += ", WavPack";
 #endif
     builtInFormats->setText(builtInFormatsStr);
+
+    // Create text color manual links
+    createLinkColor();
+    // Add link to the manual where configuration files are explained in detail
+    label_settingsManualLink->setText(coloredLinkString(
+            m_pLinkColor,
+            tr("See the manual for details"),
+            MIXXX_MANUAL_SETTINGS_DIRECTORY_URL));
+    connect(label_settingsManualLink,
+            &QLabel::linkActivated,
+            [](const QString& url) {
+                QDesktopServices::openUrl(url);
+            });
 
     connect(checkBox_SyncTrackMetadataExport,
             &QCheckBox::toggled,

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -397,6 +397,16 @@
        </widget>
       </item>
       <item>
+       <widget class="QLabel" name="label_settingsManualLink">
+        <property name="text">
+         <string></string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QLabel" name="label_settingsWarning">
         <property name="text">
          <string>Edit those files only if you know what you are doing and only while Mixxx is not running.</string>


### PR DESCRIPTION
Now, the directory and related info can be accessed from one place, and most support responses regarding log files, configs, mappings, database file etc. can be boiled down to
"Open the preferences, go to the Library page and scroll to the bottom"

![image](https://user-images.githubusercontent.com/5934199/136455711-fa53f961-b4f6-4302-bbea-b7bcb8abfa87.png)
