### PR TITLE
Changed Qt6 CI buildsystem from Arch to Ubuntu 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,11 +36,8 @@ jobs:
             artifacts_path: build/*.deb
             artifacts_slug: ubuntu-jammy
             qt_qpa_platform: offscreen
-          - name: Arch Linux (Qt 6.3, gcc)
+          - name: Ubuntu 22.04 (Qt 6.2, gcc)
             os: ubuntu-22.04
-            # The Dockerfile for this container can be found at:
-            # https://github.com/Holzhaus/mixxx-ci-docker
-            container: holzhaus/mixxx-ci:20220612-qt6
             cmake_args: >-
               -DWARNINGS_FATAL=ON
               -DQT6=ON
@@ -54,6 +51,12 @@ jobs:
             ctest_args: []
             compiler_cache: ccache
             compiler_cache_path: ~/.ccache
+            cpack_generator: DEB
+            buildenv_basepath: /home/runner/buildenv
+            buildenv_script: tools/debian_buildenv_qt6.sh
+            artifacts_name: Ubuntu 22.04 Qt6 DEB
+            artifacts_path: build/*.deb
+            artifacts_slug: ubuntu-jammy
             qt_qpa_platform: offscreen
           - name: macOS 11
             os: macos-11

--- a/tools/debian_buildenv_qt6.sh
+++ b/tools/debian_buildenv_qt6.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# This script works with Debian, Ubuntu, and derivatives.
+# shellcheck disable=SC1091
+set -o pipefail
+
+case "$1" in
+    name)
+        echo "No build environment name required for Debian based distros." >&2
+        echo "This script installs the build dependencies via apt using the \"setup\" option." >&2
+        ;;
+
+    setup)
+        source /etc/lsb-release 2>/dev/null
+        case "${DISTRIB_CODENAME}" in
+            bionic) # Ubuntu 18.04 LTS
+                PACKAGES_EXTRA=(
+                    libmp4v2-dev
+                )
+                ;;
+            *) # libmp4v2 was removed from Debian 10 & Ubuntu 20.04 due to lack of maintenance, so use FFMPEG instead
+                PACKAGES_EXTRA=(
+                    libavformat-dev
+                )
+        esac
+
+        sudo apt-get update
+
+        # If jackd2 is installed as per dpkg database, install libjack-jackd2-dev.
+        # This avoids a package deadlock, resulting in jackd2 being removed, and jackd1 being installed,
+        # to satisfy portaudio19-dev's need for a jackd dev package. In short, portaudio19-dev needs a
+        # jackd dev library, so let's give it one..
+        if [ "$(dpkg-query -W -f='${Status}' jackd2 2>/dev/null | grep -c "ok installed")" -eq 1 ];
+        then
+            sudo apt-get install libjack-jackd2-dev;
+        fi
+
+
+        sudo apt-get install -y --no-install-recommends -- \
+            ccache \
+            cmake \
+            clazy \
+            clang-tidy \
+            debhelper \
+            devscripts \
+            docbook-to-man \
+            dput \
+            fonts-open-sans \
+            fonts-ubuntu \
+            g++ \
+            lcov \
+            libchromaprint-dev \
+            libdistro-info-perl \
+            libebur128-dev \
+            libfaad-dev \
+            libfftw3-dev \
+            libflac-dev \
+            libgl1-mesa-dev \
+            libhidapi-dev \
+            libid3tag0-dev \
+            liblilv-dev \
+            libmad0-dev \
+            libmodplug-dev \
+            libmp3lame-dev \
+            libmsgsl-dev \
+            libopus-dev \
+            libopusfile-dev \
+            libportmidi-dev \
+            libprotobuf-dev \
+            libqt6core5compat6-dev\
+            libqt6opengl6-dev \
+            libqt6sql6-sqlite \
+            libqt6svg6-dev \
+            librubberband-dev \
+            libshout-idjc-dev \
+            libsndfile1-dev \
+            libsoundtouch-dev \
+            libsqlite3-dev \
+            libssl-dev \
+            libtag1-dev \
+            libudev-dev \
+            libupower-glib-dev \
+            libusb-1.0-0-dev \
+            libwavpack-dev \
+            lv2-dev \
+            markdown \
+            portaudio19-dev \
+            protobuf-compiler \
+            qtkeychain-qt6-dev \
+            qt6-declarative-dev \
+            qml-module-qtquick-controls \
+            qml-module-qtquick-controls2 \
+            qml-module-qt-labs-qmlmodels \
+            qml-module-qtquick-shapes \
+            "${PACKAGES_EXTRA[@]}"
+        ;;
+    *)
+        echo "Usage: $0 [options]"
+        echo ""
+        echo "options:"
+        echo "   help       Displays this help."
+        echo "   name       Displays the name of the required build environment."
+        echo "   setup      Installs the build environment."
+        ;;
+esac


### PR DESCRIPTION
The CI builds run currently on an Arch Linux container maintained outside mixxxdj organization. This PR uses a normal Github Action build system running Ubuntu Linux instead.

The configuration is stored in a new file `tools/debian_buildenv_qt6.sh`, which can be used by any Linux developer on Debion/Ubuntu to set up a Qt6 build locally.

Our requirements policy says that code must build on latest Ubuntu LTS release: https://github.com/mixxxdj/mixxx/wiki/Minimum-requirements-policy
Currently this is Ubuntu 22.04 with Qt 6.2.4. Therefore this is used as build system here.