### PR TITLE
Beats: Use "last marker" term instead of "end marker"

### DIFF
--- a/src/test/beatstest.cpp
+++ b/src/test/beatstest.cpp
@@ -446,8 +446,8 @@ TEST(BeatsTest, NonConstTempoFromBeatPositions) {
     EXPECT_EQ(16, markers[2].beatsTillNextMarker());
 
     EXPECT_DOUBLE_EQ((kStartPosition + 48 * beatLengthFrames).value(),
-            pBeats->getEndMarkerPosition().value());
-    EXPECT_EQ(kBpm * 2, pBeats->getEndMarkerBpm());
+            pBeats->getLastMarkerPosition().value());
+    EXPECT_EQ(kBpm * 2, pBeats->getLastMarkerBpm());
 }
 
 TEST(BeatsTest, ConstTempoFindNthBeatWhenOnBeat) {

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -22,6 +22,7 @@ namespace mixxx {
 class Beats;
 typedef std::shared_ptr<const Beats> BeatsPointer;
 
+/// A beat marker is denotes the border of a tempo section inside a track.
 class BeatMarker {
   public:
     BeatMarker(mixxx::audio::FramePos position, int beatsTillNextMarker)
@@ -52,9 +53,15 @@ inline bool operator==(const BeatMarker& lhs, const BeatMarker& rhs) {
 inline bool operator!=(const BeatMarker& lhs, const BeatMarker& rhs) {
     return !(lhs == rhs);
 }
-/// Beats is the base class for BPM and beat management classes. It provides a
-/// specification of all methods a beat-manager class must provide, as well as
-/// a capability model for representing optional features.
+
+/// This class represents the beats of a track.
+///
+/// Internally, it uses the following data structure:
+/// - 0 - N beat markers, followed by
+/// - exactly one tempo marker ("last marker").
+///
+/// If the track has a constant tempo, there are 0 beat markers, and the last
+/// marker is positioned at the first downbeat and is set to the tracks BPM.
 ///
 /// All instances of this class are supposed to be managed by std::shared_ptr!
 class Beats : private std::enable_shared_from_this<Beats> {

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -145,28 +145,28 @@ class Beats : private std::enable_shared_from_this<Beats> {
     };
 
     Beats(std::vector<BeatMarker> markers,
-            mixxx::audio::FramePos endMarkerPosition,
-            mixxx::Bpm endMarkerBpm,
+            mixxx::audio::FramePos lastMarkerPosition,
+            mixxx::Bpm lastMarkerBpm,
             mixxx::audio::SampleRate sampleRate,
             const QString& subVersion)
             : m_markers(std::move(markers)),
-              m_endMarkerPosition(endMarkerPosition),
-              m_endMarkerBpm(endMarkerBpm),
+              m_lastMarkerPosition(lastMarkerPosition),
+              m_lastMarkerBpm(lastMarkerBpm),
               m_sampleRate(sampleRate),
               m_subVersion(subVersion) {
-        DEBUG_ASSERT(m_endMarkerPosition.isValid());
-        DEBUG_ASSERT(!m_endMarkerPosition.isFractional());
-        DEBUG_ASSERT(m_endMarkerBpm.isValid());
+        DEBUG_ASSERT(m_lastMarkerPosition.isValid());
+        DEBUG_ASSERT(!m_lastMarkerPosition.isFractional());
+        DEBUG_ASSERT(m_lastMarkerBpm.isValid());
         DEBUG_ASSERT(m_sampleRate.isValid());
     }
 
-    Beats(mixxx::audio::FramePos endMarkerPosition,
-            mixxx::Bpm endMarkerBpm,
+    Beats(mixxx::audio::FramePos lastMarkerPosition,
+            mixxx::Bpm lastMarkerBpm,
             mixxx::audio::SampleRate sampleRate,
             const QString& subVersion)
             : Beats(std::vector<BeatMarker>(),
-                      endMarkerPosition,
-                      endMarkerBpm,
+                      lastMarkerPosition,
+                      lastMarkerBpm,
                       sampleRate,
                       subVersion) {
     }
@@ -206,8 +206,8 @@ class Beats : private std::enable_shared_from_this<Beats> {
 
     friend bool operator==(const Beats& lhs, const Beats& rhs) {
         return lhs.m_markers == rhs.m_markers &&
-                lhs.m_endMarkerPosition == rhs.m_endMarkerPosition &&
-                lhs.m_endMarkerBpm == rhs.m_endMarkerBpm && lhs.m_sampleRate &&
+                lhs.m_lastMarkerPosition == rhs.m_lastMarkerPosition &&
+                lhs.m_lastMarkerBpm == rhs.m_lastMarkerBpm && lhs.m_sampleRate &&
                 rhs.m_sampleRate;
     }
 
@@ -250,8 +250,8 @@ class Beats : private std::enable_shared_from_this<Beats> {
     static mixxx::BeatsPointer fromBeatMarkers(
             audio::SampleRate sampleRate,
             const std::vector<BeatMarker>& beatMarker,
-            const audio::FramePos endMarkerPosition,
-            const Bpm endMarkerBpm,
+            const audio::FramePos lastMarkerPosition,
+            const Bpm lastMarkerBpm,
             const QString& subVersion = QString());
 
     enum class BpmScale {
@@ -368,11 +368,12 @@ class Beats : private std::enable_shared_from_this<Beats> {
     const std::vector<BeatMarker>& getMarkers() const {
         return m_markers;
     }
-    mixxx::audio::FramePos getEndMarkerPosition() const {
-        return m_endMarkerPosition;
+
+    mixxx::audio::FramePos getLastMarkerPosition() const {
+        return m_lastMarkerPosition;
     }
-    mixxx::Bpm getEndMarkerBpm() const {
-        return m_endMarkerBpm;
+    mixxx::Bpm getLastMarkerBpm() const {
+        return m_lastMarkerBpm;
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -417,11 +418,11 @@ class Beats : private std::enable_shared_from_this<Beats> {
     QByteArray toBeatMapByteArray() const;
 
     mixxx::audio::FrameDiff_t firstBeatLengthFrames() const;
-    mixxx::audio::FrameDiff_t endBeatLengthFrames() const;
+    mixxx::audio::FrameDiff_t lastBeatLengthFrames() const;
 
     std::vector<BeatMarker> m_markers;
-    mixxx::audio::FramePos m_endMarkerPosition;
-    mixxx::Bpm m_endMarkerBpm;
+    mixxx::audio::FramePos m_lastMarkerPosition;
+    mixxx::Bpm m_lastMarkerBpm;
     mixxx::audio::SampleRate m_sampleRate;
 
     // The sub-version of this beatgrid.

--- a/src/track/serato/beatgrid.cpp
+++ b/src/track/serato/beatgrid.cpp
@@ -435,14 +435,14 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
     const auto markers = pBeats->getMarkers();
     QList<SeratoBeatGridNonTerminalMarkerPointer> nonTerminalMarkers;
 
-    const float bpm = static_cast<float>(pBeats->getEndMarkerBpm().value());
+    const float bpm = static_cast<float>(pBeats->getLastMarkerBpm().value());
 
     if (markers.size() == 1) {
         const auto& marker = markers.back();
         const auto lastBeatLengthFrames = 60.0 * pBeats->getSampleRate() /
-                pBeats->getEndMarkerBpm().value();
+                pBeats->getLastMarkerBpm().value();
         const auto previousBeatLengthFrames =
-                (pBeats->getEndMarkerPosition() - marker.position()) /
+                (pBeats->getLastMarkerPosition() - marker.position()) /
                 marker.beatsTillNextMarker();
         // If the following condition holds true, the marker only exists for backwards compatibility with the legacy beatgrid format.
         //
@@ -474,7 +474,7 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
 
     const float positionSecs =
             static_cast<float>(signalInfo.frames2secsFractional(
-                                       pBeats->getEndMarkerPosition().value()) -
+                                       pBeats->getLastMarkerPosition().value()) -
                     timingOffsetSecs);
 
     setTerminalMarker(std::make_shared<SeratoBeatGridTerminalMarker>(positionSecs, bpm));

--- a/src/track/serato/beatsimporter.cpp
+++ b/src/track/serato/beatsimporter.cpp
@@ -59,10 +59,10 @@ BeatsPointer SeratoBeatsImporter::importBeatsAndApplyTimingOffset(
         markers.push_back(BeatMarker{position.toLowerFrameBoundary(), beatsTillNextMarker});
     }
 
-    const auto endMarkerPosition = audio::FramePos(
+    const auto lastMarkerPosition = audio::FramePos(
             signalInfo.secs2frames(m_pTerminalMarker->positionSecs()) +
             timingOffsetFrames);
-    const auto endMarkerBpm = Bpm(m_pTerminalMarker->bpm());
+    const auto lastMarkerBpm = Bpm(m_pTerminalMarker->bpm());
 
     m_nonTerminalMarkers.clear();
     m_pTerminalMarker.reset();
@@ -70,8 +70,8 @@ BeatsPointer SeratoBeatsImporter::importBeatsAndApplyTimingOffset(
     return Beats::fromBeatMarkers(
             signalInfo.getSampleRate(),
             std::move(markers),
-            endMarkerPosition.toLowerFrameBoundary(),
-            endMarkerBpm);
+            lastMarkerPosition.toLowerFrameBoundary(),
+            lastMarkerBpm);
 }
 
 } // namespace mixxx


### PR DESCRIPTION
This was discussed on Zulip: https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/beat.20grid.20revamp.20re.3A.20pr.20.232961/near/260871852