### PR TITLE
[2.3] Fix rare SEGFAULT when closing the progress dialog

### DIFF
--- a/src/util/taskmonitor.cpp
+++ b/src/util/taskmonitor.cpp
@@ -28,6 +28,7 @@ TaskMonitor::~TaskMonitor() {
                 << "pending tasks";
         abortAllTasks();
     }
+    closeProgressDialog();
 }
 
 Task* TaskMonitor::senderTask() const {
@@ -143,11 +144,22 @@ void TaskMonitor::abortAllTasks() {
     updateProgress();
 }
 
+void TaskMonitor::closeProgressDialog() {
+    DEBUG_ASSERT(m_taskInfos.isEmpty());
+    auto* const pProgressDlg = m_pProgressDlg.release();
+    // Deleting the progress dialog immediately might cause
+    // segmentation faults due to pending signals! The deletion
+    // has to be deferred until re-entering the event loop.
+    if (pProgressDlg) {
+        pProgressDlg->deleteLater();
+    }
+}
+
 void TaskMonitor::updateProgress() {
     DEBUG_ASSERT_MAIN_THREAD_AFFINITY();
     DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
     if (m_taskInfos.isEmpty()) {
-        m_pProgressDlg.reset();
+        closeProgressDialog();
         return;
     }
     const int currentProgress = static_cast<int>(std::round(sumEstimatedPercentageOfCompletion()));

--- a/src/util/taskmonitor.cpp
+++ b/src/util/taskmonitor.cpp
@@ -146,11 +146,12 @@ void TaskMonitor::abortAllTasks() {
 
 void TaskMonitor::closeProgressDialog() {
     DEBUG_ASSERT(m_taskInfos.isEmpty());
-    auto* const pProgressDlg = m_pProgressDlg.release();
     // Deleting the progress dialog immediately might cause
     // segmentation faults due to pending signals! The deletion
     // has to be deferred until re-entering the event loop.
+    auto* const pProgressDlg = m_pProgressDlg.release();
     if (pProgressDlg) {
+        pProgressDlg->setVisible(false);
         pProgressDlg->deleteLater();
     }
 }

--- a/src/util/taskmonitor.h
+++ b/src/util/taskmonitor.h
@@ -82,6 +82,7 @@ class TaskMonitor
   private:
     Task* senderTask() const;
     void updateProgress();
+    void closeProgressDialog();
 
     const QString m_labelText;
     const Duration m_minimumProgressDuration;


### PR DESCRIPTION
Happened when aborting a batch operation on multiple tracks.