### PR TITLE
fix #11603 table draw delaying the waveformwidgetfactory render and swap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1126,6 +1126,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/waveform/visualplayposition.cpp
   src/waveform/waveform.cpp
   src/waveform/waveformfactory.cpp
+  src/waveform/waveformwidgetfactory.cpp
   src/widget/controlwidgetconnection.cpp
   src/widget/findonwebmenufactory.cpp
   src/widget/findonwebmenuservices/findonwebmenudiscogs.cpp
@@ -1244,7 +1245,6 @@ else()
     src/waveform/visualsmanager.cpp
     src/waveform/vsyncthread.cpp
     src/waveform/waveformmarklabel.cpp
-    src/waveform/waveformwidgetfactory.cpp
     src/waveform/widgets/emptywaveformwidget.cpp
     src/waveform/widgets/glrgbwaveformwidget.cpp
     src/waveform/widgets/glsimplewaveformwidget.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -844,6 +844,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/library/dao/settingsdao.cpp
   src/library/dao/trackdao.cpp
   src/library/dao/trackschema.cpp
+  src/library/defaultdelegate.cpp
   src/library/dlganalysis.cpp
   src/library/dlganalysis.ui
   src/library/dlgcoverartfullsize.cpp

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -8,6 +8,7 @@
 #include "library/coverartcache.h"
 #include "library/coverartdelegate.h"
 #include "library/dao/trackschema.h"
+#include "library/defaultdelegate.h"
 #include "library/locationdelegate.h"
 #include "library/multilineeditdelegate.h"
 #include "library/previewbuttondelegate.h"
@@ -416,7 +417,7 @@ QAbstractItemDelegate* BaseTrackTableModel::delegateForColumn(
                 &BaseTrackTableModel::slotRefreshCoverRows);
         return pCoverArtDelegate;
     }
-    return nullptr;
+    return new DefaultDelegate(pTableView);
 }
 
 QVariant BaseTrackTableModel::data(

--- a/src/library/defaultdelegate.cpp
+++ b/src/library/defaultdelegate.cpp
@@ -1,0 +1,37 @@
+#include "library/defaultdelegate.h"
+
+#include <QCoreApplication>
+#include <QPainter>
+
+#include "mixxxapplication.h"
+#include "moc_defaultdelegate.cpp"
+
+DefaultDelegate::DefaultDelegate(QTableView* pTableView)
+        : QStyledItemDelegate(pTableView), m_pTableView(pTableView) {
+}
+
+void DefaultDelegate::paint(
+        QPainter* painter,
+        const QStyleOptionViewItem& option,
+        const QModelIndex& index) const {
+    processTimeSensitiveEvents(painter);
+    QStyledItemDelegate::paint(painter, option, index);
+}
+
+void DefaultDelegate::processTimeSensitiveEvents(QPainter* painter) const {
+    // Drawing the table can be slow, resulting in time sensitive events not
+    // being delivered in time. (The WaveformWidgetFactory not receiving its
+    // render and swap signals in time). We force processing these events
+    // during the drawing of the table cells to fix this.
+    auto app = qobject_cast<MixxxApplication*>(QCoreApplication::instance());
+    if (app->hasTimeSensitiveEvents()) {
+        QPaintDevice* device = painter->device();
+        if (device) {
+            painter->end();
+        }
+        app->processTimeSensitiveEvents();
+        if (device) {
+            painter->begin(device);
+        }
+    }
+}

--- a/src/library/defaultdelegate.h
+++ b/src/library/defaultdelegate.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <QStyledItemDelegate>
+#include <QTableView>
+
+class DefaultDelegate : public QStyledItemDelegate {
+    Q_OBJECT
+  public:
+    explicit DefaultDelegate(
+            QTableView* pTableView);
+    ~DefaultDelegate() override = default;
+
+    void paint(
+            QPainter* painter,
+            const QStyleOptionViewItem& option,
+            const QModelIndex& index) const override;
+
+  protected:
+    void processTimeSensitiveEvents(QPainter* painter) const;
+
+    QTableView* m_pTableView;
+};

--- a/src/library/tableitemdelegate.cpp
+++ b/src/library/tableitemdelegate.cpp
@@ -80,5 +80,5 @@ void TableItemDelegate::paintItem(
         QPainter* painter,
         const QStyleOptionViewItem& option,
         const QModelIndex& index) const {
-    QStyledItemDelegate::paint(painter, option, index);
+    DefaultDelegate::paint(painter, option, index);
 }

--- a/src/library/tableitemdelegate.cpp
+++ b/src/library/tableitemdelegate.cpp
@@ -3,13 +3,13 @@
 #include <QPainter>
 #include <QTableView>
 
+#include "mixxxapplication.h"
 #include "moc_tableitemdelegate.cpp"
 #include "util/painterscope.h"
 #include "widget/wtracktableview.h"
 
 TableItemDelegate::TableItemDelegate(QTableView* pTableView)
-        : QStyledItemDelegate(pTableView),
-          m_pTableView(pTableView) {
+        : DefaultDelegate(pTableView) {
     DEBUG_ASSERT(m_pTableView);
     auto* pTrackTableView = qobject_cast<WTrackTableView*>(m_pTableView);
     if (pTrackTableView) {
@@ -21,6 +21,8 @@ void TableItemDelegate::paint(
         QPainter* painter,
         const QStyleOptionViewItem& option,
         const QModelIndex& index) const {
+    processTimeSensitiveEvents(painter);
+
     PainterScope painterScope(painter);
     painter->setClipRect(option.rect);
 

--- a/src/library/tableitemdelegate.h
+++ b/src/library/tableitemdelegate.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <QStyledItemDelegate>
 #include <QTableView>
 
-class TableItemDelegate : public QStyledItemDelegate {
+#include "library/defaultdelegate.h"
+
+class TableItemDelegate : public DefaultDelegate {
     Q_OBJECT
   public:
     explicit TableItemDelegate(
@@ -29,5 +30,4 @@ class TableItemDelegate : public QStyledItemDelegate {
     int columnWidth(const QModelIndex &index) const;
 
     QColor m_pFocusBorderColor;
-    QTableView* m_pTableView;
 };

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -17,6 +17,7 @@
 #include "util/color/rgbcolor.h"
 #include "util/fileinfo.h"
 #include "util/math.h"
+#include "waveform/waveformwidgetfactory.h"
 
 // When linking Qt statically, the Q_IMPORT_PLUGIN is needed for each linked plugin.
 // https://doc.qt.io/qt-5/plugins-howto.html#details-of-linking-static-plugins
@@ -169,6 +170,14 @@ bool MixxxApplication::notify(QObject* target, QEvent* event) {
         break;
     }
     return QApplication::notify(target, event);
+}
+
+bool MixxxApplication::hasTimeSensitiveEvents() const {
+    return WaveformWidgetFactory::instance()->hasPendingTimeSensitiveEvents();
+}
+
+void MixxxApplication::processTimeSensitiveEvents() {
+    QCoreApplication::sendPostedEvents(WaveformWidgetFactory::instance());
 }
 
 bool MixxxApplication::touchIsRightButton() {

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -172,14 +172,6 @@ bool MixxxApplication::notify(QObject* target, QEvent* event) {
     return QApplication::notify(target, event);
 }
 
-bool MixxxApplication::hasTimeSensitiveEvents() const {
-    return WaveformWidgetFactory::instance()->hasPendingTimeSensitiveEvents();
-}
-
-void MixxxApplication::processTimeSensitiveEvents() {
-    QCoreApplication::sendPostedEvents(WaveformWidgetFactory::instance());
-}
-
 bool MixxxApplication::touchIsRightButton() {
     if (!m_pTouchShift) {
         m_pTouchShift = new ControlProxy(
@@ -188,3 +180,11 @@ bool MixxxApplication::touchIsRightButton() {
     return m_pTouchShift->toBool();
 }
 #endif
+
+bool MixxxApplication::hasTimeSensitiveEvents() const {
+    return WaveformWidgetFactory::instance()->hasPendingTimeSensitiveEvents();
+}
+
+void MixxxApplication::processTimeSensitiveEvents() {
+    QCoreApplication::sendPostedEvents(WaveformWidgetFactory::instance());
+}

--- a/src/mixxxapplication.h
+++ b/src/mixxxapplication.h
@@ -12,6 +12,8 @@ class MixxxApplication : public QApplication {
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     bool notify(QObject*, QEvent*) override;
+    bool hasTimeSensitiveEvents() const;
+    void processTimeSensitiveEvents();
 #endif
 
   private:

--- a/src/mixxxapplication.h
+++ b/src/mixxxapplication.h
@@ -12,9 +12,9 @@ class MixxxApplication : public QApplication {
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     bool notify(QObject*, QEvent*) override;
+#endif
     bool hasTimeSensitiveEvents() const;
     void processTimeSensitiveEvents();
-#endif
 
   private:
     bool touchIsRightButton();

--- a/src/waveform/visualplayposition.h
+++ b/src/waveform/visualplayposition.h
@@ -9,11 +9,7 @@
 #include "util/performancetimer.h"
 
 class ControlProxy;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-typedef void VSyncThread;
-#else
 class VSyncThread;
-#endif
 
 // This class is for synchronizing the sound device DAC time with the waveforms, displayed on the
 // graphic device, using the CPU time

--- a/src/waveform/vsyncthread.cpp
+++ b/src/waveform/vsyncthread.cpp
@@ -53,6 +53,7 @@ void VSyncThread::run() {
             usleep(1000);
         } else { // if (m_vSyncMode == ST_TIMER) {
             emit vsyncRender(); // renders the new waveform.
+            setHasPendingRender(true);
 
             // wait until rendering was scheduled. It might be delayed due a
             // pending swap (depends one driver vSync settings)
@@ -68,6 +69,7 @@ void VSyncThread::run() {
 
             // swaps the new waveform to front in case of gl-wf
             emit vsyncSwap();
+            setHasPendingSwap(true);
 
             // wait until swap occurred. It might be delayed due to driver vSync
             // settings.

--- a/src/waveform/vsyncthread.h
+++ b/src/waveform/vsyncthread.h
@@ -41,6 +41,19 @@ class VSyncThread : public QThread {
     int getSyncIntervalTimeMicros() const {
         return m_syncIntervalTimeMicros;
     }
+    bool hasPendingRender() const {
+        return m_hasPendingRender.load();
+    }
+    bool hasPendingSwap() const {
+        return m_hasPendingSwap.load();
+    }
+
+    void setHasPendingRender(bool value) {
+        m_hasPendingRender.store(value);
+    }
+    void setHasPendingSwap(bool value) {
+        m_hasPendingSwap.store(value);
+    }
   signals:
     void vsyncRender();
     void vsyncSwap();
@@ -59,4 +72,6 @@ class VSyncThread : public QThread {
     double m_displayFrameRate;
     int m_vSyncPerRendering;
     mixxx::Duration m_sinceLastSwap;
+    std::atomic<bool> m_hasPendingRender{};
+    std::atomic<bool> m_hasPendingSwap{};
 };

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -708,6 +708,7 @@ void WaveformWidgetFactory::notifyZoomChange(WWaveformViewer* viewer) {
 }
 
 void WaveformWidgetFactory::render() {
+    m_vsyncThread->setHasPendingRender(false);
     ScopedTimer t("WaveformWidgetFactory::render() %1waveforms",
             static_cast<int>(m_waveformWidgetHolders.size()));
 
@@ -783,6 +784,7 @@ void WaveformWidgetFactory::render() {
 }
 
 void WaveformWidgetFactory::swap() {
+    m_vsyncThread->setHasPendingSwap(false);
     ScopedTimer t("WaveformWidgetFactory::swap() %1waveforms",
             static_cast<int>(m_waveformWidgetHolders.size()));
 
@@ -1223,4 +1225,8 @@ QSurfaceFormat WaveformWidgetFactory::getSurfaceFormat() {
     format.setSwapInterval(0);
 #endif
     return format;
+}
+
+bool WaveformWidgetFactory::hasPendingTimeSensitiveEvents() const {
+    return m_vsyncThread->hasPendingSwap() || m_vsyncThread->hasPendingRender();
 }

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -141,6 +141,7 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
 
     WaveformWidgetType::Type autoChooseWidgetType() const;
 
+    bool hasPendingTimeSensitiveEvents() const;
   signals:
     void waveformUpdateTick();
     void waveformMeasured(float frameRate, int droppedFrames);


### PR DESCRIPTION
Drawing the table can be slow (profiling points to the text rendering, so there is no easy way to improve this). As a result the paintEvent holds up the event loop and the WaveformWidgetFactory may not receive its render and swap signal meta events in time. See https://github.com/mixxxdj/mixxx/issues/11603

This PR fixes this by forcing the processing of such time sensitive events during the drawing of the table cells (in the paint call of each cell) to fix this.
