### PR TITLE
AsyncImageProvider: Retrieve Cover Art from database instead of file system

### DIFF
--- a/src/qml/asyncimageprovider.h
+++ b/src/qml/asyncimageprovider.h
@@ -4,8 +4,10 @@
 #include <QSize>
 #include <QString>
 #include <QThreadPool>
+#include <memory>
 
 #include "library/coverart.h"
+#include "library/trackcollectionmanager.h"
 
 namespace mixxx {
 namespace qml {
@@ -13,17 +15,27 @@ namespace qml {
 class AsyncImageResponse : public QQuickImageResponse, public QRunnable {
     Q_OBJECT
   public:
-    AsyncImageResponse(const QString& id, const QSize& requestedSize);
+    AsyncImageResponse(
+            QString id,
+            QSize requestedSize,
+            std::shared_ptr<TrackCollectionManager> pTrackCollectionManager);
+
     QQuickTextureFactory* textureFactory() const override;
+
     void run() override;
 
+  private:
     QString m_id;
     QSize m_requestedSize;
+    std::shared_ptr<TrackCollectionManager> m_pTrackCollectionManager;
+
     QImage m_image;
 };
 
 class AsyncImageProvider : public QQuickAsyncImageProvider {
   public:
+    AsyncImageProvider(std::shared_ptr<TrackCollectionManager> pTrackCollectionManager);
+
     QQuickImageResponse* requestImageResponse(
             const QString& id, const QSize& requestedSize) override;
 
@@ -33,6 +45,7 @@ class AsyncImageProvider : public QQuickAsyncImageProvider {
 
   private:
     QThreadPool pool;
+    std::shared_ptr<TrackCollectionManager> m_pTrackCollectionManager;
 };
 
 } // namespace qml

--- a/src/qml/qmlapplication.cpp
+++ b/src/qml/qmlapplication.cpp
@@ -100,7 +100,8 @@ void QmlApplication::loadQml(const QString& path) {
     m_pAppEngine->addImportPath(QStringLiteral(":/mixxx.org/imports"));
 
     // No memory leak here, the QQmlEngine takes ownership of the provider
-    QQuickAsyncImageProvider* pImageProvider = new AsyncImageProvider();
+    QQuickAsyncImageProvider* pImageProvider = new AsyncImageProvider(
+            m_pCoreServices->getTrackCollectionManager());
     m_pAppEngine->addImageProvider(AsyncImageProvider::kProviderName, pImageProvider);
 
     m_pAppEngine->load(path);


### PR DESCRIPTION
~~This triggers the following debug assertion:~~

    DEBUG ASSERT: "this->thread() == QThread::currentThread()" in function TrackCollection* TrackCollectionManager::internalCollection() const at /home/jan/Projects/mixxx/src/library/trackcollectionmanager.h:41

~~Unfortunately, we need something like this to be able to draw waveforms, waveform overviews and coverart in another thread.~~

~~Any ideas how to resolve this?~~