### PR TITLE
Define `CFBundleName` in macOS bundle

### DIFF
--- a/packaging/macos/bundle.plist.in
+++ b/packaging/macos/bundle.plist.in
@@ -14,6 +14,9 @@
     <key>CFBundleIdentifier</key>
     <string>org.mixxx.mixxx</string>
 
+    <key>CFBundleName</key>
+    <string>Mixxx</string>
+
     <key>CFBundleDisplayName</key>
     <string>Mixxx</string>
 


### PR DESCRIPTION
`CFBundleName` declares the menu bar name [as documented here](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundlename) and lets us display the name "Mixxx" with proper capitalization in the macOS menu bar:

<img width="301" alt="Screen Shot 2021-11-28 at 14 18 58" src="https://user-images.githubusercontent.com/30873659/143769622-0069cd41-2f54-4ff5-b255-2bf984f69970.png">

Previously, it looked like this:

<img width="296" alt="Screen Shot 2021-11-28 at 14 19 14" src="https://user-images.githubusercontent.com/30873659/143769636-8492d2d9-3cee-4920-97d4-0dc1d235488b.png">