### PR TITLE
ID3v2: Fix writing of undefined MusicBrainz Recording ID

### DIFF
--- a/src/track/taglib/trackmetadata_id3v2.cpp
+++ b/src/track/taglib/trackmetadata_id3v2.cpp
@@ -1225,20 +1225,11 @@ bool exportTrackMetadataIntoTag(TagLib::ID3v2::Tag* pTag,
             uuidToNullableStringWithoutBraces(
                     trackMetadata.getTrackInfo().getMusicBrainzArtistId()),
             false);
-    {
-        QByteArray identifier = trackMetadata.getTrackInfo().getMusicBrainzRecordingId().toByteArray();
-        if (identifier.size() == 38) {
-            // Strip leading/trailing curly braces
-            DEBUG_ASSERT(identifier.startsWith('{'));
-            DEBUG_ASSERT(identifier.endsWith('}'));
-            identifier = identifier.mid(1, 36);
-        }
-        DEBUG_ASSERT(identifier.size() == 36);
-        writeUniqueFileIdentifierFrame(
-                pTag,
-                kMusicBrainzOwner,
-                identifier);
-    }
+    writeUniqueFileIdentifierFrame(
+            pTag,
+            kMusicBrainzOwner,
+            uuidToCompactAsciiHexDigits(
+                    trackMetadata.getTrackInfo().getMusicBrainzRecordingId()));
     writeUserTextIdentificationFrame(
             pTag,
             "MusicBrainz Release Track Id",

--- a/src/track/taglib/trackmetadata_id3v2.cpp
+++ b/src/track/taglib/trackmetadata_id3v2.cpp
@@ -66,10 +66,7 @@ const QString kFormatTYER = QStringLiteral("yyyy");
 const QString kFormatTDAT = QStringLiteral("ddMM");
 
 // Owners of ID3v2 UFID frames.
-// NOTE(uklotzde, 2019-09-28): This is the owner string for MusicBrainz
-// as written by MusicBrainz Picard 2.1.3 although the mapping table
-// doesn't mention any "http://" prefix.
-// See also: https://picard.musicbrainz.org/docs/mappings
+// https://picard-docs.musicbrainz.org/en/appendices/tag_mapping.html#id21
 const QString kMusicBrainzOwner = QStringLiteral("http://musicbrainz.org");
 
 // Serato frames

--- a/src/util/quuid.h
+++ b/src/util/quuid.h
@@ -7,12 +7,21 @@
 /// Utility functions for QUuid
 ///
 
-/// Format a UUID without enclosing curly braces, representing a null UUID
-/// by an empty string instead of 00000000-0000-0000-0000-000000000000.
+/// Format a UUID without enclosing curly braces. Returns a null string
+/// instead of 00000000-0000-0000-0000-000000000000.
 inline QString uuidToNullableStringWithoutBraces(const QUuid& uuid) {
     if (uuid.isNull()) {
-        return QString{};
-    } else {
-        return uuid.toString(QUuid::WithoutBraces);
+        return {};
     }
+    return uuid.toString(QUuid::WithoutBraces);
+}
+
+/// Format a UUID without enclosing curly braces and no '-' separators
+/// between fields (id128). Returns an empty byte array instead of
+/// 00000000000000000000000000000000.
+inline QByteArray uuidToCompactAsciiHexDigits(const QUuid& uuid) {
+    if (uuid.isNull()) {
+        return {};
+    }
+    return uuid.toByteArray(QUuid::Id128);
 }


### PR DESCRIPTION
Null UUIDs were written as "00000000-0000-0000-0000-000000000000" which is pointless and wrong. Moreover Qt already has a built-in function for the id128 format.

https://picard-docs.musicbrainz.org/en/appendices/tag_mapping.html#id21

This feature is not enabled in regular builds.