### PR TITLE
Export CSV: fixing null values in export

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -590,21 +590,9 @@ QVariant BaseTrackTableModel::roleValue(
             break;
         }
         M_FALLTHROUGH_INTENDED;
-    // Right align BPM, duraation and bitrate so big/small values can easily be
-    // spotted by length (number of digits)
-    case Qt::TextAlignmentRole: {
-        switch (field) {
-        case ColumnCache::COLUMN_LIBRARYTABLE_BPM:
-        case ColumnCache::COLUMN_LIBRARYTABLE_DURATION:
-        case ColumnCache::COLUMN_LIBRARYTABLE_BITRATE: {
-            // We need to cast to int due to a bug similar to
-            // https://bugreports.qt.io/browse/QTBUG-67582
-            return static_cast<int>(Qt::AlignVCenter | Qt::AlignRight);
-        }
-        default:
-            return QVariant(); // default AlignLeft for all other columns
-        }
-    }
+    // NOTE: for export we need to fall through to Qt::DisplayRole,
+    // so do not add any other role cases here, or the export
+    // will be empty
     case Qt::DisplayRole:
         switch (field) {
         case ColumnCache::COLUMN_LIBRARYTABLE_DURATION: {
@@ -871,6 +859,21 @@ QVariant BaseTrackTableModel::roleValue(
         } else {
             // Undecidable
             return Qt::PartiallyChecked;
+        }
+    }
+    // Right align BPM, duration and bitrate so big/small values can easily be
+    // spotted by length (number of digits)
+    case Qt::TextAlignmentRole: {
+        switch (field) {
+        case ColumnCache::COLUMN_LIBRARYTABLE_BPM:
+        case ColumnCache::COLUMN_LIBRARYTABLE_DURATION:
+        case ColumnCache::COLUMN_LIBRARYTABLE_BITRATE: {
+            // We need to cast to int due to a bug similar to
+            // https://bugreports.qt.io/browse/QTBUG-67582
+            return static_cast<int>(Qt::AlignVCenter | Qt::AlignRight);
+        }
+        default:
+            return QVariant(); // default AlignLeft for all other columns
         }
     }
     default:


### PR DESCRIPTION
Improper location of right-alignment role caused fallthrough of export fields into the TextAlignment role instead of the DisplayRole leading null values in export.

Fixes: #11657 

Seems to be an unintended consequence of edits from #11634
