### PR TITLE
MediaFoundation: remove redundant m4v type

### DIFF
--- a/src/sources/soundsourcemediafoundation.cpp
+++ b/src/sources/soundsourcemediafoundation.cpp
@@ -52,7 +52,6 @@ const QString SoundSourceProviderMediaFoundation::kDisplayName =
 const QStringList SoundSourceProviderMediaFoundation::kSupportedFileTypes = {
         QStringLiteral("aac"),
         QStringLiteral("m4a"),
-        QStringLiteral("m4v"),
         QStringLiteral("mp4"),
 };
 


### PR DESCRIPTION
It is already registered as mp4. 
This should fix a debug assertion in https://bugs.launchpad.net/mixxx/+bug/1961623