### PR TITLE
CoverArtUtils: Fix Reload From File/Folder, Updates Wrong Cover Art

### DIFF
--- a/src/library/coverartutils.cpp
+++ b/src/library/coverartutils.cpp
@@ -117,6 +117,7 @@ CoverInfoRelative CoverArtUtils::selectCoverArtForTrack(
             } else if (bestType > TRACK_BASENAME &&
                     coverBaseName.compare(trackFile.fileName(),
                             Qt::CaseInsensitive) == 0) {
+                bestType = TRACK_BASENAME;
                 bestInfo = &file;
             } else if (bestType > ALBUM_NAME &&
                        coverBaseName.compare(albumName,

--- a/src/library/coverartutils.cpp
+++ b/src/library/coverartutils.cpp
@@ -107,13 +107,17 @@ CoverInfoRelative CoverArtUtils::selectCoverArtForTrack(
         // TODO(XXX) Sort instead so that we can fall-back if one fails to
         // open?
         foreach (const QFileInfo& file, covers) {
-            const QString coverBaseName = file.baseName();
+            const QString coverBaseName = file.completeBaseName();
             if (bestType > TRACK_BASENAME &&
-                coverBaseName.compare(trackFile.baseName(),
-                                      Qt::CaseInsensitive) == 0) {
+                    coverBaseName.compare(trackFile.completeBaseName(),
+                            Qt::CaseInsensitive) == 0) {
                 bestInfo = &file;
                 // This is the best type (TRACK_BASENAME) so we know we're done.
                 break;
+            } else if (bestType > TRACK_BASENAME &&
+                    coverBaseName.compare(trackFile.fileName(),
+                            Qt::CaseInsensitive) == 0) {
+                bestInfo = &file;
             } else if (bestType > ALBUM_NAME &&
                        coverBaseName.compare(albumName,
                                              Qt::CaseInsensitive) == 0) {


### PR DESCRIPTION
This PR aims to solve this bug mentioned on [Launchpad](https://bugs.launchpad.net/mixxx/+bug/1985843).

This simply fixes to wrong cover art update if the names has more than one "." dot. I
track.1.mp3
track.2.mp3
track.3.mp3
track.4.jpg
track.5.jpg
 
If track.1-track.2-track.3's cover arts updated via "Reload from file/folder" it updates it with track.4.jpg. 

With this change, it looks for the complete full name, so track.1.mp3 won't be updated with track.4.jpg. 

But with that change, this can change the old behavior, if the files named as;
track.1.mp3.jpg
track.1.mp3
updating wouldn't not update the cover art, to not change the behavior of old updating, there is an another block added. If complete full name is not working, this will look for file name of the track `"track.1.mp3"` and complete name of the cover art `"track.1.mp3".jpg`