### PR TITLE
Event queue compressing proxy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -461,6 +461,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/control/control.cpp
   src/control/controlaudiotaperpot.cpp
   src/control/controlbehavior.cpp
+  src/control/controlcompressingproxy.cpp
   src/control/controleffectknob.cpp
   src/control/controlencoder.cpp
   src/control/controlindicator.cpp
@@ -1589,6 +1590,7 @@ add_executable(mixxx-test
   src/test/controller_mapping_validation_test.cpp
   src/test/controllerscriptenginelegacy_test.cpp
   src/test/controlobjecttest.cpp
+  src/test/controlobjectscripttest.cpp
   src/test/coreservicestest.cpp
   src/test/coverartcache_test.cpp
   src/test/coverartutils_test.cpp

--- a/src/control/controlcompressingproxy.cpp
+++ b/src/control/controlcompressingproxy.cpp
@@ -7,8 +7,10 @@ constexpr int kMaxNumOfRecursions = 128;
 }
 
 // Event queue compressing proxy
-CompressingProxy::CompressingProxy(QObject* parent)
-        : QObject(parent), m_recursionDepth(0) {
+CompressingProxy::CompressingProxy(const ConfigKey& key,
+        const RuntimeLoggingCategory& logger,
+        QObject* pParent)
+        : QObject(pParent), m_key(key), m_logger(logger), m_recursionDepth(0) {
 }
 
 // This function is called recursive by QCoreApplication::sendPostedEvents, until no more events are in the queue.
@@ -22,6 +24,13 @@ CompressingProxy::StateOfProcessQueuedEvent CompressingProxy::processQueuedEvent
     if (m_recursionDepth >= kMaxNumOfRecursions) {
         // To many events in queue -> Delete all unprocessed events in queue, to prevent stack overflow
         QCoreApplication::removePostedEvents(this, QEvent::MetaCall);
+
+        qCWarning(m_logger) << "Deleted unprocessed events for " + m_key.group +
+                        ", " + m_key.item +
+                        ", because too many events were in the queue. This "
+                        "indicates a serious performance problem with the "
+                        "controller mapping.";
+
         // We just return, without resetting m_recursiveSearchForLastEventOngoing,
         // this ensures that the event found in the last iteration will be send
         return StateOfProcessQueuedEvent::NoEvent;
@@ -32,6 +41,15 @@ CompressingProxy::StateOfProcessQueuedEvent CompressingProxy::processQueuedEvent
     // Each call of QCoreApplication::sendPostedEvents triggers the processing of the next event in the queue,
     // by sending the signal to execute slotValueChanged again
     QCoreApplication::sendPostedEvents(this, QEvent::MetaCall);
+
+    if (m_recursiveSearchForLastEventOngoing && m_recursionDepth > 1) {
+        qCWarning(m_logger)
+                << "Skipped" << (m_recursionDepth - 1)
+                << "superseded events from " + m_key.group + ", " + m_key.item +
+                        ", because the controller mapping couldn't process "
+                        "them fast enough.";
+    }
+
     m_recursionDepth--;
 
     // Execution continues here, when last event for this slot is processed

--- a/src/control/controlcompressingproxy.cpp
+++ b/src/control/controlcompressingproxy.cpp
@@ -1,0 +1,24 @@
+#include "control/controlcompressingproxy.h"
+
+#include "moc_controlcompressingproxy.cpp"
+
+// Compressor
+CompressingProxy::CompressingProxy(QObject* parent)
+        : QObject(parent){};
+
+bool CompressingProxy::emitCheck() {
+    m_lastEventRecursionOngoing = true;
+
+    // sendPostedEventstriggers recursive execution of slotValueChanged until no more events for this slot are in the queue
+    QCoreApplication::sendPostedEvents(this, QEvent::MetaCall);
+
+    // Execution continues here, if last event for this slot is processed
+    bool isLastEvent = m_lastEventRecursionOngoing;
+    m_lastEventRecursionOngoing = false;
+    return isLastEvent;
+}
+
+void CompressingProxy::slotValueChanged(double value, QObject* obj) {
+    if (emitCheck())
+        emit signalValueChanged(value, obj);
+}

--- a/src/control/controlcompressingproxy.cpp
+++ b/src/control/controlcompressingproxy.cpp
@@ -2,6 +2,10 @@
 
 #include "moc_controlcompressingproxy.cpp"
 
+namespace {
+constexpr int kMaxNumOfRecursions = 128;
+}
+
 // Event queue compressing proxy
 CompressingProxy::CompressingProxy(QObject* parent)
         : QObject(parent), m_recursionDepth(0) {
@@ -12,7 +16,7 @@ CompressingProxy::CompressingProxy(QObject* parent)
 // and m_recursiveSearchForLastEventOngoing is set to false, while returning true itself.
 // All previous started instances of processQueuedEvents() will return false in consequence,
 // because the return value depends on the member variable and not on the stack of the instance.
-StateOfProcessQueuedEvent CompressingProxy::processQueuedEvents() {
+CompressingProxy::StateOfProcessQueuedEvent CompressingProxy::processQueuedEvents() {
     m_recursiveSearchForLastEventOngoing = true;
 
     if (m_recursionDepth >= kMaxNumOfRecursions) {

--- a/src/control/controlcompressingproxy.h
+++ b/src/control/controlcompressingproxy.h
@@ -6,9 +6,9 @@
 class CompressingProxy : public QObject {
     Q_OBJECT
   private:
-    bool emitCheck();
+    bool isLatestEventInQueue();
 
-    bool m_lastEventRecursionOngoing;
+    bool m_recursiveSearchForLastEventOngoing;
 
   public slots:
     void slotValueChanged(double value, QObject* obj);

--- a/src/control/controlcompressingproxy.h
+++ b/src/control/controlcompressingproxy.h
@@ -7,19 +7,19 @@ namespace {
 constexpr int kMaxNumOfRecursions = 128;
 }
 
-enum class stateOfprocessQueuedEvent {
-    last_event,
-    outdated_event,
-    no_event
+enum class StateOfProcessQueuedEvent {
+    LastEvent,
+    OutdatedEvent,
+    NoEvent
 };
 
 class CompressingProxy : public QObject {
     Q_OBJECT
   private:
-    stateOfprocessQueuedEvent processQueuedEvents();
+    StateOfProcessQueuedEvent processQueuedEvents();
 
     bool m_recursiveSearchForLastEventOngoing;
-    int m_recursionCounter;
+    int m_recursionDepth;
 
   public slots:
     void slotValueChanged(double value, QObject* obj);

--- a/src/control/controlcompressingproxy.h
+++ b/src/control/controlcompressingproxy.h
@@ -3,19 +3,14 @@
 #include <QApplication>
 #include <QMetaObject>
 
-namespace {
-constexpr int kMaxNumOfRecursions = 128;
-}
-
-enum class StateOfProcessQueuedEvent {
-    LastEvent,
-    OutdatedEvent,
-    NoEvent
-};
-
 class CompressingProxy : public QObject {
     Q_OBJECT
   private:
+    enum class StateOfProcessQueuedEvent {
+        LastEvent,
+        OutdatedEvent,
+        NoEvent
+    };
     StateOfProcessQueuedEvent processQueuedEvents();
 
     bool m_recursiveSearchForLastEventOngoing;

--- a/src/control/controlcompressingproxy.h
+++ b/src/control/controlcompressingproxy.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <QApplication>
+#include <QMetaObject>
+
+class CompressingProxy : public QObject {
+    Q_OBJECT
+  private:
+    bool emitCheck();
+
+    bool m_lastEventRecursionOngoing;
+
+  public slots:
+    void slotValueChanged(double value, QObject* obj);
+
+  signals:
+    void signalValueChanged(double, QObject*);
+
+  public:
+    // No default constructor, since the proxy must be a child of the
+    // target object.
+    explicit CompressingProxy(QObject* parent);
+};

--- a/src/control/controlcompressingproxy.h
+++ b/src/control/controlcompressingproxy.h
@@ -3,10 +3,13 @@
 #include <QApplication>
 #include <QMetaObject>
 
+enum class stateOfprocessQueuedEvent { last_event,
+    outdated_event };
+
 class CompressingProxy : public QObject {
     Q_OBJECT
   private:
-    bool isLatestEventInQueue();
+    stateOfprocessQueuedEvent processQueuedEvents();
 
     bool m_recursiveSearchForLastEventOngoing;
 

--- a/src/control/controlcompressingproxy.h
+++ b/src/control/controlcompressingproxy.h
@@ -3,8 +3,15 @@
 #include <QApplication>
 #include <QMetaObject>
 
-enum class stateOfprocessQueuedEvent { last_event,
-    outdated_event };
+namespace {
+constexpr int kMaxNumOfRecursions = 128;
+}
+
+enum class stateOfprocessQueuedEvent {
+    last_event,
+    outdated_event,
+    no_event
+};
 
 class CompressingProxy : public QObject {
     Q_OBJECT
@@ -12,6 +19,7 @@ class CompressingProxy : public QObject {
     stateOfprocessQueuedEvent processQueuedEvents();
 
     bool m_recursiveSearchForLastEventOngoing;
+    int m_recursionCounter;
 
   public slots:
     void slotValueChanged(double value, QObject* obj);
@@ -20,7 +28,6 @@ class CompressingProxy : public QObject {
     void signalValueChanged(double, QObject*);
 
   public:
-    // No default constructor, since the proxy must be a child of the
-    // target object.
+    // No default constructor, since the proxy must be a child of the object with the Qt event queue
     explicit CompressingProxy(QObject* parent);
 };

--- a/src/control/controlcompressingproxy.h
+++ b/src/control/controlcompressingproxy.h
@@ -3,6 +3,9 @@
 #include <QApplication>
 #include <QMetaObject>
 
+#include "preferences/configobject.h"
+#include "util/runtimeloggingcategory.h"
+
 class CompressingProxy : public QObject {
     Q_OBJECT
   private:
@@ -13,6 +16,11 @@ class CompressingProxy : public QObject {
     };
     StateOfProcessQueuedEvent processQueuedEvents();
 
+    // Members needed for warning message
+    const ConfigKey m_key;
+    const RuntimeLoggingCategory m_logger;
+
+    // Functional members
     bool m_recursiveSearchForLastEventOngoing;
     int m_recursionDepth;
 
@@ -24,5 +32,7 @@ class CompressingProxy : public QObject {
 
   public:
     // No default constructor, since the proxy must be a child of the object with the Qt event queue
-    explicit CompressingProxy(QObject* parent);
+    explicit CompressingProxy(const ConfigKey& key,
+            const RuntimeLoggingCategory& logger,
+            QObject* pParent = nullptr);
 };

--- a/src/control/controlobjectscript.cpp
+++ b/src/control/controlobjectscript.cpp
@@ -8,17 +8,17 @@ ControlObjectScript::ControlObjectScript(
           m_logger(logger) {
 }
 
-bool ControlObjectScript::addScriptConnection(ScriptConnection& conn) {
+bool ControlObjectScript::addScriptConnection(ScriptConnection* const conn) {
     if (m_scriptConnections.isEmpty()) {
         // Only connect the slots when they are actually needed
         // by script connections.
-        conn.proxy = new CompressingProxy(this);
+        conn->proxy = new CompressingProxy(this);
         connect(m_pControl.data(),
                 &ControlDoublePrivate::valueChanged,
-                conn.proxy,
+                conn->proxy,
                 &CompressingProxy::slotValueChanged,
                 Qt::QueuedConnection);
-        connect(conn.proxy,
+        connect(conn->proxy,
                 &CompressingProxy::signalValueChanged,
                 this,
                 &ControlObjectScript::slotValueChanged,
@@ -31,19 +31,19 @@ bool ControlObjectScript::addScriptConnection(ScriptConnection& conn) {
     }
 
     for (const auto& priorConnection : qAsConst(m_scriptConnections)) {
-        if (conn == priorConnection) {
-            qCWarning(m_logger) << "Connection " + conn.id.toString() +
+        if (*conn == priorConnection) {
+            qCWarning(m_logger) << "Connection " + conn->id.toString() +
                             " already connected to (" +
-                            conn.key.group + ", " + conn.key.item +
+                            conn->key.group + ", " + conn->key.item +
                             "). Ignoring attempt to connect again.";
             return false;
         }
     }
 
-    m_scriptConnections.append(conn);
+    m_scriptConnections.append(*conn);
     qCDebug(m_logger) << "Connected (" +
-                    conn.key.group + ", " + conn.key.item +
-                    ") to connection " + conn.id.toString();
+                    conn->key.group + ", " + conn->key.item +
+                    ") to connection " + conn->id.toString();
     return true;
 }
 

--- a/src/control/controlobjectscript.cpp
+++ b/src/control/controlobjectscript.cpp
@@ -5,8 +5,8 @@
 ControlObjectScript::ControlObjectScript(
         const ConfigKey& key, const RuntimeLoggingCategory& logger, QObject* pParent)
         : ControlProxy(key, pParent, ControlFlag::AllowMissingOrInvalid),
-          m_logger(logger) {
-    m_proxy = std::make_unique<CompressingProxy>(this);
+          m_logger(logger),
+          m_proxy(this) {
 }
 
 bool ControlObjectScript::addScriptConnection(const ScriptConnection& conn) {
@@ -15,10 +15,10 @@ bool ControlObjectScript::addScriptConnection(const ScriptConnection& conn) {
         // by script connections.
         connect(m_pControl.data(),
                 &ControlDoublePrivate::valueChanged,
-                m_proxy.get(),
+                &m_proxy,
                 &CompressingProxy::slotValueChanged,
                 Qt::QueuedConnection);
-        connect(m_proxy.get(),
+        connect(&m_proxy,
                 &CompressingProxy::signalValueChanged,
                 this,
                 &ControlObjectScript::slotValueChanged,
@@ -62,9 +62,9 @@ bool ControlObjectScript::removeScriptConnection(const ScriptConnection& conn) {
         // no ScriptConnections left, so disconnect signals
         disconnect(m_pControl.data(),
                 &ControlDoublePrivate::valueChanged,
-                m_proxy.get(),
+                &m_proxy,
                 &CompressingProxy::slotValueChanged);
-        disconnect(m_proxy.get(),
+        disconnect(&m_proxy,
                 &CompressingProxy::signalValueChanged,
                 this,
                 &ControlObjectScript::slotValueChanged);

--- a/src/control/controlobjectscript.cpp
+++ b/src/control/controlobjectscript.cpp
@@ -6,7 +6,7 @@ ControlObjectScript::ControlObjectScript(
         const ConfigKey& key, const RuntimeLoggingCategory& logger, QObject* pParent)
         : ControlProxy(key, pParent, ControlFlag::AllowMissingOrInvalid),
           m_logger(logger),
-          m_proxy(this) {
+          m_proxy(key, logger, this) {
 }
 
 bool ControlObjectScript::addScriptConnection(const ScriptConnection& conn) {

--- a/src/control/controlobjectscript.h
+++ b/src/control/controlobjectscript.h
@@ -5,7 +5,6 @@
 #include "control/controlcompressingproxy.h"
 #include "control/controlproxy.h"
 #include "controllers/scripting/legacy/scriptconnection.h"
-#include "util/memory.h"
 #include "util/runtimeloggingcategory.h"
 
 // this is used for communicate with controller scripts
@@ -43,5 +42,5 @@ class ControlObjectScript : public ControlProxy {
   private:
     QVector<ScriptConnection> m_scriptConnections;
     const RuntimeLoggingCategory m_logger;
-    std::unique_ptr<CompressingProxy> m_proxy;
+    CompressingProxy m_proxy;
 };

--- a/src/control/controlobjectscript.h
+++ b/src/control/controlobjectscript.h
@@ -44,4 +44,5 @@ class ControlObjectScript : public ControlProxy {
     QVector<ScriptConnection> m_scriptConnections;
     const RuntimeLoggingCategory m_logger;
     CompressingProxy m_proxy;
+    bool m_skipSuperseded; // This flag is combined for all connections of this Control Object
 };

--- a/src/control/controlobjectscript.h
+++ b/src/control/controlobjectscript.h
@@ -2,8 +2,10 @@
 
 #include <QVector>
 
+#include "control/controlcompressingproxy.h"
 #include "control/controlproxy.h"
 #include "controllers/scripting/legacy/scriptconnection.h"
+#include "util/memory.h"
 #include "util/runtimeloggingcategory.h"
 
 // this is used for communicate with controller scripts
@@ -14,7 +16,7 @@ class ControlObjectScript : public ControlProxy {
             const RuntimeLoggingCategory& logger,
             QObject* pParent = nullptr);
 
-    bool addScriptConnection(ScriptConnection* const conn);
+    bool addScriptConnection(const ScriptConnection& conn);
 
     bool removeScriptConnection(const ScriptConnection& conn);
 
@@ -41,4 +43,5 @@ class ControlObjectScript : public ControlProxy {
   private:
     QVector<ScriptConnection> m_scriptConnections;
     const RuntimeLoggingCategory m_logger;
+    std::unique_ptr<CompressingProxy> m_proxy;
 };

--- a/src/control/controlobjectscript.h
+++ b/src/control/controlobjectscript.h
@@ -14,7 +14,7 @@ class ControlObjectScript : public ControlProxy {
             const RuntimeLoggingCategory& logger,
             QObject* pParent = nullptr);
 
-    bool addScriptConnection(const ScriptConnection& conn);
+    bool addScriptConnection(ScriptConnection& conn);
 
     bool removeScriptConnection(const ScriptConnection& conn);
 
@@ -36,7 +36,7 @@ class ControlObjectScript : public ControlProxy {
 
   protected slots:
     // Receives the value from the master control by a unique queued connection
-    void slotValueChanged(double v, QObject*);
+    virtual void slotValueChanged(double v, QObject*);
 
   private:
     QVector<ScriptConnection> m_scriptConnections;

--- a/src/control/controlobjectscript.h
+++ b/src/control/controlobjectscript.h
@@ -37,6 +37,7 @@ class ControlObjectScript : public ControlProxy {
 
   protected slots:
     // Receives the value from the master control by a unique queued connection
+    // This is specified virtual, to allow gmock to replace it in the test case
     virtual void slotValueChanged(double v, QObject*);
 
   private:

--- a/src/control/controlobjectscript.h
+++ b/src/control/controlobjectscript.h
@@ -14,7 +14,7 @@ class ControlObjectScript : public ControlProxy {
             const RuntimeLoggingCategory& logger,
             QObject* pParent = nullptr);
 
-    bool addScriptConnection(ScriptConnection& conn);
+    bool addScriptConnection(ScriptConnection* const conn);
 
     bool removeScriptConnection(const ScriptConnection& conn);
 

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
@@ -246,7 +246,7 @@ QJSValue ControllerScriptInterfaceLegacy::makeConnection(
     connection.callback = callback;
     connection.id = QUuid::createUuid();
 
-    if (coScript->addScriptConnection(&connection)) {
+    if (coScript->addScriptConnection(connection)) {
         return pJsEngine->newQObject(
                 new ScriptConnectionJSProxy(connection));
     }

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
@@ -212,6 +212,16 @@ double ControllerScriptInterfaceLegacy::getDefaultParameter(
 }
 
 QJSValue ControllerScriptInterfaceLegacy::makeConnection(
+        const QString& group, const QString& name, const QJSValue& callback) {
+    return ControllerScriptInterfaceLegacy::makeConnectionInternal(group, name, callback, false);
+}
+
+QJSValue ControllerScriptInterfaceLegacy::makeCompressedConnection(
+        const QString& group, const QString& name, const QJSValue& callback) {
+    return ControllerScriptInterfaceLegacy::makeConnectionInternal(group, name, callback, true);
+}
+
+QJSValue ControllerScriptInterfaceLegacy::makeConnectionInternal(
         const QString& group, const QString& name, const QJSValue& callback, bool skipSuperseded) {
     auto pJsEngine = m_pScriptEngineLegacy->jsEngine();
     VERIFY_OR_DEBUG_ASSERT(pJsEngine) {

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
@@ -212,7 +212,7 @@ double ControllerScriptInterfaceLegacy::getDefaultParameter(
 }
 
 QJSValue ControllerScriptInterfaceLegacy::makeConnection(
-        const QString& group, const QString& name, const QJSValue& callback) {
+        const QString& group, const QString& name, const QJSValue& callback, bool skipSuperseded) {
     auto pJsEngine = m_pScriptEngineLegacy->jsEngine();
     VERIFY_OR_DEBUG_ASSERT(pJsEngine) {
         return QJSValue();
@@ -245,6 +245,7 @@ QJSValue ControllerScriptInterfaceLegacy::makeConnection(
     connection.controllerEngine = m_pScriptEngineLegacy;
     connection.callback = callback;
     connection.id = QUuid::createUuid();
+    connection.skipSuperseded = skipSuperseded;
 
     if (coScript->addScriptConnection(connection)) {
         return pJsEngine->newQObject(

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
@@ -246,7 +246,7 @@ QJSValue ControllerScriptInterfaceLegacy::makeConnection(
     connection.callback = callback;
     connection.id = QUuid::createUuid();
 
-    if (coScript->addScriptConnection(connection)) {
+    if (coScript->addScriptConnection(&connection)) {
         return pJsEngine->newQObject(
                 new ScriptConnectionJSProxy(connection));
     }

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
@@ -33,8 +33,10 @@ class ControllerScriptInterfaceLegacy : public QObject {
     Q_INVOKABLE double getDefaultParameter(const QString& group, const QString& name);
     Q_INVOKABLE QJSValue makeConnection(const QString& group,
             const QString& name,
-            const QJSValue& callback,
-            bool skipSuperseded = false);
+            const QJSValue& callback);
+    Q_INVOKABLE QJSValue makeCompressedConnection(const QString& group,
+            const QString& name,
+            const QJSValue& callback);
     // DEPRECATED: Use makeConnection instead.
     Q_INVOKABLE QJSValue connectControl(const QString& group,
             const QString& name,
@@ -68,6 +70,10 @@ class ControllerScriptInterfaceLegacy : public QObject {
     virtual void timerEvent(QTimerEvent* event);
 
   private:
+    QJSValue makeConnectionInternal(const QString& group,
+            const QString& name,
+            const QJSValue& callback,
+            bool skipSuperseded = false);
     QHash<ConfigKey, ControlObjectScript*> m_controlCache;
     ControlObjectScript* getControlObjectScript(const QString& group, const QString& name);
 

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
@@ -31,8 +31,10 @@ class ControllerScriptInterfaceLegacy : public QObject {
     Q_INVOKABLE void reset(const QString& group, const QString& name);
     Q_INVOKABLE double getDefaultValue(const QString& group, const QString& name);
     Q_INVOKABLE double getDefaultParameter(const QString& group, const QString& name);
-    Q_INVOKABLE QJSValue makeConnection(
-            const QString& group, const QString& name, const QJSValue& callback);
+    Q_INVOKABLE QJSValue makeConnection(const QString& group,
+            const QString& name,
+            const QJSValue& callback,
+            bool skipSuperseded = false);
     // DEPRECATED: Use makeConnection instead.
     Q_INVOKABLE QJSValue connectControl(const QString& group,
             const QString& name,

--- a/src/controllers/scripting/legacy/scriptconnection.h
+++ b/src/controllers/scripting/legacy/scriptconnection.h
@@ -18,6 +18,7 @@ class ScriptConnection {
     QJSValue callback;
     ControllerScriptInterfaceLegacy* engineJSProxy;
     ControllerScriptEngineLegacy* controllerEngine;
+    bool skipSuperseded;
 
     void executeCallback(double value) const;
 

--- a/src/controllers/scripting/legacy/scriptconnection.h
+++ b/src/controllers/scripting/legacy/scriptconnection.h
@@ -3,6 +3,7 @@
 #include <QJSValue>
 #include <QUuid>
 
+#include "control/controlcompressingproxy.h"
 #include "preferences/configobject.h"
 
 class ControllerScriptEngineLegacy;
@@ -18,6 +19,7 @@ class ScriptConnection {
     QJSValue callback;
     ControllerScriptInterfaceLegacy* engineJSProxy;
     ControllerScriptEngineLegacy* controllerEngine;
+    CompressingProxy* proxy;
 
     void executeCallback(double value) const;
 

--- a/src/controllers/scripting/legacy/scriptconnection.h
+++ b/src/controllers/scripting/legacy/scriptconnection.h
@@ -3,7 +3,6 @@
 #include <QJSValue>
 #include <QUuid>
 
-#include "control/controlcompressingproxy.h"
 #include "preferences/configobject.h"
 
 class ControllerScriptEngineLegacy;
@@ -19,7 +18,6 @@ class ScriptConnection {
     QJSValue callback;
     ControllerScriptInterfaceLegacy* engineJSProxy;
     ControllerScriptEngineLegacy* controllerEngine;
-    CompressingProxy* proxy;
 
     void executeCallback(double value) const;
 

--- a/src/test/controlobjectscripttest.cpp
+++ b/src/test/controlobjectscripttest.cpp
@@ -52,8 +52,13 @@ class ControlObjectScriptTest : public MixxxTest {
         conn2.callback = "mock_callback2";
         conn2.id = QUuid::createUuid();
 
-        coScript1->addScriptConnection(conn1);
-        coScript2->addScriptConnection(conn2);
+        coScript1->addScriptConnection(&conn1);
+        coScript2->addScriptConnection(&conn2);
+    }
+
+    void TearDown() override {
+        coScript1->removeScriptConnection(conn1);
+        coScript2->removeScriptConnection(conn2);
     }
 
     ConfigKey ck1, ck2;

--- a/src/test/controlobjectscripttest.cpp
+++ b/src/test/controlobjectscripttest.cpp
@@ -1,0 +1,143 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <QtDebug>
+
+#include "control/controlobject.h"
+#include "control/controlobjectscript.h"
+#include "test/mixxxtest.h"
+#include "util/memory.h"
+
+using ::testing::_;
+using ::testing::DoubleEq;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::StrictMock;
+
+namespace {
+
+const RuntimeLoggingCategory k_logger(QString("test").toLocal8Bit());
+
+class MockControlObjectScript : public ControlObjectScript {
+  public:
+    MockControlObjectScript(const ConfigKey& key,
+            const RuntimeLoggingCategory& logger,
+            QObject* pParent)
+            : ControlObjectScript(key, logger, pParent) {
+    }
+    ~MockControlObjectScript() override {
+    }
+    MOCK_METHOD2(slotValueChanged, void(double value, QObject*));
+};
+
+class ControlObjectScriptTest : public MixxxTest {
+  protected:
+    void SetUp() override {
+        ck1 = ConfigKey("[Channel1]", "co1");
+        ck2 = ConfigKey("[Channel1]", "co2");
+        co1 = std::make_unique<ControlObject>(ck1);
+        co2 = std::make_unique<ControlObject>(ck2);
+
+        coScript1 = std::make_unique<MockControlObjectScript>(ck1, k_logger, nullptr);
+        coScript2 = std::make_unique<MockControlObjectScript>(ck2, k_logger, nullptr);
+
+        conn1.key = ck1;
+        conn1.engineJSProxy = nullptr;
+        conn1.controllerEngine = nullptr;
+        conn1.callback = "mock_callback1";
+        conn1.id = QUuid::createUuid();
+
+        conn2.key = ck2;
+        conn2.engineJSProxy = nullptr;
+        conn2.controllerEngine = nullptr;
+        conn2.callback = "mock_callback2";
+        conn2.id = QUuid::createUuid();
+
+        coScript1->addScriptConnection(conn1);
+        coScript2->addScriptConnection(conn2);
+    }
+
+    ConfigKey ck1, ck2;
+    std::unique_ptr<ControlObject> co1;
+    std::unique_ptr<ControlObject> co2;
+
+    std::unique_ptr<MockControlObjectScript> coScript1;
+    std::unique_ptr<MockControlObjectScript> coScript2;
+
+    ScriptConnection conn1, conn2;
+};
+
+TEST_F(ControlObjectScriptTest, CompressingProxyCompareCount1) {
+    // Check that slotValueChanged callback is never called for conn2
+    EXPECT_CALL(*coScript2, slotValueChanged(_, _))
+            .Times(0)
+            .WillOnce(Return());
+    // Check that slotValueChanged callback is called only once (independent of the value)
+    EXPECT_CALL(*coScript1, slotValueChanged(_, _))
+            .Times(1)
+            .WillOnce(Return());
+    co1->set(1.0);
+    application()->processEvents();
+}
+
+TEST_F(ControlObjectScriptTest, CompressingProxyCompareValue1) {
+    EXPECT_CALL(*coScript1, slotValueChanged(2.0, _))
+            .Times(1)
+            .WillOnce(Return());
+
+    co1->set(2.0);
+    application()->processEvents();
+}
+
+TEST_F(ControlObjectScriptTest, CompressingProxyCompareCount2) {
+    // Check that slotValueChanged callback is never called for conn2
+    EXPECT_CALL(*coScript2, slotValueChanged(_, _))
+            .Times(0)
+            .WillOnce(Return());
+    // Check that slotValueChanged callback for conn1 is called only once (independent of the value)
+    EXPECT_CALL(*coScript1, slotValueChanged(_, _))
+            .Times(1)
+            .WillOnce(Return());
+    co1->set(3.0);
+    co1->set(4.0);
+    application()->processEvents();
+}
+
+TEST_F(ControlObjectScriptTest, CompressingProxyCompareValue2) {
+    // Check that slotValueChanged callback is called with the last set value
+    EXPECT_CALL(*coScript1, slotValueChanged(6.0, _))
+            .Times(1)
+            .WillOnce(Return());
+    co1->set(5.0);
+    co1->set(6.0);
+    application()->processEvents();
+}
+
+TEST_F(ControlObjectScriptTest, CompressingProxyCompareCountMulti) {
+    // Check that slotValueChanged callback for conn1 and conn2 is called only once (independent of the value)
+    EXPECT_CALL(*coScript1, slotValueChanged(_, _)).Times(1).WillOnce(Return());
+    // Check that slotValueChanged callback for conn1 and conn2 is called only once (independent of the value)
+    EXPECT_CALL(*coScript2, slotValueChanged(_, _)).Times(1).WillOnce(Return());
+    co1->set(10.0);
+    co2->set(11.0);
+    co1->set(12.0);
+    co2->set(13.0);
+    application()->processEvents();
+}
+
+TEST_F(ControlObjectScriptTest, CompressingProxyCompareValueMulti) {
+    // Check that slotValueChanged callback is called with the last set value
+    EXPECT_CALL(*coScript1, slotValueChanged(22.0, _))
+            .Times(1)
+            .WillOnce(Return());
+    EXPECT_CALL(*coScript2, slotValueChanged(23.0, _))
+            .Times(1)
+            .WillOnce(Return());
+    co1->set(20.0);
+    co2->set(21.0);
+    co1->set(22.0);
+    co2->set(23.0);
+    application()->processEvents();
+}
+
+} // namespace

--- a/src/test/controlobjectscripttest.cpp
+++ b/src/test/controlobjectscripttest.cpp
@@ -25,8 +25,7 @@ class MockControlObjectScript : public ControlObjectScript {
             QObject* pParent)
             : ControlObjectScript(key, logger, pParent) {
     }
-    ~MockControlObjectScript() override {
-    }
+    ~MockControlObjectScript() override = default;
     MOCK_METHOD2(slotValueChanged, void(double value, QObject*));
 };
 

--- a/src/test/controlobjectscripttest.cpp
+++ b/src/test/controlobjectscripttest.cpp
@@ -17,6 +17,7 @@ using ::testing::StrictMock;
 namespace {
 
 const RuntimeLoggingCategory k_logger(QString("test").toLocal8Bit());
+constexpr int kMaxNumOfRecursions = 128;
 
 class MockControlObjectScript : public ControlObjectScript {
   public:

--- a/src/test/controlobjectscripttest.cpp
+++ b/src/test/controlobjectscripttest.cpp
@@ -52,8 +52,8 @@ class ControlObjectScriptTest : public MixxxTest {
         conn2.callback = "mock_callback2";
         conn2.id = QUuid::createUuid();
 
-        coScript1->addScriptConnection(&conn1);
-        coScript2->addScriptConnection(&conn2);
+        coScript1->addScriptConnection(conn1);
+        coScript2->addScriptConnection(conn2);
     }
 
     void TearDown() override {

--- a/src/test/controlobjectscripttest.cpp
+++ b/src/test/controlobjectscripttest.cpp
@@ -35,47 +35,64 @@ class ControlObjectScriptTest : public MixxxTest {
     void SetUp() override {
         ck1 = ConfigKey("[Channel1]", "co1");
         ck2 = ConfigKey("[Channel1]", "co2");
+        ck4 = ConfigKey("[Channel1]", "co4");
         co1 = std::make_unique<ControlObject>(ck1);
         co2 = std::make_unique<ControlObject>(ck2);
+        co4 = std::make_unique<ControlObject>(ck4);
 
         coScript1 = std::make_unique<MockControlObjectScript>(ck1, k_logger, nullptr);
         coScript2 = std::make_unique<MockControlObjectScript>(ck2, k_logger, nullptr);
+        coScript4 = std::make_unique<MockControlObjectScript>(ck4, k_logger, nullptr);
 
         conn1.key = ck1;
         conn1.engineJSProxy = nullptr;
         conn1.controllerEngine = nullptr;
         conn1.callback = "mock_callback1";
         conn1.id = QUuid::createUuid();
+        conn1.skipSuperseded = true;
 
         conn2.key = ck2;
         conn2.engineJSProxy = nullptr;
         conn2.controllerEngine = nullptr;
         conn2.callback = "mock_callback2";
         conn2.id = QUuid::createUuid();
+        conn2.skipSuperseded = true;
 
         conn3.key = ck2;
         conn3.engineJSProxy = nullptr;
         conn3.controllerEngine = nullptr;
         conn3.callback = "mock_callback3";
         conn3.id = QUuid::createUuid();
+        conn3.skipSuperseded = true;
+
+        conn4.key = ck1;
+        conn4.engineJSProxy = nullptr;
+        conn4.controllerEngine = nullptr;
+        conn4.callback = "mock_callback1";
+        conn4.id = QUuid::createUuid();
+        conn4.skipSuperseded = false;
 
         coScript1->addScriptConnection(conn1);
         coScript2->addScriptConnection(conn2);
+        coScript4->addScriptConnection(conn4);
     }
 
     void TearDown() override {
         coScript1->removeScriptConnection(conn1);
         coScript2->removeScriptConnection(conn2);
+        coScript4->removeScriptConnection(conn4);
     }
 
-    ConfigKey ck1, ck2;
+    ConfigKey ck1, ck2, ck4;
     std::unique_ptr<ControlObject> co1;
     std::unique_ptr<ControlObject> co2;
+    std::unique_ptr<ControlObject> co4;
 
     std::unique_ptr<MockControlObjectScript> coScript1;
     std::unique_ptr<MockControlObjectScript> coScript2;
+    std::unique_ptr<MockControlObjectScript> coScript4;
 
-    ScriptConnection conn1, conn2, conn3;
+    ScriptConnection conn1, conn2, conn3, conn4;
 };
 
 TEST_F(ControlObjectScriptTest, CompressingProxyCompareCount1) {
@@ -124,6 +141,32 @@ TEST_F(ControlObjectScriptTest, CompressingProxyCompareValue2) {
     application()->processEvents();
 }
 
+TEST_F(ControlObjectScriptTest, QueuedCompareCount2) {
+    // Check that slotValueChanged callback is never called for conn4
+    EXPECT_CALL(*coScript2, slotValueChanged(_, _))
+            .Times(0)
+            .WillOnce(Return());
+    // Check that slotValueChanged callback for conn1 is called only twice (independent of the value), because proxy is disabled
+    EXPECT_CALL(*coScript4, slotValueChanged(_, _))
+            .Times(2)
+            .WillOnce(Return());
+    co4->set(53.0);
+    co4->set(54.0);
+    application()->processEvents();
+}
+
+TEST_F(ControlObjectScriptTest, QueuedCompareValue2) {
+    // Check that slotValueChanged callback is called for each value, because proxy is disabled
+    EXPECT_CALL(*coScript4, slotValueChanged(55.0, _))
+            .Times(1)
+            .WillOnce(Return());
+    EXPECT_CALL(*coScript4, slotValueChanged(56.0, _))
+            .Times(1)
+            .WillOnce(Return());
+    co4->set(55.0);
+    co4->set(56.0);
+    application()->processEvents();
+}
 TEST_F(ControlObjectScriptTest, CompressingProxyCompareCountMulti) {
     // Check that slotValueChanged callback for conn1 and conn2 is called only once (independent of the value)
     EXPECT_CALL(*coScript1, slotValueChanged(_, _)).Times(1).WillOnce(Return());
@@ -168,6 +211,41 @@ TEST_F(ControlObjectScriptTest, CompressingProxyMultiConnection) {
     application()->processEvents();
 
     coScript2->removeScriptConnection(conn3);
+}
+
+TEST_F(ControlObjectScriptTest, QueuedFallbackMultiConnection) {
+    // Check that slotValueChanged callback is called 1 time if multiple connections exist forthe same slot
+    EXPECT_CALL(*coScript1, slotValueChanged(62.0, _))
+            .Times(1)
+            .WillOnce(Return());
+    EXPECT_CALL(*coScript2, slotValueChanged(63.0, _))
+            .Times(1)
+            .WillOnce(Return());
+    EXPECT_CALL(*coScript1, slotValueChanged(66.0, _))
+            .Times(1)
+            .WillOnce(Return());
+    EXPECT_CALL(*coScript2, slotValueChanged(65.0, _))
+            .Times(1)
+            .WillOnce(Return());
+    EXPECT_CALL(*coScript2, slotValueChanged(67.0, _))
+            .Times(1)
+            .WillOnce(Return());
+
+    co1->set(60.0);
+    co2->set(61.0);
+    co1->set(62.0);
+    co2->set(63.0);
+    application()->processEvents();
+    conn3.skipSuperseded = false;
+    coScript2->addScriptConnection(conn3);
+    co1->set(64.0);
+    co2->set(65.0);
+    co1->set(66.0);
+    co2->set(67.0);
+    application()->processEvents();
+
+    coScript2->removeScriptConnection(conn3);
+    conn3.skipSuperseded = true;
 }
 
 TEST_F(ControlObjectScriptTest, CompressingProxyManyEvents) {


### PR DESCRIPTION
This PR implements a event queue compressing proxy, which skips the processing of superseded events. This is used in ControlObjectScript.
The PR also contains a unit test which checks the compressing behavior in ControlObjectScript.

What does this compressor solve:
-The compressor prevents unresponsive controllers in CPU overload conditions, when more signals are send from Mixxx, than the mapping can handle. This occurs with complex controllers (with many connected COs) and a not so powerful computer. Especially with signals that appear in high rate, like VU-Meter, Beat indication or Play position.

Behavior without this PR:
-Events are queued and processed as fast as the mapping (or the controller hardware) can
-Status LEDs on controler show oudated states from the queue
-Because controller input and output are handled in the same mapping thread. In overload conditions the mapping also queue the processing of the events send from the controller to the mapping. 

Behavior with this PR:
-As long as no CPU overload occurs everything behaves as before
-When an CPU overload occurs, the compressing proxy recursive parse the event Qt event queue vor signals of the same connection. In case of multiple events only the latest is send to the JavaScript callback function in the mapping.
-Therefore status LEDs show always the latest state, and no superseded states from the event queue
-The input is not directly affected, but due to the limited load for the mapping thread, there is always time to process the input events and there are no noticeable delays anymore, between pressing a button and the response of Mixxx.
