### PR TITLE
Fullscreen on Linux: fix issues caused by Ubuntu Unity workaround

### DIFF
--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -265,6 +265,13 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
             ConfigKey("[Config]", "StartInFullscreen"));
     if (args.getStartInFullscreen() || fullscreenPref) {
         showFullScreen();
+#ifdef __LINUX__
+        // If the desktop features a global menubar and we go fullscreen during
+        // startup, move the menubar to the window like in slotViewFullScreen()
+        if (m_pMenuBar->isNativeMenuBar()) {
+            m_pMenuBar->setNativeMenuBar(false);
+        }
+#endif
     }
 
     QString resourcePath = pConfig->getResourcePath();
@@ -1078,7 +1085,6 @@ QDialog::DialogCode MixxxMainWindow::soundDeviceBusyDlg(bool* retryClicked) {
     return soundDeviceErrorDlg(title, text, retryClicked);
 }
 
-
 QDialog::DialogCode MixxxMainWindow::soundDeviceErrorMsgDlg(
         SoundDeviceError err, bool* retryClicked) {
     QString title(tr("Sound Device Error"));
@@ -1378,7 +1384,6 @@ void MixxxMainWindow::slotFileLoadSongPlayer(int deck) {
     }
 }
 
-
 void MixxxMainWindow::slotOptionsKeyboard(bool toggle) {
     UserSettingsPointer pConfig = m_pSettingsManager->settings();
     if (toggle) {
@@ -1645,7 +1650,6 @@ void MixxxMainWindow::closeEvent(QCloseEvent *event) {
     }
     QMainWindow::closeEvent(event);
 }
-
 
 void MixxxMainWindow::checkDirectRendering() {
     // IF

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -691,6 +691,14 @@ void WMainMenuBar::createVisibilityControl(QAction* pAction,
             &WMainMenuBar::internalOnNewSkinLoaded,
             pConnection,
             &VisibilityControlConnection::slotReconnectControl);
+#ifdef __LINUX__
+    // reconnect when menu bar was recreated after toggling fullscreen
+    // so all hotkeys and menu actions continue to work
+    connect(this,
+            &WMainMenuBar::internalFullScreenStateChange,
+            pConnection,
+            &VisibilityControlConnection::slotReconnectControl);
+#endif
     connect(this,
             &WMainMenuBar::internalOnNewSkinAboutToLoad,
             pConnection,


### PR DESCRIPTION
supersedes #11259 

In order to fix #6072 the menubar is recreated and reconected when toggling fullscreen on Linux.
This causes issues on some distros. 
Fixes #11281
Fixes #11294 

* reconnect `VisibilityControlConnection`s in View menu after toglling fullscreen
* relocate the menubar when starting in fullscreen on desktops that have global menu