### PR TITLE
Refine the version check in Findhidapi.cmake

### DIFF
--- a/cmake/modules/Findhidapi.cmake
+++ b/cmake/modules/Findhidapi.cmake
@@ -64,10 +64,10 @@ mark_as_advanced(hidapi_LIBRARY)
 
 
 # Version detection
-if(DEFINED PC_hidapi_VERSION)
+if(DEFINED PC_hidapi_VERSION AND NOT PC_hidapi_VERSION STREQUAL "")
   set(hidapi_VERSION "${PC_hidapi_VERSION}")
 else()
-  if (EXISTS "${hidapi_INCLUDE_DIR}/hidapi.h")
+  if (EXISTS "${hidapi_LIBRARY}" AND EXISTS "${hidapi_INCLUDE_DIR}/hidapi.h")
       file(READ "${hidapi_INCLUDE_DIR}/hidapi.h" hidapi_H_CONTENTS)
       string(REGEX MATCH "#define HID_API_VERSION_MAJOR ([0-9]+)" _dummy "${hidapi_H_CONTENTS}")
       set(hidapi_VERSION_MAJOR "${CMAKE_MATCH_1}")
@@ -81,7 +81,10 @@ else()
         NOT hidapi_VERSION_MINOR STREQUAL "" AND
         NOT hidapi_VERSION_PATCH STREQUAL "")
         set(hidapi_VERSION "${hidapi_VERSION_MAJOR}.${hidapi_VERSION_MINOR}.${hidapi_VERSION_PATCH}")
-      endif()
+    else()
+        # take what we have found, likely "" to fail the version check.
+        set(hidapi_VERSION "${hidapi_VERSION_MAJOR}")
+    endif()
   endif()
 endif ()
 


### PR DESCRIPTION
for a situation where headers are found but not the Library

Before: 
`-- Could NOT find hidapi (missing: hidapi_LIBRARY) (found suitable version "0.12.0", minimum required is "0.10.1")`
Now:
`-- Could NOT find hidapi (missing: hidapi_LIBRARY) (Required is at least version "0.10.1")`

https://mixxx.zulipchat.com/#narrow/stream/247620-development-help/topic/cmake.20can't.20detect.20libhidapi