### PR TITLE
AutoDJ: handle "enabled" CO change requests like clicks on the GUI button

### DIFF
--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -227,6 +227,7 @@ void AutoDJProcessor::fadeNow() {
     if (!pLeftDeck || !pRightDeck) {
         // User has changed the orientation, disable Auto DJ
         toggleAutoDJ(false);
+        emit autoDJError(ADJ_NOT_TWO_DECKS);
         return;
     }
 
@@ -259,6 +260,7 @@ void AutoDJProcessor::fadeNow() {
         // Deck is empty or track too short, disable AutoDJ
         // This happens only if the user has changed deck orientation to such deck.
         toggleAutoDJ(false);
+        emit autoDJError(ADJ_NOT_TWO_DECKS);
         return;
     }
 
@@ -333,6 +335,7 @@ void AutoDJProcessor::fadeNow() {
 
 AutoDJProcessor::AutoDJError AutoDJProcessor::skipNext() {
     if (m_eState == ADJ_DISABLED) {
+        emit autoDJError(ADJ_IS_INACTIVE);
         return ADJ_IS_INACTIVE;
     }
     // Load the next song from the queue.
@@ -341,6 +344,7 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::skipNext() {
     if (!pLeftDeck || !pRightDeck) {
         // User has changed the orientation, disable Auto DJ
         toggleAutoDJ(false);
+        emit autoDJError(ADJ_NOT_TWO_DECKS);
         return ADJ_NOT_TWO_DECKS;
     }
 
@@ -625,6 +629,7 @@ void AutoDJProcessor::crossfaderChanged(double value) {
                     }
                     pToDeck->play();
                 } else {
+                    // Track in toDeck was ejected manually, stop.
                     toggleAutoDJ(false);
                     return;
                 }
@@ -1518,6 +1523,7 @@ void AutoDJProcessor::playerTrackLoaded(DeckAttributes* pDeck, TrackPointer pTra
             }
             // User has changed the orientation, disable Auto DJ
             toggleAutoDJ(false);
+            emit autoDJError(ADJ_NOT_TWO_DECKS);
             return;
         }
         pDeck->startPos = kKeepPosition;
@@ -1626,6 +1632,7 @@ void AutoDJProcessor::setTransitionTime(int time) {
         if (!pLeftDeck || !pRightDeck) {
             // User has changed the orientation, disable Auto DJ
             toggleAutoDJ(false);
+            emit autoDJError(ADJ_NOT_TWO_DECKS);
             return;
         }
         if (pLeftDeck->isPlaying()) {
@@ -1654,6 +1661,7 @@ void AutoDJProcessor::setTransitionMode(TransitionMode newMode) {
     if (!pLeftDeck || !pRightDeck) {
         // User has changed the orientation, disable Auto DJ
         toggleAutoDJ(false);
+        emit autoDJError(ADJ_NOT_TWO_DECKS);
         return;
     }
 

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -203,6 +203,7 @@ class AutoDJProcessor : public QObject {
   signals:
     void loadTrackToPlayer(TrackPointer pTrack, const QString& group, bool play);
     void autoDJStateChanged(AutoDJProcessor::AutoDJState state);
+    void autoDJError(AutoDJProcessor::AutoDJError error);
     void transitionTimeChanged(int time);
     void randomTrackRequested(int tracksToAdd);
 
@@ -219,7 +220,7 @@ class AutoDJProcessor : public QObject {
     void playerEmpty(DeckAttributes* pDeck);
     void playerRateChanged(DeckAttributes* pDeck);
 
-    void controlEnable(double value);
+    void controlEnableChangeRequest(double value);
     void controlFadeNow(double value);
     void controlShuffle(double value);
     void controlSkipNext(double value);

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -205,6 +205,11 @@ DlgAutoDJ::DlgAutoDJ(
             &DlgAutoDJ::transitionTimeChanged);
 
     connect(m_pAutoDJProcessor,
+            &AutoDJProcessor::autoDJError,
+            this,
+            &DlgAutoDJ::autoDJError);
+
+    connect(m_pAutoDJProcessor,
             &AutoDJProcessor::autoDJStateChanged,
             this,
             &DlgAutoDJ::autoDJStateChanged);
@@ -270,7 +275,12 @@ void DlgAutoDJ::fadeNowButton(bool) {
 }
 
 void DlgAutoDJ::toggleAutoDJButton(bool enable) {
-    AutoDJProcessor::AutoDJError error = m_pAutoDJProcessor->toggleAutoDJ(enable);
+    m_pAutoDJProcessor->toggleAutoDJ(enable);
+}
+
+// TODO If there's a way to migrate the translations move this
+// to AutoDJProcessor in order to keep this class minimal
+void DlgAutoDJ::autoDJError(AutoDJProcessor::AutoDJError error) {
     switch (error) {
     case AutoDJProcessor::ADJ_NOT_TWO_DECKS:
         QMessageBox::warning(nullptr,

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -287,22 +287,18 @@ void DlgAutoDJ::autoDJError(AutoDJProcessor::AutoDJError error) {
                 tr("Auto DJ"),
                 tr("Auto DJ requires two decks assigned to opposite sides of the crossfader."),
                 QMessageBox::Ok);
-        // Make sure the button becomes unpushed.
-        pushButtonAutoDJ->setChecked(false);
         break;
     case AutoDJProcessor::ADJ_BOTH_DECKS_PLAYING:
         QMessageBox::warning(nullptr,
                 tr("Auto DJ"),
                 tr("One deck must be stopped to enable Auto DJ mode."),
                 QMessageBox::Ok);
-        pushButtonAutoDJ->setChecked(false);
         break;
     case AutoDJProcessor::ADJ_DECKS_3_4_PLAYING:
         QMessageBox::warning(nullptr,
                 tr("Auto DJ"),
                 tr("Decks 3 and 4 must be stopped to enable Auto DJ mode."),
                 QMessageBox::Ok);
-        pushButtonAutoDJ->setChecked(false);
         break;
     case AutoDJProcessor::ADJ_OK:
     default:

--- a/src/library/autodj/dlgautodj.h
+++ b/src/library/autodj/dlgautodj.h
@@ -39,6 +39,7 @@ class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
     void skipNextButton(bool buttonChecked);
     void fadeNowButton(bool buttonChecked);
     void toggleAutoDJButton(bool enable);
+    void autoDJError(AutoDJProcessor::AutoDJError error);
     void transitionTimeChanged(int time);
     void transitionSliderChanged(int value);
     void autoDJStateChanged(AutoDJProcessor::AutoDJState state);


### PR DESCRIPTION
otherwise, if AutoDJ refuses to start because of unmet conditions, no error messages are shown and the CO remains in 'enabled' state.

Fixes #11494 