### PR TITLE
WSpinny: allow to toggle cover art at runtime

### DIFF
--- a/res/skins/LateNight/decks/spinny_coverart.xml
+++ b/res/skins/LateNight/decks/spinny_coverart.xml
@@ -4,18 +4,18 @@
   <WidgetGroup>
     <Layout>horizontal</Layout>
     <Children>
+
+      <!-- Spinny -->
       <WidgetGroup>
         <Layout>horizontal</Layout>
         <SizePolicy>me,me</SizePolicy>
         <Children>
-
           <WidgetGroup>
             <ObjectName>SpinnyContainer</ObjectName>
             <Layout>horizontal</Layout>
             <SizePolicy>min,me</SizePolicy>
             <Children>
-
-              <Spinny><!-- without cover -->
+              <Spinny>
                 <TooltipId>spinny</TooltipId>
                 <SizePolicy>me,me</SizePolicy>
                 <MinimumSize>40,40</MinimumSize>
@@ -24,30 +24,8 @@
                 <PathMask scalemode="STRETCH_ASPECT">skin:/<Variable name="StyleScheme"/>/style/spinny_mask_<Variable name="DeckGroup"/>.svg</PathMask>
                 <PathForeground>skin:/<Variable name="StyleScheme"/>/style/spinny_indicator.svg</PathForeground>
                 <PathGhost>skin:/<Variable name="StyleScheme"/>/style/spinny_indicator_ghost.svg</PathGhost>
-                <ShowCover>false</ShowCover>
-                <Connection>
-                  <ConfigKey persist="true">[Skin],show_coverart</ConfigKey>
-                  <Transform><Not/></Transform>
-                  <BindProperty>visible</BindProperty>
-                </Connection>
+                <ShowCoverControl>[Skin],show_coverart</ShowCoverControl>
               </Spinny>
-
-              <Spinny><!-- with cover -->
-                <TooltipId>spinny</TooltipId>
-                <SizePolicy>me,me</SizePolicy>
-                <MinimumSize>40,40</MinimumSize>
-                <Group><Variable name="Group"/></Group>
-                <PathBackground scalemode="STRETCH_ASPECT">skin:/<Variable name="StyleScheme"/>/style/spinny_bg.svg</PathBackground>
-                <PathMask scalemode="STRETCH_ASPECT">skin:/<Variable name="StyleScheme"/>/style/spinny_mask_<Variable name="DeckGroup"/>.svg</PathMask>
-                <PathForeground>skin:/<Variable name="StyleScheme"/>/style/spinny_indicator.svg</PathForeground>
-                <PathGhost>skin:/<Variable name="StyleScheme"/>/style/spinny_indicator_ghost.svg</PathGhost>
-                <ShowCover>true</ShowCover>
-                <Connection>
-                  <ConfigKey persist="true">[Skin],show_coverart</ConfigKey>
-                  <BindProperty>visible</BindProperty>
-                </Connection>
-              </Spinny>
-
             </Children>
           </WidgetGroup>
         </Children>
@@ -57,11 +35,11 @@
         </Connection>
       </WidgetGroup>
 
+      <!-- Cover Art -->
       <WidgetGroup>
         <Layout>vertical</Layout>
         <SizePolicy>min,min</SizePolicy>
         <Children>
-
           <WidgetGroup>
             <Layout>horizontal</Layout>
             <SizePolicy>min,min</SizePolicy>
@@ -86,7 +64,6 @@
               <BindProperty>visible</BindProperty>
             </Connection>
           </WidgetGroup>
-
         </Children>
         <Connection>
           <ConfigKey persist="true">[Skin],show_spinnies</ConfigKey>

--- a/res/skins/Tango/decks/spinny_cover_maxi.xml
+++ b/res/skins/Tango/decks/spinny_cover_maxi.xml
@@ -7,41 +7,22 @@ Variables:
 -->
 <Template>
   <WidgetGroup>
-    <ObjectName>SpinnyCoverCont1</ObjectName>
     <SizePolicy>max,min</SizePolicy>
     <Layout>vertical</Layout>
     <Children>
 
       <WidgetGroup>
-        <ObjectName>SpinnyCoverCont2</ObjectName>
         <SizePolicy>max,min</SizePolicy>
         <MaximumSize>111,111</MaximumSize>
         <Layout>vertical</Layout>
         <Children>
 
-          <!-- Spinny with/without Cover Art -->
+          <!-- Spinny -->
           <WidgetGroup>
             <ObjectName>SpinnyCover</ObjectName>
             <Size>111f,111f</Size>
             <Layout>vertical</Layout>
             <Children>
-              <!-- no Cover on Spinny -->
-              <Spinny>
-                <TooltipId>spinny</TooltipId>
-                <Size>111f,111f</Size>
-                <Group><Variable name="group"/></Group>
-                <PathBackground scalemode="STRETCH_ASPECT">skin:../Tango/graphics/spinny_bg.svg</PathBackground>
-                <PathMask scalemode="STRETCH_ASPECT">skin:../Tango/graphics/spinny_mask.svg</PathMask>
-                <PathForeground scalemode="STRETCH_ASPECT">skin:../Tango/graphics/spinny_indicator.svg</PathForeground>
-                <PathGhost scalemode="STRETCH_ASPECT">skin:../Tango/graphics/spinny_indicator_ghost.svg</PathGhost>
-                <ShowCover>false</ShowCover>
-                <Connection>
-                  <ConfigKey persist="true">[Skin],show_coverart</ConfigKey>
-                  <Transform><Not/></Transform>
-                  <BindProperty>visible</BindProperty>
-                </Connection>
-              </Spinny>
-              <!-- Cover on Spinny -->
               <Spinny>
                 <TooltipId>spinny</TooltipId>
                 <Size>111f,111f</Size>
@@ -51,10 +32,7 @@ Variables:
                 <PathForeground scalemode="STRETCH_ASPECT">skin:../Tango/graphics/spinny_indicator.svg</PathForeground>
                 <PathGhost scalemode="STRETCH_ASPECT">skin:../Tango/graphics/spinny_indicator_ghost.svg</PathGhost>
                 <ShowCover>true</ShowCover>
-                <Connection>
-                  <ConfigKey persist="true">[Skin],show_coverart</ConfigKey>
-                  <BindProperty>visible</BindProperty>
-                </Connection>
+                <ShowCoverControl>[Skin],show_coverart</ShowCoverControl>
               </Spinny>
             </Children>
             <Connection>
@@ -63,7 +41,7 @@ Variables:
             </Connection>
           </WidgetGroup>
 
-          <!-- Cover Art only -->
+          <!-- Cover Art -->
           <WidgetGroup>
             <ObjectName>SpinnyCover</ObjectName>
             <SizePolicy>max,max</SizePolicy>

--- a/res/skins/Tango/decks/spinny_cover_mini.xml
+++ b/res/skins/Tango/decks/spinny_cover_mini.xml
@@ -14,11 +14,11 @@ Variables:
     <Layout>vertical</Layout>
     <Children>
 
-      <WidgetGroup><!-- Spinny -->
+      <!-- Spinny -->
+      <WidgetGroup>
         <Layout>vertical</Layout>
         <SizePolicy>me,me</SizePolicy>
         <Children>
-          <!-- no Cover on Spinny -->
           <Spinny>
             <TooltipId>spinny</TooltipId>
             <Size>40me,40me</Size>
@@ -27,34 +27,14 @@ Variables:
             <PathForeground scalemode="STRETCH_ASPECT">skin:../Tango/graphics/spinny_mini_indicator.svg</PathForeground>
             <PathMask scalemode="STRETCH_ASPECT">skin:../Tango/graphics/spinny_mini_mask_<Variable name="SpinnyCoverColor"/>.svg</PathMask>
             <PathGhost scalemode="STRETCH_ASPECT">skin:../Tango/graphics/spinny_mini_indicator_ghost.svg</PathGhost>
-            <ShowCover>false</ShowCover>
-            <Connection>
-              <ConfigKey persist="true">[Skin],show_coverart</ConfigKey>
-              <Transform><Not/></Transform>
-              <BindProperty>visible</BindProperty>
-            </Connection>
-          </Spinny>
-          <!-- Cover on Spinny -->
-          <Spinny>
-            <TooltipId>spinny</TooltipId>
-            <Size>40me,40me</Size>
-            <Group><Variable name="group"/></Group>
-            <PathBackground scalemode="STRETCH_ASPECT">skin:../Tango/graphics/spinny_mini_bg.svg</PathBackground>
-            <PathForeground scalemode="STRETCH_ASPECT">skin:../Tango/graphics/spinny_mini_indicator.svg</PathForeground>
-            <PathMask scalemode="STRETCH_ASPECT">skin:../Tango/graphics/spinny_mini_mask_<Variable name="SpinnyCoverColor"/>.svg</PathMask>
-            <PathGhost scalemode="STRETCH_ASPECT">skin:../Tango/graphics/spinny_mini_indicator_ghost.svg</PathGhost>
-            <ShowCover>true</ShowCover>
-            <Connection>
-              <ConfigKey persist="true">[Skin],show_coverart</ConfigKey>
-              <BindProperty>visible</BindProperty>
-            </Connection>
+            <ShowCoverControl>[Skin],show_coverart</ShowCoverControl>
           </Spinny>
         </Children>
         <Connection>
           <ConfigKey persist="true">[Skin],show_spinnies</ConfigKey>
           <BindProperty>visible</BindProperty>
         </Connection>
-      </WidgetGroup><!-- Spinny -->
+      </WidgetGroup>
 
       <!-- Cover Art only -->
       <WidgetGroup>

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -1285,7 +1285,12 @@ QWidget* LegacySkinParser::parseSpinny(const QDomElement& node) {
     connect(spinny, &WSpinny::trackDropped, m_pPlayerManager, &PlayerManager::slotLoadToPlayer);
     connect(spinny, &WSpinny::cloneDeck, m_pPlayerManager, &PlayerManager::slotCloneDeck);
 
-    spinny->setup(node, *m_pContext);
+    ControlObject* showCoverControl = controlFromConfigNode(node.toElement(), "ShowCoverControl");
+    ConfigKey configKey;
+    if (showCoverControl) {
+        configKey = showCoverControl->getKey();
+    }
+    spinny->setup(node, *m_pContext, configKey);
     spinny->installEventFilter(m_pKeyboard);
     spinny->installEventFilter(m_pControllerManager->getControllerLearningEventFilter());
     spinny->Init();

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -148,7 +148,7 @@ void WSpinny::onVinylSignalQualityUpdate(const VinylSignalQualityReport& report)
 
 void WSpinny::setup(const QDomNode& node,
         const SkinContext& context,
-        const ConfigKey showCoverConfigKey) {
+        const ConfigKey& showCoverConfigKey) {
     // Set images
     QDomElement backPathElement = context.selectElement(node, "PathBackground");
     m_pBgImage = WImageStore::getImage(context.getPixmapSource(backPathElement),

--- a/src/widget/wspinny.h
+++ b/src/widget/wspinny.h
@@ -36,7 +36,7 @@ class WSpinny : public QGLWidget, public WBaseWidget, public VinylSignalQualityL
 
     void setup(const QDomNode& node,
             const SkinContext& context,
-            const ConfigKey showCoverConfigKey);
+            const ConfigKey& showCoverConfigKey);
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dropEvent(QDropEvent *event) override;
 

--- a/src/widget/wspinny.h
+++ b/src/widget/wspinny.h
@@ -16,6 +16,7 @@
 #include "widget/wcoverartmenu.h"
 #include "widget/wwidget.h"
 
+class ConfigKey;
 class ControlProxy;
 class VisualPlayPosition;
 class VinylControlManager;
@@ -33,7 +34,9 @@ class WSpinny : public QGLWidget, public WBaseWidget, public VinylSignalQualityL
 
     void onVinylSignalQualityUpdate(const VinylSignalQualityReport& report) override;
 
-    void setup(const QDomNode& node, const SkinContext& context);
+    void setup(const QDomNode& node,
+            const SkinContext& context,
+            const ConfigKey showCoverConfigKey);
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dropEvent(QDropEvent *event) override;
 
@@ -98,6 +101,7 @@ class WSpinny : public QGLWidget, public WBaseWidget, public VinylSignalQualityL
     ControlProxy* m_pVinylControlEnabled;
     ControlProxy* m_pSignalEnabled;
     ControlProxy* m_pSlipEnabled;
+    ControlProxy* m_pShowCoverProxy;
 
     TrackPointer m_loadedTrack;
     QPixmap m_loadedCover;


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1883362

This allows to have only one spinny instance per deck, which in return allows to simplify the skins (and probably decreases memory footprint a bit).

- [x] simplify LateNight
- [x] simplify Tango