### PR TITLE
Knob: hide cursor on wheel event for .8s

### DIFF
--- a/src/widget/knobeventhandler.h
+++ b/src/widget/knobeventhandler.h
@@ -1,11 +1,12 @@
 #pragma once
 
-#include <QMouseEvent>
-#include <QWheelEvent>
 #include <QColor>
 #include <QCursor>
-#include <QPoint>
+#include <QMouseEvent>
 #include <QPixmap>
+#include <QPoint>
+#include <QTimer>
+#include <QWheelEvent>
 
 #include "util/math.h"
 
@@ -17,6 +18,8 @@ class KnobEventHandler {
             QPixmap blankPixmap(32, 32);
             blankPixmap.fill(QColor(0, 0, 0, 0));
             m_blankCursor = QCursor(blankPixmap);
+            m_wheelCursorTimer.setSingleShot(true);
+            m_wheelCursorTimer.setInterval(800);
     }
 
     double valueFromMouseEvent(T* pWidget, QMouseEvent* e) {
@@ -103,6 +106,7 @@ class KnobEventHandler {
     }
 
     void wheelEvent(T* pWidget, QWheelEvent* e) {
+        pWidget->setCursor(m_blankCursor);
         // For legacy (MIDI) reasons this is tuned to 127.
         double wheelDirection = e->angleDelta().y() / (120.0 * 127.0);
         double newValue = pWidget->getControlParameter() + wheelDirection;
@@ -113,6 +117,13 @@ class KnobEventHandler {
         pWidget->setControlParameter(newValue);
         pWidget->inputActivity();
         e->accept();
+        m_wheelCursorTimer.start();
+        m_wheelCursorTimer.callOnTimeout(
+                [pWidget]() {
+                    if (pWidget) {
+                        pWidget->unsetCursor();
+                    }
+                });
     }
 
   private:
@@ -123,4 +134,5 @@ class KnobEventHandler {
     QPoint m_startPos;
     QPoint m_prevPos;
     QCursor m_blankCursor;
+    QTimer m_wheelCursorTimer;
 };

--- a/src/widget/knobeventhandler.h
+++ b/src/widget/knobeventhandler.h
@@ -126,6 +126,14 @@ class KnobEventHandler {
                 });
     }
 
+    void leaveEvent(T* pWidget, QEvent* e) {
+        if (m_wheelCursorTimer.isActive()) {
+            m_wheelCursorTimer.stop();
+            pWidget->unsetCursor();
+        }
+        e->accept();
+    }
+
   private:
     // True if right mouse button is pressed.
     bool m_bRightButtonPressed;

--- a/src/widget/knobeventhandler.h
+++ b/src/widget/knobeventhandler.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <QColor>
 #include <QCursor>
 #include <QMouseEvent>
 #include <QPixmap>
@@ -22,7 +21,7 @@ class KnobEventHandler {
             : m_bRightButtonPressed(false),
               m_pWheelCursorTimer(nullptr) {
         QPixmap blankPixmap(32, 32);
-        blankPixmap.fill(QColor(0, 0, 0, 0));
+        blankPixmap.fill(Qt::transparent);
         m_blankCursor = QCursor(blankPixmap);
     }
 

--- a/src/widget/wknob.cpp
+++ b/src/widget/wknob.cpp
@@ -38,6 +38,10 @@ void WKnob::wheelEvent(QWheelEvent* e) {
     m_handler.wheelEvent(this, e);
 }
 
+void WKnob::leaveEvent(QEvent* e) {
+    m_handler.leaveEvent(this, e);
+}
+
 void WKnob::inputActivity() {
 #ifdef __APPLE__
     m_renderTimer.activity();

--- a/src/widget/wknob.h
+++ b/src/widget/wknob.h
@@ -21,6 +21,7 @@ class WKnob : public WDisplay {
 
   protected:
     void wheelEvent(QWheelEvent *e) override;
+    void leaveEvent(QEvent* e) override;
     void mouseMoveEvent(QMouseEvent *e) override;
     void mousePressEvent(QMouseEvent *e) override;
     void mouseDoubleClickEvent(QMouseEvent* e) override;

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -227,6 +227,10 @@ void WKnobComposed::wheelEvent(QWheelEvent* e) {
     m_handler.wheelEvent(this, e);
 }
 
+void WKnobComposed::leaveEvent(QEvent* e) {
+    m_handler.leaveEvent(this, e);
+}
+
 void WKnobComposed::inputActivity() {
 #ifdef __APPLE__
     m_renderTimer.activity();

--- a/src/widget/wknobcomposed.h
+++ b/src/widget/wknobcomposed.h
@@ -28,6 +28,7 @@ class WKnobComposed : public WWidget {
 
   protected:
     void wheelEvent(QWheelEvent *e) override;
+    void leaveEvent(QEvent* e) override;
     void mouseMoveEvent(QMouseEvent *e) override;
     void mousePressEvent(QMouseEvent *e) override;
     void mouseDoubleClickEvent(QMouseEvent* e) override;


### PR DESCRIPTION
While working on #11041 I got bothered by the mouse pointer covering the effect parameter value when using the mouse wheel to turn the knob.

This hides the pointer like for mouse move (drag) events. Atm it's useful only for effect parameter knobs, but for consistency it's applied to all knobs.
Timeout is .8 seconds, the same time the parameter value is shown