### PR TITLE
Slip mode: consider active (regular) loop

### DIFF
--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -1062,6 +1062,11 @@ void LoopingControl::slotLoopEndPos(double positionSamples) {
 void LoopingControl::notifySeek(mixxx::audio::FramePos position) {
     LoopInfo loopInfo = m_loopInfo.getValue();
     const auto currentPosition = m_currentPosition.getValue();
+    VERIFY_OR_DEBUG_ASSERT(m_pRateControl) {
+        qWarning() << "LoopingControl: RateControl not set!";
+        return;
+    }
+    bool reverse = m_pRateControl->isReverseButtonPressed();
     if (m_bLoopingEnabled) {
         // Disable loop when we jumping out, or over a catching loop,
         // using hot cues or waveform overview.
@@ -1347,10 +1352,11 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable
     } else {
         // If running reverse, move the loop one loop size to the left.
         // Thus, the loops end will be closest to the current position
-        bool reverse = false;
-        if (m_pRateControl != nullptr) {
-            reverse = m_pRateControl->isReverseButtonPressed();
+        VERIFY_OR_DEBUG_ASSERT(m_pRateControl) {
+            qWarning() << "LoopingControl: RateControl not set!";
+            return;
         }
+        bool reverse = m_pRateControl->isReverseButtonPressed();
         if (reverse) {
             currentPosition = pBeats->findNBeatsFromPosition(currentPosition, -beats);
         }

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -1065,6 +1065,12 @@ void LoopingControl::slotLoopEndPos(double positionSamples) {
 
 // This is called from the engine thread
 void LoopingControl::notifySeek(mixxx::audio::FramePos newPosition) {
+    // Leave loop alone if we're in slip mode and if it was turned on
+    // by something that was not a rolling beatloop.
+    if (m_pSlipEnabled->toBool() && !m_bLoopRollActive) {
+        return;
+    }
+
     LoopInfo loopInfo = m_loopInfo.getValue();
     const auto currentPosition = m_currentPosition.getValue();
     VERIFY_OR_DEBUG_ASSERT(m_pRateControl) {

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -1118,6 +1118,10 @@ bool LoopingControl::isLoopingEnabled() {
     return m_bLoopingEnabled;
 }
 
+bool LoopingControl::isLoopRollActive() {
+    return m_bLoopRollActive;
+}
+
 void LoopingControl::trackLoaded(TrackPointer pNewTrack) {
     m_pTrack = pNewTrack;
     mixxx::BeatsPointer pBeats;
@@ -1600,6 +1604,28 @@ void LoopingControl::slotLoopMove(double beats) {
         emit loopUpdated(loopInfo.startPosition, loopInfo.endPosition);
         m_pCOLoopStartPosition->set(loopInfo.startPosition.toEngineSamplePosMaybeInvalid());
         m_pCOLoopEndPosition->set(loopInfo.endPosition.toEngineSamplePosMaybeInvalid());
+    }
+}
+
+// Used to simulate looping while slip mode is enabled
+mixxx::audio::FramePos LoopingControl::adjustedPositionForCurrentLoop(
+        mixxx::audio::FramePos currentPosition,
+        bool reverse) {
+    if (!m_bLoopingEnabled) {
+        return currentPosition;
+    }
+    LoopInfo loopInfo = m_loopInfo.getValue();
+    const auto targetPosition = adjustedPositionInsideAdjustedLoop(
+            currentPosition,
+            reverse,
+            loopInfo.startPosition,
+            loopInfo.endPosition,
+            loopInfo.startPosition,
+            loopInfo.endPosition);
+    if (targetPosition.isValid()) {
+        return targetPosition;
+    } else {
+        return currentPosition;
     }
 }
 

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -377,7 +377,7 @@ void LoopingControl::process(const double dRate,
                     // here the loop has changed and the play position
                     // should be moved with it
                     const auto targetPosition =
-                            seekInsideAdjustedLoop(currentPosition,
+                            adjustedPositionInsideAdjustedLoop(currentPosition,
                                     dRate < 0, // reverse
                                     m_oldLoopInfo.startPosition,
                                     m_oldLoopInfo.endPosition,
@@ -446,7 +446,7 @@ mixxx::audio::FramePos LoopingControl::nextTrigger(bool reverse,
             case LoopSeekMode::Changed:
                 // here the loop has changed and the play position
                 // should be moved with it
-                *pTargetPosition = seekInsideAdjustedLoop(currentPosition,
+                *pTargetPosition = adjustedPositionInsideAdjustedLoop(currentPosition,
                         reverse,
                         m_oldLoopInfo.startPosition,
                         m_oldLoopInfo.endPosition,
@@ -466,7 +466,7 @@ mixxx::audio::FramePos LoopingControl::nextTrigger(bool reverse,
                     }
                 }
                 if (movedOut) {
-                    *pTargetPosition = seekInsideAdjustedLoop(currentPosition,
+                    *pTargetPosition = adjustedPositionInsideAdjustedLoop(currentPosition,
                             reverse,
                             loopInfo.startPosition,
                             loopInfo.endPosition,
@@ -1603,8 +1603,7 @@ void LoopingControl::slotLoopMove(double beats) {
     }
 }
 
-// Must be called from the engine thread only
-mixxx::audio::FramePos LoopingControl::seekInsideAdjustedLoop(
+mixxx::audio::FramePos LoopingControl::adjustedPositionInsideAdjustedLoop(
         mixxx::audio::FramePos currentPosition,
         bool reverse,
         mixxx::audio::FramePos oldLoopStartPosition,
@@ -1656,7 +1655,7 @@ mixxx::audio::FramePos LoopingControl::seekInsideAdjustedLoop(
             // I'm not even sure this is possible.  The new loop would have to be bigger than the
             // old loop, and the playhead was somehow outside the old loop.
             qWarning()
-                    << "SHOULDN'T HAPPEN: seekInsideAdjustedLoop "
+                    << "SHOULDN'T HAPPEN: adjustedPositionInsideAdjustedLoop "
                        "couldn't find a new position --"
                     << " seeking to in point";
             adjustedPosition = newLoopStartPosition;
@@ -1671,7 +1670,7 @@ mixxx::audio::FramePos LoopingControl::seekInsideAdjustedLoop(
         DEBUG_ASSERT(adjustedPosition >= newLoopStartPosition);
         VERIFY_OR_DEBUG_ASSERT(adjustedPosition < newLoopEndPosition) {
             qWarning()
-                    << "SHOULDN'T HAPPEN: seekInsideAdjustedLoop "
+                    << "SHOULDN'T HAPPEN: adjustedPositionInsideAdjustedLoop "
                        "couldn't find a new position --"
                     << " seeking to in point";
             adjustedPosition = newLoopStartPosition;

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -130,8 +130,8 @@ class LoopingControl : public EngineControl {
             mixxx::audio::FramePos endPosition) const;
     // When a loop changes size such that the playposition is outside of the loop,
     // we can figure out the best place in the new loop to seek to maintain
-    // the beat.  It will even keep multi-bar phrasing correct with 4/4 tracks.
-    mixxx::audio::FramePos seekInsideAdjustedLoop(
+    // the beat. It will even keep multi-bar phrasing correct with 4/4 tracks.
+    mixxx::audio::FramePos adjustedPositionInsideAdjustedLoop(
             mixxx::audio::FramePos currentPosition,
             bool reverse,
             mixxx::audio::FramePos oldLoopInPosition,

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -133,7 +133,9 @@ class LoopingControl : public EngineControl {
     // the beat.  It will even keep multi-bar phrasing correct with 4/4 tracks.
     mixxx::audio::FramePos seekInsideAdjustedLoop(
             mixxx::audio::FramePos currentPosition,
+            bool reverse,
             mixxx::audio::FramePos oldLoopInPosition,
+            mixxx::audio::FramePos oldLoopOutPosition,
             mixxx::audio::FramePos newLoopInPosition,
             mixxx::audio::FramePos newLoopOutPosition);
     mixxx::audio::FramePos findQuantizedBeatloopStart(

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -48,12 +48,19 @@ class LoopingControl : public EngineControl {
 
     void notifySeek(mixxx::audio::FramePos position) override;
 
+    // Wrapper to use adjustedPositionInsideAdjustedLoop() with the current loop.
+    // Called from EngineBuffer while slip mode is enabled
+    mixxx::audio::FramePos adjustedPositionForCurrentLoop(
+            mixxx::audio::FramePos newPosition,
+            bool reverse);
+
     void setBeatLoop(mixxx::audio::FramePos startPosition, bool enabled);
     void setLoop(mixxx::audio::FramePos startPosition,
             mixxx::audio::FramePos endPosition,
             bool enabled);
     void setRateControl(RateControl* rateControl);
     bool isLoopingEnabled();
+    bool isLoopRollActive();
 
     void trackLoaded(TrackPointer pNewTrack) override;
     void trackBeatsUpdated(mixxx::BeatsPointer pBeats) override;


### PR DESCRIPTION
I was curious why this hasn't been implemented earlier, and couldn't really believe "this is super complicated though so it will be a lot of effort to fix" (2013, #6993).

So, this is POC and it performs nicely with active loops (no change for rolling loops).
I  didn't run the tests, yet, only tested manually: play a track, set up a loop, clone that deck, then engage slip mode, mess around a bit with the waveform. Disabled slip mode and both decks were in sync.

I don't intend to finish this (unless just polishing is required for merging), I just want to share my experiment and give a starting point for others, so feel free to pick this up.
I guess the code can be improved and the tests should probably to be extended.