### PR TITLE
Effect parameter knobs: implement ValueScaler::Integral, snap value to int

### DIFF
--- a/src/control/controlbehavior.h
+++ b/src/control/controlbehavior.h
@@ -158,3 +158,17 @@ class ControlPushButtonBehavior : public ControlNumericBehavior {
     int m_iNumStates;
     QScopedPointer<QTimer> m_pushTimer;
 };
+
+class ControlLinSteppedIntPotBehavior : public ControlPotmeterBehavior {
+  public:
+    ControlLinSteppedIntPotBehavior(
+            double dMinValue, double dMaxValue, bool allowOutOfBounds);
+
+    double valueToParameter(double dValue) override;
+    double parameterToValue(double dParam) override;
+
+  protected:
+    double m_lastSnappedParam;
+    double m_dist;
+    double m_oldVal;
+};

--- a/src/control/controleffectknob.cpp
+++ b/src/control/controleffectknob.cpp
@@ -42,5 +42,8 @@ void ControlEffectKnob::setBehaviour(EffectManifestParameter::ValueScaler type,
     } else if (type == EffectManifestParameter::ValueScaler::LogarithmicInverse) {
         m_pControl->setBehavior(
                 new ControlLogInvPotmeterBehavior(dMinValue, dMaxValue, -40));
+    } else if (type == EffectManifestParameter::ValueScaler::Integral) {
+        m_pControl->setBehavior(new ControlLinSteppedIntPotBehavior(
+                dMinValue, dMaxValue, false));
     }
 }

--- a/src/effects/backends/builtin/phasereffect.cpp
+++ b/src/effects/backends/builtin/phasereffect.cpp
@@ -63,9 +63,9 @@ EffectManifestPointer PhaserEffect::getManifest() {
     stages->setShortName(QObject::tr("Stages"));
     stages->setDescription(QObject::tr(
             "Number of stages")); // stages of what?
-    stages->setValueScaler(EffectManifestParameter::ValueScaler::Linear);
+    stages->setValueScaler(EffectManifestParameter::ValueScaler::Integral);
     stages->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
-    stages->setRange(1.0, 3.5, 6.0);
+    stages->setRange(1.0, 7.0, 12.0);
 
     EffectManifestParameterPointer depth = pManifest->addParameter();
     depth->setId("depth");
@@ -153,7 +153,7 @@ void PhaserEffect::processChannel(
 
     const auto feedback = static_cast<CSAMPLE>(m_pFeedbackParameter->value());
     const auto range = static_cast<CSAMPLE>(m_pRangeParameter->value());
-    const auto stages = static_cast<int>(2 * m_pStagesParameter->value());
+    const auto stages = static_cast<int>(m_pStagesParameter->value());
 
     CSAMPLE* oldInLeft = pState->oldInLeft;
     CSAMPLE* oldOutLeft = pState->oldOutLeft;

--- a/src/effects/backends/effectmanifestparameter.h
+++ b/src/effects/backends/effectmanifestparameter.h
@@ -26,9 +26,11 @@ class EffectManifestParameter {
         LinearInverse,
         Logarithmic,
         LogarithmicInverse,
+        /// A step rotary with integer steps arranged with equal distance on scale
+        Integral,
         /// A step rotary, steps given by m_steps are arranged with equal
         /// distance on scale
-        Integral,
+        // Stepped,
         /// For button and enum controls, not accessible from many controllers,
         /// no linking to meta knob
         Toggle,


### PR DESCRIPTION
If the effect manifest sets `ValueScaler::Integral` for a parameter knob, the resulting values snap to integers.
This adds a new ControlBehaviour type `ControlLinSteppedPotBehavior`.
Parameter changes are accumulated, and as soon as the new value would snap to the next int it's adopted.

Currently only helpful for LV2 plugin parameters, for example `# Stages` knob of LV2 Calf Phaser.

