### PR TITLE
Serato markers size serialization fixes

### DIFF
--- a/src/track/serato/markers.cpp
+++ b/src/track/serato/markers.cpp
@@ -569,7 +569,7 @@ QByteArray SeratoMarkers::dumpID3() const {
 
     QDataStream stream(&data, QIODevice::WriteOnly);
     stream.setByteOrder(QDataStream::BigEndian);
-    stream << kVersion << m_entries.size();
+    stream << kVersion << static_cast<quint32>(m_entries.size());
     for (int i = 0; i < m_entries.size(); i++) {
         SeratoMarkersEntryPointer pEntry = m_entries.at(i);
         stream.writeRawData(pEntry->dumpID3(), kEntrySizeID3);
@@ -593,7 +593,7 @@ QByteArray SeratoMarkers::dumpMP4() const {
     stream.setByteOrder(QDataStream::BigEndian);
     stream.writeRawData(kSeratoMarkersBase64EncodedPrefix.constData(),
             kSeratoMarkersBase64EncodedPrefix.length());
-    stream << kVersion << m_entries.size();
+    stream << kVersion << static_cast<quint32>(m_entries.size());
     for (int i = 0; i < m_entries.size(); i++) {
         SeratoMarkersEntryPointer pEntry = m_entries.at(i);
         stream.writeRawData(pEntry->dumpMP4(), kEntrySizeMP4);

--- a/src/track/serato/markers2.cpp
+++ b/src/track/serato/markers2.cpp
@@ -537,7 +537,7 @@ QByteArray SeratoMarkers2::dumpCommon() const {
         QByteArray entryData = entry->dump();
         stream.writeRawData(entryName.constData(), entryName.length());
         stream << static_cast<quint8>('\x00') // terminating null-byte
-               << entryData.length();
+               << static_cast<quint32>(entryData.length());
         stream.writeRawData(entryData.constData(), entryData.length());
     }
     data.append('\0');
@@ -767,7 +767,7 @@ QByteArray SeratoMarkers2::dumpBase64Encoded() const {
         QByteArray entryData = entry->dump();
         stream.writeRawData(entryName.constData(), entryName.length());
         stream << static_cast<quint8>(0x00) // terminating null-byte
-               << entryData.length();
+               << static_cast<quint32>(entryData.length());
         stream.writeRawData(entryData.constData(), entryData.length());
     }
     innerData.append('\0');

--- a/src/track/serato/markers2.cpp
+++ b/src/track/serato/markers2.cpp
@@ -26,7 +26,9 @@ QString zeroTerminatedUtf8StringtoQString(QDataStream* stream) {
     quint8 byte = '\xFF';
     while (byte != '\x00') {
         *stream >> byte;
-        data.append(byte);
+        if (byte != '\x00') {
+            data.append(byte);
+        }
         if (stream->status() != QDataStream::Status::Ok) {
             return QString();
         }


### PR DESCRIPTION
This makes some sizes explicit and prevents unintended format changes when the return values of the Qt API change.