### PR TITLE
TrackDAO::saveTrack(): Return success/failure result

### DIFF
--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -74,7 +74,7 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
             volatile const bool* pCancel) const;
 
     // Only used by friend class TrackCollection, but public for testing!
-    void saveTrack(Track* pTrack) const;
+    bool saveTrack(Track* pTrack) const;
 
     /// Update the play counter properties according to the corresponding
     /// aggregated properties obtained from the played history.

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -532,10 +532,10 @@ bool TrackCollection::updateAutoDjCrate(
     return updateCrate(crate);
 }
 
-void TrackCollection::saveTrack(Track* pTrack) const {
+bool TrackCollection::saveTrack(Track* pTrack) const {
     DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
 
-    m_trackDao.saveTrack(pTrack);
+    return m_trackDao.saveTrack(pTrack);
 }
 
 TrackPointer TrackCollection::getTrackById(

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -163,7 +163,7 @@ class TrackCollection : public QObject,
 
     void relocateDirectory(const QString& oldDir, const QString& newDir);
 
-    void saveTrack(Track* pTrack) const;
+    bool saveTrack(Track* pTrack) const;
 
     QSqlDatabase m_database;
 

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -1,5 +1,7 @@
 #include "library/trackcollectionmanager.h"
 
+#include <utility>
+
 #include "library/externaltrackcollection.h"
 #include "library/library_prefs.h"
 #include "library/scanner/libraryscanner.h"
@@ -57,7 +59,7 @@ TrackCollectionManager::TrackCollectionManager(
     } else {
         // TODO: Add external collections
     }
-    for (const auto& externalCollection : qAsConst(m_externalCollections)) {
+    for (const auto& externalCollection : std::as_const(m_externalCollections)) {
         kLogger.info()
                 << "Connecting to"
                 << externalCollection->name();
@@ -149,7 +151,7 @@ TrackCollectionManager::~TrackCollectionManager() {
     // components are accessing those files at this point.
     GlobalTrackCacheLocker().deactivateCache();
 
-    for (const auto& externalCollection : qAsConst(m_externalCollections)) {
+    for (const auto& externalCollection : std::as_const(m_externalCollections)) {
         kLogger.info()
                 << "Disconnecting from"
                 << externalCollection->name();
@@ -234,7 +236,7 @@ TrackCollectionManager::SaveTrackResult TrackCollectionManager::saveTrack(
                     << "from"
                     << m_externalCollections.size()
                     << "external collection(s)";
-            for (const auto& externalTrackCollection : qAsConst(m_externalCollections)) {
+            for (const auto& externalTrackCollection : std::as_const(m_externalCollections)) {
                 externalTrackCollection->purgeTracks(
                         QStringList{pTrack->getLocation()});
             }
@@ -273,7 +275,7 @@ TrackCollectionManager::SaveTrackResult TrackCollectionManager::saveTrack(
                 << "in"
                 << m_externalCollections.size()
                 << "external collection(s)";
-        for (const auto& externalTrackCollection : qAsConst(m_externalCollections)) {
+        for (const auto& externalTrackCollection : std::as_const(m_externalCollections)) {
             externalTrackCollection->saveTrack(
                     *pTrack,
                     ExternalTrackCollection::ChangeHint::Modified);


### PR DESCRIPTION
A straightforward refactoring to simplify the code. Makes the control and data flow explicit instead of implicitly relying on the result of side effects.

Boolean value because it is only an internal API.