### PR TITLE
[2.3.2] FFmpeg: Delete obsolete dependency / Fix 5.0 build error

### DIFF
--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -31,7 +31,6 @@
 #   libavformat
 #   libavfilter
 #   libavutil
-#   libpostproc
 #   libswscale
 #   libswresample
 #
@@ -128,7 +127,6 @@ find_component(libavdevice   libavdevice   avdevice libavdevice/avdevice.h)
 find_component(libavutil     libavutil     avutil   libavutil/avutil.h)
 find_component(libavfilter   libavfilter   avfilter libavfilter/avfilter.h)
 find_component(libswscale    libswscale    swscale  libswscale/swscale.h)
-find_component(libpostproc   libpostproc   postproc libpostproc/postprocess.h)
 find_component(libswresample libswresample swresample libswresample/swresample.h)
 
 set(FFMPEG_LIBRARIES "")

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -518,7 +518,12 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
     }
 
     // Find the best stream
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 0, 100)
+    // https://github.com/FFmpeg/FFmpeg/blob/dd17c86aa11feae2b86de054dd0679cc5f88ebab/doc/APIchanges#L175
     AVCodec* pDecoder = nullptr;
+#else
+    const AVCodec* pDecoder = nullptr;
+#endif
     const int av_find_best_stream_result = av_find_best_stream(
             m_pavInputFormatContext,
             AVMEDIA_TYPE_AUDIO,


### PR DESCRIPTION
2 minor fixes.

Should be released with 2.3.2 to allow building with FFmpeg 5.0 when distributions upgrade! No changelog needed.