### PR TITLE
Debian package version fix 

### DIFF
--- a/packaging/CPackConfig.cmake
+++ b/packaging/CPackConfig.cmake
@@ -19,7 +19,7 @@ set(CPACK_SOURCE_PACKAGE_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}-source")
 # dpkg --compare-versions 2.3~alpha~1234~g8163 lt 2.3~beta~1234~g8163 && echo true
 # dpkg --compare-versions 2.3~beta~1234~g8163 lt 2.3.0 && echo true
 # dpkg --compare-versions 2.3.0 lt 2.3.0+2345+g163  && echo true
-if (PACKAGE_VERSION MATCHES "^[0-9][A-Za-z0-9.+~-]*$")
+if (PACKAGE_VERSION MATCHES "^[0-9]+\\.[0-9]+[A-Za-z0-9.+~-]*$")
   if (PACKAGE_VERSION MATCHES "(alpha|beta)")
     string(REPLACE "-" "~" CPACK_DEBIAN_PACKAGE_VERSION "${PACKAGE_VERSION}")
   else()

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,15 @@
+mixxx (2.3.1-1~bionic) bionic; urgency=medium
+
+  * Build of 2.3.1
+
+ -- RJ Skerry-Ryan <rryan@mixxx.org>  Wed, 29 Sep 2021 19:08:14 +0000
+
+mixxx (2.3.0-1~bionic) bionic; urgency=medium
+
+  * Build of 2.3.0
+
+ -- RJ Skerry-Ryan <rryan@mixxx.org>  Mon, 28 Jun 2021 20:45:05 +0000
+
 mixxx (2.2.4-0ubuntu3) bionic; urgency=medium
 
   * Bugfix release


### PR DESCRIPTION
This fixes the creation of a debian source package in case git describe has not found a tag and the commit hash starts with a number 0-9. 
This causes the build failure in https://github.com/mixxxdj/mixxx/tree/effects_refactoring
https://github.com/mixxxdj/mixxx/pull/2618

In addition I have also updated the debian package changelog. 

This is not strictly necessary since the entries are auto generated on release, but the history is not kept.  