### PR TITLE
HID Switch to force sending of duplicate data and cleanup of JS API functions

### DIFF
--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -203,7 +203,7 @@ int HidController::close() {
 void HidController::sendBytes(const QByteArray& data) {
     // Some HIDAPI backends will fail if the device uses ReportIDs (as practical all DJ controllers),
     // because 0 is no valid ReportID for these devices.
-    m_pHidIoThread->updateCachedOutputReportData(data, 0, false);
+    m_pHidIoThread->updateCachedOutputReportData(0, data, false);
 }
 
 ControllerJSProxy* HidController::jsProxy() {

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -197,7 +197,12 @@ int HidController::close() {
     return 0;
 }
 
+/// This function is only for class compatibility with the (midi)controller
+/// and will not do the same as for MIDI devices,
+/// because sending of raw bytes is not a supported HIDAPI feature.
 void HidController::sendBytes(const QByteArray& data) {
+    // Some HIDAPI backends will fail if the device uses ReportIDs (as practical all DJ controllers),
+    // because 0 is no valid ReportID for these devices.
     m_pHidIoThread->updateCachedOutputReportData(data, 0, false);
 }
 

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -197,18 +197,8 @@ int HidController::close() {
     return 0;
 }
 
-void HidController::sendReport(const QList<int>& data, unsigned int length, unsigned int reportID) {
-    Q_UNUSED(length);
-    QByteArray temp;
-    temp.reserve(data.size());
-    for (int datum : data) {
-        temp.append(datum);
-    }
-    m_pHidIoThread->updateCachedOutputReportData(temp, reportID);
-}
-
 void HidController::sendBytes(const QByteArray& data) {
-    m_pHidIoThread->updateCachedOutputReportData(data, 0);
+    m_pHidIoThread->updateCachedOutputReportData(data, 0, false);
 }
 
 ControllerJSProxy* HidController::jsProxy() {

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -102,10 +102,6 @@ class HidControllerJSProxy : public ControllerJSProxy {
     /// @brief getInputReport receives an InputReport from the HID device on request.
     /// @details This can be used on startup to initialize the knob positions in Mixxx
     ///          to the physical position of the hardware knobs on the controller.
-    ///          The returned data structure for the input reports is the same
-    ///          as in the polling functionality (including ReportID in first byte).
-    ///          The returned list can be used to call the incomingData
-    ///          function of the common-hid-packet-parser.
     ///          This is an optional command in the HID standard - not all devices support it.
     /// @param reportID 1...255 for HID devices that uses ReportIDs - or 0 for devices, which don't use
     /// @return Returns report data with ReportID byte as prefix

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -75,7 +75,7 @@ class HidControllerJSProxy : public ControllerJSProxy {
     Q_INVOKABLE void send(const QList<int>& dataList,
             unsigned int length,
             const quint8& reportID,
-            bool resendUnchangedReport = false) {
+            const bool& resendUnchangedReport = false) {
         Q_UNUSED(length);
         QByteArray dataArray;
         dataArray.reserve(dataList.size());
@@ -91,7 +91,7 @@ class HidControllerJSProxy : public ControllerJSProxy {
     /// @param resendUnchangedReport If set, the report will also be send, if the data are unchanged since last sending
     Q_INVOKABLE void sendOutputReport(const quint8& reportID,
             const QByteArray& dataArray,
-            bool resendUnchangedReport = false) {
+            const bool& resendUnchangedReport = false) {
         VERIFY_OR_DEBUG_ASSERT(m_pHidController->m_pHidIoThread) {
             return;
         }

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -74,7 +74,7 @@ class HidControllerJSProxy : public ControllerJSProxy {
     /// @param resendUnchangedReport If set, the report will also be send, if the data are unchanged since last sending
     Q_INVOKABLE void send(const QList<int>& dataList,
             unsigned int length,
-            unsigned int reportID,
+            const quint8& reportID,
             bool resendUnchangedReport = false) {
         Q_UNUSED(length);
         QByteArray dataArray;
@@ -89,7 +89,7 @@ class HidControllerJSProxy : public ControllerJSProxy {
     /// @param reportID 1...255 for HID devices that uses ReportIDs - or 0 for devices, which don't use ReportIDs
     /// @param dataArray Data to send as byte array (Javascript type Uint8Array)
     /// @param resendUnchangedReport If set, the report will also be send, if the data are unchanged since last sending
-    Q_INVOKABLE void sendOutputReport(unsigned int reportID,
+    Q_INVOKABLE void sendOutputReport(const quint8& reportID,
             const QByteArray& dataArray,
             bool resendUnchangedReport = false) {
         VERIFY_OR_DEBUG_ASSERT(m_pHidController->m_pHidIoThread) {
@@ -110,7 +110,7 @@ class HidControllerJSProxy : public ControllerJSProxy {
     /// @param reportID 1...255 for HID devices that uses ReportIDs - or 0 for devices, which don't use
     /// @return Returns report data with ReportID byte as prefix
     Q_INVOKABLE QByteArray getInputReport(
-            unsigned int reportID) {
+            const quint8& reportID) {
         VERIFY_OR_DEBUG_ASSERT(m_pHidController->m_pHidIoThread) {
             return {};
         }
@@ -121,7 +121,7 @@ class HidControllerJSProxy : public ControllerJSProxy {
     /// @param reportID 1...255 for HID devices that uses ReportIDs - or 0 for devices, which don't use
     /// @param reportData Data to send as byte array (Javascript type Uint8Array)
     Q_INVOKABLE void sendFeatureReport(
-            unsigned int reportID, const QByteArray& reportData) {
+            const quint8& reportID, const QByteArray& reportData) {
         VERIFY_OR_DEBUG_ASSERT(m_pHidController->m_pHidIoThread) {
             return;
         }
@@ -133,7 +133,7 @@ class HidControllerJSProxy : public ControllerJSProxy {
     /// @return The returned array matches the input format of sendFeatureReport (Javascript type Uint8Array),
     ///         allowing it to be read, modified and sent it back to the controller.
     Q_INVOKABLE QByteArray getFeatureReport(
-            unsigned int reportID) {
+            const quint8& reportID) {
         VERIFY_OR_DEBUG_ASSERT(m_pHidController->m_pHidIoThread) {
             return {};
         }

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -82,15 +82,15 @@ class HidControllerJSProxy : public ControllerJSProxy {
         for (int datum : dataList) {
             dataArray.append(datum);
         }
-        this->sendOutputReport(dataArray, reportID, resendUnchangedReport);
+        this->sendOutputReport(reportID, dataArray, resendUnchangedReport);
     }
 
     /// @brief Sends an OutputReport to HID device
-    /// @param dataArray Data to send as byte array (Javascript type Uint8Array)
     /// @param reportID 1...255 for HID devices that uses ReportIDs - or 0 for devices, which don't use ReportIDs
+    /// @param dataArray Data to send as byte array (Javascript type Uint8Array)
     /// @param resendUnchangedReport If set, the report will also be send, if the data are unchanged since last sending
-    Q_INVOKABLE void sendOutputReport(const QByteArray& dataArray,
-            unsigned int reportID,
+    Q_INVOKABLE void sendOutputReport(unsigned int reportID,
+            const QByteArray& dataArray,
             bool resendUnchangedReport = false) {
         VERIFY_OR_DEBUG_ASSERT(m_pHidController->m_pHidIoThread) {
             return;
@@ -118,10 +118,10 @@ class HidControllerJSProxy : public ControllerJSProxy {
     }
 
     /// @brief Sends a FeatureReport to HID device
-    /// @param reportData Data to send as byte array (Javascript type Uint8Array)
     /// @param reportID 1...255 for HID devices that uses ReportIDs - or 0 for devices, which don't use
+    /// @param reportData Data to send as byte array (Javascript type Uint8Array)
     Q_INVOKABLE void sendFeatureReport(
-            const QByteArray& reportData, unsigned int reportID) {
+            unsigned int reportID, const QByteArray& reportData) {
         VERIFY_OR_DEBUG_ASSERT(m_pHidController->m_pHidIoThread) {
             return;
         }

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -79,7 +79,7 @@ class HidControllerJSProxy : public ControllerJSProxy {
         for (int datum : dataList) {
             dataArray.append(datum);
         }
-        this->sendOutputReport(dataArray, reportID);
+        this->sendOutputReport(dataArray, reportID, skipIdenticalReports);
     }
 
     /// @brief Sends an OutputReport to HID device

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -72,7 +72,10 @@ class HidControllerJSProxy : public ControllerJSProxy {
     /// @param length Unused but mandatory argument
     /// @param reportID 1...255 for HID devices that uses ReportIDs - or 0 for devices, which don't use ReportIDs
     /// @param skipIdenticalReports If set, the sending of the report is inhibited, when the data didn't changed
-    Q_INVOKABLE void send(const QList<int>& dataList, unsigned int length, unsigned int reportID, bool skipIdenticalReports = true) {
+    Q_INVOKABLE void send(const QList<int>& dataList,
+            unsigned int length,
+            unsigned int reportID,
+            bool skipIdenticalReports = true) {
         Q_UNUSED(length);
         QByteArray dataArray;
         dataArray.reserve(dataList.size());
@@ -86,11 +89,14 @@ class HidControllerJSProxy : public ControllerJSProxy {
     /// @param dataArray Data to send as byte array (Javascript type Uint8Array)
     /// @param reportID 1...255 for HID devices that uses ReportIDs - or 0 for devices, which don't use ReportIDs
     /// @param skipIdenticalReports If set, the sending of the report is inhibited, when the data didn't changed
-    Q_INVOKABLE void sendOutputReport(const QByteArray& dataArray, unsigned int reportID, bool skipIdenticalReports = true) {
+    Q_INVOKABLE void sendOutputReport(const QByteArray& dataArray,
+            unsigned int reportID,
+            bool skipIdenticalReports = true) {
         VERIFY_OR_DEBUG_ASSERT(m_pHidController->m_pHidIoThread) {
             return;
         }
-        m_pHidController->m_pHidIoThread->updateCachedOutputReportData(dataArray, reportID, skipIdenticalReports);
+        m_pHidController->m_pHidIoThread->updateCachedOutputReportData(
+                dataArray, reportID, skipIdenticalReports);
     }
 
     /// @brief getInputReport receives an InputReport from the HID device on request.
@@ -102,7 +108,7 @@ class HidControllerJSProxy : public ControllerJSProxy {
     ///          function of the common-hid-packet-parser.
     ///          This is an optional command in the HID standard - not all devices support it.
     /// @param reportID 1...255 for HID devices that uses ReportIDs - or 0 for devices, which don't use
-    /// @return 
+    /// @return Returns report data with ReportID byte as prefix
     Q_INVOKABLE QByteArray getInputReport(
             unsigned int reportID) {
         VERIFY_OR_DEBUG_ASSERT(m_pHidController->m_pHidIoThread) {
@@ -122,7 +128,6 @@ class HidControllerJSProxy : public ControllerJSProxy {
         m_pHidController->m_pHidIoThread->sendFeatureReport(reportData, reportID);
     }
 
-    
     /// @brief getFeatureReport receives a FeatureReport from the HID device on request.
     /// @param reportID 1...255 for HID devices that uses ReportIDs - or 0 for devices, which don't use
     /// @return The returned array matches the input format of sendFeatureReport (Javascript type Uint8Array),

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -96,7 +96,7 @@ class HidControllerJSProxy : public ControllerJSProxy {
             return;
         }
         m_pHidController->m_pHidIoThread->updateCachedOutputReportData(
-                dataArray, reportID, resendUnchangedReport);
+                reportID, dataArray, resendUnchangedReport);
     }
 
     /// @brief getInputReport receives an InputReport from the HID device on request.
@@ -121,7 +121,7 @@ class HidControllerJSProxy : public ControllerJSProxy {
         VERIFY_OR_DEBUG_ASSERT(m_pHidController->m_pHidIoThread) {
             return;
         }
-        m_pHidController->m_pHidIoThread->sendFeatureReport(reportData, reportID);
+        m_pHidController->m_pHidIoThread->sendFeatureReport(reportID, reportData);
     }
 
     /// @brief getFeatureReport receives a FeatureReport from the HID device on request.

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -74,8 +74,8 @@ class HidControllerJSProxy : public ControllerJSProxy {
     /// @param resendUnchangedReport If set, the report will also be send, if the data are unchanged since last sending
     Q_INVOKABLE void send(const QList<int>& dataList,
             unsigned int length,
-            const quint8& reportID,
-            const bool& resendUnchangedReport = false) {
+            quint8 reportID,
+            bool resendUnchangedReport = false) {
         Q_UNUSED(length);
         QByteArray dataArray;
         dataArray.reserve(dataList.size());
@@ -89,9 +89,9 @@ class HidControllerJSProxy : public ControllerJSProxy {
     /// @param reportID 1...255 for HID devices that uses ReportIDs - or 0 for devices, which don't use ReportIDs
     /// @param dataArray Data to send as byte array (Javascript type Uint8Array)
     /// @param resendUnchangedReport If set, the report will also be send, if the data are unchanged since last sending
-    Q_INVOKABLE void sendOutputReport(const quint8& reportID,
+    Q_INVOKABLE void sendOutputReport(quint8 reportID,
             const QByteArray& dataArray,
-            const bool& resendUnchangedReport = false) {
+            bool resendUnchangedReport = false) {
         VERIFY_OR_DEBUG_ASSERT(m_pHidController->m_pHidIoThread) {
             return;
         }
@@ -106,7 +106,7 @@ class HidControllerJSProxy : public ControllerJSProxy {
     /// @param reportID 1...255 for HID devices that uses ReportIDs - or 0 for devices, which don't use
     /// @return Returns report data with ReportID byte as prefix
     Q_INVOKABLE QByteArray getInputReport(
-            const quint8& reportID) {
+            quint8 reportID) {
         VERIFY_OR_DEBUG_ASSERT(m_pHidController->m_pHidIoThread) {
             return {};
         }
@@ -117,7 +117,7 @@ class HidControllerJSProxy : public ControllerJSProxy {
     /// @param reportID 1...255 for HID devices that uses ReportIDs - or 0 for devices, which don't use
     /// @param reportData Data to send as byte array (Javascript type Uint8Array)
     Q_INVOKABLE void sendFeatureReport(
-            const quint8& reportID, const QByteArray& reportData) {
+            quint8 reportID, const QByteArray& reportData) {
         VERIFY_OR_DEBUG_ASSERT(m_pHidController->m_pHidIoThread) {
             return;
         }
@@ -129,7 +129,7 @@ class HidControllerJSProxy : public ControllerJSProxy {
     /// @return The returned array matches the input format of sendFeatureReport (Javascript type Uint8Array),
     ///         allowing it to be read, modified and sent it back to the controller.
     Q_INVOKABLE QByteArray getFeatureReport(
-            const quint8& reportID) {
+            quint8 reportID) {
         VERIFY_OR_DEBUG_ASSERT(m_pHidController->m_pHidIoThread) {
             return {};
         }

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -71,32 +71,32 @@ class HidControllerJSProxy : public ControllerJSProxy {
     /// @param dataList Data to send as list of bytes
     /// @param length Unused but mandatory argument
     /// @param reportID 1...255 for HID devices that uses ReportIDs - or 0 for devices, which don't use ReportIDs
-    /// @param skipIdenticalReports If set, the sending of the report is inhibited, when the data didn't changed
+    /// @param resendUnchangedReport If set, the report will also be send, if the data are unchanged since last sending
     Q_INVOKABLE void send(const QList<int>& dataList,
             unsigned int length,
             unsigned int reportID,
-            bool skipIdenticalReports = true) {
+            bool resendUnchangedReport = false) {
         Q_UNUSED(length);
         QByteArray dataArray;
         dataArray.reserve(dataList.size());
         for (int datum : dataList) {
             dataArray.append(datum);
         }
-        this->sendOutputReport(dataArray, reportID, skipIdenticalReports);
+        this->sendOutputReport(dataArray, reportID, resendUnchangedReport);
     }
 
     /// @brief Sends an OutputReport to HID device
     /// @param dataArray Data to send as byte array (Javascript type Uint8Array)
     /// @param reportID 1...255 for HID devices that uses ReportIDs - or 0 for devices, which don't use ReportIDs
-    /// @param skipIdenticalReports If set, the sending of the report is inhibited, when the data didn't changed
+    /// @param resendUnchangedReport If set, the report will also be send, if the data are unchanged since last sending
     Q_INVOKABLE void sendOutputReport(const QByteArray& dataArray,
             unsigned int reportID,
-            bool skipIdenticalReports = true) {
+            bool resendUnchangedReport = false) {
         VERIFY_OR_DEBUG_ASSERT(m_pHidController->m_pHidIoThread) {
             return;
         }
         m_pHidController->m_pHidIoThread->updateCachedOutputReportData(
-                dataArray, reportID, skipIdenticalReports);
+                dataArray, reportID, resendUnchangedReport);
     }
 
     /// @brief getInputReport receives an InputReport from the HID device on request.

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -64,7 +64,7 @@ class HidControllerJSProxy : public ControllerJSProxy {
     Q_INVOKABLE void send(const QList<int>& dataList, unsigned int length = 0) override {
         // This function is only for class compatibility with the (midi)controller
         Q_UNUSED(length);
-        this->send(dataList, 0, 0);
+        send(dataList, 0, 0);
     }
 
     /// @brief Sends HID OutputReport to HID device
@@ -82,7 +82,7 @@ class HidControllerJSProxy : public ControllerJSProxy {
         for (int datum : dataList) {
             dataArray.append(datum);
         }
-        this->sendOutputReport(reportID, dataArray, resendUnchangedReport);
+        sendOutputReport(reportID, dataArray, resendUnchangedReport);
     }
 
     /// @brief Sends an OutputReport to HID device

--- a/src/controllers/hid/hidiooutputreport.cpp
+++ b/src/controllers/hid/hidiooutputreport.cpp
@@ -29,7 +29,7 @@ HidIoOutputReport::HidIoOutputReport(
 void HidIoOutputReport::updateCachedData(const QByteArray& data,
         const mixxx::hid::DeviceInfo& deviceInfo,
         const RuntimeLoggingCategory& logOutput,
-        const bool& resendUnchangedReport) {
+        bool resendUnchangedReport) {
     auto cacheLock = lockMutex(&m_cachedDataMutex);
 
     if (!m_lastCachedDataSize) {

--- a/src/controllers/hid/hidiooutputreport.cpp
+++ b/src/controllers/hid/hidiooutputreport.cpp
@@ -82,7 +82,7 @@ bool HidIoOutputReport::sendCachedData(QMutex* pHidDeviceAndPollMutex,
         return false;
     }
 
-    if (m_resendUnchangedReport && !m_lastSentData.compare(m_cachedData)) {
+    if (!(m_resendUnchangedReport || m_lastSentData.compare(m_cachedData))) {
         // An HID OutputReport can contain only HID OutputItems.
         // HID OutputItems are defined to represent the state of one or more similar controls or LEDs.
         // Only HID Feature items may be attributes of other items.

--- a/src/controllers/hid/hidiooutputreport.cpp
+++ b/src/controllers/hid/hidiooutputreport.cpp
@@ -28,7 +28,8 @@ HidIoOutputReport::HidIoOutputReport(
 
 void HidIoOutputReport::updateCachedData(const QByteArray& data,
         const mixxx::hid::DeviceInfo& deviceInfo,
-        const RuntimeLoggingCategory& logOutput) {
+        const RuntimeLoggingCategory& logOutput,
+        bool skipIdenticalReports) {
     auto cacheLock = lockMutex(&m_cachedDataMutex);
 
     if (!m_lastCachedDataSize) {
@@ -65,6 +66,7 @@ void HidIoOutputReport::updateCachedData(const QByteArray& data,
             data.constData(),
             data.size());
     m_possiblyUnsentDataCached = true;
+    m_skipIdenticalReports = skipIdenticalReports;
 }
 
 bool HidIoOutputReport::sendCachedData(QMutex* pHidDeviceAndPollMutex,
@@ -80,7 +82,7 @@ bool HidIoOutputReport::sendCachedData(QMutex* pHidDeviceAndPollMutex,
         return false;
     }
 
-    if (!m_lastSentData.compare(m_cachedData)) {
+    if (!m_skipIdenticalReports && !m_lastSentData.compare(m_cachedData)) {
         // An HID OutputReport can contain only HID OutputItems.
         // HID OutputItems are defined to represent the state of one or more similar controls or LEDs.
         // Only HID Feature items may be attributes of other items.

--- a/src/controllers/hid/hidiooutputreport.cpp
+++ b/src/controllers/hid/hidiooutputreport.cpp
@@ -15,7 +15,7 @@ constexpr int kMaxHidErrorMessageSize = 512;
 } // namespace
 
 HidIoOutputReport::HidIoOutputReport(
-        const unsigned char& reportId, const unsigned int& reportDataSize)
+        const quint8& reportId, const unsigned int& reportDataSize)
         : m_reportId(reportId),
           m_possiblyUnsentDataCached(false),
           m_lastCachedDataSize(0) {

--- a/src/controllers/hid/hidiooutputreport.cpp
+++ b/src/controllers/hid/hidiooutputreport.cpp
@@ -29,7 +29,7 @@ HidIoOutputReport::HidIoOutputReport(
 void HidIoOutputReport::updateCachedData(const QByteArray& data,
         const mixxx::hid::DeviceInfo& deviceInfo,
         const RuntimeLoggingCategory& logOutput,
-        bool skipIdenticalReports) {
+        bool resendUnchangedReport) {
     auto cacheLock = lockMutex(&m_cachedDataMutex);
 
     if (!m_lastCachedDataSize) {
@@ -66,7 +66,7 @@ void HidIoOutputReport::updateCachedData(const QByteArray& data,
             data.constData(),
             data.size());
     m_possiblyUnsentDataCached = true;
-    m_skipIdenticalReports = skipIdenticalReports;
+    m_resendUnchangedReport = resendUnchangedReport;
 }
 
 bool HidIoOutputReport::sendCachedData(QMutex* pHidDeviceAndPollMutex,
@@ -82,7 +82,7 @@ bool HidIoOutputReport::sendCachedData(QMutex* pHidDeviceAndPollMutex,
         return false;
     }
 
-    if (!m_skipIdenticalReports && !m_lastSentData.compare(m_cachedData)) {
+    if (m_resendUnchangedReport && !m_lastSentData.compare(m_cachedData)) {
         // An HID OutputReport can contain only HID OutputItems.
         // HID OutputItems are defined to represent the state of one or more similar controls or LEDs.
         // Only HID Feature items may be attributes of other items.

--- a/src/controllers/hid/hidiooutputreport.cpp
+++ b/src/controllers/hid/hidiooutputreport.cpp
@@ -29,7 +29,7 @@ HidIoOutputReport::HidIoOutputReport(
 void HidIoOutputReport::updateCachedData(const QByteArray& data,
         const mixxx::hid::DeviceInfo& deviceInfo,
         const RuntimeLoggingCategory& logOutput,
-        bool resendUnchangedReport) {
+        const bool& resendUnchangedReport) {
     auto cacheLock = lockMutex(&m_cachedDataMutex);
 
     if (!m_lastCachedDataSize) {

--- a/src/controllers/hid/hidiooutputreport.h
+++ b/src/controllers/hid/hidiooutputreport.h
@@ -14,7 +14,7 @@ class HidIoOutputReport {
 
             const mixxx::hid::DeviceInfo& deviceInfo,
             const RuntimeLoggingCategory& logOutput,
-            const bool& resendUnchangedReport);
+            bool resendUnchangedReport);
 
     /// Sends the OutputReport to the HID device, when changed data are cached.
     /// Returns true if a time consuming hid_write operation was executed.

--- a/src/controllers/hid/hidiooutputreport.h
+++ b/src/controllers/hid/hidiooutputreport.h
@@ -13,7 +13,8 @@ class HidIoOutputReport {
     void updateCachedData(const QByteArray& data,
 
             const mixxx::hid::DeviceInfo& deviceInfo,
-            const RuntimeLoggingCategory& logOutput, bool skipIdenticalReports);
+            const RuntimeLoggingCategory& logOutput,
+            bool skipIdenticalReports);
 
     /// Sends the OutputReport to the HID device, when changed data are cached.
     /// Returns true if a time consuming hid_write operation was executed.

--- a/src/controllers/hid/hidiooutputreport.h
+++ b/src/controllers/hid/hidiooutputreport.h
@@ -7,7 +7,7 @@
 
 class HidIoOutputReport {
   public:
-    HidIoOutputReport(const unsigned char& reportId, const unsigned int& reportDataSize);
+    HidIoOutputReport(const quint8& reportId, const unsigned int& reportDataSize);
 
     /// Caches new report data, which will later send by the IO thread
     void updateCachedData(const QByteArray& data,
@@ -24,7 +24,7 @@ class HidIoOutputReport {
             const RuntimeLoggingCategory& logOutput);
 
   private:
-    const unsigned char m_reportId;
+    const quint8 m_reportId;
     QByteArray m_lastSentData;
 
     /// Mutex must be locked when reading/writing m_cachedData

--- a/src/controllers/hid/hidiooutputreport.h
+++ b/src/controllers/hid/hidiooutputreport.h
@@ -11,8 +11,9 @@ class HidIoOutputReport {
 
     /// Caches new report data, which will later send by the IO thread
     void updateCachedData(const QByteArray& data,
+
             const mixxx::hid::DeviceInfo& deviceInfo,
-            const RuntimeLoggingCategory& logOutput);
+            const RuntimeLoggingCategory& logOutput, bool skipIdenticalReports);
 
     /// Sends the OutputReport to the HID device, when changed data are cached.
     /// Returns true if a time consuming hid_write operation was executed.
@@ -26,11 +27,12 @@ class HidIoOutputReport {
     QByteArray m_lastSentData;
 
     /// Mutex must be locked when reading/writing m_cachedData
-    /// or m_possiblyUnsentDataCached
+    /// or m_possiblyUnsentDataCached, m_skipIdenticalReports
     QMutex m_cachedDataMutex;
 
     QByteArray m_cachedData;
     bool m_possiblyUnsentDataCached;
+    bool m_skipIdenticalReports;
 
     /// Due to swapping of the QbyteArrays, we need to store
     /// this information independent of the QBytearray size

--- a/src/controllers/hid/hidiooutputreport.h
+++ b/src/controllers/hid/hidiooutputreport.h
@@ -14,7 +14,7 @@ class HidIoOutputReport {
 
             const mixxx::hid::DeviceInfo& deviceInfo,
             const RuntimeLoggingCategory& logOutput,
-            bool skipIdenticalReports);
+            bool resendUnchangedReport);
 
     /// Sends the OutputReport to the HID device, when changed data are cached.
     /// Returns true if a time consuming hid_write operation was executed.
@@ -28,12 +28,12 @@ class HidIoOutputReport {
     QByteArray m_lastSentData;
 
     /// Mutex must be locked when reading/writing m_cachedData
-    /// or m_possiblyUnsentDataCached, m_skipIdenticalReports
+    /// or m_possiblyUnsentDataCached, m_resendUnchangedReport
     QMutex m_cachedDataMutex;
 
     QByteArray m_cachedData;
     bool m_possiblyUnsentDataCached;
-    bool m_skipIdenticalReports;
+    bool m_resendUnchangedReport;
 
     /// Due to swapping of the QbyteArrays, we need to store
     /// this information independent of the QBytearray size

--- a/src/controllers/hid/hidiooutputreport.h
+++ b/src/controllers/hid/hidiooutputreport.h
@@ -14,7 +14,7 @@ class HidIoOutputReport {
 
             const mixxx::hid::DeviceInfo& deviceInfo,
             const RuntimeLoggingCategory& logOutput,
-            bool resendUnchangedReport);
+            const bool& resendUnchangedReport);
 
     /// Sends the OutputReport to the HID device, when changed data are cached.
     /// Returns true if a time consuming hid_write operation was executed.

--- a/src/controllers/hid/hidiothread.cpp
+++ b/src/controllers/hid/hidiothread.cpp
@@ -189,7 +189,9 @@ QByteArray HidIoThread::getInputReport(unsigned int reportID) {
     return returnArray;
 }
 
-void HidIoThread::updateCachedOutputReportData(const QByteArray& data, unsigned int reportID, bool skipIdenticalReports) {
+void HidIoThread::updateCachedOutputReportData(const QByteArray& data,
+        unsigned int reportID,
+        bool skipIdenticalReports) {
     auto mapLock = lockMutex(&m_outputReportMapMutex);
     if (m_outputReports.find(reportID) == m_outputReports.end()) {
         std::unique_ptr<HidIoOutputReport> pNewOutputReport;
@@ -205,7 +207,8 @@ void HidIoThread::updateCachedOutputReportData(const QByteArray& data, unsigned 
 
     mapLock.unlock();
 
-    actualOutputReportIterator->second->updateCachedData(data, m_deviceInfo, m_logOutput, skipIdenticalReports);
+    actualOutputReportIterator->second->updateCachedData(
+            data, m_deviceInfo, m_logOutput, skipIdenticalReports);
 }
 
 bool HidIoThread::sendNextCachedOutputReport() {

--- a/src/controllers/hid/hidiothread.cpp
+++ b/src/controllers/hid/hidiothread.cpp
@@ -143,7 +143,7 @@ void HidIoThread::processInputReport(int bytesRead) {
             mixxx::Time::elapsed());
 }
 
-QByteArray HidIoThread::getInputReport(unsigned int reportID) {
+QByteArray HidIoThread::getInputReport(quint8 reportID) {
     auto startOfHidGetInputReport = mixxx::Time::elapsed();
     auto hidDeviceLock = lockMutex(&m_hidDeviceAndPollMutex);
 
@@ -189,7 +189,7 @@ QByteArray HidIoThread::getInputReport(unsigned int reportID) {
 }
 
 void HidIoThread::updateCachedOutputReportData(const QByteArray& data,
-        unsigned int reportID,
+        quint8 reportID,
         bool resendUnchangedReport) {
     auto mapLock = lockMutex(&m_outputReportMapMutex);
     if (m_outputReports.find(reportID) == m_outputReports.end()) {
@@ -238,7 +238,7 @@ bool HidIoThread::sendNextCachedOutputReport() {
 }
 
 void HidIoThread::sendFeatureReport(
-        const QByteArray& reportData, unsigned int reportID) {
+        const QByteArray& reportData, quint8 reportID) {
     auto startOfHidSendFeatureReport = mixxx::Time::elapsed();
     QByteArray dataArray;
     dataArray.reserve(kReportIdSize + reportData.size());
@@ -273,7 +273,7 @@ void HidIoThread::sendFeatureReport(
 }
 
 QByteArray HidIoThread::getFeatureReport(
-        unsigned int reportID) {
+        quint8 reportID) {
     auto startOfHidGetFeatureReport = mixxx::Time::elapsed();
     unsigned char dataRead[kReportIdSize + kBufferSize];
     dataRead[0] = reportID;

--- a/src/controllers/hid/hidiothread.cpp
+++ b/src/controllers/hid/hidiothread.cpp
@@ -188,8 +188,8 @@ QByteArray HidIoThread::getInputReport(quint8 reportID) {
     return returnArray;
 }
 
-void HidIoThread::updateCachedOutputReportData(const QByteArray& data,
-        quint8 reportID,
+void HidIoThread::updateCachedOutputReportData(quint8 reportID,
+        const QByteArray& data,
         bool resendUnchangedReport) {
     auto mapLock = lockMutex(&m_outputReportMapMutex);
     if (m_outputReports.find(reportID) == m_outputReports.end()) {
@@ -238,7 +238,7 @@ bool HidIoThread::sendNextCachedOutputReport() {
 }
 
 void HidIoThread::sendFeatureReport(
-        const QByteArray& reportData, quint8 reportID) {
+        quint8 reportID, const QByteArray& reportData) {
     auto startOfHidSendFeatureReport = mixxx::Time::elapsed();
     QByteArray dataArray;
     dataArray.reserve(kReportIdSize + reportData.size());

--- a/src/controllers/hid/hidiothread.cpp
+++ b/src/controllers/hid/hidiothread.cpp
@@ -168,10 +168,9 @@ QByteArray HidIoThread::getInputReport(unsigned int reportID) {
     }
 
     // Convert array of bytes read in a JavaScript compatible return type, this is returned as deep-copy, for thread safety.
-    // For compatibility with HidController::processInputReport, the reportID prefix is included added here
     QByteArray returnArray = QByteArray(
-            reinterpret_cast<char*>(m_pPollData[m_pollingBufferIndex]),
-            bytesRead);
+            reinterpret_cast<char*>(m_pPollData[m_pollingBufferIndex] + kReportIdSize),
+            bytesRead - kReportIdSize);
 
     hidDeviceLock.unlock();
 

--- a/src/controllers/hid/hidiothread.cpp
+++ b/src/controllers/hid/hidiothread.cpp
@@ -205,7 +205,7 @@ void HidIoThread::updateCachedOutputReportData(const QByteArray& data, unsigned 
 
     mapLock.unlock();
 
-    actualOutputReportIterator->second->updateCachedData(data, m_deviceInfo, m_logOutput);
+    actualOutputReportIterator->second->updateCachedData(data, m_deviceInfo, m_logOutput, skipIdenticalReports);
 }
 
 bool HidIoThread::sendNextCachedOutputReport() {

--- a/src/controllers/hid/hidiothread.cpp
+++ b/src/controllers/hid/hidiothread.cpp
@@ -189,7 +189,7 @@ QByteArray HidIoThread::getInputReport(unsigned int reportID) {
     return returnArray;
 }
 
-void HidIoThread::updateCachedOutputReportData(const QByteArray& data, unsigned int reportID) {
+void HidIoThread::updateCachedOutputReportData(const QByteArray& data, unsigned int reportID, bool skipIdenticalReports) {
     auto mapLock = lockMutex(&m_outputReportMapMutex);
     if (m_outputReports.find(reportID) == m_outputReports.end()) {
         std::unique_ptr<HidIoOutputReport> pNewOutputReport;

--- a/src/controllers/hid/hidiothread.cpp
+++ b/src/controllers/hid/hidiothread.cpp
@@ -191,7 +191,7 @@ QByteArray HidIoThread::getInputReport(unsigned int reportID) {
 
 void HidIoThread::updateCachedOutputReportData(const QByteArray& data,
         unsigned int reportID,
-        bool skipIdenticalReports) {
+        bool resendUnchangedReport) {
     auto mapLock = lockMutex(&m_outputReportMapMutex);
     if (m_outputReports.find(reportID) == m_outputReports.end()) {
         std::unique_ptr<HidIoOutputReport> pNewOutputReport;
@@ -208,7 +208,7 @@ void HidIoThread::updateCachedOutputReportData(const QByteArray& data,
     mapLock.unlock();
 
     actualOutputReportIterator->second->updateCachedData(
-            data, m_deviceInfo, m_logOutput, skipIdenticalReports);
+            data, m_deviceInfo, m_logOutput, resendUnchangedReport);
 }
 
 bool HidIoThread::sendNextCachedOutputReport() {

--- a/src/controllers/hid/hidiothread.h
+++ b/src/controllers/hid/hidiothread.h
@@ -42,7 +42,7 @@ class HidIoThread : public QThread {
     /// Returns immediately with true if the run loop is stopped.
     [[nodiscard]] bool waitUntilRunLoopIsStopped(unsigned int timeoutMillis);
 
-    void updateCachedOutputReportData(const QByteArray& reportData, unsigned int reportID);
+    void updateCachedOutputReportData(const QByteArray& reportData, unsigned int reportID, bool skipIdenticalReports);
     QByteArray getInputReport(unsigned int reportID);
     void sendFeatureReport(const QByteArray& reportData, unsigned int reportID);
     QByteArray getFeatureReport(unsigned int reportID);

--- a/src/controllers/hid/hidiothread.h
+++ b/src/controllers/hid/hidiothread.h
@@ -42,7 +42,9 @@ class HidIoThread : public QThread {
     /// Returns immediately with true if the run loop is stopped.
     [[nodiscard]] bool waitUntilRunLoopIsStopped(unsigned int timeoutMillis);
 
-    void updateCachedOutputReportData(const QByteArray& reportData, unsigned int reportID, bool skipIdenticalReports);
+    void updateCachedOutputReportData(const QByteArray& reportData,
+            unsigned int reportID,
+            bool skipIdenticalReports);
     QByteArray getInputReport(unsigned int reportID);
     void sendFeatureReport(const QByteArray& reportData, unsigned int reportID);
     QByteArray getFeatureReport(unsigned int reportID);

--- a/src/controllers/hid/hidiothread.h
+++ b/src/controllers/hid/hidiothread.h
@@ -42,11 +42,11 @@ class HidIoThread : public QThread {
     /// Returns immediately with true if the run loop is stopped.
     [[nodiscard]] bool waitUntilRunLoopIsStopped(unsigned int timeoutMillis);
 
-    void updateCachedOutputReportData(const QByteArray& reportData,
-            quint8 reportID,
+    void updateCachedOutputReportData(quint8 reportID,
+            const QByteArray& reportData,
             bool resendUnchangedReport);
     QByteArray getInputReport(quint8 reportID);
-    void sendFeatureReport(const QByteArray& reportData, quint8 reportID);
+    void sendFeatureReport(quint8 reportID, const QByteArray& reportData);
     QByteArray getFeatureReport(quint8 reportID);
 
   signals:

--- a/src/controllers/hid/hidiothread.h
+++ b/src/controllers/hid/hidiothread.h
@@ -43,11 +43,11 @@ class HidIoThread : public QThread {
     [[nodiscard]] bool waitUntilRunLoopIsStopped(unsigned int timeoutMillis);
 
     void updateCachedOutputReportData(const QByteArray& reportData,
-            unsigned int reportID,
+            quint8 reportID,
             bool resendUnchangedReport);
-    QByteArray getInputReport(unsigned int reportID);
-    void sendFeatureReport(const QByteArray& reportData, unsigned int reportID);
-    QByteArray getFeatureReport(unsigned int reportID);
+    QByteArray getInputReport(quint8 reportID);
+    void sendFeatureReport(const QByteArray& reportData, quint8 reportID);
+    QByteArray getFeatureReport(quint8 reportID);
 
   signals:
     /// Signals that a HID InputReport received by Interrupt triggered from HID device

--- a/src/controllers/hid/hidiothread.h
+++ b/src/controllers/hid/hidiothread.h
@@ -44,7 +44,7 @@ class HidIoThread : public QThread {
 
     void updateCachedOutputReportData(const QByteArray& reportData,
             unsigned int reportID,
-            bool skipIdenticalReports);
+            bool resendUnchangedReport);
     QByteArray getInputReport(unsigned int reportID);
     void sendFeatureReport(const QByteArray& reportData, unsigned int reportID);
     QByteArray getFeatureReport(unsigned int reportID);


### PR DESCRIPTION
I added a switch to force the sending of HID OutputReports with identical data, as needed by @Be-ing to support the S4 MK3 mapping: https://github.com/mixxxdj/mixxx/pull/4585#discussion_r813208966

After looking at the JavaScript API, I found out, that
`Q_INVOKABLE void send(const QList<int>& data, unsigned int length = 0) override`
is only there to comply with the inheritance of controller.c. But this function is practically useless. It doesn't send raw bytes as the siblings for MIDI and BULK, because this is a functionality, which the HID protocoll doesn't support. Instead it sends a OutputReport with hardcoded ReportID 0. I wonder, if this function was ever used anywhere.

Than there is
`Q_INVOKABLE void send(const QList<int>& data, unsigned int length, unsigned int reportID)`
which has already one unused argument (length).

Both send functions use QLIST as argument, while since #4521, the other functions of the JavaScript API use QByteArray.

I added a new API function with QByteArray
`Q_INVOKABLE void sendOutputReport(unsigned int reportID, const QByteArray& dataArray, resendUnchangedReport = false)`
and extended the old send function backward compatibility:
`Q_INVOKABLE void send(const QList<int>& dataList, unsigned int length, unsigned int reportID, resendUnchangedReport = false)`
Note: I found no way to make an overloaded function work, which support both QList or QByteArray. Independend of the type in JavaScript, always the same function was called. 

Furthermore I noticed, that the comments describing these JavaScript API functions are no longer apply since #4521, I rewrote them (in Doxygen syntax). Especially the returned array of getInputReport became incompatible to the incommingdata function. And this compatibility was the only reason to prepend the reportId to the data array.



Now the HID API functions are:

**Unchanged since 2.3:**
`Q_INVOKABLE void send(const QList<int>& dataList, unsigned int length = 0) override`
IMHO this function makes no sense, but I kept it for backward compatibility

**Extended since 2.3:**
`Q_INVOKABLE void send(const QList<int>& dataList, unsigned int length, quint8 reportID, bool resendUnchangedReport = false)`
Added optional argument resendUnchangedReport - Note that the Length argument is unused and it uses QList

**New in 2.4 and now unified in content and type of the data array:**
`Q_INVOKABLE void sendOutputReport(quint8 reportID, const QByteArray& dataArray, bool resendUnchangedReport = false)`
`Q_INVOKABLE QByteArray getInputReport(quint8 reportID)`
`Q_INVOKABLE void sendFeatureReport(quint8 reportID, const QByteArray& reportData)`
`Q_INVOKABLE QByteArray getFeatureReport(quint8 reportID)`

This is now similar to the basic IO functions in all other HID APIs I know - as well in naming as in order of arguments

