### PR TITLE
FwdSqlQuery: Hide copy constructor

### DIFF
--- a/src/library/trackset/crate/cratestorage.cpp
+++ b/src/library/trackset/crate/cratestorage.cpp
@@ -52,12 +52,11 @@ const QString kCrateSummaryViewQuery =
                         CRATE_TABLE,
                         CRATETABLE_ID);
 
-class CrateQueryBinder {
+class CrateQueryBinder final {
   public:
     explicit CrateQueryBinder(FwdSqlQuery& query)
             : m_query(query) {
     }
-    virtual ~CrateQueryBinder() = default;
 
     void bindId(const QString& placeholder, const Crate& crate) const {
         m_query.bindValue(placeholder, crate.getId());

--- a/src/util/db/fwdsqlquery.h
+++ b/src/util/db/fwdsqlquery.h
@@ -14,22 +14,26 @@
 class SqlQueryFinisher;
 class FwdSqlQuerySelectResult;
 
-// A forward-only QSqlQuery that is prepared immediately
-// during initialization. It offers a limited set of functions
-// from QSqlQuery.
-//
-// Setting QSqlQuery to forward-only causes memory savings since
-// QSqlCachedResult (what QtSQLite uses) won't allocate a giant
-// in-memory table that we won't use at all when invoking only
-// QSqlQuery::next() to iterate over the results.
-//
-// Prefer to use this derived class instead of QSqlQuery to avoid
-// performance bottlenecks and for implicit logging failed query
-// executions.
-//
-// Please note that forward-only queries don't provide information
-// about the size of the result set!
-class FwdSqlQuery : protected QSqlQuery {
+/// A forward-only QSqlQuery that is prepared immediately
+/// during initialization. It offers a limited set of functions
+/// from QSqlQuery.
+///
+/// Setting QSqlQuery to forward-only causes memory savings since
+/// QSqlCachedResult (what QtSQLite uses) won't allocate a giant
+/// in-memory table that we won't use at all when invoking only
+/// QSqlQuery::next() to iterate over the results.
+///
+/// Prefer to use this derived class instead of QSqlQuery to avoid
+/// performance bottlenecks and for implicit logging failed query
+/// executions.
+///
+/// Please note that forward-only queries don't provide information
+/// about the size of the result set!
+///
+/// Since the destructor of the base class QSqlQuery is non-virtual
+/// FwdSqlQuery must not contain any members with a non-trivial
+/// destructor to prevent memory leaks!
+class FwdSqlQuery final : protected QSqlQuery {
     friend class SqlQueryFinisher;
     friend class FwdSqlQuerySelectResult;
 
@@ -40,6 +44,11 @@ class FwdSqlQuery : protected QSqlQuery {
     FwdSqlQuery(
             const QSqlDatabase& database,
             const QString& statement);
+    // The copy constructor of QSqlQuery is marked as deprecated in Qt6
+    FwdSqlQuery(const FwdSqlQuery&) = delete;
+    FwdSqlQuery(FwdSqlQuery&&) = default;
+
+    FwdSqlQuery& operator=(FwdSqlQuery&&) = default;
 
     bool isPrepared() const {
         return m_prepared;

--- a/src/util/db/fwdsqlqueryselectresult.cpp
+++ b/src/util/db/fwdsqlqueryselectresult.cpp
@@ -1,8 +1,7 @@
 #include "util/db/fwdsqlqueryselectresult.h"
 
-
 FwdSqlQuerySelectResult::FwdSqlQuerySelectResult()
-    : m_queryFinisher(m_query) {
+        : m_queryFinisher(&m_query) {
     DEBUG_ASSERT(!m_query.isActive());
 }
 
@@ -12,11 +11,11 @@ FwdSqlQuerySelectResult::FwdSqlQuerySelectResult()
 // be less efficient than actually moving the object's contents, but
 // meets all requirements.
 FwdSqlQuerySelectResult::FwdSqlQuerySelectResult(FwdSqlQuery&& query)
-    : m_query(std::move(query)),
-      // Pass a reference to the member to m_queryFinisher, because
-      // the contents of the r-value reference parameter might have
-      // been moved!
-      m_queryFinisher(m_query) {
+        : m_query(std::move(query)),
+          // Pass a reference to the member to m_queryFinisher, because
+          // the contents of the r-value reference parameter might have
+          // been moved!
+          m_queryFinisher(&m_query) {
     DEBUG_ASSERT(m_query.isActive());
     DEBUG_ASSERT(m_query.isSelect());
     // Verify that the query has just been executed and that
@@ -37,6 +36,6 @@ FwdSqlQuery FwdSqlQuerySelectResult::release() {
     FwdSqlQuery query(std::move(m_query));
     // Ensure that the wrapped query is inaccessible after moving it!
     m_query = FwdSqlQuery();
-    m_queryFinisher.release();
+    DEBUG_ASSERT(!m_query.isActive());
     return query;
 }

--- a/src/util/db/sqlqueryfinisher.cpp
+++ b/src/util/db/sqlqueryfinisher.cpp
@@ -1,19 +1,10 @@
 #include "util/db/sqlqueryfinisher.h"
 
-#include "util/assert.h"
-
-
-bool SqlQueryFinisher::finish() {
-    if (m_query.isActive()) {
-        m_query.finish();
-        release();
-        return true;
-    } else {
+bool SqlQueryFinisher::tryFinish() {
+    if (!m_pQuery || !m_pQuery->isActive()) {
         return false;
     }
-}
-
-void SqlQueryFinisher::release() {
-    m_query = QSqlQuery();
-    DEBUG_ASSERT(!m_query.isActive());
+    m_pQuery->finish();
+    m_pQuery = nullptr;
+    return true;
 }

--- a/src/util/db/sqlqueryfinisher.h
+++ b/src/util/db/sqlqueryfinisher.h
@@ -2,32 +2,38 @@
 
 #include <QSqlQuery>
 
+#include "util/db/fwdsqlquery.h"
 
-// Ensures that reusable queries are properly finished when
-// leaving the corresponding execution scope. This will free
-// resources of prepared statements until the next execution.
+/// Ensures that reusable queries are properly finished when
+/// leaving the corresponding execution scope. This will free
+/// resources of prepared statements until the next execution.
 class SqlQueryFinisher final {
-public:
-  explicit SqlQueryFinisher(const QSqlQuery& query)
-          : m_query(query) { // implicitly shared (not copied)
-  }
+  public:
+    explicit SqlQueryFinisher(QSqlQuery* pQuery)
+            : m_pQuery(pQuery) {
+    }
+    explicit SqlQueryFinisher(FwdSqlQuery* pQuery)
+            : m_pQuery(pQuery) {
+    }
     SqlQueryFinisher(SqlQueryFinisher&& other)
-        : m_query(std::move(other.m_query)) { // implicitly shared (not moved)
-        other.release();
+            : m_pQuery(other.m_pQuery) {
+        other.m_pQuery = nullptr;
     }
     ~SqlQueryFinisher() {
-        finish();
+        tryFinish();
     }
 
-    bool finish();
+    bool tryFinish();
 
-    void release();
+    void release() {
+        m_pQuery = nullptr;
+    }
 
-private:
+  private:
     // Disable copy construction and copy/move assignment
     SqlQueryFinisher(const SqlQueryFinisher&) = delete;
     SqlQueryFinisher& operator=(const SqlQueryFinisher&) = delete;
     SqlQueryFinisher& operator=(SqlQueryFinisher&&) = delete;
 
-    QSqlQuery m_query; // implicitly shared
+    QSqlQuery* m_pQuery;
 };


### PR DESCRIPTION
Another Qt6 prerequisite.

The design of these classes is brittle. Fortunately they are only used internally.