### PR TITLE
Fix waveform overview lenght. 

### DIFF
--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -331,6 +331,9 @@ void WOverview::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack)
     m_actualCompletion = 0;
     m_waveformPeak = -1.0;
     m_pixmapDone = false;
+    // Note: Here we already have the new track, but the engine and it's
+    // Control Objects may still have the old one until the slotTrackLoaded()
+    // signal has been received.
     m_trackLoaded = false;
     m_endOfTrack = false;
 

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -320,6 +320,10 @@ void WOverview::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack)
                 &Track::waveformSummaryUpdated,
                 this,
                 &WOverview::slotWaveformSummaryUpdated);
+        disconnect(m_pCurrentTrack.get(),
+                &Track::cuesUpdated,
+                this,
+                &WOverview::receiveCuesUpdated);
     }
 
     m_waveformSourceImage = QImage();

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -78,7 +78,11 @@ class WOverview : public WWidget, public TrackDropTarget {
     }
 
     double getTrackSamples() const {
-        return m_trackSamplesControl->get();
+        if (m_trackLoaded) {
+            return m_trackSamplesControl->get();
+        } else {
+            return 0.0;
+        }
     }
 
     QImage m_waveformSourceImage;

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -81,6 +81,8 @@ class WOverview : public WWidget, public TrackDropTarget {
         if (m_trackLoaded) {
             return m_trackSamplesControl->get();
         } else {
+            // Ignore the value, because the engine can still have the old track
+            // during loading
             return 0.0;
         }
     }

--- a/src/widget/woverviewhsv.cpp
+++ b/src/widget/woverviewhsv.cpp
@@ -39,7 +39,7 @@ bool WOverviewHSV::drawNextPixmapPart() {
         // by total_gain
         // We keep full range waveform data to scale it on paint
         m_waveformSourceImage = QImage(
-                static_cast<int>(trackSamples / audioVisualRatio / 2),
+                static_cast<int>(trackSamples / audioVisualRatio / 2) + 1,
                 2 * 255,
                 QImage::Format_ARGB32_Premultiplied);
         m_waveformSourceImage.fill(QColor(0, 0, 0, 0).value());

--- a/src/widget/woverviewhsv.cpp
+++ b/src/widget/woverviewhsv.cpp
@@ -43,6 +43,10 @@ bool WOverviewHSV::drawNextPixmapPart() {
                 2 * 255,
                 QImage::Format_ARGB32_Premultiplied);
         m_waveformSourceImage.fill(QColor(0, 0, 0, 0).value());
+        if (dataSize / 2 != m_waveformSourceImage.width()) {
+            qWarning() << "Track duration has changed since last analysis"
+                       << m_waveformSourceImage.width() << "!=" << dataSize / 2;
+        }
     }
     DEBUG_ASSERT(!m_waveformSourceImage.isNull());
 

--- a/src/widget/woverviewlmh.cpp
+++ b/src/widget/woverviewlmh.cpp
@@ -40,7 +40,7 @@ bool WOverviewLMH::drawNextPixmapPart() {
         // by total_gain
         // We keep full range waveform data to scale it on paint
         m_waveformSourceImage = QImage(
-                static_cast<int>(trackSamples / audioVisualRatio / 2),
+                static_cast<int>(trackSamples / audioVisualRatio / 2) + 1,
                 2 * 255,
                 QImage::Format_ARGB32_Premultiplied);
         m_waveformSourceImage.fill(QColor(0, 0, 0, 0).value());

--- a/src/widget/woverviewlmh.cpp
+++ b/src/widget/woverviewlmh.cpp
@@ -44,6 +44,10 @@ bool WOverviewLMH::drawNextPixmapPart() {
                 2 * 255,
                 QImage::Format_ARGB32_Premultiplied);
         m_waveformSourceImage.fill(QColor(0, 0, 0, 0).value());
+        if (dataSize / 2 != m_waveformSourceImage.width()) {
+            qWarning() << "Track duration has changed since last analysis"
+                       << m_waveformSourceImage.width() << "!=" << dataSize / 2;
+        }
     }
     DEBUG_ASSERT(!m_waveformSourceImage.isNull());
 

--- a/src/widget/woverviewrgb.cpp
+++ b/src/widget/woverviewrgb.cpp
@@ -38,7 +38,7 @@ bool WOverviewRGB::drawNextPixmapPart() {
         // by total_gain
         // We keep full range waveform data to scale it on paint
         m_waveformSourceImage = QImage(
-                static_cast<int>(trackSamples / audioVisualRatio / 2),
+                static_cast<int>(trackSamples / audioVisualRatio / 2) + 1,
                 2 * 255,
                 QImage::Format_ARGB32_Premultiplied);
         m_waveformSourceImage.fill(QColor(0, 0, 0, 0).value());

--- a/src/widget/woverviewrgb.cpp
+++ b/src/widget/woverviewrgb.cpp
@@ -42,6 +42,10 @@ bool WOverviewRGB::drawNextPixmapPart() {
                 2 * 255,
                 QImage::Format_ARGB32_Premultiplied);
         m_waveformSourceImage.fill(QColor(0, 0, 0, 0).value());
+        if (dataSize / 2 != m_waveformSourceImage.width()) {
+            qWarning() << "Track duration has changed since last analysis"
+                       << m_waveformSourceImage.width() << "!=" << dataSize / 2;
+        }
     }
     DEBUG_ASSERT(!m_waveformSourceImage.isNull());
 


### PR DESCRIPTION
This aims to fix https://github.com/mixxxdj/mixxx/issues/11344 where the waveform overview is rendered with the wrong length.
A possible regression from https://github.com/mixxxdj/mixxx/pull/11162 
[mixxx-2.3.3-145-gcfcd265afd-win64.msi](http://downloads.mixxx.org/snapshots/2.3/mixxx-2.3.3-145-gcfcd265afd-win64.msi)

