### PR TITLE
Create wmainmenubar controls in coreservices so they are available to controllers on startup

### DIFF
--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -423,28 +423,26 @@ void CoreServices::initialize(QApplication* pApp) {
 
     m_pTouchShift = std::make_unique<ControlPushButton>(ConfigKey("[Controls]", "touch_shift"));
 
-    // The following wmainmenubar controls must be created here so that controllers can bind to them
+    // The following UI controls must be created here so that controllers can bind to them
     // on startup.
-    m_pSkinSettingsControl = std::make_unique<ControlObject>(
-            ConfigKey("[Master]", "skin_settings"));
-    m_pShowMicrophoneControl = std::make_unique<ControlPushButton>(
-            ConfigKey("[Microphone]", "show_microphone"));
-    m_pShowVinylControlControl = std::make_unique<ControlPushButton>(
-            ConfigKey(VINYL_PREF_KEY, "show_vinylcontrol"));
-    m_pShowPreviewDeckControl = std::make_unique<ControlPushButton>(
-            ConfigKey("[PreviewDeck]", "show_previewdeck"));
-    m_pShowCoverArtControl = std::make_unique<ControlPushButton>(
-            ConfigKey("[Library]", "show_coverart"));
-    m_pMaximizeLibraryControl = std::make_unique<ControlPushButton>(
-            ConfigKey("[Master]", "maximize_library"));
-    m_pShowSamplersControl = std::make_unique<ControlPushButton>(
-            ConfigKey("[Samplers]", "show_samplers"));
-    m_pShowEffectRackControl = std::make_unique<ControlPushButton>(
-            ConfigKey("[EffectRack1]", "show"));
-    m_pShow4EffectUnitsControl = std::make_unique<ControlPushButton>(
-            ConfigKey("[Skin]", "show_4effectunits"));
-    m_pShowMixerControl = std::make_unique<ControlPushButton>(
-            ConfigKey("[Master]", "show_mixer"));
+    m_uiControls.clear();
+    const std::vector<ConfigKey> uiKeys = {
+            ConfigKey("[Master]", "skin_settings"),
+            ConfigKey("[Microphone]", "show_microphone"),
+            ConfigKey(VINYL_PREF_KEY, "show_vinylcontrol"),
+            ConfigKey("[PreviewDeck]", "show_previewdeck"),
+            ConfigKey("[Library]", "show_coverart"),
+            ConfigKey("[Master]", "maximize_library"),
+            ConfigKey("[Samplers]", "show_samplers"),
+            ConfigKey("[EffectRack1]", "show"),
+            ConfigKey("[Skin]", "show_4effectunits"),
+            ConfigKey("[Master]", "show_mixer"),
+    };
+
+    for (const auto& key : uiKeys) {
+        m_uiControls.emplace_back(std::make_unique<ControlPushButton>(key));
+        m_uiControls.back()->setButtonMode(ControlPushButton::TOGGLE);
+    }
 
     // Load tracks in args.qlMusicFiles (command line arguments) into player
     // 1 and 2:
@@ -619,16 +617,8 @@ void CoreServices::finalize() {
     m_pDbConnectionPool.reset(); // should drop the last reference
 
     m_pTouchShift.reset();
-    m_pSkinSettingsControl.reset();
-    m_pShowMicrophoneControl.reset();
-    m_pShowVinylControlControl.reset();
-    m_pShowPreviewDeckControl.reset();
-    m_pShowCoverArtControl.reset();
-    m_pMaximizeLibraryControl.reset();
-    m_pShowSamplersControl.reset();
-    m_pShowEffectRackControl.reset();
-    m_pShow4EffectUnitsControl.reset();
-    m_pShowMixerControl.reset();
+
+    m_uiControls.clear();
 
     m_pControlIndicatorTimer.reset();
 

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -439,6 +439,7 @@ void CoreServices::initialize(QApplication* pApp) {
             ConfigKey("[Master]", "show_mixer"),
     };
 
+    m_uiControls.reserve(uiKeys.size());
     for (const auto& key : uiKeys) {
         m_uiControls.emplace_back(std::make_unique<ControlPushButton>(key));
         m_uiControls.back()->setButtonMode(ControlPushButton::TOGGLE);

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -423,6 +423,21 @@ void CoreServices::initialize(QApplication* pApp) {
 
     m_pTouchShift = std::make_unique<ControlPushButton>(ConfigKey("[Controls]", "touch_shift"));
 
+    // The following wmainmenubar controls must be created here so that controllers can bind to them
+    // on startup.
+    m_pSkinSettingsControl = std::make_unique<ControlPushButton>(
+            ConfigKey("[Master]", "skin_settings"));
+    m_pShowMicrophoneControl = std::make_unique<ControlPushButton>(
+            ConfigKey("[Microphone]", "show_microphone"));
+    m_pShowVinylControlControl = std::make_unique<ControlPushButton>(
+            ConfigKey(VINYL_PREF_KEY, "show_vinylcontrol"));
+    m_pShowPreviewDeckControl = std::make_unique<ControlPushButton>(
+            ConfigKey("[PreviewDeck]", "show_previewdeck"));
+    m_pShowCoverArtControl = std::make_unique<ControlPushButton>(
+            ConfigKey("[Library]", "show_coverart"));
+    m_pMaximizeLibraryControl = std::make_unique<ControlPushButton>(
+            ConfigKey("[Master]", "maximize_library"));
+
     // Load tracks in args.qlMusicFiles (command line arguments) into player
     // 1 and 2:
     const QList<QString>& musicFiles = m_cmdlineArgs.getMusicFiles();
@@ -596,6 +611,12 @@ void CoreServices::finalize() {
     m_pDbConnectionPool.reset(); // should drop the last reference
 
     m_pTouchShift.reset();
+    m_pSkinSettingsControl.reset();
+    m_pShowMicrophoneControl.reset();
+    m_pShowVinylControlControl.reset();
+    m_pShowPreviewDeckControl.reset();
+    m_pShowCoverArtControl.reset();
+    m_pMaximizeLibraryControl.reset();
 
     m_pControlIndicatorTimer.reset();
 

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -425,7 +425,7 @@ void CoreServices::initialize(QApplication* pApp) {
 
     // The following wmainmenubar controls must be created here so that controllers can bind to them
     // on startup.
-    m_pSkinSettingsControl = std::make_unique<ControlPushButton>(
+    m_pSkinSettingsControl = std::make_unique<ControlObject>(
             ConfigKey("[Master]", "skin_settings"));
     m_pShowMicrophoneControl = std::make_unique<ControlPushButton>(
             ConfigKey("[Microphone]", "show_microphone"));
@@ -437,6 +437,14 @@ void CoreServices::initialize(QApplication* pApp) {
             ConfigKey("[Library]", "show_coverart"));
     m_pMaximizeLibraryControl = std::make_unique<ControlPushButton>(
             ConfigKey("[Master]", "maximize_library"));
+    m_pShowSamplersControl = std::make_unique<ControlPushButton>(
+            ConfigKey("[Samplers]", "show_samplers"));
+    m_pShowEffectRackControl = std::make_unique<ControlPushButton>(
+            ConfigKey("[EffectRack1]", "show"));
+    m_pShow4EffectUnitsControl = std::make_unique<ControlPushButton>(
+            ConfigKey("[Skin]", "show_4effectunits"));
+    m_pShowMixerControl = std::make_unique<ControlPushButton>(
+            ConfigKey("[Master]", "show_mixer"));
 
     // Load tracks in args.qlMusicFiles (command line arguments) into player
     // 1 and 2:
@@ -617,6 +625,10 @@ void CoreServices::finalize() {
     m_pShowPreviewDeckControl.reset();
     m_pShowCoverArtControl.reset();
     m_pMaximizeLibraryControl.reset();
+    m_pShowSamplersControl.reset();
+    m_pShowEffectRackControl.reset();
+    m_pShow4EffectUnitsControl.reset();
+    m_pShowMixerControl.reset();
 
     m_pControlIndicatorTimer.reset();
 

--- a/src/coreservices.h
+++ b/src/coreservices.h
@@ -152,6 +152,12 @@ class CoreServices : public QObject {
     std::shared_ptr<mixxx::ScreensaverManager> m_pScreensaverManager;
 
     std::unique_ptr<ControlPushButton> m_pTouchShift;
+    std::unique_ptr<ControlPushButton> m_pSkinSettingsControl;
+    std::unique_ptr<ControlPushButton> m_pShowMicrophoneControl;
+    std::unique_ptr<ControlPushButton> m_pShowVinylControlControl;
+    std::unique_ptr<ControlPushButton> m_pShowPreviewDeckControl;
+    std::unique_ptr<ControlPushButton> m_pShowCoverArtControl;
+    std::unique_ptr<ControlPushButton> m_pMaximizeLibraryControl;
 
     Timer m_runtime_timer;
     const CmdlineArgs& m_cmdlineArgs;

--- a/src/coreservices.h
+++ b/src/coreservices.h
@@ -152,12 +152,16 @@ class CoreServices : public QObject {
     std::shared_ptr<mixxx::ScreensaverManager> m_pScreensaverManager;
 
     std::unique_ptr<ControlPushButton> m_pTouchShift;
-    std::unique_ptr<ControlPushButton> m_pSkinSettingsControl;
+    std::unique_ptr<ControlObject> m_pSkinSettingsControl;
     std::unique_ptr<ControlPushButton> m_pShowMicrophoneControl;
     std::unique_ptr<ControlPushButton> m_pShowVinylControlControl;
     std::unique_ptr<ControlPushButton> m_pShowPreviewDeckControl;
     std::unique_ptr<ControlPushButton> m_pShowCoverArtControl;
     std::unique_ptr<ControlPushButton> m_pMaximizeLibraryControl;
+    std::unique_ptr<ControlPushButton> m_pShowSamplersControl;
+    std::unique_ptr<ControlPushButton> m_pShowEffectRackControl;
+    std::unique_ptr<ControlPushButton> m_pShow4EffectUnitsControl;
+    std::unique_ptr<ControlPushButton> m_pShowMixerControl;
 
     Timer m_runtime_timer;
     const CmdlineArgs& m_cmdlineArgs;

--- a/src/coreservices.h
+++ b/src/coreservices.h
@@ -151,17 +151,8 @@ class CoreServices : public QObject {
 
     std::shared_ptr<mixxx::ScreensaverManager> m_pScreensaverManager;
 
+    std::vector<std::unique_ptr<ControlPushButton>> m_uiControls;
     std::unique_ptr<ControlPushButton> m_pTouchShift;
-    std::unique_ptr<ControlObject> m_pSkinSettingsControl;
-    std::unique_ptr<ControlPushButton> m_pShowMicrophoneControl;
-    std::unique_ptr<ControlPushButton> m_pShowVinylControlControl;
-    std::unique_ptr<ControlPushButton> m_pShowPreviewDeckControl;
-    std::unique_ptr<ControlPushButton> m_pShowCoverArtControl;
-    std::unique_ptr<ControlPushButton> m_pMaximizeLibraryControl;
-    std::unique_ptr<ControlPushButton> m_pShowSamplersControl;
-    std::unique_ptr<ControlPushButton> m_pShowEffectRackControl;
-    std::unique_ptr<ControlPushButton> m_pShow4EffectUnitsControl;
-    std::unique_ptr<ControlPushButton> m_pShowMixerControl;
 
     Timer m_runtime_timer;
     const CmdlineArgs& m_cmdlineArgs;


### PR DESCRIPTION
The coreservices refactor broke controllers that bind a button to maximize_library.  This is because controllers are initialized before the main window, because main window initialization depends on core services, and core services sets up controllers.  So it's a catch-22.

I have solved this by creating those controls in coreservices, much like touch_shift is created.  This solves the problem with my S3 controller.  