### PR TITLE
QmlWaveformOverview: fix float conversion warning with Qt6

### DIFF
--- a/src/qml/qmlwaveformoverview.cpp
+++ b/src/qml/qmlwaveformoverview.cpp
@@ -255,7 +255,10 @@ QColor QmlWaveformOverview::getRgbPenColor(ConstWaveformPointer pWaveform, int c
     qreal max = math_max3(red, green, blue);
     if (max > 0.0) {
         QColor color;
-        color.setRgbF(red / max, green / max, blue / max);
+        color.setRgbF(
+                static_cast<float>(red / max),
+                static_cast<float>(green / max),
+                static_cast<float>(blue / max));
         return color;
     }
     return QColor();


### PR DESCRIPTION
```
[184/695] Building CXX object CMakeFiles/mixxx-lib.dir/src/qml/qmlwaveformoverview.cpp.o
../src/qml/qmlwaveformoverview.cpp: In member function ‘QColor mixxx::qml::QmlWaveformOverview::getRgbPenColor(ConstWaveformPointer, int) const’:
../src/qml/qmlwaveformoverview.cpp:258:27: warning: conversion from ‘qreal’ {aka ‘double’} to ‘float’ may change value [-Wfloat-conversion]
  258 |         color.setRgbF(red / max, green / max, blue / max);
      |                       ~~~~^~~~~
../src/qml/qmlwaveformoverview.cpp:258:40: warning: conversion from ‘qreal’ {aka ‘double’} to ‘float’ may change value [-Wfloat-conversion]
  258 |         color.setRgbF(red / max, green / max, blue / max);
      |                                  ~~~~~~^~~~~
../src/qml/qmlwaveformoverview.cpp:258:52: warning: conversion from ‘qreal’ {aka ‘double’} to ‘float’ may change value [-Wfloat-conversion]
  258 |         color.setRgbF(red / max, green / max, blue / max);
      |                                               ~~~~~^~~~~
```