### PR TITLE
Numark DJ2GO2 Touch: add missing loop_out mapping for the right deck

### DIFF
--- a/res/controllers/Numark_DJ2GO2_Touch.midi.xml
+++ b/res/controllers/Numark_DJ2GO2_Touch.midi.xml
@@ -745,6 +745,15 @@
       </control>
       <control>
         <group>[Channel2]</group>
+        <key>DJ2GO2Touch.rightDeck.loopOut.input</key>
+        <status>0x95</status>
+        <midino>0x22</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
         <key>DJ2GO2Touch.rightDeck.reLoopStop.input</key>
         <status>0x95</status>
         <midino>0x24</midino>


### PR DESCRIPTION
Added a missing section for the DJ2GO2Touch.rightDeck.loopOut.input key to the Numark DJ2GO2 Touch controller scheme.

I found that [changing the source branch of a PR is not possible](https://stackoverflow.com/questions/42381557/changing-source-branch-for-pr-on-github) so I've created a new one. Please remove the old [PR 11594](https://github.com/mixxxdj/mixxx/pull/11594) if not needed.