### PR TITLE
Don't reject file metadata Keys values with non Minor/Major scales.  

### DIFF
--- a/src/test/keyutilstest.cpp
+++ b/src/test/keyutilstest.cpp
@@ -174,6 +174,44 @@ TEST_F(KeyUtilsTest, KeyNameNotation) {
             KeyUtils::guessKeyFromText("xyz"));
 }
 
+TEST_F(KeyUtilsTest, ScaleModeNotation) {
+    EXPECT_EQ(mixxx::track::io::key::C_MAJOR,
+            KeyUtils::guessKeyFromText("C ionian"));
+    EXPECT_EQ(mixxx::track::io::key::A_MINOR,
+            KeyUtils::guessKeyFromText("A aeolian"));
+    EXPECT_EQ(mixxx::track::io::key::C_MAJOR,
+            KeyUtils::guessKeyFromText("F lydian"));
+    EXPECT_EQ(mixxx::track::io::key::C_MAJOR,
+            KeyUtils::guessKeyFromText("G mixolydian"));
+    EXPECT_EQ(mixxx::track::io::key::A_MINOR,
+            KeyUtils::guessKeyFromText("D dorian"));
+    EXPECT_EQ(mixxx::track::io::key::A_MINOR,
+            KeyUtils::guessKeyFromText("E phrygian"));
+    EXPECT_EQ(mixxx::track::io::key::A_MINOR,
+            KeyUtils::guessKeyFromText("B locrian"));
+
+    EXPECT_EQ(mixxx::track::io::key::F_SHARP_MINOR,
+            KeyUtils::guessKeyFromText("11A"));
+    EXPECT_EQ(mixxx::track::io::key::A_MAJOR,
+            KeyUtils::guessKeyFromText("11B"));
+    EXPECT_EQ(mixxx::track::io::key::A_MAJOR,
+            KeyUtils::guessKeyFromText("11I"));
+    EXPECT_EQ(mixxx::track::io::key::A_MAJOR,
+            KeyUtils::guessKeyFromText("11L"));
+    EXPECT_EQ(mixxx::track::io::key::A_MAJOR,
+            KeyUtils::guessKeyFromText("11M"));
+    EXPECT_EQ(mixxx::track::io::key::F_SHARP_MINOR,
+            KeyUtils::guessKeyFromText("11D"));
+    EXPECT_EQ(mixxx::track::io::key::F_SHARP_MINOR,
+            KeyUtils::guessKeyFromText("11P"));
+    EXPECT_EQ(mixxx::track::io::key::F_SHARP_MINOR,
+            KeyUtils::guessKeyFromText("11C"));
+
+    // Redundant Mode
+    EXPECT_EQ(mixxx::track::io::key::INVALID,
+            KeyUtils::guessKeyFromText("Cm ionian"));
+}
+
 mixxx::track::io::key::ChromaticKey incrementKey(
     mixxx::track::io::key::ChromaticKey key, int steps=1) {
     return static_cast<mixxx::track::io::key::ChromaticKey>(

--- a/src/test/keyutilstest.cpp
+++ b/src/test/keyutilstest.cpp
@@ -12,11 +12,6 @@ class KeyUtilsTest : public testing::Test {
 };
 
 TEST_F(KeyUtilsTest, OpenKeyNotation) {
-    EXPECT_EQ(mixxx::track::io::key::C_MAJOR,
-              KeyUtils::guessKeyFromText("1D"));
-    EXPECT_EQ(mixxx::track::io::key::C_SHARP_MINOR,
-              KeyUtils::guessKeyFromText("5M"));
-
     // Lower-case.
     EXPECT_EQ(mixxx::track::io::key::B_MAJOR,
               KeyUtils::guessKeyFromText("6d"));
@@ -37,18 +32,12 @@ TEST_F(KeyUtilsTest, LancelotNotation) {
     EXPECT_EQ(mixxx::track::io::key::C_SHARP_MINOR,
               KeyUtils::guessKeyFromText("12A"));
 
-    // Lower-case.
-    EXPECT_EQ(mixxx::track::io::key::B_MAJOR,
-              KeyUtils::guessKeyFromText("1b"));
-    EXPECT_EQ(mixxx::track::io::key::B_MINOR,
-              KeyUtils::guessKeyFromText("10a"));
-
     // whitespace is ok
     EXPECT_EQ(mixxx::track::io::key::B_MINOR,
-              KeyUtils::guessKeyFromText("\t10a  "));
+            KeyUtils::guessKeyFromText("\t10A  "));
     // but other stuff is not
     EXPECT_EQ(mixxx::track::io::key::INVALID,
-              KeyUtils::guessKeyFromText("\t10aa  "));
+            KeyUtils::guessKeyFromText("\t10AA  "));
 }
 
 TEST_F(KeyUtilsTest, KeyNameNotation) {

--- a/src/test/keyutilstest.cpp
+++ b/src/test/keyutilstest.cpp
@@ -159,9 +159,9 @@ TEST_F(KeyUtilsTest, KeyNameNotation) {
             KeyUtils::guessKeyFromText("Ab -50cents"));
     EXPECT_EQ(mixxx::track::io::key::A_FLAT_MAJOR, // ionian
             KeyUtils::guessKeyFromText("04B -50cents"));
-    EXPECT_EQ(mixxx::track::io::key::A_FLAT_MAJOR, // ionian
-            KeyUtils::guessKeyFromText("    4b    -50   cents    "));
     // Mixxx does not allow this but Rapid Evolution
+    // EXPECT_EQ(mixxx::track::io::key::A_FLAT_MAJOR, // ionian
+    //      KeyUtils::guessKeyFromText("    4b    -50   cents    "));
     // EXPECT_EQ(mixxx::track::io::key::A_FLAT_MAJOR, // ionian
     //          KeyUtils::guessKeyFromText("    g  #    -    50   cents    "));
     // EXPECT_EQ(mixxx::track::io::key::A_FLAT_MAJOR, // ionian

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -16,9 +16,9 @@ using mixxx::track::io::key::ChromaticKey_IsValid;
 // OpenKey notation, the numbers 1-12 followed by d (dur, major) or m (moll, minor).
 static const QString s_openKeyPattern("^\\s*(1[0-2]|[1-9])([dm])\\s*$");
 
-// Lancelot notation, the numbers 1-12 followed by a (minor) or b (major).
-// This is also used to detect RapidEvolution Key Code format using a padding "0"
-static const QString s_lancelotKeyPattern("^\\s*0*(1[0-2]|[1-9])([ab])\\s*$");
+// Lancelot notation, the numbers 1-12 followed by A (minor) or B(I) (major).
+// or "I", "L", "M", "D", "P", "C" for the advanced modes
+static const QString s_lancelotKeyPattern("^\\s*0*(1[0-2]|[1-9])([ABILMDPC])\\s*$");
 
 // a-g followed by any number of sharps or flats, optionally followed by
 // a scale spec (m = minor, min, maj)
@@ -297,7 +297,8 @@ ChromaticKey KeyUtils::guessKeyFromText(const QString& text) {
 
         int openKeyNumber = lancelotNumberToOpenKeyNumber(lancelotNumber);
 
-        bool major = lancelotKeyMatcher.cap(2).compare("B") == 0;
+        const QChar lancelotScaleMode = lancelotKeyMatcher.cap(2).at(0);
+        bool major = (QString("BILM").indexOf(lancelotScaleMode) != -1);
 
         return openKeyNumberToKey(openKeyNumber, major);
     }

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -407,11 +407,11 @@ ChromaticKey KeyUtils::guessKeyFromText(const QString& text) {
             } else {
                 // Try to find detailed scale mode
                 ScaleMode scaleMode = ScaleMode::Unknown;
-                for (size_t i = 0; i < std::size(s_scaleModeInfo); ++i) {
-                    if (scale.startsWith(s_scaleModeInfo[i].textShort, Qt::CaseInsensitive)) {
-                        scaleMode = s_scaleModeInfo[i].mode;
-                        major = s_scaleModeInfo[i].isMajor;
-                        steps += s_scaleModeInfo[i].transposeSteps;
+                for (const ScaleModeInfo& modeInfo : s_scaleModeInfo) {
+                    if (scale.startsWith(modeInfo.textShort, Qt::CaseInsensitive)) {
+                        scaleMode = modeInfo.mode;
+                        major = modeInfo.isMajor;
+                        steps += modeInfo.transposeSteps;
                         break;
                     }
                 }

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -9,156 +9,153 @@
 
 #include "util/math.h"
 
-#define MUSIC_FLAT_UTF8  "\xe299ad"
-#define MUSIC_SHARP_UTF8 "\xe299af"
-
 using mixxx::track::io::key::ChromaticKey;
 using mixxx::track::io::key::ChromaticKey_IsValid;
 
+namespace {
+
 // OpenKey notation, the numbers 1-12 followed by d (dur, major) or m (moll, minor).
-static const QString s_openKeyPattern("^\\s*(1[0-2]|[1-9])([dm])\\s*$");
+const QString s_openKeyPattern = QStringLiteral("^\\s*(1[0-2]|[1-9])([dm])\\s*$");
 
 // Lancelot notation, the numbers 1-12 followed by A (minor) or B(I) (major).
 // or "I", "L", "M", "D", "P", "C" for the advanced modes
-static const QString s_lancelotKeyPattern("^\\s*0*(1[0-2]|[1-9])([ABILMDPC])\\s*$");
+const QString s_lancelotKeyPattern = QStringLiteral("^\\s*0*(1[0-2]|[1-9])([ABILMDPC])\\s*$");
 
 // a-g followed by any number of sharps or flats, optionally followed by
 // a scale mode spec (m = minor, min, maj ..)
-static const QString s_keyPattern = QString::fromUtf8(
+const QString s_keyPattern = QString::fromUtf8(
         "^\\s*([a-g])([#♯b♭]*) *([a-z]{3}.*|m)?\\s*$");
 
-static const QString s_sharpSymbol = QString::fromUtf8("♯");
+const QString s_sharpSymbol = QString::fromUtf8("♯");
 //static const QString s_flatSymbol = QString::fromUtf8("♭");
 
-static const QString s_traditionalKeyNames[] = {
-    QString::fromUtf8("INVALID"),
-    QString::fromUtf8("C"),
-    QString::fromUtf8("D♭"),
-    QString::fromUtf8("D"),
-    QString::fromUtf8("E♭"),
-    QString::fromUtf8("E"),
-    QString::fromUtf8("F"),
-    QString::fromUtf8("F♯/G♭"),
-    QString::fromUtf8("G"),
-    QString::fromUtf8("A♭"),
-    QString::fromUtf8("A"),
-    QString::fromUtf8("B♭"),
-    QString::fromUtf8("B"),
-    QString::fromUtf8("Cm"),
-    QString::fromUtf8("C♯m"),
-    QString::fromUtf8("Dm"),
-    QString::fromUtf8("D♯m/E♭m"),
-    QString::fromUtf8("Em"),
-    QString::fromUtf8("Fm"),
-    QString::fromUtf8("F♯m"),
-    QString::fromUtf8("Gm"),
-    QString::fromUtf8("G♯m"),
-    QString::fromUtf8("Am"),
-    QString::fromUtf8("B♭m"),
-    QString::fromUtf8("Bm")
-};
+const QString s_traditionalKeyNames[] = {
+        QString::fromUtf8("INVALID"),
+        QString::fromUtf8("C"),
+        QString::fromUtf8("D♭"),
+        QString::fromUtf8("D"),
+        QString::fromUtf8("E♭"),
+        QString::fromUtf8("E"),
+        QString::fromUtf8("F"),
+        QString::fromUtf8("F♯/G♭"),
+        QString::fromUtf8("G"),
+        QString::fromUtf8("A♭"),
+        QString::fromUtf8("A"),
+        QString::fromUtf8("B♭"),
+        QString::fromUtf8("B"),
+        QString::fromUtf8("Cm"),
+        QString::fromUtf8("C♯m"),
+        QString::fromUtf8("Dm"),
+        QString::fromUtf8("D♯m/E♭m"),
+        QString::fromUtf8("Em"),
+        QString::fromUtf8("Fm"),
+        QString::fromUtf8("F♯m"),
+        QString::fromUtf8("Gm"),
+        QString::fromUtf8("G♯m"),
+        QString::fromUtf8("Am"),
+        QString::fromUtf8("B♭m"),
+        QString::fromUtf8("Bm")};
 
 // Maps an OpenKey number to its major and minor key.
-const ChromaticKey s_openKeyToKeys[][2] = {
-    // 0 is not a valid OpenKey number.
-    { mixxx::track::io::key::INVALID,       mixxx::track::io::key::INVALID },
-    { mixxx::track::io::key::C_MAJOR,       mixxx::track::io::key::A_MINOR }, // 1
-    { mixxx::track::io::key::G_MAJOR,       mixxx::track::io::key::E_MINOR }, // 2
-    { mixxx::track::io::key::D_MAJOR,       mixxx::track::io::key::B_MINOR }, // 3
-    { mixxx::track::io::key::A_MAJOR,       mixxx::track::io::key::F_SHARP_MINOR }, // 4
-    { mixxx::track::io::key::E_MAJOR,       mixxx::track::io::key::C_SHARP_MINOR }, // 5
-    { mixxx::track::io::key::B_MAJOR,       mixxx::track::io::key::G_SHARP_MINOR }, // 6
-    { mixxx::track::io::key::F_SHARP_MAJOR, mixxx::track::io::key::E_FLAT_MINOR }, // 7
-    { mixxx::track::io::key::D_FLAT_MAJOR,  mixxx::track::io::key::B_FLAT_MINOR }, // 8
-    { mixxx::track::io::key::A_FLAT_MAJOR,  mixxx::track::io::key::F_MINOR }, // 9
-    { mixxx::track::io::key::E_FLAT_MAJOR,  mixxx::track::io::key::C_MINOR }, // 10
-    { mixxx::track::io::key::B_FLAT_MAJOR,  mixxx::track::io::key::G_MINOR }, // 11
-    { mixxx::track::io::key::F_MAJOR,       mixxx::track::io::key::D_MINOR } // 12
+constexpr ChromaticKey s_openKeyToKeys[][2] = {
+        // 0 is not a valid OpenKey number.
+        {mixxx::track::io::key::INVALID, mixxx::track::io::key::INVALID},
+        {mixxx::track::io::key::C_MAJOR, mixxx::track::io::key::A_MINOR},            // 1
+        {mixxx::track::io::key::G_MAJOR, mixxx::track::io::key::E_MINOR},            // 2
+        {mixxx::track::io::key::D_MAJOR, mixxx::track::io::key::B_MINOR},            // 3
+        {mixxx::track::io::key::A_MAJOR, mixxx::track::io::key::F_SHARP_MINOR},      // 4
+        {mixxx::track::io::key::E_MAJOR, mixxx::track::io::key::C_SHARP_MINOR},      // 5
+        {mixxx::track::io::key::B_MAJOR, mixxx::track::io::key::G_SHARP_MINOR},      // 6
+        {mixxx::track::io::key::F_SHARP_MAJOR, mixxx::track::io::key::E_FLAT_MINOR}, // 7
+        {mixxx::track::io::key::D_FLAT_MAJOR, mixxx::track::io::key::B_FLAT_MINOR},  // 8
+        {mixxx::track::io::key::A_FLAT_MAJOR, mixxx::track::io::key::F_MINOR},       // 9
+        {mixxx::track::io::key::E_FLAT_MAJOR, mixxx::track::io::key::C_MINOR},       // 10
+        {mixxx::track::io::key::B_FLAT_MAJOR, mixxx::track::io::key::G_MINOR},       // 11
+        {mixxx::track::io::key::F_MAJOR, mixxx::track::io::key::D_MINOR}             // 12
 };
 
 // This is a quick hack to convert an ASCII letter into a key. Lookup the key
 // using (letter.toLower() - 'a') as the index. Make sure the letter matches
 // [a-gA-G] first.
-const ChromaticKey s_letterToMajorKey[] = {
-    mixxx::track::io::key::A_MAJOR,
-    mixxx::track::io::key::B_MAJOR,
-    mixxx::track::io::key::C_MAJOR,
-    mixxx::track::io::key::D_MAJOR,
-    mixxx::track::io::key::E_MAJOR,
-    mixxx::track::io::key::F_MAJOR,
-    mixxx::track::io::key::G_MAJOR
+constexpr ChromaticKey s_letterToMajorKey[] = {
+        mixxx::track::io::key::A_MAJOR,
+        mixxx::track::io::key::B_MAJOR,
+        mixxx::track::io::key::C_MAJOR,
+        mixxx::track::io::key::D_MAJOR,
+        mixxx::track::io::key::E_MAJOR,
+        mixxx::track::io::key::F_MAJOR,
+        mixxx::track::io::key::G_MAJOR};
+
+constexpr int s_sortKeysCircleOfFifths[] = {
+        0,  // INVALID
+        1,  // C_MAJOR
+        15, // D_FLAT_MAJOR
+        5,  // D_MAJOR
+        19, // E_FLAT_MAJOR
+        9,  // E_MAJOR
+        23, // F_MAJOR
+        13, // F_SHARP_MAJOR
+        3,  // G_MAJOR
+        17, // A_FLAT_MAJOR
+        7,  // A_MAJOR
+        21, // B_FLAT_MAJOR
+        11, // B_MAJOR
+        20, // C_MINOR
+        10, // C_SHARP_MINOR
+        24, // D_MINOR
+        14, // E_FLAT_MINOR
+        4,  // E_MINOR
+        18, // F_MINOR
+        8,  // F_SHARP_MINOR
+        22, // G_MINOR
+        12, // G_SHARP_MINOR
+        2,  // A_MINOR
+        16, // B_FLAT_MINOR
+        6,  // B_MINOR
 };
 
-static const int s_sortKeysCircleOfFifths[] = {
-    0, // INVALID
-    1, // C_MAJOR
-    15, // D_FLAT_MAJOR
-    5, // D_MAJOR
-    19, // E_FLAT_MAJOR
-    9, // E_MAJOR
-    23, // F_MAJOR
-    13, // F_SHARP_MAJOR
-    3, // G_MAJOR
-    17, // A_FLAT_MAJOR
-    7, // A_MAJOR
-    21, // B_FLAT_MAJOR
-    11, // B_MAJOR
-    20, // C_MINOR
-    10, // C_SHARP_MINOR
-    24, // D_MINOR
-    14, // E_FLAT_MINOR
-    4, // E_MINOR
-    18, // F_MINOR
-    8, // F_SHARP_MINOR
-    22, // G_MINOR
-    12, // G_SHARP_MINOR
-    2, // A_MINOR
-    16, // B_FLAT_MINOR
-    6, // B_MINOR
-};
-
-static const int s_sortKeysCircleOfFifthsLancelot[] = {
-    0, // INVALID
-    16, // C_MAJOR
-    6, // D_FLAT_MAJOR
-    20, // D_MAJOR
-    10, // E_FLAT_MAJOR
-    24, // E_MAJOR
-    14, // F_MAJOR
-    4, // F_SHARP_MAJOR
-    18, // G_MAJOR
-    8, // A_FLAT_MAJOR
-    22, // A_MAJOR
-    12, // B_FLAT_MAJOR
-    2, // B_MAJOR
-    9, // C_MINOR
-    23, // C_SHARP_MINOR
-    13, // D_MINOR
-    3, // E_FLAT_MINOR
-    17, // E_MINOR
-    7, // F_MINOR
-    21, // F_SHARP_MINOR
-    11, // G_MINOR
-    1, // G_SHARP_MINOR
-    15, // A_MINOR
-    5, // B_FLAT_MINOR
-    19, // B_MINOR
+constexpr int s_sortKeysCircleOfFifthsLancelot[] = {
+        0,  // INVALID
+        16, // C_MAJOR
+        6,  // D_FLAT_MAJOR
+        20, // D_MAJOR
+        10, // E_FLAT_MAJOR
+        24, // E_MAJOR
+        14, // F_MAJOR
+        4,  // F_SHARP_MAJOR
+        18, // G_MAJOR
+        8,  // A_FLAT_MAJOR
+        22, // A_MAJOR
+        12, // B_FLAT_MAJOR
+        2,  // B_MAJOR
+        9,  // C_MINOR
+        23, // C_SHARP_MINOR
+        13, // D_MINOR
+        3,  // E_FLAT_MINOR
+        17, // E_MINOR
+        7,  // F_MINOR
+        21, // F_SHARP_MINOR
+        11, // G_MINOR
+        1,  // G_SHARP_MINOR
+        15, // A_MINOR
+        5,  // B_FLAT_MINOR
+        19, // B_MINOR
 };
 
 /*
 // Strings used by Rapid Evolution when exporting detailed keys to file tags
-static const char* s_scaleModeText[] = {
+constexpr const char* s_scaleModeText[] = {
     "ionian", // standard major
-        "aeolian", // natural minor
-        "lydian", // major with raised 4th
-        "mixolydian", // major with lowered 7th
-        "dorian", // minor with raised 6th
-        "phrygian", // minor with lowered 2nd
-        "locrian", //  minor with lowered 2nd and 7th
+	"aeolian", // natural minor
+	"lydian", // major with raised 4th
+	"mixolydian", // major with lowered 7th
+	"dorian", // minor with raised 6th
+	"phrygian", // minor with lowered 2nd
+	"locrian", //  minor with lowered 2nd and 7th
 };
 */
 
-static const char* s_scaleModeTextShort[] = {
+constexpr const char* s_scaleModeTextShort[] = {
         "ion", // standard major
         "aeo", // natural minor
         "lyd", // major with raised 4th
@@ -168,7 +165,7 @@ static const char* s_scaleModeTextShort[] = {
         "loc"  // minor with lowered 2nd and 7th
 };
 
-static constexpr bool s_scaleModeIsMajor[] = {
+constexpr bool s_scaleModeIsMajor[] = {
         true,  // ionian (standard major)
         false, // aeolian (natural minor)
         true,  // lydian
@@ -193,7 +190,7 @@ static constexpr bool s_scaleModeIsMajor[] = {
 // "A aeolian"    8A    A – B – C – D – E – F – G
 // "Bb"
 // "B locrian"    8C    B – C – D – E – F – G – A
-static constexpr int s_scaleModeTransposeSteps[] = {
+constexpr int s_scaleModeTransposeSteps[] = {
         0,  // ionian to ionian
         0,  // aeolian to aeolian
         -5, // lydian to ionian
@@ -202,10 +199,6 @@ static constexpr int s_scaleModeTransposeSteps[] = {
         +5, // phrygian to aeolian
         -2, // locrian to aeolian
 };
-
-QMutex KeyUtils::s_notationMutex;
-QMap<ChromaticKey, QString> KeyUtils::s_notation;
-QMap<QString, ChromaticKey> KeyUtils::s_reverseNotation;
 
 // Lancelot notation is OpenKey notation rotated counter-clockwise by 5.
 inline int openKeyNumberToLancelotNumber(const int okNumber)  {
@@ -224,6 +217,12 @@ inline int lancelotNumberToOpenKeyNumber(const int lancelotNumber)  {
     }
     return okNumber;
 }
+
+} // namespace
+
+QMutex KeyUtils::s_notationMutex;
+QMap<ChromaticKey, QString> KeyUtils::s_notation;
+QMap<QString, ChromaticKey> KeyUtils::s_reverseNotation;
 
 // static
 ChromaticKey KeyUtils::openKeyNumberToKey(int openKeyNumber, bool major) {

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -23,6 +23,7 @@ const QString s_lancelotKeyPattern = QStringLiteral("^\\s*0*(1[0-2]|[1-9])([ABIL
 
 // a-g followed by any number of sharps or flats, optionally followed by
 // a scale mode spec (m = minor, min, maj ..)
+// Note: ## = x exists: https://jadebultitude.com/double-sharp-sign-in-music
 const QString s_keyPattern = QString::fromUtf8(
         "^\\s*([a-g])([#♯b♭]*) *([a-z]{3}.*|m)?\\s*$");
 

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -144,40 +144,25 @@ constexpr int s_sortKeysCircleOfFifthsLancelot[] = {
         19, // B_MINOR
 };
 
-/*
+struct ScaleModeInfo {
+    const char* text;
+    const char* textShort;
+    bool isMajor;
+    int transposeSteps;
+};
+
 // Strings used by Rapid Evolution when exporting detailed keys to file tags
-constexpr const char* s_scaleModeText[] = {
-       "ionian", // standard major
-        "aeolian", // natural minor
-        "lydian", // major with raised 4th
-        "mixolydian", // major with lowered 7th
-        "dorian", // minor with raised 6th
-        "phrygian", // minor with lowered 2nd
-        "locrian", //  minor with lowered 2nd and 7th
-};
-*/
-
-constexpr const char* s_scaleModeTextShort[] = {
-        "ion", // standard major
-        "aeo", // natural minor
-        "lyd", // major with raised 4th
-        "mix", // major with lowered 7th
-        "dor", // "dorina" or "doric" minor with raised 6th
-        "phr", // minor with lowered 2nd
-        "loc"  // minor with lowered 2nd and 7th
+constexpr ScaleModeInfo s_scaleModeInfo[] = {
+        {"ionian", "ion", true, 0},      // standard major
+        {"aeolian", "aeo", false, 0},    // natural minor
+        {"lydian", "lyd", true, -5},     // major with raised 4th
+        {"mixolydian", "mix", true, +5}, // major with lowered 7th
+        {"dorian", "dor", false, -5},    // minor with raised 6th
+        {"phrygian", "phr", false, +5},  // minor with lowered 2nd
+        {"locrian", "loc", false, -2},   //  minor with lowered 2nd and 7th
 };
 
-constexpr bool s_scaleModeIsMajor[] = {
-        true,  // ionian (standard major)
-        false, // aeolian (natural minor)
-        true,  // lydian
-        true,  // mixolydian
-        false, // dorian
-        false, // phrygian
-        false, // locrian
-};
-
-// s_scaleModeTransposeSteps is used to express the detailed modes
+// transposeSteps is used to express the detailed modes
 // as a compatible natural minor or standard major scale
 // The following table shows the relation for C major in the Circle of Fifths
 // "C ionian"     8B    C – D – E – F – G – A – B
@@ -192,15 +177,13 @@ constexpr bool s_scaleModeIsMajor[] = {
 // "A aeolian"    8A    A – B – C – D – E – F – G
 // "Bb"
 // "B locrian"    8C    B – C – D – E – F – G – A
-constexpr int s_scaleModeTransposeSteps[] = {
-        0,  // ionian to ionian
-        0,  // aeolian to aeolian
-        -5, // lydian to ionian
-        +5, // mixolydian to ionian
-        -5, // dorian to aeolian
-        +5, // phrygian to aeolian
-        -2, // locrian to aeolian
-};
+
+// We transpose according to isMajor:
+// lydian to ionian
+// mixolydian to ionian
+// dorian to aeolian
+// phrygian to aeolian
+// locrian to aeolian
 
 // Lancelot notation is OpenKey notation rotated counter-clockwise by 5.
 inline int openKeyNumberToLancelotNumber(const int okNumber)  {
@@ -395,17 +378,17 @@ ChromaticKey KeyUtils::guessKeyFromText(const QString& text) {
             } else {
                 // Try to find detailed scale mode
                 ScaleMode scaleMode = ScaleMode::Unknown;
-                for (size_t i = 0; i < std::size(s_scaleModeTextShort); ++i) {
-                    if (scale.startsWith(s_scaleModeTextShort[i], Qt::CaseInsensitive)) {
+                for (size_t i = 0; i < std::size(s_scaleModeInfo); ++i) {
+                    if (scale.startsWith(s_scaleModeInfo[i].textShort, Qt::CaseInsensitive)) {
                         scaleMode = static_cast<ScaleMode>(i);
+                        major = s_scaleModeInfo[i].isMajor;
+                        steps += s_scaleModeInfo[i].transposeSteps;
                         break;
                     }
                 }
                 if (scaleMode == ScaleMode::Unknown) {
                     return mixxx::track::io::key::INVALID;
                 }
-                major = s_scaleModeIsMajor[static_cast<int>(scaleMode)];
-                steps += s_scaleModeTransposeSteps[static_cast<int>(scaleMode)];
             }
         }
         ChromaticKey letterKey = static_cast<ChromaticKey>(

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -20,6 +20,7 @@ const QString s_openKeyPattern = QStringLiteral("^\\s*(1[0-2]|[1-9])([dm])\\s*$"
 // Lancelot notation, the numbers 1-12 followed by A (minor) or B(I) (major).
 // or "I", "L", "M", "D", "P", "C" for the advanced modes
 const QString s_lancelotKeyPattern = QStringLiteral("^\\s*0*(1[0-2]|[1-9])([ABILMDPC])\\s*$");
+constexpr std::string_view s_lancelotMajorModes = "BILM";
 
 // a-g followed by any number of sharps or flats, optionally followed by
 // a scale mode spec (m = minor, min, maj ..)
@@ -355,7 +356,7 @@ ChromaticKey KeyUtils::guessKeyFromText(const QString& text) {
         int openKeyNumber = lancelotNumberToOpenKeyNumber(lancelotNumber);
 
         const QChar lancelotScaleMode = lancelotKeyMatcher.cap(2).at(0);
-        bool major = (QString("BILM").indexOf(lancelotScaleMode) != -1);
+        bool major = (s_lancelotMajorModes.find(lancelotScaleMode.toLatin1()) != std::string::npos);
 
         return openKeyNumberToKey(openKeyNumber, major);
     }

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -270,7 +270,7 @@ ChromaticKey KeyUtils::guessKeyFromText(const QString& text) {
         }
     }
 
-    QRegExp openKeyMatcher(s_openKeyPattern, Qt::CaseInsensitive);
+    QRegExp openKeyMatcher(s_openKeyPattern);
     if (openKeyMatcher.exactMatch(trimmed)) {
         bool ok = false;
         int openKeyNumber = openKeyMatcher.cap(1).toInt(&ok);
@@ -280,13 +280,12 @@ ChromaticKey KeyUtils::guessKeyFromText(const QString& text) {
             return mixxx::track::io::key::INVALID;
         }
 
-        bool major = openKeyMatcher.cap(2)
-                .compare("d", Qt::CaseInsensitive) == 0;
+        bool major = openKeyMatcher.cap(2).compare("d") == 0;
 
         return openKeyNumberToKey(openKeyNumber, major);
     }
 
-    QRegExp lancelotKeyMatcher(s_lancelotKeyPattern, Qt::CaseInsensitive);
+    QRegExp lancelotKeyMatcher(s_lancelotKeyPattern);
     if (lancelotKeyMatcher.exactMatch(trimmed)) {
         bool ok = false;
         int lancelotNumber = lancelotKeyMatcher.cap(1).toInt(&ok);
@@ -298,8 +297,7 @@ ChromaticKey KeyUtils::guessKeyFromText(const QString& text) {
 
         int openKeyNumber = lancelotNumberToOpenKeyNumber(lancelotNumber);
 
-        bool major = lancelotKeyMatcher.cap(2)
-                .compare("b", Qt::CaseInsensitive) == 0;
+        bool major = lancelotKeyMatcher.cap(2).compare("B") == 0;
 
         return openKeyNumberToKey(openKeyNumber, major);
     }

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -145,6 +145,7 @@ constexpr int s_sortKeysCircleOfFifthsLancelot[] = {
 };
 
 struct ScaleModeInfo {
+    KeyUtils::ScaleMode mode;
     const char* text;
     const char* textShort;
     bool isMajor;
@@ -153,13 +154,41 @@ struct ScaleModeInfo {
 
 // Strings used by Rapid Evolution when exporting detailed keys to file tags
 constexpr ScaleModeInfo s_scaleModeInfo[] = {
-        {"ionian", "ion", true, 0},      // standard major
-        {"aeolian", "aeo", false, 0},    // natural minor
-        {"lydian", "lyd", true, -5},     // major with raised 4th
-        {"mixolydian", "mix", true, +5}, // major with lowered 7th
-        {"dorian", "dor", false, -5},    // minor with raised 6th
-        {"phrygian", "phr", false, +5},  // minor with lowered 2nd
-        {"locrian", "loc", false, -2},   //  minor with lowered 2nd and 7th
+        {KeyUtils::ScaleMode::Ionian, // standard major
+                "ionian",
+                "ion",
+                true,
+                0},
+        {KeyUtils::ScaleMode::Aeolian, // natural minor
+                "aeolian",
+                "aeo",
+                false,
+                0},
+        {KeyUtils::ScaleMode::Lydian, // major with raised 4th
+                "lydian",
+                "lyd",
+                true,
+                -5},
+        {KeyUtils::ScaleMode::Mixolydian, // major with lowered 7th
+                "mixolydian",
+                "mix",
+                true,
+                +5},
+        {KeyUtils::ScaleMode::Dorian, // minor with raised 6th
+                "dorian",
+                "dor",
+                false,
+                -5},
+        {KeyUtils::ScaleMode::Phrygian, // minor with lowered 2nd
+                "phrygian",
+                "phr",
+                false,
+                +5},
+        {KeyUtils::ScaleMode::Locrian, //  minor with lowered 2nd and 7th
+                "locrian",
+                "loc",
+                false,
+                -2},
 };
 
 // transposeSteps is used to express the detailed modes
@@ -380,7 +409,7 @@ ChromaticKey KeyUtils::guessKeyFromText(const QString& text) {
                 ScaleMode scaleMode = ScaleMode::Unknown;
                 for (size_t i = 0; i < std::size(s_scaleModeInfo); ++i) {
                     if (scale.startsWith(s_scaleModeInfo[i].textShort, Qt::CaseInsensitive)) {
-                        scaleMode = static_cast<ScaleMode>(i);
+                        scaleMode = s_scaleModeInfo[i].mode;
                         major = s_scaleModeInfo[i].isMajor;
                         steps += s_scaleModeInfo[i].transposeSteps;
                         break;

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -145,13 +145,13 @@ constexpr int s_sortKeysCircleOfFifthsLancelot[] = {
 /*
 // Strings used by Rapid Evolution when exporting detailed keys to file tags
 constexpr const char* s_scaleModeText[] = {
-    "ionian", // standard major
-	"aeolian", // natural minor
-	"lydian", // major with raised 4th
-	"mixolydian", // major with lowered 7th
-	"dorian", // minor with raised 6th
-	"phrygian", // minor with lowered 2nd
-	"locrian", //  minor with lowered 2nd and 7th
+       "ionian", // standard major
+        "aeolian", // natural minor
+        "lydian", // major with raised 4th
+        "mixolydian", // major with lowered 7th
+        "dorian", // minor with raised 6th
+        "phrygian", // minor with lowered 2nd
+        "locrian", //  minor with lowered 2nd and 7th
 };
 */
 

--- a/src/track/keyutils.h
+++ b/src/track/keyutils.h
@@ -22,6 +22,17 @@ class KeyUtils {
         NumKeyNotations = 7
     };
 
+    enum class ScaleMode {
+        Ionian = 0,     // standard major
+        Aeolian = 1,    // natural minor
+        Lydian = 2,     // major with raised 4th
+        Mixolydian = 3, // major with lowered 7th
+        Dorian = 4,     // minor with raised 6th
+        Phrygian = 5,   // minor with lowered 2nd
+        Locrian = 6,    // minor with lowered 2nd and 7th
+        Unknown = 7
+    };
+
     static QString keyDebugName(mixxx::track::io::key::ChromaticKey key);
 
     static inline bool keyIsMajor(mixxx::track::io::key::ChromaticKey key) {


### PR DESCRIPTION
This fixes https://github.com/mixxxdj/mixxx/issues/10995

It allows to read keys entries created by the Rapid evolution "detailed key mode" 
"Ab ionian" or "04I"

In Mixxx they are displayed as a compatible Minor/Major key. 