### PR TITLE
Report versions of found library during cmake configure.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1860,6 +1860,11 @@ endif()
 target_include_directories(mixxx-lib SYSTEM PUBLIC lib/fidlib)
 target_link_libraries(mixxx-lib PRIVATE fidlib)
 
+# Create a list from CMAKE_PREFIX_PATH with an alternate separator
+# This is required to forward CMAKE_PREFIX_PATH in ExternalProject_Add()
+# using the LIST_SEPARATOR option
+string(REPLACE ";" "|" CMAKE_PREFIX_PATH_ALT_SEP "${CMAKE_PREFIX_PATH}")
+
 # KeyFinder
 option(KEYFINDER "KeyFinder support" ON)
 if(KEYFINDER)
@@ -1886,12 +1891,14 @@ if(KEYFINDER)
         -DCMAKE_SKIP_INSTALL_ALL_DEPENDENCY=ON
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
-        -DCMAKE_PREFIX_PATH:PATH="${CMAKE_PREFIX_PATH}"
+        -DCMAKE_PREFIX_PATH:PATH=${CMAKE_PREFIX_PATH_ALT_SEP}
+        -DCMAKE_TOOLCHAIN_FILE:PATH=${CMAKE_TOOLCHAIN_FILE}
         -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
         -DBUILD_TESTING=OFF
       BUILD_COMMAND ${CMAKE_COMMAND} --build .
       BUILD_BYPRODUCTS <INSTALL_DIR>/${KeyFinder_LIBRARY}
       EXCLUDE_FROM_ALL TRUE
+      LIST_SEPARATOR |
     )
 
     # This is a bit of a hack to make sure that the include directory actually
@@ -1999,12 +2006,14 @@ else()
       -DCMAKE_SKIP_INSTALL_ALL_DEPENDENCY=ON
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
       -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
-      -DCMAKE_PREFIX_PATH=${PIPE_DELIMITED_CMAKE_PREFIX_PATH}
+      -DCMAKE_PREFIX_PATH:PATH=${CMAKE_PREFIX_PATH_ALT_SEP}
+      -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
       -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
       -DBUILD_TESTING=OFF
     BUILD_COMMAND ${CMAKE_COMMAND} --build .
     BUILD_BYPRODUCTS <INSTALL_DIR>/${PortAudio_LIBRARIES}
     EXCLUDE_FROM_ALL TRUE
+    LIST_SEPARATOR |
   )
   add_dependencies(mixxx-lib portaudio)
   target_link_libraries(mixxx-lib PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1868,8 +1868,9 @@ string(REPLACE ";" "|" CMAKE_PREFIX_PATH_ALT_SEP "${CMAKE_PREFIX_PATH}")
 # KeyFinder
 option(KEYFINDER "KeyFinder support" ON)
 if(KEYFINDER)
-  set(LIBKEYFINDER_VERSION 2.2.6)
-  find_package(KeyFinder ${LIBKEYFINDER_VERSION})
+  set(MIN_LIBKEYFINDER_VERSION 2.2.4)
+  set(FETCH_LIBKEYFINDER_VERSION 2.2.6)
+  find_package(KeyFinder ${MIN_LIBKEYFINDER_VERSION})
   if (KeyFinder_FOUND)
     target_link_libraries(mixxx-lib PRIVATE KeyFinder::KeyFinder)
   else()
@@ -1881,7 +1882,7 @@ if(KEYFINDER)
     # copy it into DOWNLOAD_DIR under DOWNLOAD_NAME prior to starting
     # the configuration.
     ExternalProject_Add(libkeyfinder
-      URL "https://github.com/mixxxdj/libkeyfinder/archive/refs/tags/v${LIBKEYFINDER_VERSION}.zip"
+      URL "https://github.com/mixxxdj/libkeyfinder/archive/refs/tags/v${FETCH_LIBKEYFINDER_VERSION}.zip"
       URL_HASH SHA256=f15deb56c2dcaa6b10dc3717a7d2f42a8407c04ad550f694de42118be998d256
       DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/downloads"
       DOWNLOAD_NAME "libkeyfinder-${LIBKEYFINDER_VERSION}.zip"

--- a/cmake/modules/FindChromaprint.cmake
+++ b/cmake/modules/FindChromaprint.cmake
@@ -62,12 +62,15 @@ find_library(Chromaprint_LIBRARY
 )
 mark_as_advanced(Chromaprint_LIBRARY)
 
+if(DEFINED PC_Chromaprint_VERSION AND NOT PC_Chromaprint_VERSION STREQUAL "")
+  set(Chromaprint_VERSION "${PC_Chromaprint_VERSION}")
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   Chromaprint
-  DEFAULT_MSG
-  Chromaprint_LIBRARY
-  Chromaprint_INCLUDE_DIR
+  REQUIRED_VARS Chromaprint_LIBRARY Chromaprint_INCLUDE_DIR
+  VERSION_VAR Chromaprint_VERSION
 )
 
 if(Chromaprint_FOUND)

--- a/cmake/modules/FindEbur128.cmake
+++ b/cmake/modules/FindEbur128.cmake
@@ -62,12 +62,15 @@ find_library(Ebur128_LIBRARY
 )
 mark_as_advanced(Ebur128_LIBRARY)
 
+if(DEFINED PC_Ebur128_VERSION AND NOT PC_Ebur128_VERSION STREQUAL "")
+  set(Ebur128_VERSION "${PC_Ebur128_VERSION}")
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   Ebur128
-  DEFAULT_MSG
-  Ebur128_LIBRARY
-  Ebur128_INCLUDE_DIR
+  REQUIRED_VARS Ebur128_LIBRARY Ebur128_INCLUDE_DIR
+  VERSION_VAR Ebur128_VERSION
 )
 
 if(Ebur128_FOUND)

--- a/cmake/modules/FindFLAC.cmake
+++ b/cmake/modules/FindFLAC.cmake
@@ -61,12 +61,15 @@ find_library(FLAC_LIBRARY
 )
 mark_as_advanced(FLAC_LIBRARY)
 
+if(DEFINED PC_FLAC_VERSION AND NOT PC_FLAC_VERSION STREQUAL "")
+  set(FLAC_VERSION "${PC_FLAC_VERSION}")
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   FLAC
-  DEFAULT_MSG
-  FLAC_LIBRARY
-  FLAC_INCLUDE_DIR
+  REQUIRED_VARS FLAC_LIBRARY FLAC_INCLUDE_DIR
+  VERSION_VAR FLAC_VERSION
 )
 
 if(FLAC_FOUND)

--- a/cmake/modules/FindID3Tag.cmake
+++ b/cmake/modules/FindID3Tag.cmake
@@ -62,12 +62,15 @@ find_library(ID3Tag_LIBRARY
 )
 mark_as_advanced(ID3Tag_LIBRARY)
 
+if(DEFINED PC_ID3Tag_VERSION AND NOT PC_ID3Tag_VERSION STREQUAL "")
+  set(ID3Tag_VERSION "${PC_ID3Tag_VERSION}")
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   ID3Tag
-  DEFAULT_MSG
-  ID3Tag_LIBRARY
-  ID3Tag_INCLUDE_DIR
+  REQUIRED_VARS ID3Tag_LIBRARY ID3Tag_INCLUDE_DIR
+  VERSION_VAR ID3Tag_VERSION
 )
 
 if(ID3Tag_FOUND)

--- a/cmake/modules/FindKeyFinder.cmake
+++ b/cmake/modules/FindKeyFinder.cmake
@@ -61,12 +61,15 @@ find_library(KeyFinder_LIBRARY
 )
 mark_as_advanced(KeyFinder_LIBRARY)
 
+if(DEFINED PC_KeyFinder_VERSION AND NOT PC_KeyFinder_VERSION STREQUAL "")
+  set(KeyFinder_VERSION "${PC_KeyFinder_VERSION}")
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   KeyFinder
-  DEFAULT_MSG
-  KeyFinder_LIBRARY
-  KeyFinder_INCLUDE_DIR
+  REQUIRED_VARS KeyFinder_LIBRARY KeyFinder_INCLUDE_DIR
+  VERSION_VAR KeyFinder_VERSION
 )
 
 if(KeyFinder_FOUND)

--- a/cmake/modules/FindLibUSB.cmake
+++ b/cmake/modules/FindLibUSB.cmake
@@ -63,12 +63,15 @@ find_library(LibUSB_LIBRARY
 )
 mark_as_advanced(LibUSB_LIBRARY)
 
+if(DEFINED PC_LibUSB_VERSION AND NOT PC_LibUSB_VERSION STREQUAL "")
+  set(LibUSB_VERSION "${PC_LibUSB_VERSION}")
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   LibUSB
-  DEFAULT_MSG
-  LibUSB_LIBRARY
-  LibUSB_INCLUDE_DIR
+  REQUIRED_VARS LibUSB_LIBRARY LibUSB_INCLUDE_DIR
+  VERSION_VAR LibUSB_VERSION
 )
 
 if(LibUSB_FOUND)

--- a/cmake/modules/FindMAD.cmake
+++ b/cmake/modules/FindMAD.cmake
@@ -62,12 +62,15 @@ find_library(MAD_LIBRARY
 )
 mark_as_advanced(MAD_LIBRARY)
 
+if(DEFINED PC_MAD_VERSION AND NOT PC_MAD_VERSION STREQUAL "")
+  set(MAD_VERSION "${PC_MAD_VERSION}")
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   MAD
-  DEFAULT_MSG
-  MAD_LIBRARY
-  MAD_INCLUDE_DIR
+  REQUIRED_VARS MAD_LIBRARY MAD_INCLUDE_DIR
+  VERSION_VAR MAD_VERSION
 )
 
 if(MAD_FOUND)

--- a/cmake/modules/FindMP4.cmake
+++ b/cmake/modules/FindMP4.cmake
@@ -61,12 +61,15 @@ find_library(MP4_LIBRARY
 )
 mark_as_advanced(MP4_LIBRARY)
 
+if(DEFINED PC_MP4_VERSION AND NOT PC_MP4_VERSION STREQUAL "")
+  set(MP4_VERSION "${PC_MP4_VERSION}")
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   MP4
-  DEFAULT_MSG
-  MP4_LIBRARY
-  MP4_INCLUDE_DIR
+  REQUIRED_VARS MP4_LIBRARY MP4_INCLUDE_DIR
+  VERSION_VAR MP4_VERSION
 )
 
 if(MP4_FOUND)

--- a/cmake/modules/FindMP4v2.cmake
+++ b/cmake/modules/FindMP4v2.cmake
@@ -61,12 +61,15 @@ find_library(MP4v2_LIBRARY
 )
 mark_as_advanced(MP4v2_LIBRARY)
 
+if(DEFINED PC_MP4v2_VERSION AND NOT PC_MP4v2_VERSION STREQUAL "")
+  set(MP4v2_VERSION "${PC_MP4v2_VERSION}")
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   MP4v2
-  DEFAULT_MSG
-  MP4v2_LIBRARY
-  MP4v2_INCLUDE_DIR
+  REQUIRED_VARS MP4v2_LIBRARY MP4v2_INCLUDE_DIR
+  VERSION_VAR MP4v2_VERSION
 )
 
 if(MP4v2_FOUND)

--- a/cmake/modules/FindModplug.cmake
+++ b/cmake/modules/FindModplug.cmake
@@ -61,12 +61,15 @@ find_library(Modplug_LIBRARY
 )
 mark_as_advanced(Modplug_LIBRARY)
 
+if(DEFINED PC_Modplug_VERSION AND NOT PC_Modplug_VERSION STREQUAL "")
+  set(Modplug_VERSION "${PC_Modplug_VERSION}")
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   Modplug
-  DEFAULT_MSG
-  Modplug_LIBRARY
-  Modplug_INCLUDE_DIR
+  REQUIRED_VARS Modplug_LIBRARY Modplug_INCLUDE_DIR
+  VERSION_VAR Modplug_VERSION
 )
 
 if(Modplug_FOUND)

--- a/cmake/modules/FindOgg.cmake
+++ b/cmake/modules/FindOgg.cmake
@@ -53,12 +53,15 @@ find_library(Ogg_LIBRARY
 )
 mark_as_advanced(Ogg_LIBRARY)
 
+if(DEFINED PC_Ogg_VERSION AND NOT PC_Ogg_VERSION STREQUAL "")
+  set(Ogg_VERSION "${PC_Ogg_VERSION}")
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   Ogg
-  REQUIRED_VARS
-  Ogg_INCLUDE_DIR
-  Ogg_LIBRARY
+  REQUIRED_VARS Ogg_LIBRARY Ogg_INCLUDE_DIR
+  VERSION_VAR Ogg_VERSION
 )
 
 if(Ogg_FOUND)

--- a/cmake/modules/FindPortMidi.cmake
+++ b/cmake/modules/FindPortMidi.cmake
@@ -61,13 +61,15 @@ find_library(PortTime_LIBRARY
 )
 mark_as_advanced(PortTime_LIBRARY)
 
+if(DEFINED PC_PortMidi_VERSION AND NOT PC_PortMidi_VERSION STREQUAL "")
+  set(PortMidi_VERSION "${PC_PortMidi_VERSION}")
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   PortMidi
-  DEFAULT_MSG
-  PortMidi_LIBRARY
-  PortMidi_INCLUDE_DIR
-  PortTime_INCLUDE_DIR
+  REQUIRED_VARS PortMidi_LIBRARY PortMidi_INCLUDE_DIR PortTime_INCLUDE_DIR
+  VERSION_VAR PortMidi_VERSION
 )
 
 if(PortMidi_FOUND)

--- a/cmake/modules/FindShoutidjc.cmake
+++ b/cmake/modules/FindShoutidjc.cmake
@@ -63,12 +63,15 @@ find_library(Shoutidjc_LIBRARY
 )
 mark_as_advanced(Shoutidjc_LIBRARY)
 
+if(DEFINED PC_Shoutidjc_VERSION AND NOT PC_Shoutidjc_VERSION STREQUAL "")
+  set(Shoutidjc_VERSION "${PC_Shoutidjc_VERSION}")
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   Shoutidjc
-  DEFAULT_MSG
-  Shoutidjc_LIBRARY
-  Shoutidjc_INCLUDE_DIR
+  REQUIRED_VARS Shoutidjc_LIBRARY Shoutidjc_INCLUDE_DIR
+  VERSION_VAR Shoutidjc_VERSION
 )
 
 if(Shoutidjc_FOUND)

--- a/cmake/modules/FindSndFile.cmake
+++ b/cmake/modules/FindSndFile.cmake
@@ -62,12 +62,15 @@ find_library(SndFile_LIBRARY
 )
 mark_as_advanced(SndFile_LIBRARY)
 
+if(DEFINED PC_SndFile_VERSION AND NOT PC_SndFile_VERSION STREQUAL "")
+  set(SndFile_VERSION "${PC_SndFile_VERSION}")
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   SndFile
-  DEFAULT_MSG
-  SndFile_LIBRARY
-  SndFile_INCLUDE_DIR
+  REQUIRED_VARS SndFile_LIBRARY SndFile_INCLUDE_DIR
+  VERSION_VAR SndFile_VERSION
 )
 
 file(STRINGS "${SndFile_INCLUDE_DIR}/sndfile.h" SndFile_SUPPORTS_SET_COMPRESSION_LEVEL REGEX ".*SFC_SET_COMPRESSION_LEVEL.*")

--- a/cmake/modules/FindSoundTouch.cmake
+++ b/cmake/modules/FindSoundTouch.cmake
@@ -62,7 +62,7 @@ find_library(SoundTouch_LIBRARY
 mark_as_advanced(SoundTouch_LIBRARY)
 
 # Version detection
-if(DEFINED PC_SoundTouch_VERSION)
+if(DEFINED PC_SoundTouch_VERSION AND NOT PC_SoundTouch_VERSION STREQUAL "")
   set(SoundTouch_VERSION "${PC_SoundTouch_VERSION}")
 else()
   if(EXISTS "${SoundTouch_INCLUDE_DIR}/soundtouch/SoundTouch.h")

--- a/cmake/modules/FindUpower.cmake
+++ b/cmake/modules/FindUpower.cmake
@@ -62,12 +62,15 @@ find_library(Upower_LIBRARY
 )
 mark_as_advanced(Upower_LIBRARY)
 
+if(DEFINED PC_Upower_VERSION AND NOT PC_Upower_VERSION STREQUAL "")
+  set(Upower_VERSION "${PC_Upower_VERSION}")
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   Upower
-  DEFAULT_MSG
-  Upower_LIBRARY
-  Upower_INCLUDE_DIR
+  REQUIRED_VARS Upower_LIBRARY Upower_INCLUDE_DIR
+  VERSION_VAR Upower_VERSION
 )
 
 if(Upower_FOUND)

--- a/cmake/modules/Findlilv.cmake
+++ b/cmake/modules/Findlilv.cmake
@@ -63,12 +63,15 @@ find_library(lilv_LIBRARY
 )
 mark_as_advanced(lilv_LIBRARY)
 
+if(DEFINED PC_lilv_VERSION AND NOT PC_lilv_VERSION STREQUAL "")
+  set(lilv_VERSION "${PC_lilv_VERSION}")
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   lilv
-  DEFAULT_MSG
-  lilv_LIBRARY
-  lilv_INCLUDE_DIR
+  REQUIRED_VARS lilv_LIBRARY lilv_INCLUDE_DIR
+  VERSION_VAR lilv_VERSION
 )
 
 if(lilv_FOUND)

--- a/cmake/modules/Findrubberband.cmake
+++ b/cmake/modules/Findrubberband.cmake
@@ -61,12 +61,15 @@ find_library(rubberband_LIBRARY
 )
 mark_as_advanced(rubberband_LIBRARY)
 
+if(DEFINED PC_rubberband_VERSION AND NOT PC_rubberband_VERSION STREQUAL "")
+  set(rubberband_VERSION "${PC_rubberband_VERSION}")
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   rubberband
-  DEFAULT_MSG
-  rubberband_LIBRARY
-  rubberband_INCLUDE_DIR
+  REQUIRED_VARS rubberband_LIBRARY rubberband_INCLUDE_DIR
+  VERSION_VAR rubberband_VERSION
 )
 
 if(rubberband_FOUND)

--- a/cmake/modules/Findwavpack.cmake
+++ b/cmake/modules/Findwavpack.cmake
@@ -61,12 +61,15 @@ find_library(wavpack_LIBRARY NAMES wavpack wv wavpackdll
 )
 mark_as_advanced(wavpack_LIBRARY)
 
+if(DEFINED PC_wavpack_VERSION AND NOT PC_wavpack_VERSION STREQUAL "")
+  set(wavpack_VERSION "${PC_wavpack_VERSION}")
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   wavpack
-  DEFAULT_MSG
-  wavpack_LIBRARY
-  wavpack_INCLUDE_DIR
+  REQUIRED_VARS wavpack_LIBRARY wavpack_INCLUDE_DIR
+  VERSION_VAR wavpack_VERSION
 )
 
 if(wavpack_FOUND)


### PR DESCRIPTION
This helps to find build errors earlier. Like the one fixed in https://github.com/mixxxdj/mixxx/pull/11144.

Like this: 
```
-- Found SoundTouch: /usr/local/lib/libSoundTouch.a (found suitable version "2.3.2", minimum required is "2.1.2")
```