### PR TITLE
CachingReader: Fix assertion when loop is before track start (lp1946759)

### DIFF
--- a/src/engine/cachingreader/cachingreader.cpp
+++ b/src/engine/cachingreader/cachingreader.cpp
@@ -528,6 +528,9 @@ void CachingReader::hintAndMaybeWake(const HintVector& hintList) {
         	hintFrameCount = kDefaultHintFrames;
             if (hintFrame < 0) {
             	hintFrameCount += hintFrame;
+                if (hintFrameCount <= 0) {
+                    continue;
+                }
                 hintFrame = 0;
             }
         }


### PR DESCRIPTION
When setting a loop in front of the actual track (i.e. so that the end
of the loop is before the first audio frame), this debug assertion is
always triggered:

    DEBUG ASSERT: "hintFrameCount >= 0" in function void CachingReader::hintAndMaybeWake(const HintVector&) at /home/jan/Projects/mixxx/src/engine/cachingreader/cachingreader.cpp:535

Steps to reproduce:

1. Go to the beginning of the track
2. Use beatjump to go to 8 beats before the beginning of the track
3. Set a beatloop of 4 beats
4. Assertion is triggered

~~This fixes the issue by just ignoring the negative hint lengths
without triggering an assertion.~~

~~This also re-adds the skipping of zero-length hints that was removed by
7d96c38e93a95bb2a987b8e2676e5e1ff16f0e61 (#3081) to avoid triggering the
assertion. However, I think skipping was correct in the zero length
case, just triggering the assertion was not.~~

See https://bugs.launchpad.net/mixxx/+bug/1946759 for details.

~~The commit that originally introduced this assertion is
8589930ff50fdf733c8b1333aa75548990c6e573 (#1223).~~