### PR TITLE
Fix checkmark in chain preset list on Windows

### DIFF
--- a/src/widget/weffectchainpresetbutton.cpp
+++ b/src/widget/weffectchainpresetbutton.cpp
@@ -50,7 +50,7 @@ void WEffectChainPresetButton::populateMenu() {
     for (const auto& pChainPreset : m_pChainPresetManager->getPresetsSorted()) {
         QString title = pChainPreset->name();
         if (title == m_pChain->presetName()) {
-            title = "\u2713 " + title;
+            title = QStringLiteral("\u2713 ") + title;
             chainIsPreset = true;
         }
         m_pMenu->addAction(title, this, [this, pChainPreset]() {


### PR DESCRIPTION
MSVC treats c strings as Windows-1252 

Warning: ..\src\widget\weffectchainpresetbutton.cpp(53): warning C4566: character represented by universal-character-name '\u2713' cannot be represented in the current code page (1252)