### PR TITLE
Return a local copy of m_cuePoints to avaoid a race condition

### DIFF
--- a/src/control/control.h
+++ b/src/control/control.h
@@ -64,7 +64,8 @@ class ControlDoublePrivate : public QObject {
     static QList<QSharedPointer<ControlDoublePrivate>> takeAllInstances();
 
     static QHash<ConfigKey, ConfigKey> getControlAliases() {
-        // Implicitly shared classes can safely be copied across threads
+        MMutexLocker locker(&s_qCOHashMutex);
+        // lock thread-unsafe copy constructors of QHash
         return s_qCOAliasHash;
     }
 

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -263,7 +263,8 @@ class Track : public QObject {
     void removeCue(const CuePointer& pCue);
     void removeCuesOfType(mixxx::CueType);
     QList<CuePointer> getCuePoints() const {
-        // Copying implicitly shared collections is thread-safe
+        const QMutexLocker lock(&m_qMutex);
+        // lock thread-unsafe copy constructors of QList
         return m_cuePoints;
     }
 


### PR DESCRIPTION
The QList copy constructor seems to be not thread-safe in case it is not already shared.
https://github.com/qt/qtbase/blob/d8efc8d718e3b3a0464f321e740541f5b221a5d6/src/corelib/tools/qlist.h#L809

This may be fix 
https://github.com/mixxxdj/mixxx/issues/10956
https://github.com/mixxxdj/mixxx/issues/10689
With two backtraces, where a crash originates to the same function. 

