### PR TITLE
DlgCoverArtFullSize: fix QMouseEvent deprecation warnings with Qt6

### DIFF
--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -223,7 +223,12 @@ void DlgCoverArtFullSize::mousePressEvent(QMouseEvent* event) {
         m_clickTimer.setSingleShot(true);
         m_clickTimer.start(500);
         m_coverPressed = true;
-        m_dragStartPosition = event->globalPos() - frameGeometry().topLeft();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        QPoint eventPosition = event->globalPosition().toPoint();
+#else
+        QPoint eventPosition = event->globalPos();
+#endif
+        m_dragStartPosition = eventPosition - frameGeometry().topLeft();
     }
 }
 
@@ -247,7 +252,12 @@ void DlgCoverArtFullSize::mouseReleaseEvent(QMouseEvent* event) {
 
 void DlgCoverArtFullSize::mouseMoveEvent(QMouseEvent* event) {
     if (m_coverPressed) {
-        move(event->globalPos() - m_dragStartPosition);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        QPoint eventPosition = event->globalPosition().toPoint();
+#else
+        QPoint eventPosition = event->globalPos();
+#endif
+        move(eventPosition - m_dragStartPosition);
         event->accept();
     } else {
         return;


### PR DESCRIPTION
https://doc.qt.io/qt-6/qmouseevent-obsolete.html#globalPos
https://www.qt.io/blog/input-events-in-qt-6