### PR TITLE
lp1956819: Show log messages from "js" category on `--controller-debug`

### DIFF
--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -30,14 +30,23 @@ QFile s_logfile;
 
 QLoggingCategory::CategoryFilter oldCategoryFilter = nullptr;
 
+/// Logging category for messages logged via the JavaScript Console API.
+constexpr char jsLoggingCategory[] = "js";
+
+/// Logging category prefix for messages logged by the controller system.
+constexpr char controllerLoggingCategoryPrefix[] = "controller.";
+
 /// Filters logging categories for the `--controller-debug` command line
 /// argument, so that debug messages are enabled for all categories in the
 /// `controller` namespace, and disabled for all other categories.
 void controllerDebugCategoryFilter(QLoggingCategory* category) {
-    // Configure controller.*.input/output category here, otherwise forward to to default filter.
-    constexpr char controllerPrefix[] = "controller.";
+    // Configure `js` or `controller.*` categories here, otherwise forward to to default filter.
     const char* categoryName = category->categoryName();
-    if (qstrncmp(categoryName, controllerPrefix, sizeof(controllerPrefix) - 1) == 0) {
+    if (qstrncmp(categoryName, jsLoggingCategory, sizeof(jsLoggingCategory)) ==
+                    0 ||
+            qstrncmp(categoryName,
+                    controllerLoggingCategoryPrefix,
+                    sizeof(controllerLoggingCategoryPrefix) - 1) == 0) {
         // If the logging category name starts with `controller.`, show debug messages.
         category->setEnabled(QtDebugMsg, true);
     } else {

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -12,6 +12,7 @@
 #include <QString>
 #include <QTextStream>
 #include <QThread>
+#include <string_view>
 
 #include "util/assert.h"
 #include "util/cmdlineargs.h"
@@ -31,22 +32,23 @@ QFile s_logfile;
 QLoggingCategory::CategoryFilter oldCategoryFilter = nullptr;
 
 /// Logging category for messages logged via the JavaScript Console API.
-constexpr char jsLoggingCategory[] = "js";
+constexpr std::string_view jsLoggingCategory = {"js"};
 
 /// Logging category prefix for messages logged by the controller system.
-constexpr char controllerLoggingCategoryPrefix[] = "controller.";
+constexpr std::string_view controllerLoggingCategoryPrefix = {"controller."};
 
 /// Filters logging categories for the `--controller-debug` command line
 /// argument, so that debug messages are enabled for all categories in the
 /// `controller` namespace, and disabled for all other categories.
 void controllerDebugCategoryFilter(QLoggingCategory* category) {
     // Configure `js` or `controller.*` categories here, otherwise forward to to default filter.
-    const char* categoryName = category->categoryName();
-    if (qstrncmp(categoryName, jsLoggingCategory, sizeof(jsLoggingCategory)) ==
-                    0 ||
-            qstrncmp(categoryName,
-                    controllerLoggingCategoryPrefix,
-                    sizeof(controllerLoggingCategoryPrefix) - 1) == 0) {
+    const std::string_view categoryName{category->categoryName()};
+    // TODO: Use `categoryName.starts_with(controllerLoggingCategoryPrefix)` once we switch to C++20.
+    if (categoryName == jsLoggingCategory ||
+            categoryName.substr(0,
+                    std::min(categoryName.size(),
+                            controllerLoggingCategoryPrefix.size())) ==
+                    controllerLoggingCategoryPrefix) {
         // If the logging category name starts with `controller.`, show debug messages.
         category->setEnabled(QtDebugMsg, true);
     } else {


### PR DESCRIPTION
The JavaScript Console API uses the `js` logging category:

> The output is generated using the qCDebug, qCWarning, qCCritical
> methods in C++, with a category of "qml" or "js", depending on the
> type of file doing the logging.
>
> Source:
> https://doc.qt.io/archives/qt-5.10/qtquick-debugging.html#console-api

Hence, the `--controller-debug` command line flag needs to enable
logging output for the `js` category, too.

Fixes lp1956819: https://bugs.launchpad.net/mixxx/+bug/1956819