### PR TITLE
Disable false positive clang-tidy warning

### DIFF
--- a/src/library/export/dlglibraryexport.cpp
+++ b/src/library/export/dlglibraryexport.cpp
@@ -253,6 +253,9 @@ void DlgLibraryExport::checkExistingDatabase() {
         djinterop::database db = el::load_database(databaseDirectory.toStdString());
         const auto version = db.version();
 
+        // Silence clang-tidy false positive:
+        // 'const auto result' can be declared as 'const auto *const result'
+        // NOLINTNEXTLINE(readability-qualified-auto)
         const auto result = std::find(el::all_versions.begin(), el::all_versions.end(), version);
         if (result == el::all_versions.end()) {
             // Unknown database version.


### PR DESCRIPTION
The proposed fix does not compile with MSVC and seems to be confusing anyway:
`'const auto result' can be declared as 'const auto *const result'`

The use of auto is however required here, because the type of "all_versions" is `std::array<engine_version, 19>` which may be a subject to change. 
https://github.com/xsco/libdjinterop/blob/8a32c822c1422843f521e2cdd16e36e7530e1d93/include/djinterop/engine/engine.hpp#L141
