### PR TITLE
README: Remove links to wrong build instructions in wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,6 @@ tools/debian_buildenv.sh setup` respectively), then run:
 There should now be a `mixxx` executable in the current directory that you can
 run. Alternatively, can generate a package using `cpack`.
 
-More Information can be found on the [wiki]:
-
-- [Compiling on Linux]
-- [Compiling on macOS]
-- [Compiling on Windows]
-
 ## Documentation
 
 For help using Mixxx, there are a variety of options:
@@ -96,9 +90,6 @@ license.
 [manual]: https://manual.mixxx.org/
 [wiki]: https://github.com/mixxxdj/mixxx/wiki
 [faq]: https://github.com/mixxxdj/mixxx/wiki/Faq
-[Compiling on Linux]: https://github.com/mixxxdj/mixxx/wiki/Compiling%20on%20Linux
-[Compiling on MacOS]: https://github.com/mixxxdj/mixxx/wiki/Compiling%20on%20macOS
-[Compiling on Windows]: https://github.com/mixxxdj/mixxx/wiki/compiling-on-windows
 [CMake]: https://cmake.org/
 [easybugs]: https://bugs.launchpad.net/mixxx/+bugs?field.searchtext=&orderby=-importance&search=Search&field.status%3Alist=NEW&field.status%3Alist=CONFIRMED&field.status%3Alist=TRIAGED&field.status%3Alist=INPROGRESS&field.status%3Alist=INCOMPLETE_WITH_RESPONSE&field.status%3Alist=INCOMPLETE_WITHOUT_RESPONSE&assignee_option=any&field.assignee=&field.bug_reporter=&field.bug_commenter=&field.subscriber=&field.structural_subscriber=&field.tag=easy&field.tags_combinator=ANY&field.has_cve.used=&field.omit_dupes.used=&field.omit_dupes=on&field.affects_me.used=&field.has_patch.used=&field.has_branches.used=&field.has_branches=on&field.has_no_branches.used=&field.has_no_branches=on&field.has_blueprints.used=&field.has_blueprints=on&field.has_no_blueprints.used=&field.has_no_blueprints=on
 [creating skins]: https://mixxx.org/wiki/doku.php/Creating-Skins

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ bug list][easybugs] and get started!
 ## Building Mixxx
 
 First, open a terminal (on Windows, use "x64 Native Tools Command Prompt for
-VS 2019"), download the mixxx source code and navigate to it:
+[VS 2019][visualstudio2019]"), download the mixxx
+source code and navigate to it:
 
     $ git clone https://github.com/mixxxdj/mixxx.git
     $ cd mixxx
@@ -90,6 +91,7 @@ license.
 [manual]: https://manual.mixxx.org/
 [wiki]: https://github.com/mixxxdj/mixxx/wiki
 [faq]: https://github.com/mixxxdj/mixxx/wiki/Faq
+[visualstudio2019]: https://docs.microsoft.com/visualstudio/install/install-visual-studio?view=vs-2019
 [CMake]: https://cmake.org/
 [easybugs]: https://bugs.launchpad.net/mixxx/+bugs?field.searchtext=&orderby=-importance&search=Search&field.status%3Alist=NEW&field.status%3Alist=CONFIRMED&field.status%3Alist=TRIAGED&field.status%3Alist=INPROGRESS&field.status%3Alist=INCOMPLETE_WITH_RESPONSE&field.status%3Alist=INCOMPLETE_WITHOUT_RESPONSE&assignee_option=any&field.assignee=&field.bug_reporter=&field.bug_commenter=&field.subscriber=&field.structural_subscriber=&field.tag=easy&field.tags_combinator=ANY&field.has_cve.used=&field.omit_dupes.used=&field.omit_dupes=on&field.affects_me.used=&field.has_patch.used=&field.has_branches.used=&field.has_branches=on&field.has_no_branches.used=&field.has_no_branches=on&field.has_blueprints.used=&field.has_blueprints=on&field.has_no_blueprints.used=&field.has_no_blueprints=on
 [creating skins]: https://mixxx.org/wiki/doku.php/Creating-Skins


### PR DESCRIPTION
Someone relied on our documentation, and again
the docs turned out to contain wrong/outdated information:

https://mixxx.zulipchat.com/#narrow/stream/247620-development-help/topic/Build.20tools.20for.20Visual.20Studio.202022.3F/near/271368532

Documentation should be helpful and make things easier, but wrong
documentation is actually harmful.

This has not been the first time that our tendency to add redundant
doxumentation for ever edge case has bitten us.

Time and again it has been proven that we are not capable of keeping
these wordy guides up to date, so the links should be removed.