### PR TITLE
feat(gh-actions): exempt "needs review" PRs from labelled stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,3 +18,4 @@ jobs:
         stale-pr-label: "stale"
         days-before-stale: 90
         days-before-close: -1
+        exempt-pr-labels: "needs review"


### PR DESCRIPTION
IMO PRs labelled "stale" mean that the contributor has abandoned the PR.
For many PRs that are not abandoned but simply not being reviewed because
of our reviewer shortage, this is not true. In this case, the PR should be
labelled "needs review" and the "stale" label should not be applied.