### PR TITLE
BaseTrackTableModel: fix Qt6 QVariant deprecation warning

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -646,7 +646,11 @@ QVariant BaseTrackTableModel::roleValue(
         }
         case ColumnCache::COLUMN_LIBRARYTABLE_LAST_PLAYED_AT: {
             QDateTime lastPlayedAt;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            if (rawValue.metaType().id() == QMetaType::QString) {
+#else
             if (rawValue.type() == QVariant::String) {
+#endif
                 // column value
                 lastPlayedAt = mixxx::sqlite::readGeneratedTimestamp(rawValue);
             } else {


### PR DESCRIPTION
```
../src/library/basetracktablemodel.cpp: In member function ‘QVariant BaseTrackTableModel::roleValue(const QModelIndex&, QVariant&&, int) const’:
../src/library/basetracktablemodel.cpp:649:30: warning: ‘QVariant::Type QVariant::type() const’ is deprecated: Use typeId() or metaType(). [-Wdeprecated-declarations]
  649 |             if (rawValue.type() == QVariant::String) {
      |                 ~~~~~~~~~~~~~^~
In file included from /usr/include/qt6/QtCore/qabstractitemmodel.h:47,
                 from /usr/include/qt6/QtCore/QAbstractTableModel:1,
                 from ../src/library/basetracktablemodel.h:3,
                 from ../src/library/basetracktablemodel.cpp:1:
/usr/include/qt6/QtCore/qvariant.h:337:10: note: declared here
  337 |     Type type() const
      |          ^~~~
```