### PR TITLE
TrackDAO: Load a single track by URL

### DIFF
--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -97,6 +97,15 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     /// access as a friend.
     static bool getTrackHeaderParsedInternal(const mixxx::TrackRecord& trackRecord);
 
+    /// Lookup and load a track by URL.
+    ///
+    /// Only local file URLs are supported.
+    ///
+    /// Returns `nullptr` if no track matches the given URL.
+    TrackPointer getTrackByUrl(const QUrl& url) const {
+        return getTrackByRef(TrackRef::fromUrl(url));
+    }
+
   signals:
     // Forwarded from Track object
     void trackDirty(TrackId trackId);

--- a/src/track/trackref.h
+++ b/src/track/trackref.h
@@ -40,6 +40,14 @@ class TrackRef final {
                 std::move(id));
     }
 
+    /// Convert a local file URL into a TrackRef.
+    static TrackRef fromUrl(
+            const QUrl& url,
+            TrackId id = TrackId()) {
+        const auto fileInfo = mixxx::FileInfo::fromQUrl(url);
+        return TrackRef::fromFileInfo(fileInfo, id);
+    }
+
     // Default constructor
     TrackRef() {
         DEBUG_ASSERT(verifyConsistency());


### PR DESCRIPTION
Needed for the migration from `TrackId` (internal database identifier) to a more versatile addressing scheme for referencing tracks.

First step to decouple the persistence layer in *some* backend, either built-in or external, from the frontend.

https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/QML.20library.20GUI/near/258830882