### PR TITLE
Verify real-time policy on Linux 

### DIFF
--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -24,6 +24,8 @@
 #ifdef __LINUX__
 // for PaAlsa_EnableRealtimeScheduling
 #include <pa_linux_alsa.h>
+// for sched_getscheduler
+#include <sched.h>
 #endif
 
 namespace {
@@ -886,12 +888,25 @@ int SoundDevicePortAudio::callbackProcessClkRef(
             m_deviceId.debugName());
 
     //qDebug() << "SoundDevicePortAudio::callbackProcess:" << m_deviceId;
-    // Turn on TimeCritical priority for the callback thread. If we are running
-    // in Linux userland, for example, this will have no effect.
-    if (!m_bSetThreadPriority) {
-        QThread::currentThread()->setPriority(QThread::TimeCriticalPriority);
-        m_bSetThreadPriority = true;
 
+    if (!m_bSetThreadPriority) {
+#ifdef __LINUX__
+        // Verify if we are a thread with "real-time" policy.
+        // The audio thread on Linux should be set to SCHED_FIFO with a priority
+        // that's somewhere between 60 and 90 depending on the allowed priority
+        // ranges (some USB devices by default get assigned a priority in the
+        // 50s with some system configs).
+        if ((sched_getscheduler(0) & SCHED_FIFO) == 0) {
+            qWarning() << "Engine thread not scheduled with the real-time policy SCHED_FIFO";
+        }
+#else
+        // Turn on TimeCritical priority for the callback thread.
+        // If we are running in Linux this will have no effect. Either the thread is
+        // already set up correctly because of the audio server, or it's still set to
+        // the SCHED_OTHER policy in which case the call also wouldn't do anything.
+        QThread::currentThread()->setPriority(QThread::TimeCriticalPriority);
+#endif
+        m_bSetThreadPriority = true;
 
 #ifdef __SSE__
         // This disables the denormals calculations, to avoid a


### PR DESCRIPTION
Instead calling not working QThread::setPriority()

This fixes obscure warning due to a QT bug reported in 
https://github.com/mixxxdj/mixxx/issues/11465

Thank you @robbert-vdh for the suggestion. 