### PR TITLE
glwaveformrenderbackground

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -949,6 +949,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/waveform/guitick.cpp
   src/waveform/renderers/glslwaveformrenderersignal.cpp
   src/waveform/renderers/glvsynctestrenderer.cpp
+  src/waveform/renderers/glwaveformrenderbackground.cpp
   src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
   src/waveform/renderers/glwaveformrendererrgb.cpp
   src/waveform/renderers/glwaveformrenderersimplesignal.cpp

--- a/src/waveform/renderers/glwaveformrenderbackground.cpp
+++ b/src/waveform/renderers/glwaveformrenderbackground.cpp
@@ -5,9 +5,6 @@ GLWaveformRenderBackground::GLWaveformRenderBackground(
         : WaveformRenderBackground(waveformWidgetRenderer) {
 }
 
-GLWaveformRenderBackground::~GLWaveformRenderBackground() {
-}
-
 #if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
 void GLWaveformRenderBackground::draw(QPainter* painter, QPaintEvent* /*event*/) {
     maybeInitializeGL();

--- a/src/waveform/renderers/glwaveformrenderbackground.cpp
+++ b/src/waveform/renderers/glwaveformrenderbackground.cpp
@@ -20,6 +20,8 @@ void GLWaveformRenderBackground::draw(QPainter* painter, QPaintEvent* /*event*/)
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     painter->endNativePainting();
 
-    drawImage(painter);
+    if (hasImage()) {
+        drawImage(painter);
+    }
 }
 #endif

--- a/src/waveform/renderers/glwaveformrenderbackground.cpp
+++ b/src/waveform/renderers/glwaveformrenderbackground.cpp
@@ -1,0 +1,25 @@
+#include "waveform/renderers/glwaveformrenderbackground.h"
+
+GLWaveformRenderBackground::GLWaveformRenderBackground(
+        WaveformWidgetRenderer* waveformWidgetRenderer)
+        : WaveformRenderBackground(waveformWidgetRenderer) {
+}
+
+GLWaveformRenderBackground::~GLWaveformRenderBackground() {
+}
+
+#if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
+void GLWaveformRenderBackground::draw(QPainter* painter, QPaintEvent* /*event*/) {
+    maybeInitializeGL();
+
+    painter->beginNativePainting();
+    glClearColor(static_cast<float>(m_backgroundColor.redF()),
+            static_cast<float>(m_backgroundColor.greenF()),
+            static_cast<float>(m_backgroundColor.blueF()),
+            1.f);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    painter->endNativePainting();
+
+    drawImage(painter);
+}
+#endif

--- a/src/waveform/renderers/glwaveformrenderbackground.h
+++ b/src/waveform/renderers/glwaveformrenderbackground.h
@@ -14,7 +14,6 @@ class GLWaveformRenderBackground : public WaveformRenderBackground
   public:
     explicit GLWaveformRenderBackground(
             WaveformWidgetRenderer* waveformWidgetRenderer);
-    virtual ~GLWaveformRenderBackground();
 
 #if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
     virtual void draw(QPainter* painter, QPaintEvent* event);

--- a/src/waveform/renderers/glwaveformrenderbackground.h
+++ b/src/waveform/renderers/glwaveformrenderbackground.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "waveform/renderers/waveformrenderbackground.h"
+#if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
+#include "waveform/renderers/glwaveformrenderer.h"
+#endif
+
+class GLWaveformRenderBackground : public WaveformRenderBackground
+#if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
+        ,
+                                   public GLWaveformRenderer
+#endif
+{
+  public:
+    explicit GLWaveformRenderBackground(
+            WaveformWidgetRenderer* waveformWidgetRenderer);
+    virtual ~GLWaveformRenderBackground();
+
+#if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
+    virtual void draw(QPainter* painter, QPaintEvent* event);
+#endif
+
+  private:
+    DISALLOW_COPY_AND_ASSIGN(GLWaveformRenderBackground);
+};

--- a/src/waveform/renderers/waveformrenderbackground.cpp
+++ b/src/waveform/renderers/waveformrenderbackground.cpp
@@ -24,8 +24,7 @@ void WaveformRenderBackground::setup(const QDomNode& node,
     setDirty(true);
 }
 
-void WaveformRenderBackground::draw(QPainter* painter,
-                                    QPaintEvent* /*event*/) {
+bool WaveformRenderBackground::drawImage(QPainter* painter) {
     if (isDirty()) {
         generateImage();
     }
@@ -33,9 +32,7 @@ void WaveformRenderBackground::draw(QPainter* painter,
     // If there is no background image, just fill the painter with the
     // background color.
     if (m_backgroundImage.isNull()) {
-        painter->fillRect(0, 0, m_waveformRenderer->getWidth(),
-                          m_waveformRenderer->getHeight(), m_backgroundColor);
-        return;
+        return false;
     }
 
     // since we use opaque widget we need to draw the background !
@@ -44,6 +41,19 @@ void WaveformRenderBackground::draw(QPainter* painter,
     // This produces a white back ground with Linux QT 4.6 QGlWidget and
     // Intel i915 driver and has peroformance issues on other setups. See lp:981210
     //painter->drawPixmap(QPoint(0, 0), m_backgroundPixmap);
+
+    return true;
+}
+
+void WaveformRenderBackground::draw(QPainter* painter,
+        QPaintEvent* /*event*/) {
+    if (!drawImage(painter)) {
+        painter->fillRect(0,
+                0,
+                m_waveformRenderer->getWidth(),
+                m_waveformRenderer->getHeight(),
+                m_backgroundColor);
+    }
 }
 
 void WaveformRenderBackground::generateImage() {

--- a/src/waveform/renderers/waveformrenderbackground.cpp
+++ b/src/waveform/renderers/waveformrenderbackground.cpp
@@ -24,36 +24,36 @@ void WaveformRenderBackground::setup(const QDomNode& node,
     setDirty(true);
 }
 
-bool WaveformRenderBackground::drawImage(QPainter* painter) {
+bool WaveformRenderBackground::hasImage() {
     if (isDirty()) {
         generateImage();
     }
 
-    // If there is no background image, just fill the painter with the
-    // background color.
-    if (m_backgroundImage.isNull()) {
-        return false;
-    }
+    return !m_backgroundImage.isNull();
+}
 
+void WaveformRenderBackground::drawImage(QPainter* painter) {
     // since we use opaque widget we need to draw the background !
     painter->drawImage(QPoint(0, 0), m_backgroundImage);
 
     // This produces a white back ground with Linux QT 4.6 QGlWidget and
     // Intel i915 driver and has peroformance issues on other setups. See lp:981210
     //painter->drawPixmap(QPoint(0, 0), m_backgroundPixmap);
-
-    return true;
 }
 
 void WaveformRenderBackground::draw(QPainter* painter,
         QPaintEvent* /*event*/) {
-    if (!drawImage(painter)) {
-        painter->fillRect(0,
-                0,
-                m_waveformRenderer->getWidth(),
-                m_waveformRenderer->getHeight(),
-                m_backgroundColor);
+    if (hasImage()) {
+        drawImage(painter);
+        return;
     }
+    // If there is no background image, just fill the painter with the
+    // background color.
+    painter->fillRect(0,
+            0,
+            m_waveformRenderer->getWidth(),
+            m_waveformRenderer->getHeight(),
+            m_backgroundColor);
 }
 
 void WaveformRenderBackground::generateImage() {

--- a/src/waveform/renderers/waveformrenderbackground.h
+++ b/src/waveform/renderers/waveformrenderbackground.h
@@ -19,11 +19,15 @@ class WaveformRenderBackground : public WaveformRendererAbstract {
     virtual void setup(const QDomNode& node, const SkinContext& context);
     virtual void draw(QPainter* painter, QPaintEvent* event);
 
+  protected:
+    bool drawImage(QPainter* painter);
+
+    QColor m_backgroundColor;
+
   private:
     void generateImage();
 
     QString m_backgroundPixmapPath;
-    QColor m_backgroundColor;
     QImage m_backgroundImage;
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRenderBackground);

--- a/src/waveform/renderers/waveformrenderbackground.h
+++ b/src/waveform/renderers/waveformrenderbackground.h
@@ -20,7 +20,8 @@ class WaveformRenderBackground : public WaveformRendererAbstract {
     virtual void draw(QPainter* painter, QPaintEvent* event);
 
   protected:
-    bool drawImage(QPainter* painter);
+    bool hasImage();
+    void drawImage(QPainter* painter);
 
     QColor m_backgroundColor;
 

--- a/src/waveform/widgets/glrgbwaveformwidget.cpp
+++ b/src/waveform/widgets/glrgbwaveformwidget.cpp
@@ -2,8 +2,8 @@
 
 #include "moc_glrgbwaveformwidget.cpp"
 #include "util/performancetimer.h"
+#include "waveform/renderers/glwaveformrenderbackground.h"
 #include "waveform/renderers/glwaveformrendererrgb.h"
-#include "waveform/renderers/waveformrenderbackground.h"
 #include "waveform/renderers/waveformrenderbeat.h"
 #include "waveform/renderers/waveformrendererendoftrack.h"
 #include "waveform/renderers/waveformrendererpreroll.h"
@@ -18,7 +18,7 @@ GLRGBWaveformWidget::GLRGBWaveformWidget(const QString& group, QWidget* parent)
              << "Valid:" << context()->isValid()
              << "Sharing:" << context()->isSharing();
 
-    addRenderer<WaveformRenderBackground>();
+    addRenderer<GLWaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
     addRenderer<WaveformRendererPreroll>();
     addRenderer<WaveformRenderMarkRange>();

--- a/src/waveform/widgets/glsimplewaveformwidget.cpp
+++ b/src/waveform/widgets/glsimplewaveformwidget.cpp
@@ -5,8 +5,8 @@
 
 #include "moc_glsimplewaveformwidget.cpp"
 #include "util/performancetimer.h"
+#include "waveform/renderers/glwaveformrenderbackground.h"
 #include "waveform/renderers/glwaveformrenderersimplesignal.h"
-#include "waveform/renderers/waveformrenderbackground.h"
 #include "waveform/renderers/waveformrenderbeat.h"
 #include "waveform/renderers/waveformrendererendoftrack.h"
 #include "waveform/renderers/waveformrendererpreroll.h"
@@ -21,7 +21,7 @@ GLSimpleWaveformWidget::GLSimpleWaveformWidget(const QString& group, QWidget* pa
              << "Valid:" << context()->isValid()
              << "Sharing:" << context()->isSharing();
 
-    addRenderer<WaveformRenderBackground>();
+    addRenderer<GLWaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
     addRenderer<WaveformRendererPreroll>();
     addRenderer<WaveformRenderMarkRange>();

--- a/src/waveform/widgets/glslwaveformwidget.cpp
+++ b/src/waveform/widgets/glslwaveformwidget.cpp
@@ -6,7 +6,7 @@
 #include "moc_glslwaveformwidget.cpp"
 #include "util/performancetimer.h"
 #include "waveform/renderers/glslwaveformrenderersignal.h"
-#include "waveform/renderers/waveformrenderbackground.h"
+#include "waveform/renderers/glwaveformrenderbackground.h"
 #include "waveform/renderers/waveformrenderbeat.h"
 #include "waveform/renderers/waveformrendererendoftrack.h"
 #include "waveform/renderers/waveformrendererpreroll.h"
@@ -39,7 +39,7 @@ GLSLWaveformWidget::GLSLWaveformWidget(
         makeCurrent();
     }
 
-    addRenderer<WaveformRenderBackground>();
+    addRenderer<GLWaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
     addRenderer<WaveformRendererPreroll>();
     addRenderer<WaveformRenderMarkRange>();

--- a/src/waveform/widgets/glvsynctestwidget.cpp
+++ b/src/waveform/widgets/glvsynctestwidget.cpp
@@ -6,8 +6,8 @@
 #include "moc_glvsynctestwidget.cpp"
 #include "util/performancetimer.h"
 #include "waveform/renderers/glvsynctestrenderer.h"
+#include "waveform/renderers/glwaveformrenderbackground.h"
 #include "waveform/renderers/glwaveformrenderersimplesignal.h"
-#include "waveform/renderers/waveformrenderbackground.h"
 #include "waveform/renderers/waveformrenderbeat.h"
 #include "waveform/renderers/waveformrendererendoftrack.h"
 #include "waveform/renderers/waveformrendererpreroll.h"
@@ -21,10 +21,10 @@ GLVSyncTestWidget::GLVSyncTestWidget(const QString& group, QWidget* parent)
              << "Valid:" << context()->isValid()
              << "Sharing:" << context()->isSharing();
 
-    addRenderer<WaveformRenderBackground>(); // 172 µs
-//  addRenderer<WaveformRendererEndOfTrack>(); // 677 µs 1145 µs (active)
-//  addRenderer<WaveformRendererPreroll>(); // 652 µs 2034 µs (active)
-//  addRenderer<WaveformRenderMarkRange>(); // 793 µs
+    addRenderer<GLWaveformRenderBackground>(); // 172 µs
+    //  addRenderer<WaveformRendererEndOfTrack>(); // 677 µs 1145 µs (active)
+    //  addRenderer<WaveformRendererPreroll>(); // 652 µs 2034 µs (active)
+    //  addRenderer<WaveformRenderMarkRange>(); // 793 µs
 
 #if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
     addRenderer<GLVSyncTestRenderer>(); // 841 µs // 2271 µs

--- a/src/waveform/widgets/glwaveformwidget.cpp
+++ b/src/waveform/widgets/glwaveformwidget.cpp
@@ -6,9 +6,9 @@
 
 #include "moc_glwaveformwidget.cpp"
 #include "util/performancetimer.h"
+#include "waveform/renderers/glwaveformrenderbackground.h"
 #include "waveform/renderers/glwaveformrendererfilteredsignal.h"
 #include "waveform/renderers/qtwaveformrendererfilteredsignal.h"
-#include "waveform/renderers/waveformrenderbackground.h"
 #include "waveform/renderers/waveformrenderbeat.h"
 #include "waveform/renderers/waveformrendererendoftrack.h"
 #include "waveform/renderers/waveformrendererpreroll.h"
@@ -23,7 +23,7 @@ GLWaveformWidget::GLWaveformWidget(const QString& group, QWidget* parent)
              << "Valid:" << context()->isValid()
              << "Sharing:" << context()->isSharing();
 
-    addRenderer<WaveformRenderBackground>();
+    addRenderer<GLWaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
     addRenderer<WaveformRendererPreroll>();
     addRenderer<WaveformRenderMarkRange>();

--- a/src/waveform/widgets/qthsvwaveformwidget.cpp
+++ b/src/waveform/widgets/qthsvwaveformwidget.cpp
@@ -5,7 +5,7 @@
 #include <QtDebug>
 
 #include "moc_qthsvwaveformwidget.cpp"
-#include "waveform/renderers/waveformrenderbackground.h"
+#include "waveform/renderers/glwaveformrenderbackground.h"
 #include "waveform/renderers/waveformrenderbeat.h"
 #include "waveform/renderers/waveformrendererendoftrack.h"
 #include "waveform/renderers/waveformrendererhsv.h"
@@ -20,7 +20,7 @@ QtHSVWaveformWidget::QtHSVWaveformWidget(const QString& group, QWidget* parent)
     if (QGLContext::currentContext() != context()) {
         makeCurrent();
     }
-    addRenderer<WaveformRenderBackground>();
+    addRenderer<GLWaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
     addRenderer<WaveformRendererPreroll>();
     addRenderer<WaveformRenderMarkRange>();

--- a/src/waveform/widgets/qtrgbwaveformwidget.cpp
+++ b/src/waveform/widgets/qtrgbwaveformwidget.cpp
@@ -5,7 +5,7 @@
 #include <QtDebug>
 
 #include "moc_qtrgbwaveformwidget.cpp"
-#include "waveform/renderers/waveformrenderbackground.h"
+#include "waveform/renderers/glwaveformrenderbackground.h"
 #include "waveform/renderers/waveformrenderbeat.h"
 #include "waveform/renderers/waveformrendererendoftrack.h"
 #include "waveform/renderers/waveformrendererpreroll.h"
@@ -22,7 +22,7 @@ QtRGBWaveformWidget::QtRGBWaveformWidget(const QString& group, QWidget* parent)
              << "Valid:" << context()->isValid()
              << "Sharing:" << context()->isSharing();
 
-    addRenderer<WaveformRenderBackground>();
+    addRenderer<GLWaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
     addRenderer<WaveformRendererPreroll>();
     addRenderer<WaveformRenderMarkRange>();

--- a/src/waveform/widgets/qtsimplewaveformwidget.cpp
+++ b/src/waveform/widgets/qtsimplewaveformwidget.cpp
@@ -5,8 +5,8 @@
 
 #include "moc_qtsimplewaveformwidget.cpp"
 #include "util/performancetimer.h"
+#include "waveform/renderers/glwaveformrenderbackground.h"
 #include "waveform/renderers/qtwaveformrenderersimplesignal.h"
-#include "waveform/renderers/waveformrenderbackground.h"
 #include "waveform/renderers/waveformrenderbeat.h"
 #include "waveform/renderers/waveformrendererendoftrack.h"
 #include "waveform/renderers/waveformrendererpreroll.h"
@@ -24,7 +24,7 @@ QtSimpleWaveformWidget::QtSimpleWaveformWidget(
              << "Valid:" << context()->isValid()
              << "Sharing:" << context()->isSharing();
 
-    addRenderer<WaveformRenderBackground>();
+    addRenderer<GLWaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
     addRenderer<WaveformRendererPreroll>();
     addRenderer<WaveformRenderMarkRange>();

--- a/src/waveform/widgets/qtvsynctestwidget.cpp
+++ b/src/waveform/widgets/qtvsynctestwidget.cpp
@@ -6,8 +6,8 @@
 
 #include "moc_qtvsynctestwidget.cpp"
 #include "util/performancetimer.h"
+#include "waveform/renderers/glwaveformrenderbackground.h"
 #include "waveform/renderers/qtvsynctestrenderer.h"
-#include "waveform/renderers/waveformrenderbackground.h"
 #include "waveform/renderers/waveformrenderbeat.h"
 #include "waveform/renderers/waveformrendererendoftrack.h"
 #include "waveform/renderers/waveformrendererpreroll.h"

--- a/src/waveform/widgets/qtwaveformwidget.cpp
+++ b/src/waveform/widgets/qtwaveformwidget.cpp
@@ -6,8 +6,8 @@
 
 #include "moc_qtwaveformwidget.cpp"
 #include "util/performancetimer.h"
+#include "waveform/renderers/glwaveformrenderbackground.h"
 #include "waveform/renderers/qtwaveformrendererfilteredsignal.h"
-#include "waveform/renderers/waveformrenderbackground.h"
 #include "waveform/renderers/waveformrenderbeat.h"
 #include "waveform/renderers/waveformrendererendoftrack.h"
 #include "waveform/renderers/waveformrendererpreroll.h"
@@ -23,7 +23,7 @@ QtWaveformWidget::QtWaveformWidget(const QString& group, QWidget* parent)
              << "Valid:" << context()->isValid()
              << "Sharing:" << context()->isSharing();
 
-    addRenderer<WaveformRenderBackground>();
+    addRenderer<GLWaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
     addRenderer<WaveformRendererPreroll>();
     addRenderer<WaveformRenderMarkRange>();


### PR DESCRIPTION
glwaveformrenderbackground  is a replacement for waveformrenderbackground, which uses glClear to clear the waveform widget. this is a potential fix for https://github.com/mixxxdj/mixxx/issues/11164
