### PR TITLE
library: right align BPM, duration & bitrate values

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -426,7 +426,8 @@ QVariant BaseTrackTableModel::data(
             role != Qt::EditRole &&
             role != Qt::CheckStateRole &&
             role != Qt::ToolTipRole &&
-            role != kDataExportRole) {
+            role != kDataExportRole &&
+            role != Qt::TextAlignmentRole) {
         return QVariant();
     }
 
@@ -571,6 +572,21 @@ QVariant BaseTrackTableModel::roleValue(
             break;
         }
         M_FALLTHROUGH_INTENDED;
+    // Right align BPM, duraation and bitrate so big/small values can easily be
+    // spotted by length (number of digits)
+    case Qt::TextAlignmentRole: {
+        switch (field) {
+        case ColumnCache::COLUMN_LIBRARYTABLE_BPM:
+        case ColumnCache::COLUMN_LIBRARYTABLE_DURATION:
+        case ColumnCache::COLUMN_LIBRARYTABLE_BITRATE: {
+            // We need to cast to int due to a bug similar to
+            // https://bugreports.qt.io/browse/QTBUG-67582
+            return static_cast<int>(Qt::AlignVCenter | Qt::AlignRight);
+        }
+        default:
+            return QVariant(); // default AlignLeft for all other columns
+        }
+    }
     case Qt::DisplayRole:
         switch (field) {
         case ColumnCache::COLUMN_LIBRARYTABLE_DURATION: {

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -92,6 +92,24 @@ QSqlDatabase cloneDatabase(
 
 } // anonymous namespace
 
+// static
+constexpr int BaseTrackTableModel::kBpmColumnPrecisionDefault;
+constexpr int BaseTrackTableModel::kBpmColumnPrecisionMinimum;
+constexpr int BaseTrackTableModel::kBpmColumnPrecisionMaximum;
+
+int BaseTrackTableModel::s_bpmColumnPrecision =
+        kBpmColumnPrecisionDefault;
+
+// static
+void BaseTrackTableModel::setBpmColumnPrecision(int precision) {
+    VERIFY_OR_DEBUG_ASSERT(precision >= BaseTrackTableModel::kBpmColumnPrecisionMinimum) {
+        precision = BaseTrackTableModel::kBpmColumnPrecisionMinimum;
+    }
+    VERIFY_OR_DEBUG_ASSERT(precision <= BaseTrackTableModel::kBpmColumnPrecisionMaximum) {
+        precision = BaseTrackTableModel::kBpmColumnPrecisionMaximum;
+    }
+    s_bpmColumnPrecision = precision;
+}
 //static
 QStringList BaseTrackTableModel::defaultTableColumns() {
     return kDefaultTableColumns;
@@ -704,7 +722,8 @@ QVariant BaseTrackTableModel::roleValue(
                 if (role == Qt::ToolTipRole || role == kDataExportRole) {
                     return QString::number(bpm.value(), 'f', 4);
                 } else {
-                    return QString::number(bpm.value(), 'f', 1);
+                    // custom precision, set in DlgPrefLibrary
+                    return QString::number(bpm.value(), 'f', s_bpmColumnPrecision);
                 }
             } else {
                 return QChar('-');

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -97,6 +97,11 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
             const QString& mood) const override;
 #endif // __EXTRA_METADATA__
 
+    static constexpr int kBpmColumnPrecisionDefault = 1;
+    static constexpr int kBpmColumnPrecisionMinimum = 0;
+    static constexpr int kBpmColumnPrecisionMaximum = 10;
+    static void setBpmColumnPrecision(int precision);
+
   protected:
     static constexpr int defaultColumnWidth() {
         return 50;
@@ -271,4 +276,6 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     int countValidColumnHeaders() const;
 
     TrackId m_previewDeckTrackId;
+
+    static int s_bpmColumnPrecision;
 };

--- a/src/library/library_prefs.cpp
+++ b/src/library/library_prefs.cpp
@@ -58,6 +58,11 @@ const ConfigKey mixxx::library::prefs::kEnableSearchHistoryShortcutsConfigKey =
                 mixxx::library::prefs::kConfigGroup,
                 QStringLiteral("EnableSearchHistoryShortcuts")};
 
+const ConfigKey mixxx::library::prefs::kBpmColumnPrecisionConfigKey =
+        ConfigKey{
+                mixxx::library::prefs::kConfigGroup,
+                QStringLiteral("BpmColumnPrecision")};
+
 // The "Export" suffix in the key is kept for backward compatibility
 const ConfigKey mixxx::library::prefs::kSyncTrackMetadataConfigKey =
         ConfigKey{

--- a/src/library/library_prefs.h
+++ b/src/library/library_prefs.h
@@ -24,6 +24,8 @@ extern const ConfigKey kEnableSearchCompletionsConfigKey;
 
 extern const ConfigKey kEnableSearchHistoryShortcutsConfigKey;
 
+extern const ConfigKey kBpmColumnPrecisionConfigKey;
+
 extern const ConfigKey kEditMetadataSelectedClickConfigKey;
 
 extern const ConfigKey kHistoryMinTracksToKeepConfigKey;

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -88,11 +88,6 @@ DlgPrefLibrary::DlgPrefLibrary(
 
     searchDebouncingTimeoutSpinBox->setMinimum(WSearchLineEdit::kMinDebouncingTimeoutMillis);
     searchDebouncingTimeoutSpinBox->setMaximum(WSearchLineEdit::kMaxDebouncingTimeoutMillis);
-    const auto searchDebouncingTimeoutMillis =
-            m_pConfig->getValue(
-                    kSearchDebouncingTimeoutMillisConfigKey,
-                    WSearchLineEdit::kDefaultDebouncingTimeoutMillis);
-    searchDebouncingTimeoutSpinBox->setValue(searchDebouncingTimeoutMillis);
     connect(searchDebouncingTimeoutSpinBox,
             QOverload<int>::of(&QSpinBox::valueChanged),
             this,

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -134,12 +134,37 @@ DlgPrefLibrary::DlgPrefLibrary(
             this,
             &DlgPrefLibrary::slotSyncTrackMetadataToggled);
 
+    // Avoid undesired spinbox value changes while scrolling the preferences page
+    setFocusPolicyInstallEventFilter(spinbox_bpm_precision);
+    setFocusPolicyInstallEventFilter(spinbox_history_track_duplicate_distance);
+    setFocusPolicyInstallEventFilter(spinbox_history_min_tracks_to_keep);
+    setFocusPolicyInstallEventFilter(spinBoxRowHeight);
+    setFocusPolicyInstallEventFilter(searchDebouncingTimeoutSpinBox);
+
     // Initialize the controls after all slots have been connected
     slotUpdate();
 }
 
 DlgPrefLibrary::~DlgPrefLibrary() = default;
 
+void DlgPrefLibrary::setFocusPolicyInstallEventFilter(QSpinBox* box) {
+    box->setFocusPolicy(Qt::StrongFocus);
+    box->installEventFilter(this);
+}
+
+// Catch scroll events over spinboxes and pass them to the scroll area instead.
+bool DlgPrefLibrary::eventFilter(QObject* obj, QEvent* e) {
+    if (e->type() == QEvent::Wheel) {
+        // Reject scrolling only if widget is unfocused.
+        // Object to widget cast is needed to check the focus state.
+        QSpinBox* spin = qobject_cast<QSpinBox*>(obj);
+        if (spin && !spin->hasFocus()) {
+            QApplication::sendEvent(verticalLayout, e);
+            return true;
+        }
+    }
+    return QObject::eventFilter(obj, e);
+}
 void DlgPrefLibrary::slotShow() {
     m_bAddedDirectory = false;
 }

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -12,6 +12,7 @@
 #include <QUrl>
 
 #include "defs_urls.h"
+#include "library/basetracktablemodel.h"
 #include "library/dlgtrackmetadataexport.h"
 #include "library/library.h"
 #include "library/library_prefs.h"
@@ -77,6 +78,13 @@ DlgPrefLibrary::DlgPrefLibrary(
             QOverload<int>::of(&QSpinBox::valueChanged),
             this,
             &DlgPrefLibrary::slotRowHeightValueChanged);
+
+    spinbox_bpm_precision->setMinimum(BaseTrackTableModel::kBpmColumnPrecisionMinimum);
+    spinbox_bpm_precision->setMaximum(BaseTrackTableModel::kBpmColumnPrecisionMaximum);
+    connect(spinbox_bpm_precision,
+            QOverload<int>::of(&QSpinBox::valueChanged),
+            this,
+            &DlgPrefLibrary::slotBpmColumnPrecisionChanged);
 
     searchDebouncingTimeoutSpinBox->setMinimum(WSearchLineEdit::kMinDebouncingTimeoutMillis);
     searchDebouncingTimeoutSpinBox->setMaximum(WSearchLineEdit::kMaxDebouncingTimeoutMillis);
@@ -199,14 +207,12 @@ void DlgPrefLibrary::slotResetToDefaults() {
     checkBox_SyncTrackMetadata->setChecked(false);
     checkBox_SeratoMetadataExport->setChecked(false);
     checkBox_use_relative_path->setChecked(false);
-    checkBox_show_rhythmbox->setChecked(true);
-    checkBox_show_banshee->setChecked(true);
-    checkBox_show_itunes->setChecked(true);
-    checkBox_show_traktor->setChecked(true);
-    checkBox_show_rekordbox->setChecked(true);
     checkBoxEditMetadataSelectedClicked->setChecked(kEditMetadataSelectedClickDefault);
     radioButton_dbclick_deck->setChecked(true);
+    spinbox_bpm_precision->setValue(BaseTrackTableModel::kBpmColumnPrecisionDefault);
+
     radioButton_cover_art_fetcher_medium->setChecked(true);
+
     spinBoxRowHeight->setValue(Library::kDefaultRowHeightPx);
     setLibraryFont(QApplication::font());
     searchDebouncingTimeoutSpinBox->setValue(
@@ -214,6 +220,12 @@ void DlgPrefLibrary::slotResetToDefaults() {
     checkBoxEnableSearchCompletions->setChecked(WSearchLineEdit::kCompletionsEnabledDefault);
     checkBoxEnableSearchHistoryShortcuts->setChecked(
             WSearchLineEdit::kHistoryShortcutsEnabledDefault);
+
+    checkBox_show_rhythmbox->setChecked(true);
+    checkBox_show_banshee->setChecked(true);
+    checkBox_show_itunes->setChecked(true);
+    checkBox_show_traktor->setChecked(true);
+    checkBox_show_rekordbox->setChecked(true);
 }
 
 void DlgPrefLibrary::slotUpdate() {
@@ -299,11 +311,18 @@ void DlgPrefLibrary::slotUpdate() {
     m_iOriginalTrackTableRowHeight = m_pLibrary->getTrackTableRowHeight();
     spinBoxRowHeight->setValue(m_iOriginalTrackTableRowHeight);
     setLibraryFont(m_originalTrackTableFont);
+
     const auto searchDebouncingTimeoutMillis =
             m_pConfig->getValue(
                     kSearchDebouncingTimeoutMillisConfigKey,
                     WSearchLineEdit::kDefaultDebouncingTimeoutMillis);
     searchDebouncingTimeoutSpinBox->setValue(searchDebouncingTimeoutMillis);
+
+    const auto bpmColumnPrecision =
+            m_pConfig->getValue(
+                    kBpmColumnPrecisionConfigKey,
+                    BaseTrackTableModel::kBpmColumnPrecisionDefault);
+    spinbox_bpm_precision->setValue(bpmColumnPrecision);
 }
 
 void DlgPrefLibrary::slotCancel() {
@@ -548,6 +567,13 @@ void DlgPrefLibrary::updateSearchLineEditHistoryOptions() {
     WSearchLineEdit::setSearchHistoryShortcutsEnabled(m_pConfig->getValue<bool>(
             kEnableSearchHistoryShortcutsConfigKey,
             WSearchLineEdit::kHistoryShortcutsEnabledDefault));
+}
+
+void DlgPrefLibrary::slotBpmColumnPrecisionChanged(int bpmPrecision) {
+    m_pConfig->setValue(
+            kBpmColumnPrecisionConfigKey,
+            bpmPrecision);
+    BaseTrackTableModel::setBpmColumnPrecision(bpmPrecision);
 }
 
 void DlgPrefLibrary::slotSyncTrackMetadataToggled() {

--- a/src/preferences/dialog/dlgpreflibrary.h
+++ b/src/preferences/dialog/dlgpreflibrary.h
@@ -61,6 +61,7 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
     void slotSelectFont();
     void slotSyncTrackMetadataToggled();
     void slotSearchDebouncingTimeoutMillisChanged(int);
+    void slotBpmColumnPrecisionChanged(int bpmPrecision);
     void slotSeratoMetadataExportClicked(bool);
 
   private:

--- a/src/preferences/dialog/dlgpreflibrary.h
+++ b/src/preferences/dialog/dlgpreflibrary.h
@@ -65,6 +65,8 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
     void slotSeratoMetadataExportClicked(bool);
 
   private:
+    void setFocusPolicyInstallEventFilter(QSpinBox* box);
+    bool eventFilter(QObject* object, QEvent* event) override;
     void initializeDirList();
     void setLibraryFont(const QFont& font);
     void updateSearchLineEditHistoryOptions();

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -204,6 +204,21 @@
        </widget>
       </item>
 
+      <item row="7" column="0">
+       <widget class="QLabel" name="bpmPrecisionLabel">
+        <property name="text">
+         <string>BPM display precision:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1" colspan="2">
+       <widget class="QSpinBox" name="spinbox_bpm_precision">
+       </widget>
+      </item>
+
      </layout>
     </widget>
    </item><!-- Track Table View -->
@@ -608,6 +623,7 @@
   <tabstop>radioButton_dbclick_bottom</tabstop>
   <tabstop>radioButton_dbclick_top</tabstop>
   <tabstop>radioButton_dbclick_ignore</tabstop>
+  <tabstop>bpmPrecisionSpinBox</tabstop>
   <tabstop>spinbox_history_track_duplicate_distance</tabstop>
   <tabstop>spinbox_history_min_tracks_to_keep</tabstop>
   <tabstop>checkBox_use_relative_path</tabstop>

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -153,7 +153,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_track_table_view">
 
-      <item row="1" column="0" colspan="2">
+      <item row="1" column="0" colspan="3">
        <widget class="QCheckBox" name="checkBoxEditMetadataSelectedClicked">
         <property name="text">
          <string>Edit metadata after clicking selected track</string>
@@ -161,7 +161,7 @@
        </widget>
       </item>
 
-      <item row="2" column="0">
+      <item row="2" column="0" colspan="3">
        <widget class="QLabel" name="doubeClickActionLabel">
         <property name="text">
          <string>Track Double-Click Action:</string>
@@ -172,7 +172,7 @@
        </widget>
       </item>
 
-      <item row="3" column="0">
+      <item row="3" column="0" colspan="3">
        <widget class="QRadioButton" name="radioButton_dbclick_deck">
         <property name="text">
          <string>Load track to next available deck</string>
@@ -182,21 +182,21 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
+      <item row="4" column="0" colspan="3">
        <widget class="QRadioButton" name="radioButton_dbclick_bottom">
         <property name="text">
          <string>Add track to Auto DJ queue (bottom)</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
+      <item row="5" column="0" colspan="3">
        <widget class="QRadioButton" name="radioButton_dbclick_top">
         <property name="text">
          <string>Add track to Auto DJ queue (top)</string>
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
+      <item row="6" column="0" colspan="3">
        <widget class="QRadioButton" name="radioButton_dbclick_ignore">
         <property name="text">
          <string>Ignore</string>
@@ -210,7 +210,7 @@
          <string>BPM display precision:</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
@@ -230,7 +230,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_history">
 
-      <item row="1" column="0" colspan="2">
+      <item row="1" column="0">
        <widget class="QLabel" name="label_history_track_duplicate_distance">
         <property name="text">
          <string>Track duplicate distance</string>
@@ -243,7 +243,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
+      <item row="1" column="1" colspan="2">
        <widget class="QSpinBox" name="spinbox_history_track_duplicate_distance">
         <property name="toolTip">
          <string>When playing a track again log it to the session history only if more than N other tracks have been played in the meantime</string>
@@ -260,7 +260,7 @@
        </widget>
       </item>
 
-      <item row="2" column="0" colspan="2">
+      <item row="2" column="0">
        <widget class="QLabel" name="label_history_cleanup">
         <property name="toolTip">
          <string>History playlist with less than N tracks will be deleted&lt;br/&gt;&lt;br/&gt;Note: the cleanup will be performed during startup and shutdown of Mixxx.</string>
@@ -273,7 +273,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="2">
+      <item row="2" column="1" colspan="2">
        <widget class="QSpinBox" name="spinbox_history_min_tracks_to_keep">
         <property name="minimum">
          <number>1</number>
@@ -312,7 +312,7 @@
          <string>Library Row Height:</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
@@ -339,7 +339,7 @@
          <string>Library Font:</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
@@ -364,7 +364,7 @@
          <string>Search-as-you-type timeout:</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -15,6 +15,7 @@
 #include "controllers/controllermanager.h"
 #include "controllers/keyboard/keyboardeventfilter.h"
 #include "effects/effectsmanager.h"
+#include "library/basetracktablemodel.h"
 #include "library/library.h"
 #include "library/library_prefs.h"
 #include "mixer/basetrackplayer.h"
@@ -1536,6 +1537,12 @@ QWidget* LegacySkinParser::parseLibrary(const QDomElement& node) {
     pLibraryWidget->installEventFilter(m_pKeyboard);
     pLibraryWidget->installEventFilter(m_pControllerManager->getControllerLearningEventFilter());
     pLibraryWidget->setup(node, *m_pContext);
+
+    const auto bpmColumnPrecision =
+            m_pConfig->getValue(
+                    mixxx::library::prefs::kBpmColumnPrecisionConfigKey,
+                    BaseTrackTableModel::kBpmColumnPrecisionDefault);
+    BaseTrackTableModel::setBpmColumnPrecision(bpmColumnPrecision);
 
     // Connect Library search signals to the WLibrary
     connect(m_pLibrary,


### PR DESCRIPTION
Right align BPM, duration & bitrate so big/small values can easily be spotted by length (number of digits).

Also adds 'BPM precision' to the Library preferences to set the number of decimals for the BPM column.