### PR TITLE
Library: keep hidden tracks in history

### DIFF
--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -757,6 +757,10 @@ void PlaylistDAO::removeTracksFromPlaylists(const QList<TrackId>& trackIds) {
                 it != playlistsTrackIsInCopy.constEnd(); ++it) {
             if (it.key() == trackId) {
                 const auto playlistId = it.value();
+                // keep tracks in history playlists
+                if (getHiddenType(playlistId) == PlaylistDAO::PLHT_SET_LOG) {
+                    continue;
+                }
                 removeTracksFromPlaylistByIdInner(playlistId, trackId);
                 playlistIds.insert(playlistId);
             }


### PR DESCRIPTION
Remove hidden tracks from playlists but keep them in the history.

https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/Hidden.20tracks.20in.20playlists.20.2F.20crates.20.2Fhistory

Interestingly the counterpart to **not** remove hidden tracks when setting the History table model is already in place:
https://github.com/mixxxdj/mixxx/blob/5b6e2e032e88d5dcd77a5c65c528611c8e4a352c/src/library/setlogfeature.cpp#L22-L33
https://github.com/mixxxdj/mixxx/blob/5b6e2e032e88d5dcd77a5c65c528611c8e4a352c/src/library/playlisttablemodel.cpp#L113-L128