### PR TITLE
Fullscreen toggle rework

### DIFF
--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -190,10 +190,12 @@ void MixxxMainWindow::initialize() {
     // Turn on fullscreen mode
     // if we were told to start in fullscreen mode on the command-line
     // or if the user chose to always start in fullscreen mode.
-    // Remember to refresh the Fullscreen menu item after connectMenuBar()
+    // The Fullscreen menu item is refreshed in connectMenuBar()
     bool fullscreenPref = m_pCoreServices->getSettings()->getValue<bool>(
             ConfigKey("[Config]", "StartInFullscreen"));
-    if (CmdlineArgs::Instance().getStartInFullscreen() || fullscreenPref) {
+    if ((CmdlineArgs::Instance().getStartInFullscreen() || fullscreenPref) &&
+            // could be we're fullscreen already after setGeomtery(previousGeometry)
+            !isFullScreen()) {
         showFullScreen();
     }
 
@@ -373,6 +375,11 @@ void MixxxMainWindow::initialize() {
     // Show the menubar after the launch image is replaced by the skin widget,
     // otherwise it would shift the launch image shortly before the skin is visible.
     m_pMenuBar->show();
+#ifndef __APPLE__
+    // If we went fullscreen earlier and the desktop features a global menu
+    // this will signal the menu to move into the window and hide itself
+    emit fullScreenChanged(isFullScreen());
+#endif
 
     // The launch image widget is automatically disposed, but we still have a
     // pointer to it.
@@ -498,7 +505,11 @@ void MixxxMainWindow::initializeWindow() {
     Pal.setColor(QPalette::Window, MenuBarBackground);
     m_pMenuBar->setPalette(Pal);
 
-    // Restore the current window state (position, maximized, etc)
+    // Restore the current window state (position, maximized, etc).
+    // This will also restore fullscreen and thereby create a seamless
+    // start if we did shut down while in fullscreen mode and with
+    // [Config],StartInFullscreen = 1
+    // (slotViewFullScreen(true) in  initialize() is a no-op then)
     restoreGeometry(QByteArray::fromBase64(
             m_pCoreServices->getSettings()
                     ->getValueString(ConfigKey("[MainWindow]", "geometry"))
@@ -728,7 +739,8 @@ void MixxxMainWindow::connectMenuBar() {
     connect(m_pMenuBar,
             &WMainMenuBar::showKeywheel,
             this,
-            &MixxxMainWindow::slotShowKeywheel);
+            &MixxxMainWindow::slotShowKeywheel,
+            Qt::UniqueConnection);
 
     // Fullscreen
     connect(m_pMenuBar,
@@ -1086,7 +1098,9 @@ void MixxxMainWindow::rebootMixxxView() {
     // window returns to 0,0 but and the backdrop disappears so it looks as if
     // it is not fullscreen, but acts as if it is.
     bool wasFullScreen = isFullScreen();
-    slotViewFullScreen(false);
+    if (wasFullScreen) {
+        showNormal();
+    }
 
     if (!loadConfiguredSkin()) {
         QMessageBox::critical(this,
@@ -1107,7 +1121,7 @@ void MixxxMainWindow::rebootMixxxView() {
 #endif
 
     if (wasFullScreen) {
-        slotViewFullScreen(true);
+        showFullScreen();
     } else {
         // Programmatic placement at this point is very problematic.
         // The screen() method returns stale data (primary screen)

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -956,31 +956,13 @@ void MixxxMainWindow::slotViewFullScreen(bool toggle) {
         return;
     }
 
+    // Just switch the window state here. eventFilter() will catch the
+    // QWindowStateChangeEvent and inform the menu bar that fullscreen changed.
     if (toggle) {
         showFullScreen();
-#ifdef __LINUX__
-        // Fix for "No menu bar with ubuntu unity in full screen mode" (issues
-        // #6072 and #6689. Before touching anything here, please read
-        // those bugs.
-        // Set this attribute instead of calling setNativeMenuBar(false), see
-        // https://github.com/mixxxdj/mixxx/issues/11320
-        if (m_supportsGlobalMenuBar) {
-            QApplication::setAttribute(Qt::AA_DontUseNativeMenuBar, true);
-            createMenuBar();
-            connectMenuBar();
-        }
-#endif
     } else {
-#ifdef __LINUX__
-        if (m_supportsGlobalMenuBar) {
-            QApplication::setAttribute(Qt::AA_DontUseNativeMenuBar, false);
-            createMenuBar();
-            connectMenuBar();
-        }
-#endif
         showNormal();
     }
-    emit fullScreenChanged(toggle);
 }
 
 void MixxxMainWindow::slotOptionsPreferences() {
@@ -1170,6 +1152,35 @@ bool MixxxMainWindow::eventFilter(QObject* obj, QEvent* event) {
             default:
                 DEBUG_ASSERT(!"m_toolTipsCfg value unknown");
                 return true;
+            }
+        }
+    } else if (event->type() == QEvent::WindowStateChange) {
+        // Detect if we entered or quit fullscreen mode.
+        QWindowStateChangeEvent* changeEvent =
+                static_cast<QWindowStateChangeEvent*>(event);
+        const bool wasFullScreen = changeEvent->oldState() & Qt::WindowFullScreen;
+        const bool isFullScreenNow = windowState() & Qt::WindowFullScreen;
+        if ((isFullScreenNow && !wasFullScreen) ||
+                (!isFullScreenNow && wasFullScreen)) {
+#ifdef __LINUX__
+            // Fix for "No menu bar with ubuntu unity in full screen mode"
+            // (issues #6072 and #6689). Before touching anything here, please
+            // read those bugs.
+            // Set this attribute instead of calling setNativeMenuBar(false),
+            // see https://github.com/mixxxdj/mixxx/issues/11320
+            if (m_supportsGlobalMenuBar) {
+                QApplication::setAttribute(Qt::AA_DontUseNativeMenuBar, isFullScreenNow);
+                createMenuBar();
+                connectMenuBar();
+            }
+#endif
+            // This will toggle the Fullscreen checkbox and hide the menubar if
+            // we go fullscreen.
+            // Skip this during startup or the launchimage will be shifted
+            // up & down when the menu is shown menu and 'hidden'. The menu
+            // will be updated when the skin finished loading.
+            if (centralWidget() != m_pLaunchImage) {
+                emit fullScreenChanged(isFullScreen());
             }
         }
     }

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -378,11 +378,6 @@ void MixxxMainWindow::initialize() {
     // Show the menubar after the launch image is replaced by the skin widget,
     // otherwise it would shift the launch image shortly before the skin is visible.
     m_pMenuBar->show();
-#ifndef __APPLE__
-    // If we went fullscreen earlier and the desktop features a global menu
-    // this will signal the menu to move into the window and hide itself
-    emit fullScreenChanged(isFullScreen());
-#endif
 
     // The launch image widget is automatically disposed, but we still have a
     // pointer to it.

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -164,6 +164,7 @@ void MixxxMainWindow::initializeQOpenGL() {
 #endif
 
 void MixxxMainWindow::initialize() {
+    qWarning() << "     $ initialize";
     m_pCoreServices->getControlIndicatorTimer()->setLegacyVsyncEnabled(true);
 
     UserSettingsPointer pConfig = m_pCoreServices->getSettings();
@@ -199,6 +200,7 @@ void MixxxMainWindow::initialize() {
     if ((CmdlineArgs::Instance().getStartInFullscreen() || fullscreenPref) &&
             // could be we're fullscreen already after setGeomtery(previousGeometry)
             !isFullScreen()) {
+        qWarning() << "     init: go fullscreen";
         showFullScreen();
     }
 
@@ -495,6 +497,7 @@ MixxxMainWindow::~MixxxMainWindow() {
 }
 
 void MixxxMainWindow::initializeWindow() {
+    qWarning() << "     $ initializeWindow";
     // be sure createMenuBar() is called first
     DEBUG_ASSERT(m_pMenuBar);
 
@@ -701,6 +704,7 @@ void MixxxMainWindow::slotUpdateWindowTitle(TrackPointer pTrack) {
 }
 
 void MixxxMainWindow::createMenuBar() {
+    qWarning() << "     $ createMenuBar";
     ScopedTimer t(u"MixxxMainWindow::createMenuBar");
     DEBUG_ASSERT(m_pCoreServices->getKeyboardConfig());
     m_pMenuBar = make_parented<WMainMenuBar>(
@@ -714,6 +718,7 @@ void MixxxMainWindow::createMenuBar() {
 void MixxxMainWindow::connectMenuBar() {
     // This function might be invoked multiple times on startup
     // so all connections must be unique!
+    qWarning() << "     $ connectMenuBar";
 
     ScopedTimer t(u"MixxxMainWindow::connectMenuBar");
     connect(this,
@@ -955,15 +960,19 @@ void MixxxMainWindow::slotDeveloperToolsClosed() {
 }
 
 void MixxxMainWindow::slotViewFullScreen(bool toggle) {
+    qWarning() << "     $ slotViewFullScreen" << toggle;
     if (isFullScreen() == toggle) {
+        qWarning() << "     (no-op)";
         return;
     }
 
     // Just switch the window state here. eventFilter() will catch the
     // QWindowStateChangeEvent and inform the menu bar that fullscreen changed.
     if (toggle) {
+        qWarning() << "     > showFullScreen()";
         showFullScreen();
     } else {
+        qWarning() << "     > showNormal()";
         showNormal();
     }
 }
@@ -1159,6 +1168,7 @@ bool MixxxMainWindow::eventFilter(QObject* obj, QEvent* event) {
         }
     } else if (event->type() == QEvent::WindowStateChange) {
 #ifndef __APPLE__
+        qWarning() << "$ WindowStateChange:" << windowState();
         if (windowState() == m_prevState) {
             // Ignore no-op. This happens if another window is raised above
             // MixxxMianWindow,  e.g. DlgPeferences. In such a case event->oldState()
@@ -1176,6 +1186,8 @@ bool MixxxMainWindow::eventFilter(QObject* obj, QEvent* event) {
         const bool isFullScreenNow = windowState() & Qt::WindowFullScreen;
         if ((isFullScreenNow && !wasFullScreen) ||
                 (!isFullScreenNow && wasFullScreen)) {
+            qWarning() << "$ fullscreen changed, now"
+                       << (isFullScreenNow ? "fullscreen" : "window");
 #ifdef __LINUX__
             // Fix for "No menu bar with ubuntu unity in full screen mode"
             // (issues #6072 and #6689). Before touching anything here, please
@@ -1183,6 +1195,7 @@ bool MixxxMainWindow::eventFilter(QObject* obj, QEvent* event) {
             // Set this attribute instead of calling setNativeMenuBar(false),
             // see https://github.com/mixxxdj/mixxx/issues/11320
             if (m_supportsGlobalMenuBar) {
+                qWarning() << "$ global menu > rebuild";
                 QApplication::setAttribute(Qt::AA_DontUseNativeMenuBar, isFullScreenNow);
                 createMenuBar();
                 connectMenuBar();

--- a/src/mixxxmainwindow.h
+++ b/src/mixxxmainwindow.h
@@ -115,6 +115,9 @@ class MixxxMainWindow : public QMainWindow {
 
     QWidget* m_pCentralWidget;
     LaunchImage* m_pLaunchImage;
+#ifndef __APPLE__
+    Qt::WindowStates m_prevState;
+#endif
 
     std::shared_ptr<mixxx::skin::SkinLoader> m_pSkinLoader;
     GuiTick* m_pGuiTick;


### PR DESCRIPTION
### Motivation
While working on #11304 I noticed that my window manager (xfwm4 on Ubuntu Studio) consumes the fullscreen hotkey F11 and `MixxxMainWindow::slotViewFullScreen()` never gets called, except when I click the menu checkbox.
This happens because the fullscreen hotkey in Mixxx and in my  window manager are identical.
(so most of my fullscreen testing was kinda worthless... : \ )

### Changes
* `MixxxMainWindow::slotViewFullScreen()` does now just **toggle** fullscreen
* `MixxxMainWindow::eventFilter()` catches ALL fullscreen changes (`QWindowStateChangeEvent`), no matter if triggered by OS or Mixxx, and also emits a signal to recreate & connect the menu bar (only on Linux desktops that use a global menu)

This works perfectly fine for me, and I'm curious how it performs on Windows and macOS. Please test!


### TODO
- [x] ensure smooth startup (fullscreen or not), i.e. no flickering, static launch screen

### Testing
* clicking `View` > `Fullscreen` as well as any of the hotkeys printed next to it should toggle fullscreen without any unusual flickering 
* Mixxx should start in fullscreen when using the fullscreen command line arguments `--f` or `--full-screen`, regardless the preferences option "Start in fullscreen"
* fullscreen main window should not flicker if any dialog is openened (About dialog, key wheel window, preferences window etc.)