### PR TITLE
avoid a zillion of "ciitical ... QNSWindow ... active key-value observers"

### DIFF
--- a/src/widget/wwidgetgroup.cpp
+++ b/src/widget/wwidgetgroup.cpp
@@ -120,6 +120,8 @@ void WWidgetGroup::setup(const QDomNode& node, const SkinContext& context) {
 
     QLayout* pLayout = nullptr;
     QString layout;
+    bool layoutIsStacked = false;
+
     if (context.hasNodeSelectString(node, "Layout", &layout)) {
         if (layout == "vertical") {
             pLayout = new QVBoxLayout();
@@ -129,12 +131,7 @@ void WWidgetGroup::setup(const QDomNode& node, const SkinContext& context) {
             auto* pStackedLayout = new QStackedLayout();
             pStackedLayout->setStackingMode(QStackedLayout::StackAll);
             pLayout = pStackedLayout;
-            // Adding a zero-size dummy widget as index 0 here before
-            // any child is added in the xml template works around
-            // https://bugs.launchpad.net/mixxx/+bug/1627859
-            QWidget *dummyWidget = new QWidget();
-            dummyWidget->setFixedSize(0, 0);
-            pLayout->addWidget(dummyWidget);
+            layoutIsStacked = true;
         }
 
         // Set common layout parameters.
@@ -152,6 +149,16 @@ void WWidgetGroup::setup(const QDomNode& node, const SkinContext& context) {
 
     if (pLayout) {
         setLayout(pLayout);
+
+        if (layoutIsStacked) {
+            // Without this zero-sized dummy widget being added before
+            // any child widgets, the stacked layout would force-show
+            // the top item, i.e. ignore the state of its 'visible' connection.
+            // See https://github.com/mixxxdj/mixxx/issues/8655
+            QWidget* dummyWidget = new QWidget();
+            dummyWidget->setFixedSize(0, 0);
+            pLayout->addWidget(dummyWidget);
+        }
     }
 }
 


### PR DESCRIPTION
move dummy widget creation in WWidgetGroup::setup after setLayout, to avoid a zillion of "ciitical ... QNSWindow ... active key-value observers" errors on startup, as discussed here: https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/lots.20of.20.22critical.22.20QNSWindow.20errors.20on.20startup
