### PR TITLE
Traktor Kontrol S2MK3: Use FX select buttons to set quick effect presets

### DIFF
--- a/res/controllers/Traktor-Kontrol-S2-MK3-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S2-MK3-hid-scripts.js
@@ -608,7 +608,7 @@ TraktorS2MK3.fxHandler = function (field) {
     }
 };
 
-TraktorS2MK3.fxOutputHandler = function (value, group, key) {
+TraktorS2MK3.fxOutputHandler = function () {
     const fxButtonCount = 4;
     const availableGroups = [ "[Channel1]", "[Channel2]" ];
 

--- a/res/controllers/Traktor-Kontrol-S2-MK3-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S2-MK3-hid-scripts.js
@@ -936,6 +936,8 @@ TraktorS2MK3.lightDeck = function (switchOff) {
     TraktorS2MK3.controller.setOutput("[ChannelX]", "fxButton2", softLight, false);
     TraktorS2MK3.controller.setOutput("[ChannelX]", "fxButton3", softLight, false);
     TraktorS2MK3.controller.setOutput("[ChannelX]", "fxButton4", softLight, false);
+    // Set FX button LED state according to active quick effects on start-up
+    if (!switchOff) TraktorS2MK3.fxOutputHandler();
 
     TraktorS2MK3.controller.setOutput("[Channel1]", "reverse", softLight, false);
     TraktorS2MK3.controller.setOutput("[Channel2]", "reverse", softLight, false);


### PR DESCRIPTION
This repurposes the "FX SELECT" buttons on the controller to change the loaded quick effect preset rather than toggle effect chains. This allows them to be used in conjunction with the filter knobs on either side.

Pressing a button will load the preset at that index of the quick effect preset list (pressing button 1 will load the first preset, 2 the second, etc.). Holding down shift while pressing a button will only change the preset for the deck whose shift button was used. Buttons will light up accordingly, and if two different presets are active on one deck each, both of the buttons will light up.

One issue now is that changing the effect in the GUI won't change the LED status of the buttons, but I'm not sure how feasible this would even be to implement.