### PR TITLE
Pref controller: prevent false-positive 'dirty' flag

### DIFF
--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -8,7 +8,6 @@
 #include <QStandardPaths>
 #include <QTableWidget>
 #include <QTableWidgetItem>
-#include <QtDebug>
 
 #include "controllers/controller.h"
 #include "controllers/controllerlearningeventfilter.h"

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -45,6 +45,7 @@ DlgPrefController::DlgPrefController(QWidget* parent,
           m_pInputProxyModel(nullptr),
           m_pOutputTableModel(nullptr),
           m_pOutputProxyModel(nullptr),
+          m_GuiInitialized(false),
           m_bDirty(false) {
     m_ui.setupUi(this);
     // Create text color for the file and wiki links
@@ -451,8 +452,8 @@ void DlgPrefController::slotUpdate() {
     enumeratePresets(m_pControllerManager->getConfiguredPresetFileForDevice(
             m_pController->getName()));
 
-    // enumeratePresets will check the m_ui.chkEnabledDevice checkbox if
-    // there is a valid mapping saved in the mixxx.cfg file. However, the
+    // enumeratePresets calls slotPresetSelected which will check the m_ui.chkEnabledDevice
+    // checkbox if there is a valid mapping saved in the mixxx.cfg file. However, the
     // checkbox should only be checked if the device is currently enabled.
     m_ui.chkEnabledDevice->setChecked(m_pController->isOpen());
 
@@ -462,6 +463,9 @@ void DlgPrefController::slotUpdate() {
     m_ui.btnLearningWizard->setEnabled(isMappable);
     m_ui.inputMappingsTab->setEnabled(isMappable);
     m_ui.outputMappingsTab->setEnabled(isMappable);
+    // When slotUpdate() is run for the first time, this bool keeps slotPresetSelected()
+    // from setting a false-postive 'dirty' flag when updating the fresh GUI.
+    m_GuiInitialized = true;
 }
 
 void DlgPrefController::slotResetToDefaults() {
@@ -532,21 +536,23 @@ QString DlgPrefController::presetPathFromIndex(int index) const {
 
 void DlgPrefController::slotPresetSelected(int chosenIndex) {
     QString presetPath = presetPathFromIndex(chosenIndex);
-    if (presetPath.isEmpty()) {
-        // User picked "No Preset" item
+    if (presetPath.isEmpty()) { // User picked "No Preset" item
         m_ui.chkEnabledDevice->setEnabled(false);
 
         if (m_ui.chkEnabledDevice->isChecked()) {
             m_ui.chkEnabledDevice->setChecked(false);
-            setDirty(true);
+            if (m_GuiInitialized) {
+                setDirty(true);
+            }
         }
-    } else {
-        // User picked a preset
+    } else { // User picked a preset
         m_ui.chkEnabledDevice->setEnabled(true);
 
         if (!m_ui.chkEnabledDevice->isChecked()) {
             m_ui.chkEnabledDevice->setChecked(true);
-            setDirty(true);
+            if (m_GuiInitialized) {
+                setDirty(true);
+            }
         }
     }
 

--- a/src/controllers/dlgprefcontroller.h
+++ b/src/controllers/dlgprefcontroller.h
@@ -117,5 +117,6 @@ class DlgPrefController : public DlgPreferencePage {
     QSortFilterProxyModel* m_pInputProxyModel;
     ControllerOutputMappingTableModel* m_pOutputTableModel;
     QSortFilterProxyModel* m_pOutputProxyModel;
+    bool m_GuiInitialized;
     bool m_bDirty;
 };

--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -81,9 +81,6 @@ void DlgPrefControllers::slotOpenLocalFile(const QString& file) {
 }
 
 void DlgPrefControllers::slotUpdate() {
-    for (DlgPrefController* pControllerDlg : qAsConst(m_controllerPages)) {
-        pControllerDlg->slotUpdate();
-    }
 }
 
 void DlgPrefControllers::slotCancel() {


### PR DESCRIPTION
Less headaches, finally.
Fixes https://bugs.launchpad.net/mixxx/+bug/1920844
Current behaviour is annoying if you use a mapping script `init()` to initialize deck / mixer / effect controls because those controls get re-initialized (= reset) when clicking Okay in the Preferences,.. which was kicking me 'off my horse' during live sets more than once.

See first commit for details.