### PR TITLE
change KeyChangeList from a QVector to a QList

### DIFF
--- a/src/track/keyfactory.cpp
+++ b/src/track/keyfactory.cpp
@@ -89,7 +89,7 @@ Keys KeyFactory::makePreferredKeys(
 
     if (version == KEY_MAP_VERSION) {
         KeyMap key_map;
-        for (const auto* it = key_changes.constBegin();
+        for (auto it = key_changes.constBegin();
                 it != key_changes.constEnd();
                 ++it) {
             // Key position is in frames. Do not accept fractional frames.

--- a/src/track/keys.h
+++ b/src/track/keys.h
@@ -1,14 +1,14 @@
 #pragma once
 
 #include <QByteArray>
+#include <QList>
 #include <QPair>
-#include <QVector>
 
 #include "proto/keys.pb.h"
 
 #define KEY_MAP_VERSION "KeyMap-1.0"
 
-typedef QVector<QPair<mixxx::track::io::key::ChromaticKey, double> > KeyChangeList;
+typedef QList<QPair<mixxx::track::io::key::ChromaticKey, double> > KeyChangeList;
 
 class KeyFactory;
 


### PR DESCRIPTION
QVector and QList have been consolidated in Qt6. In Qt5,
QVector::iterator is a pointer type, so clang-tidy wants to use
auto* rather than auto. This is not an issue using QList instead;
simply using auto works.