### PR TITLE
QML: Mark required properties as such

### DIFF
--- a/res/qml/AuxiliaryUnit.qml
+++ b/res/qml/AuxiliaryUnit.qml
@@ -5,7 +5,7 @@ import "Theme"
 Row {
     id: root
 
-    property int unitNumber // required
+    required property int unitNumber
     property string group: "[Auxiliary" + unitNumber + "]"
 
     spacing: 5

--- a/res/qml/Button.qml
+++ b/res/qml/Button.qml
@@ -7,7 +7,7 @@ AbstractButton {
     id: root
 
     property color normalColor: Theme.buttonNormalColor
-    property color activeColor // required
+    required property color activeColor
     property color pressedColor: activeColor
     property bool highlight: false
 

--- a/res/qml/ComboBox.qml
+++ b/res/qml/ComboBox.qml
@@ -12,9 +12,11 @@ ComboBox {
     delegate: ItemDelegate {
         id: itemDlgt
 
+        required property int index
+
         width: parent.width
-        highlighted: root.highlightedIndex === index
-        text: root.textAt(index)
+        highlighted: root.highlightedIndex === this.index
+        text: root.textAt(this.index)
 
         contentItem: Text {
             text: itemDlgt.text

--- a/res/qml/ControlButton.qml
+++ b/res/qml/ControlButton.qml
@@ -4,8 +4,8 @@ import Mixxx 0.1 as Mixxx
 Skin.Button {
     id: root
 
-    property string group // required
-    property string key // required
+    required property string group
+    required property string key
     property bool toggleable: false
 
     function toggle() {

--- a/res/qml/CrossfaderRow.qml
+++ b/res/qml/CrossfaderRow.qml
@@ -5,7 +5,7 @@ import "Theme"
 Item {
     id: root
 
-    property real crossfaderWidth // required
+    required property real crossfaderWidth
 
     implicitHeight: crossfader.height
 

--- a/res/qml/Deck.qml
+++ b/res/qml/Deck.qml
@@ -6,7 +6,7 @@ import "Theme"
 Item {
     id: root
 
-    property string group // required
+    required property string group
     property bool minimized: false
     property var deckPlayer: Mixxx.PlayerManager.getPlayer(group)
 
@@ -344,15 +344,9 @@ Item {
                 model: 8
 
                 Skin.HotcueButton {
-                    // TODO: Once we require Qt >= 5.14, we're going to re-add
-                    // the `required` keyword. If the component has any
-                    // required properties, we'll stumble over a Qt bug and
-                    // need the following workaround:
-                    //     required property int index
-                    // See this for details:
-                    // https://bugreports.qt.io/browse/QTBUG-86009, and need
+                    required property int index
 
-                    hotcueNumber: index + 1
+                    hotcueNumber: this.index + 1
                     group: root.group
                     width: playButton.height
                     height: playButton.height

--- a/res/qml/DeckInfoBar.qml
+++ b/res/qml/DeckInfoBar.qml
@@ -8,8 +8,8 @@ import "Theme"
 Rectangle {
     id: root
 
-    property string group // required
-    property int rightColumnWidth // required
+    required property string group
+    required property int rightColumnWidth
     property var deckPlayer: Mixxx.PlayerManager.getPlayer(group)
     property color lineColor: Theme.deckLineColor
 

--- a/res/qml/DeckRow.qml
+++ b/res/qml/DeckRow.qml
@@ -3,8 +3,8 @@ import QtQuick 2.12
 Item {
     id: root
 
-    property string leftDeckGroup // required
-    property string rightDeckGroup // required
+    required property string leftDeckGroup
+    required property string rightDeckGroup
     property alias mixer: mixer
     property bool minimized: false
 

--- a/res/qml/DeveloperToolsWindow.qml
+++ b/res/qml/DeveloperToolsWindow.qml
@@ -34,9 +34,14 @@ Window {
             syncView: tableView
 
             delegate: Item {
+                id: headerDlgt
+
+                required property int column
+                required property string display
+
                 implicitHeight: columnName.contentHeight + 5
                 implicitWidth: columnName.contentWidth + 5
-                visible: column < tableView.columnWidths.length
+                visible: this.column < tableView.columnWidths.length
 
                 BorderImage {
                     anchors.fill: parent
@@ -56,7 +61,7 @@ Window {
                 Text {
                     id: columnName
 
-                    text: display
+                    text: headerDlgt.display
                     anchors.fill: parent
                     anchors.margins: 5
                     elide: Text.ElideRight
@@ -73,7 +78,7 @@ Window {
                     id: sortIndicator
 
                     text: controlModel.sortDescending ? "▲" : "▼"
-                    visible: controlModel.sortColumn == column
+                    visible: controlModel.sortColumn == headerDlgt.column
                     anchors.fill: parent
                     anchors.margins: 5
                     elide: Text.ElideRight
@@ -87,7 +92,7 @@ Window {
                 }
 
                 TapHandler {
-                    onTapped: controlModel.toggleSortColumn(column)
+                    onTapped: controlModel.toggleSortColumn(headerDlgt.column)
                 }
 
             }
@@ -127,7 +132,12 @@ Window {
                     column: 0
 
                     delegate: Rectangle {
-                        implicitWidth: (root.width - 10) * tableView.columnWidths[column]
+                        id: groupDelegate
+
+                        required property int column
+                        required property string display
+
+                        implicitWidth: (root.width - 10) * tableView.columnWidths[groupDelegate.column]
                         implicitHeight: groupName.contentHeight
                         color: root.color
 
@@ -135,7 +145,7 @@ Window {
                             id: groupName
 
                             anchors.fill: parent
-                            text: display
+                            text: groupDelegate.display
                             verticalAlignment: Text.AlignVCenter
                             elide: Text.ElideRight
                             color: Theme.deckTextColor
@@ -149,7 +159,12 @@ Window {
                     column: 1
 
                     delegate: Rectangle {
-                        implicitWidth: (root.width - 10) * tableView.columnWidths[column]
+                        id: keyDelegate
+
+                        required property int column
+                        required property string display
+
+                        implicitWidth: (root.width - 10) * tableView.columnWidths[keyDelegate.column]
                         implicitHeight: keyName.contentHeight
                         color: root.color
 
@@ -157,7 +172,7 @@ Window {
                             id: keyName
 
                             anchors.fill: parent
-                            text: display
+                            text: keyDelegate.display
                             verticalAlignment: Text.AlignVCenter
                             elide: Text.ElideRight
                             color: Theme.deckTextColor
@@ -171,7 +186,13 @@ Window {
                     column: 2
 
                     delegate: Rectangle {
-                        implicitWidth: (root.width - 10) * tableView.columnWidths[column]
+                        id: valueDelegate
+
+                        required property int row
+                        required property int column
+                        required property string display
+
+                        implicitWidth: (root.width - 10) * tableView.columnWidths[valueDelegate.column]
                         implicitHeight: valueField.implicitHeight
                         color: root.color
 
@@ -179,10 +200,10 @@ Window {
                             id: valueField
 
                             anchors.fill: parent
-                            text: display
+                            text: valueDelegate.display
                             inputMethodHints: Qt.ImhFormattedNumbersOnly
                             onEditingFinished: {
-                                const idx = controlModel.index(row, column);
+                                const idx = controlModel.index(valueDelegate.row, valueDelegate.column);
                                 controlModel.setData(idx, parseFloat(text));
                             }
                             color: Theme.textColor
@@ -206,7 +227,13 @@ Window {
                     column: 3
 
                     delegate: Rectangle {
-                        implicitWidth: (root.width - 10) * tableView.columnWidths[column]
+                        id: parameterDelegate
+
+                        required property int row
+                        required property int column
+                        required property string display
+
+                        implicitWidth: (root.width - 10) * tableView.columnWidths[parameterDelegate.column]
                         implicitHeight: valueField.implicitHeight
                         color: root.color
 
@@ -214,10 +241,10 @@ Window {
                             id: valueField
 
                             anchors.fill: parent
-                            text: display
+                            text: parameterDelegate.display
                             inputMethodHints: Qt.ImhFormattedNumbersOnly
                             onEditingFinished: {
-                                const idx = controlModel.index(row, column);
+                                const idx = controlModel.index(parameterDelegate.row, parameterDelegate.column);
                                 controlModel.setData(idx, parseFloat(text));
                             }
                             color: Theme.textColor

--- a/res/qml/EffectSlot.qml
+++ b/res/qml/EffectSlot.qml
@@ -7,8 +7,8 @@ Item {
     id: root
 
     property Mixxx.EffectSlotProxy slot: Mixxx.EffectsManager.getEffectSlot(unitNumber, effectNumber)
-    property int unitNumber // required
-    property int effectNumber // required
+    required property int unitNumber
+    required property int effectNumber
     property bool expanded: false
     readonly property string group: slot.group
     property real maxSelectorWidth: 300
@@ -107,10 +107,14 @@ Item {
         delegate: Item {
             id: parameter
 
+            required property int index
+            required property string shortName
+            required property string name
+            required property string controlKey
+            required property int type
             property int number: index + 1
             // TODO: Use null coalescing when we switch to Qt >= 5.15
-            property string label: shortName ? shortName : name
-            property string key: controlKey
+            property string label: shortName ?? name
             property bool isKnob: type == 0
             property bool isButton: type == 1
 
@@ -132,7 +136,7 @@ Item {
                 anchors.centerIn: parent
                 arcStart: 0
                 group: root.group
-                key: parameter.key
+                key: parameter.controlKey
                 color: Theme.effectColor
                 visible: parameter.isKnob
 
@@ -142,7 +146,7 @@ Item {
                     property bool loaded: value != 0
 
                     group: root.group
-                    key: parameter.key + "_loaded"
+                    key: parameter.controlKey + "_loaded"
                 }
 
             }
@@ -154,7 +158,7 @@ Item {
                 width: parent.width
                 anchors.centerIn: parent
                 group: root.group
-                key: parameter.key
+                key: parameter.controlKey
                 activeColor: Theme.effectColor
                 visible: parameter.isButton
                 toggleable: true
@@ -166,7 +170,7 @@ Item {
                     property bool loaded: value != 0
 
                     group: root.group
-                    key: parameter.key + "_loaded"
+                    key: parameter.controlKey + "_loaded"
                 }
 
             }

--- a/res/qml/EffectUnit.qml
+++ b/res/qml/EffectUnit.qml
@@ -5,7 +5,7 @@ import "Theme"
 Item {
     id: root
 
-    property int unitNumber // required
+    required property int unitNumber
 
     implicitHeight: effectContainer.height
 

--- a/res/qml/EqColumn.qml
+++ b/res/qml/EqColumn.qml
@@ -6,7 +6,7 @@ import "Theme"
 Column {
     id: root
 
-    property string group // required
+    required property string group
 
     spacing: 4
 

--- a/res/qml/EqKnob.qml
+++ b/res/qml/EqKnob.qml
@@ -7,8 +7,8 @@ Rectangle {
     id: root
 
     property alias knob: knob
-    property string statusGroup: root.knob.group // required
-    property string statusKey // required
+    property string statusGroup: root.knob.group
+    required property string statusKey
 
     color: Theme.knobBackgroundColor
     width: 56

--- a/res/qml/Hotcue.qml
+++ b/res/qml/Hotcue.qml
@@ -5,8 +5,8 @@ import "Theme"
 Item {
     id: root
 
-    property int hotcueNumber // required
-    property string group // required
+    required property int hotcueNumber
+    required property string group
     property alias activate: hotcueActivateControl.value
     property alias clear: hotcueClearControl.value
     readonly property bool isSet: hotcueStatusControl.value != 0

--- a/res/qml/HotcueButton.qml
+++ b/res/qml/HotcueButton.qml
@@ -4,8 +4,8 @@ import QtQuick 2.12
 Skin.Button {
     id: root
 
-    property int hotcueNumber // required
-    property string group // required
+    required property int hotcueNumber
+    required property string group
 
     text: hotcueNumber
     activeColor: hotcue.color

--- a/res/qml/HotcuePopup.qml
+++ b/res/qml/HotcuePopup.qml
@@ -7,7 +7,7 @@ import "Theme"
 Popup {
     id: root
 
-    property Hotcue hotcue // required
+    required property Hotcue hotcue
 
     dim: false
     modal: true
@@ -26,6 +26,8 @@ Popup {
             model: Mixxx.Config.getHotcueColorPalette()
 
             Rectangle {
+                required property color modelData
+
                 height: 24
                 width: 24
                 color: modelData

--- a/res/qml/InfoBarButton.qml
+++ b/res/qml/InfoBarButton.qml
@@ -7,11 +7,11 @@ import "Theme"
 AbstractButton {
     id: root
 
-    property string group // required
-    property string key // required
+    required property string group
+    required property string key
     property alias foreground: foreground.data
     property color normalColor: Theme.buttonNormalColor
-    property color activeColor // required
+    required property color activeColor
     property color pressedColor: activeColor
     property alias highlight: control.value
 

--- a/res/qml/Knob.qml
+++ b/res/qml/Knob.qml
@@ -5,7 +5,7 @@ import "Theme"
 MixxxControls.Knob {
     id: root
 
-    property color color // required
+    required property color color
     property url shadowSource: Theme.imgKnobShadow
     property url backgroundSource: Theme.imgKnob
 

--- a/res/qml/Library.qml
+++ b/res/qml/Library.qml
@@ -79,15 +79,20 @@ Item {
             }
 
             delegate: Item {
-                id: itemDelegate
+                id: itemDlgt
+
+                required property int index
+                required property url fileUrl
+                required property string artist
+                required property string title
 
                 implicitWidth: listView.width
                 implicitHeight: 30
 
                 Text {
                     anchors.verticalCenter: parent.verticalCenter
-                    text: artist + " - " + title
-                    color: (listView.currentIndex == index && listView.activeFocus) ? Theme.blue : Theme.deckTextColor
+                    text: itemDlgt.artist + " - " + itemDlgt.title
+                    color: (listView.currentIndex == itemDlgt.index && listView.activeFocus) ? Theme.blue : Theme.deckTextColor
 
                     Behavior on color {
                         ColorAnimation {
@@ -105,8 +110,8 @@ Item {
                     Drag.dragType: Drag.Automatic
                     Drag.supportedActions: Qt.CopyAction
                     Drag.mimeData: {
-                        "text/uri-list": fileUrl,
-                        "text/plain": fileUrl
+                        "text/uri-list": itemDlgt.fileUrl,
+                        "text/plain": itemDlgt.fileUrl
                     }
                     anchors.fill: parent
                 }
@@ -118,7 +123,7 @@ Item {
                     drag.target: dragItem
                     onPressed: {
                         listView.forceActiveFocus();
-                        listView.currentIndex = index;
+                        listView.currentIndex = itemDlgt.index;
                         parent.grabToImage((result) => {
                             dragItem.Drag.imageSource = result.url;
                         });

--- a/res/qml/LibraryControl.qml
+++ b/res/qml/LibraryControl.qml
@@ -110,6 +110,8 @@ Item {
         model: numDecksControl.value
 
         delegate: LibraryControlLoadSelectedTrackHandler {
+            required property int index
+
             group: "[Channel" + (index + 1) + "]"
             enabled: root.focusWidget == FocusedWidgetControl.WidgetKind.LibraryView
             onLoadTrackRequested: (play) => {
@@ -130,6 +132,8 @@ Item {
         model: numPreviewDecksControl.value
 
         delegate: LibraryControlLoadSelectedTrackHandler {
+            required property int index
+
             group: "[PreviewDeck" + (index + 1) + "]"
             enabled: root.focusWidget == FocusedWidgetControl.WidgetKind.LibraryView
             onLoadTrackRequested: (play) => {
@@ -150,6 +154,8 @@ Item {
         model: numSamplersControl.value
 
         delegate: LibraryControlLoadSelectedTrackHandler {
+            required property int index
+
             group: "[Sampler" + (index + 1) + "]"
             enabled: root.focusWidget == FocusedWidgetControl.WidgetKind.LibraryView
             onLoadTrackRequested: (play) => {

--- a/res/qml/LibraryControlLoadSelectedTrackHandler.qml
+++ b/res/qml/LibraryControlLoadSelectedTrackHandler.qml
@@ -8,7 +8,7 @@ import QtQuick 2.12
 Item {
     id: root
 
-    property string group // required
+    required property string group
     property bool enabled: true
 
     signal loadTrackRequested(bool play)

--- a/res/qml/MicrophoneUnit.qml
+++ b/res/qml/MicrophoneUnit.qml
@@ -5,7 +5,7 @@ import "Theme"
 Row {
     id: root
 
-    property int unitNumber // required
+    required property int unitNumber
     property string group: unitNumber === 1 ? "[Microphone]" : "[Microphone" + unitNumber + "]"
 
     spacing: 5

--- a/res/qml/Mixer.qml
+++ b/res/qml/Mixer.qml
@@ -4,8 +4,8 @@ import QtQuick 2.12
 Item {
     id: root
 
-    property string leftDeckGroup // required
-    property string rightDeckGroup // required
+    required property string leftDeckGroup
+    required property string rightDeckGroup
     property bool show4decks: false
 
     implicitWidth: content.width + 10

--- a/res/qml/MixerColumn.qml
+++ b/res/qml/MixerColumn.qml
@@ -5,7 +5,7 @@ import "Theme"
 Item {
     id: root
 
-    property string group // required
+    required property string group
 
     Rectangle {
         id: gainKnobFrame

--- a/res/qml/Mixxx/Controls/Spinny.qml
+++ b/res/qml/Mixxx/Controls/Spinny.qml
@@ -5,7 +5,7 @@ import QtQuick.Controls 2.12
 Item {
     id: root
 
-    property string group // required
+    required property string group
     property real rpm: 33
     property bool indicatorVisible: true
     property alias indicator: indicatorContainer.contentItem

--- a/res/qml/Mixxx/Controls/WaveformOverview.qml
+++ b/res/qml/Mixxx/Controls/WaveformOverview.qml
@@ -5,7 +5,7 @@ import QtQuick 2.12
 Mixxx.WaveformOverview {
     id: root
 
-    property string group // required
+    required property string group
 
     player: Mixxx.PlayerManager.getPlayer(root.group)
 
@@ -36,9 +36,11 @@ Mixxx.WaveformOverview {
             model: 8
 
             MixxxControls.WaveformOverviewHotcueMarker {
+                required property int index
+
                 anchors.fill: parent
                 group: root.group
-                hotcueNumber: index + 1
+                hotcueNumber: this.index + 1
             }
 
         }

--- a/res/qml/Mixxx/Controls/WaveformOverviewHotcueMarker.qml
+++ b/res/qml/Mixxx/Controls/WaveformOverviewHotcueMarker.qml
@@ -5,8 +5,8 @@ import QtQuick.Shapes 1.12
 Item {
     id: root
 
-    property string group // required
-    property int hotcueNumber // required
+    required property string group
+    required property int hotcueNumber
 
     function updatePosition() {
         const totalSamples = trackSamplesControl.value;

--- a/res/qml/Mixxx/Controls/WaveformOverviewMarker.qml
+++ b/res/qml/Mixxx/Controls/WaveformOverviewMarker.qml
@@ -6,8 +6,8 @@ import QtQuick.Window 2.12
 Item {
     id: root
 
-    property string group // required
-    property string key // required
+    required property string group
+    required property string key
     property string color: "white"
 
     Shape {

--- a/res/qml/Mixxx/PlayerDropArea.qml
+++ b/res/qml/Mixxx/PlayerDropArea.qml
@@ -3,7 +3,7 @@ import QtQuick 2.12
 
 // Handles drops on decks and samplers
 DropArea {
-    property string group // required
+    required property string group
     property var player: Mixxx.PlayerManager.getPlayer(group)
 
     onDropped: (drop) => {

--- a/res/qml/OrientationToggleButton.qml
+++ b/res/qml/OrientationToggleButton.qml
@@ -5,8 +5,8 @@ import QtQuick 2.12
 Item {
     id: root
 
-    property string group // required
-    property string key // required
+    required property string group
+    required property string key
     property alias orientation: orientationSlider.value
     property color color: "white"
 

--- a/res/qml/Sampler.qml
+++ b/res/qml/Sampler.qml
@@ -6,7 +6,7 @@ import "Theme"
 Rectangle {
     id: root
 
-    property string group // required
+    required property string group
     property bool minimized: false
     property var deckPlayer: Mixxx.PlayerManager.getPlayer(group)
 

--- a/res/qml/SamplerRow.qml
+++ b/res/qml/SamplerRow.qml
@@ -9,6 +9,8 @@ RowLayout {
         model: 8
 
         Skin.Sampler {
+            required property int index
+
             Layout.fillWidth: true
             group: "[Sampler" + (index + 1) + "]"
         }

--- a/res/qml/SyncButton.qml
+++ b/res/qml/SyncButton.qml
@@ -12,7 +12,7 @@ Skin.Button {
         ExplicitLeader
     }
 
-    property string group // required
+    required property string group
     property alias mode: modeControl.value
 
     function toggleSync() {

--- a/res/qml/VuMeter.qml
+++ b/res/qml/VuMeter.qml
@@ -6,9 +6,8 @@ import "Theme"
 Rectangle {
     id: root
 
-    property string group // required
-    property string key // required
-    property color barColor // required
+    required property string group
+    required property string key
 
     radius: width / 2
     color: "black"

--- a/res/qml/WaveformOverview.qml
+++ b/res/qml/WaveformOverview.qml
@@ -7,7 +7,7 @@ import "Theme"
 Item {
     id: root
 
-    property string group // required
+    required property string group
 
     states: [
         State {

--- a/src/qml/qmlcontrolproxy.h
+++ b/src/qml/qmlcontrolproxy.h
@@ -16,8 +16,8 @@ class QmlControlProxy : public QObject, public QQmlParserStatus {
     // TODO: The REQUIRED flag only exists in Qt 5.14 and later. Once we
     // require that as minimum dependency, add it to the group and key
     // properties.
-    Q_PROPERTY(QString group READ getGroup WRITE setGroup NOTIFY groupChanged)
-    Q_PROPERTY(QString key READ getKey WRITE setKey NOTIFY keyChanged)
+    Q_PROPERTY(QString group READ getGroup WRITE setGroup NOTIFY groupChanged REQUIRED)
+    Q_PROPERTY(QString key READ getKey WRITE setKey NOTIFY keyChanged REQUIRED)
     Q_PROPERTY(bool keyValid READ isKeyValid NOTIFY keyValidChanged)
     Q_PROPERTY(bool initialized READ isInitialized NOTIFY initializedChanged)
     Q_PROPERTY(double value READ getValue WRITE setValue NOTIFY valueChanged)

--- a/src/qml/qmlwaveformoverview.h
+++ b/src/qml/qmlwaveformoverview.h
@@ -16,8 +16,8 @@ class QmlPlayerProxy;
 class QmlWaveformOverview : public QQuickPaintedItem {
     Q_OBJECT
     Q_FLAGS(Channels)
-    Q_PROPERTY(mixxx::qml::QmlPlayerProxy* player READ getPlayer
-                    WRITE setPlayer NOTIFY playerChanged)
+    Q_PROPERTY(mixxx::qml::QmlPlayerProxy* player READ getPlayer WRITE setPlayer
+                    NOTIFY playerChanged REQUIRED)
     Q_PROPERTY(Channels channels READ getChannels WRITE setChannels NOTIFY channelsChanged)
     Q_PROPERTY(Renderer renderer MEMBER m_renderer NOTIFY rendererChanged)
     Q_PROPERTY(QColor colorHigh MEMBER m_colorHigh NOTIFY colorHighChanged)

--- a/tools/qmlformat.py
+++ b/tools/qmlformat.py
@@ -45,21 +45,6 @@ def main(argv=None):
     for filename in args.file:
         subprocess.call((qmlformat_executable, "-i", filename))
 
-        # Replace required properties
-        # (incompatible with Qt 5.12)
-        with open(filename, mode="r") as fp:
-            text = fp.read()
-
-        text = re.sub(
-            r"^(\s*)required property (.*)$",
-            r"\g<1>property \g<2> // required",
-            text,
-            flags=re.MULTILINE,
-        )
-
-        with open(filename, mode="w") as fp:
-            fp.write(text)
-
     return 0
 
 


### PR DESCRIPTION
Before, this was postponed because it only works with Qt 5.15+. In #4649 we dropped support for Qt 5.x anyway, so it makes sense to add it.