### PR TITLE
iTunes: Unit-test XML importer on actual library XMLs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1719,6 +1719,7 @@ add_executable(mixxx-test
   src/test/hotcuecontrol_test.cpp
   src/test/imageutils_test.cpp
   src/test/indexrange_test.cpp
+  src/test/itunesxmlimportertest.cpp
   src/test/keyutilstest.cpp
   src/test/lcstest.cpp
   src/test/learningutilstest.cpp

--- a/src/library/itunes/itunesdao.cpp
+++ b/src/library/itunes/itunesdao.cpp
@@ -58,31 +58,35 @@ void ITunesDAO::initialize(const QSqlDatabase& database) {
     m_applyPathMappingQuery.prepare(
             "UPDATE itunes_library SET location = replace( location, "
             ":itunes_path, :mixxx_path )");
+
+    m_isDatabaseInitialized = true;
 }
 
 bool ITunesDAO::importTrack(const ITunesTrack& track) {
-    QSqlQuery& query = m_insertTrackQuery;
+    if (m_isDatabaseInitialized) {
+        QSqlQuery& query = m_insertTrackQuery;
 
-    query.bindValue(":id", track.id);
-    query.bindValue(":artist", track.artist);
-    query.bindValue(":title", track.title);
-    query.bindValue(":album", track.album);
-    query.bindValue(":album_artist", track.albumArtist);
-    query.bindValue(":genre", track.genre);
-    query.bindValue(":grouping", track.grouping);
-    query.bindValue(":year", track.year > 0 ? QVariant(track.year) : QVariant());
-    query.bindValue(":duration", track.duration);
-    query.bindValue(":location", track.location);
-    query.bindValue(":rating", track.rating);
-    query.bindValue(":comment", track.comment);
-    query.bindValue(":tracknumber",
-            track.trackNumber > 0 ? QVariant(track.trackNumber) : QVariant());
-    query.bindValue(":bpm", track.bpm);
-    query.bindValue(":bitrate", track.bitrate);
+        query.bindValue(":id", track.id);
+        query.bindValue(":artist", track.artist);
+        query.bindValue(":title", track.title);
+        query.bindValue(":album", track.album);
+        query.bindValue(":album_artist", track.albumArtist);
+        query.bindValue(":genre", track.genre);
+        query.bindValue(":grouping", track.grouping);
+        query.bindValue(":year", track.year > 0 ? QVariant(track.year) : QVariant());
+        query.bindValue(":duration", track.duration);
+        query.bindValue(":location", track.location);
+        query.bindValue(":rating", track.rating);
+        query.bindValue(":comment", track.comment);
+        query.bindValue(":tracknumber",
+                track.trackNumber > 0 ? QVariant(track.trackNumber) : QVariant());
+        query.bindValue(":bpm", track.bpm);
+        query.bindValue(":bitrate", track.bitrate);
 
-    if (!query.exec()) {
-        LOG_FAILED_QUERY(query);
-        return false;
+        if (!query.exec()) {
+            LOG_FAILED_QUERY(query);
+            return false;
+        }
     }
 
     return true;
@@ -90,14 +94,17 @@ bool ITunesDAO::importTrack(const ITunesTrack& track) {
 
 bool ITunesDAO::importPlaylist(const ITunesPlaylist& playlist) {
     QString uniqueName = uniquifyPlaylistName(playlist.name);
-    QSqlQuery& query = m_insertPlaylistQuery;
 
-    query.bindValue(":id", playlist.id);
-    query.bindValue(":name", uniqueName);
+    if (m_isDatabaseInitialized) {
+        QSqlQuery& query = m_insertPlaylistQuery;
 
-    if (!query.exec()) {
-        LOG_FAILED_QUERY(query);
-        return false;
+        query.bindValue(":id", playlist.id);
+        query.bindValue(":name", uniqueName);
+
+        if (!query.exec()) {
+            LOG_FAILED_QUERY(query);
+            return false;
+        }
     }
 
     m_playlistNameById[playlist.id] = uniqueName;
@@ -111,30 +118,34 @@ bool ITunesDAO::importPlaylistRelation(int parentId, int childId) {
 }
 
 bool ITunesDAO::importPlaylistTrack(int playlistId, int trackId, int position) {
-    QSqlQuery& query = m_insertPlaylistTrackQuery;
+    if (m_isDatabaseInitialized) {
+        QSqlQuery& query = m_insertPlaylistTrackQuery;
 
-    query.bindValue(":playlist_id", playlistId);
-    query.bindValue(":track_id", trackId);
-    query.bindValue(":position", position);
+        query.bindValue(":playlist_id", playlistId);
+        query.bindValue(":track_id", trackId);
+        query.bindValue(":position", position);
 
-    if (!query.exec()) {
-        LOG_FAILED_QUERY(query);
-        return false;
+        if (!query.exec()) {
+            LOG_FAILED_QUERY(query);
+            return false;
+        }
     }
 
     return true;
 }
 
 bool ITunesDAO::applyPathMapping(const ITunesPathMapping& pathMapping) {
-    QSqlQuery& query = m_insertPlaylistTrackQuery;
+    if (m_isDatabaseInitialized) {
+        QSqlQuery& query = m_insertPlaylistTrackQuery;
 
-    query.bindValue(":itunes_path",
-            QString(pathMapping.dbITunesRoot).replace(kiTunesLocalhostToken, ""));
-    query.bindValue(":mixxx_path", pathMapping.mixxxITunesRoot);
+        query.bindValue(":itunes_path",
+                QString(pathMapping.dbITunesRoot).replace(kiTunesLocalhostToken, ""));
+        query.bindValue(":mixxx_path", pathMapping.mixxxITunesRoot);
 
-    if (!query.exec()) {
-        LOG_FAILED_QUERY(query);
-        return false;
+        if (!query.exec()) {
+            LOG_FAILED_QUERY(query);
+            return false;
+        }
     }
 
     return true;

--- a/src/library/itunes/itunesdao.cpp
+++ b/src/library/itunes/itunesdao.cpp
@@ -8,6 +8,33 @@
 #include "library/itunes/itunespathmapping.h"
 #include "library/queryutil.h"
 
+std::ostream& operator<<(std::ostream& os, const ITunesTrack& track) {
+    os << "ITunesTrack { "
+       << ".id = " << track.id << ", "
+       << ".artist = \"" << track.artist.toStdString() << "\", "
+       << ".title = \"" << track.title.toStdString() << "\", "
+       << ".album = \"" << track.album.toStdString() << "\", "
+       << ".albumArtist = \"" << track.albumArtist.toStdString() << "\", "
+       << ".genre = \"" << track.genre.toStdString() << "\", "
+       << ".grouping = \"" << track.grouping.toStdString() << "\", "
+       << ".year = " << track.year << ", "
+       << ".duration = " << track.duration << ", "
+       << ".location = \"" << track.location.toStdString() << "\", "
+       << ".rating = " << track.rating << ", "
+       << ".comment = \"" << track.comment.toStdString() << "\", "
+       << ".trackNumber = " << track.trackNumber << ", "
+       << ".bpm = " << track.bpm << ", "
+       << ".bitrate = " << track.bitrate << " }";
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const ITunesPlaylist& playlist) {
+    os << "ITunesPlaylist { "
+       << ".id = " << playlist.id << ", "
+       << ".name = \"" << playlist.name.toStdString() << "\" }";
+    return os;
+}
+
 void ITunesDAO::initialize(const QSqlDatabase& database) {
     m_insertTrackQuery = QSqlQuery(database);
     m_insertPlaylistQuery = QSqlQuery(database);

--- a/src/library/itunes/itunesdao.h
+++ b/src/library/itunes/itunesdao.h
@@ -68,6 +68,11 @@ class ITunesDAO : public DAO {
     QHash<int, QString> m_playlistNameById;
     std::multimap<int, int> m_playlistIdsByParentId;
 
+    // Keeps track of whether the database has been initialized.
+    // In tests the database is not used, so the importer will
+    // only be used to construct a TreeItem.
+    bool m_isDatabaseInitialized = false;
+
     // Note that these queries reference the database, which is expected
     // to outlive the DAO.
     QSqlQuery m_insertTrackQuery;

--- a/src/library/itunes/itunesdao.h
+++ b/src/library/itunes/itunesdao.h
@@ -42,6 +42,9 @@ struct ITunesPlaylist {
     bool operator!=(const ITunesPlaylist&) const = default;
 };
 
+std::ostream& operator<<(std::ostream& os, const ITunesTrack& track);
+std::ostream& operator<<(std::ostream& os, const ITunesPlaylist& playlist);
+
 /// A wrapper around the iTunes database tables. Keeps track of the
 /// playlist tree, deals with duplicate disambiguation and can export
 /// the tree afterwards.

--- a/src/library/itunes/itunesdao.h
+++ b/src/library/itunes/itunesdao.h
@@ -29,11 +29,17 @@ struct ITunesTrack {
     int trackNumber;
     int bpm;
     int bitrate;
+
+    bool operator==(const ITunesTrack&) const = default;
+    bool operator!=(const ITunesTrack&) const = default;
 };
 
 struct ITunesPlaylist {
     int id;
     QString name;
+
+    bool operator==(const ITunesPlaylist&) const = default;
+    bool operator!=(const ITunesPlaylist&) const = default;
 };
 
 /// A wrapper around the iTunes database tables. Keeps track of the

--- a/src/library/itunes/itunesxmlimporter.cpp
+++ b/src/library/itunes/itunesxmlimporter.cpp
@@ -87,6 +87,7 @@ ITunesImport ITunesXMLImporter::importLibrary() {
                     }
                 } else if (key == "Tracks") {
                     parseTracks();
+                } else if (key == "Playlists") {
                     parsePlaylists();
 
                     // The parent feature may ne null during testing
@@ -425,8 +426,7 @@ bool ITunesXMLImporter::readNextStartElement() {
 void ITunesXMLImporter::parsePlaylist() {
     // qDebug() << "Parse Playlist";
 
-    QString name;
-    int id = -1;
+    ITunesPlaylist playlist = {.id = -1, .name{}};
     QString persistentId;
     QString parentPersistentId;
     int trackPosition = -1;
@@ -448,13 +448,13 @@ void ITunesXMLImporter::parsePlaylist() {
                 // Afterwars the playlist entries occur
                 if (key == "Name") {
                     readNextStartElement();
-                    name = m_xml.readElementText();
+                    playlist.name = m_xml.readElementText();
                     continue;
                 }
                 // When parsing the ID, the playlistname has already been found
                 if (key == "Playlist ID") {
                     readNextStartElement();
-                    id = m_xml.readElementText().toInt();
+                    playlist.id = m_xml.readElementText().toInt();
                     trackPosition = 1;
                     continue;
                 }
@@ -466,12 +466,17 @@ void ITunesXMLImporter::parsePlaylist() {
                 if (key == "Parent Persistent ID") {
                     readNextStartElement();
                     parentPersistentId = m_xml.readElementText();
+                    continue;
                 }
                 // Hide playlists that are system playlists
-                if (key == "Master" || key == "Movies" || key == "TV Shows" ||
-                        key == "Music" || key == "Books" || key == "Purchased") {
+                if (key == "Distinguished Kind") {
                     readNextStartElement();
-                    if (m_xml.name() == QString("true")) {
+                    isSystemPlaylist = true;
+                    continue;
+                }
+                if (key == "Visible") {
+                    readNextStartElement();
+                    if (m_xml.name() == QString("false")) {
                         isSystemPlaylist = true;
                     }
                     continue;
@@ -481,18 +486,14 @@ void ITunesXMLImporter::parsePlaylist() {
                     isPlaylistItemsStarted = true;
 
                     // if the playlist is prebuilt don't hit the database
-                    if (isSystemPlaylist) {
-                        continue;
+                    if (!isSystemPlaylist) {
+                        if (!m_dao->importPlaylist(playlist)) {
+                            // unexpected error
+                            break;
+                        }
                     }
 
-                    ITunesPlaylist playlist = {
-                            .id = id,
-                            .name = name,
-                    };
-                    if (!m_dao->importPlaylist(playlist)) {
-                        // unexpected error
-                        break;
-                    }
+                    continue;
                 }
                 // When processing playlist entries, playlist name and id have
                 // already been processed and persisted
@@ -502,7 +503,7 @@ void ITunesXMLImporter::parsePlaylist() {
 
                     // Insert tracks if we are not in a pre-built playlist
                     if (!isSystemPlaylist) {
-                        m_dao->importPlaylistTrack(id,
+                        m_dao->importPlaylistTrack(playlist.id,
                                 trackReference,
                                 trackPosition++);
                     }
@@ -522,7 +523,12 @@ void ITunesXMLImporter::parsePlaylist() {
     }
 
     if (!isSystemPlaylist) {
-        m_playlistIdByPersistentId[persistentId] = id;
+        // Make sure empty playlists are imported too
+        if (!isPlaylistItemsStarted) {
+            m_dao->importPlaylist(playlist);
+        }
+
+        m_playlistIdByPersistentId[persistentId] = playlist.id;
 
         int parentId = kRootITunesPlaylistId;
         if (!parentPersistentId.isNull()) {
@@ -532,6 +538,6 @@ void ITunesXMLImporter::parsePlaylist() {
             }
         }
 
-        m_dao->importPlaylistRelation(parentId, id);
+        m_dao->importPlaylistRelation(parentId, playlist.id);
     }
 }

--- a/src/library/itunes/itunesxmlimporter.cpp
+++ b/src/library/itunes/itunesxmlimporter.cpp
@@ -326,7 +326,13 @@ void ITunesXMLImporter::parseTrack() {
                     continue;
                 }
                 if (key == kLocation) {
-                    location = mixxx::FileInfo::fromQUrl(QUrl(content)).location();
+                    // Convert the location URL to a file path. Note that we intentionally
+                    // do not use FileInfo::location here since it would prepend a drive letter
+                    // prefix to Unix paths, something we already take care of through the
+                    // path mapping below (otherwise we'd end up with duplicate drive letter
+                    // prefixes, e.g. C:C:, if the translation rule already substitutes a
+                    // path with a drive letter).
+                    location = mixxx::FileInfo::fromQUrl(QUrl(content)).asQFileInfo().filePath();
                     // Replace first part of location with the mixxx iTunes Root
                     // on systems where iTunes installed it only strips //localhost
                     // on iTunes from foreign systems the mount point is replaced

--- a/src/library/itunes/itunesxmlimporter.cpp
+++ b/src/library/itunes/itunesxmlimporter.cpp
@@ -69,7 +69,7 @@ ITunesImport ITunesXMLImporter::importLibrary() {
     bool isMusicFolderLocatedAfterTracks = false;
 
     if (!m_xmlFile.open(QIODevice::ReadOnly)) {
-        qDebug() << "Could not open iTunes music collection";
+        qWarning() << "Could not open iTunes music collection XML at " << m_xmlFilePath;
         return iTunesImport;
     }
 

--- a/src/library/itunes/itunesxmlimporter.cpp
+++ b/src/library/itunes/itunesxmlimporter.cpp
@@ -89,7 +89,10 @@ ITunesImport ITunesXMLImporter::importLibrary() {
                     parseTracks();
                     parsePlaylists();
 
-                    std::unique_ptr<TreeItem> pRootItem = TreeItem::newRoot(m_parentFeature);
+                    // The parent feature may ne null during testing
+                    std::unique_ptr<TreeItem> pRootItem = m_parentFeature
+                            ? TreeItem::newRoot(m_parentFeature)
+                            : std::make_unique<TreeItem>();
                     m_dao->appendPlaylistTree(pRootItem.get());
 
                     iTunesImport.playlistRoot = std::move(pRootItem);

--- a/src/test/itunes/iTunes Music Library.xml
+++ b/src/test/itunes/iTunes Music Library.xml
@@ -1,0 +1,672 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Major Version</key><integer>1</integer>
+	<key>Minor Version</key><integer>1</integer>
+	<key>Application Version</key><string>12.12.8.2</string>
+	<key>Date</key><date>2023-04-25T14:20:03Z</date>
+	<key>Features</key><integer>5</integer>
+	<key>Show Content Ratings</key><true/>
+	<key>Library Persistent ID</key><string>94843965EB7D572C</string>
+	<key>Tracks</key>
+	<dict>
+		<key>77</key>
+		<dict>
+			<key>Track ID</key><integer>77</integer>
+			<key>Size</key><integer>8245330</integer>
+			<key>Total Time</key><integer>208110</integer>
+			<key>Disc Number</key><integer>1</integer>
+			<key>Disc Count</key><integer>1</integer>
+			<key>Track Number</key><integer>1</integer>
+			<key>Track Count</key><integer>10</integer>
+			<key>Year</key><integer>1979</integer>
+			<key>Date Modified</key><date>2023-04-25T12:50:28Z</date>
+			<key>Date Added</key><date>2023-04-25T14:13:36Z</date>
+			<key>Bit Rate</key><integer>256</integer>
+			<key>Sample Rate</key><integer>44100</integer>
+			<key>Release Date</key><date>1979-07-27T07:00:00Z</date>
+			<key>Persistent ID</key><string>ABB2A2150DA8ED3C</string>
+			<key>Track Type</key><string>File</string>
+			<key>Purchased</key><true/>
+			<key>File Folder Count</key><integer>-1</integer>
+			<key>Library Folder Count</key><integer>-1</integer>
+			<key>Name</key><string>Highway to Hell</string>
+			<key>Artist</key><string>AC/DC</string>
+			<key>Album Artist</key><string>AC/DC</string>
+			<key>Composer</key><string>Angus Young, Bon Scott &#38; Malcolm Young</string>
+			<key>Album</key><string>Highway to Hell</string>
+			<key>Genre</key><string>Hard Rock</string>
+			<key>Kind</key><string>Purchased AAC audio file</string>
+			<key>Sort Name</key><string>Highway to Hell</string>
+			<key>Sort Album</key><string>Highway to Hell</string>
+			<key>Sort Artist</key><string>AC/DC</string>
+			<key>Location</key><string>file://localhost/Z:/Media.localized/Music/AC_DC/Highway%20to%20Hell/01%20Highway%20to%20Hell.m4a</string>
+		</dict>
+		<key>79</key>
+		<dict>
+			<key>Track ID</key><integer>79</integer>
+			<key>Size</key><integer>6728062</integer>
+			<key>Total Time</key><integer>167129</integer>
+			<key>Disc Number</key><integer>1</integer>
+			<key>Disc Count</key><integer>1</integer>
+			<key>Track Number</key><integer>2</integer>
+			<key>Track Count</key><integer>11</integer>
+			<key>Year</key><integer>2014</integer>
+			<key>Date Modified</key><date>2023-04-25T12:50:29Z</date>
+			<key>Date Added</key><date>2023-04-25T14:13:36Z</date>
+			<key>Bit Rate</key><integer>256</integer>
+			<key>Sample Rate</key><integer>44100</integer>
+			<key>Release Date</key><date>2014-10-07T07:00:00Z</date>
+			<key>Persistent ID</key><string>DEA1712BEE90B074</string>
+			<key>Track Type</key><string>File</string>
+			<key>Purchased</key><true/>
+			<key>File Folder Count</key><integer>-1</integer>
+			<key>Library Folder Count</key><integer>-1</integer>
+			<key>Name</key><string>Play Ball</string>
+			<key>Artist</key><string>AC/DC</string>
+			<key>Album Artist</key><string>AC/DC</string>
+			<key>Composer</key><string>Angus Young &#38; Malcolm Young</string>
+			<key>Album</key><string>Rock or Bust</string>
+			<key>Genre</key><string>Rock</string>
+			<key>Kind</key><string>Purchased AAC audio file</string>
+			<key>Sort Name</key><string>Play Ball</string>
+			<key>Sort Album</key><string>Rock or Bust</string>
+			<key>Sort Artist</key><string>AC/DC</string>
+			<key>Location</key><string>file://localhost/Z:/Media.localized/Music/AC_DC/Rock%20or%20Bust/02%20Play%20Ball.m4a</string>
+		</dict>
+		<key>81</key>
+		<dict>
+			<key>Track ID</key><integer>81</integer>
+			<key>Size</key><integer>7824514</integer>
+			<key>Total Time</key><integer>213800</integer>
+			<key>Disc Number</key><integer>1</integer>
+			<key>Disc Count</key><integer>1</integer>
+			<key>Track Number</key><integer>1</integer>
+			<key>Track Count</key><integer>1</integer>
+			<key>Year</key><integer>2003</integer>
+			<key>Date Modified</key><date>2023-04-25T12:55:27Z</date>
+			<key>Date Added</key><date>2023-04-25T14:13:36Z</date>
+			<key>Bit Rate</key><integer>256</integer>
+			<key>Sample Rate</key><integer>44100</integer>
+			<key>Release Date</key><date>2003-08-25T12:00:00Z</date>
+			<key>Persistent ID</key><string>2CF1682DE1BAE7F3</string>
+			<key>Track Type</key><string>File</string>
+			<key>Purchased</key><true/>
+			<key>File Folder Count</key><integer>-1</integer>
+			<key>Library Folder Count</key><integer>-1</integer>
+			<key>Name</key><string>Are You Gonna Be My Girl</string>
+			<key>Artist</key><string>Jet</string>
+			<key>Album Artist</key><string>Jet</string>
+			<key>Composer</key><string>Cam Muncey &#38; Nic Cester</string>
+			<key>Album</key><string>Are You Gonna Be My Girl - Single</string>
+			<key>Genre</key><string>Rock</string>
+			<key>Kind</key><string>Purchased AAC audio file</string>
+			<key>Sort Name</key><string>Are You Gonna Be My Girl</string>
+			<key>Sort Album</key><string>Are You Gonna Be My Girl - Single</string>
+			<key>Sort Artist</key><string>Jet</string>
+			<key>Location</key><string>file://localhost/Z:/Media.localized/Music/Jet/Are%20You%20Gonna%20Be%20My%20Girl%20-%20Single/01%20Are%20You%20Gonna%20Be%20My%20Girl.m4a</string>
+		</dict>
+		<key>83</key>
+		<dict>
+			<key>Track ID</key><integer>83</integer>
+			<key>Size</key><integer>11000345</integer>
+			<key>Total Time</key><integer>304013</integer>
+			<key>Disc Number</key><integer>1</integer>
+			<key>Disc Count</key><integer>1</integer>
+			<key>Track Number</key><integer>1</integer>
+			<key>Track Count</key><integer>10</integer>
+			<key>Year</key><integer>2012</integer>
+			<key>Date Modified</key><date>2023-04-25T12:51:05Z</date>
+			<key>Date Added</key><date>2023-04-25T14:13:36Z</date>
+			<key>Bit Rate</key><integer>256</integer>
+			<key>Sample Rate</key><integer>44100</integer>
+			<key>Play Count</key><integer>1</integer>
+			<key>Play Date</key><integer>3765284319</integer>
+			<key>Play Date UTC</key><date>2023-04-25T14:18:39Z</date>
+			<key>Release Date</key><date>2012-08-23T00:00:00Z</date>
+			<key>Persistent ID</key><string>5CCB53FB830D3729</string>
+			<key>Track Type</key><string>File</string>
+			<key>Purchased</key><true/>
+			<key>File Folder Count</key><integer>-1</integer>
+			<key>Library Folder Count</key><integer>-1</integer>
+			<key>Name</key><string>What I'd Say</string>
+			<key>Artist</key><string>Ray Charles</string>
+			<key>Album Artist</key><string>Ray Charles</string>
+			<key>Album</key><string>What I'd Say</string>
+			<key>Genre</key><string>Rock</string>
+			<key>Kind</key><string>Purchased AAC audio file</string>
+			<key>Sort Name</key><string>What I'd Say</string>
+			<key>Sort Album</key><string>What I'd Say</string>
+			<key>Sort Artist</key><string>Ray Charles</string>
+			<key>Location</key><string>file://localhost/Z:/Media.localized/Music/Ray%20Charles/What%20I'd%20Say/01%20What%20I'd%20Say.m4a</string>
+		</dict>
+		<key>85</key>
+		<dict>
+			<key>Track ID</key><integer>85</integer>
+			<key>Size</key><integer>11437833</integer>
+			<key>Total Time</key><integer>306527</integer>
+			<key>Disc Number</key><integer>1</integer>
+			<key>Disc Count</key><integer>1</integer>
+			<key>Track Number</key><integer>1</integer>
+			<key>Track Count</key><integer>3</integer>
+			<key>Year</key><integer>2013</integer>
+			<key>Date Modified</key><date>2023-04-25T12:52:09Z</date>
+			<key>Date Added</key><date>2023-04-25T14:13:36Z</date>
+			<key>Bit Rate</key><integer>256</integer>
+			<key>Sample Rate</key><integer>44100</integer>
+			<key>Release Date</key><date>2013-07-22T07:00:00Z</date>
+			<key>Persistent ID</key><string>074663543D68462B</string>
+			<key>Track Type</key><string>File</string>
+			<key>Purchased</key><true/>
+			<key>File Folder Count</key><integer>-1</integer>
+			<key>Library Folder Count</key><integer>-1</integer>
+			<key>Name</key><string>Beast of Burden (Live)</string>
+			<key>Artist</key><string>The Rolling Stones</string>
+			<key>Album Artist</key><string>The Rolling Stones</string>
+			<key>Composer</key><string>Keith Richards &#38; Mick Jagger</string>
+			<key>Album</key><string>Sweet Summer Sun, Live in Hyde Park 2013 (Live) - Single</string>
+			<key>Genre</key><string>Rock</string>
+			<key>Kind</key><string>Purchased AAC audio file</string>
+			<key>Sort Name</key><string>Beast of Burden (Live)</string>
+			<key>Sort Album</key><string>Sweet Summer Sun, Live in Hyde Park 2013 (Live) - Single</string>
+			<key>Sort Artist</key><string>Rolling Stones</string>
+			<key>Sort Album Artist</key><string>Rolling Stones</string>
+			<key>Location</key><string>file://localhost/Z:/Media.localized/Music/The%20Rolling%20Stones/Sweet%20Summer%20Sun,%20Live%20in%20Hyde%20Park%202013%20(Live)%20-%20Single/01%20Beast%20of%20Burden%20(Live).m4a</string>
+		</dict>
+		<key>87</key>
+		<dict>
+			<key>Track ID</key><integer>87</integer>
+			<key>Size</key><integer>8484658</integer>
+			<key>Total Time</key><integer>214626</integer>
+			<key>Disc Number</key><integer>1</integer>
+			<key>Disc Count</key><integer>1</integer>
+			<key>Track Number</key><integer>1</integer>
+			<key>Track Count</key><integer>16</integer>
+			<key>Year</key><integer>1970</integer>
+			<key>Date Modified</key><date>2023-04-25T12:50:59Z</date>
+			<key>Date Added</key><date>2023-04-25T14:13:36Z</date>
+			<key>Bit Rate</key><integer>256</integer>
+			<key>Sample Rate</key><integer>44100</integer>
+			<key>Release Date</key><date>1970-01-01T12:00:00Z</date>
+			<key>Compilation</key><true/>
+			<key>Persistent ID</key><string>D7F1DFDDE09E5AC2</string>
+			<key>Track Type</key><string>File</string>
+			<key>Purchased</key><true/>
+			<key>File Folder Count</key><integer>-1</integer>
+			<key>Library Folder Count</key><integer>-1</integer>
+			<key>Name</key><string>In the Summertime</string>
+			<key>Artist</key><string>Mungo Jerry</string>
+			<key>Album Artist</key><string>Mungo Jerry</string>
+			<key>Composer</key><string>Dorset</string>
+			<key>Album</key><string>In the Summertime</string>
+			<key>Genre</key><string>Rock</string>
+			<key>Kind</key><string>Purchased AAC audio file</string>
+			<key>Sort Name</key><string>In the Summertime</string>
+			<key>Sort Album</key><string>In the Summertime</string>
+			<key>Sort Artist</key><string>Mungo Jerry</string>
+			<key>Location</key><string>file://localhost/Z:/Media.localized/Music/Compilations/In%20the%20Summertime/01%20In%20the%20Summertime.m4a</string>
+		</dict>
+	</dict>
+	<key>Playlists</key>
+	<array>
+		<dict>
+			<key>Master</key><true/>
+			<key>Playlist ID</key><integer>89</integer>
+			<key>Playlist Persistent ID</key><string>0E65D0A5FE1438D0</string>
+			<key>All Items</key><true/>
+			<key>Visible</key><false/>
+			<key>Name</key><string>Library</string>
+			<key>Playlist Items</key>
+			<array>
+				<dict>
+					<key>Track ID</key><integer>77</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>79</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>81</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>83</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>85</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>87</integer>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>Playlist ID</key><integer>98</integer>
+			<key>Playlist Persistent ID</key><string>592428045C455EB5</string>
+			<key>Distinguished Kind</key><integer>65</integer>
+			<key>All Items</key><true/>
+			<key>Name</key><string>Downloaded</string>
+			<key>Smart Info</key>
+			<data>
+			AQEAAwAAAAIAAAAZAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAA==
+			</data>
+			<key>Smart Criteria</key>
+			<data>
+			U0xzdAABAAEAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAQAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEAAAAAAAQIbEAAAAAAAAAAAAAAAAAAAAB
+			AAAAAAAQIbEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AgAEAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAAIIAE
+			AAAAAAAAAAAAAAAAAAAAAQAAAAAAIIAEAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAhQAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAEQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAAAAAAAAAAAAA
+			AAEAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+			</data>
+			<key>Playlist Items</key>
+			<array>
+				<dict>
+					<key>Track ID</key><integer>77</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>79</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>81</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>87</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>83</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>85</integer>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>Playlist ID</key><integer>107</integer>
+			<key>Playlist Persistent ID</key><string>225B9BE0BF496D2A</string>
+			<key>Distinguished Kind</key><integer>4</integer>
+			<key>Music</key><true/>
+			<key>All Items</key><true/>
+			<key>Name</key><string>Music</string>
+			<key>Smart Info</key>
+			<data>
+			AQEAAwAAAAIAAAAZAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAA==
+			</data>
+			<key>Smart Criteria</key>
+			<data>
+			U0xzdAABAAEAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAQAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEAAAAAAAQIbEAAAAAAAAAAAAAAAAAAAAB
+			AAAAAAAQIbEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AgAEAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAAIIAE
+			AAAAAAAAAAAAAAAAAAAAAQAAAAAAIIAEAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAA
+			AAAAAAAA
+			</data>
+			<key>Playlist Items</key>
+			<array>
+				<dict>
+					<key>Track ID</key><integer>77</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>79</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>81</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>87</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>83</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>85</integer>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>Playlist ID</key><integer>125</integer>
+			<key>Playlist Persistent ID</key><string>4CD95B4802211702</string>
+			<key>Distinguished Kind</key><integer>66</integer>
+			<key>All Items</key><true/>
+			<key>Name</key><string>Downloaded</string>
+			<key>Smart Info</key>
+			<data>
+			AQEAAwAAAAIAAAAZAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAA==
+			</data>
+			<key>Smart Criteria</key>
+			<data>
+			U0xzdAABAAEAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAQAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAB
+			AAAAAAAAAAIAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AgAEAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAAIKAE
+			AAAAAAAAAAAAAAAAAAAAAQAAAAAAIKAEAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAhQAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAEQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAAAAAAAAAAAAA
+			AAEAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+			</data>
+		</dict>
+		<dict>
+			<key>Playlist ID</key><integer>128</integer>
+			<key>Playlist Persistent ID</key><string>72185EA1D4EF708A</string>
+			<key>Distinguished Kind</key><integer>2</integer>
+			<key>Movies</key><true/>
+			<key>All Items</key><true/>
+			<key>Name</key><string>Movies</string>
+			<key>Smart Info</key>
+			<data>
+			AQEAAwAAAAIAAAAZAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAA==
+			</data>
+			<key>Smart Criteria</key>
+			<data>
+			U0xzdAABAAEAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAQAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAB
+			AAAAAAAAAAIAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AgAEAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAAIKAE
+			AAAAAAAAAAAAAAAAAAAAAQAAAAAAIKAEAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAA
+			AAAAAAAA
+			</data>
+		</dict>
+		<dict>
+			<key>Playlist ID</key><integer>134</integer>
+			<key>Playlist Persistent ID</key><string>B874697EC81AD4B6</string>
+			<key>Distinguished Kind</key><integer>67</integer>
+			<key>All Items</key><true/>
+			<key>Name</key><string>Downloaded</string>
+			<key>Smart Info</key>
+			<data>
+			AQEAAwAAAAIAAAAZAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAA==
+			</data>
+			<key>Smart Criteria</key>
+			<data>
+			U0xzdAABAAEAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAQAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAB
+			AAAAAAAAAEAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AgAEAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAAIKAE
+			AAAAAAAAAAAAAAAAAAAAAQAAAAAAIKAEAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAhQAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAEQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAAAAAAAAAAAAA
+			AAEAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+			</data>
+		</dict>
+		<dict>
+			<key>Playlist ID</key><integer>137</integer>
+			<key>Playlist Persistent ID</key><string>330B5E8738133109</string>
+			<key>Distinguished Kind</key><integer>3</integer>
+			<key>TV Shows</key><true/>
+			<key>All Items</key><true/>
+			<key>Name</key><string>TV Shows</string>
+			<key>Smart Info</key>
+			<data>
+			AQEAAwAAAAIAAAAZAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAA==
+			</data>
+			<key>Smart Criteria</key>
+			<data>
+			U0xzdAABAAEAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAQAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAB
+			AAAAAAAAAEAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AgAEAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAAIKAE
+			AAAAAAAAAAAAAAAAAAAAAQAAAAAAIKAEAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAA
+			AAAAAAAA
+			</data>
+		</dict>
+		<dict>
+			<key>Playlist ID</key><integer>140</integer>
+			<key>Playlist Persistent ID</key><string>24AE0A321CB43B25</string>
+			<key>Distinguished Kind</key><integer>10</integer>
+			<key>Podcasts</key><true/>
+			<key>All Items</key><true/>
+			<key>Name</key><string>Podcasts</string>
+		</dict>
+		<dict>
+			<key>Playlist ID</key><integer>147</integer>
+			<key>Playlist Persistent ID</key><string>E8E5CA0525A9DB54</string>
+			<key>Distinguished Kind</key><integer>5</integer>
+			<key>Audiobooks</key><true/>
+			<key>All Items</key><true/>
+			<key>Name</key><string>Audiobooks</string>
+			<key>Smart Info</key>
+			<data>
+			AQEAAwAAAAIAAAAZAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAA==
+			</data>
+			<key>Smart Criteria</key>
+			<data>
+			U0xzdAABAAEAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAQAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAB
+			AAAAAAAAAAgAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AgAEAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAAIKAE
+			AAAAAAAAAAAAAAAAAAAAAQAAAAAAIKAEAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAA
+			AAAAAAAA
+			</data>
+		</dict>
+		<dict>
+			<key>Playlist ID</key><integer>150</integer>
+			<key>Playlist Persistent ID</key><string>94CAA60703EFA7C7</string>
+			<key>Distinguished Kind</key><integer>26</integer>
+			<key>All Items</key><true/>
+			<key>Name</key><string>Genius</string>
+			<key>Smart Info</key>
+			<data>
+			AAABAwAAAAIAAAAZAAABAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAA==
+			</data>
+			<key>Smart Criteria</key>
+			<data>
+			U0xzdAABAAEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+			</data>
+		</dict>
+		<dict>
+			<key>Playlist ID</key><integer>153</integer>
+			<key>Playlist Persistent ID</key><string>01ADA2FCEB6CB1FE</string>
+			<key>All Items</key><true/>
+			<key>Folder</key><true/>
+			<key>Name</key><string>Folder A</string>
+			<key>Smart Info</key>
+			<data>
+			AQEAAwAAAAIAAAAZAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAA==
+			</data>
+			<key>Smart Criteria</key>
+			<data>
+			U0xzdAABAAEAAAACAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACgAAAABAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEcsherUUVflwAAAAAAAAAAAAAAAAAAAAB
+			csherUUVflwAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoAAAAAQAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARDK/SB6kzERM
+			AAAAAAAAAAAAAAAAAAAAATK/SB6kzERMAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAA
+			AAAAAAAA
+			</data>
+			<key>Playlist Items</key>
+			<array>
+				<dict>
+					<key>Track ID</key><integer>81</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>83</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>87</integer>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>Playlist ID</key><integer>159</integer>
+			<key>Parent Persistent ID</key><string>01ADA2FCEB6CB1FE</string>
+			<key>Playlist Persistent ID</key><string>72C85EAD45157E5C</string>
+			<key>All Items</key><true/>
+			<key>Folder</key><true/>
+			<key>Name</key><string>Folder B</string>
+			<key>Smart Info</key>
+			<data>
+			AQEAAwAAAAIAAAAZAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAA==
+			</data>
+			<key>Smart Criteria</key>
+			<data>
+			U0xzdAABAAEAAAACAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACgAAAABAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABE6yWufAJ8TgkAAAAAAAAAAAAAAAAAAAAB
+			6yWufAJ8TgkAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoAAAAAQAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARGH0eUmV+9IC
+			AAAAAAAAAAAAAAAAAAAAAWH0eUmV+9ICAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAA
+			AAAAAAAA
+			</data>
+			<key>Playlist Items</key>
+			<array>
+				<dict>
+					<key>Track ID</key><integer>81</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>83</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>87</integer>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>Playlist ID</key><integer>165</integer>
+			<key>Parent Persistent ID</key><string>72C85EAD45157E5C</string>
+			<key>Playlist Persistent ID</key><string>EB25AE7C027C4E09</string>
+			<key>All Items</key><true/>
+			<key>Name</key><string>Playlist A</string>
+			<key>Playlist Items</key>
+			<array>
+				<dict>
+					<key>Track ID</key><integer>83</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>87</integer>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>Playlist ID</key><integer>170</integer>
+			<key>Parent Persistent ID</key><string>72C85EAD45157E5C</string>
+			<key>Playlist Persistent ID</key><string>61F4794995FBD202</string>
+			<key>All Items</key><true/>
+			<key>Name</key><string>Playlist B</string>
+			<key>Playlist Items</key>
+			<array>
+				<dict>
+					<key>Track ID</key><integer>81</integer>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>Playlist ID</key><integer>174</integer>
+			<key>Parent Persistent ID</key><string>01ADA2FCEB6CB1FE</string>
+			<key>Playlist Persistent ID</key><string>32BF481EA4CC444C</string>
+			<key>All Items</key><true/>
+			<key>Name</key><string>Playlist C</string>
+		</dict>
+		<dict>
+			<key>Playlist ID</key><integer>177</integer>
+			<key>Playlist Persistent ID</key><string>CA8A40EF2E1F2A62</string>
+			<key>All Items</key><true/>
+			<key>Name</key><string>Downloaded</string>
+			<key>Smart Info</key>
+			<data>
+			AQEAAwAAAAIAAAAZAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAA==
+			</data>
+			<key>Smart Criteria</key>
+			<data>
+			U0xzdAABAAEAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAQAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAU0xzdAABAAEAAAACAAAAAQAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAADwAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAABEAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAB
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAg
+			AAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEBAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQRTTHN0AAEAAQAAAAEAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAhQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAEQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAAAAA
+			AAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+			</data>
+			<key>Playlist Items</key>
+			<array>
+				<dict>
+					<key>Track ID</key><integer>77</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>79</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>81</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>87</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>83</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>85</integer>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>Playlist ID</key><integer>186</integer>
+			<key>Playlist Persistent ID</key><string>37BCE99C40413841</string>
+			<key>All Items</key><true/>
+			<key>Name</key><string>Playlist D</string>
+			<key>Playlist Items</key>
+			<array>
+				<dict>
+					<key>Track ID</key><integer>85</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>79</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>77</integer>
+				</dict>
+			</array>
+		</dict>
+	</array>
+	<key>Music Folder</key><string>file://localhost/C:/Users/vm/Music/iTunes/iTunes%20Media/</string>
+</dict>
+</plist>

--- a/src/test/itunes/macOS Music Library.xml
+++ b/src/test/itunes/macOS Music Library.xml
@@ -1,0 +1,449 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Major Version</key><integer>1</integer>
+	<key>Minor Version</key><integer>1</integer>
+	<key>Date</key><date>2023-04-25T13:17:12Z</date>
+	<key>Application Version</key><string>1.3.5.3</string>
+	<key>Features</key><integer>5</integer>
+	<key>Show Content Ratings</key><true/>
+	<key>Music Folder</key><string>file:///Users/mixxxtest/Test%20Library/Media.localized/</string>
+	<key>Library Persistent ID</key><string>6DC25EC7224B4943</string>
+	<key>Tracks</key>
+	<dict>
+		<key>467</key>
+		<dict>
+			<key>Track ID</key><integer>467</integer>
+			<key>Name</key><string>In the Summertime</string>
+			<key>Artist</key><string>Mungo Jerry</string>
+			<key>Album Artist</key><string>Mungo Jerry</string>
+			<key>Composer</key><string>Dorset</string>
+			<key>Album</key><string>In the Summertime</string>
+			<key>Genre</key><string>Rock</string>
+			<key>Kind</key><string>Purchased AAC audio file</string>
+			<key>Size</key><integer>8484658</integer>
+			<key>Total Time</key><integer>214626</integer>
+			<key>Disc Number</key><integer>1</integer>
+			<key>Disc Count</key><integer>1</integer>
+			<key>Track Number</key><integer>1</integer>
+			<key>Track Count</key><integer>16</integer>
+			<key>Year</key><integer>1970</integer>
+			<key>Date Modified</key><date>2023-04-25T12:50:59Z</date>
+			<key>Date Added</key><date>2023-04-25T14:13:36Z</date>
+			<key>Bit Rate</key><integer>256</integer>
+			<key>Sample Rate</key><integer>44100</integer>
+			<key>Release Date</key><date>1970-01-01T12:00:00Z</date>
+			<key>Normalization</key><integer>1865</integer>
+			<key>Compilation</key><true/>
+			<key>Sort Album</key><string>In the Summertime</string>
+			<key>Sort Artist</key><string>Mungo Jerry</string>
+			<key>Sort Name</key><string>In the Summertime</string>
+			<key>Persistent ID</key><string>C7BBCE8A598C5E0B</string>
+			<key>Track Type</key><string>File</string>
+			<key>Purchased</key><true/>
+			<key>Location</key><string>file:///Users/mixxxtest/Test%20Library/Media.localized/Music/Compilations/In%20the%20Summertime/01%20In%20the%20Summertime.m4a</string>
+			<key>File Folder Count</key><integer>5</integer>
+			<key>Library Folder Count</key><integer>1</integer>
+		</dict>
+		<key>470</key>
+		<dict>
+			<key>Track ID</key><integer>470</integer>
+			<key>Name</key><string>Beast of Burden (Live)</string>
+			<key>Artist</key><string>The Rolling Stones</string>
+			<key>Album Artist</key><string>The Rolling Stones</string>
+			<key>Composer</key><string>Keith Richards &#38; Mick Jagger</string>
+			<key>Album</key><string>Sweet Summer Sun, Live in Hyde Park 2013 (Live) - Single</string>
+			<key>Genre</key><string>Rock</string>
+			<key>Kind</key><string>Purchased AAC audio file</string>
+			<key>Size</key><integer>11437833</integer>
+			<key>Total Time</key><integer>306527</integer>
+			<key>Disc Number</key><integer>1</integer>
+			<key>Disc Count</key><integer>1</integer>
+			<key>Track Number</key><integer>1</integer>
+			<key>Track Count</key><integer>3</integer>
+			<key>Year</key><integer>2013</integer>
+			<key>Date Modified</key><date>2023-04-25T12:52:09Z</date>
+			<key>Date Added</key><date>2023-04-25T14:13:36Z</date>
+			<key>Bit Rate</key><integer>256</integer>
+			<key>Sample Rate</key><integer>44100</integer>
+			<key>Release Date</key><date>2013-07-22T07:00:00Z</date>
+			<key>Normalization</key><integer>7486</integer>
+			<key>Sort Album</key><string>Sweet Summer Sun, Live in Hyde Park 2013 (Live) - Single</string>
+			<key>Sort Album Artist</key><string>Rolling Stones</string>
+			<key>Sort Artist</key><string>Rolling Stones</string>
+			<key>Sort Name</key><string>Beast of Burden (Live)</string>
+			<key>Persistent ID</key><string>F5DD2A5AF43460FC</string>
+			<key>Track Type</key><string>File</string>
+			<key>Purchased</key><true/>
+			<key>Location</key><string>file:///Users/mixxxtest/Test%20Library/Media.localized/Music/The%20Rolling%20Stones/Sweet%20Summer%20Sun,%20Live%20in%20Hyde%20Park%202013%20(Live)%20-%20Single/01%20Beast%20of%20Burden%20(Live).m4a</string>
+			<key>File Folder Count</key><integer>5</integer>
+			<key>Library Folder Count</key><integer>1</integer>
+		</dict>
+		<key>473</key>
+		<dict>
+			<key>Track ID</key><integer>473</integer>
+			<key>Name</key><string>What I'd Say</string>
+			<key>Artist</key><string>Ray Charles</string>
+			<key>Album Artist</key><string>Ray Charles</string>
+			<key>Album</key><string>What I'd Say</string>
+			<key>Genre</key><string>Rock</string>
+			<key>Kind</key><string>Purchased AAC audio file</string>
+			<key>Size</key><integer>11000345</integer>
+			<key>Total Time</key><integer>304013</integer>
+			<key>Disc Number</key><integer>1</integer>
+			<key>Disc Count</key><integer>1</integer>
+			<key>Track Number</key><integer>1</integer>
+			<key>Track Count</key><integer>10</integer>
+			<key>Year</key><integer>2012</integer>
+			<key>Date Modified</key><date>2023-04-25T12:51:05Z</date>
+			<key>Date Added</key><date>2023-04-25T14:13:36Z</date>
+			<key>Bit Rate</key><integer>256</integer>
+			<key>Sample Rate</key><integer>44100</integer>
+			<key>Release Date</key><date>2012-08-23T00:00:00Z</date>
+			<key>Normalization</key><integer>4339</integer>
+			<key>Sort Album</key><string>What I'd Say</string>
+			<key>Sort Artist</key><string>Ray Charles</string>
+			<key>Sort Name</key><string>What I'd Say</string>
+			<key>Persistent ID</key><string>6B15F4E7DAF366C7</string>
+			<key>Track Type</key><string>File</string>
+			<key>Purchased</key><true/>
+			<key>Location</key><string>file:///Users/mixxxtest/Test%20Library/Media.localized/Music/Ray%20Charles/What%20I'd%20Say/01%20What%20I'd%20Say.m4a</string>
+			<key>File Folder Count</key><integer>5</integer>
+			<key>Library Folder Count</key><integer>1</integer>
+		</dict>
+		<key>476</key>
+		<dict>
+			<key>Track ID</key><integer>476</integer>
+			<key>Name</key><string>Are You Gonna Be My Girl</string>
+			<key>Artist</key><string>Jet</string>
+			<key>Album Artist</key><string>Jet</string>
+			<key>Composer</key><string>Cam Muncey &#38; Nic Cester</string>
+			<key>Album</key><string>Are You Gonna Be My Girl - Single</string>
+			<key>Genre</key><string>Rock</string>
+			<key>Kind</key><string>Purchased AAC audio file</string>
+			<key>Size</key><integer>7824514</integer>
+			<key>Total Time</key><integer>213800</integer>
+			<key>Disc Number</key><integer>1</integer>
+			<key>Disc Count</key><integer>1</integer>
+			<key>Track Number</key><integer>1</integer>
+			<key>Track Count</key><integer>1</integer>
+			<key>Year</key><integer>2003</integer>
+			<key>Date Modified</key><date>2023-04-25T12:55:27Z</date>
+			<key>Date Added</key><date>2023-04-25T14:13:36Z</date>
+			<key>Bit Rate</key><integer>256</integer>
+			<key>Sample Rate</key><integer>44100</integer>
+			<key>Release Date</key><date>2003-08-25T12:00:00Z</date>
+			<key>Normalization</key><integer>11520</integer>
+			<key>Sort Album</key><string>Are You Gonna Be My Girl - Single</string>
+			<key>Sort Artist</key><string>Jet</string>
+			<key>Sort Name</key><string>Are You Gonna Be My Girl</string>
+			<key>Persistent ID</key><string>0358C36EFB35699F</string>
+			<key>Track Type</key><string>File</string>
+			<key>Purchased</key><true/>
+			<key>Location</key><string>file:///Users/mixxxtest/Test%20Library/Media.localized/Music/Jet/Are%20You%20Gonna%20Be%20My%20Girl%20-%20Single/01%20Are%20You%20Gonna%20Be%20My%20Girl.m4a</string>
+			<key>File Folder Count</key><integer>5</integer>
+			<key>Library Folder Count</key><integer>1</integer>
+		</dict>
+		<key>479</key>
+		<dict>
+			<key>Track ID</key><integer>479</integer>
+			<key>Name</key><string>Highway to Hell</string>
+			<key>Artist</key><string>AC/DC</string>
+			<key>Album Artist</key><string>AC/DC</string>
+			<key>Composer</key><string>Angus Young, Bon Scott &#38; Malcolm Young</string>
+			<key>Album</key><string>Highway to Hell</string>
+			<key>Genre</key><string>Hard Rock</string>
+			<key>Kind</key><string>Purchased AAC audio file</string>
+			<key>Size</key><integer>8245330</integer>
+			<key>Total Time</key><integer>208110</integer>
+			<key>Disc Number</key><integer>1</integer>
+			<key>Disc Count</key><integer>1</integer>
+			<key>Track Number</key><integer>1</integer>
+			<key>Track Count</key><integer>10</integer>
+			<key>Year</key><integer>1979</integer>
+			<key>Date Modified</key><date>2023-04-25T12:50:28Z</date>
+			<key>Date Added</key><date>2023-04-25T14:13:36Z</date>
+			<key>Bit Rate</key><integer>256</integer>
+			<key>Sample Rate</key><integer>44100</integer>
+			<key>Release Date</key><date>1979-07-27T07:00:00Z</date>
+			<key>Normalization</key><integer>10652</integer>
+			<key>Sort Album</key><string>Highway to Hell</string>
+			<key>Sort Artist</key><string>AC/DC</string>
+			<key>Sort Name</key><string>Highway to Hell</string>
+			<key>Persistent ID</key><string>AA472ACC8CCF0EDE</string>
+			<key>Track Type</key><string>File</string>
+			<key>Purchased</key><true/>
+			<key>Location</key><string>file:///Users/mixxxtest/Test%20Library/Media.localized/Music/AC_DC/Highway%20to%20Hell/01%20Highway%20to%20Hell.m4a</string>
+			<key>File Folder Count</key><integer>5</integer>
+			<key>Library Folder Count</key><integer>1</integer>
+		</dict>
+		<key>482</key>
+		<dict>
+			<key>Track ID</key><integer>482</integer>
+			<key>Name</key><string>Play Ball</string>
+			<key>Artist</key><string>AC/DC</string>
+			<key>Album Artist</key><string>AC/DC</string>
+			<key>Composer</key><string>Angus Young &#38; Malcolm Young</string>
+			<key>Album</key><string>Rock or Bust</string>
+			<key>Genre</key><string>Rock</string>
+			<key>Kind</key><string>Purchased AAC audio file</string>
+			<key>Size</key><integer>6728062</integer>
+			<key>Total Time</key><integer>167129</integer>
+			<key>Disc Number</key><integer>1</integer>
+			<key>Disc Count</key><integer>1</integer>
+			<key>Track Number</key><integer>2</integer>
+			<key>Track Count</key><integer>11</integer>
+			<key>Year</key><integer>2014</integer>
+			<key>Date Modified</key><date>2023-04-25T12:50:29Z</date>
+			<key>Date Added</key><date>2023-04-25T14:13:36Z</date>
+			<key>Bit Rate</key><integer>256</integer>
+			<key>Sample Rate</key><integer>44100</integer>
+			<key>Release Date</key><date>2014-10-07T07:00:00Z</date>
+			<key>Normalization</key><integer>9774</integer>
+			<key>Sort Album</key><string>Rock or Bust</string>
+			<key>Sort Artist</key><string>AC/DC</string>
+			<key>Sort Name</key><string>Play Ball</string>
+			<key>Persistent ID</key><string>001E38A54546DD36</string>
+			<key>Track Type</key><string>File</string>
+			<key>Purchased</key><true/>
+			<key>Location</key><string>file:///Users/mixxxtest/Test%20Library/Media.localized/Music/AC_DC/Rock%20or%20Bust/02%20Play%20Ball.m4a</string>
+			<key>File Folder Count</key><integer>5</integer>
+			<key>Library Folder Count</key><integer>1</integer>
+		</dict>
+	</dict>
+	<key>Playlists</key>
+	<array>
+		<dict>
+			<key>Name</key><string>Library</string>
+			<key>Description</key><string></string>
+			<key>Master</key><true/>
+			<key>Playlist ID</key><integer>65</integer>
+			<key>Playlist Persistent ID</key><string>0000000000000005</string>
+			<key>Visible</key><false/>
+			<key>All Items</key><true/>
+			<key>Playlist Items</key>
+			<array>
+				<dict>
+					<key>Track ID</key><integer>467</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>470</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>473</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>476</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>479</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>482</integer>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>Name</key><string>Downloaded</string>
+			<key>Description</key><string></string>
+			<key>Playlist ID</key><integer>1172</integer>
+			<key>Playlist Persistent ID</key><string>68E2E48A22A0801D</string>
+			<key>Distinguished Kind</key><integer>65</integer>
+			<key>All Items</key><true/>
+			<key>Playlist Items</key>
+			<array>
+				<dict>
+					<key>Track ID</key><integer>479</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>482</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>467</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>473</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>470</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>476</integer>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>Name</key><string>Music</string>
+			<key>Description</key><string></string>
+			<key>Playlist ID</key><integer>1181</integer>
+			<key>Playlist Persistent ID</key><string>47E98243439B17EE</string>
+			<key>Distinguished Kind</key><integer>4</integer>
+			<key>Music</key><true/>
+			<key>All Items</key><true/>
+			<key>Playlist Items</key>
+			<array>
+				<dict>
+					<key>Track ID</key><integer>479</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>482</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>476</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>467</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>473</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>470</integer>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>Name</key><string>Folder A</string>
+			<key>Description</key><string></string>
+			<key>Playlist ID</key><integer>1425</integer>
+			<key>Playlist Persistent ID</key><string>916A358E1A377577</string>
+			<key>All Items</key><true/>
+			<key>Folder</key><true/>
+			<key>Playlist Items</key>
+			<array>
+				<dict>
+					<key>Track ID</key><integer>467</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>473</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>476</integer>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>Name</key><string>Folder B</string>
+			<key>Description</key><string></string>
+			<key>Playlist ID</key><integer>1498</integer>
+			<key>Playlist Persistent ID</key><string>F3ECD20348F7C12C</string>
+			<key>Parent Persistent ID</key><string>916A358E1A377577</string>
+			<key>All Items</key><true/>
+			<key>Folder</key><true/>
+			<key>Playlist Items</key>
+			<array>
+				<dict>
+					<key>Track ID</key><integer>467</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>473</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>476</integer>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>Name</key><string>Playlist A</string>
+			<key>Description</key><string></string>
+			<key>Playlist ID</key><integer>1431</integer>
+			<key>Playlist Persistent ID</key><string>E227F4EBD312F7E1</string>
+			<key>Parent Persistent ID</key><string>F3ECD20348F7C12C</string>
+			<key>All Items</key><true/>
+			<key>Playlist Items</key>
+			<array>
+				<dict>
+					<key>Track ID</key><integer>473</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>467</integer>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>Name</key><string>Playlist B</string>
+			<key>Description</key><string></string>
+			<key>Playlist ID</key><integer>1436</integer>
+			<key>Playlist Persistent ID</key><string>558075E9122B3136</string>
+			<key>Parent Persistent ID</key><string>F3ECD20348F7C12C</string>
+			<key>All Items</key><true/>
+			<key>Playlist Items</key>
+			<array>
+				<dict>
+					<key>Track ID</key><integer>476</integer>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>Name</key><string>Playlist C</string>
+			<key>Description</key><string></string>
+			<key>Playlist ID</key><integer>1494</integer>
+			<key>Playlist Persistent ID</key><string>BA8725842B1738C3</string>
+			<key>Parent Persistent ID</key><string>916A358E1A377577</string>
+			<key>All Items</key><true/>
+		</dict>
+		<dict>
+			<key>Name</key><string>Downloaded</string>
+			<key>Description</key><string></string>
+			<key>Playlist ID</key><integer>1440</integer>
+			<key>Playlist Persistent ID</key><string>FF52978149C39F36</string>
+			<key>All Items</key><true/>
+			<key>Smart Info</key>
+			<data>
+			AQEAAwAAAAIAAAAZAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAA==
+			</data>
+			<key>Smart Criteria</key>
+			<data>
+			U0xzdAABAAEAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIUAAAQAAAAAAAAAAAAAAAAAAAAAAAAA
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAB
+			AAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+			</data>
+			<key>Playlist Items</key>
+			<array>
+				<dict>
+					<key>Track ID</key><integer>479</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>482</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>467</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>473</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>470</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>476</integer>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>Name</key><string>Playlist D</string>
+			<key>Description</key><string></string>
+			<key>Playlist ID</key><integer>1449</integer>
+			<key>Playlist Persistent ID</key><string>9AC2F34D7B2BAB0E</string>
+			<key>All Items</key><true/>
+			<key>Playlist Items</key>
+			<array>
+				<dict>
+					<key>Track ID</key><integer>470</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>482</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>479</integer>
+				</dict>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/src/test/itunesxmlimportertest.cpp
+++ b/src/test/itunesxmlimportertest.cpp
@@ -242,8 +242,23 @@ TEST_F(ITunesXMLImporterTest, ParseMacOSMusicXML) {
             makeImporter("macOS Music Library.xml", std::move(dao));
     ITunesImport import = importer->importLibrary();
 
-    TreeItem* playlistRoot = import.playlistRoot.get();
-    EXPECT_EQ(playlistRoot->children().size(), 4);
+    TreeItem* rootItem = import.playlistRoot.get();
+    EXPECT_EQ(rootItem->children().size(), 4);
+    EXPECT_EQ(rootItem->child(0)->getLabel().toStdString(), "Downloaded");
+    EXPECT_EQ(rootItem->child(1)->getLabel().toStdString(), "Folder A");
+    EXPECT_EQ(rootItem->child(2)->getLabel().toStdString(), "Downloaded #2");
+    EXPECT_EQ(rootItem->child(3)->getLabel().toStdString(), "Playlist D");
+
+    TreeItem* folderA = rootItem->child(1);
+    EXPECT_EQ(folderA->children().size(), 2);
+    EXPECT_EQ(folderA->child(0)->getLabel().toStdString(), "Folder B");
+    // TODO: Fix empty playlist
+    // EXPECT_EQ(folderA->child(1)->getLabel().toStdString(), "Playlist C");
+
+    TreeItem* folderB = folderA->child(0);
+    EXPECT_EQ(folderB->children().size(), 2);
+    EXPECT_EQ(folderB->child(0)->getLabel().toStdString(), "Playlist A");
+    EXPECT_EQ(folderB->child(1)->getLabel().toStdString(), "Playlist B");
 }
 
 TEST_F(ITunesXMLImporterTest, ParseITunesMusicXML) {

--- a/src/test/itunesxmlimportertest.cpp
+++ b/src/test/itunesxmlimportertest.cpp
@@ -177,6 +177,42 @@ TEST_F(ITunesXMLImporterTest, ParseMacOSMusicXML) {
                     .bitrate = 256,
             }));
 
+    EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
+                              .id = 1172,
+                              .name = "Downloaded",
+                      }));
+    EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
+                              .id = 1425,
+                              .name = "Folder A",
+                      }));
+    EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
+                              .id = 1498,
+                              .name = "Folder B",
+                      }));
+    EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
+                              .id = 1431,
+                              .name = "Playlist A",
+                      }));
+    EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
+                              .id = 1436,
+                              .name = "Playlist B",
+                      }));
+    EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
+                              .id = 1440,
+                              .name = "Downloaded",
+                      }));
+    EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
+                              .id = 1449,
+                              .name = "Playlist D",
+                      }));
+
+    // The XML importer currently does not import empty playlists.
+    EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
+                              .id = 1494,
+                              .name = "Playlist C",
+                      }))
+            .Times(0);
+
     int root = kRootITunesPlaylistId;
     EXPECT_CALL(*dao, importPlaylistRelation(root, 1172)); // Downloaded (built-in playlist)
     EXPECT_CALL(*dao, importPlaylistRelation(root, 1425)); // Folder A
@@ -317,6 +353,42 @@ TEST_F(ITunesXMLImporterTest, ParseITunesMusicXML) {
                     .bpm = 0,
                     .bitrate = 256,
             }));
+
+    EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
+                              .id = 98,
+                              .name = "Downloaded",
+                      }));
+    EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
+                              .id = 153,
+                              .name = "Folder A",
+                      }));
+    EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
+                              .id = 159,
+                              .name = "Folder B",
+                      }));
+    EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
+                              .id = 165,
+                              .name = "Playlist A",
+                      }));
+    EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
+                              .id = 170,
+                              .name = "Playlist B",
+                      }));
+    EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
+                              .id = 177,
+                              .name = "Downloaded",
+                      }));
+    EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
+                              .id = 186,
+                              .name = "Playlist D",
+                      }));
+
+    // The XML importer currently does not import empty playlists.
+    EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
+                              .id = 174,
+                              .name = "Playlist C",
+                      }))
+            .Times(0);
 
     int root = kRootITunesPlaylistId;
     EXPECT_CALL(*dao, importPlaylistRelation(root, 98));  // Downloaded (built-in playlist)

--- a/src/test/itunesxmlimportertest.cpp
+++ b/src/test/itunesxmlimportertest.cpp
@@ -52,6 +52,7 @@ std::unique_ptr<MockITunesDAO> makeMockDAO() {
 
     return dao;
 }
+
 } // anonymous namespace
 
 TEST_F(ITunesXMLImporterTest, ParseMacOSMusicXML) {
@@ -74,6 +75,125 @@ TEST_F(ITunesXMLImporterTest, ParseMacOSMusicXML) {
 
 TEST_F(ITunesXMLImporterTest, ParseITunesMusicXML) {
     std::unique_ptr<MockITunesDAO> dao = makeMockDAO();
+
+    QString mediaRoot = "/localhost/Z:/Media.localized/Music";
+    EXPECT_CALL(*dao,
+            importTrack(ITunesTrack{
+                    .id = 77,
+                    .artist = "AC/DC",
+                    .title = "Highway to Hell",
+                    .album = "Highway to Hell",
+                    .albumArtist = "AC/DC",
+                    .genre = "Hard Rock",
+                    .grouping = "",
+                    .year = 1979,
+                    .duration = 208,
+                    .location = mediaRoot +
+                            "/AC_DC/Highway to Hell/01 Highway to Hell.m4a",
+                    .rating = 0,
+                    .comment = "",
+                    .trackNumber = 1,
+                    .bpm = 0,
+                    .bitrate = 256,
+            }));
+    EXPECT_CALL(*dao, importTrack(ITunesTrack{
+                              .id = 79,
+                              .artist = "AC/DC",
+                              .title = "Play Ball",
+                              .album = "Rock or Bust",
+                              .albumArtist = "AC/DC",
+                              .genre = "Rock",
+                              .grouping = "",
+                              .year = 2014,
+                              .duration = 167,
+                              .location = mediaRoot + "/AC_DC/Rock or Bust/02 Play Ball.m4a",
+                              .rating = 0,
+                              .comment = "",
+                              .trackNumber = 2,
+                              .bpm = 0,
+                              .bitrate = 256,
+                      }));
+    EXPECT_CALL(*dao,
+            importTrack(ITunesTrack{
+                    .id = 81,
+                    .artist = "Jet",
+                    .title = "Are You Gonna Be My Girl",
+                    .album = "Are You Gonna Be My Girl - Single",
+                    .albumArtist = "Jet",
+                    .genre = "Rock",
+                    .grouping = "",
+                    .year = 2003,
+                    .duration = 213,
+                    .location = "/localhost/Z:/Media.localized/Music/Jet/Are "
+                                "You Gonna Be My Girl - Single/01 Are You "
+                                "Gonna Be My Girl.m4a",
+                    .rating = 0,
+                    .comment = "",
+                    .trackNumber = 1,
+                    .bpm = 0,
+                    .bitrate = 256,
+            }));
+    EXPECT_CALL(*dao,
+            importTrack(ITunesTrack{
+                    .id = 83,
+                    .artist = "Ray Charles",
+                    .title = "What I'd Say",
+                    .album = "What I'd Say",
+                    .albumArtist = "Ray Charles",
+                    .genre = "Rock",
+                    .grouping = "",
+                    .year = 2012,
+                    .duration = 304,
+                    .location = "/localhost/Z:/Media.localized/Music/Ray "
+                                "Charles/What I'd Say/01 What I'd Say.m4a",
+                    .rating = 0,
+                    .comment = "",
+                    .trackNumber = 1,
+                    .bpm = 0,
+                    .bitrate = 256,
+            }));
+    EXPECT_CALL(*dao,
+            importTrack(ITunesTrack{
+                    .id = 85,
+                    .artist = "The Rolling Stones",
+                    .title = "Beast of Burden (Live)",
+                    .album = "Sweet Summer Sun, Live in Hyde Park 2013 (Live) "
+                             "- Single",
+                    .albumArtist = "The Rolling Stones",
+                    .genre = "Rock",
+                    .grouping = "",
+                    .year = 2013,
+                    .duration = 306,
+                    .location =
+                            "/localhost/Z:/Media.localized/Music/The Rolling "
+                            "Stones/Sweet Summer Sun, Live in Hyde Park 2013 "
+                            "(Live) - Single/01 Beast of Burden (Live).m4a",
+                    .rating = 0,
+                    .comment = "",
+                    .trackNumber = 1,
+                    .bpm = 0,
+                    .bitrate = 256,
+            }));
+    EXPECT_CALL(*dao,
+            importTrack(ITunesTrack{
+                    .id = 87,
+                    .artist = "Mungo Jerry",
+                    .title = "In the Summertime",
+                    .album = "In the Summertime",
+                    .albumArtist = "Mungo Jerry",
+                    .genre = "Rock",
+                    .grouping = "",
+                    .year = 1970,
+                    .duration = 214,
+                    .location =
+                            "/localhost/Z:/Media.localized/Music/Compilations/"
+                            "In the Summertime/01 In the Summertime.m4a",
+                    .rating = 0,
+                    .comment = "",
+                    .trackNumber = 1,
+                    .bpm = 0,
+                    .bitrate = 256,
+            }));
 
     int root = kRootITunesPlaylistId;
     EXPECT_CALL(*dao, importPlaylistRelation(root, 98));  // Downloaded (built-in playlist)

--- a/src/test/itunesxmlimportertest.cpp
+++ b/src/test/itunesxmlimportertest.cpp
@@ -1,0 +1,59 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <QDir>
+#include <QString>
+#include <atomic>
+#include <memory>
+
+#include "library/itunes/itunesdao.h"
+#include "library/itunes/itunesimporter.h"
+#include "library/itunes/itunesxmlimporter.h"
+#include "test/mixxxtest.h"
+
+class ITunesXMLImporterTest : public MixxxTest {
+  protected:
+    QDir getITunesTestDir() {
+        return MixxxTest::getOrInitTestDir().filePath("itunes/");
+    }
+
+    std::unique_ptr<ITunesXMLImporter> makeImporter(
+            const QString& xmlFileName, std::unique_ptr<ITunesDAO> dao) {
+        QString xmlFilePath = getITunesTestDir().absoluteFilePath(xmlFileName);
+        auto importer = std::make_unique<ITunesXMLImporter>(
+                nullptr, xmlFilePath, cancelImport, std::move(dao));
+        return importer;
+    }
+
+  private:
+    std::atomic<bool> cancelImport;
+};
+
+class MockITunesDAO : public ITunesDAO {
+  public:
+    MOCK_METHOD(bool, importTrack, (const ITunesTrack&));
+    MOCK_METHOD(bool, importPlaylist, (const ITunesPlaylist&));
+    MOCK_METHOD(bool, importPlaylistRelation, (int, int));
+    MOCK_METHOD(bool, importPlaylistTrack, (int, int, int));
+    MOCK_METHOD(bool, applyPathMapping, (const ITunesPathMapping&));
+};
+
+using testing::_;
+using testing::Return;
+
+TEST_F(ITunesXMLImporterTest, ParseMacOSMusicXML) {
+    std::unique_ptr<MockITunesDAO> dao = std::make_unique<MockITunesDAO>();
+
+    ON_CALL(*dao, importTrack(_)).WillByDefault(Return(true));
+    ON_CALL(*dao, importPlaylist(_)).WillByDefault(Return(true));
+    ON_CALL(*dao, importPlaylistRelation(_, _)).WillByDefault(Return(true));
+    ON_CALL(*dao, applyPathMapping(_)).WillByDefault(Return(true));
+
+    EXPECT_CALL(*dao, importPlaylistRelation(kRootITunesPlaylistId, 1425)); // Folder A
+    EXPECT_CALL(*dao, importPlaylistRelation(kRootITunesPlaylistId, 1172)); // Downloaded
+    EXPECT_CALL(*dao, importPlaylistRelation(kRootITunesPlaylistId, 1449)); // Playlist D
+
+    std::unique_ptr<ITunesXMLImporter> importer =
+            makeImporter("macOS Music Library.xml", std::move(dao));
+    importer->importLibrary();
+}

--- a/src/test/itunesxmlimportertest.cpp
+++ b/src/test/itunesxmlimportertest.cpp
@@ -417,5 +417,21 @@ TEST_F(ITunesXMLImporterTest, ParseITunesMusicXML) {
 
     std::unique_ptr<ITunesXMLImporter> importer =
             makeImporter("iTunes Music Library.xml", std::move(dao));
-    importer->importLibrary();
+    ITunesImport import = importer->importLibrary();
+
+    TreeItem* rootItem = import.playlistRoot.get();
+    EXPECT_EQ(rootItem->children().size(), 3);
+    EXPECT_EQ(rootItem->child(0)->getLabel().toStdString(), "Folder A");
+    EXPECT_EQ(rootItem->child(1)->getLabel().toStdString(), "Downloaded");
+    EXPECT_EQ(rootItem->child(2)->getLabel().toStdString(), "Playlist D");
+
+    TreeItem* folderA = rootItem->child(0);
+    EXPECT_EQ(folderA->children().size(), 2);
+    EXPECT_EQ(folderA->child(0)->getLabel().toStdString(), "Folder B");
+    EXPECT_EQ(folderA->child(1)->getLabel().toStdString(), "Playlist C");
+
+    TreeItem* folderB = folderA->child(0);
+    EXPECT_EQ(folderB->children().size(), 2);
+    EXPECT_EQ(folderB->child(0)->getLabel().toStdString(), "Playlist A");
+    EXPECT_EQ(folderB->child(1)->getLabel().toStdString(), "Playlist B");
 }

--- a/src/test/itunesxmlimportertest.cpp
+++ b/src/test/itunesxmlimportertest.cpp
@@ -49,9 +49,15 @@ TEST_F(ITunesXMLImporterTest, ParseMacOSMusicXML) {
     ON_CALL(*dao, importPlaylistRelation(_, _)).WillByDefault(Return(true));
     ON_CALL(*dao, applyPathMapping(_)).WillByDefault(Return(true));
 
-    EXPECT_CALL(*dao, importPlaylistRelation(kRootITunesPlaylistId, 1425)); // Folder A
-    EXPECT_CALL(*dao, importPlaylistRelation(kRootITunesPlaylistId, 1172)); // Downloaded
-    EXPECT_CALL(*dao, importPlaylistRelation(kRootITunesPlaylistId, 1449)); // Playlist D
+    int root = kRootITunesPlaylistId;
+    EXPECT_CALL(*dao, importPlaylistRelation(root, 1172)); // Downloaded (built-in playlist)
+    EXPECT_CALL(*dao, importPlaylistRelation(root, 1425)); // Folder A
+    EXPECT_CALL(*dao, importPlaylistRelation(1425, 1498)); // - Folder B
+    EXPECT_CALL(*dao, importPlaylistRelation(1498, 1431)); //   - Playlist A
+    EXPECT_CALL(*dao, importPlaylistRelation(1498, 1436)); //   - Playlist B
+    EXPECT_CALL(*dao, importPlaylistRelation(1425, 1494)); // - Playlist C
+    EXPECT_CALL(*dao, importPlaylistRelation(root, 1440)); // Downloaded (smart playlist)
+    EXPECT_CALL(*dao, importPlaylistRelation(root, 1449)); // Playlist D
 
     std::unique_ptr<ITunesXMLImporter> importer =
             makeImporter("macOS Music Library.xml", std::move(dao));

--- a/src/test/itunesxmlimportertest.cpp
+++ b/src/test/itunesxmlimportertest.cpp
@@ -199,7 +199,7 @@ TEST_F(ITunesXMLImporterTest, ParseITunesMusicXML) {
 #ifdef _WIN32
             "";
 #else
-            "/localhost/";
+            "/";
 #endif
     musicRoot += "Z:/Media.localized/Music";
     EXPECT_CALL(*dao,

--- a/src/test/itunesxmlimportertest.cpp
+++ b/src/test/itunesxmlimportertest.cpp
@@ -58,6 +58,125 @@ std::unique_ptr<MockITunesDAO> makeMockDAO() {
 TEST_F(ITunesXMLImporterTest, ParseMacOSMusicXML) {
     std::unique_ptr<MockITunesDAO> dao = makeMockDAO();
 
+    QString musicRoot = getITunesTestDir().absoluteFilePath(
+            "macOS Music Library/Media.localized/Music");
+    EXPECT_CALL(*dao,
+            importTrack(ITunesTrack{
+                    .id = 479,
+                    .artist = "AC/DC",
+                    .title = "Highway to Hell",
+                    .album = "Highway to Hell",
+                    .albumArtist = "AC/DC",
+                    .genre = "Hard Rock",
+                    .grouping = "",
+                    .year = 1979,
+                    .duration = 208,
+                    .location = musicRoot +
+                            "/AC_DC/Highway to Hell/01 Highway to Hell.m4a",
+                    .rating = 0,
+                    .comment = "",
+                    .trackNumber = 1,
+                    .bpm = 0,
+                    .bitrate = 256,
+            }));
+    EXPECT_CALL(*dao, importTrack(ITunesTrack{
+                              .id = 482,
+                              .artist = "AC/DC",
+                              .title = "Play Ball",
+                              .album = "Rock or Bust",
+                              .albumArtist = "AC/DC",
+                              .genre = "Rock",
+                              .grouping = "",
+                              .year = 2014,
+                              .duration = 167,
+                              .location = musicRoot + "/AC_DC/Rock or Bust/02 Play Ball.m4a",
+                              .rating = 0,
+                              .comment = "",
+                              .trackNumber = 2,
+                              .bpm = 0,
+                              .bitrate = 256,
+                      }));
+    EXPECT_CALL(*dao,
+            importTrack(ITunesTrack{
+                    .id = 476,
+                    .artist = "Jet",
+                    .title = "Are You Gonna Be My Girl",
+                    .album = "Are You Gonna Be My Girl - Single",
+                    .albumArtist = "Jet",
+                    .genre = "Rock",
+                    .grouping = "",
+                    .year = 2003,
+                    .duration = 213,
+                    .location = musicRoot +
+                            "/Jet/Are You Gonna Be My Girl - Single/01 Are You "
+                            "Gonna Be My Girl.m4a",
+                    .rating = 0,
+                    .comment = "",
+                    .trackNumber = 1,
+                    .bpm = 0,
+                    .bitrate = 256,
+            }));
+    EXPECT_CALL(*dao,
+            importTrack(ITunesTrack{
+                    .id = 473,
+                    .artist = "Ray Charles",
+                    .title = "What I'd Say",
+                    .album = "What I'd Say",
+                    .albumArtist = "Ray Charles",
+                    .genre = "Rock",
+                    .grouping = "",
+                    .year = 2012,
+                    .duration = 304,
+                    .location = musicRoot + "/Ray Charles/What I'd Say/01 What I'd Say.m4a",
+                    .rating = 0,
+                    .comment = "",
+                    .trackNumber = 1,
+                    .bpm = 0,
+                    .bitrate = 256,
+            }));
+    EXPECT_CALL(*dao,
+            importTrack(ITunesTrack{
+                    .id = 470,
+                    .artist = "The Rolling Stones",
+                    .title = "Beast of Burden (Live)",
+                    .album = "Sweet Summer Sun, Live in Hyde Park 2013 (Live) "
+                             "- Single",
+                    .albumArtist = "The Rolling Stones",
+                    .genre = "Rock",
+                    .grouping = "",
+                    .year = 2013,
+                    .duration = 306,
+                    .location = musicRoot +
+                            "/The Rolling Stones/Sweet Summer Sun, Live in "
+                            "Hyde Park 2013 (Live) - Single/01 Beast of Burden "
+                            "(Live).m4a",
+                    .rating = 0,
+                    .comment = "",
+                    .trackNumber = 1,
+                    .bpm = 0,
+                    .bitrate = 256,
+            }));
+    EXPECT_CALL(*dao,
+            importTrack(ITunesTrack{
+                    .id = 467,
+                    .artist = "Mungo Jerry",
+                    .title = "In the Summertime",
+                    .album = "In the Summertime",
+                    .albumArtist = "Mungo Jerry",
+                    .genre = "Rock",
+                    .grouping = "",
+                    .year = 1970,
+                    .duration = 214,
+                    .location = musicRoot +
+                            "/Compilations/In the Summertime/01 In the "
+                            "Summertime.m4a",
+                    .rating = 0,
+                    .comment = "",
+                    .trackNumber = 1,
+                    .bpm = 0,
+                    .bitrate = 256,
+            }));
+
     int root = kRootITunesPlaylistId;
     EXPECT_CALL(*dao, importPlaylistRelation(root, 1172)); // Downloaded (built-in playlist)
     EXPECT_CALL(*dao, importPlaylistRelation(root, 1425)); // Folder A
@@ -76,7 +195,7 @@ TEST_F(ITunesXMLImporterTest, ParseMacOSMusicXML) {
 TEST_F(ITunesXMLImporterTest, ParseITunesMusicXML) {
     std::unique_ptr<MockITunesDAO> dao = makeMockDAO();
 
-    QString mediaRoot = "/localhost/Z:/Media.localized/Music";
+    QString musicRoot = "/localhost/Z:/Media.localized/Music";
     EXPECT_CALL(*dao,
             importTrack(ITunesTrack{
                     .id = 77,
@@ -88,7 +207,7 @@ TEST_F(ITunesXMLImporterTest, ParseITunesMusicXML) {
                     .grouping = "",
                     .year = 1979,
                     .duration = 208,
-                    .location = mediaRoot +
+                    .location = musicRoot +
                             "/AC_DC/Highway to Hell/01 Highway to Hell.m4a",
                     .rating = 0,
                     .comment = "",
@@ -106,7 +225,7 @@ TEST_F(ITunesXMLImporterTest, ParseITunesMusicXML) {
                               .grouping = "",
                               .year = 2014,
                               .duration = 167,
-                              .location = mediaRoot + "/AC_DC/Rock or Bust/02 Play Ball.m4a",
+                              .location = musicRoot + "/AC_DC/Rock or Bust/02 Play Ball.m4a",
                               .rating = 0,
                               .comment = "",
                               .trackNumber = 2,
@@ -124,9 +243,8 @@ TEST_F(ITunesXMLImporterTest, ParseITunesMusicXML) {
                     .grouping = "",
                     .year = 2003,
                     .duration = 213,
-                    .location = "/localhost/Z:/Media.localized/Music/Jet/Are "
-                                "You Gonna Be My Girl - Single/01 Are You "
-                                "Gonna Be My Girl.m4a",
+                    .location = musicRoot + "/Jet/Are You Gonna Be My Girl - Single/01 Are You "
+                                            "Gonna Be My Girl.m4a",
                     .rating = 0,
                     .comment = "",
                     .trackNumber = 1,
@@ -144,8 +262,7 @@ TEST_F(ITunesXMLImporterTest, ParseITunesMusicXML) {
                     .grouping = "",
                     .year = 2012,
                     .duration = 304,
-                    .location = "/localhost/Z:/Media.localized/Music/Ray "
-                                "Charles/What I'd Say/01 What I'd Say.m4a",
+                    .location = musicRoot + "/Ray Charles/What I'd Say/01 What I'd Say.m4a",
                     .rating = 0,
                     .comment = "",
                     .trackNumber = 1,
@@ -165,9 +282,9 @@ TEST_F(ITunesXMLImporterTest, ParseITunesMusicXML) {
                     .year = 2013,
                     .duration = 306,
                     .location =
-                            "/localhost/Z:/Media.localized/Music/The Rolling "
-                            "Stones/Sweet Summer Sun, Live in Hyde Park 2013 "
-                            "(Live) - Single/01 Beast of Burden (Live).m4a",
+                            musicRoot + "/The Rolling "
+                                        "Stones/Sweet Summer Sun, Live in Hyde Park 2013 "
+                                        "(Live) - Single/01 Beast of Burden (Live).m4a",
                     .rating = 0,
                     .comment = "",
                     .trackNumber = 1,
@@ -186,8 +303,8 @@ TEST_F(ITunesXMLImporterTest, ParseITunesMusicXML) {
                     .year = 1970,
                     .duration = 214,
                     .location =
-                            "/localhost/Z:/Media.localized/Music/Compilations/"
-                            "In the Summertime/01 In the Summertime.m4a",
+                            musicRoot + "/Compilations/"
+                                        "In the Summertime/01 In the Summertime.m4a",
                     .rating = 0,
                     .comment = "",
                     .trackNumber = 1,

--- a/src/test/itunesxmlimportertest.cpp
+++ b/src/test/itunesxmlimportertest.cpp
@@ -193,10 +193,6 @@ TEST_F(ITunesXMLImporterTest, ParseMacOSMusicXML) {
             }));
 
     EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
-                              .id = 1172,
-                              .name = "Downloaded",
-                      }));
-    EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
                               .id = 1425,
                               .name = "Folder A",
                       }));
@@ -213,6 +209,10 @@ TEST_F(ITunesXMLImporterTest, ParseMacOSMusicXML) {
                               .name = "Playlist B",
                       }));
     EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
+                              .id = 1494,
+                              .name = "Playlist C",
+                      }));
+    EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
                               .id = 1440,
                               .name = "Downloaded",
                       }));
@@ -221,15 +221,7 @@ TEST_F(ITunesXMLImporterTest, ParseMacOSMusicXML) {
                               .name = "Playlist D",
                       }));
 
-    // The XML importer currently does not import empty playlists.
-    EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
-                              .id = 1494,
-                              .name = "Playlist C",
-                      }))
-            .Times(0);
-
     int root = kRootITunesPlaylistId;
-    EXPECT_CALL(*dao, importPlaylistRelation(root, 1172)); // Downloaded (built-in playlist)
     EXPECT_CALL(*dao, importPlaylistRelation(root, 1425)); // Folder A
     EXPECT_CALL(*dao, importPlaylistRelation(1425, 1498)); // - Folder B
     EXPECT_CALL(*dao, importPlaylistRelation(1498, 1431)); //   - Playlist A
@@ -243,17 +235,15 @@ TEST_F(ITunesXMLImporterTest, ParseMacOSMusicXML) {
     ITunesImport import = importer->importLibrary();
 
     TreeItem* rootItem = import.playlistRoot.get();
-    EXPECT_EQ(rootItem->children().size(), 4);
-    EXPECT_EQ(rootItem->child(0)->getLabel().toStdString(), "Downloaded");
-    EXPECT_EQ(rootItem->child(1)->getLabel().toStdString(), "Folder A");
-    EXPECT_EQ(rootItem->child(2)->getLabel().toStdString(), "Downloaded #2");
-    EXPECT_EQ(rootItem->child(3)->getLabel().toStdString(), "Playlist D");
+    EXPECT_EQ(rootItem->children().size(), 3);
+    EXPECT_EQ(rootItem->child(0)->getLabel().toStdString(), "Folder A");
+    EXPECT_EQ(rootItem->child(1)->getLabel().toStdString(), "Downloaded");
+    EXPECT_EQ(rootItem->child(2)->getLabel().toStdString(), "Playlist D");
 
-    TreeItem* folderA = rootItem->child(1);
+    TreeItem* folderA = rootItem->child(0);
     EXPECT_EQ(folderA->children().size(), 2);
     EXPECT_EQ(folderA->child(0)->getLabel().toStdString(), "Folder B");
-    // TODO: Fix empty playlist
-    // EXPECT_EQ(folderA->child(1)->getLabel().toStdString(), "Playlist C");
+    EXPECT_EQ(folderA->child(1)->getLabel().toStdString(), "Playlist C");
 
     TreeItem* folderB = folderA->child(0);
     EXPECT_EQ(folderB->children().size(), 2);
@@ -388,10 +378,6 @@ TEST_F(ITunesXMLImporterTest, ParseITunesMusicXML) {
             }));
 
     EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
-                              .id = 98,
-                              .name = "Downloaded",
-                      }));
-    EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
                               .id = 153,
                               .name = "Folder A",
                       }));
@@ -408,6 +394,10 @@ TEST_F(ITunesXMLImporterTest, ParseITunesMusicXML) {
                               .name = "Playlist B",
                       }));
     EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
+                              .id = 174,
+                              .name = "Playlist C",
+                      }));
+    EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
                               .id = 177,
                               .name = "Downloaded",
                       }));
@@ -416,20 +406,7 @@ TEST_F(ITunesXMLImporterTest, ParseITunesMusicXML) {
                               .name = "Playlist D",
                       }));
 
-    // The XML importer currently does not import empty playlists.
-    EXPECT_CALL(*dao, importPlaylist(ITunesPlaylist{
-                              .id = 174,
-                              .name = "Playlist C",
-                      }))
-            .Times(0);
-
     int root = kRootITunesPlaylistId;
-    EXPECT_CALL(*dao, importPlaylistRelation(root, 98));  // Downloaded (built-in playlist)
-    EXPECT_CALL(*dao, importPlaylistRelation(root, 125)); // Downloaded (built-in playlist)
-    EXPECT_CALL(*dao, importPlaylistRelation(root, 134)); // Downloaded (built-in playlist)
-    EXPECT_CALL(*dao, importPlaylistRelation(root, 140)); // Podcasts (built-in playlist)
-    EXPECT_CALL(*dao, importPlaylistRelation(root, 147)); // Audiobooks (built-in playlist)
-    EXPECT_CALL(*dao, importPlaylistRelation(root, 150)); // Genius (built-in playlist)
     EXPECT_CALL(*dao, importPlaylistRelation(root, 153)); // Folder A
     EXPECT_CALL(*dao, importPlaylistRelation(153, 159));  // - Folder B
     EXPECT_CALL(*dao, importPlaylistRelation(159, 165));  //   - Playlist A

--- a/src/test/itunesxmlimportertest.cpp
+++ b/src/test/itunesxmlimportertest.cpp
@@ -195,7 +195,13 @@ TEST_F(ITunesXMLImporterTest, ParseMacOSMusicXML) {
 TEST_F(ITunesXMLImporterTest, ParseITunesMusicXML) {
     std::unique_ptr<MockITunesDAO> dao = makeMockDAO();
 
-    QString musicRoot = "/localhost/Z:/Media.localized/Music";
+    QString musicRoot =
+#ifdef _WIN32
+            "";
+#else
+            "/localhost/";
+#endif
+    musicRoot += "Z:/Media.localized/Music";
     EXPECT_CALL(*dao,
             importTrack(ITunesTrack{
                     .id = 77,

--- a/src/test/itunesxmlimportertest.cpp
+++ b/src/test/itunesxmlimportertest.cpp
@@ -41,13 +41,21 @@ class MockITunesDAO : public ITunesDAO {
 using testing::_;
 using testing::Return;
 
-TEST_F(ITunesXMLImporterTest, ParseMacOSMusicXML) {
+namespace {
+std::unique_ptr<MockITunesDAO> makeMockDAO() {
     std::unique_ptr<MockITunesDAO> dao = std::make_unique<MockITunesDAO>();
 
     ON_CALL(*dao, importTrack(_)).WillByDefault(Return(true));
     ON_CALL(*dao, importPlaylist(_)).WillByDefault(Return(true));
     ON_CALL(*dao, importPlaylistRelation(_, _)).WillByDefault(Return(true));
     ON_CALL(*dao, applyPathMapping(_)).WillByDefault(Return(true));
+
+    return dao;
+}
+} // anonymous namespace
+
+TEST_F(ITunesXMLImporterTest, ParseMacOSMusicXML) {
+    std::unique_ptr<MockITunesDAO> dao = makeMockDAO();
 
     int root = kRootITunesPlaylistId;
     EXPECT_CALL(*dao, importPlaylistRelation(root, 1172)); // Downloaded (built-in playlist)
@@ -61,5 +69,28 @@ TEST_F(ITunesXMLImporterTest, ParseMacOSMusicXML) {
 
     std::unique_ptr<ITunesXMLImporter> importer =
             makeImporter("macOS Music Library.xml", std::move(dao));
+    importer->importLibrary();
+}
+
+TEST_F(ITunesXMLImporterTest, ParseITunesMusicXML) {
+    std::unique_ptr<MockITunesDAO> dao = makeMockDAO();
+
+    int root = kRootITunesPlaylistId;
+    EXPECT_CALL(*dao, importPlaylistRelation(root, 98));  // Downloaded (built-in playlist)
+    EXPECT_CALL(*dao, importPlaylistRelation(root, 125)); // Downloaded (built-in playlist)
+    EXPECT_CALL(*dao, importPlaylistRelation(root, 134)); // Downloaded (built-in playlist)
+    EXPECT_CALL(*dao, importPlaylistRelation(root, 140)); // Podcasts (built-in playlist)
+    EXPECT_CALL(*dao, importPlaylistRelation(root, 147)); // Audiobooks (built-in playlist)
+    EXPECT_CALL(*dao, importPlaylistRelation(root, 150)); // Genius (built-in playlist)
+    EXPECT_CALL(*dao, importPlaylistRelation(root, 153)); // Folder A
+    EXPECT_CALL(*dao, importPlaylistRelation(153, 159));  // - Folder B
+    EXPECT_CALL(*dao, importPlaylistRelation(159, 165));  //   - Playlist A
+    EXPECT_CALL(*dao, importPlaylistRelation(159, 170));  //   - Playlist B
+    EXPECT_CALL(*dao, importPlaylistRelation(153, 174));  // - Playlist C
+    EXPECT_CALL(*dao, importPlaylistRelation(root, 177)); // Downloaded (smart playlist)
+    EXPECT_CALL(*dao, importPlaylistRelation(root, 186)); // Playlist D
+
+    std::unique_ptr<ITunesXMLImporter> importer =
+            makeImporter("iTunes Music Library.xml", std::move(dao));
     importer->importLibrary();
 }


### PR DESCRIPTION
This branch adds a unit test verifying that the XML importer performs correctly on real music library XMLs generated with

- Apple Music 1.3.5.3 on macOS 13.4
- iTunes 12.12.8.2 on Windows 11

To do:

- [x] Test imported tracks
- [x] Test imported playlist relations
- [x] Test imported playlists
- [x] Test generated `TreeItem`