### PR TITLE
Fix autogenerated metainfo

### DIFF
--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -96,7 +96,7 @@
   Do not edit it manually.
   -->
   <releases>
-    <release version="2.4.0" type="development" date="2023-02-26" timestamp="1677398113">
+    <release version="2.4.0" type="development" date="2023-03-15" timestamp="1678888231">
       <description>
  <p>
   Cover Art


### PR DESCRIPTION
This fixes a build regression on the 2.4 branch by updating the autogenerated `org.mixxx.Mixxx.metainfo.xml`.