### PR TITLE
Fix track selection if no track selected

### DIFF
--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -689,6 +689,9 @@ std::unique_ptr<mixxx::LibraryExporter> Library::makeLibraryExporter(
 #endif
 
 bool Library::isTrackIdInCurrentLibraryView(const TrackId& trackId) {
+    VERIFY_OR_DEBUG_ASSERT(trackId.isValid()) {
+        return false;
+    }
     if (m_pLibraryWidget) {
         return m_pLibraryWidget->isTrackInCurrentView(trackId);
     } else {

--- a/src/widget/wlibrary.cpp
+++ b/src/widget/wlibrary.cpp
@@ -95,6 +95,9 @@ LibraryView* WLibrary::getActiveView() const {
 
 bool WLibrary::isTrackInCurrentView(const TrackId& trackId) {
     //qDebug() << "WLibrary::isTrackInCurrentView" << trackId;
+    VERIFY_OR_DEBUG_ASSERT(trackId.isValid()) {
+        return false;
+    }
     QWidget* current = currentWidget();
     WTrackTableView* tracksView = qobject_cast<WTrackTableView*>(current);
     if (!tracksView) {
@@ -115,6 +118,10 @@ bool WLibrary::isTrackInCurrentView(const TrackId& trackId) {
 
 void WLibrary::slotSelectTrackInActiveTrackView(const TrackId& trackId) {
     //qDebug() << "WLibrary::slotSelectTrackInActiveTrackView" << trackId;
+    if (!trackId.isValid()) {
+        return;
+    }
+
     QWidget* current = currentWidget();
     WTrackTableView* tracksView = qobject_cast<WTrackTableView*>(current);
     if (!tracksView) {

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1022,6 +1022,9 @@ TrackId WTrackTableView::getCurrentTrackId() const {
 }
 
 bool WTrackTableView::isTrackInCurrentView(const TrackId& trackId) {
+    VERIFY_OR_DEBUG_ASSERT(trackId.isValid()) {
+        return false;
+    }
     //qDebug() << "WTrackTableView::isTrackInCurrentView" << trackId;
     TrackModel* pTrackModel = getTrackModel();
     VERIFY_OR_DEBUG_ASSERT(pTrackModel != nullptr) {
@@ -1057,6 +1060,10 @@ void WTrackTableView::setSelectedTracks(const QList<TrackId>& trackIds) {
 }
 
 bool WTrackTableView::setCurrentTrackId(const TrackId& trackId, int column, bool scrollToTrack) {
+    VERIFY_OR_DEBUG_ASSERT(trackId.isValid()) {
+        return false;
+    }
+
     QItemSelectionModel* pSelectionModel = selectionModel();
     VERIFY_OR_DEBUG_ASSERT(pSelectionModel != nullptr) {
         qWarning() << "No selection model";
@@ -1124,8 +1131,10 @@ void WTrackTableView::slotAddToAutoDJReplace() {
 }
 
 void WTrackTableView::slotSelectTrack(const TrackId& trackId) {
-    if (setCurrentTrackId(trackId, 0, true)) {
+    if (trackId.isValid() && setCurrentTrackId(trackId, 0, true)) {
         setSelectedTracks({trackId});
+    } else {
+        setSelectedTracks({});
     }
 }
 


### PR DESCRIPTION
The invocations were pointless. They also cause issues for consumers that actually check the arguments instead of blindly continuing with invalid values, hoping that other code applies safe fallbacks.