### PR TITLE
macOs: Fail early if the Xcode command line tools are not installed.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,16 @@ if(QOPENGL)
 endif()
 
 if(APPLE)
+  # Check if xcode-select is installed
+  execute_process(COMMAND xcode-select -v
+    RESULT_VARIABLE XCODE_SELECT_RESULT
+    OUTPUT_QUIET
+  )
+  if(XCODE_SELECT_RESULT)
+    # xcode-select command failed, meaning it is not installed or not configured properly
+    message(FATAL_ERROR "'xcode-select -v' failed with '${XCODE_SELECT_RESULT}'. You may need to install Xcode and run 'sudo xcode-select --install'.")
+  endif()
+
   if(QT6)
     # Minimum macOS version supported by Qt 6
     set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15 CACHE STRING "Minimum macOS version the build will be able to run on")


### PR DESCRIPTION
This avoids obscure error messages like this
```
sebastiankuhz@StorchBook-Pro build1 % cmake -DCMAKE_TOOLCHAIN_FILE=/Users/sebastiankuhz/mixxx/buildenv/mixxx-deps-2.5-x64-osx-min1012-35a3f01/scripts/buildsystems/vcpkg.cmake /Users/sebastiankuhz/mixxx
-- Using MIXXX_VCPKG_ROOT: /Users/sebastiankuhz/mixxx/buildenv/mixxx-deps-2.5-x64-osx-min1012-35a3f01
CMake Error: CMake was unable to find a build program corresponding to "Ninja". CMAKE_MAKE_PROGRAM is not set. You probably need to select a different build tool.
CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage
-- Configuring incomplete, errors occurred!
```
Instead it will show:
```
CMake Error at CMakeLists.txt:144 (message):
  'xcode-select -v' failed with 'No such file or directory'.  You may need to
  install Xcode and run 'sudo xcode-select --install'.
```