### PR TITLE
Tracks table: try to restore selection position after track removal

### DIFF
--- a/src/library/dlghidden.cpp
+++ b/src/library/dlghidden.cpp
@@ -41,26 +41,14 @@ DlgHidden::DlgHidden(
             &QPushButton::clicked,
             m_pTrackTableView,
             &WTrackTableView::slotUnhide);
-    connect(btnUnhide,
-            &QPushButton::clicked,
-            this,
-            &DlgHidden::clicked);
     connect(btnPurge,
             &QPushButton::clicked,
             m_pTrackTableView,
             &WTrackTableView::slotPurge);
-    connect(btnPurge,
-            &QPushButton::clicked,
-            this,
-            &DlgHidden::clicked);
     connect(btnDelete,
             &QPushButton::clicked,
             m_pTrackTableView,
             &WTrackTableView::slotDeleteTracksFromDisk);
-    connect(btnDelete,
-            &QPushButton::clicked,
-            this,
-            &DlgHidden::clicked);
     connect(btnSelect,
             &QPushButton::clicked,
             this,
@@ -108,11 +96,6 @@ void DlgHidden::onSearch(const QString& text) {
 
 QString DlgHidden::currentSearch() {
     return m_pHiddenTableModel->currentSearch();
-}
-
-void DlgHidden::clicked() {
-    // all marked tracks are gone now anyway
-    onShow();
 }
 
 void DlgHidden::selectAll() {

--- a/src/library/dlghidden.h
+++ b/src/library/dlghidden.h
@@ -30,7 +30,6 @@ class DlgHidden : public QWidget, public Ui::DlgHidden, public LibraryView {
     bool restoreCurrentViewState() override;
 
   public slots:
-    void clicked();
     void selectAll();
     void selectionChanged(const QItemSelection&, const QItemSelection&);
 

--- a/src/library/dlgmissing.cpp
+++ b/src/library/dlgmissing.cpp
@@ -37,7 +37,6 @@ DlgMissing::DlgMissing(
     m_pTrackTableView->loadTrackModel(m_pMissingTableModel);
 
     connect(btnPurge, &QPushButton::clicked, m_pTrackTableView, &WTrackTableView::slotPurge);
-    connect(btnPurge, &QPushButton::clicked, this, &DlgMissing::clicked);
     connect(btnSelect, &QPushButton::clicked, this, &DlgMissing::selectAll);
     connect(m_pTrackTableView->selectionModel(),
             &QItemSelectionModel::selectionChanged,
@@ -60,11 +59,6 @@ DlgMissing::~DlgMissing() {
 void DlgMissing::onShow() {
     m_pMissingTableModel->select();
     activateButtons(false);
-}
-
-void DlgMissing::clicked() {
-    // all marked tracks are gone now anyway
-    onShow();
 }
 
 void DlgMissing::onSearch(const QString& text) {

--- a/src/library/dlgmissing.h
+++ b/src/library/dlgmissing.h
@@ -30,7 +30,6 @@ class DlgMissing : public QWidget, public Ui::DlgMissing, public LibraryView {
     bool restoreCurrentViewState() override;
 
   public slots:
-    void clicked();
     void selectAll();
     void selectionChanged(const QItemSelection&, const QItemSelection&);
 

--- a/src/library/missingtablemodel.cpp
+++ b/src/library/missingtablemodel.cpp
@@ -57,7 +57,6 @@ void MissingTableModel::setTableModel(int id) {
 MissingTableModel::~MissingTableModel() {
 }
 
-
 void MissingTableModel::purgeTracks(const QModelIndexList& indices) {
     m_pTrackCollectionManager->purgeTracks(getTrackRefs(indices));
 
@@ -65,7 +64,6 @@ void MissingTableModel::purgeTracks(const QModelIndexList& indices) {
     // there.
     select(); //Repopulate the data model.
 }
-
 
 bool MissingTableModel::isColumnInternal(int column) {
     return column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ID) ||

--- a/src/widget/wlibrarytableview.cpp
+++ b/src/widget/wlibrarytableview.cpp
@@ -20,10 +20,10 @@ constexpr int kModelCacheSize = 1000;
 WLibraryTableView::WLibraryTableView(QWidget* parent,
         UserSettingsPointer pConfig)
         : QTableView(parent),
-          m_pConfig(pConfig),
-          m_modelStateCache(kModelCacheSize),
           m_prevRow(0),
-          m_prevColumn(0) {
+          m_prevColumn(0),
+          m_pConfig(pConfig),
+          m_modelStateCache(kModelCacheSize) {
     // Setup properties for table
 
     // Editing starts when clicking on an already selected item.

--- a/src/widget/wlibrarytableview.cpp
+++ b/src/widget/wlibrarytableview.cpp
@@ -187,13 +187,13 @@ void WLibraryTableView::saveCurrentIndex() {
     m_prevColumn = currentIndex().isValid() ? currentIndex().column() : columnAt(0);
 }
 
-void WLibraryTableView::restoreCurrentIndex(const std::optional<QModelIndex>& index) {
+void WLibraryTableView::restoreCurrentIndex(const QModelIndex& index) {
     QItemSelectionModel* pSelectionModel = selectionModel();
     if (!pSelectionModel) {
         return;
     }
-    int row = index ? index->row() : m_prevRow;
-    int col = index ? index->column() : m_prevColumn;
+    int row = index.isValid() ? index.row() : m_prevRow;
+    int col = index.isValid() ? index.column() : m_prevColumn;
     if (model()->rowCount() == 0 || row < 0 || col < 0) {
         // nothing to select
         return;

--- a/src/widget/wlibrarytableview.cpp
+++ b/src/widget/wlibrarytableview.cpp
@@ -166,9 +166,7 @@ bool WLibraryTableView::restoreTrackModelState(
     }
 
     QModelIndex currIndex = state->currentIndex;
-    if (currIndex.isValid()) {
-        selection->setCurrentIndex(currIndex, QItemSelectionModel::NoUpdate);
-    }
+    restoreCurrentIndex(currIndex);
 
     // reinsert the state into the cache
     m_modelStateCache.insert(key, state, 1);
@@ -189,24 +187,26 @@ void WLibraryTableView::saveCurrentIndex() {
     m_prevColumn = currentIndex().isValid() ? currentIndex().column() : columnAt(0);
 }
 
-void WLibraryTableView::restoreCurrentIndex() {
+void WLibraryTableView::restoreCurrentIndex(const std::optional<QModelIndex>& index) {
     QItemSelectionModel* pSelectionModel = selectionModel();
     if (!pSelectionModel) {
         return;
     }
-    if (model()->rowCount() == 0 || m_prevRow < 0 || m_prevColumn < 0) {
+    int row = index ? index->row() : m_prevRow;
+    int col = index ? index->column() : m_prevColumn;
+    if (model()->rowCount() == 0 || row < 0 || col < 0) {
         // nothing to select
         return;
     }
-    if (model()->rowCount() < m_prevRow + 1) {
+    if (model()->rowCount() < row + 1) {
         // select last row
-        m_prevRow = model()->rowCount() - 1;
+        row = model()->rowCount() - 1;
     }
-    if (isColumnHidden(m_prevColumn)) {
+    if (isColumnHidden(col)) {
         // select first column
-        m_prevColumn = columnAt(0);
+        col = columnAt(0);
     }
-    QModelIndex idx = model()->index(m_prevRow, m_prevColumn);
+    QModelIndex idx = model()->index(row, col);
     if (idx.isValid()) {
         pSelectionModel->setCurrentIndex(idx, QItemSelectionModel::NoUpdate);
         scrollTo(idx);

--- a/src/widget/wlibrarytableview.h
+++ b/src/widget/wlibrarytableview.h
@@ -44,6 +44,13 @@ class WLibraryTableView : public QTableView, public virtual LibraryView {
     /// @brief restores current view state.
     /// @return true if restore succeeded
     bool restoreCurrentViewState() override;
+    /// @brief store the current index
+    void saveCurrentIndex();
+    /// @brief restores the current index, meant to provide a starting point for
+    /// navigation after selected tracks have been manually removed from the view
+    /// via hide, remove or purge
+    /// @param optional: index, otherwise row/column member vars are used
+    void restoreCurrentIndex();
 
   signals:
     void loadTrack(TrackPointer pTrack);
@@ -66,4 +73,7 @@ class WLibraryTableView : public QTableView, public virtual LibraryView {
   private:
     const UserSettingsPointer m_pConfig;
     QCache<QString, ModelState> m_modelStateCache;
+
+    int m_prevRow;
+    int m_prevColumn;
 };

--- a/src/widget/wlibrarytableview.h
+++ b/src/widget/wlibrarytableview.h
@@ -70,10 +70,10 @@ class WLibraryTableView : public QTableView, public virtual LibraryView {
             Qt::KeyboardModifiers modifiers) override;
     virtual QString getModelStateKey() const = 0;
 
+    int m_prevRow;
+    int m_prevColumn;
+
   private:
     const UserSettingsPointer m_pConfig;
     QCache<QString, ModelState> m_modelStateCache;
-
-    int m_prevRow;
-    int m_prevColumn;
 };

--- a/src/widget/wlibrarytableview.h
+++ b/src/widget/wlibrarytableview.h
@@ -50,7 +50,7 @@ class WLibraryTableView : public QTableView, public virtual LibraryView {
     /// navigation after selected tracks have been manually removed from the view
     /// via hide, remove or purge
     /// @param optional: index, otherwise row/column member vars are used
-    void restoreCurrentIndex();
+    void restoreCurrentIndex(const std::optional<QModelIndex>& index = std::nullopt);
 
   signals:
     void loadTrack(TrackPointer pTrack);

--- a/src/widget/wlibrarytableview.h
+++ b/src/widget/wlibrarytableview.h
@@ -50,7 +50,7 @@ class WLibraryTableView : public QTableView, public virtual LibraryView {
     /// navigation after selected tracks have been manually removed from the view
     /// via hide, remove or purge
     /// @param optional: index, otherwise row/column member vars are used
-    void restoreCurrentIndex(const std::optional<QModelIndex>& index = std::nullopt);
+    void restoreCurrentIndex(const QModelIndex& index = QModelIndex());
 
   signals:
     void loadTrack(TrackPointer pTrack);

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -2046,6 +2046,7 @@ void WTrackMenu::slotRemoveFromDisk() {
     const QList<QString> tracksToKeep(trackOperator.getTracksToKeep());
     if (tracksToKeep.isEmpty()) {
         // All selected tracks could be processed. Finish!
+        emit restoreCurrentIndex();
         return;
     }
     // Else show a message with a list of tracks that could not be deleted.
@@ -2084,6 +2085,7 @@ void WTrackMenu::slotRemoveFromDisk() {
     // Required for being able to close the dialog
     connect(closeBtn, &QPushButton::clicked, &dlgNotDeleted, &QDialog::close);
     dlgNotDeleted.exec();
+    emit restoreCurrentIndex();
 }
 
 void WTrackMenu::slotShowDlgTrackInfo() {
@@ -2222,6 +2224,7 @@ void WTrackMenu::slotRemove() {
         return;
     }
     m_pTrackModel->removeTracks(getTrackIndices());
+    emit restoreCurrentIndex();
 }
 
 void WTrackMenu::slotHide() {
@@ -2229,6 +2232,7 @@ void WTrackMenu::slotHide() {
         return;
     }
     m_pTrackModel->hideTracks(getTrackIndices());
+    emit restoreCurrentIndex();
 }
 
 void WTrackMenu::slotUnhide() {
@@ -2236,6 +2240,7 @@ void WTrackMenu::slotUnhide() {
         return;
     }
     m_pTrackModel->unhideTracks(getTrackIndices());
+    emit restoreCurrentIndex();
 }
 
 void WTrackMenu::slotPurge() {
@@ -2243,6 +2248,7 @@ void WTrackMenu::slotPurge() {
         return;
     }
     m_pTrackModel->purgeTracks(getTrackIndices());
+    emit restoreCurrentIndex();
 }
 
 void WTrackMenu::clearTrackSelection() {

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -90,6 +90,7 @@ class WTrackMenu : public QMenu {
   signals:
     void loadTrackToPlayer(TrackPointer pTrack, const QString& group, bool play = false);
     void trackMenuVisible(bool visible);
+    void restoreCurrentIndex();
 
   private slots:
     // File

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -521,15 +521,12 @@ void WTrackTableView::onSearch(const QString& text) {
                 trackModel->currentSearch(), text);
         QList<TrackId> selectedTracks = getSelectedTrackIds();
         TrackId prevTrack = getCurrentTrackId();
-        int prevColumn = 0;
-        if (currentIndex().isValid()) {
-            prevColumn = currentIndex().column();
-        }
+        saveCurrentIndex();
         trackModel->search(text);
         if (queryIsLessSpecific) {
             // If the user removed query terms, we try to select the same
             // tracks as before
-            setCurrentTrackId(prevTrack, prevColumn);
+            setCurrentTrackId(prevTrack, m_prevColumn);
             setSelectedTracks(selectedTracks);
         } else {
             // The user created a more specific search query, try to restore a
@@ -537,7 +534,11 @@ void WTrackTableView::onSearch(const QString& text) {
             if (!restoreCurrentViewState()) {
                 // We found no saved state for this query, try to select the
                 // tracks last active, if they are part of the result set
-                setCurrentTrackId(prevTrack, prevColumn);
+                if (!setCurrentTrackId(prevTrack, m_prevColumn)) {
+                    // if the last focused track is not present try to focus the
+                    // respective index and scroll there
+                    restoreCurrentIndex();
+                }
                 setSelectedTracks(selectedTracks);
             }
         }

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -75,6 +75,9 @@ class WTrackTableView : public WLibraryTableView {
     bool slotRestoreCurrentViewState() {
         return restoreCurrentViewState();
     };
+    void slotrestoreCurrentIndex() {
+        restoreCurrentIndex();
+    }
     void slotSelectTrack(const TrackId&);
 
   private slots:


### PR DESCRIPTION
Previously, there was no selection after track removal due to `select()`, hence the selection was reset to the topmost item (which is annoying when working with large track sets).

btw it caused me quite some headaches why this wouldn't work when using the Unhide / Purge buttons in the _Missing_ and _Hidden_ views. Fixed with the first commit.