### PR TITLE
Add missing virtual destructor for AudioSource and AudioDestination

### DIFF
--- a/src/soundio/soundmanagerutil.h
+++ b/src/soundio/soundmanagerutil.h
@@ -163,46 +163,50 @@ class AudioInputBuffer : public AudioInput {
 
 
 class AudioSource {
-public:
-  virtual const CSAMPLE* buffer(const AudioOutput& output) const = 0;
+  public:
+    virtual ~AudioSource() = default;
 
-  // This is called by SoundManager whenever an output is connected for this
-  // source. When this is called it is guaranteed that no callback is
-  // active.
-  virtual void onOutputConnected(const AudioOutput& output) {
-      Q_UNUSED(output);
-  };
+    virtual const CSAMPLE* buffer(const AudioOutput& output) const = 0;
+
+    // This is called by SoundManager whenever an output is connected for this
+    // source. When this is called it is guaranteed that no callback is
+    // active.
+    virtual void onOutputConnected(const AudioOutput& output) {
+        Q_UNUSED(output);
+    };
 
     // This is called by SoundManager whenever an output is disconnected for
     // this source. When this is called it is guaranteed that no callback is
     // active.
-  virtual void onOutputDisconnected(const AudioOutput& output) {
-      Q_UNUSED(output);
-  };
+    virtual void onOutputDisconnected(const AudioOutput& output) {
+        Q_UNUSED(output);
+    };
 };
 
 class AudioDestination {
-public:
+  public:
+    virtual ~AudioDestination() = default;
+
     // This is called by SoundManager whenever there are new samples from the
     // configured input to be processed. This is run in the clock reference
     // callback thread
-  virtual void receiveBuffer(const AudioInput& input,
-          const CSAMPLE* pBuffer,
-          unsigned int iNumFrames) = 0;
+    virtual void receiveBuffer(const AudioInput& input,
+            const CSAMPLE* pBuffer,
+            unsigned int iNumFrames) = 0;
 
-  // This is called by SoundManager whenever an input is configured for this
-  // destination. When this is called it is guaranteed that no callback is
-  // active.
-  virtual void onInputConfigured(const AudioInput& input) {
-      Q_UNUSED(input);
-  };
+    // This is called by SoundManager whenever an input is configured for this
+    // destination. When this is called it is guaranteed that no callback is
+    // active.
+    virtual void onInputConfigured(const AudioInput& input) {
+        Q_UNUSED(input);
+    };
 
     // This is called by SoundManager whenever an input is unconfigured for this
     // destination. When this is called it is guaranteed that no callback is
     // active.
-  virtual void onInputUnconfigured(const AudioInput& input) {
-      Q_UNUSED(input);
-  };
+    virtual void onInputUnconfigured(const AudioInput& input) {
+        Q_UNUSED(input);
+    };
 };
 
 typedef AudioPath::AudioPathType AudioPathType;


### PR DESCRIPTION
This fixes a warning that the class has virtual functions but not a virtual destructor. 
Not really necessary in this case but maybe later.   