### PR TITLE
LibraryScanner: static_cast<int> qsizetype values for Qt6

### DIFF
--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -428,11 +428,11 @@ void LibraryScanner::slotFinishUnhashedScan() {
            "%d changed/added directories. "
            "%d tracks verified from changed/added directories. "
            "%d new tracks.",
-           m_scannerGlobal->timerElapsed().formatNanosWithUnit().toLocal8Bit().constData(),
-           m_scannerGlobal->verifiedDirectories().size(),
-           m_scannerGlobal->numScannedDirectories(),
-           m_scannerGlobal->verifiedTracks().size(),
-           m_scannerGlobal->addedTracks().size());
+            m_scannerGlobal->timerElapsed().formatNanosWithUnit().toLocal8Bit().constData(),
+            static_cast<int>(m_scannerGlobal->verifiedDirectories().size()),
+            m_scannerGlobal->numScannedDirectories(),
+            static_cast<int>(m_scannerGlobal->verifiedTracks().size()),
+            static_cast<int>(m_scannerGlobal->addedTracks().size()));
 
     m_scannerGlobal.clear();
     changeScannerState(FINISHED);


### PR DESCRIPTION
```
[356/695] Building CXX object CMakeFiles/mixxx-lib.dir/src/library/scanner/libraryscanner.cpp.o
../src/library/scanner/libraryscanner.cpp: In member function ‘void LibraryScanner::slotFinishUnhashedScan()’:
../src/library/scanner/libraryscanner.cpp:427:14: warning: format ‘%d’ expects argument of type ‘int’, but argument 4 has type ‘qsizetype’ {aka ‘long long int’} [-Wformat=]
  427 |            "%d unchanged directories. "
      |             ~^
      |              |
      |              int
      |             %lld
......
  432 |            m_scannerGlobal->verifiedDirectories().size(),
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                       |
      |                                                       qsizetype {aka long long int}
../src/library/scanner/libraryscanner.cpp:429:14: warning: format ‘%d’ expects argument of type ‘int’, but argument 6 has type ‘qsizetype’ {aka ‘long long int’} [-Wformat=]
  429 |            "%d tracks verified from changed/added directories. "
      |             ~^
      |              |
      |              int
      |             %lld
......
  434 |            m_scannerGlobal->verifiedTracks().size(),
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                  |
      |                                                  qsizetype {aka long long int}
../src/library/scanner/libraryscanner.cpp:430:14: warning: format ‘%d’ expects argument of type ‘int’, but argument 7 has type ‘qsizetype’ {aka ‘long long int’} [-Wformat=]
  430 |            "%d new tracks.",
      |             ~^
      |              |
      |              int
      |             %lld
......
  435 |            m_scannerGlobal->addedTracks().size());
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                               |
      |                                               qsizetype {aka long long int}
```