### PR TITLE
Use the real track length to scale waveforms

### DIFF
--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -767,7 +767,7 @@ QString Track::getURL() const {
     return m_record.getUrl();
 }
 
-ConstWaveformPointer Track::getWaveform() const {
+const ConstWaveformPointer& Track::getWaveform() const {
     return m_waveform;
 }
 

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -241,7 +241,7 @@ class Track : public QObject {
     /// any metadata in file tags. Otherwise just the title (even if it is empty).
     QString getTitleInfo() const;
 
-    ConstWaveformPointer getWaveform() const;
+    const ConstWaveformPointer& getWaveform() const;
     void setWaveform(ConstWaveformPointer pWaveform);
 
     ConstWaveformPointer getWaveformSummary() const;

--- a/src/waveform/renderers/glslwaveformrenderersignal.cpp
+++ b/src/waveform/renderers/glslwaveformrenderersignal.cpp
@@ -78,18 +78,14 @@ bool GLSLWaveformRendererSignal::loadShaders() {
 }
 
 bool GLSLWaveformRendererSignal::loadTexture() {
-    TrackPointer trackInfo = m_waveformRenderer->getTrackInfo();
-    ConstWaveformPointer pWaveform;
     int dataSize = 0;
     const WaveformData* data = nullptr;
 
-    if (trackInfo) {
-        pWaveform = trackInfo->getWaveform();
-        if (pWaveform) {
-            dataSize = pWaveform->getDataSize();
-            if (dataSize > 1) {
-                data = pWaveform->data();
-            }
+    ConstWaveformPointer pWaveform = m_waveformRenderer->getWaveform();
+    if (pWaveform) {
+        dataSize = pWaveform->getDataSize();
+        if (dataSize > 1) {
+            data = pWaveform->data();
         }
     }
 
@@ -222,7 +218,7 @@ void GLSLWaveformRendererSignal::onSetTrack() {
 
     slotWaveformUpdated();
 
-    TrackPointer pTrack = m_waveformRenderer->getTrackInfo();
+    const TrackPointer pTrack = m_waveformRenderer->getTrackInfo();
     if (!pTrack) {
         return;
     }
@@ -256,12 +252,7 @@ void GLSLWaveformRendererSignal::slotWaveformUpdated() {
 }
 
 void GLSLWaveformRendererSignal::draw(QPainter* painter, QPaintEvent* /*event*/) {
-    TrackPointer trackInfo = m_waveformRenderer->getTrackInfo();
-    if (!trackInfo) {
-        return;
-    }
-
-    ConstWaveformPointer pWaveform = trackInfo->getWaveform();
+    ConstWaveformPointer pWaveform = m_waveformRenderer->getWaveform();
     if (pWaveform.isNull()) {
         return;
     }

--- a/src/waveform/renderers/glslwaveformrenderersignal.cpp
+++ b/src/waveform/renderers/glslwaveformrenderersignal.cpp
@@ -79,16 +79,16 @@ bool GLSLWaveformRendererSignal::loadShaders() {
 
 bool GLSLWaveformRendererSignal::loadTexture() {
     TrackPointer trackInfo = m_waveformRenderer->getTrackInfo();
-    ConstWaveformPointer waveform;
+    ConstWaveformPointer pWaveform;
     int dataSize = 0;
     const WaveformData* data = nullptr;
 
     if (trackInfo) {
-        waveform = trackInfo->getWaveform();
-        if (waveform) {
-            dataSize = waveform->getDataSize();
+        pWaveform = trackInfo->getWaveform();
+        if (pWaveform) {
+            dataSize = pWaveform->getDataSize();
             if (dataSize > 1) {
-                data = waveform->data();
+                data = pWaveform->data();
             }
         }
     }
@@ -114,11 +114,11 @@ bool GLSLWaveformRendererSignal::loadTexture() {
     glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 
-    if (waveform != nullptr && data != nullptr) {
+    if (pWaveform != nullptr && data != nullptr) {
         // Waveform ensures that getTextureSize is a multiple of
         // getTextureStride so there is no rounding here.
-        int textureWidth = waveform->getTextureStride();
-        int textureHeight = waveform->getTextureSize() / waveform->getTextureStride();
+        int textureWidth = pWaveform->getTextureStride();
+        int textureHeight = pWaveform->getTextureSize() / pWaveform->getTextureStride();
 
         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, textureWidth, textureHeight, 0,
                      GL_RGBA, GL_UNSIGNED_BYTE, data);
@@ -261,17 +261,17 @@ void GLSLWaveformRendererSignal::draw(QPainter* painter, QPaintEvent* /*event*/)
         return;
     }
 
-    ConstWaveformPointer waveform = trackInfo->getWaveform();
-    if (waveform.isNull()) {
+    ConstWaveformPointer pWaveform = trackInfo->getWaveform();
+    if (pWaveform.isNull()) {
         return;
     }
 
-    int dataSize = waveform->getDataSize();
+    int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
         return;
     }
 
-    const WaveformData* data = waveform->data();
+    const WaveformData* data = pWaveform->data();
     if (data == nullptr) {
         return;
     }
@@ -283,7 +283,7 @@ void GLSLWaveformRendererSignal::draw(QPainter* painter, QPaintEvent* /*event*/)
 
     // NOTE(vRince): completion can change during loadTexture
     // do not remove currenCompletion temp variable !
-    const int currentCompletion = waveform->getCompletion();
+    const int currentCompletion = pWaveform->getCompletion();
     if (m_textureRenderedWaveformCompletion < currentCompletion) {
         loadTexture();
         m_textureRenderedWaveformCompletion = currentCompletion;
@@ -329,8 +329,8 @@ void GLSLWaveformRendererSignal::draw(QPainter* painter, QPaintEvent* /*event*/)
         m_frameShaderProgram->setUniformValue("framebufferSize", QVector2D(
             m_framebuffer->width(), m_framebuffer->height()));
         m_frameShaderProgram->setUniformValue("waveformLength", dataSize);
-        m_frameShaderProgram->setUniformValue("textureSize", waveform->getTextureSize());
-        m_frameShaderProgram->setUniformValue("textureStride", waveform->getTextureStride());
+        m_frameShaderProgram->setUniformValue("textureSize", pWaveform->getTextureSize());
+        m_frameShaderProgram->setUniformValue("textureStride", pWaveform->getTextureStride());
 
         m_frameShaderProgram->setUniformValue("firstVisualIndex", firstVisualIndex);
         m_frameShaderProgram->setUniformValue("lastVisualIndex", lastVisualIndex);

--- a/src/waveform/renderers/glslwaveformrenderersignal.cpp
+++ b/src/waveform/renderers/glslwaveformrenderersignal.cpp
@@ -266,6 +266,11 @@ void GLSLWaveformRendererSignal::draw(QPainter* painter, QPaintEvent* /*event*/)
         return;
     }
 
+    const double audioVisualRatio = pWaveform->getAudioVisualRatio();
+    if (audioVisualRatio <= 0) {
+        return;
+    }
+
     int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
         return;
@@ -273,6 +278,11 @@ void GLSLWaveformRendererSignal::draw(QPainter* painter, QPaintEvent* /*event*/)
 
     const WaveformData* data = pWaveform->data();
     if (data == nullptr) {
+        return;
+    }
+
+    const int trackSamples = m_waveformRenderer->getTrackSamples();
+    if (trackSamples <= 0) {
         return;
     }
 
@@ -294,9 +304,10 @@ void GLSLWaveformRendererSignal::draw(QPainter* painter, QPaintEvent* /*event*/)
     getGains(&allGain, &lowGain, &midGain, &highGain);
 
     const auto firstVisualIndex = static_cast<GLfloat>(
-            m_waveformRenderer->getFirstDisplayedPosition() * dataSize / 2.0);
+            m_waveformRenderer->getFirstDisplayedPosition() * trackSamples /
+            audioVisualRatio / 2.0);
     const auto lastVisualIndex = static_cast<GLfloat>(
-            m_waveformRenderer->getLastDisplayedPosition() * dataSize / 2.0);
+            m_waveformRenderer->getLastDisplayedPosition() * trackSamples / audioVisualRatio / 2.0);
 
     // const int firstIndex = int(firstVisualIndex+0.5);
     // firstVisualIndex = firstIndex - firstIndex%2;

--- a/src/waveform/renderers/glvsynctestrenderer.cpp
+++ b/src/waveform/renderers/glvsynctestrenderer.cpp
@@ -39,17 +39,17 @@ void GLVSyncTestRenderer::draw(QPainter* painter, QPaintEvent* /*event*/) {
         return;
     }
 
-    ConstWaveformPointer waveform = pTrack->getWaveform();
-    if (waveform.isNull()) {
+    ConstWaveformPointer pWaveform = pTrack->getWaveform();
+    if (pWaveform.isNull()) {
         return;
     }
 
-    const int dataSize = waveform->getDataSize();
+    const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
         return;
     }
 
-    const WaveformData* data = waveform->data();
+    const WaveformData* data = pWaveform->data();
     if (data == nullptr) {
         return;
     }

--- a/src/waveform/renderers/glvsynctestrenderer.cpp
+++ b/src/waveform/renderers/glvsynctestrenderer.cpp
@@ -34,12 +34,7 @@ void GLVSyncTestRenderer::draw(QPainter* painter, QPaintEvent* /*event*/) {
 
     timer.start();
 
-    TrackPointer pTrack = m_waveformRenderer->getTrackInfo();
-    if (!pTrack) {
-        return;
-    }
-
-    ConstWaveformPointer pWaveform = pTrack->getWaveform();
+    ConstWaveformPointer pWaveform = m_waveformRenderer->getWaveform();
     if (pWaveform.isNull()) {
         return;
     }

--- a/src/waveform/renderers/glvsynctestrenderer.cpp
+++ b/src/waveform/renderers/glvsynctestrenderer.cpp
@@ -44,6 +44,11 @@ void GLVSyncTestRenderer::draw(QPainter* painter, QPaintEvent* /*event*/) {
         return;
     }
 
+    const double audioVisualRatio = pWaveform->getAudioVisualRatio();
+    if (audioVisualRatio <= 0) {
+        return;
+    }
+
     const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
         return;
@@ -54,8 +59,15 @@ void GLVSyncTestRenderer::draw(QPainter* painter, QPaintEvent* /*event*/) {
         return;
     }
 
-    double firstVisualIndex = m_waveformRenderer->getFirstDisplayedPosition() * dataSize;
-    double lastVisualIndex = m_waveformRenderer->getLastDisplayedPosition() * dataSize;
+    const int trackSamples = m_waveformRenderer->getTrackSamples();
+    if (trackSamples <= 0) {
+        return;
+    }
+
+    double firstVisualIndex = m_waveformRenderer->getFirstDisplayedPosition() *
+            trackSamples / audioVisualRatio;
+    double lastVisualIndex = m_waveformRenderer->getLastDisplayedPosition() *
+            trackSamples / audioVisualRatio;
 
     const int firstIndex = int(firstVisualIndex + 0.5);
     firstVisualIndex = firstIndex - firstIndex % 2;

--- a/src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
@@ -35,6 +35,11 @@ void GLWaveformRendererFilteredSignal::draw(QPainter* painter, QPaintEvent* /*ev
         return;
     }
 
+    const double audioVisualRatio = pWaveform->getAudioVisualRatio();
+    if (audioVisualRatio <= 0) {
+        return;
+    }
+
     const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
         return;
@@ -45,10 +50,15 @@ void GLWaveformRendererFilteredSignal::draw(QPainter* painter, QPaintEvent* /*ev
         return;
     }
 
+    const int trackSamples = m_waveformRenderer->getTrackSamples();
+    if (trackSamples <= 0) {
+        return;
+    }
+
     auto firstVisualIndex = static_cast<GLfloat>(
-            m_waveformRenderer->getFirstDisplayedPosition() * dataSize);
+            m_waveformRenderer->getFirstDisplayedPosition() * trackSamples / audioVisualRatio);
     auto lastVisualIndex = static_cast<GLfloat>(
-            m_waveformRenderer->getLastDisplayedPosition() * dataSize);
+            m_waveformRenderer->getLastDisplayedPosition() * trackSamples / audioVisualRatio);
     const auto lineWidth = static_cast<GLfloat>(
             1.0 / m_waveformRenderer->getVisualSamplePerPixel() + 1);
 

--- a/src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
@@ -25,12 +25,7 @@ void GLWaveformRendererFilteredSignal::onSetup(const QDomNode& /*node*/) {
 void GLWaveformRendererFilteredSignal::draw(QPainter* painter, QPaintEvent* /*event*/) {
     maybeInitializeGL();
 
-    TrackPointer pTrack = m_waveformRenderer->getTrackInfo();
-    if (!pTrack) {
-        return;
-    }
-
-    ConstWaveformPointer pWaveform = pTrack->getWaveform();
+    ConstWaveformPointer pWaveform = m_waveformRenderer->getWaveform();
     if (pWaveform.isNull()) {
         return;
     }

--- a/src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
@@ -30,17 +30,17 @@ void GLWaveformRendererFilteredSignal::draw(QPainter* painter, QPaintEvent* /*ev
         return;
     }
 
-    ConstWaveformPointer waveform = pTrack->getWaveform();
-    if (waveform.isNull()) {
+    ConstWaveformPointer pWaveform = pTrack->getWaveform();
+    if (pWaveform.isNull()) {
         return;
     }
 
-    const int dataSize = waveform->getDataSize();
+    const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
         return;
     }
 
-    const WaveformData* data = waveform->data();
+    const WaveformData* data = pWaveform->data();
     if (data == nullptr) {
         return;
     }

--- a/src/waveform/renderers/glwaveformrendererrgb.cpp
+++ b/src/waveform/renderers/glwaveformrendererrgb.cpp
@@ -37,6 +37,11 @@ void GLWaveformRendererRGB::draw(QPainter* painter, QPaintEvent* /*event*/) {
         return;
     }
 
+    const double audioVisualRatio = pWaveform->getAudioVisualRatio();
+    if (audioVisualRatio <= 0) {
+        return;
+    }
+
     const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
         return;
@@ -47,10 +52,15 @@ void GLWaveformRendererRGB::draw(QPainter* painter, QPaintEvent* /*event*/) {
         return;
     }
 
+    const int trackSamples = m_waveformRenderer->getTrackSamples();
+    if (trackSamples <= 0) {
+        return;
+    }
+
     auto firstVisualIndex = static_cast<GLfloat>(
-            m_waveformRenderer->getFirstDisplayedPosition() * dataSize);
+            m_waveformRenderer->getFirstDisplayedPosition() * trackSamples / audioVisualRatio);
     auto lastVisualIndex = static_cast<GLfloat>(
-            m_waveformRenderer->getLastDisplayedPosition() * dataSize);
+            m_waveformRenderer->getLastDisplayedPosition() * trackSamples / audioVisualRatio);
     const auto lineWidth = static_cast<GLfloat>(
             (1.0 / m_waveformRenderer->getVisualSamplePerPixel()) + 1.5);
 

--- a/src/waveform/renderers/glwaveformrendererrgb.cpp
+++ b/src/waveform/renderers/glwaveformrendererrgb.cpp
@@ -27,12 +27,7 @@ void GLWaveformRendererRGB::onSetup(const QDomNode& /* node */) {
 void GLWaveformRendererRGB::draw(QPainter* painter, QPaintEvent* /*event*/) {
     maybeInitializeGL();
 
-    TrackPointer pTrack = m_waveformRenderer->getTrackInfo();
-    if (!pTrack) {
-        return;
-    }
-
-    ConstWaveformPointer pWaveform = pTrack->getWaveform();
+    ConstWaveformPointer pWaveform = m_waveformRenderer->getWaveform();
     if (pWaveform.isNull()) {
         return;
     }

--- a/src/waveform/renderers/glwaveformrendererrgb.cpp
+++ b/src/waveform/renderers/glwaveformrendererrgb.cpp
@@ -32,17 +32,17 @@ void GLWaveformRendererRGB::draw(QPainter* painter, QPaintEvent* /*event*/) {
         return;
     }
 
-    ConstWaveformPointer waveform = pTrack->getWaveform();
-    if (waveform.isNull()) {
+    ConstWaveformPointer pWaveform = pTrack->getWaveform();
+    if (pWaveform.isNull()) {
         return;
     }
 
-    const int dataSize = waveform->getDataSize();
+    const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
         return;
     }
 
-    const WaveformData* data = waveform->data();
+    const WaveformData* data = pWaveform->data();
     if (data == nullptr) {
         return;
     }

--- a/src/waveform/renderers/glwaveformrenderersimplesignal.cpp
+++ b/src/waveform/renderers/glwaveformrenderersimplesignal.cpp
@@ -32,17 +32,17 @@ void GLWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
         return;
     }
 
-    ConstWaveformPointer waveform = pTrack->getWaveform();
-    if (waveform.isNull()) {
+    ConstWaveformPointer pWaveform = pTrack->getWaveform();
+    if (pWaveform.isNull()) {
         return;
     }
 
-    const int dataSize = waveform->getDataSize();
+    const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
         return;
     }
 
-    const WaveformData* data = waveform->data();
+    const WaveformData* data = pWaveform->data();
     if (data == nullptr) {
         return;
     }

--- a/src/waveform/renderers/glwaveformrenderersimplesignal.cpp
+++ b/src/waveform/renderers/glwaveformrenderersimplesignal.cpp
@@ -37,6 +37,11 @@ void GLWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
         return;
     }
 
+    const double audioVisualRatio = pWaveform->getAudioVisualRatio();
+    if (audioVisualRatio <= 0) {
+        return;
+    }
+
     const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
         return;
@@ -47,10 +52,15 @@ void GLWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
         return;
     }
 
+    const int trackSamples = m_waveformRenderer->getTrackSamples();
+    if (trackSamples <= 0) {
+        return;
+    }
+
     auto firstVisualIndex = static_cast<GLfloat>(
-            m_waveformRenderer->getFirstDisplayedPosition() * dataSize);
+            m_waveformRenderer->getFirstDisplayedPosition() * trackSamples / audioVisualRatio);
     auto lastVisualIndex = static_cast<GLfloat>(
-            m_waveformRenderer->getLastDisplayedPosition() * dataSize);
+            m_waveformRenderer->getLastDisplayedPosition() * trackSamples / audioVisualRatio);
     const auto lineWidth = static_cast<GLfloat>(
             1.0 / m_waveformRenderer->getVisualSamplePerPixel() + 1);
 

--- a/src/waveform/renderers/glwaveformrenderersimplesignal.cpp
+++ b/src/waveform/renderers/glwaveformrenderersimplesignal.cpp
@@ -27,12 +27,7 @@ inline void setPoint(QPointF& point, qreal x, qreal y) {
 void GLWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*event*/) {
     maybeInitializeGL();
 
-    TrackPointer pTrack = m_waveformRenderer->getTrackInfo();
-    if (!pTrack) {
-        return;
-    }
-
-    ConstWaveformPointer pWaveform = pTrack->getWaveform();
+    ConstWaveformPointer pWaveform = m_waveformRenderer->getWaveform();
     if (pWaveform.isNull()) {
         return;
     }

--- a/src/waveform/renderers/qtvsynctestrenderer.cpp
+++ b/src/waveform/renderers/qtvsynctestrenderer.cpp
@@ -33,12 +33,7 @@ void QtVSyncTestRenderer::draw(QPainter* pPainter, QPaintEvent* /*event*/) {
 
     timer.start();
 
-    TrackPointer pTrack = m_waveformRenderer->getTrackInfo();
-    if (!pTrack) {
-        return;
-    }
-
-    ConstWaveformPointer pWaveform = pTrack->getWaveform();
+    ConstWaveformPointer pWaveform = m_waveformRenderer->getWaveform();
     if (pWaveform.isNull()) {
         return;
     }

--- a/src/waveform/renderers/qtvsynctestrenderer.cpp
+++ b/src/waveform/renderers/qtvsynctestrenderer.cpp
@@ -38,17 +38,17 @@ void QtVSyncTestRenderer::draw(QPainter* pPainter, QPaintEvent* /*event*/) {
         return;
     }
 
-    ConstWaveformPointer waveform = pTrack->getWaveform();
-    if (waveform.isNull()) {
+    ConstWaveformPointer pWaveform = pTrack->getWaveform();
+    if (pWaveform.isNull()) {
         return;
     }
 
-    const int dataSize = waveform->getDataSize();
+    const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
         return;
     }
 
-    const WaveformData* data = waveform->data();
+    const WaveformData* data = pWaveform->data();
     if (data == nullptr) {
         return;
     }

--- a/src/waveform/renderers/qtwaveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/qtwaveformrendererfilteredsignal.cpp
@@ -97,12 +97,7 @@ inline void setPoint(QPointF& point, qreal x, qreal y) {
 int QtWaveformRendererFilteredSignal::buildPolygon() {
     // We have to check the track is present because it might have been unloaded
     // between the call to draw and the call to buildPolygon
-    TrackPointer pTrack = m_waveformRenderer->getTrackInfo();
-    if (!pTrack) {
-        return 0;
-    }
-
-    ConstWaveformPointer pWaveform = pTrack->getWaveform();
+    ConstWaveformPointer pWaveform = m_waveformRenderer->getWaveform();
     if (pWaveform.isNull()) {
         return 0;
     }

--- a/src/waveform/renderers/qtwaveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/qtwaveformrendererfilteredsignal.cpp
@@ -107,6 +107,11 @@ int QtWaveformRendererFilteredSignal::buildPolygon() {
         return 0;
     }
 
+    const double audioVisualRatio = pWaveform->getAudioVisualRatio();
+    if (audioVisualRatio <= 0) {
+        return 0;
+    }
+
     const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
         return 0;
@@ -117,8 +122,17 @@ int QtWaveformRendererFilteredSignal::buildPolygon() {
         return 0;
     }
 
-    const double firstVisualIndex = m_waveformRenderer->getFirstDisplayedPosition() * dataSize;
-    const double lastVisualIndex = m_waveformRenderer->getLastDisplayedPosition() * dataSize;
+    const int trackSamples = m_waveformRenderer->getTrackSamples();
+    if (trackSamples <= 0) {
+        return 0;
+    }
+
+    const double firstVisualIndex =
+            m_waveformRenderer->getFirstDisplayedPosition() * trackSamples /
+            audioVisualRatio;
+    const double lastVisualIndex =
+            m_waveformRenderer->getLastDisplayedPosition() * trackSamples /
+            audioVisualRatio;
 
     m_polygon[0].clear();
     m_polygon[1].clear();

--- a/src/waveform/renderers/qtwaveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/qtwaveformrendererfilteredsignal.cpp
@@ -102,17 +102,17 @@ int QtWaveformRendererFilteredSignal::buildPolygon() {
         return 0;
     }
 
-    ConstWaveformPointer waveform = pTrack->getWaveform();
-    if (waveform.isNull()) {
+    ConstWaveformPointer pWaveform = pTrack->getWaveform();
+    if (pWaveform.isNull()) {
         return 0;
     }
 
-    const int dataSize = waveform->getDataSize();
+    const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
         return 0;
     }
 
-    const WaveformData* data = waveform->data();
+    const WaveformData* data = pWaveform->data();
     if (data == nullptr) {
         return 0;
     }

--- a/src/waveform/renderers/qtwaveformrenderersimplesignal.cpp
+++ b/src/waveform/renderers/qtwaveformrenderersimplesignal.cpp
@@ -49,6 +49,11 @@ void QtWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
         return;
     }
 
+    const double audioVisualRatio = pWaveform->getAudioVisualRatio();
+    if (audioVisualRatio <= 0) {
+        return;
+    }
+
     const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
         return;
@@ -56,6 +61,11 @@ void QtWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
 
     const WaveformData* data = pWaveform->data();
     if (data == nullptr) {
+        return;
+    }
+
+    const int trackSamples = m_waveformRenderer->getTrackSamples();
+    if (trackSamples <= 0) {
         return;
     }
 
@@ -90,8 +100,12 @@ void QtWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
         painter->drawLine(0,0,m_waveformRenderer->getLength(),0);
     }
 
-    const double firstVisualIndex = m_waveformRenderer->getFirstDisplayedPosition() * dataSize;
-    const double lastVisualIndex = m_waveformRenderer->getLastDisplayedPosition() * dataSize;
+    const double firstVisualIndex =
+            m_waveformRenderer->getFirstDisplayedPosition() * trackSamples /
+            audioVisualRatio;
+    const double lastVisualIndex =
+            m_waveformRenderer->getLastDisplayedPosition() * trackSamples /
+            audioVisualRatio;
     m_polygon.clear();
     m_polygon.reserve(2 * m_waveformRenderer->getLength() + 2);
     m_polygon.append(QPointF(0.0, 0.0));

--- a/src/waveform/renderers/qtwaveformrenderersimplesignal.cpp
+++ b/src/waveform/renderers/qtwaveformrenderersimplesignal.cpp
@@ -38,13 +38,7 @@ inline void setPoint(QPointF& point, qreal x, qreal y) {
 }
 
 void QtWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*event*/) {
-
-    TrackPointer pTrack = m_waveformRenderer->getTrackInfo();
-    if (!pTrack) {
-        return;
-    }
-
-    ConstWaveformPointer pWaveform = pTrack->getWaveform();
+    ConstWaveformPointer pWaveform = m_waveformRenderer->getWaveform();
     if (pWaveform.isNull()) {
         return;
     }

--- a/src/waveform/renderers/qtwaveformrenderersimplesignal.cpp
+++ b/src/waveform/renderers/qtwaveformrenderersimplesignal.cpp
@@ -44,17 +44,17 @@ void QtWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
         return;
     }
 
-    ConstWaveformPointer waveform = pTrack->getWaveform();
-    if (waveform.isNull()) {
+    ConstWaveformPointer pWaveform = pTrack->getWaveform();
+    if (pWaveform.isNull()) {
         return;
     }
 
-    const int dataSize = waveform->getDataSize();
+    const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
         return;
     }
 
-    const WaveformData* data = waveform->data();
+    const WaveformData* data = pWaveform->data();
     if (data == nullptr) {
         return;
     }

--- a/src/waveform/renderers/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/waveformrenderbeat.cpp
@@ -25,13 +25,13 @@ void WaveformRenderBeat::setup(const QDomNode& node, const SkinContext& context)
 }
 
 void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
-    TrackPointer trackInfo = m_waveformRenderer->getTrackInfo();
+    TrackPointer pTrackInfo = m_waveformRenderer->getTrackInfo();
 
-    if (!trackInfo) {
+    if (!pTrackInfo) {
         return;
     }
 
-    mixxx::BeatsPointer trackBeats = trackInfo->getBeats();
+    mixxx::BeatsPointer trackBeats = pTrackInfo->getBeats();
     if (!trackBeats) {
         return;
     }

--- a/src/waveform/renderers/waveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/waveformrendererfilteredsignal.cpp
@@ -30,12 +30,7 @@ void WaveformRendererFilteredSignal::onSetup(const QDomNode& node) {
 
 void WaveformRendererFilteredSignal::draw(QPainter* painter,
                                           QPaintEvent* /*event*/) {
-    const TrackPointer pTrackInfo = m_waveformRenderer->getTrackInfo();
-    if (!pTrackInfo) {
-        return;
-    }
-
-    ConstWaveformPointer pWaveform = pTrackInfo->getWaveform();
+    ConstWaveformPointer pWaveform = m_waveformRenderer->getWaveform();
     if (pWaveform.isNull()) {
         return;
     }

--- a/src/waveform/renderers/waveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/waveformrendererfilteredsignal.cpp
@@ -40,6 +40,11 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
         return;
     }
 
+    const double audioVisualRatio = pWaveform->getAudioVisualRatio();
+    if (audioVisualRatio <= 0) {
+        return;
+    }
+
     const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
         return;
@@ -47,6 +52,11 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
 
     const WaveformData* data = pWaveform->data();
     if (data == nullptr) {
+        return;
+    }
+
+    const int trackSamples = m_waveformRenderer->getTrackSamples();
+    if (trackSamples <= 0) {
         return;
     }
 
@@ -62,8 +72,12 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
         painter->setTransform(QTransform(0, 1, 1, 0, 0, 0));
     }
 
-    const double firstVisualIndex = m_waveformRenderer->getFirstDisplayedPosition() * dataSize;
-    const double lastVisualIndex = m_waveformRenderer->getLastDisplayedPosition() * dataSize;
+    const double firstVisualIndex =
+            m_waveformRenderer->getFirstDisplayedPosition() * trackSamples /
+            audioVisualRatio;
+    const double lastVisualIndex =
+            m_waveformRenderer->getLastDisplayedPosition() * trackSamples /
+            audioVisualRatio;
 
     // Represents the # of waveform data points per horizontal pixel.
     const double gain = (lastVisualIndex - firstVisualIndex) /

--- a/src/waveform/renderers/waveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/waveformrendererfilteredsignal.cpp
@@ -30,22 +30,22 @@ void WaveformRendererFilteredSignal::onSetup(const QDomNode& node) {
 
 void WaveformRendererFilteredSignal::draw(QPainter* painter,
                                           QPaintEvent* /*event*/) {
-    const TrackPointer trackInfo = m_waveformRenderer->getTrackInfo();
-    if (!trackInfo) {
+    const TrackPointer pTrackInfo = m_waveformRenderer->getTrackInfo();
+    if (!pTrackInfo) {
         return;
     }
 
-    ConstWaveformPointer waveform = trackInfo->getWaveform();
-    if (waveform.isNull()) {
+    ConstWaveformPointer pWaveform = pTrackInfo->getWaveform();
+    if (pWaveform.isNull()) {
         return;
     }
 
-    const int dataSize = waveform->getDataSize();
+    const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
         return;
     }
 
-    const WaveformData* data = waveform->data();
+    const WaveformData* data = pWaveform->data();
     if (data == nullptr) {
         return;
     }

--- a/src/waveform/renderers/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/waveformrendererhsv.cpp
@@ -23,22 +23,22 @@ void WaveformRendererHSV::onSetup(const QDomNode& node) {
 
 void WaveformRendererHSV::draw(QPainter* painter,
                                           QPaintEvent* /*event*/) {
-    const TrackPointer trackInfo = m_waveformRenderer->getTrackInfo();
-    if (!trackInfo) {
+    const TrackPointer pTrackInfo = m_waveformRenderer->getTrackInfo();
+    if (!pTrackInfo) {
         return;
     }
 
-    ConstWaveformPointer waveform = trackInfo->getWaveform();
-    if (waveform.isNull()) {
+    ConstWaveformPointer pWaveform = pTrackInfo->getWaveform();
+    if (pWaveform.isNull()) {
         return;
     }
 
-    const int dataSize = waveform->getDataSize();
+    const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
         return;
     }
 
-    const WaveformData* data = waveform->data();
+    const WaveformData* data = pWaveform->data();
     if (data == nullptr) {
         return;
     }

--- a/src/waveform/renderers/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/waveformrendererhsv.cpp
@@ -33,6 +33,11 @@ void WaveformRendererHSV::draw(QPainter* painter,
         return;
     }
 
+    const double audioVisualRatio = pWaveform->getAudioVisualRatio();
+    if (audioVisualRatio <= 0) {
+        return;
+    }
+
     const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
         return;
@@ -40,6 +45,11 @@ void WaveformRendererHSV::draw(QPainter* painter,
 
     const WaveformData* data = pWaveform->data();
     if (data == nullptr) {
+        return;
+    }
+
+    const int trackSamples = m_waveformRenderer->getTrackSamples();
+    if (trackSamples <= 0) {
         return;
     }
 
@@ -55,8 +65,12 @@ void WaveformRendererHSV::draw(QPainter* painter,
         painter->setTransform(QTransform(0, 1, 1, 0, 0, 0));
     }
 
-    const double firstVisualIndex = m_waveformRenderer->getFirstDisplayedPosition() * dataSize;
-    const double lastVisualIndex = m_waveformRenderer->getLastDisplayedPosition() * dataSize;
+    const double firstVisualIndex =
+            m_waveformRenderer->getFirstDisplayedPosition() * trackSamples /
+            audioVisualRatio;
+    const double lastVisualIndex =
+            m_waveformRenderer->getLastDisplayedPosition() * trackSamples /
+            audioVisualRatio;
 
     const double offset = firstVisualIndex;
 

--- a/src/waveform/renderers/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/waveformrendererhsv.cpp
@@ -21,14 +21,10 @@ void WaveformRendererHSV::onSetup(const QDomNode& node) {
     Q_UNUSED(node);
 }
 
-void WaveformRendererHSV::draw(QPainter* painter,
-                                          QPaintEvent* /*event*/) {
-    const TrackPointer pTrackInfo = m_waveformRenderer->getTrackInfo();
-    if (!pTrackInfo) {
-        return;
-    }
-
-    ConstWaveformPointer pWaveform = pTrackInfo->getWaveform();
+void WaveformRendererHSV::draw(
+        QPainter* painter,
+        QPaintEvent* /*event*/) {
+    ConstWaveformPointer pWaveform = m_waveformRenderer->getWaveform();
     if (pWaveform.isNull()) {
         return;
     }

--- a/src/waveform/renderers/waveformrendererpreroll.cpp
+++ b/src/waveform/renderers/waveformrendererpreroll.cpp
@@ -27,8 +27,8 @@ void WaveformRendererPreroll::setup(
 void WaveformRendererPreroll::draw(QPainter* painter, QPaintEvent* event) {
     Q_UNUSED(event);
 
-    const TrackPointer track = m_waveformRenderer->getTrackInfo();
-    if (!track) {
+    const TrackPointer pTrack = m_waveformRenderer->getTrackInfo();
+    if (!pTrack) {
         return;
     }
 

--- a/src/waveform/renderers/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/waveformrendererrgb.cpp
@@ -22,22 +22,22 @@ void WaveformRendererRGB::onSetup(const QDomNode& /* node */) {
 
 void WaveformRendererRGB::draw(QPainter* painter,
                                           QPaintEvent* /*event*/) {
-    const TrackPointer trackInfo = m_waveformRenderer->getTrackInfo();
-    if (!trackInfo) {
+    const TrackPointer pTrackInfo = m_waveformRenderer->getTrackInfo();
+    if (!pTrackInfo) {
         return;
     }
 
-    ConstWaveformPointer waveform = trackInfo->getWaveform();
-    if (waveform.isNull()) {
+    ConstWaveformPointer pWaveform = pTrackInfo->getWaveform();
+    if (pWaveform.isNull()) {
         return;
     }
 
-    const int dataSize = waveform->getDataSize();
+    const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
         return;
     }
 
-    const WaveformData* data = waveform->data();
+    const WaveformData* data = pWaveform->data();
     if (data == nullptr) {
         return;
     }

--- a/src/waveform/renderers/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/waveformrendererrgb.cpp
@@ -20,14 +20,10 @@ WaveformRendererRGB::~WaveformRendererRGB() {
 void WaveformRendererRGB::onSetup(const QDomNode& /* node */) {
 }
 
-void WaveformRendererRGB::draw(QPainter* painter,
-                                          QPaintEvent* /*event*/) {
-    const TrackPointer pTrackInfo = m_waveformRenderer->getTrackInfo();
-    if (!pTrackInfo) {
-        return;
-    }
-
-    ConstWaveformPointer pWaveform = pTrackInfo->getWaveform();
+void WaveformRendererRGB::draw(
+        QPainter* painter,
+        QPaintEvent* /*event*/) {
+    ConstWaveformPointer pWaveform = m_waveformRenderer->getWaveform();
     if (pWaveform.isNull()) {
         return;
     }

--- a/src/waveform/renderers/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/waveformrendererrgb.cpp
@@ -32,6 +32,11 @@ void WaveformRendererRGB::draw(QPainter* painter,
         return;
     }
 
+    const double audioVisualRatio = pWaveform->getAudioVisualRatio();
+    if (audioVisualRatio <= 0) {
+        return;
+    }
+
     const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
         return;
@@ -39,6 +44,11 @@ void WaveformRendererRGB::draw(QPainter* painter,
 
     const WaveformData* data = pWaveform->data();
     if (data == nullptr) {
+        return;
+    }
+
+    const int trackSamples = m_waveformRenderer->getTrackSamples();
+    if (trackSamples <= 0) {
         return;
     }
 
@@ -54,8 +64,12 @@ void WaveformRendererRGB::draw(QPainter* painter,
         painter->setTransform(QTransform(0, 1, 1, 0, 0, 0));
     }
 
-    const double firstVisualIndex = m_waveformRenderer->getFirstDisplayedPosition() * dataSize;
-    const double lastVisualIndex = m_waveformRenderer->getLastDisplayedPosition() * dataSize;
+    const double firstVisualIndex =
+            m_waveformRenderer->getFirstDisplayedPosition() * trackSamples /
+            audioVisualRatio;
+    const double lastVisualIndex =
+            m_waveformRenderer->getLastDisplayedPosition() * trackSamples /
+            audioVisualRatio;
 
     const double offset = firstVisualIndex;
 

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -102,23 +102,23 @@ void WaveformRenderMark::onResize() {
 void WaveformRenderMark::onSetTrack() {
     slotCuesUpdated();
 
-    TrackPointer trackInfo = m_waveformRenderer->getTrackInfo();
-    if (!trackInfo) {
+    const TrackPointer pTrackInfo = m_waveformRenderer->getTrackInfo();
+    if (!pTrackInfo) {
         return;
     }
-    connect(trackInfo.get(),
+    connect(pTrackInfo.get(),
             &Track::cuesUpdated,
             this,
             &WaveformRenderMark::slotCuesUpdated);
 }
 
 void WaveformRenderMark::slotCuesUpdated() {
-    TrackPointer trackInfo = m_waveformRenderer->getTrackInfo();
-    if (!trackInfo) {
+    const TrackPointer pTrackInfo = m_waveformRenderer->getTrackInfo();
+    if (!pTrackInfo) {
         return;
     }
 
-    QList<CuePointer> loadedCues = trackInfo->getCuePoints();
+    QList<CuePointer> loadedCues = pTrackInfo->getCuePoints();
     for (const CuePointer& pCue : loadedCues) {
         int hotCue = pCue->getHotCue();
         if (hotCue == Cue::kNoHotCue) {

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -42,7 +42,6 @@ WaveformWidgetRenderer::WaveformWidgetRenderer(const QString& group)
           m_playPosVSample(0),
           m_totalVSamples(0),
           m_pRateRatioCO(nullptr),
-          m_rateRatio(1.0),
           m_pGainControlObject(nullptr),
           m_gain(1.0),
           m_pTrackSamplesControlObject(nullptr),
@@ -110,7 +109,7 @@ void WaveformWidgetRenderer::onPreRender(VSyncThread* vsyncThread) {
     }
 
     //Fetch parameters before rendering in order the display all sub-renderers with the same values
-    m_rateRatio = m_pRateRatioCO->get();
+    double rateRatio = m_pRateRatioCO->get();
 
     // This gain adjustment compensates for an arbitrary /2 gain chop in
     // EnginePregain. See the comment there.
@@ -120,7 +119,7 @@ void WaveformWidgetRenderer::onPreRender(VSyncThread* vsyncThread) {
     // Allow waveform to spread one visual sample across a hundred pixels
     // NOTE: The hundred pixel limit is totally arbitrary. Theoretically,
     // there should be no limit to how far the waveforms can be zoomed in.
-    double visualSamplePerPixel = m_zoomFactor * m_rateRatio / m_scaleFactor;
+    double visualSamplePerPixel = m_zoomFactor * rateRatio / m_scaleFactor;
     m_visualSamplePerPixel = math_max(0.01, visualSamplePerPixel);
 
     TrackPointer pTrack = m_pTrack;
@@ -163,12 +162,12 @@ void WaveformWidgetRenderer::onPreRender(VSyncThread* vsyncThread) {
         m_playPos = -1; // disable renderers
     }
 
-    //qDebug() << "WaveformWidgetRenderer::onPreRender" <<
-    //        "m_group" << m_group <<
-    //        "m_trackSamples" << m_trackSamples <<
-    //        "m_playPos" << m_playPos <<
-    //        "m_rateRatio" << m_rate <<
-    //        "m_gain" << m_gain;
+    // qDebug() << "WaveformWidgetRenderer::onPreRender" <<
+    //         "m_group" << m_group <<
+    //         "m_trackSamples" << m_trackSamples <<
+    //         "m_playPos" << m_playPos <<
+    //         "rateRatio" << rateRatio <<
+    //         "m_gain" << m_gain;
 }
 
 void WaveformWidgetRenderer::draw(QPainter* painter, QPaintEvent* event) {
@@ -219,7 +218,7 @@ void WaveformWidgetRenderer::draw(QPainter* painter, QPaintEvent* event) {
             QString::number(m_playPos) + " [" +
                     QString::number(m_firstDisplayedPosition) + "-" +
                     QString::number(m_lastDisplayedPosition) + "]" +
-                    QString::number(m_rate) + " | " + QString::number(m_gain) +
+                    QString::number(rateRatio) + " | " + QString::number(m_gain) +
                     " | " + QString::number(m_rateDir) + " | " +
                     QString::number(m_zoomFactor));
 

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -47,7 +47,7 @@ WaveformWidgetRenderer::WaveformWidgetRenderer(const QString& group)
           m_pGainControlObject(nullptr),
           m_gain(1.0),
           m_pTrackSamplesControlObject(nullptr),
-          m_trackSamples(0.0),
+          m_trackSamples(0),
           m_scaleFactor(1.0),
           m_playMarkerPosition(s_defaultPlayMarkerPosition),
           m_playPos(-1) {
@@ -185,7 +185,7 @@ void WaveformWidgetRenderer::draw(QPainter* painter, QPaintEvent* event) {
     // not ready to display need to wait until track initialization is done
     // draw only first is stack (background)
     int stackSize = m_rendererStack.size();
-    if (m_trackSamples <= 0.0 || m_playPos == -1) {
+    if (m_trackSamples <= 0 || m_playPos == -1) {
         if (stackSize) {
             m_rendererStack.at(0)->draw(painter, event);
         }
@@ -352,7 +352,7 @@ void WaveformWidgetRenderer::setDisplayBeatGridAlpha(int alpha) {
 void WaveformWidgetRenderer::setTrack(TrackPointer track) {
     m_pTrack = track;
     //used to postpone first display until track sample is actually available
-    m_trackSamples = -1.0;
+    m_trackSamples = -1;
 
     for (int i = 0; i < m_rendererStack.size(); ++i) {
         m_rendererStack[i]->onSetTrack();

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -36,7 +36,6 @@ WaveformWidgetRenderer::WaveformWidgetRenderer(const QString& group)
           m_zoomFactor(1.0),
           m_visualSamplePerPixel(1.0),
           m_audioSamplePerPixel(1.0),
-          m_audioVisualRatio(1.0),
           m_alphaBeatGrid(90),
           // Really create some to manage those;
           m_visualPlayPosition(nullptr),
@@ -128,11 +127,9 @@ void WaveformWidgetRenderer::onPreRender(VSyncThread* vsyncThread) {
     if (pTrack) {
         ConstWaveformPointer pWaveform = pTrack->getWaveform();
         if (pWaveform) {
-            m_audioVisualRatio = pWaveform->getAudioVisualRatio();
+            m_audioSamplePerPixel = m_visualSamplePerPixel * pWaveform->getAudioVisualRatio();
         }
     }
-
-    m_audioSamplePerPixel = m_visualSamplePerPixel * m_audioVisualRatio;
 
     double truePlayPos = m_visualPlayPosition->getAtNextVSync(vsyncThread);
     // truePlayPos = -1 happens, when a new track is in buffer but m_visualPlayPosition was not updated

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -355,6 +355,13 @@ void WaveformWidgetRenderer::setTrack(TrackPointer track) {
     }
 }
 
+ConstWaveformPointer WaveformWidgetRenderer::getWaveform() const {
+    if (m_pTrack) {
+        return m_pTrack->getWaveform();
+    }
+    return {};
+}
+
 WaveformMarkPointer WaveformWidgetRenderer::getCueMarkAtPoint(QPoint point) const {
     for (auto it = m_markPositions.constBegin(); it != m_markPositions.constEnd(); ++it) {
         WaveformMarkPointer pMark = it.key();

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -11,6 +11,7 @@
 #include "waveform/renderers/waveformmark.h"
 #include "waveform/renderers/waveformrendererabstract.h"
 #include "waveform/renderers/waveformsignalcolors.h"
+#include "waveform/waveform.h"
 
 //#define WAVEFORMWIDGETRENDERER_DEBUG
 
@@ -39,9 +40,13 @@ class WaveformWidgetRenderer {
     const QString& getGroup() const {
         return m_group;
     }
+
     const TrackPointer& getTrackInfo() const {
         return m_pTrack;
     }
+
+    ConstWaveformPointer getWaveform() const;
+
     /// Get cue mark at a point on the waveform widget.
     WaveformMarkPointer getCueMarkAtPoint(QPoint point) const;
 

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -179,7 +179,6 @@ class WaveformWidgetRenderer {
     int m_playPosVSample;
     int m_totalVSamples;
     ControlProxy* m_pRateRatioCO;
-    double m_rateRatio;
     ControlProxy* m_pGainControlObject;
     double m_gain;
     ControlProxy* m_pTrackSamplesControlObject;

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -170,7 +170,6 @@ class WaveformWidgetRenderer {
     double m_zoomFactor;
     double m_visualSamplePerPixel;
     double m_audioSamplePerPixel;
-    double m_audioVisualRatio;
 
     int m_alphaBeatGrid;
 

--- a/src/waveform/waveform.h
+++ b/src/waveform/waveform.h
@@ -74,12 +74,6 @@ class Waveform {
 
     QByteArray toByteArray() const;
 
-    // We do not lock the mutex since m_dataSize and m_visualSampleRate are not
-    // changed after the constructor runs.
-    bool isValid() const {
-        return getDataSize() > 0 && getVisualSampleRate() > 0;
-    }
-
     SaveState saveState() const {
         return m_saveState;
     }

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -77,6 +77,10 @@ class WOverview : public WWidget, public TrackDropTarget {
         return m_pWaveform;
     }
 
+    double getTrackSamples() const {
+        return m_trackSamplesControl->get();
+    }
+
     QImage m_waveformSourceImage;
     QImage m_waveformImageScaled;
 

--- a/src/widget/woverviewhsv.cpp
+++ b/src/widget/woverviewhsv.cpp
@@ -28,7 +28,8 @@ bool WOverviewHSV::drawNextPixmapPart() {
     }
 
     const int dataSize = pWaveform->getDataSize();
-    if (dataSize == 0) {
+    const double audioVisualRatio = pWaveform->getAudioVisualRatio();
+    if (dataSize <= 0 || audioVisualRatio <= 0) {
         return false;
     }
 
@@ -36,7 +37,9 @@ bool WOverviewHSV::drawNextPixmapPart() {
         // Waveform pixmap twice the height of the viewport to be scalable
         // by total_gain
         // We keep full range waveform data to scale it on paint
-        m_waveformSourceImage = QImage(dataSize / 2, 2 * 255,
+        m_waveformSourceImage = QImage(
+                static_cast<int>(getTrackSamples() / audioVisualRatio / 2),
+                2 * 255,
                 QImage::Format_ARGB32_Premultiplied);
         m_waveformSourceImage.fill(QColor(0, 0, 0, 0).value());
     }

--- a/src/widget/woverviewlmh.cpp
+++ b/src/widget/woverviewlmh.cpp
@@ -29,7 +29,8 @@ bool WOverviewLMH::drawNextPixmapPart() {
     }
 
     const int dataSize = pWaveform->getDataSize();
-    if (dataSize == 0) {
+    const double audioVisualRatio = pWaveform->getAudioVisualRatio();
+    if (dataSize <= 0 || audioVisualRatio <= 0) {
         return false;
     }
 
@@ -37,7 +38,9 @@ bool WOverviewLMH::drawNextPixmapPart() {
         // Waveform pixmap twice the height of the viewport to be scalable
         // by total_gain
         // We keep full range waveform data to scale it on paint
-        m_waveformSourceImage = QImage(dataSize / 2, 2 * 255,
+        m_waveformSourceImage = QImage(
+                static_cast<int>(getTrackSamples() / audioVisualRatio / 2),
+                2 * 255,
                 QImage::Format_ARGB32_Premultiplied);
         m_waveformSourceImage.fill(QColor(0, 0, 0, 0).value());
     }

--- a/src/widget/woverviewrgb.cpp
+++ b/src/widget/woverviewrgb.cpp
@@ -27,7 +27,8 @@ bool WOverviewRGB::drawNextPixmapPart() {
     }
 
     const int dataSize = pWaveform->getDataSize();
-    if (dataSize == 0) {
+    const double audioVisualRatio = pWaveform->getAudioVisualRatio();
+    if (dataSize <= 0 || audioVisualRatio <= 0) {
         return false;
     }
 
@@ -36,7 +37,7 @@ bool WOverviewRGB::drawNextPixmapPart() {
         // by total_gain
         // We keep full range waveform data to scale it on paint
         m_waveformSourceImage = QImage(
-                dataSize / 2,
+                static_cast<int>(getTrackSamples() / audioVisualRatio / 2),
                 static_cast<int>(2 * 255 * m_devicePixelRatio),
                 QImage::Format_ARGB32_Premultiplied);
         m_waveformSourceImage.fill(QColor(0, 0, 0, 0).value());

--- a/src/widget/woverviewrgb.cpp
+++ b/src/widget/woverviewrgb.cpp
@@ -38,7 +38,7 @@ bool WOverviewRGB::drawNextPixmapPart() {
         // We keep full range waveform data to scale it on paint
         m_waveformSourceImage = QImage(
                 static_cast<int>(getTrackSamples() / audioVisualRatio / 2),
-                static_cast<int>(2 * 255 * m_devicePixelRatio),
+                2 * 255,
                 QImage::Format_ARGB32_Premultiplied);
         m_waveformSourceImage.fill(QColor(0, 0, 0, 0).value());
     }
@@ -97,8 +97,8 @@ bool WOverviewRGB::drawNextPixmapPart() {
         if (max > 0.0) {
             color.setRgbF(red / max, green / max, blue / max);
             painter.setPen(color);
-            painter.drawLine(QPointF(currentCompletion / 2, -left * m_devicePixelRatio),
-                             QPointF(currentCompletion / 2, 0));
+            painter.drawLine(QPointF(currentCompletion / 2, -left),
+                    QPointF(currentCompletion / 2, 0));
         }
 
         // Retrieve "raw" LMH values from waveform
@@ -117,7 +117,7 @@ bool WOverviewRGB::drawNextPixmapPart() {
             color.setRgbF(red / max, green / max, blue / max);
             painter.setPen(color);
             painter.drawLine(QPointF(currentCompletion / 2, 0),
-                             QPointF(currentCompletion / 2, right * m_devicePixelRatio));
+                    QPointF(currentCompletion / 2, right));
         }
     }
 


### PR DESCRIPTION
Without this PR, the waveform signal is scaled from the length of the analysis data, while beats and cue points are placed relative to the actual length of the track. In case the track length changes for some reasons the waveform signal will have a building up offset towards the end of the track. This is a visual issue that the beat marker are no longer on the beats visible in the waveform. 
This PR fixes the issue by using the loaded track length for all renders in the waveform and waveform overview. 

The original decoding issue that may lead to an offset between waveform and audio is not fixed. 
