### PR TITLE
Log export of track metadata into file

### DIFF
--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -904,12 +904,10 @@ class SafelyWritableFile final {
 std::pair<MetadataSource::ExportResult, QDateTime>
 MetadataSourceTagLib::exportTrackMetadata(
         const TrackMetadata& trackMetadata) const {
-    // NOTE(uklotzde): Log unconditionally (with debug level) to
-    // identify files in the log file that might have caused a
-    // crash while exporting metadata.
-    kLogger.debug() << "Exporting track metadata"
-                    << "into file" << m_fileName
-                    << "with type" << m_fileType;
+    // Modifying an external file is a potentially dangerous operation.
+    // If this operation unexpectedly crashes or corrupts data we need
+    // to identify the file that is affected.
+    kLogger.info() << "Exporting track metadata into file:" << m_fileName;
 
     SafelyWritableFile safelyWritableFile(m_fileName, kExportTrackMetadataIntoTemporaryFile);
     if (!safelyWritableFile.isReady()) {


### PR DESCRIPTION
Debug -> Info

Logging `m_fileType` as a number is confusing and not needed.