### PR TITLE
DlgPrefEQ: properly restore 'One EQ for all decks' setting

### DIFF
--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -70,6 +70,15 @@ DlgPrefEQ::DlgPrefEQ(QWidget* pParent, EffectsManager* pEffectsManager, UserSett
             &QCheckBox::stateChanged,
             this,
             &DlgPrefEQ::slotSingleEqChecked);
+    // Quick hack to update the checkbox "Use the same EQ filter for all decks"
+    // to not use the default state (checked) when slotNumDecksChanged() calls
+    // slotSingleEqChecked(state) here in constructor, because that would be written
+    // to config immediateley and thus reset the previous unchecked state.
+    // TODO(ronso0) Write only in slotApply(), read from config only in slotUpdate().
+    // Currently config is read in both slotUpdate() and loadSettings().
+    CheckBoxSingleEqEffect->setChecked(m_pConfig->getValue(
+                                               ConfigKey(kConfigKey, kSingleEq), "yes") == "yes");
+    slotSingleEqChecked(CheckBoxSingleEqEffect->isChecked());
 
     // Add drop down lists for current decks and connect num_decks control
     // to slotNumDecksChanged


### PR DESCRIPTION
Previously, the 'One EQ for all decks' checkbox would always be checked after start, potentially resetting user choice.
Noticed here https://mixxx.discourse.group/t/mixx-strongly-began-to-heavily-load-the-system-linux/24068/29

This is a quick hack for 2.3, instead of roundhouse kick #4667 (which also brings undesired changes).