### PR TITLE
aarch64: Fix -Wasm-operand-widths

### DIFF
--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -461,7 +461,7 @@ void SoundDeviceNetwork::callbackProcessClkRef() {
 #if defined(__aarch64__)
         // Flush-to-zero on aarch64 is controlled by the Floating-point Control Register
         // Load the register into our variable.
-        int savedFPCR;
+        int64_t savedFPCR;
         asm volatile("mrs %[savedFPCR], FPCR"
                      : [ savedFPCR ] "=r"(savedFPCR));
 

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -935,7 +935,7 @@ int SoundDevicePortAudio::callbackProcessClkRef(
 #if defined(__aarch64__)
         // Flush-to-zero on aarch64 is controlled by the Floating-point Control Register
         // Load the register into our variable.
-        int savedFPCR;
+        int64_t savedFPCR;
         asm volatile("mrs %[savedFPCR], FPCR"
                      : [ savedFPCR ] "=r"(savedFPCR));
 


### PR DESCRIPTION
Build fails on Clang 16 which is needed as a (temporary) workaround for #11483.

Broken build: https://koji.rpmfusion.org/kojifiles/work/tasks/4069/594069/build.log
Fixed build: https://koji.rpmfusion.org/kojifiles/work/tasks/4081/594081/build.log