### PR TITLE
ITunesXMLImporterTest: Fix sporadic crash due to a not initalized reference.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -798,6 +798,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/library/hiddentablemodel.cpp
   src/library/itunes/itunesdao.cpp
   src/library/itunes/itunesfeature.cpp
+  src/library/itunes/itunesimporter.cpp
   src/library/itunes/itunesplaylistmodel.cpp
   src/library/itunes/itunesxmlimporter.cpp
   src/library/library_prefs.cpp

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -315,7 +315,7 @@ std::unique_ptr<ITunesImporter> ITunesFeature::makeImporter() {
     }
 #endif
     qDebug() << "Using ITunesXMLImporter to read iTunes library from " << m_dbfile;
-    return std::make_unique<ITunesXMLImporter>(this, m_dbfile, m_cancelImport, std::move(dao));
+    return std::make_unique<ITunesXMLImporter>(this, m_dbfile, std::move(dao));
 }
 
 // This method is executed in a separate thread

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -311,7 +311,7 @@ std::unique_ptr<ITunesImporter> ITunesFeature::makeImporter() {
 #ifdef __MACOS_ITUNES_LIBRARY__
     if (isMacOSImporterUsed()) {
         qDebug() << "Using ITunesMacOSImporter to read default iTunes library";
-        return std::make_unique<ITunesMacOSImporter>(this, m_cancelImport, std::move(dao));
+        return std::make_unique<ITunesMacOSImporter>(this, std::move(dao));
     }
 #endif
     qDebug() << "Using ITunesXMLImporter to read iTunes library from " << m_dbfile;

--- a/src/library/itunes/itunesfeature.h
+++ b/src/library/itunes/itunesfeature.h
@@ -31,6 +31,11 @@ class ITunesFeature : public BaseExternalLibraryFeature {
 
     TreeItemModel* sidebarModel() const override;
 
+    // This is called form the ITunesXMLImporter thread
+    bool isImportCanceled() {
+        return m_cancelImport.load();
+    }
+
   public slots:
     void activate() override;
     void activate(bool forceReload);

--- a/src/library/itunes/itunesfeature.h
+++ b/src/library/itunes/itunesfeature.h
@@ -31,8 +31,8 @@ class ITunesFeature : public BaseExternalLibraryFeature {
 
     TreeItemModel* sidebarModel() const override;
 
-    // This is called from the ITunesXMLImporter thread
-    bool isImportCanceled() {
+    // This is called from the ITunesXMLImporter thread and generally threadsafe
+    bool isImportCanceled() const {
         return m_cancelImport.load();
     }
 

--- a/src/library/itunes/itunesfeature.h
+++ b/src/library/itunes/itunesfeature.h
@@ -31,7 +31,7 @@ class ITunesFeature : public BaseExternalLibraryFeature {
 
     TreeItemModel* sidebarModel() const override;
 
-    // This is called form the ITunesXMLImporter thread
+    // This is called from the ITunesXMLImporter thread
     bool isImportCanceled() {
         return m_cancelImport.load();
     }

--- a/src/library/itunes/itunesimporter.cpp
+++ b/src/library/itunes/itunesimporter.cpp
@@ -1,0 +1,14 @@
+#include "library/itunes/itunesfeature.h"
+#include "library/itunes/itunesxmlimporter.h"
+
+ITunesImporter::ITunesImporter(ITunesFeature* pParentFeature)
+        : m_pParentFeature(pParentFeature) {
+}
+
+bool ITunesImporter::canceled() {
+    // The parent feature may be null during testing
+    if (m_pParentFeature) {
+        return m_pParentFeature->isImportCanceled();
+    }
+    return false;
+}

--- a/src/library/itunes/itunesimporter.cpp
+++ b/src/library/itunes/itunesimporter.cpp
@@ -5,7 +5,7 @@ ITunesImporter::ITunesImporter(ITunesFeature* pParentFeature)
         : m_pParentFeature(pParentFeature) {
 }
 
-bool ITunesImporter::canceled() {
+bool ITunesImporter::canceled() const {
     // The parent feature may be null during testing
     if (m_pParentFeature) {
         return m_pParentFeature->isImportCanceled();

--- a/src/library/itunes/itunesimporter.h
+++ b/src/library/itunes/itunesimporter.h
@@ -2,7 +2,8 @@
 
 #include <memory>
 
-#include "library/treeitem.h"
+class TreeItem;
+class ITunesFeature;
 
 struct ITunesImport {
     std::unique_ptr<TreeItem> playlistRoot;
@@ -10,14 +11,14 @@ struct ITunesImport {
 
 class ITunesImporter {
   public:
+    ITunesImporter(ITunesFeature* pParentFeature);
+
     virtual ~ITunesImporter() = default;
 
     virtual ITunesImport importLibrary() = 0;
 
-    // TODO: Add thread-safe `cancelImport` method and move `m_cancelImport`
-    // from ITunesFeature to the individual importers (replacing the current
-    // mechanism of passing (the private member) `m_cancelImport` by reference
-    // to each importer). We should then call `cancelImport` from the
-    // `ITunesFeature` destructor on the importer (which we'd need to store e.g.
-    // in a member of `ITunesFeature`).
+    bool canceled();
+
+  protected:
+    ITunesFeature* m_pParentFeature;
 };

--- a/src/library/itunes/itunesimporter.h
+++ b/src/library/itunes/itunesimporter.h
@@ -20,5 +20,6 @@ class ITunesImporter {
     bool canceled() const;
 
   protected:
+    // This is a borrowed pointer. The ITunesFeature owns the ITunesImporter.
     ITunesFeature* m_pParentFeature;
 };

--- a/src/library/itunes/itunesimporter.h
+++ b/src/library/itunes/itunesimporter.h
@@ -17,7 +17,7 @@ class ITunesImporter {
 
     virtual ITunesImport importLibrary() = 0;
 
-    bool canceled();
+    bool canceled() const;
 
   protected:
     ITunesFeature* m_pParentFeature;

--- a/src/library/itunes/itunesmacosimporter.h
+++ b/src/library/itunes/itunesmacosimporter.h
@@ -5,25 +5,21 @@
 #include <atomic>
 #include <memory>
 
-#include "library/itunes/itunesdao.h"
 #include "library/itunes/itunesimporter.h"
-#include "library/libraryfeature.h"
+
+class ITunesDAO;
+class ITunesFeature;
 
 /// An importer that reads the user's default iTunes/Music.app library
 /// using the native `iTunesLibrary` framework on macOS.
 class ITunesMacOSImporter : public ITunesImporter {
   public:
-    ITunesMacOSImporter(LibraryFeature* parentFeature,
-            const std::atomic<bool>& cancelImport,
+    ITunesMacOSImporter(
+            ITunesFeature* pParentFeature,
             std::unique_ptr<ITunesDAO> dao);
 
     ITunesImport importLibrary() override;
 
   private:
-    LibraryFeature* m_parentFeature;
-    // The values behind these references are owned by the parent `ITunesFeature`,
-    // thus there is an implicit contract here that this `ITunesMacOSImporter` cannot
-    // outlive the feature (which should not happen anyway, since importers are short-lived).
-    const std::atomic<bool>& m_cancelImport;
     std::unique_ptr<ITunesDAO> m_dao;
 };

--- a/src/library/itunes/itunesmacosimporter.mm
+++ b/src/library/itunes/itunesmacosimporter.mm
@@ -2,7 +2,6 @@
 
 #import <iTunesLibrary/iTunesLibrary.h>
 #include <gsl/pointers>
-#include "library/itunes/itunesdao.h"
 
 #include <QHash>
 #include <QSqlDatabase>
@@ -16,8 +15,8 @@
 #include <optional>
 #include <utility>
 
-#include "library/itunes/itunesimporter.h"
-#include "library/libraryfeature.h"
+#include "library/itunes/itunesdao.h"
+#include "library/itunes/itunesfeature.h"
 #include "library/queryutil.h"
 #include "library/treeitem.h"
 #include "library/treeitemmodel.h"
@@ -30,8 +29,8 @@ QString qStringFrom(NSString* nsString) {
 
 class ImporterImpl {
   public:
-    ImporterImpl(const std::atomic<bool>& cancelImport, ITunesDAO& dao)
-            : m_cancelImport(cancelImport), m_dao(dao) {
+    ImporterImpl(ITunesMacOSImporter* pImporter, ITunesDAO& dao)
+            : m_pImporter(pImporter), m_dao(dao) {
     }
 
     void importPlaylists(NSArray<ITLibPlaylist*>* playlists) {
@@ -43,7 +42,7 @@ class ImporterImpl {
         // interact well with Objective-C collections.
 
         for (ITLibPlaylist* playlist in playlists) {
-            if (m_cancelImport.load()) {
+            if (m_pImporter->canceled()) {
                 break;
             }
 
@@ -55,7 +54,7 @@ class ImporterImpl {
         qDebug() << "Importing media items via native iTunesLibrary framework";
 
         for (ITLibMediaItem* item in items) {
-            if (m_cancelImport.load()) {
+            if (m_pImporter->canceled()) {
                 break;
             }
 
@@ -68,7 +67,7 @@ class ImporterImpl {
     }
 
   private:
-    const std::atomic<bool>& m_cancelImport;
+    ITunesMacOSImporter* m_pImporter;
 
     QHash<unsigned long long, int> m_dbIdByPersistentId;
     ITunesDAO& m_dao;
@@ -152,7 +151,7 @@ class ImporterImpl {
 
         int i = 0;
         for (ITLibMediaItem* item in itPlaylist.items) {
-            if (m_cancelImport.load()) {
+            if (m_pImporter->canceled()) {
                 return;
             }
 
@@ -198,12 +197,9 @@ class ImporterImpl {
 
 } // anonymous namespace
 
-ITunesMacOSImporter::ITunesMacOSImporter(LibraryFeature* parentFeature,
-        const std::atomic<bool>& cancelImport,
-        std::unique_ptr<ITunesDAO> dao)
-        : m_parentFeature(parentFeature),
-          m_cancelImport(cancelImport),
-          m_dao(std::move(dao)) {
+ITunesMacOSImporter::ITunesMacOSImporter(
+        ITunesFeature* pParentFeature, std::unique_ptr<ITunesDAO> dao)
+        : ITunesImporter(pParentFeature), m_dao(std::move(dao)) {
 }
 
 ITunesImport ITunesMacOSImporter::importLibrary() {
@@ -214,8 +210,9 @@ ITunesImport ITunesMacOSImporter::importLibrary() {
                                                          error:&error];
 
     if (library) {
-        std::unique_ptr<TreeItem> rootItem = TreeItem::newRoot(m_parentFeature);
-        ImporterImpl impl(m_cancelImport, *m_dao);
+        std::unique_ptr<TreeItem> rootItem =
+                TreeItem::newRoot(m_pParentFeature);
+        ImporterImpl impl(this, *m_dao);
 
         impl.importPlaylists(library.allPlaylists);
         impl.importMediaItems(library.allMediaItems);

--- a/src/library/itunes/itunesxmlimporter.cpp
+++ b/src/library/itunes/itunesxmlimporter.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "library/itunes/itunesdao.h"
+#include "library/itunes/itunesfeature.h"
 #include "library/itunes/itunesimporter.h"
 #include "library/itunes/ituneslocalhosttoken.h"
 #include "library/queryutil.h"
@@ -43,15 +44,14 @@ const QString kRemote = "Remote";
 
 } // anonymous namespace
 
-ITunesXMLImporter::ITunesXMLImporter(LibraryFeature* parentFeature,
+ITunesXMLImporter::ITunesXMLImporter(
+        ITunesFeature* pParentFeature,
         const QString& xmlFilePath,
-        const std::atomic<bool>& cancelImport,
         std::unique_ptr<ITunesDAO> dao)
-        : m_parentFeature(parentFeature),
+        : m_pParentFeature(pParentFeature),
           m_xmlFilePath(xmlFilePath),
           m_xmlFile(xmlFilePath),
           m_xml(&m_xmlFile),
-          m_cancelImport(cancelImport),
           m_dao(std::move(dao)) {
     // By default set m_mixxxItunesRoot and m_dbItunesRoot to strip out
     // file://localhost/ from the URL. When we load the user's iTunes XML
@@ -73,7 +73,7 @@ ITunesImport ITunesXMLImporter::importLibrary() {
         return iTunesImport;
     }
 
-    while (!m_xml.atEnd() && !m_cancelImport.load()) {
+    while (!m_xml.atEnd() && !canceled()) {
         m_xml.readNext();
         if (m_xml.isStartElement()) {
             if (m_xml.name() == QLatin1String("key")) {
@@ -90,9 +90,9 @@ ITunesImport ITunesXMLImporter::importLibrary() {
                 } else if (key == "Playlists") {
                     parsePlaylists();
 
-                    // The parent feature may ne null during testing
-                    std::unique_ptr<TreeItem> pRootItem = m_parentFeature
-                            ? TreeItem::newRoot(m_parentFeature)
+                    // The parent feature may be null during testing
+                    std::unique_ptr<TreeItem> pRootItem = m_pParentFeature
+                            ? TreeItem::newRoot(m_pParentFeature)
                             : std::make_unique<TreeItem>();
                     m_dao->appendPlaylistTree(pRootItem.get());
 
@@ -213,7 +213,7 @@ void ITunesXMLImporter::parseTracks() {
     qDebug() << "Parse iTunes music collection";
 
     // read all sunsequent <dict> until we reach the closing ENTRY tag
-    while (!m_xml.atEnd() && !m_cancelImport.load()) {
+    while (!m_xml.atEnd() && !canceled()) {
         m_xml.readNext();
 
         if (m_xml.isStartElement()) {
@@ -397,7 +397,7 @@ void ITunesXMLImporter::parseTrack() {
 void ITunesXMLImporter::parsePlaylists() {
     qDebug() << "Parse iTunes playlists";
 
-    while (!m_xml.atEnd() && !m_cancelImport.load()) {
+    while (!m_xml.atEnd() && !canceled()) {
         m_xml.readNext();
         // We process and iterate the <dict> tags holding playlist summary information here
         if (m_xml.isStartElement() && m_xml.name() == kDict) {
@@ -436,7 +436,7 @@ void ITunesXMLImporter::parsePlaylist() {
     bool isPlaylistItemsStarted = false;
 
     // We process and iterate the <dict> tags holding playlist summary information here
-    while (!m_xml.atEnd() && !m_cancelImport.load()) {
+    while (!m_xml.atEnd() && !canceled()) {
         m_xml.readNext();
 
         if (m_xml.isStartElement()) {
@@ -540,4 +540,12 @@ void ITunesXMLImporter::parsePlaylist() {
 
         m_dao->importPlaylistRelation(parentId, playlist.id);
     }
+}
+
+bool ITunesXMLImporter::canceled() {
+    // The parent feature may be null during testing
+    if (m_pParentFeature) {
+        return m_pParentFeature->isImportCanceled();
+    }
+    return false;
 }

--- a/src/library/itunes/itunesxmlimporter.cpp
+++ b/src/library/itunes/itunesxmlimporter.cpp
@@ -48,7 +48,7 @@ ITunesXMLImporter::ITunesXMLImporter(
         ITunesFeature* pParentFeature,
         const QString& xmlFilePath,
         std::unique_ptr<ITunesDAO> dao)
-        : m_pParentFeature(pParentFeature),
+        : ITunesImporter(pParentFeature),
           m_xmlFilePath(xmlFilePath),
           m_xmlFile(xmlFilePath),
           m_xml(&m_xmlFile),
@@ -540,12 +540,4 @@ void ITunesXMLImporter::parsePlaylist() {
 
         m_dao->importPlaylistRelation(parentId, playlist.id);
     }
-}
-
-bool ITunesXMLImporter::canceled() {
-    // The parent feature may be null during testing
-    if (m_pParentFeature) {
-        return m_pParentFeature->isImportCanceled();
-    }
-    return false;
 }

--- a/src/library/itunes/itunesxmlimporter.h
+++ b/src/library/itunes/itunesxmlimporter.h
@@ -9,27 +9,26 @@
 #include "library/itunes/itunesdao.h"
 #include "library/itunes/itunesimporter.h"
 #include "library/itunes/itunespathmapping.h"
-#include "library/libraryfeature.h"
+
+class ITunesFeature;
 
 /// An importer that parses an iTunes XML library.
 class ITunesXMLImporter : public ITunesImporter {
   public:
-    ITunesXMLImporter(LibraryFeature* parentFeature,
+    ITunesXMLImporter(
+            ITunesFeature* pParentFeature,
             const QString& xmlFilePath,
-            const std::atomic<bool>& cancelImport,
             std::unique_ptr<ITunesDAO> dao);
 
     ITunesImport importLibrary() override;
 
   private:
-    LibraryFeature* m_parentFeature;
+    bool canceled();
+
+    ITunesFeature* m_pParentFeature;
     const QString m_xmlFilePath;
     QFile m_xmlFile;
     QXmlStreamReader m_xml;
-    // The values behind the references are owned by the parent `ITunesFeature`
-    // thus there is an implicit contract here that this `ITunesXMLImporter` cannot
-    // outlive the feature (which should not happen anyway, since importers are short-lived).
-    const std::atomic<bool>& m_cancelImport;
     std::unique_ptr<ITunesDAO> m_dao;
 
     ITunesPathMapping m_pathMapping;

--- a/src/library/itunes/itunesxmlimporter.h
+++ b/src/library/itunes/itunesxmlimporter.h
@@ -23,9 +23,6 @@ class ITunesXMLImporter : public ITunesImporter {
     ITunesImport importLibrary() override;
 
   private:
-    bool canceled();
-
-    ITunesFeature* m_pParentFeature;
     const QString m_xmlFilePath;
     QFile m_xmlFile;
     QXmlStreamReader m_xml;

--- a/src/test/itunesxmlimportertest.cpp
+++ b/src/test/itunesxmlimportertest.cpp
@@ -22,12 +22,9 @@ class ITunesXMLImporterTest : public MixxxTest {
             const QString& xmlFileName, std::unique_ptr<ITunesDAO> dao) {
         QString xmlFilePath = getITunesTestDir().absoluteFilePath(xmlFileName);
         auto importer = std::make_unique<ITunesXMLImporter>(
-                nullptr, xmlFilePath, cancelImport, std::move(dao));
+                nullptr, xmlFilePath, std::move(dao));
         return importer;
     }
-
-  private:
-    std::atomic<bool> cancelImport;
 };
 
 class MockITunesDAO : public ITunesDAO {


### PR DESCRIPTION
Use a function call with a null check instead.

The failing test has happened on Launchpad: 
https://launchpadlibrarian.net/672913729/buildlog_ubuntu-focal-amd64.mixxx_2.4~beta~22~ge7bb02f7a5-1~focal_BUILDING.txt.gz