### PR TITLE
Pre commit python

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -26,7 +26,6 @@ ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8
 IndentCaseLabels: false
 DerivePointerAlignment: false
-ReflowComments: false
 SpaceAfterTemplateKeyword: false
 SpacesBeforeTrailingComments: 1
 # StatementMacros don't require a trailing semicolon.

--- a/.gitattributes
+++ b/.gitattributes
@@ -23,3 +23,6 @@
 
 # Treat serato test data as binary
 *.octet-stream binary
+
+# shell scripts will always have LF line endings on checkout.
+*.sh text eol=lf

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -58,6 +58,7 @@ jobs:
         run: |
           git diff-index -p HEAD > "${PATCH_FILE}"
           [ -s "${PATCH_FILE}" ] && echo "UPLOAD_PATCH_FILE=${PATCH_FILE}" >> "${GITHUB_ENV}"
+        shell: bash
         env:
           PATCH_FILE: pre-commit.patch
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -71,4 +71,5 @@ jobs:
 
       # AppStream metadata has been generated/updated by a pre-commit hook
       - name: "Validate AppStream metadata"
+        if: runner.os == 'Linux'
         run: appstreamcli validate res/linux/org.mixxx.Mixxx.metainfo.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,6 +80,8 @@ repos:
           - commit
           - manual
         language: python
+        additional_dependencies:
+          - clang-format==14.0.6
         files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|m|mm|proto|vert)$
   - repo: https://github.com/psf/black
     rev: 22.10.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,7 +89,7 @@ repos:
       - id: black
         files: ^tools/.*$
   - repo: https://gitlab.com/pycqa/flake8
-    rev: "3.9.2"
+    rev: "5.0.4"
     hooks:
       - id: flake8
         files: ^tools/.*$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,7 @@ repos:
       - id: clang-format
         name: clang-format
         description: "Run clang-format in two passes (reformat, then break long lines)"
-        entry: tools/clang_format.py
+        entry: python tools/clang_format.py
         require_serial: true
         stages:
           - commit
@@ -114,7 +114,7 @@ repos:
       - id: qsscheck
         name: qsscheck
         description: Run qsscheck to detect broken QSS.
-        entry: ./tools/qsscheck.py
+        entry: python tools/qsscheck.py
         args: [.]
         pass_filenames: false
         language: python
@@ -128,14 +128,14 @@ repos:
       - id: changelog
         name: changelog
         description: Add missing links to changelog.
-        entry: ./tools/changelog.py
+        entry: python tools/changelog.py
         language: python
         types: [text]
         files: ^CHANGELOG.md$
       - id: metainfo
         name: metainfo
         description: Update AppStream metainfo releases from CHANGELOG.md.
-        entry: ./tools/update_metainfo.py
+        entry: python tools/update_metainfo.py
         pass_filenames: false
         language: python
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -143,6 +143,6 @@ repos:
         additional_dependencies:
           - beautifulsoup4==4.11.1
           - lxml==4.9.1
-          - Markdown==3.3.4
+          - Markdown==3.4.1
         types: [text]
         files: ^(CHANGELOG\.md|res/linux/org\.mixxx\.Mixxx\.metainfo.xml)$

--- a/tools/githelper.py
+++ b/tools/githelper.py
@@ -21,7 +21,7 @@ def get_toplevel_path() -> str:
 
     cmd = ["git", "rev-parse", "--show-toplevel"]
     logger.debug("Executing: %r", cmd)
-    return subprocess.check_output(cmd, text=True).strip()
+    return os.path.normpath(subprocess.check_output(cmd, text=True).strip())
 
 
 def get_moved_files(

--- a/tools/update_metainfo.py
+++ b/tools/update_metainfo.py
@@ -188,7 +188,7 @@ def main(argv=None):
         .strip()
     )
 
-    with open(changelog_path, mode="r") as fp:
+    with open(changelog_path, mode="r", encoding="utf-8") as fp:
         for release in parse_changelog(
             fp.read(), development_release_date=parent_changelog_change_date
         ):


### PR DESCRIPTION
It turns out the "language: python" are working only by luck. 
A python hook requires a python entry. That ensures that the same python version is used and not another one found at the path.  

Our use case of starting a system script is covered by "language: system"

This also pins the clang-format version and gets around the clang-format not found issue.  