### PR TITLE
QmlControlProxy: fix type of keyValid Q_PROPERTY

### DIFF
--- a/src/qml/qmlcontrolproxy.h
+++ b/src/qml/qmlcontrolproxy.h
@@ -18,7 +18,7 @@ class QmlControlProxy : public QObject, public QQmlParserStatus {
     // properties.
     Q_PROPERTY(QString group READ getGroup WRITE setGroup NOTIFY groupChanged)
     Q_PROPERTY(QString key READ getKey WRITE setKey NOTIFY keyChanged)
-    Q_PROPERTY(QString keyValid READ isKeyValid NOTIFY keyValidChanged)
+    Q_PROPERTY(bool keyValid READ isKeyValid NOTIFY keyValidChanged)
     Q_PROPERTY(bool initialized READ isInitialized NOTIFY initializedChanged)
     Q_PROPERTY(double value READ getValue WRITE setValue NOTIFY valueChanged)
     Q_PROPERTY(double parameter READ getParameter WRITE setParameter NOTIFY parameterChanged)


### PR DESCRIPTION
The notify method for this property takes a bool argument but the
property was a QString before. That did not compile with Qt6.