### PR TITLE
Qt6: use new QSqlField constructor with QMetaType

### DIFF
--- a/src/library/queryutil.h
+++ b/src/library/queryutil.h
@@ -74,7 +74,13 @@ class FieldEscaper final {
   public:
     FieldEscaper(const QSqlDatabase& database)
             : m_database(database),
-              m_stringField("string", QVariant::String) {
+              m_stringField("string",
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                      QMetaType(QMetaType::QString)
+#else
+                      QVariant::String
+#endif
+              ) {
     }
 
     // Escapes a string for use in a SQL query by wrapping with quotes and


### PR DESCRIPTION
```
[56/585] Building CXX object CMakeFiles/mixxx-lib.dir/src/dialog/dlgreplacecuecolor.cpp.o
In file included from ../src/dialog/dlgreplacecuecolor.cpp:12:
../src/library/queryutil.h: In constructor ‘FieldEscaper::FieldEscaper(const QSqlDatabase&)’:
../src/library/queryutil.h:77:15: warning: ‘QSqlField::QSqlField(const QString&, QVariant::Type, const QString&)’ is deprecated: Use the constructor using a QMetaType instead [-Wdeprecated-declarations]
   77 |               m_stringField("string", QVariant::String) {
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/qt6/QtSql/QtSql:9,
                 from ../src/library/queryutil.h:4,
                 from ../src/dialog/dlgreplacecuecolor.cpp:12:
/usr/include/qt6/QtSql/qsqlfield.h:85:5: note: declared here
   85 |     QSqlField(const QString& fieldName, QVariant::Type type, const QString &tableName = QString())
      |     ^~~~~~~~~
```