### PR TITLE
fullscreen: remove Linux menubar workaround

### DIFF
--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -1429,21 +1429,7 @@ void MixxxMainWindow::slotViewFullScreen(bool toggle) {
 
     if (toggle) {
         showFullScreen();
-#ifdef __LINUX__
-        // Fix for "No menu bar with ubuntu unity in full screen mode" Bug
-        // #885890 and Bug #1076789. Before touching anything here, please read
-        // those bugs.
-        createMenuBar();
-        connectMenuBar();
-        if (m_pMenuBar->isNativeMenuBar()) {
-            m_pMenuBar->setNativeMenuBar(false);
-        }
-#endif
     } else {
-#ifdef __LINUX__
-        createMenuBar();
-        connectMenuBar();
-#endif
         showNormal();
     }
     emit fullScreenChanged(toggle);


### PR DESCRIPTION
It appears this is causing issues **1** on recent Ubuntu 22.04 [^1] and also 20.04 [^2] with the defaut window manager, as well as **2** with (unofficial) window manager extensions that enable the so-called 'global menu' (menubar is integrated in the window title bar) after toggling fullscreen (e.g. when switching skins while in fullscreen mode):
* **1** + **2** menubar hotkeys not working anymore
* **2** menubar is not restored in the title bar but in the windwo itself

I also saw leaked controls lately when toggling fullscreen repeatedly, the VisibiltyConnections created in WMainMenubar.

**TODO**
verify no regressions on supported distros with and without global menu, e.g.
- [ ] Ubuntu 20.04 (inofficially supported
- [ ] Ubuntu 22.04
- [ ] Linux Mint
- [ ] ... ?

[^1]: with 2.3.x https://mixxx.discourse.group/t/bug-with-full-screen-and-big-library-ubuntu/26596/6, no bug report yet
[^2]: with 2.5-prealpha, experienced myself, with Ubuntu Studio 20.04 (xfce desktop + vala-panel-appmenu)