### PR TITLE
lp1981106: Remove wrong debug assertion about source synchronization time stamps

### DIFF
--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -166,21 +166,18 @@ TrackRecord::SourceSyncStatus TrackRecord::checkSourceSyncStatus(
     if (getSourceSynchronizedAt() < fileSourceSynchronizedAt) {
         return SourceSyncStatus::Outdated;
     }
-    // This could actually happen when users replace files with
-    // an older version on the file system. But it should never
-    // happen under normal operation. Otherwise it might indicate
-    // a serious programming error and we should detect it early
-    // before the release. Debug assertions are only enabled in
-    // development and testing versions.
-    VERIFY_OR_DEBUG_ASSERT(getSourceSynchronizedAt() <= fileSourceSynchronizedAt) {
-        kLogger.warning()
+    if (getSourceSynchronizedAt() > fileSourceSynchronizedAt) {
+        // The internal metadata has either been updated and not re-exported (yet)
+        // or the file has been replaced with an older version. In both cases the
+        // file metadata should not be re-imported implicitly and is considered
+        // as synchronized.
+        kLogger.debug()
                 << "Internal source synchronization time stamp"
                 << getSourceSynchronizedAt()
                 << "is ahead of"
                 << fileSourceSynchronizedAt
                 << "for file"
-                << mixxx::FileInfo(fileInfo)
-                << ": Has this file been replaced with an older version?";
+                << mixxx::FileInfo(fileInfo);
     }
     return SourceSyncStatus::Synchronized;
 }

--- a/src/track/trackrecord.h
+++ b/src/track/trackrecord.h
@@ -120,10 +120,12 @@ class TrackRecord final {
         /// that allow to monitor the modification time of the file.
         Unknown,
 
-        /// The metadata in Mixxx is up-to-date.
+        /// The metadata in Mixxx is up-to-date, i.e. not older than the
+        /// last modification time stamp of the underlying file.
         Synchronized,
 
-        /// The metadata in Mixxx is older than the metadata stored in file tags.
+        /// The metadata in Mixxx is older than the metadata stored in file tags
+        /// and should be re-imported.
         Outdated,
 
         /// The status could not be determined for whatever reason,


### PR DESCRIPTION
https://bugs.launchpad.net/bugs/1981106

The updated comments explain why.