### PR TITLE
CI: Drop workarounds for sccache v0.2.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,7 @@ jobs:
             qt_qpa_platform: windows
 
     env:
+      SCCACHE_VERSION: "0.3.0"
       # macOS codesigning
       APPLE_CODESIGN_IDENTITY: 2C2B5D3EDCE82BA55E22E9A67F16F8D03E390870
       MACOS_CODESIGN_OPENSSL_PASSWORD: ${{ secrets.MACOS_CODESIGN_OPENSSL_PASSWORD }}
@@ -123,14 +124,14 @@ jobs:
       id: sccache-build-cache
       with:
         path: C:\Users\runneradmin\.cargo
-        key: sccache
+        key: sccache-${{ env.SCCACHE_VERSION }}
 
     # This needs to be done first because something later messes with $PATH in a way that breaks cargo
     # by causing it to find link.exe from Git for Windows instead of MSVC.
     - name: "[Windows] Build and install sccache"
       shell: bash
       if: runner.os == 'Windows' && steps.sccache-build-cache.outputs.cache-hit != 'true'
-      run: cargo install sccache
+      run: cargo install --version "${{ env.SCCACHE_VERSION }}" sccache
 
     - name: "Check out repository"
       uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,6 @@ jobs:
             qt_qpa_platform: windows
 
     env:
-      SCCACHE_COMMIT: 3f318a8675e4c3de4f5e8ab2d086189f2ae5f5cf
       # macOS codesigning
       APPLE_CODESIGN_IDENTITY: 2C2B5D3EDCE82BA55E22E9A67F16F8D03E390870
       MACOS_CODESIGN_OPENSSL_PASSWORD: ${{ secrets.MACOS_CODESIGN_OPENSSL_PASSWORD }}
@@ -118,24 +117,20 @@ jobs:
       artifact-windows-win64: ${{ steps.prepare_deploy.outputs.artifact-windows-win64 }}
     steps:
 
-    # sccache's handling of the /fp:fast MSVC compiler option is broken, so use our fork with the fix.
-    # https://github.com/mozilla/sccache/issues/950
-    - name: "[Windows] Set up cargo cache"
+    - name: "[Windows] Set up Cargo cache"
       if: runner.os == 'Windows'
       uses: actions/cache@v2
       id: sccache-build-cache
       with:
         path: C:\Users\runneradmin\.cargo
-        # hash of commit to build
-        key: sccache-${{ env.SCCACHE_COMMIT }}
+        key: sccache
 
     # This needs to be done first because something later messes with $PATH in a way that breaks cargo
     # by causing it to find link.exe from Git for Windows instead of MSVC.
-    - name: "[Windows] Build fixed sccache"
+    - name: "[Windows] Build and install sccache"
       shell: bash
       if: runner.os == 'Windows' && steps.sccache-build-cache.outputs.cache-hit != 'true'
-      # TODO: change this to simply `cargo install sccache` after 0.2.16 has been released
-      run: cargo install --git https://github.com/mozilla/sccache.git --rev "${SCCACHE_COMMIT}"
+      run: cargo install sccache
 
     - name: "Check out repository"
       uses: actions/checkout@v2


### PR DESCRIPTION
...after sccache v0.3.0 has been released.