### PR TITLE
Numark DJ2Go2: Fix inverted tempo fader

### DIFF
--- a/res/controllers/Numark_DJ2GO2_Touch_scripts.js
+++ b/res/controllers/Numark_DJ2GO2_Touch_scripts.js
@@ -94,7 +94,8 @@ DJ2GO2Touch.Deck = function(deckNumbers, midiChannel) {
     this.tempoFader = new components.Pot({
         group: "[Channel" + script.deckFromGroup(this.currentDeck) + "]",
         midi: [0xB0 + midiChannel, 0x09],
-        key: "rate"
+        key: "rate",
+        invert: true
     });
 
     this.hotcueButtons = [];


### PR DESCRIPTION
Fix the inverted tempo fader moving issue.
Part of issue #10586 (lp1948596).