### PR TITLE
Library sidebar: expand items to full width to maximize click-responsive area

### DIFF
--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -363,6 +363,10 @@ void Library::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
             &WLibrarySidebar::deleteItem,
             m_pSidebarModel,
             &SidebarModel::deleteItem);
+    connect(m_pSidebarModel,
+            &SidebarModel::dataChanged,
+            pSidebarWidget,
+            &WLibrarySidebar::queueHeaderAdjustRequest);
 
     connect(pSidebarWidget,
             &WLibrarySidebar::setLibraryFocus,

--- a/src/widget/wlibrarysidebar.h
+++ b/src/widget/wlibrarysidebar.h
@@ -5,6 +5,7 @@
 #include <QTreeView>
 
 #include "library/library_decl.h"
+#include "util/performancetimer.h"
 #include "widget/wbasewidget.h"
 
 class LibraryFeature;
@@ -33,6 +34,8 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
     void selectIndex(const QModelIndex&);
     void selectChildIndex(const QModelIndex&, bool selectItem = true);
     void slotSetFont(const QFont& font);
+    void queueHeaderAdjustRequest();
+    void adjustHeaderStretch();
 
   signals:
     void rightClicked(const QPoint&, const QModelIndex&);
@@ -48,5 +51,8 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
     QModelIndex selectedIndex();
 
     QBasicTimer m_expandTimer;
+    QBasicTimer m_headerAdjustTimer;
+    PerformanceTimer m_eventFrequencyTimer;
+
     QModelIndex m_hoverIndex;
 };


### PR DESCRIPTION
A small UX helper. Works fine without glitches.

### Issue
Currently, the sidebar header expands to the width of the widest item.
If the sidebar is wider than that, there's some space right next to items that is not responsive to clicks. This is somewhat frustration as it is perceived inconsistent with the state when e.g. Playlist are expanded and the entire 'Tracks' row responds to clicks.

Desired:
* full-width items
* full item text (no elide)
* show scrollbars as needed

Unfortunately, there's no combination of 
`header()->setStretchLastSection(true);`
`header()->setSectionResizeMode(QHeaderView::ResizeMode);`
to achieve that* 
*<sub>at least not when set in the constructor. If set later on, e.g. on `QResizeEvent`, it works as desired, though only with collapsed rows. go figure...</sub>

Probably a Qt issue, or just a use case they didn't know/care about.
(tested with Qt5. I didn't test again with Qt6, but I don't expect a fix tbh, given this is low prio and Qt is very slow with fixing such QWidget bugs)
___
### Fix
The header, and thereby the rows, are (maybe) adjusted
* on every `Resize`, `LayoutRequest`, `FontChange` & `Polish` event
* when expanding/collapsing items and
* when item text is changed (eg. playlist renamed, track count changed)

we then do
* `setStretchLastSection(false)` to show horizontal scrollbars, ie. no ellipsis in item labels
* `setStretchLastSection(true)` if sidebar is wider than the widest item

To avoid unnecessary and redundant adjustments [^1], adjust requests are queued and delayed by 50 ms [^2] so that only the last queued request is processed.
This is implemented along the drag'n'drop timer events with a lightweight QBasicTimer, so I think this is a compact solution.

[^1]: this applies in particular to skin creation/first show and manual resizing, eg. while dragging the sidebar splitter, where many events may be sent in quick succession.
[^2]: 50 ms seem to be a good compromise between fast GUI update and long enough wait time for potential follow-up events to reduce adjust requests.
Update can be seen only when expanding from width with h-scrollbars to one without.