### PR TITLE
Keep the metadata key text unchanged, use it as the origin of information 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2165,6 +2165,7 @@ add_executable(mixxx-test
   src/test/trackdao_test.cpp
   src/test/trackexport_test.cpp
   src/test/trackmetadata_test.cpp
+  src/test/trackmetadataexport_test.cpp
   src/test/tracknumberstest.cpp
   src/test/trackreftest.cpp
   src/test/trackupdate_test.cpp

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -621,7 +621,7 @@ void bindTrackLibraryValues(
     QString keysVersion = keys.getVersion();
     QString keysSubVersion = keys.getSubVersion();
     mixxx::track::io::key::ChromaticKey key = keys.getGlobalKey();
-    QString keyText = KeyUtils::formatGlobalKey(keys);
+    QString keyText = keys.getGlobalKeyText();
     pTrackLibraryQuery->bindValue(":keys", keysBlob);
     pTrackLibraryQuery->bindValue(":keys_version", keysVersion);
     pTrackLibraryQuery->bindValue(":keys_sub_version", keysSubVersion);
@@ -1251,16 +1251,18 @@ void setTrackKey(const QSqlRecord& record, const int column, Track* pTrack) {
     QString keysVersion = record.value(column + 1).toString();
     QString keysSubVersion = record.value(column + 2).toString();
     QByteArray keysBlob = record.value(column + 3).toByteArray();
-    Keys keys = KeyFactory::loadKeysFromByteArray(
-            keysVersion, keysSubVersion, &keysBlob);
-
     if (!keysVersion.isEmpty()) {
-        pTrack->setKeys(keys);
+        pTrack->setKeys(KeyFactory::loadKeysFromByteArray(
+                keysVersion,
+                keysSubVersion,
+                &keysBlob));
     } else if (!keyText.isEmpty()) {
         // Typically this happens if we are upgrading from an older (<1.12.0)
         // version of Mixxx that didn't support Keys. We treat all legacy data
         // as user-generated because that way it will be treated sensitively.
-        pTrack->setKeyText(keyText, mixxx::track::io::key::USER);
+        pTrack->setKeys(KeyFactory::makeBasicKeysKeepText(
+                keyText,
+                mixxx::track::io::key::USER));
     }
 }
 

--- a/src/sources/soundsourceproxy.h
+++ b/src/sources/soundsourceproxy.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <gtest/gtest_prod.h>
+
 #include <QMimeType>
 
 #include "sources/soundsourceproviderregistry.h"
@@ -201,7 +203,7 @@ class SoundSourceProxy {
     static QHash<QMimeType, QString> s_fileTypeByMimeType;
 
     friend class TrackCollectionManager;
-    friend class TrackMetadataExportTest_keepWithespaceKey_Test;
+    FRIEND_TEST(TrackMetadataExportTest, keepWithespaceKey);
     static ExportTrackMetadataResult exportTrackMetadataBeforeSaving(
             Track* pTrack,
             const SyncTrackMetadataParams& syncParams);

--- a/src/sources/soundsourceproxy.h
+++ b/src/sources/soundsourceproxy.h
@@ -201,6 +201,7 @@ class SoundSourceProxy {
     static QHash<QMimeType, QString> s_fileTypeByMimeType;
 
     friend class TrackCollectionManager;
+    friend class TrackMetadataExportTest_keepWithespaceKey_Test;
     static ExportTrackMetadataResult exportTrackMetadataBeforeSaving(
             Track* pTrack,
             const SyncTrackMetadataParams& syncParams);

--- a/src/test/trackmetadataexport_test.cpp
+++ b/src/test/trackmetadataexport_test.cpp
@@ -1,0 +1,138 @@
+#include <gtest/gtest.h>
+
+#include <QTemporaryDir>
+
+#include "test/mixxxtest.h"
+#include "test/soundsourceproviderregistration.h"
+#include "track/globaltrackcache.h"
+#include "track/track.h"
+
+namespace {
+
+const QString kEmptyFile = QStringLiteral("empty.mp3");
+
+void deleteTrack(Track* pTrack) {
+    // Delete track objects directly in unit tests with
+    // no main event loop
+    delete pTrack;
+};
+
+class GlobalTrackCacheHelper : public GlobalTrackCacheSaver {
+  public:
+    void saveEvictedTrack(Track* pTrack) noexcept override {
+        ASSERT_FALSE(pTrack == nullptr);
+    }
+    GlobalTrackCacheHelper() {
+        GlobalTrackCache::createInstance(this, deleteTrack);
+    }
+    ~GlobalTrackCacheHelper() override {
+        GlobalTrackCache::destroyInstance();
+    }
+};
+
+} // namespace
+
+class TrackMetadataExportTest : public MixxxTest, SoundSourceProviderRegistration {
+  public:
+    TrackMetadataExportTest()
+            : m_testDataDir(QDir::current().absoluteFilePath(
+                      "src/test/id3-test-data")) {
+    }
+
+  protected:
+    const QDir m_testDataDir;
+    QTemporaryDir m_exportTempDir;
+    GlobalTrackCacheHelper m_globalTrackCacheHelper;
+};
+
+TEST_F(TrackMetadataExportTest, keepWithespaceKey) {
+    const QString kWhiteSpacesKey = QStringLiteral("  A#m  ");
+    const QString kNormalizedDisplayKey = QString::fromUtf8("B♭m");
+    const QString kId3Key = QStringLiteral("Bbm");
+
+    // Generate a file name for exporting metadata
+    const QString exportTrackPath = m_exportTempDir.filePath(kEmptyFile);
+    mixxxtest::copyFile(m_testDataDir.absoluteFilePath(kEmptyFile), exportTrackPath);
+    TrackPointer pTrack = Track::newTemporary(exportTrackPath);
+
+    mixxx::TrackMetadata writeTrackMetadata;
+    writeTrackMetadata.refTrackInfo().setKeyText(kWhiteSpacesKey);
+
+    // the internal value is still unchanged
+    EXPECT_EQ(writeTrackMetadata.getTrackInfo().getKeyText().toStdString(),
+            kWhiteSpacesKey.toStdString());
+
+    // This saves the metadata object literally, but normalizes
+    // the global key value as StandardID3v2
+    pTrack->replaceMetadataFromSource(
+            std::move(writeTrackMetadata),
+            QDateTime::currentDateTimeUtc());
+
+    // getKeytext returns the normalized version suitable for GUI presentation
+    EXPECT_EQ(pTrack->getKeyText().toStdString(), kNormalizedDisplayKey.toStdString());
+
+    // the internal value is still unchanged
+    EXPECT_EQ(pTrack->getRecord()
+                      .getMetadata()
+                      .getTrackInfo()
+                      .getKeyText()
+                      .toStdString(),
+            kWhiteSpacesKey.toStdString());
+
+    pTrack->markForMetadataExport();
+    SyncTrackMetadataParams params;
+    ExportTrackMetadataResult result =
+            SoundSourceProxy::exportTrackMetadataBeforeSaving(
+                    pTrack.get(), params);
+    EXPECT_EQ(result, ExportTrackMetadataResult::Succeeded);
+
+    // recreate the Track
+    mixxx::TrackMetadata readTrackMetadata;
+    SoundSourceProxy::importTrackMetadataAndCoverImageFromFile(
+            mixxx::FileAccess(mixxx::FileInfo(exportTrackPath)),
+            &readTrackMetadata,
+            nullptr,
+            false);
+
+    // the internal value is still unchanged
+    EXPECT_EQ(readTrackMetadata.getTrackInfo().getKeyText().toStdString(),
+            kWhiteSpacesKey.toStdString());
+
+    pTrack->replaceMetadataFromSource(
+            readTrackMetadata,
+            QDateTime::currentDateTimeUtc());
+
+    // getKeytext returns the normalized version suitable for GUI presentation
+    EXPECT_EQ(pTrack->getKeyText().toStdString(), kNormalizedDisplayKey.toStdString());
+
+    // the internal value is still unchanged
+    EXPECT_EQ(pTrack->getRecord()
+                      .getMetadata()
+                      .getTrackInfo()
+                      .getKeyText()
+                      .toStdString(),
+            kWhiteSpacesKey.toStdString());
+
+    // Reject edits which results to the same key
+    pTrack->setKeyText(kNormalizedDisplayKey);
+    EXPECT_EQ(pTrack->getRecord()
+                      .getMetadata()
+                      .getTrackInfo()
+                      .getKeyText()
+                      .toStdString(),
+            kWhiteSpacesKey.toStdString());
+
+    // Allow to remove key with an empty string
+    pTrack->setKeyText("");
+    EXPECT_EQ(pTrack->getRecord()
+                      .getMetadata()
+                      .getTrackInfo()
+                      .getKeyText()
+                      .toStdString(),
+            QString().toStdString());
+
+    // normalize user edits
+    pTrack->setKeyText(kWhiteSpacesKey);
+    // the internal value is now at the preferred ID3v2 format
+    EXPECT_EQ(pTrack->getKeys().getGlobalKeyText().toStdString(), kId3Key.toStdString());
+}

--- a/src/test/trackmetadataexport_test.cpp
+++ b/src/test/trackmetadataexport_test.cpp
@@ -32,7 +32,7 @@ class GlobalTrackCacheHelper : public GlobalTrackCacheSaver {
 
 } // namespace
 
-class TrackMetadataExportTest : public MixxxTest, SoundSourceProviderRegistration {
+class TrackMetadataExportTest : public MixxxTest, private SoundSourceProviderRegistration {
   public:
     TrackMetadataExportTest()
             : m_testDataDir(QDir::current().absoluteFilePath(
@@ -48,7 +48,7 @@ class TrackMetadataExportTest : public MixxxTest, SoundSourceProviderRegistratio
 TEST_F(TrackMetadataExportTest, keepWithespaceKey) {
     const QString kWhiteSpacesKey = QStringLiteral("  A#m  ");
     const QString kNormalizedDisplayKey = QString::fromUtf8("B♭m");
-    const QString kId3Key = QStringLiteral("Bbm");
+    constexpr std::string_view kId3Key = "Bbm";
 
     // Generate a file name for exporting metadata
     const QString exportTrackPath = m_exportTempDir.filePath(kEmptyFile);
@@ -134,5 +134,5 @@ TEST_F(TrackMetadataExportTest, keepWithespaceKey) {
     // normalize user edits
     pTrack->setKeyText(kWhiteSpacesKey);
     // the internal value is now at the preferred ID3v2 format
-    EXPECT_EQ(pTrack->getKeys().getGlobalKeyText().toStdString(), kId3Key.toStdString());
+    EXPECT_EQ(pTrack->getKeys().getGlobalKeyText().toStdString(), kId3Key);
 }

--- a/src/track/keyfactory.cpp
+++ b/src/track/keyfactory.cpp
@@ -27,7 +27,8 @@ Keys KeyFactory::makeBasicKeys(
         mixxx::track::io::key::Source source) {
     KeyMap key_map;
     key_map.set_global_key(global_key);
-    QString global_key_text = KeyUtils::keyToString(global_key, KeyUtils::KeyNotation::Custom);
+    QString global_key_text = KeyUtils::keyToString(
+            global_key, KeyUtils::KeyNotation::StandardID3v2);
     key_map.set_global_key_text(global_key_text.toStdString());
     key_map.set_source(source);
     return Keys(key_map);

--- a/src/track/keyfactory.cpp
+++ b/src/track/keyfactory.cpp
@@ -28,7 +28,7 @@ Keys KeyFactory::makeBasicKeys(
     KeyMap key_map;
     key_map.set_global_key(global_key);
     QString global_key_text = KeyUtils::keyToString(
-            global_key, KeyUtils::KeyNotation::StandardID3v2);
+            global_key, KeyUtils::KeyNotation::ID3v2);
     key_map.set_global_key_text(global_key_text.toStdString());
     key_map.set_source(source);
     return Keys(key_map);

--- a/src/track/keys.h
+++ b/src/track/keys.h
@@ -29,12 +29,11 @@ class Keys final {
     const QString& getSubVersion() const;
     void setSubVersion(const QString& subVersion);
 
-    ////////////////////////////////////////////////////////////////////////////
-    // Key calculations
-    ////////////////////////////////////////////////////////////////////////////
-
-    // Return the average key over the entire track if the key is valid.
+    // Return the average key over the entire track if analyzed by Mixxx
+    // or the Key found in the track metadata
     mixxx::track::io::key::ChromaticKey getGlobalKey() const;
+
+    // Return key text form the track metadata literally (not normalized)
     QString getGlobalKeyText() const;
 
   private:

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -38,59 +38,66 @@ const QString s_sharpSymbol = QString::fromUtf8("♯");
 //static const QString s_flatSymbol = QString::fromUtf8("♭");
 
 const QString s_traditionalKeyNames[] = {
-        QString::fromUtf8("INVALID"),
-        QString::fromUtf8("C"),
-        QString::fromUtf8("D♭"),
-        QString::fromUtf8("D"),
-        QString::fromUtf8("E♭"),
-        QString::fromUtf8("E"),
-        QString::fromUtf8("F"),
-        QString::fromUtf8("F♯/G♭"),
-        QString::fromUtf8("G"),
-        QString::fromUtf8("A♭"),
-        QString::fromUtf8("A"),
-        QString::fromUtf8("B♭"),
-        QString::fromUtf8("B"),
-        QString::fromUtf8("Cm"),
-        QString::fromUtf8("C♯m"),
-        QString::fromUtf8("Dm"),
-        QString::fromUtf8("D♯m/E♭m"),
-        QString::fromUtf8("Em"),
-        QString::fromUtf8("Fm"),
-        QString::fromUtf8("F♯m"),
-        QString::fromUtf8("Gm"),
-        QString::fromUtf8("G♯m"),
-        QString::fromUtf8("Am"),
-        QString::fromUtf8("B♭m"),
-        QString::fromUtf8("Bm")};
+        QStringLiteral(u"INVALID"),
+        QStringLiteral(u"C"),
+        QStringLiteral(u"D♭"),
+        QStringLiteral(u"D"),
+        QStringLiteral(u"E♭"),
+        QStringLiteral(u"E"),
+        QStringLiteral(u"F"),
+        QStringLiteral(u"F♯/G♭"),
+        QStringLiteral(u"G"),
+        QStringLiteral(u"A♭"),
+        QStringLiteral(u"A"),
+        QStringLiteral(u"B♭"),
+        QStringLiteral(u"B"),
+        QStringLiteral(u"Cm"),
+        QStringLiteral(u"C♯m"),
+        QStringLiteral(u"Dm"),
+        QStringLiteral(u"D♯m/E♭m"),
+        QStringLiteral(u"Em"),
+        QStringLiteral(u"Fm"),
+        QStringLiteral(u"F♯m"),
+        QStringLiteral(u"Gm"),
+        QStringLiteral(u"G♯m"),
+        QStringLiteral(u"Am"),
+        QStringLiteral(u"B♭m"),
+        QStringLiteral(u"Bm")};
 
-// defined here: https://id3.org/id3v2.3.0
-static const QString s_standardID3v2KeyNames[] = {
-        QString::fromUtf8("o"),
-        QString::fromUtf8("C"),
-        QString::fromUtf8("Db"),
-        QString::fromUtf8("D"),
-        QString::fromUtf8("Eb"),
-        QString::fromUtf8("E"),
-        QString::fromUtf8("F"),
-        QString::fromUtf8("F#"),
-        QString::fromUtf8("G"),
-        QString::fromUtf8("Ab"),
-        QString::fromUtf8("A"),
-        QString::fromUtf8("Bb"),
-        QString::fromUtf8("B"),
-        QString::fromUtf8("Cm"),
-        QString::fromUtf8("C#m"),
-        QString::fromUtf8("Dm"),
-        QString::fromUtf8("Ebm"),
-        QString::fromUtf8("Em"),
-        QString::fromUtf8("Fm"),
-        QString::fromUtf8("F#m"),
-        QString::fromUtf8("Gm"),
-        QString::fromUtf8("G#m"),
-        QString::fromUtf8("Am"),
-        QString::fromUtf8("Bbm"),
-        QString::fromUtf8("Bm")};
+// ID3v2.3.0 specification (https://id3.org/id3v2.3.0):
+// The 'Initial key' frame contains the musical key in which the sound starts.
+// It is represented as a string with a maximum length of three characters.
+// The ground keys are represented with "A","B","C","D","E", "F" and "G" and halfkeys
+// represented with "b" and "#". Minor is represented as "m". Example "Cbm".
+// Off key is represented with an "o" only.
+const std::array s_IDv3KeyNames = {
+        // these are QStringLiterals because they're used as QStrings below, even though they
+        // only contain ASCII characters
+        QStringLiteral("o"),
+        QStringLiteral("C"),
+        QStringLiteral("Db"),
+        QStringLiteral("D"),
+        QStringLiteral("Eb"),
+        QStringLiteral("E"),
+        QStringLiteral("F"),
+        QStringLiteral("F#"),
+        QStringLiteral("G"),
+        QStringLiteral("Ab"),
+        QStringLiteral("A"),
+        QStringLiteral("Bb"),
+        QStringLiteral("B"),
+        QStringLiteral("Cm"),
+        QStringLiteral("C#m"),
+        QStringLiteral("Dm"),
+        QStringLiteral("Ebm"),
+        QStringLiteral("Em"),
+        QStringLiteral("Fm"),
+        QStringLiteral("F#m"),
+        QStringLiteral("Gm"),
+        QStringLiteral("G#m"),
+        QStringLiteral("Am"),
+        QStringLiteral("Bbm"),
+        QStringLiteral("Bm")};
 
 // Maps an OpenKey number to its major and minor key.
 constexpr ChromaticKey s_openKeyToKeys[][2] = {
@@ -300,6 +307,50 @@ void KeyUtils::setNotation(const QMap<ChromaticKey, QString>& notation) {
 }
 
 // static
+int KeyUtils::keyToOpenKeyNumber(mixxx::track::io::key::ChromaticKey key) {
+    switch (key) {
+    case mixxx::track::io::key::C_MAJOR:
+    case mixxx::track::io::key::A_MINOR:
+        return 1;
+    case mixxx::track::io::key::G_MAJOR:
+    case mixxx::track::io::key::E_MINOR:
+        return 2;
+    case mixxx::track::io::key::D_MAJOR:
+    case mixxx::track::io::key::B_MINOR:
+        return 3;
+    case mixxx::track::io::key::A_MAJOR:
+    case mixxx::track::io::key::F_SHARP_MINOR:
+        return 4;
+    case mixxx::track::io::key::E_MAJOR:
+    case mixxx::track::io::key::C_SHARP_MINOR:
+        return 5;
+    case mixxx::track::io::key::B_MAJOR:
+    case mixxx::track::io::key::G_SHARP_MINOR:
+        return 6;
+    case mixxx::track::io::key::F_SHARP_MAJOR:
+    case mixxx::track::io::key::E_FLAT_MINOR:
+        return 7;
+    case mixxx::track::io::key::D_FLAT_MAJOR:
+    case mixxx::track::io::key::B_FLAT_MINOR:
+        return 8;
+    case mixxx::track::io::key::A_FLAT_MAJOR:
+    case mixxx::track::io::key::F_MINOR:
+        return 9;
+    case mixxx::track::io::key::E_FLAT_MAJOR:
+    case mixxx::track::io::key::C_MINOR:
+        return 10;
+    case mixxx::track::io::key::B_FLAT_MAJOR:
+    case mixxx::track::io::key::G_MINOR:
+        return 11;
+    case mixxx::track::io::key::F_MAJOR:
+    case mixxx::track::io::key::D_MINOR:
+        return 12;
+    default:
+        return 0;
+    }
+}
+
+// static
 QString KeyUtils::keyToString(ChromaticKey key,
                               KeyNotation notation) {
     if (!ChromaticKey_IsValid(key) ||
@@ -337,8 +388,8 @@ QString KeyUtils::keyToString(ChromaticKey key,
         return QString::number(number) + (major ? "B" : "A") + " (" + trad + ")";
     } else if (notation == KeyNotation::Traditional) {
         return s_traditionalKeyNames[static_cast<int>(key)];
-    } else if (notation == KeyNotation::StandardID3v2) {
-        return s_standardID3v2KeyNames[static_cast<int>(key)];
+    } else if (notation == KeyNotation::ID3v2) {
+        return s_IDv3KeyNames[static_cast<int>(key)];
     }
     return keyDebugName(key);
 }

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -64,6 +64,34 @@ const QString s_traditionalKeyNames[] = {
         QString::fromUtf8("B♭m"),
         QString::fromUtf8("Bm")};
 
+// defined here: https://id3.org/id3v2.3.0
+static const QString s_standardID3v2KeyNames[] = {
+        QString::fromUtf8("o"),
+        QString::fromUtf8("C"),
+        QString::fromUtf8("Db"),
+        QString::fromUtf8("D"),
+        QString::fromUtf8("Eb"),
+        QString::fromUtf8("E"),
+        QString::fromUtf8("F"),
+        QString::fromUtf8("F#"),
+        QString::fromUtf8("G"),
+        QString::fromUtf8("Ab"),
+        QString::fromUtf8("A"),
+        QString::fromUtf8("Bb"),
+        QString::fromUtf8("B"),
+        QString::fromUtf8("Cm"),
+        QString::fromUtf8("C#m"),
+        QString::fromUtf8("Dm"),
+        QString::fromUtf8("Ebm"),
+        QString::fromUtf8("Em"),
+        QString::fromUtf8("Fm"),
+        QString::fromUtf8("F#m"),
+        QString::fromUtf8("Gm"),
+        QString::fromUtf8("G#m"),
+        QString::fromUtf8("Am"),
+        QString::fromUtf8("Bbm"),
+        QString::fromUtf8("Bm")};
+
 // Maps an OpenKey number to its major and minor key.
 constexpr ChromaticKey s_openKeyToKeys[][2] = {
         // 0 is not a valid OpenKey number.
@@ -309,6 +337,8 @@ QString KeyUtils::keyToString(ChromaticKey key,
         return QString::number(number) + (major ? "B" : "A") + " (" + trad + ")";
     } else if (notation == KeyNotation::Traditional) {
         return s_traditionalKeyNames[static_cast<int>(key)];
+    } else if (notation == KeyNotation::StandardID3v2) {
+        return s_standardID3v2KeyNames[static_cast<int>(key)];
     }
     return keyDebugName(key);
 }

--- a/src/track/keyutils.h
+++ b/src/track/keyutils.h
@@ -21,7 +21,8 @@ class KeyUtils {
         Traditional = 4,
         OpenKeyAndTraditional = 5,
         LancelotAndTraditional = 6,
-        NumKeyNotations = 7
+        StandardID3v2 = 7,
+        NumKeyNotations = 8
     };
 
     enum class ScaleMode {

--- a/src/track/keyutils.h
+++ b/src/track/keyutils.h
@@ -21,7 +21,7 @@ class KeyUtils {
         Traditional = 4,
         OpenKeyAndTraditional = 5,
         LancelotAndTraditional = 6,
-        StandardID3v2 = 7,
+        ID3v2 = 7,
         NumKeyNotations = 8
     };
 
@@ -126,48 +126,7 @@ class KeyUtils {
 
     static mixxx::track::io::key::ChromaticKey openKeyNumberToKey(int openKeyNumber, bool major);
 
-    static inline int keyToOpenKeyNumber(mixxx::track::io::key::ChromaticKey key) {
-        switch (key) {
-            case mixxx::track::io::key::C_MAJOR:
-            case mixxx::track::io::key::A_MINOR:
-                return 1;
-            case mixxx::track::io::key::G_MAJOR:
-            case mixxx::track::io::key::E_MINOR:
-                return 2;
-            case mixxx::track::io::key::D_MAJOR:
-            case mixxx::track::io::key::B_MINOR:
-                return 3;
-            case mixxx::track::io::key::A_MAJOR:
-            case mixxx::track::io::key::F_SHARP_MINOR:
-                return 4;
-            case mixxx::track::io::key::E_MAJOR:
-            case mixxx::track::io::key::C_SHARP_MINOR:
-                return 5;
-            case mixxx::track::io::key::B_MAJOR:
-            case mixxx::track::io::key::G_SHARP_MINOR:
-                return 6;
-            case mixxx::track::io::key::F_SHARP_MAJOR:
-            case mixxx::track::io::key::E_FLAT_MINOR:
-                return 7;
-            case mixxx::track::io::key::D_FLAT_MAJOR:
-            case mixxx::track::io::key::B_FLAT_MINOR:
-                return 8;
-            case mixxx::track::io::key::A_FLAT_MAJOR:
-            case mixxx::track::io::key::F_MINOR:
-                return 9;
-            case mixxx::track::io::key::E_FLAT_MAJOR:
-            case mixxx::track::io::key::C_MINOR:
-                return 10;
-            case mixxx::track::io::key::B_FLAT_MAJOR:
-            case mixxx::track::io::key::G_MINOR:
-                return 11;
-            case mixxx::track::io::key::F_MAJOR:
-            case mixxx::track::io::key::D_MINOR:
-                return 12;
-            default:
-                return 0;
-        }
-    }
+    static int keyToOpenKeyNumber(mixxx::track::io::key::ChromaticKey key);
 
     static int keyToCircleOfFifthsOrder(mixxx::track::io::key::ChromaticKey key,
                                         KeyNotation notation);

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -168,14 +168,11 @@ void Track::replaceMetadataFromSource(
         // Save some new values for later
         const auto importedBpm = importedMetadata.getTrackInfo().getBpm();
         const QString importedKeyText = importedMetadata.getTrackInfo().getKeyText();
-        // Parse the imported key before entering the locking scope
-        const mixxx::track::io::key::ChromaticKey importedKey =
-                KeyUtils::guessKeyFromText(importedKeyText);
 
         // enter locking scope
         auto locked = lockMutex(&m_qMutex);
 
-        // Preserve the both current bpm and key temporarily to avoid
+        // Preserve current bpm and key temporarily to avoid
         // overwriting with an inconsistent value. The bpm must always be
         // set together with the beat grid and the key text must be parsed
         // and validated.
@@ -207,12 +204,14 @@ void Track::replaceMetadataFromSource(
         modified |= beatsAndBpmModified;
 
         auto keysModified = false;
-        if (importedKey != mixxx::track::io::key::INVALID) {
+        Keys newKeys = KeyFactory::makeBasicKeysKeepText(
+                importedKeyText, mixxx::track::io::key::FILE_METADATA);
+        if (newKeys.getGlobalKey() != mixxx::track::io::key::INVALID &&
+                m_record.getMetadata().getTrackInfo().getKeyText() != importedKeyText) {
             // Only update the current key with a valid value. Otherwise preserve
             // the existing value.
-            keysModified = m_record.updateGlobalKeyNormalizeText(importedKeyText,
-                                   mixxx::track::io::key::FILE_METADATA) ==
-                    mixxx::UpdateResult::Updated;
+            setKeys(newKeys);
+            keysModified = true;
         }
         modified |= keysModified;
 

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -204,7 +204,7 @@ void Track::replaceMetadataFromSource(
         modified |= beatsAndBpmModified;
 
         auto keysModified = false;
-        Keys newKeys = KeyFactory::makeBasicKeysKeepText(
+        const Keys newKeys = KeyFactory::makeBasicKeysKeepText(
                 importedKeyText, mixxx::track::io::key::FILE_METADATA);
         if (newKeys.getGlobalKey() != mixxx::track::io::key::INVALID &&
                 m_record.getMetadata().getTrackInfo().getKeyText() != importedKeyText) {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1451,8 +1451,7 @@ mixxx::track::io::key::ChromaticKey Track::getKey() const {
 
 // returns the formatted key for display purpose
 QString Track::getKeyText() const {
-    const auto locked = lockMutex(&m_qMutex);
-    return m_record.getKeys().getGlobalKeyText();
+    return KeyUtils::keyToString(getKey());
 }
 
 // normalizes the keyText before storing

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -6,6 +6,7 @@
 #include "library/library_prefs.h"
 #include "moc_track.cpp"
 #include "sources/metadatasource.h"
+#include "track/keyfactory.h"
 #include "util/assert.h"
 #include "util/logger.h"
 #include "util/time.h"
@@ -1434,22 +1435,27 @@ Keys Track::getKeys() const {
 
 void Track::setKey(mixxx::track::io::key::ChromaticKey key,
                    mixxx::track::io::key::Source keySource) {
-    auto locked = lockMutex(&m_qMutex);
-    if (m_record.updateGlobalKey(key, keySource)) {
-        afterKeysUpdated(&locked);
+    if (key == mixxx::track::io::key::INVALID) {
+        return;
     }
+    const Keys keys = KeyFactory::makeBasicKeys(key, keySource);
+    QMutexLocker lock(&m_qMutex);
+    m_record.setKeys(keys);
+    afterKeysUpdated(&lock);
 }
 
 mixxx::track::io::key::ChromaticKey Track::getKey() const {
     const auto locked = lockMutex(&m_qMutex);
-    return m_record.getGlobalKey();
+    return m_record.getKeys().getGlobalKey();
 }
 
+// returns the formatted key for display purpose
 QString Track::getKeyText() const {
     const auto locked = lockMutex(&m_qMutex);
-    return m_record.getGlobalKeyText();
+    return m_record.getKeys().getGlobalKeyText();
 }
 
+// normalizes the keyText before storing
 void Track::setKeyText(const QString& keyText,
                        mixxx::track::io::key::Source keySource) {
     auto locked = lockMutex(&m_qMutex);

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -23,7 +23,7 @@ TrackRecord::TrackRecord(TrackId id)
 }
 
 void TrackRecord::setKeys(const Keys& keys) {
-    refMetadata().refTrackInfo().setKeyText(KeyUtils::formatGlobalKey(keys));
+    refMetadata().refTrackInfo().setKeyText(keys.getGlobalKeyText());
     m_keys = std::move(keys);
 }
 

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -27,21 +27,6 @@ void TrackRecord::setKeys(const Keys& keys) {
     m_keys = std::move(keys);
 }
 
-bool TrackRecord::updateGlobalKey(
-        track::io::key::ChromaticKey key,
-        track::io::key::Source keySource) {
-    if (key == track::io::key::INVALID) {
-        return false;
-    } else {
-        Keys keys = KeyFactory::makeBasicKeys(key, keySource);
-        if (m_keys.getGlobalKey() != keys.getGlobalKey()) {
-            setKeys(keys);
-            return true;
-        }
-    }
-    return false;
-}
-
 UpdateResult TrackRecord::updateGlobalKeyNormalizeText(
         const QString& keyText,
         track::io::key::Source keySource) {

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -30,6 +30,11 @@ void TrackRecord::setKeys(const Keys& keys) {
 UpdateResult TrackRecord::updateGlobalKeyNormalizeText(
         const QString& keyText,
         track::io::key::Source keySource) {
+    if (keyText.isEmpty()) {
+        // User tries to delete the key
+        setKeys(Keys());
+        return UpdateResult::Updated;
+    }
     // Try to parse the input as a key.
     mixxx::track::io::key::ChromaticKey newKey =
             KeyUtils::guessKeyFromText(keyText);

--- a/src/track/trackrecord.h
+++ b/src/track/trackrecord.h
@@ -93,16 +93,6 @@ class TrackRecord final {
         return m_keys;
     }
 
-    track::io::key::ChromaticKey getGlobalKey() const {
-        return getKeys().getGlobalKey();
-    }
-    bool updateGlobalKey(
-            track::io::key::ChromaticKey key,
-            track::io::key::Source keySource);
-
-    QString getGlobalKeyText() const {
-        return KeyUtils::formatGlobalKey(getKeys());
-    }
     UpdateResult updateGlobalKeyNormalizeText(
             const QString& keyText,
             track::io::key::Source keySource);

--- a/src/track/trackrecord.h
+++ b/src/track/trackrecord.h
@@ -93,6 +93,8 @@ class TrackRecord final {
         return m_keys;
     }
 
+    // Key text will be stored as StandardID3v2
+    // Invalid Keys are rejected and empty string deletes the key
     UpdateResult updateGlobalKeyNormalizeText(
             const QString& keyText,
             track::io::key::Source keySource);


### PR DESCRIPTION
This  fixes unnecessary writing of file metadata #11095

The issue is demonstrated in a unit-test. 

This PR is required to not loose extra metadata written by Rapid Evolution #11001 #10992

