### PR TITLE
Triplet check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,12 @@ if(APPLE)
   endif()
 endif()
 
+if(DEFINED VCPKG_ROOT AND DEFINED VCPKG_TARGET_TRIPLET)
+  if(NOT EXISTS "${VCPKG_ROOT}/installed/${VCPKG_TARGET_TRIPLET}")
+    message(FATAL_ERROR "VCPKG_TARGET_TRIPLET dir not found: ${VCPKG_ROOT}/installed/${VCPKG_TARGET_TRIPLET}")
+  endif()
+endif()
+
 project(mixxx VERSION 2.4.0)
 # Work around missing version suffixes support https://gitlab.kitware.com/cmake/cmake/-/issues/16716
 set(MIXXX_VERSION_PRERELEASE "alpha-pre") # set to "alpha-pre" "beta" or ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,8 @@ endif()
 
 if(DEFINED VCPKG_ROOT AND DEFINED VCPKG_TARGET_TRIPLET)
   if(NOT EXISTS "${VCPKG_ROOT}/installed/${VCPKG_TARGET_TRIPLET}")
-    message(FATAL_ERROR "VCPKG_TARGET_TRIPLET dir not found: ${VCPKG_ROOT}/installed/${VCPKG_TARGET_TRIPLET}")
+    message(FATAL_ERROR "VCPKG_TARGET_TRIPLET dir not found: ${VCPKG_ROOT}/installed/${VCPKG_TARGET_TRIPLET} "
+        "Make sure the VCPKG build environment is installed and contains the build for the selected triplet.")
   endif()
 endif()
 


### PR DESCRIPTION
This adds an early exit if the target triplet was not found. This happens if you try to install on a target currently not supported in the installed vcpkg environment. 

Now it fails with: 
```
CMake Error at CMakeLists.txt:109 (message):
  VCPKG_TARGET_TRIPLET dir not found: /Users/runner/buildenv/mixxx-deps-2.4-x64-osx-dynamic-min10.12-7756933/installed/x64-osx-dynamic-min10.12
```


Without this patch we have this output: 
```
CMake Error at /Users/runner/hostedtoolcache/cmake/3.16.9/x64/cmake-3.16.9-Darwin-x86_64/CMake.app/Contents/share/cmake-3.16/Modules/FindPackageHandleStandardArgs.cmake:146 (message):
  Could NOT find Chromaprint (missing: Chromaprint_LIBRARY
  Chromaprint_INCLUDE_DIR)
Call Stack (most recent call first):
  /Users/runner/hostedtoolcache/cmake/3.16.9/x64/cmake-3.16.9-Darwin-x86_64/CMake.app/Contents/share/cmake-3.16/Modules/FindPackageHandleStandardArgs.cmake:393 (_FPHSA_FAILURE_MESSAGE)
  cmake/modules/FindChromaprint.cmake:68 (find_package_handle_standard_args)
  /Users/runner/buildenv/mixxx-deps-2.4-x64-osx-dynamic-min10.12-7756933/scripts/buildsystems/vcpkg.cmake:824 (_find_package)
  CMakeLists.txt:1846 (find_package)
```