### PR TITLE
PollingControlProxy refactoring 

### DIFF
--- a/src/control/controlindicator.h
+++ b/src/control/controlindicator.h
@@ -2,6 +2,7 @@
 
 #include "control/controlobject.h"
 #include "control/controlproxy.h"
+#include "control/pollingcontrolproxy.h"
 #include "util/parented_ptr.h"
 
 /// This type of control is used for blinking buttons such as the "play" or

--- a/src/engine/channels/engineaux.cpp
+++ b/src/engine/channels/engineaux.cpp
@@ -80,7 +80,7 @@ void EngineAux::process(CSAMPLE* pOut, const int iBufferSize) {
             pEngineEffectsManager->processPreFaderInPlace(
                     m_group.handle(), m_pEffectsManager->getMasterHandle(), pOut, iBufferSize,
                     // TODO(jholthuis): Use mixxx::audio::SampleRate instead
-                    static_cast<unsigned int>(m_pSampleRate->get()));
+                    static_cast<unsigned int>(m_sampleRate.get()));
         }
         m_sampleBuffer = nullptr;
     } else {

--- a/src/engine/channels/enginechannel.cpp
+++ b/src/engine/channels/enginechannel.cpp
@@ -12,7 +12,7 @@ EngineChannel::EngineChannel(const ChannelHandleAndGroup& handleGroup,
         : m_group(handleGroup),
           m_pEffectsManager(pEffectsManager),
           m_vuMeter(getGroup()),
-          m_pSampleRate(new ControlProxy("[Master]", "samplerate")),
+          m_sampleRate("[Master]", "samplerate"),
           m_sampleBuffer(nullptr),
           m_bIsPrimaryDeck(isPrimaryDeck),
           m_bIsTalkoverChannel(isTalkoverChannel),
@@ -49,7 +49,6 @@ EngineChannel::~EngineChannel() {
     delete m_pOrientationLeft;
     delete m_pOrientationRight;
     delete m_pOrientationCenter;
-    delete m_pSampleRate;
     delete m_pTalkover;
 }
 

--- a/src/engine/channels/enginechannel.h
+++ b/src/engine/channels/enginechannel.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "control/controlproxy.h"
 #include "control/pollingcontrolproxy.h"
 #include "effects/effectsmanager.h"
 #include "engine/channelhandle.h"

--- a/src/engine/channels/enginechannel.h
+++ b/src/engine/channels/enginechannel.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include "control/controlproxy.h"
+#include "control/pollingcontrolproxy.h"
 #include "effects/effectsmanager.h"
-#include "engine/engineobject.h"
 #include "engine/channelhandle.h"
+#include "engine/engineobject.h"
 #include "engine/enginevumeter.h"
 #include "preferences/usersettings.h"
 
@@ -70,7 +71,7 @@ class EngineChannel : public EngineObject {
     EffectsManager* m_pEffectsManager;
 
     EngineVuMeter m_vuMeter;
-    ControlProxy* m_pSampleRate;
+    PollingControlProxy m_sampleRate;
     const CSAMPLE* volatile m_sampleBuffer;
 
     // If set to true, this engine channel represents one of the primary playback decks.

--- a/src/engine/channels/enginedeck.cpp
+++ b/src/engine/channels/enginedeck.cpp
@@ -80,7 +80,7 @@ void EngineDeck::process(CSAMPLE* pOut, const int iBufferSize) {
                 pOut,
                 iBufferSize,
                 // TODO(jholthuis): Use mixxx::audio::SampleRate instead
-                static_cast<unsigned int>(m_pSampleRate->get()));
+                static_cast<unsigned int>(m_sampleRate.get()));
     }
 
     // Update VU meter

--- a/src/engine/channels/enginedeck.h
+++ b/src/engine/channels/enginedeck.h
@@ -3,7 +3,6 @@
 #include <QScopedPointer>
 
 #include "preferences/usersettings.h"
-#include "control/controlproxy.h"
 #include "control/controlpushbutton.h"
 #include "engine/engineobject.h"
 #include "engine/channels/enginechannel.h"

--- a/src/engine/channels/enginemicrophone.cpp
+++ b/src/engine/channels/enginemicrophone.cpp
@@ -80,7 +80,7 @@ void EngineMicrophone::process(CSAMPLE* pOut, const int iBufferSize) {
             pEngineEffectsManager->processPreFaderInPlace(
                     m_group.handle(), m_pEffectsManager->getMasterHandle(), pOut, iBufferSize,
                     // TODO(jholthuis): Use mixxx::audio::SampleRate instead
-                    static_cast<unsigned int>(m_pSampleRate->get()));
+                    static_cast<unsigned int>(m_sampleRate.get()));
         }
     } else {
         SampleUtil::clear(pOut, iBufferSize);

--- a/src/engine/channels/enginemicrophone.h
+++ b/src/engine/channels/enginemicrophone.h
@@ -2,7 +2,6 @@
 
 #include <QScopedPointer>
 
-#include "control/controlproxy.h"
 #include "control/controlpushbutton.h"
 #include "engine/channels/enginechannel.h"
 #include "engine/enginevumeter.h"

--- a/src/engine/enginevumeter.cpp
+++ b/src/engine/enginevumeter.cpp
@@ -18,7 +18,8 @@ constexpr CSAMPLE kDecaySmoothing = 0.1f;  //.16//.4
 
 } // namespace
 
-EngineVuMeter::EngineVuMeter(const QString& group) {
+EngineVuMeter::EngineVuMeter(const QString& group)
+        : m_sampleRate("[Master]", "samplerate") {
     // The VUmeter widget is controlled via a controlpotmeter, which means
     // that it should react on the setValue(int) signal.
     m_ctrlVuMeter = new ControlPotmeter(ConfigKey(group, "VuMeter"), 0., 1.);
@@ -35,9 +36,6 @@ EngineVuMeter::EngineVuMeter(const QString& group) {
                                               0., 1.);
     m_ctrlPeakIndicatorR = new ControlPotmeter(ConfigKey(group, "PeakIndicatorR"),
                                               0., 1.);
-
-    m_pSampleRate = new ControlProxy("[Master]", "samplerate", this);
-
     // Initialize the calculation:
     reset();
 }
@@ -55,7 +53,7 @@ EngineVuMeter::~EngineVuMeter()
 void EngineVuMeter::process(CSAMPLE* pIn, const int iBufferSize) {
     CSAMPLE fVolSumL, fVolSumR;
 
-    int sampleRate = (int)m_pSampleRate->get();
+    int sampleRate = static_cast<int>(m_sampleRate.get());
 
     SampleUtil::CLIP_STATUS clipped = SampleUtil::sumAbsPerChannel(&fVolSumL,
             &fVolSumR, pIn, iBufferSize);

--- a/src/engine/enginevumeter.h
+++ b/src/engine/enginevumeter.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "control/pollingcontrolproxy.h"
 #include "engine/engineobject.h"
 
 class ControlPotmeter;
-class ControlProxy;
 
 class EngineVuMeter : public EngineObject {
     Q_OBJECT
@@ -33,5 +33,5 @@ class EngineVuMeter : public EngineObject {
     int m_peakDurationL;
     int m_peakDurationR;
 
-    ControlProxy* m_pSampleRate;
+    PollingControlProxy m_sampleRate;
 };

--- a/src/engine/sidechain/shoutconnection.h
+++ b/src/engine/sidechain/shoutconnection.h
@@ -13,7 +13,7 @@
 #include <QWaitCondition>
 
 #include "control/controlobject.h"
-#include "control/controlproxy.h"
+#include "control/pollingcontrolproxy.h"
 #include "encoder/encoder.h"
 #include "encoder/encodercallback.h"
 #include "errordialoghandler.h"
@@ -125,8 +125,8 @@ class ShoutConnection
     UserSettingsPointer m_pConfig;
     BroadcastProfilePtr m_pProfile;
     EncoderPointer m_encoder;
-    ControlProxy* m_pMasterSamplerate;
-    ControlProxy* m_pBroadcastEnabled;
+    PollingControlProxy m_masterSamplerate;
+    PollingControlProxy m_broadcastEnabled;
     // static metadata according to prefereneces
     bool m_custom_metadata;
     QString m_customArtist;

--- a/src/preferences/dialog/dlgprefcrossfader.h
+++ b/src/preferences/dialog/dlgprefcrossfader.h
@@ -2,7 +2,7 @@
 
 #include <QWidget>
 
-#include "control/controlproxy.h"
+#include "control/pollingcontrolproxy.h"
 #include "preferences/dialog/dlgpreferencepage.h"
 #include "preferences/dialog/ui_dlgprefcrossfaderdlg.h"
 #include "preferences/usersettings.h"
@@ -36,11 +36,11 @@ class DlgPrefCrossfader : public DlgPreferencePage, public Ui::DlgPrefCrossfader
     // X-fader values
     double m_xFaderMode, m_transform, m_cal;
 
-    ControlProxy m_mode;
-    ControlProxy m_curve;
-    ControlProxy m_calibration;
-    ControlProxy m_reverse;
-    ControlProxy m_crossfader;
+    PollingControlProxy m_mode;
+    PollingControlProxy m_curve;
+    PollingControlProxy m_calibration;
+    PollingControlProxy m_reverse;
+    PollingControlProxy m_crossfader;
 
     bool m_xFaderReverse;
 };

--- a/src/preferences/dialog/dlgprefreplaygain.h
+++ b/src/preferences/dialog/dlgprefreplaygain.h
@@ -3,7 +3,7 @@
 #include <QButtonGroup>
 #include <QWidget>
 
-#include "control/controlproxy.h"
+#include "control/pollingcontrolproxy.h"
 #include "preferences/dialog/dlgpreferencepage.h"
 #include "preferences/dialog/ui_dlgprefreplaygaindlg.h"
 #include "preferences/replaygainsettings.h"
@@ -38,9 +38,9 @@ class DlgPrefReplayGain: public DlgPreferencePage,
     int getReplayGainVersion() const;
 
     ReplayGainSettings m_rgSettings;
-    ControlProxy m_replayGainBoost;
-    ControlProxy m_defaultBoost;
-    ControlProxy m_enabled;
+    PollingControlProxy m_replayGainBoost;
+    PollingControlProxy m_defaultBoost;
+    PollingControlProxy m_enabled;
 
     QButtonGroup m_analysisButtonGroup;
 };

--- a/src/preferences/dialog/dlgprefvinyl.cpp
+++ b/src/preferences/dialog/dlgprefvinyl.cpp
@@ -4,6 +4,7 @@
 
 #include "control/controlobject.h"
 #include "control/controlproxy.h"
+#include "control/pollingcontrolproxy.h"
 #include "defs_urls.h"
 #include "mixer/playermanager.h"
 #include "moc_dlgprefvinyl.cpp"
@@ -144,7 +145,7 @@ void DlgPrefVinyl::slotNumDecksChanged(double dNumDecks) {
 
     for (int i = m_COSpeeds.length(); i < num_decks; ++i) {
         QString group = PlayerManager::groupForDeck(i);
-        m_COSpeeds.push_back(new ControlProxy(group, "vinylcontrol_speed_type"));
+        m_COSpeeds.push_back(new PollingControlProxy(group, "vinylcontrol_speed_type"));
         setDeckWidgetsVisible(i, true);
     }
 }

--- a/src/preferences/dialog/dlgprefvinyl.h
+++ b/src/preferences/dialog/dlgprefvinyl.h
@@ -10,6 +10,7 @@
 #include "vinylcontrol/vinylcontrolsignalwidget.h"
 
 class ControlProxy;
+class PollingControlProxy;
 class VinylControlManager;
 
 class DlgPrefVinyl : public DlgPreferencePage, Ui::DlgPrefVinylDlg  {
@@ -54,6 +55,6 @@ class DlgPrefVinyl : public DlgPreferencePage, Ui::DlgPrefVinylDlg  {
 
     std::shared_ptr<VinylControlManager> m_pVCManager;
     UserSettingsPointer config;
-    QList<ControlProxy*> m_COSpeeds;
+    QList<PollingControlProxy*> m_COSpeeds;
     ControlProxy* m_pNumDecks;
 };

--- a/src/recording/recordingmanager.cpp
+++ b/src/recording/recordingmanager.cpp
@@ -31,13 +31,13 @@ RecordingManager::RecordingManager(UserSettingsPointer pConfig, EngineMaster* pE
           m_iNumberSplits(0),
           m_secondsRecorded(0),
           m_secondsRecordedSplit(0) {
-    m_pToggleRecording = new ControlPushButton(ConfigKey(RECORDING_PREF_KEY, "toggle_recording"));
-    connect(m_pToggleRecording,
+    m_pToggleRecording = std::make_unique<ControlPushButton>(
+            ConfigKey(RECORDING_PREF_KEY, "toggle_recording"));
+    connect(m_pToggleRecording.get(),
             &ControlPushButton::valueChanged,
             this,
             &RecordingManager::slotToggleRecording);
-    m_recReadyCO = new ControlObject(ConfigKey(RECORDING_PREF_KEY, "status"));
-    m_recReady = new ControlProxy(m_recReadyCO->getKey(), this);
+    m_pCoRecStatus = std::make_unique<ControlObject>(ConfigKey(RECORDING_PREF_KEY, "status"));
 
     m_split_size = getFileSplitSize();
     m_split_time = getFileSplitSeconds();
@@ -60,13 +60,6 @@ RecordingManager::RecordingManager(UserSettingsPointer pConfig, EngineMaster* pE
                 &RecordingManager::slotDurationRecorded);
         pSidechain->addSideChainWorker(pEngineRecord);
     }
-}
-
-RecordingManager::~RecordingManager() {
-    qDebug() << "Delete RecordingManager";
-
-    delete m_recReadyCO;
-    delete m_pToggleRecording;
 }
 
 QString RecordingManager::formatDateTimeForFilename(const QDateTime& dateTime) const {
@@ -142,7 +135,7 @@ void RecordingManager::startRecording() {
     m_pConfig->set(ConfigKey(RECORDING_PREF_KEY, "Path"), m_recordingLocation);
     m_pConfig->set(ConfigKey(RECORDING_PREF_KEY, "CuePath"), ConfigValue(m_recording_base_file + QStringLiteral(".cue")));
 
-    m_recReady->set(RECORD_READY);
+    m_pCoRecStatus->set(RECORD_READY);
 }
 
 void RecordingManager::splitContinueRecording()
@@ -165,12 +158,12 @@ void RecordingManager::splitContinueRecording()
     m_pConfig->set(ConfigKey(RECORDING_PREF_KEY, "CuePath"), ConfigValue(new_base_filename + QStringLiteral(".cue")));
     m_recordingFile = QFileInfo(m_recordingLocation).fileName();
 
-    m_recReady->set(RECORD_SPLIT_CONTINUE);
+    m_pCoRecStatus->set(RECORD_SPLIT_CONTINUE);
 }
 
 void RecordingManager::stopRecording() {
     qDebug() << "Recording stopped";
-    m_recReady->set(RECORD_OFF);
+    m_pCoRecStatus->set(RECORD_OFF);
     m_recordingFile = "";
     m_recordingLocation = "";
     m_iNumberOfBytesRecorded = 0;

--- a/src/recording/recordingmanager.h
+++ b/src/recording/recordingmanager.h
@@ -26,7 +26,7 @@ class RecordingManager : public QObject {
     Q_OBJECT
   public:
     RecordingManager(UserSettingsPointer pConfig, EngineMaster* pEngine);
-    ~RecordingManager() override;
+    ~RecordingManager() override = default;
 
     // This will try to start recording. If successful, slotIsRecording will be
     // called and a signal isRecording will be emitted.
@@ -60,9 +60,8 @@ class RecordingManager : public QObject {
     // name of the first split but with a suffix.
     void splitContinueRecording();
     void warnFreespace();
-    ControlProxy* m_recReady;
-    ControlObject* m_recReadyCO;
-    ControlPushButton* m_pToggleRecording;
+    std::unique_ptr<ControlObject> m_pCoRecStatus;
+    std::unique_ptr<ControlPushButton> m_pToggleRecording;
 
     quint64 getFileSplitSize();
     unsigned int getFileSplitSeconds();

--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -31,11 +31,12 @@ const mixxx::Logger kLogger("SoundDeviceNetwork");
 } // namespace
 
 SoundDeviceNetwork::SoundDeviceNetwork(UserSettingsPointer config,
-                                       SoundManager *sm,
-                                       QSharedPointer<EngineNetworkStream> pNetworkStream)
+        SoundManager* sm,
+        QSharedPointer<EngineNetworkStream> pNetworkStream)
         : SoundDevice(config, sm),
           m_pNetworkStream(pNetworkStream),
           m_inputDrift(false),
+          m_masterAudioLatencyUsage("[Master]", "audio_latency_usage"),
           m_framesSinceAudioLatencyUsageUpdate(0),
           m_denormals(false),
           m_targetTime(0) {
@@ -46,9 +47,6 @@ SoundDeviceNetwork::SoundDeviceNetwork(UserSettingsPointer config,
     m_strDisplayName = QObject::tr("Network stream");
     m_iNumInputChannels = pNetworkStream->getNumInputChannels();
     m_iNumOutputChannels = pNetworkStream->getNumOutputChannels();
-
-    m_pMasterAudioLatencyUsage = std::make_unique<ControlProxy>("[Master]",
-            "audio_latency_usage");
 }
 
 SoundDeviceNetwork::~SoundDeviceNetwork() {
@@ -492,7 +490,7 @@ void SoundDeviceNetwork::updateAudioLatencyUsage() {
     if (m_framesSinceAudioLatencyUsageUpdate
             > (m_dSampleRate / CPU_USAGE_UPDATE_RATE)) {
         double secInAudioCb = m_timeInAudioCallback.toDoubleSeconds();
-        m_pMasterAudioLatencyUsage->set(secInAudioCb /
+        m_masterAudioLatencyUsage.set(secInAudioCb /
                 (m_framesSinceAudioLatencyUsageUpdate / m_dSampleRate));
         m_timeInAudioCallback = mixxx::Duration::empty();
         m_framesSinceAudioLatencyUsageUpdate = 0;

--- a/src/soundio/sounddevicenetwork.h
+++ b/src/soundio/sounddevicenetwork.h
@@ -8,10 +8,11 @@
 #include <pthread.h>
 #endif
 
-#include "util/performancetimer.h"
-#include "util/memory.h"
-#include "soundio/sounddevice.h"
+#include "control/pollingcontrolproxy.h"
 #include "engine/sidechain/networkoutputstreamworker.h"
+#include "soundio/sounddevice.h"
+#include "util/memory.h"
+#include "util/performancetimer.h"
 
 #define CPU_USAGE_UPDATE_RATE 30 // in 1/s, fits to display frame rate
 #define CPU_OVERLOAD_DURATION 500 // in ms
@@ -59,7 +60,7 @@ class SoundDeviceNetwork : public SoundDevice {
     std::unique_ptr<FIFO<CSAMPLE>> m_inputFifo;
     bool m_inputDrift;
 
-    std::unique_ptr<ControlProxy> m_pMasterAudioLatencyUsage;
+    PollingControlProxy m_masterAudioLatencyUsage;
     mixxx::Duration m_timeInAudioCallback;
     mixxx::Duration m_audioBufferTime;
     int m_framesSinceAudioLatencyUsageUpdate;

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -87,6 +87,7 @@ SoundDevicePortAudio::SoundDevicePortAudio(UserSettingsPointer config,
           m_outputDrift(false),
           m_inputDrift(false),
           m_bSetThreadPriority(false),
+          m_masterAudioLatencyUsage("[Master]", "audio_latency_usage"),
           m_framesSinceAudioLatencyUsageUpdate(0),
           m_syncBuffers(2),
           m_invalidTimeInfoCount(0),
@@ -117,9 +118,6 @@ SoundDevicePortAudio::SoundDevicePortAudio(UserSettingsPointer config,
     m_iNumInputChannels = m_deviceInfo->maxInputChannels;
     m_iNumOutputChannels = m_deviceInfo->maxOutputChannels;
 
-    m_pMasterAudioLatencyUsage = new ControlProxy("[Master]",
-            "audio_latency_usage");
-
     m_inputParams.device = 0;
     m_inputParams.channelCount = 0;
     m_inputParams.sampleFormat = 0;
@@ -134,7 +132,6 @@ SoundDevicePortAudio::SoundDevicePortAudio(UserSettingsPointer config,
 }
 
 SoundDevicePortAudio::~SoundDevicePortAudio() {
-    delete m_pMasterAudioLatencyUsage;
 }
 
 SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers) {
@@ -1063,9 +1060,8 @@ void SoundDevicePortAudio::updateAudioLatencyUsage(
     m_framesSinceAudioLatencyUsageUpdate += framesPerBuffer;
     if (m_framesSinceAudioLatencyUsageUpdate > (m_dSampleRate / kCpuUsageUpdateRate)) {
         double secInAudioCb = m_timeInAudioCallback.toDoubleSeconds();
-        m_pMasterAudioLatencyUsage->set(
-                secInAudioCb
-                        / (m_framesSinceAudioLatencyUsageUpdate / m_dSampleRate));
+        m_masterAudioLatencyUsage.set(
+                secInAudioCb / (m_framesSinceAudioLatencyUsageUpdate / m_dSampleRate));
         m_timeInAudioCallback = mixxx::Duration::fromSeconds(0);
         m_framesSinceAudioLatencyUsageUpdate = 0;
         //qDebug() << m_pMasterAudioLatencyUsage

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -1,9 +1,10 @@
 #pragma once
 
-
 #include <portaudio.h>
+
 #include <QString>
 
+#include "control/pollingcontrolproxy.h"
 #include "soundio/sounddevice.h"
 #include "util/duration.h"
 #include "util/performancetimer.h"
@@ -72,7 +73,7 @@ class SoundDevicePortAudio : public SoundDevice {
     QString m_lastError;
     // Whether we have set the thread priority to realtime or not.
     bool m_bSetThreadPriority;
-    ControlProxy* m_pMasterAudioLatencyUsage;
+    PollingControlProxy m_masterAudioLatencyUsage;
     mixxx::Duration m_timeInAudioCallback;
     int m_framesSinceAudioLatencyUsageUpdate;
     int m_syncBuffers;

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "audio/types.h"
+#include "control/pollingcontrolproxy.h"
 #include "engine/sidechain/enginenetworkstream.h"
 #include "preferences/usersettings.h"
 #include "soundio/sounddevice.h"
@@ -146,6 +147,6 @@ class SoundManager : public QObject {
 
     QAtomicInt m_underflowHappened;
     int m_underflowUpdateCount;
-    ControlProxy* m_pMasterAudioLatencyOverloadCount;
-    ControlProxy* m_pMasterAudioLatencyOverload;
+    PollingControlProxy m_masterAudioLatencyOverloadCount;
+    PollingControlProxy m_masterAudioLatencyOverload;
 };

--- a/src/test/looping_control_test.cpp
+++ b/src/test/looping_control_test.cpp
@@ -24,45 +24,59 @@ class LoopingControlTest : public MockedEngineBackendTest {
   protected:
     void SetUp() override {
         MockedEngineBackendTest::SetUp();
-        m_pQuantizeEnabled = std::make_unique<ControlProxy>(m_sGroup1, "quantize");
+        m_pQuantizeEnabled = std::make_unique<PollingControlProxy>(m_sGroup1, "quantize");
         m_pQuantizeEnabled->set(1.0);
-        m_pNextBeat = std::make_unique<ControlProxy>(m_sGroup1, "beat_next");
+        m_pNextBeat = std::make_unique<PollingControlProxy>(m_sGroup1, "beat_next");
 
         m_pNextBeat->set(-1);
-        m_pClosestBeat = std::make_unique<ControlProxy>(m_sGroup1, "beat_closest");
+        m_pClosestBeat = std::make_unique<PollingControlProxy>(m_sGroup1, "beat_closest");
         m_pClosestBeat->set(-1);
-        m_pTrackSamples = std::make_unique<ControlProxy>(m_sGroup1, "track_samples");
+        m_pTrackSamples = std::make_unique<PollingControlProxy>(m_sGroup1, "track_samples");
         m_pTrackSamples->set(kTrackEndPosition.toEngineSamplePos());
-        m_pButtonLoopIn = std::make_unique<ControlProxy>(m_sGroup1, "loop_in");
-        m_pButtonLoopOut = std::make_unique<ControlProxy>(m_sGroup1, "loop_out");
-        m_pButtonLoopExit = std::make_unique<ControlProxy>(m_sGroup1, "loop_exit");
-        m_pButtonReloopToggle = std::make_unique<ControlProxy>(m_sGroup1, "reloop_toggle");
-        m_pButtonReloopAndStop = std::make_unique<ControlProxy>(m_sGroup1, "reloop_andstop");
-        m_pButtonLoopDouble = std::make_unique<ControlProxy>(m_sGroup1, "loop_double");
-        m_pButtonLoopHalve = std::make_unique<ControlProxy>(m_sGroup1, "loop_halve");
-        m_pLoopEnabled = std::make_unique<ControlProxy>(m_sGroup1, "loop_enabled");
-        m_pLoopStartPoint = std::make_unique<ControlProxy>(m_sGroup1, "loop_start_position");
-        m_pLoopEndPoint = std::make_unique<ControlProxy>(m_sGroup1, "loop_end_position");
-        m_pLoopScale = std::make_unique<ControlProxy>(m_sGroup1, "loop_scale");
-        m_pButtonPlay = std::make_unique<ControlProxy>(m_sGroup1, "play");
-        m_pPlayPosition = std::make_unique<ControlProxy>(m_sGroup1, "playposition");
-        m_pButtonBeatMoveForward = std::make_unique<ControlProxy>(m_sGroup1, "loop_move_1_forward");
-        m_pButtonBeatMoveBackward = std::make_unique<ControlProxy>(m_sGroup1, "loop_move_1_backward");
-        m_pButtonBeatLoop2Activate = std::make_unique<ControlProxy>(m_sGroup1, "beatloop_2_activate");
-        m_pButtonBeatLoop4Activate = std::make_unique<ControlProxy>(m_sGroup1, "beatloop_4_activate");
-        m_pBeatLoop1Enabled = std::make_unique<ControlProxy>(m_sGroup1, "beatloop_1_enabled");
-        m_pBeatLoop2Enabled = std::make_unique<ControlProxy>(m_sGroup1, "beatloop_2_enabled");
-        m_pBeatLoop4Enabled = std::make_unique<ControlProxy>(m_sGroup1, "beatloop_4_enabled");
-        m_pBeatLoop64Enabled = std::make_unique<ControlProxy>(m_sGroup1, "beatloop_64_enabled");
-        m_pBeatLoop = std::make_unique<ControlProxy>(m_sGroup1, "beatloop");
-        m_pBeatLoopSize = std::make_unique<ControlProxy>(m_sGroup1, "beatloop_size");
-        m_pButtonBeatLoopActivate = std::make_unique<ControlProxy>(m_sGroup1, "beatloop_activate");
-        m_pBeatJumpSize = std::make_unique<ControlProxy>(m_sGroup1, "beatjump_size");
-        m_pButtonBeatJumpForward = std::make_unique<ControlProxy>(m_sGroup1, "beatjump_forward");
-        m_pButtonBeatJumpBackward = std::make_unique<ControlProxy>(m_sGroup1, "beatjump_backward");
-        m_pButtonBeatLoopRoll1Activate = std::make_unique<ControlProxy>(m_sGroup1, "beatlooproll_1_activate");
-        m_pButtonBeatLoopRoll2Activate = std::make_unique<ControlProxy>(m_sGroup1, "beatlooproll_2_activate");
-        m_pButtonBeatLoopRoll4Activate = std::make_unique<ControlProxy>(m_sGroup1, "beatlooproll_4_activate");
+        m_pButtonLoopIn = std::make_unique<PollingControlProxy>(m_sGroup1, "loop_in");
+        m_pButtonLoopOut = std::make_unique<PollingControlProxy>(m_sGroup1, "loop_out");
+        m_pButtonLoopExit = std::make_unique<PollingControlProxy>(m_sGroup1, "loop_exit");
+        m_pButtonReloopToggle = std::make_unique<PollingControlProxy>(m_sGroup1, "reloop_toggle");
+        m_pButtonReloopAndStop = std::make_unique<PollingControlProxy>(m_sGroup1, "reloop_andstop");
+        m_pButtonLoopDouble = std::make_unique<PollingControlProxy>(m_sGroup1, "loop_double");
+        m_pButtonLoopHalve = std::make_unique<PollingControlProxy>(m_sGroup1, "loop_halve");
+        m_pLoopEnabled = std::make_unique<PollingControlProxy>(m_sGroup1, "loop_enabled");
+        m_pLoopStartPoint = std::make_unique<PollingControlProxy>(m_sGroup1, "loop_start_position");
+        m_pLoopEndPoint = std::make_unique<PollingControlProxy>(m_sGroup1, "loop_end_position");
+        m_pLoopScale = std::make_unique<PollingControlProxy>(m_sGroup1, "loop_scale");
+        m_pButtonPlay = std::make_unique<PollingControlProxy>(m_sGroup1, "play");
+        m_pPlayPosition = std::make_unique<PollingControlProxy>(m_sGroup1, "playposition");
+        m_pButtonBeatMoveForward = std::make_unique<PollingControlProxy>(
+                m_sGroup1, "loop_move_1_forward");
+        m_pButtonBeatMoveBackward = std::make_unique<PollingControlProxy>(
+                m_sGroup1, "loop_move_1_backward");
+        m_pButtonBeatLoop2Activate = std::make_unique<PollingControlProxy>(
+                m_sGroup1, "beatloop_2_activate");
+        m_pButtonBeatLoop4Activate = std::make_unique<PollingControlProxy>(
+                m_sGroup1, "beatloop_4_activate");
+        m_pBeatLoop1Enabled = std::make_unique<PollingControlProxy>(
+                m_sGroup1, "beatloop_1_enabled");
+        m_pBeatLoop2Enabled = std::make_unique<PollingControlProxy>(
+                m_sGroup1, "beatloop_2_enabled");
+        m_pBeatLoop4Enabled = std::make_unique<PollingControlProxy>(
+                m_sGroup1, "beatloop_4_enabled");
+        m_pBeatLoop64Enabled = std::make_unique<PollingControlProxy>(
+                m_sGroup1, "beatloop_64_enabled");
+        m_pBeatLoop = std::make_unique<PollingControlProxy>(m_sGroup1, "beatloop");
+        m_pBeatLoopSize = std::make_unique<PollingControlProxy>(m_sGroup1, "beatloop_size");
+        m_pButtonBeatLoopActivate = std::make_unique<PollingControlProxy>(
+                m_sGroup1, "beatloop_activate");
+        m_pBeatJumpSize = std::make_unique<PollingControlProxy>(m_sGroup1, "beatjump_size");
+        m_pButtonBeatJumpForward = std::make_unique<PollingControlProxy>(
+                m_sGroup1, "beatjump_forward");
+        m_pButtonBeatJumpBackward = std::make_unique<PollingControlProxy>(
+                m_sGroup1, "beatjump_backward");
+        m_pButtonBeatLoopRoll1Activate = std::make_unique<PollingControlProxy>(
+                m_sGroup1, "beatlooproll_1_activate");
+        m_pButtonBeatLoopRoll2Activate = std::make_unique<PollingControlProxy>(
+                m_sGroup1, "beatlooproll_2_activate");
+        m_pButtonBeatLoopRoll4Activate = std::make_unique<PollingControlProxy>(
+                m_sGroup1, "beatlooproll_4_activate");
     }
 
     mixxx::audio::FramePos currentFramePos() {
@@ -78,40 +92,40 @@ class LoopingControlTest : public MockedEngineBackendTest {
         ProcessBuffer();
     }
 
-    std::unique_ptr<ControlProxy> m_pNextBeat;
-    std::unique_ptr<ControlProxy> m_pClosestBeat;
-    std::unique_ptr<ControlProxy> m_pQuantizeEnabled;
-    std::unique_ptr<ControlProxy> m_pTrackSamples;
-    std::unique_ptr<ControlProxy> m_pButtonLoopIn;
-    std::unique_ptr<ControlProxy> m_pButtonLoopOut;
-    std::unique_ptr<ControlProxy> m_pButtonLoopExit;
-    std::unique_ptr<ControlProxy> m_pButtonReloopToggle;
-    std::unique_ptr<ControlProxy> m_pButtonReloopAndStop;
-    std::unique_ptr<ControlProxy> m_pButtonLoopDouble;
-    std::unique_ptr<ControlProxy> m_pButtonLoopHalve;
-    std::unique_ptr<ControlProxy> m_pLoopEnabled;
-    std::unique_ptr<ControlProxy> m_pLoopStartPoint;
-    std::unique_ptr<ControlProxy> m_pLoopEndPoint;
-    std::unique_ptr<ControlProxy> m_pLoopScale;
-    std::unique_ptr<ControlProxy> m_pPlayPosition;
-    std::unique_ptr<ControlProxy> m_pButtonPlay;
-    std::unique_ptr<ControlProxy> m_pButtonBeatMoveForward;
-    std::unique_ptr<ControlProxy> m_pButtonBeatMoveBackward;
-    std::unique_ptr<ControlProxy> m_pButtonBeatLoop2Activate;
-    std::unique_ptr<ControlProxy> m_pButtonBeatLoop4Activate;
-    std::unique_ptr<ControlProxy> m_pBeatLoop1Enabled;
-    std::unique_ptr<ControlProxy> m_pBeatLoop2Enabled;
-    std::unique_ptr<ControlProxy> m_pBeatLoop4Enabled;
-    std::unique_ptr<ControlProxy> m_pBeatLoop64Enabled;
-    std::unique_ptr<ControlProxy> m_pBeatLoop;
-    std::unique_ptr<ControlProxy> m_pBeatLoopSize;
-    std::unique_ptr<ControlProxy> m_pButtonBeatLoopActivate;
-    std::unique_ptr<ControlProxy> m_pBeatJumpSize;
-    std::unique_ptr<ControlProxy> m_pButtonBeatJumpForward;
-    std::unique_ptr<ControlProxy> m_pButtonBeatJumpBackward;
-    std::unique_ptr<ControlProxy> m_pButtonBeatLoopRoll1Activate;
-    std::unique_ptr<ControlProxy> m_pButtonBeatLoopRoll2Activate;
-    std::unique_ptr<ControlProxy> m_pButtonBeatLoopRoll4Activate;
+    std::unique_ptr<PollingControlProxy> m_pNextBeat;
+    std::unique_ptr<PollingControlProxy> m_pClosestBeat;
+    std::unique_ptr<PollingControlProxy> m_pQuantizeEnabled;
+    std::unique_ptr<PollingControlProxy> m_pTrackSamples;
+    std::unique_ptr<PollingControlProxy> m_pButtonLoopIn;
+    std::unique_ptr<PollingControlProxy> m_pButtonLoopOut;
+    std::unique_ptr<PollingControlProxy> m_pButtonLoopExit;
+    std::unique_ptr<PollingControlProxy> m_pButtonReloopToggle;
+    std::unique_ptr<PollingControlProxy> m_pButtonReloopAndStop;
+    std::unique_ptr<PollingControlProxy> m_pButtonLoopDouble;
+    std::unique_ptr<PollingControlProxy> m_pButtonLoopHalve;
+    std::unique_ptr<PollingControlProxy> m_pLoopEnabled;
+    std::unique_ptr<PollingControlProxy> m_pLoopStartPoint;
+    std::unique_ptr<PollingControlProxy> m_pLoopEndPoint;
+    std::unique_ptr<PollingControlProxy> m_pLoopScale;
+    std::unique_ptr<PollingControlProxy> m_pPlayPosition;
+    std::unique_ptr<PollingControlProxy> m_pButtonPlay;
+    std::unique_ptr<PollingControlProxy> m_pButtonBeatMoveForward;
+    std::unique_ptr<PollingControlProxy> m_pButtonBeatMoveBackward;
+    std::unique_ptr<PollingControlProxy> m_pButtonBeatLoop2Activate;
+    std::unique_ptr<PollingControlProxy> m_pButtonBeatLoop4Activate;
+    std::unique_ptr<PollingControlProxy> m_pBeatLoop1Enabled;
+    std::unique_ptr<PollingControlProxy> m_pBeatLoop2Enabled;
+    std::unique_ptr<PollingControlProxy> m_pBeatLoop4Enabled;
+    std::unique_ptr<PollingControlProxy> m_pBeatLoop64Enabled;
+    std::unique_ptr<PollingControlProxy> m_pBeatLoop;
+    std::unique_ptr<PollingControlProxy> m_pBeatLoopSize;
+    std::unique_ptr<PollingControlProxy> m_pButtonBeatLoopActivate;
+    std::unique_ptr<PollingControlProxy> m_pBeatJumpSize;
+    std::unique_ptr<PollingControlProxy> m_pButtonBeatJumpForward;
+    std::unique_ptr<PollingControlProxy> m_pButtonBeatJumpBackward;
+    std::unique_ptr<PollingControlProxy> m_pButtonBeatLoopRoll1Activate;
+    std::unique_ptr<PollingControlProxy> m_pButtonBeatLoopRoll2Activate;
+    std::unique_ptr<PollingControlProxy> m_pButtonBeatLoopRoll4Activate;
 };
 
 TEST_F(LoopingControlTest, LoopSet) {

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -4,6 +4,7 @@
 #include <QSortFilterProxyModel>
 
 #include "control/controlproxy.h"
+#include "control/pollingcontrolproxy.h"
 #include "library/dao/playlistdao.h"
 #include "library/trackmodel.h" // Can't forward declare enums
 #include "preferences/usersettings.h"


### PR DESCRIPTION
This is the first PR with non conflicting changes after my original attempt, waiting here: 
https://github.com/daschuer/mixxx/tree/controlproxylt2

This replaces some ControlProxies with PollingControlProxies and avoids heap allocation 

