### PR TITLE
Focus library directly

### DIFF
--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -388,3 +388,7 @@ void DlgAutoDJ::shiftTabKeypress() {
             QKeyEvent{QEvent::KeyPress, Qt::Key_Tab, Qt::ShiftModifier};
     QApplication::sendEvent(this, &backwardFocusKeyEvent);
 }
+
+void DlgAutoDJ::setFocus() {
+    m_pTrackTableView->setFocus();
+}

--- a/src/library/autodj/dlgautodj.h
+++ b/src/library/autodj/dlgautodj.h
@@ -29,6 +29,7 @@ class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
 
     void onShow() override;
     bool hasFocus() const override;
+    void setFocus() override;
     void onSearch(const QString& text) override;
     void loadSelectedTrack() override;
     void loadSelectedTrackToGroup(const QString& group, bool play) override;

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -222,6 +222,7 @@ void BrowseFeature::bindLibraryWidget(WLibrary* libraryWidget,
     WLibraryTextBrowser* edit = new WLibraryTextBrowser(libraryWidget);
     edit->setHtml(getRootViewHtml());
     libraryWidget->registerView("BROWSEHOME", edit);
+    m_pLibrary->bindFeatureRootView(edit);
 }
 
 void BrowseFeature::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {

--- a/src/library/dlganalysis.cpp
+++ b/src/library/dlganalysis.cpp
@@ -111,6 +111,10 @@ bool DlgAnalysis::hasFocus() const {
     return m_pAnalysisLibraryTableView->hasFocus();
 }
 
+void DlgAnalysis::setFocus() {
+    m_pAnalysisLibraryTableView->setFocus();
+}
+
 void DlgAnalysis::onSearch(const QString& text) {
     m_pAnalysisLibraryTableModel->search(text);
 }

--- a/src/library/dlganalysis.h
+++ b/src/library/dlganalysis.h
@@ -25,6 +25,7 @@ class DlgAnalysis : public QWidget, public Ui::DlgAnalysis, public virtual Libra
     void onSearch(const QString& text) override;
     void onShow() override;
     bool hasFocus() const override;
+    void setFocus() override;
     void loadSelectedTrack() override;
     void loadSelectedTrackToGroup(const QString& group, bool play) override;
     void slotAddToAutoDJBottom() override;

--- a/src/library/dlghidden.cpp
+++ b/src/library/dlghidden.cpp
@@ -123,3 +123,7 @@ void DlgHidden::selectionChanged(const QItemSelection &selected,
 bool DlgHidden::hasFocus() const {
     return m_pTrackTableView->hasFocus();
 }
+
+void DlgHidden::setFocus() {
+    m_pTrackTableView->setFocus();
+}

--- a/src/library/dlghidden.h
+++ b/src/library/dlghidden.h
@@ -23,6 +23,7 @@ class DlgHidden : public QWidget, public Ui::DlgHidden, public LibraryView {
 
     void onShow() override;
     bool hasFocus() const override;
+    void setFocus() override;
     void onSearch(const QString& text) override;
     QString currentSearch();
 

--- a/src/library/dlgmissing.cpp
+++ b/src/library/dlgmissing.cpp
@@ -92,3 +92,7 @@ void DlgMissing::selectionChanged(const QItemSelection &selected,
 bool DlgMissing::hasFocus() const {
     return m_pTrackTableView->hasFocus();
 }
+
+void DlgMissing::setFocus() {
+    m_pTrackTableView->setFocus();
+}

--- a/src/library/dlgmissing.h
+++ b/src/library/dlgmissing.h
@@ -23,6 +23,7 @@ class DlgMissing : public QWidget, public Ui::DlgMissing, public LibraryView {
 
     void onShow() override;
     bool hasFocus() const override;
+    void setFocus() override;
     void onSearch(const QString& text) override;
     QString currentSearch();
 

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -43,6 +43,7 @@
 #include "util/sandbox.h"
 #include "widget/wlibrary.h"
 #include "widget/wlibrarysidebar.h"
+#include "widget/wlibrarytextbrowser.h"
 #include "widget/wsearchlineedit.h"
 #include "widget/wtracktableview.h"
 
@@ -288,6 +289,10 @@ void Library::bindSearchboxWidget(WSearchLineEdit* pSearchboxWidget) {
             &WSearchLineEdit::slotSetFont);
     emit setTrackTableFont(m_trackTableFont);
     m_pLibraryControl->bindSearchboxWidget(pSearchboxWidget);
+    connect(pSearchboxWidget,
+            &WSearchLineEdit::searchbarFocusChange,
+            m_pLibraryControl,
+            &LibraryControl::setLibraryFocus);
 }
 
 void Library::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
@@ -317,6 +322,11 @@ void Library::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
             &WLibrarySidebar::rightClicked,
             m_pSidebarModel,
             &SidebarModel::rightClicked);
+
+    connect(pSidebarWidget,
+            &WLibrarySidebar::sidebarFocusChange,
+            m_pLibraryControl,
+            &LibraryControl::setLibraryFocus);
 
     pSidebarWidget->slotSetFont(m_trackTableFont);
     connect(this,
@@ -375,6 +385,10 @@ void Library::bindLibraryWidget(
             &WTrackTableView::setSelectedClick);
 
     m_pLibraryControl->bindLibraryWidget(pLibraryWidget, pKeyboard);
+    connect(pTrackTableView,
+            &WTrackTableView::trackTableFocusChange,
+            m_pLibraryControl,
+            &LibraryControl::setLibraryFocus);
 
     for (const auto& feature : qAsConst(m_features)) {
         feature->bindLibraryWidget(pLibraryWidget, pKeyboard);
@@ -385,6 +399,13 @@ void Library::bindLibraryWidget(
     emit setTrackTableFont(m_trackTableFont);
     emit setTrackTableRowHeight(m_iTrackTableRowHeight);
     emit setSelectedClick(m_editMetadataSelectedClick);
+}
+
+void Library::bindFeatureRootView(WLibraryTextBrowser* pTextBrowser) {
+    connect(pTextBrowser,
+            &WLibraryTextBrowser::textBrowserFocusChange,
+            m_pLibraryControl,
+            &LibraryControl::setLibraryFocus);
 }
 
 void Library::addFeature(LibraryFeature* feature) {

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -36,6 +36,7 @@ class TrackModel;
 class WSearchLineEdit;
 class WLibrarySidebar;
 class WLibrary;
+class WLibraryTextBrowser;
 
 #ifdef __ENGINEPRIME__
 namespace mixxx {
@@ -69,6 +70,7 @@ class Library: public QObject {
     void bindSidebarWidget(WLibrarySidebar* sidebarWidget);
     void bindLibraryWidget(WLibrary* libraryWidget,
                     KeyboardEventFilter* pKeyboard);
+    void bindFeatureRootView(WLibraryTextBrowser* pTextBrowser);
 
     void addFeature(LibraryFeature* feature);
 

--- a/src/library/library_decl.h
+++ b/src/library/library_decl.h
@@ -7,3 +7,12 @@ enum class LibraryRemovalType {
     HideTracks,
     PurgeTracks
 };
+
+enum class FocusWidget {
+    None,
+    Searchbar,
+    Sidebar,
+    TracksTable, // or a feature root view (WLibraryTextBrowser)
+    Count        // used for setting the number of PushButton states of
+                 // m_pLibraryFocusedWidgetCO in librarycontrol.cpp
+};

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -62,6 +62,7 @@ LibraryControl::LibraryControl(Library* pLibrary)
           m_numDecks("[Master]", "num_decks", this),
           m_numSamplers("[Master]", "num_samplers", this),
           m_numPreviewDecks("[Master]", "num_preview_decks", this) {
+    qRegisterMetaType<FocusWidget>("FocusWidget");
 
     slotNumDecksChanged(m_numDecks.get());
     slotNumSamplersChanged(m_numSamplers.get());
@@ -121,7 +122,8 @@ LibraryControl::LibraryControl(Library* pLibrary)
             this,
             &LibraryControl::slotMoveHorizontal);
 
-    // Control to navigate between widgets (tab/shit+tab button)
+    // Controls to navigate between widgets
+    // Relative focus controls (tab/shift+tab button)
     m_pMoveFocusForward = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveFocusForward"));
     m_pMoveFocusBackward = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveFocusBackward"));
     m_pMoveFocus = std::make_unique<ControlEncoder>(ConfigKey("[Library]", "MoveFocus"), false);
@@ -137,6 +139,25 @@ LibraryControl::LibraryControl(Library* pLibrary)
             &ControlEncoder::valueChanged,
             this,
             &LibraryControl::slotMoveFocus);
+    // Direct focus control, read/write
+    m_pLibraryFocusedWidgetCO = std::make_unique<ControlPushButton>(
+            ConfigKey("[Library]", "focused_widget"));
+    m_pLibraryFocusedWidgetCO->setStates(static_cast<int>(FocusWidget::Count));
+    m_pLibraryFocusedWidgetCO->connectValueChangeRequest(
+            this,
+            [this](double value) {
+                // Focus can not be removed from a widget just moved to another one.
+                // Thus, to keep the CO and QApplication::focusWidget() in sync we
+                // have to prevent scripts or GUI buttons setting the CO to 'None'.
+                // It's only set to 'None' internally when one of the library widgets
+                // receives a FocusOutEvent(), e.g. when the focus is moved to another
+                // widget, or when the main window loses focus.
+                const int valueInt = static_cast<int>(value);
+                if (valueInt != static_cast<int>(FocusWidget::None) &&
+                        valueInt < static_cast<int>(FocusWidget::Count)) {
+                    setLibraryFocus(static_cast<FocusWidget>(valueInt));
+                }
+            });
 
     // Control to "goto" the currently selected item in focused widget (context dependent)
     m_pGoToItem = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "GoToItem"));
@@ -355,7 +376,6 @@ void LibraryControl::slotNumSamplersChanged(double v) {
     }
 }
 
-
 void LibraryControl::slotNumPreviewDecksChanged(double v) {
     int iNumPreviewDecks = static_cast<int>(v);
 
@@ -405,8 +425,6 @@ void LibraryControl::bindSearchboxWidget(WSearchLineEdit* pSearchbox) {
             this,
             &LibraryControl::searchboxWidgetDeleted);
 }
-
-
 
 void LibraryControl::libraryWidgetDeleted() {
     m_pLibraryWidget = nullptr;
@@ -612,11 +630,11 @@ void LibraryControl::emitKeyEvent(QKeyEvent&& event) {
     if (!keyIsTab && !m_pSidebarWidget->hasFocus()
             && !m_pLibraryWidget->getActiveView()->hasFocus()) {
         if (keyIsUpDown && !m_pSearchbox->hasFocus()) {
-            setLibraryFocus();
+            setLibraryFocus(FocusWidget::TracksTable);
         }
     }
     if (keyIsTab && !QApplication::focusWidget()){
-        setLibraryFocus();
+        setLibraryFocus(FocusWidget::TracksTable);
     }
 
     // Send the event pointer to the currently focused widget
@@ -628,11 +646,44 @@ void LibraryControl::emitKeyEvent(QKeyEvent&& event) {
     }
 }
 
-void LibraryControl::setLibraryFocus() {
-    VERIFY_OR_DEBUG_ASSERT(m_pLibraryWidget) {
+void LibraryControl::setLibraryFocus(FocusWidget newFocusWidget) {
+    // ignore no-op
+    if (static_cast<double>(newFocusWidget) == m_pLibraryFocusedWidgetCO->get()) {
         return;
     }
-    m_pLibraryWidget->getActiveView()->setFocus();
+    bool confirmed = false;
+    switch (newFocusWidget) {
+    case FocusWidget::Searchbar:
+        VERIFY_OR_DEBUG_ASSERT(m_pSearchbox) {
+            return;
+        }
+        m_pSearchbox->setFocus();
+        confirmed = m_pSearchbox->hasFocus();
+        break;
+    case FocusWidget::Sidebar:
+        VERIFY_OR_DEBUG_ASSERT(m_pSidebarWidget) {
+            return;
+        }
+        m_pSidebarWidget->setFocus();
+        confirmed = m_pSidebarWidget->hasFocus();
+        break;
+    case FocusWidget::TracksTable:
+        VERIFY_OR_DEBUG_ASSERT(m_pLibraryWidget) {
+            return;
+        }
+        m_pLibraryWidget->getActiveView()->setFocus();
+        confirmed = m_pLibraryWidget->getActiveView()->hasFocus();
+        break;
+    case FocusWidget::None:
+        confirmed = true;
+        break;
+    default:
+        DEBUG_ASSERT(!"Invalid focus widget change request");
+        break;
+    }
+    if (confirmed) {
+        m_pLibraryFocusedWidgetCO->setAndConfirm(static_cast<double>(newFocusWidget));
+    }
 }
 
 void LibraryControl::slotSelectSidebarItem(double v) {
@@ -694,7 +745,7 @@ void LibraryControl::slotGoToItem(double v) {
         // expanding those root items via controllers is considered dispensable
         // because the subfeatures' actions can't be accessed by controllers anyway.
         if (m_pSidebarWidget->isLeafNodeSelected()) {
-            setLibraryFocus();
+            setLibraryFocus(FocusWidget::TracksTable);
             return;
         } else {
             // Otherwise toggle the sidebar item expanded state
@@ -711,7 +762,7 @@ void LibraryControl::slotGoToItem(double v) {
 
     // If searchbox has focus jump to the tracks table
     if (m_pSearchbox->hasFocus()) {
-        return setLibraryFocus();
+        return setLibraryFocus(FocusWidget::TracksTable);
     }
 
     // Clear the search if the searchbox has focus

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -629,23 +629,10 @@ void LibraryControl::emitKeyEvent(QKeyEvent&& event) {
 }
 
 void LibraryControl::setLibraryFocus() {
-    // TODO: Set the focus of the library panel directly instead of sending tab from sidebar
-    VERIFY_OR_DEBUG_ASSERT(m_pSidebarWidget) {
+    VERIFY_OR_DEBUG_ASSERT(m_pLibraryWidget) {
         return;
     }
-    // Try to focus the sidebar.
-    m_pSidebarWidget->setFocus();
-
-    // This may have failed, for example when a Cover window still has focus,
-    // so make sure the sidebar is focused or we'll crash.
-    if (!m_pSidebarWidget->hasFocus()) {
-        return;
-    }
-    // Send Tab to move focus to the Tracks table.
-    // Obviously only works as desired if the skin widgets are arranged
-    // accordingly.
-    QKeyEvent event(QEvent::KeyPress, Qt::Key_Tab, Qt::NoModifier);
-    QApplication::sendEvent(m_pSidebarWidget, &event);
+    m_pLibraryWidget->getActiveView()->setFocus();
 }
 
 void LibraryControl::slotSelectSidebarItem(double v) {

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -4,6 +4,7 @@
 
 #include "control/controlencoder.h"
 #include "control/controlproxy.h"
+#include "library/library_decl.h"
 #include "util/memory.h"
 
 class ControlObject;
@@ -43,6 +44,8 @@ class LibraryControl : public QObject {
     void bindLibraryWidget(WLibrary* pLibrary, KeyboardEventFilter* pKeyboard);
     void bindSidebarWidget(WLibrarySidebar* pLibrarySidebar);
     void bindSearchboxWidget(WSearchLineEdit* pSearchbox);
+    // Give the keyboard focus to one of the library widgets
+    void setLibraryFocus(FocusWidget newFocusWidget);
 
   signals:
     void clearSearchIfClearButtonHasFocus();
@@ -103,8 +106,6 @@ class LibraryControl : public QObject {
 
     // Simulate pressing a key on the keyboard
     void emitKeyEvent(QKeyEvent&& event);
-    // Give the keyboard focus to the main library pane
-    void setLibraryFocus();
 
     // Controls to navigate vertically within currently focused widget (up/down buttons)
     std::unique_ptr<ControlPushButton> m_pMoveUp;
@@ -125,6 +126,7 @@ class LibraryControl : public QObject {
     std::unique_ptr<ControlPushButton> m_pMoveFocusForward;
     std::unique_ptr<ControlPushButton> m_pMoveFocusBackward;
     std::unique_ptr<ControlEncoder> m_pMoveFocus;
+    std::unique_ptr<ControlPushButton> m_pLibraryFocusedWidgetCO;
 
     // Control to choose the currently selected item in focused widget (double click)
     std::unique_ptr<ControlObject> m_pGoToItem;

--- a/src/library/libraryview.h
+++ b/src/library/libraryview.h
@@ -16,6 +16,8 @@ class LibraryView {
 
     virtual void onShow() = 0;
     virtual bool hasFocus() const = 0;
+    virtual void setFocus() {
+    }
     /// Reimplement if LibraryView should be able to search
     virtual void onSearch(const QString& text) {Q_UNUSED(text);}
 

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -112,6 +112,10 @@ bool DlgRecording::hasFocus() const {
     return m_pTrackTableView->hasFocus();
 }
 
+void DlgRecording::setFocus() {
+    m_pTrackTableView->setFocus();
+}
+
 void DlgRecording::refreshBrowseModel() {
     m_browseModel.setPath(mixxx::FileAccess(mixxx::FileInfo(m_recordingDir)));
 }

--- a/src/library/recording/dlgrecording.h
+++ b/src/library/recording/dlgrecording.h
@@ -26,6 +26,7 @@ class DlgRecording : public QWidget, public Ui::DlgRecording, public virtual Lib
     void onSearch(const QString& text) override;
     void onShow() override;
     bool hasFocus() const override;
+    void setFocus() override;
     void loadSelectedTrack() override;
     void slotAddToAutoDJBottom() override;
     void slotAddToAutoDJTop() override;

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -1421,6 +1421,7 @@ void RekordboxFeature::bindLibraryWidget(WLibrary* libraryWidget,
     edit->setOpenLinks(false);
     connect(edit, &WLibraryTextBrowser::anchorClicked, this, &RekordboxFeature::htmlLinkClicked);
     libraryWidget->registerView("REKORDBOXHOME", edit);
+    m_pLibrary->bindFeatureRootView(edit);
 }
 
 void RekordboxFeature::htmlLinkClicked(const QUrl& link) {

--- a/src/library/serato/seratofeature.cpp
+++ b/src/library/serato/seratofeature.cpp
@@ -937,6 +937,7 @@ void SeratoFeature::bindLibraryWidget(WLibrary* libraryWidget,
     edit->setOpenLinks(false);
     connect(edit, &WLibraryTextBrowser::anchorClicked, this, &SeratoFeature::htmlLinkClicked);
     libraryWidget->registerView("SERATOHOME", edit);
+    m_pLibrary->bindFeatureRootView(edit);
 }
 
 void SeratoFeature::htmlLinkClicked(const QUrl& link) {

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -670,6 +670,7 @@ void BasePlaylistFeature::bindLibraryWidget(WLibrary* libraryWidget,
             this,
             &BasePlaylistFeature::htmlLinkClicked);
     libraryWidget->registerView(m_rootViewName, edit);
+    m_pLibrary->bindFeatureRootView(edit);
 }
 
 void BasePlaylistFeature::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -270,6 +270,7 @@ void CrateFeature::bindLibraryWidget(
             this,
             &CrateFeature::htmlLinkClicked);
     libraryWidget->registerView(m_rootViewName, edit);
+    m_pLibrary->bindFeatureRootView(edit);
 }
 
 void CrateFeature::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {

--- a/src/widget/wlibrary.cpp
+++ b/src/widget/wlibrary.cpp
@@ -77,7 +77,7 @@ void WLibrary::switchToView(const QString& name) {
         WTrackTableView* ttWidgetView = qobject_cast<WTrackTableView*>(
                 widget);
 
-        if (ttWidgetView != nullptr){
+        if (ttWidgetView != nullptr) {
             qDebug("trying to restore position");
             ttWidgetView->restoreCurrentVScrollBarPos();
         }

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -15,6 +15,7 @@ constexpr int expand_time = 250;
 WLibrarySidebar::WLibrarySidebar(QWidget* parent)
         : QTreeView(parent),
           WBaseWidget(this) {
+    qRegisterMetaType<FocusWidget>("FocusWidget");
     //Set some properties
     setHeaderHidden(true);
     setSelectionMode(QAbstractItemView::SingleSelection);
@@ -155,7 +156,6 @@ void WLibrarySidebar::dropEvent(QDropEvent * event) {
     }
 }
 
-
 void WLibrarySidebar::toggleSelectedItem() {
     QModelIndexList selectedIndices = this->selectionModel()->selectedRows();
     if (selectedIndices.size() > 0) {
@@ -287,6 +287,16 @@ bool WLibrarySidebar::event(QEvent* pEvent) {
         updateTooltip();
     }
     return QTreeView::event(pEvent);
+}
+
+void WLibrarySidebar::focusInEvent(QFocusEvent* event) {
+    QTreeView::focusInEvent(event);
+    emit sidebarFocusChange(FocusWidget::Sidebar);
+}
+
+void WLibrarySidebar::focusOutEvent(QFocusEvent* event) {
+    QTreeView::focusOutEvent(event);
+    emit sidebarFocusChange(FocusWidget::None);
 }
 
 void WLibrarySidebar::slotSetFont(const QFont& font) {

--- a/src/widget/wlibrarysidebar.h
+++ b/src/widget/wlibrarysidebar.h
@@ -4,13 +4,14 @@
 #include <QContextMenuEvent>
 #include <QDragEnterEvent>
 #include <QDragMoveEvent>
+#include <QEvent>
 #include <QKeyEvent>
 #include <QModelIndex>
 #include <QPoint>
 #include <QTimerEvent>
 #include <QTreeView>
-#include <QEvent>
 
+#include "library/library_decl.h"
 #include "widget/wbasewidget.h"
 
 class WLibrarySidebar : public QTreeView, public WBaseWidget {
@@ -34,9 +35,12 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
 
   signals:
     void rightClicked(const QPoint&, const QModelIndex&);
+    FocusWidget sidebarFocusChange(FocusWidget newFocus);
 
   protected:
     bool event(QEvent* pEvent) override;
+    void focusInEvent(QFocusEvent*) override;
+    void focusOutEvent(QFocusEvent*) override;
 
   private:
     QBasicTimer m_expandTimer;

--- a/src/widget/wlibrarytextbrowser.cpp
+++ b/src/widget/wlibrarytextbrowser.cpp
@@ -9,3 +9,7 @@ WLibraryTextBrowser::WLibraryTextBrowser(QWidget* parent)
 bool WLibraryTextBrowser::hasFocus() const {
     return QWidget::hasFocus();
 }
+
+void WLibraryTextBrowser::setFocus() {
+    QWidget::setFocus();
+}

--- a/src/widget/wlibrarytextbrowser.cpp
+++ b/src/widget/wlibrarytextbrowser.cpp
@@ -4,6 +4,7 @@
 
 WLibraryTextBrowser::WLibraryTextBrowser(QWidget* parent)
         : QTextBrowser(parent) {
+    qRegisterMetaType<FocusWidget>("FocusWidget");
 }
 
 bool WLibraryTextBrowser::hasFocus() const {
@@ -12,4 +13,14 @@ bool WLibraryTextBrowser::hasFocus() const {
 
 void WLibraryTextBrowser::setFocus() {
     QWidget::setFocus();
+}
+
+void WLibraryTextBrowser::focusInEvent(QFocusEvent* event) {
+    QWidget::focusInEvent(event);
+    emit textBrowserFocusChange(FocusWidget::TracksTable);
+}
+
+void WLibraryTextBrowser::focusOutEvent(QFocusEvent* event) {
+    QWidget::focusOutEvent(event);
+    emit textBrowserFocusChange(FocusWidget::None);
 }

--- a/src/widget/wlibrarytextbrowser.h
+++ b/src/widget/wlibrarytextbrowser.h
@@ -10,4 +10,5 @@ class WLibraryTextBrowser : public QTextBrowser, public LibraryView {
     explicit WLibraryTextBrowser(QWidget* parent = nullptr);
     void onShow() override {}
     bool hasFocus() const override;
+    void setFocus() override;
 };

--- a/src/widget/wlibrarytextbrowser.h
+++ b/src/widget/wlibrarytextbrowser.h
@@ -2,6 +2,7 @@
 
 #include <QTextBrowser>
 
+#include "library/library_decl.h"
 #include "library/libraryview.h"
 
 class WLibraryTextBrowser : public QTextBrowser, public LibraryView {
@@ -11,4 +12,11 @@ class WLibraryTextBrowser : public QTextBrowser, public LibraryView {
     void onShow() override {}
     bool hasFocus() const override;
     void setFocus() override;
+
+  protected:
+    void focusInEvent(QFocusEvent* event) override;
+    void focusOutEvent(QFocusEvent* event) override;
+
+  signals:
+    FocusWidget textBrowserFocusChange(FocusWidget newFocus);
 };

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -78,6 +78,7 @@ WSearchLineEdit::WSearchLineEdit(QWidget* pParent)
         : QComboBox(pParent),
           WBaseWidget(this),
           m_clearButton(make_parented<QToolButton>(this)) {
+    qRegisterMetaType<FocusWidget>("FocusWidget");
     setAcceptDrops(false);
     setEditable(true);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
@@ -326,6 +327,7 @@ void WSearchLineEdit::focusInEvent(QFocusEvent* event) {
             << "focusInEvent";
 #endif // ENABLE_TRACE_LOG
     QComboBox::focusInEvent(event);
+    emit searchbarFocusChange(FocusWidget::Searchbar);
 }
 
 void WSearchLineEdit::focusOutEvent(QFocusEvent* event) {
@@ -334,6 +336,7 @@ void WSearchLineEdit::focusOutEvent(QFocusEvent* event) {
             << "focusOutEvent";
 #endif // ENABLE_TRACE_LOG
     QComboBox::focusOutEvent(event);
+    emit searchbarFocusChange(FocusWidget::None);
     if (m_debouncingTimer.isActive()) {
         // Trigger a pending search before leaving the edit box.
         // Otherwise the entered text might be ignored and get lost

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -6,6 +6,7 @@
 #include <QTimer>
 #include <QToolButton>
 
+#include "library/library_decl.h"
 #include "util/parented_ptr.h"
 #include "widget/wbasewidget.h"
 
@@ -39,6 +40,7 @@ class WSearchLineEdit : public QComboBox, public WBaseWidget {
 
   signals:
     void search(const QString& text);
+    FocusWidget searchbarFocusChange(FocusWidget newFocusWidget);
 
   public slots:
     void slotSetFont(const QFont& font);

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1028,6 +1028,10 @@ bool WTrackTableView::hasFocus() const {
     return QWidget::hasFocus();
 }
 
+void WTrackTableView::setFocus() {
+    QWidget::setFocus();
+}
+
 void WTrackTableView::saveCurrentVScrollBarPos() {
     saveVScrollBarPos(getTrackModel());
 }

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -60,6 +60,7 @@ WTrackTableView::WTrackTableView(QWidget* parent,
           m_sorting(sorting),
           m_selectionChangedSinceLastGuiTick(true),
           m_loadCachedOnly(false) {
+    qRegisterMetaType<FocusWidget>("FocusWidget");
     // Connect slots and signals to make the world go 'round.
     connect(this, &WTrackTableView::doubleClicked, this, &WTrackTableView::slotMouseDoubleClicked);
 
@@ -1022,6 +1023,16 @@ void WTrackTableView::slotSortingChanged(int headerSection, Qt::SortOrder order)
     if (sortingChanged) {
         applySortingIfVisible();
     }
+}
+
+void WTrackTableView::focusInEvent(QFocusEvent* event) {
+    QWidget::focusInEvent(event);
+    emit trackTableFocusChange(FocusWidget::TracksTable);
+}
+
+void WTrackTableView::focusOutEvent(QFocusEvent* event) {
+    QWidget::focusOutEvent(event);
+    emit trackTableFocusChange(FocusWidget::None);
 }
 
 bool WTrackTableView::hasFocus() const {

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -32,6 +32,7 @@ class WTrackTableView : public WLibraryTableView {
     void onSearch(const QString& text) override;
     void onShow() override;
     bool hasFocus() const override;
+    void setFocus() override;
     void keyPressEvent(QKeyEvent* event) override;
     void loadSelectedTrack() override;
     void loadSelectedTrackToGroup(const QString& group, bool play) override;

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -5,6 +5,7 @@
 
 #include "control/controlproxy.h"
 #include "library/dao/playlistdao.h"
+#include "library/library_decl.h"
 #include "library/trackmodel.h" // Can't forward declare enums
 #include "preferences/usersettings.h"
 #include "util/duration.h"
@@ -53,6 +54,9 @@ class WTrackTableView : public WLibraryTableView {
         return m_pFocusBorderColor;
     }
 
+  signals:
+    void trackTableFocusChange(FocusWidget newFocusWidget);
+
   public slots:
     void loadTrackModel(QAbstractItemModel* model);
     void slotMouseDoubleClicked(const QModelIndex &);
@@ -62,6 +66,10 @@ class WTrackTableView : public WLibraryTableView {
     void slotAddToAutoDJBottom() override;
     void slotAddToAutoDJTop() override;
     void slotAddToAutoDJReplace() override;
+
+  protected:
+    void focusInEvent(QFocusEvent* event) override;
+    void focusOutEvent(QFocusEvent* event) override;
 
   private slots:
     void doSortByColumn(int headerSection, Qt::SortOrder sortOrder);


### PR DESCRIPTION
**1** Implements an old ToDo in librarycontrol:
focus library directly, without the indirection via sidebar, and without having to assume the library is next/after the sidebar,

**2** Adds `[Library], focus_widget` control which allows mappings with more fine-grained library control.
For example Trax encoder turn or press can now trigger specific actions _per context_.

The control holds the internal number of the current lib focus widget:
``` c++
enum class FocusWidget {
    NONE,
    SEARCHBAR,
    SIDEBAR,
    LIBRARY
};
```
Internally it's updated by `[widget]FocusChange([widget] | NONE)` signal emitted by each widget's `focusInEvent` / `focusOutEvent`.
Valid external updates (from scripts) are 1...n only, verified by each widget's `hasFocus()` functions.

**ToDo**
- [ ] remove skin demo