### PR TITLE
Fix string composition of new crate names

### DIFF
--- a/src/library/trackset/crate/cratefeaturehelper.cpp
+++ b/src/library/trackset/crate/cratefeaturehelper.cpp
@@ -22,7 +22,7 @@ QString CrateFeatureHelper::proposeNameForNewCrate(
         if (suffixCounter++ > 0) {
             // Append suffix " 2", " 3", ...
             proposedName = QStringLiteral("%1 %2")
-                                   .arg(initialName, suffixCounter);
+                                   .arg(initialName, QString::number(suffixCounter));
         } else {
             proposedName = initialName;
         }


### PR DESCRIPTION
Regression caused by 76f5fae62607daccf790aececc35e302ea2d0cb6.