### PR TITLE
DlgTrackInfo: apply pending changes also when saving via hotkey

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -77,6 +77,7 @@ void DlgTrackInfo::init() {
         btnPrev->hide();
     }
 
+    // QDialog buttons
     connect(btnApply,
             &QPushButton::clicked,
             this,
@@ -92,6 +93,7 @@ void DlgTrackInfo::init() {
             this,
             &DlgTrackInfo::slotCancel);
 
+    // BPM edit buttons
     connect(bpmDouble,
             &QPushButton::clicked,
             this,
@@ -150,19 +152,22 @@ void DlgTrackInfo::init() {
             &QLineEdit::editingFinished,
             this,
             [this]() {
-                m_trackRecord.refMetadata().refTrackInfo().setTitle(txtTrackName->text().trimmed());
+                m_trackRecord.refMetadata().refTrackInfo().setTitle(
+                        txtTrackName->text().trimmed());
             });
     connect(txtArtist,
             &QLineEdit::editingFinished,
             this,
             [this]() {
-                m_trackRecord.refMetadata().refTrackInfo().setArtist(txtArtist->text().trimmed());
+                m_trackRecord.refMetadata().refTrackInfo().setArtist(
+                        txtArtist->text().trimmed());
             });
     connect(txtAlbum,
             &QLineEdit::editingFinished,
             this,
             [this]() {
-                m_trackRecord.refMetadata().refAlbumInfo().setTitle(txtAlbum->text().trimmed());
+                m_trackRecord.refMetadata().refAlbumInfo().setTitle(
+                        txtAlbum->text().trimmed());
             });
     connect(txtAlbumArtist,
             &QLineEdit::editingFinished,
@@ -196,13 +201,18 @@ void DlgTrackInfo::init() {
             &QLineEdit::editingFinished,
             this,
             [this]() {
-                m_trackRecord.refMetadata().refTrackInfo().setYear(txtYear->text().trimmed());
+                m_trackRecord.refMetadata().refTrackInfo().setYear(
+                        txtYear->text().trimmed());
             });
-    connect(txtTrackNumber, &QLineEdit::editingFinished, [this]() {
-        m_trackRecord.refMetadata().refTrackInfo().setTrackNumber(
-                txtTrackNumber->text().trimmed());
-    });
+    connect(txtTrackNumber,
+            &QLineEdit::editingFinished,
+            this,
+            [this]() {
+                m_trackRecord.refMetadata().refTrackInfo().setTrackNumber(
+                        txtTrackNumber->text().trimmed());
+            });
 
+    // Import and file browser buttons
     connect(btnImportMetadataFromFile,
             &QPushButton::clicked,
             this,
@@ -218,6 +228,7 @@ void DlgTrackInfo::init() {
             this,
             &DlgTrackInfo::slotOpenInFileBrowser);
 
+    // Cover art
     CoverArtCache* pCache = CoverArtCache::instance();
     if (pCache) {
         connect(pCache,
@@ -481,6 +492,19 @@ void DlgTrackInfo::slotOpenInFileBrowser() {
 void DlgTrackInfo::saveTrack() {
     if (!m_pLoadedTrack) {
         return;
+    }
+
+    // In case Apply is triggered by hotkey AND a QLineEdit with pending changes
+    // is focused AND the user did not hit Enter to finish editing,
+    // the content of that focused line edit would be reset to the last confirmed state.
+    // This hack makes a focused QLineEdit emit editingFinished() (clearFocus()
+    // implicitly emits a focusOutEvent()
+    if (this == QApplication::activeWindow()) {
+        auto focusWidget = QApplication::focusWidget();
+        if (focusWidget) {
+            focusWidget->clearFocus();
+            focusWidget->setFocus();
+        }
     }
 
     // First, disconnect the track changed signal. Otherwise we signal ourselves

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -1000,11 +1000,11 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
   <tabstop>bpmTap</tabstop>
   <tabstop>bpmDouble</tabstop>
   <tabstop>bpmHalve</tabstop>
-  <tabstop>bpmClear</tabstop>
   <tabstop>bpmTwoThirds</tabstop>
   <tabstop>bpmThreeFourth</tabstop>
   <tabstop>bpmThreeHalves</tabstop>
   <tabstop>bpmFourThirds</tabstop>
+  <tabstop>bpmClear</tabstop>
   <tabstop>btnPrev</tabstop>
   <tabstop>btnNext</tabstop>
   <tabstop>btnCancel</tabstop>


### PR DESCRIPTION
This fixes a small usability regression introduced by #3906
It affects my personal workflow when mass-editing metadata (same metadata field for a few tracks in a row).
https://bugs.launchpad.net/mixxx/+bug/1954346
* (Artist line focused)
* Ctrl+A, Ctrl+V
* Alt+A (Apply), Alt+N (next track)
* ...repeat that a few times
https://bugs.launchpad.net/mixxx/+bug/1954346

The issue is that the track record is only updated when changed QLineEdits send the editingFinished() signal -- which is not the case when I don't press Enter and `Apply`/saveTrack() is invoked via hotkey while the changed line is still focused.

I will definitely add this to my personal branch and I don't mind if it's rejected because _"The user should simply hit Enter, let's not add this hack"_.