### PR TITLE
DlgTagFetcher new feedback system

### DIFF
--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -10,6 +10,15 @@
 
 namespace {
 
+// Percent of QProgressBar when dialog populated, "fingerprinting".
+int kPercentOfPopulation = 10;
+
+// Percent of "identifying" and "retrieving" metadata.
+int kPercentOfConstantTask = 15;
+
+// Percent left for Recording ID's found, "Fetching track data from Musicbrainz".
+int kPercentOfRecordingsFound = 60;
+
 QStringList trackColumnValues(
         const Track& track) {
     const mixxx::TrackMetadata trackMetadata = track.getMetadata();
@@ -270,7 +279,7 @@ void DlgTagFetcher::reject() {
 void DlgTagFetcher::fetchTagProgress(const QString& text) {
     QString status = tr("Status: %1");
     loadingProgressBar->setFormat(status.arg(text));
-    m_progressBarValue += 15;
+    m_progressBarValue += kPercentOfConstantTask;
     loadingProgressBar->setValue(m_progressBarValue);
 }
 
@@ -283,7 +292,7 @@ void DlgTagFetcher::progressBarSetCurrentStep() {
 
 // TODO(fatihemreyildiz): display the task results one by one.
 void DlgTagFetcher::progressBarSetTotalSteps(int totalRecordingsFound) {
-    m_incrementBarValueBy = 60 / totalRecordingsFound;
+    m_incrementBarValueBy = kPercentOfRecordingsFound / totalRecordingsFound;
 }
 
 void DlgTagFetcher::fetchTagFinished(
@@ -319,7 +328,7 @@ void DlgTagFetcher::slotNetworkResult(
 }
 
 void DlgTagFetcher::updateStack() {
-    m_progressBarValue = 10;
+    m_progressBarValue = kPercentOfPopulation;
     loadingProgressBar->setValue(m_progressBarValue);
 
     btnApply->setDisabled(true);

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -234,9 +234,22 @@ void DlgTagFetcher::apply() {
 
 void DlgTagFetcher::retry() {
     results->clear();
-    m_data = Data();
+    disconnect(m_track.get(),
+            &Track::changed,
+            this,
+            &DlgTagFetcher::slotTrackChanged);
+
     addDivider(tr("Original tags"), results);
     addTrack(trackColumnValues(*m_track), -1, results);
+
+    m_data = Data();
+    m_networkResult = NetworkResult::Ok;
+
+    connect(m_track.get(),
+            &Track::changed,
+            this,
+            &DlgTagFetcher::slotTrackChanged);
+
     m_tagFetcher.startFetch(m_track);
     updateStack();
 }

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -319,13 +319,13 @@ void DlgTagFetcher::updateStack() {
         return;
     } else if (m_data.m_results.isEmpty()) {
         loadingProgressBar->setValue(loadingProgressBar->maximum());
-        QString emptyMessage = tr("Mixxx could not find this track in the musicbrainz database.");
+        QString emptyMessage = tr("Mixxx could not find this track in the MusicBrainz database.");
         loadingProgressBar->setFormat(emptyMessage);
         return;
     }
     btnApply->setEnabled(true);
     loadingProgressBar->setValue(loadingProgressBar->maximum());
-    QString finishedMessage = tr("Mixxx found the metadata.");
+    QString finishedMessage = tr("The results are ready to be applied.");
     loadingProgressBar->setFormat(finishedMessage);
 
     VERIFY_OR_DEBUG_ASSERT(m_track) {

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -244,23 +244,8 @@ void DlgTagFetcher::apply() {
 }
 
 void DlgTagFetcher::retry() {
-    results->clear();
-    disconnect(m_track.get(),
-            &Track::changed,
-            this,
-            &DlgTagFetcher::slotTrackChanged);
-
-    addDivider(tr("Original tags"), results);
-    addTrack(trackColumnValues(*m_track), -1, results);
-
-    m_data = Data();
+    m_data.m_pending = true;
     m_networkResult = NetworkResult::Ok;
-
-    connect(m_track.get(),
-            &Track::changed,
-            this,
-            &DlgTagFetcher::slotTrackChanged);
-
     m_tagFetcher.startFetch(m_track);
     btnRetry->setDisabled(true);
     updateStack();

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -318,14 +318,24 @@ void DlgTagFetcher::slotNetworkResult(
         QString cantConnect = tr("Can't connect to %1.");
         loadingProgressBar->setFormat(cantConnect.arg(app));
     }
-    btnRetry->setVisible(true);
-    //Some of the tracks has additional XML, but it returns the 403 error.
-    //If it happens we let user know and prevent to retry fetching many times.
+    //Some of the tracks can return XML, but they return either 203 or 403.
+    //The error 403 appears for some tracks permamently.
+    //Disabling the retry button could be an option for these tracks.
+    //But OTOH, some tracks can return suggested tags.
+    //After a few times of retry.
     if (code == 403) {
         QString cantParse = tr("Unknown error while getting metadata.");
         loadingProgressBar->setFormat(cantParse);
+    }
+    btnRetry->setVisible(true);
+    //If error is 203 that means there is no available metadata in response.
+    //We let user know and prevent to retry fetching many times.
+    if (code == 203) {
+        QString cantParse = tr("Could not find this track in the MusicBrainz database.");
+        loadingProgressBar->setFormat(cantParse);
         btnRetry->setVisible(false);
     }
+
     updateStack();
 }
 

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -265,7 +265,10 @@ void DlgTagFetcher::progressBarSetCurrentStep() {
 }
 
 void DlgTagFetcher::progressBarSetTotalSteps(int totalRecordingsFound) {
-    loadingProgressBar->setTextVisible(true);
+    if (totalRecordingsFound < 4) {
+        totalRecordingsFound = 4;
+    }
+
     loadingProgressBar->setMaximum(totalRecordingsFound);
 }
 

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -10,16 +10,28 @@
 
 namespace {
 
-// Percent of QProgressBar when dialog populated, "fingerprinting".
-int kPercentOfPopulation = 10;
+// Constant percentages for QProgressBar.
+// There are 3 constant steps while fetching metadata from musicbrainz.
+// 1. -> "Fingerprinting track"
+// 2. -> "Identifying track through Acoustid"
+// 3. -> "Retrieving metadata from MusicBrainz
+// These three steps never change.
+// After these states passed, last step remains.
+// 4. -> "Fetching track data from the Musicbrainz database"
+// These step can be changed according to recording(s) fetched from Acoust ID
 
-// Percent of "identifying" and "retrieving" metadata.
-int kPercentOfConstantTask = 15;
+// In order to have a better scaling, constant steps set to a percentage and never changes.
+// Last step is set to a constant percentage and it is divided to recording(s) found from Acoust ID.
 
-// Percent left for Recording ID's found, "Fetching track data from Musicbrainz".
-int kPercentOfRecordingsFound = 60;
+// The dialog populates with the 15% and after each step value increases by 15%.
+// Before we get recording(s), the QProgressBar will be 45%.
+// Last step set to 55% and it is going to be divided to recording(s) received from Acoust ID.
 
-// Original Index of the track tag, listed all the time below 'Orginal Tags'.
+constexpr int kPercentOfConstantTask = 15;
+
+constexpr int kPercentLeftForRecordingsFound = 55;
+
+// Original Index of the track tag, listed all the time below 'Original Tags'.
 constexpr int kOriginalTrackIndex = 1;
 
 QStringList trackColumnValues(
@@ -280,7 +292,7 @@ void DlgTagFetcher::progressBarSetCurrentStep() {
 
 // TODO(fatihemreyildiz): display the task results one by one.
 void DlgTagFetcher::progressBarSetTotalSteps(int totalRecordingsFound) {
-    m_incrementBarValueBy = kPercentOfRecordingsFound / totalRecordingsFound;
+    m_incrementBarValueBy = kPercentLeftForRecordingsFound / totalRecordingsFound;
 }
 
 void DlgTagFetcher::fetchTagFinished(
@@ -316,7 +328,7 @@ void DlgTagFetcher::slotNetworkResult(
 }
 
 void DlgTagFetcher::updateStack() {
-    m_progressBarValue = kPercentOfPopulation;
+    m_progressBarValue = kPercentOfConstantTask;
     loadingProgressBar->setValue(m_progressBarValue);
 
     btnApply->setDisabled(true);

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -391,7 +391,7 @@ void DlgTagFetcher::resultSelected() {
     }
 
     if (results->currentItem()->data(0, Qt::UserRole).toInt() == -1) {
-        results->currentItem()->setFlags(Qt::NoItemFlags);
+        results->currentItem()->setFlags(Qt::ItemIsEnabled);
         return;
     }
     const int resultIndex = results->currentItem()->data(0, Qt::UserRole).toInt();

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -384,6 +384,10 @@ void DlgTagFetcher::resultSelected() {
         return;
     }
 
+    if (results->currentItem()->data(0, Qt::UserRole).toInt() == -1) {
+        results->currentItem()->setFlags(Qt::NoItemFlags);
+        return;
+    }
     const int resultIndex = results->currentItem()->data(0, Qt::UserRole).toInt();
     m_data.m_selectedResult = resultIndex;
 }

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -74,24 +74,24 @@ QStringList trackReleaseColumnValues(
 void addTrack(
         const QStringList& trackRow,
         int tagIndex,
-        QTreeWidget* parent) {
-    QTreeWidgetItem* item = new QTreeWidgetItem(parent, trackRow);
+        QTreeWidget* pParent) {
+    QTreeWidgetItem* item = new QTreeWidgetItem(pParent, trackRow);
     item->setData(0, Qt::UserRole, tagIndex);
     item->setData(0, Qt::TextAlignmentRole, Qt::AlignLeft);
 }
 
-void updateOriginalTag(const Track& track, QTreeWidget* parent) {
-    const mixxx::TrackMetadata trackMetadata = (track).getMetadata();
+void updateOriginalTag(const Track& track, QTreeWidget* pParent) {
+    const mixxx::TrackMetadata trackMetadata = track.getMetadata();
     const QString trackNumberAndTotal = TrackNumbers::joinAsString(
             trackMetadata.getTrackInfo().getTrackNumber(),
             trackMetadata.getTrackInfo().getTrackTotal());
 
-    parent->topLevelItem(1)->setText(0, trackMetadata.getTrackInfo().getTitle());
-    parent->topLevelItem(1)->setText(1, trackMetadata.getTrackInfo().getArtist());
-    parent->topLevelItem(1)->setText(2, trackMetadata.getAlbumInfo().getTitle());
-    parent->topLevelItem(1)->setText(3, trackMetadata.getTrackInfo().getYear());
-    parent->topLevelItem(1)->setText(4, trackNumberAndTotal);
-    parent->topLevelItem(1)->setText(5, trackMetadata.getAlbumInfo().getArtist());
+    pParent->topLevelItem(1)->setText(0, trackMetadata.getTrackInfo().getTitle());
+    pParent->topLevelItem(1)->setText(1, trackMetadata.getTrackInfo().getArtist());
+    pParent->topLevelItem(1)->setText(2, trackMetadata.getAlbumInfo().getTitle());
+    pParent->topLevelItem(1)->setText(3, trackMetadata.getTrackInfo().getYear());
+    pParent->topLevelItem(1)->setText(4, trackNumberAndTotal);
+    pParent->topLevelItem(1)->setText(5, trackMetadata.getAlbumInfo().getArtist());
 }
 
 } // anonymous namespace
@@ -379,8 +379,8 @@ void DlgTagFetcher::slotNetworkResult(
     return;
 }
 
-void DlgTagFetcher::addDivider(const QString& text, QTreeWidget* parent) const {
-    QTreeWidgetItem* item = new QTreeWidgetItem(parent);
+void DlgTagFetcher::addDivider(const QString& text, QTreeWidget* pParent) const {
+    QTreeWidgetItem* item = new QTreeWidgetItem(pParent);
     item->setFirstColumnSpanned(true);
     item->setText(0, text);
     item->setFlags(Qt::NoItemFlags);

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -32,7 +32,7 @@ constexpr int kPercentOfConstantTask = 15;
 constexpr int kPercentLeftForRecordingsFound = 55;
 
 // Original Index of the track tag, listed all the time below 'Original Tags'.
-constexpr int kOriginalTrackIndex = 1;
+constexpr int kOriginalTrackIndex = -1;
 
 QStringList trackColumnValues(
         const Track& track) {

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -265,8 +265,14 @@ void DlgTagFetcher::progressBarSetCurrentStep() {
 }
 
 void DlgTagFetcher::progressBarSetTotalSteps(int totalRecordingsFound) {
-    if (totalRecordingsFound < 4) {
-        totalRecordingsFound = 4;
+    // This function updates the bar with total metadata found for the track.
+    // Tag Fetcher has 3 steps these are:
+    // Fingerprinting the track, Identifiying the track, Retrieving metadata.
+    // For every step the progress bar is incrementing by one in order to have better scaling.
+    // If the track has less metadata then 4, the scaling jumps from %0 to %100.
+    // That is why we need to rearrenge the maximum value for to have better scaling.
+    while (totalRecordingsFound < 4) {
+        totalRecordingsFound++;
     }
 
     loadingProgressBar->setMaximum(totalRecordingsFound);

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -94,7 +94,7 @@ void DlgTagFetcher::init() {
             this,
             &DlgTagFetcher::progressBarSetTotalSteps);
     connect(&m_tagFetcher, &TagFetcher::networkError, this, &DlgTagFetcher::slotNetworkResult);
-    btnRetry->setVisible(false);
+    btnRetry->setEnabled(false);
 }
 
 void DlgTagFetcher::slotNext() {
@@ -328,21 +328,22 @@ void DlgTagFetcher::slotNetworkResult(
         QString cantParse = tr("Unknown error while getting metadata.");
         loadingProgressBar->setFormat(cantParse);
     }
-    btnRetry->setVisible(true);
     //If error is 203 that means there is no available metadata in response.
     //We let user know and prevent to retry fetching many times.
     //More Info: https://bugs.launchpad.net/mixxx/+bug/1983206
     if (code == 203) {
         QString cantParse = tr("Could not find this track in the MusicBrainz database.");
         loadingProgressBar->setFormat(cantParse);
-        btnRetry->setVisible(false);
     }
-
+    btnRetry->setEnabled(true);
     updateStack();
 }
 
 void DlgTagFetcher::updateStack() {
     btnApply->setDisabled(true);
+
+    successMessage->setVisible(false);
+    loadingProgressBar->setVisible(true);
     m_progressBarStep = 0;
     loadingProgressBar->setValue(m_progressBarStep);
     results->clear();
@@ -359,13 +360,15 @@ void DlgTagFetcher::updateStack() {
     } else if (m_data.m_results.isEmpty()) {
         loadingProgressBar->setValue(loadingProgressBar->maximum());
         QString emptyMessage = tr("Could not find this track in the MusicBrainz database.");
-        btnRetry->setVisible(false);
+        btnRetry->setEnabled(true);
         loadingProgressBar->setFormat(emptyMessage);
         return;
     }
     btnApply->setEnabled(true);
-    btnRetry->setVisible(false);
+    btnRetry->setEnabled(false);
     loadingProgressBar->setValue(loadingProgressBar->maximum());
+    successMessage->setVisible(true);
+    loadingProgressBar->setVisible(false);
     QString finishedMessage = tr("The results are ready to be applied.");
     loadingProgressBar->setFormat(finishedMessage);
 

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -323,6 +323,7 @@ void DlgTagFetcher::slotNetworkResult(
     //Disabling the retry button could be an option for these tracks.
     //But OTOH, some tracks can return suggested tags.
     //After a few times of retry.
+    //More Info: https://bugs.launchpad.net/mixxx/+bug/1983204
     if (code == 403) {
         QString cantParse = tr("Unknown error while getting metadata.");
         loadingProgressBar->setFormat(cantParse);
@@ -330,6 +331,7 @@ void DlgTagFetcher::slotNetworkResult(
     btnRetry->setVisible(true);
     //If error is 203 that means there is no available metadata in response.
     //We let user know and prevent to retry fetching many times.
+    //More Info: https://bugs.launchpad.net/mixxx/+bug/1983206
     if (code == 203) {
         QString cantParse = tr("Could not find this track in the MusicBrainz database.");
         loadingProgressBar->setFormat(cantParse);

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -301,14 +301,9 @@ void DlgTagFetcher::slotNetworkResult(
     if (m_networkResult == NetworkResult::UnknownError) {
         QString unknownError = tr("Can't connect to %1 for an unknown reason.");
         loadingProgressBar->setFormat(unknownError.arg(app));
-    } else if (m_networkResult == NetworkResult::HttpError) {
+    } else {
         QString cantConnect = tr("Can't connect to %1.");
         loadingProgressBar->setFormat(cantConnect.arg(app));
-    } else {
-        QString strError = tr("HTTP Status: %1");
-        QString strCode = tr("Code: %1");
-        loadingProgressBar->setFormat(strError.arg(httpError) + " " +
-                strCode.arg(code) + " " + message);
     }
     btnRetry->setVisible(true);
     updateStack();

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -19,6 +19,9 @@ int kPercentOfConstantTask = 15;
 // Percent left for Recording ID's found, "Fetching track data from Musicbrainz".
 int kPercentOfRecordingsFound = 60;
 
+// Original Index of the track tag, listed all the time below 'Orginal Tags'.
+constexpr int kOriginalTrackIndex = 1;
+
 QStringList trackColumnValues(
         const Track& track) {
     const mixxx::TrackMetadata trackMetadata = track.getMetadata();
@@ -323,7 +326,7 @@ void DlgTagFetcher::updateStack() {
 
     results->clear();
     addDivider(tr("Original tags"), results);
-    addTrack(trackColumnValues(*m_track), -1, results);
+    addTrack(trackColumnValues(*m_track), kOriginalTrackIndex, results);
 
     if (m_data.m_pending) {
         return;
@@ -399,7 +402,7 @@ void DlgTagFetcher::resultSelected() {
         return;
     }
 
-    if (results->currentItem()->data(0, Qt::UserRole).toInt() == -1) {
+    if (results->currentItem()->data(0, Qt::UserRole).toInt() == kOriginalTrackIndex) {
         results->currentItem()->setFlags(Qt::ItemIsEnabled);
         return;
     }

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -292,10 +292,10 @@ void DlgTagFetcher::slotNetworkResult(
     m_networkResult = httpError == 0 ? NetworkResult::UnknownError : NetworkResult::HttpError;
     m_data.m_pending = false;
     if (m_networkResult == NetworkResult::UnknownError) {
-        QString unknownError = tr("Mixxx can't connect to %1 for an unknown reason.");
+        QString unknownError = tr("Can't connect to %1 for an unknown reason.");
         loadingProgressBar->setFormat(unknownError.arg(app));
     } else if (m_networkResult == NetworkResult::HttpError) {
-        QString cantConnect = tr("Mixxx can't connect to %1.");
+        QString cantConnect = tr("Can't connect to %1.");
         loadingProgressBar->setFormat(cantConnect.arg(app));
     } else {
         QString strError = tr("HTTP Status: %1");
@@ -322,7 +322,7 @@ void DlgTagFetcher::updateStack() {
         return;
     } else if (m_data.m_results.isEmpty()) {
         loadingProgressBar->setValue(loadingProgressBar->maximum());
-        QString emptyMessage = tr("Mixxx could not find this track in the MusicBrainz database.");
+        QString emptyMessage = tr("Could not find this track in the MusicBrainz database.");
         loadingProgressBar->setFormat(emptyMessage);
         return;
     }

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -277,7 +277,7 @@ void DlgTagFetcher::reject() {
 }
 
 void DlgTagFetcher::fetchTagProgress(const QString& text) {
-    QString status = tr("Status: %1");
+    QString status = tr("%1");
     loadingProgressBar->setFormat(status.arg(text));
     m_progressBarValue += kPercentOfConstantTask;
     loadingProgressBar->setValue(m_progressBarValue);

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -319,6 +319,13 @@ void DlgTagFetcher::slotNetworkResult(
         loadingProgressBar->setFormat(cantConnect.arg(app));
     }
     btnRetry->setVisible(true);
+    //Some of the tracks has additional XML, but it returns the 403 error.
+    //If it happens we let user know and prevent to retry fetching many times.
+    if (code == 403) {
+        QString cantParse = tr("Unknown error while getting metadata.");
+        loadingProgressBar->setFormat(cantParse);
+        btnRetry->setVisible(false);
+    }
     updateStack();
 }
 
@@ -340,7 +347,7 @@ void DlgTagFetcher::updateStack() {
     } else if (m_data.m_results.isEmpty()) {
         loadingProgressBar->setValue(loadingProgressBar->maximum());
         QString emptyMessage = tr("Could not find this track in the MusicBrainz database.");
-        btnRetry->setVisible(true);
+        btnRetry->setVisible(false);
         loadingProgressBar->setFormat(emptyMessage);
         return;
     }

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -94,6 +94,7 @@ void DlgTagFetcher::init() {
             this,
             &DlgTagFetcher::progressBarSetTotalSteps);
     connect(&m_tagFetcher, &TagFetcher::networkError, this, &DlgTagFetcher::slotNetworkResult);
+    btnRetry->setVisible(false);
 }
 
 void DlgTagFetcher::slotNext() {
@@ -309,10 +310,12 @@ void DlgTagFetcher::slotNetworkResult(
         loadingProgressBar->setFormat(strError.arg(httpError) + " " +
                 strCode.arg(code) + " " + message);
     }
+    btnRetry->setVisible(true);
     updateStack();
 }
 
 void DlgTagFetcher::updateStack() {
+    btnApply->setDisabled(true);
     m_progressBarStep = 0;
     loadingProgressBar->setValue(m_progressBarStep);
     results->clear();
@@ -329,10 +332,12 @@ void DlgTagFetcher::updateStack() {
     } else if (m_data.m_results.isEmpty()) {
         loadingProgressBar->setValue(loadingProgressBar->maximum());
         QString emptyMessage = tr("Could not find this track in the MusicBrainz database.");
+        btnRetry->setVisible(true);
         loadingProgressBar->setFormat(emptyMessage);
         return;
     }
     btnApply->setEnabled(true);
+    btnRetry->setVisible(false);
     loadingProgressBar->setValue(loadingProgressBar->maximum());
     QString finishedMessage = tr("The results are ready to be applied.");
     loadingProgressBar->setFormat(finishedMessage);

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -330,8 +330,6 @@ void DlgTagFetcher::fetchTagFinished(
     } else {
         btnApply->setEnabled(true);
         btnRetry->setEnabled(false);
-
-        loadingProgressBar->setValue(kMaximumValueOfQProgressBar);
         loadingProgressBar->setVisible(false);
         successMessage->setVisible(true);
 

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -345,7 +345,7 @@ void DlgTagFetcher::fetchTagFinished(
             QSet<QStringList> allColumnValues; // deduplication
             for (const auto& trackRelease : qAsConst(m_data.m_tags)) {
                 const auto columnValues = trackReleaseColumnValues(trackRelease);
-                // Ignore duplicate tags
+                // Add fetched tag into TreeItemWidget, if it is not added before
                 if (!allColumnValues.contains(columnValues)) {
                     allColumnValues.insert(columnValues);
                     addTrack(columnValues, trackIndex, tags);
@@ -371,7 +371,7 @@ void DlgTagFetcher::slotNetworkResult(
         int code) {
     QString cantConnect = tr("Can't connect to %1: %2");
     loadingProgressBar->setFormat(cantConnect.arg(app, message));
-    qWarning() << "Error while getting track metadata!"
+    qWarning() << "Error while fetching track metadata!"
                << "Service:" << app
                << "HTTP Status:" << httpError
                << "Code:" << code

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -233,9 +233,11 @@ void DlgTagFetcher::apply() {
 
 void DlgTagFetcher::retry() {
     results->clear();
+    m_data = Data();
     addDivider(tr("Original tags"), results);
     addTrack(trackColumnValues(*m_track), -1, results);
     m_tagFetcher.startFetch(m_track);
+    updateStack();
 }
 
 void DlgTagFetcher::quit() {

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -316,13 +316,17 @@ void DlgTagFetcher::slotNetworkResult(
     m_data.m_pending = false;
 
     if (m_networkResult == NetworkResult::UnknownError) {
-        QString unknownError = tr("Can't connect to %1 for an unknown reason.");
-        loadingProgressBar->setFormat(unknownError.arg(app));
+        QString unknownError = tr("Can't connect to %1 for an unknown reason: %2");
+        loadingProgressBar->setFormat(unknownError.arg(app, message));
     } else {
-        QString cantConnect = tr("Can't connect to %1.");
-        loadingProgressBar->setFormat(cantConnect.arg(app));
+        QString cantConnect = tr("Can't connect to %1: %2");
+        loadingProgressBar->setFormat(cantConnect.arg(app, message));
     }
-
+    qWarning() << "Error while getting track metadata!"
+               << "Service:" << app
+               << "HTTP Status:" << httpError
+               << "Code:" << code
+               << "Server message:" << message;
     btnRetry->setEnabled(true);
     updateStack();
 }

--- a/src/library/dlgtagfetcher.h
+++ b/src/library/dlgtagfetcher.h
@@ -62,7 +62,8 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
 
     QModelIndex m_currentTrackIndex;
 
-    int m_progressBarStep;
+    int m_progressBarValue;
+    int m_incrementBarValueBy;
 
     struct Data {
         Data()

--- a/src/library/dlgtagfetcher.h
+++ b/src/library/dlgtagfetcher.h
@@ -38,9 +38,12 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
             const QList<mixxx::musicbrainz::TrackRelease>& guessedTrackReleases);
     void resultSelected();
     void fetchTagProgress(const QString&);
+    void progressBarSetTotalSteps(int totalRecordingsFound);
+    void progressBarSetCurrentStep();
     void slotNetworkResult(int httpStatus, const QString& app, const QString& message, int code);
     void slotTrackChanged(TrackId trackId);
     void apply();
+    void retry();
     void quit();
     void reject() override;
     void slotNext();
@@ -58,6 +61,8 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
     TrackPointer m_track;
 
     QModelIndex m_currentTrackIndex;
+
+    int m_progressBarStep;
 
     struct Data {
         Data()

--- a/src/library/dlgtagfetcher.h
+++ b/src/library/dlgtagfetcher.h
@@ -38,8 +38,8 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
             const QList<mixxx::musicbrainz::TrackRelease>& guessedTrackReleases);
     void resultSelected();
     void fetchTagProgress(const QString&);
-    void progressBarSetTotalSteps(int totalRecordingsFound);
-    void progressBarSetCurrentStep();
+    void setPercentOfEachRecordings(int totalRecordingsFound);
+    void increaseValueOfProgressBar();
     void slotNetworkResult(int httpStatus, const QString& app, const QString& message, int code);
     void slotTrackChanged(TrackId trackId);
     void apply();
@@ -51,7 +51,7 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
 
   private:
     void loadTrackInternal(const TrackPointer& track);
-    void updateStack();
+    void resetStack();
     void addDivider(const QString& text, QTreeWidget* parent) const;
 
     const TrackModel* const m_pTrackModel;
@@ -62,25 +62,14 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
 
     QModelIndex m_currentTrackIndex;
 
-    int m_progressBarValue;
     int m_incrementBarValueBy;
 
     struct Data {
         Data()
-                : m_pending(true),
-                  m_selectedResult(-1) {
+                : m_selectedResult(-1) {
         }
-
-        bool m_pending;
         int m_selectedResult;
         QList<mixxx::musicbrainz::TrackRelease> m_results;
     };
     Data m_data;
-
-    enum class NetworkResult {
-        Ok,
-        HttpError,
-        UnknownError,
-    };
-    NetworkResult m_networkResult;
 };

--- a/src/library/dlgtagfetcher.h
+++ b/src/library/dlgtagfetcher.h
@@ -41,6 +41,7 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
     void setPercentOfEachRecordings(int totalRecordingsFound);
     void showProgressOfRecordingTask();
     void slotNetworkResult(int httpStatus, const QString& app, const QString& message, int code);
+    // Called when apply is pressed.
     void slotTrackChanged(TrackId trackId);
     void apply();
     void retry();
@@ -50,6 +51,7 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
     void slotPrev();
 
   private:
+    // Called on population or changed via buttons Next&Prev.
     void loadTrackInternal(const TrackPointer& track);
     void resetStack();
     void addDivider(const QString& text, QTreeWidget* parent) const;

--- a/src/library/dlgtagfetcher.h
+++ b/src/library/dlgtagfetcher.h
@@ -53,7 +53,6 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
   private:
     // Called on population or changed via buttons Next&Prev.
     void loadTrackInternal(const TrackPointer& track);
-    void resetStack();
     void addDivider(const QString& text, QTreeWidget* parent) const;
 
     const TrackModel* const m_pTrackModel;

--- a/src/library/dlgtagfetcher.h
+++ b/src/library/dlgtagfetcher.h
@@ -36,10 +36,10 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
     void fetchTagFinished(
             TrackPointer pTrack,
             const QList<mixxx::musicbrainz::TrackRelease>& guessedTrackReleases);
-    void resultSelected();
-    void fetchTagProgress(const QString&);
+    void tagSelected();
+    void showProgressOfConstantTask(const QString&);
     void setPercentOfEachRecordings(int totalRecordingsFound);
-    void increaseValueOfProgressBar();
+    void showProgressOfRecordingTask();
     void slotNetworkResult(int httpStatus, const QString& app, const QString& message, int code);
     void slotTrackChanged(TrackId trackId);
     void apply();
@@ -62,14 +62,14 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
 
     QModelIndex m_currentTrackIndex;
 
-    int m_incrementBarValueBy;
+    int m_percentForOneRecording;
 
     struct Data {
         Data()
-                : m_selectedResult(-1) {
+                : m_selectedTag(-1) {
         }
-        int m_selectedResult;
-        QList<mixxx::musicbrainz::TrackRelease> m_results;
+        int m_selectedTag;
+        QList<mixxx::musicbrainz::TrackRelease> m_tags;
     };
     Data m_data;
 };

--- a/src/library/dlgtagfetcher.ui
+++ b/src/library/dlgtagfetcher.ui
@@ -17,428 +17,8 @@
    <item>
     <widget class="QStackedWidget" name="stack">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
-     <widget class="QWidget" name="results_page">
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <item>
-        <widget class="QLabel" name="label_3">
-         <property name="styleSheet">
-          <string notr="true">QLabel { font-weight: bold; }</string>
-         </property>
-         <property name="text">
-          <string>Select best possible match</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QTreeWidget" name="results">
-         <property name="editTriggers">
-          <set>QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed</set>
-         </property>
-         <property name="rootIsDecorated">
-          <bool>false</bool>
-         </property>
-         <attribute name="headerDefaultSectionSize">
-          <number>150</number>
-         </attribute>
-         <attribute name="headerMinimumSectionSize">
-          <number>50</number>
-         </attribute>
-         <attribute name="headerStretchLastSection">
-          <bool>true</bool>
-         </attribute>
-         <column>
-          <property name="text">
-           <string>Title</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>Artist</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>Album</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>Year</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>Track</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>Album Artist</string>
-          </property>
-         </column>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="loading_page">
-      <layout class="QVBoxLayout" name="verticalLayout_4">
-       <item>
-        <spacer name="verticalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
-         <item>
-          <spacer name="horizontalSpacer_4">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QLabel" name="fetchingDataMessage">
-           <property name="text">
-            <string>Fetching track data from the MusicBrainz database</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_5">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_4">
-         <item>
-          <spacer name="horizontalSpacer_6">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QLabel" name="loadingStatus">
-           <property name="text">
-            <string notr="true">Status: %1</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_7">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_4">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="networkError_page">
-      <layout class="QVBoxLayout" name="verticalLayout_7">
-       <item>
-        <spacer name="verticalSpacer_7">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_6">
-         <item>
-          <spacer name="horizontalSpacer_12">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QLabel" name="cantConnectHttp">
-           <property name="text">
-            <string notr="true">Mixxx can't connect to %1. </string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_13">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_5">
-         <item>
-          <spacer name="horizontalSpacer_9">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QLabel" name="httpStatus">
-           <property name="maximumSize">
-            <size>
-             <width>600</width>
-             <height>300</height>
-            </size>
-           </property>
-           <property name="text">
-            <string notr="true">HTTP Status: %1</string>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::TextSelectableByMouse</set>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_8">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_8">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="generalnetworkError_page">
-      <layout class="QVBoxLayout" name="verticalLayout_6">
-       <item>
-        <spacer name="verticalSpacer_5">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_7">
-         <item>
-          <spacer name="horizontalSpacer_10">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QLabel" name="cantConnectMessage">
-           <property name="text">
-            <string notr="true">Mixxx can't connect to %1 for an unknown reason.</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_11">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_6">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="error_page">
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_10">
-         <item>
-          <spacer name="horizontalSpacer_16">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QLabel" name="trackNotFound">
-           <property name="text">
-            <string>Mixxx could not find this track in the MusicBrainz database.</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_17">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_8"/>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
      <widget class="QWidget" name="submit_page">
       <layout class="QVBoxLayout" name="verticalLayout_5">
        <item>
@@ -540,7 +120,88 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="results_page">
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QLabel" name="label_3">
+         <property name="styleSheet">
+          <string notr="true">QLabel { font-weight: bold; }</string>
+         </property>
+         <property name="text">
+          <string>Select best possible match</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTreeWidget" name="results">
+         <property name="editTriggers">
+          <set>QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed</set>
+         </property>
+         <property name="rootIsDecorated">
+          <bool>false</bool>
+         </property>
+         <attribute name="headerMinimumSectionSize">
+          <number>50</number>
+         </attribute>
+         <attribute name="headerDefaultSectionSize">
+          <number>150</number>
+         </attribute>
+         <attribute name="headerStretchLastSection">
+          <bool>true</bool>
+         </attribute>
+         <column>
+          <property name="text">
+           <string>Title</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Artist</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Album</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Year</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Track</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Album Artist</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_9">
+     <item>
+      <widget class="QProgressBar" name="loadingProgressBar">
+       <property name="value">
+        <number>24</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnRetry">
+       <property name="text">
+        <string>Retry</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
@@ -599,6 +260,7 @@
   <tabstop>btnNext</tabstop>
   <tabstop>btnApply</tabstop>
   <tabstop>btnQuit</tabstop>
+  <tabstop>btnRetry</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/library/dlgtagfetcher.ui
+++ b/src/library/dlgtagfetcher.ui
@@ -133,7 +133,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QTreeWidget" name="results">
+        <widget class="QTreeWidget" name="tags">
          <property name="editTriggers">
           <set>QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed</set>
          </property>
@@ -271,7 +271,7 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>results</tabstop>
+  <tabstop>tags</tabstop>
   <tabstop>apikey</tabstop>
   <tabstop>btnApikey</tabstop>
   <tabstop>btnSubmit</tabstop>

--- a/src/library/dlgtagfetcher.ui
+++ b/src/library/dlgtagfetcher.ui
@@ -198,18 +198,6 @@
        </item>
        <item alignment="Qt::AlignHCenter">
         <widget class="QLabel" name="successMessage">
-         <property name="maximumSize">
-          <size>
-           <width>252</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="font">
-          <font>
-           <pointsize>11</pointsize>
-           <bold>true</bold>
-          </font>
-         </property>
          <property name="text">
           <string>The results are ready to be applied.</string>
          </property>

--- a/src/library/dlgtagfetcher.ui
+++ b/src/library/dlgtagfetcher.ui
@@ -188,14 +188,43 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_9">
      <item>
-      <widget class="QProgressBar" name="loadingProgressBar">
-       <property name="value">
-        <number>24</number>
-       </property>
-      </widget>
+      <layout class="QHBoxLayout" name="horizontalLayout_4">
+       <item>
+        <widget class="QProgressBar" name="loadingProgressBar">
+         <property name="value">
+          <number>24</number>
+         </property>
+        </widget>
+       </item>
+       <item alignment="Qt::AlignHCenter">
+        <widget class="QLabel" name="successMessage">
+         <property name="maximumSize">
+          <size>
+           <width>252</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>11</pointsize>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>The results are ready to be applied.</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
      <item>
       <widget class="QPushButton" name="btnRetry">
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="text">
         <string>Retry</string>
        </property>
@@ -218,6 +247,9 @@
         <string>&amp;Next</string>
        </property>
       </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_3"/>
      </item>
      <item>
       <spacer name="horizontalSpacer">

--- a/src/musicbrainz/tagfetcher.cpp
+++ b/src/musicbrainz/tagfetcher.cpp
@@ -124,7 +124,7 @@ void TagFetcher::slotAcoustIdTaskSucceeded(
     }
 
     emit fetchProgress(tr("Retrieving metadata from MusicBrainz"));
-    emit numberOfRecordingsToFetch(recordingIds.size());
+    emit numberOfRecordingsFoundFromAcoustId(recordingIds.size());
 
     DEBUG_ASSERT(!m_pMusicBrainzTask);
     m_pMusicBrainzTask = make_parented<mixxx::MusicBrainzRecordingsTask>(
@@ -148,9 +148,9 @@ void TagFetcher::slotAcoustIdTaskSucceeded(
             this,
             &TagFetcher::slotMusicBrainzTaskNetworkError);
     connect(m_pMusicBrainzTask,
-            &mixxx::MusicBrainzRecordingsTask::currentRecordingFetched,
+            &mixxx::MusicBrainzRecordingsTask::currentRecordingFetchedFromMusicBrainz,
             this,
-            &TagFetcher::currentRecordingFetched);
+            &TagFetcher::currentRecordingFetchedFromMusicBrainz);
     m_pMusicBrainzTask->invokeStart(
             kMusicBrainzTimeoutMillis);
 }

--- a/src/musicbrainz/tagfetcher.cpp
+++ b/src/musicbrainz/tagfetcher.cpp
@@ -124,6 +124,8 @@ void TagFetcher::slotAcoustIdTaskSucceeded(
     }
 
     emit fetchProgress(tr("Retrieving metadata from MusicBrainz"));
+    emit recordingsAvailable(recordingIds.size());
+
     DEBUG_ASSERT(!m_pMusicBrainzTask);
     m_pMusicBrainzTask = make_parented<mixxx::MusicBrainzRecordingsTask>(
             &m_network,
@@ -145,6 +147,10 @@ void TagFetcher::slotAcoustIdTaskSucceeded(
             &mixxx::MusicBrainzRecordingsTask::networkError,
             this,
             &TagFetcher::slotMusicBrainzTaskNetworkError);
+    connect(m_pMusicBrainzTask,
+            &mixxx::MusicBrainzRecordingsTask::currentRecordingFetched,
+            this,
+            &TagFetcher::currentRecordingFetched);
     m_pMusicBrainzTask->invokeStart(
             kMusicBrainzTimeoutMillis);
 }

--- a/src/musicbrainz/tagfetcher.cpp
+++ b/src/musicbrainz/tagfetcher.cpp
@@ -124,7 +124,7 @@ void TagFetcher::slotAcoustIdTaskSucceeded(
     }
 
     emit fetchProgress(tr("Retrieving metadata from MusicBrainz"));
-    emit recordingsAvailable(recordingIds.size());
+    emit numberOfRecordingsToFetch(recordingIds.size());
 
     DEBUG_ASSERT(!m_pMusicBrainzTask);
     m_pMusicBrainzTask = make_parented<mixxx::MusicBrainzRecordingsTask>(

--- a/src/musicbrainz/tagfetcher.h
+++ b/src/musicbrainz/tagfetcher.h
@@ -33,8 +33,8 @@ class TagFetcher : public QObject {
             const QList<mixxx::musicbrainz::TrackRelease>& guessedTrackReleases);
     void fetchProgress(
             const QString& message);
-    void numberOfRecordingsToFetch(int totalNumberOfRecordings);
-    void currentRecordingFetched();
+    void numberOfRecordingsFoundFromAcoustId(int totalNumberOfRecordings);
+    void currentRecordingFetchedFromMusicBrainz();
     void networkError(
             int httpStatus,
             const QString& app,

--- a/src/musicbrainz/tagfetcher.h
+++ b/src/musicbrainz/tagfetcher.h
@@ -33,7 +33,7 @@ class TagFetcher : public QObject {
             const QList<mixxx::musicbrainz::TrackRelease>& guessedTrackReleases);
     void fetchProgress(
             const QString& message);
-    void recordingsAvailable(int totalNumberOfRecordings);
+    void numberOfRecordingsToFetch(int totalNumberOfRecordings);
     void currentRecordingFetched();
     void networkError(
             int httpStatus,

--- a/src/musicbrainz/tagfetcher.h
+++ b/src/musicbrainz/tagfetcher.h
@@ -33,6 +33,8 @@ class TagFetcher : public QObject {
             const QList<mixxx::musicbrainz::TrackRelease>& guessedTrackReleases);
     void fetchProgress(
             const QString& message);
+    void recordingsAvailable(int totalNumberOfRecordings);
+    void currentRecordingFetched();
     void networkError(
             int httpStatus,
             const QString& app,

--- a/src/musicbrainz/web/musicbrainzrecordingstask.cpp
+++ b/src/musicbrainz/web/musicbrainzrecordingstask.cpp
@@ -180,6 +180,7 @@ void MusicBrainzRecordingsTask::doNetworkReplyFinished(
     const Duration delayBeforeNextRequest =
             kMinDurationBetweenRequests -
             std::min(kMinDurationBetweenRequests, elapsedSinceLastRequestSent);
+    emit currentRecordingFetched();
     slotStart(m_parentTimeoutMillis, delayBeforeNextRequest.toIntegerMillis());
 }
 

--- a/src/musicbrainz/web/musicbrainzrecordingstask.cpp
+++ b/src/musicbrainz/web/musicbrainzrecordingstask.cpp
@@ -180,7 +180,7 @@ void MusicBrainzRecordingsTask::doNetworkReplyFinished(
     const Duration delayBeforeNextRequest =
             kMinDurationBetweenRequests -
             std::min(kMinDurationBetweenRequests, elapsedSinceLastRequestSent);
-    emit currentRecordingFetched();
+    emit currentRecordingFetchedFromMusicBrainz();
     slotStart(m_parentTimeoutMillis, delayBeforeNextRequest.toIntegerMillis());
 }
 

--- a/src/musicbrainz/web/musicbrainzrecordingstask.h
+++ b/src/musicbrainz/web/musicbrainzrecordingstask.h
@@ -29,6 +29,7 @@ class MusicBrainzRecordingsTask : public network::WebTask {
             const network::WebResponse& response,
             int errorCode,
             const QString& errorMessage);
+    void currentRecordingFetched();
 
   private:
     QNetworkReply* doStartNetworkRequest(

--- a/src/musicbrainz/web/musicbrainzrecordingstask.h
+++ b/src/musicbrainz/web/musicbrainzrecordingstask.h
@@ -29,7 +29,7 @@ class MusicBrainzRecordingsTask : public network::WebTask {
             const network::WebResponse& response,
             int errorCode,
             const QString& errorMessage);
-    void currentRecordingFetched();
+    void currentRecordingFetchedFromMusicBrainz();
 
   private:
     QNetworkReply* doStartNetworkRequest(


### PR DESCRIPTION
As we discussed that on [Zulip](https://mixxx.zulipchat.com/#narrow/stream/109215-gsoc/topic/cover.20art.20lookup/near/291075452), we wanted to get rid of the full screen status page in `Import metadata from MusicBrainz` - `DlgTagFetcher`.

The new GUI is simply like this:

- On startup, progress ![progress](https://user-images.githubusercontent.com/67206006/181578582-fc17b5ff-dec7-4101-86de-61393d8d3c92.png)

- After fetching completed, successful ![successful](https://user-images.githubusercontent.com/67206006/181578657-4816fb79-3559-4196-890d-6e9fed271869.png)

- Any case of error, failure: 
![Failure 1](https://user-images.githubusercontent.com/67206006/181579003-8d0614dd-9caa-4db7-80f0-777b39104af3.png)
![Failure 2](https://user-images.githubusercontent.com/67206006/181579040-e91f7468-3ceb-4606-bed8-0bb9dea53b4d.png)

What do you think generally?

