### PR TITLE
Cover Art Fetcher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -818,6 +818,8 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/musicbrainz/musicbrainzxml.cpp
   src/musicbrainz/tagfetcher.cpp
   src/musicbrainz/web/acoustidlookuptask.cpp
+  src/musicbrainz/web/coverartarchiveimagetask.cpp
+  src/musicbrainz/web/coverartarchivelinkstask.cpp
   src/musicbrainz/web/musicbrainzrecordingstask.cpp
   src/network/jsonwebtask.cpp
   src/network/networktask.cpp

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -82,7 +82,7 @@ void DlgCoverArtFullSize::init(TrackPointer pTrack) {
     slotLoadTrack(pTrack);
 }
 
-void DlgCoverArtFullSize::init(const QByteArray& fetchedCoverArtBytes) {
+void DlgCoverArtFullSize::initFetchedCoverArt(const QByteArray& fetchedCoverArtBytes) {
     QPixmap image;
     image.loadFromData(fetchedCoverArtBytes);
 
@@ -91,7 +91,7 @@ void DlgCoverArtFullSize::init(const QByteArray& fetchedCoverArtBytes) {
     raise();
     activateWindow();
 
-    QString fetchedCoverArtWindowTitle = "Fetched Cover Art";
+    QString fetchedCoverArtWindowTitle = tr("Fetched Cover Art");
 
     setWindowTitle(fetchedCoverArtWindowTitle);
 

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -82,6 +82,23 @@ void DlgCoverArtFullSize::init(TrackPointer pTrack) {
     slotLoadTrack(pTrack);
 }
 
+void DlgCoverArtFullSize::init(const QByteArray& fetchedCoverArtBytes) {
+    QPixmap image;
+    image.loadFromData(fetchedCoverArtBytes);
+
+    resize(image.size().width(), image.size().height());
+    show();
+    raise();
+    activateWindow();
+
+    QString fetchedCoverArtWindowTitle = "Fetched Cover Art";
+
+    setWindowTitle(fetchedCoverArtWindowTitle);
+
+    //TODO: Do a better scaling. It populates wrong if the cover art size highest.
+    coverArt->setPixmap(image);
+}
+
 void DlgCoverArtFullSize::slotLoadTrack(TrackPointer pTrack) {
     if (m_pLoadedTrack != nullptr) {
         disconnect(m_pLoadedTrack.get(),

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -17,7 +17,8 @@ DlgCoverArtFullSize::DlgCoverArtFullSize(
         WCoverArtMenu* pCoverMenu)
         : QDialog(parent),
           m_pPlayer(pPlayer),
-          m_pCoverMenu(pCoverMenu) {
+          m_pCoverMenu(pCoverMenu),
+          m_coverPressed(false) {
     CoverArtCache* pCache = CoverArtCache::instance();
     if (pCache) {
         connect(pCache,
@@ -83,20 +84,16 @@ void DlgCoverArtFullSize::init(TrackPointer pTrack) {
 }
 
 void DlgCoverArtFullSize::initFetchedCoverArt(const QByteArray& fetchedCoverArtBytes) {
-    QPixmap image;
-    image.loadFromData(fetchedCoverArtBytes);
+    m_pixmap.loadFromData(fetchedCoverArtBytes);
 
-    resize(image.size().width(), image.size().height());
+    // The real size will be calculated later by adjustImageAndDialogSize().
+    resize(100, 100);
     show();
+    setWindowTitle(tr("Fetched Cover Art"));
     raise();
     activateWindow();
 
-    QString fetchedCoverArtWindowTitle = tr("Fetched Cover Art");
-
-    setWindowTitle(fetchedCoverArtWindowTitle);
-
-    //TODO: Do a better scaling. It populates wrong if the cover art size highest.
-    coverArt->setPixmap(image);
+    adjustImageAndDialogSize();
 }
 
 void DlgCoverArtFullSize::slotLoadTrack(TrackPointer pTrack) {
@@ -175,6 +172,10 @@ void DlgCoverArtFullSize::slotCoverFound(
 
     m_pixmap = pixmap;
 
+    adjustImageAndDialogSize();
+}
+
+void DlgCoverArtFullSize::adjustImageAndDialogSize() {
     if (m_pixmap.isNull()) {
         coverArt->setPixmap(QPixmap());
         hide();

--- a/src/library/dlgcoverartfullsize.h
+++ b/src/library/dlgcoverartfullsize.h
@@ -39,6 +39,7 @@ class DlgCoverArtFullSize
             mixxx::cache_key_t requestedCacheKey,
             bool coverInfoUpdated);
     void slotTrackCoverArtUpdated();
+    void adjustImageAndDialogSize();
 
     // slots that handle signals from WCoverArtMenu
     void slotCoverMenu(const QPoint& pos);

--- a/src/library/dlgcoverartfullsize.h
+++ b/src/library/dlgcoverartfullsize.h
@@ -22,7 +22,7 @@ class DlgCoverArtFullSize
     ~DlgCoverArtFullSize() override = default;
 
     void init(TrackPointer pTrack);
-    void init(const QByteArray& fetchedCoverArtBytes);
+    void initFetchedCoverArt(const QByteArray& fetchedCoverArtBytes);
     void mousePressEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* ) override;
     void mouseMoveEvent(QMouseEvent* ) override;

--- a/src/library/dlgcoverartfullsize.h
+++ b/src/library/dlgcoverartfullsize.h
@@ -22,6 +22,7 @@ class DlgCoverArtFullSize
     ~DlgCoverArtFullSize() override = default;
 
     void init(TrackPointer pTrack);
+    void init(const QByteArray& fetchedCoverArtBytes);
     void mousePressEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* ) override;
     void mouseMoveEvent(QMouseEvent* ) override;

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -227,11 +227,6 @@ void DlgTagFetcher::loadTrack(const TrackPointer& pTrack) {
 
     m_pWFetchedCoverArtLabel->setCoverArt(CoverInfo{}, QPixmap{});
 
-    disconnect(m_track.get(),
-            &Track::changed,
-            this,
-            &DlgTagFetcher::slotTrackChanged);
-
     m_track = pTrack;
     if (!m_track) {
         return;

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -131,14 +131,7 @@ void DlgTagFetcher::init() {
     setupUi(this);
     setWindowIcon(QIcon(MIXXX_ICON_PATH));
 
-    currentCoverArtLayout->setAlignment(Qt::AlignRight | Qt::AlignTop | Qt::AlignCenter);
-    currentCoverArtLayout->setSpacing(0);
-    currentCoverArtLayout->setContentsMargins(0, 0, 0, 0);
     currentCoverArtLayout->insertWidget(0, m_pWCurrentCoverArtLabel.get());
-
-    fetchedCoverArtLayout->setAlignment(Qt::AlignRight | Qt::AlignBottom | Qt::AlignCenter);
-    fetchedCoverArtLayout->setSpacing(0);
-    fetchedCoverArtLayout->setContentsMargins(0, 0, 0, 0);
     fetchedCoverArtLayout->insertWidget(0, m_pWFetchedCoverArtLabel.get());
 
     if (m_pTrackModel) {

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -598,7 +598,7 @@ void DlgTagFetcher::slotLoadBytesToLabel(const QByteArray& data) {
 
     m_fetchedCoverArtByteArrays = data;
     m_pWFetchedCoverArtLabel->loadData(
-            m_fetchedCoverArtByteArrays); //This data loaded because for full size.
+            m_fetchedCoverArtByteArrays); // This data loaded because for full size.
     m_pWFetchedCoverArtLabel->setCoverArt(coverInfo, fetchedCoverArtPixmap);
 }
 

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -550,37 +550,30 @@ void DlgTagFetcher::slotStartFetchCoverArt(const QList<QString>& allUrls) {
     DlgPrefLibrary::CoverArtFetcherQuality fetcherQuality =
             static_cast<DlgPrefLibrary::CoverArtFetcherQuality>(
                     m_pConfig->getValue(mixxx::library::prefs::kCoverArtFetcherQualityConfigKey,
-                            static_cast<int>(DlgPrefLibrary::CoverArtFetcherQuality::Low)));
+                            static_cast<int>(DlgPrefLibrary::CoverArtFetcherQuality::Medium)));
 
     // Cover art links task can retrieve us variable number of links with different cover art sizes
     // Every single successful response has 2 links.
-    // These links are cover arts with 250 PX and 500 PX
-    // Some of the tags might have link of a cover art with 1200 PX
-    // Some of the tags might have link of a cover art more than 1200 PX
-    // At final, we always retrieve 2 links, but for some tags this can be 3 or 4
-    // We need to pick the correct size according to user choice
+    // These links belongs to cover arts with 250 PX and 500 PX
+    // Some of the releases might have link of a cover art with 1200 PX
+    // Some of the releases might have link of a cover art which is more than 1200 PX
+    // To sum up, 2 links are always retrieved, but for some releases this can be 3 or 4
+    // Picking the correct size according to user choice is a must.
 
     // User choices and the possible fetched cover art sizes are:
-    // Highest -> More than 1200 PX, if not available 1200 PX or 500 PX
-    // High    -> 1200 PX if not available 500 PX
-    // Medium  -> Always 500 PX fetched
-    // Low     -> Always 250 PX fetched
+    // Highest -> >1200 PX, if not available highest possible
+    // High    -> 1200 PX, if not available highest possible
+    // Medium  -> 500 PX, at all times
+    // Low     -> 250 PX, at all times
 
     VERIFY_OR_DEBUG_ASSERT(!allUrls.isEmpty()) {
         return;
     }
 
-    if (fetcherQuality == DlgPrefLibrary::CoverArtFetcherQuality::Highest) {
-        getCoverArt(allUrls.last());
-        return;
-    } else if (fetcherQuality == DlgPrefLibrary::CoverArtFetcherQuality::High) {
-        allUrls.size() < 3 ? getCoverArt(allUrls.last()) : getCoverArt(allUrls.at(2));
-        return;
-    } else if (fetcherQuality == DlgPrefLibrary::CoverArtFetcherQuality::Medium) {
-        allUrls.size() == 2 ? getCoverArt(allUrls.at(1)) : getCoverArt(allUrls.first());
-        return;
+    if (allUrls.size() > static_cast<int>(fetcherQuality)) {
+        getCoverArt(allUrls.at(static_cast<int>(fetcherQuality)));
     } else {
-        getCoverArt(allUrls.first());
+        getCoverArt(allUrls.last());
     }
 }
 

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -510,12 +510,10 @@ void DlgTagFetcher::tagSelected() {
     const int tagIndex = tags->currentItem()->data(0, Qt::UserRole).toInt();
     m_data.m_selectedTag = tagIndex;
 
-    if (!m_fetchedCoverArtByteArrays.isNull()) {
-        m_fetchedCoverArtByteArrays.clear();
-        m_pWFetchedCoverArtLabel->loadData(m_fetchedCoverArtByteArrays);
-        m_pWFetchedCoverArtLabel->setCoverArt(CoverInfo{},
-                QPixmap(CoverArtUtils::defaultCoverLocation()));
-    }
+    m_fetchedCoverArtByteArrays.clear();
+    m_pWFetchedCoverArtLabel->loadData(QByteArray());
+    m_pWFetchedCoverArtLabel->setCoverArt(CoverInfo{},
+            QPixmap(CoverArtUtils::defaultCoverLocation()));
 
     const mixxx::musicbrainz::TrackRelease& trackRelease = m_data.m_tags[tagIndex];
     QUuid selectedTagAlbumId = trackRelease.albumReleaseId;

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -107,7 +107,6 @@ DlgTagFetcher::DlgTagFetcher(UserSettingsPointer pConfig, const TrackModel* pTra
           m_pConfig(pConfig),
           m_pTrackModel(pTrackModel),
           m_tagFetcher(this),
-          m_pWCoverArtMenu(make_parented<WCoverArtMenu>(this)),
           m_pWCurrentCoverArtLabel(make_parented<WCoverArtLabel>(this)),
           m_pWFetchedCoverArtLabel(make_parented<WCoverArtLabel>(this)) {
     init();
@@ -245,6 +244,7 @@ void DlgTagFetcher::loadTrack(const TrackPointer& pTrack) {
             this,
             &DlgTagFetcher::slotTrackChanged);
 
+    loadCurrentTrackCover();
     m_tagFetcher.startFetch(m_track);
 }
 
@@ -255,10 +255,6 @@ void DlgTagFetcher::loadTrack(const QModelIndex& index) {
 }
 
 void DlgTagFetcher::slotTrackChanged(TrackId trackId) {
-    if (!m_fetchedCoverArtByteArrays.isNull()) {
-        m_fetchedCoverArtByteArrays.clear();
-    }
-
     if (m_track && m_track->getId() == trackId) {
         updateOriginalTag(*m_track, tags);
     }
@@ -448,6 +444,9 @@ void DlgTagFetcher::fetchTagFinished(
         }
     }
 
+    QString fetchTagFinishedMessage = tr("The results are ready to be applied");
+    statusMessage->setText(fetchTagFinishedMessage);
+
     // qDebug() << "number of tags = " << guessedTrackReleases.size();
 }
 
@@ -494,9 +493,9 @@ void DlgTagFetcher::tagSelected() {
 
     if (!m_fetchedCoverArtByteArrays.isNull()) {
         m_fetchedCoverArtByteArrays.clear();
-        CoverInfo coverInfo;
-        QPixmap pixmap;
-        m_pWFetchedCoverArtLabel->setCoverArt(coverInfo, pixmap);
+        m_pWFetchedCoverArtLabel->loadData(m_fetchedCoverArtByteArrays);
+        m_pWFetchedCoverArtLabel->setCoverArt(CoverInfo{},
+                QPixmap(CoverArtUtils::defaultCoverLocation()));
     }
 
     const mixxx::musicbrainz::TrackRelease& trackRelease = m_data.m_tags[tagIndex];
@@ -582,7 +581,7 @@ void DlgTagFetcher::slotLoadBytesToLabel(const QByteArray& data) {
     coverInfo.setImage();
 
     loadingProgressBar->setVisible(false);
-    QString coverArtMessage = tr("Cover art found and it is ready to be applied.");
+    QString coverArtMessage = tr("Cover art is ready to be applied");
     statusMessage->setVisible(true);
     statusMessage->setText(coverArtMessage);
 
@@ -603,6 +602,6 @@ void DlgTagFetcher::getCoverArt(const QString& url) {
 void DlgTagFetcher::slotCoverArtLinkNotFound() {
     loadingProgressBar->setVisible(false);
     statusMessage->setVisible(true);
-    QString message = tr("Cover Art not available for that tag. Please try another.");
+    QString message = tr("Cover Art is not available for selected tag");
     statusMessage->setText(message);
 }

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -337,10 +337,13 @@ void DlgTagFetcher::apply() {
 
         QFileInfo trackFileInfo = QFileInfo(m_track->getLocation());
 
+        // Compose the Cover Art file path. Use the correct file extension
+        // by checking from the fetched image bytes (disregard extension
+        // from file link).
         QString coverArtCopyFilePath =
                 trackFileInfo.absoluteFilePath().left(
                         trackFileInfo.absoluteFilePath().lastIndexOf('.') + 1) +
-                "jpeg";
+                ImageFileData::readFormatFrom(m_fetchedCoverArtByteArrays);
 
         m_worker.reset(new CoverArtCopyWorker(
                 QString(), coverArtCopyFilePath, m_fetchedCoverArtByteArrays));

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -544,19 +544,28 @@ void DlgTagFetcher::slotStartFetchCoverArt(const QList<QString>& allUrls) {
             static_cast<DlgPrefLibrary::CoverArtFetcherQuality>(
                     fetchedCoverArtQualityConfigValue);
 
-    // Maximum size of the allUrls are 4.
+    // Cover art links task can retrieve us variable number of links with different cover art sizes
+    // Every single successful response has 2 links.
+    // These links are cover arts with 250 PX and 500 PX
+    // Some of the tags might have link of a cover art with 1200 PX
+    // Some of the tags might have link of a cover art more than 1200 PX
+    // At final, we always retrieve 2 links, but for some tags this can be 3 or 4
+    // We need to pick the correct size according to user choice
+
+    // User choices and the possible fetched cover art sizes are:
+    // Highest -> More than 1200 PX, if not available 1200 PX or 500 PX
+    // High    -> 1200 PX if not available 500 PX
+    // Medium  -> Always 500 PX fetched
+    // Low     -> Always 250 PX fetched
+
     if (fetcherQuality == DlgPrefLibrary::CoverArtFetcherQuality::Highest) {
         getCoverArt(allUrls.last());
-        qDebug() << allUrls.last();
         return;
     } else if (fetcherQuality == DlgPrefLibrary::CoverArtFetcherQuality::High) {
-        qDebug() << allUrls.size();
-        qDebug() << allUrls;
-        allUrls.size() < 3 ? getCoverArt(allUrls.at(1)) : getCoverArt(allUrls.at(2));
+        allUrls.size() < 3 ? getCoverArt(allUrls.last()) : getCoverArt(allUrls.at(2));
         return;
     } else if (fetcherQuality == DlgPrefLibrary::CoverArtFetcherQuality::Medium) {
         getCoverArt(allUrls.at(1));
-        qDebug() << allUrls.at(1);
         return;
     } else {
         getCoverArt(allUrls.first());

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -37,6 +37,20 @@ constexpr int kMaximumValueOfQProgressBar = 100;
 
 constexpr int kMinimumValueOfQProgressBar = 0;
 
+// There are 2 following steps for cover art fetching.
+// 1. -> "Cover Art Links Task"
+// 2. -> "Cover Art Image Task"
+// When a tag is selected, first step starts.
+// First step looks for available cover art links for selected tag.
+// Some tags might not have any available cover arts.
+// If no links found, user is informed and cover art fetching is finished.
+// If links are found, second step starts instantly.
+// Second step gets actual cover art with according to user's chosen size.
+
+constexpr int kPercentForCoverArtLinksTask = 35;
+
+constexpr int kPercentForCoverArtImageTask = 70;
+
 // Original Index of the track tag, listed all the time below 'Original Tags'.
 constexpr int kOriginalTrackIndex = -1;
 
@@ -505,9 +519,7 @@ void DlgTagFetcher::tagSelected() {
     QString coverArtMessage = tr("Looking for cover art");
     loadingProgressBar->setVisible(true);
     loadingProgressBar->setFormat(coverArtMessage);
-    loadingProgressBar->setMinimum(0);
-    loadingProgressBar->setMaximum(100);
-    loadingProgressBar->setValue(10);
+    loadingProgressBar->setValue(kPercentForCoverArtLinksTask);
 
     m_tagFetcher.startFetchCoverArtLinks(selectedTagAlbumId);
 }
@@ -572,7 +584,6 @@ void DlgTagFetcher::slotStartFetchCoverArt(const QList<QString>& allUrls) {
 }
 
 void DlgTagFetcher::slotLoadBytesToLabel(const QByteArray& data) {
-    loadingProgressBar->setValue(80);
     QPixmap fetchedCoverArtPixmap;
     fetchedCoverArtPixmap.loadFromData(data);
     CoverInfo coverInfo;
@@ -594,8 +605,7 @@ void DlgTagFetcher::slotLoadBytesToLabel(const QByteArray& data) {
 void DlgTagFetcher::getCoverArt(const QString& url) {
     QString coverArtMessage = tr("Cover art found getting image");
     loadingProgressBar->setFormat(coverArtMessage);
-    loadingProgressBar->setValue(40);
-
+    loadingProgressBar->setValue(kPercentForCoverArtImageTask);
     m_tagFetcher.startFetchCoverArtImage(url);
 }
 

--- a/src/library/dlgtagfetcher.h
+++ b/src/library/dlgtagfetcher.h
@@ -63,6 +63,12 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
     void slotStartFetchCoverArt(const QList<QString>& allUrls);
     void slotLoadBytesToLabel(const QByteArray& data);
     void slotCoverArtLinkNotFound();
+    void slotWorkerStarted();
+    void slotWorkerAskOverwrite(const QString& coverArtAbsolutePath,
+            std::promise<CoverArtCopyWorker::OverwriteAnswer>* promise);
+    void slotWorkerCoverArtCopyFailed(const QString& errorMessage);
+    void slotWorkerCoverArtUpdated(const CoverInfoRelative& coverInfo);
+    void slotWorkerFinished();
 
   private:
     // Called on population or changed via buttons Next&Prev.
@@ -76,6 +82,8 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
     const TrackModel* const m_pTrackModel;
 
     TagFetcher m_tagFetcher;
+
+    bool m_isCoverArtCopyWorkerRunning;
 
     TrackPointer m_track;
 
@@ -98,4 +106,6 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
     Data m_data;
 
     QByteArray m_fetchedCoverArtByteArrays;
+
+    QScopedPointer<CoverArtCopyWorker> m_worker;
 };

--- a/src/library/dlgtagfetcher.h
+++ b/src/library/dlgtagfetcher.h
@@ -29,7 +29,7 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
     void init();
 
   public slots:
-    void loadTrack(const TrackPointer& track);
+    void loadTrack(const TrackPointer& pTrack);
     void loadTrack(const QModelIndex& index);
 
   signals:
@@ -64,15 +64,15 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
     void slotCoverArtLinkNotFound();
     void slotWorkerStarted();
     void slotWorkerAskOverwrite(const QString& coverArtAbsolutePath,
-            std::promise<CoverArtCopyWorker::OverwriteAnswer>* promise);
+            std::promise<CoverArtCopyWorker::OverwriteAnswer>* pPromise);
     void slotWorkerCoverArtCopyFailed(const QString& errorMessage);
     void slotWorkerCoverArtUpdated(const CoverInfoRelative& coverInfo);
     void slotWorkerFinished();
 
   private:
     // Called on population or changed via buttons Next&Prev.
-    void loadTrackInternal(const TrackPointer& track);
-    void addDivider(const QString& text, QTreeWidget* parent) const;
+    void loadTrackInternal(const TrackPointer& pTrack);
+    void addDivider(const QString& text, QTreeWidget* pParent) const;
     void getCoverArt(const QString& url);
     void loadCurrentTrackCover();
 
@@ -84,7 +84,7 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
 
     bool m_isCoverArtCopyWorkerRunning;
 
-    TrackPointer m_track;
+    TrackPointer m_pTrack;
 
     QModelIndex m_currentTrackIndex;
 
@@ -106,5 +106,5 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
 
     QByteArray m_fetchedCoverArtByteArrays;
 
-    QScopedPointer<CoverArtCopyWorker> m_worker;
+    QScopedPointer<CoverArtCopyWorker> m_pWorker;
 };

--- a/src/library/dlgtagfetcher.h
+++ b/src/library/dlgtagfetcher.h
@@ -59,7 +59,6 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
             const QPixmap& pixmap,
             mixxx::cache_key_t requestedCacheKey,
             bool coverInfoUpdated);
-    void slotUpdateStatusMessage(const QString& message);
     void slotStartFetchCoverArt(const QList<QString>& allUrls);
     void slotLoadBytesToLabel(const QByteArray& data);
     void slotCoverArtLinkNotFound();

--- a/src/library/dlgtagfetcher.h
+++ b/src/library/dlgtagfetcher.h
@@ -8,6 +8,10 @@
 #include "library/ui_dlgtagfetcher.h"
 #include "musicbrainz/tagfetcher.h"
 #include "track/track_decl.h"
+#include "track/trackrecord.h"
+#include "util/parented_ptr.h"
+#include "widget/wcoverartlabel.h"
+#include "widget/wcoverartmenu.h"
 
 /// A dialog box to fetch track metadata from MusicBrainz.
 /// Use TrackPointer to load a track into the dialog or
@@ -19,7 +23,7 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
   public:
     // TODO: Remove dependency on TrackModel
     explicit DlgTagFetcher(
-            const TrackModel* pTrackModel = nullptr);
+            UserSettingsPointer pConfig, const TrackModel* pTrackModel = nullptr);
     ~DlgTagFetcher() override = default;
 
     void init();
@@ -49,10 +53,25 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
     void reject() override;
     void slotNext();
     void slotPrev();
+    void slotCoverFound(
+            const QObject* pRequestor,
+            const CoverInfo& coverInfo,
+            const QPixmap& pixmap,
+            mixxx::cache_key_t requestedCacheKey,
+            bool coverInfoUpdated);
+    void slotUpdateStatusMessage(const QString& message);
+    void slotStartFetchCoverArt(const QList<QString>& allUrls);
+    void slotLoadBytesToLabel(const QByteArray& data);
+    void slotCoverArtLinkNotFound();
 
   private:
-    void updateStack();
+    // Called on population or changed via buttons Next&Prev.
+    void loadCurrentTrackCover();
+    void loadTrackInternal(const TrackPointer& track);
     void addDivider(const QString& text, QTreeWidget* parent) const;
+    void getCoverArt(const QString& url);
+
+    UserSettingsPointer m_pConfig;
 
     const TrackModel* const m_pTrackModel;
 
@@ -64,6 +83,14 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
 
     int m_percentForOneRecording;
 
+    parented_ptr<WCoverArtMenu> m_pWCoverArtMenu;
+    parented_ptr<WCoverArtLabel> m_pWCurrentCoverArtLabel;
+    parented_ptr<WCoverArtLabel> m_pWFetchedCoverArtLabel;
+
+    mixxx::TrackRecord m_trackRecord;
+
+    int m_progressBarStep;
+
     struct Data {
         Data()
                 : m_selectedTag(-1) {
@@ -72,4 +99,6 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
         QList<mixxx::musicbrainz::TrackRelease> m_tags;
     };
     Data m_data;
+
+    QByteArray m_fetchedCoverArtByteArrays;
 };

--- a/src/library/dlgtagfetcher.h
+++ b/src/library/dlgtagfetcher.h
@@ -66,10 +66,10 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
 
   private:
     // Called on population or changed via buttons Next&Prev.
-    void loadCurrentTrackCover();
     void loadTrackInternal(const TrackPointer& track);
     void addDivider(const QString& text, QTreeWidget* parent) const;
     void getCoverArt(const QString& url);
+    void loadCurrentTrackCover();
 
     UserSettingsPointer m_pConfig;
 
@@ -83,13 +83,10 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
 
     int m_percentForOneRecording;
 
-    parented_ptr<WCoverArtMenu> m_pWCoverArtMenu;
     parented_ptr<WCoverArtLabel> m_pWCurrentCoverArtLabel;
     parented_ptr<WCoverArtLabel> m_pWFetchedCoverArtLabel;
 
     mixxx::TrackRecord m_trackRecord;
-
-    int m_progressBarStep;
 
     struct Data {
         Data()

--- a/src/library/dlgtagfetcher.ui
+++ b/src/library/dlgtagfetcher.ui
@@ -121,9 +121,12 @@
       </layout>
      </widget>
      <widget class="QWidget" name="results_page">
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <item>
-        <widget class="QLabel" name="label_3">
+      <property name="layoutDirection">
+       <enum>Qt::LeftToRight</enum>
+      </property>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="0">
+        <widget class="QLabel" name="labelSelect">
          <property name="styleSheet">
           <string notr="true">QLabel { font-weight: bold; }</string>
          </property>
@@ -181,14 +184,102 @@
          </column>
         </widget>
        </item>
+       <item row="1" column="4">
+        <layout class="QVBoxLayout" name="coverFetcherLayout">
+         <item>
+          <widget class="QLabel" name="currentCoverLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="styleSheet">
+            <string notr="true">QLabel { font-weight: bold; }</string>
+           </property>
+           <property name="text">
+            <string>Current Cover Art</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QWidget" name="currentCover" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>250</horstretch>
+             <verstretch>250</verstretch>
+            </sizepolicy>
+           </property>
+           <layout class="QVBoxLayout" name="currentCoverArtLayout">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="sizeConstraint">
+             <enum>QLayout::SetDefaultConstraint</enum>
+            </property>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="fetchedCoverLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="styleSheet">
+            <string notr="true">QLabel { font-weight: bold; }</string>
+           </property>
+           <property name="text">
+            <string>Found Cover Art</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QWidget" name="fetchedCover" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>250</horstretch>
+             <verstretch>250</verstretch>
+            </sizepolicy>
+           </property>
+           <layout class="QVBoxLayout" name="fetchedCoverArtLayout">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="sizeConstraint">
+             <enum>QLayout::SetDefaultConstraint</enum>
+            </property>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <spacer name="lowerLabelSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
       </layout>
      </widget>
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_9">
+    <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetMaximumSize</enum>
+       </property>
        <item>
         <widget class="QProgressBar" name="loadingProgressBar">
          <property name="value">
@@ -197,15 +288,44 @@
         </widget>
        </item>
        <item alignment="Qt::AlignHCenter">
-        <widget class="QLabel" name="successMessage">
+        <widget class="QLabel" name="statusMessage">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="layoutDirection">
+          <enum>Qt::LeftToRight</enum>
+         </property>
          <property name="text">
           <string>The results are ready to be applied.</string>
          </property>
         </widget>
        </item>
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Maximum</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20000</width>
+             <height>0</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
       </layout>
      </item>
-     <item>
+     <item alignment="Qt::AlignRight">
       <widget class="QPushButton" name="btnRetry">
        <property name="maximumSize">
         <size>
@@ -221,7 +341,7 @@
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QHBoxLayout" name="btnsLowerLayout">
      <item>
       <widget class="QPushButton" name="btnPrev">
        <property name="text">
@@ -237,10 +357,7 @@
       </widget>
      </item>
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_3"/>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
+      <spacer name="btnSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>

--- a/src/library/dlgtagfetcher.ui
+++ b/src/library/dlgtagfetcher.ui
@@ -135,7 +135,7 @@
          </property>
         </widget>
        </item>
-       <item>
+       <item row="0" column="0">
         <widget class="QTreeWidget" name="tags">
          <property name="editTriggers">
           <set>QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed</set>
@@ -184,7 +184,7 @@
          </column>
         </widget>
        </item>
-       <item row="1" column="4">
+       <item row="0" column="1">
         <layout class="QVBoxLayout" name="coverFetcherLayout">
          <item>
           <widget class="QLabel" name="currentCoverLabel">

--- a/src/library/dlgtagfetcher.ui
+++ b/src/library/dlgtagfetcher.ui
@@ -217,6 +217,21 @@
             <property name="sizeConstraint">
              <enum>QLayout::SetDefaultConstraint</enum>
             </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignCenter</set>
+            </property>
            </layout>
           </widget>
          </item>
@@ -250,6 +265,21 @@
             </property>
             <property name="sizeConstraint">
              <enum>QLayout::SetDefaultConstraint</enum>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignBottom|Qt::AlignCenter</set>
             </property>
            </layout>
           </widget>

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -707,7 +707,7 @@ void DlgTrackInfo::slotTrackChanged(TrackId trackId) {
 void DlgTrackInfo::slotImportMetadataFromMusicBrainz() {
     if (!m_pDlgTagFetcher) {
         m_pDlgTagFetcher = std::make_unique<DlgTagFetcher>(
-                m_pTrackModel);
+                m_pUserSettings, m_pTrackModel);
         connect(m_pDlgTagFetcher.get(),
                 &QDialog::finished,
                 this,

--- a/src/library/export/coverartcopyworker.cpp
+++ b/src/library/export/coverartcopyworker.cpp
@@ -13,6 +13,17 @@ CoverArtCopyWorker::~CoverArtCopyWorker() {
 }
 
 void CoverArtCopyWorker::run() {
+    m_coverInfo.type = CoverInfo::FILE;
+    m_coverInfo.source = CoverInfo::USER_SELECTED;
+
+    if (m_selectedCoverArtFilePath.isEmpty()) {
+        ImageFileData imageFileData = ImageFileData(m_fetchedCoverArtByteArray);
+        m_coverInfo.coverLocation = m_oldCoverArtFilePath;
+        m_coverInfo.setImage(imageFileData);
+        copyFile(QString(), m_oldCoverArtFilePath);
+        return;
+    }
+
     // Create a security token for the file.
     auto selectedCoverFileAccess = mixxx::FileAccess(mixxx::FileInfo(m_selectedCoverArtFilePath));
 
@@ -22,8 +33,6 @@ void CoverArtCopyWorker::run() {
         return;
     }
 
-    m_coverInfo.type = CoverInfo::FILE;
-    m_coverInfo.source = CoverInfo::USER_SELECTED;
     m_coverInfo.coverLocation = m_selectedCoverArtFilePath;
     m_coverInfo.setImage(imageFileData);
 
@@ -43,7 +52,9 @@ void CoverArtCopyWorker::copyFile(
         const QString& m_selectedCoverArtFilePath,
         const QString& m_oldCoverArtFilePath) {
     QFileInfo coverArtPathFileInfo(m_oldCoverArtFilePath);
-    ImageFileData imageFileData = ImageFileData::fromFilePath(m_selectedCoverArtFilePath);
+    ImageFileData imageFileData = m_selectedCoverArtFilePath.isEmpty()
+            ? ImageFileData(m_fetchedCoverArtByteArray)
+            : ImageFileData::fromFilePath(m_selectedCoverArtFilePath);
     QString errorMessage = tr("Error while copying the cover art to: %1")
                                    .arg(m_oldCoverArtFilePath);
     if (coverArtPathFileInfo.exists()) {

--- a/src/library/export/coverartcopyworker.h
+++ b/src/library/export/coverartcopyworker.h
@@ -22,9 +22,11 @@ class CoverArtCopyWorker : public QThread {
     };
 
     CoverArtCopyWorker(const QString& selectedCoverArtFilePath,
-            const QString& oldCoverArtFilePath)
+            const QString& oldCoverArtFilePath,
+            const QByteArray& fetchedCoverArtByteArray = nullptr)
             : m_selectedCoverArtFilePath(selectedCoverArtFilePath),
-              m_oldCoverArtFilePath(oldCoverArtFilePath) {
+              m_oldCoverArtFilePath(oldCoverArtFilePath),
+              m_fetchedCoverArtByteArray(fetchedCoverArtByteArray) {
         qRegisterMetaType<CoverInfoRelative>("CoverInfoRelative");
     }
 
@@ -48,4 +50,5 @@ class CoverArtCopyWorker : public QThread {
     CoverInfoRelative m_coverInfo;
     const QString m_selectedCoverArtFilePath;
     const QString m_oldCoverArtFilePath;
+    const QByteArray m_fetchedCoverArtByteArray;
 };

--- a/src/library/library_prefs.cpp
+++ b/src/library/library_prefs.cpp
@@ -69,3 +69,8 @@ const ConfigKey mixxx::library::prefs::kUseRelativePathOnExportConfigKey =
         ConfigKey{
                 mixxx::library::prefs::kConfigGroup,
                 QStringLiteral("UseRelativePathOnExport")};
+
+const ConfigKey mixxx::library::prefs::kCoverArtFetcherQualityConfigKey =
+        ConfigKey{
+                mixxx::library::prefs::kConfigGroup,
+                QStringLiteral("CoverArtFetcherQuality")};

--- a/src/library/library_prefs.h
+++ b/src/library/library_prefs.h
@@ -40,6 +40,8 @@ extern const ConfigKey kSyncSeratoMetadataConfigKey;
 
 extern const ConfigKey kUseRelativePathOnExportConfigKey;
 
+extern const ConfigKey kCoverArtFetcherQualityConfigKey;
+
 } // namespace prefs
 
 } // namespace library

--- a/src/musicbrainz/tagfetcher.cpp
+++ b/src/musicbrainz/tagfetcher.cpp
@@ -306,8 +306,8 @@ void TagFetcher::slotMusicBrainzTaskSucceeded(
 
 void TagFetcher::startFetchCoverArtLinks(
         const QUuid& albumReleaseId) {
-    //In here the progress message can be handled better.
-    //emit fetchProgress(tr("Finding Possible Cover Arts on Cover Art Archive"));
+    // In here the progress message can be handled better.
+    // emit fetchProgress(tr("Finding Possible Cover Arts on Cover Art Archive"));
     DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
     terminate();
 

--- a/src/musicbrainz/tagfetcher.cpp
+++ b/src/musicbrainz/tagfetcher.cpp
@@ -16,6 +16,12 @@ constexpr int kAcoustIdTimeoutMillis = 60000; // msec
 // Long timeout to cope with occasional server-side unresponsiveness
 constexpr int kMusicBrainzTimeoutMillis = 60000; // msec
 
+// Long timeout to cope with occasional server-side unresponsiveness
+constexpr int kCoverArtArchiveLinksTimeoutMilis = 60000; // msec
+
+// Long timeout to cope with occasional server-side unresponsiveness
+constexpr int kCoverArtArchiveImageTimeoutMilis = 60000; // msec
+
 } // anonymous namespace
 
 TagFetcher::TagFetcher(QObject* parent)
@@ -55,6 +61,14 @@ void TagFetcher::cancel() {
     if (m_pMusicBrainzTask) {
         m_pMusicBrainzTask->invokeAbort();
         DEBUG_ASSERT(!m_pMusicBrainzTask);
+    }
+    if (m_pCoverArtArchiveLinksTask) {
+        m_pCoverArtArchiveLinksTask->invokeAbort();
+        DEBUG_ASSERT(!m_pCoverArtArchiveLinksTask);
+    }
+    if (m_pCoverArtArchiveImageTask) {
+        m_pCoverArtArchiveImageTask->invokeAbort();
+        DEBUG_ASSERT(!m_pCoverArtArchiveImageTask);
     }
 }
 
@@ -276,4 +290,203 @@ void TagFetcher::slotMusicBrainzTaskSucceeded(
     emit resultAvailable(
             std::move(pTrack),
             std::move(guessedTrackReleases));
+}
+
+void TagFetcher::startFetchCoverArtLinks(
+        const QUuid& albumReleaseId) {
+    //In here the progress message can be handled better.
+    //emit fetchProgress(tr("Finding Possible Cover Arts on Cover Art Archive"));
+    DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
+    terminate();
+
+    m_pCoverArtArchiveLinksTask = make_parented<mixxx::CoverArtArchiveLinksTask>(
+            &m_network,
+            std::move(albumReleaseId),
+            this);
+
+    connect(m_pCoverArtArchiveLinksTask,
+            &mixxx::CoverArtArchiveLinksTask::succeeded,
+            this,
+            &TagFetcher::slotCoverArtArchiveLinksTaskSucceeded);
+    connect(m_pCoverArtArchiveLinksTask,
+            &mixxx::CoverArtArchiveLinksTask::failed,
+            this,
+            &TagFetcher::slotCoverArtArchiveLinksTaskFailed);
+    connect(m_pCoverArtArchiveLinksTask,
+            &mixxx::CoverArtArchiveLinksTask::aborted,
+            this,
+            &TagFetcher::slotCoverArtArchiveLinksTaskAborted);
+    connect(m_pCoverArtArchiveLinksTask,
+            &mixxx::CoverArtArchiveLinksTask::networkError,
+            this,
+            &TagFetcher::slotCoverArtArchiveLinksTaskNetworkError);
+
+    m_pCoverArtArchiveLinksTask->invokeStart(
+            kCoverArtArchiveLinksTimeoutMilis);
+}
+
+bool TagFetcher::onCoverArtArchiveLinksTaskTerminated() {
+    DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
+    auto* const pCoverArtArchiveLinksTask = m_pCoverArtArchiveLinksTask.get();
+    DEBUG_ASSERT(sender());
+    VERIFY_OR_DEBUG_ASSERT(pCoverArtArchiveLinksTask ==
+            qobject_cast<mixxx::CoverArtArchiveLinksTask*>(sender())) {
+        return false;
+    }
+    m_pCoverArtArchiveLinksTask = nullptr;
+    const auto taskDeleter = mixxx::ScopedDeleteLater(pCoverArtArchiveLinksTask);
+    pCoverArtArchiveLinksTask->disconnect(this);
+    return true;
+}
+
+void TagFetcher::slotCoverArtArchiveLinksTaskAborted() {
+    DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
+    if (!onCoverArtArchiveLinksTaskTerminated()) {
+        return;
+    }
+
+    terminate();
+}
+
+void TagFetcher::slotCoverArtArchiveLinksTaskNetworkError(
+        QNetworkReply::NetworkError errorCode,
+        const QString& errorString,
+        const mixxx::network::WebResponseWithContent& responseWithContent) {
+    Q_UNUSED(responseWithContent);
+    DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
+    if (!onCoverArtArchiveLinksTaskTerminated()) {
+        return;
+    }
+
+    // (TODO) Handle the error better for Cover Art Archive Links.
+    emit coverArtLinkNotFound();
+    terminate();
+}
+
+void TagFetcher::slotCoverArtArchiveLinksTaskFailed(
+        const mixxx::network::JsonWebResponse& response) {
+    DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
+    if (!onCoverArtArchiveLinksTaskTerminated()) {
+        return;
+    }
+
+    terminate();
+
+    emit networkError(
+            response.statusCode(),
+            "CoverArtArchive",
+            response.content().toJson(),
+            -1);
+}
+
+void TagFetcher::slotCoverArtArchiveLinksTaskSucceeded(
+        const QList<QString>& allUrls) {
+    DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
+    if (!onCoverArtArchiveLinksTaskTerminated()) {
+        return;
+    }
+
+    auto pTrack = std::move(m_pTrack);
+    terminate();
+
+    emit coverArtArchiveLinksAvailable(std::move(allUrls));
+}
+
+void TagFetcher::startFetchCoverArtImage(
+        const QString& coverArtUrl) {
+    m_pCoverArtArchiveImageTask = make_parented<mixxx::CoverArtArchiveImageTask>(
+            &m_network,
+            coverArtUrl,
+            this);
+
+    connect(m_pCoverArtArchiveImageTask,
+            &mixxx::CoverArtArchiveImageTask::succeeded,
+            this,
+            &TagFetcher::slotCoverArtArchiveImageTaskSucceeded);
+    connect(m_pCoverArtArchiveImageTask,
+            &mixxx::CoverArtArchiveImageTask::failed,
+            this,
+            &TagFetcher::slotCoverArtArchiveImageTaskFailed);
+    connect(m_pCoverArtArchiveImageTask,
+            &mixxx::CoverArtArchiveImageTask::aborted,
+            this,
+            &TagFetcher::slotCoverArtArchiveImageTaskAborted);
+    connect(m_pCoverArtArchiveImageTask,
+            &mixxx::CoverArtArchiveImageTask::networkError,
+            this,
+            &TagFetcher::slotCoverArtArchiveImageTaskNetworkError);
+
+    m_pCoverArtArchiveImageTask->invokeStart(
+            kCoverArtArchiveImageTimeoutMilis);
+}
+
+void TagFetcher::slotCoverArtArchiveImageTaskSucceeded(const QByteArray& coverArtBytes) {
+    if (!onCoverArtArchiveImageTaskTerminated()) {
+        return;
+    }
+
+    auto pTrack = std::move(m_pTrack);
+    terminate();
+
+    emit coverArtImageFetchAvailable(coverArtBytes);
+}
+
+void TagFetcher::slotCoverArtArchiveImageTaskAborted() {
+    DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
+    if (!onCoverArtArchiveImageTaskTerminated()) {
+        return;
+    }
+
+    terminate();
+}
+
+bool TagFetcher::onCoverArtArchiveImageTaskTerminated() {
+    DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
+    auto* const pCoverArtArchiveImageTask = m_pCoverArtArchiveImageTask.get();
+    DEBUG_ASSERT(sender());
+    VERIFY_OR_DEBUG_ASSERT(pCoverArtArchiveImageTask ==
+            qobject_cast<mixxx::CoverArtArchiveImageTask*>(sender())) {
+        return false;
+    }
+    m_pCoverArtArchiveImageTask = nullptr;
+    const auto taskDeleter = mixxx::ScopedDeleteLater(pCoverArtArchiveImageTask);
+    pCoverArtArchiveImageTask->disconnect(this);
+    return true;
+}
+
+void TagFetcher::slotCoverArtArchiveImageTaskFailed(
+        const mixxx::network::WebResponse& response,
+        int errorCode,
+        const QString& errorMessage) {
+    DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
+    if (!onCoverArtArchiveImageTaskTerminated()) {
+        return;
+    }
+
+    terminate();
+
+    emit networkError(
+            response.statusCode(),
+            "CoverArtImageTask",
+            errorMessage,
+            errorCode);
+}
+
+void TagFetcher::slotCoverArtArchiveImageTaskNetworkError(
+        QNetworkReply::NetworkError errorCode,
+        const QString& errorString,
+        const mixxx::network::WebResponseWithContent& responseWithContent) {
+    Q_UNUSED(responseWithContent);
+    DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
+    if (!onCoverArtArchiveImageTaskTerminated()) {
+        return;
+    }
+
+    terminate();
+
+    emit networkError(
+            mixxx::network::kHttpStatusCodeInvalid,
+            QStringLiteral("CoverArtArchive"),
+            errorString,
+            errorCode);
 }

--- a/src/musicbrainz/tagfetcher.h
+++ b/src/musicbrainz/tagfetcher.h
@@ -26,18 +26,18 @@ class TagFetcher : public QObject {
     void startFetch(
             TrackPointer pTrack);
 
-    //This is called from dlgTagFetcher.
-    //This starts the initial task for to find the cover art links
-    //4 Possible cover art links fetched in this task.
-    //This can be >1200px-1200px-500px-250px image links.
+    // This is called from dlgTagFetcher.
+    // This starts the initial task for to find the cover art links
+    // 4 Possible cover art links fetched in this task.
+    // This can be >1200px-1200px-500px-250px image links.
     void startFetchCoverArtLinks(const QUuid& albumReleaseId);
 
-    //After the first task is done successfully.
-    //This is called automatically.
-    //This task starts to fetch the image.
-    //Link provided from preference option.
-    //After a success task, related label updated with cover art.
-    //If user presses apply, cover art downloaded and applied to the song.
+    // After the first task is done successfully.
+    // This is called automatically.
+    // This task starts to fetch the image.
+    // Link provided from preference option.
+    // After a success task, related label updated with cover art.
+    // If user presses apply, cover art downloaded and applied to the song.
     void startFetchCoverArtImage(
             const QString& coverArtUrl);
 

--- a/src/musicbrainz/tagfetcher.h
+++ b/src/musicbrainz/tagfetcher.h
@@ -4,6 +4,8 @@
 #include <QObject>
 
 #include "musicbrainz/web/acoustidlookuptask.h"
+#include "musicbrainz/web/coverartarchiveimagetask.h"
+#include "musicbrainz/web/coverartarchivelinkstask.h"
 #include "musicbrainz/web/musicbrainzrecordingstask.h"
 #include "track/track_decl.h"
 #include "util/parented_ptr.h"
@@ -24,6 +26,21 @@ class TagFetcher : public QObject {
     void startFetch(
             TrackPointer pTrack);
 
+    //This is called from dlgTagFetcher.
+    //This starts the initial task for to find the cover art links
+    //4 Possible cover art links fetched in this task.
+    //This can be >1200px-1200px-500px-250px image links.
+    void startFetchCoverArtLinks(const QUuid& albumReleaseId);
+
+    //After the first task is done successfully.
+    //This is called automatically.
+    //This task starts to fetch the image.
+    //Link provided from preference option.
+    //After a success task, related label updated with cover art.
+    //If user presses apply, cover art downloaded and applied to the song.
+    void startFetchCoverArtImage(
+            const QString& coverArtUrl);
+
   public slots:
     void cancel();
 
@@ -40,6 +57,10 @@ class TagFetcher : public QObject {
             const QString& app,
             const QString& message,
             int code);
+    void fetchedCoverUpdate(const QByteArray& coverInfo);
+    void coverArtImageFetchAvailable(const QByteArray& coverArtBytes);
+    void coverArtArchiveLinksAvailable(const QList<QString>& allUrls);
+    void coverArtLinkNotFound();
 
   private slots:
     void slotFingerprintReady();
@@ -66,6 +87,26 @@ class TagFetcher : public QObject {
             const QString& errorString,
             const mixxx::network::WebResponseWithContent& responseWithContent);
 
+    void slotCoverArtArchiveLinksTaskSucceeded(const QList<QString>& allUrls);
+    void slotCoverArtArchiveLinksTaskFailed(
+            const mixxx::network::JsonWebResponse& response);
+    void slotCoverArtArchiveLinksTaskAborted();
+    void slotCoverArtArchiveLinksTaskNetworkError(
+            QNetworkReply::NetworkError errorCode,
+            const QString& errorString,
+            const mixxx::network::WebResponseWithContent& responseWithContent);
+
+    void slotCoverArtArchiveImageTaskSucceeded(const QByteArray& coverArtBytes);
+    void slotCoverArtArchiveImageTaskFailed(
+            const mixxx::network::WebResponse& response,
+            int errorCode,
+            const QString& errorMessage);
+    void slotCoverArtArchiveImageTaskAborted();
+    void slotCoverArtArchiveImageTaskNetworkError(
+            QNetworkReply::NetworkError errorCode,
+            const QString& errorString,
+            const mixxx::network::WebResponseWithContent& responseWithContent);
+
   private:
     void terminate();
 
@@ -76,6 +117,10 @@ class TagFetcher : public QObject {
     parented_ptr<mixxx::AcoustIdLookupTask> m_pAcoustIdTask;
 
     parented_ptr<mixxx::MusicBrainzRecordingsTask> m_pMusicBrainzTask;
+
+    parented_ptr<mixxx::CoverArtArchiveLinksTask> m_pCoverArtArchiveLinksTask;
+
+    parented_ptr<mixxx::CoverArtArchiveImageTask> m_pCoverArtArchiveImageTask;
 
     TrackPointer m_pTrack;
 };

--- a/src/musicbrainz/web/coverartarchiveimagetask.cpp
+++ b/src/musicbrainz/web/coverartarchiveimagetask.cpp
@@ -63,10 +63,49 @@ void CoverArtArchiveImageTask::doNetworkReplyFinished(
         kLogger.info()
                 << "GET reply"
                 << "statusCode:" << statusCode;
+        emitFailed(
+                network::WebResponse(
+                        pFinishedNetworkReply->url(),
+                        pFinishedNetworkReply->request().url(),
+                        statusCode),
+                statusCode,
+                QStringLiteral("Failed to get Image"));
         return;
     }
 
-    emit succeeded(resultImageBytes);
+    emitSucceeded(resultImageBytes);
+}
+
+void CoverArtArchiveImageTask::emitSucceeded(
+        const QByteArray& coverArtImageBytes) {
+    VERIFY_OR_DEBUG_ASSERT(
+            isSignalFuncConnected(&CoverArtArchiveImageTask::succeeded)) {
+        kLogger.warning()
+                << "Unhandled succeeded signal";
+        deleteLater();
+        return;
+    }
+    emit succeeded(coverArtImageBytes);
+}
+
+void CoverArtArchiveImageTask::emitFailed(
+        const network::WebResponse& response,
+        int errorCode,
+        const QString& errorMessage) {
+    VERIFY_OR_DEBUG_ASSERT(
+            isSignalFuncConnected(&CoverArtArchiveImageTask::failed)) {
+        kLogger.warning()
+                << "Unhandled failed signal"
+                << response
+                << errorCode
+                << errorMessage;
+        deleteLater();
+        return;
+    }
+    emit failed(
+            response,
+            errorCode,
+            errorMessage);
 }
 
 } // namespace mixxx

--- a/src/musicbrainz/web/coverartarchiveimagetask.cpp
+++ b/src/musicbrainz/web/coverartarchiveimagetask.cpp
@@ -25,21 +25,21 @@ QNetworkRequest createNetworkRequest(const QString& coverArtUrl) {
 } // anonymous namespace
 
 CoverArtArchiveImageTask::CoverArtArchiveImageTask(
-        QNetworkAccessManager* networkAccessManager,
+        QNetworkAccessManager* pNetworkAccessManager,
         const QString& coverArtLink,
-        QObject* parent)
+        QObject* pParent)
         : network::WebTask(
-                  networkAccessManager,
-                  parent),
+                  pNetworkAccessManager,
+                  pParent),
           m_coverArtUrl(coverArtLink) {
 }
 
 QNetworkReply* CoverArtArchiveImageTask::doStartNetworkRequest(
-        QNetworkAccessManager* networkAccessManager,
+        QNetworkAccessManager* pNetworkAccessManager,
         int parentTimeoutMillis) {
-    networkAccessManager->setRedirectPolicy(QNetworkRequest::NoLessSafeRedirectPolicy);
+    pNetworkAccessManager->setRedirectPolicy(QNetworkRequest::NoLessSafeRedirectPolicy);
     DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
-    DEBUG_ASSERT(networkAccessManager);
+    DEBUG_ASSERT(pNetworkAccessManager);
 
     const QNetworkRequest networkRequest =
             createNetworkRequest(m_coverArtUrl);
@@ -49,15 +49,15 @@ QNetworkReply* CoverArtArchiveImageTask::doStartNetworkRequest(
                 << "GET"
                 << networkRequest.url();
     }
-    return networkAccessManager->get(networkRequest);
+    return pNetworkAccessManager->get(networkRequest);
 }
 
 void CoverArtArchiveImageTask::doNetworkReplyFinished(
-        QNetworkReply* finishedNetworkReply,
+        QNetworkReply* pFinishedNetworkReply,
         network::HttpStatusCode statusCode) {
     DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
 
-    const QByteArray resultImageBytes = finishedNetworkReply->readAll();
+    const QByteArray resultImageBytes = pFinishedNetworkReply->readAll();
 
     if (statusCode != 200) {
         kLogger.info()

--- a/src/musicbrainz/web/coverartarchiveimagetask.cpp
+++ b/src/musicbrainz/web/coverartarchiveimagetask.cpp
@@ -1,0 +1,72 @@
+#include "musicbrainz/web/coverartarchiveimagetask.h"
+
+#include <QMetaMethod>
+
+#include "defs_urls.h"
+#include "network/httpstatuscode.h"
+#include "util/assert.h"
+#include "util/logger.h"
+#include "util/thread_affinity.h"
+#include "util/versionstore.h"
+
+namespace mixxx {
+
+namespace {
+
+const Logger kLogger("CoverArtArchiveImageTask");
+
+QNetworkRequest createNetworkRequest(const QString& coverArtUrl) {
+    QUrl url = coverArtUrl;
+    DEBUG_ASSERT(url.isValid());
+    QNetworkRequest networkRequest(url);
+    return networkRequest;
+}
+
+} // anonymous namespace
+
+CoverArtArchiveImageTask::CoverArtArchiveImageTask(
+        QNetworkAccessManager* networkAccessManager,
+        const QString& coverArtLink,
+        QObject* parent)
+        : network::WebTask(
+                  networkAccessManager,
+                  parent),
+          m_coverArtUrl(coverArtLink) {
+}
+
+QNetworkReply* CoverArtArchiveImageTask::doStartNetworkRequest(
+        QNetworkAccessManager* networkAccessManager,
+        int parentTimeoutMillis) {
+    networkAccessManager->setRedirectPolicy(QNetworkRequest::NoLessSafeRedirectPolicy);
+    DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
+    DEBUG_ASSERT(networkAccessManager);
+
+    const QNetworkRequest networkRequest =
+            createNetworkRequest(m_coverArtUrl);
+
+    if (kLogger.traceEnabled()) {
+        kLogger.trace()
+                << "GET"
+                << networkRequest.url();
+    }
+    return networkAccessManager->get(networkRequest);
+}
+
+void CoverArtArchiveImageTask::doNetworkReplyFinished(
+        QNetworkReply* finishedNetworkReply,
+        network::HttpStatusCode statusCode) {
+    DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
+
+    const QByteArray resultImageBytes = finishedNetworkReply->readAll();
+
+    if (statusCode != 200) {
+        kLogger.info()
+                << "GET reply"
+                << "statusCode:" << statusCode;
+        return;
+    }
+
+    emit succeeded(resultImageBytes);
+}
+
+} // namespace mixxx

--- a/src/musicbrainz/web/coverartarchiveimagetask.h
+++ b/src/musicbrainz/web/coverartarchiveimagetask.h
@@ -32,6 +32,13 @@ class CoverArtArchiveImageTask : public network::WebTask {
             QNetworkReply* pFinishedNetworkReply,
             network::HttpStatusCode statusCode) override;
 
+    void emitSucceeded(const QByteArray& coverArtImageBytes);
+
+    void emitFailed(
+            const network::WebResponse& response,
+            int errorCode,
+            const QString& errorMessage);
+
     QString m_coverArtUrl;
 
     QByteArray coverArtImageBytes;

--- a/src/musicbrainz/web/coverartarchiveimagetask.h
+++ b/src/musicbrainz/web/coverartarchiveimagetask.h
@@ -9,9 +9,9 @@ class CoverArtArchiveImageTask : public network::WebTask {
 
   public:
     CoverArtArchiveImageTask(
-            QNetworkAccessManager* networkAccessManager,
+            QNetworkAccessManager* pNetworkAccessManager,
             const QString& coverArtLink,
-            QObject* parent = nullptr);
+            QObject* pParent = nullptr);
     ~CoverArtArchiveImageTask() override = default;
 
   signals:
@@ -25,11 +25,11 @@ class CoverArtArchiveImageTask : public network::WebTask {
 
   private:
     QNetworkReply* doStartNetworkRequest(
-            QNetworkAccessManager* networkAccessManager,
+            QNetworkAccessManager* pNetworkAccessManager,
             int parentTimeoutMillis) override;
 
     void doNetworkReplyFinished(
-            QNetworkReply* finishedNetworkReply,
+            QNetworkReply* pFinishedNetworkReply,
             network::HttpStatusCode statusCode) override;
 
     QString m_coverArtUrl;

--- a/src/musicbrainz/web/coverartarchiveimagetask.h
+++ b/src/musicbrainz/web/coverartarchiveimagetask.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "network/webtask.h"
+
+namespace mixxx {
+
+class CoverArtArchiveImageTask : public network::WebTask {
+    Q_OBJECT
+
+  public:
+    CoverArtArchiveImageTask(
+            QNetworkAccessManager* networkAccessManager,
+            const QString& coverArtLink,
+            QObject* parent = nullptr);
+    ~CoverArtArchiveImageTask() override = default;
+
+  signals:
+    void succeeded(
+            const QByteArray& coverArtImageBytes);
+
+    void failed(
+            const network::WebResponse& response,
+            int errorCode,
+            const QString& errorMessage);
+
+  private:
+    QNetworkReply* doStartNetworkRequest(
+            QNetworkAccessManager* networkAccessManager,
+            int parentTimeoutMillis) override;
+
+    void doNetworkReplyFinished(
+            QNetworkReply* finishedNetworkReply,
+            network::HttpStatusCode statusCode) override;
+
+    QString m_coverArtUrl;
+
+    QByteArray coverArtImageBytes;
+};
+
+} // namespace mixxx

--- a/src/musicbrainz/web/coverartarchivelinkstask.cpp
+++ b/src/musicbrainz/web/coverartarchivelinkstask.cpp
@@ -1,0 +1,158 @@
+#include "musicbrainz/web/coverartarchivelinkstask.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkRequest>
+
+#include "network/httpstatuscode.h"
+#include "util/assert.h"
+#include "util/logger.h"
+
+namespace mixxx {
+
+namespace {
+
+const Logger kLogger("CoverArtArchiveLinksTask");
+
+const QUrl kBaseUrl = QStringLiteral("https://coverartarchive.org/");
+
+const QString kRequestPath = QStringLiteral("/release/");
+
+network::JsonWebRequest lookupRequest() {
+    return network::JsonWebRequest{
+            network::HttpRequestMethod::Get,
+            kRequestPath,
+            QUrlQuery(),
+            QJsonDocument()};
+}
+
+QNetworkRequest createNetworkRequest(
+        const QUuid& releaseID) {
+    DEBUG_ASSERT(kBaseUrl.isValid());
+    DEBUG_ASSERT(!releaseID.isNull());
+    QUrl url = kBaseUrl;
+    url.setPath(kRequestPath + releaseID.toString(QUuid::WithoutBraces));
+    DEBUG_ASSERT(url.isValid());
+    QNetworkRequest networkRequest(url);
+    return networkRequest;
+}
+
+} // anonymous namespace
+
+CoverArtArchiveLinksTask::CoverArtArchiveLinksTask(
+        QNetworkAccessManager* networkAccessManager,
+        const QUuid& albumReleaseId,
+        QObject* parent)
+        : network::JsonWebTask(
+                  networkAccessManager,
+                  kBaseUrl,
+                  lookupRequest(),
+                  parent),
+          m_albumReleaseId(albumReleaseId) {
+}
+
+QNetworkReply* CoverArtArchiveLinksTask::sendNetworkRequest(
+        QNetworkAccessManager* networkAccessManager,
+        network::HttpRequestMethod method,
+        const QUrl& url,
+        const QJsonDocument& content) {
+    DEBUG_ASSERT(networkAccessManager);
+    //DEBUG_ASSERT(!m_queuedAlbumReleaseIds.first().isNull());
+    Q_UNUSED(method);
+    DEBUG_ASSERT(method == network::HttpRequestMethod::Get);
+    networkAccessManager->setRedirectPolicy(QNetworkRequest::NoLessSafeRedirectPolicy);
+
+    const QNetworkRequest networkRequest = createNetworkRequest(m_albumReleaseId);
+
+    VERIFY_OR_DEBUG_ASSERT(url.isValid()) {
+        kLogger.warning() << "Invalid URL" << url;
+        return nullptr;
+    }
+    if (kLogger.traceEnabled()) {
+        kLogger.trace()
+                << "Get"
+                << url;
+    }
+    return networkAccessManager->get(networkRequest);
+}
+
+void CoverArtArchiveLinksTask::onFinished(
+        const network::JsonWebResponse& response) {
+    if (!response.isStatusCodeSuccess()) {
+        kLogger.warning()
+                << "Request failed with HTTP status code"
+                << response.statusCode();
+        emitFailed(response);
+        return;
+    }
+    VERIFY_OR_DEBUG_ASSERT(response.statusCode() == network::kHttpStatusCodeOk) {
+        kLogger.warning()
+                << "Unexpected HTTP status code"
+                << response.statusCode();
+        emitFailed(response);
+        return;
+    }
+    VERIFY_OR_DEBUG_ASSERT(response.content().isObject()) {
+        kLogger.warning()
+                << "Invalid JSON content"
+                << response.content();
+        emitFailed(response);
+        return;
+    }
+    const auto jsonObject = response.content().object();
+
+    if (jsonObject.isEmpty()) {
+        kLogger.warning()
+                << "Empty Json";
+        emitFailed(response);
+        return;
+    }
+
+    QList<QString> allUrls;
+    DEBUG_ASSERT(jsonObject.value(QLatin1String("images")).isArray());
+    const QJsonArray images = jsonObject.value(QLatin1String("images")).toArray();
+    for (const auto& image : images) {
+        DEBUG_ASSERT(image.isObject());
+        const auto imageObject = image.toObject();
+
+        const auto thumbnails = imageObject.value(QLatin1String("thumbnails")).toObject();
+        DEBUG_ASSERT(!thumbnails.isEmpty());
+
+        const auto smallThumbnailUrl = thumbnails.value(QLatin1String("small")).toString();
+        DEBUG_ASSERT(!smallThumbnailUrl.isNull());
+        allUrls.append(smallThumbnailUrl);
+
+        const auto largeThumbnailUrl = thumbnails.value(QLatin1String("large")).toString();
+        DEBUG_ASSERT(!largeThumbnailUrl.isNull());
+        allUrls.append(largeThumbnailUrl);
+
+        if (thumbnails.value(QLatin1String("1200")).toString() != nullptr) {
+            const auto largestThumbnailUrl = thumbnails.value(QLatin1String("1200")).toString();
+            allUrls.append(largestThumbnailUrl);
+        }
+
+        if (!(imageObject.value(QLatin1String("image")).isNull())) {
+            const auto highestResolutionImageUrl =
+                    imageObject.value(QLatin1String("image")).toString();
+            allUrls.append(highestResolutionImageUrl);
+        }
+
+        break;
+    }
+    emitSucceeded(allUrls);
+}
+
+void CoverArtArchiveLinksTask::emitSucceeded(
+        const QList<QString>& allUrls) {
+    VERIFY_OR_DEBUG_ASSERT(
+            isSignalFuncConnected(&CoverArtArchiveLinksTask::succeeded)) {
+        kLogger.warning()
+                << "Unhandled succeeded signal";
+        deleteLater();
+        return;
+    }
+    emit succeeded(allUrls);
+}
+
+} // namespace mixxx

--- a/src/musicbrainz/web/coverartarchivelinkstask.cpp
+++ b/src/musicbrainz/web/coverartarchivelinkstask.cpp
@@ -41,26 +41,26 @@ QNetworkRequest createNetworkRequest(
 } // anonymous namespace
 
 CoverArtArchiveLinksTask::CoverArtArchiveLinksTask(
-        QNetworkAccessManager* networkAccessManager,
+        QNetworkAccessManager* pNetworkAccessManager,
         const QUuid& albumReleaseId,
-        QObject* parent)
+        QObject* pParent)
         : network::JsonWebTask(
-                  networkAccessManager,
+                  pNetworkAccessManager,
                   kBaseUrl,
                   lookupRequest(),
-                  parent),
+                  pParent),
           m_albumReleaseId(albumReleaseId) {
 }
 
 QNetworkReply* CoverArtArchiveLinksTask::sendNetworkRequest(
-        QNetworkAccessManager* networkAccessManager,
+        QNetworkAccessManager* pNetworkAccessManager,
         network::HttpRequestMethod method,
         const QUrl& url,
         const QJsonDocument& content) {
-    DEBUG_ASSERT(networkAccessManager);
+    DEBUG_ASSERT(pNetworkAccessManager);
     Q_UNUSED(method);
     DEBUG_ASSERT(method == network::HttpRequestMethod::Get);
-    networkAccessManager->setRedirectPolicy(QNetworkRequest::NoLessSafeRedirectPolicy);
+    pNetworkAccessManager->setRedirectPolicy(QNetworkRequest::NoLessSafeRedirectPolicy);
 
     const QNetworkRequest networkRequest = createNetworkRequest(m_albumReleaseId);
 
@@ -73,7 +73,7 @@ QNetworkReply* CoverArtArchiveLinksTask::sendNetworkRequest(
                 << "Get"
                 << url;
     }
-    return networkAccessManager->get(networkRequest);
+    return pNetworkAccessManager->get(networkRequest);
 }
 
 void CoverArtArchiveLinksTask::onFinished(

--- a/src/musicbrainz/web/coverartarchivelinkstask.cpp
+++ b/src/musicbrainz/web/coverartarchivelinkstask.cpp
@@ -58,7 +58,6 @@ QNetworkReply* CoverArtArchiveLinksTask::sendNetworkRequest(
         const QUrl& url,
         const QJsonDocument& content) {
     DEBUG_ASSERT(networkAccessManager);
-    //DEBUG_ASSERT(!m_queuedAlbumReleaseIds.first().isNull());
     Q_UNUSED(method);
     DEBUG_ASSERT(method == network::HttpRequestMethod::Get);
     networkAccessManager->setRedirectPolicy(QNetworkRequest::NoLessSafeRedirectPolicy);

--- a/src/musicbrainz/web/coverartarchivelinkstask.cpp
+++ b/src/musicbrainz/web/coverartarchivelinkstask.cpp
@@ -108,6 +108,10 @@ void CoverArtArchiveLinksTask::onFinished(
         return;
     }
 
+    // An example JSON schema can be found for the release: 48cf6a4e-4c61-4214-afe3-ed4e11d902c9
+    // JSON Schema: https://coverartarchive.org/release/48cf6a4e-4c61-4214-afe3-ed4e11d902c9
+    // See also: https://wiki.musicbrainz.org/Cover_Art_Archive/API
+
     QList<QString> allUrls;
     DEBUG_ASSERT(jsonObject.value(QLatin1String("images")).isArray());
     const QJsonArray images = jsonObject.value(QLatin1String("images")).toArray();
@@ -117,6 +121,10 @@ void CoverArtArchiveLinksTask::onFinished(
 
         const auto thumbnails = imageObject.value(QLatin1String("thumbnails")).toObject();
         DEBUG_ASSERT(!thumbnails.isEmpty());
+
+        // Due to few exceptions encountered
+        // For 250 PX and 500 PX cover arts, "small" and "large" keys are used.
+        // See: https://coverartarchive.org/release/5240094f-9d79-44fd-9985-77c7287bcc16
 
         const auto smallThumbnailUrl = thumbnails.value(QLatin1String("small")).toString();
         DEBUG_ASSERT(!smallThumbnailUrl.isNull());

--- a/src/musicbrainz/web/coverartarchivelinkstask.h
+++ b/src/musicbrainz/web/coverartarchivelinkstask.h
@@ -14,9 +14,9 @@ class CoverArtArchiveLinksTask : public network::JsonWebTask {
 
   public:
     CoverArtArchiveLinksTask(
-            QNetworkAccessManager* networkAccessManager,
+            QNetworkAccessManager* pNetworkAccessManager,
             const QUuid& albumReleaseId,
-            QObject* parent = nullptr);
+            QObject* pParent = nullptr);
 
     ~CoverArtArchiveLinksTask() override = default;
 
@@ -26,7 +26,7 @@ class CoverArtArchiveLinksTask : public network::JsonWebTask {
 
   private:
     QNetworkReply* sendNetworkRequest(
-            QNetworkAccessManager* networkAccessManager,
+            QNetworkAccessManager* pNetworkAccessManager,
             network::HttpRequestMethod method,
             const QUrl& url,
             const QJsonDocument& content) override;

--- a/src/musicbrainz/web/coverartarchivelinkstask.h
+++ b/src/musicbrainz/web/coverartarchivelinkstask.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <QList>
+#include <QMap>
+#include <QString>
+#include <QUuid>
+
+#include "network/jsonwebtask.h"
+
+namespace mixxx {
+
+class CoverArtArchiveLinksTask : public network::JsonWebTask {
+    Q_OBJECT
+
+  public:
+    CoverArtArchiveLinksTask(
+            QNetworkAccessManager* networkAccessManager,
+            const QUuid& albumReleaseId,
+            QObject* parent = nullptr);
+
+    ~CoverArtArchiveLinksTask() override = default;
+
+  signals:
+    void succeeded(
+            const QList<QString>& allUrls);
+
+  private:
+    QNetworkReply* sendNetworkRequest(
+            QNetworkAccessManager* networkAccessManager,
+            network::HttpRequestMethod method,
+            const QUrl& url,
+            const QJsonDocument& content) override;
+
+    void onFinished(
+            const network::JsonWebResponse& response) override;
+
+    void emitSucceeded(const QList<QString>& allUrls);
+
+    QUuid m_albumReleaseId;
+
+    QList<QString> m_allThumbnailUrls;
+};
+
+} // namespace mixxx

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -206,6 +206,10 @@ void DlgPrefLibrary::slotResetToDefaults() {
     radioButton_dbclick_bottom->setChecked(false);
     radioButton_dbclick_top->setChecked(false);
     radioButton_dbclick_deck->setChecked(true);
+    radioButton_cover_art_fetcher_highest->setChecked(false);
+    radioButton_cover_art_fetcher_high->setChecked(false);
+    radioButton_cover_art_fetcher_medium->setChecked(false);
+    radioButton_cover_art_fetcher_lowest->setChecked(true);
     spinBoxRowHeight->setValue(Library::kDefaultRowHeightPx);
     setLibraryFont(QApplication::font());
     searchDebouncingTimeoutSpinBox->setValue(
@@ -258,6 +262,23 @@ void DlgPrefLibrary::slotUpdate() {
         break;
     default:
         radioButton_dbclick_deck->setChecked(true);
+        break;
+    }
+
+    switch (m_pConfig->getValue<int>(
+            kCoverArtFetcherQualityConfigKey,
+            static_cast<int>(CoverArtFetcherQuality::Low))) {
+    case static_cast<int>(CoverArtFetcherQuality::Highest):
+        radioButton_cover_art_fetcher_highest->setChecked(true);
+        break;
+    case static_cast<int>(CoverArtFetcherQuality::High):
+        radioButton_cover_art_fetcher_high->setChecked(true);
+        break;
+    case static_cast<int>(CoverArtFetcherQuality::Medium):
+        radioButton_cover_art_fetcher_medium->setChecked(true);
+        break;
+    default:
+        radioButton_cover_art_fetcher_lowest->setChecked(true);
         break;
     }
 
@@ -425,6 +446,18 @@ void DlgPrefLibrary::slotApply() {
                 ConfigValue((int)checkBox_show_rekordbox->isChecked()));
     m_pConfig->set(ConfigKey("[Library]", "ShowSeratoLibrary"),
             ConfigValue((int)checkBox_show_serato->isChecked()));
+
+    int coverartfetcherquality_status;
+    if (radioButton_cover_art_fetcher_highest->isChecked()) {
+        coverartfetcherquality_status = static_cast<int>(CoverArtFetcherQuality::Highest);
+    } else if (radioButton_cover_art_fetcher_high->isChecked()) {
+        coverartfetcherquality_status = static_cast<int>(CoverArtFetcherQuality::High);
+    } else if (radioButton_cover_art_fetcher_medium->isChecked()) {
+        coverartfetcherquality_status = static_cast<int>(CoverArtFetcherQuality::Medium);
+    } else {
+        coverartfetcherquality_status = static_cast<int>(CoverArtFetcherQuality::Low);
+    }
+    m_pConfig->set(kCoverArtFetcherQualityConfigKey, ConfigValue(coverartfetcherquality_status));
 
     int dbclick_status;
     if (radioButton_dbclick_bottom->isChecked()) {

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -203,12 +203,7 @@ void DlgPrefLibrary::slotResetToDefaults() {
     checkBox_show_traktor->setChecked(true);
     checkBox_show_rekordbox->setChecked(true);
     checkBoxEditMetadataSelectedClicked->setChecked(kEditMetadataSelectedClickDefault);
-    radioButton_dbclick_bottom->setChecked(false);
-    radioButton_dbclick_top->setChecked(false);
     radioButton_dbclick_deck->setChecked(true);
-    radioButton_cover_art_fetcher_highest->setChecked(false);
-    radioButton_cover_art_fetcher_high->setChecked(false);
-    radioButton_cover_art_fetcher_medium->setChecked(false);
     radioButton_cover_art_fetcher_lowest->setChecked(true);
     spinBoxRowHeight->setValue(Library::kDefaultRowHeightPx);
     setLibraryFont(QApplication::font());

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -204,7 +204,7 @@ void DlgPrefLibrary::slotResetToDefaults() {
     checkBox_show_rekordbox->setChecked(true);
     checkBoxEditMetadataSelectedClicked->setChecked(kEditMetadataSelectedClickDefault);
     radioButton_dbclick_deck->setChecked(true);
-    radioButton_cover_art_fetcher_lowest->setChecked(true);
+    radioButton_cover_art_fetcher_medium->setChecked(true);
     spinBoxRowHeight->setValue(Library::kDefaultRowHeightPx);
     setLibraryFont(QApplication::font());
     searchDebouncingTimeoutSpinBox->setValue(

--- a/src/preferences/dialog/dlgpreflibrary.h
+++ b/src/preferences/dialog/dlgpreflibrary.h
@@ -20,6 +20,13 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
         Ignore = 3,
     };
 
+    enum class CoverArtFetcherQuality : int {
+        Low = 0,
+        Medium = 1,
+        High = 2,
+        Highest = 3,
+    };
+
     DlgPrefLibrary(
             QWidget* pParent,
             UserSettingsPointer pConfig,

--- a/src/preferences/dialog/dlgpreflibrary.h
+++ b/src/preferences/dialog/dlgpreflibrary.h
@@ -20,7 +20,7 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
         Ignore = 3,
     };
 
-    enum class CoverArtFetcherQuality : int {
+    enum class CoverArtFetcherQuality {
         Low = 0,
         Medium = 1,
         High = 2,

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -455,56 +455,56 @@
    <item>
     <widget class="QGroupBox" name="groupBox_cover_art_fetcher">
      <property name="title">
-      <string>Cover Art Fetcher</string>
+      <string>Preferred Cover Art Fetcher Resolution</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_cover_art_fetcher">
       <item row="0" column="0">
-       <widget class="QRadioButton" name="radioButton_cover_art_fetcher_highest">
-        <property name="text">
-         <string>Highest</string>
-        </property>
-        <property name="checked">
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QRadioButton" name="radioButton_cover_art_fetcher_high">
-        <property name="text">
-         <string>High</string>
-        </property>
-        <property name="checked">
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QRadioButton" name="radioButton_cover_art_fetcher_medium">
-        <property name="text">
-         <string>Medium</string>
-        </property>
-        <property name="checked">
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QRadioButton" name="radioButton_cover_art_fetcher_lowest">
-        <property name="text">
-         <string>Low</string>
-        </property>
-        <property name="checked">
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
        <widget class="QLabel" name="label_12">
         <property name="text">
          <string>Fetch cover art from coverartarchive.com by using Import Metadata From Musicbrainz.</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="label_13">
         <property name="text">
-         <string>Highest resolution can fetch up to very large cover arts. </string>
+         <string>Note: ">1200 px" can fetch up to very large cover arts.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QRadioButton" name="radioButton_cover_art_fetcher_highest">
+        <property name="text">
+         <string>>1200 px (if available)</string>
+        </property>
+        <property name="checked">
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QRadioButton" name="radioButton_cover_art_fetcher_high">
+        <property name="text">
+         <string>1200 px (if available)</string>
+        </property>
+        <property name="checked">
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QRadioButton" name="radioButton_cover_art_fetcher_medium">
+        <property name="text">
+         <string>500 px</string>
+        </property>
+        <property name="checked">
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QRadioButton" name="radioButton_cover_art_fetcher_lowest">
+        <property name="text">
+         <string>250 px</string>
+        </property>
+        <property name="checked">
         </property>
        </widget>
       </item>

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -442,9 +442,69 @@
        </widget>
       </item>
       <item row="7" column="0">
-       <widget class="QLabel" name="label_10">
+       <widget class="QLabel" name="label_11">
         <property name="text">
          <string>You will need to restart Mixxx for these settings to take effect.</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+
+   <item>
+    <widget class="QGroupBox" name="groupBox_cover_art_fetcher">
+     <property name="title">
+      <string>Cover Art Fetcher</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_cover_art_fetcher">
+      <item row="0" column="0">
+       <widget class="QRadioButton" name="radioButton_cover_art_fetcher_highest">
+        <property name="text">
+         <string>Highest</string>
+        </property>
+        <property name="checked">
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QRadioButton" name="radioButton_cover_art_fetcher_high">
+        <property name="text">
+         <string>High</string>
+        </property>
+        <property name="checked">
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QRadioButton" name="radioButton_cover_art_fetcher_medium">
+        <property name="text">
+         <string>Medium</string>
+        </property>
+        <property name="checked">
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QRadioButton" name="radioButton_cover_art_fetcher_lowest">
+        <property name="text">
+         <string>Low</string>
+        </property>
+        <property name="checked">
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_12">
+        <property name="text">
+         <string>Fetch cover art from coverartarchive.com by using Import Metadata From Musicbrainz.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_13">
+        <property name="text">
+         <string>Highest resolution can fetch up to very large cover arts. </string>
         </property>
        </widget>
       </item>
@@ -546,6 +606,10 @@
   <tabstop>checkBox_show_traktor</tabstop>
   <tabstop>checkBox_show_rekordbox</tabstop>
   <tabstop>checkBox_show_serato</tabstop>
+  <tabstop>radioButton_cover_art_fetcher_highest</tabstop>
+  <tabstop>radioButton_cover_art_fetcher_high</tabstop>
+  <tabstop>radioButton_cover_art_fetcher_medium</tabstop>
+  <tabstop>radioButton_cover_art_fetcher_lowest</tabstop>
   <tabstop>PushButtonOpenSettingsDir</tabstop>
  </tabstops>
  <resources/>

--- a/src/util/imagefiledata.cpp
+++ b/src/util/imagefiledata.cpp
@@ -50,10 +50,10 @@ bool ImageFileData::saveFile(const QString& coverArtAbsoluteFilePath) const {
     }
 
     if (QFileInfo(coverArtAbsoluteFilePath).suffix() != m_coverArtFormat) {
-        qWarning() << "Cover Art format and extension does not match"
-                   << "format"
+        qWarning() << "Cover Art format and extension does not match!"
+                   << "Cover art format:"
                    << m_coverArtFormat
-                   << "extension"
+                   << "File extension:"
                    << QFileInfo(coverArtAbsoluteFilePath).suffix();
         return save(coverArtAbsoluteFilePath);
     }

--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -84,6 +84,10 @@ void WCoverArtLabel::loadTrack(TrackPointer pTrack) {
     m_pLoadedTrack = pTrack;
 }
 
+void WCoverArtLabel::loadData(const QByteArray& data) {
+    m_Data = data;
+}
+
 void WCoverArtLabel::mousePressEvent(QMouseEvent* event) {
     if (m_pCoverMenu != nullptr && m_pCoverMenu->isVisible()) {
         return;
@@ -92,8 +96,14 @@ void WCoverArtLabel::mousePressEvent(QMouseEvent* event) {
     if (event->button() == Qt::LeftButton) {
         if (m_pDlgFullSize->isVisible()) {
             m_pDlgFullSize->close();
-        } else if (!m_loadedCover.isNull()) {
-            m_pDlgFullSize->init(m_pLoadedTrack);
+        } else {
+            if (m_loadedCover.isNull()) {
+                return;
+            } else if (!m_pLoadedTrack && !m_Data.isNull()) {
+                m_pDlgFullSize->init(m_Data);
+            } else {
+                m_pDlgFullSize->init(m_pLoadedTrack);
+            }
         }
     }
 }

--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -100,7 +100,7 @@ void WCoverArtLabel::mousePressEvent(QMouseEvent* event) {
             if (m_loadedCover.isNull()) {
                 return;
             } else if (!m_pLoadedTrack && !m_Data.isNull()) {
-                m_pDlgFullSize->init(m_Data);
+                m_pDlgFullSize->initFetchedCoverArt(m_Data);
             } else {
                 m_pDlgFullSize->init(m_pLoadedTrack);
             }

--- a/src/widget/wcoverartlabel.h
+++ b/src/widget/wcoverartlabel.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QByteArray>
 #include <QLabel>
 #include <QMouseEvent>
 #include <QPixmap>
@@ -22,6 +23,7 @@ class WCoverArtLabel : public QLabel {
 
     void setCoverArt(const CoverInfo& coverInfo, const QPixmap& px);
     void loadTrack(TrackPointer pTrack);
+    void loadData(const QByteArray& data);
 
   protected:
     void mousePressEvent(QMouseEvent* event) override;
@@ -36,6 +38,8 @@ class WCoverArtLabel : public QLabel {
     const parented_ptr<DlgCoverArtFullSize> m_pDlgFullSize;
 
     const QPixmap m_defaultCover;
+
+    QByteArray m_Data;
 
     TrackPointer m_pLoadedTrack;
 

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -2117,7 +2117,7 @@ void WTrackMenu::slotShowDlgTagFetcher() {
     }
     // Create a fresh dialog on invocation
     m_pDlgTagFetcher = std::make_unique<DlgTagFetcher>(
-            m_pTrackModel);
+            m_pConfig, m_pTrackModel);
     connect(m_pDlgTagFetcher.get(),
             &QDialog::finished,
             this,


### PR DESCRIPTION
Hey everyone!

My goal is to get cover arts of the tracks by using `coverartarchive` on the "Import Metadata from Musicbrainz" menu, aka Tag Fetcher Menu. I am working on this feature right now. This is the initial PR to get your ideas-thoughts and of course feedback about the GUI of this feature. More information about this PR can be found on our Zulip chat https://mixxx.zulipchat.com/#narrow/stream/109215-gsoc/topic/cover.20art.20lookup

This is the first interaction for now. I have displayed the existing cover art of the track on the Tag Fetcher Menu. The Tag Fetcher Menu seems like this. ![Tag Fetcher Menu](https://user-images.githubusercontent.com/67206006/178327695-4e9e0fb1-dc8c-4fc0-bc48-2672028f86fd.png)

Right now I can send the metadata of the Suggested track to coverartarchive and get a response via a button. It is better to first decide what should GUI look like? Then we can implement that (or something similar) later on. 

For to decide about GUI, we should decide how this feature can be used?
* I think there should be a button called "look for cover art" which triggers the request when pressed, and can get cover art of the selected `Suggested Tags`.
* Should we have separate buttons for the metadata and cover art? Can cover-art be updated separate then the metadata or apply button should update both the cover art and the metadata? 

Do you have any other use-case comes to your mind? These few buttons would make this menu crowded and complicated? What do you think generally? 

(This feature also needs your feedback about technical stuff, the first thing is how to store the cover-arts, cover-arts has thumbnails should we use them, if the cover art updated, should we save it as a file or embed in the file, should user choose between these storing options and so on...)