### PR TITLE
Fix convertWCStringToQString assert

### DIFF
--- a/src/util/string.h
+++ b/src/util/string.h
@@ -80,12 +80,15 @@ inline std::size_t wcsnlen_s(
 /// See also: QString::fromWCharArray()
 inline QString convertWCStringToQString(
         const wchar_t* wcs,
-        std::size_t len) {
+        std::size_t maxLen) {
     if (!wcs) {
-        DEBUG_ASSERT(len == 0);
+        DEBUG_ASSERT(maxLen == 0);
         return QString();
     }
-    DEBUG_ASSERT(wcsnlen_s(wcs, len) == len);
+
+    std::size_t len = wcsnlen_s(wcs, maxLen + 1);
+    // Assert when the string wcs has more characters than the specified maximum size
+    DEBUG_ASSERT(len <= maxLen);
     const auto ilen = static_cast<int>(len);
     DEBUG_ASSERT(ilen >= 0); // unsigned -> signed
     switch (sizeof(wchar_t)) {


### PR DESCRIPTION
convertWCStringToQString is only used at a few places in HID code currently:
Either a constant is used with the maximum string length:
https://github.com/mixxxdj/mixxx/blob/1b99e57238405cd5039480b99ca835ba4879360b/src/controllers/hid/hidiothread.cpp#L104-L108

Or it's calculated it's the caller using wcsnlen_s:
https://github.com/mixxxdj/mixxx/blob/1b99e57238405cd5039480b99ca835ba4879360b/src/controllers/hid/hiddevice.cpp#L40-L43

In th case of a constant, we always get an assert, in the second case we compare two values calculated by the same wcsnlen_s function. Therefore the actual length check assert is usesless.

This PR changes the code, that we detect strings longer than the specified length. But I wonder, if this assert is useful at all, since nothing breaks if these strings are longer.
Furthermore the function wcsnlen_s which made problems on OpenBCD https://github.com/mixxxdj/mixxx/pull/11083 is only existing in the Mixxx code, to generate this one DEBUG_ASSERT.