### PR TITLE
Cover fullsize fixes (2.4)

### DIFF
--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -65,7 +65,7 @@ void DlgCoverArtFullSize::closeEvent(QCloseEvent* event) {
     }
 }
 
-void DlgCoverArtFullSize::init(TrackPointer pTrack) {
+void DlgCoverArtFullSize::showTrackCoverArt(TrackPointer pTrack) {
     if (!pTrack) {
         return;
     }
@@ -83,7 +83,7 @@ void DlgCoverArtFullSize::init(TrackPointer pTrack) {
     slotLoadTrack(pTrack);
 }
 
-void DlgCoverArtFullSize::initFetchedCoverArt(const QByteArray& fetchedCoverArtBytes) {
+void DlgCoverArtFullSize::showFetchedCoverArt(const QByteArray& fetchedCoverArtBytes) {
     m_pixmap.loadFromData(fetchedCoverArtBytes);
 
     // The real size will be calculated later by adjustImageAndDialogSize().

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -83,9 +83,30 @@ void DlgCoverArtFullSize::showTrackCoverArt(TrackPointer pTrack) {
     raise();
     activateWindow();
 
+    loadTrack(pTrack);
     // This must be called after show() to set the window title. Refer to the
-    // comment in slotLoadTrack for details.
-    slotLoadTrack(pTrack);
+    // comment in setWindowTitleFromTrack() for details.
+    setWindowTitleFromTrack();
+    slotTrackCoverArtUpdated();
+    // slotCoverFound() calls adjustImageAndDialogSize()
+}
+
+void DlgCoverArtFullSize::showTrackCoverArt(TrackPointer pTrack,
+        const CoverInfo& coverInfo) {
+    if (!pTrack) {
+        return;
+    }
+
+    // The real size will be calculated later by adjustImageAndDialogSize().
+    resize(100, 100);
+    show();
+    raise();
+    activateWindow();
+
+    loadTrack(pTrack);
+    setWindowTitleFromTrack();
+    CoverArtCache::requestCover(this, coverInfo);
+    // slotCoverFound() calls adjustImageAndDialogSize()
 }
 
 void DlgCoverArtFullSize::showFetchedCoverArt(const QByteArray& fetchedCoverArtBytes) {

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -7,6 +7,7 @@
 
 #include "library/coverartcache.h"
 #include "library/coverartutils.h"
+#include "library/dlgtrackinfo.h"
 #include "moc_dlgcoverartfullsize.cpp"
 #include "track/track.h"
 #include "util/widgethelper.h"
@@ -32,7 +33,11 @@ DlgCoverArtFullSize::DlgCoverArtFullSize(
             &DlgCoverArtFullSize::customContextMenuRequested,
             this,
             &DlgCoverArtFullSize::slotCoverMenu);
-    if (m_pCoverMenu) {
+
+    // Only connect to the menu signals if this is not a grandchild of DlgTrackInfo.
+    // DlgTrackInfo is already connected to these signals, and catching these signals
+    // here would apply cover changes immediately, thus circumvent the Apply button there.
+    if (m_pCoverMenu && !(parent && qobject_cast<DlgTrackInfo*>(parent->parent()))) {
         connect(m_pCoverMenu,
                 &WCoverArtMenu::coverInfoSelected,
                 this,

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -32,7 +32,7 @@ DlgCoverArtFullSize::DlgCoverArtFullSize(
             &DlgCoverArtFullSize::customContextMenuRequested,
             this,
             &DlgCoverArtFullSize::slotCoverMenu);
-    if (m_pCoverMenu != nullptr) {
+    if (m_pCoverMenu) {
         connect(m_pCoverMenu,
                 &WCoverArtMenu::coverInfoSelected,
                 this,
@@ -43,7 +43,7 @@ DlgCoverArtFullSize::DlgCoverArtFullSize(
                 &DlgCoverArtFullSize::slotReloadCoverArt);
     }
 
-    if (m_pPlayer != nullptr) {
+    if (m_pPlayer) {
         connect(pPlayer,
                 &BaseTrackPlayer::newTrackLoaded,
                 this,
@@ -97,14 +97,14 @@ void DlgCoverArtFullSize::initFetchedCoverArt(const QByteArray& fetchedCoverArtB
 }
 
 void DlgCoverArtFullSize::slotLoadTrack(TrackPointer pTrack) {
-    if (m_pLoadedTrack != nullptr) {
+    if (m_pLoadedTrack) {
         disconnect(m_pLoadedTrack.get(),
                 &Track::coverArtUpdated,
                 this,
                 &DlgCoverArtFullSize::slotTrackCoverArtUpdated);
     }
     m_pLoadedTrack = pTrack;
-    if (m_pLoadedTrack != nullptr) {
+    if (m_pLoadedTrack) {
         connect(m_pLoadedTrack.get(),
                 &Track::coverArtUpdated,
                 this,
@@ -245,7 +245,7 @@ void DlgCoverArtFullSize::mousePressEvent(QMouseEvent* event) {
     if (event->button() != Qt::LeftButton) {
         return;
     }
-    if ((m_pCoverMenu != nullptr && !m_pCoverMenu->isVisible()) || m_pCoverMenu == nullptr) {
+    if ((m_pCoverMenu && !m_pCoverMenu->isVisible()) || !m_pCoverMenu) {
         m_clickTimer.setSingleShot(true);
         m_clickTimer.start(500);
         m_coverPressed = true;
@@ -260,7 +260,7 @@ void DlgCoverArtFullSize::mousePressEvent(QMouseEvent* event) {
 
 void DlgCoverArtFullSize::mouseReleaseEvent(QMouseEvent* event) {
     m_coverPressed = false;
-    if (m_pCoverMenu != nullptr && m_pCoverMenu->isVisible()) {
+    if (m_pCoverMenu && m_pCoverMenu->isVisible()) {
         return;
     }
 
@@ -291,7 +291,7 @@ void DlgCoverArtFullSize::mouseMoveEvent(QMouseEvent* event) {
 }
 
 void DlgCoverArtFullSize::slotCoverMenu(const QPoint& pos) {
-    if (m_pCoverMenu != nullptr) {
+    if (m_pCoverMenu) {
         m_pCoverMenu->popup(mapToGlobal(pos));
     }
 }

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -35,10 +35,12 @@ DlgCoverArtFullSize::DlgCoverArtFullSize(
             this,
             &DlgCoverArtFullSize::slotCoverMenu);
 
+    qWarning() << "       FullSize::";
     // Only connect to the menu signals if this is not a grandchild of DlgTrackInfo.
     // DlgTrackInfo is already connected to these signals, and catching these signals
     // here would apply cover changes immediately, thus circumvent the Apply button there.
     if (m_pCoverMenu && !(parent && qobject_cast<DlgTrackInfo*>(parent->parent()))) {
+        qWarning() << "                  connect to cover menu signals";
         connect(m_pCoverMenu,
                 &WCoverArtMenu::coverInfoSelected,
                 this,
@@ -47,6 +49,10 @@ DlgCoverArtFullSize::DlgCoverArtFullSize(
                 &WCoverArtMenu::reloadCoverArt,
                 this,
                 &DlgCoverArtFullSize::slotReloadCoverArt);
+    } else if (m_pCoverMenu) {
+        qWarning() << "                  dlgTI, don't connect to cover menu signals";
+    } else {
+        qWarning() << "                  no cover menu to connect to";
     }
 
     if (m_pPlayer) {
@@ -60,6 +66,7 @@ DlgCoverArtFullSize::DlgCoverArtFullSize(
 }
 
 void DlgCoverArtFullSize::closeEvent(QCloseEvent* event) {
+    qWarning() << "   FullSize closeEvent";
     if (parentWidget()) {
         // Since the widget has a parent, this instance will be reused again.
         // We need to prevent qt from destroying it's children
@@ -77,7 +84,10 @@ void DlgCoverArtFullSize::closeEvent(QCloseEvent* event) {
 }
 
 void DlgCoverArtFullSize::showTrackCoverArt(TrackPointer pTrack) {
+    qWarning() << "   FullSize show from track";
     if (!pTrack) {
+        qWarning() << "   FullSize show from track";
+        qWarning() << "            track == NULL";
         return;
     }
     show();
@@ -96,7 +106,12 @@ void DlgCoverArtFullSize::showTrackCoverArt(TrackPointer pTrack) {
 
 void DlgCoverArtFullSize::showTrackCoverArt(TrackPointer pTrack,
         const CoverInfo& coverInfo) {
+    qWarning() << "   FullSize show from coverInfo";
+    qWarning() << "       type:" << static_cast<int>(coverInfo.type)
+               << "hasTrLoc:" << bool(!coverInfo.trackLocation.isEmpty())
+               << "hasImg:" << coverInfo.hasImage();
     if (!pTrack) {
+        qWarning() << "            track == NULL";
         return;
     }
 
@@ -148,6 +163,14 @@ void DlgCoverArtFullSize::loadTrack(TrackPointer pTrack) {
 }
 
 void DlgCoverArtFullSize::slotLoadTrack(TrackPointer pTrack) {
+    if (sender()) {
+        qWarning() << "   FullSize slotLoadTrack (signal from" << sender();
+    } else {
+        qWarning() << "   FullSize slotLoadTrack (internal)";
+    }
+    if (!pTrack) {
+        qWarning() << "            track is NULL";
+    }
     loadTrack(pTrack);
     setWindowTitleFromTrack();
     slotTrackCoverArtUpdated();
@@ -165,8 +188,10 @@ void DlgCoverArtFullSize::setWindowTitleFromTrack() {
     // https://bugs.launchpad.net/mixxx/+bug/1789059
     // https://gitlab.freedesktop.org/xorg/lib/libx11/issues/25#note_50985
     if (!isVisible() || !m_pLoadedTrack) {
+        qWarning() << "    (FullSize setWindowTitleFromTrack)";
         return;
     }
+    qWarning() << "    FullSize setWindowTitleFromTrack";
     QString windowTitle;
     const QString albumArtist = m_pLoadedTrack->getAlbumArtist();
     const QString artist = m_pLoadedTrack->getArtist();
@@ -193,9 +218,11 @@ void DlgCoverArtFullSize::setWindowTitleFromTrack() {
 }
 
 void DlgCoverArtFullSize::slotTrackCoverArtUpdated() {
+    qWarning() << "     FullSize slotTrackCoverArtUpdated";
     if (m_pLoadedTrack) {
         CoverArtCache::requestTrackCover(this, m_pLoadedTrack);
     } else {
+        qWarning() << "            track is NULL";
         coverArt->setPixmap(QPixmap());
     }
 }
@@ -212,6 +239,7 @@ void DlgCoverArtFullSize::slotCoverFound(
             m_pLoadedTrack->getLocation() != coverInfo.trackLocation) {
         return;
     }
+    qWarning() << "      FullSize coverFound";
 
     m_pixmap = pixmap;
 
@@ -220,14 +248,19 @@ void DlgCoverArtFullSize::slotCoverFound(
 
 void DlgCoverArtFullSize::adjustImageAndDialogSize() {
     if (m_pixmap.isNull()) {
+        qWarning() << "       FullSize adjustImageAndDialogSize";
+        qWarning() << "            pix == Null, hide";
         coverArt->setPixmap(QPixmap());
         close();
         return;
     }
 
     if (!isVisible()) {
+        qWarning() << "       (FullSize adjustImageAndDialogSize)";
         return;
     }
+    qWarning() << "       FullSize adjustImageAndDialogSize";
+    qWarning() << "                wasVisible:" << m_wasVisible;
     // Keep dialog position and size and fit in the image if the dialog was already
     // visible while loading the new cover.
     // Otherwise, try to show the cover in full size. Scale down the dialog if
@@ -292,8 +325,11 @@ void DlgCoverArtFullSize::slotReloadCoverArt() {
 void DlgCoverArtFullSize::slotCoverInfoSelected(
         const CoverInfoRelative& coverInfo) {
     if (!m_pLoadedTrack) {
+        qWarning() << "   FullSize coverInfoSelected";
+        qWarning() << "            track == NULL";
         return;
     }
+    qWarning() << "   FullSize coverInfoSelected (other parent" << parent();
     m_pLoadedTrack->setCoverInfo(coverInfo);
 }
 

--- a/src/library/dlgcoverartfullsize.h
+++ b/src/library/dlgcoverartfullsize.h
@@ -39,7 +39,6 @@ class DlgCoverArtFullSize
             mixxx::cache_key_t requestedCacheKey,
             bool coverInfoUpdated);
     void slotTrackCoverArtUpdated();
-    void adjustImageAndDialogSize();
 
     // slots that handle signals from WCoverArtMenu
     void slotCoverMenu(const QPoint& pos);
@@ -47,6 +46,10 @@ class DlgCoverArtFullSize
     void slotReloadCoverArt();
 
   private:
+    void loadTrack(TrackPointer);
+    void setWindowTitleFromTrack();
+    void adjustImageAndDialogSize();
+
     QPixmap m_pixmap;
     TrackPointer m_pLoadedTrack;
     BaseTrackPlayer* m_pPlayer;

--- a/src/library/dlgcoverartfullsize.h
+++ b/src/library/dlgcoverartfullsize.h
@@ -21,8 +21,8 @@ class DlgCoverArtFullSize
             WCoverArtMenu* pCoverMenu = nullptr);
     ~DlgCoverArtFullSize() override = default;
 
-    void init(TrackPointer pTrack);
-    void initFetchedCoverArt(const QByteArray& fetchedCoverArtBytes);
+    void showTrackCoverArt(TrackPointer pTrack);
+    void showFetchedCoverArt(const QByteArray& fetchedCoverArtBytes);
     void mousePressEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* ) override;
     void mouseMoveEvent(QMouseEvent* ) override;

--- a/src/library/dlgcoverartfullsize.h
+++ b/src/library/dlgcoverartfullsize.h
@@ -58,4 +58,5 @@ class DlgCoverArtFullSize
     QTimer m_clickTimer;
     QPoint m_dragStartPosition;
     bool m_coverPressed;
+    bool m_wasVisible;
 };

--- a/src/library/dlgcoverartfullsize.h
+++ b/src/library/dlgcoverartfullsize.h
@@ -22,6 +22,7 @@ class DlgCoverArtFullSize
     ~DlgCoverArtFullSize() override = default;
 
     void showTrackCoverArt(TrackPointer pTrack);
+    void showTrackCoverArt(TrackPointer pTrack, const CoverInfo& coverInfo);
     void showFetchedCoverArt(const QByteArray& fetchedCoverArtBytes);
     void mousePressEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* ) override;

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -124,10 +124,12 @@ DlgTagFetcher::DlgTagFetcher(UserSettingsPointer pConfig, const TrackModel* pTra
           m_isCoverArtCopyWorkerRunning(false),
           m_pWCurrentCoverArtLabel(make_parented<WCoverArtLabel>(this)),
           m_pWFetchedCoverArtLabel(make_parented<WCoverArtLabel>(this)) {
+    qWarning() << "  ## DlgTF::";
     init();
 }
 
 void DlgTagFetcher::init() {
+    qWarning() << "  ## DlgTF init";
     setupUi(this);
     setWindowIcon(QIcon(MIXXX_ICON_PATH));
 

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -49,10 +49,12 @@ DlgTrackInfo::DlgTrackInfo(
           m_pWCoverArtMenu(make_parented<WCoverArtMenu>(this)),
           m_pWCoverArtLabel(make_parented<WCoverArtLabel>(this, m_pWCoverArtMenu)),
           m_pWStarRating(make_parented<WStarRating>(nullptr, this)) {
+    qWarning() << " DlgTI ::";
     init();
 }
 
 void DlgTrackInfo::init() {
+    qWarning() << " DlgTI init";
     setupUi(this);
     setWindowIcon(QIcon(MIXXX_ICON_PATH));
 
@@ -461,6 +463,7 @@ void DlgTrackInfo::slotCoverFound(
     if (pRequestor == this &&
             m_pLoadedTrack &&
             m_pLoadedTrack->getLocation() == coverInfo.trackLocation) {
+        qWarning() << " DlgTI coverFound";
         m_trackRecord.setCoverInfo(coverInfo);
         m_pWCoverArtLabel->setCoverArt(coverInfo, pixmap);
     }
@@ -476,7 +479,7 @@ void DlgTrackInfo::slotReloadCoverArt() {
 }
 
 void DlgTrackInfo::slotCoverInfoSelected(const CoverInfoRelative& coverInfo) {
-    qDebug() << "DlgTrackInfo::slotCoverInfoSelected" << coverInfo;
+    qWarning() << " DlgTI coverInfoSelected";
     VERIFY_OR_DEBUG_ASSERT(m_pLoadedTrack) {
         return;
     }

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -318,14 +318,13 @@ void DlgTrackInfo::updateFromTrack(const Track& track) {
 void DlgTrackInfo::replaceTrackRecord(
         mixxx::TrackRecord trackRecord,
         const QString& trackLocation) {
+    qWarning() << " Dlg replaceTrRec";
     // Signals are already blocked
     m_trackRecord = std::move(trackRecord);
 
     const auto coverInfo = CoverInfo(
             m_trackRecord.getCoverInfo(),
             trackLocation);
-    m_pWCoverArtLabel->setCoverArt(coverInfo, QPixmap());
-    // Executed concurrently
     CoverArtCache::requestCover(this, coverInfo);
 
     // Non-editable fields

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -262,9 +262,6 @@ void DlgTrackInfo::slotCancel() {
     reject();
 }
 
-void DlgTrackInfo::trackUpdated() {
-}
-
 void DlgTrackInfo::slotNextButton() {
     loadNextTrack();
 }
@@ -420,6 +417,7 @@ void DlgTrackInfo::loadTrackInternal(const TrackPointer& pTrack) {
 
     m_pLoadedTrack = pTrack;
 
+    // swap these two?
     updateFromTrack(*m_pLoadedTrack);
     m_pWCoverArtLabel->loadTrack(m_pLoadedTrack);
 

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -52,8 +52,6 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void slotApply();
     void slotCancel();
 
-    void trackUpdated();
-
     void slotBpmScale(mixxx::Beats::BpmScale bpmScale);
     void slotBpmClear();
     void slotBpmConstChanged(int state);

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -495,6 +495,7 @@ void Track::emitChangedSignalsForAllMetadata() {
     emit durationChanged();
     emit infoChanged();
     emit keyChanged();
+    emit coverArtUpdated();
 }
 
 bool Track::checkSourceSynchronized() const {

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -143,6 +143,7 @@ void WCoverArt::slotReset() {
 }
 
 void WCoverArt::slotTrackCoverArtUpdated() {
+    qWarning() << "   CoverArt cover update";
     if (m_loadedTrack) {
         CoverArtCache::requestTrackCover(this, m_loadedTrack);
     }
@@ -163,6 +164,7 @@ void WCoverArt::slotCoverFound(
         return;
     }
 
+    qWarning() << "    CoverArt cover found";
     m_lastRequestedCover = coverInfo;
     m_loadedCover = pixmap;
     m_loadedCoverScaled = scaledCoverArt(pixmap);
@@ -173,6 +175,7 @@ void WCoverArt::slotCoverFound(
 }
 
 void WCoverArt::slotLoadTrack(TrackPointer pTrack) {
+    qWarning() << "   CoverArt load track";
     if (m_loadedTrack) {
         disconnect(m_loadedTrack.get(),
                 &Track::coverArtUpdated,
@@ -188,6 +191,8 @@ void WCoverArt::slotLoadTrack(TrackPointer pTrack) {
                 &Track::coverArtUpdated,
                 this,
                 &WCoverArt::slotTrackCoverArtUpdated);
+    } else {
+        qWarning() << "            track == NULL";
     }
 
     if (!m_bEnable) {

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -265,14 +265,14 @@ void WCoverArt::mouseReleaseEvent(QMouseEvent* event) {
     }
 
     if (event->button() == Qt::LeftButton && m_loadedTrack &&
-            m_clickTimer.isActive()) { // init/close fullsize cover
+            m_clickTimer.isActive()) { // show/close fullsize cover
         if (m_pDlgFullSize->isVisible()) {
             m_pDlgFullSize->close();
         } else if (!m_loadedCover.isNull()) {
             // Only show the fullsize cover art dialog if the current track
-            // actually has a cover.  The `init` method already shows the
-            // window and then emits a signal to load the cover, so this can't
-            // be handled by the method itself.
+            // actually has a cover. showTrackCoverArt first shows the
+            // window and then emits a signal to load the cover, though hide()
+            // after pixmap.isNull() doesn't work unfortunately
             m_pDlgFullSize->showTrackCoverArt(m_loadedTrack);
         }
     } // else it was a long leftclick or a right click that's already been processed

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -156,17 +156,19 @@ void WCoverArt::slotCoverFound(
         bool coverInfoUpdated) {
     Q_UNUSED(requestedCacheKey);
     Q_UNUSED(coverInfoUpdated); // CoverArtCache has taken care, updating the Track.
-    if (!m_bEnable) {
+    if (!m_bEnable ||
+            pRequestor != this ||
+            !m_loadedTrack ||
+            m_loadedTrack->getLocation() != coverInfo.trackLocation) {
         return;
     }
 
-    if (pRequestor == this &&
-            m_loadedTrack &&
-            m_loadedTrack->getLocation() == coverInfo.trackLocation) {
-        m_lastRequestedCover = coverInfo;
-        m_loadedCover = pixmap;
-        m_loadedCoverScaled = scaledCoverArt(pixmap);
-        update();
+    m_lastRequestedCover = coverInfo;
+    m_loadedCover = pixmap;
+    m_loadedCoverScaled = scaledCoverArt(pixmap);
+    update();
+    if (m_pDlgFullSize->isVisible()) {
+        m_pDlgFullSize->showTrackCoverArt(m_loadedTrack);
     }
 }
 

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -273,7 +273,7 @@ void WCoverArt::mouseReleaseEvent(QMouseEvent* event) {
             // actually has a cover.  The `init` method already shows the
             // window and then emits a signal to load the cover, so this can't
             // be handled by the method itself.
-            m_pDlgFullSize->init(m_loadedTrack);
+            m_pDlgFullSize->showTrackCoverArt(m_loadedTrack);
         }
     } // else it was a long leftclick or a right click that's already been processed
 }

--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -50,6 +50,7 @@ WCoverArtLabel::~WCoverArtLabel() = default;
 
 void WCoverArtLabel::setCoverArt(const CoverInfo& coverInfo,
         const QPixmap& px) {
+    m_coverInfo = coverInfo;
     if (m_pCoverMenu) {
         m_pCoverMenu->setCoverArt(coverInfo);
     }
@@ -99,7 +100,7 @@ void WCoverArtLabel::mousePressEvent(QMouseEvent* event) {
             } else if (!m_pLoadedTrack && !m_Data.isNull()) {
                 m_pDlgFullSize->showFetchedCoverArt(m_Data);
             } else {
-                m_pDlgFullSize->showTrackCoverArt(m_pLoadedTrack);
+                m_pDlgFullSize->showTrackCoverArt(m_pLoadedTrack, m_coverInfo);
             }
         }
     }

--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -45,7 +45,7 @@ WCoverArtLabel::~WCoverArtLabel() = default;
 
 void WCoverArtLabel::setCoverArt(const CoverInfo& coverInfo,
         const QPixmap& px) {
-    if (m_pCoverMenu != nullptr) {
+    if (m_pCoverMenu) {
         m_pCoverMenu->setCoverArt(coverInfo);
     }
     if (px.isNull()) {
@@ -63,10 +63,11 @@ void WCoverArtLabel::setCoverArt(const CoverInfo& coverInfo,
     frameSize += QSize(2, 2); // margin
     setMinimumSize(frameSize);
     setMaximumSize(frameSize);
+
 }
 
 void WCoverArtLabel::slotCoverMenu(const QPoint& pos) {
-    if (m_pCoverMenu == nullptr) {
+    if (!m_pCoverMenu) {
         return;
     }
     m_pCoverMenu->popup(mapToGlobal(pos));
@@ -89,7 +90,7 @@ void WCoverArtLabel::loadData(const QByteArray& data) {
 }
 
 void WCoverArtLabel::mousePressEvent(QMouseEvent* event) {
-    if (m_pCoverMenu != nullptr && m_pCoverMenu->isVisible()) {
+    if (m_pCoverMenu && m_pCoverMenu->isVisible()) {
         return;
     }
 

--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -50,6 +50,10 @@ WCoverArtLabel::~WCoverArtLabel() = default;
 
 void WCoverArtLabel::setCoverArt(const CoverInfo& coverInfo,
         const QPixmap& px) {
+    qWarning() << "   CoverLabel setCoverArt, coverInfo:";
+    qWarning() << "       type:" << static_cast<int>(coverInfo.type)
+               << "hasTrLoc:" << bool(!coverInfo.trackLocation.isEmpty())
+               << "hasImg:" << coverInfo.hasImage();
     m_coverInfo = coverInfo;
     if (m_pCoverMenu) {
         m_pCoverMenu->setCoverArt(coverInfo);

--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -39,6 +39,11 @@ WCoverArtLabel::WCoverArtLabel(QWidget* parent, WCoverArtMenu* pCoverMenu)
     setFrameShape(QFrame::Box);
     setAlignment(Qt::AlignCenter);
     setPixmap(m_defaultCover);
+    setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(this,
+            &WCoverArtLabel::customContextMenuRequested,
+            this,
+            &WCoverArtLabel::slotCoverMenu);
 }
 
 WCoverArtLabel::~WCoverArtLabel() = default;
@@ -67,18 +72,9 @@ void WCoverArtLabel::setCoverArt(const CoverInfo& coverInfo,
 }
 
 void WCoverArtLabel::slotCoverMenu(const QPoint& pos) {
-    if (!m_pCoverMenu) {
-        return;
+    if (m_pCoverMenu) {
+        m_pCoverMenu->popup(mapToGlobal(pos));
     }
-    m_pCoverMenu->popup(mapToGlobal(pos));
-}
-
-void WCoverArtLabel::contextMenuEvent(QContextMenuEvent* event) {
-    if (m_pCoverMenu == nullptr) {
-        return;
-    }
-    event->accept();
-    m_pCoverMenu->popup(event->globalPos());
 }
 
 void WCoverArtLabel::loadTrack(TrackPointer pTrack) {

--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -97,9 +97,9 @@ void WCoverArtLabel::mousePressEvent(QMouseEvent* event) {
             if (m_loadedCover.isNull()) {
                 return;
             } else if (!m_pLoadedTrack && !m_Data.isNull()) {
-                m_pDlgFullSize->initFetchedCoverArt(m_Data);
+                m_pDlgFullSize->showFetchedCoverArt(m_Data);
             } else {
-                m_pDlgFullSize->init(m_pLoadedTrack);
+                m_pDlgFullSize->showTrackCoverArt(m_pLoadedTrack);
             }
         }
     }

--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -70,6 +70,12 @@ void WCoverArtLabel::setCoverArt(const CoverInfo& coverInfo,
     setMinimumSize(frameSize);
     setMaximumSize(frameSize);
 
+    // Update the full-size cover if it is visible.
+    // Used only if this belongs to DlgTrackInfo.
+    if (m_pDlgFullSize->isVisible() && m_pLoadedTrack) {
+        qWarning() << "              isVis > showTrackCover";
+        m_pDlgFullSize->showTrackCoverArt(m_pLoadedTrack, m_coverInfo);
+    }
 }
 
 void WCoverArtLabel::slotCoverMenu(const QPoint& pos) {

--- a/src/widget/wcoverartlabel.h
+++ b/src/widget/wcoverartlabel.h
@@ -6,6 +6,7 @@
 #include <QPixmap>
 #include <QWidget>
 
+#include "library/coverart.h"
 #include "track/track_decl.h"
 #include "util/parented_ptr.h"
 
@@ -43,4 +44,6 @@ class WCoverArtLabel : public QLabel {
     TrackPointer m_pLoadedTrack;
 
     QPixmap m_loadedCover;
+
+    CoverInfo m_coverInfo;
 };

--- a/src/widget/wcoverartlabel.h
+++ b/src/widget/wcoverartlabel.h
@@ -27,7 +27,6 @@ class WCoverArtLabel : public QLabel {
 
   protected:
     void mousePressEvent(QMouseEvent* event) override;
-    void contextMenuEvent(QContextMenuEvent* event) override;
 
   private slots:
       void slotCoverMenu(const QPoint& pos);

--- a/src/widget/wcoverartmenu.cpp
+++ b/src/widget/wcoverartmenu.cpp
@@ -127,7 +127,7 @@ void WCoverArtMenu::slotStarted() {
 }
 
 void WCoverArtMenu::slotCoverArtUpdated(const CoverInfoRelative& coverInfo) {
-    qDebug() << "WCoverArtMenu::slotChange emit" << coverInfo;
+    qDebug() << "WCoverArtMenu::slotCoverArtUpdated emit" << coverInfo;
     emit coverInfoSelected(coverInfo);
 }
 

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -298,12 +298,17 @@ void WSpinny::slotCoverFound(
         bool coverInfoUpdated) {
     Q_UNUSED(requestedCacheKey);
     Q_UNUSED(coverInfoUpdated); // CoverArtCache has taken care, updating the Track.
-    if (pRequestor == this &&
-            m_loadedTrack &&
-            m_loadedTrack->getLocation() == coverInfo.trackLocation) {
-        m_loadedCover = pixmap;
-        m_loadedCoverScaled = scaledCoverArt(pixmap);
-        update();
+    if (pRequestor != this ||
+            !m_loadedTrack ||
+            m_loadedTrack->getLocation() != coverInfo.trackLocation) {
+        return;
+    }
+
+    m_loadedCover = pixmap;
+    m_loadedCoverScaled = scaledCoverArt(pixmap);
+    update();
+    if (m_pDlgCoverArt->isVisible()) {
+        m_pDlgCoverArt->showTrackCoverArt(m_loadedTrack);
     }
 }
 

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -669,7 +669,7 @@ void WSpinny::mousePressEvent(QMouseEvent * e) {
         }
     } else {
         if (!m_loadedCover.isNull()) {
-            m_pDlgCoverArt->init(m_loadedTrack);
+            m_pDlgCoverArt->showTrackCoverArt(m_loadedTrack);
         } else if (m_bShowCover) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
             m_pCoverMenu->popup(e->globalPosition().toPoint());

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -87,7 +87,7 @@ WSpinny::WSpinny(
                 &WSpinny::slotCoverFound);
     }
 
-    if (m_pPlayer != nullptr) {
+    if (m_pPlayer) {
         connect(m_pPlayer, &BaseTrackPlayer::newTrackLoaded, this, &WSpinny::slotLoadTrack);
         connect(m_pPlayer, &BaseTrackPlayer::loadingTrack, this, &WSpinny::slotLoadingTrack);
         // just in case a track is already loaded
@@ -308,7 +308,7 @@ void WSpinny::slotCoverFound(
 }
 
 void WSpinny::slotCoverInfoSelected(const CoverInfoRelative& coverInfo) {
-    if (m_loadedTrack != nullptr) {
+    if (m_loadedTrack) {
         // Will trigger slotTrackCoverArtUpdated().
         m_loadedTrack->setCoverInfo(coverInfo);
     }
@@ -333,11 +333,11 @@ void WSpinny::render(VSyncThread* vSyncThread) {
     }
 
     auto* window = windowHandle();
-    if (window == nullptr || !window->isExposed()) {
+    if (!window || !window->isExposed()) {
         return;
     }
 
-    if (!m_pVisualPlayPos.isNull() && vSyncThread != nullptr) {
+    if (!m_pVisualPlayPos.isNull() && vSyncThread) {
         m_pVisualPlayPos->getPlaySlipAtNextVSync(
                 vSyncThread,
                 &m_dAngleCurrentPlaypos,
@@ -419,7 +419,7 @@ void WSpinny::swap() {
         return;
     }
     auto* window = windowHandle();
-    if (window == nullptr || !window->isExposed()) {
+    if (!window || !window->isExposed()) {
         return;
     }
     if (context() != QGLContext::currentContext()) {
@@ -547,7 +547,7 @@ void WSpinny::updateVinylControlSpeed(double rpm) {
 
 void WSpinny::updateVinylControlSignalEnabled(double enabled) {
 #ifdef __VINYLCONTROL__
-    if (m_pVCManager == nullptr) {
+    if (!m_pVCManager) {
         return;
     }
     m_bSignalActive = enabled != 0;
@@ -623,7 +623,7 @@ void WSpinny::mouseMoveEvent(QMouseEvent * e) {
 }
 
 void WSpinny::mousePressEvent(QMouseEvent * e) {
-    if (m_loadedTrack == nullptr) {
+    if (!m_loadedTrack) {
         return;
     }
 
@@ -670,7 +670,7 @@ void WSpinny::mousePressEvent(QMouseEvent * e) {
     } else {
         if (!m_loadedCover.isNull()) {
             m_pDlgCoverArt->init(m_loadedTrack);
-        } else if (!m_pDlgCoverArt->isVisible() && m_bShowCover) {
+        } else if (m_bShowCover) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
             m_pCoverMenu->popup(e->globalPosition().toPoint());
 #else

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -42,7 +42,6 @@
 #include "util/widgethelper.h"
 #include "widget/findonwebmenufactory.h"
 #include "widget/wcolorpickeraction.h"
-#include "widget/wcoverartlabel.h"
 #include "widget/wcoverartmenu.h"
 #include "widget/wfindonwebmenu.h"
 #include "widget/wsearchrelatedtracksmenu.h"


### PR DESCRIPTION
These are some UX improvements for the full-size cover art windows, based on @fatihemreyildiz's #4851 
starting with https://github.com/mixxxdj/mixxx/pull/11109/commits/addb8d56653e361dbab5747f4ea2eeeb19770315

* full-size cover in Track Properties dialog: changes are applied only when clicking Apply in Track Properties
* always update visible full-size covers when parent cover label changed
* in decks / library: keep size and position of full-size cover if a new track (with cover image) is loaded / selected

___
Closes #9538
WIP / double-check #10815 
fixes #10816 in main. need to backport the fix to 2.3.3 for a consistent UX
___
Notes for testing:

Full-size cover in decks (cover & spinny cover), library and Track Properties dialog:
* image is updated in place (fit into the existing window) when a new track is loaded or selected via Next/Previous, or when a new image is assigned via the cover menu (both from full-size, WCoverArt and WCoverArtLabel widgets)
* (new/fix) cover widget next to tracks table is updated if that track's cover is changed in Track Properties
* full-size is closed if new track has no cover or if the cover is cleared via the menu

In Track Properties dialog:
* cleared, reset or new cover selected via cover menu (full-size or label in dialog) is applied only when pressing Apply

In Tag Fetcher dialog:
* full-size is closed when a new MusicBrainz result is selected