### PR TITLE
ReadAheadFrameBuffer: Delete invalid debug assertion

### DIFF
--- a/src/sources/readaheadframebuffer.cpp
+++ b/src/sources/readaheadframebuffer.cpp
@@ -68,7 +68,6 @@ void ReadAheadFrameBuffer::adjustCapacityBeforeBuffering(
 
 bool ReadAheadFrameBuffer::tryContinueReadingFrom(
         FrameIndex readIndex) {
-    DEBUG_ASSERT(isValid());
     if (!isReady()) {
         return false;
     }


### PR DESCRIPTION
The debug assertion is wrong as `isReady()` first checks for `isValid()`.

This has already occurred a few times, but happens very rarely. It is reproducible when adding an ID3 tag to cover-test.flac using id3tag and starting Mixxx with a fresh profile using SoundSourceFFmpeg for mp3 decoding.