### PR TITLE
Changelog 2.3 + CI failure fix 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,23 +10,27 @@
 * Ableton Push: Show as one device [#10905](https://github.com/mixxxdj/mixxx/pull/10905)
 * Potmeters: Add support for arbitrary maximums in 7-/14-bit handlers from controller scripts [#4495](https://github.com/mixxxdj/mixxx/pull/4495)
 * Shade: Fix library sidebar splitter glitch [#4828](https://github.com/mixxxdj/mixxx/pull/4828) [lp:1979823](https://bugs.launchpad.net/mixxx/+bug/1979823)
-* MacOS builds: Perform ad-hoc signing of macOS bundle in Pull request and personal repositories [#4774](https://github.com/mixxxdj/mixxx/pull/4774)
+* macOS builds: Perform ad-hoc signing of macOS bundle in Pull request and personal repositories [#4774](https://github.com/mixxxdj/mixxx/pull/4774)
 * Waveform: Avoid visual glitch with ranges < 1 px [#4804](https://github.com/mixxxdj/mixxx/pull/4804)
 * Traktor S3: Fix issues with sampler and hotcue buttons [#4676](https://github.com/mixxxdj/mixxx/pull/4676)
-* Build Mixxx on MacOS 11, replacing deprecated MacOS 10.15 [#4863](https://github.com/mixxxdj/mixxx/pull/4863)
+* Build Mixxx on macOS 11, replacing deprecated macOS 10.15 [#4863](https://github.com/mixxxdj/mixxx/pull/4863)
 * EQ preferences: properly restore 'One EQ for all decks' setting [#4886](https://github.com/mixxxdj/mixxx/pull/4886)
 * MC7000: Fix off-by-one indexing in the controller script [#4902](https://github.com/mixxxdj/mixxx/pull/4902)
 * Cover Art: Fix picking wrong cover file, when track file name contains extra dots [#4909](https://github.com/mixxxdj/mixxx/pull/4909)
 * MusicBrainz: Respect rate limits [#10874](https://github.com/mixxxdj/mixxx/pull/10874) [#10795](https://github.com/mixxxdj/mixxx/issues/10795)
 * MusicBrainz: Stop fetching after closing the dialog [#10878](https://github.com/mixxxdj/mixxx/pull/10878) [#10877](https://github.com/mixxxdj/mixxx/issues/10877)
-* MacOs: Fix freezed skin control after Ctrl-Click [#10869](https://github.com/mixxxdj/mixxx/pull/10869) [10831](https://github.com/mixxxdj/mixxx/issues/10831)
+* macOs: Fix frozen skin control after Ctrl-Click [#10869](https://github.com/mixxxdj/mixxx/pull/10869) [10831](https://github.com/mixxxdj/mixxx/issues/10831)
 * Avoid redundant messages boxes after track loading fails [#10889](https://github.com/mixxxdj/mixxx/pull/10889)
+* Use OpenGL VU meter widgets. This aims to improve performaces with macOS. [#10893](https://github.com/mixxxdj/mixxx/pull/10893)
+* Prevent wild numbers from appearing during scratching under vinyl control. [#10916](https://github.com/mixxxdj/mixxx/pull/10916)
 
 ### Packaging
 
 * Fix compatibility with FFmpeg 5.1 and require FFmpeg v4.1.9 [#10862](https://github.com/mixxxdj/mixxx/pull/10862) [#10866](https://github.com/mixxxdj/mixxx/pull/10866)
 * Fix GCC 12.2.0 compatibility [#10863](https://github.com/mixxxdj/mixxx/pull/10863)
 * Improve CMake 3.24 compatibility [#10864](https://github.com/mixxxdj/mixxx/pull/10864)
+* Use MIXXX_VCPKG_ROOT cmake and environment variable to find the vcpkg environment [#10904](https://github.com/mixxxdj/mixxx/pull/10904)
+* Fix `-Wswitch` when building with FLAC >= 1.4.0 [#10921](https://github.com/mixxxdj/mixxx/pull/10921)
 
 ## [2.3.3](https://launchpad.net/mixxx/+milestone/2.3.3) (2022-06-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Numark DJ2GO2: Fix  sliders and knobs [#4835](https://github.com/mixxxdj/mixxx/pull/4835) [lp:1948596](https://bugs.launchpad.net/mixxx/+bug/1948596)
 * Numark DJ2Go2: support HotCue clear with pad [#10841](https://github.com/mixxxdj/mixxx/pull/10841)
 * Numark DJ2Go2: Fix inverted tempo fader [#10852](https://github.com/mixxxdj/mixxx/pull/10852) [#10586](https://github.com/mixxxdj/mixxx/issues/10586)
+* Ableton Push: Show as one device [#10905](https://github.com/mixxxdj/mixxx/pull/10905)
 * Potmeters: Add support for arbitrary maximums in 7-/14-bit handlers from controller scripts [#4495](https://github.com/mixxxdj/mixxx/pull/4495)
 * Shade: Fix library sidebar splitter glitch [#4828](https://github.com/mixxxdj/mixxx/pull/4828) [lp:1979823](https://bugs.launchpad.net/mixxx/+bug/1979823)
 * MacOS builds: Perform ad-hoc signing of macOS bundle in Pull request and personal repositories [#4774](https://github.com/mixxxdj/mixxx/pull/4774)
@@ -18,6 +19,8 @@
 * Cover Art: Fix picking wrong cover file, when track file name contains extra dots [#4909](https://github.com/mixxxdj/mixxx/pull/4909)
 * MusicBrainz: Respect rate limits [#10874](https://github.com/mixxxdj/mixxx/pull/10874) [#10795](https://github.com/mixxxdj/mixxx/issues/10795)
 * MusicBrainz: Stop fetching after closing the dialog [#10878](https://github.com/mixxxdj/mixxx/pull/10878) [#10877](https://github.com/mixxxdj/mixxx/issues/10877)
+* MacOs: Fix freezed skin control after Ctrl-Click [#10869](https://github.com/mixxxdj/mixxx/pull/10869) [10831](https://github.com/mixxxdj/mixxx/issues/10831)
+* Avoid redundant messages boxes after track loading fails [#10889](https://github.com/mixxxdj/mixxx/pull/10889)
 
 ### Packaging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 * EQ preferences: properly restore 'One EQ for all decks' setting [#4886](https://github.com/mixxxdj/mixxx/pull/4886)
 * MC7000: Fix off-by-one indexing in the controller script [#4902](https://github.com/mixxxdj/mixxx/pull/4902)
 * Cover Art: Fix picking wrong cover file, when track file name contains extra dots [#4909](https://github.com/mixxxdj/mixxx/pull/4909)
-* Respect MusicBrainz rate limits [#10874](https://github.com/mixxxdj/mixxx/pull/10874) [#10795](https://github.com/mixxxdj/mixxx/issues/10795)
+* MusicBrainz: Respect rate limits [#10874](https://github.com/mixxxdj/mixxx/pull/10874) [#10795](https://github.com/mixxxdj/mixxx/issues/10795)
+* MusicBrainz: Stop fetching after closing the dialog [#10878](https://github.com/mixxxdj/mixxx/pull/10878) [#10877](https://github.com/mixxxdj/mixxx/issues/10877)
 
 ### Packaging
 

--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -98,7 +98,7 @@
   Do not edit it manually.
   -->
   <releases>
-    <release version="2.3.4" type="development" date="2022-09-07" timestamp="1662584120">
+    <release version="2.3.4" type="development" date="2022-09-13" timestamp="1663046707">
       <description>
  <ul>
   <li>
@@ -125,6 +125,10 @@
    #10586
   </li>
   <li>
+   Ableton Push: Show as one device
+   #10905
+  </li>
+  <li>
    Potmeters: Add support for arbitrary maximums in 7-/14-bit handlers from controller scripts
    #4495
   </li>
@@ -134,7 +138,7 @@
    lp:1979823
   </li>
   <li>
-   MacOS builds: Perform ad-hoc signing of macOS bundle in Pull request and personal repositories
+   macOS builds: Perform ad-hoc signing of macOS bundle in Pull request and personal repositories
    #4774
   </li>
   <li>
@@ -146,7 +150,7 @@
    #4676
   </li>
   <li>
-   Build Mixxx on MacOS 11, replacing deprecated MacOS 10.15
+   Build Mixxx on macOS 11, replacing deprecated macOS 10.15
    #4863
   </li>
   <li>
@@ -162,9 +166,31 @@
    #4909
   </li>
   <li>
-   Respect MusicBrainz rate limits
+   MusicBrainz: Respect rate limits
    #10874
    #10795
+  </li>
+  <li>
+   MusicBrainz: Stop fetching after closing the dialog
+   #10878
+   #10877
+  </li>
+  <li>
+   macOs: Fix frozen skin control after Ctrl-Click
+   #10869
+   10831
+  </li>
+  <li>
+   Avoid redundant messages boxes after track loading fails
+   #10889
+  </li>
+  <li>
+   Use OpenGL VU meter widgets. This aims to improve performaces with macOS.
+   #10893
+  </li>
+  <li>
+   Prevent wild numbers from appearing during scratching under vinyl control.
+   #10916
   </li>
  </ul>
  <p>
@@ -183,6 +209,16 @@
   <li>
    Improve CMake 3.24 compatibility
    #10864
+  </li>
+  <li>
+   Use MIXXX_VCPKG_ROOT cmake and environment variable to find the vcpkg environment
+   #10904
+  </li>
+  <li>
+   Fix
+   -Wswitch
+   when building with FLAC &gt;= 1.4.0
+   #10921
   </li>
  </ul>
 </description>

--- a/tools/update_metainfo.py
+++ b/tools/update_metainfo.py
@@ -9,6 +9,23 @@ import bs4
 from lxml import etree
 
 
+def is_in_merge():
+    git_dir = (
+        subprocess.check_output(
+            (
+                "git",
+                "rev-parse",
+                "--git-dir",
+            )
+        )
+        .decode()
+        .strip()
+    )
+    return os.path.exists(
+        os.path.join(git_dir, "MERGE_MSG")
+    ) and os.path.exists(os.path.join(git_dir, "MERGE_HEAD"))
+
+
 def parse_changelog(content, development_release_date):
     for section in re.split("^## ", content.strip(), flags=re.MULTILINE)[1:]:
         version, sep, description_md = section.partition("\n")
@@ -87,32 +104,63 @@ def main(argv=None):
     # goes for using the latest commit date.
     #
     # As a compromise, we're using the date of the parent commit before the
-    # changelog was updated. The only feasible alternative is to remove
-    # development releases completely, or remove the appstream metadata
-    # from the repository and only generate it on demand when an actual
-    # package is built.
+    # changelog was updated.
     #
-    # We need to exclude merge commits here, because the CI checks the latest
-    # commit for pushes, but actually performs a merge when checking pull
-    # requests. Therefore, the date would differ depending on the CI job reason
-    # and cause issues when merging a stable release branch into the dev
-    # branch.
+    # In case of staged changes we use HEAD, because will becomme the parent
+    # commit, after committing. We need to skip merge commits, because we
+    # cannot modify a commit during merging of a pull request on GitHub
 
-    last_changelog_commit = (
-        subprocess.check_output(
-            (
-                "git",
-                "log",
-                "-1",
-                "--no-merges",
-                "--format=%H",
-                "--",
-                changelog_path,
-            )
-        )
-        .decode()
-        .strip()
+    diff_result = subprocess.run(
+        (
+            "git",
+            "diff",
+            "--quiet",
+            "--staged",
+            "--",
+            changelog_path,
+        ),
+        capture_output=True,
+        text=True,
     )
+    changelog_changes_staged = diff_result.returncode
+
+    last_changelog_commit_first_parent = "HEAD"
+    if is_in_merge():
+        last_changelog_commit = (
+            subprocess.check_output(
+                (
+                    "git",
+                    "log",
+                    "-1",
+                    "--no-merges",
+                    "--format=%H",
+                    "HEAD",
+                    "MERGE_HEAD",
+                    "--",
+                    changelog_path,
+                )
+            )
+            .decode()
+            .strip()
+        )
+        last_changelog_commit_first_parent = last_changelog_commit + "~1"
+    elif not changelog_changes_staged:
+        last_changelog_commit = (
+            subprocess.check_output(
+                (
+                    "git",
+                    "log",
+                    "-1",
+                    "--no-merges",
+                    "--format=%H",
+                    "--",
+                    changelog_path,
+                )
+            )
+            .decode()
+            .strip()
+        )
+        last_changelog_commit_first_parent = last_changelog_commit + "~1"
 
     parent_changelog_change_date = datetime.datetime.fromisoformat(
         subprocess.check_output(
@@ -120,9 +168,8 @@ def main(argv=None):
                 "git",
                 "log",
                 "-1",
-                "--no-merges",
-                "--format=%cI",
-                last_changelog_commit + "~1",
+                "--format=%aI",
+                last_changelog_commit_first_parent,
             )
         )
         .decode()

--- a/tools/update_metainfo.py
+++ b/tools/update_metainfo.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import datetime
 import os
+import sys
 import subprocess
 import re
 
@@ -24,6 +25,17 @@ def is_in_merge():
     return os.path.exists(
         os.path.join(git_dir, "MERGE_MSG")
     ) and os.path.exists(os.path.join(git_dir, "MERGE_HEAD"))
+
+
+def is_ammending():
+    ppid = os.getppid()
+    pppid = (
+        subprocess.check_output(("ps", "-p", str(ppid), "-oppid="))
+        .decode()
+        .strip()
+    )
+    git_command = subprocess.check_output(("ps", "-p", pppid, "-ocommand="))
+    return True if b"--amend" in git_command else False
 
 
 def parse_changelog(content, development_release_date):
@@ -144,7 +156,7 @@ def main(argv=None):
             .strip()
         )
         last_changelog_commit_first_parent = last_changelog_commit + "~1"
-    elif not changelog_changes_staged:
+    elif not changelog_changes_staged or is_ammending():
         last_changelog_commit = (
             subprocess.check_output(
                 (
@@ -190,4 +202,4 @@ def main(argv=None):
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
This should hopefully fix CI issues in case the CHANGELOG.md has changed in a merge commit. 
Like this: 
https://github.com/mixxxdj/mixxx/runs/8264160246?check_suite_focus=true