### PR TITLE
Use rate_ratio for track timing display

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1274,8 +1274,8 @@ void EngineBuffer::updateIndicators(double speed, int iBufferSize) {
 
     const double fFractionalPlaypos = fractionalPlayposFromAbsolute(m_filepos_play);
 
-    const double tempoTrackSeconds = m_trackSamplesOld / kSamplesPerFrame
-            / m_trackSampleRateOld / m_tempo_ratio_old;
+    const double tempoTrackSeconds = m_trackSamplesOld / kSamplesPerFrame /
+            m_trackSampleRateOld / getRateRatio();
     if (speed > 0 && fFractionalPlaypos == 1.0) {
         // At Track end
         speed = 0;


### PR DESCRIPTION
This prevents wild numbers from appearing during scratching under vinyl control.

(Without this, the track time can appear as extremely long or extremely short.  The vinyl control code manipulates the rate_ratio value so that it stays within reasonable boundaries). 