### PR TITLE
LateNight: fixup width of Quick Effect popup

### DIFF
--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -122,7 +122,8 @@ WTrackMenu QMenu::right-arrow {
   height: 0.7em;
 }
 
-WEffectSelector QAbstractScrollArea {
+WEffectSelector QAbstractScrollArea,
+WEffectChainPresetSelector QAbstractScrollArea {
   min-width: 160px;
 }
 #fadeModeCombobox QAbstractScrollArea {


### PR DESCRIPTION
@JoergAtGithub Please test this
Supposed to look like this (on Linux, popup unrolls differently on Windows)
![image](https://user-images.githubusercontent.com/5934199/141645029-e7a77e0c-f2f3-42e0-ad21-c9c63380c7e2.png)
