### PR TITLE
Export All Playlists Feature

### DIFF
--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -620,14 +620,17 @@ void BasePlaylistFeature::slotExportPlaylist() {
 
 void BasePlaylistFeature::slotExportPlaylists() {
     const PlaylistDAO::HiddenType hidden = PlaylistDAO::PLHT_NOT_HIDDEN;
-    QList<QPair<int, QString>> test2 = m_playlistDao.getPlaylists(hidden);
 
     QList<QPair<int, QString>> allPlaylists = m_playlistDao.getPlaylists(hidden);
 
+    QPair<int, QString> thePair;
+    int playlistId;
+    QString playlistName;
+
     for (int i = 0; i < allPlaylists.length(); i++) {
-        QPair thePair = allPlaylists.at(i);
-        int playlistId = thePair.first;
-        QString playlistName = m_playlistDao.getPlaylistName(playlistId);
+        thePair = allPlaylists.at(i);
+        playlistId = thePair.first;
+        playlistName = m_playlistDao.getPlaylistName(playlistId);
 
         if (playlistId == kInvalidPlaylistId) {
             return;

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -535,11 +535,7 @@ void BasePlaylistFeature::slotCreateImportPlaylist() {
     activatePlaylist(lastPlaylistId);
 }
 
-void BasePlaylistFeature::slotExportPlaylist() {
-    int playlistId = playlistIdFromIndex(m_lastRightClickedIndex);
-    if (playlistId == kInvalidPlaylistId) {
-        return;
-    }
+void BasePlaylistFeature::exportPlaylistById(int playlistId) {
     QString playlistName = m_playlistDao.getPlaylistName(playlistId);
     // replace separator character with something generic
     playlistName = playlistName.replace(QDir::separator(), kUnsafeFilenameReplacement);
@@ -617,6 +613,14 @@ void BasePlaylistFeature::slotExportPlaylist() {
     }
 }
 
+void BasePlaylistFeature::slotExportPlaylist() {
+    int playlistId = playlistIdFromIndex(m_lastRightClickedIndex);
+    if (playlistId == kInvalidPlaylistId) {
+        return;
+    }
+    exportPlaylistByID(playlistId);
+}
+
 void BasePlaylistFeature::slotExportPlaylists() {
     QList<QPair<int, QString>> allPlaylists =
             m_playlistDao.getPlaylists(PlaylistDAO::PLHT_NOT_HIDDEN);
@@ -625,79 +629,7 @@ void BasePlaylistFeature::slotExportPlaylists() {
         if (playlistId == kInvalidPlaylistId) {
             return;
         }
-
-        qDebug() << "Export playlist" << playlistName;
-
-        QString lastPlaylistDirectory = m_pConfig->getValue(
-                kConfigKeyLastImportExportPlaylistDirectory,
-                QStandardPaths::writableLocation(QStandardPaths::MusicLocation));
-
-        // Open a dialog to let the user choose the file location for playlist export.
-        // The location is set to the last used directory for import/export and the file
-        // name to the playlist name.
-        const QString fileLocation = getFilePathWithVerifiedExtensionFromFileDialog(
-                tr("Export Playlist"),
-                lastPlaylistDirectory.append("/").append(playlistName).append(".m3u"),
-                tr("M3U Playlist (*.m3u);;M3U8 Playlist (*.m3u8);;"
-                   "PLS Playlist (*.pls);;Text CSV (*.csv);;Readable Text (*.txt)"),
-                tr("M3U Playlist (*.m3u)"));
-        // Exit method if the file name is empty because the user cancelled the save dialog.
-        if (fileLocation.isEmpty()) {
-            return;
-        }
-
-        // Update the import/export playlist directory
-        QString fileDirectory(fileLocation);
-        fileDirectory.truncate(fileLocation.lastIndexOf("/"));
-        m_pConfig->set(kConfigKeyLastImportExportPlaylistDirectory,
-                ConfigValue(fileDirectory));
-
-        // The user has picked a new directory via a file dialog. This means the
-        // system sandboxer (if we are sandboxed) has granted us permission to this
-        // folder. We don't need access to this file on a regular basis so we do not
-        // register a security bookmark.
-
-        // Create a new table model since the main one might have an active search.
-        // This will only export songs that we think exist on default
-        QScopedPointer<PlaylistTableModel> pPlaylistTableModel(
-                new PlaylistTableModel(this,
-                        m_pLibrary->trackCollectionManager(),
-                        "mixxx.db.model.playlist_export"));
-
-        emit saveModelState();
-        pPlaylistTableModel->setTableModel(m_pPlaylistTableModel->getPlaylist());
-        pPlaylistTableModel->setSort(
-                pPlaylistTableModel->fieldIndex(
-                        ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_POSITION),
-                Qt::AscendingOrder);
-        pPlaylistTableModel->select();
-
-        // check config if relative paths are desired
-        bool useRelativePath = m_pConfig->getValue<bool>(
-                kUseRelativePathOnExportConfigKey);
-
-        if (fileLocation.endsWith(".csv", Qt::CaseInsensitive)) {
-            ParserCsv::writeCSVFile(fileLocation, pPlaylistTableModel.data(), useRelativePath);
-        } else if (fileLocation.endsWith(".txt", Qt::CaseInsensitive)) {
-            if (m_playlistDao.getHiddenType(pPlaylistTableModel->getPlaylist()) ==
-                    PlaylistDAO::PLHT_SET_LOG) {
-                ParserCsv::writeReadableTextFile(fileLocation, pPlaylistTableModel.data(), true);
-            } else {
-                ParserCsv::writeReadableTextFile(fileLocation, pPlaylistTableModel.data(), false);
-            }
-        } else {
-            // Create and populate a list of files of the playlist
-            QList<QString> playlistItems;
-            int rows = pPlaylistTableModel->rowCount();
-            for (int i = 0; i < rows; ++i) {
-                QModelIndex index = pPlaylistTableModel->index(i, 0);
-                playlistItems << pPlaylistTableModel->getTrackLocation(index);
-            }
-            exportPlaylistItemsIntoFile(
-                    fileLocation,
-                    playlistItems,
-                    useRelativePath);
-        }
+        exportPlaylistByID(playlistId);
     }
 }
 

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -618,7 +618,6 @@ void BasePlaylistFeature::slotExportPlaylist() {
     }
 }
 
-// MV added method
 void BasePlaylistFeature::slotExportPlaylists() {
     const PlaylistDAO::HiddenType hidden = PlaylistDAO::PLHT_NOT_HIDDEN;
     QList<QPair<int, QString>> test2 = m_playlistDao.getPlaylists(hidden);

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -151,7 +151,6 @@ void BasePlaylistFeature::initActions() {
             &PlaylistDAO::renamed,
             this,
             &BasePlaylistFeature::slotPlaylistTableRenamed);
-
     connect(m_pLibrary,
             &Library::trackSelected,
             this,
@@ -619,25 +618,14 @@ void BasePlaylistFeature::slotExportPlaylist() {
 }
 
 void BasePlaylistFeature::slotExportPlaylists() {
-    const PlaylistDAO::HiddenType hidden = PlaylistDAO::PLHT_NOT_HIDDEN;
+    QList<QPair<int, QString>> allPlaylists =
+            m_playlistDao.getPlaylists(PlaylistDAO::PLHT_NOT_HIDDEN);
 
-    QList<QPair<int, QString>> allPlaylists = m_playlistDao.getPlaylists(hidden);
-
-    QPair<int, QString> thePair;
-    int playlistId;
-    QString playlistName;
-
-    for (int i = 0; i < allPlaylists.length(); i++) {
-        thePair = allPlaylists.at(i);
-        playlistId = thePair.first;
-        playlistName = m_playlistDao.getPlaylistName(playlistId);
-
+    for (const auto& [playlistId, playlistName] : allPlaylists) {
         if (playlistId == kInvalidPlaylistId) {
             return;
         }
 
-        // replace separator character with something generic
-        playlistName = playlistName.replace(QDir::separator(), kUnsafeFilenameReplacement);
         qDebug() << "Export playlist" << playlistName;
 
         QString lastPlaylistDirectory = m_pConfig->getValue(

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -95,6 +95,7 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     // Get the QModelIndex of a playlist based on its id.  Returns QModelIndex()
     // on failure.
     QModelIndex indexFromPlaylistId(int playlistId);
+    void exportPlaylistById(int playlistId);
 
     PlaylistDAO& m_playlistDao;
     QModelIndex m_lastRightClickedIndex;

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -74,6 +74,7 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     void slotImportPlaylistFile(const QString& playlist_file);
     void slotCreateImportPlaylist();
     void slotExportPlaylist();
+    void slotExportPlaylists();
     // Copy all of the tracks in a playlist to a new directory.
     void slotExportTrackFiles();
     void slotAnalyzePlaylist();
@@ -109,6 +110,7 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     QAction* m_pImportPlaylistAction;
     QAction* m_pCreateImportPlaylistAction;
     QAction* m_pExportPlaylistAction;
+    QAction* m_pExportPlaylistsAction;
     QAction* m_pExportTrackFilesAction;
     QAction* m_pDuplicatePlaylistAction;
     QAction* m_pAnalyzePlaylistAction;

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -91,6 +91,7 @@ void PlaylistFeature::onRightClickChild(
     menu.addSeparator();
     menu.addAction(m_pImportPlaylistAction);
     menu.addAction(m_pExportPlaylistAction);
+    menu.addAction(m_pExportPlaylistsAction);
     menu.addAction(m_pExportTrackFilesAction);
     menu.exec(globalPos);
 }

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -60,6 +60,7 @@ void PlaylistFeature::onRightClick(const QPoint& globalPos) {
     menu.addAction(m_pCreatePlaylistAction);
     menu.addSeparator();
     menu.addAction(m_pCreateImportPlaylistAction);
+    menu.addAction(m_pExportPlaylistsAction);
     menu.exec(globalPos);
 }
 
@@ -91,7 +92,7 @@ void PlaylistFeature::onRightClickChild(
     menu.addSeparator();
     menu.addAction(m_pImportPlaylistAction);
     menu.addAction(m_pExportPlaylistAction);
-    menu.addAction(m_pExportPlaylistsAction);
+    // menu.addAction(m_pExportPlaylistsAction);
     menu.addAction(m_pExportTrackFilesAction);
     menu.exec(globalPos);
 }

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -92,7 +92,6 @@ void PlaylistFeature::onRightClickChild(
     menu.addSeparator();
     menu.addAction(m_pImportPlaylistAction);
     menu.addAction(m_pExportPlaylistAction);
-    // menu.addAction(m_pExportPlaylistsAction);
     menu.addAction(m_pExportTrackFilesAction);
     menu.exec(globalPos);
 }


### PR DESCRIPTION
This feature simply allows a user to 'Export All Playlists' when right clicking on the 'Playlist' tab within the library.

Some things to note:
- For each exported playlist, a window pops up asking what format to export the playlist in
- Pressing the 'cancel' button will cancel all other playlist exports.