### PR TITLE
Fix building with portmidi 2.0.4

### DIFF
--- a/src/test/portmidicontroller_test.cpp
+++ b/src/test/portmidicontroller_test.cpp
@@ -64,14 +64,17 @@ class PortMidiControllerTest : public MixxxTest {
     PortMidiControllerTest()
             : m_mockInput(new MockPortMidiDevice(&m_inputDeviceInfo, 0)),
               m_mockOutput(new MockPortMidiDevice(&m_outputDeviceInfo, 0)) {
-        m_inputDeviceInfo.name = "Test Input Device";
-        m_inputDeviceInfo.interf = "Test";
+        char inputDeviceName[] = "Test Input Device";
+        char outputDeviceName[] = "Test Output Device";
+        char interf[] = "Test";
+        m_inputDeviceInfo.name = inputDeviceName;
+        m_inputDeviceInfo.interf = interf;
         m_inputDeviceInfo.input = 1;
         m_inputDeviceInfo.output = 0;
         m_inputDeviceInfo.opened = 0;
 
-        m_outputDeviceInfo.name = "Test Output Device";
-        m_outputDeviceInfo.interf = "Test";
+        m_outputDeviceInfo.name = outputDeviceName;
+        m_outputDeviceInfo.interf = interf;
         m_outputDeviceInfo.input = 0;
         m_outputDeviceInfo.output = 1;
         m_outputDeviceInfo.opened = 0;

--- a/src/test/portmidicontroller_test.cpp
+++ b/src/test/portmidicontroller_test.cpp
@@ -64,9 +64,11 @@ class PortMidiControllerTest : public MixxxTest {
     PortMidiControllerTest()
             : m_mockInput(new MockPortMidiDevice(&m_inputDeviceInfo, 0)),
               m_mockOutput(new MockPortMidiDevice(&m_outputDeviceInfo, 0)) {
+        // PmDeviceInfo::name is non const since portmidi 2.0.1
+        // We maintain the memory here in place of Pm_GetDeviceInfo()
         char inputDeviceName[] = "Test Input Device";
         char outputDeviceName[] = "Test Output Device";
-        char interf[] = "Test";
+        constexpr const char interf[] = "Test";
         m_inputDeviceInfo.name = inputDeviceName;
         m_inputDeviceInfo.interf = interf;
         m_inputDeviceInfo.input = 1;


### PR DESCRIPTION
This fixes building with portmidi 2.0.4. and allows us to advance to our new vcpkg environment. 

This change might be unsafe and is probably an design flaw in PortMidi itself. I have filed an upstream bug: 
https://github.com/PortMidi/portmidi/issues/41
