### PR TITLE
libshout-idjc: fix missing function declaration

### DIFF
--- a/lib/libshout-idjc/src/common/httpp/encoding.c
+++ b/lib/libshout-idjc/src/common/httpp/encoding.c
@@ -28,6 +28,9 @@
 
 #include <sys/types.h>
 #include <string.h>
+#ifndef _MSC_VER
+#include <strings.h>
+#endif
 #include <stdlib.h>
 #include <stdio.h>
 

--- a/lib/libshout-idjc/src/common/httpp/httpp.c
+++ b/lib/libshout-idjc/src/common/httpp/httpp.c
@@ -33,6 +33,9 @@
 
 #include <stdlib.h>
 #include <string.h>
+#ifndef _MSC_VER
+#include <strings.h>
+#endif
 #include <ctype.h>
 
 #include <avl/avl.h>

--- a/lib/libshout-idjc/src/proto_http.c
+++ b/lib/libshout-idjc/src/proto_http.c
@@ -28,6 +28,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef _MSC_VER
+#include <strings.h>
+#endif
 
 #include <shoutidjc/shout.h>
 #include "shout_private.h"

--- a/lib/libshout-idjc/src/shout.c
+++ b/lib/libshout-idjc/src/shout.c
@@ -29,6 +29,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef _MSC_VER
+#include <strings.h>
+#endif
 #include <errno.h>
 
 #include <shoutidjc/shout.h>


### PR DESCRIPTION
usage of str[n]casecmp requires including <strings.h> 
not doing so leads to a implicit-function-declaration warning, which becomes a hard error with gcc14 and clang16