### PR TITLE
LegacySkin: Add missing include for QRegularExpression

### DIFF
--- a/src/skin/legacy/legacyskin.cpp
+++ b/src/skin/legacy/legacyskin.cpp
@@ -1,5 +1,7 @@
 #include "skin/legacy/legacyskin.h"
 
+#include <QRegularExpression>
+
 #include "coreservices.h"
 #include "skin/legacy/legacyskinparser.h"
 


### PR DESCRIPTION
Should fix a build error:

    /var/tmp/portage/media-sound/mixxx-9999/work/mixxx-9999/src/skin/legacy/legacyskin.cpp:8:40: error: variable ‘const QRegularExpression {anonymous}::kMinSizeRegExp’ has initializer but incomplete type
        8 | const QRegularExpression kMinSizeRegExp(QStringLiteral("<MinimumSize>(\\d+), *(\\d+)<"));
          |                                        ^
    /var/tmp/portage/media-sound/mixxx-9999/work/mixxx-9999/src/skin/legacy/legacyskin.cpp:9:37: error: variable ‘const QRegularExpression {anonymous}::kDigitRegex’ has initializer but incomplete type
        9 | const QRegularExpression kDigitRegex(QStringLiteral("\\d"));
          |                                     ^
    /var/tmp/portage/media-sound/mixxx-9999/work/mixxx-9999/src/skin/legacy/legacyskin.cpp: In member function ‘virtual bool mixxx::skin::legacy::LegacySkin::fitsScreenSize(const QScreen&) const’:
    /var/tmp/portage/media-sound/mixxx-9999/work/mixxx-9999/src/skin/legacy/legacyskin.cpp:93:33: error: aggregate ‘QRegularExpressionMatch match’ has incomplete type and cannot be defined
       93 |         QRegularExpressionMatch match;
          |                                 ^~~~~

Reported here: https://github.com/mixxxdj/mixxx/pull/4289#issuecomment-962651800