### PR TITLE
Set minimumWidth of WLabel according to the content's maximum possible width

### DIFF
--- a/res/skins/LateNight/fx/parameter_button.xml
+++ b/res/skins/LateNight/fx/parameter_button.xml
@@ -52,25 +52,16 @@
 
       <WidgetGroup><Size>1min,2f</Size></WidgetGroup>
 
-      <WidgetGroup>
-        <ObjectName>AlignBottom</ObjectName>
-        <Layout>horizontal</Layout>
+      <EffectButtonParameterName>
+        <ObjectName>FxButtonLabel</ObjectName>
         <SizePolicy>me,f</SizePolicy>
         <MinimumSize>40,10</MinimumSize>
         <MaximumSize>58,10</MaximumSize>
-        <Children>
-          <WidgetGroup><Size>1me,0min</Size></WidgetGroup>
-          <EffectButtonParameterName>
-            <ObjectName>FxButtonLabel</ObjectName>
-            <EffectUnitGroup><Variable name="FxUnitGroup"/></EffectUnitGroup>
-            <Effect><Variable name="FxNum"/></Effect>
-            <EffectButtonParameter><Variable name="FxParameter"/></EffectButtonParameter>
-            <Alignment>center</Alignment>
-          </EffectButtonParameterName>
-          <WidgetGroup><Size>1me,0min</Size></WidgetGroup>
-        </Children>
-      </WidgetGroup>
-
+        <EffectUnitGroup><Variable name="FxUnitGroup"/></EffectUnitGroup>
+        <Effect><Variable name="FxNum"/></Effect>
+        <EffectButtonParameter><Variable name="FxParameter"/></EffectButtonParameter>
+        <Alignment>center</Alignment>
+      </EffectButtonParameterName>
 
     </Children>
     <Connection>

--- a/res/skins/LateNight/fx/parameter_knob.xml
+++ b/res/skins/LateNight/fx/parameter_knob.xml
@@ -45,25 +45,17 @@
         </Children>
       </WidgetGroup>
 
-      <WidgetGroup>
-        <ObjectName>AlignBottom</ObjectName>
-        <Layout>horizontal</Layout>
+      <EffectParameterName>
+        <ObjectName>FxKnobLabel</ObjectName>
         <SizePolicy>me,f</SizePolicy>
         <MinimumSize>40,10</MinimumSize>
-        <MaximumSize>58,10</MaximumSize>
-        <Children>
-          <WidgetGroup><Size>1me,0min</Size></WidgetGroup>
-          <EffectParameterName>
-            <ObjectName>FxKnobLabel</ObjectName>
-            <EffectRack>1</EffectRack>
-            <EffectUnit><Variable name="FxUnit"/></EffectUnit>
-            <Effect><Variable name="FxNum"/></Effect>
-            <EffectParameter><Variable name="FxParameter"/></EffectParameter>
-            <Alignment>center</Alignment>
-          </EffectParameterName>
-          <WidgetGroup><Size>1me,0min</Size></WidgetGroup>
-        </Children>
-      </WidgetGroup>
+        <MaximumSize>60,10</MaximumSize>
+        <EffectRack>1</EffectRack>
+        <EffectUnit><Variable name="FxUnit"/></EffectUnit>
+        <Effect><Variable name="FxNum"/></Effect>
+        <EffectParameter><Variable name="FxParameter"/></EffectParameter>
+        <Elide>right</Elide>
+      </EffectParameterName>
 
       <WidgetGroup>
         <ObjectName>FxLinkButtons</ObjectName>

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -191,6 +191,7 @@ WSearchLineEdit::item:selected,
 #LatencyLabel {
   font-size: 10px;
   text-align: center;
+  qproperty-alignment: AlignCenter;
 }
 
 WPushButton,
@@ -284,13 +285,6 @@ WRecordingDuration {
 #SamplerBpmMini {
   text-align: right;
 }
-
-#KnobLabel,
-#FxKnobLabel,
-#FxButtonLabel {
-  qproperty-alignment: 'AlignLeft | AlignVCenter';
-}
-
 
 WTrackTableViewHeader::item {
   /* Don't set a font size to pick up the system font size. */

--- a/res/skins/Shade/effect_parameter_button.xml
+++ b/res/skins/Shade/effect_parameter_button.xml
@@ -23,9 +23,12 @@
           line-height: 8px;
           background-color: transparent;
           color: #191F24;
-          padding-left: 1px;
+          padding-left: 3px;
+          padding-right: 3px;
+         }
+        QLabel {
+          qproperty-alignment: AlignCenter;
         }
-        QLabel { qproperty-alignment: AlignCenter; }
       </Style>
       <ObjectName>ButtonLabel</ObjectName>
       <EffectRack>1</EffectRack>

--- a/res/skins/Shade/effect_parameter_button.xml
+++ b/res/skins/Shade/effect_parameter_button.xml
@@ -30,6 +30,8 @@
           qproperty-alignment: AlignCenter;
         }
       </Style>
+      <Elide>right</Elide>
+      <Alignment>center</Alignment>
       <ObjectName>ButtonLabel</ObjectName>
       <EffectRack>1</EffectRack>
       <EffectUnit><Variable name="effectunitnum"/></EffectUnit>

--- a/res/skins/Shade/effect_parameter_knob.xml
+++ b/res/skins/Shade/effect_parameter_knob.xml
@@ -30,6 +30,8 @@
             qproperty-alignment: AlignCenter;
           }
         </Style>
+        <Elide>right</Elide>
+        <Alignment>center</Alignment>
         <ObjectName>KnobLabel</ObjectName>
         <EffectRack>1</EffectRack>
         <EffectUnit><Variable name="effectunitnum"/></EffectUnit>

--- a/res/skins/Shade/effect_parameter_knob.xml
+++ b/res/skins/Shade/effect_parameter_knob.xml
@@ -23,9 +23,12 @@
             line-height: 8px;
             background-color: transparent;
             color: #191F24;
-            padding-left: 1px;
+            padding-left: 3px;
+            padding-right: 3px;
           }
-          QLabel { qproperty-alignment: AlignCenter; }
+          QLabel {
+            qproperty-alignment: AlignCenter;
+          }
         </Style>
         <ObjectName>KnobLabel</ObjectName>
         <EffectRack>1</EffectRack>

--- a/res/skins/Tango/fx/parameter_knob.xml
+++ b/res/skins/Tango/fx/parameter_knob.xml
@@ -51,26 +51,17 @@ Variables:
             </Children>
           </WidgetGroup>
 
-          <WidgetGroup><!-- Name of parameter -->
+          <EffectParameterName>
+            <ObjectName>FxParameterKnobName</ObjectName>
             <MinimumSize>42,12</MinimumSize>
             <MaximumSize>51,12</MaximumSize>
             <SizePolicy>me,f</SizePolicy>
-            <Layout>horizontal</Layout>
-            <Children>
-              <!-- To keep text centered it's in an container with spacers on the left/right -->
-              <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
-              <EffectParameterName>
-                <ObjectName>FxParameterKnobName</ObjectName>
-                <Size>-1min,12f</Size>
-                <EffectRack><Variable name="FxRack"/></EffectRack>
-                <EffectUnit><Variable name="FxUnit"/></EffectUnit>
-                <Effect><Variable name="FxNum"/></Effect>
-                <EffectParameter><Variable name="FxParameter"/></EffectParameter>
-                <Alignment>left</Alignment>
-              </EffectParameterName>
-              <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
-            </Children>
-          </WidgetGroup>
+            <EffectRack><Variable name="FxRack"/></EffectRack>
+            <EffectUnit><Variable name="FxUnit"/></EffectUnit>
+            <Effect><Variable name="FxNum"/></Effect>
+            <EffectParameter><Variable name="FxParameter"/></EffectParameter>
+            <Elide>right</Elide>
+          </EffectParameterName>
         </Children>
       </WidgetGroup><!-- Parameter knob + parameter name -->
 

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -1901,7 +1901,7 @@ decks, samplers, mic, aux, fx */
   margin-right: 1px;
 }
   #FxParameterKnobName {
-    qproperty-alignment: 'AlignLeft | AlignTop';
+    qproperty-alignment: 'AlignHCenter | AlignTop';
     font-size: 10px/10px;
     font-weight: bold;
     color: #999999;

--- a/src/widget/weffectparameternamebase.cpp
+++ b/src/widget/weffectparameternamebase.cpp
@@ -46,6 +46,8 @@ void WEffectParameterNameBase::setEffectParameterSlot(
 }
 
 void WEffectParameterNameBase::parameterUpdated() {
+    int optimumWidth = 0;
+    QFontMetrics metrics(font());
     if (m_pParameterSlot) {
         if (!m_pParameterSlot->shortName().isEmpty()) {
             m_text = m_pParameterSlot->shortName();
@@ -58,6 +60,16 @@ void WEffectParameterNameBase::parameterUpdated() {
         EffectManifestParameterPointer pManifest = m_pParameterSlot->getManifest();
         if (!pManifest.isNull()) {
             m_unitString = m_pParameterSlot->getManifest()->unitString();
+            double maxValue = m_pParameterSlot->getManifest()->getMaximum();
+            double minValue = m_pParameterSlot->getManifest()->getMaximum();
+            QString maxValueString = QString::number(maxValue - 0.01) + QChar(' ') + m_unitString;
+            QString minValueString = QString::number(minValue + 0.01) + QChar(' ') + m_unitString;
+            optimumWidth = math_max(
+                    metrics.size(0, maxValueString).width(),
+                    metrics.size(0, minValueString).width());
+
+            qDebug() << minValueString << maxValueString << "|";
+
         } else {
             m_unitString = QString();
         }
@@ -66,6 +78,11 @@ void WEffectParameterNameBase::parameterUpdated() {
         m_text = kNoEffectString;
         setBaseTooltip(tr("No effect loaded."));
     }
+    optimumWidth = math_max(
+            optimumWidth,
+            metrics.size(0, m_text).width());
+    setMinimumWidth(optimumWidth + 6);
+    qDebug() << optimumWidth << m_text << "|";
     setText(m_text);
     m_parameterUpdated = true;
 }

--- a/src/widget/weffectparameternamebase.cpp
+++ b/src/widget/weffectparameternamebase.cpp
@@ -81,7 +81,7 @@ void WEffectParameterNameBase::parameterUpdated() {
     optimumWidth = math_max(
             optimumWidth,
             metrics.size(0, m_text).width());
-    setMinimumWidth(optimumWidth + 6);
+    setMinimumWidth(optimumWidth);
     qDebug() << optimumWidth << m_text << "|";
     setText(m_text);
     m_parameterUpdated = true;

--- a/src/widget/weffectparameternamebase.cpp
+++ b/src/widget/weffectparameternamebase.cpp
@@ -79,9 +79,12 @@ void WEffectParameterNameBase::parameterUpdated() {
         m_text = kNoEffectString;
         setBaseTooltip(tr("No effect loaded."));
     }
+    // frameWidth() is the maximum of the sum of margin, border and padding
+    // width of the left and the right side.
     m_widthHint = math_max(
-            valueWidth,
-            metrics.size(0, m_text).width());
+                          valueWidth,
+                          metrics.size(0, m_text).width()) +
+            2 * frameWidth();
     setText(m_text);
     m_parameterUpdated = true;
 }

--- a/src/widget/weffectparameternamebase.cpp
+++ b/src/widget/weffectparameternamebase.cpp
@@ -14,7 +14,8 @@ const QString kMimeTextDelimiter = QStringLiteral("\n");
 WEffectParameterNameBase::WEffectParameterNameBase(
         QWidget* pParent, EffectsManager* pEffectsManager)
         : WLabel(pParent),
-          m_pEffectsManager(pEffectsManager) {
+          m_pEffectsManager(pEffectsManager),
+          m_widthHint(0) {
     setAcceptDrops(true);
     setCursor(Qt::OpenHandCursor);
     parameterUpdated();
@@ -84,8 +85,7 @@ void WEffectParameterNameBase::parameterUpdated() {
     optimumWidth = math_max(
             optimumWidth,
             metrics.size(0, m_text).width());
-    setMinimumWidth(optimumWidth);
-    qDebug() << optimumWidth << m_text << "|";
+    m_widthHint = optimumWidth;
     setText(m_text);
     m_parameterUpdated = true;
 }
@@ -163,4 +163,11 @@ const QString WEffectParameterNameBase::mimeTextIdentifier() const {
     return QStringLiteral("Mixxx effect parameter ") +
             QString::number(
                     static_cast<int>(m_pParameterSlot->parameterType()));
+}
+
+QSize WEffectParameterNameBase::sizeHint() const {
+    // make sure the sizeHint is not changing because of the label or value string
+    QSize size = WLabel::sizeHint();
+    size.setWidth(m_widthHint);
+    return size;
 }

--- a/src/widget/weffectparameternamebase.cpp
+++ b/src/widget/weffectparameternamebase.cpp
@@ -47,7 +47,7 @@ void WEffectParameterNameBase::setEffectParameterSlot(
 }
 
 void WEffectParameterNameBase::parameterUpdated() {
-    int optimumWidth = 0;
+    int valueWidth = 0;
     QFontMetrics metrics(font());
     if (m_pParameterSlot) {
         if (!m_pParameterSlot->shortName().isEmpty()) {
@@ -68,12 +68,9 @@ void WEffectParameterNameBase::parameterUpdated() {
             double minValue = m_pParameterSlot->getManifest()->getMaximum();
             QString maxValueString = QString::number(maxValue - 0.01) + m_unitString;
             QString minValueString = QString::number(minValue + 0.01) + m_unitString;
-            optimumWidth = math_max(
+            valueWidth = math_max(
                     metrics.size(0, maxValueString).width(),
                     metrics.size(0, minValueString).width());
-
-            qDebug() << minValueString << maxValueString << "|";
-
         } else {
             m_unitString = QString();
         }
@@ -82,10 +79,9 @@ void WEffectParameterNameBase::parameterUpdated() {
         m_text = kNoEffectString;
         setBaseTooltip(tr("No effect loaded."));
     }
-    optimumWidth = math_max(
-            optimumWidth,
+    m_widthHint = math_max(
+            valueWidth,
             metrics.size(0, m_text).width());
-    m_widthHint = optimumWidth;
     setText(m_text);
     m_parameterUpdated = true;
 }

--- a/src/widget/weffectparameternamebase.cpp
+++ b/src/widget/weffectparameternamebase.cpp
@@ -60,10 +60,13 @@ void WEffectParameterNameBase::parameterUpdated() {
         EffectManifestParameterPointer pManifest = m_pParameterSlot->getManifest();
         if (!pManifest.isNull()) {
             m_unitString = m_pParameterSlot->getManifest()->unitString();
+            if (!m_unitString.isEmpty()) {
+                m_unitString.prepend(QChar(' '));
+            }
             double maxValue = m_pParameterSlot->getManifest()->getMaximum();
             double minValue = m_pParameterSlot->getManifest()->getMaximum();
-            QString maxValueString = QString::number(maxValue - 0.01) + QChar(' ') + m_unitString;
-            QString minValueString = QString::number(minValue + 0.01) + QChar(' ') + m_unitString;
+            QString maxValueString = QString::number(maxValue - 0.01) + m_unitString;
+            QString minValueString = QString::number(minValue + 0.01) + m_unitString;
             optimumWidth = math_max(
                     metrics.size(0, maxValueString).width(),
                     metrics.size(0, minValueString).width());
@@ -103,11 +106,7 @@ void WEffectParameterNameBase::showNewValue(double newValue) {
     }
     double dispVal = round(newValue * tenPowDecimals) / tenPowDecimals;
 
-    if (m_unitString.isEmpty()) {
-        setText(QString::number(dispVal));
-    } else {
-        setText(QString::number(dispVal) + QChar(' ') + m_unitString);
-    }
+    setText(QString::number(dispVal) + m_unitString);
     m_displayNameResetTimer.start();
 }
 

--- a/src/widget/weffectparameternamebase.h
+++ b/src/widget/weffectparameternamebase.h
@@ -19,6 +19,7 @@ class WEffectParameterNameBase : public WLabel {
     void mousePressEvent(QMouseEvent* event) override;
     void dragEnterEvent(QDragEnterEvent* event) override;
     void dropEvent(QDropEvent* event) override;
+    QSize sizeHint() const override;
 
   protected slots:
     void parameterUpdated();
@@ -37,4 +38,5 @@ class WEffectParameterNameBase : public WLabel {
     QString m_text;
     QTimer m_displayNameResetTimer;
     bool m_parameterUpdated;
+    int m_widthHint;
 };

--- a/src/widget/wlabel.cpp
+++ b/src/widget/wlabel.cpp
@@ -95,7 +95,7 @@ void WLabel::setText(const QString& text) {
     m_longText = text;
     if (m_elideMode != Qt::ElideNone) {
         QFontMetrics metrics(font());
-        // Measure the text for label width
+        // Measure the text for the optimum label width
         // frameWidth() is the maximum of the sum of margin, border and padding
         // width of the left and the right side.
         m_widthHint = metrics.size(0, m_longText).width() + 2 * frameWidth();

--- a/src/widget/wlabel.cpp
+++ b/src/widget/wlabel.cpp
@@ -95,11 +95,9 @@ void WLabel::setText(const QString& text) {
     if (m_elideMode != Qt::ElideNone) {
         QFontMetrics metrics(font());
         // Measure the text for label width
-        // it turns out, that "-2" is required to make the text actually fit
-        // (Tested on Ubuntu Trusty)
         // TODO(lp#:1434865): Fix elide width calculation for cases where
         // this text is next to an expanding widget.
-        QString elidedText = metrics.elidedText(m_longText, m_elideMode, width() - 2);
+        QString elidedText = metrics.elidedText(m_longText, m_elideMode, width() - frameWidth());
         QLabel::setText(elidedText);
     } else {
         QLabel::setText(m_longText);

--- a/src/widget/wlabel.cpp
+++ b/src/widget/wlabel.cpp
@@ -96,8 +96,11 @@ void WLabel::setText(const QString& text) {
     if (m_elideMode != Qt::ElideNone) {
         QFontMetrics metrics(font());
         // Measure the text for label width
-        m_widthHint = metrics.size(0, m_longText).width() + frameWidth();
-        QString elidedText = metrics.elidedText(m_longText, m_elideMode, width() - frameWidth());
+        // frameWidth() is the maximum of the sum of margin, border and padding
+        // width of the left and the right side.
+        m_widthHint = metrics.size(0, m_longText).width() + 2 * frameWidth();
+        QString elidedText = metrics.elidedText(
+                m_longText, m_elideMode, width() - 2 * frameWidth());
         QLabel::setText(elidedText);
     } else {
         QLabel::setText(m_longText);

--- a/src/widget/wlabel.cpp
+++ b/src/widget/wlabel.cpp
@@ -12,7 +12,8 @@ WLabel::WLabel(QWidget* pParent)
           m_longText(),
           m_elideMode(Qt::ElideNone),
           m_scaleFactor(1.0),
-          m_highlight(0) {
+          m_highlight(0),
+          m_widthHint(0) {
 }
 
 void WLabel::setup(const QDomNode& node, const SkinContext& context) {
@@ -95,8 +96,7 @@ void WLabel::setText(const QString& text) {
     if (m_elideMode != Qt::ElideNone) {
         QFontMetrics metrics(font());
         // Measure the text for label width
-        // TODO(lp#:1434865): Fix elide width calculation for cases where
-        // this text is next to an expanding widget.
+        m_widthHint = metrics.size(0, m_longText).width() + frameWidth();
         QString elidedText = metrics.elidedText(m_longText, m_elideMode, width() - frameWidth());
         QLabel::setText(elidedText);
     } else {
@@ -143,4 +143,13 @@ void WLabel::setHighlight(int highlight) {
     }
     m_highlight = highlight;
     emit highlightChanged(m_highlight);
+}
+
+QSize WLabel::sizeHint() const {
+    // make sure the sizeHint fits for the entire string.
+    QSize size = QLabel::sizeHint();
+    if (m_elideMode != Qt::ElideNone) {
+        size.setWidth(m_widthHint);
+    }
+    return size;
 }

--- a/src/widget/wlabel.h
+++ b/src/widget/wlabel.h
@@ -24,6 +24,7 @@ class WLabel : public QLabel, public WBaseWidget {
 
     int getHighlight() const;
     void setHighlight(int highlight);
+    QSize sizeHint() const override;
 
   signals:
     void highlightChanged(int highlight);
@@ -41,4 +42,5 @@ class WLabel : public QLabel, public WBaseWidget {
     Qt::TextElideMode m_elideMode;
     double m_scaleFactor;
     int m_highlight;
+    int m_widthHint;
 };


### PR DESCRIPTION
This fixes the wiggling off the knob position during adjusting the value.

A regression caused by the switch between value and label. 




