### PR TITLE
CMake: Don't cache missng gsl/gsl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2786,6 +2786,7 @@ else()
   # check if the headers have been installed without cmake config (< 3.1.0)
   check_include_file_cxx(gsl/gsl HAVE_GSL_GSL)
   if(NOT HAVE_GSL_GSL)
+    unset(HAVE_GSL_GSL CACHE) # unset cache to re-evaluate this until it succeeds. check_include_file_cxx() has no REQUIRED flag.
     message(FATAL_ERROR "ms-gsl deveopment headers (libmsgsl-dev) not found")
   endif()
 endif()


### PR DESCRIPTION
Due to the caching nature of heck_include_file_cxx() the check will not repeated and building keeps failing even if the header have been installed. This PR removed cache entries from failing runs. 