### PR TITLE
fullscreen: rebuild & reconnect menu only on desktops with global menu

### DIFF
--- a/src/mixxx.h
+++ b/src/mixxx.h
@@ -166,6 +166,9 @@ class MixxxMainWindow : public QMainWindow {
     Library* m_pLibrary;
 
     parented_ptr<WMainMenuBar> m_pMenuBar;
+#ifdef __LINUX__
+    const bool m_supportsNativeMenuBar;
+#endif
 
     DlgDeveloperTools* m_pDeveloperToolsDlg;
 


### PR DESCRIPTION
follow-up for #11328:
keep the menubar on all Linux desktops that **don't** use global menubars to avoid pointless operations.