### PR TITLE
main EQ: properly restore parameters + also save 'no effect' to config

### DIFF
--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -822,10 +822,13 @@ void DlgPrefEQ::slotMainEqEffectChanged(int effectIndex) {
         }
     }
 
-    // Update the configured effect for the current QComboBox
     if (pManifest) {
         m_pConfig->set(ConfigKey(kConfigGroup, "EffectForGroup_[Master]"),
                 ConfigValue(pManifest->uniqueId()));
+    } else {
+        // no manifest, no id, '---' was selected.
+        m_pConfig->set(ConfigKey(kConfigGroup, "EffectForGroup_[Master]"),
+                ConfigValue());
     }
 }
 

--- a/src/preferences/dialog/dlgprefeq.h
+++ b/src/preferences/dialog/dlgprefeq.h
@@ -58,6 +58,7 @@ class DlgPrefEQ : public DlgPreferencePage, public Ui::DlgPrefEQDlg  {
     void validate_levels();
     void updateBandFilter(int index, double value);
     void setUpMainEQ();
+    void setupMainEqWidgets();
     void applySelections();
 
     typedef bool (*EffectManifestFilterFnc)(EffectManifest* pManifest);


### PR DESCRIPTION
* the empty Main EQ `---` wasn't saved to config, so the previous valid effect was restored on next start unnoticed
* Main EQ parameters were not restored because the loaded parameters were overwritten with default values during initial GUI setup, regression introduced by #4884