### PR TITLE
eject: double click does 'un-replace', i.e. reloads the previous track

### DIFF
--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -203,7 +203,13 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             transportMenu);
     addDeckAndSamplerAndPreviewDeckControl("end", tr("Jump To End"), tr("Jump to end of track"), transportMenu);
     transportMenu->addSeparator();
-    addDeckAndSamplerAndPreviewDeckControl("eject", tr("Eject"), tr("Eject track"), transportMenu);
+    addDeckAndSamplerAndPreviewDeckControl("eject",
+            tr("Eject"),
+            tr("Eject or un-eject track, i.e. reload the last-ejected track "
+               "(of any deck)<br>"
+               "Double-press to reload the last replaced track. In empty decks "
+               "it reloads the second-last ejected track."),
+            transportMenu);
     addDeckAndSamplerControl("repeat", tr("Repeat Mode"), tr("Toggle repeat mode"), transportMenu);
     addDeckAndSamplerControl("slip_enabled", tr("Slip Mode"), tr("Toggle slip mode"), transportMenu);
 

--- a/src/controllers/dlgcontrollerlearning.cpp
+++ b/src/controllers/dlgcontrollerlearning.cpp
@@ -25,6 +25,7 @@ DlgControllerLearning::DlgControllerLearning(QWidget* parent,
     qRegisterMetaType<MidiInputMappings>("MidiInputMappings");
 
     setupUi(this);
+    labelDescription->setWordWrap(true);
     labelMappedTo->setText("");
 
     QString helpTitle(tr("Click anywhere in Mixxx or choose a control to learn"));

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -316,7 +316,7 @@ void BaseTrackPlayerImpl::slotEjectTrack(double v) {
 
     // Double-click always restores the last replaced track, i.e. un-eject the second
     // last track: the first click ejects or unejects, and the second click reloads.
-    if (elapsed < mixxx::Duration::fromSeconds(0.5)) {
+    if (elapsed < mixxx::Duration::fromMillis(kUnreplaceDelay)) {
         TrackPointer lastEjected = m_pPlayerManager->getSecondLastEjectedTrack();
         if (lastEjected) {
             slotLoadTrack(lastEjected, false);

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -207,6 +207,8 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
             ConfigKey(getGroup(), "update_replaygain_from_pregain"));
     m_pUpdateReplayGainFromPregain->connectValueChangeRequest(this,
             &BaseTrackPlayerImpl::slotUpdateReplayGainFromPregain);
+
+    m_ejectTimer.start();
 }
 
 BaseTrackPlayerImpl::~BaseTrackPlayerImpl() {
@@ -309,6 +311,20 @@ void BaseTrackPlayerImpl::slotEjectTrack(double v) {
     if (v <= 0) {
         return;
     }
+
+    mixxx::Duration elapsed = m_ejectTimer.restart();
+
+    // Double-click always restores the last replaced track, i.e. un-eject the second
+    // last track: the first click ejects or unejects, and the second click reloads.
+    if (elapsed < mixxx::Duration::fromSeconds(0.5)) {
+        TrackPointer lastEjected = m_pPlayerManager->getSecondLastEjectedTrack();
+        if (lastEjected) {
+            slotLoadTrack(lastEjected, false);
+        }
+        return;
+    }
+
+    // With no loaded track a single click reloads the last ejected track.
     if (!m_pLoadedTrack) {
         TrackPointer lastEjected = m_pPlayerManager->getLastEjectedTrack();
         if (lastEjected) {

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -123,6 +123,8 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     bool m_replaygainPending;
     EngineChannel* m_pChannelToCloneFrom;
 
+    PerformanceTimer m_ejectTimer;
+
     std::unique_ptr<ControlPushButton> m_pEject;
 
     // Deck clone control

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -21,6 +21,8 @@ class ControlPotmeter;
 class ControlProxy;
 class EffectsManager;
 
+constexpr int kUnreplaceDelay = 500;
+
 // Interface for not leaking implementation details of BaseTrackPlayer into the
 // rest of Mixxx. Also makes testing a lot easier.
 class BaseTrackPlayer : public BasePlayer {

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -608,6 +608,13 @@ TrackPointer PlayerManager::getLastEjectedTrack() const {
     return nullptr;
 }
 
+TrackPointer PlayerManager::getSecondLastEjectedTrack() const {
+    if (m_pLibrary) {
+        return m_pLibrary->trackCollectionManager()->getTrackById(m_secondLastEjectedTrackId);
+    }
+    return nullptr;
+}
+
 Microphone* PlayerManager::getMicrophone(unsigned int microphone) const {
     const auto locker = lockMutex(&m_mutex);
     if (microphone < 1 || microphone >= static_cast<unsigned int>(m_microphones.size())) {
@@ -772,7 +779,12 @@ void PlayerManager::slotSaveEjectedTrack(TrackPointer track) {
     VERIFY_OR_DEBUG_ASSERT(track) {
         return;
     }
-    m_lastEjectedTrackId = track->getId();
+    const TrackId id = track->getId();
+    if (id == m_lastEjectedTrackId) {
+        return;
+    }
+    m_secondLastEjectedTrackId = m_lastEjectedTrackId;
+    m_lastEjectedTrackId = id;
 }
 
 void PlayerManager::onTrackAnalysisProgress(TrackId trackId, AnalyzerProgress analyzerProgress) {

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -602,17 +602,17 @@ Sampler* PlayerManager::getSampler(unsigned int sampler) const {
 }
 
 TrackPointer PlayerManager::getLastEjectedTrack() const {
-    if (m_pLibrary) {
-        return m_pLibrary->trackCollectionManager()->getTrackById(m_lastEjectedTrackId);
+    VERIFY_OR_DEBUG_ASSERT(m_pLibrary != nullptr) {
+        return nullptr;
     }
-    return nullptr;
+    return m_pLibrary->trackCollectionManager()->getTrackById(m_lastEjectedTrackId);
 }
 
 TrackPointer PlayerManager::getSecondLastEjectedTrack() const {
-    if (m_pLibrary) {
-        return m_pLibrary->trackCollectionManager()->getTrackById(m_secondLastEjectedTrackId);
+    VERIFY_OR_DEBUG_ASSERT(m_pLibrary != nullptr) {
+        return nullptr;
     }
-    return nullptr;
+    return m_pLibrary->trackCollectionManager()->getTrackById(m_secondLastEjectedTrackId);
 }
 
 Microphone* PlayerManager::getMicrophone(unsigned int microphone) const {

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -130,6 +130,7 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     // Returns the track that was last ejected or unloaded. Can return nullptr or
     // invalid TrackId in case of error.
     TrackPointer getLastEjectedTrack() const;
+    TrackPointer getSecondLastEjectedTrack() const;
 
     // Get the microphone by its number. Microphones are numbered starting with 1.
     Microphone* getMicrophone(unsigned int microphone) const;
@@ -285,6 +286,7 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
 
     TrackAnalysisScheduler::Pointer m_pTrackAnalysisScheduler;
 
+    TrackId m_secondLastEjectedTrackId;
     TrackId m_lastEjectedTrackId;
 
     QList<Deck*> m_decks;

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -619,9 +619,13 @@ void Tooltips::addStandardTooltips() {
             << tr("Repeat")
             << tr("When active the track will repeat if you go past the end or reverse before the start.");
 
-    add("eject")
-            << tr("Eject")
-            << tr("Ejects track from the player.");
+    add("eject") << tr("Eject") << tr("Ejects track from the player.")
+                 << tr("Un-ejects when no track is loaded, i.e. reloads the "
+                       "track that was ejected last (of any deck).")
+                 << QString("%1: %2").arg(doubleClick,
+                            "Reloads the last replaced track. "
+                            "If no track is loaded reloads the second-last "
+                            "ejected track.");
 
     add("hotcue") << tr("Hotcue")
                   << QString("%1: %2").arg(leftClick,

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -1344,7 +1344,6 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     auto pButtonSyncEnabled2 =
             std::make_unique<ControlProxy>(m_sGroup2, "sync_enabled");
-    auto pButtonEject1 = std::make_unique<ControlProxy>(m_sGroup1, "eject");
 
     mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
             m_pTrack1->getSampleRate(), mixxx::audio::kStartFramePos, mixxx::Bpm(120));
@@ -1357,7 +1356,7 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
     EXPECT_TRUE(isSoftLeader(m_sGroup1));
     assertSyncOff(m_sGroup2);
 
-    pButtonEject1->set(1.0);
+    m_pChannel1->getEngineBuffer()->ejectTrack();
     // When an eject happens, the bpm gets set to zero.
     ProcessBuffer();
 
@@ -1382,7 +1381,7 @@ TEST_F(EngineSyncTest, EjectTrackSyncRemains) {
     EXPECT_TRUE(isSoftLeader(m_sGroup1));
     EXPECT_TRUE(isFollower(m_sGroup2));
 
-    pButtonEject1->set(1.0);
+    m_pChannel1->getEngineBuffer()->ejectTrack();
     m_pTrack1->trySetBeats(mixxx::BeatsPointer());
     ProcessBuffer();
 

--- a/src/test/playermanagertest.cpp
+++ b/src/test/playermanagertest.cpp
@@ -132,7 +132,7 @@ TEST_F(PlayerManagerTest, UnEjectTest) {
     }
     // make sure eject does not trigger 'unreplace':
     // sleep for longer than 500 ms 'unreplace' period so this is not registered as double-click
-    QTest::qSleep(500); // millis
+    QTest::qSleep(kUnreplaceDelay); // millis
     deck1->slotEjectTrack(1.0);
 
     // Load another track.
@@ -144,7 +144,7 @@ TEST_F(PlayerManagerTest, UnEjectTest) {
     auto deck2 = m_pPlayerManager->getDeck(2);
     ASSERT_EQ(nullptr, deck2->getLoadedTrack());
     // make sure eject does not trigger 'unreplace'
-    QTest::qSleep(500); // millis
+    QTest::qSleep(kUnreplaceDelay); // millis
     deck2->slotEjectTrack(2.0);
     ASSERT_NE(nullptr, deck2->getLoadedTrack());
     ASSERT_EQ(testId1, deck2->getLoadedTrack()->getId());
@@ -180,7 +180,7 @@ TEST_F(PlayerManagerTest, UnEjectReplaceTrackTest) {
     auto deck2 = m_pPlayerManager->getDeck(2);
     ASSERT_EQ(nullptr, deck2->getLoadedTrack());
     // make sure eject does not trigger 'unreplace'
-    QTest::qSleep(500);
+    QTest::qSleep(kUnreplaceDelay);
     deck2->slotEjectTrack(1.0);
     ASSERT_NE(nullptr, deck2->getLoadedTrack());
     ASSERT_EQ(testId1, deck2->getLoadedTrack()->getId());
@@ -194,7 +194,7 @@ TEST_F(PlayerManagerTest, UnEjectInvalidTrackIdTest) {
     auto deck1 = m_pPlayerManager->getDeck(1);
     // Does nothing -- no crash.
     // make sure eject does not trigger 'unreplace'
-    QTest::qSleep(500);
+    QTest::qSleep(kUnreplaceDelay);
     deck1->slotEjectTrack(1.0);
     ASSERT_EQ(nullptr, deck1->getLoadedTrack());
 }
@@ -226,7 +226,7 @@ TEST_F(PlayerManagerTest, UnReplaceTest) {
 
     // Eject. Make sure eject does not trigger 'unreplace':
     // sleep for longer than 500 ms 'unreplace' period so this is not registered as double-click
-    QTest::qSleep(500); // millis
+    QTest::qSleep(kUnreplaceDelay); // millis
     deck1->slotEjectTrack(1.0);
     ASSERT_EQ(nullptr, deck1->getLoadedTrack());
 

--- a/src/test/playermanagertest.cpp
+++ b/src/test/playermanagertest.cpp
@@ -27,6 +27,12 @@ void deleteTrack(Track* pTrack) {
     delete pTrack;
 };
 
+void waitForTrackToBeLoaded(Deck* pDeck) {
+    while (!pDeck->getEngineDeck()->getEngineBuffer()->isTrackLoaded()) {
+        QTest::qSleep(100); // millis
+    }
+}
+
 } // namespace
 
 // We can't inherit from LibraryTest because that creates a key_notation control object that is also
@@ -127,9 +133,7 @@ TEST_F(PlayerManagerTest, UnEjectTest) {
     ASSERT_NE(nullptr, deck1->getLoadedTrack());
 
     m_pEngine->process(1024);
-    while (!deck1->getEngineDeck()->getEngineBuffer()->isTrackLoaded()) {
-        QTest::qSleep(100); // millis
-    }
+    waitForTrackToBeLoaded(deck1);
     // make sure eject does not trigger 'unreplace':
     // sleep for longer than 500 ms 'unreplace' period so this is not registered as double-click
     QTest::qSleep(kUnreplaceDelay); // millis
@@ -163,18 +167,14 @@ TEST_F(PlayerManagerTest, UnEjectReplaceTrackTest) {
     ASSERT_NE(nullptr, deck1->getLoadedTrack());
 
     m_pEngine->process(1024);
-    while (!deck1->getEngineDeck()->getEngineBuffer()->isTrackLoaded()) {
-        QTest::qSleep(100); // millis
-    }
+    waitForTrackToBeLoaded(deck1);
 
     // Load another track, replacing the first, causing it to be unloaded.
     TrackPointer pTrack2 = getOrAddTrackByLocation(getTestDir().filePath(kTrackLocationTest2));
     ASSERT_NE(nullptr, pTrack2);
     deck1->slotLoadTrack(pTrack2, false);
     m_pEngine->process(1024);
-    while (!deck1->getEngineDeck()->getEngineBuffer()->isTrackLoaded()) {
-        QTest::qSleep(100); // millis
-    }
+    waitForTrackToBeLoaded(deck1);
 
     // Ejecting in an empty deck loads the last-ejected track.
     auto deck2 = m_pPlayerManager->getDeck(2);
@@ -209,9 +209,7 @@ TEST_F(PlayerManagerTest, UnReplaceTest) {
     ASSERT_TRUE(testId1.isValid());
     deck1->slotLoadTrack(pTrack1, false);
     m_pEngine->process(1024);
-    while (!deck1->getEngineDeck()->getEngineBuffer()->isTrackLoaded()) {
-        QTest::qSleep(100); // millis
-    }
+    waitForTrackToBeLoaded(deck1);
     ASSERT_NE(nullptr, deck1->getLoadedTrack());
 
     // Load another track.
@@ -219,9 +217,7 @@ TEST_F(PlayerManagerTest, UnReplaceTest) {
     ASSERT_NE(nullptr, pTrack2);
     deck1->slotLoadTrack(pTrack2, false);
     m_pEngine->process(1024);
-    while (!deck1->getEngineDeck()->getEngineBuffer()->isTrackLoaded()) {
-        QTest::qSleep(100); // millis
-    }
+    waitForTrackToBeLoaded(deck1);
     ASSERT_NE(nullptr, deck1->getLoadedTrack());
 
     // Eject. Make sure eject does not trigger 'unreplace':

--- a/src/test/playermanagertest.cpp
+++ b/src/test/playermanagertest.cpp
@@ -130,6 +130,9 @@ TEST_F(PlayerManagerTest, UnEjectTest) {
     while (!deck1->getEngineDeck()->getEngineBuffer()->isTrackLoaded()) {
         QTest::qSleep(100); // millis
     }
+    // make sure eject does not trigger 'unreplace':
+    // sleep for longer than 500 ms 'unreplace' period so this is not registered as double-click
+    QTest::qSleep(500); // millis
     deck1->slotEjectTrack(1.0);
 
     // Load another track.
@@ -140,6 +143,8 @@ TEST_F(PlayerManagerTest, UnEjectTest) {
     // Ejecting in an empty deck loads the last-ejected track.
     auto deck2 = m_pPlayerManager->getDeck(2);
     ASSERT_EQ(nullptr, deck2->getLoadedTrack());
+    // make sure eject does not trigger 'unreplace'
+    QTest::qSleep(500); // millis
     deck2->slotEjectTrack(2.0);
     ASSERT_NE(nullptr, deck2->getLoadedTrack());
     ASSERT_EQ(testId1, deck2->getLoadedTrack()->getId());
@@ -174,6 +179,8 @@ TEST_F(PlayerManagerTest, UnEjectReplaceTrackTest) {
     // Ejecting in an empty deck loads the last-ejected track.
     auto deck2 = m_pPlayerManager->getDeck(2);
     ASSERT_EQ(nullptr, deck2->getLoadedTrack());
+    // make sure eject does not trigger 'unreplace'
+    QTest::qSleep(500);
     deck2->slotEjectTrack(1.0);
     ASSERT_NE(nullptr, deck2->getLoadedTrack());
     ASSERT_EQ(testId1, deck2->getLoadedTrack()->getId());
@@ -186,6 +193,8 @@ TEST_F(PlayerManagerTest, UnEjectInvalidTrackIdTest) {
     m_pPlayerManager->slotSaveEjectedTrack(pTrack);
     auto deck1 = m_pPlayerManager->getDeck(1);
     // Does nothing -- no crash.
+    // make sure eject does not trigger 'unreplace'
+    QTest::qSleep(500);
     deck1->slotEjectTrack(1.0);
     ASSERT_EQ(nullptr, deck1->getLoadedTrack());
 }


### PR DESCRIPTION
follow-up for Un-eject #4668

~~Long-press eject (> 800 ms) to reload the previous track.~~

Double-press (< 500 ms) Eject to reload the last replaced track.

Like uneject this works across decks (restore a replaced track in another deck).

TODO

- [x] adjust tests
