### PR TITLE
remove library sidebar from QML

### DIFF
--- a/res/qml/Library.qml
+++ b/res/qml/Library.qml
@@ -5,83 +5,46 @@ import QtQuick.Controls 1.4
 import "Theme"
 
 Item {
-    Rectangle {
-        color: Theme.deckBackgroundColor
-        anchors.fill: parent
+    ListView {
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.bottom: parent.bottom
+        anchors.margins: 10
+        model: Mixxx.Library.model
 
-        TreeView {
-            id: sidebar
+        delegate: Item {
+            id: itemDelegate
 
-            anchors.top: parent.top
-            anchors.left: parent.left
-            anchors.bottom: parent.bottom
-            anchors.margins: 10
-            width: 250
-            model: Mixxx.Library.getSidebarModel()
+            implicitWidth: 300
+            implicitHeight: 30
 
-            TableViewColumn {
-                title: "Icon"
-                role: "iconName"
-                width: 50
-
-                delegate: Image {
-                    fillMode: Image.PreserveAspectFit
-                    source: styleData.value ? "qrc:///images/library/ic_library_" + styleData.value + ".svg" : ""
-                }
-
+            Text {
+                anchors.fill: parent
+                text: artist + " - " + title
+                color: Theme.deckTextColor
             }
 
-            TableViewColumn {
-                title: "Title"
-                role: "display"
+            Image {
+                id: dragItem
+
+                Drag.active: dragArea.drag.active
+                Drag.dragType: Drag.Automatic
+                Drag.supportedActions: Qt.CopyAction
+                Drag.mimeData: {
+                    "text/uri-list": fileUrl,
+                    "text/plain": fileUrl
+                }
+                anchors.fill: parent
             }
 
-        }
+            MouseArea {
+                id: dragArea
 
-        ListView {
-            anchors.top: parent.top
-            anchors.left: sidebar.right
-            anchors.right: parent.right
-            anchors.bottom: parent.bottom
-            anchors.margins: 10
-            clip: true
-            model: Mixxx.Library.model
-
-            delegate: Item {
-                id: itemDelegate
-
-                implicitWidth: 300
-                implicitHeight: 30
-
-                Text {
-                    anchors.fill: parent
-                    text: artist + " - " + title
-                    color: Theme.deckTextColor
-                }
-
-                Image {
-                    id: dragItem
-
-                    Drag.active: dragArea.drag.active
-                    Drag.dragType: Drag.Automatic
-                    Drag.supportedActions: Qt.CopyAction
-                    Drag.mimeData: {
-                        "text/uri-list": fileUrl,
-                        "text/plain": fileUrl
-                    }
-                    anchors.fill: parent
-                }
-
-                MouseArea {
-                    id: dragArea
-
-                    anchors.fill: parent
-                    drag.target: dragItem
-                    onPressed: parent.grabToImage((result) => {
-                        dragItem.Drag.imageSource = result.url;
-                    })
-                }
-
+                anchors.fill: parent
+                drag.target: dragItem
+                onPressed: parent.grabToImage((result) => {
+                    dragItem.Drag.imageSource = result.url;
+                })
             }
 
         }

--- a/src/qml/qmllibraryproxy.cpp
+++ b/src/qml/qmllibraryproxy.cpp
@@ -14,9 +14,5 @@ QmlLibraryProxy::QmlLibraryProxy(std::shared_ptr<Library> pLibrary, QObject* par
           m_pModel(make_parented<QmlLibraryTrackListModel>(m_pLibrary->trackTableModel(), this)) {
 }
 
-QAbstractItemModel* QmlLibraryProxy::getSidebarModel() {
-    return m_pLibrary->sidebarModel();
-}
-
 } // namespace qml
 } // namespace mixxx

--- a/src/qml/qmllibraryproxy.h
+++ b/src/qml/qmllibraryproxy.h
@@ -22,8 +22,6 @@ class QmlLibraryProxy : public QObject {
   public:
     explicit QmlLibraryProxy(std::shared_ptr<Library> pLibrary, QObject* parent = nullptr);
 
-    Q_INVOKABLE QAbstractItemModel* getSidebarModel();
-
   private:
     std::shared_ptr<Library> m_pLibrary;
     parented_ptr<QmlLibraryTrackListModel> m_pModel;


### PR DESCRIPTION
As discussed on Zulip, we will not be continuing to work on fitting
the legacy LibraryFeatures into QML. The simple ListView for the
Tracks feature remains as a crude hack useful for developing QML
until we replace it with a new QML GUI for Aoide. The sidebar
was not functional anyway; it only showed the data with no way to
make use of it.
https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/QML.20library.20GUI/near/257370390