### PR TITLE
fix(changelog): Typos and add manufacturer names to hardare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## [2.3.3](https://launchpad.net/mixxx/+milestone/2.3.3) (unreleased)
 
-* Pioneer-DDJ-SB3: Fix controller breaking when releasing the shift button [#4659](https://github.com/mixxxdj/mixxx/pull/4659)
+* Pioneer DDJ-SB3: Fix controller breaking when releasing the shift button [#4659](https://github.com/mixxxdj/mixxx/pull/4659)
 * Traktor S3: Push two deck switches to explicitly clone decks [#4665](https://github.com/mixxxdj/mixxx/pull/4665) [#4671](https://github.com/mixxxdj/mixxx/pull/4671) [lp:1960680](https://bugs.launchpad.net/mixxx/+bug/1960680)
 * Behringer DDM4000: Improve stability and add soft-takeover for encoder knobs [#4318](https://github.com/mixxxdj/mixxx/pull/4318) [#4799](https://github.com/mixxxdj/mixxx/pull/4799)
-* MC7000: Fix 'inverted shift' bug in the controller mapping [#4755](https://github.com/mixxxdj/mixxx/pull/4755)
+* Denon MC7000: Fix 'inverted shift' bug in the controller mapping [#4755](https://github.com/mixxxdj/mixxx/pull/4755)
 * Fix spinback and break effect in the controller engine [#4708](https://github.com/mixxxdj/mixxx/pull/4708)
 * Fix scratch on first wheel touch [#4761](https://github.com/mixxxdj/mixxx/pull/4761) [lp:1800343](https://bugs.launchpad.net/mixxx/+bug/1800343)
 * Preferences: Prevent controller settings being treated as changed even though they were not [#4721](https://github.com/mixxxdj/mixxx/pull/4721) [lp:1920844](https://bugs.launchpad.net/mixxx/+bug/1920844)

--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -102,7 +102,7 @@
       <description>
  <ul>
   <li>
-   Pioneer-DDJ-SB3: Fix controller breaking when releasing the shift button
+   Pioneer DDJ-SB3: Fix controller breaking when releasing the shift button
    #4659
   </li>
   <li>
@@ -117,7 +117,7 @@
    #4799
   </li>
   <li>
-   MC7000: Fix 'inverted shift' bug in the controller mapping
+   Denon MC7000: Fix 'inverted shift' bug in the controller mapping
    #4755
   </li>
   <li>


### PR DESCRIPTION
Taken from this review: https://github.com/mixxxdj/website/pull/272#discussion_r896460060
