### PR TITLE
ci(pre-commit): Use pre-commit to fix clang-format execution on Windows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,6 +82,8 @@ repos:
           - manual
         language: python
         files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|m|mm|proto|vert)$
+        additional_dependencies:
+          - pre_commit==2.20.0
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:

--- a/tools/clang_format.py
+++ b/tools/clang_format.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import argparse
 import logging


### PR DESCRIPTION
@JoergAtGithub please check if this fixes clang_format on windows.