### PR TITLE
Passthrough: improve UI / UX

### DIFF
--- a/res/skins/LateNight/decks/overview.xml
+++ b/res/skins/LateNight/decks/overview.xml
@@ -17,6 +17,7 @@
     <PlayedOverlayColor><Variable name="PlayedOverlayColor"/></PlayedOverlayColor>
     <PlayPosColor><Variable name="PlayPosColor"/></PlayPosColor>
     <EndOfTrackColor><Variable name="EndOfTrackColor"/></EndOfTrackColor>
+    <PassthroughLabelColor><Variable name="PassthroughLabelColor"/></PassthroughLabelColor>
     <LabelFontSize><Variable name="OverviewFontSize"/></LabelFontSize>
     <DimBrightThreshold><Variable name="DimBrightThresholdOverview"/></DimBrightThreshold>
     <!--LabelTextColor>#fff</LabelTextColor>

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -172,6 +172,7 @@
       <SetVariable name="IntroOutroColor">#2c5c9a</SetVariable>
       <SetVariable name="PlayedOverlayColor">#dd151515</SetVariable>
       <SetVariable name="EndOfTrackColor">#f856e7</SetVariable>
+      <SetVariable name="PassthroughLabelColor">#b24c12</SetVariable>
       <SetVariable name="OverviewFontSizeDeck">13</SetVariable>
       <SetVariable name="OverviewFontSizeDeckMini">11</SetVariable>
       <SetVariable name="OverviewFontSizeSampler">10</SetVariable>
@@ -276,6 +277,7 @@
       <SetVariable name="IntroOutroColor">#0000ff</SetVariable>
       <SetVariable name="PlayedOverlayColor">#bb000000</SetVariable>
       <SetVariable name="EndOfTrackColor">#f856e7</SetVariable>
+      <SetVariable name="PassthroughLabelColor">#d09300</SetVariable>
       <SetVariable name="OverviewFontSizeDeck">13</SetVariable>
       <SetVariable name="OverviewFontSizeDeckMini">11</SetVariable>
       <SetVariable name="OverviewFontSizeSampler">10</SetVariable>

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -14,7 +14,6 @@ WTrackProperty,
 WRecordingDuration,
 QSpinBox,
 WBeatSpinBox,
-WOverview #PassthroughLabel,
 WCueMenuPopup,
 WCueMenuPopup QLabel,
 WCueMenuPopup QLineEdit,
@@ -54,14 +53,12 @@ WPushButton#BroadcastButton,
 WPushButton#SkinSettingsToggle,
 #LibraryFeatureControls QPushButton,
 /* Passthrough label on overview waveform */
-WOverview #PassthroughLabel,
 WPushButton#EQKillButton,
 WLabel#LatencyLabel,
 WLabel#SamplerTitleMini,
 /* SKin settings & Library */
 WPushButton#SkinSettingsNumToggle[value="1"],
-QLabel#labelRecFilename,
-WOverview #PassthroughLabel {
+QLabel#labelRecFilename {
   font-family: "Open Sans";
   font-weight: bold;
 }

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -1226,10 +1226,6 @@ QPushButton#pushButtonRecording:checked {
   background-color: #151515;
 }
 
-/* Passthrough label on overview waveform */
-WOverview #PassthroughLabel {
-  color: #d09300;
-}
   #SkinSettingsButton,
   #SkinSettingsNumToggle,
   #SkinSettingsText {

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -1376,11 +1376,6 @@ QPushButton#pushButtonRecording:checked {
   color: #444443;
 }
 
-/* Passthrough label on overview waveform */
-WOverview #PassthroughLabel {
-  color: #b24c12;
-}
-
 #SkinSettingsButton,
 #SkinSettingsNumToggle,
 #SkinSettingsText,

--- a/res/skins/LateNight/waveform.xml
+++ b/res/skins/LateNight/waveform.xml
@@ -29,6 +29,7 @@
             <BeatHighlightColor></BeatHighlightColor>
             <PlayPosColor><Variable name="PlayPosColor"/></PlayPosColor>
             <EndOfTrackColor><Variable name="EndOfTrackColor"/></EndOfTrackColor>
+            <PassthroughLabelColor><Variable name="PassthroughLabelColor"/></PassthroughLabelColor>
             <DimBrightThreshold><Variable name="DimBrightThresholdWaveform"/></DimBrightThreshold>
             <!--
             The hotcues not represented by a button in the current skin show only in the waveform under two circumstances:

--- a/res/skins/Shade/deck_overview.xml
+++ b/res/skins/Shade/deck_overview.xml
@@ -12,6 +12,7 @@
     <SignalColor>#191F24</SignalColor>
     <PlayPosColor>#00FF00</PlayPosColor>
     <EndOfTrackColor>#EA0000</EndOfTrackColor>
+    <PassthroughLabelColor><Variable name="PassthroughLabelColor"/></PassthroughLabelColor>
     <PlayedOverlayColor>#60000000</PlayedOverlayColor>
     <DefaultMark>
       <Align>bottom|right</Align>

--- a/res/skins/Shade/skin.xml
+++ b/res/skins/Shade/skin.xml
@@ -241,6 +241,7 @@
     ############################################################################################
     ############################################################################################
     -->
+    <SetVariable name="PassthroughLabelColor">#55F764</SetVariable>
     <!-- Shade has overview and waveform very close, so it would be redundant and distracting
         to paint the 'Passthrough' labels on both with an alarming color.
         This is the regular background color, so the label will be invisible: -->

--- a/res/skins/Shade/skin.xml
+++ b/res/skins/Shade/skin.xml
@@ -241,6 +241,13 @@
     ############################################################################################
     ############################################################################################
     -->
+    <!-- Shade has overview and waveform very close, so it would be redundant and distracting
+        to paint the 'Passthrough' labels on both with an alarming color.
+        This is the regular background color, so the label will be invisible: -->
+    <SetVariable name="PassthroughLabelColorWaveform">#8d98a3</SetVariable>
+    <!-- This is slightly brighter that the background: -->
+    <!-- <SetVariable name="PassthroughLabelColorWaveform">#9fabb7</SetVariable> -->
+
     <SingletonDefinition>
       <ObjectName>Overview1</ObjectName>
       <Children>

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -29,7 +29,6 @@ WTrackProperty,
 QSpinBox,
 WBeatSpinBox,
 QToolTip,
-WOverview #PassthroughLabel,
 WTrackTableViewHeader,
 WTrackTableViewHeader QMenu,
 WTrackTableViewHeader::section,
@@ -56,13 +55,6 @@ WSearchLineEdit QAbstractScrollArea,
   font-family: "Open Sans";
   font-weight: normal;
   font-style: normal;
-}
-
-/* Passthrough label on overview waveform */
-WOverview #PassthroughLabel {
-  font-size: 12px;
-  font-weight: bold;
-  color: #55F764;
 }
 
 WBeatSpinBox,

--- a/res/skins/Shade/style_dark.qss
+++ b/res/skins/Shade/style_dark.qss
@@ -140,12 +140,6 @@ WEffectSelector::indicator:unchecked:selected,
   background-color: #3F3041;
 }
 
-/* Passthrough label on overview waveform */
-WOverview #PassthroughLabel {
-  color: #00aaff;
-}
-
-
 WTrackTableView,
 WLibrarySidebar {
   /* background of Color delegate in selected row */

--- a/res/skins/Shade/style_summer_sunset.qss
+++ b/res/skins/Shade/style_summer_sunset.qss
@@ -136,11 +136,6 @@ WEffectSelector::indicator:unchecked:selected,
   background-color: #706633;
 }
 
-/* Passthrough label on overview waveform */
-WOverview #PassthroughLabel {
-  color: #FF9900;
-}
-
 WTrackTableView:focus,
 WLibrarySidebar:focus,
 WLibraryTextBrowser:focus,

--- a/res/skins/Shade/waveform.xml
+++ b/res/skins/Shade/waveform.xml
@@ -12,6 +12,7 @@
     <BeatColor>#FFFFFF</BeatColor>
     <PlayPosColor>#00FF00</PlayPosColor>
     <EndOfTrackColor>#EA0000</EndOfTrackColor>
+    <PassthroughLabelColor><Variable name="PassthroughLabelColorWaveform"/></PassthroughLabelColor>
     <AxesColor>#00FF00</AxesColor>
     <Align></Align>
     <DefaultMark>

--- a/res/skins/default.qss
+++ b/res/skins/default.qss
@@ -60,15 +60,6 @@ WColorPicker QPushButton[checked="true"] {
   qproperty-icon: url(:/images/ic_checkmark.svg);
 }
 
-/* Passthrough label on overview waveform */
-WOverview #PassthroughLabel {
-  margin-left: 4px;
-  font-family: "Open Sans";
-  font-weight: bold;
-  font-size: 18px;
-  color: #ff8800;
-}
-
 /* Clear button */
 #SearchClearButton {
   background: none;

--- a/src/engine/channels/enginedeck.cpp
+++ b/src/engine/channels/enginedeck.cpp
@@ -153,7 +153,7 @@ bool EngineDeck::isPassthroughActive() const {
     return (m_bPassthroughIsActive && m_sampleBuffer);
 }
 
-void EngineDeck::slotPassingToggle(double v) {
+void EngineDeck::slotPassthroughToggle(double v) {
     m_bPassthroughIsActive = v > 0;
 }
 
@@ -161,10 +161,10 @@ void EngineDeck::slotPassthroughChangeRequest(double v) {
     if (v <= 0 || m_pInputConfigured->get() > 0) {
         m_pPassing->setAndConfirm(v);
 
-        // Pass confirmed value to slotPassingToggle. We cannot use the
+        // Pass confirmed value to slotPassthroughToggle. We cannot use the
         // valueChanged signal for this, because the change originates from the
         // same ControlObject instance.
-        slotPassingToggle(v);
+        slotPassthroughToggle(v);
     } else {
         emit noPassthroughInputConfigured();
     }

--- a/src/engine/channels/enginedeck.h
+++ b/src/engine/channels/enginedeck.h
@@ -64,7 +64,7 @@ class EngineDeck : public EngineChannel, public AudioDestination {
     void noPassthroughInputConfigured();
 
   public slots:
-    void slotPassingToggle(double v);
+    void slotPassthroughToggle(double v);
     void slotPassthroughChangeRequest(double v);
 
   private:

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -126,7 +126,7 @@ CueControl::CueControl(const QString& group,
 
     m_pCueMode = new ControlObject(ConfigKey(group, "cue_mode"));
 
-    m_pPassthrough = make_parented<ControlProxy>(group, "passthrough");
+    m_pPassthrough = make_parented<ControlProxy>(group, "passthrough", this);
     m_pPassthrough->connectValueChanged(this,
             &CueControl::passthroughChanged,
             Qt::DirectConnection);

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -103,7 +103,9 @@ CueControl::CueControl(const QString& group,
           m_trackMutex(QT_RECURSIVE_MUTEX_INIT) {
     // To silence a compiler warning about CUE_MODE_PIONEER.
     Q_UNUSED(CUE_MODE_PIONEER);
+
     createControls();
+    connectControls();
 
     m_pTrackSamples = ControlObject::getControl(ConfigKey(group, "track_samples"));
 
@@ -123,171 +125,6 @@ CueControl::CueControl(const QString& group,
     m_pCuePoint->set(Cue::kNoPosition);
 
     m_pCueMode = new ControlObject(ConfigKey(group, "cue_mode"));
-
-    m_pCueSet = new ControlPushButton(ConfigKey(group, "cue_set"));
-    m_pCueSet->setButtonMode(ControlPushButton::TRIGGER);
-    connect(m_pCueSet, &ControlObject::valueChanged,
-            this, &CueControl::cueSet,
-            Qt::DirectConnection);
-
-    m_pCueClear = new ControlPushButton(ConfigKey(group, "cue_clear"));
-    m_pCueClear->setButtonMode(ControlPushButton::TRIGGER);
-    connect(m_pCueClear, &ControlObject::valueChanged,
-            this, &CueControl::cueClear,
-            Qt::DirectConnection);
-
-    m_pCueGoto = new ControlPushButton(ConfigKey(group, "cue_goto"));
-    connect(m_pCueGoto, &ControlObject::valueChanged,
-            this, &CueControl::cueGoto,
-            Qt::DirectConnection);
-
-    m_pCueGotoAndPlay =
-            new ControlPushButton(ConfigKey(group, "cue_gotoandplay"));
-    connect(m_pCueGotoAndPlay, &ControlObject::valueChanged,
-            this, &CueControl::cueGotoAndPlay,
-            Qt::DirectConnection);
-
-    m_pCuePlay =
-            new ControlPushButton(ConfigKey(group, "cue_play"));
-    connect(m_pCuePlay, &ControlObject::valueChanged,
-            this, &CueControl::cuePlay,
-            Qt::DirectConnection);
-
-    m_pCueGotoAndStop =
-            new ControlPushButton(ConfigKey(group, "cue_gotoandstop"));
-    connect(m_pCueGotoAndStop, &ControlObject::valueChanged,
-            this, &CueControl::cueGotoAndStop,
-            Qt::DirectConnection);
-
-    m_pCuePreview = new ControlPushButton(ConfigKey(group, "cue_preview"));
-    connect(m_pCuePreview, &ControlObject::valueChanged,
-            this, &CueControl::cuePreview,
-            Qt::DirectConnection);
-
-    m_pCueCDJ = new ControlPushButton(ConfigKey(group, "cue_cdj"));
-    connect(m_pCueCDJ, &ControlObject::valueChanged,
-            this, &CueControl::cueCDJ,
-            Qt::DirectConnection);
-
-    m_pCueDefault = new ControlPushButton(ConfigKey(group, "cue_default"));
-    connect(m_pCueDefault, &ControlObject::valueChanged,
-            this, &CueControl::cueDefault,
-            Qt::DirectConnection);
-
-    m_pPlayStutter = new ControlPushButton(ConfigKey(group, "play_stutter"));
-    connect(m_pPlayStutter, &ControlObject::valueChanged,
-            this, &CueControl::playStutter,
-            Qt::DirectConnection);
-
-    m_pCueIndicator = new ControlIndicator(ConfigKey(group, "cue_indicator"));
-    m_pPlayIndicator = new ControlIndicator(ConfigKey(group, "play_indicator"));
-
-    m_pPlayLatched = new ControlObject(ConfigKey(group, "play_latched"));
-    m_pPlayLatched->setReadOnly();
-
-    m_pIntroStartPosition = new ControlObject(ConfigKey(group, "intro_start_position"));
-    m_pIntroStartPosition->set(Cue::kNoPosition);
-
-    m_pIntroStartEnabled = new ControlObject(ConfigKey(group, "intro_start_enabled"));
-    m_pIntroStartEnabled->setReadOnly();
-
-    m_pIntroStartSet = new ControlPushButton(ConfigKey(group, "intro_start_set"));
-    connect(m_pIntroStartSet, &ControlObject::valueChanged,
-            this, &CueControl::introStartSet,
-            Qt::DirectConnection);
-
-    m_pIntroStartClear = new ControlPushButton(ConfigKey(group, "intro_start_clear"));
-    connect(m_pIntroStartClear, &ControlObject::valueChanged,
-            this, &CueControl::introStartClear,
-            Qt::DirectConnection);
-
-    m_pIntroStartActivate = new ControlPushButton(ConfigKey(group, "intro_start_activate"));
-    connect(m_pIntroStartActivate, &ControlObject::valueChanged,
-            this, &CueControl::introStartActivate,
-            Qt::DirectConnection);
-
-    m_pIntroEndPosition = new ControlObject(ConfigKey(group, "intro_end_position"));
-    m_pIntroEndPosition->set(Cue::kNoPosition);
-
-    m_pIntroEndEnabled = new ControlObject(ConfigKey(group, "intro_end_enabled"));
-    m_pIntroEndEnabled->setReadOnly();
-
-    m_pIntroEndSet = new ControlPushButton(ConfigKey(group, "intro_end_set"));
-    connect(m_pIntroEndSet, &ControlObject::valueChanged,
-            this, &CueControl::introEndSet,
-            Qt::DirectConnection);
-
-    m_pIntroEndClear = new ControlPushButton(ConfigKey(group, "intro_end_clear"));
-    connect(m_pIntroEndClear, &ControlObject::valueChanged,
-            this, &CueControl::introEndClear,
-            Qt::DirectConnection);
-
-    m_pIntroEndActivate = new ControlPushButton(ConfigKey(group, "intro_end_activate"));
-    connect(m_pIntroEndActivate, &ControlObject::valueChanged,
-            this, &CueControl::introEndActivate,
-            Qt::DirectConnection);
-
-    m_pOutroStartPosition = new ControlObject(ConfigKey(group, "outro_start_position"));
-    m_pOutroStartPosition->set(Cue::kNoPosition);
-
-    m_pOutroStartEnabled = new ControlObject(ConfigKey(group, "outro_start_enabled"));
-    m_pOutroStartEnabled->setReadOnly();
-
-    m_pOutroStartSet = new ControlPushButton(ConfigKey(group, "outro_start_set"));
-    connect(m_pOutroStartSet, &ControlObject::valueChanged,
-            this, &CueControl::outroStartSet,
-            Qt::DirectConnection);
-
-    m_pOutroStartClear = new ControlPushButton(ConfigKey(group, "outro_start_clear"));
-    connect(m_pOutroStartClear, &ControlObject::valueChanged,
-            this, &CueControl::outroStartClear,
-            Qt::DirectConnection);
-
-    m_pOutroStartActivate = new ControlPushButton(ConfigKey(group, "outro_start_activate"));
-    connect(m_pOutroStartActivate, &ControlObject::valueChanged,
-            this, &CueControl::outroStartActivate,
-            Qt::DirectConnection);
-
-    m_pOutroEndPosition = new ControlObject(ConfigKey(group, "outro_end_position"));
-    m_pOutroEndPosition->set(Cue::kNoPosition);
-
-    m_pOutroEndEnabled = new ControlObject(ConfigKey(group, "outro_end_enabled"));
-    m_pOutroEndEnabled->setReadOnly();
-
-    m_pOutroEndSet = new ControlPushButton(ConfigKey(group, "outro_end_set"));
-    connect(m_pOutroEndSet, &ControlObject::valueChanged,
-            this, &CueControl::outroEndSet,
-            Qt::DirectConnection);
-
-    m_pOutroEndClear = new ControlPushButton(ConfigKey(group, "outro_end_clear"));
-    connect(m_pOutroEndClear, &ControlObject::valueChanged,
-            this, &CueControl::outroEndClear,
-            Qt::DirectConnection);
-
-    m_pOutroEndActivate = new ControlPushButton(ConfigKey(group, "outro_end_activate"));
-    connect(m_pOutroEndActivate, &ControlObject::valueChanged,
-            this, &CueControl::outroEndActivate,
-            Qt::DirectConnection);
-
-    m_pVinylControlEnabled = new ControlProxy(group, "vinylcontrol_enabled");
-    m_pVinylControlMode = new ControlProxy(group, "vinylcontrol_mode");
-
-    m_pHotcueFocus = new ControlObject(ConfigKey(group, "hotcue_focus"));
-    setHotcueFocusIndex(Cue::kNoHotCue);
-
-    m_pHotcueFocusColorPrev = new ControlObject(ConfigKey(group, "hotcue_focus_color_prev"));
-    connect(m_pHotcueFocusColorPrev,
-            &ControlObject::valueChanged,
-            this,
-            &CueControl::hotcueFocusColorPrev,
-            Qt::DirectConnection);
-
-    m_pHotcueFocusColorNext = new ControlObject(ConfigKey(group, "hotcue_focus_color_next"));
-    connect(m_pHotcueFocusColorNext,
-            &ControlObject::valueChanged,
-            this,
-            &CueControl::hotcueFocusColorNext,
-            Qt::DirectConnection);
 }
 
 CueControl::~CueControl() {
@@ -335,9 +172,198 @@ CueControl::~CueControl() {
 }
 
 void CueControl::createControls() {
-    for (int i = 0; i < m_iNumHotCues; ++i) {
-        HotcueControl* pControl = new HotcueControl(getGroup(), i);
+    m_pCueSet = new ControlPushButton(ConfigKey(m_group, "cue_set"));
+    m_pCueSet->setButtonMode(ControlPushButton::TRIGGER);
+    m_pCueClear = new ControlPushButton(ConfigKey(m_group, "cue_clear"));
+    m_pCueClear->setButtonMode(ControlPushButton::TRIGGER);
+    m_pCueGoto = new ControlPushButton(ConfigKey(m_group, "cue_goto"));
+    m_pCueGotoAndPlay = new ControlPushButton(ConfigKey(m_group, "cue_gotoandplay"));
+    m_pCuePlay = new ControlPushButton(ConfigKey(m_group, "cue_play"));
+    m_pCueGotoAndStop = new ControlPushButton(ConfigKey(m_group, "cue_gotoandstop"));
+    m_pCuePreview = new ControlPushButton(ConfigKey(m_group, "cue_preview"));
+    m_pCueCDJ = new ControlPushButton(ConfigKey(m_group, "cue_cdj"));
+    m_pCueDefault = new ControlPushButton(ConfigKey(m_group, "cue_default"));
+    m_pPlayStutter = new ControlPushButton(ConfigKey(m_group, "play_stutter"));
 
+    m_pPlayLatched = new ControlObject(ConfigKey(m_group, "play_latched"));
+    m_pPlayLatched->setReadOnly();
+
+    m_pCueIndicator = new ControlIndicator(ConfigKey(m_group, "cue_indicator"));
+    m_pPlayIndicator = new ControlIndicator(ConfigKey(m_group, "play_indicator"));
+
+    m_pIntroStartPosition = new ControlObject(ConfigKey(m_group, "intro_start_position"));
+    m_pIntroStartPosition->set(Cue::kNoPosition);
+    m_pIntroStartEnabled = new ControlObject(ConfigKey(m_group, "intro_start_enabled"));
+    m_pIntroStartEnabled->setReadOnly();
+    m_pIntroStartSet = new ControlPushButton(ConfigKey(m_group, "intro_start_set"));
+    m_pIntroStartClear = new ControlPushButton(ConfigKey(m_group, "intro_start_clear"));
+    m_pIntroStartActivate = new ControlPushButton(ConfigKey(m_group, "intro_start_activate"));
+    m_pIntroEndPosition = new ControlObject(ConfigKey(m_group, "intro_end_position"));
+    m_pIntroEndPosition->set(Cue::kNoPosition);
+    m_pIntroEndEnabled = new ControlObject(ConfigKey(m_group, "intro_end_enabled"));
+    m_pIntroEndEnabled->setReadOnly();
+    m_pIntroEndSet = new ControlPushButton(ConfigKey(m_group, "intro_end_set"));
+    m_pIntroEndClear = new ControlPushButton(ConfigKey(m_group, "intro_end_clear"));
+    m_pIntroEndActivate = new ControlPushButton(ConfigKey(m_group, "intro_end_activate"));
+
+    m_pOutroStartPosition = new ControlObject(ConfigKey(m_group, "outro_start_position"));
+    m_pOutroStartPosition->set(Cue::kNoPosition);
+    m_pOutroStartEnabled = new ControlObject(ConfigKey(m_group, "outro_start_enabled"));
+    m_pOutroStartEnabled->setReadOnly();
+    m_pOutroStartSet = new ControlPushButton(ConfigKey(m_group, "outro_start_set"));
+    m_pOutroStartClear = new ControlPushButton(ConfigKey(m_group, "outro_start_clear"));
+    m_pOutroStartActivate = new ControlPushButton(ConfigKey(m_group, "outro_start_activate"));
+    m_pOutroEndPosition = new ControlObject(ConfigKey(m_group, "outro_end_position"));
+    m_pOutroEndPosition->set(Cue::kNoPosition);
+    m_pOutroEndEnabled = new ControlObject(ConfigKey(m_group, "outro_end_enabled"));
+    m_pOutroEndEnabled->setReadOnly();
+    m_pOutroEndSet = new ControlPushButton(ConfigKey(m_group, "outro_end_set"));
+    m_pOutroEndClear = new ControlPushButton(ConfigKey(m_group, "outro_end_clear"));
+    m_pOutroEndActivate = new ControlPushButton(ConfigKey(m_group, "outro_end_activate"));
+
+    m_pVinylControlEnabled = new ControlProxy(m_group, "vinylcontrol_enabled");
+    m_pVinylControlMode = new ControlProxy(m_group, "vinylcontrol_mode");
+
+    m_pHotcueFocus = new ControlObject(ConfigKey(m_group, "hotcue_focus"));
+    setHotcueFocusIndex(Cue::kNoHotCue);
+    m_pHotcueFocusColorPrev = new ControlObject(ConfigKey(m_group, "hotcue_focus_color_prev"));
+    m_pHotcueFocusColorNext = new ControlObject(ConfigKey(m_group, "hotcue_focus_color_next"));
+
+    // Create hotcue controls
+    for (int i = 0; i < m_iNumHotCues; ++i) {
+        HotcueControl* pControl = new HotcueControl(m_group, i);
+        m_hotcueControls.append(pControl);
+    }
+}
+
+void CueControl::connectControls() {
+    // Main Cue controls
+    connect(m_pCueSet,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::cueSet,
+            Qt::DirectConnection);
+    connect(m_pCueClear,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::cueClear,
+            Qt::DirectConnection);
+    connect(m_pCueGoto,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::cueGoto,
+            Qt::DirectConnection);
+    connect(m_pCueGotoAndPlay,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::cueGotoAndPlay,
+            Qt::DirectConnection);
+    connect(m_pCuePlay,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::cuePlay,
+            Qt::DirectConnection);
+    connect(m_pCueGotoAndStop,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::cueGotoAndStop,
+            Qt::DirectConnection);
+    connect(m_pCuePreview,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::cuePreview,
+            Qt::DirectConnection);
+    connect(m_pCueCDJ,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::cueCDJ,
+            Qt::DirectConnection);
+    connect(m_pCueDefault,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::cueDefault,
+            Qt::DirectConnection);
+    connect(m_pPlayStutter,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::playStutter,
+            Qt::DirectConnection);
+
+    connect(m_pIntroStartSet,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::introStartSet,
+            Qt::DirectConnection);
+    connect(m_pIntroStartClear,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::introStartClear,
+            Qt::DirectConnection);
+    connect(m_pIntroStartActivate,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::introStartActivate,
+            Qt::DirectConnection);
+    connect(m_pIntroEndSet,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::introEndSet,
+            Qt::DirectConnection);
+    connect(m_pIntroEndClear,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::introEndClear,
+            Qt::DirectConnection);
+    connect(m_pIntroEndActivate,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::introEndActivate,
+            Qt::DirectConnection);
+
+    connect(m_pOutroStartSet,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::outroStartSet,
+            Qt::DirectConnection);
+    connect(m_pOutroStartClear,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::outroStartClear,
+            Qt::DirectConnection);
+    connect(m_pOutroStartActivate,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::outroStartActivate,
+            Qt::DirectConnection);
+    connect(m_pOutroEndSet,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::outroEndSet,
+            Qt::DirectConnection);
+    connect(m_pOutroEndClear,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::outroEndClear,
+            Qt::DirectConnection);
+    connect(m_pOutroEndActivate,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::outroEndActivate,
+            Qt::DirectConnection);
+
+    connect(m_pHotcueFocusColorPrev,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::hotcueFocusColorPrev,
+            Qt::DirectConnection);
+    connect(m_pHotcueFocusColorNext,
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::hotcueFocusColorNext,
+            Qt::DirectConnection);
+
+    // Hotcue controls
+    for (const auto& pControl : qAsConst(m_hotcueControls)) {
         connect(pControl, &HotcueControl::hotcuePositionChanged,
                 this, &CueControl::hotcuePositionChanged,
                 Qt::DirectConnection);
@@ -391,8 +417,6 @@ void CueControl::createControls() {
                 this,
                 &CueControl::hotcueClear,
                 Qt::DirectConnection);
-
-        m_hotcueControls.append(pControl);
     }
 }
 

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -125,6 +125,11 @@ CueControl::CueControl(const QString& group,
     m_pCuePoint->set(Cue::kNoPosition);
 
     m_pCueMode = new ControlObject(ConfigKey(group, "cue_mode"));
+
+    m_pPassthrough = make_parented<ControlProxy>(group, "passthrough");
+    m_pPassthrough->connectValueChanged(this,
+            &CueControl::passthroughChanged,
+            Qt::DirectConnection);
 }
 
 CueControl::~CueControl() {
@@ -417,6 +422,52 @@ void CueControl::connectControls() {
                 this,
                 &CueControl::hotcueClear,
                 Qt::DirectConnection);
+    }
+}
+
+void CueControl::disconnectControls() {
+    disconnect(m_pCueSet, nullptr, this, nullptr);
+    disconnect(m_pCueClear, nullptr, this, nullptr);
+    disconnect(m_pCueGoto, nullptr, this, nullptr);
+    disconnect(m_pCueGotoAndPlay, nullptr, this, nullptr);
+    disconnect(m_pCuePlay, nullptr, this, nullptr);
+    disconnect(m_pCueGotoAndStop, nullptr, this, nullptr);
+    disconnect(m_pCuePreview, nullptr, this, nullptr);
+    disconnect(m_pCueCDJ, nullptr, this, nullptr);
+    disconnect(m_pCueDefault, nullptr, this, nullptr);
+    disconnect(m_pPlayStutter, nullptr, this, nullptr);
+
+    disconnect(m_pIntroStartSet, nullptr, this, nullptr);
+    disconnect(m_pIntroStartClear, nullptr, this, nullptr);
+    disconnect(m_pIntroStartActivate, nullptr, this, nullptr);
+    disconnect(m_pIntroEndSet, nullptr, this, nullptr);
+    disconnect(m_pIntroEndClear, nullptr, this, nullptr);
+    disconnect(m_pIntroEndActivate, nullptr, this, nullptr);
+
+    disconnect(m_pOutroStartSet, nullptr, this, nullptr);
+    disconnect(m_pOutroStartClear, nullptr, this, nullptr);
+    disconnect(m_pOutroStartActivate, nullptr, this, nullptr);
+    disconnect(m_pOutroEndSet, nullptr, this, nullptr);
+    disconnect(m_pOutroEndClear, nullptr, this, nullptr);
+    disconnect(m_pOutroEndActivate, nullptr, this, nullptr);
+
+    disconnect(m_pHotcueFocusColorPrev, nullptr, this, nullptr);
+    disconnect(m_pHotcueFocusColorNext, nullptr, this, nullptr);
+
+    for (const auto& pControl : qAsConst(m_hotcueControls)) {
+        disconnect(pControl, nullptr, this, nullptr);
+    }
+}
+
+void CueControl::passthroughChanged(double enabled) {
+    if (enabled > 0) {
+        // If passthrough was enabled seeking and playing is prohibited, and the
+        // waveform and overview are blocked.
+        // Disconnect all cue controls to prevent cue changes without UI feedback.
+        disconnectControls();
+    } else {
+        // Reconnect all controls when deck returns to regular mode.
+        connectControls();
     }
 }
 

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -65,7 +65,7 @@ class HotcueControl : public QObject {
         Set = 1,
         /// Hotcue is currently active (this only applies to Saved Loop cues
         /// while their loop is enabled). This status can be used by skins or
-        /// controller mappings to highlight a the cue control that has saved the current loop,
+        /// controller mappings to highlight the cue control that has saved the current loop,
         /// because resizing or moving the loop will make persistent changes to
         /// the cue.
         Active = 2,
@@ -272,6 +272,8 @@ class CueControl : public EngineControl {
 
     // These methods are not thread safe, only call them when the lock is held.
     void createControls();
+    void connectControls();
+
     void attachCue(const CuePointer& pCue, HotcueControl* pControl);
     void detachCue(HotcueControl* pControl);
     void setCurrentSavedLoopControlAndActivate(HotcueControl* pControl);

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -235,6 +235,8 @@ class CueControl : public EngineControl {
     void hotcueFocusColorNext(double v);
     void hotcueFocusColorPrev(double v);
 
+    void passthroughChanged(double v);
+
     void cueSet(double v);
     void cueClear(double v);
     void cueGoto(double v);
@@ -273,6 +275,7 @@ class CueControl : public EngineControl {
     // These methods are not thread safe, only call them when the lock is held.
     void createControls();
     void connectControls();
+    void disconnectControls();
 
     void attachCue(const CuePointer& pCue, HotcueControl* pControl);
     void detachCue(HotcueControl* pControl);
@@ -350,6 +353,8 @@ class CueControl : public EngineControl {
     ControlObject* m_pHotcueFocus;
     ControlObject* m_pHotcueFocusColorNext;
     ControlObject* m_pHotcueFocusColorPrev;
+
+    parented_ptr<ControlProxy> m_pPassthrough;
 
     QAtomicPointer<HotcueControl> m_pCurrentSavedLoopControl;
 

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1348,17 +1348,10 @@ mixxx::audio::FramePos EngineBuffer::queuedSeekPosition() const {
 }
 
 void EngineBuffer::updateIndicators(double speed, int iBufferSize) {
-    // Explicitly invalidate the visual playposition so waveformwidgetrenderer
-    // clears the visual when passthrough was activated while a track was loaded.
-    // TODO(ronso0) Check if postProcess() needs to be called at all when passthrough
-    // is active -- if no, remove this hack.
-    if (m_pPassthroughEnabled->toBool()) {
-        m_visualPlayPos->setInvalid();
-        return;
-    }
     if (!m_playPosition.isValid() ||
             !m_trackSampleRateOld.isValid() ||
-            m_tempo_ratio_old == 0) {
+            m_tempo_ratio_old == 0 ||
+            m_pPassthroughEnabled->toBool()) {
         // Skip indicator updates with invalid values to prevent undefined behavior,
         // e.g. in WaveformRenderBeat::draw().
         //

--- a/src/waveform/renderers/waveformsignalcolors.cpp
+++ b/src/waveform/renderers/waveformsignalcolors.cpp
@@ -95,11 +95,11 @@ bool WaveformSignalColors::setup(const QDomNode &node, const SkinContext& contex
     if (!m_passthroughOverlayColor.isValid()) {
         m_passthroughOverlayColor = WSkinColor::getCorrectColor(QColor(0, 0, 0, 187)).toRgb();
     }
-    // This color is for the "Passthrough" label on scrolling waveforms. Default is white.
+    // This color is for the "Passthrough" label on scrolling waveforms. Default is orange.
     m_passthroughLabelColor = context.selectColor(node, "PassthroughLabelColor");
     m_passthroughLabelColor = WSkinColor::getCorrectColor(m_passthroughLabelColor).toRgb();
     if (!m_passthroughLabelColor.isValid()) {
-        m_passthroughLabelColor = WSkinColor::getCorrectColor(QColor(255, 255, 255, 255)).toRgb();
+        m_passthroughLabelColor = WSkinColor::getCorrectColor(QColor(100, 53, 0, 255)).toRgb();
     }
 
     m_bgColor = context.selectColor(node, "BgColor");

--- a/src/waveform/renderers/waveformsignalcolors.cpp
+++ b/src/waveform/renderers/waveformsignalcolors.cpp
@@ -88,12 +88,18 @@ bool WaveformSignalColors::setup(const QDomNode &node, const SkinContext& contex
         m_playedOverlayColor = Qt::transparent;
     }
 
-    // This color is used to draw an overlay over the entire overview-waveforms
-    // if vinyl passthrough is enabled
+    // This color is used to draw an overlay over the entire overview waveforms
+    // if vinyl passthrough is enabled. Default is black with 73% opacity.
     m_passthroughOverlayColor = context.selectColor(node, "PassthroughOverlayColor");
     m_passthroughOverlayColor = WSkinColor::getCorrectColor(m_passthroughOverlayColor).toRgb();
     if (!m_passthroughOverlayColor.isValid()) {
         m_passthroughOverlayColor = WSkinColor::getCorrectColor(QColor(0, 0, 0, 187)).toRgb();
+    }
+    // This color is for the "Passthrough" label on scrolling waveforms. Default is white.
+    m_passthroughLabelColor = context.selectColor(node, "PassthroughLabelColor");
+    m_passthroughLabelColor = WSkinColor::getCorrectColor(m_passthroughLabelColor).toRgb();
+    if (!m_passthroughLabelColor.isValid()) {
+        m_passthroughLabelColor = WSkinColor::getCorrectColor(QColor(255, 255, 255, 255)).toRgb();
     }
 
     m_bgColor = context.selectColor(node, "BgColor");

--- a/src/waveform/renderers/waveformsignalcolors.h
+++ b/src/waveform/renderers/waveformsignalcolors.h
@@ -54,6 +54,9 @@ class WaveformSignalColors {
     inline const QColor& getPassthroughOverlayColor() const {
         return m_passthroughOverlayColor;
     }
+    inline const QColor& getPassthroughLabelColor() const {
+        return m_passthroughLabelColor;
+    }
     inline const QColor& getBgColor() const {
         return m_bgColor;
     }
@@ -82,6 +85,7 @@ class WaveformSignalColors {
     QColor m_playPosColor;
     QColor m_playedOverlayColor;
     QColor m_passthroughOverlayColor;
+    QColor m_passthroughLabelColor;
     QColor m_bgColor;
     int m_dimBrightThreshold;
 };

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -50,7 +50,8 @@ WaveformWidgetRenderer::WaveformWidgetRenderer(const QString& group)
           m_pTrackSamplesControlObject(nullptr),
           m_trackSamples(0.0),
           m_scaleFactor(1.0),
-          m_playMarkerPosition(s_defaultPlayMarkerPosition) {
+          m_playMarkerPosition(s_defaultPlayMarkerPosition),
+          m_passthroughEnabled(false) {
     //qDebug() << "WaveformWidgetRenderer";
 
 #ifdef WAVEFORMWIDGETRENDERER_DEBUG
@@ -104,6 +105,11 @@ bool WaveformWidgetRenderer::init() {
 }
 
 void WaveformWidgetRenderer::onPreRender(VSyncThread* vsyncThread) {
+    if (m_passthroughEnabled) {
+        m_playPos = -1; // disables renderers in draw()
+        return;
+    }
+
     // For a valid track to render we need
     m_trackSamples = static_cast<int>(m_pTrackSamplesControlObject->get());
     if (m_trackSamples <= 0) {
@@ -183,11 +189,14 @@ void WaveformWidgetRenderer::draw(QPainter* painter, QPaintEvent* event) {
     //timer.start();
 
     // not ready to display need to wait until track initialization is done
-    // draw only first is stack (background)
+    // draw only first in stack (background)
     int stackSize = m_rendererStack.size();
     if (m_trackSamples <= 0.0 || m_playPos == -1) {
         if (stackSize) {
             m_rendererStack.at(0)->draw(painter, event);
+        }
+        if (m_passthroughEnabled) {
+            drawPassthroughLabel(painter);
         }
         return;
     } else {
@@ -307,6 +316,44 @@ void WaveformWidgetRenderer::drawTriangle(QPainter* painter,
     painter->fillPath(triangle, fillColor);
 }
 
+void WaveformWidgetRenderer::drawPassthroughLabel(QPainter* painter) {
+    QFont font;
+    font.setFamily("Open Sans"); // default label font
+    // Make the label always fit
+    font.setPixelSize(math_min(25, int(m_height * 0.8)));
+    font.setWeight(75); // bold
+    font.setItalic(false);
+
+    QString label = QObject::tr("Passthrough");
+    QFontMetrics metrics(font);
+    QRect labelRect = metrics.boundingRect(label);
+    // Center label
+    labelRect.moveTo(
+            int(m_width / 2 - labelRect.width() / 2),
+            int(m_height / 2 - labelRect.height() / 2));
+
+    // Draw text
+    painter->setBrush(QBrush(QColor(0, 0, 0, 0)));
+    painter->setFont(font);
+    painter->setPen(m_passthroughLabelColor);
+    painter->drawText(labelRect, Qt::AlignCenter, label);
+}
+
+void WaveformWidgetRenderer::setPassThroughEnabled(bool enabled) {
+    m_passthroughEnabled = enabled;
+    // Nothing to do if passthrough is disabled
+    if (!enabled) {
+        return;
+    }
+    // If passthrough is activated while no track has been loaded previously mark
+    // the renderer state dirty in order trigger the render process. This is only
+    // required for the background renderer since that's the only one that'll
+    // be processed if passtrhough is active.
+    if (m_rendererStack.size()) {
+        m_rendererStack[0]->setDirty(true);
+    }
+}
+
 void WaveformWidgetRenderer::resize(int width, int height, float devicePixelRatio) {
     m_width = width;
     m_height = height;
@@ -338,6 +385,7 @@ void WaveformWidgetRenderer::setup(
         m_rendererStack[i]->setScaleFactor(m_scaleFactor);
         m_rendererStack[i]->setup(node, context);
     }
+    m_passthroughLabelColor = m_colors.getPassthroughLabelColor();
 }
 
 void WaveformWidgetRenderer::setZoom(double zoom) {

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -153,6 +153,8 @@ class WaveformWidgetRenderer {
         m_playMarkerPosition = newPos;
     }
 
+    void setPassThroughEnabled(bool enabled);
+
   protected:
     const QString m_group;
     TrackPointer m_pTrack;
@@ -163,6 +165,7 @@ class WaveformWidgetRenderer {
     int m_width;
     float m_devicePixelRatio;
     WaveformSignalColors m_colors;
+    QColor m_passthroughLabelColor;
 
     double m_firstDisplayedPosition;
     double m_lastDisplayedPosition;
@@ -210,4 +213,6 @@ private:
             QPointF p1,
             QPointF p2,
             QPointF p3);
+    void drawPassthroughLabel(QPainter* painter);
+    bool m_passthroughEnabled;
 };

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -494,6 +494,10 @@ void WOverview::mouseMoveEvent(QMouseEvent* e) {
 
 void WOverview::mouseReleaseEvent(QMouseEvent* e) {
     mouseMoveEvent(e);
+    if (m_bPassthroughEnabled) {
+        m_bLeftClickDragging = false;
+        return;
+    }
     //qDebug() << "WOverview::mouseReleaseEvent" << e->pos() << m_iPos << ">>" << dValue;
 
     if (e->button() == Qt::LeftButton) {
@@ -514,6 +518,10 @@ void WOverview::mouseReleaseEvent(QMouseEvent* e) {
 void WOverview::mousePressEvent(QMouseEvent* e) {
     //qDebug() << "WOverview::mousePressEvent" << e->pos();
     mouseMoveEvent(e);
+    if (m_bPassthroughEnabled) {
+        m_bLeftClickDragging = false;
+        return;
+    }
     if (m_pCurrentTrack == nullptr) {
         return;
     }

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -85,7 +85,9 @@ WOverview::WOverview(
     m_pPassthroughControl =
             new ControlProxy(m_group, "passthrough", this, ControlFlag::NoAssertIfMissing);
     m_pPassthroughControl->connectValueChanged(this, &WOverview::onPassthroughChange);
-    m_bPassthroughEnabled = static_cast<bool>(m_pPassthroughControl->get());
+    m_bPassthroughEnabled = m_pPassthroughControl->toBool();
+
+    m_pPassthroughLabel = new QLabel(this);
 
     setAcceptDrops(true);
 
@@ -95,18 +97,6 @@ WOverview::WOverview(
             this, &WOverview::onTrackAnalyzerProgress);
 
     connect(m_pCueMenuPopup.get(), &WCueMenuPopup::aboutToHide, this, &WOverview::slotCueMenuPopupAboutToHide);
-
-    m_pPassthroughLabel = new QLabel(this);
-    m_pPassthroughLabel->setObjectName("PassthroughLabel");
-    m_pPassthroughLabel->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
-    // Shown on the overview waveform when vinyl passthrough is enabled
-    m_pPassthroughLabel->setText(tr("Passthrough"));
-    m_pPassthroughLabel->hide();
-    QVBoxLayout *pPassthroughLayout = new QVBoxLayout(this);
-    pPassthroughLayout->setContentsMargins(0,0,0,0);
-    pPassthroughLayout->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
-    pPassthroughLayout->addWidget(m_pPassthroughLabel);
-    setLayout(pPassthroughLayout);
 }
 
 void WOverview::setup(const QDomNode& node, const SkinContext& context) {
@@ -199,6 +189,27 @@ void WOverview::setup(const QDomNode& node, const SkinContext& context) {
         }
         child = child.nextSibling();
     }
+
+    DEBUG_ASSERT(m_pPassthroughLabel != nullptr);
+    m_pPassthroughLabel->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    // Shown on the overview waveform when vinyl passthrough is enabled
+    m_pPassthroughLabel->setText(tr("Passthrough"));
+    m_pPassthroughLabel->setStyleSheet(
+            QStringLiteral("QLabel{"
+                           "font-family: 'Open Sans';"
+                           "font-size: %1px;"
+                           "font-weight: bold;"
+                           "color: %2;"
+                           "margin-left };")
+                    .arg(QString::number(int(m_iLabelFontSize * 1.5)),
+                            QColor(m_signalColors.getPassthroughLabelColor())
+                                    .name(QColor::HexRgb)));
+    m_pPassthroughLabel->hide();
+    QVBoxLayout* pPassthroughLayout = new QVBoxLayout(this);
+    pPassthroughLayout->setContentsMargins(m_iLabelFontSize, 0, 0, 0); // l, t, r, b
+    pPassthroughLayout->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    pPassthroughLayout->addWidget(m_pPassthroughLabel);
+    setLayout(pPassthroughLayout);
 
     QString orientationString = context.selectString(node, "Orientation").toLower();
     if (orientationString == "vertical") {

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -41,7 +41,7 @@ WWaveformViewer::WWaveformViewer(
     m_pWheel = new ControlProxy(
             group, "wheel", this, ControlFlag::NoAssertIfMissing);
     m_pPlayEnabled = new ControlProxy(group, "play", this, ControlFlag::NoAssertIfMissing);
-    m_pPassthroughEnabled = make_parented<ControlProxy>(group, "passthrough");
+    m_pPassthroughEnabled = make_parented<ControlProxy>(group, "passthrough", this);
     m_pPassthroughEnabled->connectValueChanged(this,
             &WWaveformViewer::passthroughChanged,
             Qt::DirectConnection);

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -41,6 +41,10 @@ WWaveformViewer::WWaveformViewer(
     m_pWheel = new ControlProxy(
             group, "wheel", this, ControlFlag::NoAssertIfMissing);
     m_pPlayEnabled = new ControlProxy(group, "play", this, ControlFlag::NoAssertIfMissing);
+    m_pPassthroughEnabled = make_parented<ControlProxy>(group, "passthrough");
+    m_pPassthroughEnabled->connectValueChanged(this,
+            &WWaveformViewer::passthroughChanged,
+            Qt::DirectConnection);
 
     setAttribute(Qt::WA_OpaquePaintEvent);
     setFocusPolicy(Qt::NoFocus);
@@ -263,6 +267,19 @@ void WWaveformViewer::setWaveformWidget(WaveformWidgetAbstract* waveformWidget) 
         QWidget* pWidget = m_waveformWidget->getWidget();
         connect(pWidget, &QWidget::destroyed, this, &WWaveformViewer::slotWidgetDead);
         m_waveformWidget->getWidget()->setMouseTracking(true);
+        // Make connection to show "Passthrough" label on the waveform, except for
+        // "Empty" waveform type
+        if (m_waveformWidget->getType() == WaveformWidgetType::EmptyWaveform) {
+            return;
+        }
+        connect(this,
+                &WWaveformViewer::passthroughChanged,
+                this,
+                [this](double value) {
+                    m_waveformWidget->setPassThroughEnabled(value > 0);
+                });
+        // Make sure the label is shown after the waveform type was changed
+        emit passthroughChanged(m_pPassthroughEnabled->toBool());
     }
 }
 

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -43,6 +43,7 @@ class WWaveformViewer : public WWidget, public TrackDropTarget {
   signals:
     void trackDropped(const QString& filename, const QString& group) override;
     void cloneDeck(const QString& sourceGroup, const QString& targetGroup) override;
+    void passthroughChanged(double value);
 
   public slots:
     void slotTrackLoaded(TrackPointer track);
@@ -77,6 +78,7 @@ class WWaveformViewer : public WWidget, public TrackDropTarget {
     ControlProxy* m_pScratchPosition;
     ControlProxy* m_pWheel;
     ControlProxy* m_pPlayEnabled;
+    parented_ptr<ControlProxy> m_pPassthroughEnabled;
     bool m_bScratching;
     bool m_bBending;
     QPoint m_mouseAnchor;


### PR DESCRIPTION
- [x] Waveforms: show 'Passthrough' label
- [x] Overview: get 'Passthrough' label color from skin node
- [x] Overview: prohibit mouse interaction
- [x] prohibit cue changes (CUE, hotcues, intro, outro) while seeking is blocked (queued, waveform doesn't move)
.
- [x] revert/adjust [5af73d2](https://github.com/mixxxdj/mixxx/pull/4793/commits/5af73d29a7bf494e3ca078aaf69c81c70f1b51d1) since that's now obsolete