### PR TITLE
Add 2.3.5 changes to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## [2.3.5](https://github.com/mixxxdj/mixxx/milestone/39) (unreleased)
 
-* Fix empty waveform overview after loading a track. This fixes a Mixxx 2.3.4 regression
-  since [#11162](https://github.com/mixxxdj/mixxx/pull/11162).
+* Fix empty waveform overview after loading a track (Mixxx 2.3.4 regression)
   Fixed by [#11333](https://github.com/mixxxdj/mixxx/pull/11333)
   [#11359](https://github.com/mixxxdj/mixxx/pull/11359)
   [#11344](https://github.com/mixxxdj/mixxx/issues/11344)
@@ -22,7 +21,7 @@
   [#11341](https://github.com/mixxxdj/mixxx/issues/11341)
 * Pioneer DDJ-400: Make Beat FX section more intuitive
   [#10912](https://github.com/mixxxdj/mixxx/pull/10912)
-* Playlist export: Fix chained file extensions after changing the playlist type.
+* Playlist export: Adopt new extension after changing the playlist type
   [#11332](https://github.com/mixxxdj/mixxx/pull/11332)
   [#11327](https://github.com/mixxxdj/mixxx/issues/11327)
 * LateNight: brighter fx parameter buttons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@
   [#11327](https://github.com/mixxxdj/mixxx/issues/11327)
 * LateNight: brighter fx parameter buttons
   [#11397](https://github.com/mixxxdj/mixxx/pull/11397)
+* Fix drift in analyzis data after exporting metadata to MP3 files with ID3v1.1 tags
+  [#11168](https://github.com/mixxxdj/mixxx/pull/11168)
+  [#11159](https://github.com/mixxxdj/mixxx/issues/11159)
+* Fix broadcasting using Opus encoding
+  [#11349](https://github.com/mixxxdj/mixxx/pull/11349)
+  [#10666](https://github.com/mixxxdj/mixxx/issues/10666)
+* Tango: Remove VU peak indicators from stacked layout. This fixes a visual regression in Mixxx 2.3.4.
+  [#11430](https://github.com/mixxxdj/mixxx/pull/11430)
+  [#11362](https://github.com/mixxxdj/mixxx/issues/11362)
 
 ## [2.3.4](https://launchpad.net/mixxx/+milestone/2.3.4) (2023-03-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [2.3.5](https://github.com/mixxxdj/mixxx/milestone/39) (unreleased)
+
+* Fix empty waveform overview after loading a track. This fixes a Mixxx 2.3.4 regression
+  since [#11162](https://github.com/mixxxdj/mixxx/pull/11162).
+  Fixed by [#11333](https://github.com/mixxxdj/mixxx/pull/11333)
+  [#11359](https://github.com/mixxxdj/mixxx/pull/11359)
+  [#11344](https://github.com/mixxxdj/mixxx/issues/11344)
+* Fullscreen: Fix a crash that occurs on Linux after enabling fullsceen and using menu
+  shortcuts e.g. Alt-F.
+  [#11328](https://github.com/mixxxdj/mixxx/pull/11328)
+  [#11320](https://github.com/mixxxdj/mixxx/issues/11320)
+* Fullscreen: Rebuild & reconnect menu only on desktops with global menu
+  [#11350](https://github.com/mixxxdj/mixxx/pull/11350)
+* macOS: Request Microphone and line-in access permission.
+  [#11367](https://github.com/mixxxdj/mixxx/pull/11367)
+  [#11365](https://github.com/mixxxdj/mixxx/issues/11365)
+* JACK API: Allow to explicit select buffers of 2048 and 4096 frames/period. They are not
+  supported by the automatic buffer setting of the used PortAudio library.
+  [#11366](https://github.com/mixxxdj/mixxx/pull/11366)
+  [#11341](https://github.com/mixxxdj/mixxx/issues/11341)
+* Pioneer DDJ-400: Make Beat FX section more intuitive
+  [#10912](https://github.com/mixxxdj/mixxx/pull/10912)
+* Playlist export: Fix chained file extensions after changing the playlist type.
+  [#11332](https://github.com/mixxxdj/mixxx/pull/11332)
+  [#11327](https://github.com/mixxxdj/mixxx/issues/11327)
+* LateNight: brighter fx parameter buttons
+  [#11397](https://github.com/mixxxdj/mixxx/pull/11397)
+
 ## [2.3.4](https://launchpad.net/mixxx/+milestone/2.3.4) (2023-03-03)
 
 * Track Properties: Show 'date added' as local time [#4838](https://github.com/mixxxdj/mixxx/pull/4838) [lp:1980658](https://bugs.launchpad.net/mixxx/+bug/1980658)

--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -98,6 +98,56 @@
   Do not edit it manually.
   -->
   <releases>
+    <release version="2.3.5" type="development" date="2023-03-26" timestamp="1679839779">
+      <description>
+ <ul>
+  <li>
+   Fix empty waveform overview after loading a track. This fixes a Mixxx 2.3.4 regression
+  since
+   #11162
+   .
+  Fixed by
+   #11333
+   #11359
+   #11344
+  </li>
+  <li>
+   Fullscreen: Fix a crash that occurs on Linux after enabling fullsceen and using menu
+  shortcuts e.g. Alt-F.
+   #11328
+   #11320
+  </li>
+  <li>
+   Fullscreen: Rebuild &amp; reconnect menu only on desktops with global menu
+   #11350
+  </li>
+  <li>
+   macOS: Request Microphone and line-in access permission.
+   #11367
+   #11365
+  </li>
+  <li>
+   JACK API: Allow to explicit select buffers of 2048 and 4096 frames/period. They are not
+  supported by the automatic buffer setting of the used PortAudio library.
+   #11366
+   #11341
+  </li>
+  <li>
+   Pioneer DDJ-400: Make Beat FX section more intuitive
+   #10912
+  </li>
+  <li>
+   Playlist export: Fix chained file extensions after changing the playlist type.
+   #11332
+   #11327
+  </li>
+  <li>
+   LateNight: brighter fx parameter buttons
+   #11397
+  </li>
+ </ul>
+</description>
+    </release>
     <release version="2.3.4" type="stable" date="2023-03-03" timestamp="1677801600">
       <description>
  <ul>

--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -98,14 +98,11 @@
   Do not edit it manually.
   -->
   <releases>
-    <release version="2.3.5" type="development" date="2023-03-26" timestamp="1679839779">
+    <release version="2.3.5" type="development" date="2023-04-03" timestamp="1680480478">
       <description>
  <ul>
   <li>
-   Fix empty waveform overview after loading a track. This fixes a Mixxx 2.3.4 regression
-  since
-   #11162
-   .
+   Fix empty waveform overview after loading a track (Mixxx 2.3.4 regression)
   Fixed by
    #11333
    #11359
@@ -137,13 +134,28 @@
    #10912
   </li>
   <li>
-   Playlist export: Fix chained file extensions after changing the playlist type.
+   Playlist export: Adopt new extension after changing the playlist type
    #11332
    #11327
   </li>
   <li>
    LateNight: brighter fx parameter buttons
    #11397
+  </li>
+  <li>
+   Fix drift in analyzis data after exporting metadata to MP3 files with ID3v1.1 tags
+   #11168
+   #11159
+  </li>
+  <li>
+   Fix broadcasting using Opus encoding
+   #11349
+   #10666
+  </li>
+  <li>
+   Tango: Remove VU peak indicators from stacked layout. This fixes a visual regression in Mixxx 2.3.4.
+   #11430
+   #11362
   </li>
  </ul>
 </description>


### PR DESCRIPTION
This is a first step towards a 2.3.5 release.
Due to some regressions in 2.3.4, we should release it soon. 

The milestone can be watched here:
https://github.com/mixxxdj/mixxx/milestone/39

This is the link to the pending 2.3 PRs: 
https://github.com/mixxxdj/mixxx/pulls?q=is%3Apr+is%3Aopen+base%3A2.3


 