### PR TITLE
Shade: fix library sidebar splitter glitch

### DIFF
--- a/res/skins/Shade/library.xml
+++ b/res/skins/Shade/library.xml
@@ -16,6 +16,11 @@
             <Children>
               <!-- Sidebar etc. -->
               <WidgetGroup>
+                <!-- Required for restoring the splitter sizes, otherwise the searchbox
+                    would force.expand the left side.
+                    Also required to avoid resize (shrink) glitch with long titles loaded
+                    to the preview deck. -->
+                <SizePolicy>i,min</SizePolicy>
                 <Layout>vertical</Layout>
                 <Children>
                   <Template src="skin:preview_deck.xml"/>


### PR DESCRIPTION
backport of #4808.
https://bugs.launchpad.net/mixxx/+bug/1979823
in main it fixed the split size persistence,
in 2.3 it fixes a resizing issue with long titles loaded to the preview deck

