### PR TITLE
add settings directory link to Help menu

### DIFF
--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -618,6 +618,18 @@ void WMainMenuBar::initialize() {
             });
     pHelpMenu->addAction(pHelpKbdShortcuts);
 
+    // User Settings Directory
+    const QString& settingsDirPath = m_pConfig->getSettingsPath();
+    QString settingsDirTitle = tr("&Settings directory");
+    QString settingsDirText = tr("Open the Mixxx user settings directory.");
+    auto* pHelpSettingsDir = new QAction(settingsDirTitle, this);
+    pHelpSettingsDir->setStatusTip(settingsDirText);
+    pHelpSettingsDir->setWhatsThis(buildWhatsThis(settingsDirTitle, settingsDirText));
+    connect(pHelpSettingsDir, &QAction::triggered, this, [this, settingsDirPath] {
+        slotVisitUrl(settingsDirPath);
+    });
+    pHelpMenu->addAction(pHelpSettingsDir);
+
     // Translate This Application
     QString translateTitle = tr("&Translate This Application") + externalLinkSuffix;
     QString translateText = tr("Help translate this application into your language.");


### PR DESCRIPTION
A menu item is a real shortcut compared to clicking the button in Pref > Library and or pasting the path into a file manager bar.

Closes #11667