### PR TITLE
Qt6: Fix qChecksum() deprecation warnings

### DIFF
--- a/src/library/coverart.cpp
+++ b/src/library/coverart.cpp
@@ -37,9 +37,15 @@ QString typeToString(CoverInfo::Type type) {
 
 quint16 calculateLegacyHash(
         const QImage& image) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    auto legacyHash = qChecksum(QByteArrayView(
+            reinterpret_cast<const char*>(image.constBits()),
+            image.sizeInBytes()));
+#else
     auto legacyHash = qChecksum(
             reinterpret_cast<const char*>(image.constBits()),
             image.sizeInBytes());
+#endif
     // In rare cases the calculated checksum could be equal to the
     // reserved value CoverInfo::defaultLegacyHash() which might cause
     // unexpected behavior. In this case we simply invert all bits to

--- a/src/library/dao/analysisdao.cpp
+++ b/src/library/dao/analysisdao.cpp
@@ -84,9 +84,15 @@ QList<AnalysisDao::AnalysisInfo> AnalysisDao::loadAnalysesFromQuery(TrackId trac
         int checksum = query->value(dataChecksumColumn).toInt();
         QString dataPath = analysisPath.absoluteFilePath(
             QString::number(info.analysisId));
-        QByteArray compressedData = loadDataFromFile(dataPath);
-        int file_checksum = qChecksum(compressedData.constData(),
-                                      compressedData.length());
+        const QByteArray compressedData = loadDataFromFile(dataPath);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        const int file_checksum = qChecksum(
+                compressedData);
+#else
+        const int file_checksum = qChecksum(
+                compressedData.constData(),
+                compressedData.length());
+#endif
         if (checksum != file_checksum) {
             qDebug() << "WARNING: Corrupt analysis loaded from" << dataPath
                      << "length" << compressedData.length();
@@ -114,10 +120,15 @@ bool AnalysisDao::saveAnalysis(AnalysisDao::AnalysisInfo* info) {
     PerformanceTimer time;
     time.start();
 
-    QByteArray compressedData = qCompress(info->data, kCompressionLevel);
-    int checksum = qChecksum(compressedData.constData(),
-                             compressedData.length());
-
+    const QByteArray compressedData = qCompress(info->data, kCompressionLevel);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    const int checksum = qChecksum(
+            compressedData);
+#else
+    const int checksum = qChecksum(
+            compressedData.constData(),
+            compressedData.length());
+#endif
     QSqlQuery query(m_database);
     if (info->analysisId == -1) {
         query.prepare(QString(


### PR DESCRIPTION
Not tested locally yet. I assumed that there is an implicit conversion from a (const) QByteArray to QByteArrayView.