### PR TITLE
fix(ci): remove workaround from labeler which broke validation

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -19,8 +19,4 @@ jobs:
       - uses: actions/labeler@main
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-
-          # This works around bug https://github.com/actions/labeler/issues/104.
-          # The workaround was proposed here:
-          # https://github.com/wesnoth/wesnoth/commit/958c82d0867568057caaf58356502ec8c87d8366
-          sync-labels: ""
+          sync-labels: false

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -16,7 +16,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/labeler@main
+      # version between v4.0.3 and the one after which has not yet been tagged
+      # at the time of writing
+      - uses: actions/labeler@7012d51fe062f0b1e26e224a3c9fb52598ee3302
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: false


### PR DESCRIPTION
We should stop using their main branch and pin a version instead. Unfortunately they have not tagged a version which includes the fix yet.