### PR TITLE
Allow loading custom sound config with '--sound-config' argument

### DIFF
--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -135,7 +135,7 @@ class SoundManager : public QObject {
     QList<unsigned int> m_samplerates;
     QList<CSAMPLE*> m_inputBuffers;
 
-    SoundManagerConfig m_config;
+    SoundManagerConfig m_soundConfig;
     SoundDevicePointer m_pErrorDevice;
     QHash<AudioOutput, AudioSource*> m_registeredSources;
     QMultiHash<AudioInput, AudioDestination*> m_registeredDestinations;

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -67,11 +67,9 @@ SoundManagerConfig::SoundManagerConfig(SoundManager* pSoundManager)
     m_configFile = QFileInfo(settDir.filePath(SOUNDMANAGERCONFIG_FILENAME));
 }
 
-/**
- * Read the SoundManagerConfig xml serialization at the predetermined
- * path
- * @returns false if the file can't be read or is invalid XML, true otherwise
- */
+/// Read the SoundManagerConfig xml serialization at the predetermined
+/// path
+/// @returns false if the file can't be read or is invalid XML, true otherwise
 bool SoundManagerConfig::readFromDisk() {
     QFile file(m_configFile.absoluteFilePath());
     QDomDocument doc;
@@ -294,12 +292,10 @@ void SoundManagerConfig::setAPI(const QString &api) {
     m_api = api;
 }
 
-/**
- * Checks that the API in the object is valid according to the list of APIs
- * given by SoundManager.
- * @returns false if the API is not found in SoundManager's list, otherwise
- *          true
- */
+/// Checks that the API in the object is valid according to the list of APIs
+/// given by SoundManager.
+/// @returns false if the API is not found in SoundManager's list, otherwise
+///          true
 bool SoundManagerConfig::checkAPI() {
     VERIFY_OR_DEBUG_ASSERT(m_pSoundManager != nullptr) {
         return false;
@@ -337,12 +333,10 @@ void SoundManagerConfig::setForceNetworkClock(bool force) {
     m_forceNetworkClock = force;
 }
 
-/**
- * Checks that the sample rate in the object is valid according to the list of
- * sample rates given by SoundManager.
- * @returns false if the sample rate is not found in SoundManager's list,
- *          otherwise true
- */
+/// Checks that the sample rate in the object is valid according to the list of
+/// sample rates given by SoundManager.
+/// @returns false if the sample rate is not found in SoundManager's list,
+///          otherwise true
 bool SoundManagerConfig::checkSampleRate(const SoundManager &soundManager) {
     if (!soundManager.getSampleRates(m_api).contains(m_sampleRate)) {
         return false;
@@ -425,13 +419,12 @@ double SoundManagerConfig::getProcessingLatency() const {
     return static_cast<double>(getFramesPerBuffer()) / m_sampleRate * 1000.0;
 }
 
-
-// Set the audio buffer size
-// @warning This IS NOT a value in milliseconds, or a number of frames per
-// buffer. It is an index, where 1 is the first power-of-two buffer size (in
-// frames) which corresponds to a latency greater than or equal to 1 ms, 2 is
-// the second, etc. This is so that latency values are roughly equivalent
-// between different sample rates.
+/// Set the audio buffer size
+/// @warning This IS NOT a value in milliseconds, or a number of frames per
+/// buffer. It is an index, where 1 is the first power-of-two buffer size (in
+/// frames) which corresponds to a latency greater than or equal to 1 ms, 2 is
+/// the second, etc. This is so that latency values are roughly equivalent
+/// between different sample rates.
 void SoundManagerConfig::setAudioBufferSizeIndex(unsigned int sizeIndex) {
     // latency should be either the min of kMaxAudioBufferSizeIndex and the passed value
     // if it's 0, pretend it was 1 -- bkgood
@@ -477,13 +470,11 @@ bool SoundManagerConfig::hasExternalRecordBroadcast() {
     return m_bExternalRecordBroadcastConnected;
 }
 
-/**
- * Loads default values for API, master output, sample rate and/or latency.
- * @param soundManager pointer to SoundManager instance to load data from
- * @param flags Bitfield to determine which defaults to load, use something
- *              like SoundManagerConfig::API | SoundManagerConfig::DEVICES to
- *              load default API and master device.
- */
+/// Loads default values for API, master output, sample rate and/or latency.
+/// @param soundManager pointer to SoundManager instance to load data from
+/// @param flags Bitfield to determine which defaults to load, use something
+///              like SoundManagerConfig::API | SoundManagerConfig::DEVICES to
+///              load default API and master device.
 void SoundManagerConfig::loadDefaults(SoundManager* soundManager, unsigned int flags) {
     if (flags & SoundManagerConfig::API) {
         QList<QString> apiList = soundManager->getHostAPIList();

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -51,7 +51,20 @@ SoundManagerConfig::SoundManagerConfig(SoundManager* pSoundManager)
       m_iNumMicInputs(0),
       m_bExternalRecordBroadcastConnected(false),
       m_pSoundManager(pSoundManager) {
-    m_configFile = QFileInfo(QDir(CmdlineArgs::Instance().getSettingsPath()).filePath(SOUNDMANAGERCONFIG_FILENAME));
+    CmdlineArgs& cla = CmdlineArgs::Instance();
+    QDir settDir = QDir(cla.getSettingsPath());
+    // Try to load custom sound config first
+    QString customCfg = cla.getSoundConfig();
+    if (!customCfg.isEmpty()) {
+        QFileInfo customCfgFileInfo = QFileInfo(settDir.filePath(customCfg));
+        QFile customCfgFile(customCfgFileInfo.absoluteFilePath());
+        if (customCfgFile.open(QIODevice::ReadOnly)) {
+            m_configFile = customCfgFileInfo;
+            return;
+        }
+    }
+    // Else use the default file
+    m_configFile = QFileInfo(settDir.filePath(SOUNDMANAGERCONFIG_FILENAME));
 }
 
 /**

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -57,8 +57,7 @@ SoundManagerConfig::SoundManagerConfig(SoundManager* pSoundManager)
     QString customCfg = cla.getSoundConfig();
     if (!customCfg.isEmpty()) {
         QFileInfo customCfgFileInfo = QFileInfo(settDir.filePath(customCfg));
-        QFile customCfgFile(customCfgFileInfo.absoluteFilePath());
-        if (customCfgFile.open(QIODevice::ReadOnly)) {
+        if (customCfgFileInfo.exists() && customCfgFileInfo.isReadable()) {
             m_configFile = customCfgFileInfo;
             return;
         }

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -146,6 +146,16 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(settingsPath);
     parser.addOption(settingsPathDeprecated);
 
+    // sound configuration file
+    const QCommandLineOption soundConfig(QStringLiteral("sound-config"),
+            forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
+                                      "Sound config file in specified settings path"
+                                      "Mixxx should use. "
+                                      "Default is: soundconfig.xml")
+                            : QString(),
+            QStringLiteral("path"));
+    parser.addOption(soundConfig);
+
     // resource path
     QCommandLineOption resourcePath(QStringLiteral("resource-path"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
@@ -317,6 +327,10 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
             m_settingsPath.append("/");
         }
         m_settingsPathSet = true;
+    }
+
+    if (parser.isSet(soundConfig)) {
+        m_soundConfig = parser.value(soundConfig);
     }
 
     if (parser.isSet(resourcePath)) {

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -111,6 +111,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
                 MIXXX_MANUAL_COMMANDLINEOPTIONS_URL);
     }
     // add options
+    // full-screen
     const QCommandLineOption fullScreen(
             QStringList({QStringLiteral("f"), QStringLiteral("full-screen")}),
             forUserFeedback ? QCoreApplication::translate(
@@ -121,6 +122,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(fullScreen);
     parser.addOption(fullScreenDeprecated);
 
+    // locale
     const QCommandLineOption locale(QStringLiteral("locale"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Use a custom locale for loading translations. (e.g "
@@ -129,7 +131,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
             QStringLiteral("locale"));
     parser.addOption(locale);
 
-    // An option with a value
+    // settings path
     const QCommandLineOption settingsPath(QStringLiteral("settings-path"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Top-level directory where Mixxx should look for settings. "
@@ -144,6 +146,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(settingsPath);
     parser.addOption(settingsPathDeprecated);
 
+    // resource path
     QCommandLineOption resourcePath(QStringLiteral("resource-path"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Top-level directory where Mixxx should look for its "
@@ -158,6 +161,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(resourcePath);
     parser.addOption(resourcePathDeprecated);
 
+    // timeline path
     const QCommandLineOption timelinePath(QStringLiteral("timeline-path"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Path the debug statistics time line is written to")
@@ -170,6 +174,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(timelinePath);
     parser.addOption(timelinePathDeprecated);
 
+    // controller debug
     const QCommandLineOption controllerDebug(QStringLiteral("controller-debug"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Causes Mixxx to display/log all of the controller data it "
@@ -182,6 +187,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(controllerDebug);
     parser.addOption(controllerDebugDeprecated);
 
+    // developer mode
     const QCommandLineOption developer(QStringLiteral("developer"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Enables developer-mode. Includes extra log info, stats on "
@@ -189,6 +195,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
                             : QString());
     parser.addOption(developer);
 
+    // safe mode
     const QCommandLineOption safeMode(QStringLiteral("safe-mode"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Enables safe-mode. Disables OpenGL waveforms, and "
@@ -200,6 +207,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(safeMode);
     parser.addOption(safeModeDeprecated);
 
+    // console colors
     const QCommandLineOption color(QStringLiteral("color"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "[auto|always|never] Use colors on the console output.")
@@ -208,6 +216,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
             QStringLiteral("auto"));
     parser.addOption(color);
 
+    // log level
     const QCommandLineOption logLevel(QStringLiteral("log-level"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Sets the verbosity of command line logging.\n"
@@ -224,6 +233,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(logLevel);
     parser.addOption(logLevelDeprecated);
 
+    // log flush level
     const QCommandLineOption logFlushLevel(QStringLiteral("log-flush-level"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Sets the the logging level at which the log buffer is "
@@ -238,6 +248,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(logFlushLevel);
     parser.addOption(logFlushLevelDeprecated);
 
+    // debug asserts
     QCommandLineOption debugAssertBreak(QStringLiteral("debug-assert-break"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Breaks (SIGINT) Mixxx, if a DEBUG_ASSERT evaluates to "
@@ -252,6 +263,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     const QCommandLineOption helpOption = parser.addHelpOption();
     const QCommandLineOption versionOption = parser.addVersionOption();
 
+    // load music files
     parser.addPositionalArgument(QStringLiteral("file"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Load the specified music file(s) at start-up. Each file "

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -46,6 +46,9 @@ class CmdlineArgs final {
     bool getTimelineEnabled() const { return !m_timelinePath.isEmpty(); }
     const QString& getLocale() const { return m_locale; }
     const QString& getSettingsPath() const { return m_settingsPath; }
+    const QString& getSoundConfig() const {
+        return m_soundConfig;
+    }
     void setSettingsPath(const QString& newSettingsPath) {
         m_settingsPath = newSettingsPath;
     }
@@ -81,6 +84,7 @@ class CmdlineArgs final {
     mixxx::LogLevel m_logFlushLevel; // Level of mixx.log file flushing
     QString m_locale;
     QString m_settingsPath;
+    QString m_soundConfig;
     QString m_resourcePath;
     QString m_timelinePath;
 };


### PR DESCRIPTION
first step to resolve https://bugs.launchpad.net/mixxx/+bug/1516035

This allows loading a custom sound config via `--sound-config config_file.xml`. For now this is restricted to files inside the settings dir.
If the argument not added or the passed file is not readable, default `soundconfig.xml` is used.
**Note**: the given config file (command line or default) is used for all read/write operations in the current session, i.e. if you change your config those changes will be stored in your custom sound config.

Thus, the workflow currently goes like this:
**Create sound profile**
* connect audio devices and start Mixxx
* adjust sound devices and options as desired
* quit Mixxx
* copy `soundconfig.xml` and rename to something like `soundconfig_DDJ-SB3_NIAudio8.xml`

**Load sound profile**
* connect audio devices and start Mixxx
* start Mixxx with `mixxx --sound-config soundconfig_DDJ-SB3_NIAudio8.xml`

____
I post-poned adding a profile selector to Preferences > Sound Hardware since that is more elaborate than I first thought. It's mainly getting the UX right, but also some flaws in current DlgPrefSound become obvious when dealing with profiles for the entire page (e.g. some settings are applied instantly).