### PR TITLE
controller_mapping_validation_test: Support all 2.4 controller mapping API functions

### DIFF
--- a/src/test/controller_mapping_validation_test.cpp
+++ b/src/test/controller_mapping_validation_test.cpp
@@ -5,16 +5,53 @@
 #include "controllers/defs_controllers.h"
 #include "moc_controller_mapping_validation_test.cpp"
 
-FakeControllerJSProxy::FakeControllerJSProxy()
+FakeMidiControllerJSProxy::FakeMidiControllerJSProxy()
         : ControllerJSProxy(nullptr) {
 }
 
-void FakeControllerJSProxy::send(const QList<int>& data, unsigned int length) {
+void FakeMidiControllerJSProxy::send(const QList<int>& data, unsigned int length) {
+    Q_UNUSED(data);
+    Q_UNUSED(length);
+    qInfo() << "LINT: Prefer to use sendSysexMsg instead of the generic alias send!";
+}
+
+void FakeMidiControllerJSProxy::sendSysexMsg(const QList<int>& data, unsigned int length) {
     Q_UNUSED(data);
     Q_UNUSED(length);
 }
 
-void FakeControllerJSProxy::sendOutputReport(quint8 reportID,
+void FakeMidiControllerJSProxy::sendShortMsg(unsigned char status,
+        unsigned char byte1,
+        unsigned char byte2) {
+    Q_UNUSED(status);
+    Q_UNUSED(byte1);
+    Q_UNUSED(byte2);
+}
+
+FakeHidControllerJSProxy::FakeHidControllerJSProxy()
+        : ControllerJSProxy(nullptr) {
+}
+
+void FakeHidControllerJSProxy::send(const QList<int>& data, unsigned int length) {
+    Q_UNUSED(data);
+    Q_UNUSED(length);
+
+    qInfo() << "LINT: Prefer to use sendOutputReport instead of send!";
+}
+
+void FakeHidControllerJSProxy::send(const QList<int>& dataList,
+        unsigned int length,
+        quint8 reportID,
+        bool useNonSkippingFIFO) {
+    Q_UNUSED(dataList);
+    Q_UNUSED(length);
+    Q_UNUSED(reportID);
+    Q_UNUSED(useNonSkippingFIFO);
+
+    qInfo() << "LINT: Prefer to use sendOutputReport instead of send!";
+}
+
+void FakeHidControllerJSProxy::sendOutputReport(quint8 reportID,
         const QByteArray& dataArray,
         bool resendUnchangedReport) {
     Q_UNUSED(reportID);
@@ -22,17 +59,31 @@ void FakeControllerJSProxy::sendOutputReport(quint8 reportID,
     Q_UNUSED(resendUnchangedReport);
 }
 
-void FakeControllerJSProxy::sendSysexMsg(const QList<int>& data, unsigned int length) {
-    Q_UNUSED(data);
-    Q_UNUSED(length);
+QByteArray FakeHidControllerJSProxy::getInputReport(
+        quint8 reportID) {
+    Q_UNUSED(reportID);
+    return QByteArray();
 }
 
-void FakeControllerJSProxy::sendShortMsg(unsigned char status,
-        unsigned char byte1,
-        unsigned char byte2) {
-    Q_UNUSED(status);
-    Q_UNUSED(byte1);
-    Q_UNUSED(byte2);
+void FakeHidControllerJSProxy::sendFeatureReport(
+        quint8 reportID, const QByteArray& reportData) {
+    Q_UNUSED(reportID);
+    Q_UNUSED(reportData);
+}
+
+QByteArray FakeHidControllerJSProxy::getFeatureReport(
+        quint8 reportID) {
+    Q_UNUSED(reportID);
+    return QByteArray();
+}
+
+FakeBulkControllerJSProxy::FakeBulkControllerJSProxy()
+        : ControllerJSProxy(nullptr) {
+}
+
+void FakeBulkControllerJSProxy::send(const QList<int>& data, unsigned int length) {
+    Q_UNUSED(data);
+    Q_UNUSED(length);
 }
 
 FakeController::FakeController()

--- a/src/test/controller_mapping_validation_test.h
+++ b/src/test/controller_mapping_validation_test.h
@@ -8,10 +8,10 @@
 #include "controllers/midi/legacymidicontrollermapping.h"
 #include "test/mixxxtest.h"
 
-class FakeControllerJSProxy : public ControllerJSProxy {
+class FakeMidiControllerJSProxy : public ControllerJSProxy {
     Q_OBJECT
   public:
-    FakeControllerJSProxy();
+    FakeMidiControllerJSProxy();
 
     Q_INVOKABLE void send(const QList<int>& data, unsigned int length = 0) override;
 
@@ -20,10 +20,36 @@ class FakeControllerJSProxy : public ControllerJSProxy {
     Q_INVOKABLE void sendShortMsg(unsigned char status,
             unsigned char byte1,
             unsigned char byte2);
+};
+
+class FakeHidControllerJSProxy : public ControllerJSProxy {
+    Q_OBJECT
+  public:
+    FakeHidControllerJSProxy();
+
+    Q_INVOKABLE void send(const QList<int>& data, unsigned int length = 0) override;
+    Q_INVOKABLE void send(const QList<int>& dataList,
+            unsigned int length,
+            quint8 reportID,
+            bool useNonSkippingFIFO = false);
 
     Q_INVOKABLE void sendOutputReport(quint8 reportID,
             const QByteArray& dataArray,
             bool resendUnchangedReport = false);
+    Q_INVOKABLE QByteArray getInputReport(
+            quint8 reportID);
+    Q_INVOKABLE void sendFeatureReport(
+            quint8 reportID, const QByteArray& reportData);
+    Q_INVOKABLE QByteArray getFeatureReport(
+            quint8 reportID);
+};
+
+class FakeBulkControllerJSProxy : public ControllerJSProxy {
+    Q_OBJECT
+  public:
+    FakeBulkControllerJSProxy();
+
+    Q_INVOKABLE void send(const QList<int>& data, unsigned int length = 0) override;
 };
 
 class FakeController : public Controller {
@@ -38,7 +64,14 @@ class FakeController : public Controller {
     }
 
     ControllerJSProxy* jsProxy() override {
-        return new FakeControllerJSProxy();
+        if (this->m_bMidiMapping == true) {
+            return new FakeMidiControllerJSProxy();
+        }
+        if (this->m_bHidMapping == true) {
+            return new FakeHidControllerJSProxy();
+        }
+        // Bulk mapping
+        return new FakeBulkControllerJSProxy();
     }
 
     void setMapping(std::shared_ptr<LegacyControllerMapping> pMapping) override {


### PR DESCRIPTION
- Not all HID API functions were allowed in controller_mapping_validation_test
- controller_mapping_validation_test wouldn't have detect, if the HID function sendOutputReport would have been used in MIDI or BULK mappings
- Now there is a hint printed, if somebody uses send for HID or MIDI were newer more specific alternatives exist