### PR TITLE
CMake: Fix linking of Google Benchmark library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1639,7 +1639,7 @@ add_subdirectory(
   "${CMAKE_CURRENT_SOURCE_DIR}/lib/benchmark"
   "${CMAKE_CURRENT_BINARY_DIR}/lib/benchmark"
 )
-target_link_libraries(mixxx-test PRIVATE benchmark)
+target_link_libraries(mixxx-test PRIVATE benchmark::benchmark)
 
 # Test Suite
 include(CTest)


### PR DESCRIPTION
- According to https://github.com/google/benchmark#usage-with-cmake
- Might fix #11202 (not tested yet)