### PR TITLE
Fix EngineDelay and EngineFilterDelay modulo calculation documentation

### DIFF
--- a/src/engine/enginedelay.cpp
+++ b/src/engine/enginedelay.cpp
@@ -50,6 +50,11 @@ void EngineDelay::slotDelayChanged() {
 
 void EngineDelay::process(CSAMPLE* pInOut, const int iBufferSize) {
     if (m_iDelay > 0) {
+        // The "+ kiMaxDelay" addition ensures positive values for the modulo calculation.
+        // From a mathematical point of view, this addition can be removed. Anyway,
+        // from the cpp point of view, the modulo operator for negative values
+        // (for example, x % y, where x is a negative value) produces negative results
+        // (but in math the result value is positive).
         int iDelaySourcePos = (m_iDelayPos + kiMaxDelay - m_iDelay) % kiMaxDelay;
 
         VERIFY_OR_DEBUG_ASSERT(iDelaySourcePos >= 0) {

--- a/src/engine/filters/enginefilterdelay.h
+++ b/src/engine/filters/enginefilterdelay.h
@@ -34,6 +34,11 @@ class EngineFilterDelay : public EngineObjectConstIn {
     virtual void process(const CSAMPLE* pIn, CSAMPLE* pOutput,
                          const int iBufferSize) {
         if (m_oldDelaySamples == m_delaySamples) {
+            // The "+ SIZE" addition ensures positive values for the modulo calculation.
+            // From a mathematical point of view, this addition can be removed. Anyway,
+            // from the cpp point of view, the modulo operator for negative values
+            // (for example, x % y, where x is a negative value) produces negative results
+            // (but in math the result value is positive).
             int delaySourcePos = (m_delayPos + SIZE - m_delaySamples) % SIZE;
 
             VERIFY_OR_DEBUG_ASSERT(delaySourcePos >= 0) {
@@ -55,6 +60,11 @@ class EngineFilterDelay : public EngineObjectConstIn {
                 delaySourcePos = (delaySourcePos + 1) % SIZE;
             }
         } else {
+            // The "+ SIZE" addition ensures positive values for the modulo calculation.
+            // From a mathematical point of view, this addition can be removed. Anyway,
+            // from the cpp point of view, the modulo operator for negative values
+            // (for example, x % y, where x is a negative value) produces negative results
+            // (but in math the result value is positive).
             int delaySourcePos = (m_delayPos + SIZE - m_delaySamples + iBufferSize / 2) % SIZE;
             int oldDelaySourcePos = (m_delayPos + SIZE - m_oldDelaySamples) % SIZE;
 


### PR DESCRIPTION
Adds documentation for the modulo calculation in the EngineDelay::process and EngineFilterDelay::process.

The mentioned documentation explains the usage of the addition. The added value is the size of the delay buffer, which is used for the modulo operator as well (as a divisor for division). From a mathematical point of view, this addition can be removed.

Anyway, from the cpp point of view, the delay buffer size addition is necessary based on an otherwise negative result using the cpp modulo operator.