### PR TITLE
Browse/Recording: disable the search box

### DIFF
--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -266,6 +266,7 @@ void BrowseFeature::activateChild(const QModelIndex& index) {
         m_browseModel.setPath(dir);
     }
     emit showTrackModel(&m_proxyModel);
+    emit disableSearch();
     emit enableCoverArtDisplay(false);
 }
 

--- a/src/library/recording/recordingfeature.cpp
+++ b/src/library/recording/recordingfeature.cpp
@@ -71,7 +71,6 @@ void RecordingFeature::bindLibraryWidget(WLibrary* pLibraryWidget,
 void RecordingFeature::activate() {
     emit refreshBrowseModel();
     emit switchToView(kViewName);
-    // Ask the view to emit a restoreSearch signal.
-    emit requestRestoreSearch();
+    emit disableSearch();
     emit enableCoverArtDisplay(false);
 }


### PR DESCRIPTION
...since it's not working anyway.
Having an active search box that does nothing is confusing.