### PR TITLE
Update controller mapping for Behringer DDM4000 mixer

### DIFF
--- a/res/controllers/Behringer-DDM4000-scripts.js
+++ b/res/controllers/Behringer-DDM4000-scripts.js
@@ -261,8 +261,6 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                         midi: { // eslint-disable-next-line key-spacing
                             parameterKnobs:   {1: [cc,   0x06], 2: [cc,   0x05], 3: [cc,   0x04]},
                             parameterButtons: {1: [note, 0x02], 2: [note, 0x01], 3: [note, 0x00]},
-                            enabled: null,
-                            super1: null,
                         },
                         output: {
                             parameterButtons: {1: [cc,   0x3D], 2: [cc,   0x3B], 3: [cc,   0x39]}, // Amber
@@ -293,8 +291,6 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                         midi: { // eslint-disable-next-line key-spacing
                             parameterKnobs:   {1: [cc,   0x0A], 2: [cc,   0x09], 3: [cc,   0x08]},
                             parameterButtons: {1: [note, 0x06], 2: [note, 0x05], 3: [note, 0x04]},
-                            enabled: null,
-                            super1: null,
                         },
                         output: {
                             parameterButtons: {1: [cc,   0x47], 2: [cc,   0x45], 3: [cc,   0x43]}, // Amber
@@ -325,8 +321,6 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                         midi: { // eslint-disable-next-line key-spacing
                             parameterKnobs:   {1: [cc,   0x0E], 2: [cc,   0x0D], 3: [cc,   0x0C]},
                             parameterButtons: {1: [note, 0x0A], 2: [note, 0x09], 3: [note, 0x08]},
-                            enabled: null,
-                            super1: null,
                         },
                         output: {
                             parameterButtons: {1: [cc,   0x51], 2: [cc,   0x4F], 3: [cc,   0x4D]}, // Amber
@@ -357,8 +351,6 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                         midi: { // eslint-disable-next-line key-spacing
                             parameterKnobs:   {1: [cc,   0x12], 2: [cc,   0x11], 3: [cc,   0x10]},
                             parameterButtons: {1: [note, 0x0E], 2: [note, 0x0D], 3: [note, 0x0C]},
-                            enabled: null,
-                            super1: null,
                         },
                         output: {
                             parameterButtons: {1: [cc,   0x5B], 2: [cc,   0x59], 3: [cc,   0x57]}, // Amber


### PR DESCRIPTION
This PR contains a small update for the controller mapping of the Behringer DDM4000 mixer, adding support for QuickEffectUnit mappings.

Before this PR, the `EqualizerUnit` mapping contained the `enabled` and `super1` controls of `QuickEffectRack1`. This decision was made with the skin in mind where the QuickEffect controls are part of the EQ section. It turned out to be confusing in mappings where both EQ and QuickEffect are in use. For example, both EQ and QuickEffect have controls for `enabled`, `super1`, `meta` and `mix`. Hence I decided to create a dedicated `QuickEffectUnit` in addition to the existing `EqualizerUnit` so that it's clear to to which section each control belongs.

The changes are fully backwards-compatible. They have been tested with a custom mapping that maps a quick effect unit and deck effects (loop, reverse) to the channel sections of the mixer. I don't plan to merge this custom mapping here (because the current mapping resembles the mixer functions best), but I plan to share it on the forums when this PR is accepted. I can provide the mapping if desired.

There's intentionally no PR for the manual because the changes do not affect the documentation.