### PR TITLE
Fetch metadata from MusicBrainz with adaptive rate limiting

### DIFF
--- a/src/musicbrainz/web/musicbrainzrecordingstask.cpp
+++ b/src/musicbrainz/web/musicbrainzrecordingstask.cpp
@@ -26,6 +26,9 @@ const QString kRequestPath = QStringLiteral("/ws/2/recording/");
 
 const QByteArray kUserAgentRawHeaderKey = "User-Agent";
 
+// MusicBrainz allows only a single request per second
+constexpr int kRateLimitMillis = 1000;
+
 QString userAgentRawHeaderValue() {
     return VersionStore::applicationName() +
             QStringLiteral("/") +
@@ -167,7 +170,7 @@ void MusicBrainzRecordingsTask::doNetworkReplyFinished(
 
     // Continue with next recording id
     DEBUG_ASSERT(!m_queuedRecordingIds.isEmpty());
-    slotStart(m_parentTimeoutMillis);
+    slotStart(m_parentTimeoutMillis, kRateLimitMillis);
 }
 
 void MusicBrainzRecordingsTask::emitSucceeded(

--- a/src/musicbrainz/web/musicbrainzrecordingstask.cpp
+++ b/src/musicbrainz/web/musicbrainzrecordingstask.cpp
@@ -26,8 +26,10 @@ const QString kRequestPath = QStringLiteral("/ws/2/recording/");
 
 const QByteArray kUserAgentRawHeaderKey = "User-Agent";
 
-// MusicBrainz allows only a single request per second
-constexpr int kRateLimitMillis = 1000;
+// MusicBrainz allows only a single request per second on average
+// to avoid rate limiting.
+// See: <https://musicbrainz.org/doc/MusicBrainz_API/Rate_Limiting>
+constexpr Duration kMinDurationBetweenRequests = Duration::fromMillis(1000);
 
 QString userAgentRawHeaderValue() {
     return VersionStore::applicationName() +
@@ -104,6 +106,7 @@ QNetworkReply* MusicBrainzRecordingsTask::doStartNetworkRequest(
                 << "GET"
                 << networkRequest.url();
     }
+    m_lastRequestSentAt.start();
     return networkAccessManager->get(networkRequest);
 }
 
@@ -170,7 +173,15 @@ void MusicBrainzRecordingsTask::doNetworkReplyFinished(
 
     // Continue with next recording id
     DEBUG_ASSERT(!m_queuedRecordingIds.isEmpty());
-    slotStart(m_parentTimeoutMillis, kRateLimitMillis);
+
+    // Ensure that at least kMinDurationBetweenRequests has passed
+    // since the last request before starting the next request.
+    // This is achieved by adjusting the start delay adaptively.
+    const Duration elapsedSinceLastRequestSent = m_lastRequestSentAt.elapsed();
+    const Duration delayBeforeNextRequest =
+            kMinDurationBetweenRequests -
+            std::min(kMinDurationBetweenRequests, elapsedSinceLastRequestSent);
+    slotStart(m_parentTimeoutMillis, delayBeforeNextRequest.toIntegerMillis());
 }
 
 void MusicBrainzRecordingsTask::emitSucceeded(

--- a/src/musicbrainz/web/musicbrainzrecordingstask.h
+++ b/src/musicbrainz/web/musicbrainzrecordingstask.h
@@ -8,6 +8,7 @@
 
 #include "musicbrainz/musicbrainz.h"
 #include "network/webtask.h"
+#include "util/performancetimer.h"
 
 namespace mixxx {
 
@@ -50,6 +51,8 @@ class MusicBrainzRecordingsTask : public network::WebTask {
     QSet<QUuid> m_finishedRecordingIds;
 
     QMap<QUuid, musicbrainz::TrackRelease> m_trackReleases;
+
+    PerformanceTimer m_lastRequestSentAt;
 
     int m_parentTimeoutMillis;
 };

--- a/src/musicbrainz/web/musicbrainzrecordingstask.h
+++ b/src/musicbrainz/web/musicbrainzrecordingstask.h
@@ -44,8 +44,6 @@ class MusicBrainzRecordingsTask : public network::WebTask {
             int errorCode,
             const QString& errorMessage);
 
-    void continueWithNextRequest();
-
     const QUrlQuery m_urlQuery;
 
     QList<QUuid> m_queuedRecordingIds;

--- a/src/network/networktask.cpp
+++ b/src/network/networktask.cpp
@@ -31,16 +31,17 @@ NetworkTask::~NetworkTask() {
     s_instanceCounter.increment(-1);
 }
 
-void NetworkTask::invokeStart(int timeoutMillis) {
+void NetworkTask::invokeStart(int timeoutMillis, int delayMillis) {
     QMetaObject::invokeMethod(
             this,
 #if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
             "slotStart",
             Qt::AutoConnection,
-            Q_ARG(int, timeoutMillis)
+            Q_ARG(int, timeoutMillis),
+            Q_ARG(int, delayMillis)
 #else
-            [this, timeoutMillis] {
-                this->slotStart(timeoutMillis);
+            [this, timeoutMillis, delayMillis] {
+                this->slotStart(timeoutMillis, delayMillis);
             }
 #endif
     );

--- a/src/network/networktask.h
+++ b/src/network/networktask.h
@@ -59,15 +59,20 @@ class NetworkTask : public QObject {
 
   public:
     static constexpr int kNoTimeout = 0;
+    static constexpr int kNoStartDelay = 0;
 
     /// Start a new task by sending a network request.
     ///
     /// timeoutMillis <= 0: No timeout (unlimited)
-    /// timeoutMillis > 0: Implicitly aborted after timeout expired
+    /// timeoutMillis > 0:  Implicitly aborted after timeout expired
+    ///
+    /// delayMillis <= 0: Send request immediately
+    /// delayMillis > 0:  Send request after a delay, e.g. for rate limiting subsequent requests
     ///
     /// This function is thread-safe and could be invoked from any thread.
     void invokeStart(
-            int timeoutMillis = kNoTimeout);
+            int timeoutMillis = kNoTimeout,
+            int delayMillis = kNoStartDelay);
 
     /// Cancel the task by aborting the pending network request.
     ///
@@ -75,8 +80,11 @@ class NetworkTask : public QObject {
     void invokeAbort();
 
   public slots:
+    /// See also: invokeStart()
     virtual void slotStart(
-            int timeoutMillis) = 0;
+            int timeoutMillis = kNoTimeout,
+            int delayMillis = kNoStartDelay) = 0;
+    /// See also: invokeAbort()
     virtual void slotAbort() = 0;
 
   signals:

--- a/src/network/webtask.cpp
+++ b/src/network/webtask.cpp
@@ -114,7 +114,8 @@ WebTask::WebTask(
         QObject* parent)
         : NetworkTask(networkAccessManager, parent),
           m_state(State::Idle),
-          m_timeoutTimerId(kInvalidTimerId) {
+          m_timeoutTimerId(kInvalidTimerId),
+          m_timeoutMillis(kNoTimeout) {
     std::call_once(registerMetaTypesOnceFlag, registerMetaTypesOnce);
 }
 
@@ -171,9 +172,9 @@ void WebTask::emitNetworkError(
             responseWithContent);
 }
 
-void WebTask::slotStart(int timeoutMillis) {
+void WebTask::slotStart(int timeoutMillis, int delayMillis) {
     DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
-    if (m_state == State::Pending) {
+    if (isBusy()) {
         kLogger.warning()
                 << "Task is still busy and cannot be started again";
         return;
@@ -183,6 +184,24 @@ void WebTask::slotStart(int timeoutMillis) {
     DEBUG_ASSERT(!m_pendingNetworkReplyWeakPtr);
     DEBUG_ASSERT(m_timeoutTimerId == kInvalidTimerId);
     m_state = State::Idle;
+    m_timeoutMillis = kNoTimeout;
+
+    if (delayMillis > 0) {
+        m_state = State::Starting;
+        kLogger.debug()
+                << this
+                << "Scheduling next request after" << delayMillis << "ms";
+        DEBUG_ASSERT(m_timeoutTimerId == kInvalidTimerId);
+        // When the task is is starting/delayed, the timeoutTimer
+        // is used for scheduling the request that should happen
+        // after the delay. Afterwards, the timemoutTimer is used for
+        // the actual request timeout.
+        m_timeoutTimerId = startTimer(delayMillis);
+        DEBUG_ASSERT(m_timeoutTimerId != kInvalidTimerId);
+        // Store timeout for later
+        m_timeoutMillis = timeoutMillis;
+        return;
+    }
 
     auto* const pNetworkAccessManager = m_networkAccessManagerWeakPtr.data();
     VERIFY_OR_DEBUG_ASSERT(pNetworkAccessManager) {
@@ -225,6 +244,7 @@ void WebTask::slotStart(int timeoutMillis) {
         DEBUG_ASSERT(timeoutMillis > 0);
         m_timeoutTimerId = startTimer(timeoutMillis);
         DEBUG_ASSERT(m_timeoutTimerId != kInvalidTimerId);
+        m_timeoutMillis = timeoutMillis;
     }
 
     // It is not necessary to connect the QNetworkReply::errorOccurred signal.
@@ -238,7 +258,7 @@ void WebTask::slotStart(int timeoutMillis) {
 
 void WebTask::slotAbort() {
     DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
-    if (m_state != State::Pending) {
+    if (!isBusy()) {
         DEBUG_ASSERT(m_timeoutTimerId == kInvalidTimerId);
         if (m_state == State::Idle) {
             kLogger.debug()
@@ -260,11 +280,13 @@ void WebTask::slotAbort() {
     if (m_timeoutTimerId != kInvalidTimerId) {
         killTimer(m_timeoutTimerId);
         m_timeoutTimerId = kInvalidTimerId;
+        m_timeoutMillis = kNoTimeout;
     }
 
-    auto* const pPendingNetworkReply = m_pendingNetworkReplyWeakPtr.data();
     QUrl requestUrl;
+    auto* const pPendingNetworkReply = m_pendingNetworkReplyWeakPtr.data();
     if (pPendingNetworkReply) {
+        DEBUG_ASSERT(m_state == State::Pending);
         if (pPendingNetworkReply->isRunning()) {
             kLogger.debug()
                     << this
@@ -307,6 +329,13 @@ void WebTask::timerEvent(QTimerEvent* event) {
 
     killTimer(m_timeoutTimerId);
     m_timeoutTimerId = kInvalidTimerId;
+
+    if (m_state == State::Starting) {
+        DEBUG_ASSERT(!m_pendingNetworkReplyWeakPtr);
+        m_state = State::Idle;
+        slotStart(m_timeoutMillis);
+        return;
+    }
 
     if (hasTerminated()) {
         DEBUG_ASSERT(!m_pendingNetworkReplyWeakPtr);

--- a/src/network/webtask.cpp
+++ b/src/network/webtask.cpp
@@ -113,7 +113,7 @@ WebTask::WebTask(
         QNetworkAccessManager* networkAccessManager,
         QObject* parent)
         : NetworkTask(networkAccessManager, parent),
-          m_state(State::Idle),
+          m_state(State::Initial),
           m_timeoutTimerId(kInvalidTimerId),
           m_timeoutMillis(kNoTimeout) {
     std::call_once(registerMetaTypesOnceFlag, registerMetaTypesOnce);
@@ -183,7 +183,7 @@ void WebTask::slotStart(int timeoutMillis, int delayMillis) {
     // Reset state
     DEBUG_ASSERT(!m_pendingNetworkReplyWeakPtr);
     DEBUG_ASSERT(m_timeoutTimerId == kInvalidTimerId);
-    m_state = State::Idle;
+    m_state = State::Initial;
     m_timeoutMillis = kNoTimeout;
 
     if (delayMillis > 0) {
@@ -227,7 +227,7 @@ void WebTask::slotStart(int timeoutMillis, int delayMillis) {
     // during the callback before it has beeen started
     // successfully. Instead it should return nullptr
     // to abort the task immediately.
-    DEBUG_ASSERT(m_state == State::Idle);
+    DEBUG_ASSERT(m_state == State::Initial);
     if (!m_pendingNetworkReplyWeakPtr) {
         kLogger.debug()
                 << this
@@ -260,7 +260,7 @@ void WebTask::slotAbort() {
     DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
     if (!isBusy()) {
         DEBUG_ASSERT(m_timeoutTimerId == kInvalidTimerId);
-        if (m_state == State::Idle) {
+        if (m_state == State::Initial) {
             kLogger.debug()
                     << this
                     << "Cannot abort idle task";
@@ -332,7 +332,7 @@ void WebTask::timerEvent(QTimerEvent* event) {
 
     if (m_state == State::Starting) {
         DEBUG_ASSERT(!m_pendingNetworkReplyWeakPtr);
-        m_state = State::Idle;
+        m_state = State::Initial;
         slotStart(m_timeoutMillis);
         return;
     }

--- a/src/network/webtask.h
+++ b/src/network/webtask.h
@@ -136,7 +136,8 @@ class WebTask : public NetworkTask {
 
   public slots:
     void slotStart(
-            int timeoutMillis) override;
+            int timeoutMillis = kNoTimeout,
+            int delayMillis = kNoStartDelay) override;
     void slotAbort() override;
 
   private slots:
@@ -148,6 +149,8 @@ class WebTask : public NetworkTask {
     enum class State {
         // Initial state
         Idle,
+        // Timed start
+        Starting,
         // Pending state
         Pending,
         // Terminal states
@@ -159,6 +162,11 @@ class WebTask : public NetworkTask {
 
     State state() const {
         return m_state;
+    }
+
+    bool isBusy() const {
+        return state() == State::Starting ||
+                state() == State::Pending;
     }
 
     bool hasTerminated() const {
@@ -210,6 +218,7 @@ class WebTask : public NetworkTask {
     PerformanceTimer m_timer;
 
     int m_timeoutTimerId;
+    int m_timeoutMillis;
 
     SafeQPointer<QNetworkReply> m_pendingNetworkReplyWeakPtr;
 };

--- a/src/network/webtask.h
+++ b/src/network/webtask.h
@@ -148,7 +148,7 @@ class WebTask : public NetworkTask {
 
     enum class State {
         // Initial state
-        Idle,
+        Initial,
         // Timed start
         Starting,
         // Pending state


### PR DESCRIPTION
Alternative implementation for #10836 without all the unrelated and questionable changes. I can no longer bother @Swiftb0y with this controversial discussion, letting him stand in the line of fire.

Just works:

```
debug [Main] mixxx::network::WebTask - mixxx::MusicBrainzRecordingsTask(0x7fffd8065980) Starting...
debug [Main] mixxx::network::WebTask - mixxx::MusicBrainzRecordingsTask(0x7fffd8065980) Received reply for request QUrl("https://musicbrainz.org/ws/2/recording/48b1c0fd-e0e9-48b8-9c22-81f6cc8d0252?inc=artists+artist-credits+releases+release-groups+media")
debug [Main] mixxx::network::WebTask - mixxx::MusicBrainzRecordingsTask(0x7fffd8065980) Received network reply after 511 ms
debug [Main] mixxx::network::WebTask - mixxx::MusicBrainzRecordingsTask(0x7fffd8065980) Scheduling next request after 487 ms
debug [Main] mixxx::network::WebTask - mixxx::MusicBrainzRecordingsTask(0x7fffd8065980) Starting...
debug [Main] mixxx::network::WebTask - mixxx::MusicBrainzRecordingsTask(0x7fffd8065980) Received reply for request QUrl("https://musicbrainz.org/ws/2/recording/fed2b990-7344-4584-a4fa-685158a410eb?inc=artists+artist-credits+releases+release-groups+media")
debug [Main] mixxx::network::WebTask - mixxx::MusicBrainzRecordingsTask(0x7fffd8065980) Received network reply after 94 ms
```

The adaptive rate limiting changes can be found in the last commit, straightforward as predicted.