### PR TITLE
Scratch on first wheel touch

### DIFF
--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -1295,8 +1295,7 @@ void ControllerEngine::scratchEnable(int deck, int intervalsPerRev, double rpm,
     if (m_dx[deck] != 0) {
         //qDebug() << "Already scratching deck" << deck << ". Overriding.";
         int timerId = m_scratchTimers.key(deck);
-        killTimer(timerId);
-        m_scratchTimers.remove(timerId);
+        stopScratchTimer(timerId);
     }
 
     // Controller resolution in intervals per second at normal speed.

--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -62,6 +62,9 @@ ControllerEngine::ControllerEngine(
         m_dx[i] = 0.0;
         m_scratchFilters[i] = new AlphaBetaFilter();
         m_ramp[i] = false;
+        m_brakeActive[i] = false;
+        m_spinbackActive[i] = false;
+        m_softStartActive[i] = false;
     }
 
     initializeScriptEngine();


### PR DESCRIPTION
fixes [lp:1800343 No scratching on touching jog wheel for the first time](https://bugs.launchpad.net/mixxx/+bug/1800343) 

When touching the wheel [`scratchEnable`](https://github.com/mixxxdj/mixxx/blob/0f2274bca2ab14300c2918e22d2b6374cb5753d0/src/controllers/controllerengine.cpp#L1288) does indeed enable scratching, though `scratchProcess` would disable it right away due to false-positive [`m_softStartActive`](https://github.com/mixxxdj/mixxx/blob/0f2274bca2ab14300c2918e22d2b6374cb5753d0/src/controllers/controllerengine.cpp#L1452-L1459) (and interpret the wheel turn as `jog` command), or even stop the deck due to false-positive [`m_brakeActive` or `m_spinbackActive`](https://github.com/mixxxdj/mixxx/blob/0f2274bca2ab14300c2918e22d2b6374cb5753d0/src/controllers/controllerengine.cpp#L1441-L1446) (regression from #4708 I think).
Either of those issues occurs, or it just works.

Initializing all related deck bools with `false` fixes the issue for me.
I don't know how this could be related to using the controller's sound card though (as reported in the bug).