### PR TITLE
GH Actions: unconditionally use Ninja CMake generator on all OSes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,6 +218,7 @@ jobs:
     - name: "Configure"
       run: >-
         cmake ${{ matrix.cmake_args }} ${{ env.CMAKE_ARGS_EXTRA }}
+        -G Ninja
         -DCMAKE_BUILD_TYPE=RelWithDebInfo
         -DCMAKE_PREFIX_PATH="${{ env.CMAKE_PREFIX_PATH }}"
         -DDEBUG_ASSERTIONS_FATAL=OFF

--- a/tools/debian_buildenv.sh
+++ b/tools/debian_buildenv.sh
@@ -80,6 +80,7 @@ case "$1" in
             libusb-1.0-0-dev \
             libwavpack-dev \
             markdown \
+            ninja-build \
             portaudio19-dev \
             protobuf-compiler \
             qt5keychain-dev \


### PR DESCRIPTION
This makes CI easier to maintain to unblock #4281.