### PR TITLE
refactor(soundsourceffmpeg): Fix compatibility with FFmpeg 5.1 [WIP]

### DIFF
--- a/src/sources/soundsourceffmpeg.h
+++ b/src/sources/soundsourceffmpeg.h
@@ -174,8 +174,8 @@ class SoundSourceFFmpeg : public SoundSource {
     };
     SwrContextPtr m_pSwrContext;
 
-    uint64_t m_avStreamChannelLayout;
-    uint64_t m_avResampledChannelLayout;
+    AVChannelLayout m_avStreamChannelLayout;
+    AVChannelLayout m_avResampledChannelLayout;
 
     AVPacket* m_pavPacket;
 


### PR DESCRIPTION
Fixes #10856.

**TODO:**
- [ ] Use ifdefs to maintain compatibility with older ffmpeg versions
- [ ] Find bug that causes two tests to segfault:

```
The following tests FAILED:
	697 - SoundSourceProxyTest.seekForwardBackward (SEGFAULT)
	699 - SoundSourceProxyTest.seekBoundaries (SEGFAULT)
```

If someone wants to take over, feel free to do so. I don't know when I'll find the time to continue working on this.