### PR TITLE
Search: update Clear button when search is disabled

### DIFF
--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -266,6 +266,7 @@ void WSearchLineEdit::slotDisableSearch() {
         return;
     }
     setTextBlockSignals(kDisabledText);
+    updateClearButton(QString());
     setEnabled(false);
 }
 
@@ -341,7 +342,6 @@ void WSearchLineEdit::updateClearButton(const QString& text) {
             << "updateClearButton"
             << text;
 #endif // ENABLE_TRACE_LOG
-    DEBUG_ASSERT(isEnabled());
 
     if (text.isEmpty()) {
         // Disable while placeholder is shown


### PR DESCRIPTION
minor issue I noticed while styling search history in `main`:
when switching from a feature with search enabled to let's say AutoDJ, the Clear button would remain even though it's pointless.