### PR TITLE
WStarRating: don't update track directly, use signals/slots

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -252,6 +252,14 @@ void DlgTrackInfo::init() {
             this,
             &DlgTrackInfo::slotReloadCoverArt);
 
+    connect(m_pWStarRating,
+            &WStarRating::ratingChanged,
+            this,
+            [this](int rating) {
+                m_pWStarRating->slotSetRating(rating);
+                m_trackRecord.setRating(rating);
+            });
+
     btnColorPicker->setStyle(QStyleFactory::create(QStringLiteral("fusion")));
     QMenu* pColorPickerMenu = new QMenu(this);
     pColorPickerMenu->addAction(m_pColorPicker);
@@ -338,7 +346,7 @@ void DlgTrackInfo::updateFromTrack(const Track& track) {
 
     reloadTrackBeats(track);
 
-    m_pWStarRating->slotTrackLoaded(m_pLoadedTrack);
+    m_pWStarRating->slotSetRating(m_pLoadedTrack->getRating());
 }
 
 void DlgTrackInfo::replaceTrackRecord(
@@ -446,7 +454,7 @@ void DlgTrackInfo::loadTrackInternal(const TrackPointer& pTrack) {
     updateFromTrack(*m_pLoadedTrack);
     m_pWCoverArtLabel->loadTrack(m_pLoadedTrack);
 
-    // We already listen to changed() so we don't need to listen to individual
+    // Listen to changed() so we don't need to listen to individual
     // signals such as cuesUpdates, coverArtUpdated(), etc.
     connect(pTrack.get(),
             &Track::changed,
@@ -603,6 +611,8 @@ void DlgTrackInfo::clear() {
     updateSpinBpmFromBeats();
 
     txtLocation->setText("");
+
+    m_pWStarRating->slotSetRating(0);
 }
 
 void DlgTrackInfo::slotBpmScale(mixxx::Beats::BpmScale bpmScale) {

--- a/src/library/starrating.h
+++ b/src/library/starrating.h
@@ -13,7 +13,7 @@ QT_FORWARD_DECLARE_CLASS(QRect);
  * The StarRating class represents a rating as a number of stars.
  * In addition to holding the data, it is also capable of painting the stars on a QPaintDevice,
  * which in this example is either a view or an editor.
- * The myStarCount member variable stores the current rating, and myMaxStarCount stores
+ * The m_starCount member variable stores the current rating, and m_maxStarCount stores
  * the highest possible rating (typically 5).
  */
 class StarRating {

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -429,6 +429,9 @@ void BaseTrackPlayerImpl::connectLoadedTrack() {
             this,
             &BaseTrackPlayerImpl::slotSetTrackColor);
 
+    // Forward the update signal, i.e. use BaseTrackPlayer as relay.
+    // Currently only used by WStarRating which is connected in
+    // LegacySkinParser::parseStarRating
     connect(m_pLoadedTrack.get(),
             &Track::ratingUpdated,
             this,

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -428,6 +428,11 @@ void BaseTrackPlayerImpl::connectLoadedTrack() {
             &Track::colorUpdated,
             this,
             &BaseTrackPlayerImpl::slotSetTrackColor);
+
+    connect(m_pLoadedTrack.get(),
+            &Track::ratingUpdated,
+            this,
+            &BaseTrackPlayerImpl::trackRatingChanged);
 }
 
 void BaseTrackPlayerImpl::disconnectLoadedTrack() {
@@ -516,6 +521,7 @@ void BaseTrackPlayerImpl::slotTrackLoaded(TrackPointer pNewTrack,
         m_pLoopOutPoint->set(kNoTrigger);
         m_pLoadedTrack.reset();
         emit playerEmpty();
+        emit trackRatingChanged(0);
     } else if (pNewTrack && pNewTrack == m_pLoadedTrack) {
         // NOTE(uklotzde): In a previous version track metadata was reloaded
         // from the source file at this point again. This is no longer necessary
@@ -596,6 +602,7 @@ void BaseTrackPlayerImpl::slotTrackLoaded(TrackPointer pNewTrack,
         }
 
         emit newTrackLoaded(m_pLoadedTrack);
+        emit trackRatingChanged(m_pLoadedTrack->getRating());
     } else {
         // this is the result from an outdated load or unload signal
         // A new load is already pending
@@ -735,6 +742,13 @@ void BaseTrackPlayerImpl::slotTrackColorChangeRequest(double v) {
     }
     m_pTrackColor->setAndConfirm(trackColorToDouble(color));
     m_pLoadedTrack->setColor(color);
+}
+
+void BaseTrackPlayerImpl::slotSetTrackRating(int rating) {
+    if (!m_pLoadedTrack) {
+        return;
+    }
+    m_pLoadedTrack->setRating(rating);
 }
 
 void BaseTrackPlayerImpl::slotPlayToggled(double value) {

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -44,6 +44,7 @@ class BaseTrackPlayer : public BasePlayer {
     virtual void slotCloneFromGroup(const QString& group) = 0;
     virtual void slotCloneDeck() = 0;
     virtual void slotEjectTrack(double) = 0;
+    virtual void slotSetTrackRating(int rating) = 0;
 
   signals:
     void newTrackLoaded(TrackPointer pLoadedTrack);
@@ -51,6 +52,7 @@ class BaseTrackPlayer : public BasePlayer {
     void loadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
     void playerEmpty();
     void noVinylControlInputConfigured();
+    void trackRatingChanged(int rating);
 };
 
 class BaseTrackPlayerImpl : public BaseTrackPlayer {
@@ -90,6 +92,7 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     // to compensate so there is no audible change in volume.
     void slotAdjustReplayGain(mixxx::ReplayGain replayGain);
     void slotSetTrackColor(const mixxx::RgbColor::optional_t& color);
+    void slotSetTrackRating(int rating) final;
     void slotPlayToggled(double);
 
   private slots:

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -24,6 +24,7 @@
 #include "skin/legacy/colorschemeparser.h"
 #include "skin/legacy/launchimage.h"
 #include "skin/legacy/skincontext.h"
+#include "track/track.h"
 #include "util/cmdlineargs.h"
 #include "util/timer.h"
 #include "util/valuetransformer.h"
@@ -441,8 +442,6 @@ LaunchImage* LegacySkinParser::parseLaunchImage(const QString& skinPath, QWidget
     setupSize(skinDocument, pLaunchImage);
     return pLaunchImage;
 }
-
-
 
 QList<QWidget*> wrapWidget(QWidget* pWidget) {
     QList<QWidget*> result;
@@ -1163,14 +1162,18 @@ QWidget* LegacySkinParser::parseStarRating(const QDomElement& node) {
     commonWidgetSetup(node, pStarRating, false);
     pStarRating->setup(node, *m_pContext);
 
-    connect(pPlayer, &BaseTrackPlayer::newTrackLoaded, pStarRating, &WStarRating::slotTrackLoaded);
-    connect(pPlayer, &BaseTrackPlayer::playerEmpty, pStarRating, [pStarRating]() {
-        pStarRating->slotTrackLoaded(TrackPointer());
-    });
+    connect(pPlayer,
+            &BaseTrackPlayer::trackRatingChanged,
+            pStarRating,
+            &WStarRating::slotSetRating);
+    connect(pStarRating,
+            &WStarRating::ratingChanged,
+            pPlayer,
+            &BaseTrackPlayer::slotSetTrackRating);
 
     TrackPointer pTrack = pPlayer->getLoadedTrack();
     if (pTrack) {
-        pStarRating->slotTrackLoaded(pTrack);
+        pStarRating->slotSetRating(pTrack->getRating());
     }
 
     return pStarRating;

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -105,6 +105,8 @@ class FakeDeck : public BaseTrackPlayer {
     MOCK_METHOD1(slotCloneFromGroup, void(const QString& group));
     MOCK_METHOD0(slotCloneDeck, void());
 
+    void slotSetTrackRating(int /*unused*/) override{};
+
     TrackPointer loadedTrack;
     ControlObject trackSamples;
     ControlObject samplerate;

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -289,6 +289,7 @@ bool Track::replaceRecord(
     const auto newKey = newRecord.getGlobalKey();
     const auto newReplayGain = newRecord.getMetadata().getTrackInfo().getReplayGain();
     const auto newColor = newRecord.getColor();
+    const auto newRating = newRecord.getRating();
 
     auto locked = lockMutex(&m_qMutex);
     const bool recordUnchanged = m_record == newRecord;
@@ -299,6 +300,7 @@ bool Track::replaceRecord(
     const auto oldKey = m_record.getGlobalKey();
     const auto oldReplayGain = m_record.getMetadata().getTrackInfo().getReplayGain();
     const auto oldColor = m_record.getColor();
+    const auto oldRating = m_record.getRating();
 
     bool bpmUpdatedFlag;
     if (pOptionalBeats) {
@@ -333,6 +335,9 @@ bool Track::replaceRecord(
     }
     if (oldColor != newColor) {
         emit colorUpdated(newColor);
+    }
+    if (oldRating != newRating) {
+        emit ratingUpdated(newRating);
     }
 
     emitChangedSignalsForAllMetadata();
@@ -1360,6 +1365,7 @@ void Track::setRating (int rating) {
     auto locked = lockMutex(&m_qMutex);
     if (compareAndSet(m_record.ptrRating(), rating)) {
         markDirtyAndUnlock(&locked);
+        emit ratingUpdated(rating);
     }
 }
 

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -436,6 +436,7 @@ class Track : public QObject {
     // adjusted in the opposite direction to compensate (no audible change).
     void replayGainAdjusted(const mixxx::ReplayGain&);
     void colorUpdated(const mixxx::RgbColor::optional_t& color);
+    void ratingUpdated(int rating);
     void cuesUpdated();
     void loopRemove();
     void analyzed();

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -11,7 +11,6 @@
 WStarRating::WStarRating(const QString& group, QWidget* pParent)
         : WWidget(pParent),
           m_starRating(0, 5),
-          m_focused(false),
           m_currRating(0) {
     // Controls to change the star rating with controllers.
     // Note that 'group' maybe NULLPTR, e.g. when called from DlgTrackInfo,
@@ -68,7 +67,6 @@ void WStarRating::paintEvent(QPaintEvent * /*unused*/) {
 }
 
 void WStarRating::mouseMoveEvent(QMouseEvent *event) {
-    m_focused = true;
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     int star = starAtPosition(event->position().toPoint().x());
 #else
@@ -96,7 +94,6 @@ void WStarRating::slotStarsDown(double v) {
 }
 
 void WStarRating::leaveEvent(QEvent* /*unused*/) {
-    m_focused = false;
     // reset to applied track rating
     m_starRating.setStarCount(m_currRating);
     update();

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -11,12 +11,11 @@
 WStarRating::WStarRating(const QString& group, QWidget* pParent)
         : WWidget(pParent),
           m_starRating(0, 5),
-          m_group(group),
           m_focused(false) {
     // Controls to change the star rating with controllers.
     // Note that 'group' maybe NULLPTR, e.g. when called from DlgTrackInfo,
     // so only create rate change COs if there's a group passed when creating deck widgets.
-    if (!m_group.isEmpty()) {
+    if (!group.isEmpty()) {
         m_pStarsUp = std::make_unique<ControlPushButton>(ConfigKey(group, "stars_up"));
         m_pStarsDown = std::make_unique<ControlPushButton>(ConfigKey(group, "stars_down"));
         connect(m_pStarsUp.get(), &ControlObject::valueChanged, this, &WStarRating::slotStarsUp);

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -11,7 +11,8 @@
 WStarRating::WStarRating(const QString& group, QWidget* pParent)
         : WWidget(pParent),
           m_starRating(0, 5),
-          m_focused(false) {
+          m_focused(false),
+          m_currRating(0) {
     // Controls to change the star rating with controllers.
     // Note that 'group' maybe NULLPTR, e.g. when called from DlgTrackInfo,
     // so only create rate change COs if there's a group passed when creating deck widgets.
@@ -49,42 +50,10 @@ QSize WStarRating::sizeHint() const {
     return widgetSize;
 }
 
-void WStarRating::slotTrackLoaded(TrackPointer pTrack) {
-    if (m_pCurrentTrack != pTrack) {
-        if (m_pCurrentTrack) {
-            disconnect(m_pCurrentTrack.get(), nullptr, this, nullptr);
-            m_pCurrentTrack.reset();
-        }
-        if (pTrack) {
-            connect(pTrack.get(),
-                    &Track::changed,
-                    this,
-                    &WStarRating::slotTrackChanged);
-            m_pCurrentTrack = pTrack;
-        }
-        updateRatingFromTrack();
-    }
-}
-
-void WStarRating::setRating(int rating) {
-    // Check consistency with the connected track
-    DEBUG_ASSERT(!m_pCurrentTrack ||
-            m_pCurrentTrack->getRating() == rating);
+void WStarRating::slotSetRating(int rating) {
     m_starRating.setStarCount(rating);
+    m_currRating = rating;
     update();
-}
-
-void WStarRating::updateRatingFromTrack() {
-    if (m_pCurrentTrack) {
-        setRating(m_pCurrentTrack->getRating());
-    } else {
-        setRating(0);
-    }
-}
-
-void WStarRating::slotTrackChanged(TrackId trackId) {
-    Q_UNUSED(trackId);
-    updateRatingFromTrack();
 }
 
 void WStarRating::paintEvent(QPaintEvent * /*unused*/) {
@@ -99,10 +68,6 @@ void WStarRating::paintEvent(QPaintEvent * /*unused*/) {
 }
 
 void WStarRating::mouseMoveEvent(QMouseEvent *event) {
-    if (!m_pCurrentTrack) {
-        return;
-    }
-
     m_focused = true;
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     int star = starAtPosition(event->position().toPoint().x());
@@ -117,32 +82,24 @@ void WStarRating::mouseMoveEvent(QMouseEvent *event) {
 }
 
 void WStarRating::slotStarsUp(double v) {
-    if (!m_pCurrentTrack) {
-        return;
-    }
-    if (v > 0 && m_starRating.starCount() < m_starRating.maxStarCount()) {
-        int star = m_starRating.starCount() + 1;
-        m_starRating.setStarCount(star);
-        update();
-        m_pCurrentTrack->setRating(star);
+    if (v > 0 && m_currRating < m_starRating.maxStarCount()) {
+        int star = m_currRating + 1;
+        emit ratingChanged(star);
     }
 }
 
 void WStarRating::slotStarsDown(double v) {
-    if (!m_pCurrentTrack) {
-        return;
-    }
-    if (v > 0 && m_starRating.starCount() > 0) {
-        int star = m_starRating.starCount() - 1;
-        m_starRating.setStarCount(star);
-        update();
-        m_pCurrentTrack->setRating(star);
+    if (v > 0 && m_currRating > 0) {
+        int star = m_currRating - 1;
+        emit ratingChanged(star);
     }
 }
 
 void WStarRating::leaveEvent(QEvent* /*unused*/) {
     m_focused = false;
-    updateRatingFromTrack();
+    // reset to applied track rating
+    m_starRating.setStarCount(m_currRating);
+    update();
 }
 
 // The method uses basic linear algebra to find out which star is under the cursor.
@@ -161,22 +118,16 @@ int WStarRating::starAtPosition(int x) {
 }
 
 void WStarRating::mouseReleaseEvent(QMouseEvent* /*unused*/) {
-    if (!m_pCurrentTrack) {
-        return;
-    }
-
-    m_pCurrentTrack->setRating(m_starRating.starCount());
+    emit ratingChanged(m_starRating.starCount());
 }
 
 void WStarRating::fillDebugTooltip(QStringList* debug) {
     WWidget::fillDebugTooltip(debug);
 
-    QString currentRating = "-";
+    QString currentRating;
+    currentRating.setNum(m_currRating);
     QString maximumRating = QString::number(m_starRating.maxStarCount());
 
-    if (m_pCurrentTrack) {
-        currentRating.setNum(m_pCurrentTrack->getRating());
-    }
 
     *debug << QString("Rating: %1/%2").arg(currentRating, maximumRating);
 }

--- a/src/widget/wstarrating.h
+++ b/src/widget/wstarrating.h
@@ -23,10 +23,10 @@ class WStarRating : public WWidget {
     QSize sizeHint() const override;
 
   public slots:
-    void slotSetRating(int rating);
+    void slotSetRating(int starCount);
 
   signals:
-    void ratingChanged(int rating);
+    void ratingChanged(int starCount);
 
   private slots:
     void slotStarsUp(double v);
@@ -40,12 +40,17 @@ class WStarRating : public WWidget {
     void fillDebugTooltip(QStringList* debug) override;
 
   private:
-    StarRating m_starRating;
+    int m_starCount;
+
+    StarRating m_visualStarRating;
     mutable QRect m_contentRect;
 
-    int starAtPosition(int x);
+    int starAtPosition(int x) const;
+    void updateVisualRating(int starCount);
+    void resetVisualRating() {
+        updateVisualRating(m_starCount);
+    }
+
     std::unique_ptr<ControlPushButton> m_pStarsUp;
     std::unique_ptr<ControlPushButton> m_pStarsDown;
-
-    int m_currRating;
 };

--- a/src/widget/wstarrating.h
+++ b/src/widget/wstarrating.h
@@ -41,7 +41,6 @@ class WStarRating : public WWidget {
 
   private:
     StarRating m_starRating;
-    bool m_focused;
     mutable QRect m_contentRect;
 
     int starAtPosition(int x);

--- a/src/widget/wstarrating.h
+++ b/src/widget/wstarrating.h
@@ -22,16 +22,13 @@ class WStarRating : public WWidget {
     virtual void setup(const QDomNode& node, const SkinContext& context);
     QSize sizeHint() const override;
 
-    /// Manually set a custom rating
-    ///
-    /// The value must be consistent with the current track if connected.
-    void setRating(int rating);
-
   public slots:
-    void slotTrackLoaded(TrackPointer pTrack = TrackPointer());
+    void slotSetRating(int rating);
+
+  signals:
+    void ratingChanged(int rating);
 
   private slots:
-    void slotTrackChanged(TrackId);
     void slotStarsUp(double v);
     void slotStarsDown(double v);
 
@@ -42,14 +39,14 @@ class WStarRating : public WWidget {
     void leaveEvent(QEvent * /*unused*/) override;
     void fillDebugTooltip(QStringList* debug) override;
 
+  private:
     StarRating m_starRating;
-    TrackPointer m_pCurrentTrack;
     bool m_focused;
     mutable QRect m_contentRect;
 
-  private:
-    void updateRatingFromTrack();
     int starAtPosition(int x);
     std::unique_ptr<ControlPushButton> m_pStarsUp;
     std::unique_ptr<ControlPushButton> m_pStarsDown;
+
+    int m_currRating;
 };

--- a/src/widget/wstarrating.h
+++ b/src/widget/wstarrating.h
@@ -43,7 +43,6 @@ class WStarRating : public WWidget {
     void fillDebugTooltip(QStringList* debug) override;
 
     StarRating m_starRating;
-    const QString m_group;
     TrackPointer m_pCurrentTrack;
     bool m_focused;
     mutable QRect m_contentRect;


### PR DESCRIPTION
fixes #11540 

changes to the star rating are now handled via change signals, like with the QLineEdits

**edit:** instead of working around the symptom, as per @uklotzde's suggestion, this PR now adds slots and signals for track rating. Now it's consistent with other track properties and WStarRating  now much smaller.

**Note:** updating the rating (or any other track property) elsewhere emits the `trackCganged` signal and will therefore still wipe pending changes in the properties dialog. This is not a bug.