### PR TITLE
Fixed invalid CMakeSettings.json generation

### DIFF
--- a/tools/windows_buildenv.bat
+++ b/tools/windows_buildenv.bat
@@ -88,7 +88,7 @@ EXIT /B 0
 
     SET "VCPKG_ROOT=!BUILDENV_PATH!"
     SET "CMAKE_GENERATOR=Ninja"
-    SET CMAKE_PREFIX_PATH=!BUILDENV_PATH!\installed\x64-windows
+    SET "CMAKE_PREFIX_PATH=!BUILDENV_PATH!\installed\x64-windows"
 
     ECHO ^Environment Variables:
     ECHO ^- VCPKG_ROOT='!VCPKG_ROOT!'

--- a/tools/windows_buildenv.bat
+++ b/tools/windows_buildenv.bat
@@ -88,6 +88,7 @@ EXIT /B 0
 
     SET "VCPKG_ROOT=!BUILDENV_PATH!"
     SET "CMAKE_GENERATOR=Ninja"
+	SET CMAKE_PREFIX_PATH=!BUILDENV_PATH!\installed\x64-windows
 
     ECHO ^Environment Variables:
     ECHO ^- VCPKG_ROOT='!VCPKG_ROOT!'

--- a/tools/windows_buildenv.bat
+++ b/tools/windows_buildenv.bat
@@ -88,7 +88,7 @@ EXIT /B 0
 
     SET "VCPKG_ROOT=!BUILDENV_PATH!"
     SET "CMAKE_GENERATOR=Ninja"
-	SET CMAKE_PREFIX_PATH=!BUILDENV_PATH!\installed\x64-windows
+    SET CMAKE_PREFIX_PATH=!BUILDENV_PATH!\installed\x64-windows
 
     ECHO ^Environment Variables:
     ECHO ^- VCPKG_ROOT='!VCPKG_ROOT!'


### PR DESCRIPTION
I noticed that CMakeSettings.json is currently being generated with an invalid key when windows_buildenv.bat is used.
Visual Studio 19 therefore won't load it, and gives:
`Failed to parse CMakeSettings.json. Bad JSON escape sequence: \=. Path 'configurations[0].variables[5].value', line 40, position 22.`
The problem seems to be `CMAKE_PREFIX_PATH` is no longer setup in the bat file,
So the line:     `CALL :AddCMakeVar2CMakeSettings_JSON "CMAKE_PREFIX_PATH"                  "STRING"   "!CMAKE_PREFIX_PATH:\=\\!"`
Causes a line `          "value": "\=\\",` in the CMakeSettings.json which isn't valid.
My fix is to add a set back into the file matching one that was removed by an earlier commit, I'm not sure if its the best solution as I'm not sure what if anything `CMAKE_PREFIX_PATH` is used for.  It's possible we may not need it and it can be removed?
