### PR TITLE
fullscreen: remove Linux menubar workaround

### DIFF
--- a/src/mixxx.h
+++ b/src/mixxx.h
@@ -183,6 +183,7 @@ class MixxxMainWindow : public QMainWindow {
 
 #ifdef __LINUX__
     bool m_recreateMenubarOnFullscreenToggle;
+    bool m_moveMenuBarToWindow;
 #endif
 
     ControlPushButton* m_pTouchShift;

--- a/src/mixxx.h
+++ b/src/mixxx.h
@@ -181,6 +181,10 @@ class MixxxMainWindow : public QMainWindow {
 
     const CmdlineArgs& m_cmdLineArgs;
 
+#ifdef __LINUX__
+    bool m_recreateMenubarOnFullscreenToggle;
+#endif
+
     ControlPushButton* m_pTouchShift;
     mixxx::ScreenSaverPreference m_inhibitScreensaver;
 

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -691,6 +691,11 @@ void WMainMenuBar::createVisibilityControl(QAction* pAction,
             &WMainMenuBar::internalOnNewSkinLoaded,
             pConnection,
             &VisibilityControlConnection::slotReconnectControl);
+    // reconnect when menu bar was recreated after toggling fullscreen
+    connect(this,
+            &WMainMenuBar::internalFullScreenStateChange,
+            pConnection,
+            &VisibilityControlConnection::slotReconnectControl);
     connect(this,
             &WMainMenuBar::internalOnNewSkinAboutToLoad,
             pConnection,


### PR DESCRIPTION
It appears this is causing issues **1** on recent Ubuntu 22.04 [^1] and also 20.04 [^2] with the defaut window manager, as well as **2** with (unofficial) window manager extensions that enable the so-called 'global menu' (menubar is integrated in the window title bar) after toggling fullscreen (e.g. when switching skins while in fullscreen mode):
* **1** + **2** menubar hotkeys not working anymore
* **2** menubar is not restored in the title bar but in the windwo itself

I also saw leaked controls lately when toggling fullscreen repeatedly, the VisibiltyConnections created in WMainMenubar.

**Edit** now this also includes a fix for #11281 
**Edit2** now also trying to fix #11294 

**TODO**
verify no regressions on supported distros with and without global menu, e.g.
- [x] Ubuntu 20.04 (Gnome desktop)
- [x] Ubuntu 20.04 with vala-panel-appmenu
- [x] Ubuntu 22.04 with Gnome desktop (default) [^4]
- [x] Ubuntu 22.04 with Unity desktop [^5]
- [ ] Linux Mint
- [x] Kubuntu 22.04 with Plasma's Application Menu bar [^3]

[^1]: with 2.3.x https://mixxx.discourse.group/t/bug-with-full-screen-and-big-library-ubuntu/26596/6, no bug report yet
[^2]: with 2.5-prealpha, experienced myself, with Ubuntu Studio 20.04 (xfce desktop + vala-panel-appmenu)
[^3]: the App bar is not visible while apps are fullscreen :shrug: or at least I didn't figure howto.. anyways, all hotkeys work after toggling fullscreen repeatedly
[^4]: hotkey issues fixed, also confirmed by the original bug reporter https://mixxx.discourse.group/t/bug-with-full-screen-and-big-library-ubuntu/26596/13
[^5]: no regression, like: View menu hotkeys cease to work after toggling fullscreen anyway

Fixes #11281 