### PR TITLE
Searchbox: Enter jumps to tracks if search query was transmitted

### DIFF
--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -69,7 +69,8 @@ WSearchLineEdit::WSearchLineEdit(QWidget* pParent, UserSettingsPointer pConfig)
         : QComboBox(pParent),
           WBaseWidget(this),
           m_pConfig(pConfig),
-          m_clearButton(make_parented<QToolButton>(this)) {
+          m_clearButton(make_parented<QToolButton>(this)),
+          m_queryEmitted(false) {
     qRegisterMetaType<FocusWidget>("FocusWidget");
     setAcceptDrops(false);
     setEditable(true);
@@ -350,7 +351,12 @@ void WSearchLineEdit::keyPressEvent(QKeyEvent* keyEvent) {
         if (findCurrentTextIndex() == -1) {
             slotSaveSearch();
         }
-        slotTriggerSearch();
+        // Jump to tracks if search signal was already emitted
+        if (!m_queryEmitted) {
+            slotTriggerSearch();
+        } else {
+            emit setLibraryFocus(FocusWidget::TracksTable);
+        }
         return;
     case Qt::Key_Space:
         // Open/close popup with Ctrl + space
@@ -467,6 +473,7 @@ void WSearchLineEdit::slotTriggerSearch() {
     DEBUG_ASSERT(isEnabled());
     m_debouncingTimer.stop();
     emit search(getSearchText());
+    m_queryEmitted = true;
 }
 
 /// saves the current query as selection
@@ -705,6 +712,7 @@ void WSearchLineEdit::slotTextChanged(const QString& text) {
             << "slotTextChanged"
             << text;
 #endif // ENABLE_TRACE_LOG
+    m_queryEmitted = false;
     m_debouncingTimer.stop();
     if (!isEnabled()) {
         setTextBlockSignals(kDisabledText);

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -208,6 +208,10 @@ void WSearchLineEdit::setup(const QDomNode& node, const SkinContext& context) {
             tr("Shortcuts") + ": \n" +
             tr("Ctrl+F") + "  " +
             tr("Focus", "Give search bar input focus") + "\n" +
+            tr("Return") + " " +
+            tr("Trigger search before search-as-you-type timeout or"
+               "jump to tracks view afterwards") +
+            "\n" +
             tr("Ctrl+Backspace") + "  " +
             tr("Clear input", "Clear the search bar input field") + "\n" +
             tr("Ctrl+Space") + "  " +

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -102,4 +102,5 @@ class WSearchLineEdit : public QComboBox, public WBaseWidget {
 
     QTimer m_debouncingTimer;
     QTimer m_saveTimer;
+    bool m_queryEmitted;
 };


### PR DESCRIPTION
1st Enter press: emit query (or debounce timeout expired)
2nd Enter press: jump to tracks table

This is mainly supposed to be a shortcut for when working with the keyboard. Currently it requires 3 x Tab to get from searchbox to tracks, while it's just one press of the Browse/Trax encoder, often mapped to `[Library], GoToItem`.

I'm planning to add some visual feedback to signal that the query was submitted, it's not clear what that'll be though.
* could be a another pushbutton next to Clear, e.g. ➜, that's greyed out as soon as the search is triggered, though that's cumbersome to integrate (layout-wise, considering we also expect right-to-left locales)
* could be a 3rd state of the Clear icon (normal | focused | query submitted)
* ...