### PR TITLE
Preserve complete file extension of temporary test files

### DIFF
--- a/src/test/mixxxtest.cpp
+++ b/src/test/mixxxtest.cpp
@@ -16,6 +16,8 @@ QString makeTestConfigFile(const QString& path) {
     return path;
 }
 
+const QString kTempFileWildcardPattern = QStringLiteral("XXXXXX");
+
 } // namespace
 
 // Static initialization
@@ -86,7 +88,15 @@ FileRemover::~FileRemover() {
     }
 }
 
-QString generateTemporaryFileName(const QString& fileNameTemplate) {
+QString generateTemporaryFileName(QString fileNameTemplate) {
+    if (!fileNameTemplate.contains(kTempFileWildcardPattern)) {
+        const int firstSuffixSeparatorPos = fileNameTemplate.indexOf('.');
+        if (firstSuffixSeparatorPos >= 0) {
+            // Insert the wildcard pattern before the first suffix separator
+            // to preserve the complete file extension.
+            fileNameTemplate.insert(firstSuffixSeparatorPos, kTempFileWildcardPattern);
+        }
+    }
     auto tmpFile = QTemporaryFile(fileNameTemplate);
     // The file must be opened to create it and to obtain
     // its file name!

--- a/src/test/mixxxtest.h
+++ b/src/test/mixxxtest.h
@@ -58,7 +58,10 @@ namespace mixxxtest {
 /// Returns the full, non-empty file path on success.
 ///
 /// For the format of fileNameTemplate refer to QTemporaryFile.
-QString generateTemporaryFileName(const QString& fileNameTemplate);
+/// If no wildcard pattern is provided then it will be inserted
+/// before the first suffix eparator to preserve the complete
+/// file extension.
+QString generateTemporaryFileName(QString fileNameTemplate);
 
 /// Returns the full, non-empty file path on success.
 ///


### PR DESCRIPTION
This fix could be used to simplify the creation of temporary files while preserving their original file extension. The test cases should not need to care about where to place the wildcard pattern.

I have noticed this issue before #4600 has been published.