### PR TITLE
add supported file types for Engine DJ

### DIFF
--- a/src/library/export/engineprimeexportjob.cpp
+++ b/src/library/export/engineprimeexportjob.cpp
@@ -30,9 +30,9 @@ constexpr int kMaxHotCues = 8;
 
 constexpr uint8_t kDefaultWaveformOpacity = 127;
 
-const QStringList kSupportedFileTypes = {"aac",
+const QStringList kSupportedFileTypes = {
+        "aac",
         "m4a",
-        "aif",
         "aiff",
         "alac",
         "flac",

--- a/src/library/export/engineprimeexportjob.cpp
+++ b/src/library/export/engineprimeexportjob.cpp
@@ -30,7 +30,16 @@ constexpr int kMaxHotCues = 8;
 
 constexpr uint8_t kDefaultWaveformOpacity = 127;
 
-const QStringList kSupportedFileTypes = {"mp3", "flac", "ogg"};
+const QStringList kSupportedFileTypes = {"aac",
+        "m4a",
+        "aif",
+        "aiff",
+        "alac",
+        "flac",
+        "mp3",
+        "mp4",
+        "ogg",
+        "wav"};
 
 std::optional<djinterop::musical_key> toDjinteropKey(
         track::io::key::ChromaticKey key) {


### PR DESCRIPTION
Just added all file types supported by Engine Prime / Engine DJ.
Formatting was done by the clang-format hook.