### PR TITLE
don't wipe inapplicable sound config immediately

### DIFF
--- a/src/mixxx.h
+++ b/src/mixxx.h
@@ -34,6 +34,7 @@ class SettingsManager;
 class BroadcastManager;
 class SkinLoader;
 class SoundManager;
+class SoundManagerConfig;
 class VinylControlManager;
 class WMainMenuBar;
 

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -81,7 +81,10 @@ SoundManager::SoundManager(UserSettingsPointer pConfig,
         m_config.loadDefaults(this, SoundManagerConfig::ALL);
     }
     checkConfig();
-    m_config.writeToDisk(); // in case anything changed by applying defaults
+    // Don't write config to disk, yet -- it may be reset to defaults in case
+    // previously configured devices were not found.
+    // Write new config after MixxxMainWindow::noOutputDlg where the user has
+    // a chance to keep the previous sound config (exit).
 }
 
 SoundManager::~SoundManager() {


### PR DESCRIPTION
When `SoundManager` is initialized and previously configured output devices aren't available the config is wiped and the default config is written to disk before the user had a chance to intervene.

With this commit the new config (empty default or reconfigured) is written to disk only if the user clicked either **Continue** (with no outputs) or **Reconfigure** (and actually set an output device).

_____

WIP though I'd appreciate feedback is this approach is acceptable until Mixxx supports multiple sound config profiles.
I didn't yet manage to comprehend how all sound devices config steps and sound error dialogs play together. I have the feeling that the inapplicable config should be discovered earlier, not just when configured outputs are missing.