### PR TITLE
Library sidebar: don't allow deleting current history

### DIFF
--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -63,7 +63,7 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     void deleteItem(const QModelIndex& index) override;
 
   protected slots:
-    void slotDeletePlaylist();
+    virtual void slotDeletePlaylist();
     void slotDuplicatePlaylist();
     void slotAddToAutoDJ();
     void slotAddToAutoDJTop();

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -103,6 +103,19 @@ void SetlogFeature::deleteAllUnlockedPlaylistsWithFewerTracks() {
     transaction.commit();
 }
 
+void SetlogFeature::slotDeletePlaylist() {
+    if (!m_lastRightClickedIndex.isValid()) {
+        return;
+    }
+    int playlistId = playlistIdFromIndex(m_lastRightClickedIndex);
+    if (playlistId == m_playlistId) {
+        // the current setlog must not be deleted
+        return;
+    }
+    // regular setlog, call the base implementation
+    BasePlaylistFeature::slotDeletePlaylist();
+}
+
 void SetlogFeature::onRightClick(const QPoint& globalPos) {
     Q_UNUSED(globalPos);
     m_lastRightClickedIndex = QModelIndex();

--- a/src/library/trackset/setlogfeature.h
+++ b/src/library/trackset/setlogfeature.h
@@ -27,6 +27,7 @@ class SetlogFeature : public BasePlaylistFeature {
     void onRightClick(const QPoint& globalPos) override;
     void onRightClickChild(const QPoint& globalPos, const QModelIndex& index) override;
     void slotJoinWithPrevious();
+    void slotDeletePlaylist() override;
     void slotGetNewPlaylist();
     void activate() override;
 


### PR DESCRIPTION
Even though the current's context-menu does not get the Delete action the actual deletion was still possible via hotkey.

fixes a regression introduced by #11172