### PR TITLE
KeyControl: make 'Unlock, reset to linear pitch' always reset `pitch_adjust`

### DIFF
--- a/src/engine/controls/keycontrol.cpp
+++ b/src/engine/controls/keycontrol.cpp
@@ -234,18 +234,12 @@ void KeyControl::updateRate() {
                 m_pPitchAdjust->set(
                         KeyUtils::powerOf2ToSemitoneChange(m_pitchRateInfo.pitchTweakRatio));
             } else { // Unlock and reset to linear pitch (orig. key + pitch fader offset)
-                // If 'current' aka 'not original' key was locked
-                // TODO(ronso0) Why does it depend on keylock mode?
-                if (m_keylockMode->get() == kLockCurrentKey) {
-                    // reset to linear pitch
-                    m_pitchRateInfo.pitchTweakRatio = 1.0;
-                    // was missing?
-                    // m_pPitchAdjust->set(
-                    //        KeyUtils::powerOf2ToSemitoneChange(m_pitchRateInfo.pitchTweakRatio));
-                }
+                m_pitchRateInfo.pitchTweakRatio = 1.0;
+                m_pPitchAdjust->set(
+                        KeyUtils::powerOf2ToSemitoneChange(m_pitchRateInfo.pitchTweakRatio));
                 if constexpr (kEnableDebugOutput) {
                     qDebug() << "   UNLOCKING reset to linear pitch";
-                    qDebug() << "   : pitchTweakRatio = 1.0";
+                    qDebug() << "   : pitchTweakRatio =" << m_pitchRateInfo.pitchTweakRatio;
                     qDebug() << "   |";
                 }
             }


### PR DESCRIPTION
follow-up for #4756 

"unlock, reset to linear pitch" changes `pitchTweakRatio` though doesn't apply it as `pitch_adjust`, thus there's an abrupt pitch change when touching the `pitch_adjust` knob afterwards.

Also, I don't remember why we decided to make the unlock behaviour depend on the keylock mode.. :man_shrugging: doesn't make much sense to me. It's not consistent, also keylock mode _could_ have changed since locking the key.
Removing that condition.

This is still WIP.
The issue was not discovered earlier because we didn't adjust the PitchRoundtrip test when we introduced the alternative keyunlock mode. I guess no one noticed in real life since it's an unusual combination to select "Reset to linear pitch" + "Lock current key" + have `pitch_adjust` mapped.
I'll try to adjust the test.