### PR TITLE
CMake: don't lookup keyfinder if KEYFINDER=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1861,10 +1861,10 @@ target_include_directories(mixxx-lib SYSTEM PUBLIC lib/fidlib)
 target_link_libraries(mixxx-lib PRIVATE fidlib)
 
 # KeyFinder
-set(LIBKEYFINDER_VERSION 2.2.6)
-find_package(KeyFinder ${LIBKEYFINDER_VERSION})
 option(KEYFINDER "KeyFinder support" ON)
 if(KEYFINDER)
+  set(LIBKEYFINDER_VERSION 2.2.6)
+  find_package(KeyFinder ${LIBKEYFINDER_VERSION})
   if (KeyFinder_FOUND)
     target_link_libraries(mixxx-lib PRIVATE KeyFinder::KeyFinder)
   else()


### PR DESCRIPTION
This has been discussed here:
https://mixxx.zulipchat.com/#narrow/stream/247620-development-help/topic/compiling.20mixxx.20on.20openbsd.20-current