### PR TITLE
controllers: show HID devices in developer mode

### DIFF
--- a/src/controllers/hid/hidenumerator.cpp
+++ b/src/controllers/hid/hidenumerator.cpp
@@ -5,6 +5,7 @@
 #include "controllers/hid/hidcontroller.h"
 #include "controllers/hid/hiddenylist.h"
 #include "controllers/hid/hiddevice.h"
+#include "util/cmdlineargs.h"
 
 namespace {
 
@@ -12,7 +13,8 @@ bool recognizeDevice(const hid_device_info& device_info) {
     // Skip mice and keyboards. Users can accidentally disable their mouse
     // and/or keyboard by enabling them as HID controllers in Mixxx.
     // https://bugs.launchpad.net/mixxx/+bug/1940599
-    if (device_info.usage_page == mixxx::hid::kGenericDesktopUsagePage &&
+    if (!CmdlineArgs::Instance().getDeveloper() &&
+            device_info.usage_page == mixxx::hid::kGenericDesktopUsagePage &&
             (device_info.usage == mixxx::hid::kGenericDesktopMouseUsage ||
                     device_info.usage == mixxx::hid::kGenericDesktopKeyboardUsage)) {
         return false;


### PR DESCRIPTION
Let's show HID (partially revert https://github.com/mixxxdj/mixxx/commit/b4bfe76da9dc1990d4d753c1952f1e020d5b8761) in dev mode.

With this, reviewing controller mapping GUIs is simplified a lot.
Recently, when I wanted to test #11300 with some [controller mapping GUI examples](https://github.com/mixxxdj/mixxx/files/10834711/Test-HID-Dummy.zip), but had no HID controller AND noticed my HID mouse wasn't available in the preferences...
AND it seems to be a bit elaborate to create dummy HID device in Linux