### PR TITLE
WMainMenuBar: Add shortcut for rescanning library

### DIFF
--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -133,6 +133,9 @@ void WMainMenuBar::initialize() {
     QString rescanTitle = tr("&Rescan Library");
     QString rescanText = tr("Rescans library folders for changes to tracks.");
     auto* pLibraryRescan = new QAction(rescanTitle, this);
+    pLibraryRescan->setShortcut(QKeySequence(m_pKbdConfig->getValue(
+            ConfigKey("[KeyboardShortcuts]", "LibraryMenu_Rescan"),
+            tr("Ctrl+Shift+L"))));
     pLibraryRescan->setStatusTip(rescanText);
     pLibraryRescan->setWhatsThis(buildWhatsThis(rescanTitle, rescanText));
     pLibraryRescan->setCheckable(false);


### PR DESCRIPTION
I frequently find myself rescanning my library when adding new songs, sometimes even during live DJ sets. Therefore, to make this a more convenient operation, this branch adds a keyboard shortcut, defaulting to <kbd>Ctrl</kbd>/<kbd>⌘ Cmd</kbd> <kbd>Shift</kbd> <kbd>R</kbd>. I haven't found any conflicting shortcut, but feel free to point out if I missed something.

### Screenshot

![Screenshot 2022-12-19 at 21 35 38](https://user-images.githubusercontent.com/30873659/208533159-84a05282-4a95-48c1-8478-fc91eef9bda8.png)
