### PR TITLE
Preferences > Controller: don't expand page horizontally if mapping description has very long lines

### DIFF
--- a/src/controllers/dlgprefcontrollerdlg.ui
+++ b/src/controllers/dlgprefcontrollerdlg.ui
@@ -237,7 +237,7 @@
           <item row="2" column="1">
            <widget class="QLabel" name="labelLoadedPresetDescription">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>


### PR DESCRIPTION
to avoid horizontal scrollbars. (wordWrap = true is not working as expected)
The label is expanding vertically instead.