### PR TITLE
Refactoring: Static vs dynamic subobject allocation

### DIFF
--- a/src/engine/controls/quantizecontrol.cpp
+++ b/src/engine/controls/quantizecontrol.cpp
@@ -13,21 +13,14 @@ QuantizeControl::QuantizeControl(const QString& group,
         UserSettingsPointer pConfig)
         : EngineControl(group, pConfig),
           // Turn quantize OFF by default. See Bug #898213
-          m_pCOQuantizeEnabled(new ControlPushButton(ConfigKey(group, "quantize"), true)),
-          m_pCONextBeat(new ControlObject(ConfigKey(group, "beat_next"))),
-          m_pCOPrevBeat(new ControlObject(ConfigKey(group, "beat_prev"))),
-          m_pCOClosestBeat(new ControlObject(ConfigKey(group, "beat_closest"))) {
+          m_pCOQuantizeEnabled(std::make_unique<ControlPushButton>(ConfigKey(group, "quantize"), true)),
+          m_pCONextBeat(std::make_unique<ControlObject>(ConfigKey(group, "beat_next"))),
+          m_pCOPrevBeat(std::make_unique<ControlObject>(ConfigKey(group, "beat_prev"))),
+          m_pCOClosestBeat(std::make_unique<ControlObject>(ConfigKey(group, "beat_closest"))) {
     m_pCOQuantizeEnabled->setButtonMode(ControlPushButton::TOGGLE);
     m_pCONextBeat->set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
     m_pCOPrevBeat->set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
     m_pCOClosestBeat->set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
-}
-
-QuantizeControl::~QuantizeControl() {
-    delete m_pCOQuantizeEnabled;
-    delete m_pCONextBeat;
-    delete m_pCOPrevBeat;
-    delete m_pCOClosestBeat;
 }
 
 void QuantizeControl::trackLoaded(TrackPointer pNewTrack) {

--- a/src/engine/controls/quantizecontrol.cpp
+++ b/src/engine/controls/quantizecontrol.cpp
@@ -13,14 +13,14 @@ QuantizeControl::QuantizeControl(const QString& group,
         UserSettingsPointer pConfig)
         : EngineControl(group, pConfig),
           // Turn quantize OFF by default. See Bug #898213
-          m_pCOQuantizeEnabled(std::make_unique<ControlPushButton>(ConfigKey(group, "quantize"), true)),
-          m_pCONextBeat(std::make_unique<ControlObject>(ConfigKey(group, "beat_next"))),
-          m_pCOPrevBeat(std::make_unique<ControlObject>(ConfigKey(group, "beat_prev"))),
-          m_pCOClosestBeat(std::make_unique<ControlObject>(ConfigKey(group, "beat_closest"))) {
-    m_pCOQuantizeEnabled->setButtonMode(ControlPushButton::TOGGLE);
-    m_pCONextBeat->set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
-    m_pCOPrevBeat->set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
-    m_pCOClosestBeat->set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
+          m_COQuantizeEnabled(ConfigKey(group, "quantize"), true),
+          m_CONextBeat(ConfigKey(group, "beat_next")),
+          m_COPrevBeat(ConfigKey(group, "beat_prev")),
+          m_COClosestBeat(ConfigKey(group, "beat_closest")) {
+    m_COQuantizeEnabled.setButtonMode(ControlPushButton::TOGGLE);
+    m_CONextBeat.set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
+    m_COPrevBeat.set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
+    m_COClosestBeat.set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
 }
 
 void QuantizeControl::trackLoaded(TrackPointer pNewTrack) {
@@ -32,9 +32,9 @@ void QuantizeControl::trackLoaded(TrackPointer pNewTrack) {
         updateClosestBeat(mixxx::audio::kStartFramePos);
     } else {
         m_pBeats.reset();
-        m_pCOPrevBeat->set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
-        m_pCONextBeat->set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
-        m_pCOClosestBeat->set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
+        m_COPrevBeat.set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
+        m_CONextBeat.set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
+        m_COClosestBeat.set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
     }
 }
 
@@ -66,10 +66,10 @@ void QuantizeControl::playPosChanged(mixxx::audio::FramePos position) {
     //       that could actually cause a problem?
     const auto prevBeatPosition =
             mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                    m_pCOPrevBeat->get());
+                    m_COPrevBeat.get());
     const auto nextBeatPosition =
             mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                    m_pCONextBeat->get());
+                    m_CONextBeat.get());
     if (!prevBeatPosition.isValid() || position < prevBeatPosition ||
             !nextBeatPosition.isValid() || position > nextBeatPosition) {
         lookupBeatPositions(position);
@@ -85,8 +85,8 @@ void QuantizeControl::lookupBeatPositions(mixxx::audio::FramePos position) {
         mixxx::audio::FramePos nextBeatPosition;
         pBeats->findPrevNextBeats(position, &prevBeatPosition, &nextBeatPosition, true);
         // FIXME: -1.0 is a valid frame position, should we set the COs to NaN?
-        m_pCOPrevBeat->set(prevBeatPosition.toEngineSamplePosMaybeInvalid());
-        m_pCONextBeat->set(nextBeatPosition.toEngineSamplePosMaybeInvalid());
+        m_COPrevBeat.set(prevBeatPosition.toEngineSamplePosMaybeInvalid());
+        m_CONextBeat.set(nextBeatPosition.toEngineSamplePosMaybeInvalid());
     }
 }
 
@@ -97,22 +97,22 @@ void QuantizeControl::updateClosestBeat(mixxx::audio::FramePos position) {
     }
     const auto prevBeatPosition =
             mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                    m_pCOPrevBeat->get());
+                    m_COPrevBeat.get());
     const auto nextBeatPosition =
             mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                    m_pCONextBeat->get());
+                    m_CONextBeat.get());
 
     // Calculate closest beat by hand since we want the beat locations themselves
     // and duplicating the work by calling the standard API would double
     // the number of mutex locks.
     if (!prevBeatPosition.isValid()) {
         if (nextBeatPosition.isValid()) {
-            m_pCOClosestBeat->set(nextBeatPosition.toEngineSamplePos());
+            m_COClosestBeat.set(nextBeatPosition.toEngineSamplePos());
         } else {
             // Likely no beat information -- can't set closest beat value.
         }
     } else if (!nextBeatPosition.isValid()) {
-        m_pCOClosestBeat->set(prevBeatPosition.toEngineSamplePos());
+        m_COClosestBeat.set(prevBeatPosition.toEngineSamplePos());
     } else {
         const mixxx::audio::FramePos currentClosestBeatPosition =
                 (nextBeatPosition - position > position - prevBeatPosition)
@@ -120,9 +120,9 @@ void QuantizeControl::updateClosestBeat(mixxx::audio::FramePos position) {
                 : nextBeatPosition;
         const auto closestBeatPosition =
                 mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                        m_pCOClosestBeat->get());
+                        m_COClosestBeat.get());
         if (closestBeatPosition != currentClosestBeatPosition) {
-            m_pCOClosestBeat->set(currentClosestBeatPosition.toEngineSamplePos());
+            m_COClosestBeat.set(currentClosestBeatPosition.toEngineSamplePos());
         }
     }
 }

--- a/src/engine/controls/quantizecontrol.cpp
+++ b/src/engine/controls/quantizecontrol.cpp
@@ -11,15 +11,15 @@
 
 QuantizeControl::QuantizeControl(const QString& group,
         UserSettingsPointer pConfig)
-        : EngineControl(group, pConfig) {
-    // Turn quantize OFF by default. See Bug #898213
-    m_pCOQuantizeEnabled = new ControlPushButton(ConfigKey(group, "quantize"), true);
+        : EngineControl(group, pConfig),
+          // Turn quantize OFF by default. See Bug #898213
+          m_pCOQuantizeEnabled(new ControlPushButton(ConfigKey(group, "quantize"), true)),
+          m_pCONextBeat(new ControlObject(ConfigKey(group, "beat_next"))),
+          m_pCOPrevBeat(new ControlObject(ConfigKey(group, "beat_prev"))),
+          m_pCOClosestBeat(new ControlObject(ConfigKey(group, "beat_closest"))) {
     m_pCOQuantizeEnabled->setButtonMode(ControlPushButton::TOGGLE);
-    m_pCONextBeat = new ControlObject(ConfigKey(group, "beat_next"));
     m_pCONextBeat->set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
-    m_pCOPrevBeat = new ControlObject(ConfigKey(group, "beat_prev"));
     m_pCOPrevBeat->set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
-    m_pCOClosestBeat = new ControlObject(ConfigKey(group, "beat_closest"));
     m_pCOClosestBeat->set(mixxx::audio::kInvalidFramePos.toEngineSamplePosMaybeInvalid());
 }
 

--- a/src/engine/controls/quantizecontrol.h
+++ b/src/engine/controls/quantizecontrol.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QObject>
+#include <memory>
 
 #include "engine/controls/enginecontrol.h"
 #include "preferences/usersettings.h"
@@ -14,7 +15,6 @@ class QuantizeControl : public EngineControl {
     Q_OBJECT
   public:
     QuantizeControl(const QString& group, UserSettingsPointer pConfig);
-    ~QuantizeControl() override;
 
     void setFrameInfo(mixxx::audio::FramePos currentPosition,
             mixxx::audio::FramePos trackEndPosition,
@@ -30,10 +30,10 @@ class QuantizeControl : public EngineControl {
     void updateClosestBeat(mixxx::audio::FramePos position);
     void playPosChanged(mixxx::audio::FramePos position);
 
-    ControlPushButton* m_pCOQuantizeEnabled;
-    ControlObject* m_pCONextBeat;
-    ControlObject* m_pCOPrevBeat;
-    ControlObject* m_pCOClosestBeat;
+    std::unique_ptr<ControlPushButton> m_pCOQuantizeEnabled;
+    std::unique_ptr<ControlObject> m_pCONextBeat;
+    std::unique_ptr<ControlObject> m_pCOPrevBeat;
+    std::unique_ptr<ControlObject> m_pCOClosestBeat;
 
     // m_pBeats is written from an engine worker thread
     mixxx::BeatsPointer m_pBeats;

--- a/src/engine/controls/quantizecontrol.h
+++ b/src/engine/controls/quantizecontrol.h
@@ -1,15 +1,13 @@
 #pragma once
 
 #include <QObject>
-#include <memory>
 
+#include "control/controlobject.h"
+#include "control/controlpushbutton.h"
 #include "engine/controls/enginecontrol.h"
 #include "preferences/usersettings.h"
 #include "track/beats.h"
 #include "track/track_decl.h"
-
-class ControlObject;
-class ControlPushButton;
 
 class QuantizeControl : public EngineControl {
     Q_OBJECT
@@ -30,10 +28,10 @@ class QuantizeControl : public EngineControl {
     void updateClosestBeat(mixxx::audio::FramePos position);
     void playPosChanged(mixxx::audio::FramePos position);
 
-    std::unique_ptr<ControlPushButton> m_pCOQuantizeEnabled;
-    std::unique_ptr<ControlObject> m_pCONextBeat;
-    std::unique_ptr<ControlObject> m_pCOPrevBeat;
-    std::unique_ptr<ControlObject> m_pCOClosestBeat;
+    ControlPushButton m_COQuantizeEnabled;
+    ControlObject m_CONextBeat;
+    ControlObject m_COPrevBeat;
+    ControlObject m_COClosestBeat;
 
     // m_pBeats is written from an engine worker thread
     mixxx::BeatsPointer m_pBeats;


### PR DESCRIPTION
Hi, I plan to perform some refactorings for code quality and this pull-request is a test balloon in order to ask how to proceed. Please do not merge (draft), but comment the ideas. Thank you!

[QuantizeControl: move sub-object creation to initializer list](https://github.com/mixxxdj/mixxx/commit/ba2b8180caec673a674e12768784c3b8658125a1):
Demonstrates how I would refactor ctors that do not make proper use of the initializer list. I think there is not too much to discuss about this. In my opinion it is a requirement for both following variants and it is the way C++ intents to write ctors.

[QuantizeControl: use automatic memory management](https://github.com/mixxxdj/mixxx/commit/78bad073c95b1869d2d0470889b57f39b1c38bdd):
Currently, most subobjects (at least in the engine) seem to be allocated manually on the heap. The intended way to perform dynamic allocations for C++17 and above is via std::make_unique/std::unique_ptr. This is how I would refactor if dynamic allocation is desired.

[QuantizeControl: statically allocate sub-objects](https://github.com/mixxxdj/mixxx/commit/5fffc7b7407823369a253a7b4eec4bdadde935fb):
As you can see in this commit, it is not necessary to allocate the subobjects on the heap. They can simply be members. However, the full class definition of the subobjects has to be available in the header to make this work. Am I missing something? Otherwise this would be the desirable way from a runtime performance and resource perspective, I guess.

Which way do you prefer? Any thoughts? I intent to perform such a refactoring starting with the engine subsystem.

Best regards, Alex.



