### PR TITLE
iTunes: Factor out `ITunesPlaylistModel` and fix sort column mapping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -750,6 +750,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/library/externaltrackcollection.cpp
   src/library/hiddentablemodel.cpp
   src/library/itunes/itunesfeature.cpp
+  src/library/itunes/itunesplaylistmodel.cpp
   src/library/itunes/itunesxmlimporter.cpp
   src/library/library_prefs.cpp
   src/library/library.cpp

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -17,6 +17,7 @@
 #include "library/dao/settingsdao.h"
 #include "library/itunes/itunesimporter.h"
 #include "library/itunes/ituneslocalhosttoken.h"
+#include "library/itunes/itunesplaylistmodel.h"
 #include "library/itunes/itunesxmlimporter.h"
 #include "library/library.h"
 #include "library/queryutil.h"
@@ -94,11 +95,8 @@ ITunesFeature::ITunesFeature(Library* pLibrary, UserSettingsPointer pConfig)
             "mixxx.db.model.itunes",
             "itunes_library",
             m_trackSource);
-    m_pITunesPlaylistModel = new BaseExternalPlaylistModel(this,
+    m_pITunesPlaylistModel = new ITunesPlaylistModel(this,
             m_pLibrary->trackCollectionManager(),
-            "mixxx.db.model.itunes_playlist",
-            "itunes_playlists",
-            "itunes_playlist_tracks",
             m_trackSource);
     m_isActivated = false;
     m_title = tr("iTunes");

--- a/src/library/itunes/itunesplaylistmodel.cpp
+++ b/src/library/itunes/itunesplaylistmodel.cpp
@@ -14,5 +14,67 @@ ITunesPlaylistModel::ITunesPlaylistModel(QObject* parent,
 }
 
 void ITunesPlaylistModel::initSortColumnMapping() {
-    // TODO
+    // Add a bijective mapping between the SortColumnIds and column indices
+    for (int i = 0; i < static_cast<int>(TrackModel::SortColumnId::IdMax); ++i) {
+        m_columnIndexBySortColumnId[i] = -1;
+    }
+
+    m_columnIndexBySortColumnId[static_cast<int>(TrackModel::SortColumnId::Artist)] =
+            fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ARTIST);
+    m_columnIndexBySortColumnId[static_cast<int>(TrackModel::SortColumnId::Title)] =
+            fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TITLE);
+    m_columnIndexBySortColumnId[static_cast<int>(TrackModel::SortColumnId::Album)] =
+            fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ALBUM);
+    m_columnIndexBySortColumnId[static_cast<int>(TrackModel::SortColumnId::AlbumArtist)] =
+            fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ALBUMARTIST);
+    m_columnIndexBySortColumnId[static_cast<int>(TrackModel::SortColumnId::Year)] =
+            fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_YEAR);
+    m_columnIndexBySortColumnId[static_cast<int>(TrackModel::SortColumnId::Genre)] =
+            fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_GENRE);
+    m_columnIndexBySortColumnId[static_cast<int>(TrackModel::SortColumnId::Grouping)] =
+            fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_GROUPING);
+    m_columnIndexBySortColumnId[static_cast<int>(TrackModel::SortColumnId::TrackNumber)] =
+            fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TRACKNUMBER);
+    m_columnIndexBySortColumnId[static_cast<int>(TrackModel::SortColumnId::Composer)] =
+            fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COMPOSER);
+    m_columnIndexBySortColumnId[static_cast<int>(TrackModel::SortColumnId::FileType)] =
+            fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_FILETYPE);
+    m_columnIndexBySortColumnId[static_cast<int>(TrackModel::SortColumnId::Comment)] =
+            fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COMMENT);
+    m_columnIndexBySortColumnId[static_cast<int>(TrackModel::SortColumnId::Duration)] =
+            fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_DURATION);
+    m_columnIndexBySortColumnId[static_cast<int>(TrackModel::SortColumnId::BitRate)] =
+            fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BITRATE);
+    m_columnIndexBySortColumnId[static_cast<int>(TrackModel::SortColumnId::Bpm)] =
+            fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM);
+    m_columnIndexBySortColumnId[static_cast<int>(TrackModel::SortColumnId::ReplayGain)] =
+            fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_REPLAYGAIN);
+    m_columnIndexBySortColumnId[static_cast<int>(
+            TrackModel::SortColumnId::DateTimeAdded)] =
+            fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_DATETIMEADDED);
+    m_columnIndexBySortColumnId[static_cast<int>(TrackModel::SortColumnId::TimesPlayed)] =
+            fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TIMESPLAYED);
+    m_columnIndexBySortColumnId[static_cast<int>(TrackModel::SortColumnId::LastPlayedAt)] =
+            fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_LAST_PLAYED_AT);
+    m_columnIndexBySortColumnId[static_cast<int>(TrackModel::SortColumnId::Rating)] =
+            fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_RATING);
+    m_columnIndexBySortColumnId[static_cast<int>(TrackModel::SortColumnId::Preview)] =
+            fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_PREVIEW);
+    m_columnIndexBySortColumnId[static_cast<int>(TrackModel::SortColumnId::CoverArt)] =
+            fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COVERART);
+    m_columnIndexBySortColumnId[static_cast<int>(TrackModel::SortColumnId::Position)] =
+            fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_POSITION);
+    m_columnIndexBySortColumnId[static_cast<int>(
+            TrackModel::SortColumnId::PlaylistDateTimeAdded)] =
+            fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_DATETIMEADDED);
+
+    m_sortColumnIdByColumnIndex.clear();
+    for (int i = static_cast<int>(TrackModel::SortColumnId::IdMin);
+            i < static_cast<int>(TrackModel::SortColumnId::IdMax);
+            ++i) {
+        TrackModel::SortColumnId sortColumn = static_cast<TrackModel::SortColumnId>(i);
+        m_sortColumnIdByColumnIndex.insert(
+                m_columnIndexBySortColumnId[static_cast<int>(sortColumn)],
+                sortColumn);
+    }
 }

--- a/src/library/itunes/itunesplaylistmodel.cpp
+++ b/src/library/itunes/itunesplaylistmodel.cpp
@@ -1,0 +1,18 @@
+#include "library/itunes/itunesplaylistmodel.h"
+
+#include "library/baseexternalplaylistmodel.h"
+
+ITunesPlaylistModel::ITunesPlaylistModel(QObject* parent,
+        TrackCollectionManager* pTrackCollectionManager,
+        QSharedPointer<BaseTrackCache> trackSource)
+        : BaseExternalPlaylistModel(parent,
+                  pTrackCollectionManager,
+                  "mixxx.db.model.itunes_playlist",
+                  "itunes_playlists",
+                  "itunes_playlist_tracks",
+                  trackSource) {
+}
+
+void ITunesPlaylistModel::initSortColumnMapping() {
+    // TODO
+}

--- a/src/library/itunes/itunesplaylistmodel.h
+++ b/src/library/itunes/itunesplaylistmodel.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <QObject>
+
+#include "library/baseexternalplaylistmodel.h"
+#include "library/basetrackcache.h"
+#include "library/trackcollectionmanager.h"
+
+class ITunesPlaylistModel : public BaseExternalPlaylistModel {
+    Q_OBJECT
+  public:
+    ITunesPlaylistModel(QObject* parent,
+            TrackCollectionManager* pTrackCollectionManager,
+            QSharedPointer<BaseTrackCache> trackSource);
+
+  protected:
+    void initSortColumnMapping() override;
+};


### PR DESCRIPTION
This fixes the second part of #11491, namely that the `#` (playlist track index) column cannot be sorted.

The fix closely follows the precedent of the Serato integration, by subclassing `BaseExternalPlaylistModel` with a custom `ITunesPlaylistModel` (instead of ad-hoc instantiating the base class) and overriding `initSortColumnMapping`.