### PR TITLE
Fix cue points being assigned invalid value of -1.0

### DIFF
--- a/res/schema.xml
+++ b/res/schema.xml
@@ -80,6 +80,8 @@ reapplying those migrations.
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         track_id INTEGER NOT NULL REFERENCES library(id),
         type INTEGER DEFAULT 0 NOT NULL,
+        <!-- Positions and lengths are actually stored as SQLite REAL (double) frame values.
+        This allows for bpm-accurate sub-sample accuracy positions and lengths. -->
         position INTEGER DEFAULT -1 NOT NULL,
         length INTEGER DEFAULT 0 NOT NULL,
         hotcue INTEGER DEFAULT -1 NOT NULL,

--- a/src/audio/frame.h
+++ b/src/audio/frame.h
@@ -44,7 +44,15 @@ class FramePos final {
     /// values), use `FramePos::toEngineSamplePosMaybeInvalid` instead.
     double toEngineSamplePos() const {
         DEBUG_ASSERT(isValid());
-        return value() * mixxx::kEngineChannelCount;
+        double engineSamplePos = value() * mixxx::kEngineChannelCount;
+        // In the rare but possible instance that the position is valid but
+        // the engine sample position is exactly -1.0, we nudge the position
+        // because otherwise fromEngineSamplePosMaybeInvalid() will think
+        // the position is invalid.
+        if (engineSamplePos == kLegacyInvalidEnginePosition) {
+            return kLegacyInvalidEnginePosition - 0.0001;
+        }
+        return engineSamplePos;
     }
 
     /// Return a `FramePos` from a given engine sample position. Sample


### PR DESCRIPTION
Fixes two issues in cue point creation:
* cue point positions are stored as doubles, not ints, so they should be loaded that way from the db.
* in the conversion to engine sample position, avoid creating invalid -1.0 values.


Fixes https://github.com/mixxxdj/mixxx/issues/10993