### PR TITLE
Effect chain selectors: add empty item to allow clearing the chain

### DIFF
--- a/res/skins/LateNight/fx/unit.xml
+++ b/res/skins/LateNight/fx/unit.xml
@@ -13,9 +13,28 @@
 
   <WidgetGroup>
     <ObjectName>FxUnitContainer</ObjectName>
-    <Layout>horizontal</Layout>
+    <Layout>vertical</Layout>
     <SizePolicy>me,max</SizePolicy>
     <Children>
+
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <SizePolicy>me,max</SizePolicy>
+        <Children>
+          <EffectChainName>
+            <Size>140me,18f</Size>
+            <EffectUnitGroup><Variable name="FxRack_FxUnit"/></EffectUnitGroup>
+          </EffectChainName>
+
+          <WidgetGroup><Size>0min</Size></WidgetGroup>
+
+          <EffectChainPresetSelector>
+            <ObjectName>QuickEffectSelectorRight</ObjectName>
+            <Size>140me,18f</Size>
+            <EffectUnitGroup><Variable name="FxRack_FxUnit"/></EffectUnitGroup>
+          </EffectChainPresetSelector>
+        </Children>
+      </WidgetGroup>
 
       <WidgetGroup>
         <Layout>horizontal</Layout>

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -1142,6 +1142,7 @@ WEffectSelector:!editable:on {
 WLabel#FxUnitLabel,
 WLabel#MicAuxLabel,
 WLabel#MicAuxLabelUnconfigured,
+WEffectChain,
 WEffectSelector,
 WEffectChainPresetSelector,
 #fadeModeCombobox {
@@ -1198,6 +1199,7 @@ WLibraryTextBrowser QMenu,
 WTrackMenu,
 WTrackMenu QMenu,
 WTrackMenu QMenu QCheckBox,
+WEffectChain,
 WEffectChainPresetButton QMenu,
 WEffectChainPresetButton QMenu QCheckBox,
 QLineEdit QMenu,
@@ -1229,6 +1231,7 @@ WEffectChainPresetSelector:!editable:on,
 #fadeModeCombobox:!editable:on {
   color: #918273;
   }
+  WEffectChain,
   WEffectSelector:!editable,
   WEffectSelector:!editable:on,
   #fadeModeCombobox:!editable,

--- a/src/effects/chains/quickeffectchain.cpp
+++ b/src/effects/chains/quickeffectchain.cpp
@@ -11,7 +11,6 @@ QuickEffectChain::QuickEffectChain(const QString& group,
                   SignalProcessingStage::Postfader,
                   pEffectsManager,
                   pEffectsMessenger) {
-    m_isQuickEffectChain = true;
     for (int i = 0; i < kNumEffectsPerUnit; ++i) {
         addEffectSlot(formatEffectSlotGroup(group, i));
         m_effectSlots.at(i)->setEnabled(true);

--- a/src/effects/chains/quickeffectchain.cpp
+++ b/src/effects/chains/quickeffectchain.cpp
@@ -11,6 +11,7 @@ QuickEffectChain::QuickEffectChain(const QString& group,
                   SignalProcessingStage::Postfader,
                   pEffectsManager,
                   pEffectsMessenger) {
+    m_isQuickEffectChain = true;
     for (int i = 0; i < kNumEffectsPerUnit; ++i) {
         addEffectSlot(formatEffectSlotGroup(group, i));
         m_effectSlots.at(i)->setEnabled(true);

--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -206,7 +206,8 @@ void EffectChain::loadChainPreset(EffectChainPresetPointer pPreset) {
         // This may happen when a chain is cleared by selecting the empty '---'
         // item in WEffectChainPresetSelector or in deck Quick Effect selectors
         // in DlgPrefEq.
-        // Quick Effect chains and other chains need to be treated differently:
+        // Quick Effect chains and other chains need to be treated differently
+        // because saving their preset/state to effects.xml is done differently:
         // * storing Quick Effect chain presets requires a preset name, otherwise
         //  (empty name) will cause the default preset being loaded on next start.
         //  Thus, we name the empty preset kNoEffectString so that the respective

--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -218,7 +218,12 @@ void EffectChain::loadChainPreset(EffectChainPresetPointer pPreset) {
         //  after loading an effect. Thus, if this is not a Quick Effetc chain, we
         //  just clear the preset name which in turn clears the chain's preset
         //  selector and chain name label.
-        m_presetName = m_isQuickEffectChain ? kNoEffectString : QString();
+
+        // Check if this is a QuickEffectChain
+        m_presetName = m_pEffectsManager->chainIsQuickEffectChain(this)
+                ? kNoEffectString
+                : QString();
+
         emit chainPresetChanged(m_presetName);
         setControlLoadedPresetIndex(std::nullopt);
         return;

--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -349,9 +349,10 @@ void EffectChain::slotControlLoadedChainPresetRequest(double value) {
     loadChainPreset(presetAtIndex(index));
 }
 
-void EffectChain::setControlLoadedPresetIndex(uint index) {
-    // add 1 to make the ControlObject 1-indexed like other ControlObjects
-    m_pControlLoadedChainPreset->setAndConfirm(index + 1);
+void EffectChain::setControlLoadedPresetIndex(std::optional<uint> index) {
+    // add 1 to make the ControlObject 1-indexed like other ControlObjects.
+    // if the effect chain is cleared (no valid index), the CO is set 0;
+    m_pControlLoadedChainPreset->setAndConfirm(index ? *index + 1 : 0);
 }
 
 void EffectChain::slotControlNextChainPreset(double value) {

--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -202,7 +202,24 @@ const QString& EffectChain::presetName() const {
 
 void EffectChain::loadChainPreset(EffectChainPresetPointer pPreset) {
     slotControlClear(1);
-    VERIFY_OR_DEBUG_ASSERT(pPreset) {
+    if (!pPreset) {
+        // This may happen when a chain is cleared by selecting the empty '---'
+        // item in WEffectChainPresetSelector or in deck Quick Effect selectors
+        // in DlgPrefEq.
+        // Quick Effect chains and other chains need to be treated differently:
+        // * storing Quick Effect chain presets requires a preset name, otherwise
+        //  (empty name) will cause the default preset being loaded on next start.
+        //  Thus, we name the empty preset kNoEffectString so that the respective
+        //  item is selected in the chain preset selector and also no chain will be
+        //  loaded on next start.
+        // * storing states of regular [EffectRack1] chains doesn't require a preset
+        //  name, also they can be edited, so kNoEffectString would be incorrect
+        //  after loading an effect. Thus, if this is not a Quick Effetc chain, we
+        //  just clear the preset name which in turn clears the chain's preset
+        //  selector and chain name label.
+        m_presetName = m_isQuickEffectChain ? kNoEffectString : QString();
+        emit chainPresetChanged(m_presetName);
+        setControlLoadedPresetIndex(std::nullopt);
         return;
     }
 

--- a/src/effects/effectchain.h
+++ b/src/effects/effectchain.h
@@ -90,6 +90,7 @@ class EffectChain : public QObject {
 
   protected:
     EffectSlotPointer addEffectSlot(const QString& group);
+    bool m_isQuickEffectChain = false;
 
     virtual int numPresets() const;
 

--- a/src/effects/effectchain.h
+++ b/src/effects/effectchain.h
@@ -91,7 +91,6 @@ class EffectChain : public QObject {
 
   protected:
     EffectSlotPointer addEffectSlot(const QString& group);
-    bool m_isQuickEffectChain = false;
 
     virtual int numPresets() const;
 

--- a/src/effects/effectchain.h
+++ b/src/effects/effectchain.h
@@ -13,6 +13,7 @@
 #include "engine/channelhandle.h"
 #include "util/class.h"
 #include "util/memory.h"
+#include "util/optional.h"
 
 class ControlPushButton;
 class ControlEncoder;
@@ -142,7 +143,7 @@ class EffectChain : public QObject {
     std::unique_ptr<ControlPushButton> m_pControlNextChainPreset;
     std::unique_ptr<ControlPushButton> m_pControlPrevChainPreset;
 
-    void setControlLoadedPresetIndex(uint index);
+    void setControlLoadedPresetIndex(std::optional<uint> index);
 
     // These COs do not affect how the effects are processed;
     // they are defined here for skins and controller mappings to communicate

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -177,6 +177,8 @@ void EffectsManager::readEffectsXml() {
     }
     file.close();
 
+    // QuickEffect chains are created only for existing main decks, so read
+    // the configured presets only for those
     QStringList deckStrings;
     for (auto it = m_quickEffectChains.begin(); it != m_quickEffectChains.end(); it++) {
         deckStrings << it.key();

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -163,6 +163,10 @@ EffectChainPointer EffectsManager::getEffectChain(
     return m_effectChainSlotsByGroup.value(group);
 }
 
+bool EffectsManager::chainIsQuickEffectChain(const EffectChain* pEffectChain) const {
+    return dynamic_cast<const QuickEffectChain*>(pEffectChain) != nullptr;
+}
+
 bool EffectsManager::isAdoptMetaknobSettingEnabled() const {
     return m_pConfig->getValue(ConfigKey("[Effects]", "AdoptMetaknobValue"), true);
 }

--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -88,6 +88,7 @@ class EffectsManager {
 
     QList<StandardEffectChainPointer> m_standardEffectChains;
     OutputEffectChainPointer m_outputEffectChain;
+    // These two store <deck group, effect chain pointer>
     QHash<QString, EqualizerEffectChainPointer> m_equalizerEffectChains;
     QHash<QString, QuickEffectChainPointer> m_quickEffectChains;
 

--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -36,6 +36,8 @@ class EffectsManager {
     EffectChainPointer getStandardEffectChain(int unitNumber) const;
     EffectChainPointer getOutputEffectChain() const;
 
+    bool chainIsQuickEffectChain(const EffectChain* pEffectChain) const;
+
     EngineEffectsManager* getEngineEffectsManager() const {
         return m_pEngineEffectsManager;
     }

--- a/src/effects/presets/effectchainpresetmanager.cpp
+++ b/src/effects/presets/effectchainpresetmanager.cpp
@@ -606,7 +606,7 @@ EffectsXmlData EffectChainPresetManager::readEffectsXml(
         quickEffectPresets.insert(deckString, defaultQuickEffectChainPreset);
     }
 
-    // Reload state of standard chains
+    // Read state of standard chains
     QDomElement root = doc.documentElement();
     QDomElement rackElement = XmlParse::selectElement(root, EffectXml::kRack);
     QDomElement chainsElement =
@@ -686,7 +686,7 @@ EffectsXmlData EffectChainPresetManager::readEffectsXml(
     emit effectChainPresetListUpdated();
     emit quickEffectChainPresetListUpdated();
 
-    // Reload presets that were loaded into QuickEffects on last shutdown
+    // Read names of presets that were loaded into QuickEffects on last shutdown
     QDomElement quickEffectPresetsElement =
             XmlParse::selectElement(root, EffectXml::kQuickEffectChainPresets);
     QDomNodeList quickEffectNodeList =
@@ -698,16 +698,17 @@ EffectsXmlData EffectChainPresetManager::readEffectsXml(
             QString deckGroup = presetNameElement.attribute(QStringLiteral("group"));
             QString presetName = presetNameElement.text();
             if (presetName == kNoEffectString) {
-                // kNoEffectString is not allowed as preset name (import,
-                // export, save as new), it can only be set by selecting
-                // kNoEffectString in the Quick Effect slot preset selector
-                // (skin & EQ preferences).
-                // Thus, it's safe to use kNoEffectString to explicitly load
-                // an empty preset.
+                // Explicitly load an empty preset.
+                // It's safe to use kNoEffectString for that because it's not
+                // allowed to used as preset name (import, export, save as new),
+                // it can only be set by selecting kNoEffectString in the Quick Effect
+                // chain preset selector in skin and EQ preferences.
                 quickEffectPresets.insert(deckGroup, nullptr);
             } else { // any name incl. empty string
                 auto pPreset = m_effectChainPresets.value(presetName);
                 if (pPreset != nullptr) {
+                    // Replace defaultQuickEffectChainPreset with pPreset
+                    // for this deck group
                     quickEffectPresets.insert(deckGroup, pPreset);
                 }
             }

--- a/src/effects/presets/effectchainpresetmanager.cpp
+++ b/src/effects/presets/effectchainpresetmanager.cpp
@@ -123,6 +123,13 @@ void EffectChainPresetManager::importPreset() {
         EffectChainPresetPointer pPreset(
                 new EffectChainPreset(doc.documentElement()));
         if (!pPreset->isEmpty() && !pPreset->name().isEmpty()) {
+            // Don't allow '---' because it is used internally for clearing effect
+            // chains and empty Quick Effect chains
+            if (pPreset->name() == kNoEffectString) {
+                pPreset->setName(pPreset->name() +
+                        QLatin1String(" (") + tr("imported") + QLatin1String(")"));
+            }
+
             while (m_effectChainPresets.contains(pPreset->name())) {
                 pPreset->setName(pPreset->name() +
                         QLatin1String(" (") + tr("duplicate") + QLatin1String(")"));
@@ -230,7 +237,8 @@ void EffectChainPresetManager::renamePreset(const QString& oldName) {
 
     QString newName;
     QString errorText;
-    while (newName.isEmpty() || m_effectChainPresets.contains(newName)) {
+    while (newName.isEmpty() || m_effectChainPresets.contains(newName) ||
+            newName == kNoEffectString) {
         bool okay = false;
         newName = QInputDialog::getText(nullptr,
                 tr("Rename effect chain preset"),
@@ -251,6 +259,8 @@ void EffectChainPresetManager::renamePreset(const QString& oldName) {
                     tr("An effect chain preset named \"%1\" already exists.")
                             .arg(newName) +
                     QStringLiteral("\n");
+        } else if (newName == kNoEffectString) {
+            errorText = tr("Invalid name \"%1\"").arg(newName) + QStringLiteral("\n");
         } else {
             errorText = QString();
         }
@@ -371,7 +381,7 @@ void EffectChainPresetManager::savePreset(EffectChainPointer pChainSlot) {
 void EffectChainPresetManager::savePreset(EffectChainPresetPointer pPreset) {
     QString name;
     QString errorText;
-    while (name.isEmpty() || m_effectChainPresets.contains(name)) {
+    while (name.isEmpty() || m_effectChainPresets.contains(name) || name == kNoEffectString) {
         bool okay = false;
         name = QInputDialog::getText(nullptr,
                 tr("Save preset for effect chain"),
@@ -391,6 +401,8 @@ void EffectChainPresetManager::savePreset(EffectChainPresetPointer pPreset) {
                     tr("An effect chain preset named \"%1\" already exists.")
                             .arg(name) +
                     QStringLiteral("\n");
+        } else if (name == kNoEffectString) {
+            errorText = tr("Invalid name \"%1\"").arg(name) + QStringLiteral("\n");
         } else {
             errorText = QString();
         }
@@ -444,6 +456,12 @@ void EffectChainPresetManager::importUserPresets() {
         EffectChainPresetPointer pEffectChainPreset = loadPresetFromFile(
                 savedPresetsPath + kFolderDelimiter + filePath);
         if (pEffectChainPreset && !pEffectChainPreset->isEmpty()) {
+            // Don't allow '---' because it is used internally for clearing effect
+            // chains and empty Quick Effect chains
+            if (pEffectChainPreset->name() == kNoEffectString) {
+                pEffectChainPreset->setName(pEffectChainPreset->name() +
+                        QLatin1String(" (") + tr("imported") + QLatin1String(")"));
+            }
             m_effectChainPresets.insert(
                     pEffectChainPreset->name(), pEffectChainPreset);
         }

--- a/src/effects/presets/effectchainpresetmanager.cpp
+++ b/src/effects/presets/effectchainpresetmanager.cpp
@@ -696,9 +696,20 @@ EffectsXmlData EffectChainPresetManager::readEffectsXml(
         QDomElement presetNameElement = quickEffectNodeList.at(i).toElement();
         if (!presetNameElement.isNull()) {
             QString deckGroup = presetNameElement.attribute(QStringLiteral("group"));
-            auto pPreset = m_effectChainPresets.value(presetNameElement.text());
-            if (pPreset != nullptr) {
-                quickEffectPresets.insert(deckGroup, pPreset);
+            QString presetName = presetNameElement.text();
+            if (presetName == kNoEffectString) {
+                // kNoEffectString is not allowed as preset name (import,
+                // export, save as new), it can only be set by selecting
+                // kNoEffectString in the Quick Effect slot preset selector
+                // (skin & EQ preferences).
+                // Thus, it's safe to use kNoEffectString to explicitly load
+                // an empty preset.
+                quickEffectPresets.insert(deckGroup, nullptr);
+            } else { // any name incl. empty string
+                auto pPreset = m_effectChainPresets.value(presetName);
+                if (pPreset != nullptr) {
+                    quickEffectPresets.insert(deckGroup, pPreset);
+                }
             }
         }
     }

--- a/src/widget/weffectchainpresetselector.cpp
+++ b/src/widget/weffectchainpresetselector.cpp
@@ -84,7 +84,6 @@ void WEffectChainPresetSelector::populate() {
 }
 
 void WEffectChainPresetSelector::slotEffectChainPresetSelected(int index) {
-    Q_UNUSED(index);
     m_pChain->loadChainPreset(
             m_pChainPresetManager->getPreset(currentData().toString()));
     setBaseTooltip(itemData(index, Qt::ToolTipRole).toString());
@@ -97,7 +96,7 @@ void WEffectChainPresetSelector::slotEffectChainPresetSelected(int index) {
 
 void WEffectChainPresetSelector::slotChainPresetChanged(const QString& name) {
     setCurrentIndex(findData(name));
-    setBaseTooltip(name);
+    setBaseTooltip(itemData(currentIndex(), Qt::ToolTipRole).toString());
 }
 
 bool WEffectChainPresetSelector::event(QEvent* pEvent) {

--- a/src/widget/weffectchainpresetselector.cpp
+++ b/src/widget/weffectchainpresetselector.cpp
@@ -63,6 +63,10 @@ void WEffectChainPresetSelector::populate() {
 
     QFontMetrics metrics(font());
 
+    // This is used to clear the effect chain
+    addItem(kNoEffectString, kNoEffectString);
+    setItemData(0, QVariant(tr("No effect chain loaded.")), Qt::ToolTipRole);
+
     QList<EffectChainPresetPointer> presetList;
     if (m_bQuickEffectChain) {
         presetList = m_pEffectsManager->getChainPresetManager()->getQuickEffectPresetsSorted();
@@ -76,7 +80,7 @@ void WEffectChainPresetSelector::populate() {
                 Qt::ElideMiddle,
                 view()->width() - 2);
         addItem(elidedDisplayName, QVariant(pChainPreset->name()));
-        setItemData(i, pChainPreset->name(), Qt::ToolTipRole);
+        setItemData(i + 1, pChainPreset->name(), Qt::ToolTipRole);
     }
 
     slotChainPresetChanged(m_pChain->presetName());
@@ -84,6 +88,8 @@ void WEffectChainPresetSelector::populate() {
 }
 
 void WEffectChainPresetSelector::slotEffectChainPresetSelected(int index) {
+    // If kNoEffectString was selected the chain will be cleared.
+    // See EffectChain::loadChainPreset for details.
     m_pChain->loadChainPreset(
             m_pChainPresetManager->getPreset(currentData().toString()));
     setBaseTooltip(itemData(index, Qt::ToolTipRole).toString());
@@ -95,8 +101,12 @@ void WEffectChainPresetSelector::slotEffectChainPresetSelected(int index) {
 }
 
 void WEffectChainPresetSelector::slotChainPresetChanged(const QString& name) {
-    setCurrentIndex(findData(name));
-    setBaseTooltip(itemData(currentIndex(), Qt::ToolTipRole).toString());
+    // This is called by signal EffectChain::chainPresetChanged(name) emitted by
+    // EffectChain::loadChainPreset. See that slot for details about the preset
+    // names being emitted for different chain types.
+    int newIndex = findData(name);
+    setCurrentIndex(newIndex);
+    setBaseTooltip(itemData(newIndex, Qt::ToolTipRole).toString());
 }
 
 bool WEffectChainPresetSelector::event(QEvent* pEvent) {


### PR DESCRIPTION
* selecting `---` in effect chain preset selectors and in EQ preferences (Quick Effects) clears the respective effect chain
* for Quick Effects chains, the preset selector (skins & prefs) will show `---` which will also be stored in effects.xml to keep the empty chain on next start
* for other effect chains, the preset selector will be cleared and an empty preset name will be stored as before (see inline comments for details)

Primary purpose is to clear the Quick Effect chain (which I don't use) to get a clean GUI and have one aspect less I need to check when deck output is... unexpected / silent.
https://bugs.launchpad.net/mixxx/+bug/1980755

Instead of a built-in empty chain preset, this approach uses the already present `---` items in DlgPrefEQ and adjusts the effect chain manager to handle it appropriately, i.e. all widgets (skin & preferences) as well as effect slots and `loaded_chain_preset` are updated. Also, the empty chain dummy item does not show up in Preferences > Effects, and thus doesn't need to be taken care of anywhere else.

@Be-ing Do you mind taking a look?

**TODO**

- [ ] remove commit with extra fx chain preset widgets in LateNight