### PR TITLE
Relax strictness of `ControllerScriptInterfaceLegacy` methods. 

### DIFF
--- a/src/controllers/scripting/controllerscriptenginebase.cpp
+++ b/src/controllers/scripting/controllerscriptenginebase.cpp
@@ -6,6 +6,7 @@
 #include "errordialoghandler.h"
 #include "mixer/playermanager.h"
 #include "moc_controllerscriptenginebase.cpp"
+#include "util/cmdlineargs.h"
 
 ControllerScriptEngineBase::ControllerScriptEngineBase(
         Controller* controller, const RuntimeLoggingCategory& logger)
@@ -13,6 +14,7 @@ ControllerScriptEngineBase::ControllerScriptEngineBase(
           m_pJSEngine(nullptr),
           m_pController(controller),
           m_logger(logger),
+          m_bPedantic(false),
           m_bTesting(false) {
     // Handle error dialog buttons
     qRegisterMetaType<QMessageBox::StandardButton>("QMessageBox::StandardButton");
@@ -22,6 +24,8 @@ bool ControllerScriptEngineBase::initialize() {
     VERIFY_OR_DEBUG_ASSERT(!m_pJSEngine) {
         return false;
     }
+
+    m_bPedantic = CmdlineArgs::Instance().getControllerPedantic();
 
     // Create the Script Engine
     m_pJSEngine = std::make_shared<QJSEngine>(this);

--- a/src/controllers/scripting/controllerscriptenginebase.cpp
+++ b/src/controllers/scripting/controllerscriptenginebase.cpp
@@ -14,7 +14,7 @@ ControllerScriptEngineBase::ControllerScriptEngineBase(
           m_pJSEngine(nullptr),
           m_pController(controller),
           m_logger(logger),
-          m_bPedantic(false),
+          m_bAbortOnWarning(false),
           m_bTesting(false) {
     // Handle error dialog buttons
     qRegisterMetaType<QMessageBox::StandardButton>("QMessageBox::StandardButton");
@@ -25,7 +25,7 @@ bool ControllerScriptEngineBase::initialize() {
         return false;
     }
 
-    m_bPedantic = CmdlineArgs::Instance().getControllerPedantic();
+    m_bAbortOnWarning = CmdlineArgs::Instance().getControllerAbortOnWarning();
 
     // Create the Script Engine
     m_pJSEngine = std::make_shared<QJSEngine>(this);

--- a/src/controllers/scripting/controllerscriptenginebase.h
+++ b/src/controllers/scripting/controllerscriptenginebase.h
@@ -32,6 +32,10 @@ class ControllerScriptEngineBase : public QObject {
     void showScriptExceptionDialog(const QJSValue& evaluationResult, bool bFatal = false);
     void throwJSError(const QString& message);
 
+    bool isPedantic() const {
+        return m_bPedantic;
+    }
+
     inline void setTesting(bool testing) {
         m_bTesting = testing;
     };
@@ -50,6 +54,8 @@ class ControllerScriptEngineBase : public QObject {
 
     Controller* m_pController;
     const RuntimeLoggingCategory m_logger;
+
+    bool m_bPedantic;
 
     bool m_bTesting;
 

--- a/src/controllers/scripting/controllerscriptenginebase.h
+++ b/src/controllers/scripting/controllerscriptenginebase.h
@@ -32,8 +32,8 @@ class ControllerScriptEngineBase : public QObject {
     void showScriptExceptionDialog(const QJSValue& evaluationResult, bool bFatal = false);
     void throwJSError(const QString& message);
 
-    bool isPedantic() const {
-        return m_bPedantic;
+    bool willAbortOnWarning() const {
+        return m_bAbortOnWarning;
     }
 
     inline void setTesting(bool testing) {
@@ -55,7 +55,7 @@ class ControllerScriptEngineBase : public QObject {
     Controller* m_pController;
     const RuntimeLoggingCategory m_logger;
 
-    bool m_bPedantic;
+    bool m_bAbortOnWarning;
 
     bool m_bTesting;
 

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
@@ -240,10 +240,10 @@ QJSValue ControllerScriptInterfaceLegacy::makeConnectionInternal(
         // The test setups do not run all of Mixxx, so ControlObjects not
         // existing during tests is okay.
         if (!m_pScriptEngineLegacy->isTesting()) {
-            m_pScriptEngineLegacy->throwJSError(
-                    "script tried to connect to "
-                    "ControlObject (" +
-                    group + ", " + name + ") which is non-existent.");
+            logOrThrowError(
+                    QStringLiteral("script tried to connect to ControlObject "
+                                   "(%1, %2) which is non-existent.")
+                            .arg(group, name));
         }
         return QJSValue();
     }
@@ -429,6 +429,14 @@ void ControllerScriptInterfaceLegacy::trigger(const QString& group, const QStrin
     ControlObjectScript* coScript = getControlObjectScript(group, name);
     if (coScript != nullptr) {
         coScript->emitValueChanged();
+    }
+}
+
+void ControllerScriptInterfaceLegacy::logOrThrowError(const QString& errorMessage) const {
+    if (m_pScriptEngineLegacy->isPedantic()) {
+        m_pScriptEngineLegacy->throwJSError(errorMessage);
+    } else {
+        qCWarning(m_logger) << errorMessage;
     }
 }
 

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
@@ -444,7 +444,7 @@ void ControllerScriptInterfaceLegacy::trigger(const QString& group, const QStrin
 }
 
 void ControllerScriptInterfaceLegacy::logOrThrowError(const QString& errorMessage) const {
-    if (m_pScriptEngineLegacy->isPedantic()) {
+    if (m_pScriptEngineLegacy->willAbortOnWarning()) {
         m_pScriptEngineLegacy->throwJSError(errorMessage);
     } else {
         qCWarning(m_logger) << errorMessage;

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
@@ -82,6 +82,7 @@ class ControllerScriptInterfaceLegacy : public QObject {
             bool skipSuperseded = false);
     QHash<ConfigKey, ControlObjectScript*> m_controlCache;
     ControlObjectScript* getControlObjectScript(const QString& group, const QString& name);
+    void logOrThrowError(const QString& errorMessage) const;
 
     SoftTakeoverCtrl m_st;
 

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -20,6 +20,7 @@
 CmdlineArgs::CmdlineArgs()
         : m_startInFullscreen(false), // Initialize vars
           m_controllerDebug(false),
+          m_controllerPedantic(false),
           m_developer(false),
           m_safeMode(false),
           m_useVuMeterGL(true),
@@ -193,6 +194,17 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(controllerDebug);
     parser.addOption(controllerDebugDeprecated);
 
+    const QCommandLineOption controllerPedantic(
+            QStringLiteral("controller-pedantic"),
+            forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
+                                      "The controller mapping will issue more "
+                                      "aggressive warnings and errors when "
+                                      "detecting misuse of controller APIs. "
+                                      "New Controller Mappings should be "
+                                      "developed with this option enabled!")
+                            : QString());
+    parser.addOption(controllerPedantic);
+
     const QCommandLineOption developer(QStringLiteral("developer"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Enables developer-mode. Includes extra log info, stats on "
@@ -332,6 +344,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
 
     m_useVuMeterGL = !(parser.isSet(disableVuMeterGL) || parser.isSet(disableVuMeterGLDeprecated));
     m_controllerDebug = parser.isSet(controllerDebug) || parser.isSet(controllerDebugDeprecated);
+    m_controllerPedantic = parser.isSet(controllerPedantic);
     m_developer = parser.isSet(developer);
     m_safeMode = parser.isSet(safeMode) || parser.isSet(safeModeDeprecated);
     m_debugAssertBreak = parser.isSet(debugAssertBreak) || parser.isSet(debugAssertBreakDeprecated);

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -20,7 +20,7 @@
 CmdlineArgs::CmdlineArgs()
         : m_startInFullscreen(false), // Initialize vars
           m_controllerDebug(false),
-          m_controllerPedantic(false),
+          m_controllerAbortOnWarning(false),
           m_developer(false),
           m_safeMode(false),
           m_useVuMeterGL(true),
@@ -194,8 +194,8 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(controllerDebug);
     parser.addOption(controllerDebugDeprecated);
 
-    const QCommandLineOption controllerPedantic(
-            QStringLiteral("controller-pedantic"),
+    const QCommandLineOption controllerAbortOnWarning(
+            QStringLiteral("controller-abort-on-warning"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "The controller mapping will issue more "
                                       "aggressive warnings and errors when "
@@ -203,7 +203,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
                                       "New Controller Mappings should be "
                                       "developed with this option enabled!")
                             : QString());
-    parser.addOption(controllerPedantic);
+    parser.addOption(controllerAbortOnWarning);
 
     const QCommandLineOption developer(QStringLiteral("developer"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
@@ -344,7 +344,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
 
     m_useVuMeterGL = !(parser.isSet(disableVuMeterGL) || parser.isSet(disableVuMeterGLDeprecated));
     m_controllerDebug = parser.isSet(controllerDebug) || parser.isSet(controllerDebugDeprecated);
-    m_controllerPedantic = parser.isSet(controllerPedantic);
+    m_controllerAbortOnWarning = parser.isSet(controllerAbortOnWarning);
     m_developer = parser.isSet(developer);
     m_safeMode = parser.isSet(safeMode) || parser.isSet(safeModeDeprecated);
     m_debugAssertBreak = parser.isSet(debugAssertBreak) || parser.isSet(debugAssertBreakDeprecated);

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -34,6 +34,9 @@ class CmdlineArgs final {
     bool getControllerDebug() const {
         return m_controllerDebug;
     }
+    bool getControllerPedantic() const {
+        return m_controllerPedantic;
+    }
     bool getDeveloper() const { return m_developer; }
     bool getSafeMode() const { return m_safeMode; }
     bool useColors() const {
@@ -73,6 +76,7 @@ class CmdlineArgs final {
     QList<QString> m_musicFiles;    // List of files to load into players at startup
     bool m_startInFullscreen;       // Start in fullscreen mode
     bool m_controllerDebug;
+    bool m_controllerPedantic; // Controller Engine will be stricter
     bool m_developer; // Developer Mode
     bool m_safeMode;
     bool m_useVuMeterGL;

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -34,8 +34,8 @@ class CmdlineArgs final {
     bool getControllerDebug() const {
         return m_controllerDebug;
     }
-    bool getControllerPedantic() const {
-        return m_controllerPedantic;
+    bool getControllerAbortOnWarning() const {
+        return m_controllerAbortOnWarning;
     }
     bool getDeveloper() const { return m_developer; }
     bool getSafeMode() const { return m_safeMode; }
@@ -76,7 +76,7 @@ class CmdlineArgs final {
     QList<QString> m_musicFiles;    // List of files to load into players at startup
     bool m_startInFullscreen;       // Start in fullscreen mode
     bool m_controllerDebug;
-    bool m_controllerPedantic; // Controller Engine will be stricter
+    bool m_controllerAbortOnWarning; // Controller Engine will be stricter
     bool m_developer; // Developer Mode
     bool m_safeMode;
     bool m_useVuMeterGL;


### PR DESCRIPTION
Should address / fix #11473. 

The primary issue is fixed in 7ab811c70fa53453bac1dfb0778e770a58f227b0. The problem is that the refactorings in 2.4 caused invalid CO connections to throw an error instead of just warning on the commandline. Especially for user-facing stable APIs we should follow the [Robustness principle](https://en.wikipedia.org/wiki/Robustness_principle). This PR makes that possible by introducing the `--controller-pedantic` flag that mapping developers should use while developing their mappings to make issues like this apparent. 
I also took the liberty to apply this conditional throwing code to more methods of the "legacy" API.