### PR TITLE
Qt6: Add a static cast to math_max 

### DIFF
--- a/src/effects/effectbuttonparameterslot.cpp
+++ b/src/effects/effectbuttonparameterslot.cpp
@@ -54,7 +54,10 @@ void EffectButtonParameterSlot::loadEffect(EffectPointer pEffect) {
 
         if (m_pEffectParameter) {
             // Set the number of states
-            int numStates = math_max(m_pEffectParameter->manifest()->getSteps().size(), 2);
+            int numStates = math_max(
+                    static_cast<int>(
+                            m_pEffectParameter->manifest()->getSteps().size()),
+                    2);
             m_pControlValue->setStates(numStates);
             //qDebug() << debugString() << "Loading effect parameter" << m_pEffectParameter->name();
             double dValue = m_pEffectParameter->getValue();


### PR DESCRIPTION
to make it work with the changed size type in Qt6