### PR TITLE
Added Trace for the mapping connections, to allow JS profiling.

### DIFF
--- a/src/controllers/scripting/legacy/scriptconnection.cpp
+++ b/src/controllers/scripting/legacy/scriptconnection.cpp
@@ -4,9 +4,7 @@
 #include "util/trace.h"
 
 void ScriptConnection::executeCallback(double value) const {
-    std::unique_ptr<Trace> pCallCallbackTrace;
-    pCallCallbackTrace = std::make_unique<Trace>(
-            QString("JS " + key.item + " callback").toStdString().c_str());
+    Trace executeCallbackTrace(QString("JS " + key.item + " callback").toStdString().c_str());
     const auto args = QJSValueList{
             value,
             key.group,

--- a/src/controllers/scripting/legacy/scriptconnection.cpp
+++ b/src/controllers/scripting/legacy/scriptconnection.cpp
@@ -4,7 +4,7 @@
 #include "util/trace.h"
 
 void ScriptConnection::executeCallback(double value) const {
-    Trace executeCallbackTrace(QString("JS " + key.item + " callback").toStdString().c_str());
+    Trace executeCallbackTrace("JS %1 callback", key.item);
     const auto args = QJSValueList{
             value,
             key.group,

--- a/src/controllers/scripting/legacy/scriptconnection.cpp
+++ b/src/controllers/scripting/legacy/scriptconnection.cpp
@@ -1,8 +1,12 @@
 #include "controllers/scripting/legacy/scriptconnection.h"
 
 #include "controllers/scripting/legacy/controllerscriptenginelegacy.h"
+#include "util/trace.h"
 
 void ScriptConnection::executeCallback(double value) const {
+    std::unique_ptr<Trace> pCallCallbackTrace;
+    pCallCallbackTrace = std::make_unique<Trace>(
+            QString("JS " + key.item + " callback").toStdString().c_str());
     QJSValueList args;
     args << QJSValue(value);
     args << QJSValue(key.group);


### PR DESCRIPTION
This PR adds a Trace statement for each connection
It's grouped by control name - not by group+name - to keep the number of entries limited. I expected that the controls show the same performance for all groups/channels.

How to test:
mixxx --developer
Menu -> Developer -> Developer Tools
![grafik](https://user-images.githubusercontent.com/64457745/169886021-9f81ac51-f84b-4c4f-8382-8d8ec0595c77.png)

Under Stats you should see two lines per JS control connection to your mapping - as for any other trace.

PS: You might notice the huge times in my screenshot - this is a correct measurement, caused by inefficient JavaScript code in common-hid-packet-parser.js (HIDController.prototype.getOutputField)