### PR TITLE
add new searchbox styles

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -641,6 +641,7 @@ QPushButton#pushButtonRepeatPlaylist {
 /* Scroll bars */
 #LibraryContainer QScrollBar:horizontal,
 WEffectSelector QAbstractScrollArea QScrollBar:horizontal,
+WSearchLineEdit QAbstractScrollArea QScrollBar:horizontal,
 #fadeModeCombobox QAbstractScrollArea QScrollBar:horizontal {
   border-top: 1px solid #141414;
   min-width: 12px;
@@ -650,6 +651,7 @@ WEffectSelector QAbstractScrollArea QScrollBar:horizontal,
 }
 #LibraryContainer QScrollBar:vertical,
 WEffectSelector QAbstractScrollArea QScrollBar:vertical,
+WSearchLineEdit QAbstractScrollArea QScrollBar:vertical,
 #fadeModeCombobox QAbstractScrollArea QScrollBar:vertical {
   border-left: 1px solid #141414;
   min-height: 12px;
@@ -662,12 +664,15 @@ WEffectSelector QAbstractScrollArea QScrollBar:vertical,
 #LibraryContainer QScrollBar::sub-page,
 WEffectSelector QAbstractScrollArea QScrollBar::add-page,
 WEffectSelector QAbstractScrollArea QScrollBar::sub-page,
+WSearchLineEdit QAbstractScrollArea QScrollBar::add-page,
+WSearchLineEdit QAbstractScrollArea QScrollBar::sub-page,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::add-page,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::sub-page {
   background: none;
 }
 #LibraryContainer QScrollBar::handle:horizontal,
 WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal,
+WSearchLineEdit QAbstractScrollArea QScrollBar::handle:horizontal,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::handle:horizontal {
   min-width: 25px;
   background-color: #5F5F5F;
@@ -676,6 +681,7 @@ WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal,
 }
 #LibraryContainer QScrollBar::handle:vertical,
 WEffectSelector QAbstractScrollArea QScrollBar::handle:vertical,
+WSearchLineEdit QAbstractScrollArea QScrollBar::handle:vertical,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::handle:vertical {
   min-height: 25px;
   background-color: #5F5F5F;
@@ -686,6 +692,8 @@ WEffectSelector QAbstractScrollArea QScrollBar::handle:vertical,
 #LibraryContainer QScrollBar::handle:vertical:hover,
 WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal:hover,
 WEffectSelector QAbstractScrollArea QScrollBar::handle:vertical:hover,
+WSearchLineEdit QAbstractScrollArea QScrollBar::handle:horizontal:hover,
+WSearchLineEdit QAbstractScrollArea QScrollBar::handle:vertical:hover,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::handle:horizontal:hover,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::handle:vertical:hover {
   background-color: #B3B3B3;
@@ -699,7 +707,11 @@ WEffectSelector QAbstractScrollArea QScrollBar::handle:vertical:hover,
 WEffectSelector QAbstractScrollArea QScrollBar::add-line:horizontal,
 WEffectSelector QAbstractScrollArea QScrollBar::add-line:vertical,
 WEffectSelector QAbstractScrollArea QScrollBar::sub-line:horizontal,
-WEffectSelector QAbstractScrollArea QScrollBar::sub-line:vertical ,
+WEffectSelector QAbstractScrollArea QScrollBar::sub-line:vertical,
+WSearchLineEdit QAbstractScrollArea QScrollBar::add-line:horizontal,
+WSearchLineEdit QAbstractScrollArea QScrollBar::add-line:vertical,
+WSearchLineEdit QAbstractScrollArea QScrollBar::sub-line:horizontal,
+WSearchLineEdit QAbstractScrollArea QScrollBar::sub-line:vertical,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::add-line:horizontal,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::add-line:vertical,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::sub-line:horizontal,
@@ -711,6 +723,7 @@ WEffectSelector QAbstractScrollArea QScrollBar::sub-line:vertical ,
 /* Corner in between two scrollbars */
 #LibraryContainer QAbstractScrollArea::corner,
 WEffectSelector QAbstractScrollArea::corner,
+WSearchLineEdit QAbstractScrollArea::corner,
 #fadeModeCombobox QAbstractScrollArea::corner {
   border-top: 1px solid #141414;
   border-left: 1px solid #141414;
@@ -821,6 +834,8 @@ WOverview /* Hotcue labels in the overview */,
 WEffectName,
 WEffectSelector,
 WEffectSelector QAbstractScrollArea,
+WSearchLineEdit,
+WSearchLineEdit QAbstractScrollArea,
 #fadeModeCombobox,
 #fadeModeCombobox QAbstractScrollArea,
 WLibrary QPushButton,
@@ -1892,6 +1907,7 @@ do not highlight either state. */
 
 /* common styles for WEffectSelector, QMenu, QToolTip */
 WEffectSelector QAbstractScrollArea,
+WSearchLineEdit QAbstractScrollArea,
 #fadeModeCombobox QAbstractScrollArea {
   font: 13px;
   min-width: 180px;
@@ -1922,6 +1938,8 @@ WCueMenuPopup,
 WCueMenuPopup QLabel,
 WEffectSelector::item:!selected,
 WEffectSelector QAbstractScrollArea,
+WSearchLineEdit::item:!selected,
+WSearchLineEdit QAbstractScrollArea,
 #fadeModeCombobox::item:!selected,
 #fadeModeCombobox QAbstractScrollArea {
   color: #c1cabe;
@@ -1937,6 +1955,7 @@ QLineEdit QMenu,
 WCueMenuPopup,
 WCoverArtMenu,
 WEffectSelector QAbstractScrollArea,
+WSearchLineEdit QAbstractScrollArea,
 #fadeModeCombobox QAbstractScrollArea {
   border-width: 1px;
   border-style: solid;
@@ -1964,6 +1983,8 @@ WEffectSelector QAbstractScrollArea,
   WCoverArtMenu::item:selected,
   WEffectSelector::item:selected,
   WEffectSelector::indicator:unchecked:selected,
+  WSearchLineEdit::item:selected,
+  WSearchLineEdit::indicator:unchecked:selected,
   #fadeModeCombobox::item:selected,
   #fadeModeCombobox::indicator:unchecked:selected {
     background-color: #565353;
@@ -1973,6 +1994,7 @@ WEffectSelector QAbstractScrollArea,
     }
     /* Remove 3D border from unchecked effects checkmark space */
     WEffectSelector::item:selected,
+    WSearchLineEdit::item:selected,
     #fadeModeCombobox::item:selected {
       border: 0px;
     }
@@ -2042,6 +2064,7 @@ WEffectSelector:!editable:on {
     border: 1px ridge #015d8d;
   }
   WEffectSelector::drop-down,
+  WSearchLineEdit::drop-down,
   #fadeModeCombobox::drop-down {
     /* This causes the Qt theme's widget style to magically not apply. Go figure. */
     border: 0;
@@ -2050,6 +2073,10 @@ WEffectSelector:!editable:on {
   #fadeModeCombobox::down-arrow {
     width: 20px;
     height: 20px;
+  }
+  WEffectSelector::down-arrow,
+  WSearchLineEdit::down-arrow,
+  #fadeModeCombobox::down-arrow {
     image: url(skin:/../Deere/icon/ic_chevron_down_48px.svg);
   }
   /* currently loaded effect */
@@ -2069,8 +2096,12 @@ WEffectSelector::checked, /* selected item */
 WEffectSelector::indicator, /* checkbox, tick mark */
 WEffectSelector::drop-down,
 WEffectSelector::indicator:unchecked,
-#fadeModeCombobox::checked, /* selected mode */
-#fadeModeCombobox::indicator, /* checkbox, tick mark */
+WSearchLineEdit::checked,
+WSearchLineEdit::indicator,
+WSearchLineEdit::drop-down,
+WSearchLineEdit::indicator:unchecked,
+#fadeModeCombobox::checked,
+#fadeModeCombobox::indicator,
 #fadeModeCombobox::drop-down,
 #fadeModeCombobox::indicator:unchecked {
   padding: 0px;

--- a/res/skins/LateNight/library.xml
+++ b/res/skins/LateNight/library.xml
@@ -35,7 +35,6 @@
                   <Template src="skin:/decks/preview_deck.xml"/>
 
                   <WidgetGroup><!--SearchBox + Library expand toggle -->
-                    <ObjectName></ObjectName>
                     <Layout>horizontal</Layout>
                     <SizePolicy>min,max</SizePolicy>
                     <Children>
@@ -56,7 +55,7 @@
                           <Template src="skin:/controls/button_2state.xml">
                             <SetVariable name="TooltipId">maximize_library</SetVariable>
                             <SetVariable name="ObjectName">LibExpand</SetVariable>
-                            <SetVariable name="Size">16f,18me</SetVariable>
+                            <SetVariable name="Size">18f,18me</SetVariable>
                             <SetVariable name="ConfigKey">[Master],maximize_library</SetVariable>
                           </Template>
                         </Children>

--- a/res/skins/LateNight/palemoon/buttons/btn__fx_selector_down.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__fx_selector_down.svg
@@ -1,5 +1,4 @@
 <svg width="16" height="24" version="1.1" xmlns="http://www.w3.org/2000/svg">
   <path d="m8 15.918 4.5715-7.9181h-9.143z" fill="none" stroke="#000001" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6"/>
-  <path d="m8-4.082 4.5715-7.9181h-9.143z" fill="none" stroke="#000001" stroke-linejoin="round" stroke-width="1.6"/>
   <path d="m8 15.918 4.5715-7.9181h-9.143z" fill="#817365"/>
 </svg>

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -136,6 +136,7 @@ WEffectChainPresetSelector QAbstractScrollArea {
   }
   WEffectSelector::down-arrow,
   WEffectChainPresetSelector::down-arrow,
+  WSearchLineEdit::down-arrow,
   #fadeModeCombobox::down-arrow,
   WTrackTableView::indicator {
     border: 0;
@@ -151,6 +152,10 @@ WEffectChainPresetSelector::checked,
 WEffectChainPresetSelector::indicator,
 WEffectChainPresetSelector::indicator:unchecked,
 WEffectChainPresetSelector::drop-down,
+WSearchLineEdit::checked,
+WSearchLineEdit::indicator,
+WSearchLineEdit::indicator:unchecked,
+WSearchLineEdit::drop-down,
 #fadeModeCombobox::checked,
 #fadeModeCombobox::indicator,
 #fadeModeCombobox::indicator:unchecked,
@@ -164,6 +169,7 @@ WEffectChainPresetSelector::drop-down,
 /* Remove 3D border from unchecked effects checkmark space */
 WEffectSelector::item:selected,
 WEffectChainPresetSelector:item:selected,
+WSearchLineEdit::item:selected,
 #fadeModeCombobox::item:selected {
   border: 0px;
 }
@@ -301,7 +307,7 @@ WTrackTableViewHeader::item {
   WTrackTableViewHeader::down-arrow {
     width: 0.8em;
     padding: 0 0.15em;
-    }
+  }
 
 
 #HotcueButton {
@@ -629,13 +635,14 @@ WEffectChainPresetSelector {
 
   WEffectSelector QAbstractScrollArea,
   WEffectChainPresetSelector QAbstractScrollArea,
+  WSearchLineEdit QAbstractScrollArea,
   #fadeModeCombobox QAbstractScrollArea {
     border: 1px solid #444;
     border-radius: 2px;
     padding: 0px;
     margin: 0px;
   }
-  /* selected item */
+  /* checked item */
   WEffectSelector:checked,
   WEffectChainPresetSelector:checked,
   #fadeModeCombobox:checked {
@@ -648,15 +655,12 @@ WEffectChainPresetSelector {
   /* hovered items */
   WEffectSelector::item:selected,
   WEffectChainPresetSelector::item:selected,
+  WSearchLineEdit::item:selected,
   #fadeModeCombobox::item:selected {
-    background-color: #333;
   /* Already one of those properties destroys font config and
      puts tick mark behind text:
     margin: 0px;
     padding: 0px; */
-  /* This moves the tick mark behind item text,
-    text sits at left border now
-    border: 0; */
   }
   WEffectSelector::indicator,
   #fadeModeCombobox::indicator {

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -285,7 +285,7 @@ WLibrary {
 #LibExpandBox {
   border-width: 1px 0px 1px 0px;
   border-radius: 0px;
-  padding: 0px 0px 2px 2px;
+  padding: 0px 0px 2px 4px;
 }
 
 #SidebarBox {
@@ -862,12 +862,15 @@ WEffectSelector,
   }
   WEffectSelector::down-arrow,
   WEffectChainPresetSelector::down-arrow,
-  #fadeModeCombobox::down-arrow {
+  #fadeModeCombobox::down-arrow,
+  /* Arrow size is set in C++ to match the library font size */
+  WSearchLineEdit::down-arrow {
     image: url(skin:/classic/buttons/btn__fx_selector_down.svg);
     }
     WEffectSelector::down-arrow:hover,
     WEffectChainPresetSelector::down-arrow:hover,
-    #fadeModeCombobox::down-arrow:hover {
+    #fadeModeCombobox::down-arrow:hover,
+    WSearchLineEdit::down-arrow:hover {
       image: url(skin:/classic/buttons/btn__fx_selector_down_pressed.svg);
     }
 
@@ -1063,6 +1066,8 @@ WEffectSelector,
 WEffectSelector QAbstractScrollArea,
 WEffectChainPresetSelector,
 WEffectChainPresetSelector QAbstractScrollArea,
+WSearchLineEdit,
+WSearchLineEdit QAbstractScrollArea,
 #fadeModeCombobox,
 #fadeModeCombobox QAbstractScrollArea {
   font-family: "Open Sans";
@@ -1149,6 +1154,7 @@ WEffectSelector:!editable:on,
 WEffectSelector QAbstractScrollArea,
 WEffectChainPresetSelector,
 WEffectChainPresetSelector QAbstractScrollArea,
+WSearchLineEdit QAbstractScrollArea,
 #fadeModeCombobox:!editable,
 #fadeModeCombobox:!editable:on,
 #fadeModeCombobox QAbstractScrollArea,
@@ -1931,6 +1937,7 @@ WPushButton#SamplerExpand[displayValue="0"],
   margin: 0px 3px;
 }
 
+/* Search bar Clear button */
 WSearchLineEdit QToolButton:!focus {
   image: url(skin:/classic/buttons/btn__lib_clear_search.svg);
   }
@@ -2173,7 +2180,8 @@ WTrackTableViewHeader {
 /*********** scrollbars *********************************/
 #LibraryContainer QScrollBar,
 WEffectSelector QAbstractScrollArea QScrollBar,
-WEffectChainPresetSelector QAbstractScrollArea QScrollBar {
+WEffectChainPresetSelector QAbstractScrollArea QScrollBar,
+WSearchLineEdit QAbstractScrollArea QScrollBar {
   border: 0px solid #585858;
   background: #000;
   border-radius: 2px;
@@ -2182,7 +2190,8 @@ WEffectChainPresetSelector QAbstractScrollArea QScrollBar {
   }
   #LibraryContainer QScrollBar:horizontal,
   WEffectSelector QAbstractScrollArea QScrollBar:horizontal,
-  WEffectChainPresetSelector QAbstractScrollArea QScrollBar:horizontal {
+  WEffectChainPresetSelector QAbstractScrollArea QScrollBar:horizontal,
+  WSearchLineEdit QAbstractScrollArea QScrollBar:horizontal {
     min-width: 12px;
     height: 15px;
     border-top-left-radius: 0px;
@@ -2191,7 +2200,8 @@ WEffectChainPresetSelector QAbstractScrollArea QScrollBar {
   }
   #LibraryContainer QScrollBar:vertical,
   WEffectSelector QAbstractScrollArea QScrollBar:vertical,
-  WEffectChainPresetSelector QAbstractScrollArea QScrollBar:vertical {
+  WEffectChainPresetSelector QAbstractScrollArea QScrollBar:vertical,
+  WSearchLineEdit QAbstractScrollArea QScrollBar:vertical {
     min-height: 12px;
     width: 15px;
     border-top-left-radius: 0px;
@@ -2204,7 +2214,8 @@ WEffectChainPresetSelector QAbstractScrollArea QScrollBar {
   }*/
 #LibraryContainer QScrollBar::handle:horizontal,
 WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal,
-WEffectChainPresetSelector QAbstractScrollArea QScrollBar::handle:horizontal {
+WEffectChainPresetSelector QAbstractScrollArea QScrollBar::handle:horizontal,
+WSearchLineEdit QAbstractScrollArea QScrollBar::handle:horizontal {
   min-width: 25px;
   border-radius: 2px;
   background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
@@ -2213,7 +2224,8 @@ WEffectChainPresetSelector QAbstractScrollArea QScrollBar::handle:horizontal {
 }
 #LibraryContainer QScrollBar::handle:vertical,
 WEffectSelector QAbstractScrollArea QScrollBar::handle:vertical,
-WEffectChainPresetSelector QAbstractScrollArea QScrollBar::handle:vertical {
+WEffectChainPresetSelector QAbstractScrollArea QScrollBar::handle:vertical,
+WSearchLineEdit QAbstractScrollArea QScrollBar::handle:vertical {
   min-height: 25px;
   border-radius: 2px;
   background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
@@ -2227,7 +2239,9 @@ WEffectChainPresetSelector QAbstractScrollArea QScrollBar::handle:vertical {
 WEffectSelector QAbstractScrollArea QScrollBar::add-page,
 WEffectSelector QAbstractScrollArea QScrollBar::sub-page,
 WEffectChainPresetSelector QAbstractScrollArea QScrollBar::add-page,
-WEffectChainPresetSelector QAbstractScrollArea QScrollBar::sub-page {
+WEffectChainPresetSelector QAbstractScrollArea QScrollBar::sub-page,
+WSearchLineEdit QAbstractScrollArea QScrollBar::add-page,
+WSearchLineEdit QAbstractScrollArea QScrollBar::sub-page {
   min-width: 15px;
   min-height: 15px;
   background-color: #000;
@@ -2239,7 +2253,9 @@ WEffectChainPresetSelector QAbstractScrollArea QScrollBar::sub-page {
 WEffectSelector QAbstractScrollArea QScrollBar::add-line,
 WEffectSelector QAbstractScrollArea QScrollBar::sub-line,
 WEffectChainPresetSelector QAbstractScrollArea QScrollBar::add-line,
-WEffectChainPresetSelector QAbstractScrollArea QScrollBar::sub-line {
+WEffectChainPresetSelector QAbstractScrollArea QScrollBar::sub-line,
+WSearchLineEdit QAbstractScrollArea QScrollBar::add-line,
+WSearchLineEdit QAbstractScrollArea QScrollBar::sub-line {
   width: 0px;
   height: 0px;
   border: 0px;
@@ -2248,7 +2264,8 @@ WEffectChainPresetSelector QAbstractScrollArea QScrollBar::sub-line {
 /* Corner in between two scrollbars */
 #LibraryContainer QAbstractScrollArea::corner,
 WEffectSelector QAbstractScrollArea QScrollBar::corner,
-WEffectChainPresetSelector QAbstractScrollArea QScrollBar::corner {
+WEffectChainPresetSelector QAbstractScrollArea QScrollBar::corner,
+WSearchLineEdit QAbstractScrollArea QScrollBar::corner {
   background-color: #1e1e1e;
 }
 /*********** scrollbars *********************************/
@@ -2266,11 +2283,9 @@ WSearchLineEdit {
     border: 2px solid #d08e00;
     border-radius: 0px;
   }
-  WSearchLineEdit[active="false"],
   WSearchLineEdit:disabled {
-    color: #999;
-  }
-  WSearchLineEdit:disabled {
+    color: #191919;
+    /* hide '---' placeholder text */
     background-color: #191919;
   }
   /* Clear button: see /skins/default.qss */
@@ -2384,6 +2399,7 @@ WCueMenuPopup,
 WCoverArtMenu,
 WEffectSelector QAbstractScrollArea,
 WEffectChainPresetSelector QAbstractScrollArea,
+WSearchLineEdit QAbstractScrollArea,
 #fadeModeCombobox QAbstractScrollArea {
   border: 1px solid #888;
   border-radius: 2px;
@@ -2418,6 +2434,8 @@ WEffectSelector QAbstractScrollArea,
 WEffectSelector::item,
 WEffectChainPresetSelector QAbstractScrollArea,
 WEffectChainPresetSelector::item,
+WSearchLineEdit QAbstractScrollArea,
+WSearchLineEdit::item,
 #fadeModeCombobox QAbstractScrollArea,
 #fadeModeCombobox::item {
   background-color: #0f0f0f;
@@ -2446,6 +2464,7 @@ WCoverArtMenu::item:selected,
 WEffectSelector::item:selected,
 WEffectChainPresetSelector:item:selected,
 #fadeModeCombobox::item:selected,
+WSearchLineEdit::item:selected,
 #SkinSettingsButton[hover="true"],
 #SkinSettingsNumToggle[hover="true"],
 #SkinSettingsNumToggleHeader[hover="true"],
@@ -2456,10 +2475,18 @@ WEffectChainPresetSelector:item:selected,
   /* remove OS focus indicator */
   outline: none;
   }
+  /* checked item */
+  WEffectSelector::item:checked,
+  WEffectChainPresetSelector::item:checked,
+  #fadeModeCombobox::item:checked,
+  WSearchLineEdit::item:checked {
+    color: #fff;
+  }
   /* hover over checked effect */
   WEffectSelector::item:checked:selected,
   WEffectChainPresetSelector::item:checked:selected,
-  #fadeModeCombobox::item:checked:selected {
+  #fadeModeCombobox::item:checked:selected,
+  WSearchLineEdit::item:checked:selected {
     background-color: #2a1e03;
     color: #fff;
     }
@@ -2561,7 +2588,9 @@ WEffectSelector::indicator:unchecked:selected,
 WEffectChainPresetSelector::indicator:unchecked,
 WEffectChainPresetSelector::indicator:unchecked:selected,
 #fadeModeCombobox::indicator:unchecked,
-#fadeModeCombobox::indicator:unchecked:selected {
+#fadeModeCombobox::indicator:unchecked:selected,
+WSearchLineEdit::indicator:unchecked,
+WSearchLineEdit::indicator:unchecked:selected {
   image: none;
 }
 /************** common styles for WEffectSelector ******************************

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -147,20 +147,6 @@ QAbstractScrollArea::corner {
     margin-top: 1px;
   }
 
-#LibraryContainer {}
-
-  #LibraryContainer QScrollBar::handle:horizontal,
-  #LibraryContainer QScrollBar::handle:vertical,
-  WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal,
-  WEffectChainPresetSelector QAbstractScrollArea QScrollBar::handle:vertical,
-  WEffectChainPresetSelector QAbstractScrollArea QScrollBar::handle:horizontal,
-  WEffectSelector QAbstractScrollArea QScrollBar::handle:vertical {
-    background-color: #333338;
-    }
-    QAbstractScrollArea::corner {
-      border: 0px;
-    }
-
 /* recessed regions */
 #WaveformBox1,
 #WaveformBox2,
@@ -269,7 +255,7 @@ WSearchLineEdit {
   border-right: 0px;
   border-left: 0px;
   border-radius: 0px;
-  padding: 0px 2px 2px 2px;
+  padding: 0px 2px 2px 4px;
 }
 
 #SidebarBox {
@@ -657,24 +643,18 @@ WBeatSpinBox,
     selection-background-color: #d2d2d2;
   }
 WBeatSpinBox {
+  margin: 1px 0px 1px 1px;
+  padding: 0px -17px 2px 1px;
   border-width: 3px 19px 2px 3px;
   border-image: url(skin:/palemoon/buttons/btn_embedded_spinbox.svg) 3 19 2 3;
 }
-#spinBoxTransition {
-  border-width: 3px 19px 2px 3px;
-  border-image: url(skin:/palemoon/buttons/btn_embedded_spinbox_autodj.svg) 3 19 2 3;
-}
-
-WBeatSpinBox {
-  margin: 1px 0px 1px 1px;
-  padding: 0px -17px 2px 1px;
-}
-
 #spinBoxTransition {
   width: 24px;
   height: 19px;
   padding: 0px -15px 0px 0px;
   margin: 0px 2px 3px 5px;
+  border-width: 3px 19px 2px 3px;
+  border-image: url(skin:/palemoon/buttons/btn_embedded_spinbox_autodj.svg) 3 19 2 3;
   }
   WBeatSpinBox:focus,
   #spinBoxTransition:focus {
@@ -901,7 +881,7 @@ WEffectSelector:!editable:on {
   max-height: 17px;
   padding: 2px 0px 0px 5px;
   margin: 4px 1px 4px 1px;
-}
+  }
   /* selected item */
   WEffectSelector::checked,
   WEffectChainPresetSelector::checked,
@@ -910,23 +890,12 @@ WEffectSelector:!editable:on {
     padding-left: 5px;  */
     padding: 0px;
     margin: 0px;
-    color: #eee;
-  }
-  /* hovered items */
-  WEffectSelector::item:selected,
-  WEffectChainPresetSelector::item:selected,
-  #fadeModeCombobox::item:selected {
-    background-color: #333;
-  /* Already of those two destroys font config and puts tick mark behind text:
-    margin: 0px;
-    padding: 0px; */
-  /* This moves the tick mark behind item text,
-    text sits at left border now
-    border: 0; */
   }
   WEffectSelector::down-arrow,
   WEffectChainPresetSelector::down-arrow,
-  #fadeModeCombobox::down-arrow {
+  #fadeModeCombobox::down-arrow,
+  /* Arrow size is set in C++ to match the library font size */
+  WSearchLineEdit::down-arrow {
     image: url(skin:/palemoon/buttons/btn__fx_selector_down.svg);
   }
 
@@ -1205,7 +1174,8 @@ WEffectChainPresetSelector,
 #MainMenu QMenu,
 #MainMenu QMenu::item,
 #MainMenu QMenu QCheckBox,
-WSearchLineEdit, WTime,
+WSearchLineEdit,
+WTime,
 #PreviewDeckTextBox, #PreviewTitle, #PreviewBPM,
 #LibraryBPMSpinBox,
 #LibraryBPMButton::item,
@@ -2438,6 +2408,7 @@ WPushButton#PlayDeck[value="0"] {
   image: url(skin:/palemoon/style/mixxx_logo_small.svg) no-repeat center center;
 }
 
+/* Search bar Clear button */
 WSearchLineEdit QToolButton:!focus {
   image: url(skin:/palemoon/buttons/btn__lib_clear_search.svg);
   }
@@ -2666,7 +2637,8 @@ WTrackTableViewHeader {
 /*********** scrollbars *********************************/
 #LibraryContainer QScrollBar,
 WEffectSelector QAbstractScrollArea QScrollBar,
-WEffectChainPresetSelector QAbstractScrollArea QScrollBar {
+WEffectChainPresetSelector QAbstractScrollArea QScrollBar,
+WSearchLineEdit QAbstractScrollArea QScrollBar {
   border: 0px solid #585858;
   background: #000;
   border-radius: 2px;
@@ -2675,7 +2647,8 @@ WEffectChainPresetSelector QAbstractScrollArea QScrollBar {
   }
   #LibraryContainer QScrollBar:horizontal,
   WEffectSelector QAbstractScrollArea QScrollBar:horizontal,
-  WEffectChainPresetSelector QAbstractScrollArea QScrollBar:horizontal {
+  WEffectChainPresetSelector QAbstractScrollArea QScrollBar:horizontal,
+  WSearchLineEdit QAbstractScrollArea QScrollBar:horizontal {
     min-width: 12px;
     height: 15px;
     border-top-left-radius: 0px;
@@ -2684,7 +2657,8 @@ WEffectChainPresetSelector QAbstractScrollArea QScrollBar {
   }
   #LibraryContainer QScrollBar:vertical,
   WEffectSelector QAbstractScrollArea QScrollBar:vertical,
-  WEffectChainPresetSelector QAbstractScrollArea QScrollBar:vertical {
+  WEffectChainPresetSelector QAbstractScrollArea QScrollBar:vertical,
+  WSearchLineEdit QAbstractScrollArea QScrollBar:vertical {
     min-height: 12px;
     width: 15px;
     border-top-left-radius: 0px;
@@ -2700,12 +2674,16 @@ WEffectChainPresetSelector QAbstractScrollArea QScrollBar {
   }*/
   #LibraryContainer QScrollBar::handle:horizontal,
   WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal,
-  WEffectChainPresetSelector QAbstractScrollArea QScrollBar::handle:horizontal {
+  WEffectChainPresetSelector QAbstractScrollArea QScrollBar::handle:horizontal,
+  WSearchLineEdit QAbstractScrollArea QScrollBar::handle:horizontal {
+    background-color: #333338;
     min-width: 25px;
   }
   #LibraryContainer QScrollBar::handle:vertical,
   WEffectSelector QAbstractScrollArea QScrollBar::handle:vertical,
-  WEffectChainPresetSelector QAbstractScrollArea QScrollBar::handle:vertical {
+  WEffectChainPresetSelector QAbstractScrollArea QScrollBar::handle:vertical,
+  WSearchLineEdit QAbstractScrollArea QScrollBar::handle:vertical {
+    background-color: #333338;
     min-height: 25px;
   }
 
@@ -2715,7 +2693,9 @@ WEffectChainPresetSelector QAbstractScrollArea QScrollBar {
 WEffectSelector QAbstractScrollArea QScrollBar::add-page,
 WEffectSelector QAbstractScrollArea QScrollBar::sub-page,
 WEffectChainPresetSelector QAbstractScrollArea QScrollBar::add-page,
-WEffectChainPresetSelector QAbstractScrollArea QScrollBar::sub-page {
+WEffectChainPresetSelector QAbstractScrollArea QScrollBar::sub-page,
+WSearchLineEdit QAbstractScrollArea QScrollBar::add-page,
+WSearchLineEdit QAbstractScrollArea QScrollBar::sub-page {
   min-width: 15px;
   min-height: 15px;
   background-color: #000;
@@ -2727,7 +2707,9 @@ WEffectChainPresetSelector QAbstractScrollArea QScrollBar::sub-page {
 WEffectSelector QAbstractScrollArea QScrollBar::add-line,
 WEffectSelector QAbstractScrollArea QScrollBar::sub-line,
 WEffectChainPresetSelector QAbstractScrollArea QScrollBar::add-line,
-WEffectChainPresetSelector QAbstractScrollArea QScrollBar::sub-line {
+WEffectChainPresetSelector QAbstractScrollArea QScrollBar::sub-line,
+WSearchLineEdit QAbstractScrollArea QScrollBar::add-line,
+WSearchLineEdit QAbstractScrollArea QScrollBar::sub-line {
   width: 0px;
   height: 0px;
   border: 0px;
@@ -2736,7 +2718,9 @@ WEffectChainPresetSelector QAbstractScrollArea QScrollBar::sub-line {
 /* Corner in between two scrollbars */
 #LibraryContainer QAbstractScrollArea::corner,
 WEffectSelector QAbstractScrollArea QScrollBar::corner,
-WEffectChainPresetSelector QAbstractScrollArea QScrollBar::corner {
+WEffectChainPresetSelector QAbstractScrollArea QScrollBar::corner,
+WSearchLineEdit QAbstractScrollArea QScrollBar::corner {
+  border: 0px;
   background-color: #1e1e1e;
 }
 /*********** scrollbars *********************************/
@@ -2753,12 +2737,9 @@ WSearchLineEdit {
     border: 2px solid #257b82;
     border-radius: 0px;
   }
-  /* Dunno when this is true */
-  WSearchLineEdit[active="false"] {
-    color: #999;
-  }
   WSearchLineEdit:disabled {
     background-color: #161617;
+    /* hide '---' placeholder text */
     color: #161617;
   }
 
@@ -2900,7 +2881,8 @@ WCueMenuPopup,
 WCoverArtMenu,
 WEffectSelector QAbstractScrollArea,
 WEffectChainPresetSelector QAbstractScrollArea,
-#fadeModeCombobox QAbstractScrollArea {
+#fadeModeCombobox QAbstractScrollArea,
+WSearchLineEdit QAbstractScrollArea {
   border: 1px solid #333;
   border-radius: 1px;
 }
@@ -2933,7 +2915,9 @@ WEffectSelector::item,
 WEffectChainPresetSelector QAbstractScrollArea,
 WEffectChainPresetSelector::item,
 #fadeModeCombobox QAbstractScrollArea,
-#fadeModeCombobox::item {
+#fadeModeCombobox::item,
+WSearchLineEdit QAbstractScrollArea,
+WSearchLineEdit::item {
   background-color: #151517;
 }
 /* hovered items */
@@ -2956,6 +2940,7 @@ WCoverArtMenu::item:selected,
 WEffectSelector::item:selected,
 WEffectChainPresetSelector::item:selected,
 #fadeModeCombobox::item:selected,
+WSearchLineEdit::item:selected,
 #SkinSettingsButton[hover="true"],
 #SkinSettingsNumToggle[hover="true"],
 #SkinSettingsNumToggleHeader[hover="true"],
@@ -2967,7 +2952,13 @@ WEffectChainPresetSelector::item:selected,
   /* remove OS focus indicator */
   outline: none;
   }
-  /* hover over checked effect */
+  /* checked item */
+  WEffectSelector::item:checked,
+  WSearchLineEdit::item:checked,
+  #fadeModeCombobox::item:checked {
+    color: #fff;
+  }
+  /* hover over checked item */
   WEffectSelector::item:checked:selected,
   WSearchLineEdit::item:checked:selected,
   #fadeModeCombobox::item:checked:selected {
@@ -3073,7 +3064,9 @@ WEffectSelector::indicator:unchecked:selected,
 WEffectChainPresetSelector::indicator:unchecked,
 WEffectChainPresetSelector::indicator:unchecked:selected,
 #fadeModeCombobox::indicator:unchecked,
-#fadeModeCombobox::indicator:unchecked:selected {
+#fadeModeCombobox::indicator:unchecked:selected,
+WSearchLineEdit::indicator:unchecked,
+WSearchLineEdit::indicator:unchecked:selected {
   image: none;
 }
 /************** common styles for WEffectSelector ******************************

--- a/res/skins/Shade/btn/btn_search_down_grey.svg
+++ b/res/skins/Shade/btn/btn_search_down_grey.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="12" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <path d="M 1.5003845,3 5.9999999,7.405 10.499616,3 Z" fill="#b3b3b3"/>
+</svg>

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -44,6 +44,8 @@ WOverview /* Hotcue labels in the overview */,
 QComboBox,
 WEffectSelector,
 WEffectSelector QAbstractScrollArea,
+WSearchLineEdit,
+WSearchLineEdit QAbstractScrollArea,
 #fadeModeCombobox,
 #fadeModeCombobox QAbstractScrollArea {
   font-family: "Open Sans";
@@ -182,6 +184,7 @@ WEffectSelector::indicator:unchecked:selected,
   }
   /* Remove 3D border from unchecked effects checkmark space */
   WEffectSelector::item:selected,
+  WSearchLineEdit::item:selected,
   #fadeModeCombobox::item:selected {
     border: 0px;
   }
@@ -289,6 +292,9 @@ WEffectSelector QAbstractScrollArea,
       margin: 0px;
       image: url(skin:/btn/btn_spin_down.png) no-repeat;
     }
+    WSearchLineEdit::down-arrow {
+      image: url(skin:/btn/btn_search_down_grey.svg) no-repeat;
+    }
 
 
 /******** TODO properties identical in all skin, move to common file *************/
@@ -297,8 +303,12 @@ WEffectSelector QAbstractScrollArea,
   WEffectSelector::indicator, /* checkbox, tick mark */
   WEffectSelector::drop-down,
   WEffectSelector::indicator:unchecked,
-  #fadeModeCombobox::checked, /* selected item */
-  #fadeModeCombobox::indicator, /* checkbox, tick mark */
+  WSearchLineEdit::checked,
+  WSearchLineEdit::indicator,
+  WSearchLineEdit::drop-down,
+  WSearchLineEdit::indicator:unchecked,
+  #fadeModeCombobox::checked,
+  #fadeModeCombobox::indicator,
   #fadeModeCombobox::drop-down,
   #fadeModeCombobox::indicator:unchecked,
   WTrackMenu QMenu QCheckBox {
@@ -444,7 +454,7 @@ WLibrarySidebar {
   alternate-background-color: #1a1a1a;
 /* In selected library rows this sets the color of
   * shapes in star rating delegate  */
-  selection-color: #000;
+  selection-color: #fff;
   /* background of Color delegate in selected row */
   selection-background-color: #656d75;
 }
@@ -454,12 +464,25 @@ WLibraryTextBrowser {
 }
 
 WTrackTableView::item:selected,
+WSearchLineEdit::item:selected,
+WSearchLineEdit::item:checked,
 WLibrarySidebar::item:selected,
 WLibrarySidebar::branch:selected,
 #LibraryBPMButton::item:selected {
-  color: #000;
+  color: #fff;
   background-color: #656d75;
-}
+  }
+  WSearchLineEdit::item:checked:!selected {
+    color: #fff;
+    background-color: #32363a;
+  }
+  WSearchLineEdit::item:checked:selected {
+    color: #fff;
+    background-color: #7f8891;
+  }
+  WSearchLineEdit::indicator {
+    width:  0;
+  }
 WLibrarySidebar,
 WLibrarySidebar::item:focus {
   outline: none;
@@ -579,18 +602,25 @@ WEffectSelector::indicator:unchecked:selected,
 WSearchLineEdit {
   margin-top: 2px;
   padding: 2px;
-  border: 1px solid #656565;
-  background: #0f0f0f;
-  color: #cfcfcf;
   }
   WSearchLineEdit:focus {
     padding: 1px;
     border: 2px solid #ff6600;
-    color: #eeeeee;
     selection-color: #0f0f0f;
     selection-background-color: #d2d2d2;
   }
   /* Clear button: see /skins/default.qss */
+
+WSearchLineEdit,
+WSearchLineEdit QAbstractScrollArea,
+WSearchLineEdit::item {
+  background: #0f0f0f;
+  color: #eeeeee;
+  }
+WSearchLineEdit,
+WSearchLineEdit QAbstractScrollArea {
+  border: 1px solid #656565;
+  }
 
 
 WLibrarySidebar {
@@ -643,6 +673,8 @@ WTrackTableViewHeader::section,
 #LibraryContainer QScrollBar:vertical,
 WEffectSelector QAbstractScrollArea QScrollBar:horizontal,
 WEffectSelector QAbstractScrollArea QScrollBar:vertical,
+WSearchLineEdit QAbstractScrollArea QScrollBar:horizontal,
+WSearchLineEdit QAbstractScrollArea QScrollBar:vertical,
 #fadeModeCombobox QAbstractScrollArea QScrollBar:horizontal,
 #fadeModeCombobox QAbstractScrollArea QScrollBar:vertical {
   background-color: #626f87;
@@ -682,6 +714,7 @@ WTrackTableViewHeader::down-arrow {
 /* Scroll bars */
 #LibraryContainer QScrollBar:horizontal,
 WEffectSelector QAbstractScrollArea QScrollBar:horizontal,
+WSearchLineEdit QAbstractScrollArea QScrollBar:horizontal,
 #fadeModeCombobox QAbstractScrollArea QScrollBar:horizontal {
   min-width: 40px;
   height: 18px;
@@ -689,6 +722,7 @@ WEffectSelector QAbstractScrollArea QScrollBar:horizontal,
 }
 #LibraryContainer QScrollBar:vertical,
 WEffectSelector QAbstractScrollArea QScrollBar:vertical,
+WSearchLineEdit QAbstractScrollArea QScrollBar:vertical,
 #fadeModeCombobox QAbstractScrollArea QScrollBar:vertical {
   min-height: 40px;
   width: 18px;
@@ -699,6 +733,8 @@ WEffectSelector QAbstractScrollArea QScrollBar:vertical,
 #LibraryContainer QScrollBar::sub-page,
 WEffectSelector QAbstractScrollArea QScrollBar::add-page,
 WEffectSelector QAbstractScrollArea QScrollBar::sub-page,
+WSearchLineEdit QAbstractScrollArea QScrollBar::add-page,
+WSearchLineEdit QAbstractScrollArea QScrollBar::sub-page,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::add-page,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::sub-page {
   min-width: 14px;
@@ -709,6 +745,8 @@ WEffectSelector QAbstractScrollArea QScrollBar::sub-page,
 #LibraryContainer QScrollBar::handle:horizontal,
 WEffectSelector QAbstractScrollArea QScrollBar::handle:vertical,
 WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal,
+WSearchLineEdit QAbstractScrollArea QScrollBar::handle:vertical,
+WSearchLineEdit QAbstractScrollArea QScrollBar::handle:horizontal,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::handle:vertical,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::handle:horizontal {
   background: #626f87;
@@ -717,11 +755,13 @@ WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal,
 }
 #LibraryContainer QScrollBar::handle:horizontal,
 WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal,
+WSearchLineEdit QAbstractScrollArea QScrollBar::handle:horizontal,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::handle:horizontal {
   min-width: 40px;
 }
 #LibraryContainer QScrollBar::handle:vertical,
 WEffectSelector QAbstractScrollArea QScrollBar::handle:vertical,
+WSearchLineEdit QAbstractScrollArea QScrollBar::handle:vertical,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::handle:vertical {
   min-height: 40px;
 }
@@ -730,6 +770,8 @@ WEffectSelector QAbstractScrollArea QScrollBar::handle:vertical,
 #LibraryContainer QScrollBar::add-line:vertical,
 WEffectSelector QAbstractScrollArea QScrollBar::add-line:horizontal,
 WEffectSelector QAbstractScrollArea QScrollBar::add-line:vertical,
+WSearchLineEdit QAbstractScrollArea QScrollBar::add-line:horizontal,
+WSearchLineEdit QAbstractScrollArea QScrollBar::add-line:vertical,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::add-line:horizontal,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::add-line:vertical {
   width: 0px;
@@ -739,6 +781,8 @@ WEffectSelector QAbstractScrollArea QScrollBar::add-line:vertical,
 #LibraryContainer QScrollBar::sub-line:vertical,
 WEffectSelector QAbstractScrollArea QScrollBar::sub-line:horizontal,
 WEffectSelector QAbstractScrollArea QScrollBar::sub-line:vertical,
+WSearchLineEdit QAbstractScrollArea QScrollBar::sub-line:horizontal,
+WSearchLineEdit QAbstractScrollArea QScrollBar::sub-line:vertical,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::sub-line:horizontal,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::sub-line:vertical {
   width: 0px;
@@ -748,6 +792,7 @@ WEffectSelector QAbstractScrollArea QScrollBar::sub-line:vertical,
 /* Corner in between two scrollbars */
 #LibraryContainer QAbstractScrollArea::corner,
 WEffectSelector QAbstractScrollArea::corner,
+WSearchLineEdit QAbstractScrollArea::corner,
 #fadeModeCombobox QAbstractScrollArea::corner {
   background-color: #0f0f0f;
   border-top: 1px solid #585858;

--- a/res/skins/Shade/style/style_branch_closed_selected.svg
+++ b/res/skins/Shade/style/style_branch_closed_selected.svg
@@ -1,3 +1,3 @@
 <svg width="16" height="16" version="1.1" xmlns="http://www.w3.org/2000/svg">
-  <path d="M 4,3.7810002 12,8 4,12.219 V 3.7810002" stroke-width=".703157"/>
+  <path d="M 4,3.7810002 12,8 4,12.219 V 3.7810002" fill="#ffffff" stroke-width=".703157"/>
 </svg>

--- a/res/skins/Shade/style/style_branch_open_selected.svg
+++ b/res/skins/Shade/style/style_branch_open_selected.svg
@@ -1,3 +1,3 @@
 <svg width="16" height="16" version="1.1" xmlns="http://www.w3.org/2000/svg">
-  <path d="M 12.219,4 8,12 3.7810002,4 H 12.219" stroke-width=".703157"/>
+  <path d="M 12.219,4 8,12 3.7810002,4 H 12.219" fill="#fefefe" stroke-width=".703157"/>
 </svg>

--- a/res/skins/Tango/library.xml
+++ b/res/skins/Tango/library.xml
@@ -43,6 +43,7 @@ Description:
                 <!-- minSize so that 8 Preview HotCues fit nicely, 23+1px each -->
                 <Size>159min,74me</Size>
                 <Children>
+
                   <Template src="skin:../Tango/decks/preview_deck.xml"/>
 
                   <WidgetGroup>
@@ -61,6 +62,7 @@ Description:
                     <Orientation>vertical</Orientation>
                     <Collapsible>0,0</Collapsible>
                     <Children>
+
                       <WidgetGroup><!-- Preview Deck, Search, Tree View -->
                         <Layout>vertical</Layout>
                         <SizePolicy>me,min</SizePolicy>

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -56,6 +56,9 @@ WEffectSelector,
 WEffectSelector QAbstractScrollArea,
 WEffectChainPresetSelector,
 WEffectChainPresetSelector QAbstractScrollArea,
+WEffectChainPresetButton QMenu,
+WEffectChainPresetButton QMenu QCheckBox,
+WSearchLineEdit QAbstractScrollArea,
 #fadeModeCombobox,
 #fadeModeCombobox QAbstractScrollArea,
 /* With 'Ubuntu' font the header section titles would always be top-aligned... */
@@ -1805,6 +1808,7 @@ decks, samplers, mic, aux, fx */
 
   WEffectSelector::down-arrow,
   WEffectChainPresetButton::menu-indicator,
+  WSearchLineEdit::down-arrow,
   #fadeModeCombobox::down-arrow {
     /* With a fixed size and the skin being scaled
     * button icon is not scaled
@@ -1816,6 +1820,7 @@ decks, samplers, mic, aux, fx */
     }
     WEffectSelector::down-arrow:hover,
     WEffectChainPresetButton::menu-indicator:hover,
+    WSearchLineEdit::down-arrow:hover,
     #fadeModeCombobox::down-arrow:hover {
       image: url(skin:/../Tango/buttons/btn_arrow_down_fx_hover.svg) no-repeat center center;
     }
@@ -1828,6 +1833,7 @@ decks, samplers, mic, aux, fx */
 
   WEffectSelector QAbstractScrollArea,
   WEffectChainPresetSelector QAbstractScrollArea,
+  WSearchLineEdit QAbstractScrollArea,
   #fadeModeCombobox QAbstractScrollArea {
     border-radius: 2px;
     margin: 0px;
@@ -2200,13 +2206,18 @@ WTrackProperty#SamplerTitle_mini {
 WEffectSelector::checked, /* selected item */
 WEffectSelector::indicator, /* checkbox, tick mark */
 WEffectSelector::indicator:unchecked,
+
 WEffectSelector::drop-down,
 WEffectChainPresetSelector::checked,
 WEffectChainPresetSelector::indicator,
 WEffectChainPresetSelector::indicator:unchecked,
 WEffectChainPresetSelector::drop-down,
-#fadeModeCombobox::checked, /* selected mode */
-#fadeModeCombobox::indicator, /* checkbox, tick mark */
+WSearchLineEdit::checked,
+WSearchLineEdit::indicator,
+WSearchLineEdit::indicator:unchecked,
+WSearchLineEdit::drop-down,
+#fadeModeCombobox::checked,
+#fadeModeCombobox::indicator,
 #fadeModeCombobox::indicator:unchecked,
 #fadeModeCombobox::drop-down {
   padding: 0px;
@@ -2299,6 +2310,7 @@ WEffectChainPresetSelector::item,
 WEffectChainPresetButton QMenu,
 WEffectChainPresetButton QMenu::item,
 WEffectChainPresetButton QMenu QCheckBox,
+WSearchLineEdit QAbstractScrollArea,
 #fadeModeCombobox,
 #fadeModeCombobox QAbstractScrollArea,
 #fadeModeCombobox QAbstractScrollArea::item {
@@ -2318,6 +2330,7 @@ WCoverArtMenu,
 WEffectSelector QAbstractScrollArea,
 WEffectChainPresetButton QMenu,
 WEffectChainPresetSelector QAbstractScrollArea,
+WSearchLineEdit QAbstractScrollArea,
 #fadeModeCombobox QAbstractScrollArea {
   border: 1px solid #888;
   border-radius: 2px;
@@ -2348,6 +2361,11 @@ QLineEdit QMenu::item:selected,
 WCoverArtMenu::item:selected,
 WEffectSelector::item:selected,
 WEffectChainPresetSelector::item:selected,
+WEffectChainPresetButton QMenu::item:selected,
+WEffectChainPresetButton QMenu QCheckBox:selected,
+WEffectChainPresetButton QMenu QCheckBox:focus,
+WEffectChainPresetButton QMenu QCheckBox:hover,
+WSearchLineEdit::item:selected,
 #fadeModeCombobox::item:selected {
   background-color: #555;
   color: #fff;
@@ -2369,6 +2387,7 @@ QLineEdit QMenu::item:disabled {
   #MainMenu QMenu::separator,
   WLibrarySidebar QMenu::separator,
   WTrackTableViewHeader QMenu::separator,
+  WEffectChainPresetButton QMenu::separator,
   WTrackMenu::separator,
   WTrackMenu QMenu::separator,
   WLibraryTextBrowser QMenu::separator,
@@ -2378,6 +2397,7 @@ QLineEdit QMenu::item:disabled {
 
 WLibrarySidebar QMenu::indicator,
 WTrackTableViewHeader QMenu::indicator,
+WEffectChainPresetButton QMenu QCheckBox::indicator,
 WTrackMenu QMenu QCheckBox::indicator {
   background-color: #0f0f0f;
   border: 1px solid #333;
@@ -2385,6 +2405,7 @@ WTrackMenu QMenu QCheckBox::indicator {
   }
   WLibrarySidebar QMenu::indicator:checked,
   WTrackTableViewHeader QMenu::indicator:checked,
+  WEffectChainPresetButton QMenu QCheckBox::indicator:checked,
   WTrackMenu QMenu QCheckBox::indicator:checked {
     image: url(skin:/../Tango/buttons/btn_lib_checkmark.svg);
     border: 1px solid #111;
@@ -2682,12 +2703,14 @@ WLibraryTextBrowser {
 #LibraryContainer QScrollBar,
 WEffectSelector QAbstractScrollArea QScrollBar,
 WEffectChainPresetSelector QAbstractScrollArea QScrollBar,
+WSearchLineEdit QAbstractScrollArea QScrollBar,
 #fadeModeCombobox QAbstractScrollArea QScrollBar {
   padding: 1px;
 }
 #LibraryContainer QScrollBar:horizontal,
 WEffectSelector QAbstractScrollArea QScrollBar:horizontal,
 WEffectChainPresetSelector QAbstractScrollArea QScrollBar:horizontal,
+WSearchLineEdit QAbstractScrollArea QScrollBar:horizontal,
 #fadeModeCombobox QAbstractScrollArea QScrollBar:horizontal {
   min-width: 12px;
   height: 10px;
@@ -2697,6 +2720,7 @@ WEffectChainPresetSelector QAbstractScrollArea QScrollBar:horizontal,
   #LibraryContainer QScrollBar:vertical,
   WEffectSelector QAbstractScrollArea QScrollBar:vertical,
   WEffectChainPresetSelector QAbstractScrollArea QScrollBar:vertical,
+  WSearchLineEdit QAbstractScrollArea QScrollBar:vertical,
   #fadeModeCombobox QAbstractScrollArea QScrollBar:vertical {
     min-height: 12px;
     width: 10px;
@@ -2710,6 +2734,8 @@ WEffectChainPresetSelector QAbstractScrollArea QScrollBar:horizontal,
   WEffectSelector QAbstractScrollArea QScrollBar::sub-page,
   WEffectChainPresetSelector QAbstractScrollArea QScrollBar::add-page,
   WEffectChainPresetSelector QAbstractScrollArea QScrollBar::sub-page,
+  WSearchLineEdit QAbstractScrollArea QScrollBar::add-page,
+  WSearchLineEdit QAbstractScrollArea QScrollBar::sub-page,
   #fadeModeCombobox QAbstractScrollArea QScrollBar::add-page,
   #fadeModeCombobox QAbstractScrollArea QScrollBar::sub-page {
     min-width: 15px;
@@ -2719,6 +2745,7 @@ WEffectChainPresetSelector QAbstractScrollArea QScrollBar:horizontal,
   #LibraryContainer QScrollBar::handle:horizontal,
   WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal,
   WEffectChainPresetSelector QAbstractScrollArea QScrollBar::handle:horizontal,
+  WSearchLineEdit QAbstractScrollArea QScrollBar::handle:horizontal,
   #fadeModeCombobox QAbstractScrollArea QScrollBar::handle:horizontal {
     min-width: 25px;
     background: #595959;
@@ -2727,12 +2754,14 @@ WEffectChainPresetSelector QAbstractScrollArea QScrollBar:horizontal,
     #LibraryContainer QScrollBar::handle:horizontal:hover,
     WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal:hover,
     WEffectChainPresetSelector QAbstractScrollArea QScrollBar::handle:horizontal:hover,
+    WSearchLineEdit QAbstractScrollArea QScrollBar::handle:horizontal:hover,
     #fadeModeCombobox QAbstractScrollArea QScrollBar::handle:horizontal:hover {
       background: #888;
     }
   #LibraryContainer QScrollBar::handle:vertical,
   WEffectSelector QAbstractScrollArea QScrollBar::handle:vertical,
   WEffectChainPresetSelector QAbstractScrollArea QScrollBar::handle:vertical,
+  WSearchLineEdit QAbstractScrollArea QScrollBar::handle:vertical,
   #fadeModeCombobox QAbstractScrollArea QScrollBar::handle:vertical {
     min-height: 25px;
     background: #595959;
@@ -2741,6 +2770,7 @@ WEffectChainPresetSelector QAbstractScrollArea QScrollBar:horizontal,
     #LibraryContainer QScrollBar::handle:vertical:hover,
     WEffectSelector QAbstractScrollArea QScrollBar::handle:vertical:hover,
     WEffectChainPresetSelector QAbstractScrollArea QScrollBar::handle:vertical:hover,
+    WSearchLineEdit QAbstractScrollArea QScrollBar::handle:vertical:hover,
     #fadeModeCombobox QAbstractScrollArea QScrollBar::handle:vertical:hover {
       background: #888;
     }
@@ -2751,6 +2781,8 @@ WEffectChainPresetSelector QAbstractScrollArea QScrollBar:horizontal,
   WEffectSelector QAbstractScrollArea QScrollBar::add-line:vertical,
   WEffectChainPresetSelector QAbstractScrollArea QScrollBar::add-line:horizontal,
   WEffectChainPresetSelector QAbstractScrollArea QScrollBar::add-line:vertical,
+  WSearchLineEdit QAbstractScrollArea QScrollBar::add-line:horizontal,
+  WSearchLineEdit QAbstractScrollArea QScrollBar::add-line:vertical,
   #fadeModeCombobox QAbstractScrollArea QScrollBar::add-line:horizontal,
   #fadeModeCombobox QAbstractScrollArea QScrollBar::add-line:vertical {
     width: 0px;
@@ -2762,6 +2794,8 @@ WEffectChainPresetSelector QAbstractScrollArea QScrollBar:horizontal,
   WEffectSelector QAbstractScrollArea QScrollBar::sub-line:vertical,
   WEffectChainPresetSelector QAbstractScrollArea QScrollBar::sub-line:horizontal,
   WEffectChainPresetSelector QAbstractScrollArea QScrollBar::sub-line:vertical,
+  WSearchLineEdit QAbstractScrollArea QScrollBar::sub-line:horizontal,
+  WSearchLineEdit QAbstractScrollArea QScrollBar::sub-line:vertical,
   #fadeModeCombobox QAbstractScrollArea QScrollBar::sub-line:horizontal,
   #fadeModeCombobox QAbstractScrollArea QScrollBar::sub-line:vertical {
     width: 0px;
@@ -2771,6 +2805,7 @@ WEffectChainPresetSelector QAbstractScrollArea QScrollBar:horizontal,
   #LibraryContainer QAbstractScrollArea::corner,
   WEffectSelector QAbstractScrollArea::corner,
   WEffectChainPresetSelector QAbstractScrollArea::corner,
+  WSearchLineEdit QAbstractScrollArea::corner,
   #fadeModeCombobox QAbstractScrollArea::corner {
     background-color: #0f0f0f;
     border: 0px;
@@ -3040,7 +3075,6 @@ WSearchLineEdit {
   margin-bottom: 5px; */
   }
   WSearchLineEdit:focus {
-    padding: 1px;
     color: #eeeeee;
   }
   /* Clear button: see /skins/default.qss */

--- a/res/skins/default.qss
+++ b/res/skins/default.qss
@@ -104,6 +104,7 @@ WCoverArtMenu,
 WEffectChainPresetButton QMenu,
 WEffectSelector QAbstractScrollArea,
 WEffectChainPresetSelector QAbstractScrollArea,
+WSearchLineEdit QAbstractScrollArea,
 #fadeModeCombobox QAbstractScrollArea {
   padding: 0.15em;
 }

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -78,8 +78,7 @@ class WSearchLineEdit : public QComboBox, public WBaseWidget {
 
     void enableSearch(const QString& text);
     void updateEditBox(const QString& text);
-    void updateClearButton(const QString& text);
-    void updateStyleMetrics();
+    void updateClearAndDropdownButton(const QString& text);
     void deleteSelectedComboboxItem();
     void deleteSelectedListItem();
 
@@ -98,9 +97,7 @@ class WSearchLineEdit : public QComboBox, public WBaseWidget {
 
     parented_ptr<QToolButton> const m_clearButton;
 
-    int m_frameWidth;
     int m_innerHeight;
-    int m_dropButtonWidth;
 
     QTimer m_debouncingTimer;
     QTimer m_saveTimer;


### PR DESCRIPTION
Skin styles for the new searchbox drop-down menu.

* wider drop-down button, aspect ratio ~2:3
* drop-down is resized with the library font


![image](https://user-images.githubusercontent.com/5934199/140626258-a826b34b-0562-45ca-84ca-8ed0dbbf66c1.png)

- [x] LateNight
- [x] Tango
- [x] Deere
- [x] Shade
