### PR TITLE
KeyControl: init keylock from config, fix pitchRatio rounding issue

### DIFF
--- a/src/engine/controls/keycontrol.cpp
+++ b/src/engine/controls/keycontrol.cpp
@@ -95,6 +95,9 @@ KeyControl::KeyControl(const QString& group,
     m_pKeylock = new ControlProxy(group, "keylock", this);
     m_pKeylock->connectValueChanged(this, &KeyControl::slotRateChanged,
             Qt::DirectConnection);
+    // m_pitchRateInfo members are initialized with default values, only keylock
+    // is persistent and needs to be updated from config
+    m_pitchRateInfo.keylock = m_pKeylock->toBool();
 }
 
 KeyControl::~KeyControl() {

--- a/src/engine/controls/keycontrol.h
+++ b/src/engine/controls/keycontrol.h
@@ -14,11 +14,11 @@ class KeyControl : public EngineControl {
   public:
 
     struct PitchTempoRatio {
-        // this is the calculated value used by engine buffer for pitch
-        // by default it is equal to the tempoRatio set by the speed slider
+        // This is the calculated value used by engine buffer for pitch.
+        // By default it is equal to the tempoRatio set by the speed slider
         double pitchRatio;
-        // this is the value of the speed slider and speed slider
-        // effecting controls at the moment of calculation
+        // This is the value of the speed slider and speed slider
+        // affecting controls at the moment of calculation
         double tempoRatio;
         // the offeset factor to the natural pitch set by the rate slider
         double pitchTweakRatio;
@@ -46,7 +46,7 @@ class KeyControl : public EngineControl {
   private:
     void setEngineKey(double key, double key_distance);
     bool syncKey(EngineBuffer* pOtherEngineBuffer);
-    void updateKeyCOs(double fileKeyNumeric, double pitch);
+    void updateKeyCOs(double fileKeyNumeric, double pitchOctaves);
     void updatePitch();
     void updatePitchAdjust();
     void updateRate();


### PR DESCRIPTION
the two first bugfix commits from #4710, + debug output

**Keylock ON not considered after start**
https://bugs.launchpad.net/mixxx/+bug/1943180

Internal `m_pitchRateInfo.keylock` is updated only in `KeyControl::updateRate()` when any rate, keylock or vc controls are touched. Though, it may be requested by EngineBuffer prior to that, e.g when nudging a track, which results in a temporary keychange.
Also, with keylock enabled after start, the first call of `KeyControl::updateRate()` would interpret the update as keylock change which seems to affect `m_pitchRateInfo` members unintentionally.
Fix: update `m_pitchRateInfo.keylock` when initializing

**Sudden false-positive pitch offset** when unlocking key, see https://github.com/mixxxdj/mixxx/pull/4710#issuecomment-1088142652
probably regression from #1222
Fix: round pitchRatio if it's veeeery close to 1.0