### PR TITLE
refactor(effects): fix wrong method return type

### DIFF
--- a/src/engine/effects/engineeffectparameter.h
+++ b/src/engine/effects/engineeffectparameter.h
@@ -34,7 +34,7 @@ class EngineEffectParameter {
     inline int toInt() const {
         return static_cast<int>(m_value);
     }
-    inline int toBool() const {
+    inline bool toBool() const {
         return m_value > 0.0;
     }
 


### PR DESCRIPTION
how did this even slip through in the first place?
Found while investigating msvc warning in #4901