### PR TITLE
Fix loading of modplug files

### DIFF
--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -23,6 +23,9 @@
 #include "mixer/playermanager.h"
 #include "moc_coreservices.cpp"
 #include "preferences/settingsmanager.h"
+#ifdef __MODPLUG__
+#include "preferences/dialog/dlgprefmodplug.h"
+#endif
 #include "soundio/soundmanager.h"
 #include "sources/soundsourceproxy.h"
 #include "util/db/dbconnectionpooled.h"
@@ -311,6 +314,13 @@ void CoreServices::initialize(QApplication* pApp) {
 
 #ifdef __VINYLCONTROL__
     m_pVCManager->init();
+#endif
+
+#ifdef __MODPLUG__
+    // Restore the configuration for the modplug library before trying to load a module.
+    DlgPrefModplug modplugPrefs{nullptr, pConfig};
+    modplugPrefs.loadSettings();
+    modplugPrefs.applySettings();
 #endif
 
     // Inhibit Screensaver

--- a/src/sources/soundsourcemodplug.h
+++ b/src/sources/soundsourcemodplug.h
@@ -13,7 +13,7 @@ namespace mixxx {
 // Class for reading tracker files using libmodplug.
 // The whole file is decoded at once and saved
 // in RAM to allow seeking and smooth operation in Mixxx.
-class SoundSourceModPlug : public SoundSource {
+class SoundSourceModPlug final : public SoundSource {
   public:
     static constexpr int kChannelCount = 2;
     static constexpr int kSampleRate = 44100;


### PR DESCRIPTION
The settings for Modplug decoding are not restored/enforced on Mixxx startup since https://github.com/mixxxdj/mixxx/pull/3446. With the "default" maximum buffer size initialized to zero, all loading attempts of tracker files are doomed to fail. A round-trip to the settings dialog and hitting the "apply" button on the "Modplug Decoder" page works around the issue currently.

This Pull Request:
* Loads and applies modplug configuration when the preferences are created.
* Marks `SoundSourceModPlug` as `final` to silence a warning about virtual dispatch not working in the destructor.
