### PR TITLE
pre-commit: update hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
     #args: [--ignore-words, .codespellignore, --ignore-regex, "\\W(?:m_p*(?=[A-Z])|m_(?=\\w)|pp*(?=[A-Z])|k(?=[A-Z])|s_(?=\\w))"]
     exclude: ^(packaging/wix/LICENSE.rtf|src/dialog/dlgabout\.cpp|.*\.(?:pot?|ts|wxl))$
 - repo: https://github.com/pre-commit/mirrors-eslint
-  rev: v8.8.0
+  rev: v8.12.0
   hooks:
   - id: eslint
     args: [--fix, --report-unused-disable-directives]
@@ -83,7 +83,7 @@ repos:
     language: python
     files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|m|mm|proto|vert)$
 - repo: https://github.com/psf/black
-  rev: 22.1.0
+  rev: 22.3.0
   hooks:
   - id: black
     files: ^tools/.*$
@@ -102,7 +102,7 @@ repos:
   hooks:
   - id: markdownlint-cli2
 - repo: https://github.com/sirosen/check-jsonschema
-  rev: 0.10.2
+  rev: 0.14.1
   hooks:
   - id: check-github-workflows
 - repo: local


### PR DESCRIPTION
fix broken pre-commit caused by psf/black#2969

occured on my CI. Black got broken a couple hours ago so this is why this didn't occur on the mixxx CI yet. 
https://github.com/Swiftb0y/mixxx/runs/5731771987