### PR TITLE
Add class unique_ptr_vector to workaround a QT 6.4 Bug

### DIFF
--- a/src/effects/backends/effectprocessor.h
+++ b/src/effects/backends/effectprocessor.h
@@ -12,6 +12,7 @@
 #include "engine/engine.h"
 #include "util/sample.h"
 #include "util/types.h"
+#include "util/unique_ptr_vector.h"
 
 /// Effects are implemented as two separate classes, an EffectState subclass and
 /// an EffectProcessorImpl subclass. Separating state from the DSP code allows
@@ -246,5 +247,5 @@ class EffectProcessorImpl : public EffectProcessor {
 
   private:
     QSet<ChannelHandleAndGroup> m_registeredOutputChannels;
-    ChannelHandleMap<std::vector<std::unique_ptr<EffectSpecificState>>> m_channelStateMatrix;
+    ChannelHandleMap<unique_ptr_vector<EffectSpecificState>> m_channelStateMatrix;
 };

--- a/src/util/unique_ptr_vector.h
+++ b/src/util/unique_ptr_vector.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+// This wrapper class can be used as a workaround for bug in QT 6.4
+// https://bugreports.qt.io/browse/QTBUG-109745 that prevents to use
+// std::vector<std::unique_ptr<T>> in QVarLengthArray
+// The only purpose of this class is to delete the copy constructor from
+// std::vector<std::unique_ptr<T>> and make std::is_copy_constructible_v<> false
+// std::vector<std::unique_ptr<T>> cannot be copied even if it is empty due to a
+// static_assert in stl_uninitialized.h
+template<typename T>
+class unique_ptr_vector : public std::vector<std::unique_ptr<T>> {
+    using std::vector<std::unique_ptr<T>>::vector;
+
+  public:
+    unique_ptr_vector(const unique_ptr_vector&) = delete;
+    unique_ptr_vector(unique_ptr_vector&&) noexcept = default;
+    unique_ptr_vector& operator=(const unique_ptr_vector&);
+};


### PR DESCRIPTION
This fixes https://github.com/mixxxdj/mixxx/issues/11167 by deleting the copy constructor from the std::vector<std::unique_ptr<T>> which cannot be used anyway due to a static_assert in stl_uninitialized.h