### PR TITLE
DlgAutoDJ: use setFocus() instead of keypress emulation

### DIFF
--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -167,7 +167,8 @@ DlgAutoDJ::DlgAutoDJ(WLibrary* parent,
     connect(lineEditTransition,
             &QLineEdit::returnPressed,
             this,
-            &DlgAutoDJ::shiftTabKeypress);
+            // Move focus to tracks table to immediately allow keyboard shortcuts again.
+            &DlgAutoDJ::setFocus);
 
     connect(spinBoxTransition,
             QOverload<int>::of(&QSpinBox::valueChanged),
@@ -341,7 +342,8 @@ void DlgAutoDJ::slotTransitionModeChanged(int newIndex) {
     m_pAutoDJProcessor->setTransitionMode(
             static_cast<AutoDJProcessor::TransitionMode>(
                     fadeModeCombobox->itemData(newIndex).toInt()));
-    shiftTabKeypress();
+    // Move focus to tracks table to immediately allow keyboard shortcuts again.
+    setFocus();
 }
 
 void DlgAutoDJ::slotRepeatPlaylistChanged(int checkState) {
@@ -378,15 +380,6 @@ void DlgAutoDJ::updateSelectionInfo() {
 
 bool DlgAutoDJ::hasFocus() const {
     return m_pTrackTableView->hasFocus();
-}
-
-void DlgAutoDJ::shiftTabKeypress() {
-    // After selecting a mode or editing the transition time, send Shift+Tab
-    // to move focus to the next keyboard-focusable widget (tracks table in
-    // official skins) in order to immediately allow keyboard shortcuts again.
-    QKeyEvent backwardFocusKeyEvent =
-            QKeyEvent{QEvent::KeyPress, Qt::Key_Tab, Qt::ShiftModifier};
-    QApplication::sendEvent(this, &backwardFocusKeyEvent);
 }
 
 void DlgAutoDJ::setFocus() {

--- a/src/library/autodj/dlgautodj.h
+++ b/src/library/autodj/dlgautodj.h
@@ -57,7 +57,6 @@ class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
     void setupActionButton(QPushButton* pButton,
             void (DlgAutoDJ::*pSlot)(bool),
             const QString& fallbackText);
-    void shiftTabKeypress();
 
     const UserSettingsPointer m_pConfig;
 


### PR DESCRIPTION
fixup for #4369: to focus Auto DJ table, use `setFocus()` instead of emulated keypresses