### PR TITLE
Reintroduce the Quick effect selectors in the EQ preferences

### DIFF
--- a/src/preferences/dialog/dlgprefeq.h
+++ b/src/preferences/dialog/dlgprefeq.h
@@ -31,6 +31,7 @@ class DlgPrefEQ : public DlgPreferencePage, public Ui::DlgPrefEQDlg  {
 
   private slots:
     void slotEffectChangedOnDeck(int effectIndex);
+    void slotQuickEffectChangedOnDeck(int effectIndex);
     void slotNumDecksChanged(double numDecks);
     void slotSingleEqChecked(int checked);
     // Slot for toggling between advanced and basic views
@@ -62,9 +63,11 @@ class DlgPrefEQ : public DlgPreferencePage, public Ui::DlgPrefEQDlg  {
     typedef bool (*EffectManifestFilterFnc)(EffectManifest* pManifest);
     const QList<EffectManifestPointer> getFilteredManifests(
             EffectManifestFilterFnc filterFunc) const;
-    void populateDeckBoxList(
+    void populateDeckEqBoxList(
             const QList<QComboBox*>& boxList,
             EffectManifestFilterFnc filterFunc);
+    void populateDeckQuickEffectBoxList(
+            const QList<QComboBox*>& boxList);
 
     void applySelectionsToDecks();
 
@@ -73,10 +76,12 @@ class DlgPrefEQ : public DlgPreferencePage, public Ui::DlgPrefEQDlg  {
     UserSettingsPointer m_pConfig;
     double m_lowEqFreq, m_highEqFreq;
 
+    EffectChainPresetManagerPointer m_pChainPresetManager;
     std::shared_ptr<EffectsManager> m_pEffectsManager;
     EffectsBackendManagerPointer m_pBackendManager;
     QLabel* m_firstSelectorLabel;
     QList<QComboBox*> m_deckEqEffectSelectors;
+    QList<QComboBox*> m_deckQuickEffectSelectors;
     ControlProxy* m_pNumDecks;
 
     bool m_inSlotPopulateDeckEffectSelectors;

--- a/src/preferences/dialog/dlgprefeqdlg.ui
+++ b/src/preferences/dialog/dlgprefeqdlg.ui
@@ -81,6 +81,22 @@
             </property>
            </widget>
           </item>
+          <item row="0" column="2">
+           <widget class="QLabel" name="label_3">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="leftMargin">
+             <number>3</number>
+            </property>
+            <property name="text">
+             <string>Quick Effect</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>


### PR DESCRIPTION
We need that to merge the effects_refactoring branch without a regression until the Skin effect GUI is in place. https://bugs.launchpad.net/mixxx/+bug/1948537

This does not revert to the 2.4 state where single effects where selected, It selects the effect chain presets and is fully aligned with the upcoming chain preset selectors in the skins. 