### PR TITLE
ControllerScriptInterfaceLegacy: Do not modify QHash while iterating over it

### DIFF
--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
@@ -42,10 +42,9 @@ ControllerScriptInterfaceLegacy::ControllerScriptInterfaceLegacy(
 
 ControllerScriptInterfaceLegacy::~ControllerScriptInterfaceLegacy() {
     // Stop all timers
-    QMutableHashIterator<int, TimerInfo> i(m_timers);
-    while (i.hasNext()) {
-        i.next();
-        stopTimer(i.key());
+    const auto timerIds = m_timers.keys();
+    for (const int timerId : timerIds) {
+        stopTimer(timerId);
     }
 
     // Prevents leaving decks in an unstable state


### PR DESCRIPTION
Modifing `m_timers` via `ControllerScriptInterfaceLegacy::stopTimer()`
invalidates all iterators for `m_timers`. The old code only worked by
chance and triggers an assertion with Qt6.