### PR TITLE
Effects: store deck & main EQ in effects.xml

### DIFF
--- a/src/effects/chains/equalizereffectchain.cpp
+++ b/src/effects/chains/equalizereffectchain.cpp
@@ -29,7 +29,6 @@ EqualizerEffectChain::EqualizerEffectChain(
                 setFilterWaveform(
                         m_effectSlots.at(0)->getManifest()->isMixingEQ());
             });
-    // DlgPrefEq loads the Effect with loadEffectToGroup
 
     setupLegacyAliasesForGroup(handleAndGroup.name());
 }

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -318,10 +318,12 @@ void EffectsManager::saveEffectsXml() {
         standardEffectChainPresets.append(pPreset);
     }
 
-    auto outputChainPreset = m_outputEffectChain.data() != nullptr
-            ? EffectChainPresetPointer::create(m_outputEffectChain.data())
-            // required for tests
-            : EffectChainPresetPointer(new EffectChainPreset());
+    const auto outputChainPreset = m_outputEffectChain.isNull()
+            // required for tests when no output effect chain exists
+            ? EffectChainPresetPointer::create()
+            // no ownership concerns apply because we're just calling
+            // EffectChainPreset::EffectChainPreset(const EffectChain* chain)
+            : EffectChainPresetPointer::create(m_outputEffectChain.data());
 
     m_pChainPresetManager->saveEffectsXml(&doc,
             EffectsXmlData{

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -184,7 +184,7 @@ void EffectsManager::loadDefaultEqsAndQuickEffects() {
         pEqEffectSlot->loadEffectWithDefaults(pDefaultEqEffect);
     }
 
-    auto pDefaultQuickEffectPreset =
+    const auto pDefaultQuickEffectPreset =
             m_pChainPresetManager->getDefaultQuickEffectPreset();
     QHashIterator<QString, QuickEffectChainPointer> qeIt(m_quickEffectChains);
     while (qeIt.hasNext()) {
@@ -293,10 +293,11 @@ void EffectsManager::saveEffectsXml() {
     doc.appendChild(rootElement);
 
     QHash<QString, EffectManifestPointer> eqEffectManifests;
+    eqEffectManifests.reserve(m_equalizerEffectChains.size());
     QHashIterator<QString, EqualizerEffectChainPointer> eqIt(m_equalizerEffectChains);
     while (eqIt.hasNext()) {
         eqIt.next();
-        const auto pEffectSlot = eqIt.value().data()->getEffectSlot(0);
+        const auto pEffectSlot = eqIt.value()->getEffectSlot(0);
         VERIFY_OR_DEBUG_ASSERT(pEffectSlot) {
             return;
         }

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -172,6 +172,27 @@ void EffectsManager::addQuickEffectChain(const ChannelHandleAndGroup& deckHandle
     m_effectChainSlotsByGroup.insert(pChainSlot->group(), pChainSlot);
 }
 
+void EffectsManager::loadDefaultEqsAndQuickEffects() {
+    auto pDefaultEqEffect = m_pChainPresetManager->getDefaultEqEffect();
+    for (auto it = m_equalizerEffectChains.begin();
+            it != m_equalizerEffectChains.end();
+            it++) {
+        auto pEqChainSlot = it.value();
+        const auto pEqEffectSlot = pEqChainSlot->getEffectSlot(0);
+        VERIFY_OR_DEBUG_ASSERT(pEqEffectSlot) {
+            return;
+        }
+        pEqEffectSlot->loadEffectWithDefaults(pDefaultEqEffect);
+    }
+
+    auto pDefaultQuickEffectPreset =
+            m_pChainPresetManager->getDefaultQuickEffectPreset();
+    for (auto it = m_quickEffectChains.begin(); it != m_quickEffectChains.end(); it++) {
+        auto pChainSlot = it.value();
+        pChainSlot->loadChainPreset(pDefaultQuickEffectPreset);
+    }
+}
+
 EffectChainPointer EffectsManager::getEffectChain(
         const QString& group) const {
     return m_effectChainSlotsByGroup.value(group);

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -174,9 +174,7 @@ void EffectsManager::addQuickEffectChain(const ChannelHandleAndGroup& deckHandle
 
 void EffectsManager::loadDefaultEqsAndQuickEffects() {
     auto pDefaultEqEffect = m_pChainPresetManager->getDefaultEqEffect();
-    QHashIterator<QString, EqualizerEffectChainPointer> eqIt(m_equalizerEffectChains);
-    while (eqIt.hasNext()) {
-        auto pEqChainSlot = eqIt.next().value();
+    for (const auto& pEqChainSlot : std::as_const(m_equalizerEffectChains)) {
         const auto pEqEffectSlot = pEqChainSlot->getEffectSlot(0);
         VERIFY_OR_DEBUG_ASSERT(pEqEffectSlot) {
             return;
@@ -186,9 +184,7 @@ void EffectsManager::loadDefaultEqsAndQuickEffects() {
 
     const auto pDefaultQuickEffectPreset =
             m_pChainPresetManager->getDefaultQuickEffectPreset();
-    QHashIterator<QString, QuickEffectChainPointer> qeIt(m_quickEffectChains);
-    while (qeIt.hasNext()) {
-        auto pChainSlot = qeIt.next().value();
+    for (const auto& pChainSlot : std::as_const(m_quickEffectChains)) {
         pChainSlot->loadChainPreset(pDefaultQuickEffectPreset);
     }
 }
@@ -214,11 +210,7 @@ void EffectsManager::readEffectsXml() {
 
     // Note: QuickEffect and EQ chains are created only for existing main decks,
     // thus only for those the configured presets are requested
-    QStringList deckStrings;
-    QHashIterator<QString, QuickEffectChainPointer> qeIt(m_quickEffectChains);
-    while (qeIt.hasNext()) {
-        deckStrings << qeIt.next().key();
-    }
+    const QStringList deckStrings = m_quickEffectChains.keys();
     EffectsXmlData data = m_pChainPresetManager->readEffectsXml(doc, deckStrings);
 
     for (int i = 0; i < data.standardEffectChainPresets.size(); i++) {

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -203,6 +203,10 @@ void EffectsManager::readEffectsXml() {
         m_standardEffectChains.value(i)->loadChainPreset(data.standardEffectChainPresets.at(i));
     }
 
+    if (!data.outputChainPreset.isNull()) {
+        m_outputEffectChain->loadChainPreset(data.outputChainPreset);
+    }
+
     for (auto it = data.eqEffectManifests.begin();
             it != data.eqEffectManifests.end();
             it++) {
@@ -288,11 +292,17 @@ void EffectsManager::saveEffectsXml() {
         standardEffectChainPresets.append(pPreset);
     }
 
+    auto outputChainPreset = m_outputEffectChain.data() != nullptr
+            ? EffectChainPresetPointer::create(m_outputEffectChain.data())
+            // required for tests
+            : EffectChainPresetPointer(new EffectChainPreset());
+
     m_pChainPresetManager->saveEffectsXml(&doc,
             EffectsXmlData{
                     eqEffectManifests,
                     quickEffectChainPresets,
-                    standardEffectChainPresets});
+                    standardEffectChainPresets,
+                    outputChainPreset});
     m_pVisibleEffectsList->saveEffectsXml(&doc);
 
     QDir settingsPath(m_pConfig->getSettingsPath());

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -298,6 +298,7 @@ void EffectsManager::saveEffectsXml() {
     }
 
     QHash<QString, EffectChainPresetPointer> quickEffectChainPresets;
+    quickEffectChainPresets.reserve(m_quickEffectChains.size());
     QHashIterator<QString, QuickEffectChainPointer> qeIt(m_quickEffectChains);
     while (qeIt.hasNext()) {
         qeIt.next();
@@ -306,6 +307,7 @@ void EffectsManager::saveEffectsXml() {
     }
 
     QList<EffectChainPresetPointer> standardEffectChainPresets;
+    standardEffectChainPresets.reserve(m_quickEffectChains.size());
     for (const auto& pChainSlot : std::as_const(m_standardEffectChains)) {
         auto pPreset = EffectChainPresetPointer::create(pChainSlot.data());
         standardEffectChainPresets.append(pPreset);

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -302,14 +302,16 @@ void EffectsManager::saveEffectsXml() {
     QHashIterator<QString, QuickEffectChainPointer> qeIt(m_quickEffectChains);
     while (qeIt.hasNext()) {
         qeIt.next();
-        auto pPreset = EffectChainPresetPointer::create(qeIt.value().data());
+        auto* pQuickEffectChain = qeIt.value().data();
+        auto pPreset = EffectChainPresetPointer::create(pQuickEffectChain);
         quickEffectChainPresets.insert(qeIt.key(), pPreset);
     }
 
     QList<EffectChainPresetPointer> standardEffectChainPresets;
     standardEffectChainPresets.reserve(m_quickEffectChains.size());
     for (const auto& pChainSlot : std::as_const(m_standardEffectChains)) {
-        auto pPreset = EffectChainPresetPointer::create(pChainSlot.data());
+        auto* pChain = pChainSlot.data();
+        auto pPreset = EffectChainPresetPointer::create(pChain);
         standardEffectChainPresets.append(pPreset);
     }
 

--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -28,6 +28,8 @@ class EffectsManager {
     void setup();
     void addDeck(const ChannelHandleAndGroup& deckHandleGroup);
 
+    void loadDefaultEqsAndQuickEffects();
+
     EffectChainPointer getEffectChain(const QString& group) const;
     EqualizerEffectChainPointer getEqualizerEffectChain(
             const QString& deckGroupName) const {

--- a/src/effects/presets/effectchainpreset.cpp
+++ b/src/effects/presets/effectchainpreset.cpp
@@ -40,7 +40,7 @@ EffectChainPreset::EffectChainPreset(const QDomElement& chainElement) {
         QDomNode effectNode = effectList.at(i);
         if (effectNode.isElement()) {
             QDomElement effectElement = effectNode.toElement();
-            EffectPresetPointer pPreset(new EffectPreset(effectElement));
+            auto pPreset = EffectPresetPointer::create(effectElement);
             m_effectPresets.append(pPreset);
         }
     }
@@ -55,7 +55,7 @@ EffectChainPreset::EffectChainPreset(const EffectChain* chain)
           m_dSuper(chain->getSuperParameter()),
           m_readOnly(false) {
     for (const auto& pEffectSlot : chain->getEffectSlots()) {
-        m_effectPresets.append(EffectPresetPointer(new EffectPreset(pEffectSlot)));
+        m_effectPresets.append(EffectPresetPointer::create(pEffectSlot));
     }
 }
 
@@ -64,7 +64,7 @@ EffectChainPreset::EffectChainPreset(EffectManifestPointer pManifest)
           m_mixMode(EffectChainMixMode::DrySlashWet),
           m_dSuper(pManifest->metaknobDefault()),
           m_readOnly(false) {
-    m_effectPresets.append(EffectPresetPointer(new EffectPreset(pManifest)));
+    m_effectPresets.append(EffectPresetPointer::create(pManifest));
 }
 
 EffectChainPreset::EffectChainPreset(EffectPresetPointer pEffectPreset)

--- a/src/effects/presets/effectchainpresetmanager.cpp
+++ b/src/effects/presets/effectchainpresetmanager.cpp
@@ -666,8 +666,7 @@ bool EffectChainPresetManager::savePresetXml(EffectChainPresetPointer pPreset) {
 EffectManifestPointer EffectChainPresetManager::getDefaultEqEffect() {
     EffectManifestPointer pDefaultEqEffect = m_pBackendManager->getManifest(
             BiquadFullKillEQEffect::getId(), EffectBackendType::BuiltIn);
-    VERIFY_OR_DEBUG_ASSERT(!pDefaultEqEffect.isNull()) {
-    }
+    DEBUG_ASSERT(!pDefaultEqEffect.isNull());
     return pDefaultEqEffect;
 }
 
@@ -939,32 +938,32 @@ void EffectChainPresetManager::saveEffectsXml(QDomDocument* pDoc, const EffectsX
     // Save ids of effects loaded to slot 1 of EQ chains
     QDomElement eqEffectsElement =
             pDoc->createElement(EffectXml::kEqualizerEffects);
-    for (auto it = data.eqEffectManifests.begin();
-            it != data.eqEffectManifests.end();
-            it++) {
+    QHashIterator<QString, EffectManifestPointer> eqIt(data.eqEffectManifests);
+    while (eqIt.hasNext()) {
+        eqIt.next();
         // Save element with '---' if no EQ is loaded
-        QString uid = it.value().isNull() ? kNoEffectString : it.value()->uniqueId();
+        QString uid = eqIt.value().isNull() ? kNoEffectString : eqIt.value()->uniqueId();
         QDomElement eqEffectElement = XmlParse::addElement(
                 *pDoc,
                 eqEffectsElement,
                 EffectXml::kEffectId,
                 uid);
-        eqEffectElement.setAttribute(QStringLiteral("group"), it.key());
+        eqEffectElement.setAttribute(QStringLiteral("group"), eqIt.key());
     }
     rootElement.appendChild(eqEffectsElement);
 
     // Save which presets are loaded to QuickEffects
     QDomElement quickEffectPresetsElement =
             pDoc->createElement(EffectXml::kQuickEffectChainPresets);
-    for (auto it = data.quickEffectChainPresets.begin();
-            it != data.quickEffectChainPresets.end();
-            it++) {
+    QHashIterator<QString, EffectChainPresetPointer> qeIt(data.quickEffectChainPresets);
+    while (qeIt.hasNext()) {
+        qeIt.next();
         QDomElement quickEffectElement = XmlParse::addElement(
                 *pDoc,
                 quickEffectPresetsElement,
                 EffectXml::kChainPresetName,
-                it.value()->name());
-        quickEffectElement.setAttribute(QStringLiteral("group"), it.key());
+                qeIt.value()->name());
+        quickEffectElement.setAttribute(QStringLiteral("group"), qeIt.key());
     }
     rootElement.appendChild(quickEffectPresetsElement);
 }

--- a/src/effects/presets/effectchainpresetmanager.cpp
+++ b/src/effects/presets/effectchainpresetmanager.cpp
@@ -33,8 +33,7 @@ EffectChainPresetPointer loadPresetFromFile(const QString& filePath) {
         qWarning() << "Could not read XML from chain preset file" << filePath;
         return nullptr;
     }
-    EffectChainPresetPointer pEffectChainPreset(
-            new EffectChainPreset(doc.documentElement()));
+    auto pEffectChainPreset = EffectChainPresetPointer::create(doc.documentElement());
     file.close();
     return pEffectChainPreset;
 }
@@ -46,8 +45,7 @@ EffectChainPresetPointer createEmptyChainPreset() {
     pEmptyManifest->setMetaknobDefault(0.5);
     // Required for the QuickEffect selector in DlgPrefEQ
     pEmptyManifest->setShortName(kNoEffectString);
-    auto pEmptyChainPreset =
-            EffectChainPresetPointer(new EffectChainPreset(pEmptyManifest));
+    auto pEmptyChainPreset = EffectChainPresetPointer::create(pEmptyManifest);
     pEmptyChainPreset->setReadOnly();
 
     return pEmptyChainPreset;
@@ -139,8 +137,7 @@ bool EffectChainPresetManager::importPreset() {
         }
         file.close();
 
-        EffectChainPresetPointer pPreset(
-                new EffectChainPreset(doc.documentElement()));
+        auto pPreset = EffectChainPresetPointer::create(doc.documentElement());
         if (!pPreset->isEmpty() && !pPreset->name().isEmpty()) {
             // Don't allow '---' because that's the name of the internal empty preset
             if (pPreset->name() == kNoEffectString) {
@@ -578,7 +575,7 @@ void EffectChainPresetManager::generateDefaultQuickEffectPresets() {
     }
     std::sort(manifestList.begin(), manifestList.end(), EffectManifest::sortLexigraphically);
     for (const auto& pManifest : manifestList) {
-        auto pChainPreset = EffectChainPresetPointer(new EffectChainPreset(pManifest));
+        auto pChainPreset = EffectChainPresetPointer::create(pManifest);
         pChainPreset->setName(pManifest->displayName());
         m_effectChainPresets.insert(pChainPreset->name(), pChainPreset);
         m_quickEffectChainPresetsSorted.append(pChainPreset);
@@ -706,8 +703,8 @@ EffectsXmlData EffectChainPresetManager::readEffectsXml(
 
         if (chainNode.isElement()) {
             QDomElement chainElement = chainNode.toElement();
-            EffectChainPresetPointer pPreset(
-                    new EffectChainPreset(chainElement));
+            EffectChainPresetPointer pPreset =
+                    EffectChainPresetPointer::create(chainElement);
             standardEffectChainPresets.append(pPreset);
         }
     }
@@ -718,8 +715,7 @@ EffectsXmlData EffectChainPresetManager::readEffectsXml(
     EffectChainPresetPointer mainEqPreset = nullptr;
     if (mainEqChainNode.isElement()) {
         QDomElement mainEqChainElement = mainEqChainNode.toElement();
-        mainEqPreset = EffectChainPresetPointer(
-                new EffectChainPreset(mainEqChainElement));
+        mainEqPreset = EffectChainPresetPointer::create(mainEqChainElement);
     }
 
     importUserPresets();

--- a/src/effects/presets/effectchainpresetmanager.cpp
+++ b/src/effects/presets/effectchainpresetmanager.cpp
@@ -711,6 +711,16 @@ EffectsXmlData EffectChainPresetManager::readEffectsXml(
         }
     }
 
+    QDomElement mainEqElement = XmlParse::selectElement(root, EffectXml::kMainEq);
+    QDomNodeList mainEqs = mainEqElement.elementsByTagName(EffectXml::kChain);
+    QDomNode mainEqChainNode = mainEqs.at(0);
+    EffectChainPresetPointer mainEqPreset;
+    if (mainEqChainNode.isElement()) {
+        QDomElement mainEqChainElement = mainEqChainNode.toElement();
+        mainEqPreset = EffectChainPresetPointer(
+                new EffectChainPreset(mainEqChainElement));
+    }
+
     importUserPresets();
 
     // Reload order of custom chain presets
@@ -822,7 +832,7 @@ EffectsXmlData EffectChainPresetManager::readEffectsXml(
     }
 
     return EffectsXmlData{
-            eqEffectManifests, quickEffectPresets, standardEffectChainPresets};
+            eqEffectManifests, quickEffectPresets, standardEffectChainPresets, mainEqPreset};
 }
 
 EffectXmlDataSingleDeck EffectChainPresetManager::readEffectsXmlSingleDeck(
@@ -891,6 +901,12 @@ void EffectChainPresetManager::saveEffectsXml(QDomDocument* pDoc, const EffectsX
     for (const auto& pPreset : std::as_const(data.standardEffectChainPresets)) {
         chainsElement.appendChild(pPreset->toXml(pDoc));
     }
+
+    // Save main EQ effect
+    QDomElement mainEqElement = pDoc->createElement(EffectXml::kMainEq);
+    rootElement.appendChild(mainEqElement);
+    const auto& mainEqPreset = data.outputChainPreset;
+    mainEqElement.appendChild(mainEqPreset->toXml(pDoc));
 
     // Save order of custom chain presets
     QDomElement chainPresetListElement =

--- a/src/effects/presets/effectchainpresetmanager.cpp
+++ b/src/effects/presets/effectchainpresetmanager.cpp
@@ -42,6 +42,8 @@ EffectChainPresetPointer loadPresetFromFile(const QString& filePath) {
 EffectChainPresetPointer createEmptyChainPreset() {
     EffectManifestPointer pEmptyManifest(new EffectManifest());
     pEmptyManifest->setName(kNoEffectString);
+    // Center the Super knob, eliminates the colored (bipolar) knob ring
+    pEmptyManifest->setMetaknobDefault(0.5);
     // Required for the QuickEffect selector in DlgPrefEQ
     pEmptyManifest->setShortName(kNoEffectString);
     auto pEmptyChainPreset =

--- a/src/effects/presets/effectchainpresetmanager.cpp
+++ b/src/effects/presets/effectchainpresetmanager.cpp
@@ -696,7 +696,7 @@ EffectsXmlData EffectChainPresetManager::readEffectsXml(
     QDomElement rackElement = XmlParse::selectElement(root, EffectXml::kRack);
     QDomElement chainsElement =
             XmlParse::selectElement(rackElement, EffectXml::kChainsRoot);
-    QDomNodeList chainsList = chainsElement.elementsByTagName(EffectXml::kChain);
+    const QDomNodeList chainsList = chainsElement.elementsByTagName(EffectXml::kChain);
 
     for (int i = 0; i < chainsList.count(); ++i) {
         QDomNode chainNode = chainsList.at(i);
@@ -723,7 +723,7 @@ EffectsXmlData EffectChainPresetManager::readEffectsXml(
     // Reload order of custom chain presets
     QDomElement chainPresetsElement =
             XmlParse::selectElement(root, EffectXml::kChainPresetList);
-    QDomNodeList presetNameList =
+    const QDomNodeList presetNameList =
             chainPresetsElement.elementsByTagName(EffectXml::kChainPresetName);
     for (int i = 0; i < presetNameList.count(); ++i) {
         QDomNode presetNameNode = presetNameList.at(i);
@@ -752,7 +752,7 @@ EffectsXmlData EffectChainPresetManager::readEffectsXml(
     // Reload order of QuickEffect chain presets
     QDomElement quickEffectChainPresetsElement =
             XmlParse::selectElement(root, EffectXml::kQuickEffectList);
-    QDomNodeList quickEffectPresetNameList =
+    const QDomNodeList quickEffectPresetNameList =
             quickEffectChainPresetsElement.elementsByTagName(EffectXml::kChainPresetName);
     for (int i = 0; i < quickEffectPresetNameList.count(); ++i) {
         QDomNode presetNameNode = quickEffectPresetNameList.at(i);
@@ -792,7 +792,7 @@ EffectsXmlData EffectChainPresetManager::readEffectsXml(
     // Read ids of effects that were loaded into Equalizer slots on last shutdown
     QDomElement eqEffectsElement =
             XmlParse::selectElement(root, EffectXml::kEqualizerEffects);
-    QDomNodeList eqEffectNodeList =
+    const QDomNodeList eqEffectNodeList =
             eqEffectsElement.elementsByTagName(
                     EffectXml::kEffectId);
     for (int i = 0; i < eqEffectNodeList.count(); ++i) {
@@ -812,7 +812,7 @@ EffectsXmlData EffectChainPresetManager::readEffectsXml(
     // Read names of presets that were loaded into QuickEffects on last shutdown
     QDomElement quickEffectPresetsElement =
             XmlParse::selectElement(root, EffectXml::kQuickEffectChainPresets);
-    QDomNodeList quickEffectNodeList =
+    const QDomNodeList quickEffectNodeList =
             quickEffectPresetsElement.elementsByTagName(
                     EffectXml::kChainPresetName);
     for (int i = 0; i < quickEffectNodeList.count(); ++i) {
@@ -842,7 +842,7 @@ EffectXmlDataSingleDeck EffectChainPresetManager::readEffectsXmlSingleDeck(
     // Read id of last loaded EQ effect
     QDomElement eqEffectsElement =
             XmlParse::selectElement(root, EffectXml::kEqualizerEffects);
-    QDomNodeList eqEffectNodeList =
+    const QDomNodeList eqEffectNodeList =
             eqEffectsElement.elementsByTagName(
                     EffectXml::kEffectId);
     for (int i = 0; i < eqEffectNodeList.count(); ++i) {
@@ -867,7 +867,7 @@ EffectXmlDataSingleDeck EffectChainPresetManager::readEffectsXmlSingleDeck(
     // Read name of last loaded QuickEffect preset
     QDomElement quickEffectPresetsElement =
             XmlParse::selectElement(root, EffectXml::kQuickEffectChainPresets);
-    QDomNodeList quickEffectNodeList =
+    const QDomNodeList quickEffectNodeList =
             quickEffectPresetsElement.elementsByTagName(
                     EffectXml::kChainPresetName);
     for (int i = 0; i < quickEffectNodeList.count(); ++i) {

--- a/src/effects/presets/effectchainpresetmanager.cpp
+++ b/src/effects/presets/effectchainpresetmanager.cpp
@@ -715,7 +715,7 @@ EffectsXmlData EffectChainPresetManager::readEffectsXml(
     QDomElement mainEqElement = XmlParse::selectElement(root, EffectXml::kMainEq);
     QDomNodeList mainEqs = mainEqElement.elementsByTagName(EffectXml::kChain);
     QDomNode mainEqChainNode = mainEqs.at(0);
-    EffectChainPresetPointer mainEqPreset;
+    EffectChainPresetPointer mainEqPreset = nullptr;
     if (mainEqChainNode.isElement()) {
         QDomElement mainEqChainElement = mainEqChainNode.toElement();
         mainEqPreset = EffectChainPresetPointer(

--- a/src/effects/presets/effectchainpresetmanager.h
+++ b/src/effects/presets/effectchainpresetmanager.h
@@ -10,6 +10,7 @@ struct EffectsXmlData {
     QHash<QString, EffectManifestPointer> eqEffectManifests;
     QHash<QString, EffectChainPresetPointer> quickEffectChainPresets;
     QList<EffectChainPresetPointer> standardEffectChainPresets;
+    EffectChainPresetPointer outputChainPreset;
 };
 
 struct EffectXmlDataSingleDeck {

--- a/src/effects/presets/effectchainpresetmanager.h
+++ b/src/effects/presets/effectchainpresetmanager.h
@@ -7,8 +7,14 @@
 #include "preferences/usersettings.h"
 
 struct EffectsXmlData {
+    QHash<QString, EffectManifestPointer> eqEffectManifests;
     QHash<QString, EffectChainPresetPointer> quickEffectChainPresets;
     QList<EffectChainPresetPointer> standardEffectChainPresets;
+};
+
+struct EffectXmlDataSingleDeck {
+    EffectManifestPointer eqEffectManifest;
+    EffectChainPresetPointer quickEffectChainPreset;
 };
 
 /// EffectChainPresetManager maintains a list of custom EffectChainPresets in the
@@ -66,10 +72,11 @@ class EffectChainPresetManager : public QObject {
     bool savePreset(EffectChainPresetPointer pPreset);
     void updatePreset(EffectChainPointer pChainSlot);
 
+    EffectManifestPointer getDefaultEqEffect();
     EffectChainPresetPointer getDefaultQuickEffectPreset();
 
     EffectsXmlData readEffectsXml(const QDomDocument& doc, const QStringList& deckStrings);
-    EffectChainPresetPointer readEffectsXmlSingleDeck(
+    EffectXmlDataSingleDeck readEffectsXmlSingleDeck(
             const QDomDocument& doc, const QString& deckString);
     void saveEffectsXml(QDomDocument* pDoc, const EffectsXmlData& data);
 

--- a/src/effects/presets/effectxmlelements.h
+++ b/src/effects/presets/effectxmlelements.h
@@ -15,6 +15,7 @@ const QString kRackGroup(QStringLiteral("Group"));
 const QString kChainPresetList(QStringLiteral("ChainPresetList"));
 const QString kQuickEffectList(QStringLiteral("QuickEffectPresetList"));
 const QString kQuickEffectChainPresets(QStringLiteral("QuickEffectChains"));
+const QString kEqualizerEffects(QStringLiteral("EqualizerEffects"));
 const QString kChainPresetName(QStringLiteral("ChainPresetName"));
 
 const QString kVisibleEffects(QStringLiteral("VisibleEffects"));

--- a/src/effects/presets/effectxmlelements.h
+++ b/src/effects/presets/effectxmlelements.h
@@ -10,6 +10,7 @@ const QString kRoot(QStringLiteral("MixxxEffects"));
 const QString kSchemaVersion(QStringLiteral("SchemaVersion"));
 
 const QString kRack(QStringLiteral("Rack"));
+const QString kMainEq(QStringLiteral("MainEQ"));
 const QString kRackGroup(QStringLiteral("Group"));
 
 const QString kChainPresetList(QStringLiteral("ChainPresetList"));

--- a/src/preferences/dialog/dlgprefmixer.cpp
+++ b/src/preferences/dialog/dlgprefmixer.cpp
@@ -7,8 +7,6 @@
 #include "control/controlobject.h"
 #include "control/controlproxy.h"
 #include "defs_urls.h"
-#include "effects/backends/builtin/biquadfullkilleqeffect.h"
-#include "effects/backends/builtin/filtereffect.h"
 #include "effects/chains/equalizereffectchain.h"
 #include "effects/chains/quickeffectchain.h"
 #include "effects/effectknobparameterslot.h"
@@ -30,9 +28,6 @@ const ConfigKey kEqsOnlyKey = ConfigKey(kMixerProfile, QStringLiteral("EQsOnly")
 const ConfigKey kSingleEqKey = ConfigKey(kMixerProfile, QStringLiteral("SingleEQEffect"));
 const ConfigKey kEqAutoResetKey = ConfigKey(kMixerProfile, QStringLiteral("EqAutoReset"));
 const ConfigKey kGainAutoResetKey = ConfigKey(kMixerProfile, QStringLiteral("GainAutoReset"));
-const QString kDefaultEqId = BiquadFullKillEQEffect::getId() + " " +
-        EffectsBackend::backendTypeToString(EffectBackendType::BuiltIn);
-const QString kDefaultQuickEffectChainName = FilterEffect::getManifest()->name();
 const QString kDefaultMainEqId = QString();
 
 const ConfigKey kHighEqFreqKey = ConfigKey(kMixerProfile, kHighEqFrequency);
@@ -464,15 +459,8 @@ void DlgPrefMixer::slotResetToDefaults() {
     radioButtonAdditive->setChecked(true);
     checkBoxReverse->setChecked(false);
 
-    // EQ //////////////////////////////////
-    for (const auto& pBox : std::as_const(m_deckEqEffectSelectors)) {
-        pBox->setCurrentIndex(
-                pBox->findData(kDefaultEqId));
-    }
-    for (const auto& pBox : std::as_const(m_deckQuickEffectSelectors)) {
-        pBox->setCurrentIndex(
-                pBox->findText(kDefaultQuickEffectChainName));
-    }
+    // EQ & QuickEffects //////////////////////////////////
+    m_pEffectsManager->loadDefaultEqsAndQuickEffects();
     CheckBoxBypass->setChecked(false);
     CheckBoxEqOnly->setChecked(true);
     CheckBoxSingleEqEffect->setChecked(true);

--- a/src/preferences/dialog/dlgprefmixer.cpp
+++ b/src/preferences/dialog/dlgprefmixer.cpp
@@ -182,7 +182,7 @@ void DlgPrefMixer::slotNumDecksChanged(double numDecks) {
         int deckNo = m_deckEqEffectSelectors.size() + 1;
         // 0-based for engine
         QString deckGroup = PlayerManager::groupForDeck(deckNo - 1);
-        QLabel* pLabel = new QLabel(QObject::tr("Deck %1").arg(deckNo), this);
+        auto pLabel = make_parented<QLabel>(QObject::tr("Deck %1").arg(deckNo), this);
 
         // Create the EQ selector //////////////////////////////////////////////
         auto pEqComboBox = make_parented<QComboBox>(this);

--- a/src/preferences/dialog/dlgprefmixer.h
+++ b/src/preferences/dialog/dlgprefmixer.h
@@ -68,7 +68,6 @@ class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
 
     void setUpMainEQ();
     void updateMainEQ();
-    void storeMainEQ();
 
     typedef bool (*EffectManifestFilterFnc)(EffectManifest* pManifest);
     const QList<EffectManifestPointer> getDeckEqManifests() const;
@@ -115,6 +114,7 @@ class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
     bool m_eqBypass;
 
     bool m_initializing;
+    bool m_updatingMainEQ;
 
     QList<int> m_eqIndiciesOnUpdate;
     QList<int> m_quickEffectIndiciesOnUpdate;


### PR DESCRIPTION
... to have all effects settings in one place.

The migration from mixxx.cfg is supposed to be done only once, hence the read lines are removed from mixxx.cfg. This means if someone decides to go back to 2.3, the deck EQs and the Main EQ will be reset to default. (IIRC downgrading has more implications and we don't guarantee that's trouble-free anyway)

Since cfg strings are removed during migration the only possibility to loose the main EQ config is if Mixxx crashes before/during shutdown (when the cleaned config is written but not the effects config).

Deck EQ effect uids:
``` xml
 <EqualizerEffects>
  <Id group="[Channel3]">org.mixxx.effects.biquadfullkilleq Built-In</Id>
  <Id group="[Channel2]">---</Id> <!-- exactly as with QuickEffect chains --- clears the EQ slot -->
  <Id group="[Channel1]"></Id>    <!-- while this (or absent Id element) loads the default EQ -->
  <Id group="[Channel4]">org.mixxx.effects.bessel8lvmixeq Built-In</Id>
 </EqualizerEffects>
```

Main EQ effect uid + parameters (stored like the standard effect chains)
``` xml
 <MainEQ>
  <EffectChain>
   <Name></Name> <!-- always empty since we just load an effect into the only slot #1 -->
   <MixMode>DRY/WET</MixMode>
   <SuperParameterValue>0</SuperParameterValue>
   <Effects>
    <Effect>
     <MetaParameterValue>0</MetaParameterValue>
     <Id>org.mixxx.effects.parametriceq</Id>
     <BackendType>Built-In</BackendType>
     <Parameters>
      ...
     </Parameters>
    </Effect>
   </Effects>
  </EffectChain>
 </MainEQ>
```

Preferences > Mixer is adjusted, though there's now one small step back in terms of UX IMO (compared to #11527, not 2.4):
main EQ changes can not be undone with Cancel -- `updateMainEQ()` always reads the state from EffectsManager. Though that's what the 'Reset Parameter' button is for.