### PR TITLE
Changelog: Fix faulty link 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -430,7 +430,7 @@
 * Fix crash when starting without a valid skin directory [#4575](https://github.com/mixxxdj/mixxx/pull/4575) [lp:1934560](https://bugs.launchpad.net/mixxx/+bug/1934560)
 * LateNight: Move logo to the right [#4677](https://github.com/mixxxdj/mixxx/pull/4677)
 * LateNight: Use correct tooltip for key control toggle [#4696](https://github.com/mixxxdj/mixxx/pull/4696)
-* LateNight: Add toggles to show loop and beatjump controls [#4713](https://github.com/mixxxdj/mixxx/pull/[#4713](https://github.com/mixxxdj/mixxx/pull/4713))
+* LateNight: Add toggles to show loop and beatjump controls [#4713](https://github.com/mixxxdj/mixxx/pull/4713)
 * LateNight: Remove blinking play indicator from mini samplers [#4807](https://github.com/mixxxdj/mixxx/pull/4807)
 * LateNight: add buffer underflow indicator [#4906](https://github.com/mixxxdj/mixxx/pull/4906)
 

--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -96,7 +96,7 @@
   Do not edit it manually.
   -->
   <releases>
-    <release version="2.4.0" type="development" date="2022-09-07" timestamp="1662584120">
+    <release version="2.4.0" type="development" date="2022-09-14" timestamp="1663109823">
       <description>
  <p>
   Cover Art
@@ -1529,7 +1529,7 @@
  </ul>
 </description>
     </release>
-    <release version="2.3.4" type="development" date="2022-09-07" timestamp="1662584120">
+    <release version="2.3.4" type="development" date="2022-09-14" timestamp="1663109823">
       <description>
  <ul>
   <li>


### PR DESCRIPTION
This should fix a build error with the manual: 
https://github.com/mixxxdj/manual/actions/runs/3072969204/jobs/4965120078