### PR TITLE
.pre-commit-config.yaml: disallow commiting to version branches

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,8 @@ repos:
     - commit
     - manual
   - id: no-commit-to-branch
+    # protect main and any branch that has a semver-like name
+    args: [-b, main, -p, '^\d+\.\d+(?:\.\d+)?$']
 - repo: https://github.com/codespell-project/codespell
   rev: v2.1.0
   hooks:


### PR DESCRIPTION
before this commit, it was possible to accidentally commit to
the stable version branches (such as 2.3). If this was done
by a member with push access, they could push untested commits
into production on accident. If this was done by a git newbie,
they would mess up their local branch and deal with conflicts
when pulling their branch later. If commiting to the branch
is justified, the check can be bypassed by
`SKIP=no-commit-to-branch git commit`