### PR TITLE
Spinback fix

### DIFF
--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -1503,8 +1503,8 @@ void ControllerEngine::softTakeoverIgnoreNextValue(
     Output:  -
     -------- ------------------------------------------------------ */
 void ControllerEngine::spinback(int deck, bool activate, double factor, double rate) {
-    // defaults for args set in header file
-    brake(deck, activate, factor, rate);
+    qDebug() << "   init spinback";
+    brake(deck, activate, -factor, rate);
 }
 
 /*  -------- ------------------------------------------------------

--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -1242,12 +1242,24 @@ bool ControllerEngine::isDeckPlaying(const QString& group) {
     ControlObjectScript* pPlay = getControlObjectScript(group, "play");
 
     if (pPlay == nullptr) {
-      QString error = QString("Could not getControlObjectScript()");
-      scriptErrorDialog(error, error);
-      return false;
+        QString error = QString("Could not get ControlObjectScript(%1, play)").arg(group);
+        scriptErrorDialog(error, error);
+        return false;
     }
 
-    return pPlay->get() > 0.0;
+    return pPlay->toBool();
+}
+
+void ControllerEngine::stopDeck(const QString& group) {
+    ControlObjectScript* pPlay = getControlObjectScript(group, "play");
+
+    if (pPlay == nullptr) {
+        QString error = QString("Could not get ControlObjectScript(%1, play)").arg(group);
+        scriptErrorDialog(error, error);
+        return;
+    }
+
+    pPlay->set(0.0);
 }
 
 /* -------- ------------------------------------------------------
@@ -1410,10 +1422,7 @@ void ControllerEngine::scratchProcess(int timerId) {
         if (m_brakeActive[deck] || m_spinbackActive[deck]) {
             // If in brake mode, set scratch2 rate to 0 and stop the deck.
             pScratch2->slotSet(0.0);
-            ControlObjectScript* pPlay = getControlObjectScript(group, "play");
-            if (pPlay != nullptr) {
-                pPlay->slotSet(0.0);
-            }
+            stopDeck(group);
         }
 
         // Clear scratch2_enable to end scratching.
@@ -1589,7 +1598,7 @@ void ControllerEngine::brake(int deck, bool activate, double factor, double rate
         m_brakeActive[deck] = false;
         m_spinbackActive[deck] = false;
         stopScratchTimer(timerId);
-        // TODO(ronso0) Stop deck as if we were braking to halt
+        stopDeck(group);
         return;
     }
     stopScratchTimer(timerId);

--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -1349,15 +1349,19 @@ void ControllerEngine::scratchProcess(int timerId) {
 
     // If we're ramping to end scratching and the wheel hasn't been turned very
     // recently (spinback after lift-off,) feed fixed data
+    qDebug() << ".";
     if (m_ramp[deck] && !m_softStartActive[deck] &&
         ((mixxx::Time::elapsed() - m_lastMovement[deck]) >= mixxx::Duration::fromMillis(1))) {
+        qDebug() << "       ramp && !softStart";
         filter->observation(m_rampTo[deck] * m_rampFactor[deck]);
         // Once this code path is run, latch so it always runs until reset
         //m_lastMovement[deck] += mixxx::Duration::fromSeconds(1);
     } else if (m_softStartActive[deck]) {
+        qDebug() << "       softStart";
         // pretend we have moved by (desired rate*default distance)
-        filter->observation(m_rampTo[deck]*kAlphaBetaDt);
+        filter->observation(m_rampTo[deck] * kAlphaBetaDt);
     } else {
+        qDebug() << "       else";
         // This will (and should) be 0 if no net ticks have been accumulated
         // (i.e. the wheel is stopped)
         filter->observation(m_dx[deck] * m_intervalAccumulator[deck]);
@@ -1375,6 +1379,10 @@ void ControllerEngine::scratchProcess(int timerId) {
     // Reset accumulator
     m_intervalAccumulator[deck] = 0;
 
+    qDebug() << "   old " << oldRate;
+    qDebug() << "   new " << newRate;
+    qDebug() << "   fabs" << fabs(trunc((m_rampTo[deck] - newRate) * 100000) / 100000);
+    qDebug() << ".";
     // End scratching if we're ramping and the current rate is really close to the rampTo value
     if ((m_ramp[deck] && fabs(m_rampTo[deck] - newRate) <= 0.00001) ||
         // or if we brake or softStart and have crossed over the desired value,
@@ -1410,6 +1418,8 @@ void ControllerEngine::scratchProcess(int timerId) {
         m_dx[deck] = 0.0;
         m_brakeActive[deck] = false;
         m_softStartActive[deck] = false;
+        qDebug() << "   DONE scratching";
+        qDebug() << ".";
     }
 }
 
@@ -1514,6 +1524,7 @@ void ControllerEngine::spinback(int deck, bool activate, double factor, double r
     Output:  -
     -------- ------------------------------------------------------ */
 void ControllerEngine::brake(int deck, bool activate, double factor, double rate) {
+    qDebug() << "   init brake";
     // PlayerManager::groupForDeck is 0-indexed.
     QString group = PlayerManager::groupForDeck(deck - 1);
 
@@ -1582,6 +1593,7 @@ void ControllerEngine::brake(int deck, bool activate, double factor, double rate
     Output:  -
     -------- ------------------------------------------------------ */
 void ControllerEngine::softStart(int deck, bool activate, double factor) {
+    qDebug() << "   init softStart";
     // PlayerManager::groupForDeck is 0-indexed.
     QString group = PlayerManager::groupForDeck(deck - 1);
 

--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -30,6 +30,8 @@ constexpr int kDecks = 16;
 // timer.
 constexpr int kScratchTimerMs = 1;
 constexpr double kAlphaBetaDt = kScratchTimerMs / 1000.0;
+// stop ramping at a rate which doesn't produce any audible output anymore
+constexpr double kBrakeRampToRate = 0.01;
 } // namespace
 
 ControllerEngine::ControllerEngine(
@@ -1555,7 +1557,9 @@ void ControllerEngine::brake(int deck, bool activate, double factor, double rate
     }
     // stop ramping at a rate which doesn't produce any audible output anymore
     m_rampTo[deck] = 0.01;
-    // if we are currently softStart()ing, stop it
+    m_rampTo[deck] = kBrakeRampToRate;
+
+    // If we want to brake or spin back and are currently softStart'ing, stop it.
     if (m_softStartActive[deck]) {
         m_softStartActive[deck] = false;
         AlphaBetaFilter* filter = m_scratchFilters[deck];

--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -1370,10 +1370,10 @@ void ControllerEngine::scratchTick(int deck, int interval) {
     Input:   ID of timer for this deck
     Output:  -
     -------- ------------------------------------------------------ */
-void ControllerEngine::scratchProcess(int timerId) {
-    int deck = m_scratchTimers[timerId];
+void ControllerEngine::scratchProcess(const int timerId) {
+    const int deck = m_scratchTimers[timerId];
     // PlayerManager::groupForDeck is 0-indexed.
-    QString group = PlayerManager::groupForDeck(deck - 1);
+    const QString group = PlayerManager::groupForDeck(deck - 1);
     AlphaBetaFilter* filter = m_scratchFilters[deck];
     if (!filter) {
         qWarning() << "Scratch filter pointer is null on deck" << deck;
@@ -1546,7 +1546,8 @@ void ControllerEngine::softTakeoverIgnoreNextValue(
              rate (optional)
     Output:  -
     -------- ------------------------------------------------------ */
-void ControllerEngine::spinback(int deck, bool activate, double factor, double rate) {
+void ControllerEngine::spinback(
+        const int deck, bool activate, const double factor, const double rate) {
     qDebug() << "   init spinback";
     brake(deck, activate, -factor, rate);
 }
@@ -1557,10 +1558,10 @@ void ControllerEngine::spinback(int deck, bool activate, double factor, double r
              rate (optional, necessary for spinback)
     Output:  -
     -------- ------------------------------------------------------ */
-void ControllerEngine::brake(int deck, bool activate, double factor, double rate) {
+void ControllerEngine::brake(const int deck, bool activate, double factor, const double rate) {
     qDebug() << "   init brake";
     // PlayerManager::groupForDeck is 0-indexed.
-    QString group = PlayerManager::groupForDeck(deck - 1);
+    const QString group = PlayerManager::groupForDeck(deck - 1);
     // enable/disable scratch2 mode
     ControlObjectScript* pScratch2Enable = getControlObjectScript(group, "scratch2_enable");
     if (pScratch2Enable != nullptr) {
@@ -1648,10 +1649,10 @@ void ControllerEngine::brake(int deck, bool activate, double factor, double rate
     Input:   deck, activate/deactivate, factor (optional)
     Output:  -
     -------- ------------------------------------------------------ */
-void ControllerEngine::softStart(int deck, bool activate, double factor) {
+void ControllerEngine::softStart(const int deck, bool activate, double factor) {
     qDebug() << "   init softStart";
     // PlayerManager::groupForDeck is 0-indexed.
-    QString group = PlayerManager::groupForDeck(deck - 1);
+    const QString group = PlayerManager::groupForDeck(deck - 1);
 
     // kill timer when both enabling or disabling
     int timerId = m_scratchTimers.key(deck);

--- a/src/controllers/controllerengine.h
+++ b/src/controllers/controllerengine.h
@@ -197,6 +197,7 @@ class ControllerEngine : public QObject {
 
     bool isDeckPlaying(const QString& group);
     void stopDeck(const QString& group);
+    bool isTrackLoaded(const QString& group);
     double getDeckRate(const QString& group);
 
     Controller* m_pController;

--- a/src/controllers/controllerengine.h
+++ b/src/controllers/controllerengine.h
@@ -193,6 +193,7 @@ class ControllerEngine : public QObject {
 
     // Scratching functions & variables
     void scratchProcess(int timerId);
+    void stopScratchTimer(const int timerId);
 
     bool isDeckPlaying(const QString& group);
     double getDeckRate(const QString& group);
@@ -216,7 +217,7 @@ class ControllerEngine : public QObject {
     QVarLengthArray<int> m_intervalAccumulator;
     QVarLengthArray<mixxx::Duration> m_lastMovement;
     QVarLengthArray<double> m_dx, m_rampTo, m_rampFactor;
-    QVarLengthArray<bool> m_ramp, m_brakeActive, m_softStartActive;
+    QVarLengthArray<bool> m_ramp, m_brakeActive, m_spinbackActive, m_softStartActive;
     QVarLengthArray<AlphaBetaFilter*> m_scratchFilters;
     QHash<int, int> m_scratchTimers;
     QHash<QString, QScriptValue> m_scriptWrappedFunctionCache;

--- a/src/controllers/controllerengine.h
+++ b/src/controllers/controllerengine.h
@@ -196,6 +196,7 @@ class ControllerEngine : public QObject {
     void stopScratchTimer(const int timerId);
 
     bool isDeckPlaying(const QString& group);
+    void stopDeck(const QString& group);
     double getDeckRate(const QString& group);
 
     Controller* m_pController;

--- a/src/controllers/controllerengine.h
+++ b/src/controllers/controllerengine.h
@@ -132,9 +132,15 @@ class ControllerEngine : public QObject {
     Q_INVOKABLE bool isScratching(int deck);
     Q_INVOKABLE void softTakeover(const QString& group, const QString& name, bool set);
     Q_INVOKABLE void softTakeoverIgnoreNextValue(const QString& group, const QString& name);
-    Q_INVOKABLE void brake(int deck, bool activate, double factor=1.0, double rate=1.0);
-    Q_INVOKABLE void spinback(int deck, bool activate, double factor=1.8, double rate=-10.0);
-    Q_INVOKABLE void softStart(int deck, bool activate, double factor=1.0);
+    Q_INVOKABLE void brake(const int deck,
+            bool activate,
+            double factor = 1.0,
+            const double rate = 1.0);
+    Q_INVOKABLE void spinback(const int deck,
+            bool activate,
+            double factor = 1.8,
+            const double rate = -10.0);
+    Q_INVOKABLE void softStart(const int deck, bool activate, double factor = 1.0);
 
     // Handler for timers that scripts set.
     virtual void timerEvent(QTimerEvent *event);
@@ -192,7 +198,7 @@ class ControllerEngine : public QObject {
     ControlObjectScript* getControlObjectScript(const QString& group, const QString& name);
 
     // Scratching functions & variables
-    void scratchProcess(int timerId);
+    void scratchProcess(const int timerId);
     void stopScratchTimer(const int timerId);
 
     bool isDeckPlaying(const QString& group);


### PR DESCRIPTION
Fixes a few spinback "regressions" noticed in #4705
* fix infinite acceleration (never comes to halt currently)
* spin**back** when interrupting softStart (was spinning forward)
* allow spinback on stopped deck

The first two are fixed by a single `-` 7fed042f29a1ed8b1f2ea62ccd1bc3f2c9bf2cf1 (after hours trying to understand the alpha-beta scratch filter).

Allowing spinback on stopped deck (IIRC that was working a few years back) was more work as it required cleaning up `brake()`, and I hope someone has motivation to review it so we can merge it to "stable" 2.3

- [x] remove debug output / use kLogger?