### PR TITLE
BaseSqlTableModel: remove duplicated line.

### DIFF
--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -142,9 +142,6 @@ void BaseSqlTableModel::initSortColumnMapping() {
     m_columnIndexBySortColumnId[static_cast<int>(
             TrackModel::SortColumnId::SampleRate)] =
             fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_SAMPLERATE);
-    m_columnIndexBySortColumnId[static_cast<int>(
-            TrackModel::SortColumnId::LastPlayedAt)] =
-            fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_LAST_PLAYED_AT);
 
     m_sortColumnIdByColumnIndex.clear();
     for (int i = static_cast<int>(TrackModel::SortColumnId::IdMin);


### PR DESCRIPTION
While I was working on the track suggestion feature, I was looking at the code base for sorting the tracks. I realized that there is a duplicated line on `basesqltablemodel.cpp`. The same block of code can be found [here.](https://github.com/mixxxdj/mixxx/blob/6fbc27d653772b438c41c41015af010a00eca6b2/src/library/basesqltablemodel.cpp#L124-L126)