### PR TITLE
LateNight: remove blinking play indicator from mini samplers

### DIFF
--- a/res/skins/LateNight/samplers/sampler_mini.xml
+++ b/res/skins/LateNight/samplers/sampler_mini.xml
@@ -30,14 +30,6 @@
               <ConfigKey><Variable name="Group"/>,play</ConfigKey>
             </Connection>
           </PushButton>
-          <PushButton>
-            <ObjectName>PlayIndicator</ObjectName>
-            <Size>34f,34f</Size>
-            <NumberStates>2</NumberStates>
-            <Connection>
-              <ConfigKey><Variable name="Group"/>,play_indicator</ConfigKey>
-            </Connection>
-          </PushButton>
         </Children>
       </WidgetGroup>
 


### PR DESCRIPTION
probably a copy/paste mistake.
It's not implemented in other skins and LateNight's regular samplers.
because it's annoying.
and doesn't make much sense either since the samplers' Play button triggers `cue_gotoandplay`.