### PR TITLE
gitignore: change /build to /build*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ compile_commands.json
 /CMakeSettings*.json
 
 # Build and distribution directories for various build configurations
-/build
+/build*
 /install
 
 # Exclude unneeded files from GoogleTest library when updating our bundled


### PR DESCRIPTION
This allows for multiple CMake build directories, for example
build-qt5, build-qt6, build-vcpkg.