### PR TITLE
Search: save queries across restarts, related tweaks & fixes

### DIFF
--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -288,6 +288,19 @@ LibraryControl::LibraryControl(Library* pLibrary)
                     m_pSearchbox->slotClearSearch();
                 }
             });
+    m_pDeleteSearchQuery = std::make_unique<ControlPushButton>(
+            ConfigKey("[Library]", "delete_search_query"));
+    connect(m_pDeleteSearchQuery.get(),
+            &ControlPushButton::valueChanged,
+            this,
+            [this](double value) {
+                VERIFY_OR_DEBUG_ASSERT(m_pSearchbox) {
+                    return;
+                }
+                if (value > 0.0) {
+                    m_pSearchbox->slotDeleteCurrentItem();
+                }
+            });
 
     /// Deprecated controls
     m_pSelectNextTrack = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "SelectNextTrack"));

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -150,6 +150,7 @@ class LibraryControl : public QObject {
     std::unique_ptr<ControlPushButton> m_pSelectHistoryPrev;
     std::unique_ptr<ControlEncoder> m_pSelectHistorySelect;
     std::unique_ptr<ControlPushButton> m_pClearSearch;
+    std::unique_ptr<ControlPushButton> m_pDeleteSearchQuery;
 
     // Font sizes
     std::unique_ptr<ControlPushButton> m_pFontSizeIncrement;

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -1299,7 +1299,7 @@ QWidget* LegacySkinParser::parseSearchBox(const QDomElement& node) {
                     WSearchLineEdit::kDefaultDebouncingTimeoutMillis);
     WSearchLineEdit::setDebouncingTimeoutMillis(searchDebouncingTimeoutMillis);
 
-    WSearchLineEdit* pLineEditSearch = new WSearchLineEdit(m_pParent);
+    WSearchLineEdit* pLineEditSearch = new WSearchLineEdit(m_pParent, m_pConfig);
     commonWidgetSetup(node, pLineEditSearch, false);
     pLineEditSearch->setup(node, *m_pContext);
 

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -442,6 +442,9 @@ void WSearchLineEdit::slotSaveSearch() {
 }
 
 void WSearchLineEdit::slotMoveSelectedHistory(int steps) {
+    if (!isEnabled()) {
+        return;
+    }
     int nIndex = currentIndex() + steps;
     // at the top we manually wrap around to the last entry.
     // at the bottom wrap-around happens automatically due to invalid nIndex.
@@ -567,7 +570,9 @@ void WSearchLineEdit::slotClearSearch() {
     kLogger.trace()
             << "slotClearSearch";
 #endif // ENABLE_TRACE_LOG
-    DEBUG_ASSERT(isEnabled());
+    if (!isEnabled()) {
+        return;
+    }
     // select the last entry as current before cleaning the text field
     // so arrow keys will work as expected
     setCurrentIndex(-1);

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -391,6 +391,7 @@ void WSearchLineEdit::focusOutEvent(QFocusEvent* event) {
     kLogger.trace()
             << "focusOutEvent";
 #endif // ENABLE_TRACE_LOG
+    slotSaveSearch();
     QComboBox::focusOutEvent(event);
     emit searchbarFocusChange(FocusWidget::None);
     if (m_debouncingTimer.isActive()) {

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -219,7 +219,8 @@ void WSearchLineEdit::setup(const QDomNode& node, const SkinContext& context) {
             tr("Use operators like bpm:115-128, artist:BooFar, -year:1990") +
             "\n" + tr("For more information see User Manual > Mixxx Library") +
             "\n\n" +
-            tr("Shortcut") + ": \n" + tr("Ctrl+F") + "  " +
+            tr("Shortcuts") + ": \n" +
+            tr("Ctrl+F") + "  " +
             tr("Focus", "Give search bar input focus") + "\n" +
             tr("Ctrl+Backspace") + "  " +
             tr("Clear input", "Clear the search bar input field") + "\n" +
@@ -227,6 +228,7 @@ void WSearchLineEdit::setup(const QDomNode& node, const SkinContext& context) {
             tr("Toggle search history",
                     "Shows/hides the search history entries") +
             "\n" +
+            tr("Delete or Backspace") + "  " + tr("Delete query from history") + "\n" +
             tr("Esc") + "  " + tr("Exit search", "Exit search bar and leave focus"));
 }
 
@@ -297,6 +299,18 @@ bool WSearchLineEdit::eventFilter(QObject* obj, QEvent* event) {
                 if (findCurrentTextIndex() == -1) {
                     slotSaveSearch();
                 }
+            }
+        } else {
+            if (keyEvent->key() == Qt::Key_Backspace ||
+                    keyEvent->key() == Qt::Key_Delete) {
+                // remove the highlighted item from the list
+                QComboBox::removeItem(view()->currentIndex().row());
+                // ToDo Resize the list to new item size
+                // Close the popup if all items were removed
+                if (count() == 0) {
+                    hidePopup();
+                }
+                return true;
             }
         }
         if (keyEvent->key() == Qt::Key_Enter) {

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -464,6 +464,14 @@ void WSearchLineEdit::showPopup() {
         setCurrentIndex(cIndex);
     }
     QComboBox::showPopup();
+    // When (empty) index -1 is selected in the combobox and the list view is opened
+    // index 0 is auto-set but not highlighted.
+    // Select first index manually (only in the list).
+    if (cIndex == -1) {
+        view()->selectionModel()->select(
+                view()->currentIndex(),
+                QItemSelectionModel::Select);
+    }
 }
 
 void WSearchLineEdit::updateEditBox(const QString& text) {

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -304,12 +304,7 @@ bool WSearchLineEdit::eventFilter(QObject* obj, QEvent* event) {
             if (keyEvent->key() == Qt::Key_Backspace ||
                     keyEvent->key() == Qt::Key_Delete) {
                 // remove the highlighted item from the list
-                QComboBox::removeItem(view()->currentIndex().row());
-                // ToDo Resize the list to new item size
-                // Close the popup if all items were removed
-                if (count() == 0) {
-                    hidePopup();
-                }
+                deleteSelectedListItem();
                 return true;
             }
         }
@@ -455,6 +450,36 @@ void WSearchLineEdit::slotMoveSelectedHistory(int steps) {
     }
     setCurrentIndex(nIndex);
     m_saveTimer.stop();
+}
+
+void WSearchLineEdit::slotDeleteCurrentItem() {
+    if (!isEnabled()) {
+        return;
+    }
+    if (view()->isVisible()) {
+        deleteSelectedListItem();
+    } else {
+        deleteSelectedComboboxItem();
+    }
+}
+
+void WSearchLineEdit::deleteSelectedComboboxItem() {
+    int cIndex = currentIndex();
+    if (cIndex == -1) {
+        return;
+    } else {
+        slotClearSearch();
+        QComboBox::removeItem(cIndex);
+    }
+}
+
+void WSearchLineEdit::deleteSelectedListItem() {
+    QComboBox::removeItem(view()->currentIndex().row());
+    // ToDo Resize the list to new item size
+    // Close the popup if all items were removed
+    if (count() == 0) {
+        hidePopup();
+    }
 }
 
 void WSearchLineEdit::refreshState() {

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -464,23 +464,32 @@ void WSearchLineEdit::slotTriggerSearch() {
 
 /// saves the current query as selection
 void WSearchLineEdit::slotSaveSearch() {
-    int cIndex = findCurrentTextIndex();
 #if ENABLE_TRACE_LOG
     kLogger.trace()
             << "save search. Index: "
             << cIndex;
 #endif // ENABLE_TRACE_LOG
     m_saveTimer.stop();
-    // entry already exists and is on top
-    if (cIndex == 0) {
+    if (currentText().isEmpty() || !isEnabled()) {
         return;
     }
-    if (!currentText().isEmpty() && isEnabled()) {
-        // we remove the existing item and add a new one at the top
-        if (cIndex != -1) {
-            removeItem(cIndex);
-        }
-        insertItem(0, currentText());
+    QString cText = currentText();
+    if (currentIndex() == -1) {
+        removeItem(-1);
+    }
+    // Check if the text is already listed
+    QSet<QString> querySet;
+    for (int index = 0; index < count(); index++) {
+        querySet.insert(itemText(index));
+    }
+    if (querySet.contains(cText)) {
+        // If query exists clear the box and use its index to set the currentIndex
+        int cIndex = findCurrentTextIndex();
+        setCurrentIndex(cIndex);
+        return;
+    } else {
+        // Else add it at the top
+        insertItem(0, cText);
         setCurrentIndex(0);
         while (count() > kMaxSearchEntries) {
             removeItem(kMaxSearchEntries);

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -534,9 +534,16 @@ void WSearchLineEdit::deleteSelectedComboboxItem() {
 }
 
 void WSearchLineEdit::deleteSelectedListItem() {
+    bool wasEmpty = currentIndex() == -1 ? true : false;
     QComboBox::removeItem(view()->currentIndex().row());
     // ToDo Resize the list to new item size
     // Close the popup if all items were removed
+
+    // When an item is removed the combobox would pick a sibling and trigger a
+    // search. Avoid this if the box was empty when the popup was opened.
+    if (wasEmpty) {
+        QComboBox::setCurrentIndex(-1);
+    }
     if (count() == 0) {
         hidePopup();
     }

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -55,6 +55,7 @@ class WSearchLineEdit : public QComboBox, public WBaseWidget {
     /// entry in the history and executes the search.
     /// The parameter specifies the distance in steps (positive/negative = downward/upward)
     void slotMoveSelectedHistory(int steps);
+    void slotDeleteCurrentItem();
 
   private slots:
     void slotSetShortcutFocus();
@@ -78,6 +79,8 @@ class WSearchLineEdit : public QComboBox, public WBaseWidget {
     void updateEditBox(const QString& text);
     void updateClearButton(const QString& text);
     void updateStyleMetrics();
+    void deleteSelectedComboboxItem();
+    void deleteSelectedListItem();
 
     inline int findCurrentTextIndex() {
         return findData(currentText(), Qt::DisplayRole);

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -7,6 +7,7 @@
 #include <QToolButton>
 
 #include "library/library_decl.h"
+#include "preferences/usersettings.h"
 #include "util/parented_ptr.h"
 #include "widget/wbasewidget.h"
 
@@ -26,8 +27,8 @@ class WSearchLineEdit : public QComboBox, public WBaseWidget {
     static void setDebouncingTimeoutMillis(int debouncingTimeoutMillis);
     virtual void showPopup() override;
 
-    explicit WSearchLineEdit(QWidget* pParent);
-    ~WSearchLineEdit() override = default;
+    explicit WSearchLineEdit(QWidget* pParent, UserSettingsPointer pConfig = nullptr);
+    ~WSearchLineEdit();
 
     void setup(const QDomNode& node, const SkinContext& context);
 
@@ -90,6 +91,10 @@ class WSearchLineEdit : public QComboBox, public WBaseWidget {
 
     // Update the displayed text without (re-)starting the timer
     void setTextBlockSignals(const QString& text);
+
+    UserSettingsPointer m_pConfig;
+    void loadQueriesFromConfig();
+    void saveQueriesInConfig();
 
     parented_ptr<QToolButton> const m_clearButton;
 


### PR DESCRIPTION
**Store queries to mixxx.cfg** when WSearchLineEdit is destroyed (shutdown or skin change), load when it's created.
(only for the library searchbar, not the control searchbar in the developer tools dialog)
Currently only the selected query is stored on skin change, others are lost.

**`Delete` and `Backspace` in the popup delete the selected item**
This allows cleaning up the history, which I consider a rare maintenance job thus I did not add a delete shortcut for the _combobox view_.
I also added a control `[Library], delete_search_query` to delete the current item from the popup or the combobox view.

**tweaks & fixes**:
* The search queries popup holds indices 0..n, while the combobox also has index -1 (empty, "Search...").
When index -1 is selected in the combobox and the list view is opened index 0 is auto-set but not highlighted.
Select first index manually (only in the list).
* Avoid storing duplicate items when switching between library features.
* Some searchbar COs could be triggered (accidentally) while the searchbar is disabled (AutoDJ, Rec, ...). Debug asserts were used which I replaced with regular tests in order to avoid unexpected behaviour in releases.

https://bugs.launchpad.net/mixxx/+bug/1943084
https://bugs.launchpad.net/mixxx/+bug/1947479