### PR TITLE
Preferences: always enable Alt shortcut keys

### DIFF
--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -65,6 +65,14 @@ DlgPreferences::DlgPreferences(
     setupUi(this);
     contentsTreeWidget->setHeaderHidden(true);
 
+    // Add '&' to default button labels to always have Alt shortcuts, indpependent
+    // of operating system.
+    buttonBox->button(QDialogButtonBox::Help)->setText(tr("&Help"));
+    buttonBox->button(QDialogButtonBox::RestoreDefaults)->setText(tr("&Restore Defaults"));
+    buttonBox->button(QDialogButtonBox::Apply)->setText(tr("&Apply"));
+    buttonBox->button(QDialogButtonBox::Cancel)->setText(tr("&Cancel"));
+    buttonBox->button(QDialogButtonBox::Ok)->setText(tr("&Ok"));
+
     connect(buttonBox,
             QOverload<QAbstractButton*>::of(&QDialogButtonBox::clicked),
             this,

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -67,10 +67,15 @@ DlgPreferences::DlgPreferences(
 
     // Add '&' to default button labels to always have Alt shortcuts, indpependent
     // of operating system.
+    //: Preferences standard buttons: consider the other buttons to choose a unique Alt hotkey (&)
     buttonBox->button(QDialogButtonBox::Help)->setText(tr("&Help"));
+    //: Preferences standard buttons: consider the other buttons to choose a unique Alt hotkey (&)
     buttonBox->button(QDialogButtonBox::RestoreDefaults)->setText(tr("&Restore Defaults"));
+    //: Preferences standard buttons: consider the other buttons to choose a unique Alt hotkey (&)
     buttonBox->button(QDialogButtonBox::Apply)->setText(tr("&Apply"));
+    //: Preferences standard buttons: consider the other buttons to choose a unique Alt hotkey (&)
     buttonBox->button(QDialogButtonBox::Cancel)->setText(tr("&Cancel"));
+    //: Preferences standard buttons: consider the other buttons to choose a unique Alt hotkey (&)
     buttonBox->button(QDialogButtonBox::Ok)->setText(tr("&Ok"));
 
     connect(buttonBox,


### PR DESCRIPTION
like in Track Properties
![image](https://user-images.githubusercontent.com/5934199/209002975-b95b79eb-28d6-4258-8b8f-75f249e30275.png)

IIRC the benefit of keeping the QDialogButtonBox::StandardButtons (instead of configuring the entire button box manually) is that the button layout is the standard OS layout.
The downside: labels need to be translated.

Closes #10413