### PR TITLE
Debug Ctrl+click on sliders & knobs on macOS

### DIFF
--- a/src/widget/knobeventhandler.h
+++ b/src/widget/knobeventhandler.h
@@ -53,6 +53,9 @@ class KnobEventHandler {
     void mousePressEvent(T* pWidget, QMouseEvent* e) {
         switch (e->button()) {
             case Qt::RightButton:
+                qDebug() << "   .";
+                qDebug() << "   . knob: right mouse button pressed > reset";
+                qDebug() << "   .";
                 pWidget->resetControlParameter();
                 m_bRightButtonPressed = true;
                 break;
@@ -81,6 +84,9 @@ class KnobEventHandler {
                 pWidget->inputActivity();
                 break;
             case Qt::RightButton:
+                qDebug() << "   .";
+                qDebug() << "   . knob: right mouse button released";
+                qDebug() << "   .";
                 m_bRightButtonPressed = false;
                 break;
             default:

--- a/src/widget/slidereventhandler.h
+++ b/src/widget/slidereventhandler.h
@@ -77,6 +77,9 @@ class SliderEventHandler {
             m_bDrag = true;
         } else {
             if (e->button() == Qt::RightButton) {
+                qDebug() << "   .";
+                qDebug() << "   . slider: right mouse button pressed > reset";
+                qDebug() << "   .";
                 pWidget->resetControlParameter();
                 m_bRightButtonPressed = true;
             } else {
@@ -96,6 +99,9 @@ class SliderEventHandler {
             m_bDrag = false;
         }
         if (e->button() == Qt::RightButton) {
+            qDebug() << "   .";
+            qDebug() << "   . slider: right mouse button released";
+            qDebug() << "   .";
             m_bRightButtonPressed = false;
         } else {
             pWidget->setControlParameter(m_dOldParameter);


### PR DESCRIPTION
Knobs and sliders can't be manipulated with touchpad after using Ctrl+click to reset the control
https://github.com/mixxxdj/mixxx/issues/10831

I suspect we don't receive a right button release event with this emulated right-click.
Please start Mixxx from command line with `--developer` argument and check if this output is printed after releasing the touchpad
```
   .
   . knob / slider: right mouse button released
   .
```
https://manual.mixxx.org/2.3/chapters/appendix/commandline_dev_tools.html