### PR TITLE
Search: don't trigger search on each cursor keys press ...

### DIFF
--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -67,6 +67,7 @@ class WSearchLineEdit : public QComboBox, public WBaseWidget {
   private slots:
     void slotSetShortcutFocus();
     void slotTextChanged(const QString& text);
+    void slotSelectionChanged();
     void slotIndexChanged(int index);
 
     void slotTriggerSearch();
@@ -111,5 +112,6 @@ class WSearchLineEdit : public QComboBox, public WBaseWidget {
 
     QTimer m_debouncingTimer;
     QTimer m_saveTimer;
+    bool m_completionAccepted;
     bool m_queryEmitted;
 };


### PR DESCRIPTION
instead, hook up to signals [`QCompleter::highlighted()`](https://doc.qt.io/qt-5/qcompleter.html#highlighted) and [`QLineEdit::selectionChanged()`](https://doc.qt.io/qt-5/qlineedit.html#selectionChanged) and accept the completer proposal if it's selection is changed (call `slotTextChanged()`).

This is an alternative to #11289 

In my tests this works reliably because the signals are emitted like this:
* type some text the completer can pick up
* the completer appends the missing part and selectes it
* the QLineEdit emits `(textChanged`) and `selectionChanged`
* the QCompleter emits `highlighted`