### PR TITLE
Rename Beats iterator methods

### DIFF
--- a/src/test/beatstest.cpp
+++ b/src/test/beatstest.cpp
@@ -219,9 +219,9 @@ TEST(BeatsTest, NonConstTempoGetBpmAroundPosition) {
 }
 
 TEST(BeatsTest, ConstTempoIteratorSubtract) {
-    EXPECT_EQ(kConstTempoBeats.cfirstmarker(), kConstTempoBeats.clastmarker() - 1);
-    EXPECT_EQ(kConstTempoBeats.cfirstmarker() - 5, kConstTempoBeats.clastmarker() - 6);
-    EXPECT_EQ(kConstTempoBeats.cfirstmarker() - 10, kConstTempoBeats.clastmarker() - 11);
+    EXPECT_EQ(kConstTempoBeats.cfirstmarker(), kConstTempoBeats.clastmarker());
+    EXPECT_EQ(kConstTempoBeats.cfirstmarker() - 5, kConstTempoBeats.clastmarker() - 5);
+    EXPECT_EQ(kConstTempoBeats.cfirstmarker() - 10, kConstTempoBeats.clastmarker() - 10);
 }
 
 TEST(BeatsTest, ConstTempoIteratorAddSubtractNegativeIsEquivalent) {
@@ -246,9 +246,9 @@ TEST(BeatsTest, ConstTempoIteratorSubtractPosition) {
 }
 
 TEST(BeatsTest, ConstTempoIteratorAdd) {
-    EXPECT_EQ(kConstTempoBeats.clastmarker(), kConstTempoBeats.cfirstmarker() + 1);
-    EXPECT_EQ(kConstTempoBeats.clastmarker() + 5, kConstTempoBeats.cfirstmarker() + 6);
-    EXPECT_EQ(kConstTempoBeats.clastmarker() + 10, kConstTempoBeats.cfirstmarker() + 11);
+    EXPECT_EQ(kConstTempoBeats.clastmarker(), kConstTempoBeats.cfirstmarker());
+    EXPECT_EQ(kConstTempoBeats.clastmarker() + 5, kConstTempoBeats.cfirstmarker() + 5);
+    EXPECT_EQ(kConstTempoBeats.clastmarker() + 10, kConstTempoBeats.cfirstmarker() + 10);
 }
 
 TEST(BeatsTest, ConstTempoIteratorAddPosition) {
@@ -262,11 +262,17 @@ TEST(BeatsTest, ConstTempoIteratorAddPosition) {
 }
 
 TEST(BeatsTest, ConstTempoIteratorDifference) {
-    EXPECT_EQ(-1, kConstTempoBeats.cfirstmarker() - kConstTempoBeats.clastmarker());
-    EXPECT_EQ(1, kConstTempoBeats.clastmarker() - kConstTempoBeats.cfirstmarker());
+    EXPECT_EQ(0, kConstTempoBeats.cfirstmarker() - kConstTempoBeats.clastmarker());
+    EXPECT_EQ(0, kConstTempoBeats.clastmarker() - kConstTempoBeats.cfirstmarker());
 
     EXPECT_EQ(0, kConstTempoBeats.clastmarker() - kConstTempoBeats.clastmarker());
     EXPECT_EQ(0, kConstTempoBeats.cfirstmarker() - kConstTempoBeats.cfirstmarker());
+
+    EXPECT_EQ(5, (kConstTempoBeats.cfirstmarker() + 5) - kConstTempoBeats.clastmarker());
+    EXPECT_EQ(7, (kConstTempoBeats.cfirstmarker() + 7) - kConstTempoBeats.clastmarker());
+    EXPECT_EQ(-7,
+            std::distance(kConstTempoBeats.clastmarker() + 7,
+                    kConstTempoBeats.cfirstmarker()));
 }
 
 TEST(BeatsTest, ConstTempoIteratorPrefixIncrement) {
@@ -279,7 +285,6 @@ TEST(BeatsTest, ConstTempoIteratorPostfixIncrement) {
     auto it = kConstTempoBeats.cfirstmarker();
     EXPECT_EQ(kConstTempoBeats.cfirstmarker(), it++);
     EXPECT_EQ(kConstTempoBeats.cfirstmarker() + 1, it++);
-    EXPECT_EQ(kConstTempoBeats.cfirstmarker() + 2, it);
 }
 
 TEST(BeatsTest, ConstTempoIteratorPrefixDecrement) {
@@ -296,33 +301,33 @@ TEST(BeatsTest, ConstTempoIteratorPostfixDecrement) {
 }
 
 TEST(BeatsTest, NonConstTempoIteratorAdd) {
-    EXPECT_EQ(kNonConstTempoBeats.clastmarker(), kNonConstTempoBeats.cfirstmarker() + 25);
+    EXPECT_EQ(kNonConstTempoBeats.clastmarker(), kNonConstTempoBeats.cfirstmarker() + 24);
 
-    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 30, kNonConstTempoBeats.clastmarker() + 5);
-    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 35, kNonConstTempoBeats.clastmarker() + 10);
-    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 40, kNonConstTempoBeats.clastmarker() + 15);
-    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 45, kNonConstTempoBeats.clastmarker() + 20);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 30, kNonConstTempoBeats.clastmarker() + 6);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 35, kNonConstTempoBeats.clastmarker() + 11);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 40, kNonConstTempoBeats.clastmarker() + 16);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 45, kNonConstTempoBeats.clastmarker() + 21);
 }
 
 TEST(BeatsTest, NonConstTempoIteratorSubtract) {
-    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker(), kNonConstTempoBeats.clastmarker() - 25);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker(), kNonConstTempoBeats.clastmarker() - 24);
 
-    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() - 5, kNonConstTempoBeats.clastmarker() - 30);
-    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() - 10, kNonConstTempoBeats.clastmarker() - 35);
-    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() - 15, kNonConstTempoBeats.clastmarker() - 40);
-    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() - 20, kNonConstTempoBeats.clastmarker() - 45);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() - 5, kNonConstTempoBeats.clastmarker() - 29);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() - 10, kNonConstTempoBeats.clastmarker() - 34);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() - 15, kNonConstTempoBeats.clastmarker() - 39);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() - 20, kNonConstTempoBeats.clastmarker() - 44);
 }
 
 TEST(BeatsTest, NonConstTempoIteratorAddSubtract) {
-    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 5, kNonConstTempoBeats.clastmarker() - 20);
-    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 10, kNonConstTempoBeats.clastmarker() - 15);
-    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 15, kNonConstTempoBeats.clastmarker() - 10);
-    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 20, kNonConstTempoBeats.clastmarker() - 5);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 5, kNonConstTempoBeats.clastmarker() - 19);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 10, kNonConstTempoBeats.clastmarker() - 14);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 15, kNonConstTempoBeats.clastmarker() - 9);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 20, kNonConstTempoBeats.clastmarker() - 4);
 }
 
 TEST(BeatsTest, NonConstTempoIteratorDifference) {
-    EXPECT_EQ(-25, kNonConstTempoBeats.cfirstmarker() - kNonConstTempoBeats.clastmarker());
-    EXPECT_EQ(25, kNonConstTempoBeats.clastmarker() - kNonConstTempoBeats.cfirstmarker());
+    EXPECT_EQ(-24, kNonConstTempoBeats.cfirstmarker() - kNonConstTempoBeats.clastmarker());
+    EXPECT_EQ(24, kNonConstTempoBeats.clastmarker() - kNonConstTempoBeats.cfirstmarker());
 
     EXPECT_EQ(0, kNonConstTempoBeats.clastmarker() - kNonConstTempoBeats.clastmarker());
     EXPECT_EQ(0, kNonConstTempoBeats.cfirstmarker() - kNonConstTempoBeats.cfirstmarker());

--- a/src/test/beatstest.cpp
+++ b/src/test/beatstest.cpp
@@ -219,169 +219,169 @@ TEST(BeatsTest, NonConstTempoGetBpmAroundPosition) {
 }
 
 TEST(BeatsTest, ConstTempoIteratorSubtract) {
-    EXPECT_EQ(kConstTempoBeats.cbegin(), kConstTempoBeats.cend() - 1);
-    EXPECT_EQ(kConstTempoBeats.cbegin() - 5, kConstTempoBeats.cend() - 6);
-    EXPECT_EQ(kConstTempoBeats.cbegin() - 10, kConstTempoBeats.cend() - 11);
+    EXPECT_EQ(kConstTempoBeats.cfirstmarker(), kConstTempoBeats.clastmarker() - 1);
+    EXPECT_EQ(kConstTempoBeats.cfirstmarker() - 5, kConstTempoBeats.clastmarker() - 6);
+    EXPECT_EQ(kConstTempoBeats.cfirstmarker() - 10, kConstTempoBeats.clastmarker() - 11);
 }
 
 TEST(BeatsTest, ConstTempoIteratorAddSubtractNegativeIsEquivalent) {
-    EXPECT_EQ(kConstTempoBeats.cbegin() + 1, kConstTempoBeats.cbegin() - (-1));
-    EXPECT_EQ(kConstTempoBeats.cbegin() + 5, kConstTempoBeats.cbegin() - (-5));
-    EXPECT_EQ(kConstTempoBeats.cbegin() - 1, kConstTempoBeats.cbegin() + (-1));
-    EXPECT_EQ(kConstTempoBeats.cbegin() - 5, kConstTempoBeats.cbegin() + (-5));
-    EXPECT_EQ(kConstTempoBeats.cend() + 1, kConstTempoBeats.cend() - (-1));
-    EXPECT_EQ(kConstTempoBeats.cend() + 5, kConstTempoBeats.cend() - (-5));
-    EXPECT_EQ(kConstTempoBeats.cend() - 1, kConstTempoBeats.cend() + (-1));
-    EXPECT_EQ(kConstTempoBeats.cend() - 5, kConstTempoBeats.cend() + (-5));
+    EXPECT_EQ(kConstTempoBeats.cfirstmarker() + 1, kConstTempoBeats.cfirstmarker() - (-1));
+    EXPECT_EQ(kConstTempoBeats.cfirstmarker() + 5, kConstTempoBeats.cfirstmarker() - (-5));
+    EXPECT_EQ(kConstTempoBeats.cfirstmarker() - 1, kConstTempoBeats.cfirstmarker() + (-1));
+    EXPECT_EQ(kConstTempoBeats.cfirstmarker() - 5, kConstTempoBeats.cfirstmarker() + (-5));
+    EXPECT_EQ(kConstTempoBeats.clastmarker() + 1, kConstTempoBeats.clastmarker() - (-1));
+    EXPECT_EQ(kConstTempoBeats.clastmarker() + 5, kConstTempoBeats.clastmarker() - (-5));
+    EXPECT_EQ(kConstTempoBeats.clastmarker() - 1, kConstTempoBeats.clastmarker() + (-1));
+    EXPECT_EQ(kConstTempoBeats.clastmarker() - 5, kConstTempoBeats.clastmarker() + (-5));
 }
 
 TEST(BeatsTest, ConstTempoIteratorSubtractPosition) {
     const audio::FrameDiff_t beatLengthFrames = 60.0 * kSampleRate.value() / kBpm.value();
-    EXPECT_NEAR((*(kConstTempoBeats.cbegin() - 100)).value(),
-            ((*kConstTempoBeats.cbegin()) - 100 * beatLengthFrames).value(),
+    EXPECT_NEAR((*(kConstTempoBeats.cfirstmarker() - 100)).value(),
+            ((*kConstTempoBeats.cfirstmarker()) - 100 * beatLengthFrames).value(),
             kMaxBeatError);
-    EXPECT_NEAR((*(kConstTempoBeats.cend() - 100)).value(),
-            ((*kConstTempoBeats.cend()) - 100 * beatLengthFrames).value(),
+    EXPECT_NEAR((*(kConstTempoBeats.clastmarker() - 100)).value(),
+            ((*kConstTempoBeats.clastmarker()) - 100 * beatLengthFrames).value(),
             kMaxBeatError);
 }
 
 TEST(BeatsTest, ConstTempoIteratorAdd) {
-    EXPECT_EQ(kConstTempoBeats.cend(), kConstTempoBeats.cbegin() + 1);
-    EXPECT_EQ(kConstTempoBeats.cend() + 5, kConstTempoBeats.cbegin() + 6);
-    EXPECT_EQ(kConstTempoBeats.cend() + 10, kConstTempoBeats.cbegin() + 11);
+    EXPECT_EQ(kConstTempoBeats.clastmarker(), kConstTempoBeats.cfirstmarker() + 1);
+    EXPECT_EQ(kConstTempoBeats.clastmarker() + 5, kConstTempoBeats.cfirstmarker() + 6);
+    EXPECT_EQ(kConstTempoBeats.clastmarker() + 10, kConstTempoBeats.cfirstmarker() + 11);
 }
 
 TEST(BeatsTest, ConstTempoIteratorAddPosition) {
     const audio::FrameDiff_t beatLengthFrames = 60.0 * kSampleRate.value() / kBpm.value();
-    EXPECT_NEAR((*(kConstTempoBeats.cbegin() + 100)).value(),
-            ((*kConstTempoBeats.cbegin()) + 100 * beatLengthFrames).value(),
+    EXPECT_NEAR((*(kConstTempoBeats.cfirstmarker() + 100)).value(),
+            ((*kConstTempoBeats.cfirstmarker()) + 100 * beatLengthFrames).value(),
             kMaxBeatError);
-    EXPECT_NEAR((*(kConstTempoBeats.cend() + 100)).value(),
-            ((*kConstTempoBeats.cend()) + 100 * beatLengthFrames).value(),
+    EXPECT_NEAR((*(kConstTempoBeats.clastmarker() + 100)).value(),
+            ((*kConstTempoBeats.clastmarker()) + 100 * beatLengthFrames).value(),
             kMaxBeatError);
 }
 
 TEST(BeatsTest, ConstTempoIteratorDifference) {
-    EXPECT_EQ(-1, kConstTempoBeats.cbegin() - kConstTempoBeats.cend());
-    EXPECT_EQ(1, kConstTempoBeats.cend() - kConstTempoBeats.cbegin());
+    EXPECT_EQ(-1, kConstTempoBeats.cfirstmarker() - kConstTempoBeats.clastmarker());
+    EXPECT_EQ(1, kConstTempoBeats.clastmarker() - kConstTempoBeats.cfirstmarker());
 
-    EXPECT_EQ(0, kConstTempoBeats.cend() - kConstTempoBeats.cend());
-    EXPECT_EQ(0, kConstTempoBeats.cbegin() - kConstTempoBeats.cbegin());
+    EXPECT_EQ(0, kConstTempoBeats.clastmarker() - kConstTempoBeats.clastmarker());
+    EXPECT_EQ(0, kConstTempoBeats.cfirstmarker() - kConstTempoBeats.cfirstmarker());
 }
 
 TEST(BeatsTest, ConstTempoIteratorPrefixIncrement) {
-    auto it = kConstTempoBeats.cbegin();
-    EXPECT_EQ(kConstTempoBeats.cbegin() + 1, ++it);
-    EXPECT_EQ(kConstTempoBeats.cbegin() + 2, ++it);
+    auto it = kConstTempoBeats.cfirstmarker();
+    EXPECT_EQ(kConstTempoBeats.cfirstmarker() + 1, ++it);
+    EXPECT_EQ(kConstTempoBeats.cfirstmarker() + 2, ++it);
 }
 
 TEST(BeatsTest, ConstTempoIteratorPostfixIncrement) {
-    auto it = kConstTempoBeats.cbegin();
-    EXPECT_EQ(kConstTempoBeats.cbegin(), it++);
-    EXPECT_EQ(kConstTempoBeats.cbegin() + 1, it++);
-    EXPECT_EQ(kConstTempoBeats.cbegin() + 2, it);
+    auto it = kConstTempoBeats.cfirstmarker();
+    EXPECT_EQ(kConstTempoBeats.cfirstmarker(), it++);
+    EXPECT_EQ(kConstTempoBeats.cfirstmarker() + 1, it++);
+    EXPECT_EQ(kConstTempoBeats.cfirstmarker() + 2, it);
 }
 
 TEST(BeatsTest, ConstTempoIteratorPrefixDecrement) {
-    auto it = kConstTempoBeats.cend();
-    EXPECT_EQ(kConstTempoBeats.cend() - 1, --it);
-    EXPECT_EQ(kConstTempoBeats.cend() - 2, --it);
+    auto it = kConstTempoBeats.clastmarker();
+    EXPECT_EQ(kConstTempoBeats.clastmarker() - 1, --it);
+    EXPECT_EQ(kConstTempoBeats.clastmarker() - 2, --it);
 }
 
 TEST(BeatsTest, ConstTempoIteratorPostfixDecrement) {
-    auto it = kConstTempoBeats.cend();
-    EXPECT_EQ(kConstTempoBeats.cend(), it--);
-    EXPECT_EQ(kConstTempoBeats.cend() - 1, it--);
-    EXPECT_EQ(kConstTempoBeats.cend() - 2, it);
+    auto it = kConstTempoBeats.clastmarker();
+    EXPECT_EQ(kConstTempoBeats.clastmarker(), it--);
+    EXPECT_EQ(kConstTempoBeats.clastmarker() - 1, it--);
+    EXPECT_EQ(kConstTempoBeats.clastmarker() - 2, it);
 }
 
 TEST(BeatsTest, NonConstTempoIteratorAdd) {
-    EXPECT_EQ(kNonConstTempoBeats.cend(), kNonConstTempoBeats.cbegin() + 25);
+    EXPECT_EQ(kNonConstTempoBeats.clastmarker(), kNonConstTempoBeats.cfirstmarker() + 25);
 
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 30, kNonConstTempoBeats.cend() + 5);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 35, kNonConstTempoBeats.cend() + 10);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 40, kNonConstTempoBeats.cend() + 15);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 45, kNonConstTempoBeats.cend() + 20);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 30, kNonConstTempoBeats.clastmarker() + 5);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 35, kNonConstTempoBeats.clastmarker() + 10);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 40, kNonConstTempoBeats.clastmarker() + 15);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 45, kNonConstTempoBeats.clastmarker() + 20);
 }
 
 TEST(BeatsTest, NonConstTempoIteratorSubtract) {
-    EXPECT_EQ(kNonConstTempoBeats.cbegin(), kNonConstTempoBeats.cend() - 25);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker(), kNonConstTempoBeats.clastmarker() - 25);
 
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() - 5, kNonConstTempoBeats.cend() - 30);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() - 10, kNonConstTempoBeats.cend() - 35);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() - 15, kNonConstTempoBeats.cend() - 40);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() - 20, kNonConstTempoBeats.cend() - 45);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() - 5, kNonConstTempoBeats.clastmarker() - 30);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() - 10, kNonConstTempoBeats.clastmarker() - 35);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() - 15, kNonConstTempoBeats.clastmarker() - 40);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() - 20, kNonConstTempoBeats.clastmarker() - 45);
 }
 
 TEST(BeatsTest, NonConstTempoIteratorAddSubtract) {
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 5, kNonConstTempoBeats.cend() - 20);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 10, kNonConstTempoBeats.cend() - 15);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 15, kNonConstTempoBeats.cend() - 10);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 20, kNonConstTempoBeats.cend() - 5);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 5, kNonConstTempoBeats.clastmarker() - 20);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 10, kNonConstTempoBeats.clastmarker() - 15);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 15, kNonConstTempoBeats.clastmarker() - 10);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 20, kNonConstTempoBeats.clastmarker() - 5);
 }
 
 TEST(BeatsTest, NonConstTempoIteratorDifference) {
-    EXPECT_EQ(-25, kNonConstTempoBeats.cbegin() - kNonConstTempoBeats.cend());
-    EXPECT_EQ(25, kNonConstTempoBeats.cend() - kNonConstTempoBeats.cbegin());
+    EXPECT_EQ(-25, kNonConstTempoBeats.cfirstmarker() - kNonConstTempoBeats.clastmarker());
+    EXPECT_EQ(25, kNonConstTempoBeats.clastmarker() - kNonConstTempoBeats.cfirstmarker());
 
-    EXPECT_EQ(0, kNonConstTempoBeats.cend() - kNonConstTempoBeats.cend());
-    EXPECT_EQ(0, kNonConstTempoBeats.cbegin() - kNonConstTempoBeats.cbegin());
+    EXPECT_EQ(0, kNonConstTempoBeats.clastmarker() - kNonConstTempoBeats.clastmarker());
+    EXPECT_EQ(0, kNonConstTempoBeats.cfirstmarker() - kNonConstTempoBeats.cfirstmarker());
 }
 
 TEST(BeatsTest, NonConstTempoIteratorPrefixIncrement) {
-    auto it = kNonConstTempoBeats.cbegin();
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 1, ++it);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 2, ++it);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 3, ++it);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 4, ++it);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 5, ++it);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 6, ++it);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 7, ++it);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 8, ++it);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 9, ++it);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 9, it);
+    auto it = kNonConstTempoBeats.cfirstmarker();
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 1, ++it);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 2, ++it);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 3, ++it);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 4, ++it);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 5, ++it);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 6, ++it);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 7, ++it);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 8, ++it);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 9, ++it);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 9, it);
 }
 
 TEST(BeatsTest, NonConstTempoIteratorPostfixIncrement) {
-    auto it = kNonConstTempoBeats.cbegin();
-    EXPECT_EQ(kNonConstTempoBeats.cbegin(), it++);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 1, it++);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 2, it++);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 3, it++);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 4, it++);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 5, it++);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 6, it++);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 7, it++);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 8, it++);
-    EXPECT_EQ(kNonConstTempoBeats.cbegin() + 9, it);
+    auto it = kNonConstTempoBeats.cfirstmarker();
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker(), it++);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 1, it++);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 2, it++);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 3, it++);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 4, it++);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 5, it++);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 6, it++);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 7, it++);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 8, it++);
+    EXPECT_EQ(kNonConstTempoBeats.cfirstmarker() + 9, it);
 }
 
 TEST(BeatsTest, NonConstTempoIteratorPrefixDecrement) {
-    auto it = kNonConstTempoBeats.cend();
-    EXPECT_EQ(kNonConstTempoBeats.cend() - 1, --it);
-    EXPECT_EQ(kNonConstTempoBeats.cend() - 2, --it);
-    EXPECT_EQ(kNonConstTempoBeats.cend() - 3, --it);
-    EXPECT_EQ(kNonConstTempoBeats.cend() - 4, --it);
-    EXPECT_EQ(kNonConstTempoBeats.cend() - 5, --it);
-    EXPECT_EQ(kNonConstTempoBeats.cend() - 6, --it);
-    EXPECT_EQ(kNonConstTempoBeats.cend() - 7, --it);
-    EXPECT_EQ(kNonConstTempoBeats.cend() - 8, --it);
-    EXPECT_EQ(kNonConstTempoBeats.cend() - 9, --it);
-    EXPECT_EQ(kNonConstTempoBeats.cend() - 9, it);
+    auto it = kNonConstTempoBeats.clastmarker();
+    EXPECT_EQ(kNonConstTempoBeats.clastmarker() - 1, --it);
+    EXPECT_EQ(kNonConstTempoBeats.clastmarker() - 2, --it);
+    EXPECT_EQ(kNonConstTempoBeats.clastmarker() - 3, --it);
+    EXPECT_EQ(kNonConstTempoBeats.clastmarker() - 4, --it);
+    EXPECT_EQ(kNonConstTempoBeats.clastmarker() - 5, --it);
+    EXPECT_EQ(kNonConstTempoBeats.clastmarker() - 6, --it);
+    EXPECT_EQ(kNonConstTempoBeats.clastmarker() - 7, --it);
+    EXPECT_EQ(kNonConstTempoBeats.clastmarker() - 8, --it);
+    EXPECT_EQ(kNonConstTempoBeats.clastmarker() - 9, --it);
+    EXPECT_EQ(kNonConstTempoBeats.clastmarker() - 9, it);
 }
 
 TEST(BeatsTest, NonConstTempoIteratorPostfixDecrement) {
-    auto it = kNonConstTempoBeats.cend();
-    EXPECT_EQ(kNonConstTempoBeats.cend(), it--);
-    EXPECT_EQ(kNonConstTempoBeats.cend() - 1, it--);
-    EXPECT_EQ(kNonConstTempoBeats.cend() - 2, it--);
-    EXPECT_EQ(kNonConstTempoBeats.cend() - 3, it--);
-    EXPECT_EQ(kNonConstTempoBeats.cend() - 4, it--);
-    EXPECT_EQ(kNonConstTempoBeats.cend() - 5, it--);
-    EXPECT_EQ(kNonConstTempoBeats.cend() - 6, it--);
-    EXPECT_EQ(kNonConstTempoBeats.cend() - 7, it--);
-    EXPECT_EQ(kNonConstTempoBeats.cend() - 8, it--);
-    EXPECT_EQ(kNonConstTempoBeats.cend() - 9, it);
+    auto it = kNonConstTempoBeats.clastmarker();
+    EXPECT_EQ(kNonConstTempoBeats.clastmarker(), it--);
+    EXPECT_EQ(kNonConstTempoBeats.clastmarker() - 1, it--);
+    EXPECT_EQ(kNonConstTempoBeats.clastmarker() - 2, it--);
+    EXPECT_EQ(kNonConstTempoBeats.clastmarker() - 3, it--);
+    EXPECT_EQ(kNonConstTempoBeats.clastmarker() - 4, it--);
+    EXPECT_EQ(kNonConstTempoBeats.clastmarker() - 5, it--);
+    EXPECT_EQ(kNonConstTempoBeats.clastmarker() - 6, it--);
+    EXPECT_EQ(kNonConstTempoBeats.clastmarker() - 7, it--);
+    EXPECT_EQ(kNonConstTempoBeats.clastmarker() - 8, it--);
+    EXPECT_EQ(kNonConstTempoBeats.clastmarker() - 9, it);
 }
 
 TEST(BeatsTest, ConstTempoSerialization) {
@@ -446,7 +446,7 @@ TEST(BeatsTest, NonConstTempoFromBeatPositions) {
 }
 
 TEST(BeatsTest, ConstTempoFindNthBeatWhenOnBeat) {
-    const auto it = kConstTempoBeats.cbegin() + 10;
+    const auto it = kConstTempoBeats.cfirstmarker() + 10;
     const audio::FrameDiff_t beatLengthFrames = 60.0 * kSampleRate.value() / kBpm.value();
     const audio::FramePos position = *it;
 
@@ -467,7 +467,7 @@ TEST(BeatsTest, ConstTempoFindNthBeatWhenOnBeat) {
 }
 
 TEST(BeatsTest, ConstTempoFindNthBeatWhenNotOnBeat) {
-    auto it = kConstTempoBeats.cbegin() + 10;
+    auto it = kConstTempoBeats.cfirstmarker() + 10;
     const mixxx::audio::FramePos previousBeat = *it;
     it++;
     const mixxx::audio::FramePos nextBeat = *it;
@@ -493,7 +493,7 @@ TEST(BeatsTest, ConstTempoFindNthBeatWhenNotOnBeat) {
 }
 
 TEST(BeatsTest, ConstTempoFindPrevNextBeatWhenOnBeat) {
-    const auto it = kConstTempoBeats.cbegin() + 10;
+    const auto it = kConstTempoBeats.cfirstmarker() + 10;
     const audio::FramePos position = *it;
     const audio::FrameDiff_t beatLengthFrames = 60.0 * kSampleRate.value() / kBpm.value();
 
@@ -514,7 +514,7 @@ TEST(BeatsTest, ConstTempoFindPrevNextBeatWhenOnBeat) {
 }
 
 TEST(BeatsTest, ConstTempoFindPrevNextBeatWhenNotOnBeat) {
-    auto it = kConstTempoBeats.cbegin() + 10;
+    auto it = kConstTempoBeats.cfirstmarker() + 10;
     const mixxx::audio::FramePos previousBeat = *it;
     it++;
     const mixxx::audio::FramePos nextBeat = *it;

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -352,7 +352,7 @@ QByteArray Beats::toBeatGridByteArray() const {
 
 QByteArray Beats::toBeatMapByteArray() const {
     mixxx::track::io::BeatMap map;
-    for (auto it = cfirstmarker(); it != clastmarker(); it++) {
+    for (auto it = cfirstmarker(); it != clastmarker() + 1; it++) {
         const auto position = (*it).toLowerFrameBoundary();
         qWarning() << position;
         track::io::Beat beat;
@@ -418,13 +418,13 @@ Beats::ConstIterator Beats::iteratorFrom(audio::FramePos position) const {
     DEBUG_ASSERT(isValid());
     auto it = cfirstmarker();
     if (position > m_endMarkerPosition) {
-        DEBUG_ASSERT(*(clastmarker() - 1) == m_endMarkerPosition);
+        DEBUG_ASSERT(*clastmarker() == m_endMarkerPosition);
         // Lookup position is after the last marker position
         const double n = std::ceil((position - m_endMarkerPosition) / endBeatLengthFrames());
         if (n >= static_cast<double>(std::numeric_limits<int>::max())) {
             return clatest();
         }
-        it = (clastmarker() - 1) + static_cast<int>(n);
+        it = clastmarker() + static_cast<int>(n);
 
         // In some rare cases there may be extremely tiny floating point errors
         // that make `std::ceil` round up and makes us end up one beat too
@@ -442,7 +442,7 @@ Beats::ConstIterator Beats::iteratorFrom(audio::FramePos position) const {
         }
         it -= static_cast<int>(n);
     } else {
-        it = std::lower_bound(cfirstmarker(), clastmarker(), position);
+        it = std::lower_bound(cfirstmarker(), clastmarker() + 1, position);
     }
     DEBUG_ASSERT(it == cearliest() || it == clatest() || *it >= position);
     DEBUG_ASSERT(it == cearliest() || it == clatest() ||

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -378,11 +378,11 @@ bool Beats::findPrevNextBeats(audio::FramePos position,
         audio::FramePos* nextBeatPosition,
         bool snapToNearBeats) const {
     auto it = iteratorFrom(position);
-    if (it == clatest()) {
+    if (it == cend()) {
         *prevBeatPosition = *it;
         *nextBeatPosition = audio::kInvalidFramePos;
         return false;
-    } else if (it == cearliest()) {
+    } else if (it == cbegin()) {
         *prevBeatPosition = audio::kInvalidFramePos;
         *nextBeatPosition = *it;
         return false;
@@ -422,7 +422,7 @@ Beats::ConstIterator Beats::iteratorFrom(audio::FramePos position) const {
         // Lookup position is after the last marker position
         const double n = std::ceil((position - m_endMarkerPosition) / endBeatLengthFrames());
         if (n >= static_cast<double>(std::numeric_limits<int>::max())) {
-            return clatest();
+            return cend();
         }
         it = clastmarker() + static_cast<int>(n);
 
@@ -438,14 +438,14 @@ Beats::ConstIterator Beats::iteratorFrom(audio::FramePos position) const {
         // Lookup position is before the first marker position
         const double n = std::floor((*it - position) / firstBeatLengthFrames());
         if (n > static_cast<double>(std::numeric_limits<int>::max())) {
-            return cearliest();
+            return cbegin();
         }
         it -= static_cast<int>(n);
     } else {
         it = std::lower_bound(cfirstmarker(), clastmarker() + 1, position);
     }
-    DEBUG_ASSERT(it == cearliest() || it == clatest() || *it >= position);
-    DEBUG_ASSERT(it == cearliest() || it == clatest() ||
+    DEBUG_ASSERT(it == cbegin() || it == cend() || *it >= position);
+    DEBUG_ASSERT(it == cbegin() || it == cend() ||
             *it - position < std::prev(it).beatLengthFrames());
     return it;
 }
@@ -585,7 +585,7 @@ mixxx::Bpm Beats::getBpmAroundPosition(audio::FramePos position, int n) const {
     audio::FramePos endPosition = *it;
 
     // If we hit the end of the beat map, recalculate the lower bound.
-    if (it == clatest()) {
+    if (it == cend()) {
         it -= 2 * n;
         startPosition = *it;
     }

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -352,7 +352,7 @@ QByteArray Beats::toBeatGridByteArray() const {
 
 QByteArray Beats::toBeatMapByteArray() const {
     mixxx::track::io::BeatMap map;
-    for (auto it = cbegin(); it != cend(); it++) {
+    for (auto it = cfirstmarker(); it != clastmarker(); it++) {
         const auto position = (*it).toLowerFrameBoundary();
         qWarning() << position;
         track::io::Beat beat;
@@ -416,15 +416,15 @@ bool Beats::findPrevNextBeats(audio::FramePos position,
 
 Beats::ConstIterator Beats::iteratorFrom(audio::FramePos position) const {
     DEBUG_ASSERT(isValid());
-    auto it = cbegin();
+    auto it = cfirstmarker();
     if (position > m_endMarkerPosition) {
-        DEBUG_ASSERT(*(cend() - 1) == m_endMarkerPosition);
+        DEBUG_ASSERT(*(clastmarker() - 1) == m_endMarkerPosition);
         // Lookup position is after the last marker position
         const double n = std::ceil((position - m_endMarkerPosition) / endBeatLengthFrames());
         if (n >= static_cast<double>(std::numeric_limits<int>::max())) {
             return clatest();
         }
-        it = (cend() - 1) + static_cast<int>(n);
+        it = (clastmarker() - 1) + static_cast<int>(n);
 
         // In some rare cases there may be extremely tiny floating point errors
         // that make `std::ceil` round up and makes us end up one beat too
@@ -442,7 +442,7 @@ Beats::ConstIterator Beats::iteratorFrom(audio::FramePos position) const {
         }
         it -= static_cast<int>(n);
     } else {
-        it = std::lower_bound(cbegin(), cend(), position);
+        it = std::lower_bound(cfirstmarker(), clastmarker(), position);
     }
     DEBUG_ASSERT(it == cearliest() || it == clatest() || *it >= position);
     DEBUG_ASSERT(it == cearliest() || it == clatest() ||
@@ -661,7 +661,7 @@ std::optional<BeatsPointer> Beats::tryScale(BpmScale scale) const {
 }
 
 std::optional<BeatsPointer> Beats::trySetBpm(mixxx::Bpm bpm) const {
-    const auto it = cbegin();
+    const auto it = cfirstmarker();
     return BeatsPointer(new Beats({}, *it, bpm, m_sampleRate, m_subVersion));
 }
 
@@ -680,7 +680,7 @@ bool Beats::isValid() const {
 }
 
 mixxx::audio::FrameDiff_t Beats::firstBeatLengthFrames() const {
-    const auto it = cbegin();
+    const auto it = cfirstmarker();
     return it.beatLengthFrames();
 }
 

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -174,13 +174,13 @@ class Beats : private std::enable_shared_from_this<Beats> {
     ~Beats() = default;
 
     /// Returns an iterator pointing to the position of the first beat marker.
-    ConstIterator cbegin() const {
+    ConstIterator cfirstmarker() const {
         return ConstIterator(this, m_markers.cbegin(), 0);
     }
 
     /// Returns an iterator pointing to the position of the first beat after
     /// the end beat marker.
-    ConstIterator cend() const {
+    ConstIterator clastmarker() const {
         return ConstIterator(this, m_markers.cend(), 1);
     }
 

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -189,7 +189,7 @@ class Beats : private std::enable_shared_from_this<Beats> {
     ///
     /// Warning: Decrementing the iterator returned by this function will
     /// result in an integer underflow.
-    ConstIterator cearliest() const {
+    ConstIterator cbegin() const {
         return ConstIterator(this, m_markers.cbegin(), std::numeric_limits<int>::lowest());
     }
 
@@ -198,7 +198,7 @@ class Beats : private std::enable_shared_from_this<Beats> {
     ///
     /// Warning: Incrementing the iterator returned by this function will
     /// result in an integer overflow.
-    ConstIterator clatest() const {
+    ConstIterator cend() const {
         return ConstIterator(this, m_markers.cend(), std::numeric_limits<int>::max());
     }
 

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -181,7 +181,7 @@ class Beats : private std::enable_shared_from_this<Beats> {
     /// Returns an iterator pointing to the position of the first beat after
     /// the end beat marker.
     ConstIterator clastmarker() const {
-        return ConstIterator(this, m_markers.cend(), 1);
+        return ConstIterator(this, m_markers.cend(), 0);
     }
 
     /// Returns an iterator pointing to earliest representable beat position

--- a/src/waveform/renderers/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/waveformrenderbeat.cpp
@@ -63,7 +63,7 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
     auto it = trackBeats->iteratorFrom(startPosition);
 
     // if no beat do not waste time saving/restoring painter
-    if (it == trackBeats->clatest() || *it > endPosition) {
+    if (it == trackBeats->cend() || *it > endPosition) {
         return;
     }
 
@@ -81,7 +81,7 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
 
     int beatCount = 0;
 
-    for (; it != trackBeats->clatest() && *it <= endPosition; ++it) {
+    for (; it != trackBeats->cend() && *it <= endPosition; ++it) {
         double beatPosition = it->toEngineSamplePos();
         double xBeatPoint =
                 m_waveformRenderer->transformSamplePositionInRendererWorld(beatPosition);


### PR DESCRIPTION
The new iterator method names should be easier to grasp:

Description | Old | New
----------------| ------- | ------
Beat on first marker | cbegin() | cfirstmarker() |
Beat after last marker | cend() |   |
Beat on last marker |    |  clastmarker()  |
Earliest beat that can be represented without wraparound | cearliest() | cbegin() |
Latest beat that can be represented without wraparound | clatest() | cend() |

This was requested by @daschuer here: https://github.com/mixxxdj/mixxx/pull/4411#issuecomment-952591891