### PR TITLE
Upload pre-commit.log in case of failure

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -72,6 +72,13 @@ jobs:
           name: ${{ env.UPLOAD_PATCH_FILE }}
           path: ${{ env.UPLOAD_PATCH_FILE }}
 
+      - name: "Upload pre-commit.log"
+        if: failure() && env.UPLOAD_PATCH_FILE == null
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: pre-commit.log
+          path: /github/home/.cache/pre-commit/pre-commit.log
+
       # AppStream metadata has been generated/updated by a pre-commit hook
       - name: "Validate AppStream metadata"
         if: runner.os == 'Linux'


### PR DESCRIPTION
This uploads the pre-commit-log in case of pre-commit is failing but we don't have a patch file. 
This is helpful for debugging:
https://github.com/pre-commit/pre-commit/issues/2823
https://github.com/mixxxdj/mixxx/issues/11386