### PR TITLE
lp1955314: Preserve file creation time when exporting track metadata (Windows)

### DIFF
--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -736,7 +736,7 @@ class SafelyWritableFile final {
             if (!oldFile.rename(backupFileName)) {
                 kLogger.critical()
                         << oldFile.errorString()
-                        << "- Failed to rename the original file for backup before writing:"
+                        << "- Failed to rename the original file for backup after writing:"
                         << oldFile.fileName()
                         << "->"
                         << backupFileName;


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1955314

Untested, because Windows.