### PR TITLE
Enable Modpug and Wavpack Support on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,8 +62,8 @@ jobs:
               -DCOREAUDIO=ON
               -DHSS1394=ON
               -DMACOS_BUNDLE=ON
-              -DMODPLUG=OFF
-              -DWAVPACK=OFF
+              -DMODPLUG=ON
+              -DWAVPACK=ON
             # TODO: Fix this broken test on macOS
             ctest_args: --exclude-regex DirectoryDAOTest.relocateDirectory
             cpack_generator: DragNDrop


### PR DESCRIPTION
The required libraries are part of the build environment and there is no reason to keep this disabled.

This has been requested here: https://github.com/mixxxdj/mixxx/issues/11119