### PR TITLE
RekordboxFeature: add missing #include <QTextCodec>

### DIFF
--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -6,6 +6,7 @@
 #include <QMessageBox>
 #include <QSettings>
 #include <QStandardPaths>
+#include <QTextCodec>
 #include <QtDebug>
 
 #include "engine/engine.h"


### PR DESCRIPTION
This is required in Qt6.