### PR TITLE
Fix sharp cut transition after cueing a track without a defined intro

### DIFF
--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1281,13 +1281,13 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
 
     // introEnd is equal introStart in case it has not yet been set
     if (toDeckStartSeconds < introEnd && introStart < introEnd) {
-        // Limit the intro length adjustments to the original length x 2
-        // or original length + transition time, whichever is longer.
-        double seekBack = introStart - toDeckStartSeconds;
-        if (seekBack <= 0 ||
-                seekBack <= m_transitionTime ||
-                seekBack <= introEnd - introStart) {
-            introLength = introEnd - toDeckStartSeconds;
+        // Limit the intro length that results from a revers seek
+        // to a reasonable values. If the seek was too big, ignore it.
+        introLength = introEnd - toDeckStartSeconds;
+        if (introLength > (introEnd - introStart) * 2 &&
+                introLength > (introEnd - introStart) + m_transitionTime &&
+                introLength > outroLength) {
+            introLength = 0;
         }
     }
 

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1281,7 +1281,14 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
 
     // introEnd is equal introStart in case it has not yet been set
     if (toDeckStartSeconds < introEnd && introStart < introEnd) {
-        introLength = introEnd - toDeckStartSeconds;
+        // Limit the intro length adjustments to the original length x 2
+        // or original length + transition time, whichever is longer.
+        double seekBack = introStart - toDeckStartSeconds;
+        if (seekBack <= 0 ||
+                seekBack <= m_transitionTime ||
+                seekBack <= introEnd - introStart) {
+            introLength = introEnd - toDeckStartSeconds;
+        }
     }
 
     if constexpr (sDebug) {

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1266,23 +1266,22 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
     }
     pToDeck->fadeBeginPos = toDeckOutroStartSecond;
 
-    double introStart;
+    double toDeckStartSeconds = toDeckPositionSeconds;
+    const double introStart = getIntroStartSecond(pToDeck);
+    const double introEnd = getIntroEndSecond(pToDeck);
     if (seekToStartPoint || toDeckPositionSeconds >= pToDeck->fadeBeginPos) {
         // toDeckPosition >= pToDeck->fadeBeginPos happens when the
         // user has seeked or played the to track behind fadeBeginPos of
         // the fade after the next.
         // In this case we recue the track just before the transition.
-        introStart = getIntroStartSecond(pToDeck);
-    } else {
-        introStart = toDeckPositionSeconds;
+        toDeckStartSeconds = introStart;
     }
 
     double introLength = 0;
 
-    // This returns introStart in case the user has not yet set an intro end
-    const double introEnd = getIntroEndSecond(pToDeck);
-    if (introStart < introEnd) {
-        introLength = introEnd - introStart;
+    // introEnd is equal introStart in case it has not yet been set
+    if (toDeckStartSeconds < introEnd && introStart < introEnd) {
+        introLength = introEnd - toDeckStartSeconds;
     }
 
     if constexpr (sDebug) {
@@ -1323,10 +1322,10 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
             }
         }
         if (transitionLength > 0) {
-            const double transitionEnd = introStart + transitionLength;
+            const double transitionEnd = toDeckStartSeconds + transitionLength;
             if (transitionEnd > pToDeck->fadeBeginPos) {
                 // End intro before next outro starts
-                transitionLength = pToDeck->fadeBeginPos - introStart;
+                transitionLength = pToDeck->fadeBeginPos - toDeckStartSeconds;
                 VERIFY_OR_DEBUG_ASSERT(transitionLength > 0) {
                     // We seek to intro start above in this case so this never happens
                     transitionLength = 1;
@@ -1334,9 +1333,9 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
             }
             pFromDeck->fadeBeginPos = outroEnd - transitionLength;
             pFromDeck->fadeEndPos = outroEnd;
-            pToDeck->startPos = introStart;
+            pToDeck->startPos = toDeckStartSeconds;
         } else {
-            useFixedFadeTime(pFromDeck, pToDeck, fromDeckPosition, outroEnd, introStart);
+            useFixedFadeTime(pFromDeck, pToDeck, fromDeckPosition, outroEnd, toDeckStartSeconds);
         }
     } break;
     case TransitionMode::FadeAtOutroStart: {
@@ -1369,10 +1368,10 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
                     transitionLength = introLength;
                 }
             }
-            const double transitionEnd = introStart + transitionLength;
+            const double transitionEnd = toDeckStartSeconds + transitionLength;
             if (transitionEnd > pToDeck->fadeBeginPos) {
                 // End intro before next outro starts
-                transitionLength = pToDeck->fadeBeginPos - introStart;
+                transitionLength = pToDeck->fadeBeginPos - toDeckStartSeconds;
                 VERIFY_OR_DEBUG_ASSERT(transitionLength > 0) {
                     // We seek to intro start above in this case so this never happens
                     transitionLength = 1;
@@ -1380,14 +1379,14 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
             }
             pFromDeck->fadeBeginPos = outroStart;
             pFromDeck->fadeEndPos = outroStart + transitionLength;
-            pToDeck->startPos = introStart;
+            pToDeck->startPos = toDeckStartSeconds;
         } else if (introLength > 0) {
             transitionLength = introLength;
             pFromDeck->fadeBeginPos = outroEnd - transitionLength;
             pFromDeck->fadeEndPos = outroEnd;
-            pToDeck->startPos = introStart;
+            pToDeck->startPos = toDeckStartSeconds;
         } else {
-            useFixedFadeTime(pFromDeck, pToDeck, fromDeckPosition, outroEnd, introStart);
+            useFixedFadeTime(pFromDeck, pToDeck, fromDeckPosition, outroEnd, toDeckStartSeconds);
         }
     } break;
     case TransitionMode::FixedSkipSilence: {


### PR DESCRIPTION
This fixed https://github.com/mixxxdj/mixxx/issues/11621

It also adds a plausibility check for the intro length. Reject intros that are extended by more than the original length or by the transition time.