### PR TITLE
Add libopengl-dev package to debian_buildenv.sh

### DIFF
--- a/tools/debian_buildenv.sh
+++ b/tools/debian_buildenv.sh
@@ -60,6 +60,7 @@ case "$1" in
             libmad0-dev \
             libmodplug-dev \
             libmp3lame-dev \
+            libopengl-dev \
             libopus-dev \
             libopusfile-dev \
             libportmidi-dev \


### PR DESCRIPTION
This package is needed to build mixxx on Debian testing but for some reason was not included in the script.