### PR TITLE
MC7000: Fix 'inverted shift' bug in the controller mapping

### DIFF
--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -112,6 +112,9 @@ MC7000.factor = [];
 //Set Shift button state to false as default
 MC7000.shift = [false, false, false, false];
 
+// For each side whether the top or bottom deck is active.
+MC7000.topDeckActive = [true, true];
+
 // initialize the PAD Mode to Hot Cue and all others off when starting
 MC7000.PADModeCue = [true, true, true, true];
 MC7000.PADModeCueLoop = [false, false, false, false];
@@ -180,6 +183,10 @@ MC7000.init = function() {
     engine.makeConnection("[Channel2]", "VuMeter", MC7000.VuMeter);
     engine.makeConnection("[Channel3]", "VuMeter", MC7000.VuMeter);
     engine.makeConnection("[Channel4]", "VuMeter", MC7000.VuMeter);
+
+    // Switch to active decks
+    midi.sendShortMsg(MC7000.topDeckActive[0] ? 0x90 : 0x92, 0x08, 0x7F);
+    midi.sendShortMsg(MC7000.topDeckActive[1] ? 0x91 : 0x93, 0x08, 0x7F);
 
     // Platter Ring LED mode
     midi.sendShortMsg(0x90, 0x64, MC7000.modeSingleLED);
@@ -889,31 +896,34 @@ MC7000.crossFaderCurve = function(control, value) {
 
 // Update state on deck changes
 MC7000.switchDeck = function(channel, control, value, status, group) {
+    var deckOffset = script.deckFromGroup(group) - 1;
+    var isTopDeck = deckOffset < 2;
+    var side = deckOffset % 2;
+
+    var previousDeckOffset;
+    switch (deckOffset) {
+    case 0:
+        previousDeckOffset = 2;
+        break;
+    case 1:
+        previousDeckOffset = 3;
+        break;
+    case 2:
+        previousDeckOffset = 0;
+        break;
+    case 3:
+        previousDeckOffset = 1;
+        break;
+    }
+
     // We need to 'transfer' the shift state when switching decks,
     // otherwise it will get stuck and result in an 'inverted'
     // shift after switching back to the deck.
     // Since the controller switches immediately upon pressing down,
     // we only do this when value is high.
 
-    if (value === 0x7F) {
-        var deckOffset = script.deckFromGroup(group) - 1;
-
-        var previousDeckOffset;
-        switch (deckOffset) {
-        case 0:
-            previousDeckOffset = 2;
-            break;
-        case 1:
-            previousDeckOffset = 3;
-            break;
-        case 2:
-            previousDeckOffset = 0;
-            break;
-        case 3:
-            previousDeckOffset = 1;
-            break;
-        }
-
+    if (value === 0x7F && MC7000.topDeckActive[side] !== isTopDeck) {
+        MC7000.topDeckActive[side] = isTopDeck;
         MC7000.shift[deckOffset] = MC7000.shift[previousDeckOffset];
         MC7000.shift[previousDeckOffset] = false;
     }

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -895,26 +895,11 @@ MC7000.crossFaderCurve = function(control, value) {
 };
 
 // Update state on deck changes
-MC7000.switchDeck = function(channel, control, value, status, group) {
-    var deckOffset = script.deckFromGroup(group) - 1;
+MC7000.switchDeck = function(channel, control, value, status) {
+    var deckOffset = status - 0x90;
     var isTopDeck = deckOffset < 2;
     var side = deckOffset % 2;
-
-    var previousDeckOffset;
-    switch (deckOffset) {
-    case 0:
-        previousDeckOffset = 2;
-        break;
-    case 1:
-        previousDeckOffset = 3;
-        break;
-    case 2:
-        previousDeckOffset = 0;
-        break;
-    case 3:
-        previousDeckOffset = 1;
-        break;
-    }
+    var previousDeckOffset = (deckOffset + 2) % 4;
 
     // We need to 'transfer' the shift state when switching decks,
     // otherwise it will get stuck and result in an 'inverted'

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -887,6 +887,38 @@ MC7000.crossFaderCurve = function(control, value) {
     script.crossfaderCurve(value);
 };
 
+// Update state on deck changes
+MC7000.switchDeck = function(channel, control, value, status, group) {
+    // We need to 'transfer' the shift state when switching decks,
+    // otherwise it will get stuck and result in an 'inverted'
+    // shift after switching back to the deck.
+    // Since the controller switches immediately upon pressing down,
+    // we only do this when value is high.
+
+    if (value === 0x7F) {
+        var deckOffset = script.deckFromGroup(group) - 1;
+
+        var previousDeckOffset;
+        switch (deckOffset) {
+        case 0:
+            previousDeckOffset = 2;
+            break;
+        case 1:
+            previousDeckOffset = 3;
+            break;
+        case 2:
+            previousDeckOffset = 0;
+            break;
+        case 3:
+            previousDeckOffset = 1;
+            break;
+        }
+
+        MC7000.shift[deckOffset] = MC7000.shift[previousDeckOffset];
+        MC7000.shift[previousDeckOffset] = false;
+    }
+};
+
 // Set FX wet/dry value
 MC7000.fxWetDry = function(channel, control, value, status, group) {
     var numTicks = (value < 0x64) ? value : (value - 128);

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -597,7 +597,7 @@ MC7000.PadButtons = function(channel, control, value, status, group) {
 // Shift Button
 MC7000.shiftButton = function(channel, control, value, status, group) {
     var deckOffset = script.deckFromGroup(group) - 1;
-    MC7000.shift[deckOffset] = ! MC7000.shift[deckOffset];
+    MC7000.shift[deckOffset] = value > 0;
     midi.sendShortMsg(0x90 + deckOffset, 0x32,
         MC7000.shift[deckOffset] ? 0x7F : 0x01);
 };

--- a/res/controllers/Denon-MC7000.midi.xml
+++ b/res/controllers/Denon-MC7000.midi.xml
@@ -860,6 +860,47 @@
                     <script-binding/>
                 </options>
             </control>
+    <!--  DECK BUTTONS  -->
+            <control>
+                <group>[Channel1]</group>
+                <key>MC7000.switchDeck</key>
+                <description>Switch to deck 1</description>
+                <status>0x90</status>
+                <midino>0x08</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>MC7000.switchDeck</key>
+                <description>Switch to deck 2</description>
+                <status>0x91</status>
+                <midino>0x08</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel3]</group>
+                <key>MC7000.switchDeck</key>
+                <description>Switch to deck 3</description>
+                <status>0x92</status>
+                <midino>0x08</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel4]</group>
+                <key>MC7000.switchDeck</key>
+                <description>Switch to deck 4</description>
+                <status>0x93</status>
+                <midino>0x08</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
     <!--  FX WET/DRY + SAMPLER + CROSS FADER CURVE  -->
             <control>
                 <group>[EffectRack1_EffectUnit1]</group>


### PR DESCRIPTION
### Based on #4757 

The controller mapping for the MC7000 has a bug where the controller keeps the wrong shift state while switching decks. For example, consider the following flow:

- Switch to deck 1
- Press shift
- Switch to deck 3 (note: both decks are on the same side)
- Release shift

Since the MC7000 will emit only a press event on deck 1 and a release event on deck 3, the mapping's shift array (`MC7000.shift`) will incorrectly end up in the state where both decks are assumed to be currently shift-held.

This PR fixes the issue by transferring the shift state when switching decks. For this, the deck switching buttons (1, 3 and 2, 4) are mapped in the MIDI XML file and associated with a new function `MC7000.switchDeck`.

To cleanly track transitions between the top and the bottom deck on each side (which we need, since holding shift while pressing the active deck's button again would result in the same bug), we also declare a new property `MC7000.topDeckActive`, indexed by the side of the controller we are dealing with (0 for left, 1 for right). Also, the active decks on the controller are now synced with `topDeckActive`, so as a side-effect this means that decks 1 and 2 are automatically switched to whenever the controller mapping is initialized (is that fine?).

In addition to the changes described above, we also update the implementation of `MC7000.shiftButton` and read the shift state directly with `value > 0` rather than simply negating the existing state. This makes the shift implementation less brittle against bugs like these in the future, since the shift state will always converge to the correct state once the user presses the button again.

cc @toszlanyi 