### PR TITLE
explicitly convert QStrings to QFileInfos

### DIFF
--- a/src/sources/soundsource.cpp
+++ b/src/sources/soundsource.cpp
@@ -40,7 +40,7 @@ inline QString fileTypeFromSuffix(const QString& suffix) {
 //static
 QString SoundSource::getTypeFromUrl(const QUrl& url) {
     const QString filePath = validateLocalFileUrl(url).toLocalFile();
-    return getTypeFromFile(filePath);
+    return getTypeFromFile(QFileInfo(filePath));
 }
 
 //static

--- a/src/test/controller_mapping_validation_test.cpp
+++ b/src/test/controller_mapping_validation_test.cpp
@@ -53,7 +53,8 @@ void LegacyControllerMappingValidationTest::SetUp() {
 
 bool LegacyControllerMappingValidationTest::testLoadMapping(const MappingInfo& mapping) {
     std::shared_ptr<LegacyControllerMapping> pMapping =
-            LegacyControllerMappingFileHandler::loadMapping(mapping.getPath(), m_mappingPath);
+            LegacyControllerMappingFileHandler::loadMapping(
+                    QFileInfo(mapping.getPath()), m_mappingPath);
     if (!pMapping) {
         return false;
     }

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -732,36 +732,38 @@ TEST_F(SoundSourceProxyTest, getTypeFromFile) {
     mixxxtest::copyFile(validFilePath, filePathWithWrongSuffix);
     mixxxtest::copyFile(validFilePath, filePathWithUppercaseAndLeadingTrailingWhitespaceSuffix);
 
-    ASSERT_STREQ(qPrintable("mp3"), qPrintable(mixxx::SoundSource::getTypeFromFile(validFilePath)));
+    ASSERT_STREQ(qPrintable("mp3"),
+            qPrintable(mixxx::SoundSource::getTypeFromFile(
+                    QFileInfo(validFilePath))));
 
     EXPECT_STREQ(qPrintable("mp3"),
             qPrintable(mixxx::SoundSource::getTypeFromFile(
-                    filePathWithoutSuffix)));
+                    QFileInfo(filePathWithoutSuffix))));
     EXPECT_STREQ(qPrintable("mp3"),
             qPrintable(mixxx::SoundSource::getTypeFromFile(
-                    filePathWithEmptySuffix)));
+                    QFileInfo(filePathWithEmptySuffix))));
     EXPECT_STREQ(qPrintable("mp3"),
             qPrintable(mixxx::SoundSource::getTypeFromFile(
-                    filePathWithUnknownSuffix)));
+                    QFileInfo(filePathWithUnknownSuffix))));
     EXPECT_STREQ(qPrintable("mp3"),
             qPrintable(mixxx::SoundSource::getTypeFromFile(
-                    filePathWithWrongSuffix)));
+                    QFileInfo(filePathWithWrongSuffix))));
     EXPECT_STREQ(qPrintable("mp3"),
             qPrintable(mixxx::SoundSource::getTypeFromFile(
-                    filePathWithUppercaseAndLeadingTrailingWhitespaceSuffix)));
+                    QFileInfo(filePathWithUppercaseAndLeadingTrailingWhitespaceSuffix))));
 }
 
 TEST_F(SoundSourceProxyTest, getTypeFromMissingFile) {
     // Also verify that the shortened suffix ".aif" (case-insensitive) is
     // mapped to file type "aiff", independent of whether the file exists or not!
-    const QFileInfo missingFileWithUppercaseSuffixAndLeadingTrailingWhitespaceSuffix =
-            kTestDir.absoluteFilePath(QStringLiteral("missing_file. AIF "));
+    const QFileInfo missingFileWithUppercaseSuffixAndLeadingTrailingWhitespaceSuffix(
+            kTestDir.absoluteFilePath(QStringLiteral("missing_file. AIF ")));
 
     ASSERT_FALSE(missingFileWithUppercaseSuffixAndLeadingTrailingWhitespaceSuffix.exists());
 
     EXPECT_STREQ(qPrintable("aiff"),
             qPrintable(mixxx::SoundSource::getTypeFromFile(
-                    missingFileWithUppercaseSuffixAndLeadingTrailingWhitespaceSuffix)));
+                    QFileInfo(missingFileWithUppercaseSuffixAndLeadingTrailingWhitespaceSuffix))));
 }
 
 TEST_F(SoundSourceProxyTest, getTypeFromAiffFile) {
@@ -771,7 +773,7 @@ TEST_F(SoundSourceProxyTest, getTypeFromAiffFile) {
     ASSERT_TRUE(QFileInfo::exists(aiffFilePath));
     ASSERT_STREQ(qPrintable("aiff"),
             qPrintable(mixxx::SoundSource::getTypeFromFile(
-                    aiffFilePath)));
+                    QFileInfo(aiffFilePath))));
 
     const QString aiffFilePathWithShortenedSuffix =
             mixxxtest::generateTemporaryFileName(QStringLiteral("cover-test.aif"));
@@ -780,5 +782,5 @@ TEST_F(SoundSourceProxyTest, getTypeFromAiffFile) {
 
     EXPECT_STREQ(qPrintable("aiff"),
             qPrintable(mixxx::SoundSource::getTypeFromFile(
-                    aiffFilePathWithShortenedSuffix)));
+                    QFileInfo(aiffFilePathWithShortenedSuffix))));
 }

--- a/src/track/serato/tags.cpp
+++ b/src/track/serato/tags.cpp
@@ -21,7 +21,7 @@ namespace {
 
 QString getPrimaryDecoderNameForFilePath(const QString& filePath) {
     const QString fileExtension =
-            mixxx::SoundSource::getTypeFromFile(filePath);
+            mixxx::SoundSource::getTypeFromFile(QFileInfo(filePath));
     const mixxx::SoundSourceProviderPointer pPrimaryProvider =
             SoundSourceProxy::getPrimaryProviderForFileExtension(fileExtension);
     if (pPrimaryProvider) {


### PR DESCRIPTION
The constructor for converting a QString to a QFileInfo was made
explicit in Qt6.