### PR TITLE
macOS packaging: Fix microphone access by adding `NSMicrophoneUsageDescription`

### DIFF
--- a/packaging/macos/bundle.plist.in
+++ b/packaging/macos/bundle.plist.in
@@ -26,6 +26,9 @@
     <key>NSHumanReadableCopyright</key>
     <string>Copyright © 2001-@MIXXX_YEAR@ Mixxx Development Team</string>
 
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Mixxx requires microphone access for microphone and vinyl input.</string>
+
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
 


### PR DESCRIPTION
Fixes #11365

On recent macOS versions Apple requires applications to provide a usage description, otherwise the app will not even ask for permission and microphone-related features will not work. This fixes it by adding such a description, which is presented at first launch:

<img width="372" alt="Screenshot 2023-03-14 at 13 43 10" src="https://user-images.githubusercontent.com/30873659/225005800-e8925dd4-c4a7-480f-8fc7-52f3ed55447a.png">

cc @daschuer 