### PR TITLE
Fix empty effect chain selector after renaming chain presets

### DIFF
--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -46,6 +46,10 @@ EffectChain::EffectChain(const QString& group,
     m_pControlNumChainPresets->set(m_pChainPresetManager->numPresets());
     m_pControlNumChainPresets->setReadOnly();
     connect(m_pChainPresetManager.data(),
+            &EffectChainPresetManager::effectChainPresetRenamed,
+            this,
+            &EffectChain::slotEffectChainPresetRenamed);
+    connect(m_pChainPresetManager.data(),
             &EffectChainPresetManager::effectChainPresetListUpdated,
             this,
             &EffectChain::slotPresetListUpdated);
@@ -368,6 +372,12 @@ void EffectChain::slotChannelStatusChanged(
         enableForInputChannel(handleGroup);
     } else {
         disableForInputChannel(handleGroup);
+    }
+}
+
+void EffectChain::slotEffectChainPresetRenamed(const QString& oldName, const QString& newName) {
+    if (m_presetName == oldName) {
+        m_presetName = newName;
     }
 }
 

--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -213,7 +213,7 @@ void EffectChain::loadChainPreset(EffectChainPresetPointer pPreset) {
     m_pControlChainSuperParameter->setDefaultValue(pPreset->superKnob());
 
     m_presetName = pPreset->name();
-    emit presetNameChanged(m_presetName);
+    emit chainPresetChanged(m_presetName);
 
     setControlLoadedPresetIndex(presetIndex());
 }

--- a/src/effects/effectchain.h
+++ b/src/effects/effectchain.h
@@ -82,7 +82,7 @@ class EffectChain : public QObject {
     void slotControlClear(double value);
 
   signals:
-    void presetNameChanged(const QString& name);
+    void chainPresetChanged(const QString& name);
 
   protected slots:
     void sendParameterUpdate();

--- a/src/effects/effectchain.h
+++ b/src/effects/effectchain.h
@@ -112,6 +112,7 @@ class EffectChain : public QObject {
     QList<EffectSlotPointer> m_effectSlots;
 
   protected slots:
+    void slotEffectChainPresetRenamed(const QString& oldName, const QString& newName);
     void slotPresetListUpdated();
 
   private slots:

--- a/src/effects/presets/effectchainpresetmanager.cpp
+++ b/src/effects/presets/effectchainpresetmanager.cpp
@@ -256,12 +256,12 @@ void EffectChainPresetManager::renamePreset(const QString& oldName) {
     }
 
     EffectChainPresetPointer pPreset = m_effectChainPresets.take(oldName);
-    int index = m_effectChainPresetsSorted.indexOf(pPreset);
 
     pPreset->setName(newName);
     m_effectChainPresets.insert(newName, pPreset);
 
     if (!savePresetXml(pPreset)) {
+        // Saving failed, revert renaming
         m_effectChainPresets.take(newName);
         pPreset->setName(oldName);
         m_effectChainPresets.insert(oldName, pPreset);
@@ -282,16 +282,20 @@ void EffectChainPresetManager::renamePreset(const QString& oldName) {
         msgBox.exec();
     }
 
+    emit effectChainPresetRenamed(oldName, newName);
+
+    int index = m_effectChainPresetsSorted.indexOf(pPreset);
     if (index != -1) {
         m_effectChainPresetsSorted.removeAt(index);
         m_effectChainPresetsSorted.insert(index, pPreset);
+        emit effectChainPresetListUpdated();
     }
     index = m_quickEffectChainPresetsSorted.indexOf(pPreset);
     if (index != -1) {
         m_quickEffectChainPresetsSorted.removeAt(index);
         m_quickEffectChainPresetsSorted.insert(index, pPreset);
+        emit quickEffectChainPresetListUpdated();
     }
-    emit effectChainPresetListUpdated();
 }
 
 bool EffectChainPresetManager::deletePreset(const QString& chainPresetName) {

--- a/src/effects/presets/effectchainpresetmanager.h
+++ b/src/effects/presets/effectchainpresetmanager.h
@@ -72,6 +72,7 @@ class EffectChainPresetManager : public QObject {
     void saveEffectsXml(QDomDocument* pDoc, const EffectsXmlData& data);
 
   signals:
+    void effectChainPresetRenamed(const QString& oldName, const QString& newName);
     void effectChainPresetListUpdated();
     void quickEffectChainPresetListUpdated();
 

--- a/src/widget/weffectchain.cpp
+++ b/src/widget/weffectchain.cpp
@@ -28,13 +28,13 @@ void WEffectChain::setEffectChain(EffectChainPointer pEffectChain) {
     if (pEffectChain) {
         m_pEffectChain = pEffectChain;
         connect(pEffectChain.data(),
-                &EffectChain::presetNameChanged,
+                &EffectChain::chainPresetChanged,
                 this,
-                &WEffectChain::presetNameChanged);
-        presetNameChanged(m_pEffectChain->presetName());
+                &WEffectChain::chainPresetChanged);
+        chainPresetChanged(m_pEffectChain->presetName());
     }
 }
 
-void WEffectChain::presetNameChanged(const QString& newName) {
+void WEffectChain::chainPresetChanged(const QString& newName) {
     setText(newName);
 }

--- a/src/widget/weffectchain.h
+++ b/src/widget/weffectchain.h
@@ -18,7 +18,7 @@ class WEffectChain : public WLabel {
     void setup(const QDomNode& node, const SkinContext& context) override;
 
   private slots:
-    void presetNameChanged(const QString& newName);
+    void chainPresetChanged(const QString& newName);
 
   private:
     // Set the EffectChain that should be monitored by this WEffectChain

--- a/src/widget/weffectchainpresetselector.cpp
+++ b/src/widget/weffectchainpresetselector.cpp
@@ -39,9 +39,9 @@ void WEffectChainPresetSelector::setup(const QDomNode& node, const SkinContext& 
             this,
             &WEffectChainPresetSelector::populate);
     connect(m_pChain.data(),
-            &EffectChain::presetNameChanged,
+            &EffectChain::chainPresetChanged,
             this,
-            &WEffectChainPresetSelector::slotEffectChainNameChanged);
+            &WEffectChainPresetSelector::slotChainPresetChanged);
     connect(this,
             QOverload<int>::of(&QComboBox::activated),
             this,
@@ -72,7 +72,7 @@ void WEffectChainPresetSelector::populate() {
         setItemData(i, pChainPreset->name(), Qt::ToolTipRole);
     }
 
-    slotEffectChainNameChanged(m_pChain->presetName());
+    slotChainPresetChanged(m_pChain->presetName());
     blockSignals(false);
 }
 
@@ -83,7 +83,7 @@ void WEffectChainPresetSelector::slotEffectChainPresetSelected(int index) {
     setBaseTooltip(itemData(index, Qt::ToolTipRole).toString());
 }
 
-void WEffectChainPresetSelector::slotEffectChainNameChanged(const QString& name) {
+void WEffectChainPresetSelector::slotChainPresetChanged(const QString& name) {
     setCurrentIndex(findData(name));
     setBaseTooltip(name);
 }

--- a/src/widget/weffectchainpresetselector.h
+++ b/src/widget/weffectchainpresetselector.h
@@ -18,7 +18,7 @@ class WEffectChainPresetSelector : public QComboBox, public WBaseWidget {
   private slots:
     void populate();
     void slotEffectChainPresetSelected(int index);
-    void slotEffectChainNameChanged(const QString& name);
+    void slotChainPresetChanged(const QString& name);
     bool event(QEvent* pEvent) override;
 
   private:


### PR DESCRIPTION
This fixes https://bugs.launchpad.net/mixxx/+bug/1948567