### PR TITLE
Beats: Round positions to lower frame boundary on translate

### DIFF
--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -599,12 +599,14 @@ std::optional<BeatsPointer> Beats::tryTranslate(audio::FrameDiff_t offsetFrames)
             m_markers.cend(),
             std::back_inserter(markers),
             [offsetFrames](const BeatMarker& marker) -> BeatMarker {
-                return BeatMarker(marker.position() + offsetFrames,
+                const auto position = marker.position() + offsetFrames;
+                return BeatMarker(position.toLowerFrameBoundary(),
                         marker.beatsTillNextMarker());
             });
 
+    const auto endMarkerPosition = m_endMarkerPosition + offsetFrames;
     return BeatsPointer(new Beats(markers,
-            m_endMarkerPosition + offsetFrames,
+            endMarkerPosition.toLowerFrameBoundary(),
             m_endMarkerBpm,
             m_sampleRate,
             m_subVersion));

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -599,8 +599,8 @@ std::optional<BeatsPointer> Beats::tryTranslate(audio::FrameDiff_t offsetFrames)
             m_markers.cend(),
             std::back_inserter(markers),
             [offsetFrames](const BeatMarker& marker) -> BeatMarker {
-                const auto position = marker.position() + offsetFrames;
-                return BeatMarker(position.toLowerFrameBoundary(),
+                const auto translatedPosition = marker.position() + offsetFrames;
+                return BeatMarker(translatedPosition.toLowerFrameBoundary(),
                         marker.beatsTillNextMarker());
             });
 


### PR DESCRIPTION
This fixes the following debug assertion:

    DEBUG ASSERT: "!m_endMarkerPosition.isFractional()" in function mixxx::Beats::Beats(std::vector<mixxx::BeatMarker>, mixxx::audio::FramePos, mixxx::Bpm, mixxx::audio::SampleRate, const QString&) at /home/jan/Projects/mixxx/src/track/beats.h:177