### PR TITLE
soundio: rename SoundDeviceError > SoundDeviceStatus

### DIFF
--- a/src/coreservices.h
+++ b/src/coreservices.h
@@ -6,7 +6,7 @@
 #include "preferences/configobject.h"
 #include "preferences/constants.h"
 #include "preferences/settingsmanager.h"
-#include "soundio/sounddeviceerror.h"
+#include "soundio/sounddevicestatus.h"
 #include "util/cmdlineargs.h"
 #include "util/timer.h"
 

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -254,12 +254,12 @@ void MixxxMainWindow::initialize() {
     do {
         retryClicked = false;
         SoundDeviceStatus result = m_pCoreServices->getSoundManager()->setupDevices();
-        if (result == SOUNDDEVICE_ERROR_DEVICE_COUNT ||
-                result == SOUNDDEVICE_ERROR_EXCESSIVE_OUTPUT_CHANNEL) {
+        if (result == SoundDeviceStatus::ErrorDeviceCount ||
+                result == SoundDeviceStatus::ErrorExcessiveOutputChannel) {
             if (soundDeviceBusyDlg(&retryClicked) != QDialog::Accepted) {
                 exit(0);
             }
-        } else if (result != SOUNDDEVICE_OK) {
+        } else if (result != SoundDeviceStatus::Ok) {
             if (soundDeviceErrorMsgDlg(result, &retryClicked) !=
                     QDialog::Accepted) {
                 exit(0);

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -253,13 +253,13 @@ void MixxxMainWindow::initialize() {
     bool retryClicked;
     do {
         retryClicked = false;
-        SoundDeviceError result = m_pCoreServices->getSoundManager()->setupDevices();
+        SoundDeviceStatus result = m_pCoreServices->getSoundManager()->setupDevices();
         if (result == SOUNDDEVICE_ERROR_DEVICE_COUNT ||
                 result == SOUNDDEVICE_ERROR_EXCESSIVE_OUTPUT_CHANNEL) {
             if (soundDeviceBusyDlg(&retryClicked) != QDialog::Accepted) {
                 exit(0);
             }
-        } else if (result != SOUNDDEVICE_ERROR_OK) {
+        } else if (result != SOUNDDEVICE_OK) {
             if (soundDeviceErrorMsgDlg(result, &retryClicked) !=
                     QDialog::Accepted) {
                 exit(0);
@@ -509,16 +509,15 @@ QDialog::DialogCode MixxxMainWindow::soundDeviceBusyDlg(bool* retryClicked) {
     return soundDeviceErrorDlg(title, text, retryClicked);
 }
 
-
 QDialog::DialogCode MixxxMainWindow::soundDeviceErrorMsgDlg(
-        SoundDeviceError err, bool* retryClicked) {
+        SoundDeviceStatus status, bool* retryClicked) {
     QString title(tr("Sound Device Error"));
     QString text("<html> <p>" %
                     tr("Mixxx was unable to open all the configured sound "
                        "devices.") +
             "</p> <p>" %
                     m_pCoreServices->getSoundManager()
-                            ->getLastErrorMessage(err)
+                            ->getLastErrorMessage(status)
                             .replace("\n", "<br/>") %
                     "</p><ul>"
                     "<li>" %

--- a/src/mixxxmainwindow.h
+++ b/src/mixxxmainwindow.h
@@ -7,7 +7,7 @@
 #include "coreservices.h"
 #include "preferences/configobject.h"
 #include "preferences/constants.h"
-#include "soundio/sounddeviceerror.h"
+#include "soundio/sounddevicestatus.h"
 #include "track/track_decl.h"
 #include "util/parented_ptr.h"
 
@@ -104,7 +104,7 @@ class MixxxMainWindow : public QMainWindow {
             const QString &title, const QString &text, bool* retryClicked);
     QDialog::DialogCode soundDeviceBusyDlg(bool* retryClicked);
     QDialog::DialogCode soundDeviceErrorMsgDlg(
-            SoundDeviceError err, bool* retryClicked);
+            SoundDeviceStatus status, bool* retryClicked);
     QDialog::DialogCode noOutputDlg(bool* continueClicked);
 
     std::shared_ptr<mixxx::CoreServices> m_pCoreServices;

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -309,17 +309,17 @@ void DlgPrefSound::slotApply() {
     m_config.clearOutputs();
     emit writePaths(&m_config);
 
-    SoundDeviceError err = SOUNDDEVICE_ERROR_OK;
+    SoundDeviceStatus status = SOUNDDEVICE_OK;
     {
         ScopedWaitCursor cursor;
         m_pKeylockEngine->set(keylockComboBox->currentData().toDouble());
         m_pSettings->set(ConfigKey("[Master]", "keylock_engine"),
                 ConfigValue(keylockComboBox->currentData().toInt()));
 
-        err = m_pSoundManager->setConfig(m_config);
+        status = m_pSoundManager->setConfig(m_config);
     }
-    if (err != SOUNDDEVICE_ERROR_OK) {
-        QString error = m_pSoundManager->getLastErrorMessage(err);
+    if (status != SOUNDDEVICE_OK) {
+        QString error = m_pSoundManager->getLastErrorMessage(status);
         QMessageBox::warning(nullptr, tr("Configuration error"), error);
     } else {
         m_settingsModified = false;

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -309,7 +309,7 @@ void DlgPrefSound::slotApply() {
     m_config.clearOutputs();
     emit writePaths(&m_config);
 
-    SoundDeviceStatus status = SOUNDDEVICE_OK;
+    SoundDeviceStatus status = SoundDeviceStatus::Ok;
     {
         ScopedWaitCursor cursor;
         m_pKeylockEngine->set(keylockComboBox->currentData().toDouble());
@@ -318,7 +318,7 @@ void DlgPrefSound::slotApply() {
 
         status = m_pSoundManager->setConfig(m_config);
     }
-    if (status != SOUNDDEVICE_OK) {
+    if (status != SoundDeviceStatus::Ok) {
         QString error = m_pSoundManager->getLastErrorMessage(status);
         QMessageBox::warning(nullptr, tr("Configuration error"), error);
     } else {

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -7,7 +7,7 @@
 #include "preferences/dialog/ui_dlgprefsounddlg.h"
 #include "preferences/usersettings.h"
 #include "soundio/sounddevice.h"
-#include "soundio/sounddeviceerror.h"
+#include "soundio/sounddevicestatus.h"
 #include "soundio/soundmanagerconfig.h"
 
 class SoundManager;

--- a/src/qml/qmlapplication.cpp
+++ b/src/qml/qmlapplication.cpp
@@ -47,9 +47,10 @@ QmlApplication::QmlApplication(
           m_fileWatcher({m_mainFilePath}) {
     m_pCoreServices->initialize(app);
     SoundDeviceStatus result = m_pCoreServices->getSoundManager()->setupDevices();
-    if (result != SOUNDDEVICE_OK) {
-        qCritical() << "Error setting up sound devices" << result;
-        exit(result);
+    if (result != SoundDeviceStatus::Ok) {
+        const int reInt = static_cast<int>(result);
+        qCritical() << "Error setting up sound devices:" << reInt;
+        exit(reInt);
     }
 
     // FIXME: DlgPreferences has some initialization logic that must be executed

--- a/src/qml/qmlapplication.cpp
+++ b/src/qml/qmlapplication.cpp
@@ -46,8 +46,8 @@ QmlApplication::QmlApplication(
           m_pAppEngine(nullptr),
           m_fileWatcher({m_mainFilePath}) {
     m_pCoreServices->initialize(app);
-    SoundDeviceError result = m_pCoreServices->getSoundManager()->setupDevices();
-    if (result != SOUNDDEVICE_ERROR_OK) {
+    SoundDeviceStatus result = m_pCoreServices->getSoundManager()->setupDevices();
+    if (result != SOUNDDEVICE_OK) {
         qCritical() << "Error setting up sound devices" << result;
         exit(result);
     }

--- a/src/soundio/sounddevice.cpp
+++ b/src/soundio/sounddevice.cpp
@@ -51,15 +51,15 @@ SoundDeviceStatus SoundDevice::addOutput(const AudioOutputBuffer& out) {
     // Check if the output channels are already used
     foreach (AudioOutputBuffer myOut, m_audioOutputs) {
         if (out.channelsClash(myOut)) {
-            return SOUNDDEVICE_ERROR_DUPLICATE_OUTPUT_CHANNEL;
+            return SoundDeviceStatus::ErrorDuplicateOutputChannel;
         }
     }
     if (out.getChannelGroup().getChannelBase()
             + out.getChannelGroup().getChannelCount() > getNumOutputChannels()) {
-        return SOUNDDEVICE_ERROR_EXCESSIVE_OUTPUT_CHANNEL;
+        return SoundDeviceStatus::ErrorExcessiveOutputChannel;
     }
     m_audioOutputs.append(out);
-    return SOUNDDEVICE_OK;
+    return SoundDeviceStatus::Ok;
 }
 
 void SoundDevice::clearOutputs() {
@@ -72,10 +72,10 @@ SoundDeviceStatus SoundDevice::addInput(const AudioInputBuffer& in) {
     // -- bkgood 20101108
     if (in.getChannelGroup().getChannelBase()
             + in.getChannelGroup().getChannelCount() > getNumInputChannels()) {
-        return SOUNDDEVICE_ERROR_EXCESSIVE_INPUT_CHANNEL;
+        return SoundDeviceStatus::ErrorExcessiveInputChannel;
     }
     m_audioInputs.append(in);
-    return SOUNDDEVICE_OK;
+    return SoundDeviceStatus::Ok;
 }
 
 void SoundDevice::clearInputs() {

--- a/src/soundio/sounddevice.cpp
+++ b/src/soundio/sounddevice.cpp
@@ -47,7 +47,7 @@ void SoundDevice::setFramesPerBuffer(unsigned int framesPerBuffer) {
     m_framesPerBuffer = framesPerBuffer;
 }
 
-SoundDeviceError SoundDevice::addOutput(const AudioOutputBuffer &out) {
+SoundDeviceStatus SoundDevice::addOutput(const AudioOutputBuffer& out) {
     // Check if the output channels are already used
     foreach (AudioOutputBuffer myOut, m_audioOutputs) {
         if (out.channelsClash(myOut)) {
@@ -59,14 +59,14 @@ SoundDeviceError SoundDevice::addOutput(const AudioOutputBuffer &out) {
         return SOUNDDEVICE_ERROR_EXCESSIVE_OUTPUT_CHANNEL;
     }
     m_audioOutputs.append(out);
-    return SOUNDDEVICE_ERROR_OK;
+    return SOUNDDEVICE_OK;
 }
 
 void SoundDevice::clearOutputs() {
     m_audioOutputs.clear();
 }
 
-SoundDeviceError SoundDevice::addInput(const AudioInputBuffer &in) {
+SoundDeviceStatus SoundDevice::addInput(const AudioInputBuffer& in) {
     // DON'T check if the input channels are already used, there's no reason
     // we can't send the same inputted samples to different places in mixxx.
     // -- bkgood 20101108
@@ -75,7 +75,7 @@ SoundDeviceError SoundDevice::addInput(const AudioInputBuffer &in) {
         return SOUNDDEVICE_ERROR_EXCESSIVE_INPUT_CHANNEL;
     }
     m_audioInputs.append(in);
-    return SOUNDDEVICE_ERROR_OK;
+    return SOUNDDEVICE_OK;
 }
 
 void SoundDevice::clearInputs() {

--- a/src/soundio/sounddevice.h
+++ b/src/soundio/sounddevice.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <QString>
 #include <QList>
+#include <QString>
 
-#include "util/types.h"
 #include "preferences/usersettings.h"
-#include "soundio/sounddeviceerror.h"
+#include "soundio/sounddevicestatus.h"
 #include "soundio/soundmanagerutil.h"
+#include "util/types.h"
 
 class SoundDevice;
 class SoundManager;
@@ -33,17 +33,17 @@ class SoundDevice {
     }
     void setSampleRate(double sampleRate);
     void setFramesPerBuffer(unsigned int framesPerBuffer);
-    virtual SoundDeviceError open(bool isClkRefDevice, int syncBuffers) = 0;
+    virtual SoundDeviceStatus open(bool isClkRefDevice, int syncBuffers) = 0;
     virtual bool isOpen() const = 0;
-    virtual SoundDeviceError close() = 0;
+    virtual SoundDeviceStatus close() = 0;
     virtual void readProcess() = 0;
     virtual void writeProcess() = 0;
     virtual QString getError() const = 0;
     virtual unsigned int getDefaultSampleRate() const = 0;
     int getNumOutputChannels() const;
     int getNumInputChannels() const;
-    SoundDeviceError addOutput(const AudioOutputBuffer& out);
-    SoundDeviceError addInput(const AudioInputBuffer& in);
+    SoundDeviceStatus addOutput(const AudioOutputBuffer& out);
+    SoundDeviceStatus addInput(const AudioInputBuffer& in);
     const QList<AudioInputBuffer>& inputs() const {
         return m_audioInputs;
     }

--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -101,7 +101,7 @@ SoundDeviceStatus SoundDeviceNetwork::open(bool isClkRefDevice, int syncBuffers)
         m_pThread->start(QThread::TimeCriticalPriority);
     }
 
-    return SOUNDDEVICE_OK;
+    return SoundDeviceStatus::Ok;
 }
 
 bool SoundDeviceNetwork::isOpen() const {
@@ -120,7 +120,7 @@ SoundDeviceStatus SoundDeviceNetwork::close() {
     m_outputFifo.reset();
     m_inputFifo.reset();
 
-    return SOUNDDEVICE_OK;
+    return SoundDeviceStatus::Ok;
 }
 
 QString SoundDeviceNetwork::getError() const {

--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -52,7 +52,7 @@ SoundDeviceNetwork::SoundDeviceNetwork(UserSettingsPointer config,
 SoundDeviceNetwork::~SoundDeviceNetwork() {
 }
 
-SoundDeviceError SoundDeviceNetwork::open(bool isClkRefDevice, int syncBuffers) {
+SoundDeviceStatus SoundDeviceNetwork::open(bool isClkRefDevice, int syncBuffers) {
     Q_UNUSED(syncBuffers);
     kLogger.debug() << "open:" << m_deviceId.name;
 
@@ -101,14 +101,14 @@ SoundDeviceError SoundDeviceNetwork::open(bool isClkRefDevice, int syncBuffers) 
         m_pThread->start(QThread::TimeCriticalPriority);
     }
 
-    return SOUNDDEVICE_ERROR_OK;
+    return SOUNDDEVICE_OK;
 }
 
 bool SoundDeviceNetwork::isOpen() const {
     return (m_inputFifo != nullptr || m_outputFifo != nullptr);
 }
 
-SoundDeviceError SoundDeviceNetwork::close() {
+SoundDeviceStatus SoundDeviceNetwork::close() {
     //kLogger.debug() << "close:" << getInternalName();
     m_pNetworkStream->stopStream();
     if (m_pThread) {
@@ -120,7 +120,7 @@ SoundDeviceError SoundDeviceNetwork::close() {
     m_outputFifo.reset();
     m_inputFifo.reset();
 
-    return SOUNDDEVICE_ERROR_OK;
+    return SOUNDDEVICE_OK;
 }
 
 QString SoundDeviceNetwork::getError() const {

--- a/src/soundio/sounddevicenetwork.h
+++ b/src/soundio/sounddevicenetwork.h
@@ -30,9 +30,9 @@ class SoundDeviceNetwork : public SoundDevice {
                        QSharedPointer<EngineNetworkStream> pNetworkStream);
     ~SoundDeviceNetwork() override;
 
-    SoundDeviceError open(bool isClkRefDevice, int syncBuffers) override;
+    SoundDeviceStatus open(bool isClkRefDevice, int syncBuffers) override;
     bool isOpen() const override;
-    SoundDeviceError close() override;
+    SoundDeviceStatus close() override;
     void readProcess() override;
     void writeProcess() override;
     QString getError() const override;

--- a/src/soundio/sounddevicenotfound.h
+++ b/src/soundio/sounddevicenotfound.h
@@ -20,14 +20,14 @@ class SoundDeviceNotFound : public SoundDevice {
         m_strDisplayName = name;
     }
 
-    SoundDeviceError open(bool isClkRefDevice, int syncBuffers) override {
+    SoundDeviceStatus open(bool isClkRefDevice, int syncBuffers) override {
         Q_UNUSED(isClkRefDevice);
         Q_UNUSED(syncBuffers);
-        return SOUNDDEVICE_ERROR_ERR;
+        return SOUNDDEVICE_ERROR;
     };
     bool isOpen() const  override { return false; };
-    SoundDeviceError close() override {
-        return SOUNDDEVICE_ERROR_ERR;
+    SoundDeviceStatus close() override {
+        return SOUNDDEVICE_ERROR;
     };
     void readProcess() override { };
     void writeProcess() override { };

--- a/src/soundio/sounddevicenotfound.h
+++ b/src/soundio/sounddevicenotfound.h
@@ -23,11 +23,11 @@ class SoundDeviceNotFound : public SoundDevice {
     SoundDeviceStatus open(bool isClkRefDevice, int syncBuffers) override {
         Q_UNUSED(isClkRefDevice);
         Q_UNUSED(syncBuffers);
-        return SOUNDDEVICE_ERROR;
+        return SoundDeviceStatus::Error;
     };
     bool isOpen() const  override { return false; };
     SoundDeviceStatus close() override {
-        return SOUNDDEVICE_ERROR;
+        return SoundDeviceStatus::Error;
     };
     void readProcess() override { };
     void writeProcess() override { };

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -142,7 +142,7 @@ SoundDeviceStatus SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffer
         m_lastError = QStringLiteral(
                 "No inputs or outputs in SDPA::open() "
                 "(THIS IS A BUG, this should be filtered by SM::setupDevices)");
-        return SOUNDDEVICE_ERROR;
+        return SoundDeviceStatus::Error;
     }
 
     memset(&m_outputParams, 0, sizeof(m_outputParams));
@@ -325,7 +325,7 @@ SoundDeviceStatus SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffer
     if (err != paNoError) {
         qWarning() << "Error opening stream:" << Pa_GetErrorText(err);
         m_lastError = QString::fromUtf8(Pa_GetErrorText(err));
-        return SOUNDDEVICE_ERROR;
+        return SoundDeviceStatus::Error;
     } else {
         qDebug() << "Opened PortAudio stream successfully... starting";
     }
@@ -347,7 +347,7 @@ SoundDeviceStatus SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffer
             qWarning() << "PortAudio: Close stream error:"
                        << Pa_GetErrorText(err) << m_deviceId;
         }
-        return SOUNDDEVICE_ERROR;
+        return SoundDeviceStatus::Error;
     } else {
         qDebug() << "PortAudio: Started stream successfully";
     }
@@ -369,7 +369,7 @@ SoundDeviceStatus SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffer
         m_clkRefTimer.start();
     }
     m_pStream = pStream;
-    return SOUNDDEVICE_OK;
+    return SoundDeviceStatus::Ok;
 }
 
 bool SoundDevicePortAudio::isOpen() const {
@@ -386,13 +386,13 @@ SoundDeviceStatus SoundDevicePortAudio::close() {
         // 1 means the stream is stopped. 0 means active.
         if (err == 1) {
             //qDebug() << "PortAudio: Stream already stopped, but no error.";
-            return SOUNDDEVICE_OK;
+            return SoundDeviceStatus::Ok;
         }
         // Real PaErrors are always negative.
         if (err < 0) {
             qWarning() << "PortAudio: Stream already stopped:"
                        << Pa_GetErrorText(err) << m_deviceId;
-            return SOUNDDEVICE_ERROR;
+            return SoundDeviceStatus::Error;
         }
 
         //Stop the stream.
@@ -408,7 +408,7 @@ SoundDeviceStatus SoundDevicePortAudio::close() {
         if (err != paNoError) {
             qWarning() << "PortAudio: Stop stream error:"
                        << Pa_GetErrorText(err) << m_deviceId;
-            return SOUNDDEVICE_ERROR;
+            return SoundDeviceStatus::Error;
         }
 
         // Close stream
@@ -416,7 +416,7 @@ SoundDeviceStatus SoundDevicePortAudio::close() {
         if (err != paNoError) {
             qWarning() << "PortAudio: Close stream error:"
                        << Pa_GetErrorText(err) << m_deviceId;
-            return SOUNDDEVICE_ERROR;
+            return SoundDeviceStatus::Error;
         }
 
         if (m_outputFifo) {
@@ -431,7 +431,7 @@ SoundDeviceStatus SoundDevicePortAudio::close() {
     m_inputFifo = nullptr;
     m_bSetThreadPriority = false;
 
-    return SOUNDDEVICE_OK;
+    return SoundDeviceStatus::Ok;
 }
 
 QString SoundDevicePortAudio::getError() const {

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -134,7 +134,7 @@ SoundDevicePortAudio::SoundDevicePortAudio(UserSettingsPointer config,
 SoundDevicePortAudio::~SoundDevicePortAudio() {
 }
 
-SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers) {
+SoundDeviceStatus SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers) {
     qDebug() << "SoundDevicePortAudio::open()" << m_deviceId;
     PaError err;
 
@@ -142,7 +142,7 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
         m_lastError = QStringLiteral(
                 "No inputs or outputs in SDPA::open() "
                 "(THIS IS A BUG, this should be filtered by SM::setupDevices)");
-        return SOUNDDEVICE_ERROR_ERR;
+        return SOUNDDEVICE_ERROR;
     }
 
     memset(&m_outputParams, 0, sizeof(m_outputParams));
@@ -325,7 +325,7 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
     if (err != paNoError) {
         qWarning() << "Error opening stream:" << Pa_GetErrorText(err);
         m_lastError = QString::fromUtf8(Pa_GetErrorText(err));
-        return SOUNDDEVICE_ERROR_ERR;
+        return SOUNDDEVICE_ERROR;
     } else {
         qDebug() << "Opened PortAudio stream successfully... starting";
     }
@@ -347,7 +347,7 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
             qWarning() << "PortAudio: Close stream error:"
                        << Pa_GetErrorText(err) << m_deviceId;
         }
-        return SOUNDDEVICE_ERROR_ERR;
+        return SOUNDDEVICE_ERROR;
     } else {
         qDebug() << "PortAudio: Started stream successfully";
     }
@@ -369,14 +369,14 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
         m_clkRefTimer.start();
     }
     m_pStream = pStream;
-    return SOUNDDEVICE_ERROR_OK;
+    return SOUNDDEVICE_OK;
 }
 
 bool SoundDevicePortAudio::isOpen() const {
     return m_pStream != nullptr;
 }
 
-SoundDeviceError SoundDevicePortAudio::close() {
+SoundDeviceStatus SoundDevicePortAudio::close() {
     //qDebug() << "SoundDevicePortAudio::close()" << m_deviceId;
     PaStream* pStream = m_pStream;
     m_pStream = nullptr;
@@ -386,13 +386,13 @@ SoundDeviceError SoundDevicePortAudio::close() {
         // 1 means the stream is stopped. 0 means active.
         if (err == 1) {
             //qDebug() << "PortAudio: Stream already stopped, but no error.";
-            return SOUNDDEVICE_ERROR_OK;
+            return SOUNDDEVICE_OK;
         }
         // Real PaErrors are always negative.
         if (err < 0) {
             qWarning() << "PortAudio: Stream already stopped:"
                        << Pa_GetErrorText(err) << m_deviceId;
-            return SOUNDDEVICE_ERROR_ERR;
+            return SOUNDDEVICE_ERROR;
         }
 
         //Stop the stream.
@@ -408,7 +408,7 @@ SoundDeviceError SoundDevicePortAudio::close() {
         if (err != paNoError) {
             qWarning() << "PortAudio: Stop stream error:"
                        << Pa_GetErrorText(err) << m_deviceId;
-            return SOUNDDEVICE_ERROR_ERR;
+            return SOUNDDEVICE_ERROR;
         }
 
         // Close stream
@@ -416,7 +416,7 @@ SoundDeviceError SoundDevicePortAudio::close() {
         if (err != paNoError) {
             qWarning() << "PortAudio: Close stream error:"
                        << Pa_GetErrorText(err) << m_deviceId;
-            return SOUNDDEVICE_ERROR_ERR;
+            return SOUNDDEVICE_ERROR;
         }
 
         if (m_outputFifo) {
@@ -431,7 +431,7 @@ SoundDeviceError SoundDevicePortAudio::close() {
     m_inputFifo = nullptr;
     m_bSetThreadPriority = false;
 
-    return SOUNDDEVICE_ERROR_OK;
+    return SOUNDDEVICE_OK;
 }
 
 QString SoundDevicePortAudio::getError() const {

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -21,9 +21,9 @@ class SoundDevicePortAudio : public SoundDevice {
             unsigned int devIndex);
     ~SoundDevicePortAudio() override;
 
-    SoundDeviceError open(bool isClkRefDevice, int syncBuffers) override;
+    SoundDeviceStatus open(bool isClkRefDevice, int syncBuffers) override;
     bool isOpen() const override;
-    SoundDeviceError close() override;
+    SoundDeviceStatus close() override;
     void readProcess() override;
     void writeProcess() override;
     QString getError() const override;

--- a/src/soundio/sounddevicestatus.h
+++ b/src/soundio/sounddevicestatus.h
@@ -1,9 +1,9 @@
 #pragma once
 
 // Used for returning errors from sounddevice functions.
-enum SoundDeviceError {
-    SOUNDDEVICE_ERROR_ERR = -1,
-    SOUNDDEVICE_ERROR_OK = 0,
+enum SoundDeviceStatus {
+    SOUNDDEVICE_ERROR = -1,
+    SOUNDDEVICE_OK = 0,
     SOUNDDEVICE_ERROR_DUPLICATE_OUTPUT_CHANNEL,
     SOUNDDEVICE_ERROR_EXCESSIVE_OUTPUT_CHANNEL,
     SOUNDDEVICE_ERROR_EXCESSIVE_INPUT_CHANNEL,

--- a/src/soundio/sounddevicestatus.h
+++ b/src/soundio/sounddevicestatus.h
@@ -1,11 +1,11 @@
 #pragma once
 
 // Used for returning errors from sounddevice functions.
-enum SoundDeviceStatus {
-    SOUNDDEVICE_ERROR = -1,
-    SOUNDDEVICE_OK = 0,
-    SOUNDDEVICE_ERROR_DUPLICATE_OUTPUT_CHANNEL,
-    SOUNDDEVICE_ERROR_EXCESSIVE_OUTPUT_CHANNEL,
-    SOUNDDEVICE_ERROR_EXCESSIVE_INPUT_CHANNEL,
-    SOUNDDEVICE_ERROR_DEVICE_COUNT
+enum class SoundDeviceStatus {
+    Error = -1,
+    Ok = 0,
+    ErrorDuplicateOutputChannel,
+    ErrorExcessiveOutputChannel,
+    ErrorExcessiveInputChannel,
+    ErrorDeviceCount
 };

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -322,7 +322,7 @@ SoundDeviceStatus SoundManager::setupDevices() {
 
     qDebug() << "SoundManager::setupDevices()";
     m_pControlObjectSoundStatusCO->set(SOUNDMANAGER_CONNECTING);
-    SoundDeviceStatus status = SOUNDDEVICE_OK;
+    SoundDeviceStatus status = SoundDeviceStatus::Ok;
     // NOTE(rryan): Do not clear m_pClkRefDevice here. If we didn't touch the
     // SoundDevice that is the clock reference, then it is safe to leave it as
     // it was. Clearing it causes the engine to stop being processed which
@@ -372,7 +372,7 @@ SoundDeviceStatus SoundManager::setupDevices() {
             // buffer value from SMConfig
             AudioInputBuffer aib(in, SampleUtil::alloc(MAX_BUFFER_LEN));
             status = pDevice->addInput(aib);
-            if (status != SOUNDDEVICE_OK) {
+            if (status != SoundDeviceStatus::Ok) {
                 SampleUtil::free(aib.getBuffer());
                 goto closeAndError;
             }
@@ -415,7 +415,7 @@ SoundDeviceStatus SoundManager::setupDevices() {
 
             AudioOutputBuffer aob(out, pBuffer);
             status = pDevice->addOutput(aob);
-            if (status != SOUNDDEVICE_OK) {
+            if (status != SoundDeviceStatus::Ok) {
                 goto closeAndError;
             }
 
@@ -465,7 +465,7 @@ SoundDeviceStatus SoundManager::setupDevices() {
             syncBuffers = 2;
         }
         status = pDevice->open(pNewMasterClockRef == pDevice, syncBuffers);
-        if (status != SOUNDDEVICE_OK) {
+        if (status != SoundDeviceStatus::Ok) {
             goto closeAndError;
         }
         devicesNotFound.remove(pDevice->getDeviceId());
@@ -497,11 +497,11 @@ SoundDeviceStatus SoundManager::setupDevices() {
     // returns OK if we were able to open all the devices the user wanted
     if (devicesNotFound.isEmpty()) {
         emit devicesSetup();
-        return SOUNDDEVICE_OK;
+        return SoundDeviceStatus::Ok;
     }
     m_pErrorDevice = SoundDevicePointer(
             new SoundDeviceNotFound(devicesNotFound.constBegin()->name));
-    return SOUNDDEVICE_ERROR_DEVICE_COUNT;
+    return SoundDeviceStatus::ErrorDeviceCount;
 
 closeAndError:
     const bool sleepAfterClosing = false;
@@ -531,7 +531,7 @@ QString SoundManager::getLastErrorMessage(SoundDeviceStatus status) const {
         detailedError = pDevice->getError();
     }
     switch (status) {
-    case SOUNDDEVICE_ERROR_DUPLICATE_OUTPUT_CHANNEL:
+    case SoundDeviceStatus::ErrorDuplicateOutputChannel:
         error = tr("Two outputs cannot share channels on \"%1\"").arg(deviceName);
         break;
     default:
@@ -546,7 +546,7 @@ SoundManagerConfig SoundManager::getConfig() const {
 }
 
 SoundDeviceStatus SoundManager::setConfig(const SoundManagerConfig& config) {
-    SoundDeviceStatus status = SOUNDDEVICE_OK;
+    SoundDeviceStatus status = SoundDeviceStatus::Ok;
     m_config = config;
     checkConfig();
 
@@ -563,7 +563,7 @@ SoundDeviceStatus SoundManager::setConfig(const SoundManagerConfig& config) {
                    ConfigValue(static_cast<int>(m_config.getSampleRate())));
 
     status = setupDevices();
-    if (status == SOUNDDEVICE_OK) {
+    if (status == SoundDeviceStatus::Ok) {
         m_config.writeToDisk();
     }
     return status;

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -57,7 +57,7 @@ class SoundManager : public QObject {
 
     // Opens all the devices chosen by the user in the preferences dialog, and
     // establishes the proper connections between them and the mixing engine.
-    SoundDeviceError setupDevices();
+    SoundDeviceStatus setupDevices();
 
     // Playermanager will notify us when the number of decks changes.
     void setConfiguredDeckCount(int count);
@@ -65,7 +65,7 @@ class SoundManager : public QObject {
 
     SoundDevicePointer getErrorDevice() const;
     QString getErrorDeviceName() const;
-    QString getLastErrorMessage(SoundDeviceError err) const;
+    QString getLastErrorMessage(SoundDeviceStatus status) const;
 
     // Returns a list of samplerates we will attempt to support for a given API.
     QList<unsigned int> getSampleRates(const QString& api) const;
@@ -76,7 +76,7 @@ class SoundManager : public QObject {
     // Get a list of host APIs supported by PortAudio.
     QList<QString> getHostAPIList() const;
     SoundManagerConfig getConfig() const;
-    SoundDeviceError setConfig(const SoundManagerConfig& config);
+    SoundDeviceStatus setConfig(const SoundManagerConfig& config);
     void checkConfig();
 
     void onDeviceOutputCallback(const SINT iFramesPerBuffer);


### PR DESCRIPTION
I found this a bit misleading/annoying that a device status is named "Error", as well as the inadequate names `SOUNDDEVICE_ERROR_OK` and `SOUNDDEVICE_ERROR_ERR`

So now it's
``` c++
enum SoundDeviceStatus {
    SOUNDDEVICE_ERROR = -1,
    SOUNDDEVICE_OK = 0,
    SOUNDDEVICE_ERROR_DUPLICATE_OUTPUT_CHANNEL,
    SOUNDDEVICE_ERROR_EXCESSIVE_OUTPUT_CHANNEL,
    SOUNDDEVICE_ERROR_EXCESSIVE_INPUT_CHANNEL,
    SOUNDDEVICE_ERROR_DEVICE_COUNT
};
```