### PR TITLE
Disconnect controller qt connections

### DIFF
--- a/src/controllers/controllermanager.cpp
+++ b/src/controllers/controllermanager.cpp
@@ -178,6 +178,9 @@ void ControllerManager::slotShutdown() {
 }
 
 void ControllerManager::updateControllerList() {
+    // NOTE: Currently this function is only called on startup. If hotplug is added, changes to the
+    // controller list must be synchronized with dlgprefcontrollers to avoid dangling connections
+    // and possible crashes.
     auto locker = lockMutex(&m_mutex);
     if (m_enumerators.isEmpty()) {
         qWarning() << "updateControllerList called but no enumerators have been added!";

--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -130,9 +130,10 @@ void DlgPrefControllers::rescanControllers() {
 }
 
 void DlgPrefControllers::destroyControllerWidgets() {
-    for (auto* pController : m_pControllerManager->getControllerList(false, true)) {
-        pController->disconnect(SIGNAL(&Controller::openChanged));
+    for (auto conn : m_controllerConnections) {
+        disconnect(conn);
     }
+    m_controllerConnections.clear();
     while (!m_controllerPages.isEmpty()) {
         DlgPrefController* pControllerDlg = m_controllerPages.takeLast();
         m_pDlgPreferences->removePageWidget(pControllerDlg);
@@ -174,11 +175,11 @@ void DlgPrefControllers::setupControllerWidgets() {
 
         m_controllerPages.append(pControllerDlg);
 
-        connect(pController,
+        m_controllerConnections.append(connect(pController,
                 &Controller::openChanged,
                 [this, pControllerDlg](bool bOpen) {
                     slotHighlightDevice(pControllerDlg, bOpen);
-                });
+                }));
 
         QTreeWidgetItem* pControllerTreeItem = new QTreeWidgetItem(
                 QTreeWidgetItem::Type);

--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -130,6 +130,9 @@ void DlgPrefControllers::rescanControllers() {
 }
 
 void DlgPrefControllers::destroyControllerWidgets() {
+    for (auto* pController : m_pControllerManager->getControllerList(false, true)) {
+        pController->disconnect();
+    }
     while (!m_controllerPages.isEmpty()) {
         DlgPrefController* pControllerDlg = m_controllerPages.takeLast();
         m_pDlgPreferences->removePageWidget(pControllerDlg);

--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -130,10 +130,14 @@ void DlgPrefControllers::rescanControllers() {
 }
 
 void DlgPrefControllers::destroyControllerWidgets() {
-    for (auto conn : m_controllerConnections) {
-        disconnect(conn);
+    // NOTE: this assumes that the list of controllers does not change during the lifetime of Mixxx.
+    // This is currently true, but once we support hotplug, we will need better lifecycle management
+    // to keep this dialog and the controllermanager consistent.
+    QList<Controller*> controllerList =
+            m_pControllerManager->getControllerList(false, true);
+    for (auto controller : controllerList) {
+        controller->disconnect(this);
     }
-    m_controllerConnections.clear();
     while (!m_controllerPages.isEmpty()) {
         DlgPrefController* pControllerDlg = m_controllerPages.takeLast();
         m_pDlgPreferences->removePageWidget(pControllerDlg);
@@ -175,11 +179,11 @@ void DlgPrefControllers::setupControllerWidgets() {
 
         m_controllerPages.append(pControllerDlg);
 
-        m_controllerConnections.append(connect(pController,
+        connect(pController,
                 &Controller::openChanged,
                 [this, pControllerDlg](bool bOpen) {
                     slotHighlightDevice(pControllerDlg, bOpen);
-                }));
+                });
 
         QTreeWidgetItem* pControllerTreeItem = new QTreeWidgetItem(
                 QTreeWidgetItem::Type);

--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -181,6 +181,7 @@ void DlgPrefControllers::setupControllerWidgets() {
 
         connect(pController,
                 &Controller::openChanged,
+                this,
                 [this, pControllerDlg](bool bOpen) {
                     slotHighlightDevice(pControllerDlg, bOpen);
                 });

--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -131,7 +131,7 @@ void DlgPrefControllers::rescanControllers() {
 
 void DlgPrefControllers::destroyControllerWidgets() {
     for (auto* pController : m_pControllerManager->getControllerList(false, true)) {
-        pController->disconnect();
+        pController->disconnect(SIGNAL(&Controller::openChanged));
     }
     while (!m_controllerPages.isEmpty()) {
         DlgPrefController* pControllerDlg = m_controllerPages.takeLast();

--- a/src/controllers/dlgprefcontrollers.h
+++ b/src/controllers/dlgprefcontrollers.h
@@ -52,4 +52,5 @@ class DlgPrefControllers : public DlgPreferencePage, public Ui::DlgPrefControlle
     QTreeWidgetItem* m_pControllersRootItem;
     QList<DlgPrefController*> m_controllerPages;
     QList<QTreeWidgetItem*> m_controllerTreeItems;
+    QList<QMetaObject::Connection> m_controllerConnections;
 };

--- a/src/controllers/dlgprefcontrollers.h
+++ b/src/controllers/dlgprefcontrollers.h
@@ -52,5 +52,4 @@ class DlgPrefControllers : public DlgPreferencePage, public Ui::DlgPrefControlle
     QTreeWidgetItem* m_pControllersRootItem;
     QList<DlgPrefController*> m_controllerPages;
     QList<QTreeWidgetItem*> m_controllerTreeItems;
-    QList<QMetaObject::Connection> m_controllerConnections;
 };


### PR DESCRIPTION
Disconnect connections from controllers when deleting controller prefs

Leaving the stale connections can cause segfaults on exit.

This should fix https://bugs.launchpad.net/mixxx/+bug/1946581