### PR TITLE
Wrap selection around at the bottom/top of the library's tracks list

### DIFF
--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -635,12 +635,14 @@ void LibraryControl::slotMoveVertical(double v) {
         return;
     }
     case FocusWidget::TracksTable: {
-        // This wraps around at top/bottom. Doesn't match Up/Down key behaviour
-        // and may not be desired.
-        //int i = static_cast<int>(v);
-        //slotSelectTrack(i);
-        //return;
-        break;
+        // This wraps around at the top/bottom of the tracks list. Doesn't match
+        // Up/Down key behaviour, but it greatly improves the ergonomics of
+        // navigating a list of tracks sorted by key from a controller.
+        // Otherwise moving from 12/C#m/E to 1/G#m/B requires either a serious
+        // workout or reaching for the mouse/keyboard.
+        const auto i = static_cast<int>(v);
+        slotSelectTrack(i);
+        return;
     }
     case FocusWidget::Dialog: {
         // For navigating dialogs map up/down to Tab/BackTab

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -635,14 +635,12 @@ void LibraryControl::slotMoveVertical(double v) {
         return;
     }
     case FocusWidget::TracksTable: {
-        // This wraps around at the top/bottom of the tracks list. Doesn't match
-        // Up/Down key behaviour, but it greatly improves the ergonomics of
-        // navigating a list of tracks sorted by key from a controller.
-        // Otherwise moving from 12/C#m/E to 1/G#m/B requires either a serious
-        // workout or reaching for the mouse/keyboard.
-        const auto i = static_cast<int>(v);
-        slotSelectTrack(i);
-        return;
+        // `WLibraryTableView`'s cursor movement function has been overridden to
+        // wrap the selection around at the top/bottom of the tracks list. This
+        // behavior is thus shared between `[Library],MoveVertical` and Up/Down
+        // cursor key presses. See `WLibraryTableView::moveCursor()` for an
+        // explanation on why this is useful.
+        break;
     }
     case FocusWidget::Dialog: {
         // For navigating dialogs map up/down to Tab/BackTab

--- a/src/widget/wlibrarytableview.cpp
+++ b/src/widget/wlibrarytableview.cpp
@@ -275,17 +275,35 @@ QModelIndex WLibraryTableView::moveCursor(CursorAction cursorAction,
                     cursorAction == QAbstractItemView::MoveDown)) {
         // This is very similar to `moveSelection()`, except that it doesn't
         // actually modify the selection
-        const int row = currentIndex().row();
-        const int column = currentIndex().column();
-        if (cursorAction == QAbstractItemView::MoveDown) {
-            if (row + 1 < pModel->rowCount()) {
-                return pModel->index(row + 1, column);
+        const QModelIndex current = currentIndex();
+        if (current.isValid()) {
+            const int row = currentIndex().row();
+            const int column = currentIndex().column();
+            if (cursorAction == QAbstractItemView::MoveDown) {
+                if (row + 1 < pModel->rowCount()) {
+                    return pModel->index(row + 1, column);
+                } else {
+                    return pModel->index(0, column);
+                }
             } else {
-                return pModel->index(0, column);
+                if (row - 1 >= 0) {
+                    return pModel->index(row - 1, column);
+                } else {
+                    return pModel->index(pModel->rowCount() - 1, column);
+                }
             }
         } else {
-            if (row - 1 >= 0) {
-                return pModel->index(row - 1, column);
+            // Selecting a hidden column doesn't work, so we'll need to find the
+            // first non-hidden column here
+            int column = 0;
+            while (isColumnHidden(column) && column < pModel->columnCount()) {
+                column++;
+            }
+
+            // If the cursor does not yet exist (because the view has not yet
+            // been interacted with) then this selects the first/last row
+            if (cursorAction == QAbstractItemView::MoveDown) {
+                return pModel->index(0, column);
             } else {
                 return pModel->index(pModel->rowCount() - 1, column);
             }

--- a/src/widget/wlibrarytableview.cpp
+++ b/src/widget/wlibrarytableview.cpp
@@ -260,3 +260,37 @@ void WLibraryTableView::focusInEvent(QFocusEvent* event) {
         }
     }
 }
+
+QModelIndex WLibraryTableView::moveCursor(CursorAction cursorAction,
+        Qt::KeyboardModifiers modifiers) {
+    // The up and down cursor keys should wrap the list around. This behavior
+    // also applies to the `[Library],MoveVertical` action that is usually bound
+    // to the library browse encoder on controllers. Otherwise browsing a
+    // key-sorted library list requires either a serious workout or the user
+    // needs to reach for the mouse or keyboard when moving between 12/C#m/E and
+    // 1/G#m/B.
+    QAbstractItemModel* pModel = model();
+    if (pModel &&
+            (cursorAction == QAbstractItemView::MoveUp ||
+                    cursorAction == QAbstractItemView::MoveDown)) {
+        // This is very similar to `moveSelection()`, except that it doesn't
+        // actually modify the selection
+        const int row = currentIndex().row();
+        const int column = currentIndex().column();
+        if (cursorAction == QAbstractItemView::MoveDown) {
+            if (row + 1 < pModel->rowCount()) {
+                return pModel->index(row + 1, column);
+            } else {
+                return pModel->index(0, column);
+            }
+        } else {
+            if (row - 1 >= 0) {
+                return pModel->index(row - 1, column);
+            } else {
+                return pModel->index(pModel->rowCount() - 1, column);
+            }
+        }
+    }
+
+    return QTableView::moveCursor(cursorAction, modifiers);
+}

--- a/src/widget/wlibrarytableview.h
+++ b/src/widget/wlibrarytableview.h
@@ -59,6 +59,8 @@ class WLibraryTableView : public QTableView, public virtual LibraryView {
 
   protected:
     void focusInEvent(QFocusEvent* event) override;
+    QModelIndex moveCursor(CursorAction cursorAction,
+            Qt::KeyboardModifiers modifiers) override;
     virtual QString getModelStateKey() const = 0;
 
   private:


### PR DESCRIPTION
As described in #11088. This makes navigating key-sorted track lists using a controller much more convenient. ~~Though as mentioned in the comment, this does not match the Up/Down cursor key behavior. Should that maybe also cause the tracks list to wrap around? On a keyboard you have Home/End to go to the start and end of the list, but there I'd also expect the cursor keys there to wrap the list around in a similar way.~~ See below.