### PR TITLE
CrateFeature: add popup to avoid accidental remove of Crate

### DIFF
--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -407,8 +407,17 @@ void CrateFeature::slotDeleteCrate() {
         // Store sibling id to restore selection after crate was deleted
         // to avoid the scroll position being reset to Crate root item.
         storePrevSiblingCrateId(crateId);
-        if (m_pTrackCollection->deleteCrate(crateId)) {
-            qDebug() << "Deleted crate" << crate;
+        QMessageBox::StandardButton btn = QMessageBox::question(nullptr,
+                tr("Confirm Deletion"),
+                tr("Do you really want to delete this crate?"),
+                QMessageBox::Yes | QMessageBox::No,
+                QMessageBox::No);
+        if (btn == QMessageBox::Yes) {
+            if (m_pTrackCollection->deleteCrate(crateId)) {
+                qDebug() << "Deleted crate" << crate;
+                return;
+            }
+        } else {
             return;
         }
     }


### PR DESCRIPTION
I have fixed the accidental remove issue for crates as well by adding a popup just like I did for the playlists. 

I know making popups everywhere is not a proper solution for accidental removal issues because these popups are affecting usability a lot. There are better solutions for that like discussed on the [other Pull request](https://github.com/mixxxdj/mixxx/pull/4697); redo/undo button, check-boxes that we can change on the Options>Preferences “Warn before deleting a playlist\crate” or a checkbox like “Don’t show this again”, etc. 

After adding this popup for the playlists, a few people wanted it for crates too. Therefore I did it. I want to contribute more so any feedback will be good for me :)

In my opinion for now popups can be our problem solver, then later on better solution can be implemented.

![image](https://user-images.githubusercontent.com/67206006/159073426-b57d0b3b-956e-4b09-a531-d0156d85cf62.png)