### PR TITLE
DlgTrackInfo: add track color selector

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -285,9 +285,6 @@ void DlgTrackInfo::slotCancel() {
     reject();
 }
 
-void DlgTrackInfo::trackUpdated() {
-}
-
 void DlgTrackInfo::slotNextButton() {
     loadNextTrack();
 }

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -264,7 +264,10 @@ void DlgTrackInfo::init() {
     connect(m_pColorPicker.get(),
             &WColorPickerAction::colorPicked,
             this,
-            &DlgTrackInfo::slotColorPicked);
+            [this](const mixxx::RgbColor::optional_t& newColor) {
+                trackColorDialogSetColor(newColor);
+                m_trackRecord.setColor(newColor);
+            });
 }
 
 void DlgTrackInfo::slotApply() {
@@ -332,7 +335,7 @@ void DlgTrackInfo::updateFromTrack(const Track& track) {
             track.getLocation());
 
     // paint the color selector and check the respective color picker button
-    slotColorPicked(track.getColor());
+    trackColorDialogSetColor(track.getColor());
 
     txtLocation->setText(QDir::toNativeSeparators(track.getLocation()));
 
@@ -524,11 +527,9 @@ void DlgTrackInfo::slotColorButtonClicked() {
     btnColorPicker->showMenu();
 }
 
-void DlgTrackInfo::slotColorPicked(const mixxx::RgbColor::optional_t& newColor) {
+void DlgTrackInfo::trackColorDialogSetColor(const mixxx::RgbColor::optional_t& newColor) {
     m_pColorPicker->setSelectedColor(newColor);
     btnColorPicker->menu()->close();
-
-    m_trackRecord.setColor(newColor);
 
     if (newColor) {
         btnColorPicker->setText("");
@@ -545,7 +546,6 @@ void DlgTrackInfo::slotColorPicked(const mixxx::RgbColor::optional_t& newColor) 
         btnColorPicker->setText(tr("(no color)"));
         // clear custom stylesheet, i.e. restore Fusion style,
         btnColorPicker->setStyleSheet("");
-        ;
     }
 }
 

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -70,7 +70,6 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void slotTrackChanged(TrackId trackId);
     void slotOpenInFileBrowser();
     void slotColorButtonClicked();
-    void slotColorPicked(const mixxx::RgbColor::optional_t& color);
 
     void slotCoverFound(
             const QObject* pRequestor,
@@ -86,6 +85,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void loadPrevTrack();
     void loadTrackInternal(const TrackPointer& pTrack);
     void reloadTrackBeats(const Track& track);
+    void trackColorDialogSetColor(const mixxx::RgbColor::optional_t& color);
     void saveTrack();
     void clear();
     void init();

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -13,12 +13,14 @@
 #include "track/trackrecord.h"
 #include "util/parented_ptr.h"
 #include "util/tapfilter.h"
+#include "widget/wcolorpickeraction.h"
 
 class TrackModel;
 class DlgTagFetcher;
 class WCoverArtLabel;
 class WCoverArtMenu;
 class WStarRating;
+class WColorPickerAction;
 
 /// A dialog box to display and edit track properties.
 /// Use TrackPointer to load a track into the dialog or
@@ -67,6 +69,8 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
 
     void slotTrackChanged(TrackId trackId);
     void slotOpenInFileBrowser();
+    void slotColorButtonClicked();
+    void slotColorPicked(const mixxx::RgbColor::optional_t& color);
 
     void slotCoverFound(
             const QObject* pRequestor,
@@ -122,6 +126,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     parented_ptr<WCoverArtMenu> m_pWCoverArtMenu;
     parented_ptr<WCoverArtLabel> m_pWCoverArtLabel;
     parented_ptr<WStarRating> m_pWStarRating;
+    parented_ptr<WColorPickerAction> m_pColorPicker;
 
     std::unique_ptr<DlgTagFetcher> m_pDlgTagFetcher;
 };

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -54,8 +54,6 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void slotApply();
     void slotCancel();
 
-    void trackUpdated();
-
     void slotBpmScale(mixxx::Beats::BpmScale bpmScale);
     void slotBpmClear();
     void slotBpmConstChanged(int state);

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -93,8 +93,7 @@
               </property>
              </widget>
             </item>
-
-            <item row="0" column="2" colspan="2" rowspan="3">
+            <item row="0" column="2" rowspan="3" colspan="2">
              <widget class="QWidget" name="verticalWidgetCover" native="true">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -438,8 +437,45 @@
              </layout>
             </item>
 
+            <item row="9" column="0">
+             <widget class="QLabel" name="lblTrackColor">
+              <property name="text">
+               <string>Color</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+              </property>
+             </widget>
+            </item>
+
+            <item row="9" column="1" colspan="3">
+             <widget class="QPushButton" name="btnColorPicker">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+
+            <item>
+             <spacer name="horizontalSpacer_5">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>10</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
            </layout>
           </item>
+
+
          </layout>
         </widget>
        </item>
@@ -1000,6 +1036,7 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
   <tabstop>txtTrackNumber</tabstop>
   <tabstop>btnImportMetadataFromMusicBrainz</tabstop>
   <tabstop>btnImportMetadataFromFile</tabstop>
+  <tabstop>btnColorPicker</tabstop>
   <tabstop>btnOpenFileBrowser</tabstop>
   <tabstop>spinBpm</tabstop>
   <tabstop>bpmConst</tabstop>


### PR DESCRIPTION
supersedes #11390 

Uses `WColorPickerAction`
This requires two buttons, each with the color picker that's used in the track menu and hotcue popup:
* colored button: 'fusion' style to allow coloring the button with a simple stylesheet
* 'no color' button with default style theme that looks like the other buttons in the dialog (unless it's focused, then the OS theme's indicator may distort the appearance)

**ToDo**
- [x] add checkmark to selected color button (like in the track menu, should actually already be styled by `skin/default.qss` :shrug: ) **edit:** IIRC this requires to allow custom styles for the entire dialog / color picker which could cause trouble (inheritance of WLibraryTableView styles, conflicts with system style) so maybe we need to fix this in c++, WColorPicker/~Action

![Screenshot_2023-04-03_14-42-57](https://user-images.githubusercontent.com/5934199/229513507-0d720ebf-c3b5-41e6-bf36-868356015d80.png)
![Screenshot_2023-04-03_14-42-42](https://user-images.githubusercontent.com/5934199/229513523-a639fe09-69d2-4808-835d-5b3e70b852bf.png)
![image](https://user-images.githubusercontent.com/5934199/229515352-32edcb72-cd55-4535-b9c2-18f5104952e1.png)

