### PR TITLE
Mouse vanish bug fix

### DIFF
--- a/src/util/scopedoverridecursor.h
+++ b/src/util/scopedoverridecursor.h
@@ -1,16 +1,16 @@
 #pragma once
 
-#include <QApplication>
+#include <QGuiApplication>
 
 class ScopedOverrideCursor {
   public:
     inline explicit ScopedOverrideCursor(const QCursor& cursor) {
-        QApplication::setOverrideCursor(cursor);
-        QApplication::processEvents();
+        QGuiApplication::setOverrideCursor(cursor);
+        QCoreApplication::processEvents();
     }
 
     inline virtual ~ScopedOverrideCursor() {
-        QApplication::restoreOverrideCursor();
+        QGuiApplication::restoreOverrideCursor();
     }
 };
 

--- a/src/widget/knobeventhandler.h
+++ b/src/widget/knobeventhandler.h
@@ -4,7 +4,6 @@
 #include <QWheelEvent>
 #include <QColor>
 #include <QCursor>
-#include <QApplication>
 #include <QPoint>
 #include <QPixmap>
 
@@ -63,7 +62,7 @@ class KnobEventHandler {
                 m_prevPos = m_startPos;
                 // Somehow using Qt::BlankCursor does not work on Windows
                 // https://mixxx.org/forums/viewtopic.php?p=40298#p40298
-                QApplication::setOverrideCursor(m_blankCursor);
+                pWidget->setCursor(m_blankCursor);
                 break;
             default:
                 break;
@@ -76,7 +75,7 @@ class KnobEventHandler {
             case Qt::LeftButton:
             case Qt::MiddleButton:
                 QCursor::setPos(m_startPos);
-                QApplication::restoreOverrideCursor();
+                pWidget->unsetCursor();
                 value = valueFromMouseEvent(pWidget, e);
                 pWidget->setControlParameterUp(value);
                 pWidget->inputActivity();

--- a/src/widget/knobeventhandler.h
+++ b/src/widget/knobeventhandler.h
@@ -21,8 +21,9 @@ class KnobEventHandler {
     }
 
     double valueFromMouseEvent(T* pWidget, QMouseEvent* e) {
-        QPoint cur(e->globalPos());
-        QPoint diff(cur - m_prevPos);
+        QPoint cur = e->globalPos();
+        QPoint diff = cur - m_prevPos;
+        m_prevPos = cur;
         double dist = sqrt(static_cast<double>(diff.x() * diff.x() + diff.y() * diff.y()));
         bool y_dominant = abs(diff.y()) > abs(diff.x());
 
@@ -47,7 +48,6 @@ class KnobEventHandler {
             double value = valueFromMouseEvent(pWidget, e);
             pWidget->setControlParameterDown(value);
             pWidget->inputActivity();
-            m_prevPos = e->globalPos();
         }
     }
 


### PR DESCRIPTION
This PR aims to fix bugs:
https://bugs.launchpad.net/mixxx/+bug/1130794
https://bugs.launchpad.net/mixxx/+bug/1969278

It replace using to global cursor stack by using the widget cursor.

This should be a workaround for the missing cursor on MacOS, probably due to a missing release event in overload situations.  If this happens again, only one knob is affected instead of whole Mixxx and it heals itself by another mouse click because it is not longer stacking up. 