### PR TITLE
MC7000: Fix off-by-one indexing in the controller script

### DIFF
--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -250,16 +250,16 @@ MC7000.padModeCue = function(channel, control, value, status, group) {
     if (value === 0x00) {
         return; // don't respond to note off messages
     }
-    MC7000.PADModeCue[deckNumber] = true;
-    MC7000.PADModeCueLoop[deckNumber] = false;
-    MC7000.PADModeFlip[deckNumber] = false;
-    MC7000.PADModeRoll[deckNumber] = false;
-    MC7000.PADModeSavedLoop[deckNumber] = false;
-    MC7000.PADModeSlicer[deckNumber] = false;
-    MC7000.PADModeSlicerLoop[deckNumber] = false;
-    MC7000.PADModeSampler[deckNumber] = false;
-    MC7000.PADModeVelSamp[deckNumber] = false;
-    MC7000.PADModePitch[deckNumber] = false;
+    MC7000.PADModeCue[deckOffset] = true;
+    MC7000.PADModeCueLoop[deckOffset] = false;
+    MC7000.PADModeFlip[deckOffset] = false;
+    MC7000.PADModeRoll[deckOffset] = false;
+    MC7000.PADModeSavedLoop[deckOffset] = false;
+    MC7000.PADModeSlicer[deckOffset] = false;
+    MC7000.PADModeSlicerLoop[deckOffset] = false;
+    MC7000.PADModeSampler[deckOffset] = false;
+    MC7000.PADModeVelSamp[deckOffset] = false;
+    MC7000.PADModePitch[deckOffset] = false;
 
     // change PAD color when switching to Hot Cue Mode
     for (var i = 1; i <= 8; i++) {
@@ -278,16 +278,16 @@ MC7000.padModeCueLoop = function(channel, control, value, status, group) {
     if (value === 0x00) {
         return; // don't respond to note off messages
     }
-    MC7000.PADModeCue[deckNumber] = false;
-    MC7000.PADModeCueLoop[deckNumber] = true;
-    MC7000.PADModeFlip[deckNumber] = false;
-    MC7000.PADModeRoll[deckNumber] = false;
-    MC7000.PADModeSavedLoop[deckNumber] = false;
-    MC7000.PADModeSlicer[deckNumber] = false;
-    MC7000.PADModeSlicerLoop[deckNumber] = false;
-    MC7000.PADModeSampler[deckNumber] = false;
-    MC7000.PADModeVelSamp[deckNumber] = false;
-    MC7000.PADModePitch[deckNumber] = false;
+    MC7000.PADModeCue[deckOffset] = false;
+    MC7000.PADModeCueLoop[deckOffset] = true;
+    MC7000.PADModeFlip[deckOffset] = false;
+    MC7000.PADModeRoll[deckOffset] = false;
+    MC7000.PADModeSavedLoop[deckOffset] = false;
+    MC7000.PADModeSlicer[deckOffset] = false;
+    MC7000.PADModeSlicerLoop[deckOffset] = false;
+    MC7000.PADModeSampler[deckOffset] = false;
+    MC7000.PADModeVelSamp[deckOffset] = false;
+    MC7000.PADModePitch[deckOffset] = false;
 
     // switch off PAD illumination
     for (var i = 0; i < 8; i++) {
@@ -302,16 +302,16 @@ MC7000.padModeFlip = function(channel, control, value, status, group) {
     if (value === 0x00) {
         return; // don't respond to note off messages
     }
-    MC7000.PADModeCue[deckNumber] = false;
-    MC7000.PADModeCueLoop[deckNumber] = false;
-    MC7000.PADModeFlip[deckNumber] = true;
-    MC7000.PADModeRoll[deckNumber] = false;
-    MC7000.PADModeSavedLoop[deckNumber] = false;
-    MC7000.PADModeSlicer[deckNumber] = false;
-    MC7000.PADModeSlicerLoop[deckNumber] = false;
-    MC7000.PADModeSampler[deckNumber] = false;
-    MC7000.PADModeVelSamp[deckNumber] = false;
-    MC7000.PADModePitch[deckNumber] = false;
+    MC7000.PADModeCue[deckOffset] = false;
+    MC7000.PADModeCueLoop[deckOffset] = false;
+    MC7000.PADModeFlip[deckOffset] = true;
+    MC7000.PADModeRoll[deckOffset] = false;
+    MC7000.PADModeSavedLoop[deckOffset] = false;
+    MC7000.PADModeSlicer[deckOffset] = false;
+    MC7000.PADModeSlicerLoop[deckOffset] = false;
+    MC7000.PADModeSampler[deckOffset] = false;
+    MC7000.PADModeVelSamp[deckOffset] = false;
+    MC7000.PADModePitch[deckOffset] = false;
 
     // switch off PAD illumination
     for (var i = 0; i < 8; i++) {
@@ -326,16 +326,16 @@ MC7000.padModeRoll = function(channel, control, value, status, group) {
     if (value === 0x00) {
         return; // don't respond to note off messages
     }
-    MC7000.PADModeCue[deckNumber] = false;
-    MC7000.PADModeCueLoop[deckNumber] = false;
-    MC7000.PADModeFlip[deckNumber] = false;
-    MC7000.PADModeRoll[deckNumber] = true;
-    MC7000.PADModeSavedLoop[deckNumber] = false;
-    MC7000.PADModeSlicer[deckNumber] = false;
-    MC7000.PADModeSlicerLoop[deckNumber] = false;
-    MC7000.PADModeSampler[deckNumber] = false;
-    MC7000.PADModeVelSamp[deckNumber] = false;
-    MC7000.PADModePitch[deckNumber] = false;
+    MC7000.PADModeCue[deckOffset] = false;
+    MC7000.PADModeCueLoop[deckOffset] = false;
+    MC7000.PADModeFlip[deckOffset] = false;
+    MC7000.PADModeRoll[deckOffset] = true;
+    MC7000.PADModeSavedLoop[deckOffset] = false;
+    MC7000.PADModeSlicer[deckOffset] = false;
+    MC7000.PADModeSlicerLoop[deckOffset] = false;
+    MC7000.PADModeSampler[deckOffset] = false;
+    MC7000.PADModeVelSamp[deckOffset] = false;
+    MC7000.PADModePitch[deckOffset] = false;
 
     // change PAD color when switching to Roll Mode
     for (var i = 0; i < 8; i++) {
@@ -350,16 +350,16 @@ MC7000.padModeSavedLoop = function(channel, control, value, status, group) {
     if (value === 0x00) {
         return; // don't respond to note off messages
     }
-    MC7000.PADModeCue[deckNumber] = false;
-    MC7000.PADModeCueLoop[deckNumber] = false;
-    MC7000.PADModeFlip[deckNumber] = false;
-    MC7000.PADModeRoll[deckNumber] = false;
-    MC7000.PADModeSavedLoop[deckNumber] = true;
-    MC7000.PADModeSlicer[deckNumber] = false;
-    MC7000.PADModeSlicerLoop[deckNumber] = false;
-    MC7000.PADModeSampler[deckNumber] = false;
-    MC7000.PADModeVelSamp[deckNumber] = false;
-    MC7000.PADModePitch[deckNumber] = false;
+    MC7000.PADModeCue[deckOffset] = false;
+    MC7000.PADModeCueLoop[deckOffset] = false;
+    MC7000.PADModeFlip[deckOffset] = false;
+    MC7000.PADModeRoll[deckOffset] = false;
+    MC7000.PADModeSavedLoop[deckOffset] = true;
+    MC7000.PADModeSlicer[deckOffset] = false;
+    MC7000.PADModeSlicerLoop[deckOffset] = false;
+    MC7000.PADModeSampler[deckOffset] = false;
+    MC7000.PADModeVelSamp[deckOffset] = false;
+    MC7000.PADModePitch[deckOffset] = false;
 
     // change PAD color when switching to Saved Loop Mode
     for (var i = 0; i < 8; i++) {
@@ -375,16 +375,16 @@ MC7000.padModeSlicer = function(channel, control, value, status, group) {
     if (value === 0x00) {
         return; // don't respond to note off messages
     }
-    MC7000.PADModeCue[deckNumber] = false;
-    MC7000.PADModeCueLoop[deckNumber] = false;
-    MC7000.PADModeFlip[deckNumber] = false;
-    MC7000.PADModeRoll[deckNumber] = false;
-    MC7000.PADModeSavedLoop[deckNumber] = false;
-    MC7000.PADModeSlicer[deckNumber] = true;
-    MC7000.PADModeSlicerLoop[deckNumber] = false;
-    MC7000.PADModeSampler[deckNumber] = false;
-    MC7000.PADModeVelSamp[deckNumber] = false;
-    MC7000.PADModePitch[deckNumber] = false;
+    MC7000.PADModeCue[deckOffset] = false;
+    MC7000.PADModeCueLoop[deckOffset] = false;
+    MC7000.PADModeFlip[deckOffset] = false;
+    MC7000.PADModeRoll[deckOffset] = false;
+    MC7000.PADModeSavedLoop[deckOffset] = false;
+    MC7000.PADModeSlicer[deckOffset] = true;
+    MC7000.PADModeSlicerLoop[deckOffset] = false;
+    MC7000.PADModeSampler[deckOffset] = false;
+    MC7000.PADModeVelSamp[deckOffset] = false;
+    MC7000.PADModePitch[deckOffset] = false;
 
     // change PAD color when switching to Slicer Mode
     for (var i = 0; i < 8; i++) {
@@ -399,16 +399,16 @@ MC7000.padModeSlicerLoop = function(channel, control, value, status, group) {
     if (value === 0x00) {
         return; // don't respond to note off messages
     }
-    MC7000.PADModeCue[deckNumber] = false;
-    MC7000.PADModeCueLoop[deckNumber] = false;
-    MC7000.PADModeFlip[deckNumber] = false;
-    MC7000.PADModeRoll[deckNumber] = false;
-    MC7000.PADModeSavedLoop[deckNumber] = false;
-    MC7000.PADModeSlicer[deckNumber] = false;
-    MC7000.PADModeSlicerLoop[deckNumber] = true;
-    MC7000.PADModeSampler[deckNumber] = false;
-    MC7000.PADModeVelSamp[deckNumber] = false;
-    MC7000.PADModePitch[deckNumber] = false;
+    MC7000.PADModeCue[deckOffset] = false;
+    MC7000.PADModeCueLoop[deckOffset] = false;
+    MC7000.PADModeFlip[deckOffset] = false;
+    MC7000.PADModeRoll[deckOffset] = false;
+    MC7000.PADModeSavedLoop[deckOffset] = false;
+    MC7000.PADModeSlicer[deckOffset] = false;
+    MC7000.PADModeSlicerLoop[deckOffset] = true;
+    MC7000.PADModeSampler[deckOffset] = false;
+    MC7000.PADModeVelSamp[deckOffset] = false;
+    MC7000.PADModePitch[deckOffset] = false;
 
     // switch off PAD illumination
     for (var i = 0; i < 8; i++) {
@@ -423,16 +423,16 @@ MC7000.padModeSampler = function(channel, control, value, status, group) {
     if (value === 0x00) {
         return; // don't respond to note off messages
     }
-    MC7000.PADModeCue[deckNumber] = false;
-    MC7000.PADModeCueLoop[deckNumber] = false;
-    MC7000.PADModeFlip[deckNumber] = false;
-    MC7000.PADModeRoll[deckNumber] = false;
-    MC7000.PADModeSavedLoop[deckNumber] = false;
-    MC7000.PADModeSlicer[deckNumber] = false;
-    MC7000.PADModeSlicerLoop[deckNumber] = false;
-    MC7000.PADModeSampler[deckNumber] = true;
-    MC7000.PADModeVelSamp[deckNumber] = false;
-    MC7000.PADModePitch[deckNumber] = false;
+    MC7000.PADModeCue[deckOffset] = false;
+    MC7000.PADModeCueLoop[deckOffset] = false;
+    MC7000.PADModeFlip[deckOffset] = false;
+    MC7000.PADModeRoll[deckOffset] = false;
+    MC7000.PADModeSavedLoop[deckOffset] = false;
+    MC7000.PADModeSlicer[deckOffset] = false;
+    MC7000.PADModeSlicerLoop[deckOffset] = false;
+    MC7000.PADModeSampler[deckOffset] = true;
+    MC7000.PADModeVelSamp[deckOffset] = false;
+    MC7000.PADModePitch[deckOffset] = false;
 
     // change PAD color when switching to Sampler Mode
     for (var i = 1; i <= 8; i++) {
@@ -453,16 +453,16 @@ MC7000.padModeVelSamp = function(channel, control, value, status, group) {
     if (value === 0x00) {
         return; // don't respond to note off messages
     }
-    MC7000.PADModeCue[deckNumber] = false;
-    MC7000.PADModeCueLoop[deckNumber] = false;
-    MC7000.PADModeFlip[deckNumber] = false;
-    MC7000.PADModeRoll[deckNumber] = false;
-    MC7000.PADModeSavedLoop[deckNumber] = false;
-    MC7000.PADModeSlicer[deckNumber] = false;
-    MC7000.PADModeSlicerLoop[deckNumber] = false;
-    MC7000.PADModeSampler[deckNumber] = false;
-    MC7000.PADModeVelSamp[deckNumber] = true;
-    MC7000.PADModePitch[deckNumber] = false;
+    MC7000.PADModeCue[deckOffset] = false;
+    MC7000.PADModeCueLoop[deckOffset] = false;
+    MC7000.PADModeFlip[deckOffset] = false;
+    MC7000.PADModeRoll[deckOffset] = false;
+    MC7000.PADModeSavedLoop[deckOffset] = false;
+    MC7000.PADModeSlicer[deckOffset] = false;
+    MC7000.PADModeSlicerLoop[deckOffset] = false;
+    MC7000.PADModeSampler[deckOffset] = false;
+    MC7000.PADModeVelSamp[deckOffset] = true;
+    MC7000.PADModePitch[deckOffset] = false;
 
     // switch off PAD illumination
     for (var i = 0; i < 8; i++) {
@@ -477,16 +477,16 @@ MC7000.padModePitch = function(channel, control, value, status, group) {
     if (value === 0x00) {
         return; // don't respond to note off messages
     }
-    MC7000.PADModeCue[deckNumber] = false;
-    MC7000.PADModeCueLoop[deckNumber] = false;
-    MC7000.PADModeFlip[deckNumber] = false;
-    MC7000.PADModeRoll[deckNumber] = false;
-    MC7000.PADModeSavedLoop[deckNumber] = false;
-    MC7000.PADModeSlicer[deckNumber] = true;
-    MC7000.PADModeSlicerLoop[deckNumber] = false;
-    MC7000.PADModeSampler[deckNumber] = false;
-    MC7000.PADModeVelSamp[deckNumber] = false;
-    MC7000.PADModePitch[deckNumber] = true;
+    MC7000.PADModeCue[deckOffset] = false;
+    MC7000.PADModeCueLoop[deckOffset] = false;
+    MC7000.PADModeFlip[deckOffset] = false;
+    MC7000.PADModeRoll[deckOffset] = false;
+    MC7000.PADModeSavedLoop[deckOffset] = false;
+    MC7000.PADModeSlicer[deckOffset] = true;
+    MC7000.PADModeSlicerLoop[deckOffset] = false;
+    MC7000.PADModeSampler[deckOffset] = false;
+    MC7000.PADModeVelSamp[deckOffset] = false;
+    MC7000.PADModePitch[deckOffset] = true;
 
     // switch off PAD illumination
     for (var i = 0; i < 8; i++) {
@@ -511,7 +511,7 @@ MC7000.PadButtons = function(channel, control, value, status, group) {
     // - MC7000.PADModePitch
 
     // activate and clear Hot Cues
-    if (MC7000.PADModeCue[deckNumber] && engine.getValue(group, "track_loaded") === 1) {
+    if (MC7000.PADModeCue[deckOffset] && engine.getValue(group, "track_loaded") === 1) {
         for (i = 1; i <= 8; i++) {
             if (control === 0x14 + i - 1 && value === 0x7F) {
                 engine.setValue(group, "hotcue_" + i + "_activate", true);
@@ -528,7 +528,7 @@ MC7000.PadButtons = function(channel, control, value, status, group) {
                 midi.sendShortMsg(0x94 + deckOffset, 0x1C + i - 1, MC7000.padColor.hotcueoff);
             }
         }
-    } else if (MC7000.PADModeRoll[deckNumber]) {
+    } else if (MC7000.PADModeRoll[deckOffset]) {
         // TODO(all): check for actual beatloop_size and apply back after a PAD Roll
         i = control - 0x14;
         if (control === 0x14 + i && value > 0x00) {
@@ -538,7 +538,7 @@ MC7000.PadButtons = function(channel, control, value, status, group) {
             engine.setValue(group, "beatlooproll_activate", false);
             midi.sendShortMsg(0x94 + deckOffset, 0x14 + i, MC7000.padColor.rolloff);
         }
-    } else if (MC7000.PADModeSavedLoop[deckNumber]) {
+    } else if (MC7000.PADModeSavedLoop[deckOffset]) {
         if (value === 0x00) {
             return; // don't respond to note off messages
         }
@@ -548,7 +548,7 @@ MC7000.PadButtons = function(channel, control, value, status, group) {
             var activeLED = engine.getValue(group, "beatloop_" + MC7000.fixedLoop[j] + "_enabled") ? MC7000.padColor.fixedloopon : MC7000.padColor.fixedloopoff;
             midi.sendShortMsg(0x94 + deckOffset, 0x14 + j, activeLED);
         }
-    } else if (MC7000.PADModeSlicer[deckNumber]) {
+    } else if (MC7000.PADModeSlicer[deckOffset]) {
         if (value > 0) {
             i = control - 0x14; // unshifted button
             j = control - 0x1C; // shifted button
@@ -572,7 +572,7 @@ MC7000.PadButtons = function(channel, control, value, status, group) {
         } else {
             midi.sendShortMsg(0x94 + deckOffset, control, MC7000.padColor.sliceron);
         }
-    } else if (MC7000.PADModeSampler[deckNumber]) {
+    } else if (MC7000.PADModeSampler[deckOffset]) {
         for (i = 1; i <= 8; i++) {
             if (control === 0x14 + i - 1 && value >= 0x01) {
                 if (engine.getValue("[Sampler" + i + "]", "track_loaded") === 0) {
@@ -712,19 +712,19 @@ MC7000.wheelTurn = function(channel, control, value, status, group) {
 
 // Needle Search Touch detection
 MC7000.needleSearchTouch = function(channel, control, value, status, group) {
-    var deckNumber = script.deckFromGroup(group);
+    var deckOffset = script.deckFromGroup(group) - 1;
     if (engine.getValue(group, "play")) {
-        MC7000.needleSearchTouched[deckNumber] = MC7000.needleSearchPlay && (!!value);
+        MC7000.needleSearchTouched[deckOffset] = MC7000.needleSearchPlay && (!!value);
     } else {
-        MC7000.needleSearchTouched[deckNumber] = !!value;
+        MC7000.needleSearchTouched[deckOffset] = !!value;
     }
 };
 
 // Needle Search Touch while "SHIFT" button is pressed
 MC7000.needleSearchTouchShift = function(channel, control, value, status,
     group) {
-    var deckNumber = script.deckFromGroup(group);
-    MC7000.needleSearchTouched[deckNumber] = !!value;
+    var deckOffset = script.deckFromGroup(group) - 1;
+    MC7000.needleSearchTouched[deckOffset] = !!value;
 };
 
 // Needle Search Position detection (MSB)
@@ -735,8 +735,8 @@ MC7000.needleSearchMSB = function(channel, control, value) {
 // Needle Search Position detection (MSB + LSB)
 MC7000.needleSearchStripPosition = function(channel, control, value, status,
     group) {
-    var deckNumber = script.deckFromGroup(group);
-    if (MC7000.needleSearchTouched[deckNumber]) {
+    var deckOffset = script.deckFromGroup(group) - 1;
+    if (MC7000.needleSearchTouched[deckOffset]) {
         var fullValue = (MC7000.needleDropMSB << 7) + value; // move MSB 7 binary digits to the left and add LSB
         var position = (fullValue / 0x3FFF); // divide by all possible positions to get relative between 0 - 1
         engine.setParameter(group, "playposition", position);
@@ -839,20 +839,21 @@ MC7000.crossfaderAssign = function(channel, control, value, status, group) {
 
 // Assign Spinback length to STOP TIME knob
 MC7000.stopTime = function(channel, control, value, status, group) {
-    var deckNumber = script.deckFromGroup(group);
+    var deckOffset = script.deckFromGroup(group) - 1;
     // "factor" for engine.brake()
     // this formula produces factors between 31 (min STOP TIME for ca 7 sec back
     // in track) and 1 (max STOP TIME for ca 18.0 sec back in track)
-    MC7000.factor[deckNumber] = (1.1 - (value / 127)) * 30 - 2;
+    MC7000.factor[deckOffset] = (1.1 - (value / 127)) * 30 - 2;
 };
 
 // Use SHIFT + CENSOR button as Spinback with STOP TIME adjusted length
 MC7000.reverse = function(channel, control, value, status, group) {
     var deckNumber = script.deckFromGroup(group);
+    var deckOffset = deckNumber - 1;
     if (value > 0) {
         // while the button is pressed spin back
         // start at a rate of -10 and decrease by "MC7000.factor"
-        engine.brake(deckNumber, true, MC7000.factor[deckNumber], -10);
+        engine.brake(deckNumber, true, MC7000.factor[deckOffset], -10);
     } else {
         if (engine.getValue(group, "slip_enabled")) {
             engine.brake(deckNumber, false); // disable brake effect
@@ -862,7 +863,7 @@ MC7000.reverse = function(channel, control, value, status, group) {
                 engine.setValue(group, "slip_enabled", true);
             }, true);
         } else {
-            engine.softStart(deckNumber, true, MC7000.factor[deckNumber]);
+            engine.softStart(deckNumber, true, MC7000.factor[deckOffset]);
         }
     }
 };
@@ -991,7 +992,7 @@ MC7000.TrackPositionLEDs = function(value, group) {
     if (!MC7000.experimental) {
         return;
     }
-    if (MC7000.PADModeSlicer[deckNumber]) {
+    if (MC7000.PADModeSlicer[deckOffset]) {
         // only send new LED status when beatCountLED really changes
         if (MC7000.prevPadLED[deckOffset] !== beatCountLED) {
             // first set all LEDs to default color incl shifted
@@ -1018,7 +1019,7 @@ MC7000.TrackPositionLEDs = function(value, group) {
 MC7000.HotCueLED = function(value, group) {
     var deckNumber = script.deckFromGroup(group);
     var deckOffset = deckNumber - 1;
-    if (MC7000.PADModeCue[deckNumber]) {
+    if (MC7000.PADModeCue[deckOffset]) {
         for (var i = 1; i <= 8; i++) {
             if (value === 1) {
                 if (engine.getValue(group, "hotcue_"+i+"_enabled") === 1) {


### PR DESCRIPTION
Almost the entire script indexes arrays with `deckNumber` (which ranges from 1 to 4) rather than `deckOffset` (which ranges from 0 to 3). This works since JavaScript implicitly lets the user assign to out-of-bounds indices:

```js
var xs = [0, 1, 2, 3];
xs[4] = 4;
// xs == [0, 1, 2, 3, 4]
```

Since most of the script doesn't care about the initial values, this bug doesn't affect the actual functionality much, since JS is happy to use indices 1-4 instead and ignore the value at index 0.

This behavior is subtle and unintuitive, especially with regards to the default values, therefore this PR fixes the script to use the correct indexing (from 0 to 3).