### PR TITLE
Effect chain: (re)load & select preset after saving with a new name

### DIFF
--- a/src/effects/presets/effectchainpresetmanager.cpp
+++ b/src/effects/presets/effectchainpresetmanager.cpp
@@ -363,12 +363,14 @@ void EffectChainPresetManager::setQuickEffectPresetOrder(
     emit quickEffectChainPresetListUpdated();
 }
 
-void EffectChainPresetManager::savePreset(EffectChainPointer pChainSlot) {
+void EffectChainPresetManager::savePresetAndReload(EffectChainPointer pChainSlot) {
     auto pPreset = EffectChainPresetPointer::create(pChainSlot.data());
-    savePreset(pPreset);
+    if (savePreset(pPreset)) {
+        pChainSlot->loadChainPreset(pPreset);
+    }
 }
 
-void EffectChainPresetManager::savePreset(EffectChainPresetPointer pPreset) {
+bool EffectChainPresetManager::savePreset(EffectChainPresetPointer pPreset) {
     QString name;
     QString errorText;
     while (name.isEmpty() || m_effectChainPresets.contains(name)) {
@@ -381,7 +383,7 @@ void EffectChainPresetManager::savePreset(EffectChainPresetPointer pPreset) {
                 &okay)
                        .trimmed();
         if (!okay) {
-            return;
+            return false;
         }
 
         if (name.isEmpty()) {
@@ -404,6 +406,7 @@ void EffectChainPresetManager::savePreset(EffectChainPresetPointer pPreset) {
     emit quickEffectChainPresetListUpdated();
 
     savePresetXml(pPreset);
+    return true;
 }
 
 void EffectChainPresetManager::updatePreset(EffectChainPointer pChainSlot) {

--- a/src/effects/presets/effectchainpresetmanager.h
+++ b/src/effects/presets/effectchainpresetmanager.h
@@ -65,8 +65,8 @@ class EffectChainPresetManager : public QObject {
         return m_effectChainPresets.value(name);
     }
 
-    void savePreset(EffectChainPresetPointer pPreset);
-    void savePreset(EffectChainPointer pChainSlot);
+    void savePresetAndReload(EffectChainPointer pChainSlot);
+    bool savePreset(EffectChainPresetPointer pPreset);
     void updatePreset(EffectChainPointer pChainSlot);
 
     EffectsXmlData readEffectsXml(const QDomDocument& doc, const QStringList& deckStrings);

--- a/src/widget/weffectchainpresetbutton.cpp
+++ b/src/widget/weffectchainpresetbutton.cpp
@@ -65,7 +65,7 @@ void WEffectChainPresetButton::populateMenu() {
         });
     }
     m_pMenu->addAction(tr("Save As New Preset..."), this, [this]() {
-        m_pChainPresetManager->savePreset(m_pChain);
+        m_pChainPresetManager->savePresetAndReload(m_pChain);
     });
 
     m_pMenu->addSeparator();


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1986439

Save preset with new name, and the new preset will be loaded and selected in WEffectChainMenuButton and WEffectChainPresetSelector.

Note: I didn't check wether the internediate preset unload causes sound issues. Please test.