### PR TITLE
Samplers, crates, playlists: fix storing import/export paths

### DIFF
--- a/src/library/baseplaylistfeature.cpp
+++ b/src/library/baseplaylistfeature.cpp
@@ -365,7 +365,7 @@ void BasePlaylistFeature::slotImportPlaylist() {
 
     // Update the import/export playlist directory
     QString fileDirectory(playlistFile);
-    fileDirectory.truncate(playlistFile.lastIndexOf(QDir::separator()));
+    fileDirectory.truncate(playlistFile.lastIndexOf("/"));
     m_pConfig->set(kConfigKeyLastImportExportPlaylistDirectory,
             ConfigValue(fileDirectory));
 
@@ -412,7 +412,7 @@ void BasePlaylistFeature::slotCreateImportPlaylist() {
 
     // Set last import directory
     QString fileDirectory(playlistFiles.first());
-    fileDirectory.truncate(playlistFiles.first().lastIndexOf(QDir::separator()));
+    fileDirectory.truncate(playlistFiles.first().lastIndexOf("/"));
     m_pConfig->set(kConfigKeyLastImportExportPlaylistDirectory,
             ConfigValue(fileDirectory));
 
@@ -483,7 +483,7 @@ void BasePlaylistFeature::slotExportPlaylist() {
 
     // Update the import/export playlist directory
     QString fileDirectory(fileLocation);
-    fileDirectory.truncate(fileLocation.lastIndexOf(QDir::separator()));
+    fileDirectory.truncate(fileLocation.lastIndexOf("/"));
     m_pConfig->set(kConfigKeyLastImportExportPlaylistDirectory,
             ConfigValue(fileDirectory));
 

--- a/src/library/crate/cratefeature.cpp
+++ b/src/library/crate/cratefeature.cpp
@@ -574,7 +574,7 @@ void CrateFeature::slotImportPlaylist() {
 
     // Update the import/export crate directory
     QString fileDirectory(playlistFile);
-    fileDirectory.truncate(playlistFile.lastIndexOf(QDir::separator()));
+    fileDirectory.truncate(playlistFile.lastIndexOf("/"));
     m_pConfig->set(kConfigKeyLastImportExportCrateDirectoryKey,
             ConfigValue(fileDirectory));
 
@@ -614,7 +614,7 @@ void CrateFeature::slotCreateImportCrate() {
 
     // Set last import directory
     QString fileDirectory(playlistFiles.first());
-    fileDirectory.truncate(playlistFiles.first().lastIndexOf(QDir::separator()));
+    fileDirectory.truncate(playlistFiles.first().lastIndexOf("/"));
     m_pConfig->set(kConfigKeyLastImportExportCrateDirectoryKey,
             ConfigValue(fileDirectory));
 
@@ -706,7 +706,7 @@ void CrateFeature::slotExportPlaylist() {
     }
     // Update the import/export crate directory
     QString fileDirectory(fileLocation);
-    fileDirectory.truncate(fileLocation.lastIndexOf(QDir::separator()));
+    fileDirectory.truncate(fileLocation.lastIndexOf("/"));
     m_pConfig->set(kConfigKeyLastImportExportCrateDirectoryKey,
             ConfigValue(fileDirectory));
 

--- a/src/mixer/samplerbank.cpp
+++ b/src/mixer/samplerbank.cpp
@@ -73,7 +73,7 @@ void SamplerBank::slotSaveSamplerBank(double v) {
 
     // Update the import/export directory
     QString fileDirectory(samplerBankPath);
-    fileDirectory.truncate(samplerBankPath.lastIndexOf(QDir::separator()));
+    fileDirectory.truncate(samplerBankPath.lastIndexOf("/"));
     m_pConfig->set(kConfigkeyLastImportExportDirectory,
             ConfigValue(fileDirectory));
 
@@ -154,7 +154,7 @@ void SamplerBank::slotLoadSamplerBank(double v) {
 
     // Update the import/export directory
     QString fileDirectory(samplerBankPath);
-    fileDirectory.truncate(samplerBankPath.lastIndexOf(QDir::separator()));
+    fileDirectory.truncate(samplerBankPath.lastIndexOf("/"));
     m_pConfig->set(kConfigkeyLastImportExportDirectory,
             ConfigValue(fileDirectory));
 


### PR DESCRIPTION
Fixing a regression introduced by #4531 and #4539
on Windows the import/export path is not stored (affects import/export of sampler banks, crates and playlists)
https://bugs.launchpad.net/bugs/1964508

https://github.com/mixxxdj/mixxx/pull/4531/files#r829445200
> I suspect this always truncates at position 0, see https://bugs.launchpad.net/bugs/1964508
> 
> Native separator is `\` on Windows and maybe Qt has already converted the path to use `/`? In that case `lastIndexOf("\")` would return -1 which is equivalent to passing 0 to `truncate`
https://doc.qt.io/qt-5/qstring.html#truncate
It is not recommended to use QDir::separator() for constructing paths, but _appearantly_ it also creates issues when computing paths
https://doc.qt.io/qt-5/qdir.html#separator