### PR TITLE
Search bar tweaks

### DIFF
--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -183,15 +183,16 @@ bool WLibrarySidebar::isLeafNodeSelected() {
 }
 
 void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
-    if (event->key() == Qt::Key_Return) {
+    const int key = event->key();
+    if (key == Qt::Key_Return) {
         toggleSelectedItem();
         return;
-    } else if (event->key() == Qt::Key_Down ||
-            event->key() == Qt::Key_Up ||
-            event->key() == Qt::Key_PageDown ||
-            event->key() == Qt::Key_PageUp ||
-            event->key() == Qt::Key_End ||
-            event->key() == Qt::Key_Home) {
+    } else if (key == Qt::Key_Down ||
+            key == Qt::Key_Up ||
+            key == Qt::Key_PageDown ||
+            key == Qt::Key_PageUp ||
+            key == Qt::Key_End ||
+            key == Qt::Key_Home) {
         // Let the tree view move up and down for us.
         QTreeView::keyPressEvent(event);
         // But force the index to be activated/clicked after the selection
@@ -204,11 +205,7 @@ void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
             emit pressed(index);
         }
         return;
-    //} else if (event->key() == Qt::Key_Enter && (event->modifiers() & Qt::AltModifier)) {
-    //    // encoder click via "GoToItem"
-    //    qDebug() << "GoToItem";
-    //    TODO(xxx) decide what todo here instead of in librarycontrol
-    } else if (event->key() == Qt::Key_Left) {
+    } else if (key == Qt::Key_Left) {
         auto selModel = selectionModel();
         QModelIndexList selectedRows = selModel->selectedRows();
         if (selectedRows.isEmpty()) {
@@ -227,6 +224,9 @@ void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
             selectIndex(parentIndex);
             emit pressed(parentIndex);
         }
+        return;
+    } else if (key == Qt::Key_Escape) {
+        emit sidebarFocusChange(FocusWidget::TracksTable);
         return;
     }
 

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -92,7 +92,13 @@ WSearchLineEdit::WSearchLineEdit(QWidget* pParent, UserSettingsPointer pConfig)
 
     //: Shown in the library search bar when it is empty.
     lineEdit()->setPlaceholderText(tr("Search..."));
-    installEventFilter(this);
+
+    // The goal is to make Esc natively close the popup, while in the line edit it
+    // should move the keyboard focus to the tracks table. Unfortunately, eventFilter()
+    // can't catch Esc before the popup is closed, and keyPressEvent() can't catch
+    // keyPresses sent to the popup. So the only way to get this to work is to use
+    // keyPressEvent() for catching all keypress events sent to the line edit,
+    // while eventFilter() catches those sent to the popup.
     view()->installEventFilter(this);
 
     m_clearButton->setCursor(Qt::ArrowCursor);
@@ -324,63 +330,76 @@ QString WSearchLineEdit::getSearchText() const {
 bool WSearchLineEdit::eventFilter(QObject* obj, QEvent* event) {
     if (event->type() == QEvent::KeyPress) {
         QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
-        // only intercept Up/Down keys if the popup is not open!
-        if (!view()->isVisible()) {
-            if (keyEvent->key() == Qt::Key_Up) {
-                // if we're at the top of the list the Up key clears the search bar,
-                // no matter if it's a saved and unsaved query
-                if (findCurrentTextIndex() == 0 ||
-                        (findCurrentTextIndex() == -1 && !currentText().isEmpty())) {
-                    slotClearSearch();
-                    return true;
-                }
-            } else if (keyEvent->key() == Qt::Key_Down) {
-                // after clearing the text field the down key is expected to
-                // show the latest entry
-                if (currentText().isEmpty()) {
-                    setCurrentIndex(0);
-                    return true;
-                }
-                // in case the user entered a new search query
-                // and presses the down key, save the query for later recall
-                if (findCurrentTextIndex() == -1) {
-                    slotSaveSearch();
-                }
-            }
-        } else { // popup is open
-            if (keyEvent->key() == Qt::Key_Backspace ||
-                    keyEvent->key() == Qt::Key_Delete) {
-                // remove the highlighted item from the list
-                deleteSelectedListItem();
-                return true;
-            }
-        }
-
-        // shortcuts applied no matter if popup is open
-        if (keyEvent->key() == Qt::Key_Enter) {
-            if (findCurrentTextIndex() == -1) {
-                slotSaveSearch();
-            }
-            // The default handler will add the entry to the list,
-            // this already happened in slotSaveSearch
-            slotTriggerSearch();
-            return true;
-        } else if (keyEvent->key() == Qt::Key_Space &&
-                keyEvent->modifiers() == Qt::ControlModifier) {
-            // open/close popup on ctrl + space
-            if (view()->isVisible()) {
-                hidePopup();
-            } else {
-                showPopup();
-            }
-            return true;
-        } else if (keyEvent->key() == Qt::Key_Escape) {
-            emit searchbarFocusChange(FocusWidget::TracksTable);
+        const int key = keyEvent->key();
+        // Esc has already closed the popup by now and we don't want to process it.
+        // We don't need to handle Up/Down in the popup either.
+        // Any other keypress is forwarded.
+        if (key != Qt::Key_Escape &&
+                key != Qt::Key_Down &&
+                key != Qt::Key_Up) {
+            keyPressEvent(keyEvent);
             return true;
         }
-        // if the line edit has focus Ctrl + F selects the text
     }
     return QComboBox::eventFilter(obj, event);
+}
+
+void WSearchLineEdit::keyPressEvent(QKeyEvent* keyEvent) {
+    const int key = keyEvent->key();
+    if (view()->isVisible()) {
+        if (key == Qt::Key_Backspace ||
+                key == Qt::Key_Delete) {
+            // remove the highlighted item from the list
+            deleteSelectedListItem();
+            return;
+        }
+    }
+
+    if (key == Qt::Key_Up) {
+        // If we're at the top of the list the Up key clears the search bar,
+        // no matter if it's a saved or unsaved query.
+        // Otherwise Up is handled by the combobox itself.
+        const int currentTextIndex = findCurrentTextIndex();
+        if (currentTextIndex == 0 ||
+                (currentTextIndex == -1 && !currentText().isEmpty())) {
+            slotClearSearch();
+            return;
+        }
+    } else if (key == Qt::Key_Down) {
+        // After clearing the text field the down key is expected to show
+        // the latest entry
+        if (currentText().isEmpty()) {
+            setCurrentIndex(0);
+            return;
+        }
+        // In case the user entered a new search query and presses the down key,
+        // save the query for later recall
+        if (findCurrentTextIndex() == -1) {
+            slotSaveSearch();
+        }
+    } else if (key == Qt::Key_Enter) {
+        if (findCurrentTextIndex() == -1) {
+            slotSaveSearch();
+        }
+        // The default handler will add the entry to the list,
+        // this already happened in slotSaveSearch
+        slotTriggerSearch();
+        return;
+    } else if (key == Qt::Key_Space &&
+            keyEvent->modifiers() == Qt::ControlModifier) {
+        // Open/close popup on ctrl + space
+        if (view()->isVisible()) {
+            hidePopup();
+        } else {
+            showPopup();
+        }
+        return;
+    } else if (key == Qt::Key_Escape) {
+        emit searchbarFocusChange(FocusWidget::TracksTable);
+        return;
+    }
+    // If the line edit has focus Ctrl + F selects the text
+    return QComboBox::keyPressEvent(keyEvent);
 }
 
 void WSearchLineEdit::focusInEvent(QFocusEvent* event) {

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -223,7 +223,7 @@ void WSearchLineEdit::setup(const QDomNode& node, const SkinContext& context) {
             tr("Shortcut") + ": \n" +
             tr("Ctrl+Backspace"));
 
-    setToolTip(tr("Search", "noun") + "\n" +
+    setBaseTooltip(tr("Search", "noun") + "\n" +
             tr("Enter a string to search for") + "\n" +
             tr("Use operators like bpm:115-128, artist:BooFar, -year:1990") +
             "\n" + tr("For more information see User Manual > Mixxx Library") +

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -324,7 +324,7 @@ QString WSearchLineEdit::getSearchText() const {
 bool WSearchLineEdit::eventFilter(QObject* obj, QEvent* event) {
     if (event->type() == QEvent::KeyPress) {
         QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
-        // if the popup is open don't intercept Up/Down keys
+        // only intercept Up/Down keys if the popup is not open!
         if (!view()->isVisible()) {
             if (keyEvent->key() == Qt::Key_Up) {
                 // if we're at the top of the list the Up key clears the search bar,
@@ -347,7 +347,7 @@ bool WSearchLineEdit::eventFilter(QObject* obj, QEvent* event) {
                     slotSaveSearch();
                 }
             }
-        } else {
+        } else { // popup is open
             if (keyEvent->key() == Qt::Key_Backspace ||
                     keyEvent->key() == Qt::Key_Delete) {
                 // remove the highlighted item from the list
@@ -355,6 +355,8 @@ bool WSearchLineEdit::eventFilter(QObject* obj, QEvent* event) {
                 return true;
             }
         }
+
+        // shortcuts applied no matter if popup is open
         if (keyEvent->key() == Qt::Key_Enter) {
             if (findCurrentTextIndex() == -1) {
                 slotSaveSearch();
@@ -371,6 +373,9 @@ bool WSearchLineEdit::eventFilter(QObject* obj, QEvent* event) {
             } else {
                 showPopup();
             }
+            return true;
+        } else if (keyEvent->key() == Qt::Key_Escape) {
+            emit searchbarFocusChange(FocusWidget::TracksTable);
             return true;
         }
         // if the line edit has focus Ctrl + F selects the text

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -345,60 +345,65 @@ bool WSearchLineEdit::eventFilter(QObject* obj, QEvent* event) {
 }
 
 void WSearchLineEdit::keyPressEvent(QKeyEvent* keyEvent) {
-    const int key = keyEvent->key();
-    if (view()->isVisible()) {
-        if (key == Qt::Key_Backspace ||
-                key == Qt::Key_Delete) {
-            // remove the highlighted item from the list
+    int currentTextIndex = 0;
+    switch (keyEvent->key()) {
+    // Ctrl + F is handled in slotSetShortcutFocus()
+    case Qt::Key_Backspace:
+    case Qt::Key_Delete:
+        // If the popup is open remove the highlighted item from the list
+        if (view()->isVisible()) {
             deleteSelectedListItem();
             return;
         }
-    }
-
-    if (key == Qt::Key_Up) {
+        break;
+    case Qt::Key_Up:
         // If we're at the top of the list the Up key clears the search bar,
         // no matter if it's a saved or unsaved query.
         // Otherwise Up is handled by the combobox itself.
-        const int currentTextIndex = findCurrentTextIndex();
+        currentTextIndex = findCurrentTextIndex();
         if (currentTextIndex == 0 ||
                 (currentTextIndex == -1 && !currentText().isEmpty())) {
             slotClearSearch();
             return;
         }
-    } else if (key == Qt::Key_Down) {
-        // After clearing the text field the down key is expected to show
-        // the latest entry
+        break;
+    case Qt::Key_Down:
+        // After clearing the text field the Down key
+        // is expected to show the latest query
         if (currentText().isEmpty()) {
             setCurrentIndex(0);
             return;
         }
-        // In case the user entered a new search query and presses the down key,
-        // save the query for later recall
+        // After entering a new search query the Down key saves the query,
+        // then selects the previous query
         if (findCurrentTextIndex() == -1) {
             slotSaveSearch();
         }
-    } else if (key == Qt::Key_Enter) {
+        break;
+    case Qt::Key_Enter:
         if (findCurrentTextIndex() == -1) {
             slotSaveSearch();
         }
-        // The default handler will add the entry to the list,
-        // this already happened in slotSaveSearch
         slotTriggerSearch();
         return;
-    } else if (key == Qt::Key_Space &&
-            keyEvent->modifiers() == Qt::ControlModifier) {
-        // Open/close popup on ctrl + space
-        if (view()->isVisible()) {
-            hidePopup();
-        } else {
-            showPopup();
+    case Qt::Key_Space:
+        // Open/close popup with Ctrl + space
+        if (keyEvent->modifiers() == Qt::ControlModifier) {
+            if (view()->isVisible()) {
+                hidePopup();
+            } else {
+                showPopup();
+            }
+            return;
         }
-        return;
-    } else if (key == Qt::Key_Escape) {
+        break;
+    case Qt::Key_Escape:
         emit searchbarFocusChange(FocusWidget::TracksTable);
         return;
+    default:
+        break;
     }
-    // If the line edit has focus Ctrl + F selects the text
+
     return QComboBox::keyPressEvent(keyEvent);
 }
 

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -38,6 +38,7 @@ class WSearchLineEdit : public QComboBox, public WBaseWidget {
     void focusOutEvent(QFocusEvent*) override;
     bool event(QEvent*) override;
     bool eventFilter(QObject* obj, QEvent* event) override;
+    void keyPressEvent(QKeyEvent* event) override;
 
   signals:
     void search(const QString& text);

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -77,13 +77,6 @@ WTrackTableView::WTrackTableView(QWidget* parent,
             &WTrackTableView::scrollValueChanged,
             this,
             &WTrackTableView::slotScrollValueChanged);
-
-    QShortcut* setFocusShortcut =
-            new QShortcut(QKeySequence(tr("ESC", "Focus")), this);
-    connect(setFocusShortcut,
-            &QShortcut::activated,
-            this,
-            QOverload<>::of(&WTrackTableView::setFocus));
 }
 
 WTrackTableView::~WTrackTableView() {


### PR DESCRIPTION
Previously, `WTrackTableView` set the global keyboard shortcut `Esc` which would always move focus to the tracks table.
Thus `Esc` closes the search bar popup BUT also immediately removes the focus from the search bar, which made me grumble too often...

This PR removes the `Esc` shortcut and uses the FocusWidget signals instead (added in #4369 ). Actually kinda straight forward, except with the search bar where I had to use a trick to not capture every `Esc` keypress. See the inline description.