### PR TITLE
Pioneer DDJ-FLX4: New mapping base on DDJ-400

### DIFF
--- a/res/controllers/Pioneer-DDJ-FLX4-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX4-script.js
@@ -1,0 +1,780 @@
+// Pioneer-DDJ-FLX4-script.js
+// ****************************************************************************
+// * Mixxx mapping script file for the Pioneer DDJ-FLX4.
+// * Mostly adapted from the DDJ-400 mapping script
+// * Authors: Warker, nschloe, dj3730, jusko, Robert904
+// * Reviewers: Be-ing, Holzhaus
+// * Manual: https://manual.mixxx.org/2.3/en/hardware/controllers/
+// ****************************************************************************
+//
+//  Implemented (as per manufacturer's manual):
+//      * Mixer Section (Faders, EQ, Filter, Gain, Cue)
+//      * Browsing and loading + Waveform zoom (shift)
+//      * Jogwheels, Scratching, Bending, Loop adjust
+//      * Cycle Temporange
+//      * Beat Sync
+//      * Hot Cue Mode
+//      * Beat Loop Mode
+//      * Beat Jump Mode
+//      * Sampler Mode
+//
+//  Custom (Mixxx specific mappings):
+//      * BeatFX: Assigned Effect Unit 1
+//                v FX_SELECT focus EFFECT1.
+//                < LEFT focus EFFECT2
+//                > RIGHT focus EFFECT3
+//                ON/OFF toggles focused effect slot
+//                SHIFT + ON/OFF disables all three effect slots.
+//                SHIFT + < loads previous effect
+//                SHIFT + > loads next effect
+//
+//      * 32 beat jump forward & back (Shift + </> CUE/LOOP CALL arrows)
+//      * Toggle quantize (Shift + channel cue)
+//
+//  Not implemented (after discussion and trial attempts):
+//      * Loop Section:
+//        * -4BEAT auto loop (hacky---prefer a clean way to set a 4 beat loop
+//                            from a previous position on long press)
+//
+//        * CUE/LOOP CALL - memory & delete (complex and not useful. Hot cues are sufficient)
+//
+//      * Secondary pad modes (trial attempts complex and too experimental)
+//        * Keyboard mode
+//        * Pad FX1
+//        * Pad FX2
+//        * Keyshift mode
+//
+//  Not implemented yet (but might be in the future):
+//      * Smart CFX
+//      * Smart fader
+
+var PioneerDDJFLX4 = {};
+
+PioneerDDJFLX4.lights = {
+    beatFx: {
+        status: 0x94,
+        data1: 0x47,
+    },
+    shiftBeatFx: {
+        status: 0x94,
+        data1: 0x43,
+    },
+    deck1: {
+        vuMeter: {
+            status: 0xB0,
+            data1: 0x02,
+        },
+        playPause: {
+            status: 0x90,
+            data1: 0x0B,
+        },
+        shiftPlayPause: {
+            status: 0x90,
+            data1: 0x47,
+        },
+        cue: {
+            status: 0x90,
+            data1: 0x0C,
+        },
+        shiftCue: {
+            status: 0x90,
+            data1: 0x48,
+        },
+        hotcueMode: {
+            status: 0x90,
+            data1: 0x1B,
+        },
+        keyboardMode: {
+            status: 0x90,
+            data1: 0x69,
+        },
+        padFX1Mode: {
+            status: 0x90,
+            data1: 0x1E,
+        },
+        padFX2Mode: {
+            status: 0x90,
+            data1: 0x6B,
+        },
+        beatJumpMode: {
+            status: 0x90,
+            data1: 0x20,
+        },
+        beatLoopMode: {
+            status: 0x90,
+            data1: 0x6D,
+        },
+        samplerMode: {
+            status: 0x90,
+            data1: 0x22,
+        },
+        keyShiftMode: {
+            status: 0x90,
+            data1: 0x6F,
+        },
+    },
+    deck2: {
+        vuMeter: {
+            status: 0xB0,
+            data1: 0x02,
+        },
+        playPause: {
+            status: 0x91,
+            data1: 0x0B,
+        },
+        shiftPlayPause: {
+            status: 0x91,
+            data1: 0x47,
+        },
+        cue: {
+            status: 0x91,
+            data1: 0x0C,
+        },
+        shiftCue: {
+            status: 0x91,
+            data1: 0x48,
+        },
+        hotcueMode: {
+            status: 0x91,
+            data1: 0x1B,
+        },
+        keyboardMode: {
+            status: 0x91,
+            data1: 0x69,
+        },
+        padFX1Mode: {
+            status: 0x91,
+            data1: 0x1E,
+        },
+        padFX2Mode: {
+            status: 0x91,
+            data1: 0x6B,
+        },
+        beatJumpMode: {
+            status: 0x91,
+            data1: 0x20,
+        },
+        beatLoopMode: {
+            status: 0x91,
+            data1: 0x6D,
+        },
+        samplerMode: {
+            status: 0x91,
+            data1: 0x22,
+        },
+        keyShiftMode: {
+            status: 0x91,
+            data1: 0x6F,
+        },
+    },
+};
+
+// Store timer IDs
+PioneerDDJFLX4.timers = {};
+
+// Jog wheel constants
+PioneerDDJFLX4.vinylMode = true;
+PioneerDDJFLX4.alpha = 1.0/8;
+PioneerDDJFLX4.beta = PioneerDDJFLX4.alpha/32;
+
+// Multiplier for fast seek through track using SHIFT+JOGWHEEL
+PioneerDDJFLX4.fastSeekScale = 150;
+PioneerDDJFLX4.bendScale = 0.8;
+
+PioneerDDJFLX4.tempoRanges = [0.06, 0.10, 0.16, 0.25];
+
+PioneerDDJFLX4.shiftButtonDown = [false, false];
+
+// Jog wheel loop adjust
+PioneerDDJFLX4.loopAdjustIn = [false, false];
+PioneerDDJFLX4.loopAdjustOut = [false, false];
+PioneerDDJFLX4.loopAdjustMultiply = 50;
+
+// Beatjump pad (beatjump_size values)
+PioneerDDJFLX4.beatjumpSizeForPad = {
+    0x20: -1, // PAD 1
+    0x21: 1,  // PAD 2
+    0x22: -2, // PAD 3
+    0x23: 2,  // PAD 4
+    0x24: -4, // PAD 5
+    0x25: 4,  // PAD 6
+    0x26: -8, // PAD 7
+    0x27: 8   // PAD 8
+};
+
+PioneerDDJFLX4.quickJumpSize = 32;
+
+// Used for tempo slider
+PioneerDDJFLX4.highResMSB = {
+    "[Channel1]": {},
+    "[Channel2]": {}
+};
+
+PioneerDDJFLX4.trackLoadedLED = function(value, group, _control) {
+    midi.sendShortMsg(
+        0x9F,
+        group.match(script.channelRegEx)[1] - 1,
+        value > 0 ? 0x7F : 0x00
+    );
+};
+
+PioneerDDJFLX4.toggleLight = function(midiIn, active) {
+    midi.sendShortMsg(midiIn.status, midiIn.data1, active ? 0x7F : 0);
+};
+
+//
+// Init
+//
+
+PioneerDDJFLX4.init = function() {
+    engine.setValue("[EffectRack1_EffectUnit1]", "show_focus", 1);
+
+    engine.makeConnection("[Channel1]", "VuMeter", PioneerDDJFLX4.vuMeterUpdate);
+    engine.makeConnection("[Channel2]", "VuMeter", PioneerDDJFLX4.vuMeterUpdate);
+
+    PioneerDDJFLX4.toggleLight(PioneerDDJFLX4.lights.deck1.vuMeter, false);
+    PioneerDDJFLX4.toggleLight(PioneerDDJFLX4.lights.deck2.vuMeter, false);
+
+    engine.softTakeover("[Channel1]", "rate", true);
+    engine.softTakeover("[Channel2]", "rate", true);
+    engine.softTakeover("[EffectRack1_EffectUnit1_Effect1]", "meta", true);
+    engine.softTakeover("[EffectRack1_EffectUnit1_Effect2]", "meta", true);
+    engine.softTakeover("[EffectRack1_EffectUnit1_Effect3]", "meta", true);
+    engine.softTakeover("[EffectRack1_EffectUnit1]", "mix", true);
+
+    for (var i = 1; i <= 16; ++i) {
+        engine.makeConnection("[Sampler" + i + "]", "play", PioneerDDJFLX4.samplerPlayOutputCallbackFunction);
+    }
+
+    engine.makeConnection("[Channel1]", "track_loaded", PioneerDDJFLX4.trackLoadedLED);
+    engine.makeConnection("[Channel2]", "track_loaded", PioneerDDJFLX4.trackLoadedLED);
+
+    // play the "track loaded" animation on both decks at startup
+    midi.sendShortMsg(0x9F, 0x00, 0x7F);
+    midi.sendShortMsg(0x9F, 0x01, 0x7F);
+
+    PioneerDDJFLX4.setLoopButtonLights(0x90, 0x7F);
+    PioneerDDJFLX4.setLoopButtonLights(0x91, 0x7F);
+
+    engine.makeConnection("[Channel1]", "loop_enabled", PioneerDDJFLX4.loopToggle);
+    engine.makeConnection("[Channel2]", "loop_enabled", PioneerDDJFLX4.loopToggle);
+
+    for (i = 1; i <= 3; i++) {
+        engine.makeConnection("[EffectRack1_EffectUnit1_Effect" + i +"]", "enabled", PioneerDDJFLX4.toggleFxLight);
+    }
+    engine.makeConnection("[EffectRack1_EffectUnit1]", "focused_effect", PioneerDDJFLX4.toggleFxLight);
+
+    // query the controller for current control positions on startup
+    midi.sendSysexMsg([0xF0, 0x00, 0x40, 0x05, 0x00, 0x00, 0x02, 0x06, 0x00, 0x03, 0x01, 0xf7], 12);
+};
+
+//
+// Channel level lights
+//
+
+PioneerDDJFLX4.vuMeterUpdate = function(value, group) {
+    var newVal = value * 150;
+
+    switch (group) {
+    case "[Channel1]":
+        midi.sendShortMsg(0xB0, 0x02, newVal);
+        break;
+
+    case "[Channel2]":
+        midi.sendShortMsg(0xB1, 0x02, newVal);
+        break;
+    }
+};
+
+//
+// Effects
+//
+
+PioneerDDJFLX4.toggleFxLight = function(_value, _group, _control) {
+    var enabled = engine.getValue(PioneerDDJFLX4.focusedFxGroup(), "enabled");
+
+    PioneerDDJFLX4.toggleLight(PioneerDDJFLX4.lights.beatFx, enabled);
+    PioneerDDJFLX4.toggleLight(PioneerDDJFLX4.lights.shiftBeatFx, enabled);
+};
+
+PioneerDDJFLX4.focusedFxGroup = function() {
+    var focusedFx = engine.getValue("[EffectRack1_EffectUnit1]", "focused_effect");
+    return "[EffectRack1_EffectUnit1_Effect" + focusedFx + "]";
+};
+
+PioneerDDJFLX4.beatFxLevelDepthRotate = function(_channel, _control, value) {
+    if (PioneerDDJFLX4.shiftButtonDown[0] || PioneerDDJFLX4.shiftButtonDown[1]) {
+        engine.softTakeoverIgnoreNextValue("[EffectRack1_EffectUnit1]", "mix");
+        engine.setParameter(PioneerDDJFLX4.focusedFxGroup(), "meta", value / 0x7F);
+    } else {
+        engine.softTakeoverIgnoreNextValue(PioneerDDJFLX4.focusedFxGroup(), "meta");
+        engine.setParameter("[EffectRack1_EffectUnit1]", "mix", value / 0x7F);
+    }
+};
+
+PioneerDDJFLX4.beatFxSelectPreviousEffect = function(_channel, _control, value) {
+    engine.setValue(PioneerDDJFLX4.focusedFxGroup(), "prev_effect", value);
+};
+
+PioneerDDJFLX4.beatFxSelectNextEffect = function(_channel, _control, value) {
+    engine.setValue(PioneerDDJFLX4.focusedFxGroup(), "next_effect", value);
+};
+
+PioneerDDJFLX4.beatFxSelectPressed = function(_channel, _control, value) {
+    if (value === 0) { return; }
+
+    engine.setValue("[EffectRack1_EffectUnit1]", "focused_effect", 1);
+};
+
+PioneerDDJFLX4.beatFxLeftPressed = function(_channel, _control, value) {
+    if (value === 0) { return; }
+
+    engine.setValue("[EffectRack1_EffectUnit1]", "focused_effect", 2);
+};
+
+PioneerDDJFLX4.beatFxRightPressed = function(_channel, _control, value) {
+    if (value === 0) { return; }
+
+    engine.setValue("[EffectRack1_EffectUnit1]", "focused_effect", 3);
+};
+
+PioneerDDJFLX4.beatFxOnOffPressed = function(_channel, _control, value) {
+    if (value === 0) { return; }
+
+    var toggleEnabled = !engine.getValue(PioneerDDJFLX4.focusedFxGroup(), "enabled");
+    engine.setValue(PioneerDDJFLX4.focusedFxGroup(), "enabled", toggleEnabled);
+};
+
+PioneerDDJFLX4.beatFxOnOffShiftPressed = function(_channel, _control, value) {
+    if (value === 0) { return; }
+
+    engine.setParameter("[EffectRack1_EffectUnit1]", "mix", 0);
+    engine.softTakeoverIgnoreNextValue("[EffectRack1_EffectUnit1]", "mix");
+
+    for (var i = 1; i <= 3; i++) {
+        engine.setValue("[EffectRack1_EffectUnit1_Effect" + i + "]", "enabled", 0);
+    }
+    PioneerDDJFLX4.toggleLight(PioneerDDJFLX4.lights.beatFx, false);
+    PioneerDDJFLX4.toggleLight(PioneerDDJFLX4.lights.shiftBeatFx, false);
+};
+
+PioneerDDJFLX4.beatFxChannel1 = function(_channel, control, value, _status, group) {
+    var enableChannel = 0;
+    
+    if ( value === 0x7f )
+        enableChannel = 1;
+    
+    engine.setValue(group, "group_[Channel1]_enable", enableChannel);
+};
+
+PioneerDDJFLX4.beatFxChannel2 = function(_channel, control, value, _status, group) {
+    var enableChannel = 0;
+    
+    if ( value === 0x7f )
+        enableChannel = 1;
+    
+    engine.setValue(group, "group_[Channel2]_enable", enableChannel);
+};
+
+//
+// Loop IN/OUT ADJUST
+//
+
+PioneerDDJFLX4.toggleLoopAdjustIn = function(channel, _control, value, _status, group) {
+    if (value === 0 || engine.getValue(group, "loop_enabled" === 0)) {
+        return;
+    }
+    PioneerDDJFLX4.loopAdjustIn[channel] = !PioneerDDJFLX4.loopAdjustIn[channel];
+    PioneerDDJFLX4.loopAdjustOut[channel] = false;
+};
+
+PioneerDDJFLX4.toggleLoopAdjustOut = function(channel, _control, value, _status, group) {
+    if (value === 0 || engine.getValue(group, "loop_enabled" === 0)) {
+        return;
+    }
+    PioneerDDJFLX4.loopAdjustOut[channel] = !PioneerDDJFLX4.loopAdjustOut[channel];
+    PioneerDDJFLX4.loopAdjustIn[channel] = false;
+};
+
+// Two signals are sent here so that the light stays lit/unlit in its shift state too
+PioneerDDJFLX4.setReloopLight = function(status, value) {
+    midi.sendShortMsg(status, 0x4D, value);
+    midi.sendShortMsg(status, 0x50, value);
+};
+
+
+PioneerDDJFLX4.setLoopButtonLights = function(status, value) {
+    [0x10, 0x11, 0x4E, 0x4C].forEach(function(control) {
+        midi.sendShortMsg(status, control, value);
+    });
+};
+
+PioneerDDJFLX4.startLoopLightsBlink = function(channel, control, status, group) {
+    var blink = 0x7F;
+
+    PioneerDDJFLX4.stopLoopLightsBlink(group, control, status);
+
+    PioneerDDJFLX4.timers[group][control] = engine.beginTimer(500, function() {
+        blink = 0x7F - blink;
+
+        // When adjusting the loop out position, turn the loop in light off
+        if (PioneerDDJFLX4.loopAdjustOut[channel]) {
+            midi.sendShortMsg(status, 0x10, 0x00);
+            midi.sendShortMsg(status, 0x4C, 0x00);
+        } else {
+            midi.sendShortMsg(status, 0x10, blink);
+            midi.sendShortMsg(status, 0x4C, blink);
+        }
+
+        // When adjusting the loop in position, turn the loop out light off
+        if (PioneerDDJFLX4.loopAdjustIn[channel]) {
+            midi.sendShortMsg(status, 0x11, 0x00);
+            midi.sendShortMsg(status, 0x4E, 0x00);
+        } else {
+            midi.sendShortMsg(status, 0x11, blink);
+            midi.sendShortMsg(status, 0x4E, blink);
+        }
+    });
+
+};
+
+PioneerDDJFLX4.stopLoopLightsBlink = function(group, control, status) {
+    PioneerDDJFLX4.timers[group] = PioneerDDJFLX4.timers[group] || {};
+
+    if (PioneerDDJFLX4.timers[group][control] !== undefined) {
+        engine.stopTimer(PioneerDDJFLX4.timers[group][control]);
+    }
+    PioneerDDJFLX4.timers[group][control] = undefined;
+    PioneerDDJFLX4.setLoopButtonLights(status, 0x7F);
+};
+
+PioneerDDJFLX4.loopToggle = function(value, group, control) {
+    var status = group === "[Channel1]" ? 0x90 : 0x91,
+        channel = group === "[Channel1]" ? 0 : 1;
+
+    PioneerDDJFLX4.setReloopLight(status, value ? 0x7F : 0x00);
+
+    if (value) {
+        PioneerDDJFLX4.startLoopLightsBlink(channel, control, status, group);
+    } else {
+        PioneerDDJFLX4.stopLoopLightsBlink(group, control, status);
+        PioneerDDJFLX4.loopAdjustIn[channel] = false;
+        PioneerDDJFLX4.loopAdjustOut[channel] = false;
+    }
+};
+
+//
+// CUE/LOOP CALL
+//
+
+PioneerDDJFLX4.cueLoopCallLeft = function(_channel, _control, value, _status, group) {
+    if (value) {
+        engine.setValue(group, "loop_scale", 0.5);
+    }
+};
+
+PioneerDDJFLX4.cueLoopCallRight = function(_channel, _control, value, _status, group) {
+    if (value) {
+        engine.setValue(group, "loop_scale", 2.0);
+    }
+};
+
+//
+// BEAT SYNC
+//
+// Note that the controller sends different signals for a short press and a long
+// press of the same button.
+//
+
+PioneerDDJFLX4.syncPressed = function(channel, control, value, status, group) {
+    if (engine.getValue(group, "sync_enabled") && value > 0) {
+        engine.setValue(group, "sync_enabled", 0);
+    } else {
+        engine.setValue(group, "beatsync", value);
+    }
+};
+
+PioneerDDJFLX4.syncLongPressed = function(channel, control, value, status, group) {
+    if (value) {
+        engine.setValue(group, "sync_enabled", 1);
+    }
+};
+
+PioneerDDJFLX4.cycleTempoRange = function(_channel, _control, value, _status, group) {
+    if (value === 0) return; // ignore release
+
+    var currRange = engine.getValue(group, "rateRange");
+    var idx = 0;
+
+    for (var i = 0; i < this.tempoRanges.length; i++) {
+        if (currRange === this.tempoRanges[i]) {
+            idx = (i + 1) % this.tempoRanges.length;
+            break;
+        }
+    }
+    engine.setValue(group, "rateRange", this.tempoRanges[idx]);
+};
+
+//
+// Jog wheels
+//
+
+PioneerDDJFLX4.jogTurn = function(channel, _control, value, _status, group) {
+    var deckNum = channel + 1;
+    // wheel center at 64; <64 rew >64 fwd
+    var newVal = value - 64;
+
+    // loop_in / out adjust
+    var loopEnabled = engine.getValue(group, "loop_enabled");
+    if (loopEnabled > 0) {
+        if (PioneerDDJFLX4.loopAdjustIn[channel]) {
+            newVal = newVal * PioneerDDJFLX4.loopAdjustMultiply + engine.getValue(group, "loop_start_position");
+            engine.setValue(group, "loop_start_position", newVal);
+            return;
+        }
+        if (PioneerDDJFLX4.loopAdjustOut[channel]) {
+            newVal = newVal * PioneerDDJFLX4.loopAdjustMultiply + engine.getValue(group, "loop_end_position");
+            engine.setValue(group, "loop_end_position", newVal);
+            return;
+        }
+    }
+
+    if (engine.isScratching(deckNum)) {
+        engine.scratchTick(deckNum, newVal);
+    } else { // fallback
+        engine.setValue(group, "jog", newVal * this.bendScale);
+    }
+};
+
+
+PioneerDDJFLX4.jogSearch = function(_channel, _control, value, _status, group) {
+    var newVal = (value - 64) * PioneerDDJFLX4.fastSeekScale;
+    engine.setValue(group, "jog", newVal);
+};
+
+PioneerDDJFLX4.jogTouch = function(channel, _control, value) {
+    var deckNum = channel + 1;
+
+    // skip while adjusting the loop points
+    if (PioneerDDJFLX4.loopAdjustIn[channel] || PioneerDDJFLX4.loopAdjustOut[channel]) {
+        return;
+    }
+
+    if (value !== 0 && this.vinylMode) {
+        engine.scratchEnable(deckNum, 720, 33+1/3, this.alpha, this.beta);
+    } else {
+        engine.scratchDisable(deckNum);
+    }
+};
+
+//
+// Shift button
+//
+
+PioneerDDJFLX4.shiftPressed = function(channel, _control, value, _status, _group) {
+    PioneerDDJFLX4.shiftButtonDown[channel] = value === 0x7F;
+};
+
+
+//
+// Tempo sliders
+//
+// The tempo option in Mixxx's deck preferences determine whether down/up
+// increases/decreases the rate. Therefore it must be inverted here so that the
+// UI and the control sliders always move in the same direction.
+//
+
+PioneerDDJFLX4.tempoSliderMSB = function(channel, control, value, status, group) {
+    PioneerDDJFLX4.highResMSB[group].tempoSlider = value;
+};
+
+PioneerDDJFLX4.tempoSliderLSB = function(channel, control, value, status, group) {
+    var fullValue = (PioneerDDJFLX4.highResMSB[group].tempoSlider << 7) + value;
+
+    engine.setValue(
+        group,
+        "rate",
+        1 - (fullValue / 0x2000)
+    );
+};
+
+//
+// Beat Jump mode
+//
+// Note that when we increase/decrease the sizes on the pad buttons, we use the
+// value of the first pad (0x21) as an upper/lower limit beyond which we don't
+// allow further increasing/decreasing of all the values.
+//
+
+PioneerDDJFLX4.beatjumpPadPressed = function(_channel, control, value, _status, group) {
+    if (value === 0) {
+        return;
+    }
+    engine.setValue(group, "beatjump_size", Math.abs(PioneerDDJFLX4.beatjumpSizeForPad[control]));
+    engine.setValue(group, "beatjump", PioneerDDJFLX4.beatjumpSizeForPad[control]);
+};
+
+PioneerDDJFLX4.increaseBeatjumpSizes = function(_channel, control, value, _status, group) {
+    if (value === 0 || PioneerDDJFLX4.beatjumpSizeForPad[0x21] * 16 > 16) {
+        return;
+    }
+    Object.keys(PioneerDDJFLX4.beatjumpSizeForPad).forEach(function(pad) {
+        PioneerDDJFLX4.beatjumpSizeForPad[pad] = PioneerDDJFLX4.beatjumpSizeForPad[pad] * 16;
+    });
+    engine.setValue(group, "beatjump_size", PioneerDDJFLX4.beatjumpSizeForPad[0x21]);
+};
+
+PioneerDDJFLX4.decreaseBeatjumpSizes = function(_channel, control, value, _status, group) {
+    if (value === 0 || PioneerDDJFLX4.beatjumpSizeForPad[0x21] / 16 < 1/16) {
+        return;
+    }
+    Object.keys(PioneerDDJFLX4.beatjumpSizeForPad).forEach(function(pad) {
+        PioneerDDJFLX4.beatjumpSizeForPad[pad] = PioneerDDJFLX4.beatjumpSizeForPad[pad] / 16;
+    });
+    engine.setValue(group, "beatjump_size", PioneerDDJFLX4.beatjumpSizeForPad[0x21]);
+};
+
+//
+// Sampler mode
+//
+
+PioneerDDJFLX4.samplerPlayOutputCallbackFunction = function(value, group, _control) {
+    if (value === 1) {
+        var curPad = group.match(script.samplerRegEx)[1];
+        PioneerDDJFLX4.startSamplerBlink(
+            0x97 + (curPad > 8 ? 2 : 0),
+            0x30 + ((curPad > 8 ? curPad - 8 : curPad) - 1),
+            group);
+    }
+};
+
+PioneerDDJFLX4.padModeKeyPressed = function(_channel, _control, value, _status, group) {
+	var deck = ( _status == 0x90 ? PioneerDDJFLX4.lights.deck1 : PioneerDDJFLX4.lights.deck2 );
+	
+	if ( _control == 0x1B )
+		PioneerDDJFLX4.toggleLight(deck.hotcueMode, true);
+	else if ( _control == 0x69 )
+		PioneerDDJFLX4.toggleLight(deck.keyboardMode, true);
+	else if ( _control == 0x1E )
+		PioneerDDJFLX4.toggleLight(deck.padFX1Mode, true);
+	else if ( _control == 0x6B )
+		PioneerDDJFLX4.toggleLight(deck.padFX2Mode, true);
+	else if ( _control == 0x20 )
+		PioneerDDJFLX4.toggleLight(deck.beatJumpMode, true);
+	else if ( _control == 0x6D )
+		PioneerDDJFLX4.toggleLight(deck.beatLoopMode, true);
+	else if ( _control == 0x22 )
+		PioneerDDJFLX4.toggleLight(deck.samplerMode, true);
+	else if ( _control == 0x6F )
+		PioneerDDJFLX4.toggleLight(deck.keyShiftMode, true);
+};
+
+PioneerDDJFLX4.samplerPadPressed = function(_channel, _control, value, _status, group) {
+    if (engine.getValue(group, "track_loaded")) {
+        engine.setValue(group, "cue_gotoandplay", value);
+    } else {
+        engine.setValue(group, "LoadSelectedTrack", value);
+    }
+};
+
+PioneerDDJFLX4.samplerPadShiftPressed = function(_channel, _control, value, _status, group) {
+    if (engine.getValue(group, "play")) {
+        engine.setValue(group, "cue_gotoandstop", value);
+    } else if (engine.getValue(group, "track_loaded")) {
+        engine.setValue(group, "eject", value);
+    }
+};
+
+PioneerDDJFLX4.startSamplerBlink = function(channel, control, group) {
+    var val = 0x7f;
+
+    PioneerDDJFLX4.stopSamplerBlink(channel, control);
+    PioneerDDJFLX4.timers[channel][control] = engine.beginTimer(250, function() {
+        val = 0x7f - val;
+
+        // blink the appropriate pad
+        midi.sendShortMsg(channel, control, val);
+        // also blink the pad while SHIFT is pressed
+        midi.sendShortMsg((channel+1), control, val);
+
+        var isPlaying = engine.getValue(group, "play") === 1;
+
+        if (!isPlaying) {
+            // kill timer
+            PioneerDDJFLX4.stopSamplerBlink(channel, control);
+            // set the pad LED to ON
+            midi.sendShortMsg(channel, control, 0x7f);
+            // set the pad LED to ON while SHIFT is pressed
+            midi.sendShortMsg((channel+1), control, 0x7f);
+        }
+    });
+};
+
+PioneerDDJFLX4.stopSamplerBlink = function(channel, control) {
+    PioneerDDJFLX4.timers[channel] = PioneerDDJFLX4.timers[channel] || {};
+
+    if (PioneerDDJFLX4.timers[channel][control] !== undefined) {
+        engine.stopTimer(PioneerDDJFLX4.timers[channel][control]);
+        PioneerDDJFLX4.timers[channel][control] = undefined;
+    }
+};
+
+//
+// Additional features
+//
+
+PioneerDDJFLX4.toggleQuantize = function(_channel, _control, value, _status, group) {
+    if (value) {
+        script.toggleControl(group, "quantize");
+    }
+};
+
+PioneerDDJFLX4.quickJumpForward = function(_channel, _control, value, _status, group) {
+    if (value) {
+        engine.setValue(group, "beatjump", PioneerDDJFLX4.quickJumpSize);
+    }
+};
+
+PioneerDDJFLX4.quickJumpBack = function(_channel, _control, value, _status, group) {
+    if (value) {
+        engine.setValue(group, "beatjump", -PioneerDDJFLX4.quickJumpSize);
+    }
+};
+
+//
+// Shutdown
+//
+
+PioneerDDJFLX4.shutdown = function() {
+    // reset vumeter
+    PioneerDDJFLX4.toggleLight(PioneerDDJFLX4.lights.deck1.vuMeter, false);
+    PioneerDDJFLX4.toggleLight(PioneerDDJFLX4.lights.deck2.vuMeter, false);
+
+    // housekeeping
+    // turn off all Sampler LEDs
+    for (var i = 0; i <= 7; ++i) {
+        midi.sendShortMsg(0x97, 0x30 + i, 0x00);    // Deck 1 pads
+        midi.sendShortMsg(0x98, 0x30 + i, 0x00);    // Deck 1 pads with SHIFT
+        midi.sendShortMsg(0x99, 0x30 + i, 0x00);    // Deck 2 pads
+        midi.sendShortMsg(0x9A, 0x30 + i, 0x00);    // Deck 2 pads with SHIFT
+    }
+    // turn off all Hotcue LEDs
+    for (i = 0; i <= 7; ++i) {
+        midi.sendShortMsg(0x97, 0x00 + i, 0x00);    // Deck 1 pads
+        midi.sendShortMsg(0x98, 0x00 + i, 0x00);    // Deck 1 pads with SHIFT
+        midi.sendShortMsg(0x99, 0x00 + i, 0x00);    // Deck 2 pads
+        midi.sendShortMsg(0x9A, 0x00 + i, 0x00);    // Deck 2 pads with SHIFT
+    }
+
+    // turn off loop in and out lights
+    PioneerDDJFLX4.setLoopButtonLights(0x90, 0x00);
+    PioneerDDJFLX4.setLoopButtonLights(0x91, 0x00);
+
+    // turn off reloop lights
+    PioneerDDJFLX4.setReloopLight(0x90, 0x00);
+    PioneerDDJFLX4.setReloopLight(0x91, 0x00);
+
+    // stop any flashing lights
+    PioneerDDJFLX4.toggleLight(PioneerDDJFLX4.lights.beatFx, false);
+    PioneerDDJFLX4.toggleLight(PioneerDDJFLX4.lights.shiftBeatFx, false);
+};

--- a/res/controllers/Pioneer-DDJ-FLX4-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX4-script.js
@@ -504,6 +504,8 @@ PioneerDDJFLX4.cycleTempoRange = function(_channel, _control, value, _status, gr
 
     for (var i = 0; i < this.tempoRanges.length; i++) {
         if (currRange === this.tempoRanges[i]) {
+            // idx get the index of the value in tempoRanges following the currently configured one
+            // or cycle back to 0 if the current is the last value of the list.
             idx = (i + 1) % this.tempoRanges.length;
             break;
         }

--- a/res/controllers/Pioneer-DDJ-FLX4-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX4-script.js
@@ -716,9 +716,6 @@ PioneerDDJFLX4.stopSamplerBlink = function(channel, control) {
     }
 };
 
-//
-// Additional features
-//
 
 PioneerDDJFLX4.toggleQuantize = function(_channel, _control, value, _status, group) {
     if (value) {

--- a/res/controllers/Pioneer-DDJ-FLX4-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX4-script.js
@@ -360,19 +360,17 @@ PioneerDDJFLX4.beatFxOnOffShiftPressed = function(_channel, _control, value) {
 
 PioneerDDJFLX4.beatFxChannel1 = function(_channel, control, value, _status, group) {
     var enableChannel = 0;
-    
-    if ( value === 0x7f )
-        enableChannel = 1;
-    
+
+    if (value === 0x7f) { enableChannel = 1; }
+
     engine.setValue(group, "group_[Channel1]_enable", enableChannel);
 };
 
 PioneerDDJFLX4.beatFxChannel2 = function(_channel, control, value, _status, group) {
     var enableChannel = 0;
-    
-    if ( value === 0x7f )
-        enableChannel = 1;
-    
+
+    if (value === 0x7f) { enableChannel = 1; }
+
     engine.setValue(group, "group_[Channel2]_enable", enableChannel);
 };
 
@@ -501,7 +499,7 @@ PioneerDDJFLX4.syncLongPressed = function(channel, control, value, status, group
 };
 
 PioneerDDJFLX4.cycleTempoRange = function(_channel, _control, value, _status, group) {
-    if (value === 0) return; // ignore release
+    if (value === 0) { return; } // ignore release
 
     var currRange = engine.getValue(group, "rateRange");
     var idx = 0;
@@ -649,24 +647,9 @@ PioneerDDJFLX4.samplerPlayOutputCallbackFunction = function(value, group, _contr
 };
 
 PioneerDDJFLX4.padModeKeyPressed = function(_channel, _control, value, _status, group) {
-	var deck = ( _status == 0x90 ? PioneerDDJFLX4.lights.deck1 : PioneerDDJFLX4.lights.deck2 );
-	
-	if ( _control == 0x1B )
-		PioneerDDJFLX4.toggleLight(deck.hotcueMode, true);
-	else if ( _control == 0x69 )
-		PioneerDDJFLX4.toggleLight(deck.keyboardMode, true);
-	else if ( _control == 0x1E )
-		PioneerDDJFLX4.toggleLight(deck.padFX1Mode, true);
-	else if ( _control == 0x6B )
-		PioneerDDJFLX4.toggleLight(deck.padFX2Mode, true);
-	else if ( _control == 0x20 )
-		PioneerDDJFLX4.toggleLight(deck.beatJumpMode, true);
-	else if ( _control == 0x6D )
-		PioneerDDJFLX4.toggleLight(deck.beatLoopMode, true);
-	else if ( _control == 0x22 )
-		PioneerDDJFLX4.toggleLight(deck.samplerMode, true);
-	else if ( _control == 0x6F )
-		PioneerDDJFLX4.toggleLight(deck.keyShiftMode, true);
+    var deck = (_status == 0x90 ? PioneerDDJFLX4.lights.deck1 : PioneerDDJFLX4.lights.deck2);
+
+    if (_control == 0x1B) { PioneerDDJFLX4.toggleLight(deck.hotcueMode, true); } else if (_control == 0x69) { PioneerDDJFLX4.toggleLight(deck.keyboardMode, true); } else if (_control == 0x1E) { PioneerDDJFLX4.toggleLight(deck.padFX1Mode, true); } else if (_control == 0x6B) { PioneerDDJFLX4.toggleLight(deck.padFX2Mode, true); } else if (_control == 0x20) { PioneerDDJFLX4.toggleLight(deck.beatJumpMode, true); } else if (_control == 0x6D) { PioneerDDJFLX4.toggleLight(deck.beatLoopMode, true); } else if (_control == 0x22) { PioneerDDJFLX4.toggleLight(deck.samplerMode, true); } else if (_control == 0x6F) { PioneerDDJFLX4.toggleLight(deck.keyShiftMode, true); }
 };
 
 PioneerDDJFLX4.samplerPadPressed = function(_channel, _control, value, _status, group) {

--- a/res/controllers/Pioneer-DDJ-FLX4-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX4-script.js
@@ -3,7 +3,6 @@
 // * Mixxx mapping script file for the Pioneer DDJ-FLX4.
 // * Mostly adapted from the DDJ-400 mapping script
 // * Authors: Warker, nschloe, dj3730, jusko, Robert904
-// * Reviewers: Be-ing, Holzhaus
 // * Manual: https://manual.mixxx.org/2.3/en/hardware/controllers/
 // ****************************************************************************
 //

--- a/res/controllers/Pioneer-DDJ-FLX4-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX4-script.js
@@ -646,10 +646,26 @@ PioneerDDJFLX4.samplerPlayOutputCallbackFunction = function(value, group, _contr
     }
 };
 
-PioneerDDJFLX4.padModeKeyPressed = function(_channel, _control, value, _status, group) {
-    var deck = (_status == 0x90 ? PioneerDDJFLX4.lights.deck1 : PioneerDDJFLX4.lights.deck2);
+PioneerDDJFLX4.padModeKeyPressed = function(_channel, _control, value, _status, _group) {
+    var deck = (_status === 0x90 ? PioneerDDJFLX4.lights.deck1 : PioneerDDJFLX4.lights.deck2);
 
-    if (_control == 0x1B) { PioneerDDJFLX4.toggleLight(deck.hotcueMode, true); } else if (_control == 0x69) { PioneerDDJFLX4.toggleLight(deck.keyboardMode, true); } else if (_control == 0x1E) { PioneerDDJFLX4.toggleLight(deck.padFX1Mode, true); } else if (_control == 0x6B) { PioneerDDJFLX4.toggleLight(deck.padFX2Mode, true); } else if (_control == 0x20) { PioneerDDJFLX4.toggleLight(deck.beatJumpMode, true); } else if (_control == 0x6D) { PioneerDDJFLX4.toggleLight(deck.beatLoopMode, true); } else if (_control == 0x22) { PioneerDDJFLX4.toggleLight(deck.samplerMode, true); } else if (_control == 0x6F) { PioneerDDJFLX4.toggleLight(deck.keyShiftMode, true); }
+    if (_control === 0x1B) {
+        PioneerDDJFLX4.toggleLight(deck.hotcueMode, true);
+    } else if (_control === 0x69) {
+        PioneerDDJFLX4.toggleLight(deck.keyboardMode, true);
+    } else if (_control === 0x1E) {
+        PioneerDDJFLX4.toggleLight(deck.padFX1Mode, true);
+    } else if (_control === 0x6B) {
+        PioneerDDJFLX4.toggleLight(deck.padFX2Mode, true);
+    } else if (_control === 0x20) {
+        PioneerDDJFLX4.toggleLight(deck.beatJumpMode, true);
+    } else if (_control === 0x6D) {
+        PioneerDDJFLX4.toggleLight(deck.beatLoopMode, true);
+    } else if (_control === 0x22) {
+        PioneerDDJFLX4.toggleLight(deck.samplerMode, true);
+    } else if (_control === 0x6F) {
+        PioneerDDJFLX4.toggleLight(deck.keyShiftMode, true);
+    }
 };
 
 PioneerDDJFLX4.samplerPadPressed = function(_channel, _control, value, _status, group) {

--- a/res/controllers/Pioneer-DDJ-FLX4-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX4-script.js
@@ -270,7 +270,7 @@ PioneerDDJFLX4.init = function() {
 //
 
 PioneerDDJFLX4.vuMeterUpdate = function(value, group) {
-    var newVal = value * 127;
+    const newVal = value * 127;
 
     switch (group) {
     case "[Channel1]":
@@ -288,14 +288,14 @@ PioneerDDJFLX4.vuMeterUpdate = function(value, group) {
 //
 
 PioneerDDJFLX4.toggleFxLight = function(_value, _group, _control) {
-    var enabled = engine.getValue(PioneerDDJFLX4.focusedFxGroup(), "enabled");
+    const enabled = engine.getValue(PioneerDDJFLX4.focusedFxGroup(), "enabled");
 
     PioneerDDJFLX4.toggleLight(PioneerDDJFLX4.lights.beatFx, enabled);
     PioneerDDJFLX4.toggleLight(PioneerDDJFLX4.lights.shiftBeatFx, enabled);
 };
 
 PioneerDDJFLX4.focusedFxGroup = function() {
-    var focusedFx = engine.getValue("[EffectRack1_EffectUnit1]", "focused_effect");
+    const focusedFx = engine.getValue("[EffectRack1_EffectUnit1]", "focused_effect");
     return "[EffectRack1_EffectUnit1_Effect" + focusedFx + "]";
 };
 
@@ -310,13 +310,13 @@ PioneerDDJFLX4.beatFxLevelDepthRotate = function(_channel, _control, value) {
 };
 
 PioneerDDJFLX4.changeFocusedEffectBy = function(numberOfSteps) {
-    var focusedEffect = engine.getValue("[EffectRack1_EffectUnit1]", "focused_effect");
+    let focusedEffect = engine.getValue("[EffectRack1_EffectUnit1]", "focused_effect");
 
     // Convert to zero-based index
     focusedEffect -= 1;
 
     // Standard Euclidean modulo by use of two plain modulos
-    var numberOfEffectsPerEffectUnit = 3;
+    const numberOfEffectsPerEffectUnit = 3;
     focusedEffect = (((focusedEffect + numberOfSteps) % numberOfEffectsPerEffectUnit) + numberOfEffectsPerEffectUnit) % numberOfEffectsPerEffectUnit;
 
     // Convert back to one-based index
@@ -352,7 +352,7 @@ PioneerDDJFLX4.beatFxRightPressed = function(_channel, _control, value) {
 PioneerDDJFLX4.beatFxOnOffPressed = function(_channel, _control, value) {
     if (value === 0) { return; }
 
-    var toggleEnabled = !engine.getValue(PioneerDDJFLX4.focusedFxGroup(), "enabled");
+    const toggleEnabled = !engine.getValue(PioneerDDJFLX4.focusedFxGroup(), "enabled");
     engine.setValue(PioneerDDJFLX4.focusedFxGroup(), "enabled", toggleEnabled);
 };
 
@@ -362,7 +362,7 @@ PioneerDDJFLX4.beatFxOnOffShiftPressed = function(_channel, _control, value) {
     engine.setParameter("[EffectRack1_EffectUnit1]", "mix", 0);
     engine.softTakeoverIgnoreNextValue("[EffectRack1_EffectUnit1]", "mix");
 
-    for (var i = 1; i <= 3; i++) {
+    for (let i = 1; i <= 3; i++) {
         engine.setValue("[EffectRack1_EffectUnit1_Effect" + i + "]", "enabled", 0);
     }
     PioneerDDJFLX4.toggleLight(PioneerDDJFLX4.lights.beatFx, false);
@@ -370,7 +370,7 @@ PioneerDDJFLX4.beatFxOnOffShiftPressed = function(_channel, _control, value) {
 };
 
 PioneerDDJFLX4.beatFxChannel1 = function(_channel, control, value, _status, group) {
-    var enableChannel = 0;
+    let enableChannel = 0;
 
     if (value === 0x7f) { enableChannel = 1; }
 
@@ -378,7 +378,7 @@ PioneerDDJFLX4.beatFxChannel1 = function(_channel, control, value, _status, grou
 };
 
 PioneerDDJFLX4.beatFxChannel2 = function(_channel, control, value, _status, group) {
-    var enableChannel = 0;
+    let enableChannel = 0;
 
     if (value === 0x7f) { enableChannel = 1; }
 
@@ -419,7 +419,7 @@ PioneerDDJFLX4.setLoopButtonLights = function(status, value) {
 };
 
 PioneerDDJFLX4.startLoopLightsBlink = function(channel, control, status, group) {
-    var blink = 0x7F;
+    let blink = 0x7F;
 
     PioneerDDJFLX4.stopLoopLightsBlink(group, control, status);
 
@@ -458,7 +458,7 @@ PioneerDDJFLX4.stopLoopLightsBlink = function(group, control, status) {
 };
 
 PioneerDDJFLX4.loopToggle = function(value, group, control) {
-    var status = group === "[Channel1]" ? 0x90 : 0x91,
+    const status = group === "[Channel1]" ? 0x90 : 0x91,
         channel = group === "[Channel1]" ? 0 : 1;
 
     PioneerDDJFLX4.setReloopLight(status, value ? 0x7F : 0x00);
@@ -512,10 +512,10 @@ PioneerDDJFLX4.syncLongPressed = function(channel, control, value, status, group
 PioneerDDJFLX4.cycleTempoRange = function(_channel, _control, value, _status, group) {
     if (value === 0) { return; } // ignore release
 
-    var currRange = engine.getValue(group, "rateRange");
-    var idx = 0;
+    const currRange = engine.getValue(group, "rateRange");
+    let idx = 0;
 
-    for (var i = 0; i < this.tempoRanges.length; i++) {
+    for (let i = 0; i < this.tempoRanges.length; i++) {
         if (currRange === this.tempoRanges[i]) {
             // idx get the index of the value in tempoRanges following the currently configured one
             // or cycle back to 0 if the current is the last value of the list.
@@ -531,12 +531,12 @@ PioneerDDJFLX4.cycleTempoRange = function(_channel, _control, value, _status, gr
 //
 
 PioneerDDJFLX4.jogTurn = function(channel, _control, value, _status, group) {
-    var deckNum = channel + 1;
+    const deckNum = channel + 1;
     // wheel center at 64; <64 rew >64 fwd
-    var newVal = value - 64;
+    let newVal = value - 64;
 
     // loop_in / out adjust
-    var loopEnabled = engine.getValue(group, "loop_enabled");
+    const loopEnabled = engine.getValue(group, "loop_enabled");
     if (loopEnabled > 0) {
         if (PioneerDDJFLX4.loopAdjustIn[channel]) {
             newVal = newVal * PioneerDDJFLX4.loopAdjustMultiply + engine.getValue(group, "loop_start_position");
@@ -559,12 +559,12 @@ PioneerDDJFLX4.jogTurn = function(channel, _control, value, _status, group) {
 
 
 PioneerDDJFLX4.jogSearch = function(_channel, _control, value, _status, group) {
-    var newVal = (value - 64) * PioneerDDJFLX4.fastSeekScale;
+    const newVal = (value - 64) * PioneerDDJFLX4.fastSeekScale;
     engine.setValue(group, "jog", newVal);
 };
 
 PioneerDDJFLX4.jogTouch = function(channel, _control, value) {
-    var deckNum = channel + 1;
+    const deckNum = channel + 1;
 
     // skip while adjusting the loop points
     if (PioneerDDJFLX4.loopAdjustIn[channel] || PioneerDDJFLX4.loopAdjustOut[channel]) {
@@ -600,7 +600,7 @@ PioneerDDJFLX4.tempoSliderMSB = function(channel, control, value, status, group)
 };
 
 PioneerDDJFLX4.tempoSliderLSB = function(channel, control, value, status, group) {
-    var fullValue = (PioneerDDJFLX4.highResMSB[group].tempoSlider << 7) + value;
+    const fullValue = (PioneerDDJFLX4.highResMSB[group].tempoSlider << 7) + value;
 
     engine.setValue(
         group,
@@ -651,9 +651,9 @@ PioneerDDJFLX4.decreaseBeatjumpSizes = function(_channel, control, value, _statu
 
 PioneerDDJFLX4.samplerPlayOutputCallbackFunction = function(value, group, _control) {
     if (value === 1) {
-        var curPad = group.match(script.samplerRegEx)[1];
-        var deckIndex = 0;
-        var padIndex = 0;
+        const curPad = group.match(script.samplerRegEx)[1];
+        let deckIndex = 0;
+        let padIndex = 0;
 
         if (curPad >=1 && curPad <= 4) {
             deckIndex = 0;
@@ -677,7 +677,7 @@ PioneerDDJFLX4.samplerPlayOutputCallbackFunction = function(value, group, _contr
 };
 
 PioneerDDJFLX4.padModeKeyPressed = function(_channel, _control, value, _status, _group) {
-    var deck = (_status === 0x90 ? PioneerDDJFLX4.lights.deck1 : PioneerDDJFLX4.lights.deck2);
+    const deck = (_status === 0x90 ? PioneerDDJFLX4.lights.deck1 : PioneerDDJFLX4.lights.deck2);
 
     if (_control === 0x1B) {
         PioneerDDJFLX4.toggleLight(deck.hotcueMode, true);
@@ -715,7 +715,7 @@ PioneerDDJFLX4.samplerPadShiftPressed = function(_channel, _control, value, _sta
 };
 
 PioneerDDJFLX4.startSamplerBlink = function(channel, control, group) {
-    var val = 0x7f;
+    let val = 0x7f;
 
     PioneerDDJFLX4.stopSamplerBlink(channel, control);
     PioneerDDJFLX4.timers[channel][control] = engine.beginTimer(250, function() {
@@ -726,7 +726,7 @@ PioneerDDJFLX4.startSamplerBlink = function(channel, control, group) {
         // also blink the pad while SHIFT is pressed
         midi.sendShortMsg((channel+1), control, val);
 
-        var isPlaying = engine.getValue(group, "play") === 1;
+        const isPlaying = engine.getValue(group, "play") === 1;
 
         if (!isPlaying) {
             // kill timer

--- a/res/controllers/Pioneer-DDJ-FLX4-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX4-script.js
@@ -18,13 +18,12 @@
 //
 //  Custom (Mixxx specific mappings):
 //      * BeatFX: Assigned Effect Unit 1
-//                v FX_SELECT focus EFFECT1.
-//                < LEFT focus EFFECT2
-//                > RIGHT focus EFFECT3
+//                v FX_SELECT Load next effect.
+//                SHIFT + v FX_SELECT Load previous effect.
+//                < LEFT Cycle effect focus leftward
+//                > RIGHT Cycle effect focus rightward
 //                ON/OFF toggles focused effect slot
 //                SHIFT + ON/OFF disables all three effect slots.
-//                SHIFT + < loads previous effect
-//                SHIFT + > loads next effect
 //
 //      * 32 beat jump forward & back (Shift + </> CUE/LOOP CALL arrows)
 //      * Toggle quantize (Shift + channel cue)
@@ -310,30 +309,44 @@ PioneerDDJFLX4.beatFxLevelDepthRotate = function(_channel, _control, value) {
     }
 };
 
-PioneerDDJFLX4.beatFxSelectPreviousEffect = function(_channel, _control, value) {
-    engine.setValue(PioneerDDJFLX4.focusedFxGroup(), "prev_effect", value);
-};
+PioneerDDJFLX4.changeFocusedEffectBy = function(numberOfSteps) {
+    var focusedEffect = engine.getValue("[EffectRack1_EffectUnit1]", "focused_effect");
 
-PioneerDDJFLX4.beatFxSelectNextEffect = function(_channel, _control, value) {
-    engine.setValue(PioneerDDJFLX4.focusedFxGroup(), "next_effect", value);
+    // Convert to zero-based index
+    focusedEffect -= 1;
+
+    // Standard Euclidean modulo by use of two plain modulos
+    var numberOfEffectsPerEffectUnit = 3;
+    focusedEffect = (((focusedEffect + numberOfSteps) % numberOfEffectsPerEffectUnit) + numberOfEffectsPerEffectUnit) % numberOfEffectsPerEffectUnit;
+
+    // Convert back to one-based index
+    focusedEffect += 1;
+
+    engine.setValue("[EffectRack1_EffectUnit1]", "focused_effect", focusedEffect);
 };
 
 PioneerDDJFLX4.beatFxSelectPressed = function(_channel, _control, value) {
     if (value === 0) { return; }
 
-    engine.setValue("[EffectRack1_EffectUnit1]", "focused_effect", 1);
+    engine.setValue(PioneerDDJFLX4.focusedFxGroup(), "next_effect", value);
+};
+
+PioneerDDJFLX4.beatFxSelectShiftPressed = function(_channel, _control, value) {
+    if (value === 0) { return; }
+
+    engine.setValue(PioneerDDJFLX4.focusedFxGroup(), "prev_effect", value);
 };
 
 PioneerDDJFLX4.beatFxLeftPressed = function(_channel, _control, value) {
     if (value === 0) { return; }
 
-    engine.setValue("[EffectRack1_EffectUnit1]", "focused_effect", 2);
+    PioneerDDJFLX4.changeFocusedEffectBy(-1);
 };
 
 PioneerDDJFLX4.beatFxRightPressed = function(_channel, _control, value) {
     if (value === 0) { return; }
 
-    engine.setValue("[EffectRack1_EffectUnit1]", "focused_effect", 3);
+    PioneerDDJFLX4.changeFocusedEffectBy(1);
 };
 
 PioneerDDJFLX4.beatFxOnOffPressed = function(_channel, _control, value) {

--- a/res/controllers/Pioneer-DDJ-FLX4-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX4-script.js
@@ -3,7 +3,6 @@
 // * Mixxx mapping script file for the Pioneer DDJ-FLX4.
 // * Mostly adapted from the DDJ-400 mapping script
 // * Authors: Warker, nschloe, dj3730, jusko, Robert904
-// * Manual: https://manual.mixxx.org/2.3/en/hardware/controllers/
 // ****************************************************************************
 //
 //  Implemented (as per manufacturer's manual):

--- a/res/controllers/Pioneer-DDJ-FLX4-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX4-script.js
@@ -271,7 +271,7 @@ PioneerDDJFLX4.init = function() {
 //
 
 PioneerDDJFLX4.vuMeterUpdate = function(value, group) {
-    var newVal = value * 150;
+    var newVal = value * 127;
 
     switch (group) {
     case "[Channel1]":

--- a/res/controllers/Pioneer-DDJ-FLX4-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX4-script.js
@@ -637,9 +637,26 @@ PioneerDDJFLX4.decreaseBeatjumpSizes = function(_channel, control, value, _statu
 PioneerDDJFLX4.samplerPlayOutputCallbackFunction = function(value, group, _control) {
     if (value === 1) {
         var curPad = group.match(script.samplerRegEx)[1];
+        var deckIndex = 0;
+        var padIndex = 0;
+
+        if (curPad >=1 && curPad <= 4) {
+            deckIndex = 0;
+            padIndex = curPad - 1;
+        } else if (curPad >=5 && curPad <= 8) {
+            deckIndex = 2;
+            padIndex = curPad - 5;
+        } else if (curPad >=9 && curPad <= 12) {
+            deckIndex = 0;
+            padIndex = curPad - 5;
+        } else if (curPad >=13 && curPad <= 16) {
+            deckIndex = 2;
+            padIndex = curPad - 9;
+        }
+
         PioneerDDJFLX4.startSamplerBlink(
-            0x97 + (curPad > 8 ? 2 : 0),
-            0x30 + ((curPad > 8 ? curPad - 8 : curPad) - 1),
+            0x97 + deckIndex,
+            0x30 + padIndex,
             group);
     }
 };

--- a/res/controllers/Pioneer-DDJ-FLX4.midi.xml
+++ b/res/controllers/Pioneer-DDJ-FLX4.midi.xml
@@ -2,7 +2,7 @@
 <MixxxMIDIPreset schemaVersion="1" mixxxVersion="2.3">
     <info>
         <name>Pioneer DDJ-FLX4</name>
-        <author>Warker/nschloe/dj3730/jusko/Robert904</author>
+        <author>Robert904</author>
         <description>Midi Mapping for the Pioneer DDJ-FLX4 (based on DDJ-400 mapping)</description>
         <manual>pioneer_ddj_FLX4</manual>
         <forums>https://mixxx.discourse.group/t/pioneer-ddj-flx4</forums>

--- a/res/controllers/Pioneer-DDJ-FLX4.midi.xml
+++ b/res/controllers/Pioneer-DDJ-FLX4.midi.xml
@@ -1,0 +1,3228 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MixxxMIDIPreset schemaVersion="1" mixxxVersion="2.3">
+    <info>
+        <name>Pioneer DDJ-FLX4</name>
+        <author>Warker/nschloe/dj3730/jusko/Robert904</author>
+        <description>Midi Mapping for the Pioneer DDJ-FLX4 (based on DDJ-400 mapping)</description>
+        <manual>pioneer_ddj_FLX4</manual>
+        <forums>https://mixxx.discourse.group/t/pioneer-ddj-flx4</forums>
+    </info>
+    <controller id="DDJ-FLX4">
+        <scriptfiles>
+            <file functionprefix="PioneerDDJFLX4" filename="Pioneer-DDJ-FLX4-script.js"/>
+        </scriptfiles>
+        <controls>
+            <!--
+                BROWSER Section START
+            -->
+            <control>
+                <description>BROWSE - rotate - Scroll tracklist/tree view</description>
+                <group>[Library]</group>
+                <key>MoveVertical</key>
+                <status>0xB6</status>
+                <midino>0x40</midino>
+                <options>
+                    <SelectKnob/>
+                </options>
+            </control>
+            <control>
+                <description>BROWSE - press - Move cursor between track list and tree view</description>
+                <group>[Library]</group>
+                <key>MoveFocusForward</key> <!-- missing function to open Folder -->
+                <status>0x96</status>
+                <midino>0x41</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+              <description>BROWSE +SHIFT - press - Move cursor between track list and tree view</description>
+                <group>[Library]</group>
+                <key>MoveFocusBackward</key> <!-- missing function to close Folder -->
+                <status>0x96</status>
+                <midino>0x42</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+
+            <control>
+                <description>LOAD (DECK1) - press - Load a Track into Deck 1</description>
+                <group>[Channel1]</group>
+                <key>LoadSelectedTrack</key>
+                <status>0x96</status>
+                <midino>0x46</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+
+            <control>
+                <description>LOAD (DECK2) - press - Load a Track into Deck 2</description>
+                <group>[Channel2]</group>
+                <key>LoadSelectedTrack</key>
+                <status>0x96</status>
+                <midino>0x47</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <!-- BROWSER Section END -->
+
+            <!--
+            DECK Section START
+            -->
+            <control>
+                <description>Shift (DECK1)</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.shiftPressed</key>
+                <status>0x90</status>
+                <midino>0x3F</midino>
+                <options>
+                  <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>Shift (DECK2)</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.shiftPressed</key>
+                <status>0x91</status>
+                <midino>0x3F</midino>
+                <options>
+                  <Script-Binding/>
+                </options>
+            </control>
+
+            <control>
+                <description>PLAY/PAUSE (DECK1) - press - Play/Pause</description>
+                <group>[Channel1]</group>
+                <key>play</key>
+                <status>0x90</status>
+                <midino>0x0B</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>PLAY/PAUSE +SHIFT (DECK1) - press - Reverse playback in Slip Mode while held (Censor)</description>
+                <group>[Channel1]</group>
+                <key>reverseroll</key>
+                <status>0x90</status>
+                <midino>0x47</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>PLAY/PAUSE (DECK2) - press - Play/Pause</description>
+                <group>[Channel2]</group>
+                <key>play</key>
+                <status>0x91</status>
+                <midino>0x0B</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>PLAY/PAUSE +SHIFT (DECK2) - press - Reverse playback in Slip Mode while held (Censor)</description>
+                <group>[Channel2]</group>
+                <key>reverseroll</key>
+                <status>0x91</status>
+                <midino>0x47</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+
+            <control>
+                <description>CUE (DECK1) - press - Set/Call Cue, Back Cue</description>
+                <group>[Channel1]</group>
+                <key>cue_default</key>
+                <status>0x90</status>
+                <midino>0x0C</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>CUE +SHIFT (DECK1) - press - Jump to track start</description>
+                <group>[Channel1]</group>
+                <key>start_play</key>
+                <status>0x90</status>
+                <midino>0x48</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>CUE (DECK2) - press - Set/Call Cue, Back Cue</description>
+                <group>[Channel2]</group>
+                <key>cue_default</key>
+                <status>0x91</status>
+                <midino>0x0C</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>CUE +SHIFT (DECK2) - press - Jump to track start</description>
+                <group>[Channel2]</group>
+                <key>start_play</key>
+                <status>0x91</status>
+                <midino>0x48</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+
+            <control>
+                <description>JOG DIAL PLATTER Vinyl mode On (DECK1) - rotate - Scratch</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.jogTurn</key>
+                <status>0xB0</status>
+                <midino>0x22</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>JOG DIAL PLATTER Vinyl mode Off (DECK1) - rotate - Pitch bend</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.jogTurn</key>
+                <status>0xB0</status>
+                <midino>0x23</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>JOG DIAL PLATTER +SHIFT (DECK1) - rotate - Search (Fast Pitch bend)</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.jogSearch</key>
+                <status>0xB0</status>
+                <midino>0x29</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>JOG DIAL PLATTER (DECK1) - touch - enable (on touch) / disable (on release) Scratching/Pitch
+                    bend
+                </description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.jogTouch</key>
+                <status>0x90</status>
+                <midino>0x36</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>JOG DIAL PLATTER +SHIFT (DECK1) - touch - enable (on touch) / disable (on release) highspeed
+                    Pitch bend
+                </description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.jogTouch</key>
+                <status>0x90</status>
+                <midino>0x67</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>JOG DIAL SIDE (DECK1) - rotate - Pitch bend</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.jogTurn</key>
+                <status>0xB0</status>
+                <midino>0x21</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+
+            <control>
+                <description>JOG DIAL PLATTER Vinyl mode On (DECK2) - rotate - Scratch</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.jogTurn</key>
+                <status>0xB1</status>
+                <midino>0x22</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>JOG DIAL PLATTER Vinyl mode Off (DECK2) - rotate - Pitch bend</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.jogTurn</key>
+                <status>0xB1</status>
+                <midino>0x23</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>JOG DIAL PLATTER +SHIFT (DECK2) - rotate - Search (Fast Pitch bend)</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.jogSearch</key>
+                <status>0xB1</status>
+                <midino>0x29</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>JOG DIAL PLATTER (DECK2) - touch - enable (on touch) / disable (on release) Scratching/Pitch
+                    bend
+                </description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.jogTouch</key>
+                <status>0x91</status>
+                <midino>0x36</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>JOG DIAL PLATTER +SHIFT (DECK2) - touch - enable (on touch) / disable (on release) highspeed
+                    Pitch bend
+                </description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.jogTouch</key>
+                <status>0x91</status>
+                <midino>0x67</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>JOG DIAL SIDE (DECK2) - rotate - Pitch bend</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.jogTurn</key>
+                <status>0xB1</status>
+                <midino>0x21</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+
+            <control>
+                <description>TEMPO (DECK1) - fader - Tempo control LSB</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.tempoSliderLSB</key>
+                <status>0xB0</status>
+                <midino>0x20</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <description>TEMPO (DECK1) - fader - Tempo control MSB</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.tempoSliderMSB</key>
+                <status>0xB0</status>
+                <midino>0x00</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <description>TEMPO (DECK2) - fader - Tempo control LSB</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.tempoSliderLSB</key>
+                <status>0xB1</status>
+                <midino>0x20</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <description>TEMPO (DECK2) - fader - Tempo control MSB</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.tempoSliderMSB</key>
+                <status>0xB1</status>
+                <midino>0x00</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+
+            <control>
+                <description>BEAT SYNC (DECK1) - press - Beat Sync to Master deck</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.syncPressed</key>
+                <status>0x90</status>
+                <midino>0x58</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>BEAT SYNC LONG PRESS (DECK1) - press - Set as Master deck</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.syncLongPressed</key>
+                <status>0x90</status>
+                <midino>0x5C</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>BEAT SYNC +SHIFT (DECK1) - press - change Tempo range</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.cycleTempoRange</key>
+                <status>0x90</status>
+                <midino>0x60</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+
+            <control>
+                <description>BEAT SYNC (DECK2) - press - Beat Sync to Master deck</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.syncPressed</key>
+                <status>0x91</status>
+                <midino>0x58</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>BEAT SYNC LONG PRESS (DECK2) - press - Set as Master deck</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.syncLongPressed</key>
+                <status>0x91</status>
+                <midino>0x5C</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>BEAT SYNC +SHIFT (DECK2) - press - change Tempo range</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.cycleTempoRange</key>
+                <status>0x91</status>
+                <midino>0x60</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+
+            <control>
+                <description>LOOP IN/4 BEAT (DECK1) - press - Set loop in</description>
+                <group>[Channel1]</group>
+                <key>loop_in</key>
+                <status>0x90</status>
+                <midino>0x10</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+
+            <control>
+                <description>LOOP IN/4 BEAT (DECK2) - press - Set loop in</description>
+                <group>[Channel2]</group>
+                <key>loop_in</key>
+                <status>0x91</status>
+                <midino>0x10</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+
+            <control>
+                <description>LOOP OUT (DECK1) - press - Set loop out</description>
+                <group>[Channel1]</group>
+                <key>loop_out</key>
+                <status>0x90</status>
+                <midino>0x11</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>LOOP OUT (DECK2) - press - Set loop out</description>
+                <group>[Channel2]</group>
+                <key>loop_out</key>
+                <status>0x91</status>
+                <midino>0x11</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+
+            <control>
+                <description>RELOOP/EXIT (DECK1) - press - (loop off) Reloop, (loop on) Loop exit</description>
+                <group>[Channel1]</group>
+                <key>reloop_toggle</key>
+                <status>0x90</status>
+                <midino>0x4D</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>RELOOP/EXIT (DECK2) - press - (loop off) Reloop, (loop on) Loop exit</description>
+                <group>[Channel2]</group>
+                <key>reloop_toggle</key> <!-- check if correct -->
+                <status>0x91</status>
+                <midino>0x4D</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+
+            <control>
+                <description>RELOOP/EXIT +SHIFT (DECK1) - press - Reloop and stop</description>
+                <group>[Channel1]</group>
+                <key>reloop_andstop</key>
+                <status>0x90</status>
+                <midino>0x50</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>RELOOP/EXIT +SHIFT (DECK2) - press - Reloop and stop</description>
+                <group>[Channel2]</group>
+                <key>reloop_andstop</key>
+                <status>0x91</status>
+                <midino>0x50</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+
+            <control>
+                <description>SHIFT + LOOP IN (DECK1) - Loop in adjust (using jog wheel)</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.toggleLoopAdjustIn</key>
+                <status>0x90</status>
+                <midino>0x4C</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>SHIFT + LOOP IN (DECK2) - Loop in adjust (using jog wheel)</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.toggleLoopAdjustIn</key>
+                <status>0x91</status>
+                <midino>0x4C</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+
+            <control>
+                <description>SHIFT + LOOP OUT (DECK1) - Loop out adjust (using jog wheel)</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.toggleLoopAdjustOut</key>
+                <status>0x90</status>
+                <midino>0x4E</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>SHIFT + LOOP OUT (DECK2) - Loop out adjust (using jog wheel)</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.toggleLoopAdjustOut</key>
+                <status>0x91</status>
+                <midino>0x4E</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+
+            <control>
+                <description>CUE/LOOP CALL LEFT (DECK1) - press - half active loop</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.cueLoopCallLeft</key>
+                <status>0x90</status>
+                <midino>0x51</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>CUE/LOOP CALL LEFT + SHIFT (DECK1) - press - quick jump back</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.quickJumpBack</key>
+                <status>0x90</status>
+                <midino>0x3E</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+
+            <control>
+                <description>CUE/LOOP CALL LEFT (DECK2) - press - half active loop</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.cueLoopCallLeft</key>
+                <status>0x91</status>
+                <midino>0x51</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>CUE/LOOP CALL LEFT + SHIFT (DECK2) - press - quick jump back</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.quickJumpBack</key>
+                <status>0x91</status>
+                <midino>0x3E</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+
+            <control>
+                <description>CUE/LOOP CALL LEFT (DECK1) - press - double active loop</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.cueLoopCallRight</key>
+                <status>0x90</status>
+                <midino>0x53</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK1) - press - quick jump forwards</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.quickJumpForward</key>
+                <status>0x90</status>
+                <midino>0x3D</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+
+            <control>
+                <description>CUE/LOOP CALL LEFT (DECK2) - press - double active loop</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.cueLoopCallRight</key>
+                <status>0x91</status>
+                <midino>0x53</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK2) - press - quick jump forwards</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.quickJumpForward</key>
+                <status>0x91</status>
+                <midino>0x3D</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <!-- DECK Section END -->
+
+            <!-- MIXER Section START -->
+            <control>
+                <description>CROSSFADER - slider</description>
+                <group>[Master]</group>
+                <key>crossfader</key>
+                <status>0xB6</status>
+                <midino>0x1F</midino>
+                <options>
+                    <fourteen-bit-msb/>
+                </options>
+            </control>
+            <control>
+                <description>CROSSFADER - slider</description>
+                <group>[Master]</group>
+                <key>crossfader</key>
+                <status>0xB6</status>
+                <midino>0x3F</midino>
+                <options>
+                    <fourteen-bit-lsb/>
+                </options>
+            </control>
+
+            <control>
+                <description>CHANNELFADER - slider</description>
+                <group>[Channel1]</group>
+                <key>volume</key>
+                <status>0xB0</status>
+                <midino>0x33</midino>
+                <options>
+                    <fourteen-bit-lsb/>
+                </options>
+            </control>
+            <control>
+                <description>CHANNELFADER - slider</description>
+                <group>[Channel1]</group>
+                <key>volume</key>
+                <status>0xB0</status>
+                <midino>0x13</midino>
+                <options>
+                    <fourteen-bit-msb/>
+                </options>
+            </control>
+            <control>
+                <description>CHANNELFADER - slider</description>
+                <group>[Channel2]</group>
+                <key>volume</key>
+                <status>0xB1</status>
+                <midino>0x33</midino>
+                <options>
+                    <fourteen-bit-lsb/>
+                </options>
+            </control>
+            <control>
+                <description>CHANNELFADER - slider</description>
+                <group>[Channel2]</group>
+                <key>volume</key>
+                <status>0xB1</status>
+                <midino>0x13</midino>
+                <options>
+                    <fourteen-bit-msb/>
+                </options>
+            </control>
+
+            <control>
+                <description>Shift + Left CUE - Toggle quantize on/off (Deck1)</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.toggleQuantize</key>
+                <status>0x90</status>
+                <midino>0x68</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>Shift + Right CUE - Toggle quantize on/off (Deck2)</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.toggleQuantize</key>
+                <status>0x91</status>
+                <midino>0x68</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+
+            <control>
+                <description>TRIM - rotate</description>
+                <group>[Channel1]</group>
+                <key>pregain</key>
+                <status>0xB0</status>
+                <midino>0x24</midino>
+                <options>
+                    <fourteen-bit-lsb/>
+                </options>
+            </control>
+            <control>
+                <description>TRIM - rotate</description>
+                <group>[Channel1]</group>
+                <key>pregain</key>
+                <status>0xB0</status>
+                <midino>0x04</midino>
+                <options>
+                    <fourteen-bit-msb/>
+                </options>
+            </control>
+            <control>
+                <description>TRIM - rotate</description>
+                <group>[Channel2]</group>
+                <key>pregain</key>
+                <status>0xB1</status>
+                <midino>0x24</midino>
+                <options>
+                    <fourteen-bit-lsb/>
+                </options>
+            </control>
+            <control>
+                <description>TRIM - rotate</description>
+                <group>[Channel2]</group>
+                <key>pregain</key>
+                <status>0xB1</status>
+                <midino>0x04</midino>
+                <options>
+                    <fourteen-bit-msb/>
+                </options>
+            </control>
+
+
+            <control>
+                <description>EQ HI - rotate</description>
+                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+                <key>parameter3</key>
+                <status>0xB0</status>
+                <midino>0x27</midino>
+                <options>
+                    <fourteen-bit-lsb/>
+                </options>
+            </control>
+            <control>
+                <description>EQ MID - rotate</description>
+                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+                <key>parameter2</key>
+                <status>0xB0</status>
+                <midino>0x2B</midino>
+                <options>
+                    <fourteen-bit-lsb/>
+                </options>
+            </control>
+            <control>
+                <description>EQ LOW - rotate</description>
+                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+                <key>parameter1</key>
+                <status>0xB0</status>
+                <midino>0x2F</midino>
+                <options>
+                    <fourteen-bit-lsb/>
+                </options>
+            </control>
+            <control>
+                <description>EQ HI - rotate</description>
+                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+                <key>parameter3</key>
+                <status>0xB0</status>
+                <midino>0x07</midino>
+                <options>
+                    <fourteen-bit-msb/>
+                </options>
+            </control>
+            <control>
+                <description>EQ MID - rotate</description>
+                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+                <key>parameter2</key>
+                <status>0xB0</status>
+                <midino>0x0B</midino>
+                <options>
+                    <fourteen-bit-msb/>
+                </options>
+            </control>
+            <control>
+                <description>EQ LOW - rotate</description>
+                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+                <key>parameter1</key>
+                <status>0xB0</status>
+                <midino>0x0F</midino>
+                <options>
+                    <fourteen-bit-msb/>
+                </options>
+            </control>
+
+            <control>
+                <description>EQ HI - rotate</description>
+                <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+                <key>parameter3</key>
+                <status>0xB1</status>
+                <midino>0x27</midino>
+                <options>
+                    <fourteen-bit-lsb/>
+                </options>
+            </control>
+            <control>
+                <description>EQ MID - rotate</description>
+                <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+                <key>parameter2</key>
+                <status>0xB1</status>
+                <midino>0x2B</midino>
+                <options>
+                    <fourteen-bit-lsb/>
+                </options>
+            </control>
+            <control>
+                <description>EQ LOW - rotate</description>
+                <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+                <key>parameter1</key>
+                <status>0xB1</status>
+                <midino>0x2F</midino>
+                <options>
+                    <fourteen-bit-lsb/>
+                </options>
+            </control>
+            <control>
+                <description>EQ HI - rotate</description>
+                <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+                <key>parameter3</key>
+                <status>0xB1</status>
+                <midino>0x07</midino>
+                <options>
+                    <fourteen-bit-msb/>
+                </options>
+            </control>
+            <control>
+                <description>EQ MID - rotate</description>
+                <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+                <key>parameter2</key>
+                <status>0xB1</status>
+                <midino>0x0B</midino>
+                <options>
+                    <fourteen-bit-msb/>
+                </options>
+            </control>
+            <control>
+                <description>EQ LOW - rotate</description>
+                <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+                <key>parameter1</key>
+                <status>0xB1</status>
+                <midino>0x0F</midino>
+                <options>
+                    <fourteen-bit-msb/>
+                </options>
+            </control>
+
+            <control>
+                <description>CUE Channel - press - toggle Headphone Cue</description>
+                <group>[Channel1]</group>
+                <key>pfl</key>
+                <status>0x90</status>
+                <midino>0x54</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>CUE Channel - press - toggle Headphone Cue</description>
+                <group>[Channel2]</group>
+                <key>pfl</key>
+                <status>0x91</status>
+                <midino>0x54</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+
+            <control>
+                <description>CUE Channel +SHIFT - press - Adjust BPM to match tapped BPM</description>
+                <group>[Channel1]</group>
+                <key>bpm_tap</key>
+                <status>0x90</status>
+                <midino>0x68</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>CUE Channel +SHIFT - press - Adjust BPM to match tapped BPM</description>
+                <group>[Channel2]</group>
+                <key>bpm_tap</key>
+                <status>0x91</status>
+                <midino>0x68</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+
+            <control>
+                <description>HEADPHONES MIXING - rotate - Monitor Balance</description>
+                <group>[Master]</group>
+                <key>headMix</key>
+                <status>0xB6</status>
+                <midino>0x2C</midino>
+                <options>
+                    <fourteen-bit-lsb/>
+                </options>
+            </control>
+            <control>
+                <description>HEADPHONES MIXING - rotate - Monitor Balance</description>
+                <group>[Master]</group>
+                <key>headMix</key>
+                <status>0xB6</status>
+                <midino>0x0C</midino>
+                <options>
+                    <fourteen-bit-msb/>
+                </options>
+            </control>
+
+            <control>
+                <description>HEADPHONES LEVEL - rotate - Headphone gain</description>
+                <group>[Master]</group>
+                <key>headGain</key>
+                <status>0xB6</status>
+                <midino>0x2D</midino>
+                <options>
+                    <fourteen-bit-lsb/>
+                </options>
+            </control>
+            <control>
+                <description>HEADPHONES LEVEL - rotate - Headphone gain</description>
+                <group>[Master]</group>
+                <key>headGain</key>
+                <status>0xB6</status>
+                <midino>0x0D</midino>
+                <options>
+                    <fourteen-bit-msb/>
+                </options>
+            </control>
+            <!-- MIXER Section END -->
+
+            <!-- EFFECT Section START -->
+            <control>
+                <description>FILTER CH1 - rotate - Filter Effect Knob</description>
+                <group>[QuickEffectRack1_[Channel1]]</group>
+                <key>super1</key>
+                <status>0xB6</status>
+                <midino>0x17</midino>
+                <options>
+                    <fourteen-bit-msb/>
+                </options>
+            </control>
+            <control>
+                <description>FILTER CH1 - rotate - Filter Effect Knob</description>
+                <group>[QuickEffectRack1_[Channel1]]</group>
+                <key>super1</key>
+                <status>0xB6</status>
+                <midino>0x37</midino>
+                <options>
+                    <fourteen-bit-lsb/>
+                </options>
+            </control>
+            <control>
+                <description>FILTER CH2 - rotate - Filter Effect Knob</description>
+                <group>[QuickEffectRack1_[Channel2]]</group>
+                <key>super1</key>
+                <status>0xB6</status>
+                <midino>0x18</midino>
+                <options>
+                    <fourteen-bit-msb/>
+                </options>
+            </control>
+            <control>
+                <description>FILTER CH2 - rotate - Filter Effect Knob</description>
+                <group>[QuickEffectRack1_[Channel2]]</group>
+                <key>super1</key>
+                <status>0xB6</status>
+                <midino>0x38</midino>
+                <options>
+                    <fourteen-bit-lsb/>
+                </options>
+            </control>
+
+            <!-- BEAT FX SECTION START -->
+
+            <control>
+              <description>BEAT FX SELECT - press once - select effect unit 1</description>
+                <group>[EffectRack1_EffectUnit1]</group>
+                <key>PioneerDDJFLX4.beatFxSelectPressed</key>
+                <status>0x94</status>
+                <midino>0x63</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+
+            <control>
+                <description>BEAT LEFT - press - select effect unit 2</description>
+                <group>[EffectRack1_EffectUnit1]</group>
+                <key>PioneerDDJFLX4.beatFxLeftPressed</key>
+                <status>0x94</status>
+                <midino>0x4A</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>BEAT LEFT + shift - select previous effect for the current unit</description>
+                <group>[EffectRack1_EffectUnit1]</group>
+                <key>PioneerDDJFLX4.beatFxSelectPreviousEffect</key>
+                <status>0x94</status>
+                <midino>0x66</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+
+            <control>
+                <description>BEAT RIGHT - press - select effect unit 3</description>
+                <group>[EffectRack1_EffectUnit1]</group>
+                <key>PioneerDDJFLX4.beatFxRightPressed</key>
+                <status>0x94</status>
+                <midino>0x4B</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>BEAT RIGHT + shift - select next effect for the current unit</description>
+                <group>[EffectRack1_EffectUnit1]</group>
+                <key>PioneerDDJFLX4.beatFxSelectNextEffect</key>
+                <status>0x94</status>
+                <midino>0x6B</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+
+            <!-- Beat Fx channel selector -->
+            <control>
+                <description>BEAT FX CH SELECT CH1 - slide - Select FX on DECK 1</description>
+                <group>[EffectRack1_EffectUnit1]</group>
+                <key>PioneerDDJFLX4.beatFxChannel1</key>
+                <status>0x94</status>
+                <midino>0x10</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>BEAT FX CH SELECT CH2 - slide - Select FX on DECK 2</description>
+                <group>[EffectRack1_EffectUnit1]</group>
+                <key>PioneerDDJFLX4.beatFxChannel2</key>
+                <status>0x95</status>
+                <midino>0x11</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+
+            <control>
+                <description>BEAT FX LEVEL/DEPTH - rotate (MSB) - Adjust FX Level (mix) and BEAT FX Depth (meta) in the
+                    selected slot
+                </description>
+                <group>[EffectRack1_EffectUnit1]</group>
+                <key>PioneerDDJFLX4.beatFxLevelDepthRotate</key>
+                <status>0xB4</status>
+                <midino>0x02</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+
+            <control>
+                <description>BEAT FX ON/OFF - press - Toggle FX in the selected Slot</description>
+                <group>[EffectRack1_EffectUnit1]</group>
+                <key>PioneerDDJFLX4.beatFxOnOffPressed</key>
+                <status>0x94</status>
+                <midino>0x47</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>BEAT FX ON/OFF +SHIFT - press - Disable all enabled Beat FX Slots</description>
+                <group>[EffectRack1_EffectUnit1]</group>
+                <key>PioneerDDJFLX4.beatFxOnOffShiftPressed</key>
+                <status>0x94</status>
+                <midino>0x43</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <!-- BEAT FX SECTION END-->
+            <!-- EFFECT Section END -->
+			
+			<!-- PAD MODE SECTION START -->
+            <control>
+                <description>HOT CUE MODE (DECK1) - press - set hotcue mode</description>
+                <group>[PadMode]</group>
+                <key>PioneerDDJFLX4.padModeKeyPressed</key>
+                <status>0x90</status>
+                <midino>0x1B</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>HOT CUE MODE (DECK2) - press - set hotcue mode</description>
+                <group>[PadMode]</group>
+                <key>PioneerDDJFLX4.padModeKeyPressed</key>
+                <status>0x91</status>
+                <midino>0x1B</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>KEYBOARD MODE (DECK1) - press - set keyboard mode</description>
+                <group>[PadMode]</group>
+                <key>PioneerDDJFLX4.padModeKeyPressed</key>
+                <status>0x90</status>
+                <midino>0x69</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>KEYBOARD MODE (DECK2) - press - set keyboard mode</description>
+                <group>[PadMode]</group>
+                <key>PioneerDDJFLX4.padModeKeyPressed</key>
+                <status>0x91</status>
+                <midino>0x69</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD FX1 MODE (DECK1) - press - set pad fx1 mode</description>
+                <group>[PadMode]</group>
+                <key>PioneerDDJFLX4.padModeKeyPressed</key>
+                <status>0x90</status>
+                <midino>0x1E</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD FX1 MODE (DECK2) - press - set pad fx1 mode</description>
+                <group>[PadMode]</group>
+                <key>PioneerDDJFLX4.padModeKeyPressed</key>
+                <status>0x91</status>
+                <midino>0x1E</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD FX2 MODE (DECK1) - press - set pad fx2 mode</description>
+                <group>[PadMode]</group>
+                <key>PioneerDDJFLX4.padModeKeyPressed</key>
+                <status>0x90</status>
+                <midino>0x6B</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD FX2 MODE (DECK2) - press - set pad fx2 mode</description>
+                <group>[PadMode]</group>
+                <key>PioneerDDJFLX4.padModeKeyPressed</key>
+                <status>0x91</status>
+                <midino>0x6B</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>BEAT JUMP MODE (DECK1) - press - set beat jump mode</description>
+                <group>[PadMode]</group>
+                <key>PioneerDDJFLX4.padModeKeyPressed</key>
+                <status>0x90</status>
+                <midino>0x20</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>BEAT JUMP MODE (DECK2) - press - set beat jump mode</description>
+                <group>[PadMode]</group>
+                <key>PioneerDDJFLX4.padModeKeyPressed</key>
+                <status>0x91</status>
+                <midino>0x20</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>BEAT LOOP MODE (DECK1) - press - set beat loop mode</description>
+                <group>[PadMode]</group>
+                <key>PioneerDDJFLX4.padModeKeyPressed</key>
+                <status>0x90</status>
+                <midino>0x6D</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>BEAT LOOP MODE (DECK2) - press - set beat loop mode</description>
+                <group>[PadMode]</group>
+                <key>PioneerDDJFLX4.padModeKeyPressed</key>
+                <status>0x91</status>
+                <midino>0x6D</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>SAMPLER MODE (DECK1) - press - set sampler mode</description>
+                <group>[PadMode]</group>
+                <key>PioneerDDJFLX4.padModeKeyPressed</key>
+                <status>0x90</status>
+                <midino>0x22</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>SAMPLER MODE (DECK2) - press - set sampler mode</description>
+                <group>[PadMode]</group>
+                <key>PioneerDDJFLX4.padModeKeyPressed</key>
+                <status>0x91</status>
+                <midino>0x22</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>KEY SHIFT MODE (DECK1) - press - set key shift mode</description>
+                <group>[PadMode]</group>
+                <key>PioneerDDJFLX4.padModeKeyPressed</key>
+                <status>0x90</status>
+                <midino>0x6F</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>KEY SHIFT MODE (DECK2) - press - set key shift mode</description>
+                <group>[PadMode]</group>
+                <key>PioneerDDJFLX4.padModeKeyPressed</key>
+                <status>0x91</status>
+                <midino>0x6F</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+			<!-- PAD MODE SECTION END -->
+
+            <!-- HOT CUE MODE START -->
+            <control>
+                <description>PAD 1 (DECK1) HOT CUE MODE - press - set hotcue</description>
+                <group>[Channel1]</group>
+                <key>hotcue_1_activate</key>
+                <status>0x97</status>
+                <midino>0x00</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 1 +SHIFT (DECK1) HOT CUE MODE - press - delete hotcue</description>
+                <group>[Channel1]</group>
+                <key>hotcue_1_clear</key>
+                <status>0x98</status>
+                <midino>0x00</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 1 (DECK2) HOT CUE MODE - press - set hotcue</description>
+                <group>[Channel2]</group>
+                <key>hotcue_1_activate</key>
+                <status>0x99</status>
+                <midino>0x00</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 1 +SHIFT (DECK2) HOT CUE MODE - press - delete hotcue</description>
+                <group>[Channel2]</group>
+                <key>hotcue_1_clear</key>
+                <status>0x9A</status>
+                <midino>0x00</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 (DECK1) HOT CUE MODE - press - set hotcue</description>
+                <group>[Channel1]</group>
+                <key>hotcue_2_activate</key>
+                <status>0x97</status>
+                <midino>0x01</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 +SHIFT (DECK1) HOT CUE MODE - press - delete hotcue</description>
+                <group>[Channel1]</group>
+                <key>hotcue_2_clear</key>
+                <status>0x98</status>
+                <midino>0x01</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 (DECK2) HOT CUE MODE - press - set hotcue</description>
+                <group>[Channel2]</group>
+                <key>hotcue_2_activate</key>
+                <status>0x99</status>
+                <midino>0x01</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 +SHIFT (DECK2) HOT CUE MODE - press - delete hotcue</description>
+                <group>[Channel2]</group>
+                <key>hotcue_2_clear</key>
+                <status>0x9A</status>
+                <midino>0x01</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 (DECK1) HOT CUE MODE - press - set hotcue</description>
+                <group>[Channel1]</group>
+                <key>hotcue_3_activate</key>
+                <status>0x97</status>
+                <midino>0x02</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 +SHIFT (DECK1) HOT CUE MODE - press - delete hotcue</description>
+                <group>[Channel1]</group>
+                <key>hotcue_3_clear</key>
+                <status>0x98</status>
+                <midino>0x02</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 (DECK2) HOT CUE MODE - press - set hotcue</description>
+                <group>[Channel2]</group>
+                <key>hotcue_3_activate</key>
+                <status>0x99</status>
+                <midino>0x02</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 +SHIFT (DECK2) HOT CUE MODE - press - delete hotcue</description>
+                <group>[Channel2]</group>
+                <key>hotcue_3_clear</key>
+                <status>0x9A</status>
+                <midino>0x02</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 (DECK1) HOT CUE MODE - press - set hotcue</description>
+                <group>[Channel1]</group>
+                <key>hotcue_4_activate</key>
+                <status>0x97</status>
+                <midino>0x03</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 +SHIFT (DECK1) HOT CUE MODE - press - delete hotcue</description>
+                <group>[Channel1]</group>
+                <key>hotcue_4_clear</key>
+                <status>0x98</status>
+                <midino>0x03</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 (DECK2) HOT CUE MODE - press - set hotcue</description>
+                <group>[Channel2]</group>
+                <key>hotcue_4_activate</key>
+                <status>0x99</status>
+                <midino>0x03</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 +SHIFT (DECK2) HOT CUE MODE - press - delete hotcue</description>
+                <group>[Channel2]</group>
+                <key>hotcue_4_clear</key>
+                <status>0x9A</status>
+                <midino>0x03</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5(DECK1) HOT CUE MODE - press - set hotcue</description>
+                <group>[Channel1]</group>
+                <key>hotcue_5_activate</key>
+                <status>0x97</status>
+                <midino>0x04</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5 +SHIFT (DECK1) HOT CUE MODE - press - delete hotcue</description>
+                <group>[Channel1]</group>
+                <key>hotcue_5_clear</key>
+                <status>0x98</status>
+                <midino>0x04</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5 (DECK2) HOT CUE MODE - press - set hotcue</description>
+                <group>[Channel2]</group>
+                <key>hotcue_5_activate</key>
+                <status>0x99</status>
+                <midino>0x04</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5 +SHIFT (DECK2) HOT CUE MODE - press - delete hotcue</description>
+                <group>[Channel2]</group>
+                <key>hotcue_5_clear</key>
+                <status>0x9A</status>
+                <midino>0x04</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 (DECK1) HOT CUE MODE - press - set hotcue</description>
+                <group>[Channel1]</group>
+                <key>hotcue_6_activate</key>
+                <status>0x97</status>
+                <midino>0x05</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 +SHIFT (DECK1) HOT CUE MODE - press - delete hotcue</description>
+                <group>[Channel1]</group>
+                <key>hotcue_6_clear</key>
+                <status>0x98</status>
+                <midino>0x05</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 (DECK2) HOT CUE MODE - press - set hotcue</description>
+                <group>[Channel2]</group>
+                <key>hotcue_6_activate</key>
+                <status>0x99</status>
+                <midino>0x05</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 +SHIFT (DECK2) HOT CUE MODE - press - delete hotcue</description>
+                <group>[Channel2]</group>
+                <key>hotcue_6_clear</key>
+                <status>0x9A</status>
+                <midino>0x05</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 (DECK1) HOT CUE MODE - press - set hotcue</description>
+                <group>[Channel1]</group>
+                <key>hotcue_7_activate</key>
+                <status>0x97</status>
+                <midino>0x06</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 +SHIFT (DECK1) HOT CUE MODE - press - delete hotcue</description>
+                <group>[Channel1]</group>
+                <key>hotcue_7_clear</key>
+                <status>0x98</status>
+                <midino>0x06</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 (DECK2) HOT CUE MODE - press - set hotcue</description>
+                <group>[Channel2]</group>
+                <key>hotcue_7_activate</key>
+                <status>0x99</status>
+                <midino>0x06</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 +SHIFT (DECK2) HOT CUE MODE - press - delete hotcue</description>
+                <group>[Channel2]</group>
+                <key>hotcue_7_clear</key>
+                <status>0x9A</status>
+                <midino>0x06</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 (DECK1) HOT CUE MODE - press - set hotcue</description>
+                <group>[Channel1]</group>
+                <key>hotcue_8_activate</key>
+                <status>0x97</status>
+                <midino>0x07</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 +SHIFT (DECK1) HOT CUE MODE - press - delete hotcue</description>
+                <group>[Channel1]</group>
+                <key>hotcue_8_clear</key>
+                <status>0x98</status>
+                <midino>0x07</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 (DECK2) HOT CUE MODE - press - set hotcue</description>
+                <group>[Channel2]</group>
+                <key>hotcue_8_activate</key>
+                <status>0x99</status>
+                <midino>0x07</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 +SHIFT (DECK2) HOT CUE MODE - press - delete hotcue</description>
+                <group>[Channel2]</group>
+                <key>hotcue_8_clear</key>
+                <status>0x9A</status>
+                <midino>0x07</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <!-- HOT CUE MODE END -->
+
+            <!-- BEAT LOOP MODE START -->
+
+            <control>
+                <description>PAD 1 (DECK1) BEAT LOOP MODE - press - 1/4 Beatloop</description>
+                <group>[Channel1]</group>
+                <key>beatloop_0.25_toggle</key>
+                <status>0x97</status>
+                <midino>0x60</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 1 (DECK2) BEAT LOOP MODE - press - 1/4 Beatloop</description>
+                <group>[Channel2]</group>
+                <key>beatloop_0.25_toggle</key>
+                <status>0x99</status>
+                <midino>0x60</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 (DECK1) BEAT LOOP MODE - press - 1/2 Beatloop</description>
+                <group>[Channel1]</group>
+                <key>beatloop_0.5_toggle</key>
+                <status>0x97</status>
+                <midino>0x61</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 (DECK2) BEAT LOOP MODE - press - 1/2 Beatloop</description>
+                <group>[Channel2]</group>
+                <key>beatloop_0.5_toggle</key>
+                <status>0x99</status>
+                <midino>0x61</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 (DECK1) BEAT LOOP MODE - press - 1/1 Beatloop</description>
+                <group>[Channel1]</group>
+                <key>beatloop_1_toggle</key>
+                <status>0x97</status>
+                <midino>0x62</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 (DECK2) BEAT LOOP MODE - press - 1/1 Beatloop</description>
+                <group>[Channel2]</group>
+                <key>beatloop_1_toggle</key>
+                <status>0x99</status>
+                <midino>0x62</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 (DECK1) BEAT LOOP MODE - press - 2 Beatloop</description>
+                <group>[Channel1]</group>
+                <key>beatloop_2_toggle</key>
+                <status>0x97</status>
+                <midino>0x63</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 (DECK2) BEAT LOOP MODE - press - 2 Beatloop</description>
+                <group>[Channel2]</group>
+                <key>beatloop_2_toggle</key>
+                <status>0x99</status>
+                <midino>0x63</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5 (DECK1) BEAT LOOP MODE - press - 4 Beatloop</description>
+                <group>[Channel1]</group>
+                <key>beatloop_4_toggle</key>
+                <status>0x97</status>
+                <midino>0x64</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5 (DECK2) BEAT LOOP MODE - press - 4 Beatloop</description>
+                <group>[Channel2]</group>
+                <key>beatloop_4_toggle</key>
+                <status>0x99</status>
+                <midino>0x64</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 (DECK1) BEAT LOOP MODE - press - 8 Beatloop</description>
+                <group>[Channel1]</group>
+                <key>beatloop_8_toggle</key>
+                <status>0x97</status>
+                <midino>0x65</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 (DECK2) BEAT LOOP MODE - press - 8 Beatloop</description>
+                <group>[Channel2]</group>
+                <key>beatloop_8_toggle</key>
+                <status>0x99</status>
+                <midino>0x65</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 (DECK1) BEAT LOOP MODE - press - 16 Beatloop</description>
+                <group>[Channel1]</group>
+                <key>beatloop_16_toggle</key>
+                <status>0x97</status>
+                <midino>0x66</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 (DECK2) BEAT LOOP MODE - press - 16 Beatloop</description>
+                <group>[Channel2]</group>
+                <key>beatloop_16_toggle</key>
+                <status>0x99</status>
+                <midino>0x66</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 (DECK1) BEAT LOOP MODE - press - 32 Beatloop</description>
+                <group>[Channel1]</group>
+                <key>beatloop_32_toggle</key>
+                <status>0x97</status>
+                <midino>0x67</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 (DECK2) BEAT LOOP MODE - press - 32 Beatloop</description>
+                <group>[Channel2]</group>
+                <key>beatloop_32_toggle</key>
+                <status>0x99</status>
+                <midino>0x67</midino>
+                <options>
+                    <Normal/>
+                </options>
+            </control>
+            <!-- BEAT LOOP MODE END -->
+
+            <!-- BEAT JUMP MODE START-->
+            <control>
+                <description>PAD 1 (DECK1) BEAT JUMP MODE - press - Jump 1 Beat backwards</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.beatjumpPadPressed</key>
+                <status>0x97</status>
+                <midino>0x20</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 1 (DECK2) BEAT JUMP MODE - press - Jump 1 Beat backwards</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.beatjumpPadPressed</key>
+                <status>0x99</status>
+                <midino>0x20</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 (DECK1) BEAT JUMP MODE - press - Jump 1 Beat forwards</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.beatjumpPadPressed</key>
+                <status>0x97</status>
+                <midino>0x21</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 (DECK2) BEAT JUMP MODE - press - Jump 1 Beat forwards</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.beatjumpPadPressed</key>
+                <status>0x99</status>
+                <midino>0x21</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 (DECK1) BEAT JUMP MODE - press - Jump 2 Beats backwards</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.beatjumpPadPressed</key>
+                <status>0x97</status>
+                <midino>0x22</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 (DECK2) BEAT JUMP MODE - press - Jump 2 Beats backwards</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.beatjumpPadPressed</key>
+                <status>0x99</status>
+                <midino>0x22</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 (DECK1) BEAT JUMP MODE - press - Jump 2 Beats forwards</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.beatjumpPadPressed</key>
+                <status>0x97</status>
+                <midino>0x23</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 (DECK2) BEAT JUMP MODE - press - Jump 2 Beats forwards</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.beatjumpPadPressed</key>
+                <status>0x99</status>
+                <midino>0x23</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5 (DECK1) BEAT JUMP MODE - press - Jump 4 Beats backwards</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.beatjumpPadPressed</key>
+                <status>0x97</status>
+                <midino>0x24</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5 (DECK2) BEAT JUMP MODE - press - Jump 4 Beats backwards</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.beatjumpPadPressed</key>
+                <status>0x99</status>
+                <midino>0x24</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 (DECK1) BEAT JUMP MODE - press - Jump 4 Beats forwards</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.beatjumpPadPressed</key>
+                <status>0x97</status>
+                <midino>0x25</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 (DECK2) BEAT JUMP MODE - press - Jump 4 Beats forwards</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.beatjumpPadPressed</key>
+                <status>0x99</status>
+                <midino>0x25</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 (DECK1) BEAT JUMP MODE - press - Jump 8 Beats backwards</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.beatjumpPadPressed</key>
+                <status>0x97</status>
+                <midino>0x26</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 (DECK2) BEAT JUMP MODE - press - Jump 8 Beats backwards</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.beatjumpPadPressed</key>
+                <status>0x99</status>
+                <midino>0x26</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 (DECK1) BEAT JUMP MODE - press - Jump 8 Beats forwards</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.beatjumpPadPressed</key>
+                <status>0x97</status>
+                <midino>0x27</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 (DECK2) BEAT JUMP MODE - press - Jump 8 Beats forwards</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.beatjumpPadPressed</key>
+                <status>0x99</status>
+                <midino>0x27</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+
+            <control>
+                <description>PAD 7 (DECK1) +SHift BEAT JUMP MODE - press - decrease Beatjump by a factor of 16</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.decreaseBeatjumpSizes</key>
+                <status>0x98</status>
+                <midino>0x26</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 (DECK2) +Shift BEAT JUMP MODE - press - decrease Beatjump by a factor of 16</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.decreaseBeatjumpSizes</key>
+                <status>0x9A</status>
+                <midino>0x26</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 (DECK1) +SHift BEAT JUMP MODE - press - increase Beatjump by a factor of 16</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.increaseBeatjumpSizes</key>
+                <status>0x98</status>
+                <midino>0x27</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 (DECK2) +Shift BEAT JUMP MODE - press - increase Beatjump by a factor of 16</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.increaseBeatjumpSizes</key>
+                <status>0x9A</status>
+                <midino>0x27</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <!-- BEAT JUMP MODE END -->
+
+            <!-- SAMPLER MODE START -->
+            <control>
+                <description>PAD 1 (LEFT) SAMPLE MODE - press - Play Sample or Load Track</description>
+                <group>[Sampler1]</group>
+                <key>PioneerDDJFLX4.samplerPadPressed</key>
+                <status>0x97</status>
+                <midino>0x30</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 1 (LEFT)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
+                <group>[Sampler1]</group>
+                <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x30</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 (LEFT) SAMPLE MODE - press - Play Sample or Load Track</description>
+                <group>[Sampler2]</group>
+                <key>PioneerDDJFLX4.samplerPadPressed</key>
+                <status>0x97</status>
+                <midino>0x31</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 (LEFT)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
+                <group>[Sampler2]</group>
+                <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x31</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 (LEFT) SAMPLE MODE - press - Play Sample or Load Track</description>
+                <group>[Sampler3]</group>
+                <key>PioneerDDJFLX4.samplerPadPressed</key>
+                <status>0x97</status>
+                <midino>0x32</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 (LEFT)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
+                <group>[Sampler3]</group>
+                <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x32</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 (LEFT) SAMPLE MODE - press - Play Sample or Load Track</description>
+                <group>[Sampler4]</group>
+                <key>PioneerDDJFLX4.samplerPadPressed</key>
+                <status>0x97</status>
+                <midino>0x33</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 (LEFT)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
+                <group>[Sampler4]</group>
+                <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x33</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5 (LEFT) SAMPLE MODE - press - Play Sample or Load Track</description>
+                <group>[Sampler5]</group>
+                <key>PioneerDDJFLX4.samplerPadPressed</key>
+                <status>0x97</status>
+                <midino>0x34</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5 (LEFT)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
+                <group>[Sampler5]</group>
+                <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x34</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 (LEFT) SAMPLE MODE - press - Play Sample or Load Track</description>
+                <group>[Sampler6]</group>
+                <key>PioneerDDJFLX4.samplerPadPressed</key>
+                <status>0x97</status>
+                <midino>0x35</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 (LEFT)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
+                <group>[Sampler6]</group>
+                <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x35</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 (LEFT) SAMPLE MODE - press - Play Sample or Load Track</description>
+                <group>[Sampler7]</group>
+                <key>PioneerDDJFLX4.samplerPadPressed</key>
+                <status>0x97</status>
+                <midino>0x36</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 (LEFT)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
+                <group>[Sampler7]</group>
+                <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x36</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 (LEFT) SAMPLE MODE - press - Play Sample or Load Track</description>
+                <group>[Sampler8]</group>
+                <key>PioneerDDJFLX4.samplerPadPressed</key>
+                <status>0x97</status>
+                <midino>0x37</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 (LEFT)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
+                <group>[Sampler8]</group>
+                <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x37</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+
+
+            <control>
+                <description>PAD 1 (RIGHT) SAMPLE MODE - press - Play Sample or Load Track</description>
+                <group>[Sampler9]</group>
+                <key>PioneerDDJFLX4.samplerPadPressed</key>
+                <status>0x99</status>
+                <midino>0x30</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 1 (Right)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
+                <group>[Sampler9]</group>
+                <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x30</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 (RIGHT) SAMPLE MODE - press - Play Sample or Load Track</description>
+                <group>[Sampler10]</group>
+                <key>PioneerDDJFLX4.samplerPadPressed</key>
+                <status>0x99</status>
+                <midino>0x31</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 (Right)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
+                <group>[Sampler10]</group>
+                <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x31</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 (RIGHT) SAMPLE MODE - press - Play Sample or Load Track</description>
+                <group>[Sampler11]</group>
+                <key>PioneerDDJFLX4.samplerPadPressed</key>
+                <status>0x99</status>
+                <midino>0x32</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 (Right)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
+                <group>[Sampler11]</group>
+                <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x32</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 (RIGHT) SAMPLE MODE - press - Play Sample or Load Track</description>
+                <group>[Sampler12]</group>
+                <key>PioneerDDJFLX4.samplerPadPressed</key>
+                <status>0x99</status>
+                <midino>0x33</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 (Right)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
+                <group>[Sampler12]</group>
+                <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x33</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5 (RIGHT) SAMPLE MODE - press - Play Sample or Load Track</description>
+                <group>[Sampler13]</group>
+                <key>PioneerDDJFLX4.samplerPadPressed</key>
+                <status>0x99</status>
+                <midino>0x34</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5 (Right)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
+                <group>[Sampler13]</group>
+                <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x34</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 (RIGHT) SAMPLE MODE - press - Play Sample or Load Track</description>
+                <group>[Sampler14]</group>
+                <key>PioneerDDJFLX4.samplerPadPressed</key>
+                <status>0x99</status>
+                <midino>0x35</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 (Right)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
+                <group>[Sampler14]</group>
+                <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x35</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 (RIGHT) SAMPLE MODE - press - Play Sample or Load Track</description>
+                <group>[Sampler15]</group>
+                <key>PioneerDDJFLX4.samplerPadPressed</key>
+                <status>0x99</status>
+                <midino>0x36</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 (Right)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
+                <group>[Sampler15]</group>
+                <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x36</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 (RIGHT) SAMPLE MODE - press - Play Sample or Load Track</description>
+                <group>[Sampler16]</group>
+                <key>PioneerDDJFLX4.samplerPadPressed</key>
+                <status>0x99</status>
+                <midino>0x37</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 (Right)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
+                <group>[Sampler16]</group>
+                <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x37</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <!-- SAMPLER MODE END -->
+
+            <!-- PAD Section END -->
+        </controls>
+        <outputs>
+            <!-- PLAY -->
+            <output>
+                <group>[Channel1]</group>
+                <key>play_indicator</key>
+                <status>0x90</status>  <!-- First byte sent to device -->
+                <midino>0x0B</midino>  <!-- Second byte -->
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>play_indicator</key>
+                <status>0x91</status>  <!-- First byte sent to device -->
+                <midino>0x0B</midino>  <!-- Second byte -->
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>play_indicator</key>
+                <status>0x90</status>  <!-- First byte sent to device -->
+                <midino>0x47</midino>  <!-- Second byte -->
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>play_indicator</key>
+                <status>0x91</status>  <!-- First byte sent to device -->
+                <midino>0x47</midino>  <!-- Second byte -->
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+
+            <!-- CUE -->
+            <output>
+                <group>[Channel1]</group>
+                <key>cue_indicator</key>
+                <status>0x90</status>
+                <midino>0x0C</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>cue_indicator</key>
+                <status>0x91</status>
+                <midino>0x0C</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+
+            <!-- CUE + Shift -->
+            <output>
+                <group>[Channel1]</group>
+                <key>cue_indicator</key>
+                <status>0x90</status>
+                <midino>0x47</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>cue_indicator</key>
+                <status>0x91</status>
+                <midino>0x47</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+
+            <!-- BEAT SYNC Ch1 9058 Shift 9060 Ch2 9158 Shift 9160 -->
+            <output>
+                <group>[Channel1]</group>
+                <key>sync_enabled</key>
+                <status>0x90</status>
+                <midino>0x58</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>sync_enabled</key>
+                <status>0x91</status>
+                <midino>0x58</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+
+            <!-- CH CUE Ch1 9054 Ch2 9154 -->
+            <output>
+                <group>[Channel1]</group>
+                <key>pfl</key>
+                <status>0x90</status>
+                <midino>0x54</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>pfl</key>
+                <status>0x91</status>
+                <midino>0x54</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+
+            <!-- Hotcue Mode Pads -->
+            <output>
+                <group>[Channel1]</group>
+                <key>hotcue_1_enabled</key>
+                <status>0x97</status>
+                <midino>0x00</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>hotcue_1_enabled</key>
+                <status>0x99</status>
+                <midino>0x00</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>hotcue_2_enabled</key>
+                <status>0x97</status>
+                <midino>0x01</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>hotcue_2_enabled</key>
+                <status>0x99</status>
+                <midino>0x01</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>hotcue_3_enabled</key>
+                <status>0x97</status>
+                <midino>0x02</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>hotcue_3_enabled</key>
+                <status>0x99</status>
+                <midino>0x02</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>hotcue_4_enabled</key>
+                <status>0x97</status>
+                <midino>0x03</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>hotcue_4_enabled</key>
+                <status>0x99</status>
+                <midino>0x03</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>hotcue_5_enabled</key>
+                <status>0x97</status>
+                <midino>0x04</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>hotcue_5_enabled</key>
+                <status>0x99</status>
+                <midino>0x04</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>hotcue_6_enabled</key>
+                <status>0x97</status>
+                <midino>0x05</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>hotcue_6_enabled</key>
+                <status>0x99</status>
+                <midino>0x05</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>hotcue_7_enabled</key>
+                <status>0x97</status>
+                <midino>0x06</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>hotcue_7_enabled</key>
+                <status>0x99</status>
+                <midino>0x06</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>hotcue_8_enabled</key>
+                <status>0x97</status>
+                <midino>0x07</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>hotcue_8_enabled</key>
+                <status>0x99</status>
+                <midino>0x07</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+
+            <!-- Repeat the output signal for the OFF status (Deck 1: 0x98, Deck 2: 0x9A.)
+            This is to ensure that the hotcue lights don't turn off when pressing the SHIFT button
+            -->
+            <output>
+                <group>[Channel1]</group>
+                <key>hotcue_1_enabled</key>
+                <status>0x98</status>
+                <midino>0x00</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>hotcue_1_enabled</key>
+                <status>0x9A</status>
+                <midino>0x00</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>hotcue_2_enabled</key>
+                <status>0x98</status>
+                <midino>0x01</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>hotcue_2_enabled</key>
+                <status>0x9A</status>
+                <midino>0x01</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>hotcue_3_enabled</key>
+                <status>0x98</status>
+                <midino>0x02</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>hotcue_3_enabled</key>
+                <status>0x9A</status>
+                <midino>0x02</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>hotcue_4_enabled</key>
+                <status>0x98</status>
+                <midino>0x03</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>hotcue_4_enabled</key>
+                <status>0x9A</status>
+                <midino>0x03</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>hotcue_5_enabled</key>
+                <status>0x98</status>
+                <midino>0x04</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>hotcue_5_enabled</key>
+                <status>0x9A</status>
+                <midino>0x04</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>hotcue_6_enabled</key>
+                <status>0x98</status>
+                <midino>0x05</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>hotcue_6_enabled</key>
+                <status>0x9A</status>
+                <midino>0x05</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>hotcue_7_enabled</key>
+                <status>0x98</status>
+                <midino>0x06</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>hotcue_7_enabled</key>
+                <status>0x9A</status>
+                <midino>0x06</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>hotcue_8_enabled</key>
+                <status>0x98</status>
+                <midino>0x07</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>hotcue_8_enabled</key>
+                <status>0x9A</status>
+                <midino>0x07</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+
+            <!-- BEATLOOP Mode Pads -->
+            <output>
+                <group>[Channel1]</group>
+                <key>beatloop_0.25_enabled</key>
+                <status>0x97</status>
+                <midino>0x60</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>beatloop_0.25_enabled</key>
+                <status>0x99</status>
+                <midino>0x60</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>beatloop_0.5_enabled</key>
+                <status>0x97</status>
+                <midino>0x61</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>beatloop_0.5_enabled</key>
+                <status>0x99</status>
+                <midino>0x61</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>beatloop_1_enabled</key>
+                <status>0x97</status>
+                <midino>0x62</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>beatloop_1_enabled</key>
+                <status>0x99</status>
+                <midino>0x62</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>beatloop_2_enabled</key>
+                <status>0x97</status>
+                <midino>0x63</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>beatloop_2_enabled</key>
+                <status>0x99</status>
+                <midino>0x63</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>beatloop_4_enabled</key>
+                <status>0x97</status>
+                <midino>0x64</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>beatloop_4_enabled</key>
+                <status>0x99</status>
+                <midino>0x64</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>beatloop_8_enabled</key>
+                <status>0x97</status>
+                <midino>0x65</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>beatloop_8_enabled</key>
+                <status>0x99</status>
+                <midino>0x65</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>beatloop_16_enabled</key>
+                <status>0x97</status>
+                <midino>0x66</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>beatloop_16_enabled</key>
+                <status>0x99</status>
+                <midino>0x66</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>beatloop_32_enabled</key>
+                <status>0x97</status>
+                <midino>0x67</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>beatloop_32_enabled</key>
+                <status>0x99</status>
+                <midino>0x67</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+
+            <!-- Repeat the output signal for the OFF status (Deck 1: 0x98, Deck 2: 0x9A.)
+            This is to ensure that the beat_loop lights don't turn off when pressing the SHIFT button
+            -->
+            <output>
+                <group>[Channel1]</group>
+                <key>beatloop_0.25_enabled</key>
+                <status>0x98</status>
+                <midino>0x60</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>beatloop_0.25_enabled</key>
+                <status>0x9A</status>
+                <midino>0x60</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>beatloop_0.5_enabled</key>
+                <status>0x98</status>
+                <midino>0x61</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>beatloop_0.5_enabled</key>
+                <status>0x9A</status>
+                <midino>0x61</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>beatloop_1_enabled</key>
+                <status>0x98</status>
+                <midino>0x62</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>beatloop_1_enabled</key>
+                <status>0x9A</status>
+                <midino>0x62</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>beatloop_2_enabled</key>
+                <status>0x98</status>
+                <midino>0x63</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>beatloop_2_enabled</key>
+                <status>0x9A</status>
+                <midino>0x63</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>beatloop_4_enabled</key>
+                <status>0x98</status>
+                <midino>0x64</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>beatloop_4_enabled</key>
+                <status>0x9A</status>
+                <midino>0x64</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>beatloop_8_enabled</key>
+                <status>0x98</status>
+                <midino>0x65</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>beatloop_8_enabled</key>
+                <status>0x9A</status>
+                <midino>0x65</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>beatloop_16_enabled</key>
+                <status>0x98</status>
+                <midino>0x66</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>beatloop_16_enabled</key>
+                <status>0x9A</status>
+                <midino>0x66</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>beatloop_32_enabled</key>
+                <status>0x98</status>
+                <midino>0x67</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>beatloop_32_enabled</key>
+                <status>0x9A</status>
+                <midino>0x67</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+
+            <!-- Beatjump (light pads 7&8 when shift is pressed) -->
+            <output>
+                <group>[Channel1]</group>
+                <key>track_loaded</key>
+                <status>0x98</status>
+                <midino>0x26</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>track_loaded</key>
+                <status>0x98</status>
+                <midino>0x27</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>track_loaded</key>
+                <status>0x9A</status>
+                <midino>0x26</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>track_loaded</key>
+                <status>0x9A</status>
+                <midino>0x27</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+
+            <!-- SAMPLER Mode Pads (while SHIFT is NOT pressed)-->
+            <!-- Deck 1 pads -->
+            <output>
+                <group>[Sampler1]</group>
+                <key>track_loaded</key>
+                <status>0x97</status>
+                <midino>0x30</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler2]</group>
+                <key>track_loaded</key>
+                <status>0x97</status>
+                <midino>0x31</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler3]</group>
+                <key>track_loaded</key>
+                <status>0x97</status>
+                <midino>0x32</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler4]</group>
+                <key>track_loaded</key>
+                <status>0x97</status>
+                <midino>0x33</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler5]</group>
+                <key>track_loaded</key>
+                <status>0x97</status>
+                <midino>0x34</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler6]</group>
+                <key>track_loaded</key>
+                <status>0x97</status>
+                <midino>0x35</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler7]</group>
+                <key>track_loaded</key>
+                <status>0x97</status>
+                <midino>0x36</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler8]</group>
+                <key>track_loaded</key>
+                <status>0x97</status>
+                <midino>0x37</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <!-- SAMPLER Mode Pads (while SHIFT is NOT pressed)-->
+            <!-- Deck 2 pads -->
+            <output>
+                <group>[Sampler9]</group>
+                <key>track_loaded</key>
+                <status>0x99</status>
+                <midino>0x30</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler10]</group>
+                <key>track_loaded</key>
+                <status>0x99</status>
+                <midino>0x31</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler11]</group>
+                <key>track_loaded</key>
+                <status>0x99</status>
+                <midino>0x32</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler12]</group>
+                <key>track_loaded</key>
+                <status>0x99</status>
+                <midino>0x33</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler13]</group>
+                <key>track_loaded</key>
+                <status>0x99</status>
+                <midino>0x34</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler14]</group>
+                <key>track_loaded</key>
+                <status>0x99</status>
+                <midino>0x35</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler15]</group>
+                <key>track_loaded</key>
+                <status>0x99</status>
+                <midino>0x36</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler16]</group>
+                <key>track_loaded</key>
+                <status>0x99</status>
+                <midino>0x37</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+
+            <!-- SAMPLER Mode Pads (while SHIFT IS pressed)-->
+            <!-- Deck 1 pads -->
+
+            <output>
+                <group>[Sampler1]</group>
+                <key>track_loaded</key>
+                <status>0x98</status>
+                <midino>0x30</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler2]</group>
+                <key>track_loaded</key>
+                <status>0x98</status>
+                <midino>0x31</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler3]</group>
+                <key>track_loaded</key>
+                <status>0x98</status>
+                <midino>0x32</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler4]</group>
+                <key>track_loaded</key>
+                <status>0x98</status>
+                <midino>0x33</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler5]</group>
+                <key>track_loaded</key>
+                <status>0x98</status>
+                <midino>0x34</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler6]</group>
+                <key>track_loaded</key>
+                <status>0x98</status>
+                <midino>0x35</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler7]</group>
+                <key>track_loaded</key>
+                <status>0x98</status>
+                <midino>0x36</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler8]</group>
+                <key>track_loaded</key>
+                <status>0x98</status>
+                <midino>0x37</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+
+            <!-- SAMPLER Mode Pads (while SHIFT IS pressed)-->
+            <!-- Deck 2 pads -->
+
+            <output>
+                <group>[Sampler9]</group>
+                <key>track_loaded</key>
+                <status>0x9A</status>
+                <midino>0x30</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler10]</group>
+                <key>track_loaded</key>
+                <status>0x9A</status>
+                <midino>0x31</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler11]</group>
+                <key>track_loaded</key>
+                <status>0x9A</status>
+                <midino>0x32</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler12]</group>
+                <key>track_loaded</key>
+                <status>0x9A</status>
+                <midino>0x33</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler13]</group>
+                <key>track_loaded</key>
+                <status>0x9A</status>
+                <midino>0x34</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler14]</group>
+                <key>track_loaded</key>
+                <status>0x9A</status>
+                <midino>0x35</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler15]</group>
+                <key>track_loaded</key>
+                <status>0x9A</status>
+                <midino>0x36</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Sampler16]</group>
+                <key>track_loaded</key>
+                <status>0x9A</status>
+                <midino>0x37</midino>
+                <on>0x7F</on>
+                <minimum>0.5</minimum>
+            </output>
+            <!-- SAMPLER Mode Pads end-->
+        </outputs>
+    </controller>
+</MixxxMIDIPreset>

--- a/res/controllers/Pioneer-DDJ-FLX4.midi.xml
+++ b/res/controllers/Pioneer-DDJ-FLX4.midi.xml
@@ -1086,7 +1086,7 @@
             </control>
 
             <control>
-                <description>BEAT FX ON/OFF - press - Toggle FX in the selected Slot</description>
+                <description>BEAT FX ON/OFF - press - Toggle FX in the selected Slot (when on CHAN1/1+2)</description>
                 <group>[EffectRack1_EffectUnit1]</group>
                 <key>PioneerDDJFLX4.beatFxOnOffPressed</key>
                 <status>0x94</status>
@@ -1096,10 +1096,30 @@
                 </options>
             </control>
             <control>
-                <description>BEAT FX ON/OFF +SHIFT - press - Disable all enabled Beat FX Slots</description>
+                <description>BEAT FX ON/OFF - press - Toggle FX in the selected Slot (when on CHAN2)</description>
+                <group>[EffectRack1_EffectUnit1]</group>
+                <key>PioneerDDJFLX4.beatFxOnOffPressed</key>
+                <status>0x95</status>
+                <midino>0x47</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>BEAT FX ON/OFF +SHIFT - press - Disable all enabled Beat FX Slots (when on CHAN1/1+2)</description>
                 <group>[EffectRack1_EffectUnit1]</group>
                 <key>PioneerDDJFLX4.beatFxOnOffShiftPressed</key>
                 <status>0x94</status>
+                <midino>0x43</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>BEAT FX ON/OFF +SHIFT - press - Disable all enabled Beat FX Slots (when on CHAN12)</description>
+                <group>[EffectRack1_EffectUnit1]</group>
+                <key>PioneerDDJFLX4.beatFxOnOffShiftPressed</key>
+                <status>0x95</status>
                 <midino>0x43</midino>
                 <options>
                     <Script-Binding/>

--- a/res/controllers/Pioneer-DDJ-FLX4.midi.xml
+++ b/res/controllers/Pioneer-DDJ-FLX4.midi.xml
@@ -3009,7 +3009,7 @@
                 <minimum>0.5</minimum>
             </output>
             <output>
-                <group>[Sampler5]</group>
+                <group>[Sampler9]</group>
                 <key>track_loaded</key>
                 <status>0x97</status>
                 <midino>0x34</midino>
@@ -3017,7 +3017,7 @@
                 <minimum>0.5</minimum>
             </output>
             <output>
-                <group>[Sampler6]</group>
+                <group>[Sampler10]</group>
                 <key>track_loaded</key>
                 <status>0x97</status>
                 <midino>0x35</midino>
@@ -3025,7 +3025,7 @@
                 <minimum>0.5</minimum>
             </output>
             <output>
-                <group>[Sampler7]</group>
+                <group>[Sampler11]</group>
                 <key>track_loaded</key>
                 <status>0x97</status>
                 <midino>0x36</midino>
@@ -3033,7 +3033,7 @@
                 <minimum>0.5</minimum>
             </output>
             <output>
-                <group>[Sampler8]</group>
+                <group>[Sampler12]</group>
                 <key>track_loaded</key>
                 <status>0x97</status>
                 <midino>0x37</midino>
@@ -3043,7 +3043,7 @@
             <!-- SAMPLER Mode Pads (while SHIFT is NOT pressed)-->
             <!-- Deck 2 pads -->
             <output>
-                <group>[Sampler9]</group>
+                <group>[Sampler5]</group>
                 <key>track_loaded</key>
                 <status>0x99</status>
                 <midino>0x30</midino>
@@ -3051,7 +3051,7 @@
                 <minimum>0.5</minimum>
             </output>
             <output>
-                <group>[Sampler10]</group>
+                <group>[Sampler6]</group>
                 <key>track_loaded</key>
                 <status>0x99</status>
                 <midino>0x31</midino>
@@ -3059,7 +3059,7 @@
                 <minimum>0.5</minimum>
             </output>
             <output>
-                <group>[Sampler11]</group>
+                <group>[Sampler7]</group>
                 <key>track_loaded</key>
                 <status>0x99</status>
                 <midino>0x32</midino>
@@ -3067,7 +3067,7 @@
                 <minimum>0.5</minimum>
             </output>
             <output>
-                <group>[Sampler12]</group>
+                <group>[Sampler8]</group>
                 <key>track_loaded</key>
                 <status>0x99</status>
                 <midino>0x33</midino>
@@ -3143,7 +3143,7 @@
                 <minimum>0.5</minimum>
             </output>
             <output>
-                <group>[Sampler5]</group>
+                <group>[Sampler9]</group>
                 <key>track_loaded</key>
                 <status>0x98</status>
                 <midino>0x34</midino>
@@ -3151,7 +3151,7 @@
                 <minimum>0.5</minimum>
             </output>
             <output>
-                <group>[Sampler6]</group>
+                <group>[Sampler10]</group>
                 <key>track_loaded</key>
                 <status>0x98</status>
                 <midino>0x35</midino>
@@ -3159,7 +3159,7 @@
                 <minimum>0.5</minimum>
             </output>
             <output>
-                <group>[Sampler7]</group>
+                <group>[Sampler11]</group>
                 <key>track_loaded</key>
                 <status>0x98</status>
                 <midino>0x36</midino>
@@ -3167,7 +3167,7 @@
                 <minimum>0.5</minimum>
             </output>
             <output>
-                <group>[Sampler8]</group>
+                <group>[Sampler12]</group>
                 <key>track_loaded</key>
                 <status>0x98</status>
                 <midino>0x37</midino>
@@ -3179,7 +3179,7 @@
             <!-- Deck 2 pads -->
 
             <output>
-                <group>[Sampler9]</group>
+                <group>[Sampler5]</group>
                 <key>track_loaded</key>
                 <status>0x9A</status>
                 <midino>0x30</midino>
@@ -3187,7 +3187,7 @@
                 <minimum>0.5</minimum>
             </output>
             <output>
-                <group>[Sampler10]</group>
+                <group>[Sampler6]</group>
                 <key>track_loaded</key>
                 <status>0x9A</status>
                 <midino>0x31</midino>
@@ -3195,7 +3195,7 @@
                 <minimum>0.5</minimum>
             </output>
             <output>
-                <group>[Sampler11]</group>
+                <group>[Sampler7]</group>
                 <key>track_loaded</key>
                 <status>0x9A</status>
                 <midino>0x32</midino>
@@ -3203,7 +3203,7 @@
                 <minimum>0.5</minimum>
             </output>
             <output>
-                <group>[Sampler12]</group>
+                <group>[Sampler8]</group>
                 <key>track_loaded</key>
                 <status>0x9A</status>
                 <midino>0x33</midino>

--- a/res/controllers/Pioneer-DDJ-FLX4.midi.xml
+++ b/res/controllers/Pioneer-DDJ-FLX4.midi.xml
@@ -2065,7 +2065,7 @@
             </control>
             <control>
                 <description>PAD 5 (LEFT) SAMPLE MODE - press - Play Sample or Load Track</description>
-                <group>[Sampler5]</group>
+                <group>[Sampler9]</group>
                 <key>PioneerDDJFLX4.samplerPadPressed</key>
                 <status>0x97</status>
                 <midino>0x34</midino>
@@ -2075,7 +2075,7 @@
             </control>
             <control>
                 <description>PAD 5 (LEFT)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
-                <group>[Sampler5]</group>
+                <group>[Sampler9]</group>
                 <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
                 <status>0x98</status>
                 <midino>0x34</midino>
@@ -2085,7 +2085,7 @@
             </control>
             <control>
                 <description>PAD 6 (LEFT) SAMPLE MODE - press - Play Sample or Load Track</description>
-                <group>[Sampler6]</group>
+                <group>[Sampler10]</group>
                 <key>PioneerDDJFLX4.samplerPadPressed</key>
                 <status>0x97</status>
                 <midino>0x35</midino>
@@ -2095,7 +2095,7 @@
             </control>
             <control>
                 <description>PAD 6 (LEFT)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
-                <group>[Sampler6]</group>
+                <group>[Sampler10]</group>
                 <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
                 <status>0x98</status>
                 <midino>0x35</midino>
@@ -2105,7 +2105,7 @@
             </control>
             <control>
                 <description>PAD 7 (LEFT) SAMPLE MODE - press - Play Sample or Load Track</description>
-                <group>[Sampler7]</group>
+                <group>[Sampler11]</group>
                 <key>PioneerDDJFLX4.samplerPadPressed</key>
                 <status>0x97</status>
                 <midino>0x36</midino>
@@ -2115,7 +2115,7 @@
             </control>
             <control>
                 <description>PAD 7 (LEFT)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
-                <group>[Sampler7]</group>
+                <group>[Sampler11]</group>
                 <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
                 <status>0x98</status>
                 <midino>0x36</midino>
@@ -2125,7 +2125,7 @@
             </control>
             <control>
                 <description>PAD 8 (LEFT) SAMPLE MODE - press - Play Sample or Load Track</description>
-                <group>[Sampler8]</group>
+                <group>[Sampler12]</group>
                 <key>PioneerDDJFLX4.samplerPadPressed</key>
                 <status>0x97</status>
                 <midino>0x37</midino>
@@ -2135,7 +2135,7 @@
             </control>
             <control>
                 <description>PAD 8 (LEFT)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
-                <group>[Sampler8]</group>
+                <group>[Sampler12]</group>
                 <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
                 <status>0x98</status>
                 <midino>0x37</midino>
@@ -2147,7 +2147,7 @@
 
             <control>
                 <description>PAD 1 (RIGHT) SAMPLE MODE - press - Play Sample or Load Track</description>
-                <group>[Sampler9]</group>
+                <group>[Sampler5]</group>
                 <key>PioneerDDJFLX4.samplerPadPressed</key>
                 <status>0x99</status>
                 <midino>0x30</midino>
@@ -2157,7 +2157,7 @@
             </control>
             <control>
                 <description>PAD 1 (Right)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
-                <group>[Sampler9]</group>
+                <group>[Sampler5]</group>
                 <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
                 <status>0x9A</status>
                 <midino>0x30</midino>
@@ -2167,7 +2167,7 @@
             </control>
             <control>
                 <description>PAD 2 (RIGHT) SAMPLE MODE - press - Play Sample or Load Track</description>
-                <group>[Sampler10]</group>
+                <group>[Sampler6]</group>
                 <key>PioneerDDJFLX4.samplerPadPressed</key>
                 <status>0x99</status>
                 <midino>0x31</midino>
@@ -2177,7 +2177,7 @@
             </control>
             <control>
                 <description>PAD 2 (Right)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
-                <group>[Sampler10]</group>
+                <group>[Sampler6]</group>
                 <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
                 <status>0x9A</status>
                 <midino>0x31</midino>
@@ -2187,7 +2187,7 @@
             </control>
             <control>
                 <description>PAD 3 (RIGHT) SAMPLE MODE - press - Play Sample or Load Track</description>
-                <group>[Sampler11]</group>
+                <group>[Sampler7]</group>
                 <key>PioneerDDJFLX4.samplerPadPressed</key>
                 <status>0x99</status>
                 <midino>0x32</midino>
@@ -2197,7 +2197,7 @@
             </control>
             <control>
                 <description>PAD 3 (Right)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
-                <group>[Sampler11]</group>
+                <group>[Sampler7]</group>
                 <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
                 <status>0x9A</status>
                 <midino>0x32</midino>
@@ -2207,7 +2207,7 @@
             </control>
             <control>
                 <description>PAD 4 (RIGHT) SAMPLE MODE - press - Play Sample or Load Track</description>
-                <group>[Sampler12]</group>
+                <group>[Sampler8]</group>
                 <key>PioneerDDJFLX4.samplerPadPressed</key>
                 <status>0x99</status>
                 <midino>0x33</midino>
@@ -2217,7 +2217,7 @@
             </control>
             <control>
                 <description>PAD 4 (Right)+SHIFT SAMPLE MODE - press - Stop Playback or Eject Track</description>
-                <group>[Sampler12]</group>
+                <group>[Sampler8]</group>
                 <key>PioneerDDJFLX4.samplerPadShiftPressed</key>
                 <status>0x9A</status>
                 <midino>0x33</midino>

--- a/res/controllers/Pioneer-DDJ-FLX4.midi.xml
+++ b/res/controllers/Pioneer-DDJ-FLX4.midi.xml
@@ -998,7 +998,7 @@
             <!-- BEAT FX SECTION START -->
 
             <control>
-              <description>BEAT FX SELECT - press once - select effect unit 1</description>
+              <description>BEAT FX SELECT - press once - select next effect</description>
                 <group>[EffectRack1_EffectUnit1]</group>
                 <key>PioneerDDJFLX4.beatFxSelectPressed</key>
                 <status>0x94</status>
@@ -1007,9 +1007,19 @@
                     <Script-Binding/>
                 </options>
             </control>
+            <control>
+              <description>BEAT FX SELECT + shift - press once - select previous effect</description>
+                <group>[EffectRack1_EffectUnit1]</group>
+                <key>PioneerDDJFLX4.beatFxSelectShiftPressed</key>
+                <status>0x94</status>
+                <midino>0x64</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
 
             <control>
-                <description>BEAT LEFT - press - select effect unit 2</description>
+                <description>BEAT LEFT - press - select previous effect unit</description>
                 <group>[EffectRack1_EffectUnit1]</group>
                 <key>PioneerDDJFLX4.beatFxLeftPressed</key>
                 <status>0x94</status>
@@ -1018,33 +1028,13 @@
                     <Script-Binding/>
                 </options>
             </control>
-            <control>
-                <description>BEAT LEFT + shift - select previous effect for the current unit</description>
-                <group>[EffectRack1_EffectUnit1]</group>
-                <key>PioneerDDJFLX4.beatFxSelectPreviousEffect</key>
-                <status>0x94</status>
-                <midino>0x66</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
 
             <control>
-                <description>BEAT RIGHT - press - select effect unit 3</description>
+                <description>BEAT RIGHT - press - select next effect unit</description>
                 <group>[EffectRack1_EffectUnit1]</group>
                 <key>PioneerDDJFLX4.beatFxRightPressed</key>
                 <status>0x94</status>
                 <midino>0x4B</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>BEAT RIGHT + shift - select next effect for the current unit</description>
-                <group>[EffectRack1_EffectUnit1]</group>
-                <key>PioneerDDJFLX4.beatFxSelectNextEffect</key>
-                <status>0x94</status>
-                <midino>0x6B</midino>
                 <options>
                     <Script-Binding/>
                 </options>

--- a/res/controllers/Pioneer-DDJ-FLX4.midi.xml
+++ b/res/controllers/Pioneer-DDJ-FLX4.midi.xml
@@ -1107,7 +1107,7 @@
             </control>
             <!-- BEAT FX SECTION END-->
             <!-- EFFECT Section END -->
-			
+
 			<!-- PAD MODE SECTION START -->
             <control>
                 <description>HOT CUE MODE (DECK1) - press - set hotcue mode</description>


### PR DESCRIPTION
Mapping for the Pioneer DDJ-FLX4 controller.

It has been based on the DDJ-400, adapting some part to the new layout and buttons.
Mostly the FX part has been adapted and the lights indication the performance pad mode.

Separate PR for the manual is also proposed