### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
     #args: [--ignore-words, .codespellignore, --ignore-regex, "\\W(?:m_p*(?=[A-Z])|m_(?=\\w)|pp*(?=[A-Z])|k(?=[A-Z])|s_(?=\\w))"]
     exclude: ^(packaging/wix/LICENSE.rtf|src/dialog/dlgabout\.cpp|.*\.(?:pot?|ts|wxl))$
 - repo: https://github.com/pre-commit/mirrors-eslint
-  rev: v8.0.0-1
+  rev: v8.4.0
   hooks:
   - id: eslint
     args: [--fix, --report-unused-disable-directives]
@@ -83,7 +83,7 @@ repos:
     language: python
     files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|m|mm|proto|vert)$
 - repo: https://github.com/psf/black
-  rev: 21.9b0
+  rev: 21.12b0
   hooks:
   - id: black
     files: ^tools/.*$
@@ -94,7 +94,7 @@ repos:
     files: ^tools/.*$
     types: [text, python]
 - repo: https://github.com/shellcheck-py/shellcheck-py
-  rev: v0.7.2.1
+  rev: v0.8.0.1
   hooks:
   - id: shellcheck
 - repo: https://github.com/DavidAnson/markdownlint-cli2

--- a/src/test/soundFileFormats/generateFiles.sh
+++ b/src/test/soundFileFormats/generateFiles.sh
@@ -17,12 +17,12 @@ samplerates=(22050 32000 44100 48000 96000)
 
 if [ "$1" == "clean" ]
 then
-    for format in ${formats[*]}
+    for format in "${formats[@]}"
     do
-        for rate in ${samplerates[*]}
+        for rate in "${samplerates[@]}"
         do
             friendlyrate=$(( "$rate" / 1000 ))
-            for channel in ${channels[*]}
+            for channel in "${channels[@]}"
             do
                 if [ "$channel" -eq 1 ]
                 then
@@ -44,7 +44,7 @@ then
                     fi
                 fi
 
-                for ssize in ${samplesizes[*]}
+                for ssize in "${samplesizes[@]}"
                 do
                     if [ -e "test${ssize}bit${friendlyrate}k${friendlychannel}.${format}" ]
                     then
@@ -80,7 +80,7 @@ then
 fi
 
 # Do the conversions/generate the table
-for format in ${formats[*]}
+for format in "${formats[@]}"
 do
     if [ "$1" == "table" ]
     then
@@ -104,7 +104,7 @@ do
         echo "==== $friendlyformat ===="
         echo "^ Channels ^ Bit depth ^ Sample Rate ^ Does it work? ^"
     fi
-    for channel in ${channels[*]}
+    for channel in "${channels[@]}"
     do
         if [ "$channel" -eq 1 ]
         then
@@ -116,7 +116,7 @@ do
             friendlychannel="Stereo"
             lameopt=()
         fi
-        for ssize in ${samplesizes[*]}
+        for ssize in "${samplesizes[@]}"
         do
             # Hack because sox doesn't abort if the parameters are out of spec
             if [ "$ssize" -gt 24 ] && [ "$format" == "flac" ]
@@ -133,7 +133,7 @@ do
             then
                 break
             fi
-            for rate in ${samplerates[*]}
+            for rate in "${samplerates[@]}"
             do
                 friendlyrate=$(( "$rate" / 1000 ))
                 problem="false"


### PR DESCRIPTION
How to test:

```sh
SKIP=clang-format,eslint,end-of-file-fixer,trailing-whitespace \
pre-commit run --all-files
```

Fixes in shell scripts as proposed by shellcheck.