### PR TITLE
use ClampToEdge instead of ClampToBorder

### DIFF
--- a/src/util/texture.cpp
+++ b/src/util/texture.cpp
@@ -7,7 +7,7 @@ QOpenGLTexture* createTexture(const QImage& image) {
     QOpenGLTexture* pTexture = new QOpenGLTexture(image);
     pTexture->setMinificationFilter(QOpenGLTexture::Linear);
     pTexture->setMagnificationFilter(QOpenGLTexture::Linear);
-    pTexture->setWrapMode(QOpenGLTexture::ClampToBorder);
+    pTexture->setWrapMode(QOpenGLTexture::ClampToEdge);
 
     return pTexture;
 }


### PR DESCRIPTION
@daschuer you reported artifacts at the vu meter edges, and I fixed it but apparently the fix didn't make it into 2.4

From the Qt docs:

QOpenGLTexture::ClampToEdge | 0x812F | Clamps the texture coordinates to [0,1]
QOpenGLTexture::ClampToBorder | 0x812D | As for ClampToEdge but also blends samples at 0 and 1 with a fixed border color

so ClampToEdge is what we want