### PR TITLE
No testdata copy and circular symlink fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,8 +107,6 @@ set(CMAKE_PROJECT_DESCRIPTION "Mixxx is Free DJ software that gives you everythi
 
 # Used for force control of color output
 set(BUILD_COLORS "auto" CACHE STRING "Try to use colors auto/always/no")
-# Option to disable symlinks
-set(USE_SYMLINKS ON CACHE BOOL "Use symlinks in build directory when possible")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 include(CMakeDependentOption)
@@ -1741,30 +1739,6 @@ add_custom_target(mixxx-benchmark
   VERBATIM
 )
 add_dependencies(mixxx-benchmark mixxx-test)
-
-if(UNIX AND USE_SYMLINKS)
-  add_custom_target(mixxx-testdata
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/src/test" "${CMAKE_CURRENT_BINARY_DIR}/src/test"
-    COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/res/controllers"
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/res/controllers/common-controller-scripts.js" "${CMAKE_CURRENT_BINARY_DIR}/res/controllers/common-controller-scripts.js"
-    COMMENT "Symlinking test data to build directory..."
-  )
-elseif(WIN32)
-  file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/test" CMAKE_CURRENT_SOURCE_TESTDATA_DIR_NATIVE)
-  file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/src/test/" CMAKE_CURRENT_BINARY_TESTDATA_DIR_NATIVE)
-  add_custom_target(mixxx-testdata
-    COMMAND xcopy ${CMAKE_CURRENT_SOURCE_TESTDATA_DIR_NATIVE} ${CMAKE_CURRENT_BINARY_TESTDATA_DIR_NATIVE} /s /d /q /y
-    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/res/controllers/common-controller-scripts.js" "${CMAKE_CURRENT_BINARY_DIR}/res/controllers/common-controller-scripts.js"
-    COMMENT "Copying missing or modified test data files to build directory..."
-  )
-else()
-  add_custom_target(mixxx-testdata
-    COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/src/test" "${CMAKE_CURRENT_BINARY_DIR}/src/test"
-    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/res/controllers/common-controller-scripts.js" "${CMAKE_CURRENT_BINARY_DIR}/res/controllers/common-controller-scripts.js"
-    COMMENT "Copying all test data files to build directory..."
-  )
-endif()
-add_dependencies(mixxx-test mixxx-testdata)
 
 #
 # Resources

--- a/src/preferences/configobject.cpp
+++ b/src/preferences/configobject.cpp
@@ -17,7 +17,7 @@ const QString kTempFilenameExtension = QStringLiteral(".tmp");
 const QString kCMakeCacheFile = QStringLiteral("CMakeCache.txt");
 const QLatin1String kSourceDirLine = QLatin1String("mixxx_SOURCE_DIR:STATIC=");
 
-QString computeResourcePath() {
+QString computeResourcePathImpl() {
     // Try to read in the resource directory from the command line
     QString qResourcePath = CmdlineArgs::Instance().getResourcePath();
 
@@ -107,7 +107,7 @@ ConfigValueKbd::ConfigValueKbd(const QKeySequence& keys)
 
 template<class ValueType>
 ConfigObject<ValueType>::ConfigObject(const QString& file)
-        : ConfigObject(file, computeResourcePath(), computeSettingsPath(file)) {
+        : ConfigObject(file, computeResourcePathImpl(), computeSettingsPath(file)) {
     reopen(file);
 }
 
@@ -479,4 +479,9 @@ QString ConfigObject<ConfigValueKbd>::getValue(
         return default_value;
     }
     return value.value;
+}
+
+template<>
+QString ConfigObject<ConfigValue>::computeResourcePath() {
+    return computeResourcePathImpl();
 }

--- a/src/preferences/configobject.cpp
+++ b/src/preferences/configobject.cpp
@@ -485,3 +485,8 @@ template<>
 QString ConfigObject<ConfigValue>::computeResourcePath() {
     return computeResourcePathImpl();
 }
+
+template<>
+QString ConfigObject<ConfigValueKbd>::computeResourcePath() {
+    return computeResourcePathImpl();
+}

--- a/src/preferences/configobject.h
+++ b/src/preferences/configobject.h
@@ -177,6 +177,8 @@ template <class ValueType> class ConfigObject {
     void reopen(const QString& file);
     bool save();
 
+    static QString computeResourcePath();
+
     // Returns the resource path -- the path where controller presets, skins,
     // library schema, keyboard mappings, and more are stored.
     QString getResourcePath() const {

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -22,8 +22,7 @@ using ::testing::Return;
 
 static int kDefaultTransitionTime = 10;
 const mixxx::audio::ChannelCount kChannelCount = mixxx::kEngineChannelCount;
-const QString kTrackLocationTest(QDir::currentPath() %
-                                 "/src/test/id3-test-data/cover-test-png.mp3");
+const QString kTrackLocationTest = QStringLiteral("/id3-test-data/cover-test-png.mp3");
 
 class FakeMaster {
   public:
@@ -176,7 +175,7 @@ class AutoDJProcessorTest : public LibraryTest {
 
     TrackPointer newTestTrack(TrackId trackId) const {
         TrackPointer pTrack(
-                Track::newDummy(kTrackLocationTest, trackId));
+                Track::newDummy(getTestPath() + kTrackLocationTest, trackId));
         EXPECT_EQ(
                 SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated,
                 SoundSourceProxy(pTrack).updateTrackFromSource(
@@ -232,7 +231,7 @@ class AutoDJProcessorTest : public LibraryTest {
 
     TrackId addTrackToCollection(const QString& trackLocation) {
         TrackPointer pTrack =
-                getOrAddTrackByLocation(trackLocation);
+                getOrAddTrackByLocation(getTestPath() + trackLocation);
         return pTrack ? pTrack->getId() : TrackId();
     }
 

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -22,7 +22,7 @@ using ::testing::Return;
 
 static int kDefaultTransitionTime = 10;
 const mixxx::audio::ChannelCount kChannelCount = mixxx::kEngineChannelCount;
-const QString kTrackLocationTest = QStringLiteral("/id3-test-data/cover-test-png.mp3");
+const QString kTrackLocationTest = QStringLiteral("id3-test-data/cover-test-png.mp3");
 
 class FakeMaster {
   public:
@@ -175,7 +175,7 @@ class AutoDJProcessorTest : public LibraryTest {
 
     TrackPointer newTestTrack(TrackId trackId) const {
         TrackPointer pTrack(
-                Track::newDummy(getTestPath() + kTrackLocationTest, trackId));
+                Track::newDummy(getTestDir().filePath(kTrackLocationTest), trackId));
         EXPECT_EQ(
                 SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated,
                 SoundSourceProxy(pTrack).updateTrackFromSource(
@@ -231,7 +231,7 @@ class AutoDJProcessorTest : public LibraryTest {
 
     TrackId addTrackToCollection(const QString& trackLocation) {
         TrackPointer pTrack =
-                getOrAddTrackByLocation(getTestPath() + trackLocation);
+                getOrAddTrackByLocation(getTestDir().filePath(trackLocation));
         return pTrack ? pTrack->getId() : TrackId();
     }
 

--- a/src/test/controllerscriptenginelegacy_test.cpp
+++ b/src/test/controllerscriptenginelegacy_test.cpp
@@ -69,7 +69,8 @@ class ControllerScriptEngineLegacyTest : public MixxxTest {
 };
 
 TEST_F(ControllerScriptEngineLegacyTest, commonScriptHasNoErrors) {
-    QFileInfo commonScript("./res/controllers/common-controller-scripts.js");
+    QFileInfo commonScript(config()->getResourcePath() +
+            QStringLiteral("/controllers/common-controller-scripts.js"));
     EXPECT_TRUE(evaluateScriptFile(commonScript));
 }
 

--- a/src/test/coverartcache_test.cpp
+++ b/src/test/coverartcache_test.cpp
@@ -54,12 +54,9 @@ class CoverArtCacheTest : public LibraryTest, public CoverArtCache {
     }
 };
 
-const QString kCoverFileTest("cover_test.jpg");
-const QString kCoverLocationTest(QDir::currentPath() %
-                                 "/src/test/id3-test-data/" % kCoverFileTest);
-const QString kTrackLocationTest(QDir::currentPath() %
-                                 "/src/test/id3-test-data/cover-test-png.mp3");
-
+const QString kCoverFileTest = QStringLiteral("cover_test.jpg");
+const QString kCoverLocationTest = QStringLiteral("/id3-test-data/") + kCoverFileTest;
+const QString kTrackLocationTest = QStringLiteral("/id3-test-data/cover-test-png.mp3");
 
 // We need 3 separate test cases:
 // 1) loadCoverFromMetadata()
@@ -76,13 +73,17 @@ const QString kTrackLocationTest(QDir::currentPath() %
 // - absolute coverLocation
 
 TEST_F(CoverArtCacheTest, loadCoverFromMetadata) {
-    loadCoverFromMetadata(kTrackLocationTest);
+    loadCoverFromMetadata(getTestPath() + kTrackLocationTest);
 }
 
 TEST_F(CoverArtCacheTest, loadCoverFromFileRelative) {
-    loadCoverFromFile(kTrackLocationTest, kCoverFileTest, kCoverLocationTest);
+    loadCoverFromFile(getTestPath() + kTrackLocationTest,
+            kCoverFileTest,
+            getTestPath() + kCoverLocationTest);
 }
 
 TEST_F(CoverArtCacheTest, loadCoverFromFileAbsolute) {
-    loadCoverFromFile(QString(), kCoverLocationTest, kCoverLocationTest);
+    loadCoverFromFile(QString(),
+            getTestPath() + kCoverLocationTest,
+            getTestPath() + kCoverLocationTest);
 }

--- a/src/test/coverartcache_test.cpp
+++ b/src/test/coverartcache_test.cpp
@@ -55,8 +55,8 @@ class CoverArtCacheTest : public LibraryTest, public CoverArtCache {
 };
 
 const QString kCoverFileTest = QStringLiteral("cover_test.jpg");
-const QString kCoverLocationTest = QStringLiteral("/id3-test-data/") + kCoverFileTest;
-const QString kTrackLocationTest = QStringLiteral("/id3-test-data/cover-test-png.mp3");
+const QString kCoverLocationTest = QStringLiteral("id3-test-data/") + kCoverFileTest;
+const QString kTrackLocationTest = QStringLiteral("id3-test-data/cover-test-png.mp3");
 
 // We need 3 separate test cases:
 // 1) loadCoverFromMetadata()
@@ -73,17 +73,19 @@ const QString kTrackLocationTest = QStringLiteral("/id3-test-data/cover-test-png
 // - absolute coverLocation
 
 TEST_F(CoverArtCacheTest, loadCoverFromMetadata) {
-    loadCoverFromMetadata(getTestPath() + kTrackLocationTest);
+    loadCoverFromMetadata(getTestDir().filePath(kTrackLocationTest));
 }
 
 TEST_F(CoverArtCacheTest, loadCoverFromFileRelative) {
-    loadCoverFromFile(getTestPath() + kTrackLocationTest,
+    loadCoverFromFile(
+            getTestDir().filePath(kTrackLocationTest),
             kCoverFileTest,
-            getTestPath() + kCoverLocationTest);
+            getTestDir().filePath(kCoverLocationTest));
 }
 
 TEST_F(CoverArtCacheTest, loadCoverFromFileAbsolute) {
-    loadCoverFromFile(QString(),
-            getTestPath() + kCoverLocationTest,
-            getTestPath() + kCoverLocationTest);
+    loadCoverFromFile(
+            QString(),
+            getTestDir().filePath(kCoverLocationTest),
+            getTestDir().filePath(kCoverLocationTest));
 }

--- a/src/test/coverartutils_test.cpp
+++ b/src/test/coverartutils_test.cpp
@@ -10,9 +10,8 @@
 
 namespace {
 
-const QDir kTestDir(QDir::current().absoluteFilePath("src/test/id3-test-data"));
-const QString kReferencePNGLocationTest(kTestDir.absoluteFilePath("reference_cover.png"));
-const QString kReferenceJPGLocationTest(kTestDir.absoluteFilePath("cover_test.jpg"));
+const QString kReferencePNGLocationTest = QStringLiteral("/id3-test-data/reference_cover.png");
+const QString kReferenceJPGLocationTest = QStringLiteral("/id3-test-data/cover_test.jpg");
 
 void extractEmbeddedCover(
         const QString& trackLocation,
@@ -33,61 +32,69 @@ class CoverArtUtilTest : public LibraryTest, CoverArtCache {
 };
 
 TEST_F(CoverArtUtilTest, extractEmbeddedCover) {
-    QImage referencePNGImage = QImage(kReferencePNGLocationTest);
-    QImage referenceJPGImage = QImage(kReferenceJPGLocationTest);
+    QImage referencePNGImage = QImage(getTestPath() + kReferencePNGLocationTest);
+    QImage referenceJPGImage = QImage(getTestPath() + kReferenceJPGLocationTest);
 
     if (SoundSourceProxy::isFileSuffixSupported(QStringLiteral("aiff"))) {
-        extractEmbeddedCover(
-                kTestDir.absoluteFilePath("cover-test.aiff"), referencePNGImage);
+        extractEmbeddedCover(getTestPath() +
+                        QStringLiteral("/id3-test-data/cover-test.aiff"),
+                referencePNGImage);
     }
 
     if (SoundSourceProxy::isFileSuffixSupported(QStringLiteral("flac"))) {
-        extractEmbeddedCover(
-                kTestDir.absoluteFilePath("cover-test.flac"), referencePNGImage);
+        extractEmbeddedCover(getTestPath() +
+                        QStringLiteral("/id3-test-data/cover-test.flac"),
+                referencePNGImage);
     }
 
     if (SoundSourceProxy::isFileSuffixSupported(QStringLiteral("m4a"))) {
-        extractEmbeddedCover(
-                kTestDir.absoluteFilePath("cover-test-itunes-12.3.0-aac.m4a"), referencePNGImage);
-        extractEmbeddedCover(
-                kTestDir.absoluteFilePath("cover-test-itunes-12.7.0-aac.m4a"), referencePNGImage);
-        extractEmbeddedCover(
-                kTestDir.absoluteFilePath("cover-test-itunes-12.7.0-alac.m4a"), referencePNGImage);
+        extractEmbeddedCover(getTestPath() +
+                        QStringLiteral("/id3-test-data/cover-test-itunes-12.3.0-aac.m4a"),
+                referencePNGImage);
+        extractEmbeddedCover(getTestPath() +
+                        QStringLiteral("/id3-test-data/cover-test-itunes-12.7.0-aac.m4a"),
+                referencePNGImage);
+        extractEmbeddedCover(getTestPath() +
+                        QStringLiteral("/id3-test-data/cover-test-itunes-12.7.0-alac.m4a"),
+                referencePNGImage);
     }
 
     if (SoundSourceProxy::isFileSuffixSupported(QStringLiteral("m4v"))) {
         extractEmbeddedCover(
-                kTestDir.absoluteFilePath("cover-test.m4v"), referencePNGImage);
+                getTestPath() + QStringLiteral("/id3-test-data/cover-test.m4v"), referencePNGImage);
     }
 
     if (SoundSourceProxy::isFileSuffixSupported(QStringLiteral("mp3"))) {
         // PNG
-        extractEmbeddedCover(
-                kTestDir.absoluteFilePath("cover-test-png.mp3"), referencePNGImage);
+        extractEmbeddedCover(getTestPath() +
+                        QStringLiteral("/id3-test-data/cover-test-png.mp3"),
+                referencePNGImage);
         // JPEG
-        extractEmbeddedCover(
-                kTestDir.absoluteFilePath("cover-test-jpg.mp3"), referenceJPGImage);
+        extractEmbeddedCover(getTestPath() +
+                        QStringLiteral("/id3-test-data/cover-test-jpg.mp3"),
+                referenceJPGImage);
     }
 
     if (SoundSourceProxy::isFileSuffixSupported(QStringLiteral("ogg"))) {
         extractEmbeddedCover(
-                kTestDir.absoluteFilePath("cover-test.ogg"), referencePNGImage);
+                getTestPath() + QStringLiteral("/id3-test-data/cover-test.ogg"), referencePNGImage);
     }
 
     if (SoundSourceProxy::isFileSuffixSupported(QStringLiteral("opus"))) {
         // opus
-        extractEmbeddedCover(
-                kTestDir.absoluteFilePath("cover-test.opus"), referencePNGImage);
+        extractEmbeddedCover(getTestPath() +
+                        QStringLiteral("/id3-test-data/cover-test.opus"),
+                referencePNGImage);
     }
 
     if (SoundSourceProxy::isFileSuffixSupported(QStringLiteral("wav"))) {
         extractEmbeddedCover(
-                kTestDir.absoluteFilePath("cover-test.wav"), referencePNGImage);
+                getTestPath() + QStringLiteral("/id3-test-data/cover-test.wav"), referencePNGImage);
     }
 
     if (SoundSourceProxy::isFileSuffixSupported(QStringLiteral("wv"))) {
         extractEmbeddedCover(
-                kTestDir.absoluteFilePath("cover-test.wv"), referencePNGImage);
+                getTestPath() + QStringLiteral("/id3-test-data/cover-test.wv"), referencePNGImage);
     }
 }
 
@@ -97,7 +104,8 @@ TEST_F(CoverArtUtilTest, searchImage) {
     ASSERT_TRUE(tempTrackDir.isValid());
     QString trackdir = QString(tempTrackDir.path());
 
-    const QString kTrackLocationTest(kTestDir.absoluteFilePath("cover-test-png.mp3"));
+    const QString kTrackLocationTest(getTestPath() +
+            QStringLiteral("/id3-test-data/cover-test-png.mp3"));
 
     TrackPointer pTrack(Track::newTemporary(kTrackLocationTest));
     QList<QFileInfo> covers;

--- a/src/test/coverartutils_test.cpp
+++ b/src/test/coverartutils_test.cpp
@@ -10,8 +10,8 @@
 
 namespace {
 
-const QString kReferencePNGLocationTest = QStringLiteral("/id3-test-data/reference_cover.png");
-const QString kReferenceJPGLocationTest = QStringLiteral("/id3-test-data/cover_test.jpg");
+const QString kReferencePNGLocationTest = QStringLiteral("id3-test-data/reference_cover.png");
+const QString kReferenceJPGLocationTest = QStringLiteral("id3-test-data/cover_test.jpg");
 
 void extractEmbeddedCover(
         const QString& trackLocation,
@@ -32,69 +32,73 @@ class CoverArtUtilTest : public LibraryTest, CoverArtCache {
 };
 
 TEST_F(CoverArtUtilTest, extractEmbeddedCover) {
-    QImage referencePNGImage = QImage(getTestPath() + kReferencePNGLocationTest);
-    QImage referenceJPGImage = QImage(getTestPath() + kReferenceJPGLocationTest);
+    QImage referencePNGImage = QImage(getTestDir().filePath(kReferencePNGLocationTest));
+    QImage referenceJPGImage = QImage(getTestDir().filePath(kReferenceJPGLocationTest));
 
     if (SoundSourceProxy::isFileSuffixSupported(QStringLiteral("aiff"))) {
-        extractEmbeddedCover(getTestPath() +
-                        QStringLiteral("/id3-test-data/cover-test.aiff"),
+        extractEmbeddedCover(getTestDir().filePath(QStringLiteral("id3-test-data/cover-test.aiff")),
                 referencePNGImage);
     }
 
     if (SoundSourceProxy::isFileSuffixSupported(QStringLiteral("flac"))) {
-        extractEmbeddedCover(getTestPath() +
-                        QStringLiteral("/id3-test-data/cover-test.flac"),
+        extractEmbeddedCover(getTestDir().filePath(QStringLiteral("id3-test-data/cover-test.flac")),
                 referencePNGImage);
     }
 
     if (SoundSourceProxy::isFileSuffixSupported(QStringLiteral("m4a"))) {
-        extractEmbeddedCover(getTestPath() +
-                        QStringLiteral("/id3-test-data/cover-test-itunes-12.3.0-aac.m4a"),
+        extractEmbeddedCover(
+                getTestDir().filePath(QStringLiteral(
+                        "id3-test-data/cover-test-itunes-12.3.0-aac.m4a")),
                 referencePNGImage);
-        extractEmbeddedCover(getTestPath() +
-                        QStringLiteral("/id3-test-data/cover-test-itunes-12.7.0-aac.m4a"),
+        extractEmbeddedCover(
+                getTestDir().filePath(QStringLiteral(
+                        "id3-test-data/cover-test-itunes-12.7.0-aac.m4a")),
                 referencePNGImage);
-        extractEmbeddedCover(getTestPath() +
-                        QStringLiteral("/id3-test-data/cover-test-itunes-12.7.0-alac.m4a"),
+        extractEmbeddedCover(
+                getTestDir().filePath(QStringLiteral(
+                        "id3-test-data/cover-test-itunes-12.7.0-alac.m4a")),
                 referencePNGImage);
     }
 
     if (SoundSourceProxy::isFileSuffixSupported(QStringLiteral("m4v"))) {
-        extractEmbeddedCover(
-                getTestPath() + QStringLiteral("/id3-test-data/cover-test.m4v"), referencePNGImage);
+        extractEmbeddedCover(getTestDir().filePath(QStringLiteral(
+                                     "id3-test-data/cover-test.m4v")),
+                referencePNGImage);
     }
 
     if (SoundSourceProxy::isFileSuffixSupported(QStringLiteral("mp3"))) {
         // PNG
-        extractEmbeddedCover(getTestPath() +
-                        QStringLiteral("/id3-test-data/cover-test-png.mp3"),
+        extractEmbeddedCover(getTestDir().filePath(QStringLiteral(
+                                     "id3-test-data/cover-test-png.mp3")),
                 referencePNGImage);
         // JPEG
-        extractEmbeddedCover(getTestPath() +
-                        QStringLiteral("/id3-test-data/cover-test-jpg.mp3"),
+        extractEmbeddedCover(getTestDir().filePath(QStringLiteral(
+                                     "id3-test-data/cover-test-jpg.mp3")),
                 referenceJPGImage);
     }
 
     if (SoundSourceProxy::isFileSuffixSupported(QStringLiteral("ogg"))) {
-        extractEmbeddedCover(
-                getTestPath() + QStringLiteral("/id3-test-data/cover-test.ogg"), referencePNGImage);
+        extractEmbeddedCover(getTestDir().filePath(QStringLiteral(
+                                     "id3-test-data/cover-test.ogg")),
+                referencePNGImage);
     }
 
     if (SoundSourceProxy::isFileSuffixSupported(QStringLiteral("opus"))) {
         // opus
-        extractEmbeddedCover(getTestPath() +
-                        QStringLiteral("/id3-test-data/cover-test.opus"),
+        extractEmbeddedCover(getTestDir().filePath(QStringLiteral("id3-test-data/cover-test.opus")),
                 referencePNGImage);
     }
 
     if (SoundSourceProxy::isFileSuffixSupported(QStringLiteral("wav"))) {
-        extractEmbeddedCover(
-                getTestPath() + QStringLiteral("/id3-test-data/cover-test.wav"), referencePNGImage);
+        extractEmbeddedCover(getTestDir().filePath(QStringLiteral(
+                                     "id3-test-data/cover-test.wav")),
+                referencePNGImage);
     }
 
     if (SoundSourceProxy::isFileSuffixSupported(QStringLiteral("wv"))) {
-        extractEmbeddedCover(
-                getTestPath() + QStringLiteral("/id3-test-data/cover-test.wv"), referencePNGImage);
+        extractEmbeddedCover(getTestDir().filePath(QStringLiteral(
+                                     "id3-test-data/cover-test.wv")),
+                referencePNGImage);
     }
 }
 
@@ -104,8 +108,8 @@ TEST_F(CoverArtUtilTest, searchImage) {
     ASSERT_TRUE(tempTrackDir.isValid());
     QString trackdir = QString(tempTrackDir.path());
 
-    const QString kTrackLocationTest(getTestPath() +
-            QStringLiteral("/id3-test-data/cover-test-png.mp3"));
+    const QString kTrackLocationTest(getTestDir().filePath(
+            QStringLiteral("id3-test-data/cover-test-png.mp3")));
 
     TrackPointer pTrack(Track::newTemporary(kTrackLocationTest));
     QList<QFileInfo> covers;

--- a/src/test/cuecontrol_test.cpp
+++ b/src/test/cuecontrol_test.cpp
@@ -27,7 +27,7 @@ class CueControlTest : public BaseSignalPathTest {
     }
 
     TrackPointer createTestTrack() const {
-        const QString kTrackLocationTest = getTestPath() + QStringLiteral("/sine-30.wav");
+        const QString kTrackLocationTest = getTestDir().filePath(QStringLiteral("sine-30.wav"));
         const auto pTrack = Track::newTemporary(
                 mixxx::FileAccess(mixxx::FileInfo(kTrackLocationTest)));
         pTrack->setAudioProperties(

--- a/src/test/cuecontrol_test.cpp
+++ b/src/test/cuecontrol_test.cpp
@@ -27,7 +27,7 @@ class CueControlTest : public BaseSignalPathTest {
     }
 
     TrackPointer createTestTrack() const {
-        const QString kTrackLocationTest = QDir::currentPath() + "/src/test/sine-30.wav";
+        const QString kTrackLocationTest = getTestPath() + QStringLiteral("/sine-30.wav");
         const auto pTrack = Track::newTemporary(
                 mixxx::FileAccess(mixxx::FileInfo(kTrackLocationTest)));
         pTrack->setAudioProperties(

--- a/src/test/globaltrackcache_test.cpp
+++ b/src/test/globaltrackcache_test.cpp
@@ -9,10 +9,8 @@
 
 namespace {
 
-const QDir kTestDir(QDir::current().absoluteFilePath("src/test/id3-test-data"));
-
-const mixxx::FileInfo kTestFile(kTestDir.absoluteFilePath("cover-test.flac"));
-const mixxx::FileInfo kTestFile2(kTestDir.absoluteFilePath("cover-test.ogg"));
+const QString kTestFile = QStringLiteral("/id3-test-data/cover-test.flac");
+const QString kTestFile2 = QStringLiteral("/id3-test-data/cover-test.ogg");
 
 class TrackTitleThread: public QThread {
   public:
@@ -97,7 +95,7 @@ TEST_F(GlobalTrackCacheTest, resolveByFileInfo) {
 
     TrackPointer track;
     {
-        auto testFileAccess = mixxx::FileAccess(mixxx::FileInfo(kTestFile));
+        auto testFileAccess = mixxx::FileAccess(mixxx::FileInfo(getTestPath() + kTestFile));
         GlobalTrackCacheResolver resolver(testFileAccess);
         track = resolver.getTrack();
         EXPECT_TRUE(static_cast<bool>(track));
@@ -147,6 +145,8 @@ TEST_F(GlobalTrackCacheTest, concurrentDelete) {
     TrackTitleThread workerThread;
     workerThread.start();
 
+    const auto testFile = mixxx::FileInfo(getTestPath() + kTestFile);
+
     // lp1744550: A decent number of iterations is needed to reliably
     // reveal potential race conditions while evicting tracks from
     // the cache!
@@ -160,7 +160,7 @@ TEST_F(GlobalTrackCacheTest, concurrentDelete) {
 
         TrackPointer track;
         {
-            auto testFileAccess = mixxx::FileAccess(mixxx::FileInfo(kTestFile));
+            auto testFileAccess = mixxx::FileAccess(testFile);
             GlobalTrackCacheResolver resolver(testFileAccess);
             track = resolver.getTrack();
             EXPECT_TRUE(static_cast<bool>(track));
@@ -203,12 +203,12 @@ TEST_F(GlobalTrackCacheTest, evictWhileMoving) {
     ASSERT_TRUE(GlobalTrackCacheLocker().isEmpty());
 
     TrackPointer track1 = GlobalTrackCacheResolver(
-            mixxx::FileAccess(mixxx::FileInfo(kTestFile)))
+            mixxx::FileAccess(mixxx::FileInfo(getTestPath() + kTestFile)))
                                   .getTrack();
     EXPECT_TRUE(static_cast<bool>(track1));
 
     TrackPointer track2 = GlobalTrackCacheResolver(
-            mixxx::FileAccess(mixxx::FileInfo(kTestFile2)))
+            mixxx::FileAccess(mixxx::FileInfo(getTestPath() + kTestFile2)))
                                   .getTrack();
     EXPECT_TRUE(static_cast<bool>(track2));
 

--- a/src/test/globaltrackcache_test.cpp
+++ b/src/test/globaltrackcache_test.cpp
@@ -9,8 +9,8 @@
 
 namespace {
 
-const QString kTestFile = QStringLiteral("/id3-test-data/cover-test.flac");
-const QString kTestFile2 = QStringLiteral("/id3-test-data/cover-test.ogg");
+const QString kTestFile = QStringLiteral("id3-test-data/cover-test.flac");
+const QString kTestFile2 = QStringLiteral("id3-test-data/cover-test.ogg");
 
 class TrackTitleThread: public QThread {
   public:
@@ -95,7 +95,7 @@ TEST_F(GlobalTrackCacheTest, resolveByFileInfo) {
 
     TrackPointer track;
     {
-        auto testFileAccess = mixxx::FileAccess(mixxx::FileInfo(getTestPath() + kTestFile));
+        auto testFileAccess = mixxx::FileAccess(mixxx::FileInfo(getTestDir().filePath(kTestFile)));
         GlobalTrackCacheResolver resolver(testFileAccess);
         track = resolver.getTrack();
         EXPECT_TRUE(static_cast<bool>(track));
@@ -145,7 +145,7 @@ TEST_F(GlobalTrackCacheTest, concurrentDelete) {
     TrackTitleThread workerThread;
     workerThread.start();
 
-    const auto testFile = mixxx::FileInfo(getTestPath() + kTestFile);
+    const auto testFile = mixxx::FileInfo(getTestDir().filePath(kTestFile));
 
     // lp1744550: A decent number of iterations is needed to reliably
     // reveal potential race conditions while evicting tracks from
@@ -203,12 +203,12 @@ TEST_F(GlobalTrackCacheTest, evictWhileMoving) {
     ASSERT_TRUE(GlobalTrackCacheLocker().isEmpty());
 
     TrackPointer track1 = GlobalTrackCacheResolver(
-            mixxx::FileAccess(mixxx::FileInfo(getTestPath() + kTestFile)))
+            mixxx::FileAccess(mixxx::FileInfo(getTestDir().filePath(kTestFile))))
                                   .getTrack();
     EXPECT_TRUE(static_cast<bool>(track1));
 
     TrackPointer track2 = GlobalTrackCacheResolver(
-            mixxx::FileAccess(mixxx::FileInfo(getTestPath() + kTestFile2)))
+            mixxx::FileAccess(mixxx::FileInfo(getTestDir().filePath(kTestFile2))))
                                   .getTrack();
     EXPECT_TRUE(static_cast<bool>(track2));
 

--- a/src/test/hotcuecontrol_test.cpp
+++ b/src/test/hotcuecontrol_test.cpp
@@ -40,7 +40,7 @@ class HotcueControlTest : public BaseSignalPathTest {
     }
 
     TrackPointer createTestTrack() const {
-        const QString kTrackLocationTest = QDir::currentPath() + "/src/test/sine-30.wav";
+        const QString kTrackLocationTest = getTestPath() + QStringLiteral("/sine-30.wav");
         const auto pTrack = Track::newTemporary(
                 mixxx::FileAccess(mixxx::FileInfo(kTrackLocationTest)));
         pTrack->setAudioProperties(

--- a/src/test/hotcuecontrol_test.cpp
+++ b/src/test/hotcuecontrol_test.cpp
@@ -40,7 +40,7 @@ class HotcueControlTest : public BaseSignalPathTest {
     }
 
     TrackPointer createTestTrack() const {
-        const QString kTrackLocationTest = getTestPath() + QStringLiteral("/sine-30.wav");
+        const QString kTrackLocationTest = getTestDir().filePath(QStringLiteral("sine-30.wav"));
         const auto pTrack = Track::newTemporary(
                 mixxx::FileAccess(mixxx::FileInfo(kTrackLocationTest)));
         pTrack->setAudioProperties(

--- a/src/test/mixxxtest.cpp
+++ b/src/test/mixxxtest.cpp
@@ -20,6 +20,7 @@ QString makeTestConfigFile(const QString& path) {
 
 // Static initialization
 QScopedPointer<MixxxApplication> MixxxTest::s_pApplication;
+QString MixxxTest::s_TestPath;
 
 MixxxTest::ApplicationScope::ApplicationScope(int& argc, char** argv) {
     CmdlineArgs args;

--- a/src/test/mixxxtest.cpp
+++ b/src/test/mixxxtest.cpp
@@ -20,7 +20,7 @@ QString makeTestConfigFile(const QString& path) {
 
 // Static initialization
 QScopedPointer<MixxxApplication> MixxxTest::s_pApplication;
-QString MixxxTest::s_TestPath;
+QDir MixxxTest::s_TestDir;
 
 MixxxTest::ApplicationScope::ApplicationScope(int& argc, char** argv) {
     CmdlineArgs args;

--- a/src/test/mixxxtest.h
+++ b/src/test/mixxxtest.h
@@ -12,6 +12,13 @@
 #define EXPECT_QSTRING_EQ(expected, test) EXPECT_STREQ(qPrintable(expected), qPrintable(test))
 #define ASSERT_QSTRING_EQ(expected, test) ASSERT_STREQ(qPrintable(expected), qPrintable(test))
 
+namespace {
+
+// We assume that the test folder is a sibling to the res folder
+const QString kTestPath = QStringLiteral("/../src/test");
+
+} // namespace
+
 class MixxxTest : public testing::Test {
   public:
     MixxxTest();
@@ -27,6 +34,13 @@ class MixxxTest : public testing::Test {
         ~ApplicationScope();
     };
     friend class ApplicationScope;
+
+    static const QString& testPath() {
+        if (s_TestPath.isEmpty()) {
+            s_TestPath = ConfigObject<ConfigValue>::computeResourcePath() + kTestPath;
+        }
+        return s_TestPath;
+    }
 
   protected:
     static QApplication* application() {
@@ -44,9 +58,16 @@ class MixxxTest : public testing::Test {
         return m_testDataDir.path();
     }
 
+    const QString& getTestPath() const {
+        if (s_TestPath.isEmpty()) {
+            s_TestPath = m_pConfig->getResourcePath() + kTestPath;
+        }
+        return s_TestPath;
+    }
+
   private:
     static QScopedPointer<MixxxApplication> s_pApplication;
-
+    static QString s_TestPath;
     const QTemporaryDir m_testDataDir;
 
   protected:

--- a/src/test/mixxxtest.h
+++ b/src/test/mixxxtest.h
@@ -35,9 +35,12 @@ class MixxxTest : public testing::Test {
     };
     friend class ApplicationScope;
 
-    static const QDir& testDir() {
+    static const QDir& getOrInitTestDir(const QString& resourcePath = QString()) {
         if (s_TestDir.path() == ".") {
-            s_TestDir.setPath(ConfigObject<ConfigValue>::computeResourcePath() +
+            s_TestDir.setPath(
+                    (resourcePath.isEmpty() ? ConfigObject<ConfigValue>::
+                                                      computeResourcePath()
+                                            : resourcePath) +
                     QChar('/') + kTestPath);
         }
         return s_TestDir;
@@ -60,10 +63,7 @@ class MixxxTest : public testing::Test {
     }
 
     const QDir& getTestDir() const {
-        if (s_TestDir.path() == ".") {
-            s_TestDir.setPath(m_pConfig->getResourcePath() + QChar('/') + kTestPath);
-        }
-        return s_TestDir;
+        return getOrInitTestDir(m_pConfig->getResourcePath());
     }
 
   private:

--- a/src/test/mixxxtest.h
+++ b/src/test/mixxxtest.h
@@ -15,7 +15,7 @@
 namespace {
 
 // We assume that the test folder is a sibling to the res folder
-const QString kTestPath = QStringLiteral("/../src/test");
+const QString kTestPath = QStringLiteral("../src/test");
 
 } // namespace
 
@@ -35,11 +35,12 @@ class MixxxTest : public testing::Test {
     };
     friend class ApplicationScope;
 
-    static const QString& testPath() {
-        if (s_TestPath.isEmpty()) {
-            s_TestPath = ConfigObject<ConfigValue>::computeResourcePath() + kTestPath;
+    static const QDir& testDir() {
+        if (s_TestDir.path() == ".") {
+            s_TestDir.setPath(ConfigObject<ConfigValue>::computeResourcePath() +
+                    QChar('/') + kTestPath);
         }
-        return s_TestPath;
+        return s_TestDir;
     }
 
   protected:
@@ -58,16 +59,16 @@ class MixxxTest : public testing::Test {
         return m_testDataDir.path();
     }
 
-    const QString& getTestPath() const {
-        if (s_TestPath.isEmpty()) {
-            s_TestPath = m_pConfig->getResourcePath() + kTestPath;
+    const QDir& getTestDir() const {
+        if (s_TestDir.path() == ".") {
+            s_TestDir.setPath(m_pConfig->getResourcePath() + QChar('/') + kTestPath);
         }
-        return s_TestPath;
+        return s_TestDir;
     }
 
   private:
     static QScopedPointer<MixxxApplication> s_pApplication;
-    static QString s_TestPath;
+    static QDir s_TestDir;
     const QTemporaryDir m_testDataDir;
 
   protected:

--- a/src/test/playermanagertest.cpp
+++ b/src/test/playermanagertest.cpp
@@ -118,6 +118,7 @@ TEST_F(PlayerManagerTest, UnEjectTest) {
 
     // Load a track and eject it
     TrackPointer pTrack1 = getOrAddTrackByLocation(kTrackLocationTest1);
+    ASSERT_NE(nullptr, pTrack1);
     TrackId testId1 = pTrack1->getId();
     ASSERT_TRUE(testId1.isValid());
     deck1->slotLoadTrack(pTrack1, false);
@@ -131,6 +132,7 @@ TEST_F(PlayerManagerTest, UnEjectTest) {
 
     // Load another track.
     TrackPointer pTrack2 = getOrAddTrackByLocation(kTrackLocationTest2);
+    ASSERT_NE(nullptr, pTrack2);
     deck1->slotLoadTrack(pTrack2, false);
 
     // Ejecting in an empty deck loads the last-ejected track.
@@ -147,6 +149,7 @@ TEST_F(PlayerManagerTest, UnEjectReplaceTrackTest) {
     auto deck1 = m_pPlayerManager->getDeck(1);
     // Load a track and the load another one
     TrackPointer pTrack1 = getOrAddTrackByLocation(kTrackLocationTest1);
+    ASSERT_NE(nullptr, pTrack1);
     TrackId testId1 = pTrack1->getId();
     ASSERT_TRUE(testId1.isValid());
     deck1->slotLoadTrack(pTrack1, false);
@@ -159,6 +162,7 @@ TEST_F(PlayerManagerTest, UnEjectReplaceTrackTest) {
 
     // Load another track, replacing the first, causing it to be unloaded.
     TrackPointer pTrack2 = getOrAddTrackByLocation(kTrackLocationTest2);
+    ASSERT_NE(nullptr, pTrack2);
     deck1->slotLoadTrack(pTrack2, false);
     m_pEngine->process(1024);
     while (!deck1->getEngineDeck()->getEngineBuffer()->isTrackLoaded()) {
@@ -176,6 +180,7 @@ TEST_F(PlayerManagerTest, UnEjectReplaceTrackTest) {
 TEST_F(PlayerManagerTest, UnEjectInvalidTrackIdTest) {
     // Save an invalid trackid in playermanager.
     auto pTrack = Track::newDummy(kTrackLocationTest1, TrackId(10));
+    ASSERT_NE(nullptr, pTrack);
     m_pPlayerManager->slotSaveEjectedTrack(pTrack);
     auto deck1 = m_pPlayerManager->getDeck(1);
     // Does nothing -- no crash.

--- a/src/test/playermanagertest.cpp
+++ b/src/test/playermanagertest.cpp
@@ -16,16 +16,18 @@
 #include "track/track.h"
 #include "util/cmdlineargs.h"
 
-const QString kTrackLocationTest1(QDir::currentPath() %
-        "/src/test/id3-test-data/cover-test-png.mp3");
-const QString kTrackLocationTest2(QDir::currentPath() %
-        "/src/test/id3-test-data/cover-test-vbr.mp3");
+namespace {
+
+const QString kTrackLocationTest1 = QStringLiteral("/id3-test-data/cover-test-png.mp3");
+const QString kTrackLocationTest2 = QStringLiteral("/id3-test-data/cover-test-vbr.mp3");
 
 void deleteTrack(Track* pTrack) {
     // Delete track objects directly in unit tests with
     // no main event loop
     delete pTrack;
 };
+
+} // namespace
 
 // We can't inherit from LibraryTest because that creates a key_notation control object that is also
 // created by the Library object itself. The duplicated CO creation causes a debug assert.
@@ -117,7 +119,7 @@ TEST_F(PlayerManagerTest, UnEjectTest) {
     ASSERT_EQ(nullptr, deck1->getLoadedTrack());
 
     // Load a track and eject it
-    TrackPointer pTrack1 = getOrAddTrackByLocation(kTrackLocationTest1);
+    TrackPointer pTrack1 = getOrAddTrackByLocation(getTestPath() + kTrackLocationTest1);
     ASSERT_NE(nullptr, pTrack1);
     TrackId testId1 = pTrack1->getId();
     ASSERT_TRUE(testId1.isValid());
@@ -131,7 +133,7 @@ TEST_F(PlayerManagerTest, UnEjectTest) {
     deck1->slotEjectTrack(1.0);
 
     // Load another track.
-    TrackPointer pTrack2 = getOrAddTrackByLocation(kTrackLocationTest2);
+    TrackPointer pTrack2 = getOrAddTrackByLocation(getTestPath() + kTrackLocationTest2);
     ASSERT_NE(nullptr, pTrack2);
     deck1->slotLoadTrack(pTrack2, false);
 
@@ -148,7 +150,7 @@ TEST_F(PlayerManagerTest, UnEjectTest) {
 TEST_F(PlayerManagerTest, UnEjectReplaceTrackTest) {
     auto deck1 = m_pPlayerManager->getDeck(1);
     // Load a track and the load another one
-    TrackPointer pTrack1 = getOrAddTrackByLocation(kTrackLocationTest1);
+    TrackPointer pTrack1 = getOrAddTrackByLocation(getTestPath() + kTrackLocationTest1);
     ASSERT_NE(nullptr, pTrack1);
     TrackId testId1 = pTrack1->getId();
     ASSERT_TRUE(testId1.isValid());
@@ -161,7 +163,7 @@ TEST_F(PlayerManagerTest, UnEjectReplaceTrackTest) {
     }
 
     // Load another track, replacing the first, causing it to be unloaded.
-    TrackPointer pTrack2 = getOrAddTrackByLocation(kTrackLocationTest2);
+    TrackPointer pTrack2 = getOrAddTrackByLocation(getTestPath() + kTrackLocationTest2);
     ASSERT_NE(nullptr, pTrack2);
     deck1->slotLoadTrack(pTrack2, false);
     m_pEngine->process(1024);
@@ -179,7 +181,7 @@ TEST_F(PlayerManagerTest, UnEjectReplaceTrackTest) {
 
 TEST_F(PlayerManagerTest, UnEjectInvalidTrackIdTest) {
     // Save an invalid trackid in playermanager.
-    auto pTrack = Track::newDummy(kTrackLocationTest1, TrackId(10));
+    auto pTrack = Track::newDummy(getTestPath() + kTrackLocationTest1, TrackId(10));
     ASSERT_NE(nullptr, pTrack);
     m_pPlayerManager->slotSaveEjectedTrack(pTrack);
     auto deck1 = m_pPlayerManager->getDeck(1);

--- a/src/test/playermanagertest.cpp
+++ b/src/test/playermanagertest.cpp
@@ -18,8 +18,8 @@
 
 namespace {
 
-const QString kTrackLocationTest1 = QStringLiteral("/id3-test-data/cover-test-png.mp3");
-const QString kTrackLocationTest2 = QStringLiteral("/id3-test-data/cover-test-vbr.mp3");
+const QString kTrackLocationTest1 = QStringLiteral("id3-test-data/cover-test-png.mp3");
+const QString kTrackLocationTest2 = QStringLiteral("id3-test-data/cover-test-vbr.mp3");
 
 void deleteTrack(Track* pTrack) {
     // Delete track objects directly in unit tests with
@@ -119,7 +119,7 @@ TEST_F(PlayerManagerTest, UnEjectTest) {
     ASSERT_EQ(nullptr, deck1->getLoadedTrack());
 
     // Load a track and eject it
-    TrackPointer pTrack1 = getOrAddTrackByLocation(getTestPath() + kTrackLocationTest1);
+    TrackPointer pTrack1 = getOrAddTrackByLocation(getTestDir().filePath(kTrackLocationTest1));
     ASSERT_NE(nullptr, pTrack1);
     TrackId testId1 = pTrack1->getId();
     ASSERT_TRUE(testId1.isValid());
@@ -133,7 +133,7 @@ TEST_F(PlayerManagerTest, UnEjectTest) {
     deck1->slotEjectTrack(1.0);
 
     // Load another track.
-    TrackPointer pTrack2 = getOrAddTrackByLocation(getTestPath() + kTrackLocationTest2);
+    TrackPointer pTrack2 = getOrAddTrackByLocation(getTestDir().filePath(kTrackLocationTest2));
     ASSERT_NE(nullptr, pTrack2);
     deck1->slotLoadTrack(pTrack2, false);
 
@@ -150,7 +150,7 @@ TEST_F(PlayerManagerTest, UnEjectTest) {
 TEST_F(PlayerManagerTest, UnEjectReplaceTrackTest) {
     auto deck1 = m_pPlayerManager->getDeck(1);
     // Load a track and the load another one
-    TrackPointer pTrack1 = getOrAddTrackByLocation(getTestPath() + kTrackLocationTest1);
+    TrackPointer pTrack1 = getOrAddTrackByLocation(getTestDir().filePath(kTrackLocationTest1));
     ASSERT_NE(nullptr, pTrack1);
     TrackId testId1 = pTrack1->getId();
     ASSERT_TRUE(testId1.isValid());
@@ -163,7 +163,7 @@ TEST_F(PlayerManagerTest, UnEjectReplaceTrackTest) {
     }
 
     // Load another track, replacing the first, causing it to be unloaded.
-    TrackPointer pTrack2 = getOrAddTrackByLocation(getTestPath() + kTrackLocationTest2);
+    TrackPointer pTrack2 = getOrAddTrackByLocation(getTestDir().filePath(kTrackLocationTest2));
     ASSERT_NE(nullptr, pTrack2);
     deck1->slotLoadTrack(pTrack2, false);
     m_pEngine->process(1024);
@@ -181,7 +181,7 @@ TEST_F(PlayerManagerTest, UnEjectReplaceTrackTest) {
 
 TEST_F(PlayerManagerTest, UnEjectInvalidTrackIdTest) {
     // Save an invalid trackid in playermanager.
-    auto pTrack = Track::newDummy(getTestPath() + kTrackLocationTest1, TrackId(10));
+    auto pTrack = Track::newDummy(getTestDir().filePath(kTrackLocationTest1), TrackId(10));
     ASSERT_NE(nullptr, pTrack);
     m_pPlayerManager->slotSaveEjectedTrack(pTrack);
     auto deck1 = m_pPlayerManager->getDeck(1);

--- a/src/test/replaygaintest.cpp
+++ b/src/test/replaygaintest.cpp
@@ -160,7 +160,7 @@ TEST_F(ReplayGainTest, NormalizePeak) {
 class AdjustReplayGainTest : public MockedEngineBackendTest {};
 
 TEST_F(AdjustReplayGainTest, AdjustReplayGainUpdatesPregain) {
-    const QString kTrackLocationTest = QDir::currentPath() + "/src/test/sine-30.wav";
+    const QString kTrackLocationTest = getTestPath() + QStringLiteral("/sine-30.wav");
     TrackPointer pTrack(Track::newTemporary(kTrackLocationTest));
 
     // Load the same track in decks 1 and 2 so we can see that the pregain is adjusted on both

--- a/src/test/replaygaintest.cpp
+++ b/src/test/replaygaintest.cpp
@@ -160,7 +160,7 @@ TEST_F(ReplayGainTest, NormalizePeak) {
 class AdjustReplayGainTest : public MockedEngineBackendTest {};
 
 TEST_F(AdjustReplayGainTest, AdjustReplayGainUpdatesPregain) {
-    const QString kTrackLocationTest = getTestPath() + QStringLiteral("/sine-30.wav");
+    const QString kTrackLocationTest = getTestDir().filePath(QStringLiteral("sine-30.wav"));
     TrackPointer pTrack(Track::newTemporary(kTrackLocationTest));
 
     // Load the same track in decks 1 and 2 so we can see that the pregain is adjusted on both

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -756,10 +756,10 @@ TEST_F(SearchQueryParserTest, CrateFilter) {
                                     QStringList(), ""));
 
     // locations for test tracks
-    const QString kTrackALocationTest(QDir::currentPath() %
-                  "/src/test/id3-test-data/cover-test-jpg.mp3");
-    const QString kTrackBLocationTest(QDir::currentPath() %
-                  "/src/test/id3-test-data/cover-test-png.mp3");
+    const QString kTrackALocationTest(getTestPath() +
+            QStringLiteral("/id3-test-data/cover-test-jpg.mp3"));
+    const QString kTrackBLocationTest(getTestPath() +
+            QStringLiteral("/id3-test-data/cover-test-png.mp3"));
 
     // Create new crate and add it to the collection
     Crate testCrate;
@@ -800,12 +800,11 @@ TEST_F(SearchQueryParserTest, ShortCrateFilter) {
                                     searchColumns, ""));
 
     // locations for test tracks
-    const QString kTrackALocationTest(QDir::currentPath() %
-                  "/src/test/id3-test-data/cover-test-jpg.mp3");
-    const QString kTrackBLocationTest(QDir::currentPath() %
-                  "/src/test/id3-test-data/cover-test-png.mp3");
-    const QString kTrackCLocationTest(QDir::currentPath() %
-                  "/src/test/id3-test-data/artist.mp3");
+    const QString kTrackALocationTest(getTestPath() +
+            QStringLiteral("/id3-test-data/cover-test-jpg.mp3"));
+    const QString kTrackBLocationTest(getTestPath() +
+            QStringLiteral("/id3-test-data/cover-test-png.mp3"));
+    const QString kTrackCLocationTest(getTestPath() + QStringLiteral("/id3-test-data/artist.mp3"));
 
     // Create new crate and add it to the collection
     Crate testCrate;
@@ -855,10 +854,10 @@ TEST_F(SearchQueryParserTest, CrateFilterQuote){
                                     QStringList(), ""));
 
     // locations for test tracks
-    const QString kTrackALocationTest(QDir::currentPath() %
-                  "/src/test/id3-test-data/cover-test-jpg.mp3");
-    const QString kTrackBLocationTest(QDir::currentPath() %
-                  "/src/test/id3-test-data/cover-test-png.mp3");
+    const QString kTrackALocationTest(getTestPath() +
+            QStringLiteral("/id3-test-data/cover-test-jpg.mp3"));
+    const QString kTrackBLocationTest(getTestPath() +
+            QStringLiteral("/id3-test-data/cover-test-png.mp3"));
 
     // Create new crate and add it to the collection
     Crate testCrate;
@@ -899,10 +898,10 @@ TEST_F(SearchQueryParserTest, CrateFilterWithOther){
                                     QStringList(), ""));
 
     // locations for test tracks
-    const QString kTrackALocationTest(QDir::currentPath() %
-                  "/src/test/id3-test-data/cover-test-jpg.mp3");
-    const QString kTrackBLocationTest(QDir::currentPath() %
-                  "/src/test/id3-test-data/cover-test-png.mp3");
+    const QString kTrackALocationTest(getTestPath() +
+            QStringLiteral("/id3-test-data/cover-test-jpg.mp3"));
+    const QString kTrackBLocationTest(getTestPath() +
+            QStringLiteral("/id3-test-data/cover-test-png.mp3"));
 
     // Create new crate and add it to the collection
     Crate testCrate;
@@ -944,10 +943,10 @@ TEST_F(SearchQueryParserTest, CrateFilterWithCrateFilterAndNegation){
                                     QStringList(), ""));
 
     // locations for test tracks
-    const QString kTrackALocationTest(QDir::currentPath() %
-                  "/src/test/id3-test-data/cover-test-jpg.mp3");
-    const QString kTrackBLocationTest(QDir::currentPath() %
-                  "/src/test/id3-test-data/cover-test-png.mp3");
+    const QString kTrackALocationTest(getTestPath() +
+            QStringLiteral("/id3-test-data/cover-test-jpg.mp3"));
+    const QString kTrackBLocationTest(getTestPath() +
+            QStringLiteral("/id3-test-data/cover-test-png.mp3"));
 
     // Create new crates and add them to the collection
     Crate testCrateA;

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -756,10 +756,10 @@ TEST_F(SearchQueryParserTest, CrateFilter) {
                                     QStringList(), ""));
 
     // locations for test tracks
-    const QString kTrackALocationTest(getTestPath() +
-            QStringLiteral("/id3-test-data/cover-test-jpg.mp3"));
-    const QString kTrackBLocationTest(getTestPath() +
-            QStringLiteral("/id3-test-data/cover-test-png.mp3"));
+    const QString kTrackALocationTest(getTestDir().filePath(
+            QStringLiteral("id3-test-data/cover-test-jpg.mp3")));
+    const QString kTrackBLocationTest(getTestDir().filePath(
+            QStringLiteral("id3-test-data/cover-test-png.mp3")));
 
     // Create new crate and add it to the collection
     Crate testCrate;
@@ -800,11 +800,12 @@ TEST_F(SearchQueryParserTest, ShortCrateFilter) {
                                     searchColumns, ""));
 
     // locations for test tracks
-    const QString kTrackALocationTest(getTestPath() +
-            QStringLiteral("/id3-test-data/cover-test-jpg.mp3"));
-    const QString kTrackBLocationTest(getTestPath() +
-            QStringLiteral("/id3-test-data/cover-test-png.mp3"));
-    const QString kTrackCLocationTest(getTestPath() + QStringLiteral("/id3-test-data/artist.mp3"));
+    const QString kTrackALocationTest(getTestDir().filePath(
+            QStringLiteral("id3-test-data/cover-test-jpg.mp3")));
+    const QString kTrackBLocationTest(getTestDir().filePath(
+            QStringLiteral("id3-test-data/cover-test-png.mp3")));
+    const QString kTrackCLocationTest(
+            getTestDir().filePath(QStringLiteral("id3-test-data/artist.mp3")));
 
     // Create new crate and add it to the collection
     Crate testCrate;
@@ -854,10 +855,10 @@ TEST_F(SearchQueryParserTest, CrateFilterQuote){
                                     QStringList(), ""));
 
     // locations for test tracks
-    const QString kTrackALocationTest(getTestPath() +
-            QStringLiteral("/id3-test-data/cover-test-jpg.mp3"));
-    const QString kTrackBLocationTest(getTestPath() +
-            QStringLiteral("/id3-test-data/cover-test-png.mp3"));
+    const QString kTrackALocationTest(getTestDir().filePath(
+            QStringLiteral("id3-test-data/cover-test-jpg.mp3")));
+    const QString kTrackBLocationTest(getTestDir().filePath(
+            QStringLiteral("id3-test-data/cover-test-png.mp3")));
 
     // Create new crate and add it to the collection
     Crate testCrate;
@@ -898,10 +899,10 @@ TEST_F(SearchQueryParserTest, CrateFilterWithOther){
                                     QStringList(), ""));
 
     // locations for test tracks
-    const QString kTrackALocationTest(getTestPath() +
-            QStringLiteral("/id3-test-data/cover-test-jpg.mp3"));
-    const QString kTrackBLocationTest(getTestPath() +
-            QStringLiteral("/id3-test-data/cover-test-png.mp3"));
+    const QString kTrackALocationTest(getTestDir().filePath(
+            QStringLiteral("id3-test-data/cover-test-jpg.mp3")));
+    const QString kTrackBLocationTest(getTestDir().filePath(
+            QStringLiteral("id3-test-data/cover-test-png.mp3")));
 
     // Create new crate and add it to the collection
     Crate testCrate;
@@ -943,10 +944,10 @@ TEST_F(SearchQueryParserTest, CrateFilterWithCrateFilterAndNegation){
                                     QStringList(), ""));
 
     // locations for test tracks
-    const QString kTrackALocationTest(getTestPath() +
-            QStringLiteral("/id3-test-data/cover-test-jpg.mp3"));
-    const QString kTrackBLocationTest(getTestPath() +
-            QStringLiteral("/id3-test-data/cover-test-png.mp3"));
+    const QString kTrackALocationTest(getTestDir().filePath(
+            QStringLiteral("id3-test-data/cover-test-jpg.mp3")));
+    const QString kTrackBLocationTest(getTestDir().filePath(
+            QStringLiteral("id3-test-data/cover-test-png.mp3")));
 
     // Create new crates and add them to the collection
     Crate testCrateA;

--- a/src/test/seratobeatgridtest.cpp
+++ b/src/test/seratobeatgridtest.cpp
@@ -5,6 +5,7 @@
 #include <QDir>
 #include <QtDebug>
 
+#include "test/mixxxtest.h"
 #include "track/beats.h"
 #include "track/serato/beatgrid.h"
 #include "track/serato/beatsimporter.h"
@@ -84,7 +85,7 @@ class SeratoBeatGridTest : public testing::Test {
 };
 
 TEST_F(SeratoBeatGridTest, ParseBeatGridDataMP3) {
-    parseBeatGridDataInDirectory(QDir("src/test/serato/data/mp3/beatgrid"),
+    parseBeatGridDataInDirectory(QDir(MixxxTest::testPath() + "/serato/data/mp3/beatgrid"),
             mixxx::taglib::FileType::MP3);
 }
 
@@ -93,7 +94,7 @@ TEST_F(SeratoBeatGridTest, ParseEmptyDataMP3) {
 }
 
 TEST_F(SeratoBeatGridTest, ParseBeatGridDataMP4) {
-    parseBeatGridDataInDirectory(QDir("src/test/serato/data/mp4/beatgrid"),
+    parseBeatGridDataInDirectory(QDir(MixxxTest::testPath() + "/serato/data/mp4/beatgrid"),
             mixxx::taglib::FileType::MP4);
 }
 
@@ -102,7 +103,7 @@ TEST_F(SeratoBeatGridTest, ParseEmptyDataMP4) {
 }
 
 TEST_F(SeratoBeatGridTest, ParseBeatGridDataFLAC) {
-    parseBeatGridDataInDirectory(QDir("src/test/serato/data/flac/beatgrid"),
+    parseBeatGridDataInDirectory(QDir(MixxxTest::testPath() + "/serato/data/flac/beatgrid"),
             mixxx::taglib::FileType::FLAC);
 }
 

--- a/src/test/seratobeatgridtest.cpp
+++ b/src/test/seratobeatgridtest.cpp
@@ -86,7 +86,7 @@ class SeratoBeatGridTest : public testing::Test {
 
 TEST_F(SeratoBeatGridTest, ParseBeatGridDataMP3) {
     parseBeatGridDataInDirectory(
-            QDir(MixxxTest::testDir().filePath(
+            QDir(MixxxTest::getOrInitTestDir().filePath(
                     QStringLiteral("serato/data/mp3/beatgrid"))),
             mixxx::taglib::FileType::MP3);
 }
@@ -97,7 +97,7 @@ TEST_F(SeratoBeatGridTest, ParseEmptyDataMP3) {
 
 TEST_F(SeratoBeatGridTest, ParseBeatGridDataMP4) {
     parseBeatGridDataInDirectory(
-            QDir(MixxxTest::testDir().filePath(
+            QDir(MixxxTest::getOrInitTestDir().filePath(
                     QStringLiteral("serato/data/mp4/beatgrid"))),
             mixxx::taglib::FileType::MP4);
 }
@@ -107,7 +107,8 @@ TEST_F(SeratoBeatGridTest, ParseEmptyDataMP4) {
 }
 
 TEST_F(SeratoBeatGridTest, ParseBeatGridDataFLAC) {
-    parseBeatGridDataInDirectory(QDir(MixxxTest::testDir().filePath("serato/data/flac/beatgrid")),
+    parseBeatGridDataInDirectory(QDir(MixxxTest::getOrInitTestDir().filePath(
+                                         "serato/data/flac/beatgrid")),
             mixxx::taglib::FileType::FLAC);
 }
 

--- a/src/test/seratobeatgridtest.cpp
+++ b/src/test/seratobeatgridtest.cpp
@@ -85,7 +85,9 @@ class SeratoBeatGridTest : public testing::Test {
 };
 
 TEST_F(SeratoBeatGridTest, ParseBeatGridDataMP3) {
-    parseBeatGridDataInDirectory(QDir(MixxxTest::testPath() + "/serato/data/mp3/beatgrid"),
+    parseBeatGridDataInDirectory(
+            QDir(MixxxTest::testDir().filePath(
+                    QStringLiteral("serato/data/mp3/beatgrid"))),
             mixxx::taglib::FileType::MP3);
 }
 
@@ -94,7 +96,9 @@ TEST_F(SeratoBeatGridTest, ParseEmptyDataMP3) {
 }
 
 TEST_F(SeratoBeatGridTest, ParseBeatGridDataMP4) {
-    parseBeatGridDataInDirectory(QDir(MixxxTest::testPath() + "/serato/data/mp4/beatgrid"),
+    parseBeatGridDataInDirectory(
+            QDir(MixxxTest::testDir().filePath(
+                    QStringLiteral("serato/data/mp4/beatgrid"))),
             mixxx::taglib::FileType::MP4);
 }
 
@@ -103,7 +107,7 @@ TEST_F(SeratoBeatGridTest, ParseEmptyDataMP4) {
 }
 
 TEST_F(SeratoBeatGridTest, ParseBeatGridDataFLAC) {
-    parseBeatGridDataInDirectory(QDir(MixxxTest::testPath() + "/serato/data/flac/beatgrid"),
+    parseBeatGridDataInDirectory(QDir(MixxxTest::testDir().filePath("serato/data/flac/beatgrid")),
             mixxx::taglib::FileType::FLAC);
 }
 

--- a/src/test/seratomarkers2test.cpp
+++ b/src/test/seratomarkers2test.cpp
@@ -400,25 +400,29 @@ TEST_F(SeratoMarkers2Test, ParseLoopEntry) {
 
 TEST_F(SeratoMarkers2Test, ParseMarkers2DataMP3) {
     parseMarkers2DataInDirectory(
-            QDir(MixxxTest::testDir().filePath(QStringLiteral("serato/data/mp3/markers2"))),
+            QDir(MixxxTest::getOrInitTestDir().filePath(
+                    QStringLiteral("serato/data/mp3/markers2"))),
             mixxx::taglib::FileType::MP3);
 }
 
 TEST_F(SeratoMarkers2Test, ParseMarkers2DataMP4) {
     parseMarkers2DataInDirectory(
-            QDir(MixxxTest::testDir().filePath(QStringLiteral("serato/data/mp4/markers2"))),
+            QDir(MixxxTest::getOrInitTestDir().filePath(
+                    QStringLiteral("serato/data/mp4/markers2"))),
             mixxx::taglib::FileType::MP4);
 }
 
 TEST_F(SeratoMarkers2Test, ParseMarkers2DataFLAC) {
     parseMarkers2DataInDirectory(
-            QDir(MixxxTest::testDir().filePath(QStringLiteral("serato/data/flac/markers2"))),
+            QDir(MixxxTest::getOrInitTestDir().filePath(
+                    QStringLiteral("serato/data/flac/markers2"))),
             mixxx::taglib::FileType::FLAC);
 }
 
 TEST_F(SeratoMarkers2Test, ParseMarkers2DataOGG) {
     parseMarkers2DataInDirectory(
-            QDir(MixxxTest::testDir().filePath(QStringLiteral("serato/data/ogg/markers2"))),
+            QDir(MixxxTest::getOrInitTestDir().filePath(
+                    QStringLiteral("serato/data/ogg/markers2"))),
             mixxx::taglib::FileType::OGG);
 }
 

--- a/src/test/seratomarkers2test.cpp
+++ b/src/test/seratomarkers2test.cpp
@@ -400,29 +400,25 @@ TEST_F(SeratoMarkers2Test, ParseLoopEntry) {
 
 TEST_F(SeratoMarkers2Test, ParseMarkers2DataMP3) {
     parseMarkers2DataInDirectory(
-            QDir(MixxxTest::testPath() +
-                    QStringLiteral("/serato/data/mp3/markers2")),
+            QDir(MixxxTest::testDir().filePath(QStringLiteral("serato/data/mp3/markers2"))),
             mixxx::taglib::FileType::MP3);
 }
 
 TEST_F(SeratoMarkers2Test, ParseMarkers2DataMP4) {
     parseMarkers2DataInDirectory(
-            QDir(MixxxTest::testPath() +
-                    QStringLiteral("/serato/data/mp4/markers2")),
+            QDir(MixxxTest::testDir().filePath(QStringLiteral("serato/data/mp4/markers2"))),
             mixxx::taglib::FileType::MP4);
 }
 
 TEST_F(SeratoMarkers2Test, ParseMarkers2DataFLAC) {
     parseMarkers2DataInDirectory(
-            QDir(MixxxTest::testPath() +
-                    QStringLiteral("/serato/data/flac/markers2")),
+            QDir(MixxxTest::testDir().filePath(QStringLiteral("serato/data/flac/markers2"))),
             mixxx::taglib::FileType::FLAC);
 }
 
 TEST_F(SeratoMarkers2Test, ParseMarkers2DataOGG) {
     parseMarkers2DataInDirectory(
-            QDir(MixxxTest::testPath() +
-                    QStringLiteral("/serato/data/ogg/markers2")),
+            QDir(MixxxTest::testDir().filePath(QStringLiteral("serato/data/ogg/markers2"))),
             mixxx::taglib::FileType::OGG);
 }
 

--- a/src/test/seratomarkers2test.cpp
+++ b/src/test/seratomarkers2test.cpp
@@ -1,12 +1,13 @@
 #include <gtest/gtest.h>
+#include <taglib/textidentificationframe.h>
+#include <taglib/tstring.h>
 
+#include <QDir>
+#include <QtDebug>
+
+#include "test/mixxxtest.h"
 #include "track/serato/markers2.h"
 #include "util/memory.h"
-
-#include <taglib/tstring.h>
-#include <taglib/textidentificationframe.h>
-#include <QtDebug>
-#include <QDir>
 
 namespace {
 
@@ -398,22 +399,30 @@ TEST_F(SeratoMarkers2Test, ParseLoopEntry) {
 }
 
 TEST_F(SeratoMarkers2Test, ParseMarkers2DataMP3) {
-    parseMarkers2DataInDirectory(QDir("src/test/serato/data/mp3/markers2"),
+    parseMarkers2DataInDirectory(
+            QDir(MixxxTest::testPath() +
+                    QStringLiteral("/serato/data/mp3/markers2")),
             mixxx::taglib::FileType::MP3);
 }
 
 TEST_F(SeratoMarkers2Test, ParseMarkers2DataMP4) {
-    parseMarkers2DataInDirectory(QDir("src/test/serato/data/mp4/markers2"),
+    parseMarkers2DataInDirectory(
+            QDir(MixxxTest::testPath() +
+                    QStringLiteral("/serato/data/mp4/markers2")),
             mixxx::taglib::FileType::MP4);
 }
 
 TEST_F(SeratoMarkers2Test, ParseMarkers2DataFLAC) {
-    parseMarkers2DataInDirectory(QDir("src/test/serato/data/flac/markers2"),
+    parseMarkers2DataInDirectory(
+            QDir(MixxxTest::testPath() +
+                    QStringLiteral("/serato/data/flac/markers2")),
             mixxx::taglib::FileType::FLAC);
 }
 
 TEST_F(SeratoMarkers2Test, ParseMarkers2DataOGG) {
-    parseMarkers2DataInDirectory(QDir("src/test/serato/data/ogg/markers2"),
+    parseMarkers2DataInDirectory(
+            QDir(MixxxTest::testPath() +
+                    QStringLiteral("/serato/data/ogg/markers2")),
             mixxx::taglib::FileType::OGG);
 }
 

--- a/src/test/seratomarkerstest.cpp
+++ b/src/test/seratomarkerstest.cpp
@@ -179,15 +179,15 @@ TEST_F(SeratoMarkersTest, ParseEntry) {
 
 TEST_F(SeratoMarkersTest, ParseMarkersDataMP3) {
     parseMarkersDataInDirectory(
-            QDir(MixxxTest::testPath() +
-                    QStringLiteral("/serato/data/mp3/markers_")),
+            QDir(MixxxTest::testDir().filePath(
+                    QStringLiteral("serato/data/mp3/markers_"))),
             mixxx::taglib::FileType::MP3);
 }
 
 TEST_F(SeratoMarkersTest, ParseMarkersDataMP4) {
     parseMarkersDataInDirectory(
-            QDir(MixxxTest::testPath() +
-                    QStringLiteral("/serato/data/mp4/markers_")),
+            QDir(MixxxTest::testDir().filePath(
+                    QStringLiteral("serato/data/mp4/markers_"))),
             mixxx::taglib::FileType::MP4);
 }
 

--- a/src/test/seratomarkerstest.cpp
+++ b/src/test/seratomarkerstest.cpp
@@ -5,6 +5,7 @@
 #include <QDir>
 #include <QtDebug>
 
+#include "test/mixxxtest.h"
 #include "track/serato/markers.h"
 #include "util/memory.h"
 
@@ -177,12 +178,16 @@ TEST_F(SeratoMarkersTest, ParseEntry) {
 }
 
 TEST_F(SeratoMarkersTest, ParseMarkersDataMP3) {
-    parseMarkersDataInDirectory(QDir("src/test/serato/data/mp3/markers_"),
+    parseMarkersDataInDirectory(
+            QDir(MixxxTest::testPath() +
+                    QStringLiteral("/serato/data/mp3/markers_")),
             mixxx::taglib::FileType::MP3);
 }
 
 TEST_F(SeratoMarkersTest, ParseMarkersDataMP4) {
-    parseMarkersDataInDirectory(QDir("src/test/serato/data/mp4/markers_"),
+    parseMarkersDataInDirectory(
+            QDir(MixxxTest::testPath() +
+                    QStringLiteral("/serato/data/mp4/markers_")),
             mixxx::taglib::FileType::MP4);
 }
 

--- a/src/test/seratomarkerstest.cpp
+++ b/src/test/seratomarkerstest.cpp
@@ -179,14 +179,14 @@ TEST_F(SeratoMarkersTest, ParseEntry) {
 
 TEST_F(SeratoMarkersTest, ParseMarkersDataMP3) {
     parseMarkersDataInDirectory(
-            QDir(MixxxTest::testDir().filePath(
+            QDir(MixxxTest::getOrInitTestDir().filePath(
                     QStringLiteral("serato/data/mp3/markers_"))),
             mixxx::taglib::FileType::MP3);
 }
 
 TEST_F(SeratoMarkersTest, ParseMarkersDataMP4) {
     parseMarkersDataInDirectory(
-            QDir(MixxxTest::testDir().filePath(
+            QDir(MixxxTest::getOrInitTestDir().filePath(
                     QStringLiteral("serato/data/mp4/markers_"))),
             mixxx::taglib::FileType::MP4);
 }

--- a/src/test/seratotagstest.cpp
+++ b/src/test/seratotagstest.cpp
@@ -201,7 +201,7 @@ TEST_F(SeratoTagsTest, CueColorConversionRoundtrip) {
 
 TEST_F(SeratoTagsTest, MarkersParseDumpRoundtrip) {
     const auto filetype = mixxx::taglib::FileType::MP3;
-    QDir dir(MixxxTest::testPath() + QStringLiteral("/serato/data/mp3/markers_/"));
+    QDir dir(MixxxTest::testDir().filePath(QStringLiteral("/serato/data/mp3/markers_/")));
     dir.setFilter(QDir::Files);
     dir.setNameFilters(QStringList() << "*.octet-stream");
     const QFileInfoList fileList = dir.entryInfoList();
@@ -234,7 +234,7 @@ TEST_F(SeratoTagsTest, MarkersParseDumpRoundtrip) {
 
 TEST_F(SeratoTagsTest, Markers2RoundTrip) {
     const auto filetype = mixxx::taglib::FileType::MP3;
-    QDir dir(MixxxTest::testPath() + QStringLiteral("/serato/data/mp3/markers2/"));
+    QDir dir(MixxxTest::testDir().filePath(QStringLiteral("serato/data/mp3/markers2/")));
     dir.setFilter(QDir::Files);
     dir.setNameFilters(QStringList() << "*.octet-stream");
     const QFileInfoList fileList = dir.entryInfoList();

--- a/src/test/seratotagstest.cpp
+++ b/src/test/seratotagstest.cpp
@@ -201,7 +201,7 @@ TEST_F(SeratoTagsTest, CueColorConversionRoundtrip) {
 
 TEST_F(SeratoTagsTest, MarkersParseDumpRoundtrip) {
     const auto filetype = mixxx::taglib::FileType::MP3;
-    QDir dir(MixxxTest::testDir().filePath(QStringLiteral("/serato/data/mp3/markers_/")));
+    QDir dir(MixxxTest::getOrInitTestDir().filePath(QStringLiteral("/serato/data/mp3/markers_/")));
     dir.setFilter(QDir::Files);
     dir.setNameFilters(QStringList() << "*.octet-stream");
     const QFileInfoList fileList = dir.entryInfoList();
@@ -234,7 +234,7 @@ TEST_F(SeratoTagsTest, MarkersParseDumpRoundtrip) {
 
 TEST_F(SeratoTagsTest, Markers2RoundTrip) {
     const auto filetype = mixxx::taglib::FileType::MP3;
-    QDir dir(MixxxTest::testDir().filePath(QStringLiteral("serato/data/mp3/markers2/")));
+    QDir dir(MixxxTest::getOrInitTestDir().filePath(QStringLiteral("serato/data/mp3/markers2/")));
     dir.setFilter(QDir::Files);
     dir.setNameFilters(QStringList() << "*.octet-stream");
     const QFileInfoList fileList = dir.entryInfoList();

--- a/src/test/seratotagstest.cpp
+++ b/src/test/seratotagstest.cpp
@@ -3,6 +3,7 @@
 #include <QDir>
 #include <QFile>
 
+#include "test/mixxxtest.h"
 #include "track/serato/tags.h"
 #include "util/color/predefinedcolorpalettes.h"
 
@@ -200,7 +201,7 @@ TEST_F(SeratoTagsTest, CueColorConversionRoundtrip) {
 
 TEST_F(SeratoTagsTest, MarkersParseDumpRoundtrip) {
     const auto filetype = mixxx::taglib::FileType::MP3;
-    QDir dir(QStringLiteral("src/test/serato/data/mp3/markers_/"));
+    QDir dir(MixxxTest::testPath() + QStringLiteral("/serato/data/mp3/markers_/"));
     dir.setFilter(QDir::Files);
     dir.setNameFilters(QStringList() << "*.octet-stream");
     const QFileInfoList fileList = dir.entryInfoList();
@@ -233,7 +234,7 @@ TEST_F(SeratoTagsTest, MarkersParseDumpRoundtrip) {
 
 TEST_F(SeratoTagsTest, Markers2RoundTrip) {
     const auto filetype = mixxx::taglib::FileType::MP3;
-    QDir dir(QStringLiteral("src/test/serato/data/mp3/markers2/"));
+    QDir dir(MixxxTest::testPath() + QStringLiteral("/serato/data/mp3/markers2/"));
     dir.setFilter(QDir::Files);
     dir.setNameFilters(QStringList() << "*.octet-stream");
     const QFileInfoList fileList = dir.entryInfoList();

--- a/src/test/signalpathtest.h
+++ b/src/test/signalpathtest.h
@@ -163,9 +163,13 @@ class BaseSignalPathTest : public MixxxTest, SoundSourceProviderRegistration {
 
         // Wait for the track to load.
         ProcessBuffer();
-        while (!pEngineDeck->getEngineBuffer()->isTrackLoaded()) {
-            QTest::qSleep(1); // millis
+        for (int i = 0; i < 2000; ++i) {
+            if (pEngineDeck->getEngineBuffer()->isTrackLoaded()) {
+                break;
+            }
+            QTest::qSleep(1); // sleep 1 ms for waiting 2 s at max
         }
+        DEBUG_ASSERT(pEngineDeck->getEngineBuffer()->isTrackLoaded());
     }
 
     // Asserts that the contents of the output buffer matches a reference

--- a/src/test/signalpathtest.h
+++ b/src/test/signalpathtest.h
@@ -185,7 +185,7 @@ class BaseSignalPathTest : public MixxxTest, SoundSourceProviderRegistration {
             const int iBufferSize,
             const QString& reference_title,
             const double delta = .0001) {
-        QFile f(getTestPath() + QStringLiteral("/reference_buffers/") + reference_title);
+        QFile f(getTestDir().filePath(QStringLiteral("reference_buffers/") + reference_title));
         bool pass = true;
         int i = 0;
         // If the file is not there, we will fail and write out the .actual
@@ -223,7 +223,8 @@ class BaseSignalPathTest : public MixxxTest, SoundSourceProviderRegistration {
             qWarning() << "Buffer does not match" << reference_title
                        << ", actual buffer written to "
                        << "reference_buffers/" + fname_actual;
-            QFile actual(getTestPath() + QStringLiteral("/reference_buffers/") + fname_actual);
+            QFile actual(getTestDir().filePath(
+                    QStringLiteral("reference_buffers/") + fname_actual));
             ASSERT_TRUE(actual.open(QFile::WriteOnly | QFile::Text));
             QTextStream out(&actual);
             for (int i = 0; i < iBufferSize; i += 2) {
@@ -270,7 +271,7 @@ class BaseSignalPathTest : public MixxxTest, SoundSourceProviderRegistration {
 class SignalPathTest : public BaseSignalPathTest {
   protected:
     SignalPathTest() {
-        const QString kTrackLocationTest = getTestPath() + QStringLiteral("/sine-30.wav");
+        const QString kTrackLocationTest = getTestDir().filePath(QStringLiteral("sine-30.wav"));
         TrackPointer pTrack(Track::newTemporary(kTrackLocationTest));
 
         loadTrack(m_pMixerDeck1, pTrack);

--- a/src/test/signalpathtest.h
+++ b/src/test/signalpathtest.h
@@ -185,7 +185,7 @@ class BaseSignalPathTest : public MixxxTest, SoundSourceProviderRegistration {
             const int iBufferSize,
             const QString& reference_title,
             const double delta = .0001) {
-        QFile f(QDir::currentPath() + "/src/test/reference_buffers/" + reference_title);
+        QFile f(getTestPath() + QStringLiteral("/reference_buffers/") + reference_title);
         bool pass = true;
         int i = 0;
         // If the file is not there, we will fail and write out the .actual
@@ -223,7 +223,7 @@ class BaseSignalPathTest : public MixxxTest, SoundSourceProviderRegistration {
             qWarning() << "Buffer does not match" << reference_title
                        << ", actual buffer written to "
                        << "reference_buffers/" + fname_actual;
-            QFile actual(QDir::currentPath() + "/src/test/reference_buffers/" + fname_actual);
+            QFile actual(getTestPath() + QStringLiteral("/reference_buffers/") + fname_actual);
             ASSERT_TRUE(actual.open(QFile::WriteOnly | QFile::Text));
             QTextStream out(&actual);
             for (int i = 0; i < iBufferSize; i += 2) {
@@ -270,7 +270,7 @@ class BaseSignalPathTest : public MixxxTest, SoundSourceProviderRegistration {
 class SignalPathTest : public BaseSignalPathTest {
   protected:
     SignalPathTest() {
-        const QString kTrackLocationTest = QDir::currentPath() + "/src/test/sine-30.wav";
+        const QString kTrackLocationTest = getTestPath() + QStringLiteral("/sine-30.wav");
         TrackPointer pTrack(Track::newTemporary(kTrackLocationTest));
 
         loadTrack(m_pMixerDeck1, pTrack);

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -12,8 +12,6 @@
 
 namespace {
 
-const QDir kTestDir(QDir::current().absoluteFilePath("src/test/id3-test-data"));
-
 const SINT kBufferSizes[] = {
         256,
         512,
@@ -77,11 +75,13 @@ class SoundSourceProxyTest : public MixxxTest, SoundSourceProviderRegistration {
         return supportedFileNameSuffixes;
     }
 
-    static QStringList getFilePaths() {
+    QStringList getFilePaths() {
         QStringList filePaths;
         const QStringList fileNameSuffixes = getFileNameSuffixes();
         for (const auto& fileNameSuffix : fileNameSuffixes) {
-            filePaths.append(kTestDir.absoluteFilePath("cover-test" + fileNameSuffix));
+            filePaths.append(getTestPath() +
+                    QStringLiteral("/id3-test-data/cover-test") +
+                    fileNameSuffix);
         }
         return filePaths;
     }
@@ -219,7 +219,7 @@ TEST_F(SoundSourceProxyTest, openEmptyFile) {
 }
 
 TEST_F(SoundSourceProxyTest, readArtist) {
-    auto pTrack = Track::newTemporary(kTestDir, "artist.mp3");
+    auto pTrack = Track::newTemporary(getTestPath() + QStringLiteral("/id3-test-data/artist.mp3"));
     SoundSourceProxy proxy(pTrack);
     EXPECT_EQ(
             SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated,
@@ -234,7 +234,7 @@ TEST_F(SoundSourceProxyTest, readNoTitle) {
 
     // Test a file with no metadata
     auto pTrack1 = Track::newTemporary(
-            kTestDir, "empty.mp3");
+            getTestPath() + QStringLiteral("/id3-test-data/empty.mp3"));
     SoundSourceProxy proxy1(pTrack1);
     EXPECT_EQ(
             SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated,
@@ -254,7 +254,7 @@ TEST_F(SoundSourceProxyTest, readNoTitle) {
 
     // Test a file with other metadata but no title
     auto pTrack2 = Track::newTemporary(
-            kTestDir, "cover-test-png.mp3");
+            getTestPath() + QStringLiteral("/id3-test-data/cover-test-png.mp3"));
     SoundSourceProxy proxy2(pTrack2);
     EXPECT_EQ(
             SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated,
@@ -274,7 +274,7 @@ TEST_F(SoundSourceProxyTest, readNoTitle) {
 
     // Test a file with a title
     auto pTrack3 = Track::newTemporary(
-            kTestDir, "cover-test-jpg.mp3");
+            getTestPath() + QStringLiteral("/id3-test-data/cover-test-jpg.mp3"));
     SoundSourceProxy proxy3(pTrack3);
     EXPECT_EQ(
             SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated,
@@ -285,7 +285,8 @@ TEST_F(SoundSourceProxyTest, readNoTitle) {
 }
 
 TEST_F(SoundSourceProxyTest, TOAL_TPE2) {
-    auto pTrack = Track::newTemporary(kTestDir, "TOAL_TPE2.mp3");
+    auto pTrack = Track::newTemporary(
+            getTestPath() + QStringLiteral("/id3-test-data/TOAL_TPE2.mp3"));
     SoundSourceProxy proxy(pTrack);
     mixxx::TrackMetadata trackMetadata;
     EXPECT_EQ(mixxx::MetadataSource::ImportResult::Succeeded,
@@ -758,7 +759,7 @@ TEST_F(SoundSourceProxyTest, getTypeFromFile) {
             tempDir.filePath("file_with_uppercase_suffix. MP3 ");
 
     // Create the temporary files by copying an existing file
-    const QString validFilePath = kTestDir.absoluteFilePath(QStringLiteral("empty.mp3"));
+    const QString validFilePath = getTestPath() + QStringLiteral("/id3-test-data/empty.mp3");
     mixxxtest::copyFile(validFilePath, filePathWithoutSuffix);
     mixxxtest::copyFile(validFilePath, filePathWithEmptySuffix);
     mixxxtest::copyFile(validFilePath, filePathWithUnknownSuffix);
@@ -790,7 +791,7 @@ TEST_F(SoundSourceProxyTest, getTypeFromMissingFile) {
     // Also verify that the shortened suffix ".aif" (case-insensitive) is
     // mapped to file type "aiff", independent of whether the file exists or not!
     const QFileInfo missingFileWithUppercaseSuffix(
-            kTestDir.absoluteFilePath(QStringLiteral("missing_file.AIF")));
+            getTestPath() + QStringLiteral("/id3-test-data/missing_file.AIF"));
 
     ASSERT_FALSE(missingFileWithUppercaseSuffix.exists());
 
@@ -808,7 +809,7 @@ TEST_F(SoundSourceProxyTest, getTypeFromAiffFile) {
     ASSERT_TRUE(SoundSourceProxy::isFileSuffixSupported(QStringLiteral("aiff")));
 
     const QString aiffFilePath =
-            kTestDir.absoluteFilePath(QStringLiteral("cover-test.aiff"));
+            getTestPath() + QStringLiteral("/id3-test-data/cover-test.aiff");
 
     ASSERT_TRUE(QFileInfo::exists(aiffFilePath));
     ASSERT_STREQ(qPrintable("aiff"),
@@ -852,7 +853,7 @@ TEST_F(SoundSourceProxyTest, handleWrongFileSuffix) {
     const QString wrongFileType = QStringLiteral("aiff");
 
     const QString contentFileTypePath =
-            kTestDir.absoluteFilePath(QStringLiteral("cover-test-png.mp3"));
+            getTestPath() + QStringLiteral("/id3-test-data/cover-test-png.mp3");
     const QString wrongFileTypePath =
             tempDir.filePath(QStringLiteral("cover-test.aiff"));
     mixxxtest::copyFile(contentFileTypePath, wrongFileTypePath);

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -79,9 +79,9 @@ class SoundSourceProxyTest : public MixxxTest, SoundSourceProviderRegistration {
         QStringList filePaths;
         const QStringList fileNameSuffixes = getFileNameSuffixes();
         for (const auto& fileNameSuffix : fileNameSuffixes) {
-            filePaths.append(getTestPath() +
-                    QStringLiteral("/id3-test-data/cover-test") +
-                    fileNameSuffix);
+            filePaths.append(getTestDir().filePath(
+                    QStringLiteral("id3-test-data/cover-test") +
+                    fileNameSuffix));
         }
         return filePaths;
     }
@@ -219,7 +219,8 @@ TEST_F(SoundSourceProxyTest, openEmptyFile) {
 }
 
 TEST_F(SoundSourceProxyTest, readArtist) {
-    auto pTrack = Track::newTemporary(getTestPath() + QStringLiteral("/id3-test-data/artist.mp3"));
+    auto pTrack = Track::newTemporary(
+            getTestDir().filePath(QStringLiteral("id3-test-data/artist.mp3")));
     SoundSourceProxy proxy(pTrack);
     EXPECT_EQ(
             SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated,
@@ -234,7 +235,7 @@ TEST_F(SoundSourceProxyTest, readNoTitle) {
 
     // Test a file with no metadata
     auto pTrack1 = Track::newTemporary(
-            getTestPath() + QStringLiteral("/id3-test-data/empty.mp3"));
+            getTestDir().filePath(QStringLiteral("id3-test-data/empty.mp3")));
     SoundSourceProxy proxy1(pTrack1);
     EXPECT_EQ(
             SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated,
@@ -254,7 +255,7 @@ TEST_F(SoundSourceProxyTest, readNoTitle) {
 
     // Test a file with other metadata but no title
     auto pTrack2 = Track::newTemporary(
-            getTestPath() + QStringLiteral("/id3-test-data/cover-test-png.mp3"));
+            getTestDir().filePath(QStringLiteral("id3-test-data/cover-test-png.mp3")));
     SoundSourceProxy proxy2(pTrack2);
     EXPECT_EQ(
             SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated,
@@ -274,7 +275,7 @@ TEST_F(SoundSourceProxyTest, readNoTitle) {
 
     // Test a file with a title
     auto pTrack3 = Track::newTemporary(
-            getTestPath() + QStringLiteral("/id3-test-data/cover-test-jpg.mp3"));
+            getTestDir().filePath(QStringLiteral("id3-test-data/cover-test-jpg.mp3")));
     SoundSourceProxy proxy3(pTrack3);
     EXPECT_EQ(
             SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated,
@@ -286,7 +287,7 @@ TEST_F(SoundSourceProxyTest, readNoTitle) {
 
 TEST_F(SoundSourceProxyTest, TOAL_TPE2) {
     auto pTrack = Track::newTemporary(
-            getTestPath() + QStringLiteral("/id3-test-data/TOAL_TPE2.mp3"));
+            getTestDir().filePath(QStringLiteral("id3-test-data/TOAL_TPE2.mp3")));
     SoundSourceProxy proxy(pTrack);
     mixxx::TrackMetadata trackMetadata;
     EXPECT_EQ(mixxx::MetadataSource::ImportResult::Succeeded,
@@ -759,7 +760,7 @@ TEST_F(SoundSourceProxyTest, getTypeFromFile) {
             tempDir.filePath("file_with_uppercase_suffix. MP3 ");
 
     // Create the temporary files by copying an existing file
-    const QString validFilePath = getTestPath() + QStringLiteral("/id3-test-data/empty.mp3");
+    const QString validFilePath = getTestDir().filePath(QStringLiteral("id3-test-data/empty.mp3"));
     mixxxtest::copyFile(validFilePath, filePathWithoutSuffix);
     mixxxtest::copyFile(validFilePath, filePathWithEmptySuffix);
     mixxxtest::copyFile(validFilePath, filePathWithUnknownSuffix);
@@ -791,7 +792,7 @@ TEST_F(SoundSourceProxyTest, getTypeFromMissingFile) {
     // Also verify that the shortened suffix ".aif" (case-insensitive) is
     // mapped to file type "aiff", independent of whether the file exists or not!
     const QFileInfo missingFileWithUppercaseSuffix(
-            getTestPath() + QStringLiteral("/id3-test-data/missing_file.AIF"));
+            getTestDir().filePath(QStringLiteral("id3-test-data/missing_file.AIF")));
 
     ASSERT_FALSE(missingFileWithUppercaseSuffix.exists());
 
@@ -809,7 +810,7 @@ TEST_F(SoundSourceProxyTest, getTypeFromAiffFile) {
     ASSERT_TRUE(SoundSourceProxy::isFileSuffixSupported(QStringLiteral("aiff")));
 
     const QString aiffFilePath =
-            getTestPath() + QStringLiteral("/id3-test-data/cover-test.aiff");
+            getTestDir().filePath(QStringLiteral("id3-test-data/cover-test.aiff"));
 
     ASSERT_TRUE(QFileInfo::exists(aiffFilePath));
     ASSERT_STREQ(qPrintable("aiff"),
@@ -853,7 +854,7 @@ TEST_F(SoundSourceProxyTest, handleWrongFileSuffix) {
     const QString wrongFileType = QStringLiteral("aiff");
 
     const QString contentFileTypePath =
-            getTestPath() + QStringLiteral("/id3-test-data/cover-test-png.mp3");
+            getTestDir().filePath(QStringLiteral("id3-test-data/cover-test-png.mp3"));
     const QString wrongFileTypePath =
             tempDir.filePath(QStringLiteral("cover-test.aiff"));
     mixxxtest::copyFile(contentFileTypePath, wrongFileTypePath);

--- a/src/test/synctrackmetadatatest.cpp
+++ b/src/test/synctrackmetadatatest.cpp
@@ -13,8 +13,8 @@
 
 namespace {
 
-const QString kTestFileWithMetadata = QStringLiteral("/id3-test-data/cover-test-jpg.mp3");
-const QString kTestFileWithoutMetadata = QStringLiteral("/id3-test-data/empty.mp3");
+const QString kTestFileWithMetadata = QStringLiteral("id3-test-data/cover-test-jpg.mp3");
+const QString kTestFileWithoutMetadata = QStringLiteral("id3-test-data/empty.mp3");
 
 enum class AdjustFileTime {
     Earlier,
@@ -124,7 +124,7 @@ class SyncTrackMetadataTest : public LibraryTest {
   protected:
     explicit SyncTrackMetadataTest(
             const QString& testFile)
-            : m_tempFileSystem(QFileInfo(getTestPath() + testFile)) {
+            : m_tempFileSystem(QFileInfo(getTestDir().filePath(testFile))) {
         // Date back the file before adding it to the track collection
         // to ensure that all newly generated time stamps are strictly
         // greater than the synchronization time stamp in the library.

--- a/src/test/synctrackmetadatatest.cpp
+++ b/src/test/synctrackmetadatatest.cpp
@@ -373,6 +373,7 @@ class SyncTrackMetadataTest : public LibraryTest {
     void checkTrackRecordSourceSyncStatus(
             mixxx::TrackRecord::SourceSyncStatus expectedSourceSyncStatus) const {
         const auto pTrack = prepareTestTrack();
+        ASSERT_NE(nullptr, pTrack);
         const mixxx::TrackRecord emptyTrackRecord;
         EXPECT_EQ(mixxx::TrackRecord::SourceSyncStatus::Void,
                 emptyTrackRecord.checkSourceSyncStatus(pTrack->getFileInfo()));

--- a/src/test/synctrackmetadatatest.cpp
+++ b/src/test/synctrackmetadatatest.cpp
@@ -13,11 +13,8 @@
 
 namespace {
 
-const auto kTestDir = QDir(QDir::current().absoluteFilePath("src/test/id3-test-data"));
-
-const auto kTestFileWithMetadata = QFileInfo(kTestDir, QStringLiteral("cover-test-jpg.mp3"));
-
-const auto kTestFileWithoutMetadata = QFileInfo(kTestDir, QStringLiteral("empty.mp3"));
+const QString kTestFileWithMetadata = QStringLiteral("/id3-test-data/cover-test-jpg.mp3");
+const QString kTestFileWithoutMetadata = QStringLiteral("/id3-test-data/empty.mp3");
 
 enum class AdjustFileTime {
     Earlier,
@@ -126,8 +123,8 @@ class SyncTrackMetadataConfigScope final {
 class SyncTrackMetadataTest : public LibraryTest {
   protected:
     explicit SyncTrackMetadataTest(
-            const QFileInfo& testFile)
-            : m_tempFileSystem(testFile) {
+            const QString& testFile)
+            : m_tempFileSystem(QFileInfo(getTestPath() + testFile)) {
         // Date back the file before adding it to the track collection
         // to ensure that all newly generated time stamps are strictly
         // greater than the synchronization time stamp in the library.
@@ -389,7 +386,7 @@ class SyncTrackMetadataTest : public LibraryTest {
 
 class SyncTrackMetadataStatusSynchronizedTest : public SyncTrackMetadataTest {
   protected:
-    explicit SyncTrackMetadataStatusSynchronizedTest(const QFileInfo& testFile)
+    explicit SyncTrackMetadataStatusSynchronizedTest(const QString& testFile)
             : SyncTrackMetadataTest(testFile) {
     }
 
@@ -446,7 +443,7 @@ TEST_F(LibraryFileWithoutMetadataSyncStatusSynchronizedTest, saveTrackMetadataWi
 
 class SyncTrackMetadataStatusOutdatedTest : public SyncTrackMetadataTest {
   public:
-    explicit SyncTrackMetadataStatusOutdatedTest(const QFileInfo& testFile)
+    explicit SyncTrackMetadataStatusOutdatedTest(const QString& testFile)
             : SyncTrackMetadataTest(testFile) {
         // Predate the file after it has already been added to the library
         // in the base class constructor.
@@ -547,7 +544,7 @@ TEST_F(LibraryFileWithoutMetadataSyncStatusOutdatedTest, saveTrackMetadataWithSy
 
 class SyncTrackMetadataStatusUnknownTest : public SyncTrackMetadataTest {
   public:
-    explicit SyncTrackMetadataStatusUnknownTest(const QFileInfo& testFile)
+    explicit SyncTrackMetadataStatusUnknownTest(const QString& testFile)
             : SyncTrackMetadataTest(testFile) {
     }
 
@@ -627,7 +624,7 @@ TEST_F(LibraryFileWithoutMetadataSyncStatusUnknownTest, saveTrackMetadataWithSyn
 
 class SyncTrackMetadataStatusUndefinedTest : public SyncTrackMetadataTest {
   public:
-    explicit SyncTrackMetadataStatusUndefinedTest(const QFileInfo& testFile)
+    explicit SyncTrackMetadataStatusUndefinedTest(const QString& testFile)
             : SyncTrackMetadataTest(testFile) {
     }
 

--- a/src/test/taglibtest.cpp
+++ b/src/test/taglibtest.cpp
@@ -33,8 +33,7 @@ TEST_F(TagLibTest, WriteID3v2Tag) {
 
     // Write metadata -> only an ID3v2 tag should be added
     mixxx::TrackMetadata trackMetadata;
-    trackMetadata.refTrackInfo().setTitle(
-            MixxxTest::testPath() + QStringLiteral("/id3-test-data/title"));
+    trackMetadata.refTrackInfo().setTitle(QStringLiteral("title"));
     const auto exported =
             mixxx::MetadataSourceTagLib(
                     tmpFileName, mixxx::taglib::FileType::MP3)
@@ -54,8 +53,7 @@ TEST_F(TagLibTest, WriteID3v2Tag) {
     qDebug() << "Updating track title";
 
     // Write metadata again -> only the ID3v2 tag should be modified
-    trackMetadata.refTrackInfo().setTitle(
-            MixxxTest::testPath() + QStringLiteral("/id3-test-data/title2"));
+    trackMetadata.refTrackInfo().setTitle(QStringLiteral("title2"));
     const auto exported2 =
             mixxx::MetadataSourceTagLib(
                     tmpFileName, mixxx::taglib::FileType::MP3)

--- a/src/test/taglibtest.cpp
+++ b/src/test/taglibtest.cpp
@@ -17,7 +17,7 @@ TEST_F(TagLibTest, WriteID3v2Tag) {
 
     // Create the temporary file by copying an existing file
     mixxxtest::copyFile(
-            MixxxTest::testDir().filePath(QStringLiteral("id3-test-data/empty.mp3")),
+            MixxxTest::getOrInitTestDir().filePath(QStringLiteral("id3-test-data/empty.mp3")),
             tmpFileName);
 
     // Verify that the file has no tags

--- a/src/test/taglibtest.cpp
+++ b/src/test/taglibtest.cpp
@@ -17,7 +17,7 @@ TEST_F(TagLibTest, WriteID3v2Tag) {
 
     // Create the temporary file by copying an existing file
     mixxxtest::copyFile(
-            MixxxTest::testPath() + QStringLiteral("/id3-test-data/empty.mp3"),
+            MixxxTest::testDir().filePath(QStringLiteral("id3-test-data/empty.mp3")),
             tmpFileName);
 
     // Verify that the file has no tags

--- a/src/test/taglibtest.cpp
+++ b/src/test/taglibtest.cpp
@@ -4,11 +4,6 @@
 #include "sources/metadatasourcetaglib.h"
 #include "test/mixxxtest.h"
 
-namespace {
-
-const QDir kTestDir = QDir::current().absoluteFilePath("src/test/id3-test-data");
-
-} // anonymous namespace
 
 class TagLibTest : public testing::Test {
 };
@@ -21,7 +16,9 @@ TEST_F(TagLibTest, WriteID3v2Tag) {
     const QString tmpFileName = tempDir.filePath("no_id3v1_mp3");
 
     // Create the temporary file by copying an existing file
-    mixxxtest::copyFile(kTestDir.absoluteFilePath("empty.mp3"), tmpFileName);
+    mixxxtest::copyFile(
+            MixxxTest::testPath() + QStringLiteral("/id3-test-data/empty.mp3"),
+            tmpFileName);
 
     // Verify that the file has no tags
     {
@@ -36,7 +33,8 @@ TEST_F(TagLibTest, WriteID3v2Tag) {
 
     // Write metadata -> only an ID3v2 tag should be added
     mixxx::TrackMetadata trackMetadata;
-    trackMetadata.refTrackInfo().setTitle("title");
+    trackMetadata.refTrackInfo().setTitle(
+            MixxxTest::testPath() + QStringLiteral("/id3-test-data/title"));
     const auto exported =
             mixxx::MetadataSourceTagLib(
                     tmpFileName, mixxx::taglib::FileType::MP3)
@@ -56,7 +54,8 @@ TEST_F(TagLibTest, WriteID3v2Tag) {
     qDebug() << "Updating track title";
 
     // Write metadata again -> only the ID3v2 tag should be modified
-    trackMetadata.refTrackInfo().setTitle("title2");
+    trackMetadata.refTrackInfo().setTitle(
+            MixxxTest::testPath() + QStringLiteral("/id3-test-data/title2"));
     const auto exported2 =
             mixxx::MetadataSourceTagLib(
                     tmpFileName, mixxx::taglib::FileType::MP3)

--- a/src/test/trackexport_test.h
+++ b/src/test/trackexport_test.h
@@ -1,15 +1,15 @@
 #pragma once
 
-#include "library/export/trackexportworker.h"
-
-#include <future>
-
 #include <gtest/gtest.h>
 
 #include <QDateTime>
 #include <QDebug>
 #include <QPair>
 #include <QTemporaryDir>
+#include <future>
+
+#include "library/export/trackexportworker.h"
+#include "test/mixxxtest.h"
 
 class FakeOverwriteAnswerer : public QObject {
     Q_OBJECT
@@ -64,9 +64,9 @@ class FakeOverwriteAnswerer : public QObject {
 
 class TrackExporterTest : public testing::Test {
   public:
-    TrackExporterTest() :
-        m_testDataDir(QDir::current().absoluteFilePath(
-                "src/test/id3-test-data")) { }
+    TrackExporterTest()
+            : m_testDataDir(MixxxTest::testPath() + QStringLiteral("/id3-test-data")) {
+    }
 
     void SetUp() override {
         ASSERT_TRUE(m_exportTempDir.isValid());

--- a/src/test/trackexport_test.h
+++ b/src/test/trackexport_test.h
@@ -65,7 +65,7 @@ class FakeOverwriteAnswerer : public QObject {
 class TrackExporterTest : public testing::Test {
   public:
     TrackExporterTest()
-            : m_testDataDir(MixxxTest::testPath() + QStringLiteral("/id3-test-data")) {
+            : m_testDataDir(MixxxTest::testDir().filePath(QStringLiteral("id3-test-data"))) {
     }
 
     void SetUp() override {

--- a/src/test/trackexport_test.h
+++ b/src/test/trackexport_test.h
@@ -65,7 +65,8 @@ class FakeOverwriteAnswerer : public QObject {
 class TrackExporterTest : public testing::Test {
   public:
     TrackExporterTest()
-            : m_testDataDir(MixxxTest::testDir().filePath(QStringLiteral("id3-test-data"))) {
+            : m_testDataDir(MixxxTest::getOrInitTestDir().filePath(
+                      QStringLiteral("id3-test-data"))) {
     }
 
     void SetUp() override {

--- a/src/test/trackupdate_test.cpp
+++ b/src/test/trackupdate_test.cpp
@@ -19,7 +19,7 @@ class TrackUpdateTest : public MixxxTest, SoundSourceProviderRegistration {
 
     static TrackPointer newTestTrack() {
         return Track::newTemporary(
-                QDir(MixxxTest::testDir().filePath(QStringLiteral("id3-test-data"))),
+                QDir(MixxxTest::getOrInitTestDir().filePath(QStringLiteral("id3-test-data"))),
                 "TOAL_TPE2.mp3");
     }
 

--- a/src/test/trackupdate_test.cpp
+++ b/src/test/trackupdate_test.cpp
@@ -6,12 +6,6 @@
 #include "test/soundsourceproviderregistration.h"
 #include "track/track.h"
 
-namespace {
-
-const QDir kTestDir(QDir::current().absoluteFilePath("src/test/id3-test-data"));
-
-} // anonymous namespace
-
 // Test for updating track metadata and cover art from files.
 class TrackUpdateTest : public MixxxTest, SoundSourceProviderRegistration {
   protected:
@@ -24,7 +18,9 @@ class TrackUpdateTest : public MixxxTest, SoundSourceProviderRegistration {
     }
 
     static TrackPointer newTestTrack() {
-        return Track::newTemporary(kTestDir, "TOAL_TPE2.mp3");
+        return Track::newTemporary(
+                QDir(MixxxTest::testPath() + QStringLiteral("/id3-test-data")),
+                "TOAL_TPE2.mp3");
     }
 
     TrackPointer newTestTrackParsed() const {

--- a/src/test/trackupdate_test.cpp
+++ b/src/test/trackupdate_test.cpp
@@ -19,7 +19,7 @@ class TrackUpdateTest : public MixxxTest, SoundSourceProviderRegistration {
 
     static TrackPointer newTestTrack() {
         return Track::newTemporary(
-                QDir(MixxxTest::testPath() + QStringLiteral("/id3-test-data")),
+                QDir(MixxxTest::testDir().filePath(QStringLiteral("id3-test-data"))),
                 "TOAL_TPE2.mp3");
     }
 

--- a/tools/clang_format.py
+++ b/tools/clang_format.py
@@ -53,8 +53,8 @@ def run_clang_format_on_lines(rootdir, file_to_format, stylepath=None):
         "clang-format",
         "--style=file",
         # The --assume-filename argument sets the path for the .clang-format
-        # config file implicitly by assuming a different location of the file to
-        # format
+        # config file implicitly by assuming a different location of the file
+        # to format
         "--assume-filename={}".format(
             os.path.join(
                 stylepath if stylepath else rootdir, file_to_format.filename


### PR DESCRIPTION
This PR removes the mixxx-testdata target that copies/symlinks the test data into the build directory. 
Instead it makes use of the existing function that is looking up the source tree path form CMakeCache. 
This replaces the hard coded paths in the test classes. 

This also fixes a circular symlink that happens when changing from 2.3 to main reported here: 
https://mixxx.zulipchat.com/#narrow/stream/247620-development-help/topic/Failing.20controller.20test 
 
