### PR TITLE
some WColorPicker fixes

### DIFF
--- a/src/dialog/dlgreplacecuecolor.cpp
+++ b/src/dialog/dlgreplacecuecolor.cpp
@@ -90,9 +90,11 @@ DlgReplaceCueColor::DlgReplaceCueColor(
     }
     setButtonColor(pushButtonNewColor, mixxx::RgbColor::toQColor(firstColor));
 
-    // Add menu for new color button
+    // Add menu for 'New color' button
     m_pNewColorPickerAction = make_parented<WColorPickerAction>(
-            WColorPicker::Option::AllowCustomColor,
+            WColorPicker::Option::AllowCustomColor |
+                    // TODO(xxx) remove this once the preferences are themed via QSS
+                    WColorPicker::Option::NoExtStyleSheet,
             colorPaletteSettings.getHotcueColorPalette(),
             this);
     m_pNewColorPickerAction->setObjectName("HotcueColorPickerAction");
@@ -110,7 +112,7 @@ DlgReplaceCueColor::DlgReplaceCueColor(
     m_pNewColorMenu->addAction(m_pNewColorPickerAction);
     pushButtonNewColor->setMenu(m_pNewColorMenu);
 
-    // Set up current color button
+    // Set up 'Current color' button
     setButtonColor(pushButtonCurrentColor,
             mixxx::RgbColor::toQColor(
                     mixxx::PredefinedColorPalettes::kDefaultCueColor));
@@ -122,9 +124,11 @@ DlgReplaceCueColor::DlgReplaceCueColor(
             this,
             &DlgReplaceCueColor::slotUpdateWidgets);
 
-    // Add menu for current color button
+    // Add menu for 'Current color' button
     m_pCurrentColorPickerAction = make_parented<WColorPickerAction>(
-            WColorPicker::Option::AllowCustomColor,
+            WColorPicker::Option::AllowCustomColor |
+                    // TODO(xxx) remove this once the preferences are themed via QSS
+                    WColorPicker::Option::NoExtStyleSheet,
             colorPaletteSettings.getHotcueColorPalette(),
             this);
     m_pCurrentColorPickerAction->setObjectName("HotcueColorPickerAction");

--- a/src/dialog/dlgreplacecuecolor.cpp
+++ b/src/dialog/dlgreplacecuecolor.cpp
@@ -132,7 +132,7 @@ DlgReplaceCueColor::DlgReplaceCueColor(
             colorPaletteSettings.getHotcueColorPalette(),
             this);
     m_pCurrentColorPickerAction->setObjectName("HotcueColorPickerAction");
-    m_pNewColorPickerAction->setSelectedColor(
+    m_pCurrentColorPickerAction->setSelectedColor(
             mixxx::PredefinedColorPalettes::kDefaultCueColor);
     connect(m_pCurrentColorPickerAction,
             &WColorPickerAction::colorPicked,

--- a/src/widget/wcolorpicker.cpp
+++ b/src/widget/wcolorpicker.cpp
@@ -152,6 +152,9 @@ void WColorPicker::addColorButton(mixxx::RgbColor color, QGridLayout* pLayout, i
             QString("QPushButton { background-color: %1; }").arg(mixxx::RgbColor::toQString(color)));
     pButton->setToolTip(mixxx::RgbColor::toQString(color));
     pButton->setCheckable(true);
+    // Without this the button might shrink when setting the checkmark icon,
+    // both here or via external stylesheets.
+    pButton->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));
     m_colorButtons.append(pButton);
 
     connect(pButton,
@@ -174,6 +177,7 @@ void WColorPicker::addNoColorButton(QGridLayout* pLayout, int row, int column) {
         pButton->setProperty("noColor", true);
         pButton->setToolTip(tr("No color"));
         pButton->setCheckable(true);
+        pButton->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));
         connect(pButton,
                 &QPushButton::clicked,
                 this,

--- a/src/widget/wcolorpicker.cpp
+++ b/src/widget/wcolorpicker.cpp
@@ -231,6 +231,9 @@ void WColorPicker::setColorButtonChecked(mixxx::RgbColor::optional_t color, bool
     }
 
     pButton->setChecked(checked);
+    if (m_options.testFlag(Option::NoExtStyleSheet)) {
+        pButton->setIcon(QIcon(checked ? ":/images/ic_checkmark.svg" : ""));
+    }
     // This is needed to re-apply skin styles (e.g. to show/hide a checkmark icon)
     pButton->style()->unpolish(pButton);
     pButton->style()->polish(pButton);

--- a/src/widget/wcolorpicker.h
+++ b/src/widget/wcolorpicker.h
@@ -18,6 +18,12 @@ class WColorPicker : public QWidget {
         NoOptions = 0,
         AllowNoColor = 1,
         AllowCustomColor = 1 << 1,
+        // Some color pickers can be styled with the skin stylesheets,
+        // for example in WCueMenuPopup or WTrackMenu.
+        // If that's not possible (or just not done yet), for example in
+        // DlgReplaceCueColor and DlgTrackInfo, use this option to un/set
+        // the checkmark icon on de/selected color buttons in c++.
+        NoExtStyleSheet = 1 << 2,
     };
     Q_DECLARE_FLAGS(Options, Option);
 


### PR DESCRIPTION
fixing some bugs I noticed when I actually just wanted to set a checkmark for the selected colors in
Preferences > Colors > Replace Cue color

* prevent color button being resized when setting an icon (preferences, hotcue menu & track menu)
Previously, color buttons would shrink when setting the checkmark icon. For me this is fixed now, please test
* set a checkmark on selected color buttons (for the color pickers in hotcue menu & track menu this is done via res/skins/default.qss)
* fix initial check state in Preferences > Colors > Replace Cue color