### PR TITLE
BaseTrackTableModel: fix float conversion warning

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -420,7 +420,7 @@ QVariant BaseTrackTableModel::data(
         DEBUG_ASSERT(bgColor.isValid());
         DEBUG_ASSERT(m_backgroundColorOpacity >= 0.0);
         DEBUG_ASSERT(m_backgroundColorOpacity <= 1.0);
-        bgColor.setAlphaF(m_backgroundColorOpacity);
+        bgColor.setAlphaF(static_cast<float>(m_backgroundColorOpacity));
         return QBrush(bgColor);
     }
 


### PR DESCRIPTION
```
[311/695] Building CXX object
CMakeFiles/mixxx-lib.dir/src/library/basetracktablemodel.cpp.o
../src/library/basetracktablemodel.cpp: In member function ‘virtual
QVariant BaseTrackTableModel::data(const QModelIndex&, int) const’:
../src/library/basetracktablemodel.cpp:423:27: warning: conversion from
‘double’ to ‘float’ may change value [-Wfloat-conversion]
  423 |         bgColor.setAlphaF(m_backgroundColorOpacity);
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~
```