### PR TITLE
Replay Gain Preferences: Fix the "adjust by" text in case of negative adjustments

### DIFF
--- a/src/preferences/dialog/dlgprefreplaygain.cpp
+++ b/src/preferences/dialog/dlgprefreplaygain.cpp
@@ -150,11 +150,10 @@ void DlgPrefReplayGain::slotUpdateReplayGainBoost() {
 
 void DlgPrefReplayGain::setLabelCurrentReplayGainBoost(int value) {
     LabelCurrentReplayGainBoost->setText(
-        QString(tr("%1 LUFS (adjust by %2 dB)")).arg(
-              QString::number(value + kReplayGainReferenceLUFS),
-              (value < 0) ? QString() : (QString("+") + QString::number(value))
-        )
-    );
+            QString(tr("%1 LUFS (adjust by %2 dB)"))
+                    .arg(QString::number(value + kReplayGainReferenceLUFS),
+                            (value < 0 ? QString() : QString("+")) +
+                                    QString::number(value)));
 }
 
 void DlgPrefReplayGain::slotUpdateDefaultBoost() {


### PR DESCRIPTION
The value was missing in the negative case due to a typo with braces. 