### PR TITLE
Fix switching from Shade to other skins

### DIFF
--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -19,7 +19,6 @@ class ControlObject;
 class ControlPotmeter;
 class ControlProxy;
 class EffectsManager;
-class VisualsManager;
 
 // Interface for not leaking implementation details of BaseTrackPlayer into the
 // rest of Mixxx. Also makes testing a lot easier.

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -24,7 +24,6 @@ class PreviewDeck;
 class Sampler;
 class SamplerBank;
 class SoundManager;
-class VisualsManager;
 class ControlProxy;
 
 // For mocking PlayerManager

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -790,8 +790,7 @@ void MixxxMainWindow::connectMenuBar() {
 }
 
 void MixxxMainWindow::slotFileLoadSongPlayer(int deck) {
-    auto pPlayerManager = m_pCoreServices->getPlayerManager();
-    QString group = pPlayerManager->groupForDeck(deck - 1);
+    QString group = PlayerManager::groupForDeck(deck - 1);
 
     QString loadTrackText = tr("Load track to Deck %1").arg(QString::number(deck));
     QString deckWarningMessage = tr("Deck %1 is currently playing a track.")
@@ -828,7 +827,7 @@ void MixxxMainWindow::slotFileLoadSongPlayer(int deck) {
         mixxx::FileInfo fileInfo(trackPath);
         Sandbox::createSecurityToken(&fileInfo);
 
-        pPlayerManager->slotLoadToDeck(trackPath, deck);
+        m_pCoreServices->getPlayerManager()->slotLoadToDeck(trackPath, deck);
     }
 }
 

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -146,6 +146,15 @@ void MixxxMainWindow::initialize() {
     for (const QString& group : visualGroups) {
         m_pVisualsManager->addDeck(group);
     }
+    connect(pPlayerManager.get(),
+            &PlayerManager::numberOfDecksChanged,
+            this,
+            [this](int decks) {
+                for (int i = 0; i < decks; ++i) {
+                    QString group = PlayerManager::groupForDeck(i);
+                    m_pVisualsManager->addDeckIfNotExist(group);
+                }
+            });
 
     // Before creating the first skin we need to create a QGLWidget so that all
     // the QGLWidget's we create can use it as a shared QGLContext.
@@ -819,7 +828,7 @@ void MixxxMainWindow::slotFileLoadSongPlayer(int deck) {
         mixxx::FileInfo fileInfo(trackPath);
         Sandbox::createSecurityToken(&fileInfo);
 
-        m_pCoreServices->getPlayerManager()->slotLoadToDeck(trackPath, deck);
+        pPlayerManager->slotLoadToDeck(trackPath, deck);
     }
 }
 

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -140,8 +140,9 @@ void MixxxMainWindow::initialize() {
     // This allows us to turn off tooltips.
     installEventFilter(m_pCoreServices->getKeyboardEventFilter().get());
 
-    DEBUG_ASSERT(m_pCoreServices->getPlayerManager());
-    const QStringList visualGroups = m_pCoreServices->getPlayerManager()->getVisualPlayerGroups();
+    auto pPlayerManager = m_pCoreServices->getPlayerManager();
+    DEBUG_ASSERT(pPlayerManager);
+    const QStringList visualGroups = pPlayerManager->getVisualPlayerGroups();
     for (const QString& group : visualGroups) {
         m_pVisualsManager->addDeck(group);
     }
@@ -195,7 +196,7 @@ void MixxxMainWindow::initialize() {
             m_pCoreServices->getScreensaverManager(),
             m_pSkinLoader,
             m_pCoreServices->getSoundManager(),
-            m_pCoreServices->getPlayerManager(),
+            pPlayerManager,
             m_pCoreServices->getControllerManager(),
             m_pCoreServices->getVinylControlManager(),
             m_pCoreServices->getLV2Backend(),
@@ -292,19 +293,19 @@ void MixxxMainWindow::initialize() {
     // pointer to it.
     m_pLaunchImage = nullptr;
 
-    connect(m_pCoreServices->getPlayerManager().get(),
+    connect(pPlayerManager.get(),
             &PlayerManager::noMicrophoneInputConfigured,
             this,
             &MixxxMainWindow::slotNoMicrophoneInputConfigured);
-    connect(m_pCoreServices->getPlayerManager().get(),
+    connect(pPlayerManager.get(),
             &PlayerManager::noAuxiliaryInputConfigured,
             this,
             &MixxxMainWindow::slotNoAuxiliaryInputConfigured);
-    connect(m_pCoreServices->getPlayerManager().get(),
+    connect(pPlayerManager.get(),
             &PlayerManager::noDeckPassthroughInputConfigured,
             this,
             &MixxxMainWindow::slotNoDeckPassthroughInputConfigured);
-    connect(m_pCoreServices->getPlayerManager().get(),
+    connect(pPlayerManager.get(),
             &PlayerManager::noVinylControlInputConfigured,
             this,
             &MixxxMainWindow::slotNoVinylControlInputConfigured);
@@ -728,13 +729,14 @@ void MixxxMainWindow::connectMenuBar() {
     }
 #endif
 
-    if (m_pCoreServices->getPlayerManager()) {
-        connect(m_pCoreServices->getPlayerManager().get(),
+    auto pPlayerManager = m_pCoreServices->getPlayerManager();
+    if (pPlayerManager) {
+        connect(pPlayerManager.get(),
                 &PlayerManager::numberOfDecksChanged,
                 m_pMenuBar,
                 &WMainMenuBar::onNumberOfDecksChanged,
                 Qt::UniqueConnection);
-        m_pMenuBar->onNumberOfDecksChanged(m_pCoreServices->getPlayerManager()->numberOfDecks());
+        m_pMenuBar->onNumberOfDecksChanged(pPlayerManager->numberOfDecks());
     }
 
     if (m_pCoreServices->getTrackCollectionManager()) {
@@ -779,7 +781,8 @@ void MixxxMainWindow::connectMenuBar() {
 }
 
 void MixxxMainWindow::slotFileLoadSongPlayer(int deck) {
-    QString group = m_pCoreServices->getPlayerManager()->groupForDeck(deck - 1);
+    auto pPlayerManager = m_pCoreServices->getPlayerManager();
+    QString group = pPlayerManager->groupForDeck(deck - 1);
 
     QString loadTrackText = tr("Load track to Deck %1").arg(QString::number(deck));
     QString deckWarningMessage = tr("Deck %1 is currently playing a track.")
@@ -1115,8 +1118,9 @@ void MixxxMainWindow::checkDirectRendering() {
 bool MixxxMainWindow::confirmExit() {
     bool playing(false);
     bool playingSampler(false);
-    unsigned int deckCount = m_pCoreServices->getPlayerManager()->numDecks();
-    unsigned int samplerCount = m_pCoreServices->getPlayerManager()->numSamplers();
+    auto pPlayerManager = m_pCoreServices->getPlayerManager();
+    unsigned int deckCount = pPlayerManager->numDecks();
+    unsigned int samplerCount = pPlayerManager->numSamplers();
     for (unsigned int i = 0; i < deckCount; ++i) {
         if (ControlObject::toBool(
                     ConfigKey(PlayerManager::groupForDeck(i), "play"))) {

--- a/src/waveform/visualsmanager.h
+++ b/src/waveform/visualsmanager.h
@@ -25,6 +25,10 @@ class DeckVisuals {
     DeckVisuals(const QString& group);
     void process(double remainingTimeTriggerSeconds);
 
+    const QString& getGroup() const {
+        return m_group;
+    }
+
   private:
     const QString m_group;
     int m_SlowTickCnt;
@@ -53,6 +57,16 @@ class VisualsManager {
     void addDeck(const QString& group) {
         m_deckVisuals.push_back(
                 std::make_unique<DeckVisuals>(group));
+        qDebug() << "VisualsManager::addDeck()" << group;
+    }
+
+    void addDeckIfNotExist(const QString& group) {
+        for (auto& pDeckVisuals : m_deckVisuals) {
+            if (pDeckVisuals->getGroup() == group) {
+                return;
+            }
+        }
+        addDeck(group);
     }
 
     void process(double remainingTimeTriggerSeconds) {

--- a/src/waveform/visualsmanager.h
+++ b/src/waveform/visualsmanager.h
@@ -55,6 +55,9 @@ class VisualsManager {
     }
 
     void addDeck(const QString& group) {
+        VERIFY_OR_DEBUG_ASSERT(!group.trimmed().isEmpty()) {
+            return;
+        }
         m_deckVisuals.push_back(
                 std::make_unique<DeckVisuals>(group));
     }

--- a/src/waveform/visualsmanager.h
+++ b/src/waveform/visualsmanager.h
@@ -57,7 +57,6 @@ class VisualsManager {
     void addDeck(const QString& group) {
         m_deckVisuals.push_back(
                 std::make_unique<DeckVisuals>(group));
-        qDebug() << "VisualsManager::addDeck()" << group;
     }
 
     void addDeckIfNotExist(const QString& group) {


### PR DESCRIPTION
This fixes debug assertions due to missing deck COs for Channel3/4
https://bugs.launchpad.net/mixxx/+bug/1946812

The issue was that VisualsManager::addDeck() was no longer called when the number ob deck increases.

This is a regression since 
https://github.com/mixxxdj/mixxx/pull/3446 and 
https://github.com/mixxxdj/mixxx/commit/3c9435da26af4b384e259884a1f5390f90a16fd0
discovered when working on https://github.com/mixxxdj/mixxx/pull/2618