### PR TITLE
restore 'Reset EQs on track load'

### DIFF
--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -36,6 +36,7 @@ class BaseTrackPlayer : public BasePlayer {
     ~BaseTrackPlayer() override = default;
 
     virtual TrackPointer getLoadedTrack() const = 0;
+    virtual void setupEqControls() = 0;
 
   public slots:
     virtual void slotLoadTrack(TrackPointer pTrack, bool bPlay = false) = 0;
@@ -71,7 +72,7 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     // connected. Delete me when EngineMaster supports AudioInput assigning.
     EngineDeck* getEngineDeck() const;
 
-    void setupEqControls();
+    void setupEqControls() final;
 
     // For testing, loads a fake track.
     TrackPointer loadFakeTrack(bool bPlay, double filebpm);

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -437,6 +437,9 @@ void PlayerManager::addDeckInner() {
 
     // Setup equalizer and QuickEffect chain for this deck.
     m_pEffectsManager->addDeck(handleGroup.m_name);
+
+    // Setup EQ ControlProxies used for resetting EQs on track load
+    pDeck->setupEqControls();
 }
 
 void PlayerManager::loadSamplers() {

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -83,6 +83,8 @@ class FakeDeck : public BaseTrackPlayer {
         return loadedTrack;
     }
 
+    void setupEqControls() override{};
+
     // This method emulates requesting a track load to a player and emits no
     // signals. Normally, the reader thread attempts to load the file and emits
     // a success or failure signal. To simulate a load success, call


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1980078

was removed in #2618/#4467 while factoring out the EQ rack setup