### PR TITLE
WSpinny: ensure DlgCoverArtFullSize has a parent on xcb

### DIFF
--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -64,7 +64,7 @@ WSpinny::WSpinny(
           m_bClampFailedWarning(false),
           m_bGhostPlayback(false),
           m_pPlayer(pPlayer),
-          m_pDlgCoverArt(new DlgCoverArtFullSize(parent, pPlayer)),
+          m_pDlgCoverArt(new DlgCoverArtFullSize(this, pPlayer)),
           m_pCoverMenu(new WCoverArtMenu(this)) {
 #ifdef __VINYLCONTROL__
     m_pVCManager = pVCMan;


### PR DESCRIPTION
see #10968 
> regression from https://github.com/mixxxdj/mixxx/commit/b8dff320982216317dc6811183bc55bcb57da21f#diff-b1b61c8dfee6e1e996c68cbc327f3c9f1654f5426ef92265550fe6775432c0e8R1281 on xcb
WSpinny is created with nullptr parent and that is used to create DlgCoverArtFullSize. When the parent is set for WSpinny it is not set for DlgCoverArtFullSize.

Alternative: 78644e4863

Closing #10968 