### PR TITLE
Preferences > Controller: a few UX fixes

### DIFF
--- a/src/controllers/controllerinputmappingtablemodel.cpp
+++ b/src/controllers/controllerinputmappingtablemodel.cpp
@@ -47,6 +47,12 @@ void ControllerInputMappingTableModel::onPresetLoaded() {
             m_midiInputMappings = m_pMidiPreset->getInputMappings().values();
             endInsertRows();
         }
+        connect(this,
+                &QAbstractTableModel::dataChanged,
+                this,
+                [this]() {
+                    m_pMidiPreset->setDirty(true);
+                });
     }
 }
 

--- a/src/controllers/controlleroutputmappingtablemodel.cpp
+++ b/src/controllers/controlleroutputmappingtablemodel.cpp
@@ -49,6 +49,12 @@ void ControllerOutputMappingTableModel::onPresetLoaded() {
             m_midiOutputMappings = m_pMidiPreset->getOutputMappings().values();
             endInsertRows();
         }
+        connect(this,
+                &QAbstractTableModel::dataChanged,
+                this,
+                [this]() {
+                    m_pMidiPreset->setDirty(true);
+                });
     }
 }
 

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -646,6 +646,11 @@ void DlgPrefController::savePreset() {
         newFilePath = oldFilePath;
     } else {
         presetName = askForPresetName(presetName);
+        if (presetName.isEmpty()) {
+            // QInputDialog was closed
+            qDebug() << "Mapping not saved, new name is empty";
+            return;
+        }
         newFilePath = presetNameToPath(m_pUserDir, presetName);
         m_pPreset->setName(presetName);
         qDebug() << "Mapping renamed to" << m_pPreset->name();
@@ -688,7 +693,8 @@ QString DlgPrefController::askForPresetName(const QString& prefilledName) const 
                              .remove(rxRemove)
                              .trimmed();
         if (!ok) {
-            continue;
+            // Return empty string if the dialog was canceled. Callers will deal with this.
+            return QString();
         }
         if (presetName.isEmpty()) {
             QMessageBox::warning(nullptr,

--- a/src/controllers/dlgprefcontroller.h
+++ b/src/controllers/dlgprefcontroller.h
@@ -73,7 +73,7 @@ class DlgPrefController : public DlgPreferencePage {
     QString presetPathFromIndex(int index) const;
     QString askForPresetName(const QString& prefilledName = QString()) const;
     void applyPresetChanges();
-    void savePreset();
+    bool savePreset();
     void initTableView(QTableView* pTable);
 
     /// Set dirty state (i.e. changes have been made).


### PR DESCRIPTION
* mark mapping dirty when I/O table was changed (those changes were wiped previously)
* prevent loop with empty name in 'Save as ...' dialog (saving couldn't be canceled after seleting Save As..)
* keep selected mapping when saving pending changes in previous mapping (info of selected mapping was displayed but in the combobox the previous mapping was selected)