### PR TITLE
Beatloop: add control to start beatloop while keeping start point.

### DIFF
--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -131,6 +131,10 @@ LoopingControl::LoopingControl(const QString& group,
     connect(m_pCOBeatLoop, &ControlObject::valueChanged, this,
             [=](double value){slotBeatLoop(value);}, Qt::DirectConnection);
 
+    m_pCOBeatLoopKeepLoopIn = new ControlObject(ConfigKey(group, "beatloop_keep_loopin"), false);
+    connect(m_pCOBeatLoopKeepLoopIn, &ControlObject::valueChanged, this,
+            [=](double value){slotBeatLoop(value, true);}, Qt::DirectConnection);
+
     m_pCOBeatLoopSize = new ControlObject(ConfigKey(group, "beatloop_size"),
                                           true, false, false, 4.0);
     m_pCOBeatLoopSize->connectValueChangeRequest(this,
@@ -239,6 +243,7 @@ LoopingControl::~LoopingControl() {
     delete m_pLoopDoubleButton;
 
     delete m_pCOBeatLoop;
+    delete m_pCOBeatLoopKeepLoopIn;
     while (!m_beatLoops.isEmpty()) {
         BeatLoopingControl* pBeatLoop = m_beatLoops.takeLast();
         delete pBeatLoop;

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -131,10 +131,6 @@ LoopingControl::LoopingControl(const QString& group,
     connect(m_pCOBeatLoop, &ControlObject::valueChanged, this,
             [=](double value){slotBeatLoop(value);}, Qt::DirectConnection);
 
-    m_pCOBeatLoopKeepLoopIn = new ControlObject(ConfigKey(group, "beatloop_keep_loopin"), false);
-    connect(m_pCOBeatLoopKeepLoopIn, &ControlObject::valueChanged, this,
-            [=](double value){slotBeatLoop(value, true);}, Qt::DirectConnection);
-
     m_pCOBeatLoopSize = new ControlObject(ConfigKey(group, "beatloop_size"),
                                           true, false, false, 4.0);
     m_pCOBeatLoopSize->connectValueChangeRequest(this,
@@ -142,6 +138,11 @@ LoopingControl::LoopingControl(const QString& group,
     m_pCOBeatLoopActivate = new ControlPushButton(ConfigKey(group, "beatloop_activate"));
     connect(m_pCOBeatLoopActivate, &ControlObject::valueChanged,
             this, &LoopingControl::slotBeatLoopToggle);
+    m_pCOBeatLoopKeepLoopIn = new ControlPushButton(ConfigKey(group, "beatloop_keep_loopin"));
+    connect(m_pCOBeatLoopKeepLoopIn,
+            &ControlObject::valueChanged,
+            this,
+            &LoopingControl::slotBeatLoopKeepLoopIn);
     m_pCOBeatLoopRollActivate = new ControlPushButton(ConfigKey(group, "beatlooproll_activate"));
     connect(m_pCOBeatLoopRollActivate, &ControlObject::valueChanged,
             this, &LoopingControl::slotBeatLoopRollActivate);
@@ -1407,6 +1408,12 @@ void LoopingControl::slotBeatLoopSizeChangeRequest(double beats) {
 void LoopingControl::slotBeatLoopToggle(double pressed) {
     if (pressed > 0) {
         slotBeatLoop(m_pCOBeatLoopSize->get());
+    }
+}
+
+void LoopingControl::slotBeatLoopKeepLoopIn(double pressed) {
+    if (pressed > 0) {
+        slotBeatLoop(m_pCOBeatLoopSize->get(), true);
     }
 }
 

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -138,7 +138,7 @@ LoopingControl::LoopingControl(const QString& group,
     m_pCOBeatLoopActivate = new ControlPushButton(ConfigKey(group, "beatloop_activate"));
     connect(m_pCOBeatLoopActivate, &ControlObject::valueChanged,
             this, &LoopingControl::slotBeatLoopToggle);
-    m_pCOBeatLoopKeepLoopIn = new ControlPushButton(ConfigKey(group, "beatloop_keep_loopin"));
+    m_pCOBeatLoopKeepLoopIn = new ControlPushButton(ConfigKey(group, "beatloop_keep_loop_in"));
     connect(m_pCOBeatLoopKeepLoopIn,
             &ControlObject::valueChanged,
             this,

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -79,6 +79,7 @@ class LoopingControl : public EngineControl {
     void slotBeatLoop(double loopSize, bool keepStartPoint=false, bool enable=true);
     void slotBeatLoopSizeChangeRequest(double beats);
     void slotBeatLoopToggle(double pressed);
+    void slotBeatLoopKeepLoopIn(double pressed);
     void slotBeatLoopRollActivate(double pressed);
     void slotBeatLoopActivate(BeatLoopingControl* pBeatLoopControl);
     void slotBeatLoopActivateRoll(BeatLoopingControl* pBeatLoopControl);

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -178,6 +178,7 @@ class LoopingControl : public EngineControl {
 
     // Base BeatLoop Control Object.
     ControlObject* m_pCOBeatLoop;
+    ControlObject* m_pCOBeatLoopKeepLoopIn;
     ControlObject* m_pCOBeatLoopSize;
     // Different sizes for Beat Loops/Seeks.
     static double s_dBeatSizes[];


### PR DESCRIPTION
Current controller scripts have no option to enable a beatloop without simultaneously setting the loop-in point to the current playback position. This PR adds a control to start a beatloop, keeping a previously set loop-in position. This is especially useful for implementing a more accurate mapping of controllers like the DDJ-400. A long-press of the loop-in button emits another midi signal which is intended for setting up an instant 4-beat loop.