### PR TITLE
Sound Profiles: allow selecting & editing of hardware/config profiles in the sound hardware preferences

### DIFF
--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -249,7 +249,8 @@ void MixxxMainWindow::initialize() {
 
     // Sound hardware setup
     // Try to open configured devices. If that fails, display dialogs
-    // that allow to either retry, reconfigure devices or exit.
+    // that allow to either retry, reconfigure devices, try another sound config
+    // profile or exit Mixxx.
     bool retryClicked;
     do {
         retryClicked = false;

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -470,8 +470,8 @@ QDialog::DialogCode MixxxMainWindow::soundDeviceErrorDlg(
             m_pCoreServices->getSoundManager()->clearAndQueryDevices();
             // This way of opening the dialog allows us to use it synchronously
             m_pPrefDlg->setWindowModality(Qt::ApplicationModal);
-            // Open preferences, sound hardware page is selected (default on first call)
-            m_pPrefDlg->exec();
+            m_pPrefDlg->show();
+            m_pPrefDlg->showSoundHardwarePage();
             if (m_pPrefDlg->result() == QDialog::Accepted) {
                 return QDialog::Accepted;
             }

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -642,11 +642,11 @@ void DlgPrefSound::soundProfileSelected(int index) {
     }
 
     // select and read new profile
-    SoundDeviceStatus status = SOUNDDEVICE_OK;
+    SoundDeviceStatus status = SoundDeviceStatus::Ok;
     {
         ScopedWaitCursor cursor;
         status = m_pSoundManager->setSoundProfile(newProfile);
-        if (status == SOUNDDEVICE_OK) {
+        if (status == SoundDeviceStatus::Ok) {
             // clear device comboboxes
             m_outputDevices.clear();
             m_inputDevices.clear();

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -1,5 +1,6 @@
 #include "preferences/dialog/dlgprefsound.h"
 
+#include <QInputDialog>
 #include <QMessageBox>
 #include <QtDebug>
 
@@ -683,6 +684,46 @@ void DlgPrefSound::duplicateProfile() {
 }
 
 void DlgPrefSound::renameProfile() {
+    if (m_settingsModified) {
+        QMessageBox::information(this,
+                tr("Pending changes"),
+                tr("Please apply pending changes before renaming this "
+                   "profile."),
+                QMessageBox::Ok,
+                QMessageBox::Ok);
+        return;
+    }
+
+    const QString oldName = profileComboBox->currentText();
+    QString newName;
+    QString errorText;
+    while (newName.isEmpty() || profileComboBox->findText(newName) != -1) {
+        bool okay = false;
+        newName = QInputDialog::getText(nullptr,
+                tr("Rename sound profile"),
+                errorText + "\n" + tr("New name for sound profile") +
+                        QStringLiteral(" \"") + oldName + QStringLiteral("\""),
+                QLineEdit::Normal,
+                oldName,
+                &okay)
+                          .trimmed();
+        if (!okay) {
+            return;
+        }
+
+        if (newName.isEmpty()) {
+            errorText = tr("Sound profile name must not be empty.") + QStringLiteral("\n");
+        } else if (profileComboBox->findText(newName) != -1) {
+            errorText =
+                    tr("A sound profile named \"%1\" already exists.")
+                            .arg(newName) +
+                    QStringLiteral("\n");
+        } else {
+            errorText = QString();
+        }
+    }
+
+    // soundmanager > newName
 }
 
 void DlgPrefSound::deleteProfile() {

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -13,10 +13,8 @@
 #include "util/rlimit.h"
 #include "util/scopedoverridecursor.h"
 
-/**
- * Construct a new sound preferences pane. Initializes and populates all the
- * all the controls to the values obtained from SoundManager.
- */
+/// Construct a new sound preferences pane. Initializes and populates all the
+/// all the controls to the values obtained from SoundManager.
 DlgPrefSound::DlgPrefSound(QWidget* pParent,
         std::shared_ptr<SoundManager> pSoundManager,
         UserSettingsPointer pSettings)
@@ -281,10 +279,6 @@ bool DlgPrefSound::eventFilter(QObject* obj, QEvent* e) {
     return QObject::eventFilter(obj, e);
 }
 
-/**
- * Slot called when the preferences dialog is opened or this pane is
- * selected.
- */
 void DlgPrefSound::slotUpdate() {
     // this is unfortunate, because slotUpdate is called every time
     // we change to this pane, we lose changed and unapplied settings
@@ -297,9 +291,6 @@ void DlgPrefSound::slotUpdate() {
     m_settingsModified = false;
 }
 
-/**
- * Slot called when the Apply or OK button is pressed.
- */
 void DlgPrefSound::slotApply() {
     if (!m_settingsModified) {
         return;
@@ -335,13 +326,11 @@ QUrl DlgPrefSound::helpUrl() const {
     return QUrl(MIXXX_MANUAL_SOUND_URL);
 }
 
-/**
- * Initializes (and creates) all the path items. Each path item widget allows
- * the user to input a sound device name and channel number given a description
- * of what will be done with that info. Inputs and outputs are grouped by tab,
- * and each path item has an identifier (Master, Headphones, ...) and an index,
- * if necessary.
- */
+/// Initializes (and creates) all the path items. Each path item widget allows
+/// the user to input a sound device name and channel number given a description
+/// of what will be done with that info. Inputs and outputs are grouped by tab,
+/// and each path item has an identifier (Master, Headphones, ...) and an index,
+/// if necessary.
 void DlgPrefSound::initializePaths() {
     foreach (AudioOutput out, m_pSoundManager->registeredOutputs()) {
         if (!out.isHidden()) {
@@ -441,17 +430,13 @@ void DlgPrefSound::insertItem(DlgPrefSoundItem *pItem, QVBoxLayout *pLayout) {
     pLayout->insertWidget(pos, pItem);
 }
 
-/**
- * Convenience overload to load settings from the SoundManagerConfig owned by
- * SoundManager.
- */
+/// Convenience overload to load settings from the SoundManagerConfig owned by
+/// SoundManager.
 void DlgPrefSound::loadSettings() {
     loadSettings(m_pSoundManager->getConfig());
 }
 
-/**
- * Loads the settings in the given SoundManagerConfig into the dialog.
- */
+/// Loads the settings in the given SoundManagerConfig into the dialog.
 void DlgPrefSound::loadSettings(const SoundManagerConfig &config) {
     m_loading = true; // so settingsChanged ignores all our modifications here
     m_config = config;
@@ -516,12 +501,10 @@ void DlgPrefSound::loadSettings(const SoundManagerConfig &config) {
     emit loadPaths(m_config);
 }
 
-/**
- * Slot called when the user selects a different API, or the
- * software changes it programmatically (for instance, when it
- * loads a value from SoundManager). Refreshes the device lists
- * for the new API and pushes those to the path items.
- */
+/// Slot called when the user selects a different API, or the
+/// software changes it programmatically (for instance, when it
+/// loads a value from SoundManager). Refreshes the device lists
+/// for the new API and pushes those to the path items.
 void DlgPrefSound::apiChanged(int index) {
     m_config.setAPI(apiComboBox->itemData(index).toString());
     refreshDevices();
@@ -539,10 +522,8 @@ void DlgPrefSound::apiChanged(int index) {
     }
 }
 
-/**
- * Updates the list of APIs, trying to keep the API and device selections
- * constant if possible.
- */
+/// Updates the list of APIs, trying to keep the API and device selections
+/// constant if possible.
 void DlgPrefSound::updateAPIs() {
     QString currentAPI(apiComboBox->itemData(apiComboBox->currentIndex()).toString());
     emit updatingAPI();
@@ -559,10 +540,8 @@ void DlgPrefSound::updateAPIs() {
     emit updatedAPI();
 }
 
-/**
- * Slot called when the sample rate combo box changes to update the
- * sample rate in the config.
- */
+/// Slot called when the sample rate combo box changes to update the
+/// sample rate in the config.
 void DlgPrefSound::sampleRateChanged(int index) {
     m_config.setSampleRate(
             sampleRateComboBox->itemData(index).toUInt());
@@ -570,10 +549,8 @@ void DlgPrefSound::sampleRateChanged(int index) {
     checkLatencyCompensation();
 }
 
-/**
- * Slot called when the latency combo box is changed to update the
- * latency in the config.
- */
+/// Slot called when the latency combo box is changed to update the
+/// latency in the config.
 void DlgPrefSound::audioBufferChanged(int index) {
     m_config.setAudioBufferSizeIndex(
             audioBufferComboBox->itemData(index).toUInt());
@@ -637,10 +614,8 @@ void DlgPrefSound::updateAudioBufferSizes(int sampleRateIndex) {
     }
 }
 
-/**
- * Slot called when device lists go bad to refresh them, or the API
- * just changes and we need to display new devices.
- */
+/// Slot called when device lists go bad to refresh them, or the API
+/// just changes and we need to display new devices.
 void DlgPrefSound::refreshDevices() {
     if (m_config.getAPI() == SoundManagerConfig::kDefaultAPI) {
         m_outputDevices.clear();
@@ -655,11 +630,9 @@ void DlgPrefSound::refreshDevices() {
     emit refreshInputDevices(m_inputDevices);
 }
 
-/**
- * Called when any of the combo boxes in this dialog are changed. Enables the
- * apply button and marks that settings have been changed so that
- * DlgPrefSound::slotApply knows to apply them.
- */
+/// Called when any of the combo boxes in this dialog are changed. Enables the
+/// apply button and marks that settings have been changed so that
+/// DlgPrefSound::slotApply knows to apply them.
 void DlgPrefSound::settingChanged() {
     if (m_loading) {
         return; // doesn't count if we're just loading prefs
@@ -675,18 +648,13 @@ void DlgPrefSound::deviceSettingChanged() {
     m_settingsModified = true;
 }
 
-/**
- * Slot called when the "Query Devices" button is clicked.
- */
+/// Slot called when the "Query Devices" button is clicked.
 void DlgPrefSound::queryClicked() {
     ScopedWaitCursor cursor;
     m_pSoundManager->clearAndQueryDevices();
     updateAPIs();
 }
 
-/**
- * Slot called when the "Reset to Defaults" button is clicked.
- */
 void DlgPrefSound::slotResetToDefaults() {
     SoundManagerConfig newConfig(m_pSoundManager.get());
     newConfig.loadDefaults(m_pSoundManager.get(), SoundManagerConfig::ALL);

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -64,7 +64,15 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void addPath(const AudioOutput& output);
     void addPath(const AudioInput& input);
     void loadSettings();
+
+    void soundProfileSelected(int index);
+    void createNewProfile();
+    void duplicateProfile();
+    void renameProfile();
+    void deleteProfile();
+
     void apiChanged(int index);
+    void maybeAdjustGuiToJackAPI();
     void updateAPIs();
     void sampleRateChanged(int index);
     void audioBufferChanged(int index);
@@ -83,6 +91,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void insertItem(DlgPrefSoundItem *pItem, QVBoxLayout *pLayout);
     void checkLatencyCompensation();
     bool eventFilter(QObject* object, QEvent* event) override;
+    void updateProfileDeleteButton();
 
     std::shared_ptr<SoundManager> m_pSoundManager;
     UserSettingsPointer m_pSettings;

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -86,7 +86,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
 
     std::shared_ptr<SoundManager> m_pSoundManager;
     UserSettingsPointer m_pSettings;
-    SoundManagerConfig m_config;
+    SoundManagerConfig m_soundConfig;
     ControlProxy* m_pMasterAudioLatencyOverloadCount;
     ControlProxy* m_pMasterLatency;
     ControlProxy* m_pHeadDelay;

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -14,8 +14,9 @@
    <string>Sound Hardware Preferences</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
+
    <item>
-    <layout class="QGridLayout" name="gridLayout">
+    <layout class="QGridLayout" name="soundOptionsLayout">
      <item row="0" column="0">
       <widget class="QLabel" name="apiLabel">
        <property name="text">
@@ -223,6 +224,7 @@
      </item>
     </layout>
    </item>
+
    <item>
     <widget class="Line" name="line_2">
      <property name="orientation">
@@ -230,8 +232,9 @@
      </property>
     </widget>
    </item>
+
    <item>
-    <layout class="QHBoxLayout" name="buttonsHLayout">
+    <layout class="QHBoxLayout" name="queryButtonHLayout">
      <item>
       <widget class="QPushButton" name="queryButton">
        <property name="text">
@@ -254,6 +257,7 @@
      </item>
     </layout>
    </item>
+
    <item>
     <widget class="QTabWidget" name="ioTabs">
      <property name="sizePolicy">
@@ -313,6 +317,7 @@
      </widget>
     </widget>
    </item>
+
    <item>
     <widget class="QGroupBox" name="Hints">
      <property name="title">
@@ -403,6 +408,7 @@
      </layout>
     </widget>
    </item>
+
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -16,6 +16,47 @@
   <layout class="QVBoxLayout" name="verticalLayout_2">
 
    <item>
+    <widget class="QGroupBox" name="groupBox_soundProfiles">
+     <property name="title">
+      <string>Sound Profile</string>
+     </property>
+     <layout class="QGridLayout" name="soundProfileLayout">
+      <item row="0" column="0" colspan="4">
+       <widget class="QComboBox" name="profileComboBox"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QPushButton" name="newProfileButton">
+        <property name="text">
+         <string>Create New Profile</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QPushButton" name="renameProfileButton">
+        <property name="text">
+         <string>Rename</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QPushButton" name="dupProfileButton">
+        <property name="text">
+         <string>Duplicate Profile</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QPushButton" name="delProfileButton">
+        <property name="text">
+         <string>Delete Profile</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+
+   <item>
     <layout class="QGridLayout" name="soundOptionsLayout">
      <item row="0" column="0">
       <widget class="QLabel" name="apiLabel">

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -43,10 +43,10 @@ constexpr unsigned int kSleepSecondsAfterClosingDevice = 5;
 #endif
 } // anonymous namespace
 
-SoundManager::SoundManager(UserSettingsPointer pConfig,
+SoundManager::SoundManager(UserSettingsPointer pSettings,
         EngineMaster* pMaster)
         : m_pMaster(pMaster),
-          m_pConfig(pConfig),
+          m_pSettings(pSettings),
           m_paInitialized(false),
           m_soundConfig(this),
           m_pErrorDevice(nullptr),
@@ -300,7 +300,7 @@ void SoundManager::queryDevicesPortaudio() {
          */
         const auto deviceTypeId = paApiIndexToTypeId.value(deviceInfo->hostApi);
         auto currentDevice = SoundDevicePointer(new SoundDevicePortAudio(
-                m_pConfig, this, deviceInfo, deviceTypeId, i));
+                m_pSettings, this, deviceInfo, deviceTypeId, i));
         m_devices.push_back(currentDevice);
         if (!strcmp(Pa_GetHostApiInfo(deviceInfo->hostApi)->name,
                     MIXXX_PORTAUDIO_JACK_STRING)) {
@@ -312,7 +312,7 @@ void SoundManager::queryDevicesPortaudio() {
 
 void SoundManager::queryDevicesMixxx() {
     auto currentDevice = SoundDevicePointer(new SoundDeviceNetwork(
-            m_pConfig, this, m_pNetworkStream));
+            m_pSettings, this, m_pNetworkStream));
     m_devices.append(currentDevice);
 }
 
@@ -559,7 +559,7 @@ SoundDeviceStatus SoundManager::setConfig(const SoundManagerConfig& soundConfig)
     // certain parts of mixxx rely on this being here, for the time being, just
     // letting those be -- bkgood
     // Do this first so vinyl control gets the right samplerate -- Owen W.
-    m_pConfig->set(ConfigKey("[Soundcard]", "Samplerate"),
+    m_pSettings->set(ConfigKey("[Soundcard]", "Samplerate"),
             ConfigValue(static_cast<int>(m_soundConfig.getSampleRate())));
 
     status = setupDevices();

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -537,6 +537,10 @@ SoundDeviceStatus SoundManager::setupDevices() {
 
     // load with all configured devices.
     // all found devices are removed below
+    // FIXME This is wrong: SoundManagerConfig::readFromDisk() already
+    // removes configured devices that are currently unavailable. Thus, the
+    // devicesNotFound.isEmpty() check below is kinda pointless and users will
+    // not notice missing devices unless there is is no output configured at all.
     QSet<SoundDeviceId> devicesNotFound = m_soundConfig.getDevices();
 
     // pair is isInput, isOutput

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -237,7 +237,7 @@ SoundDeviceStatus SoundManager::setSoundProfile(const QString& profileName) {
     qInfo() << "     +";
     qInfo() << "     + SM::setSoundProfile:" << profileName;
 
-    SoundDeviceStatus status = SOUNDDEVICE_ERROR;
+    SoundDeviceStatus status = SoundDeviceStatus::Error;
     if (profileName.isEmpty()) {
         qInfo() << "     + err: profile name empty";
         qInfo() << "     + ";
@@ -265,7 +265,7 @@ SoundDeviceStatus SoundManager::setSoundProfile(const QString& profileName) {
 
     status = setConfig(newConfig);
     // => m_soundConfig = newConfig
-    if (status == SOUNDDEVICE_OK) {
+    if (status == SoundDeviceStatus::Ok) {
         qInfo() << "     + success";
         qInfo() << "     + save" << profileName << "to config";
         //m_soundConfig = newConfig; // is set in setConfig()
@@ -502,7 +502,8 @@ SoundDeviceStatus SoundManager::setupDevices() {
     // NOTE(rryan): Big warning: This function is concurrent with calls to
     // pushBuffer and onDeviceOutputCallback until closeDevices() below.
 
-    qDebug() << "SoundManager::setupDevices()";
+    qDebug() << "   ~~ ";
+    qDebug() << "   ~~ SoundManager::setupDevices()";
     m_pControlObjectSoundStatusCO->set(SOUNDMANAGER_CONNECTING);
     SoundDeviceStatus status = SoundDeviceStatus::Ok;
     // NOTE(rryan): Do not clear m_pClkRefDevice here. If we didn't touch the
@@ -597,7 +598,10 @@ SoundDeviceStatus SoundManager::setupDevices() {
 
             AudioOutputBuffer aob(out, pBuffer);
             status = pDevice->addOutput(aob);
+            qDebug() << "   ~~ out dev" << pDevice->getDisplayName() << " > add output";
+            qDebug() << "      status:" << static_cast<int>(status);
             if (status != SoundDeviceStatus::Ok) {
+                qDebug() << "      > closeAndError";
                 goto closeAndError;
             }
 

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -85,8 +85,18 @@ class SoundManager : public QObject {
 
     // Get all sound config files in the settings dir
     void collectSoundProfiles();
+    // Provide names of found profiles
+    QStringList getSoundProfileNames() const;
+    //QString getDefaultSoundProfileName() const {
+    //    return kDefaultProfileName;
+    //}
+    QString getDefaultSoundProfileName() const;
+    // Provide name of currently loaded profile
+    QString getCurrentSoundProfileName() const;
     // Read sound profile name from user settings
     QString getConfiguredSoundProfileName() const;
+    //void setConfiguredSoundProfileName(const QString& profileName);
+    SoundDeviceStatus setSoundProfile(const QString& profileName);
 
     void onDeviceOutputCallback(const SINT iFramesPerBuffer);
 
@@ -117,6 +127,9 @@ class SoundManager : public QObject {
     }
 
     void processUnderflowHappened();
+
+  public slots:
+    //void setSoundProfile(const QString& profileName);
 
   signals:
     void devicesUpdated(); // emitted when pointers to SoundDevices go stale

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -137,6 +137,7 @@ class SoundManager : public QObject {
     QList<CSAMPLE*> m_inputBuffers;
 
     SoundManagerConfig m_soundConfig;
+    QFileInfo m_soundConfigFile;
     SoundDevicePointer m_pErrorDevice;
     QHash<AudioOutput, AudioSource*> m_registeredSources;
     QMultiHash<AudioInput, AudioDestination*> m_registeredDestinations;

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -36,6 +36,9 @@ class SoundDeviceNotFound;
 #define SOUNDMANAGER_CONNECTING 1
 #define SOUNDMANAGER_CONNECTED 2
 
+#define SOUNDMANAGERCONFIG_DEFAULT_NAME "soundconfig"
+#define SOUNDMANAGERCONFIG_EXTENSION ".xml"
+#define SOUNDMANAGERCONFIG_DEFAULT_FILE "soundconfig.xml"
 
 class SoundManager : public QObject {
     Q_OBJECT

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -2,6 +2,7 @@
 
 #include <QHash>
 #include <QList>
+#include <QMap>
 #include <QObject>
 #include <QSharedPointer>
 #include <QString>
@@ -82,13 +83,17 @@ class SoundManager : public QObject {
     SoundDeviceStatus setConfig(const SoundManagerConfig& config);
     void checkConfig();
 
+    // Get all sound config files in the settings dir
+    void collectSoundProfiles();
+    // Read sound profile name from user settings
+    QString getConfiguredSoundProfileName() const;
+
     void onDeviceOutputCallback(const SINT iFramesPerBuffer);
 
     // Used by SoundDevices to "push" any audio from their inputs that they have
     // into the mixing engine.
     void pushInputBuffers(const QList<AudioInputBuffer>& inputs,
                           const SINT iFramesPerBuffer);
-
 
     void writeProcess() const;
     void readProcess() const;
@@ -141,6 +146,9 @@ class SoundManager : public QObject {
 
     SoundManagerConfig m_soundConfig;
     QFileInfo m_soundConfigFile;
+    QDir m_settingsDir;
+    QMap<QString, QFileInfo> m_configProfiles;
+
     SoundDevicePointer m_pErrorDevice;
     QHash<AudioOutput, AudioSource*> m_registeredSources;
     QMultiHash<AudioInput, AudioDestination*> m_registeredDestinations;

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -136,7 +136,7 @@ class SoundManager : public QObject {
     QList<unsigned int> m_samplerates;
     QList<CSAMPLE*> m_inputBuffers;
 
-    SoundManagerConfig m_config;
+    SoundManagerConfig m_soundConfig;
     SoundDevicePointer m_pErrorDevice;
     QHash<AudioOutput, AudioSource*> m_registeredSources;
     QMultiHash<AudioInput, AudioDestination*> m_registeredDestinations;

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -129,7 +129,7 @@ class SoundManager : public QObject {
     void setJACKName() const;
 
     EngineMaster *m_pMaster;
-    UserSettingsPointer m_pConfig;
+    UserSettingsPointer m_pSettings;
     bool m_paInitialized;
     mixxx::audio::SampleRate m_jackSampleRate;
     QList<SoundDevicePointer> m_devices;

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -185,6 +185,7 @@ bool SoundManagerConfig::readFromDisk() {
             }
         }
 
+        // add device outputs
         for (int j = 0; j < outElements.count(); ++j) {
             QDomElement outElement(outElements.at(j).toElement());
             if (outElement.isNull()) {
@@ -208,6 +209,7 @@ bool SoundManagerConfig::readFromDisk() {
 
             addOutput(deviceIdFromFile, out);
         }
+        // add device inputs
         for (int j = 0; j < inElements.count(); ++j) {
             QDomElement inElement(inElements.at(j).toElement());
             if (inElement.isNull()) {

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -51,7 +51,10 @@ SoundManagerConfig::SoundManagerConfig(SoundManager* pSoundManager)
       m_iNumMicInputs(0),
       m_bExternalRecordBroadcastConnected(false),
       m_pSoundManager(pSoundManager) {
-    m_configFile = QFileInfo(QDir(CmdlineArgs::Instance().getSettingsPath()).filePath(SOUNDMANAGERCONFIG_FILENAME));
+}
+
+void SoundManagerConfig::setFilePath(const QFileInfo& configFile) {
+    m_configFile = configFile;
 }
 
 /// Read the SoundManagerConfig xml serialization at the predetermined
@@ -84,6 +87,7 @@ bool SoundManagerConfig::readFromDisk() {
     clearInputs();
     QDomNodeList devElements(rootElement.elementsByTagName(xmlElementSoundDevice));
 
+    // FIXME Why assert that late? Without SoundManager we're screwed anyway.
     VERIFY_OR_DEBUG_ASSERT(m_pSoundManager != nullptr) {
         return false;
     }
@@ -302,7 +306,6 @@ void SoundManagerConfig::setSampleRate(unsigned int sampleRate) {
     m_sampleRate = sampleRate != 0 ? sampleRate : kFallbackSampleRate;
 }
 
-
 unsigned int SoundManagerConfig::getSyncBuffers() const {
     return m_syncBuffers;
 }
@@ -324,6 +327,8 @@ void SoundManagerConfig::setForceNetworkClock(bool force) {
 /// sample rates given by SoundManager.
 /// @returns false if the sample rate is not found in SoundManager's list,
 ///          otherwise true
+// TODO(xxx) Why require SoundManager here? SoundManagerConfig can only be constructed
+// with SoundManager anyway, and SoundManager doesn't change
 bool SoundManagerConfig::checkSampleRate(const SoundManager &soundManager) {
     if (!soundManager.getSampleRates(m_api).contains(m_sampleRate)) {
         return false;
@@ -462,6 +467,8 @@ bool SoundManagerConfig::hasExternalRecordBroadcast() {
 /// @param flags Bitfield to determine which defaults to load, use something
 ///              like SoundManagerConfig::API | SoundManagerConfig::DEVICES to
 ///              load default API and master device.
+// TODO(xxx) Why require SoundManager here? SoundManagerConfig can only be constructed
+// with SoundManager anyway, and SoundManager doesn't change
 void SoundManagerConfig::loadDefaults(SoundManager* soundManager, unsigned int flags) {
     if (flags & SoundManagerConfig::API) {
         QList<QString> apiList = soundManager->getHostAPIList();

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -61,6 +61,8 @@ void SoundManagerConfig::setFilePath(const QFileInfo& configFile) {
 /// path
 /// @returns false if the file can't be read or is invalid XML, true otherwise
 bool SoundManagerConfig::readFromDisk() {
+    qDebug() << "   ***";
+    qDebug() << "   *** soundconfig::readFromDisk";
     QFile file(m_configFile.absoluteFilePath());
     QDomDocument doc;
     QDomElement rootElement;
@@ -103,6 +105,7 @@ bool SoundManagerConfig::readFromDisk() {
         if (deviceIdFromFile.name.isEmpty()) {
             continue;
         }
+        qDebug() << "   *** dev:" << deviceIdFromFile.name;
 
         // TODO: remove this ugly hack after Mixxx 2.2.3 is released
         QRegularExpressionMatch match = kLegacyFormatRegex.match(deviceIdFromFile.name);
@@ -116,9 +119,11 @@ bool SoundManagerConfig::readFromDisk() {
         }
 
         int devicesMatchingByName = 0;
+        qDebug() << "       trying to find dev amongst available devices";
         for (const auto& soundDevice : soundDevices) {
             SoundDeviceId hardwareDeviceId = soundDevice->getDeviceId();
             if (hardwareDeviceId.name == deviceIdFromFile.name) {
+                qDebug() << "       found" << deviceIdFromFile.name;
                 devicesMatchingByName++;
             }
         }
@@ -127,6 +132,9 @@ bool SoundManagerConfig::readFromDisk() {
         QDomNodeList inElements(devElement.elementsByTagName(xmlElementInput));
 
         if (devicesMatchingByName == 0) {
+            qDebug() << "       ! didn't find" << deviceIdFromFile.name;
+            // TODO(ronso0) Store dvice name and somehow submit to SoundManager
+            // when it's trying to setupDevices()
             continue;
         } else if (devicesMatchingByName == 1) {
             // There is only one device with this name, so it is unambiguous

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -54,11 +54,9 @@ SoundManagerConfig::SoundManagerConfig(SoundManager* pSoundManager)
     m_configFile = QFileInfo(QDir(CmdlineArgs::Instance().getSettingsPath()).filePath(SOUNDMANAGERCONFIG_FILENAME));
 }
 
-/**
- * Read the SoundManagerConfig xml serialization at the predetermined
- * path
- * @returns false if the file can't be read or is invalid XML, true otherwise
- */
+/// Read the SoundManagerConfig xml serialization at the predetermined
+/// path
+/// @returns false if the file can't be read or is invalid XML, true otherwise
 bool SoundManagerConfig::readFromDisk() {
     QFile file(m_configFile.absoluteFilePath());
     QDomDocument doc;
@@ -281,12 +279,10 @@ void SoundManagerConfig::setAPI(const QString &api) {
     m_api = api;
 }
 
-/**
- * Checks that the API in the object is valid according to the list of APIs
- * given by SoundManager.
- * @returns false if the API is not found in SoundManager's list, otherwise
- *          true
- */
+/// Checks that the API in the object is valid according to the list of APIs
+/// given by SoundManager.
+/// @returns false if the API is not found in SoundManager's list, otherwise
+///          true
 bool SoundManagerConfig::checkAPI() {
     VERIFY_OR_DEBUG_ASSERT(m_pSoundManager != nullptr) {
         return false;
@@ -324,12 +320,10 @@ void SoundManagerConfig::setForceNetworkClock(bool force) {
     m_forceNetworkClock = force;
 }
 
-/**
- * Checks that the sample rate in the object is valid according to the list of
- * sample rates given by SoundManager.
- * @returns false if the sample rate is not found in SoundManager's list,
- *          otherwise true
- */
+/// Checks that the sample rate in the object is valid according to the list of
+/// sample rates given by SoundManager.
+/// @returns false if the sample rate is not found in SoundManager's list,
+///          otherwise true
 bool SoundManagerConfig::checkSampleRate(const SoundManager &soundManager) {
     if (!soundManager.getSampleRates(m_api).contains(m_sampleRate)) {
         return false;
@@ -412,13 +406,12 @@ double SoundManagerConfig::getProcessingLatency() const {
     return static_cast<double>(getFramesPerBuffer()) / m_sampleRate * 1000.0;
 }
 
-
-// Set the audio buffer size
-// @warning This IS NOT a value in milliseconds, or a number of frames per
-// buffer. It is an index, where 1 is the first power-of-two buffer size (in
-// frames) which corresponds to a latency greater than or equal to 1 ms, 2 is
-// the second, etc. This is so that latency values are roughly equivalent
-// between different sample rates.
+/// Set the audio buffer size
+/// @warning This IS NOT a value in milliseconds, or a number of frames per
+/// buffer. It is an index, where 1 is the first power-of-two buffer size (in
+/// frames) which corresponds to a latency greater than or equal to 1 ms, 2 is
+/// the second, etc. This is so that latency values are roughly equivalent
+/// between different sample rates.
 void SoundManagerConfig::setAudioBufferSizeIndex(unsigned int sizeIndex) {
     // latency should be either the min of kMaxAudioBufferSizeIndex and the passed value
     // if it's 0, pretend it was 1 -- bkgood
@@ -464,13 +457,11 @@ bool SoundManagerConfig::hasExternalRecordBroadcast() {
     return m_bExternalRecordBroadcastConnected;
 }
 
-/**
- * Loads default values for API, master output, sample rate and/or latency.
- * @param soundManager pointer to SoundManager instance to load data from
- * @param flags Bitfield to determine which defaults to load, use something
- *              like SoundManagerConfig::API | SoundManagerConfig::DEVICES to
- *              load default API and master device.
- */
+/// Loads default values for API, master output, sample rate and/or latency.
+/// @param soundManager pointer to SoundManager instance to load data from
+/// @param flags Bitfield to determine which defaults to load, use something
+///              like SoundManagerConfig::API | SoundManagerConfig::DEVICES to
+///              load default API and master device.
 void SoundManagerConfig::loadDefaults(SoundManager* soundManager, unsigned int flags) {
     if (flags & SoundManagerConfig::API) {
         QList<QString> apiList = soundManager->getHostAPIList();

--- a/src/soundio/soundmanagerconfig.h
+++ b/src/soundio/soundmanagerconfig.h
@@ -1,9 +1,5 @@
 #pragma once
 
-#define SOUNDMANAGERCONFIG_DEFAULT_NAME "soundconfig"
-#define SOUNDMANAGERCONFIG_EXTENSION ".xml"
-#define SOUNDMANAGERCONFIG_DEFAULT_FILE "soundconfig.xml"
-
 #include <QFileInfo>
 #include <QMultiHash>
 #include <QString>

--- a/src/soundio/soundmanagerconfig.h
+++ b/src/soundio/soundmanagerconfig.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#ifndef SOUNDMANAGERCONFIG_FILENAME
-#define SOUNDMANAGERCONFIG_FILENAME "soundconfig.xml"
-#endif
+#define SOUNDMANAGERCONFIG_DEFAULT_NAME "soundconfig"
+#define SOUNDMANAGERCONFIG_EXTENSION ".xml"
+#define SOUNDMANAGERCONFIG_DEFAULT_FILE "soundconfig.xml"
 
-#include <QString>
-#include <QMultiHash>
 #include <QFileInfo>
+#include <QMultiHash>
+#include <QString>
 
 #include "soundio/soundmanagerutil.h"
 
@@ -32,6 +32,7 @@ public:
   static const int kDefaultAudioBufferSizeIndex;
   static const int kDefaultSyncBuffers;
 
+  void setFilePath(const QFileInfo& configFile);
   bool readFromDisk();
   bool writeToDisk() const;
   QString getAPI() const;

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -146,6 +146,16 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(settingsPath);
     parser.addOption(settingsPathDeprecated);
 
+    // sound configuration file
+    const QCommandLineOption soundConfig(QStringLiteral("sound-config"),
+            forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
+                                      "Sound config file in specified settings path"
+                                      "Mixxx should use. "
+                                      "Default is: soundconfig.xml")
+                            : QString(),
+            QStringLiteral("path"));
+    parser.addOption(soundConfig);
+
     // resource path
     QCommandLineOption resourcePath(QStringLiteral("resource-path"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
@@ -317,6 +327,10 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
             m_settingsPath.append("/");
         }
         m_settingsPathSet = true;
+    }
+
+    if (parser.isSet(soundConfig)) {
+        m_soundConfig = parser.value(soundConfig);
     }
 
     if (parser.isSet(resourcePath)) {

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -111,6 +111,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
                 MIXXX_MANUAL_COMMANDLINEOPTIONS_URL);
     }
     // add options
+    // full-screen
     const QCommandLineOption fullScreen(
             QStringList({QStringLiteral("f"), QStringLiteral("full-screen")}),
             forUserFeedback ? QCoreApplication::translate(
@@ -121,6 +122,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(fullScreen);
     parser.addOption(fullScreenDeprecated);
 
+    // locale
     const QCommandLineOption locale(QStringLiteral("locale"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Use a custom locale for loading translations. (e.g "
@@ -129,7 +131,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
             QStringLiteral("locale"));
     parser.addOption(locale);
 
-    // An option with a value
+    // settings path
     const QCommandLineOption settingsPath(QStringLiteral("settings-path"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Top-level directory where Mixxx should look for settings. "
@@ -144,6 +146,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(settingsPath);
     parser.addOption(settingsPathDeprecated);
 
+    // resource path
     QCommandLineOption resourcePath(QStringLiteral("resource-path"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Top-level directory where Mixxx should look for its "
@@ -158,6 +161,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(resourcePath);
     parser.addOption(resourcePathDeprecated);
 
+    // timeline path
     const QCommandLineOption timelinePath(QStringLiteral("timeline-path"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Path the debug statistics time line is written to")
@@ -170,6 +174,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(timelinePath);
     parser.addOption(timelinePathDeprecated);
 
+    // controller debug
     const QCommandLineOption controllerDebug(QStringLiteral("controller-debug"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Causes Mixxx to display/log all of the controller data it "
@@ -182,6 +187,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(controllerDebug);
     parser.addOption(controllerDebugDeprecated);
 
+    // developer mode
     const QCommandLineOption developer(QStringLiteral("developer"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Enables developer-mode. Includes extra log info, stats on "
@@ -189,6 +195,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
                             : QString());
     parser.addOption(developer);
 
+    // safe mode
     const QCommandLineOption safeMode(QStringLiteral("safe-mode"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Enables safe-mode. Disables OpenGL waveforms, and "
@@ -200,6 +207,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(safeMode);
     parser.addOption(safeModeDeprecated);
 
+    // console colors
     const QCommandLineOption color(QStringLiteral("color"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "[auto|always|never] Use colors on the console output.")
@@ -208,6 +216,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
             QStringLiteral("auto"));
     parser.addOption(color);
 
+    // log level
     const QCommandLineOption logLevel(QStringLiteral("log-level"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Sets the verbosity of command line logging.\n"
@@ -224,6 +233,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(logLevel);
     parser.addOption(logLevelDeprecated);
 
+    // log flush level
     const QCommandLineOption logFlushLevel(QStringLiteral("log-flush-level"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Sets the the logging level at which the log buffer is "
@@ -238,6 +248,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(logFlushLevel);
     parser.addOption(logFlushLevelDeprecated);
 
+    // debug asserts
     QCommandLineOption debugAssertBreak(QStringLiteral("debug-assert-break"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Breaks (SIGINT) Mixxx, if a DEBUG_ASSERT evaluates to "
@@ -252,6 +263,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     const QCommandLineOption helpOption = parser.addHelpOption();
     const QCommandLineOption versionOption = parser.addVersionOption();
 
+    // load music files
     parser.addPositionalArgument(QStringLiteral("file"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Load the specified music file(s) at start-up. Each file "

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -46,6 +46,9 @@ class CmdlineArgs final {
     bool getTimelineEnabled() const { return !m_timelinePath.isEmpty(); }
     const QString& getLocale() const { return m_locale; }
     const QString& getSettingsPath() const { return m_settingsPath; }
+    const QString& getSoundConfig() const {
+        return m_soundConfig;
+    }
     void setSettingsPath(const QString& newSettingsPath) {
         m_settingsPath = newSettingsPath;
     }
@@ -81,6 +84,7 @@ class CmdlineArgs final {
     mixxx::LogLevel m_logFlushLevel; // Level of mixx.log file flushing
     QString m_locale;
     QString m_settingsPath;
+    QString m_soundConfig;
     QString m_resourcePath;
     QString m_timelinePath;
 };


### PR DESCRIPTION
one more step for resolving https://bugs.launchpad.net/mixxx/+bug/1516035
based on #4859 

File name pattern is `soundconfig_profileName.xml`. `profileName` must consist of alphanumerics & _

**ToDo:**
- [x] select sound profile from command line `--sound-config [profileName]`
- [x] add sound profile selector to **Sound Hardware** preferences, populate with `soundconfig*.xml` files found in settings directory
- [ ] allow deleting, renaming & duplicating of profiles
- [ ] fix some issues in DlgPrefSound: save all changes only in slotApply (atm some are applied instantly)

**Nice to have:**
* allow controller mappings/scripts to load a specific config?
* store profile name in sound profile? necessary? how to deal with duplicate names?