### PR TITLE
Use the runtime audio buffer size rather than the requested size in PortAudio backend

### DIFF
--- a/src/soundio/sounddevice.cpp
+++ b/src/soundio/sounddevice.cpp
@@ -3,6 +3,7 @@
 #include <QtDebug>
 #include <cstring> // for memcpy and strcmp
 
+#include "control/controlobject.h"
 #include "soundio/soundmanager.h"
 #include "soundio/soundmanagerutil.h"
 #include "util/debug.h"
@@ -84,6 +85,14 @@ void SoundDevice::clearInputs() {
 
 bool SoundDevice::operator==(const SoundDevice &other) const {
     return m_deviceId == other.getDeviceId();
+}
+
+void SoundDevice::maybeUpdateBufferSize(double bufferSizeMs) {
+    if (bufferSizeMs != m_lastBufferSizeMs) {
+        ControlObject::set(ConfigKey("[Master]", "audio_buffer_size"), bufferSizeMs);
+
+        m_lastBufferSizeMs = bufferSizeMs;
+    }
 }
 
 void SoundDevice::composeOutputBuffer(CSAMPLE* outputBuffer,

--- a/src/soundio/sounddevice.h
+++ b/src/soundio/sounddevice.h
@@ -57,6 +57,13 @@ class SoundDevice {
     bool operator==(const QString &other) const;
 
   protected:
+    /**
+     * Broadcast the buffer size in milliseconds to the GUI if it has changed.
+     * This affects the waveform visualizers and a couple other components. This
+     * should be called at the start of a process callback.
+     */
+    void maybeUpdateBufferSize(double bufferSizeMs);
+
     void composeOutputBuffer(CSAMPLE* outputBuffer,
                              const SINT iFramesPerBuffer,
                              const SINT readOffset,
@@ -92,6 +99,13 @@ class SoundDevice {
     SINT m_framesPerBuffer;
     QList<AudioOutputBuffer> m_audioOutputs;
     QList<AudioInputBuffer> m_audioInputs;
+
+  private:
+    /**
+     * The last buffer size that was sent to the `[Master],audio_buffer_size`
+     * control object. This is set in `maybeUpdateBufferSize()`.
+     */
+    double m_lastBufferSizeMs = 0;
 };
 
 typedef QSharedPointer<SoundDevice> SoundDevicePointer;

--- a/src/soundio/sounddevice.h
+++ b/src/soundio/sounddevice.h
@@ -36,8 +36,8 @@ class SoundDevice {
     virtual SoundDeviceError open(bool isClkRefDevice, int syncBuffers) = 0;
     virtual bool isOpen() const = 0;
     virtual SoundDeviceError close() = 0;
-    virtual void readProcess() = 0;
-    virtual void writeProcess() = 0;
+    virtual void readProcess(SINT framesPerBuffer) = 0;
+    virtual void writeProcess(SINT framesPerBuffer) = 0;
     virtual QString getError() const = 0;
     virtual unsigned int getDefaultSampleRate() const = 0;
     int getNumOutputChannels() const;
@@ -84,6 +84,11 @@ class SoundDevice {
     double m_dSampleRate;
     // The name of the audio API used by this device.
     QString m_hostAPI;
+    // The **configured** number of frames per buffer. We'll tell PortAudio we
+    // want this many frames in a buffer, but PortAudio may still give us have a
+    // differently sized buffers. As such this value should only be used for
+    // configuring the audio devices. The actual runtime buffer size should be
+    // used for any computations working with audio.
     SINT m_framesPerBuffer;
     QList<AudioOutputBuffer> m_audioOutputs;
     QList<AudioInputBuffer> m_audioInputs;

--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -91,8 +91,10 @@ SoundDeviceError SoundDeviceNetwork::open(bool isClkRefDevice, int syncBuffers) 
         ControlObject::set(ConfigKey("[Master]", "latency"),
                 requestedBufferTime.toDoubleMillis());
         ControlObject::set(ConfigKey("[Master]", "samplerate"), m_dSampleRate);
-        ControlObject::set(ConfigKey("[Master]", "audio_buffer_size"),
-                requestedBufferTime.toDoubleMillis());
+        // The process callback has a fixed buffer size for network streams.
+        // We'll still use this convenience function for consistency with the
+        // PortAudio backend.
+        maybeUpdateBufferSize(requestedBufferTime.toDoubleMillis());
 
         // Network stream was just started above so we have to wait until
         // we can pass one chunk.

--- a/src/soundio/sounddevicenetwork.h
+++ b/src/soundio/sounddevicenetwork.h
@@ -32,19 +32,21 @@ class SoundDeviceNetwork : public SoundDevice {
     SoundDeviceError open(bool isClkRefDevice, int syncBuffers) override;
     bool isOpen() const override;
     SoundDeviceError close() override;
-    void readProcess() override;
-    void writeProcess() override;
+    void readProcess(SINT framesPerBuffer) override;
+    void writeProcess(SINT framesPerBuffer) override;
     QString getError() const override;
 
     unsigned int getDefaultSampleRate() const override {
         return 44100;
     }
 
+    // NOTE: This does not take a frames per buffer argument because that is
+    //       always equal to the configured buffer size for network streams
     void callbackProcessClkRef();
 
   private:
-    void updateCallbackEntryToDacTime();
-    void updateAudioLatencyUsage();
+    void updateCallbackEntryToDacTime(SINT framesPerBuffer);
+    void updateAudioLatencyUsage(SINT framesPerBuffer);
 
     void workerWriteProcess(NetworkOutputStreamWorkerPtr pWorker,
             int outChunkSize, int readAvailable,
@@ -61,10 +63,12 @@ class SoundDeviceNetwork : public SoundDevice {
 
     std::unique_ptr<ControlProxy> m_pMasterAudioLatencyUsage;
     mixxx::Duration m_timeInAudioCallback;
-    mixxx::Duration m_audioBufferTime;
     int m_framesSinceAudioLatencyUsageUpdate;
     std::unique_ptr<SoundDeviceNetworkThread> m_pThread;
     bool m_denormals;
+    /**
+     * The deadline for the next buffer, in microseconds since the Unix epoch.
+     */
     qint64 m_targetTime;
     PerformanceTimer m_clkRefTimer;
 };

--- a/src/soundio/sounddevicenotfound.h
+++ b/src/soundio/sounddevicenotfound.h
@@ -29,8 +29,8 @@ class SoundDeviceNotFound : public SoundDevice {
     SoundDeviceError close() override {
         return SOUNDDEVICE_ERROR_ERR;
     };
-    void readProcess() override { };
-    void writeProcess() override { };
+    void readProcess(SINT /*framesPerbuffer*/) override{};
+    void writeProcess(SINT /*framesPerbuffer*/) override{};
     QString getError() const override{ return QObject::tr("Device not found"); };
 
     unsigned int getDefaultSampleRate() const override {

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -438,6 +438,15 @@ void SoundDevicePortAudio::readProcess(SINT framesPerBuffer) {
     PaStream* pStream = m_pStream;
     if (pStream && m_inputParams.channelCount && m_inputFifo) {
         int inChunkSize = framesPerBuffer * m_inputParams.channelCount;
+
+        // TODO: This should not occur, but if it does it will result in
+        //       constant xruns. Should we just roll with it and reallocate the
+        //       FIFO buffer right here and now?
+        if (inChunkSize > m_inputFifo->size()) {
+            qWarning() << "Input FIFO has size " << m_inputFifo->size()
+                       << ", but we want to read " << inChunkSize << " samples";
+        }
+
         if (m_syncBuffers == 0) { // "Experimental (no delay)"
 
             if (m_inputFifo->readAvailable() == 0) {
@@ -570,6 +579,15 @@ void SoundDevicePortAudio::writeProcess(SINT framesPerBuffer) {
 
     if (pStream && m_outputParams.channelCount && m_outputFifo) {
         int outChunkSize = framesPerBuffer * m_outputParams.channelCount;
+
+        // TODO: This should not occur, but if it does it will result in
+        //       constant xruns. Should we just roll with it and reallocate the
+        //       FIFO buffer right here and now?
+        if (outChunkSize > m_outputFifo->size()) {
+            qWarning() << "Output FIFO has size " << m_inputFifo->size()
+                       << ", but we want to read " << outChunkSize << " samples";
+        }
+
         int writeAvailable = m_outputFifo->writeAvailable();
         int writeCount = outChunkSize;
         if (outChunkSize > writeAvailable) {

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -64,8 +64,8 @@ class SoundDevicePortAudio : public SoundDevice {
     PaStreamParameters m_outputParams;
     // Description of the input stream coming from the soundcard.
     PaStreamParameters m_inputParams;
-    FIFO<CSAMPLE>* m_outputFifo;
-    FIFO<CSAMPLE>* m_inputFifo;
+    std::unique_ptr<FIFO<CSAMPLE>> m_outputFifo;
+    std::unique_ptr<FIFO<CSAMPLE>> m_inputFifo;
     bool m_outputDrift;
     bool m_inputDrift;
 

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -23,8 +23,8 @@ class SoundDevicePortAudio : public SoundDevice {
     SoundDeviceError open(bool isClkRefDevice, int syncBuffers) override;
     bool isOpen() const override;
     SoundDeviceError close() override;
-    void readProcess() override;
-    void writeProcess() override;
+    void readProcess(SINT framesPerBuffer) override;
+    void writeProcess(SINT framesPerBuffer) override;
     QString getError() const override;
 
     // This callback function gets called every time the sound device runs out of
@@ -50,7 +50,8 @@ class SoundDevicePortAudio : public SoundDevice {
     }
 
   private:
-    void updateCallbackEntryToDacTime(const PaStreamCallbackTimeInfo* timeInfo);
+    void updateCallbackEntryToDacTime(const SINT framesPerBuffer,
+            const PaStreamCallbackTimeInfo* timeInfo);
     void updateAudioLatencyUsage(const SINT framesPerBuffer);
 
     // PortAudio stream for this device.

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -609,18 +609,18 @@ void SoundManager::pushInputBuffers(const QList<AudioInputBuffer>& inputs,
     }
 }
 
-void SoundManager::writeProcess() const {
+void SoundManager::writeProcess(SINT framesPerBuffer) const {
     for (const auto& pDevice: m_devices) {
         if (pDevice) {
-            pDevice->writeProcess();
+            pDevice->writeProcess(framesPerBuffer);
         }
     }
 }
 
-void SoundManager::readProcess() const {
+void SoundManager::readProcess(SINT framesPerBuffer) const {
     for (const auto& pDevice: m_devices) {
         if (pDevice) {
-            pDevice->readProcess();
+            pDevice->readProcess(framesPerBuffer);
         }
     }
 }
@@ -689,14 +689,14 @@ int SoundManager::getConfiguredDeckCount() const {
     return m_config.getDeckCount();
 }
 
-void SoundManager::processUnderflowHappened() {
+void SoundManager::processUnderflowHappened(SINT framesPerBuffer) {
     if (m_underflowUpdateCount == 0) {
         if (atomicLoadRelaxed(m_underflowHappened)) {
             m_pMasterAudioLatencyOverload->set(1.0);
             m_pMasterAudioLatencyOverloadCount->set(
                     m_pMasterAudioLatencyOverloadCount->get() + 1);
-            m_underflowUpdateCount = CPU_OVERLOAD_DURATION * m_config.getSampleRate()
-                    / m_config.getFramesPerBuffer() / 1000;
+            m_underflowUpdateCount = CPU_OVERLOAD_DURATION *
+                    m_config.getSampleRate() / framesPerBuffer / 1000;
 
             m_underflowHappened = 0; // resetting here is not thread safe,
                                      // but that is OK, because we count only

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -85,9 +85,8 @@ class SoundManager : public QObject {
     void pushInputBuffers(const QList<AudioInputBuffer>& inputs,
                           const SINT iFramesPerBuffer);
 
-
-    void writeProcess() const;
-    void readProcess() const;
+    void writeProcess(SINT framesPerBuffer) const;
+    void readProcess(SINT framesPerBuffer) const;
 
     void registerOutput(const AudioOutput& output, AudioSource* src);
     void registerInput(const AudioInput& input, AudioDestination* dest);
@@ -107,7 +106,7 @@ class SoundManager : public QObject {
         }
     }
 
-    void processUnderflowHappened();
+    void processUnderflowHappened(SINT framesPerBuffer);
 
   signals:
     void devicesUpdated(); // emitted when pointers to SoundDevices go stale

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -410,12 +410,6 @@ unsigned int SoundManagerConfig::getFramesPerBuffer() const {
     return framesPerBuffer;
 }
 
-// FIXME: This is incorrect when using JACK as the sound API!
-// m_audioBufferSizeIndex does not reflect JACK's buffer size.
-double SoundManagerConfig::getProcessingLatency() const {
-    return static_cast<double>(getFramesPerBuffer()) / m_sampleRate * 1000.0;
-}
-
 
 // Set the audio buffer size
 // @warning This IS NOT a value in milliseconds, or a number of frames per

--- a/src/soundio/soundmanagerconfig.h
+++ b/src/soundio/soundmanagerconfig.h
@@ -52,8 +52,6 @@ public:
 
     unsigned int getAudioBufferSizeIndex() const;
     unsigned int getFramesPerBuffer() const;
-    // Returns the processing latency in milliseconds
-    double getProcessingLatency() const;
     void setAudioBufferSizeIndex(unsigned int latency);
     unsigned int getSyncBuffers() const;
     void setSyncBuffers(unsigned int sampleRate);

--- a/src/util/fifo.h
+++ b/src/util/fifo.h
@@ -10,19 +10,22 @@ class FIFO {
   public:
     explicit FIFO(int size)
             : m_data(NULL) {
-        size = roundUpToPowerOf2(size);
+        m_size = roundUpToPowerOf2(size);
         // If we can't represent the next higher power of 2 then bail.
-        if (size < 0) {
+        if (m_size < 0) {
             return;
         }
-        m_data = new DataType[size];
+        m_data = new DataType[m_size];
         PaUtil_InitializeRingBuffer(&m_ringBuffer,
                 static_cast<ring_buffer_size_t>(sizeof(DataType)),
-                static_cast<ring_buffer_size_t>(size),
+                static_cast<ring_buffer_size_t>(m_size),
                 m_data);
     }
     virtual ~FIFO() {
         delete [] m_data;
+    }
+    int size() const {
+        return m_size;
     }
     int readAvailable() const {
         return PaUtil_GetRingBufferReadAvailable(&m_ringBuffer);
@@ -66,6 +69,7 @@ class FIFO {
     }
 
   private:
+    int m_size;
     DataType* m_data;
     PaUtilRingBuffer m_ringBuffer;
     DISALLOW_COPY_AND_ASSIGN(FIFO<DataType>);


### PR DESCRIPTION
This is a followup to #11092, which allowed Mixxx to use the JACK server's configured period size instead of still using the value from the grayed out latency field in the settings. The old behavior potentially introduced unnecessary buffering and made controls less responsive. @daschuer noticed that when using a very large buffer sizes in combination with a small configured latency the waveform display was jerking all over the place. As part of fixing that, this PR gets rid of all uses of `m_framesPerBuffer` and values derived from that in the PortAudio process calls and all functions called from there. The network streaming backend always uses the same size so while it has been changed similarly for consistency's sake, that still ends up using `m_framesPerBuffer` for the buffer size. The waveform display and other GUI elements that rely on the buffer size now also correctly respond to buffer size changes and thus work as expected in combination with the change from #11092 regardless of the JACK server's settings.

One part where I wasn't sure what to do was with the input and output FIFOs in the PortAudio backend. Those do not handle runtime buffer sizes that are larger than the configured sizes. They are not used for JACK and if this has never caused issues with earlier Mixxx versions, then that means that the buffer size will always be equal to `m_framesPerBuffer`, but I still added another very visible warning just in case. Another option would be to adapt to new buffer size and just reallocate the FIFOs right there and then. That would at worst introduce an xrun when starting Mixxx, but I have not yet done so since this situation doesn't seem to come up in practice.

I also targeted the 2.3 branch to be in line with the other PR. Let me know if you want me to rebase either or both PRs onto main instead.