### PR TITLE
Rubberband V3 stretcher

### DIFF
--- a/src/engine/bufferscalers/enginebufferscalerubberband.cpp
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.cpp
@@ -17,6 +17,8 @@ using RubberBand::RubberBandStretcher;
 
 namespace {
 
+// TODO (XXX): this should be removed. It is only needed to work around
+// a Rubberband 1.3 bug.
 // This is the default increment from RubberBand 1.8.1.
 size_t kRubberBandBlockSize = 256;
 
@@ -113,6 +115,8 @@ void EngineBufferScaleRubberBand::onSampleRateChanged() {
             getOutputSignal().getSampleRate(),
             getOutputSignal().getChannelCount(),
             RubberBandStretcher::OptionProcessRealTime);
+    // TODO (XXX): we should always be able to provide rubberband as
+    // many samples as it wants. So remove this.
     m_pRubberBand->setMaxProcessSize(kRubberBandBlockSize);
     // Setting the time ratio to a very high value will cause RubberBand
     // to preallocate buffers large enough to (almost certainly)
@@ -190,6 +194,9 @@ double EngineBufferScaleRubberBand::scaleBuffer(
 
         size_t iLenFramesRequired = m_pRubberBand->getSamplesRequired();
         if (iLenFramesRequired == 0) {
+            // TODO (XXX): Rubberband 1.3 is not being packaged anymore.
+            // Remove this workaround.
+            //
             // rubberband 1.3 (packaged up through Ubuntu Quantal) has a bug
             // where it can report 0 samples needed forever which leads us to an
             // infinite loop. To work around this, we check if available() is

--- a/src/engine/bufferscalers/enginebufferscalerubberband.cpp
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.cpp
@@ -53,7 +53,7 @@ void EngineBufferScaleRubberBand::setScaleParameters(double base_rate,
     //
     // References:
     // https://bugs.launchpad.net/ubuntu/+bug/1263233
-    // https://bitbucket.org/breakfastquay/rubberband/issue/4/sigfpe-zero-division-with-high-time-ratios
+    // https://todo.sr.ht/~breakfastquay/rubberband/5
     constexpr double kMinSeekSpeed = 1.0 / 128.0;
     double speed_abs = fabs(*pTempoRatio);
     if (speed_abs < kMinSeekSpeed) {
@@ -84,7 +84,7 @@ void EngineBufferScaleRubberBand::setScaleParameters(double base_rate,
         qWarning() << "EngineBufferScaleRubberBand inputIncrement is 0."
                    << "On RubberBand <=1.8.1 a SIGFPE is imminent despite"
                    << "our workaround. Taking evasive action."
-                   << "Please report this message to mixxx-devel@lists.sourceforge.net.";
+                   << "Please file an issue on https://github.com/mixxxdj/mixxx/issues";
 
         // This is much slower than the minimum seek speed workaround above.
         while (m_pRubberBand->getInputIncrement() == 0) {

--- a/src/engine/bufferscalers/enginebufferscalerubberband.h
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.h
@@ -32,6 +32,8 @@ class EngineBufferScaleRubberBand : public EngineBufferScale {
     // Reset RubberBand library with new audio signal
     void onSampleRateChanged() override;
 
+    int runningEngineVersion();
+
     void deinterleaveAndProcess(const CSAMPLE* pBuffer, SINT frames, bool flush);
     SINT retrieveAndDeinterleave(CSAMPLE* pBuffer, SINT frames);
 


### PR DESCRIPTION
if we're compiling with rubberband v3 available, automatically use the finer engine. The latest commit builds and works with Rubberband v2 and v3. This is not really intended to be merged because we want the engine to be configurable in the preferences. Consider this PR a starting point for anyone that wants to work on prefence integration. 