### PR TITLE
Fix search in external libraries 

### DIFF
--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -112,6 +112,8 @@ ITunesFeature::ITunesFeature(Library* pLibrary, UserSettingsPointer pConfig)
             &QFutureWatcher<TreeItem*>::finished,
             this,
             &ITunesFeature::onTrackCollectionLoaded);
+
+    m_pITunesTrackModel->setSearch(""); // enable search.
 }
 
 ITunesFeature::~ITunesFeature() {

--- a/src/library/rhythmbox/rhythmboxfeature.cpp
+++ b/src/library/rhythmbox/rhythmboxfeature.cpp
@@ -74,6 +74,8 @@ RhythmboxFeature::RhythmboxFeature(Library* pLibrary, UserSettingsPointer pConfi
             this,
             &RhythmboxFeature::onTrackCollectionLoaded,
             Qt::QueuedConnection);
+
+    m_pRhythmboxTrackModel->setSearch(""); // enable search.
 }
 
 RhythmboxFeature::~RhythmboxFeature() {

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -114,6 +114,8 @@ TraktorFeature::TraktorFeature(Library* pLibrary, UserSettingsPointer pConfig)
             &QFutureWatcher<TreeItem*>::finished,
             this,
             &TraktorFeature::onTrackCollectionLoaded);
+
+    m_pTraktorTableModel->setSearch(""); // enable search
 }
 
 TraktorFeature::~TraktorFeature() {


### PR DESCRIPTION
This re-anable the search for external libraries. 
It fixes bug #11216 

Yes, QString("") means search enabled and QString() disabled. This magic has already been fixed in 2.4. 
We need to make sure to revert this PR during merge. 