### PR TITLE
EngineFilterDelay: clamp wrong delay values

### DIFF
--- a/src/engine/filters/enginefilterdelay.h
+++ b/src/engine/filters/enginefilterdelay.h
@@ -29,6 +29,15 @@ class EngineFilterDelay : public EngineObjectConstIn {
 
     void setDelay(unsigned int delaySamples) {
         m_delaySamples = delaySamples;
+
+        // When mixxx will support other channel count variants than stereo,
+        // the kMaxDelay has to be divisible by the number of channels.
+        // Otherwise, channels may be swapped.
+        const int maxDelaySamples = static_cast<int>(SIZE - mixxx::kEngineChannelCount);
+
+        VERIFY_OR_DEBUG_ASSERT(m_delaySamples <= maxDelaySamples) {
+            m_delaySamples = maxDelaySamples;
+        }
     }
 
     virtual void process(const CSAMPLE* pIn, CSAMPLE* pOutput,
@@ -40,15 +49,6 @@ class EngineFilterDelay : public EngineObjectConstIn {
             // (for example, x % y, where x is a negative value) produces negative results
             // (but in math the result value is positive).
             int delaySourcePos = (m_delayPos + SIZE - m_delaySamples) % SIZE;
-
-            VERIFY_OR_DEBUG_ASSERT(delaySourcePos >= 0) {
-                SampleUtil::copy(pOutput, pIn, iBufferSize);
-                return;
-            }
-            VERIFY_OR_DEBUG_ASSERT(delaySourcePos <= static_cast<int>(SIZE)) {
-                SampleUtil::copy(pOutput, pIn, iBufferSize);
-                return;
-            }
 
             for (int i = 0; i < iBufferSize; ++i) {
                 // put sample into delay buffer:
@@ -67,23 +67,6 @@ class EngineFilterDelay : public EngineObjectConstIn {
             // (but in math the result value is positive).
             int delaySourcePos = (m_delayPos + SIZE - m_delaySamples + iBufferSize / 2) % SIZE;
             int oldDelaySourcePos = (m_delayPos + SIZE - m_oldDelaySamples) % SIZE;
-
-            VERIFY_OR_DEBUG_ASSERT(delaySourcePos >= 0) {
-                SampleUtil::copy(pOutput, pIn, iBufferSize);
-                return;
-            }
-            VERIFY_OR_DEBUG_ASSERT(delaySourcePos <= static_cast<int>(SIZE)) {
-                SampleUtil::copy(pOutput, pIn, iBufferSize);
-                return;
-            }
-            VERIFY_OR_DEBUG_ASSERT(oldDelaySourcePos >= 0) {
-                SampleUtil::copy(pOutput, pIn, iBufferSize);
-                return;
-            }
-            VERIFY_OR_DEBUG_ASSERT(oldDelaySourcePos <= static_cast<int>(SIZE)) {
-                SampleUtil::copy(pOutput, pIn, iBufferSize);
-                return;
-            }
 
             double cross_mix = 0.0;
             double cross_inc = 2 / static_cast<double>(iBufferSize);


### PR DESCRIPTION
This PR moves the delay value checking into a setter in `EngineFilterDelay`. The reason, why the delay value checking should be updated is, that the previous version allows working with a huge not acceptable delay, but which is after inner calculation allowed due to it is a k-multiple (on the left side of the modulo operator) of the delay buffer size (on the right side of the modulo operator). Three examples for which is in previous version delay allowed, and should not be:

Let's work with the used size of the delay buffer as `SIZE = 3300`.

1. The first example works with delay size as 4*3300 = 13200
`
int delaySourcePos = (m_delayPos + SIZE - m_delaySamples) % SIZE = (0 + 3300 - 13200) % 3300 = -9900 % 3300 = 0
`

2. The second example works with a huge delay, but which is the same as `m_delayPos + SIZE`.
`
int delaySourcePos = (m_delayPos + SIZE - m_delaySamples) % SIZE = (2426 + 3300 - 5726) % 3300 = 0 % 3300 = 0
`

3. The third example works with the situation similar to 1, anyway, it shows that the position has not to be zero.
`
int delaySourcePos = (m_delayPos + SIZE - m_delaySamples) % SIZE = (1024 + 3300 - 7624) % 3300 = -3300 % 3300 = 0
`

Based on the delay value checking in the setter, the situation, that the previous used `VERIFY_OR_DEBUG_ASSERT` will be violated should not occur.