### PR TITLE
MC7000: Restore beat loop size after roll loop

### DIFF
--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -531,10 +531,10 @@ MC7000.PadButtons = function(channel, control, value, status, group) {
     } else if (MC7000.PADModeRoll[deckOffset]) {
         // TODO(all): check for actual beatloop_size and apply back after a PAD Roll
         i = control - 0x14;
-        if (control === 0x14 + i && value > 0x00) {
+        if (value > 0x00) {
             engine.setValue(group, "beatlooproll_" + MC7000.beatLoopRoll[i] + "_activate", true);
             midi.sendShortMsg(0x94 + deckOffset, 0x14 + i, MC7000.padColor.rollon);
-        } else if (control === 0x14 + i && value === 0x00) {
+        } else if (value === 0x00) {
             engine.setValue(group, "beatlooproll_activate", false);
             midi.sendShortMsg(0x94 + deckOffset, 0x14 + i, MC7000.padColor.rolloff);
         }


### PR DESCRIPTION
This is a small patch that restores the previous beatloop size after holding a roll (temporary loop) button. For example:

- Initial beatloop size is 4
- User holds 1/16 roll button
  - Beatloop size of 4 is saved
  - Beatloop size is set to 1/16
- User releases 1/16 roll button
  - Beatloop size is restored to 4 `<-- This is new`

### Motivation

I have stumbled upon this a few times where I would accidentally activate a very small auto-loop later on after holding a roll button earlier, which seems counter-intuitive given the temporary nature of roll loops. Also there is already a `TODO` note in the script that suggests this particular fix.