### PR TITLE
PitchShiftEffect: add description comments

### DIFF
--- a/src/effects/backends/builtin/pitchshifteffect.cpp
+++ b/src/effects/backends/builtin/pitchshifteffect.cpp
@@ -158,7 +158,15 @@ void PitchShiftEffect::processChannel(
         pitchParameter = roundToFraction(pitchParameter, kSemitonesPerOctave);
     }
 
-    // Calculate the result pitch setting for the RubberBand.
+    // In equal temperament, all the semitones have the same size (100 cents),
+    // and there are twelve semitones in an octave (1200 cents). As a result,
+    // the notes of an equal-tempered chromatic scale are equally-spaced.
+    // The pitch scaling ratio corresponds to a shift of S equal-tempered
+    // semitones (where S is positive for an upwards shift and negative
+    // for downwards) is pow(2.0, S / 12.0). The pitch scaling ratio
+    // is the ratio of target frequency to source frequency. For example,
+    // a ratio of 2.0 would shift up by one octave, 0.5 down by one octave,
+    // or 1.0 leaving the pitch unaffected.
     const double pitch = std::pow(2.0, pitchParameter);
 
     pState->m_pRubberBand->setPitchScale(pitch);

--- a/src/effects/backends/builtin/pitchshifteffect.cpp
+++ b/src/effects/backends/builtin/pitchshifteffect.cpp
@@ -136,7 +136,6 @@ void PitchShiftEffect::processChannel(
             m_currentFormant != formantPreserving) {
         m_currentFormant = formantPreserving;
 
-        // Set the RubberBand option for the formant preserving.
         pState->m_pRubberBand->setFormantOption(m_currentFormant
                         ? RubberBand::RubberBandStretcher::
                                   OptionFormantPreserved

--- a/src/effects/backends/builtin/pitchshifteffect.cpp
+++ b/src/effects/backends/builtin/pitchshifteffect.cpp
@@ -228,14 +228,11 @@ void PitchShiftEffect::processChannel(
             engineParameters.framesPerBuffer(),
             false);
 
-    // Get the available number of frames
-    // that can be obtained from the RubberBand.
     SINT framesAvailable = pState->m_pRubberBand->available();
     SINT framesToRead = math_min(
             framesAvailable,
             engineParameters.framesPerBuffer());
 
-    // Retrieve frames from RubberBand.
     SINT receivedFrames = pState->m_pRubberBand->retrieve(
             pState->m_retrieveBuffer,
             framesToRead);

--- a/src/effects/backends/builtin/pitchshifteffect.cpp
+++ b/src/effects/backends/builtin/pitchshifteffect.cpp
@@ -198,8 +198,10 @@ void PitchShiftEffect::processChannel(
     // 2. Continuous mode (false) - The Pitch knob changes values continuously,
     //    the same as the RubberBand classic approach.
     if (m_pSemitonesModeParameter->toBool()) {
-        // TODO(davidchocholaty) describe how the rounding to fraction works to
-        //  keep the resulted values in the semitones chromatic scale.
+        // To keep the values in the semitone chromatic scale, the pitch value
+        // must be rounded to a fraction of the scale in one octave. So,
+        // the value has to be rounded to the fraction of the number
+        // of semitones in octave.
         pitchParameter = roundToFraction(pitchParameter, kSemitonesPerOctave);
     }
 


### PR DESCRIPTION
This PR adds the comments, primarily for the usage
of the RubberBand API, for the Pitch shift effect processing.