### PR TITLE
LFO reset function for effects units

### DIFF
--- a/src/effects/backends/builtin/flangereffect.cpp
+++ b/src/effects/backends/builtin/flangereffect.cpp
@@ -227,5 +227,6 @@ void FlangerEffect::processChannel(
         pState->previousPeriodFrames = -1;
         pState->prev_regen = 0;
         pState->prev_mix = 0;
+        pState->lfoFrames = 0;
     }
 }


### PR DESCRIPTION
Fix for #11496 

Added LFO reset function in `enableState` to trigger its reset when effect is activated.