### PR TITLE
Gracefully handle outdated effect IDs

### DIFF
--- a/src/effects/backends/builtin/builtinbackend.cpp
+++ b/src/effects/backends/builtin/builtinbackend.cpp
@@ -88,7 +88,6 @@ const QList<QString> BuiltInBackend::getEffectIds() const {
 }
 
 EffectManifestPointer BuiltInBackend::getManifest(const QString& effectId) const {
-    // This may return a null pointer in case a previously stored effect is no longer available
     return m_registeredEffects.value(effectId).pManifest;
 }
 

--- a/src/effects/backends/builtin/builtinbackend.cpp
+++ b/src/effects/backends/builtin/builtinbackend.cpp
@@ -88,9 +88,7 @@ const QList<QString> BuiltInBackend::getEffectIds() const {
 }
 
 EffectManifestPointer BuiltInBackend::getManifest(const QString& effectId) const {
-    VERIFY_OR_DEBUG_ASSERT(m_registeredEffects.contains(effectId)) {
-        return EffectManifestPointer();
-    }
+    // This may return a null pointer in case a previously stored effect is no longer available
     return m_registeredEffects.value(effectId).pManifest;
 }
 

--- a/src/effects/backends/effectsbackend.h
+++ b/src/effects/backends/effectsbackend.h
@@ -27,6 +27,8 @@ class EffectsBackend {
 
     /// returns a list sorted like it should be displayed in the GUI
     virtual const QList<QString> getEffectIds() const = 0;
+    /// returns a pointer to the manifest or a null pointer in case a
+    /// previously stored effect is no longer available
     virtual EffectManifestPointer getManifest(const QString& effectId) const = 0;
     virtual const QList<EffectManifestPointer> getManifests() const = 0;
     virtual bool canInstantiateEffect(const QString& effectId) const = 0;

--- a/src/effects/backends/effectsbackendmanager.cpp
+++ b/src/effects/backends/effectsbackendmanager.cpp
@@ -66,17 +66,28 @@ EffectManifestPointer EffectsBackendManager::getManifestFromUniqueId(
     // Do not manipulate the string passed to this function, just pass
     // it directly to BuiltInBackend.
     if (delimiterIndex == -1) {
-        return m_effectsBackends.value(EffectBackendType::BuiltIn)
-                ->getManifest(uid);
+        auto pEffectsBackend = m_effectsBackends.value(EffectBackendType::BuiltIn);
+        VERIFY_OR_DEBUG_ASSERT(pEffectsBackend) {
+            return {};
+        }
+        return pEffectsBackend->getManifest(uid);
     }
     backendType = EffectsBackend::backendTypeFromString(uid.mid(delimiterIndex + 1));
-    return m_effectsBackends.value(backendType)
-            ->getManifest(uid.mid(-1, delimiterIndex + 1));
+    auto pEffectsBackend = m_effectsBackends.value(backendType);
+    VERIFY_OR_DEBUG_ASSERT(pEffectsBackend) {
+        return {};
+    }
+    return pEffectsBackend->getManifest(uid.mid(-1, delimiterIndex + 1));
 }
 
 EffectManifestPointer EffectsBackendManager::getManifest(
         const QString& id, EffectBackendType backendType) const {
-    return m_effectsBackends.value(backendType)->getManifest(id);
+    auto pEffectsBackend = m_effectsBackends.value(backendType);
+    VERIFY_OR_DEBUG_ASSERT(pEffectsBackend) {
+        return {};
+    }
+    // This may return a null pointer in case a previously stored effect is no longer available
+    return pEffectsBackend->getManifest(id);
 }
 
 const QString EffectsBackendManager::getDisplayNameForEffectPreset(

--- a/src/effects/backends/effectsbackendmanager.cpp
+++ b/src/effects/backends/effectsbackendmanager.cpp
@@ -86,7 +86,6 @@ EffectManifestPointer EffectsBackendManager::getManifest(
     VERIFY_OR_DEBUG_ASSERT(pEffectsBackend) {
         return {};
     }
-    // This may return a null pointer in case a previously stored effect is no longer available
     return pEffectsBackend->getManifest(id);
 }
 

--- a/src/effects/backends/effectsbackendmanager.h
+++ b/src/effects/backends/effectsbackendmanager.h
@@ -16,6 +16,8 @@ class EffectsBackendManager {
     };
     const QList<EffectManifestPointer> getManifestsForBackend(EffectBackendType backendType) const;
     EffectManifestPointer getManifestFromUniqueId(const QString& uid) const;
+    /// returns a pointer to the manifest or a null pointer in case a
+    /// the previously stored backend or effect is no longer available
     EffectManifestPointer getManifest(const QString& id, EffectBackendType backendType) const;
     const QString getDisplayNameForEffectPreset(EffectPresetPointer pPreset) const;
 

--- a/src/effects/backends/lv2/lv2backend.cpp
+++ b/src/effects/backends/lv2/lv2backend.cpp
@@ -70,9 +70,7 @@ bool LV2Backend::canInstantiateEffect(const QString& effectId) const {
 }
 
 EffectManifestPointer LV2Backend::getManifest(const QString& effectId) const {
-    VERIFY_OR_DEBUG_ASSERT(m_registeredEffects.contains(effectId)) {
-        return EffectManifestPointer();
-    }
+    // This may return a null pointer in case a previously stored effect is no longer available
     return m_registeredEffects.value(effectId);
 }
 

--- a/src/effects/backends/lv2/lv2backend.cpp
+++ b/src/effects/backends/lv2/lv2backend.cpp
@@ -70,7 +70,6 @@ bool LV2Backend::canInstantiateEffect(const QString& effectId) const {
 }
 
 EffectManifestPointer LV2Backend::getManifest(const QString& effectId) const {
-    // This may return a null pointer in case a previously stored effect is no longer available
     return m_registeredEffects.value(effectId);
 }
 

--- a/src/effects/presets/effectchainpresetmanager.cpp
+++ b/src/effects/presets/effectchainpresetmanager.cpp
@@ -554,8 +554,10 @@ EffectsXmlData EffectChainPresetManager::readEffectsXml(
         const QDomDocument& doc, const QStringList& deckStrings) {
     EffectManifestPointer pDefaultQuickEffectManifest = m_pBackendManager->getManifest(
             FilterEffect::getId(), EffectBackendType::BuiltIn);
-    auto defaultQuickEffectChainPreset = EffectChainPresetPointer(
-            new EffectChainPreset(pDefaultQuickEffectManifest));
+    auto defaultQuickEffectChainPreset =
+            EffectChainPresetPointer(pDefaultQuickEffectManifest
+                            ? new EffectChainPreset(pDefaultQuickEffectManifest)
+                            : new EffectChainPreset());
 
     QList<EffectChainPresetPointer> standardEffectChainPresets;
     QHash<QString, EffectChainPresetPointer> quickEffectPresets;

--- a/src/effects/presets/effectpresetmanager.cpp
+++ b/src/effects/presets/effectpresetmanager.cpp
@@ -43,7 +43,9 @@ void EffectPresetManager::loadDefaultEffectPresets() {
         if (!pEffectPreset->isEmpty()) {
             EffectManifestPointer pManifest = m_pBackendManager->getManifest(
                     pEffectPreset->id(), pEffectPreset->backendType());
-            m_defaultPresets.insert(pManifest, pEffectPreset);
+            if (pManifest) {
+                m_defaultPresets.insert(pManifest, pEffectPreset);
+            }
         }
         file.close();
     }
@@ -69,6 +71,9 @@ void EffectPresetManager::saveDefaultForEffect(EffectPresetPointer pEffectPreset
 
     const auto pManifest = m_pBackendManager->getManifest(
             pEffectPreset->id(), pEffectPreset->backendType());
+    VERIFY_OR_DEBUG_ASSERT(pManifest) {
+        return;
+    }
     m_defaultPresets.insert(pManifest, pEffectPreset);
 
     QDomDocument doc(EffectXml::kEffect);


### PR DESCRIPTION
This happens when the user uninstalls LV2 effects and may also happen after a downgrade from a Mixxx version that includes new effects. 