### PR TITLE
Normalize all .bat line endings to CRLF.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,3 +26,6 @@
 
 # shell scripts will always have LF line endings on checkout.
 *.sh text eol=lf
+
+# Windows batch scripts will always have CRLF line endings.
+*.bat text eol=crlf


### PR DESCRIPTION
This pull requests fixes the EOL character bug reported in #11223. The steps taken to resolve the issue are the ones outlined [here](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings).