### PR TITLE
Control picker menu: add 'sort_focused_column'

### DIFF
--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -737,6 +737,15 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             navigationMenu,
             false,
             m_libraryStr);
+    addControl("[Library]",
+            "sort_focused_column",
+            tr("Sort focused column"),
+            tr("Sort the column of the cell that is currently focused, "
+               "equivalent to clicking on its header"),
+            navigationMenu,
+            false,
+            m_libraryStr);
+
     libraryMenu->addSeparator();
     addControl("[Library]",
             "GoToItem",
@@ -779,6 +788,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             false,
             m_libraryStr);
     libraryMenu->addSeparator();
+    // Search box
     addControl("[Library]",
             "search_history_next",
             tr("Select next search history"),


### PR DESCRIPTION
add `[Library],sort_focused_column` to the MIDI Wizard controls menu
follow-up for #4749 