### PR TITLE
Scalers: Replace the unneded flushing code with silence passing

### DIFF
--- a/src/engine/bufferscalers/enginebufferscalelinear.cpp
+++ b/src/engine/bufferscalers/enginebufferscalelinear.cpp
@@ -291,7 +291,9 @@ SINT EngineBufferScaleLinear::do_scale(CSAMPLE* buf, SINT buf_size) {
 
                 if (m_bufferIntSize == 0) {
                     if (++read_failed_count > 1) {
-                        break;
+                        DEBUG_ASSERT(!"getNextSamples must never fail");
+                        SampleUtil::clear(m_bufferInt, samples_to_read);
+                        m_bufferIntSize = getOutputSignal().samples2frames(samples_to_read);
                     } else {
                         continue;
                     }

--- a/src/engine/bufferscalers/enginebufferscalelinear.cpp
+++ b/src/engine/bufferscalers/enginebufferscalelinear.cpp
@@ -287,13 +287,9 @@ SINT EngineBufferScaleLinear::do_scale(CSAMPLE* buf, SINT buf_size) {
                 m_bufferIntSize = m_pReadAheadManager->getNextSamples(
                         rate_new == 0 ? rate_old : rate_new,
                         m_bufferInt, samples_to_read);
-
-                VERIFY_OR_DEBUG_ASSERT(m_bufferIntSize != 0) {
-                    // getNextSamples() must never fail,
-                    // using silence as a last resort
-                    SampleUtil::clear(m_bufferInt, samples_to_read);
-                    m_bufferIntSize = getOutputSignal().samples2frames(samples_to_read);
-                }
+                // Note we may get 0 samples once if we just hit a loop trigger,
+                // e.g. when reloop_toggle jumps back to loop_in, or when
+                // moving a loop causes the play position to be moved along.
 
                 frames_read += getOutputSignal().samples2frames(m_bufferIntSize);
                 unscaled_frames_needed -= getOutputSignal().samples2frames(m_bufferIntSize);

--- a/src/engine/bufferscalers/enginebufferscalerubberband.cpp
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.cpp
@@ -208,11 +208,15 @@ double EngineBufferScaleRubberBand::scaleBuffer(
                 last_read_failed = false;
                 deinterleaveAndProcess(m_buffer_back, iAvailFrames);
             } else {
+                // We may get 0 samples once if we just hit a loop trigger, e.g.
+                // when reloop_toggle jumps back to loop_in, or when moving a
+                // loop causes the play position to be moved along.
                 if (last_read_failed) {
-                    DEBUG_ASSERT(!"getNextSamples must never fail");
-                    // Flush and break out after the next retrieval. If we are
-                    // at EOF this serves to get the last samples out of
-                    // RubberBand.
+                    // If we get 0 samples repeatedly, flush and break out after
+                    // the next retrieval. If we are at EOF this serves to get
+                    // the last samples out of RubberBand.
+                    qDebug() << "ReadAheadManager::getNextSamples() returned "
+                                "zero samples repeatedly. Padding with silence.";
                     SampleUtil::clear(
                             m_buffer_back,
                             getOutputSignal().frames2samples(iLenFramesRequired));

--- a/src/engine/bufferscalers/enginebufferscalerubberband.h
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.h
@@ -32,7 +32,7 @@ class EngineBufferScaleRubberBand : public EngineBufferScale {
     // Reset RubberBand library with new audio signal
     void onSampleRateChanged() override;
 
-    void deinterleaveAndProcess(const CSAMPLE* pBuffer, SINT frames, bool flush);
+    void deinterleaveAndProcess(const CSAMPLE* pBuffer, SINT frames);
     SINT retrieveAndDeinterleave(CSAMPLE* pBuffer, SINT frames);
 
     // The read-ahead manager that we use to fetch samples

--- a/src/engine/bufferscalers/enginebufferscalest.cpp
+++ b/src/engine/bufferscalers/enginebufferscalest.cpp
@@ -154,8 +154,12 @@ double EngineBufferScaleST::scaleBuffer(
                 m_pSoundTouch->putSamples(buffer_back.data(), iAvailFrames);
             } else {
                 if (last_read_failed) {
-                    m_pSoundTouch->flush();
-                    break; // exit loop after failure
+                    DEBUG_ASSERT(!"getNextSamples must never fail");
+                    // Add silence that allows to Flush the last samples out of Soundtouch
+                    // m_pSoundTouch->flush(); must not be used, because it allocates a
+                    // temporary buffer in the heap which maybe locking
+                    SampleUtil::clear(m_bufferBack.data(), m_bufferBack.size());
+                    m_pSoundTouch->putSamples(m_bufferBack.data(), m_bufferBack.size());
                 }
                 last_read_failed = true;
             }

--- a/src/engine/bufferscalers/enginebufferscalest.cpp
+++ b/src/engine/bufferscalers/enginebufferscalest.cpp
@@ -158,8 +158,8 @@ double EngineBufferScaleST::scaleBuffer(
                     // Add silence that allows to Flush the last samples out of Soundtouch
                     // m_pSoundTouch->flush(); must not be used, because it allocates a
                     // temporary buffer in the heap which maybe locking
-                    SampleUtil::clear(m_bufferBack.data(), m_bufferBack.size());
-                    m_pSoundTouch->putSamples(m_bufferBack.data(), m_bufferBack.size());
+                    SampleUtil::clear(buffer_back.data(), buffer_back.size());
+                    m_pSoundTouch->putSamples(buffer_back.data(), buffer_back.size());
                 }
                 last_read_failed = true;
             }

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -93,8 +93,8 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
         m_cacheMissHappened = true;
     } else if (m_cacheMissHappened) {
         // Previous read was a cache miss, but now we got something back.
-        // Apply ramping gain, because the last buffer has unwanted silenced
-        // and new without fading are causing a pop.
+        // Apply ramping gain, because the last buffer has unwanted silence
+        // and new samples without fading are causing a pop.
         SampleUtil::applyRampingGain(pOutput, 0.0, 1.0, samples_from_reader);
         // Reset the cache miss flag, because we are now back on track.
         m_cacheMissHappened = false;

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -75,7 +75,7 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
     }
 
     // Sanity checks.
-    if (samples_from_reader < 0) {
+    VERIFY_OR_DEBUG_ASSERT(samples_from_reader >= 0) {
         qDebug() << "Need negative samples in ReadAheadManager::getNextSamples. Ignoring read";
         return 0;
     }
@@ -152,12 +152,10 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
         }
 
         // do crossfade from the current buffer into the new loop beginning
-        if (samples_from_reader != 0) { // avoid division by zero
-            SampleUtil::linearCrossfadeBuffersOut(
-                    pOutput,
-                    m_pCrossFadeBuffer,
-                    samples_from_reader);
-        }
+        SampleUtil::linearCrossfadeBuffersOut(
+                pOutput,
+                m_pCrossFadeBuffer,
+                samples_from_reader);
     }
 
     //qDebug() << "read" << m_currentPosition << samples_read;


### PR DESCRIPTION
This is a leftover form an earlier version of the engine, that is no longer needed. If this assumption is wrong the engine would have used old samples left in the buffer In. We now assert for this condition and clear the buffer if the assumption is wrong. 