### PR TITLE
wglwidget: thin layer on top of qglwidget or qopenglwindow based widget

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,15 @@ if(NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 option(QT6 "Build with Qt6" OFF)
+if(APPLE)
+option(QOPENGL "Use QOpenGL... classes instead of QGLWidget" ON)
+else()
+option(QOPENGL "Use QOpenGL... classes instead of QGLWidget" OFF)
+endif()
+
+if(QOPENGL)
+    add_compile_definitions(MIXXX_USE_QOPENGL)
+endif()
 
 if(APPLE)
   if(QT6)
@@ -1113,7 +1122,6 @@ else()
     src/waveform/renderers/waveformrendermarkrange.cpp
     src/waveform/renderers/waveformsignalcolors.cpp
     src/waveform/renderers/waveformwidgetrenderer.cpp
-    src/waveform/sharedglcontext.cpp
     src/waveform/visualsmanager.cpp
     src/waveform/vsyncthread.cpp
     src/waveform/waveformmarklabel.cpp
@@ -1138,10 +1146,22 @@ else()
     src/widget/woverviewlmh.cpp
     src/widget/woverviewrgb.cpp
     src/widget/wspinny.cpp
-      src/widget/wvumetergl.cpp
+    src/widget/wvumetergl.cpp
     src/widget/wwaveformviewer.cpp
   )
+  if(QOPENGL)
+    target_sources(mixxx-lib PRIVATE
+      src/widget/openglwindow.cpp
+      src/widget/wglwidgetqopengl.cpp
+    )
+  else()
+    target_sources(mixxx-lib PRIVATE
+      src/waveform/sharedglcontext.cpp
+      src/widget/wglwidgetqglwidget.cpp
+    )
+  endif()
 endif()
+
 set_target_properties(mixxx-lib PROPERTIES AUTOMOC ON AUTOUIC ON CXX_CLANG_TIDY "${CLANG_TIDY}")
 target_include_directories(mixxx-lib PUBLIC src "${CMAKE_CURRENT_BINARY_DIR}/src")
 if(UNIX AND NOT APPLE)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -122,6 +122,9 @@ int main(int argc, char * argv[]) {
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
+#ifdef MIXXX_USE_QOPENGL
+    QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+#endif
 
     // workaround for https://bugreports.qt.io/browse/QTBUG-84363
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0) && QT_VERSION < QT_VERSION_CHECK(5, 15, 1)

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -2,7 +2,11 @@
 
 #include <QDesktopServices>
 #include <QFileDialog>
+
+#ifndef MIXXX_USE_QOPENGL
 #include <QGLFormat>
+#endif
+
 #include <QUrl>
 #include <QtDebug>
 
@@ -152,6 +156,7 @@ void MixxxMainWindow::initialize() {
                 }
             });
 
+#ifndef MIXXX_USE_QOPENGL
     // Before creating the first skin we need to create a QGLWidget so that all
     // the QGLWidget's we create can use it as a shared QGLContext.
     if (!CmdlineArgs::Instance().getSafeMode() && QGLFormat::hasOpenGL()) {
@@ -181,6 +186,7 @@ void MixxxMainWindow::initialize() {
         pContextWidget->hide();
         SharedGLContext::setWidget(pContextWidget);
     }
+#endif
 
     WaveformWidgetFactory::createInstance(); // takes a long time
     WaveformWidgetFactory::instance()->setConfig(m_pCoreServices->getSettings());

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -1314,8 +1314,13 @@ QWidget* LegacySkinParser::parseSpinny(const QDomElement& node) {
     connect(waveformWidgetFactory,
             &WaveformWidgetFactory::renderSpinnies,
             pSpinny,
-            &WSpinny::render);
-    connect(waveformWidgetFactory, &WaveformWidgetFactory::swapSpinnies, pSpinny, &WSpinny::swap);
+            &WSpinny::render,
+            Qt::DirectConnection);
+    connect(waveformWidgetFactory,
+            &WaveformWidgetFactory::swapSpinnies,
+            pSpinny,
+            &WSpinny::swap,
+            Qt::DirectConnection);
     connect(pSpinny,
             &WSpinny::trackDropped,
             m_pPlayerManager,
@@ -1348,7 +1353,7 @@ QWidget* LegacySkinParser::parseVuMeter(const QDomElement& node) {
         return pVuMeterWidget;
     }
 
-    // QGLWidget derived WVuMeterGL
+    // WGLWidget derived WVuMeterGL
 
     if (CmdlineArgs::Instance().getSafeMode()) {
         WLabel* dummy = new WLabel(m_pParent);

--- a/src/util/widgetrendertimer.cpp
+++ b/src/util/widgetrendertimer.cpp
@@ -1,5 +1,7 @@
 #include "util/widgetrendertimer.h"
 
+#ifdef USE_WIDGET_RENDER_TIMER
+
 #include "moc_widgetrendertimer.cpp"
 #include "util/time.h"
 
@@ -28,3 +30,5 @@ void WidgetRenderTimer::activity() {
         m_guiTickTimer.start(m_renderFrequency);
     }
 }
+
+#endif

--- a/src/util/widgetrendertimer.h
+++ b/src/util/widgetrendertimer.h
@@ -26,6 +26,16 @@
 // Ironically, using this class somehow causes severe lagginess on mouse input
 // with Windows, so use #ifdefs to only call activity() on macOS; just call
 // QWidget::update() for other operating systems.
+//
+// Also when using the QOpenGLWindow based WGLWidget (when MIXXX_USE_QOPENGL is
+// defined) using this seems not necessary and makes causes lagginess
+#ifdef __APPLE__
+#ifndef MIXXX_USE_QOPENGL
+#define USE_WIDGET_RENDER_TIMER
+#endif
+#endif
+
+#ifdef USE_WIDGET_RENDER_TIMER
 class WidgetRenderTimer : public QObject {
     Q_OBJECT
   public:
@@ -53,3 +63,4 @@ class WidgetRenderTimer : public QObject {
     mixxx::Duration m_lastActivity;
     mixxx::Duration m_lastRender;
 };
+#endif

--- a/src/waveform/renderers/glslwaveformrenderersignal.cpp
+++ b/src/waveform/renderers/glslwaveformrenderersignal.cpp
@@ -1,6 +1,11 @@
 #include "waveform/renderers/glslwaveformrenderersignal.h"
 #if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
 
+#ifdef MIXXX_USE_QOPENGL
+#include <QOpenGLFramebufferObject>
+#include <QOpenGLShaderProgram>
+#else
+#endif
 #include <QGLFramebufferObject>
 #include <QGLShaderProgram>
 
@@ -49,14 +54,16 @@ bool GLSLWaveformRendererSignal::loadShaders() {
     m_frameShaderProgram->removeAllShaders();
 
     if (!m_frameShaderProgram->addShaderFromSourceFile(
-            QGLShader::Vertex, ":/shaders/passthrough.vert")) {
+                GL_SHADER_CLASS::Vertex,
+                ":/shaders/passthrough.vert")) {
         qDebug() << "GLWaveformRendererSignalShader::loadShaders - "
                  << m_frameShaderProgram->log();
         return false;
     }
 
     if (!m_frameShaderProgram->addShaderFromSourceFile(
-                QGLShader::Fragment, m_pFragShader)) {
+                GL_SHADER_CLASS::Fragment,
+                m_pFragShader)) {
         qDebug() << "GLWaveformRendererSignalShader::loadShaders - "
                  << m_frameShaderProgram->log();
         return false;
@@ -182,8 +189,8 @@ void GLSLWaveformRendererSignal::createFrameBuffers() {
             static_cast<int>(
                     m_waveformRenderer->getHeight() * devicePixelRatio);
 
-    m_framebuffer = std::make_unique<QGLFramebufferObject>(bufferWidth,
-                                                           bufferHeight);
+    m_framebuffer = std::make_unique<GL_FBO_CLASS>(bufferWidth,
+            bufferHeight);
 
     if (!m_framebuffer->isValid()) {
         qWarning() << "GLSLWaveformRendererSignal::createFrameBuffer - frame buffer not valid";
@@ -195,7 +202,7 @@ void GLSLWaveformRendererSignal::onInitializeGL() {
     m_textureRenderedWaveformCompletion = 0;
 
     if (!m_frameShaderProgram) {
-        m_frameShaderProgram = std::make_unique<QGLShaderProgram>();
+        m_frameShaderProgram = std::make_unique<GL_SHADER_PROGRAM_CLASS>();
     }
 
     if (!loadShaders()) {

--- a/src/waveform/renderers/glslwaveformrenderersignal.h
+++ b/src/waveform/renderers/glslwaveformrenderersignal.h
@@ -7,8 +7,18 @@
 #include "util/memory.h"
 #include "waveform/renderers/glwaveformrenderer.h"
 
-QT_FORWARD_DECLARE_CLASS(QGLFramebufferObject)
-QT_FORWARD_DECLARE_CLASS(QGLShaderProgram)
+#ifdef MIXXX_USE_QOPENGL
+#define GL_FBO_CLASS QOpenGLFramebufferObject
+#define GL_SHADER_CLASS QOpenGLShader
+#define GL_SHADER_PROGRAM_CLASS QOpenGLShaderProgram
+#else
+#define GL_FBO_CLASS QGLFramebufferObject
+#define GL_SHADER_CLASS QGLShader
+#define GL_SHADER_PROGRAM_CLASS QGLShaderProgram
+#endif
+
+QT_FORWARD_DECLARE_CLASS(GL_FBO_CLASS)
+QT_FORWARD_DECLARE_CLASS(GL_SHADER_PROGRAM_CLASS)
 
 class GLSLWaveformRendererSignal : public QObject,
                                    public GLWaveformRenderer {
@@ -50,7 +60,7 @@ class GLSLWaveformRendererSignal : public QObject,
     int m_textureRenderedWaveformCompletion;
 
     // Frame buffer for two pass rendering.
-    std::unique_ptr<QGLFramebufferObject> m_framebuffer;
+    std::unique_ptr<GL_FBO_CLASS> m_framebuffer;
 
     bool m_bDumpPng;
 
@@ -58,7 +68,7 @@ class GLSLWaveformRendererSignal : public QObject,
     bool m_shadersValid;
     ColorType m_colorType;
     const QString m_pFragShader;
-    std::unique_ptr<QGLShaderProgram> m_frameShaderProgram;
+    std::unique_ptr<GL_SHADER_PROGRAM_CLASS> m_frameShaderProgram;
 };
 
 class GLSLWaveformRendererFilteredSignal: public GLSLWaveformRendererSignal {

--- a/src/waveform/renderers/glwaveformrenderer.h
+++ b/src/waveform/renderers/glwaveformrenderer.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#ifndef MIXXX_USE_QOPENGL
 #include <QGLContext>
+#endif
 #include <QOpenGLFunctions_2_1>
 
 #include "waveform/renderers/waveformrenderersignalbase.h"
@@ -15,8 +17,12 @@
 class GLWaveformRenderer : public WaveformRendererSignalBase, protected QOpenGLFunctions_2_1 {
   public:
     GLWaveformRenderer(WaveformWidgetRenderer* waveformWidgetRenderer)
-            : WaveformRendererSignalBase(waveformWidgetRenderer),
-              m_pLastContext(nullptr) {
+            : WaveformRendererSignalBase(waveformWidgetRenderer)
+#ifndef MIXXX_USE_QOPENGL
+              ,
+              m_pLastContext(nullptr)
+#endif
+    {
     }
 
     virtual void onInitializeGL() {
@@ -28,14 +34,18 @@ class GLWaveformRenderer : public WaveformRendererSignalBase, protected QOpenGLF
     // by calling this in `draw` when the QGLContext has been made current.
     // TODO: remove this when upgrading to QOpenGLWidget
     void maybeInitializeGL() {
+#ifndef MIXXX_USE_QOPENGL
         if (QGLContext::currentContext() != m_pLastContext) {
             onInitializeGL();
             m_pLastContext = QGLContext::currentContext();
         }
+#endif
     }
 
   private:
+#ifndef MIXXX_USE_QOPENGL
     const QGLContext* m_pLastContext;
+#endif
 };
 
 #endif // !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)

--- a/src/waveform/renderers/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/waveformrenderbeat.cpp
@@ -40,7 +40,12 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
     if (alpha == 0) {
         return;
     }
+#ifdef MIXXX_USE_QOPENGL
+    // TODO @m0dB using alpha transparency for the beat lines causes has artifacts with QOpenGL.
+    m_beatColor.setAlphaF(1.f);
+#else
     m_beatColor.setAlphaF(alpha/100.0);
+#endif
 
     const int trackSamples = m_waveformRenderer->getTrackSamples();
     if (trackSamples <= 0) {

--- a/src/waveform/vsyncthread.cpp
+++ b/src/waveform/vsyncthread.cpp
@@ -1,6 +1,5 @@
 #include "vsyncthread.h"
 
-#include <QGLFormat>
 #include <QThread>
 #include <QTime>
 #include <QtDebug>

--- a/src/waveform/vsyncthread.h
+++ b/src/waveform/vsyncthread.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <QTime>
-#include <QThread>
-#include <QSemaphore>
 #include <QPair>
-#include <QGLWidget>
+#include <QSemaphore>
+#include <QThread>
+#include <QTime>
 
 #include "util/performancetimer.h"
+#include "widget/wglwidget.h"
 
 class VSyncThread : public QThread {
     Q_OBJECT
@@ -25,7 +25,7 @@ class VSyncThread : public QThread {
 
     void run();
 
-    bool waitForVideoSync(QGLWidget* glw);
+    bool waitForVideoSync(WGLWidget* glw);
     int elapsed();
     int toNextSyncMicros();
     void setSyncIntervalTimeMicros(int usSyncTimer);
@@ -35,8 +35,8 @@ class VSyncThread : public QThread {
     int fromTimerToNextSyncMicros(const PerformanceTimer& timer);
     void vsyncSlotFinished();
     void getAvailableVSyncTypes(QList<QPair<int, QString>>* list);
-    void setupSync(QGLWidget* glw, int index);
-    void waitUntilSwap(QGLWidget* glw);
+    void setupSync(WGLWidget* glw, int index);
+    void waitUntilSwap(WGLWidget* glw);
     mixxx::Duration sinceLastSwap() const;
   signals:
     void vsyncRender();

--- a/src/waveform/widgets/glrgbwaveformwidget.cpp
+++ b/src/waveform/widgets/glrgbwaveformwidget.cpp
@@ -14,9 +14,9 @@
 
 GLRGBWaveformWidget::GLRGBWaveformWidget(const QString& group, QWidget* parent)
         : GLWaveformWidgetAbstract(group, parent) {
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
+    qDebug() << "Created WGLWidget. Context"
+             << "Valid:" << isContextValid()
+             << "Sharing:" << isContextSharing();
 
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
@@ -27,11 +27,6 @@ GLRGBWaveformWidget::GLRGBWaveformWidget(const QString& group, QWidget* parent)
 #endif // !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
     addRenderer<WaveformRenderBeat>();
     addRenderer<WaveformRenderMark>();
-
-    setAttribute(Qt::WA_NoSystemBackground);
-    setAttribute(Qt::WA_OpaquePaintEvent);
-
-    setAutoBufferSwap(false);
 
     m_initSuccess = init();
 }
@@ -55,7 +50,7 @@ mixxx::Duration GLRGBWaveformWidget::render() {
     timer.start();
     // QPainter makes QGLContext::currentContext() == context()
     // this may delayed until previous buffer swap finished
-    QPainter painter(this);
+    QPainter painter(paintDevice());
     t1 = timer.restart();
     draw(&painter, nullptr);
     //t2 = timer.restart();

--- a/src/waveform/widgets/glsimplewaveformwidget.cpp
+++ b/src/waveform/widgets/glsimplewaveformwidget.cpp
@@ -17,9 +17,9 @@
 
 GLSimpleWaveformWidget::GLSimpleWaveformWidget(const QString& group, QWidget* parent)
         : GLWaveformWidgetAbstract(group, parent) {
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
+    qDebug() << "Created WGLWidget. Context"
+             << "Valid:" << isContextValid()
+             << "Sharing:" << isContextSharing();
 
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
@@ -30,11 +30,6 @@ GLSimpleWaveformWidget::GLSimpleWaveformWidget(const QString& group, QWidget* pa
 #endif // !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
     addRenderer<WaveformRenderBeat>();
     addRenderer<WaveformRenderMark>();
-
-    setAttribute(Qt::WA_NoSystemBackground);
-    setAttribute(Qt::WA_OpaquePaintEvent);
-
-    setAutoBufferSwap(false);
 
     m_initSuccess = init();
 }
@@ -57,7 +52,7 @@ mixxx::Duration GLSimpleWaveformWidget::render() {
     timer.start();
     // QPainter makes QGLContext::currentContext() == context()
     // this may delayed until previous buffer swap finished
-    QPainter painter(this);
+    QPainter painter(paintDevice());
     t1 = timer.restart();
     draw(&painter, nullptr);
     //t2 = timer.restart();

--- a/src/waveform/widgets/glvsynctestwidget.cpp
+++ b/src/waveform/widgets/glvsynctestwidget.cpp
@@ -17,9 +17,9 @@
 
 GLVSyncTestWidget::GLVSyncTestWidget(const QString& group, QWidget* parent)
         : GLWaveformWidgetAbstract(group, parent) {
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
+    qDebug() << "Created WGLWidget. Context"
+             << "Valid:" << isContextValid()
+             << "Sharing:" << isContextSharing();
 
     addRenderer<WaveformRenderBackground>(); // 172 µs
 //  addRenderer<WaveformRendererEndOfTrack>(); // 677 µs 1145 µs (active)
@@ -33,13 +33,7 @@ GLVSyncTestWidget::GLVSyncTestWidget(const QString& group, QWidget* parent)
     // addRenderer<WaveformRenderMark>(); // 711 µs
     // addRenderer<WaveformRenderBeat>(); // 1183 µs
 
-    setAttribute(Qt::WA_NoSystemBackground);
-    setAttribute(Qt::WA_OpaquePaintEvent);
-
-    setAutoBufferSwap(false);
-
     m_initSuccess = init();
-    qDebug() << "GLVSyncTestWidget.isSharing() =" << isSharing();
 }
 
 GLVSyncTestWidget::~GLVSyncTestWidget() {
@@ -60,7 +54,7 @@ mixxx::Duration GLVSyncTestWidget::render() {
     timer.start();
     // QPainter makes QGLContext::currentContext() == context()
     // this may delayed until previous buffer swap finished
-    QPainter painter(this);
+    QPainter painter(paintDevice());
     t1 = timer.restart();
     draw(&painter, nullptr);
     //t2 = timer.restart();

--- a/src/waveform/widgets/glwaveformwidget.cpp
+++ b/src/waveform/widgets/glwaveformwidget.cpp
@@ -19,9 +19,9 @@
 
 GLWaveformWidget::GLWaveformWidget(const QString& group, QWidget* parent)
         : GLWaveformWidgetAbstract(group, parent) {
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
+    qDebug() << "Created WGLWidget. Context"
+             << "Valid:" << isContextValid()
+             << "Sharing:" << isContextSharing();
 
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
@@ -32,11 +32,6 @@ GLWaveformWidget::GLWaveformWidget(const QString& group, QWidget* parent)
 #endif // !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
     addRenderer<WaveformRenderBeat>();
     addRenderer<WaveformRenderMark>();
-
-    setAttribute(Qt::WA_NoSystemBackground);
-    setAttribute(Qt::WA_OpaquePaintEvent);
-
-    setAutoBufferSwap(false);
 
     m_initSuccess = init();
 }
@@ -59,7 +54,7 @@ mixxx::Duration GLWaveformWidget::render() {
     timer.start();
     // QPainter makes QGLContext::currentContext() == context()
     // this may delayed until previous buffer swap finished
-    QPainter painter(this);
+    QPainter painter(paintDevice());
     t1 = timer.restart();
     draw(&painter, nullptr);
     //t2 = timer.restart();

--- a/src/waveform/widgets/glwaveformwidget.h
+++ b/src/waveform/widgets/glwaveformwidget.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <QGLWidget>
-
 #include "waveform/widgets/glwaveformwidgetabstract.h"
 
 class GLWaveformWidget : public GLWaveformWidgetAbstract {

--- a/src/waveform/widgets/glwaveformwidgetabstract.h
+++ b/src/waveform/widgets/glwaveformwidgetabstract.h
@@ -1,29 +1,32 @@
 #pragma once
 
-#include <QGLWidget>
-
 #include "waveform/renderers/glwaveformrenderer.h"
-#include "waveform/sharedglcontext.h"
 #include "waveform/widgets/waveformwidgetabstract.h"
+#include "widget/wglwidget.h"
+#include "widget/wwaveformviewer.h"
 
 QT_FORWARD_DECLARE_CLASS(QString)
 
-/// GLWaveformWidgetAbstract is a WaveformWidgetAbstract & QGLWidget. Its optional
+/// GLWaveformWidgetAbstract is a WaveformWidgetAbstract & WGLWidget. Its optional
 /// member GLWaveformRenderer* m_pGlRenderer can implement a virtual method
 /// onInitializeGL, which will be called from GLWaveformRenderer::initializeGL
-/// (which overrides QGLWidget::initializeGL). This can be used for initialization
+/// (which overrides WGLWidget::initializeGL). This can be used for initialization
 /// that must be deferred until the GL context has been initialized and that can't
 /// be done in the constructor.
-class GLWaveformWidgetAbstract : public WaveformWidgetAbstract, public QGLWidget {
+class GLWaveformWidgetAbstract : public WaveformWidgetAbstract, public WGLWidget {
   public:
     GLWaveformWidgetAbstract(const QString& group, QWidget* parent)
             : WaveformWidgetAbstract(group),
-              QGLWidget(parent, SharedGLContext::getWidget())
+              WGLWidget(parent)
 #if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
               ,
               m_pGlRenderer(nullptr)
 #endif // !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
     {
+    }
+
+    WGLWidget* getGLWidget() override {
+        return this;
     }
 
   protected:
@@ -33,6 +36,17 @@ class GLWaveformWidgetAbstract : public WaveformWidgetAbstract, public QGLWidget
             m_pGlRenderer->onInitializeGL();
         }
     }
+
+#ifdef MIXXX_USE_QOPENGL
+    // We need to forward events coming from the QOpenGLWindow
+    // (drag&drop, mouse) to the viewer
+    void handleEventFromWindow(QEvent* ev) override {
+        auto viewer = dynamic_cast<WWaveformViewer*>(parent());
+        if (viewer) {
+            viewer->handleEventFromWindow(ev);
+        }
+    }
+#endif
 
     GLWaveformRenderer* m_pGlRenderer;
 #endif // !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)

--- a/src/waveform/widgets/qthsvwaveformwidget.cpp
+++ b/src/waveform/widgets/qthsvwaveformwidget.cpp
@@ -16,9 +16,7 @@
 
 QtHSVWaveformWidget::QtHSVWaveformWidget(const QString& group, QWidget* parent)
         : GLWaveformWidgetAbstract(group, parent) {
-    if (QGLContext::currentContext() != context()) {
-        makeCurrent();
-    }
+    makeCurrentIfNeeded();
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
     addRenderer<WaveformRendererPreroll>();
@@ -26,9 +24,6 @@ QtHSVWaveformWidget::QtHSVWaveformWidget(const QString& group, QWidget* parent)
     addRenderer<WaveformRendererHSV>();
     addRenderer<WaveformRenderBeat>();
     addRenderer<WaveformRenderMark>();
-
-    setAttribute(Qt::WA_NoSystemBackground);
-    setAttribute(Qt::WA_OpaquePaintEvent);
 
     m_initSuccess = init();
 }
@@ -51,7 +46,7 @@ mixxx::Duration QtHSVWaveformWidget::render() {
     timer.start();
     // QPainter makes QGLContext::currentContext() == context()
     // this may delayed until previous buffer swap finished
-    QPainter painter(this);
+    QPainter painter(paintDevice());
     t1 = timer.restart();
     draw(&painter, nullptr);
     //t2 = timer.restart();

--- a/src/waveform/widgets/qtrgbwaveformwidget.cpp
+++ b/src/waveform/widgets/qtrgbwaveformwidget.cpp
@@ -13,13 +13,12 @@
 #include "waveform/renderers/waveformrendermark.h"
 #include "waveform/renderers/waveformrendermarkrange.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
-#include "waveform/sharedglcontext.h"
 
 QtRGBWaveformWidget::QtRGBWaveformWidget(const QString& group, QWidget* parent)
         : GLWaveformWidgetAbstract(group, parent) {
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
+    qDebug() << "Created WGLWidget. Context"
+             << "Valid:" << isContextValid()
+             << "Sharing:" << isContextSharing();
 
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
@@ -28,11 +27,6 @@ QtRGBWaveformWidget::QtRGBWaveformWidget(const QString& group, QWidget* parent)
     addRenderer<WaveformRendererRGB>();
     addRenderer<WaveformRenderBeat>();
     addRenderer<WaveformRenderMark>();
-
-    setAttribute(Qt::WA_NoSystemBackground);
-    setAttribute(Qt::WA_OpaquePaintEvent);
-
-    setAutoBufferSwap(false);
 
     m_initSuccess = init();
 }
@@ -55,7 +49,7 @@ mixxx::Duration QtRGBWaveformWidget::render() {
     timer.start();
     // QPainter makes QGLContext::currentContext() == context()
     // this may delayed until previous buffer swap finished
-    QPainter painter(this);
+    QPainter painter(paintDevice());
     t1 = timer.restart();
     draw(&painter, nullptr);
     //t2 = timer.restart();

--- a/src/waveform/widgets/qtsimplewaveformwidget.cpp
+++ b/src/waveform/widgets/qtsimplewaveformwidget.cpp
@@ -13,15 +13,14 @@
 #include "waveform/renderers/waveformrendermark.h"
 #include "waveform/renderers/waveformrendermarkrange.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
-#include "waveform/sharedglcontext.h"
 
 QtSimpleWaveformWidget::QtSimpleWaveformWidget(
         const QString& group,
         QWidget* parent)
         : GLWaveformWidgetAbstract(group, parent) {
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
+    qDebug() << "Created WGLWidget. Context"
+             << "Valid:" << isContextValid()
+             << "Sharing:" << isContextSharing();
 
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
@@ -30,11 +29,6 @@ QtSimpleWaveformWidget::QtSimpleWaveformWidget(
     addRenderer<QtWaveformRendererSimpleSignal>();
     addRenderer<WaveformRenderBeat>();
     addRenderer<WaveformRenderMark>();
-
-    setAttribute(Qt::WA_NoSystemBackground);
-    setAttribute(Qt::WA_OpaquePaintEvent);
-
-    setAutoBufferSwap(false);
 
     m_initSuccess = init();
 }
@@ -58,7 +52,7 @@ mixxx::Duration QtSimpleWaveformWidget::render() {
     timer.start();
     // QPainter makes QGLContext::currentContext() == context()
     // this may delayed until previous buffer swap finished
-    QPainter painter(this);
+    QPainter painter(paintDevice());
     t1 = timer.restart();
     draw(&painter, nullptr);
     //t2 = timer.restart();

--- a/src/waveform/widgets/qtvsynctestwidget.cpp
+++ b/src/waveform/widgets/qtvsynctestwidget.cpp
@@ -14,20 +14,14 @@
 #include "waveform/renderers/waveformrendermark.h"
 #include "waveform/renderers/waveformrendermarkrange.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
-#include "waveform/sharedglcontext.h"
 
 QtVSyncTestWidget::QtVSyncTestWidget(const QString& group, QWidget* parent)
         : GLWaveformWidgetAbstract(group, parent) {
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
+    qDebug() << "Created WGLWidget. Context"
+             << "Valid:" << isContextValid()
+             << "Sharing:" << isContextSharing();
 
     addRenderer<QtVSyncTestRenderer>();
-
-    setAttribute(Qt::WA_NoSystemBackground);
-    setAttribute(Qt::WA_OpaquePaintEvent);
-
-    setAutoBufferSwap(false);
 
     m_initSuccess = init();
 }
@@ -50,7 +44,7 @@ mixxx::Duration QtVSyncTestWidget::render() {
     timer.start();
     // QPainter makes QGLContext::currentContext() == context()
     // this may delayed until previous buffer swap finished
-    QPainter painter(this);
+    QPainter painter(paintDevice());
     t1 = timer.restart();
     draw(&painter, nullptr);
     //t2 = timer.restart();

--- a/src/waveform/widgets/qtwaveformwidget.cpp
+++ b/src/waveform/widgets/qtwaveformwidget.cpp
@@ -14,13 +14,12 @@
 #include "waveform/renderers/waveformrendermark.h"
 #include "waveform/renderers/waveformrendermarkrange.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
-#include "waveform/sharedglcontext.h"
 
 QtWaveformWidget::QtWaveformWidget(const QString& group, QWidget* parent)
         : GLWaveformWidgetAbstract(group, parent) {
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
+    qDebug() << "Created WGLWidget. Context"
+             << "Valid:" << isContextValid()
+             << "Sharing:" << isContextSharing();
 
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
@@ -29,11 +28,6 @@ QtWaveformWidget::QtWaveformWidget(const QString& group, QWidget* parent)
     addRenderer<QtWaveformRendererFilteredSignal>();
     addRenderer<WaveformRenderBeat>();
     addRenderer<WaveformRenderMark>();
-
-    setAttribute(Qt::WA_NoSystemBackground);
-    setAttribute(Qt::WA_OpaquePaintEvent);
-
-    setAutoBufferSwap(false);
 
     m_initSuccess = init();
 }
@@ -56,7 +50,7 @@ mixxx::Duration QtWaveformWidget::render() {
     timer.start();
     // QPainter makes QGLContext::currentContext() == context()
     // this may delayed until previous buffer swap finished
-    QPainter painter(this);
+    QPainter painter(paintDevice());
     t1 = timer.restart();
     draw(&painter, nullptr);
     //t2 = timer.restart();

--- a/src/waveform/widgets/waveformwidgetabstract.h
+++ b/src/waveform/widgets/waveformwidgetabstract.h
@@ -6,12 +6,13 @@
 #include "util/duration.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveformwidgettype.h"
+#include "widget/wglwidget.h"
 
 class VSyncThread;
 
 // NOTE(vRince) This class represent objects the waveformwidgetfactory can
 // holds, IMPORTANT all WaveformWidgetAbstract MUST inherist QWidget too !!  we
-// can't do it here because QWidget and QGLWidget are both QWidgets so they
+// can't do it here because QWidget and WGLWidget are both QWidgets so they
 // already have a common QWidget base class (ambiguous polymorphism)
 
 class WaveformWidgetAbstract : public WaveformWidgetRenderer {
@@ -24,6 +25,10 @@ class WaveformWidgetAbstract : public WaveformWidgetRenderer {
 
     bool isValid() const { return (m_widget && m_initSuccess); }
     QWidget* getWidget() { return m_widget; }
+
+    virtual WGLWidget* getGLWidget() {
+        return nullptr;
+    }
 
     void hold();
     void release();

--- a/src/widget/openglwindow.cpp
+++ b/src/widget/openglwindow.cpp
@@ -32,14 +32,11 @@ bool OpenGLWindow::event(QEvent* ev) {
 
     if (m_pWidget) {
         const auto t = ev->type();
-        if (t == QEvent::Expose) {
-            m_pWidget->exposed();
-        }
         // Forward the following events to the WGLWidget
-        else if (t == QEvent::MouseButtonDblClick || t == QEvent::MouseButtonPress ||
+        if (t == QEvent::MouseButtonDblClick || t == QEvent::MouseButtonPress ||
                 t == QEvent::MouseButtonRelease || t == QEvent::MouseMove ||
                 t == QEvent::DragEnter || t == QEvent::DragLeave ||
-                t == QEvent::DragMove || t == QEvent::Drop) {
+                t == QEvent::DragMove || t == QEvent::Drop || t == QEvent::Wheel) {
             m_pWidget->handleEventFromWindow(ev);
         }
     }

--- a/src/widget/openglwindow.cpp
+++ b/src/widget/openglwindow.cpp
@@ -1,0 +1,48 @@
+#include "widget/openglwindow.h"
+
+#include <QResizeEvent>
+
+#include "widget/wglwidget.h"
+
+OpenGLWindow::OpenGLWindow(WGLWidget* widget)
+        : m_pWidget(widget) {
+}
+
+OpenGLWindow::~OpenGLWindow() {
+}
+
+void OpenGLWindow::initializeGL() {
+    if (m_pWidget) {
+        m_pWidget->initializeGL();
+    }
+}
+
+void OpenGLWindow::paintGL() {
+}
+
+void OpenGLWindow::resizeGL(int w, int h) {
+}
+
+void OpenGLWindow::widgetDestroyed() {
+    m_pWidget = nullptr;
+}
+
+bool OpenGLWindow::event(QEvent* ev) {
+    bool result = QOpenGLWindow::event(ev);
+
+    if (m_pWidget) {
+        const auto t = ev->type();
+        if (t == QEvent::Expose) {
+            m_pWidget->exposed();
+        }
+        // Forward the following events to the WGLWidget
+        else if (t == QEvent::MouseButtonDblClick || t == QEvent::MouseButtonPress ||
+                t == QEvent::MouseButtonRelease || t == QEvent::MouseMove ||
+                t == QEvent::DragEnter || t == QEvent::DragLeave ||
+                t == QEvent::DragMove || t == QEvent::Drop) {
+            m_pWidget->handleEventFromWindow(ev);
+        }
+    }
+
+    return result;
+}

--- a/src/widget/openglwindow.h
+++ b/src/widget/openglwindow.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QOpenGLWindow>
+
+class WGLWidget;
+
+/// Helper class used by wglwidgetqopengl
+
+class OpenGLWindow : public QOpenGLWindow {
+    Q_OBJECT
+
+    WGLWidget* m_pWidget;
+
+  public:
+    OpenGLWindow(WGLWidget* widget);
+    ~OpenGLWindow();
+
+    void widgetDestroyed();
+
+  private:
+    void initializeGL() override;
+    void paintGL() override;
+    void resizeGL(int w, int h) override;
+    bool event(QEvent* ev) override;
+};

--- a/src/widget/wglwidget.h
+++ b/src/widget/wglwidget.h
@@ -1,0 +1,14 @@
+#pragma once
+
+// This define is checked in wglwidgetqglwidget.h and wglwidgetqglwidget.h
+// to make sure they are only included from this header, to enforce that
+// all code includes this header wglwidget.h.
+#define WGLWIDGET_H
+
+#ifdef MIXXX_USE_QOPENGL
+#include "widget/wglwidgetqopengl.h"
+#else
+#include "widget/wglwidgetqglwidget.h"
+#endif
+
+#undef WGLWIDGET_H

--- a/src/widget/wglwidgetqglwidget.cpp
+++ b/src/widget/wglwidgetqglwidget.cpp
@@ -1,0 +1,34 @@
+#include <QWindow>
+
+#include "waveform/sharedglcontext.h"
+#include "widget/wglwidget.h"
+
+WGLWidget::WGLWidget(QWidget* parent)
+        : QGLWidget(parent, SharedGLContext::getWidget()) {
+    setAttribute(Qt::WA_NoSystemBackground);
+    setAttribute(Qt::WA_OpaquePaintEvent);
+    setAutoFillBackground(false);
+    setAutoBufferSwap(false);
+    // Not interested in repaint or update calls, as we draw from the vsync thread
+    setUpdatesEnabled(false);
+}
+
+bool WGLWidget::isContextValid() const {
+    return context()->isValid();
+}
+
+bool WGLWidget::isContextSharing() const {
+    return context()->isSharing();
+}
+
+bool WGLWidget::shouldRender() const {
+    return true;
+    return isValid() && isVisible() && windowHandle() && windowHandle()->isExposed();
+}
+
+void WGLWidget::makeCurrentIfNeeded() {
+    // TODO m0dB is this really needed? is calling makeCurrent without this 'if' really a problem?
+    //if (context() != QGLContext::currentContext()) {
+    makeCurrent();
+    //}
+}

--- a/src/widget/wglwidgetqglwidget.h
+++ b/src/widget/wglwidgetqglwidget.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#ifndef WGLWIDGET_H
+#error "Do not include this file, include wglwidget.h instead"
+#endif
+
+#include <QGLWidget>
+
+///////////////////////////////////////
+// WGLWidget as a subclass of QGLWidget
+///////////////////////////////////////
+
+class WGLWidget : public QGLWidget {
+  public:
+    WGLWidget(QWidget* parent);
+
+    bool isContextValid() const;
+    bool isContextSharing() const;
+
+    bool shouldRender() const;
+
+    void makeCurrentIfNeeded();
+
+    QPaintDevice* paintDevice() {
+        return this;
+    }
+};

--- a/src/widget/wglwidgetqopengl.cpp
+++ b/src/widget/wglwidgetqopengl.cpp
@@ -62,14 +62,11 @@ void WGLWidget::initializeGL() {
     // to be implemented in derived widgets if needed
 }
 
-void WGLWidget::exposed() {
-    // to be implemented in derived widgets if needed
-}
-
 void WGLWidget::swapBuffers() {
     if (shouldRender()) {
         makeCurrentIfNeeded();
         m_pOpenGLWindow->context()->swapBuffers(m_pOpenGLWindow->context()->surface());
+        doneCurrent();
     }
 }
 

--- a/src/widget/wglwidgetqopengl.cpp
+++ b/src/widget/wglwidgetqopengl.cpp
@@ -1,0 +1,78 @@
+#include <QResizeEvent>
+
+#include "widget/openglwindow.h"
+#include "widget/wglwidget.h"
+
+WGLWidget::WGLWidget(QWidget* parent)
+        : QWidget(parent) {
+}
+
+WGLWidget::~WGLWidget() {
+    if (m_pOpenGLWindow) {
+        m_pOpenGLWindow->widgetDestroyed();
+    }
+}
+
+QPaintDevice* WGLWidget::paintDevice() {
+    makeCurrentIfNeeded();
+    return m_pOpenGLWindow;
+}
+
+void WGLWidget::showEvent(QShowEvent* event) {
+    if (!m_pOpenGLWindow) {
+        m_pOpenGLWindow = new OpenGLWindow(this);
+        m_pContainerWidget = createWindowContainer(m_pOpenGLWindow, this);
+        m_pContainerWidget->resize(size());
+        m_pContainerWidget->show();
+    }
+    QWidget::showEvent(event);
+}
+
+void WGLWidget::resizeEvent(QResizeEvent* event) {
+    if (m_pContainerWidget) {
+        m_pContainerWidget->resize(event->size());
+    }
+}
+
+void WGLWidget::handleEventFromWindow(QEvent* e) {
+    event(e);
+}
+
+bool WGLWidget::isContextValid() const {
+    return m_pOpenGLWindow && m_pOpenGLWindow->context() && m_pOpenGLWindow->context()->isValid();
+}
+
+bool WGLWidget::isContextSharing() const {
+    return true;
+}
+
+void WGLWidget::makeCurrentIfNeeded() {
+    if (m_pOpenGLWindow && m_pOpenGLWindow->context() != QOpenGLContext::currentContext()) {
+        m_pOpenGLWindow->makeCurrent();
+    }
+}
+
+void WGLWidget::doneCurrent() {
+    if (m_pOpenGLWindow) {
+        m_pOpenGLWindow->doneCurrent();
+    }
+}
+
+void WGLWidget::initializeGL() {
+    // to be implemented in derived widgets if needed
+}
+
+void WGLWidget::exposed() {
+    // to be implemented in derived widgets if needed
+}
+
+void WGLWidget::swapBuffers() {
+    if (shouldRender()) {
+        makeCurrentIfNeeded();
+        m_pOpenGLWindow->context()->swapBuffers(m_pOpenGLWindow->context()->surface());
+    }
+}
+
+bool WGLWidget::shouldRender() const {
+    return m_pOpenGLWindow && m_pOpenGLWindow->isExposed();
+}

--- a/src/widget/wglwidgetqopengl.h
+++ b/src/widget/wglwidgetqopengl.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#ifndef WGLWIDGET_H
+#error "Do not include this file, include wglwidget.h instead"
+#endif
+
+#include <QWidget>
+
+////////////////////////////////
+// QOpenGLWindow based WGLWidget
+////////////////////////////////
+
+class QPaintDevice;
+class OpenGLWindow;
+
+class WGLWidget : public QWidget {
+  private:
+    OpenGLWindow* m_pOpenGLWindow{};
+    QWidget* m_pContainerWidget{};
+
+  public:
+    WGLWidget(QWidget* parent);
+    ~WGLWidget();
+
+    bool isContextValid() const;
+    bool isContextSharing() const;
+
+    bool shouldRender() const;
+
+    void makeCurrentIfNeeded();
+    void doneCurrent();
+
+    void swapBuffers();
+    void resizeEvent(QResizeEvent* event) override;
+
+    void showEvent(QShowEvent* event) override;
+
+    // called by OpenGLWindow
+    virtual void handleEventFromWindow(QEvent* ev);
+    virtual void initializeGL();
+    virtual void exposed();
+
+  protected:
+    QPaintDevice* paintDevice();
+};

--- a/src/widget/wglwidgetqopengl.h
+++ b/src/widget/wglwidgetqopengl.h
@@ -38,7 +38,6 @@ class WGLWidget : public QWidget {
     // called by OpenGLWindow
     virtual void handleEventFromWindow(QEvent* ev);
     virtual void initializeGL();
-    virtual void exposed();
 
   protected:
     QPaintDevice* paintDevice();

--- a/src/widget/wknob.cpp
+++ b/src/widget/wknob.cpp
@@ -8,13 +8,18 @@
 #include "util/duration.h"
 
 WKnob::WKnob(QWidget* pParent)
-        : WDisplay(pParent),
+        : WDisplay(pParent)
+#ifdef USE_WIDGET_RENDER_TIMER
+          ,
           m_renderTimer(mixxx::Duration::fromMillis(20),
-                        mixxx::Duration::fromSeconds(1)) {
+                  mixxx::Duration::fromSeconds(1)) {
     connect(&m_renderTimer,
             &WidgetRenderTimer::update,
             this,
             QOverload<>::of(&QWidget::update));
+#else
+{
+#endif
     setFocusPolicy(Qt::NoFocus);
 }
 
@@ -39,7 +44,7 @@ void WKnob::wheelEvent(QWheelEvent* e) {
 }
 
 void WKnob::inputActivity() {
-#ifdef __APPLE__
+#ifdef USE_WIDGET_RENDER_TIMER
     m_renderTimer.activity();
 #else
     update();

--- a/src/widget/wknob.h
+++ b/src/widget/wknob.h
@@ -28,8 +28,9 @@ class WKnob : public WDisplay {
     void inputActivity();
 
   private:
+#ifdef USE_WIDGET_RENDER_TIMER
     WidgetRenderTimer m_renderTimer;
-
+#endif
     KnobEventHandler<WKnob> m_handler;
     friend class KnobEventHandler<WKnob>;
 };

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -20,13 +20,18 @@ WKnobComposed::WKnobComposed(QWidget* pParent)
           m_dArcBgThickness(0),
           m_arcUnipolar(true),
           m_arcReversed(false),
-          m_arcPenCap(Qt::FlatCap),
+          m_arcPenCap(Qt::FlatCap)
+#ifdef USE_WIDGET_RENDER_TIMER
+          ,
           m_renderTimer(mixxx::Duration::fromMillis(20),
-                        mixxx::Duration::fromSeconds(1)) {
+                  mixxx::Duration::fromSeconds(1)) {
     connect(&m_renderTimer,
             &WidgetRenderTimer::update,
             this,
             QOverload<>::of(&QWidget::update));
+#else
+{
+#endif
 }
 
 void WKnobComposed::setup(const QDomNode& node, const SkinContext& context) {
@@ -228,7 +233,7 @@ void WKnobComposed::wheelEvent(QWheelEvent* e) {
 }
 
 void WKnobComposed::inputActivity() {
-#ifdef __APPLE__
+#ifdef USE_WIDGET_RENDER_TIMER
     m_renderTimer.activity();
 #else
     update();

--- a/src/widget/wknobcomposed.h
+++ b/src/widget/wknobcomposed.h
@@ -63,7 +63,9 @@ class WKnobComposed : public WWidget {
     bool m_arcUnipolar;
     bool m_arcReversed;
     Qt::PenCapStyle m_arcPenCap;
+#ifdef USE_WIDGET_RENDER_TIMER
     WidgetRenderTimer m_renderTimer;
+#endif
 
     friend class KnobEventHandler<WKnobComposed>;
 };

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -12,30 +12,35 @@
 #include "widget/wpixmapstore.h"
 #include "widget/wskincolor.h"
 
-WSliderComposed::WSliderComposed(QWidget * parent)
-    : WWidget(parent),
-      m_dHandleLength(0.0),
-      m_dSliderLength(0.0),
-      m_bHorizontal(false),
-      m_dBarWidth(0.0),
-      m_dBarBgWidth(0.0),
-      m_dBarStart(0.0),
-      m_dBarEnd(0.0),
-      m_dBarBgStart(0.0),
-      m_dBarBgEnd(0.0),
-      m_dBarAxisPos(0.0),
-      m_bBarUnipolar(true),
-      m_barColor(nullptr),
-      m_barBgColor(nullptr),
-      m_barPenCap(Qt::FlatCap),
-      m_pSlider(nullptr),
-      m_pHandle(nullptr),
-      m_renderTimer(mixxx::Duration::fromMillis(20),
-                    mixxx::Duration::fromSeconds(1)) {
+WSliderComposed::WSliderComposed(QWidget* parent)
+        : WWidget(parent),
+          m_dHandleLength(0.0),
+          m_dSliderLength(0.0),
+          m_bHorizontal(false),
+          m_dBarWidth(0.0),
+          m_dBarBgWidth(0.0),
+          m_dBarStart(0.0),
+          m_dBarEnd(0.0),
+          m_dBarBgStart(0.0),
+          m_dBarBgEnd(0.0),
+          m_dBarAxisPos(0.0),
+          m_bBarUnipolar(true),
+          m_barColor(nullptr),
+          m_barBgColor(nullptr),
+          m_barPenCap(Qt::FlatCap),
+          m_pSlider(nullptr),
+          m_pHandle(nullptr)
+#ifdef USE_WIDGET_RENDER_TIMER
+          ,
+          m_renderTimer(mixxx::Duration::fromMillis(20),
+                  mixxx::Duration::fromSeconds(1)) {
     connect(&m_renderTimer,
             &WidgetRenderTimer::update,
             this,
             QOverload<>::of(&QWidget::update));
+#else
+                  {
+#endif
 }
 
 WSliderComposed::~WSliderComposed() {
@@ -371,7 +376,7 @@ double WSliderComposed::calculateHandleLength() {
 }
 
 void WSliderComposed::inputActivity() {
-#ifdef __APPLE__
+#ifdef USE_WIDGET_RENDER_TIMER
     m_renderTimer.activity();
 #else
     update();

--- a/src/widget/wslidercomposed.h
+++ b/src/widget/wslidercomposed.h
@@ -75,7 +75,9 @@ class WSliderComposed : public WWidget  {
     // Pointer to pixmap of the handle
     PaintablePointer m_pHandle;
     SliderEventHandler<WSliderComposed> m_handler;
+#ifdef USE_WIDGET_RENDER_TIMER
     WidgetRenderTimer m_renderTimer;
+#endif
 
     friend class SliderEventHandler<WSliderComposed>;
 };

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -17,7 +17,6 @@
 #include "util/fpclassify.h"
 #include "vinylcontrol/vinylcontrol.h"
 #include "vinylcontrol/vinylcontrolmanager.h"
-#include "waveform/sharedglcontext.h"
 #include "waveform/visualplayposition.h"
 #include "waveform/vsyncthread.h"
 #include "wimagestore.h"
@@ -29,7 +28,7 @@ WSpinny::WSpinny(
         UserSettingsPointer pConfig,
         VinylControlManager* pVCMan,
         BaseTrackPlayer* pPlayer)
-        : QGLWidget(parent, SharedGLContext::getWidget()),
+        : WGLWidget(parent),
           WBaseWidget(this),
           m_group(group),
           m_pConfig(pConfig),
@@ -72,12 +71,10 @@ WSpinny::WSpinny(
 #endif // __VINYLCONTROL__
     //Drag and drop
     setAcceptDrops(true);
-    qDebug() << "WSpinny(): Created QGLWidget, Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
-    if (QGLContext::currentContext() != context()) {
-        makeCurrent();
-    }
+    qDebug() << "WSpinny(): Created WGLWidget, Context"
+             << "Valid:" << isContextValid()
+             << "Sharing:" << isContextSharing();
+    makeCurrentIfNeeded();
 
     CoverArtCache* pCache = CoverArtCache::instance();
     if (pCache) {
@@ -96,12 +93,6 @@ WSpinny::WSpinny(
 
     connect(m_pCoverMenu, &WCoverArtMenu::coverInfoSelected, this, &WSpinny::slotCoverInfoSelected);
     connect(m_pCoverMenu, &WCoverArtMenu::reloadCoverArt, this, &WSpinny::slotReloadCoverArt);
-
-    setAttribute(Qt::WA_NoSystemBackground);
-    setAttribute(Qt::WA_OpaquePaintEvent);
-
-    setAutoFillBackground(false);
-    setAutoBufferSwap(false);
 }
 
 WSpinny::~WSpinny() {
@@ -328,12 +319,8 @@ void WSpinny::paintEvent(QPaintEvent *e) {
 }
 
 void WSpinny::render(VSyncThread* vSyncThread) {
-    if (!isValid() || !isVisible()) {
-        return;
-    }
-
-    auto* window = windowHandle();
-    if (window == nullptr || !window->isExposed()) {
+    // TODO @m0dB move outside?
+    if (!shouldRender()) {
         return;
     }
 
@@ -346,7 +333,7 @@ void WSpinny::render(VSyncThread* vSyncThread) {
 
     double scaleFactor = devicePixelRatioF();
 
-    QPainter p(this);
+    QPainter p(paintDevice());
     p.setRenderHint(QPainter::Antialiasing);
     p.setRenderHint(QPainter::SmoothPixmapTransform);
 
@@ -415,16 +402,11 @@ void WSpinny::render(VSyncThread* vSyncThread) {
 }
 
 void WSpinny::swap() {
-    if (!isValid() || !isVisible()) {
+    // TODO @m0dB move outside?
+    if (!shouldRender()) {
         return;
     }
-    auto* window = windowHandle();
-    if (window == nullptr || !window->isExposed()) {
-        return;
-    }
-    if (context() != QGLContext::currentContext()) {
-        makeCurrent();
-    }
+    makeCurrentIfNeeded();
     swapBuffers();
 }
 
@@ -439,7 +421,7 @@ QPixmap WSpinny::scaledCoverArt(const QPixmap& normal) {
     return scaled;
 }
 
-void WSpinny::resizeEvent(QResizeEvent* /*unused*/) {
+void WSpinny::resizeEvent(QResizeEvent* event) {
     m_loadedCoverScaled = scaledCoverArt(m_loadedCover);
     if (m_pFgImage && !m_pFgImage->isNull()) {
         m_fgImageScaled = m_pFgImage->scaled(
@@ -449,6 +431,7 @@ void WSpinny::resizeEvent(QResizeEvent* /*unused*/) {
         m_ghostImageScaled = m_pGhostImage->scaled(
                 size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
     }
+    WGLWidget::resizeEvent(event);
 }
 
 /* Convert between a normalized playback position (0.0 - 1.0) and an angle
@@ -691,6 +674,7 @@ void WSpinny::mouseReleaseEvent(QMouseEvent * e)
 
 void WSpinny::showEvent(QShowEvent* event) {
     Q_UNUSED(event);
+    WGLWidget::showEvent(event);
 #ifdef __VINYLCONTROL__
     // If we want to draw the VC signal on this widget then register for
     // updates.
@@ -716,7 +700,7 @@ bool WSpinny::event(QEvent* pEvent) {
     if (pEvent->type() == QEvent::ToolTip) {
         updateTooltip();
     }
-    return QGLWidget::event(pEvent);
+    return WGLWidget::event(pEvent);
 }
 
 void WSpinny::dragEnterEvent(QDragEnterEvent* event) {

--- a/src/widget/wspinny.h
+++ b/src/widget/wspinny.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <QEvent>
-#include <QGLWidget>
 #include <QHideEvent>
 #include <QShowEvent>
 
@@ -14,6 +13,7 @@
 #include "widget/trackdroptarget.h"
 #include "widget/wbasewidget.h"
 #include "widget/wcoverartmenu.h"
+#include "widget/wglwidget.h"
 #include "widget/wwidget.h"
 
 class ConfigKey;
@@ -22,7 +22,9 @@ class VisualPlayPosition;
 class VinylControlManager;
 class VSyncThread;
 
-class WSpinny : public QGLWidget, public WBaseWidget, public VinylSignalQualityListener,
+class WSpinny : public WGLWidget,
+                public WBaseWidget,
+                public VinylSignalQualityListener,
                 public TrackDropTarget {
     Q_OBJECT
   public:

--- a/src/widget/wvumetergl.h
+++ b/src/widget/wvumetergl.h
@@ -1,15 +1,14 @@
 #pragma once
 
-#include <QGLWidget>
-
 #include "skin/legacy/skincontext.h"
 #include "util/duration.h"
+#include "widget/wglwidget.h"
 #include "widget/wpixmapstore.h"
 #include "widget/wwidget.h"
 
 class VSyncThread;
 
-class WVuMeterGL : public QGLWidget, public WBaseWidget {
+class WVuMeterGL : public WGLWidget, public WBaseWidget {
     Q_OBJECT
   public:
     explicit WVuMeterGL(QWidget* parent = nullptr);
@@ -39,7 +38,7 @@ class WVuMeterGL : public QGLWidget, public WBaseWidget {
     void setPeak(double parameter);
 
     // To make sure we render at least once even when we have no signal
-    bool m_bHasRendered;
+    int m_iRendersPending;
     // To indicate that we rendered so we need to swap
     bool m_bSwapNeeded;
     // Current parameter and peak parameter.

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -40,6 +40,13 @@ class WWaveformViewer : public WWidget, public TrackDropTarget {
     void mouseReleaseEvent(QMouseEvent * /*unused*/) override;
     void leaveEvent(QEvent* /*unused*/) override;
 
+#ifdef MIXXX_USE_QOPENGL
+    // Handle the event forwarded from the QOpenGLWindow
+    void handleEventFromWindow(QEvent* e) {
+        event(e);
+    }
+#endif
+
   signals:
     void trackDropped(const QString& filename, const QString& group) override;
     void cloneDeck(const QString& sourceGroup, const QString& targetGroup) override;


### PR DESCRIPTION
This PR replaces the use of QGLWidget with a new class WGLWidget.

The new cmake option QOPENGL determines how WGLWidget is implemented:

- with QOPENGL=OFF: WGLWidget is a class derived from QGLWidget, with code that was duplicated in derived classes such as WSpinny, WVuMeterGL, the waveform widget and in waveform widget factory,  moved WGLWidget methods. This is a refactoring that should behave exactly the same as before.

- with QOPENGL=ON: WGLWidget is class derived from QWidget that has an container widget that contains an QOpenGLWindow. As far as I have tested, on macOS rendering with QOpenGLWindow is significantly faster than QGLWidget.
 
The two implementations use the same API, wit the intention of keeping all use of these classes and the derived classes identical, independent of the implementation used. There are some exceptions, where implementation specific code is needed (e.g. forwarding events to the WWaveformViewer), this is done inside #ifdef MIXXX_USE_QOPENGL blocks.

In addition to this, all use of either the old Qt QGL.. or the new Qt QOpenGL.. classes is also handled with the MIXXX_USE_QOPENGL preprocessor define (defined by cmake)

Finally, I added another WVuMeter implementation, one that uses QOpenGL code and uses textures and shaders to render the pixmaps instead of QPainter.

Note that I have a third WGLWidget implementation, which uses QOpenGLWidget, but on macOS this has the same problems as QGLWidget (bad framerate, laggy interaction), so I can't really test it. It would be good if a linux or windows dev code take over. This will allow us to completely replace the deprecated QGL... classes with QOpenGL... classes.
