### PR TITLE
Add Issue Forms

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -4,3 +4,4 @@ InOut
 copyable
 sord
 doubleClick
+Sur

--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,31 @@
+name: 🐛 Bug Report
+description: |
+  Describe your problem here.
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version of Mixxx are you running?
+  - type: dropdown
+    id: os
+    attributes:
+      label: OS
+      description: What operating system are you running?
+      options:
+        - MacOS
+        - Windows
+        - Linux

--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -11,8 +11,7 @@ body:
     id: description
     attributes:
       label: Bug Description
-      description: Also tell us, what did you expect to happen?
-      placeholder: Tell us what you see!
+      description: Tell us what happens and what should happen instead.
     validations:
       required: true
   - type: input
@@ -20,12 +19,9 @@ body:
     attributes:
       label: Version
       description: What version of Mixxx are you running?
-  - type: dropdown
+  - type: input
     id: os
     attributes:
       label: OS
-      description: What operating system are you running?
-      options:
-        - MacOS
-        - Windows
-        - Linux
+      description: What operating system (and distribution if you're on Linux) are you running?
+      placeholder: Windows 11, macOS Big Sur, Ubuntu 22.04, ...

--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -19,6 +19,7 @@ body:
     attributes:
       label: Version
       description: What version of Mixxx are you running?
+      placeholder: 2.3.4, 2.4.0, ...
   - type: input
     id: os
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🤔 Question
+    url: https://mixxx.org/forums
+    about: Please use our forums for questions

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: 🤔 Question
     url: https://mixxx.org/forums

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,6 +1,6 @@
 name: 🚀 Feature Request
 description: |
-  Describe the requested feature here.
+  Describe describe your use-case, not yet supported and a possible solution.
 labels: [feature]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,6 +1,6 @@
 name: 🚀 Feature Request
 description: |
-  Describe describe your use-case, not yet supported and a possible solution.
+  What feature would you like to see added to Mixxx?
 labels: [feature]
 body:
   - type: markdown
@@ -11,6 +11,6 @@ body:
     id: description
     attributes:
       label: Feature Description
-      description: What feature would you like to see added to Mixxx?
+      description: Describe describe your use-case, not yet supported and a possible solution.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,16 @@
+name: 🚀 Feature Request
+description: |
+  Describe the requested feature here.
+labels: [feature]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest a new feature!
+  - type: textarea
+    id: description
+    attributes:
+      label: Feature Description
+      description: What feature would you like to see added to Mixxx?
+    validations:
+      required: true


### PR DESCRIPTION
As discussed on Zulip, I added issue forms (issue templates but with defined input types and with better UI for the user) for bug reports and feature requests.
As requested, the only required input is the description.
If you want to try this, check [this example repo](https://github.com/MatteoGheza/mixxx-issue-templates-PoC/issues/new/choose).