### PR TITLE
PitchShiftEffect: add independent effect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -565,6 +565,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/effects/backends/builtin/moogladder4filtereffect.cpp
   src/effects/backends/builtin/parametriceqeffect.cpp
   src/effects/backends/builtin/phasereffect.cpp
+  src/effects/backends/builtin/pitchshifteffect.cpp
   src/effects/backends/builtin/reverbeffect.cpp
   src/effects/backends/builtin/threebandbiquadeqeffect.cpp
   src/effects/backends/builtin/tremoloeffect.cpp

--- a/src/effects/backends/builtin/builtinbackend.cpp
+++ b/src/effects/backends/builtin/builtinbackend.cpp
@@ -23,6 +23,7 @@
 #include "effects/backends/builtin/loudnesscontoureffect.h"
 #include "effects/backends/builtin/metronomeeffect.h"
 #include "effects/backends/builtin/phasereffect.h"
+#include "effects/backends/builtin/pitchshifteffect.h"
 #include "effects/backends/builtin/tremoloeffect.h"
 #include "effects/backends/builtin/whitenoiseeffect.h"
 
@@ -54,6 +55,7 @@ BuiltInBackend::BuiltInBackend() {
     registerEffect<PhaserEffect>();
     registerEffect<MetronomeEffect>();
     registerEffect<TremoloEffect>();
+    registerEffect<PitchShiftEffect>();
 }
 
 std::unique_ptr<EffectProcessor> BuiltInBackend::createProcessor(

--- a/src/effects/backends/builtin/pitchshifteffect.cpp
+++ b/src/effects/backends/builtin/pitchshifteffect.cpp
@@ -5,7 +5,7 @@
 PitchShiftGroupState::PitchShiftGroupState(
         const mixxx::EngineParameters& engineParameters)
         : EffectState(engineParameters) {
-    initializeBuffer();
+    initializeBuffer(engineParameters);
     audioParametersChanged(engineParameters);
 }
 
@@ -20,9 +20,12 @@ PitchShiftGroupState::~PitchShiftGroupState() {
     m_pRubberBand->reset();
 }
 
-void PitchShiftGroupState::initializeBuffer() {
-    m_retrieveBuffer[0] = SampleUtil::alloc(MAX_BUFFER_LEN);
-    m_retrieveBuffer[1] = SampleUtil::alloc(MAX_BUFFER_LEN);
+void PitchShiftGroupState::initializeBuffer(
+        const mixxx::EngineParameters& engineParameters) {
+    m_retrieveBuffer[0] = SampleUtil::alloc(
+            engineParameters.framesPerBuffer());
+    m_retrieveBuffer[1] = SampleUtil::alloc(
+            engineParameters.framesPerBuffer());
 }
 
 void PitchShiftGroupState::audioParametersChanged(

--- a/src/effects/backends/builtin/pitchshifteffect.cpp
+++ b/src/effects/backends/builtin/pitchshifteffect.cpp
@@ -12,12 +12,6 @@ PitchShiftGroupState::PitchShiftGroupState(
 PitchShiftGroupState::~PitchShiftGroupState() {
     SampleUtil::free(m_retrieveBuffer[0]);
     SampleUtil::free(m_retrieveBuffer[1]);
-
-    VERIFY_OR_DEBUG_ASSERT(m_pRubberBand) {
-        return;
-    }
-
-    m_pRubberBand->reset();
 }
 
 void PitchShiftGroupState::initializeBuffer(

--- a/src/effects/backends/builtin/pitchshifteffect.cpp
+++ b/src/effects/backends/builtin/pitchshifteffect.cpp
@@ -1,0 +1,98 @@
+#include "effects/backends/builtin/pitchshifteffect.h"
+
+#include "util/sample.h"
+
+PitchShiftGroupState::~PitchShiftGroupState() noexcept {
+    SampleUtil::free(m_retrieveBuffer[0]);
+    SampleUtil::free(m_retrieveBuffer[1]);
+
+    VERIFY_OR_DEBUG_ASSERT(m_pRubberBand) {
+        return;
+    }
+
+    m_pRubberBand->reset();
+}
+
+// static
+QString PitchShiftEffect::getId() {
+    return "org.mixxx.effects.pitchshift";
+}
+
+//static
+EffectManifestPointer PitchShiftEffect::getManifest() {
+    EffectManifestPointer pManifest(new EffectManifest());
+
+    pManifest->setId(getId());
+    pManifest->setName(QObject::tr("Pitch Shift"));
+    pManifest->setShortName(QObject::tr("Pitch Shift"));
+    pManifest->setAuthor("The Mixxx Team");
+    pManifest->setVersion("1.0");
+    pManifest->setDescription(QObject::tr(
+            "Raises or lowers the original pitch of a sound."));
+
+    EffectManifestParameterPointer pitch = pManifest->addParameter();
+    pitch->setId("pitch");
+    pitch->setName(QObject::tr("Pitch"));
+    pitch->setShortName(QObject::tr("Pitch"));
+    pitch->setDescription(QObject::tr(
+            "The new pitch of a sound."));
+    pitch->setValueScaler(EffectManifestParameter::ValueScaler::Linear);
+    pitch->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    pitch->setDefaultLinkType(EffectManifestParameter::LinkType::Linked);
+    pitch->setDefaultLinkInversion(EffectManifestParameter::LinkInversion::Inverted);
+    pitch->setNeutralPointOnScale(0.0);
+    pitch->setRange(-1.0, 0.0, 1.0);
+
+    return pManifest;
+}
+
+void PitchShiftEffect::loadEngineEffectParameters(
+        const QMap<QString, EngineEffectParameterPointer>& parameters) {
+    m_pPitchParameter = parameters.value("pitch");
+}
+
+void PitchShiftEffect::processChannel(
+        PitchShiftGroupState* pState,
+        const CSAMPLE* pInput,
+        CSAMPLE* pOutput,
+        const mixxx::EngineParameters& engineParameters,
+        const EffectEnableState enableState,
+        const GroupFeatureState& groupFeatures) {
+    Q_UNUSED(groupFeatures);
+    Q_UNUSED(enableState);
+
+    const double pitchParameter = m_pPitchParameter->value();
+
+    double pitch = 1.0;
+
+    if (pitchParameter < 0.0) {
+        pitch += pitchParameter / 2.0;
+    } else {
+        pitch += pitchParameter;
+    }
+
+    pState->m_pRubberBand->setPitchScale(pitch);
+
+    SampleUtil::deinterleaveBuffer(
+            pState->m_retrieveBuffer[0],
+            pState->m_retrieveBuffer[1],
+            pInput,
+            engineParameters.framesPerBuffer());
+    pState->m_pRubberBand->process(
+            (const float* const*)pState->m_retrieveBuffer,
+            engineParameters.framesPerBuffer(),
+            false);
+
+    SINT framesAvailable = pState->m_pRubberBand->available();
+    SINT framesToRead = math_min(
+            framesAvailable,
+            engineParameters.framesPerBuffer());
+    SINT receivedFrames = pState->m_pRubberBand->retrieve(
+            (float* const*)pState->m_retrieveBuffer,
+            framesToRead);
+
+    SampleUtil::interleaveBuffer(pOutput,
+            pState->m_retrieveBuffer[0],
+            pState->m_retrieveBuffer[1],
+            receivedFrames);
+}

--- a/src/effects/backends/builtin/pitchshifteffect.h
+++ b/src/effects/backends/builtin/pitchshifteffect.h
@@ -17,37 +17,17 @@ class RubberBandStretcher;
 
 class PitchShiftGroupState : public EffectState {
   public:
-    // This is the default increment from RubberBand 1.8.1.
-    static constexpr size_t kRubberBandBlockSize = 256;
+    PitchShiftGroupState(const mixxx::EngineParameters& engineParameters);
 
-    PitchShiftGroupState(const mixxx::EngineParameters& engineParameters)
-            : EffectState(engineParameters) {
-        initializeBuffer();
-        audioParametersChanged(engineParameters);
-    }
-
-    virtual ~PitchShiftGroupState();
-
-    void initializeBuffer() {
-        m_retrieveBuffer[0] = SampleUtil::alloc(MAX_BUFFER_LEN);
-        m_retrieveBuffer[1] = SampleUtil::alloc(MAX_BUFFER_LEN);
-    }
-
-    void audioParametersChanged(const mixxx::EngineParameters& engineParameters) {
-        m_pRubberBand = std::make_unique<RubberBand::RubberBandStretcher>(
-                engineParameters.sampleRate(),
-                engineParameters.channelCount(),
-                RubberBand::RubberBandStretcher::OptionProcessRealTime);
-
-        m_pRubberBand->setMaxProcessSize(kRubberBandBlockSize);
-        m_pRubberBand->setTimeRatio(1.0);
-    };
+    ~PitchShiftGroupState() override;
+    void initializeBuffer();
+    void audioParametersChanged(const mixxx::EngineParameters& engineParameters);
 
     std::unique_ptr<RubberBand::RubberBandStretcher> m_pRubberBand;
     CSAMPLE* m_retrieveBuffer[2];
 };
 
-class PitchShiftEffect : public EffectProcessorImpl<PitchShiftGroupState> {
+class PitchShiftEffect final : public EffectProcessorImpl<PitchShiftGroupState> {
   public:
     PitchShiftEffect() = default;
 

--- a/src/effects/backends/builtin/pitchshifteffect.h
+++ b/src/effects/backends/builtin/pitchshifteffect.h
@@ -20,7 +20,7 @@ class PitchShiftGroupState : public EffectState {
     PitchShiftGroupState(const mixxx::EngineParameters& engineParameters);
 
     ~PitchShiftGroupState() override;
-    void initializeBuffer();
+    void initializeBuffer(const mixxx::EngineParameters& engineParameters);
     void audioParametersChanged(const mixxx::EngineParameters& engineParameters);
 
     std::unique_ptr<RubberBand::RubberBandStretcher> m_pRubberBand;

--- a/src/effects/backends/builtin/pitchshifteffect.h
+++ b/src/effects/backends/builtin/pitchshifteffect.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <rubberband/RubberBandStretcher.h>
+
+#include <QMap>
+
+#include "effects/backends/effectprocessor.h"
+#include "engine/effects/engineeffect.h"
+#include "engine/effects/engineeffectparameter.h"
+#include "util/class.h"
+#include "util/defs.h"
+#include "util/sample.h"
+
+namespace RubberBand {
+class RubberBandStretcher;
+} // namespace RubberBand
+
+class PitchShiftGroupState : public EffectState {
+  public:
+    // This is the default increment from RubberBand 1.8.1.
+    static constexpr size_t kRubberBandBlockSize = 256;
+
+    PitchShiftGroupState(const mixxx::EngineParameters& engineParameters)
+            : EffectState(engineParameters) {
+        initializeBuffer();
+        audioParametersChanged(engineParameters);
+    }
+
+    virtual ~PitchShiftGroupState();
+
+    void initializeBuffer() {
+        m_retrieveBuffer[0] = SampleUtil::alloc(MAX_BUFFER_LEN);
+        m_retrieveBuffer[1] = SampleUtil::alloc(MAX_BUFFER_LEN);
+    }
+
+    void audioParametersChanged(const mixxx::EngineParameters& engineParameters) {
+        m_pRubberBand = std::make_unique<RubberBand::RubberBandStretcher>(
+                engineParameters.sampleRate(),
+                engineParameters.channelCount(),
+                RubberBand::RubberBandStretcher::OptionProcessRealTime);
+
+        m_pRubberBand->setMaxProcessSize(kRubberBandBlockSize);
+        m_pRubberBand->setTimeRatio(1.0);
+    };
+
+    std::unique_ptr<RubberBand::RubberBandStretcher> m_pRubberBand;
+    CSAMPLE* m_retrieveBuffer[2];
+};
+
+class PitchShiftEffect : public EffectProcessorImpl<PitchShiftGroupState> {
+  public:
+    PitchShiftEffect() = default;
+
+    static QString getId();
+    static EffectManifestPointer getManifest();
+
+    void loadEngineEffectParameters(
+            const QMap<QString, EngineEffectParameterPointer>& parameters) override;
+
+    void processChannel(
+            PitchShiftGroupState* pState,
+            const CSAMPLE* pInput,
+            CSAMPLE* pOutput,
+            const mixxx::EngineParameters& engineParameters,
+            const EffectEnableState enableState,
+            const GroupFeatureState& groupFeatures) override;
+
+  private:
+    QString debugString() const {
+        return getId();
+    }
+
+    EngineEffectParameterPointer m_pPitchParameter;
+
+    DISALLOW_COPY_AND_ASSIGN(PitchShiftEffect);
+};


### PR DESCRIPTION
Adds a new independent pitch shift effect.
The pitch shift effect contains for now one knob for setting up
the pitch of a sound. The knob has a fixed range for one octave
up or down and works in linear continuous mode.

The known issue is, that the RubberBand library processing latency
needs to be taken into account for different pitch values.
Based on that the effect works with an amount of latency.

Implements: [lp:1299035 "Add a Transpose / Pitch shift effect"](https://bugs.launchpad.net/mixxx/+bug/1299035)
Reported by: RJ Skerry-Ryan