### PR TITLE
HidController: return QByteArrays for get[Input/Feature]Report

### DIFF
--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -314,8 +314,6 @@ QByteArray HidController::getFeatureReport(
     // For compatibility with input array HidController::sendFeatureReport, a reportID prefix is not added here
     QByteArray byteArray;
     byteArray.reserve(bytesRead - kReportIdSize);
-    for (int i = kReportIdSize; i < bytesRead; i++) {
-        byteArray[i - 1] = dataRead[i];
-    }
-    return byteArray;
+    auto featureReportStart = reinterpret_cast<const char*>(dataRead + kReportIdSize);
+    return QByteArray(featureReportStart, bytesRead);
 }

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -162,7 +162,7 @@ void HidController::processInputReport(int bytesRead) {
     receive(incomingData, mixxx::Time::elapsed());
 }
 
-QList<int> HidController::getInputReport(unsigned int reportID) {
+QByteArray HidController::getInputReport(unsigned int reportID) {
     Trace hidRead("HidController getInputReport");
     int bytesRead;
 
@@ -185,17 +185,11 @@ QList<int> HidController::getInputReport(unsigned int reportID) {
         // Otherwise minimum possible value is 1, because 1 byte is for the reportID,
         // the smallest report with data is therefore 2 bytes.
         DEBUG_ASSERT(bytesRead <= kReportIdSize);
-        return QList<int>();
+        return QByteArray();
     }
 
-    // Convert array of bytes read in a JavaScript compatible return type
-    // For compatibility with the array provided by HidController::poll the reportID is contained as prefix
-    QList<int> dataList;
-    dataList.reserve(bytesRead);
-    for (int i = 0; i < bytesRead; i++) {
-        dataList.append(m_pPollData[m_pollingBufferIndex][i]);
-    }
-    return dataList;
+    return QByteArray::fromRawData(
+            reinterpret_cast<char*>(m_pPollData[m_pollingBufferIndex]), bytesRead);
 }
 
 bool HidController::poll() {
@@ -287,7 +281,7 @@ ControllerJSProxy* HidController::jsProxy() {
     return new HidControllerJSProxy(this);
 }
 
-QList<int> HidController::getFeatureReport(
+QByteArray HidController::getFeatureReport(
         unsigned int reportID) {
     unsigned char dataRead[kReportIdSize + kBufferSize];
     dataRead[0] = reportID;
@@ -318,10 +312,10 @@ QList<int> HidController::getFeatureReport(
 
     // Convert array of bytes read in a JavaScript compatible return type
     // For compatibility with input array HidController::sendFeatureReport, a reportID prefix is not added here
-    QList<int> dataList;
-    dataList.reserve(bytesRead - kReportIdSize);
+    QByteArray byteArray;
+    byteArray.reserve(bytesRead - kReportIdSize);
     for (int i = kReportIdSize; i < bytesRead; i++) {
-        dataList.append(dataRead[i]);
+        byteArray[i - 1] = dataRead[i];
     }
-    return dataList;
+    return byteArray;
 }

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -249,14 +249,14 @@ void HidController::sendBytesReport(QByteArray data, unsigned int reportID) {
 }
 
 void HidController::sendFeatureReport(
-        const QList<int>& dataList, unsigned int reportID) {
+        const QByteArray& reportData, unsigned int reportID) {
     QByteArray dataArray;
-    dataArray.reserve(kReportIdSize + dataList.size());
+    dataArray.reserve(kReportIdSize + reportData.size());
 
     // Append the Report ID to the beginning of dataArray[] per the API..
     dataArray.append(reportID);
 
-    for (const int datum : dataList) {
+    for (const int datum : reportData) {
         dataArray.append(datum);
     }
 

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -46,7 +46,7 @@ class HidController final : public Controller {
     // 0x0.
     void sendBytes(const QByteArray& data) override;
     void sendBytesReport(QByteArray data, unsigned int reportID);
-    void sendFeatureReport(const QList<int>& dataList, unsigned int reportID);
+    void sendFeatureReport(const QByteArray& reportData, unsigned int reportID);
 
     // getInputReport receives an input report on request.
     // This can be used on startup to initialize the knob positions in Mixxx
@@ -102,8 +102,8 @@ class HidControllerJSProxy : public ControllerJSProxy {
     }
 
     Q_INVOKABLE void sendFeatureReport(
-            const QList<int>& dataList, unsigned int reportID) {
-        m_pHidController->sendFeatureReport(dataList, reportID);
+            const QByteArray& reportData, unsigned int reportID) {
+        m_pHidController->sendFeatureReport(reportData, reportID);
     }
 
     Q_INVOKABLE QByteArray getFeatureReport(

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -55,7 +55,7 @@ class HidController final : public Controller {
     // as in the polling functionality (including ReportID in first byte).
     // The returned list can be used to call the incomingData
     // function of the common-hid-packet-parser.
-    QList<int> getInputReport(unsigned int reportID);
+    QByteArray getInputReport(unsigned int reportID);
 
     // getFeatureReport receives a feature reports on request.
     // HID doesn't support polling feature reports, therefore this is the
@@ -64,7 +64,7 @@ class HidController final : public Controller {
     // changing the other bits. The returned list matches the input
     // format of sendFeatureReport, allowing it to be read, modified
     // and sent it back to the controller.
-    QList<int> getFeatureReport(unsigned int reportID);
+    QByteArray getFeatureReport(unsigned int reportID);
 
     const mixxx::hid::DeviceInfo m_deviceInfo;
 
@@ -96,7 +96,7 @@ class HidControllerJSProxy : public ControllerJSProxy {
         m_pHidController->sendReport(data, length, reportID);
     }
 
-    Q_INVOKABLE QList<int> getInputReport(
+    Q_INVOKABLE QByteArray getInputReport(
             unsigned int reportID) {
         return m_pHidController->getInputReport(reportID);
     }
@@ -106,7 +106,7 @@ class HidControllerJSProxy : public ControllerJSProxy {
         m_pHidController->sendFeatureReport(dataList, reportID);
     }
 
-    Q_INVOKABLE QList<int> getFeatureReport(
+    Q_INVOKABLE QByteArray getFeatureReport(
             unsigned int reportID) {
         return m_pHidController->getFeatureReport(reportID);
     }


### PR DESCRIPTION
for compatibility with HidController::poll

Currently, passing the QList<int> return value to the script's `incomingData` function requires using [`Uint8Array.from`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from).

Unfortunately this is not working. Garbage data is returned to JavaScript. I do not understand why this does not work but #4520 does. Maybe it is the [call](https://github.com/mixxxdj/mixxx/blob/main/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp#L177) to [QJSEngine::toScriptValue](https://doc.qt.io/qt-5/qjsengine.html#toScriptValue) that does the trick? But I [thought Qt did that automatically](https://doc.qt.io/qt-5/qtqml-cppintegration-data.html#qbytearray-to-javascript-arraybuffer)... suggestions??