### PR TITLE
Fix reset Main/Intro/Outro behaviour  

### DIFF
--- a/src/analyzer/analyzersilence.cpp
+++ b/src/analyzer/analyzersilence.cpp
@@ -107,6 +107,13 @@ void AnalyzerSilence::storeResults(TrackPointer pTrack) {
     pAudibleSound->setStartPosition(firstSound);
     pAudibleSound->setEndPosition(lastSound);
 
+    setupMainAndIntroCue(pTrack.get(), firstSound, m_pConfig.get());
+    setupOutroCue(pTrack.get(), lastSound);
+}
+
+// static
+void AnalyzerSilence::setupMainAndIntroCue(
+        Track* pTrack, double firstSound, UserSettings* pConfig) {
     CuePointer pIntroCue = pTrack->findCueByType(mixxx::CueType::Intro);
 
     double mainCue = pTrack->getCuePoint().getPosition();
@@ -120,7 +127,7 @@ void AnalyzerSilence::storeResults(TrackPointer pTrack) {
     if (mainCue == Cue::kNoPosition || upgradingWithMainCueAtDefault) {
         pTrack->setCuePoint(CuePosition(firstSound));
         // NOTE: the actual default for this ConfigValue is set in DlgPrefDeck.
-    } else if (m_pConfig->getValue(ConfigKey("[Controls]", "SetIntroStartAtMainCue"), false) &&
+    } else if (pConfig->getValue(ConfigKey("[Controls]", "SetIntroStartAtMainCue"), false) &&
             pIntroCue == nullptr) {
         introStart = mainCue;
     }
@@ -131,7 +138,10 @@ void AnalyzerSilence::storeResults(TrackPointer pTrack) {
         pIntroCue->setStartPosition(introStart);
         pIntroCue->setEndPosition(Cue::kNoPosition);
     }
+}
 
+// static
+void AnalyzerSilence::setupOutroCue(Track* pTrack, double lastSound) {
     CuePointer pOutroCue = pTrack->findCueByType(mixxx::CueType::Outro);
     if (pOutroCue == nullptr) {
         pOutroCue = pTrack->createAndAddCue();

--- a/src/analyzer/analyzersilence.h
+++ b/src/analyzer/analyzersilence.h
@@ -15,6 +15,9 @@ class AnalyzerSilence : public Analyzer {
     void storeResults(TrackPointer pTrack) override;
     void cleanup() override;
 
+    static void setupMainAndIntroCue(Track* pTrack, double firstSound, UserSettings* pConfig);
+    static void setupOutroCue(Track* pTrack, double lastSound);
+
   private:
     UserSettingsPointer m_pConfig;
     CSAMPLE m_fThreshold;

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -909,7 +909,7 @@ void Track::removeCue(const CuePointer& pCue) {
     disconnect(pCue.get(), nullptr, this, nullptr);
     m_cuePoints.removeOne(pCue);
     if (pCue->getType() == mixxx::CueType::MainCue) {
-        m_record.setCuePoint(CuePosition());
+        m_record.setCuePoint(Cue::kNoPosition);
     }
     pCue->setTrackId(TrackId());
     markDirtyAndUnlock(&lock);
@@ -927,11 +927,11 @@ void Track::removeCuesOfType(mixxx::CueType type) {
             disconnect(pCue.get(), nullptr, this, nullptr);
             pCue->setTrackId(TrackId());
             it.remove();
+            if (type == mixxx::CueType::MainCue) {
+                m_record.setCuePoint(Cue::kNoPosition);
+            }
             dirty = true;
         }
-    }
-    if (compareAndSet(m_record.ptrCuePoint(), CuePosition())) {
-        dirty = true;
     }
     if (dirty) {
         markDirtyAndUnlock(&lock);

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1432,6 +1432,10 @@ class ResetWaveformTrackPointerOperation : public mixxx::TrackPointerOperation {
         m_analysisDao.deleteAnalysesForTrack(pTrack->getId());
         pTrack->setWaveform(WaveformPointer());
         pTrack->setWaveformSummary(WaveformPointer());
+        // We Remove the invisible AudibleSound cue here as well, because the
+        // same reasons that apply for reanalyze of the waveforms applies also
+        // for the AudibleSound cue.
+        pTrack->removeCuesOfType(mixxx::CueType::AudibleSound);
     }
 
     AnalysisDao& m_analysisDao;

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -85,10 +85,10 @@ class WTrackMenu : public QMenu {
     void slotClearBeats();
     void slotClearPlayCount();
     void slotClearRating();
-    void slotClearMainCue();
+    void slotResetMainCue();
     void slotClearHotCues();
-    void slotClearIntroCue();
-    void slotClearOutroCue();
+    void slotResetIntroCue();
+    void slotResetOutroCue();
     void slotClearLoop();
     void slotClearKey();
     void slotClearReplayGain();


### PR DESCRIPTION
During testing of https://github.com/mixxxdj/mixxx/issues/11448 I have discovered an issue with the "Reset" context menu. 

After resetting Main Intro or Auto cue the disappear instead of reset to their default position. They are temporary removed, which is kind of pointless, because they will re-appear if the track is loaded again. The user has no chance to verify the new position without ejecting and loading the track again. The track is then reanalyzed and after that the new position appears. 

The reanalysis is pointless because the removed cues will appear at the exact same position as after the first analysis depending on the Audible Sound cue, which is immutable like the waveform. 

The only use case where the Audible Sound changes is after the track samples have been changed. In this case the Waveform, where you can also spot the Audible Sound range needs to be reanalyzed as well. To make sure waveform and Audible Sound cue are always consistent, I have changed that the Audible Sound cue is now reset along with the wave forms. 

I consider this PR a bug fix and that's why it is for the 2.3 branch. However we may consider to merge it to 2.4 because it changes the behavior of the reset menu slightly. 
 
