### PR TITLE
fix(controllers): fix mislabeled midi io terminal messages

### DIFF
--- a/src/controllers/midi/midicontroller.cpp
+++ b/src/controllers/midi/midicontroller.cpp
@@ -209,10 +209,15 @@ void MidiController::receive(unsigned char status, unsigned char control,
         return;
     }
 
-    controllerDebug(MidiUtils::formatMidiMessage(getName(), status, control, value,
-                                                 channel, opCode, timestamp));
+    controllerDebug(QStringLiteral("incoming: ")
+            << MidiUtils::formatMidiMessage(getName(),
+                       status,
+                       control,
+                       value,
+                       channel,
+                       opCode,
+                       timestamp));
     MidiKey mappingKey(status, control);
-
     triggerActivity();
     if (isLearning()) {
         emit messageReceived(status, control, value);
@@ -461,7 +466,8 @@ double MidiController::computeValue(
 }
 
 void MidiController::receive(const QByteArray& data, mixxx::Duration timestamp) {
-    controllerDebug(MidiUtils::formatSysexMessage(getName(), data, timestamp));
+    controllerDebug(QStringLiteral("incoming: ")
+            << MidiUtils::formatSysexMessage(getName(), data, timestamp));
 
     MidiKey mappingKey(data.at(0), 0xFF);
 

--- a/src/controllers/midi/midiutils.cpp
+++ b/src/controllers/midi/midiutils.cpp
@@ -72,10 +72,8 @@ QString MidiUtils::formatMidiMessage(const QString& controllerName,
                                           unsigned char value, unsigned char channel,
                                           unsigned char opCode, mixxx::Duration timestamp) {
     QString msg2;
-    if (timestamp == mixxx::Duration::fromMillis(0)) {
-      msg2 = "outgoing:";
-    } else {
-      msg2 = QString("t:%1").arg(timestamp.formatMillisWithUnit());
+    if (timestamp != mixxx::Duration::fromMillis(0)) {
+        msg2 = QString("t:%1").arg(timestamp.formatMillisWithUnit());
     }
     switch (opCode) {
         case MIDI_PITCH_BEND:
@@ -124,10 +122,8 @@ QString MidiUtils::formatMidiMessage(const QString& controllerName,
 QString MidiUtils::formatSysexMessage(const QString& controllerName, const QByteArray& data,
                                            mixxx::Duration timestamp) {
     QString msg2;
-    if (timestamp == mixxx::Duration::fromMillis(0)) {
-      msg2 = "outgoing:";
-    } else {
-      msg2 = QString("t:%1").arg(timestamp.formatMillisWithUnit());
+    if (timestamp != mixxx::Duration::fromMillis(0)) {
+        msg2 = QString("t:%1").arg(timestamp.formatMillisWithUnit());
     }
     QString message =
             QString("%1: %2 %3 byte sysex: [")

--- a/src/controllers/midi/portmidicontroller.cpp
+++ b/src/controllers/midi/portmidicontroller.cpp
@@ -198,10 +198,12 @@ void PortMidiController::sendShortMsg(unsigned char status, unsigned char byte1,
 
     PmError err = m_pOutputDevice->writeShort(word);
     if (err == pmNoError) {
-        controllerDebug(MidiUtils::formatMidiMessage(getName(),
-                                                     status, byte1, byte2,
-                                                     MidiUtils::channelFromStatus(status),
-                                                     MidiUtils::opCodeFromStatus(status)));
+        controllerDebug(QStringLiteral("outgoing: ") << MidiUtils::formatMidiMessage(getName(),
+                                status,
+                                byte1,
+                                byte2,
+                                MidiUtils::channelFromStatus(status),
+                                MidiUtils::opCodeFromStatus(status)));
     } else {
         // Use two qWarnings() to ensure line break works on all operating systems
         qWarning() << "Error sending short message"
@@ -229,7 +231,8 @@ void PortMidiController::send(const QByteArray& data) {
 
     PmError err = m_pOutputDevice->writeSysEx((unsigned char*)data.constData());
     if (err == pmNoError) {
-        controllerDebug(MidiUtils::formatSysexMessage(getName(), data));
+        controllerDebug(QStringLiteral("outgoing: ")
+                << MidiUtils::formatSysexMessage(getName(), data));
     } else {
         // Use two qWarnings() to ensure line break works on all operating systems
         qWarning() << "Error sending SysEx message:"


### PR DESCRIPTION
Previously, the messages about midi IO when running with
--controllerDebug always prefixed messages with "outgoing: ",
mislabeling messages that were actually incoming from the
hardware.

This does not merge with `main`, I can take care of the conflicts after merge.