### PR TITLE
Adding edge case of MIDI mapping for Ableton Push

### DIFF
--- a/src/controllers/midi/portmidienumerator.cpp
+++ b/src/controllers/midi/portmidienumerator.cpp
@@ -131,6 +131,11 @@ bool namesMatchAllowableEdgeCases(const QString& input_name,
     if (input_name == "KAOSS DJ CONTROL" && output_name == "KAOSS DJ SOUND") {
         return true;
     }
+    // Ableton Push on Windows
+    // Shows 2 different devices for MIDI input and output.
+    if (input_name == "MIDIIN2 (Ableton Push)" && output_name == "MIDIOUT2 (Ableton Push)") {
+        return true;
+    }
     return false;
 }
 


### PR DESCRIPTION
Hi,
This is a little code update to take into account another edge case of MIDI in / MIDI out controller with different mappings.

As of today, I wasn't able to deploy a working dev and build environment to verify compilation of MIXXX with this update (harder under Windows...) but here is it anyway as this is only a few lines of code.