### PR TITLE
Pioneer DDJ-400: make Beat FX section more intuitive

### DIFF
--- a/res/controllers/Pioneer-DDJ-400-script.js
+++ b/res/controllers/Pioneer-DDJ-400-script.js
@@ -242,32 +242,32 @@ PioneerDDJ400.beatFxLevelDepthRotate = function(_channel, _control, value) {
     }
 };
 
+PioneerDDJ400.changeFocusedEffectBy = function(numberOfSteps) {
+    var focusedEffect = engine.getValue("[EffectRack1_EffectUnit1]", "focused_effect");
+
+    // Convert to zero-based index
+    focusedEffect -= 1;
+
+    // Standard Euclidean modulo by use of two plain modulos
+    var numberOfEffectsPerEffectUnit = 3;
+    focusedEffect = (((focusedEffect + numberOfSteps) % numberOfEffectsPerEffectUnit) + numberOfEffectsPerEffectUnit) % numberOfEffectsPerEffectUnit;
+
+    // Convert back to one-based index
+    focusedEffect += 1;
+
+    engine.setValue("[EffectRack1_EffectUnit1]", "focused_effect", focusedEffect);
+};
+
 PioneerDDJ400.beatFxLeftPressed = function(_channel, _control, value) {
     if (value === 0) { return; }
 
-    var focusedEffect = engine.getValue("[EffectRack1_EffectUnit1]", "focused_effect");
-
-    if (focusedEffect <= 1) {
-        focusedEffect = 3;
-    } else {
-        focusedEffect -= 1;
-    }
-
-    engine.setValue("[EffectRack1_EffectUnit1]", "focused_effect", focusedEffect);
+    PioneerDDJ400.changeFocusedEffectBy(-1);
 };
 
 PioneerDDJ400.beatFxRightPressed = function(_channel, _control, value) {
     if (value === 0) { return; }
 
-    var focusedEffect = engine.getValue("[EffectRack1_EffectUnit1]", "focused_effect");
-
-    if (focusedEffect >= 3) {
-        focusedEffect = 1;
-    } else {
-        focusedEffect += 1;
-    }
-
-    engine.setValue("[EffectRack1_EffectUnit1]", "focused_effect", focusedEffect);
+    PioneerDDJ400.changeFocusedEffectBy(1);
 };
 
 PioneerDDJ400.beatFxSelectPressed = function(_channel, _control, value) {

--- a/res/controllers/Pioneer-DDJ-400-script.js
+++ b/res/controllers/Pioneer-DDJ-400-script.js
@@ -1,7 +1,7 @@
 // Pioneer-DDJ-400-script.js
 // ****************************************************************************
 // * Mixxx mapping script file for the Pioneer DDJ-400.
-// * Authors: Warker, nschloe, dj3730, jusko
+// * Authors: Warker, nschloe, dj3730, jusko, tiesjan
 // * Reviewers: Be-ing, Holzhaus
 // * Manual: https://manual.mixxx.org/2.3/en/hardware/controllers/pioneer_ddj_400.html
 // ****************************************************************************
@@ -19,14 +19,14 @@
 //
 //  Custom (Mixxx specific mappings):
 //      * BeatFX: Assigned Effect Unit 1
-//                < LEFT focus EFFECT1
-//                > RIGHT focus EFFECT2
-//                v FX_SELECT focus EFFECT3.
+//                < LEFT toggles focus between Effects 1, 2 and 3 leftward
+//                > RIGHT toggles focus between Effects 1, 2 and 3 rightward
+//                v DOWN loads next effect entry for focused Effect
+//                SHIFT + v UP loads previous effect entry for focused Effect
+//                LEVEL/DEPTH controls the Mix knob of the Effect Unit
+//                SHIFT + LEVEL/DEPTH controls the Meta knob of the focused Effect
 //                ON/OFF toggles focused effect slot
 //                SHIFT + ON/OFF disables all three effect slots.
-//                SHIFT + < loads previous effect
-//                SHIFT + > loads next effect
-//
 //      * 32 beat jump forward & back (Shift + </> CUE/LOOP CALL arrows)
 //      * Toggle quantize (Shift + channel cue)
 //
@@ -34,7 +34,6 @@
 //      * Loop Section:
 //        * -4BEAT auto loop (hacky---prefer a clean way to set a 4 beat loop
 //                            from a previous position on long press)
-//
 //        * CUE/LOOP CALL - memory & delete (complex and not useful. Hot cues are sufficient)
 //
 //      * Secondary pad modes (trial attempts complex and too experimental)
@@ -243,30 +242,44 @@ PioneerDDJ400.beatFxLevelDepthRotate = function(_channel, _control, value) {
     }
 };
 
-PioneerDDJ400.beatFxSelectPreviousEffect = function(_channel, _control, value) {
-    engine.setValue(PioneerDDJ400.focusedFxGroup(), "prev_effect", value);
-};
-
-PioneerDDJ400.beatFxSelectNextEffect = function(_channel, _control, value) {
-    engine.setValue(PioneerDDJ400.focusedFxGroup(), "next_effect", value);
-};
-
 PioneerDDJ400.beatFxLeftPressed = function(_channel, _control, value) {
     if (value === 0) { return; }
 
-    engine.setValue("[EffectRack1_EffectUnit1]", "focused_effect", 1);
+    var focusedEffect = engine.getValue("[EffectRack1_EffectUnit1]", "focused_effect");
+
+    if (focusedEffect <= 1) {
+        focusedEffect = 3;
+    } else {
+        focusedEffect -= 1;
+    }
+
+    engine.setValue("[EffectRack1_EffectUnit1]", "focused_effect", focusedEffect);
 };
 
 PioneerDDJ400.beatFxRightPressed = function(_channel, _control, value) {
     if (value === 0) { return; }
 
-    engine.setValue("[EffectRack1_EffectUnit1]", "focused_effect", 2);
+    var focusedEffect = engine.getValue("[EffectRack1_EffectUnit1]", "focused_effect");
+
+    if (focusedEffect >= 3) {
+        focusedEffect = 1;
+    } else {
+        focusedEffect += 1;
+    }
+
+    engine.setValue("[EffectRack1_EffectUnit1]", "focused_effect", focusedEffect);
 };
 
 PioneerDDJ400.beatFxSelectPressed = function(_channel, _control, value) {
     if (value === 0) { return; }
 
-    engine.setValue("[EffectRack1_EffectUnit1]", "focused_effect", 3);
+    engine.setValue(PioneerDDJ400.focusedFxGroup(), "next_effect", value);
+};
+
+PioneerDDJ400.beatFxSelectShiftPressed = function(_channel, _control, value) {
+    if (value === 0) { return; }
+
+    engine.setValue(PioneerDDJ400.focusedFxGroup(), "prev_effect", value);
 };
 
 PioneerDDJ400.beatFxOnOffPressed = function(_channel, _control, value) {
@@ -426,7 +439,7 @@ PioneerDDJ400.syncLongPressed = function(channel, control, value, status, group)
 };
 
 PioneerDDJ400.cycleTempoRange = function(_channel, _control, value, _status, group) {
-    if (value === 0) return; // ignore release
+    if (value === 0) { return; } // ignore release
 
     var currRange = engine.getValue(group, "rateRange");
     var idx = 0;

--- a/res/controllers/Pioneer-DDJ-400.midi.xml
+++ b/res/controllers/Pioneer-DDJ-400.midi.xml
@@ -2,7 +2,7 @@
 <MixxxMIDIPreset schemaVersion="1" mixxxVersion="2.2">
     <info>
         <name>Pioneer DDJ-400</name>
-        <author>Warker/nschloe/dj3730/jusko</author>
+        <author>Warker, nschloe, dj3730, jusko, tiesjan</author>
         <description>Midi Mapping for the Pioneer DDJ-400</description>
         <manual>pioneer_ddj_400</manual>
         <forums>https://mixxx.discourse.group/t/pioneer-ddj-400/17476</forums>
@@ -998,7 +998,7 @@
             <!-- BEAT FX SECTION START -->
 
             <control>
-                <description>BEAT LEFT - press - select effect unit 1</description>
+                <description>BEAT LEFT - press - toggle focused Effect leftward</description>
                 <group>[EffectRack1_EffectUnit1]</group>
                 <key>PioneerDDJ400.beatFxLeftPressed</key>
                 <status>0x94</status>
@@ -1007,19 +1007,9 @@
                     <Script-Binding/>
                 </options>
             </control>
-            <control>
-                <description>BEAT LEFT + shift - select previous effect for the current unit</description>
-                <group>[EffectRack1_EffectUnit1]</group>
-                <key>PioneerDDJ400.beatFxSelectPreviousEffect</key>
-                <status>0x94</status>
-                <midino>0x66</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
 
             <control>
-                <description>BEAT RIGHT - press - select effect unit 2</description>
+                <description>BEAT RIGHT - press - toggle focused Effect rightward</description>
                 <group>[EffectRack1_EffectUnit1]</group>
                 <key>PioneerDDJ400.beatFxRightPressed</key>
                 <status>0x94</status>
@@ -1028,23 +1018,23 @@
                     <Script-Binding/>
                 </options>
             </control>
-            <control>
-                <description>BEAT RIGHT + shift - select next effect for the current unit</description>
-                <group>[EffectRack1_EffectUnit1]</group>
-                <key>PioneerDDJ400.beatFxSelectNextEffect</key>
-                <status>0x94</status>
-                <midino>0x6B</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
 
             <control>
-              <description>BEAT FX SELECT - press once - select effect unit 3 - press again - clear focus back to wet/dry mix </description>
+                <description>BEAT FX SELECT - press - load next effect entry for focused Effect</description>
                 <group>[EffectRack1_EffectUnit1]</group>
                 <key>PioneerDDJ400.beatFxSelectPressed</key>
                 <status>0x94</status>
                 <midino>0x63</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+              <description>BEAT FX SELECT +SHIFT - press - load previous effect entry for focused Effect</description>
+                <group>[EffectRack1_EffectUnit1]</group>
+                <key>PioneerDDJ400.beatFxSelectShiftPressed</key>
+                <status>0x94</status>
+                <midino>0x64</midino>
                 <options>
                     <Script-Binding/>
                 </options>


### PR DESCRIPTION
This patch makes the mapping of the Beat FX section on the Pioneer DDJ-400 slightly more intuitive:
- `Beat <` (LEFT) and `Beat >` (RIGHT) buttons now cycle through the focus of the three Effects in Effect Unit 1 leftward and rightward, respectively.
- `FX SELECT v` (DOWN) and `FX SELECT v` `+SHIFT` (UP) buttons now select the next and previous effect entry for the focused Effect, respectively.

This is more in line with the controller's button names and the Mixxx interface.

Has been tested on my own controller (with the latest firmware) using Mixxx 2.3 to work as expected.

Based on the work proposed in #4662. Changes to the Mixxx manual proposed in mixxxdj/manual#519.