### PR TITLE
Fix "Painter not active" warning after reloading a track. 

### DIFF
--- a/src/widget/woverviewhsv.cpp
+++ b/src/widget/woverviewhsv.cpp
@@ -29,7 +29,8 @@ bool WOverviewHSV::drawNextPixmapPart() {
 
     const int dataSize = pWaveform->getDataSize();
     const double audioVisualRatio = pWaveform->getAudioVisualRatio();
-    if (dataSize <= 0 || audioVisualRatio <= 0) {
+    const double trackSamples = getTrackSamples();
+    if (dataSize <= 0 || audioVisualRatio <= 0 || trackSamples <= 0) {
         return false;
     }
 
@@ -38,11 +39,12 @@ bool WOverviewHSV::drawNextPixmapPart() {
         // by total_gain
         // We keep full range waveform data to scale it on paint
         m_waveformSourceImage = QImage(
-                static_cast<int>(getTrackSamples() / audioVisualRatio / 2),
+                static_cast<int>(trackSamples / audioVisualRatio / 2),
                 2 * 255,
                 QImage::Format_ARGB32_Premultiplied);
         m_waveformSourceImage.fill(QColor(0, 0, 0, 0).value());
     }
+    DEBUG_ASSERT(!m_waveformSourceImage.isNull());
 
     // Always multiple of 2
     const int waveformCompletion = pWaveform->getCompletion();

--- a/src/widget/woverviewlmh.cpp
+++ b/src/widget/woverviewlmh.cpp
@@ -30,7 +30,8 @@ bool WOverviewLMH::drawNextPixmapPart() {
 
     const int dataSize = pWaveform->getDataSize();
     const double audioVisualRatio = pWaveform->getAudioVisualRatio();
-    if (dataSize <= 0 || audioVisualRatio <= 0) {
+    const double trackSamples = getTrackSamples();
+    if (dataSize <= 0 || audioVisualRatio <= 0 || trackSamples <= 0) {
         return false;
     }
 
@@ -39,11 +40,12 @@ bool WOverviewLMH::drawNextPixmapPart() {
         // by total_gain
         // We keep full range waveform data to scale it on paint
         m_waveformSourceImage = QImage(
-                static_cast<int>(getTrackSamples() / audioVisualRatio / 2),
+                static_cast<int>(trackSamples / audioVisualRatio / 2),
                 2 * 255,
                 QImage::Format_ARGB32_Premultiplied);
         m_waveformSourceImage.fill(QColor(0, 0, 0, 0).value());
     }
+    DEBUG_ASSERT(!m_waveformSourceImage.isNull());
 
     // Always multiple of 2
     const int waveformCompletion = pWaveform->getCompletion();

--- a/src/widget/woverviewrgb.cpp
+++ b/src/widget/woverviewrgb.cpp
@@ -28,7 +28,8 @@ bool WOverviewRGB::drawNextPixmapPart() {
 
     const int dataSize = pWaveform->getDataSize();
     const double audioVisualRatio = pWaveform->getAudioVisualRatio();
-    if (dataSize <= 0 || audioVisualRatio <= 0) {
+    const double trackSamples = getTrackSamples();
+    if (dataSize <= 0 || audioVisualRatio <= 0 || trackSamples <= 0) {
         return false;
     }
 
@@ -37,11 +38,12 @@ bool WOverviewRGB::drawNextPixmapPart() {
         // by total_gain
         // We keep full range waveform data to scale it on paint
         m_waveformSourceImage = QImage(
-                static_cast<int>(getTrackSamples() / audioVisualRatio / 2),
+                static_cast<int>(trackSamples / audioVisualRatio / 2),
                 2 * 255,
                 QImage::Format_ARGB32_Premultiplied);
         m_waveformSourceImage.fill(QColor(0, 0, 0, 0).value());
     }
+    DEBUG_ASSERT(!m_waveformSourceImage.isNull());
 
     // Always multiple of 2
     const int waveformCompletion = pWaveform->getCompletion();


### PR DESCRIPTION
I have found this while debugging #11257

getTrackSamples() returns the value from a control object written by the CachingReaderWorker thread and can change at any time. This may violate the new introduced assertion. 

