### PR TITLE
Fix MathUtil.Denormals with clang 15/16

### DIFF
--- a/src/test/mathutiltest.cpp
+++ b/src/test/mathutiltest.cpp
@@ -64,19 +64,23 @@ TEST_F(MathUtilTest, Denormal) {
     _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_OFF);
     _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_OFF);
 
-    volatile float fDenormal = std::numeric_limits<float>::min() / 2.0f;
+    volatile float fDenormal = std::numeric_limits<float>::min();
+    fDenormal /= 2.0f;
     EXPECT_NE(0.0f, fDenormal);
 
-    volatile double dDenormal = std::numeric_limits<double>::min() / 2.0;
+    volatile double dDenormal = std::numeric_limits<double>::min();
+    dDenormal /= 2.0;
     EXPECT_NE(0.0, dDenormal);
 
     _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
     _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
 
-    fDenormal = std::numeric_limits<float>::min() / 2.0f;
+    fDenormal = std::numeric_limits<float>::min();
+    fDenormal /= 2.0f;
     EXPECT_EQ(0.0f, fDenormal);
 
-    dDenormal = std::numeric_limits<double>::min() / 2.0;
+    dDenormal = std::numeric_limits<double>::min();
+    dDenormal /= 2.0;
     EXPECT_EQ(0.0, dDenormal);
 
 #endif

--- a/src/test/mathutiltest.cpp
+++ b/src/test/mathutiltest.cpp
@@ -64,6 +64,9 @@ TEST_F(MathUtilTest, Denormal) {
     _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_OFF);
     _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_OFF);
 
+    // Note: The volatile keyword makes sure that the division is executed on the target
+    // and not by the pre-processor. In case of clang >= 15 the pre-processor flushes to
+    // zero with -ffast-math enabled.
     volatile float fDenormal = std::numeric_limits<float>::min();
     fDenormal /= 2.0f;
     EXPECT_NE(0.0f, fDenormal);


### PR DESCRIPTION
With -ffastmath clang format applies the flushing to zero already at the pre-processor level. This change makes sure the target does the division.

Fixes: https://github.com/mixxxdj/mixxx/issues/11484
