### PR TITLE
LateNight: add buffer underflow indicator

### DIFF
--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -182,9 +182,12 @@ WSearchLineEdit,
 #VuMeterBox,
 #VuMeterBoxMaster,
 #VuMeterBoxMasterSingle,
-#LatencyMeterBox {
+#LatencyMeterBox[highlight="0"] {
   background-color: #040404;
-}
+  }
+  #LatencyMeterBox[highlight="1"] {
+    background-color: red;
+  }
 
 #VuMasterCover {
   background-color: rgba(21, 21, 21, 150);

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -227,9 +227,12 @@ WSearchLineEdit {
 #VuMeterBox,
 #VuMeterBoxMaster,
 #VuMeterBoxMasterSingle,
-#LatencyMeterBox {
+#LatencyMeterBox[highlight="0"] {
   background-color: #040404;
-}
+  }
+  #LatencyMeterBox[highlight="1"] {
+    background-color: yellow;
+  }
 
 #WaveformsContainer {
   border-bottom: 1px solid #0c0c0c;

--- a/res/skins/LateNight/toolbar.xml
+++ b/res/skins/LateNight/toolbar.xml
@@ -182,6 +182,10 @@
                     </Connection>
                   </VuMeter>
                 </Children>
+                <Connection>
+                  <ConfigKey>[Master],audio_latency_overload</ConfigKey>
+                  <BindProperty>highlight</BindProperty>
+                </Connection>
               </WidgetGroup><!-- LatencyMeterBox -->
               <Label>
                 <ObjectName>LatencyLabel</ObjectName>


### PR DESCRIPTION
added underneath the latency meter:
![image](https://user-images.githubusercontent.com/5934199/185761502-07e5594a-7247-4f16-ac05-e100e08ca5e9.png)
![image](https://user-images.githubusercontent.com/5934199/185788830-2d2836a8-5778-4686-bbc8-9b2adf1182a2.png)

