### PR TITLE
WTrackTableView: Fix debug assertion in setCurrentTrackId()

### DIFF
--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1060,7 +1060,7 @@ void WTrackTableView::setSelectedTracks(const QList<TrackId>& trackIds) {
 }
 
 bool WTrackTableView::setCurrentTrackId(const TrackId& trackId, int column, bool scrollToTrack) {
-    VERIFY_OR_DEBUG_ASSERT(trackId.isValid()) {
+    if (!trackId.isValid()) {
         return false;
     }
 


### PR DESCRIPTION
Invoked by onSearch() with an invalid id.