### PR TITLE
WTrackMenu: enable Reset Loops action

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -470,6 +470,12 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
             this,
             &CueControl::trackCuesUpdated,
             Qt::DirectConnection);
+
+    connect(m_pLoadedTrack.get(),
+            &Track::loopRemove,
+            this,
+            &CueControl::loopRemove);
+
     lock.unlock();
 
     // Use pNewTrack from now, because m_pLoadedTrack might have been reset

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -205,6 +205,9 @@ class CueControl : public EngineControl {
     void trackLoaded(TrackPointer pNewTrack) override;
     void trackBeatsUpdated(mixxx::BeatsPointer pBeats) override;
 
+  signals:
+    void loopRemove();
+
   public slots:
     void slotLoopReset();
     void slotLoopEnabledChanged(bool enabled);

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -219,6 +219,13 @@ LoopingControl::LoopingControl(const QString& group,
     connect(m_pLoopDoubleButton, &ControlObject::valueChanged,
             this, &LoopingControl::slotLoopDouble);
 
+    m_pLoopRemoveButton = new ControlPushButton(ConfigKey(group, "loop_remove"));
+    m_pLoopRemoveButton->setButtonMode(ControlPushButton::TRIGGER);
+    connect(m_pLoopRemoveButton,
+            &ControlObject::valueChanged,
+            this,
+            &LoopingControl::slotLoopRemove);
+
     m_pPlayButton = ControlObject::getControl(ConfigKey(group, "play"));
 }
 
@@ -237,6 +244,7 @@ LoopingControl::~LoopingControl() {
     delete m_pCOLoopScale;
     delete m_pLoopHalveButton;
     delete m_pLoopDoubleButton;
+    delete m_pLoopRemoveButton;
 
     delete m_pCOBeatLoop;
     while (!m_beatLoops.isEmpty()) {
@@ -693,6 +701,7 @@ void LoopingControl::setLoopInToCurrentPosition() {
     //qDebug() << "set loop_in to " << loopInfo.startPosition;
 }
 
+// Clear the last active loop while saved loop (cue + info) remains untouched
 void LoopingControl::slotLoopRemove() {
     setLoopingEnabled(false);
     LoopInfo loopInfo = m_loopInfo.getValue();

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -693,6 +693,17 @@ void LoopingControl::setLoopInToCurrentPosition() {
     //qDebug() << "set loop_in to " << loopInfo.startPosition;
 }
 
+void LoopingControl::slotLoopRemove() {
+    setLoopingEnabled(false);
+    LoopInfo loopInfo = m_loopInfo.getValue();
+    loopInfo.startPosition = mixxx::audio::kInvalidFramePos;
+    loopInfo.endPosition = mixxx::audio::kInvalidFramePos;
+    loopInfo.seekMode = LoopSeekMode::None;
+    m_loopInfo.setValue(loopInfo);
+    m_pCOLoopStartPosition->set(loopInfo.startPosition.toEngineSamplePosMaybeInvalid());
+    m_pCOLoopEndPosition->set(loopInfo.endPosition.toEngineSamplePosMaybeInvalid());
+}
+
 void LoopingControl::slotLoopIn(double pressed) {
     if (!m_pTrack) {
         return;

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -155,6 +155,7 @@ class LoopingControl : public EngineControl {
     ControlObject* m_pCOLoopScale;
     ControlPushButton* m_pLoopHalveButton;
     ControlPushButton* m_pLoopDoubleButton;
+    ControlPushButton* m_pLoopRemoveButton;
     ControlObject* m_pSlipEnabled;
     RateControl* m_pRateControl;
     ControlObject* m_pPlayButton;

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -98,6 +98,7 @@ class LoopingControl : public EngineControl {
     void slotLoopScale(double scaleFactor);
     void slotLoopDouble(double pressed);
     void slotLoopHalve(double pressed);
+    void slotLoopRemove();
 
   private slots:
     void slotLoopEnabledValueChangeRequest(double enabled);

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -254,6 +254,11 @@ EngineBuffer::EngineBuffer(const QString& group,
             m_pCueControl,
             &CueControl::slotLoopEnabledChanged,
             Qt::DirectConnection);
+    connect(m_pCueControl,
+            &CueControl::loopRemove,
+            m_pLoopingControl,
+            &LoopingControl::slotLoopRemove,
+            Qt::DirectConnection);
 
     m_pReadAheadManager = new ReadAheadManager(m_pReader,
                                                m_pLoopingControl);

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1032,6 +1032,10 @@ void Track::removeCuesOfType(mixxx::CueType type) {
             dirty = true;
         }
     }
+    // If loop cues are removed, also clear the last active loop
+    if (type == mixxx::CueType::Loop) {
+        emit loopRemove();
+    }
     if (compareAndSet(m_record.ptrMainCuePosition(), mixxx::audio::kStartFramePos)) {
         dirty = true;
     }

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -466,6 +466,7 @@ class Track : public QObject {
     void replayGainAdjusted(const mixxx::ReplayGain&);
     void colorUpdated(const mixxx::RgbColor::optional_t& color);
     void cuesUpdated();
+    void loopRemove();
     void analyzed();
 
     void changed(TrackId trackId);

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -333,8 +333,8 @@ void WTrackMenu::createActions() {
         m_pClearOutroCueAction = new QAction(tr("Outro"), m_pClearMetadataMenu);
         connect(m_pClearOutroCueAction, &QAction::triggered, this, &WTrackMenu::slotClearOutroCue);
 
-        m_pClearLoopAction = new QAction(tr("Loop"), m_pClearMetadataMenu);
-        connect(m_pClearLoopAction, &QAction::triggered, this, &WTrackMenu::slotClearLoop);
+        m_pClearLoopsAction = new QAction(tr("Loops"), m_pClearMetadataMenu);
+        connect(m_pClearLoopsAction, &QAction::triggered, this, &WTrackMenu::slotClearLoops);
 
         m_pClearKeyAction = new QAction(tr("Key"), m_pClearMetadataMenu);
         connect(m_pClearKeyAction, &QAction::triggered, this, &WTrackMenu::slotClearKey);
@@ -536,8 +536,7 @@ void WTrackMenu::setupActions() {
         m_pClearMetadataMenu->addAction(m_pClearHotCuesAction);
         m_pClearMetadataMenu->addAction(m_pClearIntroCueAction);
         m_pClearMetadataMenu->addAction(m_pClearOutroCueAction);
-        // FIXME: Why is clearing the loop not working?
-        //m_pClearMetadataMenu->addAction(m_pClearLoopAction);
+        m_pClearMetadataMenu->addAction(m_pClearLoopsAction);
         m_pClearMetadataMenu->addAction(m_pClearKeyAction);
         m_pClearMetadataMenu->addAction(m_pClearReplayGainAction);
         m_pClearMetadataMenu->addAction(m_pClearWaveformAction);
@@ -1576,7 +1575,7 @@ void WTrackMenu::slotClearIntroCue() {
             &trackOperator);
 }
 
-void WTrackMenu::slotClearLoop() {
+void WTrackMenu::slotClearLoops() {
     const auto progressLabelText =
             tr("Removing loop cues from %n track(s)", "", getTrackCount());
     const auto trackOperator =

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -103,7 +103,7 @@ class WTrackMenu : public QMenu {
     void slotClearHotCues();
     void slotClearIntroCue();
     void slotClearOutroCue();
-    void slotClearLoop();
+    void slotClearLoops();
     void slotClearKey();
     void slotClearReplayGain();
     void slotClearWaveform();
@@ -280,7 +280,7 @@ class WTrackMenu : public QMenu {
     QAction* m_pClearHotCuesAction{};
     QAction* m_pClearIntroCueAction{};
     QAction* m_pClearOutroCueAction{};
-    QAction* m_pClearLoopAction{};
+    QAction* m_pClearLoopsAction{};
     QAction* m_pClearWaveformAction{};
     QAction* m_pClearCommentAction{};
     QAction* m_pClearKeyAction{};


### PR DESCRIPTION
Requested on the forums + https://bugs.launchpad.net/mixxx/+bug/1978507

"Reset loops" was already in place but deactivated (though included in "Reset All" :| )
In **2.3** this does nothing as the FIXME says, in **main** it clears the saved loop cues -- though the last active loop persists, no matter if it had a loop cue attached.

- [x] show loop reset action in track menu (remove loop cues),
extent to clear the last active loop (markers removed, `reloop` detached)
- [x] add `loop_remove` control (saved loops are not touched)

Should we distinguish between saved loops and the current active loop?
The latter is requested on the forums now & then, though users are not aware of saved loops in 2.4, and with that there's at least a workaround to clear the unsaved loop (save, then delete loop cue)