### PR TITLE
Add missing `<Qt>` include in `defs.h`

### DIFF
--- a/src/util/defs.h
+++ b/src/util/defs.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Qt>
+
 // Maximum buffer length to each EngineObject::process call.
 //TODO: Replace this with mixxx::AudioParameters::bufferSize()
 constexpr unsigned int MAX_BUFFER_LEN = 160000;


### PR DESCRIPTION
Clangd complained about this one and since it is good style not to rely on implicit/transitive includes, this branch explicitly adds the corresponding header.

Note that `<Qt>`, which is effectively an alias for `<qnamespace.h>`, is the canonical header for `Qt::Key` and `Qt::Modifier`: https://doc.qt.io/qt-6/qt.html