### PR TITLE
Fixes mp3 lenght when no ID3v1 tag is added 

### DIFF
--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -618,7 +618,14 @@ ReadableSampleFrames SoundSourceMp3::readSampleFramesClamped(
                             // ...append the required guard bytes...
                             std::fill(pLeftoverBuffer + remainingBytes, pLeftoverBuffer + leftoverBytes, 0);
                             // ...and retry decoding.
-                            mad_stream_buffer(&m_madStream, pLeftoverBuffer, leftoverBytes);
+                            // Note: We must not use mad_stream_buffer() here,
+                            // because this will clear the bit reservoir used
+                            // for VBR
+                            m_madStream.buffer = pLeftoverBuffer;
+                            m_madStream.bufend = pLeftoverBuffer + leftoverBytes;
+                            m_madStream.this_frame = pLeftoverBuffer;
+                            m_madStream.next_frame = pLeftoverBuffer;
+                            m_madStream.sync = 1;
                             m_madStream.error = MAD_ERROR_NONE;
                             continue;
                         }

--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -20,9 +20,10 @@ constexpr SINT kMaxBytesPerMp3Frame = 1441;
 // mp3 supports 9 different sample rates
 constexpr int kSampleRateCount = 9;
 
-// Possible labels in the Mp3 Info Frame
+// Possible tags in the Mp3 Info Frame
 // constexpr char kVbrTag0[] = "Xing";
 // constexpr char kVbrTag1[] = "Info";
+constexpr int kInfoTagStrLen = 4;
 
 int getIndexBySampleRate(audio::SampleRate sampleRate) {
     switch (sampleRate) {
@@ -311,12 +312,13 @@ SoundSource::OpenResult SoundSourceMp3::tryOpen(
                 }
             }
 
-            QString mp3InfoLabel =
+            QString mp3InfoTag =
                     QString::fromLatin1(reinterpret_cast<const char*>(
-                            &m_madStream.this_frame[mp3InfoFrameOffset]));
+                                                &m_madStream.this_frame[mp3InfoFrameOffset]),
+                            kInfoTagStrLen);
             kLogger.debug()
                     << "Skipping MP3 Info Frame:"
-                    << mp3InfoLabel;
+                    << mp3InfoTag;
 
             mp3InfoTagSkipped = true;
             continue;

--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -132,10 +132,10 @@ bool decodeFrameHeader(
                               << mad_stream_errorstr(pMadStream);
             return false;
         }
-        if ((MAD_ERROR_LOSTSYNC == pMadStream->error) && skipId3Tag) {
+        if ((pMadStream->error == MAD_ERROR_LOSTSYNC) && skipId3Tag) {
             long tagsize = id3_tag_query(pMadStream->this_frame,
                     pMadStream->bufend - pMadStream->this_frame);
-            if (0 < tagsize) {
+            if (tagsize > 0) {
                 // Skip ID3 tag data
                 mad_stream_skip(pMadStream, tagsize);
                 // Return immediately to suppress lost

--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -767,12 +767,15 @@ bool SoundSourceMp3::copyLeftoverFrame() {
         // ensure the next frame's main_data_begin pointer is always accessible, MAD
         // requires MAD_BUFFER_GUARD (currently 8) bytes to be present in the buffer past
         // the end of the current frame in order to decode the frame."
+        unsigned char* pLeftoverBuffer = &*m_leftoverBuffer.begin();
+        if (pLeftoverBuffer == m_madStream.buffer) {
+            return false;
+        }
         const SINT remainingBytes = m_madStream.bufend - m_madStream.next_frame;
         DEBUG_ASSERT(remainingBytes <= kMaxBytesPerMp3Frame); // only last MP3 frame
         const SINT leftoverBytes = remainingBytes + MAD_BUFFER_GUARD;
         if ((remainingBytes > 0) && (leftoverBytes <= SINT(m_leftoverBuffer.size()))) {
             // Copy the data of the last MP3 frame into the leftover buffer...
-            unsigned char* pLeftoverBuffer = &*m_leftoverBuffer.begin();
             std::copy(m_madStream.next_frame,
                     m_madStream.next_frame + remainingBytes,
                     pLeftoverBuffer);

--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -128,11 +128,6 @@ bool decodeFrameHeader(
                               << mad_stream_errorstr(pMadStream);
             return false;
         }
-#ifndef QT_NO_DEBUG_OUTPUT
-        // Logging of MP3 frame headers should only be enabled
-        // for debugging purposes.
-        logFrameHeader(kLogger.debug(), *pMadHeader);
-#endif
         if ((MAD_ERROR_LOSTSYNC == pMadStream->error) && skipId3Tag) {
             long tagsize = id3_tag_query(pMadStream->this_frame,
                     pMadStream->bufend - pMadStream->this_frame);
@@ -149,7 +144,7 @@ bool decodeFrameHeader(
         // obsolete once we switched to FFmpeg for MP3 decoding.
         kLogger.info() << "Recoverable MP3 header decoding error:"
                        << mad_stream_errorstr(pMadStream);
-        logFrameHeader(kLogger.warning(), *pMadHeader);
+        logFrameHeader(kLogger.info(), *pMadHeader);
         return false;
     }
     DEBUG_ASSERT(pMadStream->error == MAD_ERROR_NONE);

--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -240,12 +240,12 @@ SoundSource::OpenResult SoundSourceMp3::tryOpen(
     quint64 cntBitrateFrames = 0; // denominator
 
     // Normally mp3 files starts with an extra frame of silence containing
-    // engoder infos called "LAME Tag". Since the early days of we skip the
+    // encoder infos called "LAME Tag". Since the early days of we skip the
     // first frame uncoditionally, to not have these extra portion of silence
-    // in the track. This has the isseue that with files without this frame real
+    // in the track. This has the issue that with files without this frame real
     // samples are dropped.
     // Since this issue exists since the early days of Mixxx the analysis data
-    // is affected by the offset. Fixing this without fixing the amalysis data
+    // is affected by the offset. Fixing this without fixing the analysis data
     // will silently invalidate analysis, cues and loops.
     // Note: A relates issue with not accurate seeks has been fixed in Mixxx 2.1.0 2015
     // https://github.com/mixxxdj/mixxx/pull/411

--- a/src/sources/soundsourcemp3.h
+++ b/src/sources/soundsourcemp3.h
@@ -56,6 +56,8 @@ class SoundSourceMp3 final : public SoundSource {
     /** Returns the position in m_seekFrameList of the requested frame index. */
     SINT findSeekFrameIndex(SINT frameIndex) const;
 
+    bool copyLeftoverFrame();
+
     SINT m_curFrameIndex;
 
     // NOTE(uklotzde): Each invocation of initDecoding() must be


### PR DESCRIPTION
Without an ID3v1 tag, the MAD_BUFFER_GUARD padding byte after the last frame are missing and the last frame was not considered when calculating the track length. This PR uses a local m_leftoverBuffer to add these padding bytes. An existing solution that was already in place when decoding the file.  

This also fixes spurious warnings that happens because of a legacy off-by-one issue. Due to a validity test on the seek destination, the decoding starts with the next frame after the seek target. The bug itself cannot be fixed, because it would make the stored analysis, cues and loops invalid. 

This PR fixes also the wrong clearing of the bit reservoir after switching to the m_leftoverBuffer. This is relevant in case of VBR encoded tracks. 

If this is merged before merging https://github.com/mixxxdj/mixxx/pull/11162 the waveform of tracks without an ID3v1 tracks will be off at the end of the track. 

Fixes https://github.com/mixxxdj/mixxx/issues/11159



