### PR TITLE
playlist export: update with newly selected extension, don't just append

### DIFF
--- a/src/util/file.cpp
+++ b/src/util/file.cpp
@@ -1,32 +1,48 @@
 #include "util/file.h"
 
 #include <QFileDialog>
+#include <QRegExp> // required for 'indexIn(QString &str, int pos)
 #include <QRegularExpression>
 
 namespace {
 
 const QRegularExpression kExtractExtensionRegex(R"(\(\*\.(.*)\)$)");
+// extract all extensions from the file filters string "Abc (*.m3u);;Cbx (*.pls)..."
+// lazy match doesn't work here unfortunately "(\(\*\.(.*?)\))"
+const QRegExp kFileFilterRegex(R"(\(\*\.(.[^\)]*)\))");
 
 } //anonymous namespace
 
 QString filePathWithSelectedExtension(const QString& fileLocationInput,
-        const QString& fileFilter) {
+        const QString& selectedFileFilter,
+        const QString& fileFilters) {
     if (fileLocationInput.isEmpty()) {
         return {};
     }
     QString fileLocation = fileLocationInput;
-    if (fileFilter.isEmpty()) {
+    if (selectedFileFilter.isEmpty()) {
         return fileLocation;
     }
 
     // Extract 'ext' from QFileDialog file filter string 'Funky type (*.ext)'
-    const auto extMatch = kExtractExtensionRegex.match(fileFilter);
+    const auto extMatch = kExtractExtensionRegex.match(selectedFileFilter);
     const QString ext = extMatch.captured(1);
     if (ext.isNull()) {
         return fileLocation;
     }
     const QFileInfo fileName(fileLocation);
     if (!ext.isEmpty() && fileName.suffix() != ext) {
+        // Check if fileLocation ends with any of the available extensions
+        int pos = 0;
+        // Extract all extensions from the filter list
+        while ((pos = kFileFilterRegex.indexIn(fileFilters, pos)) != -1) {
+            if (ext == kFileFilterRegex.cap(1)) {
+                // If it matches chop the current extension incl. dot and break
+                fileLocation.chop(ext.length() + 1);
+                break;
+            }
+            pos += kFileFilterRegex.matchedLength();
+        }
         fileLocation.append(".").append(ext);
     }
     return fileLocation;
@@ -54,7 +70,8 @@ QString getFilePathWithVerifiedExtensionFromFileDialog(
         }
         const QString fileLocationAdjusted = filePathWithSelectedExtension(
                 fileLocation,
-                selectedFileFilter);
+                selectedFileFilter,
+                fileFilters);
         // If the file path has the selected suffix we can assume the user either
         // selected a new file or already confirmed overwriting an existing file.
         // Return the file path. Also when the adjusted file path does not exist yet.

--- a/src/util/file.h
+++ b/src/util/file.h
@@ -10,7 +10,8 @@
 // Otherwise add it manually.
 // Works around https://bugreports.qt.io/browse/QTBUG-27186
 QString filePathWithSelectedExtension(const QString& fileLocationInput,
-        const QString& fileFilter);
+        const QString& fileFilter,
+        const QString& fileFilters);
 
 // Due to Qt bug https://bugreports.qt.io/browse/QTBUG-27186 we may need to
 // manually add the selected extension to the selected file name.


### PR DESCRIPTION
Fixes #11327 

Quick fix, adds include QRegExp so we can use [`QRegExp::indexIn`](https://doc.qt.io/qt-5/qregexp.html#indexIn).
I bet there are a million other ways do achieve the same, so feel free to optimize this.