### PR TITLE
Denon MC7000: Add optional jog wheel acceleration to the controller mapping

### DIFF
--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -98,7 +98,7 @@ MC7000.jogParams = {
     // set to 3 with audio buffer set to 5ms
     sensitivity: engine.getSetting("jogSensitivity") || 1,
     // Acceleration settings for the jog wheel in vinyl mode
-    // If enabled, the track speed will accelerate faster than the physical jogheel movement. Be aware, that the absolute track position will drift relative to the jogwheel position in  this mode!
+    // If enabled, the track speed will accelerate faster than the physical jogheel movement. Be aware that the absolute track position will drift relative to the jogwheel position in this mode!
     // (exponent: 0 and coefficient: 1 = no acceleration)
     acceleration: {
         // Toggles acceleration entirely.

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -98,6 +98,7 @@ MC7000.jogParams = {
     // set to 3 with audio buffer set to 5ms
     sensitivity: 1,
     // Acceleration settings for the jog wheel in vinyl mode
+    // If enabled, the track speed will accelerate faster than the physical jogheel movement. Be aware, that the absolute track position will drift relative to the jogwheel position in  this mode!
     // (exponent: 0 and coefficient: 1 = no acceleration)
     acceleration: {
         // Toggles acceleration entirely.

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -96,17 +96,17 @@ MC7000.jogParams = {
     // set to 0.5 with audio buffer set to 50ms
     // set to 1 with audio buffer set to 25ms
     // set to 3 with audio buffer set to 5ms
-    sensitivity: 1,
+    sensitivity: engine.getSetting("jogSensitivity") || 1,
     // Acceleration settings for the jog wheel in vinyl mode
     // If enabled, the track speed will accelerate faster than the physical jogheel movement. Be aware, that the absolute track position will drift relative to the jogwheel position in  this mode!
     // (exponent: 0 and coefficient: 1 = no acceleration)
     acceleration: {
         // Toggles acceleration entirely.
-        enabled: false,
+        enabled: engine.getSetting("jogAccelerationEnabled") || false,
         // Acceleration function exponent
-        exponent: 0.8,
+        exponent: engine.getSetting("jogAccelerationExponent") || 0.8,
         // Acceleration function scaling factor
-        coefficient: 1
+        coefficient: engine.getSetting("jogAccelerationCoefficient") || 1
     }
 };
 

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -89,13 +89,25 @@ MC7000.scratchParams = {
     beta: (1.0/10)/32
 };
 
-// Sensitivity factor of the jog wheel (also depends on audio latency)
-// 0.5 for half, 2 for double sensitivity - Recommendation:
-// set to 0.5 with audio buffer set to 50ms
-// set to 1 with audio buffer set to 25ms
-// set to 3 with audio buffer set to 5ms
-MC7000.jogSensitivity = 1;
-
+// Jog wheel parameters
+MC7000.jogParams = {
+    // Sensitivity factor of the jog wheel (also depends on audio latency)
+    // 0.5 for half, 2 for double sensitivity - Recommendation:
+    // set to 0.5 with audio buffer set to 50ms
+    // set to 1 with audio buffer set to 25ms
+    // set to 3 with audio buffer set to 5ms
+    sensitivity: 1,
+    // Acceleration settings for the jog wheel in vinyl mode
+    // (exponent: 0 and coefficient: 1 = no acceleration)
+    acceleration: {
+        // Toggles acceleration entirely.
+        enabled: false,
+        // Acceleration function exponent
+        exponent: 0.8,
+        // Acceleration function scaling factor
+        coefficient: 1
+    }
+};
 
 /*/////////////////////////////////
 //      USER VARIABLES END       //
@@ -705,7 +717,8 @@ MC7000.wheelTurn = function(channel, control, value, status, group) {
 
     // A: For a control that centers on 0:
     const numTicks = (value < 0x64) ? value : (value - 128);
-    const adjustedSpeed = numTicks * MC7000.jogSensitivity / 10;
+    const baseSpeed = numTicks * MC7000.jogParams.sensitivity;
+    const adjustedSpeed = baseSpeed / 10;
     const deckNumber = script.deckFromGroup(group);
     const deckIndex = deckNumber - 1;
     const libraryMaximized = engine.getValue("[Skin]", "show_maximized_library");
@@ -714,8 +727,14 @@ MC7000.wheelTurn = function(channel, control, value, status, group) {
     } else if (libraryMaximized === 1 && numTicks < 0) {
         engine.setValue("[Library]", "MoveUp", 1);
     } else if (engine.isScratching(deckNumber)) {
-    // Scratch!
-        engine.scratchTick(deckNumber, numTicks * MC7000.jogSensitivity);
+        // Scratch!
+        let scratchSpeed = baseSpeed;
+        const acceleration = MC7000.jogParams.acceleration;
+        if (acceleration && acceleration.enabled) {
+            const accelerationFactor = Math.pow(Math.abs(baseSpeed), acceleration.exponent) * acceleration.coefficient;
+            scratchSpeed *= accelerationFactor;
+        }
+        engine.scratchTick(deckNumber, scratchSpeed);
     } else {
         if (MC7000.shift[deckIndex]) {
             // While Shift Button pressed -> Search through track

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -98,7 +98,7 @@ MC7000.jogParams = {
     // set to 3 with audio buffer set to 5ms
     sensitivity: engine.getSetting("jogSensitivity") || 1,
     // Acceleration settings for the jog wheel in vinyl mode
-    // If enabled, the track speed will accelerate faster than the physical jogheel movement. Be aware that the absolute track position will drift relative to the jogwheel position in this mode!
+    // If enabled, the track speed will accelerate faster than the physical jogwheel movement. Be aware that the absolute track position will drift relative to the jogwheel position in this mode!
     // (exponent: 0 and coefficient: 1 = no acceleration)
     acceleration: {
         // Toggles acceleration entirely.

--- a/res/controllers/Denon-MC7000.midi.xml
+++ b/res/controllers/Denon-MC7000.midi.xml
@@ -14,9 +14,8 @@
                 <option
                     variable="jogSensitivity"
                     type="real"
-                    precision="2"
                     min="0.05"
-                    max="3.0"
+                    max="10.0"
                     default="1.0"
                     label="Jogwheel sensitivity">
                     <description>

--- a/res/controllers/Denon-MC7000.midi.xml
+++ b/res/controllers/Denon-MC7000.midi.xml
@@ -34,7 +34,7 @@
                     default="false"
                     label="Enable jogwheel acceleration">
                     <description>
-                        If enabled, the track speed will accelerate faster than the physical jogheel movement. Be aware that the absolute track position will drift relative to the jogwheel position in this mode!
+                        If enabled, the track speed will accelerate faster than the physical jogwheel movement. Be aware that the absolute track position will drift relative to the jogwheel position in this mode!
                         (exponent: 0 and coefficient: 1 = no acceleration)
                     </description>
                 </option>

--- a/res/controllers/Denon-MC7000.midi.xml
+++ b/res/controllers/Denon-MC7000.midi.xml
@@ -35,7 +35,7 @@
                     default="false"
                     label="Enable jogwheel acceleration">
                     <description>
-                        If enabled, the track speed will accelerate faster than the physical jogheel movement. Be aware, that the absolute track position will drift relative to the jogwheel position in  this mode!
+                        If enabled, the track speed will accelerate faster than the physical jogheel movement. Be aware that the absolute track position will drift relative to the jogwheel position in this mode!
                         (exponent: 0 and coefficient: 1 = no acceleration)
                     </description>
                 </option>

--- a/res/controllers/Denon-MC7000.midi.xml
+++ b/res/controllers/Denon-MC7000.midi.xml
@@ -43,8 +43,9 @@
                     variable="jogAccelerationExponent"
                     type="real"
                     min="0"
-                    max="2.0"
+                    max="20.0"
                     default="0.8"
+                    step="0.1"
                     label="Acceleration exponent">
                     <description>
                         The exponent of the acceleration curve
@@ -54,7 +55,8 @@
                     variable="jogAccelerationCoefficient"
                     type="real"
                     min="0.05"
-                    max="3.0"
+                    max="20.0"
+                    step="0.1"
                     default="1.0"
                     label="Acceleration coefficient">
                     <description>

--- a/res/controllers/Denon-MC7000.midi.xml
+++ b/res/controllers/Denon-MC7000.midi.xml
@@ -8,6 +8,62 @@
     	<wiki>https://github.com/mixxxdj/mixxx/wiki/Denon-MC7000</wiki>
         <manual>denon_mc7000</manual>
     </info>
+    <settings>
+        <group label="Jogwheels">
+            <group label="General">
+                <option
+                    variable="jogSensitivity"
+                    type="real"
+                    precision="2"
+                    min="0.05"
+                    max="3.0"
+                    default="1.0"
+                    label="Jogwheel sensitivity">
+                    <description>
+                        Sensitivity factor of the jog wheel (also depends on audio latency)
+                        0.5 for half, 2 for double sensitivity - Recommendation:
+                        set to 0.5 with audio buffer set to 50ms
+                        set to 1 with audio buffer set to 25ms
+                        set to 3 with audio buffer set to 5ms
+                    </description>
+                </option>
+            </group>
+            <group label="Acceleration">
+                <option
+                    variable="jogAccelerationEnabled"
+                    type="boolean"
+                    default="false"
+                    label="Enable jogwheel acceleration">
+                    <description>
+                        If enabled, the track speed will accelerate faster than the physical jogheel movement. Be aware, that the absolute track position will drift relative to the jogwheel position in  this mode!
+                        (exponent: 0 and coefficient: 1 = no acceleration)
+                    </description>
+                </option>
+                <option
+                    variable="jogAccelerationExponent"
+                    type="real"
+                    min="0"
+                    max="2.0"
+                    default="0.8"
+                    label="Acceleration exponent">
+                    <description>
+                        The exponent of the acceleration curve
+                    </description>
+                </option>
+                <option
+                    variable="jogAccelerationCoefficient"
+                    type="real"
+                    min="0.05"
+                    max="3.0"
+                    default="1.0"
+                    label="Acceleration coefficient">
+                    <description>
+                        The scaling factor of the acceleration curve
+                    </description>
+                </option>
+            </group>
+        </group>
+    </settings>
     <controller id="DENON MC7000">
         <scriptfiles>
             <file filename="Denon-MC7000-scripts.js" functionprefix="MC7000"/>


### PR DESCRIPTION
### Based on #4757 

While toying around with the jog wheels on the MC7000, I have noticed that Serato performs a form of accelerated scrubbing when scratching in vinyl mode, i.e. the jog sensitivity increases the faster you turn the wheel. Acceleration can be useful to both precisely navigate the track and scrub quickly without having to press shift.

This PR adds a simple, configurable and entirely optional acceleration whose curve is a simple monomial function. In pseudocode:

```
accelerationFactor = pow(baseSpeed, accelerationExponent) * accelerationCoefficient
scratchSpeed = baseSpeed * accelerationFactor
```

When acceleration is disabled (which it is by default, or the exponent is 0 and the coefficient 1), we get the current behavior:

```
scratchSpeed = baseSpeed
```

Thoughts?