### PR TITLE
Cover Art Label & Cover Art Full Size composition with menu

### DIFF
--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -11,10 +11,13 @@
 #include "track/track.h"
 #include "util/widgethelper.h"
 
-DlgCoverArtFullSize::DlgCoverArtFullSize(QWidget* parent, BaseTrackPlayer* pPlayer)
+DlgCoverArtFullSize::DlgCoverArtFullSize(
+        QWidget* parent,
+        BaseTrackPlayer* pPlayer,
+        WCoverArtMenu* pCoverMenu)
         : QDialog(parent),
           m_pPlayer(pPlayer),
-          m_pCoverMenu(make_parented<WCoverArtMenu>(this)) {
+          m_pCoverMenu(pCoverMenu) {
     CoverArtCache* pCache = CoverArtCache::instance();
     if (pCache) {
         connect(pCache,
@@ -28,14 +31,16 @@ DlgCoverArtFullSize::DlgCoverArtFullSize(QWidget* parent, BaseTrackPlayer* pPlay
             &DlgCoverArtFullSize::customContextMenuRequested,
             this,
             &DlgCoverArtFullSize::slotCoverMenu);
-    connect(m_pCoverMenu,
-            &WCoverArtMenu::coverInfoSelected,
-            this,
-            &DlgCoverArtFullSize::slotCoverInfoSelected);
-    connect(m_pCoverMenu,
-            &WCoverArtMenu::reloadCoverArt,
-            this,
-            &DlgCoverArtFullSize::slotReloadCoverArt);
+    if (m_pCoverMenu != nullptr) {
+        connect(m_pCoverMenu,
+                &WCoverArtMenu::coverInfoSelected,
+                this,
+                &DlgCoverArtFullSize::slotCoverInfoSelected);
+        connect(m_pCoverMenu,
+                &WCoverArtMenu::reloadCoverArt,
+                this,
+                &DlgCoverArtFullSize::slotReloadCoverArt);
+    }
 
     if (m_pPlayer != nullptr) {
         connect(pPlayer,
@@ -219,7 +224,8 @@ void DlgCoverArtFullSize::slotCoverInfoSelected(
 }
 
 void DlgCoverArtFullSize::mousePressEvent(QMouseEvent* event) {
-    if (!m_pCoverMenu->isVisible() && event->button() == Qt::LeftButton) {
+    if (m_pCoverMenu != nullptr && !m_pCoverMenu->isVisible() &&
+            event->button() == Qt::LeftButton) {
         m_clickTimer.setSingleShot(true);
         m_clickTimer.start(500);
         m_coverPressed = true;
@@ -234,7 +240,7 @@ void DlgCoverArtFullSize::mousePressEvent(QMouseEvent* event) {
 
 void DlgCoverArtFullSize::mouseReleaseEvent(QMouseEvent* event) {
     m_coverPressed = false;
-    if (m_pCoverMenu->isVisible()) {
+    if (m_pCoverMenu != nullptr && m_pCoverMenu->isVisible()) {
         return;
     }
 
@@ -265,7 +271,9 @@ void DlgCoverArtFullSize::mouseMoveEvent(QMouseEvent* event) {
 }
 
 void DlgCoverArtFullSize::slotCoverMenu(const QPoint& pos) {
-    m_pCoverMenu->popup(mapToGlobal(pos));
+    if (m_pCoverMenu != nullptr) {
+        m_pCoverMenu->popup(mapToGlobal(pos));
+    }
 }
 
 void DlgCoverArtFullSize::resizeEvent(QResizeEvent* event) {

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -224,8 +224,10 @@ void DlgCoverArtFullSize::slotCoverInfoSelected(
 }
 
 void DlgCoverArtFullSize::mousePressEvent(QMouseEvent* event) {
-    if (m_pCoverMenu != nullptr && !m_pCoverMenu->isVisible() &&
-            event->button() == Qt::LeftButton) {
+    if (event->button() != Qt::LeftButton) {
+        return;
+    }
+    if ((m_pCoverMenu != nullptr && !m_pCoverMenu->isVisible()) || m_pCoverMenu == nullptr) {
         m_clickTimer.setSingleShot(true);
         m_clickTimer.start(500);
         m_coverPressed = true;

--- a/src/library/dlgcoverartfullsize.h
+++ b/src/library/dlgcoverartfullsize.h
@@ -16,7 +16,9 @@ class DlgCoverArtFullSize
           public Ui::DlgCoverArtFullSize {
     Q_OBJECT
   public:
-    explicit DlgCoverArtFullSize(QWidget* parent, BaseTrackPlayer* pPlayer = nullptr);
+    explicit DlgCoverArtFullSize(QWidget* parent,
+            BaseTrackPlayer* pPlayer = nullptr,
+            WCoverArtMenu* pCoverMenu = nullptr);
     ~DlgCoverArtFullSize() override = default;
 
     void init(TrackPointer pTrack);
@@ -46,7 +48,7 @@ class DlgCoverArtFullSize
     QPixmap m_pixmap;
     TrackPointer m_pLoadedTrack;
     BaseTrackPlayer* m_pPlayer;
-    parented_ptr<WCoverArtMenu> m_pCoverMenu;
+    WCoverArtMenu* m_pCoverMenu;
     QTimer m_clickTimer;
     QPoint m_dragStartPosition;
     bool m_coverPressed;

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -22,6 +22,7 @@
 #include "util/desktophelper.h"
 #include "util/duration.h"
 #include "widget/wcoverartlabel.h"
+#include "widget/wcoverartmenu.h"
 #include "widget/wstarrating.h"
 
 namespace {
@@ -42,7 +43,8 @@ DlgTrackInfo::DlgTrackInfo(
         : QDialog(nullptr),
           m_pTrackModel(trackModel),
           m_tapFilter(this, kFilterLength, kMaxInterval),
-          m_pWCoverArtLabel(make_parented<WCoverArtLabel>(this)),
+          m_pWCoverArtMenu(make_parented<WCoverArtMenu>(this)),
+          m_pWCoverArtLabel(make_parented<WCoverArtLabel>(this, m_pWCoverArtMenu)),
           m_pWStarRating(make_parented<WStarRating>(nullptr, this)) {
     init();
 }
@@ -230,12 +232,14 @@ void DlgTrackInfo::init() {
                 this,
                 &DlgTrackInfo::slotCoverFound);
     }
-    connect(m_pWCoverArtLabel.get(),
-            &WCoverArtLabel::coverInfoSelected,
+
+    connect(m_pWCoverArtMenu,
+            &WCoverArtMenu::coverInfoSelected,
             this,
             &DlgTrackInfo::slotCoverInfoSelected);
-    connect(m_pWCoverArtLabel.get(),
-            &WCoverArtLabel::reloadCoverArt,
+
+    connect(m_pWCoverArtMenu,
+            &WCoverArtMenu::reloadCoverArt,
             this,
             &DlgTrackInfo::slotReloadCoverArt);
 }

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -16,6 +16,7 @@
 class TrackModel;
 class DlgTagFetcher;
 class WCoverArtLabel;
+class WCoverArtMenu;
 class WStarRating;
 
 /// A dialog box to display and edit track properties.
@@ -114,6 +115,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     TapFilter m_tapFilter;
     mixxx::Bpm m_lastTapedBpm;
 
+    parented_ptr<WCoverArtMenu> m_pWCoverArtMenu;
     parented_ptr<WCoverArtLabel> m_pWCoverArtLabel;
     parented_ptr<WStarRating> m_pWStarRating;
 

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -19,9 +19,9 @@
 #include "widget/wskincolor.h"
 
 WCoverArt::WCoverArt(QWidget* parent,
-                     UserSettingsPointer pConfig,
-                     const QString& group,
-                     BaseTrackPlayer* pPlayer)
+        UserSettingsPointer pConfig,
+        const QString& group,
+        BaseTrackPlayer* pPlayer)
         : QWidget(parent),
           WBaseWidget(this),
           m_group(group),
@@ -29,7 +29,7 @@ WCoverArt::WCoverArt(QWidget* parent,
           m_bEnable(true),
           m_pMenu(new WCoverArtMenu(this)),
           m_pPlayer(pPlayer),
-          m_pDlgFullSize(new DlgCoverArtFullSize(this, pPlayer)) {
+          m_pDlgFullSize(new DlgCoverArtFullSize(this, pPlayer, m_pMenu)) {
     // Accept drops if we have a group to load tracks into.
     setAcceptDrops(!m_group.isEmpty());
 

--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -30,20 +30,14 @@ QPixmap createDefaultCover(QWidget* parent) {
 
 } // anonymous namespace
 
-WCoverArtLabel::WCoverArtLabel(QWidget* parent)
+WCoverArtLabel::WCoverArtLabel(QWidget* parent, WCoverArtMenu* pCoverMenu)
         : QLabel(parent),
-          m_pCoverMenu(make_parented<WCoverArtMenu>(this)),
-          m_pDlgFullSize(make_parented<DlgCoverArtFullSize>(this)),
+          m_pCoverMenu(pCoverMenu),
+          m_pDlgFullSize(make_parented<DlgCoverArtFullSize>(this, nullptr, pCoverMenu)),
           m_defaultCover(createDefaultCover(this)) {
     setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
     setFrameShape(QFrame::Box);
     setAlignment(Qt::AlignCenter);
-    connect(m_pCoverMenu,
-            &WCoverArtMenu::coverInfoSelected,
-            this,
-            &WCoverArtLabel::coverInfoSelected);
-    connect(m_pCoverMenu, &WCoverArtMenu::reloadCoverArt, this, &WCoverArtLabel::reloadCoverArt);
-
     setPixmap(m_defaultCover);
 }
 
@@ -51,7 +45,9 @@ WCoverArtLabel::~WCoverArtLabel() = default;
 
 void WCoverArtLabel::setCoverArt(const CoverInfo& coverInfo,
         const QPixmap& px) {
-    m_pCoverMenu->setCoverArt(coverInfo);
+    if (m_pCoverMenu != nullptr) {
+        m_pCoverMenu->setCoverArt(coverInfo);
+    }
     if (px.isNull()) {
         m_loadedCover = px;
         setPixmap(m_defaultCover);
@@ -59,22 +55,27 @@ void WCoverArtLabel::setCoverArt(const CoverInfo& coverInfo,
         m_loadedCover = scaleCoverLabel(this, px);
         setPixmap(m_loadedCover);
     }
-
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
     QSize frameSize = pixmap(Qt::ReturnByValue).size() / devicePixelRatioF();
 #else
     QSize frameSize = pixmap()->size() / devicePixelRatioF();
 #endif
-    frameSize += QSize(2,2); // margin
+    frameSize += QSize(2, 2); // margin
     setMinimumSize(frameSize);
     setMaximumSize(frameSize);
 }
 
 void WCoverArtLabel::slotCoverMenu(const QPoint& pos) {
+    if (m_pCoverMenu == nullptr) {
+        return;
+    }
     m_pCoverMenu->popup(mapToGlobal(pos));
 }
 
 void WCoverArtLabel::contextMenuEvent(QContextMenuEvent* event) {
+    if (m_pCoverMenu == nullptr) {
+        return;
+    }
     event->accept();
     m_pCoverMenu->popup(event->globalPos());
 }
@@ -84,7 +85,7 @@ void WCoverArtLabel::loadTrack(TrackPointer pTrack) {
 }
 
 void WCoverArtLabel::mousePressEvent(QMouseEvent* event) {
-    if (m_pCoverMenu->isVisible()) {
+    if (m_pCoverMenu != nullptr && m_pCoverMenu->isVisible()) {
         return;
     }
 

--- a/src/widget/wcoverartlabel.h
+++ b/src/widget/wcoverartlabel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QLabel>
+#include <QMenu>
 #include <QMouseEvent>
 #include <QPixmap>
 #include <QWidget>
@@ -16,15 +17,12 @@ class CoverInfoRelative;
 class WCoverArtLabel : public QLabel {
     Q_OBJECT
   public:
-    explicit WCoverArtLabel(QWidget* parent = nullptr);
+    explicit WCoverArtLabel(QWidget* parent = nullptr, WCoverArtMenu* m_pWCoverArtMenu = nullptr);
+
     ~WCoverArtLabel() override; // Verifies that the base destructor is virtual
 
     void setCoverArt(const CoverInfo& coverInfo, const QPixmap& px);
     void loadTrack(TrackPointer pTrack);
-
-  signals:
-    void coverInfoSelected(const CoverInfoRelative& coverInfo);
-    void reloadCoverArt();
 
   protected:
     void mousePressEvent(QMouseEvent* event) override;
@@ -34,7 +32,8 @@ class WCoverArtLabel : public QLabel {
       void slotCoverMenu(const QPoint& pos);
 
   private:
-    const parented_ptr<WCoverArtMenu> m_pCoverMenu;
+    WCoverArtMenu* m_pCoverMenu;
+
     const parented_ptr<DlgCoverArtFullSize> m_pDlgFullSize;
 
     const QPixmap m_defaultCover;

--- a/src/widget/wcoverartlabel.h
+++ b/src/widget/wcoverartlabel.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <QLabel>
-#include <QMenu>
 #include <QMouseEvent>
 #include <QPixmap>
 #include <QWidget>

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -63,8 +63,8 @@ WSpinny::WSpinny(
           m_bClampFailedWarning(false),
           m_bGhostPlayback(false),
           m_pPlayer(pPlayer),
-          m_pDlgCoverArt(new DlgCoverArtFullSize(parent, pPlayer)),
-          m_pCoverMenu(new WCoverArtMenu(this)) {
+          m_pCoverMenu(new WCoverArtMenu(this)),
+          m_pDlgCoverArt(new DlgCoverArtFullSize(parent, pPlayer, m_pCoverMenu)) {
 #ifdef __VINYLCONTROL__
     m_pVCManager = pVCMan;
 #else

--- a/src/widget/wspinny.h
+++ b/src/widget/wspinny.h
@@ -135,6 +135,6 @@ class WSpinny : public QGLWidget, public WBaseWidget, public VinylSignalQualityL
     bool m_bGhostPlayback;
 
     BaseTrackPlayer* m_pPlayer;
-    DlgCoverArtFullSize* m_pDlgCoverArt;
     WCoverArtMenu* m_pCoverMenu;
+    DlgCoverArtFullSize* m_pDlgCoverArt;
 };


### PR DESCRIPTION
Hey everyone! 

I want to add cover art fetcher [[on this PR]](https://github.com/mixxxdj/mixxx/pull/4851), but for to do that I need to have another cover art label's without/different menu and DlgCoverArtFullSize. I have tried to make a base class without menu and inherit the existing label-full-size from that. But this caused as code duplication and new files which can make the code base crowded. Also, adding everything in a huge pr would make it difficult to review and also to merge. So, we wanted to move with small steps. Here is the first little PR of the cover art-fetcher.

To display cover arts without menu, I have tried composition approach, according to my tests, if there is no cover art menu passed to these two classes, it doesn't pop-up the menu on right click. In order for me to move forward, I need to find a best solution for to display cover art's with or without menu. 

Any feedback would be so good!

Thanks in advance.    