### PR TITLE
EngineBuffer: avoid std::bad_alloc() in WaveformRenderBeat::draw() when loading a track with active passthrough

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -617,6 +617,18 @@ void EngineBuffer::doSeekPlayPos(double new_playpos, enum SeekRequest seekType) 
     }
 #endif
 
+    // As long as passthrough is active the buffer is not processed, thus processSeek()
+    // is not called and the playposition remains at kInitalSamplePosition (-1.79..e+308).
+    // This would cause e.g. a crash in WaveformRenderBeat::draw (GUI freeze in main
+    // respectively, see https://bugs.launchpad.net/mixxx/+bug/1977662
+    // Avoid this by seeking to the first sample. When passthrough is disabled we'll
+    // seek to the queued position.
+    // TODO(ronso0) Find a better way to deal with this, for example prohibit loading
+    // tracks with passthrough enabled?
+    if (m_pPassthroughEnabled->toBool()) {
+        setNewPlaypos(kPassthroughTrackLoadSamplePosition);
+    }
+
     queueNewPlaypos(new_playpos, seekType);
 }
 

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -86,6 +86,11 @@ class EngineBuffer : public EngineObject {
     // not omitted. Therefore this value must be different for 0.0 or any likely
     // value for the main cue
     static constexpr double kInitalSamplePosition = -DBL_MAX;
+    // This is used to do a temporary seek aftertrack load while passthrough is
+    // enabled, before the actual queued position will be applied.
+    // Avoids a crash in WaveformRenderBeat::draw (GUI freeze in main
+    // respectively), see https://bugs.launchpad.net/mixxx/+bug/1977662
+    static constexpr double kPassthroughTrackLoadSamplePosition = 0.0;
 
     EngineBuffer(const QString& group, UserSettingsPointer pConfig,
                  EngineChannel* pChannel, EngineMaster* pMixingEngine);


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1977662

See comments for explanations.
I'm not sure if this is the best solution, though I consider it safe since the queued seek position is set as soon as passthrough is disabled.
We may as well prohibit loading tracks in passtrhough decks, though I didn't look into this approach.

The fix for main is slightly different: with `mixxx::audio::FramePos` we can use `setNewPlaypos(mixxx::audio::kStartFramePos);`

Note: the 'symptom' of the bug, "Non-terminating iterator, unlimited growth of memory, crash when calling m_beats.resize()." as @uklotzde pointed out, in [`WaveformRenderBeat::draw()`](https://github.com/mixxxdj/mixxx/blob/352f75428b5c8e0ab014206939c085c49b1ccc4b/src/waveform/renderers/waveformrenderbeat.cpp#L59-L92) is not addressed here (and I don't know how to fix it).