### PR TITLE
Remove from disk: add to deck track menu, fix undeleted message

### DIFF
--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1802,7 +1802,11 @@ void WTrackMenu::slotRemoveFromDisk() {
                     tr("Note: if you are in Browse or Recording you need to "
                        "click the current view again to see changes.");
         } else {
-            // ToDo(ronso0) Eject track after deletion.
+            // Eject track from deck
+            ControlProxy* ejectTrackProxy = new ControlProxy(
+                    m_deckGroup, "eject", this);
+            ejectTrackProxy->set(1.0);
+
             msgTitle = tr("Track File Deleted");
             msgText = tr(
                     "Track file was deleted from disk and purged "

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1732,24 +1732,24 @@ void WTrackMenu::slotRemoveFromDisk() {
         delListWidget->setFocusPolicy(Qt::ClickFocus);
         delListWidget->addItems(locations);
         mixxx::widgethelper::growListWidget(*delListWidget, *this);
-        // Warning text
+
         QString delWarningText;
         if (m_pTrackModel) {
             delWarningText = tr("Permanently delete these files from disk?") +
-                    QString("<br><br><b>") +
-                    tr("This can not be undone!") + QString("</b>");
+                    QStringLiteral("<br><br><b>") +
+                    tr("This can not be undone!") + QStringLiteral("</b>");
         } else {
             delWarningText =
                     tr("Stop the deck and permanently delete this track file from disk?") +
-                    QString("<br><br><b>") +
-                    tr("This can not be undone!") + QString("</b>");
+                    QStringLiteral("<br><br><b>") +
+                    tr("This can not be undone!") + QStringLiteral("</b>");
         }
         QLabel* delWarning = new QLabel();
         delWarning->setText(delWarningText);
         delWarning->setTextFormat(Qt::RichText);
         delWarning->setSizePolicy(QSizePolicy(QSizePolicy::Minimum,
                 QSizePolicy::Minimum));
-        // Buttons
+
         QDialogButtonBox* delButtons = new QDialogButtonBox();
         QPushButton* cancelBtn = delButtons->addButton(
                 tr("Cancel"),
@@ -1818,7 +1818,7 @@ void WTrackMenu::slotRemoveFromDisk() {
                     tr("%1 track files were deleted from disk and purged "
                        "from the Mixxx database.")
                             .arg(QString::number(tracksToPurge.length())) +
-                    QString("<br><br>") +
+                    QStringLiteral("<br><br>") +
                     tr("Note: if you are in Browse or Recording you need to "
                        "click the current view again to see changes.");
         } else {

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1782,12 +1782,8 @@ void WTrackMenu::slotRemoveFromDisk() {
     // If the operation was initiated from a deck's track menu
     // we'll first stop the deck and eject the track.
     if (m_pTrack) {
-        ControlProxy* stopDeckProxy = new ControlProxy(
-                m_deckGroup, "stop", this);
-        stopDeckProxy->set(1.0);
-        ControlProxy* ejectTrackProxy = new ControlProxy(
-                m_deckGroup, "eject", this);
-        ejectTrackProxy->set(1.0);
+        ControlObject::set(ConfigKey(m_deckGroup, "stop"), 1.0);
+        ControlObject::set(ConfigKey(m_deckGroup, "eject"), 1.0);
     }
 
     // Set up and initiate the track batch operation

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1844,11 +1844,11 @@ void WTrackMenu::slotRemoveFromDisk() {
     QString msgText;
     if (m_pTrackModel) {
         msgText =
-                tr("The following %1 files could not be deleted from disk")
+                tr("The following %1 file(s) could not be deleted from disk")
                         .arg(QString::number(
                                 tracksToKeep.length()));
     } else {
-        msgText = tr("Track file could not be deleted from disk.");
+        msgText = tr("This track file could not be deleted from disk");
     }
     notDeletedLabel->setText(msgText);
     notDeletedLabel->setTextFormat(Qt::RichText);

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -18,6 +18,7 @@ constexpr WTrackMenu::Features kTrackMenuFeatures =
         WTrackMenu::Feature::Reset |
         WTrackMenu::Feature::BPM |
         WTrackMenu::Feature::Color |
+        WTrackMenu::Feature::RemoveFromDisk |
         WTrackMenu::Feature::FileBrowser |
         WTrackMenu::Feature::Properties |
         WTrackMenu::Feature::UpdateReplayGain;
@@ -94,6 +95,7 @@ void WTrackProperty::mouseMoveEvent(QMouseEvent* event) {
         DragAndDropHelper::dragTrack(m_pCurrentTrack, this, m_group);
     }
 }
+
 void WTrackProperty::mouseDoubleClickEvent(QMouseEvent* event) {
     Q_UNUSED(event);
     if (m_pCurrentTrack) {


### PR DESCRIPTION
I was missing Remove From Disk in the deck menu when I was too lazy to look for the track in the library.
Here it is.