### PR TITLE
.eslintrc.json: adjust eslint rules to enforce readable chain syntax

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,7 @@
     "computed-property-spacing" : ["warn", "never", {
         "enforceForClassMembers": true
     }],
-    "dot-location": "warn",
+    "dot-location": ["warn", "property"],
     "dot-notation": "warn",
     "eqeqeq": ["error", "always"],
     "func-call-spacing": "warn",
@@ -27,6 +27,7 @@
     "key-spacing": "warn",
     "keyword-spacing": "warn",
     "linebreak-style": ["warn", "unix"],
+    "newline-per-chained-call": "warn",
     "no-constructor-return": "warn",
     "no-extra-bind": "warn",
     "no-sequences": "warn",


### PR DESCRIPTION
previously, the eslint hook would enforce that the dot of multi-
line chaining was attached to the object instead of the property
thus formatting the first example into the second which I
find less readable.

```javascript
const a = _({})
    .mapKeys(...)
    .filter(...)
    .value();
```
```javascript
const a = _({}).
    mapKeys(...).
    filter(...).
    value();
```