### PR TITLE
Qmllint fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2197,6 +2197,8 @@ if(QT6)
     FILES "res/qml/Mixxx/qmldir"
     PREFIX "/mixxx.org/imports/Mixxx"
   )
+  # to make also qmllint happy
+  configure_file(res/qml/Mixxx/qmldir qml/Mixxx/qmldir COPYONLY)
 
   # FIXME: Currently we need to add these include directories due to
   # QTBUG-87221. We should figure out a better way to fix this.

--- a/res/qml/Mixxx/Controls/WaveformOverview.qml
+++ b/res/qml/Mixxx/Controls/WaveformOverview.qml
@@ -39,7 +39,7 @@ Mixxx.WaveformOverview {
                 required property int index
 
                 anchors.fill: parent
-                group: root.group
+                group: root.group // qmllint disable unqualified
                 hotcueNumber: this.index + 1
             }
 


### PR DESCRIPTION
This fixes on remaining qmllint issue. 
It can be fixed for qmllint by 
`parent.parent.parent.group` 
But than it no longer works in the code. 

I guess it is a qmllint bug, but I have not enough experience to report it upstream. 

The other issue was introduced by: 
https://github.com/mixxxdj/mixxx/pull/4673
