### PR TITLE
Library, remove/hide tracks dialog: add 'Don't ask again' checkbox

### DIFF
--- a/src/library/trackmodel.h
+++ b/src/library/trackmodel.h
@@ -25,7 +25,8 @@ class TrackModel {
             : m_db(db),
               m_settingsNamespace(settingsNamespace),
               m_iDefaultSortColumn(-1),
-              m_eDefaultSortOrder(Qt::AscendingOrder) {
+              m_eDefaultSortOrder(Qt::AscendingOrder),
+              m_confirmHideRemoveTracks(true) {
     }
     virtual ~TrackModel() {}
 
@@ -219,6 +220,13 @@ class TrackModel {
     /// @param baseOnly return only a identifier for the whole subsystem
     virtual QString modelKey(bool noSearch) const = 0;
 
+    virtual bool getRequireConfirmationToHideRemoveTracks() {
+        return m_confirmHideRemoveTracks;
+    }
+    virtual void setRequireConfirmationToHideRemoveTracks(bool require) {
+        m_confirmHideRemoveTracks = require;
+    }
+
     virtual bool updateTrackGenre(
             Track* pTrack,
             const QString& genre) const = 0;
@@ -234,5 +242,6 @@ class TrackModel {
     QList<int> m_emptyColumns;
     int m_iDefaultSortColumn;
     Qt::SortOrder m_eDefaultSortOrder;
+    bool m_confirmHideRemoveTracks;
 };
 Q_DECLARE_OPERATORS_FOR_FLAGS(TrackModel::Capabilities)


### PR DESCRIPTION
Really helpful during library cleanups:

> Confirm track removal
> 
> Are you sure you want to remove the selected
> tracks from this crate?
>
> - [ ] Don't ask again during this session

Choice is stored per track model.