### PR TITLE
Controlobjectscripttest cleanup

### DIFF
--- a/src/test/controlobjectscripttest.cpp
+++ b/src/test/controlobjectscripttest.cpp
@@ -81,6 +81,14 @@ class ControlObjectScriptTest : public MixxxTest {
         coScript4->removeScriptConnection(conn4);
     }
 
+    void processEvents() {
+        // Calling processEvents() twice ensures that at least all queued and
+        // the next round of emitted events are processed.
+        // Test fails occurred here for a local debug build on Linux, but not on CI (see https://github.com/mixxxdj/mixxx/pull/4588)
+        application()->processEvents();
+        application()->processEvents();
+    }
+
     ConfigKey ck1, ck2, ck4;
     std::unique_ptr<ControlObject> co1;
     std::unique_ptr<ControlObject> co2;
@@ -102,7 +110,7 @@ TEST_F(ControlObjectScriptTest, CompressingProxyCompareCount1) {
             .Times(1)
             .WillOnce(Return());
     co1->set(1.0);
-    application()->processEvents();
+    processEvents();
 }
 
 TEST_F(ControlObjectScriptTest, CompressingProxyCompareValue1) {
@@ -111,7 +119,7 @@ TEST_F(ControlObjectScriptTest, CompressingProxyCompareValue1) {
             .WillOnce(Return());
 
     co1->set(2.0);
-    application()->processEvents();
+    processEvents();
 }
 
 TEST_F(ControlObjectScriptTest, CompressingProxyCompareCount2) {
@@ -124,7 +132,7 @@ TEST_F(ControlObjectScriptTest, CompressingProxyCompareCount2) {
             .WillOnce(Return());
     co1->set(3.0);
     co1->set(4.0);
-    application()->processEvents();
+    processEvents();
 }
 
 TEST_F(ControlObjectScriptTest, CompressingProxyCompareValue2) {
@@ -134,7 +142,7 @@ TEST_F(ControlObjectScriptTest, CompressingProxyCompareValue2) {
             .WillOnce(Return());
     co1->set(5.0);
     co1->set(6.0);
-    application()->processEvents();
+    processEvents();
 }
 
 TEST_F(ControlObjectScriptTest, QueuedCompareCount2) {
@@ -147,7 +155,7 @@ TEST_F(ControlObjectScriptTest, QueuedCompareCount2) {
             .WillOnce(Return());
     co4->set(53.0);
     co4->set(54.0);
-    application()->processEvents();
+    processEvents();
 }
 
 TEST_F(ControlObjectScriptTest, QueuedCompareValue2) {
@@ -160,7 +168,7 @@ TEST_F(ControlObjectScriptTest, QueuedCompareValue2) {
             .WillOnce(Return());
     co4->set(55.0);
     co4->set(56.0);
-    application()->processEvents();
+    processEvents();
 }
 TEST_F(ControlObjectScriptTest, CompressingProxyCompareCountMulti) {
     // Check that slotValueChanged callback for conn1 and conn2 is called only once (independent of the value)
@@ -171,7 +179,7 @@ TEST_F(ControlObjectScriptTest, CompressingProxyCompareCountMulti) {
     co2->set(11.0);
     co1->set(12.0);
     co2->set(13.0);
-    application()->processEvents();
+    processEvents();
 }
 
 TEST_F(ControlObjectScriptTest, CompressingProxyCompareValueMulti) {
@@ -186,7 +194,7 @@ TEST_F(ControlObjectScriptTest, CompressingProxyCompareValueMulti) {
     co2->set(21.0);
     co1->set(22.0);
     co2->set(23.0);
-    application()->processEvents();
+    processEvents();
 }
 
 TEST_F(ControlObjectScriptTest, CompressingProxyMultiConnection) {
@@ -203,7 +211,7 @@ TEST_F(ControlObjectScriptTest, CompressingProxyMultiConnection) {
     co2->set(31.0);
     co1->set(32.0);
     co2->set(33.0);
-    application()->processEvents();
+    processEvents();
 
     coScript2->removeScriptConnection(conn3);
 }
@@ -230,14 +238,14 @@ TEST_F(ControlObjectScriptTest, QueuedFallbackMultiConnection) {
     co2->set(61.0);
     co1->set(62.0);
     co2->set(63.0);
-    application()->processEvents();
+    processEvents();
     conn3.skipSuperseded = false;
     coScript2->addScriptConnection(conn3);
     co1->set(64.0);
     co2->set(65.0);
     co1->set(66.0);
     co2->set(67.0);
-    application()->processEvents();
+    processEvents();
 
     coScript2->removeScriptConnection(conn3);
     conn3.skipSuperseded = true;
@@ -262,10 +270,10 @@ TEST_F(ControlObjectScriptTest, CompressingProxyManyEvents) {
     co2->set(42);
 
     // Event queue should be cleared
-    application()->processEvents();
+    processEvents();
     EXPECT_CALL(*coScript1, slotValueChanged(_, _))
             .Times(0);
-    application()->processEvents();
+    processEvents();
 
     // Verify that compressing proxy works again after clearing event queue
     EXPECT_CALL(*coScript1, slotValueChanged(2, _))
@@ -273,7 +281,7 @@ TEST_F(ControlObjectScriptTest, CompressingProxyManyEvents) {
             .WillOnce(Return());
     co1->set(1);
     co1->set(2);
-    application()->processEvents();
+    processEvents();
 }
 
 } // namespace

--- a/src/test/controlobjectscripttest.cpp
+++ b/src/test/controlobjectscripttest.cpp
@@ -1,8 +1,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <QtDebug>
-
 #include "control/controlobject.h"
 #include "control/controlobjectscript.h"
 #include "test/mixxxtest.h"

--- a/src/test/controlobjectscripttest.cpp
+++ b/src/test/controlobjectscripttest.cpp
@@ -96,8 +96,7 @@ class ControlObjectScriptTest : public MixxxTest {
 TEST_F(ControlObjectScriptTest, CompressingProxyCompareCount1) {
     // Check that slotValueChanged callback is never called for conn2
     EXPECT_CALL(*coScript2, slotValueChanged(_, _))
-            .Times(0)
-            .WillOnce(Return());
+            .Times(0);
     // Check that slotValueChanged callback is called only once (independent of the value)
     EXPECT_CALL(*coScript1, slotValueChanged(_, _))
             .Times(1)
@@ -118,8 +117,7 @@ TEST_F(ControlObjectScriptTest, CompressingProxyCompareValue1) {
 TEST_F(ControlObjectScriptTest, CompressingProxyCompareCount2) {
     // Check that slotValueChanged callback is never called for conn2
     EXPECT_CALL(*coScript2, slotValueChanged(_, _))
-            .Times(0)
-            .WillOnce(Return());
+            .Times(0);
     // Check that slotValueChanged callback for conn1 is called only once (independent of the value)
     EXPECT_CALL(*coScript1, slotValueChanged(_, _))
             .Times(1)
@@ -142,8 +140,7 @@ TEST_F(ControlObjectScriptTest, CompressingProxyCompareValue2) {
 TEST_F(ControlObjectScriptTest, QueuedCompareCount2) {
     // Check that slotValueChanged callback is never called for conn4
     EXPECT_CALL(*coScript2, slotValueChanged(_, _))
-            .Times(0)
-            .WillOnce(Return());
+            .Times(0);
     // Check that slotValueChanged callback for conn1 is called only twice (independent of the value), because proxy is disabled
     EXPECT_CALL(*coScript4, slotValueChanged(_, _))
             .Times(2)
@@ -267,8 +264,7 @@ TEST_F(ControlObjectScriptTest, CompressingProxyManyEvents) {
     // Event queue should be cleared
     application()->processEvents();
     EXPECT_CALL(*coScript1, slotValueChanged(_, _))
-            .Times(0)
-            .WillOnce(Return());
+            .Times(0);
     application()->processEvents();
 
     // Verify that compressing proxy works again after clearing event queue


### PR DESCRIPTION
This PR contains two code cleanups:
- Removed unnecessary include statement
- Removed contradictory .WillOnce(Return()) conditions where the cardinality is specified as .Times(0)
  This generated a warning, which was only visible in verbose mode

And one fix:
- This fixes the fail of all tests in controlobjectscripttest.cpp on the local Linux from @ronso0 (see #4588 for details).
   The fix is copied from [controllerscriptenginelegacy_test.cpp](https://github.com/mixxxdj/mixxx/blob/c65c54abf2ac87802a21ea59b80c09189d7289c1/src/test/controllerscriptenginelegacy_test.cpp#L57-L66) where a similar issue occurred. But the comment is adapted, to what was seen with controlobjectscripttest.cpp.