### PR TITLE
link QPA plugins for static builds on Linux

### DIFF
--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -28,7 +28,11 @@ Q_IMPORT_PLUGIN(QWindowsVistaStylePlugin)
 Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin)
 Q_IMPORT_PLUGIN(QMacStylePlugin)
 #else
-#error "Q_IMPORT_PLUGIN() for the current patform is missing"
+Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+Q_IMPORT_PLUGIN(QWaylandIntegrationPlugin)
+Q_IMPORT_PLUGIN(QWaylandEglPlatformIntegrationPlugin)
+#endif
 #endif
 Q_IMPORT_PLUGIN(QOffscreenIntegrationPlugin)
 Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin)


### PR DESCRIPTION
I noticed this when trying to build with vcpkg on Linux. (There are still a bunch of link errors with vcpkg on Linux, but that's beyond the scope of this PR.)