### PR TITLE
Kontrol S4 Mk3: add controller mapping

### DIFF
--- a/res/controllers/Traktor Kontrol S4 MK3.hid.xml
+++ b/res/controllers/Traktor Kontrol S4 MK3.hid.xml
@@ -2,7 +2,7 @@
 <MixxxControllerPreset mixxxVersion="2.4.0" schemaVersion="1">
      <info>
         <name>Traktor Kontrol S4 MK3</name>
-        <author>Be</author>
+        <author>Be, A. Colombier</author>
         <description>HID Mapping for Traktor Kontrol S4 MK3</description>
         <manual>native_instruments_traktor_kontrol_s4_mk3</manual>
         <devices>

--- a/res/controllers/Traktor Kontrol S4 MK3.hid.xml
+++ b/res/controllers/Traktor Kontrol S4 MK3.hid.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='utf-8'?>
+<MixxxControllerPreset mixxxVersion="2.4.0" schemaVersion="1">
+     <info>
+        <name>Traktor Kontrol S4 MK3</name>
+        <author>Be</author>
+        <description>HID Mapping for Traktor Kontrol S4 MK3</description>
+        <manual>native_instruments_traktor_kontrol_s4_mk3</manual>
+        <devices>
+            <product protocol="hid" vendor_id="0x17cc" product_id="0x1720" usage_page="0xff01" usage="0x1" interface_number="0x4" />
+        </devices>
+    </info>
+    <controller id="Traktor">
+        <scriptfiles>
+            <file filename="Traktor-Kontrol-S4-MK3.js" functionprefix="TraktorS4MK3"/>
+        </scriptfiles>
+    </controller>
+</MixxxControllerPreset>

--- a/res/controllers/Traktor-Kontrol-S4-MK3.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK3.js
@@ -1,0 +1,2040 @@
+/// Copyright (C) 2022 Be <be@mixxx.org>
+///
+/// This mapping is free software; you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation; either version 2 of the License, or
+/// (at your option) any later version. The full text of the GNU
+/// General Public License, version 2 can be found below. The licenses
+/// of software libraries distributed together with Mixxx can be found
+/// below as well.
+///
+/// In addition to the terms of the GNU General Public License, the following
+/// license terms apply:
+///
+/// By using this mapping, you confirm that you are not Bob Ham, you are in no
+/// way affiliated to Bob Ham, you are not downloading this code on behalf of
+/// Bob Ham or an associate of Bob Ham. To the best of your knowledge, information
+/// and belief this mapping will not make its way into the hands of Bob Ham.
+
+const LEDColors = {
+    off: 0,
+    red: 4,
+    carrot: 8,
+    orange: 12,
+    honey: 16,
+    yellow: 20,
+    lime: 24,
+    green: 28,
+    aqua: 32,
+    celeste: 36,
+    sky: 40,
+    blue: 44,
+    purple: 48,
+    fuscia: 52,
+    magenta: 56,
+    azalea: 60,
+    salmon: 64,
+    white: 68,
+};
+
+/*
+ * USER CONFIGURABLE SETTINGS
+ * Adjust these to your liking
+ */
+
+const deckColors = [
+    LEDColors.red,
+    LEDColors.blue,
+    LEDColors.yellow,
+    LEDColors.purple,
+];
+
+const tempoFaderSoftTakeoverColorLow = LEDColors.white;
+const tempoFaderSoftTakeoverColorHigh = LEDColors.green;
+
+// The LEDs only support 16 base colors. Adding 1 in addition to
+// the normal 2 for Button.prototype.brightnessOn changes the color
+// slightly, so use that get 25 different colors to include the Filter
+// button as a 5th effect chain preset selector.
+const quickEffectPresetColors = [
+    LEDColors.red,
+    LEDColors.blue,
+    LEDColors.yellow,
+    LEDColors.purple,
+    LEDColors.white,
+
+    LEDColors.magenta,
+    LEDColors.azalea,
+    LEDColors.salmon,
+    LEDColors.red + 1,
+
+    LEDColors.sky,
+    LEDColors.celeste,
+    LEDColors.fuscia,
+    LEDColors.blue + 1,
+
+    LEDColors.carrot,
+    LEDColors.orange,
+    LEDColors.honey,
+    LEDColors.yellow + 1,
+
+    LEDColors.lime,
+    LEDColors.aqua,
+    LEDColors.green,
+    LEDColors.purple + 1,
+
+    LEDColors.magenta + 1,
+    LEDColors.azalea + 1,
+    LEDColors.salmon + 1,
+    LEDColors.fuscia + 1,
+];
+
+// assign samplers to the crossfader on startup
+const samplerCrossfaderAssign = true;
+
+/*
+ * HID packet parsing library
+ */
+
+class HIDInputPacket {
+    constructor(reportId) {
+        this.reportId = reportId;
+        this.fields = [];
+    }
+
+    registerCallback(callback, byteOffset, bitOffset, bitLength, signed) {
+        if (typeof callback !== "function") {
+            throw Error("callback must be a function");
+        }
+
+        if (byteOffset === undefined || typeof byteOffset !== "number" || !Number.isInteger(byteOffset)) {
+            throw Error("byteOffset must be 0 or a positive integer");
+        }
+
+        if (bitOffset === undefined) {
+            bitOffset = 0;
+        }
+        if (typeof bitOffset !== "number" || bitOffset < 0 || !Number.isInteger(bitOffset)) {
+            throw Error("bitOffset must be 0 or a positive integer");
+        }
+
+        if (bitLength === undefined) {
+            bitLength = 1;
+        }
+        if (typeof bitLength !== "number" || bitLength < 1 || !Number.isInteger(bitOffset) || bitLength > 32) {
+            throw Error("bitLength must be an integer between 1 and 32");
+        }
+
+        if (signed === undefined) {
+            signed = false;
+        }
+
+        const field = {
+            callback: callback,
+            byteOffset: byteOffset,
+            bitOffset: bitOffset,
+            bitLength: bitLength,
+            oldData: 0
+        };
+        this.fields.push(field);
+
+        return {
+            disconnect: () => {
+                this.fields = this.fields.filter((element) => {
+                    return element !== field;
+                });
+            }
+        };
+    }
+
+    handleInput(byteArray) {
+        const view = new DataView(byteArray);
+        if (view.getUint8(0) !== this.reportId) {
+            return;
+        }
+
+        for (const field of this.fields) {
+            const numBytes = Math.ceil(field.bitLength / 8);
+            let data;
+
+            // Little endianness is specified by the HID standard.
+            // The HID standard allows signed integers as well, but I am not aware
+            // of any HID DJ controllers which use signed integers.
+            if (numBytes === 1) {
+                data = view.getUint8(field.byteOffset);
+            } else if (numBytes === 2) {
+                data = view.getUint16(field.byteOffset, true);
+            } else if (numBytes === 3) {
+                data = view.getUint32(field.byteOffset, true) >>> 8;
+            } else if (numBytes === 4) {
+                data = view.getUint32(field.byteOffset, true);
+            } else {
+                throw Error("field bitLength must be between 1 and 32");
+            }
+
+            // The >>> 0 is required for 32 bit unsigned ints to not magically turn negative
+            // because all Numbers are really 32 bit signed floats. Because JavaScript.
+            data = ((data >> field.bitOffset) & (2 ** field.bitLength - 1)) >>> 0;
+
+            if (field.oldData !== data) {
+                field.callback(data);
+                field.oldData = data;
+            }
+        }
+    }
+}
+
+class HIDOutputPacket {
+    constructor(reportId, length) {
+        this.reportId = reportId;
+        this.data = Array(length).fill(0);
+    }
+    send() {
+        controller.send(this.data, null, this.reportId);
+    }
+}
+
+/*
+ * Components library
+ */
+
+class Component {
+    constructor(options) {
+        Object.assign(this, options);
+        if (options !== undefined && typeof options.key === "string") {
+            this.inKey = options.key;
+            this.outKey = options.key;
+        }
+        if (this.unshift !== undefined && typeof this.unshift === "function") {
+            this.unshift();
+        }
+        this.shifted = false;
+        if (this.input !== undefined && typeof this.input === "function"
+            && this.inPacket !== undefined && this.inPacket instanceof HIDInputPacket) {
+            this.inConnect();
+        }
+        this.outConnections = [];
+        this.outConnect();
+    }
+    inConnect(callback) {
+        if (this.inByte === undefined
+          || this.inBit === undefined
+          || this.inBitLength === undefined
+          || this.inPacket === undefined) {
+            return;
+        }
+        if (typeof callback === "function") {
+            this.input = callback;
+        }
+        this.inConnection = this.inPacket.registerCallback(this.input.bind(this), this.inByte, this.inBit, this.inBitLength);
+    }
+    inDisconnect() {
+        if (this.inConnection !== undefined) {
+            this.inConnection.disconnect();
+        }
+    }
+    send(value) {
+        if (this.outPacket !== undefined && this.outByte !== undefined) {
+            this.outPacket.data[this.outByte] = value;
+            this.outPacket.send();
+        }
+    }
+    output(value) {
+        this.send(value);
+    }
+    outConnect() {
+        if (this.outKey !== undefined && this.group !== undefined) {
+            this.outConnections[0] = engine.makeConnection(this.group, this.outKey, this.output.bind(this));
+        }
+    }
+    outDisconnect() {
+        for (const connection of this.outConnections) {
+            connection.disconnect();
+        }
+    }
+    outTrigger() {
+        for (const connection of this.outConnections) {
+            connection.trigger();
+        }
+    }
+}
+
+class ComponentContainer {
+    constructor() {}
+    *[Symbol.iterator]() {
+    // can't use for...of here because it would create an infinite loop
+        for (const property in this) {
+            if (Object.prototype.hasOwnProperty.call(this, property)) {
+                const obj = this[property];
+                if (obj instanceof Component) {
+                    yield obj;
+                } else if (obj instanceof ComponentContainer) {
+                    for (const nestedComponent of obj) {
+                        yield nestedComponent;
+                    }
+                } else if (Array.isArray(obj)) {
+                    for (const objectInArray of obj) {
+                        if (objectInArray instanceof Component) {
+                            yield objectInArray;
+                        } else if (objectInArray instanceof ComponentContainer) {
+                            for (const doublyNestedComponent of objectInArray) {
+                                yield doublyNestedComponent;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    reconnectComponents(callback) {
+        for (const component of this) {
+            if (component.outDisconnect !== undefined && typeof component.outDisconnect === "function") {
+                component.outDisconnect();
+            }
+            if (callback !== undefined && typeof callback === "function") {
+                callback.call(this, component);
+            }
+            if (component.outConnect !== undefined && typeof component.outConnect === "function") {
+                component.outConnect();
+            }
+            component.outTrigger();
+        }
+    }
+    unshift() {
+        for (const component of this) {
+            if (component.unshift !== undefined && typeof component.unshift === "function") {
+                component.unshift();
+            }
+            component.shifted = false;
+        }
+    }
+    shift() {
+        for (const component of this) {
+            if (component.shift !== undefined && typeof component.shift === "function") {
+                component.shift();
+            }
+            component.shifted = true;
+        }
+    }
+}
+
+/* eslint no-redeclare: "off" */
+class Deck extends ComponentContainer {
+    constructor(decks, colors) {
+        super();
+        if (typeof decks === "number") {
+            this.group = Deck.groupForNumber(decks);
+        } else if (Array.isArray(decks)) {
+            this.decks = decks;
+            this.currentDeckNumber = decks[0];
+            this.group = Deck.groupForNumber(decks[0]);
+        }
+        if (colors !== undefined && Array.isArray(colors)) {
+            this.groupsToColors = {};
+            let index = 0;
+            for (const deck of this.decks) {
+                this.groupsToColors[Deck.groupForNumber(deck)] = colors[index];
+                index++;
+            }
+            this.color = colors[0];
+        }
+    }
+    toggleDeck() {
+        if (this.decks === undefined) {
+            throw Error("toggleDeck can only be used with Decks constructed with an Array of deck numbers, for example [1, 3]");
+        }
+
+        const currentDeckIndex = this.decks.indexOf(this.currentDeckNumber);
+        let newDeckIndex = currentDeckIndex + 1;
+        if (currentDeckIndex >= this.decks.length) {
+            newDeckIndex = 0;
+        }
+
+        this.switchDeck(Deck.groupForNumber(this.decks[newDeckIndex]));
+    }
+    switchDeck(newGroup) {
+        this.group = newGroup;
+        this.color = this.groupsToColors[newGroup];
+        this.reconnectComponents(function(component) {
+            if (component.group === undefined
+                  || component.group.search(script.channelRegEx) !== -1) {
+                component.group = newGroup;
+            } else if (component.group.search(script.eqRegEx) !== -1) {
+                component.group = "[EqualizerRack1_" + newGroup + "_Effect1]";
+            } else if (component.group.search(script.quickEffectRegEx) !== -1) {
+                component.group = "[QuickEffectRack1_" + newGroup + "]";
+            }
+
+            component.color = this.groupsToColors[newGroup];
+        });
+    }
+    static groupForNumber(deckNumber) {
+        return "[Channel" + deckNumber + "]";
+    }
+}
+
+class Button extends Component {
+    constructor(options) {
+        super(options);
+        this.off = 0;
+        if (this.longPressTimeOut === undefined) {
+            this.longPressTimeOut = 225; // milliseconds
+        }
+        if (this.inBitLength === undefined) {
+            this.inBitLength = 1;
+        }
+    }
+    output(value) {
+        const brightness = (value > 0) ? this.brightnessOn : this.brightnessOff;
+        this.send(this.color + brightness);
+    }
+}
+
+class PushButton extends Button {
+    constructor(options) {
+        super(options);
+    }
+    input(pressed) {
+        engine.setValue(this.group, this.inKey, pressed);
+    }
+}
+
+class ToggleButton extends Button {
+    constructor(options) {
+        super(options);
+    }
+    input(pressed) {
+        if (pressed) {
+            script.toggleControl(this.group, this.inKey);
+        }
+    }
+}
+
+class PowerWindowButton extends Button {
+    constructor(options) {
+        super(options);
+        this.isLongPressed = false;
+        this.longPressTimer = 0;
+    }
+    input(pressed) {
+        if (pressed) {
+            script.toggleControl(this.group, this.inKey);
+            this.longPressTimer = engine.beginTimer(this.longPressTimeOut, () => {
+                this.isLongPressed = true;
+                this.longPressTimer = 0;
+            }, true);
+        } else {
+            if (this.isLongPressed) {
+                script.toggleControl(this.group, this.inKey);
+            }
+            if (this.longPressTimer !== 0) {
+                engine.stopTimer(this.longPressTimer);
+            }
+            this.longPressTimer = 0;
+            this.isLongPressed = false;
+        }
+    }
+}
+
+class PlayButton extends ToggleButton {
+    constructor(options) {
+        super(options);
+        this.inKey = "play";
+        this.outKey = "play_indicator";
+        this.outConnect();
+    }
+}
+
+class CueButton extends PushButton {
+    constructor(options) {
+        super(options);
+        this.outKey = "cue_indicator";
+        this.outConnect();
+    }
+    unshift() {
+        this.inKey = "cue_default";
+    }
+    shift() {
+        this.inKey = "start_stop";
+    }
+}
+
+class Encoder extends Component {
+    constructor(options) {
+        super(options);
+        this.lastValue = null;
+    }
+    isRightTurn(value) {
+        // detect wrap around
+        const oldValue = this.lastValue;
+        this.lastValue = value;
+        if (oldValue === this.max && value === 0) {
+            return true;
+        }
+        if (oldValue === 0 && value === this.max) {
+            return false;
+        }
+        return value > oldValue;
+    }
+}
+
+class HotcueButton extends PushButton {
+    constructor(options) {
+        super(options);
+        if (this.number === undefined || !Number.isInteger(this.number) || this.number < 1 || this.number > 32) {
+            throw Error("HotcueButton must have a number property of an integer between 1 and 32");
+        }
+        this.outKey = "hotcue_" + this.number + "_enabled";
+        this.colorKey = "hotcue_" + this.number + "_color";
+        this.outConnect();
+    }
+    unshift() {
+        this.inKey = "hotcue_" + this.number + "_activate";
+    }
+    shift() {
+        this.inKey = "hotcue_" + this.number + "_clear";
+    }
+    output(value) {
+        if (value) {
+            this.send(this.color + this.brightnessOn);
+        } else {
+            this.send(0);
+        }
+    }
+    outConnect() {
+        if (undefined !== this.group) {
+            this.outConnections[0] = engine.makeConnection(this.group, this.outKey, this.output.bind(this));
+            this.outConnections[1] = engine.makeConnection(this.group, this.colorKey, (colorCode) => {
+                this.color = this.colorMap.getValueForNearestColor(colorCode);
+                this.output(engine.getValue(this.group, this.outKey));
+            });
+        }
+    }
+}
+
+class SamplerButton extends Button {
+    constructor(options) {
+        super(options);
+        if (this.number === undefined || !Number.isInteger(this.number) || this.number < 1 || this.number > 64) {
+            throw Error("SamplerButton must have a number property of an integer between 1 and 64");
+        }
+        this.group = "[Sampler" + this.number + "]";
+        this.outConnect();
+    }
+    input(pressed) {
+        if (!this.shifted) {
+            if (pressed) {
+                if (engine.getValue(this.group, "track_loaded") === 0) {
+                    engine.setValue(this.group, "LoadSelectedTrack", 1);
+                } else {
+                    engine.setValue(this.group, "cue_gotoandplay", 1);
+                }
+            }
+        } else {
+            if (pressed) {
+                if (engine.getValue(this.group, "play") === 1) {
+                    engine.setValue(this.group, "play", 0);
+                } else {
+                    engine.setValue(this.group, "eject", 1);
+                }
+            } else {
+                if (engine.getValue(this.group, "play") === 0) {
+                    engine.setValue(this.group, "eject", 0);
+                }
+            }
+        }
+    }
+    // This function is connected to multiple Controls, so don't use the value passed in as a parameter.
+    output() {
+        if (engine.getValue(this.group, "track_loaded")) {
+            if (engine.getValue(this.group, "play")) {
+                this.send(this.color + this.brightnessOn);
+            } else {
+                this.send(this.color + this.brightnessOff);
+            }
+        } else {
+            this.send(0);
+        }
+    }
+    outConnect() {
+        if (undefined !== this.group) {
+            this.outConnections[0] = engine.makeConnection(this.group, "play", this.output.bind(this));
+            this.outConnections[1] = engine.makeConnection(this.group, "track_loaded", this.output.bind(this));
+        }
+    }
+}
+
+class IntroOutroButton extends PushButton {
+    constructor(options) {
+        super(options);
+        if (this.cueBaseName === undefined || typeof this.cueBaseName !== "string") {
+            throw Error("must specify cueBaseName as intro_start, intro_end, outro_start, or outro_end");
+        }
+        this.outKey = this.cueBaseName + "_enabled";
+        this.outConnect();
+    }
+    unshift() {
+        this.inKey = this.cueBaseName + "_activate";
+    }
+    shift() {
+        this.inKey = this.cueBaseName + "_clear";
+    }
+    output(value) {
+        if (value) {
+            this.send(this.color + this.brightnessOn);
+        } else {
+            this.send(0);
+        }
+    }
+}
+
+class Pot extends Component {
+    constructor(options) {
+        super(options);
+        this.hardwarePosition = null;
+    }
+    input(value) {
+        const receivingFirstValue = this.hardwarePosition === null;
+        this.hardwarePosition = value / this.max;
+        engine.setParameter(this.group, this.inKey, this.hardwarePosition);
+        if (receivingFirstValue) {
+            engine.softTakeover(this.group, this.inKey, true);
+        }
+    }
+    outDisconnect() {
+        if (this.hardwarePosition !== null) {
+            engine.softTakeover(this.group, this.inKey, true);
+        }
+        engine.softTakeoverIgnoreNextValue(this.group, this.inKey);
+    }
+}
+
+/*
+ * Kontrol S4 Mk3 hardware-specific constants
+ */
+
+Pot.prototype.max = 2**12 - 1;
+Pot.prototype.inBit = 0;
+Pot.prototype.inBitLength = 16;
+
+Encoder.prototype.inBitLength = 4;
+
+// valid range 0 - 3, but 3 makes some colors appear whitish
+Button.prototype.brightnessOff = 0;
+Button.prototype.brightnessOn = 2;
+Button.prototype.colorMap = new ColorMapper({
+    0xCC0000: LEDColors.red,
+    0xCC5E00: LEDColors.carrot,
+    0xCC7800: LEDColors.orange,
+    0xCC9200: LEDColors.honey,
+
+    0xCCCC00: LEDColors.yellow,
+    0x81CC00: LEDColors.lime,
+    0x00CC00: LEDColors.green,
+    0x00CC49: LEDColors.aqua,
+
+    0x00CCCC: LEDColors.celeste,
+    0x0091CC: LEDColors.sky,
+    0x0000CC: LEDColors.blue,
+    0xCC00CC: LEDColors.purple,
+
+    0xCC0091: LEDColors.fuscia,
+    0xCC0079: LEDColors.magenta,
+    0xCC477E: LEDColors.azalea,
+    0xCC4761: LEDColors.salmon,
+
+    0xCCCCCC: LEDColors.white,
+});
+
+const wheelRelativeMax = 2**16 - 1;
+const wheelAbsoluteMax = 2879;
+
+const wheelTimerMax = 2**32 - 1;
+const wheelTimerTicksPerSecond = 100000000;
+
+const baseRevolutionsPerMinute = 33 + 1/3;
+const baseRevolutionsPerSecond = baseRevolutionsPerMinute / 60;
+const wheelTicksPerTimerTicksToRevolutionsPerSecond = wheelTimerTicksPerSecond / wheelAbsoluteMax;
+
+const wheelLEDmodes = {
+    off: 0,
+    dimFlash: 1,
+    spot: 2,
+    ringFlash: 3,
+    dimSpot: 4,
+    individuallyAddressable: 5, // set byte 4 to 0 and set byes 8 - 40 to color values
+};
+
+const wheelModes = {
+    jog: 0,
+    vinyl: 1,
+    motor: 2,
+};
+
+// tracks state across input packets
+let wheelTimer = null;
+// This is a global variable so the S4Mk3Deck Components have access
+// to it and it is guaranteed to be calculated before processing
+// input for the Components.
+let wheelTimerDelta = 0;
+
+/*
+ * Kontrol S4 Mk3 hardware specific mapping logic
+ */
+
+// used for buttons whose LEDs only support a single color
+// Don't use dim colors for these because they are hard to tell apart
+// from bright colors.
+const uncoloredButtonOutput = function(value) {
+    if (value) {
+        this.send(127);
+    } else {
+        this.send(0);
+    }
+};
+
+class S4Mk3EffectUnit extends ComponentContainer {
+    constructor(unitNumber, inPackets, outPacket, io) {
+        super();
+        this.group = "[EffectRack1_EffectUnit" + unitNumber + "]";
+
+        this.mixKnob = new Pot({
+            inKey: "mix",
+            group: this.group,
+            inPacket: inPackets[2],
+            inByte: io.mixKnob.inByte,
+        });
+
+        this.knobs = [];
+        this.buttons = [];
+        for (const index of [0, 1, 2]) {
+            const effectGroup = "[EffectRack1_EffectUnit" + unitNumber + "_Effect" + (index + 1) + "]";
+            this.knobs[index] = new Pot({
+                inKey: "meta",
+                group: effectGroup,
+                inPacket: inPackets[2],
+                inByte: io.knobs[index].inByte,
+            });
+            this.buttons[index] = new PowerWindowButton({
+                key: "enabled",
+                group: effectGroup,
+                output: uncoloredButtonOutput,
+                inPacket: inPackets[1],
+                inByte: io.buttons[index].inByte,
+                inBit: io.buttons[index].inBit,
+                outByte: io.buttons[index].outByte,
+                outPacket: outPacket,
+            });
+        }
+
+        for (const component of this) {
+            component.inConnect();
+            component.outConnect();
+            component.outTrigger();
+        }
+    }
+}
+
+class S4Mk3Deck extends Deck {
+    constructor(decks, colors, inPackets, outPacket, io) {
+        super(decks, colors);
+
+        this.playButton = new PlayButton({
+            output: uncoloredButtonOutput
+        });
+
+        this.cueButton = new CueButton();
+
+        const rateRanges = [0.04, 0.06, 0.08, 0.10, 0.16, 0.24, 0.5, 0.9];
+        this.syncMasterButton = new ToggleButton({
+            key: "sync_leader",
+            input: function(pressed) {
+                if (pressed) {
+                    if (!this.shifted) {
+                        script.toggleControl(this.group, this.inKey);
+                    } else {
+                        // It is possible for the rateRange to be set to a value
+                        // that is not in the rateRanges Array, so find the nearest
+                        // value in rateRanges.
+                        const currentRateRange = engine.getValue(this.group, "rateRange");
+                        let previousDiff = null;
+                        let newRateRange = rateRanges[0];
+                        for (let i = 0; i < rateRanges.length - 1; i++) {
+                            const currentDiff = Math.abs(rateRanges[i] - currentRateRange);
+                            if (currentDiff < previousDiff || previousDiff === null) {
+                                newRateRange = rateRanges[i + 1];
+                            }
+                            previousDiff = currentDiff;
+                        }
+                        engine.setValue(this.group, "rateRange", newRateRange);
+                    }
+                }
+            },
+        });
+        this.syncButton = new ToggleButton({
+            key: "sync_enabled",
+            input: function(pressed) {
+                if (pressed) {
+                    if (!this.shifted) {
+                        script.toggleControl(this.group, this.inKey);
+                        engine.softTakeover(this.group, "rate", true);
+                    } else {
+                        // It is possible for the rateRange to be set to a value
+                        // that is not in the rateRanges Array, so find the nearest
+                        // value in rateRanges.
+                        const currentRateRange = engine.getValue(this.group, "rateRange");
+                        let previousDiff = null;
+                        let newRateRange = rateRanges[0];
+                        for (let i = rateRanges.length - 1; i > 0; i--) {
+                            const currentDiff = Math.abs(rateRanges[i] - currentRateRange);
+                            if (currentDiff < previousDiff || previousDiff === null) {
+                                newRateRange = rateRanges[i - 1];
+                            }
+                            previousDiff = currentDiff;
+                        }
+                        engine.setValue(this.group, "rateRange", newRateRange);
+                    }
+                }
+            },
+        });
+        this.tempoFader = new Pot({
+            inKey: "rate",
+        });
+        this.tempoFaderLED = new Component({
+            outKey: "rate",
+            centered: false,
+            toleranceWindow: 0.001,
+            tempoFader: this.tempoFader,
+            output: function(value) {
+                if (this.tempoFader.hardwarePosition === null) {
+                    return;
+                }
+
+                const parameterValue = engine.getParameter(this.group, this.outKey);
+                const diffFromHardware = parameterValue - this.tempoFader.hardwarePosition;
+                if (diffFromHardware > this.toleranceWindow) {
+                    this.send(tempoFaderSoftTakeoverColorHigh + Button.prototype.brightnessOn);
+                    return;
+                } else if (diffFromHardware < (-1 * this.toleranceWindow)) {
+                    this.send(tempoFaderSoftTakeoverColorLow + Button.prototype.brightnessOn);
+                    return;
+                }
+
+                const oldCentered = this.centered;
+                if (Math.abs(value) < 0.001) {
+                    this.send(this.color + Button.prototype.brightnessOn);
+                    // round to precisely 0
+                    engine.setValue(this.group, "rate", 0);
+                } else {
+                    this.send(0);
+                }
+            }
+        });
+
+        this.reverseButton = new PushButton({
+            key: "reverseroll",
+            output: uncoloredButtonOutput,
+        });
+        this.fluxButton = new PushButton({
+            key: "slip_enabled",
+            output: uncoloredButtonOutput,
+        });
+        this.gridButton = new PushButton({
+            key: "beats_translate_curpos",
+        });
+
+        this.deckButtonLeft = new Button({
+            deck: this,
+            input: function(value) {
+                if (value) {
+                    this.deck.switchDeck(Deck.groupForNumber(decks[0]));
+                    this.outPacket.data[io.deckButtonOutputByteOffset] = colors[0] + this.brightnessOn;
+                    // turn off the other deck selection button's LED
+                    this.outPacket.data[io.deckButtonOutputByteOffset+1] = 0;
+                    this.outPacket.send();
+                }
+            },
+        });
+        this.deckButtonRight = new Button({
+            deck: this,
+            input: function(value) {
+                if (value) {
+                    this.deck.switchDeck(Deck.groupForNumber(decks[1]));
+                    // turn off the other deck selection button's LED
+                    this.outPacket.data[io.deckButtonOutputByteOffset] = 0;
+                    this.outPacket.data[io.deckButtonOutputByteOffset+1] = colors[1] + this.brightnessOn;
+                    this.outPacket.send();
+                }
+            },
+        });
+
+        // set deck selection button LEDs
+        outPacket.data[io.deckButtonOutputByteOffset] = colors[0] + Button.prototype.brightnessOn;
+        outPacket.data[io.deckButtonOutputByteOffset+1] = 0;
+        outPacket.send();
+
+        this.shiftButton = new PushButton({
+            deck: this,
+            input: function(pressed) {
+                if (pressed) {
+                    this.deck.shift();
+                    // This button only has one color.
+                    this.send(LEDColors.white + this.brightnessOn);
+                } else {
+                    this.deck.unshift();
+                    this.send(LEDColors.white + this.brightnessOff);
+                }
+            },
+        });
+
+        this.leftEncoder = new Encoder({
+            deck: this,
+            input: function(value) {
+                const right = this.isRightTurn(value);
+                if (!this.shifted) {
+                    if (!this.deck.leftEncoderPress.pressed) {
+                        if (right) {
+                            script.triggerControl(this.group, "beatjump_forward");
+                        } else {
+                            script.triggerControl(this.group, "beatjump_backward");
+                        }
+                    } else {
+                        let beatjumpSize = engine.getValue(this.group, "beatjump_size");
+                        if (right) {
+                            beatjumpSize *= 2;
+                        } else {
+                            beatjumpSize /= 2;
+                        }
+                        engine.setValue(this.group, "beatjump_size", beatjumpSize);
+                    }
+                } else {
+                    // FIXME: temporary hack until jog wheels are working
+                    if (right) {
+                        engine.setValue(this.group, "jog", 3);
+                        // script.triggerControl(this.group, "pitch_up_small");
+                    } else {
+                        engine.setValue(this.group, "jog", -3);
+                        // script.triggerControl(this.group, "pitch_down_small");
+                    }
+                }
+            }
+        });
+        this.leftEncoderPress = new PushButton({
+            input: function(pressed) {
+                this.pressed = pressed;
+                if (pressed) {
+                    script.toggleControl(this.group, "pitch_adjust_set_default");
+                }
+            },
+        });
+
+        this.rightEncoder = new Encoder({
+            input: function(value) {
+                const right = this.isRightTurn(value);
+                if (!this.shifted) {
+                    if (right) {
+                        script.triggerControl(this.group, "loop_double");
+                    } else {
+                        script.triggerControl(this.group, "loop_halve");
+                    }
+                } else {
+                    if (right) {
+                        script.triggerControl(this.group, "beatjump_1_forward");
+                    } else {
+                        script.triggerControl(this.group, "beatjump_1_backward");
+                    }
+                }
+            }
+        });
+        this.rightEncoderPress = new PushButton({
+            input: function(pressed) {
+                if (!pressed) {
+                    return;
+                }
+                const loopEnabled = engine.getValue(this.group, "loop_enabled");
+                if (!this.shifted) {
+                    script.triggerControl(this.group, "beatloop_activate");
+                } else {
+                    if (loopEnabled) {
+                        script.triggerControl(this.group, "reloop_andstop");
+                    } else {
+                        script.triggerControl(this.group, "reloop_toggle");
+                    }
+                }
+            },
+        });
+
+        this.libraryEncoder = new Encoder({
+            input: function(value) {
+                const right = this.isRightTurn(value);
+                const previewPlaying = engine.getValue("[PreviewDeck1]", "play");
+                if (previewPlaying) {
+                    if (right) {
+                        script.triggerControl("[PreviewDeck1]", "beatjump_16_forward");
+                    } else {
+                        script.triggerControl("[PreviewDeck1]", "beatjump_16_backward");
+                    }
+                } else {
+                    engine.setValue("[Library]", "MoveVertical", right ? 1 : -1);
+                }
+            }
+        });
+        this.libraryEncoderPress = new ToggleButton({
+            inKey: "LoadSelectedTrack"
+        });
+        this.libraryPlayButton = new PushButton({
+            group: "[PreviewDeck1]",
+            input: function(pressed) {
+                if (pressed) {
+                    if (engine.getValue(this.group, "play")) {
+                        engine.setValue(this.group, "play", 0);
+                    } else {
+                        script.triggerControl(this.group, "LoadSelectedTrackAndPlay");
+                    }
+                }
+            },
+            outKey: "play",
+        });
+        this.libraryStarButton = new PushButton({
+            group: "[Library]",
+            key: "MoveFocusForward",
+        });
+        this.libraryPlaylistButton = new PushButton({
+            group: "[Library]",
+            key: "MoveFocusBackward",
+        });
+        this.libraryViewButton = new ToggleButton({
+            group: "[Master]",
+            inKey: "maximize_library",
+        });
+
+        this.pads = Array(8).fill(new Component());
+        const defaultPadLayer = [
+            new IntroOutroButton({
+                cueBaseName: "intro_start",
+            }),
+            new IntroOutroButton({
+                cueBaseName: "intro_end",
+            }),
+            new IntroOutroButton({
+                cueBaseName: "outro_start",
+            }),
+            new IntroOutroButton({
+                cueBaseName: "outro_end",
+            }),
+            new HotcueButton({
+                number: 1
+            }),
+            new HotcueButton({
+                number: 2
+            }),
+            new HotcueButton({
+                number: 3
+            }),
+            new HotcueButton({
+                number: 4
+            })
+        ];
+        const hotcuePage2 = Array(8).fill({});
+        const hotcuePage3 = Array(8).fill({});
+        const samplerPage1 = Array(8).fill({});
+        const samplerPage2 = Array(8).fill({});
+        let i = 0;
+        /* eslint no-unused-vars: "off" */
+        for (const pad of hotcuePage2) {
+            // start with hotcue 5; hotcues 1-4 are in defaultPadLayer
+            hotcuePage2[i] = new HotcueButton({number: i + 1});
+            hotcuePage3[i] = new HotcueButton({number: i + 13});
+            let samplerNumber = i + 1;
+            if (samplerNumber > 4) {
+                samplerNumber += 4;
+            }
+            if (decks[0] > 1) {
+                samplerNumber += 4;
+            }
+            samplerPage1[i] = new SamplerButton({number: samplerNumber});
+            samplerPage2[i] = new SamplerButton({number: samplerNumber + 16});
+            if (samplerCrossfaderAssign) {
+                engine.setValue(
+                    "[Sampler" + samplerNumber + "]",
+                    "orientation",
+                    (decks[0] === 1) ? 0 : 2
+                );
+            }
+            i++;
+        }
+
+        const switchPadLayer = (deck, newLayer) => {
+            let index = 0;
+            for (let pad of deck.pads) {
+                pad.outDisconnect();
+                pad.inDisconnect();
+
+                pad = newLayer[index];
+                Object.assign(pad, io.pads[index]);
+                if (!(pad instanceof HotcueButton)) {
+                    pad.color = deck.color;
+                }
+                // don't change the group of SamplerButtons
+                if (!(pad instanceof SamplerButton)) {
+                    pad.group = deck.group;
+                }
+                if (pad.inPacket === undefined) {
+                    pad.inPacket = inPackets[1];
+                }
+                pad.outPacket = outPacket;
+                pad.inConnect();
+                pad.outConnect();
+                pad.outTrigger();
+                deck.pads[index] = pad;
+                index++;
+            }
+        };
+
+        this.padLayers = {
+            defaultLayer: 0,
+            hotcuePage2: 1,
+            hotcuePage3: 2,
+            samplerPage1: 3,
+            samplerPage2: 4,
+        };
+        switchPadLayer(this, defaultPadLayer);
+        this.currentPadLayer = this.padLayers.defaultLayer;
+
+        this.hotcuePadModeButton = new Button({
+            deck: this,
+            input: function(pressed) {
+                if (!this.shifted) {
+                    if (pressed) {
+                        if (this.deck.currentPadLayer !== this.deck.padLayers.hotcuePage2) {
+                            switchPadLayer(this.deck, hotcuePage2);
+                            this.deck.currentPadLayer = this.deck.padLayers.hotcuePage2;
+                        } else {
+                            switchPadLayer(this.deck, defaultPadLayer);
+                            this.deck.currentPadLayer = this.deck.padLayers.defaultLayer;
+                        }
+                        this.deck.lightPadMode();
+                    }
+                } else {
+                    engine.setValue(this.deck.group, "loop_in", pressed);
+                }
+            },
+            // make sure loop_in gets reset to 0 if shift is released before this button
+            unshift: function() {
+                if (engine.getValue(this.deck.group, "loop_in") === 1) {
+                    engine.setValue(this.deck.group, "loop_in", 0);
+                }
+            },
+            // hack to switch the LED color when changing decks
+            outTrigger: function() {
+                this.deck.lightPadMode();
+            }
+        });
+        this.recordPadModeButton = new Button({
+            deck: this,
+            input: function(pressed) {
+                if (!this.shifted) {
+                    if (pressed) {
+                        if (this.deck.currentPadLayer !== this.deck.padLayers.hotcuePage3) {
+                            switchPadLayer(this.deck, hotcuePage3);
+                            this.deck.currentPadLayer = this.deck.padLayers.hotcuePage3;
+                        } else {
+                            switchPadLayer(this.deck, defaultPadLayer);
+                            this.deck.currentPadLayer = this.deck.padLayers.defaultLayer;
+                        }
+                        this.deck.lightPadMode();
+                    }
+                } else {
+                    engine.setValue(this.deck.group, "loop_out", pressed);
+                }
+            },
+            // make sure loop_out gets reset to 0 if shift is released before this button
+            unshift: function() {
+                if (engine.getValue(this.deck.group, "loop_out") === 1) {
+                    engine.setValue(this.deck.group, "loop_out", 0);
+                }
+            }
+        });
+        this.samplesPadModeButton = new Button({
+            deck: this,
+            input: function(pressed) {
+                if (pressed) {
+                    if (this.deck.currentPadLayer !== this.deck.padLayers.samplerPage1) {
+                        switchPadLayer(this.deck, samplerPage1);
+                        this.deck.currentPadLayer = this.deck.padLayers.samplerPage1;
+                    } else {
+                        switchPadLayer(this.deck, defaultPadLayer);
+                        this.deck.currentPadLayer = this.deck.padLayers.defaultLayer;
+                    }
+                    this.deck.lightPadMode();
+                }
+            },
+        });
+        this.mutePadModeButton = new Button({
+            deck: this,
+            input: function(pressed) {
+                if (pressed) {
+                    if (this.deck.currentPadLayer !== this.deck.padLayers.samplerPage2) {
+                        switchPadLayer(this.deck, samplerPage2);
+                        this.deck.currentPadLayer = this.deck.padLayers.samplerPage2;
+                    } else {
+                        switchPadLayer(this.deck, defaultPadLayer);
+                        this.deck.currentPadLayer = this.deck.padLayers.defaultLayer;
+                    }
+                    this.deck.lightPadMode();
+                }
+            },
+        });
+
+        this.stemsPadModeButton = new ToggleButton({
+            key: "keylock",
+        });
+
+        this.lightPadMode = function() {
+            const hotcuePadModeLEDOn = this.currentPadLayer === this.padLayers.hotcuePage2;
+            this.hotcuePadModeButton.send(this.color + (hotcuePadModeLEDOn ? this.brightnessOn : this.brightnessOff));
+
+            // unfortunately the other pad mode buttons only have one LED color
+            const recordPadModeLEDOn = this.currentPadLayer === this.padLayers.hotcuePage3;
+            this.recordPadModeButton.send(recordPadModeLEDOn ? 127 : 0);
+
+            const samplesPadModeLEDOn = this.currentPadLayer === this.padLayers.samplerPage1;
+            this.samplesPadModeButton.send(samplesPadModeLEDOn ? 127 : 0);
+
+            const mutePadModeButtonLEDOn = this.currentPadLayer === this.padLayers.samplerPage2;
+            this.mutePadModeButton.send(mutePadModeButtonLEDOn ? 127 : 0);
+        };
+
+        this.wheelMode = wheelModes.vinyl;
+        let motorWindDownTimer = 0;
+        const motorWindDownTimerCallback = () => {
+            engine.stopTimer(motorWindDownTimer);
+            motorWindDownTimer = 0;
+        };
+        const motorWindDownMilliseconds = 900;
+        this.turntableButton = new Button({
+            deck: this,
+            input: function(press) {
+                if (press) {
+                    if (this.deck.wheelMode === wheelModes.motor) {
+                        this.deck.wheelMode = wheelModes.vinyl;
+                        motorWindDownTimer = engine.beginTimer(motorWindDownMilliseconds, motorWindDownTimerCallback, true);
+                        //                         engine.setValue(this.group, "scratch2_enable", false);
+                    } else {
+                        this.deck.wheelMode = wheelModes.motor;
+                        //                         engine.setValue(this.group, "scratch2_enable", true);
+                    }
+                    this.outTrigger();
+                }
+            },
+            outTrigger: function() {
+                const motorOn = this.deck.wheelMode === wheelModes.motor;
+                this.send(this.color + (motorOn ? this.brightnessOn : this.brightnessOff));
+                const vinylModeOn = this.deck.wheelMode === wheelModes.vinyl;
+                this.deck.jogButton.send(this.color + (vinylModeOn ? this.brightnessOn : this.brightnessOff));
+            },
+        });
+        this.jogButton = new Button({
+            deck: this,
+            input: function(press) {
+                if (press) {
+                    if (this.deck.wheelMode === wheelModes.vinyl) {
+                        this.deck.wheelMode = wheelModes.jog;
+                    } else {
+                        if (this.deck.wheelMode === wheelModes.motor) {
+                            motorWindDownTimer = engine.beginTimer(motorWindDownMilliseconds, motorWindDownTimerCallback, true);
+                        }
+                        this.deck.wheelMode = wheelModes.vinyl;
+                    }
+                    engine.setValue(this.group, "scratch2_enable", false);
+                    this.outTrigger();
+                }
+            },
+            outTrigger: function() {
+                const vinylOn = this.deck.wheelMode === wheelModes.vinyl;
+                this.send(this.color + (vinylOn ? this.brightnessOn : this.brightnessOff));
+                const motorOn = this.deck.wheelMode === wheelModes.motor;
+                this.deck.turntableButton.send(this.color + (motorOn ? this.brightnessOn : this.brightnessOff));
+            },
+        });
+
+        this.wheelTouch = new Button({
+            touched: false,
+            deck: this,
+            input: function(touched) {
+                this.touched = touched;
+                if (this.deck.wheelMode !== wheelModes.jog) {
+                    if (touched) {
+                        engine.setValue(this.group, "scratch2_enable", true);
+                    } else {
+                        // The wheel keeps spinning
+                        engine.beginTimer(600, () => {
+                            engine.setValue(this.group, "scratch2_enable", false);
+                        }, true);
+                    }
+                }
+            },
+        });
+
+        // The relative and absolute position inputs have the same resolution but direction
+        // cannot be determined reliably with the absolute position because it is easily
+        // possible to spin the wheel fast enough that it spins more than half a revolution
+        // between input packets. So there is no need to process the absolution position
+        // at all; the relative position is sufficient.
+        this.wheelRelative = new Component({
+            oldValue: null,
+            deck: this,
+            input: function(value) {
+                const oldValue = this.oldValue;
+                this.oldValue = value;
+                let diff = value - oldValue;
+                if (diff === 0 || oldValue === null || motorWindDownTimer !== 0) {
+                    return;
+                }
+
+                if (diff > wheelRelativeMax / 2) {
+                    diff = (wheelRelativeMax - value + oldValue) * -1;
+                } else if (diff < -1 * (wheelRelativeMax / 2)) {
+                    diff = wheelRelativeMax - oldValue + value;
+                }
+
+                const wheelVelocity = diff / wheelTimerDelta * wheelTicksPerTimerTicksToRevolutionsPerSecond;
+                //                 if (this.group === "[Channel1]") {
+                //                     console.log(value + "\t" + diff + "\t" + wheelTimerDelta + "\t" + wheelVelocity + "\t" + wheelVelocity / baseRevolutionsPerSecond);
+                //                 }
+                if (engine.getValue(this.group, "scratch2_enable")) {
+                    engine.setValue(this.group, "scratch2", wheelVelocity / baseRevolutionsPerSecond);
+                } else {
+                    if (this.deck.wheelMode === wheelModes.motor
+                        || (this.deck.wheelMode === wheelModes.jog && this.deck.wheelTouch.touched)
+                    ) {
+                        return;
+                    }
+                    engine.setValue(this.group, "jog", wheelVelocity * 4);
+                }
+            },
+        });
+
+        this.wheelLED = new Component({
+            outKey: "playposition",
+            output: function(fractionOfTrack) {
+                const durationSeconds = engine.getValue(this.group, "duration");
+                const positionSeconds = fractionOfTrack * durationSeconds;
+                const revolutions = positionSeconds * baseRevolutionsPerSecond;
+                const fractionalRevolution = revolutions - Math.floor(revolutions);
+                const LEDposition = fractionalRevolution * wheelAbsoluteMax;
+
+                const wheelOutput = Array(40).fill(0);
+                wheelOutput[0] = decks[0] - 1;
+                wheelOutput[1] = wheelLEDmodes.spot;
+                wheelOutput[2] = LEDposition & (2**8 - 1);
+                wheelOutput[3] = LEDposition >> 8;
+                wheelOutput[4] = this.color + Button.prototype.brightnessOn;
+                controller.send(wheelOutput, null, 50, true);
+            }
+        });
+
+        for (const property in this) {
+            if (Object.prototype.hasOwnProperty.call(this, property)) {
+                const component = this[property];
+                if (component instanceof Component) {
+                    Object.assign(component, io[property]);
+                    if (component.inPacket === undefined) {
+                        component.inPacket = inPackets[1];
+                    }
+                    component.outPacket = outPacket;
+                    if (component.group === undefined) {
+                        component.group = this.group;
+                    }
+                    if (component.color === undefined) {
+                        component.color = this.color;
+                    }
+                    if (component instanceof Encoder) {
+                        component.max = 2**component.inBitLength - 1;
+                    }
+                    component.inConnect();
+                    component.outConnect();
+                    component.outTrigger();
+                }
+            }
+        }
+        this.shiftButton.send(LEDColors.white + this.brightnessOff);
+    }
+}
+
+class S4Mk3MixerColumn extends ComponentContainer {
+    constructor(group, inPackets, outPacket, io) {
+        super();
+
+        this.group = group;
+
+        this.gain = new Pot({
+            inKey: "pregain",
+        });
+        this.eqHigh = new Pot({
+            group: "[EqualizerRack1_" + group + "_Effect1]",
+            inKey: "parameter3",
+        });
+        this.eqMid = new Pot({
+            group: "[EqualizerRack1_" + group + "_Effect1]",
+            inKey: "parameter2",
+        });
+        this.eqLow = new Pot({
+            group: "[EqualizerRack1_" + group + "_Effect1]",
+            inKey: "parameter1",
+        });
+        this.quickEffectKnob = new Pot({
+            group: "[QuickEffectRack1_" + group + "]",
+            inKey: "super1",
+        });
+        this.volume = new Pot({
+            inKey: "volume",
+        });
+
+        this.pfl = new ToggleButton({
+            inKey: "pfl",
+            outKey: "pfl",
+            output: uncoloredButtonOutput,
+        });
+
+        this.effectUnit1Assign = new PowerWindowButton({
+            group: "[EffectRack1_EffectUnit1]",
+            key: "group_" + this.group + "_enable",
+            output: uncoloredButtonOutput,
+        });
+
+        this.effectUnit2Assign = new PowerWindowButton({
+            group: "[EffectRack1_EffectUnit2]",
+            key: "group_" + this.group + "_enable",
+            output: uncoloredButtonOutput,
+        });
+
+        // FIXME: Why is output not working for these?
+        this.saveGain = new PushButton({
+            key: "update_replaygain_from_pregain",
+            output: uncoloredButtonOutput,
+        });
+
+        this.crossfaderSwitch = new Component({
+            inBitLength: 2,
+            input: function(value) {
+                if (value === 0) {
+                    engine.setValue(this.group, "orientation", 2);
+                } else if (value === 1) {
+                    engine.setValue(this.group, "orientation", 1);
+                } else if (value === 2) {
+                    engine.setValue(this.group, "orientation", 0);
+                }
+            },
+        });
+
+        for (const property in this) {
+            if (Object.prototype.hasOwnProperty.call(this, property)) {
+                const component = this[property];
+                if (component instanceof Component) {
+                    Object.assign(component, io[property]);
+                    if (component instanceof Pot) {
+                        component.inPacket = inPackets[2];
+                    } else {
+                        component.inPacket = inPackets[1];
+                    }
+                    component.outPacket = outPacket;
+
+                    if (component.group === undefined) {
+                        component.group = this.group;
+                    }
+
+                    component.inConnect();
+                    component.outConnect();
+                    component.outTrigger();
+                }
+            }
+        }
+    }
+}
+
+const packetToBinaryString = (data) => {
+    let string = "";
+    for (const byte of data) {
+        if (byte === 0) {
+            // special case because Math.log(0) === Infinity
+            string = string + "0".repeat(8) + ",";
+        } else {
+            const numOfZeroes = 7 - Math.floor(Math.log(byte) / Math.log(2));
+            string = string + "0".repeat(numOfZeroes) + byte.toString(2) + ",";
+        }
+    }
+    // remove trailing comma
+    return string.slice(0, -1);
+};
+
+class S4MK3 {
+    constructor() {
+        if (engine.getValue("[Master]", "num_samplers") < 32) {
+            engine.setValue("[Master]", "num_samplers", 32);
+        }
+
+        this.inPackets = [];
+        this.inPackets[1] = new HIDInputPacket(1);
+        this.inPackets[2] = new HIDInputPacket(2);
+        this.inPackets[3] = new HIDInputPacket(3);
+
+        this.outPackets = [];
+        this.outPackets[128] = new HIDOutputPacket(128, 94);
+
+        this.effectUnit1 = new S4Mk3EffectUnit(1, this.inPackets, this.outPackets[128],
+            {
+                mixKnob: {inByte: 31},
+                knobs: [
+                    {inByte: 33},
+                    {inByte: 35},
+                    {inByte: 37},
+                ],
+                buttons: [
+                    {inByte: 2, inBit: 7, outByte: 63},
+                    {inByte: 2, inBit: 3, outByte: 64},
+                    {inByte: 2, inBit: 2, outByte: 65},
+                ],
+            }
+        );
+        this.effectUnit2 = new S4Mk3EffectUnit(2, this.inPackets, this.outPackets[128],
+            {
+                mixKnob: {inByte: 71},
+                knobs: [
+                    {inByte: 73},
+                    {inByte: 75},
+                    {inByte: 77},
+                ],
+                buttons: [
+                    {inByte: 10, inBit: 5, outByte: 74},
+                    {inByte: 10, inBit: 6, outByte: 75},
+                    {inByte: 10, inBit: 7, outByte: 76},
+                ],
+            }
+        );
+
+        // There is no consistent offset between the left and right deck,
+        // so every single components' IO needs to be specified individually
+        // for both decks.
+        this.leftDeck = new S4Mk3Deck(
+            [1, 3], [deckColors[0], deckColors[2]],
+            this.inPackets, this.outPackets[128],
+            {
+                playButton: {inByte: 5, inBit: 0, outByte: 55},
+                cueButton: {inByte: 5, inBit: 1, outByte: 8},
+                syncButton: {inByte: 6, inBit: 7, outByte: 14},
+                syncMasterButton: {inByte: 1, inBit: 0, outByte: 15},
+                hotcuePadModeButton: {inByte: 5, inBit: 2, outByte: 9},
+                recordPadModeButton: {inByte: 5, inBit: 3, outByte: 56},
+                samplesPadModeButton: {inByte: 5, inBit: 4, outByte: 57},
+                mutePadModeButton: {inByte: 5, inBit: 5, outByte: 58},
+                stemsPadModeButton: {inByte: 6, inBit: 0, outByte: 10},
+                deckButtonLeft: {inByte: 6, inBit: 2},
+                deckButtonRight: {inByte: 6, inBit: 3},
+                deckButtonOutputByteOffset: 12,
+                tempoFaderLED: {outByte: 11},
+                shiftButton: {inByte: 6, inBit: 1, outByte: 59},
+                leftEncoder: {inByte: 20, inBit: 0},
+                leftEncoderPress: {inByte: 7, inBit: 2},
+                rightEncoder: {inByte: 20, inBit: 4},
+                rightEncoderPress: {inByte: 7, inBit: 5},
+                libraryEncoder: {inByte: 21, inBit: 0},
+                libraryEncoderPress: {inByte: 1, inBit: 1},
+                turntableButton: {inByte: 6, inBit: 5, outByte: 17},
+                jogButton: {inByte: 6, inBit: 4, outByte: 16},
+                gridButton: {inByte: 6, inBit: 6, outByte: 18},
+                reverseButton: {inByte: 2, inBit: 4, outByte: 60},
+                fluxButton: {inByte: 2, inBit: 5, outByte: 61},
+                libraryPlayButton: {inByte: 1, inBit: 5, outByte: 22},
+                libraryStarButton: {inByte: 1, inBit: 4, outByte: 21},
+                libraryPlaylistButton: {inByte: 2, inBit: 1, outByte: 20},
+                libraryViewButton: {inByte: 2, inBit: 0, outByte: 19},
+                pads: [
+                    {inByte: 4, inBit: 5, outByte: 0},
+                    {inByte: 4, inBit: 4, outByte: 1},
+                    {inByte: 4, inBit: 7, outByte: 2},
+                    {inByte: 4, inBit: 6, outByte: 3},
+
+                    {inByte: 4, inBit: 3, outByte: 4},
+                    {inByte: 4, inBit: 2, outByte: 5},
+                    {inByte: 4, inBit: 1, outByte: 6},
+                    {inByte: 4, inBit: 0, outByte: 7},
+                ],
+                tempoFader: {inByte: 13, inBit: 0, inBitLength: 16, inPacket: this.inPackets[2]},
+                wheelRelative: {inByte: 12, inBit: 0, inBitLength: 16, inPacket: this.inPackets[3]},
+                wheelAbsolute: {inByte: 16, inBit: 0, inBitLength: 16, inPacket: this.inPackets[3]},
+                wheelTouch: {inByte: 17, inBit: 4},
+            }
+        );
+
+        this.rightDeck = new S4Mk3Deck(
+            [2, 4], [deckColors[1], deckColors[3]],
+            this.inPackets, this.outPackets[128],
+            {
+                playButton: {inByte: 13, inBit: 0, outByte: 66},
+                cueButton: {inByte: 15, inBit: 5, outByte: 31},
+                syncButton: {inByte: 15, inBit: 4, outByte: 37},
+                syncMasterButton: {inByte: 11, inBit: 0, outByte: 38},
+                hotcuePadModeButton: {inByte: 13, inBit: 2, outByte: 32},
+                recordPadModeButton: {inByte: 13, inBit: 3, outByte: 67},
+                samplesPadModeButton: {inByte: 13, inBit: 4, outByte: 68},
+                mutePadModeButton: {inByte: 13, inBit: 5, outByte: 69},
+                stemsPadModeButton: {inByte: 13, inBit: 1, outByte: 33},
+                deckButtonLeft: {inByte: 15, inBit: 2},
+                deckButtonRight: {inByte: 15, inBit: 3},
+                deckButtonOutputByteOffset: 35,
+                tempoFaderLED: {outByte: 34},
+                shiftButton: {inByte: 15, inBit: 1, outByte: 70},
+                leftEncoder: {inByte: 21, inBit: 4},
+                leftEncoderPress: {inByte: 16, inBit: 5},
+                rightEncoder: {inByte: 22, inBit: 0},
+                rightEncoderPress: {inByte: 16, inBit: 2},
+                libraryEncoder: {inByte: 22, inBit: 4},
+                libraryEncoderPress: {inByte: 11, inBit: 1},
+                turntableButton: {inByte: 15, inBit: 6, outByte: 40},
+                jogButton: {inByte: 15, inBit: 0, outByte: 39},
+                gridButton: {inByte: 15, inBit: 7, outByte: 41},
+                reverseButton: {inByte: 11, inBit: 4, outByte: 71},
+                fluxButton: {inByte: 11, inBit: 5, outByte: 72},
+                libraryPlayButton: {inByte: 10, inBit: 2, outByte: 45},
+                libraryStarButton: {inByte: 10, inBit: 1, outByte: 44},
+                libraryPlaylistButton: {inByte: 10, inBit: 3, outByte: 43},
+                libraryViewButton: {inByte: 10, inBit: 0, outByte: 42},
+                pads: [
+                    {inByte: 14, inBit: 5, outByte: 23},
+                    {inByte: 14, inBit: 4, outByte: 24},
+                    {inByte: 14, inBit: 7, outByte: 25},
+                    {inByte: 14, inBit: 6, outByte: 26},
+
+                    {inByte: 14, inBit: 3, outByte: 27},
+                    {inByte: 14, inBit: 2, outByte: 28},
+                    {inByte: 14, inBit: 1, outByte: 29},
+                    {inByte: 14, inBit: 0, outByte: 30},
+                ],
+                tempoFader: {inByte: 11, inBit: 0, inBitLength: 16, inPacket: this.inPackets[2]},
+                wheelRelative: {inByte: 40, inBit: 0, inBitLength: 16, inPacket: this.inPackets[3]},
+                wheelAbsolute: {inByte: 44, inBit: 0, inBitLength: 16, inPacket: this.inPackets[3]},
+                wheelTouch: {inByte: 17, inBit: 5},
+            }
+        );
+
+        this.mixerColumnDeck1 = new S4Mk3MixerColumn("[Channel1]", this.inPackets, this.outPackets[128],
+            {
+                saveGain: {inByte: 12, inBit: 0, outByte: 80},
+                effectUnit1Assign: {inByte: 3, inBit: 3, outByte: 78},
+                effectUnit2Assign: {inByte: 3, inBit: 4, outByte: 79},
+                gain: {inByte: 17},
+                eqHigh: {inByte: 45},
+                eqMid: {inByte: 47},
+                eqLow: {inByte: 49},
+                quickEffectKnob: {inByte: 65},
+                quickEffectButton: {},
+                volume: {inByte: 3},
+                pfl: {inByte: 8, inBit: 3, outByte: 77},
+                crossfaderSwitch: {inByte: 18, inBit: 4},
+            }
+        );
+        this.mixerColumnDeck2 = new S4Mk3MixerColumn("[Channel2]", this.inPackets, this.outPackets[128],
+            {
+                saveGain: {inByte: 12, inBit: 1, outByte: 84},
+                effectUnit1Assign: {inByte: 3, inBit: 5, outByte: 82},
+                effectUnit2Assign: {inByte: 3, inBit: 6, outByte: 83},
+                gain: {inByte: 19},
+                eqHigh: {inByte: 51},
+                eqMid: {inByte: 53},
+                eqLow: {inByte: 55},
+                quickEffectKnob: {inByte: 67},
+                volume: {inByte: 5},
+                pfl: {inByte: 8, inBit: 6, outByte: 81},
+                crossfaderSwitch: {inByte: 18, inBit: 2},
+            }
+        );
+        this.mixerColumnDeck3 = new S4Mk3MixerColumn("[Channel3]", this.inPackets, this.outPackets[128],
+            {
+                saveGain: {inByte: 3, inBit: 1, outByte: 88},
+                effectUnit1Assign: {inByte: 3, inBit: 0, outByte: 86},
+                effectUnit2Assign: {inByte: 3, inBit: 2, outByte: 87},
+                gain: {inByte: 15},
+                eqHigh: {inByte: 39},
+                eqMid: {inByte: 41},
+                eqLow: {inByte: 43},
+                quickEffectKnob: {inByte: 63},
+                volume: {inByte: 7},
+                pfl: {inByte: 8, inBit: 2, outByte: 85},
+                crossfaderSwitch: {inByte: 18, inBit: 6},
+            }
+        );
+        this.mixerColumnDeck4 = new S4Mk3MixerColumn("[Channel4]", this.inPackets, this.outPackets[128],
+            {
+                saveGain: {inByte: 12, inBit: 2, outByte: 92},
+                effectUnit1Assign: {inByte: 3, inBit: 7, outByte: 90},
+                effectUnit2Assign: {inByte: 12, inBit: 7, outByte: 91},
+                gain: {inByte: 21},
+                eqHigh: {inByte: 57},
+                eqMid: {inByte: 59},
+                eqLow: {inByte: 61},
+                quickEffectKnob: {inByte: 69},
+                volume: {inByte: 9},
+                pfl: {inByte: 8, inBit: 7, outByte: 89},
+                crossfaderSwitch: {inByte: 18, inBit: 0},
+            }
+        );
+
+        // The interaction between the FX SELECT buttons and the QuickEffect enable buttons is rather complex.
+        // It is easier to have this separate from the S4Mk3MixerColumn class and the FX SELECT buttons are not
+        // really in the mixer columns.
+        const mixer = new ComponentContainer();
+        mixer.firstPressedFxSelector = null;
+        mixer.secondPressedFxSelector = null;
+        const calculatePresetNumber = function() {
+            if (mixer.firstPressedFxSelector === mixer.secondPressedFxSelector || mixer.secondPressedFxSelector === null) {
+                return mixer.firstPressedFxSelector;
+            }
+            let presetNumber = 5 + (4 * (mixer.firstPressedFxSelector - 1)) + mixer.secondPressedFxSelector;
+            if (mixer.secondPressedFxSelector > mixer.firstPressedFxSelector) {
+                presetNumber--;
+            }
+            return presetNumber;
+        };
+        mixer.comboSelected = false;
+        const resetFxSelectorColors = () => {
+            const packet = this.outPackets[128];
+            for (const selector of [1, 2, 3, 4, 5]) {
+                packet.data[49 + selector] = quickEffectPresetColors[selector - 1] + Button.prototype.brightnessOn;
+            }
+            packet.send();
+        };
+        const fxSelectInput = function(pressed) {
+            if (pressed) {
+                if (mixer.firstPressedFxSelector === null) {
+                    mixer.firstPressedFxSelector = this.number;
+                    for (const selector of [1, 2, 3, 4, 5]) {
+                        if (selector !== this.number) {
+                            let presetNumber = 5 + (4 * (mixer.firstPressedFxSelector - 1)) + selector;
+                            if (selector > this.number) {
+                                presetNumber--;
+                            }
+                            this.outPacket.data[49 + selector] = quickEffectPresetColors[presetNumber - 1] + this.brightnessOn;
+                        }
+                    }
+                    this.outPacket.send();
+                } else {
+                    mixer.secondPressedFxSelector = this.number;
+                }
+            } else {
+            // After a second selector was released, avoid loading a different preset when
+            // releasing the first pressed selector.
+                if (mixer.comboSelected && this.number === mixer.firstPressedFxSelector) {
+                    mixer.comboSelected = false;
+                    mixer.firstPressedFxSelector = null;
+                    mixer.secondPressedFxSelector = null;
+                    resetFxSelectorColors();
+                    return;
+                }
+                // If mixer.firstPressedFxSelector === null, it was reset by the input handler for
+                // a QuickEffect enable button to load the preset for only one deck.
+                if (mixer.firstPressedFxSelector !== null) {
+                    for (const deck of [1, 2, 3, 4]) {
+                        engine.setValue("[QuickEffectRack1_[Channel" + deck + "]]", "loaded_chain_preset", calculatePresetNumber());
+                    }
+                }
+                if (mixer.firstPressedFxSelector === this.number) {
+                    mixer.firstPressedFxSelector = null;
+                    resetFxSelectorColors();
+                }
+                if (mixer.secondPressedFxSelector !== null) {
+                    mixer.comboSelected = true;
+                }
+                mixer.secondPressedFxSelector = null;
+            }
+        };
+        mixer.fxSelect1 = new Button({
+            inByte: 9,
+            inBit: 5,
+            number: 1,
+            input: fxSelectInput,
+        });
+        mixer.fxSelect2 = new Button({
+            inByte: 9,
+            inBit: 1,
+            number: 2,
+            input: fxSelectInput,
+        });
+        mixer.fxSelect3 = new Button({
+            inByte: 9,
+            inBit: 6,
+            number: 3,
+            input: fxSelectInput,
+        });
+        mixer.fxSelect4 = new Button({
+            inByte: 9,
+            inBit: 0,
+            number: 4,
+            input: fxSelectInput,
+        });
+        mixer.fxSelectFilter = new Button({
+            inByte: 9,
+            inBit: 7,
+            number: 5,
+            input: fxSelectInput,
+        });
+
+        const quickEffectButton = class extends Button {
+            constructor(options) {
+                super(options);
+                if (this.number === undefined || !Number.isInteger(this.number) || this.number < 1) {
+                    throw Error("number attribute must be an integer >= 1");
+                }
+                this.group = "[QuickEffectRack1_[Channel" + this.number + "]]";
+                this.outConnect();
+                this.isLongPressed = false;
+                this.longPressTimer = 0;
+            }
+            input(pressed) {
+                if (mixer.firstPressedFxSelector === null) {
+                    if (pressed) {
+                        script.toggleControl(this.group, "enabled");
+                        this.longPressTimer = engine.beginTimer(this.longPressTimeOut, () => {
+                            this.isLongPressed = true;
+                            this.longPressTimer = 0;
+                        }, true);
+                    } else {
+                        if (this.isLongPressed) {
+                            script.toggleControl(this.group, "enabled");
+                        }
+                        if (this.longPressTimer !== 0) {
+                            engine.stopTimer(this.longPressTimer);
+                        }
+                        this.longPressTimer = 0;
+                        this.isLongPressed = false;
+                    }
+                } else {
+                    if (pressed) {
+                        const presetNumber = calculatePresetNumber();
+                        this.color = quickEffectPresetColors[presetNumber - 1];
+                        engine.setValue(this.group, "loaded_chain_preset", presetNumber);
+                        mixer.firstPressedFxSelector = null;
+                        mixer.secondPressedFxSelector = null;
+                        resetFxSelectorColors();
+                    }
+                }
+            }
+            output(enabled) {
+                if (enabled) {
+                    this.send(this.color + this.brightnessOn);
+                } else {
+                    // It is easy to mistake the dim state for the bright state, so turn
+                    // the LED fully off.
+                    this.send(0);
+                }
+            }
+            presetLoaded(presetNumber) {
+                this.color = quickEffectPresetColors[presetNumber - 1];
+                this.outConnections[1].trigger();
+            }
+            outConnect() {
+                if (this.group !== undefined) {
+                    this.outConnections[0] = engine.makeConnection(this.group, "loaded_chain_preset", this.presetLoaded.bind(this));
+                    this.outConnections[1] = engine.makeConnection(this.group, "enabled", this.output.bind(this));
+                }
+            }
+        };
+        mixer.quickEffectButton1 = new quickEffectButton({
+            number: 1,
+            inByte: 8,
+            inBit: 0,
+            outByte: 46
+        });
+        mixer.quickEffectButton2 = new quickEffectButton({
+            number: 2,
+            inByte: 8,
+            inBit: 5,
+            outByte: 47
+        });
+        mixer.quickEffectButton3 = new quickEffectButton({
+            number: 3,
+            inByte: 8,
+            inBit: 1,
+            outByte: 48
+        });
+        mixer.quickEffectButton4 = new quickEffectButton({
+            number: 4,
+            inByte: 8,
+            inBit: 4,
+            outByte: 49
+        });
+        resetFxSelectorColors();
+
+        mixer.quantizeButton = new Button({
+            input: function(pressed) {
+                if (pressed) {
+                    this.globalQuantizeOn = !this.globalQuantizeOn;
+                    for (let i = 1; i <= 4; i++) {
+                        engine.setValue("[Channel" + i + "]", "quantize", this.globalQuantizeOn);
+                    }
+                    this.send(this.globalQuantizeOn ? 127 : 0);
+                }
+            },
+            globalQuantizeOn: false,
+            inByte: 12,
+            inBit: 6,
+            outByte: 93,
+        });
+
+        mixer.crossfader = new Pot({
+            group: "[Master]",
+            inKey: "crossfader",
+            inByte: 1,
+            inPacket: this.inPackets[2],
+        });
+        mixer.crossfaderCurveSwitch = new Component({
+            inByte: 19,
+            inBit: 0,
+            inBitLength: 2,
+            input: function(value) {
+                switch (value) {
+                case 0x00:  // Picnic Bench / Fast Cut
+                    engine.setValue("[Mixer Profile]", "xFaderMode", 0);
+                    engine.setValue("[Mixer Profile]", "xFaderCalibration", 0.9);
+                    engine.setValue("[Mixer Profile]", "xFaderCurve", 7.0);
+                    break;
+                case 0x01:  // Constant Power
+                    engine.setValue("[Mixer Profile]", "xFaderMode", 1);
+                    engine.setValue("[Mixer Profile]", "xFaderCalibration", 0.3);
+                    engine.setValue("[Mixer Profile]", "xFaderCurve", 0.6);
+                    break;
+                case 0x02: // Additive
+                    engine.setValue("[Mixer Profile]", "xFaderMode", 0);
+                    engine.setValue("[Mixer Profile]", "xFaderCalibration", 0.4);
+                    engine.setValue("[Mixer Profile]", "xFaderCurve", 0.9);
+                }
+            },
+        });
+
+        for (const component of mixer) {
+            if (component.inPacket === undefined) {
+                component.inPacket = this.inPackets[1];
+            }
+            component.outPacket = this.outPackets[128];
+            component.inConnect();
+            component.outConnect();
+            component.outTrigger();
+        }
+
+        let lightQuantizeButton = true;
+        for (let i = 1; i <= 4; i++) {
+            if (!engine.getValue("[Channel" + i + "]", "quantize")) {
+                lightQuantizeButton = false;
+            }
+        }
+        mixer.quantizeButton.send(lightQuantizeButton ? 127 : 0);
+        mixer.quantizeButton.globalQuantizeOn = lightQuantizeButton;
+
+        /* eslint no-unused-vars: "off" */
+        const meterConnection = engine.makeConnection("[Master]", "guiTick50ms", function(_value) {
+            const deckMeters = Array(78).fill(0);
+            // Each column has 14 segments, but treat the top one specially for the clip indicator.
+            const deckSegments = 13;
+            for (let deckNum = 1; deckNum <= 4; deckNum++) {
+                const deckGroup = "[Channel" + deckNum + "]";
+                const deckLevel = engine.getValue(deckGroup, "VuMeter");
+                const columnBaseIndex = (deckNum - 1) * (deckSegments + 2);
+                const scaledLevel = deckLevel * deckSegments;
+                const segmentsToLightFully = Math.floor(scaledLevel);
+                const partialSegmentValue = scaledLevel - segmentsToLightFully;
+                if (segmentsToLightFully > 0) {
+                // There are 3 brightness levels per segment: off, dim, and full.
+                    for (let i = 0; i <= segmentsToLightFully; i++) {
+                        deckMeters[columnBaseIndex + i] = 127;
+                    }
+                    if (partialSegmentValue > 0.5 && segmentsToLightFully < deckSegments) {
+                        deckMeters[columnBaseIndex + segmentsToLightFully + 1] = 125;
+                    }
+                }
+                if (engine.getValue(deckGroup, "PeakIndicator")) {
+                    deckMeters[columnBaseIndex + deckSegments + 1] = 127;
+                }
+            }
+            // There are more bytes in the packet which seem like they should be for the main
+            // mix meters, but setting those bytes does not do anything, except for lighting
+            // the clip lights on the main mix meters.
+            controller.send(deckMeters, null, 129);
+        });
+
+        const motorTimer = engine.beginTimer(20, () => {
+            const baseRate = 6068;
+            let velocityLeft = 0;
+            let velocityRight = 0;
+            const S4Mk3 = this;
+            if (this.leftDeck.wheelMode === wheelModes.motor
+                  && engine.getValue(this.leftDeck.group, "play")) {
+                velocityLeft = baseRate * engine.getValue(S4Mk3.leftDeck.group, "rate_ratio");
+            }
+            if (this.rightDeck.wheelMode === wheelModes.motor
+                  && engine.getValue(this.rightDeck.group, "play")) {
+                velocityRight = baseRate * engine.getValue(S4Mk3.rightDeck.group, "rate_ratio");
+            }
+            // byte 2 > 127 rotates backward
+            const motor = [1, 32, 1, velocityLeft & (2**8 - 1), velocityLeft >> 8,
+                1, 32, 1, velocityRight & (2**8 - 1), velocityRight >> 8];
+            controller.send(motor, null, 49, true);
+        });
+    }
+    incomingData(data) {
+        const reportId = data[0];
+        if (reportId === 1) {
+            this.inPackets[1].handleInput(data.buffer);
+        } else if (reportId === 2) {
+            this.inPackets[2].handleInput(data.buffer);
+            // The master volume, booth volume, headphone mix, and headphone volume knobs
+            // control the controller's audio interface in hardware, so they are not mapped.
+        } else if (reportId === 3) {
+            // The 32 bit unsigned ints at bytes 8 and 36 always have exactly the same value,
+            // so only process one of them. This must be processed before the wheel positions.
+            const oldWheelTimer = wheelTimer;
+            const view = new DataView(data.buffer);
+            wheelTimer = view.getUint32(8, true);
+            // Processing first value; no previous value to compare with.
+            if (oldWheelTimer === null) {
+                return;
+            }
+            wheelTimerDelta = wheelTimer - oldWheelTimer;
+            if (wheelTimerDelta < 0) {
+                wheelTimerDelta += wheelTimerMax;
+            }
+
+            this.leftDeck.wheelRelative.input(view.getUint16(12, true));
+            this.rightDeck.wheelRelative.input(view.getUint16(40, true));
+        }
+    }
+    init() {
+        // sending these magic packets is required for the jog wheel LEDs to work
+        const wheelLEDinitPacket = Array(26).fill(0);
+        wheelLEDinitPacket[1] = 1;
+        wheelLEDinitPacket[2] = 3;
+        controller.send(wheelLEDinitPacket, null, 48);
+        wheelLEDinitPacket[0] = 1;
+        // hack around https://github.com/mixxxdj/mixxx/issues/10828
+        engine.beginTimer(35, () => { controller.send(wheelLEDinitPacket, null, 48); }, true);
+
+        // get state of knobs and faders
+        this.incomingData(new Uint8Array(controller.getInputReport(2)));
+    }
+    shutdown() {
+        // button LEDs
+        controller.send(new Array(94).fill(0), null, 128);
+
+        // meter LEDs
+        controller.send(new Array(78).fill(0), null, 129);
+
+        const wheelOutput = Array(40).fill(0);
+        // left wheel LEDs
+        controller.send(wheelOutput, null, 50);
+        // right wheel LEDs
+        wheelOutput[0] = 1;
+        controller.send(wheelOutput, null, 50);
+    }
+}
+
+/* eslint no-unused-vars: "off", no-var: "off" */
+var TraktorS4MK3 = new S4MK3();

--- a/res/controllers/Traktor-Kontrol-S4-MK3.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK3.js
@@ -52,11 +52,11 @@ const DeckColors = [
 ];
 
 const LibrarySortableColumns = [
-    LibraryColumns.Artist,
-    LibraryColumns.Title,
-    LibraryColumns.BPM,
-    LibraryColumns.Key,
-    LibraryColumns.DatetimeAdded,
+    script.LIBRARY_COLUMNS.ARTIST,
+    script.LIBRARY_COLUMNS.TITLE,
+    script.LIBRARY_COLUMNS.BPM,
+    script.LIBRARY_COLUMNS.KEY,
+    script.LIBRARY_COLUMNS.DATETIME_ADDED,
 ];
 
 const LoopWheelMoveFactor = 50;
@@ -279,11 +279,11 @@ class Component {
             this.inKey = this.key;
             this.outKey = this.key;
         }
-        if (typeof this.unshift === "function") {
+        if (typeof this.unshift === "function" && this.unshift.length) {
             this.unshift();
         }
         this.shifted = false;
-        if (typeof this.input === "function" && this.inReport instanceof HIDInputReport) {
+        if (typeof this.input === "function" && this.inReport instanceof HIDInputReport && this.inReport.length === 0) {
             this.inConnect();
         }
         this.outConnect();
@@ -360,24 +360,24 @@ class ComponentContainer extends Component {
     }
     reconnectComponents(callback) {
         for (const component of this) {
-            if (typeof component.outDisconnect === "function") {
+            if (typeof component.outDisconnect === "function" && component.outDisconnect.length === 0) {
                 component.outDisconnect();
             }
-            if (typeof callback === "function") {
+            if (typeof callback === "function" && callback.length === 0) {
                 callback.call(this, component);
             }
-            if (typeof component.outConnect === "function") {
+            if (typeof component.outConnect === "function" && component.outConnect.length === 0) {
                 component.outConnect();
             }
             component.outTrigger();
-            if (typeof component.unshift === "function") {
+            if (typeof component.unshift === "function" && component.unshift.length === 0) {
                 component.unshift();
             }
         }
     }
     unshift() {
         for (const component of this) {
-            if (typeof component.unshift === "function") {
+            if (typeof component.unshift === "function" && component.unshift.length === 0) {
                 component.unshift();
             }
             component.shifted = false;
@@ -386,7 +386,7 @@ class ComponentContainer extends Component {
     }
     shift() {
         for (const component of this) {
-            if (typeof component.shift === "function") {
+            if (typeof component.shift === "function" && component.shift.length === 0) {
                 component.shift();
             }
             component.shifted = true;
@@ -485,7 +485,8 @@ class Button extends Component {
         if (this.input === undefined) {
             this.input = this.defaultInput;
             if (typeof this.input === "function"
-                && this.inReport !== undefined && this.inReport instanceof HIDInputReport) {
+                && this.inReport instanceof HIDInputReport
+                && this.input.length === 0) {
                 this.inConnect();
             }
         }
@@ -549,8 +550,8 @@ class Button extends Component {
     defaultInput(pressed) {
         if (pressed) {
             this.isLongPress = false;
-            if (typeof this.onShortPress === "function") { this.onShortPress(); }
-            if (typeof this.onLongPress === "function" || typeof this.onLongRelease === "function") {
+            if (typeof this.onShortPress === "function" && this.onShortPress.length === 0) { this.onShortPress(); }
+            if ((typeof this.onLongPress === "function" && this.onLongPress.length === 0) || (typeof this.onLongRelease === "function" && this.onLongRelease.length === 0)) {
                 this.longPressTimer = engine.beginTimer(this.longPressTimeOutMillis, () => {
                     this.isLongPress = true;
                     this.longPressTimer = 0;
@@ -559,13 +560,13 @@ class Button extends Component {
                 }, true);
             }
         } else if (this.isLongPress) {
-            if (typeof this.onLongRelease === "function") { this.onLongRelease(); }
+            if (typeof this.onLongRelease === "function" && this.onLongRelease.length === 0) { this.onLongRelease(); }
         } else {
             if (this.longPressTimer !== 0) {
                 engine.stopTimer(this.longPressTimer);
                 this.longPressTimer = 0;
             }
-            if (typeof this.onShortRelease === "function") { this.onShortRelease(); }
+            if (typeof this.onShortRelease === "function" && this.onShortRelease.length === 0) { this.onShortRelease(); }
         }
     }
 }
@@ -818,13 +819,16 @@ class BeatLoopRollButton extends TriggerButton {
         if (options.number <= 5  || !AddLoopHalveAndDoubleOnBeatloopRollTab) {
             options.key = "beatlooproll_"+BeatLoopRolls[AddLoopHalveAndDoubleOnBeatloopRollTab ? options.number + 1 : options.number]+"_activate";
             options.onShortPress = function() {
-                this.beatloopSize = engine.getValue(this.group, "beatloop_size");
+                if (!this.deck.beatloopSize) {
+                    this.deck.beatloopSize = engine.getValue(this.group, "beatloop_size");
+                }
                 engine.setValue(this.group, this.inKey, true);
             };
             options.onShortRelease = function() {
                 engine.setValue(this.group, this.inKey, false);
-                if (this.beatloopSize) {
-                    engine.setValue(this.group, "beatloop_size", this.beatloopSize);
+                if (this.deck.beatloopSize) {
+                    engine.setValue(this.group, "beatloop_size", this.deck.beatloopSize);
+                    this.deck.beatloopSize = undefined;
                 }
             };
         } else if (options.number === 6) {
@@ -1990,7 +1994,7 @@ class S4Mk3Deck extends Deck {
         });
         this.libraryEncoderPress = new Button({
             libraryViewButtonPressed: false,
-            onShortPress: function(pressed) {
+            onShortPress: function() {
                 if (this.libraryViewButtonPressed) {
                     script.toggleControl("[Library]", "sort_order");
                 } else {
@@ -2526,7 +2530,7 @@ class S4Mk3Deck extends Deck {
                     component.inConnect();
                     component.outConnect();
                     component.outTrigger();
-                    if (typeof this.unshift === "function") {
+                    if (typeof this.unshift === "function" && this.unshift.length === 0) {
                         this.unshift();
                     }
                 }

--- a/res/controllers/Traktor-Kontrol-S4-MK3.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK3.js
@@ -90,7 +90,7 @@ const keepLEDWithOneColorDimedWhenInactive = true;
 // 'true' will use "sync+master", 'false' will use "shift+sync". Default: false
 const useKeylockOnMaster = false;
 
-// Define whether the grid button would blink when the playback is going over a detcted beat. Can help to adjust beat grid.
+// Define whether the grid button would blink when the playback is going over a detected beat. Can help to adjust beat grid.
 // Default: true
 const gridButtonBlinkOverBeat = true;
 
@@ -685,9 +685,6 @@ class Encoder extends Component {
             isRight = value > oldValue;
         }
         this.onChange(isRight);
-    }
-    isRightTurn(value) {
-        // detect wrap around
     }
 }
 
@@ -1550,6 +1547,27 @@ class S4Mk3Deck extends Deck {
                     engine.setValue(this.group, this.key, false);
                 }
             },
+            loopModeOff: function(skipRestore) {
+                if (this.previousWheelMode !== null) {
+                    this.indicator(false);
+                    const wheelOutput = Array(40).fill(0);
+                    wheelOutput[0] = decks[0] - 1;
+                    const that = this;
+                    controller.send(wheelOutput, null, 50, true);
+                    if (!skipRestore) {
+                        that.deck.wheelMode = that.previousWheelMode;
+                    }
+                    that.previousWheelMode = null;
+                    if (this.loopModeConnection !== null) {
+                        this.loopModeConnection.disconnect();
+                        this.loopModeConnection = null;
+                    }
+                }
+            },
+            onLoopChange: function(loopEnabled) {
+                if (loopEnabled) { return; }
+                this.loopModeOff();
+            },
             onShortPress: function() {
                 this.indicator(false);
                 if (this.shifted) {
@@ -1561,24 +1579,13 @@ class S4Mk3Deck extends Deck {
                         this.indicator(true);
                         // Else, we enter/exit the loop in wheel mode
                     } else if (this.previousWheelMode === null) {
+                        this.deck.fluxButton.loopModeOff();
+                        engine.setValue(this.group, "scratch2_enable", false);
                         this.previousWheelMode = this.deck.wheelMode;
                         this.deck.wheelMode = wheelModes.loopIn;
 
                         if (this.loopModeConnection === null) {
-                            this.loopModeConnection = engine.makeConnection(this.group, this.outKey, (loopEnabled) => {
-                                if (loopEnabled) { return; }
-
-                                this.indicator(false);
-                                const wheelOutput = Array(40).fill(0);
-                                wheelOutput[0] = decks[0] - 1;
-                                engine.beginTimer(decks[0] * 35, () => {
-                                    controller.send(wheelOutput, null, 50, true);
-                                    this.deck.wheelMode = this.previousWheelMode;
-                                    this.previousWheelMode = null;
-                                }, true);
-                                this.loopModeConnection.disconnect();
-                                this.loopModeConnection = null;
-                            });
+                            this.loopModeConnection = engine.makeConnection(this.group, this.outKey, this.onLoopChange.bind(this));
                         }
 
                         const wheelOutput = Array(40).fill(0);
@@ -1594,17 +1601,7 @@ class S4Mk3Deck extends Deck {
 
                         this.indicator(true);
                     } else if (this.previousWheelMode !== null) {
-                        if (this.loopModeConnection !== null) {
-                            this.loopModeConnection.disconnect();
-                            this.loopModeConnection = null;
-                        }
-                        const wheelOutput = Array(40).fill(0);
-                        wheelOutput[0] = decks[0] - 1;
-                        engine.beginTimer(decks[0] * 35, () => {
-                            controller.send(wheelOutput, null, 50, true);
-                            this.deck.wheelMode = this.previousWheelMode;
-                            this.previousWheelMode = null;
-                        }, true);
+                        this.loopModeOff();
                     }
                 } else {
                     engine.setValue(this.group, this.key, true);
@@ -1640,6 +1637,27 @@ class S4Mk3Deck extends Deck {
                     engine.setValue(this.group, "scratch2_enable", false);
                 }
             },
+            loopModeOff: function(skipRestore) {
+                if (this.previousWheelMode !== null) {
+                    this.indicator(false);
+                    const wheelOutput = Array(40).fill(0);
+                    wheelOutput[0] = decks[0] - 1;
+                    const that = this;
+                    controller.send(wheelOutput, null, 50, true);
+                    if (!skipRestore) {
+                        that.deck.wheelMode = that.previousWheelMode;
+                    }
+                    that.previousWheelMode = null;
+                    if (this.loopModeConnection !== null) {
+                        this.loopModeConnection.disconnect();
+                        this.loopModeConnection = null;
+                    }
+                }
+            },
+            onLoopChange: function(loopEnabled) {
+                if (loopEnabled) { return; }
+                this.loopModeOff();
+            },
             onShortPress: function() {
                 this.indicator(false);
                 if (this.shifted) {
@@ -1650,23 +1668,12 @@ class S4Mk3Deck extends Deck {
                         this.deck.reverseButton.indicator(false);
                         // Else, we enter/exit the loop in wheel mode
                     } else if (this.previousWheelMode === null) {
+                        this.deck.reverseButton.loopModeOff();
+                        engine.setValue(this.group, "scratch2_enable", false);
                         this.previousWheelMode = this.deck.wheelMode;
                         this.deck.wheelMode = wheelModes.loopOut;
                         if (this.loopModeConnection === null) {
-                            this.loopModeConnection = engine.makeConnection(this.group, this.outKey, (loopEnabled) => {
-                                if (loopEnabled) { return; }
-
-                                this.indicator(false);
-                                const wheelOutput = Array(40).fill(0);
-                                wheelOutput[0] = decks[0] - 1;
-                                engine.beginTimer(decks[0] * 35, () => {
-                                    controller.send(wheelOutput, null, 50, true);
-                                    this.deck.wheelMode = this.previousWheelMode;
-                                    this.previousWheelMode = null;
-                                }, true);
-                                this.loopModeConnection.disconnect();
-                                this.loopModeConnection = null;
-                            });
+                            this.loopModeConnection = engine.makeConnection(this.group, this.outKey, this.onLoopChange.bind(this));
                         }
 
                         const wheelOutput = Array(40).fill(0);
@@ -1684,17 +1691,7 @@ class S4Mk3Deck extends Deck {
 
                         this.indicator(true);
                     } else if (this.previousWheelMode !== null) {
-                        if (this.loopModeConnection !== null) {
-                            this.loopModeConnection.disconnect();
-                            this.loopModeConnection = null;
-                        }
-                        const wheelOutput = Array(40).fill(0);
-                        wheelOutput[0] = decks[0] - 1;
-                        engine.beginTimer(decks[0] * 35, () => {
-                            controller.send(wheelOutput, null, 50, true);
-                            this.deck.wheelMode = this.previousWheelMode;
-                            this.previousWheelMode = null;
-                        }, true);
+                        this.loopModeOff();
                     }
                 } else {
                     engine.setValue(this.group, this.key, true);
@@ -2250,6 +2247,8 @@ class S4Mk3Deck extends Deck {
             deck: this,
             input: function(press) {
                 if (press) {
+                    this.deck.reverseButton.loopModeOff(true);
+                    this.deck.fluxButton.loopModeOff(true);
                     if (this.deck.wheelMode === wheelModes.motor) {
                         this.deck.wheelMode = wheelModes.vinyl;
                         motorWindDownTimer = engine.beginTimer(motorWindDownMilliseconds, motorWindDownTimerCallback, true);
@@ -2275,6 +2274,8 @@ class S4Mk3Deck extends Deck {
             deck: this,
             input: function(press) {
                 if (press) {
+                    this.deck.reverseButton.loopModeOff(true);
+                    this.deck.fluxButton.loopModeOff(true);
                     if (this.deck.wheelMode === wheelModes.vinyl) {
                         this.deck.wheelMode = wheelModes.jog;
                     } else {

--- a/res/controllers/Traktor-Kontrol-S4-MK3.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK3.js
@@ -16,7 +16,7 @@
 /// Bob Ham or an associate of Bob Ham. To the best of your knowledge, information
 /// and belief this mapping will not make its way into the hands of Bob Ham.
 
-const LEDColors = {
+const LedColors = {
     off: 0,
     red: 4,
     carrot: 8,
@@ -37,21 +37,44 @@ const LEDColors = {
     white: 68,
 };
 
+// A full list can be found here: https://manual.mixxx.org/2.4/en/chapters/appendix/mixxx_controls.html#control-[Library]-sort_column
+const LibraryColumns = {
+    Artist: 1,
+    Title: 2,
+    Album: 3,
+    Albumartist: 4,
+    Year: 5,
+    Genre: 6,
+    Composer: 7,
+    Grouping: 8,
+    Tracknumber: 9,
+    Filetype: 10,
+    NativeLocation: 11,
+    Comment: 12,
+    Duration: 13,
+    Bitrate: 14,
+    BPM: 15,
+    ReplayGain: 16,
+    DatetimeAdded: 17,
+    TimesPlayed: 18,
+    Rating: 19,
+};
+
 const KeyboardColors = [
-    LEDColors.red,
-    LEDColors.orange,
-    LEDColors.yellow,
-    LEDColors.lime,
-    LEDColors.green,
-    LEDColors.aqua,
-    LEDColors.celeste,
-    LEDColors.sky,
-    LEDColors.blue,
-    LEDColors.purple,
-    LEDColors.fuscia,
-    LEDColors.azalea,
-    LEDColors.salmon,
-    LEDColors.white,
+    LedColors.red,
+    LedColors.orange,
+    LedColors.yellow,
+    LedColors.lime,
+    LedColors.green,
+    LedColors.aqua,
+    LedColors.celeste,
+    LedColors.sky,
+    LedColors.blue,
+    LedColors.purple,
+    LedColors.fuscia,
+    LedColors.azalea,
+    LedColors.salmon,
+    LedColors.white,
 ];
 
 /*
@@ -59,73 +82,72 @@ const KeyboardColors = [
  * Adjust these to your liking
  */
 
-const deckColors = [
-    LEDColors.red,
-    LEDColors.blue,
-    LEDColors.yellow,
-    LEDColors.purple,
+const DeckColors = [
+    LedColors.red,
+    LedColors.blue,
+    LedColors.yellow,
+    LedColors.purple,
 ];
 
-// A full list can be found here: https://manual.mixxx.org/2.4/en/chapters/appendix/mixxx_controls.html#control-[Library]-sort_column
-const librarySortableColumns = [
-    1,  // Artist
-    2,  // Title
-    15, // BPM
-    20, // Key
-    17, // Date added
+const LibrarySortableColumns = [
+    LibraryColumns.Artist,
+    LibraryColumns.Title,
+    LibraryColumns.BPM,
+    LibraryColumns.Key,
+    LibraryColumns.DatetimeAdded,
 ];
 
-const loopWheelMoveFactor = 50;
-const loopEncoderMoveFactor = 500;
-const loopEncoderShiftMoveFactor = 2500;
+const LOOP_WHEEL_MOVE_FACTOR = 50; // LOOP_WHEEL_MOVE_FACTOR
+const LOOP_ENCODER_MOVE_FACTOR = 500; // LOOP_ENCODER_MOVE_FACTOR
+const LOOP_ENCODER_SHIFTMOVE_FACTOR = 2500; // LOOP_ENCODER_SHIFTMOVE_FACTOR
 
-const tempoFaderSoftTakeoverColorLow = LEDColors.white;
-const tempoFaderSoftTakeoverColorHigh = LEDColors.green;
+const TempoFaderSoftTakeoverColorLow = LedColors.white;
+const TempoFaderSoftTakeoverColorHigh = LedColors.green;
 
 // Define whether or not to keep LED that have only one color (reverse, flux, play) dimmed if they are inactive.
 // 'true' will keep them dimmed, 'false' will turn them off. Default: true
-const keepLEDWithOneColorDimedWhenInactive = true;
+const KeepLEDWithOneColorDimedWhenInactive = true;
 
 // Define whether the keylock is mapped when doing "shift+master" (on press) or "shift+sync" (on release since long push copies the key)".
 // 'true' will use "sync+master", 'false' will use "shift+sync". Default: false
-const useKeylockOnMaster = false;
+const UseKeylockOnMaster = false;
 
-// Define whether the grid button would blink when the playback is going over a detected beat. Can help to adjust beat grid.
-// Default: true
-const gridButtonBlinkOverBeat = true;
+// Define whether the grid button would blink when the playback is going over a detcted beat. Can help to adjust beat grid.
+// Default: false
+const GridButtonBlinkOverBeat = false;
 
 // Define how many wheel moves are sampled to compute the speed. The more you have, the more the speed is accurate, but the
 // less responsive it gets in Mixxx. Default: 5
-const wheelSpeedSample = 5;
+const WheelSpeedSample = 5;
 
 // Make the sampler tab a beatlooproll tab instead
 // Default: false
-const useBeatloopRoolInsteadOfSampler = false;
+const UseBeatloopRoolInsteadOfSampler = false;
 
 // Define the speed of the jogwheel. This will impact the speed of the LED playback indicator, the sratch, and the speed of
 // the motor if enable. Recommended value are 33 + 1/3 or 45.
 // Default: 33 + 1/3
-const baseRevolutionsPerMinute = 33 + 1/3;
+const BaseRevolutionsPerMinute = 33 + 1/3;
 
 // Define whether or not to use motors.
 // This is a BETA feature! Please use at your own risk. Setting this off means that below settings are inactive
 // Default: false
-const useMotors = true;
+const UseMotors = true;
 
 // Define how many wheel moves are sampled to compute the speed when using the motor. This is helpful to mitigate delay that
 // occurs in communication as well as Mixxx limitation to 20ms latency.
 // The more you have, the more the speed is accurate.
 // less responsive it gets in Mixxx. Default: 40
-const turnTableSpeedSample = 40;
+const TurnTableSpeedSample = 40;
 
 // Define how much the wheel will resist. It is a similar setting that the Grid+Wheel in Tracktor
 // Value must defined between 0 to 1. 0 is very tight, 1 is very loose.
 // Default: 0.5
-const tightnessFactor = 0.5;
+const TightnessFactor = 0.5;
 
 // Define how much force can the motor use. This defines how much the wheel will "fight" you when you block it in TT mode
 // This will also im
-const maxWheelForce = 25000;  // Traktor seems to cap the max value at 60000, which just sounds insane
+const MaxWheelForce = 25000;  // Traktor seems to cap the max value at 60000, which just sounds insane
 
 
 
@@ -133,44 +155,44 @@ const maxWheelForce = 25000;  // Traktor seems to cap the max value at 60000, wh
 // the normal 2 for Button.prototype.brightnessOn changes the color
 // slightly, so use that get 25 different colors to include the Filter
 // button as a 5th effect chain preset selector.
-const quickEffectPresetColors = [
-    LEDColors.red,
-    LEDColors.blue,
-    LEDColors.yellow,
-    LEDColors.purple,
-    LEDColors.white,
+const QuickEffectPresetColors = [
+    LedColors.red,
+    LedColors.blue,
+    LedColors.yellow,
+    LedColors.purple,
+    LedColors.white,
 
-    LEDColors.magenta,
-    LEDColors.azalea,
-    LEDColors.salmon,
-    LEDColors.red + 1,
+    LedColors.magenta,
+    LedColors.azalea,
+    LedColors.salmon,
+    LedColors.red + 1,
 
-    LEDColors.sky,
-    LEDColors.celeste,
-    LEDColors.fuscia,
-    LEDColors.blue + 1,
+    LedColors.sky,
+    LedColors.celeste,
+    LedColors.fuscia,
+    LedColors.blue + 1,
 
-    LEDColors.carrot,
-    LEDColors.orange,
-    LEDColors.honey,
-    LEDColors.yellow + 1,
+    LedColors.carrot,
+    LedColors.orange,
+    LedColors.honey,
+    LedColors.yellow + 1,
 
-    LEDColors.lime,
-    LEDColors.aqua,
-    LEDColors.green,
-    LEDColors.purple + 1,
+    LedColors.lime,
+    LedColors.aqua,
+    LedColors.green,
+    LedColors.purple + 1,
 
-    LEDColors.magenta + 1,
-    LEDColors.azalea + 1,
-    LEDColors.salmon + 1,
-    LEDColors.fuscia + 1,
+    LedColors.magenta + 1,
+    LedColors.azalea + 1,
+    LedColors.salmon + 1,
+    LedColors.fuscia + 1,
 ];
 
 // assign samplers to the crossfader on startup
-const samplerCrossfaderAssign = true;
+const SamplerCrossfaderAssign = true;
 
-const motorWindUpMilliseconds = 1200;
-const motorWindDownMilliseconds = 900;
+const MotorWindUpMilliseconds = 1200;
+const MotorWindDownMilliseconds = 900;
 
 /*
  * HID packet parsing library
@@ -333,7 +355,7 @@ class Component {
             if (connection) {
                 this.outConnections[0] = connection;
             } else {
-                console.warn("Unable to connect '" + this.group + "." + this.outKey + "' to the controller output. The control appears to be unaivailable.");
+                console.warn("Unable to connect '" + this.group + "." + this.outKey + "' to the controller output. The control appears to be unavailable.");
             }
         }
     }
@@ -452,7 +474,7 @@ class Deck extends ComponentContainer {
             this.moveMode = this.secondDeckModes.moveMode;
 
             if (this.wheelMode === wheelModes.motor) {
-                engine.beginTimer(motorWindUpMilliseconds, function() {
+                engine.beginTimer(MotorWindUpMilliseconds, function() {
                     engine.setValue(newGroup, "scratch2_enable", true);
                 }, true);
             }
@@ -460,7 +482,7 @@ class Deck extends ComponentContainer {
 
         if (currentModes.wheelMode === wheelModes.motor) {
             this.wheelTouch.touched = true;
-            engine.beginTimer(motorWindDownMilliseconds, () => {
+            engine.beginTimer(MotorWindDownMilliseconds, () => {
                 this.wheelTouch.touched = false;
             }, true);
         }
@@ -526,11 +548,11 @@ class Button extends Component {
             return;
         }
         const brightness = (value > 0) ? this.brightnessOn : this.brightnessOff;
-        this.send((this.color || LEDColors.white) + brightness);
+        this.send((this.color || LedColors.white) + brightness);
     }
     indicatorCallback() {
         this.indicatorState = !this.indicatorState;
-        this.send((this.indicatorColor || this.color || LEDColors.white) + (this.indicatorState ? this.brightnessOn : this.brightnessOff));
+        this.send((this.indicatorColor || this.color || LedColors.white) + (this.indicatorState ? this.brightnessOn : this.brightnessOff));
     }
     indicator(on) {
         if (on && this.indicatorTimer === 0) {
@@ -655,7 +677,7 @@ class CueButton extends PushButton {
             engine.setValue(this.group, this.inKey, pressed);
             if (this.deck.wheelMode === wheelModes.motor) {
                 engine.setValue(this.group, "scratch2_enable", false);
-                engine.beginTimer(motorWindDownMilliseconds, function() {
+                engine.beginTimer(MotorWindDownMilliseconds, function() {
                     engine.setValue(this.group, "scratch2_enable", true);
                 }, true);
             }
@@ -721,7 +743,7 @@ class HotcueButton extends PushButton {
             if (connection0) {
                 this.outConnections[0] = connection0;
             } else {
-                console.warn("Unable to connect '" + this.group + "." + this.outKey + "' to the controller output. The control appears to be unaivailable.");
+                console.warn("Unable to connect '" + this.group + "." + this.outKey + "' to the controller output. The control appears to be unavailable.");
             }
             const connection1 = engine.makeConnection(this.group, this.colorKey, (colorCode) => {
                 this.color = this.colorMap.getValueForNearestColor(colorCode);
@@ -730,7 +752,7 @@ class HotcueButton extends PushButton {
             if (connection1) {
                 this.outConnections[1] = connection1;
             } else {
-                console.warn("Unable to connect '" + this.group + "." + this.colorKey + "' to the controller output. The control appears to be unaivailable.");
+                console.warn("Unable to connect '" + this.group + "." + this.colorKey + "' to the controller output. The control appears to be unavailable.");
             }
         }
     }
@@ -784,7 +806,7 @@ class KeyboardButton extends PushButton {
             if (connection) {
                 this.outConnections[0] = connection;
             } else {
-                console.warn("Unable to connect '" + this.group + ".key' to the controller output. The control appears to be unaivailable.");
+                console.warn("Unable to connect '" + this.group + ".key' to the controller output. The control appears to be unavailable.");
             }
         }
     }
@@ -805,7 +827,7 @@ class BeatLoopRollButton extends TriggerButton {
         this.outConnect();
     }
     output(value) {
-        this.send(LEDColors.white + (value ? this.brightnessOn : this.brightnessOff));
+        this.send(LedColors.white + (value ? this.brightnessOn : this.brightnessOff));
     }
 }
 
@@ -858,13 +880,13 @@ class SamplerButton extends Button {
             if (connection0) {
                 this.outConnections[0] = connection0;
             } else {
-                console.warn("Unable to connect '" + this.group + ".play' to the controller output. The control appears to be unaivailable.");
+                console.warn("Unable to connect '" + this.group + ".play' to the controller output. The control appears to be unavailable.");
             }
             const connection1 = engine.makeConnection(this.group, "track_loaded", this.output.bind(this));
             if (connection1) {
                 this.outConnections[1] = connection1;
             } else {
-                console.warn("Unable to connect '" + this.group + ".track_loaded' to the controller output. The control appears to be unaivailable.");
+                console.warn("Unable to connect '" + this.group + ".track_loaded' to the controller output. The control appears to be unavailable.");
             }
         }
     }
@@ -1100,7 +1122,7 @@ class Mixer extends ComponentContainer {
 
     resetFxSelectorColors() {
         for (const selector of [1, 2, 3, 4, 5]) {
-            this.outPacket.data[49 + selector] = quickEffectPresetColors[selector - 1] + Button.prototype.brightnessOn;
+            this.outPacket.data[49 + selector] = QuickEffectPresetColors[selector - 1] + Button.prototype.brightnessOn;
         }
         this.outPacket.send();
     }
@@ -1124,7 +1146,7 @@ class FXSelect extends Button {
                     if (selector > this.number) {
                         presetNumber--;
                     }
-                    this.outPacket.data[49 + selector] = quickEffectPresetColors[presetNumber - 1] + this.brightnessOn;
+                    this.outPacket.data[49 + selector] = QuickEffectPresetColors[presetNumber - 1] + this.brightnessOn;
                 }
             }
             this.outPacket.send();
@@ -1182,7 +1204,7 @@ class QuickEffectButton extends Button {
             script.toggleControl(this.group, "enabled");
         } else {
             const presetNumber = this.mixer.calculatePresetNumber();
-            this.color = quickEffectPresetColors[presetNumber - 1];
+            this.color = QuickEffectPresetColors[presetNumber - 1];
             engine.setValue(this.group, "loaded_chain_preset", presetNumber + 1);
             this.mixer.firstPressedFxSelector = null;
             this.mixer.secondPressedFxSelector = null;
@@ -1204,7 +1226,7 @@ class QuickEffectButton extends Button {
         }
     }
     presetLoaded(presetNumber) {
-        this.color = quickEffectPresetColors[presetNumber - 2];
+        this.color = QuickEffectPresetColors[presetNumber - 2];
         this.outConnections[1].trigger();
     }
     outConnect() {
@@ -1213,13 +1235,13 @@ class QuickEffectButton extends Button {
             if (connection0) {
                 this.outConnections[0] = connection0;
             } else {
-                console.warn("Unable to connect '" + this.group + ".loaded_chain_preset' to the controller output. The control appears to be unaivailable.");
+                console.warn("Unable to connect '" + this.group + ".loaded_chain_preset' to the controller output. The control appears to be unavailable.");
             }
             const connection1 = engine.makeConnection(this.group, "enabled", this.output.bind(this));
             if (connection1) {
                 this.outConnections[1] = connection1;
             } else {
-                console.warn("Unable to connect '" + this.group + ".enabled' to the controller output. The control appears to be unaivailable.");
+                console.warn("Unable to connect '" + this.group + ".enabled' to the controller output. The control appears to be unavailable.");
             }
         }
     }
@@ -1242,31 +1264,31 @@ Button.prototype.uncoloredOutput = function(value) {
     if (this.indicatorTimer !== 0) {
         return;
     }
-    const color = (value > 0) ? (this.color || LEDColors.white) + this.brightnessOn : LEDColors.off;
+    const color = (value > 0) ? (this.color || LedColors.white) + this.brightnessOn : LedColors.off;
     this.send(color);
 };
 Button.prototype.colorMap = new ColorMapper({
-    0xCC0000: LEDColors.red,
-    0xCC5E00: LEDColors.carrot,
-    0xCC7800: LEDColors.orange,
-    0xCC9200: LEDColors.honey,
+    0xCC0000: LedColors.red,
+    0xCC5E00: LedColors.carrot,
+    0xCC7800: LedColors.orange,
+    0xCC9200: LedColors.honey,
 
-    0xCCCC00: LEDColors.yellow,
-    0x81CC00: LEDColors.lime,
-    0x00CC00: LEDColors.green,
-    0x00CC49: LEDColors.aqua,
+    0xCCCC00: LedColors.yellow,
+    0x81CC00: LedColors.lime,
+    0x00CC00: LedColors.green,
+    0x00CC49: LedColors.aqua,
 
-    0x00CCCC: LEDColors.celeste,
-    0x0091CC: LEDColors.sky,
-    0x0000CC: LEDColors.blue,
-    0xCC00CC: LEDColors.purple,
+    0x00CCCC: LedColors.celeste,
+    0x0091CC: LedColors.sky,
+    0x0000CC: LedColors.blue,
+    0xCC00CC: LedColors.purple,
 
-    0xCC0091: LEDColors.fuscia,
-    0xCC0079: LEDColors.magenta,
-    0xCC477E: LEDColors.azalea,
-    0xCC4761: LEDColors.salmon,
+    0xCC0091: LedColors.fuscia,
+    0xCC0079: LedColors.magenta,
+    0xCC477E: LedColors.azalea,
+    0xCC4761: LedColors.salmon,
 
-    0xCCCCCC: LEDColors.white,
+    0xCCCCCC: LedColors.white,
 });
 
 const wheelRelativeMax = 2 ** 16 - 1;
@@ -1275,7 +1297,7 @@ const wheelAbsoluteMax = 2879;
 const wheelTimerMax = 2 ** 32 - 1;
 const wheelTimerTicksPerSecond = 100000000;
 
-const baseRevolutionsPerSecond = baseRevolutionsPerMinute / 60;
+const baseRevolutionsPerSecond = BaseRevolutionsPerMinute / 60;
 const wheelTicksPerTimerTicksToRevolutionsPerSecond = wheelTimerTicksPerSecond / wheelAbsoluteMax;
 
 const wheelLEDmodes = {
@@ -1441,7 +1463,7 @@ class S4Mk3Deck extends Deck {
         super(decks, colors);
 
         this.playButton = new PlayButton({
-            output: keepLEDWithOneColorDimedWhenInactive ? undefined : Button.prototype.uncoloredOutput
+            output: KeepLEDWithOneColorDimedWhenInactive ? undefined : Button.prototype.uncoloredOutput
         });
 
         this.cueButton = new CueButton({
@@ -1452,10 +1474,10 @@ class S4Mk3Deck extends Deck {
         this.syncMasterButton = new Button({
             key: "sync_leader",
             defaultRange: 0.08,
-            shift: useKeylockOnMaster ? function() {
+            shift: UseKeylockOnMaster ? function() {
                 this.setKey("keylock");
             } : undefined,
-            unshift: useKeylockOnMaster ? function() {
+            unshift: UseKeylockOnMaster ? function() {
                 this.setKey("sync_leader");
             } : undefined,
             onShortRelease: function() {
@@ -1488,10 +1510,10 @@ class S4Mk3Deck extends Deck {
                     engine.softTakeover(this.group, "rate", true);
                 }
             },
-            shift: !useKeylockOnMaster ? function() {
+            shift: !UseKeylockOnMaster ? function() {
                 this.setKey("keylock");
             } : undefined,
-            unshift: !useKeylockOnMaster ? function() {
+            unshift: !UseKeylockOnMaster ? function() {
                 this.setKey("sync_enabled");
             } : undefined,
         });
@@ -1511,10 +1533,10 @@ class S4Mk3Deck extends Deck {
                 const parameterValue = engine.getParameter(this.group, this.outKey);
                 const diffFromHardware = parameterValue - this.tempoFader.hardwarePosition;
                 if (diffFromHardware > this.toleranceWindow) {
-                    this.send(tempoFaderSoftTakeoverColorHigh + Button.prototype.brightnessOn);
+                    this.send(TempoFaderSoftTakeoverColorHigh + Button.prototype.brightnessOn);
                     return;
                 } else if (diffFromHardware < (-1 * this.toleranceWindow)) {
-                    this.send(tempoFaderSoftTakeoverColorLow + Button.prototype.brightnessOn);
+                    this.send(TempoFaderSoftTakeoverColorLow + Button.prototype.brightnessOn);
                     return;
                 }
 
@@ -1541,7 +1563,7 @@ class S4Mk3Deck extends Deck {
             shift: function() {
                 this.setKey("loop_enabled");
             },
-            output: keepLEDWithOneColorDimedWhenInactive ? undefined : Button.prototype.uncoloredOutput,
+            output: KeepLEDWithOneColorDimedWhenInactive ? undefined : Button.prototype.uncoloredOutput,
             onShortRelease: function() {
                 if (!this.shifted) {
                     engine.setValue(this.group, this.key, false);
@@ -1626,11 +1648,11 @@ class S4Mk3Deck extends Deck {
                     if (connection) {
                         this.outConnections[0] = connection;
                     } else {
-                        console.warn("Unable to connect '" + this.group + "." + this.outKey + "' to the controller output. The control appears to be unaivailable.");
+                        console.warn("Unable to connect '" + this.group + "." + this.outKey + "' to the controller output. The control appears to be unavailable.");
                     }
                 }
             },
-            output: keepLEDWithOneColorDimedWhenInactive ? undefined : Button.prototype.uncoloredOutput,
+            output: KeepLEDWithOneColorDimedWhenInactive ? undefined : Button.prototype.uncoloredOutput,
             onShortRelease: function() {
                 if (!this.shifted) {
                     engine.setValue(this.group, this.key, false);
@@ -1699,7 +1721,7 @@ class S4Mk3Deck extends Deck {
             }
         });
         this.gridButton = new Button({
-            key: gridButtonBlinkOverBeat ? "beat_active" : undefined,
+            key: GridButtonBlinkOverBeat ? "beat_active" : undefined,
             deck: this,
             previousMoveMode: null,
             onShortPress: function() {
@@ -1767,10 +1789,10 @@ class S4Mk3Deck extends Deck {
                 if (pressed) {
                     this.deck.shift();
                     // This button only has one color.
-                    this.send(LEDColors.white + this.brightnessOn);
+                    this.send(LedColors.white + this.brightnessOn);
                 } else {
                     this.deck.unshift();
-                    this.send(LEDColors.white + this.brightnessOff);
+                    this.send(LedColors.white + this.brightnessOff);
                 }
             },
         });
@@ -1838,7 +1860,7 @@ class S4Mk3Deck extends Deck {
             deck: this,
             onChange: function(right) {
                 if (this.deck.wheelMode === wheelModes.loopIn || this.deck.wheelMode === wheelModes.loopOut) {
-                    const moveFactor = this.shifted ? loopEncoderShiftMoveFactor : loopEncoderMoveFactor;
+                    const moveFactor = this.shifted ? LOOP_ENCODER_SHIFTMOVE_FACTOR : LOOP_ENCODER_MOVE_FACTOR;
                     const valueIn = engine.getValue(this.group, "loop_start_position") + (right ? moveFactor : -moveFactor);
                     const valueOut = engine.getValue(this.group, "loop_end_position") + (right ? moveFactor : -moveFactor);
                     engine.setValue(this.group, "loop_start_position", valueIn);
@@ -1873,8 +1895,8 @@ class S4Mk3Deck extends Deck {
             currentSortedColumnIdx: -1,
             onChange: function(right) {
                 if (this.libraryViewButtonPressed) {
-                    this.currentSortedColumnIdx = (this.currentSortedColumnIdx + (right ? 1 : -1)) % librarySortableColumns.length;
-                    engine.setValue("[Library]", "sort_column", librarySortableColumns[this.currentSortedColumnIdx]);
+                    this.currentSortedColumnIdx = (this.currentSortedColumnIdx + (right ? 1 : -1)) % LibrarySortableColumns.length;
+                    engine.setValue("[Library]", "sort_column", LibrarySortableColumns[this.currentSortedColumnIdx]);
                 } else if (this.starButtonPressed) {
                     if (this.shifted) {
                         // FIXME doesn't exist, feature request needed
@@ -1965,7 +1987,7 @@ class S4Mk3Deck extends Deck {
                 if (connection) {
                     this.outConnections[0] = connection;
                 } else {
-                    console.warn("Unable to connect '" + this.group + ".focused_widget' to the controller output. The control appears to be unaivailable.");
+                    console.warn("Unable to connect '" + this.group + ".focused_widget' to the controller output. The control appears to be unavailable.");
                 }
             },
             onShortRelease: function() {
@@ -2050,7 +2072,7 @@ class S4Mk3Deck extends Deck {
             // start with hotcue 5; hotcues 1-4 are in defaultPadLayer
             hotcuePage2[i] = new HotcueButton({number: i + 1});
             hotcuePage3[i] = new HotcueButton({number: i + 13});
-            if (useBeatloopRoolInsteadOfSampler) {
+            if (UseBeatloopRoolInsteadOfSampler) {
                 samplerOrBeatloopRoolPage[i] = new BeatLoopRollButton({
                     number: i,
                     deck: this,
@@ -2067,7 +2089,7 @@ class S4Mk3Deck extends Deck {
                 samplerOrBeatloopRoolPage[i] = new SamplerButton({
                     number: samplerNumber,
                 });
-                if (samplerCrossfaderAssign) {
+                if (SamplerCrossfaderAssign) {
                     engine.setValue(
                         "[Sampler" + samplerNumber + "]",
                         "orientation",
@@ -2144,30 +2166,9 @@ class S4Mk3Deck extends Deck {
                 this.deck.lightPadMode();
             }
         });
+        // The record button doesn't have a mapping by default, but you can add yours here
         // this.recordPadModeButton = new Button({
-        //     deck: this,
-        //     input: function(pressed) {
-        //         if (!this.shifted) {
-        //             if (pressed) {
-        //                 if (this.deck.currentPadLayer !== this.deck.padLayers.hotcuePage3) {
-        //                     switchPadLayer(this.deck, hotcuePage3);
-        //                     this.deck.currentPadLayer = this.deck.padLayers.hotcuePage3;
-        //                 } else {
-        //                     switchPadLayer(this.deck, defaultPadLayer);
-        //                     this.deck.currentPadLayer = this.deck.padLayers.defaultLayer;
-        //                 }
-        //                 this.deck.lightPadMode();
-        //             }
-        //         } else {
-        //             engine.setValue(this.deck.group, "loop_out", pressed);
-        //         }
-        //     },
-        //     // make sure loop_out gets reset to 0 if shift is released before this button
-        //     unshift: function() {
-        //         if (engine.getValue(this.deck.group, "loop_out") === 1) {
-        //             engine.setValue(this.deck.group, "loop_out", 0);
-        //         }
-        //     }
+        //     ...
         // });
         this.samplesPadModeButton = new Button({
             deck: this,
@@ -2184,20 +2185,9 @@ class S4Mk3Deck extends Deck {
                 this.deck.lightPadMode();
             },
         });
+        // The mute button doesn't have a mapping by default, but you can add yours here
         // this.mutePadModeButton = new Button({
-        //     deck: this,
-        //     input: function(pressed) {
-        //         if (pressed) {
-        //             if (this.deck.currentPadLayer !== this.deck.padLayers.samplerPage2) {
-        //                 switchPadLayer(this.deck, samplerPage2);
-        //                 this.deck.currentPadLayer = this.deck.padLayers.samplerPage2;
-        //             } else {
-        //                 switchPadLayer(this.deck, defaultPadLayer);
-        //                 this.deck.currentPadLayer = this.deck.padLayers.defaultLayer;
-        //             }
-        //             this.deck.lightPadMode();
-        //         }
-        //     },
+        //    ...
         // });
 
         this.stemsPadModeButton = new Button({
@@ -2243,7 +2233,7 @@ class S4Mk3Deck extends Deck {
             engine.stopTimer(motorWindDownTimer);
             motorWindDownTimer = 0;
         };
-        this.turntableButton = useMotors ? new Button({
+        this.turntableButton = UseMotors ? new Button({
             deck: this,
             input: function(press) {
                 if (press) {
@@ -2251,12 +2241,12 @@ class S4Mk3Deck extends Deck {
                     this.deck.fluxButton.loopModeOff(true);
                     if (this.deck.wheelMode === wheelModes.motor) {
                         this.deck.wheelMode = wheelModes.vinyl;
-                        motorWindDownTimer = engine.beginTimer(motorWindDownMilliseconds, motorWindDownTimerCallback, true);
+                        motorWindDownTimer = engine.beginTimer(MotorWindDownMilliseconds, motorWindDownTimerCallback, true);
                         engine.setValue(this.group, "scratch2_enable", false);
                     } else {
                         this.deck.wheelMode = wheelModes.motor;
                         const group = this.group;
-                        engine.beginTimer(motorWindUpMilliseconds, function() {
+                        engine.beginTimer(MotorWindUpMilliseconds, function() {
                             engine.setValue(group, "scratch2_enable", true);
                         }, true);
                     }
@@ -2280,7 +2270,7 @@ class S4Mk3Deck extends Deck {
                         this.deck.wheelMode = wheelModes.jog;
                     } else {
                         if (this.deck.wheelMode === wheelModes.motor) {
-                            motorWindDownTimer = engine.beginTimer(motorWindDownMilliseconds, motorWindDownTimerCallback, true);
+                            motorWindDownTimer = engine.beginTimer(MotorWindDownMilliseconds, motorWindDownTimerCallback, true);
                         }
                         this.deck.wheelMode = wheelModes.vinyl;
                     }
@@ -2363,12 +2353,12 @@ class S4Mk3Deck extends Deck {
                 }
 
                 this.stack[this.stackIdx] = diff / wheelTimerDelta;
-                this.stackIdx = (this.stackIdx + 1) % wheelSpeedSample;
+                this.stackIdx = (this.stackIdx + 1) % WheelSpeedSample;
 
                 this.avgSpeed = (this.stack.reduce((ps, v) => ps + v, 0) / this.stack.length) * wheelTicksPerTimerTicksToRevolutionsPerSecond;
 
                 this.stackAvg[this.stackAvgIdx] = this.avgSpeed;
-                this.stackAvgIdx = (this.stackAvgIdx + 1) % turnTableSpeedSample;
+                this.stackAvgIdx = (this.stackAvgIdx + 1) % TurnTableSpeedSample;
 
                 this.ttAvgSpeed = this.stackAvg.reduce((ps, v) => ps + v, 0) / this.stackAvg.length;
 
@@ -2387,7 +2377,7 @@ class S4Mk3Deck extends Deck {
                     {
                         const loopStartPosition = engine.getValue(this.group, "loop_start_position");
                         const loopEndPosition = engine.getValue(this.group, "loop_end_position");
-                        const value = Math.min(loopStartPosition + (this.avgSpeed * loopWheelMoveFactor), loopEndPosition - loopWheelMoveFactor);
+                        const value = Math.min(loopStartPosition + (this.avgSpeed * LOOP_WHEEL_MOVE_FACTOR), loopEndPosition - LOOP_WHEEL_MOVE_FACTOR);
                         engine.setValue(
                             this.group,
                             "loop_start_position",
@@ -2398,7 +2388,7 @@ class S4Mk3Deck extends Deck {
                 case wheelModes.loopOut:
                     {
                         const loopEndPosition = engine.getValue(this.group, "loop_end_position");
-                        const value = loopEndPosition + (this.avgSpeed * loopWheelMoveFactor);
+                        const value = loopEndPosition + (this.avgSpeed * LOOP_WHEEL_MOVE_FACTOR);
                         engine.setValue(
                             this.group,
                             "loop_end_position",
@@ -2469,7 +2459,7 @@ class S4Mk3Deck extends Deck {
                 }
             }
         }
-        this.shiftButton.send(LEDColors.white + this.brightnessOff);
+        this.shiftButton.send(LedColors.white + this.brightnessOff);
     }
 
     assignKeyboardPlayMode(group, action) {
@@ -2484,7 +2474,7 @@ class S4Mk3Deck extends Deck {
         if (this.currentPadLayer === this.padLayers.hotcuePage2) {
             this.hotcuePadModeButton.send(this.hotcuePadModeButton.color + this.hotcuePadModeButton.brightnessOn);
         } else if (this.currentPadLayer === this.padLayers.hotcuePage3) {
-            this.hotcuePadModeButton.send(LEDColors.white + this.hotcuePadModeButton.brightnessOn);
+            this.hotcuePadModeButton.send(LedColors.white + this.hotcuePadModeButton.brightnessOn);
         } else {
             this.hotcuePadModeButton.send(this.hotcuePadModeButton.color + this.hotcuePadModeButton.brightnessOff);
         }
@@ -2499,7 +2489,7 @@ class S4Mk3Deck extends Deck {
         // this.mutePadModeButtonLEDOn = this.currentPadLayer === this.padLayers.samplerPage2;
         // const mutedModeButton.send(mutePadModeButtonLEDOn ? 127 : 0);
         if (this.keyboardPlayMode !== null) {
-            this.stemsPadModeButton.send(LEDColors.green + this.stemsPadModeButton.brightnessOn);
+            this.stemsPadModeButton.send(LedColors.green + this.stemsPadModeButton.brightnessOn);
         } else {
             const keyboardPadModeLEDOn = this.currentPadLayer === this.padLayers.keyboard;
             this.stemsPadModeButton.send(this.stemsPadModeButton.color + (keyboardPadModeLEDOn ? this.stemsPadModeButton.brightnessOn : this.stemsPadModeButton.brightnessOff));
@@ -2665,7 +2655,7 @@ class S4MK3 {
         // so every single components' IO needs to be specified individually
         // for both decks.
         this.leftDeck = new S4Mk3Deck(
-            [1, 3], [deckColors[0], deckColors[2]], this.effectUnit1,
+            [1, 3], [DeckColors[0], DeckColors[2]], this.effectUnit1,
             this.inPackets, this.outPackets[128],
             {
                 playButton: {inByte: 5, inBit: 0, outByte: 55},
@@ -2716,7 +2706,7 @@ class S4MK3 {
         );
 
         this.rightDeck = new S4Mk3Deck(
-            [2, 4], [deckColors[1], deckColors[3]], this.effectUnit2,
+            [2, 4], [DeckColors[1], DeckColors[3]], this.effectUnit2,
             this.inPackets, this.outPackets[128],
             {
                 playButton: {inByte: 13, inBit: 0, outByte: 66},
@@ -2801,7 +2791,7 @@ class S4MK3 {
             // the clip lights on the main mix meters.
             controller.send(deckMeters, null, 129);
         });
-        if (useMotors) {
+        if (UseMotors) {
             engine.beginTimer(20, this.motorCallback.bind(this));
             this.leftVelocityFactor = wheelAbsoluteMax * baseRevolutionsPerSecond * 2;
             this.rightVelocityFactor = wheelAbsoluteMax * baseRevolutionsPerSecond * 2;
@@ -2854,13 +2844,13 @@ class S4MK3 {
                 )
             );
         } else {
-            if (tightnessFactor > 0.5) {
+            if (TightnessFactor > 0.5) {
                 // Super loose
-                const reduceFactor = (Math.min(0.5, tightnessFactor - 0.5) / 0.5) * 0.7;
+                const reduceFactor = (Math.min(0.5, TightnessFactor - 0.5) / 0.5) * 0.7;
                 velocityLeft = currentLeftSpeed * reduceFactor;
-            } else if (tightnessFactor < 0.5) {
+            } else if (TightnessFactor < 0.5) {
                 // Super tight
-                const reduceFactor = (2 - Math.max(0, tightnessFactor) * 4);
+                const reduceFactor = (2 - Math.max(0, TightnessFactor) * 4);
                 velocityLeft = expectedLeftSpeed + Math.min(
                     maxVelocity,
                     Math.max(
@@ -2881,13 +2871,13 @@ class S4MK3 {
                 )
             );
         } else {
-            if (tightnessFactor > 0.5) {
+            if (TightnessFactor > 0.5) {
                 // Super loose
-                const reduceFactor = (Math.min(0.5, tightnessFactor - 0.5) / 0.5) * 0.7;
+                const reduceFactor = (Math.min(0.5, TightnessFactor - 0.5) / 0.5) * 0.7;
                 velocityRight = currentRightSpeed * reduceFactor;
-            } else if (tightnessFactor < 0.5) {
+            } else if (TightnessFactor < 0.5) {
                 // Super tight
-                const reduceFactor = (2 - Math.max(0, tightnessFactor) * 4);
+                const reduceFactor = (2 - Math.max(0, TightnessFactor) * 4);
                 console.log(reduceFactor);
                 velocityRight = expectedRightSpeed + Math.min(
                     maxVelocity,
@@ -2958,12 +2948,12 @@ class S4MK3 {
         }
 
         velocityLeft = Math.min(
-            maxWheelForce,
+            MaxWheelForce,
             Math.floor(velocityLeft)
         );
 
         velocityRight = Math.min(
-            maxWheelForce,
+            MaxWheelForce,
             Math.floor(velocityRight)
         );
 

--- a/res/controllers/Traktor-Kontrol-S4-MK3.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK3.js
@@ -86,7 +86,7 @@ const GridButtonBlinkOverBeat = false;
 const WheelLedBlinkOnTrackEnd = true;
 
 // When shifting either decks, the mixer will control microphones or auxiliary lines. If there is both a mic and an configure on the same channel, the mixer will control the auxiliary.
-// Default: true
+// Default: false
 const MixerControlsMixAuxOnShift = false;
 
 // Define how many wheel moves are sampled to compute the speed. The more you have, the more the speed is accurate, but the
@@ -860,7 +860,7 @@ class SamplerButton extends Button {
         if (this.number === undefined || !Number.isInteger(this.number) || this.number < 1 || this.number > 64) {
             throw Error("SamplerButton must have a number property of an integer between 1 and 64");
         }
-        this.group = "[Sampler${this.number}]";
+        this.group = `[Sampler${this.number}]`;
         this.outConnect();
     }
     onShortPress() {
@@ -1635,12 +1635,11 @@ class S4Mk3Deck extends Deck {
                     this.indicator(false);
                     const wheelOutput = new Uint8Array(40).fill(0);
                     wheelOutput[0] = decks[0] - 1;
-                    const that = this;
                     controller.sendOutputReport(50, wheelOutput.buffer, true);
                     if (!skipRestore) {
-                        that.deck.wheelMode = that.previousWheelMode;
+                        this.deck.wheelMode = this.previousWheelMode;
                     }
-                    that.previousWheelMode = null;
+                    this.previousWheelMode = null;
                     if (this.loopModeConnection !== null) {
                         this.loopModeConnection.disconnect();
                         this.loopModeConnection = null;
@@ -1721,12 +1720,11 @@ class S4Mk3Deck extends Deck {
                     this.indicator(false);
                     const wheelOutput = new Uint8Array(40).fill(0);
                     wheelOutput[0] = decks[0] - 1;
-                    const that = this;
                     controller.sendOutputReport(wheelOutput.buffer, null, 50, true);
                     if (!skipRestore) {
-                        that.deck.wheelMode = that.previousWheelMode;
+                        this.deck.wheelMode = this.previousWheelMode;
                     }
-                    that.previousWheelMode = null;
+                    this.previousWheelMode = null;
                     if (this.loopModeConnection !== null) {
                         this.loopModeConnection.disconnect();
                         this.loopModeConnection = null;
@@ -2350,8 +2348,10 @@ class S4Mk3Deck extends Deck {
             outTrigger: function() {
                 const vinylOn = this.deck.wheelMode === wheelModes.vinyl;
                 this.send(this.color + (vinylOn ? this.brightnessOn : this.brightnessOff));
-                const motorOn = this.deck.wheelMode === wheelModes.motor;
-                this.deck.turntableButton.send(this.color + (motorOn ? this.brightnessOn : this.brightnessOff));
+                if (this.deck.turntableButton) {
+                    const motorOn = this.deck.wheelMode === wheelModes.motor;
+                    this.deck.turntableButton.send(this.color + (motorOn ? this.brightnessOn : this.brightnessOff));
+                }
             },
         });
 

--- a/res/controllers/Traktor-Kontrol-S4-MK3.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK3.js
@@ -103,6 +103,10 @@ const UseKeylockOnMaster = false;
 // Default: false
 const GridButtonBlinkOverBeat = false;
 
+// Wheel led blinking if reaching the end of track warning (default 30 seconds, can be changed in the settings, under "Waveforms" > "End of track warning").
+// Default: true
+const WheelLedBlinkOnTrackEnd = true;
+
 // Define how many wheel moves are sampled to compute the speed. The more you have, the more the speed is accurate, but the
 // less responsive it gets in Mixxx. Default: 5
 const WheelSpeedSample = 3;
@@ -2502,9 +2506,14 @@ class S4Mk3Deck extends Deck {
 
                 const wheelOutput = Array(40).fill(0);
                 wheelOutput[0] = decks[0] - 1;
-                wheelOutput[1] = wheelLEDmodes.spot;
-                wheelOutput[2] = LEDposition & 0xff;
-                wheelOutput[3] = LEDposition >> 8;
+
+                if (engine.getValue(this.group, "end_of_track") && WheelLedBlinkOnTrackEnd) {
+                    wheelOutput[1] = wheelLEDmodes.ringFlash;
+                } else {
+                    wheelOutput[1] = wheelLEDmodes.spot;
+                    wheelOutput[2] = LEDposition & 0xff;
+                    wheelOutput[3] = LEDposition >> 8;
+                }
                 wheelOutput[4] = this.color + Button.prototype.brightnessOn;
 
                 controller.send(wheelOutput, null, 50, true);
@@ -3070,9 +3079,6 @@ class S4MK3 {
         wheelTimerDelta = 0;
 
         // get state of knobs and faders
-        // this.incomingData(new Uint8Array(controller.getInputReport(1)), null, 1);
-        // this.incomingData(new Uint8Array(controller.getInputReport(2)), null, 2);
-
         this.incomingData(new Uint8Array([0x01, ...Uint8Array.from(new Uint8Array(controller.getInputReport(0x01)))]));
         this.incomingData(new Uint8Array([0x02, ...Uint8Array.from(new Uint8Array(controller.getInputReport(0x02)))]));
     }

--- a/res/controllers/Traktor-Kontrol-S4-MK3.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK3.js
@@ -1,5 +1,4 @@
 /// Created by Be <be@mixxx.org> and A. Colombier <mixxx@acolombier.dev>
-/* global LibraryColumns*/
 
 const LedColors = {
     off: 0,
@@ -88,7 +87,7 @@ const WheelLedBlinkOnTrackEnd = true;
 
 // When shifting either decks, the mixer will control microphones or auxiliary lines. If there is both a mic and an configure on the same channel, the mixer will control the auxiliary.
 // Default: true
-const MixerControlsMixAnxOnShift = true;
+const MixerControlsMixAuxOnShift = false;
 
 // Define how many wheel moves are sampled to compute the speed. The more you have, the more the speed is accurate, but the
 // less responsive it gets in Mixxx. Default: 5
@@ -96,7 +95,7 @@ const WheelSpeedSample = 3;
 
 // Make the sampler tab a beatlooproll tab instead
 // Default: false
-const UseBeatloopRollInsteadOfSampler = true;
+const UseBeatloopRollInsteadOfSampler = false;
 
 // Predefined beatlooproll sizes. Note that if you use AddLoopHalveAndDoubleOnBeatloopRollTab, the first and
 // last size will be ignored
@@ -114,7 +113,7 @@ const BaseRevolutionsPerMinute = 33 + 1/3;
 // Define whether or not to use motors.
 // This is a BETA feature! Please use at your own risk. Setting this off means that below settings are inactive
 // Default: false
-const UseMotors = true;
+const UseMotors = false;
 
 // Define how many wheel moves are sampled to compute the speed when using the motor. This is helpful to mitigate delay that
 // occurs in communication as well as Mixxx limitation to 20ms latency.
@@ -279,7 +278,7 @@ class Component {
             this.inKey = this.key;
             this.outKey = this.key;
         }
-        if (typeof this.unshift === "function" && this.unshift.length) {
+        if (typeof this.unshift === "function" && this.unshift.length === 0) {
             this.unshift();
         }
         this.shifted = false;
@@ -363,7 +362,7 @@ class ComponentContainer extends Component {
             if (typeof component.outDisconnect === "function" && component.outDisconnect.length === 0) {
                 component.outDisconnect();
             }
-            if (typeof callback === "function" && callback.length === 0) {
+            if (typeof callback === "function" && callback.length === 1) {
                 callback.call(this, component);
             }
             if (typeof component.outConnect === "function" && component.outConnect.length === 0) {
@@ -2602,9 +2601,9 @@ class S4Mk3MixerColumn extends ComponentContainer {
         this.volume = new Pot({
             inKey: "volume",
             mixer: this,
-            input: MixerControlsMixAnxOnShift ? function(value) {
-                if (this.mixer.shifted) {
-                    const controlKey = (this.group === `[Microphone" +  this.mixer.${idx}]` || this.group === "[Microphone]") ? "talkover" : "master";
+            input: MixerControlsMixAuxOnShift ? function(value) {
+                if (this.mixer.shifted && this.group !== `[Channel${idx}]`) { // FIXME only if group != [ChannelX]
+                    const controlKey = (this.group === `[Microphone${idx}]` || this.group === "[Microphone]") ? "talkover" : "master";
                     const isPlaying = engine.getValue(this.group, controlKey);
                     if ((value !== 0) !== isPlaying) {
                         engine.setValue(this.group, controlKey, value !== 0);
@@ -2670,7 +2669,7 @@ class S4Mk3MixerColumn extends ComponentContainer {
             }
         }
 
-        if (MixerControlsMixAnxOnShift) {
+        if (MixerControlsMixAuxOnShift) {
             this.shift = function() {
                 engine.setValue("[Microphone]", "show_microphone", true);
                 this.updateGroup(true);

--- a/res/controllers/Traktor-Kontrol-S4-MK3.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK3.js
@@ -252,15 +252,14 @@ class HIDInputReport {
             // Little endianness is specified by the HID standard.
             // The HID standard allows signed integers as well, but I am not aware
             // of any HID DJ controllers which use signed integers.
-            // Note that `field.byteOffset` is an absolute offset from the report data, which includes the report ID on the first byte, however `reportData` omits the report ID, thus the "minus one" offset
             if (numBytes === 1) {
-                data = view.getUint8(field.byteOffset - 1);
+                data = view.getUint8(field.byteOffset);
             } else if (numBytes === 2) {
-                data = view.getUint16(field.byteOffset - 1, true);
+                data = view.getUint16(field.byteOffset, true);
             } else if (numBytes === 3) {
-                data = view.getUint32(field.byteOffset - 1, true) >>> 8;
+                data = view.getUint32(field.byteOffset, true) >>> 8;
             } else if (numBytes === 4) {
-                data = view.getUint32(field.byteOffset - 1, true);
+                data = view.getUint32(field.byteOffset, true);
             } else {
                 throw Error("field bitLength must be between 1 and 32");
             }
@@ -1010,63 +1009,63 @@ class Mixer extends ComponentContainer {
 
         this.mixerColumnDeck1 = new S4Mk3MixerColumn(1, inReports, outReports[128],
             {
-                saveGain: {inByte: 12, inBit: 0, outByte: 80},
-                effectUnit1Assign: {inByte: 3, inBit: 3, outByte: 78},
-                effectUnit2Assign: {inByte: 3, inBit: 4, outByte: 79},
-                gain: {inByte: 17},
-                eqHigh: {inByte: 45},
-                eqMid: {inByte: 47},
-                eqLow: {inByte: 49},
-                quickEffectKnob: {inByte: 65},
+                saveGain: {inByte: 11, inBit: 0, outByte: 80},
+                effectUnit1Assign: {inByte: 2, inBit: 3, outByte: 78},
+                effectUnit2Assign: {inByte: 2, inBit: 4, outByte: 79},
+                gain: {inByte: 16},
+                eqHigh: {inByte: 44},
+                eqMid: {inByte: 46},
+                eqLow: {inByte: 48},
+                quickEffectKnob: {inByte: 64},
                 quickEffectButton: {},
-                volume: {inByte: 3},
-                pfl: {inByte: 8, inBit: 3, outByte: 77},
-                crossfaderSwitch: {inByte: 18, inBit: 4},
+                volume: {inByte: 2},
+                pfl: {inByte: 7, inBit: 3, outByte: 77},
+                crossfaderSwitch: {inByte: 17, inBit: 4},
             }
         );
         this.mixerColumnDeck2 = new S4Mk3MixerColumn(2, inReports, outReports[128],
             {
-                saveGain: {inByte: 12, inBit: 1, outByte: 84},
-                effectUnit1Assign: {inByte: 3, inBit: 5, outByte: 82},
-                effectUnit2Assign: {inByte: 3, inBit: 6, outByte: 83},
-                gain: {inByte: 19},
-                eqHigh: {inByte: 51},
-                eqMid: {inByte: 53},
-                eqLow: {inByte: 55},
-                quickEffectKnob: {inByte: 67},
-                volume: {inByte: 5},
-                pfl: {inByte: 8, inBit: 6, outByte: 81},
-                crossfaderSwitch: {inByte: 18, inBit: 2},
+                saveGain: {inByte: 11, inBit: 1, outByte: 84},
+                effectUnit1Assign: {inByte: 2, inBit: 5, outByte: 82},
+                effectUnit2Assign: {inByte: 2, inBit: 6, outByte: 83},
+                gain: {inByte: 18},
+                eqHigh: {inByte: 50},
+                eqMid: {inByte: 52},
+                eqLow: {inByte: 54},
+                quickEffectKnob: {inByte: 66},
+                volume: {inByte: 4},
+                pfl: {inByte: 7, inBit: 6, outByte: 81},
+                crossfaderSwitch: {inByte: 17, inBit: 2},
             }
         );
         this.mixerColumnDeck3 = new S4Mk3MixerColumn(3, inReports, outReports[128],
             {
-                saveGain: {inByte: 3, inBit: 1, outByte: 88},
-                effectUnit1Assign: {inByte: 3, inBit: 0, outByte: 86},
-                effectUnit2Assign: {inByte: 3, inBit: 2, outByte: 87},
-                gain: {inByte: 15},
-                eqHigh: {inByte: 39},
-                eqMid: {inByte: 41},
-                eqLow: {inByte: 43},
-                quickEffectKnob: {inByte: 63},
-                volume: {inByte: 7},
-                pfl: {inByte: 8, inBit: 2, outByte: 85},
-                crossfaderSwitch: {inByte: 18, inBit: 6},
+                saveGain: {inByte: 2, inBit: 1, outByte: 88},
+                effectUnit1Assign: {inByte: 2, inBit: 0, outByte: 86},
+                effectUnit2Assign: {inByte: 2, inBit: 2, outByte: 87},
+                gain: {inByte: 14},
+                eqHigh: {inByte: 38},
+                eqMid: {inByte: 40},
+                eqLow: {inByte: 42},
+                quickEffectKnob: {inByte: 62},
+                volume: {inByte: 6},
+                pfl: {inByte: 7, inBit: 2, outByte: 85},
+                crossfaderSwitch: {inByte: 17, inBit: 6},
             }
         );
         this.mixerColumnDeck4 = new S4Mk3MixerColumn(4, inReports, outReports[128],
             {
-                saveGain: {inByte: 12, inBit: 2, outByte: 92},
-                effectUnit1Assign: {inByte: 3, inBit: 7, outByte: 90},
-                effectUnit2Assign: {inByte: 12, inBit: 7, outByte: 91},
-                gain: {inByte: 21},
-                eqHigh: {inByte: 57},
-                eqMid: {inByte: 59},
-                eqLow: {inByte: 61},
-                quickEffectKnob: {inByte: 69},
-                volume: {inByte: 9},
-                pfl: {inByte: 8, inBit: 7, outByte: 89},
-                crossfaderSwitch: {inByte: 18, inBit: 0},
+                saveGain: {inByte: 11, inBit: 2, outByte: 92},
+                effectUnit1Assign: {inByte: 2, inBit: 7, outByte: 90},
+                effectUnit2Assign: {inByte: 11, inBit: 7, outByte: 91},
+                gain: {inByte: 20},
+                eqHigh: {inByte: 56},
+                eqMid: {inByte: 58},
+                eqLow: {inByte: 60},
+                quickEffectKnob: {inByte: 68},
+                volume: {inByte: 8},
+                pfl: {inByte: 7, inBit: 7, outByte: 89},
+                crossfaderSwitch: {inByte: 17, inBit: 0},
             }
         );
 
@@ -1075,11 +1074,11 @@ class Mixer extends ComponentContainer {
         this.comboSelected = false;
 
         const fxSelectsInputs = [
-            {inByte: 9, inBit: 5},
-            {inByte: 9, inBit: 1},
-            {inByte: 9, inBit: 6},
-            {inByte: 9, inBit: 0},
-            {inByte: 9, inBit: 7},
+            {inByte: 8, inBit: 5},
+            {inByte: 8, inBit: 1},
+            {inByte: 8, inBit: 6},
+            {inByte: 8, inBit: 0},
+            {inByte: 8, inBit: 7},
         ];
         this.fxSelects = [];
         // FX SELECT buttons: Filter, 1, 2, 3, 4
@@ -1093,10 +1092,10 @@ class Mixer extends ComponentContainer {
         }
 
         const quickEffectInputs = [
-            {inByte: 8, inBit: 0, outByte: 46},
-            {inByte: 8, inBit: 5, outByte: 47},
-            {inByte: 8, inBit: 1, outByte: 48},
-            {inByte: 8, inBit: 4, outByte: 49},
+            {inByte: 7, inBit: 0, outByte: 46},
+            {inByte: 7, inBit: 5, outByte: 47},
+            {inByte: 7, inBit: 1, outByte: 48},
+            {inByte: 7, inBit: 4, outByte: 49},
         ];
         this.quickEffectButtons = [];
         // FX SELECT buttons: 1, 2, 3, 4
@@ -1121,7 +1120,7 @@ class Mixer extends ComponentContainer {
                 }
             },
             globalQuantizeOn: false,
-            inByte: 12,
+            inByte: 11,
             inBit: 6,
             outByte: 93,
         });
@@ -1129,11 +1128,11 @@ class Mixer extends ComponentContainer {
         this.crossfader = new Pot({
             group: "[Master]",
             inKey: "crossfader",
-            inByte: 1,
+            inByte: 0,
             inReport: inReports[2],
         });
         this.crossfaderCurveSwitch = new Component({
-            inByte: 19,
+            inByte: 18,
             inBit: 0,
             inBitLength: 2,
             input: function(value) {
@@ -2765,33 +2764,33 @@ class S4MK3 {
 
         this.effectUnit1 = new S4Mk3EffectUnit(1, this.inReports, this.outReports[128],
             {
-                mixKnob: {inByte: 31},
-                mainButton: {inByte: 2, inBit: 6, outByte: 62},
+                mixKnob: {inByte: 30},
+                mainButton: {inByte: 1, inBit: 6, outByte: 62},
                 knobs: [
-                    {inByte: 33},
-                    {inByte: 35},
-                    {inByte: 37},
+                    {inByte: 32},
+                    {inByte: 34},
+                    {inByte: 36},
                 ],
                 buttons: [
-                    {inByte: 2, inBit: 7, outByte: 63},
-                    {inByte: 2, inBit: 3, outByte: 64},
-                    {inByte: 2, inBit: 2, outByte: 65},
+                    {inByte: 1, inBit: 7, outByte: 63},
+                    {inByte: 1, inBit: 3, outByte: 64},
+                    {inByte: 1, inBit: 2, outByte: 65},
                 ],
             }
         );
         this.effectUnit2 = new S4Mk3EffectUnit(2, this.inReports, this.outReports[128],
             {
-                mixKnob: {inByte: 71},
-                mainButton: {inByte: 10, inBit: 4, outByte: 73},
+                mixKnob: {inByte: 70},
+                mainButton: {inByte: 9, inBit: 4, outByte: 73},
                 knobs: [
-                    {inByte: 73},
-                    {inByte: 75},
-                    {inByte: 77},
+                    {inByte: 72},
+                    {inByte: 74},
+                    {inByte: 76},
                 ],
                 buttons: [
-                    {inByte: 10, inBit: 5, outByte: 74},
-                    {inByte: 10, inBit: 6, outByte: 75},
-                    {inByte: 10, inBit: 7, outByte: 76},
+                    {inByte: 9, inBit: 5, outByte: 74},
+                    {inByte: 9, inBit: 6, outByte: 75},
+                    {inByte: 9, inBit: 7, outByte: 76},
                 ],
             }
         );
@@ -2808,50 +2807,50 @@ class S4MK3 {
             [1, 3], [DeckColors[0], DeckColors[2]], this.effectUnit1, this.mixer,
             this.inReports, this.outReports[128],
             {
-                playButton: {inByte: 5, inBit: 0, outByte: 55},
-                cueButton: {inByte: 5, inBit: 1, outByte: 8},
-                syncButton: {inByte: 6, inBit: 7, outByte: 14},
-                syncMasterButton: {inByte: 1, inBit: 0, outByte: 15},
-                hotcuePadModeButton: {inByte: 5, inBit: 2, outByte: 9},
-                recordPadModeButton: {inByte: 5, inBit: 3, outByte: 56},
-                samplesPadModeButton: {inByte: 5, inBit: 4, outByte: 57},
-                mutePadModeButton: {inByte: 5, inBit: 5, outByte: 58},
-                stemsPadModeButton: {inByte: 6, inBit: 0, outByte: 10},
-                deckButtonLeft: {inByte: 6, inBit: 2},
-                deckButtonRight: {inByte: 6, inBit: 3},
+                playButton: {inByte: 4, inBit: 0, outByte: 55},
+                cueButton: {inByte: 4, inBit: 1, outByte: 8},
+                syncButton: {inByte: 5, inBit: 7, outByte: 14},
+                syncMasterButton: {inByte: 0, inBit: 0, outByte: 15},
+                hotcuePadModeButton: {inByte: 4, inBit: 2, outByte: 9},
+                recordPadModeButton: {inByte: 4, inBit: 3, outByte: 56},
+                samplesPadModeButton: {inByte: 4, inBit: 4, outByte: 57},
+                mutePadModeButton: {inByte: 4, inBit: 5, outByte: 58},
+                stemsPadModeButton: {inByte: 5, inBit: 0, outByte: 10},
+                deckButtonLeft: {inByte: 5, inBit: 2},
+                deckButtonRight: {inByte: 5, inBit: 3},
                 deckButtonOutputByteOffset: 12,
                 tempoFaderLED: {outByte: 11},
-                shiftButton: {inByte: 6, inBit: 1, outByte: 59},
-                leftEncoder: {inByte: 20, inBit: 0},
-                leftEncoderPress: {inByte: 7, inBit: 2},
-                rightEncoder: {inByte: 20, inBit: 4},
-                rightEncoderPress: {inByte: 7, inBit: 5},
-                libraryEncoder: {inByte: 21, inBit: 0},
-                libraryEncoderPress: {inByte: 1, inBit: 1},
-                turntableButton: {inByte: 6, inBit: 5, outByte: 17},
-                jogButton: {inByte: 6, inBit: 4, outByte: 16},
-                gridButton: {inByte: 6, inBit: 6, outByte: 18},
-                reverseButton: {inByte: 2, inBit: 4, outByte: 60},
-                fluxButton: {inByte: 2, inBit: 5, outByte: 61},
-                libraryPlayButton: {inByte: 1, inBit: 5, outByte: 22},
-                libraryStarButton: {inByte: 1, inBit: 4, outByte: 21},
-                libraryPlaylistButton: {inByte: 2, inBit: 1, outByte: 20},
-                libraryViewButton: {inByte: 2, inBit: 0, outByte: 19},
+                shiftButton: {inByte: 5, inBit: 1, outByte: 59},
+                leftEncoder: {inByte: 19, inBit: 0},
+                leftEncoderPress: {inByte: 6, inBit: 2},
+                rightEncoder: {inByte: 19, inBit: 4},
+                rightEncoderPress: {inByte: 6, inBit: 5},
+                libraryEncoder: {inByte: 20, inBit: 0},
+                libraryEncoderPress: {inByte: 0, inBit: 1},
+                turntableButton: {inByte: 5, inBit: 5, outByte: 17},
+                jogButton: {inByte: 5, inBit: 4, outByte: 16},
+                gridButton: {inByte: 5, inBit: 6, outByte: 18},
+                reverseButton: {inByte: 1, inBit: 4, outByte: 60},
+                fluxButton: {inByte: 1, inBit: 5, outByte: 61},
+                libraryPlayButton: {inByte: 0, inBit: 5, outByte: 22},
+                libraryStarButton: {inByte: 0, inBit: 4, outByte: 21},
+                libraryPlaylistButton: {inByte: 1, inBit: 1, outByte: 20},
+                libraryViewButton: {inByte: 1, inBit: 0, outByte: 19},
                 pads: [
-                    {inByte: 4, inBit: 5, outByte: 0},
-                    {inByte: 4, inBit: 4, outByte: 1},
-                    {inByte: 4, inBit: 7, outByte: 2},
-                    {inByte: 4, inBit: 6, outByte: 3},
+                    {inByte: 3, inBit: 5, outByte: 0},
+                    {inByte: 3, inBit: 4, outByte: 1},
+                    {inByte: 3, inBit: 7, outByte: 2},
+                    {inByte: 3, inBit: 6, outByte: 3},
 
-                    {inByte: 4, inBit: 3, outByte: 4},
-                    {inByte: 4, inBit: 2, outByte: 5},
-                    {inByte: 4, inBit: 1, outByte: 6},
-                    {inByte: 4, inBit: 0, outByte: 7},
+                    {inByte: 3, inBit: 3, outByte: 4},
+                    {inByte: 3, inBit: 2, outByte: 5},
+                    {inByte: 3, inBit: 1, outByte: 6},
+                    {inByte: 3, inBit: 0, outByte: 7},
                 ],
-                tempoFader: {inByte: 13, inBit: 0, inBitLength: 16, inReport: this.inReports[2]},
-                wheelRelative: {inByte: 12, inBit: 0, inBitLength: 16, inReport: this.inReports[3]},
-                wheelAbsolute: {inByte: 16, inBit: 0, inBitLength: 16, inReport: this.inReports[3]},
-                wheelTouch: {inByte: 17, inBit: 4},
+                tempoFader: {inByte: 12, inBit: 0, inBitLength: 16, inReport: this.inReports[2]},
+                wheelRelative: {inByte: 11, inBit: 0, inBitLength: 16, inReport: this.inReports[3]},
+                wheelAbsolute: {inByte: 15, inBit: 0, inBitLength: 16, inReport: this.inReports[3]},
+                wheelTouch: {inByte: 16, inBit: 4},
             }
         );
 
@@ -2859,50 +2858,50 @@ class S4MK3 {
             [2, 4], [DeckColors[1], DeckColors[3]], this.effectUnit2, this.mixer,
             this.inReports, this.outReports[128],
             {
-                playButton: {inByte: 13, inBit: 0, outByte: 66},
-                cueButton: {inByte: 15, inBit: 5, outByte: 31},
-                syncButton: {inByte: 15, inBit: 4, outByte: 37},
-                syncMasterButton: {inByte: 11, inBit: 0, outByte: 38},
-                hotcuePadModeButton: {inByte: 13, inBit: 2, outByte: 32},
-                recordPadModeButton: {inByte: 13, inBit: 3, outByte: 67},
-                samplesPadModeButton: {inByte: 13, inBit: 4, outByte: 68},
-                mutePadModeButton: {inByte: 13, inBit: 5, outByte: 69},
-                stemsPadModeButton: {inByte: 13, inBit: 1, outByte: 33},
-                deckButtonLeft: {inByte: 15, inBit: 2},
-                deckButtonRight: {inByte: 15, inBit: 3},
+                playButton: {inByte: 12, inBit: 0, outByte: 66},
+                cueButton: {inByte: 14, inBit: 5, outByte: 31},
+                syncButton: {inByte: 14, inBit: 4, outByte: 37},
+                syncMasterButton: {inByte: 10, inBit: 0, outByte: 38},
+                hotcuePadModeButton: {inByte: 12, inBit: 2, outByte: 32},
+                recordPadModeButton: {inByte: 12, inBit: 3, outByte: 67},
+                samplesPadModeButton: {inByte: 12, inBit: 4, outByte: 68},
+                mutePadModeButton: {inByte: 12, inBit: 5, outByte: 69},
+                stemsPadModeButton: {inByte: 12, inBit: 1, outByte: 33},
+                deckButtonLeft: {inByte: 14, inBit: 2},
+                deckButtonRight: {inByte: 14, inBit: 3},
                 deckButtonOutputByteOffset: 35,
                 tempoFaderLED: {outByte: 34},
-                shiftButton: {inByte: 15, inBit: 1, outByte: 70},
-                leftEncoder: {inByte: 21, inBit: 4},
-                leftEncoderPress: {inByte: 16, inBit: 5},
-                rightEncoder: {inByte: 22, inBit: 0},
-                rightEncoderPress: {inByte: 16, inBit: 2},
-                libraryEncoder: {inByte: 22, inBit: 4},
-                libraryEncoderPress: {inByte: 11, inBit: 1},
-                turntableButton: {inByte: 15, inBit: 6, outByte: 40},
-                jogButton: {inByte: 15, inBit: 0, outByte: 39},
-                gridButton: {inByte: 15, inBit: 7, outByte: 41},
-                reverseButton: {inByte: 11, inBit: 4, outByte: 71},
-                fluxButton: {inByte: 11, inBit: 5, outByte: 72},
-                libraryPlayButton: {inByte: 10, inBit: 2, outByte: 45},
-                libraryStarButton: {inByte: 10, inBit: 1, outByte: 44},
-                libraryPlaylistButton: {inByte: 10, inBit: 3, outByte: 43},
-                libraryViewButton: {inByte: 10, inBit: 0, outByte: 42},
+                shiftButton: {inByte: 14, inBit: 1, outByte: 70},
+                leftEncoder: {inByte: 20, inBit: 4},
+                leftEncoderPress: {inByte: 15, inBit: 5},
+                rightEncoder: {inByte: 21, inBit: 0},
+                rightEncoderPress: {inByte: 15, inBit: 2},
+                libraryEncoder: {inByte: 21, inBit: 4},
+                libraryEncoderPress: {inByte: 10, inBit: 1},
+                turntableButton: {inByte: 14, inBit: 6, outByte: 40},
+                jogButton: {inByte: 14, inBit: 0, outByte: 39},
+                gridButton: {inByte: 14, inBit: 7, outByte: 41},
+                reverseButton: {inByte: 10, inBit: 4, outByte: 71},
+                fluxButton: {inByte: 10, inBit: 5, outByte: 72},
+                libraryPlayButton: {inByte: 9, inBit: 2, outByte: 45},
+                libraryStarButton: {inByte: 9, inBit: 1, outByte: 44},
+                libraryPlaylistButton: {inByte: 9, inBit: 3, outByte: 43},
+                libraryViewButton: {inByte: 9, inBit: 0, outByte: 42},
                 pads: [
-                    {inByte: 14, inBit: 5, outByte: 23},
-                    {inByte: 14, inBit: 4, outByte: 24},
-                    {inByte: 14, inBit: 7, outByte: 25},
-                    {inByte: 14, inBit: 6, outByte: 26},
+                    {inByte: 13, inBit: 5, outByte: 23},
+                    {inByte: 13, inBit: 4, outByte: 24},
+                    {inByte: 13, inBit: 7, outByte: 25},
+                    {inByte: 13, inBit: 6, outByte: 26},
 
-                    {inByte: 14, inBit: 3, outByte: 27},
-                    {inByte: 14, inBit: 2, outByte: 28},
-                    {inByte: 14, inBit: 1, outByte: 29},
-                    {inByte: 14, inBit: 0, outByte: 30},
+                    {inByte: 13, inBit: 3, outByte: 27},
+                    {inByte: 13, inBit: 2, outByte: 28},
+                    {inByte: 13, inBit: 1, outByte: 29},
+                    {inByte: 13, inBit: 0, outByte: 30},
                 ],
-                tempoFader: {inByte: 11, inBit: 0, inBitLength: 16, inReport: this.inReports[2]},
-                wheelRelative: {inByte: 40, inBit: 0, inBitLength: 16, inReport: this.inReports[3]},
-                wheelAbsolute: {inByte: 44, inBit: 0, inBitLength: 16, inReport: this.inReports[3]},
-                wheelTouch: {inByte: 17, inBit: 5},
+                tempoFader: {inByte: 10, inBit: 0, inBitLength: 16, inReport: this.inReports[2]},
+                wheelRelative: {inByte: 39, inBit: 0, inBitLength: 16, inReport: this.inReports[3]},
+                wheelAbsolute: {inByte: 43, inBit: 0, inBitLength: 16, inReport: this.inReports[3]},
+                wheelTouch: {inByte: 16, inBit: 5},
             }
         );
 

--- a/res/controllers/common-controller-scripts.js
+++ b/res/controllers/common-controller-scripts.js
@@ -16,38 +16,7 @@
        Control:off
        Deck:off
  */
-/* exported LibraryColumns */
 /*eslint no-var:off */
-
-// ----------------- Mapping constants ---------------------
-
-// Library column value, which can be used to interact with the CO for "[Library] sort_column"
-var LibraryColumns = {
-    Artist: 1,
-    Title: 2,
-    Album: 3,
-    Albumartist: 4,
-    Year: 5,
-    Genre: 6,
-    Composer: 7,
-    Grouping: 8,
-    Tracknumber: 9,
-    Filetype: 10,
-    NativeLocation: 11,
-    Comment: 12,
-    Duration: 13,
-    Bitrate: 14,
-    BPM: 15,
-    ReplayGain: 16,
-    DatetimeAdded: 17,
-    TimesPlayed: 18,
-    Rating: 19,
-    Key: 20,
-    Preview: 21,
-    Coverart: 22,
-    TrackColor: 30,
-    LastPlayed: 31,
-};
 
 // ----------------- Prototype enhancements ---------------------
 
@@ -158,6 +127,36 @@ var colorCodeToObject = function(colorCode) {
 
 var script = function() {
 };
+
+// ----------------- Mapping constants ---------------------
+
+// Library column value, which can be used to interact with the CO for "[Library] sort_column"
+script.LIBRARY_COLUMNS = Object.freeze({
+    ARTIST: 1,
+    TITLE: 2,
+    ALBUM: 3,
+    ALBUM_ARTIST: 4,
+    YEAR: 5,
+    GENRE: 6,
+    COMPOSER: 7,
+    GROUPING: 8,
+    TRACK_NUMBER: 9,
+    FILETYPE: 10,
+    NATIVE_LOCATION: 11,
+    COMMENT: 12,
+    DURATION: 13,
+    BITRATE: 14,
+    BPM: 15,
+    REPLAY_GAIN: 16,
+    DATETIME_ADDED: 17,
+    TIMES_PLAYED: 18,
+    RATING: 19,
+    KEY: 20,
+    PREVIEW: 21,
+    COVERART: 22,
+    TRACK_COLOR: 30,
+    LAST_PLAYED: 31,
+});
 
 // DEPRECATED -- use script.midiDebug() instead
 script.debug = function(channel, control, value, status, group) {

--- a/res/controllers/common-controller-scripts.js
+++ b/res/controllers/common-controller-scripts.js
@@ -16,7 +16,6 @@
        Control:off
        Deck:off
  */
-/*eslint no-var:off */
 
 // ----------------- Prototype enhancements ---------------------
 

--- a/res/controllers/common-controller-scripts.js
+++ b/res/controllers/common-controller-scripts.js
@@ -21,7 +21,7 @@
 
 // Returns an ASCII byte array for the string
 String.prototype.toInt = function() {
-    const a = new Array();
+    const a = [];
     for (let i = 0; i < this.length; i++) {
         a[i] = this.charCodeAt(i);
     }
@@ -124,6 +124,7 @@ var colorCodeToObject = function(colorCode) {
     };
 };
 
+/* eslint @typescript-eslint/no-empty-function: "off" */
 var script = function() {
 };
 
@@ -494,7 +495,6 @@ script.softStart = function(channel, control, value, status, group, factor) {
 };
 
 // bpm - Used for tapping the desired BPM for a deck
-
 var bpm = function() {
 };
 
@@ -584,6 +584,7 @@ var Controller = function() {
 
 Controller.prototype.addButton = function(buttonName, button, eventHandler) {
     if (eventHandler) {
+        /* eslint @typescript-eslint/no-this-alias: "off" */
         const executionEnvironment = this;
         const handler = function(value) {
             button.state = value;

--- a/res/controllers/common-controller-scripts.js
+++ b/res/controllers/common-controller-scripts.js
@@ -16,6 +16,38 @@
        Control:off
        Deck:off
  */
+/* exported LibraryColumns */
+/*eslint no-var:off */
+
+// ----------------- Mapping constants ---------------------
+
+// Library column value, which can be used to interact with the CO for "[Library] sort_column"
+var LibraryColumns = {
+    Artist: 1,
+    Title: 2,
+    Album: 3,
+    Albumartist: 4,
+    Year: 5,
+    Genre: 6,
+    Composer: 7,
+    Grouping: 8,
+    Tracknumber: 9,
+    Filetype: 10,
+    NativeLocation: 11,
+    Comment: 12,
+    Duration: 13,
+    Bitrate: 14,
+    BPM: 15,
+    ReplayGain: 16,
+    DatetimeAdded: 17,
+    TimesPlayed: 18,
+    Rating: 19,
+    Key: 20,
+    Preview: 21,
+    Coverart: 22,
+    TrackColor: 30,
+    LastPlayed: 31,
+};
 
 // ----------------- Prototype enhancements ---------------------
 

--- a/src/test/controller_mapping_validation_test.cpp
+++ b/src/test/controller_mapping_validation_test.cpp
@@ -13,6 +13,14 @@ void FakeControllerJSProxy::send(const QList<int>& data, unsigned int length) {
     Q_UNUSED(length);
 }
 
+void FakeControllerJSProxy::sendOutputReport(quint8 reportID,
+        const QByteArray& dataArray,
+        bool resendUnchangedReport) {
+    Q_UNUSED(reportID);
+    Q_UNUSED(dataArray);
+    Q_UNUSED(resendUnchangedReport);
+}
+
 void FakeControllerJSProxy::sendSysexMsg(const QList<int>& data, unsigned int length) {
     Q_UNUSED(data);
     Q_UNUSED(length);

--- a/src/test/controller_mapping_validation_test.h
+++ b/src/test/controller_mapping_validation_test.h
@@ -18,6 +18,10 @@ class FakeControllerJSProxy : public ControllerJSProxy {
     Q_INVOKABLE void sendShortMsg(unsigned char status,
             unsigned char byte1,
             unsigned char byte2);
+
+    Q_INVOKABLE void sendOutputReport(quint8 reportID,
+            const QByteArray& dataArray,
+            bool resendUnchangedReport = false);
 };
 
 class FakeController : public Controller {


### PR DESCRIPTION
Howdy Mixxx community! 

<details>
  <summary>Some irrelevant context</summary>
I have recently acquired some S4 MK3 gears, and like many as I could read online, I was somehow disappointed with the overall Traktor experience and the lack of capability, whilst extremely pleased with the hardware.

I decided to try Mixxx, which I had tried many years ago with some Reloop gears, sadly, when I plugged it (and fixed the udev rules...), the controller wasn't recognized out of the box, which was a bit of a bummer.

With this current mapping, I am now fully embracing these controllers again and thought I will share it with the community!
</details>

This work is continued from the great one that @Be-ing had started a few months back. A few mappings were changed from his first draft, but most of all, the wheel is now accurate, **both in vinyl and turntable mode**. 

Sadly the screens won't work in the current state of Mixxx as [@Be-ing mentioned it on Reddit](https://www.reddit.com/r/DJs/comments/pl7zrl/comment/hcb6sjv/?utm_source=share&utm_medium=web2x&context=3). After further reverse engineering, I can confirm that the screens are driven by sending a 320x240 pixels matrix using a 16-bits color depth. While it could easily be driven by something external as this is not on the HID class (thus not locked), there is no way to integrate this smoothly within Mixxx (just yet at least, hopefully the team has plans for these additional vendor classes, which isn't unique to NI gears I believe). Perhaps if there is no immediate plans, a socket allowing a third party program to fetch metadata (RO) from Mixxx could be a nice step forward? This way, any vendor specific could be compiled into a third party program that would interact with these specific vendor classes.

Currently, I have kept the 20 quick FX selector, but IMO, it is far too much as there is no way to remember these 20 combinations. Furthermore, now that FX units are easier to interact with, I believe that 5-10 should be the max and I will likely do a different mode.


As it stands, they are a few mild issues limitation due to either missing features or bugs in Mixxx:
- [Feat] Many configurable settings (deck colors, number of quick FXs, loop move factor, ...) must be hard-coded, while it would be great if this could easily be changed in the settings UI, for example using the XML to define configurable items. (#8135)
- [Feat] No control with preparation playlist (e.g ability to add the selected track to a selected/preparation playlist)
- [Feat] No control with the existing related search feature (e.g ability to search track with a similar key or BPM) due to missing engine controls.
- [Bug] Library browsing won't work with if Mixxx window doesn't have focus (#11285)
- [Bug] Missed HID instruction due to skipped frame (#10828) leading to the left wheel ring to stay on upon shutdown (the workaround cannot apply there)

These limitations being unrelated to the mapping itself, I believe this could be considered production ready. I had a few sessions with it and it was a blast! It might not be 100% perfect but I believe this would be better than nothing and allow s4 owner to at least have something working at first. If the team thinks this would be acceptable, I will provide more docs as per the contribution guidelines.

I will report the bug (Library browsing), however I will hold for feature requests, as I don't want to overstep boundaries and request features that may be only interesting for me (or S4 MK3 owners). If you think they are fair requests tho, I'm happy to formulate them into issues, and potentially even help with them! :) 

## Documentation

Here is a very "quick-n-dirty" documentation for anyone that would like to try this mapping. If the Mixxx team would consider this PR for merging, I would be happy to work on this more and submit an other PR to [the manual](https://github.com/mixxxdj/manual)

### Wheel mode

Wheel modes define how the wheel reacts when used. Here are all the various modes:

1. **Vinyl mode** (_default_): The wheel platter can be used for scratch. The wheel crown can be used to jog up or down the playback. This mode is on if the **Turntable button** is _off_ but the **Jog button** is _on_
2. **Jog mode**: The wheel platter and crown can be used to jog up or down the playback. This mode is on if the **Turntable button** and the **Jog button** are _off_
3. **Turntable mode**: The wheel behaves as a 33.3 turntable. If the platter or crown are slowed down or speeded up, then it will scratch down or up the track. **Warning:** Because the scratch mode is used, if the track has been pitched up, the keylock will be ignored!. This mode is on if the **Turntable button** is _on_ and the **Jog button** is _off_
4. **Loop in**: The wheel behaves similarly to CDJ. If the platter or crown are turned, it will move back or forth the start of the loop. Additionally, if the loop encoder is used, it will move the all loop back or forth. This mode is on if the **Reverse button** and the **Wheel ring** are _blinking_. *This mode is only available if a loop is active, and will be turned off if the loop is deactivated*
5. **Loop out**: The wheel linke for the **loop in** mode, but for the exit of the loop. If the platter or crown are turned, it will move back or forth the end of the loop. Additionally, if the loop encoder is used, it will move the all loop back or forth. This mode is on if the **Flux button** and the **Wheel ring** are _blinking_. *This mode is only available if a loop is active, and will be turned off if the loop is deactivated*

### Move mode

Moves modes define how the move encoder reacts when used. Here are all the various modes:

1. **Beat** (_default_): The track will jump backward or forward by the number of beats selected
2. **Grid**: The track's detected beats will be move forward or backward on the waveform. This mode is on if **Grid** is kept pressed. (The **Grid** button will _blink_)
3. **BPM**: The track's detected BPM will be increased or decreased. This mode is on if **Shift**+**Grid** are kept pressed. (The **Grid** button will _blink_)
4. **Keyboard**: The keybaord's keys displayed on pads gets offseted to display higher or lower keys. This mode is on if **Stems** is kept pressed. (The **Stems** button will _blink_)

### Mapping details




| Button | Action | Lighting |
|--------|--------|----------|
| Wheel platter | <ul><li>Scratch when in Vinyl mode and Turntable mode</li><li>Jog when in Jog mode</li><li>Move loop start when in Loop In mode</li><li>Move loop end when in Loop Out mode | </li><li>Static light rotation: Vinyl, Turntable or Jog mode on</li><li>Ring blinking: Loop in or out mode on</li></ul> |</li>
| Wheel crown | Jog when in Vinyl mode, otherwise same as wheel platter | |
| Flux | <ul><li>Toggle flux mode</li><li>On shift, set a loop end the currrent track position if no active loop, enable loop out wheel mode otherwise</li></ul>  | <ul><li>Steady on while no shifting: Reverse enabled</li><li>Steady on while shiftinh: loop is active</li><li>Blinking, but flux steady off while shifting: loop in set<li>Blinking, with flux steady on while shifting: loop in </li>wheel mode active
| Reverse | <ul><li>Toggle reverse mode</li>      <li>On shift, set a loop in the currrent track position if </li>no active loop, enable loop out wheel mode otherwise | <ul>    <li>Steady on while no shifting: Flux enabled</li>      <li>Steady on while shifting: loop is active</li><li>Blinking, with reverse steady on while shifting: loop out wheel mode active</li>
| Grid | <ul><li>Set the beatgrid at the current track position (on release, </li>short press)<li>Enable grid move mode while pressed </li><li>Enable BPM move mode while pressed and shifting</li></ul> | <ul><li>On when over a detected beat</li><li>Blinking when grid/BPM move is on</li><li>Blkinking when grid move mode is enabled
| Turntable | Toggle on or off the turntable mode | On: Turntable mode on, otherwise jog or vinyl |
| Jog | Toggle on or off the vinyl mode | On: Vinyl mode on, otherwise jog or turntable |
| Deck Select | Select a deck | The deck's main color will be the one of the selected deck |
| Shift | Shift controls for the all controller side, including effect unit | On or Off |
| Cue | <ul><li>Trigger the cue default effect</li><li>Start or stop the track while shifting</li><li>Select the cue as the play mode if keyboard move mode on | </li>Depending of the cue default mode
| Play/Pause | <ul><li>Play/Pause the track</li><li>Long press: clone the playing track</li><li>Shift+Long press: eject track</li> | On if track is playing
| Move | <ul><li>Beat jump forward (right) or backward by the number of </li>selected beats<li>Increase/Decrease the beats if turned while pressed</li><li>Increase/decrease pitch when shifting</li><li>Move backward/forward the grid when in grid move mode</li><li>Increase/decrease BPM when in BPM move mode</li><li>Move down/up the keyboard notes when in keyboard move mode </li>| |
| Loop | <ul><li>Enable/disable loop when pressed</li><li>Reactivate exited loop/exit loop when pressed and shifted</li><li>Halve/double the loop size</li><li>Move 1 beat backward/forward when shifted</li><li>On loop in/out wheel mode: move the loop with precision, </li>left precision if shifted | |
| Master | <ul><li>Make the curent deck sync leader (on release)</li><li>Long press: Enabled/disable full range tempo fader | <ul><li>Steady on: the deck is sync leader</li><li>Blinking: the tempo fader is in full range</li></ul> |
| Sync | <ul><li>Toggle the sync mode (on release)</li><li>Toggle the keylock (on release)</li><li>Long press: copy the BPM of the other deck</li><li>Shift+Long press: copy the key of the other deck</li></ul> | <ul><li>On while no shift: Sync is on</li><li>On while shift: Keylock is on</li></ul> |
| Tempo fader | While change the tempo only of the left indicator is either off or of the color of the deck. If green, it means the fader is out of sync with the software, bringing it down will eventually catch up. If white, it means the fader is out of sync with the software, bringing it up will eventually catch up. | |
| Hotcues | <ul><li>Toggle the hotcues page</li><li>Shift: toggle the second hotcue page</li></ul> | <ul><li>Deck color with dim off: Current page isn't related to hotcue</li><li>Deck color with dim on: page 1 of hotcue</li><li>White: page 2 of hotcue</li></ul> |
| Rec | *Currently unused* | |
| Sampler | <ul><li>Toggle the sampler page and display samplers on the UI</li><li>Off: Current page isn't related to samplern: sampler page is active</li></ul> |
| Mute | *Currently unused* | |
| Stems | <ul><li>Toggle the keyboard (on release) while press: enable keyboard move mode</li></ul> | <ul><li>Deck color with dim off: Current page isn't related to keyboard</li><li>deck color with dim on: Keyboard active</li></ul>
Green: keyboard play mode active |
| Pads | <ul><li>While in hotcue: <ul><li>press will activate</li><li>shift+press will delete</li></ul></li><li>While in sample: <ul><li>press will play (load selected track if none are)</li><li>shift+press will stop (if playing) or eject</li></ul></li><li>While in keyboard: <ul><li>will set the key to the selected note</li><li>will play from the cue if in keyboard play mode</li></ul> | <ul><li>In hotcue: color of the cue</li><li>In Sampler: Dim on, sample is playing, dim off sampler is stopped, off no sampler loaded</li><li>In keyboard: keyboard color on each note, if Dim on, currently active note</li></ul> |
| FX 1st knob | Master volume/mix of the unit | |
| FX 1st button | <ul><li>Trigger all effect</li><li>Assign/de-assign effect to master while shifting and no focused effect</li><li>Exit focused mode while shifting and focused effect</li></ul> | <ul><li>On if all effect are when no shifting</li><li>On when effect is attached to master when shifting</li><li>Blinking in effect focused mode</li></ul>|
| FX 2nd knob | <ul><li>Meta arg of the first selected effect</li><li>First arg of the focused effect in effect focus mode</li></ul>| |
| FX 3rd knob | <ul><li>Meta arg of the second selected effect</li><li>Second arg of the focused effect in effect focus mode</li></ul>| |
| FX 4th knob | <ul><li>Meta arg of the third selected effect</li><li>Third arg of the focused effect in effect focus mode</li></ul>| |
| FX 2nd button | <ul><li>Toggle first effect (short press) or trigger first effect (long press) and no focused effect</li><li>Toggle first arg (short press) or trigger first arg (long press) of the focus effect if any</li></ul> | <ul><li>On if effect is active and no focused effect</li><li>arg state</li></ul> |
| FX 3rd button | <ul><li>Toggle second effect (short press) or trigger second effect (long press) and no focused effect</li><li>Toggle second arg (short press) or trigger cond arg (long press) of the focus effect if any</li></ul> | <ul><li>On if effect is active and no focused effect</li><li>arg state</li></ul> |
| FX 4th button | <ul><li>Toggle third effect (short press) or trigger third effect (long press) and no focused effect</li><li>Toggle third arg (short press) or trigger ird arg (long press) of the focus effect if any</li></ul> | <ul><li>On if effect is active and no focused effect</li><li>arg state</li></ul> |
| Library knob | <ul><li>Move up/down in tracklist</li><li>Move up/down in tree structure while shifted</li><li>Move up/down in the context menu if playlist button is pressed</li><li>Zoom in/out the waveform when in grid move mode</li><li>Beatjump by 16 beats backward/forward if a track is being previewed using the button</li><li>Star down/up the currently playing track while pressing the star button</li><li>Sort by next/previous column while pressing the view button</li><li>Expand the context-manu item when pressed while pressing the playlist button</li><li>Load track when pressed or expand/collapse tree node when shifted (if view button is not pressed)</li><li>Inverse the column sorting if view button is pressed</li></ul> | |
| Preview button | Preview the currently selected track while pressed | |
| Star button | Change the selected track color on short press (next color, or previous if shifted) | |
| Star button | Change the selected track color on short press (next color, or previous if shifted) | |
| Playlist button | Open or close a context menu for the currently selected track | On if there is a context-menu open, off otherwise |
| Mixer FX button | Toggle third effect (short press) or trigger third effect (long press) or assign the quick effect of FX select buttons are pressed | Dim on if the effect is active |
| FX Select button | Apply effect to all deck on release, if no mixer FX button have been pressed | |
| Ext | Apply the current gain as default | |
