### PR TITLE
Analysis: Add support for overriding variable/constant BPM on a per-track basis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,6 +491,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/analyzer/analyzerebur128.cpp
   src/analyzer/analyzergain.cpp
   src/analyzer/analyzerkey.cpp
+  src/analyzer/analyzerscheduledtrack.cpp
   src/analyzer/analyzersilence.cpp
   src/analyzer/analyzerthread.cpp
   src/analyzer/analyzertrack.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -493,6 +493,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/analyzer/analyzerkey.cpp
   src/analyzer/analyzersilence.cpp
   src/analyzer/analyzerthread.cpp
+  src/analyzer/analyzertrack.cpp
   src/analyzer/analyzerwaveform.cpp
   src/analyzer/plugins/analyzerqueenmarybeats.cpp
   src/analyzer/plugins/analyzerqueenmarykey.cpp

--- a/src/analyzer/analyzer.h
+++ b/src/analyzer/analyzer.h
@@ -23,7 +23,7 @@ class Analyzer {
     //  1. Check if the track needs to be analyzed, otherwise return false.
     //  2. Perform the initialization and return true on success.
     //  3. If the initialization failed log the internal error and return false.
-    virtual bool initialize(AnalyzerTrack tio,
+    virtual bool initialize(const AnalyzerTrack& tio,
             mixxx::audio::SampleRate sampleRate,
             int totalSamples) = 0;
 
@@ -70,7 +70,9 @@ class AnalyzerWithState final {
         return m_active;
     }
 
-    bool initialize(AnalyzerTrack tio, mixxx::audio::SampleRate sampleRate, int totalSamples) {
+    bool initialize(const AnalyzerTrack& tio,
+            mixxx::audio::SampleRate sampleRate,
+            int totalSamples) {
         DEBUG_ASSERT(!m_active);
         return m_active = m_analyzer->initialize(tio, sampleRate, totalSamples);
     }
@@ -86,7 +88,7 @@ class AnalyzerWithState final {
         }
     }
 
-    void finish(AnalyzerTrack tio) {
+    void finish(const AnalyzerTrack& tio) {
         if (m_active) {
             m_analyzer->storeResults(tio.getTrack());
             m_analyzer->cleanup();

--- a/src/analyzer/analyzer.h
+++ b/src/analyzer/analyzer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "analyzer/analyzertrack.h"
 #include "audio/types.h"
 #include "util/assert.h"
 #include "util/types.h"
@@ -22,7 +23,7 @@ class Analyzer {
     //  1. Check if the track needs to be analyzed, otherwise return false.
     //  2. Perform the initialization and return true on success.
     //  3. If the initialization failed log the internal error and return false.
-    virtual bool initialize(TrackPointer tio,
+    virtual bool initialize(AnalyzerTrack tio,
             mixxx::audio::SampleRate sampleRate,
             int totalSamples) = 0;
 
@@ -69,7 +70,7 @@ class AnalyzerWithState final {
         return m_active;
     }
 
-    bool initialize(TrackPointer tio, mixxx::audio::SampleRate sampleRate, int totalSamples) {
+    bool initialize(AnalyzerTrack tio, mixxx::audio::SampleRate sampleRate, int totalSamples) {
         DEBUG_ASSERT(!m_active);
         return m_active = m_analyzer->initialize(tio, sampleRate, totalSamples);
     }
@@ -85,9 +86,9 @@ class AnalyzerWithState final {
         }
     }
 
-    void finish(TrackPointer tio) {
+    void finish(AnalyzerTrack tio) {
         if (m_active) {
-            m_analyzer->storeResults(tio);
+            m_analyzer->storeResults(tio.getTrack());
             m_analyzer->cleanup();
             m_active = false;
         }

--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -62,7 +62,8 @@ bool AnalyzerBeats::initialize(AnalyzerTrack track,
         return false;
     }
 
-    m_bPreferencesFixedTempo = m_bpmSettings.getFixedTempoAssumption();
+    m_bPreferencesFixedTempo = track.getOptions().useFixedTempo.value_or(
+            m_bpmSettings.getFixedTempoAssumption());
     m_bPreferencesReanalyzeOldBpm = m_bpmSettings.getReanalyzeWhenSettingsChange();
     m_bPreferencesReanalyzeImported = m_bpmSettings.getReanalyzeImported();
     m_bPreferencesFastAnalysis = m_bpmSettings.getFastAnalysis();

--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -42,7 +42,7 @@ AnalyzerBeats::AnalyzerBeats(UserSettingsPointer pConfig, bool enforceBpmDetecti
           m_iCurrentSample(0) {
 }
 
-bool AnalyzerBeats::initialize(AnalyzerTrack track,
+bool AnalyzerBeats::initialize(const AnalyzerTrack& track,
         mixxx::audio::SampleRate sampleRate,
         int totalSamples) {
     if (totalSamples == 0) {

--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -5,6 +5,7 @@
 #include <QVector>
 #include <QtDebug>
 
+#include "analyzer/analyzertrack.h"
 #include "analyzer/constants.h"
 #include "analyzer/plugins/analyzerqueenmarybeats.h"
 #include "analyzer/plugins/analyzersoundtouchbeats.h"
@@ -41,7 +42,7 @@ AnalyzerBeats::AnalyzerBeats(UserSettingsPointer pConfig, bool enforceBpmDetecti
           m_iCurrentSample(0) {
 }
 
-bool AnalyzerBeats::initialize(TrackPointer pTrack,
+bool AnalyzerBeats::initialize(AnalyzerTrack track,
         mixxx::audio::SampleRate sampleRate,
         int totalSamples) {
     if (totalSamples == 0) {
@@ -55,7 +56,7 @@ bool AnalyzerBeats::initialize(TrackPointer pTrack,
         return false;
     }
 
-    bool bpmLock = pTrack->isBpmLocked();
+    bool bpmLock = track.getTrack()->isBpmLocked();
     if (bpmLock) {
         qDebug() << "Track is BpmLocked: Beat calculation will not start";
         return false;
@@ -98,7 +99,7 @@ bool AnalyzerBeats::initialize(TrackPointer pTrack,
     m_iCurrentSample = 0;
 
     // if we can load a stored track don't reanalyze it
-    bool bShouldAnalyze = shouldAnalyze(pTrack);
+    bool bShouldAnalyze = shouldAnalyze(track.getTrack());
 
     DEBUG_ASSERT(!m_pPlugin);
     if (bShouldAnalyze) {

--- a/src/analyzer/analyzerbeats.h
+++ b/src/analyzer/analyzerbeats.h
@@ -27,7 +27,7 @@ class AnalyzerBeats : public Analyzer {
     static QList<mixxx::AnalyzerPluginInfo> availablePlugins();
     static mixxx::AnalyzerPluginInfo defaultPlugin();
 
-    bool initialize(AnalyzerTrack track,
+    bool initialize(const AnalyzerTrack& track,
             mixxx::audio::SampleRate sampleRate,
             int totalSamples) override;
     bool processSamples(const CSAMPLE *pIn, const int iLen) override;

--- a/src/analyzer/analyzerbeats.h
+++ b/src/analyzer/analyzerbeats.h
@@ -11,6 +11,7 @@
 #include <QList>
 
 #include "analyzer/analyzer.h"
+#include "analyzer/analyzertrack.h"
 #include "analyzer/plugins/analyzerplugin.h"
 #include "preferences/beatdetectionsettings.h"
 #include "preferences/usersettings.h"
@@ -26,7 +27,7 @@ class AnalyzerBeats : public Analyzer {
     static QList<mixxx::AnalyzerPluginInfo> availablePlugins();
     static mixxx::AnalyzerPluginInfo defaultPlugin();
 
-    bool initialize(TrackPointer pTrack,
+    bool initialize(AnalyzerTrack track,
             mixxx::audio::SampleRate sampleRate,
             int totalSamples) override;
     bool processSamples(const CSAMPLE *pIn, const int iLen) override;

--- a/src/analyzer/analyzerebur128.cpp
+++ b/src/analyzer/analyzerebur128.cpp
@@ -2,6 +2,7 @@
 
 #include <QtDebug>
 
+#include "analyzer/analyzertrack.h"
 #include "track/track.h"
 #include "util/math.h"
 #include "util/sample.h"
@@ -20,10 +21,10 @@ AnalyzerEbur128::~AnalyzerEbur128() {
     cleanup(); // ...to prevent memory leaks
 }
 
-bool AnalyzerEbur128::initialize(TrackPointer tio,
+bool AnalyzerEbur128::initialize(AnalyzerTrack tio,
         mixxx::audio::SampleRate sampleRate,
         int totalSamples) {
-    if (m_rgSettings.isAnalyzerDisabled(2, tio) || totalSamples == 0) {
+    if (m_rgSettings.isAnalyzerDisabled(2, tio.getTrack()) || totalSamples == 0) {
         qDebug() << "Skipping AnalyzerEbur128";
         return false;
     }

--- a/src/analyzer/analyzerebur128.cpp
+++ b/src/analyzer/analyzerebur128.cpp
@@ -21,7 +21,7 @@ AnalyzerEbur128::~AnalyzerEbur128() {
     cleanup(); // ...to prevent memory leaks
 }
 
-bool AnalyzerEbur128::initialize(AnalyzerTrack tio,
+bool AnalyzerEbur128::initialize(const AnalyzerTrack& tio,
         mixxx::audio::SampleRate sampleRate,
         int totalSamples) {
     if (m_rgSettings.isAnalyzerDisabled(2, tio.getTrack()) || totalSamples == 0) {

--- a/src/analyzer/analyzerebur128.h
+++ b/src/analyzer/analyzerebur128.h
@@ -15,7 +15,7 @@ class AnalyzerEbur128 : public Analyzer {
         return rgSettings.isAnalyzerEnabled(2);
     }
 
-    bool initialize(AnalyzerTrack track,
+    bool initialize(const AnalyzerTrack& track,
             mixxx::audio::SampleRate sampleRate,
             int totalSamples) override;
     bool processSamples(const CSAMPLE* pIn, const int iLen) override;

--- a/src/analyzer/analyzerebur128.h
+++ b/src/analyzer/analyzerebur128.h
@@ -3,6 +3,7 @@
 #include <ebur128.h>
 
 #include "analyzer/analyzer.h"
+#include "analyzer/analyzertrack.h"
 #include "preferences/replaygainsettings.h"
 
 class AnalyzerEbur128 : public Analyzer {
@@ -14,7 +15,7 @@ class AnalyzerEbur128 : public Analyzer {
         return rgSettings.isAnalyzerEnabled(2);
     }
 
-    bool initialize(TrackPointer tio,
+    bool initialize(AnalyzerTrack track,
             mixxx::audio::SampleRate sampleRate,
             int totalSamples) override;
     bool processSamples(const CSAMPLE* pIn, const int iLen) override;

--- a/src/analyzer/analyzergain.cpp
+++ b/src/analyzer/analyzergain.cpp
@@ -20,7 +20,7 @@ AnalyzerGain::~AnalyzerGain() {
     delete m_pReplayGain;
 }
 
-bool AnalyzerGain::initialize(AnalyzerTrack tio,
+bool AnalyzerGain::initialize(const AnalyzerTrack& tio,
         mixxx::audio::SampleRate sampleRate,
         int totalSamples) {
     if (m_rgSettings.isAnalyzerDisabled(1, tio.getTrack()) || totalSamples == 0) {

--- a/src/analyzer/analyzergain.cpp
+++ b/src/analyzer/analyzergain.cpp
@@ -1,7 +1,10 @@
+#include "analyzer/analyzergain.h"
+
 #include <replaygain.h>
+
 #include <QtDebug>
 
-#include "analyzer/analyzergain.h"
+#include "analyzer/analyzertrack.h"
 #include "track/track.h"
 #include "util/math.h"
 #include "util/sample.h"
@@ -17,10 +20,10 @@ AnalyzerGain::~AnalyzerGain() {
     delete m_pReplayGain;
 }
 
-bool AnalyzerGain::initialize(TrackPointer tio,
+bool AnalyzerGain::initialize(AnalyzerTrack tio,
         mixxx::audio::SampleRate sampleRate,
         int totalSamples) {
-    if (m_rgSettings.isAnalyzerDisabled(1, tio) || totalSamples == 0) {
+    if (m_rgSettings.isAnalyzerDisabled(1, tio.getTrack()) || totalSamples == 0) {
         qDebug() << "Skipping AnalyzerGain";
         return false;
     }

--- a/src/analyzer/analyzergain.h
+++ b/src/analyzer/analyzergain.h
@@ -23,7 +23,7 @@ class AnalyzerGain : public Analyzer {
         return rgSettings.isAnalyzerEnabled(1);
     }
 
-    bool initialize(TrackPointer tio,
+    bool initialize(AnalyzerTrack track,
             mixxx::audio::SampleRate sampleRate,
             int totalSamples) override;
     bool processSamples(const CSAMPLE* pIn, const int iLen) override;

--- a/src/analyzer/analyzergain.h
+++ b/src/analyzer/analyzergain.h
@@ -23,7 +23,7 @@ class AnalyzerGain : public Analyzer {
         return rgSettings.isAnalyzerEnabled(1);
     }
 
-    bool initialize(AnalyzerTrack track,
+    bool initialize(const AnalyzerTrack& track,
             mixxx::audio::SampleRate sampleRate,
             int totalSamples) override;
     bool processSamples(const CSAMPLE* pIn, const int iLen) override;

--- a/src/analyzer/analyzerkey.cpp
+++ b/src/analyzer/analyzerkey.cpp
@@ -42,7 +42,7 @@ AnalyzerKey::AnalyzerKey(const KeyDetectionSettings& keySettings)
           m_bPreferencesReanalyzeEnabled(false) {
 }
 
-bool AnalyzerKey::initialize(AnalyzerTrack tio,
+bool AnalyzerKey::initialize(const AnalyzerTrack& tio,
         mixxx::audio::SampleRate sampleRate,
         int totalSamples) {
     if (totalSamples == 0) {

--- a/src/analyzer/analyzerkey.cpp
+++ b/src/analyzer/analyzerkey.cpp
@@ -3,6 +3,7 @@
 #include <QVector>
 #include <QtDebug>
 
+#include "analyzer/analyzertrack.h"
 #include "analyzer/constants.h"
 #if defined __KEYFINDER__
 #include "analyzer/plugins/analyzerkeyfinder.h"
@@ -41,7 +42,7 @@ AnalyzerKey::AnalyzerKey(const KeyDetectionSettings& keySettings)
           m_bPreferencesReanalyzeEnabled(false) {
 }
 
-bool AnalyzerKey::initialize(TrackPointer tio,
+bool AnalyzerKey::initialize(AnalyzerTrack tio,
         mixxx::audio::SampleRate sampleRate,
         int totalSamples) {
     if (totalSamples == 0) {
@@ -86,7 +87,7 @@ bool AnalyzerKey::initialize(TrackPointer tio,
     m_iCurrentSample = 0;
 
     // if we can't load a stored track reanalyze it
-    bool bShouldAnalyze = shouldAnalyze(tio);
+    bool bShouldAnalyze = shouldAnalyze(tio.getTrack());
 
     DEBUG_ASSERT(!m_pPlugin);
     if (bShouldAnalyze) {

--- a/src/analyzer/analyzerkey.h
+++ b/src/analyzer/analyzerkey.h
@@ -5,6 +5,7 @@
 #include <QString>
 
 #include "analyzer/analyzer.h"
+#include "analyzer/analyzertrack.h"
 #include "analyzer/plugins/analyzerplugin.h"
 #include "preferences/keydetectionsettings.h"
 #include "preferences/usersettings.h"
@@ -19,7 +20,7 @@ class AnalyzerKey : public Analyzer {
     static QList<mixxx::AnalyzerPluginInfo> availablePlugins();
     static mixxx::AnalyzerPluginInfo defaultPlugin();
 
-    bool initialize(TrackPointer tio,
+    bool initialize(AnalyzerTrack tio,
             mixxx::audio::SampleRate sampleRate,
             int totalSamples) override;
     bool processSamples(const CSAMPLE *pIn, const int iLen) override;

--- a/src/analyzer/analyzerkey.h
+++ b/src/analyzer/analyzerkey.h
@@ -20,7 +20,7 @@ class AnalyzerKey : public Analyzer {
     static QList<mixxx::AnalyzerPluginInfo> availablePlugins();
     static mixxx::AnalyzerPluginInfo defaultPlugin();
 
-    bool initialize(AnalyzerTrack tio,
+    bool initialize(const AnalyzerTrack& tio,
             mixxx::audio::SampleRate sampleRate,
             int totalSamples) override;
     bool processSamples(const CSAMPLE *pIn, const int iLen) override;

--- a/src/analyzer/analyzerscheduledtrack.cpp
+++ b/src/analyzer/analyzerscheduledtrack.cpp
@@ -4,13 +4,13 @@
 #include "track/trackid.h"
 
 AnalyzerScheduledTrack::AnalyzerScheduledTrack(TrackId trackId, AnalyzerTrack::Options options)
-        : trackId(trackId), options(options) {
+        : m_trackId(trackId), m_options(options) {
 }
 
-const TrackId AnalyzerScheduledTrack::getTrackId() const {
-    return trackId;
+const TrackId& AnalyzerScheduledTrack::getTrackId() const {
+    return m_trackId;
 }
 
-const AnalyzerTrack::Options AnalyzerScheduledTrack::getOptions() const {
-    return options;
+const AnalyzerTrack::Options& AnalyzerScheduledTrack::getOptions() const {
+    return m_options;
 }

--- a/src/analyzer/analyzerscheduledtrack.cpp
+++ b/src/analyzer/analyzerscheduledtrack.cpp
@@ -1,0 +1,16 @@
+#include "analyzer/analyzerscheduledtrack.h"
+
+#include "analyzer/analyzertrack.h"
+#include "track/trackid.h"
+
+AnalyzerScheduledTrack::AnalyzerScheduledTrack(TrackId trackId, AnalyzerTrack::Options options)
+        : trackId(trackId), options(options) {
+}
+
+const TrackId AnalyzerScheduledTrack::getTrackId() const {
+    return trackId;
+}
+
+const AnalyzerTrack::Options AnalyzerScheduledTrack::getOptions() const {
+    return options;
+}

--- a/src/analyzer/analyzerscheduledtrack.h
+++ b/src/analyzer/analyzerscheduledtrack.h
@@ -13,14 +13,14 @@ class AnalyzerScheduledTrack {
             AnalyzerTrack::Options options = AnalyzerTrack::Options());
 
     /// Fetches the id of the track to be analyzed.
-    const TrackId getTrackId() const;
+    const TrackId& getTrackId() const;
 
     /// Fetches the additional options.
-    const AnalyzerTrack::Options getOptions() const;
+    const AnalyzerTrack::Options& getOptions() const;
 
   private:
     /// The id of the track to be analyzed.
-    TrackId trackId;
+    TrackId m_trackId;
     /// The additional options.
-    AnalyzerTrack::Options options;
+    AnalyzerTrack::Options m_options;
 };

--- a/src/analyzer/analyzerscheduledtrack.h
+++ b/src/analyzer/analyzerscheduledtrack.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <optional>
+
+#include "analyzer/analyzertrack.h"
+#include "track/track_decl.h"
+#include "track/trackid.h"
+
+/// A track to be scheduled for analysis with additional options.
+class AnalyzerScheduledTrack {
+  public:
+    AnalyzerScheduledTrack(TrackId trackId,
+            AnalyzerTrack::Options options = AnalyzerTrack::Options());
+
+    /// Fetches the id of the track to be analyzed.
+    const TrackId getTrackId() const;
+
+    /// Fetches the additional options.
+    const AnalyzerTrack::Options getOptions() const;
+
+  private:
+    /// The id of the track to be analyzed.
+    TrackId trackId;
+    /// The additional options.
+    AnalyzerTrack::Options options;
+};

--- a/src/analyzer/analyzersilence.cpp
+++ b/src/analyzer/analyzersilence.cpp
@@ -33,7 +33,7 @@ AnalyzerSilence::AnalyzerSilence(UserSettingsPointer pConfig)
           m_iSignalEnd(-1) {
 }
 
-bool AnalyzerSilence::initialize(AnalyzerTrack track,
+bool AnalyzerSilence::initialize(const AnalyzerTrack& track,
         mixxx::audio::SampleRate sampleRate,
         int totalSamples) {
     Q_UNUSED(sampleRate);

--- a/src/analyzer/analyzersilence.cpp
+++ b/src/analyzer/analyzersilence.cpp
@@ -1,5 +1,6 @@
 #include "analyzer/analyzersilence.h"
 
+#include "analyzer/analyzertrack.h"
 #include "analyzer/constants.h"
 #include "engine/engine.h"
 #include "track/track.h"
@@ -32,13 +33,13 @@ AnalyzerSilence::AnalyzerSilence(UserSettingsPointer pConfig)
           m_iSignalEnd(-1) {
 }
 
-bool AnalyzerSilence::initialize(TrackPointer pTrack,
+bool AnalyzerSilence::initialize(AnalyzerTrack track,
         mixxx::audio::SampleRate sampleRate,
         int totalSamples) {
     Q_UNUSED(sampleRate);
     Q_UNUSED(totalSamples);
 
-    if (!shouldAnalyze(pTrack)) {
+    if (!shouldAnalyze(track.getTrack())) {
         return false;
     }
 

--- a/src/analyzer/analyzersilence.h
+++ b/src/analyzer/analyzersilence.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "analyzer/analyzer.h"
+#include "analyzer/analyzertrack.h"
 #include "preferences/usersettings.h"
 
 class CuePointer;
@@ -10,7 +11,7 @@ class AnalyzerSilence : public Analyzer {
     explicit AnalyzerSilence(UserSettingsPointer pConfig);
     ~AnalyzerSilence() override = default;
 
-    bool initialize(TrackPointer pTrack,
+    bool initialize(AnalyzerTrack track,
             mixxx::audio::SampleRate sampleRate,
             int totalSamples) override;
     bool processSamples(const CSAMPLE* pIn, const int iLen) override;

--- a/src/analyzer/analyzersilence.h
+++ b/src/analyzer/analyzersilence.h
@@ -11,7 +11,7 @@ class AnalyzerSilence : public Analyzer {
     explicit AnalyzerSilence(UserSettingsPointer pConfig);
     ~AnalyzerSilence() override = default;
 
-    bool initialize(AnalyzerTrack track,
+    bool initialize(const AnalyzerTrack& track,
             mixxx::audio::SampleRate sampleRate,
             int totalSamples) override;
     bool processSamples(const CSAMPLE* pIn, const int iLen) override;

--- a/src/analyzer/analyzerthread.cpp
+++ b/src/analyzer/analyzerthread.cpp
@@ -188,7 +188,6 @@ void AnalyzerThread::doRun() {
 }
 
 bool AnalyzerThread::submitNextTrack(const AnalyzerTrack& nextTrack) {
-    DEBUG_ASSERT(nextTrack.getTrack());
     kLogger.debug()
             << "Enqueueing next track"
             << nextTrack.getTrack()->getId();

--- a/src/analyzer/analyzerthread.cpp
+++ b/src/analyzer/analyzerthread.cpp
@@ -126,16 +126,16 @@ void AnalyzerThread::doRun() {
     openParams.setChannelCount(mixxx::kAnalysisChannels);
 
     while (awaitWorkItemsFetched()) {
-        DEBUG_ASSERT(m_currentTrack);
-        kLogger.debug() << "Analyzing" << m_currentTrack->getFileInfo();
+        DEBUG_ASSERT(m_currentTrack.has_value());
+        kLogger.debug() << "Analyzing" << m_currentTrack->getTrack()->getFileInfo();
 
         // Get the audio
         const auto audioSource =
-                SoundSourceProxy(m_currentTrack).openAudioSource(openParams);
+                SoundSourceProxy(m_currentTrack->getTrack()).openAudioSource(openParams);
         if (!audioSource) {
             kLogger.warning()
                     << "Failed to open file for analyzing:"
-                    << m_currentTrack->getFileInfo();
+                    << m_currentTrack->getTrack()->getFileInfo();
             emitDoneProgress(kAnalyzerProgressUnknown);
             continue;
         }
@@ -144,7 +144,7 @@ void AnalyzerThread::doRun() {
         for (auto&& analyzer : m_analyzers) {
             // Make sure not to short-circuit initialize(...)
             if (analyzer.initialize(
-                        m_currentTrack,
+                        *m_currentTrack,
                         audioSource->getSignalInfo().getSampleRate(),
                         audioSource->frameLength() * mixxx::kAnalysisChannels)) {
                 processTrack = true;
@@ -164,7 +164,7 @@ void AnalyzerThread::doRun() {
                 emitBusyProgress(kAnalyzerProgressFinalizing);
                 // This takes around 3 sec on a Atom Netbook
                 for (auto&& analyzer : m_analyzers) {
-                    analyzer.finish(m_currentTrack);
+                    analyzer.finish(*m_currentTrack);
                 }
                 emitDoneProgress(kAnalyzerProgressDone);
             } else {
@@ -187,11 +187,11 @@ void AnalyzerThread::doRun() {
     emitProgress(AnalyzerThreadState::Exit);
 }
 
-bool AnalyzerThread::submitNextTrack(TrackPointer nextTrack) {
-    DEBUG_ASSERT(nextTrack);
+bool AnalyzerThread::submitNextTrack(AnalyzerTrack nextTrack) {
+    DEBUG_ASSERT(nextTrack.getTrack());
     kLogger.debug()
             << "Enqueueing next track"
-            << nextTrack->getId();
+            << nextTrack.getTrack()->getId();
     if (m_nextTrack.try_emplace(std::move(nextTrack))) {
         // Ensure that the submitted track gets processed eventually
         // by waking the worker thread up after adding a new task to
@@ -204,14 +204,14 @@ bool AnalyzerThread::submitNextTrack(TrackPointer nextTrack) {
 }
 
 WorkerThread::TryFetchWorkItemsResult AnalyzerThread::tryFetchWorkItems() {
-    DEBUG_ASSERT(!m_currentTrack);
-    TrackPointer* pFront = m_nextTrack.front();
+    DEBUG_ASSERT(!m_currentTrack.has_value());
+    AnalyzerTrack* pFront = m_nextTrack.front();
     if (pFront) {
         m_currentTrack = *pFront;
         m_nextTrack.pop();
         kLogger.debug()
                 << "Dequeued next track"
-                << m_currentTrack->getId();
+                << m_currentTrack->getTrack()->getId();
         return TryFetchWorkItemsResult::Ready;
     } else {
         emitProgress(AnalyzerThreadState::Idle);
@@ -221,7 +221,7 @@ WorkerThread::TryFetchWorkItemsResult AnalyzerThread::tryFetchWorkItems() {
 
 AnalyzerThread::AnalysisResult AnalyzerThread::analyzeAudioSource(
         const mixxx::AudioSourcePointer& audioSource) {
-    DEBUG_ASSERT(m_currentTrack);
+    DEBUG_ASSERT(m_currentTrack.has_value());
 
     mixxx::AudioSourceStereoProxy audioSourceProxy(
             audioSource,
@@ -331,7 +331,7 @@ AnalyzerThread::AnalysisResult AnalyzerThread::analyzeAudioSource(
 }
 
 void AnalyzerThread::emitBusyProgress(AnalyzerProgress busyProgress) {
-    DEBUG_ASSERT(m_currentTrack);
+    DEBUG_ASSERT(m_currentTrack.has_value());
     if ((m_emittedState == AnalyzerThreadState::Busy) &&
             (m_lastBusyProgressEmittedTimer.elapsed() < kBusyProgressInhibitDuration)) {
         // Don't emit progress signal while still busy and the
@@ -341,18 +341,18 @@ void AnalyzerThread::emitBusyProgress(AnalyzerProgress busyProgress) {
         return;
     }
     m_lastBusyProgressEmittedTimer.restart();
-    emitProgress(AnalyzerThreadState::Busy, m_currentTrack->getId(), busyProgress);
+    emitProgress(AnalyzerThreadState::Busy, m_currentTrack->getTrack()->getId(), busyProgress);
     DEBUG_ASSERT(m_emittedState == AnalyzerThreadState::Busy);
 }
 
 void AnalyzerThread::emitDoneProgress(AnalyzerProgress doneProgress) {
-    DEBUG_ASSERT(m_currentTrack);
+    DEBUG_ASSERT(m_currentTrack.has_value());
     // Release all references of the track before emitting the signal
     // to ensure that the last reference is not dropped in this worker
     // thread that might trigger database actions! The TrackAnalysisScheduler
     // must store a TrackPointer until receiving the Done signal.
-    TrackId trackId = m_currentTrack->getId();
-    m_currentTrack->analysisFinished();
+    TrackId trackId = m_currentTrack->getTrack()->getId();
+    m_currentTrack->getTrack()->analysisFinished();
     m_currentTrack.reset();
     emitProgress(AnalyzerThreadState::Done, trackId, doneProgress);
 }
@@ -363,8 +363,8 @@ void AnalyzerThread::emitProgress(AnalyzerThreadState state) {
 }
 
 void AnalyzerThread::emitProgress(AnalyzerThreadState state, TrackId trackId, AnalyzerProgress trackProgress) {
-    DEBUG_ASSERT(!m_currentTrack || (state == AnalyzerThreadState::Busy));
-    DEBUG_ASSERT(!m_currentTrack || (m_currentTrack->getId() == trackId));
+    DEBUG_ASSERT(!m_currentTrack.has_value() || (state == AnalyzerThreadState::Busy));
+    DEBUG_ASSERT(!m_currentTrack.has_value() || (m_currentTrack->getTrack()->getId() == trackId));
     DEBUG_ASSERT(trackId.isValid() || (trackProgress == kAnalyzerProgressUnknown));
     m_emittedState = state;
     emit progress(m_id, m_emittedState, trackId, trackProgress);

--- a/src/analyzer/analyzerthread.cpp
+++ b/src/analyzer/analyzerthread.cpp
@@ -187,7 +187,7 @@ void AnalyzerThread::doRun() {
     emitProgress(AnalyzerThreadState::Exit);
 }
 
-bool AnalyzerThread::submitNextTrack(AnalyzerTrack nextTrack) {
+bool AnalyzerThread::submitNextTrack(const AnalyzerTrack& nextTrack) {
     DEBUG_ASSERT(nextTrack.getTrack());
     kLogger.debug()
             << "Enqueueing next track"

--- a/src/analyzer/analyzerthread.h
+++ b/src/analyzer/analyzerthread.h
@@ -77,7 +77,7 @@ class AnalyzerThread : public WorkerThread {
     // with state Idle has been received to avoid overwriting
     // a previously sent track that has not been received by the
     // worker thread, yet.
-    bool submitNextTrack(AnalyzerTrack nextTrack);
+    bool submitNextTrack(const AnalyzerTrack& nextTrack);
 
   signals:
     // Use a single signal for progress updates to ensure that all signals

--- a/src/analyzer/analyzerthread.h
+++ b/src/analyzer/analyzerthread.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <optional>
 #include <vector>
 
 #include "analyzer/analyzer.h"
 #include "analyzer/analyzerprogress.h"
+#include "analyzer/analyzertrack.h"
 #include "preferences/usersettings.h"
 #include "rigtorp/SPSCQueue.h"
 #include "sources/audiosource.h"
@@ -75,7 +77,7 @@ class AnalyzerThread : public WorkerThread {
     // with state Idle has been received to avoid overwriting
     // a previously sent track that has not been received by the
     // worker thread, yet.
-    bool submitNextTrack(TrackPointer nextTrack);
+    bool submitNextTrack(AnalyzerTrack nextTrack);
 
   signals:
     // Use a single signal for progress updates to ensure that all signals
@@ -108,7 +110,7 @@ class AnalyzerThread : public WorkerThread {
     // safely exchanging data between two threads.
     // NOTE(uklotzde, 2018-01-04): Ideally we would use std::atomic<TrackPointer>,
     // for this purpose, which will become available in C++20.
-    rigtorp::SPSCQueue<TrackPointer> m_nextTrack;
+    rigtorp::SPSCQueue<AnalyzerTrack> m_nextTrack;
 
     /////////////////////////////////////////////////////////////////////////
     // Thread local: Only used in the constructor/destructor and within
@@ -118,7 +120,7 @@ class AnalyzerThread : public WorkerThread {
 
     mixxx::SampleBuffer m_sampleBuffer;
 
-    TrackPointer m_currentTrack;
+    std::optional<AnalyzerTrack> m_currentTrack;
 
     AnalyzerThreadState m_emittedState;
 

--- a/src/analyzer/analyzertrack.cpp
+++ b/src/analyzer/analyzertrack.cpp
@@ -1,0 +1,13 @@
+#include "analyzer/analyzertrack.h"
+
+AnalyzerTrack::AnalyzerTrack(TrackPointer track, Options options)
+        : track(track), options(options) {
+}
+
+const TrackPointer AnalyzerTrack::getTrack() const {
+    return track;
+}
+
+const AnalyzerTrack::Options AnalyzerTrack::getOptions() const {
+    return options;
+}

--- a/src/analyzer/analyzertrack.cpp
+++ b/src/analyzer/analyzertrack.cpp
@@ -1,10 +1,13 @@
 #include "analyzer/analyzertrack.h"
 
+#include "util/assert.h"
+
 AnalyzerTrack::AnalyzerTrack(TrackPointer track, Options options)
         : track(track), options(options) {
+    DEBUG_ASSERT(track);
 }
 
-const TrackPointer AnalyzerTrack::getTrack() const {
+const TrackPointer& AnalyzerTrack::getTrack() const {
     return track;
 }
 

--- a/src/analyzer/analyzertrack.cpp
+++ b/src/analyzer/analyzertrack.cpp
@@ -3,14 +3,14 @@
 #include "util/assert.h"
 
 AnalyzerTrack::AnalyzerTrack(TrackPointer track, Options options)
-        : track(track), options(options) {
+        : m_track(track), m_options(options) {
     DEBUG_ASSERT(track);
 }
 
 const TrackPointer& AnalyzerTrack::getTrack() const {
-    return track;
+    return m_track;
 }
 
-const AnalyzerTrack::Options AnalyzerTrack::getOptions() const {
-    return options;
+const AnalyzerTrack::Options& AnalyzerTrack::getOptions() const {
+    return m_options;
 }

--- a/src/analyzer/analyzertrack.h
+++ b/src/analyzer/analyzertrack.h
@@ -12,7 +12,7 @@ class AnalyzerTrack {
         std::optional<bool> useFixedTempo;
     };
 
-    AnalyzerTrack(TrackPointer track, Options options);
+    AnalyzerTrack(TrackPointer track, Options options = Options());
 
     /// Fetches the track to be analyzed.
     const TrackPointer getTrack() const;
@@ -22,7 +22,7 @@ class AnalyzerTrack {
 
   private:
     /// The track to be analyzed.
-    const TrackPointer track;
+    TrackPointer track;
     /// The additional options.
-    const Options options;
+    Options options;
 };

--- a/src/analyzer/analyzertrack.h
+++ b/src/analyzer/analyzertrack.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <optional>
+
+#include "track/track_decl.h"
+
+/// A schedulable track with additional options for analysis.
+class AnalyzerTrack {
+  public:
+    struct Options {
+        /// If set, overrides whether the analysis should assume constant BPM.
+        std::optional<bool> useFixedTempo;
+    };
+
+    AnalyzerTrack(TrackPointer track, Options options);
+
+    /// Fetches the track to be analyzed.
+    const TrackPointer getTrack() const;
+
+    /// Fetches the additional options.
+    const Options getOptions() const;
+
+  private:
+    /// The track to be analyzed.
+    const TrackPointer track;
+    /// The additional options.
+    const Options options;
+};

--- a/src/analyzer/analyzertrack.h
+++ b/src/analyzer/analyzertrack.h
@@ -4,7 +4,7 @@
 
 #include "track/track_decl.h"
 
-/// A schedulable track with additional options for analysis.
+/// A scheduled track with additional options for analysis.
 class AnalyzerTrack {
   public:
     struct Options {

--- a/src/analyzer/analyzertrack.h
+++ b/src/analyzer/analyzertrack.h
@@ -4,7 +4,7 @@
 
 #include "track/track_decl.h"
 
-/// A scheduled track with additional options for analysis.
+/// A scheduled not-null track with additional options for analysis.
 class AnalyzerTrack {
   public:
     struct Options {
@@ -14,14 +14,14 @@ class AnalyzerTrack {
 
     AnalyzerTrack(TrackPointer track, Options options = Options());
 
-    /// Fetches the track to be analyzed.
-    const TrackPointer getTrack() const;
+    /// Fetches the (not-null) track to be analyzed.
+    const TrackPointer& getTrack() const;
 
     /// Fetches the additional options.
     const Options getOptions() const;
 
   private:
-    /// The track to be analyzed.
+    /// The (not-null) track to be analyzed.
     TrackPointer track;
     /// The additional options.
     Options options;

--- a/src/analyzer/analyzertrack.h
+++ b/src/analyzer/analyzertrack.h
@@ -18,11 +18,11 @@ class AnalyzerTrack {
     const TrackPointer& getTrack() const;
 
     /// Fetches the additional options.
-    const Options getOptions() const;
+    const Options& getOptions() const;
 
   private:
     /// The (not-null) track to be analyzed.
-    TrackPointer track;
+    TrackPointer m_track;
     /// The additional options.
-    Options options;
+    Options m_options;
 };

--- a/src/analyzer/analyzerwaveform.cpp
+++ b/src/analyzer/analyzerwaveform.cpp
@@ -34,7 +34,7 @@ AnalyzerWaveform::~AnalyzerWaveform() {
     destroyFilters();
 }
 
-bool AnalyzerWaveform::initialize(AnalyzerTrack tio,
+bool AnalyzerWaveform::initialize(const AnalyzerTrack& tio,
         mixxx::audio::SampleRate sampleRate,
         int totalSamples) {
     if (totalSamples == 0) {

--- a/src/analyzer/analyzerwaveform.cpp
+++ b/src/analyzer/analyzerwaveform.cpp
@@ -1,5 +1,6 @@
 #include "analyzer/analyzerwaveform.h"
 
+#include "analyzer/analyzertrack.h"
 #include "engine/engineobject.h"
 #include "engine/filters/enginefilterbessel4.h"
 #include "engine/filters/enginefilterbutterworth8.h"
@@ -33,7 +34,7 @@ AnalyzerWaveform::~AnalyzerWaveform() {
     destroyFilters();
 }
 
-bool AnalyzerWaveform::initialize(TrackPointer tio,
+bool AnalyzerWaveform::initialize(AnalyzerTrack tio,
         mixxx::audio::SampleRate sampleRate,
         int totalSamples) {
     if (totalSamples == 0) {
@@ -42,7 +43,7 @@ bool AnalyzerWaveform::initialize(TrackPointer tio,
     }
 
     // If we don't need to calculate the waveform/wavesummary, skip.
-    if (!shouldAnalyze(tio)) {
+    if (!shouldAnalyze(tio.getTrack())) {
         return false;
     }
 
@@ -65,8 +66,8 @@ bool AnalyzerWaveform::initialize(TrackPointer tio,
     // Now, that the Waveform memory is initialized, we can set set them to
     // the TIO. Be aware that other threads of Mixxx can touch them from
     // now.
-    tio->setWaveform(m_waveform);
-    tio->setWaveformSummary(m_waveformSummary);
+    tio.getTrack()->setWaveform(m_waveform);
+    tio.getTrack()->setWaveformSummary(m_waveformSummary);
 
     m_waveformData = m_waveform->data();
     m_waveformSummaryData = m_waveformSummary->data();

--- a/src/analyzer/analyzerwaveform.h
+++ b/src/analyzer/analyzerwaveform.h
@@ -141,7 +141,7 @@ class AnalyzerWaveform : public Analyzer {
             const QSqlDatabase& dbConnection);
     ~AnalyzerWaveform() override;
 
-    bool initialize(AnalyzerTrack tio,
+    bool initialize(const AnalyzerTrack& tio,
             mixxx::audio::SampleRate sampleRate,
             int totalSamples) override;
     bool processSamples(const CSAMPLE* buffer, const int bufferLength) override;

--- a/src/analyzer/analyzerwaveform.h
+++ b/src/analyzer/analyzerwaveform.h
@@ -6,6 +6,7 @@
 #include <limits>
 
 #include "analyzer/analyzer.h"
+#include "analyzer/analyzertrack.h"
 #include "library/dao/analysisdao.h"
 #include "util/performancetimer.h"
 #include "waveform/waveform.h"
@@ -140,7 +141,7 @@ class AnalyzerWaveform : public Analyzer {
             const QSqlDatabase& dbConnection);
     ~AnalyzerWaveform() override;
 
-    bool initialize(TrackPointer tio,
+    bool initialize(AnalyzerTrack tio,
             mixxx::audio::SampleRate sampleRate,
             int totalSamples) override;
     bool processSamples(const CSAMPLE* buffer, const int bufferLength) override;

--- a/src/analyzer/trackanalysisscheduler.cpp
+++ b/src/analyzer/trackanalysisscheduler.cpp
@@ -1,5 +1,6 @@
 #include "analyzer/trackanalysisscheduler.h"
 
+#include "analyzer/analyzertrack.h"
 #include "moc_trackanalysisscheduler.cpp"
 #include "track/track.h"
 #include "util/logger.h"
@@ -279,9 +280,10 @@ bool TrackAnalysisScheduler::submitNextTrack(Worker* worker) {
         TrackId nextTrackId = m_queuedTrackIds.front();
         DEBUG_ASSERT(nextTrackId.isValid());
         if (nextTrackId.isValid()) {
-            TrackPointer nextTrack =
+            TrackPointer nextTrackPtr =
                     m_pEnvironment->loadTrackById(nextTrackId);
-            if (nextTrack) {
+            if (nextTrackPtr) {
+                AnalyzerTrack nextTrack(nextTrackPtr, AnalyzerTrack::Options());
                 if (m_pendingTrackIds.insert(nextTrackId).second) {
                     if (worker->submitNextTrack(std::move(nextTrack))) {
                         m_queuedTrackIds.pop_front();

--- a/src/analyzer/trackanalysisscheduler.h
+++ b/src/analyzer/trackanalysisscheduler.h
@@ -6,6 +6,7 @@
 #include <set>
 #include <vector>
 
+#include "analyzer/analyzerscheduledtrack.h"
 #include "analyzer/analyzerthread.h"
 #include "analyzer/analyzertrack.h"
 #include "util/db/dbconnectionpool.h"
@@ -50,8 +51,8 @@ class TrackAnalysisScheduler : public QObject {
 
     // Schedule single or multiple tracks. After all tracks have been scheduled
     // the caller must invoke resume() once.
-    bool scheduleTrackById(TrackId trackId);
-    int scheduleTracksById(const QList<TrackId>& trackIds);
+    bool scheduleTrack(AnalyzerScheduledTrack track);
+    int scheduleTracks(const QList<AnalyzerScheduledTrack>& tracks);
 
   public slots:
     void suspend();
@@ -143,7 +144,7 @@ class TrackAnalysisScheduler : public QObject {
     void emitProgressOrFinished();
 
     bool allTracksFinished() const {
-        return m_queuedTrackIds.empty() &&
+        return m_queuedTracks.empty() &&
                 m_pendingTrackIds.empty();
     }
 
@@ -151,7 +152,7 @@ class TrackAnalysisScheduler : public QObject {
 
     std::vector<Worker> m_workers;
 
-    std::deque<TrackId> m_queuedTrackIds;
+    std::deque<AnalyzerScheduledTrack> m_queuedTracks;
 
     // Tracks that have already been submitted to workers
     // and not yet reported back as finished.

--- a/src/analyzer/trackanalysisscheduler.h
+++ b/src/analyzer/trackanalysisscheduler.h
@@ -101,7 +101,7 @@ class TrackAnalysisScheduler : public QObject {
             return m_analyzerProgress;
         }
 
-        bool submitNextTrack(AnalyzerTrack track) {
+        bool submitNextTrack(const AnalyzerTrack& track) {
             DEBUG_ASSERT(m_thread);
             return m_thread->submitNextTrack(std::move(track));
         }

--- a/src/analyzer/trackanalysisscheduler.h
+++ b/src/analyzer/trackanalysisscheduler.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "analyzer/analyzerthread.h"
+#include "analyzer/analyzertrack.h"
 #include "util/db/dbconnectionpool.h"
 
 /// Callbacks for triggering side-effects in the outer context of
@@ -99,8 +100,7 @@ class TrackAnalysisScheduler : public QObject {
             return m_analyzerProgress;
         }
 
-        bool submitNextTrack(TrackPointer track) {
-            DEBUG_ASSERT(track);
+        bool submitNextTrack(AnalyzerTrack track) {
             DEBUG_ASSERT(m_thread);
             return m_thread->submitNextTrack(std::move(track));
         }

--- a/src/library/analysisfeature.cpp
+++ b/src/library/analysisfeature.cpp
@@ -1,7 +1,10 @@
 #include "library/analysisfeature.h"
 
+#include <qlist.h>
+
 #include <QtDebug>
 
+#include "analyzer/analyzerscheduledtrack.h"
 #include "controllers/keyboard/keyboardeventfilter.h"
 #include "library/dlganalysis.h"
 #include "library/library.h"
@@ -130,7 +133,7 @@ void AnalysisFeature::activate() {
     emit enableCoverArtDisplay(true);
 }
 
-void AnalysisFeature::analyzeTracks(const QList<TrackId>& trackIds) {
+void AnalysisFeature::analyzeTracks(const QList<AnalyzerScheduledTrack>& tracks) {
     if (!m_pTrackAnalysisScheduler) {
         const int numAnalyzerThreads = numberOfAnalyzerThreads();
         kLogger.info()
@@ -161,7 +164,7 @@ void AnalysisFeature::analyzeTracks(const QList<TrackId>& trackIds) {
         emit analysisActive(true);
     }
 
-    if (m_pTrackAnalysisScheduler->scheduleTracksById(trackIds) > 0) {
+    if (m_pTrackAnalysisScheduler->scheduleTracks(tracks) > 0) {
         resumeAnalysis();
     }
 }
@@ -228,8 +231,12 @@ bool AnalysisFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) {
             m_pLibrary->trackCollectionManager()->resolveTrackIdsFromUrls(
                     urls,
                     !pSource);
-    analyzeTracks(trackIds);
-    return trackIds.size() > 0;
+    QList<AnalyzerScheduledTrack> tracks;
+    for (auto trackId : trackIds) {
+        tracks.append(trackId);
+    }
+    analyzeTracks(tracks);
+    return tracks.size() > 0;
 }
 
 bool AnalysisFeature::dragMoveAccept(const QUrl& url) {

--- a/src/library/analysisfeature.h
+++ b/src/library/analysisfeature.h
@@ -7,6 +7,7 @@
 #include <QUrl>
 #include <QVariant>
 
+#include "analyzer/analyzerscheduledtrack.h"
 #include "analyzer/trackanalysisscheduler.h"
 #include "library/dlganalysis.h"
 #include "library/libraryfeature.h"
@@ -40,7 +41,7 @@ class AnalysisFeature : public LibraryFeature {
 
   public slots:
     void activate() override;
-    void analyzeTracks(const QList<TrackId>& trackIds);
+    void analyzeTracks(const QList<AnalyzerScheduledTrack>& tracks);
 
     void suspendAnalysis();
     void resumeAnalysis();

--- a/src/library/dlganalysis.cpp
+++ b/src/library/dlganalysis.cpp
@@ -3,6 +3,7 @@
 #include <QSqlTableModel>
 
 #include "analyzer/analyzerprogress.h"
+#include "analyzer/analyzerscheduledtrack.h"
 #include "library/dao/trackschema.h"
 #include "library/library.h"
 #include "library/trackcollectionmanager.h"
@@ -161,7 +162,7 @@ void DlgAnalysis::analyze() {
     if (m_bAnalysisActive) {
         emit stopAnalysis();
     } else {
-        QList<TrackId> trackIds;
+        QList<AnalyzerScheduledTrack> tracks;
 
         QModelIndexList selectedIndexes = m_pAnalysisLibraryTableView->selectionModel()->selectedRows();
         foreach(QModelIndex selectedIndex, selectedIndexes) {
@@ -169,10 +170,10 @@ void DlgAnalysis::analyze() {
                 selectedIndex.row(),
                 m_pAnalysisLibraryTableModel->fieldIndex(LIBRARYTABLE_ID)).data());
             if (trackId.isValid()) {
-                trackIds.append(trackId);
+                tracks.append(trackId);
             }
         }
-        emit analyzeTracks(trackIds);
+        emit analyzeTracks(tracks);
     }
 }
 

--- a/src/library/dlganalysis.h
+++ b/src/library/dlganalysis.h
@@ -4,6 +4,7 @@
 #include <QItemSelection>
 
 #include "analyzer/analyzerprogress.h"
+#include "analyzer/analyzerscheduledtrack.h"
 #include "library/analysislibrarytablemodel.h"
 #include "library/libraryview.h"
 #include "library/ui_dlganalysis.h"
@@ -53,7 +54,7 @@ class DlgAnalysis : public QWidget, public Ui::DlgAnalysis, public virtual Libra
   signals:
     void loadTrack(TrackPointer pTrack);
     void loadTrackToPlayer(TrackPointer pTrack, const QString& player);
-    void analyzeTracks(const QList<TrackId>& trackIds);
+    void analyzeTracks(const QList<AnalyzerScheduledTrack>& tracks);
     void stopAnalysis();
     void trackSelected(TrackPointer pTrack);
 

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -6,6 +6,7 @@
 #include <QObject>
 #include <QPointer>
 
+#include "analyzer/analyzerscheduledtrack.h"
 #include "analyzer/trackanalysisscheduler.h"
 #include "library/library_decl.h"
 #ifdef __ENGINEPRIME__
@@ -131,7 +132,7 @@ class Library: public QObject {
     void enableCoverArtDisplay(bool);
     void selectTrack(const TrackId&);
     void trackSelected(TrackPointer pTrack);
-    void analyzeTracks(const QList<TrackId>& trackIds);
+    void analyzeTracks(const QList<AnalyzerScheduledTrack>& tracks);
 #ifdef __ENGINEPRIME__
     void exportLibrary();
     void exportCrate(CrateId crateId);

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -1,5 +1,7 @@
 #include "library/trackset/baseplaylistfeature.h"
 
+#include <qlist.h>
+
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QInputDialog>
@@ -19,6 +21,7 @@
 #include "library/treeitemmodel.h"
 #include "moc_baseplaylistfeature.cpp"
 #include "track/track.h"
+#include "track/trackid.h"
 #include "util/assert.h"
 #include "util/file.h"
 #include "widget/wlibrary.h"
@@ -652,7 +655,11 @@ void BasePlaylistFeature::slotAnalyzePlaylist() {
         int playlistId = playlistIdFromIndex(m_lastRightClickedIndex);
         if (playlistId >= 0) {
             QList<TrackId> ids = m_playlistDao.getTrackIds(playlistId);
-            emit analyzeTracks(ids);
+            QList<AnalyzerScheduledTrack> tracks;
+            for (auto id : ids) {
+                tracks.append(id);
+            }
+            emit analyzeTracks(tracks);
         }
     }
 }

--- a/src/library/trackset/basetracksetfeature.h
+++ b/src/library/trackset/basetracksetfeature.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "analyzer/analyzerscheduledtrack.h"
 #include "library/libraryfeature.h"
 #include "util/parented_ptr.h"
 
@@ -13,7 +14,7 @@ class BaseTrackSetFeature : public LibraryFeature {
             const QString& iconName);
 
   signals:
-    void analyzeTracks(const QList<TrackId>&);
+    void analyzeTracks(const QList<AnalyzerScheduledTrack>&);
 
   public slots:
     void activate() override;

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <vector>
 
+#include "analyzer/analyzerscheduledtrack.h"
 #include "library/export/trackexportwizard.h"
 #include "library/library.h"
 #include "library/library_prefs.h"
@@ -686,18 +687,18 @@ void CrateFeature::slotAnalyzeCrate() {
     if (m_lastRightClickedIndex.isValid()) {
         CrateId crateId = crateIdFromIndex(m_lastRightClickedIndex);
         if (crateId.isValid()) {
-            QList<TrackId> trackIds;
-            trackIds.reserve(
+            QList<AnalyzerScheduledTrack> tracks;
+            tracks.reserve(
                     m_pTrackCollection->crates().countCrateTracks(crateId));
             {
                 CrateTrackSelectResult crateTracks(
                         m_pTrackCollection->crates().selectCrateTracksSorted(
                                 crateId));
                 while (crateTracks.next()) {
-                    trackIds.append(crateTracks.trackId());
+                    tracks.append(crateTracks.trackId());
                 }
             }
-            emit analyzeTracks(trackIds);
+            emit analyzeTracks(tracks);
         }
     }
 }

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -737,7 +737,7 @@ void PlayerManager::slotAnalyzeTrack(TrackPointer track) {
         return;
     }
     if (m_pTrackAnalysisScheduler) {
-        if (m_pTrackAnalysisScheduler->scheduleTrackById(track->getId())) {
+        if (m_pTrackAnalysisScheduler->scheduleTrack(track->getId())) {
             m_pTrackAnalysisScheduler->resume();
         }
         // The first progress signal will suspend a running batch analysis

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -9,6 +9,8 @@
 #include <QModelIndex>
 #include <QVBoxLayout>
 
+#include "analyzer/analyzerscheduledtrack.h"
+#include "analyzer/analyzertrack.h"
 #include "control/controlobject.h"
 #include "control/controlproxy.h"
 #include "library/coverartutils.h"
@@ -1360,7 +1362,7 @@ void WTrackMenu::addSelectionToNewCrate() {
     }
 }
 
-void WTrackMenu::addToAnalysis() {
+void WTrackMenu::addToAnalysis(AnalyzerTrack::Options options) {
     const TrackIdList trackIds = getTrackIds();
     if (trackIds.empty()) {
         qWarning() << "No tracks selected for analysis";
@@ -1369,7 +1371,8 @@ void WTrackMenu::addToAnalysis() {
 
     QList<AnalyzerScheduledTrack> tracks;
     for (auto trackId : trackIds) {
-        tracks.append(trackId);
+        AnalyzerScheduledTrack track(trackId, options);
+        tracks.append(track);
     }
 
     emit m_pLibrary->analyzeTracks(tracks);

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1,5 +1,7 @@
 #include "widget/wtrackmenu.h"
 
+#include <qlist.h>
+
 #include <QCheckBox>
 #include <QDialogButtonBox>
 #include <QInputDialog>
@@ -1365,7 +1367,12 @@ void WTrackMenu::addToAnalysis() {
         return;
     }
 
-    emit m_pLibrary->analyzeTracks(trackIds);
+    QList<AnalyzerScheduledTrack> tracks;
+    for (auto trackId : trackIds) {
+        tracks.append(trackId);
+    }
+
+    emit m_pLibrary->analyzeTracks(tracks);
 }
 
 void WTrackMenu::slotAnalyze() {

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -31,6 +31,7 @@
 #include "mixer/playermanager.h"
 #include "moc_wtrackmenu.cpp"
 #include "preferences/colorpalettesettings.h"
+#include "preferences/configobject.h"
 #include "sources/soundsourceproxy.h"
 #include "track/track.h"
 #include "util/defs.h"
@@ -607,7 +608,6 @@ void WTrackMenu::setupActions() {
     if (featureIsEnabled(Feature::Analyze)) {
         m_pAnalyzeMenu->addAction(m_pAnalyzeAction);
         m_pAnalyzeMenu->addAction(m_pReanalyzeAction);
-        m_pAnalyzeMenu->addSeparator();
         m_pAnalyzeMenu->addAction(m_pReanalyzeConstBpmAction);
         m_pAnalyzeMenu->addAction(m_pReanalyzeVarBpmAction);
         addMenu(m_pAnalyzeMenu);
@@ -832,6 +832,16 @@ void WTrackMenu::updateMenus() {
         // consistent with selectionChanged above.
         m_pCoverMenu->setCoverArt(getCoverInfoOfLastTrack());
         m_pMetadataMenu->addMenu(m_pCoverMenu);
+    }
+
+    if (featureIsEnabled(Feature::Analyze)) {
+        bool useFixedTempo = m_pConfig->getValue<bool>(
+                ConfigKey("[BPM]", "BeatDetectionFixedTempoAssumption"));
+        // Since we already have a 'Reanalyze' action that uses the configured
+        // default, we hide the redundant menu as per suggestion:
+        // https://github.com/mixxxdj/mixxx/pull/10931#issuecomment-1262559750
+        m_pReanalyzeConstBpmAction->setVisible(!useFixedTempo);
+        m_pReanalyzeVarBpmAction->setVisible(useFixedTempo);
     }
 
     if (featureIsEnabled(Feature::Reset) ||

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -433,6 +433,18 @@ void WTrackMenu::createActions() {
 
         m_pReanalyzeAction = new QAction(tr("Reanalyze"), this);
         connect(m_pReanalyzeAction, &QAction::triggered, this, &WTrackMenu::slotReanalyze);
+
+        m_pReanalyzeConstBpmAction = new QAction(tr("Reanalyze (constant BPM)"), this);
+        connect(m_pReanalyzeConstBpmAction,
+                &QAction::triggered,
+                this,
+                &WTrackMenu::slotReanalyzeWithFixedTempo);
+
+        m_pReanalyzeVarBpmAction = new QAction(tr("Reanalyze (variable BPM)"), this);
+        connect(m_pReanalyzeVarBpmAction,
+                &QAction::triggered,
+                this,
+                &WTrackMenu::slotReanalyzeWithVariableTempo);
     }
 
     // This action is only usable when m_deckGroup is set. That is true only
@@ -595,6 +607,9 @@ void WTrackMenu::setupActions() {
     if (featureIsEnabled(Feature::Analyze)) {
         m_pAnalyzeMenu->addAction(m_pAnalyzeAction);
         m_pAnalyzeMenu->addAction(m_pReanalyzeAction);
+        m_pAnalyzeMenu->addSeparator();
+        m_pAnalyzeMenu->addAction(m_pReanalyzeConstBpmAction);
+        m_pAnalyzeMenu->addAction(m_pReanalyzeVarBpmAction);
         addMenu(m_pAnalyzeMenu);
     }
 
@@ -1385,6 +1400,20 @@ void WTrackMenu::slotAnalyze() {
 void WTrackMenu::slotReanalyze() {
     clearBeats();
     addToAnalysis();
+}
+
+void WTrackMenu::slotReanalyzeWithFixedTempo() {
+    clearBeats();
+    AnalyzerTrack::Options options;
+    options.useFixedTempo = true;
+    addToAnalysis(options);
+}
+
+void WTrackMenu::slotReanalyzeWithVariableTempo() {
+    clearBeats();
+    AnalyzerTrack::Options options;
+    options.useFixedTempo = false;
+    addToAnalysis(options);
 }
 
 void WTrackMenu::slotLockBpm() {

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -5,6 +5,7 @@
 #include <QPointer>
 #include <memory>
 
+#include "analyzer/analyzertrack.h"
 #include "library/coverart.h"
 #include "library/dao/playlistdao.h"
 #include "library/trackprocessing.h"
@@ -188,7 +189,7 @@ class WTrackMenu : public QMenu {
     void updateSelectionCrates(QWidget* pWidget);
 
     void addToAutoDJ(PlaylistDAO::AutoDJSendLoc loc);
-    void addToAnalysis();
+    void addToAnalysis(AnalyzerTrack::Options options = AnalyzerTrack::Options());
 
     void clearBeats();
     void lockBpm(bool lock);

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -117,6 +117,8 @@ class WTrackMenu : public QMenu {
     // Analysis
     void slotAnalyze();
     void slotReanalyze();
+    void slotReanalyzeWithFixedTempo();
+    void slotReanalyzeWithVariableTempo();
 
     // BPM
     void slotLockBpm();
@@ -288,6 +290,8 @@ class WTrackMenu : public QMenu {
     // Analysis actions
     QAction* m_pAnalyzeAction{};
     QAction* m_pReanalyzeAction{};
+    QAction* m_pReanalyzeConstBpmAction{};
+    QAction* m_pReanalyzeVarBpmAction{};
 
     // Clear track metadata actions
     QAction* m_pClearBeatsAction{};


### PR DESCRIPTION
This PR, intended as a follow-up to #4806, wraps scheduled tracks in `AnalyzerScheduledTrack` and `AnalyzerTrack`, depending on whether it contains a `TrackId` or a resolved `TrackPointer`.

These wrappers add the ability to override analysis options on a per-track basis. This PR also introduced one such option, namely `useFixedTempo`, which can be used to override the constant/variable BPM setting. Additionally, it adds two new entries to `WTrackMenu` > `Analyze`:

- Reanalyze (constant BPM)
- Reanalyze (variable BPM)

<img width="369" alt="image" src="https://user-images.githubusercontent.com/30873659/193075096-14a3cb43-6110-4171-849c-d848cb4f2f48.png">

Any feedback is of course welcome!