### PR TITLE
Pref EQ: apply & save settings only in slotApply()

### DIFF
--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -165,7 +165,6 @@ void DlgPrefEQ::slotPopulateDeckEffectSelectors() {
     for (QComboBox* box : qAsConst(m_deckEqEffectSelectors)) {
         // Save current selection
         QString selectedEffectId = box->itemData(box->currentIndex()).toString();
-        QString selectedEffectName = box->itemText(box->currentIndex());
         box->clear();
         int currentIndex = -1; // Nothing selected
 
@@ -180,15 +179,9 @@ void DlgPrefEQ::slotPopulateDeckEffectSelectors() {
                 currentIndex = i + 1;
             }
         }
-
-        if (selectedEffectId.isEmpty()) {
-            // Configured effect has no id, clear selection
+        // Select 'None' if the previous EQ was not found in the updated list
+        if (currentIndex < 0) {
             currentIndex = 0;
-        } else if (currentIndex < 0 && !selectedEffectName.isEmpty() ) {
-            // current selection is not part of the new list
-            // So we need to add it
-            box->addItem(selectedEffectName, QVariant(selectedEffectId));
-            currentIndex = i + 1;
         }
         box->setCurrentIndex(currentIndex);
     }
@@ -196,13 +189,11 @@ void DlgPrefEQ::slotPopulateDeckEffectSelectors() {
     for (QComboBox* box : qAsConst(m_deckQuickEffectSelectors)) {
         // Save current selection
         QString selectedEffectId = box->itemData(box->currentIndex()).toString();
-        QString selectedEffectName = box->itemText(box->currentIndex());
         box->clear();
         int currentIndex = -1;// Nothing selected
 
         // Add empty item at the top: no Quick Effect
         box->addItem(EffectsManager::kNoEffectString);
-
         int i;
         // Select the previous QuickEffect if it's available in the updated list
         for (i = 0; i < availableQuickEffects.size(); ++i) {
@@ -212,15 +203,9 @@ void DlgPrefEQ::slotPopulateDeckEffectSelectors() {
                 currentIndex = i + 1;
             }
         }
-
-        if (selectedEffectId.isEmpty()) {
-            // Configured effect has no id, clear selection
+        // Select 'None' if the previous effect was not found in the updated list
+        if (currentIndex < 0) {
             currentIndex = 0;
-        } else if (currentIndex < 0 && !selectedEffectName.isEmpty()) {
-            // current selection is not part of the new list
-            // So we need to add it
-            box->addItem(selectedEffectName, QVariant(selectedEffectId));
-            currentIndex = i + 1;
         }
         box->setCurrentIndex(currentIndex);
     }
@@ -345,13 +330,13 @@ void DlgPrefEQ::slotResetToDefaults() {
     slotMasterEQToDefault();
 
     setDefaultShelves();
-    foreach(QComboBox* pCombo, m_deckEqEffectSelectors) {
-        pCombo->setCurrentIndex(
-               pCombo->findData(kDefaultEqId));
+
+    slotPopulateDeckEffectSelectors();
+    for (QComboBox* box : qAsConst(m_deckEqEffectSelectors)) {
+        box->setCurrentIndex(box->findData(kDefaultEqId));
     }
-    foreach(QComboBox* pCombo, m_deckQuickEffectSelectors) {
-        pCombo->setCurrentIndex(
-               pCombo->findData(kDefaultQuickEffectId));
+    for (QComboBox* box : qAsConst(m_deckQuickEffectSelectors)) {
+        box->setCurrentIndex(box->findData(kDefaultQuickEffectId));
     }
     CheckBoxEqOnly->setChecked(true);
 

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -241,10 +241,6 @@ QUrl DlgPrefEQ::helpUrl() const {
 
 // Load settings from config, except combobxes, update GUI
 void DlgPrefEQ::loadSettings() {
-    QString highEqCourse = m_pConfig->getValueString(ConfigKey(kConfigKey, "HiEQFrequency"));
-    QString highEqPrecise = m_pConfig->getValueString(ConfigKey(kConfigKey, "HiEQFrequencyPrecise"));
-    QString lowEqCourse = m_pConfig->getValueString(ConfigKey(kConfigKey, "LoEQFrequency"));
-    QString lowEqPrecise = m_pConfig->getValueString(ConfigKey(kConfigKey, "LoEQFrequencyPrecise"));
     CheckBoxEqAutoReset->setChecked(static_cast<bool>(
             m_pConfig->getValueString(ConfigKey(kConfigKey, "EqAutoReset"))
                     .toInt()));
@@ -262,6 +258,14 @@ void DlgPrefEQ::loadSettings() {
     slotBypass(CheckBoxBypass->isChecked());
     slotSingleEqChecked(CheckBoxSingleEqEffect->isChecked());
 
+    QString highEqCourse = m_pConfig->getValueString(
+            ConfigKey(kConfigKey, "HiEQFrequency"));
+    QString highEqPrecise = m_pConfig->getValueString(
+            ConfigKey(kConfigKey, "HiEQFrequencyPrecise"));
+    QString lowEqCourse = m_pConfig->getValueString(
+            ConfigKey(kConfigKey, "LoEQFrequency"));
+    QString lowEqPrecise = m_pConfig->getValueString(
+            ConfigKey(kConfigKey, "LoEQFrequencyPrecise"));
     double lowEqFreq = 0.0;
     double highEqFreq = 0.0;
 

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -36,9 +36,7 @@ DlgPrefEQ::DlgPrefEQ(QWidget* pParent, EffectsManager* pEffectsManager, UserSett
           m_highEqFreq(0.0),
           m_pEffectsManager(pEffectsManager),
           m_firstSelectorLabel(nullptr),
-          m_pNumDecks(nullptr),
-          m_bEqAutoReset(false),
-          m_bGainAutoReset(false) {
+          m_pNumDecks(nullptr) {
     m_pEQEffectRack = m_pEffectsManager->getEqualizerRack(0);
     m_pQuickEffectRack = m_pEffectsManager->getQuickEffectRack(0);
     m_pOutputEffectRack = m_pEffectsManager->getOutputsEffectRack();
@@ -287,12 +285,12 @@ void DlgPrefEQ::loadSettings() {
     QString highEqPrecise = m_pConfig->getValueString(ConfigKey(kConfigKey, "HiEQFrequencyPrecise"));
     QString lowEqCourse = m_pConfig->getValueString(ConfigKey(kConfigKey, "LoEQFrequency"));
     QString lowEqPrecise = m_pConfig->getValueString(ConfigKey(kConfigKey, "LoEQFrequencyPrecise"));
-    m_bEqAutoReset = static_cast<bool>(m_pConfig->getValueString(
-            ConfigKey(kConfigKey, "EqAutoReset")).toInt());
-    CheckBoxEqAutoReset->setChecked(m_bEqAutoReset);
-    m_bGainAutoReset = static_cast<bool>(m_pConfig->getValueString(
-            ConfigKey(kConfigKey, "GainAutoReset")).toInt());
-    CheckBoxGainAutoReset->setChecked(m_bGainAutoReset);
+    CheckBoxEqAutoReset->setChecked(static_cast<bool>(
+            m_pConfig->getValueString(ConfigKey(kConfigKey, "EqAutoReset"))
+                    .toInt()));
+    CheckBoxGainAutoReset->setChecked(static_cast<bool>(
+            m_pConfig->getValueString(ConfigKey(kConfigKey, "GainAutoReset"))
+                    .toInt()));
     CheckBoxBypass->setChecked(m_pConfig->getValue(
             ConfigKey(kConfigKey, kEnableEqs), QString("yes")) == "no");
     CheckBoxEqOnly->setChecked(m_pConfig->getValue(
@@ -350,9 +348,7 @@ void DlgPrefEQ::slotResetToDefaults() {
     CheckBoxEqOnly->setChecked(true);
 
     CheckBoxSingleEqEffect->setChecked(true);
-    m_bEqAutoReset = false;
     CheckBoxEqAutoReset->setChecked(false);
-    m_bGainAutoReset = false;
     CheckBoxGainAutoReset->setChecked(false);
     CheckBoxBypass->setChecked(false);
     slotSingleEqChecked(CheckBoxSingleEqEffect->isChecked());
@@ -536,9 +532,9 @@ void DlgPrefEQ::slotApply() {
             ConfigValue(QString::number(m_lowEqFreq, 'f')));
 
     m_pConfig->set(ConfigKey(kConfigKey, "EqAutoReset"),
-            ConfigValue(m_bEqAutoReset ? 1 : 0));
+            ConfigValue(CheckBoxEqAutoReset->isChecked() ? 1 : 0));
     m_pConfig->set(ConfigKey(kConfigKey, "GainAutoReset"),
-            ConfigValue(m_bGainAutoReset ? 1 : 0));
+            ConfigValue(CheckBoxGainAutoReset->isChecked() ? 1 : 0));
     // Note the inversion: GUI label is "Bypass EQs", config key is "EnableEQs"
     m_pConfig->set(ConfigKey(kConfigKey, kEnableEqs),
             CheckBoxBypass->isChecked() ? QString("no") : QString("yes"));
@@ -547,15 +543,6 @@ void DlgPrefEQ::slotApply() {
 // Reload settings and effect selection from config, update GUI
 void DlgPrefEQ::slotUpdate() {
     loadSettings();
-}
-
-
-void DlgPrefEQ::slotUpdateEqAutoReset(int i) {
-    m_bEqAutoReset = static_cast<bool>(i);
-}
-
-void DlgPrefEQ::slotUpdateGainAutoReset(int i) {
-    m_bGainAutoReset = static_cast<bool>(i);
 }
 
 // De/activate EQ controls when Bypass checkbox is toggled

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -391,14 +391,17 @@ void DlgPrefEQ::applySelections() {
         if (need_load) {
             EffectPointer pEffect = m_pEffectsManager->instantiateEffect(effectId);
             m_pEQEffectRack->loadEffectToGroup(group, pEffect);
-            m_pConfig->set(ConfigKey(kConfigKey, "EffectForGroup_" + group),
-                    ConfigValue(effectId));
-            m_filterWaveformEnableCOs[deck]->set(m_pEffectsManager->isEQ(effectId));
-
-            // This is required to remove a previous selected effect that does not
-            // fit to the current ShowAllEffects checkbox
-            slotPopulateDeckEffectSelectors();
         }
+        // Always update config
+        m_pConfig->set(ConfigKey(kConfigKey, "EffectForGroup_" + group),
+                ConfigValue(effectId));
+        m_filterWaveformEnableCOs[deck]->set(
+                !CheckBoxBypass->isChecked() && m_pEffectsManager->isEQ(effectId));
+        // Toggle EQ processing for this deck by setting
+        // "[EqualizerRack1_[ChannelN]_Effect1]", "enabled"
+        QString eqEffectGroup = getEQEffectGroupForDeck(deck);
+        ControlObject::set(ConfigKey(eqEffectGroup, "enabled"),
+                CheckBoxBypass->isChecked() ? 0 : 1);
         ++deck;
     }
 
@@ -435,14 +438,10 @@ void DlgPrefEQ::applySelections() {
         if (need_load) {
             EffectPointer pEffect = m_pEffectsManager->instantiateEffect(effectId);
             m_pQuickEffectRack->loadEffectToGroup(group, pEffect);
-
-            m_pConfig->set(ConfigKey(kConfigKey, "QuickEffectForGroup_" + group),
-                    ConfigValue(effectId));
-
-            // This is required to remove a previous selected effect that does not
-            // fit to the current ShowAllEffects checkbox
-            slotPopulateDeckEffectSelectors();
         }
+        // Always update config
+        m_pConfig->set(ConfigKey(kConfigKey, "QuickEffectForGroup_" + group),
+                ConfigValue(effectId));
         ++deck;
     }
 }

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -112,7 +112,7 @@ void DlgPrefEQ::slotNumDecksChanged(double numDecks) {
 
         if (deckNo == 1) {
             m_firstSelectorLabel = label;
-            if (CheckBoxEqOnly->isChecked()) {
+            if (CheckBoxSingleEqEffect->isChecked()) {
                 m_firstSelectorLabel->clear();
             }
         }

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -16,10 +16,16 @@
 #include "moc_dlgprefeq.cpp"
 #include "util/math.h"
 
-const QString kConfigKey = "[Mixer Profile]";
-const QString kEnableEqs = "EnableEQs";
-const QString kEqsOnly = "EQsOnly";
-const QString kSingleEq = "SingleEQEffect";
+const QString kConfigKey = QStringLiteral("[Mixer Profile]");
+const QString kEnableEqs = QStringLiteral("EnableEQs");
+const QString kEqsOnly = QStringLiteral("EQsOnly");
+const QString kSingleEq = QStringLiteral("SingleEQEffect");
+const QString kEqAutoReset = QStringLiteral("EqAutoReset");
+const QString kGainAutoReset = QStringLiteral("GainAutoReset");
+const QString kLoEqFrequency = QStringLiteral("LoEQFrequency");
+const QString kLoEqFrequencyPrecise = QStringLiteral("LoEQFrequencyPrecise");
+const QString kHiEqFrequency = QStringLiteral("HiEQFrequency");
+const QString kHiEqFrequencyPrecise = QStringLiteral("HiEQFrequencyPrecise");
 const QString kDefaultEqId = BiquadFullKillEQEffect::getId();
 const QString kDefaultMasterEqId = QString();
 const QString kDefaultQuickEffectId = FilterEffect::getId();
@@ -29,8 +35,8 @@ const int kFrequencyLowerLimit = 16;
 
 DlgPrefEQ::DlgPrefEQ(QWidget* pParent, EffectsManager* pEffectsManager, UserSettingsPointer pConfig)
         : DlgPreferencePage(pParent),
-          m_COLoFreq(kConfigKey, "LoEQFrequency"),
-          m_COHiFreq(kConfigKey, "HiEQFrequency"),
+          m_COLoFreq(kConfigKey, kLoEqFrequency),
+          m_COHiFreq(kConfigKey, kHiEqFrequency),
           m_pConfig(pConfig),
           m_lowEqFreq(0.0),
           m_highEqFreq(0.0),
@@ -242,10 +248,10 @@ QUrl DlgPrefEQ::helpUrl() const {
 // Load settings from config, except combobxes, update GUI
 void DlgPrefEQ::loadSettings() {
     CheckBoxEqAutoReset->setChecked(static_cast<bool>(
-            m_pConfig->getValueString(ConfigKey(kConfigKey, "EqAutoReset"))
+            m_pConfig->getValueString(ConfigKey(kConfigKey, kEqAutoReset))
                     .toInt()));
     CheckBoxGainAutoReset->setChecked(static_cast<bool>(
-            m_pConfig->getValueString(ConfigKey(kConfigKey, "GainAutoReset"))
+            m_pConfig->getValueString(ConfigKey(kConfigKey, kGainAutoReset))
                     .toInt()));
     CheckBoxBypass->setChecked(m_pConfig->getValue(
             ConfigKey(kConfigKey, kEnableEqs), QString("yes")) == "no");
@@ -259,13 +265,13 @@ void DlgPrefEQ::loadSettings() {
     slotSingleEqChecked(CheckBoxSingleEqEffect->isChecked());
 
     QString highEqCourse = m_pConfig->getValueString(
-            ConfigKey(kConfigKey, "HiEQFrequency"));
+            ConfigKey(kConfigKey, kHiEqFrequency));
     QString highEqPrecise = m_pConfig->getValueString(
-            ConfigKey(kConfigKey, "HiEQFrequencyPrecise"));
+            ConfigKey(kConfigKey, kHiEqFrequencyPrecise));
     QString lowEqCourse = m_pConfig->getValueString(
-            ConfigKey(kConfigKey, "LoEQFrequency"));
+            ConfigKey(kConfigKey, kLoEqFrequency));
     QString lowEqPrecise = m_pConfig->getValueString(
-            ConfigKey(kConfigKey, "LoEQFrequencyPrecise"));
+            ConfigKey(kConfigKey, kLoEqFrequencyPrecise));
     double lowEqFreq = 0.0;
     double highEqFreq = 0.0;
 
@@ -518,18 +524,18 @@ void DlgPrefEQ::slotApply() {
 
     m_COLoFreq.set(m_lowEqFreq);
     m_COHiFreq.set(m_highEqFreq);
-    m_pConfig->set(ConfigKey(kConfigKey, "HiEQFrequency"),
+    m_pConfig->set(ConfigKey(kConfigKey, kHiEqFrequency),
             ConfigValue(QString::number(static_cast<int>(m_highEqFreq))));
-    m_pConfig->set(ConfigKey(kConfigKey, "HiEQFrequencyPrecise"),
+    m_pConfig->set(ConfigKey(kConfigKey, kHiEqFrequencyPrecise),
             ConfigValue(QString::number(m_highEqFreq, 'f')));
-    m_pConfig->set(ConfigKey(kConfigKey, "LoEQFrequency"),
+    m_pConfig->set(ConfigKey(kConfigKey, kLoEqFrequency),
             ConfigValue(QString::number(static_cast<int>(m_lowEqFreq))));
-    m_pConfig->set(ConfigKey(kConfigKey, "LoEQFrequencyPrecise"),
+    m_pConfig->set(ConfigKey(kConfigKey, kLoEqFrequencyPrecise),
             ConfigValue(QString::number(m_lowEqFreq, 'f')));
 
-    m_pConfig->set(ConfigKey(kConfigKey, "EqAutoReset"),
+    m_pConfig->set(ConfigKey(kConfigKey, kEqAutoReset),
             ConfigValue(CheckBoxEqAutoReset->isChecked() ? 1 : 0));
-    m_pConfig->set(ConfigKey(kConfigKey, "GainAutoReset"),
+    m_pConfig->set(ConfigKey(kConfigKey, kGainAutoReset),
             ConfigValue(CheckBoxGainAutoReset->isChecked() ? 1 : 0));
     // Note the inversion: GUI label is "Bypass EQs", config key is "EnableEQs"
     m_pConfig->set(ConfigKey(kConfigKey, kEnableEqs),

--- a/src/preferences/dialog/dlgprefeq.h
+++ b/src/preferences/dialog/dlgprefeq.h
@@ -23,24 +23,17 @@ class DlgPrefEQ : public DlgPreferencePage, public Ui::DlgPrefEQDlg  {
     QString getQuickEffectGroupForDeck(int deck) const;
 
   public slots:
-    void slotEqEffectChangedOnDeck(int effectIndex);
-    void slotQuickEffectChangedOnDeck(int effectIndex);
     void slotNumDecksChanged(double numDecks);
     void slotSingleEqChecked(int checked);
-    // Slot for toggling between advanced and basic views
     void slotPopulateDeckEffectSelectors();
-    // Update Hi EQ
     void slotUpdateHiEQ();
-    // Update Lo EQ
     void slotUpdateLoEQ();
-    // Apply changes to widget
     void slotApply() override;
     void slotUpdate() override;
     void slotResetToDefaults() override;
     void slotUpdateEqAutoReset(int);
     void slotUpdateGainAutoReset(int);
     void slotBypass(int state);
-    // Update the Master EQ
     void slotUpdateMasterEQParameter(int value);
     void slotMasterEQToDefault();
     void setMasterEQParameter(int i, double value);
@@ -76,8 +69,6 @@ class DlgPrefEQ : public DlgPreferencePage, public Ui::DlgPrefEQDlg  {
     QList<bool> m_filterWaveformEffectLoaded;
     QList<ControlObject*> m_filterWaveformEnableCOs;
     ControlProxy* m_pNumDecks;
-
-    bool m_inSlotPopulateDeckEffectSelectors;
 
     // Members needed for the Master EQ
     QList<QSlider*> m_masterEQSliders;

--- a/src/preferences/dialog/dlgprefeq.h
+++ b/src/preferences/dialog/dlgprefeq.h
@@ -43,6 +43,7 @@ class DlgPrefEQ : public DlgPreferencePage, public Ui::DlgPrefEQDlg  {
 
   private:
     void loadSettings();
+    void loadEffectSelection(int oldDeckCount);
     void setDefaultShelves();
     double getEqFreq(int value, int minimum, int maximum);
     int getSliderPosition(double eqFreq, int minimum, int maximum);
@@ -67,6 +68,7 @@ class DlgPrefEQ : public DlgPreferencePage, public Ui::DlgPrefEQDlg  {
     QList<bool> m_filterWaveformEffectLoaded;
     QList<ControlObject*> m_filterWaveformEnableCOs;
     ControlProxy* m_pNumDecks;
+    int m_numDecks;
 
     // Members needed for the Master EQ
     QList<QSlider*> m_masterEQSliders;

--- a/src/preferences/dialog/dlgprefeq.h
+++ b/src/preferences/dialog/dlgprefeq.h
@@ -31,8 +31,6 @@ class DlgPrefEQ : public DlgPreferencePage, public Ui::DlgPrefEQDlg  {
     void slotApply() override;
     void slotUpdate() override;
     void slotResetToDefaults() override;
-    void slotUpdateEqAutoReset(int);
-    void slotUpdateGainAutoReset(int);
     void slotBypass(int state);
     void slotUpdateMasterEQParameter(int value);
     void slotMasterEQToDefault();
@@ -75,7 +73,4 @@ class DlgPrefEQ : public DlgPreferencePage, public Ui::DlgPrefEQDlg  {
     QList<QLabel*> m_masterEQValues;
     QList<QLabel*> m_masterEQLabels;
     QWeakPointer<Effect> m_pEffectMasterEQ;
-
-    bool m_bEqAutoReset;
-    bool m_bGainAutoReset;
 };

--- a/src/preferences/dialog/dlgprefeqdlg.ui
+++ b/src/preferences/dialog/dlgprefeqdlg.ui
@@ -306,6 +306,52 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="EQMiscOptions">
+     <property name="title">
+      <string>Miscellaneous</string>
+     </property>
+      <layout class="QVBoxLayout" name="miscOptionsLayout" stretch="0,0,0,0">
+       <item>
+        <widget class="QCheckBox" name="CheckBoxEqAutoReset">
+         <property name="toolTip">
+          <string>Resets the equalizers to their default values when loading a track.</string>
+         </property>
+         <property name="text">
+          <string>Reset equalizers on track load</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="CheckBoxGainAutoReset">
+         <property name="toolTip">
+          <string>Resets the deck gain to unity when loading a track.</string>
+         </property>
+         <property name="text">
+          <string>Reset gain on track load</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="CheckBoxBypass">
+         <property name="text">
+          <string>Bypass EQ effect processing</string>
+         </property>
+         <property name="toolTip">
+          <string>When checked, EQs are not processed, improving performance on slower computers.</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="MasterMasterEQ">
      <property name="title">
       <string>Master EQ</string>
@@ -362,45 +408,6 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="EQMiscOptions">
-     <property name="title">
-      <string>Miscellaneous</string>
-     </property>
-      <layout class="QVBoxLayout" name="miscOptionsLayout" stretch="0,0,0,0">
-       <item>
-        <widget class="QCheckBox" name="CheckBoxEqAutoReset">
-         <property name="toolTip">
-          <string>Resets the equalizers to their default values when loading a track.</string>
-         </property>
-         <property name="text">
-          <string>Reset equalizers on track load</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="CheckBoxGainAutoReset">
-         <property name="toolTip">
-          <string>Resets the deck gain to unity when loading a track.</string>
-         </property>
-         <property name="text">
-          <string>Reset gain on track load</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="CheckBoxBypass">
-         <property name="text">
-          <string>Bypass EQ effect processing</string>
-         </property>
-         <property name="toolTip">
-          <string>When checked, EQs are not processed, improving performance on slower computers.</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-    </widget>
-   </item>
-   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -419,17 +426,13 @@
  <tabstops>
   <tabstop>CheckBoxEqOnly</tabstop>
   <tabstop>CheckBoxSingleEqEffect</tabstop>
-  <!-- TODO(ronso0)
-      Dynamically add Eq / Quick Effect comboboxes -->
   <tabstop>SliderHiEQ</tabstop>
   <tabstop>SliderLoEQ</tabstop>
-  <tabstop>comboBoxMasterEq</tabstop>
-  <tabstop>pbResetMasterEq</tabstop>
-  <!-- TODO(ronso0)
-      Dynamically add Master EQ sliders -->
   <tabstop>CheckBoxEqAutoReset</tabstop>
   <tabstop>CheckBoxGainAutoReset</tabstop>
   <tabstop>CheckBoxBypass</tabstop>
+  <tabstop>comboBoxMasterEq</tabstop>
+  <tabstop>pbResetMasterEq</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
before, "Use the same EQ for all decks" was reset to `true`, overriding the config value.

Noticed here https://mixxx.discourse.group/t/mixx-strongly-began-to-heavily-load-the-system-linux/24068/29