### PR TITLE
WTrackMenu: Add ability to select loaded track in library

### DIFF
--- a/src/library/analysisfeature.cpp
+++ b/src/library/analysisfeature.cpp
@@ -127,6 +127,7 @@ void AnalysisFeature::activate() {
     if (m_pAnalysisView) {
         emit restoreSearch(m_pAnalysisView->currentSearch());
     }
+    emit showTrackModel(m_pAnalysisView->getTableModel());
     emit enableCoverArtDisplay(true);
 }
 

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -162,6 +162,7 @@ void AutoDJFeature::activate() {
     //qDebug() << "AutoDJFeature::activate()";
     emit switchToView(kViewName);
     emit disableSearch();
+    emit showTrackModel(m_pAutoDJProcessor->getTableModel());
     emit enableCoverArtDisplay(true);
 }
 

--- a/src/library/dlganalysis.h
+++ b/src/library/dlganalysis.h
@@ -32,6 +32,9 @@ class DlgAnalysis : public QWidget, public Ui::DlgAnalysis, public virtual Libra
     void slotAddToAutoDJTop() override;
     void slotAddToAutoDJReplace() override;
     void moveSelection(int delta) override;
+    AnalysisLibraryTableModel* getTableModel() const {
+        return m_pAnalysisLibraryTableModel;
+    }
     inline const QString currentSearch() {
         return m_pAnalysisLibraryTableModel->currentSearch();
     }

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -400,6 +400,7 @@ void Library::bindLibraryWidget(
             &Library::restoreModelState,
             pTrackTableView,
             &WTrackTableView::slotRestoreCurrentViewState);
+    connect(this, &Library::selectTrack, pTrackTableView, &WTrackTableView::slotSelectTrack);
     connect(pTrackTableView,
             &WTrackTableView::trackSelected,
             this,

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -74,6 +74,7 @@ Library::Library(
           m_pTrackCollectionManager(pTrackCollectionManager),
           m_pSidebarModel(make_parented<SidebarModel>(this)),
           m_pLibraryControl(make_parented<LibraryControl>(this)),
+          m_pLibraryWidget(nullptr),
           m_pMixxxLibraryFeature(nullptr),
           m_pPlaylistFeature(nullptr),
           m_pCrateFeature(nullptr),
@@ -103,6 +104,7 @@ Library::Library(
 #endif
 
     addFeature(new AutoDJFeature(this, m_pConfig, pPlayerManager));
+
     m_pPlaylistFeature = new PlaylistFeature(this, UserSettingsPointer(m_pConfig));
     addFeature(m_pPlaylistFeature);
 
@@ -138,6 +140,7 @@ Library::Library(
     addFeature(browseFeature);
 
     addFeature(new RecordingFeature(this, m_pConfig, pRecordingManager));
+
     addFeature(new SetlogFeature(this, UserSettingsPointer(m_pConfig)));
 
     m_pAnalysisFeature = new AnalysisFeature(this, m_pConfig);
@@ -368,10 +371,11 @@ void Library::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
 
 void Library::bindLibraryWidget(
         WLibrary* pLibraryWidget, KeyboardEventFilter* pKeyboard) {
-    WTrackTableView* pTrackTableView = new WTrackTableView(pLibraryWidget,
+    m_pLibraryWidget = pLibraryWidget;
+    WTrackTableView* pTrackTableView = new WTrackTableView(m_pLibraryWidget,
             m_pConfig,
             this,
-            pLibraryWidget->getTrackTableBackgroundColorOpacity(),
+            m_pLibraryWidget->getTrackTableBackgroundColorOpacity(),
             true);
     pTrackTableView->installEventFilter(pKeyboard);
     connect(this,
@@ -386,11 +390,11 @@ void Library::bindLibraryWidget(
             &WTrackTableView::loadTrackToPlayer,
             this,
             &Library::slotLoadTrackToPlayer);
-    pLibraryWidget->registerView(m_sTrackViewName, pTrackTableView);
+    m_pLibraryWidget->registerView(m_sTrackViewName, pTrackTableView);
 
     connect(this,
             &Library::switchToView,
-            pLibraryWidget,
+            m_pLibraryWidget,
             &WLibrary::switchToView);
     connect(this,
             &Library::saveModelState,
@@ -400,7 +404,10 @@ void Library::bindLibraryWidget(
             &Library::restoreModelState,
             pTrackTableView,
             &WTrackTableView::slotRestoreCurrentViewState);
-    connect(this, &Library::selectTrack, pTrackTableView, &WTrackTableView::slotSelectTrack);
+    connect(this,
+            &Library::selectTrack,
+            pTrackTableView,
+            &WTrackTableView::slotSelectTrack);
     connect(pTrackTableView,
             &WTrackTableView::trackSelected,
             this,
@@ -419,7 +426,7 @@ void Library::bindLibraryWidget(
             pTrackTableView,
             &WTrackTableView::setSelectedClick);
 
-    m_pLibraryControl->bindLibraryWidget(pLibraryWidget, pKeyboard);
+    m_pLibraryControl->bindLibraryWidget(m_pLibraryWidget, pKeyboard);
 
     connect(m_pLibraryControl,
             &LibraryControl::showHideTrackMenu,
@@ -431,7 +438,7 @@ void Library::bindLibraryWidget(
             &LibraryControl::slotUpdateTrackMenuControl);
 
     for (const auto& feature : qAsConst(m_features)) {
-        feature->bindLibraryWidget(pLibraryWidget, pKeyboard);
+        feature->bindLibraryWidget(m_pLibraryWidget, pKeyboard);
     }
 
     // Set the current font and row height on all the WTrackTableViews that were
@@ -668,6 +675,14 @@ std::unique_ptr<mixxx::LibraryExporter> Library::makeLibraryExporter(
             parent, m_pConfig, m_pTrackCollectionManager);
 }
 #endif
+
+bool Library::isTrackIdInCurrentLibraryView(const TrackId& trackId) {
+    if (m_pLibraryWidget) {
+        return m_pLibraryWidget->isTrackInCurrentView(trackId);
+    } else {
+        return false;
+    }
+}
 
 LibraryTableModel* Library::trackTableModel() const {
     VERIFY_OR_DEBUG_ASSERT(m_pMixxxLibraryFeature) {

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -127,6 +127,7 @@ class Library: public QObject {
     void disableSearch();
     // emit this signal to enable/disable the cover art widget
     void enableCoverArtDisplay(bool);
+    void selectTrack(const TrackId&);
     void trackSelected(TrackPointer pTrack);
 #ifdef __ENGINEPRIME__
     void exportLibrary();

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -79,6 +79,8 @@ class Library: public QObject {
     /// Needed for exposing models to QML
     LibraryTableModel* trackTableModel() const;
 
+    bool isTrackIdInCurrentLibraryView(const TrackId& trackId);
+
     int getTrackTableRowHeight() const {
         return m_iTrackTableRowHeight;
     }
@@ -158,6 +160,7 @@ class Library: public QObject {
     QList<LibraryFeature*> m_features;
     const static QString m_sTrackViewName;
     const static QString m_sAutoDJViewName;
+    WLibrary* m_pLibraryWidget;
     MixxxLibraryFeature* m_pMixxxLibraryFeature;
     PlaylistFeature* m_pPlaylistFeature;
     CrateFeature* m_pCrateFeature;

--- a/src/library/recording/dlgrecording.h
+++ b/src/library/recording/dlgrecording.h
@@ -11,7 +11,6 @@
 #include "recording/recordingmanager.h"
 #include "track/track_decl.h"
 
-class PlaylistTableModel;
 class WLibrary;
 class WTrackTableView;
 

--- a/src/library/recording/dlgrecording.h
+++ b/src/library/recording/dlgrecording.h
@@ -33,6 +33,9 @@ class DlgRecording : public QWidget, public Ui::DlgRecording, public virtual Lib
     void slotAddToAutoDJReplace() override;
     void loadSelectedTrackToGroup(const QString& group, bool play) override;
     void moveSelection(int delta) override;
+    ProxyTrackModel* getTableModel() {
+        return &m_proxyModel;
+    }
     inline const QString currentSearch() { return m_proxyModel.currentSearch(); }
     void saveCurrentViewState() override;
     bool restoreCurrentViewState() override;

--- a/src/library/recording/recordingfeature.cpp
+++ b/src/library/recording/recordingfeature.cpp
@@ -20,7 +20,8 @@ RecordingFeature::RecordingFeature(Library* pLibrary,
         RecordingManager* pRecordingManager)
         : LibraryFeature(pLibrary, pConfig, QStringLiteral("recordings")),
           m_pRecordingManager(pRecordingManager),
-          m_pSidebarModel(new FolderTreeModel(this)) {
+          m_pSidebarModel(new FolderTreeModel(this)),
+          m_pRecordingView(nullptr) {
 }
 
 QVariant RecordingFeature::title() {
@@ -34,35 +35,35 @@ TreeItemModel* RecordingFeature::sidebarModel() const {
 void RecordingFeature::bindLibraryWidget(WLibrary* pLibraryWidget,
                                   KeyboardEventFilter *keyboard) {
     //The view will be deleted by LibraryWidget
-    DlgRecording* pRecordingView = new DlgRecording(pLibraryWidget,
-                                                    m_pConfig,
-                                                    m_pLibrary,
-                                                    m_pRecordingManager,
-                                                    keyboard);
+    m_pRecordingView = new DlgRecording(pLibraryWidget,
+            m_pConfig,
+            m_pLibrary,
+            m_pRecordingManager,
+            keyboard);
 
-    pRecordingView->installEventFilter(keyboard);
-    pLibraryWidget->registerView(kViewName, pRecordingView);
-    connect(pRecordingView,
+    m_pRecordingView->installEventFilter(keyboard);
+    pLibraryWidget->registerView(kViewName, m_pRecordingView);
+    connect(m_pRecordingView,
             &DlgRecording::loadTrack,
             this,
             &RecordingFeature::loadTrack);
-    connect(pRecordingView,
+    connect(m_pRecordingView,
             &DlgRecording::loadTrackToPlayer,
             this,
             &RecordingFeature::loadTrackToPlayer);
     connect(this,
             &RecordingFeature::refreshBrowseModel,
-            pRecordingView,
+            m_pRecordingView,
             &DlgRecording::refreshBrowseModel);
     connect(this,
             &RecordingFeature::requestRestoreSearch,
-            pRecordingView,
+            m_pRecordingView,
             &DlgRecording::slotRestoreSearch);
-    connect(pRecordingView,
+    connect(m_pRecordingView,
             &DlgRecording::restoreSearch,
             this,
             &RecordingFeature::restoreSearch);
-    connect(pRecordingView,
+    connect(m_pRecordingView,
             &DlgRecording::restoreModelState,
             this,
             &RecordingFeature::restoreModelState);
@@ -72,5 +73,6 @@ void RecordingFeature::activate() {
     emit refreshBrowseModel();
     emit switchToView(kViewName);
     emit disableSearch();
+    emit showTrackModel(m_pRecordingView->getTableModel());
     emit enableCoverArtDisplay(false);
 }

--- a/src/library/recording/recordingfeature.h
+++ b/src/library/recording/recordingfeature.h
@@ -10,6 +10,7 @@
 #include "library/proxytrackmodel.h"
 
 class RecordingManager;
+class DlgRecording;
 
 class RecordingFeature final : public LibraryFeature {
     Q_OBJECT
@@ -38,4 +39,5 @@ class RecordingFeature final : public LibraryFeature {
     RecordingManager* const m_pRecordingManager;
 
     FolderTreeModel* m_pSidebarModel;
+    DlgRecording* m_pRecordingView;
 };

--- a/src/widget/wlibrary.cpp
+++ b/src/widget/wlibrary.cpp
@@ -37,8 +37,8 @@ bool WLibrary::registerView(const QString& name, QWidget* view) {
         return false;
     }
     if (dynamic_cast<LibraryView*>(view) == nullptr) {
-        qDebug() << "WARNING: Attempted to register a view with WLibrary "
-                 << "that does not implement the LibraryView interface. "
+        qDebug() << "WARNING: Attempted to register view" << name << "with WLibrary "
+                 << "which does not implement the LibraryView interface. "
                  << "Ignoring.";
         return false;
     }
@@ -58,8 +58,8 @@ void WLibrary::switchToView(const QString& name) {
     if (widget != nullptr) {
         LibraryView * lview = dynamic_cast<LibraryView*>(widget);
         if (lview == nullptr) {
-            qDebug() << "WARNING: Attempted to register a view with WLibrary "
-                     << "that does not implement the LibraryView interface. "
+            qDebug() << "WARNING: Attempted to switch to view" << name << "with WLibrary "
+                     << "which does not implement the LibraryView interface. "
                      << "Ignoring.";
             return;
         }
@@ -80,8 +80,8 @@ void WLibrary::search(const QString& name) {
     QWidget* current = currentWidget();
     LibraryView* view = dynamic_cast<LibraryView*>(current);
     if (view == nullptr) {
-        qDebug() << "WARNING: Attempted to register a view with WLibrary "
-          << "that does not implement the LibraryView interface. Ignoring.";
+        qDebug() << "WARNING: Attempted to search in view" << name << "with WLibrary "
+                 << "which does not implement the LibraryView interface. Ignoring.";
         return;
     }
     lock.unlock();

--- a/src/widget/wlibrary.cpp
+++ b/src/widget/wlibrary.cpp
@@ -92,6 +92,17 @@ LibraryView* WLibrary::getActiveView() const {
     return dynamic_cast<LibraryView*>(currentWidget());
 }
 
+bool WLibrary::isTrackInCurrentView(const TrackId& trackId) {
+    //qDebug() << "WLibrary::isTrackInCurrentView" << trackId;
+    QWidget* current = currentWidget();
+    WTrackTableView* tracksView = qobject_cast<WTrackTableView*>(current);
+    if (tracksView) {
+        return tracksView->isTrackInCurrentView(trackId);
+    } else {
+        return false;
+    }
+}
+
 bool WLibrary::event(QEvent* pEvent) {
     if (pEvent->type() == QEvent::ToolTip) {
         updateTooltip();

--- a/src/widget/wlibrary.h
+++ b/src/widget/wlibrary.h
@@ -29,6 +29,12 @@ class WLibrary : public QStackedWidget, public WBaseWidget {
 
     LibraryView* getActiveView() const;
 
+    // This returns true if the current view is WTracksTableView and contains trackId,
+    // otherwise false.
+    // This is primarily used to disable the "Select track in library" track menu action
+    // to avoid unintended behaviour if the current view has no tracks table.
+    bool isTrackInCurrentView(const TrackId& trackId);
+
     // Alpha value for row color background
     static constexpr double kDefaultTrackTableBackgroundColorOpacity = 0.125; // 12.5% opacity
     static constexpr double kMinTrackTableBackgroundColorOpacity = 0.0; // 0% opacity

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -255,6 +255,11 @@ void WTrackMenu::createActions() {
         connect(m_pFileBrowserAct, &QAction::triggered, this, &WTrackMenu::slotOpenInFileBrowser);
     }
 
+    if (featureIsEnabled(Feature::SelectInLibrary)) {
+        m_pSelectInLibraryAct = new QAction(tr("Select in Library"), this);
+        connect(m_pSelectInLibraryAct, &QAction::triggered, this, &WTrackMenu::slotSelectInLibrary);
+    }
+
     if (featureIsEnabled(Feature::Metadata)) {
         m_pImportMetadataFromFileAct =
                 new QAction(tr("Import From File Tags"), m_pMetadataMenu);
@@ -542,6 +547,10 @@ void WTrackMenu::setupActions() {
 
     if (featureIsEnabled(Feature::FileBrowser)) {
         addAction(m_pFileBrowserAct);
+    }
+
+    if (featureIsEnabled(Feature::SelectInLibrary)) {
+        addAction(m_pSelectInLibraryAct);
     }
 
     if (featureIsEnabled(Feature::Properties)) {
@@ -947,6 +956,12 @@ void WTrackMenu::slotOpenInFileBrowser() {
         locations << trackRef.getLocation();
     }
     mixxx::DesktopHelper::openInFileBrowser(locations);
+}
+
+void WTrackMenu::slotSelectInLibrary() {
+    if (m_pTrack) {
+        m_pLibrary->selectTrack(m_pTrack->getId());
+    }
 }
 
 namespace {
@@ -2092,6 +2107,8 @@ bool WTrackMenu::featureIsEnabled(Feature flag) const {
         return m_pLibrary != nullptr;
     case Feature::UpdateReplayGain:
         return m_pTrackModel->hasCapabilities(TrackModel::Capability::EditMetadata);
+    case Feature::SelectInLibrary:
+        return m_pTrack != nullptr;
     default:
         DEBUG_ASSERT(!"unreachable");
         return false;

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -960,7 +960,7 @@ void WTrackMenu::slotOpenInFileBrowser() {
 
 void WTrackMenu::slotSelectInLibrary() {
     if (m_pTrack) {
-        m_pLibrary->selectTrack(m_pTrack->getId());
+        emit m_pLibrary->selectTrack(m_pTrack->getId());
     }
 }
 

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -827,6 +827,14 @@ void WTrackMenu::updateMenus() {
         }
     }
 
+    if (featureIsEnabled(Feature::SelectInLibrary)) {
+        bool enabled = false;
+        if (m_pTrack) {
+            enabled = m_pLibrary->isTrackIdInCurrentLibraryView(m_pTrack->getId());
+        }
+        m_pSelectInLibraryAct->setEnabled(enabled);
+    }
+
     if (featureIsEnabled(Feature::Properties)) {
         m_pPropertiesAct->setEnabled(singleTrackSelected);
     }

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -50,10 +50,11 @@ class WTrackMenu : public QMenu {
         Properties = 1 << 12,
         SearchRelated = 1 << 13,
         UpdateReplayGain = 1 << 14,
+        SelectInLibrary = 1 << 15,
         TrackModelFeatures = Remove | HideUnhidePurge,
         All = AutoDJ | LoadTo | Playlist | Crate | Remove | Metadata | Reset |
                 BPM | Color | HideUnhidePurge | RemoveFromDisk | FileBrowser |
-                Properties | SearchRelated | UpdateReplayGain
+                Properties | SearchRelated | UpdateReplayGain | SelectInLibrary
     };
     Q_DECLARE_FLAGS(Features, Feature)
 
@@ -87,6 +88,7 @@ class WTrackMenu : public QMenu {
   private slots:
     // File
     void slotOpenInFileBrowser();
+    void slotSelectInLibrary();
 
     // Row color
     void slotColorPicked(const mixxx::RgbColor::optional_t& color);
@@ -249,6 +251,9 @@ class WTrackMenu : public QMenu {
 
     // Open file in default file browser
     QAction* m_pFileBrowserAct{};
+
+    // Select track in library
+    QAction* m_pSelectInLibraryAct{};
 
     // BPM feature
     QAction* m_pBpmLockAction{};

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -21,7 +21,8 @@ constexpr WTrackMenu::Features kTrackMenuFeatures =
         WTrackMenu::Feature::RemoveFromDisk |
         WTrackMenu::Feature::FileBrowser |
         WTrackMenu::Feature::Properties |
-        WTrackMenu::Feature::UpdateReplayGain;
+        WTrackMenu::Feature::UpdateReplayGain |
+        WTrackMenu::Feature::SelectInLibrary;
 } // namespace
 
 WTrackProperty::WTrackProperty(

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -950,7 +950,7 @@ void WTrackTableView::setSelectedTracks(const QList<TrackId>& trackIds) {
     }
 }
 
-bool WTrackTableView::setCurrentTrackId(const TrackId& trackId, int column) {
+bool WTrackTableView::setCurrentTrackId(const TrackId& trackId, int column, bool scrollToTrack) {
     QItemSelectionModel* pSelectionModel = selectionModel();
     VERIFY_OR_DEBUG_ASSERT(pSelectionModel != nullptr) {
         qWarning() << "No selected tracks available";
@@ -975,6 +975,11 @@ bool WTrackTableView::setCurrentTrackId(const TrackId& trackId, int column) {
     selectRow(idx.row());
     pSelectionModel->setCurrentIndex(idx,
             QItemSelectionModel::SelectCurrent | QItemSelectionModel::Select);
+
+    if (scrollToTrack) {
+        scrollTo(idx);
+    }
+
     return true;
 }
 
@@ -1012,7 +1017,7 @@ void WTrackTableView::slotAddToAutoDJReplace() {
 }
 
 void WTrackTableView::slotSelectTrack(const TrackId& trackId) {
-    setCurrentTrackId(trackId);
+    setCurrentTrackId(trackId, 0, true);
     setSelectedTracks({trackId});
 }
 

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1011,6 +1011,11 @@ void WTrackTableView::slotAddToAutoDJReplace() {
     addToAutoDJ(PlaylistDAO::AutoDJSendLoc::REPLACE);
 }
 
+void WTrackTableView::slotSelectTrack(const TrackId& trackId) {
+    setCurrentTrackId(trackId);
+    setSelectedTracks({trackId});
+}
+
 void WTrackTableView::doSortByColumn(int headerSection, Qt::SortOrder sortOrder) {
     TrackModel* trackModel = getTrackModel();
     QAbstractItemModel* itemModel = model();

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -950,6 +950,16 @@ TrackId WTrackTableView::getCurrentTrackId() const {
     return {};
 }
 
+bool WTrackTableView::isTrackInCurrentView(const TrackId& trackId) {
+    TrackModel* pTrackModel = getTrackModel();
+    VERIFY_OR_DEBUG_ASSERT(pTrackModel != nullptr) {
+        qWarning() << "No track model";
+        return false;
+    }
+    const QVector<int> trackRows = pTrackModel->getTrackRows(trackId);
+    return !trackRows.empty();
+}
+
 void WTrackTableView::setSelectedTracks(const QList<TrackId>& trackIds) {
     QItemSelectionModel* pSelectionModel = selectionModel();
     VERIFY_OR_DEBUG_ASSERT(pSelectionModel != nullptr) {
@@ -1040,8 +1050,9 @@ void WTrackTableView::slotAddToAutoDJReplace() {
 }
 
 void WTrackTableView::slotSelectTrack(const TrackId& trackId) {
-    setCurrentTrackId(trackId, 0, true);
-    setSelectedTracks({trackId});
+    if (setCurrentTrackId(trackId, 0, true)) {
+        setSelectedTracks({trackId});
+    }
 }
 
 void WTrackTableView::doSortByColumn(int headerSection, Qt::SortOrder sortOrder) {

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -963,13 +963,13 @@ bool WTrackTableView::isTrackInCurrentView(const TrackId& trackId) {
 void WTrackTableView::setSelectedTracks(const QList<TrackId>& trackIds) {
     QItemSelectionModel* pSelectionModel = selectionModel();
     VERIFY_OR_DEBUG_ASSERT(pSelectionModel != nullptr) {
-        qWarning() << "No selected tracks available";
+        qWarning() << "No selection model";
         return;
     }
 
     TrackModel* pTrackModel = getTrackModel();
     VERIFY_OR_DEBUG_ASSERT(pTrackModel != nullptr) {
-        qWarning() << "No selected tracks available";
+        qWarning() << "No track model";
         return;
     }
 
@@ -986,17 +986,18 @@ void WTrackTableView::setSelectedTracks(const QList<TrackId>& trackIds) {
 bool WTrackTableView::setCurrentTrackId(const TrackId& trackId, int column, bool scrollToTrack) {
     QItemSelectionModel* pSelectionModel = selectionModel();
     VERIFY_OR_DEBUG_ASSERT(pSelectionModel != nullptr) {
-        qWarning() << "No selected tracks available";
+        qWarning() << "No selection model";
         return false;
     }
 
     TrackModel* pTrackModel = getTrackModel();
     VERIFY_OR_DEBUG_ASSERT(pTrackModel != nullptr) {
-        qWarning() << "No selected tracks available";
+        qWarning() << "No track model";
         return false;
     }
     const QVector<int> trackRows = pTrackModel->getTrackRows(trackId);
     if (trackRows.empty()) {
+        qDebug() << "WTrackTableView: track" << trackId << "is not in current view";
         return false;
     }
 

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -40,6 +40,7 @@ class WTrackTableView : public WLibraryTableView {
     void assignPreviousTrackColor() override;
     TrackModel::SortColumnId getColumnIdFromCurrentIndex() override;
     QList<TrackId> getSelectedTrackIds() const;
+    bool isTrackInCurrentView(const TrackId& trackId);
     void setSelectedTracks(const QList<TrackId>& tracks);
     TrackId getCurrentTrackId() const;
     bool setCurrentTrackId(const TrackId& trackId, int column = 0, bool scrollToTrack = false);

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -69,10 +69,7 @@ class WTrackTableView : public WLibraryTableView {
     bool slotRestoreCurrentViewState() {
         return restoreCurrentViewState();
     };
-    void slotSelectTrack(const TrackId& trackId) {
-        setCurrentTrackId(trackId);
-        setSelectedTracks({trackId});
-    }
+    void slotSelectTrack(const TrackId&);
 
   private slots:
     void doSortByColumn(int headerSection, Qt::SortOrder sortOrder);

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -42,7 +42,7 @@ class WTrackTableView : public WLibraryTableView {
     QList<TrackId> getSelectedTrackIds() const;
     void setSelectedTracks(const QList<TrackId>& tracks);
     TrackId getCurrentTrackId() const;
-    bool setCurrentTrackId(const TrackId& trackId, int column = 0);
+    bool setCurrentTrackId(const TrackId& trackId, int column = 0, bool scrollToTrack = false);
 
     double getBackgroundColorOpacity() const {
         return m_backgroundColorOpacity;

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -69,6 +69,10 @@ class WTrackTableView : public WLibraryTableView {
     bool slotRestoreCurrentViewState() {
         return restoreCurrentViewState();
     };
+    void slotSelectTrack(const TrackId& trackId) {
+        setCurrentTrackId(trackId);
+        setSelectedTracks({trackId});
+    }
 
   private slots:
     void doSortByColumn(int headerSection, Qt::SortOrder sortOrder);


### PR DESCRIPTION
This PR allows user to highlight (select) track that is currently loaded to deck or sampler in library. This works across library features (Tracks, AutoDJ, Playlists, Crates).