### PR TITLE
Fix search for year 

### DIFF
--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -62,10 +62,7 @@ QVariant getTrackValueForColumn(const TrackPointer& pTrack, const QString& colum
     return QVariant();
 }
 
-} // namespace
-
-//static
-QString QueryNode::concatSqlClauses(
+QString concatSqlClauses(
         const QStringList& sqlClauses, const QString& sqlConcatOp) {
     switch (sqlClauses.size()) {
     case 0:
@@ -79,6 +76,8 @@ QString QueryNode::concatSqlClauses(
         return "(" % sqlClauses.join(") " % sqlConcatOp % " (") % ")";
     }
 }
+
+} // namespace
 
 bool AndNode::match(const TrackPointer& pTrack) const {
     for (const auto& pNode: m_nodes) {

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -10,6 +10,8 @@
 #include "util/db/dbconnection.h"
 #include "util/db/sqllikewildcards.h"
 
+namespace {
+
 QVariant getTrackValueForColumn(const TrackPointer& pTrack, const QString& column) {
     if (column == LIBRARYTABLE_ARTIST) {
         return pTrack->getArtist();
@@ -59,6 +61,8 @@ QVariant getTrackValueForColumn(const TrackPointer& pTrack, const QString& colum
 
     return QVariant();
 }
+
+} // namespace
 
 //static
 QString QueryNode::concatSqlClauses(

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -371,12 +371,10 @@ QString NumericFilterNode::toSql() const {
     if (m_bRangeQuery) {
         QStringList searchClauses;
         for (const auto& sqlColumn: m_sqlColumns) {
-            QStringList rangeClauses;
-            rangeClauses << QString("%1 >= %2").arg(
-                    sqlColumn, QString::number(m_dRangeLow));
-            rangeClauses << QString("%1 <= %2").arg(
-                    sqlColumn, QString::number(m_dRangeHigh));
-            searchClauses << concatSqlClauses(rangeClauses, "AND");
+            searchClauses << QString(QStringLiteral("%1 BETWEEN %2 AND %3"))
+                                     .arg(sqlColumn,
+                                             QString::number(m_dRangeLow),
+                                             QString::number(m_dRangeHigh));
         }
         return concatSqlClauses(searchClauses, "OR");
     }
@@ -486,8 +484,7 @@ QString YearFilterNode::toSql() const {
     if (m_bRangeQuery) {
         QStringList rangeClauses;
         return QString(
-                QStringLiteral("(CAST(substr(year,1,4) AS INTEGER) >= %1) AND "
-                               "(CAST(substr(year,1,4) AS INTEGER) <= %2)"))
+                QStringLiteral("CAST(substr(year,1,4) AS INTEGER) BETWEEN %1 AND %2"))
                 .arg(QString::number(m_dRangeLow),
                         QString::number(m_dRangeHigh));
     }

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -73,7 +73,10 @@ QString concatSqlClauses(
         // The component terms need to be wrapped into parentheses,
         // but the whole expression does not. The composite node is
         // always responsible for proper wrapping into parentheses!
-        return "(" % sqlClauses.join(") " % sqlConcatOp % " (") % ")";
+        return QChar('(') +
+                sqlClauses.join(
+                        QStringLiteral(") ") + sqlConcatOp + QStringLiteral(" (")) +
+                QChar(')');
     }
 }
 

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -466,3 +466,31 @@ QString KeyFilterNode::toSql() const {
     }
     return concatSqlClauses(searchClauses, "OR");
 }
+
+YearFilterNode::YearFilterNode(
+        const QStringList& sqlColumns, const QString& argument)
+        : NumericFilterNode(sqlColumns, argument) {
+}
+
+QString YearFilterNode::toSql() const {
+    if (m_bNullQuery) {
+        return QStringLiteral("year IS NULL");
+    }
+
+    if (m_bOperatorQuery) {
+        return QString(
+                QStringLiteral("CAST(substr(year,1,4) AS INTEGER) %1 %2"))
+                .arg(m_operator, QString::number(m_dOperatorArgument));
+    }
+
+    if (m_bRangeQuery) {
+        QStringList rangeClauses;
+        return QString(
+                QStringLiteral("(CAST(substr(year,1,4) AS INTEGER) >= %1) AND "
+                               "(CAST(substr(year,1,4) AS INTEGER) <= %2)"))
+                .arg(QString::number(m_dRangeLow),
+                        QString::number(m_dRangeHigh));
+    }
+
+    return QString();
+}

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -22,7 +22,9 @@ QVariant getTrackValueForColumn(const TrackPointer& pTrack, const QString& colum
     } else if (column == LIBRARYTABLE_ALBUMARTIST) {
         return pTrack->getAlbumArtist();
     } else if (column == LIBRARYTABLE_YEAR) {
-        return pTrack->getYear();
+        // We use only the year that is part of the first four digits
+        // In all possible formats.
+        return pTrack->getYear().left(4);
     } else if (column == LIBRARYTABLE_DATETIMEADDED) {
         return pTrack->getDateAdded();
     } else if (column == LIBRARYTABLE_GENRE) {

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -17,8 +17,6 @@
 
 const QString kMissingFieldSearchTerm = "\"\""; // "" searches for an empty string
 
-QVariant getTrackValueForColumn(const TrackPointer& pTrack, const QString& column);
-
 class QueryNode {
   public:
     QueryNode(const QueryNode&) = delete; // prevent copying

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -147,7 +147,6 @@ class NumericFilterNode : public QueryNode {
     // derived classes.
     void init(QString argument);
 
-  private:
     virtual double parse(const QString& arg, bool *ok);
 
     QStringList m_sqlColumns;
@@ -213,5 +212,10 @@ class SqlNode : public QueryNode {
     QString m_sql;
 };
 
+class YearFilterNode : public NumericFilterNode {
+  public:
+    YearFilterNode(const QStringList& sqlColumns, const QString& argument);
+    QString toSql() const override;
+};
 
 #endif /* SEARCHQUERY_H */

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -27,8 +27,6 @@ class QueryNode {
 
   protected:
     QueryNode() {}
-
-    static QString concatSqlClauses(const QStringList& sqlClauses, const QString& sqlConcatOp);
 };
 
 class GroupNode : public QueryNode {

--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -19,13 +19,13 @@ SearchQueryParser::SearchQueryParser(TrackCollection* pTrackCollection)
                   << "comment"
                   << "location"
                   << "crate";
-    m_numericFilters << "year"
-                     << "track"
+    m_numericFilters << "track"
                      << "bpm"
                      << "played"
                      << "rating"
                      << "bitrate";
-    m_specialFilters << "key"
+    m_specialFilters << "year"
+                     << "key"
                      << "duration"
                      << "added"
                      << "dateadded"
@@ -204,10 +204,13 @@ void SearchQueryParser::parseTokens(QStringList tokens,
                 } else if (field == "duration") {
                     pNode = std::make_unique<DurationFilterNode>(
                             m_fieldToSqlColumns[field], argument);
+                } else if (field == "year") {
+                    pNode = std::make_unique<YearFilterNode>(
+                            m_fieldToSqlColumns[field], argument);
                 } else if (field == "date_added" ||
-                           field == "datetime_added" ||
-                           field == "added" ||
-                           field == "dateadded") {
+                        field == "datetime_added" ||
+                        field == "added" ||
+                        field == "dateadded") {
                     field = "datetime_added";
                     pNode = std::make_unique<TextFilterNode>(
                         m_pTrackCollection->database(), m_fieldToSqlColumns[field], argument);

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -521,8 +521,8 @@ TEST_F(SearchQueryParserTest, NumericRangeFilter) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("(bpm >= 127.12) AND (bpm <= 129)")),
-        qPrintable(pQuery->toSql()));
+            qPrintable(QString("bpm BETWEEN 127.12 AND 129")),
+            qPrintable(pQuery->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, MultipleFilters) {
@@ -542,11 +542,12 @@ TEST_F(SearchQueryParserTest, MultipleFilters) {
     pTrack->setTitle("Colorvision");
     EXPECT_TRUE(pQuery->match(pTrack));
 
-    EXPECT_STREQ(
-        qPrintable(QString("((bpm >= 127.12) AND (bpm <= 129)) AND "
-                           "((artist LIKE '%com truise%') OR (album_artist LIKE '%com truise%')) AND "
-                           "((artist LIKE '%colorvision%') OR (title LIKE '%colorvision%'))")),
-        qPrintable(pQuery->toSql()));
+    EXPECT_STREQ(qPrintable(QString("(bpm BETWEEN 127.12 AND 129) AND "
+                                    "((artist LIKE '%com truise%') OR "
+                                    "(album_artist LIKE '%com truise%')) AND "
+                                    "((artist LIKE '%colorvision%') OR (title "
+                                    "LIKE '%colorvision%'))")),
+            qPrintable(pQuery->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, ExtraFilterAppended) {
@@ -722,8 +723,8 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithRangeFilter) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("(duration >= 150) AND (duration <= 200)")),
-        qPrintable(pQuery->toSql()));
+            qPrintable(QString("duration BETWEEN 150 AND 200")),
+            qPrintable(pQuery->toSql()));
 
     pQuery = m_parser.parseQuery("duration:2:30-200", searchColumns, "");
     pTrack->setDuration(80);
@@ -734,8 +735,8 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithRangeFilter) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("(duration >= 150) AND (duration <= 200)")),
-        qPrintable(pQuery->toSql()));
+            qPrintable(QString("duration BETWEEN 150 AND 200")),
+            qPrintable(pQuery->toSql()));
 
     pQuery = m_parser.parseQuery("duration:150-200", searchColumns, "");
     pTrack->setDuration(80);
@@ -746,8 +747,8 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithRangeFilter) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("(duration >= 150) AND (duration <= 200)")),
-        qPrintable(pQuery->toSql()));
+            qPrintable(QString("duration BETWEEN 150 AND 200")),
+            qPrintable(pQuery->toSql()));
 
     pQuery = m_parser.parseQuery("duration:2m30s-3m20s", searchColumns, "");
     pTrack->setDuration(80);
@@ -758,8 +759,8 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithRangeFilter) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("(duration >= 150) AND (duration <= 200)")),
-        qPrintable(pQuery->toSql()));
+            qPrintable(QString("duration BETWEEN 150 AND 200")),
+            qPrintable(pQuery->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, CrateFilter) {

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -382,6 +382,27 @@ TEST_F(SearchQueryParserTest, NumericFilter) {
         qPrintable(pQuery->toSql()));
 }
 
+TEST_F(SearchQueryParserTest, NumericFilterYear) {
+    QStringList searchColumns;
+    searchColumns << "year";
+
+    auto pQuery(
+            m_parser.parseQuery("year:1969", searchColumns, ""));
+
+    TrackPointer pTrack = newTestTrack(44100);
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->setYear(" 1969-08-15 ");
+    EXPECT_TRUE(pQuery->match(pTrack));
+    pTrack->setYear(" 19690815 ");
+    EXPECT_TRUE(pQuery->match(pTrack));
+    pTrack->setYear(" 1969-extra ");
+    EXPECT_TRUE(pQuery->match(pTrack));
+
+    EXPECT_STREQ(
+            qPrintable(QStringLiteral("CAST(substr(year,1,4) AS INTEGER) = 1969")),
+            qPrintable(pQuery->toSql()));
+}
+
 TEST_F(SearchQueryParserTest, NumericFilterEmpty) {
     QStringList searchColumns;
     searchColumns << "artist"

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -391,6 +391,7 @@ TEST_F(SearchQueryParserTest, NumericFilterYear) {
 
     TrackPointer pTrack = newTestTrack(44100);
     EXPECT_FALSE(pQuery->match(pTrack));
+    // Note: The sourounding spaces are checking that a user input is popperly trimmed.
     pTrack->setYear(" 1969-08-15 ");
     EXPECT_TRUE(pQuery->match(pTrack));
     pTrack->setYear(" 19690815 ");

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -154,6 +154,11 @@ class Track : public QObject {
     QString getAlbumArtist() const;
     void setAlbumArtist(const QString&);
 
+    // Returns the content of the year library column.
+    // This was original only the four digit (gregorian) calendar year of the release date
+    // but allows to store any user string. Now it is altenatively used as
+    // recording date/time in the ISO 8601 yyyy-MM-ddTHH:mm:ss format tunkated at any point,
+    // following the TDRC ID3v2.4 frame or if not exists, TYER + TDAT.
     QString getYear() const;
     void setYear(const QString&);
 

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -80,7 +80,6 @@ class Track : public QObject {
     }
     // The (refreshed) canonical location
     QString getCanonicalLocation() const;
-    // Checks if the file exists
     bool checkFileExists() const {
         return m_fileInfo.checkFileExists();
     }
@@ -92,14 +91,10 @@ class Track : public QObject {
     // Get number of channels
     int getChannels() const;
 
-    // Get sample rate
     mixxx::audio::SampleRate getSampleRate() const;
 
-    // Sets the bitrate
     void setBitrate(int);
-    // Returns the bitrate
     int getBitrate() const;
-    // Returns the bitrate as a string
     QString getBitrateText() const;
 
     void setDuration(mixxx::Duration duration);
@@ -128,12 +123,10 @@ class Track : public QObject {
     // Sets the BPM if not locked.
     bool trySetBpm(double bpm);
 
-    // Returns BPM
     double getBpm() const {
         const QMutexLocker lock(&m_qMutex);
         return getBpmWhileLocked().getValue();
     }
-    // Returns BPM as a string
     QString getBpmText() const;
 
     // A track with a locked BPM will not be re-analyzed by the beats or bpm
@@ -141,9 +134,7 @@ class Track : public QObject {
     void setBpmLocked(bool bpmLocked);
     bool isBpmLocked() const;
 
-    // Set ReplayGain
     void setReplayGain(const mixxx::ReplayGain&);
-    // Returns ReplayGain
     mixxx::ReplayGain getReplayGain() const;
 
     // Indicates if the metadata has been parsed from file tags.
@@ -154,47 +145,29 @@ class Track : public QObject {
     void setDateAdded(const QDateTime& dateAdded);
     QDateTime getDateAdded() const;
 
-    // Getter/Setter methods for metadata
-    // Return title
     QString getTitle() const;
-    // Set title
     void setTitle(const QString&);
-    // Return artist
     QString getArtist() const;
-    // Set artist
     void setArtist(const QString&);
-    // Return album
     QString getAlbum() const;
-    // Set album
     void setAlbum(const QString&);
-    // Return album artist
     QString getAlbumArtist() const;
-    // Set album artist
     void setAlbumArtist(const QString&);
-    // Return Year
+
     QString getYear() const;
-    // Set year
     void setYear(const QString&);
-    // Return genre
+
     QString getGenre() const;
-    // Set genre
     void setGenre(const QString&);
-    // Returns the track color
     mixxx::RgbColor::optional_t getColor() const;
-    // Sets the track color
     void setColor(mixxx::RgbColor::optional_t);
-    // Returns the user comment
     QString getComment() const;
-    // Sets the user comment
     void setComment(const QString&);
-    // Return composer
     QString getComposer() const;
-    // Set composer
     void setComposer(const QString&);
-    // Return grouping
     QString getGrouping() const;
-    // Set grouping
     void setGrouping(const QString&);
+
     // Return track number/total
     QString getTrackNumber() const;
     QString getTrackTotal() const;
@@ -215,18 +188,13 @@ class Track : public QObject {
         return getPlayCounter().getTimesPlayed();
     }
 
-    // Returns rating
     int getRating() const;
-    // Sets rating
     void setRating(int);
-    /// Resets the rating
     void resetRating() {
         setRating(mixxx::TrackRecord::kNoRating);
     }
 
-    // Get URL for track
     QString getURL() const;
-    // Set URL for track
     void setURL(const QString& url);
 
     /// Separator between artist and title string that is
@@ -494,7 +462,7 @@ class Track : public QObject {
     // Storage for the track's beats
     mixxx::BeatsPointer m_pBeats;
 
-    //Visual waveform data
+    // Visual waveform data
     ConstWaveformPointer m_waveform;
     ConstWaveformPointer m_waveformSummary;
 


### PR DESCRIPTION
This PR fixes searching for year if it contains more detailed information like month and date. 
It is fixed by considering only the first four digits that likely contains the year in case of all possible formats. 
Now these formats are discovered:
    2022-12-06
    2022-05-19T07:00:00Z

Fixes https://github.com/mixxxdj/mixxx/issues/11113

A unittest is also in place. 
