### PR TITLE
WVUMeterGL: fix initial rendering of meters invisble after skin load

### DIFF
--- a/src/widget/wvumetergl.h
+++ b/src/widget/wvumetergl.h
@@ -38,8 +38,9 @@ class WVuMeterGL : public QGLWidget, public WBaseWidget {
     void showEvent(QShowEvent* /*unused*/) override;
     void setPeak(double parameter);
 
-    // To make sure we render at least once even when we have no signal
-    bool m_bHasRendered;
+    // To make sure we render at least N times even when we have no signal,
+    // for example after showEvent()
+    int m_iPendingRenders;
     // To indicate that we rendered so we need to swap
     bool m_bSwapNeeded;
     // Current parameter and peak parameter.


### PR DESCRIPTION
Fixes the initial painting issue with VU meters that are not shown visible after skin loaded.
For example, start LateNight with compact decks, the toggle the mixer: VU meters are black.

@m0dB Please take a look. 2 rendering passes fix it for _me_, though I'm not sure if this approach is "correct"