### PR TITLE
Enable qmllint in qt6 builds. 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -144,14 +144,6 @@ repos:
         language: system
         types: [text]
         files: ^.*\.qml$
-      - id: qmllint
-        name: qmllint
-        entry: qmllint
-        pass_filenames: true
-        require_serial: true
-        language: system
-        types: [text]
-        files: ^.*\.qml$
       - id: metainfo
         name: metainfo
         description: Update AppStream metainfo releases from CHANGELOG.md.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2282,6 +2282,9 @@ if(QT6)
   # qt_finalize_target takes care that the resources :/mixxx.org/imports/Mixxx/
   # and :/mixxx.org/imports/Mixxx/Controls are placed into beginning of the binary
   qt_finalize_target(mixxx)
+
+  # Ensure linting runs when building the default "all" target
+  set_target_properties(all_qmllint PROPERTIES EXCLUDE_FROM_ALL FALSE)
 endif()
 
 target_compile_definitions(mixxx-lib PUBLIC QT_TABLET_SUPPORT QT_USE_QSTRINGBUILDER)


### PR DESCRIPTION
I am still struggling to build Mixxx wit Qt 6 on ubuntu focal. 
It turns out that the issues at runtime are with the qml files reported by qmllint. 

Has One an idea how to fix it, or is the failure expected? 