### PR TITLE
DlgPrefEQ: fix loading/saving main EQ parameters

### DIFF
--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -552,9 +552,12 @@ void DlgPrefEQ::slotUpdateMainEQParameter(int value) {
                 EffectManifestParameter::ParameterType::Knob, index);
 
         if (pParameterSlot->isLoaded()) {
-            double dValue = value / 100.0;
-            pParameterSlot->setParameter(dValue);
+            // Calculate parameter value from relative slider position
+            double paramValue = static_cast<double>(value - slider->minimum()) /
+                    static_cast<double>(slider->maximum() - slider->minimum());
+            pParameterSlot->setParameter(paramValue);
             QLabel* valueLabel = m_mainEQValues[index];
+            double dValue = value / 100.0;
             QString valueText = QString::number(dValue);
             valueLabel->setText(valueText);
 
@@ -819,8 +822,12 @@ void DlgPrefEQ::setMainEQParameter(int i, double value) {
                 EffectManifestParameter::ParameterType::Knob, i);
 
         if (pParameterSlot->isLoaded()) {
-            pParameterSlot->setParameter(value);
-            m_mainEQSliders[i]->setValue(static_cast<int>(value * 100));
+            QSlider* slider = m_mainEQSliders[i];
+            // Calculate parameter value from relative slider position
+            double paramValue = static_cast<double>(value - slider->minimum()) /
+                    static_cast<double>(slider->maximum() - slider->minimum());
+            pParameterSlot->setParameter(paramValue);
+            slider->setValue(static_cast<int>(value * 100));
 
             QLabel* valueLabel = m_mainEQValues[i];
             QString valueText = QString::number(value);

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -20,6 +20,7 @@ const QString kEffectForGroupPrefix = QStringLiteral("EffectForGroup_");
 const QString kEnableEqs = QStringLiteral("EnableEQs");
 const QString kEqsOnly = QStringLiteral("EQsOnly");
 const QString kSingleEq = QStringLiteral("SingleEQEffect");
+const QString kMainEQParameterKey = QStringLiteral("EffectForGroup_[Master]_parameter");
 const QString kDefaultEqId = BiquadFullKillEQEffect::getId() + " " +
         EffectsBackend::backendTypeToString(EffectBackendType::BuiltIn);
 const QString kDefaultQuickEffectChainName = QStringLiteral("Filter");
@@ -562,7 +563,7 @@ void DlgPrefEQ::slotApplyMainEQParameter(int value) {
             valueLabel->setText(valueText);
 
             m_pConfig->set(ConfigKey(kConfigGroup,
-                                   QString("EffectForGroup_[Master]_parameter%1").arg(index + 1)),
+                                   kMainEQParameterKey + QString::number(index + 1)),
                     ConfigValue(valueText));
         }
     }
@@ -678,7 +679,7 @@ void DlgPrefEQ::setUpMainEQ() {
 
             if (pParameterSlot->isLoaded()) {
                 QString strValue = m_pConfig->getValueString(ConfigKey(kConfigGroup,
-                        QString("EffectForGroup_[Master]_parameter%1").arg(i + 1)));
+                        kMainEQParameterKey + QString::number(i + 1)));
                 bool ok;
                 double value = strValue.toDouble(&ok);
                 if (ok) {
@@ -834,7 +835,7 @@ void DlgPrefEQ::setMainEQParameter(int i, double value) {
             valueLabel->setText(valueText);
 
             m_pConfig->set(ConfigKey(kConfigGroup,
-                                   QString("EffectForGroup_[Master]_parameter%1").arg(i + 1)),
+                                   kMainEQParameterKey + QString::number(i + 1)),
                     ConfigValue(valueText));
         }
     }

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -543,7 +543,7 @@ void DlgPrefEQ::slotUpdateLoEQ() {
     slotApply();
 }
 
-void DlgPrefEQ::slotUpdateMainEQParameter(int value) {
+void DlgPrefEQ::slotApplyMainEQParameter(int value) {
     EffectSlotPointer pEffectSlot(m_pEffectMainEQ);
     if (!pEffectSlot.isNull()) {
         QSlider* slider = qobject_cast<QSlider*>(sender());
@@ -748,7 +748,7 @@ void DlgPrefEQ::slotMainEqEffectChanged(int effectIndex) {
                     connect(slider,
                             &QSlider::sliderMoved,
                             this,
-                            &DlgPrefEQ::slotUpdateMainEQParameter);
+                            &DlgPrefEQ::slotApplyMainEQParameter);
 
                     QLabel* valueLabel = new QLabel(this);
                     m_mainEQValues.append(valueLabel);

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -756,6 +756,14 @@ void DlgPrefEQ::slotMainEqEffectChanged(int effectIndex) {
                     QString valueText = QString::number((double)slider->value() / 100);
                     valueLabel->setText(valueText);
                     slidersGridLayout->addWidget(valueLabel, 2, i + 1, Qt::AlignCenter);
+
+                    // Immediately save the new (default) parameter values in preferences.
+                    // Otherwise, without pressing 'Reset parameter', the previously saved
+                    // parameter values (of another EQ effect) would be loaded on next start
+                    // which (unnoticed) messes up the parameters displayed now.
+                    m_pConfig->set(ConfigKey(kConfigGroup,
+                                           kMainEQParameterKey + QString::number(i + 1)),
+                            ConfigValue(valueText));
                 }
             }
         }

--- a/src/preferences/dialog/dlgprefeq.h
+++ b/src/preferences/dialog/dlgprefeq.h
@@ -71,6 +71,8 @@ class DlgPrefEQ : public DlgPreferencePage, public Ui::DlgPrefEQDlg  {
 
     void applySelectionsToDecks();
 
+    bool eventFilter(QObject* obj, QEvent* e) override;
+
     ControlProxy m_COLoFreq;
     ControlProxy m_COHiFreq;
     UserSettingsPointer m_pConfig;

--- a/src/preferences/dialog/dlgprefeq.h
+++ b/src/preferences/dialog/dlgprefeq.h
@@ -45,7 +45,7 @@ class DlgPrefEQ : public DlgPreferencePage, public Ui::DlgPrefEQDlg  {
     void slotUpdateGainAutoReset(int);
     void slotBypass(int state);
     // Update the Main EQ
-    void slotUpdateMainEQParameter(int value);
+    void slotApplyMainEQParameter(int value);
     void slotMainEQToDefault();
     void setMainEQParameter(int i, double value);
     void slotMainEqEffectChanged(int effectIndex);

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -239,7 +239,7 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
 
     // Set the focus policy for QComboBoxes (and wide QDoubleSpinBoxes) and
     // connect them to the custom event filter below so they don't accept focus
-    // when we scroll the preferences page.
+    // when we scroll the preferences page to avoid undesired value changes.
     QObjectList objList = children();
     for (int i = 0; i < objList.length(); ++i) {
         QComboBox* combo = qobject_cast<QComboBox*>(objList[i]);


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1983764
https://bugs.launchpad.net/mixxx/+bug/1983789 likely a regression from effects refactoring

**Verify lp:1983764 is fixed:**
* load 'Graphic EQ'
* click 'Reset Parameter' (don't touch sliders)
* 'frequency image' and output level should not change
* restart Mixxx
*  'frequency image' and output level should still be unaffected
 

**Verify lp:1983789 is fixed:**

* load 'Parametric EQ'
* click 'Reset Parameter'
* load 'Graphic EQ' (all sliders are centered, don't touch!)
* close & restart Mixxx
* all sliders should still be still be centered

Unfortunately, that pref page is still a mess, most (all?) selections are immediately applied (okay) and stored to config (not okay since is clicking `Cancel` does not reset options to prevous state).
Eventually I'll port #4667 to main one day.