### PR TITLE
build(cmake): Fix CMake warning regarding extracted archive timestamps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,12 @@ if(POLICY CMP0099)
   cmake_policy(SET CMP0099 NEW)
 endif()
 
+# Set the timestamp of extracted files to the time of the extraction instead of
+# the archived timestamp to make sure that dependent files are rebuilt if the
+# URL changes.
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+endif()
 
 # Set up vcpkg
 if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED VCPKG_ROOT)


### PR DESCRIPTION
Fixes warnings like these for project that were added using the
`ExternalProject` module (i.e. libdjinterop and KeyFinder):

    CMake Warning (dev) at /usr/share/cmake/Modules/ExternalProject.cmake:3071 (message):
      The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
      not set.  The policy's OLD behavior will be used.  When using a URL
      download, the timestamps of extracted files should preferably be that of
      the time of extraction, otherwise code that depends on the extracted
      contents might not be rebuilt if the URL changes.  The OLD behavior
      preserves the timestamps from the archive instead, but this is usually not
      what you want.  Update your project to the NEW behavior or specify the
      DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
      robustness issue.
    Call Stack (most recent call first):
      /usr/share/cmake/Modules/ExternalProject.cmake:4167 (_ep_add_download_command)
      CMakeLists.txt:1949 (ExternalProject_Add)
    This warning is for project developers.  Use -Wno-dev to suppress it.