### PR TITLE
Shade: fix for restoring the library split size

### DIFF
--- a/res/skins/Shade/library.xml
+++ b/res/skins/Shade/library.xml
@@ -16,6 +16,9 @@
             <Children>
               <!-- Sidebar etc. -->
               <WidgetGroup>
+                <!-- Required for restoring the splitter sizes, otherwise the searchbox
+                    would force.expand the left side. -->
+                <SizePolicy>i,min</SizePolicy>
                 <Layout>vertical</Layout>
                 <Children>
                   <Template src="skin:preview_deck.xml"/>


### PR DESCRIPTION
The changed searchbox (SizePolicy explicitly set in c++) currently force-expands the left pane, thus prevents restoration of the splitter size.