### PR TITLE
Pioneer-DDJ-SB3: fix shift button release

### DIFF
--- a/res/controllers/Pioneer-DDJ-SB3-scripts.js
+++ b/res/controllers/Pioneer-DDJ-SB3-scripts.js
@@ -305,7 +305,6 @@ PioneerDDJSB3.Deck = function(deckNumber) {
         } else {
             theDeck.unshift();
             PioneerDDJSB3.shiftPressed = false;
-            PioneerDDJSB3.headphoneLevel.unshift();
             for (i = 0; i < PioneerDDJSB3.shiftListeners.length; i++) {
                 PioneerDDJSB3.shiftListeners[i](group, false);
             }


### PR DESCRIPTION
The shift button previously called shift() on an object
that has been removed shortly before merging the initial
version. I'm confused why this fault has not been discovered
earlier while testing the mapping.

CC @travstone @jevilalta please test. 