### PR TITLE
Fix DEBUG_ASSERT with Serato export enabled

### DIFF
--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1373,6 +1373,42 @@ quint16 Track::getCoverHash() const {
     return m_record.getCoverInfo().hash;
 }
 
+void Track::exportSeratoMetadata() {
+    const auto streamInfo = m_record.getStreamInfoFromSource();
+    VERIFY_OR_DEBUG_ASSERT(streamInfo &&
+            streamInfo->getSignalInfo().isValid() &&
+            streamInfo->getDuration() > mixxx::Duration::empty()) {
+        kLogger.warning() << "Cannot write Serato metadata because signal "
+                             "info and/or duration is not available:"
+                          << getLocation();
+        return;
+    }
+    const mixxx::audio::SampleRate sampleRate =
+            streamInfo->getSignalInfo().getSampleRate();
+    mixxx::SeratoTags* seratoTags =
+            m_record.refMetadata().refTrackInfo().ptrSeratoTags();
+    DEBUG_ASSERT(seratoTags);
+    if (seratoTags->status() == mixxx::SeratoTags::ParserStatus::Failed) {
+        kLogger.warning()
+                << "Refusing to overwrite Serato metadata that failed to parse:"
+                << getLocation();
+    } else {
+        seratoTags->setTrackColor(getColor());
+        seratoTags->setBpmLocked(isBpmLocked());
+        QList<mixxx::CueInfo> cueInfos;
+        for (const CuePointer& pCue : qAsConst(m_cuePoints)) {
+            cueInfos.append(pCue->getCueInfo(sampleRate));
+        }
+        const double timingOffset = mixxx::SeratoTags::guessTimingOffsetMillis(
+                getLocation(), streamInfo->getSignalInfo());
+        seratoTags->setCueInfos(cueInfos, timingOffset);
+        seratoTags->setBeats(m_pBeats,
+                streamInfo->getSignalInfo(),
+                streamInfo->getDuration(),
+                timingOffset);
+    }
+}
+
 ExportTrackMetadataResult Track::exportMetadata(
         mixxx::MetadataSourcePointer pMetadataSource,
         UserSettingsPointer pConfig) {
@@ -1403,47 +1439,6 @@ ExportTrackMetadataResult Track::exportMetadata(
         return ExportTrackMetadataResult::Skipped;
     }
 
-    if (pConfig->getValue<bool>(kConfigKeySeratoMetadataExport)) {
-        const auto streamInfo = m_record.getStreamInfoFromSource();
-        VERIFY_OR_DEBUG_ASSERT(streamInfo &&
-                streamInfo->getSignalInfo().isValid() &&
-                streamInfo->getDuration() > mixxx::Duration::empty()) {
-            kLogger.warning() << "Cannot write Serato metadata because signal "
-                                 "info and/or duration is not available:"
-                              << getLocation();
-            return ExportTrackMetadataResult::Skipped;
-        }
-
-        const mixxx::audio::SampleRate sampleRate =
-                streamInfo->getSignalInfo().getSampleRate();
-
-        mixxx::SeratoTags* seratoTags = m_record.refMetadata().refTrackInfo().ptrSeratoTags();
-        DEBUG_ASSERT(seratoTags);
-
-        if (seratoTags->status() == mixxx::SeratoTags::ParserStatus::Failed) {
-            kLogger.warning()
-                    << "Refusing to overwrite Serato metadata that failed to parse:"
-                    << getLocation();
-        } else {
-            seratoTags->setTrackColor(getColor());
-            seratoTags->setBpmLocked(isBpmLocked());
-
-            QList<mixxx::CueInfo> cueInfos;
-            for (const CuePointer& pCue : qAsConst(m_cuePoints)) {
-                cueInfos.append(pCue->getCueInfo(sampleRate));
-            }
-
-            const double timingOffset = mixxx::SeratoTags::guessTimingOffsetMillis(
-                    getLocation(), streamInfo->getSignalInfo());
-            seratoTags->setCueInfos(cueInfos, timingOffset);
-
-            seratoTags->setBeats(m_pBeats,
-                    streamInfo->getSignalInfo(),
-                    streamInfo->getDuration(),
-                    timingOffset);
-        }
-    }
-
     // Check if the metadata has actually been modified. Otherwise
     // we don't need to write it back. Exporting unmodified metadata
     // would needlessly update the file's time stamp and should be
@@ -1465,6 +1460,10 @@ ExportTrackMetadataResult Track::exportMetadata(
         // that is stored in the database. New columns that need to be populated
         // from file tags cannot be filled during a database migration.
         m_record.mergeImportedMetadata(importedFromFile);
+
+        if (pConfig->getValue<bool>(kConfigKeySeratoMetadataExport)) {
+            exportSeratoMetadata();
+        }
 
         // Prepare export by cloning and normalizing the metadata
         normalizedFromRecord = m_record.getMetadata();

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -450,7 +450,7 @@ class Track : public QObject {
     };
     double getDuration(DurationRounding rounding) const;
 
-    void exportSeratoMetadata();
+    bool exportSeratoMetadata();
 
     ExportTrackMetadataResult exportMetadata(
             mixxx::MetadataSourcePointer pMetadataSource,

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -450,6 +450,8 @@ class Track : public QObject {
     };
     double getDuration(DurationRounding rounding) const;
 
+    void exportSeratoMetadata();
+
     ExportTrackMetadataResult exportMetadata(
             mixxx::MetadataSourcePointer pMetadataSource,
             UserSettingsPointer pConfig);


### PR DESCRIPTION
Move Serato metadata export into a separate function called after the metadata has been successfully read.

This fixes a DEBUG_ASSERT failing when the track file is missing. Fixes #11225