### PR TITLE
Effect parameter: briefly show value in parameter name widget

### DIFF
--- a/src/effects/effectparameterslotbase.cpp
+++ b/src/effects/effectparameterslotbase.cpp
@@ -71,5 +71,6 @@ void EffectParameterSlotBase::onEffectMetaParameterChanged(double parameter, boo
 void EffectParameterSlotBase::slotValueChanged(double v) {
     if (m_pEffectParameter) {
         m_pEffectParameter->setValue(v);
+        emit valueChanged(v);
     }
 }

--- a/src/effects/effectparameterslotbase.h
+++ b/src/effects/effectparameterslotbase.h
@@ -55,6 +55,7 @@ class EffectParameterSlotBase : public QObject {
   signals:
     // Signal that indicates that the EffectParameterSlotBase has been updated.
     void updated();
+    void valueChanged(double v);
 
   public slots:
     // Solely for handling control changes

--- a/src/widget/weffectparameternamebase.cpp
+++ b/src/widget/weffectparameternamebase.cpp
@@ -9,13 +9,22 @@
 
 namespace {
 const QString kMimeTextDelimiter = QStringLiteral("\n");
+// for rounding the value display to 2 decimals
+constexpr int kValDecimals = 100;
 } // anonymous namespace
 
 WEffectParameterNameBase::WEffectParameterNameBase(
         QWidget* pParent, EffectsManager* pEffectsManager)
-        : WLabel(pParent), m_pEffectsManager(pEffectsManager) {
+        : WLabel(pParent),
+          m_pEffectsManager(pEffectsManager),
+          m_text("") {
     setAcceptDrops(true);
     parameterUpdated();
+    // When the parameter value changed it is display briefly.
+    // Set up the timer that restores the parameter name.
+    m_displayNameResetTimer.setSingleShot(true);
+    m_displayNameResetTimer.setInterval(800);
+    m_displayNameResetTimer.callOnTimeout(this, [this]() { setText(m_text); });
 }
 
 void WEffectParameterNameBase::setEffectParameterSlot(
@@ -33,17 +42,33 @@ void WEffectParameterNameBase::setEffectParameterSlot(
 void WEffectParameterNameBase::parameterUpdated() {
     if (m_pParameterSlot) {
         if (!m_pParameterSlot->shortName().isEmpty()) {
-            setText(m_pParameterSlot->shortName());
+            m_text = m_pParameterSlot->shortName();
         } else {
-            setText(m_pParameterSlot->name());
+            m_text = m_pParameterSlot->name();
         }
         setBaseTooltip(QString("%1\n%2").arg(
                 m_pParameterSlot->name(),
                 m_pParameterSlot->description()));
+        // Make connection to show parameter value instead of name briefly
+        // after value has changed.
+        if (m_pParameterSlot->parameterType() == EffectParameterType::Knob) {
+            connect(m_pParameterSlot.data(),
+                    &EffectParameterSlotBase::valueChanged,
+                    this,
+                    &WEffectParameterNameBase::showNewValue);
+        }
     } else {
-        setText(kNoEffectString);
+        m_text = kNoEffectString;
         setBaseTooltip(tr("No effect loaded."));
     }
+    setText(m_text);
+}
+
+void WEffectParameterNameBase::showNewValue(double newValue) {
+    double newValRounded =
+            std::ceil(newValue * kValDecimals) / kValDecimals;
+    setText(QString::number(newValRounded));
+    m_displayNameResetTimer.start();
 }
 
 void WEffectParameterNameBase::mousePressEvent(QMouseEvent* event) {

--- a/src/widget/weffectparameternamebase.h
+++ b/src/widget/weffectparameternamebase.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QDomNode>
+#include <QTimer>
 
 #include "effects/effectparameterslotbase.h"
 #include "skin/legacy/skincontext.h"
@@ -21,6 +22,7 @@ class WEffectParameterNameBase : public WLabel {
 
   protected slots:
     void parameterUpdated();
+    void showNewValue(double v);
 
   protected:
     void setEffectParameterSlot(EffectParameterSlotBasePointer pEffectKnobParameterSlot);
@@ -31,4 +33,6 @@ class WEffectParameterNameBase : public WLabel {
 
   private:
     const QString mimeTextIdentifier() const;
+    QString m_text;
+    QTimer m_displayNameResetTimer;
 };


### PR DESCRIPTION
Use the parameter name label to show the parameter value for .8 seconds after it changed.
Rounded to two decimals fo now. Maybe rounding can be made dependent on the actual range.
![image](https://user-images.githubusercontent.com/5934199/199455591-5cc6b1f6-6325-401a-a2b0-0937d802af81.png)

closes #9022
