### PR TITLE
iTunes: Properly parse boolean for system playlists

### DIFF
--- a/src/library/itunes/itunesxmlimporter.cpp
+++ b/src/library/itunes/itunesxmlimporter.cpp
@@ -484,7 +484,10 @@ void ITunesXMLImporter::parsePlaylist(QSqlQuery& queryInsertToPlaylists,
                 // Hide playlists that are system playlists
                 if (key == "Master" || key == "Movies" || key == "TV Shows" ||
                         key == "Music" || key == "Books" || key == "Purchased") {
-                    isSystemPlaylist = true;
+                    readNextStartElement();
+                    if (m_xml.name() == QString("true")) {
+                        isSystemPlaylist = true;
+                    }
                     continue;
                 }
 


### PR DESCRIPTION
A minor fix that I've extracted from #11452 (see https://github.com/mixxxdj/mixxx/pull/11452#discussion_r1160856335), since that PR seems to be a larger endeavor after all.

This parser previously assumed that the presence of the `Master` key (and others as listed above) also implies the value `true`. While this works for iTunes/Apple Music, since their serializer seems to omit the key whenever it is `false`, this is another implementation detail that we shouldn't rely on. Not to mention that it breaks third-party tools that may generate `<key>Master</key><false/>`.