### PR TITLE
Library: Home/End keys jump to first/last row

### DIFF
--- a/src/widget/wlibrarytableview.cpp
+++ b/src/widget/wlibrarytableview.cpp
@@ -57,7 +57,6 @@ WLibraryTableView::WLibraryTableView(QWidget* parent,
 WLibraryTableView::~WLibraryTableView() {
 }
 
-
 void WLibraryTableView::moveSelection(int delta) {
     QAbstractItemModel* pModel = model();
 

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -822,6 +822,35 @@ void WTrackTableView::keyPressEvent(QKeyEvent* event) {
             return;
         }
     } break;
+    case Qt::Key_Home: { // Jump to first row
+        if (model()->rowCount() == 0) {
+            return;
+        }
+        int currCol = 0;
+        QModelIndex currIdx = currentIndex();
+        if (currIdx.isValid()) {
+            currCol = currIdx.column();
+        }
+        QModelIndex newIdx = model()->index(0, currCol);
+        selectionModel()->setCurrentIndex(newIdx,
+                QItemSelectionModel::SelectCurrent | QItemSelectionModel::Rows);
+        scrollTo(newIdx);
+    } break;
+    case Qt::Key_End: { // Jump to last row
+        const int lastRow = model()->rowCount() - 1;
+        if (lastRow == -1) {
+            return;
+        }
+        int currCol = 0;
+        QModelIndex currIdx = currentIndex();
+        if (currIdx.isValid()) {
+            currCol = currIdx.column();
+        }
+        QModelIndex newIdx = model()->index(lastRow, currCol);
+        selectionModel()->setCurrentIndex(newIdx,
+                QItemSelectionModel::SelectCurrent | QItemSelectionModel::Rows);
+        scrollTo(newIdx);
+    } break;
     default:
         QTableView::keyPressEvent(event);
     }

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -802,22 +802,29 @@ TrackModel* WTrackTableView::getTrackModel() const {
 }
 
 void WTrackTableView::keyPressEvent(QKeyEvent* event) {
-    // Ctrl+Return opens track properties dialog.
-    // Ignore it if any cell editor is open.
-    // Note: the shortcut is displayed in the track context menu
-    if (event->key() == kPropertiesShortcutKey &&
-            (event->modifiers() & kPropertiesShortcutModifier) &&
-            state() != QTableView::EditingState) {
-        QModelIndexList indices = selectionModel()->selectedRows();
-        if (indices.length() == 1) {
-            m_pTrackMenu->loadTrackModelIndices(indices);
-            m_pTrackMenu->slotShowDlgTrackInfo();
+    switch (event->key()) {
+    case kPropertiesShortcutKey: {
+        // Ctrl+Return opens track properties dialog.
+        // Ignore it if any cell editor is open.
+        // Note: the shortcut is displayed in the track context menu
+        if ((event->modifiers() & kPropertiesShortcutModifier) &&
+                state() != QTableView::EditingState) {
+            QModelIndexList indices = selectionModel()->selectedRows();
+            if (indices.length() == 1) {
+                m_pTrackMenu->loadTrackModelIndices(indices);
+                m_pTrackMenu->slotShowDlgTrackInfo();
+            }
         }
-    } else if (event->key() == kHideRemoveShortcutKey &&
-            event->modifiers() == kHideRemoveShortcutModifier) {
-        hideOrRemoveSelectedTracks();
+    } break;
+    case kHideRemoveShortcutKey: {
+        if (event->modifiers() == kHideRemoveShortcutModifier) {
+            hideOrRemoveSelectedTracks();
+            return;
+        }
+    } break;
+    default:
+        QTableView::keyPressEvent(event);
     }
-    QTableView::keyPressEvent(event);
 }
 
 void WTrackTableView::hideOrRemoveSelectedTracks() {


### PR DESCRIPTION
fixing a minor annoyance I was suffering for years ; )

**Home** jump to first row
**End** jump to last row
Very convenient for jumping back to the top/bottom after re-sorting.
Previously, Home/End would move focus left/right inside the current row, but for that Left/Right can be used as well.