### PR TITLE
do not forward declare QStringList with Qt6

### DIFF
--- a/src/util/desktophelper.h
+++ b/src/util/desktophelper.h
@@ -2,7 +2,9 @@
 
 #include <QtGlobal>
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 QT_FORWARD_DECLARE_CLASS(QStringList);
+#endif
 
 namespace mixxx {
 


### PR DESCRIPTION
```
FAILED: CMakeFiles/mixxx-lib.dir/src/library/dlgtrackinfo.cpp.o
/usr/bin/ccache /usr/bin/c++ -DHAVE_INET_ATON -DHAVE_INET_PTON -DHAVE_UNISTD_H -DMIXXX_BUILD_RELEASE -DNDEBUG -DPA_USE_ALSA -DQT_CONCURRENT_LIB -DQT_CORE5COMPAT_LIB -DQT_CORE_LIB -DQT_DBUS_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_OPENGL_LIB -DQT_PRINTSUPPORT_LIB -DQT_QMLMODELS_LIB -DQT_QML_LIB -DQT_QUICKWIDGETS_LIB -DQT_QUICK_LIB -DQT_SQL_LIB -DQT_SVGWIDGETS_LIB -DQT_SVG_LIB -DQT_TABLET_SUPPORT -DQT_TESTLIB_LIB -DQT_USE_QSTRINGBUILDER -DQT_WIDGETS_LIB -DQT_XML_LIB -D__BATTERY__ -D__BROADCAST__ -D__BULK__ -D__ENGINEPRIME__ -D__FAAD__ -D__FFMPEG__ -D__HID__ -D__KEYFINDER__ -D__LILV__ -D__LINUX__ -D__MAD__ -D__MODPLUG__ -D__MP4V2__ -D__OPUS__ -D__QTKEYCHAIN__ -D__SNDFILE__ -D__SQLITE3__ -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__UNIX__ -D__VINYLCONTROL__ -D__WV__ -Dx86_64 -Imixxx-lib_autogen/include -I../src -Isrc -I/usr/include/ffmpeg -isystem /home/be/local/include -isystem ../lib/fidlib -isystem ../lib/googletest/googletest/include -isystem ../lib/portaudio -isystem ../lib/rigtorp/SPSCQueue/include -isystem ../lib/replaygain -isystem ../lib/reverb -isystem /usr/include/glib-2.0 -isystem /usr/lib64/glib-2.0/include -isystem ../lib/libshout-idjc/include -isystem ../lib/kaitai -isystem ../lib/mp3guessenc-0.27.4 -isystem /usr/include/qt6/QtConcurrent -isystem /usr/include/qt6 -isystem /usr/include/qt6/QtCore -isystem /usr/lib64/qt6/mkspecs/linux-g++ -isystem /usr/include/qt6/QtGui -isystem /usr/include/qt6/QtNetwork -isystem /usr/include/qt6/QtOpenGL -isystem /usr/include/qt6/QtPrintSupport -isystem /usr/include/qt6/QtWidgets -isystem /usr/include/qt6/QtQml -isystem /usr/include/qt6/QtQuickWidgets -isystem /usr/include/qt6/QtQuick -isystem /usr/include/qt6/QtQmlModels -isystem /usr/include/qt6/QtSql -isystem /usr/include/qt6/QtSvg -isystem /usr/include/qt6/QtTest -isystem /usr/include/qt6/QtXml -isystem /usr/include/qt6/QtSvgWidgets -isystem /usr/include/qt6/QtCore5Compat -isystem /usr/include/qt6/QtDBus -isystem ../lib/qm-dsp -isystem ../lib/qm-dsp/include -isystem /usr/include/taglib -isystem /usr/include/libupower-glib -isystem /usr/include/lilv-0 -isystem /usr/include/opus -isystem /usr/include/hidapi -isystem /usr/include/libusb-1.0 -isystem ../lib/xwax -isystem /usr/include/wavpack -fdiagnostics-color=auto -O2 -g -DNDEBUG -fvisibility=hidden -fvisibility-inlines-hidden -pipe -O3 -ffast-math -funroll-loops -fomit-frame-pointer -mtune=generic -Wall -Wextra -Woverloaded-virtual -Wfloat-conversion -Werror=return-type -Wformat=2 -Wformat-security -Wvla -Wundef -DPA_USE_JACK=1 -pthread -DPA_USE_ALSA=1 -D_REENTRANT -std=gnu++17 -MD -MT CMakeFiles/mixxx-lib.dir/src/library/dlgtrackinfo.cpp.o -MF CMakeFiles/mixxx-lib.dir/src/library/dlgtrackinfo.cpp.o.d -o CMakeFiles/mixxx-lib.dir/src/library/dlgtrackinfo.cpp.o -c ../src/library/dlgtrackinfo.cpp
In file included from /usr/include/qt6/QtGui/qtguiglobal.h:43,
                 from /usr/include/qt6/QtWidgets/qtwidgetsglobal.h:43,
                 from /usr/include/qt6/QtWidgets/qdialog.h:43,
                 from /usr/include/qt6/QtWidgets/QDialog:1,
                 from ../src/library/dlgtrackinfo.h:3,
                 from ../src/library/dlgtrackinfo.cpp:1:
../src/util/desktophelper.h:5:26: error: using typedef-name ‘using QStringList = class QList<QString>’ after ‘class’
    5 | QT_FORWARD_DECLARE_CLASS(QStringList);
      |                          ^~~~~~~~~~~
In file included from /usr/include/qt6/QtCore/qtypeinfo.h:42,
                 from /usr/include/qt6/QtCore/qglobal.h:1336,
                 from /usr/include/qt6/QtGui/qtguiglobal.h:43,
                 from /usr/include/qt6/QtWidgets/qtwidgetsglobal.h:43,
                 from /usr/include/qt6/QtWidgets/qdialog.h:43,
                 from /usr/include/qt6/QtWidgets/QDialog:1,
                 from ../src/library/dlgtrackinfo.h:3,
                 from ../src/library/dlgtrackinfo.cpp:1:
/usr/include/qt6/QtCore/qcontainerfwd.h:65:7: note: ‘using QStringList = class QList<QString>’ has a previous declaration here
   65 | using QStringList = QList<QString>;
      |       ^~~~~~~~~~~
```