### PR TITLE
Update to mixxx-deps-2.3-x64-windows-318a1b3

### DIFF
--- a/packaging/windows/build_environment
+++ b/packaging/windows/build_environment
@@ -1,1 +1,1 @@
-mixxx-deps-2.3-x64-windows-049b5ad
+mixxx-deps-2.3-x64-windows-318a1b3


### PR DESCRIPTION
This brings Portaudio fixes from https://github.com/mixxxdj/vcpkg/pull/63