### PR TITLE
Deere: add QuickEffect selector

### DIFF
--- a/res/skins/Deere/mixer.xml
+++ b/res/skins/Deere/mixer.xml
@@ -20,23 +20,74 @@
             <SizePolicy>max,me</SizePolicy>
             <Layout>vertical</Layout>
             <Children>
+
               <WidgetGroup> <!-- 2 Decks -->
-                <Layout>horizontal</Layout>
+                <Layout>vertical</Layout>
                 <Children>
-                  <Template src="skin:mixer_controls_2decks_left.xml">
-                    <SetVariable name="i">1</SetVariable>
-                  </Template>
-                  <Template src="skin:mixer_column_master_vu_2decks.xml"/>
-                  <Template src="skin:mixer_controls_2decks_right.xml">
-                    <SetVariable name="i">2</SetVariable>
-                  </Template>
+                  <WidgetGroup>
+                    <Layout>horizontal</Layout>
+                    <Children>
+                      <Template src="skin:mixer_controls_2decks_left.xml">
+                        <SetVariable name="i">1</SetVariable>
+                      </Template>
+                      <Template src="skin:mixer_column_master_vu_2decks.xml"/>
+                      <Template src="skin:mixer_controls_2decks_right.xml">
+                        <SetVariable name="i">2</SetVariable>
+                      </Template>
+                    </Children>
+                  </WidgetGroup>
+                  <WidgetGroup><!-- Quick effect selectors -->
+                    <ObjectName>QuickEffectSelectors_2Decks</ObjectName>
+                    <Layout>horizontal</Layout>
+                    <SizePolicy>min,min</SizePolicy>
+                    <Children>
+                      <WidgetGroup>
+                        <SizePolicy>i,f</SizePolicy>
+                        <MinimumSize>,18</MinimumSize>
+                        <MaximumSize>90,18</MaximumSize>
+                        <Layout>vertical</Layout>
+                        <Children>
+                          <EffectChainPresetSelector>
+                            <ObjectName>QuickEffectSelectorLeft</ObjectName>
+                            <Size>60me,18f</Size>
+                            <EffectUnitGroup>[QuickEffectRack1_[Channel1]]</EffectUnitGroup>
+                          </EffectChainPresetSelector>
+                        </Children>
+                        <Connection>
+                          <ConfigKey persist="true">[Skin],show_eq_knobs</ConfigKey>
+                          <BindProperty>visible</BindProperty>
+                        </Connection>
+                      </WidgetGroup>
+                      <!-- Spacer for a gap below MAIN VU meter -->
+                      <WidgetGroup><Size>32min,0f</Size></WidgetGroup>
+                      <WidgetGroup>
+                        <SizePolicy>i,f</SizePolicy>
+                        <MinimumSize>,18</MinimumSize>
+                        <MaximumSize>90,18</MaximumSize>
+                        <Layout>vertical</Layout>
+                        <Children>
+                          <EffectChainPresetSelector>
+                            <ObjectName>QuickEffectSelectorRight</ObjectName>
+                            <Size>60me,18f</Size>
+                            <EffectUnitGroup>[QuickEffectRack1_[Channel2]]</EffectUnitGroup>
+                          </EffectChainPresetSelector>
+                        </Children>
+                        <Connection>
+                          <ConfigKey persist="true">[Skin],show_eq_knobs</ConfigKey>
+                          <BindProperty>visible</BindProperty>
+                        </Connection>
+                      </WidgetGroup>
+                    </Children>
+                  </WidgetGroup><!-- Quick effect selectors -->
                 </Children>
                 <Connection>
                   <ConfigKey>[Skin],show_4decks</ConfigKey>
                   <BindProperty>visible</BindProperty>
                   <Transform><Not/></Transform>
                 </Connection>
-              </WidgetGroup> <!-- 2 Decks -->
+              </WidgetGroup><!-- 2 Decks -->
+
+
               <WidgetGroup> <!-- 4 Decks -->
                 <Layout>horizontal</Layout>
                 <Children>
@@ -66,6 +117,7 @@
               </WidgetGroup> <!-- 4 Decks -->
             </Children>
           </WidgetGroup><!-- DeckControls -->
+
 
           <WidgetGroup><!-- CrossfaderContainer -->
             <ObjectName>CrossfaderContainer</ObjectName>
@@ -197,7 +249,7 @@
                 </Children>
               </WidgetStack>
 
-              <WidgetStack><!-- when there is enough space for stars (min 83px) show them. -->
+              <WidgetStack><!-- when there is enough space for xFader buttons show them. -->
                 <SizePolicy>me,f</SizePolicy>
                 <MinimumSize>121,0</MinimumSize>
                 <MaximumSize>-1,0</MaximumSize>

--- a/res/skins/Deere/mixer_column_master_vu_4decks.xml
+++ b/res/skins/Deere/mixer_column_master_vu_4decks.xml
@@ -8,6 +8,7 @@
       <Template src="skin:vumeter_master.xml"/>
     </Children>
   </SingletonDefinition>
+
   <WidgetGroup>
     <ObjectName>MixerStrip_4Decks</ObjectName>
     <Layout>vertical</Layout>
@@ -35,6 +36,7 @@
           <WidgetGroup><Size>0me,25f</Size></WidgetGroup>
         </Children>
       </WidgetGroup>
+
       <!-- Same size as deck VU meters -->
       <WidgetGroup>
         <ObjectName>MixerStrip_4Decks_small</ObjectName>
@@ -52,21 +54,12 @@
           <WidgetGroup><Size>0me,34f</Size></WidgetGroup>
 
           <!-- EQ knobs spacer -->
+          <!-- 3 EQ knobs + QuickEffect knob, 34px each
+               QuickEffect selector 22px -->
           <WidgetGroup>
             <Layout>vertical</Layout>
-            <SizePolicy>me,max</SizePolicy>
-            <Children>
-              <!-- 3 EQ knobs, 34px each -->
-              <WidgetGroup><Size>0min,102f</Size></WidgetGroup>
-              <!-- QuickEffect knob, 34px optional -->
-              <WidgetGroup>
-                <Size>0min,34f</Size>
-                <Connection>
-                  <ConfigKey>[QuickEffectRack1_[Channel1]_Effect1],loaded</ConfigKey>
-                  <BindProperty>visible</BindProperty>
-                </Connection>
-              </WidgetGroup>
-            </Children>
+            <Size>0min,158f</Size>
+            <Children/>
             <Connection>
               <ConfigKey>[Skin],show_eq_knobs</ConfigKey>
               <BindProperty>visible</BindProperty>
@@ -138,7 +131,7 @@
                   <WidgetGroup>
                     <Layout>vertical</Layout>
                     <SizePolicy>min,me</SizePolicy>
-                    <MaximumSize>60,180</MaximumSize>
+                    <MaximumSize>60,193</MaximumSize>
                     <Children>
                       <SingletonContainer>
                         <ObjectName>StereoVUMeterMaster</ObjectName>

--- a/res/skins/Deere/mixer_controls_4decks_left.xml
+++ b/res/skins/Deere/mixer_controls_4decks_left.xml
@@ -107,6 +107,23 @@
 
       <WidgetGroup>
         <Layout>vertical</Layout>
+        <Size>55f,</Size>
+        <Children>
+          <EffectChainPresetSelector>
+            <ObjectName>QuickEffectSelectorLeft</ObjectName>
+            <Size>-1min,18f</Size>
+            <EffectUnitGroup>[QuickEffectRack1_<Variable name="group"/>]</EffectUnitGroup>
+          </EffectChainPresetSelector>
+          <WidgetGroup><Size>,4f</Size></WidgetGroup>
+        </Children>
+        <Connection>
+          <ConfigKey>[Skin],show_eq_knobs</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
+
+      <WidgetGroup>
+        <Layout>vertical</Layout>
         <SizePolicy>min,me</SizePolicy>
         <Children>
 

--- a/res/skins/Deere/mixer_controls_4decks_right.xml
+++ b/res/skins/Deere/mixer_controls_4decks_right.xml
@@ -107,6 +107,23 @@
 
       <WidgetGroup>
         <Layout>vertical</Layout>
+        <Size>55f,</Size>
+        <Children>
+          <EffectChainPresetSelector>
+            <ObjectName>QuickEffectSelectorRight</ObjectName>
+            <Size>-1min,18f</Size>
+            <EffectUnitGroup>[QuickEffectRack1_<Variable name="group"/>]</EffectUnitGroup>
+          </EffectChainPresetSelector>
+          <WidgetGroup><Size>,4f</Size></WidgetGroup>
+        </Children>
+        <Connection>
+          <ConfigKey>[Skin],show_eq_knobs</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
+
+      <WidgetGroup>
+        <Layout>vertical</Layout>
         <SizePolicy>min,me</SizePolicy>
         <Children>
 

--- a/res/skins/Deere/quick_effect_superknob_left.xml
+++ b/res/skins/Deere/quick_effect_superknob_left.xml
@@ -54,9 +54,5 @@
       </Template>
 
     </Children>
-    <Connection>
-      <ConfigKey><Variable name="QuickEffectEffectGroup"/>,loaded</ConfigKey>
-      <BindProperty>visible</BindProperty>
-    </Connection>
   </WidgetGroup>
 </Template>

--- a/res/skins/Deere/quick_effect_superknob_right.xml
+++ b/res/skins/Deere/quick_effect_superknob_right.xml
@@ -54,9 +54,5 @@
       </WidgetGroup>
 
     </Children>
-    <Connection>
-      <ConfigKey><Variable name="QuickEffectEffectGroup"/>,loaded</ConfigKey>
-      <BindProperty>visible</BindProperty>
-    </Connection>
   </WidgetGroup>
 </Template>

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -27,6 +27,10 @@
   background-color: #456789;  */
 }
 
+#QuickEffectSelectors_2Decks {
+  margin-top: 2px;
+}
+
 #CrossfaderContainer {
 }
 
@@ -641,6 +645,7 @@ QPushButton#pushButtonRepeatPlaylist {
 /* Scroll bars */
 #LibraryContainer QScrollBar:horizontal,
 WEffectSelector QAbstractScrollArea QScrollBar:horizontal,
+WEffectChainPresetSelector QAbstractScrollArea QScrollBar:horizontal,
 WSearchLineEdit QAbstractScrollArea QScrollBar:horizontal,
 #fadeModeCombobox QAbstractScrollArea QScrollBar:horizontal {
   border-top: 1px solid #141414;
@@ -651,6 +656,7 @@ WSearchLineEdit QAbstractScrollArea QScrollBar:horizontal,
 }
 #LibraryContainer QScrollBar:vertical,
 WEffectSelector QAbstractScrollArea QScrollBar:vertical,
+WEffectChainPresetSelector QAbstractScrollArea QScrollBar:vertical,
 WSearchLineEdit QAbstractScrollArea QScrollBar:vertical,
 #fadeModeCombobox QAbstractScrollArea QScrollBar:vertical {
   border-left: 1px solid #141414;
@@ -664,6 +670,8 @@ WSearchLineEdit QAbstractScrollArea QScrollBar:vertical,
 #LibraryContainer QScrollBar::sub-page,
 WEffectSelector QAbstractScrollArea QScrollBar::add-page,
 WEffectSelector QAbstractScrollArea QScrollBar::sub-page,
+WEffectChainPresetSelector QAbstractScrollArea QScrollBar::add-page,
+WEffectChainPresetSelector QAbstractScrollArea QScrollBar::sub-page,
 WSearchLineEdit QAbstractScrollArea QScrollBar::add-page,
 WSearchLineEdit QAbstractScrollArea QScrollBar::sub-page,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::add-page,
@@ -672,6 +680,7 @@ WSearchLineEdit QAbstractScrollArea QScrollBar::sub-page,
 }
 #LibraryContainer QScrollBar::handle:horizontal,
 WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal,
+WEffectChainPresetSelector QAbstractScrollArea QScrollBar::handle:horizontal,
 WSearchLineEdit QAbstractScrollArea QScrollBar::handle:horizontal,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::handle:horizontal {
   min-width: 25px;
@@ -681,6 +690,7 @@ WSearchLineEdit QAbstractScrollArea QScrollBar::handle:horizontal,
 }
 #LibraryContainer QScrollBar::handle:vertical,
 WEffectSelector QAbstractScrollArea QScrollBar::handle:vertical,
+WEffectChainPresetSelector QAbstractScrollArea QScrollBar::handle:vertical,
 WSearchLineEdit QAbstractScrollArea QScrollBar::handle:vertical,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::handle:vertical {
   min-height: 25px;
@@ -692,6 +702,8 @@ WSearchLineEdit QAbstractScrollArea QScrollBar::handle:vertical,
 #LibraryContainer QScrollBar::handle:vertical:hover,
 WEffectSelector QAbstractScrollArea QScrollBar::handle:horizontal:hover,
 WEffectSelector QAbstractScrollArea QScrollBar::handle:vertical:hover,
+WEffectChainPresetSelector QAbstractScrollArea QScrollBar::handle:horizontal:hover,
+WEffectChainPresetSelector QAbstractScrollArea QScrollBar::handle:vertical:hover,
 WSearchLineEdit QAbstractScrollArea QScrollBar::handle:horizontal:hover,
 WSearchLineEdit QAbstractScrollArea QScrollBar::handle:vertical:hover,
 #fadeModeCombobox QAbstractScrollArea QScrollBar::handle:horizontal:hover,
@@ -708,6 +720,10 @@ WEffectSelector QAbstractScrollArea QScrollBar::add-line:horizontal,
 WEffectSelector QAbstractScrollArea QScrollBar::add-line:vertical,
 WEffectSelector QAbstractScrollArea QScrollBar::sub-line:horizontal,
 WEffectSelector QAbstractScrollArea QScrollBar::sub-line:vertical,
+WEffectChainPresetSelector QAbstractScrollArea QScrollBar::add-line:horizontal,
+WEffectChainPresetSelector QAbstractScrollArea QScrollBar::add-line:vertical,
+WEffectChainPresetSelector QAbstractScrollArea QScrollBar::sub-line:horizontal,
+WEffectChainPresetSelector QAbstractScrollArea QScrollBar::sub-line:vertical,
 WSearchLineEdit QAbstractScrollArea QScrollBar::add-line:horizontal,
 WSearchLineEdit QAbstractScrollArea QScrollBar::add-line:vertical,
 WSearchLineEdit QAbstractScrollArea QScrollBar::sub-line:horizontal,
@@ -723,6 +739,7 @@ WSearchLineEdit QAbstractScrollArea QScrollBar::sub-line:vertical,
 /* Corner in between two scrollbars */
 #LibraryContainer QAbstractScrollArea::corner,
 WEffectSelector QAbstractScrollArea::corner,
+WEffectChainPresetSelector QAbstractScrollArea::corner,
 WSearchLineEdit QAbstractScrollArea::corner,
 #fadeModeCombobox QAbstractScrollArea::corner {
   border-top: 1px solid #141414;
@@ -834,6 +851,8 @@ WOverview /* Hotcue labels in the overview */,
 WEffectName,
 WEffectSelector,
 WEffectSelector QAbstractScrollArea,
+WEffectChainPresetSelector,
+WEffectChainPresetSelector QAbstractScrollArea,
 WSearchLineEdit,
 WSearchLineEdit QAbstractScrollArea,
 #fadeModeCombobox,
@@ -1906,11 +1925,14 @@ do not highlight either state. */
 
 
 /* common styles for WEffectSelector, QMenu, QToolTip */
-WEffectSelector QAbstractScrollArea,
-WSearchLineEdit QAbstractScrollArea,
+WEffectSelector QAbstractScrollArea {
+  min-width: 160px;
+}
+WEffectChainPresetSelector QAbstractScrollArea {
+  min-width: 140px;
+}
 #fadeModeCombobox QAbstractScrollArea {
-  font: 13px;
-  min-width: 180px;
+  min-width: 185px;
 }
 QToolTip,
 #MainMenu,
@@ -1938,6 +1960,8 @@ WCueMenuPopup,
 WCueMenuPopup QLabel,
 WEffectSelector::item:!selected,
 WEffectSelector QAbstractScrollArea,
+WEffectChainPresetSelector::item:!selected,
+WEffectChainPresetSelector QAbstractScrollArea,
 WSearchLineEdit::item:!selected,
 WSearchLineEdit QAbstractScrollArea,
 #fadeModeCombobox::item:!selected,
@@ -1955,6 +1979,7 @@ QLineEdit QMenu,
 WCueMenuPopup,
 WCoverArtMenu,
 WEffectSelector QAbstractScrollArea,
+WEffectChainPresetSelector QAbstractScrollArea,
 WSearchLineEdit QAbstractScrollArea,
 #fadeModeCombobox QAbstractScrollArea {
   border-width: 1px;
@@ -1983,6 +2008,8 @@ WSearchLineEdit QAbstractScrollArea,
   WCoverArtMenu::item:selected,
   WEffectSelector::item:selected,
   WEffectSelector::indicator:unchecked:selected,
+  WEffectChainPresetSelector::item:selected,
+  WEffectChainPresetSelector::indicator:unchecked:selected,
   WSearchLineEdit::item:selected,
   WSearchLineEdit::indicator:unchecked:selected,
   #fadeModeCombobox::item:selected,
@@ -1994,6 +2021,7 @@ WSearchLineEdit QAbstractScrollArea,
     }
     /* Remove 3D border from unchecked effects checkmark space */
     WEffectSelector::item:selected,
+    WEffectChainPresetSelector::item:selected,
     WSearchLineEdit::item:selected,
     #fadeModeCombobox::item:selected {
       border: 0px;
@@ -2036,15 +2064,24 @@ WSearchLineEdit QAbstractScrollArea,
 
 
 WEffectSelector:!editable,
+WEffectChainPresetSelector:!editable,
 #fadeModeCombobox:!editable {
   color: #c1cabe;
   /* The 3D frame on the combo box becomes flat when you give it a border */
   border: 1px solid #444342;
   border-radius: 3px;
-  font: 15px;
-}
+  }
+  WEffectSelector:!editable,
+  #fadeModeCombobox:!editable {
+    font: 15px;
+  }
+  WEffectChainPresetSelector:!editable {
+    font: 13px;
+  }
 WEffectSelector:!editable,
-WEffectSelector:!editable:on {
+WEffectSelector:!editable:on,
+WEffectChainPresetSelector:!editable,
+WEffectChainPresetSelector:!editable:on {
   /* Fixes the white bars on the top/bottom of the popup on Mac OS X */
   margin: 0px;
   /* If you use margin top/bottom 0, the combo box shrinks in width (go figure) and
@@ -2060,11 +2097,14 @@ WEffectSelector:!editable:on {
 }
 
   WEffectSelector:!editable:hover,
+  WEffectChainPresetSelector:!editable:hover,
   #fadeModeCombobox:!editable:hover {
     border: 1px ridge #015d8d;
   }
   WEffectSelector::drop-down,
+  WEffectChainPresetSelector::drop-down,
   WSearchLineEdit::drop-down,
+  WEffectChainPresetSelector::drop-down,
   #fadeModeCombobox::drop-down {
     /* This causes the Qt theme's widget style to magically not apply. Go figure. */
     border: 0;
@@ -2074,28 +2114,60 @@ WEffectSelector:!editable:on {
     width: 20px;
     height: 20px;
   }
+  WEffectChainPresetSelector::down-arrow {
+    width: 16px;
+    height: 16px;
+  }
   WEffectSelector::down-arrow,
   WSearchLineEdit::down-arrow,
+  WEffectChainPresetSelector::down-arrow,
   #fadeModeCombobox::down-arrow {
     image: url(skin:/../Deere/icon/ic_chevron_down_48px.svg);
   }
   /* currently loaded effect */
   WEffectSelector::checked,
+  WEffectChainPresetSelector::checked,
   #fadeModeCombobox::checked {
     color: #4495F4;
     font-weight: bold;
   }
   WEffectSelector::indicator:checked,
+  WEffectChainPresetSelector::indicator:checked,
   #fadeModeCombobox::indicator:checked {
     /* checkbox container is 28 x 22px;
       use margin + border to create a square checkbox sized like kill buttons */
     margin: 2px 0px 2px 5px;
   }
 
+  /* QuickEffect selector of left-hand decks and in 4-decks mixer
+    has it's down arrow on the left side, below the QuickEffect toggle */
+  WEffectChainPresetSelector#QuickEffectSelectorLeft {
+    padding: 0px -2px 0px -1px;
+    margin: 0px;
+    text-align: left;
+    }
+    WEffectChainPresetSelector#QuickEffectSelectorLeft::drop-down {
+      subcontrol-origin: margin;
+      subcontrol-position: left center;
+    }
+  WEffectChainPresetSelector#QuickEffectSelectorRight {
+    padding: 0px -1px 0px -2px;
+    margin: 0px;
+    text-align: right;
+    }
+    WEffectChainPresetSelector#QuickEffectSelectorRight::drop-down {
+      subcontrol-origin: margin;
+      subcontrol-position: right center;
+    }
+
 WEffectSelector::checked, /* selected item */
 WEffectSelector::indicator, /* checkbox, tick mark */
 WEffectSelector::drop-down,
 WEffectSelector::indicator:unchecked,
+WEffectChainPresetSelector::checked,
+WEffectChainPresetSelector::indicator,
+WEffectChainPresetSelector::drop-down,
+WEffectChainPresetSelector::indicator:unchecked,
 WSearchLineEdit::checked,
 WSearchLineEdit::indicator,
 WSearchLineEdit::drop-down,
@@ -2157,6 +2229,7 @@ WTrackMenu QMenu QCheckBox::indicator:checked {
 }
 WTrackTableViewHeader QMenu::indicator:checked,
 WEffectSelector::indicator:checked,
+WEffectChainPresetSelector::indicator:checked,
 #fadeModeCombobox::indicator:checked {
   image: url(skin:/../Deere/icon/ic_library_checkmark_blue.svg);
 }
@@ -2189,6 +2262,8 @@ WTrackTableViewHeader QMenu::indicator:unchecked,
 WTrackTableViewHeader QMenu::indicator:unchecked:selected,
 WEffectSelector::indicator:unchecked,
 WEffectSelector::indicator:unchecked:selected,
+WEffectChainPresetSelector::indicator:unchecked,
+WEffectChainPresetSelector::indicator:unchecked:selected,
 #fadeModeCombobox::indicator:unchecked,
 #fadeModeCombobox::indicator:unchecked:selected {
   image: none;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5934199/147653554-f06a9ca8-454a-405e-a2e1-68c5e4bcf40a.png)

![image](https://user-images.githubusercontent.com/5934199/147653582-56cc14ba-8bd1-462e-9c96-1f28af2cd6e6.png)

 With 4 decks the selector is quite small, but I don't really know how to fix that except expanding the entire mixer (which adds a lot of ~~white~~greyspace and results in Deere not being compatible anymore with 1024px screens. And I'm not very keen on investing more work in the complicated mixer layout)