### PR TITLE
Analyzer: Consolidate some plugin meta-functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -470,6 +470,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/analyzer/analyzersilence.cpp
   src/analyzer/analyzerthread.cpp
   src/analyzer/analyzerwaveform.cpp
+  src/analyzer/plugins/analyzerpluginsupport.cpp
   src/analyzer/plugins/analyzerqueenmarybeats.cpp
   src/analyzer/plugins/analyzerqueenmarykey.cpp
   src/analyzer/plugins/analyzersoundtouchbeats.cpp

--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -62,7 +62,7 @@ bool AnalyzerBeats::initialize(TrackPointer pTrack,
     m_bPreferencesReanalyzeImported = m_bpmSettings.getReanalyzeImported();
     m_bPreferencesFastAnalysis = m_bpmSettings.getFastAnalysis();
 
-    m_pluginId = matchAndSetPluginId(m_bpmSettings.getBeatPluginId());
+    m_pluginId = matchOrGetDefaultPluginId(m_bpmSettings.getBeatPluginId());
 
     qDebug() << "AnalyzerBeats preference settings:"
              << "\nPlugin:" << m_pluginId

--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -66,15 +66,14 @@ bool AnalyzerBeats::initialize(TrackPointer pTrack,
     m_bPreferencesReanalyzeImported = m_bpmSettings.getReanalyzeImported();
     m_bPreferencesFastAnalysis = m_bpmSettings.getFastAnalysis();
 
-    const auto plugins = availablePlugins();
-    if (!plugins.isEmpty()) {
+    if (const auto plugins = availablePlugins(); !plugins.isEmpty()) {
         m_pluginId = defaultPlugin().id();
-        QString pluginId = m_bpmSettings.getBeatPluginId();
-        for (const auto& info : plugins) {
-            if (info.id() == pluginId) {
-                m_pluginId = pluginId; // configured Plug-In available
-                break;
-            }
+        const auto pluginId = m_bpmSettings.getBeatPluginId();
+        const auto pred = [&](const auto& info) {
+            return info.id() == pluginId;
+        };
+        if (std::any_of(std::begin(plugins), std::end(plugins), pred)) {
+            m_pluginId = pluginId; // configured Plug-In available;
         }
     }
 

--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -13,7 +13,8 @@
 #include "track/beatutils.h"
 #include "track/track.h"
 
-QList<mixxx::AnalyzerPluginInfo> defaultAvailableBeatsPlugins() {
+// static
+QList<mixxx::AnalyzerPluginInfo> AnalyzerBeats::defaultPluginsList() {
     QList<mixxx::AnalyzerPluginInfo> plugins;
     // First one below is the default
     plugins.append(mixxx::AnalyzerQueenMaryBeats::pluginInfo());
@@ -22,7 +23,7 @@ QList<mixxx::AnalyzerPluginInfo> defaultAvailableBeatsPlugins() {
 }
 
 QList<mixxx::AnalyzerPluginInfo> AnalyzerBeats::availablePlugins() const {
-    return defaultAvailableBeatsPlugins();
+    return defaultPluginsList();
 }
 
 AnalyzerBeats::AnalyzerBeats(UserSettingsPointer pConfig, bool enforceBpmDetection)

--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -13,8 +13,7 @@
 #include "track/beatutils.h"
 #include "track/track.h"
 
-// static
-QList<mixxx::AnalyzerPluginInfo> AnalyzerBeats::availablePlugins() {
+QList<mixxx::AnalyzerPluginInfo> defaultAvailableBeatsPlugins() {
     QList<mixxx::AnalyzerPluginInfo> plugins;
     // First one below is the default
     plugins.append(mixxx::AnalyzerQueenMaryBeats::pluginInfo());
@@ -22,6 +21,9 @@ QList<mixxx::AnalyzerPluginInfo> AnalyzerBeats::availablePlugins() {
     return plugins;
 }
 
+QList<mixxx::AnalyzerPluginInfo> AnalyzerBeats::availablePlugins() const {
+    return defaultAvailableBeatsPlugins();
+}
 
 AnalyzerBeats::AnalyzerBeats(UserSettingsPointer pConfig, bool enforceBpmDetection)
         : m_bpmSettings(pConfig),
@@ -60,7 +62,7 @@ bool AnalyzerBeats::initialize(TrackPointer pTrack,
     m_bPreferencesReanalyzeImported = m_bpmSettings.getReanalyzeImported();
     m_bPreferencesFastAnalysis = m_bpmSettings.getFastAnalysis();
 
-    m_pluginId = matchAndSetPluginId(availablePlugins(), m_bpmSettings.getBeatPluginId());
+    m_pluginId = matchAndSetPluginId(m_bpmSettings.getBeatPluginId());
 
     qDebug() << "AnalyzerBeats preference settings:"
              << "\nPlugin:" << m_pluginId
@@ -120,7 +122,7 @@ bool AnalyzerBeats::shouldAnalyze(TrackPointer pTrack) const {
 
     QString pluginID = m_bpmSettings.getBeatPluginId();
     if (pluginID.isEmpty()) {
-        pluginID = defaultPlugin(availablePlugins()).id();
+        pluginID = defaultPlugin();
     }
 
     // If the track already has a Beats object then we need to decide whether to

--- a/src/analyzer/analyzerbeats.h
+++ b/src/analyzer/analyzerbeats.h
@@ -24,6 +24,9 @@ class AnalyzerBeats : public Analyzer {
     ~AnalyzerBeats() override = default;
 
     static QList<mixxx::AnalyzerPluginInfo> availablePlugins();
+    template<typename T1>
+    static QString matchAndSetPluginId(
+            const T1& analyzer_with_plugin_ids, const QString& pluginIdToMatch);
     static mixxx::AnalyzerPluginInfo defaultPlugin();
 
     bool initialize(TrackPointer pTrack,

--- a/src/analyzer/analyzerbeats.h
+++ b/src/analyzer/analyzerbeats.h
@@ -17,8 +17,6 @@
 #include "preferences/usersettings.h"
 #include "util/memory.h"
 
-QList<mixxx::AnalyzerPluginInfo> defaultAvailableBeatsPlugins();
-
 class AnalyzerBeats : private AnalyzerPluginSupportInfo, public Analyzer {
   public:
     explicit AnalyzerBeats(
@@ -32,6 +30,7 @@ class AnalyzerBeats : private AnalyzerPluginSupportInfo, public Analyzer {
     bool processSamples(const CSAMPLE *pIn, const int iLen) override;
     void storeResults(TrackPointer tio) override;
     void cleanup() override;
+    static QList<mixxx::AnalyzerPluginInfo> defaultPluginsList();
 
   private:
     QList<mixxx::AnalyzerPluginInfo> availablePlugins() const override;

--- a/src/analyzer/analyzerbeats.h
+++ b/src/analyzer/analyzerbeats.h
@@ -12,11 +12,12 @@
 
 #include "analyzer/analyzer.h"
 #include "analyzer/plugins/analyzerplugin.h"
+#include "analyzer/plugins/analyzerpluginsupport.h"
 #include "preferences/beatdetectionsettings.h"
 #include "preferences/usersettings.h"
 #include "util/memory.h"
 
-class AnalyzerBeats : public Analyzer {
+class AnalyzerBeats : protected AnalyzerPluginSupportInfo, public Analyzer {
   public:
     explicit AnalyzerBeats(
             UserSettingsPointer pConfig,
@@ -24,10 +25,6 @@ class AnalyzerBeats : public Analyzer {
     ~AnalyzerBeats() override = default;
 
     static QList<mixxx::AnalyzerPluginInfo> availablePlugins();
-    template<typename T1>
-    static QString matchAndSetPluginId(
-            const T1& analyzer_with_plugin_ids, const QString& pluginIdToMatch);
-    static mixxx::AnalyzerPluginInfo defaultPlugin();
 
     bool initialize(TrackPointer pTrack,
             mixxx::audio::SampleRate sampleRate,
@@ -38,13 +35,10 @@ class AnalyzerBeats : public Analyzer {
 
   private:
     bool shouldAnalyze(TrackPointer pTrack) const;
-    static QHash<QString, QString> getExtraVersionInfo(
-            const QString& pluginId, bool bPreferencesFastAnalysis);
 
     BeatDetectionSettings m_bpmSettings;
     std::unique_ptr<mixxx::AnalyzerBeatsPlugin> m_pPlugin;
     const bool m_enforceBpmDetection;
-    QString m_pluginId;
     bool m_bPreferencesReanalyzeOldBpm;
     bool m_bPreferencesReanalyzeImported;
     bool m_bPreferencesFixedTempo;

--- a/src/analyzer/analyzerbeats.h
+++ b/src/analyzer/analyzerbeats.h
@@ -17,14 +17,14 @@
 #include "preferences/usersettings.h"
 #include "util/memory.h"
 
-class AnalyzerBeats : protected AnalyzerPluginSupportInfo, public Analyzer {
+QList<mixxx::AnalyzerPluginInfo> defaultAvailableBeatsPlugins();
+
+class AnalyzerBeats : private AnalyzerPluginSupportInfo, public Analyzer {
   public:
     explicit AnalyzerBeats(
             UserSettingsPointer pConfig,
             bool enforceBpmDetection = false);
     ~AnalyzerBeats() override = default;
-
-    static QList<mixxx::AnalyzerPluginInfo> availablePlugins();
 
     bool initialize(TrackPointer pTrack,
             mixxx::audio::SampleRate sampleRate,
@@ -34,6 +34,7 @@ class AnalyzerBeats : protected AnalyzerPluginSupportInfo, public Analyzer {
     void cleanup() override;
 
   private:
+    QList<mixxx::AnalyzerPluginInfo> availablePlugins() const override;
     bool shouldAnalyze(TrackPointer pTrack) const;
 
     BeatDetectionSettings m_bpmSettings;

--- a/src/analyzer/analyzerkey.cpp
+++ b/src/analyzer/analyzerkey.cpp
@@ -57,15 +57,14 @@ bool AnalyzerKey::initialize(TrackPointer tio,
     m_bPreferencesFastAnalysisEnabled = m_keySettings.getFastAnalysis();
     m_bPreferencesReanalyzeEnabled = m_keySettings.getReanalyzeWhenSettingsChange();
 
-    const auto plugins = availablePlugins();
-    if (!plugins.isEmpty()) {
+    if (const auto plugins = availablePlugins(); !plugins.isEmpty()) {
         m_pluginId = defaultPlugin().id();
-        QString pluginId = m_keySettings.getKeyPluginId();
-        for (const auto& info : plugins) {
-            if (info.id() == pluginId) {
-                m_pluginId = pluginId; // configured Plug-In available
-                break;
-            }
+        const auto pluginId = m_keySettings.getKeyPluginId();
+        const auto pred = [&](const auto& info) {
+            return info.id() == pluginId;
+        };
+        if (std::any_of(std::begin(plugins), std::end(plugins), pred)) {
+            m_pluginId = pluginId; // configured Plug-In available;
         }
     }
 

--- a/src/analyzer/analyzerkey.cpp
+++ b/src/analyzer/analyzerkey.cpp
@@ -12,7 +12,8 @@
 #include "track/keyfactory.h"
 #include "track/track.h"
 
-QList<mixxx::AnalyzerPluginInfo> defaultAvailableKeyPlugins() {
+// static
+QList<mixxx::AnalyzerPluginInfo> AnalyzerKey::defaultPluginsList() {
     QList<mixxx::AnalyzerPluginInfo> analyzers;
     // First one below is the default
     analyzers.push_back(mixxx::AnalyzerQueenMaryKey::pluginInfo());
@@ -23,7 +24,7 @@ QList<mixxx::AnalyzerPluginInfo> defaultAvailableKeyPlugins() {
 }
 
 QList<mixxx::AnalyzerPluginInfo> AnalyzerKey::availablePlugins() const {
-    return defaultAvailableKeyPlugins();
+    return defaultPluginsList();
 }
 
 AnalyzerKey::AnalyzerKey(const KeyDetectionSettings& keySettings)

--- a/src/analyzer/analyzerkey.cpp
+++ b/src/analyzer/analyzerkey.cpp
@@ -12,8 +12,7 @@
 #include "track/keyfactory.h"
 #include "track/track.h"
 
-// static
-QList<mixxx::AnalyzerPluginInfo> AnalyzerKey::availablePlugins() {
+QList<mixxx::AnalyzerPluginInfo> defaultAvailableKeyPlugins() {
     QList<mixxx::AnalyzerPluginInfo> analyzers;
     // First one below is the default
     analyzers.push_back(mixxx::AnalyzerQueenMaryKey::pluginInfo());
@@ -21,6 +20,10 @@ QList<mixxx::AnalyzerPluginInfo> AnalyzerKey::availablePlugins() {
     analyzers.push_back(mixxx::AnalyzerKeyFinder::pluginInfo());
 #endif
     return analyzers;
+}
+
+QList<mixxx::AnalyzerPluginInfo> AnalyzerKey::availablePlugins() const {
+    return defaultAvailableKeyPlugins();
 }
 
 AnalyzerKey::AnalyzerKey(const KeyDetectionSettings& keySettings)
@@ -50,7 +53,7 @@ bool AnalyzerKey::initialize(TrackPointer tio,
     m_bPreferencesFastAnalysisEnabled = m_keySettings.getFastAnalysis();
     m_bPreferencesReanalyzeEnabled = m_keySettings.getReanalyzeWhenSettingsChange();
 
-    m_pluginId = matchAndSetPluginId(availablePlugins(), m_keySettings.getKeyPluginId());
+    m_pluginId = matchAndSetPluginId(m_keySettings.getKeyPluginId());
 
     qDebug() << "AnalyzerKey preference settings:"
              << "\nPlugin:" << m_pluginId
@@ -104,7 +107,7 @@ bool AnalyzerKey::shouldAnalyze(TrackPointer tio) const {
     bool bPreferencesFastAnalysisEnabled = m_keySettings.getFastAnalysis();
     QString pluginID = m_keySettings.getKeyPluginId();
     if (pluginID.isEmpty()) {
-        pluginID = defaultPlugin(availablePlugins()).id();
+        pluginID = defaultPlugin();
     }
 
     const Keys keys(tio->getKeys());

--- a/src/analyzer/analyzerkey.cpp
+++ b/src/analyzer/analyzerkey.cpp
@@ -53,7 +53,7 @@ bool AnalyzerKey::initialize(TrackPointer tio,
     m_bPreferencesFastAnalysisEnabled = m_keySettings.getFastAnalysis();
     m_bPreferencesReanalyzeEnabled = m_keySettings.getReanalyzeWhenSettingsChange();
 
-    m_pluginId = matchAndSetPluginId(m_keySettings.getKeyPluginId());
+    m_pluginId = matchOrGetDefaultPluginId(m_keySettings.getKeyPluginId());
 
     qDebug() << "AnalyzerKey preference settings:"
              << "\nPlugin:" << m_pluginId

--- a/src/analyzer/analyzerkey.h
+++ b/src/analyzer/analyzerkey.h
@@ -12,8 +12,6 @@
 #include "track/track_decl.h"
 #include "util/memory.h"
 
-QList<mixxx::AnalyzerPluginInfo> defaultAvailableKeyPlugins();
-
 class AnalyzerKey : private AnalyzerPluginSupportInfo, public Analyzer {
   public:
     explicit AnalyzerKey(const KeyDetectionSettings& keySettings);
@@ -25,6 +23,7 @@ class AnalyzerKey : private AnalyzerPluginSupportInfo, public Analyzer {
     bool processSamples(const CSAMPLE *pIn, const int iLen) override;
     void storeResults(TrackPointer tio) override;
     void cleanup() override;
+    static QList<mixxx::AnalyzerPluginInfo> defaultPluginsList();
 
   private:
     QList<mixxx::AnalyzerPluginInfo> availablePlugins() const override;

--- a/src/analyzer/analyzerkey.h
+++ b/src/analyzer/analyzerkey.h
@@ -17,6 +17,9 @@ class AnalyzerKey : public Analyzer {
     ~AnalyzerKey() override = default;
 
     static QList<mixxx::AnalyzerPluginInfo> availablePlugins();
+    template<typename T1>
+    static QString matchAndSetPluginId(
+            const T1& analyzer_with_plugin_ids, const QString& pluginIdToMatch);
     static mixxx::AnalyzerPluginInfo defaultPlugin();
 
     bool initialize(TrackPointer tio,

--- a/src/analyzer/analyzerkey.h
+++ b/src/analyzer/analyzerkey.h
@@ -6,21 +6,18 @@
 
 #include "analyzer/analyzer.h"
 #include "analyzer/plugins/analyzerplugin.h"
+#include "analyzer/plugins/analyzerpluginsupport.h"
 #include "preferences/keydetectionsettings.h"
 #include "preferences/usersettings.h"
 #include "track/track_decl.h"
 #include "util/memory.h"
 
-class AnalyzerKey : public Analyzer {
+class AnalyzerKey : protected AnalyzerPluginSupportInfo, public Analyzer {
   public:
     explicit AnalyzerKey(const KeyDetectionSettings& keySettings);
     ~AnalyzerKey() override = default;
 
     static QList<mixxx::AnalyzerPluginInfo> availablePlugins();
-    template<typename T1>
-    static QString matchAndSetPluginId(
-            const T1& analyzer_with_plugin_ids, const QString& pluginIdToMatch);
-    static mixxx::AnalyzerPluginInfo defaultPlugin();
 
     bool initialize(TrackPointer tio,
             mixxx::audio::SampleRate sampleRate,
@@ -30,14 +27,10 @@ class AnalyzerKey : public Analyzer {
     void cleanup() override;
 
   private:
-    static QHash<QString, QString> getExtraVersionInfo(
-            const QString& pluginId, bool bPreferencesFastAnalysis);
-
     bool shouldAnalyze(TrackPointer tio) const;
 
     KeyDetectionSettings m_keySettings;
     std::unique_ptr<mixxx::AnalyzerKeyPlugin> m_pPlugin;
-    QString m_pluginId;
     int m_iSampleRate;
     int m_iTotalSamples;
     int m_iMaxSamplesToProcess;

--- a/src/analyzer/analyzerkey.h
+++ b/src/analyzer/analyzerkey.h
@@ -12,12 +12,12 @@
 #include "track/track_decl.h"
 #include "util/memory.h"
 
-class AnalyzerKey : protected AnalyzerPluginSupportInfo, public Analyzer {
+QList<mixxx::AnalyzerPluginInfo> defaultAvailableKeyPlugins();
+
+class AnalyzerKey : private AnalyzerPluginSupportInfo, public Analyzer {
   public:
     explicit AnalyzerKey(const KeyDetectionSettings& keySettings);
     ~AnalyzerKey() override = default;
-
-    static QList<mixxx::AnalyzerPluginInfo> availablePlugins();
 
     bool initialize(TrackPointer tio,
             mixxx::audio::SampleRate sampleRate,
@@ -27,6 +27,7 @@ class AnalyzerKey : protected AnalyzerPluginSupportInfo, public Analyzer {
     void cleanup() override;
 
   private:
+    QList<mixxx::AnalyzerPluginInfo> availablePlugins() const override;
     bool shouldAnalyze(TrackPointer tio) const;
 
     KeyDetectionSettings m_keySettings;

--- a/src/analyzer/plugins/analyzerpluginsupport.cpp
+++ b/src/analyzer/plugins/analyzerpluginsupport.cpp
@@ -1,23 +1,19 @@
 #include "analyzer/plugins/analyzerpluginsupport.h"
 
-QString AnalyzerPluginSupportInfo::matchAndSetPluginId(
-        const QList<mixxx::AnalyzerPluginInfo>& availablePlugins,
-        const QString& pluginIdToMatch) {
-    if (const auto plugins = availablePlugins; !plugins.isEmpty()) {
+QString AnalyzerPluginSupportInfo::matchAndSetPluginId(const QString& pluginIdToMatch) {
+    if (const auto plugins = availablePlugins(); !plugins.isEmpty()) {
         return std::any_of(std::begin(plugins), std::end(plugins), [&](const auto& info) {
             return info.id() == pluginIdToMatch;
         })
                 ? pluginIdToMatch // configured Plug-In available;
-                : defaultPlugin(availablePlugins).id();
+                : defaultPlugin();
     }
     return m_pluginId;
 }
 
-mixxx::AnalyzerPluginInfo AnalyzerPluginSupportInfo::defaultPlugin(
-        const QList<mixxx::AnalyzerPluginInfo>& availablePlugins) const {
-    const auto plugins = availablePlugins;
-    DEBUG_ASSERT(!plugins.isEmpty());
-    return plugins.at(0);
+QString AnalyzerPluginSupportInfo::defaultPlugin() const {
+    DEBUG_ASSERT(!availablePlugins().isEmpty());
+    return availablePlugins().at(0).id();
 }
 
 QHash<QString, QString> AnalyzerPluginSupportInfo::getExtraVersionInfo(

--- a/src/analyzer/plugins/analyzerpluginsupport.cpp
+++ b/src/analyzer/plugins/analyzerpluginsupport.cpp
@@ -1,0 +1,31 @@
+#include "analyzer/plugins/analyzerpluginsupport.h"
+
+QString AnalyzerPluginSupportInfo::matchAndSetPluginId(
+        const QList<mixxx::AnalyzerPluginInfo>& availablePlugins,
+        const QString& pluginIdToMatch) {
+    if (const auto plugins = availablePlugins; !plugins.isEmpty()) {
+        return std::any_of(std::begin(plugins), std::end(plugins), [&](const auto& info) {
+            return info.id() == pluginIdToMatch;
+        })
+                ? pluginIdToMatch // configured Plug-In available;
+                : defaultPlugin(availablePlugins).id();
+    }
+    return m_pluginId;
+}
+
+mixxx::AnalyzerPluginInfo AnalyzerPluginSupportInfo::defaultPlugin(
+        const QList<mixxx::AnalyzerPluginInfo>& availablePlugins) const {
+    const auto plugins = availablePlugins;
+    DEBUG_ASSERT(!plugins.isEmpty());
+    return plugins.at(0);
+}
+
+QHash<QString, QString> AnalyzerPluginSupportInfo::getExtraVersionInfo(
+        const QString& pluginId, bool bPreferencesFastAnalysis) const {
+    QHash<QString, QString> extraVersionInfo;
+    extraVersionInfo["vamp_plugin_id"] = pluginId;
+    if (bPreferencesFastAnalysis) {
+        extraVersionInfo["fast_analysis"] = "1";
+    }
+    return extraVersionInfo;
+}

--- a/src/analyzer/plugins/analyzerpluginsupport.cpp
+++ b/src/analyzer/plugins/analyzerpluginsupport.cpp
@@ -1,12 +1,14 @@
 #include "analyzer/plugins/analyzerpluginsupport.h"
 
-QString AnalyzerPluginSupportInfo::matchAndSetPluginId(const QString& pluginIdToMatch) {
+QString AnalyzerPluginSupportInfo::matchOrGetDefaultPluginId(const QString& pluginIdToMatch) const {
     if (const auto plugins = availablePlugins(); !plugins.isEmpty()) {
-        return std::any_of(std::begin(plugins), std::end(plugins), [&](const auto& info) {
-            return info.id() == pluginIdToMatch;
-        })
-                ? pluginIdToMatch // configured Plug-In available;
-                : defaultPlugin();
+        if (std::any_of(std::begin(plugins), std::end(plugins), [&](const auto& info) {
+                return info.id() == pluginIdToMatch;
+            })) {
+            return pluginIdToMatch; // configured Plug-In available;
+        } else {
+            return defaultPlugin();
+        }
     }
     return m_pluginId;
 }

--- a/src/analyzer/plugins/analyzerpluginsupport.h
+++ b/src/analyzer/plugins/analyzerpluginsupport.h
@@ -8,7 +8,7 @@
 class AnalyzerPluginSupportInfo {
   public:
     virtual QList<mixxx::AnalyzerPluginInfo> availablePlugins() const = 0;
-    QString matchAndSetPluginId(const QString& pluginIdToMatch);
+    QString matchOrGetDefaultPluginId(const QString& pluginIdToMatch) const;
     QString defaultPlugin() const;
     virtual QHash<QString, QString> getExtraVersionInfo(
             const QString& pluginId, bool bPreferencesFastAnalysis) const;

--- a/src/analyzer/plugins/analyzerpluginsupport.h
+++ b/src/analyzer/plugins/analyzerpluginsupport.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <QString>
+
+#include "analyzer/analyzer.h"
+#include "analyzer/plugins/analyzerplugin.h"
+
+struct AnalyzerPluginSupportInfo {
+    virtual QString matchAndSetPluginId(
+            const QList<mixxx::AnalyzerPluginInfo>& availablePlugins,
+            const QString& pluginIdToMatch);
+    virtual mixxx::AnalyzerPluginInfo defaultPlugin(
+            const QList<mixxx::AnalyzerPluginInfo>& availablePlugins) const;
+    virtual QHash<QString, QString> getExtraVersionInfo(
+            const QString& pluginId, bool bPreferencesFastAnalysis) const;
+
+  protected:
+    QString m_pluginId;
+};

--- a/src/analyzer/plugins/analyzerpluginsupport.h
+++ b/src/analyzer/plugins/analyzerpluginsupport.h
@@ -5,12 +5,11 @@
 #include "analyzer/analyzer.h"
 #include "analyzer/plugins/analyzerplugin.h"
 
-struct AnalyzerPluginSupportInfo {
-    virtual QString matchAndSetPluginId(
-            const QList<mixxx::AnalyzerPluginInfo>& availablePlugins,
-            const QString& pluginIdToMatch);
-    virtual mixxx::AnalyzerPluginInfo defaultPlugin(
-            const QList<mixxx::AnalyzerPluginInfo>& availablePlugins) const;
+class AnalyzerPluginSupportInfo {
+  public:
+    virtual QList<mixxx::AnalyzerPluginInfo> availablePlugins() const = 0;
+    QString matchAndSetPluginId(const QString& pluginIdToMatch);
+    QString defaultPlugin() const;
     virtual QHash<QString, QString> getExtraVersionInfo(
             const QString& pluginId, bool bPreferencesFastAnalysis) const;
 

--- a/src/preferences/dialog/dlgprefbeats.cpp
+++ b/src/preferences/dialog/dlgprefbeats.cpp
@@ -15,7 +15,7 @@ DlgPrefBeats::DlgPrefBeats(QWidget* parent, UserSettingsPointer pConfig)
           m_bReanalyzeImported(m_bpmSettings.getReanalyzeImportedDefault()) {
     setupUi(this);
 
-    m_availablePlugins = defaultAvailableBeatsPlugins();
+    m_availablePlugins = AnalyzerBeats::defaultPluginsList();
     for (const auto& info : qAsConst(m_availablePlugins)) {
         comboBoxBeatPlugin->addItem(info.name(), info.id());
     }

--- a/src/preferences/dialog/dlgprefbeats.cpp
+++ b/src/preferences/dialog/dlgprefbeats.cpp
@@ -15,7 +15,7 @@ DlgPrefBeats::DlgPrefBeats(QWidget* parent, UserSettingsPointer pConfig)
           m_bReanalyzeImported(m_bpmSettings.getReanalyzeImportedDefault()) {
     setupUi(this);
 
-    m_availablePlugins = AnalyzerBeats::availablePlugins();
+    m_availablePlugins = defaultAvailableBeatsPlugins();
     for (const auto& info : qAsConst(m_availablePlugins)) {
         comboBoxBeatPlugin->addItem(info.name(), info.id());
     }

--- a/src/preferences/dialog/dlgprefkey.cpp
+++ b/src/preferences/dialog/dlgprefkey.cpp
@@ -43,7 +43,7 @@ DlgPrefKey::DlgPrefKey(QWidget* parent, UserSettingsPointer pConfig)
     m_keyLineEdits.insert(mixxx::track::io::key::B_FLAT_MINOR, b_flat_minor_edit);
     m_keyLineEdits.insert(mixxx::track::io::key::B_MINOR, b_minor_edit);
 
-    m_availablePlugins = defaultAvailableKeyPlugins();
+    m_availablePlugins = AnalyzerKey::defaultPluginsList();
     for (const auto& info : qAsConst(m_availablePlugins)) {
         plugincombo->addItem(info.name(), info.id());
     }

--- a/src/preferences/dialog/dlgprefkey.cpp
+++ b/src/preferences/dialog/dlgprefkey.cpp
@@ -43,7 +43,7 @@ DlgPrefKey::DlgPrefKey(QWidget* parent, UserSettingsPointer pConfig)
     m_keyLineEdits.insert(mixxx::track::io::key::B_FLAT_MINOR, b_flat_minor_edit);
     m_keyLineEdits.insert(mixxx::track::io::key::B_MINOR, b_minor_edit);
 
-    m_availablePlugins = AnalyzerKey::availablePlugins();
+    m_availablePlugins = defaultAvailableKeyPlugins();
     for (const auto& info : qAsConst(m_availablePlugins)) {
         plugincombo->addItem(info.name(), info.id());
     }


### PR DESCRIPTION
Changes: 
* Prefer using standard algorithms, to help check if plug-In is available.
* Extract some common code between the two Analyzer{Beats,Keys} classes into its own meta-interface class.

---

_Notes:_
* _I am flexible in adjusting this PR so only the first two commits (which add the standard algorithm code) are accepted._
*  _If not allowed (to adjust the PR), then I am happy to make another PR just for adding the standard algorithm code alone (if this PR is not merged). Thanks!_ :smile: 