### PR TITLE
LateNight: option to show seconds at toolbar clock widget

### DIFF
--- a/res/skins/LateNight/helpers/skin_settings_compact_deck.xml
+++ b/res/skins/LateNight/helpers/skin_settings_compact_deck.xml
@@ -9,8 +9,6 @@ Description:
     <Layout>vertical</Layout>
     <Children>
 
-      <WidgetGroup><Size>0me,6f</Size></WidgetGroup>
-
       <!-- Loop/Jump Controls in compact decks-->
       <Template src="skin:/helpers/skin_settings_button_2state.xml">
         <SetVariable name="TooltipId"></SetVariable>
@@ -56,8 +54,6 @@ Description:
         <SetVariable name="Text">Vinyl Control</SetVariable>
         <SetVariable name="Setting">[VinylControl],show_vinylcontrol</SetVariable>
       </Template>
-
-      <WidgetGroup><Size>0me,6f</Size></WidgetGroup>
 
       <!-- Level meters -->
       <Template src="skin:/helpers/skin_settings_button_2state.xml">

--- a/res/skins/LateNight/helpers/skin_settings_full_deck.xml
+++ b/res/skins/LateNight/helpers/skin_settings_full_deck.xml
@@ -64,8 +64,6 @@ Description:
         <SetVariable name="Setting">[Skin],show_intro_outro_cues</SetVariable>
       </Template>
 
-      <WidgetGroup><Size>0me,6f</Size></WidgetGroup>
-
       <!-- Rate Controls -->
       <Template src="skin:/helpers/skin_settings_button_2state.xml">
         <SetVariable name="TooltipId">rate_toggle</SetVariable>
@@ -104,8 +102,6 @@ Description:
         <SetVariable name="Text">Vinyl Control</SetVariable>
         <SetVariable name="Setting">[VinylControl],show_vinylcontrol</SetVariable>
       </Template>
-
-      <WidgetGroup><Size>0me,6f</Size></WidgetGroup>
 
       <!-- Spinny -->
       <Template src="skin:/helpers/skin_settings_button_2state.xml">

--- a/res/skins/LateNight/helpers/skin_settings_mini_deck.xml
+++ b/res/skins/LateNight/helpers/skin_settings_mini_deck.xml
@@ -9,7 +9,7 @@ Description:
     <Layout>vertical</Layout>
     <Children>
 
-      <WidgetGroup><Size>0me,120f</Size></WidgetGroup>
+      <WidgetGroup><Size>0me,108f</Size></WidgetGroup>
 
       <!-- Spinny -->
       <Template src="skin:/helpers/skin_settings_button_2state.xml">

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -39,6 +39,7 @@
     <!-- Set skin defaults -->
       <attribute config_key="[Master],num_decks">4</attribute>
       <attribute config_key="[Master],num_samplers">16</attribute>
+      <attribute persist="true" config_key="[Skin],show_seconds">0</attribute>
       <attribute persist="true" config_key="[Skin],show_waveforms">1</attribute>
       <attribute persist="true" config_key="[Skin],timing_shift_buttons">0</attribute>
 

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -25,6 +25,32 @@ Description:
         <Size>240f,1me</Size>
         <Children>
 
+          <!-- Toolbar -->
+          <Label>
+            <ObjectName>CategoryLabel</ObjectName>
+            <Text>Toolbar</Text>
+            <Size>180min,23f</Size>
+          </Label>
+
+          <WidgetGroup>
+            <ObjectName>SkinSettingsCategory</ObjectName>
+            <SizePolicy>me,min</SizePolicy>
+            <Layout>vertical</Layout>
+            <Children>
+              <!-- Show Seconds -->
+              <Template src="skin:/helpers/skin_settings_button_2state.xml">
+                <!-- <SetVariable name="TooltipId">show_seconds</SetVariable> --><!-- global tooltip at "src/skin/legacy/tooltips.cpp"? -->
+                <SetVariable name="Text">Show Seconds</SetVariable>
+                <SetVariable name="Setting">[Skin],show_seconds</SetVariable>
+              </Template>
+            </Children>
+          </WidgetGroup><!-- /Toolbar -->
+
+          <WidgetGroup>
+            <ObjectName>SkinSettingsSeparator</ObjectName>
+            <Size>1min,12f</Size>
+          </WidgetGroup>
+
           <!-- Decks -->
           <WidgetGroup>
             <Layout>horizontal</Layout>

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -29,7 +29,7 @@ Description:
           <Label>
             <ObjectName>CategoryLabel</ObjectName>
             <Text>Toolbar</Text>
-            <Size>180min,23f</Size>
+            <Size>me,min</Size>
           </Label>
 
           <WidgetGroup>
@@ -45,6 +45,61 @@ Description:
               </Template>
             </Children>
           </WidgetGroup><!-- /Toolbar -->
+
+          <WidgetGroup>
+            <ObjectName>SkinSettingsSeparator</ObjectName>
+            <Size>1min,min</Size>
+          </WidgetGroup>
+
+          <!--  Waveforms -->
+          <WidgetGroup>
+            <SizePolicy>me,f</SizePolicy>
+            <Layout>stacked</Layout>
+            <Children>
+              <!-- translucent cover when Library is not maximized -->
+              <Template src="skin:/helpers/skin_settings_cover.xml">
+                <SetVariable name="Setting">[Master],maximize_library</SetVariable>
+              </Template>
+
+              <WidgetGroup>
+                <SizePolicy>me,min</SizePolicy>
+                <Layout>vertical</Layout>
+                <Children>
+                  <Template src="skin:/helpers/skin_settings_labelbutton_2state.xml">
+                    <SetVariable name="Text">Waveforms</SetVariable>
+                    <SetVariable name="Setting">[Skin],show_waveforms</SetVariable>
+                    <SetVariable name="TooltipId">show_waveforms</SetVariable>
+                    <SetVariable name="Width">190me</SetVariable>
+                  </Template>
+
+                  <!-- Cue shift buttons in beatgrid editing section -->
+                  <WidgetGroup>
+                    <ObjectName>SkinSettingsCategory</ObjectName>
+                    <SizePolicy>me,f</SizePolicy>
+                    <Layout>stacked</Layout>
+                    <Children>
+                      <!-- translucent cover when waveforms are hidden -->
+                      <Template src="skin:/helpers/skin_settings_cover_inverted.xml">
+                        <SetVariable name="Setting">[Skin],show_waveforms</SetVariable>
+                      </Template>
+
+                      <!-- translucent cover when beatgrid controls are hidden -->
+                      <Template src="skin:/helpers/skin_settings_cover_inverted.xml">
+                        <SetVariable name="Setting">[Skin],show_beatgrid_controls</SetVariable>
+                      </Template>
+
+                      <Template src="skin:/helpers/skin_settings_button_2state.xml">
+                        <SetVariable name="TooltipId">show_intro_outro_cues</SetVariable>
+                        <SetVariable name="Text">Hotcue Shift Buttons</SetVariable>
+                        <SetVariable name="Setting">[Skin],timing_shift_buttons</SetVariable>
+                      </Template>
+
+                    </Children>
+                  </WidgetGroup>
+                </Children>
+              </WidgetGroup>
+            </Children>
+          </WidgetGroup><!-- Waveforms -->
 
           <WidgetGroup>
             <ObjectName>SkinSettingsSeparator</ObjectName>
@@ -174,7 +229,6 @@ Description:
           </WidgetGroup><!-- DeckSizeSettings -->
 <!-- Deck size selectors -->
 
-
 <!-- Deck Options FULL / Compact / mini -->
           <WidgetGroup>
             <SizePolicy>me,f</SizePolicy>
@@ -239,64 +293,6 @@ Description:
             </Children>
           </WidgetGroup>
 <!-- Deck Options FULL / Compact / mini -->
-
-
-
-<!-- Other skin options -->
-          <WidgetGroup>
-            <ObjectName>SkinSettingsSeparator</ObjectName>
-            <Size>1min,12f</Size>
-          </WidgetGroup>
-
-          <!--  Waveforms -->
-          <WidgetGroup>
-            <SizePolicy>me,f</SizePolicy>
-            <Layout>stacked</Layout>
-            <Children>
-              <!-- translucent cover when Library is not maximized -->
-              <Template src="skin:/helpers/skin_settings_cover.xml">
-                <SetVariable name="Setting">[Master],maximize_library</SetVariable>
-              </Template>
-
-              <WidgetGroup>
-                <SizePolicy>me,min</SizePolicy>
-                <Layout>vertical</Layout>
-                <Children>
-                  <Template src="skin:/helpers/skin_settings_labelbutton_2state.xml">
-                    <SetVariable name="Text">Waveforms</SetVariable>
-                    <SetVariable name="Setting">[Skin],show_waveforms</SetVariable>
-                    <SetVariable name="TooltipId">show_waveforms</SetVariable>
-                    <SetVariable name="Width">190me</SetVariable>
-                  </Template>
-
-                  <!-- Cue shift buttons in beatgrid editing section -->
-                  <WidgetGroup>
-                    <ObjectName>SkinSettingsCategory</ObjectName>
-                    <SizePolicy>me,f</SizePolicy>
-                    <Layout>stacked</Layout>
-                    <Children>
-                      <!-- translucent cover when waveforms are hidden -->
-                      <Template src="skin:/helpers/skin_settings_cover_inverted.xml">
-                        <SetVariable name="Setting">[Skin],show_waveforms</SetVariable>
-                      </Template>
-
-                      <!-- translucent cover when beatgrid controls are hidden -->
-                      <Template src="skin:/helpers/skin_settings_cover_inverted.xml">
-                        <SetVariable name="Setting">[Skin],show_beatgrid_controls</SetVariable>
-                      </Template>
-
-                      <Template src="skin:/helpers/skin_settings_button_2state.xml">
-                        <SetVariable name="TooltipId">show_intro_outro_cues</SetVariable>
-                        <SetVariable name="Text">Hotcue Shift Buttons</SetVariable>
-                        <SetVariable name="Setting">[Skin],timing_shift_buttons</SetVariable>
-                      </Template>
-
-                    </Children>
-                  </WidgetGroup>
-                </Children>
-              </WidgetGroup>
-            </Children>
-          </WidgetGroup><!-- Waveforms -->
 
           <WidgetGroup>
             <ObjectName>SkinSettingsSeparator</ObjectName>

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -254,7 +254,7 @@ WSearchLineEdit,
     max-height: 2px;
   }
   #SkinSettingsSeparator {
-    margin: 0px 4px 7px 0px;
+    margin: 0px 4px 0px 4px;
   }
 
 WBeatSpinBox,

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -254,7 +254,7 @@ WSearchLineEdit,
     max-height: 2px;
   }
   #SkinSettingsSeparator {
-    margin: 3px 4px 7px 4px;
+    margin: 0px 4px 7px 0px;
   }
 
 WBeatSpinBox,

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -318,7 +318,7 @@ WSearchLineEdit {
     margin: 0px 5px;
   }
   #SkinSettingsSeparator {
-    margin: 3px 4px 7px 4px;
+    margin: 0px 4px 7px 0px;
   }
 
 /* dynamic bottom border in #DeckRow1_ */

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -318,7 +318,7 @@ WSearchLineEdit {
     margin: 0px 5px;
   }
   #SkinSettingsSeparator {
-    margin: 0px 4px 7px 0px;
+    margin: 0px 4px 0px 4px;
   }
 
 /* dynamic bottom border in #DeckRow1_ */

--- a/res/skins/LateNight/toolbar.xml
+++ b/res/skins/LateNight/toolbar.xml
@@ -137,6 +137,8 @@
         </Connection>
       </StatusLight>
 
+      <!-- Clock widgets -->
+      <!-- Standard clock widget -->
       <WidgetGroup>
         <ObjectName>ClockWidget</ObjectName>
         <Layout>horizontal</Layout>
@@ -147,7 +149,29 @@
             <CustomFormat>hh:mm</CustomFormat>
           </Time>
         </Children>
+        <Connection>
+          <ConfigKey>[Skin],show_seconds</ConfigKey>
+          <BindProperty>visible</BindProperty>
+          <Transform><Not/></Transform>
+        </Connection>
       </WidgetGroup>
+
+      <!-- Clock widget with seconds -->
+      <WidgetGroup>
+        <ObjectName>ClockWidget</ObjectName>
+        <Layout>horizontal</Layout>
+        <SizePolicy>min,min</SizePolicy>
+        <Children>
+          <Time>
+            <TooltipId>time</TooltipId>
+            <CustomFormat>hh:mm:ss</CustomFormat>
+          </Time>
+        </Children>
+        <Connection>
+          <ConfigKey>[Skin],show_seconds</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup><!-- /Clock widgets -->
 
       <WidgetGroup><Size>7f,1min</Size></WidgetGroup>
 


### PR DESCRIPTION
This PR adds an option to LateNight skin settings to show seconds at toolbar clock widget.
Especially for radio DJs it's important to see seconds within Mixxx, otherwise they need an external clock or can not use Mixxx in fullscreen mode to see OS clock.
As there are already a lot of options at skin settings I removed spacers or margins as much as possible.

As well I reordered settings to represent the skin from top to bottom.
I'm not 100% sure about the reordering, maybe decks section should be moved to the top again because this is IMHO most used section. **So please provide feedback about this.**

Settings pane still fits to 768 vertical pixels on notebooks.
Tested on: Xubuntu, Ubuntu and Windows 10, all with PaleMoon and Classic
**Is there anybody who can test this PR on macOS?**

Currently there's no tooltip at toggle because I don't know how to add custom tooltips to toggles at skin settings menu.
**Maybe this can be added to the global tooltip file?**
On the other hand I guess this toggle is self-explanatory.

Initial setting is to show standard clock without seconds.
Setting will persist.

Screenshot before:
![before](https://user-images.githubusercontent.com/1218375/155526599-a2a6be3b-980d-40b9-93b4-2229c261de89.jpg)


Screenshot after:
![after](https://user-images.githubusercontent.com/1218375/155526628-18e47ce0-d29a-4518-ad2f-4b98b092ec4c.jpg)

