### PR TITLE
Brake: fix infinite run out

### DIFF
--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
@@ -666,10 +666,7 @@ void ControllerScriptInterfaceLegacy::scratchProcess(int timerId) {
         return;
     }
 
-    const double oldRate = filter->predictedVelocity();
-
     // Give the filter a data point:
-
     // If we're ramping to end scratching and the wheel hasn't been turned very
     // recently (spinback after lift-off,) feed fixed data
     if (m_ramp[deck] && !m_softStartActive[deck] &&
@@ -701,14 +698,11 @@ void ControllerScriptInterfaceLegacy::scratchProcess(int timerId) {
 
     // End scratching if we're ramping and the current rate is really close to the rampTo value
     if ((m_ramp[deck] && fabs(m_rampTo[deck] - newRate) <= 0.00001) ||
-            // or if we brake or softStart and have crossed over the desired value,
-            ((m_brakeActive[deck] || m_softStartActive[deck]) &&
-                    ((oldRate > m_rampTo[deck] && newRate < m_rampTo[deck]) ||
-                            (oldRate < m_rampTo[deck] &&
-                                    newRate > m_rampTo[deck]))) ||
+            // or if we have crossed over the desired value during brake or softStart
+            (m_brakeActive[deck] && newRate < m_rampTo[deck]) ||
+            (m_softStartActive[deck] && newRate > m_rampTo[deck]) ||
             // or if the deck was stopped manually during brake or softStart
-            ((m_brakeActive[deck] || m_softStartActive[deck]) &&
-                    (!isDeckPlaying(group)))) {
+            ((m_brakeActive[deck] || m_softStartActive[deck]) && !isDeckPlaying(group))) {
         // Not ramping no mo'
         m_ramp[deck] = false;
 

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
@@ -94,6 +94,7 @@ class ControllerScriptInterfaceLegacy : public QObject {
     /// Applies the accumulated movement to the track speed
     void scratchProcess(int timerId);
     bool isDeckPlaying(const QString& group);
+    void stopDeck(const QString& group);
     double getDeckRate(const QString& group);
 
     ControllerScriptEngineLegacy* m_pScriptEngineLegacy;


### PR DESCRIPTION
Multiple times I experienced that `engine.brake()` would slow down the deck until the waveforms halted but `play` was never disabled.
I suspected a broken controller button (faulty debounce filter) to initiate `brake` again, but I could also reproduce it with a MIDI Through script a few times.

There is at least one possibility that the `rampTo` rate was crossed but `scratchProcess` didn't stop, thus slowing down to zero and accelerating again very, very slowly:
```
debug [Controller]    old 0
debug [Controller]    new 1.69772e-311
debug [Controller]    fabs 0.01
debug [Controller] .
debug [Controller] .
debug [Controller]    old 1.69772e-311
debug [Controller]    new 5.08986e-311
debug [Controller]    fabs 0.01
debug [Controller] .
debug [Controller] .
debug [Controller]    old 5.08986e-311
debug [Controller]    new 1.01731e-310
debug [Controller]    fabs 0.01
...
debug [Controller]    old 1.85776e-307
debug [Controller]    new 1.88052e-307
debug [Controller]    fabs 0.01
debug [Controller] .
debug [Controller] .
debug [Controller]    old 1.88052e-307
debug [Controller]    new 1.90341e-307
debug [Controller]    fabs 0.01
debug [Controller] .
debug [Controller] .
debug [Controller]    old 1.90341e-307
debug [Controller]    new 1.92641e-307
debug [Controller]    fabs 0.01
```
I fixed that 

That and some more simplification and I couldn't reproduce the bug anymore :man_shrugging: 