### PR TITLE
fix macOS slider styling in preferences dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1258,6 +1258,10 @@ if(APPLE)
   # will automatically insert retain/release calls on Objective-C objects.
   target_compile_options(mixxx-lib PUBLIC -fobjc-arc)
 
+  target_sources(mixxx-lib PRIVATE
+    src/util/darkappearance.mm
+  )
+
   option(MACOS_ITUNES_LIBRARY "Native macOS iTunes/Music.app library integration" ON)
   if(MACOS_ITUNES_LIBRARY)
     target_sources(mixxx-lib PRIVATE

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -48,6 +48,10 @@
 #include "util/color/color.h"
 #include "util/widgethelper.h"
 
+#ifdef __APPLE__
+#include "util/darkappearance.h"
+#endif
+
 DlgPreferences::DlgPreferences(
         std::shared_ptr<mixxx::ScreensaverManager> pScreensaverManager,
         std::shared_ptr<mixxx::skin::SkinLoader> pSkinLoader,
@@ -61,6 +65,7 @@ DlgPreferences::DlgPreferences(
           m_pConfig(pSettingsManager->settings()),
           m_pageSizeHint(QSize(0, 0)) {
     setupUi(this);
+    fixSliderStyle();
     contentsTreeWidget->setHeaderHidden(true);
 
     // Add '&' to default button labels to always have Alt shortcuts, indpependent
@@ -563,4 +568,55 @@ QRect DlgPreferences::getDefaultGeometry() {
     optimumRect.setSize(optimumSize);
 
     return optimumRect;
+}
+
+void DlgPreferences::fixSliderStyle() {
+#ifdef __APPLE__
+    // Only used on macOS where the default slider style has several issues:
+    // - the handle is semi-transparent
+    // - the slider is higher than the space we give it, which causes that:
+    //   - the groove is not correctly centered vertically
+    //   - the handle is cut off at the top
+    // The style below is based on sliders in the macOS system settings dialogs.
+    if (darkAppearance()) {
+        setStyleSheet(R"--(
+QSlider::handle:horizontal {
+    background-color: #8f8c8b; 
+    border-radius: 4px;
+    width: 8px;
+    margin: -8px;
+} 
+QSlider::handle:horizontal::pressed {
+    background-color: #a9a7a7;
+}
+QSlider::groove:horizontal {
+    background: #1e1e1e; 
+    height: 4px;
+    border-radius: 2px;
+    margin-left: 8px; 
+    margin-right: 8px;
+}
+)--");
+    } else {
+        setStyleSheet(R"--(
+QSlider::handle:horizontal {
+    background-color: #ffffff;
+    border-radius: 4px;
+    border: 1px solid #d4d3d3;
+    width: 7px;
+    margin: -8px;
+}
+QSlider::handle:horizontal::pressed {
+    background-color: #ececec;
+}
+QSlider::groove:horizontal {
+    background: #c6c5c5;
+    height: 4px;
+    border-radius: 2px;
+    margin-left: 8px;
+    margin-right: 8px;
+}
+)--");
+    }
+#endif // __APPLE__
 }

--- a/src/preferences/dialog/dlgpreferences.h
+++ b/src/preferences/dialog/dlgpreferences.h
@@ -111,6 +111,7 @@ class DlgPreferences : public QDialog, public Ui::DlgPreferencesDlg {
 
   private:
     DlgPreferencePage* currentPage();
+    void fixSliderStyle();
     QList<PreferencesPage> m_allPages;
     void onShow();
     void onHide();

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -490,7 +490,7 @@ Select from different types of displays for the waveform, which differ primarily
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="4" column="1" colspan="2">
       <widget class="QSlider" name="beatGridAlphaSlider">
        <property name="maximum">
         <number>100</number>

--- a/src/util/darkappearance.h
+++ b/src/util/darkappearance.h
@@ -1,0 +1,1 @@
+bool darkAppearance();

--- a/src/util/darkappearance.mm
+++ b/src/util/darkappearance.mm
@@ -1,0 +1,14 @@
+#include "util/darkappearance.h"
+#import <AppKit/NSApplication.h>
+
+bool darkAppearance() {
+    if (__builtin_available(macOS 10.14, *)) {
+        auto appearance =
+                [NSApp.effectiveAppearance bestMatchFromAppearancesWithNames:@[
+                    NSAppearanceNameAqua,
+                    NSAppearanceNameDarkAqua
+                ]];
+        return [appearance isEqualToString:NSAppearanceNameDarkAqua];
+    }
+    return false;
+}


### PR DESCRIPTION
This PR fixes several issues with sliders in the preferences dialog:

- the handle is semi-transparent
- the groove is not correctly centered vertically in relation to the widgets left and right of it
- the handle is cut off at the top (the last two issues seem to be a consequence of the slider being higher than the space reserved for it in the layout)
- the style of the handle seems based on older versions of macOS.

The fix simply uses a different style sheet for these sliders, that fixes all these issues (the look is based on the sliders as can be found in the macOS system settings).

The PR also includes obj-c code to check if macOS is set up to use dark or light appearance, and a different style sheet is used accordingly.

This is a very non-invasive fix so I don't see any risk of regression. 


