### PR TITLE
engine: Minor refactor to prefer simplified ranged-for-loop

### DIFF
--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -894,8 +894,7 @@ void EngineMaster::addChannel(EngineChannel* pChannel) {
 }
 
 EngineChannel* EngineMaster::getChannel(const QString& group) {
-    for (int i = 0; i < m_channels.size(); ++i) {
-        ChannelInfo* pChannelInfo = m_channels[i];
+    for (const ChannelInfo* pChannelInfo : m_channels) {
         if (pChannelInfo->m_pChannel->getGroup() == group) {
             return pChannelInfo->m_pChannel;
         }
@@ -922,8 +921,7 @@ const CSAMPLE* EngineMaster::getOutputBusBuffer(unsigned int i) const {
 }
 
 const CSAMPLE* EngineMaster::getChannelBuffer(const QString& group) const {
-    for (int i = 0; i < m_channels.size(); ++i) {
-        const ChannelInfo* pChannelInfo = m_channels[i];
+    for (const ChannelInfo* pChannelInfo : m_channels) {
         if (pChannelInfo->m_pChannel->getGroup() == group) {
             return pChannelInfo->m_pBuffer;
         }


### PR DESCRIPTION
A minor refactor to reduce codebase size using standard algorithm functions.
_(Previously this PR used the C++20 ranged version, but removed it because sadly the Apple Clang buildchain does not support it)_ :crying_cat_face: 
