### PR TITLE
SqlStringFormatter: use constructor that takes QMetaType parameter

### DIFF
--- a/src/util/db/sqlstringformatter.cpp
+++ b/src/util/db/sqlstringformatter.cpp
@@ -13,7 +13,11 @@ QString SqlStringFormatter::format(
     VERIFY_OR_DEBUG_ASSERT(pDriver != nullptr) {
         return value; // unformatted
     }
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QSqlField stringField(QString(), QMetaType(QMetaType::QString));
+#else
     QSqlField stringField(QString(), QVariant::String);
+#endif
     stringField.setValue(value);
     return pDriver->formatValue(stringField);
 }


### PR DESCRIPTION
https://doc-snapshots.qt.io/qt6-dev/qsqlfield-obsolete.html#QSqlField-2