### PR TITLE
assert: require semicolon on DEBUG_ASSERT

### DIFF
--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -66,7 +66,7 @@ void ControlDoublePrivate::initialize(double defaultValue) {
         if (pConfig) {
             value = pConfig->getValue(m_key, defaultValue);
         } else {
-            DEBUG_ASSERT(!"Can't load persistent value s_pUserConfig is null")
+            DEBUG_ASSERT(!"Can't load persistent value s_pUserConfig is null");
         }
     }
     m_defaultValue.setValue(defaultValue);

--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -286,7 +286,7 @@ void EffectSlot::loadEffectInner(const EffectManifestPointer pManifest,
     DEBUG_ASSERT(!m_pManifest);
 
     // The function shall be called only with both pointers set or both null.
-    DEBUG_ASSERT(pManifest.isNull() == pEffectPreset.isNull())
+    DEBUG_ASSERT(pManifest.isNull() == pEffectPreset.isNull());
     if (!pManifest || !pEffectPreset) {
         // No new effect to load; just unload the old effect and return.
         emit effectChanged();

--- a/src/util/assert.h
+++ b/src/util/assert.h
@@ -37,31 +37,44 @@ inline void mixxx_release_assert(const char* assertion, const char* file, int li
 /// very hard before using this -- this should only be for the most dire of
 /// situations where we know Mixxx cannot take any action without potentially
 /// corrupting user data. Handle errors gracefully whenever possible.
-#define RELEASE_ASSERT(cond)                                              \
-    if (Q_UNLIKELY(!static_cast<bool>(cond))) {                           \
-        mixxx_release_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION); \
-    }
+#define RELEASE_ASSERT(cond)                                                  \
+    do                                                                        \
+        if (Q_UNLIKELY(!static_cast<bool>(cond))) {                           \
+            mixxx_release_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION); \
+        }                                                                     \
+    while (0)
 
-// Checks that cond is true in debug builds. If cond is false then prints a
-// warning message to the console. If Mixxx is built with
-// MIXXX_DEBUG_ASSERTIONS_FATAL then the warning message is fatal. Compiles
-// to nothing in release builds.
-//
-// Be careful of the common mistake with assertions:
-//   DEBUG_ASSERT(doSomething());
-//
-// In release builds, doSomething() is never called!
+/// Checks that cond is true in debug builds. If cond is false then prints a
+/// warning message to the console. If Mixxx is built with
+/// MIXXX_DEBUG_ASSERTIONS_FATAL then the warning message is fatal. Compiles
+/// to nothing in release builds.
+///
+/// Be careful of the common mistake with assertions:
+///   DEBUG_ASSERT(doSomething());
+///
+/// In release builds, doSomething() is never called!
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
-#define DEBUG_ASSERT(cond)                                              \
-    if (Q_UNLIKELY(!static_cast<bool>(cond))) {                         \
-        mixxx_debug_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION); \
-    }
+#define DEBUG_ASSERT(cond)                                                  \
+    do                                                                      \
+        if (Q_UNLIKELY(!static_cast<bool>(cond))) {                         \
+            mixxx_debug_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION); \
+        }                                                                   \
+    while (0)
 #else
-#define DEBUG_ASSERT(cond)
+#define DEBUG_ASSERT(cond) \
+    do {                   \
+    } while (0)
 #endif
 
-/// Same as DEBUG_ASSERT, but if MIXXX_DEBUG_ASSERTIONS_FATAL is disabled run the specified fallback function.
-/// In most cases you should probably use this rather than DEBUG_ASSERT. Only use DEBUG_ASSERT if there is no appropriate fallback.
+/// Same as DEBUG_ASSERT, but if MIXXX_DEBUG_ASSERTIONS_FATAL is disabled run
+/// the specified fallback function. In most cases you should probably use
+/// this rather than DEBUG_ASSERT. Only use DEBUG_ASSERT if there is no
+/// appropriate fallback.
+///
+/// Use it like:
+///   VERIFY_OR_DEBUG_ASSERT(value.is_valid()) { value = some_default; }
+///
+/// Note that the check and fallback will be included in release builds.
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
 #define VERIFY_OR_DEBUG_ASSERT(cond)            \
     if (Q_UNLIKELY(!static_cast<bool>(cond)) && \


### PR DESCRIPTION
Make `DEBUG_ASSERT()` act more like a regular "function". This also silences linter warnings about statements without effect for the currently superfluous semicolons.

This PR does:
* Wrap `DEBUG_ASSERT` expansion in `do {} while(0)` so the `;` completes the statement.
* Add the semicolons in the two places that omitted them.
* Fix up the macro comments a bit and explain the behavior of the
`VERIFY_OR_DEBUG_ASSERT` macro a little more.