### PR TITLE
2.3 fix windows buildenv

### DIFF
--- a/tools/windows_buildenv.bat
+++ b/tools/windows_buildenv.bat
@@ -202,7 +202,7 @@ REM Generate CMakeSettings.json which is read by MS Visual Studio to determine t
     >>"%CMakeSettings%" echo       "generator": "Ninja",
     >>"%CMakeSettings%" echo       "inheritEnvironments": [ "msvc_!PLATFORM!_!PLATFORM!" ],
     >>"%CMakeSettings%" echo       "installRoot": "!INSTALL_ROOT:\=\\!\\${name}",
-    >>"%CMakeSettings%" echo       "cmakeToolchain": "!BUILDENV_PATH:\=\\!\\scripts\\buildsystems\\vcpkg.cmake",
+    >>"%CMakeSettings%" echo       "cmakeToolchain": "!MIXXX_VCPKG_ROOT:\=\\!\\scripts\\buildsystems\\vcpkg.cmake",
     >>"%CMakeSettings%" echo       "intelliSenseMode": "windows-msvc-!PLATFORM!",
     >>"%CMakeSettings%" echo       "variables": [
     SET variableElementTermination=,
@@ -213,7 +213,7 @@ REM Generate CMakeSettings.json which is read by MS Visual Studio to determine t
     CALL :AddCMakeVar2CMakeSettings_JSON "BULK"                               "BOOL"   "False"
     CALL :AddCMakeVar2CMakeSettings_JSON "CMAKE_EXPORT_COMPILE_COMMANDS"      "BOOL"   "True"
     REM Replace all \ by \\ in CMAKE_PREFIX_PATH
-    CALL :AddCMakeVar2CMakeSettings_JSON "CMAKE_PREFIX_PATH"                  "STRING"   "!CMAKE_PREFIX_PATH:\=\\!"
+    REM CALL :AddCMakeVar2CMakeSettings_JSON "CMAKE_PREFIX_PATH"                  "STRING"   "!CMAKE_PREFIX_PATH:\=\\!"
     CALL :AddCMakeVar2CMakeSettings_JSON "DEBUG_ASSERTIONS_FATAL"             "BOOL"   "True"
     CALL :AddCMakeVar2CMakeSettings_JSON "FFMPEG"                             "BOOL"   "False"
     CALL :AddCMakeVar2CMakeSettings_JSON "HID"                                "BOOL"   "True"

--- a/tools/windows_buildenv.bat
+++ b/tools/windows_buildenv.bat
@@ -2,7 +2,7 @@
 SETLOCAL ENABLEDELAYEDEXPANSION
 REM this í is just to force some editors to recognize this file as ANSI, not UTF8.
 
-CALL :REALPATH %~dp0\..
+CALL :REALPATH "%~dp0\.."
 SET MIXXX_ROOT=%RETVAL%
 
 IF NOT DEFINED PLATFORM (
@@ -50,17 +50,17 @@ EXIT /B 0
     SET BUILDENV_NAME=%RETVAL%
     SET BUILDENV_PATH=%BUILDENV_BASEPATH%\%BUILDENV_NAME%
 
-    IF NOT EXIST %BUILDENV_BASEPATH% (
+    IF NOT EXIST "%BUILDENV_BASEPATH%" (
         ECHO ^Creating "buildenv" directory...
-        MD %BUILDENV_BASEPATH%
+        MD "%BUILDENV_BASEPATH%"
     )
 
-    IF NOT EXIST %BUILDENV_PATH% (
+    IF NOT EXIST "%BUILDENV_PATH%" (
         SET BUILDENV_URL=https://downloads.mixxx.org/dependencies/2.3/Windows/!BUILDENV_NAME!.zip
-        IF NOT EXIST !BUILDENV_PATH!.zip (
+        IF NOT EXIST "!BUILDENV_PATH!.zip" (
             ECHO ^Download prebuilt build environment from "!BUILDENV_URL!" to "!BUILDENV_PATH!.zip"...
             REM TODO: The /DYNAMIC parameter is required because our server does not yet support HTTP range headers
-            BITSADMIN /transfer buildenvjob /download /priority normal /DYNAMIC !BUILDENV_URL! !BUILDENV_PATH!.zip
+            BITSADMIN /transfer buildenvjob /download /priority normal /DYNAMIC !BUILDENV_URL! "!BUILDENV_PATH!.zip"
             REM TODO: verify download using sha256sum?
             ECHO ^Download complete.
         ) else (
@@ -75,13 +75,13 @@ EXIT /B 0
             ECHO ^Unpacking "!BUILDENV_PATH!.zip" using 7z...
             CALL :UNZIP_SEVENZIP "!RETVAL!" "!BUILDENV_PATH!.zip" "!BUILDENV_BASEPATH!"
         )
-        IF NOT EXIST %BUILDENV_PATH% (
+        IF NOT EXIST "%BUILDENV_PATH%" (
             ECHO ^Error: Unpacking failed. The downloaded archive might be broken, consider removing "!BUILDENV_PATH!.zip" to force redownload.
             EXIT /B 1
         )
 
         ECHO ^Unpacking complete.
-        DEL /f /q %BUILDENV_PATH%.zip
+        DEL /f /q "%BUILDENV_PATH%.zip"
     )
 
     ECHO ^Build environment path: !BUILDENV_PATH!
@@ -106,14 +106,14 @@ EXIT /B 0
         ECHO ^Generating "CMakeSettings.json"...
         CALL :GENERATE_CMakeSettings_JSON
 
-        IF NOT EXIST %BUILD_ROOT% (
+        IF NOT EXIST "%BUILD_ROOT%" (
             ECHO ^Creating subdirectory "build"...
-            MD %BUILD_ROOT%
+            MD "%BUILD_ROOT%"
         )
 
-        IF NOT EXIST %INSTALL_ROOT% (
+        IF NOT EXIST "%INSTALL_ROOT%" (
             ECHO ^Creating subdirectory "install"...
-            MD %INSTALL_ROOT%
+            MD "%INSTALL_ROOT%"
         )
     )
     GOTO :EOF
@@ -138,7 +138,7 @@ EXIT /B 0
 
 
 :UNZIP_SEVENZIP <7zippath> <newzipfile> <ExtractTo>
-    %1 x -o"%3" "%2"
+    %1 x -o%3 %2
     GOTO :EOF
 
 
@@ -155,7 +155,7 @@ EXIT /B 0
 
 :READ_ENVNAME
     ECHO Reading name of prebuild environment from "%MIXXX_ROOT%\packaging\windows\build_environment"
-    SET /P BUILDENV_NAME=<%MIXXX_ROOT%\packaging\windows\build_environment
+    SET /P BUILDENV_NAME=<"%MIXXX_ROOT%\packaging\windows\build_environment"
     SET BUILDENV_NAME=!BUILDENV_NAME:PLATFORM=%PLATFORM%!
     SET BUILDENV_NAME=!BUILDENV_NAME:CONFIGURATION=%CONFIGURATION%!
     SET RETVAL=%BUILDENV_NAME%
@@ -165,11 +165,11 @@ EXIT /B 0
 :GENERATE_CMakeSettings_JSON
 REM Generate CMakeSettings.json which is read by MS Visual Studio to determine the supported CMake build environments
     SET CMakeSettings=%MIXXX_ROOT%\CMakeSettings.json
-    IF EXIST %CMakeSettings% (
+    IF EXIST "%CMakeSettings%" (
         FOR /f "delims=" %%a in ('wmic OS Get localdatetime ^| find "."') do set DateTime=%%a
         SET CMakeSettingsBackup=CMakeSettings_!DateTime:~0,4!-!DateTime:~4,2!-!DateTime:~6,2!_!DateTime:~8,2!-!DateTime:~10,2!-!DateTime:~12,2!.json
         ECHO CMakeSettings.json already exists, creating backup at "!CMakeSettingsBackup!"...
-        REN %CMakeSettings% !CMakeSettingsBackup!
+        REN "%CMakeSettings%" "!CMakeSettingsBackup!"
     )
 
     CALL :SETANSICONSOLE
@@ -181,30 +181,30 @@ REM Generate CMakeSettings.json which is read by MS Visual Studio to determine t
     >"%CMakeSettings%" echo ï»¿{
     CALL :SETUTF8CONSOLE
 
-    >>%CMakeSettings% echo   "configurations": [
+    >>"%CMakeSettings%" echo   "configurations": [
     SET configElementTermination=,
     CALL :Configuration2CMakeSettings_JSON off       Debug
     CALL :Configuration2CMakeSettings_JSON legacy    RelWithDebInfo
     CALL :Configuration2CMakeSettings_JSON portable  RelWithDebInfo
     SET configElementTermination=
     CALL :Configuration2CMakeSettings_JSON native    Release
-    >>%CMakeSettings% echo   ]
-    >>%CMakeSettings% echo }
+    >>"%CMakeSettings%" echo   ]
+    >>"%CMakeSettings%" echo }
     CALL :RESTORECONSOLE %OLDCODEPAGE%
     GOTO :EOF
 
 :Configuration2CMakeSettings_JSON <optimize> <configurationtype>
-    >>%CMakeSettings% echo     {
-    >>%CMakeSettings% echo       "name": "!PLATFORM!__%1",
-    >>%CMakeSettings% echo       "buildRoot": "!BUILD_ROOT:\=\\!\\${name}",
-    >>%CMakeSettings% echo       "configurationType": "%2",
-    >>%CMakeSettings% echo       "enableClangTidyCodeAnalysis": true,
-    >>%CMakeSettings% echo       "generator": "Ninja",
-    >>%CMakeSettings% echo       "inheritEnvironments": [ "msvc_!PLATFORM!_!PLATFORM!" ],
-    >>%CMakeSettings% echo       "installRoot": "!INSTALL_ROOT:\=\\!\\${name}",
-    >>%CMakeSettings% echo       "cmakeToolchain": "!BUILDENV_PATH:\=\\!\\scripts\\buildsystems\\vcpkg.cmake",
-    >>%CMakeSettings% echo       "intelliSenseMode": "windows-msvc-!PLATFORM!",
-    >>%CMakeSettings% echo       "variables": [
+    >>"%CMakeSettings%" echo     {
+    >>"%CMakeSettings%" echo       "name": "!PLATFORM!__%1",
+    >>"%CMakeSettings%" echo       "buildRoot": "!BUILD_ROOT:\=\\!\\${name}",
+    >>"%CMakeSettings%" echo       "configurationType": "%2",
+    >>"%CMakeSettings%" echo       "enableClangTidyCodeAnalysis": true,
+    >>"%CMakeSettings%" echo       "generator": "Ninja",
+    >>"%CMakeSettings%" echo       "inheritEnvironments": [ "msvc_!PLATFORM!_!PLATFORM!" ],
+    >>"%CMakeSettings%" echo       "installRoot": "!INSTALL_ROOT:\=\\!\\${name}",
+    >>"%CMakeSettings%" echo       "cmakeToolchain": "!BUILDENV_PATH:\=\\!\\scripts\\buildsystems\\vcpkg.cmake",
+    >>"%CMakeSettings%" echo       "intelliSenseMode": "windows-msvc-!PLATFORM!",
+    >>"%CMakeSettings%" echo       "variables": [
     SET variableElementTermination=,
     CALL :AddCMakeVar2CMakeSettings_JSON "X_VCPKG_APPLOCAL_DEPS_INSTALL"      "BOOL"   "True"
     CALL :AddCMakeVar2CMakeSettings_JSON "VCPKG_TARGET_TRIPLET"               "STRING" "x64-windows"
@@ -231,16 +231,16 @@ REM Generate CMakeSettings.json which is read by MS Visual Studio to determine t
     CALL :AddCMakeVar2CMakeSettings_JSON "VINYLCONTROL"                       "BOOL"   "True"
     SET variableElementTermination=
     CALL :AddCMakeVar2CMakeSettings_JSON "WAVPACK"                            "BOOL"   "True"
-    >>%CMakeSettings% echo       ]
-    >>%CMakeSettings% echo     }!configElementTermination!
+    >>"%CMakeSettings%" echo       ]
+    >>"%CMakeSettings%" echo     }!configElementTermination!
   GOTO :EOF
 
 :AddCMakeVar2CMakeSettings_JSON <varname> <vartype> <value>
-    >>%CMakeSettings% echo         {
-    >>%CMakeSettings% echo           "name": %1,
-    >>%CMakeSettings% echo           "value": %3,
-    >>%CMakeSettings% echo           "type": %2
-    >>%CMakeSettings% echo         }!variableElementTermination!
+    >>"%CMakeSettings%" echo         {
+    >>"%CMakeSettings%" echo           "name": %1,
+    >>"%CMakeSettings%" echo           "value": %3,
+    >>"%CMakeSettings%" echo           "type": %2
+    >>"%CMakeSettings%" echo         }!variableElementTermination!
   GOTO :EOF
 
 :SETANSICONSOLE


### PR DESCRIPTION
Cherry pick of the "path with spaces" fix from main branch plus fix on the generated CMakeSettings file due to missing CMAKE_PREFIX_PATH.

Notes for merging:
- The last merge of this file to main damaged the encoding. Ensure that certain special characters are maintained. This is not an UTF-8 file.
- The cherry pick of "path with spaces" was not clean. Ensure that the correct cmakeToolchain line in the CMakeSettings section of the file is properly maintained.