### PR TITLE
toggle the menubar with single Alt key press

### DIFF
--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -341,8 +341,10 @@ WOverview QLabel {
 /************** font sizes / alignment ****************************************/
 /************** font settings *************************************************/
 
-
-
+WFullScreenHint QPushButton {
+  border-width: 2px 2px 2px 2px;
+  border-image: url(skin:/classic/buttons/spinbox_elevated_border.svg) 2 2 2 2;
+}
 
 
 

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -1480,7 +1480,8 @@ WPushButton#FxParameterButton[displayValue="0"] {
 #VinylCueButton[displayValue="2"],
 #FxParameterButton[displayValue="1"],
 #SplitCue[value="1"],
-QPushButton#pushButtonRepeatPlaylist:checked {
+QPushButton#pushButtonRepeatPlaylist:checked,
+WFullScreenHint QPushButton {
   background-color: #888;
 }
 

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -1200,6 +1200,9 @@ WLibrarySidebar,
 #LibraryFeatureControls QRadioButton,
 /* Tooltip and menus */
 QToolTip,
+WFullScreenHint QLabel,
+WFullScreenHint QCheckBox,
+WFullScreenHint QPushButton,
 WLibrarySidebar QMenu,
 WTrackTableViewHeader QMenu,
 WLibraryTextBrowser QMenu,
@@ -2920,6 +2923,10 @@ WSearchLineEdit QAbstractScrollArea,
   border-radius: 1px;
 }
 
+
+WFullScreenHint,
+WFullScreenHint QLabel,
+WFullScreenHint QCheckBox,
 QToolTip,
 #MainMenu,
 #MainMenu::item,

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -14,6 +14,8 @@
   padding: 5px 0px;
 }
 #Mixxx, WWidget,
+WFullScreenHint QLabel,
+WFullScreenHint QCheckBox,
 WEffectName,
 WKey,
 WLabel,
@@ -92,10 +94,17 @@ WBeatSpinBox::down-button {
 
 
 
+WFullScreenHint {
+  border: 1px solid white;
+}
+
 /* common colors for WEffectSelector, QMenu, QToolTip */
 #MainMenu QMenu,
 #MainMenu QMenu::item,
 #MainMenu QMenu QCheckBox,
+WFullScreenHint,
+WFullScreenHint QLabel,
+WFullScreenHint QCheckBox,
 QToolTip,
 WLibrarySidebar QMenu,
 WLibrarySidebar QMenu::item,

--- a/res/skins/default.qss
+++ b/res/skins/default.qss
@@ -167,3 +167,20 @@ WEffectChainPresetButton QMenu QCheckBox::indicator {
   width: 0.7em;
   height: 0.7em;
 }
+
+
+/* The popup that is shown when going fullscreen */
+WFullScreenHint {
+  font-family: "Open Sans";
+  font-weight: normal;
+  font-style: normal;
+  padding: 200px;
+  border-radius: 5px;
+  border: 1px solid white;
+}
+WFullScreenHint QLabel,
+WFullScreenHint QCheckBox,
+WFullScreenHint QPushButton {
+  /*font-size: 3em;*/
+  font-size: 20px;
+}

--- a/src/controllers/keyboard/keyboardeventfilter.cpp
+++ b/src/controllers/keyboard/keyboardeventfilter.cpp
@@ -127,9 +127,15 @@ bool KeyboardEventFilter::eventFilter(QObject*, QEvent* e) {
 }
 
 QKeySequence KeyboardEventFilter::getKeySeq(QKeyEvent* e) {
-    QString modseq;
     QKeySequence k;
 
+    if (e->key() >= 0x01000020 && e->key() <= 0x01000023) {
+        // Do not act on Modifier only
+        // avoid returning "khmer vowel sign ie (U+17C0)"
+        return k;
+    }
+
+    QString modseq;
     // TODO(XXX) check if we may simply return QKeySequence(e->modifiers()+e->key())
 
     if (e->modifiers() & Qt::ShiftModifier) {
@@ -146,12 +152,6 @@ QKeySequence KeyboardEventFilter::getKeySeq(QKeyEvent* e) {
 
     if (e->modifiers() & Qt::MetaModifier) {
         modseq += "Meta+";
-    }
-
-    if (e->key() >= 0x01000020 && e->key() <= 0x01000023) {
-        // Do not act on Modifier only
-        // avoid returning "khmer vowel sign ie (U+17C0)"
-        return k;
     }
 
     QString keyseq = QKeySequence(e->key()).toString();

--- a/src/controllers/keyboard/keyboardeventfilter.cpp
+++ b/src/controllers/keyboard/keyboardeventfilter.cpp
@@ -158,7 +158,11 @@ QKeySequence KeyboardEventFilter::getKeySeq(QKeyEvent* e) {
     k = QKeySequence(modseq + keyseq);
 
     if (CmdlineArgs::Instance().getDeveloper()) {
-        qDebug() << "keyboard press: " << k.toString();
+        if (e->type() == QEvent::KeyPress) {
+            qDebug() << "keyboard press: " << k.toString();
+        } else if (e->type() == QEvent::KeyRelease) {
+            qDebug() << "keyboard release: " << k.toString();
+        }
     }
     return k;
 }

--- a/src/controllers/keyboard/keyboardeventfilter.h
+++ b/src/controllers/keyboard/keyboardeventfilter.h
@@ -24,6 +24,11 @@ class KeyboardEventFilter : public QObject {
     void setKeyboardConfig(ConfigObject<ConfigValueKbd> *pKbdConfigObject);
     ConfigObject<ConfigValueKbd>* getKeyboardConfig();
 
+#ifndef __APPLE__
+  signals:
+    void altPressedWithoutKeys();
+#endif
+
   private:
     struct KeyDownInformation {
         KeyDownInformation(int keyId, int modifiers, ControlObject* pControl)
@@ -36,6 +41,10 @@ class KeyboardEventFilter : public QObject {
         int modifiers;
         ControlObject* pControl;
     };
+
+#ifndef __APPLE__
+    bool m_altPressedWithoutKey;
+#endif
 
     // Returns a valid QString with modifier keys from a QKeyEvent
     QKeySequence getKeySeq(QKeyEvent *e);

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -1412,6 +1412,15 @@ void WFullScreenHint::popup() {
     m_pOkayBtn->setFocus();
 }
 
+void WFullScreenHint::keyPressEvent(QKeyEvent* event) {
+    // Return/Enter should always close the popup
+    if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) {
+        close();
+        return;
+    }
+    return QWidget::keyPressEvent(event);
+}
+
 void WFullScreenHint::closeEvent(QCloseEvent* event) {
     int remind = m_pRemindCheckBox->isChecked() ? 0 : 1;
     m_pConfig->set(ConfigKey("[Config]", "hide_fullscreen_hint"), ConfigValue(remind));

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -884,10 +884,13 @@ void MixxxMainWindow::connectMenuBar() {
 
 #ifndef __APPLE__
     if (m_pCoreServices->getKeyboardEventFilter()) {
-        connect(m_pCoreServices->getKeyboardEventFilter().get(),
+        connect(
+                m_pCoreServices->getKeyboardEventFilter().get(),
                 &KeyboardEventFilter::altPressedWithoutKeys,
-                m_pMenuBar,
-                &WMainMenuBar::slotToggleMenuBar,
+                this,
+                [this]() {
+                    m_pMenuBar->slotToggleMenuBar(isFullScreen());
+                },
                 Qt::UniqueConnection);
     }
 #endif

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -377,12 +377,14 @@ void MixxxMainWindow::initialize() {
     // otherwise it would shift the launch image shortly before the skin is visible.
     m_pMenuBar->show();
 
+#ifndef __APPLE__
     // Show the fullscreen hotkey hint if we went fullscreen earlier.
     // This should make users aware of the new feature (press Alt to show/hide menu bar)
     // if they upgraded Mixxx with 'Start in fullscreen mode'.
     // Show the hint now so it doesn't interfere with other popups, e.g. the
     // sound device warnings.
     showFullScreenHotkeyHint();
+#endif
 
     // The launch image widget is automatically disposed, but we still have a
     // pointer to it.
@@ -410,6 +412,7 @@ void MixxxMainWindow::initialize() {
             this,
             &MixxxMainWindow::slotUpdateWindowTitle);
 
+#ifndef __APPLE__
     if (m_pCoreServices->getSettings()->getValueString(
                 ConfigKey("[Config]", "hide_fullscreen_hint")) != "1") {
         connect(this,
@@ -417,6 +420,7 @@ void MixxxMainWindow::initialize() {
                 this,
                 &MixxxMainWindow::showFullScreenHotkeyHint);
     }
+#endif
 }
 
 MixxxMainWindow::~MixxxMainWindow() {
@@ -1291,6 +1295,7 @@ void MixxxMainWindow::initializationProgressUpdate(int progress, const QString& 
     qApp->processEvents();
 }
 
+#ifndef __APPLE__
 void MixxxMainWindow::showFullScreenHotkeyHint() {
     if (!isFullScreen()) {
         return;
@@ -1353,11 +1358,9 @@ WFullScreenHint::WFullScreenHint(QWidget* parent, UserSettingsPointer pConfig)
         pLabelLayout->addWidget(fullScreenHotkeys);
     }
 
-#ifndef __APPLE__
     auto* menuHotkey = new QLabel(tr("Press <b>Alt</b> to toggle the menu bar"), this);
     menuHotkey->setObjectName("MenuHotkeyLabel");
     pLabelLayout->addWidget(menuHotkey);
-#endif
 
     pLabelLayout->addStretch();
 
@@ -1414,3 +1417,4 @@ void WFullScreenHint::closeEvent(QCloseEvent* event) {
     m_pConfig->set(ConfigKey("[Config]", "hide_fullscreen_hint"), ConfigValue(remind));
     QWidget::closeEvent(event);
 }
+#endif

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -858,6 +858,16 @@ void MixxxMainWindow::connectMenuBar() {
             &mixxx::LibraryExporter::slotRequestExport,
             Qt::UniqueConnection);
 #endif
+
+#ifndef __APPLE__
+    if (m_pCoreServices->getKeyboardEventFilter()) {
+        connect(m_pCoreServices->getKeyboardEventFilter().get(),
+                &KeyboardEventFilter::altPressedWithoutKeys,
+                m_pMenuBar,
+                &WMainMenuBar::slotToggleMenuBar,
+                Qt::UniqueConnection);
+    }
+#endif
 }
 
 void MixxxMainWindow::slotFileLoadSongPlayer(int deck) {

--- a/src/mixxxmainwindow.h
+++ b/src/mixxxmainwindow.h
@@ -17,7 +17,9 @@ class DlgKeywheel;
 class GuiTick;
 class LaunchImage;
 class VisualsManager;
+class WFullScreenHint;
 class WMainMenuBar;
+class QCheckBox;
 
 namespace mixxx {
 
@@ -103,6 +105,9 @@ class MixxxMainWindow : public QMainWindow {
     bool loadConfiguredSkin();
 
     bool confirmExit();
+
+    void showFullScreenHotkeyHint();
+
     QDialog::DialogCode soundDeviceErrorDlg(
             const QString &title, const QString &text, bool* retryClicked);
     QDialog::DialogCode soundDeviceBusyDlg(bool* retryClicked);
@@ -114,6 +119,7 @@ class MixxxMainWindow : public QMainWindow {
 
     QWidget* m_pCentralWidget;
     LaunchImage* m_pLaunchImage;
+    WFullScreenHint* m_pFullScreenHint;
 
     std::shared_ptr<mixxx::skin::SkinLoader> m_pSkinLoader;
     GuiTick* m_pGuiTick;
@@ -139,4 +145,20 @@ class MixxxMainWindow : public QMainWindow {
     mixxx::ScreenSaverPreference m_inhibitScreensaver;
 
     QSet<ControlObject*> m_skinCreatedControls;
+};
+
+class WFullScreenHint : public QWidget {
+    Q_OBJECT
+  public:
+    WFullScreenHint(QWidget* parent, UserSettingsPointer pConfig);
+
+    void popup();
+
+  protected:
+    void closeEvent(QCloseEvent* event) override;
+
+  private:
+    QCheckBox* m_pRemindCheckBox;
+    QPushButton* m_pOkayBtn;
+    UserSettingsPointer m_pConfig;
 };

--- a/src/mixxxmainwindow.h
+++ b/src/mixxxmainwindow.h
@@ -163,6 +163,7 @@ class WFullScreenHint : public QWidget {
 
   protected:
     void closeEvent(QCloseEvent* event) override;
+    void keyPressEvent(QKeyEvent* event) override;
 
   private:
     QCheckBox* m_pRemindCheckBox;

--- a/src/mixxxmainwindow.h
+++ b/src/mixxxmainwindow.h
@@ -17,7 +17,9 @@ class DlgKeywheel;
 class GuiTick;
 class LaunchImage;
 class VisualsManager;
+#ifndef __APPLE__
 class WFullScreenHint;
+#endif
 class WMainMenuBar;
 class QCheckBox;
 
@@ -106,7 +108,9 @@ class MixxxMainWindow : public QMainWindow {
 
     bool confirmExit();
 
+#ifndef __APPLE__
     void showFullScreenHotkeyHint();
+#endif
 
     QDialog::DialogCode soundDeviceErrorDlg(
             const QString &title, const QString &text, bool* retryClicked);
@@ -119,7 +123,9 @@ class MixxxMainWindow : public QMainWindow {
 
     QWidget* m_pCentralWidget;
     LaunchImage* m_pLaunchImage;
+#ifndef __APPLE__
     WFullScreenHint* m_pFullScreenHint;
+#endif
 
     std::shared_ptr<mixxx::skin::SkinLoader> m_pSkinLoader;
     GuiTick* m_pGuiTick;
@@ -147,6 +153,7 @@ class MixxxMainWindow : public QMainWindow {
     QSet<ControlObject*> m_skinCreatedControls;
 };
 
+#ifndef __APPLE__
 class WFullScreenHint : public QWidget {
     Q_OBJECT
   public:
@@ -162,3 +169,4 @@ class WFullScreenHint : public QWidget {
     QPushButton* m_pOkayBtn;
     UserSettingsPointer m_pConfig;
 };
+#endif

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -680,7 +680,40 @@ void WMainMenuBar::onDeveloperToolsHidden() {
 }
 
 void WMainMenuBar::onFullScreenStateChange(bool fullscreen) {
+#ifndef __APPLE__
+    if (fullscreen) {
+        hideMenuBar();
+    }
+#endif
     emit internalFullScreenStateChange(fullscreen);
+}
+
+void WMainMenuBar::slotToggleMenuBar() {
+    if (isNativeMenuBar()) {
+        return;
+    }
+
+    if (height() > 0) {
+        hideMenuBar();
+    } else {
+        showMenuBar();
+    }
+}
+
+void WMainMenuBar::showMenuBar() {
+    if (isNativeMenuBar()) {
+        return;
+    }
+
+    setMinimumHeight(sizeHint().height());
+}
+
+void WMainMenuBar::hideMenuBar() {
+    if (isNativeMenuBar()) {
+        return;
+    }
+    // don't use setHidden(bool) because hotkeys wouldn't work anymore
+    setFixedHeight(0);
 }
 
 void WMainMenuBar::onVinylControlDeckEnabledStateChange(int deck, bool enabled) {

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -70,6 +70,8 @@ QUrl documentationUrl(
 }
 }  // namespace
 
+QList<QKeySequence> WMainMenuBar::s_fullScreenShortcuts = {};
+
 WMainMenuBar::WMainMenuBar(QWidget* pParent, UserSettingsPointer pConfig,
                            ConfigObject<ConfigValueKbd>* pKbdConfig)
         : QMenuBar(pParent),
@@ -313,7 +315,7 @@ void WMainMenuBar::initialize() {
     if (!osShortcut.isEmpty() && !shortcuts.contains(osShortcut)) {
         shortcuts << osShortcut;
     }
-
+    s_fullScreenShortcuts = shortcuts;
     pViewFullScreen->setShortcuts(shortcuts);
     pViewFullScreen->setShortcutContext(Qt::ApplicationShortcut);
     pViewFullScreen->setCheckable(true);

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -1,6 +1,7 @@
 #include "widget/wmainmenubar.h"
 
 #include <QUrl>
+#include <QWidgetAction>
 
 #include "config.h"
 #include "control/controlproxy.h"
@@ -325,6 +326,13 @@ void WMainMenuBar::initialize() {
             pViewFullScreen,
             &QAction::setChecked);
     pViewMenu->addAction(pViewFullScreen);
+
+    if (!isNativeMenuBar()) {
+        auto* pAltDummyAction = new QWidgetAction(this);
+        pAltDummyAction->setText(tr("Toggle menu bar with Alt key"));
+        pAltDummyAction->setDisabled(true);
+        pViewMenu->addAction(pAltDummyAction);
+    }
 
     addMenu(pViewMenu);
 

--- a/src/widget/wmainmenubar.h
+++ b/src/widget/wmainmenubar.h
@@ -49,6 +49,7 @@ class WMainMenuBar : public QMenuBar {
     void onVinylControlDeckEnabledStateChange(int deck, bool enabled);
     void onNumberOfDecksChanged(int decks);
     void onKeywheelChange(int state);
+    void slotToggleMenuBar();
 
   signals:
     void createCrate();
@@ -88,6 +89,8 @@ class WMainMenuBar : public QMenuBar {
 
   private:
     void initialize();
+    void showMenuBar();
+    void hideMenuBar();
     void createVisibilityControl(QAction* pAction, const ConfigKey& key);
 
     UserSettingsPointer m_pConfig;

--- a/src/widget/wmainmenubar.h
+++ b/src/widget/wmainmenubar.h
@@ -51,7 +51,9 @@ class WMainMenuBar : public QMenuBar {
     void onVinylControlDeckEnabledStateChange(int deck, bool enabled);
     void onNumberOfDecksChanged(int decks);
     void onKeywheelChange(int state);
-    void slotToggleMenuBar();
+#ifndef __APPLE__
+    void slotToggleMenuBar(bool fullscreen);
+#endif
 
   signals:
     void createCrate();
@@ -93,9 +95,11 @@ class WMainMenuBar : public QMenuBar {
     void initialize();
     /// this ensures the menubar is shown when a menu hotkey is pressed
     /// while the menubar is hidden
-    void connectMenuToSlotShowMenuBar(const QMenu* pMenu);
-    void showMenuBar();
-    void hideMenuBar();
+    void maybeConnectMenuToSlotShowMenuBar(const QMenu* pMenu);
+#ifndef __APPLE__
+    void showMenuBar(bool fullscreen);
+    void hideMenuBar(bool fullscreen);
+#endif
     void createVisibilityControl(QAction* pAction, const ConfigKey& key);
 
     bool event(QEvent* pEvent) override;

--- a/src/widget/wmainmenubar.h
+++ b/src/widget/wmainmenubar.h
@@ -89,9 +89,14 @@ class WMainMenuBar : public QMenuBar {
 
   private:
     void initialize();
+    /// this ensures the menubar is shown when a menu hotkey is pressed
+    /// while the menubar is hidden
+    void connectMenuToSlotShowMenuBar(const QMenu* pMenu);
     void showMenuBar();
     void hideMenuBar();
     void createVisibilityControl(QAction* pAction, const ConfigKey& key);
+
+    bool event(QEvent* pEvent) override;
 
     UserSettingsPointer m_pConfig;
     QAction* m_pViewKeywheel;

--- a/src/widget/wmainmenubar.h
+++ b/src/widget/wmainmenubar.h
@@ -36,6 +36,8 @@ class WMainMenuBar : public QMenuBar {
     WMainMenuBar(QWidget* pParent, UserSettingsPointer pConfig,
                  ConfigObject<ConfigValueKbd>* pKbdConfig);
 
+    static QList<QKeySequence> s_fullScreenShortcuts;
+
   public slots:
     void onLibraryScanStarted();
     void onLibraryScanFinished();


### PR DESCRIPTION
I decided to make another attempt to hide the menubar, this time by filtering a single Alt keypress + the essentials from #3184, but without the ControlObject and the skin button.
This is not available on macOS since there's a permanent global menu, also in fullcreen mode

I decided to require a single Alt press so Alt bindings in custom keyboard mappings don't toggle the menubar.



**TODO**
- [x] single-press Alt to show or hide the menubar (press duration doesn't matter, only that there's no other key pressed between Alt press and release)
- [x] hide the menu when going fullscreen [^1]
- [x] unhide the menubar if a menu hotkey (like Alt+F) is pressed while the menu is hidden [^2]
- [x] add a label / dummy action to View menu "Toggle menu bar with Alt key"
that action is not clickable (or does nothing respectively), so users have to press **Alt** themselves
- [x] show a hint when going fullscreen
![image](https://user-images.githubusercontent.com/5934199/221990130-dcf34783-177a-46a5-b239-8861024c84e5.png)
I wonder if that should be omitted on macOS altogether?
- [ ] style hint for all skins
- [x] test
- [x] test
- [ ] test


**TESTING** (only done on *ubuntu so far)
I added debug output for the keystroke filtering, so in case something is not working as expected please run from the command line with `--developer` and share the relevant output snippets so we can debug it.

Closed #8902 

[^1]: for me this didn't work when I used the fullscreen **hotkey** (at least in debug builds I tested so far) because the window manager (xfwm4) hotkey and the Mixxx hotkey were identical, and the keystroke was consumed by the window manager.
I have a workaround 167c5696a2d, though that's not applicable to linux distros with a global menu that require the current menubar hack, but for those hiding the menubar isn't available anyway :shrug: Maybe if my workaround is considered mergable I'll try to polish it so it replaces the hook to slotViewFullScreen on demand.
[^2]: I tested with Ubuntu Studio 20.04 (xfce desktop) (menus open immediately) and Ubuntu 22.04 (Gnome) (a second hotkey press is required to unroll the menu)