### PR TITLE
fix(controllers): explicitly overwrite JogWheelBasic input handler

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -784,6 +784,10 @@
                 engine.scratchDisable(this.deck);
             }
         },
+        input: function(_channel, control, _value, status, _group) {
+            throw "Called wrong input handler for " + status + ": " + control + ".\n" +
+                "Please bind jogwheel-related messages to inputWheel and inputTouch!\n";
+        }
     });
 
     var EffectUnit = function(unitNumbers, allowFocusWhenParametersHidden, colors) {


### PR DESCRIPTION
This should make it obvious when JogWheelBasic controls are bound to the wrong input handler.

Would help to detect issues such as the one described on Zulip: https://mixxx.zulipchat.com/#narrow/stream/113295-controller-mapping/topic/Denon.20Prime.204/near/346282010