### PR TITLE
Keep all meta knobs when loading presets if the user preference is set to keep the values.

### DIFF
--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -259,22 +259,21 @@ EffectParameterSlotBasePointer EffectSlot::getEffectParameterSlot(
 
 void EffectSlot::loadEffectFromPreset(const EffectPresetPointer pPreset) {
     if (!pPreset || pPreset->isEmpty()) {
-        loadEffectInner(nullptr, nullptr, true);
+        loadEffectInner(nullptr, nullptr);
         return;
     }
     EffectManifestPointer pManifest = m_pBackendManager->getManifest(
             pPreset->id(), pPreset->backendType());
-    loadEffectInner(pManifest, pPreset, true);
+    loadEffectInner(pManifest, pPreset);
 }
 
 void EffectSlot::loadEffectWithDefaults(const EffectManifestPointer pManifest) {
     EffectPresetPointer pPreset = m_pPresetManager->getDefaultPreset(pManifest);
-    loadEffectInner(pManifest, pPreset, false);
+    loadEffectInner(pManifest, pPreset);
 }
 
 void EffectSlot::loadEffectInner(const EffectManifestPointer pManifest,
-        EffectPresetPointer pEffectPreset,
-        bool adoptMetaknobFromPreset) {
+        EffectPresetPointer pEffectPreset) {
     if (kEffectDebugOutput) {
         if (pManifest) {
             qDebug() << this << m_group << "loading effect" << pManifest->id();
@@ -349,14 +348,7 @@ void EffectSlot::loadEffectInner(const EffectManifestPointer pManifest,
     m_pControlLoaded->forceSet(1.0);
 
     if (m_pEffectsManager->isAdoptMetaknobSettingEnabled()) {
-        if (adoptMetaknobFromPreset) {
-            // Update the ControlObject value, but do not sync the parameters
-            // with slotEffectMetaParameter. This allows presets to intentionally
-            // save parameters in a state inconsistent with the metaknob.
-            m_pControlMetaParameter->set(pEffectPreset->metaParameter());
-        } else {
-            slotEffectMetaParameter(m_pControlMetaParameter->get(), true);
-        }
+        slotEffectMetaParameter(m_pControlMetaParameter->get(), true);
     } else {
         m_pControlMetaParameter->set(pEffectPreset->metaParameter());
         slotEffectMetaParameter(pEffectPreset->metaParameter(), true);

--- a/src/effects/effectslot.h
+++ b/src/effects/effectslot.h
@@ -159,7 +159,8 @@ class EffectSlot : public QObject {
 
     /// Call with nullptr for pManifest and pPreset to unload an effect
     void loadEffectInner(const EffectManifestPointer pManifest,
-            EffectPresetPointer pPreset);
+            EffectPresetPointer pPreset,
+            bool loadingFromPreset);
 
     void loadParameters();
     void unloadEffect();

--- a/src/effects/effectslot.h
+++ b/src/effects/effectslot.h
@@ -159,8 +159,7 @@ class EffectSlot : public QObject {
 
     /// Call with nullptr for pManifest and pPreset to unload an effect
     void loadEffectInner(const EffectManifestPointer pManifest,
-            EffectPresetPointer pPreset,
-            bool adoptMetaknobFromPreset = false);
+            EffectPresetPointer pPreset);
 
     void loadParameters();
     void unloadEffect();

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -163,8 +163,11 @@ EffectChainPointer EffectsManager::getEffectChain(
     return m_effectChainSlotsByGroup.value(group);
 }
 
-bool EffectsManager::isAdoptMetaknobSettingEnabled() const {
-    return m_pConfig->getValue(ConfigKey("[Effects]", "AdoptMetaknobValue"), true);
+AdoptMetaknobValue EffectsManager::adoptMetaknobSetting() const {
+    const QString v =
+            m_pConfig->getValue(ConfigKey("[Effects]", "AdoptMetaknobEnum"),
+                    toQString(defaultAdoptMetaknobValue));
+    return toAdoptMetaknobValue(v);
 }
 
 void EffectsManager::readEffectsXml() {
@@ -235,4 +238,29 @@ void EffectsManager::saveEffectsXml() {
     }
     file.write(doc.toString().toUtf8());
     file.close();
+}
+
+AdoptMetaknobValue toAdoptMetaknobValue(const QString& v) {
+    if (v == "KEEP_ALL") {
+        return AdoptMetaknobValue::KEEP_ALL;
+    } else if (v == "KEEP_TOP") {
+        return AdoptMetaknobValue::KEEP_TOP;
+    } else if (v == "LOAD_DEFAULT") {
+        return AdoptMetaknobValue::LOAD_DEFAULT;
+    } else {
+        return defaultAdoptMetaknobValue;
+    }
+}
+
+QString toQString(AdoptMetaknobValue v) {
+    switch (v) {
+    case AdoptMetaknobValue::KEEP_ALL:
+        return "KEEP_ALL";
+    case AdoptMetaknobValue::KEEP_TOP:
+        return "KEEP_TOP";
+    case AdoptMetaknobValue::LOAD_DEFAULT:
+        return "LOAD_DEFAULT";
+    default:
+        return toQString(defaultAdoptMetaknobValue);
+    }
 }

--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -13,6 +13,21 @@
 
 class EngineEffectsManager;
 
+// AdoptMetaknobValue determines how metaknobs behave when effects and presets are loaded.
+enum class AdoptMetaknobValue {
+    // When loading effects, never adjust the metaknob positions
+    KEEP_ALL,
+    // When loading effects presets, never adjust the top-most metaknob position.
+    KEEP_TOP,
+    // When loading effects and effect presets, always reset the metaknob positions
+    // to the stored preset value.
+    LOAD_DEFAULT,
+};
+
+const AdoptMetaknobValue defaultAdoptMetaknobValue = AdoptMetaknobValue::KEEP_ALL;
+AdoptMetaknobValue toAdoptMetaknobValue(const QString& v);
+QString toQString(AdoptMetaknobValue v);
+
 /// EffectsManager initializes and shuts down the effects system. It creates and
 /// destroys a fixed set of StandardEffectChains on Mixxx startup/shutdown
 /// and creates a QuickEffectChain and EqualizerEffectChain when
@@ -69,7 +84,7 @@ class EffectsManager {
         return m_registeredOutputChannels;
     }
 
-    bool isAdoptMetaknobSettingEnabled() const;
+    AdoptMetaknobValue adoptMetaknobSetting() const;
 
   private:
     void addStandardEffectChains();

--- a/src/preferences/dialog/dlgprefeffects.cpp
+++ b/src/preferences/dialog/dlgprefeffects.cpp
@@ -129,18 +129,45 @@ void DlgPrefEffects::slotUpdate() {
 
     loadChainPresetLists();
 
-    bool effectAdoptMetaknobValue = m_pConfig->getValue(
-            ConfigKey("[Effects]", "AdoptMetaknobValue"), true);
-    radioButtonKeepMetaknobPosition->setChecked(effectAdoptMetaknobValue);
-    radioButtonMetaknobLoadDefault->setChecked(!effectAdoptMetaknobValue);
+    // This config value was previously a bool, but now there are three options, so first check for
+    // the enum config value and fall back to the bool if necessary.
+    AdoptMetaknobValue adoptValue = defaultAdoptMetaknobValue;
+    if (m_pConfig->exists(ConfigKey("[Effects]", "AdoptMetaknobEnum"))) {
+        QString configVal = m_pConfig->getValue(
+                ConfigKey("[Effects]", "AdoptMetaknobEnum"), "KEEP_TOP");
+        if (configVal == "KEEP_ALL") {
+            adoptValue = AdoptMetaknobValue::KEEP_ALL;
+        } else if (configVal == "KEEP_TOP") {
+            adoptValue = AdoptMetaknobValue::KEEP_TOP;
+        } else {
+            adoptValue = AdoptMetaknobValue::LOAD_DEFAULT;
+        }
+    } else if (m_pConfig->exists(ConfigKey("[Effects]", "AdoptMetaknobValue"))) {
+        if (m_pConfig->getValue(
+                    ConfigKey("[Effects]", "AdoptMetaknobValue"), true)) {
+            adoptValue = AdoptMetaknobValue::KEEP_TOP;
+        } else {
+            adoptValue = AdoptMetaknobValue::LOAD_DEFAULT;
+        }
+    }
+    radioButtonKeepAllMetaknobPositions->setChecked(adoptValue == AdoptMetaknobValue::KEEP_ALL);
+    radioButtonKeepTopMetaknobPosition->setChecked(adoptValue == AdoptMetaknobValue::KEEP_TOP);
+    radioButtonMetaknobLoadDefault->setChecked(adoptValue == AdoptMetaknobValue::LOAD_DEFAULT);
 }
 
 void DlgPrefEffects::slotApply() {
     m_pVisibleEffectsList->setList(m_pVisibleEffectsModel->getList());
     saveChainPresetLists();
 
-    m_pConfig->set(ConfigKey("[Effects]", "AdoptMetaknobValue"),
-            ConfigValue(radioButtonKeepMetaknobPosition->isChecked()));
+    AdoptMetaknobValue val;
+    if (radioButtonKeepAllMetaknobPositions->isChecked()) {
+        val = AdoptMetaknobValue::KEEP_ALL;
+    } else if (radioButtonKeepTopMetaknobPosition->isChecked()) {
+        val = AdoptMetaknobValue::KEEP_TOP;
+    } else {
+        val = AdoptMetaknobValue::LOAD_DEFAULT;
+    }
+    m_pConfig->set(ConfigKey("[Effects]", "AdoptMetaknobEnum"), ConfigValue(toQString(val)));
 }
 
 void DlgPrefEffects::saveChainPresetLists() {
@@ -152,7 +179,12 @@ void DlgPrefEffects::saveChainPresetLists() {
 }
 
 void DlgPrefEffects::slotResetToDefaults() {
-    radioButtonKeepMetaknobPosition->setChecked(true);
+    radioButtonKeepAllMetaknobPositions->setChecked(
+            defaultAdoptMetaknobValue == AdoptMetaknobValue::KEEP_ALL);
+    radioButtonKeepTopMetaknobPosition->setChecked(
+            defaultAdoptMetaknobValue == AdoptMetaknobValue::KEEP_TOP);
+    radioButtonMetaknobLoadDefault->setChecked(
+            defaultAdoptMetaknobValue == AdoptMetaknobValue::LOAD_DEFAULT);
     m_pChainPresetManager->resetToDefaults();
 
     slotUpdate();

--- a/src/preferences/dialog/dlgprefeffectsdlg.ui
+++ b/src/preferences/dialog/dlgprefeffectsdlg.ui
@@ -464,9 +464,16 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayoutMetaKnob">
       <item>
-       <widget class="QRadioButton" name="radioButtonKeepMetaknobPosition">
+       <widget class="QRadioButton" name="radioButtonKeepAllMetaknobPositions">
         <property name="text">
-         <string>Keep metaknob position</string>
+         <string>Keep all metaknob positions</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radioButtonKeepTopMetaknobPosition">
+        <property name="text">
+         <string>Only keep the top-level Effect Unit metaknob position</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
The preference option "keep metaknob value" currently only restores the top-level meta value instead of applying it to the underlying effects.
Because the loaded preset will use the default metaknob values, the preference is essentially inoperative.
This causes the meta knobs in the underlying effects to be out of sync with the user's controller.
If the user wants to overwrite meta values with the saved presets, they can change the preference to restore to default values.