### PR TITLE
Traktor S3: Fix issues with sampler and hotcue buttons

### DIFF
--- a/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
@@ -41,6 +41,10 @@ TraktorS3.SamplerModePressAndHold = false;
 // enables scratch mode.
 TraktorS3.JogDefaultOn = true;
 
+// If true, the sampler buttons on Deck 1 are samplers 1-8 and the sampler buttons on Deck 2 are
+// 9-16.  If false, both decks are samplers 1-8.
+TraktorS3.SixteenSamplers = false;
+
 // You can choose the colors you want for each channel. The list of colors is:
 // RED, CARROT, ORANGE, HONEY, YELLOW, LIME, GREEN, AQUA, CELESTE, SKY, BLUE,
 // PURPLE, FUCHSIA, MAGENTA, AZALEA, SALMON, WHITE
@@ -417,7 +421,7 @@ TraktorS3.Deck.prototype.numberButtonHandler = function(field) {
 
     // Samples mode
     var sampler = padNumber;
-    if (field.group === "deck2") {
+    if (field.group === "deck2" && TraktorS3.SixteenSamplers) {
         sampler += 8;
     }
 
@@ -452,6 +456,7 @@ TraktorS3.Deck.prototype.numberButtonHandler = function(field) {
         }
         return;
     }
+    // Play on an empty sampler loads that track into that sampler
     engine.setValue("[Sampler" + sampler + "]", "LoadSelectedTrack", field.value);
 };
 
@@ -937,7 +942,7 @@ TraktorS3.Deck.prototype.lightPads = function() {
         this.colorOutput(1, "samples");
         for (var i = 1; i <= 8; i++) {
             var idx = i;
-            if (this.group === "deck2") {
+            if (this.group === "deck2" && TraktorS3.SixteenSamplers) {
                 idx += 8;
             }
             var loaded = engine.getValue("[Sampler" + idx + "]", "track_loaded");
@@ -1030,6 +1035,7 @@ TraktorS3.Channel.prototype.trackLoadedHandler = function() {
     var trackSampleRate = engine.getValue(this.group, "track_samplerate");
     // Assume stereo.
     this.trackDurationSec = trackSamples / 2.0 / trackSampleRate;
+    this.parentDeck.lightPads();
 };
 
 TraktorS3.Channel.prototype.endOfTrackHandler = function(value) {
@@ -1080,6 +1086,8 @@ TraktorS3.Channel.prototype.linkOutputs = function() {
             TraktorS3.bind(TraktorS3.Channel.prototype.hotcuesOutput, this)));
         this.hotcueCallbacks.push(engine.makeConnection(this.group, "hotcue_" + j + "_activate",
             TraktorS3.bind(TraktorS3.Channel.prototype.hotcuesOutput, this)));
+        this.hotcueCallbacks.push(engine.makeConnection(this.group, "hotcue_" + j + "_color",
+            TraktorS3.bind(TraktorS3.Channel.prototype.hotcuesOutput, this)));
     }
 };
 
@@ -1105,6 +1113,9 @@ TraktorS3.Channel.prototype.hotcuesOutput = function(_value, group, key) {
     var deck = this.controller.Channels[group].parentDeck;
     if (deck.activeChannel !== group) {
         // Not active, ignore
+        return;
+    }
+    if (deck.padModeState !== 0) {
         return;
     }
     var matches = key.match(/hotcue_(\d+)_/);
@@ -1935,7 +1946,7 @@ TraktorS3.Controller.prototype.registerOutputPackets = function() {
     // Sampler callbacks
     for (i = 1; i <= 8; ++i) {
         this.samplerCallbacks.push(engine.makeConnection("[Sampler" + i + "]", "track_loaded", TraktorS3.bind(TraktorS3.Controller.prototype.samplesOutput, this)));
-        this.samplerCallbacks.push(engine.makeConnection("[Sampler" + i + "]", "play", TraktorS3.bind(TraktorS3.Controller.prototype.samplesOutput, this)));
+        this.samplerCallbacks.push(engine.makeConnection("[Sampler" + i + "]", "play_indicator", TraktorS3.bind(TraktorS3.Controller.prototype.samplesOutput, this)));
     }
 };
 
@@ -2026,8 +2037,12 @@ TraktorS3.Controller.prototype.resolveSampler = function(group) {
         return undefined;
     }
 
-    // Return sample number
-    return result[1];
+    // Return sampler as number if we can
+    var strResult = result[1];
+    if (strResult === undefined) {
+        return undefined;
+    }
+    return parseInt(strResult);
 };
 
 TraktorS3.Controller.prototype.samplesOutput = function(value, group, key) {
@@ -2039,22 +2054,37 @@ TraktorS3.Controller.prototype.samplesOutput = function(value, group, key) {
     if (sampler === undefined) {
         return;
     } else if (sampler > 8 && sampler < 17) {
+        if (!TraktorS3.SixteenSamplers) {
+            // These samplers are ignored
+            return;
+        }
         deck = this.Decks.deck2;
         num = sampler - 8;
     }
 
     // If we are in samples modes light corresponding LED
-    if (this.padModeState === 1) {
-        if (key === "play" && engine.getValue(group, "track_loaded")) {
-            if (value) {
-                // Green light on play
-                deck.colorOutput(0x9E, "!pad_" + num);
-            } else {
-                // Reset LED to full white light
-                deck.colorOutput(1, "!pad_" + num);
+    if (deck.padModeState !== 1) {
+        return;
+    }
+    if (key === "play_indicator" && engine.getValue(group, "track_loaded")) {
+        if (value) {
+            // Green light on play
+            this.hid.setOutput("deck1", "!pad_" + num, this.hid.LEDColors.GREEN + TraktorS3.LEDBrightValue, !this.batchingOutputs);
+            // Also light deck2 samplers in 8-sampler mode.
+            if (!TraktorS3.SixteenSamplers && this.Decks.deck2.padModeState === 1) {
+                this.hid.setOutput("deck2", "!pad_" + num, this.hid.LEDColors.GREEN + TraktorS3.LEDBrightValue, !this.batchingOutputs);
             }
-        } else if (key === "track_loaded") {
-            deck.colorOutput(value, "!pad_" + num);
+        } else {
+            // Reset LED to base color
+            deck.colorOutput(1, "!pad_" + num);
+            if (!TraktorS3.SixteenSamplers && this.Decks.deck2.padModeState === 1) {
+                this.Decks.deck2.colorOutput(1, "!pad_" + num);
+            }
+        }
+    } else if (key === "track_loaded") {
+        deck.colorOutput(value, "!pad_" + num);
+        if (!TraktorS3.SixteenSamplers && this.Decks.deck2.padModeState === 1) {
+            this.Decks.deck2.colorOutput(value, "!pad_" + num);
         }
     }
 };


### PR DESCRIPTION
* Properly re-light buttons on track load
* Fix hotcues not changing color when color is updated
* Fix sampler buttons not changing color on play
* Default to 8, not 16 samplers (deck 2 sampler buttons duplicate samplers 1-8)