### PR TITLE
clang-format: Handle Objective-C(++) in config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,7 +6,7 @@ TabWidth: 8
 UseTab: Never
 # A ColumnLimit > 0 causes clang-format to unbreaks all short lines,
 # which is undesired here.
-# If the line length exceeds 100, "ColumnLimit:  80" is used in scripts/line-length.py
+# If the line length exceeds 100, "ColumnLimit:  80" is used in tools/clang_format.py
 ColumnLimit: 0
 ---
 Language: Cpp
@@ -31,6 +31,35 @@ SpacesBeforeTrailingComments: 1
 # StatementMacros don't require a trailing semicolon.
 # Trailing semicolons should be omitted after these macros
 # when compiling with -Wpedantic to avoid warnings.
+StatementMacros:
+  - Q_DECLARE_FLAGS
+  - Q_DECLARE_METATYPE
+  - Q_DECLARE_OPERATORS_FOR_FLAGS
+  - Q_OBJECT
+  - Q_PROPERTY
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+---
+Language: ObjC
+# We exclude Objective-C(++) from the second line-wrapping pass in tools/clang_format.py
+# since this pass only applies C++ rules and therefore include the ColumnLimit in the
+# 'main' clang-format config here.
+ColumnLimit: 80
+# Apply the same customizations that we use for Cpp to ObjC.
+AccessModifierOffset: -2
+AlignAfterOpenBracket: DontAlign
+AlignOperands: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+BinPackArguments: false
+BinPackParameters: false
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 8
+IndentCaseLabels: false
+DerivePointerAlignment: false
+SpaceAfterTemplateKeyword: false
+SpacesBeforeTrailingComments: 1
 StatementMacros:
   - Q_DECLARE_FLAGS
   - Q_DECLARE_METATYPE

--- a/tools/clang_format.py
+++ b/tools/clang_format.py
@@ -28,8 +28,9 @@ def get_clang_format_config_with_columnlimit(rootdir, limit):
         text=True,
     )
     proc.check_returncode()
+
     return re.sub(
-        r"(ColumnLimit:\s*)\d+", r"\g<1>{}".format(BREAK_BEFORE), proc.stdout
+        r"(ColumnLimit:\s*)\d+", r"\g<1>{}".format(limit), proc.stdout
     )
 
 
@@ -119,14 +120,16 @@ def main(argv: typing.Optional[typing.List[str]] = None) -> int:
     for changed_file in files_with_added_lines:
         run_clang_format_on_lines(rootdir, changed_file)
 
-    # Second pass: Wrap long added/changed lines using clang-format
+    # Second pass: Wrap long added/changed lines in C++ using clang-format
     logger.info("Second pass: Breaking long added/changed lines...")
     files_with_long_added_lines = githelper.get_changed_lines_grouped(
         from_ref=args.from_ref,
         to_ref=args.to_ref,
         filter_lines=lambda line: line.added
         and len(line.text) > LINE_LENGTH_THRESHOLD,
-        include_files=args.files,
+        include_files=[
+            file for file in args.files if re.search(r"\.(?:cpp|h)$", file)
+        ],
     )
     config = get_clang_format_config_with_columnlimit(rootdir, BREAK_BEFORE)
     with tempfile.TemporaryDirectory(prefix="clang-format") as tempdir:


### PR DESCRIPTION
Since there are now a couple of PRs adding Objective-C++ code, mainly for interfacing with Apple frameworks on macOS (e.g. #11353, #4809), we need to make sure that clang-format is configured correctly for this. While the aforementioned PRs bundle this patch too, I've extracted it to this PR for easier reviewability.

While clang-format has no trouble handling Objective-C++, the temporary line-breaking config currently only works on C++ (since it is based on the config dumped for a `.cpp` file). For this reason, this PR adds a second mini-configuration for `Language: ObjC` that uses a column limit of 80 and excludes Objective-C(++) from the second pass.