### PR TITLE
HidController: change getInputReport to automatically call script

### DIFF
--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -163,7 +163,7 @@ void HidController::processInputReport(int bytesRead) {
     receive(incomingData, mixxx::Time::elapsed());
 }
 
-QList<int> HidController::getInputReport(unsigned int reportID) {
+void HidController::getInputReport(unsigned int reportID) {
     Trace hidRead("HidController getInputReport");
     int bytesRead;
 
@@ -186,17 +186,10 @@ QList<int> HidController::getInputReport(unsigned int reportID) {
         // Otherwise minimum possible value is 1, because 1 byte is for the reportID,
         // the smallest report with data is therefore 2 bytes.
         DEBUG_ASSERT(bytesRead <= kReportIdSize);
-        return QList<int>();
+        return;
     }
 
-    // Convert array of bytes read in a JavaScript compatible return type
-    // For compatibility with the array provided by HidController::poll the reportID is contained as prefix
-    QList<int> dataList;
-    dataList.reserve(bytesRead);
-    for (int i = 0; i < bytesRead; i++) {
-        dataList.append(m_pPollData[m_pollingBufferIndex][i]);
-    }
-    return dataList;
+    processInputReport(bytesRead);
 }
 
 bool HidController::poll() {

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -51,11 +51,8 @@ class HidController final : public Controller {
     // getInputReport receives an input report on request.
     // This can be used on startup to initialize the knob positions in Mixxx
     // to the physical position of the hardware knobs on the controller.
-    // The returned data structure for the input reports is the same
-    // as in the polling functionality (including ReportID in first byte).
-    // The returned list can be used to call the incomingData
-    // function of the common-hid-packet-parser.
-    QList<int> getInputReport(unsigned int reportID);
+    // The data is automatically passed to the script's incomingData function.
+    void getInputReport(unsigned int reportID);
 
     // getFeatureReport receives a feature reports on request.
     // HID doesn't support polling feature reports, therefore this is the
@@ -96,7 +93,7 @@ class HidControllerJSProxy : public ControllerJSProxy {
         m_pHidController->sendReport(data, length, reportID);
     }
 
-    Q_INVOKABLE QList<int> getInputReport(
+    Q_INVOKABLE void getInputReport(
             unsigned int reportID) {
         return m_pHidController->getInputReport(reportID);
     }


### PR DESCRIPTION
This way, scripts don't need to wrap calls to
controller.getInputReport with another call to their incomingData
function.