### PR TITLE
Qt6: Re-enable Waveform and WaveformFactory classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -904,6 +904,8 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/util/workerthread.cpp
   src/util/workerthreadscheduler.cpp
   src/util/xml.cpp
+  src/waveform/waveform.cpp
+  src/waveform/waveformfactory.cpp
 )
 if(NOT QT6)
   target_sources(mixxx-lib PRIVATE
@@ -974,8 +976,6 @@ if(NOT QT6)
     src/waveform/visualplayposition.cpp
     src/waveform/visualsmanager.cpp
     src/waveform/vsyncthread.cpp
-    src/waveform/waveform.cpp
-    src/waveform/waveformfactory.cpp
     src/waveform/waveformmarklabel.cpp
     src/waveform/waveformwidgetfactory.cpp
     src/waveform/widgets/emptywaveformwidget.cpp


### PR DESCRIPTION
We don't need to exclude these classes. Reduces the number of linker errors by ~40 lines.