### PR TITLE
iTunes: Make playlist parser robust w.r.t `<dict>` key order

### DIFF
--- a/src/library/itunes/itunesxmlimporter.cpp
+++ b/src/library/itunes/itunesxmlimporter.cpp
@@ -494,9 +494,9 @@ void ITunesXMLImporter::parsePlaylist(QSqlQuery& queryInsertToPlaylists,
 
                 if (key == "Playlist Items") {
                     isPlaylistItemsStarted = true;
+                    continue;
                 }
-                // When processing playlist entries, playlist name and id have
-                // already been processed and persisted
+
                 if (key == kTrackId) {
                     readNextStartElement();
                     track_reference = m_xml.readElementText().toInt();
@@ -505,7 +505,7 @@ void ITunesXMLImporter::parsePlaylist(QSqlQuery& queryInsertToPlaylists,
                     queryInsertToPlaylistTracks.bindValue(":track_id", track_reference);
                     queryInsertToPlaylistTracks.bindValue(":position", playlist_position++);
 
-                    // Insert tracks if we are not in a pre-build playlist
+                    // Insert tracks if we are not in a pre-built playlist
                     if (!isSystemPlaylist && !queryInsertToPlaylistTracks.exec()) {
                         qDebug() << "SQL Error in ITunesXMLImporter.cpp: line" << __LINE__ << " "
                                  << queryInsertToPlaylistTracks.lastError();

--- a/src/library/itunes/itunesxmlimporter.cpp
+++ b/src/library/itunes/itunesxmlimporter.cpp
@@ -484,7 +484,10 @@ void ITunesXMLImporter::parsePlaylist(QSqlQuery& queryInsertToPlaylists,
                 // Hide playlists that are system playlists
                 if (key == "Master" || key == "Movies" || key == "TV Shows" ||
                         key == "Music" || key == "Books" || key == "Purchased") {
-                    isSystemPlaylist = true;
+                    readNextStartElement();
+                    if (m_xml.name() == QString("true")) {
+                        isSystemPlaylist = true;
+                    }
                     continue;
                 }
 

--- a/src/library/itunes/itunesxmlimporter.cpp
+++ b/src/library/itunes/itunesxmlimporter.cpp
@@ -5,6 +5,7 @@
 #include <QUrl>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "library/itunes/itunesimporter.h"
 #include "library/itunes/ituneslocalhosttoken.h"
@@ -453,11 +454,13 @@ void ITunesXMLImporter::parsePlaylist(QSqlQuery& queryInsertToPlaylists,
 
     QString playlistname;
     int playlist_id = -1;
-    int playlist_position = -1;
-    int track_reference = -1;
+    int trackReference = -1;
     // indicates that we haven't found the <
     bool isSystemPlaylist = false;
     bool isPlaylistItemsStarted = false;
+
+    // We store the list of track ids in memory to be independent of the <dict> key order.
+    std::vector<int> trackReferences;
 
     // We process and iterate the <dict> tags holding playlist summary information here
     while (!m_xml.atEnd() && !m_cancelImport.load()) {
@@ -479,7 +482,6 @@ void ITunesXMLImporter::parsePlaylist(QSqlQuery& queryInsertToPlaylists,
                 if (key == "Playlist ID") {
                     readNextStartElement();
                     playlist_id = m_xml.readElementText().toInt();
-                    playlist_position = 1;
                     continue;
                 }
                 // Hide playlists that are system playlists
@@ -499,20 +501,8 @@ void ITunesXMLImporter::parsePlaylist(QSqlQuery& queryInsertToPlaylists,
 
                 if (key == kTrackId) {
                     readNextStartElement();
-                    track_reference = m_xml.readElementText().toInt();
-
-                    queryInsertToPlaylistTracks.bindValue(":playlist_id", playlist_id);
-                    queryInsertToPlaylistTracks.bindValue(":track_id", track_reference);
-                    queryInsertToPlaylistTracks.bindValue(":position", playlist_position++);
-
-                    // Insert tracks if we are not in a pre-built playlist
-                    if (!isSystemPlaylist && !queryInsertToPlaylistTracks.exec()) {
-                        qDebug() << "SQL Error in ITunesXMLImporter.cpp: line" << __LINE__ << " "
-                                 << queryInsertToPlaylistTracks.lastError();
-                        qDebug() << "trackid" << track_reference;
-                        qDebug() << "playlistname; " << playlistname;
-                        qDebug() << "-----------------";
-                    }
+                    trackReference = m_xml.readElementText().toInt();
+                    trackReferences.push_back(trackReference);
                 }
             }
         }
@@ -553,6 +543,20 @@ void ITunesXMLImporter::parsePlaylist(QSqlQuery& queryInsertToPlaylists,
                 return;
             }
         }
+
+        // Perform the deferred track insertions.
+        int playlistPosition = 1;
+        for (int trackReference : trackReferences) {
+            queryInsertToPlaylistTracks.bindValue(":playlist_id", playlist_id);
+            queryInsertToPlaylistTracks.bindValue(":track_id", trackReference);
+            queryInsertToPlaylistTracks.bindValue(":position", playlistPosition++);
+
+            if (!queryInsertToPlaylistTracks.exec()) {
+                LOG_FAILED_QUERY(queryInsertToPlaylistTracks);
+                return;
+            }
+        }
+
         // append the playlist to the child model
         root.appendChild(playlistname);
     }


### PR DESCRIPTION
Based on #11446, see [here](https://github.com/fwcd/mixxx/compare/move-itunes-path-mapping-to-xml...fwcd:mixxx:more-robust-itunes-playlist-parser) for a clean diff based on the other PR (rather than `2.4`).

The playlist parser is currently quite dependent on the order of the `<dict>` keys, which in general isn't guaranteed in XML plists (similar to JSON). That iTunes/Apple Music always serializes the keys in a specific order is an implementation detail that we shouldn't rely on to parse playlists correctly.

This PR fixes this by inserting the playlist and its tracks _after_ the entire XML node has been parsed.