### PR TITLE
passthrough: stop rendering waveforms, disable Cue/Play indicators

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1242,6 +1242,15 @@ void EngineBuffer::postProcess(const int iBufferSize) {
 }
 
 void EngineBuffer::updateIndicators(double speed, int iBufferSize) {
+    // Explicitly invalidate the visual playposition so waveformwidgetrenderer
+    // clears the visual when passthrough was activated while a track was loaded.
+    // TODO(ronso0) Check if postProcess() needs to be called at all when passthrough
+    // is active -- if no, remove this hack.
+    if (m_pPassthroughEnabled->toBool()) {
+        m_visualPlayPos->setInvalid();
+        return;
+    }
+
     if (m_filepos_play == kInitialSamplePosition ||
             m_trackSampleRateOld == 0 ||
             m_tempo_ratio_old == 0) {
@@ -1261,7 +1270,7 @@ void EngineBuffer::updateIndicators(double speed, int iBufferSize) {
 
     const double tempoTrackSeconds = m_trackSamplesOld / kSamplesPerFrame
             / m_trackSampleRateOld / m_tempo_ratio_old;
-    if(speed > 0 && fFractionalPlaypos == 1.0) {
+    if (speed > 0 && fFractionalPlaypos == 1.0) {
         // At Track end
         speed = 0;
     }

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -581,6 +581,12 @@ void EngineBuffer::slotPassthroughChanged(double enabled) {
     if (enabled != 0) {
         // If passthrough was enabled, stop playing the current track.
         slotControlStop(1.0);
+        // Disable CUE and Play indicators
+        m_pCueControl->resetIndicators();
+    } else {
+        // Update CUE and Play indicators. Note: m_pCueControl->updateIndicators()
+        // is not sufficient.
+        updateIndicatorsAndModifyPlay(false, false);
     }
 }
 


### PR DESCRIPTION
When loading a track _while passthrough is active_ the waveforms are cleared.
* For consistency, let's clear them also when passthrough is activated _while a track is loaded_.
(makes [lp:1567645 Waveform gain changes if passthrough is enabled](https://bugs.launchpad.net/mixxx/+bug/1567645) obsolete)
* Stop CUE and Play indicators when passthrough is activated, update when disabled. Removes distraction and makes moving CUE less likely IMO.

This is only the minimal fix ~~without~~ with minimal UI changes. The complete solution is in #4794 

+ some related ToDos to avoid confusing behaviour