### PR TITLE
Properly Handle mismatch between Presets and EffectUnits with different amount of Effect slots

### DIFF
--- a/src/effects/chains/equalizereffectchain.cpp
+++ b/src/effects/chains/equalizereffectchain.cpp
@@ -18,6 +18,15 @@ EqualizerEffectChain::EqualizerEffectChain(
     addEffectSlot(formatEffectSlotGroup(handleAndGroup.name()));
     enableForInputChannel(handleAndGroup);
     m_effectSlots[0]->setEnabled(true);
+
+    QObject::connect(this,
+            &EffectChain::chainPresetChanged,
+            this,
+            [this](const QString& presetname) {
+                Q_UNUSED(presetname);
+                setFilterWaveform(
+                        m_effectSlots.at(0)->getManifest()->isMixingEQ());
+            });
     // DlgPrefEq loads the Effect with loadEffectToGroup
 
     setupLegacyAliasesForGroup(handleAndGroup.name());

--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -200,23 +200,23 @@ const QString& EffectChain::presetName() const {
     return m_presetName;
 }
 
-void EffectChain::loadChainPreset(EffectChainPresetPointer pPreset) {
+void EffectChain::loadChainPreset(EffectChainPresetPointer pChainPreset) {
     slotControlClear(1);
-    VERIFY_OR_DEBUG_ASSERT(pPreset) {
+    VERIFY_OR_DEBUG_ASSERT(pChainPreset) {
         return;
     }
 
     int effectSlotIndex = 0;
-    for (const auto& pEffectPreset : pPreset->effectPresets()) {
+    for (const auto& pEffectPreset : pChainPreset->effectPresets()) {
         EffectSlotPointer pEffectSlot = m_effectSlots.at(effectSlotIndex);
         pEffectSlot->loadEffectFromPreset(pEffectPreset);
         effectSlotIndex++;
     }
 
-    setMixMode(pPreset->mixMode());
-    m_pControlChainSuperParameter->setDefaultValue(pPreset->superKnob());
+    setMixMode(pChainPreset->mixMode());
+    m_pControlChainSuperParameter->setDefaultValue(pChainPreset->superKnob());
 
-    m_presetName = pPreset->name();
+    m_presetName = pChainPreset->name();
     emit chainPresetChanged(m_presetName);
 
     setControlLoadedPresetIndex(presetIndex());

--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -206,11 +206,17 @@ void EffectChain::loadChainPreset(EffectChainPresetPointer pChainPreset) {
         return;
     }
 
-    int effectSlotIndex = 0;
-    for (const auto& pEffectPreset : pChainPreset->effectPresets()) {
-        EffectSlotPointer pEffectSlot = m_effectSlots.at(effectSlotIndex);
-        pEffectSlot->loadEffectFromPreset(pEffectPreset);
-        effectSlotIndex++;
+    const QList effectPresets = pChainPreset->effectPresets();
+
+    // TODO: use C++23 std::ranges::views::zip instead
+    // `EffectChain`s can create arbitrary amounts of effectslots and chain presets
+    // can contain an arbitrary number of effects. This ensures we only load
+    // as many effects as we have slots available.
+    const int validPresetSlotCount = std::min(effectPresets.count(), m_effectSlots.count());
+    for (int presetSlotIndex = 0;
+            presetSlotIndex < validPresetSlotCount;
+            presetSlotIndex++) {
+        m_effectSlots[presetSlotIndex]->loadEffectFromPreset(effectPresets[presetSlotIndex]);
     }
 
     setMixMode(pChainPreset->mixMode());


### PR DESCRIPTION
Fixes #11376

However, it does not address the question whether the EQ should be implemented in terms of an EffectChain