### PR TITLE
controllers: fix Numark DJ2GO2 Touch sliders and knobs

### DIFF
--- a/res/controllers/Numark_DJ2GO2_Touch.midi.xml
+++ b/res/controllers/Numark_DJ2GO2_Touch.midi.xml
@@ -313,16 +313,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DJ2GO2Touch.leftDeck.tempoFader.inputMSB</key>
-        <status>0xB0</status>
-        <midino>0x09</midino>
-        <options>
-          <script-binding/>
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>DJ2GO2Touch.leftDeck.tempoFader.inputLSB</key>
+        <key>DJ2GO2Touch.leftDeck.tempoFader.input</key>
         <status>0xB0</status>
         <midino>0x09</midino>
         <options>
@@ -664,16 +655,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DJ2GO2Touch.rightDeck.tempoFader.inputMSB</key>
-        <status>0xB1</status>
-        <midino>0x09</midino>
-        <options>
-          <script-binding/>
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>DJ2GO2Touch.rightDeck.tempoFader.inputLSB</key>
+        <key>DJ2GO2Touch.rightDeck.tempoFader.input</key>
         <status>0xB1</status>
         <midino>0x09</midino>
         <options>
@@ -757,7 +739,7 @@
       </control>
       <control>
         <group>[Master]</group>
-        <key>DJ2GO2Touch.crossfader.inputMSB</key>
+        <key>DJ2GO2Touch.crossfader.input</key>
         <status>0xBF</status>
         <midino>0x08</midino>
         <options>
@@ -766,16 +748,7 @@
       </control>
       <control>
         <group>[Master]</group>
-        <key>DJ2GO2Touch.crossfader.inputLSB</key>
-        <status>0xBF</status>
-        <midino>0x08</midino>
-        <options>
-          <script-binding/>
-        </options>
-      </control>
-      <control>
-        <group>[Master]</group>
-        <key>DJ2GO2Touch.masterGain.inputMSB</key>
+        <key>DJ2GO2Touch.masterGain.input</key>
         <status>0xBF</status>
         <midino>0x0A</midino>
         <options>
@@ -784,25 +757,7 @@
       </control>
       <control>
         <group>[Master]</group>
-        <key>DJ2GO2Touch.masterGain.inputLSB</key>
-        <status>0xBF</status>
-        <midino>0x0A</midino>
-        <options>
-          <script-binding/>
-        </options>
-      </control>
-      <control>
-        <group>[Master]</group>
-        <key>DJ2GO2Touch.cueGain.inputMSB</key>
-        <status>0xBF</status>
-        <midino>0x0C</midino>
-        <options>
-          <script-binding/>
-        </options>
-      </control>
-      <control>
-        <group>[Master]</group>
-        <key>DJ2GO2Touch.cueGain.inputLSB</key>
+        <key>DJ2GO2Touch.cueGain.input</key>
         <status>0xBF</status>
         <midino>0x0C</midino>
         <options>

--- a/res/controllers/Numark_DJ2GO2_Touch_scripts.js
+++ b/res/controllers/Numark_DJ2GO2_Touch_scripts.js
@@ -91,7 +91,7 @@ DJ2GO2Touch.Deck = function(deckNumbers, midiChannel) {
         key: "super1"
     });
 
-    engine.setValue(this.currentDeck, "rate_dir", -1);
+    engine.setValue(this.currentDeck, "rate_dir", 1);
     this.tempoFader = new components.Pot({
         group: "[Channel" + script.deckFromGroup(this.currentDeck) + "]",
         midi: [0xB0 + midiChannel, 0x09],

--- a/res/controllers/Numark_DJ2GO2_Touch_scripts.js
+++ b/res/controllers/Numark_DJ2GO2_Touch_scripts.js
@@ -91,7 +91,6 @@ DJ2GO2Touch.Deck = function(deckNumbers, midiChannel) {
         key: "super1"
     });
 
-    engine.setValue(this.currentDeck, "rate_dir", 1);
     this.tempoFader = new components.Pot({
         group: "[Channel" + script.deckFromGroup(this.currentDeck) + "]",
         midi: [0xB0 + midiChannel, 0x09],


### PR DESCRIPTION
Fix input for sliders and knobs to use single byte value, since all
are on single CC status message.

Fix direction of tempo sliders.

Resolves: [lp1948596](https://bugs.launchpad.net/mixxx/+bug/1948596)