### PR TITLE
EncoderFdkAac: Fix memory leak

### DIFF
--- a/src/encoder/encoderfdkaac.cpp
+++ b/src/encoder/encoderfdkaac.cpp
@@ -166,7 +166,7 @@ EncoderFdkAac::~EncoderFdkAac() {
     }
 
     delete[] m_pAacDataBuffer;
-    delete m_pFifoChunkBuffer;
+    delete[] m_pFifoChunkBuffer;
     delete m_pInputFifo;
 }
 

--- a/src/encoder/encoderfdkaac.cpp
+++ b/src/encoder/encoderfdkaac.cpp
@@ -284,6 +284,9 @@ int EncoderFdkAac::initEncoder(int samplerate, QString* pUserErrorMessage) {
     // This initializes the encoder handle but not the encoder itself.
     // Actual encoder init is done below.
     aacEncOpen(&m_aacEnc, 0, m_channels);
+    VERIFY_OR_DEBUG_ASSERT(!m_pAacDataBuffer) {
+        delete[] m_pAacDataBuffer;
+    }
     m_pAacDataBuffer = new unsigned char[kOutBufferBits * m_channels]();
 
     // AAC Object Type: specifies "mode": AAC-LC, HE-AAC, HE-AACv2, DAB AAC, etc...
@@ -346,8 +349,14 @@ int EncoderFdkAac::initEncoder(int samplerate, QString* pUserErrorMessage) {
     // This is set to the buffer size of the sidechain engine because
     // Recording (which uses this engine) sends more samples at once to the encoder than
     // the Live Broadcasting implementation
+    VERIFY_OR_DEBUG_ASSERT(!m_pInputFifo) {
+        delete m_pInputFifo;
+    }
     m_pInputFifo = new FIFO<SAMPLE>(EngineSideChain::SIDECHAIN_BUFFER_SIZE * 2);
 
+    VERIFY_OR_DEBUG_ASSERT(!m_pFifoChunkBuffer) {
+        delete[] m_pFifoChunkBuffer;
+    }
     m_pFifoChunkBuffer = new SAMPLE[m_readRequired * sizeof(SAMPLE)]();
     return 0;
 }


### PR DESCRIPTION
Temporary fix for 2.3, because #4341 targets main.