### PR TITLE
DlgPrefSound: fix setting keylock engine from combobox

### DIFF
--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -88,8 +88,7 @@ class EngineBuffer : public EngineObject {
     constexpr static std::initializer_list<KeylockEngine> kKeylockEngines = {
             KeylockEngine::SoundTouch,
             KeylockEngine::RubberBandFaster,
-            KeylockEngine::RubberBandFiner,
-    };
+            KeylockEngine::RubberBandFiner};
 
     EngineBuffer(const QString& group, UserSettingsPointer pConfig,
                  EngineChannel* pChannel, EngineMaster* pMixingEngine);

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -312,9 +312,11 @@ void DlgPrefSound::slotApply() {
     SoundDeviceStatus status = SoundDeviceStatus::Ok;
     {
         ScopedWaitCursor cursor;
-        m_pKeylockEngine->set(keylockComboBox->currentData().toDouble());
+        const auto keylockEngine =
+                keylockComboBox->currentData().value<EngineBuffer::KeylockEngine>();
+        m_pKeylockEngine->set(static_cast<double>(keylockEngine));
         m_pSettings->set(ConfigKey("[Master]", "keylock_engine"),
-                ConfigValue(keylockComboBox->currentData().toInt()));
+                ConfigValue(static_cast<int>(keylockEngine)));
 
         status = m_pSoundManager->setConfig(m_config);
     }


### PR DESCRIPTION
previously the new engine wasn't applied due to wrong type conversion :grimacing: 