### PR TITLE
Make Mixxx build with Qt6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -304,6 +304,7 @@ jobs:
         QT_QPA_PLATFORM: ${{ matrix.qt_qpa_platform }}
 
     - name: "Package"
+      if: matrix.cpack_generator != null
       run: cpack -G ${{ matrix.cpack_generator }} -V
       working-directory: build
 
@@ -315,7 +316,7 @@ jobs:
 
     - name: "Package for PPA"
       # No need to do the PPA build for both Ubuntu versions
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-20.04' && matrix.container == null
       run: |
         if [[ "${{ github.ref }}" == "refs/heads/main" ]] && [[ "${{ github.repository }}" == "mixxxdj/mixxx" ]]; then
           CPACK_ARGS="-D DEB_UPLOAD_PPA=ppa:mixxx/nightlies -D CPACK_DEBIAN_DEBIAN_VERSION=0ubuntu2"
@@ -347,7 +348,7 @@ jobs:
       # also generates metadata for file artifact and write it to the job
       # output using the artifacts_slug value.
       id: prepare_deploy
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' && matrix.artifacts_path != null
       shell: bash
       run: >
         if [[ "${GITHUB_REF}" =~ ^refs/tags/.* ]];
@@ -428,6 +429,7 @@ jobs:
         echo "C:/Windows/System32;C:/ProgramData/Chocolatey/bin" >> $GITHUB_PATH
 
     - name: "Upload GitHub Actions artifacts"
+      if: matrix.artifacts_path != null
       uses: actions/upload-artifact@v2
       with:
         name: ${{ matrix.artifacts_name }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -645,10 +645,20 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/library/autodj/autodjprocessor.cpp
   src/library/autodj/dlgautodj.cpp
   src/library/autodj/dlgautodj.ui
+  src/library/banshee/bansheedbconnection.cpp
+  src/library/banshee/bansheefeature.cpp
+  src/library/banshee/bansheeplaylistmodel.cpp
+  src/library/baseexternallibraryfeature.cpp
+  src/library/baseexternalplaylistmodel.cpp
+  src/library/baseexternaltrackmodel.cpp
   src/library/basesqltablemodel.cpp
   src/library/basetrackcache.cpp
   src/library/basetracktablemodel.cpp
   src/library/bpmdelegate.cpp
+  src/library/browse/browsefeature.cpp
+  src/library/browse/browsetablemodel.cpp
+  src/library/browse/browsethread.cpp
+  src/library/browse/foldertreemodel.cpp
   src/library/colordelegate.cpp
   src/library/columncache.cpp
   src/library/coverart.cpp
@@ -681,21 +691,31 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/library/export/trackexportdlg.cpp
   src/library/export/trackexportwizard.cpp
   src/library/export/trackexportworker.cpp
+  src/library/externaltrackcollection.cpp
+  src/library/hiddentablemodel.cpp
+  src/library/itunes/itunesfeature.cpp
   src/library/library_prefs.cpp
   src/library/library.cpp
   src/library/librarycontrol.cpp
   src/library/libraryfeature.cpp
   src/library/librarytablemodel.cpp
   src/library/locationdelegate.cpp
+  src/library/missingtablemodel.cpp
   src/library/mixxxlibraryfeature.cpp
   src/library/parser.cpp
   src/library/parsercsv.cpp
   src/library/parserm3u.cpp
   src/library/parserpls.cpp
+  src/library/playlisttablemodel.cpp
   src/library/previewbuttondelegate.cpp
   src/library/proxytrackmodel.cpp
+  src/library/recording/dlgrecording.cpp
+  src/library/recording/dlgrecording.ui
+  src/library/recording/recordingfeature.cpp
   src/library/rekordbox/rekordbox_anlz.cpp
   src/library/rekordbox/rekordbox_pdb.cpp
+  src/library/rekordbox/rekordboxfeature.cpp
+  src/library/rhythmbox/rhythmboxfeature.cpp
   src/library/scanner/importfilestask.cpp
   src/library/scanner/libraryscanner.cpp
   src/library/scanner/libraryscannerdlg.cpp
@@ -703,6 +723,8 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/library/scanner/scannertask.cpp
   src/library/searchquery.cpp
   src/library/searchqueryparser.cpp
+  src/library/serato/seratofeature.cpp
+  src/library/serato/seratoplaylistmodel.cpp
   src/library/sidebarmodel.cpp
   src/library/stardelegate.cpp
   src/library/stareditor.cpp
@@ -714,9 +736,16 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/library/trackloader.cpp
   src/library/trackmodeliterator.cpp
   src/library/trackprocessing.cpp
+  src/library/trackset/baseplaylistfeature.cpp
   src/library/trackset/basetracksetfeature.cpp
+  src/library/trackset/crate/cratefeature.cpp
+  src/library/trackset/crate/cratefeaturehelper.cpp
   src/library/trackset/crate/cratestorage.cpp
+  src/library/trackset/crate/cratetablemodel.cpp
+  src/library/trackset/playlistfeature.cpp
+  src/library/trackset/setlogfeature.cpp
   src/library/trackset/tracksettablemodel.cpp
+  src/library/traktor/traktorfeature.cpp
   src/library/treeitem.cpp
   src/library/treeitemmodel.cpp
   src/mixer/auxiliary.cpp
@@ -742,6 +771,9 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/network/jsonwebtask.cpp
   src/network/networktask.cpp
   src/network/webtask.cpp
+  src/preferences/colorpaletteeditor.cpp
+  src/preferences/colorpaletteeditormodel.cpp
+  src/preferences/colorpalettesettings.cpp
   src/preferences/configobject.cpp
   src/preferences/dialog/dlgprefautodj.cpp
   src/preferences/dialog/dlgprefautodjdlg.ui
@@ -800,6 +832,14 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/qml/qmlplayerproxy.cpp
   src/qml/qmlvisibleeffectsmodel.cpp
   src/qml/qmlwaveformoverview.cpp
+  src/skin/legacy/colorschemeparser.cpp
+  src/skin/legacy/imgcolor.cpp
+  src/skin/legacy/imginvert.cpp
+  src/skin/legacy/imgloader.cpp
+  src/skin/legacy/launchimage.cpp
+  src/skin/legacy/legacyskin.cpp
+  src/skin/legacy/legacyskinparser.cpp
+  src/skin/legacy/pixmapsource.cpp
   src/skin/legacy/skincontext.cpp
   src/skin/legacy/tooltips.cpp
   src/skin/skinloader.cpp
@@ -914,49 +954,79 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/util/workerthread.cpp
   src/util/workerthreadscheduler.cpp
   src/util/xml.cpp
+  src/waveform/visualplayposition.cpp
   src/waveform/waveform.cpp
   src/waveform/waveformfactory.cpp
+  src/widget/controlwidgetconnection.cpp
+  src/widget/hexspinbox.cpp
+  src/widget/paintable.cpp
+  src/widget/wanalysislibrarytableview.cpp
+  src/widget/wbasewidget.cpp
+  src/widget/wbattery.cpp
+  src/widget/wbeatspinbox.cpp
+  src/widget/wcolorpicker.cpp
+  src/widget/wcolorpickeraction.cpp
+  src/widget/wcombobox.cpp
+  src/widget/wcoverart.cpp
+  src/widget/wcoverartlabel.cpp
+  src/widget/wcoverartmenu.cpp
+  src/widget/wcuemenupopup.cpp
+  src/widget/wdisplay.cpp
+  src/widget/weffectbuttonparametername.cpp
+  src/widget/weffectchain.cpp
+  src/widget/weffectchainpresetbutton.cpp
+  src/widget/weffectchainpresetselector.cpp
+  src/widget/weffectknobparametername.cpp
+  src/widget/weffectname.cpp
+  src/widget/weffectparameterknob.cpp
+  src/widget/weffectparameterknobcomposed.cpp
+  src/widget/weffectparameternamebase.cpp
+  src/widget/weffectpushbutton.cpp
+  src/widget/weffectselector.cpp
+  src/widget/whotcuebutton.cpp
+  src/widget/wimagestore.cpp
+  src/widget/wkey.cpp
+  src/widget/wknob.cpp
+  src/widget/wknobcomposed.cpp
+  src/widget/wlabel.cpp
+  src/widget/wlibrary.cpp
+  src/widget/wlibrarysidebar.cpp
+  src/widget/wlibrarytableview.cpp
+  src/widget/wlibrarytextbrowser.cpp
+  src/widget/wmainmenubar.cpp
+  src/widget/wnumber.cpp
+  src/widget/wnumberdb.cpp
+  src/widget/wnumberpos.cpp
+  src/widget/wnumberrate.cpp
+  src/widget/wpixmapstore.cpp
+  src/widget/wpushbutton.cpp
+  src/widget/wraterange.cpp
+  src/widget/wrecordingduration.cpp
+  src/widget/wscrollable.cpp
+  src/widget/wsearchlineedit.cpp
+  src/widget/wsearchrelatedtracksmenu.cpp
+  src/widget/wsingletoncontainer.cpp
+  src/widget/wsizeawarestack.cpp
+  src/widget/wskincolor.cpp
+  src/widget/wslidercomposed.cpp
+  src/widget/wsplitter.cpp
+  src/widget/wstarrating.cpp
+  src/widget/wstatuslight.cpp
+  src/widget/wtime.cpp
+  src/widget/wtrackmenu.cpp
+  src/widget/wtrackproperty.cpp
+  src/widget/wtracktableview.cpp
+  src/widget/wtracktableviewheader.cpp
+  src/widget/wtracktext.cpp
+  src/widget/wtrackwidgetgroup.cpp
+  src/widget/wvumeter.cpp
+  src/widget/wwidget.cpp
+  src/widget/wwidgetgroup.cpp
+  src/widget/wwidgetstack.cpp
 )
 if(NOT QT6)
   target_sources(mixxx-lib PRIVATE
-    src/library/banshee/bansheedbconnection.cpp
-    src/library/banshee/bansheefeature.cpp
-    src/library/banshee/bansheeplaylistmodel.cpp
-    src/library/browse/browsefeature.cpp
-    src/library/browse/browsetablemodel.cpp
-    src/library/browse/browsethread.cpp
-    src/library/browse/foldertreemodel.cpp
-    src/library/baseexternallibraryfeature.cpp
-    src/library/baseexternalplaylistmodel.cpp
-    src/library/baseexternaltrackmodel.cpp
-    src/library/externaltrackcollection.cpp
-    src/library/hiddentablemodel.cpp
-    src/library/itunes/itunesfeature.cpp
-    src/library/missingtablemodel.cpp
-    src/library/playlisttablemodel.cpp
-    src/library/recording/dlgrecording.cpp
-    src/library/recording/dlgrecording.ui
-    src/library/recording/recordingfeature.cpp
-    src/library/rekordbox/rekordboxfeature.cpp
-    src/library/rhythmbox/rhythmboxfeature.cpp
-    src/library/serato/seratofeature.cpp
-    src/library/serato/seratoplaylistmodel.cpp
-    src/library/trackset/baseplaylistfeature.cpp
-    src/library/trackset/crate/cratefeature.cpp
-    src/library/trackset/crate/cratefeaturehelper.cpp
-    src/library/trackset/crate/cratetablemodel.cpp
-    src/library/trackset/playlistfeature.cpp
-    src/library/trackset/setlogfeature.cpp
-    src/library/traktor/traktorfeature.cpp
     src/mixxxmainwindow.cpp
-    src/skin/legacy/colorschemeparser.cpp
-    src/skin/legacy/imgcolor.cpp
-    src/skin/legacy/imginvert.cpp
-    src/skin/legacy/imgloader.cpp
-    src/skin/legacy/launchimage.cpp
-    src/skin/legacy/legacyskinparser.cpp
-    src/skin/legacy/pixmapsource.cpp
-    src/skin/legacy/legacyskin.cpp
     src/waveform/guitick.cpp
     src/waveform/renderers/glslwaveformrenderersignal.cpp
     src/waveform/renderers/glvsynctestrenderer.cpp
@@ -983,7 +1053,6 @@ if(NOT QT6)
     src/waveform/renderers/waveformsignalcolors.cpp
     src/waveform/renderers/waveformwidgetrenderer.cpp
     src/waveform/sharedglcontext.cpp
-    src/waveform/visualplayposition.cpp
     src/waveform/visualsmanager.cpp
     src/waveform/vsyncthread.cpp
     src/waveform/waveformmarklabel.cpp
@@ -1003,78 +1072,12 @@ if(NOT QT6)
     src/waveform/widgets/rgbwaveformwidget.cpp
     src/waveform/widgets/softwarewaveformwidget.cpp
     src/waveform/widgets/waveformwidgetabstract.cpp
-    src/widget/controlwidgetconnection.cpp
-    src/widget/hexspinbox.cpp
-    src/widget/paintable.cpp
-    src/widget/wanalysislibrarytableview.cpp
-    src/widget/wbasewidget.cpp
-    src/widget/wbattery.cpp
-    src/widget/wbeatspinbox.cpp
-    src/widget/wcolorpicker.cpp
-    src/widget/wcolorpickeraction.cpp
-    src/widget/wcombobox.cpp
-    src/widget/wcoverart.cpp
-    src/widget/wcoverartlabel.cpp
-    src/widget/wcoverartmenu.cpp
-    src/widget/wcuemenupopup.cpp
-    src/widget/wdisplay.cpp
-    src/widget/weffectbuttonparametername.cpp
-    src/widget/weffectchain.cpp
-    src/widget/weffectchainpresetbutton.cpp
-    src/widget/weffectchainpresetselector.cpp
-    src/widget/weffectknobparametername.cpp
-    src/widget/weffectname.cpp
-    src/widget/weffectparameterknob.cpp
-    src/widget/weffectparameterknobcomposed.cpp
-    src/widget/weffectparameternamebase.cpp
-    src/widget/weffectpushbutton.cpp
-    src/widget/weffectselector.cpp
-    src/widget/whotcuebutton.cpp
-    src/widget/wimagestore.cpp
-    src/widget/wkey.cpp
-    src/widget/wknob.cpp
-    src/widget/wknobcomposed.cpp
-    src/widget/wlabel.cpp
-    src/widget/wlibrary.cpp
-    src/widget/wlibrarysidebar.cpp
-    src/widget/wlibrarytableview.cpp
-    src/widget/wlibrarytextbrowser.cpp
-    src/widget/wmainmenubar.cpp
-    src/widget/wnumber.cpp
-    src/widget/wnumberdb.cpp
-    src/widget/wnumberpos.cpp
-    src/widget/wnumberrate.cpp
     src/widget/woverview.cpp
     src/widget/woverviewhsv.cpp
     src/widget/woverviewlmh.cpp
     src/widget/woverviewrgb.cpp
-    src/widget/wpixmapstore.cpp
-    src/widget/wpushbutton.cpp
-    src/widget/wrecordingduration.cpp
-    src/widget/wscrollable.cpp
-    src/widget/wsearchlineedit.cpp
-    src/widget/wsearchrelatedtracksmenu.cpp
-    src/widget/wsingletoncontainer.cpp
-    src/widget/wsizeawarestack.cpp
-    src/widget/wskincolor.cpp
-    src/widget/wslidercomposed.cpp
     src/widget/wspinny.cpp
-    src/widget/wsplitter.cpp
-    src/widget/wstarrating.cpp
-    src/widget/wstatuslight.cpp
-    src/widget/wtime.cpp
-    src/widget/wtrackmenu.cpp
-    src/widget/wtrackproperty.cpp
-    src/widget/wtracktableview.cpp
-    src/widget/wtracktableviewheader.cpp
-    src/widget/wtracktext.cpp
-    src/widget/wtrackwidgetgroup.cpp
-    src/widget/wvumeter.cpp
     src/widget/wwaveformviewer.cpp
-    src/widget/wwidget.cpp
-    src/widget/wwidgetgroup.cpp
-    src/widget/wwidgetstack.cpp
-    src/widget/wraterange.cpp
   )
 endif()
 set_target_properties(mixxx-lib PROPERTIES AUTOMOC ON AUTOUIC ON CXX_CLANG_TIDY "${CLANG_TIDY}")

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -36,7 +36,9 @@
 #include "util/sample.h"
 #include "util/timer.h"
 #include "waveform/visualplayposition.h"
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include "waveform/waveformwidgetfactory.h"
+#endif
 
 #ifdef __VINYLCONTROL__
 #include "engine/controls/vinylcontrolcontrol.h"

--- a/src/library/banshee/bansheeplaylistmodel.cpp
+++ b/src/library/banshee/bansheeplaylistmodel.cpp
@@ -151,7 +151,7 @@ void BansheePlaylistModel::setTableModel(int playlistId) {
                 query.bindValue(":" CLM_GROUPING, entry.pTrack->grouping);
                 query.bindValue(":" CLM_TRACKNUMBER, entry.pTrack->tracknumber);
                 QDateTime timeAdded;
-                timeAdded.setTime_t(entry.pTrack->dateadded);
+                timeAdded.setSecsSinceEpoch(entry.pTrack->dateadded);
                 query.bindValue(":" CLM_DATEADDED, timeAdded.toString(Qt::ISODate));
                 query.bindValue(":" CLM_BPM, entry.pTrack->bpm);
                 query.bindValue(":" CLM_BITRATE, entry.pTrack->bitrate);

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -212,7 +212,11 @@ void ITunesFeature::activate(bool forceReload) {
         }
         m_isActivated =  true;
         // Let a worker thread do the XML parsing
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        m_future = QtConcurrent::run(&ITunesFeature::importLibrary, this);
+#else
         m_future = QtConcurrent::run(this, &ITunesFeature::importLibrary);
+#endif
         m_future_watcher.setFuture(m_future);
         m_title = tr("(loading) iTunes");
         // calls a slot in the sidebar model such that 'iTunes (isLoading)' is displayed.

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -404,7 +404,7 @@ TreeItem* ITunesFeature::importLibrary() {
     while (!xml.atEnd() && !m_cancelImport) {
         xml.readNext();
         if (xml.isStartElement()) {
-            if (xml.name() == "key") {
+            if (xml.name() == QLatin1String("key")) {
                 QString key = xml.readElementText();
                 if (key == "Music Folder") {
                     if (isTracksParsed) {
@@ -673,7 +673,7 @@ TreeItem* ITunesFeature::parsePlaylists(QXmlStreamReader& xml) {
             continue;
         }
         if (xml.isEndElement()) {
-            if (xml.name() == "array") {
+            if (xml.name() == QLatin1String("array")) {
                 break;
             }
         }
@@ -790,7 +790,7 @@ void ITunesFeature::parsePlaylist(QXmlStreamReader& xml, QSqlQuery& query_insert
             }
         }
         if (xml.isEndElement()) {
-            if (xml.name() == "array") {
+            if (xml.name() == QLatin1String("array")) {
                 //qDebug() << "exit playlist";
                 break;
             }

--- a/src/library/rhythmbox/rhythmboxfeature.cpp
+++ b/src/library/rhythmbox/rhythmboxfeature.cpp
@@ -179,7 +179,7 @@ TreeItem* RhythmboxFeature::importMusicCollection() {
     QXmlStreamReader xml(&db);
     while (!xml.atEnd() && !m_cancelImport) {
         xml.readNext();
-        if (xml.isStartElement() && xml.name() == "entry") {
+        if (xml.isStartElement() && xml.name() == QLatin1String("entry")) {
             QXmlStreamAttributes attr = xml.attributes();
             //Check if we really parse a track and not album art information
             if (attr.value("type").toString() == "song") {
@@ -230,7 +230,7 @@ TreeItem* RhythmboxFeature::importPlaylists() {
     QXmlStreamReader xml(&db);
     while (!xml.atEnd() && !m_cancelImport) {
         xml.readNext();
-        if (xml.isStartElement() && xml.name() == "playlist") {
+        if (xml.isStartElement() && xml.name() == QLatin1String("playlist")) {
             QXmlStreamAttributes attr = xml.attributes();
 
             //Only parse non built-in playlists
@@ -289,49 +289,49 @@ void RhythmboxFeature::importTrack(QXmlStreamReader &xml, QSqlQuery &query) {
     while (!xml.atEnd()) {
         xml.readNext();
         if (xml.isStartElement()) {
-            if (xml.name() == "title") {
+            if (xml.name() == QLatin1String("title")) {
                 title = xml.readElementText();
                 continue;
             }
-            if (xml.name() == "artist") {
+            if (xml.name() == QLatin1String("artist")) {
                 artist = xml.readElementText();
                 continue;
             }
-            if (xml.name() == "genre") {
+            if (xml.name() == QLatin1String("genre")) {
                 genre = xml.readElementText();
                 continue;
             }
-            if (xml.name() == "album") {
+            if (xml.name() == QLatin1String("album")) {
                 album = xml.readElementText();
                 continue;
             }
-            if (xml.name() == "track-number") {
+            if (xml.name() == QLatin1String("track-number")) {
                 tracknumber = xml.readElementText();
                 continue;
             }
-            if (xml.name() == "duration") {
+            if (xml.name() == QLatin1String("duration")) {
                 playtime = xml.readElementText().toInt();;
                 continue;
             }
-            if (xml.name() == "bitrate") {
+            if (xml.name() == QLatin1String("bitrate")) {
                 bitrate = xml.readElementText().toInt();
                 continue;
             }
-            if (xml.name() == "beats-per-minute") {
+            if (xml.name() == QLatin1String("beats-per-minute")) {
                 bpm = xml.readElementText().toInt();
                 continue;
             }
-            if (xml.name() == "comment") {
+            if (xml.name() == QLatin1String("comment")) {
                 comment = xml.readElementText();
                 continue;
             }
-            if (xml.name() == "location") {
+            if (xml.name() == QLatin1String("location")) {
                 locationUrl = QUrl(xml.readElementText());
                 continue;
             }
         }
         //exit the loop if we reach the closing <entry> tag
-        if (xml.isEndElement() && xml.name() == "entry") {
+        if (xml.isEndElement() && xml.name() == QLatin1String("entry")) {
             break;
         }
     }
@@ -375,7 +375,7 @@ void RhythmboxFeature::importPlaylist(QXmlStreamReader &xml,
     while (!xml.atEnd()) {
         //read next XML element
         xml.readNext();
-        if (xml.isStartElement() && xml.name() == "location") {
+        if (xml.isStartElement() && xml.name() == QLatin1String("location")) {
             const auto fileInfo = mixxx::FileInfo::fromQUrl(xml.readElementText());
 
             //get the ID of the file in the rhythmbox_library table
@@ -409,7 +409,7 @@ void RhythmboxFeature::importPlaylist(QXmlStreamReader &xml,
             }
         }
         // Exit the the loop if we reach the closing <playlist> tag
-        if (xml.isEndElement() && xml.name() == "playlist") {
+        if (xml.isEndElement() && xml.name() == QLatin1String("playlist")) {
             break;
         }
     }

--- a/src/library/rhythmbox/rhythmboxfeature.cpp
+++ b/src/library/rhythmbox/rhythmboxfeature.cpp
@@ -117,7 +117,11 @@ void RhythmboxFeature::activate() {
 
     if (!m_isActivated) {
         m_isActivated =  true;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        m_track_future = QtConcurrent::run(&RhythmboxFeature::importMusicCollection, this);
+#else
         m_track_future = QtConcurrent::run(this, &RhythmboxFeature::importMusicCollection);
+#endif
         m_track_watcher.setFuture(m_track_future);
         m_title = "(loading) Rhythmbox";
         //calls a slot in the sidebar model such that 'Rhythmbox (isLoading)' is displayed.

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -435,9 +435,10 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
 
                     parent->appendChild(name, current_path);
                     // process all the entries within the playlist 'name' having path 'current_path'
-                    parsePlaylistEntries(xml, current_path,
-                                         query_insert_to_playlists,
-                                         query_insert_to_playlist_tracks);
+                    parsePlaylistEntries(xml,
+                            current_path,
+                            std::move(query_insert_to_playlists),
+                            std::move(query_insert_to_playlist_tracks));
                 }
             }
         }

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -231,18 +231,19 @@ TreeItem* TraktorFeature::importLibrary(const QString& file) {
     while (!xml.atEnd() && !m_cancelImport) {
         xml.readNext();
         if (xml.isStartElement()) {
-            if (xml.name() == "COLLECTION") {
+            if (xml.name() == QLatin1String("COLLECTION")) {
                 inCollectionTag = true;
             }
             // Each "ENTRY" tag in <COLLECTION> represents a track
-            if (inCollectionTag && xml.name() == "ENTRY") {
+            if (inCollectionTag && xml.name() == QLatin1String("ENTRY")) {
                 //parse track
                 parseTrack(xml, query);
                 ++nAudioFiles; //increment number of files in the music collection
             }
-            if (xml.name() == "PLAYLISTS") {
+            if (xml.name() == QLatin1String("PLAYLISTS")) {
                 inPlaylistsTag = true;
-            } if (inPlaylistsTag && !isRootFolderParsed && xml.name() == "NODE") {
+            }
+            if (inPlaylistsTag && !isRootFolderParsed && xml.name() == QLatin1String("NODE")) {
                 QXmlStreamAttributes attr = xml.attributes();
                 QString nodetype = attr.value("TYPE").toString();
                 QString name = attr.value("NAME").toString();
@@ -255,10 +256,10 @@ TreeItem* TraktorFeature::importLibrary(const QString& file) {
             }
         }
         if (xml.isEndElement()) {
-            if (xml.name() == "COLLECTION") {
+            if (xml.name() == QLatin1String("COLLECTION")) {
                 inCollectionTag = false;
             }
-            if (xml.name() == "PLAYLISTS" && inPlaylistsTag) {
+            if (xml.name() == QLatin1String("PLAYLISTS") && inPlaylistsTag) {
                 inPlaylistsTag = false;
             }
         }
@@ -308,13 +309,13 @@ void TraktorFeature::parseTrack(QXmlStreamReader &xml, QSqlQuery &query) {
     while (!xml.atEnd()) {
         xml.readNext();
         if (xml.isStartElement()) {
-            if (xml.name() == "ALBUM") {
+            if (xml.name() == QLatin1String("ALBUM")) {
                 QXmlStreamAttributes attr = xml.attributes ();
                 album = attr.value("TITLE").toString();
                 tracknumber = attr.value("TRACK").toString();
                 continue;
             }
-            if (xml.name() == "LOCATION") {
+            if (xml.name() == QLatin1String("LOCATION")) {
                 QXmlStreamAttributes attr = xml.attributes ();
                 volume = attr.value("VOLUME").toString();
                 path = attr.value("DIR").toString();
@@ -332,7 +333,7 @@ void TraktorFeature::parseTrack(QXmlStreamReader &xml, QSqlQuery &query) {
                 location += filename;
                 continue;
             }
-            if (xml.name() == "INFO") {
+            if (xml.name() == QLatin1String("INFO")) {
                 QXmlStreamAttributes attr = xml.attributes();
                 key = attr.value("KEY").toString();
                 bitrate = attr.value("BITRATE").toString().toInt() / 1000;
@@ -354,14 +355,14 @@ void TraktorFeature::parseTrack(QXmlStreamReader &xml, QSqlQuery &query) {
                 }
                 continue;
             }
-            if (xml.name() == "TEMPO") {
+            if (xml.name() == QLatin1String("TEMPO")) {
                 QXmlStreamAttributes attr = xml.attributes ();
                 bpm = attr.value("BPM").toString().toFloat();
                 continue;
             }
         }
         //We leave the infinite loop, if twe have the closing tag "ENTRY"
-        if (xml.name() == "ENTRY" && xml.isEndElement()) {
+        if (xml.name() == QLatin1String("ENTRY") && xml.isEndElement()) {
             break;
         }
     }
@@ -421,7 +422,7 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
         xml.readNext();
 
         if (xml.isStartElement()) {
-            if (xml.name() == "NODE") {
+            if (xml.name() == QLatin1String("NODE")) {
                 QXmlStreamAttributes attr = xml.attributes();
                 QString name = attr.value("NAME").toString();
                 QString type = attr.value("TYPE").toString();
@@ -450,7 +451,7 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
         }
 
         if (xml.isEndElement()) {
-            if (xml.name() == "NODE") {
+            if (xml.name() == QLatin1String("NODE")) {
                 if (map.value(current_path) == "FOLDER") {
                     parent = parent->parent();
                 }
@@ -462,7 +463,7 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
                 current_path.remove(lastSlash, path_length - lastSlash);
             }
             //We leave the infinite loop, if twe have the closing "PLAYLIST" tag
-            if (xml.name() == "PLAYLISTS") {
+            if (xml.name() == QLatin1String("PLAYLISTS")) {
                 break;
             }
         }
@@ -509,7 +510,7 @@ void TraktorFeature::parsePlaylistEntries(
         //read next XML element
         xml.readNext();
         if (xml.isStartElement()) {
-            if (xml.name() == "PRIMARYKEY") {
+            if (xml.name() == QLatin1String("PRIMARYKEY")) {
                 QXmlStreamAttributes attr = xml.attributes();
                 QString key = attr.value("KEY").toString();
                 QString type = attr.value("TYPE").toString();
@@ -547,7 +548,7 @@ void TraktorFeature::parsePlaylistEntries(
         }
         if (xml.isEndElement()) {
             //We leave the infinite loop, if twe have the closing "PLAYLIST" tag
-            if (xml.name() == "PLAYLIST") {
+            if (xml.name() == QLatin1String("PLAYLIST")) {
                 break;
             }
         }

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -159,8 +159,14 @@ void TraktorFeature::activate() {
     if (!m_isActivated) {
         m_isActivated =  true;
         // Let a worker thread do the XML parsing
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        m_future = QtConcurrent::run(&TraktorFeature::importLibrary,
+                this,
+                getTraktorMusicDatabase());
+#else
         m_future = QtConcurrent::run(this, &TraktorFeature::importLibrary,
                                      getTraktorMusicDatabase());
+#endif
         m_future_watcher.setFuture(m_future);
         m_title = tr("(loading) Traktor");
         //calls a slot in the sidebar model such that 'iTunes (isLoading)' is displayed.

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -17,8 +17,10 @@
 #include "track/track.h"
 #include "util/sandbox.h"
 #include "vinylcontrol/defs_vinylcontrol.h"
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveform/visualsmanager.h"
+#endif
 
 namespace {
 
@@ -693,8 +695,13 @@ void BaseTrackPlayerImpl::slotVinylControlEnabled(double v) {
 }
 
 void BaseTrackPlayerImpl::slotWaveformZoomValueChangeRequest(double v) {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     if (v <= WaveformWidgetRenderer::s_waveformMaxZoom
             && v >= WaveformWidgetRenderer::s_waveformMinZoom) {
+#else
+    // TODO: Re-enable zoom range check or decouple zoom from engine code
+    {
+#endif
         m_pWaveformZoom->setAndConfirm(v);
     }
 }
@@ -720,8 +727,13 @@ void BaseTrackPlayerImpl::slotWaveformZoomSetDefault(double pressed) {
         return;
     }
 
-    double defaultZoom = m_pConfig->getValue(ConfigKey("[Waveform]","DefaultZoom"),
-        WaveformWidgetRenderer::s_waveformDefaultZoom);
+    double defaultZoom = m_pConfig->getValue(ConfigKey("[Waveform]", "DefaultZoom"),
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+            WaveformWidgetRenderer::s_waveformDefaultZoom);
+#else
+            // TODO: This should not be hardcoded.
+            3.0);
+#endif
     m_pWaveformZoom->set(defaultZoom);
 }
 

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -26,7 +26,9 @@
 #include "preferences/dialog/dlgprefeffects.h"
 #include "preferences/dialog/dlgprefeq.h"
 #include "preferences/dialog/dlgprefinterface.h"
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include "preferences/dialog/dlgprefwaveform.h"
+#endif
 
 #ifdef __BROADCAST__
 #include "preferences/dialog/dlgprefbroadcast.h"
@@ -140,6 +142,7 @@ DlgPreferences::DlgPreferences(
             tr("Interface"),
             "ic_preferences_interface.svg");
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     // ugly proxy for determining whether this is being instantiated for QML or legacy QWidgets GUI
     if (pSkinLoader) {
         DlgPrefWaveform* pWaveformPage = new DlgPrefWaveform(this, m_pConfig, pLibrary);
@@ -154,6 +157,7 @@ DlgPreferences::DlgPreferences(
                 &DlgPreferences::reloadUserInterface,
                 Qt::DirectConnection);
     }
+#endif
 
     addPageWidget(PreferencesPage(
                           new DlgPrefColors(this, m_pConfig, pLibrary),

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -28,7 +28,9 @@
 #include "util/timer.h"
 #include "util/valuetransformer.h"
 #include "util/xml.h"
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include "waveform/vsyncthread.h"
+#endif
 #include "waveform/waveformwidgetfactory.h"
 #include "widget/controlwidgetconnection.h"
 #include "widget/wbasewidget.h"
@@ -71,7 +73,9 @@
 #include "widget/wsizeawarestack.h"
 #include "widget/wskincolor.h"
 #include "widget/wslidercomposed.h"
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include "widget/wspinny.h"
+#endif
 #include "widget/wsplitter.h"
 #include "widget/wstarrating.h"
 #include "widget/wstatuslight.h"
@@ -528,7 +532,9 @@ QList<QWidget*> LegacySkinParser::parseNode(const QDomElement& node) {
         result = wrapWidget(parseStarRating(node));
     } else if (nodeName == "VuMeter") {
         WVuMeter* pVuMeterWidget = parseStandardWidget<WVuMeter>(node);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
         WaveformWidgetFactory::instance()->addTimerListener(pVuMeterWidget);
+#endif
         result = wrapWidget(pVuMeterWidget);
     } else if (nodeName == "StatusLight") {
         result = wrapWidget(parseStandardWidget<WStatusLight>(node));
@@ -940,6 +946,11 @@ void LegacySkinParser::setupLabelWidget(const QDomElement& element, WLabel* pLab
 }
 
 QWidget* LegacySkinParser::parseOverview(const QDomElement& node) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    Q_UNUSED(node);
+
+    return nullptr;
+#else
     QString group = lookupNodeGroup(node);
     BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
     if (!pPlayer) {
@@ -981,9 +992,15 @@ QWidget* LegacySkinParser::parseOverview(const QDomElement& node) {
     overviewWidget->slotTrackLoaded(pPlayer->getLoadedTrack());
 
     return overviewWidget;
+#endif
 }
 
 QWidget* LegacySkinParser::parseVisual(const QDomElement& node) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    Q_UNUSED(node);
+
+    return nullptr;
+#else
     QString group = lookupNodeGroup(node);
     BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
     if (!pPlayer) {
@@ -1025,6 +1042,7 @@ QWidget* LegacySkinParser::parseVisual(const QDomElement& node) {
     viewer->slotTrackLoaded(pPlayer->getLoadedTrack());
 
     return viewer;
+#endif
 }
 
 QWidget* LegacySkinParser::parseText(const QDomElement& node) {
@@ -1251,6 +1269,11 @@ QWidget* LegacySkinParser::parseRecordingDuration(const QDomElement& node) {
 }
 
 QWidget* LegacySkinParser::parseSpinny(const QDomElement& node) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    Q_UNUSED(node);
+
+    return nullptr;
+#else
     if (CmdlineArgs::Instance().getSafeMode()) {
         WLabel* dummy = new WLabel(m_pParent);
         //: Shown when Mixxx is running in safe mode.
@@ -1298,6 +1321,7 @@ QWidget* LegacySkinParser::parseSpinny(const QDomElement& node) {
     spinny->installEventFilter(m_pControllerManager->getControllerLearningEventFilter());
     spinny->Init();
     return spinny;
+#endif
 }
 
 QWidget* LegacySkinParser::parseSearchBox(const QDomElement& node) {

--- a/src/test/wpushbutton_test.cpp
+++ b/src/test/wpushbutton_test.cpp
@@ -47,7 +47,8 @@ TEST_F(WPushButtonTest, QuickPressNoLatchTest) {
     // This test can be flaky if the event simulator takes too long to deliver
     // the event.
     m_Events.addMousePress(Qt::LeftButton);
-    m_Events.addMouseRelease(Qt::LeftButton, Qt::NoModifier, QPoint(), 1);
+    m_Events.addDelay(100);
+    m_Events.addMouseRelease(Qt::LeftButton);
 
     m_Events.simulate(m_pButton.data());
 
@@ -70,7 +71,8 @@ TEST_F(WPushButtonTest, LongPressLatchTest) {
             ControlParameterWidgetConnection::EMIT_ON_PRESS_AND_RELEASE));
 
     m_Events.addMousePress(Qt::LeftButton);
-    m_Events.addMouseRelease(Qt::LeftButton, Qt::NoModifier, QPoint(), 1000);
+    m_Events.addDelay(1000);
+    m_Events.addMouseRelease(Qt::LeftButton);
 
     m_Events.simulate(m_pButton.data());
 

--- a/src/waveform/visualplayposition.cpp
+++ b/src/waveform/visualplayposition.cpp
@@ -6,7 +6,9 @@
 #include "control/controlproxy.h"
 #include "moc_visualplayposition.cpp"
 #include "util/math.h"
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include "waveform/vsyncthread.h"
+#endif
 
 namespace {
 // The offset is limited to two callback intervals.
@@ -58,7 +60,12 @@ double VisualPlayPosition::getAtNextVSync(VSyncThread* vSyncThread) {
 
     if (m_valid) {
         VisualPlayPositionData data = m_data.getValue();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        Q_UNUSED(vSyncThread);
+        int refToVSync = 0;
+#else
         int refToVSync = vSyncThread->fromTimerToNextSyncMicros(data.m_referenceTime);
+#endif
         int offset = refToVSync - data.m_callbackEntrytoDac;
         offset = math_min(offset, m_audioBufferMicros * kMaxOffsetBufferCnt);
         double playPos = data.m_enginePlayPos;  // load playPos for the first sample in Buffer
@@ -78,7 +85,12 @@ void VisualPlayPosition::getPlaySlipAtNextVSync(VSyncThread* vSyncThread, double
 
     if (m_valid) {
         VisualPlayPositionData data = m_data.getValue();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        Q_UNUSED(vSyncThread);
+        int refToVSync = 0;
+#else
         int refToVSync = vSyncThread->fromTimerToNextSyncMicros(data.m_referenceTime);
+#endif
         int offset = refToVSync - data.m_callbackEntrytoDac;
         offset = math_min(offset, m_audioBufferMicros * kMaxOffsetBufferCnt);
         double playPos = data.m_enginePlayPos;  // load playPos for the first sample in Buffer

--- a/src/waveform/visualplayposition.h
+++ b/src/waveform/visualplayposition.h
@@ -8,7 +8,11 @@
 #include "control/controlvalue.h"
 
 class ControlProxy;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+typedef void VSyncThread;
+#else
 class VSyncThread;
+#endif
 
 // This class is for synchronizing the sound device DAC time with the waveforms, displayed on the
 // graphic device, using the CPU time

--- a/src/widget/controlwidgetconnection.cpp
+++ b/src/widget/controlwidgetconnection.cpp
@@ -143,12 +143,20 @@ QString ControlWidgetPropertyConnection::toDebugString() const {
 void ControlWidgetPropertyConnection::slotControlValueChanged(double v) {
     const double parameter = getControlParameterForValue(v);
     QVariant vParameter;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    if (m_property.metaType().id() == QMetaType::Bool) {
+#else
     if (m_property.type() == QVariant::Bool) {
+#endif
         vParameter = (parameter > 0);
     } else {
         vParameter = parameter;
     }
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    bool success = vParameter.convert(m_property.metaType());
+#else
     bool success = vParameter.convert(m_property.type());
+#endif
     VERIFY_OR_DEBUG_ASSERT(success) {
         return;
     }

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -241,11 +241,7 @@ void WCoverArt::contextMenuEvent(QContextMenuEvent* event) {
     event->accept();
     if (m_loadedTrack) {
         m_pMenu->setCoverArt(m_lastRequestedCover);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-        m_pMenu->popup(event->globalPosition().toPoint());
-#else
         m_pMenu->popup(event->globalPos());
-#endif
     }
 }
 

--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -76,11 +76,7 @@ void WCoverArtLabel::slotCoverMenu(const QPoint& pos) {
 
 void WCoverArtLabel::contextMenuEvent(QContextMenuEvent* event) {
     event->accept();
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    m_pCoverMenu->popup(event->globalPosition().toPoint());
-#else
     m_pCoverMenu->popup(event->globalPos());
-#endif
 }
 
 void WCoverArtLabel::loadTrack(TrackPointer pTrack) {

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -61,7 +61,11 @@ void WLibrarySidebar::dragEnterEvent(QDragEnterEvent * event) {
 void WLibrarySidebar::dragMoveEvent(QDragMoveEvent * event) {
     //qDebug() << "dragMoveEvent" << event->mimeData()->formats();
     // Start a timer to auto-expand sections the user hovers on.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QPoint pos = event->position().toPoint();
+#else
     QPoint pos = event->pos();
+#endif
     QModelIndex index = indexAt(pos);
     if (m_hoverIndex != index) {
         m_expandTimer.stop();
@@ -84,7 +88,12 @@ void WLibrarySidebar::dragMoveEvent(QDragMoveEvent * event) {
             if (sidebarModel) {
                 accepted = false;
                 for (const QUrl& url : urls) {
-                    QModelIndex destIndex = indexAt(event->pos());
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                    QPoint pos = event->position().toPoint();
+#else
+                    QPoint pos = event->pos();
+#endif
+                    QModelIndex destIndex = indexAt(pos);
                     if (sidebarModel->dragMoveAccept(destIndex, url)) {
                         // We only need one URL to be valid for us
                         // to accept the whole drag...
@@ -138,7 +147,13 @@ void WLibrarySidebar::dropEvent(QDropEvent * event) {
             //eg. dragging a track from Windows Explorer onto the sidebar
             SidebarModel* sidebarModel = qobject_cast<SidebarModel*>(model());
             if (sidebarModel) {
-                QModelIndex destIndex = indexAt(event->pos());
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                QPoint pos = event->position().toPoint();
+#else
+                QPoint pos = event->pos();
+#endif
+
+                QModelIndex destIndex = indexAt(pos);
                 // event->source() will return NULL if something is dropped from
                 // a different application
                 const QList<QUrl> urls = event->mimeData()->urls();

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -82,8 +82,13 @@ void WSliderComposed::setup(const QDomNode& node, const SkinContext& context) {
             int comma = margins.indexOf(",");
             bool m1ok;
             bool m2ok;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            double m1 = (margins.left(comma)).toDouble(&m1ok);
+            double m2 = (margins.mid(comma + 1)).toDouble(&m2ok);
+#else
             double m1 = (margins.leftRef(comma)).toDouble(&m1ok);
             double m2 = (margins.midRef(comma + 1)).toDouble(&m2ok);
+#endif
             if (m1ok && m2ok) {
                 m_dBarStart = m1 * scaleFactor;
                 m_dBarEnd = m2 * scaleFactor;
@@ -107,8 +112,13 @@ void WSliderComposed::setup(const QDomNode& node, const SkinContext& context) {
                 int comma = bgMargins.indexOf(",");
                 bool m1ok;
                 bool m2ok;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                double m1 = (bgMargins.left(comma)).toDouble(&m1ok);
+                double m2 = (bgMargins.mid(comma + 1)).toDouble(&m2ok);
+#else
                 double m1 = (bgMargins.leftRef(comma)).toDouble(&m1ok);
                 double m2 = (bgMargins.midRef(comma + 1)).toDouble(&m2ok);
+#endif
                 if (m1ok && m2ok) {
                     m_dBarBgStart = m1 * scaleFactor;
                     m_dBarBgEnd = m2 * scaleFactor;

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -106,7 +106,7 @@ void WStarRating::mouseMoveEvent(QMouseEvent *event) {
 
     m_focused = true;
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    int star = starAtPosition(event->position().x());
+    int star = starAtPosition(event->position().toPoint().x());
 #else
     int star = starAtPosition(event->x());
 #endif

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -115,10 +115,6 @@ void WTrackProperty::contextMenuEvent(QContextMenuEvent* event) {
     if (m_pCurrentTrack) {
         m_pTrackMenu->loadTrack(m_pCurrentTrack, m_group);
         // Create the right-click menu
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-        m_pTrackMenu->popup(event->globalPosition().toPoint());
-#else
         m_pTrackMenu->popup(event->globalPos());
-#endif
     }
 }

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -609,9 +609,14 @@ void WTrackTableView::dropEvent(QDropEvent * event) {
     // (the "drop" position in a drag-and-drop)
     // The user usually drops on the seam between two rows.
     // We take the row below the seam for reference.
-    int dropRow = rowAt(event->pos().y());
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QPoint position = event->position().toPoint();
+#else
+    QPoint position = event->pos();
+#endif
+    int dropRow = rowAt(position.y());
     int height = rowHeight(dropRow);
-    QPoint pointOfRowBelowSeam(event->pos().x(), event->pos().y() + height / 2);
+    QPoint pointOfRowBelowSeam(position.x(), position.y() + height / 2);
     QModelIndex destIndex = indexAt(pointOfRowBelowSeam);
 
     //qDebug() << "destIndex.row() is" << destIndex.row();

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -472,11 +472,7 @@ void WTrackTableView::contextMenuEvent(QContextMenuEvent* event) {
     m_pTrackMenu->loadTrackModelIndices(indices);
 
     //Create the right-click menu
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    m_pTrackMenu->popup(event->globalPosition().toPoint());
-#else
     m_pTrackMenu->popup(event->globalPos());
-#endif
 }
 
 void WTrackTableView::onSearch(const QString& text) {

--- a/src/widget/wtracktableviewheader.cpp
+++ b/src/widget/wtracktableviewheader.cpp
@@ -103,11 +103,7 @@ WTrackTableViewHeader::WTrackTableViewHeader(Qt::Orientation orientation,
 }
 
 void WTrackTableViewHeader::contextMenuEvent(QContextMenuEvent* event) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    m_menu.popup(event->globalPosition().toPoint());
-#else
     m_menu.popup(event->globalPos());
-#endif
 }
 
 void WTrackTableViewHeader::setModel(QAbstractItemModel* model) {

--- a/src/widget/wtracktext.cpp
+++ b/src/widget/wtracktext.cpp
@@ -101,10 +101,6 @@ void WTrackText::contextMenuEvent(QContextMenuEvent* event) {
     if (m_pCurrentTrack) {
         m_pTrackMenu->loadTrack(m_pCurrentTrack, m_group);
         // Create the right-click menu
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-        m_pTrackMenu->popup(event->globalPosition().toPoint());
-#else
         m_pTrackMenu->popup(event->globalPos());
-#endif
     }
 }

--- a/src/widget/wtrackwidgetgroup.cpp
+++ b/src/widget/wtrackwidgetgroup.cpp
@@ -124,10 +124,6 @@ void WTrackWidgetGroup::contextMenuEvent(QContextMenuEvent* event) {
     if (m_pCurrentTrack) {
         m_pTrackMenu->loadTrack(m_pCurrentTrack, m_group);
         // Create the right-click menu
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-        m_pTrackMenu->popup(event->globalPosition().toPoint());
-#else
         m_pTrackMenu->popup(event->globalPos());
-#endif
     }
 }

--- a/src/widget/wwidget.cpp
+++ b/src/widget/wwidget.cpp
@@ -46,8 +46,12 @@ bool WWidget::event(QEvent* e) {
         case QEvent::TouchEnd:
         {
             QTouchEvent* touchEvent = dynamic_cast<QTouchEvent*>(e);
-            if (touchEvent == nullptr || touchEvent->device() == nullptr ||
-                    touchEvent->device()->type() !=  QTouchDevice::TouchScreen) {
+            if (touchEvent == nullptr
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+                    || touchEvent->device() == nullptr ||
+                    touchEvent->device()->type() != QTouchDevice::TouchScreen
+#endif
+            ) {
                 break;
             }
 
@@ -75,7 +79,12 @@ bool WWidget::event(QEvent* e) {
             }
 
             const QTouchEvent::TouchPoint& touchPoint =
-                    touchEvent->touchPoints().first();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                    touchEvent->points()
+#else
+                    touchEvent->touchPoints()
+#endif
+                            .first();
             QMouseEvent mouseEvent(eventType,
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
                     touchPoint.position(),

--- a/src/widget/wwidget.cpp
+++ b/src/widget/wwidget.cpp
@@ -77,9 +77,15 @@ bool WWidget::event(QEvent* e) {
             const QTouchEvent::TouchPoint& touchPoint =
                     touchEvent->touchPoints().first();
             QMouseEvent mouseEvent(eventType,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                    touchPoint.position(),
+                    touchPoint.position(),
+                    touchPoint.globalPosition(),
+#else
                     touchPoint.pos(),
                     touchPoint.pos(),
                     touchPoint.screenPos(),
+#endif
                     m_activeTouchButton, // Button that causes the event
                     Qt::NoButton,        // Not used, so no need to fake a proper value.
                     touchEvent->modifiers(),


### PR DESCRIPTION
Makes it possible to build Mixxx with Qt6 without any compiler warnings or linker errors. Based on:
- #4620
- #4622 
- #4623

Next step is to fix the QML UI, because there are quite some incompatibilities apparently. 