### PR TITLE
Remove from disk: shrink dialog so buttons are (hopefully) on screen

### DIFF
--- a/src/util/widgethelper.cpp
+++ b/src/util/widgethelper.cpp
@@ -66,9 +66,11 @@ void growListWidget(QListWidget& listWidget, const QWidget& parent) {
             listWidget.style()->pixelMetric(QStyle::PM_ScrollBarExtent);
     int minW = listWidget.sizeHintForColumn(0) + margin;
     int minH = listWidget.sizeHintForRow(0) * listWidget.count() + margin;
-    // The file list should fit into the window, but clamp to 90% of screen size.
-    int newW = std::min(minW, static_cast<int>(screenSpace.width() * 0.9));
-    int newH = std::min(minH, static_cast<int>(screenSpace.height() * 0.9));
+    // The file list should fit into the window, but clamp to 75% of screen size
+    // so (hoepfully) the entire containing dialog is visible even if there are
+    // toolbars at the screen edges
+    int newW = std::min(minW, static_cast<int>(screenSpace.width() * 0.75));
+    int newH = std::min(minH, static_cast<int>(screenSpace.height() * 0.75));
     // Apply new size
     if (newW > 0 && newH > 0) {
         listWidget.setMinimumSize(newW, newH);


### PR DESCRIPTION
Make the "Remove track files from disk" dialog smaller. Track file list widget is now max 75% of screen.

That should suffice as quick fix. A more robust solution ([like for the preferences](https://github.com/mixxxdj/mixxx/blob/5f5cd28b3f8b471f5f2ca271e1ecacf8f2b1a659/src/preferences/dialog/dlgpreferences.cpp#L348)) is significantly more elaborate, because IIRC the dialog needs to be shown before we can query its size and window decoration.