### PR TITLE
library, browsefeature: fix quick link path retrieval

### DIFF
--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -463,7 +463,7 @@ void BrowseFeature::loadQuickLinks() {
 }
 
 QString BrowseFeature::extractNameFromPath(const QString& spath) {
-    return QFileInfo(spath).fileName();
+    return QDir(spath).dirName();
 }
 
 QStringList BrowseFeature::getDefaultQuickLinks() const {


### PR DESCRIPTION
fixing a regression introduced by 1726c4b it seems. maybe only tested with Qt > 5.15 :shrug: 