### PR TITLE
Add missing Rubber Band padding, preventing it from eating the initial transient

### DIFF
--- a/src/engine/bufferscalers/enginebufferscalerubberband.cpp
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.cpp
@@ -26,7 +26,7 @@ constexpr size_t kRubberBandBlockSize = 256;
 EngineBufferScaleRubberBand::EngineBufferScaleRubberBand(
         ReadAheadManager* pReadAheadManager)
         : m_pReadAheadManager(pReadAheadManager),
-          m_buffers{std::vector<CSAMPLE>(MAX_BUFFER_LEN), std::vector<CSAMPLE>(MAX_BUFFER_LEN)},
+          m_buffers{mixxx::SampleBuffer(MAX_BUFFER_LEN), mixxx::SampleBuffer(MAX_BUFFER_LEN)},
           m_bufferPtrs{m_buffers[0].data(), m_buffers[1].data()},
           m_interleavedReadBuffer(MAX_BUFFER_LEN),
           m_bBackwards(false),
@@ -297,8 +297,8 @@ void EngineBufferScaleRubberBand::reset() {
     // https://github.com/breakfastquay/rubberband/blob/c5f99d5ff2cba2f4f1def6c38c7843bbb9ac7a78/main/main.cpp#L652
     size_t remaining_padding = m_pRubberBand->getLatency();
 #endif
-    std::fill_n(m_buffers[0].begin(), kRubberBandBlockSize, 0.0f);
-    std::fill_n(m_buffers[1].begin(), kRubberBandBlockSize, 0.0f);
+    std::fill_n(m_buffers[0].span().begin(), kRubberBandBlockSize, 0.0f);
+    std::fill_n(m_buffers[1].span().begin(), kRubberBandBlockSize, 0.0f);
     while (remaining_padding > 0) {
         const size_t pad_samples = std::min<size_t>(remaining_padding, kRubberBandBlockSize);
         m_pRubberBand->process(m_bufferPtrs.data(), pad_samples, false);

--- a/src/engine/bufferscalers/enginebufferscalerubberband.cpp
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.cpp
@@ -157,7 +157,7 @@ SINT EngineBufferScaleRubberBand::retrieveAndDeinterleave(
         frame_offset += drop_num_frames;
     }
 
-    DEBUG_ASSERT(received_frames <= static_cast<ssize_t>(m_buffers[0].size()));
+    DEBUG_ASSERT((received_frames + frame_offset) <= static_cast<ssize_t>(m_buffers[0].size()));
     SampleUtil::interleaveBuffer(pBuffer,
             m_buffers[0].data() + frame_offset,
             m_buffers[1].data() + frame_offset,

--- a/src/engine/bufferscalers/enginebufferscalerubberband.cpp
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.cpp
@@ -129,7 +129,10 @@ SINT EngineBufferScaleRubberBand::retrieveAndDeinterleave(
         CSAMPLE* pBuffer,
         SINT frames) {
     const SINT frames_available = m_pRubberBand->available();
-    const SINT frames_to_read = math_min(frames_available, frames);
+    // NOTE: If we still need to throw away padding, then we can also
+    //       immediately read those frames in addition to the frames we actually
+    //       need for the output
+    const SINT frames_to_read = math_min(frames_available, frames + m_remainingPaddingInOutput);
     DEBUG_ASSERT(frames_to_read <= m_buffers[0].size());
     SINT received_frames = static_cast<SINT>(m_pRubberBand->retrieve(
             m_bufferPtrs.data(), frames_to_read));

--- a/src/engine/bufferscalers/enginebufferscalerubberband.cpp
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.cpp
@@ -306,6 +306,9 @@ void EngineBufferScaleRubberBand::reset() {
     // need to run some silent samples through the time stretching engine first
     // before using it. Otherwise it will eat add a short fade-in, destroying
     // the initial transient.
+    //
+    // See https://github.com/mixxxdj/mixxx/pull/11120#discussion_r1050011104
+    // for more information.
     size_t remaining_padding = getPreferredStartPad();
     const size_t block_size = std::min<size_t>(remaining_padding, m_buffers[0].size());
     std::fill_n(m_buffers[0].span().begin(), block_size, 0.0f);

--- a/src/engine/bufferscalers/enginebufferscalerubberband.cpp
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.cpp
@@ -19,7 +19,7 @@ namespace {
 // TODO (XXX): this should be removed. It is only needed to work around
 // a Rubberband 1.3 bug.
 // This is the default increment from RubberBand 1.8.1.
-size_t kRubberBandBlockSize = 256;
+constexpr size_t kRubberBandBlockSize = 256;
 
 #define RUBBERBANDV3 (RUBBERBAND_API_MAJOR_VERSION >= 2 && RUBBERBAND_API_MINOR_VERSION >= 7)
 

--- a/src/engine/bufferscalers/enginebufferscalerubberband.cpp
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.cpp
@@ -290,7 +290,13 @@ void EngineBufferScaleRubberBand::reset() {
     // need to run some silent samples through the time stretching engine first
     // before using it. Otherwise it will eat add a short fade-in, destroying
     // the initial transient.
+#if RUBBERBANDV3
     size_t remaining_padding = m_pRubberBand->getPreferredStartPad();
+#else
+    // This _should_ be equal to the latency in older Rubber Band versions:
+    // https://github.com/breakfastquay/rubberband/blob/c5f99d5ff2cba2f4f1def6c38c7843bbb9ac7a78/main/main.cpp#L652
+    size_t remaining_padding = m_pRubberBand->getLatency();
+#endif
     std::fill_n(m_buffers[0].begin(), kRubberBandBlockSize, 0.0f);
     std::fill_n(m_buffers[1].begin(), kRubberBandBlockSize, 0.0f);
     while (remaining_padding > 0) {
@@ -300,7 +306,11 @@ void EngineBufferScaleRubberBand::reset() {
         remaining_padding -= pad_samples;
     }
 
+#if RUBBERBANDV3
     size_t padding_to_drop = m_pRubberBand->getStartDelay();
+#else
+    size_t padding_to_drop = m_pRubberBand->getLatency();
+#endif
     while (padding_to_drop > 0) {
         const size_t drop_samples = std::min<size_t>(padding_to_drop, kRubberBandBlockSize);
         m_pRubberBand->retrieve(m_bufferPtrs.data(), drop_samples);

--- a/src/engine/bufferscalers/enginebufferscalerubberband.cpp
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.cpp
@@ -130,6 +130,7 @@ SINT EngineBufferScaleRubberBand::retrieveAndDeinterleave(
         SINT frames) {
     const SINT frames_available = m_pRubberBand->available();
     const SINT frames_to_read = math_min(frames_available, frames);
+    DEBUG_ASSERT(frames_to_read <= m_buffers[0].size());
     SINT received_frames = static_cast<SINT>(m_pRubberBand->retrieve(
             m_bufferPtrs.data(), frames_to_read));
     SINT frame_offset = 0;
@@ -145,7 +146,7 @@ SINT EngineBufferScaleRubberBand::retrieveAndDeinterleave(
         frame_offset += drop_num_frames;
     }
 
-    DEBUG_ASSERT((received_frames + frame_offset) <= static_cast<ssize_t>(m_buffers[0].size()));
+    DEBUG_ASSERT(received_frames <= frames);
     SampleUtil::interleaveBuffer(pBuffer,
             m_buffers[0].data() + frame_offset,
             m_buffers[1].data() + frame_offset,

--- a/src/engine/bufferscalers/enginebufferscalerubberband.h
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.h
@@ -1,14 +1,12 @@
 #pragma once
 
+#include <rubberband/RubberBandStretcher.h>
+
 #include <array>
 #include <vector>
 
 #include "engine/bufferscalers/enginebufferscale.h"
 #include "util/memory.h"
-
-namespace RubberBand {
-class RubberBandStretcher;
-}  // namespace RubberBand
 
 class ReadAheadManager;
 
@@ -47,6 +45,10 @@ class EngineBufferScaleRubberBand : public EngineBufferScale {
     void onSampleRateChanged() override;
 
     int runningEngineVersion();
+    /// Reset the rubberband instance and run the prerequisite amount of padding
+    /// through it. This should be used instead of calling
+    /// `m_pRubberBand->reset()` directly.
+    void reset();
 
     void deinterleaveAndProcess(const CSAMPLE* pBuffer, SINT frames, bool flush);
     SINT retrieveAndDeinterleave(CSAMPLE* pBuffer, SINT frames);

--- a/src/engine/bufferscalers/enginebufferscalerubberband.h
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <array>
+#include <vector>
+
 #include "engine/bufferscalers/enginebufferscale.h"
 #include "util/memory.h"
 
@@ -15,7 +18,12 @@ class EngineBufferScaleRubberBand : public EngineBufferScale {
   public:
     explicit EngineBufferScaleRubberBand(
             ReadAheadManager* pReadAheadManager);
-    ~EngineBufferScaleRubberBand() override;
+
+    EngineBufferScaleRubberBand(const EngineBufferScaleRubberBand&) = delete;
+    EngineBufferScaleRubberBand& operator=(const EngineBufferScaleRubberBand&) = delete;
+
+    EngineBufferScaleRubberBand(EngineBufferScaleRubberBand&&) = delete;
+    EngineBufferScaleRubberBand& operator=(EngineBufferScaleRubberBand&&) = delete;
 
     // Let EngineBuffer know if engine v3 is available
     static bool isEngineFinerAvailable();
@@ -48,8 +56,17 @@ class EngineBufferScaleRubberBand : public EngineBufferScale {
 
     std::unique_ptr<RubberBand::RubberBandStretcher> m_pRubberBand;
 
-    CSAMPLE* m_retrieve_buffer[2];
-    CSAMPLE* m_buffer_back;
+    /// The audio buffers samples used to send audio to Rubber Band and to
+    /// receive processed audio from Rubber Band. This is needed because Mixxx
+    /// uses interleaved buffers in most other places.
+    std::array<std::vector<CSAMPLE>, 2> m_buffers;
+    /// These point to the buffers in `m_buffers`. They can be defined here
+    /// since this object cannot be moved or copied.
+    std::array<float*, 2> m_bufferPtrs;
+
+    /// Contains interleaved samples read from `m_pReadAheadManager`. These need
+    /// to be deinterleaved before they can be passed to Rubber Band.
+    std::vector<CSAMPLE> m_interleavedReadBuffer;
 
     // Holds the playback direction
     bool m_bBackwards;

--- a/src/engine/bufferscalers/enginebufferscalerubberband.h
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.h
@@ -78,6 +78,10 @@ class EngineBufferScaleRubberBand final : public EngineBufferScale {
 
     // Holds the playback direction
     bool m_bBackwards;
+    /// The amount of silence padding that still needs to be dropped from the
+    /// retrieve samples in `retrieveAndDeinterleave()`. See the `reset()`
+    /// function for an explanation.
+    SINT m_remainingPaddingInOutput = 0;
 
     bool m_useEngineFiner;
 };

--- a/src/engine/bufferscalers/enginebufferscalerubberband.h
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.h
@@ -3,10 +3,10 @@
 #include <rubberband/RubberBandStretcher.h>
 
 #include <array>
-#include <vector>
 
 #include "engine/bufferscalers/enginebufferscale.h"
 #include "util/memory.h"
+#include "util/samplebuffer.h"
 
 class ReadAheadManager;
 
@@ -61,14 +61,14 @@ class EngineBufferScaleRubberBand final : public EngineBufferScale {
     /// The audio buffers samples used to send audio to Rubber Band and to
     /// receive processed audio from Rubber Band. This is needed because Mixxx
     /// uses interleaved buffers in most other places.
-    std::array<std::vector<CSAMPLE>, 2> m_buffers;
+    std::array<mixxx::SampleBuffer, 2> m_buffers;
     /// These point to the buffers in `m_buffers`. They can be defined here
     /// since this object cannot be moved or copied.
     std::array<float*, 2> m_bufferPtrs;
 
     /// Contains interleaved samples read from `m_pReadAheadManager`. These need
     /// to be deinterleaved before they can be passed to Rubber Band.
-    std::vector<CSAMPLE> m_interleavedReadBuffer;
+    mixxx::SampleBuffer m_interleavedReadBuffer;
 
     // Holds the playback direction
     bool m_bBackwards;

--- a/src/engine/bufferscalers/enginebufferscalerubberband.h
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.h
@@ -11,7 +11,7 @@
 class ReadAheadManager;
 
 // Uses librubberband to scale audio.  This class is not thread safe.
-class EngineBufferScaleRubberBand : public EngineBufferScale {
+class EngineBufferScaleRubberBand final : public EngineBufferScale {
     Q_OBJECT
   public:
     explicit EngineBufferScaleRubberBand(

--- a/src/engine/bufferscalers/enginebufferscalerubberband.h
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.h
@@ -44,6 +44,12 @@ class EngineBufferScaleRubberBand final : public EngineBufferScale {
     // Reset RubberBand library with new audio signal
     void onSampleRateChanged() override;
 
+    /// Calls `m_pRubberBand->getPreferredStartPad()`, with backwards
+    /// compatibility for older librubberband versions.
+    size_t getPreferredStartPad() const;
+    /// Calls `m_pRubberBand->getStartDelay()`, with backwards compatibility for
+    /// older librubberband versions.
+    size_t getStartDelay() const;
     int runningEngineVersion();
     /// Reset the rubberband instance and run the prerequisite amount of padding
     /// through it. This should be used instead of calling


### PR DESCRIPTION
This fixes #11093. See https://github.com/mixxxdj/mixxx/issues/11093#issuecomment-1340210394 for more information on what's going on here. In short, both the [docs](https://breakfastquay.com/rubberband/code-doc/) and the [faq](https://breakfastquay.com/rubberband/integration.html#faqs) mention that you should add the requested amount of padding (and then drop that padding again) after initializing or resetting the time stretching engine. If you don't do this, then any initial transient will be replaced by a short fade in. With the r3/finer algorithm this is 2048 samples, which becomes very audible. This PR adds the required padding routine, fixing the problem See the linked issue for example videos of how this behaved before and after the change. I also replaced the manual memory management with STL data structures while I was at it and fixed some memory safety issues by explicitly deleting the copy and move constructors/assignment operators. Previously invoking these by accident would result in double frees and use after frees.