### PR TITLE
History feature: fix right-click index

### DIFF
--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -103,7 +103,7 @@ void SetlogFeature::onRightClickChild(const QPoint& globalPos, const QModelIndex
     //Save the model index so we can get it in the action slots...
     m_lastRightClickedIndex = index;
 
-    int playlistId = index.data(TreeItemModel::kDataRole).toInt();
+    int playlistId = playlistIdFromIndex(index);
     // not a real entry
     if (playlistId == kInvalidPlaylistId) {
         return;


### PR DESCRIPTION
before an invalid playlist ID was used to update the context menu actions. For example a locked playlist would still have an "Lock" action, even though the correct action would be triggered, or refused.