### PR TITLE
Fixed regression in coverart tooltip - The assert occured always

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -1,10 +1,7 @@
 #include "library/basetracktablemodel.h"
 
-#include <QScreen>
-// for hack to get primary screen instead of view widget's screen
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
 #include <QGuiApplication>
-#endif
+#include <QScreen>
 
 #include "library/bpmdelegate.h"
 #include "library/colordelegate.h"
@@ -515,14 +512,7 @@ bool BaseTrackTableModel::setData(
 QVariant BaseTrackTableModel::composeCoverArtToolTipHtml(
         const QModelIndex& index) const {
     // Determine height of the cover art image depending on the screen size
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
-    auto* pTableView = qobject_cast<WTrackTableView*>(parent());
-    VERIFY_OR_DEBUG_ASSERT(pTableView) {
-        return QVariant();
-    }
-    QScreen* pViewScreen = pTableView->screen();
-#else
-    // Ugly hack assuming that the view is on whatever Qt considers the primary screen.
+    // Assuming that the view is on whatever Qt considers the primary screen.
     QGuiApplication* app = static_cast<QGuiApplication*>(QCoreApplication::instance());
     VERIFY_OR_DEBUG_ASSERT(app) {
         qWarning() << "Unable to get application's QGuiApplication instance, "
@@ -530,7 +520,7 @@ QVariant BaseTrackTableModel::composeCoverArtToolTipHtml(
         return QVariant();
     }
     QScreen* pViewScreen = app->primaryScreen();
-#endif
+
     unsigned int absoluteHeightOfCoverartToolTip = static_cast<int>(
             pViewScreen->availableGeometry().height() *
             kRelativeHeightOfCoverartToolTip);


### PR DESCRIPTION
This fixes a regression for QT>=5.14 introduced in https://github.com/mixxxdj/mixxx/pull/4309 

If you move the mouse over a cover art in the library, the tool tip should appear, but due to this regression it always asserted. The function `parent()` returns always `nullptr`.

Stacktrace:
```
Qt5Core.dll!00007ffaae1e0598()
Qt5Core.dll!00007ffaae1de80d()
mixxx.exe!mixxx::`anonymous namespace'::handleMessage(QtMsgType type, const QMessageLogContext & context, const QString & input) Line 355
	at C:\Users\Joerg.WORLDWARTWEB\source\repos\JoergAtGithub\mixxx\src\util\logging.cpp(355)
[External Code]
[Inline Frame] mixxx.exe!mixxx_debug_assert(const char *) Line 9
	at C:\Users\Joerg.WORLDWARTWEB\source\repos\JoergAtGithub\mixxx\src\util\assert.h(9)
[Inline Frame] mixxx.exe!mixxx_debug_assert_return_true(const char *) Line 18
	at C:\Users\Joerg.WORLDWARTWEB\source\repos\JoergAtGithub\mixxx\src\util\assert.h(18)
mixxx.exe!BaseTrackTableModel::composeCoverArtToolTipHtml(const QModelIndex & index) Line 521
	at C:\Users\Joerg.WORLDWARTWEB\source\repos\JoergAtGithub\mixxx\src\library\basetracktablemodel.cpp(521)
mixxx.exe!BaseTrackTableModel::roleValue(const QModelIndex & index, QVariant && rawValue, int role) Line 573
	at C:\Users\Joerg.WORLDWARTWEB\source\repos\JoergAtGithub\mixxx\src\library\basetracktablemodel.cpp(573)
mixxx.exe!BaseTrackTableModel::data(const QModelIndex & index, int role) Line 436
	at C:\Users\Joerg.WORLDWARTWEB\source\repos\JoergAtGithub\mixxx\src\library\basetracktablemodel.cpp(436)
[External Code]
mixxx.exe!`anonymous namespace'::runMixxx(MixxxApplication * pApp, const CmdlineArgs & args) Line 72
	at C:\Users\Joerg.WORLDWARTWEB\source\repos\JoergAtGithub\mixxx\src\main.cpp(72)
mixxx.exe!main(int argc, char * * argv) Line 200
	at C:\Users\Joerg.WORLDWARTWEB\source\repos\JoergAtGithub\mixxx\src\main.cpp(200)
[External Code]
```
