### PR TITLE
BaseSqlTableModel: disable undesirable sorting

### DIFF
--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -154,6 +154,8 @@ class BaseSqlTableModel : public BaseTrackTableModel {
     QString m_currentSearchFilter;
     QVector<QHash<int, QVariant>> m_headerInfo;
     QString m_trackSourceOrderBy;
+    QHash<TrackId, int> m_sortedTracksIndexes;
+    bool m_bSaveSortedTracks;
 
     DISALLOW_COPY_AND_ASSIGN(BaseSqlTableModel);
 };

--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -455,12 +455,13 @@ QVariant BaseTrackCache::data(TrackId trackId, int column) const {
 }
 
 void BaseTrackCache::filterAndSort(const QSet<TrackId>& trackIds,
-                                   const QString& searchQuery,
-                                   const QString& extraFilter,
-                                   const QString& orderByClause,
-                                   const QList<SortColumn>& sortColumns,
-                                   const int columnOffset,
-                                   QHash<TrackId, int>* trackToIndex) {
+        const QString& searchQuery,
+        const QString& extraFilter,
+        const QString& orderByClause,
+        const QList<SortColumn>& sortColumns,
+        const int columnOffset,
+        QHash<TrackId, int>* sortedIndexes,
+        QHash<TrackId, int>* trackToIndex) {
     // Skip processing if there are no tracks to filter or sort.
     if (trackIds.size() == 0) {
         return;
@@ -501,8 +502,20 @@ void BaseTrackCache::filterAndSort(const QSet<TrackId>& trackIds,
         filter.prepend("WHERE ");
     }
 
-    QString queryString = QString("SELECT %1 FROM %2 %3 %4")
-            .arg(m_idColumn, m_tableName, filter, orderByClause);
+    QString queryString;
+
+    if (sortedIndexes->isEmpty()) {
+        // Use orderByClause value to sort the query result.
+        queryString = QString("SELECT %1 FROM %2 %3 %4")
+                              .arg(m_idColumn, m_tableName, filter, orderByClause);
+    } else {
+        // Use table order in query result.
+
+        // The query result does not need to be sorted because
+        // the new indexes will be set from the previous sorted order.
+        queryString = QString("SELECT %1 FROM %2 %3")
+                              .arg(m_idColumn, m_tableName, filter);
+    }
 
     if (sDebug) {
         qDebug() << this << "select() executing:" << queryString;
@@ -532,10 +545,22 @@ void BaseTrackCache::filterAndSort(const QSet<TrackId>& trackIds,
         m_trackOrder.reserve(rows);
     }
 
-    while (query.next()) {
-        TrackId trackId(query.value(idColumn));
-        (*trackToIndex)[trackId] = m_trackOrder.size();
-        m_trackOrder.append(trackId);
+    if (sortedIndexes->isEmpty()) {
+        // Loop through tracks and store their indexes
+        // in the query result.
+        while (query.next()) {
+            TrackId trackId(query.value(idColumn));
+            (*trackToIndex)[trackId] = m_trackOrder.size();
+            m_trackOrder.append(trackId);
+        }
+    } else {
+        // Loop through tracks and store their indexes
+        // from the previous sorted order.
+        while (query.next()) {
+            TrackId trackId(query.value(idColumn));
+            (*trackToIndex)[trackId] = sortedIndexes->value(trackId);
+            m_trackOrder.append(trackId);
+        }
     }
 
     // At this point, the original set of tracks have been divided into two

--- a/src/library/basetrackcache.h
+++ b/src/library/basetrackcache.h
@@ -64,12 +64,13 @@ class BaseTrackCache : public QObject {
     QString columnSortForFieldIndex(int index) const;
     int fieldIndex(ColumnCache::Column column) const;
     virtual void filterAndSort(const QSet<TrackId>& trackIds,
-                               const QString& query,
-                               const QString& extraFilter,
-                               const QString& orderByClause,
-                               const QList<SortColumn>& sortColumns,
-                               const int columnOffset,
-                               QHash<TrackId, int>* trackToIndex);
+            const QString& query,
+            const QString& extraFilter,
+            const QString& orderByClause,
+            const QList<SortColumn>& sortColumns,
+            const int columnOffset,
+            QHash<TrackId, int>* sortedIndexes,
+            QHash<TrackId, int>* trackToIndex);
     virtual bool isCached(TrackId trackId) const;
     virtual void ensureCached(TrackId trackId);
     virtual void ensureCached(const QSet<TrackId>& trackIds);


### PR DESCRIPTION
Fixes undesirable tracks sorting in tables.
The mentioned situation could have occurred if the star rating
was changed for some tracks and then after the action
of removing tracks, adding tracks or filtering, the tracks
were sorted.

So, when removing tracks now tracks are kept at the same position
for a user. With adding tracks the new tracks are added at the end
of the tracks table. The automatic sorting is kept when it is changed
between track tables, for example between crates and tracks.

Fixes: [lp:1387373 "Remove a track from a crate triggers sorting"](https://bugs.launchpad.net/mixxx/+bug/1387373)
Reported by: Jean Claveau