### PR TITLE
Dispose Track::refreshCoverImageDigest() reading covers from the main thread

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1567,9 +1567,6 @@ TrackPointer TrackDAO::getTrackById(TrackId trackId) const {
         }
     }
 
-    // Validate and refresh cover image hash values if needed.
-    pTrack->refreshCoverImageDigest();
-
     // Listen to signals from Track objects and forward them to
     // receivers. TrackDAO works as a relay for selected track signals
     // that allows receivers to use permanent connections with

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1428,30 +1428,6 @@ void Track::setCoverInfo(const CoverInfoRelative& coverInfo) {
     }
 }
 
-bool Track::refreshCoverImageDigest(
-        const QImage& loadedImage) {
-    auto locked = lockMutex(&m_qMutex);
-    auto coverInfo = CoverInfo(
-            m_record.getCoverInfo(),
-            m_fileAccess.info().location());
-    if (!coverInfo.refreshImageDigest(
-                loadedImage,
-                m_fileAccess.token())) {
-        return false;
-    }
-    if (!compareAndSet(
-                m_record.ptrCoverInfo(),
-                static_cast<const CoverInfoRelative&>(coverInfo))) {
-        return false;
-    }
-    kLogger.info()
-            << "Refreshed cover image digest"
-            << m_fileAccess.info().location();
-    markDirtyAndUnlock(&locked);
-    emit coverArtUpdated();
-    return true;
-}
-
 CoverInfoRelative Track::getCoverInfo() const {
     const auto locked = lockMutex(&m_qMutex);
     return m_record.getCoverInfo();

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -391,12 +391,6 @@ class Track : public QObject {
     void setCoverInfo(const CoverInfoRelative& coverInfo);
     CoverInfoRelative getCoverInfo() const;
     CoverInfo getCoverInfoWithLocation() const;
-    // Verify the cover image hash and update it if necessary.
-    // If the corresponding image has already been loaded it
-    // could be provided as a parameter to avoid reloading
-    // if actually needed.
-    bool refreshCoverImageDigest(
-            const QImage& loadedImage = QImage());
 
     /// Set track metadata after importing from the source.
     ///

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -155,7 +155,7 @@ void WCoverArt::slotCoverFound(
         mixxx::cache_key_t requestedCacheKey,
         bool coverInfoUpdated) {
     Q_UNUSED(requestedCacheKey);
-    Q_UNUSED(coverInfoUpdated);
+    Q_UNUSED(coverInfoUpdated); // CoverArtCache has taken care, updating the Track.
     if (!m_bEnable) {
         return;
     }

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -297,7 +297,7 @@ void WSpinny::slotCoverFound(
         mixxx::cache_key_t requestedCacheKey,
         bool coverInfoUpdated) {
     Q_UNUSED(requestedCacheKey);
-    Q_UNUSED(coverInfoUpdated);
+    Q_UNUSED(coverInfoUpdated); // CoverArtCache has taken care, updating the Track.
     if (pRequestor == this &&
             m_loadedTrack &&
             m_loadedTrack->getLocation() == coverInfo.trackLocation) {


### PR DESCRIPTION
This fixes https://bugs.launchpad.net/mixxx/+bug/1905124

After a cover is read by the CoverArtDelegate via a worker thread, it tries to update the Cover Image Digest via a Track object. During creation of this Track object, the cover is read again this time from the main thread, creating the scrolling issue.

When the cover is read by widgets via an existing Track object, the CoverArtCache will update the Track object in the worker thread. There is also no need for a cover lookup in the main thread when creating the Track. 
