### PR TITLE
Implement CO to set all QuickEffectRack Effects to the same Chain.

### DIFF
--- a/src/effects/chains/quickeffectchain.cpp
+++ b/src/effects/chains/quickeffectchain.cpp
@@ -58,6 +58,7 @@ void QuickEffectChain::loadChainPreset(EffectChainPresetPointer pPreset) {
     if (pPreset) {
         setSuperParameter(pPreset->superKnob(), true);
     }
+    emit presetIndexChanged(presetIndex());
 }
 
 int QuickEffectChain::numPresets() const {

--- a/src/effects/chains/quickeffectchain.h
+++ b/src/effects/chains/quickeffectchain.h
@@ -24,4 +24,7 @@ class QuickEffectChain : public PerGroupEffectChain {
 
     void loadChainPreset(EffectChainPresetPointer pPreset) override;
     int numPresets() const override;
+
+  signals:
+    void presetIndexChanged(int presetIndex);
 };

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -19,13 +19,20 @@
 namespace {
 const unsigned int kEffectMessagePipeFifoSize = 2048;
 const QString kEffectsXmlFile = QStringLiteral("effects.xml");
+static constexpr double kMixedQuickEffectsSelected = -1.0;
 } // anonymous namespace
 
-EffectsManager::EffectsManager(
-        UserSettingsPointer pConfig,
+EffectsManager::EffectsManager(UserSettingsPointer pConfig,
         std::shared_ptr<ChannelHandleFactory> pChannelHandleFactory)
         : m_pConfig(pConfig),
           m_pChannelHandleFactory(pChannelHandleFactory),
+          m_unifiedQuickEffectPresetIndex(
+                  ConfigKey(QStringLiteral("[QuickEffectRack1]"),
+                          QStringLiteral("loaded_chain_preset")),
+                  true,
+                  false,
+                  false,
+                  kMixedQuickEffectsSelected),
           m_loEqFreq(ConfigKey(kMixerProfile, kLowEqFrequency), 0., 22040),
           m_hiEqFreq(ConfigKey(kMixerProfile, kHighEqFrequency), 0., 22040),
           m_initializedFromEffectsXml(false) {
@@ -48,6 +55,20 @@ EffectsManager::EffectsManager(
             new EffectChainPresetManager(pConfig, m_pBackendManager));
 
     m_pVisibleEffectsList = VisibleEffectsListPointer(new VisibleEffectsList());
+
+    QObject::connect(&m_unifiedQuickEffectPresetIndex,
+            &ControlObject::valueChanged,
+            &m_unifiedQuickEffectPresetIndex,
+            [this](double index) {
+                if (index < 0) {
+                    return;
+                }
+                for (QuickEffectChainPointer quickEffect :
+                        std::as_const(m_quickEffectChains)) {
+                    quickEffect->loadChainPreset(quickEffect->presetAtIndex(
+                            static_cast<int>(index)));
+                }
+            });
 }
 
 EffectsManager::~EffectsManager() {
@@ -170,6 +191,24 @@ void EffectsManager::addQuickEffectChain(const ChannelHandleAndGroup& deckHandle
 
     m_quickEffectChains.insert(deckHandleGroup.name(), pChainSlot);
     m_effectChainSlotsByGroup.insert(pChainSlot->group(), pChainSlot);
+
+    QObject::connect(pChainSlot.get(),
+            &QuickEffectChain::presetIndexChanged,
+            pChainSlot.get(),
+            [this](int presetIndex) {
+                const bool allQuickEffectChainsHaveSameIndex =
+                        std::all_of(m_quickEffectChains.cbegin(),
+                                m_quickEffectChains.cend(),
+                                [presetIndex](const QuickEffectChainPointer
+                                                quickEffectChain) {
+                                    return presetIndex ==
+                                            quickEffectChain->presetIndex();
+                                });
+                m_unifiedQuickEffectPresetIndex.set(
+                        allQuickEffectChainsHaveSameIndex
+                                ? presetIndex
+                                : kMixedQuickEffectsSelected);
+            });
 }
 
 void EffectsManager::loadDefaultEqsAndQuickEffects() {

--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -90,6 +90,9 @@ class EffectsManager {
     void readEffectsXmlSingleDeck(const QString& deckGroup);
     void saveEffectsXml();
 
+    void unifiedPresetIndexChanged(int presetIndex);
+    void updateQuickEffectPresets(int presetIndex);
+
     QSet<ChannelHandleAndGroup> m_registeredInputChannels;
     QSet<ChannelHandleAndGroup> m_registeredOutputChannels;
     UserSettingsPointer m_pConfig;
@@ -109,6 +112,9 @@ class EffectsManager {
     VisibleEffectsListPointer m_pVisibleEffectsList;
     EffectPresetManagerPointer m_pEffectPresetManager;
     EffectChainPresetManagerPointer m_pChainPresetManager;
+
+    // This is used for Controlling the effect of all QuickEffectChains at once
+    ControlObject m_unifiedQuickEffectPresetIndex;
 
     // ControlObjects for Equalizers' frequencies
     // TODO: replace these with effect parameters that are hidden by default


### PR DESCRIPTION
Fixes #11371 

Current Issues to discuss:
- [ ] `[QuickEffectRack1]` is a new CO group, not sure if thats desired or where else to put the CO.
- [x] `[QuickEffectRack1]`,`loaded_chain_preset` is zero-based while their `[QuickEffectRack1_[ChannelN]]` equivalent is 1-based. Considering the first real preset starts at 2 now (since 1 is the empty chain introduced in #10859). 
  - [x] When making the CO 0-based again ,`[EqualizerRack1]` and `[EffectRack1]` `loaded_chain_preset` now get initialized to weird, very large values for some reason. 