### PR TITLE
Replace Launchpad links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ To get started with Mixxx:
 
 ## Bug tracker
 
-The Mixxx team uses [Launchpad] to manage Mixxx development.
+The Mixxx team uses [Github Issues][issues] to manage Mixxx development.
 
-Have a bug or feature request? [File a bug on Launchpad][fileabug].
+Have a bug or feature request? [File a bug on Github][fileabug].
 
 Want to get involved in Mixxx development? Assign yourself a bug from the [easy
 bug list][easybugs] and get started!
@@ -86,7 +86,8 @@ license.
 [mixxx]: https://mixxx.org
 [download-stable]: https://mixxx.org/download/#stable
 [download-testing]: https://mixxx.org/download/#testing
-[fileabug]: https://bugs.launchpad.net/mixxx/+filebug
+[issues]: https://github.com/mixxxdj/mixxx/issues
+[fileabug]: https://github.com/mixxxdj/mixxx/issues/new
 [twitter]: https://twitter.com/mixxxdj
 [facebook]: https://www.facebook.com/pages/Mixxx-DJ-Software/21723485212
 [blog]: https://mixxx.org/news/
@@ -95,7 +96,7 @@ license.
 [faq]: https://github.com/mixxxdj/mixxx/wiki/Faq
 [visualstudio2019]: https://docs.microsoft.com/visualstudio/install/install-visual-studio?view=vs-2019
 [CMake]: https://cmake.org/
-[easybugs]: https://bugs.launchpad.net/mixxx/+bugs?field.searchtext=&orderby=-importance&search=Search&field.status%3Alist=NEW&field.status%3Alist=CONFIRMED&field.status%3Alist=TRIAGED&field.status%3Alist=INPROGRESS&field.status%3Alist=INCOMPLETE_WITH_RESPONSE&field.status%3Alist=INCOMPLETE_WITHOUT_RESPONSE&assignee_option=any&field.assignee=&field.bug_reporter=&field.bug_commenter=&field.subscriber=&field.structural_subscriber=&field.tag=easy&field.tags_combinator=ANY&field.has_cve.used=&field.omit_dupes.used=&field.omit_dupes=on&field.affects_me.used=&field.has_patch.used=&field.has_branches.used=&field.has_branches=on&field.has_no_branches.used=&field.has_no_branches=on&field.has_blueprints.used=&field.has_blueprints=on&field.has_no_blueprints.used=&field.has_no_blueprints=on
+[easybugs]: https://github.com/mixxxdj/mixxx/issues?q=is%3Aopen+is%3Aissue+label%3Aeasy
 [creating skins]: https://mixxx.org/wiki/doku.php/Creating-Skins
 [help translate content]: https://www.transifex.com/projects/p/mixxxdj
 [Mixxx i18n wiki]: https://github.com/mixxxdj/mixxx/wiki/Internationalization

--- a/packaging/debian/mixxx.sgml
+++ b/packaging/debian/mixxx.sgml
@@ -367,8 +367,8 @@ manpage.1: manpage.sgml
   <refsect1>
     <title>BUGS</title>
     <para>
-      To report a bug or request a feature, go to the &dhpackage; bug tracker:
-      <ulink url="http://bugs.launchpad.net/mixxx"></ulink>
+      To report a bug or request a feature, go to the &dhpackage; bug tracker on Github:
+      <ulink url="https://github.com/mixxxdj/mixxx/issues/new"></ulink>
     </para>
   </refsect1>
 


### PR DESCRIPTION
I replaced dead Launchpad links in `README.md` to the old bug tracker with Github Issues.
BTW (unrelated to this), I think that we can add [issue templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository) for bug reports and feature requests, so users can submit bugs in a more friendly interface, and report easily the Operating System, Mixxx version and hardware configuration using checkboxes and selects. If you think this is good, I can open a draft PR for this. I used this method for an other FOSS software and it's great.