### PR TITLE
ID3v2: Write grouping field into GRP1 instead of TIT1 frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@
   [#4477](https://github.com/mixxxdj/mixxx/pull/4477)
   [#4475](https://github.com/mixxxdj/mixxx/pull/4475)
   [#4480](https://github.com/mixxxdj/mixxx/pull/4480)
+  [#4811](https://github.com/mixxxdj/mixxx/pull/4811) ID3v2: Write grouping field into GRP1 instead of TIT1 frame
 
 ### Sync
 

--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -317,6 +317,8 @@
    #4477
    #4475
    #4480
+   #4811
+   ID3v2: Write grouping field into GRP1 instead of TIT1 frame
   </li>
  </ul>
  <p>


### PR DESCRIPTION
Without saying, the way how Apple introduced the GRP1 ID3v2 frame almost 10 years ago was dumb and mindless. Nevertheless, we have to cope with it.

Our current content-sensitive strategy when exporting tags is unpredictable for users and preserves an inconsistent state. By unconditionally writing the _Grouping_/_Content Group_ data into GRP1 instead of TIT1 Mixxx becomes more predictable for users and eventually all file tags will converge to a consistent state. The comments in the code also explain this reasoning.

Sometimes its better to make a decision instead of trying to please everyone.