### PR TITLE
Fix matching of X32 MIDI in/out devices

### DIFF
--- a/src/controllers/midi/portmidienumerator.cpp
+++ b/src/controllers/midi/portmidienumerator.cpp
@@ -25,8 +25,10 @@ bool recognizeDevice(const PmDeviceInfo& deviceInfo) {
 // devices that have an equivalent "deviceName" and ### section.
 const QRegularExpression kMidiDeviceNameRegex(QStringLiteral("^(.*) MIDI (\\d+)( .*)?$"));
 
-const QRegularExpression kInputRegex(QStringLiteral("^(.*) in (\\d+)( .*)?$"));
-const QRegularExpression kOutputRegex(QStringLiteral("^(.*) out (\\d+)( .*)?$"));
+const QRegularExpression kInputRegex(QStringLiteral("^(.*) in( \\d+)?( .*)?$"),
+        QRegularExpression::CaseInsensitiveOption);
+const QRegularExpression kOutputRegex(QStringLiteral("^(.*) out( \\d+)?( .*)?$"),
+        QRegularExpression::CaseInsensitiveOption);
 
 // This is a broad pattern that matches a text blob followed by a numeral
 // potentially followed by non-numeric text. The non-numeric requirement is

--- a/src/test/portmidienumeratortest.cpp
+++ b/src/test/portmidienumeratortest.cpp
@@ -75,6 +75,19 @@ TEST_F(PortMidiEnumeratorTest, InputOutputPortsLinked) {
         "Pure Data Midi in 1",
         "Pure Data Midi out 1"));
 
+    ASSERT_FALSE(shouldLinkInputToOutput(
+            "Pure Data Midi in 1",
+            "Pure Data Midi out 2"));
+
+    ASSERT_TRUE(shouldLinkInputToOutput(
+            "foo in 123 bar test",
+            "foo out 123 bar test"));
+
+    // Bug 1986440 - Behringer X32
+    ASSERT_TRUE(shouldLinkInputToOutput(
+            "X-USB MIDI IN",
+            "X-USB MIDI OUT"));
+
     // Strip ' input ' from inputs and ' output ' from outputs.
 
     // Lemur Daemon shows 8 port pairs named like: 'Daemon Input 1' and 'Daemon


### PR DESCRIPTION
This fixes https://bugs.launchpad.net/mixxx/+bug/1986440.

PortMidiEnumeratorTests are passing.