### PR TITLE
ParserM3u: rewrite for Qt6 compatibility

### DIFF
--- a/src/library/parserm3u.h
+++ b/src/library/parserm3u.h
@@ -31,10 +31,4 @@ public:
     static bool writeM3UFile(const QString &file_str, const QList<QString> &items, bool useRelativePath, bool useUtf8);
     static bool writeM3UFile(const QString &file, const QList<QString> &items, bool useRelativePath);
     static bool writeM3U8File(const QString &file_str, const QList<QString> &items, bool useRelativePath);
-
-private:
-    /**Reads a line from the file and returns filepath if a valid file**/
-    QString getFilePath(QTextStream* stream, const QString& basePath);
-
-
 };


### PR DESCRIPTION
QTextStream no longer supports uncommon encodings like Windows-1250
in Qt6:
https://bugreports.qt.io/browse/QTBUG-75665