### PR TITLE
CmdLineArgs: fix settings path format (windows)

### DIFF
--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -133,8 +133,8 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     const QCommandLineOption settingsPath(QStringLiteral("settings-path"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Top-level directory where Mixxx should look for settings. "
-                                      "Default is:") +
-                            getSettingsPath()
+                                      "Default is: ") +
+                            QDir::toNativeSeparators(getSettingsPath())
                             : QString(),
             QStringLiteral("path"));
     QCommandLineOption settingsPathDeprecated(


### PR DESCRIPTION
Added space to prevent odd linebreak
Format getSettingsPath() to match file system

Bug #1917847
Wrong slash direction in mixxx --help on windows