### PR TITLE
Qt6 + ubuntu 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,10 @@ if(POLICY CMP0071)
   cmake_policy(SET CMP0071 NEW)
 endif()
 
-# propagate interface link properties
+# Propagate interface link properties
 if(POLICY CMP0099)
-  # this avoids a warning when qt deals with it see
+  # This avoids a warning when qt deals with different behaviours controlled by this policy
+  # in its cmake functions. See
   # https://github.com/qt/qtbase/commit/e3e1007f9778d8fc629a06f7d3d216bb7f81351b
   cmake_policy(SET CMP0099 NEW)
 endif()
@@ -1268,6 +1269,8 @@ if(QT6 AND CMAKE_VERSION VERSION_LESS "3.21")
   find_package(Qt6 REQUIRED COMPONENTS Core) # For Qt Core cmake functions
   # qt_add_executable() is the recommended initial call for qt_finalize_target()
   # below that takes care of the correct object order in the resulting binary
+  # According to https://doc.qt.io/qt-6/qt-finalize-target.html it is importand for
+  # builds with Qt < 3.21
   qt_add_executable(mixxx WIN32 src/main.cpp MANUAL_FINALIZATION)
 else()
   add_executable(mixxx WIN32 src/main.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1265,7 +1265,7 @@ elseif(UNIX)
 endif()
 
 # The mixxx executable
-if(QT6 AND CMAKE_VERSION VERSION_LESS "3.21")
+if(QT6)
   find_package(Qt6 REQUIRED COMPONENTS Core) # For Qt Core cmake functions
   # qt_add_executable() is the recommended initial call for qt_finalize_target()
   # below that takes care of the correct object order in the resulting binary
@@ -2221,11 +2221,9 @@ if(QT6)
   )
   target_link_libraries(mixxx-lib PRIVATE mixxx-qml-mixxxcontrolsplugin)
 
-  if(CMAKE_VERSION VERSION_LESS "3.21")
-    # qt_finalize_target takes care that the resources :/mixxx.org/imports/Mixxx/
-    # and :/mixxx.org/imports/Mixxx/Controls are placed into beginning of the binary
-    qt_finalize_target(mixxx)
-  endif()
+  # qt_finalize_target takes care that the resources :/mixxx.org/imports/Mixxx/
+  # and :/mixxx.org/imports/Mixxx/Controls are placed into beginning of the binary
+  qt_finalize_target(mixxx)
 endif()
 
 target_compile_definitions(mixxx-lib PUBLIC QT_TABLET_SUPPORT QT_USE_QSTRINGBUILDER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2194,7 +2194,7 @@ if(QT6)
     URI Mixxx.Controls
     VERSION 0.1
     RESOURCE_PREFIX /mixxx.org/imports
-    IMPORTS Mixxx
+    OPTIONAL_IMPORTS Mixxx
     QML_FILES
       res/qml/Mixxx/Controls/Knob.qml
       res/qml/Mixxx/Controls/Slider.qml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1258,6 +1258,8 @@ endif()
 # The mixxx executable
 if(QT6 AND CMAKE_VERSION VERSION_LESS "3.21")
   find_package(Qt6 REQUIRED COMPONENTS Core) # For Qt Core cmake functions
+  # qt_add_executable() is the recommended initial call for qt_finalize_target()
+  # below that takes care of the correct object order in the resulting binary
   qt_add_executable(mixxx WIN32 src/main.cpp MANUAL_FINALIZATION)
 else()
   add_executable(mixxx WIN32 src/main.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,14 @@ if(POLICY CMP0071)
   cmake_policy(SET CMP0071 NEW)
 endif()
 
+# propagate interface link properties
+if(POLICY CMP0099)
+  # this avoids a warning when qt deals with it see
+  # https://github.com/qt/qtbase/commit/e3e1007f9778d8fc629a06f7d3d216bb7f81351b
+  cmake_policy(SET CMP0099 NEW)
+endif()
+
+
 # Set up vcpkg
 if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED VCPKG_ROOT)
     set(VCPKG_ROOT "$ENV{VCPKG_ROOT}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2162,6 +2162,7 @@ if(QT6)
     URI Mixxx
     VERSION 0.1
     RESOURCE_PREFIX /mixxx.org/imports
+    IMPORTS QtQuick
     QML_FILES
       res/qml/Mixxx/MathUtils.mjs
       res/qml/Mixxx/PlayerDropArea.qml
@@ -2178,7 +2179,7 @@ if(QT6)
     URI Mixxx.Controls
     VERSION 0.1
     RESOURCE_PREFIX /mixxx.org/imports
-    OPTIONAL_IMPORTS Mixxx
+    IMPORTS Mixxx
     QML_FILES
       res/qml/Mixxx/Controls/Knob.qml
       res/qml/Mixxx/Controls/Slider.qml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1256,7 +1256,12 @@ elseif(UNIX)
 endif()
 
 # The mixxx executable
-add_executable(mixxx WIN32 src/main.cpp)
+if(QT6 AND CMAKE_VERSION VERSION_LESS "3.21")
+  find_package(Qt6 REQUIRED COMPONENTS Core) # For Qt Core cmake functions
+  qt_add_executable(mixxx WIN32 src/main.cpp MANUAL_FINALIZATION)
+else()
+  add_executable(mixxx WIN32 src/main.cpp)
+endif()
 # ugly hack to get #include "preferences/dialog/ui_dlgpreferencesdlg.h" to work in
 # src/qmldlgpreferencesproxy.h, which is #included from src/qmlapplication.h.
 target_include_directories(mixxx PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/mixxx-lib_autogen/include")
@@ -2189,6 +2194,12 @@ if(QT6)
       res/qml/Mixxx/Controls/WaveformOverview.qml
   )
   target_link_libraries(mixxx-lib PRIVATE mixxx-qml-mixxxcontrolsplugin)
+
+  if(CMAKE_VERSION VERSION_LESS "3.21")
+    # qt_finalize_target takes care that the resources :/mixxx.org/imports/Mixxx/
+    # and :/mixxx.org/imports/Mixxx/Controls are placed into beginning of the binary
+    qt_finalize_target(mixxx)
+  endif()
 endif()
 
 target_compile_definitions(mixxx-lib PUBLIC QT_TABLET_SUPPORT QT_USE_QSTRINGBUILDER)

--- a/res/qml/Mixxx/qmldir
+++ b/res/qml/Mixxx/qmldir
@@ -3,6 +3,7 @@ linktarget mixxx-libplugin
 optional plugin mixxx-libplugin
 classname MixxxPlugin
 typeinfo mixxx-lib.qmltypes
+import QtQuick
 prefer :/mixxx.org/imports/Mixxx/
 MathUtils 0.0 res/qml/Mixxx/MathUtils.mjs
 PlayerDropArea 0.0 res/qml/Mixxx/PlayerDropArea.qml

--- a/src/qml/qmlapplication.cpp
+++ b/src/qml/qmlapplication.cpp
@@ -18,6 +18,7 @@
 #include "qml/qmlvisibleeffectsmodel.h"
 #include "qml/qmlwaveformoverview.h"
 #include "soundio/soundmanager.h"
+Q_IMPORT_QML_PLUGIN(MixxxPlugin)
 Q_IMPORT_QML_PLUGIN(Mixxx_ControlsPlugin)
 
 namespace {

--- a/src/qml/qmlwaveformoverview.h
+++ b/src/qml/qmlwaveformoverview.h
@@ -40,6 +40,8 @@ class QmlWaveformOverview : public QQuickPaintedItem {
     Q_ENUM(Renderer)
 
     QmlWaveformOverview(QQuickItem* parent = nullptr);
+    ~QmlWaveformOverview() override = default;
+
     void paint(QPainter* painter);
 
     void setPlayer(QmlPlayerProxy* player);


### PR DESCRIPTION
This allows to build and run Mixxx on Ubuntu using https://launchpad.net/~daschuer/+archive/ubuntu/qt6-backports

The main issue was that CMake < 3.21 requires to use qt_finalize_target(mixxx) to ensure that the resources are all linked at the beginning of the mixxx binary.  