### PR TITLE
fix(qml): Fix type error in `Slider.qml`

### DIFF
--- a/res/qml/Slider.qml
+++ b/res/qml/Slider.qml
@@ -27,8 +27,6 @@ MixxxControls.Slider {
 
         width: handleImage.paintedWidth
         height: handleImage.paintedHeight
-        anchors.horizontalCenter: root.vertical ? parent.horizontalCenter : undefined
-        anchors.verticalCenter: root.horizontal ? parent.verticalCenter : undefined
         x: root.horizontal ? (root.visualPosition * (root.width - width)) : ((root.width - width) / 2)
         y: root.vertical ? (root.visualPosition * (root.height - height)) : ((root.height - height) / 2)
 


### PR DESCRIPTION
Fixes a bunch of warnings like this:

    warning [Main] file://res/qml/Slider.qml:31: TypeError: Cannot read property 'verticalCenter' of null