### PR TITLE
QML: Don't use parented_ptr for model in QmlLibraryProxy

### DIFF
--- a/src/qml/qmllibraryproxy.cpp
+++ b/src/qml/qmllibraryproxy.cpp
@@ -10,7 +10,7 @@ namespace qml {
 QmlLibraryProxy::QmlLibraryProxy(std::shared_ptr<Library> pLibrary, QObject* parent)
         : QObject(parent),
           m_pLibrary(pLibrary),
-          m_pModel(make_parented<QmlLibraryTrackListModel>(m_pLibrary->trackTableModel(), this)) {
+          m_pModelProperty(new QmlLibraryTrackListModel(m_pLibrary->trackTableModel(), this)) {
 }
 
 } // namespace qml

--- a/src/qml/qmllibraryproxy.h
+++ b/src/qml/qmllibraryproxy.h
@@ -14,14 +14,16 @@ class QmlLibraryTrackListModel;
 
 class QmlLibraryProxy : public QObject {
     Q_OBJECT
-    Q_PROPERTY(mixxx::qml::QmlLibraryTrackListModel* model MEMBER m_pModel CONSTANT)
+    Q_PROPERTY(mixxx::qml::QmlLibraryTrackListModel* model MEMBER m_pModelProperty CONSTANT)
 
   public:
     explicit QmlLibraryProxy(std::shared_ptr<Library> pLibrary, QObject* parent = nullptr);
 
   private:
     std::shared_ptr<Library> m_pLibrary;
-    parented_ptr<QmlLibraryTrackListModel> m_pModel;
+
+    /// This needs to be a plain pointer because it's used as a `Q_PROPERTY` member variable.
+    QmlLibraryTrackListModel* m_pModelProperty;
 };
 
 } // namespace qml


### PR DESCRIPTION
The type needs to match the Q_PROPERTY declaration.