### PR TITLE
add alternative Saved Loop activation mode: always jump to and loop // toggle loop if in range

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -122,8 +122,6 @@ CueControl::CueControl(const QString& group,
     m_pCuePoint = new ControlObject(ConfigKey(group, "cue_point"));
     m_pCuePoint->set(Cue::kNoPosition);
 
-    m_pCueMode = new ControlObject(ConfigKey(group, "cue_mode"));
-
     m_pPassthrough = make_parented<ControlProxy>(group, "passthrough", this);
     m_pPassthrough->connectValueChanged(this,
             &CueControl::passthroughChanged,
@@ -132,7 +130,6 @@ CueControl::CueControl(const QString& group,
 
 CueControl::~CueControl() {
     delete m_pCuePoint;
-    delete m_pCueMode;
     qDeleteAll(m_hotcueControls);
 }
 
@@ -155,6 +152,8 @@ void CueControl::createControls() {
 
     m_pCueIndicator = std::make_unique<ControlIndicator>(ConfigKey(m_group, "cue_indicator"));
     m_pPlayIndicator = std::make_unique<ControlIndicator>(ConfigKey(m_group, "play_indicator"));
+
+    m_pCueMode = std::make_unique<ControlObject>(ConfigKey(m_group, "cue_mode"));
 
     m_pIntroStartPosition = std::make_unique<ControlObject>(
             ConfigKey(m_group, "intro_start_position"));

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -46,6 +46,14 @@ enum class HotcueSetMode {
     Loop = 2,
 };
 
+/// Describes how loop cues are activated
+enum class LoopCueActivationMode {
+    /// Activate loop, jump to loop start if loop is behind play position (default)
+    Reloop = 0,
+    /// Jump to loop start and loop
+    JumpOrToggle = 1,
+};
+
 inline SeekOnLoadMode seekOnLoadModeFromDouble(double value) {
     return static_cast<SeekOnLoadMode>(int(value));
 }
@@ -131,6 +139,7 @@ class HotcueControl : public QObject {
     void slotHotcueGotoAndLoop(double v);
     void slotHotcueCueLoop(double v);
     void slotHotcueActivate(double v);
+    void slotHotcueActivateSecondary(double v);
     void slotHotcueActivateCue(double v);
     void slotHotcueActivateLoop(double v);
     void slotHotcueActivatePreview(double v);
@@ -147,6 +156,7 @@ class HotcueControl : public QObject {
     void hotcueGotoAndLoop(HotcueControl* pHotcue, double v);
     void hotcueCueLoop(HotcueControl* pHotcue, double v);
     void hotcueActivate(HotcueControl* pHotcue, double v, HotcueSetMode mode);
+    void hotcueActivateSecondary(HotcueControl* pHotcue, double v, HotcueSetMode mode);
     void hotcueActivatePreview(HotcueControl* pHotcue, double v);
     void hotcueClear(HotcueControl* pHotcue, double v);
     void hotcuePositionChanged(HotcueControl* pHotcue, double newPosition);
@@ -176,6 +186,7 @@ class HotcueControl : public QObject {
     std::unique_ptr<ControlPushButton> m_hotcueGotoAndLoop;
     std::unique_ptr<ControlPushButton> m_hotcueCueLoop;
     std::unique_ptr<ControlPushButton> m_hotcueActivate;
+    std::unique_ptr<ControlPushButton> m_hotcueActivateSecondary;
     std::unique_ptr<ControlPushButton> m_hotcueActivateCue;
     std::unique_ptr<ControlPushButton> m_hotcueActivateLoop;
     std::unique_ptr<ControlPushButton> m_hotcueActivatePreview;
@@ -224,7 +235,9 @@ class CueControl : public EngineControl {
     void hotcueGotoAndLoop(HotcueControl* pControl, double v);
     void hotcueCueLoop(HotcueControl* pControl, double v);
     void hotcueActivate(HotcueControl* pControl, double v, HotcueSetMode mode);
+    void hotcueActivateSecondary(HotcueControl* pControl, double v, HotcueSetMode mode);
     void hotcueActivatePreview(HotcueControl* pControl, double v);
+    void loopCueReloop(HotcueControl* pControl, const CuePointer& pCue);
     void updateCurrentlyPreviewingIndex(int hotcueIndex);
     void hotcueClear(HotcueControl* pControl, double v);
     void hotcuePositionChanged(HotcueControl* pControl, double newPosition);
@@ -322,6 +335,7 @@ class CueControl : public EngineControl {
     std::unique_ptr<ControlPushButton> m_pCuePreview;
 
     std::unique_ptr<ControlObject> m_pCueMode;
+    std::unique_ptr<ControlObject> m_pLoopCueActivationMode;
 
     std::unique_ptr<ControlObject> m_pIntroStartPosition;
     std::unique_ptr<ControlObject> m_pIntroStartEnabled;

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -307,7 +307,6 @@ class CueControl : public EngineControl {
 
     ControlObject* m_pTrackSamples;
     ControlObject* m_pCuePoint;
-    ControlObject* m_pCueMode;
     std::unique_ptr<ControlPushButton> m_pCueSet;
     std::unique_ptr<ControlPushButton> m_pCueClear;
     std::unique_ptr<ControlPushButton> m_pCueCDJ;
@@ -321,6 +320,8 @@ class CueControl : public EngineControl {
     std::unique_ptr<ControlPushButton> m_pCuePlay;
     std::unique_ptr<ControlPushButton> m_pCueGotoAndStop;
     std::unique_ptr<ControlPushButton> m_pCuePreview;
+
+    std::unique_ptr<ControlObject> m_pCueMode;
 
     std::unique_ptr<ControlObject> m_pIntroStartPosition;
     std::unique_ptr<ControlObject> m_pIntroStartEnabled;

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -65,8 +65,8 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent, UserSettingsPointer pConfig)
     ComboBoxCueMode->addItem(tr("CUP mode"), static_cast<int>(CueMode::CueAndPlay));
     const int cueModeIndex = cueDefaultIndexByData(cueDefaultValue);
     ComboBoxCueMode->setCurrentIndex(cueModeIndex);
-    slotCueModeCombobox(cueModeIndex);
-    for (ControlProxy* pControl : std::as_const(m_cueControls)) {
+    slotCueModeCombobox(cueModeIndex); // sets m_cueMode
+    for (ControlProxy* pControl : qAsConst(m_cueModeControls)) {
         pControl->set(static_cast<int>(m_cueMode));
     }
     connect(ComboBoxCueMode,
@@ -413,7 +413,7 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent, UserSettingsPointer pConfig)
 DlgPrefDeck::~DlgPrefDeck() {
     qDeleteAll(m_rateControls);
     qDeleteAll(m_rateDirectionControls);
-    qDeleteAll(m_cueControls);
+    qDeleteAll(m_cueModeControls);
     qDeleteAll(m_rateRangeControls);
     qDeleteAll(m_keylockModeControls);
     qDeleteAll(m_keyunlockModeControls);
@@ -439,7 +439,7 @@ void DlgPrefDeck::slotUpdate() {
     double rateDirection = m_rateDirectionControls[0]->get();
     checkBoxInvertSpeedSlider->setChecked(rateDirection == kRateDirectionInverted);
 
-    double cueMode = m_cueControls[0]->get();
+    double cueMode = m_cueModeControls[0]->get();
     index = ComboBoxCueMode->findData(static_cast<int>(cueMode));
     ComboBoxCueMode->setCurrentIndex(index);
 
@@ -686,7 +686,7 @@ void DlgPrefDeck::slotApply() {
     m_pConfig->setValue(ConfigKey("[Controls]", "TimeFormat"), timeFormat);
 
     // Set cue mode for every deck
-    for (ControlProxy* pControl : std::as_const(m_cueControls)) {
+    for (ControlProxy* pControl : qAsConst(m_cueModeControls)) {
         pControl->set(static_cast<int>(m_cueMode));
     }
     m_pConfig->setValue(ConfigKey("[Controls]", "CueDefault"), m_cueMode);
@@ -773,7 +773,7 @@ void DlgPrefDeck::slotNumDecksChanged(double new_count, bool initializing) {
                 group, "rateRange"));
         m_rateDirectionControls.push_back(new ControlProxy(
                 group, "rate_dir"));
-        m_cueControls.push_back(new ControlProxy(
+        m_cueModeControls.push_back(new ControlProxy(
                 group, "cue_mode"));
         m_keylockModeControls.push_back(new ControlProxy(
                 group, "keylockMode"));
@@ -806,7 +806,7 @@ void DlgPrefDeck::slotNumSamplersChanged(double new_count, bool initializing) {
                 group, "rateRange"));
         m_rateDirectionControls.push_back(new ControlProxy(
                 group, "rate_dir"));
-        m_cueControls.push_back(new ControlProxy(
+        m_cueModeControls.push_back(new ControlProxy(
                 group, "cue_mode"));
         m_keylockModeControls.push_back(new ControlProxy(
                 group, "keylockMode"));

--- a/src/preferences/dialog/dlgprefdeck.h
+++ b/src/preferences/dialog/dlgprefdeck.h
@@ -81,6 +81,7 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
     void slotSetTrackTimeDisplay(QAbstractButton*);
     void slotSetTrackTimeDisplay(double);
     void slotCueModeCombobox(int);
+    void slotLoopCueActivationModeSelected(QAbstractButton* pressedButton);
     void slotSetTrackLoadMode(int comboboxIndex);
     void slotLoadWhenDeckPlayingIndexChanged(int comboboxIndex);
     void slotCloneDeckOnLoadDoubleTapCheckbox(bool);
@@ -114,6 +115,7 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
     const parented_ptr<ControlProxy> m_pNumSamplers;
 
     QList<ControlProxy*> m_cueModeControls;
+    QList<ControlProxy*> m_loopCueActivationModeControls;
     QList<ControlProxy*> m_rateControls;
     QList<ControlProxy*> m_rateDirectionControls;
     QList<ControlProxy*> m_rateRangeControls;
@@ -126,6 +128,7 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
     TrackTime::DisplayMode m_timeDisplayMode;
 
     CueMode m_cueMode;
+    LoopCueActivationMode m_loopCueActivationMode;
 
     bool m_bSetIntroStartAtMainCue;
     bool m_bCloneDeckOnLoadDoubleTap;

--- a/src/preferences/dialog/dlgprefdeck.h
+++ b/src/preferences/dialog/dlgprefdeck.h
@@ -113,7 +113,7 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
     const parented_ptr<ControlProxy> m_pNumDecks;
     const parented_ptr<ControlProxy> m_pNumSamplers;
 
-    QList<ControlProxy*> m_cueControls;
+    QList<ControlProxy*> m_cueModeControls;
     QList<ControlProxy*> m_rateControls;
     QList<ControlProxy*> m_rateDirectionControls;
     QList<ControlProxy*> m_rateRangeControls;

--- a/src/preferences/dialog/dlgprefdeckdlg.ui
+++ b/src/preferences/dialog/dlgprefdeckdlg.ui
@@ -14,6 +14,7 @@
    <string>Deck Preferences</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
+
    <item row="0" column="0">
     <widget class="QGroupBox" name="groupBoxDeckOptions">
      <property name="title">
@@ -23,16 +24,6 @@
       <property name="spacing">
        <number>10</number>
       </property>
-      <item row="5" column="0">
-       <widget class="QLabel" name="labelLoadWhenDeckPlaying">
-        <property name="text">
-         <string>Loading a track, when deck is playing</string>
-        </property>
-        <property name="buddy">
-         <cstring>comboBoxLoadWhenDeckPlaying</cstring>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="labelCueMode">
         <property name="text">
@@ -40,33 +31,6 @@
         </property>
         <property name="openExternalLinks">
          <bool>true</bool>
-        </property>
-        <property name="buddy">
-         <cstring>ComboBoxCueMode</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1" colspan="2">
-       <widget class="QComboBox" name="comboBoxLoadPoint"/>
-      </item>
-      <item row="1" column="1" colspan="2">
-       <widget class="QCheckBox" name="checkBoxIntroStartMove">
-        <property name="toolTip">
-         <string>When the analyzer places the intro start point automatically,
-it will place it at the main cue point if the main cue point has been set previously.
-This may be helpful for upgrading to Mixxx 2.3 from earlier versions.
-
-If this option is disabled, the intro start point is automatically placed at the first sound.</string>
-        </property>
-        <property name="text">
-         <string>Set intro start to main cue when analyzing tracks</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="labelIntroStartMove">
-        <property name="text">
-         <string>Intro start</string>
         </property>
         <property name="buddy">
          <cstring>ComboBoxCueMode</cstring>
@@ -98,33 +62,32 @@ CUP mode:
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="labelCloneDeckOnLoadDoubleTap">
+
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelIntroStartMove">
         <property name="text">
-         <string>Clone deck</string>
+         <string>Intro start</string>
         </property>
         <property name="buddy">
-         <cstring>checkBoxCloneDeckOnLoadDoubleTap</cstring>
+         <cstring>ComboBoxCueMode</cstring>
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="labelTimeDisplay">
+      <item row="1" column="1" colspan="2">
+       <widget class="QCheckBox" name="checkBoxIntroStartMove">
+        <property name="toolTip">
+         <string>When the analyzer places the intro start point automatically,
+it will place it at the main cue point if the main cue point has been set previously.
+This may be helpful for upgrading to Mixxx 2.3 from earlier versions.
+
+If this option is disabled, the intro start point is automatically placed at the first sound.</string>
+        </property>
         <property name="text">
-         <string>Time Format</string>
+         <string>Set intro start to main cue when analyzing tracks</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
-       <widget class="QComboBox" name="comboBoxTimeFormat"/>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="labelLoadPoint">
-        <property name="text">
-         <string>Track load point</string>
-        </property>
-       </widget>
-      </item>
+
       <item row="2" column="0">
        <widget class="QLabel" name="labelPositionDisplay">
         <property name="enabled">
@@ -144,11 +107,8 @@ CUP mode:
         </property>
        </widget>
       </item>
-      <item row="5" column="1" colspan="2">
-       <widget class="QComboBox" name="comboBoxLoadWhenDeckPlaying"/>
-      </item>
       <item row="2" column="1" colspan="2">
-       <layout class="QHBoxLayout" name="horizontalLayout">
+       <layout class="QHBoxLayout" name="horizontalLayout_1">
         <item>
          <widget class="QRadioButton" name="radioButtonElapsed">
           <property name="text">
@@ -181,6 +141,53 @@ CUP mode:
         </item>
        </layout>
       </item>
+
+      <item row="3" column="0">
+       <widget class="QLabel" name="labelTimeDisplay">
+        <property name="text">
+         <string>Time Format</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QComboBox" name="comboBoxTimeFormat"/>
+      </item>
+
+      <item row="4" column="0">
+       <widget class="QLabel" name="labelLoadPoint">
+        <property name="text">
+         <string>Track load point</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1" colspan="2">
+       <widget class="QComboBox" name="comboBoxLoadPoint"/>
+      </item>
+
+      <item row="5" column="0">
+       <widget class="QLabel" name="labelLoadWhenDeckPlaying">
+        <property name="text">
+         <string>Loading a track, when deck is playing</string>
+        </property>
+        <property name="buddy">
+         <cstring>comboBoxLoadWhenDeckPlaying</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1" colspan="2">
+       <widget class="QComboBox" name="comboBoxLoadWhenDeckPlaying"/>
+      </item>
+
+      <item row="6" column="0">
+       <widget class="QLabel" name="labelCloneDeckOnLoadDoubleTap">
+        <property name="text">
+         <string>Clone deck</string>
+        </property>
+        <property name="buddy">
+         <cstring>checkBoxCloneDeckOnLoadDoubleTap</cstring>
+        </property>
+       </widget>
+      </item>
       <item row="6" column="1" colspan="2">
        <widget class="QCheckBox" name="checkBoxCloneDeckOnLoadDoubleTap">
         <property name="toolTip">
@@ -195,6 +202,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
      </layout>
     </widget>
    </item>
+
    <item row="1" column="0">
     <widget class="QGroupBox" name="groupBoxSpeedPitchOptions">
      <property name="title">
@@ -203,62 +211,47 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
      <layout class="QGridLayout" name="gridLayout_7">
       <item row="0" column="0">
        <layout class="QGridLayout" name="GridLayoutSpeedOptions">
-        <item row="11" column="2">
-         <widget class="QDoubleSpinBox" name="spinBoxPermanentRateCoarse">
-          <property name="toolTip">
-           <string>Permanent rate change when left-clicking</string>
-          </property>
-          <property name="accelerated">
+
+        <item row="0" column="0">
+         <widget class="QLabel" name="labelSpeedSliderrange">
+          <property name="enabled">
            <bool>true</bool>
           </property>
-          <property name="suffix">
-           <string>%</string>
+          <property name="font">
+           <font/>
           </property>
-          <property name="decimals">
-           <number>2</number>
+          <property name="text">
+           <string>Slider range</string>
           </property>
-          <property name="minimum">
-           <double>0.010000000000000</double>
+          <property name="wordWrap">
+           <bool>false</bool>
           </property>
-          <property name="maximum">
-           <double>10.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="value">
-           <double>0.500000000000000</double>
+          <property name="buddy">
+           <cstring>ComboBoxRateRange</cstring>
           </property>
          </widget>
         </item>
-        <item row="11" column="1">
-         <widget class="QDoubleSpinBox" name="spinBoxPermanentRateFine">
+        <item row="0" column="1">
+         <widget class="QComboBox" name="ComboBoxRateRange">
+          <property name="font">
+           <font/>
+          </property>
           <property name="toolTip">
-           <string>Permanent rate change when right-clicking</string>
-          </property>
-          <property name="accelerated">
-           <bool>true</bool>
-          </property>
-          <property name="suffix">
-           <string>%</string>
-          </property>
-          <property name="decimals">
-           <number>2</number>
-          </property>
-          <property name="minimum">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>10.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="value">
-           <double>0.050000000000000</double>
+           <string>Adjusts the range of the speed (Vinyl &quot;Pitch&quot;) slider.</string>
           </property>
          </widget>
         </item>
+        <item row="0" column="2">
+         <widget class="QCheckBox" name="checkBoxInvertSpeedSlider">
+          <property name="toolTip">
+           <string>Make the speed sliders work like those on DJ turntables and CDJs where moving downward increases the speed</string>
+          </property>
+          <property name="text">
+           <string>Down increases speed</string>
+          </property>
+         </widget>
+        </item>
+
         <item row="1" column="0">
          <widget class="QLabel" name="labelSpeedPitchReset">
           <property name="text">
@@ -267,6 +260,78 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           <property name="buddy">
            <cstring>checkBoxResetPitch</cstring>
           </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QCheckBox" name="checkBoxResetPitch">
+          <property name="text">
+           <string>Key/Pitch</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QCheckBox" name="checkBoxResetSpeed">
+          <property name="text">
+           <string>Speed/Tempo</string>
+          </property>
+         </widget>
+        </item>
+
+        <item row="2" column="0">
+         <widget class="QLabel" name="labelSyncMode">
+          <property name="text">
+           <string>Sync mode (Dynamic tempo tracks)</string>
+          </property>
+          <property name="openExternalLinks">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QRadioButton" name="radioButtonSoftLeader">
+          <property name="toolTip">
+           <string>Apply tempo changes from a soft-leading track (usually the leaving track in a transition) to the follower tracks. After the transition, the follower track will continue with the previous leader's very last tempo. Changes from explicit selected leaders are always applied.</string>
+          </property>
+          <property name="text">
+           <string>Follow soft leader's tempo</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupSyncMode</string>
+          </attribute>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="QRadioButton" name="radioButtonLockBpm">
+          <property name="toolTip">
+           <string>The tempo of a previous soft leader track at the beginning of the transition is kept steady. After the transition, the follower track will maintain this original tempo. This technique serves as a workaround to avoid dynamic tempo changes, as seen during the outro of rubato-style tracks. For instance, it prevents the follower track from continuing with a slowed-down tempo of the soft leader. This corresponds to the behavior before Mixxx 2.4. Changes from explicit selected leaders are always applied.</string>
+          </property>
+          <property name="text">
+           <string>Use steady tempo</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupSyncMode</string>
+          </attribute>
+         </widget>
+        </item>
+
+        <item row="3" column="0">
+         <widget class="QLabel" name="labelKeylockMode">
+          <property name="text">
+           <string>Keylock mode</string>
+          </property>
+          <property name="buddy">
+           <cstring>radioButtonOriginalKey</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QRadioButton" name="radioButtonOriginalKey">
+          <property name="text">
+           <string>Original key</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupKeyLockMode</string>
+          </attribute>
          </widget>
         </item>
         <item row="3" column="2">
@@ -279,7 +344,191 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </attribute>
          </widget>
         </item>
-        <item row="10" column="1">
+
+        <item row="4" column="0">
+         <widget class="QLabel" name="labelKeyunlockMode">
+          <property name="text">
+           <string>Keyunlock mode</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QRadioButton" name="radioButtonResetUnlockedKey">
+          <property name="text">
+           <string>Reset key</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupKeyUnlockMode</string>
+          </attribute>
+         </widget>
+        </item>
+        <item row="4" column="2">
+         <widget class="QRadioButton" name="radioButtonKeepUnlockedKey">
+          <property name="text">
+           <string>Keep key</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupKeyUnlockMode</string>
+          </attribute>
+         </widget>
+        </item>
+
+        <item row="5" column="0">
+         <spacer name="verticalSpacer1">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>15</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+
+        <item row="6" column="0">
+         <widget class="QLabel" name="labelSpeedBendBehavior">
+          <property name="text">
+           <string>Pitch bend behavior</string>
+          </property>
+          <property name="buddy">
+           <cstring>radioButtonRateRampModeStepping</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="1">
+         <widget class="QRadioButton" name="radioButtonRateRampModeLinear">
+          <property name="toolTip">
+           <string>Smoothly adjusts deck speed when temporary change buttons are held down</string>
+          </property>
+          <property name="text">
+           <string>Smooth ramping</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupSpeedBendBehavior</string>
+          </attribute>
+         </widget>
+        </item>
+        <item row="6" column="2">
+         <widget class="QRadioButton" name="radioButtonRateRampModeStepping">
+          <property name="text">
+           <string>Abrupt jump</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupSpeedBendBehavior</string>
+          </attribute>
+         </widget>
+        </item>
+
+        <item row="7" column="0">
+         <widget class="QLabel" name="labelSpeedRampSensitivity">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Ramping sensitivity</string>
+          </property>
+          <property name="buddy">
+           <cstring>SliderRateRampSensitivity</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="1" colspan="2">
+         <widget class="QSlider" name="SliderRateRampSensitivity">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="minimum">
+           <number>100</number>
+          </property>
+          <property name="maximum">
+           <number>2500</number>
+          </property>
+          <property name="singleStep">
+           <number>50</number>
+          </property>
+          <property name="value">
+           <number>250</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+
+        <item row="8" column="0">
+         <widget class="QLabel" name="labelSpeedAdjustment">
+          <property name="text">
+           <string>Adjustment buttons:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="1">
+         <widget class="QLabel" name="labelSpeedFine">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="font">
+           <font/>
+          </property>
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="text">
+           <string>Fine</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="wordWrap">
+           <bool>false</bool>
+          </property>
+          <property name="buddy">
+           <cstring>spinBoxPermanentRateFine</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="2">
+         <widget class="QLabel" name="labelSpeedCoarse">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="font">
+           <font/>
+          </property>
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="text">
+           <string>Coarse</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="wordWrap">
+           <bool>false</bool>
+          </property>
+          <property name="buddy">
+           <cstring>spinBoxPermanentRateCoarse</cstring>
+          </property>
+         </widget>
+        </item>
+
+        <item row="9" column="0">
+         <widget class="QLabel" name="labelSpeedTemporary">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Temporary</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="1">
          <widget class="QDoubleSpinBox" name="spinBoxTemporaryRateFine">
           <property name="enabled">
            <bool>false</bool>
@@ -310,105 +559,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="11" column="0">
-         <widget class="QLabel" name="labelSpeedPermanent">
-          <property name="text">
-           <string>Permanent</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="1" colspan="2">
-         <widget class="QSlider" name="SliderRateRampSensitivity">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="minimum">
-           <number>100</number>
-          </property>
-          <property name="maximum">
-           <number>2500</number>
-          </property>
-          <property name="singleStep">
-           <number>50</number>
-          </property>
-          <property name="value">
-           <number>250</number>
-          </property>
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-         </widget>
-        </item>
-        <item row="10" column="0">
-         <widget class="QLabel" name="labelSpeedTemporary">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Temporary</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="labelSyncMode">
-          <property name="text">
-           <string>Sync mode (Dynamic tempo tracks)</string>
-          </property>
-          <property name="openExternalLinks">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="labelKeylockMode">
-          <property name="text">
-           <string>Keylock mode</string>
-          </property>
-          <property name="buddy">
-           <cstring>radioButtonOriginalKey</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="labelSpeedRampSensitivity">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Ramping sensitivity</string>
-          </property>
-          <property name="buddy">
-           <cstring>SliderRateRampSensitivity</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="labelSpeedBendBehavior">
-          <property name="text">
-           <string>Pitch bend behavior</string>
-          </property>
-          <property name="buddy">
-           <cstring>radioButtonRateRampModeStepping</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QRadioButton" name="radioButtonOriginalKey">
-          <property name="text">
-           <string>Original key</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">buttonGroupKeyLockMode</string>
-          </attribute>
-         </widget>
-        </item>
-        <item row="10" column="2">
+        <item row="9" column="2">
          <widget class="QDoubleSpinBox" name="spinBoxTemporaryRateCoarse">
           <property name="enabled">
            <bool>false</bool>
@@ -439,210 +590,80 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="2">
-         <widget class="QCheckBox" name="checkBoxResetSpeed">
+
+        <item row="10" column="0">
+         <widget class="QLabel" name="labelSpeedPermanent">
           <property name="text">
-           <string>Speed/Tempo</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QCheckBox" name="checkBoxResetPitch">
-          <property name="text">
-           <string>Key/Pitch</string>
-          </property>
-         </widget>
-        </item>
-        <item row="9" column="0">
-         <widget class="QLabel" name="labelSpeedAdjustment">
-          <property name="text">
-           <string>Adjustment buttons:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QRadioButton" name="radioButtonSoftLeader">
-          <property name="toolTip">
-           <string>Apply tempo changes from a soft-leading track (usually the leaving track in a transition) to the follower tracks. After the transition, the follower track will continue with the previous leader's very last tempo. Changes from explicit selected leaders are always applied.</string>
-          </property>
-          <property name="text">
-           <string>Follow soft leader's tempo</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">buttonGroupSyncMode</string>
-          </attribute>
-         </widget>
-        </item>
-        <item row="9" column="2">
-         <widget class="QLabel" name="labelSpeedCoarse">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="font">
-           <font/>
-          </property>
-          <property name="toolTip">
-           <string/>
-          </property>
-          <property name="text">
-           <string>Coarse</string>
+           <string>Permanent</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignCenter</set>
           </property>
-          <property name="wordWrap">
-           <bool>false</bool>
-          </property>
-          <property name="buddy">
-           <cstring>spinBoxPermanentRateCoarse</cstring>
-          </property>
          </widget>
         </item>
-        <item row="9" column="1">
-         <widget class="QLabel" name="labelSpeedFine">
-          <property name="enabled">
+        <item row="10" column="1">
+         <widget class="QDoubleSpinBox" name="spinBoxPermanentRateFine">
+          <property name="toolTip">
+           <string>Permanent rate change when right-clicking</string>
+          </property>
+          <property name="accelerated">
            <bool>true</bool>
           </property>
-          <property name="font">
-           <font/>
+          <property name="suffix">
+           <string>%</string>
           </property>
-          <property name="toolTip">
-           <string/>
+          <property name="decimals">
+           <number>2</number>
           </property>
-          <property name="text">
-           <string>Fine</string>
+          <property name="minimum">
+           <double>0.010000000000000</double>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
+          <property name="maximum">
+           <double>10.000000000000000</double>
           </property>
-          <property name="wordWrap">
-           <bool>false</bool>
+          <property name="singleStep">
+           <double>0.010000000000000</double>
           </property>
-          <property name="buddy">
-           <cstring>spinBoxPermanentRateFine</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="QCheckBox" name="checkBoxInvertSpeedSlider">
-          <property name="toolTip">
-           <string>Make the speed sliders work like those on DJ turntables and CDJs where moving downward increases the speed</string>
-          </property>
-          <property name="text">
-           <string>Down increases speed</string>
+          <property name="value">
+           <double>0.050000000000000</double>
           </property>
          </widget>
         </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="labelSpeedSliderrange">
-          <property name="enabled">
+        <item row="10" column="2">
+         <widget class="QDoubleSpinBox" name="spinBoxPermanentRateCoarse">
+          <property name="toolTip">
+           <string>Permanent rate change when left-clicking</string>
+          </property>
+          <property name="accelerated">
            <bool>true</bool>
           </property>
-          <property name="font">
-           <font/>
+          <property name="suffix">
+           <string>%</string>
           </property>
-          <property name="text">
-           <string>Slider range</string>
+          <property name="decimals">
+           <number>2</number>
           </property>
-          <property name="wordWrap">
-           <bool>false</bool>
+          <property name="minimum">
+           <double>0.010000000000000</double>
           </property>
-          <property name="buddy">
-           <cstring>ComboBoxRateRange</cstring>
+          <property name="maximum">
+           <double>10.000000000000000</double>
           </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QComboBox" name="ComboBoxRateRange">
-          <property name="font">
-           <font/>
+          <property name="singleStep">
+           <double>0.010000000000000</double>
           </property>
-          <property name="toolTip">
-           <string>Adjusts the range of the speed (Vinyl &quot;Pitch&quot;) slider.</string>
+          <property name="value">
+           <double>0.500000000000000</double>
           </property>
          </widget>
         </item>
-        <item row="6" column="2">
-         <widget class="QRadioButton" name="radioButtonRateRampModeStepping">
-          <property name="text">
-           <string>Abrupt jump</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">buttonGroupSpeedBendBehavior</string>
-          </attribute>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="QRadioButton" name="radioButtonRateRampModeLinear">
-          <property name="toolTip">
-           <string>Smoothly adjusts deck speed when temporary change buttons are held down</string>
-          </property>
-          <property name="text">
-           <string>Smooth ramping</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">buttonGroupSpeedBendBehavior</string>
-          </attribute>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="labelKeyunlockMode">
-          <property name="text">
-           <string>Keyunlock mode</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="QRadioButton" name="radioButtonResetUnlockedKey">
-          <property name="text">
-           <string>Reset key</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">buttonGroupKeyUnlockMode</string>
-          </attribute>
-         </widget>
-        </item>
-        <item row="4" column="2">
-         <widget class="QRadioButton" name="radioButtonKeepUnlockedKey">
-          <property name="text">
-           <string>Keep key</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">buttonGroupKeyUnlockMode</string>
-          </attribute>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QRadioButton" name="radioButtonLockBpm">
-          <property name="toolTip">
-           <string>The tempo of a previous soft leader track at the beginning of the transition is kept steady. After the transition, the follower track will maintain this original tempo. This technique serves as a workaround to avoid dynamic tempo changes, as seen during the outro of rubato-style tracks. For instance, it prevents the follower track from continuing with a slowed-down tempo of the soft leader. This corresponds to the behavior before Mixxx 2.4. Changes from explicit selected leaders are always applied.</string>
-          </property>
-          <property name="text">
-           <string>Use steady tempo</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">buttonGroupSyncMode</string>
-          </attribute>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <spacer name="verticalSpacer1">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>15</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
+
        </layout>
       </item>
      </layout>
     </widget>
    </item>
+
    <item row="2" column="0">
     <spacer name="verticalSpacer2">
      <property name="orientation">
@@ -656,6 +677,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
      </property>
     </spacer>
    </item>
+
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>

--- a/src/preferences/dialog/dlgprefdeckdlg.ui
+++ b/src/preferences/dialog/dlgprefdeckdlg.ui
@@ -199,6 +199,44 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
         </property>
        </widget>
       </item>
+
+      <item row="7" column="0">
+       <widget class="QLabel" name="labelLoopCueActivationMode">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>Loop Cue Activation Mode</string>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+        <property name="buddy">
+         <cstring>radioButtonLoopCueReloop</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1" colspan="2">
+       <widget class="QRadioButton" name="radioButtonLoopCueReloop">
+        <property name="text">
+         <string>Reloop: toggle loop, jump to if loop is behind</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">buttonGroupLoopCueMode</string>
+        </attribute>
+       </widget>
+      </item>
+      <item row="8" column="1" colspan="2">
+       <widget class="QRadioButton" name="radioButtonLoopCueJumpOrToggle">
+        <property name="text">
+         <string>Cue: Always jump to and loop</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">buttonGroupLoopCueMode</string>
+        </attribute>
+       </widget>
+      </item>
+
      </layout>
     </widget>
    </item>
@@ -691,6 +729,8 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
   <tabstop>comboBoxLoadPoint</tabstop>
   <tabstop>comboBoxLoadWhenDeckPlaying</tabstop>
   <tabstop>checkBoxCloneDeckOnLoadDoubleTap</tabstop>
+  <tabstop>radioButtonLoopCueReloop</tabstop>
+  <tabstop>radioButtonLoopCueJumpOrToggle</tabstop>
   <tabstop>ComboBoxRateRange</tabstop>
   <tabstop>checkBoxInvertSpeedSlider</tabstop>
   <tabstop>checkBoxResetPitch</tabstop>
@@ -711,6 +751,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
  <resources/>
  <buttongroups>
   <buttongroup name="buttonGroupTrackTime"/>
+  <buttongroup name="buttonGroupLoopCueMode"/>
   <buttongroup name="buttonGroupKeyUnlockMode"/>
   <buttongroup name="buttonGroupKeyLockMode"/>
   <buttongroup name="buttonGroupSpeedBendBehavior"/>

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -632,9 +632,14 @@ void Tooltips::addStandardTooltips() {
     add("hotcue") << tr("Hotcue")
                   << QString("%1: %2").arg(leftClick,
                              tr("If hotcue is set, jumps to the hotcue."))
+                  << tr("If hotcue is a loop cue, toggles the loop and jumps to "
+                        "if the loop is behind the play position.")
                   << tr("If hotcue is not set, sets the hotcue to the current "
                         "play position.")
                   << quantizeSnap
+                  << tr("If the play position is inside an active loop, "
+                        "stores the loop as loop cue.")
+                  << " " // add linebreak, '\n' would result in two linebreaks
                   << QString("%1: %2").arg(rightClick,
                              tr("Opens a menu to clear hotcues or edit their "
                                 "labels and colors."))

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -632,8 +632,11 @@ void Tooltips::addStandardTooltips() {
     add("hotcue") << tr("Hotcue")
                   << QString("%1: %2").arg(leftClick,
                              tr("If hotcue is set, jumps to the hotcue."))
-                  << tr("If hotcue is a loop cue, toggles the loop and jumps to "
-                        "if the loop is behind the play position.")
+                  << tr("If hotcue is a loop cue, either toggles the loop and "
+                        "jumps to if the loop is behind the play position, "
+                        "or always jumps and activates the loop.")
+                  << tr("Hint: select the loop cue activation mode in "
+                        "Preferences -> Decks.")
                   << tr("If hotcue is not set, sets the hotcue to the current "
                         "play position.")
                   << quantizeSnap

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -642,6 +642,8 @@ void Tooltips::addStandardTooltips() {
                   << quantizeSnap
                   << tr("If the play position is inside an active loop, "
                         "stores the loop as loop cue.")
+                  << QString("%1 + %2: %3").arg(leftClick, shift,
+                             tr("Triggers alternative loop cue activation."))
                   << " " // add linebreak, '\n' would result in two linebreaks
                   << QString("%1: %2").arg(rightClick,
                              tr("Opens a menu to clear hotcues or edit their "

--- a/src/widget/whotcuebutton.cpp
+++ b/src/widget/whotcuebutton.cpp
@@ -92,6 +92,7 @@ void WHotcueButton::setup(const QDomNode& node, const SkinContext& context) {
 
 void WHotcueButton::mousePressEvent(QMouseEvent* e) {
     const bool rightClick = e->button() == Qt::RightButton;
+    const bool leftClick = e->button() == Qt::LeftButton;
     if (rightClick) {
         if (isPressed()) {
             // Discard right clicks when already left clicked.
@@ -125,6 +126,9 @@ void WHotcueButton::mousePressEvent(QMouseEvent* e) {
             // use the bottom left corner as starting point for popup
             m_pCueMenuPopup->popup(mapToGlobal(QPoint(0, height())));
         }
+        return;
+    } else if (leftClick && e->modifiers().testFlag(Qt::ShiftModifier)) {
+        ControlObject::set(createConfigKey(QStringLiteral("activate_secondary")), 1.0);
         return;
     }
 


### PR DESCRIPTION
This PR is supposed to bring the attention to this saved loops UX topic. It was touched in @Holzhaus's orginal PR https://github.com/mixxxdj/mixxx/pull/2194#issuecomment-520975024, and **nPrevail** filed #10688 

new Decks preferences option:
Loop Cue Activation Mode, sets `[Controls], loop_cue_activation_mode`, either
1. Activate loop, jump to if loop is behind, or
2. Jump to and loop, toggle if inside loop range