### PR TITLE
ControllerScriptEngineLegacy: Only remove FS watcher paths if not empty

### DIFF
--- a/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
@@ -90,6 +90,15 @@ QJSValue ControllerScriptEngineLegacy::wrapFunctionCode(
     return wrappedFunction;
 }
 
+void ControllerScriptEngineLegacy::setScriptFiles(
+        const QList<LegacyControllerMapping::ScriptFileInfo>& scripts) {
+    const QStringList paths = m_fileWatcher.files();
+    if (!paths.isEmpty()) {
+        m_fileWatcher.removePaths(paths);
+    }
+    m_scriptFiles = scripts;
+}
+
 bool ControllerScriptEngineLegacy::initialize() {
     if (!ControllerScriptEngineBase::initialize()) {
         return false;

--- a/src/controllers/scripting/legacy/controllerscriptenginelegacy.h
+++ b/src/controllers/scripting/legacy/controllerscriptenginelegacy.h
@@ -27,10 +27,7 @@ class ControllerScriptEngineLegacy : public ControllerScriptEngineBase {
     QJSValue wrapFunctionCode(const QString& codeSnippet, int numberOfArgs);
 
   public slots:
-    void setScriptFiles(const QList<LegacyControllerMapping::ScriptFileInfo>& scripts) {
-        m_fileWatcher.removePaths(m_fileWatcher.files());
-        m_scriptFiles = scripts;
-    }
+    void setScriptFiles(const QList<LegacyControllerMapping::ScriptFileInfo>& scripts);
 
   private:
     bool evaluateScriptFile(const QFileInfo& scriptFile);


### PR DESCRIPTION
Fixes this warning:

    warning [0x56043d58fd00] QFileSystemWatcher::removePaths: list is empty