### PR TITLE
Traktor S3 effects update

### DIFF
--- a/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
@@ -1393,16 +1393,13 @@ TraktorS3.FXControl.prototype.fxSelectHandler = function(field) {
     case this.STATE_FILTER:
         // If any fxEnable button is pressed, we are loading an fx preset
         if (this.anyEnablePressed()) {
-            HIDDebug("enable pressed");
             for (const key in this.enablePressed) {
                 if (this.enablePressed[key]) {
-                    this.selectPressed = true;
                     if (fxNumber === 0) {
                         const fxGroup = "[QuickEffectRack1_" + key + "_Effect1]";
                         const fxKey = "enabled";
                         script.toggleControl(fxGroup, fxKey);
                     } else {
-                        HIDDebug("ok this one");
                         const channelNumber = this.channelNumber(key);
                         if (this.getLoadedPreset(channelNumber) !== fxNumber) {
                             this.loadEffectPreset(channelNumber, fxNumber);
@@ -1424,8 +1421,6 @@ TraktorS3.FXControl.prototype.fxSelectHandler = function(field) {
     case this.STATE_EFFECT_INIT:
         // Fallthrough intended
     case this.STATE_EFFECT:
-        //  This is all messed up because now we have different effect units for each deck --
-        // which one does the user mean to edit?
         if (fxNumber === 0) {
             this.changeState(this.STATE_FILTER);
         } else if (fxNumber !== this.activeFX) {
@@ -1451,7 +1446,6 @@ TraktorS3.FXControl.prototype.fxEnableHandler = function(field) {
 
     if (!field.value) {
         this.lightFX();
-        this.chainLoaded = false;
         return;
     }
 


### PR DESCRIPTION
Redo effects system so that it fits better with the new paradigm. 

* Automatically init fx unit routing to match unit number and channel number
* Press an fx enable + fx select button to load and enable the preset given by the select button (1 through 4) in the corresponding deck
* press enable+selectfx to disable the effect
* Can still enable+filter to enable / disable filter on superknob
* Superknobs will control filter (if enabled) and also superknob for the loaded effect.  (center is zero, full left and full right are 1.0 -- this matches what the manual describes)

TODO:

- [ ] factor out changes from other S3 PR that snuck in
- [ ] manual PR
- [ ] more testing / tweaking
