### PR TITLE
Comment revert 

### DIFF
--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -378,7 +378,6 @@ void Logging::initialize(
     // Fedora: https://bugzilla.redhat.com/show_bug.cgi?id=1227295
     // Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=886437
     // Ubuntu: https://bugs.launchpad.net/ubuntu/+source/qtbase-opensource-src/+bug/1731646
-    // Somehow this causes a segfault on macOS though?? https://bugs.launchpad.net/mixxx/+bug/1871238
 #ifdef __LINUX__
     QLoggingCategory::setFilterRules(
             "*.debug=true\n"


### PR DESCRIPTION
This reverts a comment with an assumption that has turned to be wrong. Introduced in #2635 and commit 8ee1dd3bd74de976f460742cca3dbd3543658024.

We missed to revert this after it turns out that it does not fix https://bugs.launchpad.net/mixxx/+bug/1871238. It was merged on 2020-08-04 to git7232 and we have a report that git7243 is still crashing. It was finally fixed on 2020-04-12 by mixxxdj/buildserver#86.