### PR TITLE
Implement Un-eject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1640,6 +1640,7 @@ add_executable(mixxx-test
   src/test/nativeeffects_test.cpp
   src/test/performancetimer_test.cpp
   src/test/playcountertest.cpp
+  src/test/playermanagertest.cpp
   src/test/playlisttest.cpp
   src/test/portmidicontroller_test.cpp
   src/test/portmidienumeratortest.cpp

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -185,11 +185,6 @@ EngineBuffer::EngineBuffer(const QString& group,
     m_pKeylock = new ControlPushButton(ConfigKey(m_group, "keylock"), true);
     m_pKeylock->setButtonMode(ControlPushButton::TOGGLE);
 
-    m_pEject = new ControlPushButton(ConfigKey(m_group, "eject"));
-    connect(m_pEject, &ControlObject::valueChanged,
-            this, &EngineBuffer::slotEjectTrack,
-            Qt::DirectConnection);
-
     m_pTrackLoaded = new ControlObject(ConfigKey(m_group, "track_loaded"), false);
     m_pTrackLoaded->setReadOnly();
 
@@ -325,7 +320,6 @@ EngineBuffer::~EngineBuffer() {
     delete m_pScaleRB;
 
     delete m_pKeylock;
-    delete m_pEject;
 
     SampleUtil::free(m_pCrossfadeBuffer);
 
@@ -1440,17 +1434,6 @@ bool EngineBuffer::isTrackLoaded() const {
 
 TrackPointer EngineBuffer::getLoadedTrack() const {
     return m_pCurrentTrack;
-}
-
-void EngineBuffer::slotEjectTrack(double v) {
-    if (v > 0) {
-        // Don't allow rejections while playing a track. We don't need to lock to
-        // call ControlObject::get() so this is fine.
-        if (m_playButton->get() > 0) {
-            return;
-        }
-        ejectTrack();
-    }
 }
 
 mixxx::audio::FramePos EngineBuffer::getExactPlayPos() const {

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -122,6 +122,7 @@ class EngineBuffer : public EngineObject {
 
     bool isTrackLoaded() const;
     TrackPointer getLoadedTrack() const;
+    void ejectTrack();
 
     mixxx::audio::FramePos getExactPlayPos() const;
     double getVisualPlayPos() const;
@@ -174,8 +175,6 @@ class EngineBuffer : public EngineObject {
     void slotControlSeek(double);
     void slotKeylockEngineChanged(double);
 
-    void slotEjectTrack(double);
-
   signals:
     void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack);
     void trackLoadFailed(TrackPointer pTrack, const QString& reason);
@@ -206,8 +205,6 @@ class EngineBuffer : public EngineObject {
     void updateIndicators(double rate, int iBufferSize);
 
     void hintReader(const double rate);
-
-    void ejectTrack();
 
     double fractionalPlayposFromAbsolute(mixxx::audio::FramePos position);
 
@@ -351,7 +348,6 @@ class EngineBuffer : public EngineObject {
     // thread, which is required to avoid segfaults.
     ControlProxy* m_pPassthroughEnabled;
 
-    ControlPushButton* m_pEject;
     ControlObject* m_pTrackLoaded;
 
     // Whether or not to repeat the track when at the end

--- a/src/mixer/auxiliary.cpp
+++ b/src/mixer/auxiliary.cpp
@@ -7,9 +7,12 @@
 #include "soundio/soundmanager.h"
 #include "soundio/soundmanagerutil.h"
 
-Auxiliary::Auxiliary(QObject* pParent, const QString& group, int index,
-                     SoundManager* pSoundManager, EngineMaster* pEngine,
-                     EffectsManager* pEffectsManager)
+Auxiliary::Auxiliary(PlayerManager* pParent,
+        const QString& group,
+        int index,
+        SoundManager* pSoundManager,
+        EngineMaster* pEngine,
+        EffectsManager* pEffectsManager)
         : BasePlayer(pParent, group) {
     ChannelHandleAndGroup channelGroup = pEngine->registerChannelGroup(group);
     EngineAux* pAuxiliary = new EngineAux(channelGroup, pEffectsManager);

--- a/src/mixer/auxiliary.h
+++ b/src/mixer/auxiliary.h
@@ -14,12 +14,12 @@ class SoundManager;
 class Auxiliary : public BasePlayer {
     Q_OBJECT
   public:
-    Auxiliary(QObject* pParent,
-              const QString& group,
-              int index,
-              SoundManager* pSoundManager,
-              EngineMaster* pMixingEngine,
-              EffectsManager* pEffectsManager);
+    Auxiliary(PlayerManager* pParent,
+            const QString& group,
+            int index,
+            SoundManager* pSoundManager,
+            EngineMaster* pMixingEngine,
+            EffectsManager* pEffectsManager);
     ~Auxiliary() override;
 
   signals:

--- a/src/mixer/baseplayer.cpp
+++ b/src/mixer/baseplayer.cpp
@@ -2,7 +2,8 @@
 
 #include "moc_baseplayer.cpp"
 
-BasePlayer::BasePlayer(QObject* pParent, const QString& group)
+BasePlayer::BasePlayer(PlayerManager* pParent, const QString& group)
         : QObject(pParent),
+          m_pPlayerManager(pParent),
           m_group(group) {
 }

--- a/src/mixer/baseplayer.h
+++ b/src/mixer/baseplayer.h
@@ -3,15 +3,20 @@
 #include <QObject>
 #include <QString>
 
+#include "playermanager.h"
+
 class BasePlayer : public QObject {
     Q_OBJECT
   public:
-    BasePlayer(QObject* pParent, const QString& group);
+    BasePlayer(PlayerManager* pParent, const QString& group);
     ~BasePlayer() override = default;
 
     inline const QString& getGroup() const {
         return m_group;
     }
+
+  protected:
+    PlayerManager* m_pPlayerManager;
 
   private:
     const QString m_group;

--- a/src/mixer/baseplayer.h
+++ b/src/mixer/baseplayer.h
@@ -3,7 +3,7 @@
 #include <QObject>
 #include <QString>
 
-#include "playermanager.h"
+#include "mixer/playermanager.h"
 
 class BasePlayer : public QObject {
     Q_OBJECT

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -310,7 +310,7 @@ void BaseTrackPlayerImpl::slotEjectTrack(double v) {
     }
     if (!m_pLoadedTrack) {
         TrackPointer lastEjected = m_pPlayerManager->getLastEjectedTrack();
-        if (lastEjected && lastEjected->getId().isValid()) {
+        if (lastEjected) {
             slotLoadTrack(lastEjected, false);
         }
         return;

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -309,8 +309,8 @@ void BaseTrackPlayerImpl::slotEjectTrack(double v) {
         return;
     }
     if (!m_pLoadedTrack) {
-        auto lastEjected = m_pPlayerManager->getLastEjectedTrack();
-        if (lastEjected) {
+        TrackPointer lastEjected = m_pPlayerManager->getLastEjectedTrack();
+        if (lastEjected && lastEjected->getId().isValid()) {
             slotLoadTrack(lastEjected, false);
         }
         return;
@@ -318,7 +318,7 @@ void BaseTrackPlayerImpl::slotEjectTrack(double v) {
 
     // Don't allow rejections while playing a track. We don't need to lock to
     // call ControlObject::get() so this is fine.
-    if (m_pPlay->get() > 0) {
+    if (m_pPlay->toBool()) {
         return;
     }
     m_pChannel->getEngineBuffer()->ejectTrack();

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -41,6 +41,7 @@ class BaseTrackPlayer : public BasePlayer {
     virtual void slotLoadTrack(TrackPointer pTrack, bool bPlay = false) = 0;
     virtual void slotCloneFromGroup(const QString& group) = 0;
     virtual void slotCloneDeck() = 0;
+    virtual void slotEjectTrack(double) = 0;
 
   signals:
     void newTrackLoaded(TrackPointer pLoadedTrack);
@@ -77,7 +78,7 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
 
   public slots:
     void slotLoadTrack(TrackPointer track, bool bPlay) final;
-    void slotEjectTrack(double);
+    void slotEjectTrack(double) final;
     void slotCloneFromGroup(const QString& group) final;
     void slotCloneDeck() final;
     void slotTrackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack);

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -32,7 +32,7 @@ class BaseTrackPlayer : public BasePlayer {
         RESET_SPEED
     };
 
-    BaseTrackPlayer(QObject* pParent, const QString& group);
+    BaseTrackPlayer(PlayerManager* pParent, const QString& group);
     ~BaseTrackPlayer() override = default;
 
     virtual TrackPointer getLoadedTrack() const = 0;
@@ -44,6 +44,7 @@ class BaseTrackPlayer : public BasePlayer {
 
   signals:
     void newTrackLoaded(TrackPointer pLoadedTrack);
+    void trackUnloaded(TrackPointer pUnloadedTrack);
     void loadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
     void playerEmpty();
     void noVinylControlInputConfigured();
@@ -52,7 +53,7 @@ class BaseTrackPlayer : public BasePlayer {
 class BaseTrackPlayerImpl : public BaseTrackPlayer {
     Q_OBJECT
   public:
-    BaseTrackPlayerImpl(QObject* pParent,
+    BaseTrackPlayerImpl(PlayerManager* pParent,
             UserSettingsPointer pConfig,
             EngineMaster* pMixingEngine,
             EffectsManager* pEffectsManager,
@@ -76,6 +77,7 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
 
   public slots:
     void slotLoadTrack(TrackPointer track, bool bPlay) final;
+    void slotEjectTrack(double);
     void slotCloneFromGroup(const QString& group) final;
     void slotCloneDeck() final;
     void slotTrackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack);
@@ -116,6 +118,8 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     EngineDeck* m_pChannel;
     bool m_replaygainPending;
     EngineChannel* m_pChannelToCloneFrom;
+
+    std::unique_ptr<ControlPushButton> m_pEject;
 
     // Deck clone control
     std::unique_ptr<ControlObject> m_pCloneFromDeck;

--- a/src/mixer/deck.cpp
+++ b/src/mixer/deck.cpp
@@ -2,7 +2,7 @@
 
 #include "moc_deck.cpp"
 
-Deck::Deck(QObject* pParent,
+Deck::Deck(PlayerManager* pParent,
         UserSettingsPointer pConfig,
         EngineMaster* pMixingEngine,
         EffectsManager* pEffectsManager,

--- a/src/mixer/deck.h
+++ b/src/mixer/deck.h
@@ -7,7 +7,7 @@
 class Deck : public BaseTrackPlayerImpl {
     Q_OBJECT
   public:
-    Deck(QObject* pParent,
+    Deck(PlayerManager* pParent,
             UserSettingsPointer pConfig,
             EngineMaster* pMixingEngine,
             EffectsManager* pEffectsManager,

--- a/src/mixer/microphone.cpp
+++ b/src/mixer/microphone.cpp
@@ -7,9 +7,12 @@
 #include "soundio/soundmanager.h"
 #include "soundio/soundmanagerutil.h"
 
-Microphone::Microphone(QObject* pParent, const QString& group, int index,
-                       SoundManager* pSoundManager, EngineMaster* pEngine,
-                       EffectsManager* pEffectsManager)
+Microphone::Microphone(PlayerManager* pParent,
+        const QString& group,
+        int index,
+        SoundManager* pSoundManager,
+        EngineMaster* pEngine,
+        EffectsManager* pEffectsManager)
         : BasePlayer(pParent, group) {
     ChannelHandleAndGroup channelGroup = pEngine->registerChannelGroup(group);
     EngineMicrophone* pMicrophone =

--- a/src/mixer/microphone.h
+++ b/src/mixer/microphone.h
@@ -14,12 +14,12 @@ class SoundManager;
 class Microphone : public BasePlayer {
     Q_OBJECT
   public:
-    Microphone(QObject* pParent,
-               const QString& group,
-               int index,
-               SoundManager* pSoundManager,
-               EngineMaster* pMixingEngine,
-               EffectsManager* pEffectsManager);
+    Microphone(PlayerManager* pParent,
+            const QString& group,
+            int index,
+            SoundManager* pSoundManager,
+            EngineMaster* pMixingEngine,
+            EffectsManager* pEffectsManager);
     ~Microphone() override;
 
   signals:

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -600,7 +600,7 @@ Sampler* PlayerManager::getSampler(unsigned int sampler) const {
 
 TrackPointer PlayerManager::getLastEjectedTrack() const {
     if (m_pLibrary) {
-        return m_pLibrary->trackCollectionManager()->getTrackById(m_pLastEjectedTrackId);
+        return m_pLibrary->trackCollectionManager()->getTrackById(m_lastEjectedTrackId);
     }
     return nullptr;
 }
@@ -748,7 +748,7 @@ void PlayerManager::slotSaveEjectedTrack(TrackPointer track) {
     VERIFY_OR_DEBUG_ASSERT(track) {
         return;
     }
-    m_pLastEjectedTrackId = track->getId();
+    m_lastEjectedTrackId = track->getId();
 }
 
 void PlayerManager::onTrackAnalysisProgress(TrackId trackId, AnalyzerProgress analyzerProgress) {

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -188,7 +188,7 @@ void PlayerManager::bindToLibrary(Library* pLibrary) {
     // analyzed.
     foreach(Deck* pDeck, m_decks) {
         connect(pDeck, &BaseTrackPlayer::newTrackLoaded, this, &PlayerManager::slotAnalyzeTrack);
-        connect(pDeck, &BaseTrackPlayer::trackUnloaded, this, &PlayerManager::slotStoreParkedTrack);
+        connect(pDeck, &BaseTrackPlayer::trackUnloaded, this, &PlayerManager::slotSaveEjectedTrack);
     }
 
     // Connect the player to the analyzer queue so that loaded tracks are
@@ -198,7 +198,7 @@ void PlayerManager::bindToLibrary(Library* pLibrary) {
         connect(pSampler,
                 &BaseTrackPlayer::trackUnloaded,
                 this,
-                &PlayerManager::slotStoreParkedTrack);
+                &PlayerManager::slotSaveEjectedTrack);
     }
 
     // Connect the player to the analyzer queue so that loaded tracks are
@@ -734,7 +734,7 @@ void PlayerManager::slotAnalyzeTrack(TrackPointer track) {
     }
 }
 
-void PlayerManager::slotStoreParkedTrack(TrackPointer track) {
+void PlayerManager::slotSaveEjectedTrack(TrackPointer track) {
     VERIFY_OR_DEBUG_ASSERT(track) {
         return;
     }

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -188,12 +188,17 @@ void PlayerManager::bindToLibrary(Library* pLibrary) {
     // analyzed.
     foreach(Deck* pDeck, m_decks) {
         connect(pDeck, &BaseTrackPlayer::newTrackLoaded, this, &PlayerManager::slotAnalyzeTrack);
+        connect(pDeck, &BaseTrackPlayer::trackUnloaded, this, &PlayerManager::slotStoreParkedTrack);
     }
 
     // Connect the player to the analyzer queue so that loaded tracks are
     // analyzed.
     foreach(Sampler* pSampler, m_samplers) {
         connect(pSampler, &BaseTrackPlayer::newTrackLoaded, this, &PlayerManager::slotAnalyzeTrack);
+        connect(pSampler,
+                &BaseTrackPlayer::trackUnloaded,
+                this,
+                &PlayerManager::slotStoreParkedTrack);
     }
 
     // Connect the player to the analyzer queue so that loaded tracks are
@@ -727,6 +732,13 @@ void PlayerManager::slotAnalyzeTrack(TrackPointer track) {
         // before any signals from the analyzer queue arrive.
         emit trackAnalyzerProgress(track->getId(), kAnalyzerProgressUnknown);
     }
+}
+
+void PlayerManager::slotStoreParkedTrack(TrackPointer track) {
+    VERIFY_OR_DEBUG_ASSERT(track) {
+        return;
+    }
+    m_pLastEjectedTrack = track;
 }
 
 void PlayerManager::onTrackAnalysisProgress(TrackId trackId, AnalyzerProgress analyzerProgress) {

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -188,17 +188,12 @@ void PlayerManager::bindToLibrary(Library* pLibrary) {
     // analyzed.
     foreach(Deck* pDeck, m_decks) {
         connect(pDeck, &BaseTrackPlayer::newTrackLoaded, this, &PlayerManager::slotAnalyzeTrack);
-        connect(pDeck, &BaseTrackPlayer::trackUnloaded, this, &PlayerManager::slotSaveEjectedTrack);
     }
 
     // Connect the player to the analyzer queue so that loaded tracks are
     // analyzed.
     foreach(Sampler* pSampler, m_samplers) {
         connect(pSampler, &BaseTrackPlayer::newTrackLoaded, this, &PlayerManager::slotAnalyzeTrack);
-        connect(pSampler,
-                &BaseTrackPlayer::trackUnloaded,
-                this,
-                &PlayerManager::slotSaveEjectedTrack);
     }
 
     // Connect the player to the analyzer queue so that loaded tracks are
@@ -416,6 +411,10 @@ void PlayerManager::addDeckInner() {
             &BaseTrackPlayer::noVinylControlInputConfigured,
             this,
             &PlayerManager::noVinylControlInputConfigured);
+    connect(pDeck,
+            &BaseTrackPlayer::trackUnloaded,
+            this,
+            &PlayerManager::slotSaveEjectedTrack);
 
     if (m_pTrackAnalysisScheduler) {
         connect(pDeck,
@@ -474,6 +473,10 @@ void PlayerManager::addSamplerInner() {
                 this,
                 &PlayerManager::slotAnalyzeTrack);
     }
+    connect(pSampler,
+            &BaseTrackPlayer::trackUnloaded,
+            this,
+            &PlayerManager::slotSaveEjectedTrack);
 
     m_players[handleGroup.handle()] = pSampler;
     m_samplers.append(pSampler);

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -210,7 +210,7 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
 
   private slots:
     void slotAnalyzeTrack(TrackPointer track);
-    void slotStoreParkedTrack(TrackPointer track);
+    void slotSaveEjectedTrack(TrackPointer track);
 
     void onTrackAnalysisProgress(TrackId trackId, AnalyzerProgress analyzerProgress);
     void onTrackAnalysisFinished();

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -1,11 +1,15 @@
 #pragma once
 
+#include <gtest/gtest_prod.h>
+
 #include <QList>
 #include <QMap>
 #include <QObject>
 
 #include "analyzer/trackanalysisscheduler.h"
 #include "engine/channelhandle.h"
+#include "library/library.h"
+#include "library/trackcollectionmanager.h"
 #include "preferences/usersettings.h"
 #include "track/track_decl.h"
 #include "util/compatibility/qmutex.h"
@@ -123,9 +127,9 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
         return numSamplers();
     }
 
-    TrackPointer getLastEjectedTrack() const {
-        return m_pLastEjectedTrack;
-    }
+    // Returns the track that was last ejected or unloaded. Can return nullptr or
+    // invalid TrackId in case of error.
+    TrackPointer getLastEjectedTrack() const;
 
     // Get the microphone by its number. Microphones are numbered starting with 1.
     Microphone* getMicrophone(unsigned int microphone) const;
@@ -208,9 +212,12 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     void slotChangeNumMicrophones(double v);
     void slotChangeNumAuxiliaries(double v);
 
+  protected slots:
+    FRIEND_TEST(PlayerManagerTest, UnEjectInvalidTrackIdTest);
+    void slotSaveEjectedTrack(TrackPointer track);
+
   private slots:
     void slotAnalyzeTrack(TrackPointer track);
-    void slotSaveEjectedTrack(TrackPointer track);
 
     void onTrackAnalysisProgress(TrackId trackId, AnalyzerProgress analyzerProgress);
     void onTrackAnalysisFinished();
@@ -265,6 +272,7 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     QString m_lastLoadedPlayer;
 
     UserSettingsPointer m_pConfig;
+    Library* m_pLibrary;
     SoundManager* m_pSoundManager;
     EffectsManager* m_pEffectsManager;
     EngineMaster* m_pEngine;
@@ -278,7 +286,7 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
 
     TrackAnalysisScheduler::Pointer m_pTrackAnalysisScheduler;
 
-    TrackPointer m_pLastEjectedTrack;
+    TrackId m_pLastEjectedTrackId;
 
     QList<Deck*> m_decks;
     QList<Sampler*> m_samplers;

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -286,7 +286,7 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
 
     TrackAnalysisScheduler::Pointer m_pTrackAnalysisScheduler;
 
-    TrackId m_pLastEjectedTrackId;
+    TrackId m_lastEjectedTrackId;
 
     QList<Deck*> m_decks;
     QList<Sampler*> m_samplers;

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -123,6 +123,10 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
         return numSamplers();
     }
 
+    TrackPointer getLastEjectedTrack() const {
+        return m_pLastEjectedTrack;
+    }
+
     // Get the microphone by its number. Microphones are numbered starting with 1.
     Microphone* getMicrophone(unsigned int microphone) const;
 
@@ -206,6 +210,7 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
 
   private slots:
     void slotAnalyzeTrack(TrackPointer track);
+    void slotStoreParkedTrack(TrackPointer track);
 
     void onTrackAnalysisProgress(TrackId trackId, AnalyzerProgress analyzerProgress);
     void onTrackAnalysisFinished();
@@ -272,6 +277,8 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     parented_ptr<ControlProxy> m_pAutoDjEnabled;
 
     TrackAnalysisScheduler::Pointer m_pTrackAnalysisScheduler;
+
+    TrackPointer m_pLastEjectedTrack;
 
     QList<Deck*> m_decks;
     QList<Sampler*> m_samplers;

--- a/src/mixer/previewdeck.cpp
+++ b/src/mixer/previewdeck.cpp
@@ -2,7 +2,7 @@
 
 #include "moc_previewdeck.cpp"
 
-PreviewDeck::PreviewDeck(QObject* pParent,
+PreviewDeck::PreviewDeck(PlayerManager* pParent,
         UserSettingsPointer pConfig,
         EngineMaster* pMixingEngine,
         EffectsManager* pEffectsManager,

--- a/src/mixer/previewdeck.h
+++ b/src/mixer/previewdeck.h
@@ -5,7 +5,7 @@
 class PreviewDeck : public BaseTrackPlayerImpl {
     Q_OBJECT
   public:
-    PreviewDeck(QObject* pParent,
+    PreviewDeck(PlayerManager* pParent,
             UserSettingsPointer pConfig,
             EngineMaster* pMixingEngine,
             EffectsManager* pEffectsManager,

--- a/src/mixer/sampler.cpp
+++ b/src/mixer/sampler.cpp
@@ -3,7 +3,7 @@
 #include "control/controlobject.h"
 #include "moc_sampler.cpp"
 
-Sampler::Sampler(QObject* pParent,
+Sampler::Sampler(PlayerManager* pParent,
         UserSettingsPointer pConfig,
         EngineMaster* pMixingEngine,
         EffectsManager* pEffectsManager,

--- a/src/mixer/sampler.h
+++ b/src/mixer/sampler.h
@@ -5,7 +5,7 @@
 class Sampler : public BaseTrackPlayerImpl {
     Q_OBJECT
   public:
-    Sampler(QObject* pParent,
+    Sampler(PlayerManager* pParent,
             UserSettingsPointer pConfig,
             EngineMaster* pMixingEngine,
             EffectsManager* pEffectsManager,

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -93,6 +93,12 @@ class FakeDeck : public BaseTrackPlayer {
         play.set(bPlay);
     }
 
+    void slotEjectTrack(double val) override {
+        if (val > 0) {
+            loadedTrack = nullptr;
+        }
+    }
+
     MOCK_METHOD1(slotCloneFromGroup, void(const QString& group));
     MOCK_METHOD0(slotCloneDeck, void());
 

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -995,9 +995,9 @@ TEST_F(EngineSyncTest, EnableOneDeckInitializesLeader) {
 
 TEST_F(EngineSyncTest, LoadTrackInitializesLeader) {
     // First eject the fake tracks that come with the testing framework.
-    m_pChannel1->getEngineBuffer()->slotEjectTrack(1.0);
-    m_pChannel2->getEngineBuffer()->slotEjectTrack(1.0);
-    m_pChannel3->getEngineBuffer()->slotEjectTrack(1.0);
+    m_pChannel1->getEngineBuffer()->ejectTrack();
+    m_pChannel2->getEngineBuffer()->ejectTrack();
+    m_pChannel3->getEngineBuffer()->ejectTrack();
 
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
@@ -1020,7 +1020,7 @@ TEST_F(EngineSyncTest, LoadTrackInitializesLeader) {
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(0.0);
 
     // Ejecting the track has no effect on leader status
-    m_pChannel1->getEngineBuffer()->slotEjectTrack(1.0);
+    m_pChannel1->getEngineBuffer()->ejectTrack();
     EXPECT_TRUE(isFollower(m_sGroup1));
     // no relevant tempo available so internal clock is following
     EXPECT_TRUE(isFollower(m_sInternalClockGroup));

--- a/src/test/looping_control_test.cpp
+++ b/src/test/looping_control_test.cpp
@@ -651,7 +651,7 @@ TEST_F(LoopingControlTest, BeatLoopSize_SetAndToggle) {
 
 TEST_F(LoopingControlTest, BeatLoopSize_SetWithoutTrackLoaded) {
     // Eject the track that is automatically loaded by the testing framework
-    m_pChannel1->getEngineBuffer()->slotEjectTrack(1.0);
+    m_pChannel1->getEngineBuffer()->ejectTrack();
     m_pBeatLoopSize->set(5.0);
     EXPECT_EQ(5.0, m_pBeatLoopSize->get());
 }

--- a/src/test/playermanagertest.cpp
+++ b/src/test/playermanagertest.cpp
@@ -2,16 +2,22 @@
 
 #include <QTest>
 
+#include "database/mixxxdb.h"
 #include "engine/enginebuffer.h"
 #include "engine/enginemaster.h"
 #include "mixer/basetrackplayer.h"
 #include "mixer/deck.h"
 #include "mixer/playermanager.h"
-#include "test/mixxxtest.h"
+#include "test/librarytest.h"
 #include "track/track.h"
 #include "util/cmdlineargs.h"
 
-class PlayerManagerTest : public MixxxTest {
+const QString kTrackLocationTest1(QDir::currentPath() %
+        "/src/test/id3-test-data/cover-test-png.mp3");
+const QString kTrackLocationTest2(QDir::currentPath() %
+        "/src/test/id3-test-data/cover-test-vbr.mp3");
+
+class PlayerManagerTest : public LibraryTest { //, SoundSourceProviderRegistration {
     void SetUp() override {
         auto pChannelHandleFactory = std::make_shared<ChannelHandleFactory>();
         m_pEffectsManager = std::make_shared<EffectsManager>(m_pConfig, pChannelHandleFactory);
@@ -28,8 +34,18 @@ class PlayerManagerTest : public MixxxTest {
                 m_pEffectsManager.get(),
                 m_pEngine.get());
 
+        m_pRecordingManager = std::make_shared<RecordingManager>(m_pConfig, m_pEngine.get());
+        m_pLibrary = std::make_shared<Library>(
+                nullptr,
+                m_pConfig,
+                dbConnectionPooler(),
+                trackCollectionManager(),
+                m_pPlayerManager.get(),
+                m_pRecordingManager.get());
+
         m_pPlayerManager->addConfiguredDecks();
         m_pPlayerManager->addSampler();
+        m_pPlayerManager->bindToLibrary(m_pLibrary.get());
     }
 
   protected:
@@ -37,29 +53,79 @@ class PlayerManagerTest : public MixxxTest {
     std::shared_ptr<EngineMaster> m_pEngine;
     std::shared_ptr<SoundManager> m_pSoundManager;
     std::shared_ptr<PlayerManager> m_pPlayerManager;
+    std::shared_ptr<RecordingManager> m_pRecordingManager;
+    std::shared_ptr<Library> m_pLibrary;
 };
 
 TEST_F(PlayerManagerTest, UnEjectTest) {
     // Ejecting an empty deck with no previously-recorded ejected track has no effect.
     auto deck1 = m_pPlayerManager->getDeck(1);
     deck1->slotEjectTrack(1.0);
-    ASSERT_TRUE(deck1->getLoadedTrack() == nullptr);
+    ASSERT_EQ(nullptr, deck1->getLoadedTrack());
 
     // Load a track and eject it
-    deck1->loadFakeTrack(false, 130.0);
-    // Wait for the track to load.
+    TrackPointer pTrack1 = getOrAddTrackByLocation(kTrackLocationTest1);
+    TrackId testId1 = pTrack1->getId();
+    ASSERT_TRUE(testId1.isValid());
+    deck1->slotLoadTrack(pTrack1, false);
+    ASSERT_NE(nullptr, deck1->getLoadedTrack());
+
     m_pEngine->process(1024);
     while (!deck1->getEngineDeck()->getEngineBuffer()->isTrackLoaded()) {
-        QTest::qSleep(1); // millis
+        QTest::qSleep(100); // millis
     }
     deck1->slotEjectTrack(1.0);
-    // Load another track with a different bpm.
-    deck1->loadFakeTrack(false, 100.0);
+
+    // Load another track.
+    TrackPointer pTrack2 = getOrAddTrackByLocation(kTrackLocationTest2);
+    deck1->slotLoadTrack(pTrack2, false);
 
     // Ejecting in an empty deck loads the last-ejected track.
     auto deck2 = m_pPlayerManager->getDeck(2);
-    ASSERT_TRUE(deck2->getLoadedTrack() == nullptr);
+    ASSERT_EQ(nullptr, deck2->getLoadedTrack());
     deck2->slotEjectTrack(2.0);
-    ASSERT_TRUE(deck2->getLoadedTrack() != nullptr);
-    ASSERT_EQ(130, deck2->getLoadedTrack()->getBpm());
+    ASSERT_NE(nullptr, deck2->getLoadedTrack());
+    ASSERT_EQ(testId1, deck2->getLoadedTrack()->getId());
+}
+
+// Loading a new track in a deck causes the old one to be ejected.
+// That old track can be unejected into a different deck.
+TEST_F(PlayerManagerTest, UnEjectReplaceTrackTest) {
+    auto deck1 = m_pPlayerManager->getDeck(1);
+    // Load a track and the load another one
+    TrackPointer pTrack1 = getOrAddTrackByLocation(kTrackLocationTest1);
+    TrackId testId1 = pTrack1->getId();
+    ASSERT_TRUE(testId1.isValid());
+    deck1->slotLoadTrack(pTrack1, false);
+    ASSERT_NE(nullptr, deck1->getLoadedTrack());
+
+    m_pEngine->process(1024);
+    while (!deck1->getEngineDeck()->getEngineBuffer()->isTrackLoaded()) {
+        QTest::qSleep(100); // millis
+    }
+
+    // Load another track, replacing the first, causing it to be unloaded.
+    TrackPointer pTrack2 = getOrAddTrackByLocation(kTrackLocationTest2);
+    deck1->slotLoadTrack(pTrack2, false);
+    m_pEngine->process(1024);
+    while (!deck1->getEngineDeck()->getEngineBuffer()->isTrackLoaded()) {
+        QTest::qSleep(100); // millis
+    }
+
+    // Ejecting in an empty deck loads the last-ejected track.
+    auto deck2 = m_pPlayerManager->getDeck(2);
+    ASSERT_EQ(nullptr, deck2->getLoadedTrack());
+    deck2->slotEjectTrack(1.0);
+    ASSERT_NE(nullptr, deck2->getLoadedTrack());
+    ASSERT_EQ(testId1, deck2->getLoadedTrack()->getId());
+}
+
+TEST_F(PlayerManagerTest, UnEjectInvalidTrackIdTest) {
+    // Save an invalid trackid in playermanager.
+    auto pTrack = Track::newDummy(kTrackLocationTest1, TrackId(10));
+    m_pPlayerManager->slotSaveEjectedTrack(pTrack);
+    auto deck1 = m_pPlayerManager->getDeck(1);
+    // Does nothing -- no crash.
+    deck1->slotEjectTrack(1.0);
+    ASSERT_EQ(nullptr, deck1->getLoadedTrack());
 }

--- a/src/test/playermanagertest.cpp
+++ b/src/test/playermanagertest.cpp
@@ -1,0 +1,65 @@
+#include <gtest/gtest.h>
+
+#include <QTest>
+
+#include "engine/enginebuffer.h"
+#include "engine/enginemaster.h"
+#include "mixer/basetrackplayer.h"
+#include "mixer/deck.h"
+#include "mixer/playermanager.h"
+#include "test/mixxxtest.h"
+#include "track/track.h"
+#include "util/cmdlineargs.h"
+
+class PlayerManagerTest : public MixxxTest {
+    void SetUp() override {
+        auto pChannelHandleFactory = std::make_shared<ChannelHandleFactory>();
+        m_pEffectsManager = std::make_shared<EffectsManager>(m_pConfig, pChannelHandleFactory);
+        m_pEngine = std::make_shared<EngineMaster>(
+                m_pConfig,
+                "[Master]",
+                m_pEffectsManager.get(),
+                pChannelHandleFactory,
+                true);
+        m_pSoundManager = std::make_shared<SoundManager>(m_pConfig, m_pEngine.get());
+        m_pEngine->registerNonEngineChannelSoundIO(m_pSoundManager.get());
+        m_pPlayerManager = std::make_shared<PlayerManager>(m_pConfig,
+                m_pSoundManager.get(),
+                m_pEffectsManager.get(),
+                m_pEngine.get());
+
+        m_pPlayerManager->addConfiguredDecks();
+        m_pPlayerManager->addSampler();
+    }
+
+  protected:
+    std::shared_ptr<EffectsManager> m_pEffectsManager;
+    std::shared_ptr<EngineMaster> m_pEngine;
+    std::shared_ptr<SoundManager> m_pSoundManager;
+    std::shared_ptr<PlayerManager> m_pPlayerManager;
+};
+
+TEST_F(PlayerManagerTest, UnEjectTest) {
+    // Ejecting an empty deck with no previously-recorded ejected track has no effect.
+    auto deck1 = m_pPlayerManager->getDeck(1);
+    deck1->slotEjectTrack(1.0);
+    ASSERT_TRUE(deck1->getLoadedTrack() == nullptr);
+
+    // Load a track and eject it
+    deck1->loadFakeTrack(false, 130.0);
+    // Wait for the track to load.
+    m_pEngine->process(1024);
+    while (!deck1->getEngineDeck()->getEngineBuffer()->isTrackLoaded()) {
+        QTest::qSleep(1); // millis
+    }
+    deck1->slotEjectTrack(1.0);
+    // Load another track with a different bpm.
+    deck1->loadFakeTrack(false, 100.0);
+
+    // Ejecting in an empty deck loads the last-ejected track.
+    auto deck2 = m_pPlayerManager->getDeck(2);
+    ASSERT_TRUE(deck2->getLoadedTrack() == nullptr);
+    deck2->slotEjectTrack(2.0);
+    ASSERT_TRUE(deck2->getLoadedTrack() != nullptr);
+    ASSERT_EQ(130, deck2->getLoadedTrack()->getBpm());
+}

--- a/src/test/playermanagertest.cpp
+++ b/src/test/playermanagertest.cpp
@@ -63,6 +63,7 @@ class PlayerManagerTest : public MixxxDbTest {
         m_pPlayerManager->addConfiguredDecks();
         m_pPlayerManager->addSampler();
         PlayerInfo::create();
+        m_pEffectsManager->setup();
 
         const auto dbConnection = mixxx::DbConnectionPooled(dbConnectionPooler());
         if (!MixxxDb::initDatabaseSchema(dbConnection)) {

--- a/src/test/signalpathtest.h
+++ b/src/test/signalpathtest.h
@@ -157,7 +157,7 @@ class BaseSignalPathTest : public MixxxTest, SoundSourceProviderRegistration {
     void loadTrack(Deck* pDeck, TrackPointer pTrack) {
         EngineDeck* pEngineDeck = pDeck->getEngineDeck();
         if (pEngineDeck->getEngineBuffer()->isTrackLoaded()) {
-            pEngineDeck->getEngineBuffer()->slotEjectTrack(1);
+            pEngineDeck->getEngineBuffer()->ejectTrack();
         }
         pDeck->slotLoadTrack(pTrack, false);
 


### PR DESCRIPTION
When ejecting a track, save a pointer to the ejected track.  If the user presses eject on an empty track in any deck or sampler, the saved track is loaded.

The track is loaded fresh, not as a "Deck clone" operation.

This enables a sort of "eject undo" as well as "track stashing".   It requires no changes to controller configs.

This required a refactor of the eject code to remove it from the EngineBuffer.  Tests still pass. Hand-testing works.