### PR TITLE
Sync Lock: End of track checking is not needed

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1382,12 +1382,6 @@ void EngineBuffer::updateIndicators(double speed, int iBufferSize) {
         speed = 0;
     }
 
-    // Report fractional playpos to SyncControl.
-    // TODO(rryan) It's kind of hacky that this is in updateIndicators but it
-    // prevents us from computing fFractionalPlaypos multiple times per
-    // EngineBuffer::process().
-    m_pSyncControl->reportTrackPosition(fFractionalPlaypos);
-
     // Update indicators that are only updated after every
     // sampleRate/kiUpdateRate samples processed.  (e.g. playposSlider)
     if (m_iSamplesSinceLastIndicatorUpdate >

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -360,14 +360,6 @@ void SyncControl::updateInstantaneousBpm(mixxx::Bpm bpm) {
     m_pBpmControl->updateInstantaneousBpm(bpmValue);
 }
 
-void SyncControl::reportTrackPosition(double fractionalPlaypos) {
-    // If we're close to the end, and leader, disable leader so we don't stop
-    // the party.
-    if (isLeader(getSyncMode()) && fractionalPlaypos >= 1.0) {
-        m_pChannel->getEngineBuffer()->requestSyncMode(SyncMode::Follower);
-    }
-}
-
 // called from an engine worker thread
 void SyncControl::trackLoaded(TrackPointer pNewTrack) {
     mixxx::BeatsPointer pBeats;

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -75,7 +75,6 @@ class SyncControl : public EngineControl, public Syncable {
 
     void setEngineControls(RateControl* pRateControl, BpmControl* pBpmControl);
 
-    void reportTrackPosition(double fractionalPlaypos);
     void reportPlayerSpeed(double speed, bool scratching);
     void trackLoaded(TrackPointer pNewTrack) override;
     void trackBeatsUpdated(mixxx::BeatsPointer pBeats) override;


### PR DESCRIPTION
It's not necessary to unset leader status at the end of the track based on the playposition heck.  It will change automatically anyway.