### PR TITLE
use std::next on iterators

### DIFF
--- a/src/preferences/broadcastsettings.cpp
+++ b/src/preferences/broadcastsettings.cpp
@@ -194,7 +194,7 @@ void BroadcastSettings::onConnectionStatusChanged(int newStatus) {
 }
 
 BroadcastProfilePtr BroadcastSettings::profileAt(int index) {
-    auto it = m_profiles.begin() + index;
+    auto it = std::next(m_profiles.begin(), index);
     return it != m_profiles.end() ? it.value() : BroadcastProfilePtr(nullptr);
 }
 

--- a/src/preferences/broadcastsettingsmodel.cpp
+++ b/src/preferences/broadcastsettingsmodel.cpp
@@ -104,7 +104,7 @@ QVariant BroadcastSettingsModel::data(const QModelIndex& index, int role) const 
         return QVariant();
     }
 
-    auto it = m_profiles.constBegin() + rowIndex;
+    auto it = std::next(m_profiles.constBegin(), rowIndex);
     if (it != m_profiles.constEnd()) {
         BroadcastProfilePtr profile = it.value();
         int column = index.column();
@@ -165,7 +165,7 @@ Qt::ItemFlags BroadcastSettingsModel::flags(const QModelIndex& index) const {
 
 bool BroadcastSettingsModel::setData(const QModelIndex& index, const QVariant& value, int role) {
     if (index.isValid()) {
-        auto it = m_profiles.constBegin() + index.row();
+        auto it = std::next(m_profiles.constBegin(), index.row());
         if (it != m_profiles.constEnd()) {
             BroadcastProfilePtr profile = it.value();
             if (index.column() == kColumnEnabled && role == Qt::CheckStateRole) {


### PR DESCRIPTION
operator+ has been removed from QHash iterators in Qt6. It was readded
in Qt 6.2 with a deprecation warning saying to use std::next instead.