### PR TITLE
EngineEffectsDelay: introduce ring delay buffer

### DIFF
--- a/.codespellignorelines
+++ b/.codespellignorelines
@@ -42,11 +42,13 @@ void EngineDelay::process(CSAMPLE* pInOut, const std::size_t bufferSize) {
     /// Process the prefader EngineEffectChains on the pInOut buffer, modifying
     /// Process the postfader EngineEffectChains on the pInOut buffer, modifying
 void EngineEffectsDelay::process(CSAMPLE* pInOut,
+    std::span<CSAMPLE> inOutSpan = mixxx::spanutil::spanFromPtrLen(pInOut, bufferSize);
             m_pDelayBuffer[m_delayBufferWritePos] = pInOut[i];
             pInOut[i] = m_pDelayBuffer[delaySourcePos];
             pInOut[i] = m_pDelayBuffer[oldDelaySourcePos] * (1.0f - crossMix);
             pInOut[i] += m_pDelayBuffer[delaySourcePos] * crossMix;
             pInOut,
+                pInOut,
             CSAMPLE* pInOut,
     mixxx::SampleBuffer pInOut(numSamples);
     SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);

--- a/src/engine/effects/engineeffectsdelay.cpp
+++ b/src/engine/effects/engineeffectsdelay.cpp
@@ -3,8 +3,25 @@
 #include <span>
 
 #include "moc_engineeffectsdelay.cpp"
+#include "util/math.h"
 #include "util/sample.h"
 #include "util/span.h"
+
+namespace {
+SINT readWithMaxDelay(std::span<CSAMPLE> inOutSpan,
+        RingDelayBuffer& delayBuffer) {
+    // In this situation, the sum of the size of the inOutSpan
+    // and the provided delay is greater than the ring buffer.
+    // The wrong delay is minimized by using the maximum possible delay
+    // for handling with the ring buffer.
+    const SINT maxDelaySamples = math_max(
+            kDelayBufferSize - static_cast<int>(inOutSpan.size()), 0);
+    delayBuffer.read(inOutSpan, maxDelaySamples);
+
+    return maxDelaySamples;
+}
+
+} // anonymous namespace
 
 EngineEffectsDelay::EngineEffectsDelay()
         : m_currentDelaySamples(0),
@@ -17,37 +34,74 @@ EngineEffectsDelay::~EngineEffectsDelay() {
 }
 
 void EngineEffectsDelay::process(CSAMPLE* pInOut,
-        const int iBufferSize) {
-    std::span<CSAMPLE> inOutSpan = mixxx::spanutil::spanFromPtrLen(pInOut, iBufferSize);
+        const std::size_t bufferSize) {
+    std::span<CSAMPLE> inOutSpan = mixxx::spanutil::spanFromPtrLen(pInOut, bufferSize);
 
     if (m_prevDelaySamples == 0 && m_currentDelaySamples == 0) {
-        // TODO(davidchocholaty) check the returned number of written samples
-        m_delayBuffer.write(inOutSpan);
+        // We can keep writing without reading due to the implementation
+        // of the RingDelayBuffer. The implementation is specific,
+        // that the RingDelayBuffer works only with the write position only
+        // (not with the reading position). Based on that, we can keep writing
+        // and the old unread data are rewritten with the new one.
+        // So, the ring buffer can't be full.
+        const SINT writtenSamples = m_delayBuffer.write(inOutSpan);
+        VERIFY_OR_DEBUG_ASSERT(writtenSamples == static_cast<SINT>(bufferSize)) {
+            // It is not needed to return from here
+            // based on the return that follows after.
+        }
 
         return;
     }
 
     if (m_prevDelaySamples == m_currentDelaySamples) {
-        // TODO(davidchocholaty) check the returned number of written samples
-        m_delayBuffer.write(inOutSpan);
-        // TODO(davidchocholaty) check the returned number of read samples
-        m_delayBuffer.read(inOutSpan, m_currentDelaySamples);
-    } else {
-        // TODO(davidchocholaty) check the returned number of written samples
-        m_delayBuffer.write(inOutSpan);
+        const SINT writtenSamples = m_delayBuffer.write(inOutSpan);
+        VERIFY_OR_DEBUG_ASSERT(writtenSamples == static_cast<SINT>(bufferSize)) {
+            return;
+        }
 
-        // TODO(davidchocholaty) check the returned number of read samples
+        const SINT readSamples = m_delayBuffer.read(inOutSpan, m_currentDelaySamples);
+        VERIFY_OR_DEBUG_ASSERT(readSamples == static_cast<SINT>(bufferSize)) {
+            m_currentDelaySamples = readWithMaxDelay(inOutSpan, m_delayBuffer);
+        }
+
+    } else {
+        const SINT writtenSamples = m_delayBuffer.write(inOutSpan);
+        VERIFY_OR_DEBUG_ASSERT(writtenSamples == static_cast<SINT>(bufferSize)) {
+            return;
+        }
+
         // Read the samples using the previous group delay samples.
-        m_delayBuffer.read(inOutSpan, m_prevDelaySamples);
+        SINT readSamples = m_delayBuffer.read(inOutSpan, m_prevDelaySamples);
+        VERIFY_OR_DEBUG_ASSERT(readSamples == static_cast<SINT>(bufferSize)) {
+            // In this situation, it is not possible that the delay
+            // will be greater than possible. For the first call,
+            // the m_prevDelaySamples value is 0 and before assigning
+            // the m_currentDelaySamples into m_prevDelaySamples all delays
+            // which are too big are clamped.
+
+            // This VERIFY_OR_DEBUG_ASSERT can be false only for the situation,
+            // where the inOutSpan size is just too much big
+            // for the RingDelayBuffer size based on the incorrectly
+            // chosen size.
+
+            // Based on that, the inOutSpan is unchanged and the input data
+            // are kept as output.
+            return;
+        }
 
         // Read the samples using the current group delay samples.
         auto tmpBufferView = m_currentDelayBuffer.span().first(inOutSpan.size());
-        m_delayBuffer.read(tmpBufferView, m_currentDelaySamples);
+
+        readSamples = m_delayBuffer.read(tmpBufferView, m_currentDelaySamples);
+        VERIFY_OR_DEBUG_ASSERT(readSamples == static_cast<SINT>(bufferSize)) {
+            m_currentDelaySamples = readWithMaxDelay(inOutSpan, m_delayBuffer);
+        }
 
         SampleUtil::linearCrossfadeBuffersOut(
                 pInOut,
                 tmpBufferView.data(),
-                tmpBufferView.size());
+                static_cast<SINT>(bufferSize),
+                mixxx::kEngineChannelOutputCount);
 
         m_prevDelaySamples = m_currentDelaySamples;
     }

--- a/src/engine/effects/engineeffectsdelay.cpp
+++ b/src/engine/effects/engineeffectsdelay.cpp
@@ -40,7 +40,9 @@ void EngineEffectsDelay::process(CSAMPLE* pInOut,
         // Read the samples using the previous group delay samples.
         m_pDelayBuffer->read(inOutSpan, m_prevDelaySamples);
         // Read the samples using the current group delay samples.
-        m_pDelayBuffer->read(m_currentDelayBuffer.subspan(0, iBufferSize), m_currentDelaySamples);
+        m_pDelayBuffer->read(
+                m_currentDelayBuffer.span().subspan(0, iBufferSize),
+                m_currentDelaySamples);
 
         SampleUtil::linearCrossfadeBuffersOut(
                 pInOut,

--- a/src/engine/effects/engineeffectsdelay.cpp
+++ b/src/engine/effects/engineeffectsdelay.cpp
@@ -9,8 +9,8 @@
 EngineEffectsDelay::EngineEffectsDelay()
         : m_currentDelaySamples(0),
           m_prevDelaySamples(0),
-          m_currentDelayBuffer(kDelayBufferSize) {
-    m_pDelayBuffer = std::make_unique<RingDelayBuffer>(kDelayBufferSize);
+          m_currentDelayBuffer(kDelayBufferSize),
+          m_delayBuffer(kDelayBufferSize) {
 }
 
 EngineEffectsDelay::~EngineEffectsDelay() {
@@ -22,25 +22,25 @@ void EngineEffectsDelay::process(CSAMPLE* pInOut,
 
     if (m_prevDelaySamples == 0 && m_currentDelaySamples == 0) {
         // TODO(davidchocholaty) check the returned number of written samples
-        m_pDelayBuffer->write(inOutSpan);
+        m_delayBuffer.write(inOutSpan);
 
         return;
     }
 
     if (m_prevDelaySamples == m_currentDelaySamples) {
         // TODO(davidchocholaty) check the returned number of written samples
-        m_pDelayBuffer->write(inOutSpan);
+        m_delayBuffer.write(inOutSpan);
         // TODO(davidchocholaty) check the returned number of read samples
-        m_pDelayBuffer->read(inOutSpan, m_currentDelaySamples);
+        m_delayBuffer.read(inOutSpan, m_currentDelaySamples);
     } else {
         // TODO(davidchocholaty) check the returned number of written samples
-        m_pDelayBuffer->write(inOutSpan);
+        m_delayBuffer.write(inOutSpan);
 
         // TODO(davidchocholaty) check the returned number of read samples
         // Read the samples using the previous group delay samples.
-        m_pDelayBuffer->read(inOutSpan, m_prevDelaySamples);
+        m_delayBuffer.read(inOutSpan, m_prevDelaySamples);
         // Read the samples using the current group delay samples.
-        m_pDelayBuffer->read(
+        m_delayBuffer.read(
                 m_currentDelayBuffer.span().subspan(0, iBufferSize),
                 m_currentDelaySamples);
 

--- a/src/engine/effects/engineeffectsdelay.cpp
+++ b/src/engine/effects/engineeffectsdelay.cpp
@@ -1,84 +1,51 @@
 #include "engine/effects/engineeffectsdelay.h"
 
+#include <span>
+
 #include "moc_engineeffectsdelay.cpp"
-#include "util/rampingvalue.h"
 #include "util/sample.h"
+#include "util/span.h"
 
 EngineEffectsDelay::EngineEffectsDelay()
         : m_currentDelaySamples(0),
           m_prevDelaySamples(0),
-          m_delayBufferWritePos(0) {
-    m_pDelayBuffer = SampleUtil::alloc(kDelayBufferSize);
-    SampleUtil::clear(m_pDelayBuffer, kDelayBufferSize);
+          m_currentDelayBuffer(kDelayBufferSize) {
+    m_pDelayBuffer = std::make_unique<RingDelayBuffer>(kDelayBufferSize);
 }
 
 EngineEffectsDelay::~EngineEffectsDelay() {
-    SampleUtil::free(m_pDelayBuffer);
 }
 
 void EngineEffectsDelay::process(CSAMPLE* pInOut,
-        const std::size_t bufferSize) {
+        const int iBufferSize) {
+    std::span<CSAMPLE> inOutSpan = mixxx::spanutil::spanFromPtrLen(pInOut, iBufferSize);
+
     if (m_prevDelaySamples == 0 && m_currentDelaySamples == 0) {
-        for (std::size_t i = 0; i < bufferSize; ++i) {
-            // Put samples into delay buffer.
-            m_pDelayBuffer[m_delayBufferWritePos] = pInOut[i];
-            m_delayBufferWritePos = (m_delayBufferWritePos + 1) % kDelayBufferSize;
-        }
+        // TODO(davidchocholaty) check the returned number of written samples
+        m_pDelayBuffer->write(inOutSpan);
 
         return;
     }
 
-    // The "+ kDelayBufferSize" addition ensures positive values for the modulo calculation.
-    // From a mathematical point of view, this addition can be removed. Anyway,
-    // from the cpp point of view, the modulo operator for negative values
-    // (for example, x % y, where x is a negative value) produces negative results
-    // (but in math the result value is positive).
-    int delaySourcePos =
-            (m_delayBufferWritePos + kDelayBufferSize - m_currentDelaySamples) %
-            kDelayBufferSize;
-
     if (m_prevDelaySamples == m_currentDelaySamples) {
-        for (std::size_t i = 0; i < bufferSize; ++i) {
-            // Put samples into delay buffer.
-            m_pDelayBuffer[m_delayBufferWritePos] = pInOut[i];
-            m_delayBufferWritePos = (m_delayBufferWritePos + 1) % kDelayBufferSize;
-
-            // Take a delayed sample from the delay buffer
-            // and copy it to the destination buffer.
-            pInOut[i] = m_pDelayBuffer[delaySourcePos];
-            delaySourcePos = (delaySourcePos + 1) % kDelayBufferSize;
-        }
-
+        // TODO(davidchocholaty) check the returned number of written samples
+        m_pDelayBuffer->write(inOutSpan);
+        // TODO(davidchocholaty) check the returned number of read samples
+        m_pDelayBuffer->read(inOutSpan, m_currentDelaySamples);
     } else {
-        // The "+ kDelayBufferSize" addition ensures positive values for the modulo calculation.
-        // From a mathematical point of view, this addition can be removed. Anyway,
-        // from the cpp point of view, the modulo operator for negative values
-        // (for example, x % y, where x is a negative value) produces negative results
-        // (but in math the result value is positive).
-        int oldDelaySourcePos =
-                (m_delayBufferWritePos + kDelayBufferSize - m_prevDelaySamples) %
-                kDelayBufferSize;
+        // TODO(davidchocholaty) check the returned number of written samples
+        m_pDelayBuffer->write(inOutSpan);
 
-        const RampingValue<CSAMPLE_GAIN> delayChangeRamped(
-                0.0f, 1.0f, static_cast<int>(bufferSize));
+        // TODO(davidchocholaty) check the returned number of read samples
+        // Read the samples using the previous group delay samples.
+        m_pDelayBuffer->read(inOutSpan, m_prevDelaySamples);
+        // Read the samples using the current group delay samples.
+        m_pDelayBuffer->read(m_currentDelayBuffer.subspan(0, iBufferSize), m_currentDelaySamples);
 
-        for (std::size_t i = 0; i < bufferSize; ++i) {
-            // Put samples into delay buffer.
-            m_pDelayBuffer[m_delayBufferWritePos] = pInOut[i];
-            m_delayBufferWritePos = (m_delayBufferWritePos + 1) % kDelayBufferSize;
-
-            // Take delayed samples from the delay buffer
-            // and with the use of ramping (cross-fading),
-            // calculate the result sample value
-            // and put it into the dest buffer.
-            CSAMPLE_GAIN crossMix = delayChangeRamped.getNth(static_cast<int>(i));
-
-            pInOut[i] = m_pDelayBuffer[oldDelaySourcePos] * (1.0f - crossMix);
-            pInOut[i] += m_pDelayBuffer[delaySourcePos] * crossMix;
-
-            oldDelaySourcePos = (oldDelaySourcePos + 1) % kDelayBufferSize;
-            delaySourcePos = (delaySourcePos + 1) % kDelayBufferSize;
-        }
+        SampleUtil::linearCrossfadeBuffersOut(
+                pInOut,
+                m_currentDelayBuffer.data(),
+                iBufferSize);
 
         m_prevDelaySamples = m_currentDelaySamples;
     }

--- a/src/engine/effects/engineeffectsdelay.cpp
+++ b/src/engine/effects/engineeffectsdelay.cpp
@@ -39,15 +39,15 @@ void EngineEffectsDelay::process(CSAMPLE* pInOut,
         // TODO(davidchocholaty) check the returned number of read samples
         // Read the samples using the previous group delay samples.
         m_delayBuffer.read(inOutSpan, m_prevDelaySamples);
+
         // Read the samples using the current group delay samples.
-        m_delayBuffer.read(
-                m_currentDelayBuffer.span().subspan(0, iBufferSize),
-                m_currentDelaySamples);
+        auto tmpBufferView = m_currentDelayBuffer.span().first(inOutSpan.size());
+        m_delayBuffer.read(tmpBufferView, m_currentDelaySamples);
 
         SampleUtil::linearCrossfadeBuffersOut(
                 pInOut,
-                m_currentDelayBuffer.data(),
-                iBufferSize);
+                tmpBufferView.data(),
+                tmpBufferView.size());
 
         m_prevDelaySamples = m_currentDelaySamples;
     }

--- a/src/engine/effects/engineeffectsdelay.h
+++ b/src/engine/effects/engineeffectsdelay.h
@@ -3,6 +3,9 @@
 #include "engine/engine.h"
 #include "engine/engineobject.h"
 #include "util/assert.h"
+#include "util/ringdelaybuffer.h"
+#include "util/sample.h"
+#include "util/samplebuffer.h"
 #include "util/types.h"
 
 namespace {
@@ -76,6 +79,6 @@ class EngineEffectsDelay final : public EngineObject {
   private:
     SINT m_currentDelaySamples;
     SINT m_prevDelaySamples;
-    SINT m_delayBufferWritePos;
-    CSAMPLE* m_pDelayBuffer;
+    mixxx::SampleBuffer m_currentDelayBuffer;
+    std::unique_ptr<RingDelayBuffer> m_pDelayBuffer;
 };

--- a/src/engine/effects/engineeffectsdelay.h
+++ b/src/engine/effects/engineeffectsdelay.h
@@ -80,5 +80,5 @@ class EngineEffectsDelay final : public EngineObject {
     SINT m_currentDelaySamples;
     SINT m_prevDelaySamples;
     mixxx::SampleBuffer m_currentDelayBuffer;
-    std::unique_ptr<RingDelayBuffer> m_pDelayBuffer;
+    RingDelayBuffer m_delayBuffer;
 };

--- a/src/test/engineeffectsdelay_test.cpp
+++ b/src/test/engineeffectsdelay_test.cpp
@@ -91,7 +91,7 @@ TEST_F(EngineEffectsDelayTest, DelayGreaterThanDelayBufferSize) {
     m_effectsDelay.setDelayFrames(numDelayFrames);
 
     const CSAMPLE inputBuffer[] = {-100.0, 100.0, -99.0, 99.0};
-    const CSAMPLE expectedResult[] = {-100.0, 75.0, -49.5, 24.75};
+    const CSAMPLE expectedResult[] = {-50.0, 50.0, -49.5, 49.5};
 
     mixxx::SampleBuffer pInOut(numSamples);
     SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);
@@ -110,9 +110,9 @@ TEST_F(EngineEffectsDelayTest, WholeBufferDelay) {
 
     const CSAMPLE inputBuffer[] = {-100.0, 100.0, -99.0, 99.0};
     const CSAMPLE zeroBuffer[] = {0.0, 0.0, 0.0, 0.0};
-    const CSAMPLE firstExpectedResult[] = {-100.0, 75.0, -49.5, 24.75};
+    const CSAMPLE firstExpectedResult[] = {-50.0, 50.0, -49.5, 49.5};
 
-    const CSAMPLE secondExpectedResult[] = {-100.0, 100.0, -99.0, 99.0};
+    const CSAMPLE secondExpectedResult[] = {-50.0, 50.0, -99.0, 99.0};
     const CSAMPLE thirdExpectedResult[] = {0.0, 0.0, 0.0, 0.0};
 
     mixxx::SampleBuffer pInOut(numSamples);
@@ -139,7 +139,7 @@ TEST_F(EngineEffectsDelayTest, HalfBufferDelay) {
 
     const CSAMPLE inputBuffer[] = {-100.0, 100.0, -99.0, 99.0};
     const CSAMPLE zeroBuffer[] = {0.0, 0.0, 0.0, 0.0};
-    const CSAMPLE firstExpectedResult[] = {-100.0, 75.0, -99.5, 99.75};
+    const CSAMPLE firstExpectedResult[] = {-50.0, 50.0, -74.5, 74.5};
     const CSAMPLE secondExpectedResult[] = {-99.0, 99.0, -100.0, 100.0};
     const CSAMPLE thirdExpectedResult[] = {-99.0, 99.0, 0.0, 0.0};
 
@@ -171,9 +171,9 @@ TEST_F(EngineEffectsDelayTest, MisalignedDelayAccordingToBuffer) {
     const CSAMPLE zeroBuffer[] = {
             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
     const CSAMPLE firstExpectedResult[] = {
-            -100.0, 87.5, -74.25, 61.875, -49.0, 36.75, -99.25, 99.625};
+            -25.0, 25.0, -37.125, 37.125, -36.75, 36.75, -43.0, 43.0};
     const CSAMPLE secondExpectedResult[] = {
-            -99.0, 99.0, -98.0, 98.0, -97.0, 97.0, -100.0, 100.0};
+            -49.5, 49.5, -73.5, 73.5, -97.0, 97.0, -100.0, 100.0};
     const CSAMPLE thirdExpectedResult[] = {
             -99.0, 99.0, -98.0, 98.0, -97.0, 97.0, 0.0, 0.0};
 
@@ -203,11 +203,11 @@ TEST_F(EngineEffectsDelayTest, CrossfadeBetweenTwoNonZeroDelays) {
             -100.0, 100.0, -99.0, 99.0, -98.0, 98.0, -97.0, 97.0};
 
     const CSAMPLE firstExpectedResult[] = {
-            -100.0, 87.5, -74.25, 61.875, -99.0, 99.25, -98.5, 98.75};
+            -25.0, 25.0, -37.125, 37.125, -49.25, 49.25, -61.375, 61.375};
     const CSAMPLE secondExpectedResult[] = {
-            -98.0, 98.0, -97.0, 97.0, -100.0, 100.0, -99.0, 99.0};
+            -73.5, 73.5, -97.0, 97.0, -100.0, 100.0, -99.0, 99.0};
     const CSAMPLE thirdExpectedResult[] = {
-            -98.0, 98.25, -97.5, 97.75, -99.0, 98.75, -97.5, 97.25};
+            -98.0, 98.0, -97.5, 97.5, -99.0, 99.0, -97.5, 97.5};
     const CSAMPLE fourthExpectedResult[] = {
             -100.0, 100.0, -99.0, 99.0, -98.0, 98.0, -97.0, 97.0};
 
@@ -244,11 +244,11 @@ TEST_F(EngineEffectsDelayTest, CrossfadeSecondDelayGreaterThanInputBufferSize) {
             -100.0, 100.0, -99.0, 99.0, -98.0, 98.0, -97.0, 97.0};
 
     const CSAMPLE firstExpectedResult[] = {
-            -100.0, 87.5, -74.25, 61.875, -99.0, 99.25, -98.5, 98.75};
+            -25.0, 25.0, -37.125, 37.125, -49.25, 49.25, -61.375, 61.375};
     const CSAMPLE secondExpectedResult[] = {
-            -98.0, 98.0, -97.0, 97.0, -100.0, 100.0, -99.0, 99.0};
+            -73.5, 73.5, -97.0, 97.0, -100.0, 100.0, -99.0, 99.0};
     const CSAMPLE thirdExpectedResult[] = {
-            -98.0, 98.125, -97.25, 97.375, -98.5, 98.125, -99.75, 99.875};
+            -98.0, 98.0, -91.125, 91.125, -98.5, 98.5, -99.75, 99.75};
     const CSAMPLE fourthExpectedResult[] = {
             -99.0, 99.0, -98.0, 98.0, -97.0, 97.0, -100.0, 100.0};
 
@@ -285,15 +285,15 @@ TEST_F(EngineEffectsDelayTest, CrossfadeBetweenThreeNonZeroDelays) {
             -100.0, 100.0, -99.0, 99.0, -98.0, 98.0, -97.0, 97.0};
 
     const CSAMPLE firstExpectedResult[] = {
-            -100.0, 87.5, -74.25, 61.875, -49.0, 36.75, -99.25, 99.625};
+            -25.0, 25.0, -37.125, 37.125, -36.75, 36.75, -43.0, 43.0};
     const CSAMPLE secondExpectedResult[] = {
-            -99.0, 99.0, -98.0, 98.0, -97.0, 97.0, -100.0, 100.0};
+            -49.5, 49.5, -73.5, 73.5, -97.0, 97.0, -100.0, 100.0};
     const CSAMPLE thirdExpectedResult[] = {
-            -99.0, 98.75, -98.5, 98.75, -98.0, 98.25, -98.5, 98.25};
+            -99.0, 99.0, -98.5, 98.5, -98.0, 98.0, -98.5, 98.5};
     const CSAMPLE fourthExpectedResult[] = {
             -97.0, 97.0, -100.0, 100.0, -99.0, 99.0, -98.0, 98.0};
     const CSAMPLE fifthExpectedResult[] = {
-            -97.0, 97.25, -99.5, 99.25, -98.0, 97.75, -99.5, 99.75};
+            -97.0, 97.0, -99.5, 99.5, -98.0, 98.0, -99.5, 99.5};
     const CSAMPLE sixthExpectedResult[] = {
             -99.0, 99.0, -98.0, 98.0, -97.0, 97.0, -100.0, 100.0};
 

--- a/src/test/engineeffectsdelay_test.cpp
+++ b/src/test/engineeffectsdelay_test.cpp
@@ -73,7 +73,7 @@ TEST_F(EngineEffectsDelayTest, NegativeDelayValue) {
 
 //Test's purpose is to test clamping of the delay value in setter (upper bound).
 TEST_F(EngineEffectsDelayTest, DelayGreaterThanDelayBufferSize) {
-    const SINT numDelayFrames = mixxx::audio::SampleRate::kValueMax + 2;
+    const SINT numDelayFrames = mixxx::audio::SampleRate::kValueMax + 1;
 
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
     // Set thread safe for EXPECT_DEATH.
@@ -87,16 +87,35 @@ TEST_F(EngineEffectsDelayTest, DelayGreaterThanDelayBufferSize) {
 #else
     const SINT numSamples = 4;
 
+    // The number of iterations to fill the whole delay buffer and then
+    // write one another buffer to test the structure more strictly.
+    const SINT numIter = (mixxx::audio::SampleRate::kValueMax *
+                                 mixxx::kEngineChannelOutputCount) /
+                    numSamples +
+            1;
+
+    CSAMPLE inputBuffer[numSamples];
+    mixxx::SampleBuffer inOutBuffer(numSamples);
+
     // Set delay greater than the size of the delay buffer.
     m_effectsDelay.setDelayFrames(numDelayFrames);
 
-    const CSAMPLE inputBuffer[] = {-100.0, 100.0, -99.0, 99.0};
-    const CSAMPLE expectedResult[] = {-50.0, 50.0, -49.5, 49.5};
+    for (int bufferNum = 0; bufferNum < numIter; ++bufferNum) {
+        // Set input samples to keep the data in linearly increasing series.
+        for (int i = 0; i < numSamples; ++i) {
+            inputBuffer[i] = numSamples * bufferNum + i;
+        }
 
-    mixxx::SampleBuffer inOutBuffer(numSamples);
-    SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
+        SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
+        m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    }
 
-    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    // The whole delay buffer was filled up and then one another input buffer
+    // was written into the delay buffer too. So, when it will be read
+    // with the maximum possible delay, the result is the buffer, which was
+    // filled into the delay buffer as the second.
+    const CSAMPLE expectedResult[] = {4, 5, 6, 7};
+
     AssertIdenticalBufferEquals(inOutBuffer.span(), expectedResult);
 #endif
 }

--- a/src/test/engineeffectsdelay_test.cpp
+++ b/src/test/engineeffectsdelay_test.cpp
@@ -63,11 +63,11 @@ TEST_F(EngineEffectsDelayTest, NegativeDelayValue) {
     const CSAMPLE inputBuffer[] = {-100.0, 100.0, -99.0, 99.0};
     const CSAMPLE expectedResult[] = {-100.0, 100.0, -99.0, 99.0};
 
-    mixxx::SampleBuffer pInOut(numSamples);
-    SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);
+    mixxx::SampleBuffer inOutBuffer(numSamples);
+    SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
 
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), expectedResult);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), expectedResult);
 #endif
 }
 
@@ -93,11 +93,11 @@ TEST_F(EngineEffectsDelayTest, DelayGreaterThanDelayBufferSize) {
     const CSAMPLE inputBuffer[] = {-100.0, 100.0, -99.0, 99.0};
     const CSAMPLE expectedResult[] = {-50.0, 50.0, -49.5, 49.5};
 
-    mixxx::SampleBuffer pInOut(numSamples);
-    SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);
+    mixxx::SampleBuffer inOutBuffer(numSamples);
+    SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
 
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), expectedResult);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), expectedResult);
 #endif
 }
 
@@ -115,19 +115,19 @@ TEST_F(EngineEffectsDelayTest, WholeBufferDelay) {
     const CSAMPLE secondExpectedResult[] = {-50.0, 50.0, -99.0, 99.0};
     const CSAMPLE thirdExpectedResult[] = {0.0, 0.0, 0.0, 0.0};
 
-    mixxx::SampleBuffer pInOut(numSamples);
+    mixxx::SampleBuffer inOutBuffer(numSamples);
 
-    SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), firstExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), firstExpectedResult);
 
-    SampleUtil::copy(pInOut.data(), zeroBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), secondExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), zeroBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), secondExpectedResult);
 
-    SampleUtil::copy(pInOut.data(), zeroBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), thirdExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), zeroBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), thirdExpectedResult);
 }
 
 TEST_F(EngineEffectsDelayTest, HalfBufferDelay) {
@@ -143,19 +143,19 @@ TEST_F(EngineEffectsDelayTest, HalfBufferDelay) {
     const CSAMPLE secondExpectedResult[] = {-99.0, 99.0, -100.0, 100.0};
     const CSAMPLE thirdExpectedResult[] = {-99.0, 99.0, 0.0, 0.0};
 
-    mixxx::SampleBuffer pInOut(numSamples);
+    mixxx::SampleBuffer inOutBuffer(numSamples);
 
-    SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), firstExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), firstExpectedResult);
 
-    SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), secondExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), secondExpectedResult);
 
-    SampleUtil::copy(pInOut.data(), zeroBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), thirdExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), zeroBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), thirdExpectedResult);
 }
 
 TEST_F(EngineEffectsDelayTest, MisalignedDelayAccordingToBuffer) {
@@ -177,19 +177,19 @@ TEST_F(EngineEffectsDelayTest, MisalignedDelayAccordingToBuffer) {
     const CSAMPLE thirdExpectedResult[] = {
             -99.0, 99.0, -98.0, 98.0, -97.0, 97.0, 0.0, 0.0};
 
-    mixxx::SampleBuffer pInOut(numSamples);
+    mixxx::SampleBuffer inOutBuffer(numSamples);
 
-    SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), firstExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), firstExpectedResult);
 
-    SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), secondExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), secondExpectedResult);
 
-    SampleUtil::copy(pInOut.data(), zeroBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), thirdExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), zeroBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), thirdExpectedResult);
 }
 
 TEST_F(EngineEffectsDelayTest, CrossfadeBetweenTwoNonZeroDelays) {
@@ -211,27 +211,27 @@ TEST_F(EngineEffectsDelayTest, CrossfadeBetweenTwoNonZeroDelays) {
     const CSAMPLE fourthExpectedResult[] = {
             -100.0, 100.0, -99.0, 99.0, -98.0, 98.0, -97.0, 97.0};
 
-    mixxx::SampleBuffer pInOut(numSamples);
+    mixxx::SampleBuffer inOutBuffer(numSamples);
 
-    SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), firstExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), firstExpectedResult);
 
-    SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), secondExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), secondExpectedResult);
 
     // Set the number of delay frames as the size of the input buffer.
     numDelayFrames = 4;
     m_effectsDelay.setDelayFrames(numDelayFrames);
 
-    SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), thirdExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), thirdExpectedResult);
 
-    SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), fourthExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), fourthExpectedResult);
 }
 
 TEST_F(EngineEffectsDelayTest, CrossfadeSecondDelayGreaterThanInputBufferSize) {
@@ -252,27 +252,27 @@ TEST_F(EngineEffectsDelayTest, CrossfadeSecondDelayGreaterThanInputBufferSize) {
     const CSAMPLE fourthExpectedResult[] = {
             -99.0, 99.0, -98.0, 98.0, -97.0, 97.0, -100.0, 100.0};
 
-    mixxx::SampleBuffer pInOut(numSamples);
+    mixxx::SampleBuffer inOutBuffer(numSamples);
 
-    SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), firstExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), firstExpectedResult);
 
-    SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), secondExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), secondExpectedResult);
 
     // Set the number of frames greater than the size of the input buffer.
     numDelayFrames = 7;
     m_effectsDelay.setDelayFrames(numDelayFrames);
 
-    SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), thirdExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), thirdExpectedResult);
 
-    SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), fourthExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), fourthExpectedResult);
 }
 
 TEST_F(EngineEffectsDelayTest, CrossfadeBetweenThreeNonZeroDelays) {
@@ -297,38 +297,38 @@ TEST_F(EngineEffectsDelayTest, CrossfadeBetweenThreeNonZeroDelays) {
     const CSAMPLE sixthExpectedResult[] = {
             -99.0, 99.0, -98.0, 98.0, -97.0, 97.0, -100.0, 100.0};
 
-    mixxx::SampleBuffer pInOut(numSamples);
+    mixxx::SampleBuffer inOutBuffer(numSamples);
 
-    SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), firstExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), firstExpectedResult);
 
-    SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), secondExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), secondExpectedResult);
 
     numDelayFrames = 1;
     m_effectsDelay.setDelayFrames(numDelayFrames);
 
-    SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), thirdExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), thirdExpectedResult);
 
-    SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), fourthExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), fourthExpectedResult);
 
     // Set the number of frames greater than the size of the input buffer.
     numDelayFrames = 7;
     m_effectsDelay.setDelayFrames(numDelayFrames);
 
-    SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), fifthExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), fifthExpectedResult);
 
-    SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), sixthExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), sixthExpectedResult);
 }
 
 TEST_F(EngineEffectsDelayTest, CopyWholeBufferForZeroDelay) {
@@ -339,15 +339,15 @@ TEST_F(EngineEffectsDelayTest, CopyWholeBufferForZeroDelay) {
     const CSAMPLE firstExpectedResult[] = {-100.0, 100.0, -99.0, 99.0};
     const CSAMPLE secondExpectedResult[] = {0.0, 0.0, 0.0, 0.0};
 
-    mixxx::SampleBuffer pInOut(numSamples);
+    mixxx::SampleBuffer inOutBuffer(numSamples);
 
-    SampleUtil::copy(pInOut.data(), inputBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), firstExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), inputBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), firstExpectedResult);
 
-    SampleUtil::copy(pInOut.data(), zeroBuffer, numSamples);
-    m_effectsDelay.process(pInOut.data(), numSamples);
-    AssertIdenticalBufferEquals(pInOut.span(), secondExpectedResult);
+    SampleUtil::copy(inOutBuffer.data(), zeroBuffer, numSamples);
+    m_effectsDelay.process(inOutBuffer.data(), numSamples);
+    AssertIdenticalBufferEquals(inOutBuffer.span(), secondExpectedResult);
 }
 
 static void BM_ZeroDelay(benchmark::State& state) {
@@ -355,11 +355,11 @@ static void BM_ZeroDelay(benchmark::State& state) {
 
     EngineEffectsDelay effectsDelay;
 
-    mixxx::SampleBuffer pInOut(bufferSizeInSamples);
-    SampleUtil::fill(pInOut.data(), 0.0f, bufferSizeInSamples);
+    mixxx::SampleBuffer inOutBuffer(bufferSizeInSamples);
+    SampleUtil::fill(inOutBuffer.data(), 0.0f, bufferSizeInSamples);
 
     for (auto _ : state) {
-        effectsDelay.process(pInOut.data(), bufferSizeInSamples);
+        effectsDelay.process(inOutBuffer.data(), bufferSizeInSamples);
     }
 }
 BENCHMARK(BM_ZeroDelay)->Range(64, 4 << 10);
@@ -373,13 +373,13 @@ static void BM_DelaySmallerThanBufferSize(benchmark::State& state) {
 
     EngineEffectsDelay effectsDelay;
 
-    mixxx::SampleBuffer pInOut(bufferSizeInSamples);
-    SampleUtil::fill(pInOut.data(), 0.0f, bufferSizeInSamples);
+    mixxx::SampleBuffer inOutBuffer(bufferSizeInSamples);
+    SampleUtil::fill(inOutBuffer.data(), 0.0f, bufferSizeInSamples);
 
     effectsDelay.setDelayFrames(delayFrames);
 
     for (auto _ : state) {
-        effectsDelay.process(pInOut.data(), bufferSizeInSamples);
+        effectsDelay.process(inOutBuffer.data(), bufferSizeInSamples);
     }
 }
 BENCHMARK(BM_DelaySmallerThanBufferSize)->Range(64, 4 << 10);
@@ -393,13 +393,13 @@ static void BM_DelayGreaterThanBufferSize(benchmark::State& state) {
 
     EngineEffectsDelay effectsDelay;
 
-    mixxx::SampleBuffer pInOut(bufferSizeInSamples);
-    SampleUtil::fill(pInOut.data(), 0.0f, bufferSizeInSamples);
+    mixxx::SampleBuffer inOutBuffer(bufferSizeInSamples);
+    SampleUtil::fill(inOutBuffer.data(), 0.0f, bufferSizeInSamples);
 
     effectsDelay.setDelayFrames(delayFrames);
 
     for (auto _ : state) {
-        effectsDelay.process(pInOut.data(), bufferSizeInSamples);
+        effectsDelay.process(inOutBuffer.data(), bufferSizeInSamples);
     }
 }
 BENCHMARK(BM_DelayGreaterThanBufferSize)->Range(64, 4 << 10);
@@ -416,14 +416,14 @@ static void BM_DelayCrossfading(benchmark::State& state) {
 
     EngineEffectsDelay effectsDelay;
 
-    mixxx::SampleBuffer pInOut(bufferSizeInSamples);
-    SampleUtil::fill(pInOut.data(), 0.0f, bufferSizeInSamples);
+    mixxx::SampleBuffer inOutBuffer(bufferSizeInSamples);
+    SampleUtil::fill(inOutBuffer.data(), 0.0f, bufferSizeInSamples);
 
     for (auto _ : state) {
         effectsDelay.setDelayFrames(firstDelayFrames);
-        effectsDelay.process(pInOut.data(), bufferSizeInSamples);
+        effectsDelay.process(inOutBuffer.data(), bufferSizeInSamples);
         effectsDelay.setDelayFrames(secondDelayFrames);
-        effectsDelay.process(pInOut.data(), bufferSizeInSamples);
+        effectsDelay.process(inOutBuffer.data(), bufferSizeInSamples);
     }
 }
 BENCHMARK(BM_DelayCrossfading)->Range(64, 4 << 10);
@@ -437,14 +437,14 @@ static void BM_DelayNoCrossfading(benchmark::State& state) {
 
     EngineEffectsDelay effectsDelay;
 
-    mixxx::SampleBuffer pInOut(bufferSizeInSamples);
-    SampleUtil::fill(pInOut.data(), 0.0f, bufferSizeInSamples);
+    mixxx::SampleBuffer inOutBuffer(bufferSizeInSamples);
+    SampleUtil::fill(inOutBuffer.data(), 0.0f, bufferSizeInSamples);
 
     for (auto _ : state) {
         effectsDelay.setDelayFrames(delayFrames);
-        effectsDelay.process(pInOut.data(), bufferSizeInSamples);
+        effectsDelay.process(inOutBuffer.data(), bufferSizeInSamples);
         effectsDelay.setDelayFrames(delayFrames);
-        effectsDelay.process(pInOut.data(), bufferSizeInSamples);
+        effectsDelay.process(inOutBuffer.data(), bufferSizeInSamples);
     }
 }
 BENCHMARK(BM_DelayNoCrossfading)->Range(64, 4 << 10);

--- a/src/util/samplebuffer.h
+++ b/src/util/samplebuffer.h
@@ -92,6 +92,23 @@ class SampleBuffer final {
         return mixxx::spanutil::spanFromPtrLen(m_data, m_size);
     }
 
+    std::span<CSAMPLE> subspan(const SINT offset, const SINT count) {
+        DEBUG_ASSERT((m_data != nullptr) || ((offset == 0) && (count == 0)));
+        DEBUG_ASSERT(0 <= offset);
+        DEBUG_ASSERT(0 <= count);
+        DEBUG_ASSERT(m_size > offset + count);
+
+        return mixxx::spanutil::spanFromPtrLen(m_data + offset, count);
+    }
+    std::span<const CSAMPLE> subspan(const SINT offset, const SINT count) const {
+        DEBUG_ASSERT((m_data != nullptr) || ((offset == 0) && (count == 0)));
+        DEBUG_ASSERT(0 <= offset);
+        DEBUG_ASSERT(0 <= count);
+        DEBUG_ASSERT(m_size > offset + count);
+
+        return mixxx::spanutil::spanFromPtrLen(m_data + offset, count);
+    }
+
     CSAMPLE& operator[](SINT index) noexcept {
         return *data(index);
     }

--- a/src/util/samplebuffer.h
+++ b/src/util/samplebuffer.h
@@ -92,23 +92,6 @@ class SampleBuffer final {
         return mixxx::spanutil::spanFromPtrLen(m_data, m_size);
     }
 
-    std::span<CSAMPLE> subspan(const SINT offset, const SINT count) {
-        DEBUG_ASSERT((m_data != nullptr) || ((offset == 0) && (count == 0)));
-        DEBUG_ASSERT(0 <= offset);
-        DEBUG_ASSERT(0 <= count);
-        DEBUG_ASSERT(m_size > offset + count);
-
-        return mixxx::spanutil::spanFromPtrLen(m_data + offset, count);
-    }
-    std::span<const CSAMPLE> subspan(const SINT offset, const SINT count) const {
-        DEBUG_ASSERT((m_data != nullptr) || ((offset == 0) && (count == 0)));
-        DEBUG_ASSERT(0 <= offset);
-        DEBUG_ASSERT(0 <= count);
-        DEBUG_ASSERT(m_size > offset + count);
-
-        return mixxx::spanutil::spanFromPtrLen(m_data + offset, count);
-    }
-
     CSAMPLE& operator[](SINT index) noexcept {
         return *data(index);
     }


### PR DESCRIPTION
This PR introduces the `RingDelayBuffer` and replaces the previous processing approach. Based on that, the implemented crossfade is replaced with `SampleUtil::linearCrossfadeBuffersOut`. Dependent tests are upgraded because `RingDelayBuffer` uses the fading-in, for the first written chunk of data, and the crossfading is used in stereo mode.