### PR TITLE
MixxxApplication: do not build hacks for touch input with Qt6

### DIFF
--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -40,6 +40,7 @@ Q_IMPORT_PLUGIN(QJpegPlugin)
 Q_IMPORT_PLUGIN(QGifPlugin)
 #endif // QT_STATIC
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 namespace {
 
 /// This class allows to change the button of a mouse event on the fly.
@@ -53,6 +54,7 @@ class QMouseEventEditable : public QMouseEvent {
 };
 
 } // anonymous namespace
+#endif
 
 MixxxApplication::MixxxApplication(int& argc, char** argv)
         : QApplication(argc, argv),
@@ -103,6 +105,7 @@ void MixxxApplication::registerMetaTypes() {
     qRegisterMetaType<mixxx::FileInfo>("mixxx::FileInfo");
 }
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 bool MixxxApplication::notify(QObject* target, QEvent* event) {
     // All touch events are translated into two simultaneous events: one for
     // the target QWidgetWindow and one for the target QWidget.
@@ -147,3 +150,4 @@ bool MixxxApplication::touchIsRightButton() {
     }
     return m_pTouchShift->toBool();
 }
+#endif


### PR DESCRIPTION
These hacks were to simulate mouse input with touch input
with the legacy QWidgets GUI. They do not build with Qt6 and
are not needed with QML.