### PR TITLE
add History cleanup options

### DIFF
--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -16,6 +16,7 @@
 #include "engine/enginemaster.h"
 #include "library/coverartcache.h"
 #include "library/library.h"
+#include "library/library_prefs.h"
 #include "library/trackcollection.h"
 #include "library/trackcollectionmanager.h"
 #include "mixer/playerinfo.h"
@@ -375,7 +376,7 @@ void CoreServices::initialize(QApplication* pApp) {
 
     // Scan the library for new files and directories
     bool rescan = pConfig->getValue<bool>(
-            ConfigKey("[Library]", "RescanOnStartup"));
+            library::prefs::kRescanOnStartupConfigKey);
     // rescan the library if we get a new plugin
     QList<QString> prev_plugins_list =
             pConfig->getValueString(

--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -227,27 +227,18 @@ void PlaylistDAO::deletePlaylist(const int playlistId) {
     }
 }
 
-int PlaylistDAO::deleteAllPlaylistsWithFewerTracks(
-        PlaylistDAO::HiddenType type, int minNumberOfTracks, bool keepLockedPlaylists) {
+int PlaylistDAO::deleteAllUnlockedPlaylistsWithFewerTracks(
+        PlaylistDAO::HiddenType type, int minNumberOfTracks) {
     VERIFY_OR_DEBUG_ASSERT(minNumberOfTracks > 0) {
         return 0; // nothing to do, probably unintended invocation
     }
 
     QSqlQuery query(m_database);
-    if (keepLockedPlaylists) { // delete only unlocked playlists
-        query.prepare(QStringLiteral(
-                "SELECT id FROM Playlists  "
-                "WHERE (SELECT count(playlist_id) FROM PlaylistTracks WHERE "
-                "Playlists.ID = PlaylistTracks.playlist_id) < :length AND "
-                "Playlists.hidden = :hidden AND Playlists.locked = :locked"));
-        query.bindValue(":locked", 0);
-    } else { // delete ALL playlists
-        query.prepare(QStringLiteral(
-                "SELECT id FROM Playlists  "
-                "WHERE (SELECT count(playlist_id) FROM PlaylistTracks WHERE "
-                "Playlists.ID = PlaylistTracks.playlist_id) < :length AND "
-                "Playlists.hidden = :hidden"));
-    }
+    query.prepare(QStringLiteral(
+            "SELECT id FROM Playlists  "
+            "WHERE (SELECT count(playlist_id) FROM PlaylistTracks WHERE "
+            "Playlists.ID = PlaylistTracks.playlist_id) < :length AND "
+            "Playlists.hidden = :hidden AND Playlists.locked = 0"));
     query.bindValue(":hidden", static_cast<int>(type));
     query.bindValue(":length", minNumberOfTracks);
     if (!query.exec()) {

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -58,7 +58,9 @@ class PlaylistDAO : public QObject, public virtual DAO {
     /// Delete Playlists with fewer entries then "length"
     /// Needs to be called inside a transaction.
     /// @return number of deleted playlists, -1 on error
-    int deleteAllPlaylistsWithFewerTracks(PlaylistDAO::HiddenType type, int minNumberOfTracks);
+    int deleteAllPlaylistsWithFewerTracks(PlaylistDAO::HiddenType type,
+            int minNumberOfTracks,
+            bool keepLockedPlaylists = false);
     // Rename a playlist
     void renamePlaylist(const int playlistId, const QString& newName);
     // Lock or unlock a playlist

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -58,9 +58,8 @@ class PlaylistDAO : public QObject, public virtual DAO {
     /// Delete Playlists with fewer entries then "length"
     /// Needs to be called inside a transaction.
     /// @return number of deleted playlists, -1 on error
-    int deleteAllPlaylistsWithFewerTracks(PlaylistDAO::HiddenType type,
-            int minNumberOfTracks,
-            bool keepLockedPlaylists = false);
+    int deleteAllUnlockedPlaylistsWithFewerTracks(PlaylistDAO::HiddenType type,
+            int minNumberOfTracks);
     // Rename a playlist
     void renamePlaylist(const int playlistId, const QString& newName);
     // Lock or unlock a playlist

--- a/src/library/library_prefs.cpp
+++ b/src/library/library_prefs.cpp
@@ -13,15 +13,35 @@ const ConfigKey mixxx::library::prefs::kLegacyDirectoryConfigKey =
 const QString mixxx::library::prefs::kConfigGroup =
         QStringLiteral("[Library]");
 
+const ConfigKey mixxx::library::prefs::kRescanOnStartupConfigKey =
+        ConfigKey{
+                mixxx::library::prefs::kConfigGroup,
+                QStringLiteral("RescanOnStartup")};
+
 const ConfigKey mixxx::library::prefs::kKeyNotationConfigKey =
         ConfigKey{
                 mixxx::library::prefs::kConfigGroup,
                 QStringLiteral("key_notation")};
 
+const ConfigKey mixxx::library::prefs::kTrackDoubleClickActionConfigKey =
+        ConfigKey{
+                mixxx::library::prefs::kConfigGroup,
+                QStringLiteral("TrackLoadAction")};
+
 const ConfigKey mixxx::library::prefs::kEditMetadataSelectedClickConfigKey =
         ConfigKey{
                 mixxx::library::prefs::kConfigGroup,
                 QStringLiteral("EditMetadataSelectedClick")};
+
+const ConfigKey mixxx::library::prefs::kHistoryCleanupMinTracksConfigKey =
+        ConfigKey{
+                mixxx::library::prefs::kConfigGroup,
+                QStringLiteral("history_cleanup_min_tracks")};
+
+const ConfigKey mixxx::library::prefs::kHistoryCleanupKeepLockedConfigKey =
+        ConfigKey{
+                mixxx::library::prefs::kConfigGroup,
+                QStringLiteral("history_cleanup_keep_locked")};
 
 const ConfigKey mixxx::library::prefs::kSearchDebouncingTimeoutMillisConfigKey =
         ConfigKey{
@@ -39,3 +59,8 @@ const ConfigKey mixxx::library::prefs::kSyncSeratoMetadataConfigKey =
         ConfigKey{
                 mixxx::library::prefs::kConfigGroup,
                 QStringLiteral("SeratoMetadataExport")};
+
+const ConfigKey mixxx::library::prefs::kUseRelativePathOnExportConfigKey =
+        ConfigKey{
+                mixxx::library::prefs::kConfigGroup,
+                QStringLiteral("UseRelativePathOnExport")};

--- a/src/library/library_prefs.cpp
+++ b/src/library/library_prefs.cpp
@@ -38,11 +38,6 @@ const ConfigKey mixxx::library::prefs::kHistoryCleanupMinTracksConfigKey =
                 mixxx::library::prefs::kConfigGroup,
                 QStringLiteral("history_cleanup_min_tracks")};
 
-const ConfigKey mixxx::library::prefs::kHistoryCleanupKeepLockedConfigKey =
-        ConfigKey{
-                mixxx::library::prefs::kConfigGroup,
-                QStringLiteral("history_cleanup_keep_locked")};
-
 const ConfigKey mixxx::library::prefs::kHistoryRecentlyPlayedThresholdConfigKey =
         ConfigKey{
                 mixxx::library::prefs::kConfigGroup,

--- a/src/library/library_prefs.cpp
+++ b/src/library/library_prefs.cpp
@@ -43,6 +43,11 @@ const ConfigKey mixxx::library::prefs::kHistoryCleanupKeepLockedConfigKey =
                 mixxx::library::prefs::kConfigGroup,
                 QStringLiteral("history_cleanup_keep_locked")};
 
+const ConfigKey mixxx::library::prefs::kHistoryRecentlyPlayedThresholdConfigKey =
+        ConfigKey{
+                mixxx::library::prefs::kConfigGroup,
+                QStringLiteral("history_recently_played_threshold")};
+
 const ConfigKey mixxx::library::prefs::kSearchDebouncingTimeoutMillisConfigKey =
         ConfigKey{
                 mixxx::library::prefs::kConfigGroup,

--- a/src/library/library_prefs.cpp
+++ b/src/library/library_prefs.cpp
@@ -33,10 +33,10 @@ const ConfigKey mixxx::library::prefs::kEditMetadataSelectedClickConfigKey =
                 mixxx::library::prefs::kConfigGroup,
                 QStringLiteral("EditMetadataSelectedClick")};
 
-const ConfigKey mixxx::library::prefs::kHistoryCleanupMinTracksConfigKey =
+const ConfigKey mixxx::library::prefs::kHistoryMinTracksToKeepConfigKey =
         ConfigKey{
                 mixxx::library::prefs::kConfigGroup,
-                QStringLiteral("history_cleanup_min_tracks")};
+                QStringLiteral("history_min_tracks_to_keep")};
 
 const ConfigKey mixxx::library::prefs::kHistoryTrackDuplicateDistanceConfigKey =
         ConfigKey{

--- a/src/library/library_prefs.cpp
+++ b/src/library/library_prefs.cpp
@@ -38,10 +38,10 @@ const ConfigKey mixxx::library::prefs::kHistoryCleanupMinTracksConfigKey =
                 mixxx::library::prefs::kConfigGroup,
                 QStringLiteral("history_cleanup_min_tracks")};
 
-const ConfigKey mixxx::library::prefs::kHistoryRecentlyPlayedThresholdConfigKey =
+const ConfigKey mixxx::library::prefs::kHistoryTrackDuplicateDistanceConfigKey =
         ConfigKey{
                 mixxx::library::prefs::kConfigGroup,
-                QStringLiteral("history_recently_played_threshold")};
+                QStringLiteral("history_track_duplicate_distance")};
 
 const ConfigKey mixxx::library::prefs::kSearchDebouncingTimeoutMillisConfigKey =
         ConfigKey{

--- a/src/library/library_prefs.h
+++ b/src/library/library_prefs.h
@@ -26,6 +26,10 @@ extern const ConfigKey kHistoryCleanupMinTracksConfigKey;
 
 extern const ConfigKey kHistoryCleanupKeepLockedConfigKey;
 
+extern const ConfigKey kHistoryRecentlyPlayedThresholdConfigKey;
+
+const int kHistoryRecentlyPlayedThresholdDefault = 6;
+
 const bool kEditMetadataSelectedClickDefault = false;
 
 extern const ConfigKey kSyncTrackMetadataConfigKey;

--- a/src/library/library_prefs.h
+++ b/src/library/library_prefs.h
@@ -22,7 +22,9 @@ extern const ConfigKey kSearchDebouncingTimeoutMillisConfigKey;
 
 extern const ConfigKey kEditMetadataSelectedClickConfigKey;
 
-extern const ConfigKey kHistoryCleanupMinTracksConfigKey;
+extern const ConfigKey kHistoryMinTracksToKeepConfigKey;
+
+const int kHistoryMinTracksToKeepDefault = 1;
 
 extern const ConfigKey kHistoryTrackDuplicateDistanceConfigKey;
 

--- a/src/library/library_prefs.h
+++ b/src/library/library_prefs.h
@@ -24,9 +24,9 @@ extern const ConfigKey kEditMetadataSelectedClickConfigKey;
 
 extern const ConfigKey kHistoryCleanupMinTracksConfigKey;
 
-extern const ConfigKey kHistoryRecentlyPlayedThresholdConfigKey;
+extern const ConfigKey kHistoryTrackDuplicateDistanceConfigKey;
 
-const int kHistoryRecentlyPlayedThresholdDefault = 6;
+const int kHistoryTrackDuplicateDistanceDefault = 6;
 
 const bool kEditMetadataSelectedClickDefault = false;
 

--- a/src/library/library_prefs.h
+++ b/src/library/library_prefs.h
@@ -12,11 +12,19 @@ extern const ConfigKey kLegacyDirectoryConfigKey;
 
 extern const QString kConfigGroup;
 
+extern const ConfigKey kRescanOnStartupConfigKey;
+
 extern const ConfigKey kKeyNotationConfigKey;
+
+extern const ConfigKey kTrackDoubleClickActionConfigKey;
 
 extern const ConfigKey kSearchDebouncingTimeoutMillisConfigKey;
 
 extern const ConfigKey kEditMetadataSelectedClickConfigKey;
+
+extern const ConfigKey kHistoryCleanupMinTracksConfigKey;
+
+extern const ConfigKey kHistoryCleanupKeepLockedConfigKey;
 
 const bool kEditMetadataSelectedClickDefault = false;
 
@@ -25,6 +33,8 @@ extern const ConfigKey kSyncTrackMetadataConfigKey;
 extern const ConfigKey kSyncSeratoMetadataConfigKey;
 
 extern const ConfigKey kSyncSeratoMetadataConfigKey;
+
+extern const ConfigKey kUseRelativePathOnExportConfigKey;
 
 } // namespace prefs
 

--- a/src/library/library_prefs.h
+++ b/src/library/library_prefs.h
@@ -24,8 +24,6 @@ extern const ConfigKey kEditMetadataSelectedClickConfigKey;
 
 extern const ConfigKey kHistoryCleanupMinTracksConfigKey;
 
-extern const ConfigKey kHistoryCleanupKeepLockedConfigKey;
-
 extern const ConfigKey kHistoryRecentlyPlayedThresholdConfigKey;
 
 const int kHistoryRecentlyPlayedThresholdDefault = 6;

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -7,6 +7,7 @@
 #include "controllers/keyboard/keyboardeventfilter.h"
 #include "library/export/trackexportwizard.h"
 #include "library/library.h"
+#include "library/library_prefs.h"
 #include "library/parser.h"
 #include "library/parsercsv.h"
 #include "library/parserm3u.h"
@@ -30,6 +31,8 @@ const ConfigKey kConfigKeyLastImportExportPlaylistDirectory(
         "[Library]", "LastImportExportPlaylistDirectory");
 
 } // anonymous namespace
+
+using namespace mixxx::library::prefs;
 
 BasePlaylistFeature::BasePlaylistFeature(
         Library* pLibrary,
@@ -568,7 +571,7 @@ void BasePlaylistFeature::slotExportPlaylist() {
 
     // check config if relative paths are desired
     bool useRelativePath = m_pConfig->getValue<bool>(
-            ConfigKey("[Library]", "UseRelativePathOnExport"));
+            kUseRelativePathOnExportConfigKey);
 
     if (fileLocation.endsWith(".csv", Qt::CaseInsensitive)) {
         ParserCsv::writeCSVFile(fileLocation, pPlaylistTableModel.data(), useRelativePath);

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -9,6 +9,7 @@
 
 #include "library/export/trackexportwizard.h"
 #include "library/library.h"
+#include "library/library_prefs.h"
 #include "library/parser.h"
 #include "library/parsercsv.h"
 #include "library/parserm3u.h"
@@ -41,6 +42,8 @@ const ConfigKey kConfigKeyLastImportExportCrateDirectoryKey(
         "[Library]", "LastImportExportCrateDirectory");
 
 } // anonymous namespace
+
+using namespace mixxx::library::prefs;
 
 CrateFeature::CrateFeature(Library* pLibrary,
         UserSettingsPointer pConfig)
@@ -739,7 +742,7 @@ void CrateFeature::slotExportPlaylist() {
     // check config if relative paths are desired
     bool useRelativePath =
             m_pConfig->getValue<bool>(
-                    ConfigKey("[Library]", "UseRelativePathOnExport"));
+                    kUseRelativePathOnExportConfigKey);
 
     // Create list of files of the crate
     // Create a new table model since the main one might have an active search.

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -6,6 +6,7 @@
 
 #include "control/controlobject.h"
 #include "library/library.h"
+#include "library/library_prefs.h"
 #include "library/playlisttablemodel.h"
 #include "library/queryutil.h"
 #include "library/trackcollection.h"
@@ -22,6 +23,8 @@
 namespace {
 constexpr int kNumToplevelHistoryEntries = 5;
 }
+
+using namespace mixxx::library::prefs;
 
 SetlogFeature::SetlogFeature(
         Library* pLibrary,
@@ -93,9 +96,9 @@ void SetlogFeature::deleteAllPlaylistsWithFewerTracks() {
                                           ->internalCollection()
                                           ->database());
     int minTrackCount = m_pConfig->getValue(
-            ConfigKey("[Library]", "history_cleanup_min_tracks"), 1);
+            kHistoryCleanupMinTracksConfigKey, 1);
     bool keepLockedPlaylists = m_pConfig->getValue(
-            ConfigKey("[Library]", "history_cleanup_keep_locked"), false);
+            kHistoryCleanupKeepLockedConfigKey, false);
     m_playlistDao.deleteAllPlaylistsWithFewerTracks(PlaylistDAO::HiddenType::PLHT_SET_LOG,
             minTrackCount,
             keepLockedPlaylists);

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -43,7 +43,7 @@ SetlogFeature::SetlogFeature(
           m_pLibrary(pLibrary),
           m_pConfig(pConfig) {
     // remove unneeded entries
-    deleteAllPlaylistsWithFewerTracks();
+    deleteAllUnlockedPlaylistsWithFewerTracks();
 
     //construct child model
     m_pSidebarModel->setRootItem(TreeItem::newRoot(this));
@@ -74,7 +74,7 @@ SetlogFeature::~SetlogFeature() {
         m_playlistDao.deletePlaylist(m_playlistId);
     }
     // Also clean history up when shutting down in case the track threshold changed
-    deleteAllPlaylistsWithFewerTracks();
+    deleteAllUnlockedPlaylistsWithFewerTracks();
 }
 
 QVariant SetlogFeature::title() {
@@ -91,17 +91,14 @@ void SetlogFeature::bindLibraryWidget(
     m_libraryWidget = QPointer(libraryWidget);
 }
 
-void SetlogFeature::deleteAllPlaylistsWithFewerTracks() {
+void SetlogFeature::deleteAllUnlockedPlaylistsWithFewerTracks() {
     ScopedTransaction transaction(m_pLibrary->trackCollectionManager()
                                           ->internalCollection()
                                           ->database());
     int minTrackCount = m_pConfig->getValue(
             kHistoryCleanupMinTracksConfigKey, 1);
-    bool keepLockedPlaylists = m_pConfig->getValue(
-            kHistoryCleanupKeepLockedConfigKey, false);
-    m_playlistDao.deleteAllPlaylistsWithFewerTracks(PlaylistDAO::HiddenType::PLHT_SET_LOG,
-            minTrackCount,
-            keepLockedPlaylists);
+    m_playlistDao.deleteAllUnlockedPlaylistsWithFewerTracks(PlaylistDAO::HiddenType::PLHT_SET_LOG,
+            minTrackCount);
     transaction.commit();
 }
 

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -383,8 +383,8 @@ void SetlogFeature::slotPlayingTrackChanged(TrackPointer currentPlayingTrack) {
 
         // Keep a window of 6 tracks (inspired by 2 decks, 4 samplers)
         const unsigned int recentTrackWindow = m_pConfig->getValue(
-                kHistoryRecentlyPlayedThresholdConfigKey,
-                kHistoryRecentlyPlayedThresholdDefault);
+                kHistoryTrackDuplicateDistanceConfigKey,
+                kHistoryTrackDuplicateDistanceDefault);
         while (m_recentTracks.size() > recentTrackWindow) {
             m_recentTracks.pop_back();
         }

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -96,7 +96,8 @@ void SetlogFeature::deleteAllUnlockedPlaylistsWithFewerTracks() {
                                           ->internalCollection()
                                           ->database());
     int minTrackCount = m_pConfig->getValue(
-            kHistoryCleanupMinTracksConfigKey, 1);
+            kHistoryMinTracksToKeepConfigKey,
+            kHistoryMinTracksToKeepDefault);
     m_playlistDao.deleteAllUnlockedPlaylistsWithFewerTracks(PlaylistDAO::HiddenType::PLHT_SET_LOG,
             minTrackCount);
     transaction.commit();

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -94,8 +94,11 @@ void SetlogFeature::deleteAllPlaylistsWithFewerTracks() {
                                           ->database());
     int minTrackCount = m_pConfig->getValue(
             ConfigKey("[Library]", "history_cleanup_min_tracks"), 1);
+    bool keepLockedPlaylists = m_pConfig->getValue(
+            ConfigKey("[Library]", "history_cleanup_keep_locked"), false);
     m_playlistDao.deleteAllPlaylistsWithFewerTracks(PlaylistDAO::HiddenType::PLHT_SET_LOG,
-            minTrackCount);
+            minTrackCount,
+            keepLockedPlaylists);
     transaction.commit();
 }
 

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -385,8 +385,10 @@ void SetlogFeature::slotPlayingTrackChanged(TrackPointer currentPlayingTrack) {
         m_recentTracks.push_front(currentPlayingTrackId);
 
         // Keep a window of 6 tracks (inspired by 2 decks, 4 samplers)
-        constexpr int kRecentTrackWindow = 6;
-        while (m_recentTracks.size() > kRecentTrackWindow) {
+        const unsigned int recentTrackWindow = m_pConfig->getValue(
+                kHistoryRecentlyPlayedThresholdConfigKey,
+                kHistoryRecentlyPlayedThresholdDefault);
+        while (m_recentTracks.size() > recentTrackWindow) {
             m_recentTracks.pop_back();
         }
     }

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -296,6 +296,8 @@ void SetlogFeature::slotGetNewPlaylist() {
         qDebug() << "Setlog playlist Creation Failed";
         qDebug() << "An unknown error occurred while creating playlist: "
                  << set_log_name;
+    } else {
+        m_recentTracks.clear();
     }
 
     reloadChildModel(m_playlistId); // For moving selection

--- a/src/library/trackset/setlogfeature.h
+++ b/src/library/trackset/setlogfeature.h
@@ -42,7 +42,7 @@ class SetlogFeature : public BasePlaylistFeature {
     void slotPlaylistTableRenamed(int playlistId, const QString& newName) override;
 
   private:
-    void deleteAllPlaylistsWithFewerTracks();
+    void deleteAllUnlockedPlaylistsWithFewerTracks();
     void reloadChildModel(int playlistId);
     QString getRootViewHtml() const override;
 

--- a/src/library/trackset/setlogfeature.h
+++ b/src/library/trackset/setlogfeature.h
@@ -7,6 +7,8 @@
 #include "library/trackset/baseplaylistfeature.h"
 #include "preferences/usersettings.h"
 
+class Library;
+
 class SetlogFeature : public BasePlaylistFeature {
     Q_OBJECT
 
@@ -40,6 +42,7 @@ class SetlogFeature : public BasePlaylistFeature {
     void slotPlaylistTableRenamed(int playlistId, const QString& newName) override;
 
   private:
+    void deleteAllPlaylistsWithFewerTracks();
     void reloadChildModel(int playlistId);
     QString getRootViewHtml() const override;
 
@@ -48,4 +51,6 @@ class SetlogFeature : public BasePlaylistFeature {
     QAction* m_pStartNewPlaylist;
     int m_playlistId;
     QPointer<WLibrary> m_libraryWidget;
+    Library* m_pLibrary;
+    UserSettingsPointer m_pConfig;
 };

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -192,6 +192,7 @@ void DlgPrefLibrary::initializeDirList() {
 void DlgPrefLibrary::slotResetToDefaults() {
     checkBox_library_scan->setChecked(false);
     spinbox_min_history_tracks->setValue(1);
+    checkBox_history_cleanup_keep_locked->setChecked(false);
     checkBox_SyncTrackMetadata->setChecked(false);
     checkBox_SeratoMetadataExport->setChecked(false);
     checkBox_use_relative_path->setChecked(false);
@@ -217,6 +218,8 @@ void DlgPrefLibrary::slotUpdate() {
 
     spinbox_min_history_tracks->setValue(m_pConfig->getValue(
             ConfigKey("[Library]", "history_cleanup_min_tracks"), 1));
+    checkBox_history_cleanup_keep_locked->setChecked(m_pConfig->getValue(
+            ConfigKey("[Library]", "history_cleanup_keep_locked"), false));
 
     checkBox_SyncTrackMetadata->setChecked(
             m_pConfig->getValue(kSyncTrackMetadataConfigKey, false));
@@ -394,6 +397,8 @@ void DlgPrefLibrary::slotApply() {
 
     m_pConfig->set(ConfigKey("[Library]", "history_cleanup_min_tracks"),
             ConfigValue(spinbox_min_history_tracks->value()));
+    m_pConfig->set(ConfigKey("[Library]", "history_cleanup_keep_locked"),
+            ConfigValue((int)checkBox_history_cleanup_keep_locked->isChecked()));
 
     m_pConfig->set(
             kSyncTrackMetadataConfigKey,
@@ -401,6 +406,7 @@ void DlgPrefLibrary::slotApply() {
     m_pConfig->set(
             kSyncSeratoMetadataConfigKey,
             ConfigValue{checkBox_SeratoMetadataExport->isChecked()});
+
     m_pConfig->set(ConfigKey("[Library]","UseRelativePathOnExport"),
                 ConfigValue((int)checkBox_use_relative_path->isChecked()));
     m_pConfig->set(ConfigKey("[Library]","ShowRhythmboxLibrary"),
@@ -415,6 +421,7 @@ void DlgPrefLibrary::slotApply() {
                 ConfigValue((int)checkBox_show_rekordbox->isChecked()));
     m_pConfig->set(ConfigKey("[Library]", "ShowSeratoLibrary"),
             ConfigValue((int)checkBox_show_serato->isChecked()));
+
     int dbclick_status;
     if (radioButton_dbclick_bottom->isChecked()) {
         dbclick_status = static_cast<int>(TrackDoubleClickAction::AddToAutoDJBottom);

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -193,7 +193,7 @@ void DlgPrefLibrary::slotResetToDefaults() {
     checkBox_library_scan->setChecked(false);
     spinbox_history_track_duplicate_distance->setValue(
             kHistoryTrackDuplicateDistanceDefault);
-    spinbox_min_history_tracks->setValue(1);
+    spinbox_history_min_tracks_to_keep->setValue(1);
     checkBox_SyncTrackMetadata->setChecked(false);
     checkBox_SeratoMetadataExport->setChecked(false);
     checkBox_use_relative_path->setChecked(false);
@@ -220,8 +220,9 @@ void DlgPrefLibrary::slotUpdate() {
     spinbox_history_track_duplicate_distance->setValue(m_pConfig->getValue(
             kHistoryTrackDuplicateDistanceConfigKey,
             kHistoryTrackDuplicateDistanceDefault));
-    spinbox_min_history_tracks->setValue(m_pConfig->getValue(
-            kHistoryCleanupMinTracksConfigKey, 1));
+    spinbox_history_min_tracks_to_keep->setValue(m_pConfig->getValue(
+            kHistoryMinTracksToKeepConfigKey,
+            kHistoryMinTracksToKeepDefault));
 
     checkBox_SyncTrackMetadata->setChecked(
             m_pConfig->getValue(kSyncTrackMetadataConfigKey, false));
@@ -399,8 +400,8 @@ void DlgPrefLibrary::slotApply() {
 
     m_pConfig->set(kHistoryTrackDuplicateDistanceConfigKey,
             ConfigValue(spinbox_history_track_duplicate_distance->value()));
-    m_pConfig->set(kHistoryCleanupMinTracksConfigKey,
-            ConfigValue(spinbox_min_history_tracks->value()));
+    m_pConfig->set(kHistoryMinTracksToKeepConfigKey,
+            ConfigValue(spinbox_history_min_tracks_to_keep->value()));
 
     m_pConfig->set(
             kSyncTrackMetadataConfigKey,

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -191,6 +191,7 @@ void DlgPrefLibrary::initializeDirList() {
 
 void DlgPrefLibrary::slotResetToDefaults() {
     checkBox_library_scan->setChecked(false);
+    spinbox_min_history_tracks->setValue(1);
     checkBox_SyncTrackMetadata->setChecked(false);
     checkBox_SeratoMetadataExport->setChecked(false);
     checkBox_use_relative_path->setChecked(false);
@@ -213,12 +214,17 @@ void DlgPrefLibrary::slotUpdate() {
     initializeDirList();
     checkBox_library_scan->setChecked(m_pConfig->getValue(
             ConfigKey("[Library]","RescanOnStartup"), false));
+
+    spinbox_min_history_tracks->setValue(m_pConfig->getValue(
+            ConfigKey("[Library]", "history_cleanup_min_tracks"), 1));
+
     checkBox_SyncTrackMetadata->setChecked(
             m_pConfig->getValue(kSyncTrackMetadataConfigKey, false));
     checkBox_SeratoMetadataExport->setChecked(
             m_pConfig->getValue(kSyncSeratoMetadataConfigKey, false));
     checkBox_use_relative_path->setChecked(m_pConfig->getValue(
             ConfigKey("[Library]","UseRelativePathOnExport"), false));
+
     checkBox_show_rhythmbox->setChecked(m_pConfig->getValue(
             ConfigKey("[Library]","ShowRhythmboxLibrary"), true));
     checkBox_show_banshee->setChecked(m_pConfig->getValue(
@@ -245,8 +251,8 @@ void DlgPrefLibrary::slotUpdate() {
         radioButton_dbclick_ignore->setChecked(true);
         break;
     default:
-            radioButton_dbclick_deck->setChecked(true);
-            break;
+        radioButton_dbclick_deck->setChecked(true);
+        break;
     }
 
     bool editMetadataSelectedClick = m_pConfig->getValue(
@@ -385,6 +391,10 @@ void DlgPrefLibrary::slotSeratoMetadataExportClicked(bool checked) {
 void DlgPrefLibrary::slotApply() {
     m_pConfig->set(ConfigKey("[Library]","RescanOnStartup"),
                 ConfigValue((int)checkBox_library_scan->isChecked()));
+
+    m_pConfig->set(ConfigKey("[Library]", "history_cleanup_min_tracks"),
+            ConfigValue(spinbox_min_history_tracks->value()));
+
     m_pConfig->set(
             kSyncTrackMetadataConfigKey,
             ConfigValue{checkBox_SyncTrackMetadata->isChecked()});

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -214,19 +214,19 @@ void DlgPrefLibrary::slotResetToDefaults() {
 void DlgPrefLibrary::slotUpdate() {
     initializeDirList();
     checkBox_library_scan->setChecked(m_pConfig->getValue(
-            ConfigKey("[Library]","RescanOnStartup"), false));
+            kRescanOnStartupConfigKey, false));
 
     spinbox_min_history_tracks->setValue(m_pConfig->getValue(
-            ConfigKey("[Library]", "history_cleanup_min_tracks"), 1));
+            kHistoryCleanupMinTracksConfigKey, 1));
     checkBox_history_cleanup_keep_locked->setChecked(m_pConfig->getValue(
-            ConfigKey("[Library]", "history_cleanup_keep_locked"), false));
+            kHistoryCleanupKeepLockedConfigKey, false));
 
     checkBox_SyncTrackMetadata->setChecked(
             m_pConfig->getValue(kSyncTrackMetadataConfigKey, false));
     checkBox_SeratoMetadataExport->setChecked(
             m_pConfig->getValue(kSyncSeratoMetadataConfigKey, false));
     checkBox_use_relative_path->setChecked(m_pConfig->getValue(
-            ConfigKey("[Library]","UseRelativePathOnExport"), false));
+            kUseRelativePathOnExportConfigKey, false));
 
     checkBox_show_rhythmbox->setChecked(m_pConfig->getValue(
             ConfigKey("[Library]","ShowRhythmboxLibrary"), true));
@@ -242,7 +242,7 @@ void DlgPrefLibrary::slotUpdate() {
             ConfigKey("[Library]", "ShowSeratoLibrary"), true));
 
     switch (m_pConfig->getValue<int>(
-            ConfigKey("[Library]", "TrackLoadAction"),
+            kTrackDoubleClickActionConfigKey,
             static_cast<int>(TrackDoubleClickAction::LoadToDeck))) {
     case static_cast<int>(TrackDoubleClickAction::AddToAutoDJBottom):
         radioButton_dbclick_bottom->setChecked(true);
@@ -392,12 +392,12 @@ void DlgPrefLibrary::slotSeratoMetadataExportClicked(bool checked) {
 }
 
 void DlgPrefLibrary::slotApply() {
-    m_pConfig->set(ConfigKey("[Library]","RescanOnStartup"),
-                ConfigValue((int)checkBox_library_scan->isChecked()));
+    m_pConfig->set(kRescanOnStartupConfigKey,
+            ConfigValue((int)checkBox_library_scan->isChecked()));
 
-    m_pConfig->set(ConfigKey("[Library]", "history_cleanup_min_tracks"),
+    m_pConfig->set(kHistoryCleanupMinTracksConfigKey,
             ConfigValue(spinbox_min_history_tracks->value()));
-    m_pConfig->set(ConfigKey("[Library]", "history_cleanup_keep_locked"),
+    m_pConfig->set(kHistoryCleanupKeepLockedConfigKey,
             ConfigValue((int)checkBox_history_cleanup_keep_locked->isChecked()));
 
     m_pConfig->set(
@@ -407,8 +407,9 @@ void DlgPrefLibrary::slotApply() {
             kSyncSeratoMetadataConfigKey,
             ConfigValue{checkBox_SeratoMetadataExport->isChecked()});
 
-    m_pConfig->set(ConfigKey("[Library]","UseRelativePathOnExport"),
-                ConfigValue((int)checkBox_use_relative_path->isChecked()));
+    m_pConfig->set(kUseRelativePathOnExportConfigKey,
+            ConfigValue((int)checkBox_use_relative_path->isChecked()));
+
     m_pConfig->set(ConfigKey("[Library]","ShowRhythmboxLibrary"),
                 ConfigValue((int)checkBox_show_rhythmbox->isChecked()));
     m_pConfig->set(ConfigKey("[Library]","ShowBansheeLibrary"),
@@ -432,8 +433,8 @@ void DlgPrefLibrary::slotApply() {
     } else { // radioButton_dbclick_ignore
         dbclick_status = static_cast<int>(TrackDoubleClickAction::Ignore);
     }
-    m_pConfig->set(ConfigKey("[Library]","TrackLoadAction"),
-                ConfigValue(dbclick_status));
+    m_pConfig->set(kTrackDoubleClickActionConfigKey,
+            ConfigValue(dbclick_status));
 
     m_pConfig->set(kEditMetadataSelectedClickConfigKey,
             ConfigValue(checkBoxEditMetadataSelectedClicked->checkState()));

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -194,7 +194,6 @@ void DlgPrefLibrary::slotResetToDefaults() {
     spinbox_history_recently_played_threshold->setValue(
             kHistoryRecentlyPlayedThresholdDefault);
     spinbox_min_history_tracks->setValue(1);
-    checkBox_history_cleanup_keep_locked->setChecked(false);
     checkBox_SyncTrackMetadata->setChecked(false);
     checkBox_SeratoMetadataExport->setChecked(false);
     checkBox_use_relative_path->setChecked(false);
@@ -223,8 +222,6 @@ void DlgPrefLibrary::slotUpdate() {
             kHistoryRecentlyPlayedThresholdDefault));
     spinbox_min_history_tracks->setValue(m_pConfig->getValue(
             kHistoryCleanupMinTracksConfigKey, 1));
-    checkBox_history_cleanup_keep_locked->setChecked(m_pConfig->getValue(
-            kHistoryCleanupKeepLockedConfigKey, false));
 
     checkBox_SyncTrackMetadata->setChecked(
             m_pConfig->getValue(kSyncTrackMetadataConfigKey, false));
@@ -404,8 +401,6 @@ void DlgPrefLibrary::slotApply() {
             ConfigValue(spinbox_history_recently_played_threshold->value()));
     m_pConfig->set(kHistoryCleanupMinTracksConfigKey,
             ConfigValue(spinbox_min_history_tracks->value()));
-    m_pConfig->set(kHistoryCleanupKeepLockedConfigKey,
-            ConfigValue((int)checkBox_history_cleanup_keep_locked->isChecked()));
 
     m_pConfig->set(
             kSyncTrackMetadataConfigKey,

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -191,8 +191,8 @@ void DlgPrefLibrary::initializeDirList() {
 
 void DlgPrefLibrary::slotResetToDefaults() {
     checkBox_library_scan->setChecked(false);
-    spinbox_history_recently_played_threshold->setValue(
-            kHistoryRecentlyPlayedThresholdDefault);
+    spinbox_history_track_duplicate_distance->setValue(
+            kHistoryTrackDuplicateDistanceDefault);
     spinbox_min_history_tracks->setValue(1);
     checkBox_SyncTrackMetadata->setChecked(false);
     checkBox_SeratoMetadataExport->setChecked(false);
@@ -217,9 +217,9 @@ void DlgPrefLibrary::slotUpdate() {
     checkBox_library_scan->setChecked(m_pConfig->getValue(
             kRescanOnStartupConfigKey, false));
 
-    spinbox_history_recently_played_threshold->setValue(m_pConfig->getValue(
-            kHistoryRecentlyPlayedThresholdConfigKey,
-            kHistoryRecentlyPlayedThresholdDefault));
+    spinbox_history_track_duplicate_distance->setValue(m_pConfig->getValue(
+            kHistoryTrackDuplicateDistanceConfigKey,
+            kHistoryTrackDuplicateDistanceDefault));
     spinbox_min_history_tracks->setValue(m_pConfig->getValue(
             kHistoryCleanupMinTracksConfigKey, 1));
 
@@ -397,8 +397,8 @@ void DlgPrefLibrary::slotApply() {
     m_pConfig->set(kRescanOnStartupConfigKey,
             ConfigValue((int)checkBox_library_scan->isChecked()));
 
-    m_pConfig->set(kHistoryRecentlyPlayedThresholdConfigKey,
-            ConfigValue(spinbox_history_recently_played_threshold->value()));
+    m_pConfig->set(kHistoryTrackDuplicateDistanceConfigKey,
+            ConfigValue(spinbox_history_track_duplicate_distance->value()));
     m_pConfig->set(kHistoryCleanupMinTracksConfigKey,
             ConfigValue(spinbox_min_history_tracks->value()));
 

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -191,6 +191,8 @@ void DlgPrefLibrary::initializeDirList() {
 
 void DlgPrefLibrary::slotResetToDefaults() {
     checkBox_library_scan->setChecked(false);
+    spinbox_history_recently_played_threshold->setValue(
+            kHistoryRecentlyPlayedThresholdDefault);
     spinbox_min_history_tracks->setValue(1);
     checkBox_history_cleanup_keep_locked->setChecked(false);
     checkBox_SyncTrackMetadata->setChecked(false);
@@ -201,8 +203,8 @@ void DlgPrefLibrary::slotResetToDefaults() {
     checkBox_show_itunes->setChecked(true);
     checkBox_show_traktor->setChecked(true);
     checkBox_show_rekordbox->setChecked(true);
-    radioButton_dbclick_bottom->setChecked(false);
     checkBoxEditMetadataSelectedClicked->setChecked(kEditMetadataSelectedClickDefault);
+    radioButton_dbclick_bottom->setChecked(false);
     radioButton_dbclick_top->setChecked(false);
     radioButton_dbclick_deck->setChecked(true);
     spinBoxRowHeight->setValue(Library::kDefaultRowHeightPx);
@@ -216,6 +218,9 @@ void DlgPrefLibrary::slotUpdate() {
     checkBox_library_scan->setChecked(m_pConfig->getValue(
             kRescanOnStartupConfigKey, false));
 
+    spinbox_history_recently_played_threshold->setValue(m_pConfig->getValue(
+            kHistoryRecentlyPlayedThresholdConfigKey,
+            kHistoryRecentlyPlayedThresholdDefault));
     spinbox_min_history_tracks->setValue(m_pConfig->getValue(
             kHistoryCleanupMinTracksConfigKey, 1));
     checkBox_history_cleanup_keep_locked->setChecked(m_pConfig->getValue(
@@ -395,6 +400,8 @@ void DlgPrefLibrary::slotApply() {
     m_pConfig->set(kRescanOnStartupConfigKey,
             ConfigValue((int)checkBox_library_scan->isChecked()));
 
+    m_pConfig->set(kHistoryRecentlyPlayedThresholdConfigKey,
+            ConfigValue(spinbox_history_recently_played_threshold->value()));
     m_pConfig->set(kHistoryCleanupMinTracksConfigKey,
             ConfigValue(spinbox_min_history_tracks->value()));
     m_pConfig->set(kHistoryCleanupKeepLockedConfigKey,

--- a/src/preferences/dialog/dlgpreflibrary.h
+++ b/src/preferences/dialog/dlgpreflibrary.h
@@ -5,7 +5,6 @@
 #include <QWidget>
 #include <memory>
 
-#include "defs_urls.h"
 #include "library/library_decl.h"
 #include "preferences/dialog/dlgpreferencepage.h"
 #include "preferences/dialog/ui_dlgpreflibrarydlg.h"

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -197,6 +197,14 @@
       </item>
 
       <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="checkBox_history_cleanup_keep_locked">
+        <property name="text">
+         <string>Keep locked history playlists</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="3" column="0" colspan="2">
        <widget class="QCheckBox" name="checkBoxEditMetadataSelectedClicked">
         <property name="text">
          <string>Edit metadata after clicking selected track</string>
@@ -204,7 +212,7 @@
        </widget>
       </item>
 
-      <item row="3" column="0" colspan="2">
+      <item row="4" column="0" colspan="2">
        <widget class="QCheckBox" name="checkBox_use_relative_path">
         <property name="text">
          <string>Use relative paths for playlist export if possible</string>
@@ -212,7 +220,7 @@
        </widget>
       </item>
 
-      <item row="4" column="0">
+      <item row="5" column="0">
        <widget class="QLabel" name="rowHeightLabel">
         <property name="text">
          <string>Library Row Height:</string>
@@ -222,7 +230,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="1" colspan="2">
+      <item row="5" column="1" colspan="2">
        <widget class="QSpinBox" name="spinBoxRowHeight">
         <property name="suffix">
          <string> px</string>
@@ -239,7 +247,7 @@
        </widget>
       </item>
 
-      <item row="5" column="0">
+      <item row="6" column="0">
        <widget class="QLabel" name="libraryFontLabel">
         <property name="text">
          <string>Library Font:</string>
@@ -249,14 +257,14 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="1">
+      <item row="6" column="1">
        <widget class="QLineEdit" name="libraryFont">
         <property name="readOnly">
          <bool>true</bool>
         </property>
        </widget>
       </item>
-      <item row="5" column="2">
+      <item row="6" column="2">
        <widget class="QToolButton" name="libraryFontButton">
         <property name="text">
          <string>...</string>
@@ -264,7 +272,7 @@
        </widget>
       </item>
 
-      <item row="6" column="0">
+      <item row="7" column="0">
        <widget class="QLabel" name="searchDebouncingTimeoutLabel">
         <property name="text">
          <string>Search-as-you-type timeout:</string>
@@ -274,7 +282,7 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="1" colspan="2">
+      <item row="7" column="1" colspan="2">
        <widget class="QSpinBox" name="searchDebouncingTimeoutSpinBox">
         <property name="suffix">
          <string> ms</string>
@@ -494,6 +502,7 @@
   <tabstop>checkBox_SeratoMetadataExport</tabstop>
   <tabstop>checkBox_library_scan</tabstop>
   <tabstop>spinbox_min_history_tracks</tabstop>
+  <tabstop>checkBox_history_cleanup_keep_locked</tabstop>
   <tabstop>checkBoxEditMetadataSelectedClicked</tabstop>
   <tabstop>checkBox_use_relative_path</tabstop>
   <tabstop>spinBoxRowHeight</tabstop>

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -160,6 +160,7 @@
       <string>Miscellaneous</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
+
       <item row="0" column="0" colspan="2">
        <widget class="QCheckBox" name="checkBox_library_scan">
         <property name="text">
@@ -170,21 +171,48 @@
         </property>
        </widget>
       </item>
+
       <item row="1" column="0" colspan="2">
+       <widget class="QLabel" name="label_history_cleanup">
+        <property name="text">
+         <string>Delete history playlist with less than ... tracks</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSpinBox" name="spinbox_min_history_tracks">
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>99</number>
+        </property>
+        <property name="value">
+         <number>1</number>
+        </property>
+       </widget>
+      </item>
+
+      <item row="2" column="0" colspan="2">
        <widget class="QCheckBox" name="checkBoxEditMetadataSelectedClicked">
         <property name="text">
          <string>Edit metadata after clicking selected track</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2">
+
+      <item row="3" column="0" colspan="2">
        <widget class="QCheckBox" name="checkBox_use_relative_path">
         <property name="text">
          <string>Use relative paths for playlist export if possible</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
+
+      <item row="4" column="0">
        <widget class="QLabel" name="rowHeightLabel">
         <property name="text">
          <string>Library Row Height:</string>
@@ -194,7 +222,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1" colspan="2">
+      <item row="4" column="1" colspan="2">
        <widget class="QSpinBox" name="spinBoxRowHeight">
         <property name="suffix">
          <string> px</string>
@@ -210,7 +238,8 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
+
+      <item row="5" column="0">
        <widget class="QLabel" name="libraryFontLabel">
         <property name="text">
          <string>Library Font:</string>
@@ -220,21 +249,22 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="5" column="1">
        <widget class="QLineEdit" name="libraryFont">
         <property name="readOnly">
          <bool>true</bool>
         </property>
        </widget>
       </item>
-      <item row="4" column="2">
+      <item row="5" column="2">
        <widget class="QToolButton" name="libraryFontButton">
         <property name="text">
          <string>...</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
+
+      <item row="6" column="0">
        <widget class="QLabel" name="searchDebouncingTimeoutLabel">
         <property name="text">
          <string>Search-as-you-type timeout:</string>
@@ -244,13 +274,14 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="1" colspan="2">
+      <item row="6" column="1" colspan="2">
        <widget class="QSpinBox" name="searchDebouncingTimeoutSpinBox">
         <property name="suffix">
          <string> ms</string>
         </property>
        </widget>
       </item>
+
      </layout>
     </widget>
    </item>
@@ -462,6 +493,7 @@
   <tabstop>checkBox_SyncTrackMetadata</tabstop>
   <tabstop>checkBox_SeratoMetadataExport</tabstop>
   <tabstop>checkBox_library_scan</tabstop>
+  <tabstop>spinbox_min_history_tracks</tabstop>
   <tabstop>checkBoxEditMetadataSelectedClicked</tabstop>
   <tabstop>checkBox_use_relative_path</tabstop>
   <tabstop>spinBoxRowHeight</tabstop>

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -216,9 +216,9 @@
      <layout class="QGridLayout" name="gridLayout_history">
 
       <item row="1" column="0" colspan="2">
-       <widget class="QLabel" name="label_history_recently_played_threshold">
+       <widget class="QLabel" name="label_history_track_duplicate_distance">
         <property name="text">
-         <string>'Recently played' threshold</string>
+         <string>Track duplicate distance</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -229,7 +229,7 @@
        </widget>
       </item>
       <item row="1" column="2">
-       <widget class="QSpinBox" name="spinbox_history_recently_played_threshold">
+       <widget class="QSpinBox" name="spinbox_history_track_duplicate_distance">
         <property name="toolTip">
          <string>When playing a track again log it to the session history only if more than N other tracks have been played in the meantime</string>
         </property>
@@ -533,7 +533,7 @@
   <tabstop>radioButton_dbclick_bottom</tabstop>
   <tabstop>radioButton_dbclick_top</tabstop>
   <tabstop>radioButton_dbclick_ignore</tabstop>
-  <tabstop>spinbox_history_recently_played_threshold</tabstop>
+  <tabstop>spinbox_history_track_duplicate_distance</tabstop>
   <tabstop>spinbox_min_history_tracks</tabstop>
   <tabstop>checkBox_use_relative_path</tabstop>
   <tabstop>spinBoxRowHeight</tabstop>

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -259,7 +259,7 @@
        </widget>
       </item>
       <item row="2" column="2">
-       <widget class="QSpinBox" name="spinbox_min_history_tracks">
+       <widget class="QSpinBox" name="spinbox_history_min_tracks_to_keep">
         <property name="minimum">
          <number>1</number>
         </property>
@@ -534,7 +534,7 @@
   <tabstop>radioButton_dbclick_top</tabstop>
   <tabstop>radioButton_dbclick_ignore</tabstop>
   <tabstop>spinbox_history_track_duplicate_distance</tabstop>
-  <tabstop>spinbox_min_history_tracks</tabstop>
+  <tabstop>spinbox_history_min_tracks_to_keep</tabstop>
   <tabstop>checkBox_use_relative_path</tabstop>
   <tabstop>spinBoxRowHeight</tabstop>
   <tabstop>libraryFont</tabstop>

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -272,17 +272,6 @@
        </widget>
       </item>
 
-      <item row="3" column="0" colspan="2">
-       <widget class="QCheckBox" name="checkBox_history_cleanup_keep_locked">
-        <property name="toolTip">
-         <string>Locked history playlist will not be deleted no matter how many tracks they contain.&lt;br/&gt;&lt;br/&gt;Note: the cleanup will be performed during startup and shutdown of Mixxx.</string>
-        </property>
-        <property name="text">
-         <string>Keep locked history playlists</string>
-        </property>
-       </widget>
-      </item>
-
      </layout>
     </widget>
    </item><!-- History -->
@@ -546,7 +535,6 @@
   <tabstop>radioButton_dbclick_ignore</tabstop>
   <tabstop>spinbox_history_recently_played_threshold</tabstop>
   <tabstop>spinbox_min_history_tracks</tabstop>
-  <tabstop>checkBox_history_cleanup_keep_locked</tabstop>
   <tabstop>checkBox_use_relative_path</tabstop>
   <tabstop>spinBoxRowHeight</tabstop>
   <tabstop>libraryFont</tabstop>

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -173,6 +173,33 @@
       </item>
 
       <item row="1" column="0" colspan="2">
+       <widget class="QLabel" name="label_history_recently_played_threshold">
+        <property name="text">
+         <string>When playing a track again log it only if more than ... other tracks have been played in the meantime</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QSpinBox" name="spinbox_history_recently_played_threshold">
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>99</number>
+        </property>
+        <property name="value">
+         <number>1</number>
+        </property>
+       </widget>
+      </item>
+
+      <item row="2" column="0" colspan="2">
        <widget class="QLabel" name="label_history_cleanup">
         <property name="text">
          <string>Delete history playlist with less than ... tracks</string>
@@ -182,7 +209,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <widget class="QSpinBox" name="spinbox_min_history_tracks">
         <property name="minimum">
          <number>1</number>
@@ -196,7 +223,7 @@
        </widget>
       </item>
 
-      <item row="2" column="0" colspan="2">
+      <item row="3" column="0" colspan="2">
        <widget class="QCheckBox" name="checkBox_history_cleanup_keep_locked">
         <property name="text">
          <string>Keep locked history playlists</string>
@@ -204,7 +231,7 @@
        </widget>
       </item>
 
-      <item row="3" column="0" colspan="2">
+      <item row="4" column="0" colspan="2">
        <widget class="QCheckBox" name="checkBoxEditMetadataSelectedClicked">
         <property name="text">
          <string>Edit metadata after clicking selected track</string>
@@ -212,7 +239,7 @@
        </widget>
       </item>
 
-      <item row="4" column="0" colspan="2">
+      <item row="5" column="0" colspan="2">
        <widget class="QCheckBox" name="checkBox_use_relative_path">
         <property name="text">
          <string>Use relative paths for playlist export if possible</string>
@@ -220,7 +247,7 @@
        </widget>
       </item>
 
-      <item row="5" column="0">
+      <item row="6" column="0">
        <widget class="QLabel" name="rowHeightLabel">
         <property name="text">
          <string>Library Row Height:</string>
@@ -230,7 +257,7 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="1" colspan="2">
+      <item row="6" column="1" colspan="2">
        <widget class="QSpinBox" name="spinBoxRowHeight">
         <property name="suffix">
          <string> px</string>
@@ -247,7 +274,7 @@
        </widget>
       </item>
 
-      <item row="6" column="0">
+      <item row="7" column="0">
        <widget class="QLabel" name="libraryFontLabel">
         <property name="text">
          <string>Library Font:</string>
@@ -257,14 +284,14 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="1">
+      <item row="7" column="1">
        <widget class="QLineEdit" name="libraryFont">
         <property name="readOnly">
          <bool>true</bool>
         </property>
        </widget>
       </item>
-      <item row="6" column="2">
+      <item row="7" column="2">
        <widget class="QToolButton" name="libraryFontButton">
         <property name="text">
          <string>...</string>
@@ -272,7 +299,7 @@
        </widget>
       </item>
 
-      <item row="7" column="0">
+      <item row="8" column="0">
        <widget class="QLabel" name="searchDebouncingTimeoutLabel">
         <property name="text">
          <string>Search-as-you-type timeout:</string>
@@ -282,7 +309,7 @@
         </property>
        </widget>
       </item>
-      <item row="7" column="1" colspan="2">
+      <item row="8" column="1" colspan="2">
        <widget class="QSpinBox" name="searchDebouncingTimeoutSpinBox">
         <property name="suffix">
          <string> ms</string>
@@ -501,6 +528,7 @@
   <tabstop>checkBox_SyncTrackMetadata</tabstop>
   <tabstop>checkBox_SeratoMetadataExport</tabstop>
   <tabstop>checkBox_library_scan</tabstop>
+  <tabstop>spinbox_history_recently_played_threshold</tabstop>
   <tabstop>spinbox_min_history_tracks</tabstop>
   <tabstop>checkBox_history_cleanup_keep_locked</tabstop>
   <tabstop>checkBoxEditMetadataSelectedClicked</tabstop>

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -16,50 +16,13 @@
   <layout class="QVBoxLayout" name="verticalLayout">
 
    <item>
-    <widget class="QGroupBox" name="groupBoxLibrary">
+    <widget class="QGroupBox" name="groupBox_MusicDirectories">
      <property name="title">
-      <string>Library</string>
+      <string>Music Directories</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="TextLabel3_2">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>10</height>
-         </size>
-        </property>
-        <property name="font">
-         <font/>
-        </property>
-        <property name="text">
-         <string>Music Directories:</string>
-        </property>
-        <property name="wordWrap">
-         <bool>false</bool>
-        </property>
-        <property name="buddy">
-         <cstring>dirList</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QPushButton" name="PushButtonRemoveDir">
-        <property name="font">
-         <font/>
-        </property>
-        <property name="toolTip">
-         <string>If removed, Mixxx will no longer watch this directory and its subdirectories for new tracks.</string>
-        </property>
-        <property name="text">
-         <string>Remove</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" rowspan="3">
+     <layout class="QGridLayout" name="gridLayout_music_directories">
+
+      <item row="0" column="0" rowspan="3">
        <widget class="QListView" name="dirList">
         <property name="editTriggers">
          <set>QAbstractItemView::NoEditTriggers</set>
@@ -75,7 +38,8 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+
+      <item row="0" column="1">
        <widget class="QPushButton" name="PushButtonAddDir">
         <property name="font">
          <font/>
@@ -88,7 +52,8 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+
+      <item row="1" column="1">
        <widget class="QPushButton" name="PushButtonRelocateDir">
         <property name="toolTip">
          <string>If an existing music directory is moved, Mixxx doesn't know where to find the audio files in it. Choose Relink to select the music directory in its new location. &lt;br/&gt; This will re-establish the links to the audio files in the Mixxx library.</string>
@@ -98,6 +63,32 @@
         </property>
        </widget>
       </item>
+
+      <item row="2" column="1">
+       <widget class="QPushButton" name="PushButtonRemoveDir">
+        <property name="font">
+         <font/>
+        </property>
+        <property name="toolTip">
+         <string>If removed, Mixxx will no longer watch this directory and its subdirectories for new tracks.</string>
+        </property>
+        <property name="text">
+         <string>Remove</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="3" column="0" colspan="2">
+       <widget class="QCheckBox" name="checkBox_library_scan">
+        <property name="text">
+         <string>Rescan directories on start-up</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+
      </layout>
     </widget>
    </item>
@@ -110,7 +101,7 @@
      <property name="flat">
       <bool>false</bool>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2">
+     <layout class="QGridLayout" name="gridLayout_audio_formats">
       <item row="0" column="0">
        <widget class="QLabel" name="builtInFormats">
         <property name="text">
@@ -130,7 +121,7 @@
      <property name="title">
       <string>Track Metadata Synchronization</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_3">
+     <layout class="QGridLayout" name="gridLayout_metadata">
       <item row="0" column="0" colspan="2">
        <widget class="QCheckBox" name="checkBox_SyncTrackMetadata">
         <property name="text">
@@ -154,28 +145,80 @@
      </layout>
     </widget>
    </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_Miscellaneous">
-     <property name="title">
-      <string>Miscellaneous</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_4">
 
-      <item row="0" column="0" colspan="2">
-       <widget class="QCheckBox" name="checkBox_library_scan">
+   <item>
+    <widget class="QGroupBox" name="groupBox_TrackTableView">
+     <property name="title">
+      <string>Track Table View</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_track_table_view">
+
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="checkBoxEditMetadataSelectedClicked">
         <property name="text">
-         <string>Rescan library on start-up</string>
+         <string>Edit metadata after clicking selected track</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="2" column="0">
+       <widget class="QLabel" name="doubeClickActionLabel">
+        <property name="text">
+         <string>Track Double-Click Action:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+
+      <item row="3" column="0">
+       <widget class="QRadioButton" name="radioButton_dbclick_deck">
+        <property name="text">
+         <string>Load track to next available deck</string>
         </property>
         <property name="checked">
          <bool>true</bool>
         </property>
        </widget>
       </item>
+      <item row="4" column="0">
+       <widget class="QRadioButton" name="radioButton_dbclick_bottom">
+        <property name="text">
+         <string>Add track to Auto DJ queue (bottom)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QRadioButton" name="radioButton_dbclick_top">
+        <property name="text">
+         <string>Add track to Auto DJ queue (top)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QRadioButton" name="radioButton_dbclick_ignore">
+        <property name="text">
+         <string>Ignore</string>
+        </property>
+       </widget>
+      </item>
+
+     </layout>
+    </widget>
+   </item><!-- Track Table View -->
+
+   <item>
+    <widget class="QGroupBox" name="groupBox_History">
+     <property name="title">
+      <string>Session History</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_history">
 
       <item row="1" column="0" colspan="2">
        <widget class="QLabel" name="label_history_recently_played_threshold">
         <property name="text">
-         <string>When playing a track again log it only if more than ... other tracks have been played in the meantime</string>
+         <string>'Recently played' threshold</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -187,6 +230,9 @@
       </item>
       <item row="1" column="2">
        <widget class="QSpinBox" name="spinbox_history_recently_played_threshold">
+        <property name="toolTip">
+         <string>When playing a track again log it to the session history only if more than N other tracks have been played in the meantime</string>
+        </property>
         <property name="minimum">
          <number>0</number>
         </property>
@@ -201,15 +247,18 @@
 
       <item row="2" column="0" colspan="2">
        <widget class="QLabel" name="label_history_cleanup">
+        <property name="toolTip">
+         <string>History playlist with less than N tracks will be deleted&lt;br/&gt;&lt;br/&gt;Note: the cleanup will be performed during startup and shutdown of Mixxx.</string>
+        </property>
         <property name="text">
-         <string>Delete history playlist with less than ... tracks</string>
+         <string>Delete history playlist with less than N tracks</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignLeft|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="2" column="2">
        <widget class="QSpinBox" name="spinbox_min_history_tracks">
         <property name="minimum">
          <number>1</number>
@@ -225,21 +274,27 @@
 
       <item row="3" column="0" colspan="2">
        <widget class="QCheckBox" name="checkBox_history_cleanup_keep_locked">
+        <property name="toolTip">
+         <string>Locked history playlist will not be deleted no matter how many tracks they contain.&lt;br/&gt;&lt;br/&gt;Note: the cleanup will be performed during startup and shutdown of Mixxx.</string>
+        </property>
         <property name="text">
          <string>Keep locked history playlists</string>
         </property>
        </widget>
       </item>
 
-      <item row="4" column="0" colspan="2">
-       <widget class="QCheckBox" name="checkBoxEditMetadataSelectedClicked">
-        <property name="text">
-         <string>Edit metadata after clicking selected track</string>
-        </property>
-       </widget>
-      </item>
+     </layout>
+    </widget>
+   </item><!-- History -->
 
-      <item row="5" column="0" colspan="2">
+   <item>
+    <widget class="QGroupBox" name="groupBox_Miscellaneous">
+     <property name="title">
+      <string>Miscellaneous</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_misc">
+
+      <item row="0" column="0" colspan="2">
        <widget class="QCheckBox" name="checkBox_use_relative_path">
         <property name="text">
          <string>Use relative paths for playlist export if possible</string>
@@ -247,7 +302,7 @@
        </widget>
       </item>
 
-      <item row="6" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="rowHeightLabel">
         <property name="text">
          <string>Library Row Height:</string>
@@ -257,7 +312,7 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="1" colspan="2">
+      <item row="1" column="1" colspan="2">
        <widget class="QSpinBox" name="spinBoxRowHeight">
         <property name="suffix">
          <string> px</string>
@@ -274,7 +329,7 @@
        </widget>
       </item>
 
-      <item row="7" column="0">
+      <item row="2" column="0">
        <widget class="QLabel" name="libraryFontLabel">
         <property name="text">
          <string>Library Font:</string>
@@ -284,14 +339,14 @@
         </property>
        </widget>
       </item>
-      <item row="7" column="1">
+      <item row="2" column="1">
        <widget class="QLineEdit" name="libraryFont">
         <property name="readOnly">
          <bool>true</bool>
         </property>
        </widget>
       </item>
-      <item row="7" column="2">
+      <item row="2" column="2">
        <widget class="QToolButton" name="libraryFontButton">
         <property name="text">
          <string>...</string>
@@ -299,7 +354,7 @@
        </widget>
       </item>
 
-      <item row="8" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="searchDebouncingTimeoutLabel">
         <property name="text">
          <string>Search-as-you-type timeout:</string>
@@ -309,7 +364,7 @@
         </property>
        </widget>
       </item>
-      <item row="8" column="1" colspan="2">
+      <item row="3" column="1" colspan="2">
        <widget class="QSpinBox" name="searchDebouncingTimeoutSpinBox">
         <property name="suffix">
          <string> ms</string>
@@ -322,55 +377,11 @@
    </item>
 
    <item>
-    <widget class="QGroupBox" name="groupBox_4">
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="title">
-      <string extracomment="Sets default action when double-clicking a track in the library.">Track Double-Click Action</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_dblick">
-      <item row="0" column="0">
-       <widget class="QRadioButton" name="radioButton_dbclick_deck">
-        <property name="text">
-         <string>Load track to next available deck</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QRadioButton" name="radioButton_dbclick_bottom">
-        <property name="text">
-         <string>Add track to Auto DJ queue (bottom)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QRadioButton" name="radioButton_dbclick_top">
-        <property name="text">
-         <string>Add track to Auto DJ queue (top)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QRadioButton" name="radioButton_dbclick_ignore">
-        <property name="text">
-         <string>Ignore</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-
-   <item>
-    <widget class="QGroupBox" name="groupBox_3">
+    <widget class="QGroupBox" name="groupBox_external_libraries">
      <property name="title">
       <string>External Libraries</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_6">
+     <layout class="QGridLayout" name="gridLayout_external_libraries">
       <item row="0" column="0">
        <widget class="QCheckBox" name="checkBox_show_rhythmbox">
         <property name="text">
@@ -455,13 +466,13 @@
    <item>
     <widget class="QGroupBox" name="groupBox_settingsDir">
      <property name="title">
-      <string>Settings Folder</string>
+      <string>Settings Directory</string>
      </property>
      <layout class="QVBoxLayout" name="vlayout_settingsDir">
       <item>
        <widget class="QLabel" name="label_settingsDir">
         <property name="text">
-         <string>The Mixxx settings folder contains the library database, various configuration files, log files, track analysis data, as well as custom controller mappings.</string>
+         <string>The Mixxx settings directory contains the library database, various configuration files, log files, track analysis data, as well as custom controller mappings.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
@@ -525,22 +536,22 @@
   <tabstop>PushButtonAddDir</tabstop>
   <tabstop>PushButtonRelocateDir</tabstop>
   <tabstop>PushButtonRemoveDir</tabstop>
+  <tabstop>checkBox_library_scan</tabstop>
   <tabstop>checkBox_SyncTrackMetadata</tabstop>
   <tabstop>checkBox_SeratoMetadataExport</tabstop>
-  <tabstop>checkBox_library_scan</tabstop>
+  <tabstop>checkBoxEditMetadataSelectedClicked</tabstop>
+  <tabstop>radioButton_dbclick_deck</tabstop>
+  <tabstop>radioButton_dbclick_bottom</tabstop>
+  <tabstop>radioButton_dbclick_top</tabstop>
+  <tabstop>radioButton_dbclick_ignore</tabstop>
   <tabstop>spinbox_history_recently_played_threshold</tabstop>
   <tabstop>spinbox_min_history_tracks</tabstop>
   <tabstop>checkBox_history_cleanup_keep_locked</tabstop>
-  <tabstop>checkBoxEditMetadataSelectedClicked</tabstop>
   <tabstop>checkBox_use_relative_path</tabstop>
   <tabstop>spinBoxRowHeight</tabstop>
   <tabstop>libraryFont</tabstop>
   <tabstop>libraryFontButton</tabstop>
   <tabstop>searchDebouncingTimeoutSpinBox</tabstop>
-  <tabstop>radioButton_dbclick_deck</tabstop>
-  <tabstop>radioButton_dbclick_bottom</tabstop>
-  <tabstop>radioButton_dbclick_top</tabstop>
-  <tabstop>radioButton_dbclick_ignore</tabstop>
   <tabstop>checkBox_show_rhythmbox</tabstop>
   <tabstop>checkBox_show_banshee</tabstop>
   <tabstop>checkBox_show_itunes</tabstop>

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -352,9 +352,9 @@ void WTrackTableView::initTrackMenu() {
 
 // slot
 void WTrackTableView::slotMouseDoubleClicked(const QModelIndex& index) {
-    // Read the current TrackLoadAction settings
+    // Read the current TrackDoubleClickAction setting
     int doubleClickActionConfigValue =
-            m_pConfig->getValue(ConfigKey("[Library]", "TrackLoadAction"),
+            m_pConfig->getValue(mixxx::library::prefs::kTrackDoubleClickActionConfigKey,
                     static_cast<int>(DlgPrefLibrary::TrackDoubleClickAction::LoadToDeck));
     DlgPrefLibrary::TrackDoubleClickAction doubleClickAction =
             static_cast<DlgPrefLibrary::TrackDoubleClickAction>(


### PR DESCRIPTION
After the History rework #2996 I'm finally adding some options to Preferences > Library for configuring how the history playlists are cleaned up.

- [x] configure tracks threshold for histories to keep
- [x] ~~allow to keep locked playlists with fewer tracks~~
- [x] always keep locked playlists
- [x] allow adjusting the "recently played" threshold (tracks that are NOT added twice to the history) [lp:1766163](https://bugs.launchpad.net/mixxx/+bug/1766163)
- [x] reset "recently played" list when starting a new session manually ("Finish current and start new") [lp:1969217](https://bugs.launchpad.net/mixxx/+bug/1969217)
- [x] reorder / re-group the library options in the GUI

![image](https://user-images.githubusercontent.com/5934199/164211461-6d9d8893-1e8d-4439-83da-d35f7d58e98a.png)


