### PR TITLE
ChannelMixer: Use range-based for loops

### DIFF
--- a/src/engine/channelmixer.cpp
+++ b/src/engine/channelmixer.cpp
@@ -5,7 +5,7 @@
 
 // static
 void ChannelMixer::applyEffectsAndMixChannels(const EngineMaster::GainCalculator& gainCalculator,
-        QVarLengthArray<EngineMaster::ChannelInfo*, kPreallocatedChannels>* activeChannels,
+        const QVarLengthArray<EngineMaster::ChannelInfo*, kPreallocatedChannels>& activeChannels,
         QVarLengthArray<EngineMaster::GainCache, kPreallocatedChannels>* channelGainCache,
         CSAMPLE* pOutput,
         const ChannelHandle& outputHandle,
@@ -23,8 +23,7 @@ void ChannelMixer::applyEffectsAndMixChannels(const EngineMaster::GainCalculator
     // The original channel input buffers are not modified.
     SampleUtil::clear(pOutput, iBufferSize);
     ScopedTimer t("EngineMaster::applyEffectsAndMixChannels");
-    for (int i = 0; i < activeChannels->size(); ++i) {
-        EngineMaster::ChannelInfo* pChannelInfo = activeChannels->at(i);
+    for (auto* pChannelInfo : activeChannels) {
         EngineMaster::GainCache& gainCache = (*channelGainCache)[pChannelInfo->m_index];
         CSAMPLE_GAIN oldGain = gainCache.m_gain;
         CSAMPLE_GAIN newGain;
@@ -49,7 +48,7 @@ void ChannelMixer::applyEffectsAndMixChannels(const EngineMaster::GainCalculator
 
 void ChannelMixer::applyEffectsInPlaceAndMixChannels(
         const EngineMaster::GainCalculator& gainCalculator,
-        QVarLengthArray<EngineMaster::ChannelInfo*, kPreallocatedChannels>*
+        const QVarLengthArray<EngineMaster::ChannelInfo*, kPreallocatedChannels>&
                 activeChannels,
         QVarLengthArray<EngineMaster::GainCache, kPreallocatedChannels>*
                 channelGainCache,
@@ -66,8 +65,7 @@ void ChannelMixer::applyEffectsInPlaceAndMixChannels(
     // 4. Mix the channel buffers together to make pOutput, overwriting the pOutput buffer from the last engine callback
     ScopedTimer t("EngineMaster::applyEffectsInPlaceAndMixChannels");
     SampleUtil::clear(pOutput, iBufferSize);
-    for (int i = 0; i < activeChannels->size(); ++i) {
-        EngineMaster::ChannelInfo* pChannelInfo = activeChannels->at(i);
+    for (auto* pChannelInfo : activeChannels) {
         EngineMaster::GainCache& gainCache = (*channelGainCache)[pChannelInfo->m_index];
         CSAMPLE_GAIN oldGain = gainCache.m_gain;
         CSAMPLE_GAIN newGain;

--- a/src/engine/channelmixer.h
+++ b/src/engine/channelmixer.h
@@ -12,20 +12,26 @@ class ChannelMixer {
     // channel buffers is done after copying to a temporary buffer, then they are mixed
     // to make the output buffer.
     static void applyEffectsAndMixChannels(
-        const EngineMaster::GainCalculator& gainCalculator,
-        QVarLengthArray<EngineMaster::ChannelInfo*, kPreallocatedChannels>* activeChannels,
-        QVarLengthArray<EngineMaster::GainCache, kPreallocatedChannels>* channelGainCache,
-        CSAMPLE* pOutput, const ChannelHandle& outputHandle,
-        unsigned int iBufferSize,
-        unsigned int iSampleRate,
-        EngineEffectsManager* pEngineEffectsManager);
+            const EngineMaster::GainCalculator& gainCalculator,
+            const QVarLengthArray<EngineMaster::ChannelInfo*,
+                    kPreallocatedChannels>& activeChannels,
+            QVarLengthArray<EngineMaster::GainCache, kPreallocatedChannels>*
+                    channelGainCache,
+            CSAMPLE* pOutput,
+            const ChannelHandle& outputHandle,
+            unsigned int iBufferSize,
+            unsigned int iSampleRate,
+            EngineEffectsManager* pEngineEffectsManager);
     // This does modify the input channel buffers, then mixes them to make the output buffer.
     static void applyEffectsInPlaceAndMixChannels(
-        const EngineMaster::GainCalculator& gainCalculator,
-        QVarLengthArray<EngineMaster::ChannelInfo*, kPreallocatedChannels>* activeChannels,
-        QVarLengthArray<EngineMaster::GainCache, kPreallocatedChannels>* channelGainCache,
-        CSAMPLE* pOutput, const ChannelHandle& outputHandle,
-        unsigned int iBufferSize,
-        unsigned int iSampleRate,
-        EngineEffectsManager* pEngineEffectsManager);
+            const EngineMaster::GainCalculator& gainCalculator,
+            const QVarLengthArray<EngineMaster::ChannelInfo*,
+                    kPreallocatedChannels>& activeChannels,
+            QVarLengthArray<EngineMaster::GainCache, kPreallocatedChannels>*
+                    channelGainCache,
+            CSAMPLE* pOutput,
+            const ChannelHandle& outputHandle,
+            unsigned int iBufferSize,
+            unsigned int iSampleRate,
+            EngineEffectsManager* pEngineEffectsManager);
 };

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -428,8 +428,9 @@ void EngineMaster::process(const int iBufferSize) {
         // Process effects and mix PFL channels together for the headphones.
         // Effects will be reprocessed post-fader for the crossfader buses
         // and master mix, so the channel input buffers cannot be modified here.
-        ChannelMixer::applyEffectsAndMixChannels(m_headphoneGain,
-                &m_activeHeadphoneChannels,
+        ChannelMixer::applyEffectsAndMixChannels(
+                m_headphoneGain,
+                m_activeHeadphoneChannels,
                 &m_channelHeadphoneGainCache,
                 m_pHead,
                 m_headphoneHandle.handle(),
@@ -461,8 +462,9 @@ void EngineMaster::process(const int iBufferSize) {
 
     // Mix all the talkover enabled channels together.
     // Effects processing is done in place to avoid unnecessary buffer copying.
-    ChannelMixer::applyEffectsInPlaceAndMixChannels(m_talkoverGain,
-            &m_activeTalkoverChannels,
+    ChannelMixer::applyEffectsInPlaceAndMixChannels(
+            m_talkoverGain,
+            m_activeTalkoverChannels,
             &m_channelTalkoverGainCache,
             m_pTalkover,
             m_masterHandle.handle(),
@@ -518,7 +520,7 @@ void EngineMaster::process(const int iBufferSize) {
 
     for (int o = EngineChannel::LEFT; o <= EngineChannel::RIGHT; o++) {
         ChannelMixer::applyEffectsInPlaceAndMixChannels(m_masterGain,
-                &m_activeBusChannels[o],
+                m_activeBusChannels[o],
                 &m_channelMasterGainCache, // no [o] because the old gain follows an orientation switch
                 m_pOutputBusBuffers[o],
                 m_masterHandle.handle(),


### PR DESCRIPTION
Minor improvements, previously discarded. Only not to waste the efforts.