### PR TITLE
BrowseFeature: remove unused #include <QDirModel>

### DIFF
--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -1,7 +1,6 @@
 #include "library/browse/browsefeature.h"
 
 #include <QAction>
-#include <QDirModel>
 #include <QFileInfo>
 #include <QMenu>
 #include <QPushButton>


### PR DESCRIPTION
QDirModel has been removed in Qt6. The class is no longer used by
Mixxx anyway.