### PR TITLE
Replace explicit library home/end key handlers with a moveCursor override

### DIFF
--- a/src/widget/wlibrarytableview.cpp
+++ b/src/widget/wlibrarytableview.cpp
@@ -311,8 +311,8 @@ QModelIndex WLibraryTableView::moveCursor(CursorAction cursorAction,
                 }
             }
         } break;
-        // By default the home and end keys move to the first and last column
-        // rather than the first and last row
+        // Make the home and end keys move to the first and last row rather than
+        // the first and last column (QAbstractItemView default)
         case QAbstractItemView::MoveHome:
         case QAbstractItemView::MoveEnd: {
             const QModelIndex current = currentIndex();

--- a/src/widget/wlibrarytableview.cpp
+++ b/src/widget/wlibrarytableview.cpp
@@ -294,6 +294,13 @@ QModelIndex WLibraryTableView::moveCursor(CursorAction cursorAction,
                     }
                 }
             } else {
+                // If the cursor does not yet exist (because the view has not
+                // yet been interacted with) then this selects the first or last
+                // row
+                const int row = cursorAction == QAbstractItemView::MoveUp
+                        ? pModel->rowCount() - 1
+                        : 0;
+
                 // Selecting a hidden column doesn't work, so we'll need to find
                 // the first non-hidden column here
                 int column = 0;
@@ -301,14 +308,7 @@ QModelIndex WLibraryTableView::moveCursor(CursorAction cursorAction,
                     column++;
                 }
 
-                // If the cursor does not yet exist (because the view has not
-                // yet been interacted with) then this selects the first/last
-                // row
-                if (cursorAction == QAbstractItemView::MoveDown) {
-                    return pModel->index(0, column);
-                } else {
-                    return pModel->index(pModel->rowCount() - 1, column);
-                }
+                return pModel->index(row, column);
             }
         } break;
         // Make the home and end keys move to the first and last row rather than

--- a/src/widget/wlibrarytableview.cpp
+++ b/src/widget/wlibrarytableview.cpp
@@ -273,7 +273,10 @@ QModelIndex WLibraryTableView::moveCursor(CursorAction cursorAction,
         // or the user needs to reach for the mouse or keyboard when moving
         // between 12/C#m/E and 1/G#m/B. This is very similar to
         // `moveSelection()`, except that it doesn't actually modify the
-        // selection
+        // selection. It simply returns a new cursor that the keyboard event
+        // handler in `QAbstractItemView` uses to either move the cursor, move
+        // the selection, or extend the selection depending on which modifier
+        // keys are held down.
         case QAbstractItemView::MoveUp:
         case QAbstractItemView::MoveDown: {
             const QModelIndex current = currentIndex();

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -819,35 +819,6 @@ void WTrackTableView::keyPressEvent(QKeyEvent* event) {
             return;
         }
     } break;
-    case Qt::Key_Home: { // Jump to first row
-        if (model()->rowCount() == 0) {
-            return;
-        }
-        int currCol = 0;
-        QModelIndex currIdx = currentIndex();
-        if (currIdx.isValid()) {
-            currCol = currIdx.column();
-        }
-        QModelIndex newIdx = model()->index(0, currCol);
-        selectionModel()->setCurrentIndex(newIdx,
-                QItemSelectionModel::SelectCurrent | QItemSelectionModel::Rows);
-        scrollTo(newIdx);
-    } break;
-    case Qt::Key_End: { // Jump to last row
-        const int lastRow = model()->rowCount() - 1;
-        if (lastRow == -1) {
-            return;
-        }
-        int currCol = 0;
-        QModelIndex currIdx = currentIndex();
-        if (currIdx.isValid()) {
-            currCol = currIdx.column();
-        }
-        QModelIndex newIdx = model()->index(lastRow, currCol);
-        selectionModel()->setCurrentIndex(newIdx,
-                QItemSelectionModel::SelectCurrent | QItemSelectionModel::Rows);
-        scrollTo(newIdx);
-    } break;
     default:
         QTableView::keyPressEvent(event);
     }


### PR DESCRIPTION
By simply overriding the cursor movement function instead of adding an explicit key event the home and end keys in the library table view now interact as expected with other hotkeys and cursor actions. <kbd>Shift+End</kbd> now select all items through the end of the list, and <kbd>Ctrl+Home</kbd> jumps to the first item without selecting it so it can be toggled on and off with Space.

Tagging @ronso0 since they suggested it in #11090. Sorry that it took so long (since making this actual change only took a minute heh). Had a busy weekend. Once either of these PRs are merged I'll rebase the other one and refactor the `moveCursor()` function a bit.