### PR TITLE
LateNight: unipolar Quick Effect knob arcs

### DIFF
--- a/res/skins/LateNight/mixer/quick_effect_knob_4decks.xml
+++ b/res/skins/LateNight/mixer/quick_effect_knob_4decks.xml
@@ -70,7 +70,7 @@
                     <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
                     <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
                     <ArcRadius><Variable name="ArcRadius"/></ArcRadius>
-                    <ArcUnipolar><Variable name="ArcUnipolar"/></ArcUnipolar>
+                    <ArcUnipolar>true</ArcUnipolar>
                     <ArcReversed><Variable name="ArcReversed"/></ArcReversed>
                     <ArcColor><Variable name="ArcColorFx12Quick"/></ArcColor>
                     <ArcThickness><Variable name="ArcThickness"/></ArcThickness>

--- a/res/skins/LateNight/mixer/quick_effect_knob_left.xml
+++ b/res/skins/LateNight/mixer/quick_effect_knob_left.xml
@@ -57,7 +57,7 @@
                 <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
                 <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
                 <ArcRadius><Variable name="ArcRadius"/></ArcRadius>
-                <ArcUnipolar><Variable name="ArcUnipolar"/></ArcUnipolar>
+                <ArcUnipolar>true</ArcUnipolar>
                 <ArcReversed><Variable name="ArcReversed"/></ArcReversed>
                 <ArcColor><Variable name="ArcColorFx12Quick"/></ArcColor>
                 <ArcThickness><Variable name="ArcThickness"/></ArcThickness>

--- a/res/skins/LateNight/mixer/quick_effect_knob_right.xml
+++ b/res/skins/LateNight/mixer/quick_effect_knob_right.xml
@@ -25,7 +25,7 @@
                 <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
                 <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
                 <ArcRadius><Variable name="ArcRadius"/></ArcRadius>
-                <ArcUnipolar><Variable name="ArcUnipolar"/></ArcUnipolar>
+                <ArcUnipolar>true</ArcUnipolar>
                 <ArcReversed><Variable name="ArcReversed"/></ArcReversed>
                 <ArcColor><Variable name="ArcColorFx12Quick"/></ArcColor>
                 <ArcThickness><Variable name="ArcThickness"/></ArcThickness>


### PR DESCRIPTION
The knob arcs being drawn from the center notch only makes sense for filters (and maybe custom chains) but is confusing for all other effects.