### PR TITLE
library: add '[Library],sort_focused_column' control pushbutton

### DIFF
--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -212,6 +212,8 @@ LibraryControl::LibraryControl(Library* pLibrary)
     m_pSortOrder = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "sort_order"));
     m_pSortOrder->setButtonMode(ControlPushButton::TOGGLE);
     m_pSortColumnToggle = std::make_unique<ControlEncoder>(ConfigKey("[Library]", "sort_column_toggle"), false);
+    m_pSortFocusedColumn = std::make_unique<ControlPushButton>(
+            ConfigKey("[Library]", "sort_focused_column"));
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     connect(m_pSortColumn.get(),
             &ControlEncoder::valueChanged,
@@ -221,6 +223,14 @@ LibraryControl::LibraryControl(Library* pLibrary)
             &ControlEncoder::valueChanged,
             this,
             &LibraryControl::slotSortColumnToggle);
+    connect(m_pSortFocusedColumn.get(),
+            &ControlObject::valueChanged,
+            this,
+            [this](double value) {
+                if (value > 0.0) {
+                    slotSortColumnToggle(static_cast<int>(TrackModel::SortColumnId::CurrentIndex));
+                }
+            });
 
     // Font sizes
     m_pFontSizeKnob = std::make_unique<ControlObject>(

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -148,6 +148,7 @@ class LibraryControl : public QObject {
     std::unique_ptr<ControlEncoder> m_pSortColumn;
     std::unique_ptr<ControlEncoder> m_pSortColumnToggle;
     std::unique_ptr<ControlPushButton> m_pSortOrder;
+    std::unique_ptr<ControlPushButton> m_pSortFocusedColumn;
 
     // Controls to change track color
     std::unique_ptr<ControlPushButton> m_pTrackColorPrev;


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1969634

There is need for a simple "sort column with cursor on it" button.
Unfortunately [`[Library],sort_column_toggle`](https://bugs.launchpad.net/mixxx/+bug/1969634) can not be used directly in xml mappings (or equivalent) but requires scripting.

`[Library],sort_focused_column` is just a wrapper to call `slotSortColumnToggle(0)` on button press.