### PR TITLE
Change ssize_t in debug assertion to ptrdiff_t

### DIFF
--- a/src/engine/bufferscalers/enginebufferscalerubberband.cpp
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.cpp
@@ -160,7 +160,7 @@ SINT EngineBufferScaleRubberBand::retrieveAndDeinterleave(
 
 void EngineBufferScaleRubberBand::deinterleaveAndProcess(
         const CSAMPLE* pBuffer, SINT frames, bool flush) {
-    DEBUG_ASSERT(frames <= static_cast<ptrdiff_t>(m_buffers[0].size()));
+    DEBUG_ASSERT(frames <= static_cast<SINT>(m_buffers[0].size()));
 
     SampleUtil::deinterleaveBuffer(
             m_buffers[0].data(), m_buffers[1].data(), pBuffer, frames);

--- a/src/engine/bufferscalers/enginebufferscalerubberband.cpp
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.cpp
@@ -160,7 +160,7 @@ SINT EngineBufferScaleRubberBand::retrieveAndDeinterleave(
 
 void EngineBufferScaleRubberBand::deinterleaveAndProcess(
         const CSAMPLE* pBuffer, SINT frames, bool flush) {
-    DEBUG_ASSERT(frames <= static_cast<ssize_t>(m_buffers[0].size()));
+    DEBUG_ASSERT(frames <= static_cast<ptrdiff_t>(m_buffers[0].size()));
 
     SampleUtil::deinterleaveBuffer(
             m_buffers[0].data(), m_buffers[1].data(), pBuffer, frames);


### PR DESCRIPTION
`ssize_t` is only officially defined on POSIX, and apparently this results in compiler errors with Visual Studio 2022:

https://github.com/mixxxdj/mixxx/pull/11120#discussion_r1055822859

`ptrdiff_t` is the closest type defined by the standard. I could also just use `SINT` here since this shouldn't overflow. Let me know if I should change it to that.