### PR TITLE
WSearchLineEdit: push completion to top

### DIFF
--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -495,27 +495,18 @@ void WSearchLineEdit::slotSaveSearch() {
     if (cText.isEmpty() || !isEnabled()) {
         return;
     }
-    if (cIndex == -1) {
-        removeItem(-1);
-    }
 
-    // Check if the text is already listed
-    QSet<QString> querySet;
-    for (int index = 0; index < count(); index++) {
-        querySet.insert(itemText(index));
-    }
-    if (querySet.contains(cText)) {
-        // If query exists clear the box and use its index to set the currentIndex
-        int cIndex = findData(cText, Qt::DisplayRole);
-        setCurrentIndex(cIndex);
-        return;
-    } else {
-        // Else add it at the top
+    if (cIndex == -1) {
+        // If the query doesn't exist yet add it at the top
         insertItem(0, cText);
         setCurrentIndex(0);
-        while (count() > kMaxSearchEntries) {
-            removeItem(kMaxSearchEntries);
-        }
+    } else {
+        // If query exists clear the box and use its index to set the currentIndex
+        setCurrentIndex(cIndex);
+    }
+
+    while (count() > kMaxSearchEntries) {
+        removeItem(kMaxSearchEntries);
     }
 }
 

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -496,14 +496,15 @@ void WSearchLineEdit::slotSaveSearch() {
         return;
     }
 
-    if (cIndex == -1) {
-        // If the query doesn't exist yet add it at the top
-        insertItem(0, cText);
-        setCurrentIndex(0);
-    } else {
-        // If query exists clear the box and use its index to set the currentIndex
-        setCurrentIndex(cIndex);
+    if (cIndex > 0) {
+        // If query exists and is not at the top, remove the original index
+        removeItem(cIndex);
     }
+    if (cIndex > 0 || cIndex == -1) {
+        // If the query doesn't exist yet or was not at top, insert it at the top
+        insertItem(0, cText);
+    }
+    setCurrentIndex(0);
 
     while (count() > kMaxSearchEntries) {
         removeItem(kMaxSearchEntries);


### PR DESCRIPTION
The first comit is a simplification, the second one is worth discussing.
Personally I find it very confusing that recalling query would move the selection somewhere down the list, which basically throws me back into the past and makes me lose orientation in terms of most recent queries, see https://github.com/mixxxdj/mixxx/issues/10975