### PR TITLE
WTrackMenu: show 'Update ReplayGain' only in decks' menus

### DIFF
--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -388,9 +388,9 @@ void WTrackMenu::createActions() {
     // for WTrackmenu instantiated by WTrackProperty and other deck widgets, thus
     // don't create it if a track model is set.
     if (!m_pTrackModel && featureIsEnabled(Feature::UpdateReplayGain)) {
-        m_pUpdateReplayGain =
+        m_pUpdateReplayGainAct =
                 new QAction(tr("Update ReplayGain from Deck Gain"), m_pClearMetadataMenu);
-        connect(m_pUpdateReplayGain,
+        connect(m_pUpdateReplayGainAct,
                 &QAction::triggered,
                 this,
                 &WTrackMenu::slotUpdateReplayGainFromPregain);
@@ -531,8 +531,8 @@ void WTrackMenu::setupActions() {
 
     // This action is created only for menus instantiated by deck widgets (e.g.
     // WTrackProperty) and if UpdateReplayGain is supported.
-    if (m_pUpdateReplayGain) {
-        addAction(m_pUpdateReplayGain);
+    if (m_pUpdateReplayGainAct) {
+        addAction(m_pUpdateReplayGainAct);
     }
 
     addSeparator();
@@ -771,8 +771,8 @@ void WTrackMenu::updateMenus() {
     // This action is created only for menus instantiated by deck widgets (e.g.
     // WTrackProperty) and if UpdateReplayGain is supported.
     // Disable it if no deck group was set.
-    if (m_pUpdateReplayGain) {
-        m_pUpdateReplayGain->setEnabled(!m_deckGroup.isEmpty());
+    if (m_pUpdateReplayGainAct) {
+        m_pUpdateReplayGainAct->setEnabled(!m_deckGroup.isEmpty());
     }
 
     if (featureIsEnabled(Feature::Color)) {

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -384,7 +384,10 @@ void WTrackMenu::createActions() {
                 &WTrackMenu::slotClearBeats);
     }
 
-    if (featureIsEnabled(Feature::UpdateReplayGain)) {
+    // This action is only usable when m_deckGroup is set. That is true only
+    // for WTrackmenu instantiated by WTrackProperty and other deck widgets, thus
+    // don't create it if a track model is set.
+    if (!m_pTrackModel && featureIsEnabled(Feature::UpdateReplayGain)) {
         m_pUpdateReplayGain =
                 new QAction(tr("Update ReplayGain from Deck Gain"), m_pClearMetadataMenu);
         connect(m_pUpdateReplayGain,
@@ -526,7 +529,9 @@ void WTrackMenu::setupActions() {
         addMenu(m_pClearMetadataMenu);
     }
 
-    if (featureIsEnabled(Feature::UpdateReplayGain)) {
+    // This action is created only for menus instantiated by deck widgets (e.g.
+    // WTrackProperty) and if UpdateReplayGain is supported.
+    if (m_pUpdateReplayGain) {
         addAction(m_pUpdateReplayGain);
     }
 
@@ -763,7 +768,10 @@ void WTrackMenu::updateMenus() {
         }
     }
 
-    if (featureIsEnabled(Feature::UpdateReplayGain)) {
+    // This action is created only for menus instantiated by deck widgets (e.g.
+    // WTrackProperty) and if UpdateReplayGain is supported.
+    // Disable it if no deck group was set.
+    if (m_pUpdateReplayGain) {
         m_pUpdateReplayGain->setEnabled(!m_deckGroup.isEmpty());
     }
 

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -2106,8 +2106,6 @@ bool WTrackMenu::featureIsEnabled(Feature flag) const {
         return m_pTrackModel->hasCapabilities(TrackModel::Capability::EditMetadata);
     case Feature::SearchRelated:
         return m_pLibrary != nullptr;
-    case Feature::UpdateReplayGain:
-        return m_pTrackModel->hasCapabilities(TrackModel::Capability::EditMetadata);
     default:
         DEBUG_ASSERT(!"unreachable");
         return false;

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -387,7 +387,7 @@ void WTrackMenu::createActions() {
     // This action is only usable when m_deckGroup is set. That is true only
     // for WTrackmenu instantiated by WTrackProperty and other deck widgets, thus
     // don't create it if a track model is set.
-    if (!m_pTrackModel && featureIsEnabled(Feature::UpdateReplayGain)) {
+    if (!m_pTrackModel && featureIsEnabled(Feature::UpdateReplayGainFromPregain)) {
         m_pUpdateReplayGainAct =
                 new QAction(tr("Update ReplayGain from Deck Gain"), m_pClearMetadataMenu);
         connect(m_pUpdateReplayGainAct,
@@ -530,7 +530,7 @@ void WTrackMenu::setupActions() {
     }
 
     // This action is created only for menus instantiated by deck widgets (e.g.
-    // WTrackProperty) and if UpdateReplayGain is supported.
+    // WTrackProperty) and if UpdateReplayGainFromPregain is supported.
     if (m_pUpdateReplayGainAct) {
         addAction(m_pUpdateReplayGainAct);
     }
@@ -769,7 +769,7 @@ void WTrackMenu::updateMenus() {
     }
 
     // This action is created only for menus instantiated by deck widgets (e.g.
-    // WTrackProperty) and if UpdateReplayGain is supported.
+    // WTrackProperty) and if UpdateReplayGainFromPregain is supported.
     // Disable it if no deck group was set.
     if (m_pUpdateReplayGainAct) {
         m_pUpdateReplayGainAct->setEnabled(!m_deckGroup.isEmpty());

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -49,11 +49,11 @@ class WTrackMenu : public QMenu {
         FileBrowser = 1 << 11,
         Properties = 1 << 12,
         SearchRelated = 1 << 13,
-        UpdateReplayGain = 1 << 14,
+        UpdateReplayGainFromPregain = 1 << 14,
         TrackModelFeatures = Remove | HideUnhidePurge,
         All = AutoDJ | LoadTo | Playlist | Crate | Remove | Metadata | Reset |
                 BPM | Color | HideUnhidePurge | RemoveFromDisk | FileBrowser |
-                Properties | SearchRelated | UpdateReplayGain
+                Properties | SearchRelated | UpdateReplayGainFromPregain
     };
     Q_DECLARE_FLAGS(Features, Feature)
 

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -289,14 +289,15 @@ class WTrackMenu : public QMenu {
     struct UpdateExternalTrackCollection {
         QPointer<ExternalTrackCollection> externalTrackCollection;
         QAction* action{};
-        };
-        QList<UpdateExternalTrackCollection> m_updateInExternalTrackCollections;
-
-        bool m_bPlaylistMenuLoaded;
-        bool m_bCrateMenuLoaded;
-
-        Features m_eActiveFeatures;
-        const Features m_eTrackModelFeatures;
     };
+
+    QList<UpdateExternalTrackCollection> m_updateInExternalTrackCollections;
+
+    bool m_bPlaylistMenuLoaded;
+    bool m_bCrateMenuLoaded;
+
+    Features m_eActiveFeatures;
+    const Features m_eTrackModelFeatures;
+};
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(WTrackMenu::Features)

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -220,7 +220,7 @@ class WTrackMenu : public QMenu {
     QMenu* m_pRemoveFromDiskMenu{};
 
     // Update ReplayGain from Track
-    QAction* m_pUpdateReplayGain{};
+    QAction* m_pUpdateReplayGainAct{};
 
     // Reload Track Metadata Action:
     QAction* m_pImportMetadataFromFileAct{};

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -21,7 +21,7 @@ constexpr WTrackMenu::Features kTrackMenuFeatures =
         WTrackMenu::Feature::RemoveFromDisk |
         WTrackMenu::Feature::FileBrowser |
         WTrackMenu::Feature::Properties |
-        WTrackMenu::Feature::UpdateReplayGain;
+        WTrackMenu::Feature::UpdateReplayGainFromPregain;
 } // namespace
 
 WTrackProperty::WTrackProperty(

--- a/src/widget/wtracktext.cpp
+++ b/src/widget/wtracktext.cpp
@@ -20,7 +20,7 @@ constexpr WTrackMenu::Features kTrackMenuFeatures =
         WTrackMenu::Feature::Color |
         WTrackMenu::Feature::FileBrowser |
         WTrackMenu::Feature::Properties |
-        WTrackMenu::Feature::UpdateReplayGain;
+        WTrackMenu::Feature::UpdateReplayGainFromPregain;
 } // namespace
 
 WTrackText::WTrackText(QWidget* pParent,

--- a/src/widget/wtrackwidgetgroup.cpp
+++ b/src/widget/wtrackwidgetgroup.cpp
@@ -24,7 +24,7 @@ constexpr WTrackMenu::Features kTrackMenuFeatures =
         WTrackMenu::Feature::Color |
         WTrackMenu::Feature::FileBrowser |
         WTrackMenu::Feature::Properties |
-        WTrackMenu::Feature::UpdateReplayGain;
+        WTrackMenu::Feature::UpdateReplayGainFromPregain;
 
 } // anonymous namespace
 


### PR DESCRIPTION
It's confusing that the "Update ReplayGain" action is shown in the track table menu but always greyed out (and it's pointless there anyway because the menu is not related to a deck).

This also reverts 576e2cf97fbdb1e2e17ed5bb921f31158e4d0667
It's okay to debug assert if a model is asked about a unsupported feature -- that line is never reached if we check for `!m_pTrackModel` when creating the "Update ReplayGain" action

@ywwg What do you think?

- [ ] improve "Update ReplayGain" discoverability by mentioning it in the `gain` tooltip?