### PR TITLE
effects prefs: use '---' instead of 'None' to spot empty slots easier

### DIFF
--- a/src/preferences/dialog/dlgprefeffects.cpp
+++ b/src/preferences/dialog/dlgprefeffects.cpp
@@ -201,10 +201,10 @@ void DlgPrefEffects::slotChainPresetSelected(const QModelIndex& selected) {
                 // Code uses 0-indexed numbers; users see 1 indexed numbers
                 m_effectsLabels[i]->setText(QString::number(i + 1) + ": " + displayName);
             } else {
-                m_effectsLabels[i]->setText(QString::number(i + 1) + ": " + tr("None"));
+                m_effectsLabels[i]->setText(QString::number(i + 1) + ": " + "---");
             }
         } else {
-            m_effectsLabels[i]->setText(QString::number(i + 1) + ": " + tr("None"));
+            m_effectsLabels[i]->setText(QString::number(i + 1) + ": " + "---");
         }
     }
 


### PR DESCRIPTION
see #3485

before
![image](https://user-images.githubusercontent.com/5934199/138438649-5f830fd8-e856-49f4-9ff9-5100634ff4da.png)



now
![image](https://user-images.githubusercontent.com/5934199/138438784-b55eee3a-abae-426b-afc0-19bd6da26051.png)

