### PR TITLE
show effect parameter units in parameter name label

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2738,8 +2738,8 @@ endif()
 find_package(lilv)
 default_option(LILV "Lilv (LV2) support" "lilv_FOUND")
 if(LILV)
-  if(NOT TARGET lilv::lilv)
-    message(FATAL_ERROR "Lilv (LV2) support requires the liblilv-0 and its development headers.")
+  if(NOT lilv_FOUND)
+    message(FATAL_ERROR "Lilv (LV2) support requires the liblilv-0 and LV2 libraries and development headers.")
   endif()
   target_sources(mixxx-lib PRIVATE
     src/effects/backends/lv2/lv2backend.cpp

--- a/cmake/modules/Findlilv.cmake
+++ b/cmake/modules/Findlilv.cmake
@@ -7,7 +7,7 @@
 Findlilv
 --------
 
-Finds the lilv library.
+Finds the lilv library and lv2-dev package containing 'units' headers.
 
 Imported Targets
 ^^^^^^^^^^^^^^^^
@@ -37,7 +37,7 @@ Cache Variables
 The following cache variables may also be set:
 
 ``lilv_INCLUDE_DIR``
-  The directory containing ``lilv-0/lilb/lilv.h``.
+  The directory containing ``lilv-0/lilv/lilv.h``.
 ``lilv_LIBRARY``
   The path to the lilv library.
 
@@ -47,7 +47,7 @@ include(IsStaticLibrary)
 
 find_package(PkgConfig QUIET)
 if(PkgConfig_FOUND)
-  pkg_check_modules(PC_lilv QUIET lilv-0)
+  pkg_check_modules(PC_lilv QUIET lilv-0 lv2)
 endif()
 
 find_path(lilv_INCLUDE_DIR

--- a/src/effects/backends/builtin/balanceeffect.cpp
+++ b/src/effects/backends/builtin/balanceeffect.cpp
@@ -57,7 +57,7 @@ EffectManifestPointer BalanceEffect::getManifest() {
     midLowPass->setDescription(QObject::tr(
             "Frequencies below this cutoff are not adjusted in the stereo field"));
     midLowPass->setValueScaler(EffectManifestParameter::ValueScaler::Logarithmic);
-    midLowPass->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    midLowPass->setUnitsHint(EffectManifestParameter::UnitsHint::Hertz);
     midLowPass->setDefaultLinkType(EffectManifestParameter::LinkType::None);
     midLowPass->setNeutralPointOnScale(1);
     midLowPass->setRange(kMinCornerHz, kMinCornerHz, kMaxCornerHz);

--- a/src/effects/backends/builtin/flangereffect.cpp
+++ b/src/effects/backends/builtin/flangereffect.cpp
@@ -50,7 +50,7 @@ EffectManifestPointer FlangerEffect::getManifest() {
     width->setDescription(QObject::tr(
             "Delay amplitude of the LFO (low frequency oscillator)"));
     width->setValueScaler(EffectManifestParameter::ValueScaler::Logarithmic);
-    width->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    width->setUnitsHint(EffectManifestParameter::UnitsHint::Millisecond);
     width->setRange(0.0, kMaxLfoWidthMs / 2, kMaxLfoWidthMs);
 
     EffectManifestParameterPointer manual = pManifest->addParameter();
@@ -61,7 +61,7 @@ EffectManifestPointer FlangerEffect::getManifest() {
             "Delay offset of the LFO (low frequency oscillator).\n"
             "With width at zero, this allows for manually sweeping over the entire delay range."));
     manual->setValueScaler(EffectManifestParameter::ValueScaler::Logarithmic);
-    manual->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    manual->setUnitsHint(EffectManifestParameter::UnitsHint::Millisecond);
     manual->setRange(kMinDelayMs, kCenterDelayMs, kMaxDelayMs);
 
     EffectManifestParameterPointer regen = pManifest->addParameter();

--- a/src/effects/backends/builtin/parametriceqeffect.cpp
+++ b/src/effects/backends/builtin/parametriceqeffect.cpp
@@ -34,7 +34,7 @@ EffectManifestPointer ParametricEQEffect::getManifest() {
     gain1->setDescription(QObject::tr(
             "Gain for Filter 1"));
     gain1->setValueScaler(EffectManifestParameter::ValueScaler::Linear);
-    gain1->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    gain1->setUnitsHint(EffectManifestParameter::UnitsHint::Decibel);
     gain1->setNeutralPointOnScale(0.5);
     gain1->setRange(-18, 0, 18); // dB
 
@@ -69,7 +69,7 @@ EffectManifestPointer ParametricEQEffect::getManifest() {
     gain2->setDescription(QObject::tr(
             "Gain for Filter 2"));
     gain2->setValueScaler(EffectManifestParameter::ValueScaler::Linear);
-    gain2->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    gain2->setUnitsHint(EffectManifestParameter::UnitsHint::Decibel);
     gain2->setNeutralPointOnScale(0.5);
     gain2->setRange(-18, 0, 18); // dB
 

--- a/src/effects/backends/effectmanifestparameter.h
+++ b/src/effects/backends/effectmanifestparameter.h
@@ -67,60 +67,41 @@ class EffectManifestParameter {
         Time, // units?
     };
 
-    static UnitsHint lv2UnitToUnitsHint(const QString& lv2Unit) {
-        // Add custom LV2 units here (with correct case) and also
-        // in unitsHintToString()
-        if (lv2Unit == QLatin1String("bar")) {
-            return UnitsHint::Bar;
-        } else if (lv2Unit == QLatin1String("beat")) {
-            return UnitsHint::Beat;
-        } else if (lv2Unit == QLatin1String("bpm")) {
-            return UnitsHint::BPM;
-        } else if (lv2Unit == QLatin1String("cent")) {
-            return UnitsHint::Cent;
-        } else if (lv2Unit == QLatin1String("cm")) {
-            return UnitsHint::Centimetre;
-        } else if (lv2Unit == QLatin1String("coef")) {
-            return UnitsHint::Coefficient;
-        } else if (lv2Unit == QLatin1String("db")) {
-            return UnitsHint::Decibel;
-        } else if (lv2Unit == QLatin1String("degree")) {
-            return UnitsHint::Degree;
-        } else if (lv2Unit == QLatin1String("frame")) {
-            return UnitsHint::Frame;
-        } else if (lv2Unit == QLatin1String("hz")) {
-            return UnitsHint::Hertz;
-        } else if (lv2Unit == QLatin1String("inch")) {
-            return UnitsHint::Inch;
-        } else if (lv2Unit == QLatin1String("khz")) {
-            return UnitsHint::KiloHertz;
-        } else if (lv2Unit == QLatin1String("km")) {
-            return UnitsHint::Kilometer;
-        } else if (lv2Unit == QLatin1String("m")) {
-            return UnitsHint::Meter;
-        } else if (lv2Unit == QLatin1String("mhz")) {
-            return UnitsHint::MegaHertz;
-        } else if (lv2Unit == QLatin1String("midiNote")) {
-            return UnitsHint::Midinote;
-        } else if (lv2Unit == QLatin1String("mile")) {
-            return UnitsHint::Mile;
-        } else if (lv2Unit == QLatin1String("min")) {
-            return UnitsHint::Minute;
-        } else if (lv2Unit == QLatin1String("mm")) {
-            return UnitsHint::Millmeter;
-        } else if (lv2Unit == QLatin1String("ms")) {
-            return UnitsHint::Millisecond;
-        } else if (lv2Unit == QLatin1String("oct")) {
-            return UnitsHint::Octave;
-        } else if (lv2Unit == QLatin1String("pc")) {
-            return UnitsHint::Percentage;
-        } else if (lv2Unit == QLatin1String("s")) {
-            return UnitsHint::Seconds;
-        } else if (lv2Unit == QLatin1String("semitone12TET")) {
-            return UnitsHint::Semitone12tet;
-        } else {
+    const QHash<QString, UnitsHint> lv2UnitToUnitsHintHash{
+            // Add custom LV2 units here (with correct case) and also
+            // in unitsHintStringHash()
+            {QString("bar"), UnitsHint::Bar},
+            {QString("beat"), UnitsHint::Beat},
+            {QString("bpm"), UnitsHint::BPM},
+            {QString("cent"), UnitsHint::Cent},
+            {QString("cm"), UnitsHint::Centimetre},
+            {QString("coef"), UnitsHint::Coefficient},
+            {QString("db"), UnitsHint::Decibel},
+            {QString("degree"), UnitsHint::Degree},
+            {QString("frame"), UnitsHint::Frame},
+            {QString("hz"), UnitsHint::Hertz},
+            {QString("inch"), UnitsHint::Inch},
+            {QString("khz"), UnitsHint::KiloHertz},
+            {QString("km"), UnitsHint::Kilometer},
+            {QString("m"), UnitsHint::Meter},
+            {QString("mhz"), UnitsHint::MegaHertz},
+            {QString("midiNote"), UnitsHint::Midinote},
+            {QString("mile"), UnitsHint::Mile},
+            {QString("min"), UnitsHint::Minute},
+            {QString("mm"), UnitsHint::Millmeter},
+            {QString("ms"), UnitsHint::Millisecond},
+            {QString("oct"), UnitsHint::Octave},
+            {QString("pc"), UnitsHint::Percentage},
+            {QString("s"), UnitsHint::Seconds},
+            {QString("semitone12TET"), UnitsHint::Semitone12tet}};
+
+    UnitsHint lv2UnitToUnitsHint(const QString& lv2) {
+        QHash<QString, UnitsHint>::const_iterator uHintIt =
+                lv2UnitToUnitsHintHash.find(lv2);
+        if (uHintIt == lv2UnitToUnitsHintHash.constEnd()) {
             return UnitsHint::Unknown;
         }
+        return uHintIt.value();
     }
 
     const QHash<UnitsHint, QString> unitsHintStringHash{

--- a/src/effects/backends/effectmanifestparameter.h
+++ b/src/effects/backends/effectmanifestparameter.h
@@ -121,6 +121,60 @@ class EffectManifestParameter {
         }
     }
 
+    static QString unitsHintToString(const UnitsHint unitsHint) {
+        switch (unitsHint) {
+        case UnitsHint::BPM:
+            return QStringLiteral("BPM");
+        case UnitsHint::Cent:
+            return QStringLiteral("ct");
+        case UnitsHint::Centimetre:
+            return QStringLiteral("cm");
+        case UnitsHint::Decibel:
+            return QStringLiteral("dB");
+        case UnitsHint::Degree:
+            return QStringLiteral("°");
+        case UnitsHint::Frame:
+            return QStringLiteral("f");
+        case UnitsHint::Hertz:
+            return QStringLiteral("Hz");
+        case UnitsHint::Inch:
+            return QStringLiteral("in");
+        case UnitsHint::KiloHertz:
+            return QStringLiteral("kHz");
+        case UnitsHint::Kilometer:
+            return QStringLiteral("km");
+        case UnitsHint::Meter:
+            return QStringLiteral("m");
+        case UnitsHint::MegaHertz:
+            return QStringLiteral("MHz");
+        case UnitsHint::Mile:
+            return QStringLiteral("mi");
+        case UnitsHint::Minute:
+            return QStringLiteral("min");
+        case UnitsHint::Millmeter:
+            return QStringLiteral("mm");
+        case UnitsHint::Millisecond:
+            return QStringLiteral("ms");
+        case UnitsHint::Octave:
+            return QStringLiteral("oct");
+        case UnitsHint::Percentage:
+            return QStringLiteral("%");
+        case UnitsHint::Seconds:
+            return QStringLiteral("s");
+        case UnitsHint::Semitone12tet:
+            return QStringLiteral("semi");
+        case UnitsHint::Unknown:
+        case UnitsHint::Beat:
+        case UnitsHint::Beats:
+        case UnitsHint::Bar:
+        case UnitsHint::Coefficient:
+        case UnitsHint::Midinote:
+        case UnitsHint::SampleRate:
+        default:
+            return QLatin1String("");
+        }
+    }
+
     enum class LinkType : int {
         /// Not controlled by the meta knob
         None = 0,
@@ -244,6 +298,9 @@ class EffectManifestParameter {
 
     UnitsHint unitsHint() const {
         return m_unitsHint;
+    }
+    const QString unitString() const {
+        return unitsHintToString(m_unitsHint);
     }
     void setUnitsHint(UnitsHint unitsHint) {
         m_unitsHint = unitsHint;

--- a/src/effects/backends/effectmanifestparameter.h
+++ b/src/effects/backends/effectmanifestparameter.h
@@ -36,12 +36,35 @@ class EffectManifestParameter {
 
     enum class UnitsHint : int {
         Unknown = 0,
-        Time,
-        Hertz,
-        /// Fraction of the Sample Rate
-        SampleRate,
         /// Multiples of a Beat
         Beats,
+        Beat,
+        Bar,
+        BPM,
+        Cent,
+        Centimetre,
+        Coefficient,
+        Decibel,
+        Degree,
+        Frame,
+        Hertz,
+        Inch,
+        KiloHertz,
+        Kilometer,
+        Meter,
+        MegaHertz,
+        Midinote,
+        Mile,
+        Minute,
+        Millmeter,
+        Millisecond,
+        Octave,
+        Percentage,
+        /// Fraction of the Sample Rate
+        SampleRate,
+        Seconds,
+        Semitone12tet,
+        Time, // units?
     };
 
     enum class LinkType : int {

--- a/src/effects/backends/effectmanifestparameter.h
+++ b/src/effects/backends/effectmanifestparameter.h
@@ -67,6 +67,60 @@ class EffectManifestParameter {
         Time, // units?
     };
 
+    static UnitsHint lv2UnitToUnitsHint(const QString& lv2Unit) {
+        if (lv2Unit == QLatin1String("bar")) {
+            return UnitsHint::Bar;
+        } else if (lv2Unit == QLatin1String("beat")) {
+            return UnitsHint::Beat;
+        } else if (lv2Unit == QLatin1String("bpm")) {
+            return UnitsHint::BPM;
+        } else if (lv2Unit == QLatin1String("cent")) {
+            return UnitsHint::Cent;
+        } else if (lv2Unit == QLatin1String("cm")) {
+            return UnitsHint::Centimetre;
+        } else if (lv2Unit == QLatin1String("coef")) {
+            return UnitsHint::Coefficient;
+        } else if (lv2Unit == QLatin1String("db")) {
+            return UnitsHint::Decibel;
+        } else if (lv2Unit == QLatin1String("degree")) {
+            return UnitsHint::Degree;
+        } else if (lv2Unit == QLatin1String("frame")) {
+            return UnitsHint::Frame;
+        } else if (lv2Unit == QLatin1String("hz")) {
+            return UnitsHint::Hertz;
+        } else if (lv2Unit == QLatin1String("inch")) {
+            return UnitsHint::Inch;
+        } else if (lv2Unit == QLatin1String("khz")) {
+            return UnitsHint::KiloHertz;
+        } else if (lv2Unit == QLatin1String("km")) {
+            return UnitsHint::Kilometer;
+        } else if (lv2Unit == QLatin1String("m")) {
+            return UnitsHint::Meter;
+        } else if (lv2Unit == QLatin1String("mhz")) {
+            return UnitsHint::MegaHertz;
+        } else if (lv2Unit == QLatin1String("midiNote")) {
+            return UnitsHint::Midinote;
+        } else if (lv2Unit == QLatin1String("mile")) {
+            return UnitsHint::Mile;
+        } else if (lv2Unit == QLatin1String("min")) {
+            return UnitsHint::Minute;
+        } else if (lv2Unit == QLatin1String("mm")) {
+            return UnitsHint::Millmeter;
+        } else if (lv2Unit == QLatin1String("ms")) {
+            return UnitsHint::Millisecond;
+        } else if (lv2Unit == QLatin1String("oct")) {
+            return UnitsHint::Octave;
+        } else if (lv2Unit == QLatin1String("pc")) {
+            return UnitsHint::Percentage;
+        } else if (lv2Unit == QLatin1String("s")) {
+            return UnitsHint::Seconds;
+        } else if (lv2Unit == QLatin1String("semitone12TET")) {
+            return UnitsHint::Semitone12tet;
+        } else {
+            return UnitsHint::Unknown;
+        }
+    }
+
     enum class LinkType : int {
         /// Not controlled by the meta knob
         None = 0,

--- a/src/effects/backends/effectmanifestparameter.h
+++ b/src/effects/backends/effectmanifestparameter.h
@@ -68,6 +68,8 @@ class EffectManifestParameter {
     };
 
     static UnitsHint lv2UnitToUnitsHint(const QString& lv2Unit) {
+        // Add custom LV2 units here (with correct case) and also
+        // in unitsHintToString()
         if (lv2Unit == QLatin1String("bar")) {
             return UnitsHint::Bar;
         } else if (lv2Unit == QLatin1String("beat")) {
@@ -173,6 +175,17 @@ class EffectManifestParameter {
         default:
             return QLatin1String("");
         }
+    }
+
+    // Custom units we do not want to use in effect widgets
+    QSet<QString> customUnitsBlacklist = {
+            "(coef)",
+            "G",
+            "samp",
+            "st"};
+
+    bool ignoreCustomUnit(const QString& unit) {
+        return customUnitsBlacklist.contains(unit);
     }
 
     enum class LinkType : int {

--- a/src/effects/backends/effectmanifestparameter.h
+++ b/src/effects/backends/effectmanifestparameter.h
@@ -123,59 +123,28 @@ class EffectManifestParameter {
         }
     }
 
-    static QString unitsHintToString(const UnitsHint unitsHint) {
-        switch (unitsHint) {
-        case UnitsHint::BPM:
-            return QStringLiteral("BPM");
-        case UnitsHint::Cent:
-            return QStringLiteral("ct");
-        case UnitsHint::Centimetre:
-            return QStringLiteral("cm");
-        case UnitsHint::Decibel:
-            return QStringLiteral("dB");
-        case UnitsHint::Degree:
-            return QStringLiteral("°");
-        case UnitsHint::Frame:
-            return QStringLiteral("f");
-        case UnitsHint::Hertz:
-            return QStringLiteral("Hz");
-        case UnitsHint::Inch:
-            return QStringLiteral("in");
-        case UnitsHint::KiloHertz:
-            return QStringLiteral("kHz");
-        case UnitsHint::Kilometer:
-            return QStringLiteral("km");
-        case UnitsHint::Meter:
-            return QStringLiteral("m");
-        case UnitsHint::MegaHertz:
-            return QStringLiteral("MHz");
-        case UnitsHint::Mile:
-            return QStringLiteral("mi");
-        case UnitsHint::Minute:
-            return QStringLiteral("min");
-        case UnitsHint::Millmeter:
-            return QStringLiteral("mm");
-        case UnitsHint::Millisecond:
-            return QStringLiteral("ms");
-        case UnitsHint::Octave:
-            return QStringLiteral("oct");
-        case UnitsHint::Percentage:
-            return QStringLiteral("%");
-        case UnitsHint::Seconds:
-            return QStringLiteral("s");
-        case UnitsHint::Semitone12tet:
-            return QStringLiteral("semi");
-        case UnitsHint::Unknown:
-        case UnitsHint::Beat:
-        case UnitsHint::Beats:
-        case UnitsHint::Bar:
-        case UnitsHint::Coefficient:
-        case UnitsHint::Midinote:
-        case UnitsHint::SampleRate:
-        default:
-            return QLatin1String("");
-        }
-    }
+    const QHash<UnitsHint, QString> unitsHintStringHash{
+            {UnitsHint::BPM, QString("BPM")},
+            {UnitsHint::Cent, QString("ct")},
+            {UnitsHint::Centimetre, QString("cm")},
+            {UnitsHint::Decibel, QString("dB")},
+            {UnitsHint::Degree, QString("°")},
+            {UnitsHint::Frame, QString("f")},
+            {UnitsHint::Hertz, QString("Hz")},
+            {UnitsHint::Inch, QString("in")},
+            {UnitsHint::KiloHertz, QString("kHz")},
+            {UnitsHint::Kilometer, QString("km")},
+            {UnitsHint::Meter, QString("m")},
+            {UnitsHint::MegaHertz, QString("MHz")},
+            {UnitsHint::Mile, QString("mi")},
+            {UnitsHint::Minute, QString("min")},
+            {UnitsHint::Millmeter, QString("mm")},
+            {UnitsHint::Millisecond, QString("ms")},
+            {UnitsHint::Octave, QString("oct")},
+            {UnitsHint::Percentage, QString("%")},
+            {UnitsHint::Seconds, QString("s")},
+            {UnitsHint::Semitone12tet, QString("semi")},
+    };
 
     // Custom units we do not want to use in effect widgets
     QSet<QString> customUnitsBlacklist = {
@@ -312,11 +281,12 @@ class EffectManifestParameter {
     UnitsHint unitsHint() const {
         return m_unitsHint;
     }
-    const QString unitString() const {
-        return unitsHintToString(m_unitsHint);
-    }
     void setUnitsHint(UnitsHint unitsHint) {
         m_unitsHint = unitsHint;
+        m_unitString = EffectManifestParameter::unitsHintStringHash.value(unitsHint);
+    }
+    const QString unitString() const {
+        return m_unitString;
     }
 
     LinkType defaultLinkType() const {
@@ -405,6 +375,7 @@ class EffectManifestParameter {
     ParameterType m_parameterType;
     ValueScaler m_valueScaler;
     UnitsHint m_unitsHint;
+    QString m_unitString;
     LinkType m_defaultLinkType;
     LinkInversion m_defaultLinkInversion;
     double m_neutralPointOnScale;
@@ -427,4 +398,10 @@ typedef EffectManifestParameter::ParameterType EffectParameterType;
 
 inline qhash_seed_t qHash(const EffectParameterType& parameterType) {
     return static_cast<qhash_seed_t>(parameterType);
+}
+
+typedef EffectManifestParameter::UnitsHint UnitsHint;
+
+inline qhash_seed_t qHash(const UnitsHint& uhint) {
+    return static_cast<qhash_seed_t>(uhint);
 }

--- a/src/effects/backends/lv2/lv2backend.cpp
+++ b/src/effects/backends/lv2/lv2backend.cpp
@@ -1,5 +1,7 @@
 #include "effects/backends/lv2/lv2backend.h"
 
+#include <lv2/units/units.h>
+
 #include "effects/backends/lv2/lv2effectprocessor.h"
 #include "effects/backends/lv2/lv2manifest.h"
 
@@ -39,6 +41,8 @@ void LV2Backend::initializeProperties() {
     m_properties["button_port"] = lilv_new_uri(m_pWorld, LV2_CORE__toggled);
     m_properties["integer_port"] = lilv_new_uri(m_pWorld, LV2_CORE__integer);
     m_properties["enumeration_port"] = lilv_new_uri(m_pWorld, LV2_CORE__enumeration);
+    m_properties["unit"] = lilv_new_uri(m_pWorld, LV2_UNITS__unit);
+    m_properties["unit_prefix"] = lilv_new_uri(m_pWorld, LV2_UNITS_PREFIX);
 }
 
 const QList<QString> LV2Backend::getEffectIds() const {

--- a/src/effects/backends/lv2/lv2backend.cpp
+++ b/src/effects/backends/lv2/lv2backend.cpp
@@ -27,7 +27,7 @@ void LV2Backend::enumeratePlugins() {
         if (lilv_plugin_is_replaced(plug)) {
             continue;
         }
-        auto lv2Manifest = LV2EffectManifestPointer::create(plug, m_properties);
+        auto lv2Manifest = LV2EffectManifestPointer::create(m_pWorld, plug, m_properties);
         lv2Manifest->setBackendType(getType());
         m_registeredEffects.insert(lv2Manifest->id(), lv2Manifest);
     }
@@ -43,6 +43,7 @@ void LV2Backend::initializeProperties() {
     m_properties["enumeration_port"] = lilv_new_uri(m_pWorld, LV2_CORE__enumeration);
     m_properties["unit"] = lilv_new_uri(m_pWorld, LV2_UNITS__unit);
     m_properties["unit_prefix"] = lilv_new_uri(m_pWorld, LV2_UNITS_PREFIX);
+    m_properties["unit_symbol"] = lilv_new_uri(m_pWorld, LV2_UNITS__symbol);
 }
 
 const QList<QString> LV2Backend::getEffectIds() const {

--- a/src/effects/backends/lv2/lv2manifest.cpp
+++ b/src/effects/backends/lv2/lv2manifest.cpp
@@ -83,7 +83,7 @@ LV2Manifest::LV2Manifest(LilvWorld* world,
                     QString unitStr = lilv_node_as_uri(unit);
                     // that starts with the 'units' prefix, isolate the identifier
                     if (unitStr.startsWith(lilv_node_as_string(properties["unit_prefix"]))) {
-                        unitsHint = EffectManifestParameter::lv2UnitToUnitsHint(
+                        unitsHint = param->lv2UnitToUnitsHint(
                                 unitStr.remove(lilv_node_as_string(properties["unit_prefix"])));
                     }
                 } else { // Try to extract the custom unit symbol string
@@ -93,7 +93,7 @@ LV2Manifest::LV2Manifest(LilvWorld* world,
                         // Accepted custom units needs to be 'whitelisted' in
                         // EffectManifestParameter::lv2UnitToUnitsHint and added to
                         // EffectManifestParameter::unitsHintStringHash
-                        unitsHint = EffectManifestParameter::lv2UnitToUnitsHint(
+                        unitsHint = param->lv2UnitToUnitsHint(
                                 lilv_node_as_string(customUnit));
                         if (lv2ParamDebug &&
                                 unitsHint == EffectManifestParameter::UnitsHint::Unknown &&

--- a/src/effects/backends/lv2/lv2manifest.cpp
+++ b/src/effects/backends/lv2/lv2manifest.cpp
@@ -92,7 +92,7 @@ LV2Manifest::LV2Manifest(LilvWorld* world,
                     if (customUnit) {
                         // Accepted custom units needs to be 'whitelisted' in
                         // EffectManifestParameter::lv2UnitToUnitsHint and added to
-                        // EffectManifestParameter::unitsHintToString
+                        // EffectManifestParameter::unitsHintStringHash
                         unitsHint = EffectManifestParameter::lv2UnitToUnitsHint(
                                 lilv_node_as_string(customUnit));
                         if (lv2ParamDebug &&

--- a/src/effects/backends/lv2/lv2manifest.cpp
+++ b/src/effects/backends/lv2/lv2manifest.cpp
@@ -66,13 +66,11 @@ LV2Manifest::LV2Manifest(LilvWorld* world,
 
             // Get and set the parameter name
             info = lilv_port_get_name(m_pLV2plugin, port);
-            QString paramName = lilv_node_as_string(info);
-            param->setName(paramName);
+            param->setName(lilv_node_as_string(info));
             lilv_node_free(info);
 
             const LilvNode* node = lilv_port_get_symbol(m_pLV2plugin, port);
-            QString symbol = lilv_node_as_string(node);
-            param->setId(symbol);
+            param->setId(lilv_node_as_string(node));
             // node must not be freed here, it is owned by port
 
             EffectManifestParameter::UnitsHint unitsHint =
@@ -120,13 +118,7 @@ LV2Manifest::LV2Manifest(LilvWorld* world,
             }
             param->setRange(m_minimum[i], m_default[i], m_maximum[i]);
 
-            // Set the appropriate Hints
-            if (lilv_port_has_property(m_pLV2plugin, port, properties["button_port"])) {
-                param->setValueScaler(EffectManifestParameter::ValueScaler::Toggle);
-            } else if (lilv_port_has_property(m_pLV2plugin, port, properties["enumeration_port"])) {
-                buildEnumerationOptions(port, param);
-                param->setValueScaler(EffectManifestParameter::ValueScaler::Toggle);
-            } else if (lilv_port_has_property(m_pLV2plugin, port, properties["integer_port"])) {
+            if (lilv_port_has_property(m_pLV2plugin, port, properties["integer_port"])) {
                 param->setValueScaler(EffectManifestParameter::ValueScaler::Integral);
             } else {
                 param->setValueScaler(EffectManifestParameter::ValueScaler::Linear);
@@ -146,13 +138,11 @@ LV2Manifest::LV2Manifest(LilvWorld* world,
 
             // Get and set the parameter name
             info = lilv_port_get_name(m_pLV2plugin, port);
-            QString paramName = lilv_node_as_string(info);
-            param->setName(paramName);
+            param->setName(lilv_node_as_string(info));
             lilv_node_free(info);
 
             const LilvNode* node = lilv_port_get_symbol(m_pLV2plugin, port);
-            QString symbol = lilv_node_as_string(node);
-            param->setId(symbol);
+            param->setId(lilv_node_as_string(node));
             // info must not be freed here, it is owned by port
 
             param->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
@@ -225,9 +215,8 @@ void LV2Manifest::buildEnumerationOptions(const LilvPort* port,
         const LilvScalePoint* option = lilv_scale_points_get(options, iterator);
         const LilvNode* description = lilv_scale_point_get_label(option);
         const LilvNode* value = lilv_scale_point_get_value(option);
-        QString strDescription(lilv_node_as_string(description));
 
-        param->appendStep(qMakePair(strDescription,
+        param->appendStep(qMakePair(QString(lilv_node_as_string(description)),
                 static_cast<double>(lilv_node_as_float(value))));
     }
 

--- a/src/effects/backends/lv2/lv2manifest.h
+++ b/src/effects/backends/lv2/lv2manifest.h
@@ -17,7 +17,7 @@ class LV2Manifest : public EffectManifest {
         HAS_REQUIRED_FEATURES
     };
 
-    LV2Manifest(const LilvPlugin* plug, QHash<QString, LilvNode*>& properties);
+    LV2Manifest(LilvWorld* world, const LilvPlugin* plug, QHash<QString, LilvNode*>& properties);
 
     QList<int> getAudioPortIndices();
     QList<int> getControlPortIndices();

--- a/src/widget/weffectparameternamebase.cpp
+++ b/src/widget/weffectparameternamebase.cpp
@@ -9,8 +9,6 @@
 
 namespace {
 const QString kMimeTextDelimiter = QStringLiteral("\n");
-// for rounding the value display to 2 decimals
-constexpr int kValDecimals = 100;
 } // anonymous namespace
 
 WEffectParameterNameBase::WEffectParameterNameBase(
@@ -78,14 +76,19 @@ void WEffectParameterNameBase::showNewValue(double newValue) {
         m_parameterUpdated = false;
         return;
     }
-    // TODO(ronso0) Trim decimals if value string is longer than X digits to
-    // prevent labels to expand.
-    double newValRounded =
-            std::ceil(newValue * kValDecimals) / kValDecimals;
+    int absVal = abs(static_cast<int>(round(newValue)));
+    int tenPowDecimals = 1; // omit decimals
+    if (absVal < 100) {     // 0-99: round to 2 decimals
+        tenPowDecimals = 100;
+    } else if (absVal < 1000) { // 100-999: round to 1 decimal
+        tenPowDecimals = 10;
+    }
+    double dispVal = round(newValue * tenPowDecimals) / tenPowDecimals;
+
     if (m_unitString.isEmpty()) {
-        setText(QString::number(newValRounded));
+        setText(QString::number(dispVal));
     } else {
-        setText(QString::number(newValRounded) + QChar(' ') + m_unitString);
+        setText(QString::number(dispVal) + QChar(' ') + m_unitString);
     }
     m_displayNameResetTimer.start();
 }

--- a/src/widget/weffectparameternamebase.h
+++ b/src/widget/weffectparameternamebase.h
@@ -33,6 +33,8 @@ class WEffectParameterNameBase : public WLabel {
 
   private:
     const QString mimeTextIdentifier() const;
+    QString m_unitString;
     QString m_text;
     QTimer m_displayNameResetTimer;
+    bool m_parameterUpdated;
 };

--- a/tools/debian_buildenv.sh
+++ b/tools/debian_buildenv.sh
@@ -80,6 +80,7 @@ case "$1" in
             libupower-glib-dev \
             libusb-1.0-0-dev \
             libwavpack-dev \
+            lv2-dev \
             markdown \
             portaudio19-dev \
             protobuf-compiler \


### PR DESCRIPTION
Follow-up for #11032 

- [x] adopt LV2 units http://lv2plug.in/ns/extensions/units 
- [x] get parameter units from LV2 plugins and translate them to enum `EffectManifestParameter::UnitsHint`
Note: custom unit constructors are ignored.
- [x] blacklist known, undesired custom LV2 units, log unknown units (to either include or ignore them)
- [x] translate `EffectManifestParameter::UnitsHint` to display strings
- [x] show units in parameter name label
- [x] trim parameter value decimals to avoid unnecessary widget expansion
- [x] add UnitsHint to built-in effects

Nice to have:
- [x] scale / convert units depending on range, for example convert `Hz` > 10.000 to `kHz`?

![image](https://user-images.githubusercontent.com/5934199/200125244-84945a06-e664-41e0-b38f-f013bc3dfeb8.png)
