### PR TITLE
MixxxApplication: guard registerComparators behind Qt verison check

### DIFF
--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -91,7 +91,9 @@ void MixxxApplication::registerMetaTypes() {
 
     // Sound devices
     qRegisterMetaType<SoundDeviceId>();
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QMetaType::registerComparators<SoundDeviceId>();
+#endif
 
     // Various custom data types
     qRegisterMetaType<mixxx::ReplayGain>("mixxx::ReplayGain");


### PR DESCRIPTION
registerComparators was removed in Qt6 and is no longer needed:
https://doc.qt.io/qt-6/qtcore-changes-qt6.html#the-qmetatype-class