### PR TITLE
Copy channelhandle by value instead of pointers

### DIFF
--- a/src/effects/backends/effectprocessor.h
+++ b/src/effects/backends/effectprocessor.h
@@ -74,10 +74,10 @@ class EffectProcessor {
     virtual void loadEngineEffectParameters(
             const QMap<QString, EngineEffectParameterPointer>& parameters) = 0;
     virtual EffectState* createState(const mixxx::EngineParameters& engineParameters) = 0;
-    virtual void deleteStatesForInputChannel(const ChannelHandle* inputChannel) = 0;
+    virtual void deleteStatesForInputChannel(ChannelHandle inputChannel) = 0;
 
     // Called from the audio thread
-    virtual bool loadStatesForInputChannel(const ChannelHandle* inputChannel,
+    virtual bool loadStatesForInputChannel(ChannelHandle inputChannel,
             const EffectStatesMap* pStatesMap) = 0;
 
     /// Called from the audio thread
@@ -202,11 +202,11 @@ class EffectProcessorImpl : public EffectProcessor {
         return createSpecificState(engineParameters);
     };
 
-    bool loadStatesForInputChannel(const ChannelHandle* inputChannel,
+    bool loadStatesForInputChannel(ChannelHandle inputChannel,
             const EffectStatesMap* pStatesMap) final {
         if (kEffectDebugOutput) {
             qDebug() << "EffectProcessorImpl::loadStatesForInputChannel" << this
-                     << "input" << *inputChannel;
+                     << "input" << inputChannel;
         }
 
         // NOTE: ChannelHandleMap is like a map in that it associates an
@@ -220,7 +220,7 @@ class EffectProcessorImpl : public EffectProcessor {
         // pStatesMap to build a new ChannelHandleMap with
         // dynamic_cast'ed states.
         ChannelHandleMap<EffectSpecificState*>& effectSpecificStatesMap =
-                m_channelStateMatrix[*inputChannel];
+                m_channelStateMatrix[inputChannel];
 
         // deleteStatesForInputChannel should have been called before a new
         // map of EffectStates was sent to this function, or this is the first
@@ -256,10 +256,10 @@ class EffectProcessorImpl : public EffectProcessor {
     };
 
     /// Called from main thread for garbage collection after an input channel is disabled
-    void deleteStatesForInputChannel(const ChannelHandle* inputChannel) final {
+    void deleteStatesForInputChannel(ChannelHandle inputChannel) final {
         if (kEffectDebugOutput) {
             qDebug() << "EffectProcessorImpl::deleteStatesForInputChannel"
-                     << this << *inputChannel;
+                     << this << inputChannel;
         }
 
         // NOTE: ChannelHandleMap is like a map in that it associates an
@@ -269,7 +269,7 @@ class EffectProcessorImpl : public EffectProcessor {
         // engine thread in loadStatesForInputChannel.
 
         ChannelHandleMap<EffectSpecificState*>& stateMap =
-                m_channelStateMatrix[*inputChannel];
+                m_channelStateMatrix[inputChannel];
         for (EffectSpecificState* pState : stateMap) {
             VERIFY_OR_DEBUG_ASSERT(pState != nullptr) {
                 continue;

--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -394,7 +394,7 @@ void EffectChain::enableForInputChannel(const ChannelHandleAndGroup& handleGroup
     EffectsRequest* request = new EffectsRequest();
     request->type = EffectsRequest::ENABLE_EFFECT_CHAIN_FOR_INPUT_CHANNEL;
     request->pTargetChain = m_pEngineEffectChain;
-    request->EnableInputChannelForChain.pChannelHandle = &handleGroup.handle();
+    request->EnableInputChannelForChain.channelHandle = handleGroup.handle();
 
     // Allocate EffectStates here in the main thread to avoid allocating
     // memory in the realtime audio callback thread. Pointers to the
@@ -428,7 +428,7 @@ void EffectChain::disableForInputChannel(const ChannelHandleAndGroup& handleGrou
     EffectsRequest* request = new EffectsRequest();
     request->type = EffectsRequest::DISABLE_EFFECT_CHAIN_FOR_INPUT_CHANNEL;
     request->pTargetChain = m_pEngineEffectChain;
-    request->DisableInputChannelForChain.pChannelHandle = &handleGroup.handle();
+    request->DisableInputChannelForChain.channelHandle = handleGroup.handle();
     m_pMessenger->writeRequest(request);
 }
 

--- a/src/effects/effectsmessenger.cpp
+++ b/src/effects/effectsmessenger.cpp
@@ -93,10 +93,10 @@ void EffectsMessenger::collectGarbage(const EffectsRequest* pRequest) {
     } else if (pRequest->type == EffectsRequest::DISABLE_EFFECT_CHAIN_FOR_INPUT_CHANNEL) {
         if (kEffectDebugOutput) {
             qDebug() << debugString() << "deleting states for input channel"
-                     << pRequest->DisableInputChannelForChain.pChannelHandle
+                     << pRequest->DisableInputChannelForChain.channelHandle
                      << "for EngineEffectChain" << pRequest->pTargetChain;
         }
         pRequest->pTargetChain->deleteStatesForInputChannel(
-                pRequest->DisableInputChannelForChain.pChannelHandle);
+                pRequest->DisableInputChannelForChain.channelHandle);
     }
 }

--- a/src/engine/channelhandle.h
+++ b/src/engine/channelhandle.h
@@ -95,7 +95,7 @@ class ChannelHandleAndGroup {
         return m_name;
     }
 
-    inline const ChannelHandle& handle() const {
+    inline ChannelHandle handle() const {
         return m_handle;
     }
 

--- a/src/engine/channels/enginechannel.h
+++ b/src/engine/channels/enginechannel.h
@@ -30,7 +30,7 @@ class EngineChannel : public EngineObject {
 
     virtual ChannelOrientation getOrientation() const;
 
-    inline const ChannelHandle& getHandle() const {
+    inline ChannelHandle getHandle() const {
         return m_group.handle();
     }
 

--- a/src/engine/effects/engineeffect.cpp
+++ b/src/engine/effects/engineeffect.cpp
@@ -53,16 +53,16 @@ EffectState* EngineEffect::createState(const mixxx::EngineParameters& enginePara
     return m_pProcessor->createState(engineParameters);
 }
 
-void EngineEffect::loadStatesForInputChannel(const ChannelHandle* inputChannel,
+void EngineEffect::loadStatesForInputChannel(ChannelHandle inputChannel,
         EffectStatesMap* pStatesMap) {
     if (kEffectDebugOutput) {
         qDebug() << "EngineEffect::loadStatesForInputChannel" << this
-                 << "loading states for input" << *inputChannel;
+                 << "loading states for input" << inputChannel;
     }
     m_pProcessor->loadStatesForInputChannel(inputChannel, pStatesMap);
 }
 
-void EngineEffect::deleteStatesForInputChannel(const ChannelHandle* inputChannel) {
+void EngineEffect::deleteStatesForInputChannel(ChannelHandle inputChannel) {
     m_pProcessor->deleteStatesForInputChannel(inputChannel);
 }
 

--- a/src/engine/effects/engineeffect.h
+++ b/src/engine/effects/engineeffect.h
@@ -35,10 +35,10 @@ class EngineEffect final : public EffectsRequestHandler {
     EffectState* createState(const mixxx::EngineParameters& engineParameters);
 
     /// Called in audio thread to load EffectStates received from the main thread
-    void loadStatesForInputChannel(const ChannelHandle* inputChannel,
+    void loadStatesForInputChannel(ChannelHandle inputChannel,
             EffectStatesMap* pStatesMap);
     /// Called from the main thread for garbage collection after an input channel is disabled
-    void deleteStatesForInputChannel(const ChannelHandle* inputChannel);
+    void deleteStatesForInputChannel(ChannelHandle inputChannel);
 
     /// Called in audio thread
     bool processEffectsRequest(

--- a/src/engine/effects/engineeffectchain.h
+++ b/src/engine/effects/engineeffectchain.h
@@ -45,7 +45,7 @@ class EngineEffectChain final : public EffectsRequestHandler {
             const GroupFeatureState& groupFeatures);
 
     /// called from main thread
-    void deleteStatesForInputChannel(const ChannelHandle* channel);
+    void deleteStatesForInputChannel(const ChannelHandle channel);
 
   private:
     struct ChannelStatus {
@@ -64,9 +64,9 @@ class EngineEffectChain final : public EffectsRequestHandler {
     bool updateParameters(const EffectsRequest& message);
     bool addEffect(EngineEffect* pEffect, int iIndex);
     bool removeEffect(EngineEffect* pEffect, int iIndex);
-    bool enableForInputChannel(const ChannelHandle* inputHandle,
+    bool enableForInputChannel(ChannelHandle inputHandle,
             EffectStatesMapArray* statesForEffectsInChain);
-    bool disableForInputChannel(const ChannelHandle* inputHandle);
+    bool disableForInputChannel(ChannelHandle inputHandle);
 
     // Gets or creates a ChannelStatus entry in m_channelStatus for the provided
     // handle.

--- a/src/engine/effects/message.h
+++ b/src/engine/effects/message.h
@@ -40,17 +40,9 @@ struct EffectsRequest {
               value(0.0) {
         pTargetChain = nullptr;
         pTargetEffect = nullptr;
-#define CLEAR_STRUCT(x) memset(&x, 0, sizeof(x));
-        CLEAR_STRUCT(AddEffectChain);
-        CLEAR_STRUCT(RemoveEffectChain);
-        CLEAR_STRUCT(EnableInputChannelForChain);
-        CLEAR_STRUCT(DisableInputChannelForChain);
-        CLEAR_STRUCT(AddEffectToChain);
-        CLEAR_STRUCT(RemoveEffectFromChain);
-        CLEAR_STRUCT(SetEffectChainParameters);
-        CLEAR_STRUCT(SetEffectParameters);
-        CLEAR_STRUCT(SetParameterParameters);
-#undef CLEAR_STRUCT
+        // zero out the struct with the largest size to ensure the entire union memory is set to
+        // zero.
+        memset(&SetEffectChainParameters, 0, sizeof(SetEffectChainParameters));
     }
 
     // This is called from the main thread by EffectsManager after receiving a
@@ -97,10 +89,10 @@ struct EffectsRequest {
         } RemoveEffectChain;
         struct {
             EffectStatesMapArray* pEffectStatesMapArray;
-            const ChannelHandle* pChannelHandle;
+            ChannelHandle channelHandle;
         } EnableInputChannelForChain;
         struct {
-            const ChannelHandle* pChannelHandle;
+            ChannelHandle channelHandle;
         } DisableInputChannelForChain;
         struct {
             EngineEffect* pEffect;

--- a/src/engine/effects/message.h
+++ b/src/engine/effects/message.h
@@ -34,15 +34,14 @@ struct EffectsRequest {
         NUM_REQUEST_TYPES
     };
 
+    // Creates a new uninitialized EffectsRequest.  Callers are responsible for making sure that
+    // they initialize all the values of the struct corresponding to the type they select.
     EffectsRequest()
             : type(NUM_REQUEST_TYPES),
               request_id(-1),
               value(0.0) {
         pTargetChain = nullptr;
         pTargetEffect = nullptr;
-        // zero out the struct with the largest size to ensure the entire union memory is set to
-        // zero.
-        memset(&SetEffectChainParameters, 0, sizeof(SetEffectChainParameters));
     }
 
     // This is called from the main thread by EffectsManager after receiving a
@@ -84,7 +83,6 @@ struct EffectsRequest {
         } AddEffectChain;
         struct {
             EngineEffectChain* pChain;
-            int iIndex;
             SignalProcessingStage signalProcessingStage;
         } RemoveEffectChain;
         struct {


### PR DESCRIPTION
Store channelhandles in messages by value instead of pointers. This fixes issues with pointers to deleted channelhandles being accessed, causing crashes, mostly with QT6.
    
Converting to values means we can no longer trivially initialize the union/struct by memsetting all of the subtypes, because two of the struts are no longer trivial.
    
Instead, we memset what we think is the largest datatype. SetEffectChainParameters includes a bool, an enum, and a double, so it's the largest one.

