### PR TITLE
debug: omit 'QFileInfo()' when printing track file locations

### DIFF
--- a/src/analyzer/analyzerthread.cpp
+++ b/src/analyzer/analyzerthread.cpp
@@ -127,7 +127,7 @@ void AnalyzerThread::doRun() {
 
     while (awaitWorkItemsFetched()) {
         DEBUG_ASSERT(m_currentTrack);
-        kLogger.debug() << "Analyzing" << m_currentTrack->getFileInfo();
+        kLogger.debug() << "Analyzing" << m_currentTrack->getLocation();
 
         // Get the audio
         const auto audioSource =
@@ -135,7 +135,7 @@ void AnalyzerThread::doRun() {
         if (!audioSource) {
             kLogger.warning()
                     << "Failed to open file for analyzing:"
-                    << m_currentTrack->getFileInfo();
+                    << m_currentTrack->getLocation();
             emitDoneProgress(kAnalyzerProgressUnknown);
             continue;
         }

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -265,7 +265,7 @@ void AutoDJFeature::slotAddRandomTrack() {
                 if (!pRandomTrack->checkFileExists()) {
                     qWarning() << "Track does not exist:"
                                << pRandomTrack->getInfo()
-                               << pRandomTrack->getFileInfo();
+                               << pRandomTrack->getLocation();
                     pRandomTrack.reset();
                 }
             }

--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -194,7 +194,7 @@ bool BaseTrackCache::updateTrackInIndex(
         return false;
     }
     if (sDebug) {
-        qDebug() << "updateTrackInIndex:" << pTrack->getFileInfo();
+        qDebug() << "updateTrackInIndex:" << pTrack->getLocation();
     }
 
     int numColumns = columnCount();

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -279,8 +279,8 @@ void TrackDAO::saveTrack(Track* pTrack) const {
         return;
     }
     qDebug() << "TrackDAO: Saving track"
-            << trackId
-            << pTrack->getFileInfo();
+             << trackId
+             << pTrack->getLocation();
     if (updateTrack(pTrack)) {
         // BaseTrackCache must be informed separately, because the
         // track has already been disconnected and TrackDAO does
@@ -534,13 +534,13 @@ TrackId TrackDAO::addTracksAddTrack(const TrackPointer& pTrack, bool unremove) {
     VERIFY_OR_DEBUG_ASSERT(m_pQueryLibraryInsert || m_pQueryTrackLocationInsert ||
         m_pQueryLibrarySelect || m_pQueryTrackLocationSelect) {
         qDebug() << "TrackDAO::addTracksAddTrack: needed SqlQuerys have not "
-                "been prepared. Skipping track"
-                << pTrack->getFileInfo();
+                    "been prepared. Skipping track"
+                 << pTrack->getLocation();
         return TrackId();
     }
 
     qDebug() << "TrackDAO: Adding track"
-            << pTrack->getFileInfo();
+             << pTrack->getLocation();
 
     TrackId trackId;
 
@@ -572,10 +572,10 @@ TrackId TrackDAO::addTracksAddTrack(const TrackPointer& pTrack, bool unremove) {
 
         m_pQueryLibrarySelect->bindValue(":location", trackLocationId.toVariant());
         if (!m_pQueryLibrarySelect->exec()) {
-             LOG_FAILED_QUERY(*m_pQueryLibrarySelect)
-                     << "Failed to query existing track: "
-                     << pTrack->getFileInfo();
-             return TrackId();
+            LOG_FAILED_QUERY(*m_pQueryLibrarySelect)
+                    << "Failed to query existing track: "
+                    << pTrack->getLocation();
+            return TrackId();
         }
         if (m_queryLibraryIdColumn == UndefinedRecordIndex) {
             QSqlRecord queryLibraryRecord = m_pQueryLibrarySelect->record();
@@ -601,7 +601,7 @@ TrackId TrackDAO::addTracksAddTrack(const TrackPointer& pTrack, bool unremove) {
             if (!m_pQueryLibraryUpdate->exec()) {
                 LOG_FAILED_QUERY(*m_pQueryLibraryUpdate)
                         << "Failed to unremove existing track: "
-                        << pTrack->getFileInfo();
+                        << pTrack->getLocation();
                 return TrackId();
             }
         }
@@ -716,8 +716,8 @@ TrackPointer TrackDAO::addTracksAddFile(const TrackFile& trackFile, bool unremov
     const TrackId newTrackId = addTracksAddTrack(pTrack, unremove);
     if (!newTrackId.isValid()) {
         qWarning() << "TrackDAO::addTracksAddTrack:"
-                << "Failed to add track to database"
-                << pTrack->getFileInfo();
+                   << "Failed to add track to database"
+                   << pTrack->getLocation();
         // GlobalTrackCache will be unlocked implicitly
         return TrackPointer();
     }
@@ -1418,9 +1418,9 @@ bool TrackDAO::updateTrack(Track* pTrack) const {
     DEBUG_ASSERT(trackId.isValid());
 
     qDebug() << "TrackDAO:"
-            << "Updating track in database"
-            << trackId
-            << pTrack->getFileInfo();
+             << "Updating track in database"
+             << trackId
+             << pTrack->getLocation();
 
     SqlTransaction transaction(m_database);
     // PerformanceTimer time;

--- a/src/musicbrainz/chromaprinter.cpp
+++ b/src/musicbrainz/chromaprinter.cpp
@@ -119,7 +119,7 @@ QString ChromaPrinter::getFingerprint(TrackPointer pTrack) {
     if (!pAudioSource) {
         qDebug()
                 << "Failed to open file for fingerprinting"
-                << pTrack->getFileInfo();
+                << pTrack->getLocation();
         return QString();
     }
 

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -656,7 +656,7 @@ void SoundSourceProxy::updateTrackFromSource(
                 << "Parsing missing"
                 << (splitArtistTitle ? "artist/title" : "title")
                 << "from file name:"
-                << trackFile;
+                << trackFile.location();
         if (trackMetadata.refTrackInfo().parseArtistTitleFromFileName(
                     trackFile.fileName(), splitArtistTitle)) {
             // Pretend that metadata import succeeded


### PR DESCRIPTION
and simply print location directly.
should make logs a bit easier to read.