### PR TITLE
Shout.c : Add a missing c++14 fall through comment

### DIFF
--- a/lib/libshout-idjc/src/shout.c
+++ b/lib/libshout-idjc/src/shout.c
@@ -1308,6 +1308,7 @@ retry:
             }
 #endif
             self->state = SHOUT_STATE_REQ_CREATION;
+        /* fall through */
 
         case SHOUT_STATE_REQ_CREATION:
             if ((rc = create_request(self)) != SHOUTERR_SUCCESS)


### PR DESCRIPTION
The source is compiled wit the default c++14 and uses  /* fall through */ to silence the -Wimplicit-fallthrough=3 enabled by -Wextra. 