### PR TITLE
WCoverArtLabel: don't open full-size cover if no cover is loaded

### DIFF
--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -92,7 +92,7 @@ void WCoverArtLabel::mousePressEvent(QMouseEvent* event) {
     if (event->button() == Qt::LeftButton) {
         if (m_pDlgFullSize->isVisible()) {
             m_pDlgFullSize->close();
-        } else {
+        } else if (!m_loadedCover.isNull()) {
             m_pDlgFullSize->init(m_pLoadedTrack);
         }
     }


### PR DESCRIPTION
quick fix for #11021 