### PR TITLE
midi-components-0.0.js: Pot support for arbitrary maximums in 7-/14-bit handlers

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -467,9 +467,19 @@
             // For the first messages, disregard the LSB in case
             // the first LSB is received after the first MSB.
             if (this.MSB === undefined) {
-                this.max = 127;
+                // a flaw in the Pot API does not mandate consumers
+                // to supply an accurate max value when using
+                // this with non-7-bit inputs. We cannot detect
+                // that in the constructor so set the max
+                // appropriately here
+                if (this.max === Component.prototype.max) {
+                    this.max = (1 << 14) - 1;
+                }
+                var maxSaved = this.max;
+                // maximum value of MSB
+                this.max = this.max >> 7;
                 this.input(channel, control, value, status, group);
-                this.max = 16383;
+                this.max = maxSaved;
             }
             this.MSB = value;
         },

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -475,11 +475,8 @@
                 if (this.max === Component.prototype.max) {
                     this.max = (1 << 14) - 1;
                 }
-                var maxSaved = this.max;
-                // maximum value of MSB
-                this.max = this.max >> 7;
+                value = (value << 7) + (this._firstLSB ? this._firstLSB : 0);
                 this.input(channel, control, value, status, group);
-                this.max = maxSaved;
             }
             this.MSB = value;
         },
@@ -487,6 +484,8 @@
             // Make sure the first MSB has been received
             if (this.MSB !== undefined) {
                 this.input(channel, control, value, status, group);
+            } else {
+                this._firstLSB = value;
             }
         },
         connect: function() {


### PR DESCRIPTION
previously, it was not possible for 14-bit controls to have maxima
that are not (2^14)-1. Some controller might only have 3-bits of
resolution in their MSB. This commit allows for arbitrary precision
in MSB and LSB by specifying an appropriate value as the components
max property.