### PR TITLE
qmlformat: Probe first the most common Qt6 path

### DIFF
--- a/tools/qmlformat.py
+++ b/tools/qmlformat.py
@@ -30,9 +30,13 @@ def find_qt_version():
 
 def main(argv=None):
     # First look up at the most common location for QT6 which is not in PATH
+    # This applies to Debian, Arch and Fedora (i686)
     qmlformat_executable = shutil.which(
         "qmlformat", os.F_OK, "/usr/lib/qt6/bin"
     )
+    if not qmlformat_executable:
+        # On Fedora qmlformat-qt6 is on PATH
+        qmlformat_executable = shutil.which("qmlformat-qt6")
     if not qmlformat_executable:
         qmlformat_executable = shutil.which("qmlformat")
     if not qmlformat_executable:

--- a/tools/qmlformat.py
+++ b/tools/qmlformat.py
@@ -8,7 +8,6 @@ import subprocess
 import pathlib
 import sys
 import re
-import os
 
 QMLFORMAT_MISSING_MESSAGE = """
 qmlformat is not installed or not in your $PATH, please install.
@@ -29,14 +28,13 @@ def find_qt_version():
 
 
 def main(argv=None):
-    # First look up at the most common location for QT6 which is not in PATH
-    # This applies to Debian, Arch and Fedora (i686)
-    qmlformat_executable = shutil.which(
-        "qmlformat", os.F_OK, "/usr/lib/qt6/bin"
-    )
-    if not qmlformat_executable:
-        # On Fedora qmlformat-qt6 is on PATH
-        qmlformat_executable = shutil.which("qmlformat-qt6")
+    # First look up at the most common location for QT6 which is
+    # usually not in PATH
+    if sys.platform != "win32":
+        qmlformat_executable = shutil.which(
+            "qmlformat", path="/usr/lib/qt6/bin:/usr/lib64/qt6/bin"
+        )
+    # Then look in PATH
     if not qmlformat_executable:
         qmlformat_executable = shutil.which("qmlformat")
     if not qmlformat_executable:

--- a/tools/qmlformat.py
+++ b/tools/qmlformat.py
@@ -8,6 +8,7 @@ import subprocess
 import pathlib
 import sys
 import re
+import os
 
 QMLFORMAT_MISSING_MESSAGE = """
 qmlformat is not installed or not in your $PATH, please install.
@@ -28,7 +29,12 @@ def find_qt_version():
 
 
 def main(argv=None):
-    qmlformat_executable = shutil.which("qmlformat")
+    # First look up at the most common location for QT6 which is not in PATH
+    qmlformat_executable = shutil.which(
+        "qmlformat", os.F_OK, "/usr/lib/qt6/bin"
+    )
+    if not qmlformat_executable:
+        qmlformat_executable = shutil.which("qmlformat")
     if not qmlformat_executable:
         qt_version = find_qt_version()
         if qt_version is None or qt_version < (5, 15):


### PR DESCRIPTION
Normally the Qt6 tools are not at PATH, because the location is known by CMake. 
The qtchooser that puts QT5 to PATH is no longer maintained for QT6 
That is why the pre-commit hook finds the QT5 version. However we have dropped the QT5 support for the qml gui and it should prefer the QT6 version. This PR looks at the Qt6 binary path first and falls back to the old behavior. 


