### PR TITLE
Qt6 Covert art guessing: Pass future to the caller

### DIFF
--- a/src/library/coverartutils.cpp
+++ b/src/library/coverartutils.cpp
@@ -216,18 +216,19 @@ void CoverInfoGuesser::guessAndSetCoverInfoForTracks(
     }
 }
 
-void guessTrackCoverInfoConcurrently(
+QFuture<void> guessTrackCoverInfoConcurrently(
         TrackPointer pTrack) {
     VERIFY_OR_DEBUG_ASSERT(pTrack) {
-        return;
+        return {};
     }
     if (s_enableConcurrentGuessingOfTrackCoverInfo) {
-        QtConcurrent::run([pTrack] {
+        return QtConcurrent::run([pTrack] {
             CoverInfoGuesser().guessAndSetCoverInfoForTrack(*pTrack);
         });
     } else {
         // Disabled only during tests
         CoverInfoGuesser().guessAndSetCoverInfoForTrack(*pTrack);
+        return {};
     }
 }
 

--- a/src/library/coverartutils.h
+++ b/src/library/coverartutils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QFuture>
 #include <QImage>
 #include <QList>
 #include <QSize>
@@ -93,7 +94,7 @@ class CoverInfoGuesser {
 // Guesses the cover art for the provided tracks by searching the tracks'
 // metadata and folders for image files. All I/O is done in a separate
 // thread.
-void guessTrackCoverInfoConcurrently(TrackPointer pTrack);
+[[nodiscard]] QFuture<void> guessTrackCoverInfoConcurrently(TrackPointer pTrack);
 
 // Concurrent guessing of track covers during short running
 // tests may cause spurious test failures due to timing issues.

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -2181,7 +2181,9 @@ TrackPointer TrackDAO::getOrAddTrack(
 
     // If the track wasn't in the library already then it has not yet
     // been checked for cover art.
-    guessTrackCoverInfoConcurrently(pTrack);
+    const auto future = guessTrackCoverInfoConcurrently(pTrack);
+    // Don't wait for the result and keep running in the background
+    Q_UNUSED(future)
 
     return pTrack;
 }

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -99,7 +99,9 @@ void WCoverArt::slotReloadCoverArt() {
     if (!m_loadedTrack) {
         return;
     }
-    guessTrackCoverInfoConcurrently(m_loadedTrack);
+    const auto future = guessTrackCoverInfoConcurrently(m_loadedTrack);
+    // Don't wait for the result and keep running in the background
+    Q_UNUSED(future)
 }
 
 void WCoverArt::slotCoverInfoSelected(const CoverInfoRelative& coverInfo) {

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -304,7 +304,9 @@ void WSpinny::slotReloadCoverArt() {
     if (!m_loadedTrack) {
         return;
     }
-    guessTrackCoverInfoConcurrently(m_loadedTrack);
+    const auto future = guessTrackCoverInfoConcurrently(m_loadedTrack);
+    // Don't wait for the result and keep running in the background
+    Q_UNUSED(future)
 }
 
 void WSpinny::paintEvent(QPaintEvent *e) {


### PR DESCRIPTION
I decided to adopt the [[nodiscard]] attribute and pass it to the caller where the result is finally discarded explicitly.

Uncontrolled starting of background tasks should be avoided for new code. This is a code smell and only works because Mixxx uses shared, mutable data for `Track` objects.