### PR TITLE
Replace definition of invalid positions

### DIFF
--- a/src/audio/frame.h
+++ b/src/audio/frame.h
@@ -22,7 +22,8 @@ class FramePos final {
     typedef double value_t;
     static constexpr value_t kStartValue = 0;
     static constexpr value_t kInvalidValue = std::numeric_limits<FramePos::value_t>::quiet_NaN();
-    static constexpr double kLegacyInvalidEnginePosition = -1.0;
+    static constexpr double kLegacyInvalidEnginePosition =
+            -1 * std::numeric_limits<double>::infinity();
 
     constexpr FramePos()
             : m_framePosition(kInvalidValue) {

--- a/src/engine/controls/enginecontrol.h
+++ b/src/engine/controls/enginecontrol.h
@@ -18,7 +18,7 @@
 class EngineMaster;
 class EngineBuffer;
 
-constexpr int kNoTrigger = -1;
+constexpr double kNoTrigger = -1 * std::numeric_limits<double>::infinity();
 static_assert(
         mixxx::audio::FramePos::kLegacyInvalidEnginePosition == kNoTrigger,
         "Invalid engine position value mismatch");

--- a/src/engine/controls/quantizecontrol.cpp
+++ b/src/engine/controls/quantizecontrol.cpp
@@ -91,7 +91,6 @@ void QuantizeControl::lookupBeatPositions(mixxx::audio::FramePos position) {
         mixxx::audio::FramePos prevBeatPosition;
         mixxx::audio::FramePos nextBeatPosition;
         pBeats->findPrevNextBeats(position, &prevBeatPosition, &nextBeatPosition, true);
-        // FIXME: -1.0 is a valid frame position, should we set the COs to NaN?
         m_pCOPrevBeat->set(prevBeatPosition.toEngineSamplePosMaybeInvalid());
         m_pCONextBeat->set(nextBeatPosition.toEngineSamplePosMaybeInvalid());
     }

--- a/src/test/looping_control_test.cpp
+++ b/src/test/looping_control_test.cpp
@@ -172,7 +172,7 @@ TEST_F(LoopingControlTest, LoopInSetAfterLoopOutStops) {
     m_pLoopStartPoint->set(mixxx::audio::FramePos{110}.toEngineSamplePos());
     EXPECT_FALSE(isLoopEnabled());
     EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos{110}, m_pLoopStartPoint);
-    EXPECT_EQ(-1, m_pLoopEndPoint->get());
+    EXPECT_EQ(-1 * std::numeric_limits<double>::infinity(), m_pLoopEndPoint->get());
 }
 
 TEST_F(LoopingControlTest, LoopOutSetInsideLoopContinues) {

--- a/src/track/cue.h
+++ b/src/track/cue.h
@@ -20,7 +20,7 @@ class Cue : public QObject {
 
   public:
     /// A position value for the cue that signals its position is not set
-    static constexpr double kNoPosition = -1.0;
+    static constexpr double kNoPosition = -1 * std::numeric_limits<double>::infinity();
 
     /// Invalid hot cue index
     static constexpr int kNoHotCue = -1;

--- a/src/waveform/renderers/waveformmarkrange.cpp
+++ b/src/waveform/renderers/waveformmarkrange.cpp
@@ -3,6 +3,7 @@
 #include <QPainter>
 #include <QtDebug>
 
+#include "audio/frame.h"
 #include "skin/legacy/skincontext.h"
 #include "waveformsignalcolors.h"
 #include "widget/wskincolor.h"
@@ -78,7 +79,10 @@ WaveformMarkRange::WaveformMarkRange(
 bool WaveformMarkRange::active() const {
     const double startValue = start();
     const double endValue = end();
-    return startValue != endValue && startValue != -1.0 && endValue != -1.0;
+    return startValue != endValue &&
+            startValue !=
+            mixxx::audio::FramePos::kLegacyInvalidEnginePosition &&
+            endValue != mixxx::audio::FramePos::kLegacyInvalidEnginePosition;
 }
 
 bool WaveformMarkRange::enabled() const {
@@ -94,7 +98,7 @@ bool WaveformMarkRange::visible() const {
 }
 
 double WaveformMarkRange::start() const {
-    double start = -1.0;
+    double start = mixxx::audio::FramePos::kLegacyInvalidEnginePosition;
     if (m_markStartPointControl && m_markStartPointControl->valid()) {
         start = m_markStartPointControl->get();
     }
@@ -102,7 +106,7 @@ double WaveformMarkRange::start() const {
 }
 
 double WaveformMarkRange::end() const {
-    double end = -1.0;
+    double end = mixxx::audio::FramePos::kLegacyInvalidEnginePosition;
     if (m_markEndPointControl && m_markEndPointControl->valid()) {
         end = m_markEndPointControl->get();
     }


### PR DESCRIPTION
Previously "-1.0" was considered an invalid position, but we actually have good support for negative positions. This PR proposes -INF as a better invalid value.

This PR is mostly to spur discussion, I'm sure there are more edge cases to consider

Fixes https://github.com/mixxxdj/mixxx/issues/10993