### PR TITLE
 Qt5Keychain: Map missing configuration to the first one.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2597,8 +2597,27 @@ option(QTKEYCHAIN "Secure credentials storage support for Live Broadcasting prof
 if(QTKEYCHAIN)
   find_package(Qt5Keychain REQUIRED)
   target_compile_definitions(mixxx-lib PUBLIC __QTKEYCHAIN__)
-  target_link_libraries(mixxx-lib PRIVATE ${QTKEYCHAIN_LIBRARIES})
-  target_include_directories(mixxx-lib SYSTEM PUBLIC ${QTKEYCHAIN_INCLUDE_DIRS})
+  # If the current configuration is not found, using the first one.
+  # This matches the cmake implementation in cmTarget.cxx which is
+  # broken for some reasons on Ubuntu 22.04.
+  get_property(CONFIGS TARGET qt5keychain PROPERTY IMPORTED_CONFIGURATIONS)
+  string(TOUPPER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_UPPER)
+  if (NOT "${BUILD_TYPE_UPPER}" IN_LIST CONFIGS)
+    if ("RELEASE" IN_LIST CONFIGS)
+      set_target_properties(qt5keychain PROPERTIES
+          MAP_IMPORTED_CONFIG_${BUILD_TYPE_UPPER} RELEASE
+      )
+    else()
+      foreach(c ${CONFIGS})
+        message(STATUS "qt5keychain: Map ${CMAKE_BUILD_TYPE} to configuration ${c}")
+        set_target_properties(qt5keychain PROPERTIES
+           MAP_IMPORTED_CONFIG_${BUILD_TYPE_UPPER} ${c}
+        )
+        break()
+      endforeach()
+    endif()
+  endif()
+  target_link_libraries(mixxx-lib PRIVATE qt5keychain)
 endif()
 
 # USB HID or/and Bulk controller support


### PR DESCRIPTION
This is a workaround for a configuration error in Ubuntu 22.4 where Qt5Keychain is build with the configuration "None"  In case a either matching configuration is found or "Release" it is picked instead of just the first.

This is a hack around the root cause which I have not yet understand.
I think we need to debug cmTarget.cxx oc cmake to find out. 
However changing the cmake version has no effect. 

This is a PR against 2.3 to make sure it keeps building on Unbutu 22.4
A CI run for main that shows that the build is fixed can be found here:
https://github.com/daschuer/mixxx/actions/runs/3056487033

Once this is merged I will take care to merge it into main as well.