### PR TITLE
Fix blank duration in LateNight and Tango skins

### DIFF
--- a/res/skins/LateNight/decks/row_2_3_TitleArtistTime.xml
+++ b/res/skins/LateNight/decks/row_2_3_TitleArtistTime.xml
@@ -106,7 +106,7 @@
                     <TooltipId>track_duration</TooltipId>
                     <Size>0min,25f</Size>
                     <Alignment>right</Alignment>
-                    <Property>durationFormatted</Property>
+                    <Property>durationTextSeconds</Property>
                     <Channel>
                       <Variable name="ChanNum"/>
                     </Channel>

--- a/res/skins/LateNight/decks/row_2_3_TitleArtistTime_compact.xml
+++ b/res/skins/LateNight/decks/row_2_3_TitleArtistTime_compact.xml
@@ -107,7 +107,7 @@
                     <ObjectName>DurationText</ObjectName>
                     <TooltipId>track_duration</TooltipId>
                     <Size>0min,22f</Size>
-                    <Property>durationFormatted</Property>
+                    <Property>durationTextSeconds</Property>
                     <Channel>
                       <Variable name="ChanNum"/>
                     </Channel>

--- a/res/skins/Tango/decks/row_text_left.xml
+++ b/res/skins/Tango/decks/row_text_left.xml
@@ -88,7 +88,7 @@ Variables:
             <ObjectName>Duration</ObjectName>
             <Size>60min,21f</Size>
             <TooltipId>track_duration</TooltipId>
-            <Property>durationFormatted</Property>
+            <Property>durationTextSeconds</Property>
             <Alignment>right</Alignment>
             <Channel><Variable name="chanNum"/></Channel>
           </TrackProperty>

--- a/res/skins/Tango/decks/row_text_right.xml
+++ b/res/skins/Tango/decks/row_text_right.xml
@@ -83,7 +83,7 @@ Variables:
             <ObjectName>Duration</ObjectName>
             <Size>80me,21f</Size>
             <TooltipId>track_duration</TooltipId>
-            <Property>durationFormatted</Property>
+            <Property>durationTextSeconds</Property>
             <Alignment>left</Alignment>
             <Channel><Variable name="chanNum"/></Channel>
           </TrackProperty>

--- a/res/skins/Tango/mic_aux_sampler/sampler.xml
+++ b/res/skins/Tango/mic_aux_sampler/sampler.xml
@@ -109,7 +109,7 @@ Variables:
                 <TooltipId>text</TooltipId>
                 <Size>1me,1min</Size>
                 <Group><Variable name="group"/></Group>
-                <Property>durationFormatted</Property>
+                <Property>durationTextSeconds</Property>
               </TrackProperty>
 
               <Template src="skin:../Tango/controls/button_3state.xml">

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -67,7 +67,8 @@ class Track : public QObject {
     Q_PROPERTY(QString bpmText READ getBpmText STORED false NOTIFY bpmChanged)
     Q_PROPERTY(QString keyText READ getKeyText WRITE setKeyText NOTIFY keyChanged)
     Q_PROPERTY(double duration READ getDuration NOTIFY durationChanged)
-    Q_PROPERTY(QString durationText READ getDurationTextSeconds STORED false NOTIFY durationChanged)
+    Q_PROPERTY(QString durationTextSeconds READ getDurationTextSeconds
+                    STORED false NOTIFY durationChanged)
     Q_PROPERTY(QString durationTextCentiseconds READ getDurationTextCentiseconds
                     STORED false NOTIFY durationChanged)
     Q_PROPERTY(QString durationTextMilliseconds READ getDurationTextMilliseconds

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -44,6 +44,11 @@ void WTrackProperty::setup(const QDomNode& node, const SkinContext& context) {
     WLabel::setup(node, context);
 
     m_property = context.selectString(node, "Property");
+
+    // Check if property with that name exists in Track class
+    if (Track::staticMetaObject.indexOfProperty(m_property.toUtf8().constData()) == -1) {
+        qWarning() << "WTrackProperty: Unknown track property:" << m_property;
+    }
 }
 
 void WTrackProperty::slotTrackLoaded(TrackPointer pTrack) {


### PR DESCRIPTION
This fixes a minor regression introduced with 640a59d095e959302b1b52428b7891f864c09961.

Also, a warning is added to help prevent similar things from happening in the future.

Discussion: https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/Missing.20track.20duration.20in.20skins.20in.20main