### PR TITLE
enable search in Browse & Recording views

### DIFF
--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -32,7 +32,7 @@ BrowseFeature::BrowseFeature(
         : LibraryFeature(pLibrary, pConfig, QString("computer")),
           m_pTrackCollection(pLibrary->trackCollectionManager()->internalCollection()),
           m_browseModel(this, pLibrary->trackCollectionManager(), pRecordingManager),
-          m_proxyModel(&m_browseModel),
+          m_proxyModel(&m_browseModel, true),
           m_pSidebarModel(new FolderTreeModel(this)),
           m_pLastRightClickedItem(nullptr) {
     connect(this,
@@ -267,7 +267,10 @@ void BrowseFeature::activateChild(const QModelIndex& index) {
         m_browseModel.setPath(std::move(dirAccess));
     }
     emit showTrackModel(&m_proxyModel);
-    emit disableSearch();
+    // Search is restored in Library::slotShowTrackModel, disable it where it's useless
+    if (path == QUICK_LINK_NODE || path == DEVICE_NODE) {
+        emit disableSearch();
+    }
     emit enableCoverArtDisplay(false);
 }
 

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -243,7 +243,7 @@ void BrowseFeature::activate() {
 void BrowseFeature::activateChild(const QModelIndex& index) {
     TreeItem *item = static_cast<TreeItem*>(index.internalPointer());
     qDebug() << "BrowseFeature::activateChild " << item->getLabel() << " "
-             << item->getData();
+             << item->getData().toString();
 
     QString path = item->getData().toString();
     if (path == QUICK_LINK_NODE || path == DEVICE_NODE) {

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -283,6 +283,7 @@ CoverInfo BrowseTableModel::getCoverInfo(const QModelIndex& index) const {
         return CoverInfo();
     }
 }
+
 const QVector<int> BrowseTableModel::getTrackRows(TrackId trackId) const {
     Q_UNUSED(trackId);
     // We can't implement this as it stands.

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -379,7 +379,8 @@ TrackModel::Capabilities BrowseTableModel::getCapabilities() const {
 }
 
 QString BrowseTableModel::modelKey(bool noSearch) const {
-    // Browse feature does currently not support searching.
+    // Searching is handled by the proxy model, so if there is an active search
+    // modelkey is composed there, too.
     Q_UNUSED(noSearch);
     return QStringLiteral("browse:") + m_currentDirectory;
 }

--- a/src/library/proxytrackmodel.cpp
+++ b/src/library/proxytrackmodel.cpp
@@ -152,7 +152,6 @@ bool ProxyTrackModel::filterAcceptsRow(int sourceRow,
             dynamic_cast<QAbstractItemModel*>(m_pTrackModel);
     bool rowMatches = false;
 
-    QRegularExpression filter = filterRegularExpression();
     QListIterator<int> iter(filterColumns);
 
     while (!rowMatches && iter.hasNext()) {
@@ -161,7 +160,7 @@ bool ProxyTrackModel::filterAcceptsRow(int sourceRow,
         QVariant data = itemModel->data(index);
         if (data.canConvert<QString>()) {
             QString strData = data.toString();
-            if (strData.contains(filter)) {
+            if (strData.contains(m_currentSearch, Qt::CaseInsensitive)) {
                 rowMatches = true;
             }
         }

--- a/src/library/proxytrackmodel.cpp
+++ b/src/library/proxytrackmodel.cpp
@@ -155,24 +155,22 @@ bool ProxyTrackModel::filterAcceptsRow(int sourceRow,
         return false;
     }
 
-    if (m_currentSearch.trimmed().isEmpty()) {
+    const QString currSearch = m_currentSearch.trimmed();
+    if (currSearch.isEmpty()) {
         return true;
     }
 
-    QStringList tokens = SearchQueryParser::splitQueryIntoWords(
-            m_currentSearch.trimmed());
+    QStringList tokens = SearchQueryParser::splitQueryIntoWords(currSearch);
     tokens.removeDuplicates();
 
     const QList<int>& filterColumns = m_pTrackModel->searchColumns();
     QAbstractItemModel* itemModel =
             dynamic_cast<QAbstractItemModel*>(m_pTrackModel);
 
-    for (QString token : tokens) {
-        QListIterator<int> iter(filterColumns);
+    for (const auto& token : std::as_const(tokens)) {
         bool tokenMatch = false;
-        while (iter.hasNext() && !tokenMatch) {
-            int i = iter.next();
-            QModelIndex index = itemModel->index(sourceRow, i, sourceParent);
+        for (const auto column : std::as_const(filterColumns)) {
+            QModelIndex index = itemModel->index(sourceRow, column, sourceParent);
             QString strData = itemModel->data(index).toString();
             if (!strData.isEmpty()) {
                 QString tokNoQuotes = token;
@@ -181,6 +179,9 @@ bool ProxyTrackModel::filterAcceptsRow(int sourceRow,
                     tokenMatch = true;
                     tokens.removeOne(token);
                 }
+            }
+            if (tokenMatch) {
+                break;
             }
         }
     }

--- a/src/library/proxytrackmodel.cpp
+++ b/src/library/proxytrackmodel.cpp
@@ -77,7 +77,14 @@ void ProxyTrackModel::search(const QString& searchText, const QString& extraFilt
 }
 
 QString ProxyTrackModel::modelKey(bool noSearch) const {
-    return m_pTrackModel ? m_pTrackModel->modelKey(noSearch) : QString();
+    if (m_pTrackModel) {
+        if (m_bHandleSearches) {
+            return m_pTrackModel->modelKey(true) + QStringLiteral("#") + currentSearch();
+        } else {
+            return m_pTrackModel->modelKey(noSearch);
+        }
+    }
+    return QString();
 }
 
 const QString ProxyTrackModel::currentSearch() const {

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -26,7 +26,7 @@ DlgRecording::DlgRecording(
                           parent->getTrackTableBackgroundColorOpacity(),
                           true)),
           m_browseModel(this, pLibrary->trackCollectionManager(), pRecordingManager),
-          m_proxyModel(&m_browseModel),
+          m_proxyModel(&m_browseModel, true),
           m_bytesRecordedStr("--"),
           m_durationRecordedStr("--:--"),
           m_pRecordingManager(pRecordingManager) {

--- a/src/library/recording/recordingfeature.cpp
+++ b/src/library/recording/recordingfeature.cpp
@@ -71,6 +71,6 @@ void RecordingFeature::bindLibraryWidget(WLibrary* pLibraryWidget,
 void RecordingFeature::activate() {
     emit refreshBrowseModel();
     emit switchToView(kViewName);
-    emit disableSearch();
+    emit requestRestoreSearch();
     emit enableCoverArtDisplay(false);
 }


### PR DESCRIPTION
This enables a ~~simple~~ case-insensitive text filter for the Browse & Recording view via their proxymodels.
**Edit** not so simple anymore since with the last commit the query is not treated as one string but is split into words, so it allows queries like `holy "blue cow"`.

All columns are considered, incl. invisible.
Query is saved per feature only (not for individual folders).

closes #11012