### PR TITLE
LateNight: use correct tooltip for key control toggle

### DIFF
--- a/res/skins/LateNight/helpers/skin_settings_compact_deck.xml
+++ b/res/skins/LateNight/helpers/skin_settings_compact_deck.xml
@@ -45,7 +45,7 @@ Description:
 
       <!-- Key Control -->
       <Template src="skin:/helpers/skin_settings_button_2state.xml">
-        <SetVariable name="TooltipId">rate_toggle</SetVariable>
+        <SetVariable name="TooltipId">show_key_controls</SetVariable>
         <SetVariable name="Text">Key Controls</SetVariable>
         <SetVariable name="Setting">[Skin],show_key_controls_compact</SetVariable>
       </Template>

--- a/res/skins/LateNight/helpers/skin_settings_full_deck.xml
+++ b/res/skins/LateNight/helpers/skin_settings_full_deck.xml
@@ -93,7 +93,7 @@ Description:
 
       <!-- Key Control -->
       <Template src="skin:/helpers/skin_settings_button_2state.xml">
-        <SetVariable name="TooltipId">rate_toggle</SetVariable>
+        <SetVariable name="TooltipId">show_key_controls</SetVariable>
         <SetVariable name="Text">Key Controls</SetVariable>
         <SetVariable name="Setting">[Skin],show_key_controls</SetVariable>
       </Template>

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -444,11 +444,15 @@ void Tooltips::addStandardTooltips() {
             << tr("Toggling keylock during playback may result in a momentary audio glitch.");
 
     add("hotcue_toggle")
-        <<tr("Changes the number of hotcue buttons displayed in the deck");
+            << tr("Changes the number of hotcue buttons displayed in the deck");
 
     // Show Rate Control
     add("rate_toggle")
-        <<tr("Toggle visibility of Rate Control");
+            << tr("Toggle visibility of Rate Control");
+
+    // Show Key Controls
+    add("show_key_controls")
+            << tr("Toggle visibility of Key Controls");
 
     // Used in cue/hotcue/loop tooltips below.
     QString quantizeSnap = tr("If quantize is enabled, snaps to the nearest beat.");


### PR DESCRIPTION
At skin settings wrong tooltip ID was used at Key Control toggle.
As well the corresponding ID at file tooltips.cpp was missing.