### PR TITLE
Add super knob adoption option for quick effect chain presets

### DIFF
--- a/src/effects/chains/quickeffectchain.cpp
+++ b/src/effects/chains/quickeffectchain.cpp
@@ -2,6 +2,7 @@
 
 #include "control/controlobject.h"
 #include "effects/effectslot.h"
+#include "effects/effectsmanager.h"
 #include "effects/presets/effectchainpreset.h"
 #include "effects/presets/effectchainpresetmanager.h"
 #include "moc_quickeffectchain.cpp"
@@ -54,8 +55,16 @@ EffectChainPresetPointer QuickEffectChain::presetAtIndex(int index) const {
 }
 
 void QuickEffectChain::loadChainPreset(EffectChainPresetPointer pPreset) {
+    // Loading a chain preset sets the super knob's value to the value it was at
+    // when the chain preset was saved. It may be desirable to keep the knob's
+    // value as is, for instance when changing between multiple presets that
+    // contain a filter and an additional additional effect.
+    const double old_super_knob_value = getSuperParameter();
+
     EffectChain::loadChainPreset(pPreset);
-    if (pPreset) {
+    if (m_pEffectsManager->isAdoptSuperknobSettingEnabled()) {
+        setSuperParameter(old_super_knob_value, true);
+    } else if (pPreset) {
         setSuperParameter(pPreset->superKnob(), true);
     }
 }

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -180,6 +180,10 @@ bool EffectsManager::isAdoptMetaknobSettingEnabled() const {
     return m_pConfig->getValue(ConfigKey("[Effects]", "AdoptMetaknobValue"), true);
 }
 
+bool EffectsManager::isAdoptSuperknobSettingEnabled() const {
+    return m_pConfig->getValue(ConfigKey("[Effects]", "AdoptSuperknobValue"), false);
+}
+
 void EffectsManager::readEffectsXml() {
     QDir settingsPath(m_pConfig->getSettingsPath());
     QFile file(settingsPath.absoluteFilePath(kEffectsXmlFile));

--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -76,6 +76,7 @@ class EffectsManager {
     }
 
     bool isAdoptMetaknobSettingEnabled() const;
+    bool isAdoptSuperknobSettingEnabled() const;
 
   private:
     void addStandardEffectChains();

--- a/src/preferences/dialog/dlgprefeffects.cpp
+++ b/src/preferences/dialog/dlgprefeffects.cpp
@@ -118,7 +118,12 @@ void DlgPrefEffects::slotUpdate() {
 
     loadChainPresetLists();
 
-    bool effectAdoptMetaknobValue = m_pConfig->getValue(
+    const bool effectAdoptSuperknobValue = m_pConfig->getValue(
+            ConfigKey("[Effects]", "AdoptSuperknobValue"), false);
+    radioButtonKeepSuperknobPosition->setChecked(effectAdoptSuperknobValue);
+    radioButtonSuperknobLoadDefault->setChecked(!effectAdoptSuperknobValue);
+
+    const bool effectAdoptMetaknobValue = m_pConfig->getValue(
             ConfigKey("[Effects]", "AdoptMetaknobValue"), true);
     radioButtonKeepMetaknobPosition->setChecked(effectAdoptMetaknobValue);
     radioButtonMetaknobLoadDefault->setChecked(!effectAdoptMetaknobValue);
@@ -128,6 +133,8 @@ void DlgPrefEffects::slotApply() {
     m_pVisibleEffectsList->setList(m_pVisibleEffectsModel->getList());
     saveChainPresetLists();
 
+    m_pConfig->set(ConfigKey("[Effects]", "AdoptSuperknobValue"),
+            ConfigValue(radioButtonKeepSuperknobPosition->isChecked()));
     m_pConfig->set(ConfigKey("[Effects]", "AdoptMetaknobValue"),
             ConfigValue(radioButtonKeepMetaknobPosition->isChecked()));
 }
@@ -141,6 +148,7 @@ void DlgPrefEffects::saveChainPresetLists() {
 }
 
 void DlgPrefEffects::slotResetToDefaults() {
+    radioButtonSuperknobLoadDefault->setChecked(true);
     radioButtonKeepMetaknobPosition->setChecked(true);
     m_pChainPresetManager->resetToDefaults();
 

--- a/src/preferences/dialog/dlgprefeffectsdlg.ui
+++ b/src/preferences/dialog/dlgprefeffectsdlg.ui
@@ -470,12 +470,32 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupMetaKnobOption">
+    <widget class="QGroupBox" name="groupEffectKnobOptions">
      <property name="title">
       <string>Effect load behavior</string>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayoutMetaKnob">
-      <item>
+     <layout class="QGridLayout" name="verticalLayoutEffectKnobOptions">
+      <item row="0" column="0">
+       <widget class="QRadioButton" name="radioButtonKeepSuperknobPosition">
+        <property name="text">
+         <string>Keep superknob position</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">buttonGroupSuperKnob</string>
+        </attribute>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QRadioButton" name="radioButtonSuperknobLoadDefault">
+        <property name="text">
+         <string>Reset superknob to preset default</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">buttonGroupSuperKnob</string>
+        </attribute>
+       </widget>
+      </item>
+      <item row="1" column="0">
        <widget class="QRadioButton" name="radioButtonKeepMetaknobPosition">
         <property name="text">
          <string>Keep metaknob position</string>
@@ -485,7 +505,7 @@
         </attribute>
        </widget>
       </item>
-      <item>
+      <item row="1" column="1">
        <widget class="QRadioButton" name="radioButtonMetaknobLoadDefault">
         <property name="text">
          <string>Reset metaknob to effect default</string>
@@ -509,11 +529,14 @@
   <tabstop>chainPresetExportButton</tabstop>
   <tabstop>chainPresetRenameButton</tabstop>
   <tabstop>chainPresetDeleteButton</tabstop>
+  <tabstop>radioButtonKeepSuperknobPosition</tabstop>
+  <tabstop>radioButtonSuperknobLoadDefault</tabstop>
   <tabstop>radioButtonKeepMetaknobPosition</tabstop>
   <tabstop>radioButtonMetaknobLoadDefault</tabstop>
  </tabstops>
  <resources/>
  <buttongroups>
+  <buttongroup name="buttonGroupSuperKnob"/>
   <buttongroup name="buttonGroupMetaKnob"/>
   <buttongroup name="buttonGroupPresetActions"/>
  </buttongroups>


### PR DESCRIPTION
This is similar to the existing option for meta knobs. This option is needed for DJ controllers that allow the user to apply different quick effect chain presets to tracks, like the Mixer FX section on the Native Instruments Traktor Kontrol line of controllers. The idea with those controllers is that you can pick from a plain filter, or that same filter plus an effect (they have a delay, reverb, white noise, and trance gate), and assign that to a channel. You'd usually select the effect while the filter knob is still in its neutral 12 o' clock position, but if it is not then the filter frequency settings should be preserved and the other effect should merely be added on top of that. I have a Traktor Kontrol S3 script improvement ready that adds this exact feature to Mixxx. That also avoids the potential issue where an effect chain's default super knob position isn't quite at 0.5 and you need to fiddle around with the filter knob to get the soft takeover to work.

This PR doesn't change the default behavior, so if you don't enable the option nothing changes. This change also uncovered another issue with Mixxx's effect handling where changing these chain presets will not immediately switch between presets (when the new one is done loading)i. Instead it removes the old one, and it then takes one or more buffers before the new chain takes effect. Fixing this will require more investigation in the future.

I've added the preference next to the existing meta knob preference using the same style. By the way, shouldn't this be 'meta knob' and 'super knob' instead of 'metaknob' and 'superknob'?
![image](https://user-images.githubusercontent.com/748520/212423437-8b3ebba7-3bcd-4c23-b4cb-069fbb25228e.png)
