### PR TITLE
[Qt6] TrackAnalysisScheduler: Remove dependency on Library

### DIFF
--- a/src/analyzer/analyzerwaveform.cpp
+++ b/src/analyzer/analyzerwaveform.cpp
@@ -3,7 +3,6 @@
 #include "engine/engineobject.h"
 #include "engine/filters/enginefilterbessel4.h"
 #include "engine/filters/enginefilterbutterworth8.h"
-#include "library/trackcollection.h"
 #include "track/track.h"
 #include "util/logger.h"
 #include "waveform/waveformfactory.h"

--- a/src/analyzer/trackanalysisscheduler.cpp
+++ b/src/analyzer/trackanalysisscheduler.cpp
@@ -327,18 +327,3 @@ void TrackAnalysisScheduler::stop() {
     m_pendingTrackIds.clear();
     DEBUG_ASSERT((allTracksFinished()));
 }
-
-QList<TrackId> TrackAnalysisScheduler::stopAndCollectScheduledTrackIds() {
-    QList<TrackId> scheduledTrackIds;
-    scheduledTrackIds.reserve(static_cast<int>(m_queuedTrackIds.size() + m_pendingTrackIds.size()));
-    for (auto queuedTrackId: m_queuedTrackIds) {
-        scheduledTrackIds.append(std::move(queuedTrackId));
-    }
-    for (auto pendingTrackId: m_pendingTrackIds) {
-        scheduledTrackIds.append(std::move(pendingTrackId));
-    }
-    // Stopping the scheduler will clear all queued and pending tracks,
-    // so we need to do this after we have collected all scheduled tracks!
-    stop();
-    return scheduledTrackIds;
-}

--- a/src/analyzer/trackanalysisscheduler.h
+++ b/src/analyzer/trackanalysisscheduler.h
@@ -1,18 +1,17 @@
 #pragma once
 
 #include <QList>
-
 #include <deque>
+#include <memory>
 #include <set>
 #include <vector>
 
 #include "analyzer/analyzerthread.h"
-
-#include "util/memory.h"
-
+#include "util/db/dbconnectionpool.h"
+#include "util/qt.h"
 
 // forward declaration(s)
-class Library;
+class TrackDAO;
 
 class TrackAnalysisScheduler : public QObject {
     Q_OBJECT
@@ -26,14 +25,16 @@ class TrackAnalysisScheduler : public QObject {
     };
 
     static Pointer createInstance(
-            Library* library,
+            const TrackDAO* pTrackDao,
             int numWorkerThreads,
+            const mixxx::DbConnectionPoolPtr& pDbConnectionPool,
             const UserSettingsPointer& pConfig,
             AnalyzerModeFlags modeFlags);
 
     /*private*/ TrackAnalysisScheduler(
-            Library* library,
+            const TrackDAO* pTrackDao,
             int numWorkerThreads,
+            const mixxx::DbConnectionPoolPtr& pDbConnectionPool,
             const UserSettingsPointer& pConfig,
             AnalyzerModeFlags modeFlags);
     ~TrackAnalysisScheduler() override;
@@ -138,7 +139,7 @@ class TrackAnalysisScheduler : public QObject {
                 m_pendingTrackIds.empty();
     }
 
-    Library* m_library;
+    const mixxx::SafeQPointer<const TrackDAO> m_pTrackDao;
 
     std::vector<Worker> m_workers;
 

--- a/src/analyzer/trackanalysisscheduler.h
+++ b/src/analyzer/trackanalysisscheduler.h
@@ -43,14 +43,6 @@ class TrackAnalysisScheduler : public QObject {
     bool scheduleTrackById(TrackId trackId);
     int scheduleTracksById(const QList<TrackId>& trackIds);
 
-    // Returns the scheduled tracks that have not yet been analyzed.
-    // Includes both queued tracks as well as pending tracks that are
-    // currently being analyzed. The result may contain duplicates.
-    // TODO(XXX): Use this function for implementing the feature
-    // "Suspend and resume batch analysis"
-    // https://bugs.launchpad.net/mixxx/+bug/1443181
-    QList<TrackId> stopAndCollectScheduledTrackIds();
-
   public slots:
     void suspend();
 

--- a/src/library/analysisfeature.cpp
+++ b/src/library/analysisfeature.cpp
@@ -137,10 +137,8 @@ void AnalysisFeature::analyzeTracks(const QList<TrackId>& trackIds) {
                 << "Starting analysis using"
                 << numAnalyzerThreads
                 << "analyzer threads";
-        m_pTrackAnalysisScheduler = TrackAnalysisScheduler::createInstance(
-                m_pLibrary,
+        m_pTrackAnalysisScheduler = m_pLibrary->createTrackAnalysisScheduler(
                 numAnalyzerThreads,
-                m_pConfig,
                 getAnalyzerModeFlags(m_pConfig));
 
         connect(m_pTrackAnalysisScheduler.get(),

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -131,6 +131,7 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
   private:
     friend class LibraryScanner;
     friend class TrackCollection;
+    friend class TrackAnalysisScheduler;
 
     TrackId getTrackIdByLocation(
             const QString& location) const;

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -254,13 +254,22 @@ Library::Library(
             kEditMetadataSelectedClickDefault);
 }
 
-Library::~Library() {
-    // Empty but required due to forward declarations in header file!
-}
+Library::~Library() = default;
 
 TrackCollectionManager* Library::trackCollectionManager() const {
     // Cannot be implemented inline due to forward declarations
     return m_pTrackCollectionManager;
+}
+
+TrackAnalysisScheduler::Pointer Library::createTrackAnalysisScheduler(
+        int numWorkerThreads,
+        AnalyzerModeFlags modeFlags) const {
+    return TrackAnalysisScheduler::createInstance(
+            &m_pTrackCollectionManager->internalCollection()->getTrackDAO(),
+            numWorkerThreads,
+            m_pDbConnectionPool,
+            m_pConfig,
+            modeFlags);
 }
 
 void Library::stopPendingTasks() {

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -6,7 +6,7 @@
 #include <QObject>
 #include <QPointer>
 
-#include "analyzer/analyzerprogress.h"
+#include "analyzer/trackanalysisscheduler.h"
 #include "library/library_decl.h"
 #ifdef __ENGINEPRIME__
 #include "library/trackset/crate/crateid.h"
@@ -65,6 +65,10 @@ class Library: public QObject {
     }
 
     TrackCollectionManager* trackCollectionManager() const;
+
+    TrackAnalysisScheduler::Pointer createTrackAnalysisScheduler(
+            int numWorkerThreads,
+            AnalyzerModeFlags modeFlags) const;
 
     void bindSearchboxWidget(WSearchLineEdit* pSearchboxWidget);
     void bindSidebarWidget(WLibrarySidebar* sidebarWidget);

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -153,10 +153,8 @@ void PlayerManager::bindToLibrary(Library* pLibrary) {
             &Library::slotLoadLocationToPlayer);
 
     DEBUG_ASSERT(!m_pTrackAnalysisScheduler);
-    m_pTrackAnalysisScheduler = TrackAnalysisScheduler::createInstance(
-            pLibrary,
+    m_pTrackAnalysisScheduler = pLibrary->createTrackAnalysisScheduler(
             kNumberOfAnalyzerThreads,
-            m_pConfig,
             AnalyzerModeFlags::WithWaveform);
 
     connect(m_pTrackAnalysisScheduler.get(), &TrackAnalysisScheduler::trackProgress,


### PR DESCRIPTION
No need to replace `TrackId` with `QUrl` right now.

This should reduce the number of linker errors for the stripped down Qt6 build.