### PR TITLE
static_cast<size_t> for QByteArray::size with std::max

### DIFF
--- a/src/util/cache.cpp
+++ b/src/util/cache.cpp
@@ -15,10 +15,10 @@ cache_key_t cacheKeyFromMessageDigest(const QByteArray& messageDigest) {
     // SP 800-107
     // 5 Hash function Usage
     // 5.1 Truncated Message Digest
-    const auto significantByteCount = math_min(
-            messageDigest.size(),
-            static_cast<int>(sizeof(cache_key_t)));
-    for (auto i = 0; i < significantByteCount; ++i) {
+    const size_t significantByteCount = math_min(
+            static_cast<size_t>(messageDigest.size()),
+            sizeof(cache_key_t));
+    for (size_t i = 0; i < significantByteCount; ++i) {
         // Only 8 bits are relevant and we don't want the sign
         // extension of a (signed) char during the conversion.
         const cache_key_t nextByte =


### PR DESCRIPTION
QByteArray::size returns qsizetype in Qt6, which needs to be
converted to an int to pass to std::max.