### PR TITLE
2.3.4 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES)
   endif()
 endif()
 
-project(mixxx VERSION 2.3.3)
+project(mixxx VERSION 2.3.4)
 # Work around missing version suffixes support https://gitlab.kitware.com/cmake/cmake/-/issues/16716
 set(MIXXX_VERSION_PRERELEASE "") # set to "alpha-pre" "beta" or ""
 

--- a/cmake/modules/GitInfo.cmake
+++ b/cmake/modules/GitInfo.cmake
@@ -33,19 +33,13 @@ if(NOT GIT_DESCRIBE)
     else()
       message(NOTICE "Git branch: ${GIT_BRANCH}")
     endif()
-
-    # Get the number of commits on the working branch
-    execute_process(
-      COMMAND git rev-list --count --first-parent HEAD
-      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-      OUTPUT_VARIABLE GIT_COMMIT_COUNT
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-      ERROR_QUIET
-    )
-    if(NOT GIT_COMMIT_COUNT)
-      message(NOTICE "Git commit count: unknown")
-    else()
+    # Get the number of commits since the version tag
+    string(REGEX MATCH ".*-([0-9]*)-.*" GIT_COMMIT_COUNT_MATCH "${GIT_DESCRIBE}")
+    if (GIT_COMMIT_COUNT_MATCH)
+      set(GIT_COMMIT_COUNT "${CMAKE_MATCH_1}")
       message(NOTICE "Git commit count: ${GIT_COMMIT_COUNT}")
+    else()
+      message(NOTICE "Git commit count: unknown")
     endif()
   endif()
 else()

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,9 @@
+mixxx (2.3.3-1~bionic) bionic; urgency=medium
+
+  * Build of 2.3.3
+
+ -- RJ Skerry-Ryan <rryan@mixxx.org>  Tue, 21 Jun 2022 21:24:47 +0000
+
 mixxx (2.3.2-1~bionic) bionic; urgency=medium
 
   * Build of 2.3.2


### PR DESCRIPTION
This is the final step for a release. 

https://github.com/mixxxdj/mixxx/pull/11275 needs to be merged before. 
And https://github.com/mixxxdj/mixxx/pull/4729 is nearly ready. 

There is some more pending work:
https://github.com/mixxxdj/mixxx/pulls?q=is%3Aopen+is%3Apr+milestone%3A2.3.4
can we postpone all to 2.3.5?

