### PR TITLE
DjInteropt Require Version 0.16.1 exact

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1951,7 +1951,8 @@ if(ENGINEPRIME)
   set(LIBDJINTEROP_VERSION 0.16.0)
   # Look for an existing installation of libdjinterop and use that if available.
   # Otherwise, download and build from GitHub.
-  find_package(DjInterop ${LIBDJINTEROP_VERSION})
+  # Note: Version 0.17.0 is not yet compatible
+  find_package(DjInterop ${LIBDJINTEROP_VERSION} EXACT)
   if(DjInterop_FOUND)
     # An existing installation of djinterop is available.
     message(STATUS "Using existing system installation of libdjinterop")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1948,7 +1948,7 @@ endif()
 # Denon Engine Prime library export support (using libdjinterop)
 option(ENGINEPRIME "Support for library export to Denon Engine Prime" ON)
 if(ENGINEPRIME)
-  set(LIBDJINTEROP_VERSION 0.16.0)
+  set(LIBDJINTEROP_VERSION 0.16.1)
   # Look for an existing installation of libdjinterop and use that if available.
   # Otherwise, download and build from GitHub.
   # Note: Version 0.17.0 is not yet compatible
@@ -1983,7 +1983,7 @@ if(ENGINEPRIME)
     # the configuration.
     ExternalProject_Add(libdjinterop
       URL "https://github.com/xsco/libdjinterop/archive/refs/tags/${LIBDJINTEROP_VERSION}.tar.gz"
-      URL_HASH SHA256=c998831fe4d3cc80c5c031491204244c9ed0c61575dd529260304b95d79db588
+      URL_HASH SHA256=25461f5cc3ea80850d8400872f4fef08ad3730d9f2051719cccf2460f5ac15ad
       DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/downloads"
       DOWNLOAD_NAME "libdjinterop-${LIBDJINTEROP_VERSION}.tar.gz"
       INSTALL_DIR ${DJINTEROP_INSTALL_DIR}

--- a/cmake/modules/FindDjInterop.cmake
+++ b/cmake/modules/FindDjInterop.cmake
@@ -61,12 +61,15 @@ find_library(DjInterop_LIBRARY
 )
 mark_as_advanced(DjInterop_LIBRARY)
 
+if(DEFINED PC_DjInterop_VERSION AND NOT PC_DjInterop_VERSION STREQUAL "")
+  set(DjInterop_VERSION "${PC_DjInterop_VERSION}")
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   DjInterop
-  DEFAULT_MSG
-  DjInterop_LIBRARY
-  DjInterop_INCLUDE_DIR
+  REQUIRED_VARS DjInterop_LIBRARY DjInterop_INCLUDE_DIR
+  VERSION_VAR DjInterop_VERSION
 )
 
 if(DjInterop_FOUND)


### PR DESCRIPTION
The upcoming not yet released Version 0.17.0 is not yet compatible. 
This fails the build early instead of causing obscure compiler errors:

```
/home/aby/packages/mixxx-bsd/src/library/export/dlglibraryexport.cpp:20:27: error: expected namespace name
namespace el = djinterop::enginelibrary;
               ~~~~~~~~~~~^
/home/aby/packages/mixxx-bsd/src/library/export/dlglibraryexport.cpp:195:13: error: use of undeclared identifier 'el'
            el::default_database_dir_name);
            ^
/home/aby/packages/mixxx-bsd/src/library/export/dlglibraryexport.cpp:202:34: error: use of undeclared identifier 'el'
            versionIndex == -1 ? el::version_latest_firmware : el::all_versions[versionIndex];
                                 ^
/home/aby/packages/mixxx-bsd/src/library/export/dlglibraryexport.cpp:202:64: error: use of undeclared identifier 'el'
            versionIndex == -1 ? el::version_latest_firmware : el::all_versions[versionIndex];
                                                               ^
/home/aby/packages/mixxx-bsd/src/library/export/dlglibraryexport.cpp:224:13: error: use of undeclared identifier 'el'
            el::default_database_dir_name);
            ^
/home/aby/packages/mixxx-bsd/src/library/export/dlglibraryexport.cpp:228:23: error: use of undeclared identifier 'el'
        bool exists = el::database_exists(databaseDirectory.toStdString());
                      ^
/home/aby/packages/mixxx-bsd/src/library/export/dlglibraryexport.cpp:235:63: error: use of undeclared identifier 'el'
            for (const djinterop::semantic_version& version : el::all_versions) {
                                                              ^
/home/aby/packages/mixxx-bsd/src/library/export/dlglibraryexport.cpp:237:48: error: use of undeclared identifier 'el'
                        QString::fromStdString(el::version_name(version)),
                                               ^
/home/aby/packages/mixxx-bsd/src/library/export/dlglibraryexport.cpp:239:32: error: use of undeclared identifier 'el'
                if (version == el::version_latest_firmware) {
                               ^
/home/aby/packages/mixxx-bsd/src/library/export/dlglibraryexport.cpp:252:34: error: use of undeclared identifier 'el'
        djinterop::database db = el::load_database(databaseDirectory.toStdString());
                                 ^
/home/aby/packages/mixxx-bsd/src/library/export/dlglibraryexport.cpp:253:33: error: no member named 'version' in 'djinterop::database'
        const auto version = db.version();
                             ~~ ^
/home/aby/packages/mixxx-bsd/src/library/export/dlglibraryexport.cpp:255:39: error: use of undeclared identifier 'el'
        const auto result = std::find(el::all_versions.begin(), el::all_versions.end(), version);
                                      ^
/home/aby/packages/mixxx-bsd/src/library/export/dlglibraryexport.cpp:255:65: error: use of undeclared identifier 'el'
        const auto result = std::find(el::all_versions.begin(), el::all_versions.end(), version);
                                                                ^
/home/aby/packages/mixxx-bsd/src/library/export/dlglibraryexport.cpp:256:23: error: use of undeclared identifier 'el'
        if (result == el::all_versions.end()) {
                      ^
/home/aby/packages/mixxx-bsd/src/library/export/dlglibraryexport.cpp:265:46: error: use of undeclared identifier 'el'
            int versionIndex = std::distance(el::all_versions.begin(), result);
                                             ^
/home/aby/packages/mixxx-bsd/src/library/export/dlglibraryexport.cpp:271:47: error: use of undeclared identifier 'el'
                    0, QString::fromStdString(el::version_name(version)), QVariant{versionIndex});
                                              ^
16 errors generated.
``` 
