### PR TITLE
ImageFileData class added to write images without loss

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -953,6 +953,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/util/fileaccess.cpp
   src/util/fileinfo.cpp
   src/util/filename.cpp
+  src/util/imagefiledata.cpp
   src/util/imageutils.cpp
   src/util/indexrange.cpp
   src/util/logger.cpp

--- a/src/util/imagefiledata.cpp
+++ b/src/util/imagefiledata.cpp
@@ -3,6 +3,7 @@
 #include <QBuffer>
 #include <QByteArray>
 #include <QFile>
+#include <QFileInfo>
 #include <QImage>
 #include <QImageReader>
 
@@ -45,6 +46,15 @@ QByteArray ImageFileData::readFormatFrom(const QByteArray& coverArtBytes) {
 
 bool ImageFileData::saveFile(const QString& coverArtAbsoluteFilePath) const {
     if (m_coverArtBytes.isEmpty()) {
+        return save(coverArtAbsoluteFilePath);
+    }
+
+    if (QFileInfo(coverArtAbsoluteFilePath).suffix() != m_coverArtFormat) {
+        qWarning() << "Cover Art format and extension does not match"
+                   << "format"
+                   << m_coverArtFormat
+                   << "extension"
+                   << QFileInfo(coverArtAbsoluteFilePath).suffix();
         return save(coverArtAbsoluteFilePath);
     }
 

--- a/src/util/imagefiledata.cpp
+++ b/src/util/imagefiledata.cpp
@@ -1,0 +1,82 @@
+#include "util/imagefiledata.h"
+
+#include <QBuffer>
+#include <QByteArray>
+#include <QFile>
+#include <QImage>
+#include <QImageReader>
+
+#include "util/assert.h"
+
+ImageFileData::ImageFileData(
+        const QByteArray& coverArtBytes, const QByteArray& coverArtFormat)
+        : QImage(QImage::fromData(coverArtBytes)),
+          m_coverArtBytes(coverArtBytes) {
+    m_coverArtFormat = coverArtFormat.isEmpty() ? readFormatFrom(m_coverArtBytes) : coverArtFormat;
+}
+
+//static
+ImageFileData ImageFileData::fromFilePath(const QString& coverArtFilePath) {
+    QFile coverArtFile = QFile(coverArtFilePath);
+    if (!coverArtFile.open(QIODevice::ReadOnly)) {
+        qWarning() << "Failed to open cover art file";
+        return ImageFileData(QByteArray{}, QByteArray{});
+    }
+    QByteArray coverArtBytes = coverArtFile.readAll();
+    QByteArray coverArtFormat = readFormatFrom(coverArtBytes);
+    return ImageFileData(coverArtBytes, coverArtFormat);
+}
+
+//static
+QByteArray ImageFileData::readFormatFrom(const QByteArray& coverArtBytes) {
+    QByteArray bytes = coverArtBytes;
+    QBuffer b = QBuffer(&bytes);
+    if (!b.open(QIODevice::ReadOnly)) {
+        qWarning() << "Failed to open buffer";
+        return QByteArray{};
+    }
+    auto reader = QImageReader(&b);
+    QByteArray coverArtFormat = reader.format();
+    VERIFY_OR_DEBUG_ASSERT(!coverArtFormat.isEmpty()) {
+        return QByteArray{};
+    }
+    return coverArtFormat;
+}
+
+bool ImageFileData::saveFile(const QString& coverArtAbsoluteFilePath) const {
+    if (m_coverArtBytes.isEmpty()) {
+        return save(coverArtAbsoluteFilePath);
+    }
+
+    QFile coverArtFile(coverArtAbsoluteFilePath);
+    if (!coverArtFile.open(QIODevice::WriteOnly)) {
+        qWarning() << "Failed to open cover art file"
+                   << coverArtAbsoluteFilePath;
+        return false;
+    }
+    if (!coverArtFile.write(m_coverArtBytes)) {
+        qWarning() << "Failed to write cover art"
+                   << coverArtAbsoluteFilePath;
+        return false;
+    }
+
+    return true;
+}
+
+bool ImageFileData::saveFileAddSuffix(const QString& pathWithoutSuffix) const {
+    VERIFY_OR_DEBUG_ASSERT(!m_coverArtBytes.isEmpty() || !m_coverArtFormat.isEmpty()) {
+        return false;
+    }
+    QFile coverArtFile(pathWithoutSuffix + '.' + m_coverArtFormat);
+    if (!coverArtFile.open(QIODevice::WriteOnly)) {
+        qWarning() << "Failed to open cover art file"
+                   << pathWithoutSuffix;
+        return false;
+    }
+    if (!coverArtFile.write(m_coverArtBytes)) {
+        qWarning() << "Failed to write cover art"
+                   << pathWithoutSuffix;
+        return false;
+    }
+    return true;
+}

--- a/src/util/imagefiledata.h
+++ b/src/util/imagefiledata.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QByteArray>
+#include <QImage>
+
+class ImageFileData : public QImage {
+  public:
+    explicit ImageFileData(const QByteArray& coverArtBytes,
+            const QByteArray& coverArtFormat = nullptr);
+
+    static ImageFileData fromFilePath(const QString& coverArtFilePath);
+
+    static QByteArray readFormatFrom(const QByteArray& coverArtBytes);
+
+    bool saveFile(const QString& coverArtAbsoluteFilePath) const;
+    bool saveFileAddSuffix(const QString& pathWithoutSuffix) const;
+
+    QByteArray getCoverArtBytes() const {
+        return m_coverArtBytes;
+    }
+
+  private:
+    QByteArray m_coverArtBytes;
+    QByteArray m_coverArtFormat;
+};


### PR DESCRIPTION
As we talked on here #10902 before. This class aims to write images without loss especially for "jpg-jpeg" and also that will be useful when we want to write a file from online sources, in other words cover art fetcher.