### PR TITLE
LateNight: add toggles to show loop and beatjump controls

### DIFF
--- a/res/skins/LateNight/decks/row_5_transportLoopJump.xml
+++ b/res/skins/LateNight/decks/row_5_transportLoopJump.xml
@@ -293,6 +293,10 @@
                 </Children>
               </WidgetGroup>
             </Children>
+            <Connection>
+              <ConfigKey>[Skin],show_loop_controls</ConfigKey>
+              <BindProperty>visible</BindProperty>
+            </Connection>
           </WidgetGroup><!-- /Loop buttons + beatloop size spinbox -->
 
           <WidgetGroup><Size>2f,0min</Size></WidgetGroup><!--  = 2-80px wide -->
@@ -351,6 +355,10 @@
                 </Children>
               </WidgetGroup>
             </Children>
+            <Connection>
+              <ConfigKey>[Skin],show_beatjump_controls</ConfigKey>
+              <BindProperty>visible</BindProperty>
+            </Connection>
           </WidgetGroup><!-- /Jump buttons + beatjump size spinbox -->
 
           <WidgetGroup><Size>2f,0min</Size></WidgetGroup>

--- a/res/skins/LateNight/decks/row_5_transportLoopJump_compact.xml
+++ b/res/skins/LateNight/decks/row_5_transportLoopJump_compact.xml
@@ -114,13 +114,24 @@
                   <BindProperty>highlight</BindProperty>
                 </Connection> -->
               </BeatSpinBox>
+            </Children>
+              <Connection>
+                <ConfigKey persist="true">[Skin],show_loop_controls_compact</ConfigKey>
+                <BindProperty>visible</BindProperty>
+              </Connection>
+          </WidgetGroup>
 
-              <WidgetGroup>
-                <SizePolicy>me,min</SizePolicy>
-                <MinimumSize>2,</MinimumSize>
-                <MaximumSize>20,</MaximumSize>
-              </WidgetGroup>
+          <WidgetGroup>
+            <SizePolicy>me,min</SizePolicy>
+            <MinimumSize>2,</MinimumSize>
+            <MaximumSize>40,</MaximumSize>
+          </WidgetGroup>
 
+          <WidgetGroup>
+            <ObjectName>BeatjumpControls</ObjectName>
+            <Layout>horizontal</Layout>
+            <SizePolicy>me,min</SizePolicy>
+            <Children>
               <BeatSpinBox>
                 <TooltipId>beatjump_size</TooltipId>
                 <ObjectName>Spinbox_<Variable name="BtnType"/></ObjectName>
@@ -138,7 +149,7 @@
               </BeatSpinBox>
             </Children>
             <Connection>
-              <ConfigKey persist="true">[LateNight],show_loopjump_controls_compact</ConfigKey>
+              <ConfigKey persist="true">[Skin],show_beatjump_controls_compact</ConfigKey>
               <BindProperty>visible</BindProperty>
             </Connection>
           </WidgetGroup>

--- a/res/skins/LateNight/helpers/skin_settings_compact_deck.xml
+++ b/res/skins/LateNight/helpers/skin_settings_compact_deck.xml
@@ -9,14 +9,23 @@ Description:
     <Layout>vertical</Layout>
     <Children>
 
-      <WidgetGroup><Size>0me,6f</Size></WidgetGroup>
+      <WidgetGroup><Size>0me,18f</Size></WidgetGroup>
 
-      <!-- Loop/Jump Controls in compact decks-->
+      <!-- Loop Controls in compact decks -->
       <Template src="skin:/helpers/skin_settings_button_2state.xml">
-        <SetVariable name="TooltipId"></SetVariable>
-        <SetVariable name="Text">Loop / Jump Controls</SetVariable>
-        <SetVariable name="Setting">[LateNight],show_loopjump_controls_compact</SetVariable>
+        <SetVariable name="TooltipId">show_loop_controls</SetVariable>
+        <SetVariable name="Text">Loop Controls</SetVariable>
+        <SetVariable name="Setting">[Skin],show_loop_controls_compact</SetVariable>
       </Template>
+
+      <!-- Beatjump Controls in compact decks -->
+      <Template src="skin:/helpers/skin_settings_button_2state.xml">
+        <SetVariable name="TooltipId">show_beatjump_controls</SetVariable>
+        <SetVariable name="Text">Beatjump Controls</SetVariable>
+        <SetVariable name="Setting">[Skin],show_beatjump_controls_compact</SetVariable>
+      </Template>
+
+      <WidgetGroup><Size>0me,5f</Size></WidgetGroup>
 
       <!-- Rate Control -->
       <Template src="skin:/helpers/skin_settings_button_2state.xml">
@@ -57,14 +66,14 @@ Description:
         <SetVariable name="Setting">[VinylControl],show_vinylcontrol</SetVariable>
       </Template>
 
-      <WidgetGroup><Size>0me,6f</Size></WidgetGroup>
-
       <!-- Level meters -->
       <Template src="skin:/helpers/skin_settings_button_2state.xml">
         <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
         <SetVariable name="Text">VU meters</SetVariable>
         <SetVariable name="Setting">[Skin],show_vumeters_compact</SetVariable>
       </Template>
+
+      <WidgetGroup><Size>0me,5f</Size></WidgetGroup>
 
       <!-- Spinny -->
       <Template src="skin:/helpers/skin_settings_button_2state.xml">

--- a/res/skins/LateNight/helpers/skin_settings_full_deck.xml
+++ b/res/skins/LateNight/helpers/skin_settings_full_deck.xml
@@ -64,7 +64,21 @@ Description:
         <SetVariable name="Setting">[Skin],show_intro_outro_cues</SetVariable>
       </Template>
 
-      <WidgetGroup><Size>0me,6f</Size></WidgetGroup>
+      <!-- Loop Controls -->
+      <Template src="skin:/helpers/skin_settings_button_2state.xml">
+        <SetVariable name="TooltipId">show_loop_controls</SetVariable>
+        <SetVariable name="Text">Loop Controls</SetVariable>
+        <SetVariable name="Setting">[Skin],show_loop_controls</SetVariable>
+      </Template>
+
+      <!-- Beatjump Controls -->
+      <Template src="skin:/helpers/skin_settings_button_2state.xml">
+        <SetVariable name="TooltipId">show_beatjump_controls</SetVariable>
+        <SetVariable name="Text">Beatjump Controls</SetVariable>
+        <SetVariable name="Setting">[Skin],show_beatjump_controls</SetVariable>
+      </Template>
+
+      <WidgetGroup><Size>0me,5f</Size></WidgetGroup>
 
       <!-- Rate Controls -->
       <Template src="skin:/helpers/skin_settings_button_2state.xml">
@@ -105,7 +119,7 @@ Description:
         <SetVariable name="Setting">[VinylControl],show_vinylcontrol</SetVariable>
       </Template>
 
-      <WidgetGroup><Size>0me,6f</Size></WidgetGroup>
+      <WidgetGroup><Size>0me,5f</Size></WidgetGroup>
 
       <!-- Spinny -->
       <Template src="skin:/helpers/skin_settings_button_2state.xml">

--- a/res/skins/LateNight/helpers/skin_settings_mini_deck.xml
+++ b/res/skins/LateNight/helpers/skin_settings_mini_deck.xml
@@ -9,7 +9,7 @@ Description:
     <Layout>vertical</Layout>
     <Children>
 
-      <WidgetGroup><Size>0me,120f</Size></WidgetGroup>
+      <WidgetGroup><Size>0me,154f</Size></WidgetGroup>
 
       <!-- Spinny -->
       <Template src="skin:/helpers/skin_settings_button_2state.xml">

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -48,6 +48,8 @@
       <attribute persist="true" config_key="[Skin],show_hotcues">1</attribute>
       <attribute persist="true" config_key="[Skin],show_8_hotcues">1</attribute>
       <attribute persist="true" config_key="[Skin],show_intro_outro_cues">1</attribute>
+      <attribute persist="true" config_key="[Skin],show_loop_controls">1</attribute>
+      <attribute persist="true" config_key="[Skin],show_beatjump_controls">1</attribute>
       <attribute persist="true" config_key="[Skin],show_spinnies">1</attribute>
       <attribute persist="true" config_key="[Skin],show_coverart">1</attribute>
       <attribute persist="true" config_key="[Skin],show_big_spinny_coverart">0</attribute>
@@ -63,7 +65,8 @@
       <attribute persist="true" config_key="[Skin],show_beatgrid_controls">1</attribute>
       <!-- Compact deck -->
       <attribute persist="true" config_key="[Skin],show_rate_controls_compact">1</attribute>
-      <attribute persist="true" config_key="[Skin],show_loopjump_controls_compact">1</attribute>
+      <attribute persist="true" config_key="[Skin],show_loop_controls_compact">1</attribute>
+      <attribute persist="true" config_key="[Skin],show_beatjump_controls_compact">1</attribute>
       <attribute persist="true" config_key="[Skin],show_sync_button_compact">1</attribute>
       <attribute persist="true" config_key="[Skin],show_key_controls">1</attribute>
       <attribute persist="true" config_key="[Skin],show_key_controls_compact">1</attribute>

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -28,7 +28,7 @@ Description:
           <!-- Decks -->
           <WidgetGroup>
             <Layout>horizontal</Layout>
-            <Size>0me,1min</Size>
+            <Size>0me,23min</Size>
             <Children>
               <Label>
                 <ObjectName>CategoryLabel</ObjectName>

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -254,7 +254,7 @@ WSearchLineEdit,
     max-height: 2px;
   }
   #SkinSettingsSeparator {
-    margin: 3px 4px 7px 4px;
+    margin: 1px 4px 3px 4px;
   }
 
 WBeatSpinBox,

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -318,7 +318,7 @@ WSearchLineEdit {
     margin: 0px 5px;
   }
   #SkinSettingsSeparator {
-    margin: 3px 4px 7px 4px;
+    margin: 1px 4px 3px 4px;
   }
 
 /* dynamic bottom border in #DeckRow1_ */

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -446,6 +446,14 @@ void Tooltips::addStandardTooltips() {
     add("hotcue_toggle")
             << tr("Changes the number of hotcue buttons displayed in the deck");
 
+    // Show Loop Controls
+    add("show_loop_controls")
+            << tr("Toggle visibility of Loop Controls");
+
+    // Show Beatjump Controls
+    add("show_beatjump_controls")
+            << tr("Toggle visibility of Beatjump Controls");
+
     // Show Rate Control
     add("rate_toggle")
             << tr("Toggle visibility of Rate Control");


### PR DESCRIPTION
Add tooltip strings for loop controls and beatjump controls toggles.
Add toggles toLateNight skin settings to toggle visibility of loop controls and beatjump controls.
Adapt layout of skin settings to avoid hiding items when mixxx window has minimum size.