### PR TITLE
Playlists & crates: restore previous search

### DIFF
--- a/src/library/baseexternalplaylistmodel.cpp
+++ b/src/library/baseexternalplaylistmodel.cpp
@@ -111,6 +111,12 @@ void BaseExternalPlaylistModel::setPlaylist(const QString& playlist_path) {
         return;
     }
 
+    // Store search text
+    QString currSearch = currentSearch();
+    if (m_currentPlaylistId != -1 && !currSearch.trimmed().isEmpty()) {
+        m_searchTexts.insert(m_currentPlaylistId, currSearch);
+    }
+
     const auto playlistIdNumber =
             QString::number(playlistId);
     const auto playlistViewTable =
@@ -146,7 +152,8 @@ void BaseExternalPlaylistModel::setPlaylist(const QString& playlist_path) {
     setTable(playlistViewTable, playlistViewColumns.first(), playlistViewColumns, m_trackSource);
     setDefaultSort(fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_POSITION),
             Qt::AscendingOrder);
-    setSearch("");
+    // Restore search text
+    setSearch(m_searchTexts.value(m_currentPlaylistId));
 }
 
 TrackId BaseExternalPlaylistModel::doGetTrackId(const TrackPointer& pTrack) const {

--- a/src/library/baseexternalplaylistmodel.h
+++ b/src/library/baseexternalplaylistmodel.h
@@ -37,4 +37,5 @@ class BaseExternalPlaylistModel : public BaseSqlTableModel {
     QString m_playlistTracksTable;
     QSharedPointer<BaseTrackCache> m_trackSource;
     int m_currentPlaylistId;
+    QHash<int, QString> m_searchTexts;
 };

--- a/src/library/playlisttablemodel.cpp
+++ b/src/library/playlisttablemodel.cpp
@@ -127,6 +127,11 @@ void PlaylistTableModel::setTableModel(int playlistId) {
         qDebug() << "Already focused on playlist " << playlistId;
         return;
     }
+    // Store search text
+    QString currSearch = currentSearch();
+    if (m_iPlaylistId != -1 && !currSearch.trimmed().isEmpty()) {
+        m_searchTexts.insert(m_iPlaylistId, currSearch);
+    }
 
     m_iPlaylistId = playlistId;
 
@@ -173,7 +178,9 @@ void PlaylistTableModel::setTableModel(int playlistId) {
             LIBRARYTABLE_ID,
             columns,
             m_pTrackCollectionManager->internalCollection()->getTrackSource());
-    setSearch("");
+
+    // Restore search text
+    setSearch(m_searchTexts.value(m_iPlaylistId));
     setDefaultSort(fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_POSITION), Qt::AscendingOrder);
     setSort(defaultSortColumn(), defaultSortOrder());
 }

--- a/src/library/playlisttablemodel.h
+++ b/src/library/playlisttablemodel.h
@@ -40,4 +40,5 @@ class PlaylistTableModel final : public TrackSetTableModel {
 
     int m_iPlaylistId;
     bool m_keepDeletedTracks;
+    QHash<int, QString> m_searchTexts;
 };

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -1513,6 +1513,7 @@ void RekordboxFeature::activate() {
 
     emit enableCoverArtDisplay(true);
     emit switchToView("REKORDBOXHOME");
+    emit disableSearch();
 }
 
 void RekordboxFeature::activateChild(const QModelIndex& index) {

--- a/src/library/serato/seratofeature.cpp
+++ b/src/library/serato/seratofeature.cpp
@@ -1007,6 +1007,7 @@ void SeratoFeature::activate() {
 
     emit enableCoverArtDisplay(true);
     emit switchToView("SERATOHOME");
+    emit disableSearch();
 }
 
 void SeratoFeature::activateChild(const QModelIndex& index) {

--- a/src/library/trackset/crate/cratetablemodel.cpp
+++ b/src/library/trackset/crate/cratetablemodel.cpp
@@ -31,6 +31,12 @@ void CrateTableModel::selectCrate(CrateId crateId) {
         qDebug() << "Already focused on crate " << crateId;
         return;
     }
+    // Store search text
+    QString currSearch = currentSearch();
+    if (m_selectedCrate.isValid() && !currSearch.trimmed().isEmpty()) {
+        m_searchTexts.insert(m_selectedCrate.value(), currSearch);
+    }
+
     m_selectedCrate = crateId;
 
     QString tableName = QStringLiteral("crate_%1").arg(m_selectedCrate.toString());
@@ -65,7 +71,9 @@ void CrateTableModel::selectCrate(CrateId crateId) {
             LIBRARYTABLE_ID,
             columns,
             m_pTrackCollectionManager->internalCollection()->getTrackSource());
-    setSearch("");
+
+    // Restore search text
+    setSearch(m_searchTexts.value(m_selectedCrate.value()));
     setDefaultSort(fieldIndex("artist"), Qt::AscendingOrder);
 }
 

--- a/src/library/trackset/crate/cratetablemodel.h
+++ b/src/library/trackset/crate/cratetablemodel.h
@@ -27,4 +27,5 @@ class CrateTableModel final : public TrackSetTableModel {
 
   private:
     CrateId m_selectedCrate;
+    QHash<int, QString> m_searchTexts;
 };

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -459,13 +459,9 @@ void WSearchLineEdit::slotRestoreSearch(const QString& text) {
             << "slotRestoreSearch"
             << text;
 #endif // ENABLE_TRACE_LOG
-    if (text.isNull()) {
-        slotDisableSearch();
-    } else {
-        // we save the current search before we switch to a new text
-        slotSaveSearch();
-        enableSearch(text);
-    }
+    // we save the current search before we switch to a new text
+    slotSaveSearch();
+    enableSearch(text);
 }
 
 void WSearchLineEdit::slotTriggerSearch() {


### PR DESCRIPTION
Previous search queries are restored when selecting a playlist or crate.

To make users aware of this new feature we should finally highlight the searchbar when it's active #7922

Closes #11015 (see also #9522)