### PR TITLE
Do not create a new loop if it's the same as an existing loop

### DIFF
--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -16,6 +16,11 @@
 
 namespace {
 constexpr mixxx::audio::FrameDiff_t kMinimumAudibleLoopSizeFrames = 150;
+
+// returns true if a is valid and is fairly close to target (within +/- 1 frame).
+bool positionNear(mixxx::audio::FramePos a, mixxx::audio::FramePos target) {
+    return a.isValid() && a > target - 1 && a < target + 1;
+}
 }
 
 double LoopingControl::s_dBeatSizes[] = { 0.03125, 0.0625, 0.125, 0.25, 0.5,
@@ -626,7 +631,10 @@ void LoopingControl::setLoop(mixxx::audio::FramePos startPosition,
         slotLoopInGoto(1);
     }
 
+    // Don't allow loop size widget setting to trigger creation of another loop.
+    m_pCOBeatLoopSize->blockSignals(true);
     m_pCOBeatLoopSize->setAndConfirm(findBeatloopSizeForLoop(startPosition, endPosition));
+    m_pCOBeatLoopSize->blockSignals(false);
 }
 
 void LoopingControl::setLoopInToCurrentPosition() {
@@ -1197,10 +1205,6 @@ bool LoopingControl::currentLoopMatchesBeatloopSize(const LoopInfo& loopInfo) co
             loopInfo.startPosition, m_pCOBeatLoopSize->get());
 
     return positionNear(loopInfo.endPosition, loopEndPosition);
-}
-
-bool LoopingControl::positionNear(mixxx::audio::FramePos a, mixxx::audio::FramePos target) const {
-    return a.isValid() && a > target - 1 && a < target + 1;
 }
 
 double LoopingControl::findBeatloopSizeForLoop(

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -1400,9 +1400,9 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable
         return;
     }
 
-    // Only create a new loop if the start and end position have changed.
-    if (loopInfo.startPosition != newloopInfo.startPosition ||
-            loopInfo.endPosition != newloopInfo.endPosition) {
+    // Only update loopinfo if the endpoints have changed, otherwise we may clobber the existing
+    // LoopSeekMode selection.
+    if (!currentLoopMatchesBeatloopSize()) {
         // If resizing an inactive loop by changing beatloop_size,
         // do not seek to the adjusted loop.
         newloopInfo.seekMode = (keepStartPoint && (enable || m_bLoopingEnabled))
@@ -1410,10 +1410,10 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable
                 : LoopSeekMode::MovedOut;
 
         m_loopInfo.setValue(newloopInfo);
-        emit loopUpdated(newloopInfo.startPosition, newloopInfo.endPosition);
-        m_pCOLoopStartPosition->set(newloopInfo.startPosition.toEngineSamplePos());
-        m_pCOLoopEndPosition->set(newloopInfo.endPosition.toEngineSamplePos());
     }
+    emit loopUpdated(newloopInfo.startPosition, newloopInfo.endPosition);
+    m_pCOLoopStartPosition->set(newloopInfo.startPosition.toEngineSamplePos());
+    m_pCOLoopEndPosition->set(newloopInfo.endPosition.toEngineSamplePos());
 
     if (enable) {
         setLoopingEnabled(true);

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -1400,16 +1400,20 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable
         return;
     }
 
-    // If resizing an inactive loop by changing beatloop_size,
-    // do not seek to the adjusted loop.
-    newloopInfo.seekMode = (keepStartPoint && (enable || m_bLoopingEnabled))
-            ? LoopSeekMode::Changed
-            : LoopSeekMode::MovedOut;
+    // Only create a new loop if the start and end position have changed.
+    if (loopInfo.startPosition != newloopInfo.startPosition ||
+            loopInfo.endPosition != newloopInfo.endPosition) {
+        // If resizing an inactive loop by changing beatloop_size,
+        // do not seek to the adjusted loop.
+        newloopInfo.seekMode = (keepStartPoint && (enable || m_bLoopingEnabled))
+                ? LoopSeekMode::Changed
+                : LoopSeekMode::MovedOut;
 
-    m_loopInfo.setValue(newloopInfo);
-    emit loopUpdated(newloopInfo.startPosition, newloopInfo.endPosition);
-    m_pCOLoopStartPosition->set(newloopInfo.startPosition.toEngineSamplePos());
-    m_pCOLoopEndPosition->set(newloopInfo.endPosition.toEngineSamplePos());
+        m_loopInfo.setValue(newloopInfo);
+        emit loopUpdated(newloopInfo.startPosition, newloopInfo.endPosition);
+        m_pCOLoopStartPosition->set(newloopInfo.startPosition.toEngineSamplePos());
+        m_pCOLoopEndPosition->set(newloopInfo.endPosition.toEngineSamplePos());
+    }
 
     if (enable) {
         setLoopingEnabled(true);

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -1405,16 +1405,15 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable
         return;
     }
 
-    // Only update seek mode if the endpoints have changed sufficiently.
-    if (positionNear(newloopInfo.startPosition, loopInfo.startPosition) &&
-            positionNear(newloopInfo.endPosition, loopInfo.endPosition)) {
-        newloopInfo.seekMode = loopInfo.seekMode;
+    // If the start point has changed, or the loop is not enabled,
+    // or if the endpoints are nearly the same, do not seek forward into the adjusted loop.
+    if (!keepStartPoint ||
+            !(enable || m_bLoopingEnabled) ||
+            (positionNear(newloopInfo.startPosition, loopInfo.startPosition) &&
+                    positionNear(newloopInfo.endPosition, loopInfo.endPosition))) {
+        newloopInfo.seekMode = LoopSeekMode::MovedOut;
     } else {
-        // If resizing an inactive loop by changing beatloop_size,
-        // do not seek to the adjusted loop.
-        newloopInfo.seekMode = (keepStartPoint && (enable || m_bLoopingEnabled))
-                ? LoopSeekMode::Changed
-                : LoopSeekMode::MovedOut;
+        newloopInfo.seekMode = LoopSeekMode::Changed;
     }
     m_loopInfo.setValue(newloopInfo);
     emit loopUpdated(newloopInfo.startPosition, newloopInfo.endPosition);

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -121,7 +121,9 @@ class LoopingControl : public EngineControl {
     void setLoopOutToCurrentPosition();
     void clearActiveBeatLoop();
     void updateBeatLoopingControls();
-    bool currentLoopMatchesBeatloopSize();
+    bool currentLoopMatchesBeatloopSize(const LoopInfo& loopInfo) const;
+    // returns true if a is valid and is fairly close to target (within +/- 1 frame).
+    bool positionNear(mixxx::audio::FramePos a, mixxx::audio::FramePos target) const;
 
     // Given loop in and out points, determine if this is a beatloop of a particular
     // size.

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -122,8 +122,6 @@ class LoopingControl : public EngineControl {
     void clearActiveBeatLoop();
     void updateBeatLoopingControls();
     bool currentLoopMatchesBeatloopSize(const LoopInfo& loopInfo) const;
-    // returns true if a is valid and is fairly close to target (within +/- 1 frame).
-    bool positionNear(mixxx::audio::FramePos a, mixxx::audio::FramePos target) const;
 
     // Given loop in and out points, determine if this is a beatloop of a particular
     // size.


### PR DESCRIPTION
This works around https://github.com/mixxxdj/mixxx/issues/11003 in which the adjustment of the spinbox creates a new loop, causing a sudden unexpected seek