### PR TITLE
WTrackMenu: Add menu entry for (re)analyzing tracks

### DIFF
--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -374,7 +374,8 @@ TrackModel::Capabilities BrowseTableModel::getCapabilities() const {
             Capability::LoadToDeck |
             Capability::LoadToPreviewDeck |
             Capability::LoadToSampler |
-            Capability::RemoveFromDisk;
+            Capability::RemoveFromDisk |
+            Capability::Analyze;
 }
 
 QString BrowseTableModel::modelKey(bool noSearch) const {

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -374,8 +374,7 @@ TrackModel::Capabilities BrowseTableModel::getCapabilities() const {
             Capability::LoadToDeck |
             Capability::LoadToPreviewDeck |
             Capability::LoadToSampler |
-            Capability::RemoveFromDisk |
-            Capability::Analyze;
+            Capability::RemoveFromDisk;
 }
 
 QString BrowseTableModel::modelKey(bool noSearch) const {

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -152,6 +152,10 @@ Library::Library(
             &CrateFeature::analyzeTracks,
             m_pAnalysisFeature,
             &AnalysisFeature::analyzeTracks);
+    connect(this,
+            &Library::analyzeTracks,
+            m_pAnalysisFeature,
+            &AnalysisFeature::analyzeTracks);
     addFeature(m_pAnalysisFeature);
     // Suspend a batch analysis while an ad-hoc analysis of
     // loaded tracks is in progress and resume it afterwards.

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -131,6 +131,7 @@ class Library: public QObject {
     void enableCoverArtDisplay(bool);
     void selectTrack(const TrackId&);
     void trackSelected(TrackPointer pTrack);
+    void analyzeTracks(const QList<TrackId>& trackIds);
 #ifdef __ENGINEPRIME__
     void exportLibrary();
     void exportCrate(CrateId crateId);

--- a/src/library/librarytablemodel.cpp
+++ b/src/library/librarytablemodel.cpp
@@ -97,5 +97,6 @@ TrackModel::Capabilities LibraryTableModel::getCapabilities() const {
             Capability::LoadToPreviewDeck |
             Capability::Hide |
             Capability::ResetPlayed |
-            Capability::RemoveFromDisk;
+            Capability::RemoveFromDisk |
+            Capability::Analyze;
 }

--- a/src/library/playlisttablemodel.cpp
+++ b/src/library/playlisttablemodel.cpp
@@ -328,7 +328,8 @@ TrackModel::Capabilities PlaylistTableModel::getCapabilities() const {
             Capability::LoadToDeck |
             Capability::LoadToSampler |
             Capability::LoadToPreviewDeck |
-            Capability::ResetPlayed;
+            Capability::ResetPlayed |
+            Capability::Analyze;
 
     if (m_iPlaylistId !=
             m_pTrackCollectionManager->internalCollection()

--- a/src/library/trackmodel.h
+++ b/src/library/trackmodel.h
@@ -50,6 +50,7 @@ class TrackModel {
         RemovePlaylist = 1u << 14u,
         RemoveCrate = 1u << 15u,
         RemoveFromDisk = 1u << 16u,
+        Analyze = 1u << 17u,
     };
     Q_DECLARE_FLAGS(Capabilities, Capability)
 

--- a/src/library/trackset/crate/cratetablemodel.cpp
+++ b/src/library/trackset/crate/cratetablemodel.cpp
@@ -119,7 +119,8 @@ TrackModel::Capabilities CrateTableModel::getCapabilities() const {
             Capability::LoadToPreviewDeck |
             Capability::RemoveCrate |
             Capability::ResetPlayed |
-            Capability::RemoveFromDisk;
+            Capability::RemoveFromDisk |
+            Capability::Analyze;
 
     if (m_selectedCrate.isValid()) {
         Crate crate;

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -392,7 +392,7 @@ void WTrackMenu::createActions() {
                 &WTrackMenu::slotClearBeats);
     }
 
-    if (featureIsEnabled(Feature::Reanalyze)) {
+    if (featureIsEnabled(Feature::Analyze)) {
         m_pReanalyzeAction = new QAction(tr("Reanalyze"), this);
         connect(m_pReanalyzeAction, &QAction::triggered, this, &WTrackMenu::slotReanalyze);
     }
@@ -2168,7 +2168,7 @@ bool WTrackMenu::featureIsEnabled(Feature flag) const {
                         TrackModel::Capability::RemoveCrate);
     case Feature::Metadata:
         return m_pTrackModel->hasCapabilities(TrackModel::Capability::EditMetadata);
-    case Feature::Reanalyze:
+    case Feature::Analyze:
         // TODO: Do we actually need the EditMetadata capability here?
         //       (We do reset the beatgrid before reanalyzing)
         return m_pTrackModel->hasCapabilities(

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -156,6 +156,11 @@ void WTrackMenu::createMenus() {
         m_pClearMetadataMenu->setTitle(tr("Reset"));
     }
 
+    if (featureIsEnabled(Feature::Analyze)) {
+        m_pAnalyzeMenu = new QMenu(this);
+        m_pAnalyzeMenu->setTitle(tr("Analyze"));
+    }
+
     if (featureIsEnabled(Feature::SearchRelated)) {
         DEBUG_ASSERT(!m_pSearchRelatedMenu);
         m_pSearchRelatedMenu =
@@ -393,7 +398,10 @@ void WTrackMenu::createActions() {
     }
 
     if (featureIsEnabled(Feature::Analyze)) {
-        m_pReanalyzeAction = new QAction(tr("Reanalyze"), this);
+        m_pAnalyzeAction = new QAction(tr("Add to Queue"), this);
+        connect(m_pAnalyzeAction, &QAction::triggered, this, &WTrackMenu::slotAnalyze);
+
+        m_pReanalyzeAction = new QAction(tr("Reset BPM + Add to Queue"), this);
         connect(m_pReanalyzeAction, &QAction::triggered, this, &WTrackMenu::slotReanalyze);
     }
 
@@ -550,8 +558,10 @@ void WTrackMenu::setupActions() {
         addMenu(m_pClearMetadataMenu);
     }
 
-    if (m_pReanalyzeAction) {
-        addAction(m_pReanalyzeAction);
+    if (featureIsEnabled(Feature::Analyze)) {
+        m_pAnalyzeMenu->addAction(m_pAnalyzeAction);
+        m_pAnalyzeMenu->addAction(m_pReanalyzeAction);
+        addMenu(m_pAnalyzeMenu);
     }
 
     // This action is created only for menus instantiated by deck widgets (e.g.
@@ -1320,6 +1330,10 @@ void WTrackMenu::addToAnalysis() {
     }
 
     emit m_pLibrary->analyzeTracks(trackIds);
+}
+
+void WTrackMenu::slotAnalyze() {
+    addToAnalysis();
 }
 
 void WTrackMenu::slotReanalyze() {

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -398,10 +398,10 @@ void WTrackMenu::createActions() {
     }
 
     if (featureIsEnabled(Feature::Analyze)) {
-        m_pAnalyzeAction = new QAction(tr("Add to Queue"), this);
+        m_pAnalyzeAction = new QAction(tr("Analyze"), this);
         connect(m_pAnalyzeAction, &QAction::triggered, this, &WTrackMenu::slotAnalyze);
 
-        m_pReanalyzeAction = new QAction(tr("Reset BPM + Add to Queue"), this);
+        m_pReanalyzeAction = new QAction(tr("Reanalyze"), this);
         connect(m_pReanalyzeAction, &QAction::triggered, this, &WTrackMenu::slotReanalyze);
     }
 

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -2183,8 +2183,6 @@ bool WTrackMenu::featureIsEnabled(Feature flag) const {
     case Feature::Metadata:
         return m_pTrackModel->hasCapabilities(TrackModel::Capability::EditMetadata);
     case Feature::Analyze:
-        // TODO: Do we actually need the EditMetadata capability here?
-        //       (We do reset the beatgrid before reanalyzing)
         return m_pTrackModel->hasCapabilities(
                 TrackModel::Capability::EditMetadata |
                 TrackModel::Capability::Analyze);

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -110,7 +110,8 @@ class WTrackMenu : public QMenu {
     void slotClearWaveform();
     void slotClearAllMetadata();
 
-    // Analyze
+    // Analysis
+    void slotAnalyze();
     void slotReanalyze();
 
     // BPM
@@ -222,6 +223,7 @@ class WTrackMenu : public QMenu {
     QMenu* m_pMetadataMenu{};
     QMenu* m_pMetadataUpdateExternalCollectionsMenu{};
     QMenu* m_pClearMetadataMenu{};
+    QMenu* m_pAnalyzeMenu{};
     QMenu* m_pBPMMenu{};
     QMenu* m_pColorMenu{};
     WCoverArtMenu* m_pCoverMenu{};
@@ -278,7 +280,8 @@ class WTrackMenu : public QMenu {
     // Track color
     WColorPickerAction* m_pColorPickerAction{};
 
-    // Reset beats and analyze track action
+    // Analysis actions
+    QAction* m_pAnalyzeAction{};
     QAction* m_pReanalyzeAction{};
 
     // Clear track metadata actions

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -51,9 +51,9 @@ class WTrackMenu : public QMenu {
         SearchRelated = 1 << 13,
         UpdateReplayGainFromPregain = 1 << 14,
         SelectInLibrary = 1 << 15,
-        Reanalyze = 1 << 16,
+        Analyze = 1 << 16,
         TrackModelFeatures = Remove | HideUnhidePurge,
-        All = AutoDJ | LoadTo | Playlist | Crate | Remove | Metadata | Reset | Reanalyze |
+        All = AutoDJ | LoadTo | Playlist | Crate | Remove | Metadata | Reset | Analyze |
                 BPM | Color | HideUnhidePurge | RemoveFromDisk | FileBrowser |
                 Properties | SearchRelated | UpdateReplayGainFromPregain | SelectInLibrary
     };

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -51,8 +51,9 @@ class WTrackMenu : public QMenu {
         SearchRelated = 1 << 13,
         UpdateReplayGainFromPregain = 1 << 14,
         SelectInLibrary = 1 << 15,
+        Reanalyze = 1 << 16,
         TrackModelFeatures = Remove | HideUnhidePurge,
-        All = AutoDJ | LoadTo | Playlist | Crate | Remove | Metadata | Reset |
+        All = AutoDJ | LoadTo | Playlist | Crate | Remove | Metadata | Reset | Reanalyze |
                 BPM | Color | HideUnhidePurge | RemoveFromDisk | FileBrowser |
                 Properties | SearchRelated | UpdateReplayGainFromPregain | SelectInLibrary
     };
@@ -108,6 +109,9 @@ class WTrackMenu : public QMenu {
     void slotClearReplayGain();
     void slotClearWaveform();
     void slotClearAllMetadata();
+
+    // Analyze
+    void slotReanalyze();
 
     // BPM
     void slotLockBpm();
@@ -180,7 +184,9 @@ class WTrackMenu : public QMenu {
     void updateSelectionCrates(QWidget* pWidget);
 
     void addToAutoDJ(PlaylistDAO::AutoDJSendLoc loc);
+    void addToAnalysis();
 
+    void clearBeats();
     void lockBpm(bool lock);
 
     void loadSelectionToGroup(const QString& group, bool play = false);
@@ -271,6 +277,9 @@ class WTrackMenu : public QMenu {
 
     // Track color
     WColorPickerAction* m_pColorPickerAction{};
+
+    // Reset beats and analyze track action
+    QAction* m_pReanalyzeAction{};
 
     // Clear track metadata actions
     QAction* m_pClearBeatsAction{};

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -16,6 +16,7 @@ constexpr WTrackMenu::Features kTrackMenuFeatures =
         WTrackMenu::Feature::Crate |
         WTrackMenu::Feature::Metadata |
         WTrackMenu::Feature::Reset |
+        WTrackMenu::Feature::Reanalyze |
         WTrackMenu::Feature::BPM |
         WTrackMenu::Feature::Color |
         WTrackMenu::Feature::RemoveFromDisk |

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -16,7 +16,7 @@ constexpr WTrackMenu::Features kTrackMenuFeatures =
         WTrackMenu::Feature::Crate |
         WTrackMenu::Feature::Metadata |
         WTrackMenu::Feature::Reset |
-        WTrackMenu::Feature::Reanalyze |
+        WTrackMenu::Feature::Analyze |
         WTrackMenu::Feature::BPM |
         WTrackMenu::Feature::Color |
         WTrackMenu::Feature::RemoveFromDisk |

--- a/src/widget/wtracktext.cpp
+++ b/src/widget/wtracktext.cpp
@@ -16,7 +16,7 @@ constexpr WTrackMenu::Features kTrackMenuFeatures =
         WTrackMenu::Feature::Crate |
         WTrackMenu::Feature::Metadata |
         WTrackMenu::Feature::Reset |
-        WTrackMenu::Feature::Reanalyze |
+        WTrackMenu::Feature::Analyze |
         WTrackMenu::Feature::BPM |
         WTrackMenu::Feature::Color |
         WTrackMenu::Feature::FileBrowser |

--- a/src/widget/wtracktext.cpp
+++ b/src/widget/wtracktext.cpp
@@ -16,6 +16,7 @@ constexpr WTrackMenu::Features kTrackMenuFeatures =
         WTrackMenu::Feature::Crate |
         WTrackMenu::Feature::Metadata |
         WTrackMenu::Feature::Reset |
+        WTrackMenu::Feature::Reanalyze |
         WTrackMenu::Feature::BPM |
         WTrackMenu::Feature::Color |
         WTrackMenu::Feature::FileBrowser |

--- a/src/widget/wtrackwidgetgroup.cpp
+++ b/src/widget/wtrackwidgetgroup.cpp
@@ -20,7 +20,7 @@ constexpr WTrackMenu::Features kTrackMenuFeatures =
         WTrackMenu::Feature::Crate |
         WTrackMenu::Feature::Metadata |
         WTrackMenu::Feature::Reset |
-        WTrackMenu::Feature::Reanalyze |
+        WTrackMenu::Feature::Analyze |
         WTrackMenu::Feature::BPM |
         WTrackMenu::Feature::Color |
         WTrackMenu::Feature::FileBrowser |

--- a/src/widget/wtrackwidgetgroup.cpp
+++ b/src/widget/wtrackwidgetgroup.cpp
@@ -20,6 +20,7 @@ constexpr WTrackMenu::Features kTrackMenuFeatures =
         WTrackMenu::Feature::Crate |
         WTrackMenu::Feature::Metadata |
         WTrackMenu::Feature::Reset |
+        WTrackMenu::Feature::Reanalyze |
         WTrackMenu::Feature::BPM |
         WTrackMenu::Feature::Color |
         WTrackMenu::Feature::FileBrowser |


### PR DESCRIPTION
In an effort to make analysis more convenient, this branch adds a new submenu to the `WTrackMenu` for analyzing tracks (previously the user had to drag-n-drop the tracks to the analyzer queue in the sidebar):

<img width="358" alt="image" src="https://user-images.githubusercontent.com/30873659/174413256-bbef4d73-a72e-4bdd-892a-6aced0136ce3.png">

Feel free to comment and make suggestions, this is my first actual code contribution to Mixxx so I am not super familiar with the codebase yet. :)