### PR TITLE
Cleanup: Require FFmpeg v4.1.9 or later

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2375,29 +2375,30 @@ elseif(WIN32)
   endif()
 endif()
 
-# FFmpeg 4.x support
+# FFmpeg support
 # FFmpeg is multimedia library that can be found http://ffmpeg.org/
 find_package(FFMPEG COMPONENTS libavcodec libavformat libavutil libswresample)
-default_option(FFMPEG "FFmpeg 4.x support" "FFMPEG_FOUND")
+default_option(FFMPEG "FFmpeg support (version 4.1.9 or later)" "FFMPEG_FOUND")
 if(FFMPEG)
   if(NOT FFMPEG_FOUND)
     message(FATAL_ERROR "FFMPEG was not found")
   endif()
 
   # Check minimum required versions
+  # Minimum library versions according to <https://ffmpeg.org/download.html>
   # Windows: Version numbers are not available!?
   # macOS: Untested
-  if(FFMPEG_libavcodec_VERSION AND FFMPEG_libavcodec_VERSION VERSION_LESS 58)
-    message(FATAL_ERROR "FFmpeg support requires at least version 58 of libavcodec (found: ${FFMPEG_libavcodec_VERSION}).")
+  if(FFMPEG_libavcodec_VERSION AND FFMPEG_libavcodec_VERSION VERSION_LESS 58.35.100)
+    message(FATAL_ERROR "FFmpeg support requires at least version 58.35.100 of libavcodec (found: ${FFMPEG_libavcodec_VERSION}).")
   endif()
-  if(FFMPEG_libavformat_VERSION AND FFMPEG_libavformat_VERSION VERSION_LESS 58)
-    message(FATAL_ERROR "FFmpeg support requires at least version 58 of libavformat (found: ${FFMPEG_libavformat_VERSION}).")
+  if(FFMPEG_libavformat_VERSION AND FFMPEG_libavformat_VERSION VERSION_LESS 58.20.100)
+    message(FATAL_ERROR "FFmpeg support requires at least version 58.20.100 of libavformat (found: ${FFMPEG_libavformat_VERSION}).")
   endif()
-  if(FFMPEG_libavutil_VERSION AND FFMPEG_libavutil_VERSION VERSION_LESS 56)
-    message(FATAL_ERROR "FFmpeg support requires at least version 56 of libavutil (found: ${FFMPEG_libavutil_VERSION}).")
+  if(FFMPEG_libavutil_VERSION AND FFMPEG_libavutil_VERSION VERSION_LESS 56.22.100)
+    message(FATAL_ERROR "FFmpeg support requires at least version 56.22.100 of libavutil (found: ${FFMPEG_libavutil_VERSION}).")
   endif()
-  if(FFMPEG_libswresample_VERSION AND FFMPEG_libswresample_VERSION VERSION_LESS 3.1)
-    message(FATAL_ERROR "FFmpeg support requires at least version 3.1 of libswresample (found: ${FFMPEG_libswresample_VERSION}).")
+  if(FFMPEG_libswresample_VERSION AND FFMPEG_libswresample_VERSION VERSION_LESS 3.3.100)
+    message(FATAL_ERROR "FFmpeg support requires at least version 3.3.100 of libswresample (found: ${FFMPEG_libswresample_VERSION}).")
   endif()
 
   target_sources(mixxx-lib PRIVATE src/sources/soundsourceffmpeg.cpp)

--- a/src/encoder/encoderffmpegcore.cpp
+++ b/src/encoder/encoderffmpegcore.cpp
@@ -450,11 +450,7 @@ int EncoderFfmpegCore::openAudio(AVCodec *codec, AVStream *stream) {
         return -1;
     }
 
-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 89, 100)
     if (l_SCodecCtx->codec->capabilities & AV_CODEC_CAP_VARIABLE_FRAME_SIZE) {
-#else
-    if (l_SCodecCtx->codec->capabilities & CODEC_CAP_VARIABLE_FRAME_SIZE) {
-#endif
         m_iAudioInputFrameSize = 10000;
     } else {
         m_iAudioInputFrameSize = l_SCodecCtx->frame_size;
@@ -531,11 +527,7 @@ AVStream *EncoderFfmpegCore::addStream(AVFormatContext *formatctx,
 
     // Some formats want stream headers to be separate.
     if (formatctx->oformat->flags & AVFMT_GLOBALHEADER) {
-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 89, 100)
         l_SCodecCtx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
-#else
-        l_SCodecCtx->flags |= CODEC_FLAG_GLOBAL_HEADER;
-#endif
     }
 
     return l_SStream;

--- a/src/sources/soundsourceffmpeg.h
+++ b/src/sources/soundsourceffmpeg.h
@@ -196,7 +196,7 @@ class SoundSourceProviderFFmpeg : public SoundSourceProvider {
   public:
     static const QString kDisplayName;
 
-    SoundSourceProviderFFmpeg();
+    ~SoundSourceProviderFFmpeg() override = default;
 
     QString getDisplayName() const override {
         return kDisplayName;


### PR DESCRIPTION
- Require FFmpeg v4.1.9 as the minimum version
- Consistently use AV_VERSION_INT >= minimum_version
- Delete dead code