### PR TITLE
Effects: allow clearing chains with empty '---' preset

### DIFF
--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -356,13 +356,13 @@ void EffectChain::setControlLoadedPresetIndex(uint index) {
 
 void EffectChain::slotControlNextChainPreset(double value) {
     if (value > 0) {
-        loadChainPreset(presetAtIndex(presetIndex() + 1));
+        slotControlChainPresetSelector(1);
     }
 }
 
 void EffectChain::slotControlPrevChainPreset(double value) {
     if (value > 0) {
-        loadChainPreset(presetAtIndex(presetIndex() - 1));
+        slotControlChainPresetSelector(-1);
     }
 }
 

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -177,6 +177,8 @@ void EffectsManager::readEffectsXml() {
     }
     file.close();
 
+    // QuickEffect chains are created only for existing main decks, so read
+    // the configured presets only for those
     QStringList deckStrings;
     for (auto it = m_quickEffectChains.begin(); it != m_quickEffectChains.end(); it++) {
         deckStrings << it.key();

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -177,8 +177,8 @@ void EffectsManager::readEffectsXml() {
     }
     file.close();
 
-    // QuickEffect chains are created only for existing main decks, so read
-    // the configured presets only for those
+    // Note: QuickEffect chains are created only for existing main decks
+    // thus only for those the configured presets are requested
     QStringList deckStrings;
     for (auto it = m_quickEffectChains.begin(); it != m_quickEffectChains.end(); it++) {
         deckStrings << it.key();

--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -88,6 +88,7 @@ class EffectsManager {
 
     QList<StandardEffectChainPointer> m_standardEffectChains;
     OutputEffectChainPointer m_outputEffectChain;
+    // These two store <deck group, effect chain pointer>
     QHash<QString, EqualizerEffectChainPointer> m_equalizerEffectChains;
     QHash<QString, QuickEffectChainPointer> m_quickEffectChains;
 

--- a/src/effects/presets/effectchainpreset.cpp
+++ b/src/effects/presets/effectchainpreset.cpp
@@ -7,7 +7,8 @@
 EffectChainPreset::EffectChainPreset()
         : m_name(kNoEffectString),
           m_mixMode(EffectChainMixMode::DrySlashWet),
-          m_dSuper(0.0) {
+          m_dSuper(0.0),
+          m_readOnly(false) {
 }
 
 EffectChainPreset::EffectChainPreset(const QDomElement& chainElement) {

--- a/src/effects/presets/effectchainpreset.cpp
+++ b/src/effects/presets/effectchainpreset.cpp
@@ -28,6 +28,8 @@ EffectChainPreset::EffectChainPreset(const QDomElement& chainElement) {
 
     m_dSuper = XmlParse::selectNodeDouble(chainElement, EffectXml::kChainSuperParameter);
 
+    m_readOnly = false;
+
     QDomElement effectsElement = XmlParse::selectElement(chainElement, EffectXml::kEffectsRoot);
     QDomNodeList effectList = effectsElement.childNodes();
 

--- a/src/effects/presets/effectchainpreset.h
+++ b/src/effects/presets/effectchainpreset.h
@@ -56,5 +56,5 @@ class EffectChainPreset {
     EffectChainMixMode::Type m_mixMode;
     double m_dSuper;
     QList<EffectPresetPointer> m_effectPresets;
-    bool m_readOnly = false;
+    bool m_readOnly;
 };

--- a/src/effects/presets/effectchainpreset.h
+++ b/src/effects/presets/effectchainpreset.h
@@ -40,6 +40,12 @@ class EffectChainPreset {
     double superKnob() const {
         return m_dSuper;
     }
+    void setReadOnly() {
+        m_readOnly = true;
+    }
+    bool isReadOnly() const {
+        return m_readOnly;
+    }
 
     const QList<EffectPresetPointer>& effectPresets() const {
         return m_effectPresets;
@@ -50,4 +56,5 @@ class EffectChainPreset {
     EffectChainMixMode::Type m_mixMode;
     double m_dSuper;
     QList<EffectPresetPointer> m_effectPresets;
+    bool m_readOnly = false;
 };

--- a/src/effects/presets/effectchainpresetmanager.cpp
+++ b/src/effects/presets/effectchainpresetmanager.cpp
@@ -389,8 +389,24 @@ void EffectChainPresetManager::setQuickEffectPresetOrder(
         m_quickEffectChainPresetsSorted.append(
                 m_effectChainPresets.value(chainPresetName));
     }
+    prependEmptyPreset(m_quickEffectChainPresetsSorted);
 
     emit quickEffectChainPresetListUpdated();
+}
+
+void EffectChainPresetManager::prependEmptyPreset(
+        QList<EffectChainPresetPointer>& pPresetList) const {
+    // Ensure empty '---' preset is the first list item
+    const auto& pEmptyPreset = m_effectChainPresets.value(kNoEffectString);
+    VERIFY_OR_DEBUG_ASSERT(pEmptyPreset) {
+        return;
+    }
+    int index = pPresetList.indexOf(pEmptyPreset);
+    if (index == -1) { // not in list, re-add it
+        pPresetList.prepend(pEmptyPreset);
+    } else if (index != 0) { // not first item, move to top
+        pPresetList.move(index, 0);
+    }
 }
 
 void EffectChainPresetManager::savePresetAndReload(EffectChainPointer pChainSlot) {

--- a/src/effects/presets/effectchainpresetmanager.cpp
+++ b/src/effects/presets/effectchainpresetmanager.cpp
@@ -591,7 +591,7 @@ EffectsXmlData EffectChainPresetManager::readEffectsXml(
         quickEffectPresets.insert(deckString, defaultQuickEffectChainPreset);
     }
 
-    // Reload state of standard chains
+    // Read state of standard chains
     QDomElement root = doc.documentElement();
     QDomElement rackElement = XmlParse::selectElement(root, EffectXml::kRack);
     QDomElement chainsElement =
@@ -671,7 +671,7 @@ EffectsXmlData EffectChainPresetManager::readEffectsXml(
     emit effectChainPresetListUpdated();
     emit quickEffectChainPresetListUpdated();
 
-    // Reload presets that were loaded into QuickEffects on last shutdown
+    // Read names of presets that were loaded into QuickEffects on last shutdown
     QDomElement quickEffectPresetsElement =
             XmlParse::selectElement(root, EffectXml::kQuickEffectChainPresets);
     QDomNodeList quickEffectNodeList =
@@ -683,6 +683,8 @@ EffectsXmlData EffectChainPresetManager::readEffectsXml(
             QString deckGroup = presetNameElement.attribute(QStringLiteral("group"));
             auto pPreset = m_effectChainPresets.value(presetNameElement.text());
             if (pPreset != nullptr) {
+                // Replace defaultQuickEffectChainPreset with pPreset
+                // for this deck group
                 quickEffectPresets.insert(deckGroup, pPreset);
             }
         }

--- a/src/effects/presets/effectchainpresetmanager.cpp
+++ b/src/effects/presets/effectchainpresetmanager.cpp
@@ -389,24 +389,20 @@ void EffectChainPresetManager::setQuickEffectPresetOrder(
         m_quickEffectChainPresetsSorted.append(
                 m_effectChainPresets.value(chainPresetName));
     }
-    prependEmptyPreset(m_quickEffectChainPresetsSorted);
 
-    emit quickEffectChainPresetListUpdated();
-}
-
-void EffectChainPresetManager::prependEmptyPreset(
-        QList<EffectChainPresetPointer>& pPresetList) const {
     // Ensure empty '---' preset is the first list item
     const auto& pEmptyPreset = m_effectChainPresets.value(kNoEffectString);
     VERIFY_OR_DEBUG_ASSERT(pEmptyPreset) {
         return;
     }
-    int index = pPresetList.indexOf(pEmptyPreset);
+    int index = m_quickEffectChainPresetsSorted.indexOf(pEmptyPreset);
     if (index == -1) { // not in list, re-add it
-        pPresetList.prepend(pEmptyPreset);
+        m_quickEffectChainPresetsSorted.prepend(pEmptyPreset);
     } else if (index != 0) { // not first item, move to top
-        pPresetList.move(index, 0);
+        m_quickEffectChainPresetsSorted.move(index, 0);
     }
+
+    emit quickEffectChainPresetListUpdated();
 }
 
 void EffectChainPresetManager::savePresetAndReload(EffectChainPointer pChainSlot) {

--- a/src/effects/presets/effectchainpresetmanager.cpp
+++ b/src/effects/presets/effectchainpresetmanager.cpp
@@ -126,12 +126,12 @@ void EffectChainPresetManager::importPreset() {
             // Don't allow '---' because that's the name of the internal empty preset
             if (pPreset->name() == kNoEffectString) {
                 pPreset->setName(pPreset->name() +
-                        QLatin1String(" (") + tr("imported") + QLatin1String(")"));
+                        QStringLiteral(" (") + tr("imported") + QStringLiteral(")"));
             }
 
             while (m_effectChainPresets.contains(pPreset->name())) {
                 pPreset->setName(pPreset->name() +
-                        QLatin1String(" (") + tr("duplicate") + QLatin1String(")"));
+                        QStringLiteral(" (") + tr("duplicate") + QStringLiteral(")"));
             }
 
             // An imported chain preset might contain an LV2 plugin that the user does not

--- a/src/effects/presets/effectchainpresetmanager.h
+++ b/src/effects/presets/effectchainpresetmanager.h
@@ -60,7 +60,6 @@ class EffectChainPresetManager : public QObject {
 
     void setPresetOrder(const QStringList& chainPresetList);
     void setQuickEffectPresetOrder(const QStringList& chainPresetList);
-    void prependEmptyPreset(QList<EffectChainPresetPointer>& pPresetList) const;
 
     EffectChainPresetPointer getPreset(const QString& name) const {
         return m_effectChainPresets.value(name);

--- a/src/effects/presets/effectchainpresetmanager.h
+++ b/src/effects/presets/effectchainpresetmanager.h
@@ -60,6 +60,7 @@ class EffectChainPresetManager : public QObject {
 
     void setPresetOrder(const QStringList& chainPresetList);
     void setQuickEffectPresetOrder(const QStringList& chainPresetList);
+    void prependEmptyPreset(QList<EffectChainPresetPointer>& pPresetList) const;
 
     EffectChainPresetPointer getPreset(const QString& name) const {
         return m_effectChainPresets.value(name);

--- a/src/preferences/dialog/dlgprefeffects.cpp
+++ b/src/preferences/dialog/dlgprefeffects.cpp
@@ -170,6 +170,12 @@ void DlgPrefEffects::loadChainPresetLists() {
 
     QStringList quickEffectChainPresetNames;
     for (const auto& pChainPreset : m_pChainPresetManager->getQuickEffectPresetsSorted()) {
+        // Don't show the empty '---' preset.
+        // After pushing the changed preferences list back to the preset manager
+        // it is re-added to the root list.
+        if (pChainPreset->name() == kNoEffectString) {
+            continue;
+        }
         quickEffectChainPresetNames << pChainPreset->name();
     }
     pModel = dynamic_cast<EffectChainPresetListModel*>(quickEffectListView->model());

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -302,10 +302,7 @@ void DlgPrefEQ::populateDeckQuickEffectBoxList(
         QString deckGroupName = PlayerManager::groupForDeck(deck);
         QString unitGroup = QuickEffectChain::formatEffectChainGroup(deckGroupName);
         EffectChainPointer pChain = m_pEffectsManager->getEffectChain(unitGroup);
-
-        // Add empty item at the top: no effect
-        box->addItem(kNoEffectString);
-        int i = 1;
+        int i = 0;
         for (const auto& pChainPreset : presetList) {
             box->addItem(pChainPreset->name());
             if (pChain->presetName() == pChainPreset->name()) {
@@ -492,8 +489,8 @@ void DlgPrefEQ::slotQuickEffectChangedOnDeck(int effectIndex) {
     EffectChainPointer pChain = m_pEffectsManager->getEffectChain(unitGroup);
     QList<EffectChainPresetPointer> presetList =
             m_pChainPresetManager->getQuickEffectPresetsSorted();
-    if (pChain && effectIndex > 0 && effectIndex <= presetList.size()) {
-        pChain->loadChainPreset(presetList[effectIndex - 1]);
+    if (pChain && effectIndex >= 0 && effectIndex < presetList.size()) {
+        pChain->loadChainPreset(presetList[effectIndex]);
     }
 }
 

--- a/src/widget/weffectchainpresetbutton.cpp
+++ b/src/widget/weffectchainpresetbutton.cpp
@@ -46,20 +46,23 @@ void WEffectChainPresetButton::populateMenu() {
     m_pMenu->clear();
 
     // Chain preset items
-    bool chainIsPreset = false;
+    bool allowUpdatingPreset = false;
     for (const auto& pChainPreset : m_pChainPresetManager->getPresetsSorted()) {
         QString title = pChainPreset->name();
         if (title == m_pChain->presetName()) {
             title = QChar(0x2713) + // CHECK MARK
                     QChar(' ') + title;
-            chainIsPreset = true;
+            allowUpdatingPreset = !pChainPreset->isReadOnly();
         }
         m_pMenu->addAction(title, this, [this, pChainPreset]() {
             m_pChain->loadChainPreset(pChainPreset);
         });
     }
     m_pMenu->addSeparator();
-    if (chainIsPreset) {
+    // This prevents showing the Update button for the empty '---' preset, in case
+    // WEffectChainPresetButton and effect slot controls of a QuickEffect chain are
+    // exposed in a custom skin.
+    if (allowUpdatingPreset) {
         m_pMenu->addAction(tr("Update Preset"), this, [this]() {
             m_pChainPresetManager->updatePreset(m_pChain);
         });

--- a/src/widget/weffectchainpresetbutton.cpp
+++ b/src/widget/weffectchainpresetbutton.cpp
@@ -46,13 +46,13 @@ void WEffectChainPresetButton::populateMenu() {
     m_pMenu->clear();
 
     // Chain preset items
-    bool allowUpdatingPreset = false;
+    bool presetIsReadOnly = true;
     for (const auto& pChainPreset : m_pChainPresetManager->getPresetsSorted()) {
         QString title = pChainPreset->name();
         if (title == m_pChain->presetName()) {
             title = QChar(0x2713) + // CHECK MARK
                     QChar(' ') + title;
-            allowUpdatingPreset = !pChainPreset->isReadOnly();
+            presetIsReadOnly = pChainPreset->isReadOnly();
         }
         m_pMenu->addAction(title, this, [this, pChainPreset]() {
             m_pChain->loadChainPreset(pChainPreset);
@@ -62,7 +62,7 @@ void WEffectChainPresetButton::populateMenu() {
     // This prevents showing the Update button for the empty '---' preset, in case
     // WEffectChainPresetButton and effect slot controls of a QuickEffect chain are
     // exposed in a custom skin.
-    if (allowUpdatingPreset) {
+    if (!presetIsReadOnly) {
         m_pMenu->addAction(tr("Update Preset"), this, [this]() {
             m_pChainPresetManager->updatePreset(m_pChain);
         });

--- a/src/widget/weffectchainpresetselector.cpp
+++ b/src/widget/weffectchainpresetselector.cpp
@@ -84,7 +84,6 @@ void WEffectChainPresetSelector::populate() {
 }
 
 void WEffectChainPresetSelector::slotEffectChainPresetSelected(int index) {
-    Q_UNUSED(index);
     m_pChain->loadChainPreset(
             m_pChainPresetManager->getPreset(currentData().toString()));
     setBaseTooltip(itemData(index, Qt::ToolTipRole).toString());
@@ -97,7 +96,7 @@ void WEffectChainPresetSelector::slotEffectChainPresetSelected(int index) {
 
 void WEffectChainPresetSelector::slotChainPresetChanged(const QString& name) {
     setCurrentIndex(findData(name));
-    setBaseTooltip(name);
+    setBaseTooltip(itemData(currentIndex(), Qt::ToolTipRole).toString());
 }
 
 bool WEffectChainPresetSelector::event(QEvent* pEvent) {

--- a/src/widget/weffectchainpresetselector.cpp
+++ b/src/widget/weffectchainpresetselector.cpp
@@ -36,7 +36,7 @@ void WEffectChainPresetSelector::setup(const QDomNode& node, const SkinContext& 
     }
 
     auto chainPresetListUpdateSignal = &EffectChainPresetManager::effectChainPresetListUpdated;
-    auto pQuickEffectChain = dynamic_cast<QuickEffectChain*>(m_pChain.data());
+    auto pQuickEffectChain = qobject_cast<QuickEffectChain*>(m_pChain.data());
     if (pQuickEffectChain) {
         chainPresetListUpdateSignal = &EffectChainPresetManager::quickEffectChainPresetListUpdated;
         m_bQuickEffectChain = true;

--- a/src/widget/weffectchainpresetselector.cpp
+++ b/src/widget/weffectchainpresetselector.cpp
@@ -86,9 +86,6 @@ void WEffectChainPresetSelector::populate() {
 void WEffectChainPresetSelector::slotEffectChainPresetSelected(int index) {
     m_pChain->loadChainPreset(
             m_pChainPresetManager->getPreset(currentData().toString()));
-    // TODO(ronso0) Clean up. This is set again in slotChainPresetChanged
-    // after the new preset was actually loaded.
-    setBaseTooltip(itemData(index, Qt::ToolTipRole).toString());
     // After selecting an effect move focus to the tracks table in order
     // to immediately allow keyboard shortcuts again.
     // TODO(ronso0) switch to previously focused (library?) widget instead

--- a/src/widget/weffectchainpresetselector.cpp
+++ b/src/widget/weffectchainpresetselector.cpp
@@ -86,6 +86,8 @@ void WEffectChainPresetSelector::populate() {
 void WEffectChainPresetSelector::slotEffectChainPresetSelected(int index) {
     m_pChain->loadChainPreset(
             m_pChainPresetManager->getPreset(currentData().toString()));
+    // TODO(ronso0) Clean up. This is set again in slotChainPresetChanged
+    // after the new preset was actually loaded.
     setBaseTooltip(itemData(index, Qt::ToolTipRole).toString());
     // After selecting an effect move focus to the tracks table in order
     // to immediately allow keyboard shortcuts again.


### PR DESCRIPTION
Alternative to #4892 
This implementation works ~~without hacks~~ only minor adjustments in the GUI counterparts (EQ / effects preferences, skins).

An empty preset named  `---` is created by `EffectChainPresetManager` on each start.
* it is added at the top of the common chain preset list and the QuickEffect preset list
* it is shown in the chain preset selectors in Preferences > EQ & `WEffectChainPresetSelector`
* it is **hidden** from the preset lists in Preferences > Effects to avoid manipulation
when those lists are changed they are pushed back to `EffectChainPrestManager` to update the lists in effect widgets, `---` is missing and needs to be re-added to the standard and QuickEffect preset lists
* it is **not** saved to `[settings_dir]/effects/chains`
* `---` is not accepted as preset name when saving or importing chain presets to avoid conflicts
* `---` can be selected with `[fx chain], chain_preset_selector` and `.., next/prev_chain_preset`
* `loaded_chain_preset` called with `0` will now clear the chain

**Update:**
`---` is only added to the QuickEffect chain presets list to avoid a few incosistencies with standard chains.

~~When picked in **standard chains**' preset selectors, [EffectChain::loadChainPreset](https://github.com/mixxxdj/mixxx/pull/10859/files#diff-fa28becfc988b55ba9c54ec2aee6524f22af4a27efb9a4d18a2a9fe121ddab35R219-R230) will clear the name (more details in https://github.com/mixxxdj/mixxx/pull/10859#discussion_r962314889), so~~
* ~~`chainPresetChanged()` signal will clear the selector combobox (index = -1) and the selection in the chain preset menu~~
* ~~the empty preset can not be overwritten via 'Update Preset' in the `WEffectChainPresetButton` menu~~
* ~~it is **not** stored as preset name for standard effect chains in `effects.xml`~~

When picked in **QuickEffect chains**' preset selectors or in Preferences > Equalizer, the name `---` persists
* `---` remains selected in preset selectors to signal the current chain is empty (and will remain empty because there's no (skin) interface to load effects into chain slots)
* it is used as preset identifier for QuickEffect chains in `effects.xml`:
    ```
     <QuickEffectChains>
      <ChainPresetName group="[Channel1]">Echo</ChainPresetName>
      <ChainPresetName group="[Channel2]">---</ChainPresetName>
      <ChainPresetName group="[Channel3]">Filter</ChainPresetName>
      <ChainPresetName group="[Channel4]">Filter</ChainPresetName>
     </QuickEffectChains>
    ```
    which is valid to restore the empty preset when Mixxx is started