### PR TITLE
ImportPlaylist: added slotCreateImportPlaylistDirect() 

### DIFF
--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -493,7 +493,7 @@ void CoreServices::initialize(QApplication* pApp) {
             qWarning() << "Detected Playlist file!!";
             const QString playlistFile = musicFiles.at(i);
             qWarning() << playlistFile;
-            BasePlaylistFeature::slotCreateImportPlaylistDirect(playlistFile);
+            m_pLibrary->importPlaylistFile(playlistFile);
         }
     }
 

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -5,6 +5,8 @@
 #include <QPushButton>
 #include <QStandardPaths>
 
+#include "library/trackset/baseplaylistfeature.h"
+
 #ifdef __BROADCAST__
 #include "broadcast/broadcastmanager.h"
 #endif
@@ -104,6 +106,21 @@ inline QLocale inputLocale() {
 
 namespace mixxx {
 
+// Function to check if a given file is a playlist
+bool isPlaylist(QString fileName) {
+    // Create a list of known playlist file extensions
+    QStringList playlistExtensions;
+    playlistExtensions << "m3u"
+                       << "m3u8"
+                       << "pls";
+
+    // Get file information using the given file name
+    QFileInfo fileInfo(fileName);
+
+    // Check if the file extension of the given file is in the playlist
+    // extensions list, in a case-insensitive manner and return the result
+    return playlistExtensions.contains(fileInfo.suffix(), Qt::CaseInsensitive);
+}
 CoreServices::CoreServices(const CmdlineArgs& args, QApplication* pApp)
         : m_runtime_timer(QLatin1String("CoreServices::runtime")),
           m_cmdlineArgs(args),
@@ -466,10 +483,17 @@ void CoreServices::initialize(QApplication* pApp) {
 
     // Load tracks in args.qlMusicFiles (command line arguments) into player
     // 1 and 2:
+
     const QList<QString>& musicFiles = m_cmdlineArgs.getMusicFiles();
+
     for (int i = 0; i < (int)m_pPlayerManager->numDecks() && i < musicFiles.count(); ++i) {
         if (SoundSourceProxy::isFileNameSupported(musicFiles.at(i))) {
             m_pPlayerManager->slotLoadToDeck(musicFiles.at(i), i + 1);
+        } else if (isPlaylist(musicFiles.at(i))) {
+            qWarning() << "Detected Playlist file!!";
+            const QString playlistFile = musicFiles.at(i);
+            qWarning() << playlistFile;
+            BasePlaylistFeature::slotCreateImportPlaylistDirect(playlistFile);
         }
     }
 
@@ -528,11 +552,11 @@ void CoreServices::initializeKeyboard() {
 void CoreServices::slotOptionsKeyboard(bool toggle) {
     UserSettingsPointer pConfig = m_pSettingsManager->settings();
     if (toggle) {
-        //qDebug() << "Enable keyboard shortcuts/mappings";
+        // qDebug() << "Enable keyboard shortcuts/mappings";
         m_pKeyboardEventFilter->setKeyboardConfig(m_pKbdConfig.get());
         pConfig->set(ConfigKey("[Keyboard]", "Enabled"), ConfigValue(1));
     } else {
-        //qDebug() << "Disable keyboard shortcuts/mappings";
+        // qDebug() << "Disable keyboard shortcuts/mappings";
         m_pKeyboardEventFilter->setKeyboardConfig(m_pKbdConfigEmpty.get());
         pConfig->set(ConfigKey("[Keyboard]", "Enabled"), ConfigValue(0));
     }

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -490,13 +490,11 @@ void CoreServices::initialize(QApplication* pApp) {
         if (SoundSourceProxy::isFileNameSupported(musicFiles.at(i))) {
             m_pPlayerManager->slotLoadToDeck(musicFiles.at(i), i + 1);
         } else if (isPlaylist(musicFiles.at(i))) {
-            qWarning() << "Detected Playlist file!!";
             const QString playlistFile = musicFiles.at(i);
-            qWarning() << playlistFile;
+            qDebug() << "Found playlist files in the command line arguments!!" << playlistFile;
             m_pLibrary->importPlaylistFile(playlistFile);
         }
     }
-
     m_isInitialized = true;
 }
 

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -109,10 +109,10 @@ namespace mixxx {
 // Function to check if a given file is a playlist
 bool isPlaylist(QString fileName) {
     // Create a list of known playlist file extensions
-    QStringList playlistExtensions;
-    playlistExtensions << "m3u"
-                       << "m3u8"
-                       << "pls";
+    const QStringList playlistExtensions = {
+            QStringLiteral("m3u"),
+            QStringLiteral("m3u8"),
+            QStringLiteral("pls")};
 
     // Get file information using the given file name
     QFileInfo fileInfo(fileName);

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -95,6 +95,7 @@ class Library: public QObject {
     static const int kDefaultRowHeightPx;
 
     void setFont(const QFont& font);
+    void importPlaylistFile(const QString& playlistFile);
     void setRowHeight(int rowHeight);
     void setEditMedatataSelectedClick(bool enable);
 

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -194,7 +194,7 @@ void BasePlaylistFeature::selectPlaylistInSidebar(int playlistId, bool select) {
 }
 
 void BasePlaylistFeature::activateChild(const QModelIndex& index) {
-    //qDebug() << "BasePlaylistFeature::activateChild()" << index;
+    // qDebug() << "BasePlaylistFeature::activateChild()" << index;
     int playlistId = playlistIdFromIndex(index);
     if (playlistId == kInvalidPlaylistId) {
         // This happens if user clicks on group nodes
@@ -212,7 +212,7 @@ void BasePlaylistFeature::activatePlaylist(int playlistId) {
         return;
     }
     QModelIndex index = indexFromPlaylistId(playlistId);
-    //qDebug() << "BasePlaylistFeature::activatePlaylist()" << playlistId << index;
+    // qDebug() << "BasePlaylistFeature::activatePlaylist()" << playlistId << index;
     VERIFY_OR_DEBUG_ASSERT(index.isValid()) {
         return;
     }
@@ -408,7 +408,7 @@ void BasePlaylistFeature::deleteItem(const QModelIndex& index) {
 }
 
 void BasePlaylistFeature::slotDeletePlaylist() {
-    //qDebug() << "slotDeletePlaylist() row:" << m_lastRightClickedIndex.data();
+    // qDebug() << "slotDeletePlaylist() row:" << m_lastRightClickedIndex.data();
     if (!m_lastRightClickedIndex.isValid()) {
         return;
     }
@@ -456,7 +456,7 @@ void BasePlaylistFeature::slotDeletePlaylist() {
 }
 
 void BasePlaylistFeature::slotImportPlaylist() {
-    //qDebug() << "slotImportPlaylist() row:" << m_lastRightClickedIndex.data();
+    // qDebug() << "slotImportPlaylist() row:" << m_lastRightClickedIndex.data();
     const QString playlistFile = getPlaylistFile();
     if (playlistFile.isEmpty()) {
         return;
@@ -534,6 +534,27 @@ void BasePlaylistFeature::slotCreateImportPlaylist() {
         slotImportPlaylistFile(playlistFile);
     }
     activatePlaylist(lastPlaylistId);
+}
+
+void BasePlaylistFeature::slotCreateImportPlaylistDirect(const QString& playlistFile) {
+    const QFileInfo fileInfo(playlistFile);
+    const QString baseName = fileInfo.baseName();
+    QString name;
+
+    bool validNameGiven = false;
+    int i = 0;
+    while (!validNameGiven) {
+        name = baseName;
+        if (i != 0) {
+            name += QString::number(i);
+        }
+
+        // Check name
+        int existingId = m_playlistDao.getPlaylistIdFromName(name);
+
+        validNameGiven = (existingId == kInvalidPlaylistId);
+        ++i;
+    }
 }
 
 void BasePlaylistFeature::slotExportPlaylist() {
@@ -643,22 +664,22 @@ void BasePlaylistFeature::slotExportTrackFiles() {
 }
 
 void BasePlaylistFeature::slotAddToAutoDJ() {
-    //qDebug() << "slotAddToAutoDJ() row:" << m_lastRightClickedIndex.data();
+    // qDebug() << "slotAddToAutoDJ() row:" << m_lastRightClickedIndex.data();
     addToAutoDJ(PlaylistDAO::AutoDJSendLoc::BOTTOM);
 }
 
 void BasePlaylistFeature::slotAddToAutoDJTop() {
-    //qDebug() << "slotAddToAutoDJTop() row:" << m_lastRightClickedIndex.data();
+    // qDebug() << "slotAddToAutoDJTop() row:" << m_lastRightClickedIndex.data();
     addToAutoDJ(PlaylistDAO::AutoDJSendLoc::TOP);
 }
 
 void BasePlaylistFeature::slotAddToAutoDJReplace() {
-    //qDebug() << "slotAddToAutoDJReplace() row:" << m_lastRightClickedIndex.data();
+    // qDebug() << "slotAddToAutoDJReplace() row:" << m_lastRightClickedIndex.data();
     addToAutoDJ(PlaylistDAO::AutoDJSendLoc::REPLACE);
 }
 
 void BasePlaylistFeature::addToAutoDJ(PlaylistDAO::AutoDJSendLoc loc) {
-    //qDebug() << "slotAddToAutoDJ() row:" << m_lastRightClickedIndex.data();
+    // qDebug() << "slotAddToAutoDJ() row:" << m_lastRightClickedIndex.data();
     if (m_lastRightClickedIndex.isValid()) {
         int playlistId = playlistIdFromIndex(m_lastRightClickedIndex);
         if (playlistId >= 0) {
@@ -731,8 +752,8 @@ void BasePlaylistFeature::updateChildModel(int playlistId) {
 }
 
 /**
-  * Clears the child model dynamically, but the invisible root item remains
-  */
+ * Clears the child model dynamically, but the invisible root item remains
+ */
 void BasePlaylistFeature::clearChildModel() {
     m_pSidebarModel->removeRows(0, m_pSidebarModel->rowCount());
 }

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -20,6 +20,7 @@
 #include "library/treeitem.h"
 #include "library/treeitemmodel.h"
 #include "moc_baseplaylistfeature.cpp"
+#include "playlistfeature.h"
 #include "track/track.h"
 #include "track/trackid.h"
 #include "util/assert.h"
@@ -536,25 +537,10 @@ void BasePlaylistFeature::slotCreateImportPlaylist() {
     activatePlaylist(lastPlaylistId);
 }
 
-void BasePlaylistFeature::slotCreateImportPlaylistDirect(const QString& playlistFile) {
-    const QFileInfo fileInfo(playlistFile);
-    const QString baseName = fileInfo.baseName();
-    QString name;
-
-    bool validNameGiven = false;
-    int i = 0;
-    while (!validNameGiven) {
-        name = baseName;
-        if (i != 0) {
-            name += QString::number(i);
-        }
-
-        // Check name
-        int existingId = m_playlistDao.getPlaylistIdFromName(name);
-
-        validNameGiven = (existingId == kInvalidPlaylistId);
-        ++i;
-    }
+void Library::importPlaylistFile(const QString& playlistFile) {
+    qWarning() << "Reached basePlaylistfeature";
+    qWarning() << playlistFile;
+    m_pPlaylistFeature->importPlaylistFile(playlistFile);
 }
 
 void BasePlaylistFeature::slotExportPlaylist() {

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -538,8 +538,6 @@ void BasePlaylistFeature::slotCreateImportPlaylist() {
 }
 
 void Library::importPlaylistFile(const QString& playlistFile) {
-    qWarning() << "Reached basePlaylistfeature";
-    qWarning() << playlistFile;
     m_pPlaylistFeature->importPlaylistFile(playlistFile);
 }
 
@@ -737,9 +735,8 @@ void BasePlaylistFeature::updateChildModel(int playlistId) {
     }
 }
 
-/**
- * Clears the child model dynamically, but the invisible root item remains
- */
+// Clears the child model dynamically, but the invisible root item remains
+
 void BasePlaylistFeature::clearChildModel() {
     m_pSidebarModel->removeRows(0, m_pSidebarModel->rowCount());
 }

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -73,6 +73,8 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     void slotImportPlaylist();
     void slotImportPlaylistFile(const QString& playlist_file);
     void slotCreateImportPlaylist();
+    void slotCreateImportPlaylistDirect(const QString& playlistFiles);
+
     void slotExportPlaylist();
     // Copy all of the tracks in a playlist to a new directory.
     void slotExportTrackFiles();

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -73,7 +73,6 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     void slotImportPlaylist();
     void slotImportPlaylistFile(const QString& playlist_file);
     void slotCreateImportPlaylist();
-    void slotCreateImportPlaylistDirect(const QString& playlistFiles);
 
     void slotExportPlaylist();
     // Copy all of the tracks in a playlist to a new directory.

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -126,8 +126,6 @@ bool PlaylistFeature::dragMoveAcceptChild(const QModelIndex& index, const QUrl& 
 }
 
 void PlaylistFeature::importPlaylistFile(const QString& playlistFile) {
-    qWarning() << "Reached playlistfeature";
-    qWarning() << playlistFile;
     const QFileInfo fileInfo(playlistFile);
     const QString baseName = fileInfo.baseName();
     QString name;

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -125,6 +125,29 @@ bool PlaylistFeature::dragMoveAcceptChild(const QModelIndex& index, const QUrl& 
     return !locked && formatSupported;
 }
 
+void PlaylistFeature::importPlaylistFile(const QString& playlistFile) {
+    qWarning() << "Reached playlistfeature";
+    qWarning() << playlistFile;
+    const QFileInfo fileInfo(playlistFile);
+    const QString baseName = fileInfo.baseName();
+    QString name;
+
+    bool validNameGiven = false;
+    int i = 0;
+    while (!validNameGiven) {
+        name = baseName;
+        if (i != 0) {
+            name += QString::number(i);
+        }
+
+        // Check name
+        int existingId = m_playlistDao.getPlaylistIdFromName(name);
+
+        validNameGiven = (existingId == kInvalidPlaylistId);
+        ++i;
+    }
+}
+
 QList<BasePlaylistFeature::IdAndLabel> PlaylistFeature::createPlaylistLabels() {
     QSqlDatabase database =
             m_pLibrary->trackCollectionManager()->internalCollection()->database();

--- a/src/library/trackset/playlistfeature.h
+++ b/src/library/trackset/playlistfeature.h
@@ -30,6 +30,7 @@ class PlaylistFeature : public BasePlaylistFeature {
             const QList<QUrl>& urls,
             QObject* pSource) override;
     bool dragMoveAcceptChild(const QModelIndex& index, const QUrl& url) override;
+    void importPlaylistFile(const QString& playlistFile);
 
   public slots:
     void onRightClick(const QPoint& globalPos) override;


### PR DESCRIPTION
This is in reference to #11178 

added slotCreateImportPlaylistDirect(const QString&) to handle playlist file types


This function would enable to read the playlist files independent of any qAction.
Known issue: The [following calling](https://github.com/shivang0-0/mixxx/blob/playlist-import/src/coreservices.cpp#L496) is facing issue as BasePlaylistFeature is an abstract class.