### PR TITLE
Fix the Latenight skin quick effect toggle controls only affecting the first effect of the chain

### DIFF
--- a/res/skins/LateNight/mixer/quick_effect_knob_4decks.xml
+++ b/res/skins/LateNight/mixer/quick_effect_knob_4decks.xml
@@ -44,7 +44,7 @@
                       <Pressed scalemode="STRETCH">skin:/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
                     </State>
                     <Connection>
-                      <ConfigKey><Variable name="QuickEffect"/>,enabled</ConfigKey>
+                      <ConfigKey><Variable name="QuickEffectGroup"/>,enabled</ConfigKey>
                       <ButtonState>LeftButton</ButtonState>
                     </Connection>
                     <Connection>
@@ -95,7 +95,7 @@
                       <Number>1</Number>
                     </State>
                     <Connection>
-                      <ConfigKey><Variable name="QuickEffect"/>,enabled</ConfigKey>
+                      <ConfigKey><Variable name="QuickEffectGroup"/>,enabled</ConfigKey>
                       <ButtonState>LeftButton</ButtonState>
                     </Connection>
                     <Connection>

--- a/res/skins/LateNight/mixer/quick_effect_knob_4decks.xml
+++ b/res/skins/LateNight/mixer/quick_effect_knob_4decks.xml
@@ -111,7 +111,11 @@
 
             </Children>
             <Connection>
-              <ConfigKey><Variable name="QuickEffect"/>,loaded</ConfigKey>
+              <ConfigKey><Variable name="QuickEffectGroup"/>,loaded_chain_preset</ConfigKey>
+              <Transform>
+                <IsEqual>0</IsEqual>
+                <Not/>
+              </Transform>
               <BindProperty>visible</BindProperty>
             </Connection>
           </WidgetGroup><!-- /Kill button + knob -->

--- a/res/skins/LateNight/mixer/quick_effect_knob_left.xml
+++ b/res/skins/LateNight/mixer/quick_effect_knob_left.xml
@@ -34,7 +34,7 @@
                   <Pressed scalemode="STRETCH">skin:/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
                 </State>
                 <Connection>
-                  <ConfigKey><Variable name="QuickEffect"/>,enabled</ConfigKey>
+                  <ConfigKey><Variable name="QuickEffectGroup"/>,enabled</ConfigKey>
                   <ButtonState>LeftButton</ButtonState>
                 </Connection>
               </PushButton>
@@ -82,7 +82,7 @@
                   <Number>1</Number>
                 </State>
                 <Connection>
-                  <ConfigKey><Variable name="QuickEffect"/>,enabled</ConfigKey>
+                  <ConfigKey><Variable name="QuickEffectGroup"/>,enabled</ConfigKey>
                   <ButtonState>LeftButton</ButtonState>
                 </Connection>
                 <Connection>

--- a/res/skins/LateNight/mixer/quick_effect_knob_left.xml
+++ b/res/skins/LateNight/mixer/quick_effect_knob_left.xml
@@ -98,7 +98,11 @@
       </WidgetGroup>
     </Children>
     <Connection>
-      <ConfigKey><Variable name="QuickEffect"/>,loaded</ConfigKey>
+      <ConfigKey><Variable name="QuickEffectGroup"/>,loaded_chain_preset</ConfigKey>
+      <Transform>
+        <IsEqual>0</IsEqual>
+        <Not/>
+      </Transform>
       <BindProperty>visible</BindProperty>
     </Connection>
   </WidgetGroup>

--- a/res/skins/LateNight/mixer/quick_effect_knob_right.xml
+++ b/res/skins/LateNight/mixer/quick_effect_knob_right.xml
@@ -50,7 +50,7 @@
                   <Number>1</Number>
                 </State>
                 <Connection>
-                  <ConfigKey><Variable name="QuickEffect"/>,enabled</ConfigKey>
+                  <ConfigKey><Variable name="QuickEffectGroup"/>,enabled</ConfigKey>
                   <ButtonState>LeftButton</ButtonState>
                 </Connection>
                 <Connection>
@@ -83,7 +83,7 @@
                   <Pressed scalemode="STRETCH">skin:/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
                 </State>
                 <Connection>
-                  <ConfigKey><Variable name="QuickEffect"/>,enabled</ConfigKey>
+                  <ConfigKey><Variable name="QuickEffectGroup"/>,enabled</ConfigKey>
                   <ButtonState>LeftButton</ButtonState>
                 </Connection>
               </PushButton>

--- a/res/skins/LateNight/mixer/quick_effect_knob_right.xml
+++ b/res/skins/LateNight/mixer/quick_effect_knob_right.xml
@@ -98,7 +98,11 @@
       </WidgetGroup>
     </Children>
     <Connection>
-      <ConfigKey><Variable name="QuickEffect"/>,loaded</ConfigKey>
+      <ConfigKey><Variable name="QuickEffectGroup"/>,loaded_chain_preset</ConfigKey>
+      <Transform>
+        <IsEqual>0</IsEqual>
+        <Not/>
+      </Transform>
       <BindProperty>visible</BindProperty>
     </Connection>
   </WidgetGroup>


### PR DESCRIPTION
I noticed that the quick effect chain bypass wasn't working correctly for effect chain presets with multiple effects (and setting the correct value from my controller didn't result in any visible feedback in the GUI). The other skins seem to already do the right thing here, so this was probably just an oversight.