### PR TITLE
Library sidebar: allow moving focused index with Ctrl + Up/Down

### DIFF
--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -623,6 +623,7 @@ void SetlogFeature::slotPlaylistTableChanged(int playlistId) {
         rootWasSelected = m_pSidebarWidget &&
                 m_pSidebarWidget->isFeatureRootIndexSelected(this);
     }
+    // TODO Nice to have: if focused item != selected item, also refocus
 
     QModelIndex newIndex = constructChildModel(selectedPlaylistId);
 

--- a/src/widget/wlibrarysidebar.h
+++ b/src/widget/wlibrarysidebar.h
@@ -27,7 +27,6 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
     void dropEvent(QDropEvent * event) override;
     void keyPressEvent(QKeyEvent* event) override;
     void mousePressEvent(QMouseEvent* event) override;
-    void focusInEvent(QFocusEvent* event) override;
     void timerEvent(QTimerEvent* event) override;
     void toggleSelectedItem();
     bool isLeafNodeSelected();


### PR DESCRIPTION
follow-up for #11208, just the last commit.

Move focused index with Ctrl + Up/Down. Left/Right also work without Ctrl.
It's now consistent with the track view, see #11100

I find it handy for browsing history playlists without mouse, like when I want to check which History logs contain a certain track (need to keep the current tracks view obviously). If I find an interesting setlog, I just press Enter/Return to load it.

_____
~~Draft for now as it requires yet unreviewed #11208~~