### PR TITLE
Update version number in license file

### DIFF
--- a/packaging/wix/LICENSE.rtf
+++ b/packaging/wix/LICENSE.rtf
@@ -1,7 +1,7 @@
 {\rtf1\ansi\ansicpg1252\deff0\nouicompat{\fonttbl{\f0\fnil\fcharset0 Courier New;}}
 {\colortbl ;\red0\green0\blue255;}
 {\*\generator Riched20 10.0.14393}\viewkind4\uc1
-\pard\qj\ul\b\f0\fs22\lang1036 Mixxx version 2.3, Digital DJ'ing software.\ulnone\b0\fs24\par
+\pard\qj\ul\b\f0\fs22\lang1036 Mixxx version 2.4, Digital DJ'ing software.\ulnone\b0\fs24\par
 \fs22 Copyright (C) 2001-2022 Mixxx Development Team\par
 \par
 Promotional tracks are copyright their respective owners and\par


### PR DESCRIPTION
The windows installer of snapshot 2.4-alpha-pre (built from`main`) shows version 2.3. If I understand correctly, `main` is targeted against 2.4.