### PR TITLE
static_cast<int> for qsizetype so std::max works

### DIFF
--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -966,7 +966,7 @@ void PlaylistDAO::shuffleTracks(const int playlistId,
 
     QHash<int, TrackId> trackPositionIds = allIds;
     QList<int> newPositions = positions;
-    const int searchDistance = math_max(trackPositionIds.count() / 4, 1);
+    const int searchDistance = math_max(static_cast<int>(trackPositionIds.count()) / 4, 1);
 
     qDebug() << "Shuffling Tracks";
     qDebug() << "*** Search Distance: " << searchDistance;


### PR DESCRIPTION
QHash::count returns qsizetype rather than int in Qt6

```
[14/399] Building CXX object CMakeFiles/mixxx-lib.dir/src/library/dao/playlistdao.cpp.o
FAILED: CMakeFiles/mixxx-lib.dir/src/library/dao/playlistdao.cpp.o
/usr/bin/ccache /usr/bin/c++ -DHAVE_INET_ATON -DHAVE_INET_PTON -DHAVE_UNISTD_H -DMIXXX_BUILD_RELEASE -DNDEBUG -DPA_USE_ALSA -DQT_CONCURRENT_LIB -DQT_CORE5COMPAT_LIB -DQT_CORE_LIB -DQT_DBUS_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_OPENGL_LIB -DQT_PRINTSUPPORT_LIB -DQT_QMLMODELS_LIB -DQT_QML_LIB -DQT_QUICKWIDGETS_LIB -DQT_QUICK_LIB -DQT_SQL_LIB -DQT_SVGWIDGETS_LIB -DQT_SVG_LIB -DQT_TABLET_SUPPORT -DQT_TESTLIB_LIB -DQT_USE_QSTRINGBUILDER -DQT_WIDGETS_LIB -DQT_XML_LIB -D__BATTERY__ -D__BROADCAST__ -D__BULK__ -D__ENGINEPRIME__ -D__FAAD__ -D__FFMPEG__ -D__HID__ -D__KEYFINDER__ -D__LILV__ -D__LINUX__ -D__MAD__ -D__MODPLUG__ -D__MP4V2__ -D__OPUS__ -D__QTKEYCHAIN__ -D__SNDFILE__ -D__SQLITE3__ -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__UNIX__ -D__VINYLCONTROL__ -D__WV__ -Dx86_64 -Imixxx-lib_autogen/include -I../src -Isrc -I/usr/include/ffmpeg -isystem /home/be/local/include -isystem ../lib/fidlib -isystem ../lib/googletest/googletest/include -isystem ../lib/portaudio -isystem ../lib/rigtorp/SPSCQueue/include -isystem ../lib/replaygain -isystem ../lib/reverb -isystem /usr/include/glib-2.0 -isystem /usr/lib64/glib-2.0/include -isystem ../lib/libshout-idjc/include -isystem ../lib/kaitai -isystem ../lib/mp3guessenc-0.27.4 -isystem /usr/include/qt6/QtConcurrent -isystem /usr/include/qt6 -isystem /usr/include/qt6/QtCore -isystem /usr/lib64/qt6/mkspecs/linux-g++ -isystem /usr/include/qt6/QtGui -isystem /usr/include/qt6/QtNetwork -isystem /usr/include/qt6/QtOpenGL -isystem /usr/include/qt6/QtPrintSupport -isystem /usr/include/qt6/QtWidgets -isystem /usr/include/qt6/QtQml -isystem /usr/include/qt6/QtQuickWidgets -isystem /usr/include/qt6/QtQuick -isystem /usr/include/qt6/QtQmlModels -isystem /usr/include/qt6/QtSql -isystem /usr/include/qt6/QtSvg -isystem /usr/include/qt6/QtTest -isystem /usr/include/qt6/QtXml -isystem /usr/include/qt6/QtSvgWidgets -isystem /usr/include/qt6/QtCore5Compat -isystem /usr/include/qt6/QtDBus -isystem ../lib/qm-dsp -isystem ../lib/qm-dsp/include -isystem /usr/include/taglib -isystem /usr/include/libupower-glib -isystem /usr/include/lilv-0 -isystem /usr/include/opus -isystem /usr/include/hidapi -isystem /usr/include/libusb-1.0 -isystem ../lib/xwax -isystem /usr/include/wavpack -fdiagnostics-color=auto -O2 -g -DNDEBUG -fvisibility=hidden -fvisibility-inlines-hidden -pipe -O3 -ffast-math -funroll-loops -fomit-frame-pointer -mtune=generic -Wall -Wextra -Woverloaded-virtual -Wfloat-conversion -Werror=return-type -Wformat=2 -Wformat-security -Wvla -Wundef -DPA_USE_JACK=1 -pthread -DPA_USE_ALSA=1 -D_REENTRANT -std=gnu++17 -MD -MT CMakeFiles/mixxx-lib.dir/src/library/dao/playlistdao.cpp.o -MF CMakeFiles/mixxx-lib.dir/src/library/dao/playlistdao.cpp.o.d -o CMakeFiles/mixxx-lib.dir/src/library/dao/playlistdao.cpp.o -c ../src/library/dao/playlistdao.cpp
../src/library/dao/playlistdao.cpp: In member function ‘void PlaylistDAO::shuffleTracks(int, const QList<int>&, const QHash<int, TrackId>&)’:
../src/library/dao/playlistdao.cpp:969:40: error: no matching function for call to ‘max(qsizetype, int)’
  969 |     const int searchDistance = math_max(trackPositionIds.count() / 4, 1);
In file included from /usr/include/c++/11/algorithm:61,
                 from /usr/include/qt6/QtCore/qglobal.h:126,
                 from /usr/include/qt6/QtCore/qcontainertools_impl.h:50,
                 from /usr/include/qt6/QtCore/qhash.h:44,
                 from /usr/include/qt6/QtCore/QHash:1,
                 from ../src/library/dao/playlistdao.h:3,
                 from ../src/library/dao/playlistdao.cpp:1:
/usr/include/c++/11/bits/stl_algobase.h:254:5: note: candidate: ‘template<class _Tp> constexpr const _Tp& std::max(const _Tp&, const _Tp&)’
  254 |     max(const _Tp& __a, const _Tp& __b)
      |     ^~~
/usr/include/c++/11/bits/stl_algobase.h:254:5: note:   template argument deduction/substitution failed:
../src/library/dao/playlistdao.cpp:969:40: note:   deduced conflicting types for parameter ‘const _Tp’ (‘long long int’ and ‘int’)
  969 |     const int searchDistance = math_max(trackPositionIds.count() / 4, 1);
In file included from /usr/include/c++/11/algorithm:61,
                 from /usr/include/qt6/QtCore/qglobal.h:126,
                 from /usr/include/qt6/QtCore/qcontainertools_impl.h:50,
                 from /usr/include/qt6/QtCore/qhash.h:44,
                 from /usr/include/qt6/QtCore/QHash:1,
                 from ../src/library/dao/playlistdao.h:3,
                 from ../src/library/dao/playlistdao.cpp:1:
/usr/include/c++/11/bits/stl_algobase.h:300:5: note: candidate: ‘template<class _Tp, class _Compare> constexpr const _Tp& std::max(const _Tp&, const _Tp&, _Compare)’
  300 |     max(const _Tp& __a, const _Tp& __b, _Compare __comp)
      |     ^~~
/usr/include/c++/11/bits/stl_algobase.h:300:5: note:   template argument deduction/substitution failed:
../src/library/dao/playlistdao.cpp:969:40: note:   deduced conflicting types for parameter ‘const _Tp’ (‘long long int’ and ‘int’)
  969 |     const int searchDistance = math_max(trackPositionIds.count() / 4, 1);
In file included from /usr/include/c++/11/algorithm:62,
                 from /usr/include/qt6/QtCore/qglobal.h:126,
                 from /usr/include/qt6/QtCore/qcontainertools_impl.h:50,
                 from /usr/include/qt6/QtCore/qhash.h:44,
                 from /usr/include/qt6/QtCore/QHash:1,
                 from ../src/library/dao/playlistdao.h:3,
                 from ../src/library/dao/playlistdao.cpp:1:
/usr/include/c++/11/bits/stl_algo.h:3461:5: note: candidate: ‘template<class _Tp> constexpr _Tp std::max(std::initializer_list<_Tp>)’
 3461 |     max(initializer_list<_Tp> __l)
      |     ^~~
/usr/include/c++/11/bits/stl_algo.h:3461:5: note:   template argument deduction/substitution failed:
../src/library/dao/playlistdao.cpp:969:40: note:   mismatched types ‘std::initializer_list<_Tp>’ and ‘long long int’
  969 |     const int searchDistance = math_max(trackPositionIds.count() / 4, 1);
In file included from /usr/include/c++/11/algorithm:62,
                 from /usr/include/qt6/QtCore/qglobal.h:126,
                 from /usr/include/qt6/QtCore/qcontainertools_impl.h:50,
                 from /usr/include/qt6/QtCore/qhash.h:44,
                 from /usr/include/qt6/QtCore/QHash:1,
                 from ../src/library/dao/playlistdao.h:3,
                 from ../src/library/dao/playlistdao.cpp:1:
/usr/include/c++/11/bits/stl_algo.h:3467:5: note: candidate: ‘template<class _Tp, class _Compare> constexpr _Tp std::max(std::initializer_list<_Tp>, _Compare)’
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
/usr/include/c++/11/bits/stl_algo.h:3467:5: note:   template argument deduction/substitution failed:
../src/library/dao/playlistdao.cpp:969:40: note:   mismatched types ‘std::initializer_list<_Tp>’ and ‘long long int’
  969 |     const int searchDistance = math_max(trackPositionIds.count() / 4, 1);
```