### PR TITLE
do not build MixxxMainWindow with Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -750,7 +750,6 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/mixer/samplerbank.cpp
   src/coreservices.cpp
   src/mixxxapplication.cpp
-  src/mixxxmainwindow.cpp
   src/musicbrainz/chromaprinter.cpp
   src/musicbrainz/crc.cpp
   src/musicbrainz/gzip.cpp
@@ -936,6 +935,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
 )
 if(NOT QT6)
   target_sources(mixxx-lib PRIVATE
+    src/mixxxmainwindow.cpp
     src/skin/legacy/colorschemeparser.cpp
     src/skin/legacy/imgcolor.cpp
     src/skin/legacy/imginvert.cpp

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,7 +10,9 @@
 #include "coreservices.h"
 #include "errordialoghandler.h"
 #include "mixxxapplication.h"
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include "mixxxmainwindow.h"
+#endif
 #include "qml/qmlapplication.h"
 #include "sources/soundsourceproxy.h"
 #include "util/cmdlineargs.h"
@@ -34,10 +36,14 @@ int runMixxx(MixxxApplication* pApp, const CmdlineArgs& args) {
     CmdlineArgs::Instance().parseForUserFeedback();
 
     int exitCode;
-
+    // TODO: remove --qml command line option and make QML only available
+    // with Qt6 when Mixxx can build with Qt6.
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     if (args.getQml()) {
+#endif
         mixxx::qml::QmlApplication qmlApplication(pApp, pCoreServices);
         exitCode = pApp->exec();
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     } else {
         // This scope ensures that `MixxxMainWindow` is destroyed *before*
         // CoreServices is shut down. Otherwise a debug assertion complaining about
@@ -65,6 +71,7 @@ int runMixxx(MixxxApplication* pApp, const CmdlineArgs& args) {
             exitCode = pApp->exec();
         }
     }
+#endif
     return exitCode;
 }
 


### PR DESCRIPTION
MixxxMainWindow is incompatible with Qt6 due to the use of
QGLFormat.