### PR TITLE
Change the minumum Auto DJ transition time to -99

### DIFF
--- a/src/library/autodj/dlgautodj.ui
+++ b/src/library/autodj/dlgautodj.ui
@@ -127,7 +127,7 @@
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
         <property name="minimum">
-         <number>-9</number>
+         <number>-99</number>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This fixes https://bugs.launchpad.net/mixxx/+bug/1975552
The box becomes one digit wider. the range is now from -99 to 99 s. 

By default spin boxes are limited to 0 ... 99

