### PR TITLE
Added missing cmakeToolchain path setting to windows_buildenv.bat

### DIFF
--- a/tools/windows_buildenv.bat
+++ b/tools/windows_buildenv.bat
@@ -224,7 +224,8 @@ REM Generate CMakeSettings.json which is read by MS Visual Studio to determine t
     CALL :AddCMakeVar2CMakeSettings_JSON "VINYLCONTROL"                       "BOOL"   "True"
     SET variableElementTermination=
     CALL :AddCMakeVar2CMakeSettings_JSON "WAVPACK"                            "BOOL"   "True"
-    >>%CMakeSettings% echo       ]
+    >>%CMakeSettings% echo       ],
+    >>%CMakeSettings% echo       "cmakeToolchain": "!VCPKG_ROOT:\=\\!\\scripts\\buildsystems\\vcpkg.cmake"
     >>%CMakeSettings% echo     }!configElementTermination!
   GOTO :EOF
 


### PR DESCRIPTION
Without this setting the CMake cache is uneccessary often invalidated, which requires complete recompile. With this setting switching between different branches and build configurations doesn't require a full rebuild in most cases.