### PR TITLE
Replace obsolete enum datalocation

### DIFF
--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -29,7 +29,7 @@ CmdlineArgs::CmdlineArgs()
           // TODO(XXX) Trailing slash not needed anymore as we switches from String::append
           // to QDir::filePath elsewhere in the code. This is candidate for removal.
           m_settingsPath(
-                  QStandardPaths::writableLocation(QStandardPaths::DataLocation)
+                  QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation)
                           .append("/")) {
 #endif
 }


### PR DESCRIPTION
With Qt 6.3.2 QStandardPaths::DataLocation does not exist anymore. According to the Qt 5 docs this enum is the same as QStandardPaths::AppLocalDataLocation:

https://doc.qt.io/qt-5/qstandardpaths.html#StandardLocation-enum

which will work on all versions.