### PR TITLE
Fix reset of bpm and key when (re-)importing track metadata

### DIFF
--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -214,12 +214,15 @@ void DlgTagFetcher::apply() {
                 trackRelease.releaseGroupId);
     }
 #endif // __EXTRA_METADATA__
+    // Keep all existing metadata
+    constexpr auto resetMissingTagMetadataOnImport = false;
     m_track->replaceMetadataFromSource(
             std::move(trackMetadata),
             // Prevent re-import of outdated metadata from file tags
             // by explicitly setting the synchronization time stamp
             // to the current time.
-            QDateTime::currentDateTimeUtc());
+            QDateTime::currentDateTimeUtc(),
+            resetMissingTagMetadataOnImport);
 }
 
 void DlgTagFetcher::quit() {

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -666,12 +666,12 @@ void DlgTrackInfo::slotImportMetadataFromFile() {
     mixxx::TrackRecord trackRecord = m_pLoadedTrack->getRecord();
     mixxx::TrackMetadata trackMetadata = trackRecord.getMetadata();
     QImage coverImage;
-    const auto resetMissingTagMetadata = m_pUserSettings->getValue<bool>(
+    const auto resetMissingTagMetadataOnImport = m_pUserSettings->getValue<bool>(
             mixxx::library::prefs::kResetMissingTagMetadataOnImportConfigKey);
     const auto [importResult, sourceSynchronizedAt] =
             SoundSourceProxy(m_pLoadedTrack)
                     .importTrackMetadataAndCoverImage(
-                            &trackMetadata, &coverImage, resetMissingTagMetadata);
+                            &trackMetadata, &coverImage, resetMissingTagMetadataOnImport);
     if (importResult != mixxx::MetadataSource::ImportResult::Succeeded) {
         return;
     }

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -817,7 +817,8 @@ SoundSourceProxy::UpdateTrackFromSourceResult SoundSourceProxy::updateTrackFromS
 
     m_pTrack->replaceMetadataFromSource(
             std::move(trackMetadata),
-            sourceSynchronizedAt);
+            sourceSynchronizedAt,
+            syncParams.resetMissingTagMetadataOnImport);
 
     const bool pendingBeatsImport =
             m_pTrack->getBeatsImportStatus() == Track::ImportStatus::Pending;

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -404,7 +404,8 @@ class Track : public QObject {
     /// with file tags, either by importing or exporting the metadata.
     void replaceMetadataFromSource(
             mixxx::TrackMetadata importedMetadata,
-            const QDateTime& sourceSynchronizedAt);
+            const QDateTime& sourceSynchronizedAt,
+            bool resetMissingTagMetadataOnImport);
 
     mixxx::TrackMetadata getMetadata(
             mixxx::TrackRecord::SourceSyncStatus*


### PR DESCRIPTION
Resetting the bpm and key didn't work at all because of some special case handling for these fields. The comments in the code explain the reasoning when resetting those fields is desired.

Could be tested by setting `[Library] SyncTrackMetadataExport 1` in `mixxx.cfg` manually. The default behavior should be unaffected.