### PR TITLE
Excluding ELAN touch screen

### DIFF
--- a/src/controllers/hid/hiddenylist.h
+++ b/src/controllers/hid/hiddenylist.h
@@ -10,6 +10,12 @@ typedef struct hid_denylist {
 
 /// USB HID device that should not be recognized as controllers
 hid_denylist_t hid_denylisted[] = {
-        {0x1157, 0x300, 0x1, 0x2, -1},   // EKS Otus mouse pad (OS/X,windows)
-        {0x1157, 0x300, 0x0, 0x0, 0x3},  // EKS Otus mouse pad (linux)
+        {0x1157, 0x300, 0x1, 0x2, -1},  // EKS Otus mouse pad (OS/X,windows)
+        {0x1157, 0x300, 0x0, 0x0, 0x3}, // EKS Otus mouse pad (linux)
+        {0x04f3, 0x2d26, 0x0, 0x0, -1}, // ELAN2D26:00 Touch screen
+        {0x046d, 0xc539, 0x0, 0x0, -1}, // Logitech G Pro Wireless
+        // The following rules have been created using the official USB HID page
+        // spec as specified at https://usb.org/sites/default/files/hut1_4.pdf
+        {0x0, 0x0, 0x0D, 0x04, -1}, // Touch Screen
+        {0x0, 0x0, 0x0D, 0x22, -1}, // Finger
 };

--- a/src/controllers/hid/hidenumerator.cpp
+++ b/src/controllers/hid/hidenumerator.cpp
@@ -34,12 +34,12 @@ bool recognizeDevice(const hid_device_info& device_info) {
     const int denylist_len = sizeof(hid_denylisted) / sizeof(hid_denylisted[0]);
     for (int bl_index = 0; bl_index < denylist_len; bl_index++) {
         hid_denylist_t denylisted = hid_denylisted[bl_index];
-        // If vendor ids do not match, skip.
-        if (device_info.vendor_id != denylisted.vendor_id) {
+        // If vendor ids are specified and do not match, skip.
+        if (denylisted.vendor_id && device_info.vendor_id != denylisted.vendor_id) {
             continue;
         }
-        // If product IDs do not match, skip.
-        if (device_info.product_id != denylisted.product_id) {
+        // If product IDs are specified and do not match, skip.
+        if (denylisted.product_id && device_info.product_id != denylisted.product_id) {
             continue;
         }
         // Denylist entry based on interface number


### PR DESCRIPTION
Excluding ELAN touch screen, which fits XPS 15 laptops.

This should also exclude other touch screens, but unfortunately, the ELAN device exposes other HID usages through vendor specific and reserved usage pages (`01ff`, `ff00` and `ff01`) so it cannot be excluded using the global rule. 

This fixes #11323.
