### PR TITLE
Recording: fix table refresh issues

### DIFF
--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -364,8 +364,8 @@ void BrowseTableModel::slotInsert(const QList<QList<QStandardItem*>>& rows,
         for (int i = 0; i < rows.size(); ++i) {
             appendRow(rows.at(i));
         }
+        emit restoreModelState();
     }
-    emit restoreModelState();
 }
 
 TrackModel::Capabilities BrowseTableModel::getCapabilities() const {

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -210,8 +210,8 @@ void BrowseTableModel::addSearchColumn(int index) {
 }
 
 void BrowseTableModel::setPath(mixxx::FileAccess path) {
-    if (path.info().hasLocation()) {
-        m_currentDirectory = path.info().locationPath();
+    if (path.info().hasLocation() && path.info().isDir()) {
+        m_currentDirectory = path.info().location();
     } else {
         m_currentDirectory = QString();
     }

--- a/src/library/browse/browsethread.cpp
+++ b/src/library/browse/browsethread.cpp
@@ -296,12 +296,13 @@ void BrowseThread::populateModel() {
         if (row % 10 == 0) {
             // this is a blocking operation
             emit rowsAppended(rows, thisModelObserver);
-            qDebug() << "Append " << rows.count() << " from " << fileAccess.info();
+            qDebug() << "Append" << rows.count() << "tracks from "
+                     << thisPath.info().locationPath();
             rows.clear();
         }
-        // Sleep additionally for 10ms which prevents us from GUI freezes
+        // Sleep additionally for 20ms which prevents us from GUI freezes
         msleep(20);
     }
     emit rowsAppended(rows, thisModelObserver);
-    qDebug() << "Append last " << rows.count();
+    qDebug() << "Append last" << rows.count() << "tracks from" << thisPath.info().locationPath();
 }

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -81,12 +81,10 @@ DlgRecording::DlgRecording(
         box->insertWidget(1, m_pTrackTableView);
     }
 
-    m_recordingDir = m_pRecordingManager->getRecordingDir();
-
     m_proxyModel.setFilterCaseSensitivity(Qt::CaseInsensitive);
     m_proxyModel.setSortCaseSensitivity(Qt::CaseInsensitive);
 
-    m_browseModel.setPath(mixxx::FileAccess(mixxx::FileInfo(m_recordingDir)));
+    refreshBrowseModel();
     m_pTrackTableView->loadTrackModel(&m_proxyModel);
 
     connect(pushButtonRecording,
@@ -107,8 +105,7 @@ DlgRecording::~DlgRecording() {
 }
 
 void DlgRecording::onShow() {
-    m_recordingDir = m_pRecordingManager->getRecordingDir();
-    m_browseModel.setPath(mixxx::FileAccess(mixxx::FileInfo(m_recordingDir)));
+    refreshBrowseModel();
 }
 
 bool DlgRecording::hasFocus() const {
@@ -120,7 +117,8 @@ void DlgRecording::setFocus() {
 }
 
 void DlgRecording::refreshBrowseModel() {
-    m_browseModel.setPath(mixxx::FileAccess(mixxx::FileInfo(m_recordingDir)));
+    QString recordingDir = m_pRecordingManager->getRecordingDir();
+    m_browseModel.setPath(mixxx::FileAccess(mixxx::FileInfo(recordingDir)));
 }
 
 void DlgRecording::onSearch(const QString& text) {
@@ -175,7 +173,7 @@ void DlgRecording::slotRecordingStateChanged(bool isRecording) {
         labelRecStatistics->hide();
     }
     //This will update the recorded track table view
-    m_browseModel.setPath(mixxx::FileAccess(mixxx::FileInfo(m_recordingDir)));
+    refreshBrowseModel();
 }
 
 // gets number of recorded bytes and update label

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -113,6 +113,7 @@ void DlgRecording::setFocus() {
 }
 
 void DlgRecording::refreshBrowseModel() {
+    saveCurrentViewState();
     QString recordingDir = m_pRecordingManager->getRecordingDir();
     m_browseModel.setPath(mixxx::FileAccess(mixxx::FileInfo(recordingDir)));
 }

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -104,10 +104,6 @@ DlgRecording::DlgRecording(
 DlgRecording::~DlgRecording() {
 }
 
-void DlgRecording::onShow() {
-    refreshBrowseModel();
-}
-
 bool DlgRecording::hasFocus() const {
     return m_pTrackTableView->hasFocus();
 }

--- a/src/library/recording/dlgrecording.h
+++ b/src/library/recording/dlgrecording.h
@@ -24,7 +24,7 @@ class DlgRecording : public QWidget, public Ui::DlgRecording, public virtual Lib
     ~DlgRecording() override;
 
     void onSearch(const QString& text) override;
-    void onShow() override;
+    void onShow() override{};
     bool hasFocus() const override;
     void setFocus() override;
     void loadSelectedTrack() override;

--- a/src/library/recording/dlgrecording.h
+++ b/src/library/recording/dlgrecording.h
@@ -55,7 +55,6 @@ class DlgRecording : public QWidget, public Ui::DlgRecording, public virtual Lib
     WTrackTableView* m_pTrackTableView;
     BrowseTableModel m_browseModel;
     ProxyTrackModel m_proxyModel;
-    QString m_recordingDir;
 
     void refreshLabels();
     void slotRecButtonClicked(bool checked);

--- a/src/library/recording/recordingfeature.cpp
+++ b/src/library/recording/recordingfeature.cpp
@@ -30,6 +30,7 @@ QVariant RecordingFeature::title() {
 TreeItemModel* RecordingFeature::sidebarModel() const {
     return m_pSidebarModel;
 }
+
 void RecordingFeature::bindLibraryWidget(WLibrary* pLibraryWidget,
                                   KeyboardEventFilter *keyboard) {
     //The view will be deleted by LibraryWidget
@@ -66,7 +67,6 @@ void RecordingFeature::bindLibraryWidget(WLibrary* pLibraryWidget,
             this,
             &RecordingFeature::restoreModelState);
 }
-
 
 void RecordingFeature::activate() {
     emit refreshBrowseModel();

--- a/src/recording/recordingmanager.cpp
+++ b/src/recording/recordingmanager.cpp
@@ -99,7 +99,7 @@ qint64 RecordingManager::getFreeSpace() {
     // returns the free space on the recording location in bytes
     // return -1 if the free space could not be determined
     qint64 rv = -1;
-    QStorageInfo storage(getRecordingDir());
+    QStorageInfo storage(m_recordingDir);
     if (storage.isValid()) {
         rv = storage.bytesAvailable();
     }

--- a/src/recording/recordingmanager.cpp
+++ b/src/recording/recordingmanager.cpp
@@ -168,8 +168,7 @@ void RecordingManager::splitContinueRecording()
     m_recReady->set(RECORD_SPLIT_CONTINUE);
 }
 
-void RecordingManager::stopRecording()
-{
+void RecordingManager::stopRecording() {
     qDebug() << "Recording stopped";
     m_recReady->set(RECORD_OFF);
     m_recordingFile = "";
@@ -201,13 +200,10 @@ QString& RecordingManager::getRecordingDir() {
 }
 
 // Only called when recording is active.
-void RecordingManager::slotDurationRecorded(quint64 duration)
-{
-    if(m_secondsRecordedSplit != duration)
-    {
+void RecordingManager::slotDurationRecorded(quint64 duration) {
+    if (m_secondsRecordedSplit != duration) {
         m_secondsRecordedSplit = duration;
-        if(duration >= m_split_time)
-        {
+        if (duration >= m_split_time) {
             qDebug() << "Splitting after " << duration << " seconds";
             // This will reuse the previous filename but append a suffix.
             splitContinueRecording();
@@ -215,6 +211,7 @@ void RecordingManager::slotDurationRecorded(quint64 duration)
         emit durationRecorded(getRecordedDurationStr(m_secondsRecorded+m_secondsRecordedSplit));
     }
 }
+
 // Copy from the implementation in enginerecord.cpp
 QString RecordingManager::getRecordedDurationStr(unsigned int duration) {
     return QString("%1:%2")
@@ -223,8 +220,7 @@ QString RecordingManager::getRecordedDurationStr(unsigned int duration) {
 }
 
 // Only called when recording is active.
-void RecordingManager::slotBytesRecorded(int bytes)
-{
+void RecordingManager::slotBytesRecorded(int bytes) {
     // auto conversion to quint64
     m_iNumberOfBytesRecorded += bytes;
     m_iNumberOfBytesRecordedSplit += bytes;
@@ -232,8 +228,7 @@ void RecordingManager::slotBytesRecorded(int bytes)
     //Split before reaching the max size. m_split_size has some headroom, as
     //seen in the constant definitions in defs_recording.h. Also, note that
     //bytes are increased in the order of 10s of KBs each call.
-    if(m_iNumberOfBytesRecordedSplit >= m_split_size)
-    {
+    if (m_iNumberOfBytesRecordedSplit >= m_split_size) {
         qDebug() << "Splitting after " << m_iNumberOfBytesRecorded << " bytes written";
         // This will reuse the previous filename but append a suffix.
         splitContinueRecording();
@@ -314,34 +309,32 @@ const QString& RecordingManager::getRecordingLocation() const {
     return m_recordingLocation;
 }
 
-
-quint64 RecordingManager::getFileSplitSize()
-{
-     QString fileSizeStr = m_pConfig->getValueString(ConfigKey(RECORDING_PREF_KEY, "FileSize"));
-     if (fileSizeStr == SPLIT_650MB) {
-         return SIZE_650MB;
-     } else if (fileSizeStr == SPLIT_700MB) {
-         return SIZE_700MB;
-     } else if (fileSizeStr == SPLIT_1024MB) {
-         return SIZE_1GB;
-     } else if (fileSizeStr == SPLIT_2048MB) {
-         return SIZE_2GB;
-     } else if (fileSizeStr == SPLIT_4096MB) {
-         return SIZE_4GB;
-     } else if (fileSizeStr == SPLIT_60MIN) {
-         return SIZE_4GB; //Ignore size limit. use time limit
-     } else if (fileSizeStr == SPLIT_74MIN) {
-         return SIZE_4GB; //Ignore size limit. use time limit
-     } else if (fileSizeStr == SPLIT_80MIN) {
-         return SIZE_4GB; //Ignore size limit. use time limit
-     } else if (fileSizeStr == SPLIT_120MIN) {
-         return SIZE_4GB; //Ignore size limit. use time limit
-     } else {
-         return SIZE_650MB;
-     }
+quint64 RecordingManager::getFileSplitSize() {
+    QString fileSizeStr = m_pConfig->getValueString(ConfigKey(RECORDING_PREF_KEY, "FileSize"));
+    if (fileSizeStr == SPLIT_650MB) {
+        return SIZE_650MB;
+    } else if (fileSizeStr == SPLIT_700MB) {
+        return SIZE_700MB;
+    } else if (fileSizeStr == SPLIT_1024MB) {
+        return SIZE_1GB;
+    } else if (fileSizeStr == SPLIT_2048MB) {
+        return SIZE_2GB;
+    } else if (fileSizeStr == SPLIT_4096MB) {
+        return SIZE_4GB;
+    } else if (fileSizeStr == SPLIT_60MIN) {
+        return SIZE_4GB; //Ignore size limit. use time limit
+    } else if (fileSizeStr == SPLIT_74MIN) {
+        return SIZE_4GB; //Ignore size limit. use time limit
+    } else if (fileSizeStr == SPLIT_80MIN) {
+        return SIZE_4GB; //Ignore size limit. use time limit
+    } else if (fileSizeStr == SPLIT_120MIN) {
+        return SIZE_4GB; //Ignore size limit. use time limit
+    } else {
+        return SIZE_650MB;
+    }
 }
-unsigned int RecordingManager::getFileSplitSeconds()
-{
+
+unsigned int RecordingManager::getFileSplitSeconds() {
     QString fileSizeStr = m_pConfig->getValueString(ConfigKey(RECORDING_PREF_KEY, "FileSize"));
     if (fileSizeStr == SPLIT_60MIN) {
         return 60*60;


### PR DESCRIPTION
I noticed that the track view selection and position was reset when I
* was browsing Tracks without having activated  any other sidebar item earlier (= no stored state of the track view)
* toggled recording
* then tried to move vertically in the tracks view with arrow keys or [Library] controls

In the end this is a fixup for #4177, as well as some tweaks I discovered while trying to find the cause for the issue.
Selection bug fixed by
26a5ceaddfd57c22e0ea5d4262aab5b8cdf36c0e
26a5ceaddfd57c22e0ea5d4262aab5b8cdf36c0e
