### PR TITLE
Revert "Disable qml-formatter unit #11386 is fixed"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,11 +118,10 @@ repos:
     hooks:
       - id: prettier
         types: [yaml]
-  # disabled until  https://github.com/mixxxdj/mixxx/issues/11386 is fixed
-  #- repo: https://github.com/qarmin/qml_formatter.git
-  #  rev: 0.2.0
-  #  hooks:
-  #    - id: qml_formatter
+  - repo: https://github.com/qarmin/qml_formatter.git
+    rev: 0.2.0
+    hooks:
+      - id: qml_formatter
   - repo: local
     hooks:
       - id: qsscheck


### PR DESCRIPTION
This reverts commit 39a5b35be02147a63d56e201bfbb64d1be49e5dc.