### PR TITLE
ConfigObject: guard QTextStream::setCodec behind Qt version check

### DIFF
--- a/src/preferences/configobject.cpp
+++ b/src/preferences/configobject.cpp
@@ -166,7 +166,11 @@ template <class ValueType> bool ConfigObject<ValueType>::parse() {
         int group = 0;
         QString groupStr, line;
         QTextStream text(&configfile);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        DEBUG_ASSERT(text.encoding() == QStringConverter::Utf8);
+#else
         text.setCodec("UTF-8");
+#endif
 
         while (!text.atEnd()) {
             line = text.readLine().trimmed();
@@ -213,7 +217,12 @@ bool ConfigObject<ValueType>::save() {
         return false;
     }
     QTextStream stream(&tmpFile);
+    // UTF-8 is the default in Qt6.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    DEBUG_ASSERT(stream.encoding() == QStringConverter::Utf8);
+#else
     stream.setCodec("UTF-8");
+#endif
 
     QString group = "";
 


### PR DESCRIPTION
QTextSTream::setCodec was removed in Qt6:
https://bugreports.qt.io/browse/QTBUG-75665