### PR TITLE
use QString::number for explicit conversion

### DIFF
--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -85,7 +85,8 @@ bool SoundManagerConfig::readFromDisk() {
     setForceNetworkClock(rootElement.attribute(xmlAttributeForceNetworkClock,
             "0").toUInt() != 0);
     setDeckCount(rootElement.attribute(xmlAttributeDeckCount,
-            QString(kDefaultDeckCount)).toUInt());
+                                    QString::number(kDefaultDeckCount))
+                         .toUInt());
     clearOutputs();
     clearInputs();
     QDomNodeList devElements(rootElement.elementsByTagName(xmlElementSoundDevice));


### PR DESCRIPTION
This did not build with Qt6 trying to implicitly convert a number
to a QString.