### PR TITLE
Pin ChannelHandle to permanent memory address and use pointers

### DIFF
--- a/src/effects/backends/effectprocessor.h
+++ b/src/effects/backends/effectprocessor.h
@@ -74,10 +74,10 @@ class EffectProcessor {
     virtual void loadEngineEffectParameters(
             const QMap<QString, EngineEffectParameterPointer>& parameters) = 0;
     virtual EffectState* createState(const mixxx::EngineParameters& engineParameters) = 0;
-    virtual void deleteStatesForInputChannel(const ChannelHandle* inputChannel) = 0;
+    virtual void deleteStatesForInputChannel(const ChannelHandle* pInputChannel) = 0;
 
     // Called from the audio thread
-    virtual bool loadStatesForInputChannel(const ChannelHandle* inputChannel,
+    virtual bool loadStatesForInputChannel(const ChannelHandle* pInputChannel,
             const EffectStatesMap* pStatesMap) = 0;
 
     /// Called from the audio thread
@@ -91,8 +91,8 @@ class EffectProcessor {
     /// EffectProcessorImpl::process to fetch the appropriate EffectState and
     /// pass it on to EffectProcessorImpl::processChannel, allowing one
     /// EffectProcessor instance to process multiple signals simultaneously.
-    virtual void process(const ChannelHandle& inputHandle,
-            const ChannelHandle& outputHandle,
+    virtual void process(const ChannelHandle* pInputHandle,
+            const ChannelHandle* pOutputHandle,
             const CSAMPLE* pInput,
             CSAMPLE* pOutput,
             const mixxx::EngineParameters& engineParameters,
@@ -149,25 +149,25 @@ class EffectProcessorImpl : public EffectProcessor {
             const EffectEnableState enableState,
             const GroupFeatureState& groupFeatures) = 0;
 
-    void process(const ChannelHandle& inputHandle,
-            const ChannelHandle& outputHandle,
+    void process(const ChannelHandle* pInputHandle,
+            const ChannelHandle* pOutputHandle,
             const CSAMPLE* pInput,
             CSAMPLE* pOutput,
             const mixxx::EngineParameters& engineParameters,
             const EffectEnableState enableState,
             const GroupFeatureState& groupFeatures) final {
-        EffectSpecificState* pState = m_channelStateMatrix[inputHandle][outputHandle];
+        EffectSpecificState* pState = m_channelStateMatrix[pInputHandle][pOutputHandle];
         VERIFY_OR_DEBUG_ASSERT(pState != nullptr) {
             if (kEffectDebugOutput) {
                 qWarning() << "EffectProcessorImpl::process could not retrieve"
                               "EffectState for input"
-                           << inputHandle
-                           << "and output" << outputHandle
+                           << *pInputHandle
+                           << "and output" << *pOutputHandle
                            << "EffectState should have been preallocated in the"
                               "main thread.";
             }
             pState = createSpecificState(engineParameters);
-            m_channelStateMatrix[inputHandle][outputHandle] = pState;
+            m_channelStateMatrix[pInputHandle][pOutputHandle] = pState;
         }
         processChannel(pState, pInput, pOutput, engineParameters, enableState, groupFeatures);
     }
@@ -202,11 +202,11 @@ class EffectProcessorImpl : public EffectProcessor {
         return createSpecificState(engineParameters);
     };
 
-    bool loadStatesForInputChannel(const ChannelHandle* inputChannel,
+    bool loadStatesForInputChannel(const ChannelHandle* pInputHandle,
             const EffectStatesMap* pStatesMap) final {
         if (kEffectDebugOutput) {
             qDebug() << "EffectProcessorImpl::loadStatesForInputChannel" << this
-                     << "input" << *inputChannel;
+                     << "input" << *pInputHandle;
         }
 
         // NOTE: ChannelHandleMap is like a map in that it associates an
@@ -220,7 +220,7 @@ class EffectProcessorImpl : public EffectProcessor {
         // pStatesMap to build a new ChannelHandleMap with
         // dynamic_cast'ed states.
         ChannelHandleMap<EffectSpecificState*>& effectSpecificStatesMap =
-                m_channelStateMatrix[*inputChannel];
+                m_channelStateMatrix[pInputHandle];
 
         // deleteStatesForInputChannel should have been called before a new
         // map of EffectStates was sent to this function, or this is the first
@@ -256,10 +256,10 @@ class EffectProcessorImpl : public EffectProcessor {
     };
 
     /// Called from main thread for garbage collection after an input channel is disabled
-    void deleteStatesForInputChannel(const ChannelHandle* inputChannel) final {
+    void deleteStatesForInputChannel(const ChannelHandle* pInputHandle) final {
         if (kEffectDebugOutput) {
             qDebug() << "EffectProcessorImpl::deleteStatesForInputChannel"
-                     << this << *inputChannel;
+                     << this << *pInputHandle;
         }
 
         // NOTE: ChannelHandleMap is like a map in that it associates an
@@ -269,7 +269,7 @@ class EffectProcessorImpl : public EffectProcessor {
         // engine thread in loadStatesForInputChannel.
 
         ChannelHandleMap<EffectSpecificState*>& stateMap =
-                m_channelStateMatrix[*inputChannel];
+                m_channelStateMatrix[pInputHandle];
         for (EffectSpecificState* pState : stateMap) {
             VERIFY_OR_DEBUG_ASSERT(pState != nullptr) {
                 continue;

--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -394,7 +394,7 @@ void EffectChain::enableForInputChannel(const ChannelHandleAndGroup& handleGroup
     EffectsRequest* request = new EffectsRequest();
     request->type = EffectsRequest::ENABLE_EFFECT_CHAIN_FOR_INPUT_CHANNEL;
     request->pTargetChain = m_pEngineEffectChain;
-    request->EnableInputChannelForChain.pChannelHandle = &handleGroup.handle();
+    request->EnableInputChannelForChain.pChannelHandle = handleGroup.handle();
 
     // Allocate EffectStates here in the main thread to avoid allocating
     // memory in the realtime audio callback thread. Pointers to the
@@ -428,7 +428,7 @@ void EffectChain::disableForInputChannel(const ChannelHandleAndGroup& handleGrou
     EffectsRequest* request = new EffectsRequest();
     request->type = EffectsRequest::DISABLE_EFFECT_CHAIN_FOR_INPUT_CHANNEL;
     request->pTargetChain = m_pEngineEffectChain;
-    request->DisableInputChannelForChain.pChannelHandle = &handleGroup.handle();
+    request->DisableInputChannelForChain.pChannelHandle = handleGroup.handle();
     m_pMessenger->writeRequest(request);
 }
 

--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -40,7 +40,7 @@ class EffectsManager {
         return m_pEngineEffectsManager;
     }
 
-    const ChannelHandle getMasterHandle() const {
+    const ChannelHandle* getMasterHandle() const {
         return m_pChannelHandleFactory->getOrCreateHandle("[Master]");
     }
 

--- a/src/engine/channelhandle.h
+++ b/src/engine/channelhandle.h
@@ -133,7 +133,7 @@ inline qhash_seed_t qHash(
 // objects are not compatible and will produce incorrect results when compared,
 // stored in the same container, etc. In practice we only use one instance in
 // EngineMaster.
-class ChannelHandleFactory {
+class ChannelHandleFactory final {
   public:
     ChannelHandleFactory() = default;
 
@@ -180,6 +180,11 @@ class ChannelHandleFactory {
     }
 
   private:
+    ChannelHandleFactory(ChannelHandleFactory&&) = delete;
+    ChannelHandleFactory(const ChannelHandleFactory&) = delete;
+    ChannelHandleFactory& operator=(ChannelHandleFactory&&) = delete;
+    ChannelHandleFactory& operator=(const ChannelHandleFactory&) = delete;
+
     ChannelHandle m_groupHandles[kMaxExpectedChannelGroups];
     QHash<QString, int> m_groupToHandle;
     QHash<int, QString> m_handleToGroup;

--- a/src/engine/channelhandle.h
+++ b/src/engine/channelhandle.h
@@ -30,6 +30,10 @@ constexpr int kMaxExpectedChannelGroups = 256;
 ///
 /// A helper class, ChannelHandleFactory, keeps a running count of handles that
 /// have been assigned.
+///
+/// Channel handles are passed as pointers to permanent memory addresses and
+/// can neither be copied nor moved!!! This is required to pass them from/to
+/// the real-time thread, e.g. for managing effect configurations.
 class ChannelHandle final {
   public:
     bool valid() const {
@@ -133,12 +137,7 @@ class ChannelHandleFactory {
   public:
     ChannelHandleFactory() = default;
 
-    /// Obtain a reference to a channel handle for a group
-    ///
-    /// The returned reference must be stable during a session and references
-    /// an entry from an internal map. Thus it is safe to get the address of
-    /// this reference. This is REQUIRED for passing ChannelHandle to
-    /// EffectChainManager by a pointer!!!
+    /// Obtain a a channel handle for a group
     const ChannelHandle* getOrCreateHandle(const QString& group) {
         auto groupToHandleIter = m_groupToHandle.find(group);
         if (groupToHandleIter == m_groupToHandle.end()) {

--- a/src/engine/channelmixer.cpp
+++ b/src/engine/channelmixer.cpp
@@ -8,7 +8,7 @@ void ChannelMixer::applyEffectsAndMixChannels(const EngineMaster::GainCalculator
         const QVarLengthArray<EngineMaster::ChannelInfo*, kPreallocatedChannels>& activeChannels,
         QVarLengthArray<EngineMaster::GainCache, kPreallocatedChannels>* channelGainCache,
         CSAMPLE* pOutput,
-        const ChannelHandle& outputHandle,
+        const ChannelHandle* pOutputHandle,
         unsigned int iBufferSize,
         unsigned int iSampleRate,
         EngineEffectsManager* pEngineEffectsManager) {
@@ -34,8 +34,10 @@ void ChannelMixer::applyEffectsAndMixChannels(const EngineMaster::GainCalculator
             newGain = gainCalculator.getGain(pChannelInfo);
         }
         gainCache.m_gain = newGain;
-        pEngineEffectsManager->processPostFaderAndMix(pChannelInfo->m_handle,
-                outputHandle,
+        DEBUG_ASSERT(pChannelInfo->m_pHandle);
+        pEngineEffectsManager->processPostFaderAndMix(
+                pChannelInfo->m_pHandle,
+                pOutputHandle,
                 pChannelInfo->m_pBuffer,
                 pOutput,
                 iBufferSize,
@@ -53,7 +55,7 @@ void ChannelMixer::applyEffectsInPlaceAndMixChannels(
         QVarLengthArray<EngineMaster::GainCache, kPreallocatedChannels>*
                 channelGainCache,
         CSAMPLE* pOutput,
-        const ChannelHandle& outputHandle,
+        const ChannelHandle* pOutputHandle,
         unsigned int iBufferSize,
         unsigned int iSampleRate,
         EngineEffectsManager* pEngineEffectsManager) {
@@ -76,8 +78,10 @@ void ChannelMixer::applyEffectsInPlaceAndMixChannels(
             newGain = gainCalculator.getGain(pChannelInfo);
         }
         gainCache.m_gain = newGain;
-        pEngineEffectsManager->processPostFaderInPlace(pChannelInfo->m_handle,
-                outputHandle,
+        DEBUG_ASSERT(pChannelInfo->m_pHandle);
+        pEngineEffectsManager->processPostFaderInPlace(
+                pChannelInfo->m_pHandle,
+                pOutputHandle,
                 pChannelInfo->m_pBuffer,
                 iBufferSize,
                 iSampleRate,

--- a/src/engine/channelmixer.h
+++ b/src/engine/channelmixer.h
@@ -18,7 +18,7 @@ class ChannelMixer {
             QVarLengthArray<EngineMaster::GainCache, kPreallocatedChannels>*
                     channelGainCache,
             CSAMPLE* pOutput,
-            const ChannelHandle& outputHandle,
+            const ChannelHandle* pOutputHandle,
             unsigned int iBufferSize,
             unsigned int iSampleRate,
             EngineEffectsManager* pEngineEffectsManager);
@@ -30,7 +30,7 @@ class ChannelMixer {
             QVarLengthArray<EngineMaster::GainCache, kPreallocatedChannels>*
                     channelGainCache,
             CSAMPLE* pOutput,
-            const ChannelHandle& outputHandle,
+            const ChannelHandle* pOutputHandle,
             unsigned int iBufferSize,
             unsigned int iSampleRate,
             EngineEffectsManager* pEngineEffectsManager);

--- a/src/engine/channels/enginechannel.h
+++ b/src/engine/channels/enginechannel.h
@@ -30,7 +30,7 @@ class EngineChannel : public EngineObject {
 
     virtual ChannelOrientation getOrientation() const;
 
-    inline const ChannelHandle& getHandle() const {
+    inline const ChannelHandle* getHandle() const {
         return m_group.handle();
     }
 

--- a/src/engine/effects/engineeffect.cpp
+++ b/src/engine/effects/engineeffect.cpp
@@ -53,17 +53,17 @@ EffectState* EngineEffect::createState(const mixxx::EngineParameters& enginePara
     return m_pProcessor->createState(engineParameters);
 }
 
-void EngineEffect::loadStatesForInputChannel(const ChannelHandle* inputChannel,
+void EngineEffect::loadStatesForInputChannel(const ChannelHandle* pInputChannel,
         EffectStatesMap* pStatesMap) {
     if (kEffectDebugOutput) {
         qDebug() << "EngineEffect::loadStatesForInputChannel" << this
-                 << "loading states for input" << *inputChannel;
+                 << "loading states for input" << *pInputChannel;
     }
-    m_pProcessor->loadStatesForInputChannel(inputChannel, pStatesMap);
+    m_pProcessor->loadStatesForInputChannel(pInputChannel, pStatesMap);
 }
 
-void EngineEffect::deleteStatesForInputChannel(const ChannelHandle* inputChannel) {
-    m_pProcessor->deleteStatesForInputChannel(inputChannel);
+void EngineEffect::deleteStatesForInputChannel(const ChannelHandle* pInputChannel) {
+    m_pProcessor->deleteStatesForInputChannel(pInputChannel);
 }
 
 bool EngineEffect::processEffectsRequest(EffectsRequest& message,
@@ -123,8 +123,9 @@ bool EngineEffect::processEffectsRequest(EffectsRequest& message,
     return false;
 }
 
-bool EngineEffect::process(const ChannelHandle& inputHandle,
-        const ChannelHandle& outputHandle,
+bool EngineEffect::process(
+        const ChannelHandle* pInputHandle,
+        const ChannelHandle* pOutputHandle,
         const CSAMPLE* pInput,
         CSAMPLE* pOutput,
         const unsigned int numSamples,
@@ -148,7 +149,7 @@ bool EngineEffect::process(const ChannelHandle& inputHandle,
     // internal buffer for the channel when it gets the intermediate disabling signal.
 
     EffectEnableState effectiveEffectEnableState =
-            m_effectEnableStateForChannelMatrix[inputHandle][outputHandle];
+            m_effectEnableStateForChannelMatrix[pInputHandle][pOutputHandle];
 
     // If the EngineEffect is fully disabled, do not let
     // intermediate enabling/disabing signals from the chain override
@@ -182,8 +183,8 @@ bool EngineEffect::process(const ChannelHandle& inputHandle,
                 mixxx::audio::SampleRate(sampleRate),
                 numSamples / mixxx::kEngineChannelCount);
 
-        m_pProcessor->process(inputHandle,
-                outputHandle,
+        m_pProcessor->process(pInputHandle,
+                pOutputHandle,
                 pInput,
                 pOutput,
                 engineParameters,
@@ -214,7 +215,8 @@ bool EngineEffect::process(const ChannelHandle& inputHandle,
 
     // Now that the EffectProcessor has been sent the intermediate enabling/disabling
     // signal, set the channel state to fully enabled/disabled for the next engine callback.
-    EffectEnableState& effectOnChannelState = m_effectEnableStateForChannelMatrix[inputHandle][outputHandle];
+    EffectEnableState& effectOnChannelState =
+            m_effectEnableStateForChannelMatrix[pInputHandle][pOutputHandle];
     if (effectOnChannelState == EffectEnableState::Disabling) {
         effectOnChannelState = EffectEnableState::Disabled;
     } else if (effectOnChannelState == EffectEnableState::Enabling) {

--- a/src/engine/effects/engineeffect.h
+++ b/src/engine/effects/engineeffect.h
@@ -35,10 +35,10 @@ class EngineEffect final : public EffectsRequestHandler {
     EffectState* createState(const mixxx::EngineParameters& engineParameters);
 
     /// Called in audio thread to load EffectStates received from the main thread
-    void loadStatesForInputChannel(const ChannelHandle* inputChannel,
+    void loadStatesForInputChannel(const ChannelHandle* pInputChannel,
             EffectStatesMap* pStatesMap);
     /// Called from the main thread for garbage collection after an input channel is disabled
-    void deleteStatesForInputChannel(const ChannelHandle* inputChannel);
+    void deleteStatesForInputChannel(const ChannelHandle* pInputChannel);
 
     /// Called in audio thread
     bool processEffectsRequest(
@@ -46,8 +46,8 @@ class EngineEffect final : public EffectsRequestHandler {
             EffectsResponsePipe* pResponsePipe) override;
 
     /// Called in audio thread
-    bool process(const ChannelHandle& inputHandle,
-            const ChannelHandle& outputHandle,
+    bool process(const ChannelHandle* pInputHandle,
+            const ChannelHandle* pOutputHandle,
             const CSAMPLE* pInput,
             CSAMPLE* pOutput,
             const unsigned int numSamples,

--- a/src/engine/effects/engineeffectchain.h
+++ b/src/engine/effects/engineeffectchain.h
@@ -36,8 +36,9 @@ class EngineEffectChain final : public EffectsRequestHandler {
             EffectsResponsePipe* pResponsePipe) override;
 
     /// called from audio thread
-    bool process(const ChannelHandle& inputHandle,
-            const ChannelHandle& outputHandle,
+    bool process(
+            const ChannelHandle* pInputHandle,
+            const ChannelHandle* pOutputHandle,
             CSAMPLE* pIn,
             CSAMPLE* pOut,
             const unsigned int numSamples,
@@ -64,14 +65,15 @@ class EngineEffectChain final : public EffectsRequestHandler {
     bool updateParameters(const EffectsRequest& message);
     bool addEffect(EngineEffect* pEffect, int iIndex);
     bool removeEffect(EngineEffect* pEffect, int iIndex);
-    bool enableForInputChannel(const ChannelHandle* inputHandle,
+    bool enableForInputChannel(const ChannelHandle* pInputHandle,
             EffectStatesMapArray* statesForEffectsInChain);
-    bool disableForInputChannel(const ChannelHandle* inputHandle);
+    bool disableForInputChannel(const ChannelHandle* pInputHandle);
 
     // Gets or creates a ChannelStatus entry in m_channelStatus for the provided
     // handle.
-    ChannelStatus& getChannelStatus(const ChannelHandle& inputHandle,
-            const ChannelHandle& outputHandle);
+    ChannelStatus& getChannelStatus(
+            const ChannelHandle* pInputHandle,
+            const ChannelHandle* pOutputHandle);
 
     QString m_group;
     EffectEnableState m_enableState;

--- a/src/engine/effects/engineeffectsmanager.cpp
+++ b/src/engine/effects/engineeffectsmanager.cpp
@@ -94,8 +94,9 @@ void EngineEffectsManager::onCallbackStart() {
     }
 }
 
-void EngineEffectsManager::processPreFaderInPlace(const ChannelHandle& inputHandle,
-        const ChannelHandle& outputHandle,
+void EngineEffectsManager::processPreFaderInPlace(
+        const ChannelHandle* pInputHandle,
+        const ChannelHandle* pOutputHandle,
         CSAMPLE* pInOut,
         const unsigned int numSamples,
         const unsigned int sampleRate) {
@@ -103,8 +104,8 @@ void EngineEffectsManager::processPreFaderInPlace(const ChannelHandle& inputHand
     // This is okay because the equalizer effects do not make use of it.
     GroupFeatureState featureState;
     processInner(SignalProcessingStage::Prefader,
-            inputHandle,
-            outputHandle,
+            pInputHandle,
+            pOutputHandle,
             pInOut,
             pInOut,
             numSamples,
@@ -113,8 +114,8 @@ void EngineEffectsManager::processPreFaderInPlace(const ChannelHandle& inputHand
 }
 
 void EngineEffectsManager::processPostFaderInPlace(
-        const ChannelHandle& inputHandle,
-        const ChannelHandle& outputHandle,
+        const ChannelHandle* pInputHandle,
+        const ChannelHandle* pOutputHandle,
         CSAMPLE* pInOut,
         const unsigned int numSamples,
         const unsigned int sampleRate,
@@ -122,8 +123,8 @@ void EngineEffectsManager::processPostFaderInPlace(
         const CSAMPLE_GAIN oldGain,
         const CSAMPLE_GAIN newGain) {
     processInner(SignalProcessingStage::Postfader,
-            inputHandle,
-            outputHandle,
+            pInputHandle,
+            pOutputHandle,
             pInOut,
             pInOut,
             numSamples,
@@ -134,8 +135,8 @@ void EngineEffectsManager::processPostFaderInPlace(
 }
 
 void EngineEffectsManager::processPostFaderAndMix(
-        const ChannelHandle& inputHandle,
-        const ChannelHandle& outputHandle,
+        const ChannelHandle* pInputHandle,
+        const ChannelHandle* pOutputHandle,
         CSAMPLE* pIn,
         CSAMPLE* pOut,
         const unsigned int numSamples,
@@ -144,8 +145,8 @@ void EngineEffectsManager::processPostFaderAndMix(
         const CSAMPLE_GAIN oldGain,
         const CSAMPLE_GAIN newGain) {
     processInner(SignalProcessingStage::Postfader,
-            inputHandle,
-            outputHandle,
+            pInputHandle,
+            pOutputHandle,
             pIn,
             pOut,
             numSamples,
@@ -157,8 +158,8 @@ void EngineEffectsManager::processPostFaderAndMix(
 
 void EngineEffectsManager::processInner(
         const SignalProcessingStage stage,
-        const ChannelHandle& inputHandle,
-        const ChannelHandle& outputHandle,
+        const ChannelHandle* pInputHandle,
+        const ChannelHandle* pOutputHandle,
         CSAMPLE* pIn,
         CSAMPLE* pOut,
         const unsigned int numSamples,
@@ -174,8 +175,9 @@ void EngineEffectsManager::processInner(
         SampleUtil::applyRampingGain(pIn, oldGain, newGain, numSamples);
         for (EngineEffectChain* pChain : chains) {
             if (pChain) {
-                if (pChain->process(inputHandle,
-                            outputHandle,
+                if (pChain->process(
+                            pInputHandle,
+                            pOutputHandle,
                             pIn,
                             pOut,
                             numSamples,
@@ -211,8 +213,8 @@ void EngineEffectsManager::processInner(
                     pIntermediateOutput = m_buffer1.data();
                 }
 
-                if (pChain->process(inputHandle,
-                            outputHandle,
+                if (pChain->process(pInputHandle,
+                            pOutputHandle,
                             pIntermediateInput,
                             pIntermediateOutput,
                             numSamples,

--- a/src/engine/effects/engineeffectsmanager.h
+++ b/src/engine/effects/engineeffectsmanager.h
@@ -30,8 +30,8 @@ class EngineEffectsManager final : public EffectsRequestHandler {
     /// Process the prefader EngineEffectChains on the pInOut buffer, modifying
     /// the contents of the input buffer.
     void processPreFaderInPlace(
-            const ChannelHandle& inputHandle,
-            const ChannelHandle& outputHandle,
+            const ChannelHandle* pInputHandle,
+            const ChannelHandle* pOutputHandle,
             CSAMPLE* pInOut,
             const unsigned int numSamples,
             const unsigned int sampleRate);
@@ -39,8 +39,8 @@ class EngineEffectsManager final : public EffectsRequestHandler {
     /// Process the postfader EngineEffectChains on the pInOut buffer, modifying
     /// the contents of the input buffer.
     void processPostFaderInPlace(
-            const ChannelHandle& inputHandle,
-            const ChannelHandle& outputHandle,
+            const ChannelHandle* pInputHandle,
+            const ChannelHandle* pOutputHandle,
             CSAMPLE* pInOut,
             const unsigned int numSamples,
             const unsigned int sampleRate,
@@ -54,8 +54,8 @@ class EngineEffectsManager final : public EffectsRequestHandler {
     /// buffer for every channel, which would potentially require allocation on the
     /// audio thread because ChannelMixer supports an arbitrary number of channels.
     void processPostFaderAndMix(
-            const ChannelHandle& inputHandle,
-            const ChannelHandle& outputHandle,
+            const ChannelHandle* pInputHandle,
+            const ChannelHandle* pOutputHandle,
             CSAMPLE* pIn,
             CSAMPLE* pOut,
             const unsigned int numSamples,
@@ -84,8 +84,8 @@ class EngineEffectsManager final : public EffectsRequestHandler {
     // samples, so numSamples/2 left channel samples and numSamples/2 right
     // channel samples.
     void processInner(const SignalProcessingStage stage,
-            const ChannelHandle& inputHandle,
-            const ChannelHandle& outputHandle,
+            const ChannelHandle* pInputHandle,
+            const ChannelHandle* pOutputHandle,
             CSAMPLE* pIn,
             CSAMPLE* pOut,
             const unsigned int numSamples,

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -816,7 +816,7 @@ void EngineMaster::addChannel(EngineChannel* pChannel) {
     pChannel->setChannelIndex(pChannelInfo->m_index);
     pChannelInfo->m_pChannel = pChannel;
     const QString& group = pChannel->getGroup();
-    pChannelInfo->m_handle = m_pChannelHandleFactory->getOrCreateHandle(group);
+    pChannelInfo->m_pHandle = m_pChannelHandleFactory->getOrCreateHandle(group);
     pChannelInfo->m_pVolumeControl = new ControlAudioTaperPot(
             ConfigKey(group, "volume"), -20, 0, 1);
     pChannelInfo->m_pVolumeControl->setDefaultValue(1.0);

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -109,18 +109,14 @@ class EngineMaster : public QObject, public AudioSource {
     CSAMPLE_GAIN getMasterGain(int channelIndex) const;
 
     struct ChannelInfo {
-        ChannelInfo(int index)
-                : m_pChannel(NULL),
-                  m_pBuffer(NULL),
-                  m_pVolumeControl(NULL),
-                  m_pMuteControl(NULL),
-                  m_index(index) {
+        explicit ChannelInfo(int index)
+                : m_index(index) {
         }
-        ChannelHandle m_handle;
-        EngineChannel* m_pChannel;
-        CSAMPLE* m_pBuffer;
-        ControlObject* m_pVolumeControl;
-        ControlPushButton* m_pMuteControl;
+        const ChannelHandle* m_pHandle{};
+        EngineChannel* m_pChannel{};
+        CSAMPLE* m_pBuffer{};
+        ControlObject* m_pVolumeControl{};
+        ControlPushButton* m_pMuteControl{};
         GroupFeatureState m_features;
         int m_index;
     };

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -552,11 +552,11 @@ BaseTrackPlayer* PlayerManager::getPlayer(const QString& group) const {
     return getPlayer(m_pEngine->registerChannelGroup(group).handle());
 }
 
-BaseTrackPlayer* PlayerManager::getPlayer(const ChannelHandle& handle) const {
+BaseTrackPlayer* PlayerManager::getPlayer(const ChannelHandle* pHandle) const {
     const auto locker = lockMutex(&m_mutex);
 
-    if (m_players.contains(handle)) {
-        return m_players[handle];
+    if (m_players.contains(pHandle)) {
+        return m_players[pHandle];
     }
     return nullptr;
 }

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -32,7 +32,7 @@ class PlayerManagerInterface {
     virtual ~PlayerManagerInterface() = default;
 
     virtual BaseTrackPlayer* getPlayer(const QString& group) const = 0;
-    virtual BaseTrackPlayer* getPlayer(const ChannelHandle& channelHandle) const = 0;
+    virtual BaseTrackPlayer* getPlayer(const ChannelHandle* pChannelHandle) const = 0;
 
     // Get the deck by its deck number. Decks are numbered starting with 1.
     virtual Deck* getDeck(unsigned int player) const = 0;
@@ -98,7 +98,7 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     // Auxiliaries and microphones are not players.
     BaseTrackPlayer* getPlayer(const QString& group) const override;
     // Get a BaseTrackPlayer (Deck, Sampler or PreviewDeck) by its handle.
-    BaseTrackPlayer* getPlayer(const ChannelHandle& handle) const override;
+    BaseTrackPlayer* getPlayer(const ChannelHandle* pHandle) const override;
 
     // Get the deck by its deck number. Decks are numbered starting with 1.
     Deck* getDeck(unsigned int player) const override;
@@ -278,5 +278,5 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     QList<PreviewDeck*> m_previewDecks;
     QList<Microphone*> m_microphones;
     QList<Auxiliary*> m_auxiliaries;
-    QMap<ChannelHandle, BaseTrackPlayer*> m_players;
+    QMap<const ChannelHandle*, BaseTrackPlayer*> m_players;
 };

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -122,7 +122,7 @@ class MockPlayerManager : public PlayerManagerInterface {
     }
 
     MOCK_CONST_METHOD1(getPlayer, BaseTrackPlayer*(const QString&));
-    MOCK_CONST_METHOD1(getPlayer, BaseTrackPlayer*(const ChannelHandle&));
+    MOCK_CONST_METHOD1(getPlayer, BaseTrackPlayer*(const ChannelHandle*));
     MOCK_CONST_METHOD1(getDeck, Deck*(unsigned int));
     MOCK_CONST_METHOD1(getPreviewDeck, PreviewDeck*(unsigned int));
     MOCK_CONST_METHOD1(getSampler, Sampler*(unsigned int));

--- a/src/test/baseeffecttest.h
+++ b/src/test/baseeffecttest.h
@@ -42,8 +42,8 @@ class MockEffectProcessor : public EffectProcessor {
                     const EffectStatesMap* pStatesMap));
     MOCK_METHOD1(deleteStatesForInputChannel, void(const ChannelHandle* inputChannel));
     MOCK_METHOD7(process,
-            void(const ChannelHandle& inputHandle,
-                    const ChannelHandle& outputHandle,
+            void(const ChannelHandle* pInputHandle,
+                    const ChannelHandle* pOutputHandle,
                     const CSAMPLE* pInput,
                     CSAMPLE* pOutput,
                     const mixxx::EngineParameters& engineParameters,

--- a/src/test/channelhandle_test.cpp
+++ b/src/test/channelhandle_test.cpp
@@ -4,52 +4,46 @@
 #include "engine/channelhandle.h"
 #include "test/mixxxtest.h"
 
-namespace {
-
 TEST(ChannelHandleTest, BasicUsage) {
     ChannelHandleFactory factory;
     const QString group = "[Test]";
     const QString group2 = "[Test2]";
 
-    ChannelHandle nullHandle;
-    EXPECT_EQ(nullHandle, nullHandle);
-    EXPECT_FALSE(nullHandle.valid());
-
-    EXPECT_FALSE(factory.handleForGroup(group).valid());
+    EXPECT_EQ(nullptr, factory.handleForGroup(group));
     // The ChannelHandleFactory constructor creates handles for [Master] and [Headphone]
-    EXPECT_EQ(0, factory.getOrCreateHandle(group).handle());
-    EXPECT_EQ(0, factory.getOrCreateHandle(group).handle());
-    ChannelHandle testHandle = factory.handleForGroup(group);
-    EXPECT_TRUE(testHandle.valid());
-    EXPECT_EQ(0, testHandle.handle());
-    EXPECT_QSTRING_EQ(group, factory.groupForHandle(testHandle));
-    EXPECT_NE(nullHandle, testHandle);
-    EXPECT_EQ(testHandle, testHandle);
+    EXPECT_EQ(0, factory.getOrCreateHandle(group)->handle());
+    EXPECT_EQ(0, factory.getOrCreateHandle(group)->handle());
+    const ChannelHandle* pTestHandle = factory.handleForGroup(group);
+    EXPECT_NE(nullptr, pTestHandle);
+    EXPECT_TRUE(pTestHandle->valid());
+    EXPECT_EQ(0, pTestHandle->handle());
+    EXPECT_QSTRING_EQ(group, factory.groupForHandle(pTestHandle));
+    EXPECT_EQ(*pTestHandle, *pTestHandle);
 
-    EXPECT_FALSE(factory.handleForGroup(group2).valid());
-    EXPECT_EQ(1, factory.getOrCreateHandle(group2).handle());
-    EXPECT_EQ(1, factory.getOrCreateHandle(group2).handle());
-    ChannelHandle testHandle2 = factory.handleForGroup(group2);
-    EXPECT_TRUE(testHandle2.valid());
-    EXPECT_EQ(1, testHandle2.handle());
-    EXPECT_QSTRING_EQ(group2, factory.groupForHandle(testHandle2));
-    EXPECT_NE(nullHandle, testHandle2);
-    EXPECT_EQ(testHandle2, testHandle2);
+    EXPECT_EQ(nullptr, factory.handleForGroup(group2));
+    EXPECT_EQ(1, factory.getOrCreateHandle(group2)->handle());
+    EXPECT_EQ(1, factory.getOrCreateHandle(group2)->handle());
+    const ChannelHandle* pTestHandle2 = factory.handleForGroup(group2);
+    EXPECT_NE(nullptr, pTestHandle2);
+    EXPECT_TRUE(pTestHandle2->valid());
+    EXPECT_EQ(1, pTestHandle2->handle());
+    EXPECT_QSTRING_EQ(group2, factory.groupForHandle(pTestHandle2));
+    EXPECT_EQ(*pTestHandle2, *pTestHandle2);
 
-    EXPECT_NE(testHandle, testHandle2);
+    EXPECT_NE(*pTestHandle, *pTestHandle2);
 }
 
 TEST(ChannelHandleTest, ChannelHandleMap) {
     ChannelHandleFactory factory;
 
-    ChannelHandle test = factory.getOrCreateHandle("[Test]");
-    EXPECT_TRUE(test.valid());
-    ChannelHandle test2 = factory.getOrCreateHandle("[Test2]");
-    EXPECT_TRUE(test2.valid());
+    const ChannelHandle* test = factory.getOrCreateHandle("[Test]");
+    EXPECT_TRUE(test->valid());
+    const ChannelHandle* test2 = factory.getOrCreateHandle("[Test2]");
+    EXPECT_TRUE(test2->valid());
 
     ChannelHandleMap<QString> map;
 
-    EXPECT_QSTRING_EQ(QString(), map.at(ChannelHandle()));
+    EXPECT_QSTRING_EQ(QString(), map.at(nullptr));
 
     map.insert(test2, "bar");
     EXPECT_QSTRING_EQ("bar", map.at(test2));
@@ -65,5 +59,3 @@ TEST(ChannelHandleTest, ChannelHandleMap) {
     map.insert(test, "foo");
     EXPECT_QSTRING_EQ("foo", map.at(test));
 }
-
-}  // namespace

--- a/src/test/enginemicrophonetest.cpp
+++ b/src/test/enginemicrophonetest.cpp
@@ -24,7 +24,7 @@ class EngineMicrophoneTest : public SignalPathTest {
 
         // No need for a real handle in this test.
         m_pMicrophone = new EngineMicrophone(
-                ChannelHandleAndGroup(ChannelHandle(), "[Microphone]"), m_pEffectsManager);
+                ChannelHandleAndGroup(nullptr, "[Microphone]"), m_pEffectsManager);
         m_pTalkover = ControlObject::getControl(ConfigKey("[Microphone]", "talkover"));
     }
 

--- a/src/test/nativeeffects_test.cpp
+++ b/src/test/nativeeffects_test.cpp
@@ -39,7 +39,7 @@ void benchmarkBuiltInEffectDefaultParameters(const mixxx::EngineParameters& engi
     QSet<ChannelHandleAndGroup> activeInputChannels;
 
     QString channel1_group = QString("[Channel1]");
-    ChannelHandle channel1 = factory.getOrCreateHandle(channel1_group);
+    const ChannelHandle* channel1 = factory.getOrCreateHandle(channel1_group);
     ChannelHandleAndGroup handle_and_group(channel1, channel1_group);
     pEffectsManager->registerInputChannel(handle_and_group);
     pEffectsManager->registerOutputChannel(handle_and_group);


### PR DESCRIPTION
Have fun.

Disclaimer: I didn't write the code originally and I won't rewrite it. Take it as is or leave it. I am not answering any questions about design decisions and will ignore any nitpicking comments. Otherwise, cherry-pick my commit and rework it as you like. But don't expect me to review your code. **Update**: I am well aware that the code could still be optimized. But that is a rabbit hole that I prefer to avoid.

2.3 is also affected and might stop working at any time. This issue could even be the cause for the spurious std::bad_alloc crashes that some users have reported.