### PR TITLE
Make QML UI compatible with Qt 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
             os: ubuntu-20.04
             # The Dockerfile for this container can be found at:
             # https://github.com/Holzhaus/mixxx-ci-docker
-            container: holzhaus/mixxx-ci:20211016-qt6
+            container: holzhaus/mixxx-ci:20220128-qt6
             cmake_args: >-
               -DWARNINGS_FATAL=ON
               -DQT6=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2155,6 +2155,39 @@ if(QT6)
   foreach(COMPONENT ${QT6_NEW_COMPONENTS})
     target_link_libraries(mixxx-lib PUBLIC Qt6::${COMPONENT})
   endforeach()
+
+  set(QT_QML_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/qml)
+  set_target_properties(mixxx-lib PROPERTIES AUTOMOC ON)
+  qt_add_qml_module(mixxx-lib
+    URI Mixxx
+    VERSION 0.1
+    RESOURCE_PREFIX /mixxx.org/imports
+    QML_FILES
+      res/qml/Mixxx/MathUtils.mjs
+      res/qml/Mixxx/PlayerDropArea.qml
+  )
+  # FIXME: Currently we need to add these include directories due to
+  # QTBUG-87221. We should figure out a better way to fix this.
+  # See: https://bugreports.qt.io/browse/QTBUG-87221
+  target_include_directories(mixxx-lib PRIVATE src/control src/qml)
+  target_link_libraries(mixxx-lib PRIVATE mixxx-libplugin)
+
+  qt_add_library(mixxx-qml-mixxxcontrols STATIC)
+  set_target_properties(mixxx-qml-mixxxcontrols PROPERTIES AUTOMOC ON)
+  qt_add_qml_module(mixxx-qml-mixxxcontrols
+    URI Mixxx.Controls
+    VERSION 0.1
+    RESOURCE_PREFIX /mixxx.org/imports
+    OPTIONAL_IMPORTS Mixxx
+    QML_FILES
+      res/qml/Mixxx/Controls/Knob.qml
+      res/qml/Mixxx/Controls/Slider.qml
+      res/qml/Mixxx/Controls/Spinny.qml
+      res/qml/Mixxx/Controls/WaveformOverviewHotcueMarker.qml
+      res/qml/Mixxx/Controls/WaveformOverviewMarker.qml
+      res/qml/Mixxx/Controls/WaveformOverview.qml
+  )
+  target_link_libraries(mixxx-lib PRIVATE mixxx-qml-mixxxcontrolsplugin)
 endif()
 
 target_compile_definitions(mixxx-lib PUBLIC QT_TABLET_SUPPORT QT_USE_QSTRINGBUILDER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -818,20 +818,6 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/preferences/settingsmanager.cpp
   src/preferences/upgrade.cpp
   src/recording/recordingmanager.cpp
-  src/qml/asyncimageprovider.cpp
-  src/qml/qmlapplication.cpp
-  src/qml/qmlcontrolproxy.cpp
-  src/qml/qmlconfigproxy.cpp
-  src/qml/qmldlgpreferencesproxy.cpp
-  src/qml/qmleffectmanifestparametersmodel.cpp
-  src/qml/qmleffectsmanagerproxy.cpp
-  src/qml/qmleffectslotproxy.cpp
-  src/qml/qmllibraryproxy.cpp
-  src/qml/qmllibrarytracklistmodel.cpp
-  src/qml/qmlplayermanagerproxy.cpp
-  src/qml/qmlplayerproxy.cpp
-  src/qml/qmlvisibleeffectsmodel.cpp
-  src/qml/qmlwaveformoverview.cpp
   src/skin/legacy/colorschemeparser.cpp
   src/skin/legacy/imgcolor.cpp
   src/skin/legacy/imginvert.cpp
@@ -1024,7 +1010,24 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/widget/wwidgetgroup.cpp
   src/widget/wwidgetstack.cpp
 )
-if(NOT QT6)
+if(QT6)
+  target_sources(mixxx-lib PRIVATE
+    src/qml/asyncimageprovider.cpp
+    src/qml/qmlapplication.cpp
+    src/qml/qmlcontrolproxy.cpp
+    src/qml/qmlconfigproxy.cpp
+    src/qml/qmldlgpreferencesproxy.cpp
+    src/qml/qmleffectmanifestparametersmodel.cpp
+    src/qml/qmleffectsmanagerproxy.cpp
+    src/qml/qmleffectslotproxy.cpp
+    src/qml/qmllibraryproxy.cpp
+    src/qml/qmllibrarytracklistmodel.cpp
+    src/qml/qmlplayermanagerproxy.cpp
+    src/qml/qmlplayerproxy.cpp
+    src/qml/qmlvisibleeffectsmodel.cpp
+    src/qml/qmlwaveformoverview.cpp
+  )
+else()
   target_sources(mixxx-lib PRIVATE
     src/mixxxmainwindow.cpp
     src/waveform/guitick.cpp

--- a/res/qml/Button.qml
+++ b/res/qml/Button.qml
@@ -1,4 +1,4 @@
-import QtGraphicalEffects 1.12
+import Qt5Compat.GraphicalEffects
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import "Theme"
@@ -102,7 +102,6 @@ AbstractButton {
             anchors.fill: parent
             radius: 5
             spread: 0.1
-            samples: 1 + radius * 2
             color: label.color
             source: label
         }

--- a/res/qml/DeckInfoBar.qml
+++ b/res/qml/DeckInfoBar.qml
@@ -1,7 +1,7 @@
 import "." as Skin
 import Mixxx 0.1 as Mixxx
 import Mixxx.Controls 0.1 as MixxxControls
-import QtGraphicalEffects 1.12
+import Qt5Compat.GraphicalEffects
 import QtQuick 2.12
 import "Theme"
 

--- a/res/qml/InfoBarButton.qml
+++ b/res/qml/InfoBarButton.qml
@@ -1,5 +1,5 @@
 import Mixxx 0.1 as Mixxx
-import QtGraphicalEffects 1.12
+import Qt5Compat.GraphicalEffects
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import "Theme"

--- a/res/qml/Mixxx/Controls/qmldir
+++ b/res/qml/Mixxx/Controls/qmldir
@@ -1,8 +1,0 @@
-module Mixxx.Controls
-depends Mixxx 0.1
-Knob 0.1 Knob.qml
-Slider 0.1 Slider.qml
-Spinny 0.1 Spinny.qml
-WaveformOverview 0.1 WaveformOverview.qml
-WaveformOverviewMarker 0.1 WaveformOverviewMarker.qml
-WaveformOverviewHotcueMarker 0.1 WaveformOverviewHotcueMarker.qml

--- a/res/qml/Mixxx/qmldir
+++ b/res/qml/Mixxx/qmldir
@@ -1,3 +1,0 @@
-module Mixxx
-MathUtils 0.1 MathUtils.mjs
-PlayerDropArea 0.1 PlayerDropArea.qml

--- a/res/qml/Slider.qml
+++ b/res/qml/Slider.qml
@@ -1,5 +1,5 @@
 import Mixxx.Controls 0.1 as MixxxControls
-import QtGraphicalEffects 1.12
+import Qt5Compat.GraphicalEffects
 import QtQuick 2.12
 import "Theme"
 

--- a/res/qml/VuMeter.qml
+++ b/res/qml/VuMeter.qml
@@ -1,5 +1,5 @@
 import Mixxx 0.1 as Mixxx
-import QtGraphicalEffects 1.12
+import Qt5Compat.GraphicalEffects
 import QtQuick 2.12
 import "Theme"
 

--- a/src/control/controlsortfiltermodel.h
+++ b/src/control/controlsortfiltermodel.h
@@ -2,6 +2,11 @@
 
 #include <QSortFilterProxyModel>
 #include <QString>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QtQml>
+#else
+#define QML_ELEMENT
+#endif
 
 #include "control/controlmodel.h"
 
@@ -9,6 +14,7 @@ class ControlSortFilterModel : public QSortFilterProxyModel {
     Q_OBJECT
     Q_PROPERTY(int sortColumn READ sortColumn NOTIFY sortColumnChanged)
     Q_PROPERTY(bool sortDescending READ sortDescending NOTIFY sortDescendingChanged)
+    QML_ELEMENT
   public:
     ControlSortFilterModel(QObject* pParent = nullptr);
     virtual ~ControlSortFilterModel();

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -76,173 +76,173 @@ LibraryControl::LibraryControl(Library* pLibrary)
     m_pMoveUp = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveUp"));
     m_pMoveDown = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveDown"));
     m_pMoveVertical = std::make_unique<ControlEncoder>(ConfigKey("[Library]", "MoveVertical"), false);
-    if (!CmdlineArgs::Instance().getQml()) {
-        connect(m_pMoveUp.get(),
-                &ControlPushButton::valueChanged,
-                this,
-                &LibraryControl::slotMoveUp);
-        connect(m_pMoveDown.get(),
-                &ControlPushButton::valueChanged,
-                this,
-                &LibraryControl::slotMoveDown);
-        connect(m_pMoveVertical.get(),
-                &ControlEncoder::valueChanged,
-                this,
-                &LibraryControl::slotMoveVertical);
-    }
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    connect(m_pMoveUp.get(),
+            &ControlPushButton::valueChanged,
+            this,
+            &LibraryControl::slotMoveUp);
+    connect(m_pMoveDown.get(),
+            &ControlPushButton::valueChanged,
+            this,
+            &LibraryControl::slotMoveDown);
+    connect(m_pMoveVertical.get(),
+            &ControlEncoder::valueChanged,
+            this,
+            &LibraryControl::slotMoveVertical);
+#endif
 
     // Controls to navigate vertically within currently focused widget (up/down buttons)
     m_pScrollUp = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "ScrollUp"));
     m_pScrollDown = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "ScrollDown"));
     m_pScrollVertical = std::make_unique<ControlEncoder>(ConfigKey("[Library]", "ScrollVertical"), false);
-    if (!CmdlineArgs::Instance().getQml()) {
-        connect(m_pScrollUp.get(),
-                &ControlPushButton::valueChanged,
-                this,
-                &LibraryControl::slotScrollUp);
-        connect(m_pScrollDown.get(),
-                &ControlPushButton::valueChanged,
-                this,
-                &LibraryControl::slotScrollDown);
-        connect(m_pScrollVertical.get(),
-                &ControlEncoder::valueChanged,
-                this,
-                &LibraryControl::slotScrollVertical);
-    }
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    connect(m_pScrollUp.get(),
+            &ControlPushButton::valueChanged,
+            this,
+            &LibraryControl::slotScrollUp);
+    connect(m_pScrollDown.get(),
+            &ControlPushButton::valueChanged,
+            this,
+            &LibraryControl::slotScrollDown);
+    connect(m_pScrollVertical.get(),
+            &ControlEncoder::valueChanged,
+            this,
+            &LibraryControl::slotScrollVertical);
+#endif
 
     // Controls to navigate horizontally within currently selected item (left/right buttons)
     m_pMoveLeft = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveLeft"));
     m_pMoveRight = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveRight"));
     m_pMoveHorizontal = std::make_unique<ControlEncoder>(ConfigKey("[Library]", "MoveHorizontal"), false);
-    if (!CmdlineArgs::Instance().getQml()) {
-        connect(m_pMoveLeft.get(),
-                &ControlPushButton::valueChanged,
-                this,
-                &LibraryControl::slotMoveLeft);
-        connect(m_pMoveRight.get(),
-                &ControlPushButton::valueChanged,
-                this,
-                &LibraryControl::slotMoveRight);
-        connect(m_pMoveHorizontal.get(),
-                &ControlEncoder::valueChanged,
-                this,
-                &LibraryControl::slotMoveHorizontal);
-    }
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    connect(m_pMoveLeft.get(),
+            &ControlPushButton::valueChanged,
+            this,
+            &LibraryControl::slotMoveLeft);
+    connect(m_pMoveRight.get(),
+            &ControlPushButton::valueChanged,
+            this,
+            &LibraryControl::slotMoveRight);
+    connect(m_pMoveHorizontal.get(),
+            &ControlEncoder::valueChanged,
+            this,
+            &LibraryControl::slotMoveHorizontal);
+#endif
 
     // Controls to navigate between widgets
     // Relative focus controls (tab/shift+tab button)
     m_pMoveFocusForward = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveFocusForward"));
     m_pMoveFocusBackward = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveFocusBackward"));
     m_pMoveFocus = std::make_unique<ControlEncoder>(ConfigKey("[Library]", "MoveFocus"), false);
-    if (!CmdlineArgs::Instance().getQml()) {
-        connect(m_pMoveFocusForward.get(),
-                &ControlPushButton::valueChanged,
-                this,
-                &LibraryControl::slotMoveFocusForward);
-        connect(m_pMoveFocusBackward.get(),
-                &ControlPushButton::valueChanged,
-                this,
-                &LibraryControl::slotMoveFocusBackward);
-        connect(m_pMoveFocus.get(),
-                &ControlEncoder::valueChanged,
-                this,
-                &LibraryControl::slotMoveFocus);
-    }
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    connect(m_pMoveFocusForward.get(),
+            &ControlPushButton::valueChanged,
+            this,
+            &LibraryControl::slotMoveFocusForward);
+    connect(m_pMoveFocusBackward.get(),
+            &ControlPushButton::valueChanged,
+            this,
+            &LibraryControl::slotMoveFocusBackward);
+    connect(m_pMoveFocus.get(),
+            &ControlEncoder::valueChanged,
+            this,
+            &LibraryControl::slotMoveFocus);
+#endif
 
     // Direct focus control, read/write
     m_pLibraryFocusedWidgetCO = std::make_unique<ControlPushButton>(
             ConfigKey("[Library]", "focused_widget"));
     m_pLibraryFocusedWidgetCO->setStates(static_cast<int>(FocusWidget::Count));
-    if (!CmdlineArgs::Instance().getQml()) {
-        m_pLibraryFocusedWidgetCO->connectValueChangeRequest(
-                this,
-                [this](double value) {
-                    // Focus can not be removed from a widget just moved to another one.
-                    // Thus, to keep the CO and QApplication::focusWidget() in sync we
-                    // have to prevent scripts or GUI buttons setting the CO to 'None'.
-                    // It's only set to 'None' internally when one of the library widgets
-                    // receives a FocusOutEvent(), e.g. when the focus is moved to another
-                    // widget, or when the main window loses focus.
-                    const int valueInt = static_cast<int>(value);
-                    if (valueInt != static_cast<int>(FocusWidget::None) &&
-                            valueInt < static_cast<int>(FocusWidget::Count)) {
-                        setLibraryFocus(static_cast<FocusWidget>(valueInt));
-                    }
-                });
-    }
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    m_pLibraryFocusedWidgetCO->connectValueChangeRequest(
+            this,
+            [this](double value) {
+                // Focus can not be removed from a widget just moved to another one.
+                // Thus, to keep the CO and QApplication::focusWidget() in sync we
+                // have to prevent scripts or GUI buttons setting the CO to 'None'.
+                // It's only set to 'None' internally when one of the library widgets
+                // receives a FocusOutEvent(), e.g. when the focus is moved to another
+                // widget, or when the main window loses focus.
+                const int valueInt = static_cast<int>(value);
+                if (valueInt != static_cast<int>(FocusWidget::None) &&
+                        valueInt < static_cast<int>(FocusWidget::Count)) {
+                    setLibraryFocus(static_cast<FocusWidget>(valueInt));
+                }
+            });
+#endif
 
     // Control to "goto" the currently selected item in focused widget (context dependent)
     m_pGoToItem = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "GoToItem"));
-    if (!CmdlineArgs::Instance().getQml()) {
-        connect(m_pGoToItem.get(),
-                &ControlPushButton::valueChanged,
-                this,
-                &LibraryControl::slotGoToItem);
-    }
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    connect(m_pGoToItem.get(),
+            &ControlPushButton::valueChanged,
+            this,
+            &LibraryControl::slotGoToItem);
+#endif
 
     // Auto DJ controls
     m_pAutoDjAddTop = std::make_unique<ControlPushButton>(ConfigKey("[Library]","AutoDjAddTop"));
-    if (!CmdlineArgs::Instance().getQml()) {
-        connect(m_pAutoDjAddTop.get(),
-                &ControlPushButton::valueChanged,
-                this,
-                &LibraryControl::slotAutoDjAddTop);
-    }
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    connect(m_pAutoDjAddTop.get(),
+            &ControlPushButton::valueChanged,
+            this,
+            &LibraryControl::slotAutoDjAddTop);
+#endif
 
     m_pAutoDjAddBottom = std::make_unique<ControlPushButton>(ConfigKey("[Library]","AutoDjAddBottom"));
-    if (!CmdlineArgs::Instance().getQml()) {
-        connect(m_pAutoDjAddBottom.get(),
-                &ControlPushButton::valueChanged,
-                this,
-                &LibraryControl::slotAutoDjAddBottom);
-    }
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    connect(m_pAutoDjAddBottom.get(),
+            &ControlPushButton::valueChanged,
+            this,
+            &LibraryControl::slotAutoDjAddBottom);
+#endif
 
     m_pAutoDjAddReplace = std::make_unique<ControlPushButton>(
             ConfigKey("[Library]", "AutoDjAddReplace"));
-    if (!CmdlineArgs::Instance().getQml()) {
-        connect(m_pAutoDjAddReplace.get(),
-                &ControlPushButton::valueChanged,
-                this,
-                &LibraryControl::slotAutoDjAddReplace);
-    }
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    connect(m_pAutoDjAddReplace.get(),
+            &ControlPushButton::valueChanged,
+            this,
+            &LibraryControl::slotAutoDjAddReplace);
+#endif
 
     // Sort controls
     m_pSortColumn = std::make_unique<ControlEncoder>(ConfigKey("[Library]", "sort_column"));
     m_pSortOrder = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "sort_order"));
     m_pSortOrder->setButtonMode(ControlPushButton::TOGGLE);
     m_pSortColumnToggle = std::make_unique<ControlEncoder>(ConfigKey("[Library]", "sort_column_toggle"), false);
-    if (!CmdlineArgs::Instance().getQml()) {
-        connect(m_pSortColumn.get(),
-                &ControlEncoder::valueChanged,
-                this,
-                &LibraryControl::slotSortColumn);
-        connect(m_pSortColumnToggle.get(),
-                &ControlEncoder::valueChanged,
-                this,
-                &LibraryControl::slotSortColumnToggle);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    connect(m_pSortColumn.get(),
+            &ControlEncoder::valueChanged,
+            this,
+            &LibraryControl::slotSortColumn);
+    connect(m_pSortColumnToggle.get(),
+            &ControlEncoder::valueChanged,
+            this,
+            &LibraryControl::slotSortColumnToggle);
 
-        // Font sizes
-        m_pFontSizeKnob = std::make_unique<ControlObject>(
-                ConfigKey("[Library]", "font_size_knob"), false);
-        connect(m_pFontSizeKnob.get(),
-                &ControlObject::valueChanged,
-                this,
-                &LibraryControl::slotFontSize);
+    // Font sizes
+    m_pFontSizeKnob = std::make_unique<ControlObject>(
+            ConfigKey("[Library]", "font_size_knob"), false);
+    connect(m_pFontSizeKnob.get(),
+            &ControlObject::valueChanged,
+            this,
+            &LibraryControl::slotFontSize);
 
-        m_pFontSizeDecrement = std::make_unique<ControlPushButton>(
-                ConfigKey("[Library]", "font_size_decrement"));
-        connect(m_pFontSizeDecrement.get(),
-                &ControlPushButton::valueChanged,
-                this,
-                &LibraryControl::slotDecrementFontSize);
+    m_pFontSizeDecrement = std::make_unique<ControlPushButton>(
+            ConfigKey("[Library]", "font_size_decrement"));
+    connect(m_pFontSizeDecrement.get(),
+            &ControlPushButton::valueChanged,
+            this,
+            &LibraryControl::slotDecrementFontSize);
 
-        m_pFontSizeIncrement = std::make_unique<ControlPushButton>(
-                ConfigKey("[Library]", "font_size_increment"));
-        connect(m_pFontSizeIncrement.get(),
-                &ControlPushButton::valueChanged,
-                this,
-                &LibraryControl::slotIncrementFontSize);
-    }
+    m_pFontSizeIncrement = std::make_unique<ControlPushButton>(
+            ConfigKey("[Library]", "font_size_increment"));
+    connect(m_pFontSizeIncrement.get(),
+            &ControlPushButton::valueChanged,
+            this,
+            &LibraryControl::slotIncrementFontSize);
+#endif
 
     // Track Color controls
     m_pTrackColorPrev = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "track_color_prev"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,10 +10,11 @@
 #include "coreservices.h"
 #include "errordialoghandler.h"
 #include "mixxxapplication.h"
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include "qml/qmlapplication.h"
+#else
 #include "mixxxmainwindow.h"
 #endif
-#include "qml/qmlapplication.h"
 #include "sources/soundsourceproxy.h"
 #include "util/cmdlineargs.h"
 #include "util/console.h"
@@ -38,15 +39,11 @@ int runMixxx(MixxxApplication* pApp, const CmdlineArgs& args) {
     CmdlineArgs::Instance().parseForUserFeedback();
 
     int exitCode;
-    // TODO: remove --qml command line option and make QML only available
-    // with Qt6 when Mixxx can build with Qt6.
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    if (args.getQml()) {
-#endif
-        mixxx::qml::QmlApplication qmlApplication(pApp, pCoreServices);
-        exitCode = pApp->exec();
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    } else {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    mixxx::qml::QmlApplication qmlApplication(pApp, pCoreServices);
+    exitCode = pApp->exec();
+#else
+    {
         // This scope ensures that `MixxxMainWindow` is destroyed *before*
         // CoreServices is shut down. Otherwise a debug assertion complaining about
         // leaked COs may be triggered.

--- a/src/qml/qmlapplication.cpp
+++ b/src/qml/qmlapplication.cpp
@@ -1,5 +1,7 @@
 #include "qmlapplication.h"
 
+#include <QtQml/qqmlextensionplugin.h>
+
 #include "control/controlsortfiltermodel.h"
 #include "moc_qmlapplication.cpp"
 #include "qml/asyncimageprovider.h"
@@ -16,6 +18,7 @@
 #include "qml/qmlvisibleeffectsmodel.h"
 #include "qml/qmlwaveformoverview.h"
 #include "soundio/soundmanager.h"
+Q_IMPORT_QML_PLUGIN(Mixxx_ControlsPlugin)
 
 namespace {
 const QString kMainQmlFileName = QStringLiteral("qml/main.qml");
@@ -72,110 +75,13 @@ QmlApplication::QmlApplication(
     // system, which would improve nothing, or we had to expose them as
     // singletons to that they can be accessed by components instantiated by
     // QML, which would also be suboptimal.
-    //
-    // WARNING: The lambdas passed to qmlRegisterSingletonType outlive this
-    // QmlApplication. Therefore they *must not* capture any pointers which
-    // they share ownership of. Otherwise, the values captured by the lambdas
-    // would be destroyed after CoreServices and after the Qt event loop stops
-    // processing. To work around this, pass weak_ptrs into the lambdas and
-    // convert them to shared_ptrs when the QQmlApplicationEngine instantiates
-    // the QML proxy objects.
-
-    qmlRegisterSingletonType<QmlDlgPreferencesProxy>("Mixxx",
-            0,
-            1,
-            "PreferencesDialog",
-            lambda_to_singleton_type_factory_ptr(
-                    [pDlgPreferences = std::weak_ptr<DlgPreferences>(
-                             m_pDlgPreferences)](QQmlEngine* pEngine,
-                            QJSEngine* pScriptEngine) -> QObject* {
-                        Q_UNUSED(pScriptEngine);
-                        return new QmlDlgPreferencesProxy(pDlgPreferences.lock(), pEngine);
-                    }));
-
-    qmlRegisterType<QmlControlProxy>("Mixxx", 0, 1, "ControlProxy");
-    qmlRegisterType<ControlSortFilterModel>("Mixxx", 0, 1, "ControlSortFilterModel");
-    qmlRegisterType<QmlWaveformOverview>("Mixxx", 0, 1, "WaveformOverview");
-
-    qmlRegisterSingletonType<QmlEffectsManagerProxy>("Mixxx",
-            0,
-            1,
-            "EffectsManager",
-            lambda_to_singleton_type_factory_ptr(
-                    [pEffectsManager = std::weak_ptr<EffectsManager>(
-                             pCoreServices->getEffectsManager())](
-                            QQmlEngine* pEngine,
-                            QJSEngine* pScriptEngine) -> QObject* {
-                        Q_UNUSED(pScriptEngine);
-                        return new QmlEffectsManagerProxy(pEffectsManager.lock(), pEngine);
-                    }));
-    qmlRegisterUncreatableType<QmlVisibleEffectsModel>("Mixxx",
-            0,
-            1,
-            "VisibleEffectsModel",
-            "VisibleEffectsModel objects can't be created directly, please use "
-            "Mixxx.EffectsManager.visibleEffectsModel");
-    qmlRegisterUncreatableType<QmlEffectManifestParametersModel>("Mixxx",
-            0,
-            1,
-            "EffectManifestParametersModel",
-            "EffectManifestParametersModel objects can't be created directly, "
-            "please use Mixxx.EffectsSlot.parametersModel");
-    qmlRegisterUncreatableType<QmlEffectSlotProxy>("Mixxx",
-            0,
-            1,
-            "EffectSlotProxy",
-            "EffectSlotProxy objects can't be created directly, please use "
-            "Mixxx.EffectsManager.getEffectSlot(rackNumber, unitNumber, effectNumber)");
-
-    qmlRegisterSingletonType<QmlPlayerManagerProxy>("Mixxx",
-            0,
-            1,
-            "PlayerManager",
-            lambda_to_singleton_type_factory_ptr(
-                    [pPlayerManager = std::weak_ptr<PlayerManager>(
-                             pCoreServices->getPlayerManager())](
-                            QQmlEngine* pEngine,
-                            QJSEngine* pScriptEngine) -> QObject* {
-                        Q_UNUSED(pScriptEngine);
-                        return new QmlPlayerManagerProxy(pPlayerManager.lock(), pEngine);
-                    }));
-    qmlRegisterUncreatableType<QmlPlayerProxy>("Mixxx",
-            0,
-            1,
-            "Player",
-            "Player objects can't be created directly, please use "
-            "Mixxx.PlayerManager.getPlayer(group)");
-
-    qmlRegisterSingletonType<QmlConfigProxy>("Mixxx",
-            0,
-            1,
-            "Config",
-            lambda_to_singleton_type_factory_ptr(
-                    [pSettings = QWeakPointer(pCoreServices->getSettings())](
-                            QQmlEngine* pEngine,
-                            QJSEngine* pScriptEngine) -> QObject* {
-                        Q_UNUSED(pScriptEngine);
-                        return new QmlConfigProxy(pSettings, pEngine);
-                    }));
-
-    qmlRegisterUncreatableType<QmlLibraryTrackListModel>("Mixxx",
-            0,
-            1,
-            "LibraryTrackListModel",
-            "LibraryTrackListModel objects can't be created directly, "
-            "please use Mixxx.Library.model");
-    qmlRegisterSingletonType<QmlLibraryProxy>("Mixxx",
-            0,
-            1,
-            "Library",
-            lambda_to_singleton_type_factory_ptr(
-                    [pLibrary = std::weak_ptr<Library>(
-                             pCoreServices->getLibrary())](QQmlEngine* pEngine,
-                            QJSEngine* pScriptEngine) -> QObject* {
-                        Q_UNUSED(pScriptEngine);
-                        return new QmlLibraryProxy(pLibrary.lock(), pEngine);
-                    }));
+    QmlDlgPreferencesProxy::s_pInstance = new QmlDlgPreferencesProxy(m_pDlgPreferences, this);
+    QmlEffectsManagerProxy::s_pInstance = new QmlEffectsManagerProxy(
+            pCoreServices->getEffectsManager(), this);
+    QmlPlayerManagerProxy::s_pInstance =
+            new QmlPlayerManagerProxy(pCoreServices->getPlayerManager(), this);
+    QmlConfigProxy::s_pInstance = new QmlConfigProxy(pCoreServices->getSettings(), this);
+    QmlLibraryProxy::s_pInstance = new QmlLibraryProxy(pCoreServices->getLibrary(), this);
 
     loadQml(m_mainFilePath);
 
@@ -191,7 +97,7 @@ void QmlApplication::loadQml(const QString& path) {
     m_pAppEngine = std::make_unique<QQmlApplicationEngine>();
 
     const QFileInfo fileInfo(path);
-    m_pAppEngine->addImportPath(fileInfo.absoluteDir().absolutePath());
+    m_pAppEngine->addImportPath(QStringLiteral(":/mixxx.org/imports"));
 
     // No memory leak here, the QQmlEngine takes ownership of the provider
     QQuickAsyncImageProvider* pImageProvider = new AsyncImageProvider();

--- a/src/qml/qmlconfigproxy.cpp
+++ b/src/qml/qmlconfigproxy.cpp
@@ -30,5 +30,33 @@ QVariantList QmlConfigProxy::getTrackColorPalette() {
     return paletteToQColorList(colorPaletteSettings.getTrackColorPalette());
 }
 
+// static
+QmlConfigProxy* QmlConfigProxy::create(QQmlEngine* pQmlEngine, QJSEngine* pJsEngine) {
+    Q_UNUSED(pQmlEngine);
+
+    // The implementation of this method is mostly taken from the code example
+    // that shows the replacement for `qmlRegisterSingletonInstance()` when
+    // using `QML_SINGLETON`.
+    // https://doc.qt.io/qt-6/qqmlengine.html#QML_SINGLETON
+
+    // The instance has to exist before it is used. We cannot replace it.
+    DEBUG_ASSERT(s_pInstance);
+
+    // The engine has to have the same thread affinity as the singleton.
+    DEBUG_ASSERT(pJsEngine->thread() == s_pInstance->thread());
+
+    // There can only be one engine accessing the singleton.
+    if (s_pJsEngine) {
+        DEBUG_ASSERT(pJsEngine == s_pJsEngine);
+    } else {
+        s_pJsEngine = pJsEngine;
+    }
+
+    // Explicitly specify C++ ownership so that the engine doesn't delete
+    // the instance.
+    QJSEngine::setObjectOwnership(s_pInstance, QJSEngine::CppOwnership);
+    return s_pInstance;
+}
+
 } // namespace qml
 } // namespace mixxx

--- a/src/qml/qmlconfigproxy.h
+++ b/src/qml/qmlconfigproxy.h
@@ -2,6 +2,7 @@
 #include <QColor>
 #include <QObject>
 #include <QVariantList>
+#include <QtQml>
 
 #include "preferences/usersettings.h"
 
@@ -10,6 +11,8 @@ namespace qml {
 
 class QmlConfigProxy : public QObject {
     Q_OBJECT
+    QML_NAMED_ELEMENT(Config)
+    QML_SINGLETON
   public:
     explicit QmlConfigProxy(
             UserSettingsPointer pConfig,
@@ -18,7 +21,11 @@ class QmlConfigProxy : public QObject {
     Q_INVOKABLE QVariantList getHotcueColorPalette();
     Q_INVOKABLE QVariantList getTrackColorPalette();
 
+    static QmlConfigProxy* create(QQmlEngine* pQmlEngine, QJSEngine* pJsEngine);
+    static inline QmlConfigProxy* s_pInstance = nullptr;
+
   private:
+    static inline QJSEngine* s_pJsEngine = nullptr;
     const UserSettingsPointer m_pConfig;
 };
 

--- a/src/qml/qmlcontrolproxy.h
+++ b/src/qml/qmlcontrolproxy.h
@@ -22,6 +22,7 @@ class QmlControlProxy : public QObject, public QQmlParserStatus {
     Q_PROPERTY(bool initialized READ isInitialized NOTIFY initializedChanged)
     Q_PROPERTY(double value READ getValue WRITE setValue NOTIFY valueChanged)
     Q_PROPERTY(double parameter READ getParameter WRITE setParameter NOTIFY parameterChanged)
+    QML_NAMED_ELEMENT(ControlProxy)
 
   public:
     explicit QmlControlProxy(QObject* parent = nullptr);

--- a/src/qml/qmldlgpreferencesproxy.cpp
+++ b/src/qml/qmldlgpreferencesproxy.cpp
@@ -13,5 +13,34 @@ void QmlDlgPreferencesProxy::show() {
     m_pDlgPreferences->show();
 }
 
+// static
+QmlDlgPreferencesProxy* QmlDlgPreferencesProxy::create(
+        QQmlEngine* pQmlEngine, QJSEngine* pJsEngine) {
+    Q_UNUSED(pQmlEngine);
+
+    // The implementation of this method is mostly taken from the code example
+    // that shows the replacement for `qmlRegisterSingletonInstance()` when
+    // using `QML_SINGLETON`.
+    // https://doc.qt.io/qt-6/qqmlengine.html#QML_SINGLETON
+
+    // The instance has to exist before it is used. We cannot replace it.
+    DEBUG_ASSERT(s_pInstance);
+
+    // The engine has to have the same thread affinity as the singleton.
+    DEBUG_ASSERT(pJsEngine->thread() == s_pInstance->thread());
+
+    // There can only be one engine accessing the singleton.
+    if (s_pJsEngine) {
+        DEBUG_ASSERT(pJsEngine == s_pJsEngine);
+    } else {
+        s_pJsEngine = pJsEngine;
+    }
+
+    // Explicitly specify C++ ownership so that the engine doesn't delete
+    // the instance.
+    QJSEngine::setObjectOwnership(s_pInstance, QJSEngine::CppOwnership);
+    return s_pInstance;
+}
+
 } // namespace qml
 } // namespace mixxx

--- a/src/qml/qmldlgpreferencesproxy.h
+++ b/src/qml/qmldlgpreferencesproxy.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <QObject>
+#include <QtQml>
+#include <memory>
 
 #include "preferences/dialog/dlgpreferences.h"
 
@@ -8,6 +10,8 @@ namespace qml {
 
 class QmlDlgPreferencesProxy : public QObject {
     Q_OBJECT
+    QML_NAMED_ELEMENT(PreferencesDialog)
+    QML_SINGLETON
   public:
     explicit QmlDlgPreferencesProxy(
             std::shared_ptr<DlgPreferences> pDlgPreferences,
@@ -15,7 +19,11 @@ class QmlDlgPreferencesProxy : public QObject {
 
     Q_INVOKABLE void show();
 
+    static QmlDlgPreferencesProxy* create(QQmlEngine* pQmlEngine, QJSEngine* pJsEngine);
+    static inline QmlDlgPreferencesProxy* s_pInstance = nullptr;
+
   private:
+    static inline QJSEngine* s_pJsEngine = nullptr;
     std::shared_ptr<DlgPreferences> m_pDlgPreferences;
 };
 

--- a/src/qml/qmleffectmanifestparametersmodel.h
+++ b/src/qml/qmleffectmanifestparametersmodel.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <QAbstractListModel>
+#include <QtQml>
 #include <memory>
 
 #include "effects/effectsmanager.h"
@@ -9,6 +10,8 @@ namespace qml {
 
 class QmlEffectManifestParametersModel : public QAbstractListModel {
     Q_OBJECT
+    QML_NAMED_ELEMENT(EffectManifestParametersModel)
+    QML_UNCREATABLE("Only accessible via Mixxx.EffectSlot.parametersModel")
   public:
     enum Roles {
         IdRole = Qt::UserRole + 1,

--- a/src/qml/qmleffectslotproxy.h
+++ b/src/qml/qmleffectslotproxy.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <QObject>
+#include <QtQml>
 
 #include "effects/effectsmanager.h"
 
@@ -17,6 +18,11 @@ class QmlEffectSlotProxy : public QObject {
     Q_PROPERTY(QString effectId READ getEffectId WRITE setEffectId NOTIFY effectIdChanged)
     Q_PROPERTY(mixxx::qml::QmlEffectManifestParametersModel* parametersModel
                     READ getParametersModel NOTIFY parametersModelChanged)
+    QML_NAMED_ELEMENT(EffectSlotProxy)
+    QML_UNCREATABLE(
+            "Only accessible via "
+            "Mixxx.EffectsManager.getEffectSlot(rackNumber, unitNumber, "
+            "effectNumber)");
 
   public:
     explicit QmlEffectSlotProxy(

--- a/src/qml/qmleffectsmanagerproxy.cpp
+++ b/src/qml/qmleffectsmanagerproxy.cpp
@@ -45,5 +45,34 @@ QmlEffectSlotProxy* QmlEffectsManagerProxy::getEffectSlot(int unitNumber, int ef
     return pEffectSlotProxy;
 }
 
+// static
+QmlEffectsManagerProxy* QmlEffectsManagerProxy::create(
+        QQmlEngine* pQmlEngine, QJSEngine* pJsEngine) {
+    Q_UNUSED(pQmlEngine);
+
+    // The implementation of this method is mostly taken from the code example
+    // that shows the replacement for `qmlRegisterSingletonInstance()` when
+    // using `QML_SINGLETON`.
+    // https://doc.qt.io/qt-6/qqmlengine.html#QML_SINGLETON
+
+    // The instance has to exist before it is used. We cannot replace it.
+    DEBUG_ASSERT(s_pInstance);
+
+    // The engine has to have the same thread affinity as the singleton.
+    DEBUG_ASSERT(pJsEngine->thread() == s_pInstance->thread());
+
+    // There can only be one engine accessing the singleton.
+    if (s_pJsEngine) {
+        DEBUG_ASSERT(pJsEngine == s_pJsEngine);
+    } else {
+        s_pJsEngine = pJsEngine;
+    }
+
+    // Explicitly specify C++ ownership so that the engine doesn't delete
+    // the instance.
+    QJSEngine::setObjectOwnership(s_pInstance, QJSEngine::CppOwnership);
+    return s_pInstance;
+}
+
 } // namespace qml
 } // namespace mixxx

--- a/src/qml/qmleffectsmanagerproxy.h
+++ b/src/qml/qmleffectsmanagerproxy.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <QObject>
+#include <QtQml>
 
 #include "effects/effectsmanager.h"
 #include "qml/qmlvisibleeffectsmodel.h"
@@ -13,6 +14,8 @@ class QmlEffectsManagerProxy : public QObject {
     Q_OBJECT
     Q_PROPERTY(mixxx::qml::QmlVisibleEffectsModel* visibleEffectsModel
                     MEMBER m_pVisibleEffectsModel CONSTANT);
+    QML_NAMED_ELEMENT(EffectsManager)
+    QML_SINGLETON
 
   public:
     explicit QmlEffectsManagerProxy(
@@ -22,7 +25,11 @@ class QmlEffectsManagerProxy : public QObject {
     Q_INVOKABLE mixxx::qml::QmlEffectSlotProxy* getEffectSlot(
             int unitNumber, int effectNumber) const;
 
+    static QmlEffectsManagerProxy* create(QQmlEngine* pQmlEngine, QJSEngine* pJsEngine);
+    static inline QmlEffectsManagerProxy* s_pInstance = nullptr;
+
   private:
+    static inline QJSEngine* s_pJsEngine = nullptr;
     const std::shared_ptr<EffectsManager> m_pEffectsManager;
     QmlVisibleEffectsModel* m_pVisibleEffectsModel;
 };

--- a/src/qml/qmllibraryproxy.cpp
+++ b/src/qml/qmllibraryproxy.cpp
@@ -13,5 +13,33 @@ QmlLibraryProxy::QmlLibraryProxy(std::shared_ptr<Library> pLibrary, QObject* par
           m_pModelProperty(new QmlLibraryTrackListModel(m_pLibrary->trackTableModel(), this)) {
 }
 
+// static
+QmlLibraryProxy* QmlLibraryProxy::create(QQmlEngine* pQmlEngine, QJSEngine* pJsEngine) {
+    Q_UNUSED(pQmlEngine);
+
+    // The implementation of this method is mostly taken from the code example
+    // that shows the replacement for `qmlRegisterSingletonInstance()` when
+    // using `QML_SINGLETON`.
+    // https://doc.qt.io/qt-6/qqmlengine.html#QML_SINGLETON
+
+    // The instance has to exist before it is used. We cannot replace it.
+    DEBUG_ASSERT(s_pInstance);
+
+    // The engine has to have the same thread affinity as the singleton.
+    DEBUG_ASSERT(pJsEngine->thread() == s_pInstance->thread());
+
+    // There can only be one engine accessing the singleton.
+    if (s_pJsEngine) {
+        DEBUG_ASSERT(pJsEngine == s_pJsEngine);
+    } else {
+        s_pJsEngine = pJsEngine;
+    }
+
+    // Explicitly specify C++ ownership so that the engine doesn't delete
+    // the instance.
+    QJSEngine::setObjectOwnership(s_pInstance, QJSEngine::CppOwnership);
+    return s_pInstance;
+}
+
 } // namespace qml
 } // namespace mixxx

--- a/src/qml/qmllibraryproxy.h
+++ b/src/qml/qmllibraryproxy.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <QObject>
+#include <QtQml>
 #include <memory>
 
 #include "qml/qmllibrarytracklistmodel.h"
@@ -15,11 +16,17 @@ class QmlLibraryTrackListModel;
 class QmlLibraryProxy : public QObject {
     Q_OBJECT
     Q_PROPERTY(mixxx::qml::QmlLibraryTrackListModel* model MEMBER m_pModelProperty CONSTANT)
+    QML_NAMED_ELEMENT(Library)
+    QML_SINGLETON
 
   public:
     explicit QmlLibraryProxy(std::shared_ptr<Library> pLibrary, QObject* parent = nullptr);
 
+    static QmlLibraryProxy* create(QQmlEngine* pQmlEngine, QJSEngine* pJsEngine);
+    static inline QmlLibraryProxy* s_pInstance = nullptr;
+
   private:
+    static inline QJSEngine* s_pJsEngine = nullptr;
     std::shared_ptr<Library> m_pLibrary;
 
     /// This needs to be a plain pointer because it's used as a `Q_PROPERTY` member variable.

--- a/src/qml/qmllibrarytracklistmodel.h
+++ b/src/qml/qmllibrarytracklistmodel.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <QIdentityProxyModel>
+#include <QtQml>
 
 class LibraryTableModel;
 
@@ -8,6 +9,9 @@ namespace qml {
 
 class QmlLibraryTrackListModel : public QIdentityProxyModel {
     Q_OBJECT
+    QML_NAMED_ELEMENT(LibraryTrackListModel)
+    QML_UNCREATABLE("Only accessible via Mixxx.Library.model")
+
   public:
     enum Roles {
         TitleRole = Qt::UserRole,

--- a/src/qml/qmlplayermanagerproxy.cpp
+++ b/src/qml/qmlplayermanagerproxy.cpp
@@ -58,5 +58,33 @@ void QmlPlayerManagerProxy::loadLocationToPlayer(
     m_pPlayerManager->slotLoadLocationToPlayer(location, group, play);
 }
 
+// static
+QmlPlayerManagerProxy* QmlPlayerManagerProxy::create(QQmlEngine* pQmlEngine, QJSEngine* pJsEngine) {
+    Q_UNUSED(pQmlEngine);
+
+    // The implementation of this method is mostly taken from the code example
+    // that shows the replacement for `qmlRegisterSingletonInstance()` when
+    // using `QML_SINGLETON`.
+    // https://doc.qt.io/qt-6/qqmlengine.html#QML_SINGLETON
+
+    // The instance has to exist before it is used. We cannot replace it.
+    DEBUG_ASSERT(s_pInstance);
+
+    // The engine has to have the same thread affinity as the singleton.
+    DEBUG_ASSERT(pJsEngine->thread() == s_pInstance->thread());
+
+    // There can only be one engine accessing the singleton.
+    if (s_pJsEngine) {
+        DEBUG_ASSERT(pJsEngine == s_pJsEngine);
+    } else {
+        s_pJsEngine = pJsEngine;
+    }
+
+    // Explicitly specify C++ ownership so that the engine doesn't delete
+    // the instance.
+    QJSEngine::setObjectOwnership(s_pInstance, QJSEngine::CppOwnership);
+    return s_pInstance;
+}
+
 } // namespace qml
 } // namespace mixxx

--- a/src/qml/qmlplayermanagerproxy.h
+++ b/src/qml/qmlplayermanagerproxy.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <QObject>
 #include <QString>
+#include <QtQml>
 
 #include "mixer/playermanager.h"
 
@@ -9,6 +10,8 @@ namespace qml {
 
 class QmlPlayerManagerProxy : public QObject {
     Q_OBJECT
+    QML_NAMED_ELEMENT(PlayerManager)
+    QML_SINGLETON
   public:
     explicit QmlPlayerManagerProxy(
             std::shared_ptr<PlayerManager> pPlayerManager,
@@ -21,7 +24,11 @@ class QmlPlayerManagerProxy : public QObject {
     Q_INVOKABLE void loadLocationToPlayer(
             const QString& location, const QString& group, bool play = false);
 
+    static QmlPlayerManagerProxy* create(QQmlEngine* pQmlEngine, QJSEngine* pJsEngine);
+    static inline QmlPlayerManagerProxy* s_pInstance = nullptr;
+
   private:
+    static inline QJSEngine* s_pJsEngine = nullptr;
     const std::shared_ptr<PlayerManager> m_pPlayerManager;
 };
 

--- a/src/qml/qmlplayerproxy.h
+++ b/src/qml/qmlplayerproxy.h
@@ -1,8 +1,10 @@
+#pragma once
 #include <QColor>
 #include <QObject>
 #include <QPointer>
 #include <QString>
 #include <QUrl>
+#include <QtQml>
 
 #include "mixer/basetrackplayer.h"
 #include "track/track.h"
@@ -29,6 +31,8 @@ class QmlPlayerProxy : public QObject {
     Q_PROPERTY(QColor color READ getColor WRITE setColor NOTIFY colorChanged)
     Q_PROPERTY(QUrl coverArtUrl READ getCoverArtUrl NOTIFY coverArtUrlChanged)
     Q_PROPERTY(QUrl trackLocationUrl READ getTrackLocationUrl NOTIFY trackLocationUrlChanged)
+    QML_NAMED_ELEMENT(Player)
+    QML_UNCREATABLE("Only accessible via Mixxx.PlayerManager.getPlayer(group)")
 
   public:
     explicit QmlPlayerProxy(BaseTrackPlayer* pTrackPlayer, QObject* parent = nullptr);

--- a/src/qml/qmlvisibleeffectsmodel.h
+++ b/src/qml/qmlvisibleeffectsmodel.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <QAbstractListModel>
+#include <QtQml>
 #include <memory>
 
 #include "effects/effectsmanager.h"
@@ -9,6 +10,8 @@ namespace qml {
 
 class QmlVisibleEffectsModel : public QAbstractListModel {
     Q_OBJECT
+    QML_NAMED_ELEMENT(VisibleEffectsModel)
+    QML_UNCREATABLE("Only accessible via Mixxx.EffectsManager.visibleEffectsModel")
   public:
     enum Roles {
         EffectIdRole = Qt::UserRole + 1,

--- a/src/qml/qmlwaveformoverview.h
+++ b/src/qml/qmlwaveformoverview.h
@@ -23,6 +23,7 @@ class QmlWaveformOverview : public QQuickPaintedItem {
     Q_PROPERTY(QColor colorHigh MEMBER m_colorHigh NOTIFY colorHighChanged)
     Q_PROPERTY(QColor colorMid MEMBER m_colorMid NOTIFY colorMidChanged)
     Q_PROPERTY(QColor colorLow MEMBER m_colorLow NOTIFY colorLowChanged)
+    QML_NAMED_ELEMENT(WaveformOverview)
 
   public:
     enum class ChannelFlag : int {

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -189,12 +189,6 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
                             : QString());
     parser.addOption(developer);
 
-    const QCommandLineOption qml(QStringLiteral("qml"),
-            forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
-                                      "Loads experimental QML GUI instead of legacy QWidget skin")
-                            : QString());
-    parser.addOption(qml);
-
     const QCommandLineOption safeMode(QStringLiteral("safe-mode"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Enables safe-mode. Disables OpenGL waveforms, and "
@@ -327,7 +321,6 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
 
     m_controllerDebug = parser.isSet(controllerDebug) || parser.isSet(controllerDebugDeprecated);
     m_developer = parser.isSet(developer);
-    m_qml = parser.isSet(qml);
     m_safeMode = parser.isSet(safeMode) || parser.isSet(safeModeDeprecated);
     m_debugAssertBreak = parser.isSet(debugAssertBreak) || parser.isSet(debugAssertBreakDeprecated);
 

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -35,9 +35,6 @@ class CmdlineArgs final {
         return m_controllerDebug;
     }
     bool getDeveloper() const { return m_developer; }
-    bool getQml() const {
-        return m_qml;
-    }
     bool getSafeMode() const { return m_safeMode; }
     bool useColors() const {
         return m_useColors;
@@ -74,7 +71,6 @@ class CmdlineArgs final {
     bool m_startInFullscreen;       // Start in fullscreen mode
     bool m_controllerDebug;
     bool m_developer; // Developer Mode
-    bool m_qml;
     bool m_safeMode;
     bool m_debugAssertBreak;
     bool m_settingsPathSet; // has --settingsPath been set on command line ?


### PR DESCRIPTION
Please see the individual commit messages for details.

**Note:** This makes QML Qt6-only because the qml type registration changed considerably since Qt 5.12.