### PR TITLE
RingDelayBuffer: fix buffer clearing

### DIFF
--- a/src/util/ringdelaybuffer.cpp
+++ b/src/util/ringdelaybuffer.cpp
@@ -76,8 +76,8 @@ RingDelayBuffer::RingDelayBuffer(SINT bufferSize)
         : m_firstInputChunk(true),
           m_writePos(0),
           m_buffer(bufferSize) {
-    // Set the ring buffer items to 0.
-    m_buffer.fill(0);
+    // Set the ring buffer items to zero.
+    m_buffer.fill(0.0f);
 }
 
 SINT RingDelayBuffer::read(std::span<CSAMPLE> destinationBuffer, const SINT delayItems) {

--- a/src/util/ringdelaybuffer.h
+++ b/src/util/ringdelaybuffer.h
@@ -43,7 +43,7 @@ class RingDelayBuffer final {
         m_firstInputChunk = true;
         m_writePos = 0;
 
-        m_buffer.fill(0);
+        m_buffer.fill(0.0f);
     }
 
     /// The method returns the size of the ring buffer.


### PR DESCRIPTION
This PR fixes the default value for RingDelayBuffer clearing. The previous value 0 is replaced with the CSAMPLE 0.0f zero value. The change should probably fix the failing macOS CI due to rounding error with float for the [#10840](https://github.com/mixxxdj/mixxx/pull/10840).