### PR TITLE
Beats: Remove legacy BeatIterator class in favor of std iterator

### DIFF
--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -10,15 +10,6 @@ using namespace mixxx;
 
 namespace {
 
-int countRemainingBeats(std::unique_ptr<BeatIterator> pIterator) {
-    int numBeatsFound = 0;
-    while (pIterator->hasNext()) {
-        pIterator->next();
-        numBeatsFound++;
-    }
-    return numBeatsFound;
-}
-
 class BeatMapTest : public testing::Test {
   protected:
     BeatMapTest()
@@ -226,53 +217,6 @@ TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
     pMap->findPrevNextBeats(position, &foundPrevBeat, &foundNextBeat, false);
     EXPECT_EQ(previousBeat, foundPrevBeat);
     EXPECT_EQ(nextBeat, foundNextBeat);
-}
-
-TEST_F(BeatMapTest, FindBeatsWithFractionalPos) {
-    constexpr mixxx::Bpm bpm(60.0);
-    constexpr int numBeats = 120;
-    const mixxx::audio::FrameDiff_t beatLengthFrames = getBeatLengthFrames(bpm);
-    ASSERT_EQ(beatLengthFrames, std::round(beatLengthFrames));
-
-    mixxx::audio::FramePos beatPos = mixxx::audio::kStartFramePos;
-    const mixxx::audio::FramePos lastBeatPos = beatPos + beatLengthFrames * (numBeats - 1);
-    QVector<mixxx::audio::FramePos> beats;
-    for (; beatPos <= lastBeatPos; beatPos += beatLengthFrames) {
-        beats.append(beatPos);
-    }
-    const auto pMap = Beats::fromBeatPositions(m_pTrack->getSampleRate(), beats);
-
-    // All beats are in range
-    auto it = pMap->findBeats(mixxx::audio::kStartFramePos, lastBeatPos);
-    int numBeatsFound = countRemainingBeats(std::move(it));
-    EXPECT_EQ(numBeats, numBeatsFound);
-
-    // Only half the beats are in range
-    const auto halfBeatsPosition = mixxx::audio::kStartFramePos +
-            beatLengthFrames * ((numBeats / 2) - 1);
-    it = pMap->findBeats(mixxx::audio::kStartFramePos, halfBeatsPosition);
-    numBeatsFound = countRemainingBeats(std::move(it));
-    EXPECT_EQ(numBeats / 2, numBeatsFound);
-
-    // First beat is not in range
-    it = pMap->findBeats(mixxx::audio::kStartFramePos + 0.5, lastBeatPos + 0.5);
-    numBeatsFound = countRemainingBeats(std::move(it));
-    EXPECT_EQ(numBeats - 1, numBeatsFound);
-
-    // Last beat is not in range
-    it = pMap->findBeats(mixxx::audio::kStartFramePos - 0.5, lastBeatPos - 0.5);
-    numBeatsFound = countRemainingBeats(std::move(it));
-    EXPECT_EQ(numBeats - 1, numBeatsFound);
-
-    // All beats are in range
-    it = pMap->findBeats(mixxx::audio::kStartFramePos - 0.5, lastBeatPos + 0.5);
-    numBeatsFound = countRemainingBeats(std::move(it));
-    EXPECT_EQ(numBeats, numBeatsFound);
-
-    // First and last beats in range
-    it = pMap->findBeats(mixxx::audio::kStartFramePos + 0.5, lastBeatPos - 0.5);
-    numBeatsFound = countRemainingBeats(std::move(it));
-    EXPECT_EQ(numBeats - 2, numBeatsFound);
 }
 
 TEST_F(BeatMapTest, HasBeatInRangeWithFractionalPos) {

--- a/src/test/seratobeatgridtest.cpp
+++ b/src/test/seratobeatgridtest.cpp
@@ -173,16 +173,15 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
         const auto pImportedBeats =
                 beatsImporter.importBeatsAndApplyTimingOffset(
                         timingOffsetMillis, signalInfo);
-        auto pBeatsIterator =
-                pImportedBeats->findBeats(beatPositionsFrames.first() - 1000,
-                        beatPositionsFrames.last() + 1000);
+        auto it = pImportedBeats->iteratorFrom(beatPositionsFrames.first() - 1000);
         for (int i = 0; i < beatPositionsFrames.size(); i++) {
-            const auto importedPosition = pBeatsIterator->next();
+            const auto importedPosition = *it;
             EXPECT_NEAR(beatPositionsFrames[i].value(),
                     importedPosition.value(),
                     kEpsilon);
+            it++;
         }
-        ASSERT_FALSE(pBeatsIterator->hasNext());
+        ASSERT_TRUE(*it >= beatPositionsFrames.last() + 1000);
     }
 
     constexpr int kNumBeats60BPM = 4;
@@ -226,16 +225,15 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
         const auto pImportedBeats =
                 beatsImporter.importBeatsAndApplyTimingOffset(
                         timingOffsetMillis, signalInfo);
-        auto pBeatsIterator =
-                pImportedBeats->findBeats(beatPositionsFrames.first() - 1000,
-                        beatPositionsFrames.last() + 1000);
+        auto it = pImportedBeats->iteratorFrom(beatPositionsFrames.first() - 1000);
         for (int i = 0; i < beatPositionsFrames.size(); i++) {
-            const auto importedPosition = pBeatsIterator->next();
+            const auto importedPosition = *it;
             EXPECT_NEAR(beatPositionsFrames[i].value(),
                     importedPosition.value(),
                     kEpsilon);
+            it++;
         }
-        ASSERT_FALSE(pBeatsIterator->hasNext());
+        ASSERT_TRUE(*it >= beatPositionsFrames.last() + 1000);
     }
 
     qInfo() << "Step 3: Add" << kNumBeats120BPM << "beats at 100 bpm to the beatgrid";
@@ -287,16 +285,15 @@ TEST_F(SeratoBeatGridTest, SerializeBeatMap) {
         const auto pImportedBeats =
                 beatsImporter.importBeatsAndApplyTimingOffset(
                         timingOffsetMillis, signalInfo);
-        auto pBeatsIterator =
-                pImportedBeats->findBeats(beatPositionsFrames.first() - 1000,
-                        beatPositionsFrames.last() + 1000);
+        auto it = pImportedBeats->iteratorFrom(beatPositionsFrames.first() - 1000);
         for (int i = 0; i < beatPositionsFrames.size(); i++) {
-            const auto importedPosition = pBeatsIterator->next();
+            const auto importedPosition = *it;
             EXPECT_NEAR(beatPositionsFrames[i].value(),
                     importedPosition.value(),
                     kEpsilon);
+            it++;
         }
-        ASSERT_FALSE(pBeatsIterator->hasNext());
+        ASSERT_TRUE(*it >= beatPositionsFrames.last() + 1000);
     }
 }
 

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -24,19 +24,6 @@ constexpr double kEpsilon = 0.01;
 
 namespace mixxx {
 
-bool BeatIterator::hasNext() const {
-    return *m_it <= m_endPosition;
-}
-
-audio::FramePos BeatIterator::next() {
-    VERIFY_OR_DEBUG_ASSERT(hasNext()) {
-        return audio::kInvalidFramePos;
-    }
-    const audio::FramePos position = *m_it;
-    m_it++;
-    return position;
-}
-
 mixxx::audio::FrameDiff_t Beats::ConstIterator::beatLengthFrames() const {
     if (m_it == m_beats->m_markers.cend()) {
         return m_beats->endBeatLengthFrames();
@@ -510,13 +497,6 @@ audio::FramePos Beats::findNBeatsFromPosition(audio::FramePos position, double b
     }
 
     return basePosition + it.beatLengthFrames() * fractionBeats;
-}
-
-std::unique_ptr<BeatIterator> Beats::findBeats(
-        audio::FramePos startPosition,
-        audio::FramePos endPosition) const {
-    auto it = iteratorFrom(startPosition);
-    return std::make_unique<BeatIterator>(std::move(it), endPosition);
 }
 
 bool Beats::hasBeatInRange(audio::FramePos startPosition, audio::FramePos endPosition) const {

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -173,18 +173,31 @@ class Beats : private std::enable_shared_from_this<Beats> {
 
     ~Beats() = default;
 
+    /// Returns an iterator pointing to the position of the first beat marker.
     ConstIterator cbegin() const {
         return ConstIterator(this, m_markers.cbegin(), 0);
     }
 
+    /// Returns an iterator pointing to the position of the first beat after
+    /// the end beat marker.
     ConstIterator cend() const {
         return ConstIterator(this, m_markers.cend(), 1);
     }
 
+    /// Returns an iterator pointing to earliest representable beat position
+    /// (which is INT_MIN beats before the first beat marker).
+    ///
+    /// Warning: Decrementing the iterator returned by this function will
+    /// result in an integer underflow.
     ConstIterator cearliest() const {
         return ConstIterator(this, m_markers.cbegin(), std::numeric_limits<int>::lowest());
     }
 
+    /// Returns an iterator pointing to latest representable beat position
+    /// (which is INT_MAX beats behind the end beat marker).
+    ///
+    /// Warning: Incrementing the iterator returned by this function will
+    /// result in an integer overflow.
     ConstIterator clatest() const {
         return ConstIterator(this, m_markers.cend(), std::numeric_limits<int>::max());
     }

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -20,7 +20,6 @@
 namespace mixxx {
 
 class Beats;
-class BeatIterator;
 typedef std::shared_ptr<const Beats> BeatsPointer;
 
 class BeatMarker {
@@ -335,15 +334,6 @@ class Beats : private std::enable_shared_from_this<Beats> {
     audio::FramePos findNBeatsFromPosition(
             audio::FramePos position, double beats) const;
 
-    /// Returns an iterator that yields frame position of every beat occurring
-    /// between `startPosition` and `endPosition`. `BeatIterator` must be iterated
-    /// while holding a strong references to the `Beats` object to ensure that
-    /// the `Beats` object is not deleted. Caller takes ownership of the returned
-    /// `BeatIterator`.
-    std::unique_ptr<BeatIterator> findBeats(
-            audio::FramePos startPosition,
-            audio::FramePos endPosition) const;
-
     /// Return whether or not a beat exists between `startPosition` and `endPosition`.
     bool hasBeatInRange(audio::FramePos startPosition,
             audio::FramePos endPosition) const;
@@ -423,22 +413,6 @@ class Beats : private std::enable_shared_from_this<Beats> {
 
     // The sub-version of this beatgrid.
     const QString m_subVersion;
-};
-
-class BeatIterator {
-  public:
-    BeatIterator(Beats::ConstIterator it, audio::FramePos endPosition)
-            : m_it(std::move(it)),
-              m_endPosition(endPosition) {
-    }
-
-    ~BeatIterator() = default;
-    bool hasNext() const;
-    audio::FramePos next();
-
-  private:
-    Beats::ConstIterator m_it;
-    const audio::FramePos m_endPosition;
 };
 
 } // namespace mixxx

--- a/src/waveform/renderers/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/waveformrenderbeat.cpp
@@ -56,12 +56,14 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
     //          << "firstDisplayedPosition" << firstDisplayedPosition
     //          << "lastDisplayedPosition" << lastDisplayedPosition;
 
-    std::unique_ptr<mixxx::BeatIterator> it(trackBeats->findBeats(
-            mixxx::audio::FramePos::fromEngineSamplePos(firstDisplayedPosition * trackSamples),
-            mixxx::audio::FramePos::fromEngineSamplePos(lastDisplayedPosition * trackSamples)));
+    const auto startPosition = mixxx::audio::FramePos::fromEngineSamplePos(
+            firstDisplayedPosition * trackSamples);
+    const auto endPosition = mixxx::audio::FramePos::fromEngineSamplePos(
+            lastDisplayedPosition * trackSamples);
+    auto it = trackBeats->iteratorFrom(startPosition);
 
     // if no beat do not waste time saving/restoring painter
-    if (!it || !it->hasNext()) {
+    if (it == trackBeats->clatest() || *it > endPosition) {
         return;
     }
 
@@ -79,8 +81,8 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
 
     int beatCount = 0;
 
-    while (it->hasNext()) {
-        double beatPosition = it->next().toEngineSamplePos();
+    for (; it != trackBeats->clatest() && *it <= endPosition; ++it) {
+        double beatPosition = it->toEngineSamplePos();
         double xBeatPoint =
                 m_waveformRenderer->transformSamplePositionInRendererWorld(beatPosition);
 


### PR DESCRIPTION
The custom, legacy iterator API was only used for rendering beats on the
waveform and for importing beats from Serato BeatGrids.

Since the new iterator API is way more powerful and can be used
with the iterator-based functions from `<algorithm>`, it makes sense to
replace the only occurrence and then remove the old API entirely.

Based on #4255.