### PR TITLE
WFindOnWebMenu: Implementing the factory pattern

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -965,6 +965,10 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/waveform/waveform.cpp
   src/waveform/waveformfactory.cpp
   src/widget/controlwidgetconnection.cpp
+  src/widget/findonwebmenufactory.cpp
+  src/widget/findonwebmenuservices/findonwebmenudiscogs.cpp
+  src/widget/findonwebmenuservices/findonwebmenulastfm.cpp
+  src/widget/findonwebmenuservices/findonwebmenusoundcloud.cpp
   src/widget/hexspinbox.cpp
   src/widget/paintable.cpp
   src/widget/wanalysislibrarytableview.cpp

--- a/src/widget/findonwebmenufactory.cpp
+++ b/src/widget/findonwebmenufactory.cpp
@@ -1,0 +1,26 @@
+#include "findonwebmenufactory.h"
+
+#include <QMenu>
+
+#include "findonwebmenuservices/findonwebmenudiscogs.h"
+#include "findonwebmenuservices/findonwebmenulastfm.h"
+#include "findonwebmenuservices/findonwebmenusoundcloud.h"
+
+namespace mixxx {
+
+namespace library {
+
+void createFindOnWebSubmenus(QMenu* pFindOnWebMenu, const Track& track) {
+    auto pFindOnWebMenuSoundcloud = make_parented<QMenu>(
+            new FindOnWebMenuSoundcloud(pFindOnWebMenu, track));
+
+    auto pFindOnWebMenuDiscogs = make_parented<QMenu>(
+            new FindOnWebMenuDiscogs(pFindOnWebMenu, track));
+
+    auto pFindOnWebMenuLastfm = make_parented<QMenu>(
+            new FindOnWebMenuLastfm(pFindOnWebMenu, track));
+}
+
+} // namespace library
+
+} // namespace mixxx

--- a/src/widget/findonwebmenufactory.h
+++ b/src/widget/findonwebmenufactory.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <QMenu>
+
+class Track;
+
+namespace mixxx {
+
+namespace library {
+
+void createFindOnWebSubmenus(QMenu* pFindOnWebMenu, const Track& track);
+
+} // namespace library
+
+} // namespace mixxx

--- a/src/widget/findonwebmenuservices/findonwebmenudiscogs.cpp
+++ b/src/widget/findonwebmenuservices/findonwebmenudiscogs.cpp
@@ -1,0 +1,76 @@
+#include "findonwebmenudiscogs.h"
+
+#include <QMenu>
+#include <QUrlQuery>
+
+#include "track/track.h"
+#include "util/parented_ptr.h"
+
+namespace {
+const QString kServiceTitle = QStringLiteral("Discogs");
+
+const QString kQueryTypeRelease = QStringLiteral("release");
+
+const QString kQueryTypeArtist = QStringLiteral("artist");
+
+const QString kSearchUrl = QStringLiteral(
+        "https://www.discogs.com/search/?");
+
+const QUrl composeDiscogsUrl(const QString& serviceDefaultUrl,
+        const QString& query,
+        const QString& queryType) {
+    QUrlQuery urlQuery;
+    urlQuery.addQueryItem("q", query);
+    urlQuery.addQueryItem("type", queryType);
+    QUrl url(serviceDefaultUrl);
+    url.setQuery(urlQuery);
+    return url;
+}
+} //namespace
+
+FindOnWebMenuDiscogs::FindOnWebMenuDiscogs(QMenu* pFindOnWebMenu, const Track& track) {
+    const QString artist = track.getArtist();
+    const QString trackTitle = track.getTitle();
+    const QString album = track.getAlbum();
+    auto pDiscogsMenu = make_parented<QMenu>(pFindOnWebMenu);
+    pDiscogsMenu->setTitle(kServiceTitle);
+    pFindOnWebMenu->addMenu(pDiscogsMenu);
+    addSeparator();
+    if (!artist.isEmpty()) {
+        const QUrl discogsUrlArtist = composeDiscogsUrl(kSearchUrl, artist, kQueryTypeArtist);
+        addActionToServiceMenu(pDiscogsMenu,
+                composeActionText(tr("Artist"), artist),
+                discogsUrlArtist);
+    }
+    if (!trackTitle.isEmpty()) {
+        if (!artist.isEmpty()) {
+            const QString artistWithTrackTitle = composeSearchQuery(artist, trackTitle);
+            const QUrl discogsUrlArtistWithTrackTitle = composeDiscogsUrl(
+                    kSearchUrl, artistWithTrackTitle, kQueryTypeRelease);
+            addActionToServiceMenu(pDiscogsMenu,
+                    composeActionText(
+                            tr("Artist + Title"), artistWithTrackTitle),
+                    discogsUrlArtistWithTrackTitle);
+        }
+        const QUrl discogsUrlTrackTitle =
+                composeDiscogsUrl(kSearchUrl, trackTitle, kQueryTypeRelease);
+        addActionToServiceMenu(pDiscogsMenu,
+                composeActionText(tr("Title"), trackTitle),
+                discogsUrlTrackTitle);
+    }
+    if (!album.isEmpty()) {
+        if (!artist.isEmpty()) {
+            const QString artistWithAlbum = composeSearchQuery(artist, album);
+            const QUrl discogsUrlArtistWithAlbum = composeDiscogsUrl(
+                    kSearchUrl, artistWithAlbum, kQueryTypeRelease);
+            addActionToServiceMenu(pDiscogsMenu,
+                    composeActionText(tr("Artist + Album"), artistWithAlbum),
+                    discogsUrlArtistWithAlbum);
+        } else {
+            const QUrl discogsUrlAlbum = composeDiscogsUrl(kSearchUrl, album, kQueryTypeRelease);
+            addActionToServiceMenu(pDiscogsMenu,
+                    composeActionText(tr("Album"), album),
+                    discogsUrlAlbum);
+        }
+    }
+}

--- a/src/widget/findonwebmenuservices/findonwebmenudiscogs.h
+++ b/src/widget/findonwebmenuservices/findonwebmenudiscogs.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "track/track.h"
+#include "util/parented_ptr.h"
+#include "widget/wfindonwebmenu.h"
+
+class FindOnWebMenuDiscogs : public WFindOnWebMenu {
+  public:
+    FindOnWebMenuDiscogs(QMenu* pFindOnWebMenu, const Track& track);
+};

--- a/src/widget/findonwebmenuservices/findonwebmenulastfm.cpp
+++ b/src/widget/findonwebmenuservices/findonwebmenulastfm.cpp
@@ -1,0 +1,73 @@
+#include "findonwebmenulastfm.h"
+
+#include <QMenu>
+#include <QUrlQuery>
+
+#include "track/track.h"
+#include "util/parented_ptr.h"
+
+namespace {
+const QString kServiceTitle = QStringLiteral("LastFm");
+
+const QString kSearchUrlArtist = QStringLiteral("https://www.last.fm/search/artists?");
+
+const QString kSearchUrlTitle = QStringLiteral("https://www.last.fm/search/tracks?");
+
+const QString kSearchUrlAlbum = QStringLiteral("https://www.last.fm/search/albums?");
+
+const QUrl composeLastfmUrl(const QString& serviceSearchUrl,
+        const QString& query) {
+    QUrlQuery urlQuery;
+    urlQuery.addQueryItem("q", query);
+    QUrl url(serviceSearchUrl);
+    url.setQuery(urlQuery);
+    return url;
+}
+
+} //namespace
+
+FindOnWebMenuLastfm::FindOnWebMenuLastfm(QMenu* pFindOnWebMenu, const Track& track) {
+    const QString artist = track.getArtist();
+    const QString trackTitle = track.getTitle();
+    const QString album = track.getAlbum();
+    auto pLastfmMenu = make_parented<QMenu>(pFindOnWebMenu);
+    pLastfmMenu->setTitle(kServiceTitle);
+    pFindOnWebMenu->addMenu(pLastfmMenu);
+    pLastfmMenu->addSeparator();
+    if (!artist.isEmpty()) {
+        const QUrl lastfmUrlArtist = composeLastfmUrl(kSearchUrlArtist, artist);
+        addActionToServiceMenu(pLastfmMenu,
+                composeActionText(tr("Artist"), artist),
+                lastfmUrlArtist);
+    }
+    if (!trackTitle.isEmpty()) {
+        if (!artist.isEmpty()) {
+            const QString artistWithTrackTitle = composeSearchQuery(artist, trackTitle);
+            const QUrl lastfmUrlArtistWithTrackTitle =
+                    composeLastfmUrl(kSearchUrlTitle, artistWithTrackTitle);
+            addActionToServiceMenu(pLastfmMenu,
+                    composeActionText(
+                            tr("Artist + Title"), artistWithTrackTitle),
+                    lastfmUrlArtistWithTrackTitle);
+        }
+        const QUrl lastfmUrlTrackTitle = composeLastfmUrl(kSearchUrlTitle, trackTitle);
+        addActionToServiceMenu(pLastfmMenu,
+                composeActionText(tr("Title"), trackTitle),
+                lastfmUrlTrackTitle);
+    }
+    if (!album.isEmpty()) {
+        if (!artist.isEmpty()) {
+            const QString artistWithAlbum = composeSearchQuery(artist, album);
+            const QUrl lastfmUrlArtistWithAlbum =
+                    composeLastfmUrl(kSearchUrlAlbum, artistWithAlbum);
+            addActionToServiceMenu(pLastfmMenu,
+                    composeActionText(tr("Artist + Album"), artistWithAlbum),
+                    lastfmUrlArtistWithAlbum);
+        } else {
+            const QUrl lastfmUrlAlbum = composeLastfmUrl(kSearchUrlAlbum, album);
+            addActionToServiceMenu(pLastfmMenu,
+                    composeActionText(tr("Album"), album),
+                    lastfmUrlAlbum);
+        }
+    }
+}

--- a/src/widget/findonwebmenuservices/findonwebmenulastfm.h
+++ b/src/widget/findonwebmenuservices/findonwebmenulastfm.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "track/track.h"
+#include "util/parented_ptr.h"
+#include "widget/wfindonwebmenu.h"
+
+class FindOnWebMenuLastfm : public WFindOnWebMenu {
+  public:
+    FindOnWebMenuLastfm(QMenu* pFindOnWebMenu, const Track& track);
+};

--- a/src/widget/findonwebmenuservices/findonwebmenusoundcloud.cpp
+++ b/src/widget/findonwebmenuservices/findonwebmenusoundcloud.cpp
@@ -1,0 +1,73 @@
+#include "findonwebmenusoundcloud.h"
+
+#include <QMenu>
+#include <QUrlQuery>
+
+#include "track/track.h"
+#include "util/parented_ptr.h"
+
+namespace {
+const QString kServiceTitle = QStringLiteral("Soundcloud");
+
+const QString kSearchUrlArtist = QStringLiteral("https://soundcloud.com/search/people?");
+
+const QString kSearchUrlTitle = QStringLiteral("https://soundcloud.com/search/sounds?");
+
+const QString kSearchUrlAlbum = QStringLiteral("https://soundcloud.com/search/albums?");
+
+const QUrl composeSoundcloudUrl(const QString& serviceSearchUrl,
+        const QString& query) {
+    QUrlQuery urlQuery;
+    urlQuery.addQueryItem("q", query);
+    QUrl url(serviceSearchUrl);
+    url.setQuery(urlQuery);
+    return url;
+}
+} // namespace
+
+FindOnWebMenuSoundcloud::FindOnWebMenuSoundcloud(
+        QMenu* pFindOnWebMenu, const Track& track) {
+    const QString artist = track.getArtist();
+    const QString trackTitle = track.getTitle();
+    const QString album = track.getAlbum();
+    auto pSoundcloudMenu = make_parented<QMenu>(pFindOnWebMenu);
+    pSoundcloudMenu->setTitle(kServiceTitle);
+    pFindOnWebMenu->addMenu(pSoundcloudMenu);
+    pSoundcloudMenu->addSeparator();
+    if (!artist.isEmpty()) {
+        const QUrl SoundcloudUrlArtist = composeSoundcloudUrl(kSearchUrlArtist, artist);
+        addActionToServiceMenu(pSoundcloudMenu,
+                composeActionText(tr("Artist"), artist),
+                SoundcloudUrlArtist);
+    }
+    if (!trackTitle.isEmpty()) {
+        if (!artist.isEmpty()) {
+            const QString artistWithTrackTitle = composeSearchQuery(artist, trackTitle);
+            const QUrl SoundcloudUrlArtistWithTrackTitle =
+                    composeSoundcloudUrl(kSearchUrlTitle, artistWithTrackTitle);
+            addActionToServiceMenu(pSoundcloudMenu,
+                    composeActionText(
+                            tr("Artist + Title"), artistWithTrackTitle),
+                    SoundcloudUrlArtistWithTrackTitle);
+        }
+        const QUrl SoundcloudUrlTrackTitle = composeSoundcloudUrl(kSearchUrlTitle, trackTitle);
+        addActionToServiceMenu(pSoundcloudMenu,
+                composeActionText(tr("Title"), trackTitle),
+                SoundcloudUrlTrackTitle);
+    }
+    if (!album.isEmpty()) {
+        if (!artist.isEmpty()) {
+            const QString artistWithAlbum = composeSearchQuery(artist, album);
+            const QUrl SoundcloudUrlArtistWithAlbum =
+                    composeSoundcloudUrl(kSearchUrlAlbum, artistWithAlbum);
+            addActionToServiceMenu(pSoundcloudMenu,
+                    composeActionText(tr("Artist + Album"), artistWithAlbum),
+                    SoundcloudUrlArtistWithAlbum);
+        } else {
+            const QUrl SoundcloudUrlAlbum = composeSoundcloudUrl(kSearchUrlAlbum, album);
+            addActionToServiceMenu(pSoundcloudMenu,
+                    composeActionText(tr("Album"), album),
+                    SoundcloudUrlAlbum);
+        }
+    }
+}

--- a/src/widget/findonwebmenuservices/findonwebmenusoundcloud.h
+++ b/src/widget/findonwebmenuservices/findonwebmenusoundcloud.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "track/track.h"
+#include "util/parented_ptr.h"
+#include "widget/wfindonwebmenu.h"
+
+class FindOnWebMenuSoundcloud : public WFindOnWebMenu {
+  public:
+    FindOnWebMenuSoundcloud(QMenu* pFindOnWebMenu, const Track& track);
+};

--- a/src/widget/wfindonwebmenu.cpp
+++ b/src/widget/wfindonwebmenu.cpp
@@ -1,127 +1,16 @@
-#include "widget/wfindonwebmenu.h"
+#include "wfindonwebmenu.h"
 
 #include <QDesktopServices>
-#include <QScreen>
-#include <QUrl>
+#include <QMenu>
 #include <QUrlQuery>
 #include <QtDebug>
 
 #include "track/track.h"
-#include "util/math.h"
 #include "util/parented_ptr.h"
-#include "util/qt.h"
 #include "util/widgethelper.h"
-
-namespace {
-
-QString composeActionText(const QString& prefix, const QString& trackProperty) {
-    return prefix + QStringLiteral(" | ") + trackProperty;
-}
-
-QString composeSearchQuery(const QString& trackAlbumOrTitle, const QString& artist) {
-    return trackAlbumOrTitle + QStringLiteral(" ") + artist;
-}
-
-QString composePrefixAction(WFindOnWebMenu::TrackSearchProperties trackSearchProperties) {
-    switch (trackSearchProperties) {
-    case WFindOnWebMenu::TrackSearchProperties::Title:
-        return QObject::tr("Title");
-    case WFindOnWebMenu::TrackSearchProperties::Artist:
-        return QObject::tr("Artist");
-    case WFindOnWebMenu::TrackSearchProperties::ArtistAndTitle:
-        return QObject::tr("Title + Artist");
-    case WFindOnWebMenu::TrackSearchProperties::ArtistAndAlbum:
-        return QObject::tr("Album + Artist");
-    default:
-        return QObject::tr("Album");
-    }
-}
-
-const QString kSearchUrlSoundCloudArtist = QStringLiteral("https://soundcloud.com/search/people?");
-
-const QString kSearchUrlSoundCloudTitle = QStringLiteral("https://soundcloud.com/search/sounds?");
-
-const QString kSearchUrlSoundCloudAlbum = QStringLiteral("https://soundcloud.com/search/albums?");
-
-const QString kSearchUrlDiscogsGen = QStringLiteral("https://www.discogs.com/search/?");
-
-const QString kSearchUrlLastFmArtist = QStringLiteral("https://www.last.fm/search/artists?");
-
-const QString kSearchUrlLastFmTitle = QStringLiteral("https://www.last.fm/search/tracks?");
-
-const QString kSearchUrlLastFmAlbum = QStringLiteral("https://www.last.fm/search/albums?");
-
-const QString kSearchUrlDefault = QStringLiteral("https://soundcloud.com/search?");
-
-QString getServiceUrl(WFindOnWebMenu::Service service,
-        WFindOnWebMenu::TrackSearchProperties trackSearchProperties) {
-    switch (service) {
-    case WFindOnWebMenu::Service::Discogs:
-        return kSearchUrlDiscogsGen;
-    case WFindOnWebMenu::Service::LastFm:
-        if (trackSearchProperties == WFindOnWebMenu::TrackSearchProperties::Title ||
-                trackSearchProperties == WFindOnWebMenu::TrackSearchProperties::ArtistAndTitle) {
-            return kSearchUrlLastFmTitle;
-        } else if (trackSearchProperties == WFindOnWebMenu::TrackSearchProperties::Artist) {
-            return kSearchUrlLastFmArtist;
-        } else {
-            return kSearchUrlLastFmAlbum;
-        }
-    case WFindOnWebMenu::Service::SoundCloud:
-        if (trackSearchProperties == WFindOnWebMenu::TrackSearchProperties::Title ||
-                trackSearchProperties == WFindOnWebMenu::TrackSearchProperties::ArtistAndTitle) {
-            return kSearchUrlSoundCloudTitle;
-        } else if (trackSearchProperties == WFindOnWebMenu::TrackSearchProperties::Artist) {
-            return kSearchUrlSoundCloudArtist;
-        } else {
-            return kSearchUrlSoundCloudAlbum;
-        }
-    default:
-        return kSearchUrlDefault;
-    }
-}
-} // namespace
 
 WFindOnWebMenu::WFindOnWebMenu(QWidget* parent)
         : QMenu(tr("Find on Web"), parent) {
-}
-
-void WFindOnWebMenu::addSubmenusForServices(const Track& track) {
-    WFindOnWebMenu::populateFromTrackProperties(
-            track,
-            QStringLiteral("SoundCloud"),
-            Service::SoundCloud);
-    WFindOnWebMenu::populateFromTrackProperties(
-            track, QStringLiteral("LastFm"), Service::LastFm);
-    WFindOnWebMenu::populateFromTrackProperties(
-            track, QStringLiteral("Discogs"), Service::Discogs);
-}
-
-void WFindOnWebMenu::addActions(Service service,
-        const QString& queryValue,
-        QMenu* pServiceMenu,
-        TrackSearchProperties trackSearchProperties) {
-    const QString prefixAction = composePrefixAction(trackSearchProperties);
-    pServiceMenu->addAction(
-            composeActionText(prefixAction, queryValue),
-            this,
-            [this, service, trackSearchProperties, queryValue]() {
-                openInBrowser(service, trackSearchProperties, queryValue);
-            });
-}
-
-void WFindOnWebMenu::openInBrowser(Service service,
-        TrackSearchProperties trackSearchProperties,
-        const QString& queryValue) {
-    const QString serviceUrl = getServiceUrl(service, trackSearchProperties);
-    QUrlQuery urlQuery;
-    urlQuery.addQueryItem("q", queryValue);
-    QUrl url(serviceUrl);
-    url.setQuery(urlQuery);
-    if (!QDesktopServices::openUrl(url)) {
-        qWarning() << "QDesktopServices::openUrl() failed for " << url;
-        DEBUG_ASSERT(false);
-    }
 }
 
 bool WFindOnWebMenu::hasEntriesForTrack(const Track& track) {
@@ -130,48 +19,27 @@ bool WFindOnWebMenu::hasEntriesForTrack(const Track& track) {
             track.getTitle().isEmpty());
 }
 
-void WFindOnWebMenu::populateFromTrackProperties(
-        const Track& track,
-        const QString& serviceTitle,
-        Service service) {
-    const QString artist = track.getArtist();
-    const QString trackTitle = track.getTitle();
-    const QString album = track.getAlbum();
-    auto pServiceMenu = make_parented<QMenu>(this);
-    pServiceMenu->setTitle(serviceTitle);
-    addMenu(pServiceMenu);
-    addSeparator();
-    if (!artist.isEmpty()) {
-        addActions(service,
-                artist,
-                pServiceMenu,
-                WFindOnWebMenu::TrackSearchProperties::Artist);
-    }
-    if (!trackTitle.isEmpty()) {
-        if (!artist.isEmpty()) {
-            const QString artistWithTrackTitle = composeSearchQuery(trackTitle, artist);
-            addActions(service,
-                    artistWithTrackTitle,
-                    pServiceMenu,
-                    WFindOnWebMenu::TrackSearchProperties::ArtistAndTitle);
-        }
-        addActions(service,
-                trackTitle,
-                pServiceMenu,
-                WFindOnWebMenu::TrackSearchProperties::Title);
-    }
-    if (!album.isEmpty()) {
-        if (!artist.isEmpty()) {
-            const QString artistWithAlbum = composeSearchQuery(album, artist);
-            addActions(service,
-                    artistWithAlbum,
-                    pServiceMenu,
-                    WFindOnWebMenu::TrackSearchProperties::ArtistAndAlbum);
-        } else {
-            addActions(service,
-                    album,
-                    pServiceMenu,
-                    WFindOnWebMenu::TrackSearchProperties::Album);
-        }
+void WFindOnWebMenu::addActionToServiceMenu(
+        QMenu* serviceMenu, const QString& actionText, const QUrl& serviceUrl) {
+    serviceMenu->addAction(actionText,
+            this,
+            [this, serviceUrl] {
+                openInBrowser(serviceUrl);
+            });
+}
+
+QString WFindOnWebMenu::composeActionText(const QString& prefix, const QString& trackProperty) {
+    return prefix + QStringLiteral(" | ") + trackProperty;
+}
+
+QString WFindOnWebMenu::composeSearchQuery(
+        const QString& artist, const QString& trackAlbumOrTitle) {
+    return artist + QStringLiteral(" ") + trackAlbumOrTitle;
+}
+
+void WFindOnWebMenu::openInBrowser(const QUrl& url) {
+    if (!QDesktopServices::openUrl(url)) {
+        qWarning() << "QDesktopServices::openUrl() failed for " << url;
+        DEBUG_ASSERT(false);
     }
 }

--- a/src/widget/wfindonwebmenu.h
+++ b/src/widget/wfindonwebmenu.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <QAction>
 #include <QMenu>
-#include <QUrlQuery>
 
 class Track;
 
@@ -13,36 +11,16 @@ class WFindOnWebMenu : public QMenu {
             QWidget* parent = nullptr);
     ~WFindOnWebMenu() override = default;
 
-    enum class Service {
-        SoundCloud,
-        LastFm,
-        Discogs
-    };
-
-    enum class TrackSearchProperties {
-        Artist,
-        ArtistAndTitle,
-        ArtistAndAlbum,
-        Album,
-        Title
-    };
+    void addActionToServiceMenu(QMenu* serviceMenu,
+            const QString& actionText,
+            const QUrl& serviceUrl);
 
     static bool hasEntriesForTrack(const Track& track);
 
-    void addSubmenusForServices(const Track& track);
+  protected:
+    QString composeActionText(const QString& prefix, const QString& trackProperty);
 
-  private:
-    void openInBrowser(WFindOnWebMenu::Service service,
-            WFindOnWebMenu::TrackSearchProperties trackSearchProperties,
-            const QString& queryValue);
+    QString composeSearchQuery(const QString& artist, const QString& trackAlbumOrTitle);
 
-    void populateFromTrackProperties(
-            const Track& track,
-            const QString& serviceTitle,
-            Service service);
-
-    void addActions(Service service,
-            const QString& queryValue,
-            QMenu* pServiceMenu,
-            TrackSearchProperties trackSearchProperties);
+    void openInBrowser(const QUrl& url);
 };

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -34,6 +34,7 @@
 #include "util/parented_ptr.h"
 #include "util/qt.h"
 #include "util/widgethelper.h"
+#include "widget/findonwebmenufactory.h"
 #include "widget/wcolorpickeraction.h"
 #include "widget/wcoverartlabel.h"
 #include "widget/wcoverartmenu.h"
@@ -187,21 +188,21 @@ void WTrackMenu::createMenus() {
     }
 
     if (featureIsEnabled(Feature::FindOnWeb)) {
-        DEBUG_ASSERT(!m_pFindOnMenu);
-        m_pFindOnMenu =
-                make_parented<WFindOnWebMenu>(this);
-
-        connect(m_pFindOnMenu,
+        DEBUG_ASSERT(!m_pFindOnWebMenu);
+        m_pFindOnWebMenu = make_parented<WFindOnWebMenu>(this);
+        connect(m_pFindOnWebMenu,
                 &QMenu::aboutToShow,
                 this,
                 [this] {
-                    m_pFindOnMenu->clear();
+                    m_pFindOnWebMenu->clear();
                     const auto pTrack = getFirstTrackPointer();
                     if (pTrack) {
-                        m_pFindOnMenu->addSubmenusForServices(*pTrack);
+                        mixxx::library::createFindOnWebSubmenus(
+                                m_pFindOnWebMenu,
+                                *pTrack);
                     }
-                    m_pFindOnMenu->setEnabled(
-                            !m_pFindOnMenu->isEmpty());
+                    m_pFindOnWebMenu->setEnabled(
+                            !m_pFindOnWebMenu->isEmpty());
                 });
     }
 
@@ -563,9 +564,9 @@ void WTrackMenu::setupActions() {
 
         m_pMetadataMenu->addMenu(m_pCoverMenu);
         if (featureIsEnabled(Feature::FindOnWeb)) {
-            m_pMetadataMenu->addMenu(m_pFindOnMenu);
-            addSeparator();
+            m_pMetadataMenu->addMenu(m_pFindOnWebMenu);
         }
+        addSeparator();
         addMenu(m_pMetadataMenu);
     }
 
@@ -893,7 +894,7 @@ void WTrackMenu::updateMenus() {
     if (featureIsEnabled(Feature::FindOnWeb)) {
         const auto pTrack = getFirstTrackPointer();
         const bool enableMenu = pTrack ? WFindOnWebMenu::hasEntriesForTrack(*pTrack) : false;
-        m_pFindOnMenu->setEnabled(enableMenu);
+        m_pFindOnWebMenu->setEnabled(enableMenu);
     }
 }
 

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -23,8 +23,8 @@ class Library;
 class TrackModel;
 class WColorPickerAction;
 class WCoverArtMenu;
-class WSearchRelatedTracksMenu;
 class WFindOnWebMenu;
+class WSearchRelatedTracksMenu;
 
 /// A context menu for track(s).
 /// Can be used with individual track type widgets based on TrackPointer
@@ -231,7 +231,7 @@ class WTrackMenu : public QMenu {
     QMenu* m_pColorMenu{};
     WCoverArtMenu* m_pCoverMenu{};
     parented_ptr<WSearchRelatedTracksMenu> m_pSearchRelatedMenu;
-    parented_ptr<WFindOnWebMenu> m_pFindOnMenu;
+    parented_ptr<WFindOnWebMenu> m_pFindOnWebMenu;
     QMenu* m_pRemoveFromDiskMenu{};
 
     // Update ReplayGain from Track


### PR DESCRIPTION
Hey everyone, this PR is the continue of #4772

This feature is called Find On Web. Which is located under the Metadata menu, with a sub menus of different online databases that can help users to look up track properties on online databases. It will populate the fav browser of the user with the given service and query. It basically looks like this:
![FindOn](https://user-images.githubusercontent.com/67206006/177057261-0bea1360-507a-49f4-982d-dc2b39f7f6fe.png)

This feature is aimed for the users who accordingly looks additional info about the tracks. There are few queries with the chosen track. We can lookup for only for the artist, only for the track title (It is good for to look for remixes), track title + artist (make sure we find the correct song), artist + album (To find the other songs in that album). If has no property, the menu is grayed out.

This can be also helpful for later for to find suggested songs on the online services as discussed on the Zulip channel.

Factory Method used for this feature, so for later on another online databases (services) can be added easily by just changing the URL of the searches.