### PR TITLE
don't use deprecated QNetworkReply::error when compiling against Qt 5.15

### DIFF
--- a/src/test/mock_networkaccessmanager.cpp
+++ b/src/test/mock_networkaccessmanager.cpp
@@ -107,7 +107,11 @@ void MockNetworkReply::SetData(const QByteArray& data) {
 void MockNetworkReply::abort() {
     setAttribute(QNetworkRequest::HttpStatusCodeAttribute, {});
     setError(OperationCanceledError, tr("Operation canceled"));
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
     emit error(OperationCanceledError);
+#else
+    emit errorOccurred(OperationCanceledError);
+#endif
     emit finished();
 }
 


### PR DESCRIPTION
This will fix the build failure with main CI after merging 2.3 with this fix to main.  