### PR TITLE
Tracks table: remove parenthesis from play counter display

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -624,7 +624,7 @@ QVariant BaseTrackTableModel::roleValue(
             VERIFY_OR_DEBUG_ASSERT(ok && timesPlayed >= 0) {
                 return QVariant();
             }
-            return QString("(%1)").arg(timesPlayed);
+            return QString::number(timesPlayed);
         }
         case ColumnCache::COLUMN_LIBRARYTABLE_DATETIMEADDED:
         case ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_DATETIMEADDED: {


### PR DESCRIPTION
(no idea why these were added in the first place)

This allows to shrink the Played column and make another one _a bit_ wider.

nice to have:
grey out `0` so unplayed tracks are easier to spot