### PR TITLE
create [Master], maximize_library in C++

### DIFF
--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -70,6 +70,10 @@ LibraryControl::LibraryControl(Library* pLibrary)
     m_numSamplers.connectValueChanged(this, &LibraryControl::slotNumSamplersChanged);
     m_numPreviewDecks.connectValueChanged(this, &LibraryControl::slotNumPreviewDecksChanged);
 
+    // There is no C++ code interacting with this, but it needs to be created before
+    // controller scripts are initialized.
+    m_pMaximize = std::make_unique<ControlPushButton>(ConfigKey("[Master]", "maximize_library"));
+
     // Controls to navigate vertically within currently focused widget (up/down buttons)
     m_pMoveUp = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveUp"));
     m_pMoveDown = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveDown"));

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -106,6 +106,8 @@ class LibraryControl : public QObject {
     // Give the keyboard focus to the main library pane
     void setLibraryFocus();
 
+    std::unique_ptr<ControlPushButton> m_pMaximize;
+
     // Controls to navigate vertically within currently focused widget (up/down buttons)
     std::unique_ptr<ControlPushButton> m_pMoveUp;
     std::unique_ptr<ControlPushButton> m_pMoveDown;


### PR DESCRIPTION
This prevents a race condition between this ControlObject getting
created by loading a skin and a controller script getting loaded.

Required for #4056