### PR TITLE
Pref > Controller: allow creating a new mapping with 'No Mapping' selected

### DIFF
--- a/src/controllers/controllermanager.cpp
+++ b/src/controllers/controllermanager.cpp
@@ -415,6 +415,7 @@ void ControllerManager::slotApplyMapping(Controller* pController,
         closeController(pController);
         // Unset the controller mapping for this controller
         m_pConfig->remove(key);
+        emit mappingApplied(false);
         return;
     }
 
@@ -432,8 +433,10 @@ void ControllerManager::slotApplyMapping(Controller* pController,
 
     if (bEnabled) {
         openController(pController);
+        emit mappingApplied(pController->isMappable());
     } else {
         closeController(pController);
+        emit mappingApplied(false);
     }
 }
 

--- a/src/controllers/controllermanager.h
+++ b/src/controllers/controllermanager.h
@@ -47,6 +47,7 @@ class ControllerManager : public QObject {
     void requestSetUpDevices();
     void requestShutdown();
     void requestInitialize();
+    void mappingApplied(bool applied);
 
   public slots:
     void updateControllerList();

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -584,8 +584,9 @@ void DlgPrefController::slotMappingSelected(int chosenIndex) {
     }
 
     // Check if the mapping is different from the configured mapping
-    if (m_pControllerManager->getConfiguredMappingFileForDevice(
-                m_pController->getName()) != mappingPath) {
+    if (m_GuiInitialized &&
+            m_pControllerManager->getConfiguredMappingFileForDevice(
+                    m_pController->getName()) != mappingPath) {
         setDirty(true);
     }
 

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -565,6 +565,7 @@ void DlgPrefController::slotMappingSelected(int chosenIndex) {
             if (m_GuiInitialized) {
                 setDirty(true);
             }
+            enableWizardAndIOTabs(false);
         }
     } else { // User picked a mapping
         m_ui.chkEnabledDevice->setEnabled(true);

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -167,6 +167,8 @@ void DlgPrefController::showLearningWizard() {
     if (!m_pMapping) {
         m_pMapping = std::shared_ptr<LegacyControllerMapping>(new LegacyMidiControllerMapping());
         emit applyMapping(m_pController, m_pMapping, true);
+        // shortcut for creating and assigning required I/O table models
+        slotShowMapping(m_pMapping);
     }
 
     // Note that DlgControllerLearning is set to delete itself on close using

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -541,7 +541,10 @@ QUrl DlgPrefController::helpUrl() const {
 }
 
 void DlgPrefController::enableWizardAndIOTabs(bool enable) {
-    m_ui.btnLearningWizard->setEnabled(enable);
+    // We always enable the Wizard button if this is a MIDI controller so we can
+    // create a new mapping from scratch with 'No Mapping'
+    const auto* midiController = qobject_cast<MidiController*>(m_pController);
+    m_ui.btnLearningWizard->setEnabled(midiController != nullptr);
     m_ui.inputMappingsTab->setEnabled(enable);
     m_ui.outputMappingsTab->setEnabled(enable);
 }

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -97,6 +97,11 @@ DlgPrefController::DlgPrefController(
             &DlgPrefController::applyMapping,
             m_pControllerManager.get(),
             &ControllerManager::slotApplyMapping);
+    // Update GUI
+    connect(m_pControllerManager.get(),
+            &ControllerManager::mappingApplied,
+            this,
+            &DlgPrefController::enableWizardAndIOTabs);
 
     // Open script file links
     connect(m_ui.labelLoadedMappingScriptFileLinks,
@@ -471,10 +476,8 @@ void DlgPrefController::slotUpdate() {
 
     // If the controller is not mappable, disable the input and output mapping
     // sections and the learning wizard button.
-    bool isMappable = m_pController->isMappable();
-    m_ui.btnLearningWizard->setEnabled(isMappable);
-    m_ui.inputMappingsTab->setEnabled(isMappable);
-    m_ui.outputMappingsTab->setEnabled(isMappable);
+    enableWizardAndIOTabs(m_pController->isMappable() && m_pController->isOpen());
+
     // When slotUpdate() is run for the first time, this bool keeps slotPresetSelected()
     // from setting a false-postive 'dirty' flag when updating the fresh GUI.
     m_GuiInitialized = true;
@@ -535,6 +538,12 @@ void DlgPrefController::slotApply() {
 
 QUrl DlgPrefController::helpUrl() const {
     return QUrl(MIXXX_MANUAL_CONTROLLERS_URL);
+}
+
+void DlgPrefController::enableWizardAndIOTabs(bool enable) {
+    m_ui.btnLearningWizard->setEnabled(enable);
+    m_ui.inputMappingsTab->setEnabled(enable);
+    m_ui.outputMappingsTab->setEnabled(enable);
 }
 
 QString DlgPrefController::mappingPathFromIndex(int index) const {

--- a/src/controllers/dlgprefcontroller.h
+++ b/src/controllers/dlgprefcontroller.h
@@ -53,6 +53,7 @@ class DlgPrefController : public DlgPreferencePage {
     void slotShowMapping(std::shared_ptr<LegacyControllerMapping> mapping);
     /// Called when the Controller Learning Wizard is closed.
     void slotStopLearning();
+    void enableWizardAndIOTabs(bool enable);
 
     // Input mappings
     void addInputMapping();

--- a/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
@@ -167,11 +167,17 @@ bool ControllerScriptEngineLegacy::initialize() {
 }
 
 void ControllerScriptEngineLegacy::shutdown() {
-    callFunctionOnObjects(m_scriptFunctionPrefixes, "shutdown");
+    // There is no js engine if the mapping was not loaded from a file but by
+    // creating a new, empty mapping LegacyMidiControllerMapping with the wizard
+    if (m_pJSEngine) {
+        callFunctionOnObjects(m_scriptFunctionPrefixes, "shutdown");
+    }
     m_scriptWrappedFunctionCache.clear();
     m_incomingDataFunctions.clear();
     m_scriptFunctionPrefixes.clear();
-    ControllerScriptEngineBase::shutdown();
+    if (m_pJSEngine) {
+        ControllerScriptEngineBase::shutdown();
+    }
 }
 
 bool ControllerScriptEngineLegacy::handleIncomingData(const QByteArray& data) {


### PR DESCRIPTION
* 'Learning Wizard' button and in/output tabs are now enabled/disabled after applying a mapping (previously this was only in `slotUpdate()` when re-opening the preferences)
* this also allows starting the Wizard with 'No Mapping' selected
* fix creating a new mapping with the wizard by creating the I/O table models & assigning them to the new, empty mapping
* fix false-positive `isDirty` when starting the Wizard with 'No Mapping' selected after opening the peferences
