### PR TITLE
Tracks view: keep current item visible when the view shrinks vertically

### DIFF
--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -858,18 +858,18 @@ void WTrackTableView::resizeEvent(QResizeEvent* event) {
     }
 
     QModelIndex currIndex = currentIndex();
-    int rHeight = rowHeight(0);
+    int currRow = currIndex.row();
+    int rHeight = rowHeight(currRow);
 
-    if (!currIndex.isValid() || rHeight <= 0) {
+    if (currRow < 0 || rHeight == 0) { // true if currIndex is invalid
         QTableView::resizeEvent(event);
         return;
     }
 
-    int currRow = currIndex.row();
     // y-pos of the top edge, negative value means above viewport boundary
     int posInView = rowViewportPosition(currRow);
     // Check if the row is visible.
-    // Note: don't use viewport()->height() because that may already have changed (??)
+    // Note: don't use viewport()->height() because that may already have changed
     bool rowWasVisible = posInView > 0 && posInView - rHeight < oldHeight;
 
     QTableView::resizeEvent(event);
@@ -878,9 +878,6 @@ void WTrackTableView::resizeEvent(QResizeEvent* event) {
         return;
     }
 
-    // TODO(xxx) When resizing, the top row is static, at least on Linux.
-    // If that is true on other OS as well we could calculate the new relative
-    // position before resizing.
     // Check if the item is fully visible. If not, scroll to show it
     posInView = rowViewportPosition(currRow);
     if (posInView - rHeight < 0 || posInView + rHeight > newHeight) {

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -35,6 +35,7 @@ class WTrackTableView : public WLibraryTableView {
     bool hasFocus() const override;
     void setFocus() override;
     void keyPressEvent(QKeyEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
     void activateSelectedTrack() override;
     void loadSelectedTrackToGroup(const QString& group, bool play) override;
     void assignNextTrackColor() override;


### PR DESCRIPTION
Just a small helper to fix an issue I had on my list for a long time:
if you toggle/expand a hidden/collapsed container (waveforms, effects, sampler) the track view shrinks which can push the track selection out of sight.
This commit makes sure it is pulled into view again if required.

### Testing
Pick a track at the bottom of the view, and make sure there are some hidden skin regions to expand.
That track should reman visible both when showing a hidden region, as well as when manually (slowly) dragging the waveform splitter downwards.

Note: even though this handles the currentIndex (focused item, not the selection) this doesn't matter unless you use Ctrl + keys to move independent from the selection.