### PR TITLE
ci: upgrade ubuntu VMs from 20.04 to 22.04

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -14,7 +14,7 @@ jobs:
           - name: clazy
           - name: clang-tidy
           - name: coverage
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: ${{ matrix.name }}
     steps:
     - name: Check out repository
@@ -137,6 +137,6 @@ jobs:
       continue-on-error: true
       uses: coverallsapp/github-action@master
       with:
-        flag-name: ubuntu-20.04
+        flag-name: ubuntu-22.04
         path-to-lcov: build/lcov.info
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,27 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - name: Ubuntu 22.04 (gcc)
+            os: ubuntu-22.04
+            cmake_args: >-
+              -DWARNINGS_FATAL=ON
+              -DBULK=ON
+              -DFFMPEG=ON
+              -DLOCALECOMPARE=ON
+              -DMAD=ON
+              -DMODPLUG=ON
+              -DWAVPACK=ON
+              -DINSTALL_USER_UDEV_RULES=OFF
+            ctest_args: []
+            compiler_cache: ccache
+            compiler_cache_path: ~/.ccache
+            cpack_generator: DEB
+            buildenv_basepath: /home/runner/buildenv
+            buildenv_script: tools/debian_buildenv.sh
+            artifacts_name: Ubuntu 22.04 DEB
+            artifacts_path: build/*.deb
+            artifacts_slug: ubuntu-jammy
+            qt_qpa_platform: offscreen
           - name: Ubuntu 20.04 (gcc)
             os: ubuntu-20.04
             cmake_args: >-
@@ -34,7 +55,7 @@ jobs:
             artifacts_slug: ubuntu-focal
             qt_qpa_platform: offscreen
           - name: Arch Linux (Qt 6.3, gcc)
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             # The Dockerfile for this container can be found at:
             # https://github.com/Holzhaus/mixxx-ci-docker
             container: holzhaus/mixxx-ci:20220612-qt6
@@ -150,7 +171,7 @@ jobs:
 
     - name: "[macOS] Set up cmake"
       uses: jwlawson/actions-setup-cmake@v1.12
-      # Ubuntu 20.04 should use the CMake version from the repos, and Visual
+      # Ubuntu 22.04 should use the CMake version from the repos, and Visual
       # Studio on Windows comes with its own CMake version anyway.
       if: runner.os == 'macOS'
       with:
@@ -319,7 +340,7 @@ jobs:
 
     - name: "Package for PPA"
       # No need to do the PPA build for both Ubuntu versions
-      if: matrix.os == 'ubuntu-20.04' && matrix.container == null
+      if: matrix.os == 'ubuntu-22.04' && matrix.container == null
       run: |
         if [[ "${{ github.ref }}" == "refs/heads/main" ]] && [[ "${{ github.repository }}" == "mixxxdj/mixxx" ]]; then
           CPACK_ARGS="-D DEB_UPLOAD_PPA=ppa:mixxx/nightlies -D CPACK_DEBIAN_DEBIAN_VERSION=0ubuntu2"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ default_language_version:
   python: python3
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.2.0
+  rev: v4.3.0
   hooks:
   - id: fix-byte-order-marker
     exclude: ^.*(\.cbproj|\.groupproj|\.props|\.sln|\.vcxproj|\.vcxproj.filters)$
@@ -63,7 +63,7 @@ repos:
     #args: [--ignore-words, .codespellignore, --ignore-regex, "\\W(?:m_p*(?=[A-Z])|m_(?=\\w)|pp*(?=[A-Z])|k(?=[A-Z])|s_(?=\\w))"]
     exclude: ^(packaging/wix/LICENSE.rtf|src/dialog/dlgabout\.cpp|.*\.(?:pot?|ts|wxl))$
 - repo: https://github.com/pre-commit/mirrors-eslint
-  rev: v8.14.0
+  rev: v8.20.0
   hooks:
   - id: eslint
     args: [--fix, --report-unused-disable-directives]
@@ -88,12 +88,12 @@ repos:
     language: python
     files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|m|mm|proto|vert)$
 - repo: https://github.com/psf/black
-  rev: 22.3.0
+  rev: 22.6.0
   hooks:
   - id: black
     files: ^tools/.*$
-- repo: https://gitlab.com/pycqa/flake8
-  rev: '3.9.2'
+- repo: https://github.com/pycqa/flake8
+  rev: '4.0.1'
   hooks:
   - id: flake8
     files: ^tools/.*$
@@ -106,8 +106,8 @@ repos:
   rev: v0.4.0
   hooks:
   - id: markdownlint-cli2
-- repo: https://github.com/sirosen/check-jsonschema
-  rev: 0.14.3
+- repo: https://github.com/python-jsonschema/check-jsonschema
+  rev: 0.17.1
   hooks:
   - id: check-github-workflows
 - repo: local

--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -23,7 +23,7 @@ DlgPrefControllers::DlgPrefControllers(DlgPreferences* pPreferences,
     createLinkColor();
     setupControllerWidgets();
 
-    connect(btnOpenUserMappings, &QPushButton::clicked, [=, this]() {
+    connect(btnOpenUserMappings, &QPushButton::clicked, this, [=, this]() {
         QString mappingsPath = userMappingsPath(m_pConfig);
         openLocalFile(mappingsPath);
     });


### PR DESCRIPTION
~~As per our minimum requirement policy and https://wiki.ubuntu.com/Releases, this can be merged On August 4th when Ubuntu 22.04.1 gets released.~~
Lets merge this ASAP. I added an extra 22.04 VM instead of upgrading. This way we can verify main continues to work while we can also make sure that C++20 code actually works.
Putting as draft until then.
The pre-commit error is simply bogus. 