### PR TITLE
workaround qt 5.12 bug for simulated rightbutton mouse events

### DIFF
--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -127,8 +127,7 @@ bool MixxxApplication::notify(QObject* target, QEvent* event) {
             // assigned to the event's mouseState for simulated rightbutton press events
             // (using ctrl+leftbotton), which results in a missing release event for that
             // press event.
-            QMouseEventEditable* editEvent = static_cast<QMouseEventEditable*>(event);
-            editEvent->setButtons(Qt::RightButton);
+            mouseEvent->setButtons(Qt::RightButton);
         }
         break;
     }

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -47,11 +47,13 @@ class QMouseEventEditable : public QMouseEvent {
     void setButton(Qt::MouseButton button) {
         b = button;
     }
+#if QT_VERSION <= QT_VERSION_CHECK(5, 12, 4) && defined(__APPLE__)
     // We also use this class to modify erroneous mouseState. See
     // MixxxApplication::notify(...) for details.
     void setButtons(Qt::MouseButtons mouseState) {
         this->mouseState = mouseState;
     }
+#endif
 };
 
 } // anonymous namespace
@@ -122,13 +124,18 @@ bool MixxxApplication::notify(QObject* target, QEvent* event) {
             mouseEvent->setButton(Qt::RightButton);
             m_rightPressedButtons++;
         }
+#if QT_VERSION <= QT_VERSION_CHECK(5, 12, 4) && defined(__APPLE__)
         if (mouseEvent->button() == Qt::RightButton && mouseEvent->buttons() == Qt::LeftButton) {
             // Workaround for a bug in Qt 5.12 qnsview_mouse.mm, where the wrong value is
             // assigned to the event's mouseState for simulated rightbutton press events
             // (using ctrl+leftbotton), which results in a missing release event for that
             // press event.
+            //
+            // Fixed in Qt 5.12.5. See
+            // https://github.com/qt/qtbase/commit/9a47768b46f5e5eed407b70dfa9183fa1d21e242
             mouseEvent->setButtons(Qt::RightButton);
         }
+#endif
         break;
     }
     case QEvent::MouseButtonRelease: {


### PR DESCRIPTION
Qt 5.12.3 has a bug which results in missing mouse button release events for simulated right clicks (ctrl+left click). Details of the exact bug can be found here: https://mixxx.zulipchat.com/#narrow/stream/109171-development ; see comments about the call to QApplicationPrivate::pickMouseReceiver from QWidgetWindow and the call to  QWindowSystemInterface::handleMouseEvent from qnsview_mouse.mm

Fixing this with a patched Qt 5.12.3 would be desirable, but this workaround allows continuing with the existing build-env for 2.3, by correcting the event when it is handled by MixxxApplication::notify(...), effectively having the same result.