### PR TITLE
Update precommit deps for python 3.11

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -140,8 +140,8 @@ repos:
         pass_filenames: false
         language: python
         additional_dependencies:
-          - beautifulsoup4==4.9.3
-          - lxml==4.6.3
+          - beautifulsoup4==4.11.1
+          - lxml==4.9.1
           - Markdown==3.3.4
         types: [text]
         files: ^(CHANGELOG\.md|res/linux/org\.mixxx\.Mixxx\.metainfo.xml)$


### PR DESCRIPTION
This fixes an issue with pre-commit deps not installing under python3.11