### PR TITLE
Fix writing of track metadata on Windows  

### DIFF
--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -34,6 +34,14 @@ const QString kSafelyWritableTempFileSuffix = QStringLiteral("_temp");
 // potential failures caused by exceeded path length.
 const QString kSafelyWritableOrigFileSuffix = QStringLiteral("_orig");
 
+#ifdef __WINDOWS__
+// After Mixxx has closed the track file, the indexer or virus scanner
+// might kick in and fail ReplaceFileW() with a sharing violation when
+// replacing the original file with the one with the updated metadata.
+const int kWindowsSharingViolationsRetries = 5;
+const int kWindowsSharingViolationsSleepMs = 100;
+#endif
+
 // Workaround for missing functionality in TagLib 1.11.x that
 // doesn't support to read text chunks from AIFF files.
 // See also:
@@ -708,74 +716,79 @@ class SafelyWritableFile final {
         }
         QString backupFileName = m_origFileName + kSafelyWritableOrigFileSuffix;
 #ifdef __WINDOWS__
-        if (!ReplaceFileW(
-                    reinterpret_cast<LPCWSTR>(m_origFileName.utf16()),
-                    reinterpret_cast<LPCWSTR>(m_tempFileName.utf16()),
-                    reinterpret_cast<LPCWSTR>(backupFileName.utf16()),
-                    REPLACEFILE_IGNORE_MERGE_ERRORS | REPLACEFILE_IGNORE_ACL_ERRORS,
-                    nullptr,
-                    nullptr)) {
-            DWORD error = GetLastError();
-            switch (error) {
-            case ERROR_UNABLE_TO_MOVE_REPLACEMENT:
-                // The m_tempFileName file could not be renamed. m_origFileName
-                // file and m_tempFileName file retain their original file names.
-                kLogger.critical()
-                        << "Unable to rename replacement file"
-                        << m_tempFileName
-                        << "->"
-                        << m_origFileName;
-                return false;
-            case ERROR_UNABLE_TO_MOVE_REPLACEMENT_2:
-                // The m_tempFileName file could not be moved. The m_tempFileName file still exists
-                // under its original name; however, it has inherited the file streams and
-                // attributes from the file it is replacing. The m_origFileName file still exists.
-                kLogger.critical()
-                        << "Unable to move replacement file"
-                        << m_tempFileName
-                        << "->"
-                        << m_origFileName;
-                return false;
-            case ERROR_UNABLE_TO_REMOVE_REPLACED:
-                // The replaced file could not be deleted. The replaced and replacement files
-                // retain their original file names.
-                kLogger.critical()
-                        << "Unable to remove"
-                        << m_origFileName
-                        << "before replacing by"
-                        << m_tempFileName;
-                return false;
-            case ERROR_SHARING_VIOLATION:  
-                // The process cannot access the file because it is being used by another process.
-                kLogger.critical()
-                        << "Unable to replace"
-                        << m_origFileName
-                        << "by"
-                        << m_tempFileName
-                        << "because it is used by another process";
-                return false;
-            case ERROR_ACCESS_DENIED:
-                kLogger.critical()
-                        << "Unable to replace"
-                        << m_origFileName
-                        << "by"
-                        << m_tempFileName
-                        << "Access is denied";
-                return false;
-            default:
-                // If any other error is returned, such as ERROR_INVALID_PARAMETER, the replaced
-                // and replacement files will retain their original file names. In this scenario,
-                // a backup file does not exist and it is not guaranteed that the replacement file
-                // will have inherited all of the attributes and streams of the replaced file.
-                kLogger.critical()
-                        << "Error"
-                        << error
-                        << "during replacing"
-                        << m_origFileName
-                        << "by"
-                        << m_tempFileName;
-                return false;
+        int i = 0;
+        for (; i < kWindowsSharingViolationsRetries; ++i) {
+            if (!ReplaceFileW(
+                        reinterpret_cast<LPCWSTR>(m_origFileName.utf16()),
+                        reinterpret_cast<LPCWSTR>(m_tempFileName.utf16()),
+                        reinterpret_cast<LPCWSTR>(backupFileName.utf16()),
+                        REPLACEFILE_IGNORE_MERGE_ERRORS | REPLACEFILE_IGNORE_ACL_ERRORS,
+                        nullptr,
+                        nullptr)) {
+                DWORD error = GetLastError();
+                switch (error) {
+                case ERROR_UNABLE_TO_MOVE_REPLACEMENT:
+                    // The m_tempFileName file could not be renamed. m_origFileName
+                    // file and m_tempFileName file retain their original file names.
+                    kLogger.critical()
+                            << "Unable to rename replacement file"
+                            << m_tempFileName
+                            << "->"
+                            << m_origFileName;
+                    return false;
+                case ERROR_UNABLE_TO_MOVE_REPLACEMENT_2:
+                    // The m_tempFileName file could not be moved. The m_tempFileName file still exists
+                    // under its original name; however, it has inherited the file streams and
+                    // attributes from the file it is replacing. The m_origFileName file still exists.
+                    kLogger.critical()
+                            << "Unable to move replacement file"
+                            << m_tempFileName
+                            << "->"
+                            << m_origFileName;
+                    return false;
+                case ERROR_UNABLE_TO_REMOVE_REPLACED:
+                    // The replaced file could not be deleted. The replaced and replacement files
+                    // retain their original file names.
+                    kLogger.critical()
+                            << "Unable to remove"
+                            << m_origFileName
+                            << "before replacing by"
+                            << m_tempFileName;
+                    return false;
+                case ERROR_SHARING_VIOLATION:
+                    // The process cannot access the file because it is being used by another process.
+                    kLogger.critical()
+                            << "Unable to replace"
+                            << m_origFileName
+                            << "by"
+                            << m_tempFileName
+                            << "because it is used by another process";
+                    Sleep(kWindowsSharingViolationsSleepMs); // Note: Capital S for Windows API Sleep()
+                    continue;                                // Retry
+                case ERROR_ACCESS_DENIED:
+                    kLogger.critical()
+                            << "Unable to replace"
+                            << m_origFileName
+                            << "by"
+                            << m_tempFileName
+                            << "Access is denied";
+                    return false;
+                default:
+                    // If any other error is returned, such as ERROR_INVALID_PARAMETER, the replaced
+                    // and replacement files will retain their original file names. In this scenario,
+                    // a backup file does not exist and it is not guaranteed that the replacement file
+                    // will have inherited all of the attributes and streams of the replaced file.
+                    kLogger.critical()
+                            << "Error"
+                            << error
+                            << "during replacing"
+                            << m_origFileName
+                            << "by"
+                            << m_tempFileName;
+                    return false;
+                }
             }
+            break;
         }
         QFile backupFile(backupFileName);
         if (backupFile.exists()) {
@@ -786,6 +799,10 @@ class SafelyWritableFile final {
                         << backupFile.fileName();
                 return false;
             }
+        }
+        if (i >= kWindowsSharingViolationsRetries) {
+            // We have given up after the maximum retries in the loop above.
+            return false;
         }
 #else
         QFile newFile(m_tempFileName);

--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -745,6 +745,23 @@ class SafelyWritableFile final {
                         << "before replacing by"
                         << m_tempFileName;
                 return false;
+            case ERROR_SHARING_VIOLATION:  
+                // The process cannot access the file because it is being used by another process.
+                kLogger.critical()
+                        << "Unable to replace"
+                        << m_origFileName
+                        << "by"
+                        << m_tempFileName
+                        << "because it is used by another process";
+                return false;
+            case ERROR_ACCESS_DENIED:
+                kLogger.critical()
+                        << "Unable to replace"
+                        << m_origFileName
+                        << "by"
+                        << m_tempFileName
+                        << "Access is denied";
+                return false;
             default:
                 // If any other error is returned, such as ERROR_INVALID_PARAMETER, the replaced
                 // and replacement files will retain their original file names. In this scenario,

--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -13,6 +13,10 @@
 #include <taglib/opusfile.h>
 #endif
 
+#if __WINDOWS__
+#include <Windows.h>
+#endif
+
 namespace mixxx {
 
 namespace {
@@ -702,6 +706,71 @@ class SafelyWritableFile final {
         if (m_tempFileName.isNull()) {
             return true; // nothing to do
         }
+        QString backupFileName = m_origFileName + kSafelyWritableOrigFileSuffix;
+#ifdef __WINDOWS__
+        if (!ReplaceFileW(
+                    reinterpret_cast<LPCWSTR>(m_origFileName.utf16()),
+                    reinterpret_cast<LPCWSTR>(m_tempFileName.utf16()),
+                    reinterpret_cast<LPCWSTR>(backupFileName.utf16()),
+                    REPLACEFILE_IGNORE_MERGE_ERRORS | REPLACEFILE_IGNORE_ACL_ERRORS,
+                    nullptr,
+                    nullptr)) {
+            DWORD error = GetLastError();
+            switch (error) {
+            case ERROR_UNABLE_TO_MOVE_REPLACEMENT:
+                // The m_tempFileName file could not be renamed. m_origFileName
+                // file and m_tempFileName file retain their original file names.
+                kLogger.critical()
+                        << "Unable to rename replacement file"
+                        << m_tempFileName
+                        << "->"
+                        << m_origFileName;
+                return false;
+            case ERROR_UNABLE_TO_MOVE_REPLACEMENT_2:
+                // The m_tempFileName file could not be moved. The m_tempFileName file still exists
+                // under its original name; however, it has inherited the file streams and
+                // attributes from the file it is replacing. The m_origFileName file still exists.
+                kLogger.critical()
+                        << "Unable to move replacement file"
+                        << m_tempFileName
+                        << "->"
+                        << m_origFileName;
+                return false;
+            case ERROR_UNABLE_TO_REMOVE_REPLACED:
+                // The replaced file could not be deleted. The replaced and replacement files
+                // retain their original file names.
+                kLogger.critical()
+                        << "Unable to remove"
+                        << m_origFileName
+                        << "before replacing by"
+                        << m_tempFileName;
+                return false;
+            default:
+                // If any other error is returned, such as ERROR_INVALID_PARAMETER, the replaced
+                // and replacement files will retain their original file names. In this scenario,
+                // a backup file does not exist and it is not guaranteed that the replacement file
+                // will have inherited all of the attributes and streams of the replaced file.
+                kLogger.critical()
+                        << "Error"
+                        << error
+                        << "during replacing"
+                        << m_origFileName
+                        << "by"
+                        << m_tempFileName;
+                return false;
+            }
+        }
+        QFile backupFile(backupFileName);
+        if (backupFile.exists()) {
+            if (!backupFile.remove()) {
+                kLogger.warning()
+                        << backupFile.errorString()
+                        << "- Failed to remove backup file after writing:"
+                        << backupFile.fileName();
+                return false;
+            }
+        }
+#else
         QFile newFile(m_tempFileName);
         if (!newFile.exists()) {
             kLogger.warning()
@@ -711,7 +780,6 @@ class SafelyWritableFile final {
         }
         QFile oldFile(m_origFileName);
         if (oldFile.exists()) {
-            QString backupFileName = m_origFileName + kSafelyWritableOrigFileSuffix;
             DEBUG_ASSERT(!QFile::exists(backupFileName)); // very unlikely, otherwise renaming fails
             if (!oldFile.rename(backupFileName)) {
                 kLogger.critical()
@@ -753,6 +821,7 @@ class SafelyWritableFile final {
                 return false;
             }
         }
+#endif
         // Prevent any further interaction and file access
         m_origFileName = QString();
         m_tempFileName = QString();

--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -13,7 +13,7 @@
 #include <taglib/opusfile.h>
 #endif
 
-#if __WINDOWS__
+#if defined(__WINDOWS__)
 #include <Windows.h>
 #endif
 
@@ -34,7 +34,7 @@ const QString kSafelyWritableTempFileSuffix = QStringLiteral("_temp");
 // potential failures caused by exceeded path length.
 const QString kSafelyWritableOrigFileSuffix = QStringLiteral("_orig");
 
-#ifdef __WINDOWS__
+#if defined(__WINDOWS__)
 const int kWindowsSharingViolationMaxRetries = 5;
 const int kWindowsSharingViolationSleepBeforeNextRetryMillis = 100;
 #endif

--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -1,14 +1,14 @@
 #include "sources/metadatasourcetaglib.h"
 
-#include "track/taglib/trackmetadata.h"
-
-#include "util/logger.h"
-#include "util/memory.h"
+#include <taglib/vorbisfile.h>
 
 #include <QFile>
 #include <QFileInfo>
+#include <QThread>
 
-#include <taglib/vorbisfile.h>
+#include "track/taglib/trackmetadata.h"
+#include "util/logger.h"
+#include "util/memory.h"
 #if (TAGLIB_HAS_OPUSFILE)
 #include <taglib/opusfile.h>
 #endif
@@ -763,8 +763,8 @@ class SafelyWritableFile final {
                             << "by"
                             << m_tempFileName
                             << "because it is used by another process";
-                    Sleep(kWindowsSharingViolationsSleepMs); // Note: Capital S for Windows API Sleep()
-                    continue;                                // Retry
+                    QThread::msleep(kWindowsSharingViolationsSleepMs);
+                    continue; // Retry
                 case ERROR_ACCESS_DENIED:
                     kLogger.critical()
                             << "Unable to replace"

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -362,11 +362,12 @@ SoundSourceProxy::exportTrackMetadataBeforeSaving(Track* pTrack, UserSettingsPoi
                         pAudioSource->getStreamInfo());
                 DEBUG_ASSERT(pTrack->hasStreamInfoFromSource());
                 // Make sure that the track file is closed after reading.
-                // proxy.closeAudioSource() does not work here, because
-                // proxy.m_pAuidioSource is still null because SoundSourceProxy
-                // has been created without a TrackPointer
-                DEBUG_ASSERT(!proxy.m_pAudioSource);
-                proxy.m_pSoundSource->close();
+                // Otherwise writing of track metadata into file tags
+                // might fail.
+                proxy.closeAudioSource();
+                // The SoundSource must still be available after closing
+                // the AudioSource.
+                DEBUG_ASSERT(proxy.m_pSoundSource);
             } else {
                 kLogger.warning()
                         << "Failed to update stream info from audio "
@@ -737,8 +738,11 @@ mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(
                 // before exporting metadata. In this case the caller (this class)
                 // is responsible for updating the stream info if needed.
                 if (!m_pTrack) {
-                    // TODO: It is surprising that openAudioSource returns a m_pSoundSource
-                    return m_pSoundSource;
+                    // Initialize the internal AudioSource without a valid TrackPointer
+                    // This is required to ensure that the corresponding invocation of
+                    // closeAudioSource() works as expected.
+                    m_pAudioSource = m_pSoundSource;
+                    return m_pAudioSource;
                 }
                 m_pAudioSource = mixxx::AudioSourceTrackProxy::create(m_pTrack, m_pSoundSource);
                 DEBUG_ASSERT(m_pAudioSource);

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -361,8 +361,8 @@ SoundSourceProxy::exportTrackMetadataBeforeSaving(Track* pTrack, UserSettingsPoi
                 pTrack->updateStreamInfoFromSource(
                         pAudioSource->getStreamInfo());
                 DEBUG_ASSERT(pTrack->hasStreamInfoFromSource());
-                // Make sure that the track file is closes after reading
-                // proxy.closeAudioSource(); does not work here, because
+                // Make sure that the track file is closed after reading.
+                // proxy.closeAudioSource() does not work here, because
                 // proxy.m_pAuidioSource is still null because SoundSourceProxy
                 // has been created without a TrackPointer
                 DEBUG_ASSERT(!proxy.m_pAudioSource);
@@ -737,7 +737,7 @@ mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(
                 // before exporting metadata. In this case the caller (this class)
                 // is responsible for updating the stream info if needed.
                 if (!m_pTrack) {
-                    // TODO() It is surprising to receive here a m_pSoundSource;
+                    // TODO: It is surprising that openAudioSource returns a m_pSoundSource
                     return m_pSoundSource;
                 }
                 m_pAudioSource = mixxx::AudioSourceTrackProxy::create(m_pTrack, m_pSoundSource);

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -788,7 +788,7 @@ mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(
         openMode = nextProviderWithOpenModePair.second;
         m_pProvider.reset();
         m_pSoundSource.reset();
-        initSoundSource(std::move(std::move(pNextProvider)));
+        initSoundSource(std::move(pNextProvider));
         // try again
     }
     // All available providers have returned OpenResult::Aborted when

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -361,6 +361,12 @@ SoundSourceProxy::exportTrackMetadataBeforeSaving(Track* pTrack, UserSettingsPoi
                 pTrack->updateStreamInfoFromSource(
                         pAudioSource->getStreamInfo());
                 DEBUG_ASSERT(pTrack->hasStreamInfoFromSource());
+                // Make sure that the track file is closes after reading
+                // proxy.closeAudioSource(); does not work here, because
+                // proxy.m_pAuidioSource is still null because SoundSourceProxy
+                // has been created without a TrackPointer
+                DEBUG_ASSERT(!proxy.m_pAudioSource);
+                proxy.m_pSoundSource->close();
             } else {
                 kLogger.warning()
                         << "Failed to update stream info from audio "
@@ -731,6 +737,7 @@ mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(
                 // before exporting metadata. In this case the caller (this class)
                 // is responsible for updating the stream info if needed.
                 if (!m_pTrack) {
+                    // TODO() It is surprising to receive here a m_pSoundSource;
                     return m_pSoundSource;
                 }
                 m_pAudioSource = mixxx::AudioSourceTrackProxy::create(m_pTrack, m_pSoundSource);


### PR DESCRIPTION
This fixes https://bugs.launchpad.net/mixxx/+bug/1955314 and https://bugs.launchpad.net/mixxx/+bug/1955331. 

This is a mayor bugfix that should be released soon. Because the track metadata was not exported on windows when the track has not been loaded into a deck. Since the user assumes that the metadata is written, there is a risk of data loss. This was discovered in the first attempt for a fix here: https://github.com/mixxxdj/mixxx/pull/4572 

The fix makes use of the ReplaceFileW() API function that is recommended instead of the deprecated transition feature for atomic file operations. ReplaceFileW() avoids virus scanner and indexer locking and keeps the file creation time at its old value. 

The refactoring part has been issued here https://github.com/mixxxdj/mixxx/pull/4584 for the main branch. 