### PR TITLE
Build with Qt6 and optionally with QML

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,10 +109,19 @@ if(NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 option(QT6 "Build with Qt6" OFF)
-
+option(QML "Build with QML" OFF)
 option(QOPENGL "Use QOpenGLWindow based widget instead of QGLWidget" ON)
+
+if(QML AND NOT QT6)
+  message(FATAL_ERROR "Building with option QML=ON requires QT6=ON")
+endif()
+
 if(QOPENGL)
   add_compile_definitions(MIXXX_USE_QOPENGL)
+endif()
+
+if(QML)
+  add_compile_definitions(MIXXX_USE_QML)
 endif()
 
 if(APPLE)
@@ -120,7 +129,7 @@ if(APPLE)
     # Minimum macOS version supported by Qt 6
     set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15 CACHE STRING "Minimum macOS version the build will be able to run on")
     if(NOT VCPKG_TARGET_TRIPLET)
-      set(VCPKG_TARGET_TRIPLET "x64-osx-min10.15")
+      set(VCPKG_TARGET_TRIPLET "x64-osx-min1012")
     endif()
   else()
     if(VCPKG_TARGET_TRIPLET STREQUAL "arm64-osx-min1100")
@@ -1103,7 +1112,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/widget/wwidgetgroup.cpp
   src/widget/wwidgetstack.cpp
 )
-if(QT6)
+if(QML)
   target_sources(mixxx-lib PRIVATE
     src/qml/asyncimageprovider.cpp
     src/qml/qmlapplication.cpp
@@ -2038,6 +2047,8 @@ if(ENGINEPRIME)
     message(STATUS "Using existing system installation of libdjinterop")
     target_include_directories(mixxx-lib PUBLIC ${DjInterop_INCLUDE_DIRS})
     target_link_libraries(mixxx-lib PRIVATE DjInterop::DjInterop)
+    find_package(ZLIB 1.2.8 REQUIRED)
+    target_link_libraries(mixxx-lib PRIVATE ${ZLIB_LIBRARIES})
   else()
     # Fetch djinterop sources from GitHub and build them statically.
 
@@ -2318,7 +2329,9 @@ if(QT6)
   foreach(COMPONENT ${QT6_NEW_COMPONENTS})
     target_link_libraries(mixxx-lib PUBLIC Qt6::${COMPONENT})
   endforeach()
+endif()
 
+if(QML)
   set(QT_QML_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/qml)
   set_target_properties(mixxx-lib PROPERTIES AUTOMOC ON)
   qt_add_qml_module(mixxx-lib
@@ -2416,7 +2429,7 @@ endif()
 
 
 if(APPLE)
-  if(Qt_IS_STATIC)
+  if(Qt_IS_STATIC OR QT6)
     target_link_libraries(mixxx-lib PRIVATE
         "-weak_framework Accelerate"
         "-weak_framework AppKit"
@@ -2520,7 +2533,11 @@ endif()
 if(APPLE OR WIN32)
   # qt_de.qm is just one arbitrary file in the directory that needs to be located;
   # there is no particular reason to look for this file versus any other one in the directory.
-  find_file(QT_TRANSLATION_FILE qt_de.qm PATHS "${Qt5_DIR}/../../../translations" "${Qt5_DIR}/../../qt5/translations" REQUIRED NO_DEFAULT_PATH)
+  if(QT6)
+    find_file(QT_TRANSLATION_FILE qt_de.qm PATHS "${Qt6_DIR}/../../../translations" "${Qt6_DIR}/../../qt5/translations" REQUIRED NO_DEFAULT_PATH)
+  else()
+    find_file(QT_TRANSLATION_FILE qt_de.qm PATHS "${Qt5_DIR}/../../../translations" "${Qt5_DIR}/../../qt5/translations" REQUIRED NO_DEFAULT_PATH)
+  endif()
   get_filename_component(QT_TRANSLATIONS ${QT_TRANSLATION_FILE} DIRECTORY)
   install(
     DIRECTORY "${QT_TRANSLATIONS}"

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -421,7 +421,7 @@
 
                     <WidgetGroup>
                       <Layout>vertical</Layout>
-                      <SizePolicy>me,max</SizePolicy>
+                      <SizePolicy>me,me</SizePolicy>
                       <Children>
                         <Template src="skin:waveforms_container.xml"/>
                       </Children>

--- a/src/control/controlsortfiltermodel.h
+++ b/src/control/controlsortfiltermodel.h
@@ -2,7 +2,7 @@
 
 #include <QSortFilterProxyModel>
 #include <QString>
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#ifdef MIXXX_USE_QML
 #include <QtQml>
 #else
 #define QML_ELEMENT

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -36,7 +36,7 @@
 #include "util/sample.h"
 #include "util/timer.h"
 #include "waveform/visualplayposition.h"
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#ifndef MIXXX_USE_QML
 #include "waveform/waveformwidgetfactory.h"
 #endif
 

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -183,7 +183,7 @@ LibraryControl::LibraryControl(Library* pLibrary)
 
     // Auto DJ controls
     m_pAutoDjAddTop = std::make_unique<ControlPushButton>(ConfigKey("[Library]","AutoDjAddTop"));
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#ifndef MIXXX_USE_QML
     connect(m_pAutoDjAddTop.get(),
             &ControlPushButton::valueChanged,
             this,
@@ -191,7 +191,7 @@ LibraryControl::LibraryControl(Library* pLibrary)
 #endif
 
     m_pAutoDjAddBottom = std::make_unique<ControlPushButton>(ConfigKey("[Library]","AutoDjAddBottom"));
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#ifndef MIXXX_USE_QML
     connect(m_pAutoDjAddBottom.get(),
             &ControlPushButton::valueChanged,
             this,
@@ -200,7 +200,7 @@ LibraryControl::LibraryControl(Library* pLibrary)
 
     m_pAutoDjAddReplace = std::make_unique<ControlPushButton>(
             ConfigKey("[Library]", "AutoDjAddReplace"));
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#ifndef MIXXX_USE_QML
     connect(m_pAutoDjAddReplace.get(),
             &ControlPushButton::valueChanged,
             this,
@@ -214,7 +214,7 @@ LibraryControl::LibraryControl(Library* pLibrary)
     m_pSortColumnToggle = std::make_unique<ControlEncoder>(ConfigKey("[Library]", "sort_column_toggle"), false);
     m_pSortFocusedColumn = std::make_unique<ControlPushButton>(
             ConfigKey("[Library]", "sort_focused_column"));
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#ifndef MIXXX_USE_QML
     connect(m_pSortColumn.get(),
             &ControlEncoder::valueChanged,
             this,
@@ -405,7 +405,7 @@ LibraryControl::LibraryControl(Library* pLibrary)
     ControlDoublePrivate::insertAlias(ConfigKey("[Playlist]", "AutoDjAddTop"), ConfigKey("[Library]", "AutoDjAddTop"));
     ControlDoublePrivate::insertAlias(ConfigKey("[Playlist]", "AutoDjAddBottom"), ConfigKey("[Library]", "AutoDjAddBottom"));
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#ifndef MIXXX_USE_QML
     QApplication* app = qApp;
     // Update controls if any widget in any Mixxx window gets or loses focus
     connect(app,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,7 +13,7 @@
 #include "coreservices.h"
 #include "errordialoghandler.h"
 #include "mixxxapplication.h"
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#ifdef MIXXX_USE_QML
 #include "qml/qmlapplication.h"
 #else
 #include "mixxxmainwindow.h"
@@ -27,7 +27,7 @@
 namespace {
 
 // Exit codes
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#ifndef MIXXX_USE_QML
 constexpr int kFatalErrorOnStartupExitCode = 1;
 #endif
 constexpr int kParseCmdlineArgsErrorExitCode = 2;
@@ -42,7 +42,7 @@ int runMixxx(MixxxApplication* pApp, const CmdlineArgs& args) {
     CmdlineArgs::Instance().parseForUserFeedback();
 
     int exitCode;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#ifdef MIXXX_USE_QML
     mixxx::qml::QmlApplication qmlApplication(pApp, pCoreServices);
     exitCode = pApp->exec();
 #else

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -17,7 +17,7 @@
 #include "track/track.h"
 #include "util/sandbox.h"
 #include "vinylcontrol/defs_vinylcontrol.h"
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#ifndef MIXXX_USE_QML
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveform/visualsmanager.h"
 #endif

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -78,7 +78,9 @@
 #undef max
 #undef min
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include <QtX11Extras/QX11Info>
+#endif
 #endif
 
 namespace {

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -24,8 +24,7 @@
 #include "preferences/dialog/dlgprefdeck.h"
 #include "preferences/dialog/dlgprefeffects.h"
 #include "preferences/dialog/dlgprefinterface.h"
-#include "preferences/dialog/dlgprefmixer.h"
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#ifndef MIXXX_USE_QML
 #include "preferences/dialog/dlgprefwaveform.h"
 #endif
 
@@ -153,7 +152,7 @@ DlgPreferences::DlgPreferences(
             tr("Interface"),
             "ic_preferences_interface.svg");
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#ifndef MIXXX_USE_QML
     // ugly proxy for determining whether this is being instantiated for QML or legacy QWidgets GUI
     if (pSkinLoader) {
         DlgPrefWaveform* pWaveformPage = new DlgPrefWaveform(this, m_pConfig, pLibrary);

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -24,6 +24,7 @@
 #include "preferences/dialog/dlgprefdeck.h"
 #include "preferences/dialog/dlgprefeffects.h"
 #include "preferences/dialog/dlgprefinterface.h"
+#include "preferences/dialog/dlgprefmixer.h"
 #ifndef MIXXX_USE_QML
 #include "preferences/dialog/dlgprefwaveform.h"
 #endif

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -28,7 +28,7 @@
 #include "util/timer.h"
 #include "util/valuetransformer.h"
 #include "util/xml.h"
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#ifndef MIXXX_USE_QML
 #include "waveform/vsyncthread.h"
 #endif
 #include "waveform/waveformwidgetfactory.h"
@@ -73,7 +73,7 @@
 #include "widget/wsizeawarestack.h"
 #include "widget/wskincolor.h"
 #include "widget/wslidercomposed.h"
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#ifndef MIXXX_USE_QML
 #include "widget/wspinny.h"
 #include "widget/wspinnyglsl.h"
 #endif
@@ -84,7 +84,7 @@
 #include "widget/wtrackproperty.h"
 #include "widget/wtracktext.h"
 #include "widget/wtrackwidgetgroup.h"
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#ifndef MIXXX_USE_QML
 #include "widget/wvumeter.h"
 #include "widget/wvumeterglsl.h"
 #include "widget/wvumeterlegacy.h"
@@ -950,7 +950,7 @@ void LegacySkinParser::setupLabelWidget(const QDomElement& element, WLabel* pLab
 }
 
 QWidget* LegacySkinParser::parseOverview(const QDomElement& node) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#ifdef MIXXX_USE_QML
     Q_UNUSED(node);
 
     return nullptr;
@@ -996,7 +996,7 @@ QWidget* LegacySkinParser::parseOverview(const QDomElement& node) {
 }
 
 QWidget* LegacySkinParser::parseVisual(const QDomElement& node) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#ifdef MIXXX_USE_QML
     Q_UNUSED(node);
 
     return nullptr;
@@ -1269,7 +1269,7 @@ QWidget* LegacySkinParser::parseRecordingDuration(const QDomElement& node) {
 }
 
 QWidget* LegacySkinParser::parseSpinny(const QDomElement& node) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#ifdef MIXXX_USE_QML
     Q_UNUSED(node);
 
     return nullptr;
@@ -1354,7 +1354,7 @@ QWidget* LegacySkinParser::parseSpinny(const QDomElement& node) {
 }
 
 QWidget* LegacySkinParser::parseVuMeter(const QDomElement& node) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#ifdef MIXXX_USE_QML
     Q_UNUSED(node);
 
     return nullptr;

--- a/src/waveform/renderers/allshader/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderbeat.cpp
@@ -49,7 +49,7 @@ void WaveformRenderBeat::paintGL() {
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-    m_color.setAlphaF(alpha / 100.0);
+    m_color.setAlphaF(alpha / 100.0f);
 
     const int trackSamples = m_waveformRenderer->getTrackSamples();
     if (trackSamples <= 0) {

--- a/src/waveform/renderers/allshader/waveformrendererendoftrack.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererendoftrack.cpp
@@ -104,7 +104,7 @@ void WaveformRendererEndOfTrack::paintGL() {
 
     if (alpha != 0.0) {
         QColor color = m_color;
-        color.setAlphaF(alpha);
+        color.setAlphaF(static_cast<float>(alpha));
 
         glEnable(GL_BLEND);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);

--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -208,7 +208,7 @@ void allshader::WaveformRenderMark::paintGL() {
 
                 if (visible || currentMarkEndPoint > 0) {
                     QColor color = pMark->fillColor();
-                    color.setAlphaF(0.4);
+                    color.setAlphaF(0.4f);
 
                     drawMark(
                             QRectF(QPointF(currentMarkPoint, 0),

--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -444,7 +444,11 @@ void allshader::WaveformRenderMark::generateMarkImage(WaveformMarkPointer pMark,
         // though as soon as other OS-based font and app scaling mechanics join the
         // party the resulting font size is hard to predict (affects all supported OS).
         font.setPixelSize(13);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
         font.setWeight(75); // bold
+#else
+        font.setWeight(QFont::Bold); // bold
+#endif
         font.setItalic(false);
 
         QFontMetrics metrics(font);

--- a/src/waveform/renderers/allshader/waveformrendermarkrange.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermarkrange.cpp
@@ -108,7 +108,7 @@ void allshader::WaveformRenderMarkRange::paintGL() {
         }
 
         QColor color = markRange.enabled() ? markRange.m_activeColor : markRange.m_disabledColor;
-        color.setAlphaF(0.3);
+        color.setAlphaF(0.3f);
 
         fillRect(QRectF(startPosition, 0, span, m_waveformRenderer->getBreadth()), color);
     }

--- a/src/waveform/renderers/qtwaveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/qtwaveformrendererfilteredsignal.cpp
@@ -28,13 +28,13 @@ void QtWaveformRendererFilteredSignal::onSetup(const QDomNode& /*node*/) {
     QColor midCenter = mid;
     QColor highCenter = high;
 
-    low.setAlphaF(0.9);
-    mid.setAlphaF(0.9);
-    high.setAlphaF(0.9);
+    low.setAlphaF(0.9f);
+    mid.setAlphaF(0.9f);
+    high.setAlphaF(0.9f);
 
-    lowCenter.setAlphaF(0.5);
-    midCenter.setAlphaF(0.5);
-    highCenter.setAlphaF(0.5);
+    lowCenter.setAlphaF(0.5f);
+    midCenter.setAlphaF(0.5f);
+    highCenter.setAlphaF(0.5f);
 
     QLinearGradient gradientLow(QPointF(0.0,-255.0/2.0),QPointF(0.0,255.0/2.0));
     gradientLow.setColorAt(0.0, low);
@@ -60,9 +60,9 @@ void QtWaveformRendererFilteredSignal::onSetup(const QDomNode& /*node*/) {
     gradientHigh.setColorAt(1.0, high);
     m_highBrush = QBrush(gradientHigh);
 
-    low.setAlphaF(0.3);
-    mid.setAlphaF(0.3);
-    high.setAlphaF(0.3);
+    low.setAlphaF(0.3f);
+    mid.setAlphaF(0.3f);
+    high.setAlphaF(0.3f);
 
     QLinearGradient gradientKilledLow(QPointF(0.0,-255.0/2.0),QPointF(0.0,255.0/2.0));
     gradientKilledLow.setColorAt(0.0,low.darker(80));

--- a/src/waveform/renderers/qtwaveformrenderersimplesignal.cpp
+++ b/src/waveform/renderers/qtwaveformrenderersimplesignal.cpp
@@ -23,12 +23,12 @@ void QtWaveformRendererSimpleSignal::onSetup(const QDomNode& node) {
     Q_UNUSED(node);
 
     QColor borderColor = m_pColors->getSignalColor().lighter(125);
-    borderColor.setAlphaF(0.5);
+    borderColor.setAlphaF(0.5f);
     m_borderPen.setColor(borderColor);
-    m_borderPen.setWidthF(1.25);
+    m_borderPen.setWidthF(1.25f);
 
     QColor signalColor = m_pColors->getSignalColor();
-    signalColor.setAlphaF(0.8);
+    signalColor.setAlphaF(0.8f);
     m_brush = QBrush(signalColor);
 }
 

--- a/src/waveform/renderers/waveformmarkrange.cpp
+++ b/src/waveform/renderers/waveformmarkrange.cpp
@@ -122,7 +122,7 @@ void WaveformMarkRange::generateImage(int weidth, int height) {
     m_disabledImage.fill(QColor(0,0,0,0).rgba());
 
     QColor activeColor = m_activeColor;
-    activeColor.setAlphaF(0.3);
+    activeColor.setAlphaF(0.3f);
     QBrush brush(activeColor);
 
     QPainter painter;
@@ -131,7 +131,7 @@ void WaveformMarkRange::generateImage(int weidth, int height) {
     painter.end();
 
     QColor disabledColor = m_disabledColor;
-    disabledColor.setAlphaF(0.3);
+    disabledColor.setAlphaF(0.3f);
     brush = QBrush(disabledColor);
 
     painter.begin(&m_disabledImage);

--- a/src/waveform/renderers/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/waveformrendererhsv.cpp
@@ -162,11 +162,11 @@ void WaveformRendererHSV::draw(
                 lo = (maxLow[0] + maxLow[1]) / total;
                 hi = (maxHigh[0] + maxHigh[1]) / total;
             } else {
-                lo = hi = 0.0;
+                lo = hi = 0.0f;
             }
 
             // Set color
-            color.setHsvF(h, 1.0-hi, 1.0-lo);
+            color.setHsvF(h, 1.0f - hi, 1.0f - lo);
 
             pen.setColor(color);
 

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -263,7 +263,11 @@ void WaveformRenderMark::generateMarkImage(WaveformMarkPointer pMark) {
     // though as soon as other OS-based font and app scaling mechanics join the
     // party the resulting font size is hard to predict (affects all supported OS).
     font.setPixelSize(13);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     font.setWeight(75); // bold
+#else
+    font.setWeight(QFont::Bold); // bold
+#endif
     font.setItalic(false);
 
     QFontMetrics metrics(font);

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -88,7 +88,7 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
                                     sampleEndPosition);
                     if (visible || currentMarkEndPoint > 0) {
                         QColor color = pMark->fillColor();
-                        color.setAlphaF(0.4);
+                        color.setAlphaF(0.4f);
 
                         QLinearGradient gradient(QPointF(0, 0),
                                 QPointF(0, m_waveformRenderer->getHeight()));
@@ -131,7 +131,7 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
                                             sampleEndPosition);
                     if (currentMarkEndPoint < m_waveformRenderer->getHeight()) {
                         QColor color = pMark->fillColor();
-                        color.setAlphaF(0.4);
+                        color.setAlphaF(0.4f);
 
                         QLinearGradient gradient(QPointF(0, 0),
                                 QPointF(m_waveformRenderer->getWidth(), 0));

--- a/src/waveform/renderers/waveformsignalcolors.cpp
+++ b/src/waveform/renderers/waveformsignalcolors.cpp
@@ -142,29 +142,41 @@ void WaveformSignalColors::fallBackFromSignalColor() {
     if (s < 0.1) { // gray
         const float sMax = 1.0f - h;
         m_lowColor.setHslF(h,s,l);
-        m_midColor.setHslF(h,s+sMax*0.2,l);
-        m_highColor.setHslF(h,s+sMax*0.4,l);
+        m_midColor.setHslF(h, s + sMax * 0.2f, l);
+        m_highColor.setHslF(h, s + sMax * 0.4f, l);
     } else {
         if (l < 0.1) { // ~white
             const float lMax = 1.0f - l;
             m_lowColor.setHslF(h,s,l);
-            m_midColor.setHslF(h,s,l+lMax*0.2);
-            m_highColor.setHslF(h,s,l+lMax*0.4);
+            m_midColor.setHslF(h, s, l + lMax * 0.2f);
+            m_highColor.setHslF(h, s, l + lMax * 0.4f);
         } else if (l < 0.5) {
             const float lMax = 1.0f - l;
             m_lowColor.setHslF(h,s,l);
-            m_midColor.setHslF(stableHue(h-analogousAngle*0.3),s,l+lMax*0.1);
-            m_highColor.setHslF(stableHue(h+analogousAngle*0.3),s,l+lMax*0.4);
+            m_midColor.setHslF(
+                    static_cast<float>(stableHue(h - analogousAngle * 0.3)),
+                    s,
+                    l + lMax * 0.1f);
+            m_highColor.setHslF(
+                    static_cast<float>(stableHue(h + analogousAngle * 0.3)),
+                    s,
+                    l + lMax * 0.4f);
         } else if (l < 0.9) {
             const float lMin = l;
             m_lowColor.setHslF(h,s,l);
-            m_midColor.setHslF(stableHue(h-analogousAngle*0.3),s,l-lMin*0.1);
-            m_highColor.setHslF(stableHue(h+analogousAngle*0.3),s,l-lMin*0.4);
+            m_midColor.setHslF(
+                    static_cast<float>(stableHue(h - analogousAngle * 0.3)),
+                    s,
+                    l - lMin * 0.1f);
+            m_highColor.setHslF(
+                    static_cast<float>(stableHue(h + analogousAngle * 0.3)),
+                    s,
+                    l - lMin * 0.4f);
         } else { // ~black
             const float lMin = l;
             m_lowColor.setHslF(h,s,l);
-            m_midColor.setHslF(h,s,l-lMin*0.2);
-            m_highColor.setHslF(h,s,l-lMin*0.4);
+            m_midColor.setHslF(h, s, l - lMin * 0.2f);
+            m_highColor.setHslF(h, s, l - lMin * 0.4f);
         }
     }
 

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -319,7 +319,11 @@ void WaveformWidgetRenderer::drawPassthroughLabel(QPainter* painter) {
     font.setFamily("Open Sans"); // default label font
     // Make the label always fit
     font.setPixelSize(math_min(25, int(m_height * 0.8)));
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     font.setWeight(75); // bold
+#else
+    font.setWeight(QFont::Bold); // bold
+#endif
     font.setItalic(false);
 
     QString label = QObject::tr("Passthrough");

--- a/src/waveform/visualplayposition.cpp
+++ b/src/waveform/visualplayposition.cpp
@@ -6,7 +6,7 @@
 #include "control/controlproxy.h"
 #include "moc_visualplayposition.cpp"
 #include "util/math.h"
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#ifndef MIXXX_USE_QML
 #include "waveform/vsyncthread.h"
 #endif
 
@@ -51,7 +51,7 @@ void VisualPlayPosition::set(
 double VisualPlayPosition::calcOffsetAtNextVSync(
         VSyncThread* pVSyncThread, const VisualPlayPositionData& data) {
     if (data.m_audioBufferMicroS != 0.0) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#ifdef MIXXX_USE_QML
         Q_UNUSED(pVSyncThread);
         const int refToVSync = 0;
         const int syncIntervalTimeMicros = 0;

--- a/src/waveform/visualplayposition.h
+++ b/src/waveform/visualplayposition.h
@@ -8,7 +8,7 @@
 #include "control/controlvalue.h"
 
 class ControlProxy;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#ifdef MIXXX_USE_QML
 typedef void VSyncThread;
 #else
 class VSyncThread;

--- a/src/waveform/widgets/glwaveformwidget.cpp
+++ b/src/waveform/widgets/glwaveformwidget.cpp
@@ -1,6 +1,5 @@
 #include "waveform/widgets/glwaveformwidget.h"
 
-#include <QGLContext>
 #include <QPainter>
 #include <QtDebug>
 

--- a/src/waveform/widgets/qthsvwaveformwidget.cpp
+++ b/src/waveform/widgets/qthsvwaveformwidget.cpp
@@ -1,6 +1,5 @@
 #include "waveform/widgets/qthsvwaveformwidget.h"
 
-#include <QGLContext>
 #include <QPainter>
 #include <QtDebug>
 

--- a/src/waveform/widgets/qtrgbwaveformwidget.cpp
+++ b/src/waveform/widgets/qtrgbwaveformwidget.cpp
@@ -1,6 +1,5 @@
 #include "waveform/widgets/qtrgbwaveformwidget.h"
 
-#include <QGLContext>
 #include <QPainter>
 #include <QtDebug>
 

--- a/src/waveform/widgets/qtvsynctestwidget.cpp
+++ b/src/waveform/widgets/qtvsynctestwidget.cpp
@@ -1,6 +1,5 @@
 #include "waveform/widgets/qtvsynctestwidget.h"
 
-#include <QGLContext>
 #include <QPainter>
 #include <QtDebug>
 

--- a/src/waveform/widgets/qtwaveformwidget.cpp
+++ b/src/waveform/widgets/qtwaveformwidget.cpp
@@ -1,6 +1,5 @@
 #include "waveform/widgets/qtwaveformwidget.h"
 
-#include <QGLContext>
 #include <QPainter>
 #include <QtDebug>
 

--- a/src/widget/openglwindow.cpp
+++ b/src/widget/openglwindow.cpp
@@ -68,8 +68,12 @@ bool OpenGLWindow::event(QEvent* ev) {
         // Tooltip don't work by forwarding the events. This mimics the
         // tooltip behavior.
         if (t == QEvent::MouseMove) {
-            ToolTipQOpenGL::singleton().start(
-                    m_pWidget, dynamic_cast<QMouseEvent*>(ev)->globalPos());
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            QPoint eventPosition = dynamic_cast<QMouseEvent*>(ev)->globalPosition().toPoint();
+#else
+            QPoint eventPosition = dynamic_cast<QMouseEvent*>(ev)->globalPos();
+#endif
+            ToolTipQOpenGL::singleton().start(m_pWidget, eventPosition);
         }
         if (t == QEvent::Leave) {
             ToolTipQOpenGL::singleton().stop(m_pWidget);

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -465,13 +465,13 @@ void WOverview::mouseMoveEvent(QMouseEvent* e) {
     if (m_bLeftClickDragging) {
         if (m_orientation == Qt::Horizontal) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-            m_iPickupPos = math_clamp(e->position().x(), 0, width() - 1);
+            m_iPickupPos = math_clamp(static_cast<int>(e->position().x()), 0, width() - 1);
 #else
             m_iPickupPos = math_clamp(e->x(), 0, width() - 1);
 #endif
         } else {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-            m_iPickupPos = math_clamp(e->position().y(), 0, height() - 1);
+            m_iPickupPos = math_clamp(static_cast<int>(e->position().y()), 0, height() - 1);
 #else
             m_iPickupPos = math_clamp(e->y(), 0, height() - 1);
 #endif
@@ -546,13 +546,13 @@ void WOverview::mousePressEvent(QMouseEvent* e) {
     if (e->button() == Qt::LeftButton) {
         if (m_orientation == Qt::Horizontal) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-            m_iPickupPos = math_clamp(e->position().x(), 0, width() - 1);
+            m_iPickupPos = math_clamp(static_cast<int>(e->position().x()), 0, width() - 1);
 #else
             m_iPickupPos = math_clamp(e->x(), 0, width() - 1);
 #endif
         } else {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-            m_iPickupPos = math_clamp(e->position().y(), 0, height() - 1);
+            m_iPickupPos = math_clamp(static_cast<int>(e->position().y()), 0, height() - 1);
 #else
             m_iPickupPos = math_clamp(e->y(), 0, height() - 1);
 #endif
@@ -1100,7 +1100,11 @@ void WOverview::drawTimeRuler(QPainter* pPainter) {
     QFontMetricsF fontMetrics(markerFont);
 
     QFont shadowFont = pPainter->font();
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     shadowFont.setWeight(99);
+#else
+    shadowFont.setWeight(QFont::Black);
+#endif
     shadowFont.setPixelSize(static_cast<int>(m_iLabelFontSize * m_scaleFactor));
     QPen shadowPen(Qt::black, 2.5 * m_scaleFactor);
 

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -912,7 +912,7 @@ void WOverview::drawMarks(QPainter* pPainter, const float offset, const float ga
 
         if (rect.isValid()) {
             QColor loopColor = pMark->fillColor();
-            loopColor.setAlphaF(0.5);
+            loopColor.setAlphaF(0.5f);
             pPainter->fillRect(rect, loopColor);
         }
 
@@ -1260,7 +1260,7 @@ void WOverview::drawPassthroughOverlay(QPainter* pPainter) {
 
 void WOverview::paintText(const QString& text, QPainter* pPainter) {
     PainterScope painterScope(pPainter);
-    m_lowColor.setAlphaF(0.5);
+    m_lowColor.setAlphaF(0.5f);
     QPen lowColorPen(
             QBrush(m_lowColor), 1.25 * m_scaleFactor, Qt::SolidLine, Qt::RoundCap);
     pPainter->setPen(lowColorPen);

--- a/src/widget/woverviewhsv.cpp
+++ b/src/widget/woverviewhsv.cpp
@@ -113,7 +113,7 @@ bool WOverviewHSV::drawNextPixmapPart() {
             }
 
             // Set color
-            color.setHsvF(h, 1.0-hi, 1.0-lo);
+            color.setHsvF(h, 1.0f - hi, 1.0f - lo);
 
             painter.setPen(color);
             painter.drawLine(QPoint(currentCompletion / 2, -maxAll[0]),

--- a/src/widget/wspinnybase.cpp
+++ b/src/widget/wspinnybase.cpp
@@ -513,8 +513,8 @@ void WSpinnyBase::updateSlipEnabled(double enabled) {
 
 void WSpinnyBase::mouseMoveEvent(QMouseEvent* e) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    int y = e->position().y();
-    int x = e->position().x();
+    int y = static_cast<int>(e->position().y());
+    int x = static_cast<int>(e->position().x());
 #else
     int y = e->y();
     int x = e->x();
@@ -577,8 +577,13 @@ void WSpinnyBase::mousePressEvent(QMouseEvent* e) {
     }
 
     if (e->button() == Qt::LeftButton) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        int y = static_cast<int>(e->position().y());
+        int x = static_cast<int>(e->position().x());
+#else
         int y = e->y();
         int x = e->x();
+#endif
 
         m_iStartMouseX = x;
         m_iStartMouseY = y;


### PR DESCRIPTION
With this PR mixxx with its current skin-based UI can be built with Qt 6. Building with Qt 6 + QML is still possible, but the cmake option QT6 now builds the skin-based UI with Qt6, while the combination of cmake options QT6 and QML build the QML-based UI.

I have been using the official Qt 6.5 binary installer:

```
cmake .. -DCMAKE_PREFIX_PATH=~/Qt6/6.5.0/macos/ -DCMAKE_BUILD_TYPE=Release -DQT6=ON -DQTKEYCHAIN=OFF
```

As far as I see, after some smoke testing on macOS, everything works as expected except for the following:

- The splitter below the waveforms doesn't work. I have done some debugging and found that the size policy of the child widgets changes somewhere between when the skin is read in the legacy skin parser and when I try to move the splitter. If I force the size policy back to it's original value it works.

- The Latenight knobs look slightly different (more pronounced outline?), but nothing major.

- I get a lot of the following warning: warning [Main] skipping QEventPoint(id=1 ts=0 pos=0,0 scn=599.994,259.461 gbl=599.994,259.461 Released ellipse=(1x1 ∡ 0) vel=0,0 press=-599.994,-259.461 last=-599.994,-259.461 Δ 599.994,259.461) : no target window

Also during compilation there are still a bunch of "deprecated" warnings for the Qt API. These should be easy to fix.
