### PR TITLE
on macos, set preferences dialog title to the selected page title

### DIFF
--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -109,13 +109,16 @@ bool DlgPrefControllers::handleTreeItemClick(QTreeWidgetItem* clickedItem) {
     if (controllerIndex >= 0) {
         DlgPrefController* pControllerDlg = m_controllerPages.value(controllerIndex);
         if (pControllerDlg) {
-            m_pDlgPreferences->switchToPage(pControllerDlg);
+            const QString pageTitle = m_pControllersRootItem->text(0) + " - " +
+                    clickedItem->text(0);
+            m_pDlgPreferences->switchToPage(pageTitle, pControllerDlg);
         }
         return true;
     } else if (clickedItem == m_pControllersRootItem) {
         // Switch to the root page and expand the controllers tree item.
         m_pDlgPreferences->expandTreeItem(clickedItem);
-        m_pDlgPreferences->switchToPage(this);
+        const QString pageTitle = clickedItem->text(0);
+        m_pDlgPreferences->switchToPage(pageTitle, this);
         return true;
     }
     return false;

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -303,14 +303,14 @@ void DlgPreferences::changePage(QTreeWidgetItem* pCurrent, QTreeWidgetItem* pPre
 
     for (PreferencesPage page : qAsConst(m_allPages)) {
         if (pCurrent == page.pTreeItem) {
-            switchToPage(page.pDlg);
+            switchToPage(pCurrent->text(0), page.pDlg);
             break;
         }
     }
 }
 
 void DlgPreferences::showSoundHardwarePage() {
-    switchToPage(m_soundPage.pDlg);
+    switchToPage(m_soundPage.pTreeItem->text(0), m_soundPage.pDlg);
     contentsTreeWidget->setCurrentItem(m_soundPage.pTreeItem);
 }
 
@@ -507,7 +507,16 @@ void DlgPreferences::expandTreeItem(QTreeWidgetItem* pItem) {
     contentsTreeWidget->expandItem(pItem);
 }
 
-void DlgPreferences::switchToPage(DlgPreferencePage* pWidget) {
+void DlgPreferences::switchToPage(const QString& pageTitle, DlgPreferencePage* pWidget) {
+#ifdef __APPLE__
+    // According to Apple's Human Interface Guidelines, settings dialogs have to
+    // "Update the window’s title to reflect the currently visible pane."
+    // This also solves the problem of the changed in terminology, Settings instead
+    // of Preferences, since macOS Ventura.
+    setWindowTitle(pageTitle);
+#else
+    Q_UNUSED(pageTitle);
+#endif
     pagesWidget->setCurrentWidget(pWidget->parentWidget()->parentWidget());
 
     QPushButton* pButton = buttonBox->button(QDialogButtonBox::Help);

--- a/src/preferences/dialog/dlgpreferences.h
+++ b/src/preferences/dialog/dlgpreferences.h
@@ -83,7 +83,7 @@ class DlgPreferences : public QDialog, public Ui::DlgPreferencesDlg {
             const QString& iconFile);
     void removePageWidget(DlgPreferencePage* pWidget);
     void expandTreeItem(QTreeWidgetItem* pItem);
-    void switchToPage(DlgPreferencePage* pPage);
+    void switchToPage(const QString& pageTitle, DlgPreferencePage* pPage);
 
   public slots:
     void changePage(QTreeWidgetItem* pCurrent, QTreeWidgetItem* pPrevious);


### PR DESCRIPTION
On macOS Ventura / SDK 13, the "Preferences..." application menu item has been renamed to "Settings...". This leads to an inconsistency with Mixxx preferences dialog title, which is still "Preferences".

According to Apple's Human Interface Guidelines, however, the title of the dialog should actually be neither Preferences nor Settings. See https://developer.apple.com/design/human-interface-guidelines/patterns/settings/ which reads:

> Update the window’s title to reflect the currently visible pane. If your settings window doesn’t have multiple panes, use the title App Name Settings.

As we do have multiple panes in the dialog (called pages, in the mixxx source code), where the current page is selected from the list (tree item) on the left, it makes sense to use that. This way we kill two birds with one stone: we don't have to worry about a inconsistency between the menu item and the dialog title, and we integrate more correctly in the host OS.

This PR sets the dialog title to the text (pageTitle) from the selected item from the tree. E.g. "Sound hardware", "Library", "Controllers". In the case of "Controllers", when a specific controller is selected from the subtree, this is concatenated, e.g. "Controllers - DJControl Inpulse 200". The dialog title is only changed on macOS, Linux and Windows behave like before.

