### PR TITLE
Traktor S3: Push two deck switches to explicitly clone decks.

### DIFF
--- a/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
@@ -1803,13 +1803,14 @@ TraktorS3.Controller.prototype.deckSwitchHandler = function(field) {
     if (this.deckSwitchPressed === "") {
         this.deckSwitchPressed = field.group;
     } else {
-        // If a different deck switch is already pressed, do an instant double.
+        // If a different deck switch is already pressed, do an instant double and do not select the
+        // deck.
         var cloneFrom = this.Channels[this.deckSwitchPressed];
         var cloneFromNum = cloneFrom.parentDeck.deckNumber;
         engine.setValue(field.group, "CloneFromDeck", cloneFromNum);
+        return;
     }
 
-    // Always activated pressed deck switch.
     var channel = this.Channels[field.group];
     var deck = channel.parentDeck;
 

--- a/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
@@ -146,6 +146,9 @@ TraktorS3.Controller = function() {
     // If true, channel 4 is in input mode
     this.channel4InputMode = false;
 
+    // Represents the first-pressed deck switch button, used for tracking deck clones.
+    this.deckSwitchPressed = "";
+
     // callbacks
     this.samplerCallbacks = [];
 };
@@ -1791,9 +1794,22 @@ TraktorS3.Controller.prototype.headphoneHandler = function(field) {
 
 TraktorS3.Controller.prototype.deckSwitchHandler = function(field) {
     if (field.value === 0) {
+        if (this.deckSwitchPressed === field.group) {
+            this.deckSwitchPressed = "";
+        }
         return;
     }
 
+    if (this.deckSwitchPressed === "") {
+        this.deckSwitchPressed = field.group;
+    } else {
+        // If a different deck switch is already pressed, do an instant double.
+        var cloneFrom = this.Channels[this.deckSwitchPressed];
+        var cloneFromNum = cloneFrom.parentDeck.deckNumber;
+        engine.setValue(field.group, "CloneFromDeck", cloneFromNum);
+    }
+
+    // Always activated pressed deck switch.
     var channel = this.Channels[field.group];
     var deck = channel.parentDeck;
 


### PR DESCRIPTION
Because the S3 has individual buttons for each deck, deck cloning is as easy as pressing and holding the deck you want to clone from, and tapping the deck you want to copy to.  Manual update: https://github.com/mixxxdj/manual/pull/472