### PR TITLE
Fix undesired jump-cuts in auto DJ 

### DIFF
--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -957,26 +957,29 @@ void AutoDJProcessor::playerPlayChanged(DeckAttributes* thisDeck, bool playing) 
         return;
     }
 
-    if (playing && !otherDeck->isPlaying()) {
-        // In case both decks were stopped and now this one just started, make
-        // this deck the "from deck".
-        calculateTransition(thisDeck, getOtherDeck(thisDeck), false);
-    }
-
-    // If the user manually pressed play on the "to deck" before fading, for
-    // example to adjust the intro/outro cues, and lets the deck play until the
-    // end, seek back to the start point instead of keeping the deck stopped at
-    // the end.
-    if (!playing && thisDeck->playPosition() >= 1.0 && !thisDeck->isFromDeck) {
-        // toDeck has stopped at the end. Recalculate the transition, because
-        // it has been done from a now irrelevant previous position.
-        // This forces the other deck to be the fromDeck.
-        thisDeck->startPos = kKeepPosition;
-        calculateTransition(otherDeck, thisDeck, true);
-        if (thisDeck->startPos != kKeepPosition) {
-            // Note: this seek will trigger the playerPositionChanged slot
-            // which may calls the calculateTransition() again without seek = true;
-            thisDeck->setPlayPosition(thisDeck->startPos);
+    if (playing) {
+        if (!otherDeck->isPlaying()) {
+            // In case both decks were stopped and now this one just started, make
+            // this deck the "from deck".
+            calculateTransition(thisDeck, getOtherDeck(thisDeck), false);
+        }
+    } else {
+        // Deck paused    
+        // This may happen if the user has previously pressed play on the "to deck" 
+        // before fading, for example to adjust the intro/outro cues, and lets the 
+        // deck play until the end, seek back to the start point instead of keeping 
+        // the deck stopped at the end.
+        if (thisDeck->playPosition() >= 1.0 && !thisDeck->isFromDeck) {
+            // toDeck has stopped at the end. Recalculate the transition, because
+            // it has been done from a now irrelevant previous position.
+            // This forces the other deck to be the fromDeck.
+            thisDeck->startPos = kKeepPosition;
+            calculateTransition(otherDeck, thisDeck, true);
+            if (thisDeck->startPos != kKeepPosition) {
+                // Note: this seek will trigger the playerPositionChanged slot
+                // which may calls the calculateTransition() again without seek = true;
+                thisDeck->setPlayPosition(thisDeck->startPos);
+            }
         }
     }
 }

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1236,6 +1236,12 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
     }
 
     double introLength = introEnd - introStart;
+        
+    if (sDebug) {
+        qDebug() << this << "calculateTransition"
+                 << "introLength" << introLength
+                 << "outroLength" << outroLength;
+    }
 
     switch (m_transitionMode) {
     case TransitionMode::FullIntroOutro: {

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -621,11 +621,6 @@ void AutoDJProcessor::crossfaderChanged(double value) {
 
 void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
                                             double thisPlayPosition) {
-    if (sDebug) {
-        //qDebug() << this << "playerPositionChanged" << pAttributes->group
-        //         << thisPlayPosition;
-    }
-
     // Auto-DJ needs at least two decks
     VERIFY_OR_DEBUG_ASSERT(m_decks.length() > 1) {
         return;
@@ -778,6 +773,12 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
                 // that was "on deck" from the top of the queue.
                 // Note: This is a DB call and takes long.
                 removeLoadedTrackFromTopOfQueue(*otherDeck);
+            } else {
+                if (sDebug) {
+                    qDebug() << this << "playerPositionChanged()"
+                             << pAttributes->group << thisPlayPosition
+                             << "but not playing";
+                }
             }
         }
 
@@ -1137,22 +1138,22 @@ double AutoDJProcessor::samplePositionToSeconds(double samplePosition, DeckAttri
 void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
         DeckAttributes* pToDeck,
         bool seekToStartPoint) {
-    if (pFromDeck == nullptr || pToDeck == nullptr) {
+    VERIFY_OR_DEBUG_ASSERT(pFromDeck && pToDeck) {
         return;
     }
-    if (pFromDeck->loading || pToDeck->loading) {
+    VERIFY_OR_DEBUG_ASSERT(!pFromDeck->loading && !pToDeck->loading) {
         // don't use halve new halve old data during
         // changing of tracks
         return;
     }
-
-    qDebug() << "player" << pFromDeck->group << "calculateTransition()";
 
     // We require ADJ_IDLE to prevent changing the thresholds in the middle of a
     // fade.
     VERIFY_OR_DEBUG_ASSERT(m_eState == ADJ_IDLE) {
         return;
     }
+
+    qDebug() << "player" << pFromDeck->group << "calculateTransition()";
 
     const double fromDeckEndPosition = getEndSecond(pFromDeck);
     const double toDeckEndPosition = getEndSecond(pToDeck);
@@ -1169,7 +1170,7 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
         pToDeck->startPos = kKeepPosition;
         return;
     }
-    if (toDeckDuration <= 0) {
+    VERIFY_OR_DEBUG_ASSERT(toDeckDuration > 0) {
         // Playing Track has no duration. This should not happen, because short
         // tracks are skipped after load.
         loadNextTrackFromQueue(*pToDeck, false);
@@ -1459,6 +1460,10 @@ void AutoDJProcessor::playerTrackLoaded(DeckAttributes* pDeck, TrackPointer pTra
                     // repeat a probably missed update
                     playerPositionChanged(fromDeck, 1.0);
                 }
+            } else {
+                if (sDebug) {
+                    qDebug() << this << "playerTrackLoaded()" << pDeck->group << "but not a toDeck";
+                }
             }
         }
     }
@@ -1468,8 +1473,8 @@ void AutoDJProcessor::playerLoadingTrack(DeckAttributes* pDeck,
         TrackPointer pNewTrack, TrackPointer pOldTrack) {
     if (sDebug) {
         qDebug() << this << "playerLoadingTrack" << pDeck->group
-                 << "new:"<< (pNewTrack ? pNewTrack->getLocation() : "(null)")
-                 << "old:"<< (pOldTrack ? pOldTrack->getLocation() : "(null)");
+                 << "new:" << (pNewTrack ? pNewTrack->getLocation() : "(null)")
+                 << "old:" << (pOldTrack ? pOldTrack->getLocation() : "(null)");
     }
 
     pDeck->loading = true;

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -692,6 +692,10 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
             } else {
                 // At least right deck is playing
                 // Set crossfade thresholds for right deck.
+                if (sDebug) {
+                    qDebug() << this << "playerPositionChanged"
+                             << "right deck playing";
+                }
                 calculateTransition(rightDeck, leftDeck, false);
             }
             emitAutoDJStateChanged(m_eState);
@@ -738,6 +742,10 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
             // recalculated here.
             // Don't adjust transition when reaching the end. In this case it is
             // always stopped.
+            if (sDebug) {
+                qDebug() << this << "playerPositionChanged"
+                         << "cueing seek";
+            }
             calculateTransition(otherDeck, thisDeck, false);
         } else if (thisDeck->isRepeat()) {
             // repeat pauses auto DJ
@@ -964,11 +972,10 @@ void AutoDJProcessor::playerPlayChanged(DeckAttributes* thisDeck, bool playing) 
             calculateTransition(thisDeck, getOtherDeck(thisDeck), false);
         }
     } else {
-        // Deck paused    
-        // This may happen if the user has previously pressed play on the "to deck" 
-        // before fading, for example to adjust the intro/outro cues, and lets the 
-        // deck play until the end, seek back to the start point instead of keeping 
-        // the deck stopped at the end.
+        // Deck paused
+        // This may happen if the user has previously pressed play on the "to deck"
+        // before fading, for example to adjust the intro/outro cues, and lets the
+        // deck play until the end, seek back to the start point instead of keeping
         if (thisDeck->playPosition() >= 1.0 && !thisDeck->isFromDeck) {
             // toDeck has stopped at the end. Recalculate the transition, because
             // it has been done from a now irrelevant previous position.

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1163,8 +1163,6 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
         return;
     }
 
-    qDebug() << "player" << pFromDeck->group << "calculateTransition()";
-
     const double fromDeckEndPosition = getEndSecond(pFromDeck);
     const double toDeckEndPosition = getEndSecond(pToDeck);
     // Since the end position is measured in seconds from 0:00 it is also
@@ -1227,16 +1225,15 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
         introStart = toDeckPositionSeconds;
     }
 
-    double introEnd = getIntroEndSecond(pToDeck);
-    if (introEnd < introStart) {
-        // introEnd is invalid. Assume a zero length intro.
-        // The introStart is automatically placed by AnalyzerSilence, so use
-        // that as a fallback if the user has not placed introEnd.
-        introEnd = introStart;
+    double introLength = 0;
+    const double introEndSample = pToDeck->introEndPosition();
+    if (introEndSample != Cue::kNoPosition) {
+        const double introEnd = samplePositionToSeconds(introEndSample, pToDeck);
+        if (introStart < introEnd) {
+            introLength = introEnd - introStart;
+        }
     }
 
-    double introLength = introEnd - introStart;
-        
     if (sDebug) {
         qDebug() << this << "calculateTransition"
                  << "introLength" << introLength

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1151,7 +1151,7 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
     VERIFY_OR_DEBUG_ASSERT(pFromDeck && pToDeck) {
         return;
     }
-    VERIFY_OR_DEBUG_ASSERT(!pFromDeck->loading && !pToDeck->loading) {
+    if (pFromDeck->loading || pToDeck->loading) {
         // don't use halve new halve old data during
         // changing of tracks
         return;

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -19,7 +19,7 @@ const double kKeepPosition = -1.0;
 
 const mixxx::audio::ChannelCount kChannelCount = mixxx::kEngineChannelCount;
 
-static const bool sDebug = false;
+constexpr bool sDebug = false;
 } // anonymous namespace
 
 DeckAttributes::DeckAttributes(int index,
@@ -692,7 +692,7 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
             } else {
                 // At least right deck is playing
                 // Set crossfade thresholds for right deck.
-                if (sDebug) {
+                if constexpr (sDebug) {
                     qDebug() << this << "playerPositionChanged"
                              << "right deck playing";
                 }
@@ -742,7 +742,7 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
             // recalculated here.
             // Don't adjust transition when reaching the end. In this case it is
             // always stopped.
-            if (sDebug) {
+            if constexpr (sDebug) {
                 qDebug() << this << "playerPositionChanged"
                          << "cueing seek";
             }
@@ -782,7 +782,7 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
                 // Note: This is a DB call and takes long.
                 removeLoadedTrackFromTopOfQueue(*otherDeck);
             } else {
-                if (sDebug) {
+                if constexpr (sDebug) {
                     qDebug() << this << "playerPositionChanged()"
                              << pAttributes->group << thisPlayPosition
                              << "but not playing";
@@ -944,7 +944,7 @@ void AutoDJProcessor::maybeFillRandomTracks() {
 }
 
 void AutoDJProcessor::playerPlayChanged(DeckAttributes* thisDeck, bool playing) {
-    if (sDebug) {
+    if constexpr (sDebug) {
         qDebug() << this << "playerPlayChanged" << thisDeck->group << playing;
     }
 
@@ -992,7 +992,7 @@ void AutoDJProcessor::playerPlayChanged(DeckAttributes* thisDeck, bool playing) 
 }
 
 void AutoDJProcessor::playerIntroStartChanged(DeckAttributes* pAttributes, double position) {
-    if (sDebug) {
+    if constexpr (sDebug) {
         qDebug() << this << "playerIntroStartChanged" << pAttributes->group << position;
     }
     // nothing to do, because we want not to re-cue the toDeck and the from
@@ -1000,7 +1000,7 @@ void AutoDJProcessor::playerIntroStartChanged(DeckAttributes* pAttributes, doubl
 }
 
 void AutoDJProcessor::playerIntroEndChanged(DeckAttributes* pAttributes, double position) {
-    if (sDebug) {
+    if constexpr (sDebug) {
         qDebug() << this << "playerIntroEndChanged" << pAttributes->group << position;
     }
 
@@ -1021,7 +1021,7 @@ void AutoDJProcessor::playerIntroEndChanged(DeckAttributes* pAttributes, double 
 }
 
 void AutoDJProcessor::playerOutroStartChanged(DeckAttributes* pAttributes, double position) {
-    if (sDebug) {
+    if constexpr (sDebug) {
         qDebug() << this << "playerOutroStartChanged" << pAttributes->group << position;
     }
 
@@ -1038,7 +1038,7 @@ void AutoDJProcessor::playerOutroStartChanged(DeckAttributes* pAttributes, doubl
 }
 
 void AutoDJProcessor::playerOutroEndChanged(DeckAttributes* pAttributes, double position) {
-    if (sDebug) {
+    if constexpr (sDebug) {
         qDebug() << this << "playerOutroEndChanged" << pAttributes->group << position;
     }
 
@@ -1234,7 +1234,7 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
         }
     }
 
-    if (sDebug) {
+    if constexpr (sDebug) {
         qDebug() << this << "calculateTransition"
                  << "introLength" << introLength
                  << "outroLength" << outroLength;
@@ -1384,7 +1384,7 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
         pFromDeck->fadeBeginPos = 1;
     }
 
-    if (sDebug) {
+    if constexpr (sDebug) {
         qDebug() << this << "calculateTransition" << pFromDeck->group
                  << pFromDeck->fadeBeginPos << pFromDeck->fadeEndPos
                  << pToDeck->startPos;
@@ -1435,7 +1435,7 @@ void AutoDJProcessor::useFixedFadeTime(
 }
 
 void AutoDJProcessor::playerTrackLoaded(DeckAttributes* pDeck, TrackPointer pTrack) {
-    if (sDebug) {
+    if constexpr (sDebug) {
         qDebug() << this << "playerTrackLoaded" << pDeck->group
                  << (pTrack ? pTrack->getLocation() : "(null)");
     }
@@ -1474,7 +1474,7 @@ void AutoDJProcessor::playerTrackLoaded(DeckAttributes* pDeck, TrackPointer pTra
                     playerPositionChanged(fromDeck, 1.0);
                 }
             } else {
-                if (sDebug) {
+                if constexpr (sDebug) {
                     qDebug() << this << "playerTrackLoaded()" << pDeck->group << "but not a toDeck";
                 }
             }
@@ -1484,7 +1484,7 @@ void AutoDJProcessor::playerTrackLoaded(DeckAttributes* pDeck, TrackPointer pTra
 
 void AutoDJProcessor::playerLoadingTrack(DeckAttributes* pDeck,
         TrackPointer pNewTrack, TrackPointer pOldTrack) {
-    if (sDebug) {
+    if constexpr (sDebug) {
         qDebug() << this << "playerLoadingTrack" << pDeck->group
                  << "new:" << (pNewTrack ? pNewTrack->getLocation() : "(null)")
                  << "old:" << (pOldTrack ? pOldTrack->getLocation() : "(null)");
@@ -1513,7 +1513,7 @@ void AutoDJProcessor::playerLoadingTrack(DeckAttributes* pDeck,
 }
 
 void AutoDJProcessor::playerEmpty(DeckAttributes* pDeck) {
-    if (sDebug) {
+    if constexpr (sDebug) {
         qDebug() << this << "playerEmpty()" << pDeck->group;
     }
 
@@ -1530,7 +1530,7 @@ void AutoDJProcessor::playerEmpty(DeckAttributes* pDeck) {
 }
 
 void AutoDJProcessor::playerRateChanged(DeckAttributes* pAttributes) {
-    if (sDebug) {
+    if constexpr (sDebug) {
         qDebug() << this << "playerRateChanged" << pAttributes->group;
     }
 
@@ -1547,7 +1547,7 @@ void AutoDJProcessor::playerRateChanged(DeckAttributes* pAttributes) {
 }
 
 void AutoDJProcessor::setTransitionTime(int time) {
-    if (sDebug) {
+    if constexpr (sDebug) {
         qDebug() << this << "setTransitionTime" << time;
     }
 


### PR DESCRIPTION
This fixes https://bugs.launchpad.net/mixxx/+bug/1948975

The also improves the logging in auto DJ in the first commits, disabled by the sDebug. 

This is IMHO a major bug that rectifies a 2.3.3 release. 

Hopefully we can also fix the issue https://bugs.launchpad.net/mixxx/+bug/1893197