### PR TITLE
RuntimeLoggingCategory: Fix compile error with Qt 6.3.0

### DIFF
--- a/src/util/runtimeloggingcategory.h
+++ b/src/util/runtimeloggingcategory.h
@@ -38,6 +38,12 @@ struct RuntimeLoggingCategory {
     /// Implicit converter for passing a RuntimeLoggingCategory to the
     /// qCInfo/qCDebug/qCWarning/qCCritical macros as if it was a
     /// QLoggingCategory.
+    operator const QLoggingCategory&() const {
+        return m_logger;
+    }
+
+    /// Converter for accessing QLoggingCategory members such as the
+    /// `isDebugEnabled()` method.
     const QLoggingCategory& operator()() const {
         return m_logger;
     }


### PR DESCRIPTION
    [ 19%] Building CXX object CMakeFiles/mixxx-lib.dir/src/control/controlcompressingproxy.cpp.o
    In file included from /usr/include/qt6/QtCore/QLoggingCategory:1,
                     from src/util/runtimeloggingcategory.h:3,
                     from src/control/controlcompressingproxy.h:7,
                     from src/control/controlcompressingproxy.cpp:1:
    src/control/controlcompressingproxy.cpp: In member function ‘CompressingProxy::StateOfProcessQueuedEvent CompressingProxy::processQueuedEvents()’:
    src/control/controlcompressingproxy.cpp:28:9: error: no matching function for call to ‘{anonymous}::QLoggingCategoryMacroHolder<QtWarningMsg>::QLoggingCategoryMacroHolder(const RuntimeLoggingCategory&)’
       28 |         qCWarning(m_logger) << "Deleted unprocessed events for " + m_key.group +
          |         ^~~~~~~~~
    /usr/include/qt6/QtCore/qloggingcategory.h:120:5: note: candidate: ‘{anonymous}::QLoggingCategoryMacroHolder<Which>::QLoggingCategoryMacroHolder(QMessageLogger::CategoryFunction) [with QtMsgType Which = QtWarningMsg; QMessageLogger::CategoryFunction = const QLoggingCategory& (*)()]’
      120 |     QLoggingCategoryMacroHolder(QMessageLogger::CategoryFunction catfunc)
          |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
    /usr/include/qt6/QtCore/qloggingcategory.h:120:66: note:   no known conversion for argument 1 from ‘const RuntimeLoggingCategory’ to ‘QMessageLogger::CategoryFunction’ {aka ‘const QLoggingCategory& (*)()’}
      120 |     QLoggingCategoryMacroHolder(QMessageLogger::CategoryFunction catfunc)
          |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
    /usr/include/qt6/QtCore/qloggingcategory.h:115:5: note: candidate: ‘{anonymous}::QLoggingCategoryMacroHolder<Which>::QLoggingCategoryMacroHolder(const QLoggingCategory&) [with QtMsgType Which = QtWarningMsg]’
      115 |     QLoggingCategoryMacroHolder(const QLoggingCategory &cat)
          |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
    /usr/include/qt6/QtCore/qloggingcategory.h:115:57: note:   no known conversion for argument 1 from ‘const RuntimeLoggingCategory’ to ‘const QLoggingCategory&’
      115 |     QLoggingCategoryMacroHolder(const QLoggingCategory &cat)
          |                                 ~~~~~~~~~~~~~~~~~~~~~~~~^~~
    /usr/include/qt6/QtCore/qloggingcategory.h:110:35: note: candidate: ‘constexpr {anonymous}::QLoggingCategoryMacroHolder<QtWarningMsg>::QLoggingCategoryMacroHolder(const {anonymous}::QLoggingCategoryMacroHolder<QtWarningMsg>&)’
      110 | template <QtMsgType Which> struct QLoggingCategoryMacroHolder
          |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
    /usr/include/qt6/QtCore/qloggingcategory.h:110:35: note:   no known conversion for argument 1 from ‘const RuntimeLoggingCategory’ to ‘const {anonymous}::QLoggingCategoryMacroHolder<QtWarningMsg>&’
    /usr/include/qt6/QtCore/qloggingcategory.h:110:35: note: candidate: ‘constexpr {anonymous}::QLoggingCategoryMacroHolder<QtWarningMsg>::QLoggingCategoryMacroHolder({anonymous}::QLoggingCategoryMacroHolder<QtWarningMsg>&&)’
    /usr/include/qt6/QtCore/qloggingcategory.h:110:35: note:   no known conversion for argument 1 from ‘const RuntimeLoggingCategory’ to ‘{anonymous}::QLoggingCategoryMacroHolder<QtWarningMsg>&&’
    src/control/controlcompressingproxy.cpp:46:9: error: no matching function for call to ‘{anonymous}::QLoggingCategoryMacroHolder<QtWarningMsg>::QLoggingCategoryMacroHolder(const RuntimeLoggingCategory&)’
       46 |         qCWarning(m_logger)
          |         ^~~~~~~~~
    /usr/include/qt6/QtCore/qloggingcategory.h:120:5: note: candidate: ‘{anonymous}::QLoggingCategoryMacroHolder<Which>::QLoggingCategoryMacroHolder(QMessageLogger::CategoryFunction) [with QtMsgType Which = QtWarningMsg; QMessageLogger::CategoryFunction = const QLoggingCategory& (*)()]’
      120 |     QLoggingCategoryMacroHolder(QMessageLogger::CategoryFunction catfunc)
          |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
    /usr/include/qt6/QtCore/qloggingcategory.h:120:66: note:   no known conversion for argument 1 from ‘const RuntimeLoggingCategory’ to ‘QMessageLogger::CategoryFunction’ {aka ‘const QLoggingCategory& (*)()’}
      120 |     QLoggingCategoryMacroHolder(QMessageLogger::CategoryFunction catfunc)
          |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
    /usr/include/qt6/QtCore/qloggingcategory.h:115:5: note: candidate: ‘{anonymous}::QLoggingCategoryMacroHolder<Which>::QLoggingCategoryMacroHolder(const QLoggingCategory&) [with QtMsgType Which = QtWarningMsg]’
      115 |     QLoggingCategoryMacroHolder(const QLoggingCategory &cat)
          |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
    /usr/include/qt6/QtCore/qloggingcategory.h:115:57: note:   no known conversion for argument 1 from ‘const RuntimeLoggingCategory’ to ‘const QLoggingCategory&’
      115 |     QLoggingCategoryMacroHolder(const QLoggingCategory &cat)
          |                                 ~~~~~~~~~~~~~~~~~~~~~~~~^~~
    /usr/include/qt6/QtCore/qloggingcategory.h:110:35: note: candidate: ‘constexpr {anonymous}::QLoggingCategoryMacroHolder<QtWarningMsg>::QLoggingCategoryMacroHolder(const {anonymous}::QLoggingCategoryMacroHolder<QtWarningMsg>&)’
      110 | template <QtMsgType Which> struct QLoggingCategoryMacroHolder
          |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
    /usr/include/qt6/QtCore/qloggingcategory.h:110:35: note:   no known conversion for argument 1 from ‘const RuntimeLoggingCategory’ to ‘const {anonymous}::QLoggingCategoryMacroHolder<QtWarningMsg>&’
    /usr/include/qt6/QtCore/qloggingcategory.h:110:35: note: candidate: ‘constexpr {anonymous}::QLoggingCategoryMacroHolder<QtWarningMsg>::QLoggingCategoryMacroHolder({anonymous}::QLoggingCategoryMacroHolder<QtWarningMsg>&&)’
    /usr/include/qt6/QtCore/qloggingcategory.h:110:35: note:   no known conversion for argument 1 from ‘const RuntimeLoggingCategory’ to ‘{anonymous}::QLoggingCategoryMacroHolder<QtWarningMsg>&&’
    make[2]: *** [CMakeFiles/mixxx-lib.dir/build.make:413: CMakeFiles/mixxx-lib.dir/src/control/controlcompressingproxy.cpp.o] Error 1
    make[1]: *** [CMakeFiles/Makefile2:295: CMakeFiles/mixxx-lib.dir/all] Error 2
    make: *** [Makefile:166: all] Error 2