### PR TITLE
Fix gain compensation for the Moog filter

### DIFF
--- a/src/engine/filters/enginefiltermoogladder4.h
+++ b/src/engine/filters/enginefiltermoogladder4.h
@@ -100,6 +100,15 @@ class EngineFilterMoogLadderBase : public EngineObjectConstIn {
             // m_postGainNew = 0.9999999983339118f + (4.58745459575558e-13f * resonance);
             m_postGainNew = 1.0;
         } else {
+            // Analyzing this filter as a linear system will show a small dip in
+            // passband/DC gain when the cutoff frequency is around 10 kHz:
+            // https://github.com/mixxxdj/mixxx/pull/11177#issuecomment-1374833386
+            //
+            // In practice this is either not a noticeable issue when running
+            // music through the filter, or it might even be desirable as it
+            // keeps the overall gain increase a bit lower when the resonance is
+            // turned up and the cutoff frequency is around 10 kHz. This may be
+            // worth more experimentation in the future.
             m_postGainNew = 1.0001784074555027f + (0.9331585678097162f * resonance);
         }
 

--- a/src/engine/filters/enginefiltermoogladder4.h
+++ b/src/engine/filters/enginefiltermoogladder4.h
@@ -96,8 +96,9 @@ class EngineFilterMoogLadderBase : public EngineObjectConstIn {
         if (MODE == MoogMode::HighPassOversampling || MODE == MoogMode::HighPass) {
             m_postGainNew = 1;
         } else {
-            m_postGainNew = (1 + resonance / 4 * (1.1f + cutoff / sampleRate * 3.5f))
-                    * (2 - (1.0f - resonance / 4) * (1.0f - resonance / 4));
+            // Determined by fitting a polynomial on the output. See TODO: link
+            // the PR here for a Jupyter notebook
+            m_postGainNew = 1.0001784074555027f + (resonance * 0.9331585678097162f);
         }
 
         m_doRamping = true;

--- a/src/engine/filters/enginefiltermoogladder4.h
+++ b/src/engine/filters/enginefiltermoogladder4.h
@@ -93,12 +93,12 @@ class EngineFilterMoogLadderBase : public EngineObjectConstIn {
         // Resonance correction for self oscillation ~4
         m_kacrNew = resonance * (-3.9364f * (kfc * kfc) + 1.8409f * kfc + 0.9968f);
 
+        // See https://github.com/mixxxdj/mixxx/pull/11177 for the Jupyter
+        // notebook used to derive this
         if (MODE == MoogMode::HighPassOversampling || MODE == MoogMode::HighPass) {
-            m_postGainNew = 1;
+            m_postGainNew = 0.8478175496499384f + (0.09022626934231257f * resonance);
         } else {
-            // See https://github.com/mixxxdj/mixxx/pull/11177 for the Jupyter
-            // notebook used to derive this
-            m_postGainNew = 1.0001784074555027f + (resonance * 0.9331585678097162f);
+            m_postGainNew = 1.0001784074555027f + (0.9331585678097162f * resonance);
         }
 
         m_doRamping = true;

--- a/src/engine/filters/enginefiltermoogladder4.h
+++ b/src/engine/filters/enginefiltermoogladder4.h
@@ -96,7 +96,9 @@ class EngineFilterMoogLadderBase : public EngineObjectConstIn {
         // See https://github.com/mixxxdj/mixxx/pull/11177 for the Jupyter
         // notebook used to derive this
         if (MODE == MoogMode::HighPassOversampling || MODE == MoogMode::HighPass) {
-            m_postGainNew = 0.8478175496499384f + (0.09022626934231257f * resonance);
+            // This for all intents and purposes is just 1.0, so let's just stick with that
+            // m_postGainNew = 0.9999999983339118f + (4.58745459575558e-13f * resonance);
+            m_postGainNew = 1.0;
         } else {
             m_postGainNew = 1.0001784074555027f + (0.9331585678097162f * resonance);
         }

--- a/src/engine/filters/enginefiltermoogladder4.h
+++ b/src/engine/filters/enginefiltermoogladder4.h
@@ -96,8 +96,8 @@ class EngineFilterMoogLadderBase : public EngineObjectConstIn {
         if (MODE == MoogMode::HighPassOversampling || MODE == MoogMode::HighPass) {
             m_postGainNew = 1;
         } else {
-            // Determined by fitting a polynomial on the output. See TODO: link
-            // the PR here for a Jupyter notebook
+            // See https://github.com/mixxxdj/mixxx/pull/11177 for the Jupyter
+            // notebook used to derive this
             m_postGainNew = 1.0001784074555027f + (resonance * 0.9331585678097162f);
         }
 


### PR DESCRIPTION
This would previously add a bunch of gain when the low-pass filter is engaged. These new coefficients have been determined by filtering `1/sqrt(2)` RMS pink noise using all resonance settings and then fitting a curve on the ratio between the input's RMS values and the output's. Here is the Jupyter notebook used to compute these coefficients: 
[mixxx-moog-filter-gain-compensation.tar.gz](https://github.com/mixxxdj/mixxx/files/10369655/mixxx-moog-filter-gain-compensation.tar.gz)
