### PR TITLE
FIX: Tag Fetcher close button doesn't abort task 

### DIFF
--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -229,6 +229,11 @@ void DlgTagFetcher::quit() {
     accept();
 }
 
+void DlgTagFetcher::reject() {
+    m_tagFetcher.cancel();
+    accept();
+}
+
 void DlgTagFetcher::fetchTagProgress(const QString& text) {
     QString status = tr("Status: %1");
     loadingStatus->setText(status.arg(text));

--- a/src/library/dlgtagfetcher.h
+++ b/src/library/dlgtagfetcher.h
@@ -42,6 +42,7 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
     void slotTrackChanged(TrackId trackId);
     void apply();
     void quit();
+    void reject() override;
     void slotNext();
     void slotPrev();
 


### PR DESCRIPTION
I mentioned the bug earlier #10877 .

As far as I tested, it aborts the tasks now without any problem. 

I hope that is the correct approach.