### PR TITLE
fix & improve Sampler export

### DIFF
--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -81,7 +81,7 @@ PlayerManager::PlayerManager(UserSettingsPointer pConfig,
             &PlayerManager::slotChangeNumAuxiliaries, Qt::DirectConnection);
 
     // This is parented to the PlayerManager so does not need to be deleted
-    m_pSamplerBank = new SamplerBank(this);
+    m_pSamplerBank = new SamplerBank(m_pConfig, this);
 
     m_cloneTimer.start();
 }

--- a/src/mixer/samplerbank.cpp
+++ b/src/mixer/samplerbank.cpp
@@ -16,6 +16,8 @@ namespace {
 
 const ConfigKey kConfigkeyLastImportExportDirectory(
         "[Samplers]", "last_import_export_directory");
+// This is used in multiple tr() calls below which accepts const char* as a key.
+// lupdate finds the single string here.
 const char kSamplerFileType[] = QT_TR_NOOP("Mixxx Sampler Banks (*.xml)");
 
 } // anonymous namespace

--- a/src/mixer/samplerbank.cpp
+++ b/src/mixer/samplerbank.cpp
@@ -2,6 +2,7 @@
 
 #include <QFileDialog>
 #include <QMessageBox>
+#include <QStandardPaths>
 
 #include "control/controlpushbutton.h"
 #include "mixer/playermanager.h"
@@ -9,9 +10,20 @@
 #include "moc_samplerbank.cpp"
 #include "track/track.h"
 #include "util/assert.h"
+#include "util/file.h"
 
-SamplerBank::SamplerBank(PlayerManager* pPlayerManager)
+namespace {
+
+const ConfigKey kConfigkeyLastImportExportDirectory(
+        "[Samplers]", "last_import_export_directory");
+const char kSamplerFileType[] = QT_TR_NOOP("Mixxx Sampler Banks (*.xml)");
+
+} // anonymous namespace
+
+SamplerBank::SamplerBank(UserSettingsPointer pConfig,
+        PlayerManager* pPlayerManager)
         : QObject(pPlayerManager),
+          m_pConfig(pConfig),
           m_pPlayerManager(pPlayerManager) {
     DEBUG_ASSERT(m_pPlayerManager);
 
@@ -38,23 +50,30 @@ void SamplerBank::slotSaveSamplerBank(double v) {
         return;
     }
 
-    const QString xmlSuffix = QStringLiteral(".xml");
-    QString fileFilter = tr("Mixxx Sampler Banks (*%1)").arg(xmlSuffix);
-    QString samplerBankPath = QFileDialog::getSaveFileName(nullptr,
+    QString lastImportExportDirectory = m_pConfig->getValue(
+            kConfigkeyLastImportExportDirectory,
+            // When Mixxx exits samplers are auto-exported to the config directory.
+            // Let's choose a different location to avoid confusion.
+            QStandardPaths::writableLocation(QStandardPaths::MusicLocation));
+
+    // Open a dialog to let the user choose the file location for crate export.
+    // The location is set to the last used directory for import/export and the file
+    // name to the playlist name.
+    const QString samplerBankPath = getFilePathWithVerifiedExtensionFromFileDialog(
             tr("Save Sampler Bank"),
-            QString(),
-            fileFilter,
-            &fileFilter);
-    if (samplerBankPath.isNull() || samplerBankPath.isEmpty()) {
+            lastImportExportDirectory.append("/").append("samplers").append(".xml"),
+            tr(kSamplerFileType),
+            tr(kSamplerFileType));
+    // Exit method if user cancelled the open dialog.
+    if (samplerBankPath.isEmpty()) {
         return;
     }
 
-    // Manually add extension due to bug in QFileDialog
-    // via https://bugreports.qt-project.org/browse/QTBUG-27186
-    QFileInfo fileName(samplerBankPath);
-    if (fileName.suffix().isEmpty() || !fileName.suffix().endsWith(xmlSuffix)) {
-        samplerBankPath.append(xmlSuffix);
-    }
+    // Update the import/export directory
+    QString fileDirectory(samplerBankPath);
+    fileDirectory.truncate(samplerBankPath.lastIndexOf(QDir::separator()));
+    m_pConfig->set(kConfigkeyLastImportExportDirectory,
+            ConfigValue(fileDirectory));
 
     if (!saveSamplerBankToPath(samplerBankPath)) {
         QMessageBox::warning(nullptr,
@@ -117,13 +136,25 @@ void SamplerBank::slotLoadSamplerBank(double v) {
         return;
     }
 
+    QString lastImportExportDirectory = m_pConfig->getValue(
+            kConfigkeyLastImportExportDirectory,
+            QStandardPaths::writableLocation(QStandardPaths::MusicLocation));
+
+    QString fileFilter(tr(kSamplerFileType));
     QString samplerBankPath = QFileDialog::getOpenFileName(nullptr,
             tr("Load Sampler Bank"),
-            QString(),
-            tr("Mixxx Sampler Banks (*.xml)"));
+            lastImportExportDirectory,
+            fileFilter,
+            &fileFilter);
     if (samplerBankPath.isEmpty()) {
         return;
     }
+
+    // Update the import/export directory
+    QString fileDirectory(samplerBankPath);
+    fileDirectory.truncate(samplerBankPath.lastIndexOf(QDir::separator()));
+    m_pConfig->set(kConfigkeyLastImportExportDirectory,
+            ConfigValue(fileDirectory));
 
     if (!loadSamplerBankFromPath(samplerBankPath)) {
         QMessageBox::warning(nullptr,

--- a/src/mixer/samplerbank.h
+++ b/src/mixer/samplerbank.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <QObject>
+
+#include "preferences/usersettings.h"
 #include "util/memory.h"
 
 class ControlObject;
@@ -13,7 +15,8 @@ class PlayerManager;
 class SamplerBank : public QObject {
     Q_OBJECT
   public:
-    SamplerBank(PlayerManager* pPlayerManager);
+    SamplerBank(UserSettingsPointer pConfig,
+            PlayerManager* pPlayerManager);
     ~SamplerBank() override;
 
     bool saveSamplerBankToPath(const QString& samplerBankPath);
@@ -24,6 +27,7 @@ class SamplerBank : public QObject {
     void slotLoadSamplerBank(double v);
 
   private:
+    UserSettingsPointer m_pConfig;
     PlayerManager* m_pPlayerManager;
     std::unique_ptr<ControlObject> m_pCOLoadBank;
     std::unique_ptr<ControlObject> m_pCOSaveBank;


### PR DESCRIPTION
* before `.xml` was added to any specified export file even if it ended with `.xml`
* remember the import/export directory