### PR TITLE
Parserm3u export

### DIFF
--- a/src/library/parserm3u.cpp
+++ b/src/library/parserm3u.cpp
@@ -101,7 +101,7 @@ bool ParserM3u::writeM3UFile(const QString &file_str, const QList<QString> &item
     // Important note:
     // On Windows \n will produce a <CR><CL> (=\r\n)
     // On Linux and OS X \n is <CR> (which remains \n)
-
+    bool urlEncodingUsed = false;
     QDir baseDirectory(QFileInfo(file_str).canonicalPath());
     QTextCodec* codec = QTextCodec::codecForName(kStandardM3uTextEncoding);
     QString fileContents(QStringLiteral("#EXTM3U\n"));
@@ -126,6 +126,7 @@ bool ParserM3u::writeM3UFile(const QString &file_str, const QList<QString> &item
                 QUrl itemUrl = QUrl::fromLocalFile(item);
                 QString itemUrlEncoded = itemUrl.toEncoded();
                 fileContents += itemUrlEncoded + QStringLiteral("\n");
+                urlEncodingUsed = true;
             }
         }
     }
@@ -145,6 +146,13 @@ bool ParserM3u::writeM3UFile(const QString &file_str, const QList<QString> &item
                 QObject::tr("Playlist Export Failed"),
                 QObject::tr("Could not create file") + " " + file_str);
         return false;
+    }
+    if (urlEncodingUsed) {
+        QMessageBox::information(nullptr,
+                QObject::tr("Playlist Export Has Special Characters"),
+                QObject::tr("Some file paths in the playlist have special characters. "
+                            "These file paths will be encoded as absolute path URLs. "
+                            "Please select the m3u8 format for better and lossless exporting."));
     }
     file.write(outputByteArray);
     file.close();

--- a/src/library/parserm3u.cpp
+++ b/src/library/parserm3u.cpp
@@ -107,15 +107,23 @@ bool ParserM3u::writeM3UFile(const QString &file_str, const QList<QString> &item
     QString fileContents(QStringLiteral("#EXTM3U\n"));
     for (const QString& item : items) {
         fileContents += QStringLiteral("#EXTINF\n");
-        QUrl itemUrl = QUrl::fromLocalFile(item);
-        QString itemUrlEncoded = itemUrl.toEncoded();
-        if (useRelativePath) {
-            fileContents += baseDirectory.relativeFilePath(item) + QStringLiteral("\n");
-        } else {
-            if (!useUtf8) {
-                fileContents += itemUrlEncoded + QStringLiteral("\n");
+        QByteArray trackByteArray = QTextCodec::codecForName(kStandardM3uTextEncoding)
+                                            ->fromUnicode(item);
+        if ((trackByteArray == item) || useUtf8) {
+            if (useRelativePath) {
+                fileContents += baseDirectory.relativeFilePath(item) + QStringLiteral("\n");
             } else {
                 fileContents += item + QStringLiteral("\n");
+            }
+        } else {
+            if (useRelativePath) {
+                QUrl itemRelativeUrl = QUrl::fromLocalFile(baseDirectory.relativeFilePath(item));
+                QString itemRelativeUrlEncoded = itemRelativeUrl.toEncoded();
+                fileContents += itemRelativeUrlEncoded + QStringLiteral("\n");
+            } else {
+                QUrl itemUrl = QUrl::fromLocalFile(item);
+                QString itemUrlEncoded = itemUrl.toEncoded();
+                fileContents += itemUrlEncoded + QStringLiteral("\n");
             }
         }
     }

--- a/src/library/parserm3u.cpp
+++ b/src/library/parserm3u.cpp
@@ -107,8 +107,7 @@ bool ParserM3u::writeM3UFile(const QString &file_str, const QList<QString> &item
     QString fileContents(QStringLiteral("#EXTM3U\n"));
     for (const QString& item : items) {
         fileContents += QStringLiteral("#EXTINF\n");
-        if (useUtf8 ||
-                useRelativePath) { //Issue: URL Location is not working properly for Relative Paths
+        if (useUtf8) {
             if (useRelativePath) {
                 fileContents += baseDirectory.relativeFilePath(item) + QStringLiteral("\n");
             } else {
@@ -118,7 +117,11 @@ bool ParserM3u::writeM3UFile(const QString &file_str, const QList<QString> &item
             QByteArray trackByteArray = codec->fromUnicode(item);
             QString trackName = codec->toUnicode(trackByteArray);
             if (trackName == item) {
-                fileContents += item + QStringLiteral("\n");
+                if (useRelativePath) { //Issue: URL Location is not working properly for Relative Paths
+                    fileContents += baseDirectory.relativeFilePath(item) + QStringLiteral("\n");
+                } else {
+                    fileContents += item + QStringLiteral("\n");
+                }
             } else {
                 QUrl itemUrl = QUrl::fromLocalFile(item);
                 QString itemUrlEncoded = itemUrl.toEncoded();

--- a/src/library/parserm3u.cpp
+++ b/src/library/parserm3u.cpp
@@ -103,23 +103,22 @@ bool ParserM3u::writeM3UFile(const QString &file_str, const QList<QString> &item
     // On Linux and OS X \n is <CR> (which remains \n)
 
     QDir baseDirectory(QFileInfo(file_str).canonicalPath());
-
+    QTextCodec* codec = QTextCodec::codecForName(kStandardM3uTextEncoding);
     QString fileContents(QStringLiteral("#EXTM3U\n"));
     for (const QString& item : items) {
         fileContents += QStringLiteral("#EXTINF\n");
-        QByteArray trackByteArray = QTextCodec::codecForName(kStandardM3uTextEncoding)
-                                            ->fromUnicode(item);
-        if ((trackByteArray == item) || useUtf8) {
+        if (useUtf8 ||
+                useRelativePath) { //Issue: URL Location is not working properly for Relative Paths
             if (useRelativePath) {
                 fileContents += baseDirectory.relativeFilePath(item) + QStringLiteral("\n");
             } else {
                 fileContents += item + QStringLiteral("\n");
             }
         } else {
-            if (useRelativePath) {
-                QUrl itemRelativeUrl = QUrl::fromLocalFile(baseDirectory.relativeFilePath(item));
-                QString itemRelativeUrlEncoded = itemRelativeUrl.toEncoded();
-                fileContents += itemRelativeUrlEncoded + QStringLiteral("\n");
+            QByteArray trackByteArray = codec->fromUnicode(item);
+            QString trackName = codec->toUnicode(trackByteArray);
+            if (trackName == item) {
+                fileContents += item + QStringLiteral("\n");
             } else {
                 QUrl itemUrl = QUrl::fromLocalFile(item);
                 QString itemUrlEncoded = itemUrl.toEncoded();

--- a/src/library/parserm3u.cpp
+++ b/src/library/parserm3u.cpp
@@ -112,7 +112,11 @@ bool ParserM3u::writeM3UFile(const QString &file_str, const QList<QString> &item
         if (useRelativePath) {
             fileContents += baseDirectory.relativeFilePath(item) + QStringLiteral("\n");
         } else {
-            fileContents += itemUrlEncoded + QStringLiteral("\n");
+            if (!useUtf8) {
+                fileContents += itemUrlEncoded + QStringLiteral("\n");
+            } else {
+                fileContents += item + QStringLiteral("\n");
+            }
         }
     }
 

--- a/src/library/parserm3u.cpp
+++ b/src/library/parserm3u.cpp
@@ -107,10 +107,12 @@ bool ParserM3u::writeM3UFile(const QString &file_str, const QList<QString> &item
     QString fileContents(QStringLiteral("#EXTM3U\n"));
     for (const QString& item : items) {
         fileContents += QStringLiteral("#EXTINF\n");
+        QUrl itemUrl = QUrl::fromLocalFile(item);
+        QString itemUrlEncoded = itemUrl.toEncoded();
         if (useRelativePath) {
             fileContents += baseDirectory.relativeFilePath(item) + QStringLiteral("\n");
         } else {
-            fileContents += item + QStringLiteral("\n");
+            fileContents += itemUrlEncoded + QStringLiteral("\n");
         }
     }
 


### PR DESCRIPTION
I was trying to Export and Import my playlists. Then I realized when I tried to export my playlist with m3u there were some missing tracks. That was because of non encodable characters in Turkish. m3u8 was totally fine tho.

According to our conversation on Zulipchat, with your suggestion I tried to use URL Locations for m3u.

After I tried URL Locations, there were no missing tracks with m3u export/import.