### PR TITLE
QmlControlProxy: fix Q_PROPERTY type

### DIFF
--- a/src/qml/qmlcontrolproxy.h
+++ b/src/qml/qmlcontrolproxy.h
@@ -19,7 +19,7 @@ class QmlControlProxy : public QObject, public QQmlParserStatus {
     Q_PROPERTY(QString group READ getGroup WRITE setGroup NOTIFY groupChanged)
     Q_PROPERTY(QString key READ getKey WRITE setKey NOTIFY keyChanged)
     Q_PROPERTY(QString keyValid READ isKeyValid NOTIFY keyValidChanged)
-    Q_PROPERTY(QString initialized READ isInitialized NOTIFY initializedChanged)
+    Q_PROPERTY(bool initialized READ isInitialized NOTIFY initializedChanged)
     Q_PROPERTY(double value READ getValue WRITE setValue NOTIFY valueChanged)
     Q_PROPERTY(double parameter READ getParameter WRITE setParameter NOTIFY parameterChanged)
 


### PR DESCRIPTION
initializedChanged takes a bool parameter but the property
was a QString. That failed to compile with Qt6:

```
[128/530] Building CXX object CMakeFiles/mixxx-lib.dir/src/qml/qmlcontrolproxy.cpp.o
FAILED: CMakeFiles/mixxx-lib.dir/src/qml/qmlcontrolproxy.cpp.o
/usr/bin/ccache /usr/bin/c++ -DHAVE_INET_ATON -DHAVE_INET_PTON -DHAVE_UNISTD_H -DMIXXX_BUILD_DEBUG -DMIXXX_DEBUG_ASSERTIONS_ENABLED -DPA_USE_ALSA -DQT_CONCURRENT_LIB -DQT_CORE5COMPAT_LIB -DQT_CORE_LIB -DQT_DBUS_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_OPENGL_LIB -DQT_PRINTSUPPORT_LIB -DQT_QMLMODELS_LIB -DQT_QML_DEBUG -DQT_QML_LIB -DQT_QUICKWIDGETS_LIB -DQT_QUICK_LIB -DQT_SQL_LIB -DQT_SVGWIDGETS_LIB -DQT_SVG_LIB -DQT_TABLET_SUPPORT -DQT_TESTLIB_LIB -DQT_USE_QSTRINGBUILDER -DQT_WIDGETS_LIB -DQT_XML_LIB -D__BATTERY__ -D__BROADCAST__ -D__BULK__ -D__ENGINEPRIME__ -D__FAAD__ -D__FFMPEG__ -D__HID__ -D__KEYFINDER__ -D__LILV__ -D__LINUX__ -D__MAD__ -D__MODPLUG__ -D__MP4V2__ -D__OPUS__ -D__QTKEYCHAIN__ -D__SNDFILE__ -D__SQLITE3__ -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__UNIX__ -D__VINYLCONTROL__ -D__WV__ -Dx86_64 -Imixxx-lib_autogen/include -I../src -Isrc -I/usr/include/ffmpeg -isystem /home/be/local/include -isystem ../lib/fidlib -isystem ../lib/googletest/googletest/include -isystem ../lib/portaudio -isystem ../lib/rigtorp/SPSCQueue/include -isystem ../lib/replaygain -isystem ../lib/reverb -isystem /usr/include/glib-2.0 -isystem /usr/lib64/glib-2.0/include -isystem ../lib/libshout-idjc/include -isystem ../lib/kaitai -isystem ../lib/mp3guessenc-0.27.4 -isystem /usr/include/qt6/QtConcurrent -isystem /usr/include/qt6 -isystem /usr/include/qt6/QtCore -isystem /usr/lib64/qt6/mkspecs/linux-g++ -isystem /usr/include/qt6/QtGui -isystem /usr/include/qt6/QtNetwork -isystem /usr/include/qt6/QtOpenGL -isystem /usr/include/qt6/QtPrintSupport -isystem /usr/include/qt6/QtWidgets -isystem /usr/include/qt6/QtQml -isystem /usr/include/qt6/QtQuickWidgets -isystem /usr/include/qt6/QtQuick -isystem /usr/include/qt6/QtQmlModels -isystem /usr/include/qt6/QtSql -isystem /usr/include/qt6/QtSvg -isystem /usr/include/qt6/QtTest -isystem /usr/include/qt6/QtXml -isystem /usr/include/qt6/QtSvgWidgets -isystem /usr/include/qt6/QtCore5Compat -isystem /usr/include/qt6/QtDBus -isystem ../lib/qm-dsp -isystem ../lib/qm-dsp/include -isystem /usr/include/taglib -isystem /usr/include/libupower-glib -isystem /usr/include/lilv-0 -isystem /usr/include/opus -isystem /usr/include/hidapi -isystem /usr/include/libusb-1.0 -isystem ../lib/xwax -isystem /usr/include/wavpack -fdiagnostics-color=auto -g -fvisibility=hidden -fvisibility-inlines-hidden -pipe -O3 -ffast-math -funroll-loops -fomit-frame-pointer -mtune=generic -Wall -Wextra -Woverloaded-virtual -Wfloat-conversion -Werror=return-type -Wformat=2 -Wformat-security -Wvla -Wundef -DPA_USE_JACK=1 -pthread -DPA_USE_ALSA=1 -D_REENTRANT -std=gnu++17 -MD -MT CMakeFiles/mixxx-lib.dir/src/qml/qmlcontrolproxy.cpp.o -MF CMakeFiles/mixxx-lib.dir/src/qml/qmlcontrolproxy.cpp.o.d -o CMakeFiles/mixxx-lib.dir/src/qml/qmlcontrolproxy.cpp.o -c ../src/qml/qmlcontrolproxy.cpp
In file included from ../src/qml/qmlcontrolproxy.cpp:3:
mixxx-lib_autogen/include/moc_qmlcontrolproxy.cpp: In static member function ‘static void mixxx::qml::QmlControlProxy::qt_static_metacall(QObject*, QMetaObject::Call, int, void**)’:
mixxx-lib_autogen/include/moc_qmlcontrolproxy.cpp:185:66: error: conversion from ‘bool’ to ‘QChar’ is ambiguous
  185 |         case 2: *reinterpret_cast< QString*>(_v) = _t->isKeyValid(); break;
      |                                                    ~~~~~~~~~~~~~~^~
In file included from /usr/include/qt6/QtCore/qstring.h:50,
                 from /usr/include/qt6/QtCore/qobject.h:47,
                 from /usr/include/qt6/QtCore/QObject:1,
                 from ../src/qml/qmlcontrolproxy.h:3,
                 from ../src/qml/qmlcontrolproxy.cpp:1:
/usr/include/qt6/QtCore/qchar.h:125:45: note: candidate: ‘constexpr QChar::QChar(char)’
  125 |     QT_ASCII_CAST_WARN constexpr Q_IMPLICIT QChar(char c) noexcept : ucs(uchar(c)) { }
      |                                             ^~~~~
/usr/include/qt6/QtCore/qchar.h:118:26: note: candidate: ‘constexpr QChar::QChar(char16_t)’
  118 |     constexpr Q_IMPLICIT QChar(char16_t ch) noexcept : ucs(ch) {}
      |                          ^~~~~
/usr/include/qt6/QtCore/qchar.h:113:26: note: candidate: ‘constexpr QChar::QChar(short int)’
  113 |     constexpr Q_IMPLICIT QChar(short rc) noexcept : ucs(char16_t(rc)) {}
      |                          ^~~~~
/usr/include/qt6/QtCore/qchar.h:111:26: note: candidate: ‘constexpr QChar::QChar(ushort)’
  111 |     constexpr Q_IMPLICIT QChar(ushort rc) noexcept : ucs(rc) {}
      |                          ^~~~~
In file included from /usr/include/qt6/QtCore/qobject.h:47,
                 from /usr/include/qt6/QtCore/QObject:1,
                 from ../src/qml/qmlcontrolproxy.h:3,
                 from ../src/qml/qmlcontrolproxy.cpp:1:
/usr/include/qt6/QtCore/qstring.h:397:30: note:   initializing argument 1 of ‘QString& QString::operator=(QChar)’
  397 |     QString &operator=(QChar c);
      |                        ~~~~~~^
In file included from ../src/qml/qmlcontrolproxy.cpp:3:
mixxx-lib_autogen/include/moc_qmlcontrolproxy.cpp:186:69: error: conversion from ‘bool’ to ‘QChar’ is ambiguous
  186 |         case 3: *reinterpret_cast< QString*>(_v) = _t->isInitialized(); break;
      |                                                    ~~~~~~~~~~~~~~~~~^~
In file included from /usr/include/qt6/QtCore/qstring.h:50,
                 from /usr/include/qt6/QtCore/qobject.h:47,
                 from /usr/include/qt6/QtCore/QObject:1,
                 from ../src/qml/qmlcontrolproxy.h:3,
                 from ../src/qml/qmlcontrolproxy.cpp:1:
/usr/include/qt6/QtCore/qchar.h:125:45: note: candidate: ‘constexpr QChar::QChar(char)’
  125 |     QT_ASCII_CAST_WARN constexpr Q_IMPLICIT QChar(char c) noexcept : ucs(uchar(c)) { }
      |                                             ^~~~~
/usr/include/qt6/QtCore/qchar.h:118:26: note: candidate: ‘constexpr QChar::QChar(char16_t)’
  118 |     constexpr Q_IMPLICIT QChar(char16_t ch) noexcept : ucs(ch) {}
      |                          ^~~~~
/usr/include/qt6/QtCore/qchar.h:113:26: note: candidate: ‘constexpr QChar::QChar(short int)’
  113 |     constexpr Q_IMPLICIT QChar(short rc) noexcept : ucs(char16_t(rc)) {}
      |                          ^~~~~
/usr/include/qt6/QtCore/qchar.h:111:26: note: candidate: ‘constexpr QChar::QChar(ushort)’
  111 |     constexpr Q_IMPLICIT QChar(ushort rc) noexcept : ucs(rc) {}
      |                          ^~~~~
In file included from /usr/include/qt6/QtCore/qobject.h:47,
                 from /usr/include/qt6/QtCore/QObject:1,
                 from ../src/qml/qmlcontrolproxy.h:3,
                 from ../src/qml/qmlcontrolproxy.cpp:1:
/usr/include/qt6/QtCore/qstring.h:397:30: note:   initializing argument 1 of ‘QString& QString::operator=(QChar)’
  397 |     QString &operator=(QChar c);
      |                        ~~~~~~^
```