### PR TITLE
Search: Ctrl+F in focused search box selects the entire search string

### DIFF
--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -373,6 +373,7 @@ bool WSearchLineEdit::eventFilter(QObject* obj, QEvent* event) {
             }
             return true;
         }
+        // if the line edit has focus Ctrl + F selects the text
     }
     return QComboBox::eventFilter(obj, event);
 }
@@ -691,7 +692,11 @@ void WSearchLineEdit::slotTextChanged(const QString& text) {
 }
 
 void WSearchLineEdit::slotSetShortcutFocus() {
-    setFocus(Qt::ShortcutFocusReason);
+    if (hasFocus()) {
+        lineEdit()->selectAll();
+    } else {
+        setFocus(Qt::ShortcutFocusReason);
+    }
 }
 
 // Use the same font as the library table and the sidebar


### PR DESCRIPTION
Recently I didn't pay attention to focus borders when browsing tracks, and reflexively hit Ctrl+F and started typing to replace the search query.
Unfortunately, if the search box was already focused, that only appended the new string.

With this Ctrl + F always selects the entitre string.