### PR TITLE
BaseSqlTableModel: Fix bounds check

### DIFF
--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -423,7 +423,7 @@ void BaseSqlTableModel::setSort(int column, Qt::SortOrder order) {
     int trackSourceColumnCount = m_trackSource ? m_trackSource->columnCount() : 0;
 
     if (column < 0 ||
-            column >= trackSourceColumnCount + m_sortColumns.size() - 1) {
+            column >= trackSourceColumnCount + m_tableColumns.size() - 1) {
         // -1 because id column is in both tables
         qWarning() << "BaseSqlTableModel::setSort invalid column:" << column;
         return;


### PR DESCRIPTION
This fixes #11491, i.e. fixes the sorting for certain columns (e.g. BPM).

I hope this solution is also semantically correct, since I don't have a super deep understanding of the different indexing schemes (sort columns vs column indices etc.).

From what I understand, the issue was that the table columns  (`track_id`, `position`, `preview`) weren't considered and then caused the bound check to fail. This was particularly an issue for columns such as BPM and rating since they have a rather high index and thus fell outside the range of the 3 track table columns that weren't considered:

![Screenshot 2023-04-19 at 17 08 59](https://user-images.githubusercontent.com/30873659/233119779-e1d5fcd5-34d2-4f24-bf81-37952714d5db.png)

Once `m_sortColumns` was populated (which happens on the first sort), the bound check 'accidentally' passed since the previously out-of-bounds column indices were suddenly in bounds. This is also why sorting by a key such as title or artist would 'fix' the BPM sorting issue.

This should hopefully resolve the issue both for iTunes and Traktor (and perhaps other external) playlists.