### PR TITLE
TrackRef: Use implicitly defined copy constructor and assignment operator

### DIFF
--- a/src/track/trackref.h
+++ b/src/track/trackref.h
@@ -31,8 +31,6 @@ public:
     TrackRef() {
         DEBUG_ASSERT(verifyConsistency());
     }
-    // Regular copy constructor
-    TrackRef(const TrackRef& other) = default;
     // Custom copy constructor:  Creates a copy of an existing TrackRef,
     // but overwrite the TrackId with a custom value.
     TrackRef(


### PR DESCRIPTION
Fix another Clang build warning/error.