### PR TITLE
Fix too strict debug assertion

### DIFF
--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -152,7 +152,9 @@ bool decodeFrameHeader(
         logFrameHeader(kLogger.info(), *pMadHeader);
         return false;
     }
-    DEBUG_ASSERT(pMadStream->error == MAD_ERROR_NONE);
+    // Note: Recoverable errors are maintained until a frame has been successfully decoded
+    // Kurt Roeckx's length-check.patch applied on Debian fixes that.
+    DEBUG_ASSERT(!hasUnrecoverableError(pMadStream));
     return true;
 }
 


### PR DESCRIPTION
It seems to be not correct to use the error value after a libmad function succeeds. 
This has slipped through, because the debian package of this library uses a patch that fixes the behavior. 
I was able to reproduce the issue with a unpatched local build of libmad. 