### PR TITLE
DlgPrefEffects: restore list selection only if FocusIn reason is keyboard

### DIFF
--- a/src/preferences/dialog/dlgprefeffects.cpp
+++ b/src/preferences/dialog/dlgprefeffects.cpp
@@ -313,8 +313,8 @@ bool DlgPrefEffects::eventFilter(QObject* object, QEvent* event) {
         // * clear selection in adjacent view
         // * restore previous selection (select first item if none was selected)
         //   which updates the info box via 'currentRowChanged' signals
-        auto pChainList = dynamic_cast<QListView*>(object);
-        auto pEffectList = dynamic_cast<QTableView*>(object);
+        auto pChainList = qobject_cast<QListView*>(object);
+        auto pEffectList = qobject_cast<QTableView*>(object);
         // Restore previous selection only if focus was changed with keyboard.
         // For mouse clicks, that procedure would select the wrong index.
         QFocusEvent* focEv = static_cast<QFocusEvent*>(event);


### PR DESCRIPTION
restoring the selection while using the keyboard works fine, though mouse clicks sent to unfocused lists that
* had an item selected  previously and
* were scrolled afterwards without being focused

would select the wrong index.
___
Test main:
* go to Pref > Effects, choose chain or visible tab and
* make sure the scrollbars popup in one of the lists (decrease window height if list is too short)
* click topmost item in scrollable list
* click any item in adjacent list = selection in scrollable list is cleared
* scroll down scrollable list (don't click)
* select any item in that list
= wrong item is selected