### PR TITLE
use QOpenGLWindow::update to trigger the WVuMeter rendering

### DIFF
--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -138,12 +138,10 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     WaveformWidgetType::Type autoChooseWidgetType() const;
 
   signals:
-    void waveformUpdateTick();
+    void maybeUpdateVuMeters();
     void waveformMeasured(float frameRate, int droppedFrames);
     void renderSpinnies(VSyncThread*);
     void swapSpinnies();
-    void renderVuMeters(VSyncThread*);
-    void swapVuMeters();
 
   public slots:
     void slotSkinLoaded();

--- a/src/widget/wglwidgetqopengl.cpp
+++ b/src/widget/wglwidgetqopengl.cpp
@@ -74,6 +74,12 @@ void WGLWidget::doneCurrent() {
     }
 }
 
+void WGLWidget::updateGL() {
+    if (m_pOpenGLWindow) {
+        m_pOpenGLWindow->update();
+    }
+}
+
 void WGLWidget::paintGL() {
     // to be implemented in derived widgets if needed
 }

--- a/src/widget/wglwidgetqopengl.h
+++ b/src/widget/wglwidgetqopengl.h
@@ -29,6 +29,8 @@ class WGLWidget : public QWidget {
 
     void swapBuffers();
 
+    void updateGL();
+
     // called (indirectly) by WaveformWidgetFactory
     virtual void paintGL();
     // called by OpenGLWindow

--- a/src/widget/wvumeter.cpp
+++ b/src/widget/wvumeter.cpp
@@ -7,7 +7,7 @@ WVuMeter::WVuMeter(QWidget* pParent)
         : WVuMeterBase(pParent) {
 }
 
-void WVuMeter::draw() {
+void WVuMeter::paintGL() {
     QPainter p(paintDevice());
     // fill the background, in case the image contains transparency
     p.fillRect(rect(), m_qBgColor);

--- a/src/widget/wvumeter.h
+++ b/src/widget/wvumeter.h
@@ -7,5 +7,5 @@ class WVuMeter : public WVuMeterBase {
   public:
     explicit WVuMeter(QWidget* parent = nullptr);
 
-    void draw() override;
+    void paintGL() override;
 };

--- a/src/widget/wvumeterbase.h
+++ b/src/widget/wvumeterbase.h
@@ -2,6 +2,7 @@
 
 #include "skin/legacy/skincontext.h"
 #include "util/duration.h"
+#include "util/performancetimer.h"
 #include "widget/wglwidget.h"
 #include "widget/wpixmapstore.h"
 #include "widget/wwidget.h"
@@ -27,26 +28,16 @@ class WVuMeterBase : public WGLWidget, public WBaseWidget {
     void onConnectedControlChanged(double dParameter, double dValue) override;
 
   public slots:
-    void render(VSyncThread* vSyncThread);
-    void swap();
+    void maybeUpdate();
 
   protected slots:
     void updateState(mixxx::Duration elapsed);
 
   private:
-    virtual void draw() = 0;
-
-    void paintEvent(QPaintEvent* /*unused*/) override;
     void showEvent(QShowEvent* /*unused*/) override;
     void setPeak(double parameter);
-    void renderQPainter();
 
   protected:
-    // To make sure we render at least N times even when we have no signal,
-    // for example after showEvent()
-    int m_iPendingRenders;
-    // To indicate that we rendered so we need to swap
-    bool m_bSwapNeeded;
     // Current parameter and peak parameter.
     double m_dParameter;
     double m_dPeakParameter;
@@ -76,4 +67,5 @@ class WVuMeterBase : public WGLWidget, public WBaseWidget {
     double m_dPeakHoldCountdownMs;
 
     QColor m_qBgColor;
+    PerformanceTimer m_timer;
 };

--- a/src/widget/wvumeterglsl.cpp
+++ b/src/widget/wvumeterglsl.cpp
@@ -13,14 +13,6 @@ WVuMeterGLSL::~WVuMeterGLSL() {
     cleanupGL();
 }
 
-void WVuMeterGLSL::draw() {
-    if (shouldRender()) {
-        makeCurrentIfNeeded();
-        paintGL();
-        doneCurrent();
-    }
-}
-
 void WVuMeterGLSL::initializeGL() {
     m_pTextureBack.reset(createTexture(m_pPixmapBack));
     m_pTextureVu.reset(createTexture(m_pPixmapVu));
@@ -137,6 +129,9 @@ void WVuMeterGLSL::paintGL() {
     m_textureShader.disableAttributeArray(positionLocation);
     m_textureShader.disableAttributeArray(texcoordLocation);
     m_textureShader.release();
+
+    m_dLastParameter = m_dParameter;
+    m_dLastPeakParameter = m_dPeakParameter;
 }
 
 void WVuMeterGLSL::cleanupGL() {

--- a/src/widget/wvumeterglsl.h
+++ b/src/widget/wvumeterglsl.h
@@ -19,7 +19,6 @@ class WVuMeterGLSL : public WVuMeterBase {
     std::unique_ptr<QOpenGLTexture> m_pTextureVu;
     mixxx::TextureShader m_textureShader;
 
-    void draw() override;
     void initializeGL() override;
     void cleanupGL();
     void paintGL() override;


### PR DESCRIPTION
Instead of rendering and swapping the opengl-based WVuMeter directly from WaveformWidgetFactory, call updateGL (through QOpenGLWindow::update()), similar to the mechanism used for WVuMeterLegacy.

