### PR TITLE
User more gsl::not_null 

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -82,7 +82,7 @@ void appendCueHint(gsl::not_null<HintVector*> pHintList,
     }
 }
 
-void appendCueHint(HintVector* pHintList, const double playPos, Hint::Type type) {
+void appendCueHint(gsl::not_null<HintVector*> pHintList, const double playPos, Hint::Type type) {
     const auto frame = mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(playPos);
     appendCueHint(pHintList, frame, type);
 }

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -23,7 +23,7 @@ constexpr bool kLogStats = false;
 std::atomic<int> s_numberOfInstances;
 
 template<typename T>
-inline bool compareAndSet(T* pField, const T& value) {
+inline bool compareAndSet(gsl::not_null<T*> pField, const T& value) {
     if (*pField != value) {
         // Copy the value into its final location
         *pField = value;
@@ -37,7 +37,7 @@ inline bool compareAndSet(T* pField, const T& value) {
 // Overload with a forwarding reference argument for efficiently
 // passing large, movable values.
 template<typename T>
-inline bool compareAndSet(T* pField, T&& value) {
+inline bool compareAndSet(gsl::not_null<T*> pField, T&& value) {
     if (*pField != value) {
         // Forward the value into its final location
         *pField = std::forward<T>(value);

--- a/src/util/macros.h
+++ b/src/util/macros.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <type_traits>
-
 #include <QtDebug>
+#include <gsl/pointers>
+#include <type_traits>
 
 // Helper macro for defining simple properties with setters and
 // getters.
@@ -49,12 +49,12 @@
     }                                                                   \
                                                                         \
   public:                                                               \
-    constexpr TYPE* ptr##CAP_NAME() {                                   \
+    constexpr gsl::not_null<TYPE*> ptr##CAP_NAME() {                    \
         return &m_##NAME;                                               \
     }                                                                   \
                                                                         \
   public:                                                               \
-    constexpr const TYPE* ptr##CAP_NAME() const {                       \
+    constexpr gsl::not_null<const TYPE*> ptr##CAP_NAME() const {        \
         return &m_##NAME;                                               \
     }                                                                   \
                                                                         \


### PR DESCRIPTION
I couldn't resist to try to get rid of the party stopping runtime checks of gsl::not_null. 

This is the case when the compiler sees null checks in our own code. So I went ahead creating a wrapper header that checks this by turning the runtime checks into link-time checks. It is a drop in replacement for `#include <gsl/pointers>` and re-defines the `Expects(a)` and `Ensures(a)` macros as link-time assertions. 
https://github.com/daschuer/mixxx/blob/not_null_link_assert/src/util/not_null_link_assert.h

With this in place, I found the changes presented in this PR, required to have no run-time null check in the constructor. 
Unfortunately without this wrapping header there is still a null check involved with each copy by a pedantic "Postcondition" that verifies that gsl::not_null template itself works. 

Here you see the failing workflow without this PR: 
https://github.com/daschuer/mixxx/actions/runs/2807983581

And this is the workflow using not_null_link_assert.h and the changes from this PR:
https://github.com/daschuer/mixxx/actions/runs/2807984837

I would like to include not_null_link_assert.h in a second PR to make sure all null checks are in place before creating a not_null pointer in future changes as well. 

The changes of this PR should be non-controversial. 

What do you think? 




