### PR TITLE
Waveform: avoid QPainter glitch with ranges < 1 px

### DIFF
--- a/src/waveform/renderers/waveformrendermarkrange.cpp
+++ b/src/waveform/renderers/waveformrendermarkrange.cpp
@@ -64,6 +64,10 @@ void WaveformRenderMarkRange::draw(QPainter *painter, QPaintEvent * /*event*/) {
 
         double startPosition = m_waveformRenderer->transformSamplePositionInRendererWorld(startSample);
         double endPosition = m_waveformRenderer->transformSamplePositionInRendererWorld(endSample);
+        // The painter would extend the rectangle to the entire width while
+        // span is < 1 AND span != 0.25 * [1;3], i.e. works with span = [.25; 0.75] px
+        // TODO(xxx) Figure what's wrong with QPainter / the renderer
+        const double span = std::max(endPosition - startPosition, 1.0);
 
         //range not in the current display
         if (startPosition > m_waveformRenderer->getLength() || endPosition < 0) {
@@ -78,9 +82,9 @@ void WaveformRenderMarkRange::draw(QPainter *painter, QPaintEvent * /*event*/) {
         // this shouldn't involve *any* scaling it should be fast even in software mode
         QRectF rect;
         if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
-            rect.setRect(startPosition, 0, endPosition - startPosition, m_waveformRenderer->getHeight());
+            rect.setRect(startPosition, 0, span, m_waveformRenderer->getHeight());
         } else {
-            rect.setRect(0, startPosition, m_waveformRenderer->getWidth(), endPosition - startPosition);
+            rect.setRect(0, startPosition, m_waveformRenderer->getWidth(), span);
         }
         painter->drawImage(rect, *selectedImage, rect);
     }


### PR DESCRIPTION
Noticed when setting `loop_in` and `loop_out` at the same position (it's not, seems they are correct to be 1+ samples apart):
If the range is < 1 xp, as long as the range start marker is visible in the waveform, the range would be rendered to span until the end of the view.

Can't tell what the actual issue is, QPainter with QRectF // rendering engine?
It's strange though: the glitch does not occur at zoom levels 16.7%, 50% and 100% (on FullHD screen, LateNight @ min width) where the range rectangle width is 0.25 * [odd int].
Anyway, rounding up the width to 1 px solves the issue on all zoom levels.

| zoom | rect.width() | okay? |
| ------- | ---- | ---- |
| 10% | 0.15 | :x: |
| 11% | 0.166 | :x: |
| 12.5 | 0.1875 | :x: |
| 14.3% | 0.214 | :x: |
| 16.7% | **0.25** | :heavy_check_mark:  |
| 20% | 0.3 | :x: |
| 25% | 0.375 | :x: |
| 33.3% | 0.5 | :x: |
| 50% | **0.75** | :heavy_check_mark:  |
| 100% | 1.5 | :heavy_check_mark:  |

_I don't mind if this goes into 2.3.3 or the next release_