### PR TITLE
Soundsource filetype detection fix

### DIFF
--- a/src/sources/soundsource.cpp
+++ b/src/sources/soundsource.cpp
@@ -48,7 +48,8 @@ QString SoundSource::getTypeFromFile(const QFileInfo& fileInfo) {
     const QString fileSuffix = fileInfo.suffix();
     const QString fileType = fileTypeFromSuffix(fileSuffix);
     DEBUG_ASSERT(!fileType.isEmpty() || fileType == QString{});
-    const QMimeType mimeType = QMimeDatabase().mimeTypeForFile(fileInfo);
+    const QMimeType mimeType = QMimeDatabase().mimeTypeForFile(
+            fileInfo, QMimeDatabase::MatchContent);
     // According to the documentation mimeTypeForFile always returns a valid
     // type, using the generic type application/octet-stream as a fallback.
     // This might also occur for missing files as seen on Qt 5.12.

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -740,11 +740,8 @@ TEST_F(SoundSourceProxyTest, getTypeFromFile) {
             tempDir.filePath("file_with_empty_suffix.");
     const QString filePathWithUnknownSuffix =
             tempDir.filePath("file_with.unknown_suffix");
-    // TODO: Currently, our SoundSource::getTypeFromFile() can not detect the
-    // file type of files with a known but wrong file extension properly, so
-    // this test needs to be disabled.
-    //const QString filePathWithWrongSuffix =
-    //        tempDir.filePath("file_with_wrong_suffix.wav");
+    const QString filePathWithWrongSuffix =
+            tempDir.filePath("file_with_wrong_suffix.wav");
     const QString filePathWithUppercaseAndLeadingTrailingWhitespaceSuffix =
             tempDir.filePath("file_with_uppercase_suffix. MP3 ");
 
@@ -753,7 +750,7 @@ TEST_F(SoundSourceProxyTest, getTypeFromFile) {
     mixxxtest::copyFile(validFilePath, filePathWithoutSuffix);
     mixxxtest::copyFile(validFilePath, filePathWithEmptySuffix);
     mixxxtest::copyFile(validFilePath, filePathWithUnknownSuffix);
-    //mixxxtest::copyFile(validFilePath, filePathWithWrongSuffix);
+    mixxxtest::copyFile(validFilePath, filePathWithWrongSuffix);
     mixxxtest::copyFile(validFilePath, filePathWithUppercaseAndLeadingTrailingWhitespaceSuffix);
 
     ASSERT_STREQ(qPrintable("mp3"),
@@ -769,9 +766,9 @@ TEST_F(SoundSourceProxyTest, getTypeFromFile) {
     EXPECT_STREQ(qPrintable("mp3"),
             qPrintable(mixxx::SoundSource::getTypeFromFile(
                     QFileInfo(filePathWithUnknownSuffix))));
-    //EXPECT_STREQ(qPrintable("mp3"),
-    //        qPrintable(mixxx::SoundSource::getTypeFromFile(
-    //                QFileInfo(filePathWithWrongSuffix))));
+    EXPECT_STREQ(qPrintable("mp3"),
+            qPrintable(mixxx::SoundSource::getTypeFromFile(
+                    QFileInfo(filePathWithWrongSuffix))));
     EXPECT_STREQ(qPrintable("mp3"),
             qPrintable(mixxx::SoundSource::getTypeFromFile(
                     QFileInfo(filePathWithUppercaseAndLeadingTrailingWhitespaceSuffix))));


### PR DESCRIPTION
Continuation of #4600 for the `main` branch.

### Proposed changelog entry

    - Fix file type detection when file has wrong file extension by determining the MIME type from content #4602