### PR TITLE
fix(soundsourceflac): Fix `-Wswitch` when building with FLAC >= 1.4.0

### DIFF
--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -581,6 +581,11 @@ void SoundSourceFLAC::flacError(FLAC__StreamDecoderErrorStatus status) {
     case FLAC__STREAM_DECODER_ERROR_STATUS_UNPARSEABLE_STREAM:
         error = "STREAM_DECODER_ERROR_STATUS_UNPARSEABLE_STREAM";
         break;
+#if FLAC_API_VERSION_CURRENT >= 12
+    case FLAC__STREAM_DECODER_ERROR_STATUS_BAD_METADATA:
+        error = "STREAM_DECODER_ERROR_STATUS_BAD_METADATA";
+        break;
+#endif
     }
     kLogger.warning()
             << "FLAC decoding error" << error


### PR DESCRIPTION
Fixes the following warning:

    src/sources/soundsourceflac.cpp: In member function ‘void mixxx::SoundSourceFLAC::flacError(FLAC__StreamDecoderErrorStatus)’:
    src/sources/soundsourceflac.cpp:571:12: error: enumeration value ‘FLAC__STREAM_DECODER_ERROR_STATUS_BAD_METADATA’ not handled in switch [-Werror=switch]
      571 |     switch (status) {
          |            ^

The enumeration value has been mentioned in the FLAC 1.3.4 to 1.4.0 porting guide:
https://xiph.org/flac/api/group__porting__1__3__4__to__1__4__0.html