### PR TITLE
Add `KeyboardConfigPointer` typedef and propagate the config to `WTrackMenu`

### DIFF
--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -341,6 +341,7 @@ void CoreServices::initialize(QApplication* pApp) {
     m_pLibrary = std::make_shared<Library>(
             this,
             pConfig,
+            m_pKbdConfig.get(),
             m_pDbConnectionPool,
             m_pTrackCollectionManager.get(),
             m_pPlayerManager.get(),

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -341,7 +341,7 @@ void CoreServices::initialize(QApplication* pApp) {
     m_pLibrary = std::make_shared<Library>(
             this,
             pConfig,
-            m_pKbdConfig.get(),
+            m_pKbdConfig,
             m_pDbConnectionPool,
             m_pTrackCollectionManager.get(),
             m_pPlayerManager.get(),

--- a/src/coreservices.h
+++ b/src/coreservices.h
@@ -5,6 +5,7 @@
 #include "control/controlpushbutton.h"
 #include "preferences/configobject.h"
 #include "preferences/constants.h"
+#include "preferences/keyboardconfig.h"
 #include "preferences/settingsmanager.h"
 #include "soundio/sounddevicestatus.h"
 #include "util/cmdlineargs.h"
@@ -47,7 +48,7 @@ class CoreServices : public QObject {
         return m_pKeyboardEventFilter;
     }
 
-    std::shared_ptr<ConfigObject<ConfigValueKbd>> getKeyboardConfig() const {
+    std::shared_ptr<KeyboardConfig> getKeyboardConfig() const {
         return m_pKbdConfig;
     }
 
@@ -146,8 +147,8 @@ class CoreServices : public QObject {
     std::shared_ptr<Library> m_pLibrary;
 
     std::shared_ptr<KeyboardEventFilter> m_pKeyboardEventFilter;
-    std::shared_ptr<ConfigObject<ConfigValueKbd>> m_pKbdConfig;
-    std::shared_ptr<ConfigObject<ConfigValueKbd>> m_pKbdConfigEmpty;
+    std::shared_ptr<KeyboardConfig> m_pKbdConfig;
+    std::shared_ptr<KeyboardConfig> m_pKbdConfigEmpty;
 
     std::shared_ptr<mixxx::ScreensaverManager> m_pScreensaverManager;
 

--- a/src/library/analysisfeature.cpp
+++ b/src/library/analysisfeature.cpp
@@ -78,9 +78,9 @@ void AnalysisFeature::setTitleProgress(int currentTrackNumber, int totalTracksCo
 void AnalysisFeature::bindLibraryWidget(WLibrary* libraryWidget,
                                  KeyboardEventFilter* keyboard) {
     m_pAnalysisView = new DlgAnalysis(libraryWidget,
-                                      m_pConfig,
-                                      m_pKbdConfig,
-                                      m_pLibrary);
+            m_pConfig,
+            m_pKbdConfig,
+            m_pLibrary);
     connect(m_pAnalysisView,
             &DlgAnalysis::loadTrack,
             this,

--- a/src/library/analysisfeature.cpp
+++ b/src/library/analysisfeature.cpp
@@ -11,6 +11,7 @@
 #include "library/librarytablemodel.h"
 #include "library/trackcollectionmanager.h"
 #include "moc_analysisfeature.cpp"
+#include "preferences/configobject.h"
 #include "sources/soundsourceproxy.h"
 #include "util/debug.h"
 #include "util/dnd.h"
@@ -50,8 +51,9 @@ AnalyzerModeFlags getAnalyzerModeFlags(
 
 AnalysisFeature::AnalysisFeature(
         Library* pLibrary,
-        UserSettingsPointer pConfig)
-        : LibraryFeature(pLibrary, pConfig, QStringLiteral("prepare")),
+        UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig)
+        : LibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("prepare")),
           m_baseTitle(tr("Analyze")),
           m_pTrackAnalysisScheduler(TrackAnalysisScheduler::NullPointer()),
           m_pSidebarModel(make_parented<TreeItemModel>(this)),
@@ -76,6 +78,7 @@ void AnalysisFeature::bindLibraryWidget(WLibrary* libraryWidget,
                                  KeyboardEventFilter* keyboard) {
     m_pAnalysisView = new DlgAnalysis(libraryWidget,
                                       m_pConfig,
+                                      m_pKbdConfig,
                                       m_pLibrary);
     connect(m_pAnalysisView,
             &DlgAnalysis::loadTrack,

--- a/src/library/analysisfeature.cpp
+++ b/src/library/analysisfeature.cpp
@@ -12,6 +12,7 @@
 #include "library/trackcollectionmanager.h"
 #include "moc_analysisfeature.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "sources/soundsourceproxy.h"
 #include "util/debug.h"
 #include "util/dnd.h"
@@ -52,7 +53,7 @@ AnalyzerModeFlags getAnalyzerModeFlags(
 AnalysisFeature::AnalysisFeature(
         Library* pLibrary,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig)
+        KeyboardConfigPointer pKbdConfig)
         : LibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("prepare")),
           m_baseTitle(tr("Analyze")),
           m_pTrackAnalysisScheduler(TrackAnalysisScheduler::NullPointer()),

--- a/src/library/analysisfeature.h
+++ b/src/library/analysisfeature.h
@@ -13,6 +13,7 @@
 #include "library/libraryfeature.h"
 #include "library/treeitemmodel.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "preferences/usersettings.h"
 #include "util/parented_ptr.h"
 
@@ -23,7 +24,7 @@ class AnalysisFeature : public LibraryFeature {
   public:
     AnalysisFeature(Library* pLibrary,
                     UserSettingsPointer pConfig,
-                    ConfigObject<ConfigValueKbd>* pKbdConfig);
+                    KeyboardConfigPointer pKbdConfig);
     ~AnalysisFeature() override = default;
 
     QVariant title() override {

--- a/src/library/analysisfeature.h
+++ b/src/library/analysisfeature.h
@@ -23,8 +23,8 @@ class AnalysisFeature : public LibraryFeature {
     Q_OBJECT
   public:
     AnalysisFeature(Library* pLibrary,
-                    UserSettingsPointer pConfig,
-                    KeyboardConfigPointer pKbdConfig);
+            UserSettingsPointer pConfig,
+            KeyboardConfigPointer pKbdConfig);
     ~AnalysisFeature() override = default;
 
     QVariant title() override {

--- a/src/library/analysisfeature.h
+++ b/src/library/analysisfeature.h
@@ -12,6 +12,7 @@
 #include "library/dlganalysis.h"
 #include "library/libraryfeature.h"
 #include "library/treeitemmodel.h"
+#include "preferences/configobject.h"
 #include "preferences/usersettings.h"
 #include "util/parented_ptr.h"
 
@@ -21,7 +22,8 @@ class AnalysisFeature : public LibraryFeature {
     Q_OBJECT
   public:
     AnalysisFeature(Library* pLibrary,
-                    UserSettingsPointer pConfig);
+                    UserSettingsPointer pConfig,
+                    ConfigObject<ConfigValueKbd>* pKbdConfig);
     ~AnalysisFeature() override = default;
 
     QVariant title() override {

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -15,6 +15,7 @@
 #include "library/treeitem.h"
 #include "mixer/playermanager.h"
 #include "moc_autodjfeature.cpp"
+#include "preferences/configobject.h"
 #include "sources/soundsourceproxy.h"
 #include "track/track.h"
 #include "util/dnd.h"
@@ -46,8 +47,9 @@ constexpr int kMaxRetrieveAttempts = 3;
 
 AutoDJFeature::AutoDJFeature(Library* pLibrary,
         UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig,
         PlayerManagerInterface* pPlayerManager)
-        : LibraryFeature(pLibrary, pConfig, QStringLiteral("autodj")),
+        : LibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("autodj")),
           m_pTrackCollection(pLibrary->trackCollectionManager()->internalCollection()),
           m_playlistDao(m_pTrackCollection->getPlaylistDAO()),
           m_iAutoDJPlaylistId(findOrCrateAutoDjPlaylistId(m_playlistDao)),
@@ -120,6 +122,7 @@ void AutoDJFeature::bindLibraryWidget(
     m_pAutoDJView = new DlgAutoDJ(
             libraryWidget,
             m_pConfig,
+            m_pKbdConfig,
             m_pLibrary,
             m_pAutoDJProcessor,
             keyboard);

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -16,6 +16,7 @@
 #include "mixer/playermanager.h"
 #include "moc_autodjfeature.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "sources/soundsourceproxy.h"
 #include "track/track.h"
 #include "util/dnd.h"
@@ -47,7 +48,7 @@ constexpr int kMaxRetrieveAttempts = 3;
 
 AutoDJFeature::AutoDJFeature(Library* pLibrary,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig,
+        KeyboardConfigPointer pKbdConfig,
         PlayerManagerInterface* pPlayerManager)
         : LibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("autodj")),
           m_pTrackCollection(pLibrary->trackCollectionManager()->internalCollection()),

--- a/src/library/autodj/autodjfeature.h
+++ b/src/library/autodj/autodjfeature.h
@@ -15,6 +15,7 @@
 #include "library/trackset/crate/crate.h"
 #include "library/treeitemmodel.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "preferences/usersettings.h"
 #include "util/parented_ptr.h"
 
@@ -31,7 +32,7 @@ class AutoDJFeature : public LibraryFeature {
   public:
     AutoDJFeature(Library* pLibrary,
                   UserSettingsPointer pConfig,
-                  ConfigObject<ConfigValueKbd>* pKbdConfig,
+                  KeyboardConfigPointer pKbdConfig,
                   PlayerManagerInterface* pPlayerManager);
     virtual ~AutoDJFeature();
 

--- a/src/library/autodj/autodjfeature.h
+++ b/src/library/autodj/autodjfeature.h
@@ -14,6 +14,7 @@
 #include "library/libraryfeature.h"
 #include "library/trackset/crate/crate.h"
 #include "library/treeitemmodel.h"
+#include "preferences/configobject.h"
 #include "preferences/usersettings.h"
 #include "util/parented_ptr.h"
 
@@ -30,6 +31,7 @@ class AutoDJFeature : public LibraryFeature {
   public:
     AutoDJFeature(Library* pLibrary,
                   UserSettingsPointer pConfig,
+                  ConfigObject<ConfigValueKbd>* pKbdConfig,
                   PlayerManagerInterface* pPlayerManager);
     virtual ~AutoDJFeature();
 

--- a/src/library/autodj/autodjfeature.h
+++ b/src/library/autodj/autodjfeature.h
@@ -31,9 +31,9 @@ class AutoDJFeature : public LibraryFeature {
     Q_OBJECT
   public:
     AutoDJFeature(Library* pLibrary,
-                  UserSettingsPointer pConfig,
-                  KeyboardConfigPointer pKbdConfig,
-                  PlayerManagerInterface* pPlayerManager);
+            UserSettingsPointer pConfig,
+            KeyboardConfigPointer pKbdConfig,
+            PlayerManagerInterface* pPlayerManager);
     virtual ~AutoDJFeature();
 
     QVariant title() override;

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -7,6 +7,7 @@
 #include "library/trackcollectionmanager.h"
 #include "moc_dlgautodj.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "track/track.h"
 #include "util/assert.h"
 #include "util/duration.h"
@@ -20,7 +21,7 @@ const char* kRepeatPlaylistPreference = "Requeue";
 
 DlgAutoDJ::DlgAutoDJ(WLibrary* parent,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig,
+        KeyboardConfigPointer pKbdConfig,
         Library* pLibrary,
         AutoDJProcessor* pProcessor,
         KeyboardEventFilter* pKeyboard)

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -6,6 +6,7 @@
 #include "library/playlisttablemodel.h"
 #include "library/trackcollectionmanager.h"
 #include "moc_dlgautodj.cpp"
+#include "preferences/configobject.h"
 #include "track/track.h"
 #include "util/assert.h"
 #include "util/duration.h"
@@ -19,15 +20,18 @@ const char* kRepeatPlaylistPreference = "Requeue";
 
 DlgAutoDJ::DlgAutoDJ(WLibrary* parent,
         UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig,
         Library* pLibrary,
         AutoDJProcessor* pProcessor,
         KeyboardEventFilter* pKeyboard)
         : QWidget(parent),
           Ui::DlgAutoDJ(),
           m_pConfig(pConfig),
+          m_pKbdConfig(pKbdConfig),
           m_pAutoDJProcessor(pProcessor),
           m_pTrackTableView(new WTrackTableView(this,
                   m_pConfig,
+                  m_pKbdConfig,
                   pLibrary,
                   parent->getTrackTableBackgroundColorOpacity(),
                   /*no sorting*/ false)),

--- a/src/library/autodj/dlgautodj.h
+++ b/src/library/autodj/dlgautodj.h
@@ -11,6 +11,7 @@
 #include "library/libraryview.h"
 #include "library/trackcollection.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "preferences/usersettings.h"
 #include "track/track_decl.h"
 
@@ -23,7 +24,7 @@ class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
   public:
     DlgAutoDJ(WLibrary* parent,
             UserSettingsPointer pConfig,
-            ConfigObject<ConfigValueKbd>* pKbdConfig,
+            KeyboardConfigPointer pKbdConfig,
             Library* pLibrary,
             AutoDJProcessor* pProcessor,
             KeyboardEventFilter* pKeyboard);
@@ -64,7 +65,7 @@ class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
     void keyPressEvent(QKeyEvent* pEvent) override;
 
     const UserSettingsPointer m_pConfig;
-    ConfigObject<ConfigValueKbd>* m_pKbdConfig;
+    const KeyboardConfigPointer m_pKbdConfig;
 
     AutoDJProcessor* const m_pAutoDJProcessor;
     WTrackTableView* const m_pTrackTableView;

--- a/src/library/autodj/dlgautodj.h
+++ b/src/library/autodj/dlgautodj.h
@@ -10,6 +10,7 @@
 #include "library/library.h"
 #include "library/libraryview.h"
 #include "library/trackcollection.h"
+#include "preferences/configobject.h"
 #include "preferences/usersettings.h"
 #include "track/track_decl.h"
 
@@ -22,6 +23,7 @@ class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
   public:
     DlgAutoDJ(WLibrary* parent,
             UserSettingsPointer pConfig,
+            ConfigObject<ConfigValueKbd>* pKbdConfig,
             Library* pLibrary,
             AutoDJProcessor* pProcessor,
             KeyboardEventFilter* pKeyboard);
@@ -62,6 +64,7 @@ class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
     void keyPressEvent(QKeyEvent* pEvent) override;
 
     const UserSettingsPointer m_pConfig;
+    ConfigObject<ConfigValueKbd>* m_pKbdConfig;
 
     AutoDJProcessor* const m_pAutoDJProcessor;
     WTrackTableView* const m_pTrackTableView;

--- a/src/library/banshee/bansheefeature.cpp
+++ b/src/library/banshee/bansheefeature.cpp
@@ -11,13 +11,14 @@
 #include "library/library.h"
 #include "library/trackcollectionmanager.h"
 #include "moc_bansheefeature.cpp"
+#include "preferences/configobject.h"
 #include "track/track.h"
 
 const QString BansheeFeature::BANSHEE_MOUNT_KEY = "mixxx.BansheeFeature.mount";
 QString BansheeFeature::m_databaseFile;
 
-BansheeFeature::BansheeFeature(Library* pLibrary, UserSettingsPointer pConfig)
-        : BaseExternalLibraryFeature(pLibrary, pConfig, QStringLiteral("banshee")),
+BansheeFeature::BansheeFeature(Library* pLibrary, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig)
+        : BaseExternalLibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("banshee")),
           m_pSidebarModel(make_parented<TreeItemModel>(this)),
           m_cancelImport(false) {
     Q_UNUSED(pConfig);

--- a/src/library/banshee/bansheefeature.cpp
+++ b/src/library/banshee/bansheefeature.cpp
@@ -12,12 +12,13 @@
 #include "library/trackcollectionmanager.h"
 #include "moc_bansheefeature.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "track/track.h"
 
 const QString BansheeFeature::BANSHEE_MOUNT_KEY = "mixxx.BansheeFeature.mount";
 QString BansheeFeature::m_databaseFile;
 
-BansheeFeature::BansheeFeature(Library* pLibrary, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig)
+BansheeFeature::BansheeFeature(Library* pLibrary, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig)
         : BaseExternalLibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("banshee")),
           m_pSidebarModel(make_parented<TreeItemModel>(this)),
           m_cancelImport(false) {

--- a/src/library/banshee/bansheefeature.cpp
+++ b/src/library/banshee/bansheefeature.cpp
@@ -18,8 +18,11 @@
 const QString BansheeFeature::BANSHEE_MOUNT_KEY = "mixxx.BansheeFeature.mount";
 QString BansheeFeature::m_databaseFile;
 
-BansheeFeature::BansheeFeature(Library* pLibrary, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig)
-        : BaseExternalLibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("banshee")),
+BansheeFeature::BansheeFeature(Library* pLibrary,
+        UserSettingsPointer pConfig,
+        KeyboardConfigPointer pKbdConfig)
+        : BaseExternalLibraryFeature(
+                  pLibrary, pConfig, pKbdConfig, QStringLiteral("banshee")),
           m_pSidebarModel(make_parented<TreeItemModel>(this)),
           m_cancelImport(false) {
     Q_UNUSED(pConfig);

--- a/src/library/banshee/bansheefeature.h
+++ b/src/library/banshee/bansheefeature.h
@@ -1,26 +1,27 @@
 #pragma once
 
-#include <QStringListModel>
-#include <QtSql>
 #include <QFuture>
-#include <QtConcurrentRun>
 #include <QFutureWatcher>
+#include <QStringListModel>
+#include <QtConcurrentRun>
+#include <QtSql>
 
+#include "library/banshee/bansheedbconnection.h"
 #include "library/baseexternallibraryfeature.h"
 #include "library/trackcollection.h"
-#include "library/treeitemmodel.h"
 #include "library/treeitem.h"
-#include "library/banshee/bansheedbconnection.h"
+#include "library/treeitemmodel.h"
 #include "preferences/configobject.h"
 #include "preferences/keyboardconfig.h"
-
 
 class BansheePlaylistModel;
 
 class BansheeFeature : public BaseExternalLibraryFeature {
     Q_OBJECT
   public:
-    BansheeFeature(Library* pLibrary, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig);
+    BansheeFeature(Library* pLibrary,
+            UserSettingsPointer pConfig,
+            KeyboardConfigPointer pKbdConfig);
     virtual ~BansheeFeature();
     static bool isSupported();
     static void prepareDbPath(UserSettingsPointer pConfig);

--- a/src/library/banshee/bansheefeature.h
+++ b/src/library/banshee/bansheefeature.h
@@ -11,6 +11,7 @@
 #include "library/treeitemmodel.h"
 #include "library/treeitem.h"
 #include "library/banshee/bansheedbconnection.h"
+#include "preferences/configobject.h"
 
 
 class BansheePlaylistModel;
@@ -18,7 +19,7 @@ class BansheePlaylistModel;
 class BansheeFeature : public BaseExternalLibraryFeature {
     Q_OBJECT
   public:
-    BansheeFeature(Library* pLibrary, UserSettingsPointer pConfig);
+    BansheeFeature(Library* pLibrary, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig);
     virtual ~BansheeFeature();
     static bool isSupported();
     static void prepareDbPath(UserSettingsPointer pConfig);

--- a/src/library/banshee/bansheefeature.h
+++ b/src/library/banshee/bansheefeature.h
@@ -12,6 +12,7 @@
 #include "library/treeitem.h"
 #include "library/banshee/bansheedbconnection.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 
 
 class BansheePlaylistModel;
@@ -19,7 +20,7 @@ class BansheePlaylistModel;
 class BansheeFeature : public BaseExternalLibraryFeature {
     Q_OBJECT
   public:
-    BansheeFeature(Library* pLibrary, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig);
+    BansheeFeature(Library* pLibrary, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig);
     virtual ~BansheeFeature();
     static bool isSupported();
     static void prepareDbPath(UserSettingsPointer pConfig);

--- a/src/library/baseexternallibraryfeature.cpp
+++ b/src/library/baseexternallibraryfeature.cpp
@@ -8,6 +8,7 @@
 #include "library/trackcollectionmanager.h"
 #include "moc_baseexternallibraryfeature.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "util/logger.h"
 #include "widget/wlibrarysidebar.h"
 
@@ -20,7 +21,7 @@ const mixxx::Logger kLogger("BaseExternalLibraryFeature");
 BaseExternalLibraryFeature::BaseExternalLibraryFeature(
         Library* pLibrary,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig,
+        KeyboardConfigPointer pKbdConfig,
         const QString& iconName)
         : LibraryFeature(pLibrary, pConfig, pKbdConfig, iconName),
           m_pTrackCollection(pLibrary->trackCollectionManager()->internalCollection()) {

--- a/src/library/baseexternallibraryfeature.cpp
+++ b/src/library/baseexternallibraryfeature.cpp
@@ -7,6 +7,7 @@
 #include "library/trackcollection.h"
 #include "library/trackcollectionmanager.h"
 #include "moc_baseexternallibraryfeature.cpp"
+#include "preferences/configobject.h"
 #include "util/logger.h"
 #include "widget/wlibrarysidebar.h"
 
@@ -19,8 +20,9 @@ const mixxx::Logger kLogger("BaseExternalLibraryFeature");
 BaseExternalLibraryFeature::BaseExternalLibraryFeature(
         Library* pLibrary,
         UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig,
         const QString& iconName)
-        : LibraryFeature(pLibrary, pConfig, iconName),
+        : LibraryFeature(pLibrary, pConfig, pKbdConfig, iconName),
           m_pTrackCollection(pLibrary->trackCollectionManager()->internalCollection()) {
     m_pAddToAutoDJAction = make_parented<QAction>(tr("Add to Auto DJ Queue (bottom)"), this);
     connect(m_pAddToAutoDJAction,

--- a/src/library/baseexternallibraryfeature.h
+++ b/src/library/baseexternallibraryfeature.h
@@ -8,6 +8,7 @@
 #include "library/dao/playlistdao.h"
 #include "library/libraryfeature.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "util/parented_ptr.h"
 
 class BaseSqlTableModel;
@@ -19,7 +20,7 @@ class BaseExternalLibraryFeature : public LibraryFeature {
     BaseExternalLibraryFeature(
             Library* pLibrary,
             UserSettingsPointer pConfig,
-            ConfigObject<ConfigValueKbd>* pKbdConfig,
+            KeyboardConfigPointer pKbdConfig,
             const QString& iconName);
     ~BaseExternalLibraryFeature() override = default;
 

--- a/src/library/baseexternallibraryfeature.h
+++ b/src/library/baseexternallibraryfeature.h
@@ -7,6 +7,7 @@
 
 #include "library/dao/playlistdao.h"
 #include "library/libraryfeature.h"
+#include "preferences/configobject.h"
 #include "util/parented_ptr.h"
 
 class BaseSqlTableModel;
@@ -18,6 +19,7 @@ class BaseExternalLibraryFeature : public LibraryFeature {
     BaseExternalLibraryFeature(
             Library* pLibrary,
             UserSettingsPointer pConfig,
+            ConfigObject<ConfigValueKbd>* pKbdConfig,
             const QString& iconName);
     ~BaseExternalLibraryFeature() override = default;
 

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -14,6 +14,7 @@
 #include "library/treeitem.h"
 #include "moc_browsefeature.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "track/track.h"
 #include "util/memory.h"
 #include "widget/wlibrary.h"
@@ -29,7 +30,7 @@ const QString kQuickLinksSeparator = QStringLiteral("-+-");
 BrowseFeature::BrowseFeature(
         Library* pLibrary,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig,
+        KeyboardConfigPointer pKbdConfig,
         RecordingManager* pRecordingManager)
         : LibraryFeature(pLibrary, pConfig, pKbdConfig, QString("computer")),
           m_pTrackCollection(pLibrary->trackCollectionManager()->internalCollection()),

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -13,6 +13,7 @@
 #include "library/trackcollectionmanager.h"
 #include "library/treeitem.h"
 #include "moc_browsefeature.cpp"
+#include "preferences/configobject.h"
 #include "track/track.h"
 #include "util/memory.h"
 #include "widget/wlibrary.h"
@@ -28,8 +29,9 @@ const QString kQuickLinksSeparator = QStringLiteral("-+-");
 BrowseFeature::BrowseFeature(
         Library* pLibrary,
         UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig,
         RecordingManager* pRecordingManager)
-        : LibraryFeature(pLibrary, pConfig, QString("computer")),
+        : LibraryFeature(pLibrary, pConfig, pKbdConfig, QString("computer")),
           m_pTrackCollection(pLibrary->trackCollectionManager()->internalCollection()),
           m_browseModel(this, pLibrary->trackCollectionManager(), pRecordingManager),
           m_proxyModel(&m_browseModel, true),

--- a/src/library/browse/browsefeature.h
+++ b/src/library/browse/browsefeature.h
@@ -9,6 +9,7 @@
 #include <QPoint>
 #include <QString>
 
+#include "preferences/keyboardconfig.h"
 #include "preferences/usersettings.h"
 #include "library/browse/browsetablemodel.h"
 #include "library/browse/foldertreemodel.h"
@@ -27,7 +28,7 @@ class BrowseFeature : public LibraryFeature {
   public:
     BrowseFeature(Library* pLibrary,
             UserSettingsPointer pConfig,
-            ConfigObject<ConfigValueKbd>* pKbdConfig,
+            KeyboardConfigPointer pKbdConfig,
             RecordingManager* pRecordingManager);
     virtual ~BrowseFeature();
 

--- a/src/library/browse/browsefeature.h
+++ b/src/library/browse/browsefeature.h
@@ -1,20 +1,20 @@
 #pragma once
 
-#include <QStringListModel>
-#include <QSortFilterProxyModel>
-#include <QObject>
-#include <QVariant>
 #include <QIcon>
 #include <QModelIndex>
+#include <QObject>
 #include <QPoint>
+#include <QSortFilterProxyModel>
 #include <QString>
+#include <QStringListModel>
+#include <QVariant>
 
-#include "preferences/keyboardconfig.h"
-#include "preferences/usersettings.h"
 #include "library/browse/browsetablemodel.h"
 #include "library/browse/foldertreemodel.h"
 #include "library/libraryfeature.h"
 #include "library/proxytrackmodel.h"
+#include "preferences/keyboardconfig.h"
+#include "preferences/usersettings.h"
 
 #define QUICK_LINK_NODE "::mixxx_quick_lnk_node::"
 #define DEVICE_NODE "::mixxx_device_node::"

--- a/src/library/browse/browsefeature.h
+++ b/src/library/browse/browsefeature.h
@@ -27,6 +27,7 @@ class BrowseFeature : public LibraryFeature {
   public:
     BrowseFeature(Library* pLibrary,
             UserSettingsPointer pConfig,
+            ConfigObject<ConfigValueKbd>* pKbdConfig,
             RecordingManager* pRecordingManager);
     virtual ~BrowseFeature();
 

--- a/src/library/dlganalysis.cpp
+++ b/src/library/dlganalysis.cpp
@@ -17,9 +17,9 @@
 #include "widget/wwidget.h"
 
 DlgAnalysis::DlgAnalysis(WLibrary* parent,
-                       UserSettingsPointer pConfig,
-                       KeyboardConfigPointer pKbdConfig,
-                       Library* pLibrary)
+        UserSettingsPointer pConfig,
+        KeyboardConfigPointer pKbdConfig,
+        Library* pLibrary)
         : QWidget(parent),
           m_pConfig(pConfig),
           m_bAnalysisActive(false) {

--- a/src/library/dlganalysis.cpp
+++ b/src/library/dlganalysis.cpp
@@ -9,6 +9,7 @@
 #include "library/trackcollectionmanager.h"
 #include "moc_dlganalysis.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "util/assert.h"
 #include "widget/wanalysislibrarytableview.h"
 #include "widget/wlibrary.h"
@@ -17,7 +18,7 @@
 
 DlgAnalysis::DlgAnalysis(WLibrary* parent,
                        UserSettingsPointer pConfig,
-                       ConfigObject<ConfigValueKbd>* pKbdConfig,
+                       KeyboardConfigPointer pKbdConfig,
                        Library* pLibrary)
         : QWidget(parent),
           m_pConfig(pConfig),

--- a/src/library/dlganalysis.cpp
+++ b/src/library/dlganalysis.cpp
@@ -8,6 +8,7 @@
 #include "library/library.h"
 #include "library/trackcollectionmanager.h"
 #include "moc_dlganalysis.cpp"
+#include "preferences/configobject.h"
 #include "util/assert.h"
 #include "widget/wanalysislibrarytableview.h"
 #include "widget/wlibrary.h"
@@ -16,6 +17,7 @@
 
 DlgAnalysis::DlgAnalysis(WLibrary* parent,
                        UserSettingsPointer pConfig,
+                       ConfigObject<ConfigValueKbd>* pKbdConfig,
                        Library* pLibrary)
         : QWidget(parent),
           m_pConfig(pConfig),
@@ -27,6 +29,7 @@ DlgAnalysis::DlgAnalysis(WLibrary* parent,
     m_pAnalysisLibraryTableView = new WAnalysisLibraryTableView(
             this,
             pConfig,
+            pKbdConfig,
             pLibrary,
             parent->getTrackTableBackgroundColorOpacity());
     connect(m_pAnalysisLibraryTableView,

--- a/src/library/dlganalysis.h
+++ b/src/library/dlganalysis.h
@@ -8,6 +8,7 @@
 #include "library/analysislibrarytablemodel.h"
 #include "library/libraryview.h"
 #include "library/ui_dlganalysis.h"
+#include "preferences/configobject.h"
 #include "preferences/usersettings.h"
 
 class AnalysisLibraryTableModel;
@@ -20,6 +21,7 @@ class DlgAnalysis : public QWidget, public Ui::DlgAnalysis, public virtual Libra
   public:
     DlgAnalysis(WLibrary *parent,
                UserSettingsPointer pConfig,
+               ConfigObject<ConfigValueKbd>* pKbdConfig,
                Library* pLibrary);
     ~DlgAnalysis() override = default;
 

--- a/src/library/dlganalysis.h
+++ b/src/library/dlganalysis.h
@@ -9,6 +9,7 @@
 #include "library/libraryview.h"
 #include "library/ui_dlganalysis.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "preferences/usersettings.h"
 
 class AnalysisLibraryTableModel;
@@ -21,7 +22,7 @@ class DlgAnalysis : public QWidget, public Ui::DlgAnalysis, public virtual Libra
   public:
     DlgAnalysis(WLibrary *parent,
                UserSettingsPointer pConfig,
-               ConfigObject<ConfigValueKbd>* pKbdConfig,
+               KeyboardConfigPointer pKbdConfig,
                Library* pLibrary);
     ~DlgAnalysis() override = default;
 

--- a/src/library/dlganalysis.h
+++ b/src/library/dlganalysis.h
@@ -20,10 +20,10 @@ class WLibrary;
 class DlgAnalysis : public QWidget, public Ui::DlgAnalysis, public virtual LibraryView {
     Q_OBJECT
   public:
-    DlgAnalysis(WLibrary *parent,
-               UserSettingsPointer pConfig,
-               KeyboardConfigPointer pKbdConfig,
-               Library* pLibrary);
+    DlgAnalysis(WLibrary* parent,
+            UserSettingsPointer pConfig,
+            KeyboardConfigPointer pKbdConfig,
+            Library* pLibrary);
     ~DlgAnalysis() override = default;
 
     void onSearch(const QString& text) override;

--- a/src/library/dlghidden.cpp
+++ b/src/library/dlghidden.cpp
@@ -4,6 +4,7 @@
 #include "library/trackcollectionmanager.h"
 #include "moc_dlghidden.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "util/assert.h"
 #include "widget/wlibrary.h"
 #include "widget/wtracktableview.h"
@@ -11,7 +12,7 @@
 DlgHidden::DlgHidden(
         WLibrary* parent,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig,
+        KeyboardConfigPointer pKbdConfig,
         Library* pLibrary,
         KeyboardEventFilter* pKeyboard)
         : QWidget(parent),

--- a/src/library/dlghidden.cpp
+++ b/src/library/dlghidden.cpp
@@ -3,6 +3,7 @@
 #include "library/hiddentablemodel.h"
 #include "library/trackcollectionmanager.h"
 #include "moc_dlghidden.cpp"
+#include "preferences/configobject.h"
 #include "util/assert.h"
 #include "widget/wlibrary.h"
 #include "widget/wtracktableview.h"
@@ -10,6 +11,7 @@
 DlgHidden::DlgHidden(
         WLibrary* parent,
         UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig,
         Library* pLibrary,
         KeyboardEventFilter* pKeyboard)
         : QWidget(parent),
@@ -18,6 +20,7 @@ DlgHidden::DlgHidden(
                   new WTrackTableView(
                           this,
                           pConfig,
+                          pKbdConfig,
                           pLibrary,
                           parent->getTrackTableBackgroundColorOpacity(),
                           true)) {

--- a/src/library/dlghidden.h
+++ b/src/library/dlghidden.h
@@ -18,9 +18,11 @@ class DlgHidden : public QWidget, public Ui::DlgHidden, public LibraryView {
     Q_OBJECT
 
   public:
-    DlgHidden(WLibrary* parent, UserSettingsPointer pConfig,
-              KeyboardConfigPointer pKbdConfig, Library* pLibrary,
-              KeyboardEventFilter* pKeyboard);
+    DlgHidden(WLibrary* parent,
+            UserSettingsPointer pConfig,
+            KeyboardConfigPointer pKbdConfig,
+            Library* pLibrary,
+            KeyboardEventFilter* pKeyboard);
     ~DlgHidden() override;
 
     void onShow() override;

--- a/src/library/dlghidden.h
+++ b/src/library/dlghidden.h
@@ -6,6 +6,7 @@
 #include "library/library.h"
 #include "library/libraryview.h"
 #include "library/ui_dlghidden.h"
+#include "preferences/configobject.h"
 #include "preferences/usersettings.h"
 
 class WLibrary;
@@ -17,7 +18,7 @@ class DlgHidden : public QWidget, public Ui::DlgHidden, public LibraryView {
 
   public:
     DlgHidden(WLibrary* parent, UserSettingsPointer pConfig,
-              Library* pLibrary,
+              ConfigObject<ConfigValueKbd>* pKbdConfig, Library* pLibrary,
               KeyboardEventFilter* pKeyboard);
     ~DlgHidden() override;
 

--- a/src/library/dlghidden.h
+++ b/src/library/dlghidden.h
@@ -7,6 +7,7 @@
 #include "library/libraryview.h"
 #include "library/ui_dlghidden.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "preferences/usersettings.h"
 
 class WLibrary;
@@ -18,7 +19,7 @@ class DlgHidden : public QWidget, public Ui::DlgHidden, public LibraryView {
 
   public:
     DlgHidden(WLibrary* parent, UserSettingsPointer pConfig,
-              ConfigObject<ConfigValueKbd>* pKbdConfig, Library* pLibrary,
+              KeyboardConfigPointer pKbdConfig, Library* pLibrary,
               KeyboardEventFilter* pKeyboard);
     ~DlgHidden() override;
 

--- a/src/library/dlgmissing.cpp
+++ b/src/library/dlgmissing.cpp
@@ -3,6 +3,7 @@
 #include "library/missingtablemodel.h"
 #include "library/trackcollectionmanager.h"
 #include "moc_dlgmissing.cpp"
+#include "preferences/configobject.h"
 #include "util/assert.h"
 #include "widget/wlibrary.h"
 #include "widget/wtracktableview.h"
@@ -10,6 +11,7 @@
 DlgMissing::DlgMissing(
         WLibrary* parent,
         UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig,
         Library* pLibrary,
         KeyboardEventFilter* pKeyboard)
         : QWidget(parent),
@@ -18,6 +20,7 @@ DlgMissing::DlgMissing(
                   new WTrackTableView(
                           this,
                           pConfig,
+                          pKbdConfig,
                           pLibrary,
                           parent->getTrackTableBackgroundColorOpacity(),
                           true)) {

--- a/src/library/dlgmissing.cpp
+++ b/src/library/dlgmissing.cpp
@@ -4,6 +4,7 @@
 #include "library/trackcollectionmanager.h"
 #include "moc_dlgmissing.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "util/assert.h"
 #include "widget/wlibrary.h"
 #include "widget/wtracktableview.h"
@@ -11,7 +12,7 @@
 DlgMissing::DlgMissing(
         WLibrary* parent,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig,
+        KeyboardConfigPointer pKbdConfig,
         Library* pLibrary,
         KeyboardEventFilter* pKeyboard)
         : QWidget(parent),

--- a/src/library/dlgmissing.h
+++ b/src/library/dlgmissing.h
@@ -18,9 +18,11 @@ class DlgMissing : public QWidget, public Ui::DlgMissing, public LibraryView {
     Q_OBJECT
 
   public:
-    DlgMissing(WLibrary* parent, UserSettingsPointer pConfig,
-               KeyboardConfigPointer pKbdConfig, Library* pLibrary,
-               KeyboardEventFilter* pKeyboard);
+    DlgMissing(WLibrary* parent,
+            UserSettingsPointer pConfig,
+            KeyboardConfigPointer pKbdConfig,
+            Library* pLibrary,
+            KeyboardEventFilter* pKeyboard);
     ~DlgMissing() override;
 
     void onShow() override;

--- a/src/library/dlgmissing.h
+++ b/src/library/dlgmissing.h
@@ -7,6 +7,7 @@
 #include "library/libraryview.h"
 #include "library/ui_dlgmissing.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "preferences/usersettings.h"
 
 class WLibrary;
@@ -18,7 +19,7 @@ class DlgMissing : public QWidget, public Ui::DlgMissing, public LibraryView {
 
   public:
     DlgMissing(WLibrary* parent, UserSettingsPointer pConfig,
-               ConfigObject<ConfigValueKbd>* pKbdConfig, Library* pLibrary,
+               KeyboardConfigPointer pKbdConfig, Library* pLibrary,
                KeyboardEventFilter* pKeyboard);
     ~DlgMissing() override;
 

--- a/src/library/dlgmissing.h
+++ b/src/library/dlgmissing.h
@@ -6,6 +6,7 @@
 #include "library/library.h"
 #include "library/libraryview.h"
 #include "library/ui_dlgmissing.h"
+#include "preferences/configobject.h"
 #include "preferences/usersettings.h"
 
 class WLibrary;
@@ -17,7 +18,7 @@ class DlgMissing : public QWidget, public Ui::DlgMissing, public LibraryView {
 
   public:
     DlgMissing(WLibrary* parent, UserSettingsPointer pConfig,
-               Library* pLibrary,
+               ConfigObject<ConfigValueKbd>* pKbdConfig, Library* pLibrary,
                KeyboardEventFilter* pKeyboard);
     ~DlgMissing() override;
 

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -18,6 +18,7 @@
 #include "library/trackcollectionmanager.h"
 #include "moc_itunesfeature.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "util/lcs.h"
 #include "util/sandbox.h"
 #include "widget/wlibrarysidebar.h"
@@ -62,7 +63,7 @@ QString localhost_token() {
 
 } // anonymous namespace
 
-ITunesFeature::ITunesFeature(Library* pLibrary, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig)
+ITunesFeature::ITunesFeature(Library* pLibrary, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig)
         : BaseExternalLibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("itunes")),
           m_pSidebarModel(make_parented<TreeItemModel>(this)),
           m_cancelImport(false) {

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -63,8 +63,11 @@ QString localhost_token() {
 
 } // anonymous namespace
 
-ITunesFeature::ITunesFeature(Library* pLibrary, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig)
-        : BaseExternalLibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("itunes")),
+ITunesFeature::ITunesFeature(Library* pLibrary,
+        UserSettingsPointer pConfig,
+        KeyboardConfigPointer pKbdConfig)
+        : BaseExternalLibraryFeature(
+                  pLibrary, pConfig, pKbdConfig, QStringLiteral("itunes")),
           m_pSidebarModel(make_parented<TreeItemModel>(this)),
           m_cancelImport(false) {
     QString tableName = "itunes_library";

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -17,6 +17,7 @@
 #include "library/queryutil.h"
 #include "library/trackcollectionmanager.h"
 #include "moc_itunesfeature.cpp"
+#include "preferences/configobject.h"
 #include "util/lcs.h"
 #include "util/sandbox.h"
 #include "widget/wlibrarysidebar.h"
@@ -61,8 +62,8 @@ QString localhost_token() {
 
 } // anonymous namespace
 
-ITunesFeature::ITunesFeature(Library* pLibrary, UserSettingsPointer pConfig)
-        : BaseExternalLibraryFeature(pLibrary, pConfig, QStringLiteral("itunes")),
+ITunesFeature::ITunesFeature(Library* pLibrary, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig)
+        : BaseExternalLibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("itunes")),
           m_pSidebarModel(make_parented<TreeItemModel>(this)),
           m_cancelImport(false) {
     QString tableName = "itunes_library";

--- a/src/library/itunes/itunesfeature.h
+++ b/src/library/itunes/itunesfeature.h
@@ -22,54 +22,53 @@ class WLibrarySidebar;
 class ITunesFeature : public BaseExternalLibraryFeature {
     Q_OBJECT
  public:
-    ITunesFeature(Library* pLibrary, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig);
-    virtual ~ITunesFeature();
-    static bool isSupported();
+   ITunesFeature(Library* pLibrary, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig);
+   virtual ~ITunesFeature();
+   static bool isSupported();
 
-    QVariant title() override;
-    void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
+   QVariant title() override;
+   void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
 
-    TreeItemModel* sidebarModel() const override;
+   TreeItemModel* sidebarModel() const override;
 
-  public slots:
-    void activate() override;
-    void activate(bool forceReload);
-    void activateChild(const QModelIndex& index) override;
-    void onRightClick(const QPoint& globalPos) override;
-    void onTrackCollectionLoaded();
+ public slots:
+   void activate() override;
+   void activate(bool forceReload);
+   void activateChild(const QModelIndex& index) override;
+   void onRightClick(const QPoint& globalPos) override;
+   void onTrackCollectionLoaded();
 
-  private:
-    std::unique_ptr<BaseSqlTableModel> createPlaylistModelForPlaylist(
-            const QString& playlist) override;
-    static QString getiTunesMusicPath();
-    // returns the invisible rootItem for the sidebar model
-    TreeItem* importLibrary();
-    void guessMusicLibraryMountpoint(QXmlStreamReader& xml);
-    void parseTracks(QXmlStreamReader& xml);
-    void parseTrack(QXmlStreamReader& xml, QSqlQuery& query);
-    TreeItem* parsePlaylists(QXmlStreamReader &xml);
-    void parsePlaylist(QXmlStreamReader& xml, QSqlQuery& query1,
-                       QSqlQuery &query2, TreeItem*);
-    void clearTable(const QString& table_name);
-    bool readNextStartElement(QXmlStreamReader& xml);
+ private:
+   std::unique_ptr<BaseSqlTableModel> createPlaylistModelForPlaylist(
+           const QString& playlist) override;
+   static QString getiTunesMusicPath();
+   // returns the invisible rootItem for the sidebar model
+   TreeItem* importLibrary();
+   void guessMusicLibraryMountpoint(QXmlStreamReader& xml);
+   void parseTracks(QXmlStreamReader& xml);
+   void parseTrack(QXmlStreamReader& xml, QSqlQuery& query);
+   TreeItem* parsePlaylists(QXmlStreamReader& xml);
+   void parsePlaylist(QXmlStreamReader& xml, QSqlQuery& query1, QSqlQuery& query2, TreeItem*);
+   void clearTable(const QString& table_name);
+   bool readNextStartElement(QXmlStreamReader& xml);
 
-    BaseExternalTrackModel* m_pITunesTrackModel;
-    BaseExternalPlaylistModel* m_pITunesPlaylistModel;
-    parented_ptr<TreeItemModel> m_pSidebarModel;
-    QStringList m_playlists;
-    // a new DB connection for the worker thread
-    QSqlDatabase m_database;
-    bool m_cancelImport;
-    bool m_isActivated;
-    QString m_dbfile;
+   BaseExternalTrackModel* m_pITunesTrackModel;
+   BaseExternalPlaylistModel* m_pITunesPlaylistModel;
+   parented_ptr<TreeItemModel> m_pSidebarModel;
+   QStringList m_playlists;
+   // a new DB connection for the worker thread
+   QSqlDatabase m_database;
+   bool m_cancelImport;
+   bool m_isActivated;
+   QString m_dbfile;
 
-    QFutureWatcher<TreeItem*> m_future_watcher;
-    QFuture<TreeItem*> m_future;
-    QString m_title;
+   QFutureWatcher<TreeItem*> m_future_watcher;
+   QFuture<TreeItem*> m_future;
+   QString m_title;
 
-    QString m_dbItunesRoot;
-    QString m_mixxxItunesRoot;
+   QString m_dbItunesRoot;
+   QString m_mixxxItunesRoot;
 
-    QSharedPointer<BaseTrackCache> m_trackSource;
-    QPointer<WLibrarySidebar> m_pSidebarWidget;
+   QSharedPointer<BaseTrackCache> m_trackSource;
+   QPointer<WLibrarySidebar> m_pSidebarWidget;
 };

--- a/src/library/itunes/itunesfeature.h
+++ b/src/library/itunes/itunesfeature.h
@@ -11,6 +11,7 @@
 #include "library/trackcollection.h"
 #include "library/treeitem.h"
 #include "library/treeitemmodel.h"
+#include "preferences/configobject.h"
 #include "util/parented_ptr.h"
 
 class BaseExternalTrackModel;
@@ -20,7 +21,7 @@ class WLibrarySidebar;
 class ITunesFeature : public BaseExternalLibraryFeature {
     Q_OBJECT
  public:
-    ITunesFeature(Library* pLibrary, UserSettingsPointer pConfig);
+    ITunesFeature(Library* pLibrary, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig);
     virtual ~ITunesFeature();
     static bool isSupported();
 

--- a/src/library/itunes/itunesfeature.h
+++ b/src/library/itunes/itunesfeature.h
@@ -12,6 +12,7 @@
 #include "library/treeitem.h"
 #include "library/treeitemmodel.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "util/parented_ptr.h"
 
 class BaseExternalTrackModel;
@@ -21,7 +22,7 @@ class WLibrarySidebar;
 class ITunesFeature : public BaseExternalLibraryFeature {
     Q_OBJECT
  public:
-    ITunesFeature(Library* pLibrary, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig);
+    ITunesFeature(Library* pLibrary, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig);
     virtual ~ITunesFeature();
     static bool isSupported();
 

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -37,6 +37,7 @@
 #include "library/traktor/traktorfeature.h"
 #include "mixer/playermanager.h"
 #include "moc_library.cpp"
+#include "preferences/keyboardconfig.h"
 #include "recording/recordingmanager.h"
 #include "util/assert.h"
 #include "util/db/dbconnectionpooled.h"
@@ -65,7 +66,7 @@ const int Library::kDefaultRowHeightPx = 20;
 Library::Library(
         QObject* parent,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig,
+        KeyboardConfigPointer pKbdConfig,
         mixxx::DbConnectionPoolPtr pDbConnectionPool,
         TrackCollectionManager* pTrackCollectionManager,
         PlayerManager* pPlayerManager,

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -10,6 +10,7 @@
 #include "analyzer/trackanalysisscheduler.h"
 #include "library/library_decl.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #ifdef __ENGINEPRIME__
 #include "library/trackset/crate/crateid.h"
 #endif
@@ -53,7 +54,7 @@ class Library: public QObject {
   public:
     Library(QObject* parent,
             UserSettingsPointer pConfig,
-            ConfigObject<ConfigValueKbd>* pKbdConfig,
+            KeyboardConfigPointer pKbdConfig,
             mixxx::DbConnectionPoolPtr pDbConnectionPool,
             TrackCollectionManager* pTrackCollectionManager,
             PlayerManager* pPlayerManager,
@@ -152,7 +153,7 @@ class Library: public QObject {
 
   private:
     const UserSettingsPointer m_pConfig;
-    ConfigObject<ConfigValueKbd>* m_pKbdConfig;
+    const KeyboardConfigPointer m_pKbdConfig;
 
     // The Mixxx database connection pool
     const mixxx::DbConnectionPoolPtr m_pDbConnectionPool;

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -9,6 +9,7 @@
 #include "analyzer/analyzerscheduledtrack.h"
 #include "analyzer/trackanalysisscheduler.h"
 #include "library/library_decl.h"
+#include "preferences/configobject.h"
 #ifdef __ENGINEPRIME__
 #include "library/trackset/crate/crateid.h"
 #endif
@@ -52,6 +53,7 @@ class Library: public QObject {
   public:
     Library(QObject* parent,
             UserSettingsPointer pConfig,
+            ConfigObject<ConfigValueKbd>* pKbdConfig,
             mixxx::DbConnectionPoolPtr pDbConnectionPool,
             TrackCollectionManager* pTrackCollectionManager,
             PlayerManager* pPlayerManager,
@@ -150,6 +152,7 @@ class Library: public QObject {
 
   private:
     const UserSettingsPointer m_pConfig;
+    ConfigObject<ConfigValueKbd>* m_pKbdConfig;
 
     // The Mixxx database connection pool
     const mixxx::DbConnectionPoolPtr m_pDbConnectionPool;

--- a/src/library/libraryfeature.cpp
+++ b/src/library/libraryfeature.cpp
@@ -5,6 +5,7 @@
 #include "library/library.h"
 #include "library/parserm3u.h"
 #include "library/parserpls.h"
+#include "preferences/keyboardconfig.h"
 #include "moc_libraryfeature.cpp"
 #include "util/logger.h"
 
@@ -22,7 +23,7 @@ const QString kIconPath = QStringLiteral(":/images/library/ic_library_%1.svg");
 LibraryFeature::LibraryFeature(
         Library* pLibrary,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig,
+        KeyboardConfigPointer pKbdConfig,
         const QString& iconName)
         : QObject(pLibrary),
           m_pLibrary(pLibrary),

--- a/src/library/libraryfeature.cpp
+++ b/src/library/libraryfeature.cpp
@@ -5,8 +5,8 @@
 #include "library/library.h"
 #include "library/parserm3u.h"
 #include "library/parserpls.h"
-#include "preferences/keyboardconfig.h"
 #include "moc_libraryfeature.cpp"
+#include "preferences/keyboardconfig.h"
 #include "util/logger.h"
 
 // KEEP THIS cpp file to tell scons that moc should be called on the class!!!

--- a/src/library/libraryfeature.cpp
+++ b/src/library/libraryfeature.cpp
@@ -22,10 +22,12 @@ const QString kIconPath = QStringLiteral(":/images/library/ic_library_%1.svg");
 LibraryFeature::LibraryFeature(
         Library* pLibrary,
         UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig,
         const QString& iconName)
         : QObject(pLibrary),
           m_pLibrary(pLibrary),
           m_pConfig(pConfig),
+          m_pKbdConfig(pKbdConfig),
           m_iconName(iconName) {
     if (!m_iconName.isEmpty()) {
         m_icon = QIcon(kIconPath.arg(m_iconName));

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -15,6 +15,7 @@
 #include "library/coverartcache.h"
 #include "library/dao/trackdao.h"
 #include "library/treeitemmodel.h"
+#include "preferences/configobject.h"
 #include "track/track_decl.h"
 
 class KeyboardEventFilter;
@@ -30,6 +31,7 @@ class LibraryFeature : public QObject {
     LibraryFeature(
             Library* pLibrary,
             UserSettingsPointer pConfig,
+            ConfigObject<ConfigValueKbd>* pKbdConfig,
             const QString& iconName);
     ~LibraryFeature() override = default;
 
@@ -98,6 +100,7 @@ class LibraryFeature : public QObject {
     Library* const m_pLibrary;
 
     const UserSettingsPointer m_pConfig;
+    ConfigObject<ConfigValueKbd>* m_pKbdConfig;
 
   public slots:
     // called when you single click on the root item

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -16,6 +16,7 @@
 #include "library/dao/trackdao.h"
 #include "library/treeitemmodel.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "track/track_decl.h"
 
 class KeyboardEventFilter;
@@ -31,7 +32,7 @@ class LibraryFeature : public QObject {
     LibraryFeature(
             Library* pLibrary,
             UserSettingsPointer pConfig,
-            ConfigObject<ConfigValueKbd>* pKbdConfig,
+            KeyboardConfigPointer pKbdConfig,
             const QString& iconName);
     ~LibraryFeature() override = default;
 
@@ -100,7 +101,7 @@ class LibraryFeature : public QObject {
     Library* const m_pLibrary;
 
     const UserSettingsPointer m_pConfig;
-    ConfigObject<ConfigValueKbd>* m_pKbdConfig;
+    const KeyboardConfigPointer m_pKbdConfig;
 
   public slots:
     // called when you single click on the root item

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -1,6 +1,7 @@
 #include "library/mixxxlibraryfeature.h"
 
 #include <QtDebug>
+
 #include "preferences/configobject.h"
 #include "preferences/keyboardconfig.h"
 #ifdef __ENGINEPRIME__
@@ -28,9 +29,9 @@
 #include "widget/wlibrarysidebar.h"
 #endif
 
-
 MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
-        UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig)
+        UserSettingsPointer pConfig,
+        KeyboardConfigPointer pKbdConfig)
         : LibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("tracks")),
           kMissingTitle(tr("Missing Tracks")),
           kHiddenTitle(tr("Hidden Tracks")),
@@ -136,16 +137,14 @@ MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
 
 void MixxxLibraryFeature::bindLibraryWidget(WLibrary* pLibraryWidget,
                                      KeyboardEventFilter* pKeyboard) {
-    m_pHiddenView = new DlgHidden(pLibraryWidget, m_pConfig, m_pKbdConfig, m_pLibrary,
-                                  pKeyboard);
+    m_pHiddenView = new DlgHidden(pLibraryWidget, m_pConfig, m_pKbdConfig, m_pLibrary, pKeyboard);
     pLibraryWidget->registerView(kHiddenTitle, m_pHiddenView);
     connect(m_pHiddenView,
             &DlgHidden::trackSelected,
             this,
             &MixxxLibraryFeature::trackSelected);
 
-    m_pMissingView = new DlgMissing(pLibraryWidget, m_pConfig, m_pKbdConfig, m_pLibrary,
-                                    pKeyboard);
+    m_pMissingView = new DlgMissing(pLibraryWidget, m_pConfig, m_pKbdConfig, m_pLibrary, pKeyboard);
     pLibraryWidget->registerView(kMissingTitle, m_pMissingView);
     connect(m_pMissingView,
             &DlgMissing::trackSelected,

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -2,6 +2,7 @@
 
 #include <QtDebug>
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #ifdef __ENGINEPRIME__
 #include <QMenu>
 #endif
@@ -29,7 +30,7 @@
 
 
 MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
-        UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig)
+        UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig)
         : LibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("tracks")),
           kMissingTitle(tr("Missing Tracks")),
           kHiddenTitle(tr("Hidden Tracks")),

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -1,6 +1,7 @@
 #include "library/mixxxlibraryfeature.h"
 
 #include <QtDebug>
+#include "preferences/configobject.h"
 #ifdef __ENGINEPRIME__
 #include <QMenu>
 #endif
@@ -28,8 +29,8 @@
 
 
 MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
-        UserSettingsPointer pConfig)
-        : LibraryFeature(pLibrary, pConfig, QStringLiteral("tracks")),
+        UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig)
+        : LibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("tracks")),
           kMissingTitle(tr("Missing Tracks")),
           kHiddenTitle(tr("Hidden Tracks")),
           m_pTrackCollection(pLibrary->trackCollectionManager()->internalCollection()),
@@ -134,7 +135,7 @@ MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
 
 void MixxxLibraryFeature::bindLibraryWidget(WLibrary* pLibraryWidget,
                                      KeyboardEventFilter* pKeyboard) {
-    m_pHiddenView = new DlgHidden(pLibraryWidget, m_pConfig, m_pLibrary,
+    m_pHiddenView = new DlgHidden(pLibraryWidget, m_pConfig, m_pKbdConfig, m_pLibrary,
                                   pKeyboard);
     pLibraryWidget->registerView(kHiddenTitle, m_pHiddenView);
     connect(m_pHiddenView,
@@ -142,7 +143,7 @@ void MixxxLibraryFeature::bindLibraryWidget(WLibrary* pLibraryWidget,
             this,
             &MixxxLibraryFeature::trackSelected);
 
-    m_pMissingView = new DlgMissing(pLibraryWidget, m_pConfig, m_pLibrary,
+    m_pMissingView = new DlgMissing(pLibraryWidget, m_pConfig, m_pKbdConfig, m_pLibrary,
                                     pKeyboard);
     pLibraryWidget->registerView(kMissingTitle, m_pMissingView);
     connect(m_pMissingView,

--- a/src/library/mixxxlibraryfeature.h
+++ b/src/library/mixxxlibraryfeature.h
@@ -16,6 +16,7 @@
 #include "library/libraryfeature.h"
 #include "library/treeitemmodel.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "preferences/usersettings.h"
 #include "util/parented_ptr.h"
 
@@ -30,7 +31,7 @@ class MixxxLibraryFeature final : public LibraryFeature {
   public:
     MixxxLibraryFeature(Library* pLibrary,
                         UserSettingsPointer pConfig,
-                        ConfigObject<ConfigValueKbd>* pKbdConfig);
+                        KeyboardConfigPointer pKbdConfig);
     ~MixxxLibraryFeature() override = default;
 
     QVariant title() override;

--- a/src/library/mixxxlibraryfeature.h
+++ b/src/library/mixxxlibraryfeature.h
@@ -30,8 +30,8 @@ class MixxxLibraryFeature final : public LibraryFeature {
     Q_OBJECT
   public:
     MixxxLibraryFeature(Library* pLibrary,
-                        UserSettingsPointer pConfig,
-                        KeyboardConfigPointer pKbdConfig);
+            UserSettingsPointer pConfig,
+            KeyboardConfigPointer pKbdConfig);
     ~MixxxLibraryFeature() override = default;
 
     QVariant title() override;

--- a/src/library/mixxxlibraryfeature.h
+++ b/src/library/mixxxlibraryfeature.h
@@ -15,6 +15,7 @@
 #include "library/dao/trackdao.h"
 #include "library/libraryfeature.h"
 #include "library/treeitemmodel.h"
+#include "preferences/configobject.h"
 #include "preferences/usersettings.h"
 #include "util/parented_ptr.h"
 
@@ -28,7 +29,8 @@ class MixxxLibraryFeature final : public LibraryFeature {
     Q_OBJECT
   public:
     MixxxLibraryFeature(Library* pLibrary,
-                        UserSettingsPointer pConfig);
+                        UserSettingsPointer pConfig,
+                        ConfigObject<ConfigValueKbd>* pKbdConfig);
     ~MixxxLibraryFeature() override = default;
 
     QVariant title() override;

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -5,6 +5,7 @@
 #include "library/trackcollectionmanager.h"
 #include "moc_dlgrecording.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "util/assert.h"
 #include "widget/wlibrary.h"
 #include "widget/wskincolor.h"
@@ -14,7 +15,7 @@
 DlgRecording::DlgRecording(
         WLibrary* parent,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig,
+        KeyboardConfigPointer pKbdConfig,
         Library* pLibrary,
         RecordingManager* pRecordingManager,
         KeyboardEventFilter* pKeyboard)

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -1,6 +1,5 @@
 #include "library/recording/dlgrecording.h"
 
-
 #include "control/controlobject.h"
 #include "library/trackcollectionmanager.h"
 #include "moc_dlgrecording.cpp"

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -4,6 +4,7 @@
 #include "control/controlobject.h"
 #include "library/trackcollectionmanager.h"
 #include "moc_dlgrecording.cpp"
+#include "preferences/configobject.h"
 #include "util/assert.h"
 #include "widget/wlibrary.h"
 #include "widget/wskincolor.h"
@@ -13,6 +14,7 @@
 DlgRecording::DlgRecording(
         WLibrary* parent,
         UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig,
         Library* pLibrary,
         RecordingManager* pRecordingManager,
         KeyboardEventFilter* pKeyboard)
@@ -22,6 +24,7 @@ DlgRecording::DlgRecording(
                   new WTrackTableView(
                           this,
                           pConfig,
+                          pKbdConfig,
                           pLibrary,
                           parent->getTrackTableBackgroundColorOpacity(),
                           true)),

--- a/src/library/recording/dlgrecording.h
+++ b/src/library/recording/dlgrecording.h
@@ -7,6 +7,7 @@
 #include "library/proxytrackmodel.h"
 #include "library/recording/ui_dlgrecording.h"
 #include "library/trackcollection.h"
+#include "preferences/configobject.h"
 #include "preferences/usersettings.h"
 #include "recording/recordingmanager.h"
 #include "track/track_decl.h"
@@ -18,7 +19,7 @@ class DlgRecording : public QWidget, public Ui::DlgRecording, public virtual Lib
     Q_OBJECT
   public:
     DlgRecording(WLibrary *parent, UserSettingsPointer pConfig,
-                 Library* pLibrary,
+                 ConfigObject<ConfigValueKbd>* pKbdConfig, Library* pLibrary,
                  RecordingManager* pRecManager, KeyboardEventFilter* pKeyboard);
     ~DlgRecording() override;
 

--- a/src/library/recording/dlgrecording.h
+++ b/src/library/recording/dlgrecording.h
@@ -8,6 +8,7 @@
 #include "library/recording/ui_dlgrecording.h"
 #include "library/trackcollection.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "preferences/usersettings.h"
 #include "recording/recordingmanager.h"
 #include "track/track_decl.h"
@@ -19,7 +20,7 @@ class DlgRecording : public QWidget, public Ui::DlgRecording, public virtual Lib
     Q_OBJECT
   public:
     DlgRecording(WLibrary *parent, UserSettingsPointer pConfig,
-                 ConfigObject<ConfigValueKbd>* pKbdConfig, Library* pLibrary,
+                 KeyboardConfigPointer pKbdConfig, Library* pLibrary,
                  RecordingManager* pRecManager, KeyboardEventFilter* pKeyboard);
     ~DlgRecording() override;
 

--- a/src/library/recording/dlgrecording.h
+++ b/src/library/recording/dlgrecording.h
@@ -19,9 +19,12 @@ class WTrackTableView;
 class DlgRecording : public QWidget, public Ui::DlgRecording, public virtual LibraryView {
     Q_OBJECT
   public:
-    DlgRecording(WLibrary *parent, UserSettingsPointer pConfig,
-                 KeyboardConfigPointer pKbdConfig, Library* pLibrary,
-                 RecordingManager* pRecManager, KeyboardEventFilter* pKeyboard);
+    DlgRecording(WLibrary* parent,
+            UserSettingsPointer pConfig,
+            KeyboardConfigPointer pKbdConfig,
+            Library* pLibrary,
+            RecordingManager* pRecManager,
+            KeyboardEventFilter* pKeyboard);
     ~DlgRecording() override;
 
     void onSearch(const QString& text) override;

--- a/src/library/recording/recordingfeature.cpp
+++ b/src/library/recording/recordingfeature.cpp
@@ -38,11 +38,11 @@ void RecordingFeature::bindLibraryWidget(WLibrary* pLibraryWidget,
                                   KeyboardEventFilter *keyboard) {
     //The view will be deleted by LibraryWidget
     DlgRecording* pRecordingView = new DlgRecording(pLibraryWidget,
-                                                    m_pConfig,
-                                                    m_pKbdConfig,
-                                                    m_pLibrary,
-                                                    m_pRecordingManager,
-                                                    keyboard);
+            m_pConfig,
+            m_pKbdConfig,
+            m_pLibrary,
+            m_pRecordingManager,
+            keyboard);
 
     pRecordingView->installEventFilter(keyboard);
     pLibraryWidget->registerView(kViewName, pRecordingView);

--- a/src/library/recording/recordingfeature.cpp
+++ b/src/library/recording/recordingfeature.cpp
@@ -5,6 +5,7 @@
 #include "library/recording/dlgrecording.h"
 #include "library/treeitem.h"
 #include "moc_recordingfeature.cpp"
+#include "preferences/configobject.h"
 #include "recording/recordingmanager.h"
 #include "track/track.h"
 #include "widget/wlibrary.h"
@@ -17,8 +18,9 @@ const QString kViewName = QStringLiteral("Recording");
 
 RecordingFeature::RecordingFeature(Library* pLibrary,
         UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig,
         RecordingManager* pRecordingManager)
-        : LibraryFeature(pLibrary, pConfig, QStringLiteral("recordings")),
+        : LibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("recordings")),
           m_pRecordingManager(pRecordingManager),
           m_pSidebarModel(new FolderTreeModel(this)) {
 }
@@ -36,6 +38,7 @@ void RecordingFeature::bindLibraryWidget(WLibrary* pLibraryWidget,
     //The view will be deleted by LibraryWidget
     DlgRecording* pRecordingView = new DlgRecording(pLibraryWidget,
                                                     m_pConfig,
+                                                    m_pKbdConfig,
                                                     m_pLibrary,
                                                     m_pRecordingManager,
                                                     keyboard);

--- a/src/library/recording/recordingfeature.cpp
+++ b/src/library/recording/recordingfeature.cpp
@@ -6,6 +6,7 @@
 #include "library/treeitem.h"
 #include "moc_recordingfeature.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "recording/recordingmanager.h"
 #include "track/track.h"
 #include "widget/wlibrary.h"
@@ -18,7 +19,7 @@ const QString kViewName = QStringLiteral("Recording");
 
 RecordingFeature::RecordingFeature(Library* pLibrary,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig,
+        KeyboardConfigPointer pKbdConfig,
         RecordingManager* pRecordingManager)
         : LibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("recordings")),
           m_pRecordingManager(pRecordingManager),

--- a/src/library/recording/recordingfeature.h
+++ b/src/library/recording/recordingfeature.h
@@ -15,6 +15,7 @@ class RecordingFeature final : public LibraryFeature {
   public:
     RecordingFeature(Library* parent,
                      UserSettingsPointer pConfig,
+                     ConfigObject<ConfigValueKbd>* pKbdConfig,
                      RecordingManager* pRecordingManager);
     ~RecordingFeature() override = default;
 

--- a/src/library/recording/recordingfeature.h
+++ b/src/library/recording/recordingfeature.h
@@ -4,6 +4,7 @@
 #include <QSortFilterProxyModel>
 
 #include "preferences/usersettings.h"
+#include "preferences/keyboardconfig.h"
 #include "library/browse/browsetablemodel.h"
 #include "library/browse/foldertreemodel.h"
 #include "library/libraryfeature.h"
@@ -15,7 +16,7 @@ class RecordingFeature final : public LibraryFeature {
   public:
     RecordingFeature(Library* parent,
                      UserSettingsPointer pConfig,
-                     ConfigObject<ConfigValueKbd>* pKbdConfig,
+                     KeyboardConfigPointer pKbdConfig,
                      RecordingManager* pRecordingManager);
     ~RecordingFeature() override = default;
 

--- a/src/library/recording/recordingfeature.h
+++ b/src/library/recording/recordingfeature.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <QStringListModel>
 #include <QSortFilterProxyModel>
+#include <QStringListModel>
 
-#include "preferences/usersettings.h"
-#include "preferences/keyboardconfig.h"
 #include "library/browse/browsetablemodel.h"
 #include "library/browse/foldertreemodel.h"
 #include "library/libraryfeature.h"
+#include "preferences/keyboardconfig.h"
+#include "preferences/usersettings.h"
 
 class RecordingManager;
 
@@ -15,9 +15,9 @@ class RecordingFeature final : public LibraryFeature {
     Q_OBJECT
   public:
     RecordingFeature(Library* parent,
-                     UserSettingsPointer pConfig,
-                     KeyboardConfigPointer pKbdConfig,
-                     RecordingManager* pRecordingManager);
+            UserSettingsPointer pConfig,
+            KeyboardConfigPointer pKbdConfig,
+            RecordingManager* pRecordingManager);
     ~RecordingFeature() override = default;
 
     QVariant title() override;

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -20,6 +20,7 @@
 #include "library/treeitem.h"
 #include "moc_rekordboxfeature.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "track/beats.h"
 #include "track/cue.h"
 #include "track/keyfactory.h"
@@ -1338,7 +1339,7 @@ bool RekordboxPlaylistModel::isColumnInternal(int column) {
 RekordboxFeature::RekordboxFeature(
         Library* pLibrary,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig)
+        KeyboardConfigPointer pKbdConfig)
         : BaseExternalLibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("rekordbox")),
           m_pSidebarModel(make_parented<TreeItemModel>(this)) {
     QString tableName = kRekordboxLibraryTable;

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -19,6 +19,7 @@
 #include "library/trackcollectionmanager.h"
 #include "library/treeitem.h"
 #include "moc_rekordboxfeature.cpp"
+#include "preferences/configobject.h"
 #include "track/beats.h"
 #include "track/cue.h"
 #include "track/keyfactory.h"
@@ -1336,8 +1337,9 @@ bool RekordboxPlaylistModel::isColumnInternal(int column) {
 
 RekordboxFeature::RekordboxFeature(
         Library* pLibrary,
-        UserSettingsPointer pConfig)
-        : BaseExternalLibraryFeature(pLibrary, pConfig, QStringLiteral("rekordbox")),
+        UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig)
+        : BaseExternalLibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("rekordbox")),
           m_pSidebarModel(make_parented<TreeItemModel>(this)) {
     QString tableName = kRekordboxLibraryTable;
     QString idColumn = LIBRARYTABLE_ID;

--- a/src/library/rekordbox/rekordboxfeature.h
+++ b/src/library/rekordbox/rekordboxfeature.h
@@ -35,6 +35,7 @@
 #include "library/baseexternaltrackmodel.h"
 #include "library/treeitemmodel.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "util/parented_ptr.h"
 
 class TrackCollectionManager;
@@ -57,7 +58,7 @@ class RekordboxPlaylistModel : public BaseExternalPlaylistModel {
 class RekordboxFeature : public BaseExternalLibraryFeature {
     Q_OBJECT
   public:
-    RekordboxFeature(Library* pLibrary, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig);
+    RekordboxFeature(Library* pLibrary, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig);
     ~RekordboxFeature() override;
 
     QVariant title() override;

--- a/src/library/rekordbox/rekordboxfeature.h
+++ b/src/library/rekordbox/rekordboxfeature.h
@@ -58,7 +58,9 @@ class RekordboxPlaylistModel : public BaseExternalPlaylistModel {
 class RekordboxFeature : public BaseExternalLibraryFeature {
     Q_OBJECT
   public:
-    RekordboxFeature(Library* pLibrary, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig);
+    RekordboxFeature(Library* pLibrary,
+            UserSettingsPointer pConfig,
+            KeyboardConfigPointer pKbdConfig);
     ~RekordboxFeature() override;
 
     QVariant title() override;

--- a/src/library/rekordbox/rekordboxfeature.h
+++ b/src/library/rekordbox/rekordboxfeature.h
@@ -34,6 +34,7 @@
 #include "library/baseexternalplaylistmodel.h"
 #include "library/baseexternaltrackmodel.h"
 #include "library/treeitemmodel.h"
+#include "preferences/configobject.h"
 #include "util/parented_ptr.h"
 
 class TrackCollectionManager;
@@ -56,7 +57,7 @@ class RekordboxPlaylistModel : public BaseExternalPlaylistModel {
 class RekordboxFeature : public BaseExternalLibraryFeature {
     Q_OBJECT
   public:
-    RekordboxFeature(Library* pLibrary, UserSettingsPointer pConfig);
+    RekordboxFeature(Library* pLibrary, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig);
     ~RekordboxFeature() override;
 
     QVariant title() override;

--- a/src/library/rhythmbox/rhythmboxfeature.cpp
+++ b/src/library/rhythmbox/rhythmboxfeature.cpp
@@ -14,8 +14,9 @@
 #include "library/treeitem.h"
 #include "moc_rhythmboxfeature.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 
-RhythmboxFeature::RhythmboxFeature(Library* pLibrary, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig)
+RhythmboxFeature::RhythmboxFeature(Library* pLibrary, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig)
         : BaseExternalLibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("rhythmbox")),
           m_pSidebarModel(make_parented<TreeItemModel>(this)),
           m_cancelImport(false) {

--- a/src/library/rhythmbox/rhythmboxfeature.cpp
+++ b/src/library/rhythmbox/rhythmboxfeature.cpp
@@ -16,8 +16,11 @@
 #include "preferences/configobject.h"
 #include "preferences/keyboardconfig.h"
 
-RhythmboxFeature::RhythmboxFeature(Library* pLibrary, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig)
-        : BaseExternalLibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("rhythmbox")),
+RhythmboxFeature::RhythmboxFeature(Library* pLibrary,
+        UserSettingsPointer pConfig,
+        KeyboardConfigPointer pKbdConfig)
+        : BaseExternalLibraryFeature(
+                  pLibrary, pConfig, pKbdConfig, QStringLiteral("rhythmbox")),
           m_pSidebarModel(make_parented<TreeItemModel>(this)),
           m_cancelImport(false) {
     QString tableName = "rhythmbox_library";

--- a/src/library/rhythmbox/rhythmboxfeature.cpp
+++ b/src/library/rhythmbox/rhythmboxfeature.cpp
@@ -13,9 +13,10 @@
 #include "library/trackcollectionmanager.h"
 #include "library/treeitem.h"
 #include "moc_rhythmboxfeature.cpp"
+#include "preferences/configobject.h"
 
-RhythmboxFeature::RhythmboxFeature(Library* pLibrary, UserSettingsPointer pConfig)
-        : BaseExternalLibraryFeature(pLibrary, pConfig, QStringLiteral("rhythmbox")),
+RhythmboxFeature::RhythmboxFeature(Library* pLibrary, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig)
+        : BaseExternalLibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("rhythmbox")),
           m_pSidebarModel(make_parented<TreeItemModel>(this)),
           m_cancelImport(false) {
     QString tableName = "rhythmbox_library";

--- a/src/library/rhythmbox/rhythmboxfeature.h
+++ b/src/library/rhythmbox/rhythmboxfeature.h
@@ -20,44 +20,46 @@ class BaseExternalPlaylistModel;
 class RhythmboxFeature : public BaseExternalLibraryFeature {
     Q_OBJECT
  public:
-    RhythmboxFeature(Library* pLibrary, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig);
-    virtual ~RhythmboxFeature();
-    static bool isSupported();
+   RhythmboxFeature(Library* pLibrary,
+           UserSettingsPointer pConfig,
+           KeyboardConfigPointer pKbdConfig);
+   virtual ~RhythmboxFeature();
+   static bool isSupported();
 
-    QVariant title();
+   QVariant title();
 
-    TreeItemModel* sidebarModel() const;
-    // processes the music collection
-    TreeItem* importMusicCollection();
-    // processes the playlist entries
-    TreeItem* importPlaylists();
+   TreeItemModel* sidebarModel() const;
+   // processes the music collection
+   TreeItem* importMusicCollection();
+   // processes the playlist entries
+   TreeItem* importPlaylists();
 
-  public slots:
-    void activate();
-    void activateChild(const QModelIndex& index);
-    void onTrackCollectionLoaded();
+ public slots:
+   void activate();
+   void activateChild(const QModelIndex& index);
+   void onTrackCollectionLoaded();
 
-  private:
-    virtual BaseSqlTableModel* getPlaylistModelForPlaylist(const QString& playlist);
-    // Removes all rows from a given table
-    void clearTable(const QString& table_name);
-    // reads the properties of a track and executes a SQL statement
-    void importTrack(QXmlStreamReader &xml, QSqlQuery &query);
-    // reads all playlist entries and executes a SQL statement
-    void importPlaylist(QXmlStreamReader &xml, QSqlQuery &query, int playlist_id);
+ private:
+   virtual BaseSqlTableModel* getPlaylistModelForPlaylist(const QString& playlist);
+   // Removes all rows from a given table
+   void clearTable(const QString& table_name);
+   // reads the properties of a track and executes a SQL statement
+   void importTrack(QXmlStreamReader& xml, QSqlQuery& query);
+   // reads all playlist entries and executes a SQL statement
+   void importPlaylist(QXmlStreamReader& xml, QSqlQuery& query, int playlist_id);
 
-    BaseExternalTrackModel* m_pRhythmboxTrackModel;
-    BaseExternalPlaylistModel* m_pRhythmboxPlaylistModel;
+   BaseExternalTrackModel* m_pRhythmboxTrackModel;
+   BaseExternalPlaylistModel* m_pRhythmboxPlaylistModel;
 
-    // new DB object because of threads
-    QSqlDatabase m_database;
-    bool m_isActivated;
-    QString m_title;
+   // new DB object because of threads
+   QSqlDatabase m_database;
+   bool m_isActivated;
+   QString m_title;
 
-    QFutureWatcher<TreeItem*> m_track_watcher;
-    QFuture<TreeItem*> m_track_future;
-    parented_ptr<TreeItemModel> m_pSidebarModel;
-    bool m_cancelImport;
+   QFutureWatcher<TreeItem*> m_track_watcher;
+   QFuture<TreeItem*> m_track_future;
+   parented_ptr<TreeItemModel> m_pSidebarModel;
+   bool m_cancelImport;
 
-    QSharedPointer<BaseTrackCache>  m_trackSource;
+   QSharedPointer<BaseTrackCache> m_trackSource;
 };

--- a/src/library/rhythmbox/rhythmboxfeature.h
+++ b/src/library/rhythmbox/rhythmboxfeature.h
@@ -10,6 +10,7 @@
 #include "library/baseexternallibraryfeature.h"
 #include "library/trackcollection.h"
 #include "library/treeitemmodel.h"
+#include "preferences/configobject.h"
 #include "util/parented_ptr.h"
 
 class BaseExternalTrackModel;
@@ -18,7 +19,7 @@ class BaseExternalPlaylistModel;
 class RhythmboxFeature : public BaseExternalLibraryFeature {
     Q_OBJECT
  public:
-    RhythmboxFeature(Library* pLibrary, UserSettingsPointer pConfig);
+    RhythmboxFeature(Library* pLibrary, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig);
     virtual ~RhythmboxFeature();
     static bool isSupported();
 

--- a/src/library/rhythmbox/rhythmboxfeature.h
+++ b/src/library/rhythmbox/rhythmboxfeature.h
@@ -11,6 +11,7 @@
 #include "library/trackcollection.h"
 #include "library/treeitemmodel.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "util/parented_ptr.h"
 
 class BaseExternalTrackModel;
@@ -19,7 +20,7 @@ class BaseExternalPlaylistModel;
 class RhythmboxFeature : public BaseExternalLibraryFeature {
     Q_OBJECT
  public:
-    RhythmboxFeature(Library* pLibrary, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig);
+    RhythmboxFeature(Library* pLibrary, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig);
     virtual ~RhythmboxFeature();
     static bool isSupported();
 

--- a/src/library/serato/seratofeature.cpp
+++ b/src/library/serato/seratofeature.cpp
@@ -13,6 +13,7 @@
 #include "library/trackcollectionmanager.h"
 #include "library/treeitem.h"
 #include "moc_seratofeature.cpp"
+#include "preferences/configobject.h"
 #include "track/cue.h"
 #include "track/keyfactory.h"
 #include "util/assert.h"
@@ -847,8 +848,9 @@ bool dropTable(QSqlDatabase& database, const QString& tableName) {
 
 SeratoFeature::SeratoFeature(
         Library* pLibrary,
-        UserSettingsPointer pConfig)
-        : BaseExternalLibraryFeature(pLibrary, pConfig, QStringLiteral("serato")),
+        UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig)
+        : BaseExternalLibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("serato")),
           m_pSidebarModel(make_parented<TreeItemModel>(this)) {
     QString idColumn = LIBRARYTABLE_ID;
     QStringList columns = {

--- a/src/library/serato/seratofeature.cpp
+++ b/src/library/serato/seratofeature.cpp
@@ -14,6 +14,7 @@
 #include "library/treeitem.h"
 #include "moc_seratofeature.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "track/cue.h"
 #include "track/keyfactory.h"
 #include "util/assert.h"
@@ -849,7 +850,7 @@ bool dropTable(QSqlDatabase& database, const QString& tableName) {
 SeratoFeature::SeratoFeature(
         Library* pLibrary,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig)
+        KeyboardConfigPointer pKbdConfig)
         : BaseExternalLibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("serato")),
           m_pSidebarModel(make_parented<TreeItemModel>(this)) {
     QString idColumn = LIBRARYTABLE_ID;

--- a/src/library/serato/seratofeature.h
+++ b/src/library/serato/seratofeature.h
@@ -21,12 +21,13 @@
 #include "library/baseexternaltrackmodel.h"
 #include "library/serato/seratoplaylistmodel.h"
 #include "library/treeitemmodel.h"
+#include "preferences/configobject.h"
 #include "util/parented_ptr.h"
 
 class SeratoFeature : public BaseExternalLibraryFeature {
     Q_OBJECT
   public:
-    SeratoFeature(Library* pLibrary, UserSettingsPointer pConfig);
+    SeratoFeature(Library* pLibrary, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig);
     ~SeratoFeature() override;
 
     QVariant title() override;

--- a/src/library/serato/seratofeature.h
+++ b/src/library/serato/seratofeature.h
@@ -22,12 +22,13 @@
 #include "library/serato/seratoplaylistmodel.h"
 #include "library/treeitemmodel.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "util/parented_ptr.h"
 
 class SeratoFeature : public BaseExternalLibraryFeature {
     Q_OBJECT
   public:
-    SeratoFeature(Library* pLibrary, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig);
+    SeratoFeature(Library* pLibrary, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig);
     ~SeratoFeature() override;
 
     QVariant title() override;

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -21,6 +21,7 @@
 #include "library/treeitemmodel.h"
 #include "moc_baseplaylistfeature.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "track/track.h"
 #include "track/trackid.h"
 #include "util/assert.h"
@@ -42,7 +43,7 @@ using namespace mixxx::library::prefs;
 BasePlaylistFeature::BasePlaylistFeature(
         Library* pLibrary,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig,
+        KeyboardConfigPointer pKbdConfig,
         PlaylistTableModel* pModel,
         const QString& rootViewName,
         const QString& iconName)

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -20,6 +20,7 @@
 #include "library/treeitem.h"
 #include "library/treeitemmodel.h"
 #include "moc_baseplaylistfeature.cpp"
+#include "preferences/configobject.h"
 #include "track/track.h"
 #include "track/trackid.h"
 #include "util/assert.h"
@@ -41,10 +42,11 @@ using namespace mixxx::library::prefs;
 BasePlaylistFeature::BasePlaylistFeature(
         Library* pLibrary,
         UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig,
         PlaylistTableModel* pModel,
         const QString& rootViewName,
         const QString& iconName)
-        : BaseTrackSetFeature(pLibrary, pConfig, rootViewName, iconName),
+        : BaseTrackSetFeature(pLibrary, pConfig, pKbdConfig, rootViewName, iconName),
           m_playlistDao(pLibrary->trackCollectionManager()
                                 ->internalCollection()
                                 ->getPlaylistDAO()),

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -13,6 +13,7 @@
 #include "library/dao/playlistdao.h"
 #include "library/trackset/basetracksetfeature.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "track/trackid.h"
 
 class WLibrary;
@@ -30,7 +31,7 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
   public:
     BasePlaylistFeature(Library* pLibrary,
             UserSettingsPointer pConfig,
-            ConfigObject<ConfigValueKbd>* pKbdConfig,
+            KeyboardConfigPointer pKbdConfig,
             PlaylistTableModel* pModel,
             const QString& rootViewName,
             const QString& iconName);

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -12,6 +12,7 @@
 
 #include "library/dao/playlistdao.h"
 #include "library/trackset/basetracksetfeature.h"
+#include "preferences/configobject.h"
 #include "track/trackid.h"
 
 class WLibrary;
@@ -29,6 +30,7 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
   public:
     BasePlaylistFeature(Library* pLibrary,
             UserSettingsPointer pConfig,
+            ConfigObject<ConfigValueKbd>* pKbdConfig,
             PlaylistTableModel* pModel,
             const QString& rootViewName,
             const QString& iconName);

--- a/src/library/trackset/basetracksetfeature.cpp
+++ b/src/library/trackset/basetracksetfeature.cpp
@@ -1,12 +1,13 @@
 #include "library/trackset/basetracksetfeature.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 
 #include "moc_basetracksetfeature.cpp"
 
 BaseTrackSetFeature::BaseTrackSetFeature(
         Library* pLibrary,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig,
+        KeyboardConfigPointer pKbdConfig,
         const QString& rootViewName,
         const QString& iconName)
         : LibraryFeature(pLibrary, pConfig, pKbdConfig, iconName),

--- a/src/library/trackset/basetracksetfeature.cpp
+++ b/src/library/trackset/basetracksetfeature.cpp
@@ -1,13 +1,15 @@
 #include "library/trackset/basetracksetfeature.h"
+#include "preferences/configobject.h"
 
 #include "moc_basetracksetfeature.cpp"
 
 BaseTrackSetFeature::BaseTrackSetFeature(
         Library* pLibrary,
         UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig,
         const QString& rootViewName,
         const QString& iconName)
-        : LibraryFeature(pLibrary, pConfig, iconName),
+        : LibraryFeature(pLibrary, pConfig, pKbdConfig, iconName),
           m_rootViewName(rootViewName),
           m_pSidebarModel(make_parented<TreeItemModel>(this)) {
 }

--- a/src/library/trackset/basetracksetfeature.cpp
+++ b/src/library/trackset/basetracksetfeature.cpp
@@ -1,8 +1,8 @@
 #include "library/trackset/basetracksetfeature.h"
-#include "preferences/configobject.h"
-#include "preferences/keyboardconfig.h"
 
 #include "moc_basetracksetfeature.cpp"
+#include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 
 BaseTrackSetFeature::BaseTrackSetFeature(
         Library* pLibrary,

--- a/src/library/trackset/basetracksetfeature.h
+++ b/src/library/trackset/basetracksetfeature.h
@@ -2,6 +2,7 @@
 
 #include "analyzer/analyzerscheduledtrack.h"
 #include "library/libraryfeature.h"
+#include "preferences/configobject.h"
 #include "util/parented_ptr.h"
 
 class BaseTrackSetFeature : public LibraryFeature {
@@ -10,6 +11,7 @@ class BaseTrackSetFeature : public LibraryFeature {
   public:
     BaseTrackSetFeature(Library* pLibrary,
             UserSettingsPointer pConfig,
+            ConfigObject<ConfigValueKbd>* pKbdConfig,
             const QString& rootViewName,
             const QString& iconName);
 

--- a/src/library/trackset/basetracksetfeature.h
+++ b/src/library/trackset/basetracksetfeature.h
@@ -3,6 +3,7 @@
 #include "analyzer/analyzerscheduledtrack.h"
 #include "library/libraryfeature.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "util/parented_ptr.h"
 
 class BaseTrackSetFeature : public LibraryFeature {
@@ -11,7 +12,7 @@ class BaseTrackSetFeature : public LibraryFeature {
   public:
     BaseTrackSetFeature(Library* pLibrary,
             UserSettingsPointer pConfig,
-            ConfigObject<ConfigValueKbd>* pKbdConfig,
+            KeyboardConfigPointer pKbdConfig,
             const QString& rootViewName,
             const QString& iconName);
 

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -21,6 +21,7 @@
 #include "library/treeitem.h"
 #include "moc_cratefeature.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "sources/soundsourceproxy.h"
 #include "track/track.h"
 #include "util/defs.h"
@@ -50,7 +51,7 @@ using namespace mixxx::library::prefs;
 
 CrateFeature::CrateFeature(Library* pLibrary,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig)
+        KeyboardConfigPointer pKbdConfig)
         : BaseTrackSetFeature(pLibrary, pConfig, pKbdConfig, "CRATEHOME", QStringLiteral("crates")),
           m_lockedCrateIcon(":/images/library/ic_library_locked_tracklist.svg"),
           m_pTrackCollection(pLibrary->trackCollectionManager()->internalCollection()),

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -20,6 +20,7 @@
 #include "library/trackset/crate/cratefeaturehelper.h"
 #include "library/treeitem.h"
 #include "moc_cratefeature.cpp"
+#include "preferences/configobject.h"
 #include "sources/soundsourceproxy.h"
 #include "track/track.h"
 #include "util/defs.h"
@@ -48,8 +49,9 @@ const ConfigKey kConfigKeyLastImportExportCrateDirectoryKey(
 using namespace mixxx::library::prefs;
 
 CrateFeature::CrateFeature(Library* pLibrary,
-        UserSettingsPointer pConfig)
-        : BaseTrackSetFeature(pLibrary, pConfig, "CRATEHOME", QStringLiteral("crates")),
+        UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig)
+        : BaseTrackSetFeature(pLibrary, pConfig, pKbdConfig, "CRATEHOME", QStringLiteral("crates")),
           m_lockedCrateIcon(":/images/library/ic_library_locked_tracklist.svg"),
           m_pTrackCollection(pLibrary->trackCollectionManager()->internalCollection()),
           m_crateTableModel(this, pLibrary->trackCollectionManager()) {

--- a/src/library/trackset/crate/cratefeature.h
+++ b/src/library/trackset/crate/cratefeature.h
@@ -13,6 +13,7 @@
 #include "library/trackset/crate/cratetablemodel.h"
 #include "library/treeitemmodel.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "preferences/usersettings.h"
 #include "track/trackid.h"
 #include "util/parented_ptr.h"
@@ -27,7 +28,7 @@ class CrateFeature : public BaseTrackSetFeature {
   public:
     CrateFeature(Library* pLibrary,
             UserSettingsPointer pConfig,
-            ConfigObject<ConfigValueKbd>* pKbdConfig);
+            KeyboardConfigPointer pKbdConfig);
     ~CrateFeature() override = default;
 
     QVariant title() override;

--- a/src/library/trackset/crate/cratefeature.h
+++ b/src/library/trackset/crate/cratefeature.h
@@ -12,6 +12,7 @@
 #include "library/trackset/crate/cratestorage.h"
 #include "library/trackset/crate/cratetablemodel.h"
 #include "library/treeitemmodel.h"
+#include "preferences/configobject.h"
 #include "preferences/usersettings.h"
 #include "track/trackid.h"
 #include "util/parented_ptr.h"
@@ -25,7 +26,8 @@ class CrateFeature : public BaseTrackSetFeature {
 
   public:
     CrateFeature(Library* pLibrary,
-            UserSettingsPointer pConfig);
+            UserSettingsPointer pConfig,
+            ConfigObject<ConfigValueKbd>* pKbdConfig);
     ~CrateFeature() override = default;
 
     QVariant title() override;

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -38,7 +38,9 @@ QString createPlaylistLabel(
 
 } // anonymous namespace
 
-PlaylistFeature::PlaylistFeature(Library* pLibrary, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig)
+PlaylistFeature::PlaylistFeature(Library* pLibrary,
+        UserSettingsPointer pConfig,
+        KeyboardConfigPointer pKbdConfig)
         : BasePlaylistFeature(pLibrary,
                   pConfig,
                   pKbdConfig,

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -13,6 +13,7 @@
 #include "library/trackcollectionmanager.h"
 #include "library/treeitem.h"
 #include "moc_playlistfeature.cpp"
+#include "preferences/configobject.h"
 #include "sources/soundsourceproxy.h"
 #include "util/db/dbconnection.h"
 #include "util/dnd.h"
@@ -36,9 +37,10 @@ QString createPlaylistLabel(
 
 } // anonymous namespace
 
-PlaylistFeature::PlaylistFeature(Library* pLibrary, UserSettingsPointer pConfig)
+PlaylistFeature::PlaylistFeature(Library* pLibrary, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig)
         : BasePlaylistFeature(pLibrary,
                   pConfig,
+                  pKbdConfig,
                   new PlaylistTableModel(nullptr,
                           pLibrary->trackCollectionManager(),
                           "mixxx.db.model.playlist"),

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -14,6 +14,7 @@
 #include "library/treeitem.h"
 #include "moc_playlistfeature.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "sources/soundsourceproxy.h"
 #include "util/db/dbconnection.h"
 #include "util/dnd.h"
@@ -37,7 +38,7 @@ QString createPlaylistLabel(
 
 } // anonymous namespace
 
-PlaylistFeature::PlaylistFeature(Library* pLibrary, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig)
+PlaylistFeature::PlaylistFeature(Library* pLibrary, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig)
         : BasePlaylistFeature(pLibrary,
                   pConfig,
                   pKbdConfig,

--- a/src/library/trackset/playlistfeature.h
+++ b/src/library/trackset/playlistfeature.h
@@ -9,6 +9,7 @@
 #include <QVariant>
 
 #include "library/trackset/baseplaylistfeature.h"
+#include "preferences/configobject.h"
 #include "preferences/usersettings.h"
 
 class TrackCollection;
@@ -21,7 +22,8 @@ class PlaylistFeature : public BasePlaylistFeature {
   public:
     PlaylistFeature(
             Library* pLibrary,
-            UserSettingsPointer pConfig);
+            UserSettingsPointer pConfig,
+            ConfigObject<ConfigValueKbd>* pKbdConfig);
     ~PlaylistFeature() override = default;
 
     QVariant title() override;

--- a/src/library/trackset/playlistfeature.h
+++ b/src/library/trackset/playlistfeature.h
@@ -10,6 +10,7 @@
 
 #include "library/trackset/baseplaylistfeature.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "preferences/usersettings.h"
 
 class TrackCollection;
@@ -23,7 +24,7 @@ class PlaylistFeature : public BasePlaylistFeature {
     PlaylistFeature(
             Library* pLibrary,
             UserSettingsPointer pConfig,
-            ConfigObject<ConfigValueKbd>* pKbdConfig);
+            KeyboardConfigPointer pKbdConfig);
     ~PlaylistFeature() override = default;
 
     QVariant title() override;

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -15,6 +15,7 @@
 #include "mixer/playerinfo.h"
 #include "mixer/playermanager.h"
 #include "moc_setlogfeature.cpp"
+#include "preferences/configobject.h"
 #include "track/track.h"
 #include "widget/wlibrary.h"
 #include "widget/wlibrarysidebar.h"
@@ -28,10 +29,12 @@ using namespace mixxx::library::prefs;
 
 SetlogFeature::SetlogFeature(
         Library* pLibrary,
-        UserSettingsPointer pConfig)
+        UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig)
         : BasePlaylistFeature(
                   pLibrary,
                   pConfig,
+                  pKbdConfig,
                   new PlaylistTableModel(
                           nullptr,
                           pLibrary->trackCollectionManager(),

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -16,6 +16,7 @@
 #include "mixer/playermanager.h"
 #include "moc_setlogfeature.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "track/track.h"
 #include "widget/wlibrary.h"
 #include "widget/wlibrarysidebar.h"
@@ -30,7 +31,7 @@ using namespace mixxx::library::prefs;
 SetlogFeature::SetlogFeature(
         Library* pLibrary,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig)
+        KeyboardConfigPointer pKbdConfig)
         : BasePlaylistFeature(
                   pLibrary,
                   pConfig,

--- a/src/library/trackset/setlogfeature.h
+++ b/src/library/trackset/setlogfeature.h
@@ -5,6 +5,7 @@
 #include <QSqlTableModel>
 
 #include "library/trackset/baseplaylistfeature.h"
+#include "preferences/configobject.h"
 #include "preferences/usersettings.h"
 
 class Library;
@@ -14,7 +15,8 @@ class SetlogFeature : public BasePlaylistFeature {
 
   public:
     SetlogFeature(Library* pLibrary,
-            UserSettingsPointer pConfig);
+            UserSettingsPointer pConfig,
+            ConfigObject<ConfigValueKbd>* pKbdConfig);
     virtual ~SetlogFeature();
 
     QVariant title() override;

--- a/src/library/trackset/setlogfeature.h
+++ b/src/library/trackset/setlogfeature.h
@@ -6,6 +6,7 @@
 
 #include "library/trackset/baseplaylistfeature.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "preferences/usersettings.h"
 
 class Library;
@@ -16,7 +17,7 @@ class SetlogFeature : public BasePlaylistFeature {
   public:
     SetlogFeature(Library* pLibrary,
             UserSettingsPointer pConfig,
-            ConfigObject<ConfigValueKbd>* pKbdConfig);
+            KeyboardConfigPointer pKbdConfig);
     virtual ~SetlogFeature();
 
     QVariant title() override;

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -17,6 +17,7 @@
 #include "library/treeitem.h"
 #include "moc_traktorfeature.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "track/keyutils.h"
 #include "util/sandbox.h"
 #include "util/semanticversion.h"
@@ -64,7 +65,7 @@ bool TraktorPlaylistModel::isColumnHiddenByDefault(int column) {
     return BaseSqlTableModel::isColumnHiddenByDefault(column);
 }
 
-TraktorFeature::TraktorFeature(Library* pLibrary, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig)
+TraktorFeature::TraktorFeature(Library* pLibrary, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig)
         : BaseExternalLibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("traktor")),
           m_pSidebarModel(make_parented<TreeItemModel>(this)),
           m_cancelImport(false) {

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -16,6 +16,7 @@
 #include "library/trackcollectionmanager.h"
 #include "library/treeitem.h"
 #include "moc_traktorfeature.cpp"
+#include "preferences/configobject.h"
 #include "track/keyutils.h"
 #include "util/sandbox.h"
 #include "util/semanticversion.h"
@@ -63,8 +64,8 @@ bool TraktorPlaylistModel::isColumnHiddenByDefault(int column) {
     return BaseSqlTableModel::isColumnHiddenByDefault(column);
 }
 
-TraktorFeature::TraktorFeature(Library* pLibrary, UserSettingsPointer pConfig)
-        : BaseExternalLibraryFeature(pLibrary, pConfig, QStringLiteral("traktor")),
+TraktorFeature::TraktorFeature(Library* pLibrary, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig)
+        : BaseExternalLibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("traktor")),
           m_pSidebarModel(make_parented<TreeItemModel>(this)),
           m_cancelImport(false) {
     QString tableName = "traktor_library";

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -65,8 +65,11 @@ bool TraktorPlaylistModel::isColumnHiddenByDefault(int column) {
     return BaseSqlTableModel::isColumnHiddenByDefault(column);
 }
 
-TraktorFeature::TraktorFeature(Library* pLibrary, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig)
-        : BaseExternalLibraryFeature(pLibrary, pConfig, pKbdConfig, QStringLiteral("traktor")),
+TraktorFeature::TraktorFeature(Library* pLibrary,
+        UserSettingsPointer pConfig,
+        KeyboardConfigPointer pKbdConfig)
+        : BaseExternalLibraryFeature(
+                  pLibrary, pConfig, pKbdConfig, QStringLiteral("traktor")),
           m_pSidebarModel(make_parented<TreeItemModel>(this)),
           m_cancelImport(false) {
     QString tableName = "traktor_library";

--- a/src/library/traktor/traktorfeature.h
+++ b/src/library/traktor/traktorfeature.h
@@ -12,6 +12,7 @@
 #include "library/baseexternalplaylistmodel.h"
 #include "library/treeitemmodel.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 
 class TraktorTrackModel : public BaseExternalTrackModel {
     Q_OBJECT
@@ -34,7 +35,7 @@ class TraktorPlaylistModel : public BaseExternalPlaylistModel {
 class TraktorFeature : public BaseExternalLibraryFeature {
     Q_OBJECT
   public:
-    TraktorFeature(Library* pLibrary, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig);
+    TraktorFeature(Library* pLibrary, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig);
     virtual ~TraktorFeature();
 
     QVariant title() override;

--- a/src/library/traktor/traktorfeature.h
+++ b/src/library/traktor/traktorfeature.h
@@ -11,6 +11,7 @@
 #include "library/baseexternaltrackmodel.h"
 #include "library/baseexternalplaylistmodel.h"
 #include "library/treeitemmodel.h"
+#include "preferences/configobject.h"
 
 class TraktorTrackModel : public BaseExternalTrackModel {
     Q_OBJECT
@@ -33,7 +34,7 @@ class TraktorPlaylistModel : public BaseExternalPlaylistModel {
 class TraktorFeature : public BaseExternalLibraryFeature {
     Q_OBJECT
   public:
-    TraktorFeature(Library* pLibrary, UserSettingsPointer pConfig);
+    TraktorFeature(Library* pLibrary, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig);
     virtual ~TraktorFeature();
 
     QVariant title() override;

--- a/src/library/traktor/traktorfeature.h
+++ b/src/library/traktor/traktorfeature.h
@@ -1,15 +1,15 @@
 #pragma once
 
-#include <QStringListModel>
-#include <QtSql>
-#include <QXmlStreamReader>
 #include <QFuture>
-#include <QtConcurrentRun>
 #include <QFutureWatcher>
+#include <QStringListModel>
+#include <QXmlStreamReader>
+#include <QtConcurrentRun>
+#include <QtSql>
 
 #include "library/baseexternallibraryfeature.h"
-#include "library/baseexternaltrackmodel.h"
 #include "library/baseexternalplaylistmodel.h"
+#include "library/baseexternaltrackmodel.h"
 #include "library/treeitemmodel.h"
 #include "preferences/configobject.h"
 #include "preferences/keyboardconfig.h"
@@ -35,7 +35,9 @@ class TraktorPlaylistModel : public BaseExternalPlaylistModel {
 class TraktorFeature : public BaseExternalLibraryFeature {
     Q_OBJECT
   public:
-    TraktorFeature(Library* pLibrary, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig);
+    TraktorFeature(Library* pLibrary,
+            UserSettingsPointer pConfig,
+            KeyboardConfigPointer pKbdConfig);
     virtual ~TraktorFeature();
 
     QVariant title() override;

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -85,7 +85,9 @@ MixxxMainWindow::MixxxMainWindow(std::shared_ptr<mixxx::CoreServices> pCoreServi
     initializeWindow();
 
     // Show launch image immediately so the user knows Mixxx is starting
-    m_pSkinLoader = std::make_unique<mixxx::skin::SkinLoader>(m_pCoreServices->getSettings(), m_pCoreServices->getKeyboardConfig());
+    m_pSkinLoader = std::make_unique<mixxx::skin::SkinLoader>(
+            m_pCoreServices->getSettings(),
+            m_pCoreServices->getKeyboardConfig());
     m_pLaunchImage = m_pSkinLoader->loadLaunchImage(this);
     m_pCentralWidget = (QWidget*)m_pLaunchImage;
     setCentralWidget(m_pCentralWidget);

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -85,7 +85,7 @@ MixxxMainWindow::MixxxMainWindow(std::shared_ptr<mixxx::CoreServices> pCoreServi
     initializeWindow();
 
     // Show launch image immediately so the user knows Mixxx is starting
-    m_pSkinLoader = std::make_unique<mixxx::skin::SkinLoader>(m_pCoreServices->getSettings(), m_pCoreServices->getKeyboardConfig().get());
+    m_pSkinLoader = std::make_unique<mixxx::skin::SkinLoader>(m_pCoreServices->getSettings(), m_pCoreServices->getKeyboardConfig());
     m_pLaunchImage = m_pSkinLoader->loadLaunchImage(this);
     m_pCentralWidget = (QWidget*)m_pLaunchImage;
     setCentralWidget(m_pCentralWidget);
@@ -611,7 +611,7 @@ void MixxxMainWindow::createMenuBar() {
     ScopedTimer t("MixxxMainWindow::createMenuBar");
     DEBUG_ASSERT(m_pCoreServices->getKeyboardConfig());
     m_pMenuBar = make_parented<WMainMenuBar>(
-            this, m_pCoreServices->getSettings(), m_pCoreServices->getKeyboardConfig().get());
+            this, m_pCoreServices->getSettings(), m_pCoreServices->getKeyboardConfig());
     if (m_pCentralWidget) {
         m_pMenuBar->setStyleSheet(m_pCentralWidget->styleSheet());
     }

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -85,7 +85,7 @@ MixxxMainWindow::MixxxMainWindow(std::shared_ptr<mixxx::CoreServices> pCoreServi
     initializeWindow();
 
     // Show launch image immediately so the user knows Mixxx is starting
-    m_pSkinLoader = std::make_unique<mixxx::skin::SkinLoader>(m_pCoreServices->getSettings());
+    m_pSkinLoader = std::make_unique<mixxx::skin::SkinLoader>(m_pCoreServices->getSettings(), m_pCoreServices->getKeyboardConfig().get());
     m_pLaunchImage = m_pSkinLoader->loadLaunchImage(this);
     m_pCentralWidget = (QWidget*)m_pLaunchImage;
     setCentralWidget(m_pCentralWidget);

--- a/src/preferences/keyboardconfig.h
+++ b/src/preferences/keyboardconfig.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <memory>
+
+#include "preferences/configobject.h"
+
+typedef ConfigObject<ConfigValueKbd> KeyboardConfig;
+typedef std::shared_ptr<KeyboardConfig> KeyboardConfigPointer;

--- a/src/preferences/keyboardconfig.h
+++ b/src/preferences/keyboardconfig.h
@@ -4,5 +4,5 @@
 
 #include "preferences/configobject.h"
 
-typedef ConfigObject<ConfigValueKbd> KeyboardConfig;
-typedef std::shared_ptr<KeyboardConfig> KeyboardConfigPointer;
+using KeyboardConfig = ConfigObject<ConfigValueKbd>;
+using KeyboardConfigPointer = std::shared_ptr<KeyboardConfig>;

--- a/src/skin/legacy/legacyskin.cpp
+++ b/src/skin/legacy/legacyskin.cpp
@@ -118,7 +118,9 @@ bool LegacySkin::fitsScreenSize(const QScreen& screen) const {
             skinHeight.toInt() <= screenSize.height();
 }
 
-LaunchImage* LegacySkin::loadLaunchImage(QWidget* pParent, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig) const {
+LaunchImage* LegacySkin::loadLaunchImage(QWidget* pParent,
+        UserSettingsPointer pConfig,
+        KeyboardConfigPointer pKbdConfig) const {
     VERIFY_OR_DEBUG_ASSERT(isValid()) {
         return nullptr;
     }

--- a/src/skin/legacy/legacyskin.cpp
+++ b/src/skin/legacy/legacyskin.cpp
@@ -3,6 +3,7 @@
 #include <QRegularExpression>
 
 #include "coreservices.h"
+#include "preferences/configobject.h"
 #include "skin/legacy/legacyskinparser.h"
 
 namespace {
@@ -116,23 +117,25 @@ bool LegacySkin::fitsScreenSize(const QScreen& screen) const {
             skinHeight.toInt() <= screenSize.height();
 }
 
-LaunchImage* LegacySkin::loadLaunchImage(QWidget* pParent, UserSettingsPointer pConfig) const {
+LaunchImage* LegacySkin::loadLaunchImage(QWidget* pParent, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig) const {
     VERIFY_OR_DEBUG_ASSERT(isValid()) {
         return nullptr;
     }
-    LegacySkinParser parser(pConfig);
+    LegacySkinParser parser(pConfig, pKbdConfig);
     LaunchImage* pLaunchImage = parser.parseLaunchImage(m_path.absoluteFilePath(), pParent);
     return pLaunchImage;
 }
 
 QWidget* LegacySkin::loadSkin(QWidget* pParent,
         UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig,
         QSet<ControlObject*>* pSkinCreatedControls,
         mixxx::CoreServices* pCoreServices) const {
     VERIFY_OR_DEBUG_ASSERT(isValid()) {
         return nullptr;
     }
     LegacySkinParser legacy(pConfig,
+            pKbdConfig,
             pSkinCreatedControls,
             pCoreServices->getKeyboardEventFilter().get(),
             pCoreServices->getPlayerManager().get(),

--- a/src/skin/legacy/legacyskin.cpp
+++ b/src/skin/legacy/legacyskin.cpp
@@ -4,6 +4,7 @@
 
 #include "coreservices.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "skin/legacy/legacyskinparser.h"
 
 namespace {
@@ -117,7 +118,7 @@ bool LegacySkin::fitsScreenSize(const QScreen& screen) const {
             skinHeight.toInt() <= screenSize.height();
 }
 
-LaunchImage* LegacySkin::loadLaunchImage(QWidget* pParent, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig) const {
+LaunchImage* LegacySkin::loadLaunchImage(QWidget* pParent, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig) const {
     VERIFY_OR_DEBUG_ASSERT(isValid()) {
         return nullptr;
     }
@@ -128,7 +129,7 @@ LaunchImage* LegacySkin::loadLaunchImage(QWidget* pParent, UserSettingsPointer p
 
 QWidget* LegacySkin::loadSkin(QWidget* pParent,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig,
+        KeyboardConfigPointer pKbdConfig,
         QSet<ControlObject*>* pSkinCreatedControls,
         mixxx::CoreServices* pCoreServices) const {
     VERIFY_OR_DEBUG_ASSERT(isValid()) {

--- a/src/skin/legacy/legacyskin.h
+++ b/src/skin/legacy/legacyskin.h
@@ -8,6 +8,7 @@
 #include <QString>
 
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "skin/skin.h"
 
 namespace mixxx {
@@ -33,10 +34,10 @@ class LegacySkin : public mixxx::skin::Skin {
     QList<QString> colorschemes() const override;
 
     bool fitsScreenSize(const QScreen& screen) const override;
-    LaunchImage* loadLaunchImage(QWidget* pParent, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig) const override;
+    LaunchImage* loadLaunchImage(QWidget* pParent, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig) const override;
     QWidget* loadSkin(QWidget* pParent,
             UserSettingsPointer pConfig,
-            ConfigObject<ConfigValueKbd>* pKbdConfig,
+            KeyboardConfigPointer pKbdConfig,
             QSet<ControlObject*>* pSkinCreatedControls,
             mixxx::CoreServices* pCoreServices) const override;
 

--- a/src/skin/legacy/legacyskin.h
+++ b/src/skin/legacy/legacyskin.h
@@ -34,7 +34,9 @@ class LegacySkin : public mixxx::skin::Skin {
     QList<QString> colorschemes() const override;
 
     bool fitsScreenSize(const QScreen& screen) const override;
-    LaunchImage* loadLaunchImage(QWidget* pParent, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig) const override;
+    LaunchImage* loadLaunchImage(QWidget* pParent,
+            UserSettingsPointer pConfig,
+            KeyboardConfigPointer pKbdConfig) const override;
     QWidget* loadSkin(QWidget* pParent,
             UserSettingsPointer pConfig,
             KeyboardConfigPointer pKbdConfig,

--- a/src/skin/legacy/legacyskin.h
+++ b/src/skin/legacy/legacyskin.h
@@ -7,6 +7,7 @@
 #include <QScreen>
 #include <QString>
 
+#include "preferences/configobject.h"
 #include "skin/skin.h"
 
 namespace mixxx {
@@ -32,9 +33,10 @@ class LegacySkin : public mixxx::skin::Skin {
     QList<QString> colorschemes() const override;
 
     bool fitsScreenSize(const QScreen& screen) const override;
-    LaunchImage* loadLaunchImage(QWidget* pParent, UserSettingsPointer pConfig) const override;
+    LaunchImage* loadLaunchImage(QWidget* pParent, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig) const override;
     QWidget* loadSkin(QWidget* pParent,
             UserSettingsPointer pConfig,
+            ConfigObject<ConfigValueKbd>* pKbdConfig,
             QSet<ControlObject*>* pSkinCreatedControls,
             mixxx::CoreServices* pCoreServices) const override;
 

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -21,6 +21,7 @@
 #include "mixer/playermanager.h"
 #include "moc_legacyskinparser.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "recording/recordingmanager.h"
 #include "skin/legacy/colorschemeparser.h"
 #include "skin/legacy/launchimage.h"
@@ -161,7 +162,7 @@ ControlObject* LegacySkinParser::controlFromConfigNode(const QDomElement& elemen
     return controlFromConfigKey(key, bPersist, pCreated);
 }
 
-LegacySkinParser::LegacySkinParser(UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig)
+LegacySkinParser::LegacySkinParser(UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig)
         : m_pConfig(pConfig),
           m_pKbdConfig(pKbdConfig),
           m_pSkinCreatedControls(nullptr),
@@ -176,7 +177,7 @@ LegacySkinParser::LegacySkinParser(UserSettingsPointer pConfig, ConfigObject<Con
 }
 
 LegacySkinParser::LegacySkinParser(UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig,
+        KeyboardConfigPointer pKbdConfig,
         QSet<ControlObject*>* pSkinCreatedControls,
         KeyboardEventFilter* pKeyboard,
         PlayerManager* pPlayerManager,

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -20,6 +20,7 @@
 #include "mixer/basetrackplayer.h"
 #include "mixer/playermanager.h"
 #include "moc_legacyskinparser.cpp"
+#include "preferences/configobject.h"
 #include "recording/recordingmanager.h"
 #include "skin/legacy/colorschemeparser.h"
 #include "skin/legacy/launchimage.h"
@@ -160,8 +161,9 @@ ControlObject* LegacySkinParser::controlFromConfigNode(const QDomElement& elemen
     return controlFromConfigKey(key, bPersist, pCreated);
 }
 
-LegacySkinParser::LegacySkinParser(UserSettingsPointer pConfig)
+LegacySkinParser::LegacySkinParser(UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig)
         : m_pConfig(pConfig),
+          m_pKbdConfig(pKbdConfig),
           m_pSkinCreatedControls(nullptr),
           m_pKeyboard(nullptr),
           m_pPlayerManager(nullptr),
@@ -174,6 +176,7 @@ LegacySkinParser::LegacySkinParser(UserSettingsPointer pConfig)
 }
 
 LegacySkinParser::LegacySkinParser(UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig,
         QSet<ControlObject*>* pSkinCreatedControls,
         KeyboardEventFilter* pKeyboard,
         PlayerManager* pPlayerManager,
@@ -183,6 +186,7 @@ LegacySkinParser::LegacySkinParser(UserSettingsPointer pConfig,
         EffectsManager* pEffectsManager,
         RecordingManager* pRecordingManager)
         : m_pConfig(pConfig),
+          m_pKbdConfig(pKbdConfig),
           m_pSkinCreatedControls(pSkinCreatedControls),
           m_pKeyboard(pKeyboard),
           m_pPlayerManager(pPlayerManager),
@@ -1053,6 +1057,7 @@ QWidget* LegacySkinParser::parseText(const QDomElement& node) {
 
     WTrackText* pTrackText = new WTrackText(m_pParent,
             m_pConfig,
+            m_pKbdConfig,
             m_pLibrary,
             group);
     setupLabelWidget(node, pTrackText);
@@ -1084,6 +1089,7 @@ QWidget* LegacySkinParser::parseTrackProperty(const QDomElement& node) {
     WTrackProperty* pTrackProperty = new WTrackProperty(
             m_pParent,
             m_pConfig,
+            m_pKbdConfig,
             m_pLibrary,
             group);
     setupLabelWidget(node, pTrackProperty);
@@ -1124,6 +1130,7 @@ QWidget* LegacySkinParser::parseTrackWidgetGroup(const QDomElement& node) {
     WTrackWidgetGroup* pGroup = new WTrackWidgetGroup(
             m_pParent,
             m_pConfig,
+            m_pKbdConfig,
             m_pLibrary,
             group);
     commonWidgetSetup(node, pGroup);

--- a/src/skin/legacy/legacyskinparser.h
+++ b/src/skin/legacy/legacyskinparser.h
@@ -7,6 +7,7 @@
 #include <QString>
 
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "preferences/usersettings.h"
 #include "proto/skin.pb.h"
 #include "skin/legacy/skinparser.h"
@@ -30,9 +31,9 @@ class WWidgetGroup;
 class LegacySkinParser : public QObject, public SkinParser {
     Q_OBJECT
   public:
-    LegacySkinParser(UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig);
+    LegacySkinParser(UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig);
     LegacySkinParser(UserSettingsPointer pConfig,
-            ConfigObject<ConfigValueKbd>* pKbdConfig,
+            KeyboardConfigPointer pKbdConfig,
             QSet<ControlObject*>* pSkinCreatedControls,
             KeyboardEventFilter* pKeyboard,
             PlayerManager* pPlayerManager,
@@ -152,7 +153,7 @@ class LegacySkinParser : public QObject, public SkinParser {
     void parseChildren(const QDomElement& node, WWidgetGroup* pGroup);
 
     UserSettingsPointer m_pConfig;
-    ConfigObject<ConfigValueKbd>* m_pKbdConfig;
+    const KeyboardConfigPointer m_pKbdConfig;
     QSet<ControlObject*>* m_pSkinCreatedControls;
     KeyboardEventFilter* m_pKeyboard;
     PlayerManager* m_pPlayerManager;

--- a/src/skin/legacy/legacyskinparser.h
+++ b/src/skin/legacy/legacyskinparser.h
@@ -6,6 +6,7 @@
 #include <QSet>
 #include <QString>
 
+#include "preferences/configobject.h"
 #include "preferences/usersettings.h"
 #include "proto/skin.pb.h"
 #include "skin/legacy/skinparser.h"
@@ -29,8 +30,9 @@ class WWidgetGroup;
 class LegacySkinParser : public QObject, public SkinParser {
     Q_OBJECT
   public:
-    LegacySkinParser(UserSettingsPointer pConfig);
+    LegacySkinParser(UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig);
     LegacySkinParser(UserSettingsPointer pConfig,
+            ConfigObject<ConfigValueKbd>* pKbdConfig,
             QSet<ControlObject*>* pSkinCreatedControls,
             KeyboardEventFilter* pKeyboard,
             PlayerManager* pPlayerManager,
@@ -150,6 +152,7 @@ class LegacySkinParser : public QObject, public SkinParser {
     void parseChildren(const QDomElement& node, WWidgetGroup* pGroup);
 
     UserSettingsPointer m_pConfig;
+    ConfigObject<ConfigValueKbd>* m_pKbdConfig;
     QSet<ControlObject*>* m_pSkinCreatedControls;
     KeyboardEventFilter* m_pKeyboard;
     PlayerManager* m_pPlayerManager;

--- a/src/skin/skin.h
+++ b/src/skin/skin.h
@@ -10,6 +10,7 @@
 #include <memory>
 
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "preferences/usersettings.h"
 
 class ControlObject;
@@ -42,10 +43,10 @@ class Skin {
 
     virtual bool fitsScreenSize(const QScreen& screen) const = 0;
 
-    virtual LaunchImage* loadLaunchImage(QWidget* pParent, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig) const = 0;
+    virtual LaunchImage* loadLaunchImage(QWidget* pParent, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig) const = 0;
     virtual QWidget* loadSkin(QWidget* pParent,
             UserSettingsPointer pConfig,
-            ConfigObject<ConfigValueKbd>* pKbdConfig,
+            KeyboardConfigPointer pKbdConfig,
             QSet<ControlObject*>* pSkinCreatedControls,
             mixxx::CoreServices* pCoreServices) const = 0;
 };

--- a/src/skin/skin.h
+++ b/src/skin/skin.h
@@ -43,7 +43,9 @@ class Skin {
 
     virtual bool fitsScreenSize(const QScreen& screen) const = 0;
 
-    virtual LaunchImage* loadLaunchImage(QWidget* pParent, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig) const = 0;
+    virtual LaunchImage* loadLaunchImage(QWidget* pParent,
+            UserSettingsPointer pConfig,
+            KeyboardConfigPointer pKbdConfig) const = 0;
     virtual QWidget* loadSkin(QWidget* pParent,
             UserSettingsPointer pConfig,
             KeyboardConfigPointer pKbdConfig,

--- a/src/skin/skin.h
+++ b/src/skin/skin.h
@@ -9,6 +9,7 @@
 #include <QWidget>
 #include <memory>
 
+#include "preferences/configobject.h"
 #include "preferences/usersettings.h"
 
 class ControlObject;
@@ -41,9 +42,10 @@ class Skin {
 
     virtual bool fitsScreenSize(const QScreen& screen) const = 0;
 
-    virtual LaunchImage* loadLaunchImage(QWidget* pParent, UserSettingsPointer pConfig) const = 0;
+    virtual LaunchImage* loadLaunchImage(QWidget* pParent, UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig) const = 0;
     virtual QWidget* loadSkin(QWidget* pParent,
             UserSettingsPointer pConfig,
+            ConfigObject<ConfigValueKbd>* pKbdConfig,
             QSet<ControlObject*>* pSkinCreatedControls,
             mixxx::CoreServices* pCoreServices) const = 0;
 };

--- a/src/skin/skinloader.cpp
+++ b/src/skin/skinloader.cpp
@@ -11,6 +11,7 @@
 #include "effects/effectsmanager.h"
 #include "library/library.h"
 #include "mixer/playermanager.h"
+#include "preferences/configobject.h"
 #include "recording/recordingmanager.h"
 #include "skin/legacy/launchimage.h"
 #include "skin/legacy/legacyskin.h"
@@ -24,8 +25,9 @@ namespace skin {
 
 using legacy::LegacySkin;
 
-SkinLoader::SkinLoader(UserSettingsPointer pConfig)
+SkinLoader::SkinLoader(UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig)
         : m_pConfig(pConfig),
+          m_pKbdConfig(pKbdConfig),
           m_spinnyCoverControlsCreated(false),
           m_micDuckingControlsCreated(false),
           m_numMicsEnabled(1) {
@@ -157,7 +159,7 @@ QWidget* SkinLoader::loadConfiguredSkin(QWidget* pParent,
     // the skin was loaded.
     setupMicDuckingControls();
 
-    QWidget* pLoadedSkin = pSkin->loadSkin(pParent, m_pConfig, pSkinCreatedControls, pCoreServices);
+    QWidget* pLoadedSkin = pSkin->loadSkin(pParent, m_pConfig, m_pKbdConfig, pSkinCreatedControls, pCoreServices);
 
     // If the skin exists but failed to load, try to fall back to the default skin.
     if (pLoadedSkin == nullptr) {
@@ -178,7 +180,7 @@ QWidget* SkinLoader::loadConfiguredSkin(QWidget* pParent,
             }
 
             // This might also fail, but
-            pLoadedSkin = pSkin->loadSkin(pParent, m_pConfig, pSkinCreatedControls, pCoreServices);
+            pLoadedSkin = pSkin->loadSkin(pParent, m_pConfig, m_pKbdConfig, pSkinCreatedControls, pCoreServices);
         }
         DEBUG_ASSERT(pLoadedSkin);
     }
@@ -195,7 +197,7 @@ LaunchImage* SkinLoader::loadLaunchImage(QWidget* pParent) const {
         return nullptr;
     }
 
-    LaunchImage* pLaunchImage = pSkin->loadLaunchImage(pParent, m_pConfig);
+    LaunchImage* pLaunchImage = pSkin->loadLaunchImage(pParent, m_pConfig, m_pKbdConfig);
     if (pLaunchImage == nullptr) {
         // Construct default LaunchImage
         pLaunchImage = new LaunchImage(pParent, QString());

--- a/src/skin/skinloader.cpp
+++ b/src/skin/skinloader.cpp
@@ -160,7 +160,11 @@ QWidget* SkinLoader::loadConfiguredSkin(QWidget* pParent,
     // the skin was loaded.
     setupMicDuckingControls();
 
-    QWidget* pLoadedSkin = pSkin->loadSkin(pParent, m_pConfig, m_pKbdConfig, pSkinCreatedControls, pCoreServices);
+    QWidget* pLoadedSkin = pSkin->loadSkin(pParent,
+            m_pConfig,
+            m_pKbdConfig,
+            pSkinCreatedControls,
+            pCoreServices);
 
     // If the skin exists but failed to load, try to fall back to the default skin.
     if (pLoadedSkin == nullptr) {
@@ -181,7 +185,11 @@ QWidget* SkinLoader::loadConfiguredSkin(QWidget* pParent,
             }
 
             // This might also fail, but
-            pLoadedSkin = pSkin->loadSkin(pParent, m_pConfig, m_pKbdConfig, pSkinCreatedControls, pCoreServices);
+            pLoadedSkin = pSkin->loadSkin(pParent,
+                    m_pConfig,
+                    m_pKbdConfig,
+                    pSkinCreatedControls,
+                    pCoreServices);
         }
         DEBUG_ASSERT(pLoadedSkin);
     }

--- a/src/skin/skinloader.cpp
+++ b/src/skin/skinloader.cpp
@@ -12,6 +12,7 @@
 #include "library/library.h"
 #include "mixer/playermanager.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "recording/recordingmanager.h"
 #include "skin/legacy/launchimage.h"
 #include "skin/legacy/legacyskin.h"
@@ -25,7 +26,7 @@ namespace skin {
 
 using legacy::LegacySkin;
 
-SkinLoader::SkinLoader(UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig)
+SkinLoader::SkinLoader(UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig)
         : m_pConfig(pConfig),
           m_pKbdConfig(pKbdConfig),
           m_spinnyCoverControlsCreated(false),

--- a/src/skin/skinloader.h
+++ b/src/skin/skinloader.h
@@ -6,6 +6,7 @@
 #include <QSet>
 #include <QWidget>
 
+#include "preferences/configobject.h"
 #include "preferences/usersettings.h"
 #include "skin/skin.h"
 #include "util/parented_ptr.h"
@@ -19,7 +20,7 @@ namespace skin {
 class SkinLoader : public QObject {
     Q_OBJECT
   public:
-    SkinLoader(UserSettingsPointer pConfig);
+    SkinLoader(UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig);
     virtual ~SkinLoader();
 
     QWidget* loadConfiguredSkin(QWidget* pParent,
@@ -42,6 +43,7 @@ class SkinLoader : public QObject {
     SkinPointer skinFromDirectory(const QDir& dir) const;
 
     UserSettingsPointer m_pConfig;
+    ConfigObject<ConfigValueKbd>* m_pKbdConfig;
 
     bool m_spinnyCoverControlsCreated;
     void setupSpinnyCoverControls();

--- a/src/skin/skinloader.h
+++ b/src/skin/skinloader.h
@@ -7,6 +7,7 @@
 #include <QWidget>
 
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "preferences/usersettings.h"
 #include "skin/skin.h"
 #include "util/parented_ptr.h"
@@ -20,7 +21,7 @@ namespace skin {
 class SkinLoader : public QObject {
     Q_OBJECT
   public:
-    SkinLoader(UserSettingsPointer pConfig, ConfigObject<ConfigValueKbd>* pKbdConfig);
+    SkinLoader(UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig);
     virtual ~SkinLoader();
 
     QWidget* loadConfiguredSkin(QWidget* pParent,
@@ -43,7 +44,7 @@ class SkinLoader : public QObject {
     SkinPointer skinFromDirectory(const QDir& dir) const;
 
     UserSettingsPointer m_pConfig;
-    ConfigObject<ConfigValueKbd>* m_pKbdConfig;
+    const KeyboardConfigPointer m_pKbdConfig;
 
     bool m_spinnyCoverControlsCreated;
     void setupSpinnyCoverControls();

--- a/src/test/mixxxtest.cpp
+++ b/src/test/mixxxtest.cpp
@@ -4,6 +4,7 @@
 
 #include "control/control.h"
 #include "library/coverartutils.h"
+#include "preferences/configobject.h"
 #include "util/cmdlineargs.h"
 #include "util/logging.h"
 
@@ -57,6 +58,8 @@ MixxxTest::MixxxTest() {
     DEBUG_ASSERT(m_testDataDir.isValid());
     m_pConfig = UserSettingsPointer(new UserSettings(
             makeTestConfigFile(getTestDataDir().filePath("test.cfg"))));
+    m_pKbdConfig = new ConfigObject<ConfigValueKbd>(
+            makeTestConfigFile(getTestDataDir().filePath("testKbd.cfg")));
     ControlDoublePrivate::setUserConfig(m_pConfig);
 }
 
@@ -73,6 +76,9 @@ void MixxxTest::saveAndReloadConfig() {
     m_pConfig->save();
     m_pConfig = UserSettingsPointer(
             new UserSettings(getTestDataDir().filePath("test.cfg")));
+    m_pKbdConfig->save();
+    m_pKbdConfig = new ConfigObject<ConfigValueKbd>(
+            makeTestConfigFile(getTestDataDir().filePath("testKbd.cfg")));
     ControlDoublePrivate::setUserConfig(m_pConfig);
 }
 

--- a/src/test/mixxxtest.cpp
+++ b/src/test/mixxxtest.cpp
@@ -5,6 +5,7 @@
 #include "control/control.h"
 #include "library/coverartutils.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "util/cmdlineargs.h"
 #include "util/logging.h"
 
@@ -58,8 +59,8 @@ MixxxTest::MixxxTest() {
     DEBUG_ASSERT(m_testDataDir.isValid());
     m_pConfig = UserSettingsPointer(new UserSettings(
             makeTestConfigFile(getTestDataDir().filePath("test.cfg"))));
-    m_pKbdConfig = new ConfigObject<ConfigValueKbd>(
-            makeTestConfigFile(getTestDataDir().filePath("testKbd.cfg")));
+    m_pKbdConfig = KeyboardConfigPointer(new KeyboardConfig(
+            makeTestConfigFile(getTestDataDir().filePath("testKbd.cfg"))));
     ControlDoublePrivate::setUserConfig(m_pConfig);
 }
 
@@ -77,8 +78,8 @@ void MixxxTest::saveAndReloadConfig() {
     m_pConfig = UserSettingsPointer(
             new UserSettings(getTestDataDir().filePath("test.cfg")));
     m_pKbdConfig->save();
-    m_pKbdConfig = new ConfigObject<ConfigValueKbd>(
-            makeTestConfigFile(getTestDataDir().filePath("testKbd.cfg")));
+    m_pKbdConfig = KeyboardConfigPointer(new KeyboardConfig(
+            makeTestConfigFile(getTestDataDir().filePath("testKbd.cfg"))));
     ControlDoublePrivate::setUserConfig(m_pConfig);
 }
 

--- a/src/test/mixxxtest.h
+++ b/src/test/mixxxtest.h
@@ -8,6 +8,7 @@
 
 #include "mixxxapplication.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "preferences/usersettings.h"
 
 #define EXPECT_QSTRING_EQ(expected, test) EXPECT_STREQ(qPrintable(expected), qPrintable(test))
@@ -74,7 +75,7 @@ class MixxxTest : public testing::Test {
 
   protected:
     UserSettingsPointer m_pConfig;
-    ConfigObject<ConfigValueKbd>* m_pKbdConfig;
+    KeyboardConfigPointer m_pKbdConfig;
 };
 
 namespace mixxxtest {

--- a/src/test/mixxxtest.h
+++ b/src/test/mixxxtest.h
@@ -7,6 +7,7 @@
 #include <QTemporaryDir>
 
 #include "mixxxapplication.h"
+#include "preferences/configobject.h"
 #include "preferences/usersettings.h"
 
 #define EXPECT_QSTRING_EQ(expected, test) EXPECT_STREQ(qPrintable(expected), qPrintable(test))
@@ -73,6 +74,7 @@ class MixxxTest : public testing::Test {
 
   protected:
     UserSettingsPointer m_pConfig;
+    ConfigObject<ConfigValueKbd>* m_pKbdConfig;
 };
 
 namespace mixxxtest {

--- a/src/test/playermanagertest.cpp
+++ b/src/test/playermanagertest.cpp
@@ -75,6 +75,7 @@ class PlayerManagerTest : public MixxxDbTest, SoundSourceProviderRegistration {
         m_pLibrary = std::make_shared<Library>(
                 nullptr,
                 m_pConfig,
+                m_pKbdConfig,
                 dbConnectionPooler(),
                 m_pTrackCollectionManager.get(),
                 m_pPlayerManager.get(),

--- a/src/widget/wanalysislibrarytableview.cpp
+++ b/src/widget/wanalysislibrarytableview.cpp
@@ -1,13 +1,16 @@
 #include "library/trackcollection.h"
+#include "preferences/configobject.h"
 #include "widget/wanalysislibrarytableview.h"
 
 WAnalysisLibraryTableView::WAnalysisLibraryTableView(
         QWidget* parent,
         UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig,
         Library* pLibrary,
         double trackTableBackgroundColorOpacity)
         : WTrackTableView(parent,
                   pConfig,
+                  pKbdConfig,
                   pLibrary,
                   trackTableBackgroundColorOpacity,
                   true) {

--- a/src/widget/wanalysislibrarytableview.cpp
+++ b/src/widget/wanalysislibrarytableview.cpp
@@ -1,7 +1,8 @@
+#include "widget/wanalysislibrarytableview.h"
+
 #include "library/trackcollection.h"
 #include "preferences/configobject.h"
 #include "preferences/keyboardconfig.h"
-#include "widget/wanalysislibrarytableview.h"
 
 WAnalysisLibraryTableView::WAnalysisLibraryTableView(
         QWidget* parent,

--- a/src/widget/wanalysislibrarytableview.cpp
+++ b/src/widget/wanalysislibrarytableview.cpp
@@ -1,11 +1,12 @@
 #include "library/trackcollection.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "widget/wanalysislibrarytableview.h"
 
 WAnalysisLibraryTableView::WAnalysisLibraryTableView(
         QWidget* parent,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig,
+        KeyboardConfigPointer pKbdConfig,
         Library* pLibrary,
         double trackTableBackgroundColorOpacity)
         : WTrackTableView(parent,

--- a/src/widget/wanalysislibrarytableview.h
+++ b/src/widget/wanalysislibrarytableview.h
@@ -2,6 +2,7 @@
 
 #include <QWidget>
 
+#include "preferences/configobject.h"
 #include "preferences/usersettings.h"
 #include "widget/wtracktableview.h"
 
@@ -11,6 +12,7 @@ class WAnalysisLibraryTableView : public WTrackTableView {
     WAnalysisLibraryTableView(
             QWidget* parent,
             UserSettingsPointer pConfig,
+            ConfigObject<ConfigValueKbd>* pKbdConfig,
             Library* pLibrary,
             double trackTableBackgroundColorOpacity);
 

--- a/src/widget/wanalysislibrarytableview.h
+++ b/src/widget/wanalysislibrarytableview.h
@@ -3,6 +3,7 @@
 #include <QWidget>
 
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "preferences/usersettings.h"
 #include "widget/wtracktableview.h"
 
@@ -12,7 +13,7 @@ class WAnalysisLibraryTableView : public WTrackTableView {
     WAnalysisLibraryTableView(
             QWidget* parent,
             UserSettingsPointer pConfig,
-            ConfigObject<ConfigValueKbd>* pKbdConfig,
+            KeyboardConfigPointer pKbdConfig,
             Library* pLibrary,
             double trackTableBackgroundColorOpacity);
 

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -70,11 +70,10 @@ QUrl documentationUrl(
 }
 }  // namespace
 
-WMainMenuBar::WMainMenuBar(QWidget* pParent, UserSettingsPointer pConfig,
-                           KeyboardConfigPointer pKbdConfig)
-        : QMenuBar(pParent),
-          m_pConfig(pConfig),
-          m_pKbdConfig(pKbdConfig) {
+WMainMenuBar::WMainMenuBar(QWidget* pParent,
+        UserSettingsPointer pConfig,
+        KeyboardConfigPointer pKbdConfig)
+        : QMenuBar(pParent), m_pConfig(pConfig), m_pKbdConfig(pKbdConfig) {
     setObjectName(QStringLiteral("MainMenu"));
     initialize();
 }

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -7,6 +7,7 @@
 #include "defs_urls.h"
 #include "mixer/playermanager.h"
 #include "moc_wmainmenubar.cpp"
+#include "preferences/keyboardconfig.h"
 #include "util/cmdlineargs.h"
 #include "util/experiment.h"
 #include "vinylcontrol/defs_vinylcontrol.h"
@@ -70,7 +71,7 @@ QUrl documentationUrl(
 }  // namespace
 
 WMainMenuBar::WMainMenuBar(QWidget* pParent, UserSettingsPointer pConfig,
-                           ConfigObject<ConfigValueKbd>* pKbdConfig)
+                           KeyboardConfigPointer pKbdConfig)
         : QMenuBar(pParent),
           m_pConfig(pConfig),
           m_pKbdConfig(pKbdConfig) {

--- a/src/widget/wmainmenubar.h
+++ b/src/widget/wmainmenubar.h
@@ -8,6 +8,7 @@
 
 #include "control/controlproxy.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "preferences/usersettings.h"
 
 class VisibilityControlConnection : public QObject {
@@ -34,7 +35,7 @@ class WMainMenuBar : public QMenuBar {
     Q_OBJECT
   public:
     WMainMenuBar(QWidget* pParent, UserSettingsPointer pConfig,
-                 ConfigObject<ConfigValueKbd>* pKbdConfig);
+                 KeyboardConfigPointer pKbdConfig);
 
   public slots:
     void onLibraryScanStarted();
@@ -92,7 +93,7 @@ class WMainMenuBar : public QMenuBar {
 
     UserSettingsPointer m_pConfig;
     QAction* m_pViewKeywheel;
-    ConfigObject<ConfigValueKbd>* m_pKbdConfig;
+    const KeyboardConfigPointer m_pKbdConfig;
     QList<QAction*> m_loadToDeckActions;
     QList<QAction*> m_vinylControlEnabledActions;
 };

--- a/src/widget/wmainmenubar.h
+++ b/src/widget/wmainmenubar.h
@@ -34,8 +34,7 @@ class VisibilityControlConnection : public QObject {
 class WMainMenuBar : public QMenuBar {
     Q_OBJECT
   public:
-    WMainMenuBar(QWidget* pParent, UserSettingsPointer pConfig,
-                 KeyboardConfigPointer pKbdConfig);
+    WMainMenuBar(QWidget* pParent, UserSettingsPointer pConfig, KeyboardConfigPointer pKbdConfig);
 
   public slots:
     void onLibraryScanStarted();

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -33,6 +33,7 @@
 #include "preferences/colorpalettesettings.h"
 #include "preferences/configobject.h"
 #include "preferences/dialog/dlgprefdeck.h"
+#include "preferences/keyboardconfig.h"
 #include "sources/soundsourceproxy.h"
 #include "track/track.h"
 #include "util/defs.h"
@@ -53,7 +54,7 @@
 WTrackMenu::WTrackMenu(
         QWidget* parent,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig,
+        KeyboardConfigPointer pKbdConfig,
         Library* pLibrary,
         Features flags,
         TrackModel* trackModel)

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -53,12 +53,14 @@
 WTrackMenu::WTrackMenu(
         QWidget* parent,
         UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig,
         Library* pLibrary,
         Features flags,
         TrackModel* trackModel)
         : QMenu(parent),
           m_pTrackModel(trackModel),
           m_pConfig(pConfig),
+          m_pKbdConfig(pKbdConfig),
           m_pLibrary(pLibrary),
           m_bPlaylistMenuLoaded(false),
           m_bCrateMenuLoaded(false),

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -9,6 +9,7 @@
 #include "library/coverart.h"
 #include "library/dao/playlistdao.h"
 #include "library/trackprocessing.h"
+#include "preferences/configobject.h"
 #include "preferences/usersettings.h"
 #include "track/beats.h"
 #include "track/trackref.h"
@@ -65,6 +66,7 @@ class WTrackMenu : public QMenu {
 
     WTrackMenu(QWidget* parent,
             UserSettingsPointer pConfig,
+            ConfigObject<ConfigValueKbd>* pKbdConfig,
             Library* pLibrary,
             Features flags = Feature::All,
             TrackModel* trackModel = nullptr);
@@ -310,6 +312,7 @@ class WTrackMenu : public QMenu {
     QAction* m_pClearAllMetadataAction{};
 
     const UserSettingsPointer m_pConfig;
+    ConfigObject<ConfigValueKbd>* m_pKbdConfig;
     Library* const m_pLibrary;
 
     std::unique_ptr<DlgTrackInfo> m_pDlgTrackInfo;

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -10,6 +10,7 @@
 #include "library/dao/playlistdao.h"
 #include "library/trackprocessing.h"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "preferences/usersettings.h"
 #include "track/beats.h"
 #include "track/trackref.h"
@@ -66,7 +67,7 @@ class WTrackMenu : public QMenu {
 
     WTrackMenu(QWidget* parent,
             UserSettingsPointer pConfig,
-            ConfigObject<ConfigValueKbd>* pKbdConfig,
+            KeyboardConfigPointer pKbdConfig,
             Library* pLibrary,
             Features flags = Feature::All,
             TrackModel* trackModel = nullptr);
@@ -312,7 +313,7 @@ class WTrackMenu : public QMenu {
     QAction* m_pClearAllMetadataAction{};
 
     const UserSettingsPointer m_pConfig;
-    ConfigObject<ConfigValueKbd>* m_pKbdConfig;
+    const KeyboardConfigPointer m_pKbdConfig;
     Library* const m_pLibrary;
 
     std::unique_ptr<DlgTrackInfo> m_pDlgTrackInfo;

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -6,6 +6,7 @@
 #include "control/controlobject.h"
 #include "moc_wtrackproperty.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "track/track.h"
 #include "util/dnd.h"
 #include "widget/wtrackmenu.h"
@@ -31,7 +32,7 @@ constexpr WTrackMenu::Features kTrackMenuFeatures =
 WTrackProperty::WTrackProperty(
         QWidget* pParent,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig,
+        KeyboardConfigPointer pKbdConfig,
         Library* pLibrary,
         const QString& group)
         : WLabel(pParent),

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -5,6 +5,7 @@
 
 #include "control/controlobject.h"
 #include "moc_wtrackproperty.cpp"
+#include "preferences/configobject.h"
 #include "track/track.h"
 #include "util/dnd.h"
 #include "widget/wtrackmenu.h"
@@ -30,13 +31,14 @@ constexpr WTrackMenu::Features kTrackMenuFeatures =
 WTrackProperty::WTrackProperty(
         QWidget* pParent,
         UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig,
         Library* pLibrary,
         const QString& group)
         : WLabel(pParent),
           m_group(group),
           m_pConfig(pConfig),
           m_pTrackMenu(make_parented<WTrackMenu>(
-                  this, pConfig, pLibrary, kTrackMenuFeatures)) {
+                  this, pConfig, pKbdConfig, pLibrary, kTrackMenuFeatures)) {
     setAcceptDrops(true);
 }
 

--- a/src/widget/wtrackproperty.h
+++ b/src/widget/wtrackproperty.h
@@ -5,6 +5,7 @@
 #include <QMouseEvent>
 
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "preferences/usersettings.h"
 #include "skin/legacy/skincontext.h"
 #include "track/track_decl.h"
@@ -22,7 +23,7 @@ class WTrackProperty : public WLabel, public TrackDropTarget {
     WTrackProperty(
             QWidget* pParent,
             UserSettingsPointer pConfig,
-            ConfigObject<ConfigValueKbd>* pKbdConfig,
+            KeyboardConfigPointer pKbdConfig,
             Library* pLibrary,
             const QString& group);
     ~WTrackProperty() override;

--- a/src/widget/wtrackproperty.h
+++ b/src/widget/wtrackproperty.h
@@ -4,6 +4,7 @@
 #include <QDropEvent>
 #include <QMouseEvent>
 
+#include "preferences/configobject.h"
 #include "preferences/usersettings.h"
 #include "skin/legacy/skincontext.h"
 #include "track/track_decl.h"
@@ -21,6 +22,7 @@ class WTrackProperty : public WLabel, public TrackDropTarget {
     WTrackProperty(
             QWidget* pParent,
             UserSettingsPointer pConfig,
+            ConfigObject<ConfigValueKbd>* pKbdConfig,
             Library* pLibrary,
             const QString& group);
     ~WTrackProperty() override;

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -17,6 +17,7 @@
 #include "mixer/playermanager.h"
 #include "moc_wtracktableview.cpp"
 #include "preferences/colorpalettesettings.h"
+#include "preferences/configobject.h"
 #include "preferences/dialog/dlgprefdeck.h"
 #include "preferences/dialog/dlgpreflibrary.h"
 #include "sources/soundsourceproxy.h"
@@ -45,11 +46,13 @@ const QColor kDefaultFocusBorderColor = Qt::white;
 
 WTrackTableView::WTrackTableView(QWidget* parent,
         UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig,
         Library* pLibrary,
         double backgroundColorOpacity,
         bool sorting)
         : WLibraryTableView(parent, pConfig),
           m_pConfig(pConfig),
+          m_pKbdConfig(pKbdConfig),
           m_pLibrary(pLibrary),
           m_backgroundColorOpacity(backgroundColorOpacity),
           m_pFocusBorderColor(kDefaultFocusBorderColor),
@@ -331,6 +334,7 @@ void WTrackTableView::initTrackMenu() {
 
     m_pTrackMenu = make_parented<WTrackMenu>(this,
             m_pConfig,
+            m_pKbdConfig,
             m_pLibrary,
             WTrackMenu::Feature::All,
             trackModel);

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -20,6 +20,7 @@
 #include "preferences/configobject.h"
 #include "preferences/dialog/dlgprefdeck.h"
 #include "preferences/dialog/dlgpreflibrary.h"
+#include "preferences/keyboardconfig.h"
 #include "sources/soundsourceproxy.h"
 #include "track/track.h"
 #include "track/trackref.h"
@@ -46,7 +47,7 @@ const QColor kDefaultFocusBorderColor = Qt::white;
 
 WTrackTableView::WTrackTableView(QWidget* parent,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig,
+        KeyboardConfigPointer pKbdConfig,
         Library* pLibrary,
         double backgroundColorOpacity,
         bool sorting)

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -8,6 +8,7 @@
 #include "library/dao/playlistdao.h"
 #include "library/trackmodel.h" // Can't forward declare enums
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "preferences/usersettings.h"
 #include "util/duration.h"
 #include "util/parented_ptr.h"
@@ -26,7 +27,7 @@ class WTrackTableView : public WLibraryTableView {
     WTrackTableView(
             QWidget* parent,
             UserSettingsPointer pConfig,
-            ConfigObject<ConfigValueKbd>* pKbdConfig,
+            KeyboardConfigPointer pKbdConfig,
             Library* pLibrary,
             double backgroundColorOpacity,
             bool sorting);
@@ -119,7 +120,7 @@ class WTrackTableView : public WLibraryTableView {
     void hideOrRemoveSelectedTracks();
 
     const UserSettingsPointer m_pConfig;
-    ConfigObject<ConfigValueKbd>* m_pKbdConfig;
+    const KeyboardConfigPointer m_pKbdConfig;
     Library* const m_pLibrary;
 
     // Context menu container

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -7,6 +7,7 @@
 #include "control/pollingcontrolproxy.h"
 #include "library/dao/playlistdao.h"
 #include "library/trackmodel.h" // Can't forward declare enums
+#include "preferences/configobject.h"
 #include "preferences/usersettings.h"
 #include "util/duration.h"
 #include "util/parented_ptr.h"
@@ -25,6 +26,7 @@ class WTrackTableView : public WLibraryTableView {
     WTrackTableView(
             QWidget* parent,
             UserSettingsPointer pConfig,
+            ConfigObject<ConfigValueKbd>* pKbdConfig,
             Library* pLibrary,
             double backgroundColorOpacity,
             bool sorting);
@@ -117,6 +119,7 @@ class WTrackTableView : public WLibraryTableView {
     void hideOrRemoveSelectedTracks();
 
     const UserSettingsPointer m_pConfig;
+    ConfigObject<ConfigValueKbd>* m_pKbdConfig;
     Library* const m_pLibrary;
 
     // Context menu container

--- a/src/widget/wtracktext.cpp
+++ b/src/widget/wtracktext.cpp
@@ -6,6 +6,7 @@
 #include "control/controlobject.h"
 #include "moc_wtracktext.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "track/track.h"
 #include "util/dnd.h"
 #include "widget/wtrackmenu.h"
@@ -29,7 +30,7 @@ constexpr WTrackMenu::Features kTrackMenuFeatures =
 
 WTrackText::WTrackText(QWidget* pParent,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig,
+        KeyboardConfigPointer pKbdConfig,
         Library* pLibrary,
         const QString& group)
         : WLabel(pParent),

--- a/src/widget/wtracktext.cpp
+++ b/src/widget/wtracktext.cpp
@@ -5,6 +5,7 @@
 
 #include "control/controlobject.h"
 #include "moc_wtracktext.cpp"
+#include "preferences/configobject.h"
 #include "track/track.h"
 #include "util/dnd.h"
 #include "widget/wtrackmenu.h"
@@ -28,13 +29,14 @@ constexpr WTrackMenu::Features kTrackMenuFeatures =
 
 WTrackText::WTrackText(QWidget* pParent,
         UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig,
         Library* pLibrary,
         const QString& group)
         : WLabel(pParent),
           m_group(group),
           m_pConfig(pConfig),
           m_pTrackMenu(make_parented<WTrackMenu>(
-                  this, pConfig, pLibrary, kTrackMenuFeatures)) {
+                  this, pConfig, pKbdConfig, pLibrary, kTrackMenuFeatures)) {
     setAcceptDrops(true);
 }
 

--- a/src/widget/wtracktext.h
+++ b/src/widget/wtracktext.h
@@ -4,6 +4,7 @@
 #include <QDropEvent>
 #include <QMouseEvent>
 
+#include "preferences/configobject.h"
 #include "preferences/usersettings.h"
 #include "track/track_decl.h"
 #include "track/trackid.h"
@@ -20,6 +21,7 @@ class WTrackText : public WLabel, public TrackDropTarget {
     WTrackText(
             QWidget* pParent,
             UserSettingsPointer pConfig,
+            ConfigObject<ConfigValueKbd>* pKbdConfig,
             Library* pLibrary,
             const QString& group);
     ~WTrackText() override;

--- a/src/widget/wtracktext.h
+++ b/src/widget/wtracktext.h
@@ -5,6 +5,7 @@
 #include <QMouseEvent>
 
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "preferences/usersettings.h"
 #include "track/track_decl.h"
 #include "track/trackid.h"
@@ -21,7 +22,7 @@ class WTrackText : public WLabel, public TrackDropTarget {
     WTrackText(
             QWidget* pParent,
             UserSettingsPointer pConfig,
-            ConfigObject<ConfigValueKbd>* pKbdConfig,
+            KeyboardConfigPointer pKbdConfig,
             Library* pLibrary,
             const QString& group);
     ~WTrackText() override;

--- a/src/widget/wtrackwidgetgroup.cpp
+++ b/src/widget/wtrackwidgetgroup.cpp
@@ -7,6 +7,7 @@
 #include "control/controlobject.h"
 #include "moc_wtrackwidgetgroup.cpp"
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "track/track.h"
 #include "util/dnd.h"
 #include "widget/wtrackmenu.h"
@@ -34,7 +35,7 @@ constexpr WTrackMenu::Features kTrackMenuFeatures =
 
 WTrackWidgetGroup::WTrackWidgetGroup(QWidget* pParent,
         UserSettingsPointer pConfig,
-        ConfigObject<ConfigValueKbd>* pKbdConfig,
+        KeyboardConfigPointer pKbdConfig,
         Library* pLibrary,
         const QString& group)
         : WWidgetGroup(pParent),

--- a/src/widget/wtrackwidgetgroup.cpp
+++ b/src/widget/wtrackwidgetgroup.cpp
@@ -6,6 +6,7 @@
 
 #include "control/controlobject.h"
 #include "moc_wtrackwidgetgroup.cpp"
+#include "preferences/configobject.h"
 #include "track/track.h"
 #include "util/dnd.h"
 #include "widget/wtrackmenu.h"
@@ -33,6 +34,7 @@ constexpr WTrackMenu::Features kTrackMenuFeatures =
 
 WTrackWidgetGroup::WTrackWidgetGroup(QWidget* pParent,
         UserSettingsPointer pConfig,
+        ConfigObject<ConfigValueKbd>* pKbdConfig,
         Library* pLibrary,
         const QString& group)
         : WWidgetGroup(pParent),
@@ -40,7 +42,7 @@ WTrackWidgetGroup::WTrackWidgetGroup(QWidget* pParent,
           m_pConfig(pConfig),
           m_trackColorAlpha(kDefaultTrackColorAlpha),
           m_pTrackMenu(make_parented<WTrackMenu>(
-                  this, pConfig, pLibrary, kTrackMenuFeatures)) {
+                  this, pConfig, pKbdConfig, pLibrary, kTrackMenuFeatures)) {
     setAcceptDrops(true);
 }
 

--- a/src/widget/wtrackwidgetgroup.h
+++ b/src/widget/wtrackwidgetgroup.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "preferences/configobject.h"
 #include "skin/legacy/skincontext.h"
 #include "track/track_decl.h"
 #include "track/trackid.h"
@@ -15,6 +16,7 @@ class WTrackWidgetGroup : public WWidgetGroup, public TrackDropTarget {
   public:
     WTrackWidgetGroup(QWidget* pParent,
             UserSettingsPointer pConfig,
+            ConfigObject<ConfigValueKbd>* pKbdConfig,
             Library* pLibrary,
             const QString& group);
     ~WTrackWidgetGroup() override;

--- a/src/widget/wtrackwidgetgroup.h
+++ b/src/widget/wtrackwidgetgroup.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "preferences/configobject.h"
+#include "preferences/keyboardconfig.h"
 #include "skin/legacy/skincontext.h"
 #include "track/track_decl.h"
 #include "track/trackid.h"
@@ -16,7 +17,7 @@ class WTrackWidgetGroup : public WWidgetGroup, public TrackDropTarget {
   public:
     WTrackWidgetGroup(QWidget* pParent,
             UserSettingsPointer pConfig,
-            ConfigObject<ConfigValueKbd>* pKbdConfig,
+            KeyboardConfigPointer pKbdConfig,
             Library* pLibrary,
             const QString& group);
     ~WTrackWidgetGroup() override;


### PR DESCRIPTION
While looking into customizing the keyboard shortcuts for `WTrackMenu`, I ran into the issue that there was no `ConfigObject<ConfigValueKbd>` in immediate reach. So I started propagating it through the application all the way to the core services. The change became quite sweeping, however, since `WTrackMenu` has quite a few (transitive) dependents.

To avoid relying too much on raw pointers, I've added a `KeyboardConfigPointer` wrapper around `std::shared_ptr<ConfigObject<ConfigValueKbd>>`.

This PR doesn't add any new shortcuts or features since the change is quite large in and of itself and I'd be curious to hear some opinions on whether this is a fine approach before e.g. making the track properties shortcut etc. customizable.