### PR TITLE
iTunes: Move path mapping logic into XML importer and clean up slightly

### DIFF
--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-const QString ITDB_PATH_KEY = "mixxx.itunesfeature.itdbpath";
+const QString kItdbPathKey = "mixxx.itunesfeature.itdbpath";
 
 bool isMacOSImporterAvailable() {
 #ifdef __MACOS_ITUNES_LIBRARY__
@@ -179,7 +179,7 @@ void ITunesFeature::activate(bool forceReload) {
         emit showTrackModel(m_pITunesTrackModel);
 
         SettingsDAO settings(m_pTrackCollection->database());
-        QString dbSetting(settings.getValue(ITDB_PATH_KEY));
+        QString dbSetting(settings.getValue(kItdbPathKey));
         // if a path exists in the database, use it
         if (!dbSetting.isEmpty() && QFile::exists(dbSetting)) {
             m_dbfile = dbSetting;
@@ -210,7 +210,7 @@ void ITunesFeature::activate(bool forceReload) {
                 // that we can access the folder on future runs. We need to canonicalize
                 // the path so we first wrap the directory string with a QDir.
                 Sandbox::createSecurityToken(&fileInfo);
-                settings.setValue(ITDB_PATH_KEY, m_dbfile);
+                settings.setValue(kItdbPathKey, m_dbfile);
             }
         }
         m_isActivated =  true;
@@ -264,7 +264,7 @@ void ITunesFeature::onRightClick(const QPoint& globalPos) {
     QAction *chosen(menu.exec(globalPos));
     if (chosen == &useDefault) {
         SettingsDAO settings(m_database);
-        settings.setValue(ITDB_PATH_KEY, QString());
+        settings.setValue(kItdbPathKey, QString());
         activate(true); // clears tables before parsing
     } else if (chosen == &chooseNew) {
         SettingsDAO settings(m_database);
@@ -281,7 +281,7 @@ void ITunesFeature::onRightClick(const QPoint& globalPos) {
         // the path so we first wrap the directory string with a QDir.
         Sandbox::createSecurityToken(&dbFileInfo);
 
-        settings.setValue(ITDB_PATH_KEY, dbfile);
+        settings.setValue(kItdbPathKey, dbfile);
         activate(true); // clears tables before parsing
     }
 }

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -188,7 +188,7 @@ void ITunesFeature::activate(bool forceReload) {
             m_dbfile = getiTunesMusicPath();
         }
 
-        if (!m_dbfile.isEmpty() || !isMacOSImporterAvailable()) {
+        if (!isMacOSImporterUsed()) {
             mixxx::FileInfo fileInfo(m_dbfile);
             if (fileInfo.checkFileExists()) {
                 // Users of Mixxx <1.12.0 didn't support sandboxing. If we are sandboxed
@@ -250,6 +250,10 @@ QString ITunesFeature::showOpenDialog() {
             "iTunes XML (*.xml)");
 }
 
+bool ITunesFeature::isMacOSImporterUsed() {
+    return isMacOSImporterAvailable() && m_dbfile.isEmpty();
+}
+
 void ITunesFeature::onRightClick(const QPoint& globalPos) {
     BaseExternalLibraryFeature::onRightClick(globalPos);
     QMenu menu(m_pSidebarWidget);
@@ -304,7 +308,7 @@ QString ITunesFeature::getiTunesMusicPath() {
 
 std::unique_ptr<ITunesImporter> ITunesFeature::makeImporter() {
 #ifdef __MACOS_ITUNES_LIBRARY__
-    if (isMacOSImporterAvailable()) {
+    if (isMacOSImporterUsed()) {
         qDebug() << "Using ITunesMacOSImporter to read default iTunes library";
         return std::make_unique<ITunesMacOSImporter>(this, m_database, m_cancelImport);
     }

--- a/src/library/itunes/itunesfeature.h
+++ b/src/library/itunes/itunesfeature.h
@@ -59,6 +59,8 @@ class ITunesFeature : public BaseExternalLibraryFeature {
     /// returns the file path.
     QString showOpenDialog();
 
+    bool isMacOSImporterUsed();
+
     BaseExternalTrackModel* m_pITunesTrackModel;
     BaseExternalPlaylistModel* m_pITunesPlaylistModel;
     parented_ptr<TreeItemModel> m_pSidebarModel;

--- a/src/library/itunes/itunesfeature.h
+++ b/src/library/itunes/itunesfeature.h
@@ -10,7 +10,6 @@
 
 #include "library/baseexternallibraryfeature.h"
 #include "library/itunes/itunesimporter.h"
-#include "library/itunes/itunespathmapping.h"
 #include "library/trackcollection.h"
 #include "library/treeitem.h"
 #include "library/treeitemmodel.h"
@@ -80,8 +79,6 @@ class ITunesFeature : public BaseExternalLibraryFeature {
     QFutureWatcher<TreeItem*> m_future_watcher;
     QFuture<TreeItem*> m_future;
     QString m_title;
-
-    ITunesPathMapping m_pathMapping;
 
     QSharedPointer<BaseTrackCache> m_trackSource;
     QPointer<WLibrarySidebar> m_pSidebarWidget;

--- a/src/library/itunes/itunesimporter.h
+++ b/src/library/itunes/itunesimporter.h
@@ -6,7 +6,6 @@
 
 struct ITunesImport {
     std::unique_ptr<TreeItem> playlistRoot;
-    bool isMusicFolderLocatedAfterTracks;
 };
 
 class ITunesImporter {

--- a/src/library/itunes/itunesmacosimporter.mm
+++ b/src/library/itunes/itunesmacosimporter.mm
@@ -271,7 +271,6 @@ ITunesMacOSImporter::ITunesMacOSImporter(LibraryFeature* parentFeature,
 
 ITunesImport ITunesMacOSImporter::importLibrary() {
     ITunesImport iTunesImport;
-    iTunesImport.isMusicFolderLocatedAfterTracks = false;
 
     NSError* error = nil;
     ITLibrary* library = [[ITLibrary alloc] initWithAPIVersion:@"1.0"

--- a/src/library/itunes/itunesxmlimporter.h
+++ b/src/library/itunes/itunesxmlimporter.h
@@ -15,7 +15,6 @@ class ITunesXMLImporter : public ITunesImporter {
     ITunesXMLImporter(LibraryFeature* parentFeature,
             const QString& xmlFilePath,
             const QSqlDatabase& database,
-            ITunesPathMapping& pathMapping,
             const std::atomic<bool>& cancelImport);
 
     ITunesImport importLibrary() override;
@@ -29,8 +28,9 @@ class ITunesXMLImporter : public ITunesImporter {
     // thus there is an implicit contract here that this `ITunesXMLImporter` cannot
     // outlive the feature (which should not happen anyway, since importers are short-lived).
     const QSqlDatabase& m_database;
-    ITunesPathMapping& m_pathMapping;
     const std::atomic<bool>& m_cancelImport;
+
+    ITunesPathMapping m_pathMapping;
 
     void parseTracks();
     void guessMusicLibraryMountpoint();


### PR DESCRIPTION
This allows for cleaner separation of concerns, since the path mapping is not needed in the macOS importer (and potentially others in the future). Also, since the mapping is applied by the XML importer itself, having the iTunes feature own it at a higher level doesn't really prove beneficial.