### PR TITLE
Precommit qmlformat crash fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -141,9 +141,9 @@ repos:
         files: ^CHANGELOG.md$
       - id: qmlformat
         name: qmlformat
-        entry: tools/qmlformat.py
+        entry: python tools/qmlformat.py
         pass_filenames: true
-        language: system
+        language: python
         types: [text]
         files: ^.*\.qml$
       - id: qmllint

--- a/tools/qmlformat.py
+++ b/tools/qmlformat.py
@@ -28,6 +28,7 @@ def find_qt_version():
 
 
 def main(argv=None):
+    qmlformat_executable = None
     # First look up at the most common location for QT6 which is
     # usually not in PATH
     if sys.platform != "win32":


### PR DESCRIPTION
This fixes two crashes if qmlformat precommit hook runs on Windows.
But it doesn't fix the detection of the qt directory. It always returns with 0, because qt is not found (it seems to expect a executable moc in the search PATH, instead of following the buildenv path).