### PR TITLE
replace QHashIterator with QMultiHash::cbegin/cend

### DIFF
--- a/src/preferences/dialog/dlgprefsounditem.cpp
+++ b/src/preferences/dialog/dlgprefsounditem.cpp
@@ -167,10 +167,8 @@ void DlgPrefSoundItem::channelChanged() {
  */
 void DlgPrefSoundItem::loadPath(const SoundManagerConfig &config) {
     if (m_isInput) {
-        QMultiHash<SoundDeviceId, AudioInput> inputs(config.getInputs());
-        QHashIterator<SoundDeviceId, AudioInput> it(inputs);
-        while (it.hasNext()) {
-            it.next();
+        const auto inputDeviceMap = config.getInputs();
+        for (auto it = inputDeviceMap.cbegin(); it != inputDeviceMap.cend(); ++it) {
             if (it.value().getType() == m_type && it.value().getIndex() == m_index) {
                 setDevice(it.key());
                 setChannel(it.value().getChannelGroup().getChannelBase(),
@@ -179,10 +177,8 @@ void DlgPrefSoundItem::loadPath(const SoundManagerConfig &config) {
             }
         }
     } else {
-        QMultiHash<SoundDeviceId, AudioOutput> outputs(config.getOutputs());
-        QHashIterator<SoundDeviceId, AudioOutput> it(outputs);
-        while (it.hasNext()) {
-            it.next();
+        const auto ouputDeviceMap = config.getOutputs();
+        for (auto it = ouputDeviceMap.cbegin(); it != ouputDeviceMap.cend(); ++it) {
             if (it.value().getType() == m_type && it.value().getIndex() == m_index) {
                 setDevice(it.key());
                 setChannel(it.value().getChannelGroup().getChannelBase(),


### PR DESCRIPTION
QMultiHash is not a subclass of QHash in Qt6:
https://doc.qt.io/qt-6/qtcore-changes-qt6.html#removal-of-qhash-insertmulti
so the
QHashIterator(const QHash<Key, T> &hash)
constructor cannot be used with QMultiHash.