### PR TITLE
History: restore menu action "Remove from playlist"

### DIFF
--- a/src/library/playlisttablemodel.cpp
+++ b/src/library/playlisttablemodel.cpp
@@ -354,12 +354,11 @@ TrackModel::Capabilities PlaylistTableModel::getCapabilities() const {
     } else {
         caps |= Capability::Remove;
     }
-    if (PlaylistDAO::PLHT_SET_LOG ==
-            m_pTrackCollectionManager->internalCollection()
+    if (m_pTrackCollectionManager->internalCollection()
                     ->getPlaylistDAO()
-                    .getHiddenType(m_iPlaylistId)) {
-        // Disable track reordering for history playlists
-        caps &= ~(Capability::ReceiveDrops | Capability::Reorder | Capability::RemovePlaylist);
+                    .getHiddenType(m_iPlaylistId) == PlaylistDAO::PLHT_SET_LOG) {
+        // Disable track reordering and adding tracks via drag'n'drop for history playlists
+        caps &= ~(Capability::ReceiveDrops | Capability::Reorder);
     }
     bool locked = m_pTrackCollectionManager->internalCollection()->getPlaylistDAO().isPlaylistLocked(m_iPlaylistId);
     if (locked) {


### PR DESCRIPTION
The "Remove" action is really useful to clean up set lists, for example to remove

* tracks from the soundcheck after forgetting about 'Start new' (split history)
* played tracks that didn't make it into the main mix (recording) in a back-to-back session
* duplicate tracks that were not filtered

And it would comply with disallowing rewriting the history. 'Forgetting' events is different from creating new ones : )

Fixes #10974