### PR TITLE
Update changelog with bugfix for Traktor S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Don't wipe sound config during startup if configured devices are unavailable [#4544](https://github.com/mixxxdj/mixxx/pull/4544)
 * Append selected file extension when exporting to playlist files [#4531](https://github.com/mixxxdj/mixxx/pull/4531) [lp:1889352](https://bugs.launchpad.net/mixxx/+bug/1889352)
 * Fix crash when using midi.sendShortMsg and platform vnc [#4635](https://github.com/mixxxdj/mixxx/pull/4635) [lp:1956144](https://bugs.launchpad.net/mixxx/+bug/1956144)
+* Traktor S3: Fix timedelta calculation bugs [#4646](https://github.com/mixxxdj/mixxx/pull/4646) [lp:1958925](https://bugs.launchpad.net/mixxx/+bug/1958925)
 
 ### Packaging
 

--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -150,6 +150,11 @@
    #4635
    lp:1956144
   </li>
+  <li>
+   Traktor S3: Fix timedelta calculation bugs
+   #4646
+   lp:1958925
+  </li>
  </ul>
  <p>
   Packaging


### PR DESCRIPTION
One last changelog entry ..

We have already release candidates: 
https://downloads.mixxx.org/snapshots/2.3/mixxx-2.3.1-53-g69edad9c6b-win64.msi
https://downloads.mixxx.org/snapshots/2.3/mixxx-2.3.1-53-g69edad9c6b-macosintel.dmg
https://launchpad.net/~mixxx/+archive/ubuntu/mixxxbetas

We need a smoke test for all our targets and the we can tag the branch and continue publishing 2.3 

