### PR TITLE
WBeatSpinBox/AutoDJ spinbox: Enter & Esc also move focus to library

### DIFF
--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -79,8 +79,6 @@ DlgAutoDJ::DlgAutoDJ(WLibrary* parent,
     m_pAutoDJTableModel = m_pAutoDJProcessor->getTableModel();
     m_pTrackTableView->loadTrackModel(m_pAutoDJTableModel);
 
-    // Override some playlist-view properties:
-
     // Do not set this because it disables auto-scrolling
     //m_pTrackTableView->setDragDropMode(QAbstractItemView::InternalMove);
 
@@ -163,12 +161,8 @@ DlgAutoDJ::DlgAutoDJ(WLibrary* parent,
     // work around QLineEdit being protected
     QLineEdit* lineEditTransition(spinBoxTransition->findChild<QLineEdit*>());
     lineEditTransition->setFocusPolicy(Qt::ClickFocus);
-    // Catch any Return keypress to pass focus to tracks table
-    connect(lineEditTransition,
-            &QLineEdit::returnPressed,
-            this,
-            // Move focus to tracks table to immediately allow keyboard shortcuts again.
-            &DlgAutoDJ::setFocus);
+    // Needed to catch Enter, Return and Escape keypresses
+    lineEditTransition->installEventFilter(this);
 
     connect(spinBoxTransition,
             QOverload<int>::of(&QSpinBox::valueChanged),
@@ -384,6 +378,18 @@ bool DlgAutoDJ::hasFocus() const {
 
 void DlgAutoDJ::setFocus() {
     m_pTrackTableView->setFocus();
+}
+
+void DlgAutoDJ::keyPressEvent(QKeyEvent* pEvent) {
+    // Return, Enter and Escape key move focus to the AutoDJ queue to immediately
+    // allow keyboard shortcuts again.
+    if (pEvent->key() == Qt::Key_Return ||
+            pEvent->key() == Qt::Key_Enter ||
+            pEvent->key() == Qt::Key_Escape) {
+        setFocus();
+        return;
+    }
+    return QWidget::keyPressEvent(pEvent);
 }
 
 void DlgAutoDJ::saveCurrentViewState() {

--- a/src/library/autodj/dlgautodj.h
+++ b/src/library/autodj/dlgautodj.h
@@ -59,6 +59,7 @@ class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
     void setupActionButton(QPushButton* pButton,
             void (DlgAutoDJ::*pSlot)(bool),
             const QString& fallbackText);
+    void keyPressEvent(QKeyEvent* pEvent) override;
 
     const UserSettingsPointer m_pConfig;
 

--- a/src/widget/wbeatspinbox.cpp
+++ b/src/widget/wbeatspinbox.cpp
@@ -297,12 +297,15 @@ bool WBeatSpinBox::event(QEvent* pEvent) {
 }
 
 void WBeatSpinBox::keyPressEvent(QKeyEvent* pEvent) {
-    // Return key applies current value and sends a Shift+Tab event in order
-    // to focus a library widget. In official skins this would be the tracks table.
-    if (pEvent->key() == Qt::Key_Return) {
+    // Return & Enter keys apply current value.
+    // Return, Enter and Escape send a Shift+Tab event in order to move focus
+    // to a library widget. In official skins this would be the tracks table.
+    if (pEvent->key() == Qt::Key_Return ||
+            pEvent->key() == Qt::Key_Enter ||
+            pEvent->key() == Qt::Key_Escape) {
         QDoubleSpinBox::keyPressEvent(pEvent);
-        QKeyEvent returnKeyEvent = QKeyEvent{QEvent::KeyPress, Qt::Key_Tab, Qt::ShiftModifier};
-        QApplication::sendEvent(this, &returnKeyEvent);
+        QKeyEvent shiftTabKeyEvent = QKeyEvent{QEvent::KeyPress, Qt::Key_Tab, Qt::ShiftModifier};
+        QApplication::sendEvent(this, &shiftTabKeyEvent);
         return;
     }
     return QDoubleSpinBox::keyPressEvent(pEvent);


### PR DESCRIPTION
I noticed the num block `Enter` key didn't pass the focus back to the library.
Also, `Escape` key wasn't working anymore either since #4360