### PR TITLE
Improve buffers size function const-correctness

### DIFF
--- a/src/util/circularbuffer.h
+++ b/src/util/circularbuffer.h
@@ -40,7 +40,7 @@ class CircularBuffer {
     }
 
     // Returns the total capacity of the CircularBuffer in units of T
-    inline unsigned int length() const {
+    constexpr unsigned int length() const {
         return m_iLength;
     }
 

--- a/src/util/readaheadsamplebuffer.h
+++ b/src/util/readaheadsamplebuffer.h
@@ -45,7 +45,7 @@ class ReadAheadSampleBuffer final {
             ReadAheadSampleBuffer& that);
 
     // The capacity is limited by the size of the underlying buffer.
-    SINT capacity() const {
+    constexpr SINT capacity() const {
         return m_sampleBuffer.size();
     }
 
@@ -122,7 +122,7 @@ class ReadAheadSampleBuffer final {
 } // namespace mixxx
 
 namespace std {
-    
+
 // Template specialization of std::swap() for ReadAheadSampleBuffer
 template<>
 inline void swap(::mixxx::ReadAheadSampleBuffer& lhs, ::mixxx::ReadAheadSampleBuffer& rhs) {

--- a/src/util/samplebuffer.h
+++ b/src/util/samplebuffer.h
@@ -55,7 +55,7 @@ class SampleBuffer final {
         return *this;
     }
 
-    SINT size() const {
+    constexpr SINT size() const {
         return m_size;
     }
 


### PR DESCRIPTION
This PR improves the const-correctness of the function which returns the size of the buffer for a specific buffer implementation. Due to the returned value can be evaluated in the compile time, the value can be marked as a constant expression. 

The idea of this improvement is inspired by the size function from std::span.

What do you think about it?