### PR TITLE
pre-commit: add eslint-plugin-jsdoc

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "eslint:recommended",
+  "extends": ["eslint:recommended", "plugin:jsdoc/recommended"],
   "parserOptions": {
     "ecmaVersion": 7,
     "sourceType": "script"
@@ -7,6 +7,7 @@
   "env": {
     "es6": true
   },
+  "plugins": ["jsdoc"],
   "rules": {
     "array-bracket-spacing" : "warn",
     "block-spacing": "warn",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,6 +70,8 @@ repos:
     stages:
     - commit
     - manual
+    additional_dependencies:
+    - eslint-plugin-jsdoc@^v37.4.0
 - repo: local
   hooks:
   - id: clang-format


### PR DESCRIPTION
This allows us to enforce that the libraries we ship
come with good JSDoc comments which should improve DX
when mapping with capable code editors.