### PR TITLE
Effect chain preset menu tweaks

### DIFF
--- a/src/preferences/dialog/dlgprefeffects.cpp
+++ b/src/preferences/dialog/dlgprefeffects.cpp
@@ -219,10 +219,10 @@ void DlgPrefEffects::slotChainPresetSelected(const QModelIndex& selected) {
                 // Code uses 0-indexed numbers; users see 1 indexed numbers
                 m_effectsLabels[i]->setText(QString::number(i + 1) + ": " + displayName);
             } else {
-                m_effectsLabels[i]->setText(QString::number(i + 1) + ": " + "---");
+                m_effectsLabels[i]->setText(QString::number(i + 1) + ": " + kNoEffectString);
             }
         } else {
-            m_effectsLabels[i]->setText(QString::number(i + 1) + ": " + "---");
+            m_effectsLabels[i]->setText(QString::number(i + 1) + ": " + kNoEffectString);
         }
     }
 

--- a/src/widget/weffectchainpresetbutton.cpp
+++ b/src/widget/weffectchainpresetbutton.cpp
@@ -62,7 +62,7 @@ void WEffectChainPresetButton::populateMenu() {
         const QString effectSlotNumPrefix(QString::number(effectSlotIndex + 1) + ": ");
         auto pManifest = pEffectSlot->getManifest();
         if (pManifest == nullptr) {
-            m_pMenu->addAction(effectSlotNumPrefix + tr("Empty Effect Slot"));
+            m_pMenu->addAction(effectSlotNumPrefix + kNoEffectString);
             continue;
         }
 

--- a/src/widget/weffectchainpresetbutton.cpp
+++ b/src/widget/weffectchainpresetbutton.cpp
@@ -58,18 +58,20 @@ void WEffectChainPresetButton::populateMenu() {
     // TODO: get number of currently visible effect slots from skin
     for (int effectSlotIndex = 0; effectSlotIndex < 3; effectSlotIndex++) {
         auto pEffectSlot = m_pChain->getEffectSlots().at(effectSlotIndex);
-        const ParameterMap loadedParameters = pEffectSlot->getLoadedParameters();
-        const ParameterMap hiddenParameters = pEffectSlot->getHiddenParameters();
 
+        const QString effectSlotNumPrefix(QString::number(effectSlotIndex + 1) + ": ");
         auto pManifest = pEffectSlot->getManifest();
         if (pManifest == nullptr) {
-            m_pMenu->addAction(tr("Empty Effect Slot %1").arg(effectSlotIndex + 1));
+            m_pMenu->addAction(effectSlotNumPrefix + tr("Empty Effect Slot"));
             continue;
         }
 
-        auto pEffectMenu = make_parented<QMenu>(m_pMenu);
-        pEffectMenu->setTitle(pEffectSlot->getManifest()->displayName());
+        auto pEffectMenu = make_parented<QMenu>(
+                effectSlotNumPrefix + pEffectSlot->getManifest()->displayName(),
+                m_pMenu);
 
+        const ParameterMap loadedParameters = pEffectSlot->getLoadedParameters();
+        const ParameterMap hiddenParameters = pEffectSlot->getHiddenParameters();
         int numTypes = static_cast<int>(EffectManifestParameter::ParameterType::NumTypes);
         for (int parameterTypeId = 0; parameterTypeId < numTypes; ++parameterTypeId) {
             const EffectManifestParameter::ParameterType parameterType =
@@ -111,8 +113,9 @@ void WEffectChainPresetButton::populateMenu() {
 
                 pEffectMenu->addAction(pAction.get());
             }
-            pEffectMenu->addSeparator();
         }
+        pEffectMenu->addSeparator();
+
         pEffectMenu->addAction(tr("Save snapshot"), this, [this, pEffectSlot] {
             m_pEffectsManager->getEffectPresetManager()->saveDefaultForEffect(pEffectSlot);
         });


### PR DESCRIPTION
* always show the effect slot number in the menu
* use `kNoEffectString` constant in DlgPrefEffects
* use `kNoEffectString` instead of "Empty Effect Slot" in the menu

![image](https://user-images.githubusercontent.com/5934199/144218902-f2aafc28-4888-456b-a197-237b7f290909.png)

