### PR TITLE
WIP Search 'date_added': add support for operators < <= > >=

### DIFF
--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -500,6 +500,11 @@ void BaseTrackCache::filterAndSort(const QSet<TrackId>& trackIds,
     if (!filter.isEmpty()) {
         filter.prepend("WHERE ");
     }
+    qDebug() << "   .";
+    qDebug() << "   .";
+    qDebug() << "   query filter:" << filter;
+    qDebug() << "   .";
+    qDebug() << "   .";
 
     QString queryString = QString("SELECT %1 FROM %2 %3 %4")
             .arg(m_idColumn, m_tableName, filter, orderByClause);

--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -443,6 +443,6 @@ QString SearchQueryParser::parseDateAddedArgument(const QString& argRaw,
     }
 
     *special = true;
-    query = QString(" %1 '%2'").arg(op, date);
+    query = QString(" %1 datetime('%2', 'utc')").arg(op, date);
     return query;
 }

--- a/src/library/searchqueryparser.h
+++ b/src/library/searchqueryparser.h
@@ -32,6 +32,8 @@ class SearchQueryParser {
     QString getTextArgument(QString argument,
                             QStringList* tokens) const;
 
+    QString parseDateAddedArgument(const QString& argument, bool* ok) const;
+
     TrackCollection* m_pTrackCollection;
     QStringList m_textFilters;
     QStringList m_numericFilters;


### PR DESCRIPTION
this is a rough first draft, not optimized, unpolished and possibly wrong in some places.

but for now this serves the purpose of illustrting the sqlite `datetime()` issue I noticed.
https://mixxx.zulipchat.com/#narrow/stream/247620-development-help/topic/issue.20with.20sqlite.20'datetime.28.29'

Issue: search for
`added:<2022-05-12`
would show results incl. tracks added on 2022-05-12

____
right now `added:` is parsed for the following arguments:
* `lastweek`, `lastmonth`, `lastyear`
* operators `<`|`<=`|`>`|`>=` + `yyyy-mm-dd`|`yyyy-mm`|`yyyy`
tbc..