### PR TITLE
ci(github): Add `openssh` pkg to Arch Linux image to restore ssh-agent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
             os: ubuntu-20.04
             # The Dockerfile for this container can be found at:
             # https://github.com/Holzhaus/mixxx-ci-docker
-            container: holzhaus/mixxx-ci:20220611-qt6
+            container: holzhaus/mixxx-ci:20220612-qt6
             cmake_args: >-
               -DWARNINGS_FATAL=ON
               -DQT6=ON


### PR DESCRIPTION
Added `openssh` package explicitly to resolve the issue reported in https://github.com/mixxxdj/mixxx/pull/4795#issuecomment-1153154046.