### PR TITLE
This descibes possible causes for a rare crasher with effects.

### DIFF
--- a/src/effects/backends/effectprocessor.h
+++ b/src/effects/backends/effectprocessor.h
@@ -157,6 +157,11 @@ class EffectProcessorImpl : public EffectProcessor {
             const EffectEnableState enableState,
             const GroupFeatureState& groupFeatures) final {
         EffectSpecificState* pState = m_channelStateMatrix[inputHandle][outputHandle];
+        // TODO: The state can be null if we are in the deleteStatesForInputChannel() loop.
+        // A protection against this is missing. Since it can happen the assertion is incorrect
+        // The memory will be leaked.
+        // Idea: Skip the processing here?
+        // Probably related: https://bugs.launchpad.net/mixxx/+bug/1775497
         VERIFY_OR_DEBUG_ASSERT(pState != nullptr) {
             if (kEffectDebugOutput) {
                 qWarning() << "EffectProcessorImpl::process could not retrieve"

--- a/src/effects/backends/effectprocessor.h
+++ b/src/effects/backends/effectprocessor.h
@@ -194,9 +194,11 @@ class EffectProcessorImpl : public EffectProcessor {
                 outputChannelMap.insert(outputChannel.handle(),
                         createSpecificState(engineParameters));
                 if (kEffectDebugOutput) {
-                    qDebug() << this << "EffectProcessorImpl::initialize "
-                                        "registering output"
-                             << outputChannel << outputChannelMap[outputChannel.handle()];
+                    qDebug() << this
+                             << "EffectProcessorImpl::initialize "
+                                "registering output"
+                             << outputChannel << outputChannel.handle()
+                             << outputChannelMap[outputChannel.handle()];
                 }
             }
             m_channelStateMatrix.insert(inputChannel.handle(), outputChannelMap);
@@ -286,7 +288,7 @@ class EffectProcessorImpl : public EffectProcessor {
             }
             if (kEffectDebugOutput) {
                 qDebug() << "EffectProcessorImpl::deleteStatesForInputChannel"
-                         << this << "deleting state" << pState;
+                         << inputChannel << this << "deleting state" << pState;
             }
             delete pState;
         }

--- a/src/effects/backends/effectprocessor.h
+++ b/src/effects/backends/effectprocessor.h
@@ -273,6 +273,11 @@ class EffectProcessorImpl : public EffectProcessor {
         // m_channelStateMatrix may be accessed concurrently in the audio
         // engine thread in loadStatesForInputChannel.
 
+        // TODO: How is ensure that the statMap is not accessed during this loop?
+        // This is called in responds to DISABLE_EFFECT_CHAIN_FOR_INPUT_CHANNEL
+        // and it looks like that the objects pointed by m_channelStateMatrix
+        // may be still in use.
+        // Probably related: https://bugs.launchpad.net/mixxx/+bug/1775497
         ChannelHandleMap<EffectSpecificState*>& stateMap =
                 m_channelStateMatrix[inputChannel];
         for (EffectSpecificState* pState : stateMap) {

--- a/src/effects/chains/equalizereffectchain.cpp
+++ b/src/effects/chains/equalizereffectchain.cpp
@@ -16,6 +16,7 @@ EqualizerEffectChain::EqualizerEffectChain(
                   new ControlObject(ConfigKey(handleAndGroup.name(), "filterWaveformEnable"))) {
     // Add a single effect slot
     addEffectSlot(formatEffectSlotGroup(handleAndGroup.name()));
+    enableForInputChannel(handleAndGroup);
     m_effectSlots[0]->setEnabled(true);
     // DlgPrefEq loads the Effect with loadEffectToGroup
 

--- a/src/effects/chains/equalizereffectchain.cpp
+++ b/src/effects/chains/equalizereffectchain.cpp
@@ -2,22 +2,24 @@
 
 #include "effects/effectslot.h"
 
-EqualizerEffectChain::EqualizerEffectChain(const QString& group,
+EqualizerEffectChain::EqualizerEffectChain(
+        const ChannelHandleAndGroup& handleAndGroup,
         EffectsManager* pEffectsManager,
         EffectsMessengerPointer pEffectsMessenger)
-        : PerGroupEffectChain(group,
-                  formatEffectChainGroup(group),
+        : PerGroupEffectChain(
+                  handleAndGroup,
+                  formatEffectChainGroup(handleAndGroup.name()),
                   SignalProcessingStage::Prefader,
                   pEffectsManager,
                   pEffectsMessenger),
           m_pCOFilterWaveform(
-                  new ControlObject(ConfigKey(group, "filterWaveformEnable"))) {
+                  new ControlObject(ConfigKey(handleAndGroup.name(), "filterWaveformEnable"))) {
     // Add a single effect slot
-    addEffectSlot(formatEffectSlotGroup(group));
+    addEffectSlot(formatEffectSlotGroup(handleAndGroup.name()));
     m_effectSlots[0]->setEnabled(true);
     // DlgPrefEq loads the Effect with loadEffectToGroup
 
-    setupLegacyAliasesForGroup(group);
+    setupLegacyAliasesForGroup(handleAndGroup.name());
 }
 
 void EqualizerEffectChain::setFilterWaveform(bool state) {

--- a/src/effects/chains/equalizereffectchain.h
+++ b/src/effects/chains/equalizereffectchain.h
@@ -11,7 +11,8 @@
 class EqualizerEffectChain : public PerGroupEffectChain {
     Q_OBJECT
   public:
-    EqualizerEffectChain(const QString& group,
+    EqualizerEffectChain(
+            const ChannelHandleAndGroup& handleAndGroup,
             EffectsManager* pEffectsManager,
             EffectsMessengerPointer pEffectsMessenger);
 

--- a/src/effects/chains/pergroupeffectchain.cpp
+++ b/src/effects/chains/pergroupeffectchain.cpp
@@ -18,5 +18,4 @@ PerGroupEffectChain::PerGroupEffectChain(
 
     // Register this channel alone with the chain slot.
     registerInputChannel(handleAndGroup);
-    enableForInputChannel(handleAndGroup);
 }

--- a/src/effects/chains/pergroupeffectchain.cpp
+++ b/src/effects/chains/pergroupeffectchain.cpp
@@ -2,7 +2,8 @@
 
 #include "effects/effectsmanager.h"
 
-PerGroupEffectChain::PerGroupEffectChain(const QString& group,
+PerGroupEffectChain::PerGroupEffectChain(
+        const ChannelHandleAndGroup& handleAndGroup,
         const QString& chainSlotGroup,
         SignalProcessingStage stage,
         EffectsManager* pEffectsManager,
@@ -15,18 +16,7 @@ PerGroupEffectChain::PerGroupEffectChain(const QString& group,
     m_pControlChainMix->set(1.0);
     sendParameterUpdate();
 
-    // TODO(rryan): remove.
-    const ChannelHandleAndGroup* handleAndGroup = nullptr;
-    for (const ChannelHandleAndGroup& handle_group :
-            m_pEffectsManager->registeredInputChannels()) {
-        if (handle_group.name() == group) {
-            handleAndGroup = &handle_group;
-            break;
-        }
-    }
-    DEBUG_ASSERT(handleAndGroup != nullptr);
-
     // Register this channel alone with the chain slot.
-    registerInputChannel(*handleAndGroup);
-    enableForInputChannel(*handleAndGroup);
+    registerInputChannel(handleAndGroup);
+    enableForInputChannel(handleAndGroup);
 }

--- a/src/effects/chains/pergroupeffectchain.h
+++ b/src/effects/chains/pergroupeffectchain.h
@@ -7,7 +7,8 @@
 class PerGroupEffectChain : public EffectChain {
     Q_OBJECT
   public:
-    PerGroupEffectChain(const QString& group,
+    PerGroupEffectChain(
+            const ChannelHandleAndGroup& handleGroup,
             const QString& chainSlotGroup,
             SignalProcessingStage stage,
             EffectsManager* pEffectsManager,

--- a/src/effects/chains/quickeffectchain.cpp
+++ b/src/effects/chains/quickeffectchain.cpp
@@ -3,16 +3,18 @@
 #include "effects/effectslot.h"
 #include "effects/presets/effectchainpresetmanager.h"
 
-QuickEffectChain::QuickEffectChain(const QString& group,
+QuickEffectChain::QuickEffectChain(
+        const ChannelHandleAndGroup& handleAndGroup,
         EffectsManager* pEffectsManager,
         EffectsMessengerPointer pEffectsMessenger)
-        : PerGroupEffectChain(group,
-                  formatEffectChainGroup(group),
+        : PerGroupEffectChain(
+                  handleAndGroup,
+                  formatEffectChainGroup(handleAndGroup.name()),
                   SignalProcessingStage::Postfader,
                   pEffectsManager,
                   pEffectsMessenger) {
     for (int i = 0; i < kNumEffectsPerUnit; ++i) {
-        addEffectSlot(formatEffectSlotGroup(group, i));
+        addEffectSlot(formatEffectSlotGroup(handleAndGroup.name(), i));
         m_effectSlots.at(i)->setEnabled(true);
     }
     // The base EffectChain class constructor connects to the signal for the list of StandardEffectChain presets,

--- a/src/effects/chains/quickeffectchain.cpp
+++ b/src/effects/chains/quickeffectchain.cpp
@@ -17,6 +17,7 @@ QuickEffectChain::QuickEffectChain(
         addEffectSlot(formatEffectSlotGroup(handleAndGroup.name(), i));
         m_effectSlots.at(i)->setEnabled(true);
     }
+    enableForInputChannel(handleAndGroup);
     // The base EffectChain class constructor connects to the signal for the list of StandardEffectChain presets,
     // but QuickEffectChain has a separate list, so disconnect the signal which is inappropriate for this subclass.
     disconnect(m_pChainPresetManager.data(),

--- a/src/effects/chains/quickeffectchain.h
+++ b/src/effects/chains/quickeffectchain.h
@@ -10,7 +10,8 @@
 class QuickEffectChain : public PerGroupEffectChain {
     Q_OBJECT
   public:
-    QuickEffectChain(const QString& group,
+    QuickEffectChain(
+            const ChannelHandleAndGroup& handleAndGroup,
             EffectsManager* pEffectsManager,
             EffectsMessengerPointer pEffectsMessenger);
 

--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -396,24 +396,12 @@ void EffectChain::enableForInputChannel(const ChannelHandleAndGroup& handleGroup
     request->pTargetChain = m_pEngineEffectChain;
     request->EnableInputChannelForChain.channelHandle = handleGroup.handle();
 
-    // Allocate EffectStates here in the main thread to avoid allocating
-    // memory in the realtime audio callback thread. Pointers to the
-    // EffectStates are passed to the EffectRequest and the EffectProcessorImpls
-    // store the pointers. The containers of EffectState* pointers get deleted
-    // by ~EffectsRequest, but the EffectStates are managed by EffectProcessorImpl.
+    // Initialize EffectStates for the input channel here in the main thread to
+    // avoid allocating memory in the realtime audio callback thread.
 
-    // The EffectStates for one EngineEffectChain must be sent all together in
-    // the same message using an EffectStatesMapArray. If they were separated
-    // into a message for each effect, there would be a chance that the
-    // EngineEffectChain could get activated in one cycle of the audio callback
-    // thread but the EffectStates for an EngineEffect would not be received by
-    // EngineEffectsManager until the next audio callback cycle.
-
-    auto* pEffectStatesMapArray = new EffectStatesMapArray;
     for (int i = 0; i < m_effectSlots.size(); ++i) {
-        m_effectSlots[i]->fillEffectStatesMap(&(*pEffectStatesMapArray)[i]);
+        m_effectSlots[i]->initalizeInputChannel(handleGroup.handle());
     }
-    request->EnableInputChannelForChain.pEffectStatesMapArray = pEffectStatesMapArray;
 
     m_pMessenger->writeRequest(request);
 

--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -192,26 +192,11 @@ void EffectSlot::updateEngineState() {
     }
 }
 
-void EffectSlot::fillEffectStatesMap(EffectStatesMap* pStatesMap) const {
-    //TODO: get actual configuration of engine
-    const mixxx::EngineParameters engineParameters(
-            mixxx::audio::SampleRate(96000),
-            MAX_BUFFER_LEN / mixxx::kEngineChannelCount);
-
-    if (isLoaded()) {
-        for (const auto& outputChannel :
-                m_pEffectsManager->registeredOutputChannels()) {
-            pStatesMap->insert(outputChannel.handle(),
-                    m_pEngineEffect->createState(engineParameters));
-        }
-    } else {
-        for (EffectState* pState : *pStatesMap) {
-            if (pState) {
-                delete pState;
-            }
-        }
-        pStatesMap->clear();
+void EffectSlot::initalizeInputChannel(ChannelHandle inputChannel) {
+    if (!m_pEngineEffect) {
+        return;
     }
+    m_pEngineEffect->initalizeInputChannel(inputChannel);
 };
 
 EffectManifestPointer EffectSlot::getManifest() const {

--- a/src/effects/effectslot.h
+++ b/src/effects/effectslot.h
@@ -123,7 +123,7 @@ class EffectSlot : public QObject {
         return m_group;
     }
 
-    void fillEffectStatesMap(EffectStatesMap* pStatesMap) const;
+    void initalizeInputChannel(ChannelHandle inputChannel);
 
     EffectManifestPointer getManifest() const;
 

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -127,34 +127,34 @@ EffectChainPointer EffectsManager::getStandardEffectChain(int unitNumber) const 
     return m_standardEffectChains.at(unitNumber);
 }
 
-void EffectsManager::addDeck(const QString& deckGroupName) {
-    addEqualizerEffectChain(deckGroupName);
-    addQuickEffectChain(deckGroupName);
+void EffectsManager::addDeck(const ChannelHandleAndGroup& deckHandleGroup) {
+    addEqualizerEffectChain(deckHandleGroup);
+    addQuickEffectChain(deckHandleGroup);
 }
 
-void EffectsManager::addEqualizerEffectChain(const QString& deckGroupName) {
+void EffectsManager::addEqualizerEffectChain(const ChannelHandleAndGroup& deckHandleGroup) {
     VERIFY_OR_DEBUG_ASSERT(!m_equalizerEffectChains.contains(
-            EqualizerEffectChain::formatEffectChainGroup(deckGroupName))) {
+            EqualizerEffectChain::formatEffectChainGroup(deckHandleGroup.name()))) {
         return;
     }
 
     auto pChainSlot = EqualizerEffectChainPointer(
-            new EqualizerEffectChain(deckGroupName, this, m_pMessenger));
+            new EqualizerEffectChain(deckHandleGroup, this, m_pMessenger));
 
-    m_equalizerEffectChains.insert(deckGroupName, pChainSlot);
+    m_equalizerEffectChains.insert(deckHandleGroup.name(), pChainSlot);
     m_effectChainSlotsByGroup.insert(pChainSlot->group(), pChainSlot);
 }
 
-void EffectsManager::addQuickEffectChain(const QString& deckGroupName) {
+void EffectsManager::addQuickEffectChain(const ChannelHandleAndGroup& deckHandleGroup) {
     VERIFY_OR_DEBUG_ASSERT(!m_quickEffectChains.contains(
-            QuickEffectChain::formatEffectChainGroup(deckGroupName))) {
+            QuickEffectChain::formatEffectChainGroup(deckHandleGroup.name()))) {
         return;
     }
 
     auto pChainSlot = QuickEffectChainPointer(
-            new QuickEffectChain(deckGroupName, this, m_pMessenger));
+            new QuickEffectChain(deckHandleGroup, this, m_pMessenger));
 
-    m_quickEffectChains.insert(deckGroupName, pChainSlot);
+    m_quickEffectChains.insert(deckHandleGroup.name(), pChainSlot);
     m_effectChainSlotsByGroup.insert(pChainSlot->group(), pChainSlot);
 }
 

--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -26,7 +26,7 @@ class EffectsManager {
     virtual ~EffectsManager();
 
     void setup();
-    void addDeck(const QString& deckGroupName);
+    void addDeck(const ChannelHandleAndGroup& deckHandleGroup);
 
     EffectChainPointer getEffectChain(const QString& group) const;
     EqualizerEffectChainPointer getEqualizerEffectChain(
@@ -75,8 +75,8 @@ class EffectsManager {
     void addStandardEffectChains();
     void addOutputEffectChain();
 
-    void addEqualizerEffectChain(const QString& deckGroupName);
-    void addQuickEffectChain(const QString& deckGroupName);
+    void addEqualizerEffectChain(const ChannelHandleAndGroup& deckHandleGroup);
+    void addQuickEffectChain(const ChannelHandleAndGroup& deckHandleGroup);
 
     void readEffectsXml();
     void saveEffectsXml();

--- a/src/effects/effectsmessenger.cpp
+++ b/src/effects/effectsmessenger.cpp
@@ -90,13 +90,5 @@ void EffectsMessenger::collectGarbage(const EffectsRequest* pRequest) {
             qDebug() << debugString() << "delete" << pRequest->RemoveEffectChain.pChain;
         }
         delete pRequest->RemoveEffectChain.pChain;
-    } else if (pRequest->type == EffectsRequest::DISABLE_EFFECT_CHAIN_FOR_INPUT_CHANNEL) {
-        if (kEffectDebugOutput) {
-            qDebug() << debugString() << "deleting states for input channel"
-                     << pRequest->DisableInputChannelForChain.channelHandle
-                     << "for EngineEffectChain" << pRequest->pTargetChain;
-        }
-        pRequest->pTargetChain->deleteStatesForInputChannel(
-                pRequest->DisableInputChannelForChain.channelHandle);
     }
 }

--- a/src/engine/cachingreader/cachingreader.cpp
+++ b/src/engine/cachingreader/cachingreader.cpp
@@ -282,7 +282,9 @@ void CachingReader::process() {
                 // track is already loading! In this case the TRACK_LOADED will
                 // be the very next status update.
                 if (!m_state.testAndSetRelease(STATE_TRACK_UNLOADING, STATE_IDLE)) {
-                    DEBUG_ASSERT(atomicLoadRelaxed(m_state) == STATE_TRACK_LOADING);
+                    DEBUG_ASSERT(
+                            atomicLoadRelaxed(m_state) == STATE_TRACK_LOADING ||
+                            atomicLoadRelaxed(m_state) == STATE_IDLE);
                 }
             }
         }

--- a/src/engine/channelhandle.h
+++ b/src/engine/channelhandle.h
@@ -207,6 +207,10 @@ class ChannelHandleMap {
         m_data.clear();
     }
 
+    bool isEmpty() {
+        return m_data.isEmpty();
+    }
+
     typename container_type::iterator begin() {
         return m_data.begin();
     }

--- a/src/engine/channelhandle.h
+++ b/src/engine/channelhandle.h
@@ -207,6 +207,10 @@ class ChannelHandleMap {
         m_data.clear();
     }
 
+    int size() const {
+        return m_data.size();
+    }
+
     bool isEmpty() {
         return m_data.isEmpty();
     }

--- a/src/engine/channelmixer.cpp
+++ b/src/engine/channelmixer.cpp
@@ -27,7 +27,10 @@ void ChannelMixer::applyEffectsAndMixChannels(const EngineMaster::GainCalculator
         EngineMaster::GainCache& gainCache = (*channelGainCache)[pChannelInfo->m_index];
         CSAMPLE_GAIN oldGain = gainCache.m_gain;
         CSAMPLE_GAIN newGain;
-        if (gainCache.m_fadeout) {
+        bool fadeout = gainCache.m_fadeout ||
+                (pChannelInfo->m_pChannel &&
+                        !pChannelInfo->m_pChannel->isActive());
+        if (fadeout) {
             newGain = 0;
             gainCache.m_fadeout = false;
         } else {
@@ -42,7 +45,8 @@ void ChannelMixer::applyEffectsAndMixChannels(const EngineMaster::GainCalculator
                 iSampleRate,
                 pChannelInfo->m_features,
                 oldGain,
-                newGain);
+                newGain,
+                fadeout);
     }
 }
 
@@ -69,7 +73,10 @@ void ChannelMixer::applyEffectsInPlaceAndMixChannels(
         EngineMaster::GainCache& gainCache = (*channelGainCache)[pChannelInfo->m_index];
         CSAMPLE_GAIN oldGain = gainCache.m_gain;
         CSAMPLE_GAIN newGain;
-        if (gainCache.m_fadeout) {
+        bool fadeout = gainCache.m_fadeout ||
+                (pChannelInfo->m_pChannel &&
+                        !pChannelInfo->m_pChannel->isActive());
+        if (fadeout) {
             newGain = 0;
             gainCache.m_fadeout = false;
         } else {
@@ -83,7 +90,8 @@ void ChannelMixer::applyEffectsInPlaceAndMixChannels(
                 iSampleRate,
                 pChannelInfo->m_features,
                 oldGain,
-                newGain);
+                newGain,
+                fadeout);
         SampleUtil::add(pOutput, pChannelInfo->m_pBuffer, iBufferSize);
     }
 }

--- a/src/engine/channels/engineaux.cpp
+++ b/src/engine/channels/engineaux.cpp
@@ -15,8 +15,7 @@ EngineAux::EngineAux(const ChannelHandleAndGroup& handleGroup, EffectsManager* p
                   /*isTalkoverChannel*/ false,
                   /*isPrimaryDeck*/ false),
           m_pInputConfigured(new ControlObject(ConfigKey(getGroup(), "input_configured"))),
-          m_pPregain(new ControlAudioTaperPot(ConfigKey(getGroup(), "pregain"), -12, 12, 0.5)),
-          m_wasActive(false) {
+          m_pPregain(new ControlAudioTaperPot(ConfigKey(getGroup(), "pregain"), -12, 12, 0.5)) {
     // Make input_configured read-only.
     m_pInputConfigured->setReadOnly();
     ControlDoublePrivate::insertAlias(ConfigKey(getGroup(), "enabled"),
@@ -32,15 +31,18 @@ EngineAux::~EngineAux() {
     delete m_pPregain;
 }
 
-bool EngineAux::isActive() {
+EngineChannel::ActiveState EngineAux::updateActiveState() {
     bool enabled = m_pInputConfigured->toBool();
     if (enabled && m_sampleBuffer) {
-        m_wasActive = true;
-    } else if (m_wasActive) {
-        m_vuMeter.reset();
-        m_wasActive = false;
+        m_active = true;
+        return ActiveState::Active;
     }
-    return m_wasActive;
+    if (m_active) {
+        m_vuMeter.reset();
+        m_active = false;
+        return ActiveState::WasActive;
+    }
+    return ActiveState::Inactive;
 }
 
 void EngineAux::onInputConfigured(const AudioInput& input) {

--- a/src/engine/channels/engineaux.h
+++ b/src/engine/channels/engineaux.h
@@ -18,7 +18,7 @@ class EngineAux : public EngineChannel, public AudioDestination {
     EngineAux(const ChannelHandleAndGroup& handleGroup, EffectsManager* pEffectsManager);
     virtual ~EngineAux();
 
-    bool isActive();
+    ActiveState updateActiveState() override;
 
     /// Called by EngineMaster whenever is requesting a new buffer of audio.
     virtual void process(CSAMPLE* pOutput, const int iBufferSize);
@@ -45,5 +45,4 @@ class EngineAux : public EngineChannel, public AudioDestination {
   private:
     QScopedPointer<ControlObject> m_pInputConfigured;
     ControlAudioTaperPot* m_pPregain;
-    bool m_wasActive;
 };

--- a/src/engine/channels/enginechannel.cpp
+++ b/src/engine/channels/enginechannel.cpp
@@ -15,6 +15,7 @@ EngineChannel::EngineChannel(const ChannelHandleAndGroup& handleGroup,
           m_pSampleRate(new ControlProxy("[Master]", "samplerate")),
           m_sampleBuffer(nullptr),
           m_bIsPrimaryDeck(isPrimaryDeck),
+          m_active(false),
           m_bIsTalkoverChannel(isTalkoverChannel),
           m_channelIndex(-1) {
     m_pPFL = new ControlPushButton(ConfigKey(getGroup(), "pfl"));

--- a/src/engine/channels/enginechannel.h
+++ b/src/engine/channels/enginechannel.h
@@ -21,6 +21,12 @@ class EngineChannel : public EngineObject {
         RIGHT,
     };
 
+    enum class ActiveState {
+        Inactive = 0,
+        Active,
+        WasActive
+    };
+
     EngineChannel(const ChannelHandleAndGroup& handleGroup,
             ChannelOrientation defaultOrientation,
             EffectsManager* pEffectsManager,
@@ -38,7 +44,11 @@ class EngineChannel : public EngineObject {
         return m_group.name();
     }
 
-    virtual bool isActive() = 0;
+    virtual ActiveState updateActiveState() = 0;
+    bool isActive() {
+        return m_active;
+    }
+
     void setPfl(bool enabled);
     virtual bool isPflEnabled() const;
     void setMaster(bool enabled);
@@ -76,6 +86,7 @@ class EngineChannel : public EngineObject {
     // If set to true, this engine channel represents one of the primary playback decks.
     // It is used to check for valid bpm targets by the sync code.
     const bool m_bIsPrimaryDeck;
+    bool m_active;
 
   private slots:
     void slotOrientationLeft(double v);

--- a/src/engine/channels/enginedeck.cpp
+++ b/src/engine/channels/enginedeck.cpp
@@ -22,10 +22,7 @@ EngineDeck::EngineDeck(
                   primaryDeck),
           m_pConfig(pConfig),
           m_pInputConfigured(new ControlObject(ConfigKey(getGroup(), "input_configured"))),
-          m_pPassing(new ControlPushButton(ConfigKey(getGroup(), "passthrough"))),
-          // Need a +1 here because the CircularBuffer only allows its size-1
-          // items to be held at once (it keeps a blank spot open persistently)
-          m_wasActive(false) {
+          m_pPassing(new ControlPushButton(ConfigKey(getGroup(), "passthrough"))) {
     m_pInputConfigured->setReadOnly();
     // Set up passthrough utilities and fields
     m_pPassing->setButtonMode(ControlPushButton::POWERWINDOW);
@@ -101,7 +98,7 @@ EngineBuffer* EngineDeck::getEngineBuffer() {
     return m_pBuffer;
 }
 
-bool EngineDeck::isActive() {
+EngineChannel::ActiveState EngineDeck::updateActiveState() {
     bool active = false;
     if (m_bPassthroughWasActive && !m_bPassthroughIsActive) {
         active = true;
@@ -109,11 +106,16 @@ bool EngineDeck::isActive() {
         active = m_pBuffer->isTrackLoaded() || isPassthroughActive();
     }
 
-    if (!active && m_wasActive) {
-        m_vuMeter.reset();
+    if (active) {
+        m_active = true;
+        return ActiveState::Active;
     }
-    m_wasActive = active;
-    return active;
+    if (m_active) {
+        m_vuMeter.reset();
+        m_active = false;
+        return ActiveState::WasActive;
+    }
+    return ActiveState::Inactive;
 }
 
 void EngineDeck::receiveBuffer(

--- a/src/engine/channels/enginedeck.h
+++ b/src/engine/channels/enginedeck.h
@@ -38,7 +38,7 @@ class EngineDeck : public EngineChannel, public AudioDestination {
     // TODO(XXX) This hack needs to be removed.
     virtual EngineBuffer* getEngineBuffer();
 
-    virtual bool isActive();
+    EngineChannel::ActiveState updateActiveState() override;
 
     // This is called by SoundManager whenever there are new samples from the
     // configured input to be processed. This is run in the callback thread of
@@ -77,5 +77,4 @@ class EngineDeck : public EngineChannel, public AudioDestination {
     ControlPushButton* m_pPassing;
     bool m_bPassthroughIsActive;
     bool m_bPassthroughWasActive;
-    bool m_wasActive;
 };

--- a/src/engine/channels/enginemicrophone.cpp
+++ b/src/engine/channels/enginemicrophone.cpp
@@ -16,8 +16,7 @@ EngineMicrophone::EngineMicrophone(const ChannelHandleAndGroup& handleGroup,
                   /*isTalkoverChannel*/ true,
                   /*isPrimaryDeck*/ false),
           m_pInputConfigured(new ControlObject(ConfigKey(getGroup(), "input_configured"))),
-          m_pPregain(new ControlAudioTaperPot(ConfigKey(getGroup(), "pregain"), -12, 12, 0.5)),
-          m_wasActive(false) {
+          m_pPregain(new ControlAudioTaperPot(ConfigKey(getGroup(), "pregain"), -12, 12, 0.5)) {
     // Make input_configured read-only.
     m_pInputConfigured->setReadOnly();
     ControlDoublePrivate::insertAlias(ConfigKey(getGroup(), "enabled"),
@@ -30,15 +29,18 @@ EngineMicrophone::~EngineMicrophone() {
     delete m_pPregain;
 }
 
-bool EngineMicrophone::isActive() {
+EngineChannel::ActiveState EngineMicrophone::updateActiveState() {
     bool enabled = m_pInputConfigured->toBool();
     if (enabled && m_sampleBuffer) {
-        m_wasActive = true;
-    } else if (m_wasActive) {
-        m_vuMeter.reset();
-        m_wasActive = false;
+        m_active = true;
+        return ActiveState::Active;
     }
-    return m_wasActive;
+    if (m_active) {
+        m_vuMeter.reset();
+        m_active = false;
+        return ActiveState::WasActive;
+    }
+    return ActiveState::Inactive;
 }
 
 void EngineMicrophone::onInputConfigured(const AudioInput& input) {

--- a/src/engine/channels/enginemicrophone.h
+++ b/src/engine/channels/enginemicrophone.h
@@ -22,7 +22,7 @@ class EngineMicrophone : public EngineChannel, public AudioDestination {
             EffectsManager* pEffectsManager);
     virtual ~EngineMicrophone();
 
-    bool isActive();
+    ActiveState updateActiveState();
 
     // Called by EngineMaster whenever is requesting a new buffer of audio.
     virtual void process(CSAMPLE* pOutput, const int iBufferSize);
@@ -52,6 +52,4 @@ class EngineMicrophone : public EngineChannel, public AudioDestination {
   private:
     QScopedPointer<ControlObject> m_pInputConfigured;
     ControlAudioTaperPot* m_pPregain;
-
-    bool m_wasActive;
 };

--- a/src/engine/effects/engineeffect.cpp
+++ b/src/engine/effects/engineeffect.cpp
@@ -46,24 +46,16 @@ EngineEffect::~EngineEffect() {
     m_parameters.clear();
 }
 
-EffectState* EngineEffect::createState(const mixxx::EngineParameters& engineParameters) {
-    VERIFY_OR_DEBUG_ASSERT(m_pProcessor) {
-        return new EffectState(engineParameters);
+void EngineEffect::initalizeInputChannel(ChannelHandle inputChannel) {
+    if (m_pProcessor->hasStatesForInputChannel(inputChannel)) {
+        // already initialized for this input channel
     }
-    return m_pProcessor->createState(engineParameters);
-}
 
-void EngineEffect::loadStatesForInputChannel(ChannelHandle inputChannel,
-        EffectStatesMap* pStatesMap) {
-    if (kEffectDebugOutput) {
-        qDebug() << "EngineEffect::loadStatesForInputChannel" << this
-                 << "loading states for input" << inputChannel;
-    }
-    m_pProcessor->loadStatesForInputChannel(inputChannel, pStatesMap);
-}
-
-void EngineEffect::deleteStatesForInputChannel(ChannelHandle inputChannel) {
-    m_pProcessor->deleteStatesForInputChannel(inputChannel);
+    //TODO: get actual configuration of engine
+    const mixxx::EngineParameters engineParameters(
+            mixxx::audio::SampleRate(96000),
+            MAX_BUFFER_LEN / mixxx::kEngineChannelCount);
+    m_pProcessor->initializeInputChannel(inputChannel, engineParameters);
 }
 
 bool EngineEffect::processEffectsRequest(EffectsRequest& message,

--- a/src/engine/effects/engineeffect.h
+++ b/src/engine/effects/engineeffect.h
@@ -31,14 +31,8 @@ class EngineEffect final : public EffectsRequestHandler {
     /// Called in main thread by EffectSlot
     ~EngineEffect();
 
-    /// Called in main thread to allocate an EffectState
-    EffectState* createState(const mixxx::EngineParameters& engineParameters);
-
-    /// Called in audio thread to load EffectStates received from the main thread
-    void loadStatesForInputChannel(ChannelHandle inputChannel,
-            EffectStatesMap* pStatesMap);
-    /// Called from the main thread for garbage collection after an input channel is disabled
-    void deleteStatesForInputChannel(ChannelHandle inputChannel);
+    /// Called from the main thread to make sure that the channel already has states
+    void initalizeInputChannel(ChannelHandle inputChannel);
 
     /// Called in audio thread
     bool processEffectsRequest(

--- a/src/engine/effects/engineeffectchain.cpp
+++ b/src/engine/effects/engineeffectchain.cpp
@@ -342,11 +342,10 @@ bool EngineEffectChain::process(const ChannelHandle& inputHandle,
     // enabling/disabling state, set the channel state or chain state
     // to the fully enabled/disabled state for the next engine callback.
 
-    EffectEnableState& chainOnChannelEnableState = channelStatus.enableState;
-    if (chainOnChannelEnableState == EffectEnableState::Disabling) {
-        chainOnChannelEnableState = EffectEnableState::Disabled;
-    } else if (chainOnChannelEnableState == EffectEnableState::Enabling) {
-        chainOnChannelEnableState = EffectEnableState::Enabled;
+    if (channelStatus.enableState == EffectEnableState::Disabling) {
+        channelStatus.enableState = EffectEnableState::Disabled;
+    } else if (channelStatus.enableState == EffectEnableState::Enabling) {
+        channelStatus.enableState = EffectEnableState::Enabled;
     }
 
     if (m_enableState == EffectEnableState::Disabling) {

--- a/src/engine/effects/engineeffectchain.cpp
+++ b/src/engine/effects/engineeffectchain.cpp
@@ -220,13 +220,6 @@ void EngineEffectChain::deleteStatesForInputChannel(const ChannelHandle inputCha
     }
 }
 
-EngineEffectChain::ChannelStatus& EngineEffectChain::getChannelStatus(
-        const ChannelHandle& inputHandle,
-        const ChannelHandle& outputHandle) {
-    ChannelStatus& status = m_chainStatusForChannelMatrix[inputHandle][outputHandle];
-    return status;
-}
-
 bool EngineEffectChain::process(const ChannelHandle& inputHandle,
         const ChannelHandle& outputHandle,
         CSAMPLE* pIn,

--- a/src/engine/effects/engineeffectchain.cpp
+++ b/src/engine/effects/engineeffectchain.cpp
@@ -183,7 +183,14 @@ bool EngineEffectChain::enableForInputChannel(ChannelHandle inputHandle,
 bool EngineEffectChain::disableForInputChannel(ChannelHandle inputHandle) {
     auto& outputMap = m_chainStatusForChannelMatrix[inputHandle];
     for (auto&& outputChannelStatus : outputMap) {
-        if (outputChannelStatus.enableState != EffectEnableState::Disabled) {
+        qDebug() << "EngineEffectChain::disableForInputChannel" << inputHandle
+                 << &outputChannelStatus
+                 << (int)outputChannelStatus.enableState;
+        if (outputChannelStatus.enableState == EffectEnableState::Enabling) {
+            // Channel has never been processed and can be disabled immediately
+            outputChannelStatus.enableState = EffectEnableState::Disabled;
+        } else if (outputChannelStatus.enableState == EffectEnableState::Enabled) {
+            // Channel was enabled, fade effect out via Disabling state
             outputChannelStatus.enableState = EffectEnableState::Disabling;
         }
     }
@@ -211,7 +218,10 @@ void EngineEffectChain::deleteStatesForInputChannel(const ChannelHandle inputCha
     // enableForInputChannel(), or disableForInputChannel().
     auto& outputMap = m_chainStatusForChannelMatrix[inputChannel];
     for (auto&& outputChannelStatus : outputMap) {
-        outputChannelStatus.enableState = EffectEnableState::Disabled;
+        qDebug() << "EngineEffectChain::deleteStatesForInputChannel"
+                 << inputChannel << &outputChannelStatus
+                 << (int)outputChannelStatus.enableState;
+        //DEBUG_ASSERT(outputChannelStatus.enableState == EffectEnableState::Disabled);
     }
     for (EngineEffect* pEffect : qAsConst(m_effects)) {
         if (pEffect != nullptr) {

--- a/src/engine/effects/engineeffectchain.h
+++ b/src/engine/effects/engineeffectchain.h
@@ -45,9 +45,6 @@ class EngineEffectChain final : public EffectsRequestHandler {
             const GroupFeatureState& groupFeatures,
             bool fadeout);
 
-    /// called from main thread
-    void deleteStatesForInputChannel(const ChannelHandle channel);
-
   private:
     struct ChannelStatus {
         ChannelStatus()
@@ -65,8 +62,7 @@ class EngineEffectChain final : public EffectsRequestHandler {
     bool updateParameters(const EffectsRequest& message);
     bool addEffect(EngineEffect* pEffect, int iIndex);
     bool removeEffect(EngineEffect* pEffect, int iIndex);
-    bool enableForInputChannel(ChannelHandle inputHandle,
-            EffectStatesMapArray* statesForEffectsInChain);
+    bool enableForInputChannel(ChannelHandle inputHandle);
     bool disableForInputChannel(ChannelHandle inputHandle);
 
     QString m_group;

--- a/src/engine/effects/engineeffectchain.h
+++ b/src/engine/effects/engineeffectchain.h
@@ -42,7 +42,8 @@ class EngineEffectChain final : public EffectsRequestHandler {
             CSAMPLE* pOut,
             const unsigned int numSamples,
             const unsigned int sampleRate,
-            const GroupFeatureState& groupFeatures);
+            const GroupFeatureState& groupFeatures,
+            bool fadeout);
 
     /// called from main thread
     void deleteStatesForInputChannel(const ChannelHandle channel);

--- a/src/engine/effects/engineeffectchain.h
+++ b/src/engine/effects/engineeffectchain.h
@@ -68,11 +68,6 @@ class EngineEffectChain final : public EffectsRequestHandler {
             EffectStatesMapArray* statesForEffectsInChain);
     bool disableForInputChannel(ChannelHandle inputHandle);
 
-    // Gets or creates a ChannelStatus entry in m_channelStatus for the provided
-    // handle.
-    ChannelStatus& getChannelStatus(const ChannelHandle& inputHandle,
-            const ChannelHandle& outputHandle);
-
     QString m_group;
     EffectEnableState m_enableState;
     EffectChainMixMode::Type m_mixMode;

--- a/src/engine/effects/engineeffectsmanager.cpp
+++ b/src/engine/effects/engineeffectsmanager.cpp
@@ -97,8 +97,8 @@ void EngineEffectsManager::onCallbackStart() {
 void EngineEffectsManager::processPreFaderInPlace(const ChannelHandle& inputHandle,
         const ChannelHandle& outputHandle,
         CSAMPLE* pInOut,
-        const unsigned int numSamples,
-        const unsigned int sampleRate) {
+        unsigned int numSamples,
+        unsigned int sampleRate) {
     // Feature state is gathered after prefader effects processing.
     // This is okay because the equalizer effects do not make use of it.
     GroupFeatureState featureState;
@@ -116,11 +116,12 @@ void EngineEffectsManager::processPostFaderInPlace(
         const ChannelHandle& inputHandle,
         const ChannelHandle& outputHandle,
         CSAMPLE* pInOut,
-        const unsigned int numSamples,
-        const unsigned int sampleRate,
+        unsigned int numSamples,
+        unsigned int sampleRate,
         const GroupFeatureState& groupFeatures,
-        const CSAMPLE_GAIN oldGain,
-        const CSAMPLE_GAIN newGain) {
+        CSAMPLE_GAIN oldGain,
+        CSAMPLE_GAIN newGain,
+        bool fadeout) {
     processInner(SignalProcessingStage::Postfader,
             inputHandle,
             outputHandle,
@@ -130,7 +131,8 @@ void EngineEffectsManager::processPostFaderInPlace(
             sampleRate,
             groupFeatures,
             oldGain,
-            newGain);
+            newGain,
+            fadeout);
 }
 
 void EngineEffectsManager::processPostFaderAndMix(
@@ -138,11 +140,12 @@ void EngineEffectsManager::processPostFaderAndMix(
         const ChannelHandle& outputHandle,
         CSAMPLE* pIn,
         CSAMPLE* pOut,
-        const unsigned int numSamples,
-        const unsigned int sampleRate,
+        unsigned int numSamples,
+        unsigned int sampleRate,
         const GroupFeatureState& groupFeatures,
-        const CSAMPLE_GAIN oldGain,
-        const CSAMPLE_GAIN newGain) {
+        CSAMPLE_GAIN oldGain,
+        CSAMPLE_GAIN newGain,
+        bool fadeout) {
     processInner(SignalProcessingStage::Postfader,
             inputHandle,
             outputHandle,
@@ -152,7 +155,8 @@ void EngineEffectsManager::processPostFaderAndMix(
             sampleRate,
             groupFeatures,
             oldGain,
-            newGain);
+            newGain,
+            fadeout);
 }
 
 void EngineEffectsManager::processInner(
@@ -161,11 +165,12 @@ void EngineEffectsManager::processInner(
         const ChannelHandle& outputHandle,
         CSAMPLE* pIn,
         CSAMPLE* pOut,
-        const unsigned int numSamples,
-        const unsigned int sampleRate,
+        unsigned int numSamples,
+        unsigned int sampleRate,
         const GroupFeatureState& groupFeatures,
-        const CSAMPLE_GAIN oldGain,
-        const CSAMPLE_GAIN newGain) {
+        CSAMPLE_GAIN oldGain,
+        CSAMPLE_GAIN newGain,
+        bool fadeout) {
     const QList<EngineEffectChain*>& chains = m_chainsByStage.value(stage);
 
     if (pIn == pOut) {
@@ -180,7 +185,8 @@ void EngineEffectsManager::processInner(
                             pOut,
                             numSamples,
                             sampleRate,
-                            groupFeatures)) {
+                            groupFeatures,
+                            fadeout)) {
                 }
             }
         }
@@ -217,7 +223,8 @@ void EngineEffectsManager::processInner(
                             pIntermediateOutput,
                             numSamples,
                             sampleRate,
-                            groupFeatures)) {
+                            groupFeatures,
+                            fadeout)) {
                     // Output of this chain becomes the input of the next chain.
                     pIntermediateInput = pIntermediateOutput;
                 }

--- a/src/engine/effects/engineeffectsmanager.cpp
+++ b/src/engine/effects/engineeffectsmanager.cpp
@@ -45,7 +45,6 @@ void EngineEffectsManager::onCallbackStart() {
                 response.status = EffectsResponse::NO_SUCH_CHAIN;
                 break;
             }
-        }
             processed = request->pTargetChain->processEffectsRequest(
                     *request, m_pResponsePipe.data());
             if (processed) {
@@ -64,6 +63,7 @@ void EngineEffectsManager::onCallbackStart() {
                 response.status = EffectsResponse::INVALID_REQUEST;
             }
             break;
+        }
         case EffectsRequest::SET_EFFECT_PARAMETERS:
         case EffectsRequest::SET_PARAMETER_PARAMETERS:
             VERIFY_OR_DEBUG_ASSERT(m_effects.contains(request->pTargetEffect)) {

--- a/src/engine/effects/engineeffectsmanager.h
+++ b/src/engine/effects/engineeffectsmanager.h
@@ -33,8 +33,8 @@ class EngineEffectsManager final : public EffectsRequestHandler {
             const ChannelHandle& inputHandle,
             const ChannelHandle& outputHandle,
             CSAMPLE* pInOut,
-            const unsigned int numSamples,
-            const unsigned int sampleRate);
+            unsigned int numSamples,
+            unsigned int sampleRate);
 
     /// Process the postfader EngineEffectChains on the pInOut buffer, modifying
     /// the contents of the input buffer.
@@ -42,11 +42,12 @@ class EngineEffectsManager final : public EffectsRequestHandler {
             const ChannelHandle& inputHandle,
             const ChannelHandle& outputHandle,
             CSAMPLE* pInOut,
-            const unsigned int numSamples,
-            const unsigned int sampleRate,
+            unsigned int numSamples,
+            unsigned int sampleRate,
             const GroupFeatureState& groupFeatures,
-            const CSAMPLE_GAIN oldGain = CSAMPLE_GAIN_ONE,
-            const CSAMPLE_GAIN newGain = CSAMPLE_GAIN_ONE);
+            CSAMPLE_GAIN oldGain = CSAMPLE_GAIN_ONE,
+            CSAMPLE_GAIN newGain = CSAMPLE_GAIN_ONE,
+            bool fadeout = false);
 
     /// Process the postfader EngineEffectChains, leaving the pIn buffer unmodified
     /// and mixing the output into the pOut buffer. Using EngineEffectsManager's
@@ -58,11 +59,12 @@ class EngineEffectsManager final : public EffectsRequestHandler {
             const ChannelHandle& outputHandle,
             CSAMPLE* pIn,
             CSAMPLE* pOut,
-            const unsigned int numSamples,
-            const unsigned int sampleRate,
+            unsigned int numSamples,
+            unsigned int sampleRate,
             const GroupFeatureState& groupFeatures,
-            const CSAMPLE_GAIN oldGain = CSAMPLE_GAIN_ONE,
-            const CSAMPLE_GAIN newGain = CSAMPLE_GAIN_ONE);
+            CSAMPLE_GAIN oldGain = CSAMPLE_GAIN_ONE,
+            CSAMPLE_GAIN newGain = CSAMPLE_GAIN_ONE,
+            bool fadeout = false);
 
     bool processEffectsRequest(
             EffectsRequest& message,
@@ -88,11 +90,12 @@ class EngineEffectsManager final : public EffectsRequestHandler {
             const ChannelHandle& outputHandle,
             CSAMPLE* pIn,
             CSAMPLE* pOut,
-            const unsigned int numSamples,
-            const unsigned int sampleRate,
+            unsigned int numSamples,
+            unsigned int sampleRate,
             const GroupFeatureState& groupFeatures,
-            const CSAMPLE_GAIN oldGain = CSAMPLE_GAIN_ONE,
-            const CSAMPLE_GAIN newGain = CSAMPLE_GAIN_ONE);
+            CSAMPLE_GAIN oldGain = CSAMPLE_GAIN_ONE,
+            CSAMPLE_GAIN newGain = CSAMPLE_GAIN_ONE,
+            bool fadeout = false);
 
     QScopedPointer<EffectsResponsePipe> m_pResponsePipe;
     QHash<SignalProcessingStage, QList<EngineEffectChain*>> m_chainsByStage;

--- a/src/engine/effects/message.h
+++ b/src/engine/effects/message.h
@@ -44,20 +44,6 @@ struct EffectsRequest {
         pTargetEffect = nullptr;
     }
 
-    // This is called from the main thread by EffectsManager after receiving a
-    // response from EngineEffectsManager in the audio engine thread.
-    ~EffectsRequest() {
-        if (type == ENABLE_EFFECT_CHAIN_FOR_INPUT_CHANNEL) {
-            VERIFY_OR_DEBUG_ASSERT(EnableInputChannelForChain.pEffectStatesMapArray != nullptr) {
-                return;
-            }
-            // This only deletes the container used to passed the EffectStates
-            // to EffectProcessorImpl. The EffectStates are managed by
-            // EffectProcessorImpl.
-            delete EnableInputChannelForChain.pEffectStatesMapArray;
-        }
-    }
-
     MessageType type;
     qint64 request_id;
 
@@ -86,7 +72,6 @@ struct EffectsRequest {
             SignalProcessingStage signalProcessingStage;
         } RemoveEffectChain;
         struct {
-            EffectStatesMapArray* pEffectStatesMapArray;
             ChannelHandle channelHandle;
         } EnableInputChannelForChain;
         struct {

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1000,18 +1000,23 @@ void EngineBuffer::processTrackLocked(
         rate = m_rate_old;
     }
 
-    const mixxx::audio::FramePos trackEndPosition = getTrackEndPosition();
-    bool atEnd = m_playPosition >= trackEndPosition;
-    bool backwards = rate < 0;
-
     bool bCurBufferPaused = false;
-    if (atEnd && !backwards) {
-        // do not play past end
-        bCurBufferPaused = true;
-    } else if (rate == 0 && !is_scratching) {
-        // do not process samples if have no transport
-        // the linear scaler supports ramping down to 0
-        // this is used for pause by scratching only
+    bool atEnd = false;
+    bool backwards = rate < 0;
+    const mixxx::audio::FramePos trackEndPosition = getTrackEndPosition();
+    if (trackEndPosition.isValid()) {
+        atEnd = m_playPosition >= trackEndPosition;
+        if (atEnd && !backwards) {
+            // do not play past end
+            bCurBufferPaused = true;
+        } else if (rate == 0 && !is_scratching) {
+            // do not process samples if have no transport
+            // the linear scaler supports ramping down to 0
+            // this is used for pause by scratching only
+            bCurBufferPaused = true;
+        }
+    } else {
+        // Track has already been ejected.
         bCurBufferPaused = true;
     }
 
@@ -1072,12 +1077,10 @@ void EngineBuffer::processTrackLocked(
 
     // Handle repeat mode
     const bool atStart = m_playPosition <= mixxx::audio::kStartFramePos;
-    atEnd = m_playPosition >= trackEndPosition;
 
     bool repeat_enabled = m_pRepeat->toBool();
 
-    bool end_of_track = //(at_start && backwards) ||
-            (atEnd && !backwards);
+    bool end_of_track = atEnd && !backwards;
 
     // If playbutton is pressed, check if we are at start or end of track
     if ((m_playButton->toBool() || (m_fwdButton->toBool() || m_backButton->toBool()))

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -291,7 +291,17 @@ void EngineMaster::processChannels(int iBufferSize) {
         EngineChannel* pChannel = pChannelInfo->m_pChannel;
 
         // Skip inactive channels.
-        if (!pChannel || !pChannel->isActive()) {
+        VERIFY_OR_DEBUG_ASSERT(pChannel) {
+            continue;
+        }
+
+        EngineChannel::ActiveState activeState = pChannel->updateActiveState();
+        if (activeState == EngineChannel::ActiveState::Inactive) {
+            continue;
+        }
+
+        if (activeState == EngineChannel::ActiveState::WasActive) {
+            // TODO() Clean up effect buffers.
             continue;
         }
 

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -300,11 +300,6 @@ void EngineMaster::processChannels(int iBufferSize) {
             continue;
         }
 
-        if (activeState == EngineChannel::ActiveState::WasActive) {
-            // TODO() Clean up effect buffers.
-            continue;
-        }
-
         if (pChannel->isTalkoverEnabled() &&
                 !pChannelInfo->m_pMuteControl->toBool()) {
             // talkover is an exclusive channel

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -487,7 +487,10 @@ void EngineMaster::process(const int iBufferSize) {
                 m_pTalkover,
                 m_iBufferSize,
                 static_cast<int>(m_sampleRate.value()),
-                busFeatures);
+                busFeatures,
+                CSAMPLE_GAIN_ONE,
+                CSAMPLE_GAIN_ONE,
+                false);
     }
 
     switch (m_pTalkoverDucking->getMode()) {
@@ -542,21 +545,30 @@ void EngineMaster::process(const int iBufferSize) {
                 m_pOutputBusBuffers[EngineChannel::LEFT],
                 m_iBufferSize,
                 static_cast<int>(m_sampleRate.value()),
-                busFeatures);
+                busFeatures,
+                CSAMPLE_GAIN_ONE,
+                CSAMPLE_GAIN_ONE,
+                false);
         m_pEngineEffectsManager->processPostFaderInPlace(
                 m_busCrossfaderCenterHandle.handle(),
                 m_masterHandle.handle(),
                 m_pOutputBusBuffers[EngineChannel::CENTER],
                 m_iBufferSize,
                 static_cast<int>(m_sampleRate.value()),
-                busFeatures);
+                busFeatures,
+                CSAMPLE_GAIN_ONE,
+                CSAMPLE_GAIN_ONE,
+                false);
         m_pEngineEffectsManager->processPostFaderInPlace(
                 m_busCrossfaderRightHandle.handle(),
                 m_masterHandle.handle(),
                 m_pOutputBusBuffers[EngineChannel::RIGHT],
                 m_iBufferSize,
                 static_cast<int>(m_sampleRate.value()),
-                busFeatures);
+                busFeatures,
+                CSAMPLE_GAIN_ONE,
+                CSAMPLE_GAIN_ONE,
+                false);
     }
 
     if (masterEnabled) {
@@ -787,7 +799,10 @@ void EngineMaster::applyMasterEffects() {
                 m_pMaster,
                 m_iBufferSize,
                 static_cast<int>(m_sampleRate.value()),
-                masterFeatures);
+                masterFeatures,
+                CSAMPLE_GAIN_ONE,
+                CSAMPLE_GAIN_ONE,
+                false);
     }
 }
 

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -436,7 +436,7 @@ void PlayerManager::addDeckInner() {
             AudioInput(AudioInput::VINYLCONTROL, 0, 2, deckIndex), pEngineDeck);
 
     // Setup equalizer and QuickEffect chain for this deck.
-    m_pEffectsManager->addDeck(handleGroup.m_name);
+    m_pEffectsManager->addDeck(handleGroup);
 }
 
 void PlayerManager::loadSamplers() {

--- a/src/test/enginemastertest.cpp
+++ b/src/test/enginemastertest.cpp
@@ -30,6 +30,7 @@ class EngineChannelMock : public EngineChannel {
         Q_UNUSED(iBufferSize);
     }
 
+    MOCK_METHOD0(updateActiveState, ActiveState());
     MOCK_METHOD0(isActive, bool());
     MOCK_CONST_METHOD0(isMasterEnabled, bool());
     MOCK_CONST_METHOD0(isPflEnabled, bool());
@@ -64,9 +65,9 @@ TEST_F(EngineMasterTest, SingleChannelOutputWorks) {
     SampleUtil::fill(pChannelBuffer, 0.1f, MAX_BUFFER_LEN);
 
     // Instruct the mock to claim it is active, master and not PFL.
-    EXPECT_CALL(*pChannel, isActive())
+    EXPECT_CALL(*pChannel, updateActiveState())
             .Times(1)
-            .WillOnce(Return(true));
+            .WillOnce(Return(EngineChannel::ActiveState::Active));
     EXPECT_CALL(*pChannel, isMasterEnabled())
             .Times(1)
             .WillOnce(Return(true));
@@ -101,9 +102,9 @@ TEST_F(EngineMasterTest, SingleChannelPFLOutputWorks) {
     SampleUtil::fill(pChannelBuffer, 0.1f, MAX_BUFFER_LEN);
 
     // Instruct the mock to claim it is active, not master and PFL
-    EXPECT_CALL(*pChannel, isActive())
+    EXPECT_CALL(*pChannel, updateActiveState())
             .Times(1)
-            .WillOnce(Return(true));
+            .WillOnce(Return(EngineChannel::ActiveState::Active));
     EXPECT_CALL(*pChannel, isMasterEnabled())
             .Times(1)
             .WillOnce(Return(false));
@@ -144,9 +145,9 @@ TEST_F(EngineMasterTest, TwoChannelOutputWorks) {
     SampleUtil::fill(pChannel2Buffer, 0.2f, MAX_BUFFER_LEN);
 
     // Instruct channel 1 to claim it is active, master and not PFL.
-    EXPECT_CALL(*pChannel1, isActive())
+    EXPECT_CALL(*pChannel1, updateActiveState())
             .Times(1)
-            .WillOnce(Return(true));
+            .WillOnce(Return(EngineChannel::ActiveState::Active));
     EXPECT_CALL(*pChannel1, isMasterEnabled())
             .Times(1)
             .WillOnce(Return(true));
@@ -155,9 +156,9 @@ TEST_F(EngineMasterTest, TwoChannelOutputWorks) {
             .WillOnce(Return(false));
 
     // Instruct channel 2 to claim it is active, master and not PFL.
-    EXPECT_CALL(*pChannel2, isActive())
+    EXPECT_CALL(*pChannel2, updateActiveState())
             .Times(1)
-            .WillOnce(Return(true));
+            .WillOnce(Return(EngineChannel::ActiveState::Active));
     EXPECT_CALL(*pChannel2, isMasterEnabled())
             .Times(1)
             .WillOnce(Return(true));
@@ -201,9 +202,9 @@ TEST_F(EngineMasterTest, TwoChannelPFLOutputWorks) {
     SampleUtil::fill(pChannel2Buffer, 0.2f, MAX_BUFFER_LEN);
 
     // Instruct channel 1 to claim it is active, master and PFL.
-    EXPECT_CALL(*pChannel1, isActive())
+    EXPECT_CALL(*pChannel1, updateActiveState())
             .Times(1)
-            .WillOnce(Return(true));
+            .WillOnce(Return(EngineChannel::ActiveState::Active));
     EXPECT_CALL(*pChannel1, isMasterEnabled())
             .Times(1)
             .WillOnce(Return(true));
@@ -212,9 +213,9 @@ TEST_F(EngineMasterTest, TwoChannelPFLOutputWorks) {
             .WillOnce(Return(true));
 
     // Instruct channel 2 to claim it is active, master and PFL.
-    EXPECT_CALL(*pChannel2, isActive())
+    EXPECT_CALL(*pChannel2, updateActiveState())
             .Times(1)
-            .WillOnce(Return(true));
+            .WillOnce(Return(EngineChannel::ActiveState::Active));
     EXPECT_CALL(*pChannel2, isMasterEnabled())
             .Times(1)
             .WillOnce(Return(true));
@@ -263,9 +264,9 @@ TEST_F(EngineMasterTest, ThreeChannelOutputWorks) {
     SampleUtil::fill(pChannel3Buffer, 0.3f, MAX_BUFFER_LEN);
 
     // Instruct channel 1 to claim it is active, master and not PFL.
-    EXPECT_CALL(*pChannel1, isActive())
+    EXPECT_CALL(*pChannel1, updateActiveState())
             .Times(1)
-            .WillOnce(Return(true));
+            .WillOnce(Return(EngineChannel::ActiveState::Active));
     EXPECT_CALL(*pChannel1, isMasterEnabled())
             .Times(1)
             .WillOnce(Return(true));
@@ -274,9 +275,9 @@ TEST_F(EngineMasterTest, ThreeChannelOutputWorks) {
             .WillOnce(Return(false));
 
     // Instruct channel 2 to claim it is active, master and not PFL.
-    EXPECT_CALL(*pChannel2, isActive())
+    EXPECT_CALL(*pChannel2, updateActiveState())
             .Times(1)
-            .WillOnce(Return(true));
+            .WillOnce(Return(EngineChannel::ActiveState::Active));
     EXPECT_CALL(*pChannel2, isMasterEnabled())
             .Times(1)
             .WillOnce(Return(true));
@@ -285,9 +286,9 @@ TEST_F(EngineMasterTest, ThreeChannelOutputWorks) {
             .WillOnce(Return(false));
 
     // Instruct channel 3 to claim it is active, master and not PFL.
-    EXPECT_CALL(*pChannel3, isActive())
+    EXPECT_CALL(*pChannel3, updateActiveState())
             .Times(1)
-            .WillOnce(Return(true));
+            .WillOnce(Return(EngineChannel::ActiveState::Active));
     EXPECT_CALL(*pChannel3, isMasterEnabled())
             .Times(1)
             .WillOnce(Return(true));
@@ -339,9 +340,9 @@ TEST_F(EngineMasterTest, ThreeChannelPFLOutputWorks) {
     SampleUtil::fill(pChannel3Buffer, 0.3f, MAX_BUFFER_LEN);
 
     // Instruct channel 1 to claim it is active, master and not PFL.
-    EXPECT_CALL(*pChannel1, isActive())
+    EXPECT_CALL(*pChannel1, updateActiveState())
             .Times(1)
-            .WillOnce(Return(true));
+            .WillOnce(Return(EngineChannel::ActiveState::Active));
     EXPECT_CALL(*pChannel1, isMasterEnabled())
             .Times(1)
             .WillOnce(Return(true));
@@ -350,9 +351,9 @@ TEST_F(EngineMasterTest, ThreeChannelPFLOutputWorks) {
             .WillOnce(Return(true));
 
     // Instruct channel 2 to claim it is active, master and not PFL.
-    EXPECT_CALL(*pChannel2, isActive())
+    EXPECT_CALL(*pChannel2, updateActiveState())
             .Times(1)
-            .WillOnce(Return(true));
+            .WillOnce(Return(EngineChannel::ActiveState::Active));
     EXPECT_CALL(*pChannel2, isMasterEnabled())
             .Times(1)
             .WillOnce(Return(true));
@@ -361,9 +362,9 @@ TEST_F(EngineMasterTest, ThreeChannelPFLOutputWorks) {
             .WillOnce(Return(true));
 
     // Instruct channel 3 to claim it is active, master and not PFL.
-    EXPECT_CALL(*pChannel3, isActive())
+    EXPECT_CALL(*pChannel3, updateActiveState())
             .Times(1)
-            .WillOnce(Return(true));
+            .WillOnce(Return(EngineChannel::ActiveState::Active));
     EXPECT_CALL(*pChannel3, isMasterEnabled())
             .Times(1)
             .WillOnce(Return(true));

--- a/src/widget/weffectpushbutton.cpp
+++ b/src/widget/weffectpushbutton.cpp
@@ -22,6 +22,10 @@ void WEffectPushButton::setup(const QDomNode& node, const SkinContext& context) 
     auto pEffectSlot = EffectWidgetUtils::getEffectSlotFromNode(node, context, pChainSlot);
     m_pEffectParameterSlot = EffectWidgetUtils::getButtonParameterSlotFromNode(
             node, context, pEffectSlot);
+    if (!m_pEffectParameterSlot) {
+        SKIN_WARNING(node, context) << "Could not find effect parameter slot";
+        DEBUG_ASSERT(false);
+    }
     connect(m_pEffectParameterSlot.data(),
             &EffectParameterSlotBase::updated,
             this,
@@ -33,9 +37,6 @@ void WEffectPushButton::setup(const QDomNode& node, const SkinContext& context) 
             this,
             &WEffectPushButton::slotActionChosen);
     parameterUpdated();
-    VERIFY_OR_DEBUG_ASSERT(m_pEffectParameterSlot) {
-        SKIN_WARNING(node, context) << "Could not find effect parameter slot";
-    }
 }
 
 void WEffectPushButton::onConnectedControlChanged(double dParameter, double dValue) {


### PR DESCRIPTION
I have experienced a crasher during testing of https://github.com/mixxxdj/mixxx/pull/2618

Probably related: 
https://bugs.launchpad.net/mixxx/+bug/1775497

Here is the log, unfortunately it has not happen to me under GDB. 

```
QML debugging is enabled. Only use this in a safe environment.
Loading resources from  "/home/daniel/workspace/2.3/res/"
Configuration file is at version "2.3.0-beta" instead of the current "2.4.0-alpha-pre"
BroadcastSettings - Found 1 profile(s)
Loading resources from  "/home/daniel/workspace/2.3/res/"
Found and will use default keyboard mapping "/home/daniel/workspace/2.3/res/keyboard/en_US.kbd.cfg"
Loading resources from  "/home/daniel/workspace/2.3/res/"
Loaded skin "Shade"
DBus screensaver  org.freedesktop.ScreenSaver  inhibited
ALSA lib pcm.c:2642:(snd_pcm_open_noupdate) Unknown PCM cards.pcm.rear
ALSA lib pcm.c:2642:(snd_pcm_open_noupdate) Unknown PCM cards.pcm.center_lfe
ALSA lib pcm.c:2642:(snd_pcm_open_noupdate) Unknown PCM cards.pcm.side
ALSA lib pcm_route.c:869:(find_matching_chmap) Found no matching channel map
ALSA lib pcm_route.c:869:(find_matching_chmap) Found no matching channel map
ALSA lib pcm_route.c:869:(find_matching_chmap) Found no matching channel map
ALSA lib pcm_route.c:869:(find_matching_chmap) Found no matching channel map
Cannot connect to server socket err = Datei oder Verzeichnis nicht gefunden
Cannot connect to server request channel
jack server is not running or cannot be started
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for -1, skipping unlock
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for -1, skipping unlock
Cannot connect to server socket err = Datei oder Verzeichnis nicht gefunden
Cannot connect to server request channel
jack server is not running or cannot be started
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for -1, skipping unlock
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for -1, skipping unlock
ALSA lib pcm_oss.c:377:(_snd_pcm_oss_open) Unknown field port
ALSA lib pcm_oss.c:377:(_snd_pcm_oss_open) Unknown field port
ALSA lib pcm_usb_stream.c:486:(_snd_pcm_usb_stream_open) Invalid type for card
ALSA lib pcm_usb_stream.c:486:(_snd_pcm_usb_stream_open) Invalid type for card
Cannot connect to server socket err = Datei oder Verzeichnis nicht gefunden
Cannot connect to server request channel
jack server is not running or cannot be started
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for -1, skipping unlock
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for -1, skipping unlock
warning [Main] Library - Skipping access check for missing or invalid directory QFileInfo(/home/daniel/Öffen)
warning [BrowseThread] MetadataSourceTagLib - Cannot import track metadata from file "/home/daniel/Musik/Mixxx/Recordings/2021-03-16_15h27m08s.aac" with unknown or unsupported type 0
warning [BrowseThread] MetadataSourceTagLib - Cannot import track metadata from file "/home/daniel/Musik/Mixxx/Recordings/2021-03-16_15h26m32s.aac" with unknown or unsupported type 0
warning [BrowseThread] MetadataSourceTagLib - Cannot import track metadata from file "/home/daniel/Musik/Mixxx/Recordings/2021-03-16_15h26m02s.aac" with unknown or unsupported type 0
warning [Main] ControlDoublePrivate::getControl returning NULL for ( "[Master]" , "skin_settings" )
Abgebrochen (Speicherabzug geschrieben)
```