### PR TITLE
Preferences: use helper for input widget scroll safeguard

### DIFF
--- a/src/preferences/dialog/dlgprefautodj.cpp
+++ b/src/preferences/dialog/dlgprefautodj.cpp
@@ -61,6 +61,8 @@ DlgPrefAutoDJ::DlgPrefAutoDJ(QWidget* pParent,
             QOverload<int>::of(&QSpinBox::valueChanged),
             this,
             &DlgPrefAutoDJ::slotSetRandomQueueMin);
+
+    setScrollSafeGuardForAllInputWidgets(this);
 }
 
 DlgPrefAutoDJ::~DlgPrefAutoDJ() {

--- a/src/preferences/dialog/dlgprefbeats.cpp
+++ b/src/preferences/dialog/dlgprefbeats.cpp
@@ -47,6 +47,8 @@ DlgPrefBeats::DlgPrefBeats(QWidget* parent, UserSettingsPointer pConfig)
             &QCheckBox::stateChanged,
             this,
             &DlgPrefBeats::slotReanalyzeImportedChanged);
+
+    setScrollSafeGuard(comboBoxBeatPlugin);
 }
 
 DlgPrefBeats::~DlgPrefBeats() {

--- a/src/preferences/dialog/dlgprefbroadcast.cpp
+++ b/src/preferences/dialog/dlgprefbroadcast.cpp
@@ -158,6 +158,8 @@ DlgPrefBroadcast::DlgPrefBroadcast(QWidget *parent,
              &QCheckBox::stateChanged,
              this,
              &DlgPrefBroadcast::enableCustomMetadataChanged);
+
+     setScrollSafeGuardForAllInputWidgets(this);
 }
 
 DlgPrefBroadcast::~DlgPrefBroadcast() {

--- a/src/preferences/dialog/dlgprefcolors.cpp
+++ b/src/preferences/dialog/dlgprefcolors.cpp
@@ -69,6 +69,7 @@ DlgPrefColors::DlgPrefColors(
             &DlgPrefColors::slotReplaceCueColorClicked);
 
     loadSettings();
+    setScrollSafeGuardForAllInputWidgets(this);
 }
 
 DlgPrefColors::~DlgPrefColors() {

--- a/src/preferences/dialog/dlgprefcolors.cpp
+++ b/src/preferences/dialog/dlgprefcolors.cpp
@@ -68,18 +68,15 @@ DlgPrefColors::DlgPrefColors(
             this,
             &DlgPrefColors::slotReplaceCueColorClicked);
 
-    loadSettings();
     setScrollSafeGuardForAllInputWidgets(this);
+
+    slotUpdate();
 }
 
 DlgPrefColors::~DlgPrefColors() {
 }
 
 void DlgPrefColors::slotUpdate() {
-    loadSettings();
-}
-
-void DlgPrefColors::loadSettings() {
     comboBoxHotcueColors->clear();
     comboBoxTrackColors->clear();
     for (const auto& palette : qAsConst(mixxx::PredefinedColorPalettes::kPalettes)) {

--- a/src/preferences/dialog/dlgprefcolors.h
+++ b/src/preferences/dialog/dlgprefcolors.h
@@ -24,6 +24,7 @@ class DlgPrefColors : public DlgPreferencePage, public Ui::DlgPrefColorsDlg {
 
   public slots:
     /// Called when the preference dialog (not this page) is shown to the user.
+    /// Loads the config keys and sets the widgets in the dialog to match
     void slotUpdate() override;
     /// Called when the user clicks the global "Apply" button.
     void slotApply() override;
@@ -43,8 +44,6 @@ class DlgPrefColors : public DlgPreferencePage, public Ui::DlgPrefColorsDlg {
     void slotEditHotcuePaletteClicked();
 
   private:
-    /// Loads the config keys and sets the widgets in the dialog to match
-    void loadSettings();
     void openColorPaletteEditor(
             const QString& paletteName,
             bool editHotcuePalette);

--- a/src/preferences/dialog/dlgpreferencepage.cpp
+++ b/src/preferences/dialog/dlgpreferencepage.cpp
@@ -1,5 +1,13 @@
 #include "preferences/dialog/dlgpreferencepage.h"
 
+#include <QApplication>
+#include <QComboBox>
+#include <QDoubleSpinBox>
+#include <QGroupBox>
+#include <QLayout>
+#include <QSlider>
+#include <QSpinBox>
+
 #include "defs_urls.h"
 #include "moc_dlgpreferencepage.cpp"
 
@@ -12,4 +20,64 @@ DlgPreferencePage::~DlgPreferencePage() {
 
 QUrl DlgPreferencePage::helpUrl() const {
     return QUrl();
+}
+
+void DlgPreferencePage::setScrollSafeGuardForAllInputWidgets(QObject* obj) {
+    // Set the focus policy to for scrollable input widgets and connect them
+    // to the custom event filter
+    for (auto* ch : obj->children()) {
+        // children() does not descend into QGroupBox,
+        // so we need to do it manually
+        QGroupBox* gBox = qobject_cast<QGroupBox*>(ch);
+        if (gBox) {
+            setScrollSafeGuardForAllInputWidgets(gBox);
+            continue;
+        }
+
+        QComboBox* combo = qobject_cast<QComboBox*>(ch);
+        if (combo) {
+            setScrollSafeGuard(combo);
+            continue;
+        }
+        QSpinBox* spin = qobject_cast<QSpinBox*>(ch);
+        if (spin) {
+            setScrollSafeGuard(spin);
+            continue;
+        }
+        QDoubleSpinBox* spinDouble = qobject_cast<QDoubleSpinBox*>(ch);
+        if (spinDouble) {
+            setScrollSafeGuard(spinDouble);
+            continue;
+        }
+        QSlider* slider = qobject_cast<QSlider*>(ch);
+        if (slider) {
+            setScrollSafeGuard(slider);
+            continue;
+        }
+    }
+}
+
+void DlgPreferencePage::setScrollSafeGuard(QWidget* pWidget) {
+    pWidget->setFocusPolicy(Qt::StrongFocus);
+    pWidget->installEventFilter(this);
+}
+
+bool DlgPreferencePage::eventFilter(QObject* obj, QEvent* e) {
+    if (e->type() == QEvent::Wheel) {
+        // Reject scrolling only if widget is unfocused.
+        // Object to widget cast is needed to check the focus state.
+        QComboBox* combo = qobject_cast<QComboBox*>(obj);
+        QSpinBox* spin = qobject_cast<QSpinBox*>(obj);
+        QDoubleSpinBox* spinDbl = qobject_cast<QDoubleSpinBox*>(obj);
+        QSlider* slider = qobject_cast<QSlider*>(obj);
+        if ((combo && !combo->hasFocus()) ||
+                (spin && !spin->hasFocus()) ||
+                (spinDbl && !spinDbl->hasFocus()) ||
+                (slider && !slider->hasFocus())) {
+            QApplication::sendEvent(qobject_cast<QObject*>(layout()), e);
+            // QApplication::sendEvent(layout()->parent(), e); ??
+            return true;
+        }
+    }
+    return QObject::eventFilter(obj, e);
 }

--- a/src/preferences/dialog/dlgpreferencepage.h
+++ b/src/preferences/dialog/dlgpreferencepage.h
@@ -19,6 +19,14 @@ class DlgPreferencePage : public QWidget {
     /// overriding this. The default implementation returns an invalid QUrl.
     virtual QUrl helpUrl() const;
 
+    void setScrollSafeGuardForAllInputWidgets(QObject* obj);
+    /// Avoid undesired value changes when scrolling a preferences page while
+    /// the pointer is above an input widget (QSpinBox, QComboBox, QSlider):
+    /// * set the focus policy to Qt::StrongFocus (focusable by click & tab key)
+    /// * forward wheel events to the top-level layout
+    void setScrollSafeGuard(QWidget* pWidget);
+    bool eventFilter(QObject* obj, QEvent* e);
+
     QColor m_pLinkColor;
 
   public slots:

--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -205,6 +205,8 @@ DlgPrefInterface::DlgPrefInterface(
                 slotSetTooltips();
             });
 
+    setScrollSafeGuardForAllInputWidgets(this);
+
     slotUpdate();
 }
 

--- a/src/preferences/dialog/dlgprefkey.cpp
+++ b/src/preferences/dialog/dlgprefkey.cpp
@@ -55,6 +55,8 @@ DlgPrefKey::DlgPrefKey(QWidget* parent, UserSettingsPointer pConfig)
     // Connections
     connect(plugincombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
             this, &DlgPrefKey::pluginSelected);
+    setScrollSafeGuard(plugincombo);
+
     connect(banalyzerenabled, &QCheckBox::stateChanged,
             this, &DlgPrefKey::analyzerEnabled);
     connect(bfastAnalysisEnabled, &QCheckBox::stateChanged,

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -134,12 +134,7 @@ DlgPrefLibrary::DlgPrefLibrary(
             this,
             &DlgPrefLibrary::slotSyncTrackMetadataToggled);
 
-    // Avoid undesired spinbox value changes while scrolling the preferences page
-    setFocusPolicyInstallEventFilter(spinbox_bpm_precision);
-    setFocusPolicyInstallEventFilter(spinbox_history_track_duplicate_distance);
-    setFocusPolicyInstallEventFilter(spinbox_history_min_tracks_to_keep);
-    setFocusPolicyInstallEventFilter(spinBoxRowHeight);
-    setFocusPolicyInstallEventFilter(searchDebouncingTimeoutSpinBox);
+    setScrollSafeGuardForAllInputWidgets(this);
 
     // Initialize the controls after all slots have been connected
     slotUpdate();
@@ -147,24 +142,6 @@ DlgPrefLibrary::DlgPrefLibrary(
 
 DlgPrefLibrary::~DlgPrefLibrary() = default;
 
-void DlgPrefLibrary::setFocusPolicyInstallEventFilter(QSpinBox* box) {
-    box->setFocusPolicy(Qt::StrongFocus);
-    box->installEventFilter(this);
-}
-
-// Catch scroll events over spinboxes and pass them to the scroll area instead.
-bool DlgPrefLibrary::eventFilter(QObject* obj, QEvent* e) {
-    if (e->type() == QEvent::Wheel) {
-        // Reject scrolling only if widget is unfocused.
-        // Object to widget cast is needed to check the focus state.
-        QSpinBox* spin = qobject_cast<QSpinBox*>(obj);
-        if (spin && !spin->hasFocus()) {
-            QApplication::sendEvent(verticalLayout, e);
-            return true;
-        }
-    }
-    return QObject::eventFilter(obj, e);
-}
 void DlgPrefLibrary::slotShow() {
     m_bAddedDirectory = false;
 }

--- a/src/preferences/dialog/dlgpreflibrary.h
+++ b/src/preferences/dialog/dlgpreflibrary.h
@@ -65,8 +65,6 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
     void slotSeratoMetadataExportClicked(bool);
 
   private:
-    void setFocusPolicyInstallEventFilter(QSpinBox* box);
-    bool eventFilter(QObject* object, QEvent* event) override;
     void initializeDirList();
     void setLibraryFont(const QFont& font);
     void updateSearchLineEditHistoryOptions();

--- a/src/preferences/dialog/dlgprefmixer.cpp
+++ b/src/preferences/dialog/dlgprefmixer.cpp
@@ -91,16 +91,6 @@ DlgPrefMixer::DlgPrefMixer(
     connect(radioButtonAdditive, &QRadioButton::clicked, this, &DlgPrefMixer::slotUpdate);
     connect(radioButtonConstantPower, &QRadioButton::clicked, this, &DlgPrefMixer::slotUpdate);
 
-    // Set the focus policy for comboboxes and sliders and connect them to the
-    // custom event filter. See eventFilter() for details.
-    // Deck EQ & QuickEffect comboxboxes are set up accordingly in slotNumDecksChanged(),
-    // main EQ sliders in slotMainEqEffectChanged()
-    SliderHiEQ->setFocusPolicy(Qt::StrongFocus);
-    SliderHiEQ->installEventFilter(this);
-    SliderLoEQ->setFocusPolicy(Qt::StrongFocus);
-    SliderLoEQ->installEventFilter(this);
-    comboBoxMainEq->setFocusPolicy(Qt::StrongFocus);
-    comboBoxMainEq->installEventFilter(this);
     // Don't allow the xfader graph getting keyboard focus
     graphicsViewXfader->setFocusPolicy(Qt::NoFocus);
 
@@ -158,6 +148,8 @@ DlgPrefMixer::DlgPrefMixer(
 
     setUpMainEQ();
 
+    setScrollSafeGuardForAllInputWidgets(this);
+
     slotUpdate();
     slotApply();
 }
@@ -172,25 +164,6 @@ DlgPrefMixer::~DlgPrefMixer() {
     m_deckQuickEffectSelectors.clear();
 }
 
-// Catch scroll events and filter them if they addressed an unfocused combobox or
-// silder and send them to the scroll area instead.
-// This avoids undesired value changes of unfocused widget when scrolling the page.
-// Values can be changed only by explicit selection, dragging sliders and with
-// Up/Down (Left/Right respectively), PageUp/PageDown as well as Home/End keys.
-bool DlgPrefMixer::eventFilter(QObject* obj, QEvent* e) {
-    if (e->type() == QEvent::Wheel) {
-        // Reject scrolling only if widget is unfocused.
-        // Object to widget cast is needed to check the focus state.
-        QComboBox* combo = qobject_cast<QComboBox*>(obj);
-        QSlider* slider = qobject_cast<QSlider*>(obj);
-        if ((combo && !combo->hasFocus()) || (slider && !slider->hasFocus())) {
-            QApplication::sendEvent(verticalLayout, e);
-            return true;
-        }
-    }
-    return QObject::eventFilter(obj, e);
-}
-
 void DlgPrefMixer::slotNumDecksChanged(double numDecks) {
     int oldDecks = m_deckEqEffectSelectors.size();
     while (m_deckEqEffectSelectors.size() < static_cast<int>(numDecks)) {
@@ -200,25 +173,21 @@ void DlgPrefMixer::slotNumDecksChanged(double numDecks) {
 
         // Create the drop down list for deck EQs
         QComboBox* pEqComboBox = new QComboBox(this);
-        // Ignore scroll events if combobox is not focused.
-        // See eventFilter() for details.
-        pEqComboBox->setFocusPolicy(Qt::StrongFocus);
-        pEqComboBox->installEventFilter(this);
         m_deckEqEffectSelectors.append(pEqComboBox);
         connect(pEqComboBox,
                 QOverload<int>::of(&QComboBox::currentIndexChanged),
                 this,
                 &DlgPrefMixer::slotEffectChangedOnDeck);
+        setScrollSafeGuard(pEqComboBox);
 
         // Create the drop down list for Quick Effects
         QComboBox* pQuickEffectComboBox = new QComboBox(this);
-        pQuickEffectComboBox->setFocusPolicy(Qt::StrongFocus);
-        pQuickEffectComboBox->installEventFilter(this);
         m_deckQuickEffectSelectors.append(pQuickEffectComboBox);
         connect(pQuickEffectComboBox,
                 QOverload<int>::of(&QComboBox::currentIndexChanged),
                 this,
                 &DlgPrefMixer::slotQuickEffectChangedOnDeck);
+        setScrollSafeGuard(pQuickEffectComboBox);
 
         QString deckGroupName = PlayerManager::groupForDeck(deckNo - 1);
         QString unitGroup = QuickEffectChain::formatEffectChainGroup(deckGroupName);
@@ -980,10 +949,7 @@ void DlgPrefMixer::slotMainEqEffectChanged(int effectIndex) {
                     slider->setMinimumHeight(90);
                     // Set the index as a property because we need it inside slotUpdateFilter()
                     slider->setProperty("index", QVariant(i));
-                    // Ignore scroll events if slider is not focused.
-                    // See eventFilter() for details.
-                    slider->setFocusPolicy(Qt::StrongFocus);
-                    slider->installEventFilter(this);
+                    setScrollSafeGuard(slider);
                     slidersGridLayout->addWidget(slider, 1, i + 1, Qt::AlignCenter);
                     m_mainEQSliders.append(slider);
                     // catch drag event

--- a/src/preferences/dialog/dlgprefmixer.h
+++ b/src/preferences/dialog/dlgprefmixer.h
@@ -72,8 +72,6 @@ class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
 
     void applySelectionsToDecks();
 
-    bool eventFilter(QObject* obj, QEvent* e) override;
-
     UserSettingsPointer m_pConfig;
 
     QGraphicsScene* m_pxfScene;

--- a/src/preferences/dialog/dlgprefmodplug.cpp
+++ b/src/preferences/dialog/dlgprefmodplug.cpp
@@ -40,6 +40,8 @@ DlgPrefModplug::DlgPrefModplug(QWidget *parent,
                             m_pLinkColor,
                             "OpenMPT manual",
                             "http://wiki.openmpt.org/Manual:_Setup/Player")));
+
+    setScrollSafeGuardForAllInputWidgets(this);
 }
 
 DlgPrefModplug::~DlgPrefModplug() {

--- a/src/preferences/dialog/dlgprefrecord.cpp
+++ b/src/preferences/dialog/dlgprefrecord.cpp
@@ -99,6 +99,8 @@ DlgPrefRecord::DlgPrefRecord(QWidget* parent, UserSettingsPointer pConfig)
         comboBoxSplitting->setCurrentIndex(4);
     }
 
+    setScrollSafeGuard(comboBoxSplitting);
+
     // Do the one-time connection of signals here.
     connect(SliderQuality, &QAbstractSlider::valueChanged, this, &DlgPrefRecord::slotSliderQuality);
     connect(SliderQuality, &QAbstractSlider::sliderMoved, this, &DlgPrefRecord::slotSliderQuality);

--- a/src/preferences/dialog/dlgprefreplaygain.cpp
+++ b/src/preferences/dialog/dlgprefreplaygain.cpp
@@ -41,6 +41,8 @@ DlgPrefReplayGain::DlgPrefReplayGain(QWidget* parent, UserSettingsPointer pConfi
             &QAbstractSlider::sliderReleased,
             this,
             &DlgPrefReplayGain::slotApply);
+    setScrollSafeGuard(SliderReplayGainBoost);
+
     connect(SliderDefaultBoost,
             &QAbstractSlider::valueChanged,
             this,
@@ -49,6 +51,8 @@ DlgPrefReplayGain::DlgPrefReplayGain(QWidget* parent, UserSettingsPointer pConfi
             &QAbstractSlider::sliderReleased,
             this,
             &DlgPrefReplayGain::slotApply);
+    setScrollSafeGuard(SliderDefaultBoost);
+
     connect(checkBoxReanalyze,
             &QCheckBox::stateChanged,
             this,

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -82,7 +82,6 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void loadSettings(const SoundManagerConfig &config);
     void insertItem(DlgPrefSoundItem *pItem, QVBoxLayout *pLayout);
     void checkLatencyCompensation();
-    bool eventFilter(QObject* object, QEvent* event) override;
 
     std::shared_ptr<SoundManager> m_pSoundManager;
     UserSettingsPointer m_pSettings;

--- a/src/preferences/dialog/dlgprefsounditem.cpp
+++ b/src/preferences/dialog/dlgprefsounditem.cpp
@@ -32,14 +32,6 @@ DlgPrefSoundItem::DlgPrefSoundItem(
     deviceComboBox->addItem(SoundManagerConfig::kEmptyComboBox,
             QVariant::fromValue(SoundDeviceId()));
 
-    // Set the focus policy for QComboBoxes (and wide QDoubleSpinBoxes) and
-    // connect them to the custom event filter below so they don't accept focus
-    // when we scroll the preferences page.
-    deviceComboBox->setFocusPolicy(Qt::StrongFocus);
-    deviceComboBox->installEventFilter(this);
-    channelComboBox->setFocusPolicy(Qt::StrongFocus);
-    channelComboBox->installEventFilter(this);
-
     connect(deviceComboBox,
             QOverload<int>::of(&QComboBox::currentIndexChanged),
             this,
@@ -53,20 +45,6 @@ DlgPrefSoundItem::DlgPrefSoundItem(
 
 DlgPrefSoundItem::~DlgPrefSoundItem() {
 
-}
-
-// Catch scroll events over comboboxes and pass them to the scroll area instead.
-bool DlgPrefSoundItem::eventFilter(QObject* obj, QEvent* e) {
-    if (e->type() == QEvent::Wheel) {
-        // Reject scrolling only if widget is unfocused.
-        // Object to widget cast is needed to check the focus state.
-        QComboBox* combo = qobject_cast<QComboBox*>(obj);
-        if (combo && !combo->hasFocus()) {
-            QApplication::sendEvent(this->parentWidget(), e);
-            return true;
-        }
-    }
-    return QObject::eventFilter(obj, e);
 }
 
 /**

--- a/src/preferences/dialog/dlgprefsounditem.h
+++ b/src/preferences/dialog/dlgprefsounditem.h
@@ -41,7 +41,6 @@ class DlgPrefSoundItem : public QWidget, public Ui::DlgPrefSoundItem {
     void setDevice(const SoundDeviceId& device);
     void setChannel(unsigned int channelBase, unsigned int channels);
     int hasSufficientChannels(const SoundDevice& device) const;
-    bool eventFilter(QObject* object, QEvent* event) override;
 
     AudioPathType m_type;
     unsigned int m_index;

--- a/src/preferences/dialog/dlgprefvinyl.cpp
+++ b/src/preferences/dialog/dlgprefvinyl.cpp
@@ -15,10 +15,10 @@
 DlgPrefVinyl::DlgPrefVinyl(
         QWidget* parent,
         std::shared_ptr<VinylControlManager> pVCMan,
-        UserSettingsPointer _config)
+        UserSettingsPointer config)
         : DlgPreferencePage(parent),
           m_pVCManager(pVCMan),
-          config(_config) {
+          config(config) {
     m_pNumDecks = new ControlProxy("[Master]", "num_decks", this);
     m_pNumDecks->connectValueChanged(this, &DlgPrefVinyl::slotNumDecksChanged);
 
@@ -26,73 +26,58 @@ DlgPrefVinyl::DlgPrefVinyl(
     // Create text color for the Troubleshooting link
     createLinkColor();
 
-    delete groupBoxSignalQuality->layout();
-    QHBoxLayout *layout = new QHBoxLayout;
+    // Add per-deck vinyl selectors
+    m_vcLabels = {VinylLabel1,
+            VinylLabel2,
+            VinylLabel3,
+            VinylLabel4};
 
-    for (int i = 0; i < kMaximumVinylControlInputs; ++i) {
-        m_signalWidgets.push_back(new VinylControlSignalWidget());
-        VinylControlSignalWidget* widget = m_signalWidgets.back();
-        widget->setVinylInput(i);
-        widget->setSize(MIXXX_VINYL_SCOPE_SIZE);
-        layout->layout()->addWidget(widget);
+    m_vcTypeBoxes = {ComboBoxVinylType1,
+            ComboBoxVinylType2,
+            ComboBoxVinylType3,
+            ComboBoxVinylType4};
+    for (auto* box : qAsConst(m_vcTypeBoxes)) {
+        box->addItem(MIXXX_VINYL_SERATOCV02VINYLSIDEA);
+        box->addItem(MIXXX_VINYL_SERATOCV02VINYLSIDEB);
+        box->addItem(MIXXX_VINYL_SERATOCD);
+        box->addItem(MIXXX_VINYL_TRAKTORSCRATCHSIDEA);
+        box->addItem(MIXXX_VINYL_TRAKTORSCRATCHSIDEB);
+        box->addItem(MIXXX_VINYL_MIXVIBESDVS);
+        box->addItem(MIXXX_VINYL_MIXVIBES7INCH);
+        box->addItem(MIXXX_VINYL_PIONEERA);
+        box->addItem(MIXXX_VINYL_PIONEERB);
+        connect(box,
+                &QComboBox::currentTextChanged,
+                this,
+                &DlgPrefVinyl::slotVinylTypeChanged);
     }
 
-    groupBoxSignalQuality->setLayout(layout);
+    m_vcSpeedBoxes = {ComboBoxVinylSpeed1,
+            ComboBoxVinylSpeed2,
+            ComboBoxVinylSpeed3,
+            ComboBoxVinylSpeed4};
+    for (auto* box : qAsConst(m_vcSpeedBoxes)) {
+        box->addItem(MIXXX_VINYL_SPEED_33);
+        box->addItem(MIXXX_VINYL_SPEED_45);
+    }
 
-    // Add vinyl types
-    ComboBoxVinylType1->addItem(MIXXX_VINYL_SERATOCV02VINYLSIDEA);
-    ComboBoxVinylType1->addItem(MIXXX_VINYL_SERATOCV02VINYLSIDEB);
-    ComboBoxVinylType1->addItem(MIXXX_VINYL_SERATOCD);
-    ComboBoxVinylType1->addItem(MIXXX_VINYL_TRAKTORSCRATCHSIDEA);
-    ComboBoxVinylType1->addItem(MIXXX_VINYL_TRAKTORSCRATCHSIDEB);
-    ComboBoxVinylType1->addItem(MIXXX_VINYL_MIXVIBESDVS);
-    ComboBoxVinylType1->addItem(MIXXX_VINYL_MIXVIBES7INCH);
-    ComboBoxVinylType1->addItem(MIXXX_VINYL_PIONEERA);
-    ComboBoxVinylType1->addItem(MIXXX_VINYL_PIONEERB);
+    m_vcLeadInBoxes = {LeadinTime1, LeadinTime2, LeadinTime3, LeadinTime4};
+    for (auto* box : qAsConst(m_vcLeadInBoxes)) {
+        box->setSuffix(" s");
+    }
 
-    ComboBoxVinylType2->addItem(MIXXX_VINYL_SERATOCV02VINYLSIDEA);
-    ComboBoxVinylType2->addItem(MIXXX_VINYL_SERATOCV02VINYLSIDEB);
-    ComboBoxVinylType2->addItem(MIXXX_VINYL_SERATOCD);
-    ComboBoxVinylType2->addItem(MIXXX_VINYL_TRAKTORSCRATCHSIDEA);
-    ComboBoxVinylType2->addItem(MIXXX_VINYL_TRAKTORSCRATCHSIDEB);
-    ComboBoxVinylType2->addItem(MIXXX_VINYL_MIXVIBESDVS);
-    ComboBoxVinylType2->addItem(MIXXX_VINYL_MIXVIBES7INCH);
-    ComboBoxVinylType2->addItem(MIXXX_VINYL_PIONEERA);
-    ComboBoxVinylType2->addItem(MIXXX_VINYL_PIONEERB);
+    DEBUG_ASSERT(m_vcLabels.length() == kMaximumVinylControlInputs);
+    DEBUG_ASSERT(m_vcTypeBoxes.length() == kMaximumVinylControlInputs);
+    DEBUG_ASSERT(m_vcSpeedBoxes.length() == kMaximumVinylControlInputs);
+    DEBUG_ASSERT(m_vcLeadInBoxes.length() == kMaximumVinylControlInputs);
 
-    ComboBoxVinylType3->addItem(MIXXX_VINYL_SERATOCV02VINYLSIDEA);
-    ComboBoxVinylType3->addItem(MIXXX_VINYL_SERATOCV02VINYLSIDEB);
-    ComboBoxVinylType3->addItem(MIXXX_VINYL_SERATOCD);
-    ComboBoxVinylType3->addItem(MIXXX_VINYL_TRAKTORSCRATCHSIDEA);
-    ComboBoxVinylType3->addItem(MIXXX_VINYL_TRAKTORSCRATCHSIDEB);
-    ComboBoxVinylType3->addItem(MIXXX_VINYL_MIXVIBESDVS);
-    ComboBoxVinylType4->addItem(MIXXX_VINYL_MIXVIBES7INCH);
-    ComboBoxVinylType4->addItem(MIXXX_VINYL_PIONEERA);
-    ComboBoxVinylType4->addItem(MIXXX_VINYL_PIONEERB);
-
-    ComboBoxVinylType4->addItem(MIXXX_VINYL_SERATOCV02VINYLSIDEA);
-    ComboBoxVinylType4->addItem(MIXXX_VINYL_SERATOCV02VINYLSIDEB);
-    ComboBoxVinylType4->addItem(MIXXX_VINYL_SERATOCD);
-    ComboBoxVinylType4->addItem(MIXXX_VINYL_TRAKTORSCRATCHSIDEA);
-    ComboBoxVinylType4->addItem(MIXXX_VINYL_TRAKTORSCRATCHSIDEB);
-    ComboBoxVinylType4->addItem(MIXXX_VINYL_MIXVIBESDVS);
-    ComboBoxVinylType4->addItem(MIXXX_VINYL_MIXVIBES7INCH);
-    ComboBoxVinylType4->addItem(MIXXX_VINYL_PIONEERA);
-    ComboBoxVinylType4->addItem(MIXXX_VINYL_PIONEERB);
-
-    ComboBoxVinylSpeed1->addItem(MIXXX_VINYL_SPEED_33);
-    ComboBoxVinylSpeed1->addItem(MIXXX_VINYL_SPEED_45);
-    ComboBoxVinylSpeed2->addItem(MIXXX_VINYL_SPEED_33);
-    ComboBoxVinylSpeed2->addItem(MIXXX_VINYL_SPEED_45);
-    ComboBoxVinylSpeed3->addItem(MIXXX_VINYL_SPEED_33);
-    ComboBoxVinylSpeed3->addItem(MIXXX_VINYL_SPEED_45);
-    ComboBoxVinylSpeed4->addItem(MIXXX_VINYL_SPEED_33);
-    ComboBoxVinylSpeed4->addItem(MIXXX_VINYL_SPEED_45);
-
-    LeadinTime1->setSuffix(" s");
-    LeadinTime2->setSuffix(" s");
-    LeadinTime3->setSuffix(" s");
-    LeadinTime4->setSuffix(" s");
+    for (int i = 0; i < kMaximumVinylControlInputs; ++i) {
+        VinylControlSignalWidget* widget = new VinylControlSignalWidget();
+        m_signalWidgets.push_back(widget);
+        widget->setVinylInput(i);
+        widget->setSize(MIXXX_VINYL_SCOPE_SIZE);
+        signalQualityLayout->addWidget(widget);
+    }
 
     TroubleshootingLink->setText(coloredLinkString(
             m_pLinkColor,
@@ -100,29 +85,11 @@ DlgPrefVinyl::DlgPrefVinyl(
             "Troubleshooting",
             MIXXX_MANUAL_VINYL_TROUBLESHOOTING_URL));
 
-    connect(VinylGain, &QSlider::sliderReleased, this, &DlgPrefVinyl::slotVinylGainApply);
-    connect(VinylGain,
+    connect(SliderVinylGain, &QSlider::sliderReleased, this, &DlgPrefVinyl::slotVinylGainApply);
+    connect(SliderVinylGain,
             QOverload<int>::of(&QSlider::valueChanged),
             this,
             &DlgPrefVinyl::slotUpdateVinylGain);
-
-    // No real point making this a mapper since the combos aren't indexed.
-    connect(ComboBoxVinylType1,
-            &QComboBox::currentTextChanged,
-            this,
-            &DlgPrefVinyl::slotVinylType1Changed);
-    connect(ComboBoxVinylType2,
-            &QComboBox::currentTextChanged,
-            this,
-            &DlgPrefVinyl::slotVinylType2Changed);
-    connect(ComboBoxVinylType3,
-            &QComboBox::currentTextChanged,
-            this,
-            &DlgPrefVinyl::slotVinylType3Changed);
-    connect(ComboBoxVinylType4,
-            &QComboBox::currentTextChanged,
-            this,
-            &DlgPrefVinyl::slotVinylType4Changed);
 
     for (int i = 0; i < kMaxNumberOfDecks; ++i) {
         setDeckWidgetsVisible(i, false);
@@ -152,20 +119,10 @@ void DlgPrefVinyl::slotNumDecksChanged(double dNumDecks) {
     }
 }
 
-void DlgPrefVinyl::slotVinylType1Changed(const QString& text) {
-    LeadinTime1->setValue(getDefaultLeadIn(text));
-}
-
-void DlgPrefVinyl::slotVinylType2Changed(const QString& text) {
-    LeadinTime2->setValue(getDefaultLeadIn(text));
-}
-
-void DlgPrefVinyl::slotVinylType3Changed(const QString& text) {
-    LeadinTime3->setValue(getDefaultLeadIn(text));
-}
-
-void DlgPrefVinyl::slotVinylType4Changed(const QString& text) {
-    LeadinTime4->setValue(getDefaultLeadIn(text));
+void DlgPrefVinyl::slotVinylTypeChanged(const QString& text) {
+    QComboBox* c = qobject_cast<QComboBox*>(sender());
+    int i = m_vcTypeBoxes.indexOf(c);
+    m_vcLeadInBoxes[i]->setValue(getDefaultLeadIn(text));
 }
 
 /// Performs any necessary actions that need to happen when the prefs dialog is opened.
@@ -193,114 +150,71 @@ void DlgPrefVinyl::slotHide() {
 
 void DlgPrefVinyl::slotResetToDefaults() {
     // Default to Serato Side A.
-    ComboBoxVinylType1->setCurrentIndex(0);
-    ComboBoxVinylType2->setCurrentIndex(0);
-    ComboBoxVinylType3->setCurrentIndex(0);
-    ComboBoxVinylType4->setCurrentIndex(0);
-    // Default to 33 RPM.
-    ComboBoxVinylSpeed1->setCurrentIndex(0);
-    ComboBoxVinylSpeed2->setCurrentIndex(0);
-    ComboBoxVinylSpeed3->setCurrentIndex(0);
-    ComboBoxVinylSpeed4->setCurrentIndex(0);
+    for (auto* box : qAsConst(m_vcTypeBoxes)) {
+        box->setCurrentIndex(0);
+    }
 
-    LeadinTime1->setValue(MIXXX_VINYL_SERATOCV02VINYLSIDEA_LEADIN);
-    LeadinTime2->setValue(MIXXX_VINYL_SERATOCV02VINYLSIDEA_LEADIN);
-    LeadinTime3->setValue(MIXXX_VINYL_SERATOCV02VINYLSIDEA_LEADIN);
-    LeadinTime4->setValue(MIXXX_VINYL_SERATOCV02VINYLSIDEA_LEADIN);
+    // Default to 33 RPM.
+    for (auto* box : qAsConst(m_vcTypeBoxes)) {
+        box->setCurrentIndex(0);
+    }
+
+    for (auto* box : qAsConst(m_vcLeadInBoxes)) {
+        box->setValue(MIXXX_VINYL_SERATOCV02VINYLSIDEA_LEADIN);
+    }
+
     SignalQualityEnable->setChecked(true);
-    VinylGain->setValue(0);
+    SliderVinylGain->setValue(0);
     slotUpdateVinylGain();
 }
 
 void DlgPrefVinyl::slotUpdate() {
-    // Set vinyl control types in the comboboxes
-    int combo_index =
-            ComboBoxVinylType1->findText(config->getValueString(
-                    ConfigKey("[Channel1]", "vinylcontrol_vinyl_type")));
-    if (combo_index != -1) {
-        ComboBoxVinylType1->setCurrentIndex(combo_index);
-    }
-
-    combo_index =
-            ComboBoxVinylType2->findText(config->getValueString(
-                    ConfigKey("[Channel2]", "vinylcontrol_vinyl_type")));
-    if (combo_index != -1) {
-        ComboBoxVinylType2->setCurrentIndex(combo_index);
-    }
-
-    combo_index =
-            ComboBoxVinylType3->findText(config->getValueString(
-                    ConfigKey("[Channel3]", "vinylcontrol_vinyl_type")));
-    if (combo_index != -1) {
-        ComboBoxVinylType3->setCurrentIndex(combo_index);
-    }
-
-    combo_index =
-            ComboBoxVinylType4->findText(config->getValueString(
-                    ConfigKey("[Channel4]", "vinylcontrol_vinyl_type")));
-    if (combo_index != -1) {
-        ComboBoxVinylType4->setCurrentIndex(combo_index);
-    }
-
-    combo_index =
-            ComboBoxVinylSpeed1->findText(config->getValueString(
-                    ConfigKey("[Channel1]", "vinylcontrol_speed_type")));
-    if (combo_index != -1) {
-        ComboBoxVinylSpeed1->setCurrentIndex(combo_index);
-    }
-
-    combo_index =
-            ComboBoxVinylSpeed2->findText(config->getValueString(
-                    ConfigKey("[Channel2]", "vinylcontrol_speed_type")));
-    if (combo_index != -1) {
-        ComboBoxVinylSpeed2->setCurrentIndex(combo_index);
-    }
-
-    combo_index =
-            ComboBoxVinylSpeed3->findText(config->getValueString(
-                    ConfigKey("[Channel3]", "vinylcontrol_speed_type")));
-    if (combo_index != -1) {
-        ComboBoxVinylSpeed3->setCurrentIndex(combo_index);
-    }
-
-    combo_index =
-            ComboBoxVinylSpeed4->findText(config->getValueString(
-                    ConfigKey("[Channel4]", "vinylcontrol_speed_type")));
-    if (combo_index != -1) {
-        ComboBoxVinylSpeed4->setCurrentIndex(combo_index);
-    }
-
-    // set lead-in time
-    LeadinTime1->setValue((config->getValue(ConfigKey("[Channel1]", "vinylcontrol_lead_in_time"), "0")).toInt());
-    LeadinTime2->setValue((config->getValue(ConfigKey("[Channel2]", "vinylcontrol_lead_in_time"), "0")).toInt());
-    LeadinTime3->setValue((config->getValue(ConfigKey("[Channel3]", "vinylcontrol_lead_in_time"), "0")).toInt());
-    LeadinTime4->setValue((config->getValue(ConfigKey("[Channel4]", "vinylcontrol_lead_in_time"), "0")).toInt());
+    // set vinyl control gain
+    const double ratioGain = config->getValue<double>(ConfigKey(VINYL_PREF_KEY, "gain"));
+    const double dbGain = ratio2db(ratioGain);
+    SliderVinylGain->setValue(static_cast<int>(dbGain + 0.5));
+    slotUpdateVinylGain();
 
     SignalQualityEnable->setChecked(
             (bool)config->getValue<bool>(ConfigKey(VINYL_PREF_KEY, "show_signal_quality")));
 
-    // set vinyl control gain
-    const double ratioGain = config->getValue<double>(ConfigKey(VINYL_PREF_KEY, "gain"));
-    const double dbGain = ratio2db(ratioGain);
-    VinylGain->setValue(static_cast<int>(dbGain + 0.5));
-    slotUpdateVinylGain();
-
     for (int i = 0; i < kMaximumVinylControlInputs; ++i) {
+        QString group = PlayerManager::groupForDeck(i);
+
+        // Set vinyl control types in the comboboxes
+        int comboIndex =
+                m_vcTypeBoxes[i]->findText(config->getValueString(
+                        ConfigKey(group, "vinylcontrol_vinyl_type")));
+        if (comboIndex != -1) {
+            m_vcTypeBoxes[i]->setCurrentIndex(comboIndex);
+        }
+
+        // set speed
+        comboIndex =
+                m_vcSpeedBoxes[i]->findText(config->getValueString(
+                        ConfigKey(group, "vinylcontrol_speed_type")));
+        if (comboIndex != -1) {
+            m_vcSpeedBoxes[i]->setCurrentIndex(comboIndex);
+        }
+
+        // set lead-in time
+        int leadIn = config->getValue(
+                ConfigKey(group, "vinylcontrol_lead_in_time"),
+                getDefaultLeadIn(m_vcTypeBoxes[i]->currentText()));
+        m_vcLeadInBoxes[i]->setValue(leadIn);
+
         m_signalWidgets[i]->setVinylActive(m_pVCManager->vinylInputConnected(i));
     }
 }
 
 void DlgPrefVinyl::verifyAndSaveLeadInTime(
-        QSpinBox* widget, const QString& group, const QString& vinyl_type) {
-    QString strLeadIn = widget->cleanText();
+        int deck, const QString& group) {
     bool isInteger;
-    strLeadIn.toInt(&isInteger);
-    if (isInteger) {
-        config->set(ConfigKey(group, "vinylcontrol_lead_in_time"), strLeadIn);
-    } else {
-        config->setValue(ConfigKey(group, "vinylcontrol_lead_in_time"),
-                         getDefaultLeadIn(vinyl_type));
+    int iLeadIn = m_vcLeadInBoxes[deck]->cleanText().toInt(&isInteger);
+    if (!isInteger || iLeadIn < 0) {
+        iLeadIn = getDefaultLeadIn(m_vcTypeBoxes[deck]->currentText());
     }
+    config->setValue(ConfigKey(group, "vinylcontrol_lead_in_time"), iLeadIn);
 }
 
 int DlgPrefVinyl::getDefaultLeadIn(const QString& vinyl_type) const {
@@ -328,18 +242,31 @@ int DlgPrefVinyl::getDefaultLeadIn(const QString& vinyl_type) const {
 }
 
 // Update the config object with parameters from dialog
-void DlgPrefVinyl::slotApply()
-{
-    qDebug() << "DlgPrefVinyl::Apply";
-
-    verifyAndSaveLeadInTime(LeadinTime1, "[Channel1]", ComboBoxVinylType1->currentText());
-    verifyAndSaveLeadInTime(LeadinTime2, "[Channel2]", ComboBoxVinylType2->currentText());
-    verifyAndSaveLeadInTime(LeadinTime3, "[Channel3]", ComboBoxVinylType3->currentText());
-    verifyAndSaveLeadInTime(LeadinTime4, "[Channel4]", ComboBoxVinylType4->currentText());
-
-    // Apply updates for everything else...
-    VinylTypeSlotApply();
+void DlgPrefVinyl::slotApply() {
     slotVinylGainApply();
+
+    // Save vinyl types, speed and lead-in, activate signal wdgets
+    for (int i = 0; i < kMaximumVinylControlInputs; ++i) {
+        QString group = PlayerManager::groupForDeck(i);
+
+        config->set(ConfigKey(group, "vinylcontrol_vinyl_type"),
+                ConfigValue(m_vcTypeBoxes[i]->currentText()));
+        config->set(ConfigKey(group, "vinylcontrol_speed_type"),
+                ConfigValue(m_vcSpeedBoxes[i]->currentText()));
+        verifyAndSaveLeadInTime(i, group);
+
+        m_signalWidgets[i]->setVinylActive(m_pVCManager->vinylInputConnected(i));
+    }
+
+    // Save the vinylcontrol_speed_type in ControlObjects as well so it can be
+    // retrieved quickly on the fly. (eg. WSpinny needs to know how fast to spin)
+    for (auto* co : qAsConst(m_COSpeeds)) {
+        int i = m_COSpeeds.indexOf(co);
+        double speed = m_vcSpeedBoxes[i]->currentText() == MIXXX_VINYL_SPEED_33
+                ? MIXXX_VINYL_SPEED_33_NUM
+                : MIXXX_VINYL_SPEED_45_NUM;
+        co->set(speed);
+    }
 
     config->set(ConfigKey(VINYL_PREF_KEY,"show_signal_quality"),
                 ConfigValue((int)(SignalQualityEnable->isChecked())));
@@ -348,64 +275,8 @@ void DlgPrefVinyl::slotApply()
     slotUpdate();
 }
 
-void DlgPrefVinyl::VinylTypeSlotApply()
-{
-    config->set(ConfigKey("[Channel1]","vinylcontrol_vinyl_type"),
-                ConfigValue(ComboBoxVinylType1->currentText()));
-    config->set(ConfigKey("[Channel2]","vinylcontrol_vinyl_type"),
-                ConfigValue(ComboBoxVinylType2->currentText()));
-    config->set(ConfigKey("[Channel3]","vinylcontrol_vinyl_type"),
-                ConfigValue(ComboBoxVinylType3->currentText()));
-    config->set(ConfigKey("[Channel4]","vinylcontrol_vinyl_type"),
-                ConfigValue(ComboBoxVinylType4->currentText()));
-    config->set(ConfigKey("[Channel1]","vinylcontrol_speed_type"),
-                ConfigValue(ComboBoxVinylSpeed1->currentText()));
-    config->set(ConfigKey("[Channel2]","vinylcontrol_speed_type"),
-                ConfigValue(ComboBoxVinylSpeed2->currentText()));
-    config->set(ConfigKey("[Channel3]","vinylcontrol_speed_type"),
-                ConfigValue(ComboBoxVinylSpeed3->currentText()));
-    config->set(ConfigKey("[Channel4]","vinylcontrol_speed_type"),
-                ConfigValue(ComboBoxVinylSpeed4->currentText()));
-
-    // Save the vinylcontrol_speed_type in ControlObjects as well so it can be retrieved quickly
-    // on the fly. (eg. WSpinny needs to know how fast to spin)
-
-    switch (m_COSpeeds.length()) {
-    case 4:
-        if (ComboBoxVinylSpeed4->currentText() == MIXXX_VINYL_SPEED_33) {
-            m_COSpeeds[3]->set(MIXXX_VINYL_SPEED_33_NUM);
-        } else if (ComboBoxVinylSpeed4->currentText() == MIXXX_VINYL_SPEED_45) {
-            m_COSpeeds[3]->set(MIXXX_VINYL_SPEED_45_NUM);
-        }
-        M_FALLTHROUGH_INTENDED;
-    case 3:
-        if (ComboBoxVinylSpeed3->currentText() == MIXXX_VINYL_SPEED_33) {
-            m_COSpeeds[2]->set(MIXXX_VINYL_SPEED_33_NUM);
-        } else if (ComboBoxVinylSpeed3->currentText() == MIXXX_VINYL_SPEED_45) {
-            m_COSpeeds[2]->set(MIXXX_VINYL_SPEED_45_NUM);
-        }
-        M_FALLTHROUGH_INTENDED;
-    case 2:
-        if (ComboBoxVinylSpeed2->currentText() == MIXXX_VINYL_SPEED_33) {
-            m_COSpeeds[1]->set(MIXXX_VINYL_SPEED_33_NUM);
-        } else if (ComboBoxVinylSpeed2->currentText() == MIXXX_VINYL_SPEED_45) {
-            m_COSpeeds[1]->set(MIXXX_VINYL_SPEED_45_NUM);
-        }
-        M_FALLTHROUGH_INTENDED;
-    case 1:
-        if (ComboBoxVinylSpeed1->currentText() == MIXXX_VINYL_SPEED_33) {
-            m_COSpeeds[0]->set(MIXXX_VINYL_SPEED_33_NUM);
-        } else if (ComboBoxVinylSpeed1->currentText() == MIXXX_VINYL_SPEED_45) {
-            m_COSpeeds[0]->set(MIXXX_VINYL_SPEED_45_NUM);
-        }
-        break;
-    default:
-        qWarning() << "Unexpected number of vinyl speed preference items";
-    }
-}
-
 void DlgPrefVinyl::slotVinylGainApply() {
-    const int dBGain = VinylGain->value();
+    const int dBGain = SliderVinylGain->value();
     qDebug() << "in VinylGainSlotApply()" << "with gain:" << dBGain << "dB";
     // Update the config key...
     const double ratioGain = db2ratio(static_cast<double>(dBGain));
@@ -416,7 +287,7 @@ void DlgPrefVinyl::slotVinylGainApply() {
 }
 
 void DlgPrefVinyl::slotUpdateVinylGain() {
-    int value = VinylGain->value();
+    int value = SliderVinylGain->value();
     textLabelPreampCurrent->setText(
             QString("%1 dB").arg(value));
 }
@@ -426,100 +297,21 @@ QUrl DlgPrefVinyl::helpUrl() const {
 }
 
 void DlgPrefVinyl::setDeckWidgetsVisible(int deck, bool visible) {
-    switch(deck) {
-    case 0:
-        setDeck1WidgetsVisible(visible);
-        break;
-    case 1:
-        setDeck2WidgetsVisible(visible);
-        break;
-    case 2:
-        setDeck3WidgetsVisible(visible);
-        break;
-    case 3:
-        setDeck4WidgetsVisible(visible);
-        break;
-    default:
+    if (deck < 0 || deck > 3) {
         qWarning() << "Tried to set a vinyl preference widget visible that doesn't exist: " << deck;
     }
-}
 
-void DlgPrefVinyl::setDeck1WidgetsVisible(bool visible) {
     if (visible) {
-        VinylLabel1->show();
-        ComboBoxVinylType1->show();
-        ComboBoxVinylSpeed1->show();
-        if (m_signalWidgets.length() > 0) {
-            m_signalWidgets[0]->show();
-        }
-        LeadinTime1->show();
+        m_vcLabels[deck]->show();
+        m_vcTypeBoxes[deck]->show();
+        m_vcSpeedBoxes[deck]->show();
+        m_vcLeadInBoxes[deck]->show();
+        m_signalWidgets[deck]->show();
     } else {
-        VinylLabel1->hide();
-        ComboBoxVinylType1->hide();
-        ComboBoxVinylSpeed1->hide();
-        if (m_signalWidgets.length() > 0) {
-            m_signalWidgets[0]->hide();
-        }
-        LeadinTime1->hide();
-    }
-}
-
-void DlgPrefVinyl::setDeck2WidgetsVisible(bool visible) {
-    if (visible) {
-        VinylLabel2->show();
-        ComboBoxVinylType2->show();
-        ComboBoxVinylSpeed2->show();
-        if (m_signalWidgets.length() > 1) {
-            m_signalWidgets[1]->show();
-        }
-        LeadinTime2->show();
-    } else {
-        VinylLabel2->hide();
-        ComboBoxVinylType2->hide();
-        ComboBoxVinylSpeed2->hide();
-        if (m_signalWidgets.length() > 1) {
-            m_signalWidgets[1]->hide();
-        }
-        LeadinTime2->hide();
-    }
-}
-
-void DlgPrefVinyl::setDeck3WidgetsVisible(bool visible) {
-    if (visible) {
-        VinylLabel3->show();
-        ComboBoxVinylType3->show();
-        ComboBoxVinylSpeed3->show();
-        if (m_signalWidgets.length() > 2) {
-            m_signalWidgets[2]->show();
-        }
-        LeadinTime3->show();
-    } else {
-        VinylLabel3->hide();
-        ComboBoxVinylType3->hide();
-        ComboBoxVinylSpeed3->hide();
-        if (m_signalWidgets.length() > 2) {
-            m_signalWidgets[2]->hide();
-        }
-        LeadinTime3->hide();
-    }
-}
-
-void DlgPrefVinyl::setDeck4WidgetsVisible(bool visible) {
-    if (visible) {
-        VinylLabel4->show();
-        ComboBoxVinylType4->show();
-        ComboBoxVinylSpeed4->show();
-        if (m_signalWidgets.length() > 3) {
-            m_signalWidgets[3]->show();
-        }
-        LeadinTime4->show();
-    } else {
-        VinylLabel4->hide();
-        ComboBoxVinylType4->hide();
-        ComboBoxVinylSpeed4->hide();
-        if (m_signalWidgets.length() > 3) {
-            m_signalWidgets[3]->hide();
-        }
-        LeadinTime4->hide();
+        m_vcLabels[deck]->hide();
+        m_vcTypeBoxes[deck]->hide();
+        m_vcSpeedBoxes[deck]->hide();
+        m_vcLeadInBoxes[deck]->hide();
+        m_signalWidgets[deck]->hide();
     }
 }

--- a/src/preferences/dialog/dlgprefvinyl.cpp
+++ b/src/preferences/dialog/dlgprefvinyl.cpp
@@ -128,6 +128,8 @@ DlgPrefVinyl::DlgPrefVinyl(
         setDeckWidgetsVisible(i, false);
     }
 
+    setScrollSafeGuardForAllInputWidgets(this);
+
     slotNumDecksChanged(m_pNumDecks->get());
 }
 

--- a/src/preferences/dialog/dlgprefvinyl.h
+++ b/src/preferences/dialog/dlgprefvinyl.h
@@ -31,26 +31,22 @@ class DlgPrefVinyl : public DlgPreferencePage, Ui::DlgPrefVinylDlg  {
 
     void slotHide() override;
     void slotShow() override;
-    void VinylTypeSlotApply();
     void slotVinylGainApply();
     void slotUpdateVinylGain();
 
   private slots:
     void slotNumDecksChanged(double);
-    void slotVinylType1Changed(const QString&);
-    void slotVinylType2Changed(const QString&);
-    void slotVinylType3Changed(const QString&);
-    void slotVinylType4Changed(const QString&);
+    void slotVinylTypeChanged(const QString&);
 
   private:
     void setDeckWidgetsVisible(int deck, bool visible);
-    void setDeck1WidgetsVisible(bool visible);
-    void setDeck2WidgetsVisible(bool visible);
-    void setDeck3WidgetsVisible(bool visible);
-    void setDeck4WidgetsVisible(bool visible);
-    void verifyAndSaveLeadInTime(QSpinBox* widget, const QString& group, const QString& vinyl_type);
+    void verifyAndSaveLeadInTime(int deck, const QString& group);
     int getDefaultLeadIn(const QString& vinyl_type) const;
 
+    QList<QLabel*> m_vcLabels;
+    QList<QComboBox*> m_vcTypeBoxes;
+    QList<QComboBox*> m_vcSpeedBoxes;
+    QList<QSpinBox*> m_vcLeadInBoxes;
     QList<VinylControlSignalWidget*> m_signalWidgets;
 
     std::shared_ptr<VinylControlManager> m_pVCManager;

--- a/src/preferences/dialog/dlgprefvinyldlg.ui
+++ b/src/preferences/dialog/dlgprefvinyldlg.ui
@@ -31,13 +31,13 @@
          <bool>false</bool>
         </property>
         <property name="buddy">
-         <cstring>VinylGain</cstring>
+         <cstring>SliderVinylGain</cstring>
         </property>
        </widget>
       </item>
 
       <item>
-       <widget class="QSlider" name="VinylGain">
+       <widget class="QSlider" name="SliderVinylGain">
         <property name="minimum">
          <number>0</number>
         </property>
@@ -572,7 +572,7 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <layout class="QGridLayout">
+     <layout class="QHBoxLayout" name="signalQualityLayout">
      </layout>
     </widget>
    </item>
@@ -677,5 +677,20 @@
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <resources/>
+ <tabstops>
+  <tabstop>SliderVinylGain</tabstop>
+  <tabstop>ComboBoxVinylType1</tabstop>
+  <tabstop>ComboBoxVinylSpeed1</tabstop>
+  <tabstop>LeadinTime1</tabstop>
+  <tabstop>ComboBoxVinylType2</tabstop>
+  <tabstop>ComboBoxVinylSpeed2</tabstop>
+  <tabstop>LeadinTime2</tabstop>
+  <tabstop>ComboBoxVinylType3</tabstop>
+  <tabstop>ComboBoxVinylSpeed3</tabstop>
+  <tabstop>LeadinTime3</tabstop>
+  <tabstop>ComboBoxVinylType4</tabstop>
+  <tabstop>ComboBoxVinylSpeed4</tabstop>
+  <tabstop>LeadinTime4</tabstop>
+ </tabstops>
  <connections/>
 </ui>

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -131,6 +131,8 @@ DlgPrefWaveform::DlgPrefWaveform(
             &QSlider::valueChanged,
             this,
             &DlgPrefWaveform::slotSetPlayMarkerPosition);
+
+    setScrollSafeGuardForAllInputWidgets(this);
 }
 
 DlgPrefWaveform::~DlgPrefWaveform() {


### PR DESCRIPTION
This moves the existing safeguards (I started with #2941) to helpers in DlgPreferencePage and uses it in the other pages as well. 

Btw, am I the only who's annoyed by this hover scroll issue? or is just that we have too many big pref pages that require scrolling even on large screens so the issue is relevant at all?

The helper iterates over all dialog children and install the safeguard for input widgets.
There's also a per-widget helper if a page only has a few widgets.

Unfortunately, this doesn't work for QGroupBoxes.
But before I found a way to deal with this, I already started reworking `DlgPrefVinyl` to store the input widgets in lists (and simplified the entire page code, and fixed an init bug¹, and added proper tabstops)... so this page is pretty much rewritten with widget lists. There are now quite some lines to review in that page. I didn't want to throw away that work so I finished it. If no one wants to review that I can move that commit to a separate PR (and maybe isolate the init bugfix, too).

¹on show, the lead-in time for non existing config values was set to 0 instead of the default time that is picked when selecting a VC type.