### PR TITLE
Interface with macOS's media controls and now playing info in Control Center

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1588,6 +1588,15 @@ if(APPLE)
       target_link_libraries(mixxx-lib PRIVATE "-weak_framework iTunesLibrary")
       target_compile_definitions(mixxx-lib PUBLIC __MACOS_ITUNES_LIBRARY__)
     endif()
+
+    option(MACOS_MEDIAPLAYER "macOS media player integration" ON)
+    if(MACOS_MEDIAPLAYER)
+      target_sources(mixxx-lib PRIVATE
+        src/broadcast/macos/macosmediaplayerservice.mm
+      )
+      target_link_libraries(mixxx-lib PRIVATE "-weak_framework MediaPlayer")
+      target_compile_definitions(mixxx-lib PUBLIC __MACOS_MEDIAPLAYER__)
+    endif()
   endif()
 
   option(AU_EFFECTS "Audio Unit (AU) effects integration" ON)

--- a/src/broadcast/macos/macosmediaplayerservice.h
+++ b/src/broadcast/macos/macosmediaplayerservice.h
@@ -10,6 +10,10 @@
 #include "util/cache.h"
 
 // TODO: Implement ScrobblingService once merged
+
+/// A service that interfaces with macOS's media controls and allows the user to
+/// view and control the playback through the system-wide control center, media
+/// keys etc.
 class MacOSMediaPlayerService : public QObject {
     Q_OBJECT
   public:
@@ -17,7 +21,9 @@ class MacOSMediaPlayerService : public QObject {
     ~MacOSMediaPlayerService() override;
 
   public slots:
+    /// Sends the updated track info to the external 'now playing' center.
     void slotBroadcastCurrentTrack(TrackPointer pTrack); // TODO: override
+    /// Notifies the external 'now playing' center that all tracks are paused.
     void slotAllTracksPaused();                          // TODO: override
 
   private:
@@ -26,18 +32,28 @@ class MacOSMediaPlayerService : public QObject {
     ControlProxy* m_pCPFadeNow;
     double m_lastSentPosition;
 
+    /// Fetches the currently playing deck. Returns a `nullptr` if nothing plays.
     DeckAttributes* getCurrentDeck();
+    /// Checks whether the given deck is the currently playing one.
     bool isCurrentDeck(DeckAttributes* attributes);
 
+    /// Called when the play state is toggled externally. Returns whether this was successful.
     bool togglePlayState();
+    /// Called when the play state is changed externally. Returns whether this was successful.
     bool updatePlayState(bool playing);
+    /// Called when the play position is changed externally. Returns whether this was successful.
     bool updatePlayPosition(double absolutePosition);
+    /// Called when the user skips to the next track externally. Returns whether
+    /// this was successful.
     bool skipToNextTrack();
 
   private slots:
+    /// Notifies the external 'now playing' center that the play state of some deck has changed.
     void slotPlayChanged(DeckAttributes* attributes, bool playing);
+    /// Notifies the external 'now playing' center that the play position of some deck has changed.
     void slotPlayPositionChanged(DeckAttributes* attributes, double position);
 
+    /// Updates the cover art if needed.
     void slotCoverFound(const QObject* pRequestor,
             const CoverInfo& coverInfo,
             const QPixmap& pixmap);

--- a/src/broadcast/macos/macosmediaplayerservice.h
+++ b/src/broadcast/macos/macosmediaplayerservice.h
@@ -21,6 +21,7 @@ class MacOSMediaPlayerService : public QObject {
 
   private:
     QList<DeckAttributes*> m_deckAttributes;
+    double m_lastSentPosition;
 
     bool isCurrentDeck(DeckAttributes* attributes);
 

--- a/src/broadcast/macos/macosmediaplayerservice.h
+++ b/src/broadcast/macos/macosmediaplayerservice.h
@@ -32,6 +32,9 @@ class MacOSMediaPlayerService : public QObject {
     ControlProxy* m_pCPFadeNow;
     double m_lastSentPosition;
 
+    /// Sets up the callbacks for controlling playback externally.
+    void setupCommandHandlers();
+
     /// Fetches the currently playing deck. Returns a `nullptr` if nothing plays.
     DeckAttributes* getCurrentDeck();
     /// Checks whether the given deck is the currently playing one.

--- a/src/broadcast/macos/macosmediaplayerservice.h
+++ b/src/broadcast/macos/macosmediaplayerservice.h
@@ -3,6 +3,7 @@
 #include <QList>
 #include <QObject>
 
+#include "control/controlproxy.h"
 #include "library/autodj/autodjprocessor.h"
 #include "library/coverart.h"
 #include "mixer/playermanager.h"
@@ -21,6 +22,8 @@ class MacOSMediaPlayerService : public QObject {
 
   private:
     QList<DeckAttributes*> m_deckAttributes;
+    ControlProxy* m_pCPAutoDjEnabled;
+    ControlProxy* m_pCPFadeNow;
     double m_lastSentPosition;
 
     DeckAttributes* getCurrentDeck();
@@ -29,6 +32,7 @@ class MacOSMediaPlayerService : public QObject {
     bool togglePlayState();
     bool updatePlayState(bool playing);
     bool updatePlayPosition(double absolutePosition);
+    bool skipToNextTrack();
 
   private slots:
     void slotPlayChanged(DeckAttributes* attributes, bool playing);

--- a/src/broadcast/macos/macosmediaplayerservice.h
+++ b/src/broadcast/macos/macosmediaplayerservice.h
@@ -24,7 +24,7 @@ class MacOSMediaPlayerService : public QObject {
     /// Sends the updated track info to the external 'now playing' center.
     void slotBroadcastCurrentTrack(TrackPointer pTrack); // TODO: override
     /// Notifies the external 'now playing' center that all tracks are paused.
-    void slotAllTracksPaused();                          // TODO: override
+    void slotAllTracksPaused(); // TODO: override
 
   private:
     QList<DeckAttributes*> m_deckAttributes;

--- a/src/broadcast/macos/macosmediaplayerservice.h
+++ b/src/broadcast/macos/macosmediaplayerservice.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <QObject.h>
-#include <qlist.h>
+#include <QList>
+#include <QObject>
 
 #include "library/autodj/autodjprocessor.h"
 #include "library/coverart.h"
@@ -23,7 +23,12 @@ class MacOSMediaPlayerService : public QObject {
     QList<DeckAttributes*> m_deckAttributes;
     double m_lastSentPosition;
 
+    DeckAttributes* getCurrentDeck();
     bool isCurrentDeck(DeckAttributes* attributes);
+
+    bool togglePlayState();
+    bool updatePlayState(bool playing);
+    bool updatePlayPosition(double absolutePosition);
 
   private slots:
     void slotPlayChanged(DeckAttributes* attributes, bool playing);

--- a/src/broadcast/macos/macosmediaplayerservice.h
+++ b/src/broadcast/macos/macosmediaplayerservice.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <QObject.h>
+#include <qlist.h>
 
+#include "library/autodj/autodjprocessor.h"
 #include "library/coverart.h"
 #include "mixer/playermanager.h"
 #include "util/cache.h"
@@ -10,11 +12,22 @@
 class MacOSMediaPlayerService : public QObject {
     Q_OBJECT
   public:
-    MacOSMediaPlayerService();
+    MacOSMediaPlayerService(PlayerManagerInterface& pPlayerManager);
+    ~MacOSMediaPlayerService() override;
+
   public slots:
     void slotBroadcastCurrentTrack(TrackPointer pTrack); // TODO: override
     void slotAllTracksPaused();                          // TODO: override
+
+  private:
+    QList<DeckAttributes*> m_deckAttributes;
+
+    bool isCurrentDeck(DeckAttributes* attributes);
+
   private slots:
+    void slotPlayChanged(DeckAttributes* attributes, bool playing);
+    void slotPlayPositionChanged(DeckAttributes* attributes, double position);
+
     void slotCoverFound(const QObject* pRequestor,
             const CoverInfo& coverInfo,
             const QPixmap& pixmap);

--- a/src/broadcast/macos/macosmediaplayerservice.h
+++ b/src/broadcast/macos/macosmediaplayerservice.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <QObject.h>
+
+#include "library/coverart.h"
+#include "mixer/playermanager.h"
+#include "util/cache.h"
+
+// TODO: Implement ScrobblingService once merged
+class MacOSMediaPlayerService : public QObject {
+    Q_OBJECT
+  public:
+    MacOSMediaPlayerService();
+  public slots:
+    void slotBroadcastCurrentTrack(TrackPointer pTrack); // TODO: override
+    void slotAllTracksPaused();                          // TODO: override
+  private slots:
+    void slotCoverFound(const QObject* pRequestor,
+            const CoverInfo& coverInfo,
+            const QPixmap& pixmap);
+};

--- a/src/broadcast/macos/macosmediaplayerservice.mm
+++ b/src/broadcast/macos/macosmediaplayerservice.mm
@@ -35,6 +35,7 @@ void setCoverArt(NSMutableDictionary* nowPlayingInfo, const QPixmap& pixmap) {
         // Wrap the converted image in an artwork object as required
         // Since the block escapes, we need to de-stackify it with 'copy'
         auto fetchArtworkImage = ^NSImage*(CGSize size) {
+            Q_UNUSED(size);
             return nsImage;
         };
         MPMediaItemArtwork* artwork = [[MPMediaItemArtwork alloc]
@@ -98,12 +99,14 @@ void MacOSMediaPlayerService::setupCommandHandlers() {
 
     [center.playCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(
             MPRemoteCommandEvent* event) {
+        Q_UNUSED(event);
         bool success = updatePlayState(true);
         return commandHandlerStatusFor(success);
     }];
 
     [center.pauseCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(
             MPRemoteCommandEvent* event) {
+        Q_UNUSED(event);
         bool success = updatePlayState(false);
         return commandHandlerStatusFor(success);
     }];
@@ -111,6 +114,7 @@ void MacOSMediaPlayerService::setupCommandHandlers() {
     [center.togglePlayPauseCommand
             addTargetWithHandler:^MPRemoteCommandHandlerStatus(
                     MPRemoteCommandEvent* event) {
+                Q_UNUSED(event);
                 bool success = togglePlayState();
                 return commandHandlerStatusFor(success);
             }];
@@ -126,6 +130,7 @@ void MacOSMediaPlayerService::setupCommandHandlers() {
 
     [center.nextTrackCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(
             MPRemoteCommandEvent* event) {
+        Q_UNUSED(event);
         bool success = skipToNextTrack();
         return commandHandlerStatusFor(success);
     }];
@@ -271,6 +276,8 @@ void MacOSMediaPlayerService::slotPlayPositionChanged(
 void MacOSMediaPlayerService::slotCoverFound(const QObject* pRequestor,
         const CoverInfo& coverInfo,
         const QPixmap& pixmap) {
+    Q_UNUSED(coverInfo);
+
     if (pRequestor != this) {
         return;
     }

--- a/src/broadcast/macos/macosmediaplayerservice.mm
+++ b/src/broadcast/macos/macosmediaplayerservice.mm
@@ -1,0 +1,125 @@
+#include "broadcast/macos/macosmediaplayerservice.h"
+#include "library/coverartcache.h"
+#include "mixer/playermanager.h"
+#include "track/track.h"
+
+#import <AppKit/AppKit.h>
+#import <MediaPlayer/MediaPlayer.h>
+#include <qpixmap.h>
+
+#include "moc_macosmediaplayerservice.cpp"
+
+constexpr int coverArtSize = 128;
+
+MacOSMediaPlayerService::MacOSMediaPlayerService() {
+    // Register command handlers.
+    // At least one handler must be registered, otherwise the now playing info
+    // will not show up.
+    MPRemoteCommandCenter* center = [MPRemoteCommandCenter sharedCommandCenter];
+    [center.playCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(
+            MPRemoteCommandEvent* event) {
+      // TODO: Implement play
+      return MPRemoteCommandHandlerStatusCommandFailed;
+    }];
+
+    // Wire up cover art cache so loaded covers get passed to our slot
+    CoverArtCache* coverArtCache = CoverArtCache::instance();
+    connect(coverArtCache,
+            &CoverArtCache::coverFound,
+            this,
+            &MacOSMediaPlayerService::slotCoverFound);
+}
+
+namespace {
+void setCoverArt(NSMutableDictionary* nowPlayingInfo, const QPixmap& pixmap) {
+    if (@available(macOS 10.13.2, *)) {
+        // Convert the Qt image to a Cocoa image
+        CGImageRef cgImage = pixmap.toImage().toCGImage();
+        NSImage* nsImage = [[NSImage alloc] initWithCGImage:cgImage
+                                                       size:NSZeroSize];
+
+        // Wrap the converted image in an artwork object as required
+        // Since the block escapes, we need to de-stackify it with 'copy'
+        auto fetchArtworkImage = ^NSImage*(CGSize size) {
+            return nsImage;
+        };
+        MPMediaItemArtwork* artwork = [[MPMediaItemArtwork alloc]
+                initWithBoundsSize:CGSizeMake(coverArtSize, coverArtSize)
+                    requestHandler:[fetchArtworkImage copy]];
+        [nowPlayingInfo setObject:artwork forKey:MPMediaItemPropertyArtwork];
+    }
+}
+} // namespace
+
+void MacOSMediaPlayerService::slotBroadcastCurrentTrack(TrackPointer pTrack) {
+    MPNowPlayingInfoCenter* center = [MPNowPlayingInfoCenter defaultCenter];
+    NSMutableDictionary* nowPlayingInfo = [[NSMutableDictionary alloc] init];
+
+    if (pTrack == nullptr) {
+        [center setPlaybackState:MPNowPlayingPlaybackStatePaused];
+    } else {
+        // Request cover art, possibly loaded asynchronously
+        if (@available(macOS 10.13.2, *)) {
+            CoverArtCache::requestTrackCover(this, pTrack);
+        }
+
+        // Retrieve general track metadata
+        NSURL* url = [NSURL fileURLWithPath:pTrack->getLocation().toNSString()];
+        NSString* title = pTrack->getTitle().toNSString();
+        NSString* artist = pTrack->getArtist().toNSString();
+        NSString* album = pTrack->getAlbum().toNSString();
+        NSString* albumArtist = pTrack->getAlbumArtist().toNSString();
+        NSNumber* duration = @(pTrack->getDuration());
+
+        [nowPlayingInfo setObject:@(MPNowPlayingInfoMediaTypeAudio)
+                           forKey:MPNowPlayingInfoPropertyMediaType];
+        [nowPlayingInfo setObject:url forKey:MPNowPlayingInfoPropertyAssetURL];
+        [nowPlayingInfo setObject:@(false)
+                           forKey:MPNowPlayingInfoPropertyIsLiveStream];
+        [nowPlayingInfo setObject:title forKey:MPMediaItemPropertyTitle];
+        [nowPlayingInfo setObject:artist forKey:MPMediaItemPropertyArtist];
+        [nowPlayingInfo setObject:album forKey:MPMediaItemPropertyAlbumTitle];
+        [nowPlayingInfo setObject:albumArtist
+                           forKey:MPMediaItemPropertyAlbumArtist];
+        [nowPlayingInfo setObject:duration
+                           forKey:MPMediaItemPropertyPlaybackDuration];
+
+        // TODO: Use actual play time and (relative) tempo for rate
+        [nowPlayingInfo setObject:@(0.0)
+                           forKey:MPNowPlayingInfoPropertyElapsedPlaybackTime];
+        [nowPlayingInfo setObject:@(1.0)
+                           forKey:MPNowPlayingInfoPropertyDefaultPlaybackRate];
+        [nowPlayingInfo setObject:@(1.0)
+                           forKey:MPNowPlayingInfoPropertyPlaybackRate];
+
+        [center setPlaybackState:MPNowPlayingPlaybackStatePlaying];
+    }
+
+    [center setNowPlayingInfo:nowPlayingInfo];
+}
+
+void MacOSMediaPlayerService::slotCoverFound(const QObject* pRequestor,
+        const CoverInfo& coverInfo,
+        const QPixmap& pixmap) {
+    if (pRequestor != this) {
+        return;
+    }
+
+    MPNowPlayingInfoCenter* center = [MPNowPlayingInfoCenter defaultCenter];
+    NSDictionary* existingInfo = [center nowPlayingInfo];
+    NSMutableDictionary* nowPlayingInfo = existingInfo == nil
+            ? [[NSMutableDictionary alloc] init]
+            : [[NSMutableDictionary alloc] initWithDictionary:existingInfo];
+
+    // Update cover art in now playing with our found image
+    if (!pixmap.isNull()) {
+        setCoverArt(nowPlayingInfo, pixmap);
+    }
+
+    [center setNowPlayingInfo:nowPlayingInfo];
+}
+
+void MacOSMediaPlayerService::slotAllTracksPaused() {
+    MPNowPlayingInfoCenter* center = [MPNowPlayingInfoCenter defaultCenter];
+    [center setPlaybackState:MPNowPlayingPlaybackStatePaused];
+}

--- a/src/broadcast/macos/macosmediaplayerservice.mm
+++ b/src/broadcast/macos/macosmediaplayerservice.mm
@@ -1,5 +1,6 @@
 #include "broadcast/macos/macosmediaplayerservice.h"
 #include "library/coverartcache.h"
+#include "mixer/playerinfo.h"
 #include "mixer/playermanager.h"
 #include "track/track.h"
 
@@ -22,9 +23,14 @@ MacOSMediaPlayerService::MacOSMediaPlayerService() {
       return MPRemoteCommandHandlerStatusCommandFailed;
     }];
 
+    // Write up player info so we get notified about track updates
+    connect(&PlayerInfo::instance(),
+            &PlayerInfo::currentPlayingTrackChanged,
+            this,
+            &MacOSMediaPlayerService::slotBroadcastCurrentTrack);
+
     // Wire up cover art cache so loaded covers get passed to our slot
-    CoverArtCache* coverArtCache = CoverArtCache::instance();
-    connect(coverArtCache,
+    connect(CoverArtCache::instance(),
             &CoverArtCache::coverFound,
             this,
             &MacOSMediaPlayerService::slotCoverFound);

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -382,10 +382,6 @@ void CoreServices::initialize(QApplication* pApp) {
 
 #ifdef __MACOS_MEDIAPLAYER__
     m_pMacOSMediaPlayerService = std::make_shared<MacOSMediaPlayerService>();
-    connect(&PlayerInfo::instance(),
-            &PlayerInfo::currentPlayingTrackChanged,
-            m_pMacOSMediaPlayerService.get(),
-            &MacOSMediaPlayerService::slotBroadcastCurrentTrack);
 #endif
 
     bool musicDirAdded = false;

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -381,7 +381,7 @@ void CoreServices::initialize(QApplication* pApp) {
     m_pPlayerManager->bindToLibrary(m_pLibrary.get());
 
 #ifdef __MACOS_MEDIAPLAYER__
-    m_pMacOSMediaPlayerService = std::make_shared<MacOSMediaPlayerService>();
+    m_pMacOSMediaPlayerService = std::make_shared<MacOSMediaPlayerService>(*m_pPlayerManager);
 #endif
 
     bool musicDirAdded = false;

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -8,6 +8,9 @@
 #ifdef __BROADCAST__
 #include "broadcast/broadcastmanager.h"
 #endif
+#ifdef __MACOS_MEDIAPLAYER__
+#include "broadcast/macos/macosmediaplayerservice.h"
+#endif
 #include "control/controlindicatortimer.h"
 #include "controllers/controllermanager.h"
 #include "controllers/keyboard/keyboardeventfilter.h"
@@ -376,6 +379,14 @@ void CoreServices::initialize(QApplication* pApp) {
     // been created. Otherwise Mixxx might hang when accessing
     // the uninitialized singleton instance!
     m_pPlayerManager->bindToLibrary(m_pLibrary.get());
+
+#ifdef __MACOS_MEDIAPLAYER__
+    m_pMacOSMediaPlayerService = std::make_shared<MacOSMediaPlayerService>();
+    connect(&PlayerInfo::instance(),
+            &PlayerInfo::currentPlayingTrackChanged,
+            m_pMacOSMediaPlayerService.get(),
+            &MacOSMediaPlayerService::slotBroadcastCurrentTrack);
+#endif
 
     bool musicDirAdded = false;
 

--- a/src/coreservices.h
+++ b/src/coreservices.h
@@ -16,6 +16,9 @@ class RecordingManager;
 #ifdef __BROADCAST__
 class BroadcastManager;
 #endif
+#ifdef __MACOS_MEDIAPLAYER__
+class MacOSMediaPlayerService;
+#endif
 class ControllerManager;
 class VinylControlManager;
 class TrackCollectionManager;
@@ -131,6 +134,9 @@ class CoreServices : public QObject {
     std::shared_ptr<RecordingManager> m_pRecordingManager;
 #ifdef __BROADCAST__
     std::shared_ptr<BroadcastManager> m_pBroadcastManager;
+#endif
+#ifdef __MACOS_MEDIAPLAYER__
+    std::shared_ptr<MacOSMediaPlayerService> m_pMacOSMediaPlayerService;
 #endif
     std::shared_ptr<ControllerManager> m_pControllerManager;
 


### PR DESCRIPTION
This branch exposes Mixxx's playback state to macOS through the `Media Player` framework, making it externally controllable (e.g. via control center, media keys etc.):

<img width="548" alt="Screen Shot 2022-06-18 at 05 53 16" src="https://user-images.githubusercontent.com/30873659/174421910-4b164b39-4307-4f4e-8ca6-4724fac370f2.png">

Some notes on the implementation:

- The implementation of `MacOSMediaPlayerService` is written in Objective-C++. This should not be an issue, given that Clang handles ObjC++ natively pretty well, but something to be aware of (I needed to tweak the clang-format config, since it would otherwise fail when trying to format some ObjC constructs)
- The API of the `MacOSMediaPlayerService` closely follows the `ScrobblingService` from #3483, to make integration with the more general abstractions from the other PR for exposing playback metadata easy (in the future).
  - Ideally, all of the general challenges surrounding exposing playback metadata should be handled abstractly (e.g. figuring out which decks to play/pause etc.), so the service implementations can focus on the platform-specifics (e.g. macOS in this case or MPRIS, ...)

### To do

- [x] Set up basic infrastructure (`MacOSMediaPlayerService`, Objective-C++, linking the `Media Player` framework)
- [x] Expose basic track metadata (title, artist, album, ...)
- [x] Expose cover art
- [x] Expose track playback info
  - [x] Duration
  - [x] Elapsed time
- [x] Implement remote command callbacks
  - [x] Play
  - [x] Pause
  - [x] Seek
  - [x] Skipping via auto-DJ
- [x] Figure out whether we need to manually manage memory on ObjC objects and blocks
  - We've enabled Automatic Reference Counting (ARC) via `-fobjc-arc` that takes care of this

### Future Directions

- Compute correct rate from bpm adjustment in `slotBroadcastCurrentTrack`. This isn't that urgent though since the playback position corrects itself ~every second in `slotPlayPositionChanged` and might just be nice to have a smoother slider.
- Implement `ScrobblingService` interface from #3483 (once ready)