### PR TITLE
Fix stopped Auto DJ. 

### DIFF
--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1426,18 +1426,18 @@ void AutoDJProcessor::useFixedFadeTime(
             // no outro defined, the toDeck will also use the transition time
             toDeckOutroStart -= m_transitionTime;
         }
-        if (toDeckOutroStart <= toDeckStartSecond) {
+        if (toDeckOutroStart <= toDeckStartSecond + kMinimumTrackDurationSec) {
             // we have already passed the outro start
             // Check OutroEnd as alternative, which is for all transition mode
             // better than directly default to duration()
             double end = getOutroEndSecond(pToDeck);
-            if (end <= toDeckStartSecond) {
+            if (end <= toDeckStartSecond + kMinimumTrackDurationSec) {
                 // we have also passed the outro end
                 end = getEndSecond(pToDeck);
-                VERIFY_OR_DEBUG_ASSERT(end > toDeckStartSecond) {
+                VERIFY_OR_DEBUG_ASSERT(end > toDeckStartSecond + kMinimumTrackDurationSec) {
                     // as last resort move start point
                     // The caller makes sure that this never happens
-                    toDeckStartSecond = end - 1;
+                    toDeckStartSecond = end - kMinimumTrackDurationSec;
                 }
             }
             // use the remaining time for fading
@@ -1445,7 +1445,11 @@ void AutoDJProcessor::useFixedFadeTime(
         }
         double transitionTime = math_min(toDeckOutroStart - toDeckStartSecond,
                 m_transitionTime);
-
+        VERIFY_OR_DEBUG_ASSERT(transitionTime >= kMinimumTrackDurationSec / 2) {
+            transitionTime = kMinimumTrackDurationSec / 2;
+        }
+        // Note: pFromDeck->fadeBeginPos >= pFromDeck->fadeEndPos is handled in
+        // playerPositionChanged() causing a jump cut.
         pFromDeck->fadeBeginPos = math_max(fadeEndSecond - transitionTime, fromDeckSecond);
         pFromDeck->fadeEndPos = fadeEndSecond;
         pToDeck->startPos = toDeckStartSecond;

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1451,10 +1451,9 @@ void AutoDJProcessor::playerTrackLoaded(DeckAttributes* pDeck, TrackPointer pTra
         DeckAttributes* fromDeck = getOtherDeck(pDeck);
         // check if this deck has suitable alignment
         if (fromDeck && getOtherDeck(fromDeck) != pDeck) {
-            //if constexpr (sDebug) {
-            qDebug() << this << "playerTrackLoaded()" << pDeck->group << "but not a toDeck";
-            qDebug() << this << "playerTrackLoaded()" << fromDeck->group << "but not a toDeck";
-            //}
+            if constexpr (sDebug) {
+                qDebug() << this << "playerTrackLoaded()" << pDeck->group << "but not a toDeck";
+            }
             // User has changed the orientation, disable Auto DJ
             toggleAutoDJ(false);
             return;

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1608,26 +1608,33 @@ void AutoDJProcessor::setTransitionMode(TransitionMode newMode) {
     }
 }
 
+DeckAttributes* AutoDJProcessor::getLeftDeck() {
+    // find first left deck
+    foreach (DeckAttributes* pDeck, m_decks) {
+        if (pDeck->isLeft()) {
+            return pDeck;
+        }
+    }
+    return nullptr;
+}
+
+DeckAttributes* AutoDJProcessor::getRightDeck() {
+    // find first right deck
+    foreach (DeckAttributes* pDeck, m_decks) {
+        if (pDeck->isRight()) {
+            return pDeck;
+        }
+    }
+    return nullptr;
+}
+
 DeckAttributes* AutoDJProcessor::getOtherDeck(
         const DeckAttributes* pThisDeck) {
     if (pThisDeck->isLeft()) {
-        // find first right deck
-        foreach(DeckAttributes* pDeck, m_decks) {
-            if (pDeck->isRight()) {
-                return pDeck;
-            }
-        }
-        return nullptr;
+        return getRightDeck();
     }
-
     if (pThisDeck->isRight()) {
-        // find first left deck
-        foreach(DeckAttributes* pDeck, m_decks) {
-            if (pDeck->isLeft()) {
-                return pDeck;
-            }
-        }
-        return nullptr;
+        return getLeftDeck();
     }
     return nullptr;
 }

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -781,11 +781,15 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
                 m_transitionProgress = 0.0;
                 emitAutoDJStateChanged(m_eState);
 
+                const double toDeckFadeDisatance =
+                        (thisDeck->fadeEndPos - thisDeck->fadeBeginPos) *
+                        getEndSecond(thisDeck) / getEndSecond(thisDeck);
+                // Re-cue the track if the user has seeked forward and will miss the fadeBeginPos
+                if (otherDeck->playPosition() >= otherDeck->fadeBeginPos - toDeckFadeDisatance) {
+                    otherDeck->setPlayPosition(otherDeck->startPos);
+                }
+
                 if (!otherDeckPlaying) {
-                    // Re-cue the track if the user has seeked past the fadeBeginPos
-                    if (otherDeck->playPosition() >= otherDeck->fadeBeginPos) {
-                        otherDeck->setPlayPosition(otherDeck->startPos);
-                    }
                     otherDeck->play();
                 }
 

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -23,8 +23,7 @@ constexpr bool sDebug = false;
 } // anonymous namespace
 
 DeckAttributes::DeckAttributes(int index,
-        BaseTrackPlayer* pPlayer,
-        EngineChannel::ChannelOrientation orientation)
+        BaseTrackPlayer* pPlayer)
         : index(index),
           group(pPlayer->getGroup()),
           startPos(kKeepPosition),
@@ -32,7 +31,7 @@ DeckAttributes::DeckAttributes(int index,
           fadeEndPos(1.0),
           isFromDeck(false),
           loading(false),
-          m_orientation(orientation),
+          m_orientation(group, "orientation"),
           m_playPos(group, "playposition"),
           m_play(group, "play"),
           m_repeat(group, "repeat"),
@@ -153,13 +152,10 @@ AutoDJProcessor::AutoDJProcessor(
         QString group = PlayerManager::groupForDeck(i);
         BaseTrackPlayer* pPlayer = pPlayerManager->getPlayer(group);
         // Shouldn't be possible.
-        if (pPlayer == nullptr) {
-            qWarning() << "PROGRAMMING ERROR deck does not exist" << i;
+        VERIFY_OR_DEBUG_ASSERT(pPlayer) {
             continue;
         }
-        EngineChannel::ChannelOrientation orientation =
-                (i % 2 == 0) ? EngineChannel::LEFT : EngineChannel::RIGHT;
-        m_decks.append(new DeckAttributes(i, pPlayer, orientation));
+        m_decks.append(new DeckAttributes(i, pPlayer));
     }
     // Auto-DJ needs at least two decks
     DEBUG_ASSERT(m_decks.length() > 1);

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -216,7 +216,6 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::shufflePlaylist(
 }
 
 void AutoDJProcessor::fadeNow() {
-    // Auto-DJ needs at least two decks
     if (m_eState != ADJ_IDLE) {
         // we cannot fade if AutoDj is disabled or already fading
         return;

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -267,6 +267,12 @@ void AutoDJProcessor::fadeNow() {
     const double fromDeckCurrentSecond = fromDeckDuration * pFromDeck->playPosition();
     const double toDeckCurrentSecond = toDeckDuration * pToDeck->playPosition();
 
+    if (toDeckDuration - toDeckCurrentSecond < kMinimumTrackDurationSec) {
+        // Remaining Track time is too short, user has has seeked near the end
+        // Re-cue the track
+        pToDeck->setPlayPosition(pToDeck->startPos);
+    }
+
     pFromDeck->fadeBeginPos = fromDeckCurrentSecond;
     // Do not seek to a calculated start point; start the to deck from wherever
     // it is if the user has seeked since loading the track.
@@ -310,8 +316,10 @@ void AutoDJProcessor::fadeNow() {
         fadeTime = spinboxTime;
     }
 
-    double timeUntilEndOfFromTrack = fromDeckEndSecond - fromDeckCurrentSecond;
-    fadeTime = math_min(fadeTime, timeUntilEndOfFromTrack);
+    fadeTime = math_min(fadeTime, fromDeckEndSecond - fromDeckCurrentSecond);
+    fadeTime = math_min(fadeTime,
+            (toDeckEndSecond - toDeckCurrentSecond) / 2); // for fade in and out
+
     pFromDeck->fadeEndPos = fromDeckCurrentSecond + fadeTime;
 
     // These are expected to be a fraction of the track length.

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -371,7 +371,7 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
         // TODO: This is a total bandaid for making Auto DJ work with decks 3
         // and 4.  We should design a nicer way to handle this.
         for (int i = 2; i < m_decks.length(); ++i) {
-            if (m_decks[i] != NULL && m_decks[i]->isPlaying()) {
+            if (m_decks[i] && m_decks[i]->isPlaying()) {
                 return ADJ_DECKS_3_4_PLAYING;
             }
         }
@@ -547,7 +547,7 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
                 &ControlProxy::valueChanged,
                 this,
                 &AutoDJProcessor::crossfaderChanged);
-        foreach (DeckAttributes* pDeck, m_decks) {
+        for (const auto& pDeck : std::as_const(m_decks)) {
             pDeck->disconnect(this);
         }
         m_pCOCrossfader->set(0);
@@ -1614,7 +1614,7 @@ void AutoDJProcessor::setTransitionMode(TransitionMode newMode) {
 
 DeckAttributes* AutoDJProcessor::getLeftDeck() {
     // find first left deck
-    foreach (DeckAttributes* pDeck, m_decks) {
+    for (const auto& pDeck : std::as_const(m_decks)) {
         if (pDeck->isLeft()) {
             return pDeck;
         }
@@ -1624,7 +1624,7 @@ DeckAttributes* AutoDJProcessor::getLeftDeck() {
 
 DeckAttributes* AutoDJProcessor::getRightDeck() {
     // find first right deck
-    foreach (DeckAttributes* pDeck, m_decks) {
+    for (const auto& pDeck : std::as_const(m_decks)) {
         if (pDeck->isRight()) {
             return pDeck;
         }
@@ -1644,7 +1644,7 @@ DeckAttributes* AutoDJProcessor::getOtherDeck(
 }
 
 DeckAttributes* AutoDJProcessor::getFromDeck() {
-    for (const auto& pDeck : qAsConst(m_decks)) {
+    for (const auto& pDeck : std::as_const(m_decks)) {
         if (pDeck->isFromDeck) {
             return pDeck;
         }

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -355,6 +355,8 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
         DeckAttributes* pLeftDeck = getLeftDeck();
         DeckAttributes* pRightDeck = getRightDeck();
         if (!pLeftDeck || !pRightDeck) {
+            // Keep the current state.
+            emitAutoDJStateChanged(m_eState);
             return ADJ_NOT_TWO_DECKS;
         }
 
@@ -372,6 +374,7 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
         // and 4.  We should design a nicer way to handle this.
         for (int i = 2; i < m_decks.length(); ++i) {
             if (m_decks[i] && m_decks[i]->isPlaying()) {
+                // Keep the current state.
                 return ADJ_DECKS_3_4_PLAYING;
             }
         }

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1231,8 +1231,13 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
     // This is used to check if it will be possible or a re-cue is required.
     // here it is done for FullIntroOutro and FadeAtOutroStart.
     // It is adjusted below for the other modes.
-    pToDeck->fadeBeginPos = getOutroStartSecond(pToDeck);
     pToDeck->fadeEndPos = getOutroEndSecond(pToDeck);
+    double toDeckOutroStartSecond = getOutroStartSecond(pToDeck);
+    if (pToDeck->fadeEndPos == toDeckOutroStartSecond) {
+        // outro not defined, use transition time.
+        toDeckOutroStartSecond -= m_transitionTime;
+    }
+    pToDeck->fadeBeginPos = toDeckOutroStartSecond;
 
     double introStart;
     if (seekToStartPoint || toDeckPositionSeconds >= pToDeck->fadeBeginPos) {

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1471,6 +1471,16 @@ void AutoDJProcessor::playerTrackLoaded(DeckAttributes* pDeck, TrackPointer pTra
             // repeat a probably missed update
             playerPositionChanged(fromDeck, 1.0);
         }
+    } else if (m_eState == ADJ_LEFT_FADING) {
+        if (pDeck == getRightDeck()) {
+            // restore the play state lost during loading
+            pDeck->play();
+        }
+    } else if (m_eState == ADJ_RIGHT_FADING) {
+        if (pDeck == getLeftDeck()) {
+            // restore the play state lost during loading
+            pDeck->play();
+        }
     }
 }
 

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -322,7 +322,7 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::skipNext() {
     // Load the next song from the queue.
     DeckAttributes* pLeftDeck = getLeftDeck();
     DeckAttributes* pRightDeck = getRightDeck();
-    if (!pLeftDeck && !pRightDeck) {
+    if (!pLeftDeck || !pRightDeck) {
         // User has changed the orientation, disable Auto DJ
         toggleAutoDJ(false);
         return ADJ_NOT_TWO_DECKS;
@@ -1562,6 +1562,8 @@ void AutoDJProcessor::setTransitionTime(int time) {
         DeckAttributes* pLeftDeck = getLeftDeck();
         DeckAttributes* pRightDeck = getRightDeck();
         if (!pLeftDeck || !pRightDeck) {
+            // User has changed the orientation, disable Auto DJ
+            toggleAutoDJ(false);
             return;
         }
         if (pLeftDeck->isPlaying()) {
@@ -1588,6 +1590,8 @@ void AutoDJProcessor::setTransitionMode(TransitionMode newMode) {
     DeckAttributes* pRightDeck = getRightDeck();
 
     if (!pLeftDeck || !pRightDeck) {
+        // User has changed the orientation, disable Auto DJ
+        toggleAutoDJ(false);
         return;
     }
 
@@ -1659,7 +1663,7 @@ bool AutoDJProcessor::nextTrackLoaded() {
 
     DeckAttributes* pLeftDeck = getLeftDeck();
     DeckAttributes* pRightDeck = getRightDeck();
-    VERIFY_OR_DEBUG_ASSERT(pLeftDeck && pRightDeck) {
+    if (!pLeftDeck || !pRightDeck) {
         return false;
     }
 

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -16,6 +16,8 @@ const char* kTransitionPreferenceName = "Transition";
 const char* kTransitionModePreferenceName = "TransitionMode";
 const double kTransitionPreferenceDefault = 10.0;
 const double kKeepPosition = -1.0;
+const double kMinimumTrackDurationSec =
+        0.2; // A track needs to be longer than two callbacks to not stop AutoDJ
 
 const mixxx::audio::ChannelCount kChannelCount = mixxx::kEngineChannelCount;
 
@@ -254,6 +256,13 @@ void AutoDJProcessor::fadeNow() {
     // the track duration. Use this alias for better readability.
     const double fromDeckDuration = fromDeckEndSecond;
     const double toDeckDuration = toDeckEndSecond;
+    if (toDeckDuration < kMinimumTrackDurationSec) {
+        // Deck is empty or track too short, disable AutoDJ
+        // This happens only if the user has changed deck orientation to such deck.
+        toggleAutoDJ(false);
+        return;
+    }
+
     // playPosition() is in the range of 0..1
     const double fromDeckCurrentSecond = fromDeckDuration * pFromDeck->playPosition();
     const double toDeckCurrentSecond = toDeckDuration * pToDeck->playPosition();
@@ -1439,7 +1448,7 @@ void AutoDJProcessor::playerTrackLoaded(DeckAttributes* pDeck, TrackPointer pTra
     // Since the end position is measured in seconds from 0:00 it is also
     // the track duration.
     double duration = getEndSecond(pDeck);
-    if (duration < 0.2) {
+    if (duration < kMinimumTrackDurationSec) {
         qWarning() << "Skip track with" << duration << "Duration"
                    << pTrack->getLocation();
         // Remove Tack with duration smaller than two callbacks

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -780,11 +780,11 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
                 m_transitionProgress = 0.0;
                 emitAutoDJStateChanged(m_eState);
 
-                const double toDeckFadeDisatance =
+                const double toDeckFadeDistance =
                         (thisDeck->fadeEndPos - thisDeck->fadeBeginPos) *
-                        getEndSecond(thisDeck) / getEndSecond(thisDeck);
+                        getEndSecond(thisDeck) / getEndSecond(otherDeck);
                 // Re-cue the track if the user has seeked forward and will miss the fadeBeginPos
-                if (otherDeck->playPosition() >= otherDeck->fadeBeginPos - toDeckFadeDisatance) {
+                if (otherDeck->playPosition() >= otherDeck->fadeBeginPos - toDeckFadeDistance) {
                     otherDeck->setPlayPosition(otherDeck->startPos);
                 }
 

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1190,16 +1190,21 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
     const double fromDeckDuration = fromDeckEndPosition;
     const double toDeckDuration = toDeckEndPosition;
 
-    VERIFY_OR_DEBUG_ASSERT(fromDeckDuration > 0) {
-        // Playing Track has no duration. This should not happen, because short
+    VERIFY_OR_DEBUG_ASSERT(fromDeckDuration >= kMinimumTrackDurationSec) {
+        // Track has no duration or too short. This should not happen, because short
         // tracks are skipped after load. Play ToDeck immediately.
         pFromDeck->fadeBeginPos = 0;
         pFromDeck->fadeEndPos = 0;
         pToDeck->startPos = kKeepPosition;
         return;
     }
-    VERIFY_OR_DEBUG_ASSERT(toDeckDuration > 0) {
-        // Playing Track has no duration. This should not happen, because short
+    if (toDeckDuration == 0) {
+        // This is a seek call to zero after ejecting the track
+        // this signal is received before the track pointer becomes null
+        return;
+    }
+    VERIFY_OR_DEBUG_ASSERT(toDeckDuration >= kMinimumTrackDurationSec) {
+        // Track has no duration or too short. This should not happen, because short
         // tracks are skipped after load.
         loadNextTrackFromQueue(*pToDeck, false);
         return;

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -757,7 +757,7 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
     // - transition into fading mode, play the other deck and fade to it.
     // - check if fading is done and stop the deck
     // - update the crossfader
-    if (thisPlayPosition >= thisDeck->fadeBeginPos && thisDeck->isFromDeck) {
+    if (thisPlayPosition >= thisDeck->fadeBeginPos && thisDeck->isFromDeck && !otherDeck->loading) {
         if (m_eState == ADJ_IDLE) {
             if (thisDeckPlaying || thisPlayPosition >= 1.0) {
                 // Set the state as FADING.

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -264,6 +264,8 @@ class AutoDJProcessor : public QObject {
             double fromDeckSecond,
             double fadeEndSecond,
             double toDeckStartSecond);
+    DeckAttributes* getLeftDeck();
+    DeckAttributes* getRightDeck();
     DeckAttributes* getOtherDeck(const DeckAttributes* pThisDeck);
     DeckAttributes* getFromDeck();
 

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -21,16 +21,15 @@ class DeckAttributes : public QObject {
     Q_OBJECT
   public:
     DeckAttributes(int index,
-                   BaseTrackPlayer* pPlayer,
-                   EngineChannel::ChannelOrientation orientation);
+            BaseTrackPlayer* pPlayer);
     virtual ~DeckAttributes();
 
     bool isLeft() const {
-        return m_orientation == EngineChannel::LEFT;
+        return m_orientation.get() == EngineChannel::LEFT;
     }
 
     bool isRight() const {
-        return m_orientation == EngineChannel::RIGHT;
+        return m_orientation.get() == EngineChannel::RIGHT;
     }
 
     bool isPlaying() const {
@@ -125,7 +124,7 @@ class DeckAttributes : public QObject {
     bool loading; // The data is inconsistent during loading a deck
 
   private:
-    EngineChannel::ChannelOrientation m_orientation;
+    ControlProxy m_orientation;
     ControlProxy m_playPos;
     ControlProxy m_play;
     ControlProxy m_repeat;

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -39,7 +39,7 @@ class FakeMaster {
 
 class FakeDeck : public BaseTrackPlayer {
   public:
-    FakeDeck(const QString& group)
+    FakeDeck(const QString& group, EngineChannel::ChannelOrientation orient)
             : BaseTrackPlayer(NULL, group),
               trackSamples(ConfigKey(group, "track_samples")),
               samplerate(ConfigKey(group, "track_samplerate")),
@@ -50,11 +50,13 @@ class FakeDeck : public BaseTrackPlayer {
               introStartPos(ConfigKey(group, "intro_start_position")),
               introEndPos(ConfigKey(group, "intro_end_position")),
               outroStartPos(ConfigKey(group, "outro_start_position")),
-              outroEndPos(ConfigKey(group, "outro_end_position")) {
+              outroEndPos(ConfigKey(group, "outro_end_position")),
+              orientation(ConfigKey(group, "orientation")) {
         play.setButtonMode(ControlPushButton::TOGGLE);
         repeat.setButtonMode(ControlPushButton::TOGGLE);
         outroStartPos.set(Cue::kNoPosition);
         outroEndPos.set(Cue::kNoPosition);
+        orientation.set(orient);
     }
 
     void fakeTrackLoadedEvent(TrackPointer pTrack) {
@@ -107,6 +109,7 @@ class FakeDeck : public BaseTrackPlayer {
     ControlObject introEndPos;
     ControlObject outroStartPos;
     ControlObject outroEndPos;
+    ControlObject orientation;
 };
 
 class MockPlayerManager : public PlayerManagerInterface {
@@ -174,10 +177,10 @@ class AutoDJProcessorTest : public LibraryTest {
     }
 
     AutoDJProcessorTest()
-            :  deck1("[Channel1]"),
-               deck2("[Channel2]"),
-               deck3("[Channel3]"),
-               deck4("[Channel4]") {
+            : deck1("[Channel1]", EngineChannel::LEFT),
+              deck2("[Channel2]", EngineChannel::RIGHT),
+              deck3("[Channel3]", EngineChannel::LEFT),
+              deck4("[Channel4]", EngineChannel::RIGHT) {
         qRegisterMetaType<TrackPointer>("TrackPointer");
 
         PlaylistDAO& playlistDao = internalCollection()->getPlaylistDAO();


### PR DESCRIPTION
This fixes unintended Auto DJ stops due to transitions during track loading and deck orientation. 
It fixes https://bugs.launchpad.net/mixxx/+bug/1893197 and https://bugs.launchpad.net/mixxx/+bug/1961970

This is on top of https://github.com/mixxxdj/mixxx/pull/4693 which should be merged first. 