### PR TITLE
BPM: allow to round / snap decimals

### DIFF
--- a/src/engine/controls/ratecontrol.h
+++ b/src/engine/controls/ratecontrol.h
@@ -128,6 +128,9 @@ private:
   ControlObject* m_pBackButton;
   ControlObject* m_pForwardButton;
 
+  std::unique_ptr<ControlPushButton> m_pBpmSnapEnabled;
+  std::unique_ptr<ControlPushButton> m_pBpmSnapDecimals;
+
   ControlTTRotary* m_pWheel;
   ControlObject* m_pScratch2;
   PositionScratchController* m_pScratchController;

--- a/src/preferences/dialog/dlgprefdeck.h
+++ b/src/preferences/dialog/dlgprefdeck.h
@@ -109,6 +109,8 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
     QList<ControlProxy*> m_rateControls;
     QList<ControlProxy*> m_rateDirectionControls;
     QList<ControlProxy*> m_rateRangeControls;
+    QList<ControlProxy*> m_bpmSnapEnabledControls;
+    QList<ControlProxy*> m_bpmSnapDecimalsControls;
     QList<ControlProxy*> m_keylockModeControls;
     QList<ControlProxy*> m_keyunlockModeControls;
 

--- a/src/preferences/dialog/dlgprefdeckdlg.ui
+++ b/src/preferences/dialog/dlgprefdeckdlg.ui
@@ -258,6 +258,46 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
         </item>
 
         <item row="1" column="0">
+         <widget class="QCheckBox" name="checkBoxSnapBpm">
+          <property name="toolTip">
+           <string>Simplify manual BPM matching, especially with short, high-res pitch sliders on MIDI/HID controllers</string>
+          </property>
+          <property name="text">
+           <string>Snap BPM</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLabel" name="labelBpmSnapDecimals">
+          <property name="text">
+           <string>Decimals:</string>
+          </property>
+          <property name="buddy">
+           <cstring>spinBoxSnapBpmDecimals</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QSpinBox" name="spinBoxSnapBpmDecimals">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>2</number>
+          </property>
+          <property name="singleStep">
+           <number>1</number>
+          </property>
+          <property name="value">
+           <number>1</number>
+          </property>
+         </widget>
+        </item>
+
+        <item row="2" column="0">
          <widget class="QLabel" name="labelSpeedPitchReset">
           <property name="text">
            <string>Reset on track load</string>
@@ -267,14 +307,14 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
+        <item row="2" column="1">
          <widget class="QCheckBox" name="checkBoxResetPitch">
           <property name="text">
            <string>Key/Pitch</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="2">
+        <item row="2" column="2">
          <widget class="QCheckBox" name="checkBoxResetSpeed">
           <property name="text">
            <string>Speed/Tempo</string>
@@ -282,7 +322,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
          </widget>
         </item>
 
-        <item row="2" column="0">
+        <item row="3" column="0">
          <widget class="QLabel" name="labelKeylockMode">
           <property name="text">
            <string>Keylock mode</string>
@@ -292,7 +332,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
+        <item row="3" column="1">
          <widget class="QRadioButton" name="radioButtonOriginalKey">
           <property name="text">
            <string>Original key</string>
@@ -302,7 +342,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </attribute>
          </widget>
         </item>
-        <item row="2" column="2">
+        <item row="3" column="2">
          <widget class="QRadioButton" name="radioButtonCurrentKey">
           <property name="text">
            <string>Current key</string>
@@ -313,14 +353,14 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
          </widget>
         </item>
 
-        <item row="3" column="0">
+        <item row="4" column="0">
          <widget class="QLabel" name="labelKeyunlockMode">
           <property name="text">
            <string>Keyunlock mode</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
+        <item row="4" column="1">
          <widget class="QRadioButton" name="radioButtonResetUnlockedKey">
           <property name="text">
            <string>Reset key</string>
@@ -330,7 +370,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </attribute>
          </widget>
         </item>
-        <item row="3" column="2">
+        <item row="4" column="2">
          <widget class="QRadioButton" name="radioButtonKeepUnlockedKey">
           <property name="text">
            <string>Keep key</string>
@@ -341,7 +381,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
          </widget>
         </item>
 
-        <item row="4" column="0">
+        <item row="5" column="0">
          <spacer name="verticalSpacer1">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
@@ -355,7 +395,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
          </spacer>
         </item>
 
-        <item row="5" column="0">
+        <item row="6" column="0">
          <widget class="QLabel" name="labelSpeedBendBehavior">
           <property name="text">
            <string>Pitch bend behavior</string>
@@ -365,7 +405,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="5" column="1">
+        <item row="6" column="1">
          <widget class="QRadioButton" name="radioButtonRateRampModeLinear">
           <property name="toolTip">
            <string>Smoothly adjusts deck speed when temporary change buttons are held down</string>
@@ -378,7 +418,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </attribute>
          </widget>
         </item>
-        <item row="5" column="2">
+        <item row="6" column="2">
          <widget class="QRadioButton" name="radioButtonRateRampModeStepping">
           <property name="text">
            <string>Abrupt jump</string>
@@ -389,7 +429,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
          </widget>
         </item>
 
-        <item row="6" column="0">
+        <item row="7" column="0">
          <widget class="QLabel" name="labelSpeedRampSensitivity">
           <property name="enabled">
            <bool>false</bool>
@@ -402,8 +442,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-
-        <item row="6" column="1" colspan="2">
+        <item row="7" column="1" colspan="2">
          <layout class="QHBoxLayout" name="horizontalLayout_3">
           <item>
            <widget class="QSlider" name="SliderRateRampSensitivity">
@@ -452,14 +491,14 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
          </layout>
         </item>
 
-        <item row="7" column="0">
+        <item row="8" column="0">
          <widget class="QLabel" name="labelSpeedAdjustment">
           <property name="text">
            <string>Adjustment buttons:</string>
           </property>
          </widget>
         </item>
-        <item row="7" column="1">
+        <item row="8" column="1">
          <widget class="QLabel" name="labelSpeedFine">
           <property name="enabled">
            <bool>true</bool>
@@ -484,7 +523,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="7" column="2">
+        <item row="8" column="2">
          <widget class="QLabel" name="labelSpeedCoarse">
           <property name="enabled">
            <bool>true</bool>
@@ -510,7 +549,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
          </widget>
         </item>
 
-        <item row="8" column="0">
+        <item row="9" column="0">
          <widget class="QLabel" name="labelSpeedTemporary">
           <property name="enabled">
            <bool>false</bool>
@@ -523,7 +562,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="8" column="1">
+        <item row="9" column="1">
          <widget class="QDoubleSpinBox" name="spinBoxTemporaryRateFine">
           <property name="enabled">
            <bool>false</bool>
@@ -554,7 +593,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="8" column="2">
+        <item row="9" column="2">
          <widget class="QDoubleSpinBox" name="spinBoxTemporaryRateCoarse">
           <property name="enabled">
            <bool>false</bool>
@@ -586,7 +625,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
          </widget>
         </item>
 
-        <item row="9" column="0">
+        <item row="10" column="0">
          <widget class="QLabel" name="labelSpeedPermanent">
           <property name="text">
            <string>Permanent</string>
@@ -596,7 +635,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="9" column="1">
+        <item row="10" column="1">
          <widget class="QDoubleSpinBox" name="spinBoxPermanentRateFine">
           <property name="toolTip">
            <string>Permanent rate change when right-clicking</string>
@@ -624,7 +663,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="9" column="2">
+        <item row="10" column="2">
          <widget class="QDoubleSpinBox" name="spinBoxPermanentRateCoarse">
           <property name="toolTip">
            <string>Permanent rate change when left-clicking</string>
@@ -688,6 +727,8 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
   <tabstop>checkBoxCloneDeckOnLoadDoubleTap</tabstop>
   <tabstop>ComboBoxRateRange</tabstop>
   <tabstop>checkBoxInvertSpeedSlider</tabstop>
+  <tabstop>checkBoxSnapBpm</tabstop>
+  <tabstop>spinBoxSnapBpmDecimals</tabstop>
   <tabstop>checkBoxResetPitch</tabstop>
   <tabstop>checkBoxResetSpeed</tabstop>
   <tabstop>radioButtonOriginalKey</tabstop>

--- a/src/preferences/dialog/dlgprefdeckdlg.ui
+++ b/src/preferences/dialog/dlgprefdeckdlg.ui
@@ -14,6 +14,7 @@
    <string>Deck Preferences</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
+
    <item row="0" column="0">
     <widget class="QGroupBox" name="groupBoxDeckOptions">
      <property name="title">
@@ -23,16 +24,7 @@
       <property name="spacing">
        <number>10</number>
       </property>
-      <item row="5" column="0">
-       <widget class="QLabel" name="labelPlayingTrackProtection">
-        <property name="text">
-         <string>Playing track protection</string>
-        </property>
-        <property name="buddy">
-         <cstring>checkBoxDisallowLoadToPlayingDeck</cstring>
-        </property>
-       </widget>
-      </item>
+
       <item row="0" column="0">
        <widget class="QLabel" name="labelCueMode">
         <property name="text">
@@ -40,33 +32,6 @@
         </property>
         <property name="openExternalLinks">
          <bool>true</bool>
-        </property>
-        <property name="buddy">
-         <cstring>ComboBoxCueMode</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1" colspan="2">
-       <widget class="QComboBox" name="comboBoxLoadPoint"/>
-      </item>
-      <item row="1" column="1" colspan="2">
-       <widget class="QCheckBox" name="checkBoxIntroStartMove">
-        <property name="toolTip">
-         <string>When the analyzer places the intro start point automatically,
-it will place it at the main cue point if the main cue point has been set previously.
-This may be helpful for upgrading to Mixxx 2.3 from earlier versions.
-
-If this option is disabled, the intro start point is automatically placed at the first sound.</string>
-        </property>
-        <property name="text">
-         <string>Set intro start to main cue when analyzing tracks</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="labelIntroStartMove">
-        <property name="text">
-         <string>Intro start</string>
         </property>
         <property name="buddy">
          <cstring>ComboBoxCueMode</cstring>
@@ -98,33 +63,32 @@ CUP mode:
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="labelCloneDeckOnLoadDoubleTap">
+
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelIntroStartMove">
         <property name="text">
-         <string>Clone deck</string>
+         <string>Intro start</string>
         </property>
         <property name="buddy">
-         <cstring>checkBoxCloneDeckOnLoadDoubleTap</cstring>
+         <cstring>ComboBoxCueMode</cstring>
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="labelTimeDisplay">
+      <item row="1" column="1" colspan="2">
+       <widget class="QCheckBox" name="checkBoxIntroStartMove">
+        <property name="toolTip">
+         <string>When the analyzer places the intro start point automatically,
+it will place it at the main cue point if the main cue point has been set previously.
+This may be helpful for upgrading to Mixxx 2.3 from earlier versions.
+
+If this option is disabled, the intro start point is automatically placed at the first sound.</string>
+        </property>
         <property name="text">
-         <string>Time Format</string>
+         <string>Set intro start to main cue when analyzing tracks</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
-       <widget class="QComboBox" name="comboBoxTimeFormat"/>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="labelLoadPoint">
-        <property name="text">
-         <string>Track load point</string>
-        </property>
-       </widget>
-      </item>
+
       <item row="2" column="0">
        <widget class="QLabel" name="labelPositionDisplay">
         <property name="enabled">
@@ -144,15 +108,8 @@ CUP mode:
         </property>
        </widget>
       </item>
-      <item row="5" column="1" colspan="2">
-       <widget class="QCheckBox" name="checkBoxDisallowLoadToPlayingDeck">
-        <property name="text">
-         <string>Do not load tracks into playing decks</string>
-        </property>
-       </widget>
-      </item>
       <item row="2" column="1" colspan="2">
-       <layout class="QHBoxLayout" name="horizontalLayout">
+       <layout class="QHBoxLayout" name="horizontalLayout_1">
         <item>
          <widget class="QRadioButton" name="radioButtonElapsed">
           <property name="text">
@@ -185,6 +142,57 @@ CUP mode:
         </item>
        </layout>
       </item>
+
+      <item row="3" column="0">
+       <widget class="QLabel" name="labelTimeDisplay">
+        <property name="text">
+         <string>Time Format</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QComboBox" name="comboBoxTimeFormat"/>
+      </item>
+
+      <item row="4" column="0">
+       <widget class="QLabel" name="labelLoadPoint">
+        <property name="text">
+         <string>Track load point</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1" colspan="2">
+       <widget class="QComboBox" name="comboBoxLoadPoint"/>
+      </item>
+
+      <item row="5" column="0">
+       <widget class="QLabel" name="labelPlayingTrackProtection">
+        <property name="text">
+         <string>Playing track protection</string>
+        </property>
+        <property name="buddy">
+         <cstring>checkBoxDisallowLoadToPlayingDeck</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1" colspan="2">
+       <widget class="QCheckBox" name="checkBoxDisallowLoadToPlayingDeck">
+        <property name="text">
+         <string>Do not load tracks into playing decks</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="6" column="0">
+       <widget class="QLabel" name="labelCloneDeckOnLoadDoubleTap">
+        <property name="text">
+         <string>Clone deck</string>
+        </property>
+        <property name="buddy">
+         <cstring>checkBoxCloneDeckOnLoadDoubleTap</cstring>
+        </property>
+       </widget>
+      </item>
       <item row="6" column="1" colspan="2">
        <widget class="QCheckBox" name="checkBoxCloneDeckOnLoadDoubleTap">
         <property name="toolTip">
@@ -199,6 +207,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
      </layout>
     </widget>
    </item>
+
    <item row="1" column="0">
     <widget class="QGroupBox" name="groupBoxSpeedPitchOptions">
      <property name="title">
@@ -207,62 +216,47 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
      <layout class="QGridLayout" name="gridLayout_7">
       <item row="0" column="0">
        <layout class="QGridLayout" name="GridLayoutSpeedOptions">
-        <item row="9" column="2">
-         <widget class="QDoubleSpinBox" name="spinBoxPermanentRateCoarse">
-          <property name="toolTip">
-           <string>Permanent rate change when left-clicking</string>
-          </property>
-          <property name="accelerated">
+
+        <item row="0" column="0">
+         <widget class="QLabel" name="labelSpeedSliderrange">
+          <property name="enabled">
            <bool>true</bool>
           </property>
-          <property name="suffix">
-           <string>%</string>
+          <property name="font">
+           <font/>
           </property>
-          <property name="decimals">
-           <number>2</number>
+          <property name="text">
+           <string>Slider range</string>
           </property>
-          <property name="minimum">
-           <double>0.010000000000000</double>
+          <property name="wordWrap">
+           <bool>false</bool>
           </property>
-          <property name="maximum">
-           <double>10.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="value">
-           <double>0.500000000000000</double>
+          <property name="buddy">
+           <cstring>ComboBoxRateRange</cstring>
           </property>
          </widget>
         </item>
-        <item row="9" column="1">
-         <widget class="QDoubleSpinBox" name="spinBoxPermanentRateFine">
+        <item row="0" column="1">
+         <widget class="QComboBox" name="ComboBoxRateRange">
+          <property name="font">
+           <font/>
+          </property>
           <property name="toolTip">
-           <string>Permanent rate change when right-clicking</string>
-          </property>
-          <property name="accelerated">
-           <bool>true</bool>
-          </property>
-          <property name="suffix">
-           <string>%</string>
-          </property>
-          <property name="decimals">
-           <number>2</number>
-          </property>
-          <property name="minimum">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>10.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="value">
-           <double>0.050000000000000</double>
+           <string>Adjusts the range of the speed (Vinyl &quot;Pitch&quot;) slider.</string>
           </property>
          </widget>
         </item>
+        <item row="0" column="2">
+         <widget class="QCheckBox" name="checkBoxInvertSpeedSlider">
+          <property name="toolTip">
+           <string>Make the speed sliders work like those on DJ turntables and CDJs where moving downward increases the speed</string>
+          </property>
+          <property name="text">
+           <string>Down increases speed</string>
+          </property>
+         </widget>
+        </item>
+
         <item row="1" column="0">
          <widget class="QLabel" name="labelSpeedPitchReset">
           <property name="text">
@@ -271,6 +265,41 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           <property name="buddy">
            <cstring>checkBoxResetPitch</cstring>
           </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QCheckBox" name="checkBoxResetPitch">
+          <property name="text">
+           <string>Key/Pitch</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QCheckBox" name="checkBoxResetSpeed">
+          <property name="text">
+           <string>Speed/Tempo</string>
+          </property>
+         </widget>
+        </item>
+
+        <item row="2" column="0">
+         <widget class="QLabel" name="labelKeylockMode">
+          <property name="text">
+           <string>Keylock mode</string>
+          </property>
+          <property name="buddy">
+           <cstring>radioButtonOriginalKey</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QRadioButton" name="radioButtonOriginalKey">
+          <property name="text">
+           <string>Original key</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupKeyLockMode</string>
+          </attribute>
          </widget>
         </item>
         <item row="2" column="2">
@@ -283,49 +312,99 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </attribute>
          </widget>
         </item>
-        <item row="8" column="1">
-         <widget class="QDoubleSpinBox" name="spinBoxTemporaryRateFine">
+
+        <item row="3" column="0">
+         <widget class="QLabel" name="labelKeyunlockMode">
+          <property name="text">
+           <string>Keyunlock mode</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QRadioButton" name="radioButtonResetUnlockedKey">
+          <property name="text">
+           <string>Reset key</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupKeyUnlockMode</string>
+          </attribute>
+         </widget>
+        </item>
+        <item row="3" column="2">
+         <widget class="QRadioButton" name="radioButtonKeepUnlockedKey">
+          <property name="text">
+           <string>Keep key</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupKeyUnlockMode</string>
+          </attribute>
+         </widget>
+        </item>
+
+        <item row="4" column="0">
+         <spacer name="verticalSpacer1">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>15</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+
+        <item row="5" column="0">
+         <widget class="QLabel" name="labelSpeedBendBehavior">
+          <property name="text">
+           <string>Pitch bend behavior</string>
+          </property>
+          <property name="buddy">
+           <cstring>radioButtonRateRampModeStepping</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QRadioButton" name="radioButtonRateRampModeLinear">
+          <property name="toolTip">
+           <string>Smoothly adjusts deck speed when temporary change buttons are held down</string>
+          </property>
+          <property name="text">
+           <string>Smooth ramping</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupSpeedBendBehavior</string>
+          </attribute>
+         </widget>
+        </item>
+        <item row="5" column="2">
+         <widget class="QRadioButton" name="radioButtonRateRampModeStepping">
+          <property name="text">
+           <string>Abrupt jump</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupSpeedBendBehavior</string>
+          </attribute>
+         </widget>
+        </item>
+
+        <item row="6" column="0">
+         <widget class="QLabel" name="labelSpeedRampSensitivity">
           <property name="enabled">
            <bool>false</bool>
           </property>
-          <property name="toolTip">
-           <string>Temporary rate change when right-clicking</string>
-          </property>
-          <property name="accelerated">
-           <bool>true</bool>
-          </property>
-          <property name="suffix">
-           <string>%</string>
-          </property>
-          <property name="decimals">
-           <number>2</number>
-          </property>
-          <property name="minimum">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>10.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="value">
-           <double>1.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item row="9" column="0">
-         <widget class="QLabel" name="labelSpeedPermanent">
           <property name="text">
-           <string>Permanent</string>
+           <string>Ramping sensitivity</string>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
+          <property name="buddy">
+           <cstring>SliderRateRampSensitivity</cstring>
           </property>
          </widget>
         </item>
+
         <item row="6" column="1" colspan="2">
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
           <item>
            <widget class="QSlider" name="SliderRateRampSensitivity">
             <property name="enabled">
@@ -372,6 +451,65 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </item>
          </layout>
         </item>
+
+        <item row="7" column="0">
+         <widget class="QLabel" name="labelSpeedAdjustment">
+          <property name="text">
+           <string>Adjustment buttons:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="1">
+         <widget class="QLabel" name="labelSpeedFine">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="font">
+           <font/>
+          </property>
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="text">
+           <string>Fine</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="wordWrap">
+           <bool>false</bool>
+          </property>
+          <property name="buddy">
+           <cstring>spinBoxPermanentRateFine</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="2">
+         <widget class="QLabel" name="labelSpeedCoarse">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="font">
+           <font/>
+          </property>
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="text">
+           <string>Coarse</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="wordWrap">
+           <bool>false</bool>
+          </property>
+          <property name="buddy">
+           <cstring>spinBoxPermanentRateCoarse</cstring>
+          </property>
+         </widget>
+        </item>
+
         <item row="8" column="0">
          <widget class="QLabel" name="labelSpeedTemporary">
           <property name="enabled">
@@ -385,47 +523,35 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="labelKeylockMode">
-          <property name="text">
-           <string>Keylock mode</string>
-          </property>
-          <property name="buddy">
-           <cstring>radioButtonOriginalKey</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="labelSpeedRampSensitivity">
+        <item row="8" column="1">
+         <widget class="QDoubleSpinBox" name="spinBoxTemporaryRateFine">
           <property name="enabled">
            <bool>false</bool>
           </property>
-          <property name="text">
-           <string>Ramping sensitivity</string>
+          <property name="toolTip">
+           <string>Temporary rate change when right-clicking</string>
           </property>
-          <property name="buddy">
-           <cstring>SliderRateRampSensitivity</cstring>
+          <property name="accelerated">
+           <bool>true</bool>
           </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="labelSpeedBendBehavior">
-          <property name="text">
-           <string>Pitch bend behavior</string>
+          <property name="suffix">
+           <string>%</string>
           </property>
-          <property name="buddy">
-           <cstring>radioButtonRateRampModeStepping</cstring>
+          <property name="decimals">
+           <number>2</number>
           </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QRadioButton" name="radioButtonOriginalKey">
-          <property name="text">
-           <string>Original key</string>
+          <property name="minimum">
+           <double>0.010000000000000</double>
           </property>
-          <attribute name="buttonGroup">
-           <string notr="true">buttonGroupKeyLockMode</string>
-          </attribute>
+          <property name="maximum">
+           <double>10.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.010000000000000</double>
+          </property>
+          <property name="value">
+           <double>1.000000000000000</double>
+          </property>
          </widget>
         </item>
         <item row="8" column="2">
@@ -459,184 +585,80 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="2">
-         <widget class="QCheckBox" name="checkBoxResetSpeed">
+
+        <item row="9" column="0">
+         <widget class="QLabel" name="labelSpeedPermanent">
           <property name="text">
-           <string>Speed/Tempo</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QCheckBox" name="checkBoxResetPitch">
-          <property name="text">
-           <string>Key/Pitch</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="labelSpeedAdjustment">
-          <property name="text">
-           <string>Adjustment buttons:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="2">
-         <widget class="QLabel" name="labelSpeedCoarse">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="font">
-           <font/>
-          </property>
-          <property name="toolTip">
-           <string/>
-          </property>
-          <property name="text">
-           <string>Coarse</string>
+           <string>Permanent</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignCenter</set>
           </property>
-          <property name="wordWrap">
-           <bool>false</bool>
-          </property>
-          <property name="buddy">
-           <cstring>spinBoxPermanentRateCoarse</cstring>
-          </property>
          </widget>
         </item>
-        <item row="7" column="1">
-         <widget class="QLabel" name="labelSpeedFine">
-          <property name="enabled">
+        <item row="9" column="1">
+         <widget class="QDoubleSpinBox" name="spinBoxPermanentRateFine">
+          <property name="toolTip">
+           <string>Permanent rate change when right-clicking</string>
+          </property>
+          <property name="accelerated">
            <bool>true</bool>
           </property>
-          <property name="font">
-           <font/>
+          <property name="suffix">
+           <string>%</string>
           </property>
-          <property name="toolTip">
-           <string/>
+          <property name="decimals">
+           <number>2</number>
           </property>
-          <property name="text">
-           <string>Fine</string>
+          <property name="minimum">
+           <double>0.010000000000000</double>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
+          <property name="maximum">
+           <double>10.000000000000000</double>
           </property>
-          <property name="wordWrap">
-           <bool>false</bool>
+          <property name="singleStep">
+           <double>0.010000000000000</double>
           </property>
-          <property name="buddy">
-           <cstring>spinBoxPermanentRateFine</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="QCheckBox" name="checkBoxInvertSpeedSlider">
-          <property name="toolTip">
-           <string>Make the speed sliders work like those on DJ turntables and CDJs where moving downward increases the speed</string>
-          </property>
-          <property name="text">
-           <string>Down increases speed</string>
+          <property name="value">
+           <double>0.050000000000000</double>
           </property>
          </widget>
         </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="labelSpeedSliderrange">
-          <property name="enabled">
+        <item row="9" column="2">
+         <widget class="QDoubleSpinBox" name="spinBoxPermanentRateCoarse">
+          <property name="toolTip">
+           <string>Permanent rate change when left-clicking</string>
+          </property>
+          <property name="accelerated">
            <bool>true</bool>
           </property>
-          <property name="font">
-           <font/>
+          <property name="suffix">
+           <string>%</string>
           </property>
-          <property name="text">
-           <string>Slider range</string>
+          <property name="decimals">
+           <number>2</number>
           </property>
-          <property name="wordWrap">
-           <bool>false</bool>
+          <property name="minimum">
+           <double>0.010000000000000</double>
           </property>
-          <property name="buddy">
-           <cstring>ComboBoxRateRange</cstring>
+          <property name="maximum">
+           <double>10.000000000000000</double>
           </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QComboBox" name="ComboBoxRateRange">
-          <property name="font">
-           <font/>
+          <property name="singleStep">
+           <double>0.010000000000000</double>
           </property>
-          <property name="toolTip">
-           <string>Adjusts the range of the speed (Vinyl &quot;Pitch&quot;) slider.</string>
+          <property name="value">
+           <double>0.500000000000000</double>
           </property>
          </widget>
         </item>
-        <item row="5" column="2">
-         <widget class="QRadioButton" name="radioButtonRateRampModeStepping">
-          <property name="text">
-           <string>Abrupt jump</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">buttonGroupSpeedBendBehavior</string>
-          </attribute>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="QRadioButton" name="radioButtonRateRampModeLinear">
-          <property name="toolTip">
-           <string>Smoothly adjusts deck speed when temporary change buttons are held down</string>
-          </property>
-          <property name="text">
-           <string>Smooth ramping</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">buttonGroupSpeedBendBehavior</string>
-          </attribute>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="labelKeyunlockMode">
-          <property name="text">
-           <string>Keyunlock mode</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QRadioButton" name="radioButtonResetUnlockedKey">
-          <property name="text">
-           <string>Reset key</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">buttonGroupKeyUnlockMode</string>
-          </attribute>
-         </widget>
-        </item>
-        <item row="3" column="2">
-         <widget class="QRadioButton" name="radioButtonKeepUnlockedKey">
-          <property name="text">
-           <string>Keep key</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">buttonGroupKeyUnlockMode</string>
-          </attribute>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <spacer name="verticalSpacer1">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>15</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
+
        </layout>
       </item>
      </layout>
     </widget>
    </item>
+
    <item row="2" column="0">
     <spacer name="verticalSpacer2">
      <property name="orientation">
@@ -650,6 +672,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
      </property>
     </spacer>
    </item>
+
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>


### PR DESCRIPTION
This should simplify BPM matching with short, high-res pitch faders on controllers.
Snap/round to
* integers
* nnn.N
* nnn.nN

BPM is snapped only if the pitch fader is off center to avoid unintended and unnecessary pitch shift.

![image](https://user-images.githubusercontent.com/5934199/175838199-706d1ee4-9136-4564-a073-8523b53dde99.png)

requested here https://mixxx.discourse.group/t/pitch-fader-sensitivity-round-value-to-1/25140
https://bugs.launchpad.net/mixxx/+bug/1979822
One of the features for which I did quick and dirty test, which turned out to be rather easy to implement*.

What do you think?

*In case there are regressions with the sync engine / too much complications there or elsewhere I overlooked, the alternative would be a helper function in `common-controller-scripts.js`
