### PR TITLE
Log re-import of track metadata from file tags with time stamps

### DIFF
--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -547,20 +547,20 @@ inline bool shouldImportSeratoTagsFromSource(
 
 } // namespace
 
-bool SoundSourceProxy::updateTrackFromSource(
+SoundSourceProxy::UpdateTrackFromSourceResult SoundSourceProxy::updateTrackFromSource(
         UpdateTrackFromSourceMode mode,
         const SyncTrackMetadataParams& syncParams) {
     DEBUG_ASSERT(m_pTrack);
 
     if (getUrl().isEmpty()) {
         // Silently skip tracks without a corresponding file
-        return false; // abort
+        return UpdateTrackFromSourceResult::NotUpdated;
     }
     if (!m_pSoundSource) {
         kLogger.warning()
                 << "Unable to update track from unsupported file type"
                 << getUrl().toString();
-        return false; // abort
+        return UpdateTrackFromSourceResult::NotUpdated;
     }
 
     // The SoundSource provides the actual type of the corresponding file
@@ -629,7 +629,7 @@ bool SoundSourceProxy::updateTrackFromSource(
             // warning message already identifies the track that is affected.
             kLogger.critical() << "Aborting update of track metadata from source "
                                   "due to unexpected inconsistencies during recovery";
-            return false;
+            return UpdateTrackFromSourceResult::MetadataImportFailed;
         }
     }
 
@@ -640,10 +640,14 @@ bool SoundSourceProxy::updateTrackFromSource(
         // in the database.
         DEBUG_ASSERT(!pCoverImg);
         if (metadataImportedFromSource.first == mixxx::MetadataSource::ImportResult::Succeeded) {
-            return m_pTrack->mergeExtraMetadataFromSource(trackMetadata);
+            if (m_pTrack->mergeExtraMetadataFromSource(trackMetadata)) {
+                return UpdateTrackFromSourceResult::ExtraMetadataImportedAndMerged;
+            } else {
+                return UpdateTrackFromSourceResult::NotUpdated;
+            }
         } else {
             // Nothing to do if no metadata has been imported
-            return false;
+            return UpdateTrackFromSourceResult::NotUpdated;
         }
     }
 
@@ -722,7 +726,7 @@ bool SoundSourceProxy::updateTrackFromSource(
 
     // Do not continue with unknown and maybe invalid metadata!
     if (metadataImportedFromSource.first != mixxx::MetadataSource::ImportResult::Succeeded) {
-        return false;
+        return UpdateTrackFromSourceResult::MetadataImportFailed;
     }
 
     m_pTrack->replaceMetadataFromSource(
@@ -762,7 +766,7 @@ bool SoundSourceProxy::updateTrackFromSource(
         m_pTrack->setCoverInfo(coverInfo);
     }
 
-    return true;
+    return UpdateTrackFromSourceResult::MetadataImportedAndUpdated;
 }
 
 bool SoundSourceProxy::openSoundSource(

--- a/src/sources/soundsourceproxy.h
+++ b/src/sources/soundsourceproxy.h
@@ -128,6 +128,13 @@ class SoundSourceProxy {
         Always,
     };
 
+    enum class UpdateTrackFromSourceResult {
+        NotUpdated,
+        MetadataImportFailed,
+        MetadataImportedAndUpdated,
+        ExtraMetadataImportedAndMerged,
+    };
+
     /// Updates file type, metadata, and cover image of the track object
     /// from the source file according to the given mode.
     ///
@@ -150,7 +157,7 @@ class SoundSourceProxy {
     /// analysis in case unexpected behavior has been reported.
     ///
     /// Returns true if the track has been modified and false otherwise.
-    bool updateTrackFromSource(
+    UpdateTrackFromSourceResult updateTrackFromSource(
             UpdateTrackFromSourceMode mode,
             const SyncTrackMetadataParams& syncParams);
 

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -171,9 +171,11 @@ class AutoDJProcessorTest : public LibraryTest {
     TrackPointer newTestTrack(TrackId trackId) const {
         TrackPointer pTrack(
                 Track::newDummy(kTrackLocationTest, trackId));
-        EXPECT_TRUE(SoundSourceProxy(pTrack).updateTrackFromSource(
-                SoundSourceProxy::UpdateTrackFromSourceMode::Once,
-                SyncTrackMetadataParams{}));
+        EXPECT_EQ(
+                SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated,
+                SoundSourceProxy(pTrack).updateTrackFromSource(
+                        SoundSourceProxy::UpdateTrackFromSourceMode::Once,
+                        SyncTrackMetadataParams{}));
         return pTrack;
     }
 

--- a/src/test/coverartutils_test.cpp
+++ b/src/test/coverartutils_test.cpp
@@ -114,9 +114,11 @@ TEST_F(CoverArtUtilTest, searchImage) {
 
     // Looking for a track with embedded cover.
     pTrack = Track::newTemporary(kTrackLocationTest);
-    EXPECT_TRUE(SoundSourceProxy(pTrack).updateTrackFromSource(
-            SoundSourceProxy::UpdateTrackFromSourceMode::Once,
-            SyncTrackMetadataParams{}));
+    EXPECT_EQ(
+            SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated,
+            SoundSourceProxy(pTrack).updateTrackFromSource(
+                    SoundSourceProxy::UpdateTrackFromSourceMode::Once,
+                    SyncTrackMetadataParams{}));
     CoverInfo result = pTrack->getCoverInfoWithLocation();
     EXPECT_EQ(result.type, CoverInfo::METADATA);
     EXPECT_EQ(result.source, CoverInfo::GUESSED);

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -221,9 +221,11 @@ TEST_F(SoundSourceProxyTest, openEmptyFile) {
 TEST_F(SoundSourceProxyTest, readArtist) {
     auto pTrack = Track::newTemporary(kTestDir, "artist.mp3");
     SoundSourceProxy proxy(pTrack);
-    EXPECT_TRUE(proxy.updateTrackFromSource(
-            SoundSourceProxy::UpdateTrackFromSourceMode::Once,
-            SyncTrackMetadataParams{}));
+    EXPECT_EQ(
+            SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated,
+            proxy.updateTrackFromSource(
+                    SoundSourceProxy::UpdateTrackFromSourceMode::Once,
+                    SyncTrackMetadataParams{}));
     EXPECT_EQ("Test Artist", pTrack->getArtist());
 }
 
@@ -234,41 +236,51 @@ TEST_F(SoundSourceProxyTest, readNoTitle) {
     auto pTrack1 = Track::newTemporary(
             kTestDir, "empty.mp3");
     SoundSourceProxy proxy1(pTrack1);
-    EXPECT_TRUE(proxy1.updateTrackFromSource(
-            SoundSourceProxy::UpdateTrackFromSourceMode::Once,
-            SyncTrackMetadataParams{}));
+    EXPECT_EQ(
+            SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated,
+            proxy1.updateTrackFromSource(
+                    SoundSourceProxy::UpdateTrackFromSourceMode::Once,
+                    SyncTrackMetadataParams{}));
     EXPECT_EQ("empty", pTrack1->getTitle());
 
     // Test a reload also works
     pTrack1->setTitle("");
-    EXPECT_TRUE(proxy1.updateTrackFromSource(
-            SoundSourceProxy::UpdateTrackFromSourceMode::Always,
-            SyncTrackMetadataParams{}));
+    EXPECT_EQ(
+            SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated,
+            proxy1.updateTrackFromSource(
+                    SoundSourceProxy::UpdateTrackFromSourceMode::Always,
+                    SyncTrackMetadataParams{}));
     EXPECT_EQ("empty", pTrack1->getTitle());
 
     // Test a file with other metadata but no title
     auto pTrack2 = Track::newTemporary(
             kTestDir, "cover-test-png.mp3");
     SoundSourceProxy proxy2(pTrack2);
-    EXPECT_TRUE(proxy2.updateTrackFromSource(
-            SoundSourceProxy::UpdateTrackFromSourceMode::Once,
-            SyncTrackMetadataParams{}));
+    EXPECT_EQ(
+            SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated,
+            proxy2.updateTrackFromSource(
+                    SoundSourceProxy::UpdateTrackFromSourceMode::Once,
+                    SyncTrackMetadataParams{}));
     EXPECT_EQ("cover-test-png", pTrack2->getTitle());
 
     // Test a reload also works
     pTrack2->setTitle("");
-    EXPECT_TRUE(proxy2.updateTrackFromSource(
-            SoundSourceProxy::UpdateTrackFromSourceMode::Always,
-            SyncTrackMetadataParams{}));
+    EXPECT_EQ(
+            SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated,
+            proxy2.updateTrackFromSource(
+                    SoundSourceProxy::UpdateTrackFromSourceMode::Always,
+                    SyncTrackMetadataParams{}));
     EXPECT_EQ("cover-test-png", pTrack2->getTitle());
 
     // Test a file with a title
     auto pTrack3 = Track::newTemporary(
             kTestDir, "cover-test-jpg.mp3");
     SoundSourceProxy proxy3(pTrack3);
-    EXPECT_TRUE(proxy3.updateTrackFromSource(
-            SoundSourceProxy::UpdateTrackFromSourceMode::Once,
-            SyncTrackMetadataParams{}));
+    EXPECT_EQ(
+            SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated,
+            proxy3.updateTrackFromSource(
+                    SoundSourceProxy::UpdateTrackFromSourceMode::Once,
+                    SyncTrackMetadataParams{}));
     EXPECT_EQ("test22kMono", pTrack3->getTitle());
 }
 

--- a/src/test/trackupdate_test.cpp
+++ b/src/test/trackupdate_test.cpp
@@ -29,9 +29,11 @@ class TrackUpdateTest : public MixxxTest, SoundSourceProviderRegistration {
 
     TrackPointer newTestTrackParsed() const {
         auto pTrack = newTestTrack();
-        EXPECT_TRUE(SoundSourceProxy(pTrack).updateTrackFromSource(
-                SoundSourceProxy::UpdateTrackFromSourceMode::Once,
-                SyncTrackMetadataParams{}));
+        EXPECT_EQ(
+                SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated,
+                SoundSourceProxy(pTrack).updateTrackFromSource(
+                        SoundSourceProxy::UpdateTrackFromSourceMode::Once,
+                        SyncTrackMetadataParams{}));
         EXPECT_TRUE(pTrack->checkSourceSynchronized());
         EXPECT_TRUE(hasTrackMetadata(pTrack));
         EXPECT_TRUE(hasCoverArt(pTrack));
@@ -61,9 +63,11 @@ TEST_F(TrackUpdateTest, parseModifiedCleanOnce) {
     const auto coverInfoBefore = pTrack->getCoverInfo();
 
     // Re-update from source should have no effect
-    ASSERT_FALSE(SoundSourceProxy(pTrack).updateTrackFromSource(
-            SoundSourceProxy::UpdateTrackFromSourceMode::Once,
-            SyncTrackMetadataParams{}));
+    ASSERT_EQ(
+            SoundSourceProxy::UpdateTrackFromSourceResult::NotUpdated,
+            SoundSourceProxy(pTrack).updateTrackFromSource(
+                    SoundSourceProxy::UpdateTrackFromSourceMode::Once,
+                    SyncTrackMetadataParams{}));
 
     const auto trackMetadataAfter = pTrack->getMetadata();
     const auto coverInfoAfter = pTrack->getCoverInfo();
@@ -82,9 +86,11 @@ TEST_F(TrackUpdateTest, parseModifiedCleanAgainSkipCover) {
     const auto trackMetadataBefore = pTrack->getMetadata();
     const auto coverInfoBefore = pTrack->getCoverInfo();
 
-    EXPECT_TRUE(SoundSourceProxy(pTrack).updateTrackFromSource(
-            SoundSourceProxy::UpdateTrackFromSourceMode::Always,
-            SyncTrackMetadataParams{}));
+    EXPECT_EQ(
+            SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated,
+            SoundSourceProxy(pTrack).updateTrackFromSource(
+                    SoundSourceProxy::UpdateTrackFromSourceMode::Always,
+                    SyncTrackMetadataParams{}));
 
     const auto trackMetadataAfter = pTrack->getMetadata();
     const auto coverInfoAfter = pTrack->getCoverInfo();
@@ -107,9 +113,11 @@ TEST_F(TrackUpdateTest, parseModifiedCleanAgainUpdateCover) {
     const auto trackMetadataBefore = pTrack->getMetadata();
     const auto coverInfoBefore = pTrack->getCoverInfo();
 
-    EXPECT_TRUE(SoundSourceProxy(pTrack).updateTrackFromSource(
-            SoundSourceProxy::UpdateTrackFromSourceMode::Always,
-            SyncTrackMetadataParams{}));
+    EXPECT_EQ(
+            SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated,
+            SoundSourceProxy(pTrack).updateTrackFromSource(
+                    SoundSourceProxy::UpdateTrackFromSourceMode::Always,
+                    SyncTrackMetadataParams{}));
 
     const auto trackMetadataAfter = pTrack->getMetadata();
     const auto coverInfoAfter = pTrack->getCoverInfo();
@@ -127,9 +135,11 @@ TEST_F(TrackUpdateTest, parseModifiedDirtyAgain) {
     const auto trackMetadataBefore = pTrack->getMetadata();
     const auto coverInfoBefore = pTrack->getCoverInfo();
 
-    EXPECT_TRUE(SoundSourceProxy(pTrack).updateTrackFromSource(
-            SoundSourceProxy::UpdateTrackFromSourceMode::Always,
-            SyncTrackMetadataParams{}));
+    EXPECT_EQ(
+            SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated,
+            SoundSourceProxy(pTrack).updateTrackFromSource(
+                    SoundSourceProxy::UpdateTrackFromSourceMode::Always,
+                    SyncTrackMetadataParams{}));
 
     const auto trackMetadataAfter = pTrack->getMetadata();
     const auto coverInfoAfter = pTrack->getCoverInfo();


### PR DESCRIPTION
Replace the boolean result from updateTrackFromSource() with a dedicated result enum that allows to distinguish the different outcomes.

Related to #4628 for debugging purposes. Easier to review as a standalone PR.