### PR TITLE
Remove usage of ControlObject::getControl

### DIFF
--- a/src/control/controlobject.cpp
+++ b/src/control/controlobject.cpp
@@ -67,6 +67,10 @@ ControlObject* ControlObject::getControl(const ConfigKey& key, ControlFlags flag
     return nullptr;
 }
 
+bool ControlObject::exists(const ConfigKey& key) {
+    return !ControlDoublePrivate::getControl(key, ControlFlag::NoWarnIfMissing).isNull();
+}
+
 void ControlObject::setValueFromMidi(MidiOpCode o, double v) {
     m_pControl->setValueFromMidi(o, v);
 }

--- a/src/control/controlobject.h
+++ b/src/control/controlobject.h
@@ -33,6 +33,9 @@ class ControlObject : public QObject {
         return getControl(key, flags);
     }
 
+    // Checks whether a ControlObject exists or not
+    static bool exists(const ConfigKey& key);
+
     QString name() const {
         return m_pControl ?  m_pControl->name() : QString();
     }

--- a/src/controllers/controllerlearningeventfilter.cpp
+++ b/src/controllers/controllerlearningeventfilter.cpp
@@ -4,6 +4,7 @@
 #include <QMouseEvent>
 #include <QtDebug>
 
+#include "control/pollingcontrolproxy.h"
 #include "moc_controllerlearningeventfilter.cpp"
 #include "widget/wknob.h"
 #include "widget/wknobcomposed.h"
@@ -19,7 +20,7 @@ ControllerLearningEventFilter::~ControllerLearningEventFilter() {
 }
 
 bool ControllerLearningEventFilter::eventFilter(QObject* pObject, QEvent* pEvent) {
-    //qDebug() << "ControllerLearningEventFilter::eventFilter" << pObject << pEvent;
+    // qDebug() << "ControllerLearningEventFilter::eventFilter" << pObject << pEvent;
 
     WWidget* pWidget = qobject_cast<WWidget*>(pObject);
     if (!pWidget || !m_bListening) {
@@ -42,10 +43,10 @@ bool ControllerLearningEventFilter::eventFilter(QObject* pObject, QEvent* pEvent
             if (info.leftClickControl) {
                 ConfigKey key = info.leftClickControl->getKey();
                 qDebug() << "Left-click maps MIDI to:" << key.group << key.item;
-                emit controlClicked(info.leftClickControl);
+                emit controlClicked(key);
             } else if (info.clickControl) {
                 ConfigKey key = info.clickControl->getKey();
-                emit controlClicked(info.clickControl);
+                emit controlClicked(key);
                 qDebug() << "Default-click maps MIDI to:" << key.group << key.item;
             } else {
                 qDebug() << "No control bound to left-click for" << pWidget;
@@ -55,7 +56,7 @@ bool ControllerLearningEventFilter::eventFilter(QObject* pObject, QEvent* pEvent
             if (info.rightClickControl) {
                 ConfigKey key = info.rightClickControl->getKey();
                 qDebug() << "Right-click maps MIDI to:" << key.group << key.item;
-                emit controlClicked(info.rightClickControl);
+                emit controlClicked(key);
             } else if (has_right_click_reset && (info.leftClickControl || info.clickControl)) {
                 // WKnob and WSliderComposed emits a reset signal on
                 // right-click. For controls that are derived from
@@ -67,15 +68,15 @@ bool ControllerLearningEventFilter::eventFilter(QObject* pObject, QEvent* pEvent
                 }
                 ConfigKey key = pControl->getKey();
                 key.item = key.item + "_set_default";
-                ControlObject* pResetControl = ControlObject::getControl(key);
-                if (pResetControl) {
+                auto pResetControl = PollingControlProxy(key, ControlFlag::AllowMissingOrInvalid);
+                if (pResetControl.valid()) {
                     qDebug() << "Right-click reset maps MIDI to:" << key.group << key.item;
-                    emit controlClicked(pResetControl);
+                    emit controlClicked(key);
                 }
             } else if (info.clickControl) {
                 ConfigKey key = info.clickControl->getKey();
                 qDebug() << "Default-click maps MIDI to:" << key.group << key.item;
-                emit controlClicked(info.clickControl);
+                emit controlClicked(key);
             } else {
                 qDebug() << "No control bound to right-click for" << pWidget;
             }
@@ -88,8 +89,8 @@ bool ControllerLearningEventFilter::eventFilter(QObject* pObject, QEvent* pEvent
     return false;
 }
 
-void ControllerLearningEventFilter::addWidgetClickInfo(
-        QWidget* pWidget, Qt::MouseButton buttonState,
+void ControllerLearningEventFilter::addWidgetClickInfo(QWidget* pWidget,
+        Qt::MouseButton buttonState,
         ControlObject* pControl,
         ControlParameterWidgetConnection::EmitOption emitOption) {
     ControlInfo& info = m_widgetControlInfo[pWidget];

--- a/src/controllers/controllerlearningeventfilter.cpp
+++ b/src/controllers/controllerlearningeventfilter.cpp
@@ -68,8 +68,7 @@ bool ControllerLearningEventFilter::eventFilter(QObject* pObject, QEvent* pEvent
                 }
                 ConfigKey key = pControl->getKey();
                 key.item = key.item + "_set_default";
-                auto pResetControl = PollingControlProxy(key, ControlFlag::AllowMissingOrInvalid);
-                if (pResetControl.valid()) {
+                if (ControlObject::exists(key)) {
                     qDebug() << "Right-click reset maps MIDI to:" << key.group << key.item;
                     emit controlClicked(key);
                 }

--- a/src/controllers/controllerlearningeventfilter.h
+++ b/src/controllers/controllerlearningeventfilter.h
@@ -41,7 +41,7 @@ class ControllerLearningEventFilter : public QObject {
     void stopListening();
 
   signals:
-    void controlClicked(ControlObject* pControl);
+    void controlClicked(const ConfigKey& controlKey);
 
   private:
     QHash<QWidget*, ControlInfo> m_widgetControlInfo;

--- a/src/controllers/dlgcontrollerlearning.cpp
+++ b/src/controllers/dlgcontrollerlearning.cpp
@@ -487,15 +487,11 @@ void DlgControllerLearning::controlPicked(const ConfigKey& control) {
     loadControl(control, title, description);
 }
 
-void DlgControllerLearning::controlClicked(ControlObject* pControl) {
-    if (!pControl) {
-        return;
-    }
-
-    ConfigKey key = pControl->getKey();
-    if (!m_pControlPickerMenu->controlExists(key)) {
+void DlgControllerLearning::controlClicked(const ConfigKey& controlKey) {
+    if (!m_pControlPickerMenu->controlExists(controlKey)) {
         qWarning() << "Mixxx UI element clicked for which there is no "
-                      "learnable control " << key.group << " " << key.item;
+                      "learnable control "
+                   << controlKey.group << " " << controlKey.item;
         QMessageBox::warning(
                 this,
                 VersionStore::applicationName(),
@@ -506,12 +502,12 @@ void DlgControllerLearning::controlClicked(ControlObject* pControl) {
                    " and can only be mapped to outputs like LEDs via"
                    " scripts.\n"
                    "\nYou tried to learn: %1,%2")
-                        .arg(key.group, key.item),
+                        .arg(controlKey.group, controlKey.item),
                 QMessageBox::Ok,
                 QMessageBox::Ok);
         return;
     }
-    controlPicked(key);
+    controlPicked(controlKey);
 }
 
 void DlgControllerLearning::comboboxIndexChanged(int index) {

--- a/src/controllers/dlgcontrollerlearning.h
+++ b/src/controllers/dlgcontrollerlearning.h
@@ -49,7 +49,7 @@ class DlgControllerLearning : public QDialog,
     // Triggered when the user picks a control from the menu.
     void controlPicked(const ConfigKey& control);
     // Triggered when user clicks a control from the GUI
-    void controlClicked(ControlObject* pControl);
+    void controlClicked(const ConfigKey& controlKey);
     void comboboxIndexChanged(int index);
 
     void slotMessageReceived(unsigned char status,


### PR DESCRIPTION
This is a small PR removing one usage of `ControlObject::getControl`, which we want to eventually remove AFAIU.