### PR TITLE
Beats deserialization: Fix misleading warning logs if no data available

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1245,6 +1245,11 @@ bool setTrackBeats(const QSqlRecord& record, const int column, Track* pTrack) {
     QString beatsVersion = record.value(column + 1).toString();
     QString beatsSubVersion = record.value(column + 2).toString();
     QByteArray beatsBlob = record.value(column + 3).toByteArray();
+    if (beatsVersion.isEmpty()) {
+        DEBUG_ASSERT(beatsSubVersion.isEmpty());
+        DEBUG_ASSERT(beatsBlob.isEmpty());
+        return false;
+    }
     bool bpmLocked = record.value(column + 4).toBool();
     const mixxx::BeatsPointer pBeats = mixxx::Beats::fromByteArray(
             pTrack->getSampleRate(), beatsVersion, beatsSubVersion, beatsBlob);

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -248,6 +248,9 @@ mixxx::BeatsPointer Beats::fromByteArray(
         const QString& beatsVersion,
         const QString& beatsSubVersion,
         const QByteArray& byteArray) {
+    VERIFY_OR_DEBUG_ASSERT(!beatsVersion.isEmpty()) {
+        return nullptr;
+    }
     mixxx::BeatsPointer pBeats = nullptr;
     if (beatsVersion == BEAT_GRID_1_VERSION || beatsVersion == BEAT_GRID_2_VERSION) {
         pBeats = fromBeatGridByteArray(sampleRate, beatsSubVersion, byteArray);


### PR DESCRIPTION
I get lots of warnings:
```
Warning [Main] Failed to deserialize Beats (""): Invalid beats version
```