### PR TITLE
JACK buffer size fix.

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -560,7 +560,7 @@ void EngineBuffer::ejectTrack() {
     m_pTrackLoaded->forceSet(0);
     m_pTrackSamples->set(0);
     m_pTrackSampleRate->set(0);
-    m_visualPlayPos->set(0.0, 0.0, 0.0, 0.0, 0.0);
+    m_visualPlayPos->set(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
     TrackPointer pTrack = m_pCurrentTrack;
     m_pCurrentTrack.reset();
     m_playButton->set(0.0);
@@ -1298,10 +1298,13 @@ void EngineBuffer::updateIndicators(double speed, int iBufferSize) {
 
     // Update visual control object, this needs to be done more often than the
     // playpos slider
-    m_visualPlayPos->set(fFractionalPlaypos, speed * m_baserate_old,
+    m_visualPlayPos->set(
+            fFractionalPlaypos,
+            speed * m_baserate_old,
             (double)iBufferSize / m_trackSamplesOld,
             fractionalPlayposFromAbsolute(m_dSlipPosition),
-            tempoTrackSeconds);
+            tempoTrackSeconds,
+            iBufferSize / kSamplesPerFrame / static_cast<double>(m_iSampleRate) * 1000000.0);
 }
 
 void EngineBuffer::hintReader(const double dRate) {

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -71,8 +71,9 @@ EngineMaster::EngineMaster(
     m_pMasterSampleRate->set(44100.);
 
     // Latency control
-    m_pMasterLatency = new ControlObject(ConfigKey(group, "latency"), true, true);
-    m_pMasterAudioBufferSize = new ControlObject(ConfigKey(group, "audio_buffer_size"));
+    m_pMasterLatency = new ControlObject(ConfigKey(group, "latency"),
+            true,
+            true); // reported latency (sometimes correct)
     m_pAudioLatencyOverloadCount = new ControlObject(ConfigKey(group, "audio_latency_overload_count"), true, true);
     m_pAudioLatencyUsage = new ControlPotmeter(ConfigKey(group, "audio_latency_usage"), 0.0, 0.25);
     m_pAudioLatencyOverload  = new ControlPotmeter(ConfigKey(group, "audio_latency_overload"), 0.0, 1.0);
@@ -220,7 +221,6 @@ EngineMaster::~EngineMaster() {
     delete m_pMasterSync;
     delete m_pMasterSampleRate;
     delete m_pMasterLatency;
-    delete m_pMasterAudioBufferSize;
     delete m_pAudioLatencyOverloadCount;
     delete m_pAudioLatencyUsage;
     delete m_pAudioLatencyOverload;

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -818,6 +818,7 @@ void EngineMaster::processHeadphones(
     // buffer with a mono mix of the master output buffer.
     if (m_pHeadSplitEnabled->toBool()) {
         // note: NOT VECTORIZED because of in place copy
+        // with all compilers, except clang >= 14.
         for (SINT i = 0; i + 1 < iBufferSize; i += 2) {
             m_pHead[i] = (m_pHead[i] + m_pHead[i + 1]) / 2;
             m_pHead[i + 1] = (m_pMaster[i] + m_pMaster[i + 1]) / 2;

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -303,7 +303,6 @@ class EngineMaster : public QObject, public AudioSource {
     ControlObject* m_pHeadGain;
     ControlObject* m_pMasterSampleRate;
     ControlObject* m_pMasterLatency;
-    ControlObject* m_pMasterAudioBufferSize;
     ControlObject* m_pAudioLatencyOverloadCount;
     ControlObject* m_pNumMicsConfigured;
     ControlPotmeter* m_pAudioLatencyUsage;

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -262,8 +262,10 @@ class EngineMaster : public QObject, public AudioSource {
     void processChannels(int iBufferSize);
 
     ChannelHandleFactoryPointer m_pChannelHandleFactory;
-    void applyMasterEffects();
-    void processHeadphones(const CSAMPLE_GAIN masterMixGainInHeadphones);
+    void applyMasterEffects(int iBufferSize);
+    void processHeadphones(
+            const CSAMPLE_GAIN masterMixGainInHeadphones,
+            int iBufferSize);
     bool sidechainMixRequired() const;
 
     EngineEffectsManager* m_pEngineEffectsManager;
@@ -284,7 +286,6 @@ class EngineMaster : public QObject, public AudioSource {
     QVarLengthArray<ChannelInfo*, kPreallocatedChannels> m_activeTalkoverChannels;
 
     unsigned int m_iSampleRate;
-    unsigned int m_iBufferSize;
 
     // Mixing buffers for each output.
     CSAMPLE* m_pOutputBusBuffers[3];

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -522,10 +522,15 @@ void DlgPrefSound::apiChanged(int index) {
         sampleRateComboBox->setEnabled(false);
         latencyLabel->setEnabled(false);
         audioBufferComboBox->setEnabled(false);
+        deviceSyncComboBox->setEnabled(false);
+        engineClockComboBox->setEnabled(false);
+
     } else {
         sampleRateComboBox->setEnabled(true);
         latencyLabel->setEnabled(true);
         audioBufferComboBox->setEnabled(true);
+        deviceSyncComboBox->setEnabled(true);
+        engineClockComboBox->setEnabled(true);
     }
 }
 

--- a/src/soundio/sounddevice.cpp
+++ b/src/soundio/sounddevice.cpp
@@ -17,7 +17,7 @@ SoundDevice::SoundDevice(UserSettingsPointer config, SoundManager* sm)
           m_iNumInputChannels(2),
           m_dSampleRate(44100.0),
           m_hostAPI("Unknown API"),
-          m_framesPerBuffer(0) {
+          m_configFramesPerBuffer(0) {
 }
 
 int SoundDevice::getNumInputChannels() const {
@@ -36,7 +36,7 @@ void SoundDevice::setSampleRate(double sampleRate) {
     m_dSampleRate = sampleRate;
 }
 
-void SoundDevice::setFramesPerBuffer(unsigned int framesPerBuffer) {
+void SoundDevice::setConfigFramesPerBuffer(unsigned int framesPerBuffer) {
     if (framesPerBuffer * 2 > MAX_BUFFER_LEN) {
         // framesPerBuffer * 2 because a frame will generally end up
         // being 2 samples and MAX_BUFFER_LEN is a number of samples
@@ -44,7 +44,7 @@ void SoundDevice::setFramesPerBuffer(unsigned int framesPerBuffer) {
         reportFatalErrorAndQuit("framesPerBuffer too big in "
                                 "SoundDevice::setFramesPerBuffer(uint)");
     }
-    m_framesPerBuffer = framesPerBuffer;
+    m_configFramesPerBuffer = framesPerBuffer;
 }
 
 SoundDeviceError SoundDevice::addOutput(const AudioOutputBuffer &out) {

--- a/src/soundio/sounddevice.h
+++ b/src/soundio/sounddevice.h
@@ -32,7 +32,7 @@ class SoundDevice {
         return m_hostAPI;
     }
     void setSampleRate(double sampleRate);
-    void setFramesPerBuffer(unsigned int framesPerBuffer);
+    void setConfigFramesPerBuffer(unsigned int framesPerBuffer);
     virtual SoundDeviceError open(bool isClkRefDevice, int syncBuffers) = 0;
     virtual bool isOpen() const = 0;
     virtual SoundDeviceError close() = 0;
@@ -89,7 +89,7 @@ class SoundDevice {
     // differently sized buffers. As such this value should only be used for
     // configuring the audio devices. The actual runtime buffer size should be
     // used for any computations working with audio.
-    SINT m_framesPerBuffer;
+    SINT m_configFramesPerBuffer;
     QList<AudioOutputBuffer> m_audioOutputs;
     QList<AudioInputBuffer> m_audioInputs;
 };

--- a/src/soundio/sounddevice.h
+++ b/src/soundio/sounddevice.h
@@ -36,8 +36,8 @@ class SoundDevice {
     virtual SoundDeviceError open(bool isClkRefDevice, int syncBuffers) = 0;
     virtual bool isOpen() const = 0;
     virtual SoundDeviceError close() = 0;
-    virtual void readProcess() = 0;
-    virtual void writeProcess() = 0;
+    virtual void readProcess(SINT framesPerBuffer) = 0;
+    virtual void writeProcess(SINT framesPerBuffer) = 0;
     virtual QString getError() const = 0;
     virtual unsigned int getDefaultSampleRate() const = 0;
     int getNumOutputChannels() const;
@@ -84,6 +84,11 @@ class SoundDevice {
     double m_dSampleRate;
     // The name of the audio API used by this device.
     QString m_hostAPI;
+    // The **configured** number of frames per buffer. We'll tell PortAudio we
+    // want this many frames in a buffer, but PortAudio may still give us have a
+    // differently sized buffers. As such this value should only be used for
+    // configuring the audio devices. The actual runtime buffer size should be
+    // used for any computations working with audio.
     SINT m_framesPerBuffer;
     QList<AudioOutputBuffer> m_audioOutputs;
     QList<AudioInputBuffer> m_audioInputs;

--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -92,8 +92,6 @@ SoundDeviceError SoundDeviceNetwork::open(bool isClkRefDevice, int syncBuffers) 
         ControlObject::set(ConfigKey("[Master]", "latency"),
                 requestedBufferTime.toDoubleMillis());
         ControlObject::set(ConfigKey("[Master]", "samplerate"), m_dSampleRate);
-        ControlObject::set(ConfigKey("[Master]", "audio_buffer_size"),
-                requestedBufferTime.toDoubleMillis());
 
         // Network stream was just started above so we have to wait until
         // we can pass one chunk.

--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -63,10 +63,10 @@ SoundDeviceError SoundDeviceNetwork::open(bool isClkRefDevice, int syncBuffers) 
         m_dSampleRate = 44100.0;
     }
 
-    qDebug() << "framesPerBuffer:" << m_framesPerBuffer;
+    qDebug() << "framesPerBuffer:" << m_configFramesPerBuffer;
 
     const auto requestedBufferTime = mixxx::Duration::fromSeconds(
-            m_framesPerBuffer / m_dSampleRate);
+            m_configFramesPerBuffer / m_dSampleRate);
     qDebug() << "Requested sample rate: " << m_dSampleRate << "Hz, latency:"
              << requestedBufferTime;
 
@@ -74,12 +74,12 @@ SoundDeviceError SoundDeviceNetwork::open(bool isClkRefDevice, int syncBuffers) 
     // clock reference device callback
     // This is what should work best.
     if (m_iNumOutputChannels) {
-        m_outputFifo = std::make_unique<FIFO<CSAMPLE> >(
-                m_iNumOutputChannels * m_framesPerBuffer * 2);
+        m_outputFifo = std::make_unique<FIFO<CSAMPLE>>(
+                m_iNumOutputChannels * m_configFramesPerBuffer * 2);
     }
     if (m_iNumInputChannels) {
-        m_inputFifo = std::make_unique<FIFO<CSAMPLE> >(
-                m_iNumInputChannels * m_framesPerBuffer * 2);
+        m_inputFifo = std::make_unique<FIFO<CSAMPLE>>(
+                m_iNumInputChannels * m_configFramesPerBuffer * 2);
     }
 
     m_pNetworkStream->startStream(m_dSampleRate);
@@ -412,7 +412,7 @@ void SoundDeviceNetwork::callbackProcessClkRef() {
     // This must be the very first call, to measure an exact value
     // NOTE: For network streams the buffer size is always the configured buffer
     //       size
-    updateCallbackEntryToDacTime(m_framesPerBuffer);
+    updateCallbackEntryToDacTime(m_configFramesPerBuffer);
 
     Trace trace("SoundDeviceNetwork::callbackProcessClkRef %1",
                 m_deviceId.name);
@@ -464,19 +464,19 @@ void SoundDeviceNetwork::callbackProcessClkRef() {
         }
     }
 
-    m_pSoundManager->readProcess(m_framesPerBuffer);
+    m_pSoundManager->readProcess(m_configFramesPerBuffer);
 
     {
         ScopedTimer t("SoundDevicePortAudio::callbackProcess prepare %1",
                 m_deviceId.name);
-        m_pSoundManager->onDeviceOutputCallback(m_framesPerBuffer);
+        m_pSoundManager->onDeviceOutputCallback(m_configFramesPerBuffer);
     }
 
-    m_pSoundManager->writeProcess(m_framesPerBuffer);
+    m_pSoundManager->writeProcess(m_configFramesPerBuffer);
 
-    m_pSoundManager->processUnderflowHappened(m_framesPerBuffer);
+    m_pSoundManager->processUnderflowHappened(m_configFramesPerBuffer);
 
-    updateAudioLatencyUsage(m_framesPerBuffer);
+    updateAudioLatencyUsage(m_configFramesPerBuffer);
 }
 
 void SoundDeviceNetwork::updateCallbackEntryToDacTime(SINT framesPerBuffer) {

--- a/src/soundio/sounddevicenetwork.h
+++ b/src/soundio/sounddevicenetwork.h
@@ -32,19 +32,21 @@ class SoundDeviceNetwork : public SoundDevice {
     SoundDeviceError open(bool isClkRefDevice, int syncBuffers) override;
     bool isOpen() const override;
     SoundDeviceError close() override;
-    void readProcess() override;
-    void writeProcess() override;
+    void readProcess(SINT framesPerBuffer) override;
+    void writeProcess(SINT framesPerBuffer) override;
     QString getError() const override;
 
     unsigned int getDefaultSampleRate() const override {
         return 44100;
     }
 
+    // NOTE: This does not take a frames per buffer argument because that is
+    //       always equal to the configured buffer size for network streams
     void callbackProcessClkRef();
 
   private:
-    void updateCallbackEntryToDacTime();
-    void updateAudioLatencyUsage();
+    void updateCallbackEntryToDacTime(SINT framesPerBuffer);
+    void updateAudioLatencyUsage(SINT framesPerBuffer);
 
     void workerWriteProcess(NetworkOutputStreamWorkerPtr pWorker,
             int outChunkSize, int readAvailable,
@@ -61,10 +63,12 @@ class SoundDeviceNetwork : public SoundDevice {
 
     std::unique_ptr<ControlProxy> m_pMasterAudioLatencyUsage;
     mixxx::Duration m_timeInAudioCallback;
-    mixxx::Duration m_audioBufferTime;
     int m_framesSinceAudioLatencyUsageUpdate;
     std::unique_ptr<SoundDeviceNetworkThread> m_pThread;
     bool m_denormals;
+    /**
+     * The deadline for the next buffer, in microseconds since the Unix epoch.
+     */
     qint64 m_targetTime;
     PerformanceTimer m_clkRefTimer;
 };

--- a/src/soundio/sounddevicenetwork.h
+++ b/src/soundio/sounddevicenetwork.h
@@ -66,9 +66,7 @@ class SoundDeviceNetwork : public SoundDevice {
     int m_framesSinceAudioLatencyUsageUpdate;
     std::unique_ptr<SoundDeviceNetworkThread> m_pThread;
     bool m_denormals;
-    /**
-     * The deadline for the next buffer, in microseconds since the Unix epoch.
-     */
+    /// The deadline for the next buffer, in microseconds since the Unix epoch.
     qint64 m_targetTime;
     PerformanceTimer m_clkRefTimer;
 };

--- a/src/soundio/sounddevicenotfound.h
+++ b/src/soundio/sounddevicenotfound.h
@@ -29,8 +29,8 @@ class SoundDeviceNotFound : public SoundDevice {
     SoundDeviceError close() override {
         return SOUNDDEVICE_ERROR_ERR;
     };
-    void readProcess() override { };
-    void writeProcess() override { };
+    void readProcess(SINT /*framesPerbuffer*/) override{};
+    void writeProcess(SINT /*framesPerbuffer*/) override{};
     QString getError() const override{ return QObject::tr("Device not found"); };
 
     unsigned int getDefaultSampleRate() const override {

--- a/src/soundio/sounddevicenotfound.h
+++ b/src/soundio/sounddevicenotfound.h
@@ -31,7 +31,9 @@ class SoundDeviceNotFound : public SoundDevice {
     };
     void readProcess(SINT /*framesPerbuffer*/) override{};
     void writeProcess(SINT /*framesPerbuffer*/) override{};
-    QString getError() const override{ return QObject::tr("Device not found"); };
+    QString getError() const override {
+        return QObject::tr("Device not found");
+    };
 
     unsigned int getDefaultSampleRate() const override {
         return 44100;

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -217,9 +217,10 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
         // PortAudio's JACK back end has its own buffering to split or merge the buffer
         // received from JACK to the desired size.
         // However, we use here paFramesPerBufferUnspecified to use the JACK buffer size
-        // which offers the best responds time without additional jitter.
+        // which offers the best response time without additional jitter due to two
+        // successive callback without the expected pause.
         framesPerBuffer = paFramesPerBufferUnspecified;
-        qDebug() << "framesPerBuffer: Unspecified";
+        qDebug() << "Using JACK server's frames per buffer";
     } else {
         qDebug() << "framesPerBuffer:" << framesPerBuffer;
     }

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -221,10 +221,10 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
              << "| Input channels:"
              << m_inputParams.channelCount;
 
-    // PortAudio's JACK backend also only properly supports
-    // paFramesPerBufferUnspecified in non-blocking mode because the latency
-    // comes from the JACK daemon. (PA should give an error or something though,
-    // but it doesn't.)
+    // PortAudio's JACK back end has its own buffering to split or merge the buffer
+    // received from JACK to the desired size.
+    // However, we use here paFramesPerBufferUnspecified to use the JACK buffer size
+    // which offers the best responds time without additional jitter.
     if (m_deviceTypeId == paJACK) {
         m_configFramesPerBuffer = paFramesPerBufferUnspecified;
     }

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -220,7 +220,7 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
         // which offers the best response time without additional jitter due to two
         // successive callback without the expected pause.
         framesPerBuffer = paFramesPerBufferUnspecified;
-        qDebug() << "Using JACK server's frames per buffer";
+        qDebug() << "Using JACK server's frames per period";
     } else {
         qDebug() << "framesPerBuffer:" << framesPerBuffer;
     }

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -368,7 +368,6 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
         // waveform view to properly correct for the latency.
         ControlObject::set(ConfigKey("[Master]", "latency"), currentLatencyMSec);
         ControlObject::set(ConfigKey("[Master]", "samplerate"), m_dSampleRate);
-        ControlObject::set(ConfigKey("[Master]", "audio_buffer_size"), bufferMSec);
         m_invalidTimeInfoCount = 0;
         m_clkRefTimer.start();
     }

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -262,7 +262,7 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
         // This causes even with the "Experimental (no delay)" setting
         // one extra buffer delay for the non clock reference device
         pCallback = paV19Callback;
-        if (m_outputParams.channelCount) {
+        if (m_outputParams.channelCount > 0) {
             m_outputFifo = std::make_unique<FIFO<CSAMPLE>>(MAX_BUFFER_LEN);
         }
         if (m_inputParams.channelCount) {
@@ -273,7 +273,7 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
         // to avoid overflows when one callback overtakes the other or
         // when there is a clock drift compared to the clock reference device
         // we need an additional artificial delay
-        if (m_outputParams.channelCount) {
+        if (m_outputParams.channelCount > 0) {
             // On chunk for reading one for writing and on for drift correction
             m_outputFifo = std::make_unique<FIFO<CSAMPLE>>(
                     m_outputParams.channelCount * framesPerBuffer * kFifoSize);
@@ -292,7 +292,7 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
             SampleUtil::clear(dataPtr2, size2);
             m_outputFifo->releaseWriteRegions(writeCount);
         }
-        if (m_inputParams.channelCount) {
+        if (m_inputParams.channelCount > 0) {
             m_inputFifo = std::make_unique<FIFO<CSAMPLE>>(
                     m_inputParams.channelCount * framesPerBuffer * kFifoSize);
             // Clear first 1.5 chunks (see above)
@@ -312,7 +312,7 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
         // this can be used on a second device when it is driven by the Clock
         // reference device clock
         pCallback = paV19Callback;
-        if (m_outputParams.channelCount) {
+        if (m_outputParams.channelCount > 0) {
             m_outputFifo = std::make_unique<FIFO<CSAMPLE>>(
                     m_outputParams.channelCount * framesPerBuffer);
         }
@@ -321,11 +321,11 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
                     m_inputParams.channelCount * framesPerBuffer);
         }
     } else if (m_syncBuffers == 0) { // "Experimental (no delay)"
-        if (m_outputParams.channelCount) {
+        if (m_outputParams.channelCount > 0) {
             m_outputFifo = std::make_unique<FIFO<CSAMPLE>>(
                     m_outputParams.channelCount * framesPerBuffer * 2);
         }
-        if (m_inputParams.channelCount) {
+        if (m_inputParams.channelCount > 0) {
             m_inputFifo = std::make_unique<FIFO<CSAMPLE>>(
                     m_inputParams.channelCount * framesPerBuffer * 2);
         }
@@ -769,7 +769,7 @@ int SoundDevicePortAudio::callbackProcessDrift(
         }
     }
 
-    if (m_outputParams.channelCount) {
+    if (m_outputParams.channelCount > 0) {
         int outChunkSize = framesPerBuffer * m_outputParams.channelCount;
         int readAvailable = m_outputFifo->readAvailable();
 
@@ -816,7 +816,7 @@ int SoundDevicePortAudio::callbackProcessDrift(
             m_pSoundManager->underflowHappened(11);
             //qDebug() << "callbackProcess read:" << (float)readAvailable / outChunkSize << "Buffer empty";
         }
-     }
+    }
     return paContinue;
 }
 
@@ -849,7 +849,7 @@ int SoundDevicePortAudio::callbackProcess(const SINT framesPerBuffer,
         }
     }
 
-    if (m_outputParams.channelCount) {
+    if (m_outputParams.channelCount > 0) {
         int outChunkSize = framesPerBuffer * m_outputParams.channelCount;
         int readAvailable = m_outputFifo->readAvailable();
         if (readAvailable >= outChunkSize) {
@@ -868,7 +868,7 @@ int SoundDevicePortAudio::callbackProcess(const SINT framesPerBuffer,
             m_pSoundManager->underflowHappened(5);
             //qDebug() << "callbackProcess read:" << "Buffer empty";
         }
-     }
+    }
     return paContinue;
 }
 

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -982,7 +982,7 @@ int SoundDevicePortAudio::callbackProcessClkRef(
 }
 
 void SoundDevicePortAudio::updateCallbackEntryToDacTime(
-        const SINT framesPerBuffer,
+        SINT framesPerBuffer,
         const PaStreamCallbackTimeInfo* timeInfo) {
     double timeSinceLastCbSecs = m_clkRefTimer.restart().toDoubleSeconds();
 

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -262,10 +262,10 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
         // one extra buffer delay for the non clock reference device
         pCallback = paV19Callback;
         if (m_outputParams.channelCount) {
-            m_outputFifo = new FIFO<CSAMPLE>(MAX_BUFFER_LEN);
+            m_outputFifo = std::make_unique<FIFO<CSAMPLE>>(MAX_BUFFER_LEN);
         }
         if (m_inputParams.channelCount) {
-            m_inputFifo = new FIFO<CSAMPLE>(MAX_BUFFER_LEN);
+            m_inputFifo = std::make_unique<FIFO<CSAMPLE>>(MAX_BUFFER_LEN);
         }
     } else if (m_syncBuffers == 2) { // "Default (long delay)"
         pCallback = paV19CallbackDrift;

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -225,7 +225,7 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
     // paFramesPerBufferUnspecified in non-blocking mode because the latency
     // comes from the JACK daemon. (PA should give an error or something though,
     // but it doesn't.)
-    if (m_deviceInfo->hostApi == paJACK) {
+    if (m_deviceTypeId == paJACK) {
         m_framesPerBuffer = paFramesPerBufferUnspecified;
     }
 

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -51,8 +51,8 @@ class SoundDevicePortAudio : public SoundDevice {
     }
 
   private:
-    void updateCallbackEntryToDacTime(const SINT framesPerBuffer,
-            const PaStreamCallbackTimeInfo* timeInfo);
+    void updateCallbackEntryToDacTime(
+            SINT framesPerBuffer, const PaStreamCallbackTimeInfo* timeInfo);
     void updateAudioLatencyUsage(const SINT framesPerBuffer);
 
     // PortAudio stream for this device.

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -1,8 +1,9 @@
 #pragma once
 
-
 #include <portaudio.h>
+
 #include <QString>
+#include <memory>
 
 #include "soundio/sounddevice.h"
 #include "util/duration.h"
@@ -64,8 +65,8 @@ class SoundDevicePortAudio : public SoundDevice {
     PaStreamParameters m_outputParams;
     // Description of the input stream coming from the soundcard.
     PaStreamParameters m_inputParams;
-    FIFO<CSAMPLE>* m_outputFifo;
-    FIFO<CSAMPLE>* m_inputFifo;
+    std::unique_ptr<FIFO<CSAMPLE>> m_outputFifo;
+    std::unique_ptr<FIFO<CSAMPLE>> m_inputFifo;
     bool m_outputDrift;
     bool m_inputDrift;
 

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -23,8 +23,8 @@ class SoundDevicePortAudio : public SoundDevice {
     SoundDeviceError open(bool isClkRefDevice, int syncBuffers) override;
     bool isOpen() const override;
     SoundDeviceError close() override;
-    void readProcess() override;
-    void writeProcess() override;
+    void readProcess(SINT framesPerBuffer) override;
+    void writeProcess(SINT framesPerBuffer) override;
     QString getError() const override;
 
     // This callback function gets called every time the sound device runs out of
@@ -50,7 +50,8 @@ class SoundDevicePortAudio : public SoundDevice {
     }
 
   private:
-    void updateCallbackEntryToDacTime(const PaStreamCallbackTimeInfo* timeInfo);
+    void updateCallbackEntryToDacTime(const SINT framesPerBuffer,
+            const PaStreamCallbackTimeInfo* timeInfo);
     void updateAudioLatencyUsage(const SINT framesPerBuffer);
 
     // PortAudio stream for this device.

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -609,18 +609,18 @@ void SoundManager::pushInputBuffers(const QList<AudioInputBuffer>& inputs,
     }
 }
 
-void SoundManager::writeProcess() const {
+void SoundManager::writeProcess(SINT framesPerBuffer) const {
     for (const auto& pDevice: m_devices) {
         if (pDevice) {
-            pDevice->writeProcess();
+            pDevice->writeProcess(framesPerBuffer);
         }
     }
 }
 
-void SoundManager::readProcess() const {
+void SoundManager::readProcess(SINT framesPerBuffer) const {
     for (const auto& pDevice: m_devices) {
         if (pDevice) {
-            pDevice->readProcess();
+            pDevice->readProcess(framesPerBuffer);
         }
     }
 }
@@ -689,14 +689,14 @@ int SoundManager::getConfiguredDeckCount() const {
     return m_config.getDeckCount();
 }
 
-void SoundManager::processUnderflowHappened() {
+void SoundManager::processUnderflowHappened(SINT framesPerBuffer) {
     if (m_underflowUpdateCount == 0) {
         if (atomicLoadRelaxed(m_underflowHappened)) {
             m_pMasterAudioLatencyOverload->set(1.0);
             m_pMasterAudioLatencyOverloadCount->set(
                     m_pMasterAudioLatencyOverloadCount->get() + 1);
-            m_underflowUpdateCount = CPU_OVERLOAD_DURATION * m_config.getSampleRate()
-                    / m_config.getFramesPerBuffer() / 1000;
+            m_underflowUpdateCount = CPU_OVERLOAD_DURATION *
+                    m_config.getSampleRate() / framesPerBuffer / 1000;
 
             m_underflowHappened = 0; // resetting here is not thread safe,
                                      // but that is OK, because we count only

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -445,7 +445,7 @@ SoundDeviceError SoundManager::setupDevices() {
 
         if (mode.isInput || mode.isOutput) {
             pDevice->setSampleRate(m_config.getSampleRate());
-            pDevice->setFramesPerBuffer(m_config.getFramesPerBuffer());
+            pDevice->setConfigFramesPerBuffer(m_config.getFramesPerBuffer());
             toOpen.append(mode);
         }
     }

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -400,7 +400,7 @@ SoundDeviceError SoundManager::setupDevices() {
         if (pDevice->getDeviceId().name == kNetworkDeviceInternalName) {
             AudioOutput out(AudioPath::RECORD_BROADCAST, 0, 2, 0);
             outputs.append(out);
-            if (m_config.getForceNetworkClock()) {
+            if (m_config.getForceNetworkClock() && !jackApiUsed()) {
                 pNewMasterClockRef = pDevice;
             }
         }
@@ -424,7 +424,7 @@ SoundDeviceError SoundManager::setupDevices() {
                 goto closeAndError;
             }
 
-            if (!m_config.getForceNetworkClock()) {
+            if (!m_config.getForceNetworkClock() || jackApiUsed()) {
                 if (out.getType() == AudioOutput::MASTER) {
                     pNewMasterClockRef = pDevice;
                 } else if ((out.getType() == AudioOutput::DECK ||

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -85,9 +85,8 @@ class SoundManager : public QObject {
     void pushInputBuffers(const QList<AudioInputBuffer>& inputs,
                           const SINT iFramesPerBuffer);
 
-
-    void writeProcess() const;
-    void readProcess() const;
+    void writeProcess(SINT framesPerBuffer) const;
+    void readProcess(SINT framesPerBuffer) const;
 
     void registerOutput(const AudioOutput& output, AudioSource* src);
     void registerInput(const AudioInput& input, AudioDestination* dest);
@@ -107,7 +106,7 @@ class SoundManager : public QObject {
         }
     }
 
-    void processUnderflowHappened();
+    void processUnderflowHappened(SINT framesPerBuffer);
 
   signals:
     void devicesUpdated(); // emitted when pointers to SoundDevices go stale

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -126,7 +126,7 @@ class SoundManager : public QObject {
 
     void setJACKName() const;
     bool jackApiUsed() const {
-        return m_jackSampleRate.isValid();
+        return m_config.getAPI() == MIXXX_PORTAUDIO_JACK_STRING;
     }
 
     EngineMaster *m_pMaster;

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -125,6 +125,9 @@ class SoundManager : public QObject {
     void closeDevices(bool sleepAfterClosing);
 
     void setJACKName() const;
+    bool jackApiUsed() const {
+        return m_jackSampleRate.isValid();
+    }
 
     EngineMaster *m_pMaster;
     UserSettingsPointer m_pConfig;

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -410,12 +410,6 @@ unsigned int SoundManagerConfig::getFramesPerBuffer() const {
     return framesPerBuffer;
 }
 
-// FIXME: This is incorrect when using JACK as the sound API!
-// m_audioBufferSizeIndex does not reflect JACK's buffer size.
-double SoundManagerConfig::getProcessingLatency() const {
-    return static_cast<double>(getFramesPerBuffer()) / m_sampleRate * 1000.0;
-}
-
 
 // Set the audio buffer size
 // @warning This IS NOT a value in milliseconds, or a number of frames per

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -390,8 +390,8 @@ unsigned int SoundManagerConfig::getAudioBufferSizeIndex() const {
     return m_audioBufferSizeIndex;
 }
 
-// FIXME: This is incorrect when using JACK as the sound API!
-// m_audioBufferSizeIndex does not reflect JACK's buffer size.
+// This reflects the configured value only. In case of JACK the
+// setting of the JACK server is used.
 unsigned int SoundManagerConfig::getFramesPerBuffer() const {
     // endless loop otherwise
     unsigned int audioBufferSizeIndex = m_audioBufferSizeIndex;
@@ -409,7 +409,6 @@ unsigned int SoundManagerConfig::getFramesPerBuffer() const {
     }
     return framesPerBuffer;
 }
-
 
 // Set the audio buffer size
 // @warning This IS NOT a value in milliseconds, or a number of frames per

--- a/src/soundio/soundmanagerconfig.h
+++ b/src/soundio/soundmanagerconfig.h
@@ -52,8 +52,6 @@ public:
 
     unsigned int getAudioBufferSizeIndex() const;
     unsigned int getFramesPerBuffer() const;
-    // Returns the processing latency in milliseconds
-    double getProcessingLatency() const;
     void setAudioBufferSizeIndex(unsigned int latency);
     unsigned int getSyncBuffers() const;
     void setSyncBuffers(unsigned int sampleRate);

--- a/src/test/co_dumps/co_dump_inital.csv
+++ b/src/test/co_dumps/co_dump_inital.csv
@@ -13742,7 +13742,6 @@
 [Channel4],beatloop_2_toggle,0
 [Sampler1],hotcue_13_activate_preview,0
 [Channel2],hotcue_15_activate,0
-[Master],audio_buffer_size,5.80499
 [EffectRack1_EffectUnit2_Effect3],parameter8_type,0
 [PreviewDeck1],visual_bpm,0
 [Microphone2],PeakIndicator_set_default,0

--- a/src/waveform/visualplayposition.cpp
+++ b/src/waveform/visualplayposition.cpp
@@ -52,7 +52,7 @@ void VisualPlayPosition::set(
 double VisualPlayPosition::calcPosAtNextVSync(
         VSyncThread* pVSyncThread, const VisualPlayPositionData& data) {
     double playPos = data.m_enginePlayPos; // load playPos for the first sample in Buffer
-    if (data.m_audioBufferMicroS) {
+    if (data.m_audioBufferMicroS != 0.0) {
         int refToVSync = pVSyncThread->fromTimerToNextSyncMicros(data.m_referenceTime);
         int offset = refToVSync - data.m_callbackEntrytoDac;
         // The offset is limited to the audio buffer + waveform sync interval

--- a/src/waveform/visualplayposition.cpp
+++ b/src/waveform/visualplayposition.cpp
@@ -8,11 +8,6 @@
 #include "util/math.h"
 #include "waveform/vsyncthread.h"
 
-namespace {
-constexpr int kMicrosPerMillis = 1000; // 1 ms contains 1000 µs
-} // anonymous namespace
-
-
 //static
 QMap<QString, QWeakPointer<VisualPlayPosition> > VisualPlayPosition::m_listVisualPlayPosition;
 PerformanceTimer VisualPlayPosition::m_timeInfoTime;

--- a/src/waveform/visualplayposition.cpp
+++ b/src/waveform/visualplayposition.cpp
@@ -64,7 +64,9 @@ double VisualPlayPosition::getAtNextVSync(VSyncThread* vSyncThread) {
         double playPos = data.m_enginePlayPos;  // load playPos for the first sample in Buffer
         // add the offset for the position of the sample that will be transferred to the DAC
         // When the next display frame is displayed
-        playPos += data.m_positionStep * offset * data.m_rate / m_audioBufferMicros;
+        if (m_audioBufferMicros) {
+            playPos += data.m_positionStep * offset * data.m_rate / m_audioBufferMicros;
+        }
         //qDebug() << "playPos" << playPos << offset;
         return playPos;
     }
@@ -82,7 +84,9 @@ void VisualPlayPosition::getPlaySlipAtNextVSync(VSyncThread* vSyncThread, double
         int offset = refToVSync - data.m_callbackEntrytoDac;
         offset = math_min(offset, m_audioBufferMicros * kMaxOffsetBufferCnt);
         double playPos = data.m_enginePlayPos;  // load playPos for the first sample in Buffer
-        playPos += data.m_positionStep * offset * data.m_rate / m_audioBufferMicros;
+        if (m_audioBufferMicros) {
+            playPos += data.m_positionStep * offset * data.m_rate / m_audioBufferMicros;
+        }
         *pPlayPosition = playPos;
         *pSlipPosition = data.m_slipPosition;
     }

--- a/src/waveform/visualplayposition.h
+++ b/src/waveform/visualplayposition.h
@@ -47,8 +47,10 @@ class VisualPlayPosition : public QObject {
     // engine thread.
     void set(double playPos, double rate, double positionStep,
             double slipPosition, double tempoTrackSeconds);
-    double getAtNextVSync(VSyncThread* vsyncThread);
-    void getPlaySlipAtNextVSync(VSyncThread* vSyncThread, double* playPosition, double* slipPosition);
+    double getAtNextVSync(VSyncThread* pVSyncThread);
+    void getPlaySlipAtNextVSync(VSyncThread* pVSyncThread,
+            double* playPosition,
+            double* slipPosition);
     double getEnginePlayPos();
     void getTrackTime(double* pPlayPosition, double* pTempoTrackSeconds);
 
@@ -68,6 +70,7 @@ class VisualPlayPosition : public QObject {
     void slotAudioBufferSizeChanged(double sizeMs);
 
   private:
+    double calcPosAtNextVSync(VSyncThread* pVSyncThread, const VisualPlayPositionData& data);
     ControlValueAtomic<VisualPlayPositionData> m_data;
     ControlProxy* m_audioBufferSize;
     int m_audioBufferMicros; // Audio buffer size in µs

--- a/src/waveform/visualplayposition.h
+++ b/src/waveform/visualplayposition.h
@@ -34,6 +34,7 @@ class VisualPlayPositionData {
     double m_positionStep;
     double m_slipPosition;
     double m_tempoTrackSeconds; // total track time, taking the current tempo into account
+    double m_audioBufferMicroS;
 };
 
 
@@ -45,8 +46,14 @@ class VisualPlayPosition : public QObject {
 
     // WARNING: Not thread safe. This function must be called only from the
     // engine thread.
-    void set(double playPos, double rate, double positionStep,
-            double slipPosition, double tempoTrackSeconds);
+    void set(
+            double playPos,
+            double rate,
+            double positionStep,
+            double slipPosition,
+            double tempoTrackSeconds,
+            double audioBufferMicroS);
+
     double getAtNextVSync(VSyncThread* pVSyncThread);
     void getPlaySlipAtNextVSync(VSyncThread* pVSyncThread,
             double* playPosition,
@@ -66,14 +73,9 @@ class VisualPlayPosition : public QObject {
         return m_valid;
     }
 
-  private slots:
-    void slotAudioBufferSizeChanged(double sizeMs);
-
   private:
     double calcPosAtNextVSync(VSyncThread* pVSyncThread, const VisualPlayPositionData& data);
     ControlValueAtomic<VisualPlayPositionData> m_data;
-    ControlProxy* m_audioBufferSize;
-    int m_audioBufferMicros; // Audio buffer size in µs
     bool m_valid;
     QString m_key;
 

--- a/src/waveform/vsyncthread.h
+++ b/src/waveform/vsyncthread.h
@@ -38,6 +38,9 @@ class VSyncThread : public QThread {
     void setupSync(QGLWidget* glw, int index);
     void waitUntilSwap(QGLWidget* glw);
     mixxx::Duration sinceLastSwap() const;
+    int getSyncIntervalTimeMicros() const {
+        return m_syncIntervalTimeMicros;
+    }
   signals:
     void vsyncRender();
     void vsyncSwap();


### PR DESCRIPTION
This PR disposes all stored buffer size values and uses consequently the value passed as callback parameter.
This is required because the JACK buffer size is externally controlled and can change at any time.
Current main uses the crazed out buffer size form hardware preferences. 

Because if that the timing compensation with two soundcards or the network clock fails and is now grayed out in the hardware preferences. 

Note: Multi soundcard setup is working, but because if the joint stream in JACK and the split-up in Portaudio. It adds an extra buffer latency for the non main device. It is also known that the clock synchronisation in native JACK is broken and the situation is not clear in case in pipewire. 

So if you want a minimum latency setup, use ALSA directly. 

This PR is on top of https://github.com/mixxxdj/mixxx/pull/11092

Many thanks to @robbert-vdh for finding the original issues and for the initial PR
