### PR TITLE
This descibes possible causes for a rare crasher with effects. 

### DIFF
--- a/src/effects/backends/effectprocessor.h
+++ b/src/effects/backends/effectprocessor.h
@@ -273,6 +273,11 @@ class EffectProcessorImpl : public EffectProcessor {
         // m_channelStateMatrix may be accessed concurrently in the audio
         // engine thread in loadStatesForInputChannel.
 
+        // TODO: How is ensure that the statMap is not accessed during this loop?
+        // This is called in responds to DISABLE_EFFECT_CHAIN_FOR_INPUT_CHANNEL
+        // and it looks like that the objects pointed by m_channelStateMatrix
+        // may be still in use.
+        // Probably related: https://bugs.launchpad.net/mixxx/+bug/1775497
         ChannelHandleMap<EffectSpecificState*>& stateMap =
                 m_channelStateMatrix[*inputChannel];
         for (EffectSpecificState* pState : stateMap) {

--- a/src/effects/backends/effectprocessor.h
+++ b/src/effects/backends/effectprocessor.h
@@ -157,6 +157,11 @@ class EffectProcessorImpl : public EffectProcessor {
             const EffectEnableState enableState,
             const GroupFeatureState& groupFeatures) final {
         EffectSpecificState* pState = m_channelStateMatrix[inputHandle][outputHandle];
+        // TODO: The state can be null if we are in the deleteStatesForInputChannel() loop.
+        // A protection against this is missing. Since it can happen the assertion is incorrect
+        // The memory will be leaked.
+        // Idea: Skip the processing here?
+        // Probably related: https://bugs.launchpad.net/mixxx/+bug/1775497
         VERIFY_OR_DEBUG_ASSERT(pState != nullptr) {
             if (kEffectDebugOutput) {
                 qWarning() << "EffectProcessorImpl::process could not retrieve"


### PR DESCRIPTION
I have experienced a crasher during testing of https://github.com/mixxxdj/mixxx/pull/2618

Probably related: 
https://bugs.launchpad.net/mixxx/+bug/1775497

Here is the log, unfortunately it has not happen to me under GDB. 

```
QML debugging is enabled. Only use this in a safe environment.
Loading resources from  "/home/daniel/workspace/2.3/res/"
Configuration file is at version "2.3.0-beta" instead of the current "2.4.0-alpha-pre"
BroadcastSettings - Found 1 profile(s)
Loading resources from  "/home/daniel/workspace/2.3/res/"
Found and will use default keyboard mapping "/home/daniel/workspace/2.3/res/keyboard/en_US.kbd.cfg"
Loading resources from  "/home/daniel/workspace/2.3/res/"
Loaded skin "Shade"
DBus screensaver  org.freedesktop.ScreenSaver  inhibited
ALSA lib pcm.c:2642:(snd_pcm_open_noupdate) Unknown PCM cards.pcm.rear
ALSA lib pcm.c:2642:(snd_pcm_open_noupdate) Unknown PCM cards.pcm.center_lfe
ALSA lib pcm.c:2642:(snd_pcm_open_noupdate) Unknown PCM cards.pcm.side
ALSA lib pcm_route.c:869:(find_matching_chmap) Found no matching channel map
ALSA lib pcm_route.c:869:(find_matching_chmap) Found no matching channel map
ALSA lib pcm_route.c:869:(find_matching_chmap) Found no matching channel map
ALSA lib pcm_route.c:869:(find_matching_chmap) Found no matching channel map
Cannot connect to server socket err = Datei oder Verzeichnis nicht gefunden
Cannot connect to server request channel
jack server is not running or cannot be started
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for -1, skipping unlock
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for -1, skipping unlock
Cannot connect to server socket err = Datei oder Verzeichnis nicht gefunden
Cannot connect to server request channel
jack server is not running or cannot be started
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for -1, skipping unlock
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for -1, skipping unlock
ALSA lib pcm_oss.c:377:(_snd_pcm_oss_open) Unknown field port
ALSA lib pcm_oss.c:377:(_snd_pcm_oss_open) Unknown field port
ALSA lib pcm_usb_stream.c:486:(_snd_pcm_usb_stream_open) Invalid type for card
ALSA lib pcm_usb_stream.c:486:(_snd_pcm_usb_stream_open) Invalid type for card
Cannot connect to server socket err = Datei oder Verzeichnis nicht gefunden
Cannot connect to server request channel
jack server is not running or cannot be started
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for -1, skipping unlock
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for -1, skipping unlock
warning [Main] Library - Skipping access check for missing or invalid directory QFileInfo(/home/daniel/Öffen)
warning [BrowseThread] MetadataSourceTagLib - Cannot import track metadata from file "/home/daniel/Musik/Mixxx/Recordings/2021-03-16_15h27m08s.aac" with unknown or unsupported type 0
warning [BrowseThread] MetadataSourceTagLib - Cannot import track metadata from file "/home/daniel/Musik/Mixxx/Recordings/2021-03-16_15h26m32s.aac" with unknown or unsupported type 0
warning [BrowseThread] MetadataSourceTagLib - Cannot import track metadata from file "/home/daniel/Musik/Mixxx/Recordings/2021-03-16_15h26m02s.aac" with unknown or unsupported type 0
warning [Main] ControlDoublePrivate::getControl returning NULL for ( "[Master]" , "skin_settings" )
Abgebrochen (Speicherabzug geschrieben)
```