### PR TITLE
Serato color types 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -860,6 +860,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/track/replaygain.cpp
   src/track/serato/beatgrid.cpp
   src/track/serato/beatsimporter.cpp
+  src/track/serato/color.cpp
   src/track/serato/cueinfoimporter.cpp
   src/track/serato/markers.cpp
   src/track/serato/markers2.cpp

--- a/src/test/seratomarkers2test.cpp
+++ b/src/test/seratomarkers2test.cpp
@@ -29,7 +29,9 @@ class SeratoMarkers2Test : public testing::Test {
         EXPECT_EQ(inputValue, bpmlockEntry->dump());
     }
 
-    void parseColorEntry(const QByteArray& inputValue, bool valid, mixxx::RgbColor color) {
+    void parseColorEntry(const QByteArray& inputValue,
+            bool valid,
+            mixxx::SeratoStoredTrackColor color) {
         const mixxx::SeratoMarkers2EntryPointer parsedEntry = mixxx::SeratoMarkers2ColorEntry::parse(inputValue);
         if (!parsedEntry) {
             EXPECT_FALSE(valid);
@@ -48,7 +50,7 @@ class SeratoMarkers2Test : public testing::Test {
             bool valid,
             quint8 index,
             quint32 position,
-            mixxx::RgbColor color,
+            mixxx::SeratoStoredHotcueColor color,
             const QString& label) {
         const mixxx::SeratoMarkers2EntryPointer parsedEntry = mixxx::SeratoMarkers2CueEntry::parse(inputValue);
         if (!parsedEntry) {
@@ -161,28 +163,30 @@ TEST_F(SeratoMarkers2Test, ParseBpmLockEntry) {
 TEST_F(SeratoMarkers2Test, ParseColorEntry) {
     parseColorEntry(QByteArray("\x00\xcc\x00\x00", 4),
             true,
-            mixxx::RgbColor(qRgb(0xcc, 0, 0)));
+            mixxx::SeratoStoredTrackColor(qRgb(0xcc, 0, 0)));
     parseColorEntry(QByteArray("\x00\x00\xcc\x00", 4),
             true,
-            mixxx::RgbColor(qRgb(0, 0xcc, 0)));
+            mixxx::SeratoStoredTrackColor(qRgb(0, 0xcc, 0)));
     parseColorEntry(QByteArray("\x00\x00\x00\xcc", 4),
             true,
-            mixxx::RgbColor(qRgb(0, 0, 0xcc)));
+            mixxx::SeratoStoredTrackColor(qRgb(0, 0, 0xcc)));
     parseColorEntry(QByteArray("\x00\x89\xab\xcd", 4),
             true,
-            mixxx::RgbColor(qRgb(0x89, 0xab, 0xcd)));
+            mixxx::SeratoStoredTrackColor(qRgb(0x89, 0xab, 0xcd)));
 
     // Invalid value
     parseColorEntry(QByteArray("\x01\xff\x00\x00", 1),
             false,
-            mixxx::RgbColor(qRgb(0, 0, 0)));
+            mixxx::SeratoStoredTrackColor(qRgb(0, 0, 0)));
 
     // Invalid size
     parseColorEntry(
-            QByteArray("\x00", 1), false, mixxx::RgbColor(qRgb(0, 0, 0)));
+            QByteArray("\x00", 1),
+            false,
+            mixxx::SeratoStoredTrackColor(qRgb(0, 0, 0)));
     parseColorEntry(QByteArray("\x00\xff\x00\x00\x00", 5),
             false,
-            mixxx::RgbColor(qRgb(0, 0, 0)));
+            mixxx::SeratoStoredTrackColor(qRgb(0, 0, 0)));
 }
 
 TEST_F(SeratoMarkers2Test, ParseCueEntry) {
@@ -192,7 +196,7 @@ TEST_F(SeratoMarkers2Test, ParseCueEntry) {
             true,
             0,
             0,
-            mixxx::RgbColor(qRgb(0, 0, 0)),
+            mixxx::SeratoStoredHotcueColor(qRgb(0, 0, 0)),
             QString(""));
     parseCueEntry(
             QByteArray(
@@ -201,24 +205,25 @@ TEST_F(SeratoMarkers2Test, ParseCueEntry) {
             true,
             1,
             4096,
-            mixxx::RgbColor(qRgb(0xcc, 0, 0)),
+            mixxx::SeratoStoredHotcueColor(qRgb(0xcc, 0, 0)),
             QString("Test"));
     parseCueEntry(
-            QByteArray("\x00\x02\x00\x00\x00\xff\x00\x00\xcc\x00\x00\x00\xc3"
-                       "\xa4\xc3\xbc\xc3\xb6\xc3\x9f\xc3\xa9\xc3\xa8!\x00",
+            QByteArray(
+                    "\x00\x02\x00\x00\x00\xff\x00\x00\xcc\x00\x00\x00\xc3"
+                    "\xa4\xc3\xbc\xc3\xb6\xc3\x9f\xc3\xa9\xc3\xa8!\x00",
                     26),
             true,
             2,
             255,
-            mixxx::RgbColor(qRgb(0, 0xcc, 0)),
+            mixxx::SeratoStoredHotcueColor(qRgb(0, 0xcc, 0)),
             QString("äüößéè!"));
-    parseCueEntry(QByteArray("\x00\x03\x02\x03\x04\x05\x00\x06\x07\x08\x00\x00H"
-                             "ello World\x00",
-                          24),
+    parseCueEntry(
+            QByteArray(
+                    "\x00\x03\x02\x03\x04\x05\x00\x06\x07\x08\x00\x00Hello World\x00", 24),
             true,
             3,
             33752069,
-            mixxx::RgbColor(qRgb(0x06, 0x07, 0x08)),
+            mixxx::SeratoStoredHotcueColor(qRgb(0x06, 0x07, 0x08)),
             QString("Hello World"));
 
     // Invalid value
@@ -229,7 +234,7 @@ TEST_F(SeratoMarkers2Test, ParseCueEntry) {
             false,
             0,
             0,
-            mixxx::RgbColor(qRgb(0, 0, 0)),
+            mixxx::SeratoStoredHotcueColor(qRgb(0, 0, 0)),
             QString());
     parseCueEntry(
             QByteArray(
@@ -238,7 +243,7 @@ TEST_F(SeratoMarkers2Test, ParseCueEntry) {
             false,
             0,
             0,
-            mixxx::RgbColor(qRgb(0, 0, 0)),
+            mixxx::SeratoStoredHotcueColor(qRgb(0, 0, 0)),
             QString());
     parseCueEntry(
             QByteArray(
@@ -247,7 +252,7 @@ TEST_F(SeratoMarkers2Test, ParseCueEntry) {
             false,
             0,
             0,
-            mixxx::RgbColor(qRgb(0, 0, 0)),
+            mixxx::SeratoStoredHotcueColor(qRgb(0, 0, 0)),
             QString());
     parseCueEntry(
             QByteArray(
@@ -256,7 +261,7 @@ TEST_F(SeratoMarkers2Test, ParseCueEntry) {
             false,
             0,
             0,
-            mixxx::RgbColor(qRgb(0, 0, 0)),
+            mixxx::SeratoStoredHotcueColor(qRgb(0, 0, 0)),
             QString());
 
     // Missing null terminator
@@ -266,7 +271,7 @@ TEST_F(SeratoMarkers2Test, ParseCueEntry) {
             false,
             0,
             0,
-            mixxx::RgbColor(qRgb(0, 0, 0)),
+            mixxx::SeratoStoredHotcueColor(qRgb(0, 0, 0)),
             QString());
 
     //Invalid size
@@ -275,7 +280,7 @@ TEST_F(SeratoMarkers2Test, ParseCueEntry) {
             false,
             0,
             0,
-            mixxx::RgbColor(qRgb(0, 0, 0)),
+            mixxx::SeratoStoredHotcueColor(qRgb(0, 0, 0)),
             QString());
     parseCueEntry(
             QByteArray(
@@ -284,42 +289,50 @@ TEST_F(SeratoMarkers2Test, ParseCueEntry) {
             false,
             0,
             0,
-            mixxx::RgbColor(qRgb(0, 0, 0)),
+            mixxx::SeratoStoredHotcueColor(qRgb(0, 0, 0)),
             QString());
 }
 
 TEST_F(SeratoMarkers2Test, ParseLoopEntry) {
-    parseLoopEntry(QByteArray("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff"
-                              "\xff\xff\x00\x27\xaa\xe1\x00\x00\x00",
-                           21),
+    parseLoopEntry(
+            QByteArray(
+                    "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff"
+                    "\xff\xff\x00\x27\xaa\xe1\x00\x00\x00",
+                    21),
             true,
             0,
             0,
             0,
             false,
             QString(""));
-    parseLoopEntry(QByteArray("\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\xff\xff"
-                              "\xff\xff\x00\x27\xaa\xe1\x00\x01Test\x00",
-                           25),
+    parseLoopEntry(
+            QByteArray(
+                    "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\xff\xff"
+                    "\xff\xff\x00\x27\xaa\xe1\x00\x01Test\x00",
+                    25),
             true,
             1,
             33752069,
             101124105,
             true,
             QString("Test"));
-    parseLoopEntry(QByteArray("\x00\x02\x00\x00\x00\xff\x00\x00\x10\x00\xff\xff"
-                              "\xff\xff\x00\x27\xaa\xe1\x00\x00\xc3\xa4\xc3\xbc"
-                              "\xc3\xb6\xc3\x9f\xc3\xa9\xc3\xa8!\x00",
-                           34),
+    parseLoopEntry(
+            QByteArray(
+                    "\x00\x02\x00\x00\x00\xff\x00\x00\x10\x00\xff\xff"
+                    "\xff\xff\x00\x27\xaa\xe1\x00\x00\xc3\xa4\xc3\xbc"
+                    "\xc3\xb6\xc3\x9f\xc3\xa9\xc3\xa8!\x00",
+                    34),
             true,
             2,
             255,
             4096,
             false,
             QString("äüößéè!"));
-    parseLoopEntry(QByteArray("\x00\x03\x00\x00\x00\x00\x00\x00\x01\x00\xff\xff"
-                              "\xff\xff\x00\x27\xaa\xe1\x00\x01Hello World\x00",
-                           32),
+    parseLoopEntry(
+            QByteArray(
+                    "\x00\x03\x00\x00\x00\x00\x00\x00\x01\x00\xff\xff"
+                    "\xff\xff\x00\x27\xaa\xe1\x00\x01Hello World\x00",
+                    32),
             true,
             3,
             0,
@@ -328,36 +341,44 @@ TEST_F(SeratoMarkers2Test, ParseLoopEntry) {
             QString("Hello World"));
 
     // Invalid value
-    parseLoopEntry(QByteArray("\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x0f\xff"
-                              "\xff\xff\x00\x27\xaa\xe1\x00\x00\x00",
-                           21),
+    parseLoopEntry(
+            QByteArray(
+                    "\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x0f\xff"
+                    "\xff\xff\x00\x27\xaa\xe1\x00\x00\x00",
+                    21),
             false,
             0,
             0,
             0,
             false,
             QString());
-    parseLoopEntry(QByteArray("\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff"
-                              "\xff\xff\x01\x27\xaa\xe1\x00\x00\x00\x00",
-                           23),
+    parseLoopEntry(
+            QByteArray(
+                    "\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff"
+                    "\xff\xff\x01\x27\xaa\xe1\x00\x00\x00\x00",
+                    23),
             false,
             0,
             0,
             0,
             false,
             QString());
-    parseLoopEntry(QByteArray("\x01\x05\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff"
-                              "\xff\xff\x00\x27\xaa\xe1\x00\x00\x00\x00",
-                           23),
+    parseLoopEntry(
+            QByteArray(
+                    "\x01\x05\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff"
+                    "\xff\xff\x00\x27\xaa\xe1\x00\x00\x00\x00",
+                    23),
             false,
             0,
             0,
             0,
             false,
             QString());
-    parseLoopEntry(QByteArray("\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff"
-                              "\xff\xff\x00\x27\xaa\xe1\x01\x00\x00\x00",
-                           23),
+    parseLoopEntry(
+            QByteArray(
+                    "\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff"
+                    "\xff\xff\x00\x27\xaa\xe1\x01\x00\x00\x00",
+                    23),
             false,
             0,
             0,
@@ -366,9 +387,11 @@ TEST_F(SeratoMarkers2Test, ParseLoopEntry) {
             QString());
 
     // Missing null terminator
-    parseLoopEntry(QByteArray("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff"
-                              "\xff\xff\x00\x27\xaa\xe1\x00\x00Test",
-                           24),
+    parseLoopEntry(
+            QByteArray(
+                    "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff"
+                    "\xff\xff\x00\x27\xaa\xe1\x00\x00Test",
+                    24),
             false,
             0,
             0,
@@ -376,19 +399,23 @@ TEST_F(SeratoMarkers2Test, ParseLoopEntry) {
             false,
             QString());
 
-    //Invalid size
-    parseLoopEntry(QByteArray("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff"
-                              "\xff\xff\x00\x27\xaa\xe1\x00\x00",
-                           20),
+    // Invalid size
+    parseLoopEntry(
+            QByteArray(
+                    "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff"
+                    "\xff\xff\x00\x27\xaa\xe1\x00\x00",
+                    20),
             false,
             0,
             0,
             0,
             false,
             QString());
-    parseLoopEntry(QByteArray("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff"
-                              "\xff\xff\x00\x27\xaa\xe1\x00\x00\x00\x00",
-                           22),
+    parseLoopEntry(
+            QByteArray(
+                    "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff"
+                    "\xff\xff\x00\x27\xaa\xe1\x00\x00\x00\x00",
+                    22),
             false,
             0,
             0,

--- a/src/test/seratomarkerstest.cpp
+++ b/src/test/seratomarkerstest.cpp
@@ -19,7 +19,7 @@ class SeratoMarkersTest : public testing::Test {
             quint32 startPosition,
             bool hasEndPosition,
             quint32 endPosition,
-            mixxx::RgbColor color,
+            mixxx::SeratoStoredTrackColor color,
             mixxx::SeratoMarkersEntry::TypeId typeId,
             bool isLocked) {
         const mixxx::SeratoMarkersEntryPointer pEntry =
@@ -94,7 +94,7 @@ TEST_F(SeratoMarkersTest, ParseEntry) {
             0x7f7f7f7f,
             false,
             0x7f7f7f7f,
-            mixxx::RgbColor(0x000000),
+            mixxx::SeratoStoredTrackColor(0x000000),
             mixxx::SeratoMarkersEntry::TypeId::Unknown,
             false);
     parseEntry(QByteArray("\x00\x00\x00\x00\x00\x7f\x7f\x7f\x7f\x7f\x00\x7f\x7f"
@@ -105,7 +105,7 @@ TEST_F(SeratoMarkersTest, ParseEntry) {
             0,
             false,
             0x7f7f7f7f,
-            mixxx::RgbColor(0xcc0000),
+            mixxx::SeratoStoredTrackColor(0xcc0000),
             mixxx::SeratoMarkersEntry::TypeId::Cue,
             false);
     parseEntry(QByteArray("\x00\x00\x0d\x2a\x58\x7f\x7f\x7f\x7f\x7f\x00\x7f\x7f"
@@ -116,7 +116,7 @@ TEST_F(SeratoMarkersTest, ParseEntry) {
             218456,
             false,
             0x7f7f7f7f,
-            mixxx::RgbColor(0xcc8800),
+            mixxx::SeratoStoredTrackColor(0xcc8800),
             mixxx::SeratoMarkersEntry::TypeId::Cue,
             false);
     parseEntry(QByteArray("\x00\x00\x03\x54\x64\x7f\x7f\x7f\x7f\x7f\x00\x7f\x7f"
@@ -127,7 +127,7 @@ TEST_F(SeratoMarkersTest, ParseEntry) {
             60004,
             false,
             0x7f7f7f7f,
-            mixxx::RgbColor(0x0000cc),
+            mixxx::SeratoStoredTrackColor(0x0000cc),
             mixxx::SeratoMarkersEntry::TypeId::Cue,
             false);
     parseEntry(QByteArray("\x00\x00\x00\x00\x6c\x7f\x7f\x7f\x7f\x7f\x00\x7f\x7f"
@@ -138,7 +138,7 @@ TEST_F(SeratoMarkersTest, ParseEntry) {
             108,
             false,
             0x7f7f7f7f,
-            mixxx::RgbColor(0xcccc00),
+            mixxx::SeratoStoredTrackColor(0xcccc00),
             mixxx::SeratoMarkersEntry::TypeId::Cue,
             false);
     parseEntry(QByteArray("\x00\x00\x00\x07\x77\x7f\x7f\x7f\x7f\x7f\x00\x7f\x7f"
@@ -149,7 +149,7 @@ TEST_F(SeratoMarkersTest, ParseEntry) {
             1015,
             false,
             0x7f7f7f7f,
-            mixxx::RgbColor(0x00cc00),
+            mixxx::SeratoStoredTrackColor(0x00cc00),
             mixxx::SeratoMarkersEntry::TypeId::Cue,
             false);
     parseEntry(QByteArray("\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x00\x7f\x7f"
@@ -160,7 +160,7 @@ TEST_F(SeratoMarkersTest, ParseEntry) {
             0x7f7f7f7f,
             false,
             0x7f7f7f7f,
-            mixxx::RgbColor(0x000000),
+            mixxx::SeratoStoredTrackColor(0x000000),
             mixxx::SeratoMarkersEntry::TypeId::Cue,
             false);
     parseEntry(QByteArray("\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x00\x7f\x7f"
@@ -171,7 +171,7 @@ TEST_F(SeratoMarkersTest, ParseEntry) {
             0x7f7f7f7f,
             false,
             0x7f7f7f7f,
-            mixxx::RgbColor(0x000000),
+            mixxx::SeratoStoredTrackColor(0x000000),
             mixxx::SeratoMarkersEntry::TypeId::Loop,
             false);
 }

--- a/src/test/seratotagstest.cpp
+++ b/src/test/seratotagstest.cpp
@@ -22,68 +22,69 @@ bool dumpToFile(const QString& filename, const QByteArray& data) {
 class SeratoTagsTest : public testing::Test {
   protected:
     void trackColorRoundtrip(mixxx::RgbColor::optional_t displayedColor) {
-        mixxx::RgbColor storedColor =
-                mixxx::SeratoTags::displayedToStoredTrackColor(displayedColor);
-        mixxx::RgbColor::optional_t actualDisplayedColor = mixxx::SeratoTags::storedToDisplayedTrackColor(storedColor);
+        mixxx::SeratoStoredTrackColor storedColor =
+                mixxx::SeratoStoredTrackColor::fromDisplayedColor(displayedColor);
+        mixxx::RgbColor::optional_t actualDisplayedColor = storedColor.toDisplayedColor();
         EXPECT_EQ(displayedColor, actualDisplayedColor);
     }
     void trackColorRoundtripWithKnownStoredColor(
             mixxx::RgbColor::optional_t displayedColor,
-            mixxx::RgbColor storedColor) {
-        mixxx::RgbColor actualStoredColor =
-                mixxx::SeratoTags::displayedToStoredTrackColor(displayedColor);
+            mixxx::SeratoStoredTrackColor storedColor) {
+        mixxx::SeratoStoredTrackColor actualStoredColor =
+                mixxx::SeratoStoredTrackColor::fromDisplayedColor(displayedColor);
         EXPECT_EQ(actualStoredColor, storedColor);
 
         mixxx::RgbColor::optional_t actualDisplayedColor =
-                mixxx::SeratoTags::storedToDisplayedTrackColor(storedColor);
+                storedColor.toDisplayedColor();
         EXPECT_EQ(displayedColor, actualDisplayedColor);
     }
 };
 
 TEST_F(SeratoTagsTest, TrackColorConversionRoundtripWithKnownStoredColor) {
     trackColorRoundtripWithKnownStoredColor(
-            mixxx::RgbColor::optional(0x993399), mixxx::RgbColor(0xFF99FF));
+            mixxx::RgbColor::optional(0x993399), mixxx::SeratoStoredTrackColor(0xFF99FF));
     trackColorRoundtripWithKnownStoredColor(
-            mixxx::RgbColor::optional(0x993377), mixxx::RgbColor(0xFF99DD));
+            mixxx::RgbColor::optional(0x993377), mixxx::SeratoStoredTrackColor(0xFF99DD));
     trackColorRoundtripWithKnownStoredColor(
-            mixxx::RgbColor::optional(0x993355), mixxx::RgbColor(0xFF99BB));
+            mixxx::RgbColor::optional(0x993355), mixxx::SeratoStoredTrackColor(0xFF99BB));
     trackColorRoundtripWithKnownStoredColor(
-            mixxx::RgbColor::optional(0x993333), mixxx::RgbColor(0xFF9999));
+            mixxx::RgbColor::optional(0x993333), mixxx::SeratoStoredTrackColor(0xFF9999));
     trackColorRoundtripWithKnownStoredColor(
-            mixxx::RgbColor::optional(0x995533), mixxx::RgbColor(0xFFBB99));
+            mixxx::RgbColor::optional(0x995533), mixxx::SeratoStoredTrackColor(0xFFBB99));
     trackColorRoundtripWithKnownStoredColor(
-            mixxx::RgbColor::optional(0x997733), mixxx::RgbColor(0xFFDD99));
+            mixxx::RgbColor::optional(0x997733), mixxx::SeratoStoredTrackColor(0xFFDD99));
     trackColorRoundtripWithKnownStoredColor(
-            mixxx::RgbColor::optional(0x999933), mixxx::RgbColor(0xFFFF99));
+            mixxx::RgbColor::optional(0x999933), mixxx::SeratoStoredTrackColor(0xFFFF99));
     trackColorRoundtripWithKnownStoredColor(
-            mixxx::RgbColor::optional(0x779933), mixxx::RgbColor(0xDDFF99));
+            mixxx::RgbColor::optional(0x779933), mixxx::SeratoStoredTrackColor(0xDDFF99));
     trackColorRoundtripWithKnownStoredColor(
-            mixxx::RgbColor::optional(0x559933), mixxx::RgbColor(0xBBFF99));
+            mixxx::RgbColor::optional(0x559933), mixxx::SeratoStoredTrackColor(0xBBFF99));
     trackColorRoundtripWithKnownStoredColor(
-            mixxx::RgbColor::optional(0x339933), mixxx::RgbColor(0x99FF99));
+            mixxx::RgbColor::optional(0x339933), mixxx::SeratoStoredTrackColor(0x99FF99));
     trackColorRoundtripWithKnownStoredColor(
-            mixxx::RgbColor::optional(0x339955), mixxx::RgbColor(0x99FFBB));
+            mixxx::RgbColor::optional(0x339955), mixxx::SeratoStoredTrackColor(0x99FFBB));
     trackColorRoundtripWithKnownStoredColor(
-            mixxx::RgbColor::optional(0x339977), mixxx::RgbColor(0x99FFDD));
+            mixxx::RgbColor::optional(0x339977), mixxx::SeratoStoredTrackColor(0x99FFDD));
     trackColorRoundtripWithKnownStoredColor(
-            mixxx::RgbColor::optional(0x339999), mixxx::RgbColor(0x99FFFF));
+            mixxx::RgbColor::optional(0x339999), mixxx::SeratoStoredTrackColor(0x99FFFF));
     trackColorRoundtripWithKnownStoredColor(
-            mixxx::RgbColor::optional(0x337799), mixxx::RgbColor(0x99DDFF));
+            mixxx::RgbColor::optional(0x337799), mixxx::SeratoStoredTrackColor(0x99DDFF));
     trackColorRoundtripWithKnownStoredColor(
-            mixxx::RgbColor::optional(0x335599), mixxx::RgbColor(0x99BBFF));
+            mixxx::RgbColor::optional(0x335599), mixxx::SeratoStoredTrackColor(0x99BBFF));
     trackColorRoundtripWithKnownStoredColor(
-            mixxx::RgbColor::optional(0x333399), mixxx::RgbColor(0x9999FF));
+            mixxx::RgbColor::optional(0x333399), mixxx::SeratoStoredTrackColor(0x9999FF));
     trackColorRoundtripWithKnownStoredColor(
-            mixxx::RgbColor::optional(0x553399), mixxx::RgbColor(0xBB99FF));
+            mixxx::RgbColor::optional(0x553399), mixxx::SeratoStoredTrackColor(0xBB99FF));
     trackColorRoundtripWithKnownStoredColor(
-            mixxx::RgbColor::optional(0x773399), mixxx::RgbColor(0xDD99FF));
+            mixxx::RgbColor::optional(0x773399), mixxx::SeratoStoredTrackColor(0xDD99FF));
     trackColorRoundtripWithKnownStoredColor(
-            mixxx::RgbColor::optional(0x333333), mixxx::RgbColor(0x000000));
+            mixxx::RgbColor::optional(0x333333), mixxx::SeratoStoredTrackColor(0x000000));
     trackColorRoundtripWithKnownStoredColor(
-            mixxx::RgbColor::optional(0x555555), mixxx::RgbColor(0xBBBBBB));
+            mixxx::RgbColor::optional(0x555555), mixxx::SeratoStoredTrackColor(0xBBBBBB));
     trackColorRoundtripWithKnownStoredColor(
-            mixxx::RgbColor::optional(0x090909), mixxx::RgbColor(0x999999));
-    trackColorRoundtripWithKnownStoredColor(std::nullopt, mixxx::RgbColor(0xFFFFFF));
+            mixxx::RgbColor::optional(0x090909), mixxx::SeratoStoredTrackColor(0x999999));
+    trackColorRoundtripWithKnownStoredColor(
+            std::nullopt, mixxx::SeratoStoredTrackColor(0xFFFFFF));
 }
 
 TEST_F(SeratoTagsTest, TrackColorConversionRoundtrip) {
@@ -182,18 +183,14 @@ TEST_F(SeratoTagsTest, SetCueInfos) {
 TEST_F(SeratoTagsTest, CueColorConversionRoundtrip) {
     for (const auto color : mixxx::PredefinedColorPalettes::
                     kSeratoTrackMetadataHotcueColorPalette) {
-        const auto displayedColor = mixxx::SeratoTags::storedToDisplayedSeratoDJProCueColor(color);
-        const auto storedColor =
-                mixxx::SeratoTags::displayedToStoredSeratoDJProCueColor(
-                        displayedColor);
-        EXPECT_EQ(color, storedColor);
+        const auto displayedColor = mixxx::SeratoStoredHotcueColor(color).toDisplayedColor();
+        const auto storedColor = mixxx::SeratoStoredHotcueColor::fromDisplayedColor(displayedColor);
+        EXPECT_EQ(color, storedColor.toQRgb());
     }
 
     for (const auto color : mixxx::PredefinedColorPalettes::kSeratoDJProHotcueColorPalette) {
-        const auto storedColor = mixxx::SeratoTags::displayedToStoredSeratoDJProCueColor(color);
-        const auto displayedColor =
-                mixxx::SeratoTags::storedToDisplayedSeratoDJProCueColor(
-                        storedColor);
+        const auto storedColor = mixxx::SeratoStoredHotcueColor::fromDisplayedColor(color);
+        const auto displayedColor = storedColor.toDisplayedColor();
         EXPECT_EQ(color, displayedColor);
     }
 }

--- a/src/track/serato/color.cpp
+++ b/src/track/serato/color.cpp
@@ -1,0 +1,101 @@
+#include "track/serato/color.h"
+
+#include "util/color/predefinedcolorpalettes.h"
+
+namespace {
+
+mixxx::RgbColor getColorFromOtherPalette(
+        const ColorPalette& source,
+        const ColorPalette& dest,
+        mixxx::RgbColor color) {
+    DEBUG_ASSERT(source.size() == dest.size());
+    int sourceIndex = source.indexOf(color);
+    if (sourceIndex >= 0 && sourceIndex < dest.size()) {
+        return dest.at(sourceIndex);
+    }
+    return color;
+}
+
+} // namespace
+
+namespace mixxx {
+
+/// Serato stores Track colors differently from how they are displayed in
+/// the library column. Instead of the color from the library view, the
+/// value from the color picker is stored instead (which is different).
+/// To make sure that the track looks the same in both Mixxx' and Serato's
+/// libraries, we need to convert between the two values.
+///
+/// See this for details:
+/// https://github.com/Holzhaus/serato-tags/blob/master/docs/colors.md#track-colors
+RgbColor::optional_t SeratoStoredTrackColor::toDisplayedColor() const {
+    RgbColor::code_t colorCode = m_color;
+    if (colorCode == SeratoStoredColor::kNoColor) {
+        return RgbColor::nullopt();
+    }
+
+    if (colorCode == 0x999999) {
+        return RgbColor::optional(0x090909);
+    }
+
+    if (colorCode == 0x000000) {
+        return RgbColor::optional(0x333333);
+    }
+    colorCode = (colorCode < 0x666666) ? colorCode + 0x99999A : colorCode - 0x666666;
+    return RgbColor::optional(colorCode);
+}
+
+// static
+SeratoStoredTrackColor SeratoStoredTrackColor::fromDisplayedColor(RgbColor::optional_t color) {
+    if (!color) {
+        return SeratoStoredTrackColor(SeratoStoredColor::kNoColor);
+    }
+
+    RgbColor::code_t colorCode = *color;
+
+    if (colorCode == 0x090909) {
+        return SeratoStoredTrackColor(0x999999);
+    }
+
+    if (colorCode == 0x333333) {
+        return SeratoStoredTrackColor(0x000000);
+    }
+
+    // Special case: 0x999999 and 0x99999a are not representable as Serato
+    // track color We'll just modify them a little, so that the look the
+    // same in Serato.
+    if (colorCode == 0x999999) {
+        return SeratoStoredTrackColor(0x999998);
+    }
+
+    if (colorCode == 0x99999a) {
+        return SeratoStoredTrackColor(0x99999b);
+    }
+
+    colorCode = (colorCode < 0x99999A) ? colorCode + 0x666666 : colorCode - 0x99999A;
+    return SeratoStoredTrackColor(colorCode);
+}
+
+RgbColor::optional_t SeratoStoredHotcueColor::toDisplayedColor() const {
+    if (m_color == SeratoStoredColor::kNoColor) {
+        return RgbColor::nullopt();
+    }
+
+    return RgbColor::optional(getColorFromOtherPalette(
+            PredefinedColorPalettes::kSeratoTrackMetadataHotcueColorPalette,
+            PredefinedColorPalettes::kSeratoDJProHotcueColorPalette,
+            m_color));
+}
+
+// static
+SeratoStoredHotcueColor SeratoStoredHotcueColor::fromDisplayedColor(RgbColor::optional_t color) {
+    if (!color) {
+        return SeratoStoredHotcueColor(SeratoStoredColor::kNoColor);
+    }
+    return SeratoStoredHotcueColor(getColorFromOtherPalette(
+            PredefinedColorPalettes::kSeratoDJProHotcueColorPalette,
+            PredefinedColorPalettes::kSeratoTrackMetadataHotcueColorPalette,
+            *color));
+}
+
+} // namespace mixxx

--- a/src/track/serato/color.h
+++ b/src/track/serato/color.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <QDebug>
+#include <QRgb>
+
+#include "util/color/rgbcolor.h"
+
+namespace mixxx {
+
+class SeratoStoredColor {
+  public:
+    static constexpr RgbColor kNoColor = RgbColor(0xFFFFFF);
+    static constexpr RgbColor kDefaultTrackColor = RgbColor(0xFF9999);
+    static constexpr RgbColor kDefaultCueColor = RgbColor(0xCC0000);
+    static constexpr RgbColor kFixedLoopColor = RgbColor(0x27AAE1);
+    static constexpr RgbColor kFixedUnsetColor = RgbColor(0x000000);
+
+    explicit constexpr SeratoStoredColor(RgbColor::code_t code)
+            : m_color(code) {
+    }
+
+    friend bool operator==(SeratoStoredColor lhs, SeratoStoredColor rhs) {
+        return lhs.m_color == rhs.m_color;
+    }
+
+    friend QDebug operator<<(QDebug dbg, SeratoStoredColor color) {
+        return dbg << color.m_color;
+    }
+
+    QRgb toQRgb() const {
+        return m_color;
+    }
+
+  protected:
+    RgbColor m_color;
+};
+
+class SeratoStoredTrackColor final : public SeratoStoredColor {
+  public:
+    using SeratoStoredColor::SeratoStoredColor;
+
+    RgbColor::optional_t toDisplayedColor() const;
+    static SeratoStoredTrackColor fromDisplayedColor(RgbColor::optional_t color);
+};
+
+class SeratoStoredHotcueColor final : public SeratoStoredColor {
+  public:
+    using SeratoStoredColor::SeratoStoredColor;
+
+    RgbColor::optional_t toDisplayedColor() const;
+    static SeratoStoredHotcueColor fromDisplayedColor(RgbColor::optional_t color);
+};
+
+} // namespace mixxx

--- a/src/track/serato/color.h
+++ b/src/track/serato/color.h
@@ -10,8 +10,6 @@ namespace mixxx {
 class SeratoStoredColor {
   public:
     static constexpr RgbColor kNoColor = RgbColor(0xFFFFFF);
-    static constexpr RgbColor kDefaultTrackColor = RgbColor(0xFF9999);
-    static constexpr RgbColor kDefaultCueColor = RgbColor(0xCC0000);
     static constexpr RgbColor kFixedLoopColor = RgbColor(0x27AAE1);
     static constexpr RgbColor kFixedUnsetColor = RgbColor(0x000000);
 

--- a/src/track/serato/markers.cpp
+++ b/src/track/serato/markers.cpp
@@ -97,7 +97,7 @@ QByteArray SeratoMarkersEntry::dumpID3() const {
                       (m_hasEndPosition ? serato32fromUint24(m_endPosition)
                                         : kNoPosition));
     stream.writeRawData("\x00\x7F\x7F\x7F\x7F\x7F", 6);
-    stream << serato32fromUint24(static_cast<quint32>(m_color))
+    stream << serato32fromUint24(m_color.toQRgb())
            << static_cast<quint8>(m_type) << static_cast<quint8>(m_isLocked);
     return data;
 }
@@ -111,9 +111,9 @@ QByteArray SeratoMarkersEntry::dumpMP4() const {
     stream << static_cast<quint32>(m_startPosition)
            << static_cast<quint32>(m_endPosition);
     stream.writeRawData("\x00\xFF\xFF\xFF\xFF\x00", 6);
-    stream << static_cast<quint8>(qRed(m_color))
-           << static_cast<quint8>(qGreen(m_color))
-           << static_cast<quint8>(qBlue(m_color))
+    stream << static_cast<quint8>(qRed(m_color.toQRgb()))
+           << static_cast<quint8>(qGreen(m_color.toQRgb()))
+           << static_cast<quint8>(qBlue(m_color.toQRgb()))
            << static_cast<quint8>(m_type)
            << static_cast<quint8>(m_isLocked);
     return data;
@@ -159,7 +159,7 @@ SeratoMarkersEntryPointer SeratoMarkersEntry::parseID3(const QByteArray& data) {
         return nullptr;
     }
 
-    const RgbColor color = RgbColor(serato32toUint24(colorSerato32));
+    const auto color = SeratoStoredHotcueColor(serato32toUint24(colorSerato32));
 
     // Parse Start Position
     bool hasStartPosition = (startPositionStatus != 0x7F);
@@ -281,7 +281,7 @@ SeratoMarkersEntryPointer SeratoMarkersEntry::parseMP4(const QByteArray& data) {
         return nullptr;
     }
 
-    const RgbColor color = RgbColor(qRgb(colorRed, colorGreen, colorBlue));
+    const auto color = SeratoStoredHotcueColor(qRgb(colorRed, colorGreen, colorBlue));
 
     // Make sure that the unknown (and probably unused) bytes have the expected value
     if (strncmp(buffer, "\x00\xFF\xFF\xFF\xFF\x00", sizeof(buffer)) != 0) {
@@ -409,7 +409,7 @@ bool SeratoMarkers::parseID3(
 
     quint32 trackColorSerato32;
     stream >> trackColorSerato32;
-    RgbColor trackColor = RgbColor(serato32toUint24(trackColorSerato32));
+    const auto trackColor = SeratoStoredTrackColor(serato32toUint24(trackColorSerato32));
 
     if (stream.status() != QDataStream::Status::Ok) {
         kLogger.warning() << "Parsing SeratoMarkers_ failed:"
@@ -513,7 +513,7 @@ bool SeratoMarkers::parseMP4(
     quint8 colorGreen;
     quint8 colorBlue;
     stream >> field1 >> colorRed >> colorGreen >> colorBlue;
-    RgbColor trackColor = RgbColor(qRgb(colorRed, colorGreen, colorBlue));
+    const auto trackColor = SeratoStoredTrackColor(qRgb(colorRed, colorGreen, colorBlue));
 
     if (field1 != 0x00) {
         // This should never happen with Metadata exported from Serato. We fail
@@ -574,8 +574,11 @@ QByteArray SeratoMarkers::dumpID3() const {
         SeratoMarkersEntryPointer pEntry = m_entries.at(i);
         stream.writeRawData(pEntry->dumpID3(), kEntrySizeID3);
     }
-    stream << serato32fromUint24(static_cast<quint32>(
-            m_trackColor.value_or(SeratoTags::kDefaultTrackColor)));
+    // TODO(): Why we do not use kNoColor? The Roundtrip is probably broken.
+    SeratoStoredTrackColor trackColor = m_pTrackColor.value_or(
+            SeratoStoredTrackColor(SeratoStoredColor::kDefaultTrackColor));
+    stream << serato32fromUint24(trackColor.toQRgb());
+
     return data;
 }
 
@@ -599,11 +602,12 @@ QByteArray SeratoMarkers::dumpMP4() const {
         stream.writeRawData(pEntry->dumpMP4(), kEntrySizeMP4);
     }
 
-    RgbColor trackColor = m_trackColor.value_or(SeratoTags::kDefaultTrackColor);
+    SeratoStoredTrackColor trackColor = m_pTrackColor.value_or(
+            SeratoStoredTrackColor(SeratoStoredColor::kDefaultTrackColor));
     stream << static_cast<quint8>(0x00)
-           << static_cast<quint8>(qRed(trackColor))
-           << static_cast<quint8>(qGreen(trackColor))
-           << static_cast<quint8>(qBlue(trackColor));
+           << static_cast<quint8>(qRed(trackColor.toQRgb()))
+           << static_cast<quint8>(qGreen(trackColor.toQRgb()))
+           << static_cast<quint8>(qBlue(trackColor.toQRgb()));
 
     // A newline char is inserted at every 72 bytes of base64-encoded content.
     // Hence, we can split the data into blocks of 72 bytes * 3/4 = 54 bytes
@@ -647,7 +651,7 @@ QList<CueInfo> SeratoMarkers::getCues() const {
                         std::nullopt,
                         cueIndex,
                         QString(),
-                        pEntry->getColor(),
+                        pEntry->getColor().toDisplayedColor(),
                         CueFlag::None);
                 cueInfos.append(cueInfo);
             }
@@ -731,7 +735,7 @@ void SeratoMarkers::setCues(const QList<CueInfo>& cueInfos) {
                     static_cast<int>(*cueInfo.getStartPositionMillis()),
                     false,
                     0,
-                    *cueInfo.getColor(),
+                    SeratoStoredHotcueColor::fromDisplayedColor(cueInfo.getColor()),
                     static_cast<int>(SeratoMarkersEntry::TypeId::Cue),
                     false);
         } else {
@@ -740,7 +744,7 @@ void SeratoMarkers::setCues(const QList<CueInfo>& cueInfos) {
                     0,
                     false,
                     0,
-                    RgbColor(0),
+                    SeratoStoredHotcueColor(SeratoStoredColor::kFixedUnsetColor),
                     static_cast<int>(SeratoMarkersEntry::TypeId::Unknown),
                     false);
         }
@@ -761,7 +765,7 @@ void SeratoMarkers::setCues(const QList<CueInfo>& cueInfos) {
                     // We *could* export the actual color here if we also
                     // import the blue-ish default color in the code above, but
                     // it will not be used by Serato.
-                    SeratoTags::kFixedLoopColor,
+                    SeratoStoredHotcueColor(SeratoStoredColor::kFixedLoopColor),
                     static_cast<int>(SeratoMarkersEntry::TypeId::Loop),
                     cueInfo.isLocked());
         } else {
@@ -770,7 +774,7 @@ void SeratoMarkers::setCues(const QList<CueInfo>& cueInfos) {
                     0,
                     false,
                     0,
-                    RgbColor(0),
+                    SeratoStoredHotcueColor(SeratoStoredColor::kFixedUnsetColor),
                     // In contrast to cues, unset saved loop have the same type
                     // ID as set ones.
                     static_cast<int>(SeratoMarkersEntry::TypeId::Loop),

--- a/src/track/serato/markers.cpp
+++ b/src/track/serato/markers.cpp
@@ -574,9 +574,10 @@ QByteArray SeratoMarkers::dumpID3() const {
         SeratoMarkersEntryPointer pEntry = m_entries.at(i);
         stream.writeRawData(pEntry->dumpID3(), kEntrySizeID3);
     }
-    // TODO(): Why we do not use kNoColor? The Roundtrip is probably broken.
+
+    DEBUG_ASSERT(m_pTrackColor);
     SeratoStoredTrackColor trackColor = m_pTrackColor.value_or(
-            SeratoStoredTrackColor(SeratoStoredColor::kDefaultTrackColor));
+            SeratoStoredTrackColor(SeratoStoredColor::kNoColor));
     stream << serato32fromUint24(trackColor.toQRgb());
 
     return data;
@@ -602,8 +603,9 @@ QByteArray SeratoMarkers::dumpMP4() const {
         stream.writeRawData(pEntry->dumpMP4(), kEntrySizeMP4);
     }
 
+    DEBUG_ASSERT(m_pTrackColor);
     SeratoStoredTrackColor trackColor = m_pTrackColor.value_or(
-            SeratoStoredTrackColor(SeratoStoredColor::kDefaultTrackColor));
+            SeratoStoredTrackColor(SeratoStoredColor::kNoColor));
     stream << static_cast<quint8>(0x00)
            << static_cast<quint8>(qRed(trackColor.toQRgb()))
            << static_cast<quint8>(qGreen(trackColor.toQRgb()))

--- a/src/track/serato/markers.h
+++ b/src/track/serato/markers.h
@@ -1,12 +1,13 @@
 #pragma once
 
 #include <QByteArray>
-#include <QColor>
 #include <QDataStream>
 #include <QList>
 #include <memory>
+#include <optional>
 
 #include "track/cueinfo.h"
+#include "track/serato/color.h"
 #include "track/taglib/trackmetadata_file.h"
 #include "util/types.h"
 
@@ -33,7 +34,7 @@ class SeratoMarkersEntry {
             int startPosition,
             bool hasEndPosition,
             int endPosition,
-            RgbColor color,
+            SeratoStoredHotcueColor color,
             quint8 type,
             bool isLocked)
             : m_color(color),
@@ -71,7 +72,7 @@ class SeratoMarkersEntry {
         return typeId;
     }
 
-    RgbColor getColor() const {
+    SeratoStoredHotcueColor getColor() const {
         return m_color;
     }
 
@@ -96,7 +97,7 @@ class SeratoMarkersEntry {
     }
 
   private:
-    RgbColor m_color;
+    SeratoStoredHotcueColor m_color;
     bool m_hasStartPosition;
     bool m_hasEndPosition;
     ;
@@ -152,7 +153,7 @@ class SeratoMarkers final {
     QByteArray dump(taglib::FileType fileType) const;
 
     bool isEmpty() const {
-        return m_entries.isEmpty() && !m_trackColor;
+        return m_entries.isEmpty() && !m_pTrackColor;
     }
 
     const QList<SeratoMarkersEntryPointer>& getEntries() const {
@@ -164,14 +165,11 @@ class SeratoMarkers final {
 
     /// Always returns a color if the tag is present (i.e. `isEmpty()` is
     /// false).
-    ///
-    /// Note that the color returned by this function needs to be converted
-    /// into a display color using `SeratoTags::storedToDisplayedTrackColor()`.
-    RgbColor::optional_t getTrackColor() const {
-        return m_trackColor;
+    const std::optional<SeratoStoredTrackColor>& getTrackColor() const {
+        return m_pTrackColor;
     }
-    void setTrackColor(RgbColor::optional_t color) {
-        m_trackColor = color;
+    void setTrackColor(SeratoStoredTrackColor color) {
+        m_pTrackColor = color;
     }
 
     QList<CueInfo> getCues() const;
@@ -189,7 +187,7 @@ class SeratoMarkers final {
     QByteArray dumpMP4() const;
 
     QList<SeratoMarkersEntryPointer> m_entries;
-    RgbColor::optional_t m_trackColor;
+    std::optional<SeratoStoredTrackColor> m_pTrackColor;
 };
 
 inline bool operator==(const SeratoMarkers& lhs, const SeratoMarkers& rhs) {

--- a/src/track/serato/markers2.cpp
+++ b/src/track/serato/markers2.cpp
@@ -111,7 +111,7 @@ SeratoMarkers2EntryPointer SeratoMarkers2ColorEntry::parse(const QByteArray& dat
         return nullptr;
     }
 
-    RgbColor color = RgbColor(qRgb(
+    const auto color = SeratoStoredTrackColor(qRgb(
             static_cast<quint8>(data.at(1)),
             static_cast<quint8>(data.at(2)),
             static_cast<quint8>(data.at(3))));
@@ -128,9 +128,9 @@ QByteArray SeratoMarkers2ColorEntry::dump() const {
     QDataStream stream(&data, QIODevice::WriteOnly);
     stream.setByteOrder(QDataStream::BigEndian);
     stream << static_cast<quint8>('\x00')
-           << static_cast<quint8>(qRed(m_color))
-           << static_cast<quint8>(qGreen(m_color))
-           << static_cast<quint8>(qBlue(m_color));
+           << static_cast<quint8>(qRed(m_color.toQRgb()))
+           << static_cast<quint8>(qGreen(m_color.toQRgb()))
+           << static_cast<quint8>(qBlue(m_color.toQRgb()));
 
     return data;
 }
@@ -180,7 +180,7 @@ SeratoMarkers2EntryPointer SeratoMarkers2CueEntry::parse(const QByteArray& data)
     }
 
     stream >> rawRgbRed >> rawRgbGreen >> rawRgbBlue >> unknownField3;
-    RgbColor color = RgbColor(qRgb(rawRgbRed, rawRgbGreen, rawRgbBlue));
+    const auto color = SeratoStoredHotcueColor(qRgb(rawRgbRed, rawRgbGreen, rawRgbBlue));
 
     // Unknown field(s), make sure it's 0 in case it's a
     // null-terminated string
@@ -220,9 +220,9 @@ QByteArray SeratoMarkers2CueEntry::dump() const {
            << m_index
            << m_position
            << static_cast<quint8>('\x00')
-           << static_cast<quint8>(qRed(m_color))
-           << static_cast<quint8>(qGreen(m_color))
-           << static_cast<quint8>(qBlue(m_color))
+           << static_cast<quint8>(qRed(m_color.toQRgb()))
+           << static_cast<quint8>(qGreen(m_color.toQRgb()))
+           << static_cast<quint8>(qBlue(m_color.toQRgb()))
            << static_cast<quint8>('\x00')
            << static_cast<quint8>('\x00');
 
@@ -288,7 +288,7 @@ SeratoMarkers2EntryPointer SeratoMarkers2LoopEntry::parse(const QByteArray& data
     }
 
     stream >> colorRed >> colorGreen >> colorBlue;
-    RgbColor color(qRgb(colorRed, colorGreen, colorBlue));
+    const auto color = SeratoStoredHotcueColor(qRgb(colorRed, colorGreen, colorBlue));
 
     stream >> unknownField4;
     // Unknown field, make sure it's 0 in case it's a
@@ -334,9 +334,9 @@ QByteArray SeratoMarkers2LoopEntry::dump() const {
 
     stream.writeRawData("\xff\xff\xff\xff\x00", 5);
 
-    stream << static_cast<quint8>(qRed(m_color))
-           << static_cast<quint8>(qGreen(m_color))
-           << static_cast<quint8>(qBlue(m_color))
+    stream << static_cast<quint8>(qRed(m_color.toQRgb()))
+           << static_cast<quint8>(qGreen(m_color.toQRgb()))
+           << static_cast<quint8>(qBlue(m_color.toQRgb()))
            << static_cast<quint8>('\x00')
            << static_cast<quint8>(m_locked);
 
@@ -620,7 +620,7 @@ QList<CueInfo> SeratoMarkers2::getCues() const {
                 std::nullopt,
                 pCueEntry->getIndex(),
                 pCueEntry->getLabel(),
-                pCueEntry->getColor(),
+                pCueEntry->getColor().toDisplayedColor(),
                 CueFlag::None);
         cueInfos.append(cueInfo);
     }
@@ -669,9 +669,6 @@ void SeratoMarkers2::setCues(const QList<CueInfo>& cueInfos) {
         VERIFY_OR_DEBUG_ASSERT(hotcueIndex >= kFirstHotCueIndex) {
             continue;
         }
-        VERIFY_OR_DEBUG_ASSERT(cueInfo.getColor()) {
-            continue;
-        }
         VERIFY_OR_DEBUG_ASSERT(cueInfo.getStartPositionMillis()) {
             continue;
         }
@@ -707,7 +704,7 @@ void SeratoMarkers2::setCues(const QList<CueInfo>& cueInfos) {
         auto pEntry = std::make_shared<SeratoMarkers2CueEntry>(
                 *cueInfo.getHotCueIndex(),
                 *cueInfo.getStartPositionMillis(),
-                *cueInfo.getColor(),
+                SeratoStoredHotcueColor::fromDisplayedColor(cueInfo.getColor()),
                 cueInfo.getLabel());
         newEntries.append(pEntry);
     }
@@ -719,7 +716,7 @@ void SeratoMarkers2::setCues(const QList<CueInfo>& cueInfos) {
                 *cueInfo.getHotCueIndex(),
                 *cueInfo.getStartPositionMillis(),
                 *cueInfo.getEndPositionMillis(),
-                SeratoTags::kFixedLoopColor,
+                SeratoStoredHotcueColor(SeratoStoredColor::kFixedLoopColor),
                 cueInfo.isLocked(),
                 cueInfo.getLabel());
         newEntries.append(pEntry);
@@ -803,7 +800,7 @@ QByteArray SeratoMarkers2::dumpFLAC() const {
     return data;
 }
 
-RgbColor::optional_t SeratoMarkers2::getTrackColor() const {
+std::optional<SeratoStoredTrackColor> SeratoMarkers2::getTrackColor() const {
     kLogger.info() << "Reading track color from 'Serato Markers2' tag data...";
 
     for (const auto& pEntry : qAsConst(m_entries)) {
@@ -816,13 +813,13 @@ RgbColor::optional_t SeratoMarkers2::getTrackColor() const {
         }
 
         const auto pColorEntry = std::static_pointer_cast<SeratoMarkers2ColorEntry>(pEntry);
-        return RgbColor::optional(pColorEntry->getColor());
+        return pColorEntry->getColor();
     }
 
     return std::nullopt;
 }
 
-void SeratoMarkers2::setTrackColor(RgbColor color) {
+void SeratoMarkers2::setTrackColor(SeratoStoredTrackColor color) {
     QList<SeratoMarkers2EntryPointer> newEntries;
 
     // Append COLOR entry

--- a/src/track/serato/markers2.h
+++ b/src/track/serato/markers2.h
@@ -1,12 +1,13 @@
 #pragma once
 
 #include <QByteArray>
-#include <QColor>
 #include <QDataStream>
 #include <QList>
 #include <memory>
+#include <optional>
 
 #include "track/cueinfo.h"
+#include "track/serato/color.h"
 #include "track/taglib/trackmetadata_file.h"
 #include "util/types.h"
 
@@ -130,7 +131,7 @@ inline QDebug operator<<(QDebug dbg, const SeratoMarkers2BpmLockEntry& arg) {
 
 class SeratoMarkers2ColorEntry : public SeratoMarkers2Entry {
   public:
-    SeratoMarkers2ColorEntry(RgbColor color)
+    SeratoMarkers2ColorEntry(SeratoStoredTrackColor color)
             : m_color(color) {
     }
     SeratoMarkers2ColorEntry() = delete;
@@ -147,18 +148,18 @@ class SeratoMarkers2ColorEntry : public SeratoMarkers2Entry {
 
     QByteArray dump() const override;
 
-    RgbColor getColor() const {
+    SeratoStoredTrackColor getColor() const {
         return m_color;
     }
 
-    void setColor(RgbColor color) {
+    void setColor(SeratoStoredTrackColor color) {
         m_color = color;
     }
 
     quint32 length() const override;
 
   private:
-    RgbColor m_color;
+    SeratoStoredTrackColor m_color;
 };
 
 inline bool operator==(const SeratoMarkers2ColorEntry& lhs,
@@ -177,7 +178,10 @@ inline QDebug operator<<(QDebug dbg, const SeratoMarkers2ColorEntry& arg) {
 
 class SeratoMarkers2CueEntry : public SeratoMarkers2Entry {
   public:
-    SeratoMarkers2CueEntry(quint8 index, quint32 position, RgbColor color, const QString& label)
+    SeratoMarkers2CueEntry(quint8 index,
+            quint32 position,
+            SeratoStoredHotcueColor color,
+            const QString& label)
             : m_index(index),
               m_position(position),
               m_color(color),
@@ -213,11 +217,11 @@ class SeratoMarkers2CueEntry : public SeratoMarkers2Entry {
         m_position = position;
     }
 
-    RgbColor getColor() const {
+    SeratoStoredHotcueColor getColor() const {
         return m_color;
     }
 
-    void setColor(RgbColor color) {
+    void setColor(SeratoStoredHotcueColor color) {
         m_color = color;
     }
 
@@ -234,7 +238,7 @@ class SeratoMarkers2CueEntry : public SeratoMarkers2Entry {
   private:
     quint8 m_index;
     quint32 m_position;
-    RgbColor m_color;
+    SeratoStoredHotcueColor m_color;
     QString m_label;
 };
 
@@ -263,7 +267,7 @@ class SeratoMarkers2LoopEntry : public SeratoMarkers2Entry {
     SeratoMarkers2LoopEntry(quint8 index,
             quint32 startposition,
             quint32 endposition,
-            RgbColor color,
+            SeratoStoredHotcueColor color,
             bool locked,
             const QString& label)
             : m_index(index),
@@ -311,11 +315,11 @@ class SeratoMarkers2LoopEntry : public SeratoMarkers2Entry {
         m_endposition = endposition;
     }
 
-    RgbColor getColor() const {
+    SeratoStoredHotcueColor getColor() const {
         return m_color;
     }
 
-    void setColor(RgbColor color) {
+    void setColor(SeratoStoredHotcueColor color) {
         m_color = color;
     }
 
@@ -341,7 +345,7 @@ class SeratoMarkers2LoopEntry : public SeratoMarkers2Entry {
     quint8 m_index;
     quint32 m_startposition;
     quint32 m_endposition;
-    RgbColor m_color;
+    SeratoStoredHotcueColor m_color;
     bool m_locked;
     QString m_label;
 };
@@ -433,11 +437,8 @@ class SeratoMarkers2 final {
     /// Returns a color if the tag is present and contains a `COLOR` entry.
     /// Usually, such an entry should always exist, even if the track has no
     /// color assigned to it in Serato (in that case the color is `0xFFFFFF`).
-    ///
-    /// Note that the color returned by this function needs to be converted
-    /// into a display color using `SeratoTags::storedToDisplayedTrackColor()`.
-    RgbColor::optional_t getTrackColor() const;
-    void setTrackColor(RgbColor color);
+    std::optional<SeratoStoredTrackColor> getTrackColor() const;
+    void setTrackColor(SeratoStoredTrackColor color);
 
     bool isBpmLocked() const;
     void setBpmLocked(bool bpmLocked);

--- a/src/track/serato/tags.cpp
+++ b/src/track/serato/tags.cpp
@@ -341,7 +341,8 @@ std::optional<RgbColor::optional_t> SeratoTags::getTrackColor() const {
         return std::nullopt;
     }
 
-    return pStoredColor->toDisplayedColor();
+    return std::optional<RgbColor::optional_t>(
+            pStoredColor->toDisplayedColor());
 }
 
 void SeratoTags::setTrackColor(RgbColor::optional_t color) {

--- a/src/track/serato/tags.h
+++ b/src/track/serato/tags.h
@@ -21,16 +21,12 @@ class SeratoTags final {
         Failed = 2,
     };
 
-    static constexpr RgbColor kDefaultTrackColor = RgbColor(0xFF9999);
-    static constexpr RgbColor kDefaultCueColor = RgbColor(0xCC0000);
-    static constexpr RgbColor kFixedLoopColor = RgbColor(0x27AAE1);
+    SeratoTags()
+            : m_seratoBeatGridParserStatus(ParserStatus::None),
+              m_seratoMarkersParserStatus(ParserStatus::None),
+              m_seratoMarkers2ParserStatus(ParserStatus::None) {
+    }
 
-    SeratoTags() = default;
-
-    static RgbColor::optional_t storedToDisplayedTrackColor(RgbColor color);
-    static RgbColor displayedToStoredTrackColor(RgbColor::optional_t color);
-    static RgbColor storedToDisplayedSeratoDJProCueColor(RgbColor color);
-    static RgbColor displayedToStoredSeratoDJProCueColor(RgbColor color);
     static double guessTimingOffsetMillis(
             const QString& filePath, const audio::SignalInfo& signalInfo);
 


### PR DESCRIPTION
This PR introduces SeratoStoredTrackColor and SeratoStoredHotcueColor along with the common base class SeratoStoredColor.
With the help of these Types the color conversion should be automatically correct and well documented. 
A positive side effect is that CueInfo now always have the displayed color representation.   