### PR TITLE
Traktor library: fix importing track key

### DIFF
--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -366,7 +366,7 @@ void TraktorFeature::parseTrack(QXmlStreamReader &xml, QSqlQuery &query) {
                 // Traktor happens to use the same key numbering
                 key = KeyUtils::keyToString(
                         KeyUtils::keyFromNumericValue(
-                                attr.value("VALUE").toString().toInt()),
+                                attr.value("VALUE").toInt()),
                         KeyUtils::KeyNotation::Custom);
                 continue;
             }

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -16,6 +16,7 @@
 #include "library/trackcollectionmanager.h"
 #include "library/treeitem.h"
 #include "moc_traktorfeature.cpp"
+#include "track/keyutils.h"
 #include "util/sandbox.h"
 #include "util/semanticversion.h"
 
@@ -358,6 +359,15 @@ void TraktorFeature::parseTrack(QXmlStreamReader &xml, QSqlQuery &query) {
             if (xml.name() == QLatin1String("TEMPO")) {
                 QXmlStreamAttributes attr = xml.attributes ();
                 bpm = attr.value("BPM").toString().toFloat();
+                continue;
+            }
+            if (xml.name() == QLatin1String("MUSICAL_KEY")) {
+                QXmlStreamAttributes attr = xml.attributes();
+                // Traktor happens to use the same key numbering
+                key = KeyUtils::keyToString(
+                        KeyUtils::keyFromNumericValue(
+                                attr.value("VALUE").toString().toInt()),
+                        KeyUtils::KeyNotation::Custom);
                 continue;
             }
         }


### PR DESCRIPTION
It looks like there used to be a KEY attribute in the INFO tag[https://github.com/mixxxdj/mixxx/blob/02150fa2b666fac5157b8028907534869b09eb66/src/library/traktor/traktorfeature.cpp#L338](https://github.com/mixxxdj/mixxx/blob/02150fa2b666fac5157b8028907534869b09eb66/src/library/traktor/traktorfeature.cpp#L338) but Traktor 3.5.1 (the latest version) does not use this and has a MUSICAL_KEY node in ENTRY instead.

The keys are converted to string during import and are therefore immune to changes to preferred key notation in preferences.